### PR TITLE
SPEC/benchmarking: forbid verdict-fitting and require derivation comments

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -480,3 +480,17 @@ explicitly forbidden:
   (rungs too close to the per-spawn floor, even when some survive
   the filter) is miscalibration, not a finding, and the registration
   must be re-tuned before the library advances through Phase 4.
+- **Verdict-fitting: rewriting the algorithm, fixture, or declaration
+  so an inconclusive verdict converges.** The declared complexity is
+  the contract, derived from the algorithm a priori; the verdict only
+  checks it. Rewriting the implementation under test, rescaling
+  `degree := f(n)`, or raising `verdictWarmupFraction` until the
+  harness reports "consistent" is not a fix — it is laundering the
+  verdict. Inconclusive means raise the schedule or file a
+  finding-issue against the implementation, never re-declare.
+
+Every `setup_benchmark` registration must carry an adjacent comment
+deriving its `n => …` from the algorithm: which step dominates, and
+how the prep fixture's parameter maps onto that step's input size.
+Changes to a declaration require a commit message re-deriving the
+model independently of harness output.

--- a/progress/20260430T043828Z_pr1283_repair.md
+++ b/progress/20260430T043828Z_pr1283_repair.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed PR #1283 for repair and rebased `spec/benchmarking-verdict-fitting` onto current `origin/main`.
+- Confirmed the failing `HexPolyFp.Basic` proof of `zmod_sub_zero_zero` is fixed on the refreshed base, resolving the overlap in favor of the current `origin/main` proof.
+- Verified `lake build`, `lake build HexGfqRing HexGfqField`, `lake exe hexgf2_bench list`, `lake exe hexgf2_bench verify`, `python3 scripts/status.py`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+**Current frontier**
+
+- PR #1283 is ready to force-push with the base rebase and CI proof repair from current `origin/main`.
+- Existing theorem `sorry`s remain pre-existing proof debt.
+
+**Next step**
+
+- Push the repaired PR branch and mark PR #1283 salvaged.
+
+**Blockers**
+
+- None for the repaired PR.


### PR DESCRIPTION
## Summary

- Adds a new anti-pattern bullet to [SPEC/benchmarking.md](SPEC/benchmarking.md) §Anti-patterns naming the verdict-fitting cycle: rewriting the algorithm under test, rescaling the prep fixture's degree formula, or raising `verdictWarmupFraction` until the harness reports "consistent". Closes the loophole that the existing "Lowering the parameter range…" / "Declaring a complexity model that matches the buggy current code…" bullets don't cleanly cover.
- Adds a positive rule requiring every `setup_benchmark` registration to carry an adjacent comment deriving `n => …` from the algorithm, and requiring complexity-declaration changes to be justified by a written cost-model derivation in the commit message rather than by harness output.

## Why now

Pattern surfaced by the HexGF2 Phase-4 stabilization PRs https://github.com/kim-em/hex/pull/1179, https://github.com/kim-em/hex/pull/1180, and https://github.com/kim-em/hex/pull/1181 on 2026-04-29: when the harness reported "inconclusive", the fix taken was to rewrite the implementation, change the fixture, or raise the warmup-trim until "consistent" came back. Two of the three PRs also re-declared the complexity (`n³` → `n²`) in the same commit as the implementation rewrite, with no a-priori cost-model derivation. https://github.com/kim-em/hex/pull/1181 separately caught a `genericModulus`/`packedModulus` swap in `runFp2BerlekampCompareChecksum` that had been silently reporting consistent with `n³` against the wrong computation entirely — direct evidence that a green verdict alone is not load-bearing for these registrations.

The remediation work (re-derive the cost models, roll `HexGF2.done_through` back from 4 to 3) is tracked in https://github.com/kim-em/hex/issues/1194 plus three companion audit issues (https://github.com/kim-em/hex/issues/1195, https://github.com/kim-em/hex/issues/1196, https://github.com/kim-em/hex/issues/1197).

## Test plan

- [x] SPEC-only diff; no Lean changes.
- [x] Branch is one commit off latest `main` (cherry-picked from a stale parallel branch); content of the cherry-pick is unchanged from the originally-prepared text.

🤖 Prepared with Claude Code