### PR TITLE
fix: add UInt64 wide externs

### DIFF
--- a/HexArith/UInt64/Wide.lean
+++ b/HexArith/UInt64/Wide.lean
@@ -12,6 +12,7 @@ namespace UInt64
 def word : Nat := 2 ^ 64
 
 /-- The high 64 bits of the product `a * b`, viewed in radix `2^64`. -/
+@[extern "lean_hex_uint64_mul_hi"]
 def mulHi (a b : UInt64) : UInt64 :=
   .ofNat (a.toNat * b.toNat / word)
 
@@ -19,6 +20,7 @@ def mulHi (a b : UInt64) : UInt64 :=
 Add `a`, `b`, and an incoming carry bit, returning the wrapped low word and the
 outgoing carry bit.
 -/
+@[extern "lean_hex_uint64_add_carry"]
 def addCarry (a b : UInt64) (cin : Bool) : UInt64 × Bool :=
   let total := a.toNat + b.toNat + cin.toNat
   (.ofNat total, decide (word ≤ total))
@@ -27,6 +29,7 @@ def addCarry (a b : UInt64) (cin : Bool) : UInt64 × Bool :=
 Subtract `b` and an incoming borrow bit from `a`, returning the wrapped low
 word and the outgoing borrow bit.
 -/
+@[extern "lean_hex_uint64_sub_borrow"]
 def subBorrow (a b : UInt64) (bin : Bool) : UInt64 × Bool :=
   let rhs := b.toNat + bin.toNat
   if rhs ≤ a.toNat then

--- a/HexArith/ffi/wide_arith.c
+++ b/HexArith/ffi/wide_arith.c
@@ -1,0 +1,28 @@
+#include <lean/lean.h>
+#include <stdint.h>
+
+LEAN_EXPORT uint64_t lean_hex_uint64_mul_hi(uint64_t a, uint64_t b) {
+    return (uint64_t)(((__uint128_t)a * (__uint128_t)b) >> 64);
+}
+
+LEAN_EXPORT lean_obj_res lean_hex_uint64_add_carry(uint64_t a, uint64_t b, uint8_t cin) {
+    uint64_t sum;
+    uint64_t total;
+    uint8_t carry1 = __builtin_add_overflow(a, b, &sum);
+    uint8_t carry2 = __builtin_add_overflow(sum, (uint64_t)cin, &total);
+    lean_object* pair = lean_alloc_ctor(0, 2, 0);
+    lean_ctor_set(pair, 0, lean_box_uint64(total));
+    lean_ctor_set(pair, 1, lean_box(carry1 | carry2));
+    return pair;
+}
+
+LEAN_EXPORT lean_obj_res lean_hex_uint64_sub_borrow(uint64_t a, uint64_t b, uint8_t bin) {
+    uint64_t diff;
+    uint64_t total;
+    uint8_t borrow1 = __builtin_sub_overflow(a, b, &diff);
+    uint8_t borrow2 = __builtin_sub_overflow(diff, (uint64_t)bin, &total);
+    lean_object* pair = lean_alloc_ctor(0, 2, 0);
+    lean_ctor_set(pair, 0, lean_box_uint64(total));
+    lean_ctor_set(pair, 1, lean_box(borrow1 | borrow2));
+    return pair;
+}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -14,7 +14,7 @@ rev = "v4.30.0-rc2"
 
 [[lean_lib]]
 name = "HexArith"
-moreLinkArgs = ["HexArith/ffi/mpz_gcdext.c"]
+moreLinkArgs = ["HexArith/ffi/mpz_gcdext.c", "HexArith/ffi/wide_arith.c"]
 
 [[lean_lib]]
 name = "HexPoly"

--- a/progress/2026-04-28T07:11:36Z_bd2c8e80.md
+++ b/progress/2026-04-28T07:11:36Z_bd2c8e80.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed issue `#539` and attached `@[extern]` runtime hooks to `UInt64.mulHi`, `UInt64.addCarry`, and `UInt64.subBorrow` in [HexArith/UInt64/Wide.lean](/home/kim/hex/worktrees/bd2c8e80/HexArith/UInt64/Wide.lean:1).
+- Added the C shim [HexArith/ffi/wide_arith.c](/home/kim/hex/worktrees/bd2c8e80/HexArith/ffi/wide_arith.c:1) implementing high-word multiply plus carry/borrow helpers via `__uint128_t` and compiler overflow intrinsics, and wired it into [lakefile.toml](/home/kim/hex/worktrees/bd2c8e80/lakefile.toml:14).
+- Verified the fix with `lake build HexArith`, `lake build`, `python3 scripts/check_dag.py`, a standalone `-Wall -Wextra` compile of the C file, and runtime smoke tests for `mulHi`, `addCarry`, and `subBorrow`.
+
+**Current frontier**
+
+- Issue `#539` is ready to publish; the requested extern-backed wide-word operations are implemented and validated.
+
+**Next step**
+
+- Commit the `HexArith` wide-arithmetic FFI repair and open the PR closing `#539`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #539

Session: `bd2c8e80-4d37-4d06-8a15-16af1faf5eed`

00d509e fix: add UInt64 wide externs (progress 2026-04-28T07:11:36Z_bd2c8e80.md)

🤖 Prepared with Claude Code