### PR TITLE
SPEC/benchmarking: forbid no-data and inconclusive-as-pass benchmarks

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -463,3 +463,21 @@ explicitly forbidden:
 - **Rolling a hex-local benchmark harness.** lean-bench is the
   harness; gaps in its API are filed against it, not papered over
   locally.
+- **Shipping a registration that produces no verdict-eligible rows.**
+  A parametric `run` that emits `only 0 verdict-eligible row(s)
+  survived warmup-trim + signal-floor filter` is evidence the
+  schedule, the per-call cap, or the target inner nanos was set too
+  low for the host the benchmark is scientifically supposed to run
+  on. The fix is the same as for any Phase-4 calibration miss: file
+  an issue, don't merge a registration whose largest interesting rung
+  is below 10× the per-spawn floor on the intended hardware. (Until
+  lean-bench exits non-zero in this case — see [#1045](https://github.com/kim-em/hex/issues/1045)
+  — every parametric registration must be visually inspected the
+  first time it runs on a target host.)
+- **Treating an "inconclusive" verdict as a passing scientific run.**
+  Phase-4 exit criteria require either "consistent with declared
+  complexity" or a tracked finding-issue explaining the mismatch
+  ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). Inconclusive
+  verdicts on a registration whose schedule needed bumping are
+  miscalibration, not findings, and the registration must be
+  re-tuned before the library advances through Phase 4.


### PR DESCRIPTION
## Summary

Adds two anti-patterns to [SPEC/benchmarking.md](SPEC/benchmarking.md) §Anti-patterns surfaced while running PR #914's `Hex.ArithBench.runPowMod` on a fast Apple Silicon laptop:

1. **Shipping a registration that produces no verdict-eligible rows.** Every rung in the `.custom` schedule fell below 10× the per-spawn floor, so all rows were filtered as `<floor` and the parametric verdict was inconclusive. The bullet references #1045 so the "until lean-bench exits non-zero…" caveat can be dropped once that upstream UX is fixed.

2. **Treating an "inconclusive" verdict as a passing scientific run.** Restates the Phase-4 exit criterion (consistent with declared complexity, or a tracked finding) — a miscalibrated schedule is not a finding.

## Related

- #1045 — human-oversight tracker for upstream lean-bench `--param-ceiling` UX + non-zero exit fixes
- #1046 — human-oversight follow-up to re-calibrate the 15 existing parametric registrations

## Test plan

- [x] Read back the rendered Anti-patterns section to confirm the two new bullets land in the right place and read consistently with the surrounding tone.
- [ ] Markdown link check (CI).

🤖 Prepared with Claude Code