### PR TITLE
HexPolyFp: enumerate quotient representatives

### DIFF
--- a/HexPolyFp/Enumeration.lean
+++ b/HexPolyFp/Enumeration.lean
@@ -252,6 +252,48 @@ theorem mem_polysBelowDegree_of_degree_getD_lt {f : FpPoly p} {d : Nat}
       exact ZMod64.mem_values (f.coeff i)
   · exact of_first_coeffs_eq_of_degree_getD_lt hdeg
 
+private theorem ofCoeffList_degree_getD_lt_of_length_eq
+    {coeffs : List (ZMod64 p)} {d : Nat}
+    (hd : 0 < d) (hlen : coeffs.length = d) :
+    (ofCoeffList coeffs).degree?.getD 0 < d := by
+  have hzero_ge : ∀ i, d ≤ i → (ofCoeffList coeffs).coeff i = 0 := by
+    intro i hi
+    unfold ofCoeffList FpPoly.ofCoeffs
+    rw [DensePoly.coeff_ofCoeffs_list]
+    have hlen_le : coeffs.length ≤ i := by omega
+    change coeffs.getD i (0 : ZMod64 p) = (0 : ZMod64 p)
+    simp [List.getD, hlen_le]
+  have hsize_le : (ofCoeffList coeffs).size ≤ d := by
+    by_cases hle : (ofCoeffList coeffs).size ≤ d
+    · exact hle
+    · exfalso
+      have hd_lt_size : d < (ofCoeffList coeffs).size := Nat.lt_of_not_ge hle
+      let i := (ofCoeffList coeffs).size - 1
+      have hi_ge : d ≤ i := by omega
+      have hi_pos : 0 < (ofCoeffList coeffs).size := by omega
+      have hzero : (ofCoeffList coeffs).coeff i = 0 := hzero_ge i hi_ge
+      have hne : (ofCoeffList coeffs).coeff i ≠ 0 :=
+        DensePoly.coeff_last_ne_zero_of_pos_size (ofCoeffList coeffs) hi_pos
+      exact hne hzero
+  by_cases hsize : (ofCoeffList coeffs).size = 0
+  · simp [DensePoly.degree?, hsize, hd]
+  · have hdeg : (ofCoeffList coeffs).degree?.getD 0 =
+        (ofCoeffList coeffs).size - 1 := by
+      simp [DensePoly.degree?, hsize]
+    rw [hdeg]
+    omega
+
+/-- Every polynomial in the bounded-degree enumeration has degree below the
+bound, provided the bound is positive. -/
+theorem degree_getD_lt_of_mem_polysBelowDegree {f : FpPoly p} {d : Nat}
+    (hd : 0 < d) (hmem : f ∈ polysBelowDegree p d) :
+    f.degree?.getD 0 < d := by
+  unfold polysBelowDegree at hmem
+  rcases List.mem_map.mp hmem with ⟨coeffs, hcoeffs, hf⟩
+  rw [← hf]
+  exact ofCoeffList_degree_getD_lt_of_length_eq hd
+    (length_of_mem_coeffLists hcoeffs)
+
 private theorem list_eq_of_length_eq_of_getD_eq
     {α : Type} [Zero α] {xs ys : List α}
     (hlen : xs.length = ys.length)

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -87,6 +87,72 @@ theorem reduce_eq_reduce_iff_congr (f h : FpPoly p) :
       Congr (g := g) f h :=
   ⟨congr_of_reduce_eq_reduce, reduce_eq_reduce_of_congr⟩
 
+private theorem nodup_map_of_injective
+    {α β : Type} {xs : List α} {f : α → β}
+    (hxs : xs.Nodup)
+    (hinj : ∀ a, a ∈ xs → ∀ b, b ∈ xs → f a = f b → a = b) :
+    (xs.map f).Nodup := by
+  induction xs with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      simp only [List.map_cons]
+      rw [List.nodup_cons] at hxs ⊢
+      constructor
+      · intro hx
+        rcases List.mem_map.mp hx with ⟨y, hy, hxy⟩
+        have hyx : y = x := hinj y (by simp [hy]) x (by simp) hxy
+        exact hxs.1 (by simpa [hyx] using hy)
+      · exact ih hxs.2 (by
+          intro a ha b hb hab
+          exact hinj a (by simp [ha]) b (by simp [hb]) hab)
+
+/-- All canonical quotient representatives, enumerated via bounded-degree
+polynomials. -/
+def elements : List (Quotient g hmonic hg_pos) :=
+  (Enumeration.polysBelowDegree p (g.degree?.getD 0)).map
+    (reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos))
+
+@[simp] theorem elements_length :
+    (elements (g := g) (hmonic := hmonic) (hg_pos := hg_pos)).length =
+      p ^ g.degree?.getD 0 := by
+  simp [elements]
+
+/-- Every quotient element appears in `elements`. -/
+theorem mem_elements (a : Quotient g hmonic hg_pos) :
+    a ∈ elements (g := g) (hmonic := hmonic) (hg_pos := hg_pos) := by
+  unfold elements
+  apply List.mem_map.mpr
+  refine ⟨a.val, Enumeration.mem_polysBelowDegree_of_degree_getD_lt a.reduced, ?_⟩
+  apply ext
+  rw [reduce_val, FpPoly.modByMonic, DensePoly.modByMonic_eq_mod]
+  exact DensePoly.mod_eq_self_of_degree_lt a.val g a.reduced
+
+/-- The quotient enumeration has no duplicate elements. -/
+theorem elements_nodup :
+    (elements (g := g) (hmonic := hmonic) (hg_pos := hg_pos)).Nodup := by
+  unfold elements
+  apply nodup_map_of_injective
+  · exact Enumeration.polysBelowDegree_nodup (p := p) (g.degree?.getD 0)
+  · intro a ha b hb hab
+    have hval := congrArg Quotient.val hab
+    rw [reduce_val, reduce_val, FpPoly.modByMonic, FpPoly.modByMonic,
+      DensePoly.modByMonic_eq_mod, DensePoly.modByMonic_eq_mod] at hval
+    have ha_deg : a.degree?.getD 0 < g.degree?.getD 0 :=
+      Enumeration.degree_getD_lt_of_mem_polysBelowDegree hg_pos ha
+    have hb_deg : b.degree?.getD 0 < g.degree?.getD 0 :=
+      Enumeration.degree_getD_lt_of_mem_polysBelowDegree hg_pos hb
+    rw [DensePoly.mod_eq_self_of_degree_lt a g ha_deg,
+      DensePoly.mod_eq_self_of_degree_lt b g hb_deg] at hval
+    exact hval
+
+/-- The quotient has `p ^ deg(g)` canonical representatives in the executable
+list-cardinality sense. -/
+theorem elements_card :
+    (elements (g := g) (hmonic := hmonic) (hg_pos := hg_pos)).length =
+      p ^ g.degree?.getD 0 :=
+  elements_length (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
+
 omit [ZMod64.PrimeModulus p] in
 /-- Equality of quotient elements is equality of canonical remainders. -/
 theorem eq_iff_val_eq {a b : Quotient g hmonic hg_pos} :

--- a/progress/20260505T222319Z_1f4f5d13.md
+++ b/progress/20260505T222319Z_1f4f5d13.md
@@ -1,0 +1,35 @@
+# 2026-05-05 22:23 UTC — feature session (1f4f5d13)
+
+## Accomplished
+
+Claimed #2381 after the higher-priority human-oversight issues both failed
+coordination claiming as `needs replan`.
+
+Added the quotient-cardinality enumeration surface:
+
+- `FpPoly.Enumeration.degree_getD_lt_of_mem_polysBelowDegree`
+- `FpPoly.Quotient.elements`
+- `FpPoly.Quotient.mem_elements`
+- `FpPoly.Quotient.elements_nodup`
+- `FpPoly.Quotient.elements_length` / `elements_card`
+
+The quotient enumeration maps `reduce` over the bounded-degree polynomial
+enumeration from #2380, proves every quotient element appears, proves no
+duplicates using reduced-representative uniqueness, and records length
+`p ^ g.degree?.getD 0`.
+
+## Current frontier
+
+#2381 is ready for PR. The quotient fixed-point theorem chain can now use the
+finite executable list surface in `HexPolyFp/Quotient.lean`.
+
+## Next step
+
+Pick up #2382 to prove the quotient Frobenius fixed-point theorem, then continue
+the dependent Rabin order/divisibility chain.
+
+## Blockers
+
+None for this issue. Pre-existing warnings remain in unrelated modules
+(`HexPolyFp.Basic`, `HexPolyFp.SquareFree`, `HexMatrix.RREF`,
+`HexMatrix.Bareiss`, and `HexBerlekamp.RabinSoundness`).


### PR DESCRIPTION
Closes #2381

Session: `1f4f5d13-27ec-495e-bf8e-328d7af7590a`

9525968 HexPolyFp: enumerate quotient representatives

🤖 Prepared with Claude Code