### PR TITLE
chore: record HexGfqField benchmark verdicts

### DIFF
--- a/progress/20260430T080409Z_821ee18f.md
+++ b/progress/20260430T080409Z_821ee18f.md
@@ -1,0 +1,21 @@
+**Accomplished**
+
+- Claimed feature issue #1309 and ran the `HexGfqField` Phase 4 scientific benchmark suite.
+- Verified seven registrations as `consistent with declared complexity`: `runOfPolyReprChecksum`, `runAddChecksum`, `runMulChecksum`, `runNegSubChecksum`, `runPowChecksum`, `runZPowChecksum`, and `runFrobChecksum`.
+- Found `Hex.GFqFieldBench.runInvDivChecksum` inconclusive on both the initial run and an isolated rerun; the isolated rerun reported `cMin=496.848`, `cMax=780.021`, and `β=-0.259`.
+- Left `libraries.yml[HexGfqField].done_through` at `3` because the Phase 4 suite did not fully pass.
+- Filed follow-up issue #1310 with the emitted verdict and exported benchmark evidence.
+- Verified `lake build HexGfqField`, `lake build hexgfqfield_bench`, `lake exe hexgfqfield_bench list`, `lake exe hexgfqfield_bench verify`, the full scientific benchmark suite using namespace-qualified registration names, `python3 scripts/status.py HexGfqField`, `python3 scripts/check_dag.py`, `python3 scripts/check_phase4.py`, and `git diff --check`.
+
+**Current frontier**
+
+- `HexGfqField` remains Phase 4-ready but not Phase 4-complete because the inverse/division benchmark model or benchmark window needs diagnosis.
+- The benchmark harness registers namespace-qualified names such as `Hex.GFqFieldBench.runInvDivChecksum`; the short names listed in #1309 are not accepted by `lake exe hexgfqfield_bench run`.
+
+**Next step**
+
+- Resolve #1310 by diagnosing whether `runInvDivChecksum` needs a split fixture, a different parameter window, or a revised model, then rerun the full `hexgfqfield_bench` scientific suite before advancing `HexGfqField.done_through` to `4`.
+
+**Blockers**
+
+- `Hex.GFqFieldBench.runInvDivChecksum` reports `inconclusive`, so `HexGfqField` cannot be bumped to Phase 4 completion in this session.


### PR DESCRIPTION
Closes #1309

Session: `821ee18f-2b88-4e0b-9cc6-6d98697e85c3`

## Benchmark verdicts

All commands were run against namespace-qualified registrations shown by `lake exe hexgfqfield_bench list`; the short names from the issue are not accepted by the harness.

- `Hex.GFqFieldBench.runOfPolyReprChecksum`: consistent with declared complexity (`cMin=287.619`, `cMax=322.955`, `β=-0.062`)
- `Hex.GFqFieldBench.runAddChecksum`: consistent with declared complexity (`cMin=62.307`, `cMax=63.003`, `β=+0.004`)
- `Hex.GFqFieldBench.runMulChecksum`: consistent with declared complexity (`cMin=448.323`, `cMax=476.003`, `β=-0.030`)
- `Hex.GFqFieldBench.runNegSubChecksum`: consistent with declared complexity (`cMin=412.343`, `cMax=418.811`, `β=-0.006`)
- `Hex.GFqFieldBench.runPowChecksum`: consistent with declared complexity (`cMin=954.632`, `cMax=1059.399`, `β=-0.052`)
- `Hex.GFqFieldBench.runInvDivChecksum`: inconclusive on isolated rerun (`cMin=496.848`, `cMax=780.021`, `β=-0.259`, looks faster than declared by `~n^0.259`)
- `Hex.GFqFieldBench.runZPowChecksum`: consistent with declared complexity (`cMin=1051.950`, `cMax=1210.100`, `β=-0.080`)
- `Hex.GFqFieldBench.runFrobChecksum`: consistent with declared complexity (`cMin=936.585`, `cMax=991.748`, `β=-0.033`)

Because `runInvDivChecksum` was inconclusive, this PR does not bump `libraries.yml[HexGfqField].done_through`. Follow-up issue #1310 records the verdict and exported evidence.

## Verification

- `lake build HexGfqField`
- `lake build hexgfqfield_bench`
- `lake exe hexgfqfield_bench list`
- `lake exe hexgfqfield_bench verify`
- Full scientific `hexgfqfield_bench` suite using namespace-qualified names
- `python3 scripts/status.py HexGfqField`
- `python3 scripts/check_dag.py`
- `python3 scripts/check_phase4.py`
- `git diff --check`
