### PR TITLE
Repair HexModArith/Basic.lean: ZMod64.inv must call HexArith.Int.extGcd (extern), not Hex.pureIntExtGcd

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -170,7 +170,7 @@ still exposes the executable Bezout-derived residue needed by later algebraic
 layers.
 -/
 def inv (a : ZMod64 p) : ZMod64 p :=
-  let (_, s, _) := Hex.pureIntExtGcd (Int.ofNat a.toNat) (Int.ofNat p)
+  let (_, s, _) := HexArith.Int.extGcd (Int.ofNat a.toNat) (Int.ofNat p)
   ofNat p (Int.toNat (s % Int.ofNat p))
 
 instance : Zero (ZMod64 p) where
@@ -215,7 +215,7 @@ instance : Inv (ZMod64 p) where
 
 @[simp] theorem toNat_inv_def (a : ZMod64 p) :
     (inv a).toNat =
-      (Int.toNat ((let (_, s, _) := Hex.pureIntExtGcd (Int.ofNat a.toNat) (Int.ofNat p); s)
+      (Int.toNat ((let (_, s, _) := HexArith.Int.extGcd (Int.ofNat a.toNat) (Int.ofNat p); s)
         % Int.ofNat p)) % p := by
   rw [inv, toNat_ofNat]
 

--- a/progress/2026-04-29T04:54:15Z_608a5c3b.md
+++ b/progress/2026-04-29T04:54:15Z_608a5c3b.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed human-oversight feature issue `#796`.
+- Replaced both `Hex.pureIntExtGcd` call sites in `HexModArith/Basic.lean` with `HexArith.Int.extGcd`, so `ZMod64.inv` routes through the extern-backed wrapper and `toNat_inv_def` matches the implementation body.
+- Verified `lake build HexModArith` and `python3 scripts/check_dag.py`.
+- Built a temporary `HexModArith.TmpInvEval` smoke module for the requested large inverse check; it returned `2022730182801753852` through the compiled path, then the temporary file was removed before commit.
+
+**Current frontier**
+
+- The issue deliverables are complete and scoped to the call-site repair.
+
+**Next step**
+
+- Open a PR closing `#796`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #796

Session: `608a5c3b-bc5c-4350-b3ad-9f0b02a71a4c`

e3e54e8 fix: route ZMod64 inverse through extern extGcd

🤖 Prepared with Claude Code