### PR TITLE
fix: route UInt64 extgcd through Int extgcd

### DIFF
--- a/HexArith/ExtGcd.lean
+++ b/HexArith/ExtGcd.lean
@@ -38,8 +38,8 @@ namespace Hex
 /--
 Pure-Lean `UInt64` extended GCD reference implementation.
 
-The scaffold computes the coefficients through the `Nat` implementation
-and repackages the gcd into a machine word.
+This remains available as a proof/reference helper. The public runtime
+`HexArith.UInt64.extGcd` API delegates through `HexArith.Int.extGcd`.
 -/
 def pureUInt64ExtGcd (a b : UInt64) : UInt64 × Int × Int :=
   let (g, s, t) := HexArith.extGcd a.toNat b.toNat
@@ -97,7 +97,8 @@ namespace UInt64
 
 /-- Public `UInt64` extended GCD API surface. -/
 def extGcd (a b : UInt64) : UInt64 × Int × Int :=
-  Hex.pureUInt64ExtGcd a b
+  let (g, s, t) := Int.extGcd (Int.ofNat a.toNat) (Int.ofNat b.toNat)
+  (.ofNat g, s, t)
 
 theorem extGcd_fst (a b : UInt64) :
     (extGcd a b).1.toNat = Nat.gcd a.toNat b.toNat := by

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -49,7 +49,10 @@ extern_lib hexmodarithffi (pkg) := do
 
 lean_lib HexArith where
   precompileModules := true
-  moreLinkArgs := #["-lgmp"]
+  moreLinkArgs := #[
+    s!"{(defaultBuildDir / "lib" / nameToStaticLib "hexarithffi").toString}",
+    "-lgmp"
+  ]
 
 lean_lib HexPoly where
 

--- a/progress/2026-04-28T08:01:21Z_e55e9267.md
+++ b/progress/2026-04-28T08:01:21Z_e55e9267.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed issue `#575` and updated [HexArith/ExtGcd.lean](/home/kim/hex/worktrees/e55e9267/HexArith/ExtGcd.lean:1) so `HexArith.UInt64.extGcd` now delegates through `HexArith.Int.extGcd` instead of the pure-`Nat` reference path.
+- Kept `Hex.pureUInt64ExtGcd` as a proof/reference helper and documented that it is no longer on the runtime path.
+- Repaired [lakefile.lean](/home/kim/hex/worktrees/e55e9267/lakefile.lean:1) so `lean_lib HexArith` links the `hexarithffi` static archive into the precompiled module, allowing `lake lean` to resolve the `mpz_gcdext` and wide-`UInt64` extern symbols.
+- Verified with `lake build HexArith`, `lake build`, `python3 scripts/check_dag.py`, `nm -D .lake/build/lib/lean/Hex_HexArith_ExtGcd.so`, and `lake lean /tmp/test_extern_link.lean`.
+
+**Current frontier**
+
+- The `UInt64` extended-GCD public API now follows the updated `hex-arith` spec and runs through the extern-backed `Int.extGcd` path under Lake's native execution path.
+- The sibling FFI issue `#561` still exists on GitHub, but this worktree now contains the missing static-link edge needed for the runtime smoke test exercised here.
+
+**Next step**
+
+- Commit these changes and open the PR for `#575`, calling out that the verification uses `lake lean` because that path successfully loads the precompiled native modules and extern symbols.
+
+**Blockers**
+
+- `lake env lean` still reports missing native implementations for the extern-backed declarations even though the symbols are present in the built module `.so`s and `lake lean` executes them successfully.


### PR DESCRIPTION
Closes #575

Session: `e55e9267-0c11-43fc-8ded-53526d561eb3`

3ea9372 fix: route UInt64 extgcd through Int extgcd

🤖 Prepared with Claude Code