### PR TITLE
SPEC/benchmarking: forbid no-data and inconclusive-as-pass benchmarks; bump lean-bench

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -463,3 +463,20 @@ explicitly forbidden:
 - **Rolling a hex-local benchmark harness.** lean-bench is the
   harness; gaps in its API are filed against it, not papered over
   locally.
+- **Shipping a registration that produces no verdict-eligible rows.**
+  A parametric `run` whose every rung is filtered out by the
+  warmup-trim or signal-floor filter exits with code `2` and reports
+  `only 0 verdict-eligible row(s) survived…`. That is the harness
+  telling you the schedule, the per-call cap, or the target inner
+  nanos was set too low for the host the benchmark is supposed to
+  run on. CI treats exit 2 the same as a verdict mismatch: file an
+  issue, roll back, fix. Don't shrink scientific settings to dodge
+  the verdict.
+- **Treating an "inconclusive" verdict as a passing scientific run.**
+  Phase-4 exit criteria require either "consistent with declared
+  complexity" or a tracked finding-issue explaining the mismatch
+  ([PLAN/Phase4.md](../PLAN/Phase4.md) §Exit criteria). An
+  inconclusive verdict whose root cause is a too-narrow schedule
+  (rungs too close to the per-spawn floor, even when some survive
+  the filter) is miscalibration, not a finding, and the registration
+  must be re-tuned before the library advances through Phase 4.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "81e2ff683f3fdf6803eafe60251716f9c95c73ea",
+   "rev": "e2a36e639b7f04cc4a02e547f83d4d00f83ed7c5",
    "name": "«lean-bench»",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",


### PR DESCRIPTION
## Summary

Adds two anti-patterns to [SPEC/benchmarking.md](SPEC/benchmarking.md) §Anti-patterns surfaced while running PR #914's \`Hex.ArithBench.runPowMod\` on a fast Apple Silicon laptop, plus the lean-bench bump that makes the first one mechanically enforceable.

1. **Shipping a registration that produces no verdict-eligible rows.** Lean-bench now exits with code \`2\` from \`run\`/\`compare\` (https://github.com/kim-em/lean-bench/pull/49) when zero rungs survive the warmup-trim + signal-floor filter. CI can detect this without scraping stdout.

2. **Treating an "inconclusive" verdict as a passing scientific run.** Even when some rows survive, an inconclusive verdict whose root cause is rungs too close to the per-spawn floor is miscalibration. Restates the Phase-4 exit criterion (consistent with declared complexity, or a tracked finding).

Bumps lean-bench from \`81e2ff6\` to \`e2a36e6\` to pick up both upstream fixes:
- https://github.com/kim-em/lean-bench/pull/48 — schedule-aware advisory; warns on stderr when \`--param-floor\`/\`--param-ceiling\` is passed alongside a \`.custom\` schedule
- https://github.com/kim-em/lean-bench/pull/49 — exit code \`2\` from \`run\`/\`compare\` on no usable data

## Test plan

- [x] \`lake update lean-bench\` resolved cleanly to e2a36e6.
- [x] \`lake build hexarith_bench\` succeeds (101/101).
- [x] \`lake exe hexarith_bench list\` still lists all six registered benchmarks.
- [x] \`lake exe hexarith_bench run Hex.ArithBench.runPowMod\` now surfaces the new schedule-aware advisory text:
      \`Drop the smallest params from the declared \\\`paramSchedule := .custom #[...]\\\` array to skip the cold regime if the trimmed warmup isn't enough.\`
      (Replacing the old, misleading \`Try \\\`--param-ceiling\\\` higher\` suggestion.)
- [ ] Markdown link-check (CI).

## Follow-up

A separate \`human-oversight\` issue tracks re-calibrating the 15 existing parametric registrations against the new exit-code-2 contract.

🤖 Prepared with Claude Code