### PR TITLE
doc: mandate single-ubuntu-job CI shape for new oracles

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -34,3 +34,26 @@ Never introduce an `axiom`. This includes converting an existing
 `theorem`/`def`/`example` into an `axiom` when a refactor breaks its
 proof — fix the proof or fix the API. For unfinished proofs use
 `sorry`, which is grep-able and produces a warning; `axiom` is silent.
+
+## CI: extend, don't fan out
+
+Before touching anything under `.github/workflows/`, read
+[SPEC/CI.md](../SPEC/CI.md). Each workflow runs in **exactly one
+ubuntu job** (`ci.yml` also has one macOS job for the dyld
+cross-check). New conformance targets, new oracles, and new bench
+targets **extend the script** of the existing single job — they do
+not introduce new top-level jobs, `strategy.matrix` blocks, or new
+workflow files. New oracles append a tuple to
+`scripts/ci/run_oracles.sh` and (if needed) an entry to the existing
+apt/pip install step; see
+[SPEC/testing.md § Adding a new oracle](../SPEC/testing.md).
+
+GitHub-hosted Actions on a personal account is concurrency-capped at
+~20 parallel ubuntu runners across all repositories the account
+owns; a 10-entry matrix saturates the cap, a 40-entry matrix
+produces 24-hour queue waits. Per-target parallelism does not
+amortise the fixed Mathlib cache fetch and startup cost on this
+project, so the rule is "no parallelism in CI." Routine timing-
+sensitive runs live on a separate scheduled workflow on dedicated
+hardware (per [SPEC/benchmarking.md](../SPEC/benchmarking.md)),
+not on the merge-gating workflows.

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -450,11 +450,23 @@ pattern.
    `scripts/oracle/poly_flint.py`: it must read the JSONL stream,
    re-run each `op` through the external oracle, and call
    `assert_equal` against the Lean `value`.
-5. Add a CI job (or extend `oracle-pyflint`) in
-   `.github/workflows/conformance.yml` that installs the oracle,
-   diffs the freshly-emitted JSONL against the committed fixture,
-   and pipes Lean's emission into the driver. Upload
-   `conformance-failures/*.json` on failure.
+5. Wire the new oracle into the **single-ubuntu-job** Conformance
+   workflow at `.github/workflows/conformance.yml`. Concretely:
+   - if a new system dependency is needed, append it to the existing
+     `apt-get install` step;
+   - if a new Python dependency is needed, append it to the existing
+     `pip install --user` step;
+   - append a tuple
+     `<lib>|<emit_exe>|<oracle_script>|<fixture_path>` to the
+     `ORACLES` array in `scripts/ci/run_oracles.sh`. The runner
+     diffs the freshly-emitted JSONL against the committed fixture
+     and pipes Lean's emission into the driver per library.
+
+   **Do NOT** add a new top-level workflow job, do **NOT** add a
+   `strategy.matrix`, and do **NOT** add a new workflow file. The
+   Conformance workflow runs as exactly one ubuntu job — see
+   [SPEC/CI.md](CI.md). Conformance failure artefacts are uploaded
+   by the workflow's existing `if: failure()` artifact step.
 
 The initial `core` profile does not require JSONL; a library's
 `#guard`s suffice until its oracle is wired.


### PR DESCRIPTION
Updates the doctrine that allowed the 41-job Conformance fan-out:

- [SPEC/testing.md § \"Adding a new oracle\"](SPEC/testing.md) previously said \"Add a CI job (or extend \`oracle-pyflint\`)\" — phrased as an option, not a rule. New oracles defaulted to \"add a CI job\", which compounded across 11 oracle-* libraries became a 41-job fan-out and a 24-hour queue. The section is rewritten to mandate the single-job shape: append apt/pip deps to the existing install steps, then append a `(lib, emit, oracle, fixture)` tuple to `scripts/ci/run_oracles.sh`.
- [.claude/CLAUDE.md](.claude/CLAUDE.md) gets a \"CI: extend, don't fan out\" section that forward-references [SPEC/CI.md](SPEC/CI.md). Pod's per-session command prompts (`.claude/commands/*.md`) are not version-controlled in this repo, so doctrine that needs to be visible to every agent goes in the tracked `.claude/CLAUDE.md`.

Depends on #2560 (the workflow refactor that introduces the single ubuntu job and `scripts/ci/run_oracles.sh` referenced from this doctrine).

🤖 Prepared with Claude Code