### PR TITLE
fix: remove scaffold vocabulary from HexGfqField docstring

### DIFF
--- a/HexGfqField.lean
+++ b/HexGfqField.lean
@@ -2,7 +2,7 @@ import HexGfqField.Basic
 import HexGfqField.Operations
 
 /-!
-Thin finite-field wrapper scaffolding for executable `F_p[x] / (f)`.
+Thin finite-field wrapper for executable `F_p[x] / (f)`.
 
 `HexGfqField` reuses the quotient-ring representation from `HexGfqRing`
 unchanged: `GFqField.FiniteField` is just a wrapper around reduced residues,

--- a/progress/2026-04-28T10:46:10Z_5c123bed.md
+++ b/progress/2026-04-28T10:46:10Z_5c123bed.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed review issue `#670`, audited `HexGfqField` against `SPEC/Libraries/hex-gfq-field.md` and `PLAN/Phase1.md`, and verified the wrapper, quotient conversions, inversion/division path, Frobenius layer, and `Lean.Grind.Field` / `IsCharP` instances are present with `lake build HexGfqField` succeeding.
+- Identified the remaining Phase 1 blocker as exported scaffold vocabulary in [HexGfqField.lean](/home/kim/hex/worktrees/5c123bed/HexGfqField.lean:5), created follow-up issue `#692`, and released `#670` for replan.
+- Claimed `#692`, removed the prohibited scaffold wording from the exported `HexGfqField` module docstring, verified the grep gate is clean, and rebuilt `HexGfqField`.
+
+**Current frontier**
+
+- The narrow docstring fix for `HexGfqField` is ready to commit and publish as the targeted follow-up for the broader Phase 1 review.
+
+**Next step**
+
+- Commit the `HexGfqField.lean` docstring edit together with this progress note and open the PR closing `#692`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #692

Session: `5c123bed-7ef8-4325-a06f-2fcbf85f7519`

f954bd4 fix: clean HexGfqField docstring for issue 692

🤖 Prepared with Claude Code