### PR TITLE
spec: rewrite Phase 4 around lean-bench, make benchmarks bug-finders

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -14,6 +14,18 @@ once per session.
 agents may fix SPEC clauses that are internally contradictory or
 mathematically impossible, with rationale in the PR description.
 
+### Scaffolding is for proofs only
+
+`sorry` is permitted in proofs (`theorem` bodies, propositional
+`structure` fields). It is **not** permitted as a data-level body,
+and neither is any other placeholder shape (wrong-but-plausible
+trivial returns, identity casts, `axiom` stand-ins, alternative
+implementations with the wrong complexity). Every committed `def`
+ships with its intended-final implementation. See
+[design-principles.md §7](../SPEC/design-principles.md), the rule
+restated in [PLAN/Phase1.md](Phase1.md), and the bench-discovery
+rollback path in [SPEC/benchmarking.md](../SPEC/benchmarking.md).
+
 ### PR workflow
 
 Every PR gets auto-merge at creation:
@@ -137,6 +149,35 @@ depends-on: #124
 Keep these lines literal and easy to grep. They are the only
 dependency syntax the orchestration layer should rely on by default.
 
+### Bench-found and conformance-found issues
+
+Issues filed in response to a benchmark verdict mismatch or a
+conformance failure use the [canonical issue body shape](#canonical-issue-body-shape)
+plus a **Symptom** section recording the evidence:
+
+- **Declared expectation.** For a bench finding: the complexity model
+  declared in `setup_benchmark` (e.g. `n => n * Nat.log2 (n + 1)`).
+  For a conformance finding: the property the failing `#guard` was
+  checking, or the oracle's expected output.
+- **Observed result.** For a bench finding: the verdict text emitted
+  by `lake exe ... run NAME` (e.g. `inconclusive (cMin=10.5,
+  cMax=25.3, β=0.42)`), plus a copy of the relevant JSONL rows. For
+  a conformance finding: the failing input, the Lean output, and the
+  oracle output.
+- **Root-cause hypothesis.** One paragraph: what algorithmic shape
+  produces this observation? "Quadratic on `p` because we search
+  `List.range p`," "factor of `n` slower because we rebuild
+  Gram–Schmidt instead of incremental update," etc. Best guess is
+  enough; the next agent verifies.
+
+The **Deliverables** section lists two PRs:
+
+1. The rollback PR setting `libraries.yml[L].done_through` backward
+   (per [Rollback is a normal action](#rollback-is-a-normal-action)).
+2. The implementation PR fixing the bug at the rolled-back phase.
+
+Cross-link both PRs to this issue.
+
 ### Decomposition is normal
 
 If an agent is assigned an issue and concludes that it is too large
@@ -222,6 +263,41 @@ read its output.
 - Once deps reach `dep.dt ≥ 4`, the hardest cross-lib gate is
   satisfied and L can run through all subsequent local phases (5, 6,
   7) regardless of where deps go next.
+
+### Rollback is a normal action
+
+Bumping `done_through` *backward* is a normal, encouraged action
+when conformance or benchmarking finds an implementation bug. The
+forward bump records "phases 1..K are complete"; a backward bump
+records "we discovered phase ≤K wasn't actually complete and we are
+redoing it." Both directions are first-class.
+
+Operationally, rolling library `L` back from `K` to `K-1` (or
+further) means:
+
+1. File a GitHub issue describing the bug; use the issue body shape
+   in [Issue creation](#issue-creation), with the extra **Symptom**
+   section described under [Bench-found and conformance-found
+   issues](#bench-found-and-conformance-found-issues).
+2. Close any open phase-K PRs whose work depends on the broken code
+   (or convert them to draft and add `depends-on: <issue>`).
+3. Edit `libraries.yml` to set the affected library's `done_through`
+   to the new lower value, in a small dedicated PR. The PR
+   description names the issue.
+4. Mark any cross-library work that was unblocked by `L.dt ≥ K` as
+   blocked again where appropriate. The phase-dependency table
+   (above) makes this mechanical: any `M` with `L ∈ M.deps` and a
+   dep-coupled phase ≥ K is now ineligible until L recovers.
+
+The next agent picking up `L` enters the rolled-back phase with the
+bug-finding evidence (the issue, the JSONL artefact for a bench
+finding, the failing `#guard` for a conformance finding) as its
+context.
+
+Rollback is preferable to "weaken the test" or "lower the parameter
+range to make the bench pass" — both forms of paving over the bug.
+[SPEC/benchmarking.md](../SPEC/benchmarking.md) explicitly forbids
+the latter.
 
 ### Where state lives
 

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -4,57 +4,107 @@
 `libraries.yml[L].done_through ≥ 3` and every `d ∈ L.deps` has
 `libraries.yml[d].done_through ≥ 4`.
 
-Performance is part of the project spec, not an optional cleanup task.
-Before calling a release target successful, measure the cost of the
-native Lean implementations on representative workloads.
+Phase 4 makes algorithmic complexity a first-class deliverable. By
+the end of Phase 4 every advertised operation in the library's API
+has a textbook complexity model declared at its `setup_benchmark`
+registration, and a benchmark family whose verdict is *consistent
+with declared complexity*. An *inconclusive* verdict is not a Phase
+4 exit; it is a finding that triggers a rollback per
+[Conventions.md §Rollback is a normal action](Conventions.md#rollback-is-a-normal-action)
+and a fix at the rolled-back phase.
 
-## Goals
+The harness, the registration forms, the CLI surface, the
+verdict-as-bug-trigger doctrine, and the anti-patterns all live in
+[SPEC/benchmarking.md](../SPEC/benchmarking.md). Read it before
+opening Phase 4 issues.
 
-- Catch major performance regressions early.
-- Validate that specialized code paths (`UInt64`, Barrett/Montgomery,
-  packed GF(2), d-representation LLL) are actually paying for their
-  complexity.
-- Keep the finite-field-oriented releases honest: field construction and
-  irreducibility checking must be usable, not merely correct on paper.
+## Deliverables
 
-## Scope
+For each library `HexFoo` advancing through Phase 4:
 
-- **hex-mod-arith:** modular multiply, inverse, exponentiation.
-- **hex-poly / hex-poly-fp:** multiply, div/mod, GCD, Frobenius powers.
-- **hex-gf2:** packed multiply, modular reduction, GCD, `GF(2^n)` ops.
-- **hex-berlekamp:** Berlekamp matrix construction, nullspace, factor
-  splits, Rabin test.
-- **hex-hensel:** linear lifting baseline; quadratic lifting once added.
-- **hex-lll:** size reduction, swap-heavy cases, full reduction.
-- **hex-gfq / hex-gfq-field:** field multiplication/inversion for
-  representative `(p, n)` pairs.
-- **hex-berlekamp-zassenhaus:** end-to-end factoring on small and
-  medium examples, with and without LLL where both paths exist.
+1. **`HexFoo/Bench.lean`** — a single Lean module that imports
+   `LeanBench` and registers every advertised operation in the
+   library's SPEC API surface with `setup_benchmark` (parametric)
+   or `setup_fixed_benchmark` (canonical input). The complexity
+   expression in each `setup_benchmark` is the *textbook*
+   complexity, not the observed one.
 
-## Benchmark discipline
+2. **`lakefile.toml` exe entry**:
 
-- Maintain a small committed benchmark suite with fixed seeds and named
-  inputs so regressions are reproducible.
-- Benchmark both micro-kernels and end-to-end workflows.
-- Track at least relative comparisons where they matter:
-  - `GF2Poly` vs `FpPoly 2`
-  - Barrett vs Montgomery crossover regimes
-  - linear vs quadratic Hensel lifting
-  - exponential recombination vs LLL-assisted recombination
-- Keep benchmarking separate from proof obligations: benchmark the
-  executable code path actually used at runtime.
+   ```toml
+   [[lean_exe]]
+   name = "hexfoo_bench"
+   root = "HexFoo.Bench"
+   ```
 
-## Release expectations
+   On the first library to enter Phase 4, also add the lean-bench
+   `[[require]]` (per the snippet in
+   [SPEC/benchmarking.md §Harness](../SPEC/benchmarking.md#harness-lean-bench)).
 
-- Each release target must name the benchmark cases it must pass.
-- Specific cases and thresholds may evolve between releases, but every
-  such change must be accompanied by a short rationale in the PR that
-  changes the benchmark set (one paragraph per change). This keeps the
-  release gate machine-checkable without freezing the case list, and
-  keeps release-specific churn out of `SPEC/`.
-- A release is blocked by obvious performance pathologies even if proofs
-  are complete.
-- Record benchmark results in PRs or milestone notes so the orchestrator
-  can detect regressions over time.
+3. **CI smoke step** invoking
+   `lake exe hexfoo_bench list && lake exe hexfoo_bench verify`.
+   `verify` is the bitrot gate; it does not assert timing values.
+   Total wall budget across all libraries' verify calls is `< 60 s`.
+
+4. **`compare` registrations** for any pair of alternative algorithms
+   the library SPEC calls out (e.g. Barrett vs Montgomery, linear vs
+   quadratic Hensel, exponential-recombination vs LLL-assisted
+   recombination). The `compare` invocation joins on result hashes
+   and serves as the cross-implementation conformance check; a
+   divergence at a common parameter is treated as any other
+   conformance failure.
+
+5. **External-comparator registrations** where the library SPEC
+   names an architecturally important external tool (FLINT, fpLLL,
+   GMP, NTL for FFI; Sage, GAP, PARI, python-flint for process
+   calls). FFI is preferred; see
+   [SPEC/benchmarking.md §External comparators](../SPEC/benchmarking.md#external-comparators)
+   for the integration patterns.
+
+The PR description records, in one paragraph, any case where the
+declared complexity model differs from the canonical textbook
+complexity (e.g. amortised vs worst-case, randomised vs
+deterministic). This is the only "performance rationale" section
+required.
+
+## Discipline
+
+- **Declare textbook complexity.** Not the observed complexity of
+  the current implementation. If the textbook is `O(n²)` and the
+  current code is `O(n³)`, declare `O(n²)`, run the benchmark, get
+  the inconclusive verdict, file the issue, roll back. The
+  benchmark's job is to reveal the gap, not to ratify it.
+- **Use one harness.** lean-bench is the inner harness; gaps go to
+  its issue tracker, not into a hex-local replacement.
+- **Use stable case names.** The `setup_benchmark` declaration name
+  is the case name; renaming a registration is a tracked change.
+- **Use fixed seeds and committed inputs.** Randomised inputs
+  derive from a seed tied to the benchmark name; canonical hard
+  inputs live under `HexFoo/Bench/Inputs/`.
+
+## Exit criteria
+
+For library `hex-foo`, Phase 4 is done when:
+
+- every operation listed in the library's SPEC API surface has a
+  `setup_benchmark` or `setup_fixed_benchmark` registration in
+  `HexFoo/Bench.lean`;
+- every parametric registration declares a complexity model that
+  matches the SPEC's textbook complexity for that operation;
+- `lake exe hexfoo_bench verify` succeeds, and
+  `lake exe hexfoo_bench run NAME` returns *consistent with declared
+  complexity* for every parametric registration at the library's
+  standard sizes;
+- every `compare` group named by the SPEC is registered and reports
+  `allAgreed` at common parameters;
+- every external-comparator registration named by the SPEC is wired
+  (FFI shim or process call), with link arguments / install
+  instructions recorded in `lakefile.toml` or the bench module's
+  docstring;
+- the CI smoke step (`list` + `verify`) runs on every PR.
+
+If any of these fail, the right action is rollback per
+[Conventions.md](Conventions.md), not a SPEC-text edit weakening
+the criterion.
 
 Record completion by bumping `libraries.yml[L].done_through` to `4`.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -1,190 +1,389 @@
 # Benchmarking
 
 This document specifies the performance-measurement contract for the
-project. It complements [testing.md](testing.md): testing asks whether
-the implementation is correct, benchmarking asks how fast the verified
-implementation is and how it compares with reference systems.
+project. It complements [testing.md](testing.md): testing asks
+whether the implementation is correct against an oracle, benchmarking
+asks whether the implementation matches its declared algorithmic
+complexity. Both are bug-finding tools and route to the same response
+when they fire.
 
-Benchmarking is part of the SPEC, not an afterthought. The project is
-building executable computational algebra, so every major library must
-have named benchmark cases, reproducible harnesses, and published
-results.
+## Why benchmark
 
-## Goals
+Benchmarking serves three purposes, in priority order:
 
-Benchmarking serves four purposes:
+1. **Detect wrong implementations** by checking declared algorithmic
+   complexity against observed scaling. A Phase-1 commit ships a
+   `def` with the *real* algorithm at the *intended* complexity (per
+   [design-principles.md §7](design-principles.md)). A Phase-4
+   benchmark whose verdict disagrees with the declared model means
+   that promise was broken — the `def` is scaffolding in disguise.
+2. **Measure how Lean compares to external systems** on hard
+   problems. "Factoring `x^128 + 1` over `F_2` takes ~2 s in Lean
+   versus ~0.8 s in FLINT" is a useful sentence even when both
+   systems agree on the answer; benchmarking is how that sentence
+   gets recorded.
+3. **Make design tradeoffs evidence-based.** "Barrett or Montgomery?"
+   "Linear or quadratic Hensel lifting?" are answered by running
+   both and looking at the numbers, not by argument from textbook.
 
-1. Detect performance regressions in Lean implementations over time.
-2. Compare alternative verified algorithms or representations.
-3. Compare Lean implementations against external CAS/reference tools.
-4. Provide concrete evidence for design decisions in the library specs.
+Detecting time-series regressions is a side effect of (1) and (2),
+not the primary goal. A correctly-declared and correctly-implemented
+operation should be regression-stable; if it isn't, the test is the
+benchmark itself.
 
-Benchmarks do **not** relax the requirement that all trusted runtime
-computation happens in Lean. External tools are used as comparators and
-oracles for measurement only.
+## The verdict-as-bug-trigger model
 
-## Benchmark classes
+Every benchmarked operation has a textbook complexity model declared
+*at the registration site* in the per-library `Bench.lean`. The
+benchmark harness ([§Harness](#harness-lean-bench)) fits the
+observed scaling against that model and emits one of two verdicts:
 
-Each computational library must define both microbenchmarks and
-end-to-end benchmarks.
+- **consistent with declared complexity** — observed scaling matches
+  the model within tolerance.
+- **inconclusive** — observed scaling does not match. The
+  implementation is either wrong, or the model was misdeclared.
 
-### Required microbenchmarks
+The latter case is the **valuable** outcome of a benchmark run.
+"Everything looks consistent and within a small constant factor of
+the external comparator" is acceptable but unexciting; "the verdict
+came back inconclusive and the slope is `+0.4` over `n`" is the run
+that earned its keep.
 
-- `hex-poly-fp`: addition, multiplication, modular reduction, GCD,
-  exponentiation mod `f`, Rabin/Berlekamp irreducibility kernels
-- `hex-poly-z`: multiplication, division/remainder, content/primitive
-  part, GCD
-- `hex-berlekamp`: Berlekamp matrix construction, nullspace, factor
-  splitting, irreducibility tests
-- `hex-hensel`: linear lifting and quadratic lifting on the same named
-  inputs
-- `hex-lll`: size reduction, swap-heavy inputs, full reduction
-- `hex-gfq-ring` / `hex-gfq-field` / `hex-gfq`: multiplication,
-  inversion, Frobenius, norm/trace on representative `(p, n)` pairs
-- `hex-conway`: Tier 1 irreducibility verification, Tier 2 Conway-table
-  verification, and Tier 3 search when implemented
+When a verdict is `inconclusive`, or when the verdict is consistent
+but the constant is wildly off an external reference (more than
+about 100×), the response is mandatory and uniform:
 
-### Required end-to-end benchmarks
+1. **File a GitHub issue.** Use the bench-found-bug template in
+   [PLAN/Conventions.md](../PLAN/Conventions.md#bench-found-and-conformance-found-issues).
+2. **Roll the library's `done_through` back** to the phase
+   predating the broken `def`, per
+   [PLAN/Conventions.md §Rollback is a normal action](../PLAN/Conventions.md#rollback-is-a-normal-action).
+3. **Re-enter the rolled-back phase** to fix the implementation;
+   the benchmark stays as written.
 
-- finite-field construction for named `(p, n)` pairs
-- irreducibility certification for named polynomials over `F_p`
-- integer polynomial factorization on small and medium examples
-- end-to-end Berlekamp-Zassenhaus with and without LLL when both paths
-  exist
+Worked examples:
 
-## Required comparisons
+- HexArith Montgomery `mulMont` was declared `O(log p)` per call but
+  observed `O(p)` because `montgomeryRadixInvNat` did
+  `(List.range p.toNat).find?` instead of using the existing
+  Bezout-based `extGcd`. Verdict: `inconclusive` with a slope of
+  `+1.0`. Response: file issue, roll HexArith back, replace the
+  brute-force inverse.
+- HexLLL `swapStep` was declared `O(n²)` (incremental Gram–Schmidt
+  update) but observed `O(n³)` because the implementation rebuilt
+  Gram–Schmidt from scratch on every swap. Verdict: `inconclusive`
+  with a slope of `+1.0` versus the declared model. Response: file
+  issue, roll HexLLL back, implement the incremental update.
 
-The benchmark suite must include direct comparisons where they are
-architecturally important.
+These are not retrospectives; they are the canonical shape of a
+benchmark finding.
 
-- `GF2Poly` vs `FpPoly 2`
-- Barrett vs Montgomery crossover regimes
-- linear vs quadratic Hensel lifting
-- exponential recombination vs LLL-assisted recombination
-- Tier 1 vs Tier 2 Conway verification costs
-- Tier 2 Conway verification vs Tier 3 Conway search
+## Scaffolding cross-link
 
-## External comparison tools
+[Design principles §7](design-principles.md) already forbids
+data-level scaffolding: every committed `def` ships with the
+intended-final implementation, not a wrong-but-plausible stand-in.
+Benchmarking is the third enforcement point for that rule, after
+Phase 1 (the author's own discipline) and Phase 2 (skeptical
+review). A benchmark verdict revealing a scaffolding `def` triggers
+the rollback above; the doctrine is symmetric with conformance
+failures (see [testing.md](testing.md)).
 
-The benchmark harness should compare against the strongest practical
-reference available for each task.
+## Harness: lean-bench
 
-- GAP: Conway polynomial tables, Conway compatibility checks, primitive
-  polynomial checks
-- PARI/GP: finite-field irreducibility checks and large-degree
-  irreducibility experiments
-- FLINT: dense polynomial arithmetic and integer polynomial factoring
-- SageMath: higher-level reference workflows where it offers a simpler
-  orchestration layer than direct FLINT/PARI calls
-- fpLLL: lattice reduction comparisons
+The benchmark harness is [`kim-em/lean-bench`](https://github.com/kim-em/lean-bench).
+It is the only harness; do not roll a per-library replacement.
 
-The spec does not require every machine to have every external tool
-preinstalled. The harness may provision tools via Nix, containers, or
-documented local setup, but the provisioning path must itself be
-reproducible.
+A library's Phase-4 deliverable is `HexFoo/Bench.lean`, registered
+as a Lake exe target named `hexfoo_bench`:
+
+```toml
+# lakefile.toml
+[[require]]
+name = "lean-bench"
+git = "https://github.com/kim-em/lean-bench.git"
+rev = "main"
+
+[[lean_exe]]
+name = "hexfoo_bench"
+root = "HexFoo.Bench"
+```
+
+```lean
+-- HexFoo/Bench.lean
+import LeanBench
+import HexFoo
+
+setup_benchmark Hex.Foo.op n => n * Nat.log2 (n + 1)
+setup_fixed_benchmark Hex.Foo.canonicalHardProblem
+  where { repeats := 10 }
+
+def main (args : List String) : IO UInt32 :=
+  LeanBench.Cli.dispatch args
+```
+
+Two registration forms:
+
+- **`setup_benchmark <fn> <param> => <complexity>`** for parametric
+  sweeps. `<fn> : Nat → α`. `<complexity> : Nat → Nat` is the
+  textbook complexity (e.g. `n`, `n * n`, `n * Nat.log2 (n + 1)`,
+  `2 ^ n`). Optional `with prep := <prepFn>` clause hoists per-param
+  setup out of the timing loop, useful when the hot path takes
+  `σ → α` and `σ` is expensive to construct (random matrices,
+  pre-canonicalised polynomials).
+- **`setup_fixed_benchmark <name>`** for absolute-time measurements
+  on a single canonical input. `<name> : α` (pure) or `<name> : IO α`
+  (effectful — required when the input must be read from disk or
+  the call shells out to an external tool). No parameter, no
+  complexity model; runs `--repeats N` measured calls (default 5)
+  and reports median / min / max.
+
+Both forms accept a `where { … }` clause to override fields of the
+per-benchmark config (`maxSecondsPerCall`, `repeats`, `paramCeiling`,
+slope tolerance, etc.); CLI flags layer on top.
+
+The CLI surface is `lake exe hexfoo_bench <subcommand>`:
+
+- `list` — print every registered benchmark, annotating fixed ones.
+- `run NAME` — run a single benchmark, print the result table and
+  verdict.
+- `compare A B [C…]` — run multiple benchmarks (all parametric or
+  all fixed), report `allAgreed` / `divergedAt` based on result
+  hashes at common parameters, plus a relative-timing summary.
+- `verify [NAMES…]` — smoke-test registration wiring: spawn each
+  benchmark with a tight inner-tuning budget, check the child exits
+  cleanly and emits a hash where one is expected. Used as a CI
+  gate; see [§CI integration](#ci-integration).
+
+Per-library SPECs declare the complexity for each operation in their
+API surface. The textbook model is the contract; the benchmark
+checks observation against it. **Do not declare a complexity model
+that matches the buggy current code.** If the textbook model says
+`O(n²)` but the current implementation is `O(n³)`, declare `O(n²)`,
+let the verdict come back inconclusive, file the issue, roll back.
+
+### Adaptive ladder
+
+The harness picks the parameter ladder (doubling vs. linear) at
+runtime by probing the declared complexity at small parameters.
+Polynomial complexity gets a doubling ladder (`2, 4, 8, …`)
+extending to the configured `paramCeiling`; exponential complexity
+gets a narrow linear ladder bracketing the productive band before
+the wallclock cap kicks in. The user just declares the model
+correctly; the harness handles ladder shape.
+
+### What we don't measure
+
+`lean-bench` measures compiled-code execution. The following are
+**out of scope** for this contract; their performance is a separate
+concern:
+
+- elaboration-time `decide` and `decide +kernel`,
+- `#eval` and `#eval!`,
+- kernel reduction (proof terms, `decide` after elaboration),
+- proof-search tactics inside `Bench.lean`.
+
+If a tactic's compile time matters, it's a Lean / tactic-author
+issue and goes to a different tracker.
+
+## Within-Lean comparisons
+
+Where a SPEC names alternative algorithms or representations,
+register them all and `compare` them in the same exe:
+
+- `Hex.GF2.GF2Poly.mul` vs `Hex.PolyFp.mul` at `p = 2`
+- `Hex.ModArith.mulModBarrett` vs `Hex.ModArith.mulModMontgomery`
+  on overlapping modulus regimes
+- `Hex.Hensel.linearLift` vs `Hex.Hensel.quadraticLift` on the same
+  named inputs
+- exponential-recombination versus LLL-assisted recombination
+  inside Berlekamp–Zassenhaus
+
+`compare` joins on result hashes (`Hashable α` registers the hash
+in the JSONL output), so divergence shows up as a hash mismatch at
+a common parameter. This makes a `compare` invocation
+double-purpose: a timing report and a cross-implementation
+conformance check, in one go. A divergence triggers the same
+response as any other conformance failure: file an issue, roll back.
+
+## External comparators
+
+Where a SPEC marks an operation as architecturally important against
+an external reference, register the comparator alongside the Lean
+implementation in the same `Bench.lean` and let `compare` join them.
+Two integration patterns:
+
+- **FFI shim, preferred for hot-path comparisons.** The external
+  tool is C/C++ with a stable ABI (FLINT, fpLLL, GMP, NTL). Wrap
+  the relevant function with `@[extern]` returning a pure `α`,
+  register it as a `setup_benchmark` target, and let the
+  inner-repeat loop amortise the call cost. Per-call overhead is
+  one C call. Add the shim sources under
+  `HexFoo/ffi/<comparator>.c`; record any link arguments in
+  `lakefile.toml` (`moreLinkArgs`). The same `@[extern]` boundary
+  rules from [Conventions.md](../PLAN/Conventions.md) apply.
+- **Process call, acceptable for one-shot comparisons.** The
+  external tool is scripted (Sage, python-flint, GAP, PARI) or
+  the operation is expensive enough that process-spawn cost is
+  negligible. Use `setup_fixed_benchmark` with an `IO α` body
+  that shells out, parses the output, and returns it. The
+  parametric `setup_benchmark` form does not currently accept
+  `IO α`, so process-call comparisons with a parameter sweep are
+  not directly modellable today; if you need this, file an issue
+  against lean-bench rather than rolling a hex-local harness.
+
+Where a SPEC asks for a comparison lean-bench cannot directly model
+(e.g. a comparison whose only useful axis is wall-clock on a single
+canonical input that lean-bench's API doesn't yet support), file
+the gap as a feature request against lean-bench. Do not invent a
+parallel hex-local benchmark harness; one harness is the rule.
+
+## Fixed-problem benchmarks
+
+Some benchmarks are absolute-wall-clock measurements on canonical
+hard inputs, not parameter sweeps:
+
+- factoring `x^128 + 1` over `F_2`,
+- LLL-reducing a Lagarias–Odlyzko knapsack basis at dim 30,
+- verifying irreducibility of a committed Conway polynomial like
+  `(2, 409)`,
+- computing a `GF(p^n)` inverse for fixed `(p, n)` and chosen element.
+
+Use `setup_fixed_benchmark` for these. The bench module's docstring
+records the canonical input, the source it came from, and the
+reference timing the project considers reasonable (typically: time
+on the same canonical input in a comparator like FLINT or fpLLL).
+Comparison against the comparator is then a `compare` invocation
+across two `setup_fixed_benchmark` registrations, one per
+implementation.
+
+## Conway tier separation
+
+Conway-polynomial benchmarks reflect the three-tier design and must
+be reported separately:
+
+- **Tier 1.** Verify irreducibility of committed Conway polynomials.
+  Registered as `Hex.Conway.tier1.<p>_<n>` fixed benchmarks.
+- **Tier 2.** Full Conway-table verification (irreducibility,
+  primitivity, compatibility with divisor-degree entries) on
+  committed entries. Registered as `Hex.Conway.tier2.<p>_<n>`.
+- **Tier 3.** Search for missing Conway entries. Registered as
+  `Hex.Conway.tier3.<p>_<n>`.
+
+The tier prefix is part of the registration name; reports and CI
+gating MUST NOT aggregate tiers into a single "Conway runtime"
+number. Named cases include existing entries near the top of the
+Lübeck table (e.g. `(2, 409)`, `(3, 263)`, `(5, 251)`), entries for
+medium and large primes (e.g. `(97, 127)`, `(521, 13)`,
+`(65537, 7)`), just-beyond-table search probes (e.g. `(2, 410)`,
+`(97, 128)`), and large-degree irreducibility stress tests over
+`F_2` at degrees `512`, `1024`, `2048` and beyond when feasible.
+
+## CI integration
+
+Every library at `done_through ≥ 4` ships a CI job that runs:
+
+```sh
+lake exe hexfoo_bench list
+lake exe hexfoo_bench verify
+```
+
+The `verify` subcommand is the smoke gate: it spawns each
+registered benchmark at a tight inner-tuning budget, checks the
+child exits cleanly, and verifies hashable benchmarks emit hashes.
+It does NOT assert timing values — the gate detects bitrot of the
+bench module itself, not regressions in the implementation.
+
+For the repository-wide CI step, total wall-clock budget is `< 60 s`
+across all libraries' `verify` calls combined. A library whose
+`verify` cannot complete inside its share of that budget needs
+either tighter `setup_benchmark` config (lower `paramCeiling`) or
+a closer look at why its tiniest invocation is slow.
+
+Full timing runs (`lake exe hexfoo_bench run NAME` with a real
+budget) are not part of merge-gating CI. They run on a scheduled
+workflow or release-candidate workflow, on dedicated hardware where
+timing comparisons are meaningful. Each release names the libraries
+whose timing runs must succeed; a release is blocked by an
+inconclusive verdict or a comparator divergence even when proofs
+are complete.
 
 ## Reproducibility contract
 
-Every benchmark run must be reproducible from committed inputs and
-metadata.
+Every benchmark run is reproducible from committed inputs and
+metadata:
 
-- Each benchmark case has a stable name.
-- Randomized benchmarks use fixed committed seeds.
-- Generated inputs that matter for comparisons are either committed or
-  regenerated deterministically from the seed and recorded parameters.
-- Output artifacts record the Git commit, benchmark harness version,
-  machine description, date, Lean toolchain, and external tool versions.
-- Failures and timeouts are recorded explicitly rather than silently
-  dropped.
+- Each registered benchmark has a stable name (the
+  `setup_benchmark` declaration name); renaming or removing a
+  registration is a tracked PR-level change.
+- Randomized inputs are generated from a seed derived from the
+  benchmark name (so the seed is itself stable across runs).
+- Generated inputs that matter for a comparison are committed under
+  `HexFoo/Bench/Inputs/` or regenerated deterministically from the
+  seed plus the parameter.
+- The JSONL emitted by lean-bench is the canonical machine-readable
+  artefact. Schema (fields per row, `kind` discriminator for
+  fixed-mode rows, status enum) is defined by lean-bench; do not
+  re-specify it here.
+- Run metadata (git SHA, Lean toolchain, hostname, CPU model) is
+  recorded by the harness or by the script that invokes it.
+- Failures, timeouts, and budget skips are recorded explicitly via
+  the `status` field rather than silently dropped.
 
-## Conway benchmarks
+Rendering JSONL into HTML, posting to GitHub Pages, or building a
+benchmark dashboard are downstream concerns and not required for
+the SPEC's contract to be met.
 
-The `hex-conway` benchmark suite must reflect the three-tier design.
+## Relationship to conformance
 
-### Tier 1
+Conformance and benchmarking share one bug-finding loop:
 
-Measure verification of irreducibility for committed imported Conway
-polynomials. These runs answer: how expensive is it to certify a known
-modulus for `GF(p^n)`?
+- Conformance asks: do Lean and the oracle agree on outputs?
+- Benchmarking asks: does the implementation match its declared
+  complexity?
 
-### Tier 2
+Both failure modes route to the same response — file an issue, roll
+back `done_through`, fix at the rolled-back phase — and the same
+canonical issue body shape (with the **Symptom** section described
+in [Conventions.md](../PLAN/Conventions.md#bench-found-and-conformance-found-issues)).
+Where a SPEC names the same canonical input for both views (a
+committed hard polynomial, a committed lattice basis), the same
+`setup_benchmark`-style registration carries both signals: timing
+in the JSONL output, agreement via the result hash and `compare`.
 
-Measure full verification of committed imported Conway entries:
+## Anti-patterns
 
-- irreducible
-- primitive
-- compatibility with divisor-degree entries
+These behaviours have surfaced in past benchmarking work and are
+explicitly forbidden:
 
-These runs answer: how expensive is it to certify the imported table as
-Conway data?
-
-### Tier 3
-
-Measure explicit search for missing Conway polynomials when implemented.
-Tier 3 benchmarks must be reported separately from Tier 1 and Tier 2.
-The benchmark report must never aggregate them into a single
-"hex-conway runtime" number.
-
-Named `hex-conway` cases should include:
-
-- existing table entries near the top of the Lübeck table for small
-  primes, such as `(2, 409)`, `(3, 263)`, `(5, 251)`
-- existing table entries for medium and large primes, such as
-  `(97, 127)`, `(521, 13)`, `(65537, 7)`
-- just-beyond-table search probes, such as `(2, 410)`, `(97, 128)`,
-  `(521, 17)`, `(65537, 8)`, or updated analogues if the committed table
-  changes
-- large-degree irreducibility stress tests over `F_2`, e.g. degrees
-  `512`, `1024`, `2048`, `4096`, `8192`, and beyond when feasible
-
-## Output artifacts
-
-Benchmark runs must produce machine-readable and human-readable outputs.
-
-- machine-readable summary, e.g. JSON or CSV
-- raw logs for replay/debugging
-- rendered HTML report pages for human inspection
-
-The HTML reports are required project artifacts.
-
-## Publication contract
-
-Benchmark outputs must be published to GitHub Pages associated with the
-repository.
-
-- the repo contains a workflow or documented script that renders HTML
-  benchmark reports
-- rendered reports are published on GitHub Pages
-- the repo `README.md` links to the benchmark index page
-- the benchmark index page links to individual runs or release snapshots
-- release or milestone notes should link to the corresponding benchmark
-  pages
-
-The goal is that a reader can move from the repository front page to the
-current benchmark dashboard with one click.
-
-## CI and release expectations
-
-Not every benchmark must run on every PR, but the contract must say
-which ones run where.
-
-- smoke benchmarks may run on PRs
-- the full benchmark suite may run on a scheduled workflow or
-  release-candidate workflow
-- each release target must name the benchmark cases it must pass
-- specific cases and thresholds may evolve between releases, but every
-  such change must be accompanied by a short rationale in the PR that
-  changes the benchmark set (one paragraph per change). This keeps the
-  release gate machine-checkable without freezing the case list.
-- a release is blocked by obvious performance regressions even if proofs
-  are complete
-
-## Relationship to conformance testing
-
-Conformance and benchmarking should share harness infrastructure when
-useful, but they remain distinct:
-
-- conformance asks whether Lean and the reference agree
-- benchmarking asks how long Lean and the reference take
-
-The same named cases should usually support both views.
+- **Lowering the parameter range to make a budget-skip go away
+  without naming the implementation bug.** If a benchmark would
+  exceed its wallclock cap at the declared range, the implementation
+  is too slow at that range — file an issue, roll back, fix. Don't
+  shrink the range to dodge the verdict.
+- **Declaring a complexity model that matches the buggy current
+  code instead of textbook.** The model is the contract. Observation
+  disagreeing with textbook is a finding; observation agreeing with
+  a buggy implementation that itself disagrees with textbook is a
+  cover-up.
+- **Top-level `def` of proof-carrying context structures evaluated
+  at module init.** A module-level `def ctx : BarrettCtx p := …`
+  whose initializer transitively calls a heavy computation
+  deadlocks the bench exe at module load. Construct such contexts
+  inside the benchmarked function or inside its `with prep := …`
+  clause.
+- **Benchmarking `decide`, `#eval`, or kernel reduction.** Out of
+  scope per [§What we don't measure](#what-we-dont-measure).
+- **Runtime-`n` dispatch wrappers around dimension-typed
+  operations.** Lean accepts dependent types fine at runtime; pass
+  the dimension and its bound as parameters and let the caller
+  fill them in. A pattern-match-on-dimension ladder buried inside
+  the bench module is over-engineering and ties dimension choices
+  to Lean rather than to the bench parameter.
+- **Committed expected-output tables that the harness never reads.**
+  The hash-agreement check via `compare` is the conformance leg of
+  the harness; do not duplicate it in committed expected-output
+  fixtures.
+- **Rolling a hex-local benchmark harness.** lean-bench is the
+  harness; gaps in its API are filed against it, not papered over
+  locally.

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -31,6 +31,23 @@
    collisions with Mathlib's root-namespace types (`Matrix`,
    `Polynomial`, etc.).
 
+7. **Scaffolding applies only to proofs.** A proof skeleton may carry
+   `sorry` placeholders, where allowed. Every `def`, data-carrying
+   `structure` field, `class`, and `instance` ships with its
+   intended-final implementation on the first commit — the *real*
+   algorithm with the *intended* complexity, not a wrong-but-plausible
+   stand-in. If you cannot write that implementation in the current
+   session, do not commit the declaration; leave it out of Lean
+   entirely and open a follow-up issue. This rule is enforced at
+   three points: when a library is scaffolded
+   ([PLAN/Phase1.md](../PLAN/Phase1.md)), when its scaffolding is
+   reviewed ([PLAN/Phase2.md](../PLAN/Phase2.md)), and when its
+   benchmarks run ([benchmarking.md](benchmarking.md)). If
+   benchmarking later reveals that a committed `def` was scaffolding
+   in disguise — wrong shape, wrong complexity — the response is to
+   roll back the affected library's `done_through` and re-enter the
+   relevant phase, not to weaken the benchmark.
+
 ## Fully autonomous execution
 
 The project runs without human interaction after launch. Lean, Mathlib,

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -6,6 +6,16 @@ oracle (Sage, FLINT, python-flint, fpLLL, GAP, PARI). The goal is to
 catch implementation bugs *before* proof work starts. No point proving
 theorems about wrong implementations.
 
+When conformance fails, the response is the same as when benchmarking
+returns an unexpected complexity verdict ([benchmarking.md](benchmarking.md)):
+file a GitHub issue ([PLAN/Conventions.md §Bench-found and
+conformance-found issues](../PLAN/Conventions.md#bench-found-and-conformance-found-issues))
+and roll the affected library's `done_through` backward
+([PLAN/Conventions.md §Rollback is a normal action](../PLAN/Conventions.md#rollback-is-a-normal-action)).
+Conformance and benchmarking share one bug-finding loop; the choice
+of harness depends on which axis the bug is on (output correctness
+vs. algorithmic complexity), but the response is uniform.
+
 Conformance testing is a tiered system rather than one monolithic
 workflow. The repository supports three profiles:
 
@@ -151,6 +161,7 @@ MUST NOT appear in any `Conformance.lean`:
   *current stub output* rather than against the SPEC contract —
   e.g. `#guard (rref M).rank = 0` when `rref` is a placeholder —
   locks the wrong answer in and hides the scaffold. Per
+  [design-principles.md §7](design-principles.md) and
   [PLAN/Phase1.md](../PLAN/Phase1.md), no data-level placeholders
   are allowed in committed Lean at all; if a conformance test has to
   lock in trivial output to pass, the underlying implementation is
@@ -333,6 +344,5 @@ primary CI mechanism.
 ---
 
 This file specifies correctness-oriented cross-checking only.
-Performance measurement, benchmark case definitions, external timing
-comparisons, and publication of benchmark reports on GitHub Pages are
-specified in [benchmarking.md](benchmarking.md).
+Performance measurement, complexity-verdict checking, and external
+timing comparisons are specified in [benchmarking.md](benchmarking.md).

--- a/progress/2026-04-23T12:57:18Z_bench-prototype.md
+++ b/progress/2026-04-23T12:57:18Z_bench-prototype.md
@@ -1,0 +1,61 @@
+**Accomplished**
+
+Landed prototype benchmarking frameworks for HexArith and HexLLL, working tree only. Both libraries have:
+
+- A Lean exec (`hex_arith_bench`, `hex_lll_bench`) with online calibration, JSONL emission, and `--ladder` / `--smoke` modes.
+- Rich JSONL schema from day one (schema_version, family_version, param_origin, seed, run_index, wall_nanos, result_hash, status enum, git_sha, hostname, cpu_model, …).
+- A shared harness (`scripts/bench/run.sh`, `smoke.sh`, `report.py`) and Python comparators (`python_arith.py` uses stdlib, `fpylll_lll.py` is optional and skips gracefully when unavailable).
+- Markdown report output to `HexManual/Benchmarks/<Lib>.md`, rendered from JSONL (JSONL remains the source of truth).
+- CI smoke step in [.github/workflows/ci.yml](../.github/workflows/ci.yml); smoke validated locally in ~8s total for both libraries.
+
+HexArith results at seconds=3: A1 extgcd (B=65536) 137ms vs python-stdlib 282ms (0.49×), A2 powMod (B=15808) 690ms vs python 6.16s (0.11×), A3 Barrett mulMod (N=10⁸) 553ms vs python 10.10s (0.05×).
+
+HexLLL results at seconds=3: L1 uniform (dim=8) 1.55s, L2 arith-heavy (dim=6, B=256) 35ms. fpylll not installed; comparator gracefully skipped.
+
+Plan file: [let-s-make-a-plan-synchronous-token.md](/home/kim/.claude/plans/let-s-make-a-plan-synchronous-token.md).
+
+**Current frontier**
+
+Both libraries produce valid end-to-end runs. The harness surfaced several real findings that belong in SPEC v2:
+
+1. **`MontCtx.mulMont` / `fromMont` scaffolding is unbenchmarkable.** They call `montgomeryRadixInvNat p = (List.range p.toNat).find? ...` — brute-force search of `[0, p)` on every call. For p=65537 that's 65k iterations per `mulMont`, making even a tiny N unusable. HexArith should replace this with a real Bezout-based inverse before Montgomery throughput can be measured. A4 is dropped from both budgeted and smoke families for now.
+
+2. **`lll` requires `n` in the type** — we can't dispatch a runtime `n`. The workaround (discrete dim ladder via pattern match on snapped dim) works but bakes dimension choices into Lean. SPEC v2 should decide: do we require libraries to expose a `runtime-n` wrapper, or do benchmarks live with discrete dims?
+
+3. **`decide` on Rat comparisons is broken without `+kernel`.** `(1 : Rat) / 4 < 3 / 4` can't be decided by elaboration-time `decide` because `Rat.blt` doesn't reduce through the literal-division form. `decide +kernel` works (slow but acceptable for fixed small literals). SPEC v2 should require libraries that take Rat bound-constraints to provide a decidable instance shim or helper lemma. The workaround adds compile-time cost.
+
+4. **`Decidable b.independent` isn't auto-synthesized** — we had to provide the instance explicitly with `unfold Matrix.independent; exact inferInstance`. HexLLL would benefit from a public Decidable instance.
+
+5. **Top-level `def` of proof-carrying structures (BarrettCtx, MontCtx) gets eagerly evaluated at module init**. A module-level `def a3Ctx : BarrettCtx 4294967291 := ...` deadlocked module load because the closure inside `fromMont` referenced the Montgomery search. Fix: inline the ctx construction inside the runner. SPEC v2 should call this out as a benchmark-harness convention.
+
+6. **Online calibration works but has a latency floor.** We can't cancel a trial mid-flight, so a first-guess param that's way too large kills the budget (e.g. L1 initially tried dim=12 and would have taken minutes). Mitigations: start from `paramFloor`, use a very small first probe, or add SIGALRM-style cancellation.
+
+7. **Well-founded recursion in PRNG blew up the kernel.** Original SplitMix `nextBits` with a helper recursion and omega termination proof caused "(kernel) deep recursion detected" at elaboration. Rewrote with an explicit `for` loop over precomputed chunks. SPEC v2 should note that Bench harnesses should avoid well-founded recursion where possible.
+
+8. **`L2.arith-bit-sweep` dropped from plan's `n=20` to `n=6`.** The naive swap step's cost at n=20 is prohibitive at any bit-width, so the arith-vs-swap distinction L2 was meant to highlight is blurred.
+
+9. **Python's `ext_gcd` recurses too deep.** Lean's equivalent trampolines tail-calls fine, but stock Python hits the recursion limit on 1000+ bit inputs; iterative Bezout is the fix.
+
+Both benchmarks consistently show Lean beating Python-stdlib by significant ratios (2×–20×), which is meaningful baseline data. Scaling-law slopes are not yet populated because ladder mode isn't being used by default — the infrastructure to fit and report them is in [report.py](../scripts/bench/report.py) but needs `--ladder` runs to populate.
+
+**Next step**
+
+For SPEC v2 of benchmarking.md, the following should be mandated or recommended (ordered by severity):
+
+- **Required**: JSONL schema with the fields we emit today, status enum, and distinction between `predicted` and `discovered` param origins.
+- **Required**: per-family max-wall cap as a first-class concept, distinct from `budget_skip` from ladder exhaustion.
+- **Required**: `smoke.sh`-equivalent CI gate that exercises every family in <60s.
+- **Recommended**: harness-authoring conventions — avoid top-level `def` of proof-carrying structures, avoid well-founded recursion in runners, always use a hash result so comparator joins work.
+- **Recommended**: comparator version auto-capture and `comparator_unavailable` as a first-class status.
+- **Deferred**: Markdown vs HTML rendering, baseline regression gates.
+
+Run `./scripts/bench/run.sh hex_arith 30 --ladder --runs 3` for the first scaling-law data set.
+
+**Blockers**
+
+None for the prototype; the retrospective is the handoff for SPEC v2 drafting.
+
+Not done intentionally:
+- Third HexLLL family (Lagarias-Odlyzko knapsack) — trimmed during implementation time-budgeting.
+- fpylll/gmpy2 install instructions — comparators are optional.
+- HTML rendering / baseline regression detection — explicitly out of scope for v1 per the plan.

--- a/progress/2026-04-28T04:38:58Z_spec-rewrite-lean-bench.md
+++ b/progress/2026-04-28T04:38:58Z_spec-rewrite-lean-bench.md
@@ -1,0 +1,69 @@
+**Accomplished**
+
+Rewrote the Phase-4 (benchmarking) doctrine around `kim-em/lean-bench`
+and promoted "scaffolding is for proofs only" to a project-wide
+principle. Single commit on `spec/benchmarking-rewrite-lean-bench`:
+
+- [SPEC/benchmarking.md](../SPEC/benchmarking.md) — substantial
+  rewrite. New structure: why benchmark, the verdict-as-bug-trigger
+  model with the HexArith Montgomery / HexLLL swapStep findings as
+  worked examples, lean-bench as the only harness (with the lakefile
+  snippet and both `setup_benchmark` / `setup_fixed_benchmark`
+  forms), within-Lean comparisons via `compare`, external
+  comparators via FFI (preferred) or process call, fixed-problem
+  benchmarks, Conway tier separation, CI integration via
+  `lake exe ... verify`, reproducibility contract, and an explicit
+  anti-patterns list distilled from the prototype.
+- [SPEC/design-principles.md](../SPEC/design-principles.md) — added
+  principle 7: scaffolding applies only to proofs. Every `def` ships
+  with the intended-final implementation; the rule is enforced at
+  Phase 1 (author), Phase 2 (review), and Phase 4 (benchmark
+  verdict).
+- [SPEC/testing.md](../SPEC/testing.md) — preamble now cross-links
+  the bug-finding doctrine; conformance and benchmarking share one
+  loop. Scaffold-locking `#guard`s text references the new
+  principle 7.
+- [PLAN/Conventions.md](../PLAN/Conventions.md) — three additions:
+  "Scaffolding is for proofs only" under Hard rules; "Rollback is
+  a normal action" under `done_through` semantics (operational
+  steps for a backward bump); "Bench-found and conformance-found
+  issues" issue template under Issue creation.
+- [PLAN/Phase4.md](../PLAN/Phase4.md) — replaced. Phase 4
+  deliverable is `HexFoo/Bench.lean` with `setup_benchmark`
+  registrations using *textbook* complexity. An `inconclusive`
+  verdict is not a Phase 4 exit; it triggers a rollback.
+
+Filed [kim-em/lean-bench#24](https://github.com/kim-em/lean-bench/issues/24)
+during planning ("Fixed-problem benchmarks (no parameter sweep)"),
+implemented in
+[kim-em/lean-bench#26](https://github.com/kim-em/lean-bench/pull/26).
+The SPEC references both `setup_benchmark` and `setup_fixed_benchmark`
+because both now exist.
+
+Imported the prototype retrospective at
+[progress/2026-04-23T12:57:18Z_bench-prototype.md](2026-04-23T12:57:18Z_bench-prototype.md)
+into git so the reasoning behind the rewrite is preserved. Removed
+TODO.md (its content is now in the SPEC).
+
+**Current frontier**
+
+The SPEC rewrite is committed but not pushed. The Phase-4 prototype
+implementation (HexArith/Bench/, HexLLL/Bench/, scripts/bench/,
+working-tree edits to lakefile.toml and HexArith.lean / HexLLL.lean
+and .github/workflows/ci.yml) is still in the working tree —
+deliberately untouched per Kim's direction; a separate rollback PR
+will handle it.
+
+**Next step**
+
+- Push branch and open the SPEC rewrite PR.
+- Kim handles the broader rollback (Phase-4 prototype + any older
+  committed Phase-4 fixture work like HexArith/Benchmark.lean and
+  HexManual/Benchmarks/index.md) in a follow-up.
+- After the rewrite lands, when a library re-enters Phase 4, that PR
+  adds `[[require]] name = "lean-bench"` to the lakefile and creates
+  the first `HexFoo/Bench.lean`.
+
+**Blockers**
+
+None.


### PR DESCRIPTION
## Summary

- Rewrites [SPEC/benchmarking.md](SPEC/benchmarking.md) around [`kim-em/lean-bench`](https://github.com/kim-em/lean-bench) v0.1+ as the mandatory inner harness; replaces the hand-rolled-harness prose, the HTML/Pages publication contract, and the blanket external-CAS requirement with a focused doctrine.
- Promotes the **success criterion for a benchmark is "we found a bug"** doctrine: a textbook complexity model declared at the registration site, an `inconclusive` verdict triggers a GitHub issue + a backward bump of `done_through`, and the prototype's HexArith Montgomery / HexLLL `swapStep` findings are worked examples.
- Promotes the **scaffolding-is-for-proofs-only** rule from [PLAN/Phase1.md](PLAN/Phase1.md) to a project-wide principle (new [SPEC/design-principles.md](SPEC/design-principles.md) §7), with [SPEC/testing.md](SPEC/testing.md) and [SPEC/benchmarking.md](SPEC/benchmarking.md) as the third enforcement point.
- Adds **rollback as a first-class action** in [PLAN/Conventions.md](PLAN/Conventions.md), with operational steps and an issue template for bench-found and conformance-found bugs.
- Replaces [PLAN/Phase4.md](PLAN/Phase4.md): per-library deliverable is `HexFoo/Bench.lean` with `setup_benchmark` registrations using textbook complexity, plus a CI smoke step (`lake exe ... verify`). Inconclusive verdict ≠ Phase 4 exit.

The Phase-4 prototype that motivated this rewrite is captured at [progress/2026-04-23T12:57:18Z_bench-prototype.md](progress/2026-04-23T12:57:18Z_bench-prototype.md). The corresponding `TODO.md` is removed (content superseded by the SPEC).

This is a **user-authorised SPEC rewrite** — per [PLAN/Conventions.md](PLAN/Conventions.md) agents do not autonomously rewrite SPEC unless clauses are internally contradictory; this rewrite happens by Kim's instruction.

The Phase-4 prototype implementation itself (`HexArith/Bench/`, `HexLLL/Bench/`, `scripts/bench/`, working-tree edits to `lakefile.toml`, `HexArith.lean`, `HexLLL.lean`, `.github/workflows/ci.yml`) is left in the working tree on purpose — Kim handles the broader rollback in a separate PR.

Filed [kim-em/lean-bench#24](https://github.com/kim-em/lean-bench/issues/24) during planning ("Fixed-problem benchmarks (no parameter sweep)"); implemented in [kim-em/lean-bench#26](https://github.com/kim-em/lean-bench/pull/26). The SPEC references both `setup_benchmark` and `setup_fixed_benchmark` because both now exist.

## Test plan

- [ ] Re-read [SPEC/benchmarking.md](SPEC/benchmarking.md) end-to-end and check every cross-link resolves (anchors verified locally; spot-check on the rendered PR).
- [ ] Confirm no spec language promises lean-bench features that don't exist in v0.1+ (auto-fit complexity, memory metrics, baseline-diff, hyperfine export, `lake bench`, parametric `IO α` benchmarks all remain v0.2+ roadmap items).
- [ ] Walkthrough check: starting from [SPEC/SPEC.md](SPEC/SPEC.md), a reader can answer: "what harness?" / "what do I do with an inconclusive verdict?" / "how do I declare expected complexity?" / "what about a comparison lean-bench can't model?".
- [ ] Search the SPEC tree for the words "scaffolding", "rollback", "done_through", "wrong implementation": every hit aligns with the new doctrine.

🤖 Prepared with Claude Code