### PR TITLE
bench: stabilize gramschmidt adjacent scaled coefficients

### DIFF
--- a/HexGramSchmidt/Bench.lean
+++ b/HexGramSchmidt/Bench.lean
@@ -43,7 +43,7 @@ structure IntBasisInput where
 
 /-- Prepared typed matrix plus stable row indices for update-helper
 benchmarks. `prepUpdateInput n` uses `n + 3` rows so the adjacent-swap
-benchmarks always have a previous row and an above-row sample. -/
+benchmarks always have a previous row and a scaling above-row sample. -/
 structure UpdateInput where
   rows : Nat
   cols : Nat
@@ -126,8 +126,8 @@ def prepUpdateInput (n : Nat) : UpdateInput :=
       entries := flatUpdateBasis rows cols 83 }
   let sizeReduceSrc : Fin rows := ⟨0, by simp [rows]⟩
   let pivotK : Fin rows := ⟨n + 2, by simp [rows]⟩
-  let aboveK : Fin rows := ⟨1, by simp [rows]⟩
-  let aboveI : Fin rows := ⟨2, by simp [rows]⟩
+  let aboveK : Fin rows := ⟨n + 1, by simp [rows]⟩
+  let aboveI : Fin rows := ⟨n + 2, by simp [rows]⟩
   { rows := rows
     cols := cols
     matrix := matrixOfFlat flat
@@ -138,7 +138,7 @@ def prepUpdateInput (n : Nat) : UpdateInput :=
       omega
     aboveK := aboveK
     aboveHK := by
-      change 0 < 1
+      change 0 < n + 1
       omega
     aboveI := aboveI
     coeff := Int.ofNat ((n * 17 + 5) % 9) - 4 }
@@ -312,15 +312,17 @@ setup_benchmark runAdjacentSwapDenom n => updateGramComplexity n
 /- `prepUpdateInput n` uses `rows = n + 3`. The pivot coefficient reads one
 entry from `scaledCoeffs b`; because matrices are dense vectors, constructing
 that surface is the dominant step, giving `scaledCoeffSurfaceComplexity
-(n + 3)`. -/
+(n + 3)`. The ladder starts after the smallest cold rungs used for the full
+surface benchmark because this scalar helper otherwise spends too much of its
+signal on fixed evaluator overhead. -/
 setup_benchmark runAdjacentSwapPivotCoeff n => updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
-    paramFloor := 3
-    paramCeiling := 6
-    paramSchedule := .custom #[3, 4, 5, 6]
+    paramFloor := 8
+    paramCeiling := 16
+    paramSchedule := .custom #[8, 10, 12, 14, 16]
     maxSecondsPerCall := 5.0
-    targetInnerNanos := 200000000
+    targetInnerNanos := 1000000000
     signalFloorMultiplier := 1.0
   }
 
@@ -345,44 +347,48 @@ dominant step, so the model is still `scaledCoeffSurfaceComplexity (n + 3)`. -/
 setup_benchmark runAdjacentSwapGramDetQuotient n => updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
-    paramFloor := 3
-    paramCeiling := 6
-    paramSchedule := .custom #[3, 4, 5, 6]
+    paramFloor := 8
+    paramCeiling := 16
+    paramSchedule := .custom #[8, 10, 12, 14, 16]
     maxSecondsPerCall := 5.0
     targetInnerNanos := 200000000
     signalFloorMultiplier := 1.0
-    verdictWarmupFraction := 0.25
+    verdictWarmupFraction := 0.4
   }
 
 /- For the above-row previous-column update, `prepUpdateInput n` supplies
-`rows = n + 3`. The formula reads two `scaledCoeffs` entries and the adjacent
-swap quotient; dense `scaledCoeffs` construction dominates, so the declared
-model uses `scaledCoeffSurfaceComplexity (n + 3)`. -/
+`rows = n + 3` and chooses `aboveK = rows - 2`, `aboveI = rows - 1`, so the
+sampled scaled-coefficient entries have prefixes that grow with the fixture.
+The formula reads two `scaledCoeffs` entries and the adjacent-swap quotient;
+dense `scaledCoeffs` construction dominates, so the declared model uses
+`scaledCoeffSurfaceComplexity (n + 3)`. -/
 setup_benchmark runAdjacentSwapScaledCoeffAbovePrevNumerator n =>
     updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
-    paramFloor := 3
-    paramCeiling := 6
-    paramSchedule := .custom #[3, 4, 5, 6]
+    paramFloor := 4
+    paramCeiling := 12
+    paramSchedule := .custom #[4, 6, 8, 10, 12]
     maxSecondsPerCall := 5.0
     targetInnerNanos := 200000000
     signalFloorMultiplier := 1.0
+    verdictWarmupFraction := 0.4
   }
 
 /- For the above-row current-column update, `prepUpdateInput n` again maps to
-`rows = n + 3`. The dominant operation is constructing the dense `scaledCoeffs`
-surface for the two coefficient entries, while the Gram determinant and scalar
-operations are lower-order. -/
+`rows = n + 3` and uses the final above-row sample, so the coefficient prefixes
+scale with the prepared fixture. The dominant operation is constructing the
+dense `scaledCoeffs` surface for the two coefficient entries, while the Gram
+determinant and scalar operations are lower-order. -/
 setup_benchmark runAdjacentSwapScaledCoeffAboveCurrNumerator n =>
     updateScaledCoeffComplexity n
   with prep := prepUpdateInput
   where {
-    paramFloor := 3
-    paramCeiling := 6
-    paramSchedule := .custom #[3, 4, 5, 6]
+    paramFloor := 4
+    paramCeiling := 12
+    paramSchedule := .custom #[4, 6, 8, 10, 12]
     maxSecondsPerCall := 5.0
-    targetInnerNanos := 200000000
+    targetInnerNanos := 1000000000
     signalFloorMultiplier := 1.0
   }
 

--- a/progress/20260430T010207Z_0a98191c.md
+++ b/progress/20260430T010207Z_0a98191c.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed feature issue #1200 for the `HexGramSchmidt` adjacent scaled-coefficient benchmark investigation.
+- Updated `HexGramSchmidt/Bench.lean` so above-row adjacent-swap fixtures use scaling indices (`aboveK = rows - 2`, `aboveI = rows - 1`) instead of fixed tiny prefixes.
+- Kept the scaled-coefficient cost model, but moved the affected scalar-helper benchmark ladders out of the noisy cold region and raised the pivot/current numerator timing budget where needed.
+- Re-ran the four affected scientific benchmark commands on `carica`; all now report `consistent with declared complexity`.
+- Verified `lake build HexGramSchmidt`, `python3 scripts/status.py HexGramSchmidt`, `python3 scripts/check_dag.py`, `git diff --check`, and the target registration grep.
+
+**Current frontier**
+
+- `HexGramSchmidt` remains Phase 4-ready with `done_through: 3`.
+- The #1200 blocker is resolved in this branch by fixture and measurement-domain corrections, not by changing the declared scaled-coefficient model.
+
+**Next step**
+
+- Create the PR for #1200 with the benchmark verdict output in the description/commit context so Phase 4 promotion can proceed after review.
+
+**Blockers**
+
+- None for this session.


### PR DESCRIPTION
Closes #1200

Session: `0a98191c-b050-4d28-8a2d-a5ae1ae3c07a`

## Summary

- Fixed the adjacent above-row benchmark fixture so `aboveK = rows - 2` and `aboveI = rows - 1`; the prior fixed `1,2` sample only exercised tiny determinant prefixes as `n` grew.
- Kept the scaled-coefficient surface model for the affected scalar helpers, but moved the scientific ladders out of the cold/noisy region and raised timing budget where needed.
- Left `HexGramSchmidt.done_through` unchanged at `3`.

## Scientific Benchmark Verdicts

Host `carica`, Lean `4.30.0-rc2`, branch commit `77ae737-dirty`.

```text
Hex.GramSchmidtBench.runAdjacentSwapPivotCoeff
params 8,10,12,14,16; verdict: consistent with declared complexity (cMin=2.685, cMax=3.562)

Hex.GramSchmidtBench.runAdjacentSwapGramDetQuotient
params 8,10,12,14,16; verdict: consistent with declared complexity (cMin=1.397, cMax=1.609)

Hex.GramSchmidtBench.runAdjacentSwapScaledCoeffAbovePrevNumerator
params 4,6,8,10,12; verdict: consistent with declared complexity (cMin=4.363, cMax=4.633)

Hex.GramSchmidtBench.runAdjacentSwapScaledCoeffAboveCurrNumerator
params 4,6,8,10,12; verdict: consistent with declared complexity (cMin=4.144, cMax=5.502)
```

## Verification

```text
lake build HexGramSchmidt
lake exe hexgramschmidt_bench run Hex.GramSchmidtBench.runAdjacentSwapPivotCoeff
lake exe hexgramschmidt_bench run Hex.GramSchmidtBench.runAdjacentSwapGramDetQuotient
lake exe hexgramschmidt_bench run Hex.GramSchmidtBench.runAdjacentSwapScaledCoeffAbovePrevNumerator
lake exe hexgramschmidt_bench run Hex.GramSchmidtBench.runAdjacentSwapScaledCoeffAboveCurrNumerator
python3 scripts/status.py HexGramSchmidt
python3 scripts/check_dag.py
git diff --check
rg -n "runAdjacentSwap(PivotCoeff|GramDetQuotient|ScaledCoeffAbovePrevNumerator|ScaledCoeffAboveCurrNumerator)|aboveK|aboveI|updateScaledCoeffComplexity" HexGramSchmidt/Bench.lean -S
```
