### PR TITLE
spec: add Mignotte complexity contract to hex-poly-z

### DIFF
--- a/SPEC/Libraries/hex-poly-z.md
+++ b/SPEC/Libraries/hex-poly-z.md
@@ -16,6 +16,28 @@ Specialized polynomial arithmetic over `Z`.
   factor `g | f` in `Z[x]`. The computation is just binomial coefficients
   and the 2-norm of `f`'s coefficients. The proof that the bound is valid
   lives in `hex-poly-z-mathlib`.
+
+  **Complexity contract for the Mignotte computation.** Both bodies
+  must be polynomial in their inputs:
+
+  - `binom n k` uses the multiplicative formula
+    `(∏ i<k, (n − i)) / k!` and runs in `O(k)` `Nat` multiplications.
+    The Pascal-triangle recursion `binom (n+1) (k+1) = binom n k +
+    binom n (k+1)` is forbidden as the executable body — without
+    memoisation it takes `Θ(2^k)` calls and a Mignotte computation
+    over a degree-50 factor cannot terminate.
+  - `floorSqrt n` runs in `O(log n)` iterations via Newton's method
+    `x ← (x + n / x) / 2` (or bit-by-bit binary search). Descending
+    linear search is forbidden: `coeffNormSq f` for any non-trivial
+    `ZPoly` is at least `2^40`, and a linear-time `floorSqrt` makes
+    `coeffNorm f` non-terminating in practice.
+
+  Both prohibitions are instances of [PLAN/Phase1.md](../../PLAN/Phase1.md)'s
+  general "no alternative implementations with the wrong algorithmic
+  complexity" rule; they are spelt out here because the SPEC's
+  one-line description "binomial coefficients and the 2-norm" is
+  satisfied by both correct and wrong-complexity bodies.
+
 **Key properties:**
 - `primitivePart(f)` is primitive (content = 1)
 - Gauss's lemma (`content(f * g) = content(f) * content(g)`) is not


### PR DESCRIPTION
## Summary

Adds an explicit complexity contract to the Mignotte bullet of
`SPEC/Libraries/hex-poly-z.md`:

- `binom n k` must use the multiplicative formula in `O(k)` `Nat`
  multiplications. Pascal's-triangle recursion is forbidden as the
  executable body (without memoisation, it's `Θ(2^k)` calls).
- `floorSqrt n` must run in `O(log n)` iterations via Newton's
  method or bit-by-bit binary search. Descending linear scan is
  forbidden.

Both bodies as currently committed in `HexPolyZ/Mignotte.lean`
violate the spirit of [PLAN/Phase1.md](https://github.com/kim-em/hex/blob/main/PLAN/Phase1.md)
("no alternative implementations with the wrong algorithmic
complexity"), but the SPEC's single-line description (\"binomial
coefficients and the 2-norm of f's coefficients\") was satisfied by
both. This PR closes that gap so future scaffolders can't make the
same choice.

The repair PRs for the already-landed bodies will be filed as
separate `human-oversight` issues with `depends-on: #PR-this`.

## Scope of autonomous SPEC edits

Per [SPEC/design-principles.md §7](https://github.com/kim-em/hex/blob/main/SPEC/design-principles.md):
the constraint already exists in spirit in `PLAN/Phase1.md`. This PR
spells out the per-function consequences inside the Mignotte bullet
so they're discoverable to scaffolders. No public API contract or
release goal is changed.

## Test plan

- [ ] `python3 scripts/check_dag.py` passes (DAG unchanged).
- [ ] Manual reading: the new sub-bullet doesn't introduce a new
      Lean declaration (it's a complexity constraint on existing
      ones).

🤖 Prepared with Claude Code