### PR TITLE
feat: move ZPoly congruence helpers to HexPolyZ

### DIFF
--- a/HexHensel/Basic.lean
+++ b/HexHensel/Basic.lean
@@ -45,18 +45,6 @@ theorem congr_reduceModPow_of_congr (f g : ZPoly) (p k : Nat)
     reduceModPow f p k = reduceModPow g p k := by
   sorry
 
-theorem congr_add (f g f' g' : ZPoly) (m : Nat)
-    (hf : congr f f' m) (hg : congr g g' m) :
-    congr (f + g) (f' + g') m := by
-  intro i
-  sorry
-
-theorem congr_mul (f g f' g' : ZPoly) (m : Nat)
-    (hf : congr f f' m) (hg : congr g g' m) :
-    congr (f * g) (f' * g') m := by
-  intro i
-  sorry
-
 end ZPoly
 
 namespace FpPoly

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -48,6 +48,18 @@ theorem congr_trans (f g h : ZPoly) (m : Nat) (hfg : congr f g m) (hgh : congr g
     congr f h m := by
   sorry
 
+theorem congr_add (f g f' g' : ZPoly) (m : Nat)
+    (hf : congr f f' m) (hg : congr g g' m) :
+    congr (f + g) (f' + g') m := by
+  intro i
+  sorry
+
+theorem congr_mul (f g f' g' : ZPoly) (m : Nat)
+    (hf : congr f f' m) (hg : congr g g' m) :
+    congr (f * g) (f' * g') m := by
+  intro i
+  sorry
+
 theorem content_mul_primitivePart (f : ZPoly) :
     DensePoly.scale (content f) (primitivePart f) = f := by
   simpa [content, primitivePart] using DensePoly.content_mul_primitivePart f

--- a/progress/2026-04-28T09:25:19Z_74e6b20b.md
+++ b/progress/2026-04-28T09:25:19Z_74e6b20b.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Checked the `work` queue, attempted the highest-priority `human-oversight` items, and confirmed `#561` and `#583` were both already in `replan` state and unclaimable.
+- Claimed `#626`, verified that it was stale because PR `#625` had already been closed as unsalvageable and its remaining scope moved to `#616`, then released it with a concrete skip reason.
+- Claimed `#632` and moved the shared `ZPoly.congr_add` / `ZPoly.congr_mul` helper surface into `HexPolyZ/Basic.lean`, removing the duplicate downstream definitions from `HexHensel/Basic.lean`.
+- Verified the narrow API move with `lake build HexPolyZ HexHensel`, `python3 scripts/check_dag.py`, and `rg -n "theorem congr_add|theorem congr_mul" HexPolyZ HexHensel`.
+
+**Current frontier**
+
+- `HexPolyZ` now owns the additive and multiplicative congruence-preservation lemmas for `ZPoly.congr`, and `HexHensel` consumes that root-library surface instead of redefining it locally.
+
+**Next step**
+
+- Commit the `#632` congruence-helper move with this progress note and open the PR closing `#632`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #632

Session: `74e6b20b-eed4-44bc-ac40-1f52d3ddcbf3`

b54c948 feat: move ZPoly congruence helpers to HexPolyZ (#632, progress 2026-04-28T09:25:19Z_74e6b20b)

🤖 Prepared with Claude Code