### PR TITLE
fix: route UInt64 extGcd through Int runtime path

### DIFF
--- a/HexArith/ExtGcd.lean
+++ b/HexArith/ExtGcd.lean
@@ -163,7 +163,8 @@ namespace UInt64
 
 /-- Public `UInt64` extended GCD API surface. -/
 def extGcd (a b : UInt64) : UInt64 × Int × Int :=
-  Hex.pureUInt64ExtGcd a b
+  let (g, s, t) := HexArith.Int.extGcd (Int.ofNat a.toNat) (Int.ofNat b.toNat)
+  (UInt64.ofNat g, s, t)
 
 theorem extGcd_fst (a b : UInt64) :
     (extGcd a b).1.toNat = Nat.gcd a.toNat b.toNat := by

--- a/progress/2026-04-28T10:48:31Z_f0e2f5f9.md
+++ b/progress/2026-04-28T10:48:31Z_f0e2f5f9.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed feature issue `#693` and updated `HexArith.UInt64.extGcd` in `HexArith/ExtGcd.lean` to delegate through `HexArith.Int.extGcd`, repackaging only the returned gcd into `UInt64`.
+- Verified the body shape with `rg` so the public `UInt64` API no longer calls `Hex.pureUInt64ExtGcd`.
+- Rebuilt `HexArith` successfully with `lake build HexArith`.
+
+**Current frontier**
+
+- The targeted `UInt64.extGcd` runtime-path fix is ready to commit and publish as the issue-closing PR.
+
+**Next step**
+
+- Commit `HexArith/ExtGcd.lean` together with this progress note and open the PR closing `#693`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #693

Session: `f0e2f5f9-e500-4c05-9828-6ef0b97d42ef`

05287eb fix: route UInt64 extGcd via Int runtime path (progress/2026-04-28T10:48:31Z_f0e2f5f9.md)

🤖 Prepared with Claude Code