### PR TITLE
HexPoly: prove executable xgcd Bezout invariant

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -2107,6 +2107,82 @@ theorem zero_add {S : Type _}
   rw [coeff_add 0 p n hzero_add, coeff_zero]
   grind
 
+private theorem xgcd_bezout_step {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S]
+    (a s₀ t₀ s₁ t₁ p q : DensePoly S) :
+    (s₀ - a * s₁) * p + (t₀ - a * t₁) * q =
+      (s₀ * p + t₀ * q) - a * (s₁ * p + t₁ * q) := by
+  rw [sub_eq_add_neg_poly s₀ (a * s₁), sub_eq_add_neg_poly t₀ (a * t₁)]
+  rw [mul_add_left_poly, mul_add_left_poly]
+  rw [neg_mul_right_poly, neg_mul_right_poly]
+  rw [mul_assoc_poly a s₁ p, mul_assoc_poly a t₁ q]
+  rw [mul_add_right_poly]
+  apply ext_coeff
+  intro n
+  have hzero_add : (0 : S) + (0 : S) = 0 := by grind
+  have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
+  rw [coeff_add (s₀ * p + (0 - a * (s₁ * p))) (t₀ * q + (0 - a * (t₁ * q))) n
+    hzero_add]
+  rw [coeff_add (s₀ * p) (0 - a * (s₁ * p)) n hzero_add]
+  rw [coeff_sub 0 (a * (s₁ * p)) n hzero_sub, coeff_zero]
+  rw [coeff_add (t₀ * q) (0 - a * (t₁ * q)) n hzero_add]
+  rw [coeff_sub 0 (a * (t₁ * q)) n hzero_sub, coeff_zero]
+  rw [coeff_sub (s₀ * p + t₀ * q) (a * (s₁ * p) + a * (t₁ * q)) n hzero_sub]
+  rw [coeff_add (s₀ * p) (t₀ * q) n hzero_add]
+  rw [coeff_add (a * (s₁ * p)) (a * (t₁ * q)) n hzero_add]
+  grind
+
+private theorem xgcdAux_bezout {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
+    (p q r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly S) (fuel : Nat)
+    (hr₀ : s₀ * p + t₀ * q = r₀)
+    (hr₁ : s₁ * p + t₁ * q = r₁) :
+    let r := xgcdAux r₀ s₀ t₀ r₁ s₁ t₁ fuel
+    r.left * p + r.right * q = r.gcd := by
+  induction fuel generalizing r₀ s₀ t₀ r₁ s₁ t₁ with
+  | zero =>
+      simpa [xgcdAux] using hr₀
+  | succ fuel ih =>
+      unfold xgcdAux
+      by_cases hr₁zero : r₁.isZero
+      · simp [hr₁zero, hr₀]
+      · simp [hr₁zero]
+        let qr := divMod r₀ r₁
+        let r := qr.2
+        let s := s₀ - qr.1 * s₁
+        let t := t₀ - qr.1 * t₁
+        apply ih r₁ s₁ t₁ r s t
+        · exact hr₁
+        · have hspec : qr.1 * r₁ + qr.2 = r₀ := by
+            simpa [qr] using DivModLaws.divMod_spec r₀ r₁
+          calc
+            s * p + t * q
+                = (s₀ * p + t₀ * q) - qr.1 * (s₁ * p + t₁ * q) := by
+                  exact xgcd_bezout_step qr.1 s₀ t₀ s₁ t₁ p q
+            _ = r₀ - qr.1 * r₁ := by rw [hr₀, hr₁]
+            _ = qr.2 := by
+              have h : r₀ = qr.1 * r₁ + qr.2 := hspec.symm
+              rw [h]
+              apply ext_coeff
+              intro n
+              have hzero_add : (0 : S) + (0 : S) = 0 := by grind
+              have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
+              rw [coeff_sub]
+              · rw [coeff_add]
+                · grind
+                · exact hzero_add
+              · exact hzero_sub
+
+theorem xgcd_bezout_of_divModLaws {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
+    (p q : DensePoly S) :
+    let r := xgcd p q
+    r.left * p + r.right * q = r.gcd := by
+  unfold xgcd
+  apply xgcdAux_bezout p q
+  · rw [mul_comm_poly (1 : DensePoly S) p, mul_one_right_poly, zero_mul, add_zero_poly]
+  · rw [zero_mul, mul_comm_poly (1 : DensePoly S) q, mul_one_right_poly, zero_add]
+
 /-- Recursive reconstruction invariant for the array-backed long-division loop.
 Under the cancellation hypothesis for the leading-coefficient scaling function
 together with sparsity bounds on `quot` and `rem`, each step of `divModArrayAux`

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -1484,7 +1484,7 @@ private instance ratGcdLaws : DensePoly.GcdLaws Rat where
     sorry
   xgcd_bezout := by
     intro f g
-    sorry
+    exact DensePoly.xgcd_bezout_of_divModLaws f g
 
 private theorem rat_div_gcd_mul_reconstruct (f df : DensePoly Rat) :
     (f / DensePoly.gcd f df) * DensePoly.gcd f df = f := by

--- a/progress/20260504T233534Z_d483a7c1.md
+++ b/progress/20260504T233534Z_d483a7c1.md
@@ -1,0 +1,23 @@
+# HexPoly executable xgcd Bezout
+
+## Accomplished
+
+- Read the latest progress note and claimed #1930 after checking the unclaimed queue.
+- Confirmed #1930 was too broad as a single worker item because it needs reusable executable `xgcd` correctness infrastructure before the Rat gcd-law instance can close.
+- Decomposed #1930 into #2107, #2108, and #2109, then marked #1930 `replan` with the required breadcrumb.
+- Claimed #2107.
+- Added a generic `DensePoly.xgcd_bezout_of_divModLaws` theorem in `HexPoly/Euclid.lean`.
+- Used that theorem to replace the `xgcd_bezout` placeholder in the private `ratGcdLaws` instance in `HexPolyZ/Basic.lean`.
+
+## Current frontier
+
+The executable `xgcd` Bezout identity is now available under `DensePoly.DivModLaws`. The Rat gcd-law instance still has the three divisibility/maximality placeholders, which are covered by #2108 and #2109.
+
+## Next step
+
+Prove the executable gcd order laws from #2108, then use them in #2109 to close the remaining `ratGcdLaws` fields.
+
+## Blockers
+
+- None for #2107.
+- Closing the original #1930 still depends on the gcd divisibility/maximality infrastructure split into #2108.


### PR DESCRIPTION
Closes #2107

Verification:
- lake build HexPoly
- lake build HexPolyZ.Basic
- python3 scripts/check_dag.py
- git diff --check