### PR TITLE
review: mark HexPoly Phase 4 complete

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -28,7 +28,7 @@ libraries:
   HexPoly:
     deps: []
     mathlib: false
-    done_through: 3
+    done_through: 4
   HexMatrix:
     deps: []
     mathlib: false

--- a/progress/20260429T112019Z_d33763c8.md
+++ b/progress/20260429T112019Z_d33763c8.md
@@ -1,0 +1,22 @@
+**Accomplished**
+
+- Claimed review issue `#1013`.
+- Re-ran the full `HexPoly` Phase 4 benchmark review on current `main`.
+- Verified `lake build HexPoly.Bench`, `lake exe hexpoly_bench list`, and `lake exe hexpoly_bench verify`.
+- Ran all 15 parametric `Hex.PolyBench` registrations; every run returned `consistent with declared complexity`, including the repaired eval, derivative, and primitive-part registrations.
+- Bumped `HexPoly.done_through` from `3` to `4` in `libraries.yml`.
+- Verified `python3 scripts/status.py HexPoly`, `python3 scripts/status.py`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+**Current frontier**
+
+- `HexPoly` is now ready for Phase 5.
+- `HexPolyZ` is now ready for Phase 4 because its `HexPoly.done_through >= 4` dependency is satisfied.
+- `HexPolyFp` remains blocked on `HexModArith.done_through >= 4`.
+
+**Next step**
+
+- Dispatch or claim downstream Phase 4 work for `HexPolyZ`, and complete the existing HexModArith Phase 4 benchmark infrastructure work to unblock `HexPolyFp`.
+
+**Blockers**
+
+- None for this session's `#1013` work.


### PR DESCRIPTION
Closes #1013

Session: `d33763c8-b1e4-4f21-9649-5b1316924969`

Summary:
- Re-ran the full HexPoly Phase 4 benchmark review after the eval (#1005), derivative (#1006), and primitive-part (#1007) repairs.
- `lake exe hexpoly_bench list` exposes 15 parametric `Hex.PolyBench` registrations and no fixed or compare registrations.
- All 15 scientific runs returned `consistent with declared complexity`: runEval, runDivChecksum, runContent, runAddChecksum, runPolyCRTChecksum, runPrimitivePartChecksum, runGcdChecksum, runXGcdChecksum, runDerivativeChecksum, runSubChecksum, runComposeChecksum, runModByMonicChecksum, runModChecksum, runMulChecksum, and runDivModChecksum.
- Bumped `HexPoly.done_through` from `3` to `4`, which moves HexPoly to Phase 5 and unblocks HexPolyZ Phase 4. HexPolyFp remains blocked on HexModArith Phase 4.

Verification:
- `lake build HexPoly.Bench`
- `lake exe hexpoly_bench list`
- `lake exe hexpoly_bench verify`
- `lake exe hexpoly_bench run NAME` for all 15 listed parametric registrations
- `python3 scripts/status.py HexPoly`
- `python3 scripts/status.py`
- `python3 scripts/check_dag.py`
- `git diff --check`