### PR TITLE
Prove HexGramSchmidt coefficient matrix shape facts

### DIFF
--- a/HexGramSchmidt/Basic.lean
+++ b/HexGramSchmidt/Basic.lean
@@ -83,6 +83,10 @@ def prefixRows (M : Matrix R n m) (i : Nat) (hi : i < n) : Matrix R (i + 1) m :=
 def prefixSpan (M : Matrix Rat n m) (i : Nat) (hi : i < n) (v : Vector Rat m) : Prop :=
   ∃ c : Vector Rat (i + 1), Matrix.rowCombination (prefixRows M i hi) c = v
 
+private theorem entry_ofFn (f : Fin n → Fin m → R) (i : Fin n) (j : Fin m) :
+    entry (Matrix.ofFn f) i j = f i j := by
+  simp [entry, Matrix.row, Matrix.ofFn, Vector.getElem_ofFn]
+
 end GramSchmidt
 
 namespace GramSchmidt.Int
@@ -114,12 +118,16 @@ theorem basis_decomposition (b : Matrix Int n m) (i : Nat) (hi : i < n) :
 
 theorem coeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 1 := by
-  sorry
+  simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn]
 
 theorem coeffs_upper (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hj⟩ = 0 := by
-  sorry
+  have hnot_lt : ¬j < i := Nat.not_lt_of_ge (Nat.le_of_lt hij)
+  have hne : (⟨i, hi⟩ : Fin n) ≠ ⟨j, hj⟩ := by
+    intro h
+    exact (Nat.ne_of_lt hij) (congrArg Fin.val h)
+  simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn, hnot_lt, hne]
 
 theorem basis_span (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     ∀ v : Vector Rat m,
@@ -156,12 +164,16 @@ theorem basis_decomposition (b : Matrix Rat n m) (i : Nat) (hi : i < n) :
 
 theorem coeffs_diag (b : Matrix Rat n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 1 := by
-  sorry
+  simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn]
 
 theorem coeffs_upper (b : Matrix Rat n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hj⟩ = 0 := by
-  sorry
+  have hnot_lt : ¬j < i := Nat.not_lt_of_ge (Nat.le_of_lt hij)
+  have hne : (⟨i, hi⟩ : Fin n) ≠ ⟨j, hj⟩ := by
+    intro h
+    exact (Nat.ne_of_lt hij) (congrArg Fin.val h)
+  simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn, hnot_lt, hne]
 
 theorem basis_span (b : Matrix Rat n m) (i : Nat) (hi : i < n) :
     ∀ v : Vector Rat m,

--- a/progress/20260502T040624Z_2bc7450f.md
+++ b/progress/20260502T040624Z_2bc7450f.md
@@ -1,0 +1,29 @@
+**Accomplished**
+
+- Claimed #1760 for the HexGramSchmidt coefficient-matrix shape facts.
+- Added a private `GramSchmidt.entry_ofFn` helper for indexing matrices built by `Matrix.ofFn`.
+- Proved `GramSchmidt.Int.coeffs_diag`, `GramSchmidt.Int.coeffs_upper`,
+  `GramSchmidt.Rat.coeffs_diag`, and `GramSchmidt.Rat.coeffs_upper` in
+  `HexGramSchmidt/Basic.lean`.
+- Verified `lake build HexGramSchmidt.Basic`, `lake build HexGramSchmidt`,
+  `python3 scripts/status.py HexGramSchmidt`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and forbidden-placeholder scans for touched
+  HexGramSchmidt changes.
+
+**Current frontier**
+
+- The lower-unitriangular coefficient-matrix surface in
+  `HexGramSchmidt/Basic.lean` no longer has placeholders for the diagonal and
+  above-diagonal facts.
+- Remaining HexGramSchmidt placeholders are still in the basis zero,
+  orthogonality, decomposition, span, scaled coefficient, determinant, and
+  update theorem surfaces.
+
+**Next step**
+
+- Continue HexGramSchmidt Phase 5 with the remaining basis/decomposition/span
+  proofs or the integer scaled-coefficient/update frontiers.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1760

Session: `2bc7450f-aecf-4cc5-8a23-aff110abbed9`

f964818 prove GramSchmidt coeff matrix shape facts

🤖 Prepared with Claude Code