### PR TITLE
fix: require prime contract for HexPolyFp square-free API

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1,12 +1,15 @@
+import HexModArith.Prime
 import HexPolyFp.Basic
 
 /-!
 Executable square-free decomposition for `F_p[x]`.
 
-This module adds a Yun-style square-free decomposition scaffold for
+This module adds a Yun-style square-free decomposition for
 `Hex.FpPoly p`, recording the unit factor and the positive-multiplicity
 square-free factors obtained from repeated gcd/derivative steps and
-`p`-th-root descent in characteristic `p`.
+`p`-th-root descent in characteristic `p`. The public API carries an
+explicit `Nat.Prime p` contract because the exported factorization and
+square-free theorems are intended for prime-field coefficients.
 -/
 namespace Hex
 
@@ -112,25 +115,26 @@ private def squareFreeAux (f : FpPoly p) (multiplicity : Nat) :
 Compute a square-free decomposition by normalizing away the leading scalar and
 running Yun's algorithm on the resulting monic polynomial.
 -/
-def squareFreeDecomposition (f : FpPoly p) : SquareFreeDecomposition p :=
+def squareFreeDecomposition (hp : Nat.Prime p) (f : FpPoly p) : SquareFreeDecomposition p :=
+  let _ := hp
   let normalized := normalizeMonic f
   let unit := normalized.1
   let monicPart := normalized.2
   let factors := squareFreeAux monicPart 1 (monicPart.size + 1)
   { unit, factors }
 
-theorem squareFree_pairwise_coprime (f : FpPoly p) :
-    let d := squareFreeDecomposition f
+theorem squareFree_pairwise_coprime (hp : Nat.Prime p) (f : FpPoly p) :
+    let d := squareFreeDecomposition hp f
     d.factors.Pairwise (fun a b => DensePoly.gcd a.factor b.factor = 1) := by
   sorry
 
-theorem squareFree_weightedProduct (f : FpPoly p) :
-    let d := squareFreeDecomposition f
+theorem squareFree_weightedProduct (hp : Nat.Prime p) (f : FpPoly p) :
+    let d := squareFreeDecomposition hp f
     DensePoly.C d.unit * weightedProduct d.factors = f := by
   sorry
 
-theorem squareFree_factors_squareFree (f : FpPoly p) :
-    let d := squareFreeDecomposition f
+theorem squareFree_factors_squareFree (hp : Nat.Prime p) (f : FpPoly p) :
+    let d := squareFreeDecomposition hp f
     ∀ sf ∈ d.factors, DensePoly.gcd sf.factor (DensePoly.derivative sf.factor) = 1 := by
   sorry
 

--- a/progress/2026-04-28T10:42:53Z_10922fb7.md
+++ b/progress/2026-04-28T10:42:53Z_10922fb7.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed feature issue `#680` and audited `HexPolyFp/SquareFree.lean` against the reported Phase 2 review gap from `#674`.
+- Tightened the exported square-free API so `squareFreeDecomposition` and its public theorem surface now require an explicit `hp : Nat.Prime p`, matching the intended `F_p[x]` contract instead of advertising field-level properties for arbitrary bounded moduli.
+- Added the required `HexModArith.Prime` import and refreshed the module docstring so the prime-field contract is stated at the API boundary.
+- Verified the change with `lake build HexPolyFp` and `python3 scripts/check_dag.py`.
+
+**Current frontier**
+
+- The issue fix is implemented and verified locally; the branch is ready to commit and publish as the closing PR for `#680`.
+
+**Next step**
+
+- Commit `HexPolyFp/SquareFree.lean` together with this progress note and create the feature PR closing `#680`.
+- Let the blocked re-review issue `#687` proceed once this PR lands.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #680

Session: `10922fb7-e3e0-46fe-8ea6-5b8ee3e1cf06`

089bccd fix: require prime contract for HexPolyFp square-free API

🤖 Prepared with Claude Code