### PR TITLE
fix: correct prefixRowDeletionMinor column border to k

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -339,11 +339,16 @@ theorem det_leadingPrefix_borderedMinor_succ_eq_det_borderedMinor {R : Type u}
 off-diagonal final-column expansion.
 
 For `r : Fin k`, this is the `(k + 1) × (k + 1)` minor with source rows
-`0, ..., r - 1, r + 1, ..., k, i` and source columns `0, ..., k - 1, j`.
+`0, ..., r - 1, r + 1, ..., k, i` and source columns `0, ..., k - 1, k`.
 It is the matrix left after the successor bordered minor's final column is
-chosen by prefix row `r`. -/
+chosen by prefix row `r`; the consumed entry `M[⟨r.val, _⟩][j]` is paired
+with the determinant of this minor at the call site. The `j` parameter is
+retained for API symmetry with the surrounding successor bordered-minor
+context but does not appear in the minor itself, which uses the level-`k`
+pivot column `⟨k, _⟩` as its column border (parallel to the boundary case
+`borderedMinor M k hk i ⟨k, hk⟩`). -/
 def prefixRowDeletionMinor (M : Matrix R n n) (k : Nat) (hnext : k + 1 < n)
-    (i j : Fin n) (r : Fin k) : Matrix R (k + 1) (k + 1) :=
+    (i _j : Fin n) (r : Fin k) : Matrix R (k + 1) (k + 1) :=
   ofFn fun row col =>
     let rr : Fin n :=
       if hrow : row.val < r.val then
@@ -356,7 +361,7 @@ def prefixRowDeletionMinor (M : Matrix R n n) (k : Nat) (hnext : k + 1 < n)
       if hcol : col.val < k then
         ⟨col.val, by omega⟩
       else
-        j
+        ⟨k, by omega⟩
     M[rr][cc]
 
 @[simp] theorem prefixRowDeletionMinor_entry_before_prefix (M : Matrix R n n)
@@ -370,7 +375,7 @@ def prefixRowDeletionMinor (M : Matrix R n n) (k : Nat) (hnext : k + 1 < n)
     (k : Nat) (hnext : k + 1 < n) (i j : Fin n) (r : Fin k)
     (row : Fin (k + 1)) (hrow : row.val < r.val) :
     (prefixRowDeletionMinor M k hnext i j r)[row][Fin.last k] =
-      M[(⟨row.val, by omega⟩ : Fin n)][j] := by
+      M[(⟨row.val, by omega⟩ : Fin n)][(⟨k, by omega⟩ : Fin n)] := by
   simp [prefixRowDeletionMinor, ofFn, hrow]
 
 @[simp] theorem prefixRowDeletionMinor_entry_shifted_prefix (M : Matrix R n n)
@@ -386,7 +391,7 @@ def prefixRowDeletionMinor (M : Matrix R n n) (k : Nat) (hnext : k + 1 < n)
     (k : Nat) (hnext : k + 1 < n) (i j : Fin n) (r : Fin k)
     (row : Fin (k + 1)) (hrle : r.val ≤ row.val) (hrow : row.val < k) :
     (prefixRowDeletionMinor M k hnext i j r)[row][Fin.last k] =
-      M[(⟨row.val + 1, by omega⟩ : Fin n)][j] := by
+      M[(⟨row.val + 1, by omega⟩ : Fin n)][(⟨k, by omega⟩ : Fin n)] := by
   have hnot : ¬ row.val < r.val := by omega
   simp [prefixRowDeletionMinor, ofFn, hnot, hrow]
 
@@ -402,7 +407,7 @@ def prefixRowDeletionMinor (M : Matrix R n n) (k : Nat) (hnext : k + 1 < n)
 @[simp] theorem prefixRowDeletionMinor_entry_border_last (M : Matrix R n n)
     (k : Nat) (hnext : k + 1 < n) (i j : Fin n) (r : Fin k) :
     (prefixRowDeletionMinor M k hnext i j r)[Fin.last k][Fin.last k] =
-      M[i][j] := by
+      M[i][(⟨k, by omega⟩ : Fin n)] := by
   have hnot₁ : ¬ k < r.val := by omega
   have hnot₂ : ¬ k < k := by omega
   simp [prefixRowDeletionMinor, ofFn, hnot₁, hnot₂]

--- a/progress/20260505T032658Z_0615192c.md
+++ b/progress/20260505T032658Z_0615192c.md
@@ -1,0 +1,57 @@
+# Work session: HexMatrix prefix-row deletion minor column-border correction
+
+## Accomplished
+
+- Claimed #2220 and analyzed why the requested prefix-row sum theorem is
+  unprovable with `prefixRowDeletionMinor` as landed by PR #2222.
+  - `B := borderedMinor M (k + 1) hnext i j` has columns
+    `B-cols 0..k = M-cols 0..k`, with col `last = k+1` being `M-col j`.
+  - The sum
+    `Σ_v detTerm B (insertAt last (v.map cs) r.castSucc.castSucc)`
+    expands as `M[⟨r.val,_⟩][j]` (the consumed entry at row r, col j)
+    times a product over the natural sub-matrix with rows
+    `{0..r-1, r+1..k, i}` and columns `{0..k}` (M-cols 0..k).
+  - The previous worker's `prefixRowDeletionMinor` definition placed
+    `j` (rather than `⟨k, _⟩`) at the column border, giving columns
+    `{0..k-1, j}` ≠ `{0..k}`. The two determinants differ in general,
+    so the sum theorem as stated would equate unequal expressions.
+  - The boundary case `detTerm_borderedMinor_succ_insertAt_oldBoundary`
+    uses `borderedMinor M k hk i ⟨k, hk⟩` (col border `⟨k, hk⟩`, NOT
+    `j`); the prefix-row analogue should follow the same pattern.
+- Corrected the `prefixRowDeletionMinor` column border from `j` to
+  `⟨k, _⟩` (derived via `omega` from `hnext : k + 1 < n`).
+- Updated the three affected entry simp lemmas
+  (`prefixRowDeletionMinor_entry_before_last`,
+  `_entry_shifted_last`, `_entry_border_last`) and the doc comment.
+- Renamed the `j` parameter to `_j` to avoid linter warnings while
+  keeping the API signature `prefixRowDeletionMinor M k hnext i j r`
+  compatible with the issue spec and downstream call sites.
+- Verified `lake build HexMatrix.Determinant` succeeds with the fix.
+- Created follow-up issue #2250 for the actual sum theorem and left
+  a `Decomposed into #2250` breadcrumb on #2220.
+
+## Current frontier
+
+The corrected `prefixRowDeletionMinor` is now compatible with the
+natural sub-determinant arising from the prefix-row final-column
+expansion, so the sum theorem in #2250 is now provable. The proof
+path (described in the sub-issue body) is: exact inversion-count
+formula for `(xs.map cs).insertIdx p (Fin.last n)`, the resulting
+`detSign` formula `(-1)^(k+1-r.val) * detSign v`, a product
+identity factoring `M[⟨r.val,_⟩][j]` out of `detProduct B σ_v`,
+and combining via `detTerm_insertAt_last`.
+
+## Next step
+
+Pick up #2250 to prove the prefix-row sum theorem itself, then
+return to #2118 with both the boundary-case theorem and the
+corrected prefix-row sum theorem in hand.
+
+## Blockers
+
+- No blocker for the partial change.
+- The full sum theorem proof is non-trivial: chaining `(k+1 - r.val)`
+  row transpositions in the per-term style of
+  `detTerm_borderedMinor_succ_insertAt_oldBoundary` does not extend
+  cleanly, so the cleanest path is direct inversion-count and product
+  reindexing rather than iterated row swaps.


### PR DESCRIPTION
Partial progress on #2220

Session: `0615192c-98c2-401a-ad6c-2ecafd5bbcf3`

2853b7a docs: progress entry for prefixRowDeletionMinor column-border fix
55b43b0 fix: correct prefixRowDeletionMinor column border to k (not j)

🤖 Prepared with Claude Code