### PR TITLE
HexGF2Mathlib follow-up: add finite packed-representative support for GF2nPoly transport

### DIFF
--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -17,6 +17,14 @@ open Hex
 
 universe u v
 
+/-! A minimal project-local equivalence structure for bridge support that does
+not need Mathlib's heavier equivalence hierarchy. -/
+structure TypeEquiv (α : Type u) (β : Type v) where
+  toFun : α → β
+  invFun : β → α
+  left_inv : Function.LeftInverse invFun toFun
+  right_inv : Function.RightInverse invFun toFun
+
 /-! A minimal project-local ring equivalence structure for executable algebra
 types that have not imported Mathlib's heavier equivalence hierarchy. -/
 structure RingEquiv (R : Type u) (S : Type v) [Mul R] [Mul S] [Add R] [Add S] where
@@ -145,6 +153,51 @@ theorem equiv_apply (p : Hex.GF2Poly) :
 theorem equiv_symm_apply (p : Hex.FpPoly 2) :
     RingEquiv.symm equiv p = ofFpPoly p := by
   rfl
+
+/-- Interpret a packed polynomial as the natural number with the same binary
+coefficient bits. This gives bridge modules a finite index for bounded-degree
+representatives without changing the executable `HexGF2` representation. -/
+private def wordsToNatAux : List UInt64 → Nat → Nat
+  | [], _ => 0
+  | w :: ws, i => w.toNat * 2 ^ (64 * i) + wordsToNatAux ws (i + 1)
+
+def toNat (p : Hex.GF2Poly) : Nat :=
+  wordsToNatAux p.toWords.toList 0
+
+/-- Rebuild the low `degree` bits of a natural number as a packed polynomial.
+The input is expected to be bounded by `2 ^ degree` by callers that need a
+canonical finite representative. -/
+def ofNatBelowDegree (degree : Nat) (n : Nat) : Hex.GF2Poly :=
+  let wordCount := (degree + 63) / 64
+  Hex.GF2Poly.ofWords <|
+    Array.ofFn fun i : Fin wordCount =>
+      UInt64.ofNat (n / 2 ^ (64 * i.1))
+
+/-- A polynomial known to have degree `< degree` has an index below
+`2 ^ degree` under the packed binary interpretation. -/
+theorem toNat_lt_of_degree_lt {p : Hex.GF2Poly} {degree : Nat}
+    (h : p.IsZero ∨ p.degree < degree) :
+    toNat p < 2 ^ degree := by
+  sorry
+
+/-- Decoding a bounded index as low binary bits produces a reduced packed
+representative for that degree bound. -/
+theorem ofNatBelowDegree_reduced (degree : Nat) (i : Fin (2 ^ degree)) :
+    (ofNatBelowDegree degree i.1).IsZero ∨
+      (ofNatBelowDegree degree i.1).degree < degree := by
+  sorry
+
+/-- Encoding after decoding a bounded packed index preserves the index. -/
+theorem toNat_ofNatBelowDegree (degree : Nat) (i : Fin (2 ^ degree)) :
+    toNat (ofNatBelowDegree degree i.1) = i.1 := by
+  sorry
+
+/-- Decoding after encoding a reduced packed representative preserves the
+polynomial. -/
+theorem ofNatBelowDegree_toNat {p : Hex.GF2Poly} {degree : Nat}
+    (h : p.IsZero ∨ p.degree < degree) :
+    ofNatBelowDegree degree (toNat p) = p := by
+  sorry
 
 end GF2Poly
 

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -109,6 +109,58 @@ instance : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 variable {f : Hex.GF2Poly} {hirr : Hex.GF2Poly.Irreducible f}
 
+/-- Reduced packed representatives modulo `f`, isolated from the field wrapper
+so Mathlib-side finite support can be transported before the final public
+`GF2nPoly` cardinality statements are proved. -/
+abbrev ReducedPackedRep (f : Hex.GF2Poly) : Type :=
+  { p : Hex.GF2Poly // p.IsZero ∨ p.degree < f.degree }
+
+/-- The executable packed quotient wrapper is exactly the reduced-representative
+subtype used for finite support. -/
+def reducedPackedRepEquiv : TypeEquiv (Hex.GF2nPoly f hirr) (ReducedPackedRep f) where
+  toFun x := ⟨x.val, x.val_reduced⟩
+  invFun x := ⟨x.1, x.2⟩
+  left_inv := by
+    intro x
+    cases x
+    rfl
+  right_inv := by
+    intro x
+    cases x
+    rfl
+
+/-- Encode a reduced packed representative as a bounded binary index. -/
+def reducedPackedRepIndex (x : ReducedPackedRep f) : Fin (2 ^ f.degree) :=
+  ⟨HexGF2Mathlib.GF2Poly.toNat x.1, HexGF2Mathlib.GF2Poly.toNat_lt_of_degree_lt x.2⟩
+
+/-- Decode a bounded binary index into the corresponding reduced packed
+representative. -/
+def reducedPackedRepOfIndex (i : Fin (2 ^ f.degree)) : ReducedPackedRep f :=
+  ⟨HexGF2Mathlib.GF2Poly.ofNatBelowDegree f.degree i.1,
+    HexGF2Mathlib.GF2Poly.ofNatBelowDegree_reduced f.degree i⟩
+
+@[simp]
+theorem reducedPackedRepIndex_ofIndex (i : Fin (2 ^ f.degree)) :
+    reducedPackedRepIndex (f := f) (reducedPackedRepOfIndex (f := f) i) = i := by
+  apply Fin.ext
+  exact HexGF2Mathlib.GF2Poly.toNat_ofNatBelowDegree f.degree i
+
+@[simp]
+theorem reducedPackedRepOfIndex_index (x : ReducedPackedRep f) :
+    reducedPackedRepOfIndex (f := f) (reducedPackedRepIndex (f := f) x) = x := by
+  cases x with
+  | mk p hp =>
+      apply Subtype.ext
+      exact HexGF2Mathlib.GF2Poly.ofNatBelowDegree_toNat hp
+
+/-- Reduced packed representatives are equivalent to the finite binary index
+space determined by the modulus degree. -/
+def reducedPackedRepFinEquiv : TypeEquiv (ReducedPackedRep f) (Fin (2 ^ f.degree)) where
+  toFun := reducedPackedRepIndex (f := f)
+  invFun := reducedPackedRepOfIndex (f := f)
+  left_inv := reducedPackedRepOfIndex_index (f := f)
+  right_inv := reducedPackedRepIndex_ofIndex (f := f)
+
 /-- The packed irreducible modulus viewed inside the generic `FpPoly 2`
 representation. -/
 def modulusFpPoly : Hex.FpPoly 2 :=

--- a/progress/2026-04-29T05-32-04Z_34d46917.md
+++ b/progress/2026-04-29T05-32-04Z_34d46917.md
@@ -1,0 +1,28 @@
+**Accomplished**
+
+- Claimed feature issue `#797`.
+- Added a lightweight `TypeEquiv` bridge helper in `HexGF2Mathlib/Basic.lean`.
+- Added packed-polynomial binary indexing helpers for bounded-degree `GF2Poly`
+  representatives.
+- Added `GF2nPoly.ReducedPackedRep`, equivalences between `GF2nPoly` and the
+  reduced-representative subtype, and an explicit finite index equivalence to
+  `Fin (2 ^ f.degree)` in `HexGF2Mathlib/Field.lean`.
+- Verified `lake build HexGF2Mathlib`, `python3 scripts/check_dag.py`, and
+  `git diff --check`.
+
+**Current frontier**
+
+- The packed-representative support layer for later `GF2nPoly` transport exists
+  without importing Mathlib finset/cardinality machinery into the bridge file.
+- The new binary encoding/decoding proof obligations follow the existing
+  scaffold style and remain as `sorry`s alongside the current bridge proof
+  placeholders.
+
+**Next step**
+
+- A follow-up worker can use `reducedPackedRepFinEquiv` to derive the final
+  Mathlib-side `Fintype` and cardinality statements for `GF2nPoly`.
+
+**Blockers**
+
+- No blocker for this issue.


### PR DESCRIPTION
Closes #797

Session: `34d46917-543a-4b4c-a407-8c4f0a165db2`

0595d6d feat: add GF2nPoly finite representative support

🤖 Prepared with Claude Code