### PR TITLE
chore: roll HexHensel back from done_through 5 → 3

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -80,7 +80,7 @@ libraries:
   HexHensel:
     deps: [HexPolyFp, HexPolyZ]
     mathlib: false
-    done_through: 5
+    done_through: 3
   HexConway:
     deps: [HexBerlekamp]
     mathlib: false


### PR DESCRIPTION
This PR rolls `HexHensel.done_through` from 5 to 3, per [PLAN/Conventions.md §Rollback is a normal action](PLAN/Conventions.md), in response to a bench-coverage gap that hid an exponential-vs-polynomial bug in `iterateQuadraticHensel`.

Symptom: `HexBerlekampZassenhaus.factor (x-1)(x-2)(x-3)` does not return within 30 s of CPU time, blocked at `henselLiftData → multifactorLiftQuadratic → iterateQuadraticHensel`. The doubling loop is invoked with `fuel := k` (where `k` is the *target precision*, i.e. the result must be valid mod `p^k`), so it transits through modulus `p^(2^k)` before reducing back. Quadratic Hensel needs `⌈log₂ k⌉` doublings to reach `p^k`, not `k` doublings. With `k = 42` (a realistic Mignotte bound for a degree-3 input) we work with `p^(2^42)`-sized integers — galaxy-sized.

The Phase 4 bench did not catch this because [HexHensel/Bench.lean](HexHensel/Bench.lean) parameterises `runMultifactorLiftQuadraticChecksum` only over the polynomial degree `n`, with the precision `k` fixed at `3`. At `k = 3` the over-shoot is `p^8` either way and the declared complexity model `n => n * n` is consistent with observed scaling. The bench could not detect the wrong iteration count.

Tracked in #2445 (the implementation issue, `human-oversight`). A follow-up PR tightens [SPEC/Libraries/hex-hensel.md](SPEC/Libraries/hex-hensel.md) on the iteration-count contract and on Phase 4 bench-domain coverage. The implementation fix and the bench expansion happen at re-entry to Phase 4 once those land.

🤖 Prepared with Claude Code