### PR TITLE
fix: bound HexPoly eval benchmark coefficients

### DIFF
--- a/HexPoly/Bench.lean
+++ b/HexPoly/Bench.lean
@@ -5,9 +5,9 @@ import LeanBench
 Benchmark registrations for `hex-poly`.
 
 This Phase 4 slice measures the dense core operations over deterministic
-integer polynomials and Euclidean operations over a fixed-size prime field.
-Input construction is hoisted into `prep`, and each timed target returns a
-small checksum or scalar observable rather than the full polynomial.
+integer polynomials, with scalar-cost-sensitive operations over a fixed-size
+prime field. Input construction is hoisted into `prep`, and each timed target
+returns a small checksum or scalar observable rather than the full polynomial.
 
 Scientific registrations:
 
@@ -100,8 +100,8 @@ structure ContentInput where
 
 /-- Prepared input for Horner evaluation. -/
 structure EvalInput where
-  poly : DensePoly Int
-  point : Int
+  poly : DensePoly F7
+  point : F7
   deriving Hashable
 
 /-- Prepared input for polynomial composition. -/
@@ -195,8 +195,8 @@ def prepContentInput (n : Nat) : ContentInput :=
 
 /-- Per-parameter fixture for Horner evaluation. -/
 def prepEvalInput (n : Nat) : EvalInput :=
-  { poly := densePoly n 71
-    point := 3 }
+  { poly := denseF7Poly n 71
+    point := F7.ofNat 3 }
 
 /-- Per-parameter fixture for same-size dense polynomial composition. -/
 def prepComposeInput (n : Nat) : ComposeInput :=
@@ -250,7 +250,7 @@ def runMulChecksum (input : BinaryInput) : UInt64 :=
   checksum (input.lhs * input.rhs)
 
 /-- Benchmark target: evaluate a prepared dense polynomial at a fixed point. -/
-def runEval (input : EvalInput) : Int :=
+def runEval (input : EvalInput) : F7 :=
   DensePoly.eval input.poly input.point
 
 /-- Benchmark target: compose two prepared same-size dense polynomials. -/

--- a/progress/20260429T111219Z_f7fd7662.md
+++ b/progress/20260429T111219Z_f7fd7662.md
@@ -1,0 +1,22 @@
+**Accomplished**
+
+- Claimed feature issue `#1005`.
+- Repaired `Hex.PolyBench.runEval` by changing its prepared input from `DensePoly Int` evaluated at `3` to `DensePoly F7` evaluated at `F7.ofNat 3`, so the benchmark measures Horner step count with bounded coefficient cost.
+- Updated the `HexPoly/Bench.lean` module summary to mention fixed-size-field use for scalar-cost-sensitive operations.
+- Verified `lake build HexPoly.Bench`.
+- Verified `lake exe hexpoly_bench verify Hex.PolyBench.runEval`.
+- Ran `lake exe hexpoly_bench run Hex.PolyBench.runEval`; verdict is `consistent with declared complexity (cMin=21.712, cMax=22.162, β=-0.006)`.
+- Verified `python3 scripts/status.py HexPoly` and `git diff --check`.
+- Left `libraries.yml` unchanged with `HexPoly.done_through: 3`.
+
+**Current frontier**
+
+- HexPoly Phase 4 still has the remaining benchmark blockers `#1006` and `#1007`; this session only resolved the eval fixture/model mismatch.
+
+**Next step**
+
+- Work `#1006` for the derivative benchmark and `#1007` for primitive part, then re-run the full HexPoly Phase 4 review before any `HexPoly.done_through` bump.
+
+**Blockers**
+
+- None for `#1005`.


### PR DESCRIPTION
Closes #1005

Session: `f7fd7662-f09c-42cf-8870-d49b5cad3b04`

Summary:
- Move `Hex.PolyBench.runEval` from arbitrary-precision `Int` inputs to the existing fixed-size `F7` benchmark field.
- Keep the declared `n => n` scientific settings unchanged; the fixture now measures Horner step count with bounded scalar cost.
- Add this session progress note at `progress/20260429T111219Z_f7fd7662.md`.

Benchmark verdict:
- `lake exe hexpoly_bench run Hex.PolyBench.runEval`: consistent with declared complexity (cMin=21.712, cMax=22.162, β=-0.006).

Verification:
- `lake build HexPoly.Bench`
- `lake exe hexpoly_bench verify Hex.PolyBench.runEval`
- `lake exe hexpoly_bench run Hex.PolyBench.runEval`
- `python3 scripts/status.py HexPoly`
- `git diff --check`

Note: `libraries.yml` remains unchanged at `HexPoly.done_through: 3` because #1006 and #1007 still block Phase 4 completion.