### PR TITLE
fix: normalize multifactor Hensel bezout witnesses

### DIFF
--- a/HexHensel/Conformance.lean
+++ b/HexHensel/Conformance.lean
@@ -195,37 +195,12 @@ a follow-up issue.
 #guard reduceArrModPow (ZPoly.multifactorLift 5 1 qmEdgeF qmEdgeFactors) 5 1
      = reduceArrModPow (ZPoly.multifactorLiftQuadratic 5 1 qmEdgeF qmEdgeFactors) 5 1
 
-/-
-Deferred cross-check (`k ≥ 2`).
+#guard reduceArrModPow (ZPoly.multifactorLift 5 4 qmTypicalF qmTypicalFactors) 5 4
+     = reduceArrModPow (ZPoly.multifactorLiftQuadratic 5 4 qmTypicalF qmTypicalFactors) 5 4
 
-The SPEC's lift-uniqueness obligation predicts that `multifactorLift` and
-`multifactorLiftQuadratic` agree after canonicalisation by
-`ZPoly.reduceModPow _ p k` for every `k`. Empirically, the agreement
-holds at `k = 1` but breaks at `k ≥ 2` on the fixtures above: on
-`qmTypicalFactors` at `p = 5, k = 4`, the linear path returns
-`#[x + 476, x + 307, x + 18]` while the quadratic path returns
-`#[x + 1, x + 2, x + 3]`, and the product of the linear factors reduces
-to `x³ + 176x² + 226x + 376 (mod 625)` rather than to
-`f = x³ + 6x² + 11x + 6`.
-
-Root cause: `ZPoly.multifactorLift` calls `DensePoly.xgcd` on the
-mod-`p` factors and feeds the raw `(left, right)` Bezout witnesses to
-`henselLift`. `xgcd_bezout` returns `left * g + right * h = gcd`, where
-`gcd` is the last non-zero remainder of the Euclidean iteration —
-typically a non-trivial unit of `F_p`, not `1`. The
-`MultifactorLiftInvariant` precondition explicitly demands
-`liftToZ (left * g + right * h) ≡ 1 (mod p)`, which the raw `xgcd` output
-violates whenever `gcd ≠ 1` in `F_p`. The quadratic path tolerates the
-miscalibration because `quadraticHenselStep` re-normalises the Bezout
-pair on every doubling iteration; the linear path does not.
-
-Fix: have `multifactorLift` (or a shared helper) divide
-`(left, right, gcd)` through by `gcd` in `F_p` before passing the
-witnesses to `henselLift`, restoring the SPEC precondition. That fix is
-tracked as a follow-up issue and is out of scope for this conformance
-file; the corresponding `k ≥ 2` cross-check pair lands together with the
-fix.
--/
+#guard reduceArrModPow (ZPoly.multifactorLift 5 6 qmAdversarialF qmAdversarialFactors) 5 6
+     = reduceArrModPow
+        (ZPoly.multifactorLiftQuadratic 5 6 qmAdversarialF qmAdversarialFactors) 5 6
 
 /-
 Asymptotic-gap commentary (observation only; no timing assertion).

--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -20,6 +20,19 @@ namespace Hex
 
 namespace ZPoly
 
+/--
+Extended gcd witnesses scaled so their Bezout combination is monic when the
+raw Euclidean gcd is a nonzero constant unit.
+-/
+def normalizedXGCD
+    (p : Nat) [ZMod64.Bounds p]
+    (g h : ZPoly) : DensePoly.XGCDResult (ZMod64 p) :=
+  let raw := DensePoly.xgcd (modP p g) (modP p h)
+  let unitInv := (DensePoly.leadingCoeff raw.gcd)⁻¹
+  { gcd := DensePoly.scale unitInv raw.gcd
+    left := DensePoly.scale unitInv raw.left
+    right := DensePoly.scale unitInv raw.right }
+
 private def multifactorLiftList
     (p k : Nat) [ZMod64.Bounds p]
     (f : ZPoly) : List ZPoly → Array ZPoly
@@ -28,7 +41,7 @@ private def multifactorLiftList
   | g :: rest =>
       let restFactors := rest.toArray
       let h := Array.polyProduct restFactors
-      let xgcd := DensePoly.xgcd (modP p g) (modP p h)
+      let xgcd := normalizedXGCD p g h
       let lifted := henselLift p k f g h xgcd.left xgcd.right
       #[lifted.g] ++ multifactorLiftList p k lifted.h rest
 
@@ -55,7 +68,7 @@ def MultifactorLiftInvariant
   | [_g] => True
   | g :: rest =>
       let h := Array.polyProduct rest.toArray
-      let xgcd := DensePoly.xgcd (modP p g) (modP p h)
+      let xgcd := normalizedXGCD p g h
       let lifted := henselLift p k f g h xgcd.left xgcd.right
       LinearLiftLoopInvariant p 1 f xgcd.left xgcd.right
         { g := reduceModPow g p 1
@@ -125,7 +138,7 @@ private theorem multifactorLiftList_spec
       | cons h tail =>
           let restFactors := (h :: tail).toArray
           let splitProduct := Array.polyProduct restFactors
-          let xgcd := DensePoly.xgcd (ZPoly.modP p g) (ZPoly.modP p splitProduct)
+          let xgcd := normalizedXGCD p g splitProduct
           let lifted := henselLift p k f g splitProduct xgcd.left xgcd.right
           rcases hinv with ⟨hstart, hstepDegree, hstepBezout, htail⟩
           have htailCongr :

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -57,7 +57,7 @@ private def multifactorLiftQuadraticList
   | g :: rest =>
       let restFactors := rest.toArray
       let h := Array.polyProduct restFactors
-      let xgcd := DensePoly.xgcd (ZPoly.modP p g) (ZPoly.modP p h)
+      let xgcd := ZPoly.normalizedXGCD p g h
       let s := FpPoly.liftToZ xgcd.left
       let t := FpPoly.liftToZ xgcd.right
       let lifted := henselLiftQuadratic p k f g h s t

--- a/progress/20260503T221139Z_caf324e1.md
+++ b/progress/20260503T221139Z_caf324e1.md
@@ -1,0 +1,28 @@
+**Accomplished**
+
+- Claimed #1845 and normalized multifactor Hensel Bezout witnesses by scaling
+  `DensePoly.xgcd` output through the inverse of the returned gcd leading
+  coefficient.
+- Routed both linear and quadratic multifactor lift call sites through the
+  normalized witness helper.
+- Replaced the deferred `k >= 2` linear/quadratic conformance note with
+  executable `#guard` agreement checks for the typical `k = 4` and
+  adversarial `k = 6` fixtures.
+
+**Current frontier**
+
+- Verification passed:
+  - `lake build HexHensel`
+  - `lake build HexHensel.Conformance`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+- Placeholder scan over touched Lean files found only the pre-existing
+  `multifactorLiftQuadratic_spec` Phase 1 `sorry`.
+
+**Next step**
+
+- Create the PR for #1845 and let normal CI validate the conformance guards.
+
+**Blockers**
+
+- None for this issue.


### PR DESCRIPTION
Closes #1845

Session: `caf324e1-ae9c-4adb-b6c1-df96f0ae658c`

af3f638 fix: normalize multifactor Hensel bezout witnesses

🤖 Prepared with Claude Code