### PR TITLE
spec+plan: add canonical fast defaults for standard operations

### DIFF
--- a/PLAN/Phase2.md
+++ b/PLAN/Phase2.md
@@ -60,27 +60,21 @@ These are not rubber-stamp coverage audits — they ask:
   `eventual`, `placeholder`, `Phase 1`, `bridge for` in `*.lean`
   and `ffi/*.c` files.** Every hit is a candidate violation; flag
   in the review issue.
-- **Does each data-level `def` body match the algorithm named in the
-  library SPEC for its operation?** [PLAN/Phase1.md](Phase1.md)
-  forbids "alternative implementations with the wrong algorithmic
+- **Does each data-level `def` body run at the canonical fast
+  complexity for its operation?** [PLAN/Phase1.md](Phase1.md) forbids
+  "alternative implementations with the wrong algorithmic
   complexity"; this question makes the rule enforceable at review
   time. Per [SPEC/design-principles.md §7](../SPEC/design-principles.md),
-  the binding complexity contract for an operation lives in its
-  library's SPEC: `hex-arith.md` names the algorithm for `powMod` and
-  `extGcd`, `hex-poly-z.md` for `binom` / `floorSqrt`, and so on.
-  Read the SPEC bullet for each declaration before judging its body,
-  and flag any body whose algorithmic shape doesn't match the
-  library SPEC's named algorithm — linear-time `pow` where
-  square-and-multiply was named, `a^n % p` where Nat-level
-  square-and-multiply was named, descending linear-scan `floorSqrt`
-  where Newton was named, unmemoised Pascal `binom` where the
-  multiplicative formula was named, rebuild-from-scratch where an
-  in-place update was named. If a library SPEC bullet names only
-  "exponentiation" / "binomial coefficient" without naming an
-  algorithm, that's a SPEC gap — file a SPEC issue alongside any
-  implementation issue. Same remedy as wrong-shape scaffolds: fix
-  the body to match the SPEC, fix the SPEC to name the canonical
-  algorithm, or delete the declaration.
+  if the library SPEC names an algorithm for the operation, the body
+  must implement it; if the SPEC is silent on performance, the body
+  must still be optimal for that operation's standard problem. Flag
+  linear-time `pow` where square-and-multiply is canonical, `a^n % p`
+  where Nat-level square-and-multiply is canonical, descending
+  linear-scan `floorSqrt` where Newton is canonical, unmemoised
+  Pascal `binom` where the multiplicative formula is canonical,
+  rebuild-from-scratch where an incremental update is canonical.
+  Same remedy as wrong-shape scaffolds: fix the body, or delete the
+  declaration.
 - **Are there one-line aliases of an adjacent declaration, lemmas
   duplicating Lean core, or names that misrepresent the body?**
   Flag any `def`/`theorem` whose body is `exact <other-decl>` for

--- a/SPEC/Libraries/hex-gf2.md
+++ b/SPEC/Libraries/hex-gf2.md
@@ -124,6 +124,13 @@ the packed `GF2Poly` representation rather than `FpPoly`) without
 introducing Mathlib-only `Fintype` machinery into the computational
 core.
 
+`pow x n` on `GF2n` and `GF2nPoly` is square-and-multiply
+(`O(log n)` field multiplications). The textbook `n+1 ↦ pow n * x`
+recursion is forbidden — typical use cases (Tonelli–Shanks-style
+square roots, Frobenius squarings, irreducibility witnesses)
+exponentiate by `2^n`-sized integers, which a linear-time `pow`
+cannot complete.
+
 The ring equivalences `GF2n ≃+* FiniteField 2 f hf hirr` and
 `GF2nPoly ≃+* FiniteField 2 f hf hirr` live in hex-gf2-mathlib,
 transferring via `GF2Poly ≃+* FpPoly 2`; that bridge library is also the

--- a/SPEC/Libraries/hex-gfq-field.md
+++ b/SPEC/Libraries/hex-gfq-field.md
@@ -16,8 +16,14 @@ field libraries.
   f.degree` and `hirr : Irreducible f`
 - Coercions or conversion functions to and from `PolyQuotient p f hf`
 - Multiplicative inverse via extended GCD in `F_p[x]`
-- Division and exponentiation
-- Frobenius map `frob : FiniteField p f hf hirr → FiniteField p f hf hirr`
+- Division and exponentiation. `pow x n` is square-and-multiply
+  (`O(log n)` field multiplications); the textbook `n+1 ↦ pow n * x`
+  recursion is forbidden because cryptographic exponents (e.g. `n =
+  p` for Frobenius, with `p ≈ 2^31`) make linear-time `pow`
+  non-terminating.
+- Frobenius map `frob : FiniteField p f hf hirr → FiniteField p f hf hirr`,
+  computed as `pow x p` (and therefore inheriting the
+  square-and-multiply complexity)
 - `Lean.Grind.Field (FiniteField p f hf hirr)` instance
 - `IsCharP (FiniteField p f hf hirr) p`
 

--- a/SPEC/Libraries/hex-gfq-ring.md
+++ b/SPEC/Libraries/hex-gfq-ring.md
@@ -16,7 +16,11 @@ API.
 - Smart constructor `ofPoly : FpPoly p → PolyQuotient p f hf`
 - Projection `repr : PolyQuotient p f hf → FpPoly p`
 - Ring operations: addition, multiplication, negation, subtraction,
-  exponentiation; every operation reduces via `reduceMod`
+  exponentiation; every operation reduces via `reduceMod`.
+  `pow x n` is square-and-multiply (`O(log n)` quotient-ring
+  multiplications). `nsmul n x` and `natCast n` use binary
+  decomposition with the same complexity; the textbook
+  `n+1 ↦ pred + 1` recursion is forbidden.
 - `Lean.Grind.CommRing (PolyQuotient p f hf)` instance
 
 Representation choice: the stored representative is always canonical.

--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -35,7 +35,13 @@ noncomputable def coeffs (b : Matrix Int n m) : Matrix Rat n n
     and the public API wraps via .toNat). -/
 def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Nat
 
-/-- All Gram determinants as a vector. -/
+/-- All Gram determinants as a vector.
+    Computed incrementally (e.g. one Bareiss-style elimination pass
+    over the full Gram matrix that emits each leading-principal
+    minor along its diagonal): O(n^3 + n^2 m) total. Recomputing
+    `gramDet b k` independently for each k by rebuilding the
+    leading k × k Gram matrix and its determinant from scratch is
+    forbidden — that body is `O(n^4 + n^3 m)`. -/
 def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
 
 /-- Scaled GS coefficients (the ν-values): entry (i,j) = d_{j+1} * μ_{i,j}

--- a/SPEC/Libraries/hex-poly-fp.md
+++ b/SPEC/Libraries/hex-poly-fp.md
@@ -7,7 +7,12 @@ Specialized polynomial arithmetic over `Z/pZ` using `UInt64` coefficients.
 - Frobenius map: `X^p mod f` via repeated squaring
 - `X^(p^k) mod f` for arbitrary k (square-and-multiply on polynomials)
 - Modular composition (evaluate one polynomial at another, mod a third)
-- Square-free decomposition (Yun's algorithm adapted for `F_p`)
+- Square-free decomposition (Yun's algorithm adapted for `F_p`).
+  Any internal polynomial-power helper used to reconstruct a
+  decomposition's product (e.g. `factor^multiplicity`) is
+  square-and-multiply, `O(log multiplicity)` polynomial
+  multiplications. The textbook `n+1 ↦ f * pow f n` recursion is
+  forbidden.
 
 **Key properties:**
 - Frobenius endomorphism: `frob(a + b) = frob(a) + frob(b)`

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -48,18 +48,12 @@
    roll back the affected library's `done_through` and re-enter the
    relevant phase, not to weaken the benchmark.
 
-   *"Intended complexity"* means the canonical fast algorithm for the
-   operation — square-and-multiply for `pow`, Newton iteration for
-   floor square root, the multiplicative formula for binomial
-   coefficients, Euclidean for `gcd`, and so on. A SPEC bullet that
-   names an operation without naming an algorithm does not license
-   the textbook-recursive body. The binding contract for any
-   particular operation lives in its library's SPEC file — it's the
-   per-library SPEC that says "`pow` here uses square-and-multiply"
-   or "`floorSqrt` here is Newton, not linear scan" — not this
-   document. Library SPECs are responsible for naming the canonical
-   algorithm at the SPEC bullet for any operation whose complexity
-   class isn't already obvious from the type signature.
+   *"Intended complexity"* means the canonical fast algorithm for
+   the operation — square-and-multiply for `pow`, Newton iteration
+   for floor square root, the multiplicative formula for binomial
+   coefficients, Euclidean for `gcd`. If a library SPEC doesn't
+   mention performance requirements for an operation, assume the
+   implementation needs to be optimal.
 
 ## Fully autonomous execution
 


### PR DESCRIPTION
## Summary

Two coordinated changes:

**1. Tighten design-principles.md principle 7's complexity wording.**
The previous version (#788, #800) had a long blame-assigning paragraph
about library SPECs being "responsible" for naming canonical
algorithms — too prescriptive about ownership and silent on what to
do when the per-library SPEC doesn't say. Replaced with a one-line
safety net: \"If a library SPEC doesn't mention performance
requirements for an operation, assume the implementation needs to be
optimal.\" Plus a few illustrative examples.

PLAN/Phase2.md's review question is rewritten in the same spirit: it
consults the library SPEC if it names an algorithm, and the canonical
fast default otherwise. The \"SPEC gap, file a SPEC issue alongside\"
framing is removed.

**2. Add per-library complexity contracts** where the existing SPEC
bullet says only \"exponentiation\" / \"decomposition\" without naming
an algorithm. With the safety net in (1), these additions are
guidance at the use site, not strictly required — but they save a
scaffolder from having to derive \"optimal pow = square-and-multiply\"
from first principles, and each addition matches a real Phase 1
scaffold defect that's already in the human-oversight repair queue
(#742, #743, #744, #799).

| File                          | Bullet                                                |
| ----------------------------- | ----------------------------------------------------- |
| `hex-gfq-ring.md`             | \`pow\` / \`nsmul\` / \`natCast\` are binary decomposition |
| `hex-gfq-field.md`            | \`pow\` is square-and-multiply; \`frob\` inherits         |
| `hex-gf2.md`                  | \`GF2n.pow\` / \`GF2nPoly.pow\` are square-and-multiply   |
| `hex-poly-fp.md`              | Internal pow for decomposition reconstruction is sq-mul |
| `hex-gram-schmidt.md`         | \`gramDetVec\` is `O(n^3)` incremental, not `O(n^4)`    |

## Scope of autonomous SPEC edits

Per [SPEC/design-principles.md §7](https://github.com/kim-em/hex/blob/main/SPEC/design-principles.md):
each clause was either ill-typed (the long design-principles
paragraph that didn't say what to do when libraries don't name an
algorithm) or filled a gap that already caused a Phase 1 mistake.
No public API contract or release goal is changed.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: each per-library bullet adds a complexity
      requirement next to the existing operation it constrains.

🤖 Prepared with Claude Code