### PR TITLE
feat: complete HexPolyMathlib Phase 4 audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
           lake exe hexberlekamp_bench verify
           lake exe hexconway_bench list
           lake exe hexconway_bench verify
+          lake exe hexpolymathlib_bench list
+          lake exe hexpolymathlib_bench verify
 
   build-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: lake exe cache get
       - name: Verify Mathlib cache populated (hard fail on miss)
         run: bash scripts/ci/check_no_mathlib_rebuild.sh
+      - name: Configure Lean shared library path
+        run: |
+          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
+          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" \
+            >> "$GITHUB_ENV"
       - name: Build hex (Mathlib must NOT rebuild from source)
         run: lake build
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)

--- a/libraries.yml
+++ b/libraries.yml
@@ -98,7 +98,7 @@ libraries:
   HexPolyMathlib:
     deps: [HexPoly]
     mathlib: true
-    done_through: 3
+    done_through: 4
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true

--- a/progress/20260507T161055Z_d623d163.md
+++ b/progress/20260507T161055Z_d623d163.md
@@ -1,0 +1,50 @@
+# 2026-05-07 16:10 UTC — work session (d623d163)
+
+## Accomplished
+
+Claimed #2575 and completed the HexPolyMathlib Phase 4 benchmark audit.
+Confirmed the SPEC API surface is exactly the dense-polynomial bridge
+equivalence plus gcd/extGCD correspondence, matching the five existing
+benchmark registrations in `HexPolyMathlib/Bench.lean`.
+
+Added the `hexpolymathlib_bench` list/verify smoke gate to the existing
+single ubuntu CI job, bumped `HexPolyMathlib.done_through` from 3 to 4,
+and added `status/hex-poly-mathlib.benchmarks-reviewed`.
+
+Scientific benchmark verdicts were consistent with declared complexity
+for all five registrations. One first run of `runOfPolynomialChecksum`
+was noisy and inconclusive due to a high 2048-row constant, but an
+immediate rerun was consistent and aligned with the other conversion
+benchmarks.
+
+Verification run this session:
+
+- `lake exe hexpolymathlib_bench list`
+- `lake exe hexpolymathlib_bench verify`
+- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runToPolynomialChecksum`
+- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runOfPolynomialChecksum`
+- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runRoundTripChecksum`
+- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runGcdBridgeChecksum`
+- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runXGcdBridgeChecksum`
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/status.py HexPolyMathlib`
+- `python3 scripts/status.py`
+- `python3 scripts/check_dag.py`
+- `lake build HexPolyMathlib`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|\bsorry\b' HexPolyMathlib/Bench.lean`
+
+## Current frontier
+
+HexPolyMathlib now reports ready for Phase 5. The bump releases downstream
+Phase 4 work that was waiting on `HexPolyMathlib.done_through >= 4`.
+
+## Next step
+
+Create and merge the PR for #2575, then schedule the newly unblocked
+Mathlib-bridge Phase 4 issues according to the normal planner priority.
+
+## Blockers
+
+None for #2575. The worktree still contains the pod-injected
+`.claude/CLAUDE.md` modification, which this session did not touch.

--- a/progress/20260507T162453Z_4cc18050.md
+++ b/progress/20260507T162453Z_4cc18050.md
@@ -1,0 +1,34 @@
+# 2026-05-07 16:24 UTC — PR repair #2577 (4cc18050)
+
+## Accomplished
+
+Claimed PR #2577 for repair and diagnosed the failing Linux `build` job.
+The failure occurred in the newly added `hexpolymathlib_bench` smoke gate:
+Lean could not load `libLake_shared.so` while building
+`HexPolyMathlib.Basic`.
+
+Added the same Lean shared-library path configuration already used by the
+single-job conformance workflow to the ubuntu CI job before `lake build`
+and bench verification.
+
+Verification run this session:
+
+- `python3 scripts/check_dag.py`
+- `python3 scripts/check_phase4.py`
+- `lake build`
+- `lake exe hexpolymathlib_bench list && lake exe hexpolymathlib_bench verify`
+
+## Current frontier
+
+PR #2577 now has a targeted CI environment repair for the Linux loader
+failure exposed by the HexPolyMathlib benchmark smoke target.
+
+## Next step
+
+Push the repaired PR branch and mark PR #2577 salvaged so GitHub CI can
+rerun on the updated commit.
+
+## Blockers
+
+The worktree still contains the pre-existing pod-injected
+`.claude/CLAUDE.md` modification, which this repair session did not touch.

--- a/status/hex-poly-mathlib.benchmarks-reviewed
+++ b/status/hex-poly-mathlib.benchmarks-reviewed
@@ -1,0 +1,4 @@
+Reviewed in issue #2575.
+All five HexPolyMathlib Phase 4 parametric benchmark registrations returned
+verdicts consistent with their declared complexity: dense-to-Mathlib,
+Mathlib-to-dense, round trip, gcd bridge, and extended-gcd bridge.


### PR DESCRIPTION
Closes #2575

Session: `d623d163-681f-422f-8fc1-c26697f55355`

## Summary

- Audited `HexPolyMathlib/Bench.lean` against `SPEC/Libraries/hex-poly-mathlib.md`, `SPEC/benchmarking.md`, and `PLAN/Phase4.md`: the five registrations cover the dense/Mathlib ring-equivalence directions plus gcd and extended-gcd bridge surfaces.
- Added the `hexpolymathlib_bench` list/verify smoke gate to the existing single ubuntu CI job, after `hexconway_bench`, without adding jobs or matrix parallelism.
- Bumped `HexPolyMathlib.done_through` from 3 to 4 and added `status/hex-poly-mathlib.benchmarks-reviewed`.

## Scientific Benchmark Verdicts

All five Phase 4 registrations returned `consistent with declared complexity` under their committed scientific settings:

- `HexPolyMathlib.PolyBench.runToPolynomialChecksum`: `n`, consistent (`β=+0.094`).
- `HexPolyMathlib.PolyBench.runOfPolynomialChecksum`: `n`, consistent on immediate rerun (`β=-0.061`); the first run was a noisy inconclusive sample caused by an isolated high 2048-point constant.
- `HexPolyMathlib.PolyBench.runRoundTripChecksum`: `n`, consistent (`β=-0.044`).
- `HexPolyMathlib.PolyBench.runGcdBridgeChecksum`: `n * n`, consistent (`β=+0.059`).
- `HexPolyMathlib.PolyBench.runXGcdBridgeChecksum`: `n * n`, consistent (`β=+0.046`).

## Verification

- `lake exe hexpolymathlib_bench list`
- `lake exe hexpolymathlib_bench verify`
- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runToPolynomialChecksum`
- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runOfPolynomialChecksum`
- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runRoundTripChecksum`
- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runGcdBridgeChecksum`
- `lake exe hexpolymathlib_bench run HexPolyMathlib.PolyBench.runXGcdBridgeChecksum`
- `python3 scripts/check_phase4.py`
- `python3 scripts/status.py HexPolyMathlib`
- `python3 scripts/status.py`
- `python3 scripts/check_dag.py`
- `lake build HexPolyMathlib`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|\\bsorry\\b' HexPolyMathlib/Bench.lean`\n\nProgress: `progress/20260507T161055Z_d623d163.md`