### PR TITLE
HexBerlekamp: bridge xPowSubX divisibility to frobeniusDiffMod isZero

### DIFF
--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -40,6 +40,83 @@ follow-up issues. Every other declaration in this file is a small
 orchestration step on top of them. -/
 
 /--
+Trivial case for `deg f = 0`: `frobeniusDiffMod` is already its own
+canonical remainder modulo `f`. When `deg f = 0` and `f` is monic, `f`
+must have size 1 (since `Monic 0` is impossible over a prime field), and
+every polynomial mod a degree-0 monic divisor is `0`; `frobeniusDiffMod`
+is no exception, so both sides reduce to `0`.
+-/
+theorem frobeniusDiffMod_mod_self_of_degree_zero
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) (k : Nat)
+    (hdeg : ¬ 0 < f.degree?.getD 0) :
+    (frobeniusDiffMod f hmonic k) % f = frobeniusDiffMod f hmonic k := by
+  -- f.size ≥ 1 (Monic excludes f = 0).
+  have hf_size_pos : 0 < f.size := by
+    apply Nat.pos_of_ne_zero
+    intro hfsize
+    have hfzero : f = 0 := by
+      apply DensePoly.ext_coeff
+      intro i; rw [DensePoly.coeff_zero]
+      exact DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    rw [hfzero] at hmonic
+    have h0lead : (0 : FpPoly p).leadingCoeff = 0 := by
+      change (0 : FpPoly p).coeffs.back?.getD 0 = 0
+      have hcoeffs : (0 : FpPoly p).coeffs = #[] := rfl
+      rw [hcoeffs]; rfl
+    unfold DensePoly.Monic at hmonic
+    rw [h0lead] at hmonic
+    -- hmonic : (0 : ZMod64 p) = 1, contradiction in a prime field.
+    have h2 : 2 ≤ p := Hex.Nat.Prime.two_le ZMod64.PrimeModulus.prime
+    have htoNat0 : (0 : ZMod64 p).toNat = 0 := ZMod64.toNat_zero
+    have htoNat1 : (1 : ZMod64 p).toNat = 1 := by
+      change (ZMod64.natCast p 1).toNat = 1
+      rw [ZMod64.toNat_natCast]
+      exact Nat.one_mod_eq_one.mpr (by omega)
+    have htoNat : (0 : ZMod64 p).toNat = (1 : ZMod64 p).toNat :=
+      congrArg ZMod64.toNat hmonic
+    rw [htoNat0, htoNat1] at htoNat
+    omega
+  -- f.size = 1.
+  have hf_size : f.size = 1 := by
+    unfold DensePoly.degree? at hdeg
+    have hne : f.size ≠ 0 := Nat.pos_iff_ne_zero.mp hf_size_pos
+    simp [hne] at hdeg
+    omega
+  -- The cancellation property holds: a - (a / 1) * 1 = a - a = 0.
+  have hcancel :
+      ∀ a : ZMod64 p, a - (a / f.leadingCoeff) * f.leadingCoeff = (Zero.zero : ZMod64 p) := by
+    intro a
+    have hlead : f.leadingCoeff = (1 : ZMod64 p) := hmonic
+    rw [hlead]
+    have ha_div : a / (1 : ZMod64 p) = a := ZMod64.zmod_div_one a
+    rw [ha_div]
+    show a - a * 1 = (Zero.zero : ZMod64 p)
+    have h_a_mul_one : a * (1 : ZMod64 p) = a := Lean.Grind.Semiring.mul_one a
+    rw [h_a_mul_one]
+    show a - a = (Zero.zero : ZMod64 p)
+    have hzero_eq : (Zero.zero : ZMod64 p) = 0 := rfl
+    rw [hzero_eq]
+    grind
+  -- For any p, p % f = 0 (since f has size 1 and the cancellation holds).
+  have hmod_zero : ∀ q : FpPoly p, q % f = 0 := by
+    intro q
+    show (DensePoly.divMod q f).2 = 0
+    exact DensePoly.divMod_remainder_eq_zero_of_degree_zero_core q f hf_size hcancel
+  -- Show frobeniusDiffMod = 0.
+  have hfrob_zero : FpPoly.frobeniusXPowMod f hmonic k = 0 := by
+    have h := hmod_zero (FpPoly.frobeniusXPowMod f hmonic k)
+    rw [FpPoly.frobeniusXPowMod_mod_self] at h
+    exact h
+  have hX_zero : FpPoly.modByMonic f FpPoly.X hmonic = 0 := by
+    rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+          DensePoly.modByMonic_eq_mod _ _ hmonic]
+    exact hmod_zero _
+  have hdiff_zero : frobeniusDiffMod f hmonic k = 0 := by
+    unfold frobeniusDiffMod
+    rw [hfrob_zero, hX_zero, FpPoly.sub_self]
+  rw [hdiff_zero, hmod_zero]
+
+/--
 `f` divides `X^(p^k) - X` (in the absolute sense) exactly when the
 Berlekamp Frobenius remainder `frobeniusDiffMod f hmonic k` vanishes.
 
@@ -51,7 +128,151 @@ remainder used by the executable `rabinTest`. The proof goes through
 theorem dvd_xPowSubX_iff_frobeniusDiffMod_isZero
     (f : FpPoly p) (hmonic : DensePoly.Monic f) (k : Nat) :
     f ∣ xPowSubX (p := p) k ↔ (frobeniusDiffMod f hmonic k).isZero = true := by
-  sorry
+  have inst_dvd : DensePoly.DivModLaws (ZMod64 p) := inferInstance
+  -- Helper 1: f ∣ q ↔ q % f = 0.
+  have hdvd_iff_mod : ∀ q : FpPoly p, f ∣ q ↔ q % f = 0 := fun q => by
+    refine ⟨DensePoly.mod_eq_zero_of_dvd q f, ?_⟩
+    intro hmod
+    refine ⟨q / f, ?_⟩
+    have h := DensePoly.div_mul_add_mod q f
+    rw [hmod, FpPoly.add_zero, FpPoly.mul_comm] at h
+    exact h.symm
+  -- Helper 2: q.isZero = true ↔ q = 0.
+  have hisZero_iff_eq : ∀ q : FpPoly p, q.isZero = true ↔ q = 0 := fun q => by
+    refine ⟨?_, ?_⟩
+    · intro h
+      apply DensePoly.ext_coeff
+      intro i
+      have hsize : q.size = 0 := by
+        simpa [DensePoly.isZero, DensePoly.size, Array.isEmpty_iff_size_eq_zero] using h
+      rw [DensePoly.coeff_zero]
+      exact DensePoly.coeff_eq_zero_of_size_le q (by omega)
+    · intro h
+      subst h
+      rfl
+  -- Step 1: f ∣ ((xPowSubX k) - frobeniusDiffMod).
+  have hdvd_diff : f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    have hp1 : f ∣ ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+                    FpPoly.frobeniusXPowMod f hmonic k) :=
+      @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _
+        (FpPoly.frobeniusXPowMod_mod_eq_monomial_mod f hmonic k).symm
+    have hp2 : f ∣ (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+            DensePoly.modByMonic_eq_mod _ _ hmonic]
+      have hmm : (FpPoly.X (p := p)) % f = (FpPoly.X (p := p) % f) % f :=
+        (DensePoly.mod_mod FpPoly.X f).symm
+      exact @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _ hmm
+    have heq :
+        xPowSubX (p := p) k - frobeniusDiffMod f hmonic k =
+          ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+              FpPoly.frobeniusXPowMod f hmonic k) -
+            (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      unfold xPowSubX frobeniusDiffMod
+      apply DensePoly.ext_coeff
+      intro n
+      have hzero_sub : ((0 : ZMod64 p) - 0) = 0 := by grind
+      rw [DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub]
+      grind
+    rw [heq]
+    exact DensePoly.dvd_sub_poly hp1 hp2
+  -- Step 2: (xPowSubX k) % f = (frobeniusDiffMod) % f.
+  have hmodeq : (xPowSubX (p := p) k) % f = (frobeniusDiffMod f hmonic k) % f :=
+    @DensePoly.mod_eq_mod_of_congr (ZMod64 p) _ _ _ inst_dvd _ _ _ hdvd_diff
+  -- Step 3: frobeniusDiffMod % f = frobeniusDiffMod.
+  -- Two cases: 0 < deg f or deg f = 0 (so f = 1, frobeniusDiffMod = 0).
+  have hreduced : (frobeniusDiffMod f hmonic k) % f = frobeniusDiffMod f hmonic k := by
+    by_cases hdeg : 0 < f.degree?.getD 0
+    · -- 0 < deg f: show frobeniusDiffMod is reduced via coefficient bound.
+      apply DensePoly.mod_eq_self_of_degree_lt
+      -- Need: (frobeniusDiffMod).degree?.getD 0 < f.degree?.getD 0.
+      -- Both frobeniusXPowMod and modByMonic f X hmonic have degree < f.degree.
+      have hfrob_deg : (FpPoly.frobeniusXPowMod f hmonic k).degree?.getD 0 <
+          f.degree?.getD 0 := by
+        rw [← FpPoly.frobeniusXPowMod_mod_self f hmonic k]
+        exact DensePoly.mod_degree_lt_of_pos_degree _ _ hdeg
+      have hX_deg : (FpPoly.modByMonic f FpPoly.X hmonic).degree?.getD 0 <
+          f.degree?.getD 0 := by
+        rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+              DensePoly.modByMonic_eq_mod _ _ hmonic]
+        exact DensePoly.mod_degree_lt_of_pos_degree _ _ hdeg
+      -- Coefficient bound: for i ≥ f.size, (frobeniusDiffMod).coeff i = 0.
+      have hf_size_pos : 0 < f.size := by
+        apply Nat.pos_of_ne_zero
+        intro hfsize
+        unfold DensePoly.degree? at hdeg
+        simp [hfsize] at hdeg
+      have hf_deg_eq : f.degree?.getD 0 = f.size - 1 := by
+        unfold DensePoly.degree?
+        simp [Nat.ne_of_gt hf_size_pos]
+      -- Convert hfrob_deg to a size bound.
+      have hfrob_size : (FpPoly.frobeniusXPowMod f hmonic k).size ≤ f.size - 1 := by
+        rw [hf_deg_eq] at hfrob_deg
+        by_cases hsize : (FpPoly.frobeniusXPowMod f hmonic k).size = 0
+        · omega
+        · have hdeg' :
+              (FpPoly.frobeniusXPowMod f hmonic k).degree?.getD 0 =
+                (FpPoly.frobeniusXPowMod f hmonic k).size - 1 := by
+            unfold DensePoly.degree?; simp [hsize]
+          rw [hdeg'] at hfrob_deg
+          omega
+      have hX_size : (FpPoly.modByMonic f FpPoly.X hmonic).size ≤ f.size - 1 := by
+        rw [hf_deg_eq] at hX_deg
+        by_cases hsize : (FpPoly.modByMonic f FpPoly.X hmonic).size = 0
+        · omega
+        · have hdeg' :
+              (FpPoly.modByMonic f FpPoly.X hmonic).degree?.getD 0 =
+                (FpPoly.modByMonic f FpPoly.X hmonic).size - 1 := by
+            unfold DensePoly.degree?; simp [hsize]
+          rw [hdeg'] at hX_deg
+          omega
+      have hcoeff_zero :
+          ∀ i, f.size - 1 ≤ i → (frobeniusDiffMod f hmonic k).coeff i = 0 := by
+        intro i hi
+        unfold frobeniusDiffMod
+        have hzero_sub : ((0 : ZMod64 p) - 0) = 0 := by grind
+        rw [DensePoly.coeff_sub _ _ _ hzero_sub]
+        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i)]
+        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i)]
+        grind
+      -- Conclude: (frobeniusDiffMod).size ≤ f.size - 1.
+      have hdiff_size : (frobeniusDiffMod f hmonic k).size ≤ f.size - 1 := by
+        rcases Nat.lt_or_ge (f.size - 1) (frobeniusDiffMod f hmonic k).size with hcontra | hle
+        · exfalso
+          have hi : f.size - 1 ≤ (frobeniusDiffMod f hmonic k).size - 1 := by omega
+          have hc :=
+            DensePoly.coeff_last_ne_zero_of_pos_size (frobeniusDiffMod f hmonic k)
+              (by omega)
+          exact hc (hcoeff_zero _ hi)
+        · exact hle
+      -- Translate back to degree.
+      by_cases hsize : (frobeniusDiffMod f hmonic k).size = 0
+      · -- frobeniusDiffMod = 0 case: degree = 0 < f.degree.
+        have hdeg_zero :
+            (frobeniusDiffMod f hmonic k).degree?.getD 0 = 0 := by
+          unfold DensePoly.degree?
+          simp [hsize]
+        rw [hdeg_zero]
+        exact hdeg
+      · -- size > 0: degree = size - 1 ≤ f.size - 2 < f.size - 1 = f.degree.
+        have hdeg_eq :
+            (frobeniusDiffMod f hmonic k).degree?.getD 0 =
+              (frobeniusDiffMod f hmonic k).size - 1 := by
+          unfold DensePoly.degree?
+          simp [hsize]
+        rw [hdeg_eq, hf_deg_eq]
+        omega
+    · -- deg f = 0. We use the absolute identity: f = monomial 0 1 (since Monic + size 1).
+      -- This case is the trivial one where f is the constant polynomial 1.
+      -- Discharged via the `f = 1` lemma, which is itself a clean foundational fact.
+      exact frobeniusDiffMod_mod_self_of_degree_zero f hmonic k hdeg
+  -- Chain: f ∣ xPowSubX k ↔ (xPowSubX k) % f = 0 ↔ frobeniusDiffMod % f = 0
+  --                       ↔ frobeniusDiffMod = 0 ↔ isZero = true.
+  rw [hdvd_iff_mod, hmodeq, hreduced, hisZero_iff_eq]
 
 omit [ZMod64.PrimeModulus p] in
 /--
@@ -155,10 +376,59 @@ with the `divMod_spec` characterization of polynomial remainders.
 -/
 theorem dvd_frobeniusDiffMod_of_dvd_dvd
     {f g : FpPoly p} (hmonic : DensePoly.Monic f)
-    (_hg_dvd_f : g ∣ f) {k : Nat}
-    (_hg_dvd_pow : g ∣ xPowSubX (p := p) k) :
+    (hg_dvd_f : g ∣ f) {k : Nat}
+    (hg_dvd_pow : g ∣ xPowSubX (p := p) k) :
     g ∣ frobeniusDiffMod f hmonic k := by
-  sorry
+  have inst_dvd : DensePoly.DivModLaws (ZMod64 p) := inferInstance
+  -- Step 1: f ∣ ((xPowSubX k) - frobeniusDiffMod), reusing the algebra from the iff proof.
+  have hdvd_diff : f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    have hp1 : f ∣ ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+                    FpPoly.frobeniusXPowMod f hmonic k) :=
+      @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _
+        (FpPoly.frobeniusXPowMod_mod_eq_monomial_mod f hmonic k).symm
+    have hp2 : f ∣ (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+            DensePoly.modByMonic_eq_mod _ _ hmonic]
+      have hmm : (FpPoly.X (p := p)) % f = (FpPoly.X (p := p) % f) % f :=
+        (DensePoly.mod_mod FpPoly.X f).symm
+      exact @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _ hmm
+    have heq :
+        xPowSubX (p := p) k - frobeniusDiffMod f hmonic k =
+          ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+              FpPoly.frobeniusXPowMod f hmonic k) -
+            (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      unfold xPowSubX frobeniusDiffMod
+      apply DensePoly.ext_coeff
+      intro n
+      have hzero_sub : ((0 : ZMod64 p) - 0) = 0 := by grind
+      rw [DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub,
+          DensePoly.coeff_sub _ _ _ hzero_sub]
+      grind
+    rw [heq]
+    exact DensePoly.dvd_sub_poly hp1 hp2
+  -- Step 2: g ∣ (xPowSubX k - frobeniusDiffMod) since g ∣ f and f ∣ ...
+  have hg_dvd_diff : g ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    rcases hdvd_diff with ⟨c, hc⟩
+    rcases hg_dvd_f with ⟨d, hd⟩
+    refine ⟨d * c, ?_⟩
+    rw [hc, hd, FpPoly.mul_assoc]
+  -- Step 3: g ∣ frobeniusDiffMod from g ∣ xPowSubX k and g ∣ (xPowSubX k - frobeniusDiffMod).
+  -- Specifically, frobeniusDiffMod = xPowSubX k - (xPowSubX k - frobeniusDiffMod).
+  have hgoal :
+      frobeniusDiffMod f hmonic k =
+        xPowSubX (p := p) k - (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    apply DensePoly.ext_coeff
+    intro n
+    have hzero_sub : ((0 : ZMod64 p) - 0) = 0 := by grind
+    rw [DensePoly.coeff_sub _ _ _ hzero_sub,
+        DensePoly.coeff_sub _ _ _ hzero_sub]
+    grind
+  rw [hgoal]
+  exact DensePoly.dvd_sub_poly hg_dvd_pow hg_dvd_diff
 
 /--
 A divisor of a unit polynomial is itself a unit polynomial.

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -2071,6 +2071,97 @@ theorem mul_one_right_poly {S : Type _}
   rw [coeff_mul, mulCoeffSum_eq_diagonal]
   exact fold_diagonal_one_right p n
 
+/-- Product of two monomials: `xⁱ * cⱼ * xʲ = cᵢcⱼ * xⁱ⁺ʲ`. -/
+theorem monomial_mul_monomial {S : Type _}
+    [Lean.Grind.CommRing S] [DecidableEq S]
+    (m k : Nat) (c d : S) :
+    (monomial m c) * (monomial k d) = monomial (m + k) (c * d) := by
+  apply ext_coeff
+  intro n
+  rw [coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound]
+  rw [coeff_monomial]
+  have hterm : ∀ i,
+      diagonalMulCoeffTerm (monomial m c) (monomial k d) n i =
+        if i = m ∧ n = m + k then c * d else 0 := by
+    intro i
+    unfold diagonalMulCoeffTerm
+    rw [coeff_monomial, coeff_monomial]
+    by_cases hni : n < i
+    · have hcond : ¬ (i = m ∧ n = m + k) := by
+        intro ⟨h1, h2⟩; omega
+      rw [if_pos hni, if_neg hcond]
+    · have hile : i ≤ n := Nat.le_of_not_gt hni
+      rw [if_neg hni]
+      by_cases him : i = m
+      · subst i
+        rw [if_pos rfl]
+        by_cases hnmk : n - m = k
+        · have hn : n = m + k := by omega
+          rw [if_pos hnmk]
+          simp [hn]
+        · have hn : n ≠ m + k := by omega
+          rw [if_neg hnmk]
+          have hcond : ¬ (m = m ∧ n = m + k) := fun ⟨_, h⟩ => hn h
+          rw [if_neg hcond]
+          -- c * Zero.zero = 0.
+          show c * (Zero.zero : S) = 0
+          have : (Zero.zero : S) = 0 := rfl
+          rw [this]
+          grind
+      · rw [if_neg him]
+        have hcond : ¬ (i = m ∧ n = m + k) := fun ⟨h, _⟩ => him h
+        rw [if_neg hcond]
+        -- Zero.zero * anything = 0.
+        exact Lean.Grind.Semiring.zero_mul _
+  have hfold : ∀ (xs : List Nat) (acc : S),
+      xs.foldl (fun acc i =>
+          acc + diagonalMulCoeffTerm (monomial m c) (monomial k d) n i) acc =
+        xs.foldl (fun acc i =>
+          acc + if i = m ∧ n = m + k then c * d else 0) acc := by
+    intro xs
+    induction xs with
+    | nil => intro acc; rfl
+    | cons i xs ih =>
+        intro acc
+        simp only [List.foldl_cons]
+        rw [hterm i]
+        exact ih _
+  rw [hfold (List.range (n + 1)) 0]
+  by_cases hnmk : n = m + k
+  · have hsimp : ∀ i,
+        (if i = m ∧ n = m + k then c * d else 0) =
+          (if i = m then c * d else 0) := fun i => by simp [hnmk]
+    have hfold2 : ∀ (xs : List Nat) (acc : S),
+        xs.foldl (fun acc i => acc + if i = m ∧ n = m + k then c * d else 0) acc =
+          xs.foldl (fun acc i => acc + if i = m then c * d else 0) acc := by
+      intro xs
+      induction xs with
+      | nil => intro acc; rfl
+      | cons i xs ih =>
+          intro acc
+          simp only [List.foldl_cons]
+          rw [hsimp i]
+          exact ih _
+    rw [hfold2 (List.range (n + 1)) 0]
+    rw [fold_single_index]
+    have hm_lt : m < n + 1 := by omega
+    rw [if_pos hm_lt, if_pos hnmk]
+  · have hzero_fold : ∀ (xs : List Nat) (acc : S),
+        xs.foldl (fun acc i => acc + if i = m ∧ n = m + k then c * d else 0) acc = acc := by
+      intro xs
+      induction xs with
+      | nil => intro acc; rfl
+      | cons i xs ih =>
+          intro acc
+          simp only [List.foldl_cons]
+          have hcond : ¬ (i = m ∧ n = m + k) := fun ⟨_, h⟩ => hnmk h
+          rw [if_neg hcond]
+          rw [show acc + (0 : S) = acc by grind]
+          exact ih _
+    rw [hzero_fold]
+    rw [if_neg hnmk]
+    rfl
+
 theorem neg_mul_right_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p q : DensePoly S) :
@@ -2267,19 +2358,19 @@ private theorem degree_getD_lt_size_add_one {S : Type _} [Zero S] [DecidableEq S
       simp [degree?, hsize]
     omega
 
-private theorem dvd_refl_poly {S : Type _}
+theorem dvd_refl_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
     p ∣ p := by
   exact ⟨1, (mul_one_right_poly p).symm⟩
 
-private theorem dvd_zero_poly {S : Type _}
+theorem dvd_zero_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
     p ∣ 0 := by
   exact ⟨0, by rw [mul_comm_poly p 0, zero_mul]⟩
 
-private theorem dvd_mul_left_poly {S : Type _}
+theorem dvd_mul_left_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     {d p : DensePoly S} (q : DensePoly S) :
     d ∣ p → d ∣ q * p := by
@@ -2288,7 +2379,7 @@ private theorem dvd_mul_left_poly {S : Type _}
   refine ⟨q * a, ?_⟩
   rw [ha, ← mul_assoc_poly q d a, mul_comm_poly q d, mul_assoc_poly d q a]
 
-private theorem dvd_add_poly {S : Type _}
+theorem dvd_add_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     {d p q : DensePoly S} :
     d ∣ p → d ∣ q → d ∣ p + q := by
@@ -2298,7 +2389,7 @@ private theorem dvd_add_poly {S : Type _}
   refine ⟨a + b, ?_⟩
   rw [ha, hb, mul_add_right_poly]
 
-private theorem dvd_sub_poly {S : Type _}
+theorem dvd_sub_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     {d p q : DensePoly S} :
     d ∣ p → d ∣ q → d ∣ p - q := by
@@ -3055,6 +3146,42 @@ theorem mod_eq_mod_of_congr {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S]
     {p q m : DensePoly S} :
     Congr p q m -> p % m = q % m := by
   exact mod_eq_mod_of_dvd_sub
+
+/-- Reverse direction of `mod_eq_mod_of_congr`: equal canonical remainders force the
+operands to be congruent modulo the divisor. -/
+theorem dvd_of_mod_eq_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
+    [DivModLaws S]
+    {p q m : DensePoly S} (h : p % m = q % m) :
+    m ∣ (p - q) := by
+  refine ⟨(p / m) - (q / m), ?_⟩
+  apply ext_coeff
+  intro n
+  have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
+  have hzero_add : (0 : S) + (0 : S) = 0 := by grind
+  have hp := congrArg (fun x : DensePoly S => x.coeff n) (div_mul_add_mod p m)
+  have hq := congrArg (fun x : DensePoly S => x.coeff n) (div_mul_add_mod q m)
+  have hh := congrArg (fun x : DensePoly S => x.coeff n) h
+  change ((p / m) * m + (p % m)).coeff n = p.coeff n at hp
+  change ((q / m) * m + (q % m)).coeff n = q.coeff n at hq
+  change (p % m).coeff n = (q % m).coeff n at hh
+  rw [coeff_add ((p / m) * m) (p % m) n hzero_add] at hp
+  rw [coeff_add ((q / m) * m) (q % m) n hzero_add] at hq
+  rw [coeff_sub p q n hzero_sub]
+  -- Reduce m * ((p/m) - (q/m)) via mul_sub_zero_comm-style manipulation.
+  have hgoal :
+      (m * ((p / m) - (q / m))).coeff n =
+        ((p / m) * m).coeff n - ((q / m) * m).coeff n := by
+    rw [show m * ((p / m) - (q / m)) = (p / m) * m + (0 - (q / m) * m) from ?_]
+    · rw [coeff_add ((p / m) * m) (0 - (q / m) * m) n hzero_add]
+      rw [coeff_sub 0 ((q / m) * m) n hzero_sub, coeff_zero]
+      grind
+    · -- m * (a - b) = a * m + (0 - b * m), via sub_eq_add_neg + mul_sub_zero_comm + mul_comm.
+      rw [sub_eq_add_neg_poly]
+      rw [mul_add_right_poly]
+      rw [mul_sub_zero_comm m (q / m)]
+      rw [mul_comm_poly m (p / m)]
+  rw [hgoal]
+  grind
 
 /-- Reducing both summands before addition preserves the canonical remainder. -/
 theorem mod_add_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -599,7 +599,7 @@ private theorem zmod_one_ne_zero [PrimeModulus p] :
       Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
   exact absurd htoNat (by omega)
 
-private theorem zmod_div_one [PrimeModulus p] (a : ZMod64 p) :
+theorem zmod_div_one [PrimeModulus p] (a : ZMod64 p) :
     a / (1 : ZMod64 p) = a := by
   have h1ne : (1 : ZMod64 p) ≠ 0 := zmod_one_ne_zero
   have hinv : ZMod64.inv (1 : ZMod64 p) * 1 = 1 :=

--- a/HexPolyFp/Frobenius.lean
+++ b/HexPolyFp/Frobenius.lean
@@ -325,5 +325,53 @@ theorem frobeniusXPowMod_succ
   rw [show (p : Nat) * p ^ k = p ^ (k + 1) from by
         rw [Nat.pow_succ]; exact Nat.mul_comm _ _]
 
+/-! ### Bridge to the absolute monomial
+
+Connect `frobeniusXPowMod` to the absolute polynomial `X^(p^k)` via
+`monomial (p^k) 1`, modulo `f`. This is consumed by the project-side
+Rabin soundness bridge in `HexBerlekamp.RabinSoundness`. -/
+
+private theorem powLinear_X_eq_monomial (n : Nat) :
+    powLinear (FpPoly.X (p := p)) n = DensePoly.monomial n (1 : ZMod64 p) := by
+  induction n with
+  | zero =>
+      show (1 : FpPoly p) = DensePoly.monomial 0 (1 : ZMod64 p)
+      apply DensePoly.ext_coeff
+      intro i
+      show (DensePoly.C (1 : ZMod64 p)).coeff i =
+        (DensePoly.monomial 0 (1 : ZMod64 p)).coeff i
+      rw [DensePoly.coeff_C, DensePoly.coeff_monomial]
+  | succ n ih =>
+      have hX : (FpPoly.X (p := p)) = DensePoly.monomial 1 (1 : ZMod64 p) := rfl
+      rw [powLinear_succ, ih, hX]
+      have hmm := DensePoly.monomial_mul_monomial (S := ZMod64 p) n 1 (1 : ZMod64 p) 1
+      have h1 : ((1 : ZMod64 p) * 1) = 1 := by grind
+      rw [h1] at hmm
+      exact hmm
+
+/--
+`frobeniusXPowMod f hmonic k` reduces modulo `f` to the absolute monomial
+`X^(p^k)` reduced modulo `f`. This is the key bridge between the executable
+Frobenius computation and the absolute polynomial identity it represents.
+-/
+theorem frobeniusXPowMod_mod_eq_monomial_mod
+    [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) (k : Nat) :
+    (frobeniusXPowMod f hmonic k) % f =
+      (DensePoly.monomial (p ^ k) (1 : ZMod64 p)) % f := by
+  unfold frobeniusXPowMod
+  rw [powModMonic_mod_eq, powLinear_X_eq_monomial]
+
+/-- `frobeniusXPowMod` outputs an already-reduced polynomial. -/
+theorem frobeniusXPowMod_mod_self
+    [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) (k : Nat) :
+    (frobeniusXPowMod f hmonic k) % f = frobeniusXPowMod f hmonic k := by
+  have hp_pos : 0 < p := by
+    have h2 : 2 ≤ p := Hex.Nat.Prime.two_le ZMod64.PrimeModulus.prime
+    omega
+  unfold frobeniusXPowMod
+  exact powModMonic_pos_self_mod _ _ hmonic _ (Nat.pow_pos hp_pos)
+
 end FpPoly
 end Hex

--- a/progress/20260505T053139Z_8f4b5889.md
+++ b/progress/20260505T053139Z_8f4b5889.md
@@ -1,0 +1,53 @@
+# Progress 2026-05-05 (#2266)
+
+## Accomplished
+
+Discharged both sorried theorems in `HexBerlekamp/RabinSoundness.lean`
+that were the deliverables of #2266:
+
+- `dvd_xPowSubX_iff_frobeniusDiffMod_isZero`: bridges absolute
+  divisibility `f ∣ X^(p^k) - X` to the modular Frobenius remainder
+  vanishing predicate `(frobeniusDiffMod f hmonic k).isZero = true`.
+  Handles both `0 < deg f` (via degree reduction of the difference) and
+  `deg f = 0` (via a small helper that derives `frobeniusDiffMod = 0`).
+- `dvd_frobeniusDiffMod_of_dvd_dvd`: routes `g ∣ f` and
+  `g ∣ xPowSubX k` through the modular bridge to conclude
+  `g ∣ frobeniusDiffMod f hmonic k`.
+
+Added supporting public infrastructure:
+
+- `DensePoly.monomial_mul_monomial` in `HexPoly/Euclid.lean`: the
+  standard monomial product `monomial m c * monomial k d =
+  monomial (m + k) (c * d)`.
+- `FpPoly.frobeniusXPowMod_mod_eq_monomial_mod` in
+  `HexPolyFp/Frobenius.lean`: `frobeniusXPowMod f hmonic k % f =
+  monomial (p^k) 1 % f`. Uses a private helper
+  `powLinear_X_eq_monomial`.
+- `FpPoly.frobeniusXPowMod_mod_self`: `frobeniusXPowMod` is reduced.
+- `DensePoly.dvd_of_mod_eq_mod`: reverse direction of
+  `mod_eq_mod_of_congr` (`p % m = q % m → m ∣ (p - q)`).
+- Made `dvd_refl_poly`, `dvd_zero_poly`, `dvd_mul_left_poly`,
+  `dvd_add_poly`, `dvd_sub_poly` public (were private).
+- Made `ZMod64.zmod_div_one` public.
+- Local helper `frobeniusDiffMod_mod_self_of_degree_zero` for the
+  trivial `deg f = 0` case in `HexBerlekamp/RabinSoundness.lean`.
+
+## Current frontier
+
+Both deliverables of #2266 are discharged with no new sorries. Five
+foundational sorries in `HexBerlekamp/RabinSoundness.lean` remain
+(belong to other open issues #2267, #2269, #2270, etc.).
+
+## Next step
+
+- Push branch and create PR closing #2266.
+
+## Blockers
+
+None. The `dvd_of_mod_eq_mod` and similar helpers required passing
+the `DivModLaws (ZMod64 p)` instance explicitly via `@`-syntax —
+typeclass synthesis fails without the explicit instance, possibly
+because the existing `instDivModLawsZMod64Fp` declares `(p : Nat)` as
+an explicit (rather than implicit) parameter. Worked around with an
+explicit `inferInstance` binding in each consumer. Could be a future
+cleanup target.


### PR DESCRIPTION
Closes #2266

Session: `8f4b5889-c65a-4c94-8fc0-44d98808006b`

7f7a42a feat: discharge dvd_xPowSubX iff and dvd_frobeniusDiffMod for #2266
8cf07e2 feat: monomial_mul_monomial + frobeniusXPowMod monomial bridge

🤖 Prepared with Claude Code