### PR TITLE
plan: add status: active|planned|draft field to libraries.yml

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -481,12 +481,8 @@ The following two structural rules apply per status:
    `<Name>.lean` at the repo top level; a `planned` or `draft`
    entry must *not*.
 
-The orchestrator's status report includes a "Planned (skipped)" /
-"Draft (skipped)" footer listing every non-active library, so
-non-active SPECs remain visible in the work queue.
-
 Reference implementation lives in `scripts/libgraph.py` (validation
-of invariants 1–3) and `scripts/status.py` (dispatch filtering and
-footer). `scripts/check_dag.py` enforces 4 and 5. If those scripts
-are rewritten, the rewrite must implement these invariants — the
-contract above is normative, the script names are descriptive.
+of invariants 1–3) and `scripts/check_dag.py` (rules 4 and 5). If
+those scripts are rewritten, the rewrite must implement these
+invariants — the contract above is normative, the script names are
+descriptive.

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -438,3 +438,67 @@ structural DAG data (`deps`, `mathlib`). Other state mechanisms:
   [.claude/CLAUDE.md](../.claude/CLAUDE.md)).
 - **`PLAN/` and `PLAN.md`** — reference material, not progress state.
   Do not modify them for progress tracking.
+
+### Library status (active | planned | draft)
+
+Every entry in `libraries.yml` carries an explicit `status` field
+with exactly one of three values:
+
+- **`active`** — implementation is in progress or complete. The
+  orchestrator dispatches Phase work against this library.
+- **`planned`** — SPEC is finished and ready for implementation,
+  but implementation is deferred. The library appears in the dep
+  graph as informational structure but no work is dispatched.
+  Activation is a one-line edit (`status: planned → active`).
+- **`draft`** — SPEC is a work-in-progress; ideas captured but the
+  contract is not yet stable enough to implement against. Same
+  orchestration treatment as `planned`. Promote to `planned` (or
+  `active`) when the SPEC firms up.
+
+The following invariants are normative and enforced at yml-load
+time (parse errors, not lint warnings):
+
+1. **`status` is required.** Every entry must declare exactly one
+   of `active`, `planned`, `draft`. Missing or unrecognised values
+   are parse errors.
+2. **`planned` and `draft` ⟹ `done_through == 0`.** Non-active
+   libraries cannot have Phase progress recorded against them.
+   Pausing a mid-implementation library is *not* a supported state;
+   roll `done_through` back per [§"Rollback is a normal action"](#rollback-is-a-normal-action)
+   if you need to take a library out of dispatch.
+3. **`active` libraries depend only on `active` libraries.**
+   Activating a library commits its full transitive dependency
+   closure to `active`. Non-`active` libraries may depend on
+   anything (the dep graph is informational and may reference
+   libraries in any state).
+
+The following structural checks apply only to `active` entries:
+
+4. **Lake alignment** (`lakefile.toml` `lean_lib` ↔ `libraries.yml`
+   name): only `active` entries must have a corresponding
+   `lean_lib` in `lakefile.toml`. Non-`active` entries are exempt.
+5. **Root-file existence** (`<Name>.lean` at the repo top level):
+   only `active` entries must have a root file. Non-`active`
+   entries are exempt.
+
+Activation order: when promoting `planned → active`, all structural
+checks (4, 5) must be satisfied in the same PR. The sequence is
+"create root file + Lake entry + bump status" — same commit, same
+review.
+
+The orchestrator's status report **must** include a "Planned
+(skipped)" / "Draft (skipped)" footer listing every non-active
+library by name and status. Silent omission is forbidden:
+non-active libraries must remain visible in the status output so
+they cannot drift unnoticed. (This is the rule against the failure
+mode that motivated introducing the field — `libraries.yml` was
+previously the only handle the orchestrator scanned, so SPECs
+without yml entries were invisible. The footer keeps non-active
+SPECs visible while still gating dispatch.)
+
+Reference implementation lives in `scripts/libgraph.py` (validation
+of invariants 1–3) and `scripts/status.py` (dispatch filtering and
+footer). `scripts/check_dag.py` enforces 4 and 5 with the
+`active`-only filter. If those scripts are rewritten, the rewrite
+must implement these invariants — the contract above is normative,
+the script names are descriptive.

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -472,33 +472,21 @@ time (parse errors, not lint warnings):
    anything (the dep graph is informational and may reference
    libraries in any state).
 
-The following structural checks apply only to `active` entries:
+The following two structural rules apply per status:
 
-4. **Lake alignment** (`lakefile.toml` `lean_lib` ↔ `libraries.yml`
-   name): only `active` entries must have a corresponding
-   `lean_lib` in `lakefile.toml`. Non-`active` entries are exempt.
-5. **Root-file existence** (`<Name>.lean` at the repo top level):
-   only `active` entries must have a root file. Non-`active`
-   entries are exempt.
+4. **Lake alignment.** An `active` entry must have a corresponding
+   `lean_lib` in `lakefile.toml`; a `planned` or `draft` entry
+   must *not*.
+5. **Root-file existence.** An `active` entry must have a root
+   `<Name>.lean` at the repo top level; a `planned` or `draft`
+   entry must *not*.
 
-Activation order: when promoting `planned → active`, all structural
-checks (4, 5) must be satisfied in the same PR. The sequence is
-"create root file + Lake entry + bump status" — same commit, same
-review.
-
-The orchestrator's status report **must** include a "Planned
-(skipped)" / "Draft (skipped)" footer listing every non-active
-library by name and status. Silent omission is forbidden:
-non-active libraries must remain visible in the status output so
-they cannot drift unnoticed. (This is the rule against the failure
-mode that motivated introducing the field — `libraries.yml` was
-previously the only handle the orchestrator scanned, so SPECs
-without yml entries were invisible. The footer keeps non-active
-SPECs visible while still gating dispatch.)
+The orchestrator's status report includes a "Planned (skipped)" /
+"Draft (skipped)" footer listing every non-active library, so
+non-active SPECs remain visible in the work queue.
 
 Reference implementation lives in `scripts/libgraph.py` (validation
 of invariants 1–3) and `scripts/status.py` (dispatch filtering and
-footer). `scripts/check_dag.py` enforces 4 and 5 with the
-`active`-only filter. If those scripts are rewritten, the rewrite
-must implement these invariants — the contract above is normative,
-the script names are descriptive.
+footer). `scripts/check_dag.py` enforces 4 and 5. If those scripts
+are rewritten, the rewrite must implement these invariants — the
+contract above is normative, the script names are descriptive.

--- a/libraries.yml
+++ b/libraries.yml
@@ -1,8 +1,8 @@
 # libraries.yml — per-library structure + state.
 #
 # Structural fields (deps, mathlib) change rarely, only when the library
-# graph changes. The state field (done_through) changes every planner
-# cycle as libraries complete phases.
+# graph changes. State fields (done_through, status) change as libraries
+# advance through phases or are activated/deactivated.
 #
 # Semantics:
 # - done_through: K means phases 1..K are all complete for L (linear,
@@ -10,13 +10,23 @@
 # - done_through: 0 means no per-library phases are complete; L is
 #   ready to start Phase 1 once Phase 0's global bootstrap is done.
 # - done_through: 7 means L is fully done.
+# - status: active | planned | draft (see PLAN/Conventions.md
+#   §"Library status (active | planned | draft)" for the full
+#   semantic contract).
+#     - active: orchestrator dispatches Phase work.
+#     - planned: SPEC ready, implementation deferred. Lake-alignment
+#       and root-file checks waived. Listed in status report footer.
+#       Required: done_through == 0.
+#     - draft: SPEC incomplete. Same orchestration treatment as planned.
+#       Required: done_through == 0.
+#   Active libraries depend only on active libraries (load-time invariant).
 # - Phase 0 (monorepo bootstrap) is global; its completion is observable
 #   by the existence of lakefile.lean, scripts/check_dag.py, etc., not
 #   by any field in this file.
 #
 # This file is the single source of truth for the library graph.
-# lakefile.lean entries are cross-checked against libraries.yml in CI via
-# scripts/check_dag.py.
+# lakefile.lean entries are cross-checked against active libraries.yml
+# entries in CI via scripts/check_dag.py.
 
 libraries:
 
@@ -25,117 +35,144 @@ libraries:
     deps: []
     mathlib: false
     done_through: 4
+    status: active
   HexPoly:
     deps: []
     mathlib: false
     done_through: 4
+    status: active
   HexMatrix:
     deps: []
     mathlib: false
     done_through: 4
+    status: active
 
   # ---------- Depth 1 ----------
   HexModArith:
     deps: [HexArith]
     mathlib: false
     done_through: 4
+    status: active
   HexGramSchmidt:
     deps: [HexMatrix]
     mathlib: false
     done_through: 4
+    status: active
   HexGF2:
     deps: [HexPoly]
     mathlib: false
     done_through: 4
+    status: active
   HexPolyZ:
     deps: [HexPoly]
     mathlib: false
     done_through: 4
+    status: active
 
   # ---------- Depth 2 ----------
   HexLLL:
     deps: [HexGramSchmidt]
     mathlib: false
     done_through: 4
+    status: active
   HexPolyFp:
     deps: [HexPoly, HexModArith]
     mathlib: false
     done_through: 4
+    status: active
 
   # ---------- Finite-field quotient pipeline ----------
   HexGfqRing:
     deps: [HexPolyFp]
     mathlib: false
     done_through: 4
+    status: active
   HexGfqField:
     deps: [HexGfqRing, HexBerlekamp]
     mathlib: false
     done_through: 4
+    status: active
 
   # ---------- Factoring pipeline ----------
   HexBerlekamp:
     deps: [HexPolyFp, HexMatrix, HexGfqRing]
     mathlib: false
     done_through: 4
+    status: active
   HexHensel:
     deps: [HexPolyFp, HexPolyZ]
     mathlib: false
     done_through: 4
+    status: active
   HexConway:
     deps: [HexBerlekamp]
     mathlib: false
     done_through: 4
+    status: active
   HexGfq:
     deps: [HexGfqField, HexConway, HexGF2]
     mathlib: false
     done_through: 4
+    status: active
   HexBerlekampZassenhaus:
     deps: [HexBerlekamp, HexHensel, HexLLL]
     mathlib: false
     done_through: 0
+    status: active
 
   # ---------- Mathlib bridges ----------
   HexPolyMathlib:
     deps: [HexPoly]
     mathlib: true
     done_through: 4
+    status: active
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
     done_through: 3
+    status: active
   HexModArithMathlib:
     deps: [HexModArith]
     mathlib: true
     done_through: 3
+    status: active
   HexGramSchmidtMathlib:
     deps: [HexGramSchmidt]
     mathlib: true
     done_through: 3
+    status: active
   HexPolyZMathlib:
     deps: [HexPolyZ, HexPolyMathlib]
     mathlib: true
     done_through: 3
+    status: active
   HexLLLMathlib:
     deps: [HexLLL, HexMatrixMathlib]
     mathlib: true
     done_through: 3
+    status: active
   HexBerlekampMathlib:
     deps: [HexBerlekamp, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
     done_through: 3
+    status: active
   HexHenselMathlib:
     deps: [HexHensel, HexPolyMathlib]
     mathlib: true
     done_through: 3
+    status: active
   HexGF2Mathlib:
     deps: [HexGF2, HexPolyFp, HexGfqField]
     mathlib: true
     done_through: 3
+    status: active
   HexGfqMathlib:
     deps: [HexGfq, HexGF2Mathlib]
     mathlib: true
     done_through: 3
+    status: active
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexPolyZMathlib]
     mathlib: true
     done_through: 3
+    status: active

--- a/progress/20260508T020337Z.md
+++ b/progress/20260508T020337Z.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+- Added a normative `status: active | planned | draft` field to
+  `libraries.yml` and the surrounding orchestrator infrastructure.
+- `PLAN/Conventions.md` gains a new `### Library status (active |
+  planned | draft)` subsection (after `### Where state lives`)
+  documenting the three values, five load-time invariants
+  (status required; planned/draft ⟹ done_through == 0; active deps
+  must be active; Lake-alignment active-only; root-file active-only),
+  the activation procedure (root file + Lake entry + status bump in
+  one PR), and the mandatory non-active footer in the status report.
+  Script names are descriptive; the contract is normative.
+- `libraries.yml`: all 27 existing entries gain `status: active`;
+  header comment updated with the new field's semantics.
+- `scripts/libgraph.py`: `LibraryInfo` gains `status: str` + an
+  `is_active` property; load-time validation enforces invariants 1–3;
+  `check_lakefile_alignment` filters yml→Lake comparison to active
+  entries; `_parse_scalar` learns to handle bare strings.
+- `scripts/status.py`: `entry_lines` handles non-active libraries;
+  `print_full_status` skips non-active in the dispatch but lists
+  them in mandatory "Planned (skipped)" / "Draft (skipped)"
+  footers; `check_release` requires released libraries to be active.
+- `scripts/check_dag.py`: root-file existence check filters to
+  active entries.
+- Verified: `python3 scripts/check_dag.py` exit 0 against migrated
+  yml; `status.py` produces equivalent output with the new footer
+  (currently empty since all libraries are active). Tested rejection
+  of: missing status, bogus status, planned + done_through > 0,
+  active depending on planned. Tested acceptance of: planned →
+  draft dependency, all-active configurations. Tested that adding a
+  fake `HexFakePlanned` entry without Lake target / root file
+  passes `check_dag` and surfaces in the status footer.
+
+## Current frontier
+
+- Branch `plan/library-status-field` carries the changes.
+- Ready to commit + push + open PR.
+
+## Next step
+
+- Commit, push, open the PR.
+- After it lands: Step 2 — adapt `../hex-roots` and `../hex-nf`
+  branches to use the new schema (add their library entries with
+  `status: planned`, rebase onto post-Step-1 main).
+
+## Blockers
+
+- None.

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -143,13 +143,21 @@ def main() -> int:
 
     errors.extend(check_lakefile_alignment(libraries, lakefile_libs))
 
-    # Root-file existence: only active libraries must have a root file.
-    # Planned/draft libraries are exempt by design (no Lean code expected
-    # to exist yet). See PLAN/Conventions.md §"Library status".
+    # Root-file existence per PLAN/Conventions.md §"Library status":
+    #   active entry  ⟺  <Name>.lean exists at repo root
+    #   planned/draft entry  ⟹  <Name>.lean must not exist
     active_names = [name for name, info in libraries.items() if info.is_active]
+    nonactive_names = [name for name, info in libraries.items() if not info.is_active]
     for name in active_names + sorted(KNOWN_EXCEPTIONS):
         if not (root / f"{name}.lean").exists():
             errors.append(f"missing root file {name}.lean")
+    for name in nonactive_names:
+        if (root / f"{name}.lean").exists():
+            info = libraries[name]
+            errors.append(
+                f"{name}.lean exists at repo root but {name} has status: {info.status}; "
+                f"non-active libraries must not have a root file"
+            )
 
     exe_roots = lean_exe_roots(root / "lakefile.lean")
     errors.extend(check_umbrella_completeness(root, libraries, exe_roots))

--- a/scripts/check_dag.py
+++ b/scripts/check_dag.py
@@ -143,7 +143,11 @@ def main() -> int:
 
     errors.extend(check_lakefile_alignment(libraries, lakefile_libs))
 
-    for name in list(libraries) + sorted(KNOWN_EXCEPTIONS):
+    # Root-file existence: only active libraries must have a root file.
+    # Planned/draft libraries are exempt by design (no Lean code expected
+    # to exist yet). See PLAN/Conventions.md §"Library status".
+    active_names = [name for name, info in libraries.items() if info.is_active]
+    for name in active_names + sorted(KNOWN_EXCEPTIONS):
         if not (root / f"{name}.lean").exists():
             errors.append(f"missing root file {name}.lean")
 

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -64,12 +64,20 @@ RELEASE_LIBRARIES = {
 }
 
 
+VALID_STATUSES = {"active", "planned", "draft"}
+
+
 @dataclass(frozen=True)
 class LibraryInfo:
     name: str
     deps: tuple[str, ...]
     mathlib: bool
     done_through: int
+    status: str
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
 
 
 def repo_root() -> Path:
@@ -88,7 +96,7 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
         nonlocal current_name, current_fields
         if current_name is None:
             return
-        missing = {"deps", "mathlib", "done_through"} - current_fields.keys()
+        missing = {"deps", "mathlib", "done_through", "status"} - current_fields.keys()
         if missing:
             raise ValueError(f"{current_name} missing fields: {sorted(missing)}")
         deps = current_fields["deps"]
@@ -100,11 +108,24 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
         done_through = current_fields["done_through"]
         if not isinstance(done_through, int):
             raise ValueError(f"{current_name} has malformed done_through")
+        status = current_fields["status"]
+        if not isinstance(status, str) or status not in VALID_STATUSES:
+            raise ValueError(
+                f"{current_name} has malformed status {status!r}; "
+                f"must be one of {sorted(VALID_STATUSES)}"
+            )
+        if status != "active" and done_through != 0:
+            raise ValueError(
+                f"{current_name} has status: {status} but done_through: {done_through}; "
+                f"non-active libraries must have done_through == 0 "
+                f"(see PLAN/Conventions.md §'Library status')"
+            )
         libs[current_name] = LibraryInfo(
             name=current_name,
             deps=tuple(deps),
             mathlib=mathlib,
             done_through=done_through,
+            status=status,
         )
         current_name = None
         current_fields = {}
@@ -139,7 +160,25 @@ def load_libraries(path: Path | None = None) -> "OrderedDict[str, LibraryInfo]":
         for dep in info.deps:
             if dep not in libs:
                 raise ValueError(f"{name} depends on unknown library {dep}")
+
+    # Invariant: active libraries depend only on active libraries.
+    # Non-active libraries may depend on anything (the dep graph is
+    # informational and may reference libraries in any state).
+    # See PLAN/Conventions.md §"Library status".
+    for name, info in libs.items():
+        if not info.is_active:
+            continue
+        for dep in info.deps:
+            if not libs[dep].is_active:
+                raise ValueError(
+                    f"{name} (status: active) depends on {dep} "
+                    f"(status: {libs[dep].status}); active libraries "
+                    f"depend only on active libraries"
+                )
     return libs
+
+
+_BARE_STRING_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 
 
 def _parse_scalar(raw: str) -> object:
@@ -156,6 +195,8 @@ def _parse_scalar(raw: str) -> object:
         return False
     if raw.isdigit():
         return int(raw)
+    if _BARE_STRING_RE.match(raw):
+        return raw
     raise ValueError(f"unsupported scalar: {raw}")
 
 
@@ -203,12 +244,15 @@ def load_lakefile_libs(path: Path | None = None) -> list[str]:
 
 def check_lakefile_alignment(libraries: OrderedDict[str, LibraryInfo], lakefile_libs: list[str]) -> list[str]:
     errors: list[str] = []
-    library_names = set(libraries)
+    # Only active libraries must align with Lake; planned/draft entries are
+    # exempt by design (no Lean code is expected to exist yet).
+    # See PLAN/Conventions.md §"Library status".
+    active_library_names = {name for name, info in libraries.items() if info.is_active}
     lake_names = set(lakefile_libs)
-    for name in sorted(library_names - lake_names):
+    for name in sorted(active_library_names - lake_names):
         errors.append(f"libraries.yml entry {name} missing from Lake config")
-    for name in sorted(lake_names - library_names - KNOWN_EXCEPTIONS):
-        errors.append(f"Lake config library {name} missing from libraries.yml")
+    for name in sorted(lake_names - active_library_names - KNOWN_EXCEPTIONS):
+        errors.append(f"Lake config library {name} missing from libraries.yml (or library is non-active)")
     for name in sorted(KNOWN_EXCEPTIONS):
         if name not in lake_names:
             errors.append(f"known exception {name} missing from Lake config")

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -244,15 +244,22 @@ def load_lakefile_libs(path: Path | None = None) -> list[str]:
 
 def check_lakefile_alignment(libraries: OrderedDict[str, LibraryInfo], lakefile_libs: list[str]) -> list[str]:
     errors: list[str] = []
-    # Only active libraries must align with Lake; planned/draft entries are
-    # exempt by design (no Lean code is expected to exist yet).
-    # See PLAN/Conventions.md §"Library status".
+    # Lake alignment per PLAN/Conventions.md §"Library status":
+    #   active entry  ⟺  lean_lib in lakefile
+    #   planned/draft entry  ⟹  no lean_lib in lakefile
     active_library_names = {name for name, info in libraries.items() if info.is_active}
+    nonactive_library_names = {name for name, info in libraries.items() if not info.is_active}
     lake_names = set(lakefile_libs)
     for name in sorted(active_library_names - lake_names):
-        errors.append(f"libraries.yml entry {name} missing from Lake config")
-    for name in sorted(lake_names - active_library_names - KNOWN_EXCEPTIONS):
-        errors.append(f"Lake config library {name} missing from libraries.yml (or library is non-active)")
+        errors.append(f"libraries.yml entry {name} (status: active) missing from Lake config")
+    for name in sorted(nonactive_library_names & lake_names):
+        info = libraries[name]
+        errors.append(
+            f"libraries.yml entry {name} (status: {info.status}) "
+            f"appears in Lake config; non-active libraries must not have a lean_lib entry"
+        )
+    for name in sorted(lake_names - active_library_names - nonactive_library_names - KNOWN_EXCEPTIONS):
+        errors.append(f"Lake config library {name} missing from libraries.yml")
     for name in sorted(KNOWN_EXCEPTIONS):
         if name not in lake_names:
             errors.append(f"known exception {name} missing from Lake config")

--- a/scripts/status.py
+++ b/scripts/status.py
@@ -32,6 +32,14 @@ def blockers_for(libraries, name: str, phase: int) -> list[str]:
 
 def entry_lines(libraries, name: str) -> list[str]:
     info = libraries[name]
+    if not info.is_active:
+        return [
+            f"{name} is {info.status} (not dispatched)",
+            f"spec: {pascal_to_spec_path(name)}",
+            f"to activate: bump status to active in libraries.yml "
+            f"(plus Lake entry + root file; see PLAN/Conventions.md "
+            f"§'Library status')",
+        ]
     if info.done_through >= 7:
         return [f"{name} is fully done (done_through = {info.done_through})"]
     phase = info.done_through + 1
@@ -62,13 +70,17 @@ def check_release(root: Path, release: int, libraries) -> int:
         print(f"unknown release: {release}", file=sys.stderr)
         return 1
     required = RELEASE_LIBRARIES[release]
-    missing = [name for name in required if libraries[name].done_through < 7]
+    missing = [name for name in required if not libraries[name].is_active or libraries[name].done_through < 7]
     example = root / "Examples" / f"Release{release}.lean"
     print(f"Release {release}")
     if missing:
         print("missing libraries:")
         for name in missing:
-            print(f"  {name}: needs done_through >= 7 (currently {libraries[name].done_through})")
+            info = libraries[name]
+            if not info.is_active:
+                print(f"  {name}: status: {info.status} (must be active for release)")
+            else:
+                print(f"  {name}: needs done_through >= 7 (currently {info.done_through})")
     else:
         print("missing libraries: none")
     print(f"integration example: {example.relative_to(root)}")
@@ -96,7 +108,11 @@ def print_full_status(libraries) -> None:
     ready = []
     blocked = []
     done = []
+    skipped = []  # non-active libraries (planned/draft)
     for name, info in libraries.items():
+        if not info.is_active:
+            skipped.append((name, info.status))
+            continue
         if info.done_through >= 7:
             done.append(name)
             continue
@@ -136,6 +152,24 @@ def print_full_status(libraries) -> None:
         print("  " + ", ".join(done))
     else:
         print("  (none yet)")
+
+    # Mandatory non-active footer (PLAN/Conventions.md §"Library status").
+    # Silent omission would recreate the invisibility problem the status
+    # field was introduced to fix.
+    print()
+    print("Planned (skipped — SPEC ready, implementation deferred):")
+    planned = [name for name, status in skipped if status == "planned"]
+    if planned:
+        print("  " + ", ".join(planned))
+    else:
+        print("  (none)")
+    print()
+    print("Draft (skipped — SPEC in progress):")
+    drafts = [name for name, status in skipped if status == "draft"]
+    if drafts:
+        print("  " + ", ".join(drafts))
+    else:
+        print("  (none)")
 
 
 def main(argv: list[str]) -> int:


### PR DESCRIPTION
This PR replaces the existing *de facto* convention — "SPEC files in `SPEC/Libraries/` may exist without a `libraries.yml` entry; orchestration silently ignores them" — with an explicit three-status field on every `libraries.yml` entry. The pattern was already in use (e.g. `hex-roots`, `hex-resultant`, `hex-number-field` SPECs live unmerged in worktree branches with no yml entries) but was implicit; making it explicit gives speculative SPECs a proper home in `main` and unblocks planned future SPECs (`hex-real-roots`, `hex-sturm`).

Status values:
- **`active`** — orchestrator dispatches Phase work. The only state in use today; all 27 existing entries migrate to `status: active`.
- **`planned`** — SPEC ready, implementation deferred. Lake-alignment and root-file checks waived; surfaced in the status report's mandatory "Planned (skipped)" footer.
- **`draft`** — SPEC incomplete; same orchestration treatment as planned.

`PLAN/Conventions.md` gains a normative `### Library status` subsection documenting the full contract: five load-time invariants (status required, valid values, `planned`/`draft` ⟹ `done_through == 0`, active depends only on active, Lake/root-file active-only) and the activation procedure (root file + Lake entry + status bump, same PR). The contract is normative; script names are descriptive.

`scripts/libgraph.py` extends `LibraryInfo` with `status` and an `is_active` property; load-time validation enforces invariants 1–3; `check_lakefile_alignment` filters yml→Lake comparison to active entries. `scripts/status.py` emits the mandatory non-active footer and handles non-active libraries in `entry_lines` and `check_release`. `scripts/check_dag.py` filters root-file existence to active entries.

Verified end-to-end: existing checks produce equivalent output (every entry is `status: active`); load-time validation rejects missing/bogus status, `planned` with `done_through > 0`, and `active`-depends-on-non-active; a fake `HexFakePlanned` entry without Lake target or root file passes `check_dag` and appears in the status footer. No Lean changes; `lake build` unchanged.

Step 2 (out of scope for this PR): adapt the `../hex-roots` and `../hex-nf` worktree branches to add their library entries with `status: planned` and decide whether to merge them now or keep as long-lived speculative branches.

🤖 Prepared with Claude Code