### PR TITLE
spec: introduce Factorization record for HexBerlekampZassenhaus.factor

### DIFF
--- a/SPEC/Libraries/hex-berlekamp-zassenhaus-mathlib.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus-mathlib.md
@@ -3,29 +3,59 @@
 Instantiates the conditional correctness theorems from
 hex-berlekamp-zassenhaus (which take an abstract coefficient bound)
 with the Mignotte bound from hex-poly-z-mathlib, giving unconditional
-results:
+results. All statements use the `Factorization` record from
+`hex-berlekamp-zassenhaus.md`'s output-convention section:
+
 ```lean
 theorem factor_product (f : ZPoly) :
-    Array.foldl (· * ·) 1 (factor f) = f
+    Factorization.product (factor f) = f
 
-theorem factor_irreducible (f : ZPoly) :
-    ∀ g ∈ factor f, Irreducible g
+theorem factor_irreducible_of_nonUnit (f : ZPoly) :
+    ∀ (g, m) ∈ (factor f).factors, Hex.ZPoly.Irreducible g
 
--- Follows from Mathlib's `UniqueFactorizationMonoid.factors_unique`
+theorem factor_unique (f : ZPoly) (φ ψ : Factorization) :
+    Factorization.product φ = f →
+    Factorization.product ψ = f →
+    (∀ (g, m) ∈ φ.factors, Hex.ZPoly.Irreducible g) →
+    (∀ (g, m) ∈ ψ.factors, Hex.ZPoly.Irreducible g) →
+    φ.scalar = ψ.scalar ∧
+    φ.factors.toList.toFinmap = ψ.factors.toList.toFinmap
+-- Multiset equality of polynomial factors with multiplicities; the
+-- scalar matches because both Factorizations encode the same f.
+-- Follows from `UniqueFactorizationMonoid.factors_unique` over `Int`
 -- (in `Mathlib.RingTheory.UniqueFactorizationDomain.Basic`) via the
--- ring equivalence. `Polynomial ℤ` gets the `UniqueFactorizationMonoid`
--- instance from `Mathlib.RingTheory.Polynomial.UniqueFactorization`.
-theorem factor_unique (f : ZPoly) (gs hs : Array ZPoly) :
-    Array.foldl (· * ·) 1 gs = f →
-    Array.foldl (· * ·) 1 hs = f →
-    (∀ g ∈ gs, Irreducible g) →
-    (∀ h ∈ hs, Irreducible h) →
-    gs.toList ~ hs.toList  -- multiset equality up to associates
+-- ring equivalence. `Polynomial ℤ` gets the
+-- `UniqueFactorizationMonoid` instance from
+-- `Mathlib.RingTheory.Polynomial.UniqueFactorization`.
 
 theorem checkIrreducibleCert_sound
     (f : ZPoly) (cert : ZPolyIrreducibilityCertificate) :
     checkIrreducibleCert f cert = true → Irreducible f
 ```
+
+`factor_irreducible_of_nonUnit` is the corrected form of the old
+`factor_irreducible` (which incorrectly claimed *every* element of
+the old `Array ZPoly` output was irreducible — false for content
+factors like `[C 6, ...]` since `C 6 = C 2 · C 3` is reducible in
+`Polynomial ℤ`). Under the new `Factorization` API, the
+`factors` field by SPEC contains *only* irreducible non-unit
+polynomial factors, so the per-element irreducibility claim is
+precisely what we want.
+
+**Bridge for `Hex.ZPoly.Irreducible`** (the Mathlib-free class
+defined in `hex-berlekamp-zassenhaus.md`):
+
+```lean
+theorem Hex.ZPoly.Irreducible_iff_polynomialIrreducible (f : ZPoly) :
+    Hex.ZPoly.Irreducible f ↔ Irreducible (toPolynomial f)
+```
+
+Cheap from the existing `irreducibleByFactorization_iff` infrastructure
+plus the `Hex.ZPoly.IsUnit f ↔ IsUnit (toPolynomial f)` bridge from
+`hex-poly-z-mathlib`. The two definitions of irreducibility (ours and
+Mathlib's) are propositionally identical when phrased over the
+respective unit predicates; the bridge unfolds both sides and
+rewrites `IsUnit` and `(· * ·)` through `toPolynomial`.
 
 Also connects to Mathlib's `Polynomial ℤ` and provides
 `Decidable (Irreducible f)` for `f : Polynomial ℤ`.

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -17,23 +17,158 @@ its Mathlib bridge; every theorem has a real proof.
 The public API accepts arbitrary input polynomials and normalizes
 internally: extract content, remove powers of `X`, and reduce to the
 primitive square-free case before running the recombination pipeline.
-The output is an `Array ZPoly` of primitive factors. Factor order is
-operationally the array order, but the mathematical contract is
-through product and membership rather than any semantic significance
+The output is a **`Factorization` record** explicitly separating the
+signed scalar (sign · content) from the polynomial-factor multiset
+with explicit multiplicities. Factor order in the polynomial-factor
+array is operationally the array order, but the mathematical contract
+is through product and membership rather than any semantic significance
 of that order.
 
 **Top-level API:**
 ```lean
-def factorSlow (f : ZPoly) : Array ZPoly
-def factorFast (f : ZPoly) : Option (Array ZPoly)
-def factor (f : ZPoly) : Array ZPoly := (factorFast f).getD (factorSlow f)
-def factorWithBound (f : ZPoly) (B : Nat) : Array ZPoly
+def factorSlow (f : ZPoly) : Factorization
+def factorFast (f : ZPoly) : Option Factorization
+def factor (f : ZPoly) : Factorization := (factorFast f).getD (factorSlow f)
+def factorWithBound (f : ZPoly) (B : Nat) : Factorization
 ```
 
 `factorSlow` is the unconditionally-correct exhaustive recombination
 path; `factorFast` is the production van Hoeij CLD path; `factor` is
 the public-facing combinator. `factorWithBound` retains its existing
 contract and uses the same combinator under the hood.
+
+**Output convention: the `Factorization` record.**
+
+```lean
+structure Factorization where
+  /-- Signed scalar absorbing both sign and content of the input.
+      For nonzero input: `scalar = sign(lc(f)) · ZPoly.content(f)`.
+      For `f = 0`: `scalar = 0`. -/
+  scalar  : Int
+  /-- Polynomial factors (each irreducible primitive with positive
+      leading coefficient) with multiplicities ≥ 1; no two pairs
+      share a polynomial. -/
+  factors : Array (ZPoly × Nat)
+deriving DecidableEq
+
+def Factorization.product (φ : Factorization) : ZPoly :=
+  φ.factors.foldl (fun acc ⟨g, m⟩ => acc * g^m) (DensePoly.C φ.scalar)
+```
+
+For `f : ZPoly`, `factor f` returns a `Factorization` such that:
+
+1. `scalar = sign(lc(f)) · ZPoly.content(f)`. Zero iff `f = 0`.
+2. Each `(g, m) ∈ factors` has:
+   - `g` primitive with positive leading coefficient
+     (`Hex.ZPoly.Primitive g ∧ 0 < g.leadingCoeff`),
+   - `g` irreducible (`Hex.ZPoly.Irreducible g`; see below),
+   - `m > 0`.
+3. **No duplicate polynomial factors**: distinct entries in `factors`
+   have distinct first components.
+4. **Product preservation**: `Factorization.product (factor f) = f`.
+5. Factor order is operationally array order; the mathematical
+   contract is product + membership (an array of pairs as a multiset).
+
+**Convention: don't break content into primes.** `factor 6 = ⟨6, #[]⟩`,
+not `⟨1, #[(C 2, 1), (C 3, 1)]⟩`. The `factors` field carries
+*polynomial* factors of `primitivePart(f)`; the integer
+factorisation of the content lives in the `scalar` field as a single
+signed integer. This matches FLINT and SymPy.
+
+### Edge cases
+
+| Input `f` | `factor f` |
+|---|---|
+| `0` | `⟨0, #[]⟩` |
+| `1` | `⟨1, #[]⟩` |
+| `-1` | `⟨-1, #[]⟩` |
+| `2` | `⟨2, #[]⟩` |
+| `-6` | `⟨-6, #[]⟩` |
+| `X` | `⟨1, #[(X, 1)]⟩` |
+| `-X` | `⟨-1, #[(X, 1)]⟩` |
+| `X²` | `⟨1, #[(X, 2)]⟩` |
+| `-X² + 1` | `⟨-1, #[(X-1, 1), (X+1, 1)]⟩` |
+| `(X-1)²` | `⟨1, #[(X-1, 2)]⟩` |
+| `-(X-1)²` | `⟨-1, #[(X-1, 2)]⟩` |
+| `2(X-1)(X+1)` | `⟨2, #[(X-1, 1), (X+1, 1)]⟩` |
+| `-2(X-1)²` | `⟨-2, #[(X-1, 2)]⟩` |
+
+**Why this representation, vs. `Array ZPoly` with content folded as
+a constant element?** Two reasons:
+
+1. The signed-scalar field gives uniform sign handling. With a flat
+   `Array ZPoly`, sign would have to be encoded as a constant-
+   polynomial factor or as a separately-tracked `Int`, neither
+   ergonomic. The Mathlib-bridge product theorem
+   `Factorization.product (factor f) = f` then becomes provably
+   exact (no "up to sign" caveat).
+2. Multiplicity is explicit, matching how mature CAS systems
+   (FLINT's `fmpz_poly_factor_t`, SageMath's `Factorization`,
+   SymPy's `factor_list`, Mathematica's `FactorList`) represent
+   integer-polynomial factorisations.
+
+**Mathlib-free `Hex.ZPoly.Irreducible` class.**
+
+```lean
+namespace Hex.ZPoly
+
+/-- Mathlib-free irreducibility for ZPoly. Defined as a `class` (not
+    a plain `Prop`) so that downstream APIs that require `p`
+    irreducible — particularly `NumberField.Inv` and the `Field`
+    instance on `NumberField p x` in `hex-number-field` — can use it
+    as an instance argument and have `x⁻¹` notation work via
+    typeclass inference.
+
+    A bare `Prop` would force inverse-related operations to take
+    explicit hypothesis arguments, breaking the `Inv` typeclass
+    contract. Mathlib's `Fact` wrapper would solve this at the
+    Mathlib level, but `Fact` is unavailable in our Mathlib-free
+    setting.
+
+    This contradicts the project's usual "irreducibility is a
+    term-level fact, not a class" convention (cf.
+    `HexGfqField.FiniteField`'s explicit `_hirr` constructor
+    argument), but the convention applies when irreducibility is
+    *part of a type's identity*. For `NumberField.Inv`'s case,
+    irreducibility is an *ambient assumption used by an operation*
+    on an existing type, so a class is appropriate. -/
+class Irreducible (f : ZPoly) : Prop where
+  not_zero  : f ≠ 0
+  not_unit  : ¬ Hex.ZPoly.IsUnit f       -- IsUnit defined in hex-poly-z
+  no_factors : ∀ a b : ZPoly, f = a * b →
+                Hex.ZPoly.IsUnit a ∨ Hex.ZPoly.IsUnit b
+
+/-- Computational checker for irreducibility. -/
+def isIrreducible (f : ZPoly) : Bool :=
+  if f = 0 then false
+  else if f.natDegree = 0 then
+    -- Constant case: f = C k. Irreducible iff |k| > 1 and |k| is prime.
+    let k := (f.coeff 0).natAbs
+    1 < k && k.Prime
+  else
+    -- Polynomial case: irreducible iff `factor f` returns a
+    -- `Factorization` whose scalar is a unit (±1) and whose
+    -- factors array has exactly one entry with multiplicity 1.
+    let φ := factor f
+    decide (φ.scalar.natAbs = 1) &&
+    φ.factors.size == 1 &&
+    decide ((φ.factors.get! 0).snd = 1)
+
+theorem isIrreducible_iff (f : ZPoly) :
+    isIrreducible f = true ↔ Irreducible f
+
+instance (f : ZPoly) : Decidable (Irreducible f) :=
+  decidable_of_iff _ (isIrreducible_iff f)
+
+end Hex.ZPoly
+```
+
+`Irreducible 0 = False` is explicit by the `not_zero` clause; the
+boolean checker returns `false` on zero input. The constant-case
+primality test on `Nat` lives in `HexArith`. The polynomial-case
+predicate uses the `Factorization` projections directly: scalar
+must be a unit (i.e., `f` is primitive up to sign), `factors` has
+exactly one entry, and that entry has multiplicity 1.
 
 **Prime selection sub-API:**
 ```lean
@@ -85,9 +220,9 @@ threshold (see *Precision schedule* below).
 
 Three top-level functions, all with full Mathlib-bridge proofs:
 
-- **`factorSlow : ZPoly → Array ZPoly`.** Exhaustive subset enumeration. Worst-case `O(2^r)`. **Unconditional correctness:** `factorSlow f = irreducibleFactorisationOf f`.
-- **`factorFast : ZPoly → Option (Array ZPoly)`.** Van Hoeij CLD with precision cap. **Conditional correctness:** `factorFast f = some gs ⟹ gs is the irreducible factorisation of f`. May return `none`.
-- **`factor : ZPoly → Array ZPoly := λ f, (factorFast f).getD (factorSlow f)`.** Unconditionally correct combinator with polynomial-time average performance.
+- **`factorSlow : ZPoly → Factorization`.** Exhaustive subset enumeration. Worst-case `O(2^r)`. **Unconditional correctness:** `factorSlow f = irreducibleFactorisationOf f`.
+- **`factorFast : ZPoly → Option Factorization`.** Van Hoeij CLD with precision cap. **Conditional correctness:** `factorFast f = some φ ⟹ φ is the irreducible factorisation of f`. May return `none`.
+- **`factor : ZPoly → Factorization := λ f, (factorFast f).getD (factorSlow f)`.** Unconditionally correct combinator with polynomial-time average performance.
 
 No axioms. BHKS Theorem 5.2 ("for precision exceeding a paper-stated
 bound, `factorFast` always returns `some`") is a leaf theorem of this
@@ -259,9 +394,11 @@ The conditional correctness contract `factor_product_of_bound`:
 ```lean
 theorem factor_product_of_bound (f : ZPoly) (B : Nat)
     (hB : ∀ g : ZPoly, g ∣ f → ∀ i, |g.coeff i| ≤ B) :
-    Array.foldl (· * ·) 1 (factorWithBound f B) = f
+    Factorization.product (factorWithBound f B) = f
 ```
-follows from C1 specialised to the bound-aware variant.
+follows from C1 specialised to the bound-aware variant. (Old
+`Array.foldl`-based formulation superseded by `Factorization.product`
+per the new output-convention section above.)
 
 ### Group D — leaf performance theorem (BHKS Theorem 5.2; not on the correctness critical path)
 

--- a/SPEC/Libraries/hex-poly-z.md
+++ b/SPEC/Libraries/hex-poly-z.md
@@ -43,3 +43,21 @@ Specialized polynomial arithmetic over `Z`.
 - Gauss's lemma (`content(f * g) = content(f) * content(g)`) is not
   needed in this library — it transfers from Mathlib via the ring
   equivalence in hex-poly-z-mathlib.
+
+**Units in `ℤ[x]`:**
+
+```lean
+/-- A ZPoly is a unit iff it equals ±1 as a constant polynomial.
+    Coefficient-ring-specific (units in `R[x]` depend on units in
+    `R`), so this lives in `HexPolyZ` rather than the generic
+    `HexPoly`. -/
+def Hex.ZPoly.IsUnit (f : ZPoly) : Prop := f = .C 1 ∨ f = .C (-1)
+
+instance : Decidable (Hex.ZPoly.IsUnit f) := …   -- structural via DecidableEq
+```
+
+Used by downstream irreducibility predicates (in
+`hex-berlekamp-zassenhaus`) and by any code that needs to test
+unit-ness in `ℤ[x]`. The Mathlib bridge
+`Hex.ZPoly.IsUnit f ↔ IsUnit (toPolynomial f)` lives in
+`hex-poly-z-mathlib`.

--- a/progress/20260508T002255Z_factorization_record_spec.md
+++ b/progress/20260508T002255Z_factorization_record_spec.md
@@ -1,0 +1,73 @@
+# 2026-05-08 00:22 UTC — interactive session (Factorization record SPEC PR)
+
+## Accomplished
+
+Drafted the `Factorization` record SPEC PR on a new branch
+`bz-factorization-record-spec` cut off `origin/main` (post-#2563).
+
+### SPEC additions
+
+- `SPEC/Libraries/hex-berlekamp-zassenhaus.md`:
+  - Replaced `Array ZPoly` with `Factorization` in the public API:
+    `factorSlow : ZPoly → Factorization`,
+    `factorFast : ZPoly → Option Factorization`,
+    `factor : ZPoly → Factorization`,
+    `factorWithBound : ZPoly → Nat → Factorization`.
+  - Inserted a new "Output convention: the `Factorization` record"
+    section defining the record (signed `scalar : Int` field +
+    `factors : Array (ZPoly × Nat)` with multiplicities), the
+    `Factorization.product` function, the post-condition contract
+    for `factor`'s output (5 invariants), the "don't break content
+    into primes" convention with FLINT/SymPy precedent, and an
+    explicit edge-case table covering 13 inputs (including `0`,
+    `±1`, constant primes, `X`, `X²`, repeated factors, signed
+    inputs).
+  - Added a "Mathlib-free `Hex.ZPoly.Irreducible` class" section
+    with the rationale comment (why a class, not a plain Prop:
+    `Fact` is unavailable in our Mathlib-free setting) and
+    `isIrreducible` boolean checker built on the `Factorization`
+    projections.
+  - Updated the Group C `factor_product_of_bound` theorem statement
+    to use `Factorization.product` instead of `Array.foldl`.
+
+- `SPEC/Libraries/hex-berlekamp-zassenhaus-mathlib.md`:
+  - Updated `factor_product`, `factor_irreducible_of_nonUnit` (the
+    corrected form of the broken `factor_irreducible`), and
+    `factor_unique` theorem statements to use the `Factorization`
+    record API.
+  - Documented why `factor_irreducible` had to be downgraded:
+    constant content factors like `C 6` are reducible in
+    `Polynomial ℤ`, but `Factorization.factors` by SPEC contains
+    only irreducible non-unit polynomial factors, so the per-element
+    irreducibility claim becomes precisely correct.
+  - Added the `Hex.ZPoly.Irreducible_iff_polynomialIrreducible`
+    bridge theorem.
+
+- `SPEC/Libraries/hex-poly-z.md`: added `Hex.ZPoly.IsUnit`
+  definition + decidable instance.
+
+## Current frontier
+
+The SPEC PR is ready to push and open. After it lands:
+
+- The pending human-oversight issue (deliverable B) can reference
+  it from Context.
+- The hex-nf branch's references to `Factorization` and
+  `Hex.ZPoly.Irreducible` (currently forward references) become
+  resolvable.
+
+## Next step
+
+1. Commit this work as a single SPEC commit on
+   `bz-factorization-record-spec`.
+2. Push to `origin`.
+3. Open the PR via `gh pr create`. Title:
+   `spec: introduce Factorization record for HexBerlekampZassenhaus.factor`.
+4. After PR is open: file the human-oversight issue (deliverable
+   B) referencing this SPEC PR.
+
+## Blockers
+
+None. The implementation work to migrate
+`HexBerlekampZassenhaus/Basic.lean` to the new API is the
+human-oversight issue's deliverable, separate from this SPEC PR.


### PR DESCRIPTION
This PR replaces `HexBerlekampZassenhaus.factor`'s flat `Array ZPoly` output with a structured `Factorization` record, separating the signed scalar (sign · content) from the polynomial-factor multiset with explicit multiplicities. The change aligns hex's factorization output with how mature CAS systems represent integer-polynomial factorizations and resolves two pre-existing correctness bugs in the slow-path normalization chain.

\`\`\`lean
structure Factorization where
  scalar  : Int                       -- sign(lc f) · ZPoly.content f
  factors : Array (ZPoly × Nat)       -- (irreducible primitive polynomial, multiplicity)
deriving DecidableEq

def Factorization.product (φ : Factorization) : ZPoly := …

def factorSlow (f : ZPoly) : Factorization
def factorFast (f : ZPoly) : Option Factorization
def factor (f : ZPoly) : Factorization := (factorFast f).getD (factorSlow f)
def factorWithBound (f : ZPoly) (B : Nat) : Factorization
\`\`\`

The product theorem \`Factorization.product (factor f) = f\` becomes provably exact, with no "up to sign" caveat. The previously-broken \`factor_irreducible\` theorem (claiming every array entry is irreducible — false for content factors like \`C 6 = C 2 · C 3\`) is corrected to \`factor_irreducible_of_nonUnit\`, which under the new API is precisely what we want: \`Factorization.factors\` by SPEC contains only irreducible non-unit polynomial factors.

Comparison with mature CAS systems (FLINT's \`fmpz_poly_factor_t\`, SageMath's \`Factorization\`, SymPy's \`factor_list\`, Mathematica's \`FactorList\`): all track sign/content as a separate field and represent multiplicities explicitly. The hex change brings us in line on both axes.

Also adds:
- \`Hex.ZPoly.IsUnit\` predicate + decidable instance in \`hex-poly-z.md\`.
- \`Hex.ZPoly.Irreducible\` (as a \`class\`, not a plain \`Prop\`, so \`x⁻¹\` notation works on \`NumberField p x\` via typeclass inference; \`Mathlib.Fact\` would do this cleanly but is unavailable in our Mathlib-free setting).
- \`isIrreducible\` boolean checker built on the \`Factorization\` projections.
- \`Hex.ZPoly.Irreducible_iff_polynomialIrreducible\` Mathlib bridge theorem in \`hex-berlekamp-zassenhaus-mathlib.md\`.

This PR is SPEC-only; no Lean code or fixture changes. The implementation work to migrate \`HexBerlekampZassenhaus/Basic.lean\` to return \`Factorization\` values, plus discharging the surrounding \`sorry\`'d normalization/reassembly lemmas (\`factor_product_of_bound\`, \`normalizeForFactor_reassembles\`, \`reassembleNormalizedFactors_product\`, \`normalizedConstantFactors_product\`), is tracked in a forthcoming \`human-oversight\` issue.

🤖 Prepared with Claude Code