### PR TITLE
HexPolyFp: bump conformance fixture sizes toward SPEC profile-size ceilings

### DIFF
--- a/HexPolyFp/Conformance.lean
+++ b/HexPolyFp/Conformance.lean
@@ -27,7 +27,14 @@ Covered edge cases:
 - the indeterminate `X` and constant polynomial inputs
 - reductions modulo `x^2 + 2` over `F_5`
 - linear modulus `x + 3` over `F_5`
-- sparse inputs with internal zero coefficients
+- reductions modulo a degree-6 modulus (matches the SPEC `core`
+  finite-field-extension upper end)
+- degree-10 polynomial inputs to `powModMonic`, `composeModMonic`,
+  `squareFreeDecomposition`, and `weightedProduct` (matches the SPEC
+  `core` polynomial-degree upper end)
+- sparse inputs with internal zero coefficients at degree 10
+- square-free decomposition with mixed multiplicities `(2, 3)` from a
+  product of four distinct linear factors
 - square-free, repeated-factor, derivative-zero, zero, and scalar square-free inputs
 -/
 
@@ -173,6 +180,120 @@ private theorem quadModulus_monic : DensePoly.Monic quadModulus := by
   let f := polyFive #[3]
   sfSummary (squareFreeDecomposition prime_five f) = (3, []) ∧
     coeffNats (sfReconstruction (squareFreeDecomposition prime_five f)) = coeffNats f
+
+/-!
+Degree-10 / extension-degree-6 fixtures matching the SPEC `core`
+profile-size upper end (polynomial degrees `8-12`, finite-field
+extensions up to degree `6`). These scale the typical / edge /
+adversarial cases above without dropping any of the smaller cases.
+
+- `bigModulus` — degree-6 monic `x^6 + 2x + 3`, the upper end of the
+  finite-field extension band.
+- `bigInput` — typical degree-10 polynomial `x^10 + 2x^5 + 3` (dense
+  enough to exercise reduction beyond the modulus degree).
+- `bigSparse` — adversarial degree-10 polynomial with internal zeros
+  `2x^10 + 3x^4 + x` (shape mirrors the smaller sparse fixtures).
+- `sfBigFactors` — four distinct linear factors with mixed
+  multiplicities `(x+1)^2 (x+2)^3 (x+3)^2 (x+4)^3`. The product has
+  degree 10; same-multiplicity factors aggregate as
+  `((x+1)(x+3))^2 ((x+2)(x+4))^3 = (x^2+4x+3)^2 (x^2+x+3)^3`.
+-/
+
+private def bigModulus : FpPoly 5 :=
+  -- x^6 + 2x + 3
+  { coeffs := #[(3 : ZMod64 5), 2, 0, 0, 0, 0, 1]
+    normalized := by
+      right
+      simpa using one_ne_zero_five }
+
+private theorem bigModulus_monic : DensePoly.Monic bigModulus := by
+  rfl
+
+private def bigInput : FpPoly 5 :=
+  -- x^10 + 2x^5 + 3
+  polyFive #[3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1]
+
+private def bigSparse : FpPoly 5 :=
+  -- 2x^10 + 3x^4 + x
+  polyFive #[0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 2]
+
+private def sfBigFactors : List (SquareFreeFactor 5) :=
+  [sfFactorFive #[1, 1] 2,  -- (x + 1)^2
+   sfFactorFive #[2, 1] 3,  -- (x + 2)^3
+   sfFactorFive #[3, 1] 2,  -- (x + 3)^2
+   sfFactorFive #[4, 1] 3]  -- (x + 4)^3
+
+private def sfBigInput : FpPoly 5 := weightedProduct sfBigFactors
+
+/-- info: [3, 2, 0, 0, 0, 0, 1] -/
+#guard_msgs in
+#eval! coeffNats bigModulus
+
+/-- info: [3, 0, 0, 0, 0, 2, 0, 0, 0, 0, 1] -/
+#guard_msgs in
+#eval! coeffNats bigInput
+
+/-- info: [0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 2] -/
+#guard_msgs in
+#eval! coeffNats bigSparse
+
+#guard coeffNats (powModMonic bigInput bigModulus bigModulus_monic 0) = [1]
+#guard coeffNats (powModMonic 0 bigModulus bigModulus_monic 7) = []
+
+-- `bigInput` reduces from degree 10 down into the degree-6 quotient ring.
+/-- info: [3, 0, 0, 0, 2] -/
+#guard_msgs in
+#eval! coeffNats (powModMonic bigInput bigModulus bigModulus_monic 1)
+
+/-- info: [3, 0, 1, 2, 3, 4] -/
+#guard_msgs in
+#eval! coeffNats (powModMonic bigInput bigModulus bigModulus_monic 5)
+
+/-- info: [2, 0, 4, 4, 1, 1] -/
+#guard_msgs in
+#eval! coeffNats (powModMonic bigSparse bigModulus bigModulus_monic 3)
+
+-- `frobeniusXMod` returns `x^5` (degree 5 < 6) so no modular reduction occurs.
+/-- info: [0, 0, 0, 0, 0, 1] -/
+#guard_msgs in
+#eval! coeffNats (frobeniusXMod bigModulus bigModulus_monic)
+
+-- `frobeniusXPowMod _ _ 2` returns `x^25 mod (x^6 + 2x + 3)`, exercising the
+-- degree-25 → degree-≤5 reduction loop.
+/-- info: [0, 1, 1, 1, 1, 1] -/
+#guard_msgs in
+#eval! coeffNats (frobeniusXPowMod bigModulus bigModulus_monic 2)
+
+#guard coeffNats (frobeniusXPowMod bigModulus bigModulus_monic 0) = [0, 1]
+
+-- `composeModMonic bigInput X` is `bigInput mod bigModulus` since `f ∘ X = f`.
+/-- info: [3, 0, 0, 0, 2] -/
+#guard_msgs in
+#eval! coeffNats (composeModMonic bigInput X bigModulus bigModulus_monic)
+
+-- `composeModMonic bigInput (x + 1)` is `bigInput(x + 1) mod bigModulus`,
+-- exercising both the substitution and the modular reduction.
+/-- info: [1, 0, 0, 0, 2, 2] -/
+#guard_msgs in
+#eval! coeffNats (composeModMonic bigInput (polyFive #[1, 1]) bigModulus bigModulus_monic)
+
+#guard composeModMonic 0 bigInput bigModulus bigModulus_monic = 0
+
+-- `sfBigInput = (x+1)^2 (x+2)^3 (x+3)^2 (x+4)^3` is degree 10 over F_5.
+/-- info: [3, 1, 1, 0, 4, 3, 3, 0, 3, 1, 1] -/
+#guard_msgs in
+#eval! coeffNats sfBigInput
+
+-- Same-multiplicity factors aggregate: mult-2 part is
+-- `3·((x+1)(x+3)) = 3·(x^2 + 4x + 3)` and mult-3 part is
+-- `4·((x+2)(x+4)) = 4·(x^2 + x + 3)`. Unit `3^2·4^3 = 576 ≡ 1 (mod 5)`.
+/-- info: (1, [([4, 2, 3], 2), ([2, 4, 4], 3)]) -/
+#guard_msgs in
+#eval! sfSummary (squareFreeDecomposition prime_five sfBigInput)
+
+#guard
+  coeffNats (sfReconstruction (squareFreeDecomposition prime_five sfBigInput)) =
+    coeffNats sfBigInput
 
 end FpPoly
 end Hex

--- a/progress/20260504T074514Z_9dfd14f9.md
+++ b/progress/20260504T074514Z_9dfd14f9.md
@@ -1,0 +1,65 @@
+# 2026-05-04 07:45Z — feature session, issue #2016
+
+## Accomplished
+
+- Closed #2016 by adding degree-10 / extension-degree-6 fixtures to
+  `HexPolyFp/Conformance.lean`, hitting the SPEC `core`
+  polynomial-degree band (8-12) and finite-field-extension band
+  (up to 6) at the upper end. All five operations covered.
+- New fixtures (typical / edge / adversarial / structured):
+  - `bigModulus` — degree-6 monic `x^6 + 2x + 3` (extension-degree
+    upper end).
+  - `bigInput` — typical degree-10 dense `x^10 + 2x^5 + 3`.
+  - `bigSparse` — adversarial degree-10 sparse `2x^10 + 3x^4 + x`,
+    mirroring the smaller `[0, 0, 1]` pattern at scale.
+  - `sfBigFactors` / `sfBigInput` — `(x+1)^2 (x+2)^3 (x+3)^2 (x+4)^3`
+    over F_5, a degree-10 polynomial whose square-free decomposition
+    has mixed multiplicities `(2, 3)` from four distinct linear
+    factors.
+- New `#eval!` / `#guard_msgs in` checks at the upper-end inputs:
+  - `powModMonic bigInput bigModulus _ k` for `k ∈ {0, 1, 5}`,
+    plus `powModMonic bigSparse … 3` (adversarial input).
+  - `powModMonic 0 bigModulus _ 7` — zero base / nonzero exponent.
+  - `frobeniusXMod bigModulus` — returns `x^5` (degree 5 < 6, no
+    reduction), and `frobeniusXPowMod bigModulus _ k` for `k ∈ {0, 2}`,
+    where `k = 2` exercises the full `x^25 mod (x^6 + 2x + 3)`
+    reduction loop and lands at `[0, 1, 1, 1, 1, 1]`.
+  - `composeModMonic bigInput X` (identity composition reduces to
+    `bigInput mod bigModulus`), `composeModMonic bigInput (x + 1)`
+    (substitution + reduction), and the zero-source edge case.
+  - `weightedProduct` reconstruction via `sfBigInput`.
+  - `squareFreeDecomposition prime_five sfBigInput` returning
+    `(1, [([4, 2, 3], 2), ([2, 4, 4], 3)])`. The factors are
+    non-monic representatives (`3·(x^2+4x+3)` and `4·(x^2+x+3)`)
+    with the unit `3^2·4^3 = 576 ≡ 1 (mod 5)` absorbing the scalar.
+  - Reconstruction equality `sfReconstruction ∘ squareFreeDecomposition
+    prime_five = id` on `sfBigInput`.
+- Updated the file header's "Covered edge cases" docstring to list
+  the new degree-6 modulus, degree-10 inputs, and mixed-multiplicity
+  square-free fixture.
+- All existing smaller fixtures (constant modulus 1, linear modulus,
+  quadratic modulus, sparse `[1, 0, 0, 0, 0, 1]`) preserved — scaled,
+  not replaced.
+- Verified deliberate corruption (changed expected mult `3` to `4` in
+  the SF summary) trips the build, then reverted.
+- Elaboration time after fresh `lake build HexPolyFp.Conformance`:
+  706–738ms. Baseline before bumps was 1.3s; the rebuild jobs are
+  faster now because `replayed` shortcuts dominate. Both well under
+  the 2s soft budget.
+
+## Current frontier
+
+`HexPolyFp/Conformance.lean` now exercises the SPEC `core` profile at
+the upper end of both the polynomial-degree (10) and field-extension
+(6) bands. Sibling fixture-size bumps remain for HexGramSchmidt
+(#2013) and HexLLL (#2014).
+
+## Next step
+
+Successor session on one of the remaining fixture-size bumps, or on
+the python-flint oracle items (#2003 HexGfqField, #2004 HexGfq, #2022
+local oracle bootstrap).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2016

Session: `9dfd14f9-977d-4c54-841b-ea3d8b22f419`

f832e97 feat: bump HexPolyFp conformance to degree-10 / extension-degree-6

🤖 Prepared with Claude Code