### PR TITLE
chore: add macOS CI job and umbrella-completeness DAG check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,16 @@ jobs:
       - run: python3 scripts/check_phase4.py
       - run: sudo apt-get install -y libgmp-dev
       - uses: leanprover/lean-action@v1
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: python3 scripts/check_dag.py
+      - run: brew install gmp
+      - uses: leanprover/lean-action@v1
       - run: |
           lake exe hexmatrix_bench list
           lake exe hexmatrix_bench verify

--- a/HexPolyFp.lean
+++ b/HexPolyFp.lean
@@ -1,7 +1,10 @@
 import HexPolyFp.Basic
+import HexPolyFp.Enumeration
 import HexPolyFp.Frobenius
 import HexPolyFp.SquareFree
 import HexPolyFp.ModCompose
+import HexPolyFp.Quotient
+import HexPolyFp.QuotientFrobenius
 import HexPolyFp.Conformance
 
 /-!

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -119,6 +119,34 @@ For ad hoc interpreter smoke tests of extern-backed declarations, use
 of `@[extern]` declarations can fail with `Could not find native
 implementation`.
 
+### Library umbrella discipline
+
+Each library `Foo` has a root file `Foo.lean` (the *umbrella*) and a
+directory `Foo/` containing its modules. The umbrella **must import
+every regular module** under `Foo/`. The only exempt files are those
+declared as `lean_exe` roots in `lakefile.lean` (typically
+`Foo/Bench.lean` and `Foo/EmitFixtures.lean`).
+
+Why this matters: with `precompileModules := true` (the default), Lake
+builds a per-library shared object `libHex_Foo.dylib`/`.so` from the
+`.c.o.export` files of the modules the umbrella imports, and lists
+that shared object as a plugin when elaborating any downstream library.
+A module file under `Foo/` that the umbrella does **not** import is
+absent from the shared object even though it is imported individually
+by downstream code. On Linux, flat-namespace lazy binding hides the
+gap by resolving the missing symbols against per-module dylibs that
+happen to be loaded for the same elaboration run. On macOS, dyld's
+stricter symbol resolution aborts with `dyld[..]: missing symbol
+called` on the first downstream elaboration that needs the absent
+symbols. This is exactly the failure mode that motivated adding macOS
+to CI in [Phase0.md §6](Phase0.md).
+
+`scripts/check_dag.py` enforces this rule mechanically: every
+`Foo/X.lean` is either listed as a `lean_exe` root in `lakefile.lean`
+or imported (directly or transitively) by `Foo.lean`. Any PR that adds
+a new module under `Foo/` must also update `Foo.lean` (or chain the
+import through an existing intermediate module).
+
 ---
 
 ## Issue creation

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -194,6 +194,13 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - run: python3 scripts/check_dag.py
          - run: sudo apt-get install -y libgmp-dev
          - uses: leanprover/lean-action@v1
+     build-macos:
+       runs-on: macos-latest
+       steps:
+         - uses: actions/checkout@v4
+         - run: python3 scripts/check_dag.py
+         - run: brew install gmp
+         - uses: leanprover/lean-action@v1
    ```
 
    The DAG check runs before the Lean build so import-boundary
@@ -201,7 +208,15 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    performs the `lake build` itself. `libgmp-dev` is installed
    explicitly because the `hex-arith` extern C shims `#include
    <gmp.h>`; Lean's toolchain ships `libgmp.a` for linking but not the
-   headers, and `ubuntu-latest` does not preinstall `libgmp-dev`.
+   headers, and `ubuntu-latest` does not preinstall `libgmp-dev`. The
+   macOS job is required, not optional: macOS dyld uses a stricter
+   symbol-resolution discipline than Linux's flat-namespace lazy
+   binding, so a build that succeeds on Linux can still fail on macOS
+   with `dyld[..]: missing symbol called`. The most common trigger is
+   an incomplete library umbrella file (see
+   [Conventions.md §Library umbrella discipline](Conventions.md#library-umbrella-discipline));
+   `check_dag.py` enforces the source-side condition and the macOS
+   `lake build` is the cross-check.
 
    **`.github/workflows/conformance.yml`** (optional, manual trigger):
    Manual or locally-triggered conformance workflow following

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -18,6 +18,93 @@ from libgraph import (
 
 
 IMPORT_RE = re.compile(r"^\s*import\s+(.+?)\s*$")
+LEAN_EXE_ROOT_RE = re.compile(r"^\s*root\s*:=\s*`([A-Za-z0-9_.]+)\s*$")
+QUALIFIED_IMPORT_RE = re.compile(r"^\s*import\s+([A-Za-z0-9_.]+)\s*$")
+
+
+def parse_imports(path: Path) -> list[str]:
+    imports: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = QUALIFIED_IMPORT_RE.match(line.split("--", 1)[0].rstrip())
+        if match:
+            imports.append(match.group(1))
+    return imports
+
+
+def lean_exe_roots(lakefile: Path) -> set[str]:
+    r"""Module names declared as ``lean_exe ... root := `X.Y.Z`/``."""
+    roots: set[str] = set()
+    for line in lakefile.read_text(encoding="utf-8").splitlines():
+        match = LEAN_EXE_ROOT_RE.match(line)
+        if match:
+            roots.add(match.group(1))
+    return roots
+
+
+def module_name_for(rel_path: Path) -> str:
+    """`HexFoo/Bar/Baz.lean` → `HexFoo.Bar.Baz`."""
+    return ".".join(rel_path.with_suffix("").parts)
+
+
+def import_closure_in_library(
+    root: Path, entry_module: str, owner: str
+) -> set[str]:
+    """Modules belonging to `owner` reachable from `entry_module`.
+
+    Walks `import` lines, but only crawls into modules whose name starts
+    with `owner.`; that's enough for the umbrella-completeness check,
+    which only compares against files under `owner/`.
+    """
+    seen: set[str] = set()
+    stack: list[str] = [entry_module]
+    while stack:
+        module = stack.pop()
+        if module in seen:
+            continue
+        rel = Path(*module.split(".")).with_suffix(".lean")
+        path = root / rel
+        if not path.exists():
+            continue
+        seen.add(module)
+        for imported in parse_imports(path):
+            if imported == owner or imported.startswith(owner + "."):
+                stack.append(imported)
+    return seen
+
+
+def check_umbrella_completeness(
+    root: Path, libraries, exe_roots: set[str]
+) -> list[str]:
+    """Every regular module under `Foo/` must be reachable from either
+    `Foo.lean` (umbrella) or some `lean_exe` root.
+
+    A module reachable only from a `lean_exe` root is still absent from
+    the library's shared object `libHex_Foo.dylib`, but that's fine —
+    its symbols ship with the executable and downstream libraries don't
+    expect to call into bench / emit-fixture code.
+    """
+    errors: list[str] = []
+    for owner in libraries:
+        directory = root / owner
+        if not directory.is_dir():
+            continue
+        umbrella_path = root / f"{owner}.lean"
+        if not umbrella_path.exists():
+            continue
+        reachable = import_closure_in_library(root, owner, owner)
+        for exe_root in exe_roots:
+            reachable |= import_closure_in_library(root, exe_root, owner)
+        for lean_file in sorted(directory.rglob("*.lean")):
+            module = module_name_for(lean_file.relative_to(root))
+            if module in exe_roots:
+                continue
+            if module in reachable:
+                continue
+            errors.append(
+                f"{owner}.lean does not (transitively) import {module}; "
+                "add it to the umbrella, or declare it as a lean_exe root"
+            )
+    return errors
 
 
 def project_lean_files(root: Path) -> list[Path]:
@@ -59,6 +146,9 @@ def main() -> int:
     for name in list(libraries) + sorted(KNOWN_EXCEPTIONS):
         if not (root / f"{name}.lean").exists():
             errors.append(f"missing root file {name}.lean")
+
+    exe_roots = lean_exe_roots(root / "lakefile.lean")
+    errors.extend(check_umbrella_completeness(root, libraries, exe_roots))
 
     for rel_path in project_lean_files(root):
         owner = library_owner_for_path(rel_path, libraries)


### PR DESCRIPTION
This PR adds preventative scaffolding for a class of cross-platform linking bugs that the current Linux-only CI cannot catch.

When a library's umbrella `.lean` does not import every module file under its directory, Lake builds the umbrella shared library `libHex_Foo.dylib`/`.so` from only the umbrella's import set, so the shared library is missing those modules' private symbols. On Linux, flat-namespace lazy binding hides this by resolving the missing symbols against per-module dylibs that happen to be loaded for the same elaboration run. On macOS, dyld's stricter symbol resolution aborts with `dyld[..]: missing symbol called` on the first downstream elaboration that touches the absent symbols. The gap surfaced in `HexPolyFp` (`Quotient`, `QuotientFrobenius`, `Enumeration`) when `HexBerlekampZassenhaus.factor` was exercised end-to-end on macOS, and cascaded to apparent breakage of every umbrella that transitively imports `HexPolyFp`.

Three preventative pieces:

- `.github/workflows/ci.yml` gains a `build-macos` job (`macos-latest`, `brew install gmp`, `lake build` via `leanprover/lean-action@v1`).
- `scripts/check_dag.py` gains an umbrella-completeness rule: every `Foo/Bar.lean` is either declared as a `lean_exe` root in `lakefile.lean` or reachable in the import closure of `Foo.lean` (or any `lean_exe` root). This catches the regression at PR-creation time, before CI spends build minutes on it.
- `PLAN/Phase0.md` is updated so a from-scratch run of Phase 0 emits the macOS job and the `check_dag.py` rule, and `PLAN/Conventions.md` gains a "Library umbrella discipline" subsection explaining the rule and the platform asymmetry behind it.

Also applies the immediate concrete fix: `HexPolyFp.lean` now imports `Enumeration`, `Quotient`, and `QuotientFrobenius`, so `check_dag.py` passes and `libHex_HexPolyFp.dylib` rebuilds with their `.c.o.export` symbols included. Verified locally on macOS: `python3 scripts/check_dag.py` exits 0, `lake build hexbz_emit_fixtures` builds clean from a fresh state.

🤖 Prepared with Claude Code