### PR TITLE
feat: split clmul two-word associativity proof

### DIFF
--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -3402,11 +3402,71 @@ private def rightAssocFixedTripleContribs
   (List.range slotBound).map
     (fun slot => clmulCoeffAt (i + slot) x (clmulWordAt (j + k) y z slot) n)
 
+/-- The selected bit of one machine word, using the same projection shape as
+the existing coefficient bridges. -/
+private def wordBitAt (word : UInt64) (bit : Nat) : Bool :=
+  (((word >>> bit.toUInt64) &&& 1) != 0)
+
+/-- Source bit-triple contribution for the coefficient of total bit index
+`total` in a three-word carry-less product. -/
+private def clmulSourceTripleCoeff (x y z : UInt64) (total : Nat) : Bool :=
+  xorBoolList
+    (List.flatMap
+      (fun a =>
+        List.flatMap
+          (fun b =>
+            (List.range 64).map
+              (fun c =>
+                (wordBitAt x a && wordBitAt y b && wordBitAt z c) &&
+                  decide (a + b + c = total)))
+          (List.range 64))
+      (List.range 64))
+
+private theorem clmulAssoc_left_low_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    wordBitAt (clmul (clmul x y).2 z).2 bit =
+      clmulSourceTripleCoeff x y z bit := by
+  sorry
+
+private theorem clmulAssoc_right_low_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    wordBitAt (clmul x (clmul y z).2).2 bit =
+      clmulSourceTripleCoeff x y z bit := by
+  sorry
+
+private theorem clmulAssoc_left_middle_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    (wordBitAt (clmul (clmul x y).2 z).1 bit !=
+        wordBitAt (clmul (clmul x y).1 z).2 bit) =
+      clmulSourceTripleCoeff x y z (bit + 64) := by
+  sorry
+
+private theorem clmulAssoc_right_middle_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    (wordBitAt (clmul x (clmul y z).2).1 bit !=
+        wordBitAt (clmul x (clmul y z).1).2 bit) =
+      clmulSourceTripleCoeff x y z (bit + 64) := by
+  sorry
+
+private theorem clmulAssoc_left_high_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    wordBitAt (clmul (clmul x y).1 z).1 bit =
+      clmulSourceTripleCoeff x y z (bit + 128) := by
+  sorry
+
+private theorem clmulAssoc_right_high_sourceTriple
+    (x y z : UInt64) (bit : Nat) :
+    wordBitAt (clmul x (clmul y z).1).1 bit =
+      clmulSourceTripleCoeff x y z (bit + 128) := by
+  sorry
+
 private theorem clmulCoeffAt_assoc_twoWord_low
     (x y z : UInt64) (bit : Nat) :
     ((((clmul (clmul x y).2 z).2 >>> bit.toUInt64) &&& 1) != 0) =
       ((((clmul x (clmul y z).2).2 >>> bit.toUInt64) &&& 1) != 0) := by
-  sorry
+  change wordBitAt (clmul (clmul x y).2 z).2 bit =
+    wordBitAt (clmul x (clmul y z).2).2 bit
+  rw [clmulAssoc_left_low_sourceTriple, clmulAssoc_right_low_sourceTriple]
 
 private theorem clmulCoeffAt_assoc_twoWord_middle
     (x y z : UInt64) (bit : Nat) :
@@ -3414,13 +3474,19 @@ private theorem clmulCoeffAt_assoc_twoWord_middle
         ((((clmul (clmul x y).1 z).2 >>> bit.toUInt64) &&& 1) != 0)) =
       (((((clmul x (clmul y z).2).1 >>> bit.toUInt64) &&& 1) != 0) !=
         ((((clmul x (clmul y z).1).2 >>> bit.toUInt64) &&& 1) != 0)) := by
-  sorry
+  change (wordBitAt (clmul (clmul x y).2 z).1 bit !=
+      wordBitAt (clmul (clmul x y).1 z).2 bit) =
+    (wordBitAt (clmul x (clmul y z).2).1 bit !=
+      wordBitAt (clmul x (clmul y z).1).2 bit)
+  rw [clmulAssoc_left_middle_sourceTriple, clmulAssoc_right_middle_sourceTriple]
 
 private theorem clmulCoeffAt_assoc_twoWord_high
     (x y z : UInt64) (bit : Nat) :
     ((((clmul (clmul x y).1 z).1 >>> bit.toUInt64) &&& 1) != 0) =
       ((((clmul x (clmul y z).1).1 >>> bit.toUInt64) &&& 1) != 0) := by
-  sorry
+  change wordBitAt (clmul (clmul x y).1 z).1 bit =
+    wordBitAt (clmul x (clmul y z).1).1 bit
+  rw [clmulAssoc_left_high_sourceTriple, clmulAssoc_right_high_sourceTriple]
 
 private theorem clmulCoeffAt_assoc_twoWord
     (base n : Nat) (x y z : UInt64) :

--- a/progress/20260502T000833Z_0528d291.md
+++ b/progress/20260502T000833Z_0528d291.md
@@ -1,0 +1,33 @@
+**Accomplished**
+
+- Claimed #1718 and confirmed the active frontier in `HexGF2/Multiply.lean`.
+- Tried two direct `bv_decide` strategies for the low/middle/high two-word
+  `clmul` associativity leaves; both were too expensive to finish.
+- Rewired `clmulCoeffAt_assoc_twoWord_low`,
+  `clmulCoeffAt_assoc_twoWord_middle`, and
+  `clmulCoeffAt_assoc_twoWord_high` through a shared semantic source-triple
+  coefficient, `clmulSourceTripleCoeff`.
+- Created follow-up #1720 for the six focused source-triple expansion leaves
+  and added #1720 as a dependency of #1717.
+- Verified `lake build HexGF2.Multiply`, `lake build HexGF2`,
+  `python3 scripts/status.py HexGF2`, `python3 scripts/check_dag.py`, and
+  `git diff --check`.
+
+**Current frontier**
+
+- #1718 is partially advanced: the wrapper theorem now has a clear finite
+  source-bit-triple proof interface, but the six `clmulAssoc_*_sourceTriple`
+  helpers remain as proof-body `sorry`s.
+- #1720 is the next direct work item for proving those six helpers.
+- #1717 remains blocked until #1720 closes the two-word helper path.
+
+**Next step**
+
+- Prove reusable low/high `clmul` bit-expansion lemmas against finite XORs over
+  source bit pairs, then instantiate and reindex them to close the six
+  `clmulAssoc_*_sourceTriple` helpers in #1720.
+
+**Blockers**
+
+- Fully unfolding nested `clmul` products into `bv_decide`, even after splitting
+  the selected bit into concrete word positions, did not complete in-session.


### PR DESCRIPTION
Partial progress on #1718

Session: `0528d291-7580-44cc-8dc0-62a43b3b695d`

cef6f7e feat: split clmul two-word associativity proof

🤖 Prepared with Claude Code