### PR TITLE
Add UInt64.mulFull helper and FFI shim in HexArith/UInt64/Wide.lean

### DIFF
--- a/HexArith/UInt64/Wide.lean
+++ b/HexArith/UInt64/Wide.lean
@@ -1,10 +1,10 @@
 /-!
 Wide-word helper operations for `UInt64`.
 
-This module provides the executable logical definitions of the high half of a
-`UInt64 × UInt64` product together with add-with-carry and subtract-with-borrow
-operations. Later Barrett and Montgomery reductions use these operations as the
-only interface to machine-word overflow behavior.
+This module provides the executable logical definitions of fused and projected
+`UInt64 × UInt64` products together with add-with-carry and
+subtract-with-borrow operations. Later Barrett and Montgomery reductions use
+these operations as the only interface to machine-word overflow behavior.
 -/
 namespace UInt64
 
@@ -15,6 +15,12 @@ def word : Nat := 2 ^ 64
 @[extern "lean_hex_uint64_mul_hi"]
 def mulHi (a b : UInt64) : UInt64 :=
   .ofNat (a.toNat * b.toNat / word)
+
+/-- The full `UInt64 × UInt64` product, split into high and low radix-`2^64` words. -/
+@[extern "lean_hex_uint64_mul_full"]
+def mulFull (a b : UInt64) : UInt64 × UInt64 :=
+  let p := a.toNat * b.toNat
+  (.ofNat (p / word), .ofNat p)
 
 /--
 Add `a`, `b`, and an incoming carry bit, returning the wrapped low word and the
@@ -40,6 +46,13 @@ def subBorrow (a b : UInt64) (bin : Bool) : UInt64 × Bool :=
 /-- `mulHi` agrees with Nat-level division by `2^64`. -/
 theorem toNat_mulHi (a b : UInt64) :
     (mulHi a b).toNat = a.toNat * b.toNat / word := by
+  sorry
+
+/-- `mulFull` agrees with Nat-level division and remainder by `2^64`. -/
+theorem toNat_mulFull (a b : UInt64) :
+    let (hi, lo) := mulFull a b
+    hi.toNat = a.toNat * b.toNat / word ∧
+    lo.toNat = a.toNat * b.toNat % word := by
   sorry
 
 /--

--- a/HexArith/ffi/wide_arith.c
+++ b/HexArith/ffi/wide_arith.c
@@ -5,6 +5,14 @@ LEAN_EXPORT uint64_t lean_hex_uint64_mul_hi(uint64_t a, uint64_t b) {
     return (uint64_t)(((__uint128_t)a * (__uint128_t)b) >> 64);
 }
 
+LEAN_EXPORT lean_obj_res lean_hex_uint64_mul_full(uint64_t a, uint64_t b) {
+    __uint128_t p = (__uint128_t)a * (__uint128_t)b;
+    lean_object* pair = lean_alloc_ctor(0, 2, 0);
+    lean_ctor_set(pair, 0, lean_box_uint64((uint64_t)(p >> 64)));
+    lean_ctor_set(pair, 1, lean_box_uint64((uint64_t)p));
+    return pair;
+}
+
 LEAN_EXPORT lean_obj_res lean_hex_uint64_add_carry(uint64_t a, uint64_t b, uint8_t cin) {
     uint64_t sum;
     uint64_t total;

--- a/progress/2026-04-28T11:54:09Z_00f9679d.md
+++ b/progress/2026-04-28T11:54:09Z_00f9679d.md
@@ -1,0 +1,17 @@
+**Accomplished**
+
+- Claimed human-oversight feature issue `#725` and added `UInt64.mulFull` to [HexArith/UInt64/Wide.lean](/home/kim/hex/worktrees/00f9679d/HexArith/UInt64/Wide.lean) with its companion `toNat_mulFull` statement.
+- Added the `lean_hex_uint64_mul_full` extern implementation to [HexArith/ffi/wide_arith.c](/home/kim/hex/worktrees/00f9679d/HexArith/ffi/wide_arith.c), following the existing pair-returning FFI pattern.
+- Verified the slice with `lake build HexArith`, `cc -Wall -Wextra -I"$(lean --print-prefix)/include" -c HexArith/ffi/wide_arith.c`, `python3 scripts/check_dag.py`, and an interpreter smoke check using `lake env lean --load-dynlib=.lake/build/lib/lean/Hex_HexArith_UInt64_Wide.so` for `#eval UInt64.mulFull (UInt64.ofNat (2^63)) 4`.
+
+**Current frontier**
+
+- Issue `#725` is implementation-complete and ready to publish as the dependency-unlocking precursor for the `Montgomery/Redc.lean` consumer rewrite in `#726`.
+
+**Next step**
+
+- Commit the `mulFull` helper addition, push `agent/00f9679d`, and create the PR closing `#725`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #725

Session: `00f9679d-3b9a-45b1-aeb9-d03a1ad3dfd2`

6e6bc09 feat: add UInt64.mulFull helper

🤖 Prepared with Claude Code