### PR TITLE
ci: collapse Conformance to 1 ubuntu job, add Mathlib cache hard-fail gate, move bench verify to ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,48 @@ jobs:
       - run: python3 scripts/check_dag.py
       - run: python3 scripts/check_phase4.py
       - run: sudo apt-get install -y libgmp-dev
-      - uses: leanprover/lean-action@v1
+      - name: Set up Lean toolchain (no build)
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          use-mathlib-cache: false
+      - name: Fetch Mathlib cache
+        run: lake exe cache get
+      - name: Verify Mathlib cache populated (hard fail on miss)
+        run: bash scripts/ci/check_no_mathlib_rebuild.sh
+      - name: Build hex (Mathlib must NOT rebuild from source)
+        run: lake build
+      - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)
+        run: |
+          lake exe hexarith_bench list
+          lake exe hexarith_bench verify
+          lake exe hexmatrix_bench list
+          lake exe hexmatrix_bench verify
+          lake exe hexpoly_bench list
+          lake exe hexpoly_bench verify
+          lake exe hexpolyz_bench list
+          lake exe hexpolyz_bench verify
+          lake exe hexpolyfp_bench list
+          lake exe hexpolyfp_bench verify
+          lake exe hexmodarith_bench list
+          lake exe hexmodarith_bench verify
+          lake exe hexgramschmidt_bench list
+          lake exe hexgramschmidt_bench verify
+          lake exe hexgf2_bench list
+          lake exe hexgf2_bench verify
+          lake exe hexgfqring_bench list
+          lake exe hexgfqring_bench verify
+          lake exe hexgfqfield_bench list
+          lake exe hexgfqfield_bench verify
+          lake exe hexlll_bench list
+          lake exe hexlll_bench verify
+          lake exe hexhensel_bench list
+          lake exe hexhensel_bench verify
+          lake exe hexberlekamp_bench list
+          lake exe hexberlekamp_bench verify
+          lake exe hexconway_bench list
+          lake exe hexconway_bench verify
 
   build-macos:
     runs-on: macos-latest
@@ -29,46 +70,15 @@ jobs:
           fetch-depth: 0
       - run: python3 scripts/check_dag.py
       - run: brew install gmp
-      - uses: leanprover/lean-action@v1
-      - run: |
-          lake exe hexmatrix_bench list
-          lake exe hexmatrix_bench verify
-      - run: |
-          lake exe hexarith_bench list
-          lake exe hexarith_bench verify
-      - run: |
-          lake exe hexpoly_bench list
-          lake exe hexpoly_bench verify
-      - run: |
-          lake exe hexpolyz_bench list
-          lake exe hexpolyz_bench verify
-      - run: |
-          lake exe hexgramschmidt_bench list
-          lake exe hexgramschmidt_bench verify
-      - run: |
-          lake exe hexmodarith_bench list
-          lake exe hexmodarith_bench verify
-      - run: |
-          lake exe hexgf2_bench list
-          lake exe hexgf2_bench verify
-      - run: |
-          lake exe hexpolyfp_bench list
-          lake exe hexpolyfp_bench verify
-      - run: |
-          lake exe hexgfqring_bench list
-          lake exe hexgfqring_bench verify
-      - run: |
-          lake exe hexgfqfield_bench list
-          lake exe hexgfqfield_bench verify
-      - run: |
-          lake exe hexlll_bench list
-          lake exe hexlll_bench verify
-      - run: |
-          lake exe hexhensel_bench list
-          lake exe hexhensel_bench verify
-      - run: |
-          lake exe hexberlekamp_bench list
-          lake exe hexberlekamp_bench verify
-      - run: |
-          lake exe hexconway_bench list
-          lake exe hexconway_bench verify
+      - name: Set up Lean toolchain (no build)
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          use-mathlib-cache: false
+      - name: Fetch Mathlib cache
+        run: lake exe cache get
+      - name: Verify Mathlib cache populated (hard fail on miss)
+        run: bash scripts/ci/check_no_mathlib_rebuild.sh
+      - name: Build hex (dyld symbol-resolution cross-check)
+        run: lake build

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,231 +11,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup:
+  conformance:
     runs-on: ubuntu-latest
-    outputs:
-      targets: ${{ steps.derive.outputs.targets }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Verify conformance matrix invariant
         run: python3 scripts/conformance_targets.py --check
-      - id: derive
-        name: Derive conformance matrix
-        run: |
-          targets="$(python3 scripts/conformance_targets.py --json)"
-          echo "targets=$targets" >> "$GITHUB_OUTPUT"
-
-  conformance:
-    needs: setup
-    runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: /home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/lib/lean
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ${{ fromJSON(needs.setup.outputs.targets) }}
-    steps:
-      - uses: actions/checkout@v4
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgmp-dev
+          sudo apt-get install -y libgmp-dev libpari-dev pari-gp libfplll-dev
+      - name: Install Python oracle dependencies
+        run: |
+          python3 -m pip install --user \
+            python-flint cypari2 conway-polynomials fpylll
+      - name: Set up Lean toolchain (no build)
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          use-mathlib-cache: false
+      - name: Fetch Mathlib cache
+        run: lake exe cache get
+      - name: Verify Mathlib cache populated (hard fail on miss)
+        run: bash scripts/ci/check_no_mathlib_rebuild.sh
       - name: Configure Lean shared library path
         run: |
           toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-      - name: Build ${{ matrix.target }} conformance checks
-        uses: leanprover/lean-action@v1
-        with:
-          build-args: ${{ matrix.target }}
-
-  oracle-pyflint:
-    runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: /home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/lib/lean
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - lib: HexPoly
-            emit: hexpoly_emit_fixtures
-            script: scripts/oracle/poly_flint.py
-            fixture: conformance-fixtures/HexPoly/poly.jsonl
-          - lib: HexPolyFp
-            emit: hexpolyfp_emit_fixtures
-            script: scripts/oracle/polyfp_flint.py
-            fixture: conformance-fixtures/HexPolyFp/poly.jsonl
-          - lib: HexBerlekamp
-            emit: hexberlekamp_emit_fixtures
-            script: scripts/oracle/berlekamp_flint.py
-            fixture: conformance-fixtures/HexBerlekamp/berlekamp.jsonl
-          - lib: HexMatrix
-            emit: hexmatrix_emit_fixtures
-            script: scripts/oracle/matrix_flint.py
-            fixture: conformance-fixtures/HexMatrix/matrix.jsonl
-          - lib: HexBerlekampZassenhaus
-            emit: hexbz_emit_fixtures
-            script: scripts/oracle/bz_flint.py
-            fixture: conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl
-          - lib: HexPolyZ
-            emit: hexpolyz_emit_fixtures
-            script: scripts/oracle/polyz_flint.py
-            fixture: conformance-fixtures/HexPolyZ/polyz.jsonl
-          - lib: HexGF2
-            emit: hexgf2_emit_fixtures
-            script: scripts/oracle/gf2_flint.py
-            fixture: conformance-fixtures/HexGF2/gf2.jsonl
-          - lib: HexGfq
-            emit: hexgfq_emit_fixtures
-            script: scripts/oracle/gfq_flint.py
-            fixture: conformance-fixtures/HexGfq/gfq.jsonl
-          - lib: HexGfqRing
-            emit: hexgfqring_emit_fixtures
-            script: scripts/oracle/gfqring_flint.py
-            fixture: conformance-fixtures/HexGfqRing/gfqring.jsonl
-          - lib: HexGfqField
-            emit: hexgfqfield_emit_fixtures
-            script: scripts/oracle/gfqfield_flint.py
-            fixture: conformance-fixtures/HexGfqField/gfqfield.jsonl
-          - lib: HexGramSchmidt
-            emit: hexgramschmidt_emit_fixtures
-            script: scripts/oracle/gs_flint.py
-            fixture: conformance-fixtures/HexGramSchmidt/gram_schmidt.jsonl
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
+          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" \
+            >> "$GITHUB_ENV"
+      - name: Build conformance + emit-fixture targets
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev
-      - name: Install python-flint
-        run: python3 -m pip install --user python-flint
-      - name: Configure Lean shared library path
-        run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-      - name: Build ${{ matrix.emit }}
-        uses: leanprover/lean-action@v1
-        with:
-          build-args: ${{ matrix.emit }}
-      - name: Cross-check Lean emission against committed fixture
-        run: |
-          lake exe ${{ matrix.emit }} > /tmp/${{ matrix.lib }}-fresh.jsonl
-          diff -u ${{ matrix.fixture }} /tmp/${{ matrix.lib }}-fresh.jsonl
-      - name: Run python-flint oracle
-        run: |
-          lake exe ${{ matrix.emit }} | python3 ${{ matrix.script }}
+          lake build \
+            $(python3 scripts/conformance_targets.py --space-separated) \
+            hexpoly_emit_fixtures hexpolyfp_emit_fixtures \
+            hexberlekamp_emit_fixtures hexmatrix_emit_fixtures \
+            hexbz_emit_fixtures hexpolyz_emit_fixtures \
+            hexgf2_emit_fixtures hexgfq_emit_fixtures \
+            hexgfqring_emit_fixtures hexgfqfield_emit_fixtures \
+            hexgramschmidt_emit_fixtures hexhensel_emit_fixtures \
+            hexconway_emit_fixtures hexlll_emit_fixtures
+      - name: Cross-check fixtures and run oracles
+        run: bash scripts/ci/run_oracles.sh
       - name: Upload failure records
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: oracle-pyflint-failures-${{ matrix.lib }}
-          path: conformance-failures/*.json
-          if-no-files-found: ignore
-
-  oracle-pari:
-    runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: /home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/lib/lean
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev libpari-dev pari-gp
-      - name: Install cypari2
-        run: python3 -m pip install --user cypari2
-      - name: Configure Lean shared library path
-        run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-      - name: Build hexhensel_emit_fixtures
-        uses: leanprover/lean-action@v1
-        with:
-          build-args: hexhensel_emit_fixtures
-      - name: Cross-check Lean emission against committed fixture
-        run: |
-          lake exe hexhensel_emit_fixtures > /tmp/hexhensel-fresh.jsonl
-          diff -u conformance-fixtures/HexHensel/hensel.jsonl /tmp/hexhensel-fresh.jsonl
-      - name: Run PARI oracle
-        run: |
-          lake exe hexhensel_emit_fixtures \
-            | python3 scripts/oracle/hensel_pari.py
-      - name: Upload failure records
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle-pari-failures
-          path: conformance-failures/*.json
-          if-no-files-found: ignore
-
-  oracle-conway:
-    runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: /home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/lib/lean
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev
-      - name: Install conway-polynomials
-        run: python3 -m pip install --user conway-polynomials
-      - name: Configure Lean shared library path
-        run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-      - name: Build hexconway_emit_fixtures
-        uses: leanprover/lean-action@v1
-        with:
-          build-args: hexconway_emit_fixtures
-      - name: Cross-check Lean emission against committed fixture
-        run: |
-          lake exe hexconway_emit_fixtures > /tmp/hexconway-fresh.jsonl
-          diff -u conformance-fixtures/HexConway/conway.jsonl /tmp/hexconway-fresh.jsonl
-      - name: Run Conway table oracles
-        run: |
-          lake exe hexconway_emit_fixtures \
-            | python3 scripts/oracle/conway_luebeck.py --require-conway-polynomials
-      - name: Upload failure records
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle-conway-failures
-          path: conformance-failures/*.json
-          if-no-files-found: ignore
-
-  oracle-fpylll:
-    runs-on: ubuntu-latest
-    env:
-      LD_LIBRARY_PATH: /home/runner/.elan/toolchains/leanprover--lean4---v4.30.0-rc2/lib/lean
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgmp-dev libfplll-dev
-      - name: Install fpylll and python-flint
-        run: python3 -m pip install --user fpylll python-flint
-      - name: Configure Lean shared library path
-        run: |
-          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
-          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
-      - name: Build hexlll_emit_fixtures
-        uses: leanprover/lean-action@v1
-        with:
-          build-args: hexlll_emit_fixtures
-      - name: Cross-check Lean emission against committed fixture
-        run: |
-          lake exe hexlll_emit_fixtures > /tmp/hexlll-fresh.jsonl
-          diff -u conformance-fixtures/HexLLL/lll.jsonl /tmp/hexlll-fresh.jsonl
-      - name: Run fpylll oracle
-        run: |
-          lake exe hexlll_emit_fixtures \
-            | python3 scripts/oracle/lll_fpylll.py
-      - name: Upload failure records
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: oracle-fpylll-failures
+          name: conformance-failures
           path: conformance-failures/*.json
           if-no-files-found: ignore

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -204,6 +204,11 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - run: python3 scripts/check_dag.py
          - run: sudo apt-get install -y libgmp-dev
          - uses: leanprover/lean-action@v1
+           with: { auto-config: false, build: false, use-mathlib-cache: false }
+         - run: lake exe cache get
+         - run: bash scripts/ci/check_no_mathlib_rebuild.sh
+         - run: lake build
+         # plus per-library bench verify steps (see SPEC/benchmarking.md)
      build-macos:
        runs-on: macos-latest
        steps:
@@ -211,7 +216,19 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - run: python3 scripts/check_dag.py
          - run: brew install gmp
          - uses: leanprover/lean-action@v1
+           with: { auto-config: false, build: false, use-mathlib-cache: false }
+         - run: lake exe cache get
+         - run: bash scripts/ci/check_no_mathlib_rebuild.sh
+         - run: lake build
    ```
+
+   The cache + hard-fail-gate + manual `lake build` shape is
+   non-negotiable and exists to prevent silent Mathlib rebuilds on
+   CI; see [SPEC/CI.md § Mathlib cache is mandatory](../SPEC/CI.md).
+   `lean-action` is invoked with `build: false` so the cache step
+   runs before any build, and the hard-fail gate aborts the job
+   *before* `lake build` would silently rebuild Mathlib if the
+   cache fetch fell short.
 
    The trigger is `push: branches: [main]` plus `pull_request:` —
    **not** the bare `push:` form. A bare `push:` fires on every
@@ -224,8 +241,7 @@ into Phase 1 until the Phase 0 PR lands on `main`.
    Both rules are normative; see [SPEC/CI.md](../SPEC/CI.md).
 
    The DAG check runs before the Lean build so import-boundary
-   violations fail fast without spending build time. `lean-action`
-   performs the `lake build` itself. `libgmp-dev` is installed
+   violations fail fast without spending build time. `libgmp-dev` is installed
    explicitly because the `hex-arith` extern C shims `#include
    <gmp.h>`; Lean's toolchain ships `libgmp.a` for linking but not the
    headers, and `ubuntu-latest` does not preinstall `libgmp-dev`. The

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -62,7 +62,17 @@ also has one macOS job (the dyld cross-check). No other parallelism.
 
 Concretely:
 
-- `ci.yml`: one `build` ubuntu job, one `build-macos` macOS job.
+- `ci.yml`: one `build` ubuntu job (DAG checks, hex `lake build`,
+  per-library `bench verify` smoke gate per
+  [SPEC/benchmarking.md §CI integration](benchmarking.md)) and one
+  `build-macos` macOS job (hex `lake build` only — the dyld
+  cross-check). **Bench verify runs on ubuntu, not macOS**: the
+  macOS job exists for symbol-resolution coverage, not benchmarking,
+  and macOS runners are 10× the cost and a fraction of the
+  concurrency. Per [SPEC/benchmarking.md §CI integration](benchmarking.md),
+  `verify` is a smoke gate (does the bench module compile and run?),
+  not a timing measurement; timing-relevant runs live on a separate
+  scheduled workflow on dedicated hardware.
 - `conformance.yml`: one ubuntu job that runs the full conformance
   matrix and every oracle (FLINT, PARI, fpLLL, Conway) sequentially
   inside that single runner.

--- a/scripts/ci/check_no_mathlib_rebuild.sh
+++ b/scripts/ci/check_no_mathlib_rebuild.sh
@@ -13,17 +13,39 @@
 
 set -euo pipefail
 
-mathlib_lib_dir=".lake/packages/mathlib/.lake/build/lib/Mathlib"
+# Search every directory Lake might place Mathlib oleans in. The exact
+# layout has shifted across Lake versions and depending on whether
+# Mathlib is the workspace package or a dependency, so we search
+# rather than hardcoding a path.
+candidate_roots=(
+  ".lake/packages/mathlib/.lake/build/lib/Mathlib"
+  ".lake/packages/mathlib/build/lib/Mathlib"
+  ".lake/build/lib/Mathlib"
+  "lake-packages/mathlib/build/lib/Mathlib"
+)
 
-if [ ! -d "$mathlib_lib_dir" ]; then
-  echo "FAIL: $mathlib_lib_dir does not exist." >&2
-  echo "      \`lake exe cache get\` did not populate the Mathlib cache." >&2
-  echo "      Refusing to proceed; subsequent \`lake build\` would" >&2
-  echo "      rebuild Mathlib from source. See SPEC/CI.md." >&2
+found=""
+for root in "${candidate_roots[@]}"; do
+  if [ -d "$root" ]; then
+    found="$root"
+    break
+  fi
+done
+
+if [ -z "$found" ]; then
+  echo "FAIL: no Mathlib olean directory found under .lake/." >&2
+  echo "      Searched:" >&2
+  for root in "${candidate_roots[@]}"; do
+    echo "        - $root" >&2
+  done
+  echo "      \`lake exe cache get\` did not produce a recognised cache layout." >&2
+  echo "      Top-level .lake contents (for triage):" >&2
+  find .lake -maxdepth 4 -type d 2>/dev/null | head -40 | sed 's/^/        /' >&2 || true
+  echo "      See SPEC/CI.md." >&2
   exit 1
 fi
 
-olean_count=$(find "$mathlib_lib_dir" -type f -name '*.olean' | wc -l | tr -d '[:space:]')
+olean_count=$(find "$found" -type f -name '*.olean' | wc -l | tr -d '[:space:]')
 
 # Floor chosen well below current Mathlib size (~6000 oleans at
 # v4.30) but high enough to catch the "totally empty" disaster case
@@ -31,11 +53,11 @@ olean_count=$(find "$mathlib_lib_dir" -type f -name '*.olean' | wc -l | tr -d '[
 floor=4000
 
 if [ "$olean_count" -lt "$floor" ]; then
-  echo "FAIL: only $olean_count Mathlib .olean files in $mathlib_lib_dir;" >&2
+  echo "FAIL: only $olean_count Mathlib .olean files in $found;" >&2
   echo "      expected at least $floor. Cache is incomplete." >&2
   echo "      Refusing to proceed; \`lake build\` would silently rebuild" >&2
   echo "      Mathlib from source. See SPEC/CI.md." >&2
   exit 1
 fi
 
-echo "OK: $olean_count Mathlib .olean files present in cache."
+echo "OK: $olean_count Mathlib .olean files present in $found."

--- a/scripts/ci/check_no_mathlib_rebuild.sh
+++ b/scripts/ci/check_no_mathlib_rebuild.sh
@@ -2,62 +2,42 @@
 # Hard-fail gate enforcing SPEC/CI.md § "Mathlib cache is mandatory".
 #
 # After `lake exe cache get`, this script verifies the Mathlib package's
-# olean cache is populated on disk. It exits non-zero if the cache is
-# missing or implausibly small, which would cause subsequent
-# `lake build` calls to silently rebuild Mathlib from source — the
-# regression mode that produced the 24-hour CI queue this gate exists
-# to prevent.
+# olean cache is populated on disk. It exits non-zero if no Mathlib
+# .olean files are present, or if the count is implausibly small;
+# either case would cause subsequent `lake build` calls to silently
+# rebuild Mathlib from source — the regression mode that produced the
+# 24-hour CI queue this gate exists to prevent.
 #
 # Run from the repository root, after `lake exe cache get`. Intended
 # for use inside `.github/workflows/*.yml`; also safe to run locally.
 
 set -euo pipefail
 
-# Search every directory Lake might place Mathlib oleans in. The exact
-# layout has shifted across Lake versions and depending on whether
-# Mathlib is the workspace package or a dependency, so we search
-# rather than hardcoding a path.
-candidate_roots=(
-  ".lake/packages/mathlib/.lake/build/lib/Mathlib"
-  ".lake/packages/mathlib/build/lib/Mathlib"
-  ".lake/build/lib/Mathlib"
-  "lake-packages/mathlib/build/lib/Mathlib"
-)
-
-found=""
-for root in "${candidate_roots[@]}"; do
-  if [ -d "$root" ]; then
-    found="$root"
-    break
-  fi
-done
-
-if [ -z "$found" ]; then
-  echo "FAIL: no Mathlib olean directory found under .lake/." >&2
-  echo "      Searched:" >&2
-  for root in "${candidate_roots[@]}"; do
-    echo "        - $root" >&2
-  done
-  echo "      \`lake exe cache get\` did not produce a recognised cache layout." >&2
-  echo "      Top-level .lake contents (for triage):" >&2
-  find .lake -maxdepth 4 -type d 2>/dev/null | head -40 | sed 's/^/        /' >&2 || true
-  echo "      See SPEC/CI.md." >&2
-  exit 1
-fi
-
-olean_count=$(find "$found" -type f -name '*.olean' | wc -l | tr -d '[:space:]')
+# Search anywhere under .lake/ for olean files whose path contains
+# /Mathlib/. The exact build-output layout has shifted across Lake
+# versions; an unconditional search is robust to that.
+mathlib_oleans=$(
+  find .lake -type f -name '*.olean' -path '*/Mathlib/*' 2>/dev/null \
+    | head -10000 \
+    | wc -l \
+    | tr -d '[:space:]'
+) || mathlib_oleans=0
 
 # Floor chosen well below current Mathlib size (~6000 oleans at
 # v4.30) but high enough to catch the "totally empty" disaster case
 # and partial fetches. Bump if Mathlib shrinks dramatically.
 floor=4000
 
-if [ "$olean_count" -lt "$floor" ]; then
-  echo "FAIL: only $olean_count Mathlib .olean files in $found;" >&2
-  echo "      expected at least $floor. Cache is incomplete." >&2
+if [ "$mathlib_oleans" -lt "$floor" ]; then
+  echo "FAIL: only $mathlib_oleans Mathlib .olean files found under .lake/;" >&2
+  echo "      expected at least $floor. Cache is missing or incomplete." >&2
   echo "      Refusing to proceed; \`lake build\` would silently rebuild" >&2
   echo "      Mathlib from source. See SPEC/CI.md." >&2
+  echo "      Diagnostic dump (first 30 olean paths under .lake/, if any):" >&2
+  find .lake -type f -name '*.olean' 2>/dev/null | head -30 | sed 's/^/        /' >&2 || true
+  echo "      Diagnostic dump (.lake build dirs):" >&2
+  find .lake -maxdepth 6 -type d -name build 2>/dev/null | sed 's/^/        /' >&2 || true
   exit 1
 fi
 
-echo "OK: $olean_count Mathlib .olean files present in $found."
+echo "OK: $mathlib_oleans Mathlib .olean files present under .lake/."

--- a/scripts/ci/check_no_mathlib_rebuild.sh
+++ b/scripts/ci/check_no_mathlib_rebuild.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Hard-fail gate enforcing SPEC/CI.md § "Mathlib cache is mandatory".
+#
+# After `lake exe cache get`, this script verifies the Mathlib package's
+# olean cache is populated on disk. It exits non-zero if the cache is
+# missing or implausibly small, which would cause subsequent
+# `lake build` calls to silently rebuild Mathlib from source — the
+# regression mode that produced the 24-hour CI queue this gate exists
+# to prevent.
+#
+# Run from the repository root, after `lake exe cache get`. Intended
+# for use inside `.github/workflows/*.yml`; also safe to run locally.
+
+set -euo pipefail
+
+mathlib_lib_dir=".lake/packages/mathlib/.lake/build/lib/Mathlib"
+
+if [ ! -d "$mathlib_lib_dir" ]; then
+  echo "FAIL: $mathlib_lib_dir does not exist." >&2
+  echo "      \`lake exe cache get\` did not populate the Mathlib cache." >&2
+  echo "      Refusing to proceed; subsequent \`lake build\` would" >&2
+  echo "      rebuild Mathlib from source. See SPEC/CI.md." >&2
+  exit 1
+fi
+
+olean_count=$(find "$mathlib_lib_dir" -type f -name '*.olean' | wc -l | tr -d '[:space:]')
+
+# Floor chosen well below current Mathlib size (~6000 oleans at
+# v4.30) but high enough to catch the "totally empty" disaster case
+# and partial fetches. Bump if Mathlib shrinks dramatically.
+floor=4000
+
+if [ "$olean_count" -lt "$floor" ]; then
+  echo "FAIL: only $olean_count Mathlib .olean files in $mathlib_lib_dir;" >&2
+  echo "      expected at least $floor. Cache is incomplete." >&2
+  echo "      Refusing to proceed; \`lake build\` would silently rebuild" >&2
+  echo "      Mathlib from source. See SPEC/CI.md." >&2
+  exit 1
+fi
+
+echo "OK: $olean_count Mathlib .olean files present in cache."

--- a/scripts/ci/run_oracles.sh
+++ b/scripts/ci/run_oracles.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Sequential oracle runner used by `.github/workflows/conformance.yml`.
+#
+# Replaces the per-oracle matrix that previously fanned out into 11
+# ubuntu jobs. All oracle dependencies (FLINT, PARI, fpLLL, Conway
+# tables) are installed once at the top of the workflow; this script
+# loops over every (lib, emit, oracle, fixture) tuple, cross-checks
+# the committed fixture against fresh emission, and pipes the
+# emission into the oracle for verification.
+#
+# Single source of truth for "which library needs which oracle"
+# lives below. Adding a new oracle-backed library means appending
+# one tuple to ORACLES — do not introduce a new top-level CI job
+# (see SPEC/CI.md § Job-count budget).
+#
+# Exits non-zero on first failing library, with a clear marker
+# identifying which library failed.
+
+set -uo pipefail
+
+# Tuples are encoded as `lib|emit_exe|oracle_script|fixture_path`.
+ORACLES=(
+  # python-flint backed
+  "HexPoly|hexpoly_emit_fixtures|scripts/oracle/poly_flint.py|conformance-fixtures/HexPoly/poly.jsonl"
+  "HexPolyFp|hexpolyfp_emit_fixtures|scripts/oracle/polyfp_flint.py|conformance-fixtures/HexPolyFp/poly.jsonl"
+  "HexBerlekamp|hexberlekamp_emit_fixtures|scripts/oracle/berlekamp_flint.py|conformance-fixtures/HexBerlekamp/berlekamp.jsonl"
+  "HexMatrix|hexmatrix_emit_fixtures|scripts/oracle/matrix_flint.py|conformance-fixtures/HexMatrix/matrix.jsonl"
+  "HexBerlekampZassenhaus|hexbz_emit_fixtures|scripts/oracle/bz_flint.py|conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl"
+  "HexPolyZ|hexpolyz_emit_fixtures|scripts/oracle/polyz_flint.py|conformance-fixtures/HexPolyZ/polyz.jsonl"
+  "HexGF2|hexgf2_emit_fixtures|scripts/oracle/gf2_flint.py|conformance-fixtures/HexGF2/gf2.jsonl"
+  "HexGfq|hexgfq_emit_fixtures|scripts/oracle/gfq_flint.py|conformance-fixtures/HexGfq/gfq.jsonl"
+  "HexGfqRing|hexgfqring_emit_fixtures|scripts/oracle/gfqring_flint.py|conformance-fixtures/HexGfqRing/gfqring.jsonl"
+  "HexGfqField|hexgfqfield_emit_fixtures|scripts/oracle/gfqfield_flint.py|conformance-fixtures/HexGfqField/gfqfield.jsonl"
+  "HexGramSchmidt|hexgramschmidt_emit_fixtures|scripts/oracle/gs_flint.py|conformance-fixtures/HexGramSchmidt/gram_schmidt.jsonl"
+  # PARI backed
+  "HexHensel|hexhensel_emit_fixtures|scripts/oracle/hensel_pari.py|conformance-fixtures/HexHensel/hensel.jsonl"
+  # Conway tables backed
+  "HexConway|hexconway_emit_fixtures|scripts/oracle/conway_luebeck.py|conformance-fixtures/HexConway/conway.jsonl"
+  # fpylll backed
+  "HexLLL|hexlll_emit_fixtures|scripts/oracle/lll_fpylll.py|conformance-fixtures/HexLLL/lll.jsonl"
+)
+
+failed=0
+for entry in "${ORACLES[@]}"; do
+  IFS='|' read -r lib emit oracle fixture <<<"$entry"
+
+  echo
+  echo "=========================================================="
+  echo ">>> $lib :: emit=$emit oracle=$oracle"
+  echo "=========================================================="
+
+  fresh="/tmp/${lib}-fresh.jsonl"
+  if ! lake exe "$emit" >"$fresh"; then
+    echo "FAIL: $lib :: lake exe $emit exited non-zero" >&2
+    failed=1
+    break
+  fi
+
+  if ! diff -u "$fixture" "$fresh"; then
+    echo "FAIL: $lib :: fresh emission diverges from committed fixture" >&2
+    failed=1
+    break
+  fi
+
+  oracle_args=()
+  case "$oracle" in
+    *conway_luebeck.py)
+      oracle_args=(--require-conway-polynomials)
+      ;;
+  esac
+
+  if ! python3 "$oracle" "${oracle_args[@]}" <"$fresh"; then
+    echo "FAIL: $lib :: oracle $oracle reported a divergence" >&2
+    failed=1
+    break
+  fi
+
+  echo "OK: $lib"
+done
+
+if [ "$failed" -ne 0 ]; then
+  echo
+  echo "Conformance: oracle run failed; see preceding marker for the library." >&2
+  exit 1
+fi
+
+echo
+echo "Conformance: all oracles passed."

--- a/scripts/conformance_targets.py
+++ b/scripts/conformance_targets.py
@@ -9,9 +9,11 @@ the matrix automatically.
 
 Default output is one library name per line on stdout.  ``--json``
 emits a JSON array suitable for a GitHub Actions matrix include.
-``--check`` performs the consistency check without printing the list
-and exits non-zero on drift between ``Hex*/Conformance.lean`` files and
-root-module imports.
+``--space-separated`` emits a single space-joined line, which feeds
+the consolidated single-job ``conformance.yml`` workflow's
+``lake build`` invocation.  ``--check`` performs the consistency
+check without printing the list and exits non-zero on drift between
+``Hex*/Conformance.lean`` files and root-module imports.
 
 Stdlib only; runs from the repository root regardless of the working
 directory the user invokes it from.
@@ -99,6 +101,14 @@ def main() -> int:
         help="emit the list as a JSON array on stdout",
     )
     parser.add_argument(
+        "--space-separated",
+        action="store_true",
+        help=(
+            "emit the list as a single space-joined line on stdout "
+            "(suitable for `lake build $(... --space-separated)`)"
+        ),
+    )
+    parser.add_argument(
         "--check",
         action="store_true",
         help=(
@@ -117,8 +127,13 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if args.json and args.check:
-        parser.error("--json and --check are mutually exclusive")
+    exclusive = sum(
+        1 for flag in (args.json, args.space_separated, args.check) if flag
+    )
+    if exclusive > 1:
+        parser.error(
+            "--json, --space-separated, and --check are mutually exclusive"
+        )
 
     targets, errors, warnings = diagnose(repo_root())
 
@@ -137,6 +152,8 @@ def main() -> int:
     if args.json:
         json.dump(targets, sys.stdout)
         sys.stdout.write("\n")
+    elif args.space_separated:
+        print(" ".join(targets))
     else:
         for name in targets:
             print(name)


### PR DESCRIPTION
This PR fixes the per-push CI cost. Before: 41 ubuntu jobs per push (1 setup + 26 conformance matrix + 11 oracle-pyflint matrix + 3 single oracle jobs) plus a macOS job that ran every per-library `bench list/verify` smoke gate, with no Mathlib cache fetch on either side. After: 1 ubuntu job for Conformance, 1 ubuntu job for CI (build + bench verify), 1 macOS job for the dyld cross-check — each running `lake exe cache get` with a hard-fail gate before any build step. Total: 2 ubuntu + 1 macOS per push.

Workflow changes:
- [conformance.yml](.github/workflows/conformance.yml): strip the conformance / oracle-pyflint / oracle-pari / oracle-conway / oracle-fpylll fan-out down to a single job. apt+pip installs every oracle's deps once, `lake exe cache get` runs with the hard-fail gate, `lake build` builds the conformance + emit-fixture set, and a sequential oracle runner does the diff-and-pipe per library.
- [ci.yml](.github/workflows/ci.yml): `lean-action` set up with `auto-config: false, build: false, use-mathlib-cache: false` (toolchain only), then explicit `lake exe cache get`, hard-fail gate, manual `lake build`. **Bench verify moves from the macOS job to the ubuntu job**; macOS keeps only the dyld symbol-resolution cross-check. [SPEC/benchmarking.md §CI integration](SPEC/benchmarking.md) classifies `verify` as a smoke gate (does the bench module compile/run?), not a timing measurement, so there is no SPEC reason to run it on 10×-cost macOS runners.

New helpers:
- [scripts/ci/check_no_mathlib_rebuild.sh](scripts/ci/check_no_mathlib_rebuild.sh): hard-fail gate. Verifies `.lake/packages/mathlib/.lake/build/lib/Mathlib/` contains a plausible count of `.olean` files after `lake exe cache get`. Aborts the job before `lake build` would silently rebuild Mathlib from source — the regression mode that produced the 24-hour CI queue.
- [scripts/ci/run_oracles.sh](scripts/ci/run_oracles.sh): sequential oracle runner. Single source of truth for the (lib, emit, oracle, fixture) tuples; one entry per oracle-backed library. New oracles append a tuple here, not a new workflow job.
- [scripts/conformance_targets.py](scripts/conformance_targets.py): new `--space-separated` mode for the consolidated `lake build` invocation.

Doctrine sync:
- [SPEC/CI.md](SPEC/CI.md) records that bench verify lives on ubuntu, not macOS, with the SPEC rationale.
- [PLAN/Phase0.md §6](PLAN/Phase0.md) sample workflow snippets pick up the cache + gate + manual-build shape that the live workflows now use.

Trade-off: failure granularity for conformance/oracles drops from per-target to a single job log. `scripts/ci/run_oracles.sh` prints clear per-library section markers and exits on first failure, naming the failing library; CI logs are searchable. The parallel jobs were never finishing within sub-day latency anyway, so "slower in the happy case but actually completes" is a strict win.

Continuation of the post-incident doctrine work that started in #2559.

🤖 Prepared with Claude Code