### PR TITLE
HexGF2: prove maximal proper divisor routing lemma

### DIFF
--- a/HexGF2/RabinSoundness.lean
+++ b/HexGF2/RabinSoundness.lean
@@ -82,6 +82,65 @@ theorem xPowSubX_dvd_of_dvd {d m : Nat} (_hdvd : d ∣ m) :
     xPowSubX d ∣ xPowSubX m := by
   sorry
 
+private theorem lt_of_mem_properDivisors {n d : Nat}
+    (hmem : d ∈ properDivisors n) : d < n := by
+  unfold properDivisors at hmem
+  simp only [List.mem_filter, List.mem_map, List.mem_range,
+    decide_eq_true_eq] at hmem
+  rcases hmem with ⟨⟨k, hk, rfl⟩, _⟩
+  omega
+
+private theorem dvd_of_mem_properDivisors {n d : Nat}
+    (hmem : d ∈ properDivisors n) : d ∣ n := by
+  unfold properDivisors at hmem
+  simp only [List.mem_filter, List.mem_map, List.mem_range,
+    decide_eq_true_eq] at hmem
+  rcases hmem with ⟨⟨k, _, rfl⟩, hmod⟩
+  exact Nat.dvd_of_mod_eq_zero hmod
+
+private theorem mem_properDivisors_of_pos_of_dvd_of_lt {n d : Nat}
+    (hpos : 0 < d) (hdvd : d ∣ n) (hlt : d < n) :
+    d ∈ properDivisors n := by
+  unfold properDivisors
+  simp only [List.mem_filter, List.mem_map, List.mem_range,
+    decide_eq_true_eq]
+  refine ⟨⟨d - 1, ?_, ?_⟩, ?_⟩
+  · omega
+  · omega
+  · exact Nat.mod_eq_zero_of_dvd hdvd
+
+private theorem exists_maximalProperDivisor_dvd_aux (n : Nat) :
+    ∀ (k d : Nat), 0 < d → d ∣ n → d < n → n - d ≤ k →
+        ∃ m, m ∈ maximalProperDivisors n ∧ d ∣ m
+  | 0, _d, _hpos, _hdvd, hlt, hbound => by omega
+  | k + 1, d, hpos, hdvd, hlt, hbound => by
+      by_cases hmax : ∃ e, e ∈ properDivisors n ∧ d < e ∧ d ∣ e
+      · obtain ⟨e, he_mem, he_lt, he_dvd⟩ := hmax
+        have he_lt_n := lt_of_mem_properDivisors he_mem
+        have he_dvd_n := dvd_of_mem_properDivisors he_mem
+        have he_pos : 0 < e := Nat.lt_of_lt_of_le hpos (Nat.le_of_lt he_lt)
+        have hsmaller : n - e ≤ k := by omega
+        obtain ⟨m, hm_mem, hm_dvd⟩ :=
+          exists_maximalProperDivisor_dvd_aux n k e he_pos he_dvd_n he_lt_n hsmaller
+        exact ⟨m, hm_mem, Nat.dvd_trans he_dvd hm_dvd⟩
+      · refine ⟨d, ?_, Nat.dvd_refl d⟩
+        have hd_in : d ∈ properDivisors n :=
+          mem_properDivisors_of_pos_of_dvd_of_lt hpos hdvd hlt
+        unfold maximalProperDivisors
+        simp only [List.mem_filter]
+        refine ⟨hd_in, ?_⟩
+        have hany_false :
+            (properDivisors n).any
+                (fun e => decide (d < e) && decide (e % d = 0)) = false := by
+          apply Bool.eq_false_iff.mpr
+          intro hany
+          rw [List.any_eq_true] at hany
+          obtain ⟨e, he_mem, he_cond⟩ := hany
+          simp only [Bool.and_eq_true, decide_eq_true_eq] at he_cond
+          exact hmax ⟨e, he_mem, he_cond.1, Nat.dvd_of_mod_eq_zero he_cond.2⟩
+        rw [hany_false]
+        rfl
+
 /--
 Every positive proper divisor of `n` is contained in a maximal proper divisor
 of `n`.
@@ -91,8 +150,8 @@ This routes an irreducible factor degree to one of the gcd legs checked by
 -/
 theorem exists_maximalProperDivisor_dvd
     {n d : Nat} (hd_pos : 0 < d) (hd_dvd : d ∣ n) (hd_lt : d < n) :
-    ∃ m, m ∈ maximalProperDivisors n ∧ d ∣ m := by
-  sorry
+    ∃ m, m ∈ maximalProperDivisors n ∧ d ∣ m :=
+  exists_maximalProperDivisor_dvd_aux n (n - d) d hd_pos hd_dvd hd_lt (Nat.le_refl _)
 
 /--
 A common divisor of `f` and the absolute Rabin polynomial also divides the

--- a/progress/20260505T080842Z_0249a13a.md
+++ b/progress/20260505T080842Z_0249a13a.md
@@ -1,0 +1,40 @@
+# 2026-05-05 08:08 UTC — feature session (0249a13a)
+
+## Accomplished
+
+Claimed #2301 and discharged the `exists_maximalProperDivisor_dvd` proof
+leaf in `HexGF2/RabinSoundness.lean`. The lemma states that every
+positive proper divisor `d < n` of `n` is dominated by some maximal
+proper divisor of `n`.
+
+The HexGF2 definitions of `properDivisors` and `maximalProperDivisors`
+agree exactly with the HexBerlekamp ones (both `Nat → List Nat`,
+identical bodies), so the proof from
+`HexBerlekamp/RabinSoundness.lean::exists_maximalProperDivisor_dvd`
+ports directly. Added four private helpers (`lt_of_mem_properDivisors`,
+`dvd_of_mem_properDivisors`, `mem_properDivisors_of_pos_of_dvd_of_lt`,
+`exists_maximalProperDivisor_dvd_aux`) and the wrapping theorem.
+
+Sorry count in `HexGF2/RabinSoundness.lean` dropped 8 → 7.
+
+## Current frontier
+
+Seven proof leaves remain in `HexGF2/RabinSoundness.lean`:
+
+- #2294 absolute-to-modular Frobenius bridge
+- #2295 existence of irreducible factor for nonconstant factor
+- #2297 forward Rabin degree theorem
+- #2299 backward Rabin divisibility theorem
+- #2300 xPowSubX divisibility chain
+- #2302 common divisor lifts to Frobenius remainder (blocked on #2294)
+- #2304 divisor of unit polynomial is unit (currently claimed)
+
+## Next step
+
+Pick up another GF2 leaf — #2300 (`xPowSubX_dvd_of_dvd`) is the next
+combinatorial fact and similarly tractable; the Berlekamp analogue is
+already proved.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2301

Session: `0249a13a-e07e-47a7-aeb0-25664929974d`

24bba4b feat: prove exists_maximalProperDivisor_dvd for HexGF2.RabinSoundness

🤖 Prepared with Claude Code