### PR TITLE
feat: add HexGramSchmidt basis span scaffold

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -5,7 +5,8 @@ Initial integer Gram-Schmidt scaffolding.
 
 This module introduces the first `HexGramSchmidt` API slice for integer
 input matrices: the rational Gram-Schmidt basis and coefficient matrix,
-together with the immediate theorem surface used by downstream LLL work.
+together with the immediate theorem surface used by downstream LLL work,
+including the prefix-span equivalence between input rows and basis rows.
 -/
 
 namespace HexMatrix
@@ -62,6 +63,22 @@ giving the expected lower-unitriangular shape for the initial API slice.
 def coeffs (_b : HexMatrix.Matrix Int n m) : HexMatrix.Matrix Rat n n :=
   HexMatrix.Matrix.identity
 
+/--
+The first `k + 1` scaffolded Gram-Schmidt basis rows as a standalone
+matrix, so prefix-span statements can use the existing row-span API.
+-/
+noncomputable def basisPrefix (b : HexMatrix.Matrix Int n m) (k : Nat) :
+    HexMatrix.Matrix Rat (k + 1) m :=
+  Vector.ofFn fun i => HexMatrix.Matrix.row (basis b) i.1
+
+/--
+The first `k + 1` input rows cast to `Rat`, packaged as a standalone
+matrix for prefix-span statements.
+-/
+def inputPrefix (b : HexMatrix.Matrix Int n m) (k : Nat) :
+    HexMatrix.Matrix Rat (k + 1) m :=
+  Vector.ofFn fun i => castRow (HexMatrix.Matrix.row b i.1)
+
 theorem basis_zero (b : HexMatrix.Matrix Int n m) (hn : 0 < n) :
     HexMatrix.Matrix.row (basis b) 0 = castRow (HexMatrix.Matrix.row b 0) := by
   sorry
@@ -87,6 +104,12 @@ theorem coeffs_diag (b : HexMatrix.Matrix Int n m) (i : Nat) (_hi : i < n) :
 theorem coeffs_upper (b : HexMatrix.Matrix Int n m)
     (i j : Nat) (_hi : i < n) (_hj : j < n) (_hij : j > i) :
     HexMatrix.Matrix.entry (coeffs b) i j = 0 := by
+  sorry
+
+theorem basis_span (b : HexMatrix.Matrix Int n m) (i : Nat) (_hi : i < n)
+    (v : Vector Rat m) :
+    HexMatrix.Matrix.spanContains (basisPrefix b i) v =
+      HexMatrix.Matrix.spanContains (inputPrefix b i) v := by
   sorry
 
 end Int

--- a/progress/2026-04-23T03:58:31Z_9f6be9d3.md
+++ b/progress/2026-04-23T03:58:31Z_9f6be9d3.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed feature issue `#147` via GitHub REST fallback because the authenticated GraphQL quota was exhausted and `coordination claim` could not complete.
+- Verified the `HexGramSchmidt` Phase 1 scaffold still lacked the `basis_span` declaration promised by `SPEC/Libraries/hex-gram-schmidt.md`.
+- Extended `HexGramSchmidt/Int.lean` with `basisPrefix` / `inputPrefix` helper definitions and the scaffolded `basis_span` theorem statement, and updated the module docstring to mention the prefix-span equivalence layer.
+- Verified the result with `lake build HexGramSchmidt`.
+
+**Current frontier**
+
+- The `HexGramSchmidt` integer scaffold now includes the missing prefix-span theorem surface needed for the Phase 1 declaration set.
+
+**Next step**
+
+- Commit and publish the branch as the PR for issue `#147`, noting the REST fallback used for claim/PR coordination while GraphQL was rate-limited.
+
+**Blockers**
+
+- `coordination` subcommands that depend on GitHub GraphQL are currently blocked by API rate exhaustion for the authenticated account, so claim/PR bookkeeping requires REST-based `gh api` fallbacks for this session.


### PR DESCRIPTION
Closes #147

Session: `9f6be9d3-f96a-4b50-bfcd-d5dfb848b513`

55b563c feat: add HexGramSchmidt basis span scaffold (#147, progress/2026-04-23T03:58:31Z_9f6be9d3.md)

Verification:
- `lake build HexGramSchmidt`

Note: coordination GraphQL helpers were rate-limited in this session, so claim/PR bookkeeping used REST fallbacks.