### PR TITLE
PLAN+SPEC: reframe profile-sizes to favor upper end of ranges

### DIFF
--- a/PLAN/Phase3.md
+++ b/PLAN/Phase3.md
@@ -58,6 +58,9 @@ Reviewer checklist for Phase 3 PRs:
 - [ ] No `#guard` / `example` where RHS is a literal copy of the
   LHS's evaluation (i.e. the assertion carries content beyond "the
   evaluator is deterministic").
+- [ ] Input sizes pushed toward the upper end of
+  [SPEC/testing.md § "Profile sizes"](../SPEC/testing.md#profile-sizes)
+  ranges (or a comment explains why a smaller size was chosen).
 - [ ] `lake build HexFoo` green.
 - [ ] Conformance workflow green on the PR.
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -258,7 +258,10 @@ instances.
 Size policies per profile. Generators must be parameterised by size
 bounds and seed.
 
-- `core`: tiny deterministic cases only. Polynomial degrees up to
+- `core`: deterministic cases at the *upper end* of the ranges
+  below by default. Shrink only if elaboration time exceeds budget.
+  Larger-than-stated inputs are fine if they elaborate fast — these
+  are floors of coverage, not ceilings. Polynomial degrees up to
   about `8-12`, matrix dimensions up to about `6-8`, finite-field
   extensions up to degree `6`, LLL dimensions up to about `10`.
 - `ci`: modest randomised cases. Integer/finite-field polynomial

--- a/progress/20260504T043446Z_38121a32.md
+++ b/progress/20260504T043446Z_38121a32.md
@@ -1,0 +1,31 @@
+# Reframe profile-sizes to favor upper end of ranges
+
+Issue #2021. Pure-text edits to PLAN/SPEC.
+
+## Accomplished
+
+- `SPEC/testing.md` § "Profile sizes" `core` bullet reframed: previously
+  read "tiny deterministic cases only" (which biased Phase 3 workers
+  toward the bottom of the range); now reads "deterministic cases at the
+  upper end of the ranges below by default. Shrink only if elaboration
+  time exceeds budget. Larger-than-stated inputs are fine if they
+  elaborate fast — these are floors of coverage, not ceilings."
+- `PLAN/Phase3.md` reviewer checklist: added bullet asking reviewers to
+  confirm input sizes are pushed toward the upper end of SPEC's profile
+  sizes ranges (or that a comment explains why a smaller size was
+  chosen).
+- `lake build` green.
+
+## Current frontier
+
+C1 size-bump issues (#2012-#2020) now have a SPEC/PLAN basis to cite
+when justifying the bumps. Each of those is independently claimable.
+
+## Next step
+
+Workers picking up #2012-#2020 should read the new SPEC/PLAN wording
+and bump fixture sizes accordingly.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2021

Session: `38121a32-16e7-42cd-a81c-8ffb00fabbf4`

986e12a doc: reframe SPEC profile-sizes to favor upper end of ranges (#2021)

🤖 Prepared with Claude Code