### PR TITLE
HexMatrix: add prefix insertion inversion helper

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -991,6 +991,85 @@ private theorem inversionCount_insert_last_castSucc {n : Nat} (xs : List (Fin n)
       rw [inversionFold_map_castSucc]
       simp [Fin.lt_def]
 
+private theorem foldl_insertIdx_last_castSucc_not_lt {n : Nat} (xs : List (Fin n))
+    (x : Fin n) (p acc : Nat) :
+    ((xs.map Fin.castSucc).insertIdx p (Fin.last n)).foldl
+        (fun acc y => acc + if y < x.castSucc then 1 else 0) acc =
+      (xs.map Fin.castSucc).foldl
+        (fun acc y => acc + if y < x.castSucc then 1 else 0) acc := by
+  induction xs generalizing p acc with
+  | nil =>
+      cases p <;> simp [List.insertIdx, Fin.lt_def]
+  | cons y ys ih =>
+      cases p with
+      | zero =>
+          have hnlt : ¬ n < x.val := by omega
+          simp [List.insertIdx, Fin.lt_def, hnlt]
+      | succ p =>
+          simp only [List.map_cons]
+          rw [List.insertIdx, List.modifyTailIdx_succ_cons]
+          simp only [List.foldl_cons]
+          change
+            ((ys.map Fin.castSucc).insertIdx p (Fin.last n)).foldl
+                (fun acc y => acc + if y < x.castSucc then 1 else 0)
+                (acc + if y.castSucc < x.castSucc then 1 else 0) =
+              (ys.map Fin.castSucc).foldl
+                (fun acc y => acc + if y < x.castSucc then 1 else 0)
+                (acc + if y.castSucc < x.castSucc then 1 else 0)
+          rw [ih p (acc + if y.castSucc < x.castSucc then 1 else 0)]
+
+private theorem foldl_all_lt_last_castSucc {n : Nat} (xs : List (Fin n)) (acc : Nat) :
+    (xs.map Fin.castSucc).foldl
+        (fun acc y => acc + if y < Fin.last n then 1 else 0) acc =
+      acc + xs.length := by
+  induction xs generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.map_cons, List.foldl_cons, List.length_cons]
+      rw [ih (acc + if x.castSucc < Fin.last n then 1 else 0)]
+      simp [Fin.lt_def]
+      omega
+
+private theorem inversionCount_insertIdx_castSucc_last_eq {n : Nat}
+    (xs : List (Fin n)) (p : Nat) (hp : p ≤ xs.length) :
+    inversionCount ((xs.map Fin.castSucc).insertIdx p (Fin.last n)) =
+      inversionCount xs + (xs.length - p) := by
+  induction xs generalizing p with
+  | nil =>
+      cases p with
+      | zero => rfl
+      | succ p => cases hp
+  | cons x xs ih =>
+      cases p with
+      | zero =>
+          simp only [List.map_cons]
+          rw [List.insertIdx, List.modifyTailIdx_zero]
+          simp only [inversionCount, List.foldl_cons]
+          rw [foldl_all_lt_last_castSucc xs
+            (0 + if x.castSucc < Fin.last n then 1 else 0)]
+          rw [inversionFold_map_castSucc]
+          rw [inversionCount_map_castSucc]
+          simp [Fin.lt_def]
+          omega
+      | succ p =>
+          have hp' : p ≤ xs.length := Nat.succ_le_succ_iff.mp hp
+          have hlen : (x :: xs).length - (p + 1) = xs.length - p := by
+            simp
+          simp only [List.map_cons]
+          rw [List.insertIdx, List.modifyTailIdx_succ_cons]
+          simp only [inversionCount]
+          change
+            ((xs.map Fin.castSucc).insertIdx p (Fin.last n)).foldl
+                (fun acc y => acc + if y < x.castSucc then 1 else 0) 0 +
+                inversionCount ((xs.map Fin.castSucc).insertIdx p (Fin.last n)) =
+              xs.foldl (fun acc y => acc + if y < x then 1 else 0) 0 +
+                inversionCount xs + ((x :: xs).length - (p + 1))
+          rw [foldl_insertIdx_last_castSucc_not_lt xs x p]
+          rw [inversionFold_map_castSucc]
+          rw [ih p hp']
+          rw [hlen]
+          grind
+
 private theorem list_insertIdx_length {α : Type u} (xs : List α) (x : α) :
     xs.insertIdx xs.length x = xs ++ [x] := by
   induction xs with

--- a/progress/2026-05-05T05-51-45Z_9fe71c14.md
+++ b/progress/2026-05-05T05-51-45Z_9fe71c14.md
@@ -1,0 +1,37 @@
+# 2026-05-05 05:51 UTC — feature session (9fe71c14)
+
+## Accomplished
+
+Claimed issue #2250. Read the required HexMatrix SPEC/PLAN context and
+oriented around the determinant proof cluster in `HexMatrix/Determinant.lean`.
+
+Added the foundational local inversion helper for the prefix-row insertion
+case:
+
+- `foldl_insertIdx_last_castSucc_not_lt`
+- `foldl_all_lt_last_castSucc`
+- `inversionCount_insertIdx_castSucc_last_eq`
+
+The final theorem proved too large for one session because it still needs a
+deleted-row determinant-product reindexing lemma in addition to sign packaging.
+Decomposed the remaining work into:
+
+- #2293 — prefix inserted final-column sign helper
+- #2296 — prefix row-deletion determinant product helper
+- #2298 — final prefix-row sum theorem assembly
+
+## Current frontier
+
+The inversion-count formula is available locally and should let #2293 package
+the sign as `(-1) ^ (k + 1 - r.val) * detSign v`. The product helper #2296 is
+the main remaining proof burden; it needs a fold lemma deleting the selected
+prefix row from the successor determinant product.
+
+## Next step
+
+Land the partial PR for #2250, then let workers take #2293 and #2296 before
+#2298 assembles the final theorem.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Partial progress on #2250

Session: `9fe71c14-291c-4bce-ac83-688678c7d7a0`

1a471c4 HexMatrix: add prefix insertion inversion helper

🤖 Prepared with Claude Code