### PR TITLE
fix: make ZMod64 pow benchmark linear

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -149,6 +149,7 @@ Raise a residue to a natural power using exponentiation by squaring.
 The accumulator form keeps the executable path close to the intended downstream
 runtime usage while preserving a simple semantic contract.
 -/
+@[extern "lean_hex_zmod64_pow"]
 def pow (a : ZMod64 p) (n : Nat) : ZMod64 p :=
   let rec go (base acc : ZMod64 p) (k : Nat) : ZMod64 p :=
     match k with

--- a/HexModArith/Bench.lean
+++ b/HexModArith/Bench.lean
@@ -118,7 +118,7 @@ def mulInnerRepeats : Nat :=
 
 /-- Hot-loop multiplier for repeated exponentiation by squaring. -/
 def powInnerRepeats : Nat :=
-  64
+  256
 
 /-- Hot-loop multiplier for the Barrett chain benchmark. -/
 def barrettInnerRepeats : Nat :=
@@ -334,9 +334,9 @@ setup_benchmark runMulChecksum n => n
 setup_benchmark runPow n => n
   with prep := prepPowInput
   where {
-    paramFloor := 8192
-    paramCeiling := 32768
-    paramSchedule := .custom #[8192, 16384, 32768]
+    paramFloor := 65536
+    paramCeiling := 262144
+    paramSchedule := .custom #[65536, 131072, 262144]
     maxSecondsPerCall := 8.0
     targetInnerNanos := 500000000
   }

--- a/HexModArith/ffi/zmod64_mul.c
+++ b/HexModArith/ffi/zmod64_mul.c
@@ -1,5 +1,21 @@
 #include <lean/lean.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
 #include <stdint.h>
+
+typedef unsigned long mp_limb_t;
+typedef struct {
+    int _mp_alloc;
+    int _mp_size;
+    mp_limb_t* _mp_d;
+} __mpz_struct;
+typedef __mpz_struct mpz_t[1];
+
+extern void __gmpz_init(mpz_t);
+extern void __gmpz_clear(mpz_t);
+extern void* __gmpz_export(void*, size_t*, int, size_t, int, size_t, const mpz_t);
+extern void lean_extract_mpz_value(lean_object*, mpz_t);
 
 LEAN_EXPORT uint64_t lean_hex_zmod64_mul(b_lean_obj_arg p, uint64_t a, uint64_t b) {
     lean_object* max_word_nat = lean_uint64_to_nat(UINT64_MAX);
@@ -16,4 +32,96 @@ LEAN_EXPORT uint64_t lean_hex_zmod64_mul(b_lean_obj_arg p, uint64_t a, uint64_t 
 
     lean_dec(max_word_nat);
     return result;
+}
+
+static bool lean_hex_modulus_is_word(lean_object* p) {
+    lean_object* max_word_nat = lean_uint64_to_nat(UINT64_MAX);
+    bool is_word = lean_nat_lt(max_word_nat, p);
+    lean_dec(max_word_nat);
+    return is_word;
+}
+
+static uint64_t lean_hex_mul_mod_word(uint64_t a, uint64_t b, uint64_t modulus, bool word_modulus) {
+    __uint128_t product = (__uint128_t)a * (__uint128_t)b;
+    if (word_modulus) {
+        return (uint64_t)product;
+    }
+    return (uint64_t)(product % modulus);
+}
+
+static uint64_t lean_hex_pow_mod_u64(uint64_t base, uint64_t exponent, uint64_t modulus, bool word_modulus) {
+    uint64_t acc = word_modulus ? 1 : 1 % modulus;
+
+    while (exponent != 0) {
+        if ((exponent & 1) != 0) {
+            acc = lean_hex_mul_mod_word(acc, base, modulus, word_modulus);
+        }
+        exponent >>= 1;
+        if (exponent != 0) {
+            base = lean_hex_mul_mod_word(base, base, modulus, word_modulus);
+        }
+    }
+
+    return acc;
+}
+
+static size_t lean_hex_bit_length_u64(uint64_t word) {
+    size_t bits = 0;
+    while (word != 0) {
+        ++bits;
+        word >>= 1;
+    }
+    return bits;
+}
+
+static uint64_t* lean_hex_nat_to_u64_limbs(b_lean_obj_arg exponent, size_t* limb_count) {
+    mpz_t exponent_z;
+    __gmpz_init(exponent_z);
+    lean_extract_mpz_value(exponent, exponent_z);
+
+    uint64_t* limbs =
+        (uint64_t*)__gmpz_export(NULL, limb_count, -1, sizeof(uint64_t), 0, 0, exponent_z);
+    __gmpz_clear(exponent_z);
+    return limbs;
+}
+
+static uint64_t lean_hex_pow_mod_big_nat(uint64_t base, b_lean_obj_arg exponent,
+        uint64_t modulus, bool word_modulus) {
+    size_t limb_count = 0;
+    uint64_t* limbs = lean_hex_nat_to_u64_limbs(exponent, &limb_count);
+    uint64_t acc = word_modulus ? 1 : 1 % modulus;
+
+    if (limb_count != 0) {
+        size_t top_bits = lean_hex_bit_length_u64(limbs[limb_count - 1]);
+        for (size_t limb_index = limb_count; limb_index > 0; --limb_index) {
+            uint64_t limb = limbs[limb_index - 1];
+            size_t bit_limit = (limb_index == limb_count) ? top_bits : 64;
+            for (size_t bit = bit_limit; bit > 0; --bit) {
+                acc = lean_hex_mul_mod_word(acc, acc, modulus, word_modulus);
+                if (((limb >> (bit - 1)) & 1) != 0) {
+                    acc = lean_hex_mul_mod_word(acc, base, modulus, word_modulus);
+                }
+            }
+        }
+    }
+
+    free(limbs);
+    return acc;
+}
+
+LEAN_EXPORT uint64_t lean_hex_zmod64_pow(b_lean_obj_arg p, uint64_t a, b_lean_obj_arg n) {
+    bool word_modulus = lean_hex_modulus_is_word(p);
+    uint64_t modulus = word_modulus ? 0 : lean_uint64_of_nat(p);
+
+    if (!word_modulus && modulus == 1) {
+        return 0;
+    }
+
+    uint64_t base = word_modulus ? a : a % modulus;
+
+    if (lean_is_scalar(n)) {
+        return lean_hex_pow_mod_u64(base, (uint64_t)lean_unbox(n), modulus, word_modulus);
+    }
+
+    return lean_hex_pow_mod_big_nat(base, n, modulus, word_modulus);
 }

--- a/SPEC/Libraries/hex-mod-arith.md
+++ b/SPEC/Libraries/hex-mod-arith.md
@@ -35,9 +35,9 @@ Mathlib dependency.
 ## Default operations
 
 Operations are stated as semantic contracts on the canonical
-representative. Only `mul` carries a mandatory `@[extern]` for
-runtime; `add`/`sub`/`zero`/`one`/`pow` lower to native `UInt64`
-arithmetic in pure Lean already, and `inv` routes through the
+representative. `mul` and `pow` carry mandatory `@[extern]` runtime
+paths; `add`/`sub`/`zero`/`one` lower to native `UInt64` arithmetic
+in pure Lean already, and `inv` routes through the
 `@[extern "lean_hex_mpz_gcdext"]`-bearing `extGcd` declared in
 `HexArith.Int` (see "Extern contract: `mpz_gcdext`" in
 `SPEC/Libraries/hex-arith.md`). **`inv` must NOT call
@@ -56,6 +56,7 @@ def ZMod64.sub (a b : ZMod64 p) : ZMod64 p          -- pure Lean
 def ZMod64.zero : ZMod64 p
 def ZMod64.one  : ZMod64 p                          -- equals zero when p = 1
 def ZMod64.inv  (a : ZMod64 p) : ZMod64 p           -- via Hex.Int.extGcd
+@[extern "lean_hex_zmod64_pow"]
 def ZMod64.pow  (a : ZMod64 p) (n : Nat) : ZMod64 p
 ```
 
@@ -105,6 +106,22 @@ The Phase-1 deliverable is the strategy-1 reference body plus the
 `p`-dispatched Barrett/Montgomery implementation behind the same
 extern symbol. Whichever strategy is used, it must agree with the
 logical body — the SPEC mandates the contract, not the strategy.
+
+### `ZMod64.pow` runtime contract
+
+Logical body (used by Lean for proofs and as the portable semantic
+contract): exponentiation by squaring over `ZMod64.mul`, reading the
+natural exponent from low bits to high bits.
+
+The runtime implementation is supplied by `lean_hex_zmod64_pow` in
+`HexModArith/ffi/zmod64_mul.c`. It exports large Lean `Nat` exponents
+to 64-bit limbs once, then scans those limbs from high bits to low
+bits while performing the same square-and-multiply recurrence on
+`UInt64` residues. This keeps exponent-bit traversal linear in the
+bit length instead of repeatedly dividing a shrinking arbitrary-
+precision `Nat` by two. The runtime result must agree with the
+logical body for every bounded modulus, including the degenerate
+modulus `1` and the word modulus `2^64`.
 
 ## Hot-loop optimization (opt-in)
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -65,7 +65,8 @@ lean_lib HexMatrix where
 lean_lib HexModArith where
   precompileModules := true
   moreLinkArgs := #[
-    s!"{(defaultBuildDir / "lib" / nameToStaticLib "hexmodarithffi").toString}"
+    s!"{(defaultBuildDir / "lib" / nameToStaticLib "hexmodarithffi").toString}",
+    "-lgmp"
   ]
 
 lean_lib HexGramSchmidt where

--- a/progress/20260429T123312Z_62ccd84f.md
+++ b/progress/20260429T123312Z_62ccd84f.md
@@ -1,0 +1,24 @@
+**Accomplished**
+
+- Claimed feature issue `#1043` for the `HexModArith` pow benchmark scaling finding.
+- Added an extern-backed runtime path for public `ZMod64.pow`, preserving the Lean square-and-multiply body as the semantic contract.
+- Implemented `lean_hex_zmod64_pow` in `HexModArith/ffi/zmod64_mul.c`; large Lean `Nat` exponents are exported once to 64-bit limbs and scanned high-to-low.
+- Tuned `Hex.ModArithBench.runPow` to use stronger hot-loop amplification and a larger scientific schedule now that the implementation is fast enough.
+- Updated `SPEC/Libraries/hex-mod-arith.md` so the documented runtime contract includes the new `pow` extern.
+- Verified `runPow` reports `consistent with declared complexity` at params `65536`, `131072`, and `262144`.
+- Ran the full `HexModArith` benchmark smoke verification successfully.
+- Filed follow-up issue `#1055` for residual non-pow Phase 4 scientific verdict blockers found during the full review, and marked it blocked on `#1043`.
+
+**Current frontier**
+
+- `Hex.ModArithBench.runPow` is no longer the Phase 4 blocker.
+- `HexModArith.done_through` remains `3`; Phase 4 still needs `#1055` before it can be bumped to `4`.
+- `HexPolyFp` Phase 4 remains blocked on `HexModArith.done_through >= 4`.
+
+**Next step**
+
+- Land this pow fix PR, then a worker should claim `#1055` and stabilize or diagnose the remaining non-pow `HexModArith` Phase 4 benchmark verdicts.
+
+**Blockers**
+
+- Residual non-pow benchmark findings are tracked in `#1055`.


### PR DESCRIPTION
Closes #1043

Session: `62ccd84f-edc4-4fd4-8249-7507ce3599f4`

46608a5 fix: make ZMod64 pow benchmark linear

🤖 Prepared with Claude Code