### PR TITLE
Reland: bench Phase-4 prototype harnesses for HexArith and HexLLL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,6 @@ jobs:
       - run: python3 scripts/check_dag.py
       - run: sudo apt-get install -y libgmp-dev
       - uses: leanprover/lean-action@v1
+      - name: Benchmark smoke
+        run: ./scripts/bench/smoke.sh
+        timeout-minutes: 5

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 *.olean
 *.ilean
 *.trace
+.claude/.pod-checksums

--- a/HexArith.lean
+++ b/HexArith.lean
@@ -1,6 +1,7 @@
 import HexArith.Barrett.Context
 import HexArith.Barrett.Reduce
 import HexArith.Barrett.ReduceNat
+import HexArith.Bench
 import HexArith.Benchmark
 import HexArith.Binomial
 import HexArith.Conformance

--- a/HexArith/Bench.lean
+++ b/HexArith/Bench.lean
@@ -1,0 +1,17 @@
+import HexArith.Bench.Calibration
+import HexArith.Bench.Driver
+import HexArith.Bench.Families
+import HexArith.Bench.Inputs
+import HexArith.Bench.Random
+
+/-!
+# `HexArith.Bench` — Phase 4 timed benchmark surface for HexArith
+
+See [Main.lean](Bench/Main.lean) for the executable entry point and
+[the project plan](../.claude/plans/let-s-make-a-plan-synchronous-token.md)
+for the architecture.
+
+This namespace is distinct from the older
+[HexArith.Benchmark](Benchmark.lean) result-only fixture registry. The
+two coexist; see [SPEC/benchmarking.md](../SPEC/benchmarking.md).
+-/

--- a/HexArith/Bench/Calibration.lean
+++ b/HexArith/Bench/Calibration.lean
@@ -1,0 +1,67 @@
+/-!
+# HexArith benchmark calibration constants
+
+Initial-guess parameters per family, expressed as
+`(refSeconds → refParam)` curves so the driver can invert them.
+These are *initial guesses only*: the online calibration in
+`HexArith.Bench.Driver.pickParam` always brackets the target budget
+empirically before declaring the chosen parameter.
+
+The constants below were committed by hand during prototyping and will
+drift on faster or slower CPUs. That is fine — see
+[SPEC/benchmarking.md](../../SPEC/benchmarking.md): the harness must
+record whether the param was `predicted` (initial guess hit the band)
+or `discovered` (online search converged).
+-/
+
+namespace HexArith.Bench.Calibration
+
+/--
+Initial param-from-budget guess for `A1.nat-extgcd`.
+Parameter is the bit-width of the input pair; expected slope ~2 (O(B²)).
+
+`refSeconds = 1.0  →  refParam = 4096` was the prototype reading on the
+author's machine. The inversion uses the schoolbook exponent.
+-/
+@[inline] def a1NatExtGcd (seconds : Float) : Nat :=
+  let refSeconds : Float := 1.0
+  let refParam : Float := 4096.0
+  let exponent : Float := 2.0
+  let scale := (seconds / refSeconds) ^ (1.0 / exponent)
+  let raw := refParam * scale
+  if raw ≤ 8.0 then 8 else raw.toUInt64.toNat
+
+/--
+Initial param-from-budget guess for `A2.nat-powmod`.
+Parameter is the bit-width of `p` (and of the exponent); expected slope ~3.
+-/
+@[inline] def a2NatPowMod (seconds : Float) : Nat :=
+  let refSeconds : Float := 1.0
+  let refParam : Float := 1024.0
+  let exponent : Float := 3.0
+  let scale := (seconds / refSeconds) ^ (1.0 / exponent)
+  let raw := refParam * scale
+  if raw ≤ 8.0 then 8 else raw.toUInt64.toNat
+
+/--
+Initial param-from-budget guess for `A3.barrett-mulmod`.
+Parameter is the call count `N`; expected slope ~1 (linear in N).
+
+The number of mulMod ops we can do per second is large (~10^7–10^8),
+so the reference is set generously.
+-/
+@[inline] def a3BarrettMulMod (seconds : Float) : Nat :=
+  let perSecond : Float := 5.0e6
+  let raw := perSecond * seconds
+  if raw ≤ 100.0 then 100 else raw.toUInt64.toNat
+
+/--
+Initial param-from-budget guess for `A4.montgomery-mulmont`.
+Parameter is the call count `N`; expected slope ~1.
+-/
+@[inline] def a4MontgomeryMulMont (seconds : Float) : Nat :=
+  let perSecond : Float := 5.0e6
+  let raw := perSecond * seconds
+  if raw ≤ 100.0 then 100 else raw.toUInt64.toNat
+
+end HexArith.Bench.Calibration

--- a/HexArith/Bench/Driver.lean
+++ b/HexArith/Bench/Driver.lean
@@ -1,0 +1,260 @@
+import HexArith.Bench.Random
+
+/-!
+# HexArith benchmark driver
+
+Timing wrapper, online calibration loop, JSONL emission. Parameterised
+over a `FamilySpec` so each family in
+[Families.lean](./Families.lean) plugs in identically.
+-/
+
+namespace HexArith.Bench
+
+/-- Status enum for a single recorded measurement. -/
+inductive Status
+  | ok
+  | timeout
+  | budgetSkip
+  | comparatorUnavailable
+  | error
+  deriving Repr, BEq
+
+def Status.toJsonString : Status → String
+  | .ok => "ok"
+  | .timeout => "timeout"
+  | .budgetSkip => "budget_skip"
+  | .comparatorUnavailable => "comparator_unavailable"
+  | .error => "error"
+
+/-- Origin of the chosen parameter. -/
+inductive ParamOrigin
+  | predicted
+  | discovered
+  deriving Repr, BEq, Inhabited
+
+def ParamOrigin.toJsonString : ParamOrigin → String
+  | .predicted => "predicted"
+  | .discovered => "discovered"
+
+/-- Spec for one benchmark family with a single Nat parameter. -/
+structure FamilySpec where
+  name : String
+  familyVersion : Nat := 1
+  paramName : String
+  expectedSlope : Float
+  paramFloor : Nat
+  paramCeiling : Nat
+  /-- target seconds → suggested param -/
+  initialGuess : Float → Nat
+  /-- run one trial; driver times the call and records the returned hash -/
+  runOne : Nat → IO UInt64
+
+/-- Process-wide metadata captured once at startup. -/
+structure RunMeta where
+  schemaVersion : Nat := 1
+  library : String
+  gitSha : String
+  leanToolchain : String
+  hostname : String
+  cpuModel : Option String
+  ts : String
+  seed : UInt64
+  deriving Inhabited
+
+def envOr (key default : String) : IO String := do
+  return (← IO.getEnv key).getD default
+
+def envOpt (key : String) : IO (Option String) := do
+  match ← IO.getEnv key with
+  | some v => pure (if v.isEmpty then none else some v)
+  | none => pure none
+
+def collectMeta (library : String) (seed : UInt64) : IO RunMeta := do
+  let gitSha ← envOr "BENCH_GIT_SHA" "unknown"
+  let toolchain ← envOr "BENCH_TOOLCHAIN" "unknown"
+  let hostname ← envOr "BENCH_HOSTNAME" "unknown"
+  let cpu ← envOpt "BENCH_CPU_MODEL"
+  let ts ← envOr "BENCH_TS" "unknown"
+  pure { library, gitSha, leanToolchain := toolchain, hostname, cpuModel := cpu, ts, seed }
+
+/-- Time an `IO` action, returning `(value, elapsed_nanos)`. -/
+@[inline] def timeNanos (act : IO α) : IO (α × Nat) := do
+  let t₀ ← IO.monoNanosNow
+  let v ← act
+  let t₁ ← IO.monoNanosNow
+  pure (v, t₁ - t₀)
+
+/-- Result of online calibration. -/
+structure CalibratedParam where
+  param : Nat
+  origin : ParamOrigin
+  observedNanos : Nat
+  cappedDuringSearch : Bool := false
+  deriving Inhabited
+
+partial def pickParamSearch (f : FamilySpec) (lo hi capNanos : Nat)
+    (p t : Nat) (tries : Nat) (cappedSoFar : Bool) : IO CalibratedParam := do
+  if tries = 0 then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := cappedSoFar }
+  let p' :=
+    if t < lo then min f.paramCeiling (p * 2)
+    else max f.paramFloor (p / 2)
+  if p' = p then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := cappedSoFar }
+  let (_, t') ← timeNanos (f.runOne p')
+  if t' > capNanos then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := true }
+  if lo ≤ t' ∧ t' ≤ hi then
+    return { param := p', origin := .discovered, observedNanos := t', cappedDuringSearch := cappedSoFar }
+  pickParamSearch f lo hi capNanos p' t' (tries - 1) cappedSoFar
+
+/--
+Pick a parameter that brings one trial into `[targetNanos/2, targetNanos*2]`,
+refusing to spend more than `capNanos` on any single trial. Initial guess
+from `f.initialGuess`; otherwise ×2 / ÷2 geometric search for up to 6 steps.
+-/
+def pickParam (f : FamilySpec) (targetNanos capNanos : Nat) : IO CalibratedParam := do
+  let lo := targetNanos / 2
+  let hi := targetNanos * 2
+  let p₀ := min f.paramCeiling
+              (max f.paramFloor (f.initialGuess (targetNanos.toFloat / 1.0e9)))
+  let (_, t₀) ← timeNanos (f.runOne p₀)
+  if t₀ > capNanos then
+    return { param := p₀, origin := .discovered, observedNanos := t₀, cappedDuringSearch := true }
+  if lo ≤ t₀ ∧ t₀ ≤ hi then
+    return { param := p₀, origin := .predicted, observedNanos := t₀ }
+  pickParamSearch f lo hi capNanos p₀ t₀ 6 false
+
+/-- Build a parameter ladder for scaling-law fitting (×2 per rung). -/
+def buildLadder (f : FamilySpec) (anchor : Nat) (rungs : Nat) : Array Nat := Id.run do
+  let mut acc : Array Nat := #[]
+  let halfRungs := rungs / 2
+  let mut p := anchor
+  for _ in [0:halfRungs] do
+    p := max f.paramFloor (p / 2)
+  for _ in [0:rungs] do
+    if f.paramFloor ≤ p ∧ p ≤ f.paramCeiling then
+      acc := acc.push p
+    p := p * 2
+  return acc
+
+/-- One JSONL row to emit. -/
+structure RowRecord where
+  family : String
+  familyVersion : Nat
+  param : Nat
+  paramOrigin : ParamOrigin
+  runIndex : Nat
+  wallNanos : Nat
+  resultHash : UInt64
+  status : Status
+  errMsg? : Option String := none
+  comparator? : Option String := none
+  comparatorVersion? : Option String := none
+
+def jsonStr (s : String) : String :=
+  let escaped := s.foldl (init := "") fun acc c =>
+    match c with
+    | '"' => acc ++ "\\\""
+    | '\\' => acc ++ "\\\\"
+    | '\n' => acc ++ "\\n"
+    | '\r' => acc ++ "\\r"
+    | '\t' => acc ++ "\\t"
+    | c => acc.push c
+  "\"" ++ escaped ++ "\""
+
+def jsonOptStr : Option String → String
+  | none => "null"
+  | some s => jsonStr s
+
+def hex64 (n : UInt64) : String :=
+  "0x" ++ String.ofList (Nat.toDigits 16 n.toNat)
+
+def renderRow (runMeta : RunMeta) (r : RowRecord) : String :=
+  "{" ++ String.intercalate ","
+    [ "\"schema_version\":" ++ toString runMeta.schemaVersion
+    , "\"library\":" ++ jsonStr runMeta.library
+    , "\"family\":" ++ jsonStr r.family
+    , "\"family_version\":" ++ toString r.familyVersion
+    , "\"param\":" ++ toString r.param
+    , "\"param_origin\":" ++ jsonStr r.paramOrigin.toJsonString
+    , "\"seed\":" ++ toString runMeta.seed.toNat
+    , "\"run_index\":" ++ toString r.runIndex
+    , "\"wall_nanos\":" ++ toString r.wallNanos
+    , "\"result_hash\":" ++ jsonStr (hex64 r.resultHash)
+    , "\"status\":" ++ jsonStr r.status.toJsonString
+    , "\"error\":" ++ jsonOptStr r.errMsg?
+    , "\"git_sha\":" ++ jsonStr runMeta.gitSha
+    , "\"lean_toolchain\":" ++ jsonStr runMeta.leanToolchain
+    , "\"hostname\":" ++ jsonStr runMeta.hostname
+    , "\"cpu_model\":" ++ jsonOptStr runMeta.cpuModel
+    , "\"comparator\":" ++ jsonOptStr r.comparator?
+    , "\"comparator_version\":" ++ jsonOptStr r.comparatorVersion?
+    , "\"ts\":" ++ jsonStr runMeta.ts
+    ] ++ "}"
+
+def emitRow (h : IO.FS.Stream) (runMeta : RunMeta) (r : RowRecord) : IO Unit :=
+  h.putStrLn (renderRow runMeta r)
+
+structure RunSettings where
+  totalSeconds : Float
+  capNanos : Nat
+  runs : Nat := 3
+  ladder : Bool := false
+  ladderRungs : Nat := 5
+
+/-- Non-ladder mode: calibrate, warm, take `runs` samples. -/
+def runFamilyMeasured (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit := do
+  let targetNanos := (familyShareSeconds * 1.0e9).toUInt64.toNat
+  IO.eprintln s!"[bench] {f.name}: calibrating (target {targetNanos / 1000000} ms)"
+  let cal ← pickParam f targetNanos settings.capNanos
+  IO.eprintln s!"[bench] {f.name}: param={cal.param} observed={cal.observedNanos / 1000000} ms"
+  let _ ← timeNanos (f.runOne cal.param)
+  for i in [0:settings.runs] do
+    let (hash, wall) ← timeNanos (f.runOne cal.param)
+    let status :=
+      if cal.cappedDuringSearch ∧ wall > settings.capNanos then Status.budgetSkip
+      else Status.ok
+    emitRow h runMeta
+      { family := f.name
+      , familyVersion := f.familyVersion
+      , param := cal.param
+      , paramOrigin := cal.origin
+      , runIndex := i
+      , wallNanos := wall
+      , resultHash := hash
+      , status := status }
+
+/-- Ladder mode: sweep params around the calibration anchor. -/
+def runFamilyLadder (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit := do
+  let targetNanos := (familyShareSeconds * 1.0e9).toUInt64.toNat
+  let cal ← pickParam f targetNanos settings.capNanos
+  let ladder := buildLadder f cal.param settings.ladderRungs
+  let mut skipRest := false
+  for i in [0:ladder.size] do
+    let p := ladder[i]!
+    if skipRest then
+      emitRow h runMeta
+        { family := f.name, familyVersion := f.familyVersion
+        , param := p, paramOrigin := cal.origin, runIndex := 0
+        , wallNanos := 0, resultHash := 0, status := .budgetSkip }
+    else
+      let (hash, wall) ← timeNanos (f.runOne p)
+      let st := if wall > settings.capNanos then Status.budgetSkip else Status.ok
+      emitRow h runMeta
+        { family := f.name, familyVersion := f.familyVersion
+        , param := p, paramOrigin := cal.origin, runIndex := 0
+        , wallNanos := wall, resultHash := hash, status := st }
+      if wall > settings.capNanos then
+        skipRest := true
+
+def runFamily (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit :=
+  if settings.ladder then
+    runFamilyLadder h runMeta settings familyShareSeconds f
+  else
+    runFamilyMeasured h runMeta settings familyShareSeconds f
+
+end HexArith.Bench

--- a/HexArith/Bench/Families.lean
+++ b/HexArith/Bench/Families.lean
@@ -1,0 +1,84 @@
+import HexArith.Bench.Calibration
+import HexArith.Bench.Driver
+import HexArith.Bench.Inputs
+
+/-!
+# HexArith benchmark family registry
+
+The four committed families (per the [plan](../../../.claude/plans/let-s-make-a-plan-synchronous-token.md))
+with their weights for the seconds-budget split.
+-/
+
+namespace HexArith.Bench.Families
+
+open HexArith.Bench
+
+def a1 (seed : UInt64) : FamilySpec :=
+  { name := "A1.nat-extgcd"
+  , familyVersion := 1
+  , paramName := "bits"
+  , expectedSlope := 2.0
+  , paramFloor := 16
+  , paramCeiling := 65536
+  , initialGuess := Calibration.a1NatExtGcd
+  , runOne := fun bits => pure (Inputs.runA1 seed bits) }
+
+def a2 (seed : UInt64) : FamilySpec :=
+  { name := "A2.nat-powmod"
+  , familyVersion := 1
+  , paramName := "bits"
+  , expectedSlope := 3.0
+  , paramFloor := 16
+  , paramCeiling := 16384
+  , initialGuess := Calibration.a2NatPowMod
+  , runOne := fun bits => pure (Inputs.runA2 seed bits) }
+
+def a3 (seed : UInt64) : FamilySpec :=
+  { name := "A3.barrett-mulmod"
+  , familyVersion := 1
+  , paramName := "calls"
+  , expectedSlope := 1.0
+  , paramFloor := 100
+  , paramCeiling := 100000000
+  , initialGuess := Calibration.a3BarrettMulMod
+  , runOne := fun n => pure (Inputs.runA3 seed n) }
+
+def a4 (seed : UInt64) : FamilySpec :=
+  { name := "A4.montgomery-mulmont"
+  , familyVersion := 1
+  , paramName := "calls"
+  , expectedSlope := 1.0
+  , paramFloor := 100
+  , paramCeiling := 100000000
+  , initialGuess := Calibration.a4MontgomeryMulMont
+  , runOne := fun n => pure (Inputs.runA4 seed n) }
+
+/--
+Budgeted families with their seconds-budget weights (must sum to 1.0).
+
+**A4 is intentionally excluded.** The current `HexArith.MontCtx`
+scaffolding calls `montgomeryRadixInvNat p` (a brute-force `List.range`
+search) inside every `mulMont` and `fromMont`, making throughput
+benchmarks meaningless until that's replaced with a real Bezout-based
+inverse. A4 is exercised only by the smoke set below — long enough to
+confirm it doesn't crash at tiny `N`. See progress retrospective for
+the SPEC v2 implication.
+-/
+def all (seed : UInt64) : List (Float × FamilySpec) :=
+  [ (0.40, a1 seed)
+  , (0.30, a2 seed)
+  , (0.30, a3 seed) ]
+
+/--
+Smoke-only families: exercised by `scripts/bench/smoke.sh` once at tiny param.
+
+**Empty for now.** A4 (Montgomery) was planned here but its inner
+`mulMont` / `fromMont` call `montgomeryRadixInvNat` (a brute-force
+`List.range p.toNat` search) on every invocation — even a smoke-sized
+N of 100 is too slow to complete inside the CI budget at any modulus
+worth benchmarking. The SPEC v2 retrospective lists this as an
+action item for HexArith itself.
+-/
+def smokeOnly (_seed : UInt64) : List FamilySpec := []
+
+end HexArith.Bench.Families

--- a/HexArith/Bench/Inputs.lean
+++ b/HexArith/Bench/Inputs.lean
@@ -1,0 +1,97 @@
+import HexArith.Bench.Random
+import HexArith.ExtGcd
+import HexArith.PowMod
+import HexArith.Barrett.Context
+import HexArith.Montgomery.Context
+
+/-!
+# HexArith benchmark input generators / runners
+
+One `runX` per family. Each takes a seed plus the family parameter and
+returns a `UInt64` hash of the result (used by the driver to verify
+that timing variations don't come with output drift).
+
+Inputs are derived deterministically from the seed; the same `(seed, param)`
+always yields the same input, which matches the `hyperfine`-style
+expectation that repeat runs measure steady-state throughput on the same
+work.
+-/
+
+namespace HexArith.Bench.Inputs
+
+open HexArith
+
+/-- Return the low 64 bits of a Nat, padded with zeros if smaller. -/
+@[inline] def natHash (n : Nat) : UInt64 :=
+  (n % (1 <<< 64)).toUInt64
+
+/--
+A1 — random coprimality-not-required `Nat.extGcd` on a pair of `bits`-bit
+inputs. Hash of `gcd ⊕ s ⊕ t-low` (mod 2^64).
+-/
+def runA1 (seed : UInt64) (bits : Nat) : UInt64 :=
+  let (a, s₁) := Random.nextNonZeroBits seed bits
+  let (b, _) := Random.nextNonZeroBits s₁ bits
+  let (g, sCoeff, tCoeff) := extGcd a b
+  natHash g ^^^ (Int.toNat sCoeff.natAbs).toUInt64 ^^^ (Int.toNat tCoeff.natAbs).toUInt64
+
+/--
+A2 — `Nat.powMod` with `bits`-bit base, exponent, and modulus.
+-/
+def runA2 (seed : UInt64) (bits : Nat) : UInt64 :=
+  let (a, s₁) := Random.nextNonZeroBits seed bits
+  let (n, s₂) := Random.nextNonZeroBits s₁ bits
+  let (p₀, _) := Random.nextNonZeroBits s₂ bits
+  -- ensure p > 1 (powMod tolerates p=1 but it gives a degenerate result)
+  let p := p₀ + 2
+  natHash (powMod a n p)
+
+/-- The committed Barrett modulus for A3 (near-2³² prime, 4294967291 = 2³² − 5). -/
+abbrev a3Modulus : UInt64 := 4294967291
+
+/--
+A3 — `BarrettCtx.mulMod` throughput: do `n` mulMods at the committed
+modulus. The Barrett context is constructed inside the function rather
+than at top level — top-level `def`s of structures with proof fields
+get eagerly evaluated by the Lean runtime, which deadlocked module
+init in earlier versions.
+-/
+def runA3 (seed : UInt64) (n : Nat) : UInt64 := Id.run do
+  let ctx : BarrettCtx a3Modulus := BarrettCtx.mk a3Modulus (by decide) (by decide)
+  let (a₀, s₁) := Random.nextRange seed a3Modulus.toNat
+  let (b₀, _) := Random.nextRange s₁ a3Modulus.toNat
+  let y : UInt64 := b₀.toUInt64
+  let mut x : UInt64 := a₀.toUInt64
+  for _ in [0:n] do
+    x := ctx.mulMod x y
+  return x
+
+/--
+The committed Montgomery modulus for A4. **Caveat:** the current
+`HexArith.MontCtx` scaffolding uses `montgomeryRadixInvNat` inside
+`mulMont` / `fromMont`, which is `(List.range p.toNat).find? …` —
+brute-force search of `[0, p)`. So any modulus larger than ~10⁶ is
+unusable here. We pick 65537 (Fermat prime) as the largest workable
+choice for now and document that this is a scaffold limitation, not a
+benchmark choice. The HexArith plan to replace `montgomeryRadixInvNat`
+with a real Bezout-based inverse will lift this.
+-/
+abbrev a4Modulus : UInt64 := 65537
+
+/--
+A4 — `MontCtx.mulMont` throughput: round-trip `toMont` once, do `n`
+`mulMont`s, round-trip `fromMont` once. Ctx constructed inside the
+function (see runA3 for why).
+-/
+def runA4 (seed : UInt64) (n : Nat) : UInt64 := Id.run do
+  let ctx : MontCtx a4Modulus := MontCtx.mk a4Modulus (by decide)
+  let (a₀, s₁) := Random.nextRange seed (a4Modulus.toNat - 1)
+  let (b₀, _) := Random.nextRange s₁ (a4Modulus.toNat - 1)
+  let aM := ctx.toMont a₀.toUInt64
+  let bM := ctx.toMont b₀.toUInt64
+  let mut x : UInt64 := aM
+  for _ in [0:n] do
+    x := ctx.mulMont x bM
+  return ctx.fromMont x
+
+end HexArith.Bench.Inputs

--- a/HexArith/Bench/Main.lean
+++ b/HexArith/Bench/Main.lean
@@ -1,0 +1,92 @@
+import HexArith.Bench.Driver
+import HexArith.Bench.Families
+
+/-!
+# `hex_arith_bench` — HexArith benchmark CLI
+
+Usage:
+
+    hex_arith_bench <seconds> [--out PATH] [--ladder]
+                              [--max-per-family-seconds N]
+                              [--seed N] [--runs N]
+
+Reads run metadata from environment variables (set by
+`scripts/bench/run.sh`):
+
+    BENCH_GIT_SHA, BENCH_TOOLCHAIN, BENCH_HOSTNAME,
+    BENCH_CPU_MODEL, BENCH_TS
+
+Emits one JSONL row per measurement to `--out` (default: stdout).
+-/
+
+open HexArith.Bench
+open HexArith.Bench.Families
+
+structure CliArgs where
+  seconds : Float := 5.0
+  out : Option String := none
+  ladder : Bool := false
+  smoke : Bool := false
+  maxPerFamilySeconds : Float := 30.0
+  seed : UInt64 := 0xC0FFEE
+  runs : Nat := 3
+  deriving Inhabited
+
+def usage : String :=
+  "usage: hex_arith_bench <seconds> [--out PATH] [--ladder] " ++
+  "[--max-per-family-seconds N] [--seed N] [--runs N]"
+
+partial def parseArgs (args : List String) (acc : CliArgs) : Except String CliArgs :=
+  match args with
+  | [] => .ok acc
+  | "--out" :: p :: rest => parseArgs rest { acc with out := some p }
+  | "--ladder" :: rest => parseArgs rest { acc with ladder := true }
+  | "--smoke" :: rest => parseArgs rest { acc with smoke := true }
+  | "--max-per-family-seconds" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with maxPerFamilySeconds := n.toFloat }
+      | none => .error s!"invalid --max-per-family-seconds: {v}"
+  | "--seed" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with seed := n.toUInt64 }
+      | none => .error s!"invalid --seed: {v}"
+  | "--runs" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with runs := n }
+      | none => .error s!"invalid --runs: {v}"
+  | s :: rest =>
+      match s.toNat? with
+      | some n => parseArgs rest { acc with seconds := n.toFloat }
+      | none => .error s!"unrecognised argument: {s} (only integer seconds supported)"
+
+def main (args : List String) : IO UInt32 := do
+  IO.eprintln "[bench] main start"
+  let cli ← match parseArgs args {} with
+            | .ok c => pure c
+            | .error e => do
+              IO.eprintln e
+              IO.eprintln usage
+              return 1
+  IO.eprintln s!"[bench] args parsed: seconds={cli.seconds} runs={cli.runs}"
+  let runMeta ← collectMeta "HexArith" cli.seed
+  IO.eprintln s!"[bench] meta collected"
+  let settings : RunSettings :=
+    { totalSeconds := cli.seconds
+    , capNanos := (cli.maxPerFamilySeconds * 1.0e9).toUInt64.toNat
+    , runs := cli.runs
+    , ladder := cli.ladder }
+  let runWith (h : IO.FS.Stream) : IO Unit := do
+    for (weight, fam) in Families.all cli.seed do
+      runFamily h runMeta settings (cli.seconds * weight) fam
+    if cli.smoke then
+      for fam in Families.smokeOnly cli.seed do
+        -- Tiny share so smoke runs are short. We still go through
+        -- the full pickParam → measure pipeline for shape consistency.
+        runFamily h runMeta settings 0.05 fam
+  match cli.out with
+  | some path =>
+      IO.FS.withFile path .write fun handle => runWith (IO.FS.Stream.ofHandle handle)
+  | none =>
+      let h ← IO.getStdout
+      runWith h
+  return 0

--- a/HexArith/Bench/Random.lean
+++ b/HexArith/Bench/Random.lean
@@ -1,0 +1,64 @@
+/-!
+# SplitMix64 PRNG for benchmark inputs
+
+A tiny deterministic PRNG used by the HexArith benchmark harness to
+generate seed-stable inputs. Duplicated (intentionally, for prototype)
+in [HexLLL/Bench/Random.lean](../../HexLLL/Bench/Random.lean) with an
+identical API.
+
+The algorithm is Vigna's SplitMix64; see
+<https://prng.di.unimi.it/splitmix64.c>. UInt64 arithmetic in Lean 4
+wraps, which matches the C reference exactly.
+-/
+
+namespace HexArith.Bench.Random
+
+/-- Advance the SplitMix64 state and return `(out, newState)`. -/
+@[inline] def next (s : UInt64) : UInt64 × UInt64 :=
+  let s' := s + 0x9E3779B97F4A7C15
+  let z₁ := s'
+  let z₂ := (z₁ ^^^ (z₁ >>> 30)) * 0xBF58476D1CE4E5B9
+  let z₃ := (z₂ ^^^ (z₂ >>> 27)) * 0x94D049BB133111EB
+  let z₄ := z₃ ^^^ (z₃ >>> 31)
+  (z₄, s')
+
+/-- Draw a Nat in `[0, n)` from the PRNG. Uniform up to a tiny modulo bias. -/
+@[inline] def nextRange (s : UInt64) (n : Nat) : Nat × UInt64 :=
+  let (z, s') := next s
+  (z.toNat % n, s')
+
+/-- Draw a Nat with up to `bits` random bits (i.e. in `[0, 2^bits)`). -/
+def nextBits (s : UInt64) (bits : Nat) : Nat × UInt64 := Id.run do
+  if bits = 0 then return (0, s)
+  let mut st := s
+  let mut acc : Nat := 0
+  let numChunks := (bits + 63) / 64
+  for _ in [0:numChunks] do
+    let (z, st') := next st
+    st := st'
+    acc := (acc <<< 64) ||| z.toNat
+  let totalBits := numChunks * 64
+  if totalBits > bits then
+    acc := acc >>> (totalBits - bits)
+  return (acc, st)
+
+/--
+Draw a non-zero Nat with `bits` random bits, retrying on zero. Used
+for benchmark inputs where zero would trivialise the workload.
+-/
+def nextNonZeroBits (s : UInt64) (bits : Nat) : Nat × UInt64 :=
+  let (n, s') := nextBits s bits
+  if n = 0 then (1, s') else (n, s')
+
+/--
+Draw an Int in `[-2^bits, 2^bits]` (inclusive). The harness uses this
+for signed-coefficient inputs in HexLLL; HexArith does not need it but
+the API is shared for future deduplication.
+-/
+def nextSignedBits (s : UInt64) (bits : Nat) : Int × UInt64 :=
+  let (n, s') := nextBits s (bits + 1)
+  let sign := n &&& 1
+  let mag := n >>> 1
+  if sign = 0 then (Int.ofNat mag, s') else (-(Int.ofNat mag), s')
+
+end HexArith.Bench.Random

--- a/HexLLL.lean
+++ b/HexLLL.lean
@@ -1,3 +1,4 @@
+import HexLLL.Bench
 import HexLLL.Core
 import HexLLL.Reducedness
 import HexLLL.State

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1,0 +1,11 @@
+import HexLLL.Bench.Calibration
+import HexLLL.Bench.Driver
+import HexLLL.Bench.Families
+import HexLLL.Bench.Inputs
+import HexLLL.Bench.Random
+
+/-!
+# `HexLLL.Bench` — Phase 4 timed benchmark surface for HexLLL
+
+See [Main.lean](Bench/Main.lean) for the executable entry point.
+-/

--- a/HexLLL/Bench/Calibration.lean
+++ b/HexLLL/Bench/Calibration.lean
@@ -1,0 +1,36 @@
+/-!
+# HexLLL benchmark calibration constants
+
+Static initial guesses for the budget → param map. As with HexArith,
+these only seed the online calibration loop.
+
+Both budgeted families (L1 dim-sweep, L2 arith-heavy bit-sweep) snap
+to a discrete ladder of supported parameters in
+[Inputs.lean](./Inputs.lean), so the initial guess is always rounded
+to the nearest supported rung.
+-/
+
+namespace HexLLL.Bench.Calibration
+
+/-- L1 (uniform random, square, B0=20 fixed): param = dim n. Expected
+slope superlinear because the swap step rebuilds Gram-Schmidt on every
+swap (see [HexLLL/SwapStep.lean](../../HexLLL/SwapStep.lean#L74)). -/
+@[inline] def l1RandomDim (seconds : Float) : Nat :=
+  -- Reference: dim 8 ≈ 0.5s on author machine. Use slope ~4.
+  let refSeconds : Float := 0.5
+  let refParam : Float := 8.0
+  let exponent : Float := 4.0
+  let scale := (seconds / refSeconds) ^ (1.0 / exponent)
+  let raw := refParam * scale
+  if raw ≤ 4.0 then 4 else raw.toUInt64.toNat
+
+/-- L2 (arith-heavy, n=20 fixed, vary entry bits): param = bits B. -/
+@[inline] def l2ArithBits (seconds : Float) : Nat :=
+  let refSeconds : Float := 1.0
+  let refParam : Float := 32.0
+  let exponent : Float := 2.0
+  let scale := (seconds / refSeconds) ^ (1.0 / exponent)
+  let raw := refParam * scale
+  if raw ≤ 8.0 then 8 else raw.toUInt64.toNat
+
+end HexLLL.Bench.Calibration

--- a/HexLLL/Bench/Driver.lean
+++ b/HexLLL/Bench/Driver.lean
@@ -1,0 +1,260 @@
+import HexLLL.Bench.Random
+
+/-!
+# HexArith benchmark driver
+
+Timing wrapper, online calibration loop, JSONL emission. Parameterised
+over a `FamilySpec` so each family in
+[Families.lean](./Families.lean) plugs in identically.
+-/
+
+namespace HexLLL.Bench
+
+/-- Status enum for a single recorded measurement. -/
+inductive Status
+  | ok
+  | timeout
+  | budgetSkip
+  | comparatorUnavailable
+  | error
+  deriving Repr, BEq
+
+def Status.toJsonString : Status → String
+  | .ok => "ok"
+  | .timeout => "timeout"
+  | .budgetSkip => "budget_skip"
+  | .comparatorUnavailable => "comparator_unavailable"
+  | .error => "error"
+
+/-- Origin of the chosen parameter. -/
+inductive ParamOrigin
+  | predicted
+  | discovered
+  deriving Repr, BEq, Inhabited
+
+def ParamOrigin.toJsonString : ParamOrigin → String
+  | .predicted => "predicted"
+  | .discovered => "discovered"
+
+/-- Spec for one benchmark family with a single Nat parameter. -/
+structure FamilySpec where
+  name : String
+  familyVersion : Nat := 1
+  paramName : String
+  expectedSlope : Float
+  paramFloor : Nat
+  paramCeiling : Nat
+  /-- target seconds → suggested param -/
+  initialGuess : Float → Nat
+  /-- run one trial; driver times the call and records the returned hash -/
+  runOne : Nat → IO UInt64
+
+/-- Process-wide metadata captured once at startup. -/
+structure RunMeta where
+  schemaVersion : Nat := 1
+  library : String
+  gitSha : String
+  leanToolchain : String
+  hostname : String
+  cpuModel : Option String
+  ts : String
+  seed : UInt64
+  deriving Inhabited
+
+def envOr (key default : String) : IO String := do
+  return (← IO.getEnv key).getD default
+
+def envOpt (key : String) : IO (Option String) := do
+  match ← IO.getEnv key with
+  | some v => pure (if v.isEmpty then none else some v)
+  | none => pure none
+
+def collectMeta (library : String) (seed : UInt64) : IO RunMeta := do
+  let gitSha ← envOr "BENCH_GIT_SHA" "unknown"
+  let toolchain ← envOr "BENCH_TOOLCHAIN" "unknown"
+  let hostname ← envOr "BENCH_HOSTNAME" "unknown"
+  let cpu ← envOpt "BENCH_CPU_MODEL"
+  let ts ← envOr "BENCH_TS" "unknown"
+  pure { library, gitSha, leanToolchain := toolchain, hostname, cpuModel := cpu, ts, seed }
+
+/-- Time an `IO` action, returning `(value, elapsed_nanos)`. -/
+@[inline] def timeNanos (act : IO α) : IO (α × Nat) := do
+  let t₀ ← IO.monoNanosNow
+  let v ← act
+  let t₁ ← IO.monoNanosNow
+  pure (v, t₁ - t₀)
+
+/-- Result of online calibration. -/
+structure CalibratedParam where
+  param : Nat
+  origin : ParamOrigin
+  observedNanos : Nat
+  cappedDuringSearch : Bool := false
+  deriving Inhabited
+
+partial def pickParamSearch (f : FamilySpec) (lo hi capNanos : Nat)
+    (p t : Nat) (tries : Nat) (cappedSoFar : Bool) : IO CalibratedParam := do
+  if tries = 0 then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := cappedSoFar }
+  let p' :=
+    if t < lo then min f.paramCeiling (p * 2)
+    else max f.paramFloor (p / 2)
+  if p' = p then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := cappedSoFar }
+  let (_, t') ← timeNanos (f.runOne p')
+  if t' > capNanos then
+    return { param := p, origin := .discovered, observedNanos := t, cappedDuringSearch := true }
+  if lo ≤ t' ∧ t' ≤ hi then
+    return { param := p', origin := .discovered, observedNanos := t', cappedDuringSearch := cappedSoFar }
+  pickParamSearch f lo hi capNanos p' t' (tries - 1) cappedSoFar
+
+/--
+Pick a parameter that brings one trial into `[targetNanos/2, targetNanos*2]`,
+refusing to spend more than `capNanos` on any single trial. Initial guess
+from `f.initialGuess`; otherwise ×2 / ÷2 geometric search for up to 6 steps.
+-/
+def pickParam (f : FamilySpec) (targetNanos capNanos : Nat) : IO CalibratedParam := do
+  let lo := targetNanos / 2
+  let hi := targetNanos * 2
+  let p₀ := min f.paramCeiling
+              (max f.paramFloor (f.initialGuess (targetNanos.toFloat / 1.0e9)))
+  let (_, t₀) ← timeNanos (f.runOne p₀)
+  if t₀ > capNanos then
+    return { param := p₀, origin := .discovered, observedNanos := t₀, cappedDuringSearch := true }
+  if lo ≤ t₀ ∧ t₀ ≤ hi then
+    return { param := p₀, origin := .predicted, observedNanos := t₀ }
+  pickParamSearch f lo hi capNanos p₀ t₀ 6 false
+
+/-- Build a parameter ladder for scaling-law fitting (×2 per rung). -/
+def buildLadder (f : FamilySpec) (anchor : Nat) (rungs : Nat) : Array Nat := Id.run do
+  let mut acc : Array Nat := #[]
+  let halfRungs := rungs / 2
+  let mut p := anchor
+  for _ in [0:halfRungs] do
+    p := max f.paramFloor (p / 2)
+  for _ in [0:rungs] do
+    if f.paramFloor ≤ p ∧ p ≤ f.paramCeiling then
+      acc := acc.push p
+    p := p * 2
+  return acc
+
+/-- One JSONL row to emit. -/
+structure RowRecord where
+  family : String
+  familyVersion : Nat
+  param : Nat
+  paramOrigin : ParamOrigin
+  runIndex : Nat
+  wallNanos : Nat
+  resultHash : UInt64
+  status : Status
+  errMsg? : Option String := none
+  comparator? : Option String := none
+  comparatorVersion? : Option String := none
+
+def jsonStr (s : String) : String :=
+  let escaped := s.foldl (init := "") fun acc c =>
+    match c with
+    | '"' => acc ++ "\\\""
+    | '\\' => acc ++ "\\\\"
+    | '\n' => acc ++ "\\n"
+    | '\r' => acc ++ "\\r"
+    | '\t' => acc ++ "\\t"
+    | c => acc.push c
+  "\"" ++ escaped ++ "\""
+
+def jsonOptStr : Option String → String
+  | none => "null"
+  | some s => jsonStr s
+
+def hex64 (n : UInt64) : String :=
+  "0x" ++ String.ofList (Nat.toDigits 16 n.toNat)
+
+def renderRow (runMeta : RunMeta) (r : RowRecord) : String :=
+  "{" ++ String.intercalate ","
+    [ "\"schema_version\":" ++ toString runMeta.schemaVersion
+    , "\"library\":" ++ jsonStr runMeta.library
+    , "\"family\":" ++ jsonStr r.family
+    , "\"family_version\":" ++ toString r.familyVersion
+    , "\"param\":" ++ toString r.param
+    , "\"param_origin\":" ++ jsonStr r.paramOrigin.toJsonString
+    , "\"seed\":" ++ toString runMeta.seed.toNat
+    , "\"run_index\":" ++ toString r.runIndex
+    , "\"wall_nanos\":" ++ toString r.wallNanos
+    , "\"result_hash\":" ++ jsonStr (hex64 r.resultHash)
+    , "\"status\":" ++ jsonStr r.status.toJsonString
+    , "\"error\":" ++ jsonOptStr r.errMsg?
+    , "\"git_sha\":" ++ jsonStr runMeta.gitSha
+    , "\"lean_toolchain\":" ++ jsonStr runMeta.leanToolchain
+    , "\"hostname\":" ++ jsonStr runMeta.hostname
+    , "\"cpu_model\":" ++ jsonOptStr runMeta.cpuModel
+    , "\"comparator\":" ++ jsonOptStr r.comparator?
+    , "\"comparator_version\":" ++ jsonOptStr r.comparatorVersion?
+    , "\"ts\":" ++ jsonStr runMeta.ts
+    ] ++ "}"
+
+def emitRow (h : IO.FS.Stream) (runMeta : RunMeta) (r : RowRecord) : IO Unit :=
+  h.putStrLn (renderRow runMeta r)
+
+structure RunSettings where
+  totalSeconds : Float
+  capNanos : Nat
+  runs : Nat := 3
+  ladder : Bool := false
+  ladderRungs : Nat := 5
+
+/-- Non-ladder mode: calibrate, warm, take `runs` samples. -/
+def runFamilyMeasured (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit := do
+  let targetNanos := (familyShareSeconds * 1.0e9).toUInt64.toNat
+  IO.eprintln s!"[bench] {f.name}: calibrating (target {targetNanos / 1000000} ms)"
+  let cal ← pickParam f targetNanos settings.capNanos
+  IO.eprintln s!"[bench] {f.name}: param={cal.param} observed={cal.observedNanos / 1000000} ms"
+  let _ ← timeNanos (f.runOne cal.param)
+  for i in [0:settings.runs] do
+    let (hash, wall) ← timeNanos (f.runOne cal.param)
+    let status :=
+      if cal.cappedDuringSearch ∧ wall > settings.capNanos then Status.budgetSkip
+      else Status.ok
+    emitRow h runMeta
+      { family := f.name
+      , familyVersion := f.familyVersion
+      , param := cal.param
+      , paramOrigin := cal.origin
+      , runIndex := i
+      , wallNanos := wall
+      , resultHash := hash
+      , status := status }
+
+/-- Ladder mode: sweep params around the calibration anchor. -/
+def runFamilyLadder (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit := do
+  let targetNanos := (familyShareSeconds * 1.0e9).toUInt64.toNat
+  let cal ← pickParam f targetNanos settings.capNanos
+  let ladder := buildLadder f cal.param settings.ladderRungs
+  let mut skipRest := false
+  for i in [0:ladder.size] do
+    let p := ladder[i]!
+    if skipRest then
+      emitRow h runMeta
+        { family := f.name, familyVersion := f.familyVersion
+        , param := p, paramOrigin := cal.origin, runIndex := 0
+        , wallNanos := 0, resultHash := 0, status := .budgetSkip }
+    else
+      let (hash, wall) ← timeNanos (f.runOne p)
+      let st := if wall > settings.capNanos then Status.budgetSkip else Status.ok
+      emitRow h runMeta
+        { family := f.name, familyVersion := f.familyVersion
+        , param := p, paramOrigin := cal.origin, runIndex := 0
+        , wallNanos := wall, resultHash := hash, status := st }
+      if wall > settings.capNanos then
+        skipRest := true
+
+def runFamily (h : IO.FS.Stream) (runMeta : RunMeta) (settings : RunSettings)
+    (familyShareSeconds : Float) (f : FamilySpec) : IO Unit :=
+  if settings.ladder then
+    runFamilyLadder h runMeta settings familyShareSeconds f
+  else
+    runFamilyMeasured h runMeta settings familyShareSeconds f
+
+end HexLLL.Bench

--- a/HexLLL/Bench/Families.lean
+++ b/HexLLL/Bench/Families.lean
@@ -1,0 +1,47 @@
+import HexLLL.Bench.Calibration
+import HexLLL.Bench.Driver
+import HexLLL.Bench.Inputs
+
+/-!
+# HexLLL benchmark family registry
+
+Two budgeted families and (per the SPEC v2 plan) a `smokeOnly` slot.
+-/
+
+namespace HexLLL.Bench.Families
+
+open HexLLL.Bench
+
+/-- L1: uniform random integer basis, square. Param = dim n (snapped
+to a discrete ladder by [Inputs.runL1](./Inputs.lean)). -/
+def l1 (seed : UInt64) : FamilySpec :=
+  { name := "L1.uniform-dim-sweep"
+  , familyVersion := 1
+  , paramName := "dim"
+  , expectedSlope := 4.0
+  , paramFloor := 4
+  , paramCeiling := 8
+  , initialGuess := Calibration.l1RandomDim
+  , runOne := fun n => pure (Inputs.runL1 seed n) }
+
+/-- L2: arith-heavy. Fixed dim n=20, sweep entry bit-width B. -/
+def l2 (seed : UInt64) : FamilySpec :=
+  { name := "L2.arith-bit-sweep"
+  , familyVersion := 1
+  , paramName := "bits"
+  , expectedSlope := 2.0
+  , paramFloor := 8
+  , paramCeiling := 256
+  , initialGuess := Calibration.l2ArithBits
+  , runOne := fun bits => pure (Inputs.runL2 seed bits) }
+
+/-- All budgeted families. -/
+def all (seed : UInt64) : List (Float × FamilySpec) :=
+  [ (0.50, l1 seed)
+  , (0.50, l2 seed) ]
+
+/-- Smoke-only families. None for HexLLL in this prototype — both
+budgeted families are well-defined. -/
+def smokeOnly (_seed : UInt64) : List FamilySpec := []
+
+end HexLLL.Bench.Families

--- a/HexLLL/Bench/Inputs.lean
+++ b/HexLLL/Bench/Inputs.lean
@@ -1,0 +1,100 @@
+import HexLLL.Bench.Random
+import HexLLL.Loop
+import HexMatrix
+
+/-!
+# HexLLL benchmark input generators
+
+Because `lll` has `n : Nat` in the type, we can't dispatch on a runtime
+`n`. Instead we enumerate a small discrete ladder of dimensions
+`{4, 6, 8, 12, 16, 20, 24}` and dispatch the runner by pattern match.
+Dimensions outside the ladder snap to the nearest supported value.
+
+Inputs are generated deterministically from a `(seed, dim, bits)`
+triple using SplitMix64 from [Random.lean](./Random.lean).
+-/
+
+namespace HexLLL.Bench.Inputs
+
+open HexMatrix HexLLL
+
+/-- Generate an `n × n` Int matrix with entries uniformly drawn in
+`[-(2^bits), 2^bits]`. Uses a monadic SplitMix64 unfold; same seed →
+same matrix. -/
+def uniformIntMatrix (n : Nat) (bits : Nat) (seed : UInt64) : Matrix Int n n := Id.run do
+  let mut state := seed
+  let mut rows : Array (Vector Int n) := Array.mkEmpty n
+  for _ in [0:n] do
+    let mut row : Array Int := Array.mkEmpty n
+    for _ in [0:n] do
+      let (v, s') := Random.nextSignedBits state bits
+      state := s'
+      row := row.push v
+    rows := rows.push (Vector.ofFn fun i => row[i.1]!)
+  return Vector.ofFn fun i => rows[i.1]!
+
+/-- A monoidal hash of a matrix: XOR the low-64 bits of each entry. -/
+def hashMatrix (M : Matrix Int n n) : UInt64 :=
+  M.toList.foldl (init := 0) fun acc row =>
+    row.toList.foldl (init := acc) fun acc' entry =>
+      acc' ^^^ (Int.natAbs entry % (1 <<< 64)).toUInt64
+
+/-- The `independent` predicate decomposes to per-row positivity of leading
+Gram determinants — each is `0 < Int`, decidable. Lean doesn't synthesize
+this automatically because the `gramDet` definitions are wrapped, so we
+make the instance explicit. -/
+instance Matrix.decidableIndependent {n m : Nat} (b : Matrix Int n m) :
+    Decidable b.independent := by
+  unfold Matrix.independent
+  exact inferInstance
+
+/--
+One LLL run at statically known dimension `n`, given a matrix `b`.
+`hn : 1 ≤ n` is supplied by the caller. Independence is checked at
+runtime via the explicit `Decidable` instance above; degenerate
+samples (very rare for random large-entry inputs) return 0.
+-/
+def runLllAt (n : Nat) (hn : 1 ≤ n) (b : Matrix Int n n) : UInt64 :=
+  if h : b.independent then
+    hashMatrix (lll b (3/4) (by decide +kernel) (by decide +kernel) hn h)
+  else
+    0
+
+/-- L1: square uniform random at a given dim. Entry bit-width fixed at 20. -/
+def runL1AtDim (n : Nat) (hn : 1 ≤ n) (seed : UInt64) : UInt64 :=
+  runLllAt n hn (uniformIntMatrix n 20 seed)
+
+/-- L2: arith-heavy; fixed dim, sweep entry bit-width. Plan picked
+n=20; with the current naive swap-step that already costs seconds even
+at tiny bit-widths. For the prototype we drop to n=6 so we can actually
+sweep B, at the cost of making the arith-vs-swap distinction less sharp.
+This is a known simplification — see progress retrospective. -/
+def runL2AtBits (bits : Nat) (seed : UInt64) : UInt64 :=
+  runLllAt 6 (by decide) (uniformIntMatrix 6 bits seed)
+
+/-- Snap an arbitrary dim to the supported ladder. -/
+def snapL1Dim (n : Nat) : Nat :=
+  if n ≤ 4 then 4
+  else if n ≤ 6 then 6
+  else if n ≤ 8 then 8
+  else if n ≤ 12 then 12
+  else if n ≤ 16 then 16
+  else if n ≤ 20 then 20
+  else 24
+
+/-- Dispatch `runL1` by snapped dim. Unsupported dims fall through to 24. -/
+def runL1 (seed : UInt64) (n : Nat) : UInt64 :=
+  match snapL1Dim n with
+  |  4 => runL1AtDim  4 (by decide) seed
+  |  6 => runL1AtDim  6 (by decide) seed
+  |  8 => runL1AtDim  8 (by decide) seed
+  | 12 => runL1AtDim 12 (by decide) seed
+  | 16 => runL1AtDim 16 (by decide) seed
+  | 20 => runL1AtDim 20 (by decide) seed
+  | _  => runL1AtDim 24 (by decide) seed
+
+/-- Dispatch `runL2` at fixed dim, varying bits. -/
+def runL2 (seed : UInt64) (bits : Nat) : UInt64 :=
+  runL2AtBits bits seed
+
+end HexLLL.Bench.Inputs

--- a/HexLLL/Bench/Main.lean
+++ b/HexLLL/Bench/Main.lean
@@ -1,0 +1,92 @@
+import HexLLL.Bench.Driver
+import HexLLL.Bench.Families
+
+/-!
+# `hex_lll_bench` — HexLLL benchmark CLI
+
+Usage:
+
+    hex_lll_bench <seconds> [--out PATH] [--ladder]
+                              [--max-per-family-seconds N]
+                              [--seed N] [--runs N]
+
+Reads run metadata from environment variables (set by
+`scripts/bench/run.sh`):
+
+    BENCH_GIT_SHA, BENCH_TOOLCHAIN, BENCH_HOSTNAME,
+    BENCH_CPU_MODEL, BENCH_TS
+
+Emits one JSONL row per measurement to `--out` (default: stdout).
+-/
+
+open HexLLL.Bench
+open HexLLL.Bench.Families
+
+structure CliArgs where
+  seconds : Float := 5.0
+  out : Option String := none
+  ladder : Bool := false
+  smoke : Bool := false
+  maxPerFamilySeconds : Float := 30.0
+  seed : UInt64 := 0xC0FFEE
+  runs : Nat := 3
+  deriving Inhabited
+
+def usage : String :=
+  "usage: hex_lll_bench <seconds> [--out PATH] [--ladder] " ++
+  "[--max-per-family-seconds N] [--seed N] [--runs N]"
+
+partial def parseArgs (args : List String) (acc : CliArgs) : Except String CliArgs :=
+  match args with
+  | [] => .ok acc
+  | "--out" :: p :: rest => parseArgs rest { acc with out := some p }
+  | "--ladder" :: rest => parseArgs rest { acc with ladder := true }
+  | "--smoke" :: rest => parseArgs rest { acc with smoke := true }
+  | "--max-per-family-seconds" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with maxPerFamilySeconds := n.toFloat }
+      | none => .error s!"invalid --max-per-family-seconds: {v}"
+  | "--seed" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with seed := n.toUInt64 }
+      | none => .error s!"invalid --seed: {v}"
+  | "--runs" :: v :: rest =>
+      match v.toNat? with
+      | some n => parseArgs rest { acc with runs := n }
+      | none => .error s!"invalid --runs: {v}"
+  | s :: rest =>
+      match s.toNat? with
+      | some n => parseArgs rest { acc with seconds := n.toFloat }
+      | none => .error s!"unrecognised argument: {s} (only integer seconds supported)"
+
+def main (args : List String) : IO UInt32 := do
+  IO.eprintln "[bench] main start"
+  let cli ← match parseArgs args {} with
+            | .ok c => pure c
+            | .error e => do
+              IO.eprintln e
+              IO.eprintln usage
+              return 1
+  IO.eprintln s!"[bench] args parsed: seconds={cli.seconds} runs={cli.runs}"
+  let runMeta ← collectMeta "HexLLL" cli.seed
+  IO.eprintln s!"[bench] meta collected"
+  let settings : RunSettings :=
+    { totalSeconds := cli.seconds
+    , capNanos := (cli.maxPerFamilySeconds * 1.0e9).toUInt64.toNat
+    , runs := cli.runs
+    , ladder := cli.ladder }
+  let runWith (h : IO.FS.Stream) : IO Unit := do
+    for (weight, fam) in Families.all cli.seed do
+      runFamily h runMeta settings (cli.seconds * weight) fam
+    if cli.smoke then
+      for fam in Families.smokeOnly cli.seed do
+        -- Tiny share so smoke runs are short. We still go through
+        -- the full pickParam → measure pipeline for shape consistency.
+        runFamily h runMeta settings 0.05 fam
+  match cli.out with
+  | some path =>
+      IO.FS.withFile path .write fun handle => runWith (IO.FS.Stream.ofHandle handle)
+  | none =>
+      let h ← IO.getStdout
+      runWith h
+  return 0

--- a/HexLLL/Bench/Random.lean
+++ b/HexLLL/Bench/Random.lean
@@ -1,0 +1,64 @@
+/-!
+# SplitMix64 PRNG for benchmark inputs
+
+A tiny deterministic PRNG used by the HexArith benchmark harness to
+generate seed-stable inputs. Duplicated (intentionally, for prototype)
+in [HexLLL/Bench/Random.lean](../../HexLLL/Bench/Random.lean) with an
+identical API.
+
+The algorithm is Vigna's SplitMix64; see
+<https://prng.di.unimi.it/splitmix64.c>. UInt64 arithmetic in Lean 4
+wraps, which matches the C reference exactly.
+-/
+
+namespace HexLLL.Bench.Random
+
+/-- Advance the SplitMix64 state and return `(out, newState)`. -/
+@[inline] def next (s : UInt64) : UInt64 × UInt64 :=
+  let s' := s + 0x9E3779B97F4A7C15
+  let z₁ := s'
+  let z₂ := (z₁ ^^^ (z₁ >>> 30)) * 0xBF58476D1CE4E5B9
+  let z₃ := (z₂ ^^^ (z₂ >>> 27)) * 0x94D049BB133111EB
+  let z₄ := z₃ ^^^ (z₃ >>> 31)
+  (z₄, s')
+
+/-- Draw a Nat in `[0, n)` from the PRNG. Uniform up to a tiny modulo bias. -/
+@[inline] def nextRange (s : UInt64) (n : Nat) : Nat × UInt64 :=
+  let (z, s') := next s
+  (z.toNat % n, s')
+
+/-- Draw a Nat with up to `bits` random bits (i.e. in `[0, 2^bits)`). -/
+def nextBits (s : UInt64) (bits : Nat) : Nat × UInt64 := Id.run do
+  if bits = 0 then return (0, s)
+  let mut st := s
+  let mut acc : Nat := 0
+  let numChunks := (bits + 63) / 64
+  for _ in [0:numChunks] do
+    let (z, st') := next st
+    st := st'
+    acc := (acc <<< 64) ||| z.toNat
+  let totalBits := numChunks * 64
+  if totalBits > bits then
+    acc := acc >>> (totalBits - bits)
+  return (acc, st)
+
+/--
+Draw a non-zero Nat with `bits` random bits, retrying on zero. Used
+for benchmark inputs where zero would trivialise the workload.
+-/
+def nextNonZeroBits (s : UInt64) (bits : Nat) : Nat × UInt64 :=
+  let (n, s') := nextBits s bits
+  if n = 0 then (1, s') else (n, s')
+
+/--
+Draw an Int in `[-2^bits, 2^bits]` (inclusive). The harness uses this
+for signed-coefficient inputs in HexLLL; HexArith does not need it but
+the API is shared for future deduplication.
+-/
+def nextSignedBits (s : UInt64) (bits : Nat) : Int × UInt64 :=
+  let (n, s') := nextBits s (bits + 1)
+  let sign := n &&& 1
+  let mag := n >>> 1
+  if sign = 0 then (Int.ofNat mag, s') else (-(Int.ofNat mag), s')
+
+end HexLLL.Bench.Random

--- a/HexManual/Benchmarks/HexArith.md
+++ b/HexManual/Benchmarks/HexArith.md
@@ -1,106 +1,45 @@
-# `HexArith` benchmark reference
+# HexArith benchmarks
 
-This page documents the committed `HexArith` benchmark surface in
-[`HexArith/Benchmark.lean`](/home/kim/hex/worktrees/858547d6/HexArith/Benchmark.lean).
-It covers the currently checked-in fixture families, their stable case
-names, and the CSV-style Lean entrypoints that materialize those cases.
-It does not record timing results or claim any rendered benchmark
-publication beyond the repository source tree.
+- Run: `f5c368aa10365e7722e576a92946638b5e5ad46b`
+- Machine: chungus (CPU: AMD EPYC 9455 48-Core Processor)
+- Date: 2026-04-23T12:39:47Z
+- Toolchain: `leanprover/lean4:v4.30.0-rc2`
+- Seed: `12648430`
 
-## Benchmark families
+Per-family detail follows; the **Summary** table at the end aggregates.
 
-### `Nat` extended GCD
+## A1.nat-extgcd
 
-- Cases live in `HexArith.Benchmark.natExtGcdCases`.
-- Result rows come from `HexArith.Benchmark.runNatExtGcdCsv`.
-- CSV header: `name,gcd,s,t`
+- Mode: measured (2 runs)
+- Parameter: `65536` (origin: discovered)
+- Statuses: ok
+- Wall: median **137.18 ms**, min 137.04 ms, max 137.31 ms
+- Comparator `python-stdlib`: median 282.70 ms (2 runs)
 
-Stable cases:
+## A2.nat-powmod
 
-- `nat-coprime-small`
-- `nat-composite-shared-factor`
-- `nat-power-of-two-boundary`
+- Mode: measured (2 runs)
+- Parameter: `15808` (origin: discovered)
+- Statuses: ok
+- Wall: median **689.56 ms**, min 688.84 ms, max 690.29 ms
+- Comparator `python-stdlib`: median 6.16 s (2 runs)
 
-### `Int` extended GCD
+## A3.barrett-mulmod
 
-- Cases live in `HexArith.Benchmark.intExtGcdCases`.
-- Result rows come from `HexArith.Benchmark.runIntExtGcdCsv`.
-- CSV header: `name,gcd,s,t`
+- Mode: measured (2 runs)
+- Parameter: `100000000` (origin: discovered)
+- Statuses: ok
+- Wall: median **553.14 ms**, min 553.08 ms, max 553.20 ms
+- Comparator `python-stdlib`: median 10.10 s (2 runs)
 
-Stable cases:
+## Summary
 
-- `int-mixed-sign-large`
-- `int-both-negative`
-- `int-asymmetric-magnitudes`
+| family | param | origin | wall (median) | comparator | ratio (Lean/cmp) | log-log slope |
+|---|---|---|---|---|---|---|
+| A1.nat-extgcd | 65536 | discovered | 137.18 ms | 282.70 ms | 0.49× | — |
+| A2.nat-powmod | 15808 | discovered | 689.56 ms | 6.16 s | 0.11× | — |
+| A3.barrett-mulmod | 100000000 | discovered | 553.14 ms | 10.10 s | 0.05× | — |
 
-### `UInt64` extended GCD
+## Honest assessment
 
-- Cases live in `HexArith.Benchmark.uint64ExtGcdCases`.
-- Result rows come from `HexArith.Benchmark.runUInt64ExtGcdCsv`.
-- CSV header: `name,gcd,s,t`
-
-Stable cases:
-
-- `u64-coprime-near-word`
-- `u64-shared-factor`
-- `u64-fibonacci-shaped`
-
-### Modular exponentiation
-
-- Cases live in `HexArith.Benchmark.powModCases`.
-- Result rows come from `HexArith.Benchmark.runPowModCsv`.
-- CSV header: `name,value`
-
-Stable cases:
-
-- `powmod-small-prime`
-- `powmod-large-base`
-- `powmod-fermat-boundary`
-
-### Barrett vs Montgomery reduction comparison
-
-- Cases live in `HexArith.Benchmark.reductionComparisonCases`.
-- Result rows come from `HexArith.Benchmark.runReductionComparisonCsv`.
-- CSV header: `name,modulus,a,b,preference,barrett,montgomery`
-- Preference tags are rendered with `ReductionPreference.csvTag` as one
-  of `barrett`, `montgomery`, or `crossover`.
-- Unsupported paths are rendered as `NA`.
-
-Stable cases:
-
-- `reduction-barrett-tiny`
-- `reduction-barrett-upper-edge`
-- `reduction-montgomery-crossover`
-
-## Case scope
-
-The current `HexArith` Phase 4 slice covers microbenchmarks for:
-
-- extended GCD over `Nat`, `Int`, and `UInt64`
-- modular exponentiation via `HexArith.powMod`
-- the committed Barrett-versus-Montgomery crossover comparison cases
-
-The reduction comparison rows report both executable paths when the
-current implementation supports them. In the committed cases,
-`reduction-barrett-upper-edge` has no Montgomery value and therefore
-emits `NA` in the `montgomery` column.
-
-## How to regenerate
-
-The benchmark page is derived directly from the Lean runners in
-[`HexArith/Benchmark.lean`](/home/kim/hex/worktrees/858547d6/HexArith/Benchmark.lean).
-To regenerate the documented CSV-style outputs from Lean, import
-`HexArith.Benchmark` and evaluate the runner definitions:
-
-```lean
-import HexArith.Benchmark
-
-#eval HexArith.Benchmark.runNatExtGcdCsv
-#eval HexArith.Benchmark.runIntExtGcdCsv
-#eval HexArith.Benchmark.runUInt64ExtGcdCsv
-#eval HexArith.Benchmark.runPowModCsv
-#eval HexArith.Benchmark.runReductionComparisonCsv
-```
-
-Those definitions are the repository's current source of truth for the
-named `HexArith` benchmark fixtures and exported columns.
+_Hand-edit this section after each run with what surprised you, what calibration got wrong, and what the report doesn't yet capture._

--- a/HexManual/Benchmarks/HexLLL.md
+++ b/HexManual/Benchmarks/HexLLL.md
@@ -1,0 +1,34 @@
+# HexLLL benchmarks
+
+- Run: `f5c368aa10365e7722e576a92946638b5e5ad46b`
+- Machine: chungus (CPU: AMD EPYC 9455 48-Core Processor)
+- Date: 2026-04-23T12:55:04Z
+- Toolchain: `leanprover/lean4:v4.30.0-rc2`
+- Seed: `12648430`
+
+Per-family detail follows; the **Summary** table at the end aggregates.
+
+## L1.uniform-dim-sweep
+
+- Mode: measured (1 runs)
+- Parameter: `8` (origin: predicted)
+- Statuses: ok
+- Wall: median **1.55 s**, min 1.55 s, max 1.55 s
+
+## L2.arith-bit-sweep
+
+- Mode: measured (1 runs)
+- Parameter: `256` (origin: discovered)
+- Statuses: ok
+- Wall: median **35.46 ms**, min 35.46 ms, max 35.46 ms
+
+## Summary
+
+| family | param | origin | wall (median) | comparator | ratio (Lean/cmp) | log-log slope |
+|---|---|---|---|---|---|---|
+| L1.uniform-dim-sweep | 8 | predicted | 1.55 s | — | — | — |
+| L2.arith-bit-sweep | 256 | discovered | 35.46 ms | — | — | — |
+
+## Honest assessment
+
+_Hand-edit this section after each run with what surprised you, what calibration got wrong, and what the report doesn't yet capture._

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -45,6 +45,14 @@ rev = "v4.30.0-rc2"
 name = "HexArith"
 moreLinkArgs = ["HexArith/ffi/mpz_gcdext.c"]
 
+[[lean_exe]]
+name = "hex_arith_bench"
+root = "HexArith.Bench.Main"
+
+[[lean_exe]]
+name = "hex_lll_bench"
+root = "HexLLL.Bench.Main"
+
 [[lean_lib]]
 name = "HexPoly"
 

--- a/scripts/bench/external/fpylll_lll.py
+++ b/scripts/bench/external/fpylll_lll.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""HexLLL Python comparator using fpylll (if available).
+
+Reads Lean-emitted JSONL, regenerates the same matrix using the
+mirrored SplitMix64 from [python_arith.py](./python_arith.py), runs
+fpylll's LLL.reduction on it, times it, and appends comparator rows.
+
+If fpylll is not installed, we emit nothing (run.sh continues and the
+report shows "comparator unavailable"). This script exits 0 either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+_MASK = (1 << 64) - 1
+
+
+def splitmix64_next(state: int) -> tuple[int, int]:
+    state = (state + 0x9E3779B97F4A7C15) & _MASK
+    z = state
+    z = ((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9) & _MASK
+    z = ((z ^ (z >> 27)) * 0x94D049BB133111EB) & _MASK
+    z = z ^ (z >> 31)
+    return z, state
+
+
+def next_bits(state: int, bits: int) -> tuple[int, int]:
+    if bits <= 0:
+        return 0, state
+    n_chunks = (bits + 63) // 64
+    acc = 0
+    for _ in range(n_chunks):
+        z, state = splitmix64_next(state)
+        acc = (acc << 64) | z
+    total = n_chunks * 64
+    if total > bits:
+        acc >>= total - bits
+    return acc, state
+
+
+def next_signed_bits(state: int, bits: int) -> tuple[int, int]:
+    n, state = next_bits(state, bits + 1)
+    sign = n & 1
+    mag = n >> 1
+    return (mag if sign == 0 else -mag), state
+
+
+def gen_matrix(n: int, bits: int, seed: int) -> list[list[int]]:
+    state = seed
+    rows: list[list[int]] = []
+    for _ in range(n):
+        row: list[int] = []
+        for _ in range(n):
+            v, state = next_signed_bits(state, bits)
+            row.append(v)
+        rows.append(row)
+    return rows
+
+
+def snap_l1_dim(n: int) -> int:
+    for rung in (4, 6, 8, 12, 16, 20, 24):
+        if n <= rung:
+            return rung
+    return 24
+
+
+def hash_low64_matrix(M: list[list[int]]) -> int:
+    h = 0
+    for row in M:
+        for e in row:
+            h ^= abs(e) & _MASK
+    return h
+
+
+def run_l1(fpylll_mod, seed: int, n_param: int) -> tuple[int, int]:
+    n = snap_l1_dim(n_param)
+    mat = gen_matrix(n, 20, seed)
+    IM = fpylll_mod.IntegerMatrix.from_matrix(mat)
+    t0 = time.perf_counter_ns()
+    fpylll_mod.LLL.reduction(IM, delta=0.75)
+    t1 = time.perf_counter_ns()
+    reduced = [[IM[i, j] for j in range(n)] for i in range(n)]
+    return hash_low64_matrix(reduced), t1 - t0
+
+
+def run_l2(fpylll_mod, seed: int, bits: int) -> tuple[int, int]:
+    n = 6
+    mat = gen_matrix(n, bits, seed)
+    IM = fpylll_mod.IntegerMatrix.from_matrix(mat)
+    t0 = time.perf_counter_ns()
+    fpylll_mod.LLL.reduction(IM, delta=0.75)
+    t1 = time.perf_counter_ns()
+    reduced = [[IM[i, j] for j in range(n)] for i in range(n)]
+    return hash_low64_matrix(reduced), t1 - t0
+
+
+FAMILIES = {"L1.uniform-dim-sweep": run_l1, "L2.arith-bit-sweep": run_l2}
+
+
+def make_comparator_row(lean_row: dict[str, Any], wall_nanos: int, h: int,
+                        comparator: str, version: str) -> dict[str, Any]:
+    out = dict(lean_row)
+    out["wall_nanos"] = wall_nanos
+    out["result_hash"] = f"0x{h:x}"
+    out["comparator"] = comparator
+    out["comparator_version"] = version
+    out["status"] = "ok"
+    out["error"] = None
+    out["ts"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, type=Path)
+    ap.add_argument("--append", required=True, type=Path)
+    args = ap.parse_args()
+
+    try:
+        import fpylll
+    except Exception as e:
+        print(f"fpylll not available: {e}; skipping comparator rows", file=sys.stderr)
+        return 0
+
+    version = getattr(fpylll, "__version__", "unknown")
+    rows = [json.loads(l) for l in args.inp.read_text().splitlines() if l.strip()]
+    out_lines: list[str] = []
+    for r in rows:
+        if r.get("comparator"):
+            continue
+        if r.get("status") != "ok":
+            continue
+        fn = FAMILIES.get(r["family"])
+        if fn is None:
+            continue
+        h, wall = fn(fpylll, int(r["seed"]), int(r["param"]))
+        out_lines.append(json.dumps(make_comparator_row(r, wall, h, "fpylll", version)))
+
+    if out_lines:
+        with args.append.open("a") as f:
+            for ln in out_lines:
+                f.write(ln + "\n")
+    print(f"appended {len(out_lines)} comparator row(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/external/python_arith.py
+++ b/scripts/bench/external/python_arith.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""HexArith Python comparator.
+
+Reads the Lean-emitted JSONL (to learn which families ran at which
+params), then runs the equivalent operation in Python's stdlib (with
+gmpy2 as a richer fallback when available), measuring wall_nanos for
+each. Appends one comparator row per Lean row to the JSONL.
+
+JSONL schema is shared with the Lean emitter — see
+HexArith/Bench/Driver.lean's `renderRow`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import hashlib
+import json
+import math
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+# SplitMix64 mirror of HexArith.Bench.Random.next, so the comparator
+# uses the same input distribution as the Lean side.
+_MASK = (1 << 64) - 1
+
+
+def splitmix64_next(state: int) -> tuple[int, int]:
+    state = (state + 0x9E3779B97F4A7C15) & _MASK
+    z = state
+    z = ((z ^ (z >> 30)) * 0xBF58476D1CE4E5B9) & _MASK
+    z = ((z ^ (z >> 27)) * 0x94D049BB133111EB) & _MASK
+    z = z ^ (z >> 31)
+    return z, state
+
+
+def next_bits(state: int, bits: int) -> tuple[int, int]:
+    if bits <= 0:
+        return 0, state
+    n_chunks = (bits + 63) // 64
+    acc = 0
+    for _ in range(n_chunks):
+        z, state = splitmix64_next(state)
+        acc = (acc << 64) | z
+    total = n_chunks * 64
+    if total > bits:
+        acc >>= total - bits
+    return acc, state
+
+
+def next_nonzero_bits(state: int, bits: int) -> tuple[int, int]:
+    n, state = next_bits(state, bits)
+    return (1 if n == 0 else n), state
+
+
+def next_range(state: int, n: int) -> tuple[int, int]:
+    z, state = splitmix64_next(state)
+    return z % n, state
+
+
+def hash_low64(n: int) -> int:
+    return n & _MASK
+
+
+# ─── per-family Python runners ──────────────────────────────────────────
+
+def run_a1(seed: int, bits: int) -> int:
+    a, s1 = next_nonzero_bits(seed, bits)
+    b, _ = next_nonzero_bits(s1, bits)
+    g, x, y = ext_gcd(a, b)
+    return hash_low64(g) ^ (abs(x) & _MASK) ^ (abs(y) & _MASK)
+
+
+def ext_gcd(a: int, b: int) -> tuple[int, int, int]:
+    # Iterative Bezout — recursive version blows the Python stack on
+    # 1000+ bit inputs, where extGcd takes ~3000 steps.
+    old_r, r = a, b
+    old_s, s = 1, 0
+    old_t, t = 0, 1
+    while r != 0:
+        q = old_r // r
+        old_r, r = r, old_r - q * r
+        old_s, s = s, old_s - q * s
+        old_t, t = t, old_t - q * t
+    return old_r, old_s, old_t
+
+
+def run_a2(seed: int, bits: int) -> int:
+    a, s1 = next_nonzero_bits(seed, bits)
+    n, s2 = next_nonzero_bits(s1, bits)
+    p0, _ = next_nonzero_bits(s2, bits)
+    p = p0 + 2
+    return hash_low64(pow(a, n, p))
+
+
+A3_MOD = 4294967291  # Barrett
+
+
+def run_a3(seed: int, n: int) -> int:
+    a0, s1 = next_range(seed, A3_MOD)
+    b0, _ = next_range(s1, A3_MOD)
+    x = a0
+    y = b0
+    for _ in range(n):
+        x = (x * y) % A3_MOD
+    return x & _MASK
+
+
+# ─── driver ─────────────────────────────────────────────────────────────
+
+FAMILIES: dict[str, Callable[[int, int], int]] = {
+    "A1.nat-extgcd": run_a1,
+    "A2.nat-powmod": run_a2,
+    "A3.barrett-mulmod": run_a3,
+    # A4 not implemented here — Lean side is smoke-only because of a
+    # scaffolding limitation, comparator would dominate the noise.
+}
+
+
+def time_one(fn: Callable[[int, int], int], seed: int, param: int) -> tuple[int, int]:
+    t0 = time.perf_counter_ns()
+    h = fn(seed, param)
+    t1 = time.perf_counter_ns()
+    return h, t1 - t0
+
+
+def make_comparator_row(lean_row: dict[str, Any], wall_nanos: int, h: int,
+                        comparator: str, version: str) -> dict[str, Any]:
+    out = dict(lean_row)
+    out["wall_nanos"] = wall_nanos
+    out["result_hash"] = f"0x{h:x}"
+    out["comparator"] = comparator
+    out["comparator_version"] = version
+    out["status"] = "ok"
+    out["error"] = None
+    out["ts"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    out["run_index"] = lean_row.get("run_index", 0)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, type=Path,
+                    help="JSONL produced by hex_arith_bench")
+    ap.add_argument("--append", required=True, type=Path,
+                    help="Append comparator rows here (often same as --in)")
+    args = ap.parse_args()
+
+    py_version = f"python-{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+
+    rows = [json.loads(l) for l in args.inp.read_text().splitlines() if l.strip()]
+    appended = 0
+    out_lines: list[str] = []
+    for r in rows:
+        if r.get("comparator"):
+            continue  # don't comparate a comparator row
+        if r.get("status") != "ok":
+            continue
+        fam = r["family"]
+        fn = FAMILIES.get(fam)
+        if fn is None:
+            continue
+        seed = int(r["seed"])
+        param = int(r["param"])
+        h, wall = time_one(fn, seed, param)
+        out_lines.append(json.dumps(make_comparator_row(r, wall, h, "python-stdlib", py_version)))
+        appended += 1
+
+    if out_lines:
+        with args.append.open("a") as f:
+            for ln in out_lines:
+                f.write(ln + "\n")
+    print(f"appended {appended} comparator row(s)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/report.py
+++ b/scripts/bench/report.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Render a markdown view of one library's benchmark JSONL.
+
+Reads JSONL written by HexArith.Bench (and its HexLLL twin), groups
+records by `(family, comparator)`, computes median/min/max wall_nanos
+across runs, fits a log-log slope when there are ≥3 distinct params
+for a family, and emits a markdown report. JSONL is the source of
+truth; this script is just a view.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open() as f:
+        for ln, raw in enumerate(f, 1):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                rows.append(json.loads(raw))
+            except json.JSONDecodeError as e:
+                print(f"warning: {path}:{ln}: bad JSON: {e}", file=sys.stderr)
+    return rows
+
+
+def fmt_ms(ns: int | float) -> str:
+    if ns is None:
+        return "—"
+    ms = ns / 1_000_000.0
+    if ms < 1:
+        return f"{ms*1000:.1f} µs"
+    if ms < 1000:
+        return f"{ms:.2f} ms"
+    return f"{ms/1000:.2f} s"
+
+
+def fit_loglog_slope(points: list[tuple[float, float]]) -> float | None:
+    """Least-squares slope of log y vs log x. Returns None on bad input."""
+    pts = [(x, y) for x, y in points if x > 0 and y > 0]
+    if len(pts) < 3:
+        return None
+    xs = [math.log(x) for x, _ in pts]
+    ys = [math.log(y) for _, y in pts]
+    n = len(xs)
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den = sum((x - mean_x) ** 2 for x in xs)
+    if den == 0:
+        return None
+    return num / den
+
+
+def verdict(observed: float | None, expected: float | None) -> str:
+    if observed is None or expected is None:
+        return "insufficient-data"
+    if abs(observed - expected) <= 0.5:
+        return f"match (Δ={observed-expected:+.2f})"
+    return f"off (observed {observed:.2f} vs expected {expected:.2f})"
+
+
+def render(jsonl_path: Path, library: str, out_path: Path) -> None:
+    rows = load_rows(jsonl_path)
+    if not rows:
+        out_path.write_text(f"# {library} benchmarks\n\n_No JSONL rows; nothing to report._\n")
+        return
+
+    # Header context: take from any row (they share meta).
+    head = rows[0]
+    git_sha = head.get("git_sha", "?")
+    hostname = head.get("hostname", "?")
+    cpu = head.get("cpu_model") or "?"
+    ts = head.get("ts", "?")
+    toolchain = head.get("lean_toolchain", "?")
+    seed = head.get("seed", "?")
+
+    # Group rows by family. Comparator rows have comparator != null.
+    by_family: dict[str, dict[str, Any]] = defaultdict(lambda: {
+        "lean": [],          # list of {param, wall_nanos, status, run_index, origin, hash}
+        "comparators": defaultdict(list),  # name -> list of dicts
+    })
+    for r in rows:
+        fam = r["family"]
+        if r.get("comparator"):
+            by_family[fam]["comparators"][r["comparator"]].append(r)
+        else:
+            by_family[fam]["lean"].append(r)
+
+    lines = [
+        f"# {library} benchmarks",
+        "",
+        f"- Run: `{git_sha}`",
+        f"- Machine: {hostname} (CPU: {cpu})",
+        f"- Date: {ts}",
+        f"- Toolchain: `{toolchain}`",
+        f"- Seed: `{seed}`",
+        "",
+        "Per-family detail follows; the **Summary** table at the end aggregates.",
+        "",
+    ]
+
+    summary_rows: list[tuple[str, str, str, str, str, str, str]] = []
+
+    for fam, data in sorted(by_family.items()):
+        lean_rows = data["lean"]
+        if not lean_rows:
+            continue
+        lines.append(f"## {fam}")
+        lines.append("")
+        # Group lean rows by param so we can detect ladder vs measured-mode.
+        by_param: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for r in lean_rows:
+            by_param[r["param"]].append(r)
+        params = sorted(by_param)
+        if len(params) == 1:
+            # measured mode: many runs at one param.
+            p = params[0]
+            samples = [r["wall_nanos"] for r in by_param[p] if r["status"] == "ok"]
+            origin = by_param[p][0]["param_origin"]
+            statuses = sorted({r["status"] for r in by_param[p]})
+            lines.append(f"- Mode: measured ({len(samples)} runs)")
+            lines.append(f"- Parameter: `{p}` (origin: {origin})")
+            lines.append(f"- Statuses: {', '.join(statuses)}")
+            if samples:
+                med = statistics.median(samples)
+                lo = min(samples); hi = max(samples)
+                lines.append(f"- Wall: median **{fmt_ms(med)}**, min {fmt_ms(lo)}, max {fmt_ms(hi)}")
+            else:
+                lines.append("- Wall: no `ok` samples")
+            slope_str = "—"
+        else:
+            # ladder mode: one or more runs per param, varying param.
+            lines.append(f"- Mode: ladder ({len(params)} rungs)")
+            lines.append("")
+            lines.append("| param | runs | median | status |")
+            lines.append("|---|---|---|---|")
+            ladder_pts = []
+            for p in params:
+                samples = [r["wall_nanos"] for r in by_param[p] if r["status"] == "ok"]
+                statuses = sorted({r["status"] for r in by_param[p]})
+                med = statistics.median(samples) if samples else None
+                lines.append(f"| {p} | {len(by_param[p])} | {fmt_ms(med) if med else '—'} | {','.join(statuses)} |")
+                if med is not None:
+                    ladder_pts.append((float(p), float(med)))
+            slope = fit_loglog_slope(ladder_pts)
+            slope_str = f"{slope:.2f}" if slope is not None else "—"
+            # Expected slope is metadata we don't currently emit; report's
+            # "verdict" field stays "insufficient-data" until we plumb that.
+            lines.append("")
+            lines.append(f"- Observed log-log slope: **{slope_str}**")
+
+        # Comparators.
+        for cmp_name, cmp_rows in sorted(data["comparators"].items()):
+            cmp_samples = [r["wall_nanos"] for r in cmp_rows if r["status"] == "ok"]
+            if cmp_samples:
+                cmp_med = statistics.median(cmp_samples)
+                lines.append(f"- Comparator `{cmp_name}`: median {fmt_ms(cmp_med)} ({len(cmp_samples)} runs)")
+            else:
+                statuses = sorted({r["status"] for r in cmp_rows})
+                lines.append(f"- Comparator `{cmp_name}`: no `ok` samples ({','.join(statuses)})")
+
+        # Summary row: use first param's median.
+        first_param = params[0]
+        lean_samples = [r["wall_nanos"] for r in by_param[first_param] if r["status"] == "ok"]
+        lean_med = statistics.median(lean_samples) if lean_samples else None
+        cmp_med = None; cmp_name = "—"
+        for cn, cr in sorted(data["comparators"].items()):
+            cs = [r["wall_nanos"] for r in cr if r["status"] == "ok" and r["param"] == first_param]
+            if cs:
+                cmp_med = statistics.median(cs); cmp_name = cn
+                break
+        ratio = (lean_med / cmp_med) if (lean_med and cmp_med) else None
+        summary_rows.append((
+            fam,
+            str(first_param),
+            by_param[first_param][0]["param_origin"],
+            fmt_ms(lean_med) if lean_med else "—",
+            fmt_ms(cmp_med) if cmp_med else "—",
+            f"{ratio:.2f}×" if ratio else "—",
+            slope_str,
+        ))
+        lines.append("")
+
+    # Summary
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| family | param | origin | wall (median) | comparator | ratio (Lean/cmp) | log-log slope |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for row in summary_rows:
+        lines.append("| " + " | ".join(row) + " |")
+    lines.append("")
+    lines.append("## Honest assessment")
+    lines.append("")
+    lines.append("_Hand-edit this section after each run with what surprised you,"
+                 " what calibration got wrong, and what the report doesn't yet capture._")
+    lines.append("")
+
+    out_path.write_text("\n".join(lines))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--jsonl", required=True, type=Path)
+    ap.add_argument("--library", required=True)
+    ap.add_argument("--out", required=True, type=Path)
+    args = ap.parse_args()
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    render(args.jsonl, args.library, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench/run.sh
+++ b/scripts/bench/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/bench/run.sh <library> <seconds> [extra-args …]
+#
+# Drives one benchmark library end-to-end:
+#  1. Builds the bench exe.
+#  2. Captures run metadata into env vars.
+#  3. Runs the bench, streaming JSONL to results/.
+#  4. Runs the matching Python comparator (if available) and appends rows.
+#  5. Renders the markdown report into HexManual/Benchmarks/<Lib>.md.
+#
+# Library is one of: hex_arith, hex_lll.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <hex_arith|hex_lll> <seconds> [--ladder] [--smoke] [--runs N]" >&2
+  exit 2
+fi
+
+lib="$1"; shift
+seconds="$1"; shift
+extra_args=("$@")
+
+case "$lib" in
+  hex_arith) lib_pretty="HexArith" ; comparator="python_arith.py" ;;
+  hex_lll)   lib_pretty="HexLLL"   ; comparator="fpylll_lll.py" ;;
+  *) echo "unknown library: $lib (expected hex_arith or hex_lll)" >&2; exit 2 ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+mkdir -p results
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+out_jsonl="results/${lib}-${ts}.jsonl"
+
+export BENCH_GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+export BENCH_TOOLCHAIN="$(cat lean-toolchain 2>/dev/null || echo 'unknown')"
+export BENCH_HOSTNAME="$(hostname)"
+export BENCH_TS="$ts"
+# CPU model is best-effort: works on Linux via /proc/cpuinfo, otherwise unset.
+if [[ -r /proc/cpuinfo ]]; then
+  cpu="$(grep -m1 '^model name' /proc/cpuinfo | cut -d: -f2- | sed 's/^ *//')"
+  [[ -n "$cpu" ]] && export BENCH_CPU_MODEL="$cpu"
+fi
+
+echo "==> Building ${lib}_bench"
+lake build "${lib}_bench" 2>&1 | grep -E '✔|✖|error|warning' | tail -20
+
+echo "==> Running Lean bench (${seconds}s budget)"
+"./.lake/build/bin/${lib}_bench" "$seconds" --out "$out_jsonl" "${extra_args[@]}"
+
+# Comparator is optional; SKIP_COMPARATOR=1 disables.
+comparator_path="scripts/bench/external/${comparator}"
+if [[ "${SKIP_COMPARATOR:-0}" != "1" && -x "$comparator_path" ]]; then
+  echo "==> Running comparator ${comparator}"
+  if "$comparator_path" --in "$out_jsonl" --append "$out_jsonl" 2>&1; then
+    echo "    comparator OK"
+  else
+    echo "    comparator failed (continuing)"
+  fi
+elif [[ "${SKIP_COMPARATOR:-0}" != "1" ]]; then
+  echo "==> No executable comparator at $comparator_path; skipping"
+fi
+
+echo "==> Rendering report → HexManual/Benchmarks/${lib_pretty}.md"
+python3 scripts/bench/report.py --jsonl "$out_jsonl" --library "$lib_pretty" \
+  --out "HexManual/Benchmarks/${lib_pretty}.md"
+
+echo "==> Done. JSONL: $out_jsonl  Report: HexManual/Benchmarks/${lib_pretty}.md"

--- a/scripts/bench/smoke.sh
+++ b/scripts/bench/smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# scripts/bench/smoke.sh — CI-style smoke for both bench libraries.
+#
+# Each library runs at seconds=1 with --max-per-family-seconds 5 and
+# --runs 1. Smoke-only families (the ones excluded from the budgeted
+# set because of scaffolding limitations — see Families.smokeOnly) are
+# also exercised once at tiny share. The run is bounded by an outer
+# wallclock cap so a misbehaving family fails CI loudly.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+OUTER_TIMEOUT="${OUTER_TIMEOUT:-60}"
+
+mkdir -p results
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+export BENCH_GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
+export BENCH_TOOLCHAIN="$(cat lean-toolchain 2>/dev/null || echo 'unknown')"
+export BENCH_HOSTNAME="$(hostname)"
+export BENCH_TS="$ts"
+
+for lib in hex_arith hex_lll; do
+  if [[ ! -x "./.lake/build/bin/${lib}_bench" ]]; then
+    echo "==> Building ${lib}_bench"
+    lake build "${lib}_bench" 2>&1 | tail -5
+  fi
+  out="results/smoke-${lib}-${ts}.jsonl"
+  echo "==> Smoke ${lib} (cap ${OUTER_TIMEOUT}s outer)"
+  timeout "$OUTER_TIMEOUT" "./.lake/build/bin/${lib}_bench" 1 \
+    --runs 1 --max-per-family-seconds 5 --smoke --out "$out"
+  rows=$(wc -l < "$out")
+  echo "    emitted $rows JSONL row(s) → $out"
+  if [[ "$rows" -lt 1 ]]; then
+    echo "    smoke FAILED: no rows emitted" >&2
+    exit 1
+  fi
+done
+
+echo "==> Smoke OK"


### PR DESCRIPTION
## Summary

- Relands #426 (reverted in #427 because of a DAG-check failure on `import HexMatrix` from `HexLLL/Bench/Inputs.lean`).
- The DAG check has since been corrected: spec in #428, implementation in #429. `import HexMatrix` from HexLLL is now allowed because HexMatrix is in the dep closure (HexLLL → HexGramSchmidt → HexMatrix), matching Lake's symbol-visibility.
- Verified locally: \`python3 scripts/check_dag.py\` exits 0 on this branch.

Same caveats as #426: this prototype predates the SPEC v2 lean-bench mandate (#425). Conversion to lean-bench is a follow-up. The two implementation bugs the prototype found (HexArith Montgomery brute-force inverse; HexLLL swapStep O(n³) rebuild) remain unfixed.

🤖 Prepared with Claude Code