### PR TITLE
feat: implement executable HexMatrix rref

### DIFF
--- a/HexMatrix/Conformance.lean
+++ b/HexMatrix/Conformance.lean
@@ -38,8 +38,14 @@ private def serializeVector (v : Vector α n) : List α :=
 private def serializeMatrix (M : Matrix Int n m) : List (List Int) :=
   M.toList.map Vector.toList
 
+private def serializeRatMatrix (M : Matrix Rat n m) : List (List Rat) :=
+  M.toList.map Vector.toList
+
 private def serializeBasis (B : Vector (Vector α m) n) : List (List α) :=
   B.toList.map serializeVector
+
+private def serializePivotCols (v : Vector (Fin n) k) : List Nat :=
+  v.toList.map Fin.val
 
 private def matrixOfList2D! [Inhabited α] (rows : List (List α)) : Matrix α n m :=
   (Matrix.ofList2D (n := n) (m := m) rows).get!
@@ -62,6 +68,9 @@ private def identity3 : Matrix Int 3 3 :=
 
 private def denseAdversarial : Matrix Int 3 3 :=
   matrixOfList2D! [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+private def rrefTypical : Matrix Rat 2 3 :=
+  matrixOfList2D! [[1, 2, 3], [0, 1, 4]]
 /-- info: 9 -/
 #guard_msgs in
 #eval Matrix.det detTypical
@@ -137,6 +146,23 @@ private def denseAdversarial : Matrix Int 3 3 :=
 #guard Matrix.det (Matrix.rowAdd detTypical fin3_2 fin3_0 3) = Matrix.det detTypical
 #guard Matrix.det (Matrix.rowAdd identity3 fin3_0 fin3_1 0) = Matrix.det identity3
 #guard Matrix.det (Matrix.rowAdd denseAdversarial fin3_1 fin3_2 (-2)) = Matrix.det denseAdversarial
+
+/-- info: [[1, 0, -5], [0, 1, 4]] -/
+#guard_msgs in
+#eval serializeRatMatrix (rref rrefTypical).echelon
+
+/-- info: [[1, -2], [0, 1]] -/
+#guard_msgs in
+#eval serializeRatMatrix (rref rrefTypical).transform
+
+/-- info: [0, 1] -/
+#guard_msgs in
+#eval serializePivotCols (rref rrefTypical).pivotCols
+
+#guard (rref rrefTypical).rank = 2
+#guard serializeRatMatrix (rref rrefTypical).echelon = [[1, 0, -5], [0, 1, 4]]
+#guard serializeRatMatrix (rref rrefTypical).transform = [[1, -2], [0, 1]]
+#guard serializePivotCols (rref rrefTypical).pivotCols = [0, 1]
 end Conformance
 
 end HexMatrix

--- a/HexMatrix/Nullspace.lean
+++ b/HexMatrix/Nullspace.lean
@@ -64,7 +64,8 @@ theorem nullspace_complete {R : Type u} [Field R] {n m : Nat} {M : Matrix R n m}
 namespace Matrix
 
 /-- Convenience wrapper: compute the scaffolded nullspace through RREF. -/
-noncomputable def nullspace {R : Type u} [Field R] {n m : Nat} (M : Matrix R n m) :
+noncomputable def nullspace {R : Type u} [Field R] [DecidableEq R] {n m : Nat}
+    (M : Matrix R n m) :
     Vector (Vector R m) (m - (rref M).rank) := by
   sorry
 

--- a/HexMatrix/Rref.lean
+++ b/HexMatrix/Rref.lean
@@ -1,4 +1,4 @@
-import HexMatrix.RowEchelon
+import HexMatrix.RowOps
 
 /-!
 RREF and column-partition scaffolding for dense matrices.
@@ -13,15 +13,115 @@ universe u
 
 open Lean.Grind
 
-/-- Temporary Phase 1 scaffold for dense reduced row-echelon reduction. -/
-def rref {R : Type u} [Field R] (M : Matrix R n m) : RowEchelonData R n m where
-  rank := 0
+namespace RrefImpl
+
+variable {R : Type u} [Field R] [DecidableEq R]
+
+private structure State (n m : Nat) where
+  echelon : Matrix R n m
+  transform : Matrix R n n
+  rank : Nat
+  pivotCols : Array (Fin m)
+  pivotCols_size : pivotCols.size = rank
+
+private def init (M : Matrix R n m) : State (R := R) n m where
   echelon := M
   transform := 1
-  pivotCols := Vector.ofFn (fun i => nomatch i)
+  rank := 0
+  pivotCols := #[]
+  pivotCols_size := rfl
+
+private def findPivotRow? (M : Matrix R n m) (start : Nat) (col : Fin m) : Option (Fin n) :=
+  let rec loop (i remaining : Nat) : Option (Fin n) :=
+    match remaining with
+    | 0 => none
+    | remaining + 1 =>
+        if h : i < n then
+          let row : Fin n := ⟨i, h⟩
+          if M[row][col] = 0 then
+            loop (i + 1) remaining
+          else
+            some row
+        else
+          none
+  loop start (n - start)
+
+private def clearPivotColumn
+    (echelon : Matrix R n m) (transform : Matrix R n n) (pivotRow : Fin n) (col : Fin m) :
+    Matrix R n m × Matrix R n n :=
+  let rec loop (i remaining : Nat) (A : Matrix R n m) (T : Matrix R n n) :
+      Matrix R n m × Matrix R n n :=
+    match remaining with
+    | 0 => (A, T)
+    | remaining + 1 =>
+        if h : i < n then
+          let row : Fin n := ⟨i, h⟩
+          if hRow : row = pivotRow then
+            loop (i + 1) remaining A T
+          else
+            let coeff := -A[row][col]
+            let A' := if coeff = 0 then A else Matrix.rowAdd A row pivotRow coeff
+            let T' := if coeff = 0 then T else Matrix.rowAdd T row pivotRow coeff
+            loop (i + 1) remaining A' T'
+        else
+          (A, T)
+  loop 0 n echelon transform
+
+private def eliminateAt
+    (S : State (R := R) n m) (row pivotRow : Fin n) (col : Fin m) :
+    State (R := R) n m :=
+  let swappedEchelon := Matrix.rowSwap S.echelon row pivotRow
+  let swappedTransform := Matrix.rowSwap S.transform row pivotRow
+  let pivotInv := (swappedEchelon[row][col])⁻¹
+  let scaledEchelon := Matrix.rowScale swappedEchelon row pivotInv
+  let scaledTransform := Matrix.rowScale swappedTransform row pivotInv
+  let (reducedEchelon, reducedTransform) :=
+    clearPivotColumn (R := R) scaledEchelon scaledTransform row col
+  { echelon := reducedEchelon
+    transform := reducedTransform
+    rank := S.rank + 1
+    pivotCols := S.pivotCols.push col
+    pivotCols_size := by
+      simp [Array.size_push, S.pivotCols_size] }
+
+private def runColumns (remaining col : Nat) (S : State (R := R) n m) :
+    State (R := R) n m :=
+  match remaining with
+  | 0 => S
+  | remaining + 1 =>
+      if hCol : col < m then
+        if hRow : S.rank < n then
+          let pivotCol : Fin m := ⟨col, hCol⟩
+          match findPivotRow? (R := R) S.echelon S.rank pivotCol with
+          | none =>
+              runColumns remaining (col + 1) S
+          | some pivotRow =>
+              let row : Fin n := ⟨S.rank, hRow⟩
+              let S' := eliminateAt (R := R) S row pivotRow pivotCol
+              runColumns remaining (col + 1) S'
+        else
+          S
+      else
+        S
+
+private def run (M : Matrix R n m) : State (R := R) n m :=
+  runColumns (R := R) m 0 (init (R := R) M)
+
+private def toRowEchelonData (S : State (R := R) n m) : RowEchelonData R n m where
+  rank := S.rank
+  echelon := S.echelon
+  transform := S.transform
+  pivotCols := ⟨S.pivotCols, S.pivotCols_size⟩
+
+end RrefImpl
+
+/-- Executable dense reduced row-echelon reduction over decidable fields. -/
+def rref {R : Type u} [Field R] [DecidableEq R] (M : Matrix R n m) : RowEchelonData R n m :=
+  RrefImpl.toRowEchelonData (R := R) (RrefImpl.run (R := R) M)
 
 /-- The scaffolded `rref` output satisfies the intended RREF interface. -/
-theorem rref_isRREF {R : Type u} [Field R] (M : Matrix R n m) : IsRREF M (rref M) := by
+theorem rref_isRREF {R : Type u} [Field R] [DecidableEq R] (M : Matrix R n m) :
+    IsRREF M (rref M) := by
   sorry
 
 namespace IsEchelonForm

--- a/progress/2026-04-23T10:39:19Z_83747e3f.md
+++ b/progress/2026-04-23T10:39:19Z_83747e3f.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#413` and replaced the fake `HexMatrix.rref` scaffold in [HexMatrix/Rref.lean](/home/kim/hex/worktrees/83747e3f/HexMatrix/Rref.lean:1) with an executable Gaussian-elimination loop that tracks rank, pivot columns, the reduced matrix, and the accumulated left transform witness.
+- Made the executability boundary explicit by requiring `[DecidableEq R]` for generic `rref` users and updating [HexMatrix/Nullspace.lean](/home/kim/hex/worktrees/83747e3f/HexMatrix/Nullspace.lean:1) accordingly.
+- Added committed RREF conformance guards in [HexMatrix/Conformance.lean](/home/kim/hex/worktrees/83747e3f/HexMatrix/Conformance.lean:1) for a non-trivial rational `2 × 3` example, checking the computed echelon matrix, transform matrix, pivot columns, and rank.
+- Verified `lake build HexMatrix` and `lake build HexBerlekamp` both succeed after the change; `python3 scripts/status.py` remains unchanged.
+
+**Current frontier**
+
+- Issue `#413` is implemented locally and verified; the remaining work is publishing the branch as a PR.
+
+**Next step**
+
+- Commit the `HexMatrix` RREF/conformance changes together with this progress note and open the PR closing `#413`.
+
+**Blockers**
+
+- None for this slice.


### PR DESCRIPTION
Closes #413

Implements an executable `HexMatrix.rref` over decidable fields, updates the generic nullspace wrapper to use the honest executability bound, and adds committed RREF conformance guards.