### PR TITLE
chore: complete HexConway Phase 4 benchmark audit

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -84,7 +84,7 @@ libraries:
   HexConway:
     deps: [HexBerlekamp]
     mathlib: false
-    done_through: 3
+    done_through: 4
   HexGfq:
     deps: [HexGfqField, HexConway, HexGF2]
     mathlib: false

--- a/progress/20260507T161127Z_2751c275.md
+++ b/progress/20260507T161127Z_2751c275.md
@@ -1,0 +1,32 @@
+# 2026-05-07 16:11 UTC — HexConway Phase 4 bump (2751c275)
+
+## Accomplished
+
+Claimed #2574 after the human-oversight queue proved unclaimable due to replan state and #2575 raced to another agent. Audited `HexConway/Bench.lean` against the Tier 1-only Phase 4 scope in `SPEC/Libraries/hex-conway.md`, `SPEC/benchmarking.md`, and `PLAN/Phase4.md`.
+
+Verified the existing HexConway benchmark surface:
+
+- `lake build HexConway` succeeded.
+- `lake exe hexconway_bench list` showed the lookup benchmark plus eight fixed registrations.
+- `lake exe hexconway_bench verify` passed all 9 registrations.
+- `lake exe hexconway_bench run Hex.ConwayBench.runLuebeckConwayPolynomialLookupChecksum` returned `consistent with declared complexity` with β = `+0.013`.
+- All eight fixed registrations ran with all repeats agreeing and expected hashes matching.
+- `lake build HexConway.Conformance` succeeded.
+- `python3 scripts/check_phase4.py` passed for changed registrations.
+- `python3 scripts/status.py HexConway` reports HexConway ready for Phase 5 after the bump.
+- `python3 scripts/status.py` now lists HexGfq as Phase 4-ready.
+- `python3 scripts/check_dag.py` and `git diff --check` passed.
+
+Bumped `HexConway.done_through` from 3 to 4 in `libraries.yml` and added `status/hex-conway.benchmarks-reviewed`.
+
+## Current frontier
+
+HexConway is Phase 4-complete for the committed Tier 1 benchmark scope. Tier 2 full Conway verification and Tier 3 on-demand search remain explicitly out of scope per the SPEC and issue.
+
+## Next step
+
+Open the PR for #2574. Downstream, HexGfq can now start its Phase 4 benchmark pass.
+
+## Blockers
+
+`python3 scripts/check_phase4.py --all` fails on pre-existing adjacent cost-model comment gaps in unrelated benchmark modules, so this session used the script's changed-registration mode for PR-local validation. The worktree still contains the pre-existing pod-managed `.claude/CLAUDE.md` modification, left untouched.

--- a/status/hex-conway.benchmarks-reviewed
+++ b/status/hex-conway.benchmarks-reviewed
@@ -1,0 +1,2 @@
+Reviewed in issue #2574.
+Tier 1 HexConway benchmark registrations cover the committed Luebeck lookup and selected fixed irreducibility checks; Phase 4 excludes Tier 2 and Tier 3 Conway work per SPEC.


### PR DESCRIPTION
Closes #2574

Session: `2751c275-5664-4220-a0e9-65410ebba8bc`

## Summary

Completed the HexConway Tier 1 Phase 4 audit and bumped `HexConway.done_through` from 3 to 4. Added `status/hex-conway.benchmarks-reviewed`.

The audit confirms the existing benchmark surface covers the committed Tier 1 API promised by `SPEC/Libraries/hex-conway.md`: finite Luebeck lookup over the 36 committed `(p, n)` entries, the exported `SupportedEntry` path for `C(2, 1)`, and fixed Rabin irreducibility checks for selected committed table entries. Tier 2 full Conway verification and Tier 3 on-demand search remain out of scope for this bump.

## Benchmark Results

`Hex.ConwayBench.runLuebeckConwayPolynomialLookupChecksum` returned `consistent with declared complexity` for the constant committed-table lookup model (`β = +0.013`, `cMin = 317.943`, `cMax = 852.511`).

Fixed registrations all ran under their declared `repeats := 5`; every run reported `hash: all repeats agree` and `expected hash: matches`:

- `Hex.ConwayBench.runConwayPolySupported_2_1Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_2_1Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_2_6Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_3_6Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_5_6Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_7_6Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_11_6Checksum`
- `Hex.ConwayBench.runTier1Irreducibility_13_6Checksum`

The supported-entry fixed microbenchmark emitted the harness sub-microsecond advisory; the benchmark already threads input through `IO.Ref`, and the measured operation is intentionally tiny committed-table access.

## Verification

- `lake build HexConway`
- `lake exe hexconway_bench list`
- `lake exe hexconway_bench verify`
- `lake exe hexconway_bench run Hex.ConwayBench.runLuebeckConwayPolynomialLookupChecksum`
- fixed benchmark runs listed above
- `lake build HexConway.Conformance`
- `python3 scripts/check_phase4.py`
- `python3 scripts/status.py HexConway`
- `python3 scripts/status.py`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n "^axiom\\b|native_decide|TODO|FIXME|\\bsorry\\b" HexConway/Bench.lean HexConway/Basic.lean status/hex-conway.benchmarks-reviewed libraries.yml` returned no hits

Note: `python3 scripts/check_phase4.py --all` currently fails on pre-existing adjacent cost-model comment gaps in unrelated benchmark modules, so PR-local validation used the script default, which checks changed registrations.