### PR TITLE
spec: oracle discipline for conformance cross-checks

### DIFF
--- a/PLAN/Phase3.md
+++ b/PLAN/Phase3.md
@@ -69,6 +69,15 @@ Reviewer checklist for Phase 3 PRs:
 - [ ] CI conformance matrix builds this library (either via the
   derivation script picking up the root-import, or via an explicit
   matrix entry).
+- [ ] Every `emitResult` in `HexFoo/EmitFixtures.lean` is
+  cross-checked by the corresponding oracle script under the three
+  rules in
+  [../SPEC/testing.md §Oracle discipline](../SPEC/testing.md#oracle-discipline):
+  independent expected value (no re-running the operation under
+  test on Lean's output), uniform contract across input classes (no
+  shape-dependent bypass to a weaker invariant), and a tracking
+  issue for any deliberately uncovered op (with the conformance
+  docstring not claiming it as covered).
 
 ## Oracle wiring (forward reference)
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -117,6 +117,57 @@ is the `core` profile for `HexFoo`. It MUST:
    wrong-asymptotic intermediate stage that the entry point would
    exercise at realistic input sizes.
 
+## Oracle discipline
+
+Every operation in a library's SPEC API surface that is exercised by
+fixtures via `HexFoo/EmitFixtures.lean` MUST have an external-oracle
+cross-check that satisfies all three rules below. A SPEC declaration
+that names an operation but cannot be paired with an oracle satisfying
+these rules is not Phase-3-ready: file the oracle issue first and hold
+the library at `done_through ≤ 2`.
+
+1. **Independent expected value.** The oracle computes the expected
+   value from the original fixture input, using the oracle's own
+   implementation, never by re-running the operation under test on
+   Lean's output. Canonicalisation between Lean and oracle outputs
+   (e.g. monic-normalisation, sorting by a deterministic key,
+   extracting an explicit unit field) is permitted; re-applying the
+   operation under test as a "canonicalisation" is not. An oracle
+   that re-factors each component of Lean's factorisation through
+   FLINT and compares the union as a multiset accepts any Lean
+   output the oracle's own factor call can refine to the right
+   answer — including Lean returning the input unchanged. That is
+   not a cross-check.
+
+2. **Uniform contract on every input class.** No input-shape-dependent
+   bypass to a strictly weaker invariant. If the fixture set covers
+   square-free and non-square-free inputs, both must be cross-checked
+   against the same correctness contract. A self-consistency invariant
+   like `∏ buckets · residual = f` is a sanity check, not a
+   cross-check. If a class genuinely cannot be cross-checked under the
+   same contract, remove it from the fixture set or split it into a
+   separate operation with its own oracle.
+
+3. **Explicit non-coverage is a tracking obligation.** An emitted
+   operation that has no external oracle (whether deferred or
+   genuinely blocked) must be paired with an open `human-oversight`
+   issue, linked from both `EmitFixtures.lean` and the corresponding
+   oracle script's docstring. The library's `Conformance.lean`
+   docstring must not claim the operation as covered. Self-consistency
+   invariants are not a substitute for an external oracle and must
+   not be advertised as conformance coverage.
+
+For factorisation operations specifically, the canonical oracle
+pattern is **multiplicity-bucket comparison**: factor the input via
+the oracle into its irreducibles `∏ pᵢ^eᵢ`, group by exponent,
+monic-normalise each side, and require Lean's output to be a valid
+refinement of the oracle's irreducible decomposition under the
+operation's documented bucket semantics (full irreducible
+factorisation, distinct-degree factorisation, square-free
+decomposition, etc.). This pattern is strict (rejects unfactored or
+under-decomposed Lean outputs) while still admitting the legitimate
+non-uniqueness of factor order.
+
 ## Banned anti-patterns
 
 These patterns have produced ceremony-heavy modules with no teeth and


### PR DESCRIPTION
This PR adds three rules and one canonical pattern under a new \"Oracle discipline\" section of [SPEC/testing.md](SPEC/testing.md), plus a reviewer-checklist item in [PLAN/Phase3.md](PLAN/Phase3.md).

The rules close a class of permissive cross-check defects discovered in the BZ and Berlekamp oracle scripts during a survey of the conformance suite:

- `bz_flint` re-factors each Lean output component through FLINT before comparing as a multiset, so a Lean output of `[(input)]` (unfactored) is treated as equivalent to the full decomposition. Concretely, [conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl](conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl) freezes Lean's incomplete factorisations of `red/x4_minus_1`, `red/x16_minus_1`, and `red/x10_minus_1` as the expected baseline, and the oracle accepts them. Rule 1 (independent expected value) bans the pattern.
- `berlekamp_flint` skips the strict per-bucket equality check on non-square-free inputs and falls back to the trivial product invariant. The committed `rep/*` cases all live in this permissive path. Rule 2 (uniform contract on every input class) bans the pattern.
- `HexBerlekamp.squareFreeDecomposition` is emitted but explicitly not cross-checked at all, with the EmitFixtures docstring deferring to a Lean-internal product invariant. Rule 3 (explicit non-coverage is a tracking obligation) requires a `human-oversight` issue and forbids advertising the operation as conformance-covered.

The canonical-pattern note codifies multiplicity-bucket comparison: factor via the oracle into irreducibles, group by exponent, monic-normalise, and require Lean's output to be a valid refinement of the oracle's irreducible decomposition under the operation's documented bucket semantics. This is strict (rejects unfactored outputs) while admitting legitimate factor-order non-uniqueness, and is the design every factorisation oracle in this repo should converge on.

Falls under [SPEC/design-principles.md §Scope of autonomous SPEC edits](SPEC/design-principles.md): the original SPEC implies factorisation outputs are correctness-checked by external oracles; the unstated discretion on what \"cross-check\" means in a re-canonicalising oracle made the implication unenforceable. This is a clarification of an internally-implied contract.

Three follow-up `human-oversight` issues filed alongside this PR cover the concrete defects.

🤖 Prepared with Claude Code