### PR TITLE
Thread PrimeModulus through HexPolyFp DivModLaws instance and downstream consumers

### DIFF
--- a/HexGfqField/Basic.lean
+++ b/HexGfqField/Basic.lean
@@ -75,8 +75,9 @@ def repr {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
 @[simp] theorem degree_repr_lt_degree
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) :
-    FpPoly.degree (repr x) < FpPoly.degree f :=
-  GFqRing.degree_repr_lt_degree x.toQuotient
+    FpPoly.degree (repr x) < FpPoly.degree f := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  exact GFqRing.degree_repr_lt_degree x.toQuotient
 
 @[ext] theorem ext
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}

--- a/HexGfqField/Operations.lean
+++ b/HexGfqField/Operations.lean
@@ -12,7 +12,9 @@ namespace Hex
 
 namespace GFqField
 
-variable {p : Nat} [ZMod64.Bounds p] {hp : Hex.Nat.Prime p}
+set_option linter.unusedSectionVars false
+
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p] {hp : Hex.Nat.Prime p}
 
 /-- Natural-number literals reuse the quotient-ring cast and then rewrap the
 resulting reduced residue. -/

--- a/HexGfqRing/Basic.lean
+++ b/HexGfqRing/Basic.lean
@@ -24,7 +24,9 @@ end FpPoly
 
 namespace GFqRing
 
-variable {p : Nat} [ZMod64.Bounds p]
+set_option linter.unusedSectionVars false
+
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
 
 /-- Canonical remainder reduction modulo `f`, using the existing division surface. -/
 def reduceMod (f : FpPoly p) : FpPoly p → FpPoly p :=

--- a/HexGfqRing/Operations.lean
+++ b/HexGfqRing/Operations.lean
@@ -13,7 +13,9 @@ namespace Hex
 
 namespace GFqRing
 
-variable {p : Nat} [ZMod64.Bounds p]
+set_option linter.unusedSectionVars false
+
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
 
 /-- The quotient zero element. -/
 def zero (f : FpPoly p) (hf : 0 < FpPoly.degree f) : PolyQuotient f hf :=
@@ -654,7 +656,7 @@ private theorem nsmul_go_eq_acc_add_linearNSmul
                   = add (add acc base) (linearNSmul (add base base) (k / 2)) := by
                     exact ih (k / 2) hlt (add acc base) (add base base)
               _ = add acc (add base (linearNSmul (add base base) (k / 2))) := by
-                    exact @linearNSmul_add_assoc_raw p _ f hf acc base
+                    exact @linearNSmul_add_assoc_raw p _ _ f hf acc base
                       (linearNSmul (add base base) (k / 2))
               _ = add acc (linearNSmul base (2 * (k / 2) + 1)) := by
                     rw [linearNSmul_double_add_one]
@@ -978,7 +980,7 @@ private theorem pow_go_eq_acc_mul_linearPow
                   = mul (mul acc base) (linearPow (mul base base) (k / 2)) := by
                     exact ih (k / 2) hlt (mul acc base) (mul base base)
               _ = mul acc (mul base (linearPow (mul base base) (k / 2))) := by
-                    exact @linearPow_mul_assoc_raw p _ f hf acc base
+                    exact @linearPow_mul_assoc_raw p _ _ f hf acc base
                       (linearPow (mul base base) (k / 2))
               _ = mul acc (linearPow base (2 * (k / 2) + 1)) := by
                     rw [linearPow_double_add_one]

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -1018,7 +1018,7 @@ private theorem linearHenselStep_raw_factor_congr_from_correction
     linearHenselStep_product_expansion_congr p k f g h r hCorrection hk hprod hscaled
 
 private theorem linearHenselStep_raw_factor_congr
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
     (hk : 1 ≤ k)
     (hprod : ZPoly.congr (g * h) f (p ^ k))
@@ -1054,7 +1054,7 @@ private theorem linearHenselStep_raw_factor_congr
       p k f g h r hCorrection eMod hk hprod hcorr
 
 private theorem linearHenselStep_reduced_factor_congr
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
     (hk : 1 ≤ k)
     (hprod : ZPoly.congr (g * h) f (p ^ k))
@@ -1139,7 +1139,7 @@ def henselLift
 
 /-- The lifted factors still multiply to `f` modulo the next power of `p`. -/
 theorem linearHenselStep_spec
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
     (hk : 1 ≤ k)
     (hprod : ZPoly.congr (g * h) f (p ^ k))
@@ -1471,7 +1471,7 @@ theorem linearHenselStep_h_degree?_eq
       simpa [e, gMod, hMod, eMod, qr, hCorrection, h'] using hhRawDegree
 
 private theorem henselLiftLoop_invariant
-    (p steps current : Nat) [ZMod64.Bounds p]
+    (p steps current : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f : ZPoly) (s t : FpPoly p) (acc : LinearLiftResult)
     (hp : 1 < p)
     (hcurrent : 1 ≤ current)
@@ -1522,7 +1522,7 @@ private theorem henselLiftLoop_invariant
 
 /-- The iterative linear wrapper lifts the factorization to congruence modulo `p^k`. -/
 theorem henselLift_spec
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
     (hk : 1 ≤ k)
     (hp : 1 < p)
@@ -1562,7 +1562,7 @@ theorem henselLift_spec
 
 /-- The iterative linear wrapper preserves monicity of the lifted `g` factor. -/
 theorem henselLift_monic
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
     (hk : 1 ≤ k)
     (hp : 1 < p)

--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -107,7 +107,7 @@ private theorem polyProduct_singleton_append (g : ZPoly) (rest : Array ZPoly) :
         list_foldl_mul_eq_mul_foldl_one g xs
 
 private theorem multifactorLiftList_spec
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f : ZPoly) (factors : List ZPoly)
     (hk : 1 ≤ k)
     (hp : 1 < p)
@@ -163,7 +163,7 @@ The product of the lifted factors is congruent to `f` modulo `p^k`, provided
 each recursive binary split supplies the linear Hensel invariant package.
 -/
 theorem multifactorLift_spec
-    (p k : Nat) [ZMod64.Bounds p]
+    (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f : ZPoly) (factors : Array ZPoly)
     (hk : 1 ≤ k)
     (hp : 1 < p)

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -113,12 +113,14 @@ private theorem add_sub_add_right (a b c d : DensePoly (ZMod64 p)) :
   rw [DensePoly.coeff_sub a c n hzero_sub, DensePoly.coeff_sub b d n hzero_sub]
   grind
 
-private theorem divMod_remainder_degree_lt_core (f m : DensePoly (ZMod64 p))
+private theorem divMod_remainder_degree_lt_core
+    [PrimeModulus p] (f m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0) :
     (DensePoly.divMod f m).2.degree?.getD 0 < m.degree?.getD 0 := by
   sorry
 
-private theorem mod_remainder_degree_lt_core (f m : DensePoly (ZMod64 p))
+private theorem mod_remainder_degree_lt_core
+    [PrimeModulus p] (f m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0) :
     (f % m).degree?.getD 0 < m.degree?.getD 0 := by
   simpa [DensePoly.mod] using divMod_remainder_degree_lt_core f m hdegree
@@ -170,7 +172,8 @@ private theorem mod_remainders_congr_of_congr (f g m : DensePoly (ZMod64 p))
       exact (DensePoly.mul_add_right_poly m (q + rf)
         ((0 : DensePoly (ZMod64 p)) - rg)).symm
 
-private theorem mod_eq_mod_of_congr_pos_degree (f g m : DensePoly (ZMod64 p))
+private theorem mod_eq_mod_of_congr_pos_degree
+    [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0)
     (hcongr : DensePoly.Congr f g m) :
     f % m = g % m := by
@@ -185,7 +188,8 @@ private theorem mod_eq_mod_of_congr_not_pos_degree (f g m : DensePoly (ZMod64 p)
     f % m = g % m := by
   sorry
 
-private theorem mod_eq_mod_of_congr_core (f g m : DensePoly (ZMod64 p))
+private theorem mod_eq_mod_of_congr_core
+    [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hcongr : DensePoly.Congr f g m) :
     f % m = g % m := by
   by_cases hdegree : 0 < m.degree?.getD 0
@@ -248,7 +252,7 @@ private theorem mul_left_remainder_delta (f g m rf rg : DensePoly (ZMod64 p))
 These are the concrete finite-field instances of the generic `DensePoly.DivModLaws` proof
 surface used by downstream quotient-ring code; the executable division operations
 themselves are inherited from `DensePoly`. -/
-instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] :
+instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
     DensePoly.DivModLaws (ZMod64 p) where
   divMod_spec := by
     intro f g

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1316,7 +1316,7 @@ private theorem pthRoot_reachable_of_derivative_zero
   rw [hf_one]
   exact pthRoot_one hp
 
-private theorem div_gcd_mul_reconstruct (f df : FpPoly p) :
+private theorem div_gcd_mul_reconstruct [ZMod64.PrimeModulus p] (f df : FpPoly p) :
     (f / DensePoly.gcd f df) * DensePoly.gcd f df = f := by
   have hspec := DensePoly.div_mul_add_mod f (DensePoly.gcd f df)
   have hmod :
@@ -1327,12 +1327,12 @@ private theorem div_gcd_mul_reconstruct (f df : FpPoly p) :
   rw [add_zero] at hspec
   exact hspec
 
-private theorem gcd_mul_div_reconstruct (f df : FpPoly p) :
+private theorem gcd_mul_div_reconstruct [ZMod64.PrimeModulus p] (f df : FpPoly p) :
     DensePoly.gcd f df * (f / DensePoly.gcd f df) = f := by
   rw [mul_comm]
   exact div_gcd_mul_reconstruct f df
 
-private theorem div_gcd_right_mul_reconstruct (c w : FpPoly p) :
+private theorem div_gcd_right_mul_reconstruct [ZMod64.PrimeModulus p] (c w : FpPoly p) :
     (w / DensePoly.gcd c w) * DensePoly.gcd c w = w := by
   have hspec := DensePoly.div_mul_add_mod w (DensePoly.gcd c w)
   have hmod :
@@ -1343,12 +1343,13 @@ private theorem div_gcd_right_mul_reconstruct (c w : FpPoly p) :
   rw [add_zero] at hspec
   exact hspec
 
-private theorem gcd_mul_div_right_reconstruct (c w : FpPoly p) :
+private theorem gcd_mul_div_right_reconstruct [ZMod64.PrimeModulus p] (c w : FpPoly p) :
     DensePoly.gcd c w * (w / DensePoly.gcd c w) = w := by
   rw [mul_comm]
   exact div_gcd_right_mul_reconstruct c w
 
 private theorem yunFactorsContribution_step_split
+    [ZMod64.PrimeModulus p]
     (c w : FpPoly p) :
     let y := DensePoly.gcd c w
     let z := c / y
@@ -1409,6 +1410,7 @@ private theorem yunFactorsContribution_tail_repeated_descent
   · simp [yunFactorsContribution, hc, hz]
 
 private theorem yunFactorsContribution_step_preserves_target
+    [ZMod64.PrimeModulus p]
     (c w : FpPoly p) (multiplicity fuel : Nat) (target : FpPoly p)
     (hc : isOne c = false)
     (htarget_one :
@@ -1457,6 +1459,7 @@ for the recursive tail, and the lemma returns the corresponding current-state
 facts plus the two gcd/division reconstruction equalities.
 -/
 private theorem yunFactorsContribution_step_target_combiner
+    [ZMod64.PrimeModulus p]
     (c w : FpPoly p) (multiplicity fuel : Nat) (target : FpPoly p)
     (hc : isOne c = false)
     (htarget_one :
@@ -1493,6 +1496,7 @@ private theorem yunFactorsContribution_step_target_combiner
       htarget.2.2.1, htarget.2.2.2⟩
 
 private theorem yunFactorsContribution_initial_state_split
+    [ZMod64.PrimeModulus p]
     (f : FpPoly p) :
     let g := DensePoly.gcd f (DensePoly.derivative f)
     let c := f / g
@@ -1568,6 +1572,7 @@ private theorem yunFactorsContribution_derivative_active_split_algebra_succ
           contribution.1 *
             squareFreeAuxRevContribution (pthRoot contribution.2) (multiplicity * p) (fuel + 1) =
               pow f multiplicity) := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   let g := DensePoly.gcd f (DensePoly.derivative f)
   let c := f / g
   have hcg : c * g = f := by

--- a/progress/20260503T220245Z_96a79d24.md
+++ b/progress/20260503T220245Z_96a79d24.md
@@ -1,0 +1,38 @@
+**Accomplished**
+
+- Claimed #1843 and threaded `ZMod64.PrimeModulus p` through the
+  `HexPolyFp` finite-field division-law surface:
+  `instDivModLawsZMod64Fp`, the positive-degree remainder helper path,
+  and the congruence-to-equal-remainders helper path.
+- Updated downstream proof surfaces that rely on `DensePoly.DivModLaws`
+  over `ZMod64 p` in `HexPolyFp.SquareFree`, `HexGfqRing`,
+  `HexGfqField`, `HexHensel.Linear`, and `HexHensel.Multifactor`.
+- Preserved executable polynomial and Hensel definitions; changes are
+  limited to typeclass assumptions and local `Hex.Nat.Prime p` to
+  `ZMod64.PrimeModulus p` bridges where existing public APIs already
+  carry primality explicitly.
+
+**Current frontier**
+
+- Verification passed:
+  - `lake build HexPolyFp.Basic`
+  - `lake build HexPolyFp`
+  - `lake build HexGfqRing`
+  - `lake build HexGfqField`
+  - `lake build HexHensel`
+  - `python3 scripts/status.py HexPolyFp`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+- Banned-placeholder scan over touched Lean files found no new `axiom`,
+  `native_decide`, `TODO`, `FIXME`, or added `sorry`.
+- Builds still report only pre-existing `sorry` warnings in the broader
+  dependency graph.
+
+**Next step**
+
+- Prove the sibling `divMod_remainder_degree_lt_core` field-cancellation
+  obligation under `[ZMod64.PrimeModulus p]`.
+
+**Blockers**
+
+- None for this issue.


### PR DESCRIPTION
Closes #1843

Session: `96a79d24-1b79-4661-a25e-bab020ca07e4`

e750451 fix: require prime modulus for Fp division laws

🤖 Prepared with Claude Code