### PR TITLE
HexGfqMathlib: add missing PrimeModulus instance to unbreak main

### DIFF
--- a/HexGfqMathlib/Basic.lean
+++ b/HexGfqMathlib/Basic.lean
@@ -63,7 +63,7 @@ end FpPoly
 
 namespace FiniteField
 
-variable {p : Nat} [Hex.ZMod64.Bounds p]
+variable {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 variable {f : Hex.FpPoly p}
 variable {hf : 0 < Hex.FpPoly.degree f}
 variable {hp : Hex.Nat.Prime p}
@@ -152,7 +152,7 @@ end FiniteField
 
 namespace GFq
 
-variable {p n : Nat} [Hex.ZMod64.Bounds p]
+variable {p n : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
 
 /-- Canonical Conway-backed `GFq` values inherit the generic finite-field
 enumeration. -/

--- a/HexGfqMathlib/Conformance.lean
+++ b/HexGfqMathlib/Conformance.lean
@@ -39,6 +39,9 @@ private instance conformanceBoundsTwo : Hex.ZMod64.Bounds 2 := ⟨by decide, by 
 private abbrev Entry21 : Conway.SupportedEntry 2 1 :=
   Conway.supportedEntry_2_1
 
+private instance conformancePrimeModulusTwo : Hex.ZMod64.PrimeModulus 2 :=
+  Hex.ZMod64.primeModulusOfPrime Entry21.prime
+
 private def polyTwo (coeffs : Array Nat) : Hex.FpPoly 2 :=
   Hex.FpPoly.ofCoeffs (coeffs.map (fun n => Hex.ZMod64.ofNat 2 n))
 

--- a/progress/20260504T083220Z_2b6d4ec4.md
+++ b/progress/20260504T083220Z_2b6d4ec4.md
@@ -1,0 +1,43 @@
+# 2026-05-04T08:32Z — feature session 2b6d4ec4
+
+## Accomplished
+
+Closed critical-path issue #2061 ("HexGfqMathlib: add missing PrimeModulus
+instance to unbreak main"). Three surgical edits:
+
+- `HexGfqMathlib/Basic.lean:66` and `:155` — added
+  `[Hex.ZMod64.PrimeModulus p]` alongside the existing
+  `[Hex.ZMod64.Bounds p]` on the `namespace FiniteField` and
+  `namespace GFq` `variable` lines, so the `Field`/`Grind` instances
+  from `HexGfqField/Operations.lean:17` can be synthesized.
+- `HexGfqMathlib/Conformance.lean` — added
+  `private instance conformancePrimeModulusTwo` immediately after
+  `Entry21`, deriving `Hex.ZMod64.PrimeModulus 2` from
+  `Entry21.prime` via `primeModulusOfPrime`.
+
+`lake build HexGfqMathlib` now succeeds (the conformance CI matrix
+target). All `#guard`s in the conformance file still elaborate; the
+pre-existing four `sorry`s in `Basic.lean:37, 44, 50, 57` are
+out-of-scope and untouched.
+
+One new linter note from `unusedSectionVars` flags
+`fintype_card` as not using `[ZMod64.PrimeModulus p]`. It is a
+warning, not an error, and the issue explicitly asked for surgical
+edits; per-theorem `omit` clauses would broaden the diff beyond the
+plan's three edits.
+
+## Current frontier
+
+`conformance (HexGfqMathlib)` should turn green once this PR's CI
+reports back. Two `human-oversight` directives (#2021, #2005) and the
+two cross-check PRs (#2031, #2032) that piggybacked the same fix are
+unblocked once this lands.
+
+## Next step
+
+Repair flow (or next worker rebasing #2031, #2032) drops the
+piggybacked PrimeModulus edits from those branches.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2061

Session: `2b6d4ec4-a9c5-4b2c-9c06-589f86f9a454`

af42994 fix: thread PrimeModulus through HexGfqMathlib field instance

🤖 Prepared with Claude Code