### PR TITLE
HexMatrixMathlib: prove Bareiss pivot-search failure surface

### DIFF
--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -135,6 +135,52 @@ theorem findPivot?_ge_start (M : Matrix Int n n) (col : Fin n)
     start ≤ pivot.val :=
   findPivotAux_ge_start M col start (n - start) hfind
 
+/-- If bounded pivot search fails, every checked entry in the pivot column is
+zero. -/
+theorem findPivotAux_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
+    (start fuel : Nat) (hfind : findPivotAux M col start fuel = none)
+    (i : Fin n) (hstart : start ≤ i.val) (hfuel : i.val < start + fuel) :
+    M[i][col] = 0 := by
+  induction fuel generalizing start with
+  | zero =>
+      omega
+  | succ fuel ih =>
+      by_cases hlt : start < n
+      · by_cases hi : i.val = start
+        · have hentry : M[(⟨start, hlt⟩ : Fin n)][col] = 0 := by
+            by_cases hzero : M[(⟨start, hlt⟩ : Fin n)][col] = 0
+            · exact hzero
+            · have hzeroNat : ¬ M[start][col.val] = 0 := by
+                simpa using hzero
+              simp [findPivotAux, hlt, hzeroNat] at hfind
+          have hiFin : i = (⟨start, hlt⟩ : Fin n) := Fin.ext hi
+          rw [hiFin]
+          exact hentry
+        · have hentry : M[(⟨start, hlt⟩ : Fin n)][col] = 0 := by
+            by_cases hzero : M[(⟨start, hlt⟩ : Fin n)][col] = 0
+            · exact hzero
+            · have hzeroNat : ¬ M[start][col.val] = 0 := by
+                simpa using hzero
+              simp [findPivotAux, hlt, hzeroNat] at hfind
+          have hnext : findPivotAux M col (start + 1) fuel = none := by
+            have hentryNat : M[start][col.val] = 0 := by
+              simpa using hentry
+            simp [findPivotAux, hlt, hentryNat] at hfind
+            exact hfind
+          have hstart' : start + 1 ≤ i.val := by omega
+          have hfuel' : i.val < start + 1 + fuel := by omega
+          exact ih (start + 1) hnext hstart' hfuel'
+      · omega
+
+/-- If pivot search fails, every entry in the searched suffix of the pivot
+column is zero. -/
+theorem findPivot?_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
+    (start : Nat) (hfind : findPivot? M col start = none)
+    (i : Fin n) (hstart : start ≤ i.val) :
+    M[i][col] = 0 := by
+  apply findPivotAux_eq_zero_of_none M col start (n - start) hfind i hstart
+  omega
+
 /-- Apply one Bareiss update step to the trailing submatrix strictly below and
 to the right of the current pivot. -/
 def stepMatrix (M : Matrix Int n n) (k : Nat) (pivot prevPivot : Int) :

--- a/HexMatrixMathlib/Determinant/Bareiss.lean
+++ b/HexMatrixMathlib/Determinant/Bareiss.lean
@@ -234,6 +234,61 @@ theorem bareissPivotInvariant_regular_no_swap
         singularStep := none } :=
   bareissNoPivotInvariant_step source state hinv hDone hp
 
+/-- In the pivot-search failure branch, the current pivot column is zero at
+and below the current step. -/
+theorem bareissPivotNoPivot_column_eq_zero
+    (state : Hex.Matrix.BareissState n) (hDone : state.step + 1 < n)
+    (hp0 : state.matrix[state.step][state.step] = 0)
+    (hfind :
+      Hex.Matrix.findPivot? state.matrix
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+        (state.step + 1) = none) :
+    ∀ i : Fin n, state.step ≤ i.val →
+      state.matrix[i][
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)] =
+        0 := by
+  intro i hi
+  by_cases heq : i.val = state.step
+  · have hiFin :
+        i = (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ :
+          Fin n) :=
+      Fin.ext heq
+    rw [hiFin]
+    simpa using hp0
+  · have hstart : state.step + 1 ≤ i.val := by omega
+    exact Hex.Matrix.findPivot?_eq_zero_of_none state.matrix
+      (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+      (state.step + 1) hfind i hstart
+
+/-- In the pivot-search failure branch, the bordered-minor invariant identifies
+the zero current pivot with the next leading-prefix determinant. -/
+theorem bareissPivotNoPivot_leadingPrefix_det_eq_zero
+    (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
+    (hinv : BareissNoPivotInvariant source state)
+    (hDone : state.step + 1 < n)
+    (hp0 : state.matrix[state.step][state.step] = 0)
+    (hfind :
+      Hex.Matrix.findPivot? state.matrix
+        (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
+        (state.step + 1) = none) :
+    Hex.Matrix.det
+      (Hex.Matrix.leadingPrefix source (state.step + 1)
+        (Nat.succ_le_of_lt (Nat.lt_of_succ_lt hDone))) = 0 := by
+  have hcol := bareissPivotNoPivot_column_eq_zero state hDone hp0 hfind
+  have hk : state.step < n := Nat.lt_of_succ_lt hDone
+  have hpivot :
+      state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
+        0 := hcol ⟨state.step, hk⟩ (Nat.le_refl _)
+  have hpivot_det :
+      state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
+        Hex.Matrix.det
+          (Hex.Matrix.borderedMinor source state.step hk
+            (⟨state.step, hk⟩ : Fin n) (⟨state.step, hk⟩ : Fin n)) :=
+    hinv.trailing_eq hk ⟨state.step, hk⟩ ⟨state.step, hk⟩
+      (Nat.le_refl _) (Nat.le_refl _)
+  rw [hpivot_det, borderedMinor_corner_eq_leadingPrefix source state.step hk] at hpivot
+  exact hpivot
+
 private theorem findPivot?_some_ne_current
     (state : Hex.Matrix.BareissState n) (hDone : state.step + 1 < n)
     {pivot : Fin n}

--- a/progress/20260507T013721Z_5b62a82e.md
+++ b/progress/20260507T013721Z_5b62a82e.md
@@ -1,0 +1,37 @@
+# 2026-05-07 01:37 UTC — work session (5b62a82e)
+
+## Accomplished
+
+Claimed #2523 and added the pivot-search-failure proof surface:
+
+- exposed `Hex.Matrix.findPivotAux_eq_zero_of_none` and
+  `Hex.Matrix.findPivot?_eq_zero_of_none` in `HexMatrix/Bareiss.lean`;
+- added `bareissPivotNoPivot_column_eq_zero` and
+  `bareissPivotNoPivot_leadingPrefix_det_eq_zero` in
+  `HexMatrixMathlib/Determinant/Bareiss.lean`.
+
+Verification completed:
+
+- `lake build HexMatrix.Bareiss`
+- `lake build HexMatrixMathlib.Determinant.Bareiss`
+- `lake build HexMatrixMathlib.Determinant`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexMatrix/Bareiss.lean HexMatrixMathlib/Determinant/Bareiss.lean`
+
+The only `sorry` hit in the touched files is the pre-existing Bareiss capstone
+in `HexMatrix/Bareiss.lean`.
+
+## Current frontier
+
+#2523 has the branch API needed to connect failed pivot search with a zero
+next leading-prefix determinant under the existing bordered-minor invariant.
+
+## Next step
+
+Create the PR for #2523.
+
+## Blockers
+
+The worktree still contains an unrelated pre-existing `.claude/CLAUDE.md`
+modification that this session did not touch.


### PR DESCRIPTION
Closes #2523

Session: `5b62a82e-f920-41c3-a868-fa84fda1c8ed`

7fe8b22 prove Bareiss pivot-search failure surface

🤖 Prepared with Claude Code