### PR TITLE
doc: record HexLLL Phase 4 review verdicts and follow-up

### DIFF
--- a/progress/20260505T014033Z_a4cb66ec.md
+++ b/progress/20260505T014033Z_a4cb66ec.md
@@ -1,0 +1,56 @@
+# Work session: HexLLL Phase 4 benchmark review
+
+## Accomplished
+
+- Claimed #2176 and reviewed `HexLLL/Bench.lean` against `PLAN/Phase4.md`,
+  `SPEC/benchmarking.md`, and `SPEC/Libraries/hex-lll.md`.
+- Confirmed all six advertised executable LLL operations are registered with
+  `setup_benchmark`: `runSizeReduceColumnChecksum`, `runSizeReduceChecksum`,
+  `runSwapStepChecksum`, `runGramSchmidtCoeffChecksum`, `runPotential`, and
+  `runFirstShortVectorIdentityChecksum`. Each has a declared complexity model,
+  an adjacent cost-model derivation comment, and an explicit scientific
+  schedule distinct from the smoke `verify` budget. The hex-lll SPEC names no
+  in-Lean `compare` group nor external comparator that would gate Phase 4
+  beyond these registrations.
+- Ran `lake exe hexlll_bench list && lake exe hexlll_bench verify` (smoke):
+  all six pass.
+- Ran each of the six parametric benchmarks at scientific settings:
+  - `runSizeReduceColumnChecksum`: consistent with declared complexity.
+  - `runSizeReduceChecksum`: consistent with declared complexity.
+  - `runSwapStepChecksum`: **inconclusive** — rung at param 160 killed at
+    `maxSecondsPerCall = 3.000s`, only 2 verdict-eligible rows survived.
+  - `runGramSchmidtCoeffChecksum`: consistent with declared complexity
+    (β = +0.027 over n).
+  - `runPotential`: **inconclusive** — rung at param 224 killed at
+    `maxSecondsPerCall = 8.000s`, only 2 verdict-eligible rows survived.
+  - `runFirstShortVectorIdentityChecksum`: consistent with declared
+    complexity.
+- Did not bump `libraries.yml[HexLLL].done_through` and did not add
+  `status/hex-lll.benchmarks-reviewed`, per #2176's deliverable 3 for
+  inconclusive verdicts.
+- Filed #2188 as the narrow bench-found follow-up capturing the two
+  inconclusive registrations, the observed evidence, the
+  schedule-miscalibration vs algorithmic-bug branching, and the work
+  required for HexLLL to advance to Phase 4.
+
+## Current frontier
+
+`HexLLL` is at `done_through: 3` with four of six Phase 4 registrations
+returning consistent verdicts; advance is blocked on #2188.
+
+## Next step
+
+A worker on #2188 determines whether the two inconclusive verdicts reflect
+schedule miscalibration or an algorithmic-bug finding, applies the
+appropriate fix (re-tune schedule, or rollback + implementation fix), and
+on success bumps `libraries.yml` and adds the status token.
+
+## Blockers
+
+The GitHub GraphQL rate limit was exhausted during the session, so
+`coordination plan` and `coordination create-pr` are unavailable; this
+session created #2188 and the PR for #2176 directly via the REST API
+(`gh api repos/.../issues`, `gh api repos/.../pulls`). The
+`coordination` shell wrapper uses `gh repo view` (GraphQL) at
+startup, so the wrapper itself fails until the GraphQL window resets;
+the REST endpoints stayed within the core rate limit throughout.


### PR DESCRIPTION
Closes #2176

Session: `a4cb66ec-c519-45af-8114-8c995bf5f320`

430ece4 doc: record HexLLL Phase 4 review verdicts and follow-up

Review of HexLLL Phase 4 benchmark verdicts. Four of six parametric
registrations return verdicts consistent with declared complexity at
scientific settings; `runSwapStepChecksum` and `runPotential` return
inconclusive verdicts and the largest scheduled rung is killed at
`maxSecondsPerCall`. Per #2176 deliverable 3, did not bump
`libraries.yml` and did not add the status token; filed #2188 as the
narrow bench-found follow-up capturing the Phase 4 blocker.

🤖 Prepared with Claude Code