### PR TITLE
feat: complete HexGfq phase 1 scaffold

### DIFF
--- a/HexGfqRing/Operations.lean
+++ b/HexGfqRing/Operations.lean
@@ -704,6 +704,10 @@ private theorem zmod64_zero_add (a : ZMod64 p) : (0 : ZMod64 p) + a = a := by
   rw [h]
   rw [ZMod64.toNat_eq_val, ZMod64.toNat_eq_val, hz, Nat.zero_add, hmod]
 
+private theorem zmod64_zero_add_zero :
+    (Zero.zero : ZMod64 p) + (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p) :=
+  zmod64_zero_add Zero.zero
+
 private theorem fpPoly_C_add (a b : ZMod64 p) :
     FpPoly.C (a + b) = (FpPoly.C a + FpPoly.C b : FpPoly p) := by
   apply DensePoly.ext_coeff
@@ -712,11 +716,13 @@ private theorem fpPoly_C_add (a b : ZMod64 p) :
   · subst i
     change DensePoly.coeff (DensePoly.C (a + b)) 0 =
       DensePoly.coeff (DensePoly.C a + DensePoly.C b) 0
-    rw [DensePoly.coeff_add, DensePoly.coeff_C, DensePoly.coeff_C, DensePoly.coeff_C]
+    rw [DensePoly.coeff_add _ _ _ zmod64_zero_add_zero, DensePoly.coeff_C,
+      DensePoly.coeff_C, DensePoly.coeff_C]
     simp
   · change DensePoly.coeff (DensePoly.C (a + b)) i =
       DensePoly.coeff (DensePoly.C a + DensePoly.C b) i
-    rw [DensePoly.coeff_add, DensePoly.coeff_C, DensePoly.coeff_C, DensePoly.coeff_C]
+    rw [DensePoly.coeff_add _ _ _ zmod64_zero_add_zero, DensePoly.coeff_C,
+      DensePoly.coeff_C, DensePoly.coeff_C]
     simp [hi]
     exact (zmod64_zero_add (p := p) (0 : ZMod64 p)).symm
 

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -91,6 +91,26 @@ private theorem zmod_add_zero (a : ZMod64 p) : a + 0 = a := by
 private theorem zmod_zero_add (a : ZMod64 p) : 0 + a = a := by
   grind
 
+private theorem zmod_add_zero_zero :
+    (Zero.zero : ZMod64 p) + (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p) :=
+  zmod_add_zero Zero.zero
+
+private theorem zmod_sub_zero_zero :
+    (Zero.zero : ZMod64 p) - (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p) := by
+  have hzval : (Zero.zero : ZMod64 p).val = 0 := rfl
+  change ZMod64.sub (Zero.zero : ZMod64 p) Zero.zero = Zero.zero
+  unfold ZMod64.sub
+  split
+  · apply ZMod64.ext
+    simp [hzval]
+  · split
+    · apply ZMod64.ext
+      simp [hzval]
+    · exfalso
+      apply (show ¬(Zero.zero : ZMod64 p).val ≤ (Zero.zero : ZMod64 p).val from ‹_›)
+      rw [hzval]
+      exact Nat.le_refl 0
+
 private theorem zmod_mul_zero (a : ZMod64 p) : a * 0 = 0 := by
   grind
 
@@ -109,56 +129,68 @@ theorem add_zero (f : FpPoly p) :
     f + 0 = f := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem zero_add (f : FpPoly p) :
     0 + f = f := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem add_comm (f g : FpPoly p) :
     f + g = g + f := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
   grind
 
 theorem add_assoc (f g h : FpPoly p) :
     f + g + h = f + (g + h) := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add]
+  rw [DensePoly.coeff_add (f + g) h i zmod_add_zero_zero]
+  rw [DensePoly.coeff_add f (g + h) i zmod_add_zero_zero]
+  rw [DensePoly.coeff_add f g i zmod_add_zero_zero]
+  rw [DensePoly.coeff_add g h i zmod_add_zero_zero]
   grind
 
 theorem neg_zero :
     -(0 : FpPoly p) = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_neg]
+  rw [DensePoly.coeff_neg _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem add_left_neg (f : FpPoly p) :
     -f + f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add, DensePoly.coeff_neg]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_neg _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem add_right_neg (f : FpPoly p) :
     f + -f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add, DensePoly.coeff_neg]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_neg _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem sub_zero (f : FpPoly p) :
     f - 0 = f := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_sub]
+  rw [DensePoly.coeff_sub _ _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem zero_sub (f : FpPoly p) :
@@ -169,14 +201,17 @@ theorem sub_self (f : FpPoly p) :
     f - f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_sub]
+  rw [DensePoly.coeff_sub _ _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_zero]
   grind
 
 theorem sub_eq_add_neg (f g : FpPoly p) :
     f - g = f + -g := by
   apply DensePoly.ext_coeff
   intro i
-  simp [DensePoly.coeff_add, DensePoly.coeff_sub, DensePoly.coeff_neg]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  rw [DensePoly.coeff_sub _ _ _ zmod_sub_zero_zero]
+  rw [DensePoly.coeff_neg _ _ zmod_sub_zero_zero]
   grind
 
 @[simp] theorem zero_mul (f : FpPoly p) :
@@ -198,7 +233,7 @@ private theorem coeff_mul_one_fold (f : FpPoly p) (n k : Nat) :
   | succ n ih =>
       rw [List.range_succ, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [DensePoly.coeff_add, ih]
+      rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero, ih]
       rw [DensePoly.coeff_shift_scale]
       · rw [coeff_one]
         by_cases hk : k < n
@@ -243,7 +278,8 @@ private theorem coeff_mul_fold (xs : List Nat) (acc f g : FpPoly p) (n : Nat) :
       rw [ih]
       congr 1
       have hzero : f.coeff i * (0 : ZMod64 p) = 0 := by grind
-      rw [DensePoly.coeff_add, DensePoly.coeff_shift_scale i (f.coeff i) g n hzero]
+      rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero,
+        DensePoly.coeff_shift_scale i (f.coeff i) g n hzero]
       rfl
 
 theorem coeff_mul (f g : FpPoly p) (n : Nat) :
@@ -415,7 +451,8 @@ private theorem mulCoeffTerm_left_distrib (f g h : FpPoly p) (n i : Nat) :
   by_cases hi : n < i
   · simp [hi]
     grind
-  · simp [hi, DensePoly.coeff_add]
+  · rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+    simp [hi]
     grind
 
 private theorem mulCoeffTerm_right_distrib (f g h : FpPoly p) (n i : Nat) :
@@ -425,7 +462,8 @@ private theorem mulCoeffTerm_right_distrib (f g h : FpPoly p) (n i : Nat) :
   by_cases hi : n < i
   · simp [hi]
     grind
-  · simp [hi, DensePoly.coeff_add]
+  · rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+    simp [hi]
     grind
 
 private theorem fold_distrib_acc
@@ -865,14 +903,15 @@ theorem left_distrib (f g h : FpPoly p) :
     f * (g + h) = f * g + f * h := by
   apply DensePoly.ext_coeff
   intro n
-  simp [DensePoly.coeff_add, coeff_mul, mulCoeffSum, fold_left_distrib]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
+  simp [coeff_mul, mulCoeffSum, fold_left_distrib]
 
 theorem right_distrib (f g h : FpPoly p) :
     (f + g) * h = f * h + g * h := by
   apply DensePoly.ext_coeff
   intro n
   let m := max (max (f + g).size f.size) g.size
-  rw [DensePoly.coeff_add]
+  rw [DensePoly.coeff_add _ _ _ zmod_add_zero_zero]
   rw [coeff_mul_of_size_le (f + g) h n m (by dsimp [m]; omega)]
   rw [coeff_mul_of_size_le f h n m (by dsimp [m]; omega)]
   rw [coeff_mul_of_size_le g h n m (by dsimp [m]; omega)]

--- a/libraries.yml
+++ b/libraries.yml
@@ -88,7 +88,7 @@ libraries:
   HexGfq:
     deps: [HexGfqField, HexConway, HexGF2]
     mathlib: false
-    done_through: 0
+    done_through: 1
   HexBerlekampZassenhaus:
     deps: [HexBerlekamp, HexHensel]
     mathlib: false

--- a/progress/20260430T015032Z_68c43763.md
+++ b/progress/20260430T015032Z_68c43763.md
@@ -1,0 +1,24 @@
+**Accomplished**
+
+- Claimed feature issue #1217 for the HexGfq Phase 1 scaffold audit.
+- Audited `HexGfq.lean` against the HexGfq, HexGfqField, HexConway, HexGF2, design-principles, and Phase 1 specs.
+- Confirmed the implemented committed-entry API covers the currently honest Phase 1 surface for `GFq`, `GFq.modulus`, `GFq.ofPoly`, `GFq.repr`, `GF2q`, and the packed `GF2q` helpers.
+- Deferred `GF2q.equivGFq` rather than committing a placeholder, and opened follow-up issue #1219 for the real packed-to-generic bridge.
+- Bumped `libraries.yml[HexGfq].done_through` from 0 to 1.
+- Repaired stale proof calls in `HexPolyFp/Basic.lean` and `HexGfqRing/Operations.lean` after the generic `DensePoly.coeff_add`/`coeff_sub`/`coeff_neg` lemmas gained explicit zero-law premises.
+- Verified `lake build HexGfq`, `python3 scripts/status.py HexGfq`, `python3 scripts/check_dag.py`, `git diff --check`, and the requested `HexGfq.lean` placeholder scan.
+
+**Current frontier**
+
+- `HexGfq` is now ready for Phase 2 scaffolding review.
+- `GF2q.equivGFq` remains intentionally absent from Lean pending the real bridge work tracked by #1219.
+- The build still reports existing `sorry` warnings in dependency proof files; no new executable placeholders were added.
+
+**Next step**
+
+- Run a Phase 2 review pass for `HexGfq`.
+- Separately implement the `GF2q.equivGFq` bridge once the packed `GF2n` to generic `FiniteField 2` correspondence is available in the appropriate bridge layer.
+
+**Blockers**
+
+- None for the completed Phase 1 bump.


### PR DESCRIPTION
Closes #1217

Session: `68c43763-5285-461d-b190-454d64a91eab`

Summary:
- Bumps `HexGfq.done_through` to 1 after auditing the existing committed-entry scaffold against the Phase 1 SPEC.
- Repairs stale proof calls in `HexPolyFp.Basic` and `HexGfqRing.Operations` for the explicit zero-law premises on generic `DensePoly` coefficient lemmas, restoring `lake build HexGfq`.
- Leaves the executable `HexGfq` API unchanged: `GFq`, `GFq.modulus`, `GFq.ofPoly`, `GFq.repr`, `GF2q`, and packed `GF2q` helpers are the honest implemented surface.

Deferred:
- `GF2q.equivGFq` is intentionally not committed in Lean because the real packed `GF2n` to generic `FiniteField 2` correspondence is not available in this core library. Follow-up issue: #1219.

Verification:
- `lake build HexGfq`
- `python3 scripts/status.py HexGfq`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n "\\b(native_decide|axiom)\\b|TODO|FIXME|\\.\\.\\." HexGfq.lean -S`
