### PR TITLE
docs: clarify HexPoly Euclidean benchmark model

### DIFF
--- a/HexPoly/Bench.lean
+++ b/HexPoly/Bench.lean
@@ -414,8 +414,9 @@ setup_benchmark runModByMonicChecksum n => n * n
 
 /-
 The prepared inputs are consecutive polynomial Fibonacci values. That shape
-intentionally forces the Euclidean worst case: Theta(n) quotient steps, with
-schoolbook division work across decreasing degrees summing to Theta(n^2).
+intentionally forces the Euclidean worst case: Theta(n) quotient steps. Each
+division in the chain has quotient `x` and spends linear work in the current
+degree, so the decreasing-degree divisions sum to Theta(n^2).
 -/
 setup_benchmark runGcdChecksum n => n * n
   with prep := prepEuclidWorstInput
@@ -430,8 +431,11 @@ setup_benchmark runGcdChecksum n => n * n
 
 /-
 This uses the same Fibonacci quotient-chain fixture as `runGcdChecksum`.
-Extended gcd carries Bezout updates in the same Euclidean loop, so the declared
-model is the worst-case polynomial Euclidean bound, not an average-case claim.
+Extended gcd carries Bezout updates in the same Euclidean loop; here every
+quotient is degree one, so each Bezout multiplication/update is linear in the
+current coefficient length. Those updates and the divisions both sum to
+Theta(n^2) over the decreasing-degree chain, matching the declared worst-case
+polynomial Euclidean bound.
 -/
 setup_benchmark runXGcdChecksum n => n * n
   with prep := prepEuclidWorstInput

--- a/progress/20260430T011250Z_314f820d.md
+++ b/progress/20260430T011250Z_314f820d.md
@@ -1,0 +1,19 @@
+**Accomplished**
+
+- Claimed feature issue #1202 for the HexPoly Euclidean worst-case benchmark investigation.
+- Re-ran `Hex.PolyBench.runGcdChecksum` and `Hex.PolyBench.runXGcdChecksum` on `carica`; both reported `consistent with declared complexity` on the existing scientific schedule.
+- Strengthened the adjacent `HexPoly/Bench.lean` derivation comments to spell out the Fibonacci quotient-chain, degree-one quotient, and Bezout-update cost argument for the declared `Theta(n^2)` model.
+- Verified `lake build hexpoly_bench`, `lake exe hexpoly_bench run Hex.PolyBench.runGcdChecksum`, `lake exe hexpoly_bench run Hex.PolyBench.runXGcdChecksum`, `python3 scripts/status.py HexPoly`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+**Current frontier**
+
+- HexPoly remains `done_through: 4` and ready for Phase 5; the reported Euclidean benchmark inconclusiveness did not reproduce at the current HEAD.
+- No rollback is needed because the current implementation and benchmark verdicts support the documented worst-case model.
+
+**Next step**
+
+- Open the PR for #1202 with the benchmark verdicts in the description.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1202

Session: `314f820d-c6c2-40ad-a241-9b5e9133affc`

## Summary

- Re-ran the HexPoly Euclidean worst-case benchmark registrations on `carica`; the reported inconclusive verdicts did not reproduce at current HEAD.
- Left the scientific schedule and `n * n` declarations unchanged.
- Clarified the adjacent derivation comments for the Fibonacci quotient-chain fixture and extended-gcd Bezout updates.

## Benchmark verdicts

`lake exe hexpoly_bench run Hex.PolyBench.runGcdChecksum`:

```
verdict: consistent with declared complexity (cMin=108.024, cMax=120.790, β=-0.078)
```

`lake exe hexpoly_bench run Hex.PolyBench.runXGcdChecksum`:

```
verdict: consistent with declared complexity (cMin=104.510, cMax=118.064, β=-0.080)
```

No rollback is needed: HexPoly remains `done_through: 4`, and `python3 scripts/status.py HexPoly` reports it ready for Phase 5.

## Verification

- `lake build hexpoly_bench`
- `lake exe hexpoly_bench run Hex.PolyBench.runGcdChecksum`
- `lake exe hexpoly_bench run Hex.PolyBench.runXGcdChecksum`
- `python3 scripts/status.py HexPoly`
- `python3 scripts/check_dag.py`
- `git diff --check`
