### PR TITLE
fix: make polynomial remainder congruence core explicit

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -213,6 +213,8 @@ class DivModLaws (R : Type u) [Zero R] [DecidableEq R] [One R] [Add R] [Sub R] [
     ∀ p q : DensePoly R, q ∣ p → p % q = 0
   mod_mod_of_not_pos_degree :
     ∀ p q : DensePoly R, ¬ 0 < q.degree?.getD 0 → (p % q) % q = p % q
+  mod_eq_mod_of_congr :
+    ∀ p q m : DensePoly R, m ∣ (p - q) → p % m = q % m
   mod_add_mod :
     ∀ p q m : DensePoly R, (p + q) % m = ((p % m) + (q % m)) % m
   mod_mul_mod :
@@ -351,20 +353,6 @@ theorem mod_mod [One R] [Add R] [Sub R] [Mul R] [Div R]
   by_cases hq : 0 < q.degree?.getD 0
   · exact mod_eq_self_of_degree_lt (p % q) q (mod_degree_lt_of_pos_degree p q hq)
   · exact mod_mod_of_not_pos_degree p q hq
-
-/-- Reducing both summands before addition preserves the canonical remainder. -/
-theorem mod_add_mod [One R] [Add R] [Sub R] [Mul R] [Div R]
-    [DivModLaws R]
-    (p q m : DensePoly R) :
-    (p + q) % m = ((p % m) + (q % m)) % m := by
-  exact DivModLaws.mod_add_mod p q m
-
-/-- Reducing both factors before multiplication preserves the canonical remainder. -/
-theorem mod_mul_mod [One R] [Add R] [Sub R] [Mul R] [Div R]
-    [DivModLaws R]
-    (p q m : DensePoly R) :
-    (p * q) % m = ((p % m) * (q % m)) % m := by
-  exact DivModLaws.mod_mul_mod p q m
 
 end DensePoly
 
@@ -1601,6 +1589,34 @@ private theorem zero_mod_eq_zero {S : Type _}
       change (ofCoeffs #[] : DensePoly S) = 0
       rfl
 
+private theorem mod_eq_mod_of_dvd_sub {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
+    {p q m : DensePoly S} :
+    m ∣ (p - q) -> p % m = q % m := by
+  exact DivModLaws.mod_eq_mod_of_congr p q m
+
+/-- Congruent polynomials have the same canonical remainder once the divisor law package
+supplies the executable `%` invariants. -/
+theorem mod_eq_mod_of_congr {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    [DivModLaws S]
+    {p q m : DensePoly S} :
+    Congr p q m -> p % m = q % m := by
+  exact mod_eq_mod_of_dvd_sub
+
+/-- Reducing both summands before addition preserves the canonical remainder. -/
+theorem mod_add_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    [DivModLaws S]
+    (p q m : DensePoly S) :
+    (p + q) % m = ((p % m) + (q % m)) % m := by
+  exact DivModLaws.mod_add_mod p q m
+
+/-- Reducing both factors before multiplication preserves the canonical remainder. -/
+theorem mod_mul_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    [DivModLaws S]
+    (p q m : DensePoly S) :
+    (p * q) % m = ((p % m) * (q % m)) % m := by
+  exact DivModLaws.mod_mul_mod p q m
+
 private theorem mod_mul_self_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m r : DensePoly S) :
@@ -1614,26 +1630,16 @@ private theorem mod_add_mul_self {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (q m r : DensePoly S) :
     (q + m * r) % m = q % m := by
-  rw [mod_add_mod]
-  rw [mod_mul_self_left]
-  rw [add_zero_right]
-  rw [mod_mod]
-
-private theorem mod_eq_mod_of_dvd_sub {S : Type _}
-    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
-    {p q m : DensePoly S} :
-    m ∣ (p - q) -> p % m = q % m := by
-  rintro ⟨r, hmul⟩
-  rw [eq_add_mul_of_sub_eq_mul hmul]
-  exact mod_add_mul_self q m r
-
-/-- Congruent polynomials have the same canonical remainder once the divisor law package
-supplies the executable `%` invariants. -/
-theorem mod_eq_mod_of_congr {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
-    [DivModLaws S]
-    {p q m : DensePoly S} :
-    Congr p q m -> p % m = q % m := by
-  exact mod_eq_mod_of_dvd_sub
+  apply mod_eq_mod_of_congr
+  exact ⟨r, by
+    apply ext_coeff
+    intro n
+    have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
+    have hzero_add : (0 : S) + (0 : S) = 0 := by grind
+    rw [coeff_sub (q + m * r) q n hzero_sub]
+    rw [coeff_add q (m * r) n hzero_add]
+    rw [coeff_mul]
+    grind⟩
 
 private theorem polyCRT_sub_left_factor {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -83,6 +83,9 @@ instance : DensePoly.DivModLaws (ZMod64 p) where
   mod_mod_of_not_pos_degree := by
     intro f g hdegree
     sorry
+  mod_eq_mod_of_congr := by
+    intro f g m hcongr
+    sorry
   mod_add_mod := by
     intro f g m
     sorry

--- a/progress/20260502T071657Z_c1215d2f.md
+++ b/progress/20260502T071657Z_c1215d2f.md
@@ -1,0 +1,20 @@
+**Accomplished**
+
+- Claimed #1799 and made `DensePoly.DivModLaws` carry `mod_eq_mod_of_congr` as the primitive congruent-remainder core.
+- Rewired the public `DensePoly.mod_eq_mod_of_congr` theorem in `HexPoly/Euclid.lean` to project that core directly instead of proving it via `mod_add_mod`/`mod_mul_mod`.
+- Updated the private `mod_add_mul_self` helper to depend on the new congruent-remainder core rather than feeding back through the modular addition law.
+- Updated the existing `DensePoly.DivModLaws (ZMod64 p)` proof-obligation instance in `HexPolyFp/Basic.lean` with the new core field.
+- Verified with `lake build HexPoly.Euclid`, `lake build HexPoly`, `lake build HexPolyFp.Basic`, `python3 scripts/status.py HexPoly`, `python3 scripts/status.py HexPolyFp`, `python3 scripts/check_dag.py`, `git diff --check`, and forbidden-token scans over touched Lean files.
+
+**Current frontier**
+
+- `DensePoly.mod_eq_mod_of_congr` is no longer circular through the modular reduction fields.
+- The concrete `ZMod64 p` instance now has a direct `mod_eq_mod_of_congr` proof obligation alongside the existing Phase 5 division-law placeholders.
+
+**Next step**
+
+- Prove the concrete `DensePoly.DivModLaws (ZMod64 p)` `mod_eq_mod_of_congr` field, then use it to discharge the `mod_add_mod` and `mod_mul_mod` fields.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1799

Session: `c1215d2f-ab6a-4ce5-be29-b55b796fb254`

f881da0 fix: make polynomial remainder congruence core explicit

🤖 Prepared with Claude Code