### PR TITLE
HexGF2: prove xPowSubX divisibility chain

### DIFF
--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -6779,5 +6779,39 @@ theorem add_monomial_mul (quot q : GF2Poly) (k : Nat) :
     (quot + monomial k) * q = quot * q + q.mulXk k := by
   rw [left_distrib, monomial_mul]
 
+/-- The product of two monomials is the monomial whose exponent is the sum. -/
+theorem monomial_mul_monomial (a b : Nat) :
+    monomial a * monomial b = monomial (a + b) := by
+  rw [monomial_mul]
+  apply ext_coeff
+  intro n
+  by_cases hn_eq : n = a + b
+  · subst hn_eq
+    have hdeg : ((monomial b).mulXk a).degree? = some (b + a) :=
+      degree?_mulXk_of_degree?_eq_some (degree?_monomial b)
+    rw [coeff_monomial_self,
+      show a + b = b + a from Nat.add_comm a b]
+    exact coeff_eq_true_of_degree?_eq_some hdeg
+  · rw [coeff_monomial_ne hn_eq]
+    by_cases h_gt : a + b < n
+    · have hdeg : ((monomial b).mulXk a).degree? = some (b + a) :=
+        degree?_mulXk_of_degree?_eq_some (degree?_monomial b)
+      exact coeff_eq_false_of_degree?_lt hdeg (by omega)
+    · rw [coeff_mulXk]
+      by_cases hn_lt_a : n < a
+      · exact coeff_shiftLeft_lt (monomial b) hn_lt_a
+      · have hn_ge_a : a ≤ n := Nat.le_of_not_gt hn_lt_a
+        have hlt : n < a + b := by omega
+        have hsource_lt_b : n - a < b := by omega
+        have hsource_ne_b : n - a ≠ b := Nat.ne_of_lt hsource_lt_b
+        have hword : (n - a) / 64 < (monomial b).words.size := by
+          rw [words_monomial_size]
+          have : (n - a) / 64 ≤ b / 64 :=
+            Nat.div_le_div_right (Nat.le_of_lt hsource_lt_b)
+          omega
+        have hn_eq_source : n = (n - a) + a := by omega
+        rw [hn_eq_source, coeff_shiftLeft_add_of_word_lt (monomial b) hword]
+        exact coeff_monomial_ne hsource_ne_b
+
 end GF2Poly
 end Hex

--- a/HexGF2/RabinSoundness.lean
+++ b/HexGF2/RabinSoundness.lean
@@ -74,13 +74,122 @@ theorem irreducible_dvd_xPowSubX_degree
     g ∣ xPowSubX g.degree := by
   sorry
 
+private theorem mulXk_zero' (p : GF2Poly) : p.mulXk 0 = p := by
+  apply ext_coeff
+  intro n
+  rw [coeff_mulXk, coeff_shiftLeft]
+  simp [coeff]
+
+private theorem one_mul' (p : GF2Poly) : (1 : GF2Poly) * p = p := by
+  show monomial 0 * p = p
+  rw [monomial_mul, mulXk_zero']
+
+private theorem mul_one' (p : GF2Poly) : p * (1 : GF2Poly) = p := by
+  rw [mul_comm, one_mul']
+
+private theorem dvd_refl' (p : GF2Poly) : p ∣ p :=
+  ⟨1, (mul_one' p).symm⟩
+
+private theorem dvd_zero' (p : GF2Poly) : p ∣ 0 :=
+  ⟨0, (mul_zero p).symm⟩
+
+private theorem dvd_add' {d a b : GF2Poly} (hda : d ∣ a) (hdb : d ∣ b) :
+    d ∣ a + b := by
+  rcases hda with ⟨ra, hra⟩
+  rcases hdb with ⟨rb, hrb⟩
+  exact ⟨ra + rb, by rw [hra, hrb, right_distrib]⟩
+
+private theorem dvd_mul_left' {d a : GF2Poly} (c : GF2Poly) (hda : d ∣ a) :
+    d ∣ c * a := by
+  rcases hda with ⟨r, hr⟩
+  refine ⟨c * r, ?_⟩
+  rw [hr, ← mul_assoc, ← mul_assoc, mul_comm c d]
+
+private theorem mul_dvd_mul_left' (c : GF2Poly) {a b : GF2Poly} (h : a ∣ b) :
+    c * a ∣ c * b := by
+  rcases h with ⟨r, hr⟩
+  exact ⟨r, by rw [hr, mul_assoc]⟩
+
+/--
+Geometric-series divisibility in characteristic two: `X^k + 1` divides
+`X^(k*n) + 1` for any `k` and `n`.
+
+Iterated XOR-cancellation gives the identity
+`X^(k*(n+1)) + 1 = X^k * (X^(k*n) + 1) + (X^k + 1)`,
+so the result reduces by induction on `n` to the base cases `n = 0`
+(both sides are zero) and `n = 1` (reflexivity).
+-/
+private theorem monomial_add_one_dvd_geom (k : Nat) :
+    ∀ n, (monomial k + 1) ∣ (monomial (k * n) + 1)
+  | 0 => by
+      rw [Nat.mul_zero, show (monomial 0 : GF2Poly) = 1 from rfl, add_self]
+      exact dvd_zero' _
+  | n + 1 => by
+      have ih := monomial_add_one_dvd_geom k n
+      have heq :
+          monomial (k * (n + 1)) + 1 =
+            monomial k * (monomial (k * n) + 1) + (monomial k + 1) := by
+        rw [right_distrib, mul_one', monomial_mul_monomial]
+        rw [show k + k * n = k * (n + 1) from by rw [Nat.mul_succ]; omega]
+        rw [add_assoc]
+        congr 1
+        rw [← add_assoc, add_self, zero_add]
+      rw [heq]
+      exact dvd_add' (dvd_mul_left' (monomial k) ih) (dvd_refl' _)
+
+/--
+Number-theoretic companion to `monomial_add_one_dvd_geom`: when `d ∣ m`,
+the integer `2 ^ d - 1` divides `2 ^ m - 1`.
+
+Both follow from the same telescoping identity, transposed between the
+polynomial and natural-number rings.
+-/
+private theorem two_pow_sub_one_dvd_two_pow_sub_one_of_dvd
+    {d m : Nat} (hdvd : d ∣ m) : (2 ^ d - 1) ∣ (2 ^ m - 1) := by
+  obtain ⟨k, rfl⟩ := hdvd
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      have h2dk_pos : 0 < 2 ^ (d * k) := Nat.two_pow_pos _
+      have h2d_pos : 0 < 2 ^ d := Nat.two_pow_pos _
+      have hexp : 2 ^ (d * (k + 1)) = 2 ^ d * 2 ^ (d * k) := by
+        rw [Nat.mul_succ, Nat.pow_add, Nat.mul_comm]
+      have hge : 2 ^ d ≤ 2 ^ d * 2 ^ (d * k) := by
+        calc 2 ^ d = 2 ^ d * 1 := (Nat.mul_one _).symm
+          _ ≤ 2 ^ d * 2 ^ (d * k) := Nat.mul_le_mul_left _ h2dk_pos
+      have hkey :
+          2 ^ (d * (k + 1)) - 1 = 2 ^ d * (2 ^ (d * k) - 1) + (2 ^ d - 1) := by
+        rw [hexp, Nat.mul_sub, Nat.mul_one]
+        omega
+      rw [hkey]
+      exact Nat.dvd_add (Nat.dvd_mul_left_of_dvd ih _) (Nat.dvd_refl _)
+
+/--
+Factor `xPowSubX d = monomial 1 * (monomial (2 ^ d - 1) + 1)`.
+
+In characteristic two this collapses `X^(2^d) + X = X * (X^(2^d - 1) + 1)`.
+The factor is uniform in `d ≥ 0`: when `d = 0` both sides reduce to `0`.
+-/
+private theorem xPowSubX_factor (d : Nat) :
+    xPowSubX d = monomial 1 * (monomial (2 ^ d - 1) + 1) := by
+  unfold xPowSubX
+  rw [right_distrib, mul_one', monomial_mul_monomial]
+  have hpos : 0 < 2 ^ d := Nat.two_pow_pos _
+  rw [show 1 + (2 ^ d - 1) = 2 ^ d from by omega]
+
 /--
 Divisibility chain on Rabin polynomials: if `d ∣ m`, then
 `X^(2^d) - X` divides `X^(2^m) - X`.
 -/
-theorem xPowSubX_dvd_of_dvd {d m : Nat} (_hdvd : d ∣ m) :
+theorem xPowSubX_dvd_of_dvd {d m : Nat} (hdvd : d ∣ m) :
     xPowSubX d ∣ xPowSubX m := by
-  sorry
+  obtain ⟨n, hn⟩ :=
+    two_pow_sub_one_dvd_two_pow_sub_one_of_dvd hdvd
+  have hgeo : (monomial (2 ^ d - 1) + 1) ∣ (monomial (2 ^ m - 1) + 1) := by
+    rw [hn]
+    exact monomial_add_one_dvd_geom (2 ^ d - 1) n
+  rw [xPowSubX_factor d, xPowSubX_factor m]
+  exact mul_dvd_mul_left' (monomial 1) hgeo
 
 private theorem lt_of_mem_properDivisors {n d : Nat}
     (hmem : d ∈ properDivisors n) : d < n := by

--- a/progress/20260505T083638Z_0e039df4.md
+++ b/progress/20260505T083638Z_0e039df4.md
@@ -1,0 +1,51 @@
+# 2026-05-05 08:36 UTC — feature session (0e039df4)
+
+## Accomplished
+
+Claimed #2300 and discharged the `xPowSubX_dvd_of_dvd` proof leaf in
+`HexGF2/RabinSoundness.lean`. The lemma states that whenever `d ∣ m`,
+`X^(2^d) - X` divides `X^(2^m) - X` in packed `GF(2)`.
+
+The Berlekamp analogue is itself still a sorry, so the port had to be
+done from scratch. The strategy avoids polynomial exponentiation
+entirely (GF2Poly has no `Pow` instance) by combining three pieces:
+
+- **Monomial product** (added to `HexGF2/Multiply.lean`):
+  `monomial_mul_monomial : monomial a * monomial b = monomial (a + b)`.
+  Proved via `ext_coeff` with the standard case split on
+  `n = a + b`, `n > a + b`, `n < a` (uses the now-needed private
+  helpers `coeff_shiftLeft_lt`, `words_monomial_size`).
+- **Geometric series in characteristic two**:
+  `(monomial k + 1) ∣ (monomial (k * n) + 1)`. Proved by induction
+  on `n` using the XOR-cancellation identity
+  `monomial (k*(n+1)) + 1 = monomial k * (monomial (k*n) + 1) + (monomial k + 1)`.
+- **Number-theoretic companion**: `d ∣ m → (2^d - 1) ∣ (2^m - 1)`.
+  Same telescoping identity, transposed to `Nat`.
+
+The factorization `xPowSubX d = monomial 1 * (monomial (2^d - 1) + 1)`
+is uniform in `d ≥ 0` (collapses to `0 = monomial 1 * 0` when `d = 0`),
+so cancellation by `monomial 1` directly bridges the geometric series
+divisibility to the main statement.
+
+Sorry count in `HexGF2/RabinSoundness.lean` dropped 6 → 5.
+
+## Current frontier
+
+Five proof leaves remain in `HexGF2/RabinSoundness.lean`:
+
+- #2294 absolute-to-modular Frobenius bridge
+- #2295 existence of irreducible factor for nonconstant factor
+- #2297 forward Rabin degree theorem
+- #2299 backward Rabin divisibility theorem
+- #2302 common divisor lifts to Frobenius remainder (blocked on #2294)
+
+## Next step
+
+The combinatorial / pure-Nat / structural leaves are now done. The
+remaining sorries are all polynomial-algebra facts; #2295 is the most
+combinatorially tractable (descent on degree, mirroring the Berlekamp
+analogue at `exists_irreducible_factor_of_factor`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2300

Session: `0e039df4-f9c1-45db-b8e0-f6846369c87d`

568701b feat: prove xPowSubX_dvd_of_dvd for HexGF2.RabinSoundness (#2300)

🤖 Prepared with Claude Code