### PR TITLE
partial: add HexPolyFp Frobenius additivity boundary

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -398,6 +398,12 @@ private theorem coeffFold_size_eq (g : FpPoly p) :
     coeffFold g g.size = g := by
   exact coeffFold_eq_of_size_le g g.size (Nat.le_refl g.size)
 
+private theorem powLinear_add_prime_coeff
+    (hp : Hex.Nat.Prime p) (f g : FpPoly p) (n : Nat) :
+    (powLinear (f + g) p).coeff n =
+      (powLinear f p).coeff n + (powLinear g p).coeff n := by
+  sorry
+
 /--
 Freshman's-dream coefficient support for a `p`th power over `F_p[x]`.
 This is the dense-polynomial convolution fact needed by the formal

--- a/progress/20260501T063415Z_638397f5.md
+++ b/progress/20260501T063415Z_638397f5.md
@@ -1,0 +1,18 @@
+**Accomplished**
+
+- Read the latest progress note and claimed #1555 for the HexPolyFp two-summand Frobenius bridge.
+- Added the private `powLinear_add_prime_coeff` theorem boundary in `HexPolyFp/SquareFree.lean` immediately before `powLinear_prime_coeff`, matching the dependency point needed by the finite `coeffFold` work in #1556.
+- Verified `lake build HexPolyFp.SquareFree`, `lake build HexPolyFp`, `python3 scripts/status.py HexPolyFp`, `python3 scripts/check_dag.py`, `git diff --check`, and the forbidden-term scan for touched HexPolyFp files.
+
+**Current frontier**
+
+- The new theorem boundary still has an admitted proof body; the polynomial-level binomial/Freshman's-dream argument remains the hard proof obligation for #1555.
+- #1556 should not be unblocked as complete until `powLinear_add_prime_coeff` is proved without its `sorry`.
+
+**Next step**
+
+- Prove `powLinear_add_prime_coeff` from a polynomial-level binomial expansion or an equivalent finite support/reindexing argument over dense coefficients, then use it in #1556's finite `coeffFold` reconstruction.
+
+**Blockers**
+
+- No build blocker. The remaining blocker is proof content: the current local APIs do not yet expose a polynomial-level binomial expansion theorem, only scalar Freshman's dream and coefficient-fold multiplication lemmas.


### PR DESCRIPTION
Partial progress on #1555

Session: `638397f5-1c20-4100-916d-1aa21f9f4b2b`

2d0674f partial: add HexPolyFp Frobenius additivity boundary

🤖 Prepared with Claude Code