### PR TITLE
fix: make HexGramSchmidt Int.basis an honest placeholder

### DIFF
--- a/HexGramSchmidt/Conformance.lean
+++ b/HexGramSchmidt/Conformance.lean
@@ -17,8 +17,8 @@ Gram-Schmidt basis, coefficient, and Gram-determinant surface.
   `Hex.GramSchmidt.Int.gramDetVec`, `Hex.GramSchmidt.Int.scaledCoeffs`,
   `Hex.GramSchmidt.Rat.basis`, `Hex.GramSchmidt.Rat.gramDet`.
 - **Covered properties:**
-  - integer-input basis rows are the cast input rows on committed
-    examples, including the `basis_zero` theorem;
+  - integer-input basis satisfies the theorem-backed `basis_zero`
+    contract on committed fixtures;
   - integer coefficient checks stay on the theorem-backed diagonal and
     upper-triangular shape guarantees, including `coeffs_diag` and
     `coeffs_upper`;
@@ -94,14 +94,6 @@ private def adjacentSwapAdversarial : Matrix Int 3 2 :=
   matrixOfList2D! [[4, -1], [4, -1], [-8, 5]]
 
 /-! ## Integer basis and coefficients -/
-
-example :
-    Matrix.row (GramSchmidt.Int.basis intTypical) 1 = vectorOfList! [0, 3] := by
-  rfl
-
-example :
-    Matrix.row (GramSchmidt.Int.basis intEdge) 1 = vectorOfList! [0, 1] := by
-  rfl
 
 example :
     Matrix.row (GramSchmidt.Int.basis intTypical) 0 =

--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -52,9 +52,14 @@ open HexMatrix
 def castRow (v : Vector Int m) : Vector Rat m :=
   Vector.ofFn fun j => (v.get j : Rat)
 
-/-- The Gram-Schmidt basis scaffold currently casts each input row to `Rat`. -/
+/--
+Placeholder for the integer-input Gram-Schmidt basis.
+
+This surface promises the true orthogonalization from the SPEC; the
+implementation remains future work.
+-/
 noncomputable def basis (b : HexMatrix.Matrix Int n m) : HexMatrix.Matrix Rat n m :=
-  Vector.ofFn fun i => castRow (b.get i)
+  sorry
 
 /--
 The Gram-Schmidt coefficient scaffold is currently the identity matrix,

--- a/progress/2026-04-23T10:21:27Z_783db249.md
+++ b/progress/2026-04-23T10:21:27Z_783db249.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#375` after verifying the higher-priority `human-oversight` issue `#332` was already claimed by another agent.
+- Replaced `Hex.GramSchmidt.Int.basis` in [HexGramSchmidt/Int.lean](/home/kim/hex/worktrees/783db249/HexGramSchmidt/Int.lean) with an honest `sorry` placeholder and updated its documentation to stop advertising the old cast-through scaffold as acceptable behavior.
+- Trimmed the stale executable basis-row conformance checks in [HexGramSchmidt/Conformance.lean](/home/kim/hex/worktrees/783db249/HexGramSchmidt/Conformance.lean) while preserving the theorem-backed `basis_zero` contract coverage.
+- Verified the result with `lake build HexGramSchmidt` and confirmed `python3 scripts/status.py` was unchanged.
+
+**Current frontier**
+
+- The branch is ready to commit and publish for issue `#375`.
+
+**Next step**
+
+- Commit the `HexGramSchmidt` updates together with this progress file and open the PR closing `#375`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #375

Session: `783db249-07df-4611-95ee-3f08587cbbae`

c38db4c fix: make HexGramSchmidt Int.basis an honest placeholder

🤖 Prepared with Claude Code