### PR TITLE
feat: add HexGF2 zero monomial fold helpers

### DIFF
--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -91,6 +91,50 @@ private theorem coeffWords_xorClmulAt_ne (acc : Array UInt64) {idx n : Nat}
   have hHigh : idx + 1 ≠ n / 64 := Ne.symm hnHigh
   simp [xorClmulAt, coeffWords, hLow, hHigh]
 
+private theorem foldl_keep {α β : Type} (xs : List β) (acc : α) :
+    xs.foldl (fun acc _ => acc) acc = acc := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons _ xs ih => simp [ih]
+
+private theorem clmul_zero_right (x : UInt64) : clmul x 0 = (0, 0) := by
+  simp [clmul, pureClmul, foldl_keep]
+
+private theorem Array.setIfInBounds_getElem! (xs : Array UInt64) (idx : Nat) :
+    xs.setIfInBounds idx xs[idx]! = xs := by
+  unfold Array.setIfInBounds
+  by_cases h : idx < xs.size
+  · simp [h]
+  · simp [h]
+
+private theorem xorClmulAt_zero_right (acc : Array UInt64) (idx : Nat) (x : UInt64) :
+    xorClmulAt acc idx x 0 = acc := by
+  simp [xorClmulAt, clmul_zero_right, Array.setIfInBounds_getElem!]
+
+private theorem coeffWords_xorClmulAt_zero_right (acc : Array UInt64) (idx n : Nat)
+    (x : UInt64) :
+    coeffWords (xorClmulAt acc idx x 0) n = coeffWords acc n := by
+  rw [xorClmulAt_zero_right]
+
+private theorem foldl_xorClmulAt_zero_right_coeff (js : List Nat) (acc : Array UInt64)
+    (idx n : Nat) (x : UInt64) (ys : Array UInt64)
+    (hzero : ∀ j ∈ js, ys[j]! = 0) :
+    coeffWords
+        (js.foldl (fun acc j => xorClmulAt acc (idx + j) x ys[j]!) acc)
+        n =
+      coeffWords acc n := by
+  induction js generalizing acc with
+  | nil =>
+      simp
+  | cons j js ih =>
+      have hjzero : ys[j]! = 0 := hzero j (by simp)
+      have htail : ∀ j' ∈ js, ys[j']! = 0 := by
+        intro j' hj'
+        exact hzero j' (by simp [hj'])
+      simp only [List.foldl_cons]
+      rw [hjzero, ih (acc := xorClmulAt acc (idx + j) x 0) htail,
+        coeffWords_xorClmulAt_zero_right]
+
 /-- Raw packed-word multiplication before trailing zero normalization. -/
 private def mulWords (xs ys : Array UInt64) : Array UInt64 :=
   if xs.isEmpty || ys.isEmpty then

--- a/progress/20260429T113634Z_28b390d3.md
+++ b/progress/20260429T113634Z_28b390d3.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed `#1016`, confirmed the right-monomial theorem is larger than one proof slice, and decomposed it into `#1022`, `#1023`, and `#1024`.
+- Claimed `#1022`.
+- Added private `HexGF2/Multiply.lean` helpers for `clmul x 0`, zero-right `xorClmulAt`, coefficient preservation, and zero-selected-word inner folds.
+- Verified `lake build HexGF2.Multiply`, `lake build HexGF2.Clmul`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+**Current frontier**
+
+- `#1022` has the zero-right raw-fold base needed by the active one-hot contribution issue.
+- `#1023` is blocked on `#1022` and should use the new fold helper with a concrete zero-prefix premise for monomial words before proving the active word contribution.
+
+**Next step**
+
+- Prove the monomial-prefix zero lookup and the active `j = k / 64` one-hot update in `#1023`, then assemble `mul_monomial` in `#1024`.
+
+**Blockers**
+
+- `rg -n "axiom|native_decide|sorry|admit" HexGF2 -S` still reports pre-existing placeholders in `HexGF2/Field.lean`, `HexGF2/Euclid.lean`, and the smoke-test axiom in `HexGF2/Smoke.lean`; this session added none.


### PR DESCRIPTION
Closes #1022

## Summary
- add private zero-right carry-less multiplication helper lemmas in HexGF2.Multiply
- add a reusable inner-fold coefficient preservation lemma for zero selected right words
- record session progress in progress/20260429T113634Z_28b390d3.md

## Verification
- lake build HexGF2.Multiply
- lake build HexGF2.Clmul
- python3 scripts/check_dag.py
- git diff --check
- rg -n "axiom|native_decide|sorry|admit" HexGF2 -S (pre-existing hits only)