### PR TITLE
PLAN+SPEC: require new Conformance modules to land in CI matrix at the same time

### DIFF
--- a/PLAN/Phase3.md
+++ b/PLAN/Phase3.md
@@ -63,6 +63,9 @@ Reviewer checklist for Phase 3 PRs:
   derivable from the function's documented contract.
 - [ ] `lake build HexFoo` green.
 - [ ] Conformance workflow green on the PR.
+- [ ] CI conformance matrix builds this library (either via the
+  derivation script picking up the root-import, or via an explicit
+  matrix entry).
 
 ## Oracle wiring (forward reference)
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -311,6 +311,12 @@ Separately, the default `lake build` MUST elaborate every
 `HexFoo/Conformance.lean` as part of the ordinary library build, so
 even the minimal CI job (no oracle) catches broken `#guard`s.
 
+When the workflow's matrix is derived (e.g. via
+`scripts/conformance_targets.py`), ensuring the new library appears
+amounts to importing `Hex<X>.Conformance` from `Hex<X>.lean`. When
+the matrix is hand-listed, the same PR that lands `Conformance.lean`
+MUST update the matrix.
+
 ## Infrastructure contract
 
 Lean produces and consumes a simple serialised case/result format —

--- a/progress/20260504T044941Z_483adcf2.md
+++ b/progress/20260504T044941Z_483adcf2.md
@@ -1,0 +1,35 @@
+# 2026-05-04 04:49Z — feature session, issue #1980
+
+## Accomplished
+
+- Closed #1980 (PLAN+SPEC: require new Conformance modules to land
+  in CI matrix at the same time).
+- `SPEC/testing.md` § "CI integration": appended a paragraph after
+  the `lake build` mandate explaining that with the derivation
+  script (`scripts/conformance_targets.py`, from #1978) the matrix
+  is implicit in the root-import; with a hand-listed matrix the
+  conformance PR must update it.
+- `PLAN/Phase3.md` reviewer checklist: added a bullet "CI
+  conformance matrix builds this library" so reviewers verify the
+  library is picked up either way.
+- `lake build` green; pure-text edits, no Lean change.
+
+## Current frontier
+
+PLAN+SPEC documentation cluster around oracle and conformance
+matrix bootstrap. With #1978 already merged and #1980 now done,
+the remaining unblocked human-oversight items are conformance
+fixture-size bumps (#2012-#2020) and cross-check fixtures
+(#2006-#2011). #1986 (oracle infrastructure bootstrap) is claimed
+but unmerged — its dependents stay blocked until it lands.
+
+## Next step
+
+Future Phase-3 reviewers can cite the new checklist bullet
+directly. C1-cluster workers (per-library fixture-size bumps)
+should read this SPEC paragraph alongside the existing run-and-
+paste guard rule from #1981.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #1980

Session: `483adcf2-db7b-462c-801e-93061306d82b`

efb1b76 doc: require conformance matrix coverage when landing Conformance modules

🤖 Prepared with Claude Code