### PR TITLE
spec: forbid wrong-but-plausible scaffolds; sharpen conformance idioms

### DIFF
--- a/PLAN/Phase1.md
+++ b/PLAN/Phase1.md
@@ -20,13 +20,45 @@ unless it explicitly fixes the public API or theorem split.
 
 ## Rules
 
-- **Real definitions, no definition-level sorry.** Every `structure`,
-  `def`, `class`, and `instance` must have a real implementation.
-  Data must be constructed. Propositional obligations (theorem
-  proofs, proof fields within structures) should use `sorry`.
+- **Correct implementations, or honest placeholders — no middle
+  ground.** Every `def`, `structure` field, `class`, and `instance`
+  must have a body that either
+  (a) *correctly* implements the SPEC contract for that declaration,
+  or
+  (b) is `sorry` (making the declaration `noncomputable`, trapping
+  at runtime via `sorryAx`, and leaving a visible warning).
+  **Placeholder bodies that typecheck but return wrong-but-plausible
+  output are forbidden** — they lie to downstream callers and invite
+  scaffold-locking conformance tests that pretend the stub is right.
+
+  Examples of forbidden bodies, each observed in practice:
+  - `def rref M := { rank := 0, echelon := M, transform := 1 }`
+    — the name promises RREF; the body is not RREF.
+  - `def spanCoeffs _ _ := none` — promises a span decomposition;
+    always says "no".
+  - `def gramSchmidt.basis b := b` — promises orthogonalisation;
+    returns input unchanged.
+  - `def gramSchmidt.coeffs _ := Matrix.identity` — promises the
+    lower-triangular Gram-Schmidt coefficient matrix; returns the
+    identity.
+
+  If you cannot implement a function correctly in this PR, either
+  defer the declaration entirely (if nothing downstream needs the
+  signature yet) or write the signature with a `sorry` body:
+
+  ```lean
+  noncomputable def rref (M : Matrix Rat n m) : RrefResult n m := sorry
+  ```
+
+  The next agent picking it up sees the `sorry` and knows there's
+  real work to do. A plausible-looking lie is invisible to both the
+  next agent and to conformance tests.
 
 - **`sorry`'d theorem proofs are expected.** The point of scaffolding
-  is to get the API surface compiling, not to fill in proofs.
+  is to get the API surface compiling, not to fill in proofs. This
+  rule applies to `theorem` bodies and propositional `structure`
+  fields. It does **not** extend an escape valve for data-level
+  bodies — see the rule above.
 
 - **Helper definitions** not in the SPEC are fine if needed to state
   the API. Note them in the PR.
@@ -52,8 +84,9 @@ For library `hex-foo`, Phase 1 is done when:
 - every named `def`, `structure`, `class`, `instance`, and `theorem`
   in `SPEC/Libraries/hex-foo.md` has a matching Lean declaration
   with the SPEC's signature;
-- `lake build <HexFooLib>` succeeds (proofs may be `sorry`;
-  data-level declarations must not be);
+- `lake build <HexFooLib>` succeeds (proofs may be `sorry`; data-level
+  declarations are either correct implementations or `sorry`-bodied
+  noncomputable stubs — wrong-but-plausible bodies are forbidden);
 - each new `.lean` file carries a module docstring summarising the
   library contents;
 - no `TODO`, `FIXME`, or `...` placeholder remains in the scaffolded

--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -19,6 +19,17 @@ These are not rubber-stamp coverage audits — they ask:
 - Are the theorem statements faithful to the SPEC? (Not "verbatim" — but
   do they capture the same mathematical content?)
 - Are there missing imports or DAG violations?
+- **Does every `def` / `structure` / `class` / `instance` body
+  actually implement the SPEC contract, or is it `sorry`?** Flag any
+  data-level body that returns the input unchanged, `0`,
+  `Matrix.identity`, `none`, an empty list, or similar trivial output
+  where the SPEC promises non-trivial computation. These are
+  "wrong-but-plausible" scaffolds — forbidden by
+  [PLAN/Phase1.md](Phase1.md) ("correct implementations, or honest
+  placeholders — no middle ground"). A reviewer flagging a wrong
+  scaffold is an acceptable Phase 2 outcome: open a follow-up issue
+  that rewrites the body as `sorry` (or implements it correctly), and
+  do not commit the `scaffolding-reviewed` token until the fix lands.
 
 ## Output
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -132,6 +132,38 @@ MUST NOT appear in any `Conformance.lean`:
   Int)` alongside `matrix := intMatN …` alongside a third copy on the
   RHS of `by decide`.
 
+- **Literal duplication across `#guard_msgs` and `#guard`.** A
+  `#guard X = [literal]` that immediately follows a `#guard_msgs in
+  #eval X` producing the same `[literal]` is redundant — the
+  expected value appears twice. Use one idiom per case:
+  - `#guard_msgs in #eval X` when the expected value fits on one
+    line and belongs in the source for reviewer benefit.
+  - `#guard X = formula(inputs)` when there is a closed-form
+    identity (`n % p`, `Nat.gcd a b`, `a * b % c`, Bézout, etc.)
+    that carries more content than a literal copy.
+
+  `#guard_msgs` documents *what the evaluator produces*; `#guard`
+  against a formula documents *what the contract says it should
+  produce*. Both together on the same case is either duplication or
+  contradiction.
+
+- **Scaffold-locking `#guard`s.** A `#guard` that asserts against
+  *current stub output* rather than against the SPEC contract —
+  e.g. `#guard (rref M).rank = 0` when `rref` is a placeholder —
+  locks the wrong answer in and hides the scaffold. If the
+  implementation is not yet correct, **do not** commit a conformance
+  check that accepts its wrong output. Either:
+  1. mark the implementation `sorry` per
+     [PLAN/Phase1.md](../PLAN/Phase1.md) and omit the conformance
+     check for that operation (it returns when the real
+     implementation lands); or
+  2. fix the implementation to match the contract before committing
+     the conformance check.
+
+  If the committed implementation returns wrong output, the
+  implementation is the bug — don't paper over it with a test that
+  says "this wrong output is expected".
+
 - **`native_decide`.** Banned project-wide (see
   [SPEC.md](SPEC.md#project-wide-proof-policy)). Restated here because
   conformance checks on large fixtures are a common temptation.
@@ -139,6 +171,44 @@ MUST NOT appear in any `Conformance.lean`:
 - **Conformance modules not reached by `lake build HexFoo`.** Every
   `Conformance.lean` MUST be imported from the library's root module
   so that `lake build HexFoo` elaborates its `#guard`s.
+
+## `#eval` vs `#eval!`
+
+`#eval e` errors when `e` transitively depends on any `sorry`,
+including `sorry` in Prop-valued proof fields of structures (see
+e.g. `HexPoly.DensePoly.ofArray`, which carries a `sorry`'d
+`isNormalized` proof field — this makes every `HexPoly.DensePoly`
+value's `#eval` refuse). `#eval!` bypasses the safety check.
+
+Prefer `#eval` when it works. Fall back to `#eval!` **only** when
+Lean's strict dependency check forces it — that is, when the
+structure being evaluated transitively depends on an unproven
+theorem-level `sorry`. In that case, a one-line comment above the
+`#eval!` should state which sorry-bearing declaration is blocking
+plain `#eval`, so future readers know when the `!` can come off.
+
+```lean
+-- #eval requires all of DensePoly's propositional fields to be
+-- non-sorry; `isNormalized_normalizeCoeffs` is currently `sorry`.
+/-- info: [3, 0, -2] -/
+#guard_msgs in #eval! (HexPoly.DensePoly.ofArray #[3, 0, -2, 0, 0]).coeffs.toList
+```
+
+Do not cargo-cult `#eval!` just because a neighbouring file uses it.
+`HexArith/Conformance.lean` uses plain `#eval` throughout — its
+computational dependencies are sorry-free — and other libraries
+whose computational graph is similarly clean should follow suit.
+
+## `#guard` vs `#guard decide`
+
+Prefer `#guard <bool-expr>` over `#guard decide (<prop>)`. The
+`decide` form is only needed when the assertion is a propositional
+equation that does not have a `BEq` / `DecidableEq` instance
+available directly — quantified statements, equality on types
+without `DecidableEq`, and similar cases. `List` of concrete types,
+polynomial coefficient comparisons, matrix-entry equality, option of
+such, and nearly every other conformance target have `BEq`
+instances; plain `#guard` works and is easier to read.
 
 ## Oracle strategy
 


### PR DESCRIPTION
## Summary

Three SPEC/PLAN edits that codify lessons from reviewing the six Conformance modules workers produced after https://github.com/kim-em/hex/pull/173:

1. `PLAN/Phase1.md`: replace "Real definitions, no sorry" with "correct implementations, or honest placeholders — no middle ground". Wrong-but-plausible bodies (`def rref M := { rank := 0, echelon := M, transform := 1 }`) are forbidden. A data-level def may either correctly implement the SPEC contract or be `noncomputable def ... := sorry` — not some third thing. Four observed forbidden examples included so the rule has teeth.

2. `PLAN/Phase2.md`: add a review question asking reviewers to flag bodies returning the input unchanged / `Matrix.identity` / `none` where the SPEC promises non-trivial computation, and say that flagging a wrong scaffold is an acceptable outcome (don't commit `scaffolding-reviewed` until fixed).

3. `SPEC/testing.md`: three new guardrails for conformance modules:
   - **Literal duplication** across `#guard_msgs` and `#guard` is an anti-pattern. Pick one idiom per case.
   - **Scaffold-locking `#guard`s** are forbidden. If the implementation is a stub, defer the conformance check — don't commit a test that accepts the stub's wrong output.
   - **`#guard` vs `#guard decide`**: prefer plain `#guard <bool>`.

Also a new `#eval` vs `#eval!` subsection: plain `#eval` errors on any transitive `sorry` dependency, including Prop-valued sorries in proof fields. Empirically verified (HexPoly.DensePoly.eval requires `#eval!` because ofArray's normalized field is sorry'd; HexArith.extGcd works with plain `#eval`). Prefer `#eval`; fall back to `#eval!` only when forced, with a comment naming the blocking sorry.

## Motivation

The first conformance-spec rewrite (#173) killed the original ceremony but several subtler failure modes still slipped through the followup conformance modules:

- `HexMatrix/Rref.lean` returns `{ rank := 0, echelon := M, transform := 1 }`. `HexMatrix/Conformance.lean` then asserts `(rref M).rank = 0` for every committed M — passing against the stub, wrong for any real rref. Both the Phase 1 author and the Phase 2 reviewer missed this.
- `HexGramSchmidt/Rat.lean` `basis` returns the input unchanged; `coeffs` returns `Matrix.identity`. Same pattern.
- `HexPoly/Conformance.lean` has ~15 lines where a `#guard X = [literal]` immediately follows a `#guard_msgs in #eval! X` producing the same literal — duplicated expected data.

All three failure modes are preventable at the prompt level; they happened because the rules weren't sharp enough.

Five follow-up `human-oversight` issues will be filed to clean up the existing artefacts this PR newly classifies as violations.

## Verification

- `lake build` still succeeds — all three edits are Markdown.
- `python3 scripts/check_dag.py` and `python3 scripts/status.py` unchanged.

🤖 Prepared with Claude Code