### PR TITLE
spec+plan: move canonical-fast-default catalogue out of design-principles

### DIFF
--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -60,26 +60,27 @@ These are not rubber-stamp coverage audits — they ask:
   `eventual`, `placeholder`, `Phase 1`, `bridge for` in `*.lean`
   and `ffi/*.c` files.** Every hit is a candidate violation; flag
   in the review issue.
-- **Does each data-level `def` body match the canonical fast default
-  for its operation?** [PLAN/Phase1.md](Phase1.md) forbids
-  "alternative implementations with the wrong algorithmic
+- **Does each data-level `def` body match the algorithm named in the
+  library SPEC for its operation?** [PLAN/Phase1.md](Phase1.md)
+  forbids "alternative implementations with the wrong algorithmic
   complexity"; this question makes the rule enforceable at review
-  time. The acceptable bodies for standard mathematical operations
-  are listed in [SPEC/design-principles.md §7
-  "Canonical fast defaults"](../SPEC/design-principles.md). Flag any
-  body whose row in that table is the *forbidden* column: linear-time
-  `pow` in a ring/field, `a^n % p` modular exponentiation, descending
-  linear-scan `floorSqrt`, unmemoised Pascal `binom`, `Nat.rec` over
-  `n` for `nsmul` / `natCast`, `toNat`/`ofNat` round-trip in a
-  `UInt64`-typed operation, rebuild-from-scratch where the SPEC
-  prescribes an in-place update. The table is binding even when the
-  per-library SPEC says only "exponentiation" / "binomial coefficient"
-  / etc. without naming an algorithm. Same remedy as wrong-shape
-  scaffolds: fix the body, or delete the declaration. If a body's
-  operation isn't in the design-principles table and the per-library
-  SPEC doesn't constrain complexity, ask whether a textbook would
-  call the body "the standard fast algorithm" for that operation; if
-  not, flag it.
+  time. Per [SPEC/design-principles.md §7](../SPEC/design-principles.md),
+  the binding complexity contract for an operation lives in its
+  library's SPEC: `hex-arith.md` names the algorithm for `powMod` and
+  `extGcd`, `hex-poly-z.md` for `binom` / `floorSqrt`, and so on.
+  Read the SPEC bullet for each declaration before judging its body,
+  and flag any body whose algorithmic shape doesn't match the
+  library SPEC's named algorithm — linear-time `pow` where
+  square-and-multiply was named, `a^n % p` where Nat-level
+  square-and-multiply was named, descending linear-scan `floorSqrt`
+  where Newton was named, unmemoised Pascal `binom` where the
+  multiplicative formula was named, rebuild-from-scratch where an
+  in-place update was named. If a library SPEC bullet names only
+  "exponentiation" / "binomial coefficient" without naming an
+  algorithm, that's a SPEC gap — file a SPEC issue alongside any
+  implementation issue. Same remedy as wrong-shape scaffolds: fix
+  the body to match the SPEC, fix the SPEC to name the canonical
+  algorithm, or delete the declaration.
 - **Are there one-line aliases of an adjacent declaration, lemmas
   duplicating Lean core, or names that misrepresent the body?**
   Flag any `def`/`theorem` whose body is `exact <other-decl>` for

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -48,42 +48,18 @@
    roll back the affected library's `done_through` and re-enter the
    relevant phase, not to weaken the benchmark.
 
-   **Canonical fast defaults for standard operations.** A SPEC that
-   says only "exponentiation", "binomial coefficient", or
-   "square root" without naming an algorithm does NOT license the
-   textbook-recursive body. Scaffolders default to the canonical fast
-   algorithm for the operation, even when the SPEC is silent. The
-   table below lists the defaults that have already cost reviewer
-   time on this project; it is not exhaustive but is binding for the
-   listed operations.
-
-   | Operation                                                              | Canonical fast default                         | Forbidden naive shape                                                |
-   | ---------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------- |
-   | `pow x n` in any monoid / group / ring / field                         | square-and-multiply, `O(log n)` ops            | `pow x (n+1) = mul (pow x n) x` (or any linear-time accumulator)     |
-   | Modular exponentiation `a^n mod p` at `Nat`                            | square-and-multiply, reducing after each mul   | `a^n % p` (full-precision exponent before reducing)                  |
-   | Frobenius `frob(a) = a^p` in `F_p[x]/(f)`                              | square-and-multiply via `pow`                  | `Nat.rec` over `p` (cryptographic `p` is `~2^31`+)                   |
-   | `gcd` / `extGcd` in any Euclidean domain                               | Euclidean algorithm, tail-recursive            | linear search; recursive Bezout build-up that's not tail-recursive   |
-   | Integer floor square root                                              | Newton iteration, `O(log n)`                   | descending linear scan from `n` down to `√n`                         |
-   | Binomial coefficient `C(n, k)`                                         | multiplicative formula `(∏ i<k, (n−i)) / k!`   | unmemoised Pascal recursion (`Θ(2^k)` calls)                         |
-   | Modular reduction inside a hot loop (Frobenius, polynomial eval)       | Barrett (`p < 2^32`) / Montgomery (general)    | naive `%` in the inner loop                                          |
-   | Native-word arithmetic on `UInt64` / `UInt32` / `Fin n`                | the typed operation directly                   | `toNat → Nat → .ofNat` round-trip (boxes the bignum cost in)         |
-   | `nsmul n x` / `natCast n` in a ring with fast `pow`                    | binary decomposition (or share `pow`'s code)   | linear `Nat.rec` over `n`                                            |
-   | In-place update (Bareiss step, GS row update, LLL swap)                | mutate or thread state through the recurrence  | rebuild the matrix/basis from scratch each iteration                 |
-   | Linear search across a structure with a known fast lookup              | the fast lookup                                | walk the whole structure regardless                                  |
-
-   The list is consulted by the Phase 2 review checklist when judging
-   whether a body is "wrong-complexity" in the absence of an explicit
-   SPEC contract: an entry on the list is treated as if the SPEC said
-   "use the canonical fast default" for that row's operation. If a
-   library's SPEC genuinely wants the slow variant (e.g. for a proof
-   reference that's never called at runtime), it must say so
-   explicitly — and the corresponding `def` must be private and
-   un-imported by hot-path code. Entries on the list aren't a complete
-   formal definition; scaffolders confronting an operation not on the
-   list pick what a textbook calls "the standard fast algorithm" for
-   that operation, and open a clarification issue if the choice
-   requires a SPEC tradeoff (e.g. Karatsuba threshold, Barrett vs.
-   Montgomery selection).
+   *"Intended complexity"* means the canonical fast algorithm for the
+   operation — square-and-multiply for `pow`, Newton iteration for
+   floor square root, the multiplicative formula for binomial
+   coefficients, Euclidean for `gcd`, and so on. A SPEC bullet that
+   names an operation without naming an algorithm does not license
+   the textbook-recursive body. The binding contract for any
+   particular operation lives in its library's SPEC file — it's the
+   per-library SPEC that says "`pow` here uses square-and-multiply"
+   or "`floorSqrt` here is Newton, not linear scan" — not this
+   document. Library SPECs are responsible for naming the canonical
+   algorithm at the SPEC bullet for any operation whose complexity
+   class isn't already obvious from the type signature.
 
 ## Fully autonomous execution
 


### PR DESCRIPTION
## Summary

Reverts most of #788. The \"canonical fast defaults\" table belonged
in the per-library SPEC files all along, not in
\`SPEC/design-principles.md\`.

\`design-principles.md\` is for project-wide design philosophy. The
table I added in #788 enumerated algorithm choices for individual
operations (square-and-multiply for \`pow\`, Newton for floor sqrt,
multiplicative formula for \`binom\`, etc.) — which is the per-library
SPEC's job. \`hex-arith.md\` already names the algorithm for
\`powMod\` and \`extGcd\`; \`hex-poly-z.md\` already names it for
\`binom\` and \`floorSqrt\`. The pattern was right; centralising the
catalogue was wrong.

This PR:

1. **Reverts the canonical-fast-defaults table** from
   \`design-principles.md\` principle 7. Replaces it with one
   paragraph that states the abstract rule (\"intended complexity =
   canonical fast algorithm\"), gives a few illustrative examples,
   and points the reader at the per-library SPEC for the binding
   contract.

2. **Rewrites the Phase 2 review question** to consult the
   per-library SPEC's named algorithm rather than a centralised
   table. If a library SPEC bullet doesn't name an algorithm for an
   operation, that's a SPEC gap; the reviewer files a SPEC issue
   alongside any implementation issue.

Per-library SPEC PRs that still need to land (because their existing
bullets say only \"exponentiation\" / etc. without naming an
algorithm) are queued as follow-ups:

- \`hex-gfq-ring.md\` — \`pow\` complexity contract
- \`hex-gfq-field.md\` — \`frob\` complexity contract
- \`hex-gf2.md\` — \`pow\` complexity contract for \`GF2n\` and \`GF2nPoly\`
- \`hex-poly-fp.md\` — \`pow\` complexity contract for \`SquareFree\` reconstruction
- \`hex-gram-schmidt.md\` — \`gramDetVec\` incremental contract

## Scope of autonomous SPEC edits

Per [SPEC/design-principles.md §7](https://github.com/kim-em/hex/blob/main/SPEC/design-principles.md):
this corrects the placement of guidance that was in the wrong file.
No public API contract or release goal is changed.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: design-principles principle 7 is back to
      one paragraph with a forward pointer to library SPECs;
      Phase 2 review question consults the per-library SPEC.

🤖 Prepared with Claude Code