### PR TITLE
HexPolyFp: prove gcd_dvd_left and gcd_dvd_right fields for ZMod64

### DIFF
--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -730,14 +730,40 @@ instance instDivModLawsZMod64Fp (p : Nat) [Bounds p] [PrimeModulus p] :
         grind
       exact mul_left_remainder_delta f g m rf rg hf' hg'⟩
 
+private theorem divMod_remainder_eq_zero_of_not_pos_degree_core
+    [PrimeModulus p] (f m : DensePoly (ZMod64 p))
+    (hmzero : m.isZero = false)
+    (hdegree : ¬ 0 < m.degree?.getD 0) :
+    (DensePoly.divMod f m).2 = 0 := by
+  have hpos_size : 0 < m.size := by
+    have hsize : m.coeffs.size ≠ 0 := by
+      simpa [DensePoly.isZero, Array.isEmpty_iff_size_eq_zero] using hmzero
+    simpa [DensePoly.size, Nat.pos_iff_ne_zero] using hsize
+  have hsize0 : m.size ≠ 0 := Nat.pos_iff_ne_zero.mp hpos_size
+  have hsize1 : m.size = 1 := by
+    have hdeg_eq : m.degree?.getD 0 = m.size - 1 := by
+      simp [DensePoly.degree?, hsize0]
+    have hnot_pos : ¬ 0 < m.size - 1 := by
+      intro h
+      apply hdegree
+      rw [hdeg_eq]
+      exact h
+    omega
+  have hcancel := cancel_lead_at_pos_size_core m hpos_size
+  exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core f m hsize1 hcancel
+
 /-- The `F_p[x]` gcd law obligations used by finite-field inverse construction. -/
-instance : DensePoly.GcdLaws (ZMod64 p) where
+instance [PrimeModulus p] : DensePoly.GcdLaws (ZMod64 p) where
   gcd_dvd_left := by
     intro f g
-    sorry
+    exact @DensePoly.gcd_dvd_left_of_divModLaws (ZMod64 p) _ _ _
+      (instDivModLawsZMod64Fp p)
+      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree_core a b) f g
   gcd_dvd_right := by
     intro f g
-    sorry
+    exact @DensePoly.gcd_dvd_right_of_divModLaws (ZMod64 p) _ _ _
+      (instDivModLawsZMod64Fp p)
+      (fun a b => divMod_remainder_eq_zero_of_not_pos_degree_core a b) f g
   dvd_gcd := by
     intro d f g hdf hdg
     sorry

--- a/progress/20260505T043255Z_f6c342d8.md
+++ b/progress/20260505T043255Z_f6c342d8.md
@@ -1,0 +1,45 @@
+# 2026-05-05 04:32 UTC — feature session (f6c342d8)
+
+## Accomplished
+
+Discharged the two `hsmall`-dependent `GcdLaws` field sorries in
+`HexPolyFp/Basic.lean` (issue #2241):
+
+- Added `private theorem divMod_remainder_eq_zero_of_not_pos_degree_core`
+  in `HexPolyFp/Basic.lean`. It packages
+  `m.isZero = false ∧ ¬ 0 < m.degree?.getD 0 ⇒ m.size = 1`, then chains
+  through `cancel_lead_at_pos_size_core m hpos_size` and
+  `DensePoly.divMod_remainder_eq_zero_of_degree_zero_core` to conclude
+  `(divMod f m).2 = 0`.
+- Discharged `gcd_dvd_left` and `gcd_dvd_right` in the
+  `DensePoly.GcdLaws (ZMod64 p)` instance via
+  `DensePoly.gcd_dvd_left_of_divModLaws` and
+  `gcd_dvd_right_of_divModLaws`.
+- Tightened the `GcdLaws` instance constraint to `[PrimeModulus p]`
+  (the helper requires it; downstream callers in `SquareFree.lean`
+  already have it in scope).
+
+## Implementation note
+
+`instDivModLawsZMod64Fp` declares `(p : Nat)` as an explicit parameter,
+which prevents typeclass synthesis from finding `DivModLaws (ZMod64 p)`
+inside the GcdLaws instance body via implicit-argument unification.
+Used `@`-application to pass `instDivModLawsZMod64Fp p` explicitly.
+
+## Current frontier
+
+`instDivModLawsZMod64Fp` still has 2 sorries (`mod_self_eq_zero`,
+`mod_eq_zero_of_dvd`) and `instGcdLawsZMod64Fp` still has 2 sorries
+(`dvd_gcd`, `xgcd_bezout`) — all out of scope per the issue.
+
+## Next step
+
+Cover the remaining `dvd_gcd` and `xgcd_bezout` GcdLaws fields via
+`DensePoly.dvd_gcd_of_divModLaws` and
+`DensePoly.xgcd_bezout_of_divModLaws` (those don't need `hsmall`).
+The `instDivModLawsZMod64Fp` `mod_self_eq_zero` and `mod_eq_zero_of_dvd`
+sorries are tracked under sibling issues.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2241

Session: `f6c342d8-9615-49f2-aeb6-0b655bdf3c5a`

c1c3b3d feat: discharge GcdLaws gcd_dvd_left/right sorries for ZMod64 (#2241)

🤖 Prepared with Claude Code