### PR TITLE
Prove transposePermutationValues preserves permutationVectors

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -1184,6 +1184,37 @@ private theorem transposePermutationValues_get {n : Nat}
     (transposePermutationValues perm i j)[r] = perm[finTranspose i j r] := by
   simp [transposePermutationValues]
 
+private theorem vector_toList_eq_finRange_map_get {α : Type u} {n : Nat}
+    (v : Vector α n) :
+    v.toList = (List.finRange n).map fun i => v[i] := by
+  apply List.ext_getElem
+  · simp [Vector.length_toList]
+  · intro k hk₁ hk₂
+    simp
+
+private theorem transposePermutationValues_toList_perm {n : Nat}
+    (perm : Vector (Fin n) n) (i j : Fin n) :
+    (transposePermutationValues perm i j).toList.Perm perm.toList := by
+  rw [vector_toList_eq_finRange_map_get (transposePermutationValues perm i j)]
+  rw [vector_toList_eq_finRange_map_get perm]
+  have hleft :
+      (List.finRange n).map (fun r => (transposePermutationValues perm i j)[r]) =
+        (List.finRange n).map ((fun r => perm[r]) ∘ finTranspose i j) := by
+    apply List.map_congr_left
+    intro r _hr
+    exact transposePermutationValues_get perm i j r
+  rw [hleft]
+  simpa [List.map_map] using
+    (finRange_map_finTranspose_perm i j).map fun r => perm[r]
+
+private theorem transposePermutationValues_mem_permutationVectors {n : Nat}
+    {perm : Vector (Fin n) n} (i j : Fin n)
+    (hmem : perm ∈ permutationVectors n) :
+    transposePermutationValues perm i j ∈ permutationVectors n := by
+  apply permutationVectors_complete
+  exact (transposePermutationValues_toList_perm perm i j).symm.nodup
+    (permutationVectors_nodup hmem)
+
 private theorem vector_get_fin_congr {α : Type u} {n : Nat} (v : Vector α n)
     {a b : Fin n} (h : a = b) : v[a] = v[b] := by
   subst b

--- a/progress/20260430T172114Z_bebb5fbf.md
+++ b/progress/20260430T172114Z_bebb5fbf.md
@@ -1,0 +1,25 @@
+**Accomplished**
+
+- Claimed issue #1391.
+- Added private determinant helpers in `HexMatrix/Determinant.lean`:
+  - `vector_toList_eq_finRange_map_get`
+  - `transposePermutationValues_toList_perm`
+  - `transposePermutationValues_mem_permutationVectors`
+- Proved that `transposePermutationValues perm i j` remains in
+  `permutationVectors n` whenever `perm` is in the executable enumeration.
+- Verified the targeted HexMatrix builds and project checks.
+
+**Current frontier**
+
+- The focused transpose-membership prerequisite for the determinant fold
+  reindexing proof is now available.
+- Later determinant row-operation placeholders remain outside this issue.
+
+**Next step**
+
+- Continue with the dependent determinant transpose fold reindexing issue
+  (#1392).
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1391

Session: `bebb5fbf-6ac1-4c37-9c69-8996dd4538d9`

ccdc349 Prove transpose permutation enumeration membership

🤖 Prepared with Claude Code