### PR TITLE
spec: forbid wrong-complexity bodies; require reading SPEC before writing

### DIFF
--- a/PLAN/Phase1.md
+++ b/PLAN/Phase1.md
@@ -20,63 +20,38 @@ unless it explicitly fixes the public API or theorem split.
 
 ## Rules
 
-- **Writing a `def` with anything other than a complete and plausibly
-  true body is worse than nothing.** Every `def`, `structure` field,
-  `class`, and `instance` MUST have a body that the author *believes*
-  correctly implements the SPEC contract for that declaration. There
-  is no acceptable placeholder form:
+- **Read the SPEC prose for each declaration before writing its
+  body.** The signature alone is not the contract. Locate the SPEC
+  prose that describes *what algorithm* the declaration computes,
+  read it end to end, and make sure your body implements that
+  algorithm. If the SPEC gives explicit update formulas, case
+  analysis, or a pseudocode sketch, your body must follow it. If
+  you cannot find such prose, or cannot understand it, do not
+  commit the declaration.
+
+- Every `def`, data-carrying `structure` field, `class`, and
+  `instance` MUST have a body that the author *believes*
+  correctly implements the SPEC contract for that declaration.
+  There is no acceptable placeholder form:
   - NOT wrong-but-plausible bodies
     (`def rref M := { rank := 0, echelon := M, transform := 1 }`),
   - NOT `sorry` bodies (`noncomputable def rref ... := sorry`),
   - NOT `axiom rref : ...`,
   - NOT trivial returns (`Matrix.identity`, `none`, the input
     unchanged, an identity cast),
+  - NOT alternative implementations with the wrong algorithmic
+    complexity,
   - NOT a body marked "honest placeholder" or "Phase 1 scaffold
     returns <trivial>" in its docstring.
 
   If you cannot implement the function correctly in this PR: **do
   not commit the declaration**. Leave it out of Lean entirely. The
-  SPEC file is the record of what's *designed*; the Lean surface is
-  the record of what's *implemented correctly so far*. An
-  incomplete-but-honest Phase 1 is strictly better than a
-  complete-looking one with placeholder bodies.
-
-  **If an older issue asks you to commit a `sorry` body or "honest
-  placeholder": refuse it.** Comment on the issue, link this rule,
-  and close the issue in favour of one that either (a) correctly
-  implements the declaration, or (b) deletes it. The rule here
-  overrides any pre-existing issue text.
-
-  Why: a placeholder that typechecks lies to downstream code and to
-  future agents. A wrong-but-plausible body invites scaffold-locking
-  conformance tests. A `sorry` body makes every caller's `#eval`
-  refuse to run (Lean conservatively refuses any term transitively
-  depending on `sorry`), so any conformance test against that caller
-  has to use `#eval!`, which then silently accepts whatever bits the
-  runtime produces for `sorryAx` — neither "correct" nor "obviously
-  wrong", just untrustworthy. An omitted declaration, by contrast,
-  breaks the build at the use site loudly and points the next agent
-  directly at the thing to implement.
-
-  Forbidden data-level body patterns, each observed in practice:
-  - `def rref M := { rank := 0, echelon := M, transform := 1 }`
-    — the name promises RREF; the body is not RREF.
-  - `def spanCoeffs _ _ := none` — promises a span decomposition;
-    always says "no".
-  - `def gramSchmidt.basis b := b` — promises orthogonalisation;
-    returns input unchanged.
-  - `def gramSchmidt.coeffs _ := Matrix.identity` — promises the
-    lower-triangular coefficient matrix; returns the identity.
-  - `noncomputable def rref ... := sorry` — an explicit placeholder;
-    still forbidden, same reasons.
-
-  What to do if you can't implement it: narrow the Phase 1 issue,
-  commit only the declarations you *can* correctly implement,
-  document (in the PR description) which SPEC declarations are being
-  deferred to a follow-up issue, and open that follow-up. Don't
-  commit stubs to keep the PR "complete" — an incomplete but honest
-  Phase 1 is strictly better than a complete-looking one with
-  placeholders.
+  SPEC file is the record of what's *designed*; the Lean surface
+  is the record of what's *implemented correctly so far*. Any bad
+  definitions will poison all downstream conformance testing,
+  benchmarking, and theorem proving. We need to get definitions
+  right, and if we ever discover they are wrong, fix them
+  immediately rather than working around them.
 
 - **`sorry`'d theorem proofs are expected.** The point of scaffolding
   is to get the API surface compiling, not to fill in proofs. This

--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -19,19 +19,29 @@ These are not rubber-stamp coverage audits — they ask:
 - Are the theorem statements faithful to the SPEC? (Not "verbatim" — but
   do they capture the same mathematical content?)
 - Are there missing imports or DAG violations?
-- **Does every committed `def` / `structure` field / `class` /
-  `instance` body actually implement the SPEC contract correctly?**
-  [PLAN/Phase1.md](Phase1.md) forbids data-level placeholders of any
-  kind — no `sorry` bodies, no `axiom`s standing in for data, no
-  trivial returns (input unchanged, `0`, `Matrix.identity`, `none`,
-  empty list). A library must commit only the declarations it can
-  correctly implement; everything else stays out of Lean until a
-  later PR implements it. Flag any committed declaration whose body
-  is a placeholder in any of these forms. Flagged bodies must be
-  deleted (and any downstream callers updated) in a follow-up issue
-  before the `scaffolding-reviewed` token is committed — either the
+- **Does every committed `def` / data-carrying `structure` field /
+  `class` / `instance` body actually implement the SPEC contract
+  correctly?** [PLAN/Phase1.md](Phase1.md) forbids data-level
+  placeholders of any kind — no `sorry` bodies, no `axiom`s
+  standing in for data, no trivial returns (input unchanged, `0`,
+  `Matrix.identity`, `none`, empty list). A library must commit
+  only the declarations it can correctly implement; everything
+  else stays out of Lean until a later PR implements it. Flag any
+  committed declaration whose body is a placeholder in any of
+  these forms. Flagged bodies must be deleted (and any downstream
+  callers updated) in a follow-up issue before the
+  `scaffolding-reviewed` token is committed — either the
   implementation becomes correct, or the declaration leaves the
   tree. "Rewrite as `sorry`" is **not** an acceptable fix.
+- **Does each data-level body match the SPEC's intended algorithmic
+  shape — not just its input/output contract?** Flag any body that
+  produces the right output via an unrelated algorithm: a full
+  rebuild where the SPEC prescribes an in-place update; a
+  reference implementation behind a name that promises the
+  optimised version; a detour through canonical form when the SPEC
+  gives explicit update formulas. These are "wrong-shape" scaffolds
+  and are forbidden by [PLAN/Phase1.md](Phase1.md), same remedy as
+  wrong-output scaffolds: fix the body, or delete the declaration.
 
 ## Output
 

--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -93,12 +93,16 @@ def LLLState.potential (s : LLLState n m) : Nat :=
   s.d[1:n].foldl (· * ·) 1    -- d_1 * d_2 * ... * d_{n-1}
 ```
 
+The signatures shown for `sizeReduce` and `swapStep` below are the
+required types; the body must implement the algorithm described in
+the prose that follows each block.
+
 **Size reduction.** Size-reduce b[k] against b[k-1], ..., b[0].
 Updates b and ν; d is unchanged (basis is unchanged by size
 reduction).
 
 ```lean
-def LLLState.sizeReduce (s : LLLState n m) (k : Nat) : LLLState n m := sorry
+def LLLState.sizeReduce (s : LLLState n m) (k : Nat) : LLLState n m
 ```
 
 For j = k-1 downto 0: if 2 * |ν[k][j]| > d[j+1] (i.e., |coeffs[k][j]| > 1/2):
@@ -111,7 +115,7 @@ For j = k-1 downto 0: if 2 * |ν[k][j]| > d[j+1] (i.e., |coeffs[k][j]| > 1/2):
 **Swap step.** Swap b[k] and b[k-1], updating ν and d.
 
 ```lean
-def LLLState.swapStep (s : LLLState n m) (k : Nat) : LLLState n m := sorry
+def LLLState.swapStep (s : LLLState n m) (k : Nat) : LLLState n m
 ```
 
 Let B = ν[k][k-1]. After swapping b[k] and b[k-1]:


### PR DESCRIPTION
## Context

Previous SPEC/PLAN hardening (#384, #412) closed the
\"wrong-but-plausible trivial body\" and the \"sorry / honest
placeholder\" escape valves in [PLAN/Phase1.md](PLAN/Phase1.md).
A new failure mode has surfaced, visible in
[HexLLL/SwapStep.lean](HexLLL/SwapStep.lean):

\`\`\`lean
def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
  ofBasis (swapBasis s k)
\`\`\`

Each \`def\` is type-correct and outputs the right swapped state.
But the body does a full O(n²) Gram-Schmidt recompute via
\`ofBasis\`, whereas the SPEC
([SPEC/Libraries/hex-lll.md](SPEC/Libraries/hex-lll.md), Cohen
Algorithm 2.6.3) prescribes an in-place O(n) update — there are
even 100+ lines of unused update-formula defs
(\`swapGramDetValue\`, \`swapTailPrevValue\`,
\`swapTailCurrValue\`, \`exactDivNat\`, \`exactDivInt\`) sitting
next to the rebuild body. The ensemble lies about implementing
the algorithm.

Two prompting holes let this through:

1. The current Phase 1 rule forbids trivial *outputs* (\`input
   unchanged\`, \`Matrix.identity\`, \`none\`) but is
   output-shaped; it doesn't forbid a semantically-correct body
   at the wrong complexity. The rule had also accreted enough
   restating and worked examples that the core sentence was buried.
2. \`SPEC/Libraries/hex-lll.md:101,114\` contained two code blocks
   of the form \`def LLLState.swapStep ... := sorry\`. Agents
   reading the SPEC took \`:= sorry\` as \"fill this in with the
   simplest typechecking body\".

## Changes

- **[PLAN/Phase1.md](PLAN/Phase1.md)**
  - Prepended a new rule: **read the SPEC prose for each
    declaration before writing its body**.
  - Condensed the data-body rule: dropped the opening \"worse
    than nothing\" sentence, the legacy \"refuse stale issues\"
    paragraph, the \"Why\" paragraph, the duplicated
    forbidden-patterns bullet list, and the \"What to do if you
    can't\" paragraph — all repeated content now carried by the
    tighter remaining prose.
  - Extended the NOT-list to include \"alternative
    implementations with the wrong algorithmic complexity\".
  - Narrowed \`structure\` field → \`data-carrying structure
    field\` so propositional fields stay under the \`sorry\`'d
    theorem rule.
  - Replaced the \"incomplete-but-honest is better than
    complete-with-placeholders\" framing with \"any bad
    definitions poison all downstream conformance testing,
    benchmarking, and theorem proving — get them right, or fix
    them immediately rather than working around them\".

- **[PLAN/Phase2.md](PLAN/Phase2.md)**
  - Updated the existing data-body reviewer question to reference
    \`data-carrying structure field\`.
  - Added a new reviewer question: *\"Does each data-level body
    match the SPEC's intended algorithmic shape — not just its
    input/output contract?\"* — full rebuild where the SPEC
    prescribes an in-place update, reference implementation
    behind a name that promises the optimised version, detour
    through canonical form, etc.

- **[SPEC/Libraries/hex-lll.md](SPEC/Libraries/hex-lll.md)**
  - Elided the two \`:= sorry\` code blocks (\`sizeReduce\`,
    \`swapStep\`) — the signatures alone now appear; the algorithm
    description in the prose below each block is unchanged.
  - Added a one-line note explaining that the signatures are
    reference types and the body must implement the prose.

## SPEC-wide scan

\`grep -rn \":= sorry\" SPEC/\` — the two hex-lll occurrences were
the only matches; they're both elided by this PR.
\`:= id\`, \`:= 0\$\`, \`:= pure\`, \`:= none\`, \`:= Matrix.identity\`
— no matches anywhere in SPEC/.

## No code touched

Implementation of \`swapStep\` / \`sizeReduce\` / \`lllAux\` is
Phase 5 work, out of scope for this PR. Kim is resetting the
implementation tree anyway; this PR is prompting-only.

🤖 Prepared with Claude Code