### PR TITLE
HexMatrixMathlib: prove Hex detSign matches Mathlib Perm.sign

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -1346,13 +1346,38 @@ theorem permutationVectors_nodup_list {n : Nat} :
         (permutationVectors n) ih
         (fun v hv => permutationVectors_nodup hv)
 
-private theorem detSign_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
+theorem detSign_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     (v : Vector (Fin n) n) :
     detSign (R := R)
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
     detSign (R := R) v := by
   unfold detSign
   rw [insertAt_last_toList, vector_toList_map, inversionCount_insert_last_castSucc]
+
+theorem detSign_identity {R : Type u} [Lean.Grind.Ring R] (n : Nat) :
+    detSign (R := R) (Vector.ofFn fun i : Fin n => i) = 1 := by
+  induction n with
+  | zero =>
+      have hvec : (Vector.ofFn fun i : Fin 0 => i) = emptyVec := by
+        apply Vector.ext
+        intro i hi
+        omega
+      simp [hvec, detSign, emptyVec, inversionCount]
+  | succ n ih =>
+      have hvec :
+          (Vector.ofFn fun i : Fin (n + 1) => i) =
+            insertAt (Fin.last n)
+              ((Vector.ofFn fun i : Fin n => i).map Fin.castSucc) (Fin.last n) := by
+        apply Vector.ext
+        intro k hk
+        by_cases hlast : k = n
+        · subst k
+          simp [insertAt, List.getElem_insertIdx_self]
+          exact Fin.ext rfl
+        · have hklt : k < n := by omega
+          simp [insertAt, List.getElem_insertIdx_of_lt, hklt]
+      rw [hvec, detSign_insertAt_last]
+      exact ih
 
 /-- Product reindexing for a permutation that fixes the final column. The
 Leibniz product splits into the product on the leading prefix times the final
@@ -1933,7 +1958,7 @@ private theorem transposePermutationValues_map_permutationVectors_perm {n : Nat}
       transposePermutationValues_mem_permutationVectors i j hmem, ?_⟩
     exact transposePermutationValues_involutive perm i j
 
-private def swapPermutationValues {n : Nat}
+def swapPermutationValues {n : Nat}
     (perm : Vector (Fin n) n) (i j : Fin n) : Vector (Fin n) n :=
   perm.map (finTranspose i j)
 
@@ -1941,6 +1966,13 @@ private theorem swapPermutationValues_get {n : Nat}
     (perm : Vector (Fin n) n) (i j r : Fin n) :
     (swapPermutationValues perm i j)[r] = finTranspose i j perm[r] := by
   simp [swapPermutationValues]
+
+theorem swapPermutationValues_get_if {n : Nat}
+    (perm : Vector (Fin n) n) (i j r : Fin n) :
+    (swapPermutationValues perm i j)[r] =
+      if perm[r] = i then j else if perm[r] = j then i else perm[r] := by
+  rw [swapPermutationValues_get]
+  rfl
 
 private theorem swapPermutationValues_toList_nodup {n : Nat}
     (perm : Vector (Fin n) n) (i j : Fin n)
@@ -2217,7 +2249,7 @@ private theorem detSign_transposeValues {R : Type u}
       omega
     simp [hp, ht]
 
-private theorem detSign_swapPermutationValues {R : Type u}
+theorem detSign_swapPermutationValues {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat}
     (perm : Vector (Fin n) n) (i j : Fin n)
     (hnodup : perm.toList.Nodup) (h : i ≠ j) :

--- a/HexMatrixMathlib/Determinant.lean
+++ b/HexMatrixMathlib/Determinant.lean
@@ -102,6 +102,56 @@ theorem equivs_nodup (n : Nat) :
     exact toPerm_injective hpq
   exact congrArg (fun x : {perm : Vector (Fin n) n // perm.toList.Nodup} => x.1) hpq'
 
+private theorem vectorOfPerm_swap_mul (σ : Equiv.Perm (Fin n)) (i j : Fin n) :
+    (Vector.ofFn fun r : Fin n => (Equiv.swap i j * σ) r) =
+      Hex.Matrix.swapPermutationValues (Vector.ofFn fun r : Fin n => σ r) i j := by
+  apply Vector.ext
+  intro r hr
+  show (Vector.ofFn fun r : Fin n => (Equiv.swap i j * σ) r)[(⟨r, hr⟩ : Fin n)] =
+    (Hex.Matrix.swapPermutationValues (Vector.ofFn fun r : Fin n => σ r) i j)[(⟨r, hr⟩ : Fin n)]
+  rw [Hex.Matrix.swapPermutationValues_get_if]
+  simp [Equiv.Perm.mul_apply, Equiv.swap_apply_def]
+
+/-- Hex's inversion-count determinant sign agrees with Mathlib's permutation sign. -/
+theorem detSign_vectorOfPerm_eq_permSign [CommRing R] (σ : Equiv.Perm (Fin n)) :
+    Hex.Matrix.detSign (R := R) (Vector.ofFn fun i : Fin n => σ i) =
+      ((Equiv.Perm.sign σ : Int) : R) := by
+  induction σ using Equiv.Perm.swap_induction_on with
+  | one =>
+      simp [Hex.Matrix.detSign_identity]
+  | swap_mul σ i j hne ih =>
+      rw [vectorOfPerm_swap_mul σ i j]
+      have hflip := Hex.Matrix.detSign_swapPermutationValues (R := R)
+        (perm := (Vector.ofFn fun r : Fin n => σ r)) (i := i) (j := j)
+        (hnodup := vectorOfPerm_nodup σ) hne
+      have hswapped :
+          Hex.Matrix.detSign (R := R)
+              (Hex.Matrix.swapPermutationValues (Vector.ofFn fun r : Fin n => σ r) i j) =
+            -Hex.Matrix.detSign (R := R) (Vector.ofFn fun r : Fin n => σ r) := by
+        rw [hflip]
+        simp
+      rw [hswapped]
+      rw [Equiv.Perm.sign_mul, Equiv.Perm.sign_swap hne]
+      rw [ih]
+      norm_num
+
+/-- Hex's inversion-count determinant sign agrees with Mathlib's permutation sign. -/
+theorem detSign_eq_permSign [CommRing R]
+    (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
+    Hex.Matrix.detSign (R := R) perm =
+      ((Equiv.Perm.sign (toPerm perm hnodup) : Int) : R) := by
+  have hperm :
+      (Vector.ofFn fun i : Fin n => toPerm perm hnodup i) = perm := by
+    apply Vector.ext
+    intro i hi
+    simp [toPerm]
+  calc
+    Hex.Matrix.detSign (R := R) perm =
+        Hex.Matrix.detSign (R := R) (Vector.ofFn fun i : Fin n => toPerm perm hnodup i) := by
+          rw [hperm]
+    _ = ((Equiv.Perm.sign (toPerm perm hnodup) : Int) : R) := by
+          exact detSign_vectorOfPerm_eq_permSign (R := R) (toPerm perm hnodup)
+
 end PermutationVector
 
 @[simp]

--- a/progress/20260505T123837Z_9328d1ef.md
+++ b/progress/20260505T123837Z_9328d1ef.md
@@ -1,0 +1,35 @@
+# 2026-05-05 12:38 UTC — work session (9328d1ef)
+
+## Accomplished
+
+Claimed #2331 and proved the determinant-sign compatibility bridge in
+`HexMatrixMathlib/Determinant.lean`.
+
+Added reusable public Hex determinant-sign API in `HexMatrix/Determinant.lean`:
+`detSign_identity`, `swapPermutationValues`, `swapPermutationValues_get_if`,
+and `detSign_swapPermutationValues`. The Mathlib bridge proves
+`detSign_vectorOfPerm_eq_permSign` by `Equiv.Perm.swap_induction_on`, then
+specializes it to Hex permutation vectors via `PermutationVector.toPerm`.
+
+Verification run:
+
+* `lake build HexMatrixMathlib.Determinant` (only pre-existing sorry warnings,
+  including the existing `det_eq` sorry in this file).
+* `python3 scripts/check_dag.py`.
+* `git diff --check`.
+* `rg -n "axiom|native_decide|TODO|FIXME" HexMatrix/Determinant.lean HexMatrixMathlib/Determinant.lean`
+  returns no hits.
+
+## Current frontier
+
+Hex's inversion-count sign is now available in the convention of the
+row-to-column permutation represented by `PermutationVector.toPerm`.
+
+## Next step
+
+Use `PermutationVector.detSign_eq_permSign` when reindexing the executable Hex
+Leibniz determinant sum against Mathlib's `Matrix.det` expansion.
+
+## Blockers
+
+None for this session.


### PR DESCRIPTION
Closes #2331

Session: `9328d1ef-f5db-4d39-8245-179f43aa9be5`

ffb493c feat: prove determinant sign bridge

🤖 Prepared with Claude Code