### PR TITLE
feat: scaffold HexPolyFp modular composition surface

### DIFF
--- a/HexPolyFp.lean
+++ b/HexPolyFp.lean
@@ -1,10 +1,12 @@
 import HexPolyFp.Core
+import HexPolyFp.ModCompose
 
 /-!
 `HexPolyFp` re-exports the dense `FpPoly p := DensePoly (ZMod64 p)` core
 surface together with normalization-preserving constructors, basic
-arithmetic wrappers, and the first modular-power/Frobenius API used by
-downstream quotient-ring libraries.
+arithmetic wrappers, the first modular-power/Frobenius API, and the
+initial modular-composition surface used by downstream quotient-ring and
+factorization libraries.
 -/
 
 namespace HexPolyFp

--- a/HexPolyFp/ModCompose.lean
+++ b/HexPolyFp/ModCompose.lean
@@ -1,0 +1,77 @@
+import HexPolyFp.Core
+
+/-!
+Modular composition scaffolding for `FpPoly`.
+
+This module adds the first executable modular-composition entry point
+for `HexPolyFp.FpPoly p`: evaluate one polynomial at another and reduce
+intermediate results modulo a supplied monic polynomial. The theorem
+surface records the expected relationship with ordinary dense-polynomial
+composition and the reduced-remainder range condition needed by
+downstream quotient-ring code.
+-/
+
+namespace HexPolyFp
+
+namespace FpPoly
+
+open HexModArith
+
+variable {p : Nat} [NeZero p]
+
+/--
+Horner-style modular composition on ascending coefficient lists.
+
+Each recursive step reduces modulo `modulus` so the executable surface
+already returns a canonical quotient-ring representative.
+-/
+private def modComposeMonicList (g modulus : FpPoly p) :
+    List (HexModArith.ZMod64 p) → FpPoly p
+  | [] => 0
+  | a :: as =>
+      modMonic (C a + mul g (modComposeMonicList g modulus as)) modulus
+
+/--
+Evaluate `f` at `g` modulo `modulus` using Horner recursion with
+monic-remainder reduction at every step.
+-/
+def modComposeMonic (f g modulus : FpPoly p) : FpPoly p :=
+  modComposeMonicList g modulus f.coeffs.toList
+
+/-- Modular composition returns a normalized dense polynomial. -/
+theorem modComposeMonic_isNormalized (f g modulus : FpPoly p) :
+    HexPoly.DensePoly.IsNormalized (modComposeMonic f g modulus).coeffs := by
+  simpa [HexPoly.DensePoly.IsNormalized, modComposeMonic]
+    using (modComposeMonic f g modulus).normalized
+
+/--
+The modular-composition scaffold agrees with dense composition followed
+by monic reduction.
+-/
+theorem modComposeMonic_eq_modMonic_compose (f g modulus : FpPoly p) :
+    modComposeMonic f g modulus =
+      modMonic
+        (HexPoly.DensePoly.compose (R := HexModArith.ZMod64 p) f g)
+        modulus := by
+  sorry
+
+/--
+Reducing the modular-composition output again does not change it.
+-/
+theorem modComposeMonic_modMonic_self (f g modulus : FpPoly p) :
+    modMonic (modComposeMonic f g modulus) modulus = modComposeMonic f g modulus := by
+  sorry
+
+/--
+For nonzero monic moduli, the modular-composition result has remainder
+degree strictly below the modulus unless it vanishes.
+-/
+theorem modComposeMonic_degree_lt (f g modulus : FpPoly p)
+    (hmonic : HexPoly.DensePoly.Monic modulus) (hmodulus : modulus ≠ 0) :
+    (modComposeMonic f g modulus).natDegree? = none ∨
+      (modComposeMonic f g modulus).degree < modulus.degree := by
+  sorry
+
+end FpPoly
+
+end HexPolyFp

--- a/progress/2026-04-23T04:49:52Z_90a33551.md
+++ b/progress/2026-04-23T04:49:52Z_90a33551.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed critical-path feature issue `#177` via GitHub REST fallback because `coordination` repo discovery was blocked by a GraphQL rate-limit error.
+- Added [HexPolyFp/ModCompose.lean](/home/kim/hex/worktrees/90a33551/HexPolyFp/ModCompose.lean) with an executable Horner-style `FpPoly.modComposeMonic` API that reduces intermediate results modulo the supplied modulus, plus scaffold theorems for normalization, compatibility with dense composition followed by reduction, idempotent remainder reduction, and the expected degree bound.
+- Updated [HexPolyFp.lean](/home/kim/hex/worktrees/90a33551/HexPolyFp.lean) to re-export the modular-composition module and advertise the expanded Phase 1 surface.
+- Ran `lake build HexPolyFp` successfully.
+
+**Current frontier**
+
+- `HexPolyFp` now exposes carrier/basic arithmetic/Frobenius/modular-composition scaffolding, so the remaining Phase 1 frontier is the square-free/decomposition slice and then the skeptical completion review that can unblock downstream `HexGfqRing`, `HexBerlekamp`, and `HexHensel` work.
+
+**Next step**
+
+- Publish the branch as a PR closing `#177`, then let planners or follow-up workers pick up the remaining `HexPolyFp` Phase 1 work.
+
+**Blockers**
+
+- `coordination` commands that rely on `gh repo view` GraphQL discovery are currently failing with `API rate limit already exceeded`, so claim/PR bookkeeping needed REST fallbacks in this session.


### PR DESCRIPTION
## Summary
- add `HexPolyFp.ModCompose` with an executable Horner-style `FpPoly.modComposeMonic` API
- expose scaffold theorems for normalization, reduction compatibility, and degree/range behavior
- re-export the new module from `HexPolyFp` and record session progress

## Testing
- `lake build HexPolyFp`

Closes #177