### PR TITLE
HexBerlekampZassenhausMathlib: Phase 1 scaffold

### DIFF
--- a/HexBerlekampZassenhausMathlib.lean
+++ b/HexBerlekampZassenhausMathlib.lean
@@ -1,0 +1,6 @@
+import HexBerlekampZassenhausMathlib.Basic
+
+/-!
+Root module for the Mathlib bridge of the integer Berlekamp-Zassenhaus
+factorization pipeline.
+-/

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1,0 +1,55 @@
+import HexBerlekampZassenhaus
+import HexPolyZMathlib.Basic
+import Mathlib.RingTheory.Polynomial.UniqueFactorization
+
+/-!
+Mathlib-facing correctness surface for `HexBerlekampZassenhaus`.
+
+This module states the unconditional integer factorization and irreducibility
+certificate theorems after transporting executable `Hex.ZPoly` values to
+Mathlib polynomials over `ℤ`.
+-/
+
+namespace HexBerlekampZassenhausMathlib
+
+noncomputable section
+
+open Polynomial
+
+/-- The default executable factorization multiplies back to the input. -/
+theorem factor_product (f : Hex.ZPoly) :
+    Array.foldl (· * ·) 1 (Hex.factor f) = f := by
+  sorry
+
+/--
+Every factor emitted by the default executable factorization is irreducible
+after transport to Mathlib's polynomial model.
+-/
+theorem factor_irreducible (f : Hex.ZPoly) :
+    ∀ g ∈ Hex.factor f, Irreducible (HexPolyZMathlib.toPolynomial g) := by
+  sorry
+
+/--
+Two irreducible executable factorizations of the same polynomial have the same
+factor list, up to the equality relation used by `List.Perm`.
+-/
+theorem factor_unique (f : Hex.ZPoly) (gs hs : Array Hex.ZPoly) :
+    Array.foldl (· * ·) 1 gs = f →
+    Array.foldl (· * ·) 1 hs = f →
+    (∀ g ∈ gs, Irreducible (HexPolyZMathlib.toPolynomial g)) →
+    (∀ h ∈ hs, Irreducible (HexPolyZMathlib.toPolynomial h)) →
+    List.Perm gs.toList hs.toList := by
+  sorry
+
+/--
+The executable integer-polynomial irreducibility checker is sound after
+transport to Mathlib's polynomial model.
+-/
+theorem checkIrreducibleCert_sound
+    (f : Hex.ZPoly) (cert : Hex.ZPolyIrreducibilityCertificate) :
+    Hex.checkIrreducibleCert f cert = true → Irreducible (HexPolyZMathlib.toPolynomial f) := by
+  sorry
+
+end
+
+end HexBerlekampZassenhausMathlib

--- a/libraries.yml
+++ b/libraries.yml
@@ -138,4 +138,4 @@ libraries:
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexPolyZMathlib]
     mathlib: true
-    done_through: 0
+    done_through: 1

--- a/progress/20260504T224956Z_30450f3c.md
+++ b/progress/20260504T224956Z_30450f3c.md
@@ -1,0 +1,24 @@
+# HexBerlekampZassenhausMathlib Phase 1 scaffold (#2076)
+
+## Accomplished
+
+- Claimed issue #2076 and created the Phase 1 scaffold for `HexBerlekampZassenhausMathlib`.
+- Added `HexBerlekampZassenhausMathlib/Basic.lean` with module docstring and the four SPEC theorem signatures:
+  `factor_product`, `factor_irreducible`, `factor_unique`, and `checkIrreducibleCert_sound`.
+- Wired the root `HexBerlekampZassenhausMathlib.lean` to import `Basic`.
+- Removed the tracked `.keep` placeholder from the now-populated module directory.
+- Bumped `libraries.yml` so `HexBerlekampZassenhausMathlib.done_through` is `1`.
+- Opened follow-up issue #2088 for the deferred honest `Decidable (Irreducible f)` surface.
+- Verified `lake build HexBerlekampZassenhausMathlib`, `python3 scripts/check_dag.py`, `python3 scripts/status.py HexBerlekampZassenhausMathlib`, `git diff --check`, and placeholder scans.
+
+## Current frontier
+
+`HexBerlekampZassenhausMathlib` now has its Phase 1 theorem scaffold and reports Phase 2 as ready. The only new proof placeholders are the four intended theorem `sorry`s.
+
+## Next step
+
+Run the Phase 2 scaffolding review for `HexBerlekampZassenhausMathlib` after this PR lands; separately, #2088 tracks the data-level decidability surface.
+
+## Blockers
+
+None for this scaffold slice.


### PR DESCRIPTION
Closes #2076

Session: `30450f3c-a9a5-4e6a-993a-03998cefb071`

Phase 1 scaffold outcome: committed `factor_product`, `factor_irreducible`, `factor_unique`, and `checkIrreducibleCert_sound` in `HexBerlekampZassenhausMathlib/Basic.lean`, each as a theorem with a proof-side `sorry`. The module and root file both have module docstrings, and `libraries.yml` now marks `HexBerlekampZassenhausMathlib.done_through: 1`.

Intentionally deferred: the SPEC's `Decidable (Irreducible f)` surface for `f : Polynomial ℤ` is data-level and was not stubbed. Follow-up #2088 tracks adding an honest instance once the required correctness surface is available.

Verification:
- `lake build HexBerlekampZassenhausMathlib`
- `python3 scripts/check_dag.py`
- `python3 scripts/status.py HexBerlekampZassenhausMathlib` reports Phase 2 ready
- `git diff --check`
- `rg -n "axiom|native_decide|TODO|FIXME" HexBerlekampZassenhausMathlib/` returns nothing
- `rg -n "sorry" HexBerlekampZassenhausMathlib/` shows only the four expected theorem placeholders

Progress: `progress/20260504T224956Z_30450f3c.md`