### PR TITLE
fix: prove GF2 coefficient cancellation slice

### DIFF
--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -270,6 +270,26 @@ theorem UInt64.bne_zero_eq_toNat_bne_zero (w : UInt64) :
     subst hw
     exact (bne_iff_ne.mp hnat) rfl
 
+private theorem bit_eq_one_eq_testBit (x i : Nat) :
+    (x >>> i % 2 == 1) = x.testBit i := by
+  rw [Nat.testBit_eq_decide_div_mod_eq]
+  rw [Nat.shiftRight_eq_div_pow]
+  apply decide_eq_decide.mpr
+  exact Iff.rfl
+
+private theorem UInt64.bit_xor_bne (a b : UInt64) (i : Nat) :
+    ((((a ^^^ b) >>> i.toUInt64) &&& 1) != 0) =
+      ((((a >>> i.toUInt64) &&& 1) != 0) !=
+        (((b >>> i.toUInt64) &&& 1) != 0)) := by
+  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  simp [UInt64.toNat_xor, UInt64.toNat_shiftRight, UInt64.toNat_and]
+  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit]
+  simp [Nat.testBit_xor]
+
 private theorem oneHotWord_bit_toNat {hot bit : Nat} (hhot : hot < 64) (hbit : bit < 64) :
     (((((1 : UInt64) <<< hot.toUInt64) >>> bit.toUInt64) &&& 1).toNat) =
       ((2 ^ hot >>> bit) &&& 1) := by
@@ -603,7 +623,8 @@ theorem coeff_add (p q : GF2Poly) (n : Nat) :
 /-- Addition over packed `GF(2)` polynomials is coefficientwise XOR. -/
 theorem coeff_add_eq_bne (p q : GF2Poly) (n : Nat) :
     (p + q).coeff n = (p.coeff n != q.coeff n) := by
-  sorry
+  rw [coeff_add]
+  simp [coeffWords, xorWords_get?_getD, coeff, UInt64.bit_xor_bne]
 
 /-- Equal set coefficients cancel under `GF(2)` addition. -/
 theorem coeff_add_of_true_true {p q : GF2Poly} {n : Nat}

--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -847,21 +847,27 @@ theorem degree?_mulXk_of_degree?_eq_some {p : GF2Poly} {d k : Nat}
 theorem coeff_mulXk_degree_add {p : GF2Poly} {d k : Nat}
     (h : p.degree? = some d) :
     (p.mulXk k).coeff (d + k) = true := by
-  sorry
+  exact coeff_eq_true_of_degree?_eq_some (degree?_mulXk_of_degree?_eq_some h)
 
 /-- In a long-division step, shifting the divisor by `rd - qd` aligns its
 leading coefficient with the current remainder degree. -/
 theorem coeff_mulXk_division_step {q : GF2Poly} {rd qd : Nat}
     (hq : q.degree? = some qd) (hrd : ¬ rd < qd) :
     (q.mulXk (rd - qd)).coeff rd = true := by
-  sorry
+  have hshift := coeff_mulXk_degree_add (p := q) (d := qd) (k := rd - qd) hq
+  have hrd_eq : qd + (rd - qd) = rd := by
+    omega
+  simpa [hrd_eq] using hshift
 
 /-- The leading coefficient cancels after the characteristic-two subtraction
 step used by long division. -/
 theorem coeff_division_step_cancel {rem q : GF2Poly} {rd qd : Nat}
     (hrem : rem.degree? = some rd) (hq : q.degree? = some qd) (hrd : ¬ rd < qd) :
     (rem + q.mulXk (rd - qd)).coeff rd = false := by
-  sorry
+  rw [coeff_add_eq_bne]
+  rw [coeff_eq_true_of_degree?_eq_some hrem]
+  rw [coeff_mulXk_division_step hq hrd]
+  rfl
 
 /-- Alias for exact division by a power of `x` when the low coefficients vanish;
 otherwise this drops the discarded remainder. -/

--- a/progress/2026-04-29T08:39:19Z_e62683e3.md
+++ b/progress/2026-04-29T08:39:19Z_e62683e3.md
@@ -1,0 +1,29 @@
+**Accomplished**
+
+- Claimed issue `#913` and partially discharged the `HexGF2/Basic.lean`
+  `mulXk` division-step proof cluster.
+- Proved `GF2Poly.coeff_add_eq_bne` using a new local UInt64 bit-XOR helper
+  backed by `Nat.testBit_xor`.
+- Proved `coeff_mulXk_degree_add`, `coeff_mulXk_division_step`, and
+  `coeff_division_step_cancel` from the remaining degree-shift theorem and
+  the new coefficient-addition lemma.
+- Created follow-up issue `#920` for the remaining
+  `degree?_mulXk_of_degree?_eq_some` proof over packed word-shift carries.
+
+**Current frontier**
+
+- The only remaining `sorry` in the targeted `mulXk` cluster is
+  `degree?_mulXk_of_degree?_eq_some`.
+- That proof should focus on helper lemmas for `shiftLeftBitsList`, especially
+  the high-word carry case when `k % 64 != 0`.
+
+**Next step**
+
+- Prove `degree?_mulXk_of_degree?_eq_some` in follow-up `#920`, then rerun the
+  full `#913` verification commands to confirm the `mulXk` cluster has no
+  placeholder proofs.
+
+**Blockers**
+
+- Full issue `#913` remains incomplete because the packed word-shift degree
+  proof is larger than the coefficient-cancellation slice completed here.


### PR DESCRIPTION
Partial progress on #913

Session: `e62683e3-3666-44fd-bec7-1d12f1c271de`

c5a75cc chore: record GF2 partial proof progress
831e7d3 fix: prove GF2 division-step cancellation
1f69a08 fix: prove GF2 coefficient addition

🤖 Prepared with Claude Code