### PR TITLE
feat: scaffold HexGramSchmidtMathlib bridge

### DIFF
--- a/HexGramSchmidtMathlib.lean
+++ b/HexGramSchmidtMathlib.lean
@@ -1,1 +1,13 @@
+import HexGramSchmidtMathlib.Bridge
+
+/-!
+Mathlib bridge scaffolding for Hex's Gram-Schmidt library.
+
+This root module re-exports the current `HexGramSchmidtMathlib` bridge
+surface: the rowwise conversion from Hex's rational basis rows into
+Mathlib's Euclidean-space vectors, together with the scaffolded
+correspondence theorems relating `Hex.GramSchmidt.Int.basis` to
+Mathlib's `gramSchmidt`.
+-/
+
 namespace HexGramSchmidtMathlib

--- a/HexGramSchmidtMathlib/Bridge.lean
+++ b/HexGramSchmidtMathlib/Bridge.lean
@@ -1,0 +1,68 @@
+import HexGramSchmidt
+import Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho
+
+/-!
+Bridge scaffolding between `HexGramSchmidt` and Mathlib's `gramSchmidt`.
+
+This module packages the rowwise conversion from Hex's rational-basis
+matrices into Mathlib's Euclidean-space view, then states the scaffolded
+correspondence theorem surface asserting that the integer-input
+Gram-Schmidt basis agrees row-by-row with Mathlib's `gramSchmidt` after
+coercing coefficients into `ℝ`.
+-/
+
+namespace HexGramSchmidtMathlib
+
+open HexMatrix
+
+namespace Bridge
+
+open Hex
+
+/-- View a dense rational row as a real Euclidean-space vector. -/
+def toEuclideanRow (v : Vector Rat m) : EuclideanSpace ℝ (Fin m) :=
+  WithLp.toLp 2 (V := Fin m → ℝ) fun j => (v.get j : ℝ)
+
+/--
+The integer-input rows, coerced into the Euclidean-space family expected
+by Mathlib's `gramSchmidt`.
+-/
+def inputFamily (b : HexMatrix.Matrix Int n m) : Fin n → EuclideanSpace ℝ (Fin m) :=
+  fun i => toEuclideanRow (Hex.GramSchmidt.Int.castRow (b.get i))
+
+/--
+The scaffolded Hex Gram-Schmidt basis viewed as a family of Euclidean-space
+vectors, one row at a time.
+-/
+noncomputable def basisFamily (b : HexMatrix.Matrix Int n m) : Fin n → EuclideanSpace ℝ (Fin m) :=
+  fun i => toEuclideanRow ((Hex.GramSchmidt.Int.basis b).get i)
+
+/--
+After coercing coefficients into `ℝ`, the scaffolded Hex basis is intended
+to agree with Mathlib's `gramSchmidt` family.
+-/
+theorem basisFamily_eq_gramSchmidt (b : HexMatrix.Matrix Int n m) :
+    basisFamily b = InnerProductSpace.gramSchmidt ℝ (inputFamily b) := by
+  sorry
+
+/--
+Each scaffolded Hex basis row corresponds to the matching Mathlib
+`gramSchmidt` vector on the coerced input family.
+-/
+theorem basisFamily_apply_eq_gramSchmidt (b : HexMatrix.Matrix Int n m) (i : Fin n) :
+    basisFamily b i = InnerProductSpace.gramSchmidt ℝ (inputFamily b) i := by
+  simpa using congrFun (basisFamily_eq_gramSchmidt b) i
+
+/--
+The coerced Hex basis spans the same real subspace as the coerced input
+rows, matching Mathlib's span-preservation theorem for `gramSchmidt`.
+-/
+theorem span_basisFamily_eq_span_inputFamily (b : HexMatrix.Matrix Int n m) :
+    Submodule.span ℝ (Set.range (basisFamily b)) =
+      Submodule.span ℝ (Set.range (inputFamily b)) := by
+  simpa [basisFamily_eq_gramSchmidt b] using
+    (InnerProductSpace.span_gramSchmidt (𝕜 := ℝ) (f := inputFamily b))
+
+end Bridge
+
+end HexGramSchmidtMathlib

--- a/progress/2026-04-23T06:08:45Z_967461ce.md
+++ b/progress/2026-04-23T06:08:45Z_967461ce.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed feature issue `#188` via GitHub REST fallback because `coordination`'s GraphQL path was throttled in this session.
+- Added [`HexGramSchmidtMathlib/Bridge.lean`](/home/kim/hex/worktrees/967461ce/HexGramSchmidtMathlib/Bridge.lean) with the Phase 1 bridge scaffold: a conversion from Hex rational rows into Mathlib's real Euclidean-space vectors, the rowwise `basisFamily = gramSchmidt ℝ inputFamily` theorem surface, and the corresponding span-preservation theorem.
+- Updated [`HexGramSchmidtMathlib.lean`](/home/kim/hex/worktrees/967461ce/HexGramSchmidtMathlib.lean) to re-export the bridge module and document the public bridge surface.
+- Verified the new module with `lake env lean HexGramSchmidtMathlib/Bridge.lean` and `lake build HexGramSchmidtMathlib`; both succeeded, with only the expected scaffold-stage `sorry` warning in the new theorem.
+
+**Current frontier**
+
+- `HexGramSchmidtMathlib` now has its initial Phase 1 rowwise bridge scaffold on this branch and is ready for PR publication plus later completeness review work.
+
+**Next step**
+
+- Push the branch, open the PR closing `#188`, and let the queue advance to the next ready feature or review item.
+
+**Blockers**
+
+- `coordination list-unclaimed` / `claim` / `create-pr` were unusable in this session because the authenticated GitHub CLI had exhausted its GraphQL quota; REST API calls still worked for issue inspection and updates.


### PR DESCRIPTION
Closes #188

## Summary
- add `HexGramSchmidtMathlib/Bridge.lean` with the initial rowwise bridge from Hex's rational Gram-Schmidt basis into Mathlib's real Euclidean-space view
- state the scaffolded `basisFamily = InnerProductSpace.gramSchmidt ℝ inputFamily` and span-preservation theorem surface
- re-export the bridge module from `HexGramSchmidtMathlib.lean` and document the public bridge surface

## Verification
- `lake env lean HexGramSchmidtMathlib/Bridge.lean`
- `lake build HexGramSchmidtMathlib`
