### PR TITLE
prompting: name-by-example the failure modes that landed in #438

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -14,17 +14,26 @@ once per session.
 agents may fix SPEC clauses that are internally contradictory or
 mathematically impossible, with rationale in the PR description.
 
-### Scaffolding is for proofs only
+### Placeholders are for proofs only
 
 `sorry` is permitted in proofs (`theorem` bodies, propositional
 `structure` fields). It is **not** permitted as a data-level body,
-and neither is any other placeholder shape (wrong-but-plausible
-trivial returns, identity casts, `axiom` stand-ins, alternative
-implementations with the wrong complexity). Every committed `def`
-ships with its intended-final implementation. See
+and neither is any other placeholder shape: wrong-but-plausible
+trivial returns, identity casts, `axiom` stand-ins, native-typed
+functions that detour through `Nat`/`Int`, `@[extern]` shims that
+trampoline back to a Lean fallback, alternative implementations
+with the wrong complexity. Every committed `def` ships with its
+intended-final implementation. See
 [design-principles.md §7](../SPEC/design-principles.md), the rule
 restated in [PLAN/Phase1.md](Phase1.md), and the bench-discovery
 rollback path in [SPEC/benchmarking.md](../SPEC/benchmarking.md).
+
+The word "scaffold" in this project refers to *adding a declaration
+to the Lean source*, not to filling that declaration with a stub. A
+scaffolded `def` is fully implemented; only its proofs may be
+`sorry`. Phrases like "Phase 1 scaffold returns <trivial>",
+"scaffold for the eventual <X> bridge", "honest placeholder", and
+"for now ..." are forbidden in committed code.
 
 ### PR workflow
 

--- a/PLAN/Phase1.md
+++ b/PLAN/Phase1.md
@@ -34,15 +34,31 @@ unless it explicitly fixes the public API or theorem split.
   correctly implements the SPEC contract for that declaration.
   There is no acceptable placeholder form:
   - NOT wrong-but-plausible bodies
-    (`def rref M := { rank := 0, echelon := M, transform := 1 }`),
-  - NOT `sorry` bodies (`noncomputable def rref ... := sorry`),
-  - NOT `axiom rref : ...`,
+    (`def rref M := { rank := 0, echelon := M, transform := 1 }`).
+  - NOT `sorry` bodies (`noncomputable def rref ... := sorry`).
+  - NOT `axiom rref : ...`.
   - NOT trivial returns (`Matrix.identity`, `none`, the input
-    unchanged, an identity cast),
+    unchanged, an identity cast).
   - NOT alternative implementations with the wrong algorithmic
-    complexity,
-  - NOT a body marked "honest placeholder" or "Phase 1 scaffold
-    returns <trivial>" in its docstring.
+    complexity. **In particular**: a function whose name or
+    signature promises a *native-typed* algorithm (`UInt64`,
+    `UInt32`, `Float`, `Fin n`, ...) but whose body is `f a.toNat
+    b.toNat` followed by `.ofNat` of the result is a wrong-shape
+    scaffold — it moves all the work into bignum `Nat` arithmetic,
+    which is the wrong asymptotic and the wrong algorithm. Native
+    type signatures must perform native arithmetic.
+  - NOT a body marked "honest placeholder", "Phase 1 scaffold
+    returns <trivial>", "scaffold for the eventual <X> bridge",
+    "for now", or any equivalent phrase in its docstring or
+    comments. Such phrases are meta-commentary about implementation
+    history, not documentation; their presence is itself the bug.
+  - NOT a fake `@[extern "name"]` whose C body delegates straight
+    back to the Lean fallback. An `@[extern]` whose only effect is
+    to call `l_Hex_*___boxed` (or otherwise re-enter the Lean
+    runtime to do the actual work) is not a valid extern boundary.
+    Either the C side does work native to C (calling GMP, CLMUL,
+    `__uint128_t`, etc.), or the `@[extern]` attribute and its C
+    file must not be committed yet.
 
   If you cannot implement the function correctly in this PR: **do
   not commit the declaration**. Leave it out of Lean entirely. The

--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -42,6 +42,24 @@ These are not rubber-stamp coverage audits — they ask:
   gives explicit update formulas. These are "wrong-shape" scaffolds
   and are forbidden by [PLAN/Phase1.md](Phase1.md), same remedy as
   wrong-output scaffolds: fix the body, or delete the declaration.
+- **For each `@[extern]` in the library, open its C body in
+  `HexFoo/ffi/<name>.c` and confirm it does work native to C.** A C
+  body that consists of (or reduces to) `return l_Hex_*___boxed(a,
+  b);` — i.e. a trampoline back to the Lean runtime — is a fake
+  extern. Remedy: delete the `@[extern]` attribute, delete the C
+  file, drop the `moreLinkArgs`/`moreLeancArgs` entry in the
+  lakefile, and open a follow-up issue for the real extern.
+- **For each declaration whose name or signature mentions a native
+  numeric type (`UInt64`, `UInt32`, `UInt8`, `Float`, `Fin n`,
+  ...), confirm the body uses native arithmetic on that type.** A
+  body that converts to `Nat`/`Int`, runs the Nat-level algorithm,
+  and converts back is a wrong-shape scaffold even when the
+  input/output contract is satisfied: the asymptotic complexity is
+  bignum, not the native single-word cost the type promises.
+- **Grep the library for the words `scaffold`, `for now`,
+  `eventual`, `placeholder`, `Phase 1`, `bridge for` in `*.lean`
+  and `ffi/*.c` files.** Every hit is a candidate violation; flag
+  in the review issue.
 
 ## Output
 

--- a/SPEC/SPEC.md
+++ b/SPEC/SPEC.md
@@ -42,6 +42,15 @@ implementation. For each approved extern, the corresponding library spec
 should state the intended contract, any fallback path, and any relevant
 platform assumptions.
 
+**Property all `@[extern]` declarations must satisfy.** The C body of
+every `@[extern]` declaration must do work that is not equivalent to
+calling its Lean fallback. An `@[extern]` shim whose only effect is to
+re-enter the Lean runtime — for example a `lean_hex_foo` whose body is
+`return l_Hex_pureFoo___boxed(a, b);` — is not a valid extern boundary.
+Until the C side performs work native to C (GMP call, CLMUL intrinsic,
+`__uint128_t` arithmetic, etc.), ship only the pure-Lean definition
+without `@[extern]`.
+
 ## Applications
 
 **Cryptographic field construction:** To build `GF(2^128)` for AES, you

--- a/progress/2026-04-28T07:56:48Z.md
+++ b/progress/2026-04-28T07:56:48Z.md
@@ -1,0 +1,62 @@
+**Accomplished**
+
+- Audited the failure of the autonomous pipeline that produced PR
+  #545's `HexArith.ExtGcd` work (issue #438), naming three classes
+  of doctrine violation that landed despite explicit existing rules:
+  native-typed defs detouring through `Nat`
+  ([HexArith/ExtGcd.lean:44](/home/kim/hex/HexArith/ExtGcd.lean#L44),
+  [HexArith/ExtGcd.lean:54](/home/kim/hex/HexArith/ExtGcd.lean#L54));
+  fake `@[extern]` whose C body trampolines back to Lean
+  ([HexArith/ffi/mpz_gcdext.c:11](/home/kim/hex/HexArith/ffi/mpz_gcdext.c#L11));
+  scaffold-vocabulary in shipped Lean docstrings (23 hits across
+  `Hex*/`).
+- Wrote and got user approval for the prompting fix plan at
+  `~/.claude/plans/well-first-we-need-golden-gizmo.md`. The
+  approved plan rejected mechanical CI lints, a universal PR-template
+  attestation, and an AGENTS.md onboarding reorder as too narrow,
+  too noisy, and over-prioritising a localised problem.
+- Branched off main as `prompting/named-by-example-failure-modes`
+  and made the four doctrine prose edits the plan calls for, all
+  against the same "named-by-example failure modes" theme:
+  - [PLAN/Phase1.md](/home/kim/hex/PLAN/Phase1.md) — extended the
+    forbidden-placeholder bullet list with three new named patterns
+    drawn directly from the audited PR (UInt-typed Nat-detour, fake
+    `@[extern]` trampoline, scaffold-narrating docstrings).
+  - [SPEC/SPEC.md](/home/kim/hex/SPEC/SPEC.md) — added a "Property
+    all `@[extern]` declarations must satisfy" paragraph forbidding
+    C bodies that re-enter the Lean runtime to do the actual work.
+  - [PLAN/Phase2.md](/home/kim/hex/PLAN/Phase2.md) — added three
+    reviewer checks (open every C body and confirm it does C-native
+    work; for every native-typed def, confirm native arithmetic;
+    grep the library for forbidden vocabulary).
+  - [PLAN/Conventions.md](/home/kim/hex/PLAN/Conventions.md) —
+    renamed "Scaffolding is for proofs only" to "Placeholders are
+    for proofs only"; added the explicit gloss that "scaffold" in
+    this project means *adding the declaration*, not stubbing it.
+- Confirmed via grep that no anchor-style cross-reference pointed at
+  the renamed section; the rename does not break any
+  `[link](#...)` in tracked files.
+
+**Current frontier**
+
+The four doctrine edits are committed locally on
+`prompting/named-by-example-failure-modes`, awaiting user approval
+to push and open the PR. The cleanup-issue track (B in the plan) is
+queued: 8 `human-oversight`-labelled GitHub issues to file (B.1
+through B.5, with B.4 split into one issue per affected library
+directory).
+
+**Next step**
+
+Get user approval, push the branch, open the PR with auto-merge per
+[PLAN/Conventions.md PR workflow](/home/kim/hex/PLAN/Conventions.md).
+Then create the `human-oversight` label if it does not already exist
+and file the eight cleanup issues with the bodies drafted in the
+plan file.
+
+**Blockers**
+
+None — both tracks are unblocked once the user authorises the
+GitHub-side actions (push, PR creation, issue creation), each of
+which is a "shared state" action requiring confirmation per
+~/.claude/CLAUDE.md.


### PR DESCRIPTION
## Summary

Three classes of doctrine violation shipped under issue #438 despite the doctrine in `PLAN/Phase1.md`, `SPEC/SPEC.md`, and `PLAN/Conventions.md` already forbidding them:

1. **`UInt64`-typed `def` with bignum body.** [`HexArith/ExtGcd.lean:44`](https://github.com/kim-em/hex/blob/main/HexArith/ExtGcd.lean#L44) `pureUInt64ExtGcd` is `let (g,s,t) := HexArith.extGcd a.toNat b.toNat ; (.ofNat g, s, t)` — UInt64 signature, bignum work.
2. **Fake `@[extern]`.** [`HexArith/ffi/mpz_gcdext.c:11`](https://github.com/kim-em/hex/blob/main/HexArith/ffi/mpz_gcdext.c#L11) is `return l_Hex_pureIntExtGcd___boxed(a, b);` — trampolines back to Lean.
3. **Scaffold-vocabulary in shipped docstrings.** 23 hits across `Hex*/` for `scaffold` / `for now` / `eventual` / `Phase N`.

The fix is to restate each existing rule with the specific failure shape **named by example**, so future agents reading the prose at session start cannot mistake their own stub code for "Phase 1 scaffolding" the way the previous round did. The doctrine is correct; the previous formulation was just abstract enough to be ignored under context pressure.

- `PLAN/Phase1.md`: extended the forbidden-placeholder bullet list with the UInt-typed Nat-detour pattern, the scaffold-narrating-docstring pattern, and the trampoline-`@[extern]` pattern.
- `SPEC/SPEC.md`: added the property "the C body of every `@[extern]` must do work that is not equivalent to calling its Lean fallback."
- `PLAN/Phase2.md`: added three reviewer checks paralleling the new Phase 1 sins.
- `PLAN/Conventions.md`: renamed "Scaffolding is for proofs only" to "Placeholders are for proofs only" and added the gloss that "scaffold" means *adding a declaration*, not stubbing one.

CI lints, a universal PR-template attestation, and an AGENTS.md onboarding reorder were considered and rejected as too narrow / too noisy / over-prioritising a localised problem.

## Test plan

- [ ] `grep -RIn "Scaffolding is for proofs"` returns nothing in tracked files (the renamed header).
- [ ] `grep -RIn "Conventions.md#"` shows only `#rollback-is-a-normal-action` and `#bench-found-and-conformance-found-issues` references — no broken anchor links from the rename.
- [ ] Cleanup issues filed under the `human-oversight` label cite the new PLAN/Phase1.md bullets verbatim (issues B.1–B.5 per ~/.claude/plans/well-first-we-need-golden-gizmo.md).

🤖 Prepared with Claude Code