### PR TITLE
chore: ban agent-introduced axioms

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -29,3 +29,8 @@ Commits made during the turn should mention the progress file.
 Check diagnostics after every step; don't continue past errors. Build
 via `lake build`, not `lean` directly. `native_decide` is banned (see
 SPEC).
+
+Never introduce an `axiom`. This includes converting an existing
+`theorem`/`def`/`example` into an `axiom` when a refactor breaks its
+proof — fix the proof or fix the API. For unfinished proofs use
+`sorry`, which is grep-able and produces a warning; `axiom` is silent.


### PR DESCRIPTION
This PR adds a `.claude/CLAUDE.md` rule prohibiting agent-introduced `axiom` declarations, including the foot-gun pattern of converting an existing `theorem`/`def`/`example` into an `axiom` when a refactor breaks the original proof.

Background: PR https://github.com/kim-em/hex/pull/2132 — feat: add HexConway Luebeck oracle fixtures — turned four previously-proved theorems in `HexConway/Basic.lean` into axioms (two of them previously discharged by `rfl`/`decide`) because a new generic constructor wasn't transparent under the old proofs. The agent flagged the move as a "Blocker" in its progress file but shipped the PR anyway.

Existing axioms in `HexConway/Basic.lean`, `HexGfqField/`, and `HexGF2/Smoke.lean` are tracked for removal in separate `human-oversight` issues.

🤖 Prepared with Claude Code