### PR TITLE
Prove HexGF2 raw product normalization transparency for associativity

### DIFF
--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -2943,6 +2943,39 @@ private theorem coeffWords_mulWords_comm (xs ys : Array UInt64) (n : Nat) :
   intro i hi
   exact clmulCoeffAt_comm i j xs[i]! ys[j]! n
 
+private theorem coeffWords_mulWords_normalize_left
+    (xs ys : Array UInt64) (n : Nat) :
+    coeffWords (mulWords (normalizeWords xs) ys) n =
+      coeffWords (mulWords xs ys) n := by
+  rw [← coeffWords_mulWords_common_left (normalizeWords xs) ys n xs.size
+    (normalizeWords_size_le xs)]
+  rw [← coeffWords_mulWords_common_left xs ys n xs.size (Nat.le_refl xs.size)]
+  simp [normalizeWords_getElem!]
+
+private theorem coeffWords_mulWords_normalize_right
+    (xs ys : Array UInt64) (n : Nat) :
+    coeffWords (mulWords xs (normalizeWords ys)) n =
+      coeffWords (mulWords xs ys) n := by
+  rw [coeffWords_mulWords_comm xs (normalizeWords ys)]
+  rw [coeffWords_mulWords_normalize_left ys xs]
+  rw [coeffWords_mulWords_comm ys xs]
+
+private theorem coeffWords_mulWords_ofWords_left
+    (xs ys zs : Array UInt64) (n : Nat) :
+    coeffWords (mulWords (ofWords (mulWords xs ys)).words zs) n =
+      coeffWords (mulWords (mulWords xs ys) zs) n := by
+  change coeffWords (mulWords (normalizeWords (mulWords xs ys)) zs) n =
+    coeffWords (mulWords (mulWords xs ys) zs) n
+  exact coeffWords_mulWords_normalize_left (mulWords xs ys) zs n
+
+private theorem coeffWords_mulWords_ofWords_right
+    (xs ys zs : Array UInt64) (n : Nat) :
+    coeffWords (mulWords xs (ofWords (mulWords ys zs)).words) n =
+      coeffWords (mulWords xs (mulWords ys zs)) n := by
+  change coeffWords (mulWords xs (normalizeWords (mulWords ys zs))) n =
+    coeffWords (mulWords xs (mulWords ys zs)) n
+  exact coeffWords_mulWords_normalize_right xs (mulWords ys zs) n
+
 /-- Multiplication in `F_2[x]` via carry-less word products and XOR
 accumulation. -/
 def mul (p q : GF2Poly) : GF2Poly :=

--- a/progress/20260501T173119Z_b3e74b4e.md
+++ b/progress/20260501T173119Z_b3e74b4e.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed #1646, assessed the remaining `GF2Poly.mul_assoc` proof surface, and decomposed it into #1655, #1656, and #1657.
+- Claimed #1655 and added private `HexGF2/Multiply.lean` coefficient lemmas showing raw multiplication coefficients are unchanged by normalizing either input.
+- Added left and right intermediate-product `ofWords` bridge lemmas for later associativity work.
+- Verified `lake build HexGF2.Multiply`, `lake build HexGF2`, `python3 scripts/status.py HexGF2`, `python3 scripts/check_dag.py`, `git diff --check`, and scanned `HexGF2/Multiply.lean` for forbidden placeholders.
+
+**Current frontier**
+
+- #1655 is complete as the normalization-transparency prerequisite.
+- #1656 is the next blocked-on-#1655 step: prove the raw `mulWords` associativity contribution bridge.
+- The only `sorry` in `HexGF2/Multiply.lean` remains the pre-existing `GF2Poly.mul_assoc` placeholder.
+
+**Next step**
+
+- Land #1655, then work #1656 by expanding nested raw-product coefficients into a triple-indexed XOR contribution and proving the reindexing/association bridge.
+
+**Blockers**
+
+- None for #1655.


### PR DESCRIPTION
Closes #1655

Session: `b3e74b4e-6d1a-4c71-bd18-f057c65d014d`

8866078 feat: bridge HexGF2 normalized raw products

🤖 Prepared with Claude Code