### PR TITLE
prompting: bootstrap to lakefile.lean only — never lakefile.toml

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -50,7 +50,7 @@ until merged PRs land.
 | SPEC library files | kebab-case | `hex-poly-z-mathlib.md` |
 | Lean modules/dirs | PascalCase | `HexPolyZMathlib` |
 | `libraries.yml` keys | PascalCase | `HexPolyZMathlib:` |
-| `lakefile.toml` names | PascalCase | `name = "HexPolyZMathlib"` |
+| `lakefile.lean` names | PascalCase | `lean_lib HexPolyZMathlib where` |
 
 The PascalCase form is a direct transliteration of the kebab-case
 name: each hyphen-separated segment becomes capitalised and joined
@@ -253,7 +253,7 @@ read its output.
   complete.
 - `done_through: 7` is fully done.
 - Phase 0 is *global*, not per-library — its completion is observable
-  via on-disk artifacts (`lakefile.toml`, `scripts/check_dag.py`,
+  via on-disk artifacts (`lakefile.lean`, `scripts/check_dag.py`,
   etc.), not via any `libraries.yml` field.
 - "Dep-coupled" phases (1, 3, 4) require same-phase completion in
   every direct dep before L can start them. "Local" phases (2, 5,

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -2,7 +2,7 @@
 
 **Coupling:** global. One-time repo-level bootstrap; not tracked
 per-library in `libraries.yml`. Its completion is observable by the
-existence of `lakefile.toml`, `scripts/check_dag.py`, etc.
+existence of `lakefile.lean`, `scripts/check_dag.py`, etc.
 
 One-time setup. Create the Lake monorepo infrastructure by reading the
 spec and this document.
@@ -20,17 +20,40 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    `leanprover/lean4:v4.30.0-rc2`. This is the project baseline; do
    not substitute a different release.
 
-2. Create `lakefile.toml` with one `[[lean_lib]]` per library in
-   `libraries.yml` (the 27 computational + bridge libraries), plus
-   one additional `[[lean_lib]]` for `HexManual` (the Verso-based
-   documentation aggregator — see [Phase7.md](Phase7.md)). All
-   `-mathlib` bridge libraries depend on the Mathlib tag
-   `v4.30.0-rc2`. `HexManual` depends on Verso and on every `hex-*`
-   library.
+2. Create `lakefile.lean` (Lake's DSL form, **not** `lakefile.toml`)
+   with one `lean_lib` per library in `libraries.yml` (the 27
+   computational + bridge libraries), plus one additional `lean_lib`
+   for `HexManual` (the Verso-based documentation aggregator — see
+   [Phase7.md](Phase7.md)). All `-mathlib` bridge libraries depend
+   on the Mathlib tag `v4.30.0-rc2`. `HexManual` depends on Verso
+   and on every `hex-*` library, and is the `@[default_target]`.
 
-   Each computational/bridge library entry needs:
-   - `name` — PascalCase (e.g. `HexArith`, `HexPolyZMathlib`)
-   - Mathlib bridge libraries should declare `needs = ["mathlib"]`
+   **Use `lakefile.lean`, not `lakefile.toml`, even though the toml
+   form would suffice for Phase 0's "all empty libraries" state.**
+   Several libraries (`hex-arith` for `mpz_gcdext` and the wide-word
+   externs, `hex-gf2` for CLMUL) require FFI shims wired via Lake's
+   `extern_lib` DSL form, which is not expressible in
+   `lakefile.toml`. A later switch from `.toml` to `.lean` means a
+   migration step that has historically been missed (Lake silently
+   ignores `lakefile.toml` when both are present, so a later-added
+   `lakefile.lean` orphans the toml's `moreLinkArgs` without warning).
+   Establish `lakefile.lean` as the only build configuration from the
+   start.
+
+   Each computational/bridge library entry should be a bare
+   `lean_lib HexX where` (Mathlib bridge libraries do not need an
+   explicit `needs` declaration in this DSL form — Lake reads the
+   `import` lines for actual dependencies). Names are PascalCase
+   (e.g. `HexArith`, `HexPolyZMathlib`).
+
+   Phase 0 does **not** add `extern_lib` blocks. Those are
+   per-library Phase-1 deliverables, added when each FFI-using
+   library's C shim lands. The Phase 0 lakefile is FFI-free.
+
+   This repo does **not** carry a `lakefile.toml`. If any agent
+   adds one later, delete it: Lake's behaviour with both files
+   present is to silently use `.lean` and ignore `.toml`, which
+   creates dead config that confuses future workers.
 
 3. Create empty root files and source directories for every library
    listed in `libraries.yml`:
@@ -50,11 +73,17 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    **Structural checks:**
    - Verify the graph is acyclic (topological sort succeeds).
    - Every dependency in `libraries.yml` names an existing entry.
-   - Every `libraries.yml` entry has a matching `[[lean_lib]]` in
-     `lakefile.toml` (parse TOML via `tomllib`, available since 3.11).
-   - Every `[[lean_lib]]` in `lakefile.toml` either has a matching
+   - Every `libraries.yml` entry has a matching `lean_lib` in
+     `lakefile.lean`. Parse via a regex that matches
+     `^\s*lean_lib\s+(\w+)\s+where` (Lake DSL has a stable shape
+     for these declarations); a 5–10-line scanner is sufficient.
+   - Every `lean_lib` in `lakefile.lean` either has a matching
      `libraries.yml` entry, or is on a known-exceptions list
      (currently: just `HexManual`).
+   - Reject `lakefile.toml` if it exists: Lake silently prefers
+     `lakefile.lean`, so a stray `lakefile.toml` is dead config that
+     misleads future workers. Exit non-zero with a message
+     instructing the agent to delete it.
    - Every library's root `.lean` file exists on disk.
 
    **Import boundary checks:**
@@ -149,7 +178,7 @@ into Phase 1 until the Phase 0 PR lands on `main`.
      and builds.
 
    - Exit non-zero on malformed `libraries.yml` or disagreement
-     between `libraries.yml` and `lakefile.toml`.
+     between `libraries.yml` and `lakefile.lean`.
 
 6. Set up CI using `leanprover/lean-action`.
 
@@ -196,8 +225,9 @@ into Phase 1 until the Phase 0 PR lands on `main`.
 Phase 0 is done when:
 
 - `lean-toolchain` is the pinned baseline;
-- `lakefile.toml` lists every library in `libraries.yml` (plus
-  `HexManual`);
+- `lakefile.lean` lists every library in `libraries.yml` (plus
+  `HexManual`) via `lean_lib` declarations; no `lakefile.toml`
+  is present in the repo root;
 - `lake-manifest.json` pins Mathlib to the resolved tag for
   `v4.30.0-rc2`;
 - every library has an empty-or-stub root `.lean` file and source

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -30,16 +30,15 @@ For each library `HexFoo` advancing through Phase 4:
    expression in each `setup_benchmark` is the *textbook*
    complexity, not the observed one.
 
-2. **`lakefile.toml` exe entry**:
+2. **`lakefile.lean` exe entry**:
 
-   ```toml
-   [[lean_exe]]
-   name = "hexfoo_bench"
-   root = "HexFoo.Bench"
+   ```lean
+   lean_exe hexfoo_bench where
+     root := `HexFoo.Bench
    ```
 
    On the first library to enter Phase 4, also add the lean-bench
-   `[[require]]` (per the snippet in
+   `require` (per the snippet in
    [SPEC/benchmarking.md §Harness](../SPEC/benchmarking.md#harness-lean-bench)).
 
 3. **CI smoke step** invoking

--- a/PLAN/Phase7.md
+++ b/PLAN/Phase7.md
@@ -20,8 +20,8 @@ the actual Lean API.
 
 ## Structure: `HexManual` lean_lib
 
-The manual is a single `[[lean_lib]]` named `HexManual` in the root
-`lakefile.toml` (set up during Phase 0). It depends on Verso and on
+The manual is a single `lean_lib HexManual` in the root
+`lakefile.lean` (set up during Phase 0). It depends on Verso and on
 every `hex-*` library.
 
 - Verso's dependency on Mathlib (if any) flows only through

--- a/SPEC/Libraries/hex-arith.md
+++ b/SPEC/Libraries/hex-arith.md
@@ -230,12 +230,19 @@ The C extern bodies live in `HexArith/ffi/wide_arith.c`:
 - `lean_hex_uint64_sub_borrow(...)` is the analogous
   `__builtin_sub_overflow` call.
 
-The C source is wired into the `[[lean_lib]] name = "HexArith"` block
-of `lakefile.toml` via `moreLeancArgs`/`precompileModules`/`extraSrcs`
-(whichever Lake mechanism matches the current toolchain), paralleling
-the GMP linkage used by `lean_hex_mpz_gcdext`. The pure-Lean fallback
-body is the portable spec; `@[extern]` falls through to it when the C
-symbol is unavailable.
+The C source is wired into `lakefile.lean` via an `extern_lib`
+block (paralleling `extern_lib hexgf2ffi` for HexGF2's CLMUL). The
+block compiles the `.c` sources to `.o` via `compileO` (with
+`-I (← getLeanIncludeDir).toString -fPIC`), bundles them into a
+static library via `buildStaticLib`, and Lake links that library
+into anything depending on `lean_lib HexArith`. The same
+`extern_lib` block carries `mpz_gcdext.c` (see "Extern contract:
+`mpz_gcdext`" below). Putting `.c` paths in `moreLinkArgs` (or in
+`lakefile.toml`) does **not** work — Lake ignores `lakefile.toml`
+when `lakefile.lean` is present, and `moreLinkArgs` is for
+link-time flags, not source compilation. The pure-Lean fallback
+body is the portable spec; `@[extern]` falls through to it when
+the C symbol is unavailable.
 
 Carries are `Bool` (not `UInt64`) — no preconditions needed. The
 extern boundary is the only place where overflow semantics surface.
@@ -401,8 +408,12 @@ the portable fallback. The C wrapper
 `lean_hex_mpz_gcdext(lean_object *, lean_object *) → lean_object *`
 in `HexArith/ffi/mpz_gcdext.c` converts to `mpz_t`, calls GMP's
 `mpz_gcdext(g, s, t, a, b)`, and packs `(g.toNat, s, t)` back into
-`Nat × Int × Int`. GMP is linked via `moreLinkArgs := #["-lgmp"]` in
-`lakefile.toml`; the extern is trusted in the same way as every other
-`@[extern]` GMP binding in Lean. If GMP is unavailable, the
-attachment falls through to `Hex.pureIntExtGcd` — correct, but slow
-on large inputs.
+`Nat × Int × Int`. The C source is bundled into the same
+`extern_lib` block as Layer 1's `wide_arith.c` (see Layer 1 for the
+shape) so a single static library carries all HexArith-side
+externs; GMP itself is linked via
+`moreLinkArgs := #["-lgmp"]` on `lean_lib HexArith` in
+`lakefile.lean`. The extern is trusted in the same way as every
+other `@[extern]` GMP binding in Lean. If GMP is unavailable, the
+attachment falls through to `Hex.pureIntExtGcd` — correct, but
+slow on large inputs.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -109,16 +109,13 @@ A library's Phase-4 deliverable is a `HexFoo.Bench` exe rooted at
 `HexFoo/Bench.lean`. Supporting modules may live under
 `HexFoo/Bench/`. The Lake target is named `hexfoo_bench`:
 
-```toml
-# lakefile.toml
-[[require]]
-name = "lean-bench"
-git = "https://github.com/kim-em/lean-bench.git"
-rev = "main"
+```lean
+-- lakefile.lean
+require «lean-bench» from git
+  "https://github.com/kim-em/lean-bench.git" @ "main"
 
-[[lean_exe]]
-name = "hexfoo_bench"
-root = "HexFoo.Bench"
+lean_exe hexfoo_bench where
+  root := `HexFoo.Bench
 ```
 
 Reproducibility comes from committing `lake-manifest.json` alongside
@@ -254,8 +251,16 @@ Two integration patterns:
   register it as a `setup_benchmark` target, and let the
   inner-repeat loop amortise the call cost. Per-call overhead is
   one C call. Add the shim sources under
-  `HexFoo/ffi/<comparator>.c`; record any link arguments in
-  `lakefile.toml` (`moreLinkArgs`). The same `@[extern]` boundary
+  `HexFoo/ffi/<comparator>.c`; wire them into `lakefile.lean` via
+  an `extern_lib hexfooffi (pkg)` block that builds the `.c`
+  sources to `.o` (via `compileO`) and links them into a static
+  library that the corresponding `lean_lib HexFoo` depends on.
+  See `lakefile.lean`'s `extern_lib hexgf2ffi` for the canonical
+  shape. Record any system link arguments (e.g. `-lgmp`) on the
+  `lean_lib` block via `moreLinkArgs := #[…]`. **Do not put `.c`
+  paths in `moreLinkArgs`** — that field is for link-time flags,
+  not source compilation, and putting `.c` paths there silently
+  produces no extern resolution. The same `@[extern]` boundary
   rules from [Conventions.md](../PLAN/Conventions.md) apply.
 - **Process call, acceptable when FFI isn't viable.** The external
   tool is scripted (Sage, python-flint, GAP, PARI) or the per-call

--- a/libraries.yml
+++ b/libraries.yml
@@ -11,11 +11,11 @@
 #   ready to start Phase 1 once Phase 0's global bootstrap is done.
 # - done_through: 7 means L is fully done.
 # - Phase 0 (monorepo bootstrap) is global; its completion is observable
-#   by the existence of lakefile.toml, scripts/check_dag.py, etc., not
+#   by the existence of lakefile.lean, scripts/check_dag.py, etc., not
 #   by any field in this file.
 #
 # This file is the single source of truth for the library graph.
-# lakefile.toml entries are cross-checked against libraries.yml in CI via
+# lakefile.lean entries are cross-checked against libraries.yml in CI via
 # scripts/check_dag.py.
 
 libraries:


### PR DESCRIPTION
## Context

The autonomous loop's Phase-0 bootstrap (PLAN/Phase0.md) created `lakefile.toml`. Several libraries (HexArith for `mpz_gcdext` + wide-word externs, HexGF2 for CLMUL) need FFI shims wired via Lake's `extern_lib` DSL form, which `lakefile.toml` cannot express. The repo accumulated both files: a `lakefile.lean` with real `extern_lib hexgf2ffi` for HexGF2, and a `lakefile.toml` with misleading `moreLinkArgs = [".../wide_arith.c", ".../mpz_gcdext.c"]` lines for HexArith that Lake silently ignores.

Lake's behaviour with both files present: use `lakefile.lean`, ignore `lakefile.toml`. So the toml's HexArith FFI lines are dead config, the externs don't resolve at runtime, and `lake env lean` of any `#eval UInt64.mulHi …` errors out with "Could not find native implementation of external declaration 'UInt64.mulHi'". The Phase 1 verification step (`lake build`) does not catch it because Lake never invokes the linker for HexArith.

Repair of the existing repo is tracked in https://github.com/kim-em/hex/issues/561 (which also deletes `lakefile.toml`).

This PR fixes the prompting so a fresh bootstrap produces only `lakefile.lean`.

## Change

- **PLAN/Phase0.md**: Step 2 now instructs creating `lakefile.lean` with explicit prose calling out *why* — FFI needs the DSL form, and a later toml→lean migration is the regression class above. Step 4 changes the DAG cross-check to parse `lakefile.lean` via a regex on `^lean_lib (\w+) where`, and adds an explicit reject-if-`lakefile.toml`-exists check. Verify step and exit criteria updated.
- **PLAN/Conventions.md**: name-convention table row updated (`lakefile.toml names` → `lakefile.lean names`).
- **PLAN/Phase4.md**: bench-exe `[[lean_exe]]` snippet rewritten as `lean_exe hexfoo_bench where`.
- **PLAN/Phase7.md**: HexManual `lean_lib` reference.
- **SPEC/benchmarking.md**: lean-bench `[[require]]` snippet rewritten for `lakefile.lean`. The "FFI shim" external-comparator section now points at `extern_lib` blocks with `compileO` / `buildStaticLib` (mirroring `extern_lib hexgf2ffi`), with an explicit warning that putting `.c` paths in `moreLinkArgs` does **not** work — that field is for link-time flags, not source compilation.
- **SPEC/Libraries/hex-arith.md**: Layer 1 wiring text and the `mpz_gcdext` extern-contract section both rewritten to point at `lakefile.lean` `extern_lib` blocks (paralleling `hexgf2ffi`). Both `wide_arith.c` and `mpz_gcdext.c` bundle into a single static lib; `-lgmp` rides on `moreLinkArgs := #["-lgmp"]` on the `lean_lib HexArith` block.
- **libraries.yml**: header comment updated.

## Replay test

A fresh bootstrap run from this prompting would:

1. Read PLAN/Phase0.md Step 2; create `lakefile.lean` (only).
2. Read Step 4; write `scripts/libgraph.py` to parse `lakefile.lean` via regex and reject any `lakefile.toml`.
3. Read SPEC/Libraries/hex-arith.md Layer 1 / `mpz_gcdext` sections; HexArith Phase 1 work would land the `@[extern]` annotations *together with* an `extern_lib hexarithffi` block in `lakefile.lean` — not in a non-existent `lakefile.toml`.

🤖 Prepared with Claude Code