### PR TITLE
Prove HexPolyFp derivative-zero coefficient support

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -487,11 +487,55 @@ private theorem squareFreeAuxRevContribution_pthRoot_correct_pow
       pow (pthRoot f) (multiplicity * p) := by
   sorry
 
+private theorem derivative_coeff_pred_of_pos_lt
+    (f : FpPoly p) {n : Nat} (hn0 : 0 < n) (hn : n < f.size) :
+    (DensePoly.derivative f).coeff (n - 1) =
+      ((n : Nat) : ZMod64 p) * f.coeff n := by
+  unfold DensePoly.derivative
+  rw [DensePoly.coeff_ofCoeffs_list]
+  have hpred : n - 1 < f.size - 1 := by omega
+  have hget :
+      (((List.range (f.size - 1)).map
+          (fun i => (((i + 1 : Nat) : ZMod64 p) * f.coeff (i + 1)))).getD
+        (n - 1) (0 : ZMod64 p)) =
+          (((n - 1 + 1 : Nat) : ZMod64 p) * f.coeff (n - 1 + 1)) := by
+    simp [List.getD, hpred]
+  have hsucc : n - 1 + 1 = n := by omega
+  simpa [hsucc] using hget
+
+private theorem zmod64_natCast_ne_zero_of_mod_ne_zero
+    (n : Nat) (hn : n % p ≠ 0) :
+    ((n : Nat) : ZMod64 p) ≠ 0 := by
+  intro hzero
+  apply hn
+  have hnat := congrArg ZMod64.toNat hzero
+  simpa using hnat
+
 private theorem derivative_zero_coeff_non_pmultiple
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (n : Nat)
     (hdf : (DensePoly.derivative f).isZero = true) (hn : n % p ≠ 0) :
     f.coeff n = 0 := by
-  sorry
+  by_cases hsize : f.size ≤ n
+  · exact DensePoly.coeff_eq_zero_of_size_le f hsize
+  · have hnlt : n < f.size := Nat.lt_of_not_ge hsize
+    have hn0 : 0 < n := by
+      cases n with
+      | zero =>
+          simp at hn
+      | succ n =>
+          exact Nat.succ_pos n
+    have hderiv_zero_poly : DensePoly.derivative f = 0 :=
+      eq_zero_of_isZero_true (DensePoly.derivative f) hdf
+    have hderiv_coeff : (DensePoly.derivative f).coeff (n - 1) = 0 := by
+      rw [hderiv_zero_poly]
+      exact DensePoly.coeff_zero (R := ZMod64 p) (n - 1)
+    have hmul :
+        ((n : Nat) : ZMod64 p) * f.coeff n = 0 := by
+      rw [← derivative_coeff_pred_of_pos_lt f hn0 hnlt]
+      exact hderiv_coeff
+    rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp hmul with hnzero | hcoeff
+    · exact False.elim (zmod64_natCast_ne_zero_of_mod_ne_zero n hn hnzero)
+    · exact hcoeff
 
 private theorem pthRoot_frobenius_of_derivative_zero
     (hp : Hex.Nat.Prime p) (f : FpPoly p)

--- a/progress/20260501T041526Z_4bfb1e7c.md
+++ b/progress/20260501T041526Z_4bfb1e7c.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Claimed #1527 and proved `derivative_zero_coeff_non_pmultiple` in `HexPolyFp/SquareFree.lean`.
+- Added private helper lemmas for the formal derivative coefficient at predecessor indices and for nonzero `ZMod64` natural casts when `n % p ≠ 0`.
+- Verified `lake build HexPolyFp.SquareFree`, `lake build HexPolyFp`, `python3 scripts/status.py HexPolyFp`, `python3 scripts/check_dag.py`, `git diff --check`, and a forbidden-token scan of `HexPolyFp/SquareFree.lean`.
+
+**Current frontier**
+
+- The derivative-zero coefficient-support leaf from #1527 is closed.
+- Remaining local proof leaves in this branch include `pthRoot_frobenius_of_derivative_zero` and `squareFreeAuxRevContribution_pthRoot_correct_pow`.
+
+**Next step**
+
+- Continue with the Frobenius reconstruction follow-up that uses `derivative_zero_coeff_non_pmultiple` to prove `pow (pthRoot f) p = f`.
+
+**Blockers**
+
+- No blockers for this session.


### PR DESCRIPTION
Closes #1527

Session: `4bfb1e7c-b5b6-44f8-9255-05e5c19a51a6`

651a6c0 Prove derivative-zero coefficient support

🤖 Prepared with Claude Code