### PR TITLE
Add HexHensel public henselLift precision wrapper

### DIFF
--- a/HexHensel.lean
+++ b/HexHensel.lean
@@ -1,10 +1,12 @@
 import HexHensel.Bridge
+import HexHensel.Lift
 import HexHensel.Linear
 
 /-!
 `HexHensel` re-exports the executable bridge surface between integer
 polynomials and residue-field polynomials together with the first
-linear-lifting scaffold that later Hensel algorithms build on.
+linear-lifting scaffold that later Hensel algorithms build on, including
+the public iterative `henselLift` wrapper.
 -/
 
 namespace HexHensel

--- a/HexHensel/Lift.lean
+++ b/HexHensel/Lift.lean
@@ -1,0 +1,62 @@
+import HexHensel.Linear
+
+/-!
+Executable iterative Hensel-lift scaffolding.
+
+This module packages the public `henselLift` wrapper promised by the
+`hex-hensel` specification. It iterates the existing linear step from an
+initial factorization modulo `p`, keeping the API total and computational
+while recording the intended precision contract as theorem statements for
+later phases.
+-/
+
+namespace HexHensel
+
+open HexPolyFp
+open HexPolyZ
+
+/--
+Number of linear refinement steps needed to reach the public precision
+target `p^k` when the input factorization already starts modulo `p`.
+-/
+def henselLiftStepCount (k : Nat) : Nat :=
+  k - 1
+
+/--
+Canonicalize the initial `mod p` input factors before iterative lifting.
+-/
+def henselLiftBase {p : Nat} [NeZero p] (g h : ZPoly) : LinearLiftResult :=
+  { g := ZPoly.reduceModPow g p 1
+    h := ZPoly.reduceModPow h p 1 }
+
+/--
+Iterate the linear Hensel step from current precision `p^precision` for a
+given number of remaining refinements.
+-/
+def henselLiftAux {p : Nat} [NeZero p]
+    (precision : Nat) (f : ZPoly) (s t : FpPoly p) : Nat → LinearLiftResult → LinearLiftResult
+  | 0, acc => acc
+  | steps + 1, acc =>
+      henselLiftAux (precision + 1) f s t steps (linearHenselStep precision f acc.g acc.h s t)
+
+/--
+Public iterative Hensel-lift wrapper producing factors intended to be
+valid modulo `p^k`.
+-/
+def henselLift {p : Nat} [NeZero p]
+    (k : Nat) (f g h : ZPoly) (s t : FpPoly p) : LinearLiftResult :=
+  henselLiftAux (p := p) 1 f s t (henselLiftStepCount k) (henselLiftBase (p := p) g h)
+
+/--
+If the initial factors are valid modulo `p`, iterating the linear step to
+precision `k` preserves the factorization modulo `p^k`.
+-/
+theorem henselLift_spec {p : Nat} [NeZero p]
+    (k : Nat) (hk : 1 ≤ k) (f g h : ZPoly) (s t : FpPoly p)
+    (hprod : ZPoly.congr (g * h) f p)
+    (hbez : s * ZPoly.modP p g + t * ZPoly.modP p h = FpPoly.C (p := p) 1)
+    (hmonic : HexPoly.DensePoly.Monic g) :
+    ZPoly.congr (LinearLiftResult.product (henselLift k f g h s t)) f (p ^ k) := by
+  sorry
+
+end HexHensel

--- a/progress/2026-04-23T07:58:13Z_246ed6aa.md
+++ b/progress/2026-04-23T07:58:13Z_246ed6aa.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed work item `#276` and added the public iterative Hensel wrapper surface for `HexHensel`.
+- Added [`HexHensel/Lift.lean`](/home/kim/hex/worktrees/246ed6aa/HexHensel/Lift.lean:1) with `henselLiftStepCount`, `henselLiftBase`, `henselLiftAux`, `henselLift`, and the theorem stub `henselLift_spec`.
+- Updated [`HexHensel.lean`](/home/kim/hex/worktrees/246ed6aa/HexHensel.lean:1) to re-export the new wrapper module.
+- Verified `lake build HexHensel` succeeds.
+
+**Current frontier**
+
+- `HexHensel` still lacks the remaining Phase 1 scaffold slices after the iterative single-factor wrapper, especially the quadratic doubling surface and the public multifactor API.
+- This session intentionally stopped at the linear-wrapper boundary and did not add `QuadraticLiftResult`, `quadraticHenselStep`, or `multifactorLift`.
+
+**Next step**
+
+- Publish the `#276` branch/PR if GitHub API limits allow, then let the next worker continue the remaining `HexHensel` scaffolding items on top of the new `henselLift` surface.
+
+**Blockers**
+
+- `coordination` and `gh` GraphQL-backed issue/PR helpers are currently hitting the account GraphQL rate limit, so publishing may need REST-only fallbacks until the limit resets.


### PR DESCRIPTION
Closes #276

## Summary
- add the dedicated `HexHensel.Lift` module for the public iterative `henselLift` wrapper
- expose helper definitions for the base normalization and linear-step iteration boundary
- re-export the wrapper from `HexHensel` and record this session in the required progress note

## Verification
- `lake build HexHensel`