### PR TITLE
HexGF2: extern clmul vs pure-Lean fallback cross-check on 10^4 word stream

### DIFF
--- a/HexGF2.lean
+++ b/HexGF2.lean
@@ -1,6 +1,7 @@
 import HexGF2.Basic
 import HexGF2.Clmul
 import HexGF2.Conformance
+import HexGF2.CrossCheck
 import HexGF2.Euclid
 import HexGF2.Field
 import HexGF2.Multiply

--- a/HexGF2/CrossCheck.lean
+++ b/HexGF2/CrossCheck.lean
@@ -1,0 +1,94 @@
+import HexGF2.Clmul
+
+/-!
+Extern-vs-pure-Lean cross-check for `Hex.clmul`.
+
+`Hex.clmul` carries an `@[extern "lean_hex_clmul_u64"]` attribute, so
+compiled code may call into a C wrapper that dispatches to a CPU
+intrinsic (`_mm_clmulepi64_si128` on x86, `vmull_p64` on aarch64) or a
+portable shift-and-XOR fallback. The Lean reference implementation is
+`Hex.pureClmul`. The hex-gf2 SPEC explicitly flags this extern boundary
+as a divergence risk and requires that the compiled wrapper agree with
+`pureClmul` on a stream of inputs.
+
+The stream below is a deterministic 64-bit LCG (Knuth's MMIX
+constants, multiplier `6364136223846793005`, increment
+`1442695040888963407`) seeded from a fixed start state. Successive
+draws supply `(a, b)` pairs; the cross-check passes iff every pair
+satisfies `clmul a b = pureClmul a b`.
+
+Mode: `always` (Lean-only, no oracle).
+Profile: `core`.
+-/
+
+namespace Hex
+namespace ClmulCrossCheck
+
+/-- One step of a 64-bit linear congruential generator using the MMIX
+constants. The `UInt64` arithmetic wraps modulo `2^64`, which is
+exactly the LCG modulus. -/
+private def stepLCG (s : UInt64) : UInt64 :=
+  s * 6364136223846793005 + 1442695040888963407
+
+/-- True iff the extern-backed `clmul` agrees with `pureClmul` on the
+first `n` pairs `(a, b)` produced by `stepLCG` starting from `s`.
+Each pair consumes two consecutive draws so that `a` and `b` are
+independent within the stream. -/
+private def streamAgreesAux (s : UInt64) : Nat → Bool
+  | 0 => true
+  | n + 1 =>
+    let a := s
+    let s₁ := stepLCG s
+    let b := s₁
+    let s₂ := stepLCG s₁
+    if clmul a b == pureClmul a b then
+      streamAgreesAux s₂ n
+    else
+      false
+
+@[inline] private def streamAgrees (seed : UInt64) (n : Nat) : Bool :=
+  streamAgreesAux seed n
+
+/-- Production stream length required by the SPEC cross-check. -/
+private def streamLength : Nat := 10000
+
+/-- Fixed seed for the production cross-check. Chosen to be nonzero in
+both halves so the very first draws exercise carries past bit 32. -/
+private def streamSeed : UInt64 := 0xCAFEBABEDEADBEEF
+
+-- Sanity: the LCG is not stuck on the seed.
+#guard stepLCG streamSeed != streamSeed
+
+-- Sanity: agreement on the empty prefix is vacuous.
+#guard streamAgrees streamSeed 0 = true
+
+-- Sanity: agreement on a single pair matches the direct check.
+#guard streamAgrees streamSeed 1 =
+  (clmul streamSeed (stepLCG streamSeed) == pureClmul streamSeed (stepLCG streamSeed))
+
+-- The SPEC cross-check: `clmul` agrees with `pureClmul` on
+-- `streamLength` pseudorandom 64-bit pairs.
+#guard streamAgrees streamSeed streamLength
+
+/-- Discriminator self-test: replace `clmul` with a deliberately flipped
+reference whose low word is XORed with `1`, and confirm that the same
+stream rejects it. Without this guard, `streamAgrees` returning `true`
+on the production stream would not by itself prove the loop ever
+performs a meaningful comparison. -/
+private def streamAgreesFlippedAux (s : UInt64) : Nat → Bool
+  | 0 => true
+  | n + 1 =>
+    let a := s
+    let s₁ := stepLCG s
+    let b := s₁
+    let s₂ := stepLCG s₁
+    let (hi, lo) := pureClmul a b
+    if clmul a b == (hi, lo ^^^ 1) then
+      streamAgreesFlippedAux s₂ n
+    else
+      false
+
+#guard streamAgreesFlippedAux streamSeed streamLength = false
+
+end ClmulCrossCheck
+end Hex

--- a/HexGfqMathlib/Basic.lean
+++ b/HexGfqMathlib/Basic.lean
@@ -63,7 +63,7 @@ end FpPoly
 
 namespace FiniteField
 
-variable {p : Nat} [Hex.ZMod64.Bounds p]
+variable {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 variable {f : Hex.FpPoly p}
 variable {hf : 0 < Hex.FpPoly.degree f}
 variable {hp : Hex.Nat.Prime p}
@@ -141,6 +141,7 @@ noncomputable instance fintype :
     Fintype (Hex.GFqField.FiniteField f hf hp hirr) :=
   Fintype.ofEquiv (Fin (p ^ Hex.FpPoly.degree f)) finEquiv.symm
 
+omit [Hex.ZMod64.PrimeModulus p] in
 /-- The generic executable finite-field wrapper has the expected cardinality. -/
 theorem fintype_card :
     Fintype.card (Hex.GFqField.FiniteField f hf hp hirr) =
@@ -152,7 +153,7 @@ end FiniteField
 
 namespace GFq
 
-variable {p n : Nat} [Hex.ZMod64.Bounds p]
+variable {p n : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 
 /-- Canonical Conway-backed `GFq` values inherit the generic finite-field
 enumeration. -/
@@ -160,6 +161,7 @@ noncomputable instance fintype (h : Hex.Conway.SupportedEntry p n) :
     Fintype (Hex.GFq p n h) :=
   FiniteField.fintype
 
+omit [Hex.ZMod64.PrimeModulus p] in
 /-- Cardinality of the canonical Conway-backed `GFq` in terms of its selected
 modulus degree. -/
 theorem fintype_card (h : Hex.Conway.SupportedEntry p n) :

--- a/HexGfqMathlib/Conformance.lean
+++ b/HexGfqMathlib/Conformance.lean
@@ -36,6 +36,20 @@ noncomputable section
 
 private instance conformanceBoundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
+private theorem conformancePrimeTwo : Hex.Nat.Prime 2 := by
+  constructor
+  · decide
+  · intro m hm
+    have hmle : m ≤ 2 := Nat.le_of_dvd (by decide : 0 < 2) hm
+    have hcases : m = 0 ∨ m = 1 ∨ m = 2 := by omega
+    rcases hcases with rfl | rfl | rfl
+    · simp at hm
+    · exact Or.inl rfl
+    · exact Or.inr rfl
+
+private instance conformancePrimeModulusTwo : Hex.ZMod64.PrimeModulus 2 :=
+  Hex.ZMod64.primeModulusOfPrime conformancePrimeTwo
+
 private abbrev Entry21 : Conway.SupportedEntry 2 1 :=
   Conway.supportedEntry_2_1
 

--- a/progress/20260504T051341Z_10ccf10f.md
+++ b/progress/20260504T051341Z_10ccf10f.md
@@ -1,0 +1,55 @@
+# 2026-05-04 — HexGF2 extern-vs-pure-Lean cross-check (#2008)
+
+## Accomplished
+
+- Added `HexGF2/CrossCheck.lean`, a new conformance-style module that
+  drives `Hex.clmul` (extern-backed) and `Hex.pureClmul` against each
+  other on a deterministic 10⁴-pair stream. The stream is a 64-bit
+  MMIX LCG seeded from `0xCAFEBABEDEADBEEF`; consecutive draws supply
+  `a` and `b` so the two arguments are independent within the stream.
+- Wired the new module into `HexGF2.lean` so `lake build HexGF2` (and
+  the auto-derived conformance matrix in
+  `scripts/conformance_targets.py`) elaborate it on every CI run.
+- Added a permanent discriminator self-test in the same file: a
+  `streamAgreesFlippedAux` variant that compares `clmul a b` against a
+  reference whose low word is XORed with `1`. The accompanying
+  `#guard streamAgreesFlippedAux streamSeed streamLength = false`
+  documents that the loop actually performs a meaningful comparison
+  (it short-circuits on the first pair because the LSBs always
+  disagree), so the production guard cannot be vacuously satisfied
+  by a no-op loop.
+- Verified locally that a deliberate flip in `pureClmul` does trip
+  the build: editing `clmulAccumulateBit` to XOR `1` into the high
+  partial product caused six existing `Clmul.lean` proofs to fail
+  immediately. Restored `Clmul.lean` from a backup before committing.
+
+## Decisions
+
+- Chose a hand-rolled tail recursion over `(List.range n).foldl` to
+  avoid allocating a 10000-node list before the first step. This
+  brought elaboration of `HexGF2.CrossCheck` from ~10s to ~7.5s on
+  the first build (production guard only). With the discriminator
+  guard added, elaboration sits at ~9.7s — over the 5s soft target
+  in #2008 but well inside CI tolerances. The discriminator iteration
+  itself is O(1) because it returns `false` on the first pair.
+- Used plain `--` line comments next to each `#guard`. Doc strings
+  (`/-- … -/`) attach to the next declaration, but `#guard` is a
+  command, not a declaration, so a leading doc string aborts parsing.
+- Followed the SPEC ban on run-and-paste `#guard` literals: every
+  `#guard` here asserts an algebraic property (LCG progresses,
+  empty-prefix vacuity, single-pair direct comparison, full-stream
+  agreement, flipped-reference rejection) rather than baking in a
+  computed numeric output.
+
+## Current frontier
+
+`HexGF2.CrossCheck` is reachable from `HexGF2.lean`, so the
+auto-derived conformance matrix picks it up without further wiring.
+
+## Next step
+
+PR closing #2008.
+
+## Blockers
+
+None.

--- a/progress/20260504T074713Z_10ccf10f.md
+++ b/progress/20260504T074713Z_10ccf10f.md
@@ -1,0 +1,49 @@
+# 2026-05-04T07:47:13Z — repair session (10ccf10f)
+
+## Accomplished
+
+Salvaged PR #2031 (HexGF2 extern-vs-pure-Lean clmul cross-check) by
+fixing the pre-existing `HexGfqMathlib` build failure that was
+blocking its conformance matrix.
+
+* `HexGfqMathlib/Basic.lean`: added `[Hex.ZMod64.PrimeModulus p]` to
+  the `FiniteField` and `GFq` namespace section variables. Without it
+  the propagated `Lean.Grind.Field`, `Lean.Grind.Semiring`, and
+  related instances on `GFqField.FiniteField` could not synthesize,
+  failing every dependent `Field`/`Fintype.card`/`RingEquiv` use.
+  Added `omit [Hex.ZMod64.PrimeModulus p] in` to the two cardinality
+  theorems that don't actually need the new instance, suppressing the
+  unused-section-variable linter warning.
+* `HexGfqMathlib/Conformance.lean`: added `private` `conformancePrimeTwo`
+  and `conformancePrimeModulusTwo` instances so the `p = 2` examples
+  can elaborate the `Field`/`RingEquiv` surfaces that now require
+  `[ZMod64.PrimeModulus p]`. The proof of `Hex.Nat.Prime 2` mirrors the
+  existing pattern in `HexGF2Mathlib/Field.lean`.
+
+The breakage was not introduced by the PR. It surfaced on `main` after
+`df1e8ee` ("ci: derive conformance matrix from Conformance.lean files"),
+which started building `HexGfqMathlib` in the conformance matrix for
+the first time. The `FiniteField.field` instance had always required
+`[ZMod64.PrimeModulus p]` (it relies on `GFqField.zero_ne_one` which
+itself depends on the `ZMod64.PrimeModulus`-flavored quotient laws),
+but the variable was never declared in this bridge file.
+
+Verification locally:
+
+* `lake build HexGfqMathlib` green (only pre-existing `sorry` warnings
+  in unrelated declarations).
+* `lake build HexGF2` green (the PR's own scope unaffected).
+
+## Current frontier
+
+PR ready to push. Force-with-lease, then `coordination mark-pr-salvaged 2031`.
+
+## Next step
+
+PR #2032 (HexHensel lift cross-check) and any other in-flight PRs
+were failing on the same `HexGfqMathlib` synth error; once this PR's
+fix lands on `main`, those PRs should rebuild green without changes.
+
+## Blockers
+
+None for this PR.


### PR DESCRIPTION
Closes #2008

Session: `10ccf10f-3366-4c41-b741-dde914775bef`

bb2a828 feat: add HexGF2 extern-vs-pure-Lean clmul cross-check

🤖 Prepared with Claude Code