### PR TITLE
HexLLL: bump conformance fixture sizes toward SPEC profile-size ceilings

### DIFF
--- a/HexLLL/Conformance.lean
+++ b/HexLLL/Conformance.lean
@@ -38,7 +38,10 @@ Covered edge cases:
 - a zero basis and a dependent rectangular basis.
 - a size-reduction pivot with positive quotient and an already-small pivot that
   does not change the state.
-- adjacent swaps at the first and second nonzero row positions.
+- adjacent swaps at the first two nonzero row positions and at a higher-index
+  orthogonal-block position that exercises the multi-row update loop.
+- size-reduction at the highest valid row index that exercises the full
+  earlier-row loop.
 - a downstream basis with one integer coefficient row per lifted local factor.
 - out-of-range `sizeReduce` / `swapStep` calls that leave the state unchanged.
 -/
@@ -46,28 +49,41 @@ Covered edge cases:
 namespace Hex
 namespace LLLConformance
 
-private def identity2 : Matrix Int 2 2 := 1
+private def identity8 : Matrix Int 8 8 := 1
 
-private def zero2 : Matrix Int 2 2 := 0
+private def zero8 : Matrix Int 8 8 := 0
 
-private def dependent3x2 : Matrix Int 3 2 :=
+private def dependent8x4 : Matrix Int 8 4 :=
   Matrix.ofFn fun i j =>
     match i.val, j.val with
     | 0, 0 => 2
     | 1, 0 => 4
     | 2, 0 => -1
     | 2, 1 => 3
+    | 3, 2 => 1
+    | 4, 3 => 1
+    | 5, 0 => 1
+    | 5, 2 => 2
+    | 6, 1 => 1
+    | 6, 3 => -1
+    | 7, 2 => -1
     | _, _ => 0
 
-private def unreduced2 : Matrix Int 2 2 :=
+private def unreduced8 : Matrix Int 8 8 :=
   Matrix.ofFn fun i j =>
     match i.val, j.val with
     | 0, 0 => 1
     | 1, 0 => 3
     | 1, 1 => 1
+    | 2, 2 => 1
+    | 3, 3 => 1
+    | 4, 4 => 1
+    | 5, 5 => 1
+    | 6, 6 => 1
+    | 7, 7 => 1
     | _, _ => 0
 
-private def typical3 : Matrix Int 3 3 :=
+private def typical8 : Matrix Int 8 8 :=
   Matrix.ofFn fun i j =>
     match i.val, j.val with
     | 0, 0 => 1
@@ -76,6 +92,11 @@ private def typical3 : Matrix Int 3 3 :=
     | 1, 2 => 1
     | 2, 1 => 1
     | 2, 2 => 1
+    | 3, 3 => 1
+    | 4, 4 => 1
+    | 5, 5 => 1
+    | 6, 6 => 1
+    | 7, 7 => 1
     | _, _ => 0
 
 private def bzStyleBasis : Matrix Int 3 4 :=
@@ -89,52 +110,102 @@ private def bzStyleBasis : Matrix Int 3 4 :=
     | 2, 3 => 2
     | _, _ => 0
 
-private abbrev f0_2 : Fin 2 := ⟨0, by decide⟩
-private abbrev f1_2 : Fin 2 := ⟨1, by decide⟩
 private abbrev f0_3 : Fin 3 := ⟨0, by decide⟩
 private abbrev f1_3 : Fin 3 := ⟨1, by decide⟩
 private abbrev f2_3 : Fin 3 := ⟨2, by decide⟩
+private abbrev f0_4 : Fin 4 := ⟨0, by decide⟩
+private abbrev f1_4 : Fin 4 := ⟨1, by decide⟩
+private abbrev f2_4 : Fin 4 := ⟨2, by decide⟩
 private abbrev f3_4 : Fin 4 := ⟨3, by decide⟩
+private abbrev f0_8 : Fin 8 := ⟨0, by decide⟩
+private abbrev f1_8 : Fin 8 := ⟨1, by decide⟩
+private abbrev f2_8 : Fin 8 := ⟨2, by decide⟩
+private abbrev f3_8 : Fin 8 := ⟨3, by decide⟩
+private abbrev f4_8 : Fin 8 := ⟨4, by decide⟩
+private abbrev f5_8 : Fin 8 := ⟨5, by decide⟩
+private abbrev f6_8 : Fin 8 := ⟨6, by decide⟩
+private abbrev f7_8 : Fin 8 := ⟨7, by decide⟩
+private abbrev f0_9 : Fin 9 := ⟨0, by decide⟩
+private abbrev f1_9 : Fin 9 := ⟨1, by decide⟩
+private abbrev f2_9 : Fin 9 := ⟨2, by decide⟩
+private abbrev f3_9 : Fin 9 := ⟨3, by decide⟩
+private abbrev f4_9 : Fin 9 := ⟨4, by decide⟩
+private abbrev f5_9 : Fin 9 := ⟨5, by decide⟩
+private abbrev f6_9 : Fin 9 := ⟨6, by decide⟩
+private abbrev f7_9 : Fin 9 := ⟨7, by decide⟩
+private abbrev f8_9 : Fin 9 := ⟨8, by decide⟩
 
-private def identityLatticeVec : Vector Int 2 :=
-  Vector.ofFn fun i => if i.val = 0 then 7 else -2
+private def identityLatticeVec : Vector Int 8 :=
+  Vector.ofFn fun i =>
+    match i.val with
+    | 0 => 7
+    | 1 => -2
+    | 2 => 5
+    | 3 => -1
+    | 4 => 3
+    | 5 => 0
+    | 6 => 2
+    | _ => -4
 
-private def dependentLatticeVec : Vector Int 2 :=
-  Vector.ofFn fun i => if i.val = 0 then 0 else 6
+private def dependentLatticeVec : Vector Int 4 :=
+  Vector.ofFn fun i =>
+    match i.val with
+    | 1 => 6
+    | _ => 0
 
-private def typicalLatticeVec : Vector Int 3 :=
+private def typicalLatticeVec : Vector Int 8 :=
   Vector.ofFn fun i =>
     match i.val with
     | 0 => 2
     | 1 => -1
-    | _ => -1
+    | 2 => -1
+    | 3 => 5
+    | 4 => -1
+    | 5 => 0
+    | 6 => 2
+    | _ => 3
 
-private def identityWitness : Vector Int 2 :=
-  Vector.ofFn fun i => if i.val = 0 then 7 else -2
+private def identityWitness : Vector Int 8 :=
+  Vector.ofFn fun i =>
+    match i.val with
+    | 0 => 7
+    | 1 => -2
+    | 2 => 5
+    | 3 => -1
+    | 4 => 3
+    | 5 => 0
+    | 6 => 2
+    | _ => -4
 
-private def dependentWitness : Vector Int 3 :=
+private def dependentWitness : Vector Int 8 :=
   Vector.ofFn fun i =>
     match i.val with
     | 0 => 3
     | 1 => -1
-    | _ => 2
+    | 2 => 2
+    | _ => 0
 
-private def typicalWitness : Vector Int 3 :=
+private def typicalWitness : Vector Int 8 :=
   Vector.ofFn fun i =>
     match i.val with
     | 0 => 1
     | 1 => 1
-    | _ => -2
+    | 2 => -2
+    | 3 => 5
+    | 4 => -1
+    | 5 => 0
+    | 6 => 2
+    | _ => 3
 
-example : Matrix.memLattice identity2 identityLatticeVec := by
+example : Matrix.memLattice identity8 identityLatticeVec := by
   refine ⟨identityWitness, ?_⟩
   decide
 
-example : Matrix.memLattice dependent3x2 dependentLatticeVec := by
+example : Matrix.memLattice dependent8x4 dependentLatticeVec := by
   refine ⟨dependentWitness, ?_⟩
   decide
 
-example : Matrix.memLattice typical3 typicalLatticeVec := by
+example : Matrix.memLattice typical8 typicalLatticeVec := by
   refine ⟨typicalWitness, ?_⟩
   decide
 
@@ -170,9 +241,9 @@ private noncomputable def lllReducedCheck (b : Matrix Int n m) (δ : Rat) : Bool
         true
   sizeReduced && lovasz
 
-#guard independentCheck identity2
-#guard !independentCheck zero2
-#guard !independentCheck dependent3x2
+#guard independentCheck identity8
+#guard !independentCheck zero8
+#guard !independentCheck dependent8x4
 
 private def stateOf (b : Matrix Int n m) : LLLState n m where
   b := b
@@ -188,30 +259,38 @@ private def stateOf (b : Matrix Int n m) : LLLState n m where
     intro i hi
     exact GramSchmidt.Int.gramDetVec_eq_gramDet b i (Nat.le_of_lt_succ hi)
 
-private def identityState : LLLState 2 2 := stateOf identity2
-private def zeroState : LLLState 2 2 := stateOf zero2
-private def unreducedState : LLLState 2 2 := stateOf unreduced2
-private def typicalState : LLLState 3 3 := stateOf typical3
+private def identityState : LLLState 8 8 := stateOf identity8
+private def zeroState : LLLState 8 8 := stateOf zero8
+private def unreducedState : LLLState 8 8 := stateOf unreduced8
+private def typicalState : LLLState 8 8 := stateOf typical8
 
-private abbrev f0_4 : Fin 4 := ⟨0, by decide⟩
-private abbrev f1_4 : Fin 4 := ⟨1, by decide⟩
-private abbrev f2_4 : Fin 4 := ⟨2, by decide⟩
-
-#guard (identityState.d.get f0_3) = 1
-#guard (identityState.d.get f1_3) = 1
-#guard (identityState.d.get f2_3) = 1
+#guard (identityState.d.get f0_9) = 1
+#guard (identityState.d.get f1_9) = 1
+#guard (identityState.d.get f2_9) = 1
+#guard (identityState.d.get f3_9) = 1
+#guard (identityState.d.get f4_9) = 1
+#guard (identityState.d.get f5_9) = 1
+#guard (identityState.d.get f6_9) = 1
+#guard (identityState.d.get f7_9) = 1
+#guard (identityState.d.get f8_9) = 1
 #guard identityState.potential = 1
 
-#guard (zeroState.d.get f0_3) = 1
-#guard (zeroState.d.get f1_3) = 0
-#guard (zeroState.d.get f2_3) = 0
+#guard (zeroState.d.get f0_9) = 1
+#guard (zeroState.d.get f1_9) = 0
+#guard (zeroState.d.get f2_9) = 0
+#guard (zeroState.d.get f8_9) = 0
 #guard zeroState.potential = 0
 
-#guard (typicalState.d.get f0_4) = 1
-#guard (typicalState.d.get f1_4) = 2
-#guard (typicalState.d.get f2_4) = 3
-#guard (typicalState.d.get f3_4) = 4
-#guard typicalState.potential = 6
+#guard (typicalState.d.get f0_9) = 1
+#guard (typicalState.d.get f1_9) = 2
+#guard (typicalState.d.get f2_9) = 3
+#guard (typicalState.d.get f3_9) = 4
+#guard (typicalState.d.get f4_9) = 4
+#guard (typicalState.d.get f5_9) = 4
+#guard (typicalState.d.get f6_9) = 4
+#guard (typicalState.d.get f7_9) = 4
+#guard (typicalState.d.get f8_9) = 4
+#guard typicalState.potential = 6144
 
 #guard independentCheck bzStyleBasis
 #guard (Matrix.row bzStyleBasis f0_3).get f0_4 = 1
@@ -235,86 +314,109 @@ example (hδ : (1 / 4 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
 
 example :
     identityState.gramSchmidtCoeff 1 0 (by decide) (by decide) =
-      (((identityState.ν.get f1_2).get f0_2 : Int) : Rat) / (identityState.d.get f1_3 : Rat) := by
+      (((identityState.ν.get f1_8).get f0_8 : Int) : Rat) / (identityState.d.get f1_9 : Rat) := by
   rfl
 
 example :
     unreducedState.gramSchmidtCoeff 1 0 (by decide) (by decide) =
-      (((unreducedState.ν.get f1_2).get f0_2 : Int) : Rat) / (unreducedState.d.get f1_3 : Rat) := by
+      (((unreducedState.ν.get f1_8).get f0_8 : Int) : Rat) /
+        (unreducedState.d.get f1_9 : Rat) := by
   rfl
 
 example :
     typicalState.gramSchmidtCoeff 2 1 (by decide) (by decide) =
-      (((typicalState.ν.get f2_3).get f1_3 : Int) : Rat) / (typicalState.d.get f2_4 : Rat) := by
+      (((typicalState.ν.get f2_8).get f1_8 : Int) : Rat) / (typicalState.d.get f2_9 : Rat) := by
   rfl
 
-#guard (((identityState.ν.get f1_2).get f0_2 : Int) : Rat) / (identityState.d.get f1_3 : Rat) = 0
-#guard (((unreducedState.ν.get f1_2).get f0_2 : Int) : Rat) / (unreducedState.d.get f1_3 : Rat) = 3
-#guard (((typicalState.ν.get f2_3).get f1_3 : Int) : Rat) / (typicalState.d.get f2_4 : Rat) =
-  ((1 : Rat) / 3)
+#guard (((identityState.ν.get f1_8).get f0_8 : Int) : Rat) /
+  (identityState.d.get f1_9 : Rat) = 0
+#guard (((unreducedState.ν.get f1_8).get f0_8 : Int) : Rat) /
+  (unreducedState.d.get f1_9 : Rat) = 3
+#guard (((typicalState.ν.get f2_8).get f1_8 : Int) : Rat) /
+  (typicalState.d.get f2_9 : Rat) = ((1 : Rat) / 3)
 
-private def sizeReducedUnreduced : LLLState 2 2 :=
-  unreducedState.sizeReduceColumn f0_2 f1_2 (by decide)
+private def sizeReducedUnreduced : LLLState 8 8 :=
+  unreducedState.sizeReduceColumn f0_8 f1_8 (by decide)
 
-#guard Matrix.row sizeReducedUnreduced.b f0_2 = Matrix.row unreduced2 f0_2
-#guard Matrix.row sizeReducedUnreduced.b f1_2 =
-  (Vector.ofFn fun i => if i.val = 0 then 0 else 1)
+#guard Matrix.row sizeReducedUnreduced.b f0_8 = Matrix.row unreduced8 f0_8
+#guard Matrix.row sizeReducedUnreduced.b f1_8 =
+  (Vector.ofFn fun i => if i.val = 1 then 1 else 0)
 #guard sizeReducedUnreduced.d = unreducedState.d
-#guard (sizeReducedUnreduced.ν.get f1_2).get f0_2 = 0
+#guard (sizeReducedUnreduced.ν.get f1_8).get f0_8 = 0
 
-private def unchangedIdentityColumn : LLLState 2 2 :=
-  identityState.sizeReduceColumn f0_2 f1_2 (by decide)
+private def unchangedIdentityColumn : LLLState 8 8 :=
+  identityState.sizeReduceColumn f0_8 f1_8 (by decide)
 
 #guard unchangedIdentityColumn.b = identityState.b
 #guard unchangedIdentityColumn.ν = identityState.ν
 #guard unchangedIdentityColumn.d = identityState.d
 
-private def sizeReducedTypical : LLLState 3 3 :=
+private def sizeReducedTypical : LLLState 8 8 :=
   typicalState.sizeReduce 2
 
-#guard Matrix.row sizeReducedTypical.b f0_3 = Matrix.row typical3 f0_3
-#guard Matrix.row sizeReducedTypical.b f1_3 = Matrix.row typical3 f1_3
-#guard Matrix.row sizeReducedTypical.b f2_3 =
+#guard Matrix.row sizeReducedTypical.b f0_8 = Matrix.row typical8 f0_8
+#guard Matrix.row sizeReducedTypical.b f1_8 = Matrix.row typical8 f1_8
+#guard Matrix.row sizeReducedTypical.b f2_8 =
   (Vector.ofFn fun i =>
     match i.val with
     | 0 => 0
     | 1 => 1
-    | _ => 1)
+    | 2 => 1
+    | _ => 0)
 #guard sizeReducedTypical.d = typicalState.d
 
 #guard (identityState.sizeReduce 2).b = identityState.b
 #guard (identityState.sizeReduce 2).ν = identityState.ν
 #guard (identityState.sizeReduce 2).d = identityState.d
 
-private def swappedFirstTypical : LLLState 3 3 :=
+private def sizeReducedTypicalHigh : LLLState 8 8 :=
+  typicalState.sizeReduce 7
+
+#guard sizeReducedTypicalHigh.b = typicalState.b
+#guard sizeReducedTypicalHigh.ν = typicalState.ν
+#guard sizeReducedTypicalHigh.d = typicalState.d
+
+private def swappedFirstTypical : LLLState 8 8 :=
   typicalState.swapStep 1
 
-#guard Matrix.row swappedFirstTypical.b f0_3 = Matrix.row typical3 f1_3
-#guard Matrix.row swappedFirstTypical.b f1_3 = Matrix.row typical3 f0_3
-#guard Matrix.row swappedFirstTypical.b f2_3 = Matrix.row typical3 f2_3
-#guard (swappedFirstTypical.d.get f0_4) = 1
-#guard (swappedFirstTypical.d.get f1_4) = 2
-#guard (swappedFirstTypical.d.get f2_4) = 3
-#guard (swappedFirstTypical.d.get f3_4) = 4
-#guard (swappedFirstTypical.ν.get f1_3).get f0_3 = 1
-#guard swappedFirstTypical.potential = 6
+#guard Matrix.row swappedFirstTypical.b f0_8 = Matrix.row typical8 f1_8
+#guard Matrix.row swappedFirstTypical.b f1_8 = Matrix.row typical8 f0_8
+#guard Matrix.row swappedFirstTypical.b f2_8 = Matrix.row typical8 f2_8
+#guard (swappedFirstTypical.d.get f0_9) = 1
+#guard (swappedFirstTypical.d.get f1_9) = 2
+#guard (swappedFirstTypical.d.get f2_9) = 3
+#guard (swappedFirstTypical.d.get f3_9) = 4
+#guard (swappedFirstTypical.d.get f8_9) = 4
+#guard (swappedFirstTypical.ν.get f1_8).get f0_8 = 1
+#guard swappedFirstTypical.potential = 6144
 
-private def swappedSecondTypical : LLLState 3 3 :=
+private def swappedSecondTypical : LLLState 8 8 :=
   typicalState.swapStep 2
 
-#guard Matrix.row swappedSecondTypical.b f0_3 = Matrix.row typical3 f0_3
-#guard Matrix.row swappedSecondTypical.b f1_3 = Matrix.row typical3 f2_3
-#guard Matrix.row swappedSecondTypical.b f2_3 = Matrix.row typical3 f1_3
-#guard (swappedSecondTypical.d.get f0_4) = 1
-#guard (swappedSecondTypical.d.get f1_4) = 2
-#guard (swappedSecondTypical.d.get f2_4) = 3
-#guard (swappedSecondTypical.d.get f3_4) = 4
-#guard (swappedSecondTypical.ν.get f2_3).get f1_3 = 1
-#guard swappedSecondTypical.potential = 6
+#guard Matrix.row swappedSecondTypical.b f0_8 = Matrix.row typical8 f0_8
+#guard Matrix.row swappedSecondTypical.b f1_8 = Matrix.row typical8 f2_8
+#guard Matrix.row swappedSecondTypical.b f2_8 = Matrix.row typical8 f1_8
+#guard (swappedSecondTypical.d.get f0_9) = 1
+#guard (swappedSecondTypical.d.get f1_9) = 2
+#guard (swappedSecondTypical.d.get f2_9) = 3
+#guard (swappedSecondTypical.d.get f3_9) = 4
+#guard (swappedSecondTypical.d.get f8_9) = 4
+#guard (swappedSecondTypical.ν.get f2_8).get f1_8 = 1
+#guard swappedSecondTypical.potential = 6144
+
+private def swappedHighTypical : LLLState 8 8 :=
+  typicalState.swapStep 4
+
+#guard Matrix.row swappedHighTypical.b f3_8 = Matrix.row typical8 f4_8
+#guard Matrix.row swappedHighTypical.b f4_8 = Matrix.row typical8 f3_8
+#guard Matrix.row swappedHighTypical.b f0_8 = Matrix.row typical8 f0_8
+#guard Matrix.row swappedHighTypical.b f7_8 = Matrix.row typical8 f7_8
+#guard swappedHighTypical.d = typicalState.d
+#guard swappedHighTypical.potential = 6144
 
 #guard (typicalState.swapStep 0).b = typicalState.b
-#guard (typicalState.swapStep 3).b = typicalState.b
-#guard (typicalState.swapStep 3).d = typicalState.d
+#guard (typicalState.swapStep 8).b = typicalState.b
+#guard (typicalState.swapStep 8).d = typicalState.d
 
 end LLLConformance
 end Hex

--- a/progress/20260504T081924Z_ab8cd5fc.md
+++ b/progress/20260504T081924Z_ab8cd5fc.md
@@ -1,0 +1,43 @@
+# 20260504T081924Z — feature session ab8cd5fc
+
+Issue: #2014 — HexLLL: bump conformance fixture sizes toward SPEC profile-size ceilings.
+
+## Accomplished
+
+- Bumped the typical, edge, and adversarial fixtures in `HexLLL/Conformance.lean`
+  from dim 2/3 to dim 8.
+  - `identity2` → `identity8`, `zero2` → `zero8`, `unreduced2` → `unreduced8`,
+    `typical3` → `typical8` (block-diagonal: typical3 in upper-left, identity in
+    lower-right so `d = [1, 2, 3, 4, 4, 4, 4, 4, 4]`, `potential = 6144`).
+  - `dependent3x2` → `dependent8x4`: 8 rows over 4 columns; preserves the
+    "rectangular dependent" structure (row 1 = 2 · row 0).
+- Added two new tests that exercise larger-input code paths the original dim-3
+  fixtures could not reach:
+  - `swappedHighTypical = typicalState.swapStep 4`: exercises the swap's
+    multi-row update loop over rows `i > 4` (rows 5, 6, 7).
+  - `sizeReducedTypicalHigh = typicalState.sizeReduce 7`: exercises the
+    full earlier-row loop iterating `j = 6 ↘ 0`.
+- Preserved `bzStyleBasis` (the unchanged 3×4 downstream basis used to test
+  `lll`, `lll.firstShortVector`, `lll.shortVectors`) since it lies outside
+  the typical/edge/adversarial scope of the issue.
+- Updated the docstring's "covered edge cases" list to reflect the new
+  high-index swap and high-index size-reduction tests.
+
+## Verification
+
+- `lake build HexLLL` green.
+- `HexLLL.Conformance` elaborates in 1.4s (well under the 2s budget).
+- `git diff --check` clean.
+- 84 `#guard` checks (up from 53), 8 `example`s (unchanged).
+
+## Current frontier
+
+PR posted; no follow-up work expected from this session.
+
+## Next step
+
+None for this session. CI auto-merges if green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2014

Session: `ab8cd5fc-5f5d-48d7-bbf0-dc32e0225b3f`

a14caf5 test: bump HexLLL conformance fixtures to dim 8

🤖 Prepared with Claude Code