### PR TITLE
fix: isolate arithmetic prime API from Mathlib Nat namespace

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -3,10 +3,12 @@ import HexArith.Nat.ModArith
 /-!
 Mathlib-free combinatorial and prime-number lemmas for `HexArith`.
 
-This module owns the local `Nat.choose` and `Nat.Prime` surfaces that the
+This module owns the local `Hex.Nat.choose` and `Hex.Nat.Prime` surfaces that the
 computational core needs for binomial divisibility and Fermat-style congruence
 statements, without importing Mathlib into the root arithmetic layer.
 -/
+
+namespace Hex
 
 namespace Nat
 
@@ -39,9 +41,9 @@ def Prime (p : Nat) : Prop :=
 
 namespace Prime
 
-theorem two_le {p : Nat} (hp : Nat.Prime p) : 2 ≤ p := hp.1
+theorem two_le {p : Nat} (hp : Hex.Nat.Prime p) : 2 ≤ p := hp.1
 
-theorem dvd_mul {p a b : Nat} (hp : Nat.Prime p) (h : p ∣ a * b) :
+theorem dvd_mul {p a b : Nat} (hp : Hex.Nat.Prime p) (h : p ∣ a * b) :
     p ∣ a ∨ p ∣ b := by
   sorry
 
@@ -51,22 +53,24 @@ end Prime
 Every nontrivial binomial coefficient in the `p`th row of Pascal's triangle is
 divisible by `p` when `p` is prime.
 -/
-theorem choose_prime_dvd {p k : Nat} (hp : Nat.Prime p) (hk : 0 < k) (hk' : k < p) :
-    p ∣ Nat.choose p k := by
+theorem choose_prime_dvd {p k : Nat} (hp : Prime p) (hk : 0 < k) (hk' : k < p) :
+    p ∣ choose p k := by
   sorry
 
 /--
 Freshman's dream modulo a prime: all middle binomial terms vanish.
 -/
-theorem add_pow_prime_mod {p : Nat} (hp : Nat.Prime p) (a b : Nat) :
+theorem add_pow_prime_mod {p : Nat} (hp : Prime p) (a b : Nat) :
     (a + b) ^ p % p = (a ^ p + b ^ p) % p := by
   sorry
 
 /--
 Fermat's little theorem in the form used by downstream modular arithmetic code.
 -/
-theorem pow_prime_mod {p : Nat} (hp : Nat.Prime p) (a : Nat) :
+theorem pow_prime_mod {p : Nat} (hp : Prime p) (a : Nat) :
     a ^ p % p = a % p := by
   sorry
 
 end Nat
+
+end Hex

--- a/HexModArith/Prime.lean
+++ b/HexModArith/Prime.lean
@@ -5,7 +5,7 @@ import HexModArith.Ring
 Prime-modulus theorem surface for `hex-mod-arith`.
 
 This module packages the `ZMod64` consequences that only hold when the modulus
-is prime, reusing the upstream `HexArith.Nat.Prime` lemmas rather than
+is prime, reusing the upstream `Hex.Nat.Prime` lemmas rather than
 re-proving prime arithmetic locally.
 -/
 namespace Hex
@@ -24,7 +24,7 @@ private theorem eq_zero_of_dvd_modulus {a : ZMod64 p} (h : p ∣ a.toNat) : a = 
 Prime-modulus residues have no zero divisors: if `a * b = 0`, then one of the
 factors is already zero.
 -/
-theorem eq_zero_or_eq_zero_of_mul_eq_zero (hp : Nat.Prime p) {a b : ZMod64 p}
+theorem eq_zero_or_eq_zero_of_mul_eq_zero (hp : Hex.Nat.Prime p) {a b : ZMod64 p}
     (h : a * b = 0) : a = 0 ∨ b = 0 := by
   have hmod : (a.toNat * b.toNat) % p = 0 := by
     simpa using congrArg ZMod64.toNat h
@@ -32,7 +32,7 @@ theorem eq_zero_or_eq_zero_of_mul_eq_zero (hp : Nat.Prime p) {a b : ZMod64 p}
     have hdecomp := Nat.mod_add_div (a.toNat * b.toNat) p
     rw [hmod, Nat.zero_add] at hdecomp
     exact ⟨(a.toNat * b.toNat) / p, hdecomp.symm⟩
-  rcases Nat.Prime.dvd_mul hp hdvd with hA | hB
+  rcases Hex.Nat.Prime.dvd_mul hp hdvd with hA | hB
   · exact Or.inl (eq_zero_of_dvd_modulus hA)
   · exact Or.inr (eq_zero_of_dvd_modulus hB)
 
@@ -40,13 +40,13 @@ theorem eq_zero_or_eq_zero_of_mul_eq_zero (hp : Nat.Prime p) {a b : ZMod64 p}
 Fermat's little theorem for `ZMod64`: raising a residue mod a prime `p` to the
 `p`th power returns the original residue.
 -/
-theorem pow_prime (hp : Nat.Prime p) (a : ZMod64 p) : a ^ p = a := by
+theorem pow_prime (hp : Hex.Nat.Prime p) (a : ZMod64 p) : a ^ p = a := by
   apply ext
   apply UInt64.toNat_inj.mp
   have hpow : (a ^ p).toNat = a.toNat := by
     calc
       (a ^ p).toNat = a.toNat ^ p % p := toNat_pow a p
-      _ = a.toNat % p := Nat.pow_prime_mod hp a.toNat
+      _ = a.toNat % p := Hex.Nat.pow_prime_mod hp a.toNat
       _ = a.toNat := Nat.mod_eq_of_lt a.toNat_lt
   simpa [ZMod64.toNat_eq_val] using hpow
 

--- a/HexPolyFp/Conformance.lean
+++ b/HexPolyFp/Conformance.lean
@@ -41,7 +41,7 @@ private theorem one_ne_zero_five : (1 : ZMod64 5) ≠ 0 := by
   have hm := (ZMod64.natCast_eq_natCast_iff (p := 5) 1 0).mp h
   simp at hm
 
-private theorem prime_five : Nat.Prime 5 := by
+private theorem prime_five : Hex.Nat.Prime 5 := by
   constructor
   · decide
   · intro m hm

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -8,7 +8,7 @@ This module implements a Yun-style square-free decomposition for
 `Hex.FpPoly p`, recording the unit factor and the positive-multiplicity
 square-free factors obtained from repeated gcd/derivative steps and
 `p`-th-root descent in characteristic `p`. The public API carries an
-explicit `Nat.Prime p` contract because the exported factorization and
+explicit `Hex.Nat.Prime p` contract because the exported factorization and
 square-free theorems are intended for prime-field coefficients.
 -/
 namespace Hex
@@ -124,7 +124,7 @@ private def squareFreeAux (f : FpPoly p) (multiplicity : Nat) :
 Compute a square-free decomposition by normalizing away the leading scalar and
 running Yun's algorithm on the resulting monic polynomial.
 -/
-def squareFreeDecomposition (hp : Nat.Prime p) (f : FpPoly p) : SquareFreeDecomposition p :=
+def squareFreeDecomposition (hp : Hex.Nat.Prime p) (f : FpPoly p) : SquareFreeDecomposition p :=
   let _ := hp
   let normalized := normalizeMonic f
   let unit := normalized.1
@@ -132,17 +132,17 @@ def squareFreeDecomposition (hp : Nat.Prime p) (f : FpPoly p) : SquareFreeDecomp
   let factors := squareFreeAux monicPart 1 (monicPart.size + 1)
   { unit, factors }
 
-theorem squareFree_pairwise_coprime (hp : Nat.Prime p) (f : FpPoly p) :
+theorem squareFree_pairwise_coprime (hp : Hex.Nat.Prime p) (f : FpPoly p) :
     let d := squareFreeDecomposition hp f
     d.factors.Pairwise (fun a b => DensePoly.gcd a.factor b.factor = 1) := by
   sorry
 
-theorem squareFree_weightedProduct (hp : Nat.Prime p) (f : FpPoly p) :
+theorem squareFree_weightedProduct (hp : Hex.Nat.Prime p) (f : FpPoly p) :
     let d := squareFreeDecomposition hp f
     DensePoly.C d.unit * weightedProduct d.factors = f := by
   sorry
 
-theorem squareFree_factors_squareFree (hp : Nat.Prime p) (f : FpPoly p) :
+theorem squareFree_factors_squareFree (hp : Hex.Nat.Prime p) (f : FpPoly p) :
     let d := squareFreeDecomposition hp f
     ∀ sf ∈ d.factors, DensePoly.gcd sf.factor (DensePoly.derivative sf.factor) = 1 := by
   sorry

--- a/progress/20260429T155016Z_42a06292.md
+++ b/progress/20260429T155016Z_42a06292.md
@@ -1,0 +1,24 @@
+**Accomplished**
+- Claimed #1099, diagnosed that its Berlekamp/Mathlib scaffold is blocked by the
+  existing root `Nat.choose` collision with Mathlib, filed #1119, linked it as a
+  dependency, and skipped #1099 as blocked.
+- Claimed #1119 and moved the local mathlib-free combinatorial and prime API
+  from root `Nat` into `Hex.Nat`.
+- Updated the downstream prime contracts in `HexModArith` and `HexPolyFp` to use
+  `Hex.Nat.Prime`.
+- Verified both import orders: `HexModArithMathlib` can import after Mathlib,
+  and `HexBerlekamp` can coexist with `HexPolyMathlib.Basic` in one module.
+
+**Current frontier**
+- The arithmetic layer no longer defines `Nat.choose` or `Nat.Prime`, removing
+  the collision that blocked Mathlib-facing imports.
+- The Berlekamp correctness scaffold from #1099 remains unimplemented until its
+  own issue is re-claimed.
+
+**Next step**
+- Re-claim #1099 or a follow-up bridge issue and add the initial
+  `HexBerlekampMathlib` theorem surface now that the import-order blocker is
+  gone.
+
+**Blockers**
+- None for #1119.


### PR DESCRIPTION
Closes #1119

Session: `42a06292-7c85-4c90-b701-6d8bb7f85e84`

845c624 fix: isolate arithmetic prime API

🤖 Prepared with Claude Code