### PR TITLE
HexMatrix: expose successor off-diagonal partition

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -2062,6 +2062,38 @@ def detFinalColumnOffDiagonalSum {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     (fun acc v => acc + detFinalColumnOffDiagonal M v)
     0
 
+/-- Split the off-diagonal final-column row choices for a successor-sized
+matrix into the old prefix rows and the new boundary row. -/
+theorem detFinalColumnOffDiagonal_succ_split_last {R : Type u}
+    [Lean.Grind.Ring R] {k : Nat} (M : Matrix R (k + 2) (k + 2))
+    (v : Vector (Fin (k + 1)) (k + 1)) :
+    detFinalColumnOffDiagonal M v =
+      (List.finRange k).foldl
+          (fun acc i =>
+            acc + detTerm M
+              (insertAt (Fin.last (k + 1)) (v.map Fin.castSucc) i.castSucc.castSucc))
+          0 +
+        detTerm M
+          (insertAt (Fin.last (k + 1)) (v.map Fin.castSucc) (Fin.last k).castSucc) := by
+  unfold detFinalColumnOffDiagonal
+  exact foldl_det_sum_finRange_succ_last
+    (fun i => detTerm M (insertAt (Fin.last (k + 1)) (v.map Fin.castSucc) i.castSucc)) 0
+
+/-- Expose the recursive permutation enumeration behind a successor-sized
+off-diagonal final-column sum. -/
+theorem detFinalColumnOffDiagonalSum_succ_flatMap {R : Type u}
+    [Lean.Grind.Ring R] {k : Nat} (M : Matrix R (k + 2) (k + 2)) :
+    detFinalColumnOffDiagonalSum M =
+      (permutationVectors k).foldl
+        (fun acc v =>
+          ((List.finRange (k + 1)).map fun i =>
+              insertAt (Fin.last k) (v.map Fin.castSucc) i).foldl
+            (fun acc perm => acc + detFinalColumnOffDiagonal M perm) acc)
+        0 := by
+  unfold detFinalColumnOffDiagonalSum
+  simp only [permutationVectors]
+  rw [foldl_det_sum_flatMap]
+
 /-- The diagonal part of the final-column partition is the determinant of the
 leading prefix times the final row/final column entry. -/
 theorem det_finalColumn_diagonal_sum {R : Type u}

--- a/progress/20260505T000110Z_2fff0c58.md
+++ b/progress/20260505T000110Z_2fff0c58.md
@@ -1,0 +1,22 @@
+# HexMatrix successor off-diagonal partition API
+
+## Accomplished
+
+- Attempted to claim human-oversight issue #1997; coordination rejected it as needing replan.
+- Attempted to claim #2108 and #2112; both were claimed by other agents before this session could take them.
+- Claimed #2113, assessed it as too large for one coherent proof patch, decomposed it into #2116, #2117, and #2118, then released #2113 for replan.
+- Claimed #2116.
+- Added `detFinalColumnOffDiagonal_succ_split_last` and `detFinalColumnOffDiagonalSum_succ_flatMap` in `HexMatrix/Determinant.lean`.
+
+## Current frontier
+
+The successor off-diagonal final-column sum now has a reusable recursive `permutationVectors` flatMap theorem and a row-choice split at the new boundary row. This supports the next term-level reindexing issue #2117.
+
+## Next step
+
+Use #2116's new API in #2117 to prove the bordered-minor term reindexing lemmas for the nonduplicate successor case.
+
+## Blockers
+
+- The full nonduplicate product identity remains intentionally split into follow-up issues #2117 and #2118.
+- `lake build HexMatrix` reports pre-existing `sorry` warnings in `HexMatrix/RREF.lean` and `HexMatrix/Bareiss.lean`; no new placeholders were added in `HexMatrix/Determinant.lean`.


### PR DESCRIPTION
Closes #2116

Session: `2fff0c58-37e2-41a6-b2bb-9b413eec8811`

07fe8b9 HexMatrix: expose successor off-diagonal partition

🤖 Prepared with Claude Code