### PR TITLE
Review HexGF2 Phase 4 benchmark completion

### DIFF
--- a/progress/20260430T034644Z_7ddb1d30.md
+++ b/progress/20260430T034644Z_7ddb1d30.md
@@ -1,0 +1,25 @@
+**Accomplished**
+
+- Claimed #1266 for the HexGF2 Phase 4 benchmark completion review.
+- Re-read the HexGF2 SPEC, benchmarking doctrine, Phase 4 exit criteria, and benchmark registrations.
+- Verified `lake build HexGF2`, `lake exe hexgf2_bench list`, and `lake exe hexgf2_bench verify`.
+- Ran the full scientific `lake exe hexgf2_bench run ...` sweep for all 23 registered parametric benchmarks.
+- Ran both required comparison commands; both reported agreement on common parameters.
+- Found that Phase 4 cannot be marked complete because several scientific runs returned inconclusive verdicts, with repeated failures around the GCD comparison family and variable failures among low-level linear kernels.
+- Opened follow-up #1272 with the benchmark evidence and left `HexGF2` at `done_through: 3`.
+- Verified `python3 scripts/status.py HexGF2`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+**Current frontier**
+
+- `HexGF2` is still ready for Phase 4 work, but completion is blocked by #1272.
+- The benchmark harness wiring and comparison domains are present; the blocker is scientific verdict stability/fit, not missing registrations or hash disagreement.
+- `status/hex-gf2.scaffolding-reviewed` remains the only HexGF2 status token.
+
+**Next step**
+
+- Claim #1272 and diagnose the inconclusive verdicts without weakening the scientific benchmark families.
+
+**Blockers**
+
+- Phase 4 completion is blocked by inconclusive scientific benchmark verdicts.
+- The pre-existing `.claude/CLAUDE.md` worktree modification was not touched.


### PR DESCRIPTION
Closes #1266.\n\nRan the HexGF2 Phase 4 benchmark review. Build/list/verify passed and both required comparison groups reported hash agreement, but scientific runs produced inconclusive verdicts, especially around the GCD comparison family and some low-level linear kernels.\n\nOpened follow-up #1272 and intentionally left HexGF2 at done_through 3 without adding a Phase 4 completion token.\n\nVerification run:\n- lake build HexGF2\n- lake exe hexgf2_bench list\n- lake exe hexgf2_bench verify\n- lake exe hexgf2_bench run <all 23 registered benchmarks>\n- lake exe hexgf2_bench compare Hex.GF2Bench.runPackedGcdCompareChecksum Hex.GF2Bench.runFp2GcdCompareChecksum\n- lake exe hexgf2_bench compare Hex.GF2Bench.runPackedBerlekampCompareChecksum Hex.GF2Bench.runFp2BerlekampCompareChecksum\n- python3 scripts/status.py HexGF2\n- python3 scripts/check_dag.py\n- git diff --check