### PR TITLE
bench: raise HexArith fast benchmark signal target

### DIFF
--- a/HexArith/Bench.lean
+++ b/HexArith/Bench.lean
@@ -218,7 +218,7 @@ setup_benchmark runBarrettMulChain n => n
     paramCeiling := 131072
     paramSchedule := .custom #[8192, 16384, 32768, 65536, 131072]
     maxSecondsPerCall := 2.0
-    targetInnerNanos := 200000000
+    targetInnerNanos := 500000000
   }
 
 setup_benchmark runMontgomeryMulChain n => n
@@ -228,7 +228,7 @@ setup_benchmark runMontgomeryMulChain n => n
     paramCeiling := 131072
     paramSchedule := .custom #[8192, 16384, 32768, 65536, 131072]
     maxSecondsPerCall := 2.0
-    targetInnerNanos := 200000000
+    targetInnerNanos := 500000000
   }
 
 setup_benchmark runPowMod n => n
@@ -238,7 +238,7 @@ setup_benchmark runPowMod n => n
     paramCeiling := 16384
     paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384]
     maxSecondsPerCall := 2.0
-    targetInnerNanos := 200000000
+    targetInnerNanos := 500000000
   }
 
 setup_benchmark runNatExtGcdShapes n => n

--- a/progress/2026-04-29T10-27-13Z_af01378d.md
+++ b/progress/2026-04-29T10-27-13Z_af01378d.md
@@ -1,0 +1,25 @@
+**Accomplished**
+
+- Claimed `#965` and reviewed `HexArith/Bench.lean` against the HexArith SPEC, benchmarking rules, and Phase 4 exit criteria.
+- Confirmed `lake build HexArith.Bench`, `lake exe hexarith_bench list`, and `lake exe hexarith_bench verify` succeed.
+- Ran scientific checks for the registered HexArith benchmark families.
+- Confirmed the extended-GCD comparison reports agreement on common parameters and consistent linear verdicts for `Nat`, `Int`, and `UInt64`.
+- Found that the Barrett/Montgomery multiplication-chain comparison and `powMod` run are below the lean-bench signal floor and return inconclusive verdicts.
+- Filed follow-up `#978` for HexArith benchmark signal calibration.
+- Left `HexArith.done_through` unchanged at `3` and released `#965` to replan with the review result recorded.
+- Claimed `#978` and raised the scientific `targetInnerNanos` for `runBarrettMulChain`, `runMontgomeryMulChain`, and `runPowMod` from 200ms to 500ms.
+- Verified the Barrett/Montgomery comparison now reports agreement and consistent linear verdicts for both registrations.
+- Confirmed `runPowMod` now clears the signal floor but still reports a superlinear inconclusive verdict against its declared linear model.
+- Filed implementation follow-up `#980` for the public `powMod` exponent-bit complexity mismatch.
+
+**Current frontier**
+
+- HexArith Phase 4 has complete-looking registrations and smoke wiring. The multiplication-chain signal-floor issue is fixed; `powMod` now has a real complexity mismatch tracked by `#980`.
+
+**Next step**
+
+- Repair `powMod` exponent-bit complexity in `#980`, then rerun the HexArith Phase 4 review before bumping `HexArith.done_through`.
+
+**Blockers**
+
+- HexArith Phase 4 bump is blocked on `#980`.


### PR DESCRIPTION
Partial progress on #978

Session: `af01378d-cce8-4774-a2f1-c7c82bd549fd`

2ab1cf2 bench: raise HexArith fast benchmark signal target

🤖 Prepared with Claude Code