### PR TITLE
fix: repair HexArith mpz_gcdext fallback symbol

### DIFF
--- a/HexArith/ffi/mpz_gcdext.c
+++ b/HexArith/ffi/mpz_gcdext.c
@@ -1,6 +1,6 @@
 #include <lean/lean.h>
 
-LEAN_EXPORT lean_object* lp_Hex_Hex_pureIntExtGcd___boxed(lean_object*, lean_object*);
+LEAN_EXPORT lean_obj_res lp_Hex_Hex_pureIntExtGcd(b_lean_obj_arg, b_lean_obj_arg);
 
 LEAN_EXPORT lean_obj_res lean_hex_mpz_gcdext(b_lean_obj_arg a, b_lean_obj_arg b) {
     /*
@@ -8,5 +8,5 @@ LEAN_EXPORT lean_obj_res lean_hex_mpz_gcdext(b_lean_obj_arg a, b_lean_obj_arg b)
     For now, keep runtime behavior aligned with the logical Lean model by
     delegating to the pure reference implementation.
     */
-    return lp_Hex_Hex_pureIntExtGcd___boxed(a, b);
+    return lp_Hex_Hex_pureIntExtGcd(a, b);
 }

--- a/progress/2026-04-28T09:03:48Z_c37f8596.md
+++ b/progress/2026-04-28T09:03:48Z_c37f8596.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed `#616` after confirming the `human-oversight` predecessor `#561` was in `replan` and no longer claimable.
+- Reproduced the current `HexArith` extern-loading behavior: `lake build HexArith` succeeds, but plain `lake env lean /tmp/test_extern.lean` still reports missing native implementations for `UInt64.mulHi`, `UInt64.addCarry`, and `HexArith.Int.extGcd`.
+- Fixed [HexArith/ffi/mpz_gcdext.c](/home/kim/hex/worktrees/c37f8596/HexArith/ffi/mpz_gcdext.c:1) so the fallback shim calls the exported `lp_Hex_Hex_pureIntExtGcd` symbol instead of the nonexistent boxed helper.
+- Verified the repaired shim by rebuilding `HexArith` and running the explicit-load smoke test successfully:
+  `lake env lean --load-dynlib=.lake/build/lib/lean/Hex_HexArith_UInt64_Wide.so --load-dynlib=.lake/build/lib/lean/Hex_HexArith_ExtGcd.so /tmp/test_extern.lean`
+- Created follow-up issue `#624` for the remaining plain-CLI autoload problem, with Lean/Lake source-level diagnosis and next-step options.
+
+**Current frontier**
+
+- The concrete `mpz_gcdext` fallback symbol bug is fixed, but the original `#616` smoke test still fails unchanged because ad hoc `lake env lean` invocations do not receive Lake's module dynlib/plugin graph.
+
+**Next step**
+
+- Publish the `mpz_gcdext` shim repair as a partial completion of `#616`, linked to `#624` for the unresolved autoload strategy work.
+
+**Blockers**
+
+- Plain `lake env lean <external-file>` appears limited by Lean/Lake import setup rather than by local `HexArith` build wiring: `Lean.importModules` loads extra dynlibs/plugins only when they are passed in the top-level setup, which plain CLI invocation does not do for workspace module dynlibs.


### PR DESCRIPTION
Partial progress on #616

Session: `c37f8596-c39e-468e-80c5-c9ebf243722d`

29a6f07 fix: repair HexArith mpz_gcdext fallback symbol

🤖 Prepared with Claude Code