### PR TITLE
HexHenselMathlib: add multifactor linear-vs-quadratic lift uniqueness surface

### DIFF
--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -211,6 +211,38 @@ theorem hensel_unique (f g h g' h' : Polynomial ℤ) (p : ℕ) (k : ℕ)
     g.map φ = g'.map φ ∧ h.map φ = h'.map φ := by
   sorry
 
+/--
+The linear and quadratic multifactor lifters agree modulo `p ^ k` after
+canonical reduction, when both are applied to the same input under the
+recursive `MultifactorLiftInvariant` precondition consumed by both
+`Hex.ZPoly.multifactorLift_spec` and
+`Hex.ZPoly.multifactorLiftQuadratic_spec`.
+
+The result is stated over the public array/product multifactor surface
+rather than the private split-tree helpers, and is expressed in Mathlib
+form via `Polynomial.map (Int.castRingHom (ZMod (p ^ k)))`. Through
+`zpoly_congr_toPolynomial_map_eq` / `zpoly_congr_of_toPolynomial_map_eq`,
+this is equivalent to per-factor canonicalisation by
+`Hex.ZPoly.reduceModPow _ p k`.
+
+This is the lift-uniqueness obligation that `hex-hensel` defers to
+`hex-hensel-mathlib`; see `SPEC/Libraries/hex-hensel.md` and the
+companion-statement note at the top of `HexHensel/QuadraticMultifactor.lean`.
+-/
+theorem multifactorLift_eq_multifactorLiftQuadratic
+    (p k : Nat) [Fact (Nat.Prime p)] [Hex.ZMod64.Bounds p]
+    [Hex.ZMod64.PrimeModulus p]
+    (f : Hex.ZPoly) (factors : Array Hex.ZPoly)
+    (hk : 1 ≤ k)
+    (hp : 1 < p)
+    (hinv : Hex.ZPoly.MultifactorLiftInvariant p k f factors.toList) :
+    let φ := Int.castRingHom (ZMod (p ^ k))
+    (Hex.ZPoly.multifactorLift p k f factors).toList.map
+        (fun g => (HexPolyMathlib.toPolynomial g).map φ) =
+      (Hex.ZPoly.multifactorLiftQuadratic p k f factors).toList.map
+        (fun g => (HexPolyMathlib.toPolynomial g).map φ) := by
+  sorry
+
 end
 
 end HexHenselMathlib

--- a/progress/20260504T081054Z_abb3a97b.md
+++ b/progress/20260504T081054Z_abb3a97b.md
@@ -1,0 +1,56 @@
+# 2026-05-04T08:10:54Z — feature session (abb3a97b)
+
+## Accomplished
+
+Closed issue #1977 by adding the multifactor linear-vs-quadratic lift
+uniqueness theorem surface in `HexHenselMathlib/Correctness.lean`.
+
+* `HexHenselMathlib/Correctness.lean` — added
+  `multifactorLift_eq_multifactorLiftQuadratic`, stating that
+  `Hex.ZPoly.multifactorLift` and `Hex.ZPoly.multifactorLiftQuadratic`,
+  applied to the same input under the recursive
+  `Hex.ZPoly.MultifactorLiftInvariant` precondition consumed by both
+  `*_spec` theorems, produce arrays that agree element-wise modulo
+  `p ^ k` after the standard `Int.castRingHom (ZMod (p ^ k))` map
+  through `HexPolyMathlib.toPolynomial`. The statement uses the public
+  array surface (`.toList.map`) rather than the private split-tree
+  helpers, as required by the deliverable.
+
+The theorem body is `sorry`, consistent with the rest of the
+`HexHenselMathlib` proof-only theorem surface in this phase. No
+executable definitions were modified.
+
+## Verification
+
+* `lake build HexHenselMathlib` — green; only the new line-232 sorry
+  added on top of the existing eleven sorries in
+  `HexHenselMathlib/Correctness.lean` and the two in
+  `HexHenselMathlib/Basic.lean`.
+* `git diff --check` — clean.
+* `grep -nE "axiom|native_decide|TODO|FIXME" HexHenselMathlib/Correctness.lean`
+  — none.
+
+## Current frontier
+
+The Mathlib-facing surface for `hex-hensel-mathlib` now exposes:
+per-step linear/quadratic correctness, per-step quadratic uniqueness
+(`quadraticHenselStep_unique_mod_pow_two_mul`), the binary lift
+uniqueness `hensel_unique`, and now the array-level multifactor
+linear-vs-quadratic agreement. Remaining holes (all pre-existing):
+`hensel_correct`, `hensel_extends`, `hensel_degree`, the executable
+`zpoly_congr` ↔ Mathlib `.map` bridges, the per-step quadratic
+correctness/Bezout/monicity statements, the per-step quadratic
+uniqueness bridge, and `hensel_unique`.
+
+## Next step
+
+Discharge the `sorry` in `multifactorLift_eq_multifactorLiftQuadratic`
+by induction along the shared sequential split tree, applying
+`hensel_unique` (binary uniqueness) at each split and the per-step
+bridges between `ZPoly.congr` and `Polynomial.map (Int.castRingHom _)`.
+The `MultifactorLiftInvariant` already supplies the per-split Bezout
+preservation and degree invariants needed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #1977

Session: `abb3a97b-8ae8-4603-a678-0301a28cd885`

d3ab96e feat: add HexHenselMathlib multifactor linear-vs-quadratic lift uniqueness surface

🤖 Prepared with Claude Code