### PR TITLE
fix: refresh stale HexGfq Conway lookup guards for (2,2) and (3,1)

### DIFF
--- a/HexGfq/Conformance.lean
+++ b/HexGfq/Conformance.lean
@@ -23,7 +23,7 @@ Covered edge cases:
 - the committed binary linear entry `(p, n) = (2, 1)`
 - zero, already-reduced, modulus, and high-degree generic inputs
 - zero, one, modulus-word, and high-bit packed inputs
-- unsupported Conway lookup boundaries adjacent to the selected entry
+- the unsupported `(p, n) = (2, 0)` Conway lookup boundary
 -/
 
 namespace Hex
@@ -85,8 +85,9 @@ example : 1 < 64 :=
 #guard GFq.modulus Entry21 = Conway.conwayPoly 2 1 Conway.supportedEntry_2_1
 #guard 0 < FpPoly.degree (GFq.modulus Entry21)
 #guard Conway.luebeckConwayPolynomial? 2 0 = (none : Option (FpPoly 2))
-#guard Conway.luebeckConwayPolynomial? 2 2 = (none : Option (FpPoly 2))
-#guard Conway.luebeckConwayPolynomial? 3 1 = (none : Option (FpPoly 3))
+-- `(2, 2)` and `(3, 1)` were previously unsupported boundaries; PR #2365
+-- extended the committed Lübeck table to cover them, so their positive
+-- lookups are now exercised in `HexConway/Conformance.lean`.
 
 #guard genericReprNats (generic #[]) = []
 #guard genericReprNats (generic #[1]) = [1]

--- a/progress/20260507T134143Z_fbbe19c4.md
+++ b/progress/20260507T134143Z_fbbe19c4.md
@@ -1,0 +1,38 @@
+# Session fbbe19c4 — fix HexGfq/Conformance stale Conway lookup guards
+
+Issue: #2562 (human-oversight)
+
+## Accomplished
+
+- Diagnosed the two failing `#guard`s on `HexGfq/Conformance.lean` lines
+  88–89. PR #2365 (`feat: discharge Conway irreducibility table`)
+  extended `Conway.luebeckConwayPolynomial?` to cover the full
+  `(p, n)` slice for `p ∈ {2, 3, 5, 7, 11, 13}`, `n ∈ {1..6}`, including
+  `(2, 2)` and `(3, 1)`. The conformance file's old "unsupported
+  boundary" probes therefore became stale.
+- Removed the two now-stale `none` guards. The positive lookups for
+  `(2, 2)` and `(3, 1)` are already exercised in
+  `HexConway/Conformance.lean` lines 36 and 42, so no coverage is lost.
+  Left a short comment pointing at PR #2365.
+- Kept the `(2, 0)` guard — that entry is still genuinely unsupported,
+  see `Conway.luebeckConwayPolynomial?_miss_two_zero`.
+- Tightened the file's `Covered edge cases:` docstring bullet to name
+  `(2, 0)` explicitly instead of the vaguer "boundaries adjacent to the
+  selected entry".
+- `lake build HexGfq.Conformance` is green.
+
+## Current frontier
+
+`HexGfq/Conformance.lean` is back in sync with the committed Lübeck
+table.
+
+## Next step
+
+PR up; once it merges, the post-#2560 single-job Conformance workflow
+should go green on `main`. The remaining open human-oversight items
+(#2565 HO-2 adversarial BZ inputs, #2566 HO-3 BZ Bench.lean, #2567 HO-4
+BHKS Theorem 5.2) are independent and ready for the next worker.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2562

Session: `fbbe19c4-a313-4f61-ba57-12cd39c165d7`

87ff8cf fix: drop stale HexGfq/Conformance Lübeck `none` guards for (2,2) and (3,1)

🤖 Prepared with Claude Code