### PR TITLE
test: extend HexGfqRing unit-cast conformance

### DIFF
--- a/HexGfqRing/Conformance.lean
+++ b/HexGfqRing/Conformance.lean
@@ -13,19 +13,27 @@ quotient-representation boundary of `HexGfqRing`.
   reduction invariants.
 - **Mode:** `always`.
 - **Covered operations:** `HexGfqRing.reduceMod`, `HexGfqRing.ofPoly`,
-  `HexGfqRing.repr`, quotient addition, quotient negation, quotient
+  `HexGfqRing.repr`, quotient `0`, quotient `1`, natural-number casts,
+  integer casts, quotient addition, quotient negation, quotient
   subtraction, quotient multiplication, quotient exponentiation.
 - **Covered properties:**
   - `ofPoly` stores `reduceMod`'s canonical representative on committed
     examples;
   - stored representatives stay reduced under another `reduceMod`
     pass on committed examples;
+  - the typeclass-facing unit and cast constructors agree with the
+    corresponding reduced constant-polynomial representatives on
+    committed examples;
   - the top-level `repr_add`, `repr_neg`, `repr_sub`, `repr_mul`, and
     `repr_pow` formulas agree with the reduced arithmetic formulas on
-    committed examples.
+    committed examples;
+  - the quotient `CommRing` surface satisfies `x + 0 = x`, `x * 1 = x`,
+    `x + (-x) = 0`, and cast-negation sanity checks on committed
+    examples.
 - **Covered edge cases:** zero-polynomial inputs, a linear modulus, a
-  `pow` exponent of `0`, and trailing-zero coefficient arrays that must
-  normalize before quotient reduction.
+  `pow` exponent of `0`, zero/unit/cast constructors under the linear
+  modulus, and trailing-zero coefficient arrays that must normalize
+  before quotient reduction.
 -/
 
 namespace HexGfqRing
@@ -55,26 +63,30 @@ private theorem typicalModulus_pos : 0 < typicalModulus.degree := by decide
 private theorem edgeModulus_pos : 0 < edgeModulus.degree := by decide
 private theorem adversarialModulus_pos : 0 < adversarialModulus.degree := by decide
 
+private abbrev TypicalQ := PolyQuotient 5 typicalModulus typicalModulus_pos
+private abbrev EdgeQ := PolyQuotient 3 edgeModulus edgeModulus_pos
+private abbrev AdversarialQ := PolyQuotient 3 adversarialModulus adversarialModulus_pos
+
 private def reduceTypicalInput : P5 := poly5 [3, 4, 1]
 private def reduceEdgeInput : P3 := 0
 private def reduceAdversarialInput : P3 := poly3 [2, 0, 0, 1, 0, 0]
 
-private def typicalX : PolyQuotient 5 typicalModulus typicalModulus_pos :=
+private def typicalX : TypicalQ :=
   ofPoly (f := typicalModulus) typicalModulus_pos reduceTypicalInput
 
-private def typicalY : PolyQuotient 5 typicalModulus typicalModulus_pos :=
+private def typicalY : TypicalQ :=
   ofPoly (f := typicalModulus) typicalModulus_pos (poly5 [1, 2])
 
-private def edgeX : PolyQuotient 3 edgeModulus edgeModulus_pos :=
+private def edgeX : EdgeQ :=
   ofPoly (f := edgeModulus) edgeModulus_pos (poly3 [0, 2, 0, 0])
 
-private def edgeY : PolyQuotient 3 edgeModulus edgeModulus_pos :=
+private def edgeY : EdgeQ :=
   ofPoly (f := edgeModulus) edgeModulus_pos (poly3 [1])
 
-private def adversarialX : PolyQuotient 3 adversarialModulus adversarialModulus_pos :=
+private def adversarialX : AdversarialQ :=
   ofPoly (f := adversarialModulus) adversarialModulus_pos reduceAdversarialInput
 
-private def adversarialY : PolyQuotient 3 adversarialModulus adversarialModulus_pos :=
+private def adversarialY : AdversarialQ :=
   ofPoly (f := adversarialModulus) adversarialModulus_pos (poly3 [1, 2, 1])
 
 -- `#eval` must bypass sorry-bearing proof fields in `DensePoly` and
@@ -123,6 +135,73 @@ private def adversarialY : PolyQuotient 3 adversarialModulus adversarialModulus_
 
 #guard coeffsToNat (repr adversarialX) = coeffsToNat (reduceMod adversarialModulus reduceAdversarialInput)
 #guard coeffsToNat (reduceMod adversarialModulus (repr adversarialX)) = coeffsToNat (repr adversarialX)
+
+/-! ## Quotient units and casts -/
+
+/-- info: [] -/
+#guard_msgs in
+#eval! coeffsToNat (repr (0 : TypicalQ))
+
+/-- info: [1] -/
+#guard_msgs in
+#eval! coeffsToNat (repr (1 : EdgeQ))
+
+/-- info: [2] -/
+#guard_msgs in
+#eval! coeffsToNat (repr (5 : AdversarialQ))
+
+#guard coeffsToNat (repr (0 : TypicalQ)) = coeffsToNat (reduceMod typicalModulus 0)
+#guard coeffsToNat (repr (1 : EdgeQ)) = coeffsToNat (reduceMod edgeModulus (FpPoly.C 1))
+#guard coeffsToNat (repr (5 : AdversarialQ)) =
+  coeffsToNat (reduceMod adversarialModulus (FpPoly.C 5))
+
+/-- info: [3] -/
+#guard_msgs in
+#eval! coeffsToNat (repr (3 : TypicalQ))
+
+/-- info: [] -/
+#guard_msgs in
+#eval! coeffsToNat (repr (0 : EdgeQ))
+
+/-- info: [3] -/
+#guard_msgs in
+#eval! coeffsToNat (repr ((-2 : Int) : TypicalQ))
+
+/-- info: [2] -/
+#guard_msgs in
+#eval! coeffsToNat (repr ((-1 : Int) : EdgeQ))
+
+/-- info: [2] -/
+#guard_msgs in
+#eval! coeffsToNat (repr ((-4 : Int) : AdversarialQ))
+
+#guard coeffsToNat (repr (3 : TypicalQ)) = coeffsToNat (reduceMod typicalModulus (FpPoly.C 3))
+#guard coeffsToNat (repr (0 : EdgeQ)) = coeffsToNat (reduceMod edgeModulus (FpPoly.C 0))
+#guard coeffsToNat (repr ((-2 : Int) : TypicalQ)) =
+  coeffsToNat (reduceMod typicalModulus (0 - FpPoly.C 2))
+#guard coeffsToNat (repr ((-1 : Int) : EdgeQ)) =
+  coeffsToNat (reduceMod edgeModulus (0 - FpPoly.C 1))
+#guard coeffsToNat (repr ((-4 : Int) : AdversarialQ)) =
+  coeffsToNat (reduceMod adversarialModulus (0 - FpPoly.C 4))
+
+/-! ## Quotient unit and cast identities -/
+
+#guard coeffsToNat (repr (typicalX + (0 : TypicalQ))) = coeffsToNat (repr typicalX)
+#guard coeffsToNat (repr (edgeX + (0 : EdgeQ))) = coeffsToNat (repr edgeX)
+#guard coeffsToNat (repr (adversarialX + (0 : AdversarialQ))) = coeffsToNat (repr adversarialX)
+
+#guard coeffsToNat (repr (typicalY * (1 : TypicalQ))) = coeffsToNat (repr typicalY)
+#guard coeffsToNat (repr (edgeY * (1 : EdgeQ))) = coeffsToNat (repr edgeY)
+#guard coeffsToNat (repr (adversarialY * (1 : AdversarialQ))) = coeffsToNat (repr adversarialY)
+
+#guard coeffsToNat (repr (typicalX + -typicalX)) = coeffsToNat (repr (0 : TypicalQ))
+#guard coeffsToNat (repr (edgeX + -edgeX)) = coeffsToNat (repr (0 : EdgeQ))
+#guard coeffsToNat (repr (adversarialX + -adversarialX)) = coeffsToNat (repr (0 : AdversarialQ))
+
+#guard coeffsToNat (repr ((-(3 : Int)) : TypicalQ)) = coeffsToNat (repr (-((3 : TypicalQ))))
+#guard coeffsToNat (repr ((-(1 : Int)) : EdgeQ)) = coeffsToNat (repr (-((1 : EdgeQ))))
+#guard coeffsToNat (repr ((-(4 : Int)) : AdversarialQ)) =
+  coeffsToNat (repr (-((4 : AdversarialQ))))
 
 /-! ## Quotient representative formulas -/
 

--- a/progress/2026-04-23T10:01:04Z_a4f80f99.md
+++ b/progress/2026-04-23T10:01:04Z_a4f80f99.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#370` via GitHub REST fallback because GraphQL quota exhaustion prevented `coordination claim`.
+- Extended `HexGfqRing/Conformance.lean` so the Phase 3 core conformance slice now covers quotient `0`, quotient `1`, natural casts, and integer casts in addition to the existing representative-formula checks.
+- Added committed typical/edge/adversarial guards for unit and cast representatives plus concrete `CommRing`-surface identity checks for `x + 0 = x`, `x * 1 = x`, `x + (-x) = 0`, and cast negation sanity.
+- Verified the updated library with `lake build HexGfqRing`.
+
+**Current frontier**
+
+- Issue `#370` is implemented locally on `agent/a4f80f99`; the remaining coordination work is publishing the branch/PR through REST-compatible GitHub commands because the standard `coordination create-pr` path depends on exhausted GraphQL quota.
+
+**Next step**
+
+- Commit the conformance update, push `agent/a4f80f99`, and open a PR closing `#370` with a note that REST fallbacks were required for claim/PR lifecycle actions.
+
+**Blockers**
+
+- GitHub GraphQL rate limit is exhausted for this session, so `coordination` commands that rely on GraphQL fail even though REST API quota remains available.


### PR DESCRIPTION
Closes #370

## Summary
- extend `HexGfqRing/Conformance.lean` to cover quotient `0`/`1`, nat casts, and int casts
- add committed typical, edge, and adversarial guards for representative agreement on the unit/cast surface
- add concrete `CommRing`-surface identity guards for `x + 0`, `x * 1`, `x + (-x)`, and cast negation sanity

## Verification
- `lake build HexGfqRing`

## Coordination
- GitHub GraphQL quota is exhausted for this session, so claim/PR lifecycle updates used REST fallbacks instead of `coordination create-pr`.
- Progress: `progress/2026-04-23T10:01:04Z_a4f80f99.md`