### PR TITLE
SPEC: revise oracle-strategy to drop Sage in favor of python-flint+cypari2+fpylll

### DIFF
--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -2,8 +2,8 @@
 
 Conformance testing cross-checks Lean implementations against either
 (a) independently stated algebraic properties, or (b) an external
-oracle (Sage, FLINT, python-flint, fpLLL, GAP, PARI). The goal is to
-catch implementation bugs *before* proof work starts. No point proving
+oracle (python-flint, fpylll, cypari2). The goal is to catch
+implementation bugs *before* proof work starts. No point proving
 theorems about wrong implementations.
 
 When conformance fails, the response is the same as when benchmarking
@@ -237,23 +237,26 @@ subsection. Default oracle assignments:
   property checks (Bézout, `Nat.gcd` agreement) sufficient for `core`.
 - `hex-mod-arith` — Lean big-integer modular arithmetic as property
   oracle.
-- `hex-poly`, `hex-poly-z`, `hex-poly-fp` — `python-flint` for
-  univariate polynomial arithmetic; Sage as fallback.
-- `hex-matrix`, `hex-gram-schmidt` — Sage exact matrix / rational
-  linear algebra; numpy/scipy accepted for cross-checks that only
-  need float-level agreement on well-conditioned inputs.
-- `hex-gf2`, `hex-gfq-ring`, `hex-gfq-field`, `hex-gfq` — Sage finite
-  field and quotient-ring computations; GAP acceptable for the
-  character-table adjacent checks.
-- `hex-berlekamp`, `hex-berlekamp-zassenhaus` — FLINT or Sage
-  factorisation / irreducibility checks.
-- `hex-hensel` — Sage or FLINT Hensel-lifting support, plus direct
-  Lean-side congruence/product checks.
-- `hex-lll` — fpLLL or Sage `LLL`, comparing reducedness, lattice
-  equality, and determinant preservation rather than exact basis
-  equality.
-- `hex-conway` — committed database fixtures cross-checked against
-  Sage's Conway tables. No random generation.
+- `hex-poly`, `hex-poly-z`, `hex-poly-fp` — `python-flint` primary
+  (`fmpz_poly`, `fmpq_poly`, `nmod_poly`) for univariate polynomial
+  arithmetic.
+- `hex-matrix`, `hex-gram-schmidt` — `python-flint` exact (`fmpz_mat`
+  / `fmpq_mat`); numpy/scipy float for well-conditioned float-level
+  cross-checks; fpylll's `GSO.Mat` for Gram-Schmidt size reduction
+  parity.
+- `hex-gf2`, `hex-gfq-ring`, `hex-gfq-field`, `hex-gfq` —
+  `python-flint` (`nmod_poly`, `fq_nmod`, `fq_default`); cypari2 as a
+  secondary independent finite-field oracle when independence from
+  FLINT matters.
+- `hex-berlekamp`, `hex-berlekamp-zassenhaus` — `python-flint`
+  factorisation primary; cypari2 secondary.
+- `hex-hensel` — cypari2 (PARI `factorpadic`) primary for the
+  mod-`p^k` lift surface — python-flint does not expose mod-`p^k`
+  polynomial factorisation.
+- `hex-lll` — fpylll (wraps fpLLL directly).
+- `hex-conway` — cypari2 (PARI `ffinit`) plus a committed Frank
+  Lübeck flat-file cache for triple-source independence (Lean ≡
+  PARI ≡ Lübeck). No random generation.
 
 The `-mathlib` bridge libraries are not the primary target of
 external conformance testing. They rely mainly on internal
@@ -392,18 +395,13 @@ The initial `core` profile does not require JSONL; a library's
 
 ## Sage strategy
 
-Sage is important enough to deserve an explicit deployment story.
-Ubuntu's `apt` packages are not a stable basis for Sage-backed CI;
-the preferred path is Nix-based Sage:
-
-- local use via `nix shell nixpkgs#sage --command ...`
-- CI use via `cachix/install-nix-action` followed by Sage commands
-  through `nix shell`
-
-This keeps local and CI execution close and avoids depending on
-Ubuntu package availability. A conda-forge Sage install is an
-acceptable secondary path for local experimentation, but not the
-primary CI mechanism.
+Sage is not used as an oracle in this project. Every operation we
+want to cross-check has a lighter pip-installable wrapper that
+reaches the same FLINT / fpLLL / PARI internals as Sage would:
+`python-flint`, `fpylll`, `cypari2`. Together they cover the entire
+oracle surface without a Sage runtime in CI. Local developers who
+already have Sage are free to use it ad-hoc, but no CI job depends
+on it.
 
 ---
 

--- a/progress/20260504T053000Z_6fbeaedc.md
+++ b/progress/20260504T053000Z_6fbeaedc.md
@@ -1,0 +1,40 @@
+# 2026-05-04 05:30Z — feature session, issue #2005
+
+## Accomplished
+
+- Closed #2005 by editing `SPEC/testing.md` to align the SPEC text
+  with the python-flint+cypari2+fpylll oracle strategy already used
+  by the per-library oracle issues E1-E5.
+- Three sections updated:
+  - Introduction (line 5) — oracle list now reads
+    `(python-flint, fpylll, cypari2)`.
+  - "Oracle strategy" assignments — python-flint primary for poly /
+    matrix / GF(q) / Berlekamp; cypari2 primary for Hensel and
+    Conway (with a Lübeck flat-file cache for triple-source
+    independence); fpylll for LLL.
+  - "Sage strategy" section — replaced the Nix-Sage deployment
+    description with a one-paragraph note that Sage is not used as
+    an oracle in this project.
+- No remaining `Sage` references in `SPEC/testing.md` outside the
+  ad-hoc-local-use footnote. Other Sage mentions (in `SPEC/SPEC.md`
+  about replacing SageMath as a downstream dependency, and in
+  `SPEC/benchmarking.md` about per-call benchmarking targets) are
+  out of scope for this issue.
+
+## Current frontier
+
+SPEC text now matches the actual oracle strategy. Downstream oracle
+implementation issues (#1987 / #1988 / #1989 / #1994 / #1995 / #1996 /
+#1997 / #1998 / #1999 / #2000 / #2002 / #2003 / #2004 / #2023) can
+proceed knowing the SPEC and the implementation point at the same
+toolchain.
+
+## Next step
+
+Pick up one of the still-open python-flint oracle issues, or the
+local-bootstrap script (#2022), or a conformance-fixture-size bump
+(#2012-#2019).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2005

Session: `6fbeaedc-a8f1-41dc-a0b6-5b108d05c8e1`

5413cb7 chore: progress entry for #2005
5afc474 doc: drop Sage from oracle strategy in favor of python-flint+cypari2+fpylll

🤖 Prepared with Claude Code