### PR TITLE
plan: add complexity and alias review questions to Phase 2

### DIFF
--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -60,6 +60,29 @@ These are not rubber-stamp coverage audits — they ask:
   `eventual`, `placeholder`, `Phase 1`, `bridge for` in `*.lean`
   and `ffi/*.c` files.** Every hit is a candidate violation; flag
   in the review issue.
+- **Does each data-level `def` body match the SPEC's stated
+  asymptotic complexity, not just its input/output?** [PLAN/Phase1.md](Phase1.md)
+  forbids "alternative implementations with the wrong algorithmic
+  complexity"; this question makes the rule enforceable at review
+  time. Flag bodies that produce the right output via an
+  asymptotically worse algorithm: descending linear search where
+  the SPEC implies binary search or Newton iteration; Pascal-triangle
+  recursion where the SPEC implies the multiplicative formula;
+  full-precision exponentiation `a ^ n % p` where the SPEC implies
+  square-and-multiply; rebuild-from-scratch where the SPEC implies
+  an in-place update. Same remedy as wrong-shape scaffolds: fix the
+  body, or delete the declaration.
+- **Are there one-line aliases of an adjacent declaration, lemmas
+  duplicating Lean core, or names that misrepresent the body?**
+  Flag any `def`/`theorem` whose body is `exact <other-decl>` for
+  an `<other-decl>` defined in the same file (it should be deleted
+  and call sites pointed at the real declaration). Flag any local
+  `Nat`/`Int`/`UInt64`/`Array`/`List` lemma whose statement
+  matches a same-shape declaration in `Init.*` or the Lean stdlib
+  (it should be deleted and call sites pointed at the core lemma).
+  Flag any name whose verb or qualifier doesn't appear anywhere in
+  the body (e.g. a lemma named `foo_sub_bar` whose statement
+  contains no subtraction).
 
 ## Output
 


### PR DESCRIPTION
## Summary

Adds two new review questions to the Phase 2 scaffolding-review
checklist, both prompted by patterns that landed in Phase 1 and were
not caught by existing reviews:

1. **\"Does each data-level def body match the SPEC's stated
   asymptotic complexity, not just its input/output?\"** Concrete
   examples: descending linear search where Newton iteration was
   intended; Pascal-triangle recursion where the multiplicative
   formula was intended; full-precision \`a ^ n % p\` where
   square-and-multiply was intended.

2. **\"Are there one-line aliases of an adjacent declaration, lemmas
   duplicating Lean core, or names that misrepresent the body?\"**
   Concrete examples: a \`def\` whose body is \`exact <other-decl>\`
   for an \`<other-decl>\` three lines above; a local lemma whose
   statement matches a same-shape declaration in \`Init.*\`; a name
   whose verb doesn't appear in the body.

Both questions parallel the existing \"wrong-shape scaffold\" and
\"fake extern\" questions: they describe classes of body that
type-check and dispatch correctly but are wrong in ways no compile-
time check would catch.

The existing Phase 2 reviews for hex-arith
(\`status/hex-arith.scaffolding-reviewed\`) and hex-poly-z
(\`status/hex-poly-z.scaffolding-reviewed\`) signed off without
flagging the underlying patterns. Repair PRs for the already-landed
violations are filed as separate \`human-oversight\` issues.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: each new bullet is a question, not a directive,
      matching the file's \"Review questions\" section style.

🤖 Prepared with Claude Code