### PR TITLE
feat: add HexMatrixMathlib determinant bridge benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           lake exe hexarith_bench verify
           lake exe hexmatrix_bench list
           lake exe hexmatrix_bench verify
+          lake exe hexmatrixmathlib_bench list
+          lake exe hexmatrixmathlib_bench verify
           lake exe hexpoly_bench list
           lake exe hexpoly_bench verify
           lake exe hexpolyz_bench list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: lake exe cache get
       - name: Verify Mathlib cache populated (hard fail on miss)
         run: bash scripts/ci/check_no_mathlib_rebuild.sh
+      - name: Configure Lean shared library path
+        run: |
+          toolchain="$(sed 's|/|--|; s|:|---|' lean-toolchain)"
+          echo "LD_LIBRARY_PATH=$HOME/.elan/toolchains/$toolchain/lib/lean:${LD_LIBRARY_PATH:-}" \
+            >> "$GITHUB_ENV"
       - name: Build hex (Mathlib must NOT rebuild from source)
         run: lake build
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)

--- a/HexMatrixMathlib/Bench.lean
+++ b/HexMatrixMathlib/Bench.lean
@@ -1,4 +1,4 @@
-import HexMatrixMathlib.Basic
+import HexMatrixMathlib.Determinant
 import LeanBench
 
 /-!
@@ -6,8 +6,8 @@ Benchmark registrations for the `HexMatrixMathlib` dense-matrix bridge.
 
 This Phase 4 slice measures the representation conversion surfaces between the
 executable `Hex.Matrix` representation and Mathlib's function-based `Matrix`
-representation. Determinant, row-operation, rank, span, and nullspace bridge
-benchmarks are left to later Phase 4 slices.
+representation, plus the determinant bridge theorem surface. Row-operation,
+rank, span, and nullspace bridge benchmarks are left to later Phase 4 slices.
 
 Scientific registrations:
 
@@ -17,6 +17,16 @@ Scientific registrations:
   dense matrix and checksum its entries, `O(n^2)`.
 * `runRoundTripChecksum`: perform both dense and Mathlib conversion round trips
   over generated square integer matrices, `O(n^2)`.
+* `runHexDetBridge`: convert a generated Mathlib matrix to `Hex.Matrix` and
+  compute `Hex.Matrix.det`, using the Leibniz determinant model `O(n * n!)`.
+* `runMathlibDetBridge`: convert the same generated dense matrix through
+  `matrixEquiv` and compute `Matrix.det`, using the same textbook Leibniz
+  determinant model.
+
+Compare groups:
+
+* `compare runHexDetBridge runMathlibDetBridge` checks the determinant bridge on
+  the shared small-domain integer fixture schedule.
 -/
 
 namespace HexMatrixMathlib.MatrixBench
@@ -32,6 +42,12 @@ structure RoundTripInput where
   n : Nat
   denseEntries : Array Int
   mathlibEntries : Array Int
+  deriving Repr, BEq, Hashable
+
+/-- Flattened benchmark input for determinant bridge checks. -/
+structure DetInput where
+  n : Nat
+  entries : Array Int
   deriving Repr, BEq, Hashable
 
 /-- Deterministic mixing over machine words for compact benchmark observables. -/
@@ -98,6 +114,11 @@ def prepRoundTripInput (n : Nat) : RoundTripInput :=
     denseEntries := flatMatrix n 131
     mathlibEntries := flatMatrix n 173 }
 
+/-- Per-parameter determinant fixture shared by Hex and Mathlib determinant paths. -/
+def prepDetInput (n : Nat) : DetInput :=
+  { n := n
+    entries := flatMatrix n 211 }
+
 /-- Benchmark target: convert one dense matrix and checksum Mathlib entries. -/
 def runMatrixEquivChecksum (input : MatrixInput) : UInt64 :=
   let dense : Hex.Matrix Int input.n input.n := hexMatrixOfFlat input.n input.entries
@@ -118,6 +139,27 @@ def runRoundTripChecksum (input : RoundTripInput) : UInt64 :=
   let denseRoundTrip := matrixEquiv.symm (matrixEquiv dense)
   let mathlibRoundTrip := matrixEquiv (matrixEquiv.symm mathlib)
   mixWord (checksumHex denseRoundTrip) (checksumMathlib mathlibRoundTrip)
+
+/-- Benchmark target: convert from Mathlib representation and compute Hex's determinant. -/
+def runHexDetBridge (input : DetInput) : Int :=
+  let mathlib : Matrix (Fin input.n) (Fin input.n) Int :=
+    mathlibMatrixOfFlat input.n input.entries
+  let dense : Hex.Matrix Int input.n input.n := matrixEquiv.symm mathlib
+  Hex.Matrix.det dense
+
+/-- Benchmark target: convert from dense representation and compute Mathlib's determinant. -/
+def runMathlibDetBridge (input : DetInput) : Int :=
+  let dense : Hex.Matrix Int input.n input.n := hexMatrixOfFlat input.n input.entries
+  Matrix.det (matrixEquiv dense)
+
+/-- Textbook Leibniz determinant operation-count model, `n!`. -/
+def determinantFactorialComplexity : Nat → Nat
+  | 0 => 1
+  | n + 1 => (n + 1) * determinantFactorialComplexity n
+
+/-- Textbook determinant bridge model for the Leibniz sum, `O(n * n!)`. -/
+def determinantBridgeComplexity (n : Nat) : Nat :=
+  n * determinantFactorialComplexity n
 
 /- Cost model: `matrixEquiv` exposes each dense matrix entry through a function
 view. The checksum forces every entry of the generated `n x n` matrix once. -/
@@ -155,6 +197,36 @@ setup_benchmark runRoundTripChecksum n => n * n
     paramSchedule := .custom #[128, 256, 384, 512]
     maxSecondsPerCall := 2.0
     targetInnerNanos := 200000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: `Hex.Matrix.det` uses the Leibniz formula. The bridge conversion
+is quadratic, dominated on the shared comparison domain by the `n!` terms, each
+touching `n` entries. -/
+setup_benchmark runHexDetBridge n => determinantBridgeComplexity n
+  with prep := prepDetInput
+  where {
+    paramFloor := 3
+    paramCeiling := 7
+    paramSchedule := .custom #[3, 4, 5, 6, 7]
+    maxSecondsPerCall := 1.5
+    targetInnerNanos := 800000000
+    verdictWarmupFraction := 0.5
+    signalFloorMultiplier := 1.0
+  }
+
+/- Cost model: Mathlib's determinant is exercised through the same Leibniz
+determinant model on the same fixture schedule; `matrixEquiv` conversion is
+quadratic and does not dominate the determinant work. -/
+setup_benchmark runMathlibDetBridge n => determinantBridgeComplexity n
+  with prep := prepDetInput
+  where {
+    paramFloor := 3
+    paramCeiling := 7
+    paramSchedule := .custom #[3, 4, 5, 6, 7]
+    maxSecondsPerCall := 1.5
+    targetInnerNanos := 800000000
+    verdictWarmupFraction := 0.5
     signalFloorMultiplier := 1.0
   }
 

--- a/progress/20260507T181221Z_239744aa.md
+++ b/progress/20260507T181221Z_239744aa.md
@@ -1,0 +1,45 @@
+# 2026-05-07 18:12 UTC — HexMatrixMathlib determinant bench slice (239744aa)
+
+## Accomplished
+
+Claimed issue #2584 and added the HexMatrixMathlib determinant bridge benchmark
+slice. `HexMatrixMathlib/Bench.lean` now imports the determinant bridge, defines
+a shared deterministic integer square-matrix fixture, registers
+`runHexDetBridge` and `runMathlibDetBridge` on the same small-domain Leibniz
+determinant model, and documents the compare group for bridge agreement.
+
+Extended the existing single ubuntu CI bench-smoke script with sequential
+`hexmatrixmathlib_bench list` and `hexmatrixmathlib_bench verify` commands.
+
+Verification passed:
+
+- `lake build HexMatrixMathlib.Bench`
+- `lake exe hexmatrixmathlib_bench list`
+- `lake exe hexmatrixmathlib_bench verify`
+- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runHexDetBridge`
+- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runMathlibDetBridge`
+- `lake exe hexmatrixmathlib_bench compare HexMatrixMathlib.MatrixBench.runHexDetBridge HexMatrixMathlib.MatrixBench.runMathlibDetBridge`
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/status.py HexMatrixMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|\bsorry\b' HexMatrixMathlib/Bench.lean`
+
+`scripts/check_phase4.py HexMatrixMathlib` was also attempted, but this checkout
+does not support a per-library positional argument.
+
+## Current frontier
+
+The determinant bridge part of the HexMatrixMathlib Phase 4 benchmark surface is
+covered and CI now smoke-checks the HexMatrixMathlib benchmark executable.
+
+## Next step
+
+Open the PR for #2584. Later Phase 4 slices still need row-operation, rank,
+span, and nullspace bridge benchmark coverage before `HexMatrixMathlib` can bump
+`done_through` to 4.
+
+## Blockers
+
+None for this slice. The worktree still contains the pre-existing
+pod-managed `.claude/CLAUDE.md` modification, left untouched.

--- a/progress/20260507T182337Z_pr2590_repair.md
+++ b/progress/20260507T182337Z_pr2590_repair.md
@@ -1,0 +1,36 @@
+# 2026-05-07 18:23 UTC — PR #2590 repair
+
+## Accomplished
+
+Claimed repair PR #2590 and diagnosed the failed Ubuntu `build` check. The
+failure occurred during `lake exe hexmatrixmathlib_bench verify`, where Lean
+could not load `libLake_shared.so` while building `HexMatrixMathlib` modules on
+Linux.
+
+Added the existing conformance workflow's Lean shared-library path setup to the
+Ubuntu CI job before `lake build` and the benchmark smoke gate. This keeps the
+new HexMatrixMathlib benchmark checks in the existing single job while exposing
+the Lean toolchain shared libraries to dynamic loading.
+
+Verification passed:
+
+- `python3 scripts/check_dag.py`
+- `python3 scripts/check_phase4.py`
+- `git diff --check`
+- `lake build`
+- `lake exe hexmatrixmathlib_bench list`
+- `lake exe hexmatrixmathlib_bench verify`
+
+## Current frontier
+
+PR #2590 is locally repaired and ready to push. The pre-existing pod-managed
+`.claude/CLAUDE.md` modification remains untouched.
+
+## Next step
+
+Commit the CI repair plus this progress note, force-push the PR branch, and mark
+PR #2590 salvaged.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2584

Session: `239744aa-d518-483e-b926-37e04f24a5ad`

## Summary

- Added `HexMatrixMathlib.MatrixBench.runHexDetBridge` and `runMathlibDetBridge` on a shared deterministic integer square-matrix fixture.
- Declared the determinant bridge cost model as the textbook Leibniz model `O(n * n!)` and documented the compare group `compare runHexDetBridge runMathlibDetBridge`.
- Extended the existing single ubuntu CI bench-smoke script with sequential `hexmatrixmathlib_bench list` and `verify` commands.

## Benchmark Verdicts

Scientific runs on the committed schedule `#[3, 4, 5, 6, 7]`:

- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runHexDetBridge`: consistent with declared complexity.
- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runMathlibDetBridge`: consistent with declared complexity.
- `lake exe hexmatrixmathlib_bench compare HexMatrixMathlib.MatrixBench.runHexDetBridge HexMatrixMathlib.MatrixBench.runMathlibDetBridge`: common params `3, 4, 5, 6, 7`; agreement: all functions agree on common params.

## Verification

- `lake build HexMatrixMathlib.Bench`
- `lake exe hexmatrixmathlib_bench list`
- `lake exe hexmatrixmathlib_bench verify`
- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runHexDetBridge`
- `lake exe hexmatrixmathlib_bench run HexMatrixMathlib.MatrixBench.runMathlibDetBridge`
- `lake exe hexmatrixmathlib_bench compare HexMatrixMathlib.MatrixBench.runHexDetBridge HexMatrixMathlib.MatrixBench.runMathlibDetBridge`
- `python3 scripts/check_phase4.py`
- `python3 scripts/status.py HexMatrixMathlib`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|\\bsorry\\b' HexMatrixMathlib/Bench.lean`\n\n`python3 scripts/check_phase4.py HexMatrixMathlib` was attempted, but this checkout does not support a per-library positional argument, so the default full changed-registration check was run instead.