### PR TITLE
Fix HexPoly primitivePart content caching

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -280,11 +280,13 @@ def content (p : DensePoly Int) : Int :=
 
 /-- The primitive part obtained by dividing every coefficient by the content. -/
 def primitivePart (p : DensePoly Int) : DensePoly Int :=
-  if contentNat p = 0 then
+  let cNat := contentNat p
+  if cNat = 0 then
     0
   else
+    let c := Int.ofNat cNat
     ofCoeffs <|
-      (List.range p.size).map (fun i => p.coeff i / content p) |>.toArray
+      p.toArray.toList.map (fun coeff => coeff / c) |>.toArray
 
 theorem content_mul_primitivePart (p : DensePoly Int) :
     scale (content p) (primitivePart p) = p := by

--- a/progress/20260429T111201Z_9e094674.md
+++ b/progress/20260429T111201Z_9e094674.md
@@ -1,0 +1,22 @@
+**Accomplished**
+
+- Claimed feature issue `#1007`.
+- Updated `DensePoly.primitivePart` in `HexPoly/Euclid.lean` to compute polynomial content once and divide the stored coefficient array by that cached content.
+- Verified `lake build HexPoly.Bench`.
+- Verified `lake exe hexpoly_bench verify Hex.PolyBench.runPrimitivePartChecksum Hex.PolyBench.runContent`.
+- Re-ran `lake exe hexpoly_bench run Hex.PolyBench.runPrimitivePartChecksum`; verdict is `consistent with declared complexity` with `cMin=178.318`, `cMax=182.247`, and `β=-0.008`.
+- Re-ran adjacent `lake exe hexpoly_bench run Hex.PolyBench.runContent`; verdict is `consistent with declared complexity` with `cMin=138.867`, `cMax=139.920`, and `β=-0.003`.
+- Verified `python3 scripts/status.py HexPoly`, `git diff --check`, and no `native_decide` use under `HexPoly`.
+
+**Current frontier**
+
+- HexPoly remains at `done_through: 3`; this resolves the primitive-part Phase 4 blocker but does not complete the full Phase 4 review.
+- Remaining known HexPoly Phase 4 blockers are `#1005` for eval and `#1006` for derivative.
+
+**Next step**
+
+- Work `#1005` and `#1006`, then rerun the full HexPoly Phase 4 review before considering a `libraries.yml` bump to `HexPoly.done_through: 4`.
+
+**Blockers**
+
+- None for issue `#1007`.


### PR DESCRIPTION
Closes #1007

Session: `9e094674-5b85-4d6b-9de3-9b922fb43d9c`

## Summary
- Cache `DensePoly.primitivePart` content once before mapping coefficients.
- Divide the stored coefficient array directly by the cached content value.

## Benchmark verdicts
- `lake exe hexpoly_bench run Hex.PolyBench.runPrimitivePartChecksum`: `consistent with declared complexity` (`cMin=178.318`, `cMax=182.247`, `β=-0.008`).
- `lake exe hexpoly_bench run Hex.PolyBench.runContent`: `consistent with declared complexity` (`cMin=138.867`, `cMax=139.920`, `β=-0.003`).

## Verification
- `lake build HexPoly.Bench`
- `lake exe hexpoly_bench verify Hex.PolyBench.runPrimitivePartChecksum Hex.PolyBench.runContent`
- `lake exe hexpoly_bench run Hex.PolyBench.runPrimitivePartChecksum`
- `lake exe hexpoly_bench run Hex.PolyBench.runContent`
- `python3 scripts/status.py HexPoly`
- `git diff --check`
- `rg -n "native_decide" HexPoly -S`