### PR TITLE
chore: roll HexHensel/HexLLL/HexBerlekampZassenhaus back to Phase 0

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -56,7 +56,7 @@ libraries:
   HexLLL:
     deps: [HexGramSchmidt]
     mathlib: false
-    done_through: 4
+    done_through: 0
   HexPolyFp:
     deps: [HexPoly, HexModArith]
     mathlib: false
@@ -80,7 +80,7 @@ libraries:
   HexHensel:
     deps: [HexPolyFp, HexPolyZ]
     mathlib: false
-    done_through: 4
+    done_through: 0
   HexConway:
     deps: [HexBerlekamp]
     mathlib: false
@@ -90,9 +90,9 @@ libraries:
     mathlib: false
     done_through: 3
   HexBerlekampZassenhaus:
-    deps: [HexBerlekamp, HexHensel]
+    deps: [HexBerlekamp, HexHensel, HexLLL]
     mathlib: false
-    done_through: 3
+    done_through: 0
 
   # ---------- Mathlib bridges ----------
   HexPolyMathlib:
@@ -118,7 +118,7 @@ libraries:
   HexLLLMathlib:
     deps: [HexLLL, HexMatrixMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 0
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
@@ -126,7 +126,7 @@ libraries:
   HexHenselMathlib:
     deps: [HexHensel, HexPolyMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 0
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGfqField]
     mathlib: true


### PR DESCRIPTION
This PR rolls the affected libraries' done_through counters back to 0
in libraries.yml, in response to the audit-driven SPEC PRs that
mandate quadratic multifactor Hensel lifting and LLL-based
recombination as Phase 1 deliverables. It also adds the new BZ -> HexLLL
production dep edge.

Rollback target values:
- HexHensel: 4 -> 0
- HexLLL: 4 -> 0
- HexBerlekampZassenhaus: 3 -> 0 (and deps += HexLLL)
- HexLLLMathlib: 2 -> 0 (Phase 1 dep-coupled to HexLLL)
- HexHenselMathlib: 2 -> 0 (Phase 1 dep-coupled to HexHensel)
- HexBerlekampZassenhausMathlib: already at 0

Symptom (per `PLAN/Conventions.md` guidance for conformance/audit-found
rollback issues):

- **Declared expectation.** `factor : ZPoly -> Array ZPoly` runs in
  polynomial time backed by quadratic Hensel + LLL recombination.
- **Observed result.** `multifactorLift` uses linear-only `henselLift`
  (`HexHensel/Multifactor.lean:32`); `recombine` uses exhaustive
  `subsetSplits` (`HexBerlekampZassenhaus/Basic.lean:591`); HexLLL
  exposes only state-mutation steps and predicates with no top-level
  entry point or short-vector recovery.
- **Root-cause hypothesis.** The previous SPEC explicitly deferred
  both quadratic Hensel and LLL-in-BZ to "later"; Phase 3 conformance
  and Phase 4 benchmarks passed because tests do not exercise the
  asymptotic path. The companion SPEC PRs fix the framing; this PR
  makes the metadata reflect reality.

Companion SPEC PRs (must land before or together with this one):
- https://github.com/kim-em/hex/pull/1828 - spec: mandate quadratic multifactor Hensel lift as Phase 1
- https://github.com/kim-em/hex/pull/1829 - spec: mandate LLL-based recombination as Phase 1 in BZ
- https://github.com/kim-em/hex/pull/1830 - spec: pin hex-lll top-level entry as a Phase 1 deliverable
- https://github.com/kim-em/hex/pull/1831 - spec: add hex-lll edge to BZ in Libraries DAG

The umbrella `human-oversight` issue and per-library implementation
issues will be filed once this PR lands.

`scripts/check_dag.py` passes locally with the new BZ -> HexLLL edge
(no `lakefile.lean` change needed; lakefile `lean_lib` entries are
declaration-only and `check_dag` verifies imports against
`libraries.yml` deps directly).

🤖 Prepared with Claude Code