### PR TITLE
human-oversight: strip scaffold-vocabulary from HexMatrix docstrings and comments

### DIFF
--- a/HexMatrix.lean
+++ b/HexMatrix.lean
@@ -8,6 +8,6 @@ import HexMatrix.Conformance
 /-!
 The `HexMatrix` library exposes the dense matrix core used throughout the
 project's linear-algebra stack, including dense matrix operations,
-row-echelon scaffolding, determinant APIs, and the executable Bareiss
-determinant path over `Int`.
+row-echelon transforms, determinant APIs, and the executable Bareiss
+determinant algorithm over `Int`.
 -/

--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -1,7 +1,7 @@
 import HexMatrix.Determinant
 
 /-!
-Executable Bareiss determinant scaffolding for `hex-matrix`.
+Executable Bareiss determinant algorithm for `hex-matrix`.
 
 This module implements fraction-free Bareiss elimination over `Int` in two
 layers: a no-pivot recurrence that follows the standard exact-division update,

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -3,7 +3,7 @@ import Init.Grind.Ring.Field
 import HexMatrix.RowEchelon
 
 /-!
-Determinant scaffolding for `hex-matrix`.
+Determinant routines for `hex-matrix`.
 
 This module adds the generic Leibniz-formula determinant for dense square
 matrices together with the determinant behavior of the elementary row

--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -2,12 +2,13 @@ import Std
 import HexMatrix.RowEchelon
 
 /-!
-Executable RREF, row-span, and nullspace scaffolding for `hex-matrix`.
+Executable RREF, row-span, and nullspace routines for `hex-matrix`.
 
 This module implements a simple Gaussian-elimination-based `rref` routine over
 decidable fields, then exposes the row-span and nullspace APIs layered on top of
-the resulting echelon data. Correctness theorems are scaffolded for later proof
-work.
+the resulting echelon data. It also states the theorem surface connecting the
+computed data to the `IsRREF` contract and the derived span/nullspace
+characterizations.
 -/
 
 namespace Hex

--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -1,11 +1,11 @@
 import HexMatrix.Basic
 
 /-!
-Row operations and echelon-form scaffolding for `hex-matrix`.
+Row operations and echelon-form data for `hex-matrix`.
 
 This module adds executable row-operation helpers together with the pure data
-structures and API surface used by later row-reduction, span/nullspace, and
-determinant work.
+structures and contracts used by later row-reduction, span/nullspace, and
+determinant routines.
 -/
 
 namespace Hex

--- a/progress/2026-04-28T08:12:28Z_545e3d88.md
+++ b/progress/2026-04-28T08:12:28Z_545e3d88.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed issue `#587` (`human-oversight`) and removed forbidden scaffold-history vocabulary from the module docstrings in `HexMatrix.lean`, `HexMatrix/RowEchelon.lean`, `HexMatrix/RREF.lean`, `HexMatrix/Determinant.lean`, and `HexMatrix/Bareiss.lean`.
+- Audited the cited HexMatrix files while editing; the issue scope remained a docstring cleanup and did not require deleting declarations or opening a follow-up issue.
+- Verified the cleanup with a zero-match `rg` check for the forbidden vocabulary and `lake build HexMatrix`.
+
+**Current frontier**
+
+- The branch is ready to commit and publish for issue `#587`.
+
+**Next step**
+
+- Commit the docstring cleanup, push `agent/545e3d88`, and open the PR closing `#587`.
+
+**Blockers**
+
+- The optional `second-opinion` wrapper did not return output during this session, so no external review notes were incorporated.


### PR DESCRIPTION
Closes #587

Session: `545e3d88-ca1b-4272-8773-484deae70c83`

1cc8e0d docs: remove scaffold vocabulary from HexMatrix

🤖 Prepared with Claude Code