### PR TITLE
ci: scope push trigger to main, add concurrency groups, document doctrine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -2,8 +2,13 @@ name: Conformance
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   setup:

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -58,6 +58,21 @@ At the start of every planner cycle, merge all mergeable+green open
 PRs before creating new work. Downstream agents are blocked on `main`
 until merged PRs land.
 
+`main` is branch-protected: auto-merge only fires once every required
+status check (`build`, `build-macos`, `conformance`) is green. CI
+gating is non-negotiable — see [SPEC/CI.md](../SPEC/CI.md).
+
+### CI work expansion
+
+When adding a new conformance check, oracle, benchmark, or build
+target, **extend the script of the existing single ubuntu job** in
+the relevant workflow (`conformance.yml` for conformance/oracle work,
+`ci.yml` for build/check work). Do **not** add a new top-level job,
+a new `strategy.matrix`, or a new workflow file. The full rationale
+and the trigger / concurrency / Mathlib-cache rules every workflow
+must satisfy live in [SPEC/CI.md](../SPEC/CI.md); read it before
+editing any file under `.github/workflows/`.
+
 ---
 
 ## Lexical conventions

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -180,12 +180,22 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    - Exit non-zero on malformed `libraries.yml` or disagreement
      between `libraries.yml` and `lakefile.lean`.
 
-6. Set up CI using `leanprover/lean-action`.
+6. Set up CI using `leanprover/lean-action`. **Read
+   [SPEC/CI.md](../SPEC/CI.md) before editing any workflow file** —
+   it pins the trigger, concurrency, job-count, and Mathlib-cache
+   rules every workflow in this repo must satisfy.
 
-   **`.github/workflows/ci.yml`** (required, runs on every push/PR):
+   **`.github/workflows/ci.yml`** (required, runs on every PR and on
+   pushes to `main`):
    ```yaml
    name: CI
-   on: [push, pull_request]
+   on:
+     push:
+       branches: [main]
+     pull_request:
+   concurrency:
+     group: ${{ github.workflow }}-${{ github.ref }}
+     cancel-in-progress: true
    jobs:
      build:
        runs-on: ubuntu-latest
@@ -203,6 +213,16 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - uses: leanprover/lean-action@v1
    ```
 
+   The trigger is `push: branches: [main]` plus `pull_request:` —
+   **not** the bare `push:` form. A bare `push:` fires on every
+   commit to every branch *and* on every PR, doubling CI cost on
+   every PR push. Restricting `push:` to `main` and relying on
+   `pull_request:` for branch-side coverage avoids the duplication.
+   The `concurrency:` block cancels superseded runs on the same
+   branch when a new commit arrives — agent branches that get
+   re-pushed during a single session must not stack up queued runs.
+   Both rules are normative; see [SPEC/CI.md](../SPEC/CI.md).
+
    The DAG check runs before the Lean build so import-boundary
    violations fail fast without spending build time. `lean-action`
    performs the `lake build` itself. `libgmp-dev` is installed
@@ -218,14 +238,18 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    `check_dag.py` enforces the source-side condition and the macOS
    `lake build` is the cross-check.
 
-   **`.github/workflows/conformance.yml`** (optional, manual trigger):
-   Manual or locally-triggered conformance workflow following
-   `SPEC/testing.md`. Also uses `leanprover/lean-action` for the
-   Lean portion of the build; external tools (Sage, FLINT, fpLLL)
-   layer on top via `cachix/install-nix-action` when available. The
-   full conformance workflow is not required for the minimal Phase 0
-   repository bootstrap — a stub file pointing at `SPEC/testing.md`
-   is sufficient at this stage.
+   **`.github/workflows/conformance.yml`** (required; runs on every
+   PR and on pushes to `main`): same trigger + concurrency shape as
+   `ci.yml`, plus a `workflow_dispatch:` trigger for ad-hoc runs.
+   Following [SPEC/testing.md](../SPEC/testing.md) and the single-job
+   budget in [SPEC/CI.md](../SPEC/CI.md), the workflow runs the full
+   conformance + oracle pipeline in **one** ubuntu job: external
+   tools (FLINT, PARI, fpLLL, Conway) install side-by-side via apt
+   and pip, the Mathlib cache is fetched via `lake exe cache get`
+   with a hard-fail gate against silent rebuilds, and per-library
+   oracle checks run sequentially. New oracles or new conformance
+   targets extend the existing job's script — they do not introduce
+   new top-level jobs, matrices, or workflows.
 
 7. Create `.gitignore` (at minimum: `.lake/`, `build/`).
 

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -1,0 +1,173 @@
+# CI doctrine
+
+Normative rules for every GitHub Actions workflow under
+`.github/workflows/`. Read this before editing any workflow file or
+adding a new one.
+
+The rules in this file are tight on purpose. CI for this repository
+is shared with several other repositories under the same personal
+account (`kim-em/pod`, `kim-em/bubble`, …); a fan-out here pushes
+queue waits up to a day across all of them. The rules below cap that
+exposure at the source.
+
+## Triggers
+
+Every workflow uses **exactly** this trigger shape:
+
+```yaml
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # plus workflow_dispatch: where useful
+```
+
+The bare `on: [push, pull_request]` form is forbidden. It fires
+twice on every PR commit (once for the push event, once for the
+pull-request synchronize event) and once on every push to every
+agent/feature branch even before a PR exists. Restricting `push:` to
+`main` and relying on `pull_request:` for everything else makes each
+PR commit fire each workflow exactly once.
+
+`workflow_dispatch:` is allowed wherever an ad-hoc manual run is
+useful (currently `conformance.yml`).
+
+Other triggers (`schedule:`, `repository_dispatch:`, `release:`) are
+case-by-case; they must be documented in the workflow file with a
+comment explaining why they're justified.
+
+## Concurrency
+
+Every workflow MUST set:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+The group is `<workflow>-<ref>` so different workflows don't cancel
+each other but repeated commits to the same branch do. Without this,
+agent branches that re-push during a session leave a tail of queued
+runs that will all eventually pick up runners — pure waste.
+
+`cancel-in-progress: true` is the default the project wants; do not
+flip it to `false` without a documented reason. Conformance "almost
+finished" on a now-superseded commit is not worth keeping.
+
+## Job-count budget
+
+**Each workflow run uses exactly one ubuntu job.** The CI workflow
+also has one macOS job (the dyld cross-check). No other parallelism.
+
+Concretely:
+
+- `ci.yml`: one `build` ubuntu job, one `build-macos` macOS job.
+- `conformance.yml`: one ubuntu job that runs the full conformance
+  matrix and every oracle (FLINT, PARI, fpLLL, Conway) sequentially
+  inside that single runner.
+- Future workflows: one ubuntu job, period. If a second runner is
+  genuinely needed (e.g. a separate macOS bench cross-check), state
+  the reason in a workflow-level comment.
+
+**Do not introduce matrices.** GitHub-hosted Actions on a personal
+account is concurrency-capped at ~20 parallel ubuntu runners across
+*all* repositories owned by the account. A 10-entry matrix on one
+push will saturate the cap by itself; a 40-entry matrix will create
+24-hour queue waits. Per-target parallelism does not pay back in
+this project — every job re-builds the project's own Lean libraries
+on top of Mathlib, so a matrix entry that "only does one target"
+still pays the same fixed startup cost as the consolidated job.
+
+**New oracles, new conformance targets, and new bench targets
+extend the script of the single existing job.** Add an apt step
+for new system deps, a pip step for new Python deps, and a sequential
+shell loop for new per-library checks. Do not add a new top-level
+job, do not add `strategy.matrix`, and do not split a workflow.
+
+## Mathlib cache is mandatory
+
+Hex depends transitively on Mathlib (see `lakefile.lean`). Every
+job that runs `lake build` MUST first run `lake exe cache get` and
+then **hard-fail** if any Mathlib `.olean` would still be rebuilt
+from source.
+
+The hard-fail gate is `scripts/ci/check_no_mathlib_rebuild.sh`,
+which is responsible for:
+
+- running `lake exe cache get`;
+- inspecting Lake's reported plan (e.g. via `lake build Mathlib
+  --no-build` or by parsing `cache get`'s own output) to confirm
+  every Mathlib module already has a fetched `.olean`;
+- exiting non-zero with a clear message if any Mathlib module would
+  be rebuilt from source.
+
+The reason is operational, not aesthetic. Mathlib has thousands of
+modules; rebuilding from source on each runner adds 30+ minutes of
+compilation per job. Pre-cache, hex CI was spending the bulk of
+every runner-minute recompiling Mathlib that someone had already
+compiled upstream — that was the dominant cost driver of the
+24-hour queue this doctrine exists to prevent.
+
+A stale or missing cache is a fixable upstream problem (the
+Mathlib `cache` service publishes oleans for every Mathlib commit
+on `master`); the right response is to fix the upstream pin or the
+cache step, not to silently rebuild.
+
+## Branch protection
+
+`main` requires every status check produced by `ci.yml` and
+`conformance.yml` to pass before merge. The pod auto-merger
+(`gh pr merge --auto`) respects branch protection, so this is the
+mechanism that gates merges on CI.
+
+Required contexts (kept in sync with the actual job names in the
+workflow files):
+
+- `build` (from `ci.yml`)
+- `build-macos` (from `ci.yml`)
+- `conformance` (from `conformance.yml`)
+
+`enforce_admins: false` is acceptable — humans occasionally need to
+override (e.g. a known-good revert during incident response). PR
+reviews are not required by branch protection; review policy lives
+elsewhere.
+
+When job names change, the protection contexts need to be updated
+in the same PR via `gh api -X PUT
+/repos/<owner>/<repo>/branches/main/protection`. Update this section
+of `SPEC/CI.md` simultaneously so the source of truth doesn't
+drift.
+
+## Runners
+
+GitHub-hosted runners only at this stage: `ubuntu-latest`,
+`macos-latest`. Self-hosted runners would solve the concurrency
+problem but introduce maintenance burden, secrets management, and a
+trust boundary that this project hasn't decided on. If the
+single-job budget plus the cache discipline isn't enough, revisit
+self-hosted runners explicitly rather than drifting toward them.
+
+## How to add new CI work
+
+To add a new conformance check, oracle, benchmark, or build target:
+
+1. **Default**: extend the script of the existing single job in the
+   workflow that already covers this kind of work (`conformance.yml`
+   for conformance/oracle, `ci.yml` for build/check).
+2. Add any new system dependency to the existing apt/brew step.
+3. Add any new Python or Lean dependency to the existing install
+   step.
+4. Add a new sequential block to the helper script (e.g.
+   `scripts/ci/run_oracles.sh`) that performs the new check.
+5. Confirm the run still fits in one ubuntu job and the Mathlib
+   cache fetch still passes the hard-fail gate.
+6. Update the relevant SPEC and PLAN cross-references (this file,
+   `PLAN/Phase0.md` §6, `SPEC/testing.md`'s "Adding a new oracle"
+   section) if the change introduces a new category of check.
+
+A new top-level workflow is justified only by a clearly distinct
+class of CI work that genuinely cannot share a runner with existing
+work — e.g. a release workflow that runs on tag push only. Even
+then, the trigger, concurrency, single-job, and cache rules above
+all still apply.

--- a/SPEC/SPEC.md
+++ b/SPEC/SPEC.md
@@ -76,5 +76,6 @@ verified LLL gives confidence in attack results.
 - [Tutorials](tutorials.md)
 - [Testing](testing.md)
 - [Benchmarking](benchmarking.md)
+- [CI](CI.md)
 - [Prior art](prior-art.md)
 - [Future work](future-work.md)


### PR DESCRIPTION
This PR fixes the immediate hex-CI fan-out: every push to an agent branch was firing both the `push` and `pull_request` events of `ci.yml` and `conformance.yml`, and re-pushes to the same branch left a tail of queued runs that never got cancelled. Combined with a 41-job Conformance fan-out, the queue grew to ~500 runs with 24-hour wait times. This PR addresses the trigger and concurrency half of the fix; the Conformance single-job collapse, the mandatory Mathlib cache, the branch protection on `main`, and the prompting fixes follow as separate PRs.

Workflow changes:
- both workflows: `on: push (main only) + pull_request` (was bare `push + pull_request`).
- both workflows: new `concurrency: { group: <workflow>-<ref>, cancel-in-progress: true }`.

Doctrine changes (so a future re-implementation or agent can't regress this):
- new [SPEC/CI.md](SPEC/CI.md) captures triggers, concurrency, single-job budget, mandatory `lake exe cache get` with hard-fail gate, branch-protection requirements, and the "extend the existing job rather than fan out" rule.
- [PLAN/Phase0.md §6](PLAN/Phase0.md) is updated to match the new workflow shape and forward-references `SPEC/CI.md`.
- [PLAN/Conventions.md](PLAN/Conventions.md) gets a short "CI work expansion" subsection.

[SPEC/SPEC.md](SPEC/SPEC.md) gets a one-line navigation entry for `CI.md`.

Note: this touches `SPEC/`, which is normally agent-immutable. The addition is a deliberate doctrine entry prompted by the 24-hour CI queue incident, not a per-task SPEC edit.

🤖 Prepared with Claude Code