### PR TITLE
spec: UInt64.extGcd must delegate through Int.extGcd, not pure-Nat

### DIFF
--- a/SPEC/Libraries/hex-arith.md
+++ b/SPEC/Libraries/hex-arith.md
@@ -353,7 +353,24 @@ theorem extGcd_bezout (a b : Nat) :
     let (g, s, t) := extGcd a b
     s * a + t * b = g
 ```
-Also for `Int` and `UInt64` variants.
+Also for `Int` and `UInt64` variants. The `Int` variant carries
+`@[extern "lean_hex_mpz_gcdext"]` (see "Extern contract:
+`mpz_gcdext`" below). **The `UInt64` variant must delegate through
+`Int.extGcd`**, not through the pure-Lean `Nat` recursion:
+
+```lean
+def UInt64.extGcd (a b : UInt64) : UInt64 × Int × Int :=
+  let (g, s, t) := Int.extGcd (Int.ofNat a.toNat) (Int.ofNat b.toNat)
+  (.ofNat g, s, t)
+```
+
+Routing through `Int.extGcd` means a `UInt64` extended-GCD is one
+GMP `mpz_gcdext` call. Routing through the pure-Nat recursion
+instead (the obvious "stay in Nat" implementation) is ~64 levels
+of boxed-Nat arithmetic per call — the same regression class as
+omitting `@[extern]` on `mulHi`. The pure-`Nat` `HexArith.extGcd`
+is the proof reference, not the runtime path; runtime `UInt64`
+callers go through GMP.
 
 **Modular exponentiation:**
 ```lean


### PR DESCRIPTION
## Context

The hex-arith SPEC said only *"Also for \`Int\` and \`UInt64\` variants"* without specifying how the UInt64 variant should reach the GMP extern. The Phase-1 worker scaffolded `UInt64.extGcd` via `Hex.pureUInt64ExtGcd` → `HexArith.extGcd a.toNat b.toNat` (the pure-Lean Nat recursion). That is ~64 levels of boxed-Nat arithmetic per call rather than one GMP `mpz_gcdext` — same regression class as omitting `@[extern]` on `mulHi`, just with a smaller blast radius (extGcd isn't a hot loop).

The SPEC named the right contract for `Int` (the GMP extern) but not the delegation chain for `UInt64`, so an autonomous worker had no way to know to route through `Int.extGcd`.

## Change

Patch the "Extended GCD" section of `SPEC/Libraries/hex-arith.md` to specify explicitly:

```lean
def UInt64.extGcd (a b : UInt64) : UInt64 × Int × Int :=
  let (g, s, t) := Int.extGcd (Int.ofNat a.toNat) (Int.ofNat b.toNat)
  (.ofNat g, s, t)
```

The pure-`Nat` `HexArith.extGcd` stays as the proof reference only; it is no longer in the runtime path for the `UInt64` API.

## Follow-up

A `human-oversight` issue will be filed once this lands to repair `HexArith/ExtGcd.lean` per the new SPEC: rewrite the body of `UInt64.extGcd` to delegate through `Int.extGcd`. Single-line fix.

🤖 Prepared with Claude Code