### PR TITLE
ci: add HexGF2 benchmark smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
       - run: |
           lake exe hexmodarith_bench list
           lake exe hexmodarith_bench verify
+      - run: |
+          lake exe hexgf2_bench list
+          lake exe hexgf2_bench verify

--- a/progress/20260429T224332Z_a4c067bd.md
+++ b/progress/20260429T224332Z_a4c067bd.md
@@ -1,0 +1,22 @@
+**Accomplished**
+
+- Claimed issue #1174 for the HexGF2 Phase 4 verdict and CI smoke slice.
+- Added the missing `hexgf2_bench` CI smoke step to run `lake exe hexgf2_bench list` and `lake exe hexgf2_bench verify`.
+- Ran the HexGF2 benchmark wiring checks; `list` and `verify` passed for all 23 registrations.
+- Ran the Phase 4 scientific benchmark registrations via the built `hexgf2_bench` executable using the fully qualified registered names.
+- Confirmed the two packed-versus-generic compare groups have hash agreement on all common parameters.
+- Filed follow-up issues #1175, #1176, and #1177 for the three inconclusive benchmark verdicts found during the Phase 4 check.
+
+**Current frontier**
+
+- `HexGF2.done_through` remains at `3`; Phase 4 is intentionally not complete because `runFp2GcdCompareChecksum`, `runPackedBerlekampCompareChecksum`, and `runFp2BerlekampCompareChecksum` returned inconclusive verdicts.
+- The CI smoke coverage is now ready to land independently of the remaining scientific verdict fixes.
+
+**Next step**
+
+- Fix the inconclusive comparison benchmark verdicts tracked by #1175, #1176, and #1177, then rerun the full HexGF2 Phase 4 check before bumping `libraries.yml`.
+
+**Blockers**
+
+- No CI-smoke blocker remains.
+- HexGF2 Phase 4 completion is blocked on the three benchmark finding issues above.


### PR DESCRIPTION
Closes #1174

## Summary

- Add the missing CI smoke step for `hexgf2_bench list` and `hexgf2_bench verify`.
- Ran the HexGF2 Phase 4 benchmark check and left `libraries.yml` unchanged because three registrations returned inconclusive verdicts.
- Filed follow-up findings: #1175 (`runFp2GcdCompareChecksum`), #1176 (`runPackedBerlekampCompareChecksum`), and #1177 (`runFp2BerlekampCompareChecksum`).

## Verification

- `lake exe hexgf2_bench list`
- `lake exe hexgf2_bench verify`
- scientific runs for all 23 registered HexGF2 benchmarks via `.lake/build/bin/hexgf2_bench run Hex.GF2Bench.<name>`
- `.lake/build/bin/hexgf2_bench compare Hex.GF2Bench.runPackedGcdCompareChecksum Hex.GF2Bench.runFp2GcdCompareChecksum`
- `.lake/build/bin/hexgf2_bench compare Hex.GF2Bench.runPackedBerlekampCompareChecksum Hex.GF2Bench.runFp2BerlekampCompareChecksum`
- `lake build HexGF2`
- `python3 scripts/status.py HexGF2`
- `python3 scripts/check_dag.py`
- `git diff --check`

Session: `a4c067bd-d81d-4bac-857c-e6596459b2d2`