### PR TITLE
doc: derive gramschmidt adjacent benchmark models

### DIFF
--- a/HexGramSchmidt/Bench.lean
+++ b/HexGramSchmidt/Bench.lean
@@ -294,6 +294,10 @@ setup_benchmark runAdjacentSwapChecksum n => rowUpdateComplexity n
     targetInnerNanos := 200000000
   }
 
+/- `prepUpdateInput n` produces `rows = n + 3`, and
+`runAdjacentSwapDenom` calls `gramDet b k` with `k = rows - 1`. The dominant
+work is building the leading Gram surface and Bareiss-eliminating it, so the
+fixture parameter maps to `gramSurfaceComplexity (n + 3)`. -/
 setup_benchmark runAdjacentSwapDenom n => updateGramComplexity n
   with prep := prepUpdateInput
   where {
@@ -305,6 +309,10 @@ setup_benchmark runAdjacentSwapDenom n => updateGramComplexity n
     signalFloorMultiplier := 1.0
   }
 
+/- `prepUpdateInput n` uses `rows = n + 3`. The pivot coefficient reads one
+entry from `scaledCoeffs b`; because matrices are dense vectors, constructing
+that surface is the dominant step, giving `scaledCoeffSurfaceComplexity
+(n + 3)`. -/
 setup_benchmark runAdjacentSwapPivotCoeff n => updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
@@ -316,6 +324,10 @@ setup_benchmark runAdjacentSwapPivotCoeff n => updateScaledCoeffComplexity n
     signalFloorMultiplier := 1.0
   }
 
+/- The numerator combines two Gram determinants with the pivot coefficient.
+Under `prepUpdateInput n`, `rows = n + 3`; the pivot coefficient constructs
+the dense `scaledCoeffs` surface, which dominates the scalar arithmetic and
+Gram determinant calls. -/
 setup_benchmark runAdjacentSwapGramDetNumerator n => updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
@@ -327,6 +339,9 @@ setup_benchmark runAdjacentSwapGramDetNumerator n => updateScaledCoeffComplexity
     signalFloorMultiplier := 1.0
   }
 
+/- The quotient adds one denominator call to the numerator path. With
+`rows = n + 3`, the numerator's dense `scaledCoeffs` construction remains the
+dominant step, so the model is still `scaledCoeffSurfaceComplexity (n + 3)`. -/
 setup_benchmark runAdjacentSwapGramDetQuotient n => updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
@@ -339,6 +354,10 @@ setup_benchmark runAdjacentSwapGramDetQuotient n => updateScaledCoeffComplexity 
     verdictWarmupFraction := 0.25
   }
 
+/- For the above-row previous-column update, `prepUpdateInput n` supplies
+`rows = n + 3`. The formula reads two `scaledCoeffs` entries and the adjacent
+swap quotient; dense `scaledCoeffs` construction dominates, so the declared
+model uses `scaledCoeffSurfaceComplexity (n + 3)`. -/
 setup_benchmark runAdjacentSwapScaledCoeffAbovePrevNumerator n =>
     updateScaledCoeffComplexity n
   with prep := prepUpdateInput
@@ -351,6 +370,10 @@ setup_benchmark runAdjacentSwapScaledCoeffAbovePrevNumerator n =>
     signalFloorMultiplier := 1.0
   }
 
+/- For the above-row current-column update, `prepUpdateInput n` again maps to
+`rows = n + 3`. The dominant operation is constructing the dense `scaledCoeffs`
+surface for the two coefficient entries, while the Gram determinant and scalar
+operations are lower-order. -/
 setup_benchmark runAdjacentSwapScaledCoeffAboveCurrNumerator n =>
     updateScaledCoeffComplexity n
   with prep := prepUpdateInput

--- a/progress/20260430T003402Z_033c4c72.md
+++ b/progress/20260430T003402Z_033c4c72.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed human-oversight issue #1195 for the `HexGramSchmidt` adjacent-swap benchmark audit.
+- Added adjacent derivation comments for the six `n + 3` adjacent-swap benchmark registrations in `HexGramSchmidt/Bench.lean`.
+- Re-ran the six scientific benchmark commands on `carica`; `runAdjacentSwapDenom` was consistent, and the scaled-coefficient cluster exposed inconclusive verdicts.
+- Filed follow-up issue #1200 for the inconclusive adjacent scaled-coefficient benchmark findings.
+- Verified `lake build HexGramSchmidt`, `lake exe hexgramschmidt_bench list`, the six requested `lake exe hexgramschmidt_bench run ...` commands, `python3 scripts/status.py HexGramSchmidt`, `python3 scripts/check_dag.py`, `git diff --check`, and the target registration grep.
+
+**Current frontier**
+
+- `HexGramSchmidt` remains at `done_through: 3` and Phase 4-ready; no rollback edit was needed because Phase 4 has not been promoted.
+- Four exported benchmark rows in #1200 remain inconclusive against `updateScaledCoeffComplexity n`: `runAdjacentSwapPivotCoeff`, `runAdjacentSwapGramDetQuotient`, `runAdjacentSwapScaledCoeffAbovePrevNumerator`, and `runAdjacentSwapScaledCoeffAboveCurrNumerator`.
+
+**Next step**
+
+- Work #1200 before any `HexGramSchmidt` Phase 4 promotion: determine whether the inconclusive verdicts come from implementation complexity, benchmark instability, or a misdeclared cost model.
+
+**Blockers**
+
+- `HexGramSchmidt` Phase 4 promotion should not proceed until #1200 is resolved or explicitly scoped out by a follow-up audit.


### PR DESCRIPTION
Closes #1195

Session: `033c4c72-0ab8-441f-b99d-c6d1ea1e21b4`

Commit:
- 2d60695 doc: derive gramschmidt adjacent benchmark models

Benchmark audit output on host `carica`:
- `runAdjacentSwapDenom`: consistent with declared complexity (cMin=29.466, cMax=37.830)
- `runAdjacentSwapPivotCoeff`: inconclusive (cMin=3.490844, cMax=6.906397) -> tracked by #1200
- `runAdjacentSwapGramDetNumerator`: consistent on JSON export rerun (cMin=6.955247, cMax=8.24685)
- `runAdjacentSwapGramDetQuotient`: inconclusive (cMin=2.4603, cMax=5.73434) -> tracked by #1200
- `runAdjacentSwapScaledCoeffAbovePrevNumerator`: inconclusive (cMin=8.696824, cMax=25.392119) -> tracked by #1200
- `runAdjacentSwapScaledCoeffAboveCurrNumerator`: inconclusive (cMin=4.741022, cMax=10.092951) -> tracked by #1200

Verification:
- `lake build HexGramSchmidt`
- `lake exe hexgramschmidt_bench list`
- six `lake exe hexgramschmidt_bench run Hex.GramSchmidtBench.<name>` scientific runs
- `lake exe hexgramschmidt_bench run --export-file /tmp/hexgramschmidt-adjacent-scaledcoeff-1195.json ...`
- `python3 scripts/status.py HexGramSchmidt`
- `python3 scripts/check_dag.py`
- `git diff --check`