### PR TITLE
doc: require Library placement justification on every issue

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -162,6 +162,12 @@ shape:
 - **Current state** — what is already true, and what assumptions the
   worker should begin from.
 - **Deliverables** — the concrete outputs expected from this issue.
+- **Library placement** — the file path the deliverables will land in,
+  the SPEC § that governs that path (quote 1–3 lines), and a one-line
+  answer to each of the four placement questions in
+  [Library placement is a hard precondition](#library-placement-is-a-hard-precondition).
+  If any answer is "unknown" or "blocked", file the prerequisite issue
+  first and add `depends-on:` here; do not file the dependent issue.
 - **Context** — links to every SPEC file the worker should re-read,
   including adjacent ones likely to be relevant (the library being
   touched, sibling library SPECs whose contracts cross the boundary,
@@ -181,6 +187,49 @@ depends-on: #124
 
 Keep these lines literal and easy to grep. They are the only
 dependency syntax the orchestration layer should rely on by default.
+
+### Library placement is a hard precondition
+
+Every issue that adds or modifies a Lean declaration names its target
+file *and justifies it*. Decomposition inherits the parent's
+placement only if the parent's placement was justified; otherwise
+re-justify in the child. A worker who picks up an issue whose Library
+placement is missing or wrong stops, fixes the issue, and re-queues —
+they do not "fix it in the PR".
+
+Answer all four. One line each is enough.
+
+1. **Which SPEC § governs this file?** Quote the sentence that pins
+   the deliverable to a library or file. If no SPEC § names this
+   placement, the issue is not ready: file a SPEC-clarification
+   issue first.
+2. **Does the natural strategy use Mathlib?** If yes, the file lives
+   in a `*-mathlib` bridge library. Mathlib-free libraries cannot
+   host a proof whose shortest path goes through `Matrix.adjugate`,
+   the universal polynomial ring, `MvPolynomial`,
+   `IsIntegralClosure`, or similar. "We will reprove the Mathlib
+   lemma locally" is not a justification; it is the failure mode
+   this rule exists to catch.
+3. **Is this result already in Mathlib, or in an open Mathlib PR?**
+   Choose one strategy:
+   - **Import** if it is on Mathlib `master` *now*.
+   - **Inline with attribution** otherwise — including any open,
+     draft, or stalled PR. Hex moves much faster than Mathlib's
+     review cycle and treats Mathlib as a static artefact; do not
+     gate hex on upstream merging. Copy the proof in, modify
+     types/namespaces/proof shape as needed, credit the upstream
+     author(s) in a file-level docstring linking the PR.
+   What is *not* allowed: reproving from a blank page without
+   consulting the upstream work.
+4. **Does the deliverable presuppose missing infrastructure?**
+   Type-class instances the statement quantifies over (`HPow`,
+   `Module`, `Algebra`), helper definitions, kernel-reducible
+   evaluators. If yes, file the infrastructure issue first and
+   `depends-on:` it here. A claim against a non-statable theorem is
+   churn, not progress.
+
+A `depends-on:` answer to any of (1)–(4) is healthy. An unanswered
+question is the failure shape.
 
 ### Bench-found and conformance-found issues
 

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -11,6 +11,15 @@
    libraries also prove correspondence with Mathlib's mathematical
    definitions (e.g. `ZMod64 p ≃+* ZMod p`).
 
+   The procedural consequence — "before filing or claiming an issue,
+   verify which side of this boundary the deliverable sits on" — is
+   captured in [PLAN/Conventions.md, "Library placement is a hard
+   precondition"](../PLAN/Conventions.md#library-placement-is-a-hard-precondition).
+   A proof whose shortest path uses Mathlib's `adjugate`, universal
+   polynomial rings, or any Mathlib-only structure does not live in a
+   Mathlib-free library, regardless of which file the issue happens
+   to name.
+
 3. **Performant by default.** Dense array-backed representations, `UInt64`
    coefficients for `F_p`, Barrett/Montgomery reduction for modular
    arithmetic. New GMP `@[extern]` primitives where Lean's runtime


### PR DESCRIPTION
This PR adds a mandatory **Library placement** field to the canonical issue body in `PLAN/Conventions.md`, with an inline four-question gate that forces planners to identify the SPEC § governing the deliverable's file path, name the proof strategy, choose between import and inline-with-attribution for upstream Mathlib work, and confirm the required infrastructure exists. Decomposition inherits placement only when the parent justified it. The procedural rule is cross-referenced from `SPEC/design-principles.md` §2 so workers reaching the principle from a Context link also reach the gate.

Motivation: nine open `blocked` issues (#1873, #1875, #1880, #1890, #1893, #1901, #2097, #2114, #2118 — the Bareiss tower) attempt to reprove Desnanot–Jacobi inside the Mathlib-free `HexMatrix/Determinant.lean`, despite [`SPEC/Libraries/hex-matrix.md:131-147`](SPEC/Libraries/hex-matrix.md) saying the proof lives in `HexMatrixMathlib` and that [mathlib4 PR #37716](https://github.com/leanprover-community/mathlib4/pull/37716) should be tracked. The doctrine the SPEC already states was not enforced at issue-creation time; this change adds the missing procedural step. Counterfactual: filing #1900 ("HexMatrix: prove bordered-minor Desnanot–Jacobi") under the new template would have been blocked by Q1 (the SPEC sentence "the proof lives in hex-matrix-mathlib" disqualifies the named file), Q2 (yes — `Matrix.adjugate`), or Q3 (mathlib4 PR #37716 exists; inline-with-attribution applies).

The same gate generalises beyond library placement. Q4 catches the failure modes behind #2247–#2248 (statement quantifies over `HPow (DensePoly Rat) Nat _`, which has no instance) and #2285 (proof needs to kernel-reduce a well-founded-recursion `def`); both should have been filed as `depends-on:` infrastructure issues rather than claimable theorems.

A follow-up `human-oversight` issue will execute the recovery for the existing Bareiss tower (close-and-rewrite the nine blocked issues, file replacement issues against `HexMatrixMathlib` that inline mathlib4 PR #37716 with attribution, audit the placement of the other blocked clusters).

🤖 Prepared with Claude Code