### PR TITLE
feat: add HexPolyMathlib gcd bridge benchmarks

### DIFF
--- a/HexPolyMathlib/Bench.lean
+++ b/HexPolyMathlib/Bench.lean
@@ -1,12 +1,12 @@
-import HexPolyMathlib.Basic
+import HexPolyMathlib.Euclid
 import LeanBench
 
 /-!
 Benchmark registrations for the `HexPolyMathlib` dense-polynomial bridge.
 
 This Phase 4 slice measures the conversion surfaces that connect the executable
-`Hex.DensePoly` representation to Mathlib's `Polynomial` representation. GCD and
-extended-GCD bridge benchmarks are left to later Phase 4 slices.
+`Hex.DensePoly` representation to Mathlib's `Polynomial` representation, plus
+the GCD and extended-GCD bridge surfaces over deterministic Euclidean fixtures.
 
 Scientific registrations:
 
@@ -17,6 +17,10 @@ Scientific registrations:
   Mathlib polynomial and checksum its coefficients, `O(n)`.
 * `runRoundTripChecksum`: perform both dense and Mathlib conversion round trips
   over bounded-degree generated inputs, `O(n)`.
+* `runGcdBridgeChecksum`: compute the executable polynomial gcd and transport
+  it through the Mathlib bridge on a Fibonacci quotient-chain fixture, `O(n^2)`.
+* `runXGcdBridgeChecksum`: compute executable extended-gcd components and
+  transport them through the same bridge fixture, `O(n^2)`.
 -/
 
 namespace HexPolyMathlib.PolyBench
@@ -24,11 +28,11 @@ namespace HexPolyMathlib.PolyBench
 open Hex
 
 /-- Hash prepared dense-polynomial inputs by their normalized coefficient arrays. -/
-instance : Hashable (DensePoly Int) where
+instance [Hashable R] [Zero R] [DecidableEq R] : Hashable (DensePoly R) where
   hash p := hash p.toArray
 
 /-- Hash prepared Mathlib polynomial inputs by their finite coefficient window. -/
-instance : Hashable (Polynomial Int) where
+instance [Semiring R] [Hashable R] : Hashable (Polynomial R) where
   hash p := hash <| (Array.range (p.natDegree + 1)).map p.coeff
 
 /-- Prepared dense bridge input with degree bounded by the generated coefficients. -/
@@ -45,6 +49,12 @@ structure MathlibInput where
 structure RoundTripInput where
   dense : DensePoly Int
   mathlib : Polynomial Int
+  deriving Hashable
+
+/-- Prepared executable inputs for Euclidean bridge checksums. -/
+structure GcdBridgeInput where
+  lhs : DensePoly Rat
+  rhs : DensePoly Rat
   deriving Hashable
 
 /-- Deterministic mixing over machine words for compact benchmark observables. -/
@@ -66,7 +76,7 @@ def densePoly (n salt : Nat) : DensePoly Int :=
       if i + 1 = n ∧ coeff = 0 then 1 else coeff
 
 /-- Exact finite-support coefficient payload for a dense polynomial. -/
-def denseFinsupp (p : DensePoly Int) : AddMonoidAlgebra Int Nat where
+def denseFinsupp [Semiring R] [DecidableEq R] (p : DensePoly R) : AddMonoidAlgebra R Nat where
   support := (Finset.range p.size).filter fun i => p.coeff i ≠ 0
   toFun := p.coeff
   mem_support_toFun := by
@@ -81,7 +91,7 @@ def denseFinsupp (p : DensePoly Int) : AddMonoidAlgebra Int Nat where
       exact Finset.mem_filter.mpr ⟨Finset.mem_range.mpr hlt, hne⟩
 
 /-- Executable mirror of `toPolynomial`, avoiding Mathlib's noncomputable semiring wrapper. -/
-def toPolynomialBench (p : DensePoly Int) : Polynomial Int :=
+def toPolynomialBench [Semiring R] [DecidableEq R] (p : DensePoly R) : Polynomial R :=
   Polynomial.ofFinsupp (denseFinsupp p)
 
 /-- Deterministic Mathlib polynomial with `n` generated coefficients. -/
@@ -93,9 +103,13 @@ def checksumDense (p : DensePoly Int) : UInt64 :=
   p.toArray.foldl (fun acc coeff => mixWord acc (hash coeff)) 0
 
 /-- Stable checksum for a Mathlib polynomial's finite coefficient window. -/
-def checksumMathlib (p : Polynomial Int) : UInt64 :=
+def checksumMathlib [Semiring R] [Hashable R] (p : Polynomial R) : UInt64 :=
   (Array.range (p.natDegree + 1)).foldl
     (fun acc i => mixWord acc (hash (p.coeff i))) 0
+
+/-- Stable checksum for a pair of Mathlib polynomial values. -/
+def checksumMathlibPair [Semiring R] [Hashable R] (p q : Polynomial R) : UInt64 :=
+  mixWord (checksumMathlib p) (checksumMathlib q)
 
 /-- Per-parameter dense fixture for conversion to Mathlib. -/
 def prepDenseInput (n : Nat) : DenseInput :=
@@ -110,6 +124,19 @@ def prepRoundTripInput (n : Nat) : RoundTripInput :=
   { dense := densePoly n 131
     mathlib := mathlibPoly n 173 }
 
+/-- Consecutive polynomial Fibonacci inputs force many Euclidean quotient steps. -/
+def prepGcdBridgeInput (n : Nat) : GcdBridgeInput :=
+  let x := DensePoly.monomial 1 (1 : Rat)
+  let pair :=
+    (List.range (n + 1)).foldl
+      (fun state _ =>
+        let prev := state.1
+        let curr := state.2
+        (curr, x * curr + prev))
+      ((0 : DensePoly Rat), (1 : DensePoly Rat))
+  { lhs := pair.2
+    rhs := pair.1 }
+
 /-- Benchmark target: convert one dense polynomial and checksum Mathlib coefficients. -/
 def runToPolynomialChecksum (input : DenseInput) : UInt64 :=
   checksumMathlib (toPolynomialBench input.poly)
@@ -123,6 +150,16 @@ def runRoundTripChecksum (input : RoundTripInput) : UInt64 :=
   let denseRoundTrip := ofPolynomial (toPolynomialBench input.dense)
   let mathlibRoundTrip := toPolynomialBench (ofPolynomial input.mathlib)
   mixWord (checksumDense denseRoundTrip) (checksumMathlib mathlibRoundTrip)
+
+/-- Benchmark target: compute the executable gcd and transport it across the bridge. -/
+def runGcdBridgeChecksum (input : GcdBridgeInput) : UInt64 :=
+  checksumMathlib (toPolynomialBench (DensePoly.gcd input.lhs input.rhs))
+
+/-- Benchmark target: compute executable extended-gcd data and transport it across the bridge. -/
+def runXGcdBridgeChecksum (input : GcdBridgeInput) : UInt64 :=
+  let denseResult := DensePoly.xgcd input.lhs input.rhs
+  mixWord (checksumMathlib (toPolynomialBench denseResult.gcd))
+    (checksumMathlibPair (toPolynomialBench denseResult.left) (toPolynomialBench denseResult.right))
 
 /- Cost model: the executable `toPolynomial` payload enumerates the stored dense
 coefficients once, so the generated `n`-coefficient fixture performs linear
@@ -160,6 +197,42 @@ setup_benchmark runRoundTripChecksum n => n
     paramCeiling := 16384
     paramSchedule := .custom #[1024, 2048, 4096, 8192, 16384]
     maxSecondsPerCall := 2.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/-
+The prepared inputs are consecutive polynomial Fibonacci values. They force
+Theta(n) Euclidean quotient steps. Each degree-one quotient step spends linear
+work in the current degree, and the final dense-to-Mathlib transport is linear
+in the output degree. The Euclidean loop dominates, so the bridge task is
+quadratic in the generated degree.
+-/
+setup_benchmark runGcdBridgeChecksum n => n * n
+  with prep := prepGcdBridgeInput
+  where {
+    paramFloor := 16
+    paramCeiling := 96
+    paramSchedule := .custom #[16, 24, 32, 48, 64, 96]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/-
+This uses the same Fibonacci quotient-chain fixture as `runGcdBridgeChecksum`.
+Extended gcd carries Bezout updates through the Euclidean loop. With degree-one
+quotients, those updates are linear at each decreasing degree, and transporting
+the three output components is linear in their output sizes. The Euclidean loop
+dominates, so the bridge checksum remains Theta(n^2).
+-/
+setup_benchmark runXGcdBridgeChecksum n => n * n
+  with prep := prepGcdBridgeInput
+  where {
+    paramFloor := 16
+    paramCeiling := 96
+    paramSchedule := .custom #[16, 24, 32, 48, 64, 96]
+    maxSecondsPerCall := 4.0
     targetInnerNanos := 200000000
     signalFloorMultiplier := 1.0
   }

--- a/progress/20260504T010930Z_e6579656.md
+++ b/progress/20260504T010930Z_e6579656.md
@@ -1,0 +1,34 @@
+**Accomplished**
+
+- Claimed #1955 and added `HexPolyMathlib.PolyBench.runGcdBridgeChecksum` plus `runXGcdBridgeChecksum` registrations in `HexPolyMathlib/Bench.lean`.
+- Replaced the deferred-GCD wording in the bench module docstring with the new Euclidean bridge benchmark surface.
+- Generalized the executable `toPolynomialBench` support helpers enough to checksum transported `Rat` gcd/xgcd outputs.
+- Created PR #1971 from `agent/e6579656` and manually moved #1955 from `claimed` to `has-pr`.
+
+**Current frontier**
+
+- `HexPolyMathlib/Bench.lean` now lists five registrations: the three existing conversion checks plus the new gcd and extended-gcd bridge checks.
+- Verification passed:
+  - `lake build HexPolyMathlib.Bench`
+  - `lake exe hexpolymathlib_bench list`
+  - `lake exe hexpolymathlib_bench verify`
+  - `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runGcdBridgeChecksum`
+  - `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runXGcdBridgeChecksum`
+  - `python3 scripts/check_phase4.py`
+  - `python3 scripts/status.py HexPolyMathlib`
+  - `python3 scripts/status.py`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n "axiom|native_decide|TODO|FIXME|sorry" HexPolyMathlib/Bench.lean`
+- The two new scientific runs both reported `consistent with declared complexity`.
+
+**Next step**
+
+- Review and merge PR #1971 once CI is green.
+
+**Blockers**
+
+- `python3 scripts/check_phase4.py HexPolyMathlib` is not a supported invocation in the current script; the script accepts only `--base` and `--all`.
+- `python3 scripts/check_phase4.py --all` fails on pre-existing unrelated benchmark files that lack adjacent derivation comments; `HexPolyMathlib/Bench.lean` was not among the reported failures.
+- `coordination create-pr 1955` failed because the GitHub GraphQL rate limit was exhausted. The PR was created through the REST API instead, so auto-merge was not enabled by the coordination script.
+- Builds still replay pre-existing `sorry` warnings in `HexPolyMathlib.Basic` and `HexPolyMathlib.Euclid`.


### PR DESCRIPTION
Closes #1955

## Summary
- add GCD and extended-GCD bridge benchmark registrations for HexPolyMathlib
- update the bench docstring and reusable checksum helpers for Rat bridge outputs
- include adjacent cost-model derivations for the new O(n^2) registrations

## Verification
- lake build HexPolyMathlib.Bench
- lake exe hexpolymathlib_bench list
- lake exe hexpolymathlib_bench verify
- lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runGcdBridgeChecksum
- lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runXGcdBridgeChecksum
- python3 scripts/check_phase4.py
- python3 scripts/status.py HexPolyMathlib
- python3 scripts/status.py
- python3 scripts/check_dag.py
- git diff --check
- rg -n "axiom|native_decide|TODO|FIXME|sorry" HexPolyMathlib/Bench.lean

Note: python3 scripts/check_phase4.py HexPolyMathlib is not supported by the current script CLI; after commit, the supported changed-registration check passed for 2 registrations. The --all mode still fails on unrelated pre-existing files.