### PR TITLE
docs: remove scaffold vocabulary from HexPoly and HexPolyZ

### DIFF
--- a/HexPoly.lean
+++ b/HexPoly.lean
@@ -2,6 +2,6 @@ import HexPoly.Dense
 import HexPoly.Euclid
 import HexPoly.Operations
 
-/-! Dense polynomial scaffolding for the Hex project. The initial surface exposes the normalized
+/-! Dense polynomial support for the Hex project. The library exposes the normalized
 array-backed representation together with basic constructors, structural queries, arithmetic,
-Euclidean-algorithm helpers, and the Phase 1 CRT/content surface. -/
+Euclidean-algorithm helpers, and CRT/content operations. -/

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -3,7 +3,7 @@ import HexPoly.Dense
 /-!
 Executable arithmetic operations for dense array-backed polynomials.
 
-This module adds the Phase 1 algebra surface for `DensePoly`: addition,
+This module implements executable `DensePoly` operations: addition,
 subtraction, schoolbook multiplication, Horner evaluation, composition,
 and derivative. All constructors route through `ofCoeffs`, so results are
 re-normalized automatically.

--- a/HexPolyZ.lean
+++ b/HexPolyZ.lean
@@ -2,7 +2,7 @@ import HexPolyZ.Basic
 import HexPolyZ.Mignotte
 
 /-!
-The `HexPolyZ` library specializes the generic dense polynomial scaffold to
+The `HexPolyZ` library specializes the generic dense polynomial library to
 integer coefficients, exposing the `ZPoly` alias together with congruence,
 content, primitive-part, and conservative executable Mignotte-bound APIs used
 by the factoring pipeline.

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -3,9 +3,9 @@ import HexPoly
 /-!
 Core `ZPoly` definitions for `hex-poly-z`.
 
-This module specializes the generic dense-polynomial scaffold to integer
+This module specializes the generic dense-polynomial library to integer
 coefficients, adds the shared congruence predicate used by Hensel lifting,
-and exposes the content/primitive-part surface expected from the
+and exposes the content/primitive-part operations expected from the
 `hex-poly-z` root library.
 -/
 namespace Hex

--- a/progress/2026-04-28T08:12:36Z_08411c21.md
+++ b/progress/2026-04-28T08:12:36Z_08411c21.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed issue `#589` (`human-oversight`) and removed scaffold-oriented wording from the `HexPoly` and `HexPolyZ` root/module docstrings in [HexPoly.lean](/home/kim/hex/worktrees/08411c21/HexPoly.lean:5), [HexPoly/Operations.lean](/home/kim/hex/worktrees/08411c21/HexPoly/Operations.lean:6), [HexPolyZ.lean](/home/kim/hex/worktrees/08411c21/HexPolyZ.lean:5), and [HexPolyZ/Basic.lean](/home/kim/hex/worktrees/08411c21/HexPolyZ/Basic.lean:6).
+- Verified the touched files are free of the forbidden vocabulary with a direct `grep` over the cited targets.
+- Verified `lake build HexPoly HexPolyZ` succeeds on this branch.
+
+**Current frontier**
+
+- The issue body's verification command is stale on the current tree because the `HexPoly* HexPolyZ*` globs also include `HexPolyFp`, `HexPolyMathlib`, and `HexPolyZMathlib`, which still carry separate-scope vocabulary cleanup work.
+
+**Next step**
+
+- Commit the docstring cleanup and open the PR for `#589`, noting the stale verification command in the PR description or follow-up comment if needed.
+
+**Blockers**
+
+- None for landing the scoped cleanup itself.


### PR DESCRIPTION
Closes #589

Session: `08411c21-6b27-4c1b-8035-b02c3b6846f5`

76ed6af docs: remove scaffold vocabulary from HexPoly and HexPolyZ (progress/2026-04-28T08:12:36Z_08411c21.md)

🤖 Prepared with Claude Code