### PR TITLE
Repair HexGramSchmidt/Int.lean: compute gramDetVec incrementally (O(n^3)), not by per-prefix recomputation (O(n^4))

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -1,4 +1,5 @@
 import HexGramSchmidt.Basic
+import HexMatrix.Bareiss
 import HexMatrix.Determinant
 
 /-!
@@ -51,10 +52,34 @@ principal Gram matrix of the integer input. -/
 def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Nat :=
   (Matrix.det (GramSchmidt.leadingGramMatrixInt b k hk)).toNat
 
+/-- Read a diagonal entry from a Bareiss elimination matrix as a natural
+determinant value. -/
+private def bareissDiagNat (data : Matrix.BareissData n) (r : Nat) (hr : r < n) : Nat :=
+  let i : Fin n := ⟨r, hr⟩
+  ((data.matrix.get i).get i).toNat
+
+/-- Read the `k`-th leading-principal determinant from one no-pivot Bareiss
+elimination pass over the full Gram matrix. This helper is only used for Gram
+matrices: once a leading row prefix is singular, every larger leading prefix is
+also singular, so all later leading determinants are zero. -/
+private def gramDetVecEntry (data : Matrix.BareissData n) (k : Fin (n + 1)) : Nat :=
+  match hk : k.val with
+  | 0 => 1
+  | r + 1 =>
+      have hrSucc : r + 1 < n + 1 := by
+        simpa [hk] using k.isLt
+      have hr : r < n := Nat.succ_lt_succ_iff.mp hrSucc
+      match data.singularStep with
+      | some s => if s < r + 1 then 0 else
+          bareissDiagNat data r hr
+      | none => bareissDiagNat data r hr
+
 /-- All leading Gram determinants, starting with the empty-prefix value
 `d₀ = 1`. -/
 def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1) :=
-  Vector.ofFn fun k => gramDet b k.val (Nat.le_of_lt_succ k.isLt)
+  let gram := Matrix.gramMatrix b
+  let data := Matrix.bareissNoPivotData gram
+  Vector.ofFn fun k => gramDetVecEntry data k
 
 /-- Integral scaled Gram-Schmidt coefficients. For `j < i`, the entry is the
 determinant formula corresponding to `d_{j+1} * μ_{i,j}`; on the diagonal we

--- a/progress/2026-04-29T05:04:49Z_12bf70bd.md
+++ b/progress/2026-04-29T05:04:49Z_12bf70bd.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed human-oversight feature issue `#799`.
+- Replaced `GramSchmidt.Int.gramDetVec`'s per-prefix determinant recomputation with a single full Gram-matrix build plus one no-pivot Bareiss pass, reading leading-principal determinants from the Bareiss diagonal.
+- Added private helpers in `HexGramSchmidt/Int.lean` for Bareiss diagonal extraction and Gram-specific singular-prefix handling.
+- Ran a temporary 16x16 `#eval` smoke module for `gramDetVec`; it built successfully in 2.73s wall time and returned the full determinant vector, then the temporary module was removed.
+- Ran the second-opinion review workflow; it confirmed the indexing/singular-prefix cases and led to a small cleanup of duplicated extraction branches plus a clearer Gram-specific helper comment.
+- Verified `lake build HexGramSchmidt`, `lake build HexLLL`, and `python3 scripts/check_dag.py`.
+
+**Current frontier**
+
+- Issue `#799` deliverables are complete for `gramDetVec`; theorem statements remain in place with their existing `sorry` proofs.
+
+**Next step**
+
+- Open a PR closing `#799`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #799

Session: `12bf70bd-5a94-4c02-8ade-b318f507e917`

7dfc4ec fix: compute gramDetVec incrementally

🤖 Prepared with Claude Code