### PR TITLE
review: complete HexModArith Phase 2 review

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -38,7 +38,7 @@ libraries:
   HexModArith:
     deps: [HexArith]
     mathlib: false
-    done_through: 1
+    done_through: 2
   HexGramSchmidt:
     deps: [HexMatrix]
     mathlib: false

--- a/progress/2026-04-23T04:54:45Z_925c1373.md
+++ b/progress/2026-04-23T04:54:45Z_925c1373.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Audited `SPEC/Libraries/hex-mod-arith.md` against `HexModArith/Core.lean`, `HexModArith/Instances.lean`, `HexModArith/Theorems.lean`, and `HexModArith.lean` for issue `#171`.
+- Confirmed the Phase 1 scaffold matches the spec’s required surface: `ZMod64 p`, executable add/sub/mul/inversion/pow operations, `Lean.Grind.CommRing` and `IsCharP` instances, plus the prime-modulus inverse/no-zero-divisors/Fermat theorem layer.
+- Recorded the completed Phase 2 review by adding `status/hex-mod-arith.scaffolding-reviewed` and bumping `libraries.yml` so `HexModArith.done_through` is `2`.
+- Verified the result with `lake build HexModArith` and `python3 scripts/status.py`.
+
+**Current frontier**
+
+- `HexModArith` is now ready for later Phase 3 conformance work once `HexArith.done_through` reaches `3`.
+- The immediate open review frontier in the ready queue is `HexGramSchmidt -> Phase 2`; the immediate implementation frontier still includes `HexGf2`, `HexPolyFp`, and the Mathlib bridge libraries.
+
+**Next step**
+
+- Publish the review result for issue `#171` in a PR or issue comment once the GitHub coordination tooling is usable again, then let the next worker take the highest-value remaining ready issue.
+
+**Blockers**
+
+- `coordination orient`, `coordination list-unclaimed`, and likely `coordination create-pr` are currently unusable in this worktree because the session’s GitHub GraphQL quota is exhausted. REST API calls still work and were sufficient for claim/release fallback, but the normal publish flow could not be exercised yet.

--- a/status/hex-mod-arith.scaffolding-reviewed
+++ b/status/hex-mod-arith.scaffolding-reviewed
@@ -1,0 +1,1 @@
+Phase 2 review completed in issue #171.


### PR DESCRIPTION
Closes #171

## Review result

Audited `SPEC/Libraries/hex-mod-arith.md` against the current `HexModArith` scaffold and found the Phase 1 surface complete for downstream use. The carrier, executable arithmetic/inversion/power operations, `Lean.Grind.CommRing` / `IsCharP` instance layer, and prime-modulus theorem surface are all present in the expected modules.

## Changes

- add the Phase 2 attestation token `status/hex-mod-arith.scaffolding-reviewed`
- bump `libraries.yml` so `HexModArith.done_through` is `2`
- add the per-turn progress note required by `AGENTS.md`

## Verification

- `lake build HexModArith`
- `python3 scripts/status.py`