### PR TITLE
feat: add HexMatrix determinant benchmarks

### DIFF
--- a/HexMatrix/Bench.lean
+++ b/HexMatrix/Bench.lean
@@ -4,10 +4,21 @@ import LeanBench
 /-!
 Benchmark registrations for `hex-matrix`.
 
-This initial Phase 4 slice measures dense square matrix multiplication on
-deterministically generated integer inputs. The benchmark hoists input
-generation into `prep` so the declared `O(n^3)` model tracks matrix
-multiplication itself rather than fixture construction.
+This Phase 4 slice measures dense square matrix multiplication and determinant
+computation on deterministically generated integer inputs. Matrix construction
+is hoisted into `prep` for every parametric family, so each declared model
+tracks the timed algebraic operation rather than fixture construction.
+
+Scientific registrations:
+
+* `runSquareMulChecksum`: dense square multiplication, `O(n^3)`.
+* `runBareissDet`: row-pivoted Bareiss determinant over `Int`, `O(n^3)`.
+
+Small-domain cross-check registrations:
+
+* `runLeibnizDet`: generic Leibniz determinant, `O(n * n!)`, capped at small
+  dimensions so `compare runBareissDet runLeibnizDet` exercises the shared
+  determinant API where both implementations are practical.
 -/
 
 namespace Hex.MatrixBench
@@ -20,6 +31,12 @@ structure MulInput where
   rhs : Array Int
   deriving Repr, BEq, Hashable
 
+/-- Flattened benchmark input for one square integer matrix. -/
+structure DetInput where
+  n : Nat
+  entries : Array Int
+  deriving Repr, BEq, Hashable
+
 /-- Deterministic pseudo-random-looking entry generator keyed by matrix
 dimension, coordinates, and a salt distinguishing the two operands. -/
 def entryValue (n row col salt : Nat) : Int :=
@@ -29,6 +46,13 @@ def entryValue (n row col salt : Nat) : Int :=
       ((col.toUInt64 + 1) * 0x94D049BB133111EB) +
       salt.toUInt64)
   Int.ofNat (x.toNat % 65_521)
+
+/-- Small signed deterministic entries for determinant benchmarks. Keeping
+coefficients small makes the Bareiss registration test elimination scaling
+rather than artificial coefficient growth in the fixture generator. -/
+def smallEntryValue (n row col salt : Nat) : Int :=
+  let x := entryValue n row col salt
+  (x % 11) - 5
 
 /-- Deterministic row-major matrix fixture of shape `n × n`. -/
 def flatMatrix (n salt : Nat) : Array Int :=
@@ -40,11 +64,26 @@ def flatMatrix (n salt : Nat) : Array Int :=
       let col := idx % n
       entryValue n row col salt
 
+/-- Deterministic small-entry row-major matrix fixture of shape `n × n`. -/
+def flatSmallMatrix (n salt : Nat) : Array Int :=
+  if n = 0 then
+    #[]
+  else
+    (Array.range (n * n)).map fun idx =>
+      let row := idx / n
+      let col := idx % n
+      smallEntryValue n row col salt
+
 /-- Per-parameter benchmark fixture: two deterministic square matrices. -/
 def prepMulInput (n : Nat) : MulInput :=
   { n := n
     lhs := flatMatrix n 17
     rhs := flatMatrix n 43 }
+
+/-- Per-parameter determinant fixture: one deterministic square matrix. -/
+def prepDetInput (n : Nat) : DetInput :=
+  { n := n
+    entries := flatSmallMatrix n 71 }
 
 /-- Reconstruct a typed dense square matrix from a row-major array. -/
 def matrixOfFlat (n : Nat) (entries : Array Int) : Hex.Matrix Int n n :=
@@ -65,6 +104,23 @@ def runSquareMulChecksum (input : MulInput) : Int :=
   let rhs : Hex.Matrix Int input.n input.n := matrixOfFlat input.n input.rhs
   checksum (lhs * rhs)
 
+/-- Benchmark target: compute the determinant using row-pivoted Bareiss
+elimination. Fixture construction is supplied by `prepDetInput`. -/
+def runBareissDet (input : DetInput) : Int :=
+  let M : Hex.Matrix Int input.n input.n := matrixOfFlat input.n input.entries
+  Hex.Matrix.bareiss M
+
+/-- Benchmark target: compute the same determinant using the generic Leibniz
+definition. This is intended only for small-domain conformance comparison. -/
+def runLeibnizDet (input : DetInput) : Int :=
+  let M : Hex.Matrix Int input.n input.n := matrixOfFlat input.n input.entries
+  Hex.Matrix.det M
+
+/-- Textbook operation-count model for the generic Leibniz determinant path. -/
+def leibnizDetComplexity : Nat → Nat
+  | 0 => 1
+  | n + 1 => (n + 1) * leibnizDetComplexity n
+
 setup_benchmark runSquareMulChecksum n => n * n * n
   with prep := prepMulInput
   where {
@@ -72,6 +128,24 @@ setup_benchmark runSquareMulChecksum n => n * n * n
     paramCeiling := 64
     maxSecondsPerCall := 0.5
     targetInnerNanos := 200000000
+  }
+
+setup_benchmark runBareissDet n => n * n * n
+  with prep := prepDetInput
+  where {
+    paramFloor := 4
+    paramCeiling := 64
+    maxSecondsPerCall := 1.5
+    targetInnerNanos := 800000000
+  }
+
+setup_benchmark runLeibnizDet n => n * leibnizDetComplexity n
+  with prep := prepDetInput
+  where {
+    paramFloor := 2
+    paramCeiling := 7
+    maxSecondsPerCall := 1.5
+    targetInnerNanos := 800000000
   }
 
 end Hex.MatrixBench

--- a/progress/2026-04-29T05:44:36Z_27632df4.md
+++ b/progress/2026-04-29T05:44:36Z_27632df4.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed feature issue `#669`.
+- Extended `HexMatrix/Bench.lean` with prepared determinant fixtures, a Bareiss determinant benchmark registration, and a small-domain generic Leibniz determinant registration for `compare`.
+- Updated the benchmark module docstring to distinguish scientific registrations from the small determinant cross-check.
+- Ran the new determinant benchmark; it exposed an inconclusive Bareiss cubic-model verdict, so I filed follow-up bench-found issue `#824`.
+
+**Current frontier**
+
+- `hexmatrix_bench` now lists and verifies three registrations: multiplication checksum, Bareiss determinant, and Leibniz determinant.
+- `compare Hex.MatrixBench.runBareissDet Hex.MatrixBench.runLeibnizDet` reports agreement on the common small determinant parameter.
+- The Bareiss implementation still appears slower than the declared cubic model and is tracked by `#824`.
+
+**Next step**
+
+- Address `#824` by inspecting the executable Bareiss update/indexing path and either fixing the implementation or rolling metadata back if `HexMatrix` advances past Phase 3 before the fix lands.
+
+**Blockers**
+
+- No blocker for landing the benchmark registrations from `#669`.


### PR DESCRIPTION
Closes #669

Session: `27632df4-52e2-4693-ba62-c81c8c6c6795`

814827c feat: add HexMatrix determinant benchmarks

🤖 Prepared with Claude Code