### PR TITLE
chore: review HexMatrixMathlib phase 1 completeness

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -102,7 +102,7 @@ libraries:
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
-    done_through: 0
+    done_through: 1
   HexModArithMathlib:
     deps: [HexModArith]
     mathlib: true

--- a/progress/2026-04-23T06:01:03Z_f2831340.md
+++ b/progress/2026-04-23T06:01:03Z_f2831340.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Selected review issue `#209` as the highest-leverage unclaimed work item after inspecting the live open issue queue through the GitHub REST API, because GraphQL quota exhaustion prevented the normal `coordination` queries.
+- Claimed `#209` via REST fallback, audited `SPEC/Libraries/hex-matrix-mathlib.md` against `HexMatrixMathlib.lean` plus `HexMatrixMathlib/MatrixEquiv.lean`, `Determinant.lean`, `RowOps.lean`, `Rank.lean`, `Nullspace.lean`, and `Span.lean`, and confirmed the promised Phase 1 bridge surface is present and re-exported from the root module.
+- Bumped `libraries.yml` so `HexMatrixMathlib.done_through` is now `1`, posted the review result on issue `#209`, and verified the readiness graph now advances `HexMatrixMathlib` to Phase 2.
+- Ran `lake build HexMatrixMathlib`, which completed successfully in this worktree with only existing scaffold-stage `sorry` warnings in the reviewed modules.
+
+**Current frontier**
+
+- `HexMatrixMathlib` is ready for Phase 2 review work, and downstream planning can treat the Phase 1 scaffold as complete.
+
+**Next step**
+
+- Commit and publish the `libraries.yml` phase bump for issue `#209` via PR, using REST fallbacks where needed while the GitHub GraphQL quota remains exhausted.
+
+**Blockers**
+
+- `coordination` commands that depend on GitHub GraphQL are unavailable in this session because the GraphQL rate limit is exhausted, so claim/comment/PR publish steps require REST fallbacks.


### PR DESCRIPTION
Closes #209

## Summary
- audit `SPEC/Libraries/hex-matrix-mathlib.md` against the current `HexMatrixMathlib` scaffold
- record the successful Phase 1 completeness review by bumping `HexMatrixMathlib.done_through` to `1`
- add the required session progress note

## Verification
- `lake build HexMatrixMathlib`
- `python3 scripts/status.py`