### PR TITLE
plan: require workers re-read SPEC, planners link it explicitly

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -35,6 +35,26 @@ scaffolded `def` is fully implemented; only its proofs may be
 "scaffold for the eventual <X> bridge", "honest placeholder", and
 "for now ..." are forbidden in committed code.
 
+### Read the SPEC, not just the issue body
+
+When you pick up an issue, re-read every SPEC file linked in its
+**Context** section, in full, before starting implementation. Issue
+bodies summarise and paraphrase: they trade fidelity for brevity,
+and previous review rounds have turned up several cases where worker
+agents implemented an issue's misstated condensation rather than the
+SPEC clause it referenced. The SPEC is the source of truth.
+
+If a contradiction surfaces between the issue body and the SPEC,
+follow the SPEC and comment on the issue noting the discrepancy —
+don't silently re-interpret the SPEC to match the issue.
+
+Read adjacent SPEC and PLAN files when they look plausibly relevant:
+sibling library SPECs you depend on, `SPEC/design-principles.md`
+when complexity or extern policy is in play, the Phase K conventions
+for the phase you're in, the convention sections that govern the
+artefacts you're producing. The extra tokens are cheap relative to
+the cost of implementing a misunderstood contract.
+
 ### PR workflow
 
 Every PR gets auto-merge at creation:
@@ -152,7 +172,18 @@ shape:
 - **Current state** — what is already true, and what assumptions the
   worker should begin from.
 - **Deliverables** — the concrete outputs expected from this issue.
-- **Context** — links to SPEC sections, files, related issues, or PRs.
+- **Context** — explicit links to the SPEC files (and section
+  anchors where helpful) the worker should re-read in full before
+  starting. Issue bodies summarise and paraphrase, and previous
+  rounds have turned up cases where workers implemented the issue's
+  condensation rather than the SPEC clause it referenced; the SPEC
+  is the source of truth. List every SPEC file that constrains the
+  task, including adjacent ones the worker is likely to want — the
+  SPEC for the library being touched, plus any sibling library
+  SPECs whose contracts cross the boundary, plus
+  `SPEC/design-principles.md` when complexity or extern policy is
+  in play. Also link related issues, PRs, conformance/bench
+  artefacts, and any PLAN sections that govern the phase.
 - **Verification** — the checks to run for this issue.
 - **Out of scope** — nearby work that should not be folded into this
   issue.


### PR DESCRIPTION
## Summary

A failure mode that's recurred in recent review rounds: worker
agents implement an issue body's *summary* of a SPEC clause rather
than the SPEC clause itself. Issue bodies paraphrase to stay narrow,
and the paraphrase occasionally misstates or condenses away a
constraint.

Two coordinated edits to \`PLAN/Conventions.md\`:

1. **New \"Read the SPEC, not just the issue body\" hard rule** in
   the cross-phase Conventions section. When a worker picks up an
   issue, re-read every SPEC file linked in **Context** in full
   before starting; if the issue and SPEC disagree, follow the SPEC
   and comment on the issue noting the discrepancy. Read adjacent
   SPEC/PLAN files when relevant — sibling library SPECs,
   \`SPEC/design-principles.md\`, the Phase K conventions for the
   current phase. Extra tokens are cheap relative to implementing a
   misunderstood contract.

2. **Tighter canonical issue body \"Context\" bullet** on the
   planner side: explicit links to every SPEC file the worker
   should re-read, including adjacent ones (sibling library SPECs
   whose contracts cross the boundary, design-principles when
   complexity or extern policy is in play). Plus PLAN section links
   that govern the phase. Replaces the previous \"links to SPEC
   sections, files, related issues, or PRs\" one-liner that didn't
   say *re-read* and didn't list the adjacency obligation.

Both rules co-locate in \`PLAN/Conventions.md\` so a worker reading
\"once per session\" sees the read-the-SPEC instruction at session
start, and a planner reading the canonical issue body shape sees
the explicit-link instruction next to it.

## Test plan

- [ ] \`python3 scripts/check_dag.py\` passes (DAG unchanged).
- [ ] Manual reading: the new hard rule sits next to the other
      cross-phase hard rules (placeholders, PR workflow); the new
      Context wording sits inside the canonical issue body shape.

🤖 Prepared with Claude Code