### PR TITLE
HexPolyFp: prove degree?_mul_eq_add_degree? and divisor-of-unit corollary for the Rabin bridge

### DIFF
--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -167,9 +167,57 @@ Routine consequence of degree arithmetic: if `g ∣ h` and `h` has degree 0
 with nonzero constant, then `g` also has degree 0 with nonzero constant.
 -/
 theorem isUnitPolynomial_of_dvd_isUnitPolynomial
-    {g h : FpPoly p} (_hgh : g ∣ h) (_hh : isUnitPolynomial h = true) :
+    {g h : FpPoly p} (hgh : g ∣ h) (hh : isUnitPolynomial h = true) :
     isUnitPolynomial g = true := by
-  sorry
+  -- Translate `isUnitPolynomial h = true` into `h.degree? = some 0`.
+  have hh_deg : h.degree? = some 0 := by
+    unfold isUnitPolynomial at hh
+    cases hdeg : h.degree? with
+    | none => rw [hdeg] at hh; simp at hh
+    | some k =>
+      rw [hdeg] at hh
+      cases k with
+      | zero => rfl
+      | succ _ => simp at hh
+  have hh_ne_zero : h ≠ 0 := by
+    intro heq
+    rw [heq] at hh_deg
+    unfold DensePoly.degree? at hh_deg
+    simp at hh_deg
+  rcases hgh with ⟨r, hr⟩
+  have hg_ne_zero : g ≠ 0 := by
+    intro hg
+    apply hh_ne_zero
+    rw [hr, hg, FpPoly.zero_mul]
+  have hr_ne_zero : r ≠ 0 := by
+    intro hzero
+    apply hh_ne_zero
+    rw [hr, hzero, FpPoly.mul_zero]
+  -- `deg h = deg g + deg r` and `deg h = 0`, so `deg g = 0`.
+  have hsum : h.degree?.getD 0 = g.degree?.getD 0 + r.degree?.getD 0 := by
+    rw [hr]
+    exact FpPoly.degree?_mul_eq_add_degree? g r hg_ne_zero hr_ne_zero
+  have hh_deg_zero : h.degree?.getD 0 = 0 := by simp [hh_deg]
+  have hg_deg_zero : g.degree?.getD 0 = 0 := by omega
+  -- Translate `g ≠ 0 ∧ deg g = 0` back to `isUnitPolynomial g = true`.
+  have hg_size_pos : 0 < g.size := by
+    apply Nat.pos_of_ne_zero
+    intro hsize
+    apply hg_ne_zero
+    apply DensePoly.ext_coeff
+    intro i
+    rw [DensePoly.coeff_zero]
+    exact DensePoly.coeff_eq_zero_of_size_le g (by omega)
+  have hg_size_ne_zero : g.size ≠ 0 := Nat.pos_iff_ne_zero.mp hg_size_pos
+  have hg_deg : g.degree? = some (g.size - 1) := by
+    unfold DensePoly.degree?
+    simp [hg_size_ne_zero]
+  rw [hg_deg] at hg_deg_zero
+  simp at hg_deg_zero
+  have hg_deg_some : g.degree? = some 0 := by
+    rw [hg_deg, hg_deg_zero]
+  unfold isUnitPolynomial
+  rw [hg_deg_some]
 
 omit [ZMod64.PrimeModulus p] in
 /-- The factor `a` of a nontrivial product `a * b = f` is nonzero. -/
@@ -216,9 +264,13 @@ match the Berlekamp / Rabin scaffolding.
 -/
 theorem factor_degree_lt_basisSize
     {f a b : FpPoly p}
-    (_hab : a * b = f) (_hb_pos : 0 < b.degree?.getD 0) :
+    (hab : a * b = f) (ha_ne_zero : a ≠ 0) (hb_pos : 0 < b.degree?.getD 0) :
     a.degree?.getD 0 < basisSize f := by
-  sorry
+  have hb_ne_zero : b ≠ 0 := ne_zero_of_pos_degree hb_pos
+  unfold basisSize
+  rw [← hab]
+  rw [FpPoly.degree?_mul_eq_add_degree? a b ha_ne_zero hb_ne_zero]
+  omega
 
 omit [ZMod64.PrimeModulus p] in
 /--
@@ -334,7 +386,7 @@ theorem rabinTest_imp_irreducible
   have hb_pos : 0 < b.degree?.getD 0 :=
     pos_degree_of_ne_zero_of_not_isUnit hb_ne_zero hb_unit
   have ha_lt : a.degree?.getD 0 < basisSize f :=
-    factor_degree_lt_basisSize hab hb_pos
+    factor_degree_lt_basisSize hab ha_ne_zero hb_pos
   -- Pick a monic irreducible factor `g` of `a`.
   obtain ⟨g, hg_irr, hg_monic, hg_dvd_a, hg_deg_pos, hg_deg_le_a⟩ :=
     exists_monic_irreducible_factor_of_factor hmonic hab ha_pos

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -1905,5 +1905,110 @@ theorem scale_mul_left (c : ZMod64 p) (f g : FpPoly p) :
   · simp [hn]
     rw [DensePoly.coeff_scale _ _ _ hzero]
     grind
+
+private theorem mulCoeffTerm_eq_zero_above_top
+    (f g : FpPoly p) {n i : Nat} (hi : i < f.size)
+    (hbound : f.size - 1 + (g.size - 1) < n) :
+    mulCoeffTerm f g n i = 0 := by
+  unfold mulCoeffTerm
+  have hni : ¬ n < i := by omega
+  have h_gi : g.size ≤ n - i := by omega
+  have hg_zero : g.coeff (n - i) = 0 :=
+    DensePoly.coeff_eq_zero_of_size_le g h_gi
+  simp [hni, hg_zero]
+  grind
+
+private theorem coeff_mul_eq_zero_above_top
+    (f g : FpPoly p) {n : Nat}
+    (hbound : f.size - 1 + (g.size - 1) < n) :
+    (f * g).coeff n = 0 := by
+  rw [coeff_mul]
+  unfold mulCoeffSum
+  have hfold : ∀ (xs : List Nat) (acc : ZMod64 p),
+      (∀ j ∈ xs, j < f.size) →
+      xs.foldl (fun acc i => acc + mulCoeffTerm f g n i) acc = acc := by
+    intro xs
+    induction xs with
+    | nil => intro acc _; rfl
+    | cons j xs ih =>
+        intro acc hxs
+        have hj : j < f.size := hxs j (by simp)
+        simp only [List.foldl_cons]
+        have hzero : mulCoeffTerm f g n j = 0 :=
+          mulCoeffTerm_eq_zero_above_top f g hj hbound
+        rw [hzero]
+        have hadd : acc + (0 : ZMod64 p) = acc := zmod_add_zero acc
+        rw [hadd]
+        exact ih acc (fun k hk => hxs k (by simp [hk]))
+  exact hfold (List.range f.size) 0 (fun j hj => List.mem_range.mp hj)
+
+/--
+Over a prime modulus, the degree of a product of nonzero polynomials in
+`FpPoly p` equals the sum of the degrees. This is the no-zero-divisors
+identity expressed at the level of `degree?.getD 0`.
+-/
+theorem degree?_mul_eq_add_degree?
+    [ZMod64.PrimeModulus p] (a b : FpPoly p)
+    (ha : a ≠ 0) (hb : b ≠ 0) :
+    (a * b).degree?.getD 0 = a.degree?.getD 0 + b.degree?.getD 0 := by
+  have ha_size_pos : 0 < a.size := by
+    apply Nat.pos_of_ne_zero
+    intro hsize
+    apply ha
+    apply DensePoly.ext_coeff
+    intro i
+    rw [DensePoly.coeff_zero]
+    exact DensePoly.coeff_eq_zero_of_size_le a (by omega)
+  have hb_size_pos : 0 < b.size := by
+    apply Nat.pos_of_ne_zero
+    intro hsize
+    apply hb
+    apply DensePoly.ext_coeff
+    intro i
+    rw [DensePoly.coeff_zero]
+    exact DensePoly.coeff_eq_zero_of_size_le b (by omega)
+  have ha_lead_ne : a.coeff (a.size - 1) ≠ 0 :=
+    DensePoly.coeff_last_ne_zero_of_pos_size a ha_size_pos
+  have hb_lead_ne : b.coeff (b.size - 1) ≠ 0 :=
+    DensePoly.coeff_last_ne_zero_of_pos_size b hb_size_pos
+  have hp_prime : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime
+  have hprod_ne : a.coeff (a.size - 1) * b.coeff (b.size - 1) ≠ 0 := by
+    intro hprod
+    rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp_prime hprod with hh | hh
+    · exact ha_lead_ne hh
+    · exact hb_lead_ne hh
+  have htop_ne : (a * b).coeff (a.size - 1 + (b.size - 1)) ≠ 0 := by
+    rw [ZMod64.coeff_mul_at_top a b ha_size_pos hb_size_pos]
+    exact hprod_ne
+  have hab_size_lower : a.size - 1 + (b.size - 1) < (a * b).size := by
+    rcases Nat.lt_or_ge (a.size - 1 + (b.size - 1)) (a * b).size with h | hle
+    · exact h
+    · exact False.elim (htop_ne (DensePoly.coeff_eq_zero_of_size_le _ hle))
+  have hab_size_upper : (a * b).size ≤ a.size + b.size - 1 := by
+    rcases Nat.lt_or_ge (a.size + b.size - 1) (a * b).size with hgt | hle
+    · exfalso
+      have hab_size_pos : 0 < (a * b).size := by omega
+      have hbound : a.size - 1 + (b.size - 1) < (a * b).size - 1 := by omega
+      have htop_zero : (a * b).coeff ((a * b).size - 1) = 0 :=
+        coeff_mul_eq_zero_above_top a b hbound
+      exact DensePoly.coeff_last_ne_zero_of_pos_size (a * b) hab_size_pos htop_zero
+    · exact hle
+  have hab_size : (a * b).size = a.size + b.size - 1 := by omega
+  have hab_size_ne_zero : (a * b).size ≠ 0 := by omega
+  have ha_size_ne_zero : a.size ≠ 0 := Nat.pos_iff_ne_zero.mp ha_size_pos
+  have hb_size_ne_zero : b.size ≠ 0 := Nat.pos_iff_ne_zero.mp hb_size_pos
+  have hab_deg : (a * b).degree? = some ((a * b).size - 1) := by
+    unfold DensePoly.degree?
+    simp [hab_size_ne_zero]
+  have ha_deg : a.degree? = some (a.size - 1) := by
+    unfold DensePoly.degree?
+    simp [ha_size_ne_zero]
+  have hb_deg : b.degree? = some (b.size - 1) := by
+    unfold DensePoly.degree?
+    simp [hb_size_ne_zero]
+  rw [hab_deg, ha_deg, hb_deg]
+  simp
+  omega
+
 end FpPoly
 end Hex

--- a/progress/20260505T044822Z_ee7f77ac.md
+++ b/progress/20260505T044822Z_ee7f77ac.md
@@ -1,0 +1,62 @@
+# 2026-05-05 04:48 UTC — feature session (ee7f77ac)
+
+## Accomplished
+
+Discharged the two degree-arithmetic sorries in
+`HexBerlekamp/RabinSoundness.lean` (issue #2272):
+
+- **`FpPoly.degree?_mul_eq_add_degree?`** (new public theorem in
+  `HexPolyFp/Basic.lean`): for nonzero `a, b : FpPoly p` over a prime
+  modulus, `(a * b).degree?.getD 0 = a.degree?.getD 0 + b.degree?.getD 0`.
+  Proved via the existing `ZMod64.coeff_mul_at_top` (leading
+  coefficient is the product of leading coefficients) plus a new
+  private helper `coeff_mul_eq_zero_above_top` (above the leading
+  exponent the schoolbook fold collapses term-by-term to zero
+  because the right factor's coefficient is out of range). The
+  no-zero-divisors step uses the existing
+  `ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero`.
+
+- **`isUnitPolynomial_of_dvd_isUnitPolynomial`** (`RabinSoundness.lean`):
+  unfolds the `match` form of `isUnitPolynomial h = true` to
+  `h.degree? = some 0`, derives `h ≠ 0`, splits `h = g * r`,
+  derives `g ≠ 0` and `r ≠ 0` from `FpPoly.zero_mul`/`mul_zero`,
+  applies the new product-degree identity to get
+  `0 = deg g + deg r`, hence `deg g = 0` and (with `g ≠ 0`)
+  `g.degree? = some 0`.
+
+- **`factor_degree_lt_basisSize`** (`RabinSoundness.lean`): now takes
+  an extra `ha_ne_zero : a ≠ 0` hypothesis (the original signature was
+  unprovable when `a = 0`, since then `f = 0` and the conclusion
+  `0 < 0` is false). Updated the single call site in
+  `rabinTest_imp_irreducible` to pass `ha_ne_zero`, which is already
+  in scope from `factor_ne_zero_of_ne_zero`. Proof reduces directly to
+  the product-degree identity plus omega.
+
+## Implementation note
+
+`degree?_mul_eq_add_degree?` lives on `Hex.FpPoly` and references the
+private `Hex.ZMod64.coeff_mul_at_top` from earlier in the same file.
+The size-bounding helper `coeff_mul_eq_zero_above_top` is also private
+since it's only used to prove `degree?_mul_eq_add_degree?`.
+
+The `factor_degree_lt_basisSize` signature change is contained: the
+single internal caller (`rabinTest_imp_irreducible`) had `ha_ne_zero`
+available locally. No external callers exist.
+
+## Current frontier
+
+Issue #2272 fully closed. Two sorries removed, zero added.
+`HexBerlekamp/RabinSoundness.lean` still has 7 sorries, all belonging
+to sibling foundational issues (#2266, #2267, #2269, #2270, #2271,
+#2266 again).
+
+## Next step
+
+Other workers can claim the sibling Rabin-foundation issues
+(#2266, #2267, #2269, #2270 — #2271 was already claimed when this
+session started). The Rabin bridge proof orchestration in
+`rabinTest_imp_irreducible` is now waiting only on those.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2272

Session: `ee7f77ac-1593-4307-8227-43cab9730673`

c0bb349 chore: progress entry for ee7f77ac feature session
fe40683 feat: discharge isUnitPolynomial_of_dvd and factor_degree_lt_basisSize sorries
4a20aba feat: prove FpPoly.degree?_mul_eq_add_degree? for the Rabin soundness bridge

🤖 Prepared with Claude Code