### PR TITLE
spec+plan: add canonical fast defaults for standard operations

### DIFF
--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -60,18 +60,26 @@ These are not rubber-stamp coverage audits — they ask:
   `eventual`, `placeholder`, `Phase 1`, `bridge for` in `*.lean`
   and `ffi/*.c` files.** Every hit is a candidate violation; flag
   in the review issue.
-- **Does each data-level `def` body match the SPEC's stated
-  asymptotic complexity, not just its input/output?** [PLAN/Phase1.md](Phase1.md)
-  forbids "alternative implementations with the wrong algorithmic
+- **Does each data-level `def` body match the canonical fast default
+  for its operation?** [PLAN/Phase1.md](Phase1.md) forbids
+  "alternative implementations with the wrong algorithmic
   complexity"; this question makes the rule enforceable at review
-  time. Flag bodies that produce the right output via an
-  asymptotically worse algorithm: descending linear search where
-  the SPEC implies binary search or Newton iteration; Pascal-triangle
-  recursion where the SPEC implies the multiplicative formula;
-  full-precision exponentiation `a ^ n % p` where the SPEC implies
-  square-and-multiply; rebuild-from-scratch where the SPEC implies
-  an in-place update. Same remedy as wrong-shape scaffolds: fix the
-  body, or delete the declaration.
+  time. The acceptable bodies for standard mathematical operations
+  are listed in [SPEC/design-principles.md §7
+  "Canonical fast defaults"](../SPEC/design-principles.md). Flag any
+  body whose row in that table is the *forbidden* column: linear-time
+  `pow` in a ring/field, `a^n % p` modular exponentiation, descending
+  linear-scan `floorSqrt`, unmemoised Pascal `binom`, `Nat.rec` over
+  `n` for `nsmul` / `natCast`, `toNat`/`ofNat` round-trip in a
+  `UInt64`-typed operation, rebuild-from-scratch where the SPEC
+  prescribes an in-place update. The table is binding even when the
+  per-library SPEC says only "exponentiation" / "binomial coefficient"
+  / etc. without naming an algorithm. Same remedy as wrong-shape
+  scaffolds: fix the body, or delete the declaration. If a body's
+  operation isn't in the design-principles table and the per-library
+  SPEC doesn't constrain complexity, ask whether a textbook would
+  call the body "the standard fast algorithm" for that operation; if
+  not, flag it.
 - **Are there one-line aliases of an adjacent declaration, lemmas
   duplicating Lean core, or names that misrepresent the body?**
   Flag any `def`/`theorem` whose body is `exact <other-decl>` for

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -48,6 +48,43 @@
    roll back the affected library's `done_through` and re-enter the
    relevant phase, not to weaken the benchmark.
 
+   **Canonical fast defaults for standard operations.** A SPEC that
+   says only "exponentiation", "binomial coefficient", or
+   "square root" without naming an algorithm does NOT license the
+   textbook-recursive body. Scaffolders default to the canonical fast
+   algorithm for the operation, even when the SPEC is silent. The
+   table below lists the defaults that have already cost reviewer
+   time on this project; it is not exhaustive but is binding for the
+   listed operations.
+
+   | Operation                                                              | Canonical fast default                         | Forbidden naive shape                                                |
+   | ---------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
+   | `pow x n` in any monoid / group / ring / field                         | square-and-multiply, `O(log n)` ops            | `pow x (n+1) = mul (pow x n) x` (or any linear-time accumulator)     |
+   | Modular exponentiation `a^n mod p` at `Nat`                            | square-and-multiply, reducing after each mul   | `a^n % p` (full-precision exponent before reducing)                  |
+   | Frobenius `frob(a) = a^p` in `F_p[x]/(f)`                              | square-and-multiply via `pow`                  | `Nat.rec` over `p` (cryptographic `p` is `~2^31`+)                   |
+   | `gcd` / `extGcd` in any Euclidean domain                               | Euclidean algorithm, tail-recursive            | linear search; recursive Bezout build-up that's not tail-recursive   |
+   | Integer floor square root                                              | Newton iteration, `O(log n)`                   | descending linear scan from `n` down to `√n`                         |
+   | Binomial coefficient `C(n, k)`                                         | multiplicative formula `(∏ i<k, (n−i)) / k!`   | unmemoised Pascal recursion (`Θ(2^k)` calls)                         |
+   | Modular reduction inside a hot loop (Frobenius, polynomial eval)       | Barrett (`p < 2^32`) / Montgomery (general)    | naive `%` in the inner loop                                          |
+   | Native-word arithmetic on `UInt64` / `UInt32` / `Fin n`                | the typed operation directly                   | `toNat → Nat → .ofNat` round-trip (boxes the bignum cost in)         |
+   | `nsmul n x` / `natCast n` in a ring with fast `pow`                    | binary decomposition (or share `pow`'s code)   | linear `Nat.rec` over `n`                                            |
+   | In-place update (Bareiss step, GS row update, LLL swap)                | mutate or thread state through the recurrence  | rebuild the matrix/basis from scratch each iteration                 |
+   | Linear search across a structure with a known fast lookup              | the fast lookup                                | walk the whole structure regardless                                  |
+
+   The list is consulted by the Phase 2 review checklist when judging
+   whether a body is "wrong-complexity" in the absence of an explicit
+   SPEC contract: an entry on the list is treated as if the SPEC said
+   "use the canonical fast default" for that row's operation. If a
+   library's SPEC genuinely wants the slow variant (e.g. for a proof
+   reference that's never called at runtime), it must say so
+   explicitly — and the corresponding `def` must be private and
+   un-imported by hot-path code. Entries on the list aren't a complete
+   formal definition; scaffolders confronting an operation not on the
+   list pick what a textbook calls "the standard fast algorithm" for
+   that operation, and open a clarification issue if the choice
+   requires a SPEC tradeoff (e.g. Karatsuba threshold, Barrett vs.
+   Montgomery selection).
+
 ## Fully autonomous execution
 
 The project runs without human interaction after launch. Lean, Mathlib,


### PR DESCRIPTION
## Summary

A follow-up to #715/#716/#719. Those three closed the specific
SPEC/PLAN holes in hex-arith and hex-poly-z, but a second review
across the field libraries (HexGfqRing, HexGfqField, HexGF2,
HexPolyFp) found the same wrong-complexity pattern: linear-time
\`pow\` cascading into Frobenius (where \`frob = pow x p\` makes a
Mersenne-prime modulus catastrophic).

Phase 2's wrong-complexity question (post-#719) only fires \"where
the SPEC implies\" a fast algorithm. The four field-library SPECs
say only \"exponentiation\" without prescribing an algorithm, so
the question is silent and a fresh-start scaffolder would re-create
the bug.

This PR closes the prevention gap with two coordinated edits:

1. **\`SPEC/design-principles.md\`** gains a \"Canonical fast defaults\"
   sub-section under principle 7 with a table covering the
   operations that have already cost reviewer time. The table is
   binding even when the per-library SPEC is silent on complexity.

2. **\`PLAN/Phase2.md\`'s wrong-complexity review question** is
   rewritten to consult the design-principles table directly,
   removing the \"where the SPEC implies\" weasel-word that made
   the question inactive in the absence of an explicit SPEC clause.

Repair issues for the already-landed wrong-complexity bodies are
already filed (#742, #743, #744; plus the prior round #721, #722,
#723).

## Scope of autonomous SPEC edits

Per [SPEC/design-principles.md §7](https://github.com/kim-em/hex/blob/main/SPEC/design-principles.md):
the constraint exists in spirit in principle 7's \"intended
complexity\" wording. This PR makes the per-operation defaults
concrete and binding, so scaffolders don't have to guess what
\"intended\" means for a given operation. No public API contract
or release goal is changed.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: each table row corresponds to a forbidden
      shape that has actually appeared in the recent scaffold work.

🤖 Prepared with Claude Code