### PR TITLE
spec: require adaptive precision in BZ Hensel-lift + recombine loop

### DIFF
--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -102,6 +102,25 @@ the pipeline. An exhaustive subset fallback may be retained as an
 internal small-input shortcut and as a conformance-test oracle, but
 never as the production path.
 
+**Precision selection.** The Hensel-lift target precision `k` is
+chosen *adaptively*, not set once to the worst-case Mignotte bound.
+The pipeline starts with a small initial `k₀` (e.g. constant or
+`O(log deg f)`), invokes `multifactorLiftQuadratic` to that
+precision, and calls `recombine`. If `recombineLLL?` returns `none`,
+the pipeline doubles `k` and retries the lift + recombination.
+Doubling continues until either recombination succeeds or `k`
+exceeds the Mignotte upper bound from
+`ZPoly.defaultFactorCoeffBound`, in which case the pipeline reports
+the input as irreducible — the Mignotte bound being a mathematical
+guarantee that no factor with smaller coefficients exists.
+
+The conditional correctness contract `factor_product_of_bound` is
+unchanged: implementations may pick any `k₀` and any escalation
+schedule, provided the upper bound is the Mignotte bound and the
+loop terminates. `recombineLLL?`'s `Option (Array ZPoly)` return
+type is the escalation signal: `none` means "this `k` was not
+sufficient, escalate".
+
 **Conditional correctness (proved in this library, no Mathlib):**
 
 The algorithm's correctness is proved conditionally on the coefficient

--- a/SPEC/Libraries/hex-hensel.md
+++ b/SPEC/Libraries/hex-hensel.md
@@ -221,7 +221,11 @@ using `⌈log₂ k⌉` doubling steps from modulus `p`, then reducing modulo
 `p^k`. The iteration count is `O(log k)` — never `O(k)`. In the
 Berlekamp–Zassenhaus pipeline `k` is a Mignotte bound, polynomial in
 the input size; `O(log k)` doublings is what keeps the lifter
-polynomial.
+polynomial. Note that `hex-berlekamp-zassenhaus` calls this wrapper
+*adaptively* (see that library's "Precision selection" subsection):
+typically multiple times with successively larger `k`, not once at
+the Mignotte upper bound. Each individual call still uses
+`⌈log₂ k⌉` doublings for its given target.
 
 **Phase 4 bench coverage.** Bench registrations for `multifactorLift`,
 `multifactorLiftQuadratic`, `henselLift`, and `henselLiftQuadratic`


### PR DESCRIPTION
Adds a **Precision selection** subsection to [SPEC/Libraries/hex-berlekamp-zassenhaus.md](SPEC/Libraries/hex-berlekamp-zassenhaus.md) requiring `Hex.factor`'s Hensel-lift target precision `k` to be chosen adaptively: start with small `k₀`, attempt LLL recombination, on `recombineLLL? = none` double `k` and retry, halt on success or when `k` exceeds the Mignotte upper bound (in which case the input is irreducible).

The existing SPEC asserts polynomial-time complexity for the BZ pipeline but does not constrain how `k` is chosen. The unstated discretion admits the current single-shot-at-Mignotte implementation, which is exponentially over-provisioned on cyclotomic / sparse / small-coefficient inputs. Concrete runtime evidence: `factor (Φ₁₁·Φ₂₂)` (deg 20, Mignotte bound 739 024) takes ~4.6 s on this machine vs. ~0.2 ms in python-flint, with ~97% of the cost in the single Hensel-lift call to mod 7^739024. Adaptive precision lifts to a small `k`, retries on recombination failure, and stops as soon as the true factor coefficient size is bracketed.

The conditional correctness contract `factor_product_of_bound` is unchanged: only the implementation freedom is constrained, not the theorem statement. `recombineLLL?`'s existing `Option (Array ZPoly)` return type is the natural escalation signal — `none` means "this `k` was not sufficient, escalate".

Falls under [SPEC/design-principles.md §Scope of autonomous SPEC edits](SPEC/design-principles.md): clarifying an internally-implied contract (polynomial-time complexity) that the unstated `k`-choice freedom made unenforceable.

Also a one-paragraph consistency note in [SPEC/Libraries/hex-hensel.md](SPEC/Libraries/hex-hensel.md)'s "Iteration count for the quadratic wrapper" subsection clarifying that BZ now calls the wrapper multiple times with successively larger `k`. No new requirement on Hensel itself; the `⌈log₂ k⌉` discipline per individual call is unchanged.

Implementation issue (`human-oversight`) filed separately with the runtime evidence and the adaptive-loop sketch.

🤖 Prepared with Claude Code