### PR TITLE
Add determinant minor infrastructure for Bareiss prefixes

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -159,5 +159,85 @@ def submatrix (M : Matrix R n n) (k : Fin n) : Matrix R (k.val + 1) (k.val + 1) 
     let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
     M[ii][jj]
 
+/-- Leading principal `k × k` prefix of a square matrix. This variant includes
+the empty prefix and is convenient for Bareiss pivot/minor statements. -/
+def leadingPrefix (M : Matrix R n n) (k : Nat) (hk : k ≤ n) : Matrix R k k :=
+  ofFn fun i j =>
+    let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+    let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+    M[ii][jj]
+
+@[simp] theorem leadingPrefix_entry (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
+    (i j : Fin k) :
+    (leadingPrefix M k hk)[i][j] =
+      (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+       let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+       M[ii][jj]) := by
+  simp [leadingPrefix, ofFn]
+
+@[simp] theorem submatrix_entry (M : Matrix R n n) (k : Fin n)
+    (i j : Fin (k.val + 1)) :
+    (submatrix M k)[i][j] =
+      (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt (Nat.succ_le_of_lt k.isLt)⟩
+       let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
+       M[ii][jj]) := by
+  simp [submatrix, ofFn]
+
+/-- The existing `submatrix` API is the `(k + 1)` leading-prefix API at the
+same boundary. -/
+theorem submatrix_eq_leadingPrefix (M : Matrix R n n) (k : Fin n) :
+    submatrix M k = leadingPrefix M (k.val + 1) (Nat.succ_le_of_lt k.isLt) := by
+  apply Vector.ext
+  intro i hi
+  apply Vector.ext
+  intro j hj
+  simp [submatrix, leadingPrefix, ofFn]
+
+/-- Bordered Bareiss minor with the first `k` rows/columns and one extra
+border row `i` and column `j`. For Bareiss applications `i` and `j` are in the
+trailing part, but the constructor is total and leaves that side condition to
+the invariant using it. -/
+def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
+    Matrix R (k + 1) (k + 1) :=
+  ofFn fun r c =>
+    let rr : Fin n :=
+      if hr : r.val < k then
+        ⟨r.val, Nat.lt_trans hr hk⟩
+      else
+        i
+    let cc : Fin n :=
+      if hc : c.val < k then
+        ⟨c.val, Nat.lt_trans hc hk⟩
+      else
+        j
+    M[rr][cc]
+
+@[simp] theorem borderedMinor_entry_lt_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
+    (i j : Fin n) (r c : Fin (k + 1)) (hr : r.val < k) (hc : c.val < k) :
+    (borderedMinor M k hk i j)[r][c] =
+      (let rr : Fin n := ⟨r.val, Nat.lt_trans hr hk⟩
+       let cc : Fin n := ⟨c.val, Nat.lt_trans hc hk⟩
+       M[rr][cc]) := by
+  simp [borderedMinor, ofFn, hr, hc]
+
+@[simp] theorem borderedMinor_entry_lt_last (M : Matrix R n n) (k : Nat) (hk : k < n)
+    (i j : Fin n) (r : Fin (k + 1)) (hr : r.val < k) :
+    (borderedMinor M k hk i j)[r][Fin.last k] =
+      (let rr : Fin n := ⟨r.val, Nat.lt_trans hr hk⟩
+       M[rr][j]) := by
+  simp [borderedMinor, ofFn, hr]
+
+@[simp] theorem borderedMinor_entry_last_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
+    (i j : Fin n) (c : Fin (k + 1)) (hc : c.val < k) :
+    (borderedMinor M k hk i j)[Fin.last k][c] =
+      (let cc : Fin n := ⟨c.val, Nat.lt_trans hc hk⟩
+       M[i][cc]) := by
+  simp [borderedMinor, ofFn, hc]
+
+@[simp] theorem borderedMinor_entry_last_last (M : Matrix R n n) (k : Nat) (hk : k < n)
+    (i j : Fin n) :
+    (borderedMinor M k hk i j)[Fin.last k][Fin.last k] = M[i][j] := by
+  simp [borderedMinor, ofFn]
+
 end Matrix
 end Hex

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -272,6 +272,14 @@ def detTerm {R : Type u} [Lean.Grind.Ring R] {n : Nat}
 def det {R : Type u} [Lean.Grind.Ring R] {n : Nat} (M : Matrix R n n) : R :=
   (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0
 
+/-- The determinant of the empty leading prefix is the Bareiss previous-pivot
+convention `1`. -/
+@[simp] theorem det_leadingPrefix_zero {R : Type u} [Lean.Grind.Ring R]
+    (M : Matrix R n n) :
+    det (leadingPrefix M 0 (Nat.zero_le n)) = (1 : R) := by
+  simp [det, detTerm, detSign, detProduct, permutationVectors, emptyVec, inversionCount]
+  grind
+
 /-- Congruence for the determinant-style left fold over a finite list. -/
 private theorem foldl_det_sum_congr {R : Type u} [Add R] {β : Type v}
     (xs : List β) (f g : β → R) (z : R)

--- a/progress/20260503T231533Z_b1aa3f1d.md
+++ b/progress/20260503T231533Z_b1aa3f1d.md
@@ -1,0 +1,27 @@
+**Accomplished**
+
+- Claimed #1878 and added `Matrix.leadingPrefix` for `k × k` leading principal prefixes, including the empty prefix.
+- Added `Matrix.borderedMinor` for the Bareiss bordered-minor shape with simp lemmas for prefix/prefix, prefix/border, border/prefix, and border/border entries.
+- Linked the existing `(k + 1) × (k + 1)` `submatrix` API to `leadingPrefix`.
+- Added `det_leadingPrefix_zero` so the empty leading-prefix determinant states the Bareiss previous-pivot convention `1`.
+
+**Current frontier**
+
+- Verification passed:
+  - `lake build HexMatrix.Basic`
+  - `lake build HexMatrix.Determinant`
+  - `lake build HexMatrix.Bareiss`
+  - `lake build HexMatrix`
+  - `python3 scripts/status.py HexMatrix`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n "axiom|native_decide|TODO|FIXME|sorry" HexMatrix/Basic.lean HexMatrix/Determinant.lean`
+- `lake build HexMatrix.Bareiss` and `lake build HexMatrix` still report pre-existing `sorry` warnings in downstream files.
+
+**Next step**
+
+- Use these helpers in #1879 to state and prove the no-pivot Bareiss bordered-minor invariant.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
Closes #1878

Session: `b1aa3f1d-2576-478e-9d67-ace623b90e83`

2ecbb8c Add Bareiss determinant minor helpers

🤖 Prepared with Claude Code