### PR TITLE
fix: remove HexGramSchmidt rat placeholders

### DIFF
--- a/HexGramSchmidt.lean
+++ b/HexGramSchmidt.lean
@@ -7,11 +7,10 @@ import HexGramSchmidt.Update
 /-!
 Gram-Schmidt scaffolding.
 
-This root module re-exports the scaffolded integer-input
-and rational-input Gram-Schmidt basis, coefficient, and
-Gram-determinant declarations, together with the integer
-scaled-coefficient and row-operation update surface that downstream
-LLL work will build on.
+This root module re-exports the scaffolded integer-input Gram-Schmidt
+basis, coefficient, Gram-determinant, and row-operation surface,
+together with the executable rational-input Gram-determinant helper
+used by downstream LLL work.
 -/
 
 namespace HexGramSchmidt

--- a/HexGramSchmidt/Conformance.lean
+++ b/HexGramSchmidt/Conformance.lean
@@ -15,15 +15,17 @@ Gram-Schmidt basis, coefficient, and Gram-determinant surface.
 - **Covered operations:** `Hex.GramSchmidt.Int.basis`,
   `Hex.GramSchmidt.Int.coeffs`, `Hex.GramSchmidt.Int.gramDet`,
   `Hex.GramSchmidt.Int.gramDetVec`, `Hex.GramSchmidt.Int.scaledCoeffs`,
-  `Hex.GramSchmidt.Rat.basis`, `Hex.GramSchmidt.Rat.gramDet`.
+  `Hex.GramSchmidt.Rat.gramDet`.
 - **Covered properties:**
   - integer-input basis satisfies the theorem-backed `basis_zero`
     contract on committed fixtures;
   - integer coefficient checks stay on the theorem-backed diagonal and
     upper-triangular shape guarantees, including `coeffs_diag` and
     `coeffs_upper`;
-  - integer and rational Gram determinants match the leading Gram-matrix
-    determinant on typical, edge, and adversarial fixtures;
+- rational Gram determinants match the leading Gram-matrix determinant
+  on typical, edge, and adversarial fixtures;
+- integer Gram determinants match the leading Gram-matrix
+  determinant on typical, edge, and adversarial fixtures;
   - integer `gramDetVec` packages the full prefix determinant sequence;
   - integer scaled coefficients agree with the determinant witnesses and
     the `scaledCoeffs_eq` theorem on committed lower-triangular entries;
@@ -143,15 +145,7 @@ example :
         Matrix.entry (GramSchmidt.Int.coeffs intTypical) 2 1 := by
   simpa using GramSchmidt.Int.scaledCoeffs_eq intTypical 2 1 (by decide) (by decide)
 
-/-! ## Rational basis, coefficients, and Gram determinants -/
-
-example :
-    Matrix.row (GramSchmidt.Rat.basis ratTypical) 1 = vectorOfList! [3 / 2, -1] := by
-  rfl
-
-example :
-    Matrix.row (GramSchmidt.Rat.basis ratEdge) 1 = vectorOfList! [0, 1] := by
-  rfl
+/-! ## Rational Gram determinants -/
 
 #guard GramSchmidt.Rat.gramDet ratTypical 0 (by decide) = 1
 #guard GramSchmidt.Rat.gramDet ratTypical 1 (by decide) = 5

--- a/HexGramSchmidt/Rat.lean
+++ b/HexGramSchmidt/Rat.lean
@@ -3,9 +3,8 @@ import HexMatrix
 /-!
 Initial rational Gram-Schmidt scaffolding.
 
-This module introduces the Phase 1 `HexGramSchmidt` API slice for
-rational input matrices: the rational Gram-Schmidt basis, coefficient
-matrix, and Gram-determinant declarations used by downstream LLL work.
+This module introduces the executable rational-input Gram-determinant
+surface for `HexGramSchmidt`.
 -/
 
 namespace Hex
@@ -22,18 +21,6 @@ outside the matrix bounds.
 -/
 def row (M : HexMatrix.Matrix Rat n m) (i : Nat) : Vector Rat m :=
   if h : i < n then M.get ⟨i, h⟩ else 0
-
-/-- The rational-input Gram-Schmidt basis scaffold currently returns the input rows. -/
-noncomputable def basis (b : HexMatrix.Matrix Rat n m) : HexMatrix.Matrix Rat n m :=
-  b
-
-/--
-The rational-input coefficient scaffold is currently the identity
-matrix, giving the expected lower-unitriangular shape for this API
-slice.
--/
-noncomputable def coeffs (_b : HexMatrix.Matrix Rat n m) : HexMatrix.Matrix Rat n n :=
-  HexMatrix.Matrix.identity
 
 /-- The leading Gram matrix built from the first `k` rows of `b`. -/
 def gramMatrix (b : HexMatrix.Matrix Rat n m) (k : Nat) : HexMatrix.Matrix Rat k k :=

--- a/progress/2026-04-23T10:28:21Z_e105c252.md
+++ b/progress/2026-04-23T10:28:21Z_e105c252.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#401` after refreshing stale blocked-state metadata so the merged dependency `#384` no longer hid the unclaimed `human-oversight` work item.
+- Removed the wrong data-level placeholder declarations `Hex.GramSchmidt.Rat.basis` and `Hex.GramSchmidt.Rat.coeffs` from [HexGramSchmidt/Rat.lean](/home/kim/hex/worktrees/e105c252/HexGramSchmidt/Rat.lean).
+- Updated [HexGramSchmidt/Conformance.lean](/home/kim/hex/worktrees/e105c252/HexGramSchmidt/Conformance.lean) and [HexGramSchmidt.lean](/home/kim/hex/worktrees/e105c252/HexGramSchmidt.lean) so the documented and tested surface matches the remaining honest rational API.
+- Verified `lake build HexGramSchmidt` succeeds on the edited tree.
+
+**Current frontier**
+
+- The branch is ready to commit and publish for issue `#401`.
+
+**Next step**
+
+- Commit the placeholder-removal patch with this progress file and open the PR closing `#401`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #401

Session: `e105c252-770c-4300-a903-7a231103de92`

4423941 fix: remove HexGramSchmidt rat placeholders

🤖 Prepared with Claude Code