### PR TITLE
spec: check_dag.py should allow transitive imports

### DIFF
--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -61,7 +61,15 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    - For each `.lean` file (excluding `.lake/`), determine its library
      from the file path (top-level directory or root file name).
    - For each `import` statement, verify the imported module belongs to
-     the same library, a declared dependency, or stdlib/core.
+     the same library, a library reachable in the `libraries.yml`
+     dep closure of the importing library (i.e. a declared
+     dependency, direct **or transitive**), or stdlib/core. The
+     check matches Lake's actual symbol-visibility semantics: if a
+     library is reachable in the dep graph, its modules are
+     importable. Forbidding transitive imports would force HexLLL
+     (whose `deps: [HexGramSchmidt]`) to re-export every
+     HexMatrix-derived symbol it uses just to dodge the rule, which
+     is the opposite of clarity.
    - If the import starts with `Mathlib`, verify the library has
      `mathlib: true` in `libraries.yml` (or is `HexManual`, which may
      import from any hex-* library and from Verso, but not from


### PR DESCRIPTION
## Summary

- Tightens the import-boundary rule in [PLAN/Phase0.md](PLAN/Phase0.md) to allow transitive deps, matching Lake's actual symbol-visibility semantics.
- The strict-direct-deps rule was forcing libraries to dodge it via re-exports — e.g. HexLLL (whose `deps: [HexGramSchmidt]`) uses `HexMatrix.Matrix` types pervasively in its own source files, but never writes `import HexMatrix` because the strict rule would flag it. The new wording authorises what the code already does.

## Out of scope

`scripts/check_dag.py` still implements the old strict rule. A small follow-up patches the implementation; that's the next PR.

🤖 Prepared with Claude Code