### PR TITLE
spec: mark Hex.pureIntExtGcd as proofs-only on the ZMod64.inv contract

### DIFF
--- a/SPEC/Libraries/hex-mod-arith.md
+++ b/SPEC/Libraries/hex-mod-arith.md
@@ -37,10 +37,16 @@ Mathlib dependency.
 Operations are stated as semantic contracts on the canonical
 representative. Only `mul` carries a mandatory `@[extern]` for
 runtime; `add`/`sub`/`zero`/`one`/`pow` lower to native `UInt64`
-arithmetic in pure Lean already, and `inv` routes through
-`Hex.Int.extGcd` which is itself the `mpz_gcdext` extern at the
-hex-arith level (see "Extern contract: `mpz_gcdext`" in
-`SPEC/Libraries/hex-arith.md`).
+arithmetic in pure Lean already, and `inv` routes through the
+`@[extern "lean_hex_mpz_gcdext"]`-bearing `extGcd` declared in
+`HexArith.Int` (see "Extern contract: `mpz_gcdext`" in
+`SPEC/Libraries/hex-arith.md`). **`inv` must NOT call
+`Hex.pureIntExtGcd` directly** — that's the pure-Lean reference
+body the extern falls through to as a portable fallback, and is
+intended for proofs only. Calling it bypasses GMP and runs the
+recursive `Nat` reference at runtime, which allocates a fresh `Nat`
+blob per recursive step (the same regression class as omitting
+`@[extern]` on `mulHi`).
 
 ```lean
 @[extern "lean_hex_zmod64_mul"]


### PR DESCRIPTION
## Summary

The hex-mod-arith SPEC said \`inv\` \"routes through \`Hex.Int.extGcd\`
which is itself the mpz_gcdext extern\". A Phase 1 scaffolder reading
\`HexArith/ExtGcd.lean\` sees three plausible candidates that all
return the same \`Nat × Int × Int\` triple:

- \`HexArith.Int.extGcd\` — carries \`@[extern \"lean_hex_mpz_gcdext\"]\`
- \`Hex.pureIntExtGcd\` — pure-Lean fallback the extern falls through
  to (tail-recursive \`Nat\` reference, allocates per recursive step
  at runtime)
- \`HexArith.UInt64.extGcd\` / \`Hex.pureUInt64ExtGcd\` — UInt64 variants

The SPEC's prose was correct in spirit but didn't name the wrong
choice. The recently-landed \`HexModArith/Basic.lean\`'s \`ZMod64.inv\`
calls \`Hex.pureIntExtGcd\` directly, so runtime modular inverse runs
the pure-Lean fallback in arbitrary-precision \`Nat\` arithmetic —
defeating the purpose of the GMP extern.

This PR makes the SPEC explicit about the symbol to call and the
symbol NOT to call, so a fresh-start scaffolder couldn't make the
same choice without contradicting the SPEC clause.

The implementation repair lands as a separate \`human-oversight\`
issue.

## Scope of autonomous SPEC edits

Per [SPEC/design-principles.md §7](https://github.com/kim-em/hex/blob/main/SPEC/design-principles.md):
this clarifies an existing clause that was ambiguous in a way that
already caused a Phase 1 mistake. No public API contract or release
goal is changed.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: the new sentence names \`Hex.pureIntExtGcd\`
      explicitly as the wrong choice, with the regression-class
      hint that mirrors the existing \`mulHi\` extern guidance.

🤖 Prepared with Claude Code