### PR TITLE
docs: remove remaining scaffold-vocabulary docstrings

### DIFF
--- a/HexGramSchmidt/Basic.lean
+++ b/HexGramSchmidt/Basic.lean
@@ -3,10 +3,11 @@ import HexMatrix.Basic
 /-!
 Core Gram-Schmidt basis and coefficient definitions for `hex-gram-schmidt`.
 
-This module provides the initial executable basis/coefficient surface over
-the dense `Hex.Matrix` representation. Integer inputs are cast to rationals
-before applying Gram-Schmidt; rational inputs operate directly on the ambient
-matrix. The structural theorem API is scaffolded here for later proof work.
+This module provides executable Gram-Schmidt basis and coefficient
+constructions over the dense `Hex.Matrix` representation. Integer inputs are
+cast to rationals before applying Gram-Schmidt; rational inputs operate
+directly on the ambient matrix. It also states the structural theorems used by
+downstream lattice and reduction code.
 -/
 namespace Hex
 

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -2,7 +2,7 @@ import HexGramSchmidt
 import HexMatrix
 
 /-!
-Core LLL predicates and integer state scaffolding for `hex-lll`.
+Core LLL predicates and integer state for `hex-lll`.
 
 This module introduces the executable lattice-membership and independence
 predicates used by the LLL library together with the `δ`-reducedness contract

--- a/HexMatrixMathlib.lean
+++ b/HexMatrixMathlib.lean
@@ -6,9 +6,9 @@ import HexMatrixMathlib.RankSpanNullspace
 The `HexMatrixMathlib` library bridges the executable `HexMatrix` core to
 Mathlib's matrix API and linear-algebra definitions.
 
-The initial Phase 1 surface exposes the concrete equivalence between the two
-matrix representations and the row-operation lemmas relating our executable
+This library exposes the concrete equivalence between the two matrix
+representations and the row-operation lemmas relating our executable
 `rowSwap`, `rowScale`, and `rowAdd` helpers to Mathlib's standard elementary
 matrix operations, the determinant comparison theorem, and the
-rank/span/nullspace bridge theorems for the row-reduction surface.
+rank/span/nullspace bridge theorems for row reduction.
 -/

--- a/HexMatrixMathlib/RankSpanNullspace.lean
+++ b/HexMatrixMathlib/RankSpanNullspace.lean
@@ -6,9 +6,9 @@ import Mathlib.LinearAlgebra.Matrix.Rank
 /-!
 Rank, row-span, and nullspace bridge theorems for `hex-matrix-mathlib`.
 
-This module converts the executable `Hex.Matrix` row-reduction surface into
-Mathlib's function-based matrix model, then states the Phase 1 bridge theorems
-relating computed rank, span membership, and nullspace bases to Mathlib's
+This module converts the executable `Hex.Matrix` row-reduction data into
+Mathlib's function-based matrix model, then states bridge theorems relating
+computed rank, span membership, and nullspace bases to Mathlib's
 noncomputable linear-algebra definitions.
 -/
 

--- a/HexPolyMathlib.lean
+++ b/HexPolyMathlib.lean
@@ -4,7 +4,7 @@ import HexPolyMathlib.Basic
 The `HexPolyMathlib` library bridges the executable `HexPoly` core to
 Mathlib's `Polynomial` API.
 
-The initial Phase 1 surface exposes the concrete conversion functions between
+This library exposes the concrete conversion functions between
 `Hex.DensePoly` and `Polynomial`, together with the ring equivalence used by
 downstream Mathlib-facing polynomial libraries.
 -/

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -7,8 +7,8 @@ import HexPoly
 Bridge definitions between the executable `Hex.DensePoly` representation and
 Mathlib's `Polynomial`.
 
-This Phase 1 module provides the concrete conversion functions and the ring
-equivalence used by downstream proof-transfer libraries.
+This module provides the concrete conversion functions and ring equivalence
+used by downstream proof-transfer libraries.
 -/
 
 open scoped BigOperators

--- a/progress/2026-04-28T08:20:03Z_fa5e4d61.md
+++ b/progress/2026-04-28T08:20:03Z_fa5e4d61.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed issue `#593` (`human-oversight`) and rewrote the cited docstrings in `HexLLL`, `HexPolyMathlib`, `HexMatrixMathlib`, and `HexGramSchmidt` to describe their concrete APIs without scaffold/phase vocabulary.
+- Verified the issue grep over `HexLLL*`, `HexPolyMathlib*`, `HexMatrixMathlib*`, and `HexGramSchmidt*` returns empty for the forbidden terms.
+- Verified `lake build HexLLL HexPolyMathlib HexMatrixMathlib HexGramSchmidt` succeeds on this branch.
+
+**Current frontier**
+
+- The branch is ready to package as the `#593` cleanup PR; no code-level follow-up surfaced from this docstring-only pass.
+
+**Next step**
+
+- Commit the docstring cleanup with this progress note and open the PR closing `#593`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #593

Session: `fa5e4d61-678c-42ee-8db0-1c1c0083e1a9`

982c733 docs: remove remaining scaffold-vocabulary docstrings

🤖 Prepared with Claude Code