### PR TITLE
fix: salvage HexGramSchmidt row-op conformance

### DIFF
--- a/HexGramSchmidt/Conformance.lean
+++ b/HexGramSchmidt/Conformance.lean
@@ -1,5 +1,6 @@
 import HexGramSchmidt.GramDet
 import HexGramSchmidt.Rat
+import HexGramSchmidt.Update
 
 /-!
 # `HexGramSchmidt` -- core conformance
@@ -74,6 +75,24 @@ private def ratEdge : Matrix Rat 2 2 :=
 private def ratAdversarial : Matrix Rat 2 2 :=
   matrixOfList2D! [[1, 2], [1, 2]]
 
+private def sizeReduceTypical : Matrix Int 3 3 :=
+  matrixOfList2D! [[5, -1, 2], [0, 3, 4], [7, 8, -6]]
+
+private def sizeReduceEdge : Matrix Int 2 3 :=
+  matrixOfList2D! [[0, 0, 0], [0, 0, 0]]
+
+private def sizeReduceAdversarial : Matrix Int 3 2 :=
+  matrixOfList2D! [[2, -3], [2, -3], [-5, 11]]
+
+private def adjacentSwapTypical : Matrix Int 3 2 :=
+  matrixOfList2D! [[1, 2], [3, 4], [5, 6]]
+
+private def adjacentSwapEdge : Matrix Int 2 2 :=
+  matrixOfList2D! [[9, -2], [4, 7]]
+
+private def adjacentSwapAdversarial : Matrix Int 3 2 :=
+  matrixOfList2D! [[4, -1], [4, -1], [-8, 5]]
+
 /-! ## Integer basis and coefficients -/
 
 example :
@@ -147,6 +166,30 @@ example :
 #guard GramSchmidt.Rat.gramDet ratTypical 2 (by decide) = 16
 #guard GramSchmidt.Rat.gramDet ratEdge 2 (by decide) = 1
 #guard GramSchmidt.Rat.gramDet ratAdversarial 2 (by decide) = 0
+
+/-! ## Integer row operations -/
+
+#guard GramSchmidt.Int.sizeReduce sizeReduceTypical 2 0 3 =
+  Matrix.rowAdd sizeReduceTypical ⟨2, by decide⟩ ⟨0, by decide⟩ (-3)
+
+#guard GramSchmidt.Int.sizeReduce sizeReduceEdge 2 0 7 = sizeReduceEdge
+
+#guard GramSchmidt.Int.sizeReduce sizeReduceAdversarial 2 3 (-2) =
+  sizeReduceAdversarial
+
+#guard GramSchmidt.Int.sizeReduce sizeReduceAdversarial 1 0 (-2) =
+  Matrix.rowAdd sizeReduceAdversarial ⟨1, by decide⟩ ⟨0, by decide⟩ 2
+
+#guard GramSchmidt.Int.adjacentSwap adjacentSwapTypical 2 =
+  Matrix.rowSwap adjacentSwapTypical ⟨2, by decide⟩ ⟨1, by decide⟩
+
+#guard GramSchmidt.Int.adjacentSwap adjacentSwapEdge 0 = adjacentSwapEdge
+
+#guard GramSchmidt.Int.adjacentSwap adjacentSwapAdversarial 3 =
+  adjacentSwapAdversarial
+
+#guard GramSchmidt.Int.adjacentSwap adjacentSwapAdversarial 1 =
+  Matrix.rowSwap adjacentSwapAdversarial ⟨1, by decide⟩ ⟨0, by decide⟩
 
 end
 end Conformance

--- a/progress/2026-04-23T10:16:33Z_884f77ac.md
+++ b/progress/2026-04-23T10:16:33Z_884f77ac.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed issue `#383` and diagnosed PR `#381` as stale against `main`: its original change replaced the entire `HexGramSchmidt/Conformance.lean` file, but current `main` already carries the core conformance slice there.
+- Repaired the row-operation conformance slice by merging the `sizeReduce` / `adjacentSwap` `#guard` coverage into [HexGramSchmidt/Conformance.lean](/home/kim/hex/worktrees/884f77ac/HexGramSchmidt/Conformance.lean) and importing `HexGramSchmidt.Update`, preserving the existing core conformance checks.
+- Verified the repair with `lake build HexGramSchmidt` and `python3 scripts/check_dag.py`.
+
+**Current frontier**
+
+- The superseding repair branch is ready to commit and publish for issue `#383`; the remaining coordination work is opening the replacement PR and closing the conflicting PR `#381`.
+
+**Next step**
+
+- Commit [HexGramSchmidt/Conformance.lean](/home/kim/hex/worktrees/884f77ac/HexGramSchmidt/Conformance.lean) together with this progress note, create the PR for `#383`, and close PR `#381` as superseded by the repaired branch.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #383
Closes #353

Supersedes #381 by replaying the row-operation conformance slice on current `main` without dropping the existing core conformance coverage in `HexGramSchmidt/Conformance.lean`.

Session: `884f77ac-75f9-4724-9dec-291bb75fd9aa`

201d2b0 fix: salvage HexGramSchmidt row-op conformance

🤖 Prepared with Claude Code