### PR TITLE
SPEC: forbid wrong-complexity shapes found by perf audit

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -45,7 +45,12 @@ def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Nat
 def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
 
 /-- Scaled GS coefficients (the ν-values): entry (i,j) = d_{j+1} * μ_{i,j}
-    for j < i. Always integers (integrality lemma). -/
+    for j < i. Always integers (integrality lemma).
+    Computed in a single Bareiss-style integer pass shared across all
+    entries, reusing the same elimination scaffolding as `gramDetVec`:
+    O(n^3 + n^2 m) total. Computing each below-diagonal entry
+    independently as a (j+1) × (j+1) Bareiss determinant is forbidden —
+    that body is `O(n^5)`. -/
 def scaledCoeffs (b : Matrix Int n m) : Matrix Int n n
 
 end Hex.GramSchmidt.Int

--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -112,6 +112,14 @@ For j = k-1 downto 0: if 2 * |ν[k][j]| > d[j+1] (i.e., |coeffs[k][j]| > 1/2):
     ν[k][l] := ν[k][l] - r * ν[j][l]    for l < j
     ν[k][j] := ν[k][j] - r * d[j+1]
 
+These are pointwise updates: only ν cells in row k change, only d[j+1]
+is read, and d itself is unchanged. Implementations must do targeted
+writes — `O(k)` cells per j-step, `O(k^2)` per `sizeReduce` call.
+Rebuilding the full ν matrix via `Matrix.ofFn` (or any equivalent that
+allocates a fresh n × n matrix per step) is forbidden — that turns
+size reduction into `O(n^3)` per column and the overall algorithm
+into `O(n^5 · log B)`.
+
 **Swap step.** Swap b[k] and b[k-1], updating ν and d.
 
 ```lean
@@ -143,6 +151,11 @@ von zur Gathen & Gerhard Algorithm 16.10 during implementation.) All
 divisions are exact (see integrality section below). Only d[k] changes
 among d-values, and only ν values with one index equal to k or k-1
 change.
+
+These are pointwise updates: targeted writes only. Rebuilding the full
+ν matrix or d vector via `Matrix.ofFn` / `Vector.ofFn` per swap is
+forbidden — that turns a per-swap `O(n)` update into `O(n^2)` and adds
+a factor of `n` to the overall LLL cost.
 
 **Main loop.** The Lovász condition in integer form (see integrality
 section below for derivation) is:

--- a/SPEC/Libraries/hex-poly-fp.md
+++ b/SPEC/Libraries/hex-poly-fp.md
@@ -12,7 +12,11 @@ Specialized polynomial arithmetic over `Z/pZ` using `UInt64` coefficients.
   decomposition's product (e.g. `factor^multiplicity`) is
   square-and-multiply, `O(log multiplicity)` polynomial
   multiplications. The textbook `n+1 ↦ f * pow f n` recursion is
-  forbidden.
+  forbidden. Factor accumulation: assembling the output list of
+  `(factor, multiplicity)` pairs must be linear in the output size.
+  Building via repeated `acc ++ [x]` is `O(|acc|)` per append and
+  `O(k^2)` overall, and is forbidden; use `Array.push` or
+  cons-then-reverse.
 
 **Key properties:**
 - Frobenius endomorphism: `frob(a + b) = frob(a) + frob(b)`


### PR DESCRIPTION
## Summary

Adds explicit forbidding clauses to three library SPECs for the
implementation shapes that an algorithm-efficiency audit on `main`
just found silently committed. Each matches the voice of existing
clauses in the same files (e.g. the `gramDetVec` complexity clause
already in `hex-gram-schmidt.md`), naming both the canonical fast
algorithm and the obvious-but-slow approach that must not be used.

The three affected libraries:

- **hex-gram-schmidt.md** — `scaledCoeffs` computed via per-entry
  Bareiss is `O(n^5)`. Must share a single Bareiss-style elimination
  pass with `gramDetVec` for `O(n^3 + n^2 m)`.
- **hex-poly-fp.md** — Yun-style factor lists assembled via
  `acc ++ [x]` are `O(k^2)`. Use `Array.push` or cons-then-reverse.
- **hex-lll.md** — `sizeReduce` and `swapStep` ν / d updates rebuilt
  via `Matrix.ofFn` / `Vector.ofFn` are `O(n^2)` per step. Targeted
  writes only — pointwise updates as the algebraic formulas describe.

The diff is 24 added lines across three files. No code changes; no
new SPEC files.

## Why this isn't covered by the autonomous SPEC-edit clause

This is a **human-directed SPEC update**, not an autonomous fix to a
contradictory or ill-typed clause. The motivating finding is that an
audit caught three implementations whose committed shape silently
violated `design-principles §7` ("intended complexity is the canonical
fast algorithm"). Tightening the affected library SPECs to forbid the
obvious-but-slow approaches prevents the same mistakes on a clean-room
reimplementation.

## Follow-up

Three issues will be filed against the affected libraries citing this
PR, each with `depends-on: <this PR>` so workers see the tightened
guidance when they pick up the implementation fix.

## Test plan

- [x] `git diff main -- SPEC/Libraries/` shows exactly the three
      intended files changed
- [x] Each new clause is grep-able for `forbidden` within its file,
      consistent with existing voice
- [ ] After merge, follow-up audit confirms the new clauses correctly
      identify the existing implementations as violations

🤖 Prepared with Claude Code