### PR TITLE
spec: require end-to-end conformance and downstream-realistic bench domains

### DIFF
--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -88,6 +88,14 @@ required.
   inputs live under `HexFoo/Bench/Inputs/`.
 - **Keep smoke and scientific settings distinct.** `verify` is for
   wiring; Phase 4 completion is judged on real runs.
+- **Cover downstream call patterns.** When the SPEC declares an
+  operation the production hot path of a downstream operation, the
+  bench parameter schedule must cover the parameter values the
+  downstream caller actually produces. A schedule that excludes the
+  downstream-realistic range cannot detect a wrong-asymptotic
+  implementation that downstream use exercises. The schedule must
+  vary every parameter the operation takes that the downstream
+  caller varies — not only the most obvious one.
 
 ## Exit criteria
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -107,6 +107,16 @@ is the `core` profile for `HexFoo`. It MUST:
    #guard let (g, s, t) := HexArith.extGcd 30 12; s * 30 + t * 12 = g
    ```
 
+8. **Exercise top-level entry points end-to-end.** When the library
+   SPEC names a public top-level entry point (e.g.
+   `HexBerlekampZassenhaus.factor`), at least one conformance case
+   per such entry point must call it with a raw input and assert the
+   output — not bypass it via internal-stage helpers (e.g. supplying
+   pre-lifted factors directly to `recombine`). Internal-stage checks
+   are useful but not a substitute: they cannot detect a
+   wrong-asymptotic intermediate stage that the entry point would
+   exercise at realistic input sizes.
+
 ## Banned anti-patterns
 
 These patterns have produced ceremony-heavy modules with no teeth and


### PR DESCRIPTION
This PR closes two SPEC/PLAN gaps that issues #2445 and #2449 would otherwise be the only record of: a from-scratch reimplementation against the current SPEC and PLAN would still ship the same Hensel iteration-count bug and the same end-to-end runtime hang in `HexBerlekampZassenhaus.factor`.

[SPEC/testing.md](SPEC/testing.md) gains an item 8 requiring at least one Phase 3 conformance case per public top-level entry point that calls the entry point with a raw input — not via an internal-stage helper with prepared intermediate data. The existing per-operation rule was satisfiable by testing `recombine` directly with pre-supplied lifted factors, which is exactly how the BZ pipeline's `henselLiftData → multifactorLiftQuadratic` chain escaped Phase 3 conformance scrutiny.

[PLAN/Phase4.md](PLAN/Phase4.md) Discipline gains a "Cover downstream call patterns" bullet requiring a bench parameter schedule to vary every parameter the downstream caller varies, over the values the downstream caller actually produces. The general form of the Hensel `k`-axis gap that let an `O(k)`-vs-`O(log k)` iteration-count bug pass Phase 4 verification at fixed `k = 3` while the BZ pipeline calls with `k ≈ 40`.

Falls under [SPEC/design-principles.md §Scope of autonomous SPEC edits](SPEC/design-principles.md): both rules are clarifications of disciplines the SPEC/PLAN already imply (Phase 3 conformance is meant to test the *library's API contract*, Phase 4 benchmarking is meant to *detect wrong implementations*). Without them stated, both can be satisfied vacuously.

🤖 Prepared with Claude Code