### PR TITLE
PLAN+SPEC: ban '#guard f(x)=literal' where literal was obtained by running f

### DIFF
--- a/PLAN/Phase3.md
+++ b/PLAN/Phase3.md
@@ -58,6 +58,9 @@ Reviewer checklist for Phase 3 PRs:
 - [ ] No `#guard` / `example` where RHS is a literal copy of the
   LHS's evaluation (i.e. the assertion carries content beyond "the
   evaluator is deterministic").
+- [ ] No `#guard f(x) = literal` where the literal was obtained by
+  running `f`. Each `#guard`'s expected value must be independently
+  derivable from the function's documented contract.
 - [ ] `lake build HexFoo` green.
 - [ ] Conformance workflow green on the PR.
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -170,6 +170,15 @@ MUST NOT appear in any `Conformance.lean`:
   it's implementable), don't paper over it with a test that says
   "this wrong output is expected".
 
+  *Process rule.* Don't compute the expected RHS by running the
+  function under test, even with the result hand-copied into the
+  source. The expected value must be independently derivable from
+  the function's documented contract on the committed input —
+  via a closed-form identity, an oracle, a hand calculation, or
+  a different implementation. If the implementation isn't ready,
+  leave a `-- TODO` comment and stop; don't write the `#guard`
+  against output you obtained by running the function.
+
 - **`native_decide`.** Banned project-wide (see
   [SPEC.md](SPEC.md#project-wide-proof-policy)). Restated here because
   conformance checks on large fixtures are a common temptation.

--- a/progress/20260504T043540Z_2555dd2e.md
+++ b/progress/20260504T043540Z_2555dd2e.md
@@ -1,0 +1,35 @@
+# 2026-05-04 04:35Z — feature session, issue #1981
+
+## Accomplished
+
+- Closed #1981 (PLAN+SPEC: ban `#guard f(x) = literal` where the
+  literal was obtained by running `f`).
+- `SPEC/testing.md` § "Scaffold-locking `#guard`s": appended a
+  *Process rule* paragraph forbidding the run-and-paste pattern.
+  The expected RHS must be independently derivable from the
+  documented contract (closed-form identity, oracle, hand
+  calculation, or a different implementation). If the implementation
+  isn't ready, leave a `-- TODO` and stop.
+- `PLAN/Phase3.md` reviewer checklist: added a bullet matching the
+  process rule so reviewers explicitly check for run-and-paste guards.
+- `lake build` green; pure-text edits, no Lean change.
+
+## Current frontier
+
+PLAN+SPEC documentation cluster. The remaining unclaimed
+`human-oversight` items are mostly conformance fixture-size bumps
+(#2012-#2020) and cross-check fixtures (#2006-#2011), plus the
+oracle-bootstrap chain (#1986 and dependents). #2021 (sister
+PLAN+SPEC item, profile-sizes upper-end framing) was claimed by
+another agent during this session.
+
+## Next step
+
+Reviewer of the next conformance PR can now cite this checklist
+bullet directly. C1-cluster workers (per-library size bumps) should
+read the new SPEC bullet alongside #2021's reframing once both
+land.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #1981

Session: `2555dd2e-f5d2-42b5-892a-c5cec0d5d941`

a066541 doc: ban run-and-paste #guard literals in conformance modules

🤖 Prepared with Claude Code