### PR TITLE
HexGF2: prove low-word left one-hot clmul fold invariant

### DIFF
--- a/HexGF2/Clmul.lean
+++ b/HexGF2/Clmul.lean
@@ -1,4 +1,5 @@
 import HexGF2.Basic
+import Std.Tactic.BVDecide
 
 /-!
 Carry-less `UInt64` multiplication for `hex-gf2`.
@@ -236,6 +237,93 @@ theorem pureClmul_oneHot (a : UInt64) {bit : Nat} (hbit : bit < 64) :
     pureClmul a ((1 : UInt64) <<< bit.toUInt64) =
       if bit = 0 then (0, a) else (a >>> (64 - bit).toUInt64, a <<< bit.toUInt64) := by
   rw [pureClmul, foldl_oneHot a hbit, clmulAccumulateBit_zero]
+
+private def clmulOneHotLeftLowStep (hot : Nat) (a lo : UInt64) (bitIdx : Nat) : UInt64 :=
+  if (((a >>> bitIdx.toUInt64) &&& 1) != 0) then
+    if hot + bitIdx < 64 then
+      lo ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64)
+    else
+      lo
+  else
+    lo
+
+private theorem foldl_oneHot_left_snd_eq_lowStep (a : UInt64) {hot : Nat}
+    (hhot : hot < 64) :
+    ∀ (xs : List Nat) (acc : UInt64 × UInt64),
+      (∀ bitIdx ∈ xs, bitIdx < 64) →
+      (xs.foldl
+          (fun acc bitIdx =>
+            if (((a >>> bitIdx.toUInt64) &&& 1) != 0) then
+              clmulAccumulateBit acc ((1 : UInt64) <<< hot.toUInt64) bitIdx
+            else
+              acc)
+          acc).2 =
+        xs.foldl (clmulOneHotLeftLowStep hot a) acc.2 := by
+  intro xs
+  induction xs with
+  | nil =>
+      intro acc _
+      simp
+  | cons bitIdx xs ih =>
+      intro acc hlt
+      have hbitIdx : bitIdx < 64 := hlt bitIdx (by simp)
+      have hltTail : ∀ idx ∈ xs, idx < 64 := by
+        intro idx hmem
+        exact hlt idx (by simp [hmem])
+      rw [List.foldl_cons, List.foldl_cons]
+      by_cases hset : (((a >>> bitIdx.toUInt64) &&& 1) != 0) = true
+      · by_cases hsum : hot + bitIdx < 64
+        · rw [if_pos hset]
+          have hlowStep :
+              clmulOneHotLeftLowStep hot a acc.2 bitIdx =
+                acc.2 ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64) := by
+            simp [clmulOneHotLeftLowStep, hset, hsum]
+          rw [clmulAccumulateBit_oneHot_low acc hhot hbitIdx hsum]
+          simpa [hlowStep] using
+            ih (acc.1, acc.2 ^^^ ((1 : UInt64) <<< (hot + bitIdx).toUInt64)) hltTail
+        · have hsumGe : 64 ≤ hot + bitIdx := Nat.le_of_not_gt hsum
+          rw [if_pos hset]
+          have hlowStep : clmulOneHotLeftLowStep hot a acc.2 bitIdx = acc.2 := by
+            simp [clmulOneHotLeftLowStep, hset, hsum]
+          rw [clmulAccumulateBit_oneHot_high acc hhot hbitIdx hsumGe]
+          simpa [hlowStep] using
+            ih (acc.1 ^^^ ((1 : UInt64) <<< (hot + bitIdx - 64).toUInt64), acc.2) hltTail
+      · rw [if_neg hset]
+        have hlowStep : clmulOneHotLeftLowStep hot a acc.2 bitIdx = acc.2 := by
+          simp [clmulOneHotLeftLowStep, hset]
+        simpa [hlowStep] using ih acc hltTail
+
+set_option maxHeartbeats 2000000 in
+/-- Low word of pure carry-less multiplication with an in-word monomial on the
+left. -/
+theorem pureClmul_oneHot_left_snd (a : UInt64) {bit : Nat} (hbit : bit < 64) :
+    (pureClmul ((1 : UInt64) <<< bit.toUInt64) a).2 =
+      if bit = 0 then a else a <<< bit.toUInt64 := by
+  rw [pureClmul]
+  rw [foldl_oneHot_left_snd_eq_lowStep a hbit (List.range 64) (0, 0)
+    (by
+      intro bitIdx hmem
+      exact List.mem_range.mp hmem)]
+  have hcases : bit = 0 ∨ bit = 1 ∨ bit = 2 ∨ bit = 3 ∨ bit = 4 ∨ bit = 5 ∨
+      bit = 6 ∨ bit = 7 ∨ bit = 8 ∨ bit = 9 ∨ bit = 10 ∨ bit = 11 ∨
+      bit = 12 ∨ bit = 13 ∨ bit = 14 ∨ bit = 15 ∨ bit = 16 ∨ bit = 17 ∨
+      bit = 18 ∨ bit = 19 ∨ bit = 20 ∨ bit = 21 ∨ bit = 22 ∨ bit = 23 ∨
+      bit = 24 ∨ bit = 25 ∨ bit = 26 ∨ bit = 27 ∨ bit = 28 ∨ bit = 29 ∨
+      bit = 30 ∨ bit = 31 ∨ bit = 32 ∨ bit = 33 ∨ bit = 34 ∨ bit = 35 ∨
+      bit = 36 ∨ bit = 37 ∨ bit = 38 ∨ bit = 39 ∨ bit = 40 ∨ bit = 41 ∨
+      bit = 42 ∨ bit = 43 ∨ bit = 44 ∨ bit = 45 ∨ bit = 46 ∨ bit = 47 ∨
+      bit = 48 ∨ bit = 49 ∨ bit = 50 ∨ bit = 51 ∨ bit = 52 ∨ bit = 53 ∨
+      bit = 54 ∨ bit = 55 ∨ bit = 56 ∨ bit = 57 ∨ bit = 58 ∨ bit = 59 ∨
+      bit = 60 ∨ bit = 61 ∨ bit = 62 ∨ bit = 63 := by
+    omega
+  rcases hcases with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl |
+    rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
+    simp [List.range, List.range.loop, List.foldl, clmulOneHotLeftLowStep] <;>
+    bv_decide
 
 /-- Trusted runtime hook for carry-less multiplication.
 

--- a/progress/20260429T145827Z_2d8d2c4e.md
+++ b/progress/20260429T145827Z_2d8d2c4e.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed `#1112`.
+- Added the low-word left one-hot `pureClmul` theorem in `HexGF2/Clmul.lean`.
+- Added a private low-projection fold helper that reduces the folded pair accumulator to a low-word step function using `clmulAccumulateBit_oneHot_low` and `clmulAccumulateBit_oneHot_high`.
+- Verified `lake build HexGF2.Clmul`, `lake build HexGF2.Multiply`, `python3 scripts/check_dag.py`, `git diff --check`, and `rg -n "axiom|native_decide" HexGF2 -S`.
+
+**Current frontier**
+
+- `#1112` is complete.
+- The sibling high-word fold invariant remains in `#1113`.
+
+**Next step**
+
+- Publish the PR for `#1112`; the next HexGF2 proof step should be `#1113`.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1112

Session: `2d8d2c4e-5729-4ee3-baa4-49bff2fd16b1`

8f1d72b feat: prove low-word left one-hot clmul

🤖 Prepared with Claude Code