### PR TITLE
feat: prove gramDet_rowAdd_earlier in HexGramSchmidt.Int

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -815,6 +815,33 @@ private theorem leadingGramMatrixInt_rowAdd_inside
   exact leadingGramMatrixInt_rowAdd_entry_inside b j k c t ht hjk hkt
     ⟨p, hp⟩ ⟨q, hq⟩
 
+/-- Adding a multiple of an earlier row to a later row leaves the leading
+Gram determinant unchanged. The hypothesis `j.val < k.val` makes the source
+row earlier than the destination row in the basis. -/
+theorem gramDet_rowAdd_earlier
+    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+    (hjk : j.val < k.val) :
+    gramDet (Matrix.rowAdd b j k c) t ht = gramDet b t ht := by
+  unfold gramDet
+  -- Reduce to the underlying Bareiss-determinant equality on `Int`.
+  congr 1
+  by_cases hkt : k.val < t
+  · -- Inside case: bareiss = det, then det_rowAdd / det_colAdd preserve.
+    rw [leadingGramMatrixInt_rowAdd_inside b j k c t ht hjk hkt]
+    rw [Matrix.bareiss_eq_det, Matrix.bareiss_eq_det]
+    -- Indices and inequality between `jt` and `kt` in `Fin t`.
+    have hjt_ne_kt : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t) ≠ ⟨k.val, hkt⟩ := by
+      intro h
+      have hval : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t).val =
+          (⟨k.val, hkt⟩ : Fin t).val :=
+        congrArg Fin.val h
+      exact Nat.ne_of_lt hjk hval
+    rw [Matrix.det_colAdd _ _ _ _ hjt_ne_kt]
+    rw [Matrix.det_rowAdd _ _ _ _ hjt_ne_kt]
+  · -- Outside case: leading prefix unchanged.
+    have hkt' : t ≤ k.val := Nat.le_of_not_lt hkt
+    rw [leadingGramMatrixInt_rowAdd_outside b j k c t ht hkt']
+
 end GramSchmidt.Int
 
 namespace GramSchmidt.Rat

--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -531,6 +531,107 @@ theorem normSq_latticeVec_ge_min_basis_normSq
       Vector.normSq ((basis b).row i) ≤ ((Vector.normSq v : Int) : Rat) := by
   sorry
 
+/-! ### Row-add invariance of the leading Gram determinant
+
+The remaining theorems show that adding a multiple of an earlier row to a later
+row leaves `gramDet` unchanged. Concretely, when `j.val < k.val` and the
+modified row `k` lies inside the leading `t`-prefix, the leading Gram matrix
+acquires a `rowAdd`-then-`colAdd` decoration at the corresponding `Fin t`
+indices; both operations preserve determinants. When `t ≤ k.val`, the leading
+prefix is untouched. -/
+
+/-- Entry-level expansion of `Matrix.rowAdd` for a rectangular matrix. -/
+private theorem rowAdd_get_rect {R : Type u} [Mul R] [Add R] {n' m' : Nat}
+    (M : Matrix R n' m') (src dst r : Fin n') (c : R) (k : Fin m') :
+    (Matrix.rowAdd M src dst c)[r][k] =
+      if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
+  by_cases h : r = dst
+  · subst r
+    simp [Matrix.rowAdd]
+  · simp [Matrix.rowAdd, h]
+    have hval : dst.val ≠ r.val := by
+      intro hval
+      exact h (Fin.ext hval.symm)
+    have hrow :
+        (M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]))[r] = M[r] :=
+      (Vector.getElem_set_ne (xs := M)
+        (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
+        dst.isLt r.isLt hval)
+    simpa [Matrix.rowAdd] using congrArg (fun row => row[k]) hrow
+
+private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))
+    (u v : Vector Int n') (accU accV : Int) (hacc : accU = accV) :
+    xs.foldl (fun acc i => acc + u[i] * v[i]) accU =
+      xs.foldl (fun acc i => acc + v[i] * u[i]) accV := by
+  induction xs generalizing accU accV with
+  | nil =>
+      simp [hacc]
+  | cons i xs ih =>
+      simp only [List.foldl_cons]
+      apply ih
+      grind
+
+/-- The dot product of integer vectors is commutative. -/
+private theorem dot_comm_int {n' : Nat} (u v : Vector Int n') :
+    Matrix.dot u v = Matrix.dot v u := by
+  simpa [Matrix.dot, Hex.Vector.dotProduct] using
+    foldl_dot_comm_int (xs := List.finRange n') (u := u) (v := v)
+      (accU := 0) (accV := 0) rfl
+
+/-- A row of `Matrix.rowAdd M src dst c` away from `dst` is unchanged. -/
+private theorem rowAdd_row_eq_of_ne {R : Type u} [Mul R] [Add R] {n' m' : Nat}
+    (M : Matrix R n' m') (src dst r : Fin n') (c : R) (hr : r.val ≠ dst.val) :
+    (Matrix.rowAdd M src dst c)[r] = M[r] :=
+  Vector.getElem_set_ne (xs := M)
+    (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
+    dst.isLt r.isLt (fun heq => hr heq.symm)
+
+/-- The row of `Matrix.rowAdd M src dst c` at index `dst` is the entry-wise
+sum `M[dst] + c * M[src]`. -/
+private theorem rowAdd_row_at {R : Type u} [Mul R] [Add R] {n' m' : Nat}
+    (M : Matrix R n' m') (src dst : Fin n') (c : R) :
+    (Matrix.rowAdd M src dst c)[dst] =
+      Vector.ofFn fun k => M[dst][k] + c * M[src][k] := by
+  unfold Matrix.rowAdd
+  simp
+
+/-- Inductive helper for `dot_rowAdd_row_at_left`: distribution along a foldl. -/
+private theorem foldl_dot_rowAdd_at {n' m' : Nat}
+    (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m')
+    (xs : List (Fin m')) (acc accX accY : Int) (hacc : acc = accX + c * accY) :
+    xs.foldl (fun a i => a + (Matrix.rowAdd M src dst c)[dst][i] * w[i]) acc =
+      xs.foldl (fun a i => a + M[dst][i] * w[i]) accX +
+        c * xs.foldl (fun a i => a + M[src][i] * w[i]) accY := by
+  induction xs generalizing acc accX accY with
+  | nil =>
+      simpa using hacc
+  | cons i xs ih =>
+      simp only [List.foldl_cons]
+      apply ih
+      have hentry : (Matrix.rowAdd M src dst c)[dst][i] = M[dst][i] + c * M[src][i] := by
+        rw [rowAdd_get_rect]
+        simp
+      rw [hentry, hacc]
+      grind
+
+/-- Distribute dot product on the left over the row produced by
+`Matrix.rowAdd`: at index `dst`, the row is `M[dst] + c * M[src]` componentwise,
+so dot with `w` distributes over the sum. -/
+private theorem dot_rowAdd_row_at_left {n' m' : Nat}
+    (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m') :
+    Matrix.dot ((Matrix.rowAdd M src dst c)[dst]) w =
+      Matrix.dot M[dst] w + c * Matrix.dot M[src] w := by
+  simp only [Matrix.dot, Hex.Vector.dotProduct]
+  exact foldl_dot_rowAdd_at M src dst c w (List.finRange m')
+    0 0 0 (by show (0 : Int) = 0 + c * 0; grind)
+
+/-- Symmetric form: dot product on the right with the modified row. -/
+private theorem dot_rowAdd_row_at_right {n' m' : Nat}
+    (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m') :
+    Matrix.dot w ((Matrix.rowAdd M src dst c)[dst]) =
+      Matrix.dot w M[dst] + c * Matrix.dot w M[src] := by
+  rw [dot_comm_int w, dot_rowAdd_row_at_left, dot_comm_int w M[dst], dot_comm_int w M[src]]
+
 end GramSchmidt.Int
 
 namespace GramSchmidt.Rat

--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -632,6 +632,189 @@ private theorem dot_rowAdd_row_at_right {n' m' : Nat}
       Matrix.dot w M[dst] + c * Matrix.dot w M[src] := by
   rw [dot_comm_int w, dot_rowAdd_row_at_left, dot_comm_int w M[dst], dot_comm_int w M[src]]
 
+/-- When the modified row index `k` lies outside the leading `t`-prefix
+(`t ≤ k.val`), the leading Gram matrix of `Matrix.rowAdd b j k c` agrees with
+that of `b`. -/
+private theorem leadingGramMatrixInt_rowAdd_outside
+    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+    (hkt : t ≤ k.val) :
+    GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht =
+      GramSchmidt.leadingGramMatrixInt b t ht := by
+  -- Prove the matrices agree row-by-row using a stronger row-level identity:
+  -- for all r : Fin n with r.val < t, the rows of `rowAdd b j k c` and `b`
+  -- agree.
+  apply Vector.ext
+  intro p hp
+  apply Vector.ext
+  intro q hq
+  have hp_ne : (GramSchmidt.liftFinLE ⟨p, hp⟩ ht).val ≠ k.val :=
+    Nat.ne_of_lt (Nat.lt_of_lt_of_le hp hkt)
+  have hq_ne : (GramSchmidt.liftFinLE ⟨q, hq⟩ ht).val ≠ k.val :=
+    Nat.ne_of_lt (Nat.lt_of_lt_of_le hq hkt)
+  have hp_eq : (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE ⟨p, hp⟩ ht] =
+      b[GramSchmidt.liftFinLE ⟨p, hp⟩ ht] :=
+    rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE ⟨p, hp⟩ ht) c hp_ne
+  have hq_eq : (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE ⟨q, hq⟩ ht] =
+      b[GramSchmidt.liftFinLE ⟨q, hq⟩ ht] :=
+    rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE ⟨q, hq⟩ ht) c hq_ne
+  simp only [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
+    Vector.getElem_ofFn, hp_eq, hq_eq]
+
+/-- Entry-level structural identity for the leading Gram matrix of
+`Matrix.rowAdd b j k c` when the modified row `k` lies inside the leading
+`t`-prefix. The four cases (`p = k.val ∨ p ≠ k.val` × `q = k.val ∨ q ≠ k.val`)
+are handled separately. -/
+private theorem leadingGramMatrixInt_rowAdd_entry_inside
+    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+    (hjk : j.val < k.val) (hkt : k.val < t)
+    (p q : Fin t) :
+    (GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht)[p][q] =
+      (Matrix.colAdd
+          (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht)
+            ⟨j.val, Nat.lt_trans hjk hkt⟩ ⟨k.val, hkt⟩ c)
+          ⟨j.val, Nat.lt_trans hjk hkt⟩ ⟨k.val, hkt⟩ c)[p][q] := by
+  -- Abbreviations as Fin t.
+  let jt : Fin t := ⟨j.val, Nat.lt_trans hjk hkt⟩
+  let kt : Fin t := ⟨k.val, hkt⟩
+  -- liftFinLE jt ht = j, liftFinLE kt ht = k as Fin n.
+  have hjt_lift : GramSchmidt.liftFinLE jt ht = j := Fin.ext rfl
+  have hkt_lift : GramSchmidt.liftFinLE kt ht = k := Fin.ext rfl
+  -- The Gram matrix entry as a dot product of integer rows.
+  have hM_entry : ∀ (a b' : Fin t),
+      (GramSchmidt.leadingGramMatrixInt b t ht)[a][b'] =
+        Matrix.dot (b[GramSchmidt.liftFinLE a ht]) (b[GramSchmidt.liftFinLE b' ht]) := by
+    intro a b'
+    simp [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
+      Vector.getElem_ofFn]
+  -- LHS is a dot product over `Matrix.rowAdd b j k c` rows.
+  have hLHS :
+      (GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht)[p][q] =
+        Matrix.dot ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht])
+          ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE q ht]) := by
+    simp [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
+      Vector.getElem_ofFn]
+  -- RHS: the colAdd-rowAdd entry as a conditional.
+  have hRHS :
+      (Matrix.colAdd
+          (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c) jt kt c)[p][q] =
+        if q = kt then
+          (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] +
+            c * (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][jt]
+        else (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] := by
+    simp [Matrix.colAdd, Matrix.ofFn, Vector.getElem_ofFn]
+  rw [hLHS, hRHS]
+  -- Case split on `q = kt` and `p = kt`.
+  by_cases hqk : q = kt
+  · -- q = kt branch
+    rw [if_pos hqk]
+    rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q,
+        rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c jt]
+    -- The `b[·]` rewrites for `liftFinLE jt ht` and `liftFinLE kt ht`
+    -- give `b[j]` and `b[k]` respectively. These survive even when direct
+    -- `rw` fails on motive: we rewrite the matrix row indexings via
+    -- `congrArg b.get` once and reuse.
+    have hbjt_lift : b[GramSchmidt.liftFinLE jt ht] = b[j] :=
+      congrArg b.get hjt_lift
+    have hbkt_lift : b[GramSchmidt.liftFinLE kt ht] = b[k] :=
+      congrArg b.get hkt_lift
+    by_cases hpk : p = kt
+    · -- p = kt, q = kt
+      have hpn_k : GramSchmidt.liftFinLE p ht = k :=
+        Fin.ext (Fin.val_eq_of_eq hpk : p.val = kt.val)
+      have hqn_k : GramSchmidt.liftFinLE q ht = k :=
+        Fin.ext (Fin.val_eq_of_eq hqk : q.val = kt.val)
+      have hrowAdd_p :
+          (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht] =
+            (Matrix.rowAdd b j k c)[k] :=
+        congrArg (Matrix.rowAdd b j k c).get hpn_k
+      have hrowAdd_q :
+          (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE q ht] =
+            (Matrix.rowAdd b j k c)[k] :=
+        congrArg (Matrix.rowAdd b j k c).get hqn_k
+      rw [hrowAdd_p, hrowAdd_q]
+      rw [dot_rowAdd_row_at_left b j k c ((Matrix.rowAdd b j k c)[k])]
+      have hrec_k :
+          Matrix.dot b[k] ((Matrix.rowAdd b j k c)[k]) =
+            Matrix.dot b[k] b[k] + c * Matrix.dot b[k] b[j] :=
+        dot_rowAdd_row_at_right b j k c b[k]
+      have hrec_j :
+          Matrix.dot b[j] ((Matrix.rowAdd b j k c)[k]) =
+            Matrix.dot b[j] b[k] + c * Matrix.dot b[j] b[j] :=
+        dot_rowAdd_row_at_right b j k c b[j]
+      rw [hrec_k, hrec_j]
+      simp only [if_pos hpk]
+      rw [hM_entry kt q, hM_entry jt q, hM_entry kt jt, hM_entry jt jt]
+      have hb_q : b[GramSchmidt.liftFinLE q ht] = b[k] :=
+        congrArg b.get hqn_k
+      rw [hbjt_lift, hbkt_lift, hb_q]
+      have hsym : Matrix.dot b[j] b[k] = Matrix.dot b[k] b[j] := dot_comm_int _ _
+      rw [hsym]
+    · -- p ≠ kt, q = kt
+      have hpn_ne : (GramSchmidt.liftFinLE p ht).val ≠ k.val :=
+        fun h => hpk (Fin.ext h)
+      have hqn_k : GramSchmidt.liftFinLE q ht = k :=
+        Fin.ext (Fin.val_eq_of_eq hqk : q.val = kt.val)
+      have hrowAdd_q :
+          (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE q ht] =
+            (Matrix.rowAdd b j k c)[k] :=
+        congrArg (Matrix.rowAdd b j k c).get hqn_k
+      have hb_q : b[GramSchmidt.liftFinLE q ht] = b[k] :=
+        congrArg b.get hqn_k
+      rw [hrowAdd_q]
+      rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne]
+      rw [dot_rowAdd_row_at_right b j k c (b[GramSchmidt.liftFinLE p ht])]
+      simp only [if_neg hpk]
+      rw [hM_entry p q, hM_entry p jt]
+      rw [hbjt_lift, hb_q]
+  · -- q ≠ kt branch
+    rw [if_neg hqk]
+    have hqn_ne : (GramSchmidt.liftFinLE q ht).val ≠ k.val :=
+      fun h => hqk (Fin.ext h)
+    rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q]
+    rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE q ht) c hqn_ne]
+    have hbjt_lift : b[GramSchmidt.liftFinLE jt ht] = b[j] :=
+      congrArg b.get hjt_lift
+    have hbkt_lift : b[GramSchmidt.liftFinLE kt ht] = b[k] :=
+      congrArg b.get hkt_lift
+    by_cases hpk : p = kt
+    · -- p = kt, q ≠ kt
+      have hpn_k : GramSchmidt.liftFinLE p ht = k :=
+        Fin.ext (Fin.val_eq_of_eq hpk : p.val = kt.val)
+      have hrowAdd_p :
+          (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht] =
+            (Matrix.rowAdd b j k c)[k] :=
+        congrArg (Matrix.rowAdd b j k c).get hpn_k
+      rw [hrowAdd_p]
+      rw [dot_rowAdd_row_at_left b j k c (b[GramSchmidt.liftFinLE q ht])]
+      simp only [if_pos hpk]
+      rw [hM_entry kt q, hM_entry jt q]
+      rw [hbjt_lift, hbkt_lift]
+    · -- p ≠ kt, q ≠ kt
+      have hpn_ne : (GramSchmidt.liftFinLE p ht).val ≠ k.val :=
+        fun h => hpk (Fin.ext h)
+      rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne]
+      simp only [if_neg hpk]
+      rw [hM_entry p q]
+
+/-- When the modified row index `k` lies inside the leading `t`-prefix
+(`k.val < t`), the leading Gram matrix of `Matrix.rowAdd b j k c` agrees with
+the row-and-column-add of the original leading Gram matrix at the lifted
+`Fin t` indices `jt`, `kt`. -/
+private theorem leadingGramMatrixInt_rowAdd_inside
+    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+    (hjk : j.val < k.val) (hkt : k.val < t) :
+    GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht =
+      Matrix.colAdd
+        (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht)
+          ⟨j.val, Nat.lt_trans hjk hkt⟩ ⟨k.val, hkt⟩ c)
+        ⟨j.val, Nat.lt_trans hjk hkt⟩ ⟨k.val, hkt⟩ c := by
+  apply Vector.ext
+  intro p hp
+  apply Vector.ext
+  intro q hq
+  exact leadingGramMatrixInt_rowAdd_entry_inside b j k c t ht hjk hkt
+    ⟨p, hp⟩ ⟨q, hq⟩
+
 end GramSchmidt.Int
 
 namespace GramSchmidt.Rat

--- a/progress/20260507T144425Z_d8a62e2d.md
+++ b/progress/20260507T144425Z_d8a62e2d.md
@@ -1,0 +1,73 @@
+# 2026-05-07 14:44 UTC — work session (d8a62e2d)
+
+## Accomplished
+
+Audited the human-oversight queue first per the worker skill: claimed and
+skipped #2565, #2566, #2567 with explicit blocker reasons (each depends on
+#2564 (HO-1) which is itself in `replan` because PR #2563 has not yet
+landed; #2565 also depends on #2563 directly).
+
+Claimed #2558 (`HexHensel: complete Phase 4 benchmark audit and bump`) but
+identified it as a duplicate of #2555 — PR #2568 (claimed by an earlier
+session) already performs the same `libraries.yml` 3 → 4 bump. PR #2568 is
+currently red only on an unrelated `HexGfq.Conformance` Conway-guard
+failure, which PR #2569 fixes. Skipped #2558 with this reasoning.
+
+Claimed #2543 (`HexGramSchmidt.Int: prove rowAdd leading Gram prefix
+bridge`) and discharged the named target theorem `gramDet_rowAdd_earlier`
+without any new `sorry` or `axiom`.
+
+Concretely, added to [HexGramSchmidt/Int.lean](../blob/main/HexGramSchmidt/Int.lean):
+
+* row-add dot-product helpers: rectangular `rowAdd_get_rect`, integer dot
+  commutativity `dot_comm_int`, and bilinearity helpers
+  `dot_rowAdd_row_at_left` / `dot_rowAdd_row_at_right`;
+* the structural identity for the leading Gram matrix under `Matrix.rowAdd`
+  in two cases:
+  * `leadingGramMatrixInt_rowAdd_outside` (when `t ≤ k.val`): the leading
+    prefix is unchanged;
+  * `leadingGramMatrixInt_rowAdd_inside` (when `k.val < t`): the leading
+    prefix equals `colAdd (rowAdd M jt kt c) jt kt c` where `M` is the
+    original leading Gram matrix and `jt, kt : Fin t` are the lifted
+    indices;
+* the named target theorem `gramDet_rowAdd_earlier`:
+
+  ```lean
+  theorem gramDet_rowAdd_earlier
+      (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+      (hjk : j.val < k.val) :
+      gramDet (Matrix.rowAdd b j k c) t ht = gramDet b t ht
+  ```
+
+  The proof case-splits on `k.val < t`: inside, it composes
+  `leadingGramMatrixInt_rowAdd_inside` with `Matrix.bareiss_eq_det`,
+  `Matrix.det_colAdd`, and `Matrix.det_rowAdd`; outside, it uses
+  `leadingGramMatrixInt_rowAdd_outside` directly.
+
+Verification completed:
+
+* `lake build HexGramSchmidt.Int`
+* `lake build` (full)
+* `python3 scripts/check_dag.py`
+* `git diff --check`
+* No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level
+  `sorry`. The eight pre-existing `sorry`s in `HexGramSchmidt/Int.lean`
+  are unchanged.
+
+## Current frontier
+
+`gramDet_rowAdd_earlier` is now available at the `HexGramSchmidt.Int`
+public surface. The follow-up issue #2544 (currently blocked on #2543)
+can now consume this theorem to discharge `gramDet_sizeReduce` in
+`HexGramSchmidt/Update.lean`.
+
+## Next step
+
+Open the PR closing #2543 with these three commits (helpers, structural
+lemmas, main theorem) and this progress file.
+
+## Blockers
+
+None for this corner of the project. The worktree still contains an
+unrelated pre-existing `.claude/CLAUDE.md` modification that this session
+did not touch.


### PR DESCRIPTION
This PR proves the named target `gramDet_rowAdd_earlier` from #2543 in
[HexGramSchmidt/Int.lean](HexGramSchmidt/Int.lean). Adding a multiple of an
earlier row to a later row (`j.val < k.val`) leaves the leading Gram
determinant unchanged.

The proof case-splits on whether the modified row index `k` lies inside
the leading `t`-prefix:

- `k.val < t`: the new structural identity
  `leadingGramMatrixInt_rowAdd_inside` rewrites the leading Gram matrix as
  `colAdd (rowAdd M jt kt c) jt kt c` at the lifted indices `jt, kt : Fin t`;
  `Matrix.bareiss_eq_det`, `Matrix.det_colAdd`, and `Matrix.det_rowAdd`
  then close the determinant equality. The `jt ≠ kt` precondition is the
  contrapositive of `j.val < k.val`.
- `t ≤ k.val`: the matching `leadingGramMatrixInt_rowAdd_outside` shows
  the leading prefix is identical, so the Bareiss determinant is too.

Supporting helpers in the same file: rectangular `rowAdd_get_rect`,
integer dot-product commutativity `dot_comm_int`, and bilinearity along
the modified row (`dot_rowAdd_row_at_left` / `dot_rowAdd_row_at_right`).

No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level
`sorry`. Pre-existing `sorry` count in this file is unchanged.

Closes #2543.

Session: `d8a62e2d-11e3-421c-b605-d85a98899efd`

🤖 Prepared with Claude Code
