### PR TITLE
fix: remove scaffold-locking conformance guards

### DIFF
--- a/HexGramSchmidt/Conformance.lean
+++ b/HexGramSchmidt/Conformance.lean
@@ -14,13 +14,13 @@ Gram-Schmidt basis, coefficient, and Gram-determinant surface.
 - **Covered operations:** `Hex.GramSchmidt.Int.basis`,
   `Hex.GramSchmidt.Int.coeffs`, `Hex.GramSchmidt.Int.gramDet`,
   `Hex.GramSchmidt.Int.gramDetVec`, `Hex.GramSchmidt.Int.scaledCoeffs`,
-  `Hex.GramSchmidt.Rat.basis`, `Hex.GramSchmidt.Rat.coeffs`,
-  `Hex.GramSchmidt.Rat.gramDet`.
+  `Hex.GramSchmidt.Rat.basis`, `Hex.GramSchmidt.Rat.gramDet`.
 - **Covered properties:**
   - integer-input basis rows are the cast input rows on committed
     examples, including the `basis_zero` theorem;
-  - both integer and rational coefficient matrices stay identity on
-    committed examples, including `coeffs_diag` and `coeffs_upper`;
+  - integer coefficient checks stay on the theorem-backed diagonal and
+    upper-triangular shape guarantees, including `coeffs_diag` and
+    `coeffs_upper`;
   - integer and rational Gram determinants match the leading Gram-matrix
     determinant on typical, edge, and adversarial fixtures;
   - integer `gramDetVec` packages the full prefix determinant sequence;
@@ -30,7 +30,7 @@ Gram-Schmidt basis, coefficient, and Gram-determinant surface.
     `basisNormSqProduct` on committed examples.
 - **Covered edge cases:** zero row prefixes, repeated rows producing a
   zero Gram determinant, the `k = 0` Gram-determinant convention, and
-  diagonal/upper-triangular coefficient entries.
+  integer diagonal/upper-triangular coefficient entries.
 -/
 
 namespace HexGramSchmidt
@@ -136,12 +136,6 @@ example :
     Matrix.row (GramSchmidt.Int.basis intEdge) 1 = ratRow2 0 1 := by
   rfl
 
-#guard serializeRatMatrix (GramSchmidt.Int.coeffs intTypical) =
-  [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-
-#guard serializeRatMatrix (GramSchmidt.Int.coeffs intAdversarial) =
-  [[1, 0], [0, 1]]
-
 example :
     Matrix.row (GramSchmidt.Int.basis intTypical) 0 =
       GramSchmidt.Int.castRow (Matrix.row intTypical 0) := by
@@ -198,14 +192,6 @@ example :
 
 example :
     Matrix.row (GramSchmidt.Rat.basis ratEdge) 1 = ratRow2 0 1 := by
-  rfl
-
-example :
-    Matrix.entry (GramSchmidt.Rat.coeffs ratTypical) 2 2 = 1 := by
-  rfl
-
-example :
-    Matrix.entry (GramSchmidt.Rat.coeffs ratAdversarial) 0 1 = 0 := by
   rfl
 
 #guard GramSchmidt.Rat.gramDet ratTypical 0 (by decide) = 1

--- a/HexMatrix/Conformance.lean
+++ b/HexMatrix/Conformance.lean
@@ -13,11 +13,7 @@ the executable dense-matrix surface fail CI immediately.
 - **Oracle:** `none`.
 - **Mode:** `always`.
 - **Covered operations:** `Matrix.det`, `Matrix.bareiss`,
-  `Matrix.rowSwap`, `Matrix.rowScale`, `Matrix.rowAdd`, `rref`,
-  `IsEchelonForm.freeCols`, `IsEchelonForm.spanCoeffs`,
-  `IsEchelonForm.spanContains`, `Matrix.spanCoeffs`,
-  `Matrix.spanContains`, `IsRREF.nullspaceMatrix`,
-  `IsRREF.nullspace`, `Matrix.nullspace`.
+  `Matrix.rowSwap`, `Matrix.rowScale`, `Matrix.rowAdd`.
 - **Covered properties:**
   - `Matrix.bareiss` agrees with `Matrix.det` on committed examples.
   - Swapping distinct rows negates the determinant, while a self-swap
@@ -26,23 +22,11 @@ the executable dense-matrix surface fail CI immediately.
     including the zero-scalar edge case.
   - Adding a multiple of one row to another preserves the
     determinant, including the zero-coefficient edge case.
-  - The current `rref` scaffold keeps `rank = 0`, leaves the echelon
-    matrix unchanged, and uses the identity transform on committed
-    field-valued examples.
-  - For committed zero-matrix witnesses, `freeCols` enumerates every
-    column, `spanCoeffs` returns coefficients whose row-span
-    evaluation matches the zero target, and `spanContains` accepts the
-    zero vector.
-  - For committed zero-matrix witnesses, `nullspaceMatrix` and
-    `nullspace` return the standard-basis free-column vectors, and
-    each basis vector multiplies back to zero.
 - **Covered edge cases:**
   - identity and singular matrices for determinant evaluation
   - self-swap on the identity matrix
   - zero scaling on the identity matrix
   - zero-coefficient row addition on the identity matrix
-  - zero matrices with full free-column sets
-  - rectangular zero matrices for span and nullspace scaffolding
 -/
 namespace HexMatrix
 
@@ -86,53 +70,8 @@ private def intMat3
     else
       intRow3 a20 a21 a22
 
-private def ratRow1 (a0 : Rat) : Vector Rat 1 :=
-  Vector.ofFn fun _ => a0
-
 private def ratRow2 (a0 a1 : Rat) : Vector Rat 2 :=
   Vector.ofFn fun i => if i.1 = 0 then a0 else a1
-
-private def ratRow3 (a0 a1 a2 : Rat) : Vector Rat 3 :=
-  Vector.ofFn fun i =>
-    if i.1 = 0 then
-      a0
-    else if i.1 = 1 then
-      a1
-    else
-      a2
-
-private def ratMat11 (a00 : Rat) : Matrix Rat 1 1 :=
-  Vector.ofFn fun _ => ratRow1 a00
-
-private def ratMat23
-    (a00 a01 a02 : Rat)
-    (a10 a11 a12 : Rat) : Matrix Rat 2 3 :=
-  Vector.ofFn fun i => if i.1 = 0 then ratRow3 a00 a01 a02 else ratRow3 a10 a11 a12
-
-private def ratMat32
-    (a00 a01 : Rat)
-    (a10 a11 : Rat)
-    (a20 a21 : Rat) : Matrix Rat 3 2 :=
-  Vector.ofFn fun i =>
-    if i.1 = 0 then
-      ratRow2 a00 a01
-    else if i.1 = 1 then
-      ratRow2 a10 a11
-    else
-      ratRow2 a20 a21
-
-private def ratVec1 (a0 : Rat) : Vector Rat 1 :=
-  ratRow1 a0
-
-private def ratVec2 (a0 a1 : Rat) : Vector Rat 2 :=
-  ratRow2 a0 a1
-
-private def ratVec3 (a0 a1 a2 : Rat) : Vector Rat 3 :=
-  ratRow3 a0 a1 a2
-
-private def fin1_0 : Fin 1 := ⟨0, by decide⟩
-private def fin2_0 : Fin 2 := ⟨0, by decide⟩
-private def fin2_1 : Fin 2 := ⟨1, by decide⟩
 private def fin3_0 : Fin 3 := ⟨0, by decide⟩
 private def fin3_1 : Fin 3 := ⟨1, by decide⟩
 private def fin3_2 : Fin 3 := ⟨2, by decide⟩
@@ -151,39 +90,6 @@ private def identity3 : Matrix Int 3 3 :=
 
 private def denseAdversarial : Matrix Int 3 3 :=
   intMat3 1 2 3 4 5 6 7 8 9
-
-private def zeroRat11 : Matrix Rat 1 1 :=
-  ratMat11 0
-
-private def zeroRat23 : Matrix Rat 2 3 :=
-  ratMat23 0 0 0 0 0 0
-
-private def zeroRat32 : Matrix Rat 3 2 :=
-  ratMat32 0 0 0 0 0 0
-
-private def identityRat2 : Matrix Rat 2 2 :=
-  Matrix.identity
-
-private def rrefTypical : Matrix Rat 2 3 :=
-  ratMat23 1 2 3 0 1 4
-
-private def rrefZeroWitness23 : IsEchelonForm zeroRat23 (rref zeroRat23) :=
-  (rref_isRREF zeroRat23).toIsEchelonForm
-
-private def rrefZeroWitness11 : IsEchelonForm zeroRat11 (rref zeroRat11) :=
-  (rref_isRREF zeroRat11).toIsEchelonForm
-
-private def rrefZeroWitness32 : IsEchelonForm zeroRat32 (rref zeroRat32) :=
-  (rref_isRREF zeroRat32).toIsEchelonForm
-
-private def rrefZeroRref23 : IsRREF zeroRat23 (rref zeroRat23) :=
-  rref_isRREF zeroRat23
-
-private def rrefZeroRref11 : IsRREF zeroRat11 (rref zeroRat11) :=
-  rref_isRREF zeroRat11
-
-private def rrefZeroRref32 : IsRREF zeroRat32 (rref zeroRat32) :=
-  rref_isRREF zeroRat32
 
 /-- info: 9 -/
 #guard_msgs in
@@ -260,60 +166,6 @@ private def rrefZeroRref32 : IsRREF zeroRat32 (rref zeroRat32) :=
 #guard Matrix.det (Matrix.rowAdd detTypical fin3_2 fin3_0 3) = Matrix.det detTypical
 #guard Matrix.det (Matrix.rowAdd identity3 fin3_0 fin3_1 0) = Matrix.det identity3
 #guard Matrix.det (Matrix.rowAdd denseAdversarial fin3_1 fin3_2 (-2)) = Matrix.det denseAdversarial
-
-/-! ## `rref` and free-column scaffolding -/
-
-/-- info: (0, [[1, 2, 3], [0, 1, 4]]) -/
-#guard_msgs in
-#eval ((rref rrefTypical).rank, serializeBasis (rref rrefTypical).echelon)
-
-/-- info: (0, [[0, 0, 0], [0, 0, 0]]) -/
-#guard_msgs in
-#eval ((rref zeroRat23).rank, serializeBasis (rref zeroRat23).echelon)
-
-/-- info: [[1, 0], [0, 1]] -/
-#guard_msgs in
-#eval serializeBasis (rref identityRat2).transform
-
-#guard (rref rrefTypical).rank = 0
-#guard serializeBasis (rref rrefTypical).echelon = [[1, 2, 3], [0, 1, 4]]
-#guard serializeBasis (rref zeroRat23).echelon = [[0, 0, 0], [0, 0, 0]]
-#guard serializeBasis (rref identityRat2).transform = [[1, 0], [0, 1]]
-#guard rrefZeroWitness23.freeCols.toList.map Fin.val = [0, 1, 2]
-
-/-! ## `spanCoeffs` and `spanContains` -/
-
-#guard match rrefZeroWitness23.spanCoeffs (ratVec3 0 0 0) with
-  | some c => serializeVector c = [0, 0] ∧ serializeVector (zeroRat23 * c) = [0, 0, 0]
-  | none => False
-#guard match rrefZeroWitness11.spanCoeffs (ratVec1 0) with
-  | some c => serializeVector c = [0] ∧ serializeVector (zeroRat11 * c) = [0]
-  | none => False
-#guard match rrefZeroWitness32.spanCoeffs (ratVec2 0 0) with
-  | some c => serializeVector c = [0, 0, 0] ∧ serializeVector (zeroRat32 * c) = [0, 0]
-  | none => False
-#guard rrefZeroWitness23.spanContains (ratVec3 0 0 0) = true
-#guard rrefZeroWitness11.spanContains (ratVec1 0) = true
-#guard rrefZeroWitness32.spanContains (ratVec2 0 0) = true
-#guard Matrix.spanCoeffs identityRat2 (ratVec2 1 0) = none
-#guard Matrix.spanCoeffs zeroRat23 (ratVec3 0 0 0) = none
-#guard Matrix.spanContains rrefTypical (ratVec3 0 1 0) = false
-
-/-! ## `nullspaceMatrix`, `nullspace`, and `Matrix.nullspace` -/
-
-#guard serializeBasis (rrefZeroRref23.nullspaceMatrix) = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-#guard serializeBasis (rrefZeroRref11.nullspaceMatrix) = [[1]]
-#guard serializeBasis (rrefZeroRref32.nullspaceMatrix) = [[1, 0], [0, 1]]
-#guard serializeBasis (rrefZeroRref23.nullspace) = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-#guard serializeBasis (Matrix.nullspace zeroRat23) = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
-#guard serializeBasis (Matrix.nullspace zeroRat11) = [[1]]
-#guard serializeBasis (Matrix.nullspace zeroRat32) = [[1, 0], [0, 1]]
-#guard serializeVector (zeroRat23 * (Matrix.nullspace zeroRat23)[fin3_0]) = [0, 0]
-#guard serializeVector (zeroRat23 * (Matrix.nullspace zeroRat23)[fin3_1]) = [0, 0]
-#guard serializeVector (zeroRat23 * (Matrix.nullspace zeroRat23)[fin3_2]) = [0, 0]
-#guard serializeVector (zeroRat11 * (Matrix.nullspace zeroRat11)[fin1_0]) = [0]
-#guard serializeVector (zeroRat32 * (Matrix.nullspace zeroRat32)[fin2_0]) = [0, 0, 0]
-#guard serializeVector (zeroRat32 * (Matrix.nullspace zeroRat32)[fin2_1]) = [0, 0, 0]
 
 end Conformance
 

--- a/progress/2026-04-23T09:14:42Z_95611ae3.md
+++ b/progress/2026-04-23T09:14:42Z_95611ae3.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed human-oversight issue `#333` and removed scaffold-locking `#guard` assertions from `HexMatrix/Conformance.lean` covering `rref`, `freeCols`, `spanCoeffs`, `spanContains`, `nullspaceMatrix`, and `nullspace`.
+- Removed the scaffold-locking coefficient checks from `HexGramSchmidt/Conformance.lean` and rewrote both module docstrings so they describe only the remaining contract-backed coverage.
+- Ran `lake build HexMatrix HexGramSchmidt`; the build succeeded with the existing expected `sorry` warnings in scaffold modules.
+
+**Current frontier**
+
+- `HexMatrix` and `HexGramSchmidt` no longer certify the placeholder `rref`/nullspace and coefficient outputs through conformance checks, matching the updated testing rules.
+- The remaining cleanup in this area is the state rewind tracked by human-oversight issue `#334`, which depends on the broader scaffold-fix thread.
+
+**Next step**
+
+- Land this cleanup PR for `#333`, then handle `#334` or other follow-up review/state work once the dependency situation is appropriate.
+
+**Blockers**
+
+- None for `#333`; only the existing project scaffold `sorry`s remain as warnings during `lake build`.


### PR DESCRIPTION
Closes #333

Session: `95611ae3-99c8-46f3-9fd7-e615c9c62aa8`

ec290a4 fix: remove scaffold-locking conformance guards (progress 2026-04-23T09:14:42Z_95611ae3)

🤖 Prepared with Claude Code