### PR TITLE
spec: tighten hex-hensel on quadratic doubling count and bench domains

### DIFF
--- a/SPEC/Libraries/hex-hensel.md
+++ b/SPEC/Libraries/hex-hensel.md
@@ -32,7 +32,13 @@ statements like "mod `p^k`" and "mod `p^(k+1)`".
     representative in `[0, p^k)`, then renormalizes the resulting
     `ZPoly` to remove trailing zero coefficients.
 - **Linear Hensel lifting**: from `mod p^k` to `mod p^(k+1)`
-- **Quadratic Hensel lifting**: from `mod p^k` to `mod p^(2k)` (doubling)
+- **Quadratic Hensel lifting**: a single doubling step takes data
+  valid `mod m` to data valid `mod m²`. The wrapper that lifts from
+  `mod p` to a target precision `mod p^k` must run `⌈log₂ k⌉` doubling
+  steps (then reduce modulo `p^k`), **not** `k` doubling steps. With
+  `k` doublings the intermediate modulus is `p^(2^k)`, exponential in
+  `k`, which breaks the polynomial-time complexity model for the
+  Berlekamp–Zassenhaus pipeline.
 - **Multifactor lifting**: public API returns a list/array of lifted
   factors; any binary factor tree is internal to the implementation
 
@@ -209,6 +215,25 @@ Examples include uniqueness of lifts (including the
 linear-vs-quadratic agreement statement), `coprime_mod_p_lifts`, and
 transfer theorems phrased in terms of Mathlib polynomials.
 
+**Iteration count for the quadratic wrapper.** `multifactorLiftQuadratic
+p k` and `henselLiftQuadratic p k` produce data valid modulo `p^k`
+using `⌈log₂ k⌉` doubling steps from modulus `p`, then reducing modulo
+`p^k`. The iteration count is `O(log k)` — never `O(k)`. In the
+Berlekamp–Zassenhaus pipeline `k` is a Mignotte bound, polynomial in
+the input size; `O(log k)` doublings is what keeps the lifter
+polynomial.
+
+**Phase 4 bench coverage.** Bench registrations for `multifactorLift`,
+`multifactorLiftQuadratic`, `henselLift`, and `henselLiftQuadratic`
+must vary `k` as a benchmark parameter (not only the degree `n`) with
+a declared complexity model in both. The `k` schedule must include
+realistic Mignotte-bound values produced by
+`ZPoly.defaultFactorCoeffBound` on the inputs
+`HexBerlekampZassenhaus.Bench` exercises — typically tens, not single
+digits. A registration over only `n` at fixed small `k` cannot detect
+a wrong iteration count and is not an admissible Phase 4 deliverable.
+The linear-vs-quadratic `compare` cross-check varies both `n` and `k`.
+
 **Strategy**: Quadratic Hensel lifting is the production lifter for
 the Berlekamp–Zassenhaus pipeline, and the `multifactorLiftQuadratic`
 surface is a Phase 1 deliverable, not an optimisation deferred to a
@@ -218,6 +243,7 @@ shared inputs, and that agreement is the obligation of
 `hex-hensel-mathlib` via lift uniqueness. Phase 3 conformance must
 exercise `multifactorLiftQuadratic` end-to-end (cross-checked against
 `multifactorLift` at small `k`); Phase 4 benchmarks must register
-quadratic lifting as the hot path. Treating quadratic lifting as
-"later" is incompatible with the polynomial-time complexity model
-declared for the Berlekamp–Zassenhaus pipeline.
+quadratic lifting as the hot path, under the iteration-count and
+`k`-coverage rules in the previous subsections. Treating quadratic
+lifting as "later" is incompatible with the polynomial-time complexity
+model declared for the Berlekamp–Zassenhaus pipeline.


### PR DESCRIPTION
This PR tightens [SPEC/Libraries/hex-hensel.md](SPEC/Libraries/hex-hensel.md) on two points the original spec left implicit and that downstream benchmarking failed to enforce.

Adds an explicit asymptotic requirement for the quadratic multifactor wrapper: `multifactorLiftQuadratic p k` and `henselLiftQuadratic p k` must use `⌈log₂ k⌉` doublings to reach precision `p^k`, not `k`. Performing `k` doublings transits through `p^(2^k)`, exponential in the target precision, and is incompatible with the polynomial-time complexity model the spec already declares for the Berlekamp–Zassenhaus pipeline. The unstated implementation freedom on iteration count was the root cause of #2445.

Adds a Phase 4 bench-coverage clause requiring Hensel-lift bench registrations to vary the target precision `k`, with realistic Mignotte-bound values, and to declare a complexity model dependent on both `n` and `k`. The current `HexHensel.Bench` registrations parameterise only on `n` with `k` fixed at `3`, which is why the verdict surface accepted an `O(k)`-vs-`O(log k)` over-shoot that hangs `HexBerlekampZassenhaus.factor` on degree-3 inputs at runtime.

Falls under [SPEC/design-principles.md §Scope of autonomous SPEC edits](SPEC/design-principles.md): the original SPEC asserts a polynomial-time complexity model for BZ that the unstated implementation freedom on iteration count would have made unattainable. This is a clarification of an existing internally-implied contract, not a new design choice.

Tracks #2445; rollback #2446 has already merged.

🤖 Prepared with Claude Code