### PR TITLE
HexGfqField follow-up: finish characteristic-p transport after constant-helper landing

### DIFF
--- a/HexGfqField/Operations.lean
+++ b/HexGfqField/Operations.lean
@@ -292,6 +292,19 @@ theorem natCast_eq_natCast_iff_reduceMod_const_eq
     apply GFqRing.ext
     simpa [repr_natCast] using h
 
+theorem natCast_eq_natCast_iff_mod_eq
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hirr : FpPoly.Irreducible f)
+    (m n : Nat) :
+    ((m : FiniteField f hf hirr) = n) ↔ m % p = n % p := by
+  constructor
+  · intro h
+    have hq :
+        ((m : GFqRing.PolyQuotient f hf) = n) := by
+      simpa using congrArg FiniteField.toQuotient h
+    exact (GFqRing.natCast_eq_natCast_iff_mod_eq f hf m n).1 hq
+  · intro h
+    exact natCast_eq_of_mod_eq f hf hirr h
+
 @[simp] theorem toQuotient_add
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x y : FiniteField f hf hirr) :
@@ -583,13 +596,7 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
 
 instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f} :
     Lean.Grind.IsCharP (FiniteField f hf hirr) p where
-  ofNat_ext_iff {x y} := by
-    constructor
-    · intro h
-      sorry
-    · intro h
-      ext
-      all_goals sorry
+  ofNat_ext_iff {x y} := natCast_eq_natCast_iff_mod_eq f hf hirr x y
 
 theorem frob_eq_pow
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}

--- a/HexGfqRing/Operations.lean
+++ b/HexGfqRing/Operations.lean
@@ -222,6 +222,42 @@ theorem natCast_eq_natCast_iff_reduceMod_const_eq
     apply ext
     simpa [repr_natCast] using h
 
+private theorem coeff_zero_C (c : ZMod64 p) : (FpPoly.C c).coeff 0 = c := by
+  by_cases hc : c = 0
+  · subst c
+    change (DensePoly.C (0 : ZMod64 p)).coeff 0 = 0
+    have hcoeffs : (DensePoly.C (0 : ZMod64 p)).coeffs = #[] :=
+      DensePoly.coeffs_C_zero
+    have hzero : (Zero.zero : ZMod64 p) = (0 : ZMod64 p) := by
+      change ZMod64.zero = ZMod64.natCast p 0
+      rfl
+    simpa [DensePoly.coeff, hcoeffs] using hzero
+  · change (DensePoly.C c).coeff 0 = c
+    simp [DensePoly.coeff, DensePoly.coeffs_C_of_ne_zero hc]
+
+theorem natCast_eq_natCast_iff_mod_eq
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (m n : Nat) :
+    ((m : PolyQuotient f hf) = n) ↔ m % p = n % p := by
+  constructor
+  · intro h
+    have hrepr := (natCast_eq_natCast_iff_reduceMod_const_eq f hf m n).1 h
+    have hmred :
+        reduceMod f (FpPoly.C (m : ZMod64 p)) = FpPoly.C (m : ZMod64 p) := by
+      apply reduceMod_eq_self_of_degree_lt
+      simpa using hf
+    have hnred :
+        reduceMod f (FpPoly.C (n : ZMod64 p)) = FpPoly.C (n : ZMod64 p) := by
+      apply reduceMod_eq_self_of_degree_lt
+      simpa using hf
+    have hconst : FpPoly.C (m : ZMod64 p) = FpPoly.C (n : ZMod64 p) := by
+      simpa [hmred, hnred] using hrepr
+    have hz : (m : ZMod64 p) = (n : ZMod64 p) := by
+      have hcoeff := congrArg (fun g : FpPoly p => g.coeff 0) hconst
+      simpa [coeff_zero_C] using hcoeff
+    exact (ZMod64.natCast_eq_natCast_iff (p := p) m n).1 hz
+  · intro h
+    exact natCast_eq_of_mod_eq f hf h
+
 @[simp] theorem repr_add {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x y : PolyQuotient f hf) :
     repr (x + y) = reduceMod f (repr x + repr y) :=

--- a/progress/2026-04-29T07:12:10Z_36176b46.md
+++ b/progress/2026-04-29T07:12:10Z_36176b46.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed issue `#791`.
+- Added `GFqRing.natCast_eq_natCast_iff_mod_eq`, bridging quotient nat-cast equality for constants back to equality modulo `p`.
+- Added `GFqField.natCast_eq_natCast_iff_mod_eq` and used it to complete the `Lean.Grind.IsCharP (FiniteField f hf hirr) p` instance.
+- Verified with `lake build HexGfqField`, `python3 scripts/check_dag.py`, and the issue grep target.
+- `/second-opinion` and `/reflect` slash commands were not available in this session.
+
+**Current frontier**
+
+- The HexGfqField characteristic instance no longer has placeholders.
+- Remaining `sorry`s in `HexGfqField/Operations.lean` are still in the inverse/xgcd path and were outside this issue.
+
+**Next step**
+
+- Open the PR for `#791`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #791

Session: `36176b46-c84a-4d13-a4d1-18dc433f6e8a`

acda809 feat: finish GFqField characteristic transport

🤖 Prepared with Claude Code