### PR TITLE
spec: strengthen rule — no data-level placeholders of any kind

### DIFF
--- a/PLAN/Phase1.md
+++ b/PLAN/Phase1.md
@@ -20,18 +20,30 @@ unless it explicitly fixes the public API or theorem split.
 
 ## Rules
 
-- **Correct implementations, or honest placeholders — no middle
-  ground.** Every `def`, `structure` field, `class`, and `instance`
-  must have a body that either
-  (a) *correctly* implements the SPEC contract for that declaration,
-  or
-  (b) is `sorry` (making the declaration `noncomputable`, trapping
-  at runtime via `sorryAx`, and leaving a visible warning).
-  **Placeholder bodies that typecheck but return wrong-but-plausible
-  output are forbidden** — they lie to downstream callers and invite
-  scaffold-locking conformance tests that pretend the stub is right.
+- **No data-level placeholders — at all.** Every `def`, `structure`
+  field, `class`, and `instance` must have a body that *correctly*
+  implements the SPEC contract for that declaration. There is no
+  placeholder form that's acceptable: not wrong-but-plausible bodies
+  (`def rref M := { rank := 0, echelon := M, transform := 1 }`),
+  not `sorry` bodies (`noncomputable def rref ... := sorry`), not
+  `axiom rref : ...`, not trivial returns (`Matrix.identity`, `none`,
+  the input unchanged). If you cannot implement it correctly in this
+  PR, **do not commit the declaration** — leave it out of Lean
+  entirely. The SPEC file is the record of what's designed; the Lean
+  surface is the record of what's implemented correctly so far.
 
-  Examples of forbidden bodies, each observed in practice:
+  Why: a placeholder that typechecks lies to downstream code and to
+  future agents. A wrong-but-plausible body invites scaffold-locking
+  conformance tests. A `sorry` body makes every caller's `#eval`
+  refuse to run (Lean conservatively refuses any term transitively
+  depending on `sorry`), so any conformance test against that caller
+  has to use `#eval!`, which then silently accepts whatever bits the
+  runtime produces for `sorryAx` — neither "correct" nor "obviously
+  wrong", just untrustworthy. An omitted declaration, by contrast,
+  breaks the build at the use site loudly and points the next agent
+  directly at the thing to implement.
+
+  Forbidden data-level body patterns, each observed in practice:
   - `def rref M := { rank := 0, echelon := M, transform := 1 }`
     — the name promises RREF; the body is not RREF.
   - `def spanCoeffs _ _ := none` — promises a span decomposition;
@@ -39,29 +51,28 @@ unless it explicitly fixes the public API or theorem split.
   - `def gramSchmidt.basis b := b` — promises orthogonalisation;
     returns input unchanged.
   - `def gramSchmidt.coeffs _ := Matrix.identity` — promises the
-    lower-triangular Gram-Schmidt coefficient matrix; returns the
-    identity.
+    lower-triangular coefficient matrix; returns the identity.
+  - `noncomputable def rref ... := sorry` — an explicit placeholder;
+    still forbidden, same reasons.
 
-  If you cannot implement a function correctly in this PR, either
-  defer the declaration entirely (if nothing downstream needs the
-  signature yet) or write the signature with a `sorry` body:
-
-  ```lean
-  noncomputable def rref (M : Matrix Rat n m) : RrefResult n m := sorry
-  ```
-
-  The next agent picking it up sees the `sorry` and knows there's
-  real work to do. A plausible-looking lie is invisible to both the
-  next agent and to conformance tests.
+  What to do if you can't implement it: narrow the Phase 1 issue,
+  commit only the declarations you *can* correctly implement,
+  document (in the PR description) which SPEC declarations are being
+  deferred to a follow-up issue, and open that follow-up. Don't
+  commit stubs to keep the PR "complete" — an incomplete but honest
+  Phase 1 is strictly better than a complete-looking one with
+  placeholders.
 
 - **`sorry`'d theorem proofs are expected.** The point of scaffolding
   is to get the API surface compiling, not to fill in proofs. This
   rule applies to `theorem` bodies and propositional `structure`
-  fields. It does **not** extend an escape valve for data-level
-  bodies — see the rule above.
+  fields — those produce `Prop` values, and a `sorry` proof doesn't
+  propagate into computation. It does **not** extend an escape
+  valve for data-level bodies — see the rule above.
 
 - **Helper definitions** not in the SPEC are fine if needed to state
-  the API. Note them in the PR.
+  the API. Note them in the PR. The same "correctly implemented or
+  not committed" rule applies.
 
 - **Verify:** `lake build` must succeed after each scaffolding PR.
 
@@ -81,12 +92,14 @@ shape, decomposition, partial progress) live in
 
 For library `hex-foo`, Phase 1 is done when:
 
-- every named `def`, `structure`, `class`, `instance`, and `theorem`
-  in `SPEC/Libraries/hex-foo.md` has a matching Lean declaration
-  with the SPEC's signature;
-- `lake build <HexFooLib>` succeeds (proofs may be `sorry`; data-level
-  declarations are either correct implementations or `sorry`-bodied
-  noncomputable stubs — wrong-but-plausible bodies are forbidden);
+- every SPEC declaration that has been implemented in Lean has a
+  signature matching the SPEC, and a body that correctly implements
+  the SPEC contract (no `sorry`, no `axiom`, no wrong-but-plausible
+  trivial body);
+- SPEC declarations that have *not* yet been correctly implemented
+  are not present in Lean — the PR description records which ones
+  are deferred to follow-ups, and a follow-up issue exists for each;
+- `lake build <HexFooLib>` succeeds;
 - each new `.lean` file carries a module docstring summarising the
   library contents;
 - no `TODO`, `FIXME`, or `...` placeholder remains in the scaffolded

--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -19,17 +19,19 @@ These are not rubber-stamp coverage audits — they ask:
 - Are the theorem statements faithful to the SPEC? (Not "verbatim" — but
   do they capture the same mathematical content?)
 - Are there missing imports or DAG violations?
-- **Does every `def` / `structure` / `class` / `instance` body
-  actually implement the SPEC contract, or is it `sorry`?** Flag any
-  data-level body that returns the input unchanged, `0`,
-  `Matrix.identity`, `none`, an empty list, or similar trivial output
-  where the SPEC promises non-trivial computation. These are
-  "wrong-but-plausible" scaffolds — forbidden by
-  [PLAN/Phase1.md](Phase1.md) ("correct implementations, or honest
-  placeholders — no middle ground"). A reviewer flagging a wrong
-  scaffold is an acceptable Phase 2 outcome: open a follow-up issue
-  that rewrites the body as `sorry` (or implements it correctly), and
-  do not commit the `scaffolding-reviewed` token until the fix lands.
+- **Does every committed `def` / `structure` field / `class` /
+  `instance` body actually implement the SPEC contract correctly?**
+  [PLAN/Phase1.md](Phase1.md) forbids data-level placeholders of any
+  kind — no `sorry` bodies, no `axiom`s standing in for data, no
+  trivial returns (input unchanged, `0`, `Matrix.identity`, `none`,
+  empty list). A library must commit only the declarations it can
+  correctly implement; everything else stays out of Lean until a
+  later PR implements it. Flag any committed declaration whose body
+  is a placeholder in any of these forms. Flagged bodies must be
+  deleted (and any downstream callers updated) in a follow-up issue
+  before the `scaffolding-reviewed` token is committed — either the
+  implementation becomes correct, or the declaration leaves the
+  tree. "Rewrite as `sorry`" is **not** an acceptable fix.
 
 ## Output
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -150,19 +150,14 @@ MUST NOT appear in any `Conformance.lean`:
 - **Scaffold-locking `#guard`s.** A `#guard` that asserts against
   *current stub output* rather than against the SPEC contract —
   e.g. `#guard (rref M).rank = 0` when `rref` is a placeholder —
-  locks the wrong answer in and hides the scaffold. If the
-  implementation is not yet correct, **do not** commit a conformance
-  check that accepts its wrong output. Either:
-  1. mark the implementation `sorry` per
-     [PLAN/Phase1.md](../PLAN/Phase1.md) and omit the conformance
-     check for that operation (it returns when the real
-     implementation lands); or
-  2. fix the implementation to match the contract before committing
-     the conformance check.
-
-  If the committed implementation returns wrong output, the
-  implementation is the bug — don't paper over it with a test that
-  says "this wrong output is expected".
+  locks the wrong answer in and hides the scaffold. Per
+  [PLAN/Phase1.md](../PLAN/Phase1.md), no data-level placeholders
+  are allowed in committed Lean at all; if a conformance test has to
+  lock in trivial output to pass, the underlying implementation is
+  a placeholder that should not have been committed in the first
+  place. Fix the implementation (or remove the declaration until
+  it's implementable), don't paper over it with a test that says
+  "this wrong output is expected".
 
 - **`native_decide`.** Banned project-wide (see
   [SPEC.md](SPEC.md#project-wide-proof-policy)). Restated here because


### PR DESCRIPTION
## Summary

Follow-up to #331, which I wrote too permissively. The rule said "correct implementations, or honest placeholders — no middle ground" and suggested `noncomputable def ... := sorry` as an acceptable placeholder form. Kim's pushback: that's still an escape valve.

This PR removes the escape valve. The Phase 1 rule is now:

> **No data-level placeholders — at all.** Every `def`, `structure` field, `class`, and `instance` must have a body that *correctly* implements the SPEC contract. No `sorry` bodies, no `axiom`s standing in for data, no trivial wrong-but-plausible returns (input unchanged, `0`, `Matrix.identity`, `none`). If you can't implement it correctly in this PR, **don't commit the declaration** — leave it out of Lean until a future PR can implement it correctly. The SPEC file records what's designed; the Lean surface records what's implemented correctly so far.

## Why not `sorry`

A `sorry`-bodied data-level def makes every caller's `#eval` refuse to run (Lean conservatively refuses any term transitively depending on `sorry`). Any conformance test against that caller falls back to `#eval!`, which silently accepts whatever `sorryAx` produces at runtime — neither correct nor obviously wrong, just untrustworthy. An omitted declaration, by contrast, fails the build at every use site, pointing the next agent directly at the implementation gap.

Theorem-level `sorry`s stay allowed (they're Prop-valued and don't propagate into computation). Scope of the ban is data only.

## Corresponding tightening in Phase 2 and SPEC/testing.md

- [PLAN/Phase2.md](https://github.com/kim-em/hex/blob/main/PLAN/Phase2.md) review question: "rewrite as `sorry`" is explicitly NOT an acceptable fix for a flagged placeholder. Either the body becomes correct or the declaration is removed from the tree.

- [SPEC/testing.md](https://github.com/kim-em/hex/blob/main/SPEC/testing.md) scaffold-locking anti-pattern text updated: since placeholders are banned upstream, a conformance test that has to lock in trivial output is really a symptom of an illegally committed placeholder.

## Impact on pending issues

Issues #332, #333, #334 currently describe the fix as "rewrite as `sorry` / noncomputable". That fix is no longer valid under this rule. I'll update those issue bodies to say "either correctly implement the declaration, or delete it (along with every downstream use)" — follow-up.

## Verification

- `lake build` still succeeds — all edits are Markdown.
- `python3 scripts/check_dag.py`, `python3 scripts/status.py` unchanged.

🤖 Prepared with Claude Code