### PR TITLE
fix: make HexPolyZ Mignotte bound conservative

### DIFF
--- a/HexPolyZ.lean
+++ b/HexPolyZ.lean
@@ -4,6 +4,6 @@ import HexPolyZ.Mignotte
 /-!
 The `HexPolyZ` library specializes the generic dense polynomial scaffold to
 integer coefficients, exposing the `ZPoly` alias together with congruence,
-content, primitive-part, and Mignotte-bound APIs used by the factoring
-pipeline.
+content, primitive-part, and conservative executable Mignotte-bound APIs used
+by the factoring pipeline.
 -/

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -5,8 +5,9 @@ Executable Mignotte-bound helpers for `hex-poly-z`.
 
 This module packages the integer computations that appear in the classical
 Mignotte coefficient bound: binomial coefficients together with the Euclidean
-norm of the ambient polynomial's coefficient vector. The mathematical proof
-that these quantities bound factors lives in `HexPolyZMathlib`.
+norm upper bound of the ambient polynomial's coefficient vector. The
+mathematical proof that these quantities bound factors lives in
+`HexPolyZMathlib`.
 -/
 namespace Hex
 
@@ -31,18 +32,27 @@ private def sqrtAux (n : Nat) : Nat → Nat
 def floorSqrt (n : Nat) : Nat :=
   sqrtAux n n
 
+/-- The least natural number whose square is at least `n`. -/
+def ceilSqrt (n : Nat) : Nat :=
+  let r := floorSqrt n
+  if r * r = n then
+    r
+  else
+    r + 1
+
 /-- The squared Euclidean norm of the coefficient vector of `f`. -/
 def coeffNormSq (f : ZPoly) : Nat :=
   (List.range f.size).foldl (fun acc i => acc + (f.coeff i).natAbs ^ 2) 0
 
-/-- The integer square-root of the coefficient Euclidean norm. -/
-def coeffNorm (f : ZPoly) : Nat :=
-  floorSqrt (coeffNormSq f)
+/-- A conservative natural-number upper bound on the Euclidean norm of the
+coefficient vector of `f`. -/
+def coeffL2NormBound (f : ZPoly) : Nat :=
+  ceilSqrt (coeffNormSq f)
 
 /-- The executable Mignotte bound for the `j`-th coefficient of a degree-`k`
-factor of `f`. -/
+factor of `f`, using the conservative `coeffL2NormBound`. -/
 def mignotteCoeffBound (f : ZPoly) (k j : Nat) : Nat :=
-  binom k j * coeffNorm f
+  binom k j * coeffL2NormBound f
 
 @[simp] theorem binom_zero_right (n : Nat) : binom n 0 = 1 := by
   cases n <;> rfl
@@ -60,21 +70,24 @@ theorem binom_eq_zero_of_lt : ∀ {n k : Nat}, n < k → binom n k = 0
 @[simp] theorem floorSqrt_zero : floorSqrt 0 = 0 := by
   rfl
 
+@[simp] theorem ceilSqrt_zero : ceilSqrt 0 = 0 := by
+  simp [ceilSqrt]
+
 theorem coeffNormSq_eq_sum (f : ZPoly) :
     coeffNormSq f =
       (List.range f.size).foldl (fun acc i => acc + (f.coeff i).natAbs ^ 2) 0 := rfl
 
-theorem coeffNorm_eq_sqrt_coeffNormSq (f : ZPoly) :
-    coeffNorm f = floorSqrt (coeffNormSq f) := rfl
+theorem coeffL2NormBound_eq_ceilSqrt_coeffNormSq (f : ZPoly) :
+    coeffL2NormBound f = ceilSqrt (coeffNormSq f) := rfl
 
 theorem mignotteCoeffBound_eq (f : ZPoly) (k j : Nat) :
-    mignotteCoeffBound f k j = binom k j * coeffNorm f := rfl
+    mignotteCoeffBound f k j = binom k j * coeffL2NormBound f := rfl
 
 @[simp] theorem coeffNormSq_zero : coeffNormSq (0 : ZPoly) = 0 := by
   rfl
 
-@[simp] theorem coeffNorm_zero : coeffNorm (0 : ZPoly) = 0 := by
-  simp [coeffNorm]
+@[simp] theorem coeffL2NormBound_zero : coeffL2NormBound (0 : ZPoly) = 0 := by
+  simp [coeffL2NormBound]
 
 @[simp] theorem mignotteCoeffBound_zero (k j : Nat) :
     mignotteCoeffBound (0 : ZPoly) k j = 0 := by

--- a/progress/2026-04-28T07:46:38Z_f9d2cac5.md
+++ b/progress/2026-04-28T07:46:38Z_f9d2cac5.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed issue `#563` and updated [HexPolyZ/Mignotte.lean](/home/kim/hex/worktrees/f9d2cac5/HexPolyZ/Mignotte.lean:1) so the executable Mignotte helper now uses `ceilSqrt` and exposes `coeffL2NormBound` instead of the old floor-based norm helper.
+- Kept `mignotteCoeffBound` as the public coefficient-bound entry point, but retargeted it to the conservative norm bound and tightened the surrounding docstrings/theorem names to make the contract explicit.
+- Updated the root module docstring in [HexPolyZ.lean](/home/kim/hex/worktrees/f9d2cac5/HexPolyZ.lean:1) to advertise the conservative executable Mignotte-bound surface.
+- Verified with `lake build HexPolyZ`, `python3 scripts/check_dag.py`, and a `lake env lean` `#eval!` smoke test on coefficients `[1, 1]`, which produced `coeffNormSq = 2`, `coeffL2NormBound = 2`, and `mignotteCoeffBound ... 1 0 = 2`.
+
+**Current frontier**
+
+- The conservative executable bound is in place for `HexPolyZ`; the next downstream step is for review / Mathlib work to connect this executable contract to the real-valued Mignotte theorem.
+
+**Next step**
+
+- Commit the `HexPolyZ` bound fix and open the PR closing `#563`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #563

Session: `f9d2cac5-665f-4368-a2ad-6a1c43b4e01f`

1b00e2a fix: make HexPolyZ Mignotte bound conservative

🤖 Prepared with Claude Code