### PR TITLE
feat: scaffold HexBerlekamp distinct-degree shell

### DIFF
--- a/HexBerlekamp.lean
+++ b/HexBerlekamp.lean
@@ -1,4 +1,5 @@
 import HexBerlekamp.Irreducibility
+import HexBerlekamp.DistinctDegree
 import HexBerlekamp.Rabin
 import HexBerlekamp.Splitting
 
@@ -7,8 +8,9 @@ import HexBerlekamp.Splitting
 the executable Berlekamp-matrix surface for Frobenius action modulo a
 polynomial, the immediate `Q_f - I` / kernel boundary, and the rank-based
 irreducibility test interface together with the first `gcd(f, h - c)`
-factor-splitting shell used by later factorization work, plus the
-certificate/checker boundary for Rabin's irreducibility criterion.
+factor-splitting shell used by later factorization work, the initial
+distinct-degree bucket extraction surface, and the certificate/checker
+boundary for Rabin's irreducibility criterion.
 -/
 
 namespace HexBerlekamp

--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -1,0 +1,169 @@
+import HexBerlekamp.Splitting
+
+/-!
+Executable distinct-degree factorization scaffolding for `HexBerlekamp`.
+
+This module adds the next public Phase 1 boundary after the single-step
+split scaffold: degree-bucket extraction driven by the standard
+`gcd(f, X^(p^d) - X)` witness polynomials. The executable layer packages
+each bucket attempt together with the corresponding Frobenius witness and
+quotient-by-gcd cofactor, while the theorem layer records the intended
+factorization contract for later phases.
+-/
+
+namespace HexBerlekamp
+
+open HexModArith
+
+variable {p : Nat} [NeZero p]
+
+/--
+Executable coefficient division for `ZMod64 p`.
+
+This matches the coefficient-division shell already used by the
+Berlekamp split and Rabin scaffolds.
+-/
+private def coeffDiv (a b : HexModArith.ZMod64 p) : HexModArith.ZMod64 p :=
+  match HexModArith.ZMod64.inv? b with
+  | some bInv => a * bInv
+  | none => 0
+
+/-- Polynomial division over `FpPoly` using the executable coefficient inverse shell. -/
+private def divBy (f g : HexPolyFp.FpPoly p) : HexPolyFp.FpPoly p := by
+  let _ : Div (HexModArith.ZMod64 p) := ⟨coeffDiv (p := p)⟩
+  exact HexPoly.DensePoly.div (R := HexModArith.ZMod64 p) f g
+
+/-- Polynomial gcd over `FpPoly` using the executable coefficient inverse shell. -/
+private def gcd (f g : HexPolyFp.FpPoly p) : HexPolyFp.FpPoly p := by
+  let _ : Div (HexModArith.ZMod64 p) := ⟨coeffDiv (p := p)⟩
+  exact HexPoly.DensePoly.gcd (R := HexModArith.ZMod64 p) f g
+
+/--
+One distinct-degree bucket attempt for a fixed positive degree `d`.
+
+The intended interpretation is that `extractedFactor` contains the
+product of the factors of `f` whose irreducible degrees divide `d`,
+while `remainingFactor` stores the corresponding quotient shell.
+-/
+structure DistinctDegreeBucket (p : Nat) [NeZero p] where
+  degreeIndex : Nat
+  frobeniusWitness : HexPolyFp.FpPoly p
+  splitPolynomial : HexPolyFp.FpPoly p
+  extractedFactor : HexPolyFp.FpPoly p
+  remainingFactor : HexPolyFp.FpPoly p
+
+/-- Public output of the current distinct-degree factorization scaffold. -/
+structure DistinctDegreeFactorizationResult (p : Nat) [NeZero p] where
+  source : HexPolyFp.FpPoly p
+  buckets : List (DistinctDegreeBucket p)
+
+/--
+The canonical distinct-degree witness polynomial `X^(p^d) - X (mod f)`.
+-/
+def distinctDegreeSplitPolynomial (f : HexPolyFp.FpPoly p) (d : Nat) :
+    HexPolyFp.FpPoly p :=
+  HexPolyFp.FpPoly.sub
+    (HexPolyFp.FpPoly.frobeniusPowModMonic HexPolyFp.FpPoly.X f d)
+    HexPolyFp.FpPoly.X
+
+/--
+Package the executable `gcd(f, X^(p^d) - X)` bucket extraction for a
+fixed degree `d`.
+-/
+def extractDistinctDegreeBucket (f : HexPolyFp.FpPoly p) (d : Nat) :
+    DistinctDegreeBucket p :=
+  let witness := HexPolyFp.FpPoly.frobeniusPowModMonic HexPolyFp.FpPoly.X f d
+  let splitPolynomial := distinctDegreeSplitPolynomial (p := p) f d
+  let extractedFactor := gcd f splitPolynomial
+  { degreeIndex := d
+    frobeniusWitness := witness
+    splitPolynomial := splitPolynomial
+    extractedFactor := extractedFactor
+    remainingFactor := divBy f extractedFactor }
+
+/--
+Enumerate the first-pass degree buckets `d = 1, ..., deg(f)` against the
+current polynomial `f`.
+-/
+def distinctDegreeBuckets (f : HexPolyFp.FpPoly p) : List (DistinctDegreeBucket p) :=
+  (List.range f.degree).map fun k => extractDistinctDegreeBucket (p := p) f (k + 1)
+
+/--
+Public distinct-degree factorization entry point.
+
+The current scaffold records the source polynomial together with the
+ordered bucket extractions for degrees `1` through `deg(f)`.
+-/
+def distinctDegreeFactorization (f : HexPolyFp.FpPoly p) :
+    DistinctDegreeFactorizationResult p :=
+  { source := f
+    buckets := distinctDegreeBuckets (p := p) f }
+
+/--
+`extractDistinctDegreeBucket` stores the advertised Frobenius witness
+`X^(p^d) mod f`.
+-/
+theorem extractDistinctDegreeBucket_frobeniusWitness (f : HexPolyFp.FpPoly p) (d : Nat) :
+    (extractDistinctDegreeBucket (p := p) f d).frobeniusWitness =
+      HexPolyFp.FpPoly.frobeniusPowModMonic HexPolyFp.FpPoly.X f d := by
+  rfl
+
+/--
+`extractDistinctDegreeBucket` stores the advertised witness polynomial
+`X^(p^d) - X (mod f)`.
+-/
+theorem extractDistinctDegreeBucket_splitPolynomial (f : HexPolyFp.FpPoly p) (d : Nat) :
+    (extractDistinctDegreeBucket (p := p) f d).splitPolynomial =
+      distinctDegreeSplitPolynomial (p := p) f d := by
+  rfl
+
+/-- `extractDistinctDegreeBucket` records the `gcd(f, X^(p^d) - X)` branch as its extracted factor. -/
+theorem extractDistinctDegreeBucket_extractedFactor (f : HexPolyFp.FpPoly p) (d : Nat) :
+    (extractDistinctDegreeBucket (p := p) f d).extractedFactor =
+      gcd f (distinctDegreeSplitPolynomial (p := p) f d) := by
+  rfl
+
+/-- `extractDistinctDegreeBucket` records the quotient-by-gcd branch as its remaining factor. -/
+theorem extractDistinctDegreeBucket_remainingFactor (f : HexPolyFp.FpPoly p) (d : Nat) :
+    (extractDistinctDegreeBucket (p := p) f d).remainingFactor =
+      divBy f (gcd f (distinctDegreeSplitPolynomial (p := p) f d)) := by
+  rfl
+
+/--
+Each bucket extraction is intended to package a factor/cofactor pair
+whose product reconstructs the input polynomial.
+-/
+theorem extractDistinctDegreeBucket_product (f : HexPolyFp.FpPoly p) (d : Nat) :
+    let result := extractDistinctDegreeBucket (p := p) f d
+    result.extractedFactor * result.remainingFactor = f := by
+  sorry
+
+/--
+The public factorization entry point preserves the source polynomial in
+its result record.
+-/
+theorem distinctDegreeFactorization_source (f : HexPolyFp.FpPoly p) :
+    (distinctDegreeFactorization (p := p) f).source = f := by
+  rfl
+
+/--
+The initial distinct-degree scaffold emits one bucket attempt for each
+degree `1, ..., deg(f)`.
+-/
+theorem distinctDegreeFactorization_buckets_length (f : HexPolyFp.FpPoly p) :
+    (distinctDegreeFactorization (p := p) f).buckets.length = f.degree := by
+  simp [distinctDegreeFactorization, distinctDegreeBuckets]
+
+/--
+Every bucket reported by `distinctDegreeFactorization` is intended to
+store the corresponding `gcd(f, X^(p^d) - X)` extraction data for its
+recorded degree index.
+-/
+theorem distinctDegreeFactorization_bucket_spec (f : HexPolyFp.FpPoly p) :
+    ∀ bucket ∈ (distinctDegreeFactorization (p := p) f).buckets,
+      bucket.splitPolynomial =
+          distinctDegreeSplitPolynomial (p := p) f bucket.degreeIndex ∧
+        bucket.extractedFactor = gcd f bucket.splitPolynomial := by
+  sorry
+
+end HexBerlekamp

--- a/HexBerlekamp/Rabin.lean
+++ b/HexBerlekamp/Rabin.lean
@@ -1,5 +1,4 @@
 import HexBerlekamp.Splitting
-import HexPoly.Gcd
 
 /-!
 Executable Rabin irreducibility scaffolding for `HexBerlekamp`.

--- a/progress/2026-04-23T09-54-30Z_c96080e8.md
+++ b/progress/2026-04-23T09-54-30Z_c96080e8.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#366` via GitHub REST fallback after `coordination claim` failed under an exhausted GraphQL quota.
+- Added [`HexBerlekamp/DistinctDegree.lean`](/home/kim/hex/worktrees/c96080e8/HexBerlekamp/DistinctDegree.lean) with an executable distinct-degree bucket scaffold: witness polynomial `X^(p^d) - X (mod f)`, `gcd`-based bucket extraction, a public factorization result record, and theorem stubs for the intended product/spec contracts.
+- Updated [`HexBerlekamp.lean`](/home/kim/hex/worktrees/c96080e8/HexBerlekamp.lean) to re-export the new distinct-degree module and mention the new surface in the library docstring.
+- Verified the issue scope with `lake build HexBerlekamp`.
+
+**Current frontier**
+
+- `HexBerlekamp` now has a dedicated distinct-degree-factorization entrypoint, but Phase 1 still needs the remaining scaffold surface beyond this slice before `libraries.yml` can move to `done_through: 1`.
+
+**Next step**
+
+- Land this slice as the PR for `#366`, then pick up the next missing `HexBerlekamp` or `HexHensel` Phase 1 scaffold that blocks downstream factorization libraries.
+
+**Blockers**
+
+- `coordination` commands that rely on GitHub GraphQL repo detection are currently failing because the authenticated account has exhausted its GraphQL rate limit; REST endpoints still work.

--- a/progress/2026-04-23T10:11:06Z_2c94571b.md
+++ b/progress/2026-04-23T10:11:06Z_2c94571b.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed PR `#372` for repair and checked out `agent/c96080e8`.
+- Diagnosed the failed CI as a DAG-boundary violation from [`HexBerlekamp/Rabin.lean`](/home/kim/hex/worktrees/2c94571b/HexBerlekamp/Rabin.lean:2) importing `HexPoly.Gcd` outside the `HexBerlekamp` library boundary.
+- Removed the out-of-boundary import; the file still builds through the transitive API already exposed by `HexBerlekamp.Splitting`.
+- Verified the repair with `python3 scripts/check_dag.py` and a full `lake build` run, both passing locally.
+
+**Current frontier**
+
+- This repair branch is ready to push back to PR `#372` and mark salvaged.
+
+**Next step**
+
+- Force-push the repair commit and call `coordination mark-pr-salvaged 372`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #366

## Summary
- add `HexBerlekamp/DistinctDegree.lean` with executable `gcd(f, X^(p^d) - X)` bucket extraction scaffolding
- expose a public distinct-degree factorization result surface and theorem stubs for the intended contracts
- re-export the new module from `HexBerlekamp.lean`

## Verification
- `lake build HexBerlekamp`

## Coordination
- GitHub GraphQL quota is exhausted for this session, so claim/PR lifecycle updates are using REST fallbacks instead of `coordination create-pr`.