### PR TITLE
Split linear Hensel correction proof

### DIFF
--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -169,16 +169,29 @@ private theorem modP_one (p : Nat) [ZMod64.Bounds p] :
   exact Eq.trans (ZPoly.modP_eq_of_congr p _ _ (ZPoly.congr_symm _ _ _ hcong))
     (FpPoly.modP_liftToZ (p := p) (1 : FpPoly p))
 
+private theorem linearHenselStep_raw_factor_congr_from_correction
+    (p k : Nat) [ZMod64.Bounds p]
+    (f g h : ZPoly) (r hCorrection e : FpPoly p)
+    (_hk : 1 ≤ k)
+    (hprod : ZPoly.congr (g * h) f (p ^ k))
+    (hcorr :
+      r * ZPoly.modP p h + ZPoly.modP p g * hCorrection =
+        ZPoly.modP p (ZPoly.coeffwiseDiv (f - g * h) (p ^ k))) :
+    let g' := g + LinearLiftResult.liftScaledIncrement p k r
+    let h' := h + LinearLiftResult.liftScaledIncrement p k hCorrection
+    ZPoly.congr (g' * h') f (p ^ (k + 1)) := by
+  sorry
+
 private theorem linearHenselStep_raw_factor_congr
     (p k : Nat) [ZMod64.Bounds p]
     (f g h : ZPoly) (s t : FpPoly p)
-    (_hk : 1 ≤ k)
+    (hk : 1 ≤ k)
     (hprod : ZPoly.congr (g * h) f (p ^ k))
     (hbez :
       ZPoly.congr
         (FpPoly.liftToZ (s * ZPoly.modP p g + t * ZPoly.modP p h))
         1 p)
-    (hmonic : DensePoly.Monic g) :
+    (_hmonic : DensePoly.Monic g) :
     let e := ZPoly.coeffwiseDiv (f - g * h) (p ^ k)
     let gMod := ZPoly.modP p g
     let hMod := ZPoly.modP p h
@@ -190,7 +203,20 @@ private theorem linearHenselStep_raw_factor_congr
     let hCorrection := s * eMod + q * hMod
     let h' := h + LinearLiftResult.liftScaledIncrement p k hCorrection
     ZPoly.congr (g' * h') f (p ^ (k + 1)) := by
-  sorry
+  intro e gMod hMod eMod qr q r g' hCorrection h'
+  have hdiv : q * gMod + r = t * eMod := by
+    simpa [qr, q, r] using DensePoly.divMod_spec (t * eMod) gMod
+  have hbezFp : s * gMod + t * hMod = 1 := by
+    have hmod := ZPoly.modP_eq_of_congr p _ _ hbez
+    rw [FpPoly.modP_liftToZ, modP_one] at hmod
+    exact hmod
+  have hcorr :
+      r * hMod + gMod * hCorrection = eMod := by
+    simpa [hCorrection] using
+      linearHenselStep_correction_identity p gMod hMod eMod s t q r hdiv hbezFp
+  exact
+    linearHenselStep_raw_factor_congr_from_correction
+      p k f g h r hCorrection eMod hk hprod hcorr
 
 private theorem linearHenselStep_reduced_factor_congr
     (p k : Nat) [ZMod64.Bounds p]

--- a/progress/20260430T184810Z_146d1268.md
+++ b/progress/20260430T184810Z_146d1268.md
@@ -1,0 +1,22 @@
+**Accomplished**
+
+- Claimed #1426 and split `linearHenselStep_raw_factor_congr` in `HexHensel/Linear.lean` so the theorem now proves the finite-field correction layer explicitly.
+- Derived the `FpPoly` Bezout equality from the lifted `ZPoly.congr` hypothesis using `ZPoly.modP_eq_of_congr`, `FpPoly.modP_liftToZ`, and `modP_one`.
+- Instantiated `DensePoly.divMod_spec` for `DensePoly.divMod (t * eMod) gMod` and used `linearHenselStep_correction_identity` to prove the correction identity consumed by the raw congruence theorem.
+- Isolated the remaining integer scaling/product bridge as the private helper `linearHenselStep_raw_factor_congr_from_correction`.
+- Created follow-up #1428 for that helper and linked it from #1426.
+- Ran `lake build HexHensel`, `lake build HexHensel.Conformance`, `python3 scripts/status.py HexHensel`, `python3 scripts/check_dag.py`, `git diff --check`, and a forbidden-pattern scan of `HexHensel/Linear.lean`.
+
+**Current frontier**
+
+- `linearHenselStep_raw_factor_congr` no longer has a direct opaque proof body; it is reduced to finite-field correction plus the private helper.
+- The only new remaining obligation from this session is `linearHenselStep_raw_factor_congr_from_correction`, which owns the coefficient/divisibility bridge from the correction congruence modulo `p` to the product congruence modulo `p^(k+1)`.
+- Existing unrelated `HexHensel/Linear.lean` proof-body `sorry`s remain.
+
+**Next step**
+
+- Prove `linearHenselStep_raw_factor_congr_from_correction` by expanding the product of `g + p^k*r` and `h + p^k*hCorrection`, using `scale_coeffwiseDiv_sub_of_congr` for `f - g*h`, using the correction congruence for the first-order term, and discharging the cross term via `hk : 1 ≤ k` so `p^(k+1)` divides `p^(2*k)`.
+
+**Blockers**
+
+- No build blockers.


### PR DESCRIPTION
Partial progress on #1426

Session: `146d1268-4e9f-4662-baf7-33ca78959a01`

dcf377c Split linear Hensel correction proof

🤖 Prepared with Claude Code