### PR TITLE
HexBerlekampZassenhausMathlib: add Phase 3 conformance

### DIFF
--- a/HexBerlekampZassenhausMathlib.lean
+++ b/HexBerlekampZassenhausMathlib.lean
@@ -1,4 +1,5 @@
 import HexBerlekampZassenhausMathlib.Basic
+import HexBerlekampZassenhausMathlib.Conformance
 
 /-!
 Root module for the Mathlib bridge of the integer Berlekamp-Zassenhaus

--- a/HexBerlekampZassenhausMathlib/Conformance.lean
+++ b/HexBerlekampZassenhausMathlib/Conformance.lean
@@ -1,0 +1,133 @@
+import HexBerlekampZassenhausMathlib.Basic
+
+/-!
+Core conformance checks for `hex-berlekamp-zassenhaus-mathlib`.
+
+Oracle: none
+Mode: always
+Covered operations:
+- `irreducibleByFactorization` on transported `Polynomial ℤ` inputs
+- `irreducibleDecidablePred` as the Mathlib-facing decidability bridge
+- `Hex.factor` observed through `HexPolyZMathlib.ofPolynomial` and
+  `HexPolyZMathlib.toPolynomial`
+Covered properties:
+- executable irreducibility accepts a prime constant and rejects zero and unit
+  inputs
+- the decidability bridge elaborates for concrete `Polynomial ℤ` inputs
+- transporting between `Polynomial ℤ` and `Hex.ZPoly` agrees on the
+  nonconstant fixtures used by the executable checks
+- executable factor products multiply back to the committed nonconstant inputs
+Covered edge cases:
+- zero and unit polynomials
+- degree-zero prime constants
+- primitive linear polynomials
+- reducible products of linears
+- a small irreducible quadratic over `ℤ`
+-/
+
+namespace HexBerlekampZassenhausMathlib
+
+open Polynomial
+
+noncomputable section
+
+private def zpoly (coeffs : Array Int) : Hex.ZPoly :=
+  Hex.DensePoly.ofCoeffs coeffs
+
+private def linear (r : Int) : Hex.ZPoly :=
+  zpoly #[-r, 1]
+
+private def hexZero : Hex.ZPoly := 0
+
+private def hexOne : Hex.ZPoly := 1
+
+private def hexConstantPrime : Hex.ZPoly :=
+  zpoly #[5]
+
+private def hexLinearPrimitive : Hex.ZPoly :=
+  zpoly #[3, 1]
+
+private def hexReducibleQuadratic : Hex.ZPoly :=
+  zpoly #[2, 3, 1]
+
+private def hexIrreducibleQuadratic : Hex.ZPoly :=
+  zpoly #[1, 0, 1]
+
+private def mathZero : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexZero
+
+private def mathOne : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexOne
+
+private def mathConstantPrime : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexConstantPrime
+
+private def mathLinearPrimitive : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexLinearPrimitive
+
+private def mathReducibleQuadratic : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexReducibleQuadratic
+
+private def mathIrreducibleQuadratic : Polynomial ℤ :=
+  HexPolyZMathlib.toPolynomial hexIrreducibleQuadratic
+
+example : irreducibleByFactorization mathZero = false := by
+  rw [mathZero, irreducibleByFactorization, HexPolyZMathlib.ofPolynomial_toPolynomial]
+  rfl
+
+example : irreducibleByFactorization mathOne = false := by
+  rw [mathOne, irreducibleByFactorization, HexPolyZMathlib.ofPolynomial_toPolynomial]
+  rfl
+
+example : irreducibleByFactorization mathConstantPrime = true := by
+  rw [mathConstantPrime, irreducibleByFactorization, HexPolyZMathlib.ofPolynomial_toPolynomial]
+  rfl
+
+example : Decidable (Irreducible mathConstantPrime) := inferInstance
+
+example : Decidable (Irreducible mathLinearPrimitive) := inferInstance
+
+example : Decidable (Irreducible mathReducibleQuadratic) := inferInstance
+
+example : Decidable (Irreducible mathIrreducibleQuadratic) := inferInstance
+
+example :
+    HexPolyZMathlib.toPolynomial (HexPolyZMathlib.ofPolynomial mathLinearPrimitive) =
+      mathLinearPrimitive :=
+  HexPolyZMathlib.toPolynomial_ofPolynomial mathLinearPrimitive
+
+example :
+    HexPolyZMathlib.toPolynomial (HexPolyZMathlib.ofPolynomial mathReducibleQuadratic) =
+      mathReducibleQuadratic :=
+  HexPolyZMathlib.toPolynomial_ofPolynomial mathReducibleQuadratic
+
+example :
+    HexPolyZMathlib.toPolynomial (HexPolyZMathlib.ofPolynomial mathIrreducibleQuadratic) =
+      mathIrreducibleQuadratic :=
+  HexPolyZMathlib.toPolynomial_ofPolynomial mathIrreducibleQuadratic
+
+example :
+    HexPolyZMathlib.ofPolynomial (HexPolyZMathlib.toPolynomial (linear (-3))) =
+      linear (-3) :=
+  HexPolyZMathlib.ofPolynomial_toPolynomial (linear (-3))
+
+example :
+    HexPolyZMathlib.ofPolynomial (HexPolyZMathlib.toPolynomial (zpoly #[2, 3, 1])) =
+      zpoly #[2, 3, 1] :=
+  HexPolyZMathlib.ofPolynomial_toPolynomial (zpoly #[2, 3, 1])
+
+#guard
+  let factors := Hex.factor hexLinearPrimitive
+  Array.polyProduct factors = hexLinearPrimitive
+
+#guard
+  let factors := Hex.factor hexReducibleQuadratic
+  Array.polyProduct factors = hexReducibleQuadratic
+
+#guard
+  let factors := Hex.factor hexIrreducibleQuadratic
+  Array.polyProduct factors = hexIrreducibleQuadratic
+
+end
+
+end HexBerlekampZassenhausMathlib

--- a/libraries.yml
+++ b/libraries.yml
@@ -138,4 +138,4 @@ libraries:
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexPolyZMathlib]
     mathlib: true
-    done_through: 2
+    done_through: 3

--- a/progress/20260505T023740Z_e3375fff.md
+++ b/progress/20260505T023740Z_e3375fff.md
@@ -1,0 +1,40 @@
+# Work session: HexBerlekampZassenhausMathlib Phase 3 conformance
+
+## Accomplished
+
+- Claimed #2217 and added `HexBerlekampZassenhausMathlib/Conformance.lean`.
+- Covered Lean-only checks for `irreducibleByFactorization` on constant
+  edge cases, concrete `Decidable (Irreducible f)` bridge elaboration,
+  `HexPolyZMathlib` transport round trips, and `Hex.factor` product
+  preservation on linear, reducible quadratic, and irreducible quadratic
+  fixtures.
+- Imported the conformance module from `HexBerlekampZassenhausMathlib.lean`.
+- Bumped `libraries.yml[HexBerlekampZassenhausMathlib].done_through` from
+  `2` to `3`.
+- Verified:
+  - `lake build HexBerlekampZassenhausMathlib.Conformance`
+  - `lake build HexBerlekampZassenhausMathlib`
+  - `python3 scripts/status.py HexBerlekampZassenhausMathlib`
+  - `python3 scripts/conformance_targets.py --check`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - targeted scan of touched files for forbidden placeholders and
+    conformance anti-patterns
+
+## Current frontier
+
+`HexBerlekampZassenhausMathlib` now reports Phase 4 readiness, blocked on
+`HexBerlekampZassenhaus.done_through >= 4` and
+`HexPolyZMathlib.done_through >= 4`.
+
+## Next step
+
+Once both dependencies reach Phase 4, add Phase 4 benchmark coverage for the
+Mathlib-facing Berlekamp-Zassenhaus surfaces if the Phase 4 plan calls for this
+library.
+
+## Blockers
+
+- No blocker for #2217.
+- Existing upstream `sorry` warnings remain in imported proof-skeleton modules;
+  this session did not add new `sorry`s.


### PR DESCRIPTION
Closes #2217.

## Summary

- Add `HexBerlekampZassenhausMathlib/Conformance.lean` with the Phase 3 Lean-only contract.
- Import the conformance module from the root library module.
- Bump `HexBerlekampZassenhausMathlib.done_through` to 3.
- Add progress note `progress/20260505T023740Z_e3375fff.md`.

## Verification

- `lake build HexBerlekampZassenhausMathlib.Conformance`
- `lake build HexBerlekampZassenhausMathlib`
- `python3 scripts/status.py HexBerlekampZassenhausMathlib`
- `python3 scripts/conformance_targets.py --check`
- `python3 scripts/check_dag.py`
- `git diff --check`
- targeted scan of touched files for forbidden placeholders and conformance anti-patterns

Existing upstream `sorry` warnings remain in imported proof-skeleton modules; this PR adds no new `sorry`s.