### PR TITLE
Repair HexGF2/Field.lean: replace linear-time pow with square-and-multiply (GF2n + GF2nPoly)

### DIFF
--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -148,10 +148,20 @@ def mul (a b : GF2n n irr hn hn64 hirr) : GF2n n irr hn hn64 hirr :=
 instance : Mul (GF2n n irr hn hn64 hirr) where
   mul := mul
 
-/-- Natural power in `GF(2^n)` by repeated multiplication. -/
-def pow (a : GF2n n irr hn hn64 hirr) : Nat → GF2n n irr hn hn64 hirr
-  | 0 => 1
-  | exp + 1 => pow a exp * a
+/-- Natural power in `GF(2^n)` by repeated squaring. -/
+def pow (a : GF2n n irr hn hn64 hirr) (k : Nat) : GF2n n irr hn hn64 hirr :=
+  let rec go (acc base : GF2n n irr hn hn64 hirr) (k : Nat) : GF2n n irr hn hn64 hirr :=
+    if hk : k = 0 then
+      acc
+    else
+      let acc' := if k % 2 = 1 then acc * base else acc
+      let base' := base * base
+      go acc' base' (k / 2)
+  termination_by k
+  decreasing_by
+    simp_wf
+    exact Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide)
+  go 1 a k
 
 instance : Pow (GF2n n irr hn hn64 hirr) Nat where
   pow := pow
@@ -359,10 +369,20 @@ def mul (a b : GF2nPoly f hirr) : GF2nPoly f hirr :=
 instance : Mul (GF2nPoly f hirr) where
   mul := mul
 
-/-- Natural power in the packed quotient field by repeated multiplication. -/
-def pow (a : GF2nPoly f hirr) : Nat → GF2nPoly f hirr
-  | 0 => 1
-  | exp + 1 => pow a exp * a
+/-- Natural power in the packed quotient field by repeated squaring. -/
+def pow (a : GF2nPoly f hirr) (k : Nat) : GF2nPoly f hirr :=
+  let rec go (acc base : GF2nPoly f hirr) (k : Nat) : GF2nPoly f hirr :=
+    if hk : k = 0 then
+      acc
+    else
+      let acc' := if k % 2 = 1 then acc * base else acc
+      let base' := base * base
+      go acc' base' (k / 2)
+  termination_by k
+  decreasing_by
+    simp_wf
+    exact Nat.div_lt_self (Nat.pos_of_ne_zero hk) (by decide)
+  go 1 a k
 
 instance : Pow (GF2nPoly f hirr) Nat where
   pow := pow

--- a/progress/2026-04-28T12:05:06Z_ce2f2421.md
+++ b/progress/2026-04-28T12:05:06Z_ce2f2421.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed human-oversight issue `#743` and replaced the linear recursive `pow` implementations in `HexGF2/Field.lean` for both `GF2n` and `GF2nPoly` with square-and-multiply loops.
+- Updated the adjacent docstrings to describe repeated squaring while leaving the existing `Pow` instances wired to the revised definitions.
+- Verified the repair with `lake build HexGF2` and `python3 scripts/check_dag.py`.
+
+**Current frontier**
+
+- The issue work is complete and ready to commit and publish as a PR closing `#743`.
+- A direct large-exponent interpreter smoke check is still blocked in this environment because `lake env lean` cannot load the external `Hex.clmul` symbol, and plain `#eval` is additionally blocked by existing `sorry` dependencies in the field wrappers.
+
+**Next step**
+
+- Commit `HexGF2/Field.lean` together with this progress entry, push branch `agent/ce2f2421-v2`, and run `coordination create-pr 743`.
+
+**Blockers**
+
+- None for landing the repair; only the optional interpreter-only runtime probe is unavailable in this session environment.


### PR DESCRIPTION
Closes #743

Session: `ce2f2421-0bbe-423d-ba48-26ec0870d452`

7bbaad2 fix: optimize GF2 field exponentiation

🤖 Prepared with Claude Code