### PR TITLE
HexMatrix: bump conformance fixture sizes toward SPEC profile-size ceilings

### DIFF
--- a/HexMatrix/Conformance.lean
+++ b/HexMatrix/Conformance.lean
@@ -226,6 +226,50 @@ private def emptyNullspace : Vector (Vector Rat 2) 0 :=
 #guard dependentRat * dependentNullspace.get ⟨0, by decide⟩ = 0
 #guard dependentRat * dependentNullspace.get ⟨1, by decide⟩ = 0
 
+/-!
+6×6 fixtures matching the SPEC `core` matrix-dimension band, with the
+same typical / edge / adversarial structure as the 2×2 cases above:
+
+- `bigInt` — typical full-rank Int (entries `min i j + 1`); factorises
+  as `L·U` with unit lower- and upper-triangular all-ones, so
+  `det = 1`. Dense enough that Bareiss exercises the inner update loop
+  at every step.
+- `bigZeroInt` — edge zero matrix.
+- `bigSingularInt` — adversarial singular Int with row 1 proportional
+  to row 0 (mirrors the `singularInt` 2×2 pattern at 6×6).
+- `bigPivotInt` — adversarial zero leading pivot (`M[0][0] = 0`),
+  forcing one Bareiss row swap (`bigInt` with the `(0,0)` entry
+  cleared).
+-/
+
+private def bigInt : Matrix Int 6 6 :=
+  Matrix.ofFn fun i j => (min i.val j.val + 1 : Int)
+
+private def bigZeroInt : Matrix Int 6 6 := 0
+
+private def bigSingularInt : Matrix Int 6 6 :=
+  Matrix.ofFn fun i j =>
+    if i.val = 1 then (2 : Int)
+    else (min i.val j.val + 1 : Int)
+
+private def bigPivotInt : Matrix Int 6 6 :=
+  Matrix.ofFn fun i j =>
+    if i.val = 0 ∧ j.val = 0 then (0 : Int)
+    else (min i.val j.val + 1 : Int)
+
+#guard Matrix.transpose (Matrix.transpose bigInt) = bigInt
+#guard (1 : Matrix Int 6 6) * bigInt = bigInt
+
+#guard Matrix.bareiss bigInt = 1
+#guard Matrix.bareiss bigZeroInt = 0
+#guard Matrix.bareiss bigSingularInt = 0
+#guard Matrix.bareiss bigPivotInt = -1
+#guard (Matrix.bareissData bigPivotInt).rowSwaps = 1
+
+#guard Matrix.bareiss (Matrix.rowSwap bigInt ⟨0, by decide⟩ ⟨5, by decide⟩) = -1
+#guard Matrix.bareiss (Matrix.rowScale bigInt ⟨2, by decide⟩ 4) = 4
+#guard Matrix.bareiss (Matrix.rowAdd bigInt ⟨0, by decide⟩ ⟨3, by decide⟩ 7) = 1
+
 end Matrix
 
 end Hex

--- a/progress/20260504T062006Z_196646b0.md
+++ b/progress/20260504T062006Z_196646b0.md
@@ -1,0 +1,49 @@
+# 2026-05-04 06:20Z — feature session, issue #2012
+
+## Accomplished
+
+- Closed #2012 by adding 6×6 fixtures and `#guard`s to
+  `HexMatrix/Conformance.lean`, hitting the SPEC `core`
+  matrix-dimension band:
+  - `bigInt` (typical full-rank): `M[i][j] = min i j + 1`. Factors as
+    `L · U` with `L` lower-triangular all-ones and `U` upper-triangular
+    all-ones (each unit triangular), giving `det bigInt = 1`. Dense
+    enough that Bareiss exercises the inner update loop at every step.
+  - `bigZeroInt` (edge): zero matrix.
+  - `bigSingularInt` (adversarial): row 1 set to `[2,2,2,2,2,2] = 2 ·
+    row 0`, mirroring the proportional-row pattern of the 2×2
+    `singularInt`.
+  - `bigPivotInt` (adversarial): `bigInt` with `M[0][0]` cleared to
+    `0`, forcing exactly one Bareiss row swap.
+- Verified `bareiss bigPivotInt = -1` by multilinearity along row 0:
+  `det(bigPivotInt) = det(bigInt) - det(bigInt with row 0 = e_0) =
+   1 - det(M_{0,0}) = 1 - 2 = -1`, where `M_{0,0}` is the 5×5
+  leading minor `min(i+1,j+1)+1` whose det is 2 (subtract row 0,
+  factor 2, recurse).
+- New `#guard`s:
+  - structural: `transpose ∘ transpose = id`, `1 * bigInt = bigInt`
+  - determinants: `bareiss = 1, 0, 0, -1` for typical / zero /
+    singular / pivot
+  - pivot detection: `(bareissData bigPivotInt).rowSwaps = 1`
+  - row-operation laws at 6×6: `rowSwap → -1`, `rowScale 4 → 4`,
+    `rowAdd 7 → 1`
+- Verified deliberate corruption (`bareiss bigPivotInt = -2`) trips
+  the build, then reverted.
+- Elaboration time: 1.2–1.4s across three fresh rebuilds (well under
+  the 2s soft budget; baseline was 1.6s).
+
+## Current frontier
+
+`HexMatrix/Conformance.lean` now exercises the SPEC `core` matrix
+band at the upper end (6×6, with SPEC ceiling 8). Sibling
+fixture-size bumps remain for HexGramSchmidt (#2013), HexLLL
+(#2014), HexPolyFp (#2016).
+
+## Next step
+
+Successor session on one of the remaining fixture-size bumps, or on
+the python-flint oracle items (#2000, #2002–#2004, #2022).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2012

Session: `196646b0-e9c8-4862-8731-4c792722d30b`

afdc4c0 feat: bump HexMatrix conformance to 6×6 fixtures

🤖 Prepared with Claude Code