### PR TITLE
refactor determinant row-swap proof boundary

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -397,6 +397,28 @@ private theorem detProduct_rowScale {R : Type u} [Lean.Grind.CommRing R] {n : Na
           (List.finRange n) i c (fun r => M[r][perm[r]]) 1
           (List.mem_finRange i) (List.nodup_finRange n)
 
+private def finTranspose {n : Nat} (i j : Fin n) (r : Fin n) : Fin n :=
+  if r = i then j else if r = j then i else r
+
+private def transposePermutationValues {n : Nat}
+    (perm : Vector (Fin n) n) (i j : Fin n) : Vector (Fin n) n :=
+  Vector.ofFn fun r => perm[finTranspose i j r]
+
+private theorem detTerm_rowSwap_transposeValues {R : Type u}
+    [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R n n) (i j : Fin n) (h : i ≠ j) (perm : Vector (Fin n) n) :
+    detTerm (rowSwap M i j) perm =
+      -detTerm M (transposePermutationValues perm i j) := by
+  sorry
+
+private theorem permutationVectors_transposeValues_neg_sum {R : Type u}
+    [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R n n) (i j : Fin n) (h : i ≠ j) :
+    (permutationVectors n).foldl
+        (fun acc perm => acc + -detTerm M (transposePermutationValues perm i j)) 0 =
+      -((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
+  sorry
+
 /-- The permutation-vector enumeration contributes `1` on the identity
 matrix: all non-identity terms vanish and the identity vector appears once. -/
 private theorem permutationVectors_identity_sum {R : Type u} [Lean.Grind.CommRing R]
@@ -411,7 +433,16 @@ private theorem permutationVectors_rowSwap_sum {R : Type u} [Lean.Grind.CommRing
     (permutationVectors n).foldl
         (fun acc perm => acc + detTerm (rowSwap M i j) perm) 0 =
       -((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
-  sorry
+  calc
+    (permutationVectors n).foldl
+        (fun acc perm => acc + detTerm (rowSwap M i j) perm) 0 =
+      (permutationVectors n).foldl
+        (fun acc perm => acc + -detTerm M (transposePermutationValues perm i j)) 0 := by
+        apply foldl_det_sum_congr
+        intro perm _hmem
+        exact detTerm_rowSwap_transposeValues M i j h perm
+    _ = -((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
+        exact permutationVectors_transposeValues_neg_sum M i j h
 
 /-- Scaling one matrix row scales each Leibniz term by the same scalar. -/
 private theorem detTerm_rowScale {R : Type u} [Lean.Grind.CommRing R] {n : Nat}

--- a/progress/20260430T140610Z_4ccacd96.md
+++ b/progress/20260430T140610Z_4ccacd96.md
@@ -1,0 +1,36 @@
+**Accomplished**
+
+- Claimed #1364, verified its theorem assumptions are false as stated, and
+  released it for replanning with the concrete `p = 1`/degree-bound blockers.
+- Claimed #1352 for the determinant row-swap Leibniz cancellation.
+- Added `finTranspose` and `transposePermutationValues` in
+  `HexMatrix/Determinant.lean`.
+- Refactored `permutationVectors_rowSwap_sum` so it is no longer an opaque
+  proof-body placeholder, reducing it to two named row-transposition proof
+  boundaries.
+- Opened successor issues #1367 and #1368 for the remaining term-level and
+  permutation-enumeration row-swap obligations.
+- Verified `lake build HexMatrix`, `lake build HexMatrix.Conformance`,
+  `python3 scripts/status.py HexMatrix`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and the forbidden-pattern scan on
+  `HexMatrix/Determinant.lean`.
+
+**Current frontier**
+
+- `permutationVectors_rowSwap_sum` now exposes the intended proof structure:
+  per-term row-swap transposition followed by cancellation over the
+  permutation-vector enumeration.
+- The remaining #1352 proof work is concentrated in
+  `detTerm_rowSwap_transposeValues` and
+  `permutationVectors_transposeValues_neg_sum`.
+
+**Next step**
+
+- Claim #1367 to prove the term transposition lemma, then #1368 to prove the
+  finite-sum pairing/involution lemma over `permutationVectors`.
+
+**Blockers**
+
+- #1364 needs replanning before proof work resumes because the current
+  monicity/degree theorem statements are false under `ZMod64.Bounds p` alone
+  and the `h` degree theorem lacks a correction degree-bound hypothesis.


### PR DESCRIPTION
Partial progress on #1352

Session: `4ccacd96-7342-4847-a65f-71a69e0077f3`

27cb175 refactor determinant row-swap proof boundary

🤖 Prepared with Claude Code