### PR TITLE
Move Berlekamp certificate irreducibility to Mathlib

### DIFF
--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -455,13 +455,6 @@ theorem checkIrreducibilityCertificate_rabinTest
       · exact checkRabinBezoutWitnesses_rabinWitnesses_all
           f hmonic samePrimeCert hwitnesses hpow hn
 
-theorem checkIrreducibilityCertificate_irreducible_predicate
-    (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    (cert : IrreducibilityCertificate) :
-    checkIrreducibilityCertificate f hmonic cert = true →
-      FpPoly.Irreducible f := by
-  sorry
-
 end Berlekamp
 
 end Hex

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -257,6 +257,20 @@ theorem rabin_irreducible_of_positive_degree
     Hex.Berlekamp.rabinTest f hmonic = true ↔ Irreducible (toMathlibPolynomial f) := by
   sorry
 
+/--
+Accepted executable irreducibility certificates imply Mathlib irreducibility
+after transporting the checked polynomial to `Polynomial (ZMod p)`.
+-/
+theorem checkIrreducibilityCertificate_irreducible
+    (f : Hex.FpPoly p) (hmonic : Hex.DensePoly.Monic f)
+    [Hex.ZMod64.PrimeModulus p] [Fact (Nat.Prime p)]
+    (cert : Hex.Berlekamp.IrreducibilityCertificate) :
+    Hex.Berlekamp.checkIrreducibilityCertificate f hmonic cert = true →
+      Irreducible (toMathlibPolynomial f) := by
+  intro hcheck
+  exact (rabin_irreducible f hmonic (Hex.Berlekamp.basisSize f) rfl).mp
+    (Hex.Berlekamp.checkIrreducibilityCertificate_rabinTest f hmonic cert hcheck)
+
 /-- Mathlib irreducibility over `Polynomial (ZMod p)` is classically decidable. -/
 instance irreducibleDecidablePred (p : Nat) [Fact (Nat.Prime p)] :
     DecidablePred (fun f : Polynomial (ZMod p) => Irreducible f) :=

--- a/progress/20260505T020024Z_88981b95.md
+++ b/progress/20260505T020024Z_88981b95.md
@@ -1,0 +1,36 @@
+# Work session: Berlekamp certificate correctness split
+
+## Accomplished
+
+- Claimed #2187.
+- Removed the stale Mathlib-free theorem
+  `Hex.Berlekamp.checkIrreducibilityCertificate_irreducible_predicate`
+  from `HexBerlekamp/Irreducibility.lean`.
+- Added `HexBerlekampMathlib.checkIrreducibilityCertificate_irreducible`,
+  composing the executable certificate-to-Rabin bridge with the existing
+  Mathlib Rabin irreducibility theorem.
+- Verified:
+  - `lake build HexBerlekamp.Irreducibility`
+  - `lake build HexBerlekampMathlib`
+  - `lake build HexBerlekamp`
+  - `python3 scripts/status.py HexBerlekamp`
+  - `python3 scripts/status.py HexBerlekampMathlib`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+
+## Current frontier
+
+#2187 is complete. The non-Mathlib certificate checker now only proves the
+computational Rabin-test bridge, and the irreducibility conclusion lives at the
+Mathlib transport layer.
+
+## Next step
+
+Continue HexBerlekamp Phase 5 proof work, or dispatch Phase 3 conformance work
+for `HexBerlekampMathlib` before advancing that library further.
+
+## Blockers
+
+- No blocker for #2187.
+- `HexBerlekampMathlib/Basic.lean` still has its pre-existing foundational
+  Rabin and transport `sorry`s.


### PR DESCRIPTION
Closes #2187

Session: `88981b95-9def-44a9-9815-c3d56a12f35f`

90ebfb1 Move Berlekamp certificate irreducibility to Mathlib

🤖 Prepared with Claude Code