### PR TITLE
chore: complete HexPolyZ phase4 benchmark review

### DIFF
--- a/progress/20260430T100922Z_56bb116c.md
+++ b/progress/20260430T100922Z_56bb116c.md
@@ -1,0 +1,25 @@
+**Accomplished**
+
+- Claimed #1328 after checking there were no unclaimed `human-oversight` issues.
+- Reviewed `HexPolyZ/Bench.lean` against `SPEC/Libraries/hex-poly-z.md`, `SPEC/benchmarking.md`, and `PLAN/Phase4.md`.
+- Confirmed the benchmark surface has ten parametric registrations covering coefficient congruence, Bezout witness checking, content, primitive part, binomial coefficients, floor/ceiling square-root helpers, coefficient norm helpers, and the executable Mignotte coefficient bound.
+- Ran the `HexPolyZ` Phase 4 smoke suite. `lake exe hexpolyz_bench verify` passed all ten registrations.
+- Ran scientific benchmark runs for every `Hex.PolyZBench.*` registration. Nine were consistent with their declared complexity: `runCongrPrefix`, `runCoprimeModPWitness`, `runContent`, `runPrimitivePartChecksum`, `runFloorSqrtChecksum`, `runCeilSqrtChecksum`, `runCoeffNormSq`, `runCoeffL2NormBound`, and `runMignotteCoeffBound`.
+- Found a Phase 4 blocker: `runBinom` returned `inconclusive` against the declared `n * Nat.log2 (n + 1) * Nat.log2 (n + 1)` model, with the exported rerun reporting `β=-0.210` and "looks faster than declared by ~n^0.210".
+- Opened follow-up issue #1329 for the `runBinom` benchmark model/domain mismatch.
+- Left `libraries.yml[HexPolyZ].done_through` unchanged at `3`.
+- Verified `lake build HexPolyZ`, `lake build HexPolyZ.Conformance`, `lake exe hexpolyz_bench list`, `lake exe hexpolyz_bench verify`, `python3 scripts/status.py HexPolyZ`, `python3 scripts/check_phase4.py`, and `python3 scripts/check_dag.py`.
+
+**Current frontier**
+
+- `HexPolyZ` remains ready for Phase 4 but cannot be marked complete until #1329 is resolved and `runBinom` produces a consistent scientific verdict.
+- The issue body for #1328 is stale about the conformance executable name: `lake exe hexpolyz_conformance` is not registered. The conformance module does build via `lake build HexPolyZ.Conformance`.
+
+**Next step**
+
+- Work #1329: reproduce the `runBinom` mismatch with exported results, decide whether the parameter domain or the model rationale is the issue, and rerun the full `HexPolyZ` Phase 4 checks before any `done_through: 4` bump.
+
+**Blockers**
+
+- #1329 blocks `HexPolyZ` Phase 4 completion.
+- The worktree still has a pre-existing unrelated `.claude/CLAUDE.md` modification that this session did not touch.


### PR DESCRIPTION
Closes #1328

Session: `56bb116c-00d0-46d8-9564-b7d3c0468741`

Summary:
- Reviewed `HexPolyZ/Bench.lean` against the Phase 4 benchmark contract.
- Confirmed ten registrations cover the advertised `HexPolyZ` benchmark surface.
- Left `libraries.yml[HexPolyZ].done_through` at `3` because `runBinom` was inconclusive.
- Opened follow-up #1329 for the `runBinom` model/domain mismatch.

Scientific benchmark verdicts:
- Consistent: `runCongrPrefix`, `runCoprimeModPWitness`, `runContent`, `runPrimitivePartChecksum`, `runFloorSqrtChecksum`, `runCeilSqrtChecksum`, `runCoeffNormSq`, `runCoeffL2NormBound`, `runMignotteCoeffBound`.
- Inconclusive: `runBinom` against `n * Nat.log2 (n + 1) * Nat.log2 (n + 1)`; exported rerun reported `β=-0.210` and `looks faster than declared by ~n^0.210`.

Verification:
- `lake build HexPolyZ`
- `lake build HexPolyZ.Conformance`
- `lake exe hexpolyz_bench list`
- `lake exe hexpolyz_bench verify`
- Scientific `lake exe hexpolyz_bench run ...` for all ten registrations
- `python3 scripts/status.py HexPolyZ`
- `python3 scripts/check_phase4.py`
- `python3 scripts/check_dag.py`
- `git diff --check`