### PR TITLE
feat: add permutation vector cardinal helpers

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -745,6 +745,33 @@ private theorem insertAt_last_castSucc_nodup {n : Nat}
     simpa using Nat.lt_succ_iff.mp i.isLt
   exact (List.perm_insertIdx (Fin.last n) (v.map Fin.castSucc).toList hidx).symm.nodup hcons
 
+private theorem finList_length_le_card {n : Nat} {xs : List (Fin n)}
+    (hnodup : xs.Nodup) :
+    xs.length ≤ n := by
+  have hsub : List.Subperm xs (List.finRange n) := by
+    exact List.subperm_of_subset hnodup (fun x _hx => List.mem_finRange x)
+  simpa [List.length_finRange] using List.Subperm.length_le hsub
+
+private theorem finLast_mem_of_full_nodup {n : Nat} {xs : List (Fin (n + 1))}
+    (hlen : xs.length = n + 1) (hnodup : xs.Nodup) :
+    Fin.last n ∈ xs := by
+  by_cases hmem : Fin.last n ∈ xs
+  · exact hmem
+  · exfalso
+    have hsub : List.Subperm xs ((List.finRange (n + 1)).erase (Fin.last n)) := by
+      apply List.subperm_of_subset hnodup
+      intro x hx
+      exact (List.mem_erase_of_ne (by
+        intro hxlast
+        exact hmem (hxlast ▸ hx))).2 (List.mem_finRange x)
+    have hle : xs.length ≤ ((List.finRange (n + 1)).erase (Fin.last n)).length :=
+      List.Subperm.length_le hsub
+    have herase :
+        ((List.finRange (n + 1)).erase (Fin.last n)).length = n := by
+      rw [List.length_erase]
+      simp [List.mem_finRange, List.length_finRange]
+    omega
+
 private theorem permutationVectors_nodup {n : Nat} {perm : Vector (Fin n) n}
     (hmem : perm ∈ permutationVectors n) :
     perm.toList.Nodup := by

--- a/progress/20260430T164016Z_03757868.md
+++ b/progress/20260430T164016Z_03757868.md
@@ -1,0 +1,30 @@
+**Accomplished**
+
+- Claimed issue #1394.
+- Added `finList_length_le_card` and `finLast_mem_of_full_nodup` in
+  `HexMatrix/Determinant.lean`, establishing the finite-list cardinal
+  helper layer needed by the permutation-vector completeness proof.
+- Created follow-up issue #1406 for the remaining peel/reinsert
+  reconstruction proof and left the required decomposition breadcrumb on
+  #1394.
+- Verified `lake build HexMatrix`, `lake build HexMatrix.Conformance`,
+  `python3 scripts/status.py HexMatrix`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and a forbidden-placeholder scan of
+  `HexMatrix/Determinant.lean`.
+
+**Current frontier**
+
+- Full-length nodup `List (Fin (n + 1))` values can now be shown to contain
+  `Fin.last n`.
+- The remaining #1394 work is to use that membership to locate the last
+  value, erase/peel it into the predecessor permutation vector, invoke the
+  recursive enumeration hypothesis, and reconstruct with `insertAt`.
+
+**Next step**
+
+- Work issue #1406 to finish the `permutationVectors` nodup completeness
+  theorem.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Partial progress on #1394

Session: `03757868-769f-4ec1-90f1-55490f72f388`

8d9724c feat: add permutation vector cardinal helpers

🤖 Prepared with Claude Code