### PR TITLE
feat: scaffold HexGf2 GF2nPoly quotient-field operations

### DIFF
--- a/HexGf2.lean
+++ b/HexGf2.lean
@@ -2,6 +2,7 @@ import HexGf2.Core
 import HexGf2.DivMod
 import HexGf2.FiniteExtension
 import HexGf2.GF2n
+import HexGf2.GF2nPoly
 import HexGf2.Gcd
 import HexGf2.Mul
 import HexGf2.Ops
@@ -10,6 +11,7 @@ import HexGf2.Ops
 `HexGf2` exposes packed `GF(2)` polynomial scaffolding, the carry-less
 multiply boundary, XOR/shift/multiplication/division/GCD polynomial
 operations, the finite-extension carrier records, and the executable
-small-word `GF(2^n)` arithmetic layer used by later optimized binary-field
-code.
+small-word `GF(2^n)` arithmetic layer together with the large-degree
+`GF2nPoly` quotient arithmetic and field scaffolding used by later
+optimized binary-field code.
 -/

--- a/HexGf2/FiniteExtension.lean
+++ b/HexGf2/FiniteExtension.lean
@@ -65,8 +65,8 @@ structure GF2n (n : Nat) (irr : UInt64)
 /--
 Packed `GF(2^n)` carrier for arbitrary-degree irreducible moduli.
 
-The reduction invariant is stated now; executable modular arithmetic arrives
-in later scaffolding slices.
+The reduction invariant is stated here; executable quotient arithmetic and
+field scaffolding over this carrier live in `HexGf2.GF2nPoly`.
 -/
 structure GF2nPoly (f : GF2Poly) (hirr : GF2Poly.Irreducible f) where
   val : GF2Poly

--- a/HexGf2/GF2nPoly.lean
+++ b/HexGf2/GF2nPoly.lean
@@ -1,0 +1,379 @@
+import Init.Grind.Ring.Field
+import HexGf2.Gcd
+
+/-!
+Executable quotient arithmetic for large-degree packed `GF(2^n)` extensions.
+
+This module upgrades `GF2nPoly` from a reduced-representative carrier to the
+Phase 1 large-degree quotient surface promised by the spec: canonical
+reduction modulo the packed irreducible polynomial, executable `Zero`/`One`/
+`Add`/`Mul`/`Inv`/`Div` operations, and scaffolded ring/field theorems around
+that quotient presentation.
+-/
+
+namespace HexGf2
+
+namespace GF2nPoly
+
+open Lean.Grind
+
+variable {f : GF2Poly} {hirr : GF2Poly.Irreducible f}
+
+/-- The packed modulus used for quotient reduction. -/
+def modulus (f : GF2Poly) : GF2Poly :=
+  f
+
+/-- Irreducibility implies the packed modulus is not zero. -/
+private theorem modulus_ne_zero (hirr : GF2Poly.Irreducible f) :
+    ¬ (modulus f).IsZero :=
+  hirr.1
+
+/-- Canonical reduction of a packed polynomial representative modulo the modulus. -/
+def reduce (value : GF2Poly) (f : GF2Poly) : GF2Poly :=
+  value % modulus f
+
+/-- Reduction modulo an irreducible polynomial lands in the expected reduced range. -/
+private theorem reduce_reduced (value : GF2Poly) (hirr : GF2Poly.Irreducible f) :
+    (reduce value f).IsZero ∨ (reduce value f).degree < f.degree := by
+  by_cases hzero : (reduce value f).IsZero
+  · exact Or.inl hzero
+  · exact Or.inr (GF2Poly.mod_degree_lt value (modulus f) (modulus_ne_zero hirr) hzero)
+
+/-- Canonical quotient-ring constructor from an arbitrary packed polynomial. -/
+def ofPoly (value : GF2Poly) (hirr : GF2Poly.Irreducible f) : GF2nPoly f hirr where
+  val := reduce value f
+  val_reduced := reduce_reduced (f := f) value hirr
+
+/-- Extract the packed representative underlying a quotient element. -/
+def toPoly (x : GF2nPoly f hirr) : GF2Poly :=
+  x.val
+
+/-- Equality of quotient elements is determined by their reduced representatives. -/
+@[ext] theorem ext {x y : GF2nPoly f hirr} (h : x.val = y.val) : x = y := by
+  cases x
+  cases y
+  cases h
+  rfl
+
+/-- The reduced representative returned by `ofPoly` is definitionally the modulus remainder. -/
+theorem ofPoly_val (value : GF2Poly) (hirr : GF2Poly.Irreducible f) :
+    (ofPoly (f := f) value hirr).val = reduce value f := by
+  rfl
+
+/-- `0` is represented by the zero packed polynomial. -/
+instance : Zero (GF2nPoly f hirr) where
+  zero := ofPoly (f := f) (GF2Poly.ofWords #[]) hirr
+
+/-- `1` is represented by the packed constant polynomial `1`. -/
+instance : One (GF2nPoly f hirr) where
+  one := ofPoly (f := f) GF2Poly.one hirr
+
+/-- Quotient addition is packed-polynomial addition followed by reduction. -/
+instance : Add (GF2nPoly f hirr) where
+  add x y := ofPoly (f := f) (x.val + y.val) hirr
+
+/-- Negation is the identity on `GF(2)` quotient representatives. -/
+instance : Neg (GF2nPoly f hirr) where
+  neg x := x
+
+/-- Subtraction agrees with addition in characteristic two. -/
+instance : Sub (GF2nPoly f hirr) where
+  sub x y := x + y
+
+/-- Quotient multiplication is packed-polynomial multiplication followed by reduction. -/
+instance : Mul (GF2nPoly f hirr) where
+  mul x y := ofPoly (f := f) (x.val * y.val) hirr
+
+/-- Natural-number exponentiation by repeated quotient multiplication. -/
+instance instPowNat : Pow (GF2nPoly f hirr) Nat where
+  pow x n := Id.run do
+    let mut acc : GF2nPoly f hirr := One.one
+    for _ in List.range n do
+      acc := acc * x
+    pure acc
+
+/--
+Executable inverse candidate from extended GCD data.
+
+For nonzero reduced representatives modulo an irreducible modulus, the `s`
+coefficient in `xgcd x.val f` is the expected inverse witness; zero keeps the
+junk-value convention required by `Field`.
+-/
+def inv (x : GF2nPoly f hirr) : GF2nPoly f hirr :=
+  if _hzero : x.val.words = #[] then
+    0
+  else
+    ofPoly (f := f) (GF2Poly.xgcd x.val f).s hirr
+
+instance : Inv (GF2nPoly f hirr) where
+  inv := inv
+
+/-- Division is multiplication by the executable inverse candidate. -/
+def div (x y : GF2nPoly f hirr) : GF2nPoly f hirr :=
+  x * y⁻¹
+
+instance : Div (GF2nPoly f hirr) where
+  div := div
+
+/-- Natural-number casts follow parity, matching characteristic two. -/
+def natCast : Nat → GF2nPoly f hirr
+  | 0 => 0
+  | n + 1 => natCast n + 1
+
+instance : NatCast (GF2nPoly f hirr) where
+  natCast := natCast
+
+instance (n : Nat) : OfNat (GF2nPoly f hirr) n where
+  ofNat := natCast n
+
+/-- Integer casts also collapse to parity because `-x = x` in characteristic two. -/
+instance : IntCast (GF2nPoly f hirr) where
+  intCast z := natCast (Int.natAbs z)
+
+instance : SMul Nat (GF2nPoly f hirr) where
+  smul n x := (n : GF2nPoly f hirr) * x
+
+instance : SMul Int (GF2nPoly f hirr) where
+  smul z x := (z : GF2nPoly f hirr) * x
+
+/-- Integer exponentiation uses inversion on negative powers. -/
+def zpow (x : GF2nPoly f hirr) : Int → GF2nPoly f hirr
+  | .ofNat n => x ^ n
+  | .negSucc n => (x ^ (n + 1))⁻¹
+
+instance : HPow (GF2nPoly f hirr) Int (GF2nPoly f hirr) where
+  hPow := zpow
+
+/-- The quotient constructor preserves the reduced representative convention. -/
+theorem toPoly_ofPoly (value : GF2Poly) (hirr : GF2Poly.Irreducible f) :
+    toPoly (ofPoly (f := f) value hirr) = reduce value f := by
+  rfl
+
+/-- Quotient addition reduces the sum of representatives. -/
+theorem add_val (x y : GF2nPoly f hirr) :
+    (x + y).val = reduce (x.val + y.val) f := by
+  rfl
+
+/-- Quotient multiplication reduces the product of representatives. -/
+theorem mul_val (x y : GF2nPoly f hirr) :
+    (x * y).val = reduce (x.val * y.val) f := by
+  rfl
+
+/-- The quotient zero has the zero representative. -/
+theorem zero_val :
+    (0 : GF2nPoly f hirr).val = reduce (GF2Poly.ofWords #[]) f := by
+  rfl
+
+/-- The quotient one has the reduced constant representative. -/
+theorem one_val :
+    ((One.one : GF2nPoly f hirr)).val = reduce GF2Poly.one f := by
+  rfl
+
+/-- Negation is definitionally the identity on quotient representatives. -/
+theorem neg_eq (x : GF2nPoly f hirr) : -x = x := by
+  rfl
+
+/-- A quotient element is zero exactly when its representative is the zero polynomial. -/
+theorem eq_zero_iff_val_isZero (x : GF2nPoly f hirr) :
+    x = 0 ↔ x.val.IsZero := by
+  sorry
+
+/-- Quotient addition is associative. -/
+theorem add_assoc (a b c : GF2nPoly f hirr) :
+    a + b + c = a + (b + c) := by
+  sorry
+
+/-- Quotient addition is commutative. -/
+theorem add_comm (a b : GF2nPoly f hirr) :
+    a + b = b + a := by
+  sorry
+
+/-- Quotient addition has `0` as a right identity. -/
+theorem add_zero (a : GF2nPoly f hirr) :
+    a + 0 = a := by
+  sorry
+
+/-- Quotient addition has `0` as a left identity. -/
+theorem zero_add (a : GF2nPoly f hirr) :
+    0 + a = a := by
+  sorry
+
+/-- Every quotient element is its own additive inverse. -/
+theorem neg_add_cancel (a : GF2nPoly f hirr) :
+    -a + a = 0 := by
+  sorry
+
+/-- Quotient multiplication is associative. -/
+theorem mul_assoc (a b c : GF2nPoly f hirr) :
+    a * b * c = a * (b * c) := by
+  sorry
+
+/-- Quotient multiplication is commutative. -/
+theorem mul_comm (a b : GF2nPoly f hirr) :
+    a * b = b * a := by
+  sorry
+
+/-- Quotient multiplication has `1` as a right identity. -/
+theorem mul_one (a : GF2nPoly f hirr) :
+    a * 1 = a := by
+  sorry
+
+/-- Quotient multiplication has `1` as a left identity. -/
+theorem one_mul (a : GF2nPoly f hirr) :
+    1 * a = a := by
+  sorry
+
+/-- Quotient multiplication distributes over addition on the left. -/
+theorem left_distrib (a b c : GF2nPoly f hirr) :
+    a * (b + c) = a * b + a * c := by
+  sorry
+
+/-- Quotient multiplication distributes over addition on the right. -/
+theorem right_distrib (a b c : GF2nPoly f hirr) :
+    (a + b) * c = a * c + b * c := by
+  sorry
+
+/-- Zero annihilates quotient multiplication on the left. -/
+theorem zero_mul (a : GF2nPoly f hirr) :
+    0 * a = 0 := by
+  sorry
+
+/-- Zero annihilates quotient multiplication on the right. -/
+theorem mul_zero (a : GF2nPoly f hirr) :
+    a * 0 = 0 := by
+  sorry
+
+/-- Natural powers satisfy the expected base case. -/
+theorem pow_zero (a : GF2nPoly f hirr) :
+    a ^ 0 = 1 := by
+  sorry
+
+/-- Natural powers satisfy the expected successor recursion. -/
+theorem pow_succ (a : GF2nPoly f hirr) (n : Nat) :
+    a ^ (n + 1) = a ^ n * a := by
+  sorry
+
+/-- Successive natural casts differ by `1` as expected in the quotient ring. -/
+theorem ofNat_succ (n : Nat) :
+    OfNat.ofNat (α := GF2nPoly f hirr) (n + 1) =
+      OfNat.ofNat (α := GF2nPoly f hirr) n + 1 := by
+  sorry
+
+/-- Subtraction is quotient addition because the characteristic is two. -/
+theorem sub_eq_add_neg (a b : GF2nPoly f hirr) :
+    a - b = a + -b := by
+  rfl
+
+/-- Integer casts commute with negation. -/
+theorem intCast_neg (z : Int) :
+    Int.cast (R := GF2nPoly f hirr) (-z) = -Int.cast z := by
+  sorry
+
+instance instCommRing : CommRing (GF2nPoly f hirr) where
+  nsmul := inferInstance
+  zsmul := inferInstance
+  natCast := inferInstance
+  intCast := inferInstance
+  add_assoc := add_assoc
+  add_comm := add_comm
+  add_zero := add_zero
+  neg_add_cancel := neg_add_cancel
+  mul_assoc := mul_assoc
+  mul_comm := mul_comm
+  mul_one := mul_one
+  one_mul := one_mul
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  nsmul_eq_natCast_mul n a := by
+    sorry
+  pow_zero := pow_zero
+  pow_succ := pow_succ
+  ofNat_succ := ofNat_succ
+  sub_eq_add_neg := sub_eq_add_neg
+  intCast_ofNat n := by
+    sorry
+  intCast_neg := intCast_neg
+  neg_zsmul i a := by
+    sorry
+  zsmul_natCast_eq_nsmul n a := by
+    sorry
+
+/-- Quotient division is definitionally multiplication by the inverse candidate. -/
+theorem div_eq_mul_inv (a b : GF2nPoly f hirr) :
+    a / b = a * b⁻¹ := by
+  rfl
+
+/-- Irreducible quotients are nontrivial. -/
+theorem zero_ne_one :
+    (0 : GF2nPoly f hirr) ≠ 1 := by
+  sorry
+
+/-- The field inverse uses the standard zero junk-value convention. -/
+theorem inv_zero :
+    (0 : GF2nPoly f hirr)⁻¹ = 0 := by
+  sorry
+
+/-- Nonzero quotient elements multiply with their inverse to `1`. -/
+theorem mul_inv_cancel {a : GF2nPoly f hirr} (ha : a ≠ 0) :
+    a * a⁻¹ = 1 := by
+  sorry
+
+/-- Integer powers satisfy the expected zero case. -/
+theorem zpow_zero (a : GF2nPoly f hirr) :
+    a ^ (0 : Int) = 1 := by
+  sorry
+
+/-- Integer powers satisfy the expected positive successor recursion. -/
+theorem zpow_succ (a : GF2nPoly f hirr) (n : Nat) :
+    a ^ (n + 1 : Int) = a ^ (n : Int) * a := by
+  sorry
+
+/-- Negative integer powers invert the corresponding positive power. -/
+theorem zpow_neg (a : GF2nPoly f hirr) (n : Int) :
+    a ^ (-n) = (a ^ n)⁻¹ := by
+  sorry
+
+instance instField : Field (GF2nPoly f hirr) where
+  nsmul := inferInstance
+  zsmul := inferInstance
+  natCast := inferInstance
+  intCast := inferInstance
+  add_assoc := add_assoc
+  add_comm := add_comm
+  add_zero := add_zero
+  neg_add_cancel := neg_add_cancel
+  mul_assoc := mul_assoc
+  mul_comm := mul_comm
+  mul_one := mul_one
+  one_mul := one_mul
+  left_distrib := left_distrib
+  right_distrib := right_distrib
+  zero_mul := zero_mul
+  mul_zero := mul_zero
+  nsmul_eq_natCast_mul n a := by
+    sorry
+  pow_zero := pow_zero
+  pow_succ := pow_succ
+  ofNat_succ := ofNat_succ
+  sub_eq_add_neg := sub_eq_add_neg
+  intCast_ofNat n := by
+    sorry
+  intCast_neg := intCast_neg
+  neg_zsmul i a := by
+    sorry
+  zsmul_natCast_eq_nsmul n a := by
+    sorry
+  div_eq_mul_inv := div_eq_mul_inv
+  zero_ne_one := zero_ne_one
+  inv_zero := inv_zero
+  mul_inv_cancel := mul_inv_cancel
+  zpow := inferInstance
+  zpow_zero := zpow_zero
+  zpow_succ := zpow_succ
+  zpow_neg := zpow_neg
+
+end GF2nPoly
+
+end HexGf2

--- a/progress/2026-04-23T04:58:53Z_f6d8e97f.md
+++ b/progress/2026-04-23T04:58:53Z_f6d8e97f.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed feature issue `#179` via GitHub REST fallback because the authenticated GraphQL quota was exhausted, then verified that `HexGf2/FiniteExtension.lean` still exposed only the bare `GF2nPoly` carrier.
+- Added [HexGf2/GF2nPoly.lean](/home/kim/hex/worktrees/f6d8e97f/HexGf2/GF2nPoly.lean) with the large-degree quotient-arithmetic scaffold promised by `SPEC/Libraries/hex-gf2.md`: modulus reduction helpers, canonical `ofPoly`/`toPoly`, executable `Zero`/`One`/`Add`/`Mul`/`Inv`/`Div`, natural/int casts, nat/int power shells, and scaffolded `CommRing`/`Field` theorem surface over reduced representatives.
+- Updated [HexGf2.lean](/home/kim/hex/worktrees/f6d8e97f/HexGf2.lean) and [HexGf2/FiniteExtension.lean](/home/kim/hex/worktrees/f6d8e97f/HexGf2/FiniteExtension.lean) to re-export the new quotient module and document that the large-degree `GF2nPoly` carrier now has executable quotient arithmetic and field scaffolding.
+- Ran `lake build HexGf2` successfully.
+
+**Current frontier**
+
+- `HexGf2` still needs the separate small-word `GF2n` `Field`/`Fintype` slice from issue `#178` before the Phase 1 review in `#174` can pass and `HexGf2.done_through` can move to `1`.
+
+**Next step**
+
+- Publish the branch as the PR for `#179`, noting the REST fallback used for claim/PR coordination while GraphQL remains rate-limited.
+
+**Blockers**
+
+- `coordination` subcommands that depend on GitHub GraphQL are still blocked by API rate exhaustion for the authenticated account, so claim/PR bookkeeping needs REST-based fallback handling in this session.


### PR DESCRIPTION
## Summary
- add `HexGf2.GF2nPoly` with modulus reduction helpers, canonical constructors, executable quotient operations, and scaffolded `CommRing`/`Field` surfaces for large-degree binary-field quotients
- re-export the new quotient module from `HexGf2` and update the finite-extension docstrings to point at the executable large-degree path
- record the session progress note for issue `#179`

## Testing
- `lake build HexGf2`

Closes #179