### PR TITLE
spec: add hex-roots and hex-roots-mathlib (status: planned)

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -8,6 +8,7 @@
 - **hex-poly-fp** — polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
 - **hex-gf2** — packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
 - **hex-poly-z** — polynomials over `Z`, content/primitive part, Mignotte bound
+- **hex-roots** — certified complex root isolation for `Z[x]` via dyadic squares + Pellet test + speculative Newton
 - **hex-berlekamp** — Berlekamp factoring and Rabin irreducibility test over `F_p`
 - **hex-hensel** — Hensel lifting from `mod p` to `mod p^k`
 - **hex-lll** — LLL lattice basis reduction
@@ -25,6 +26,7 @@ proving correspondence with Mathlib's mathematical definitions):
 - **hex-matrix-mathlib** — matrix equivalence, `det` agreement, rank = `Matrix.rank`, nullspace = `LinearMap.ker`, row ops = transvections
 - **hex-gram-schmidt-mathlib** — `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib** — `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
+- **hex-roots-mathlib** — Pellet on circles (built from `circleIntegral`) + Mahler/Mignotte separation bound; correctness of refinement and `isolate`
 - **hex-berlekamp-mathlib** — `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
 - **hex-hensel-mathlib** — Hensel correctness, uniqueness, `coprime_mod_p_lifts`
 - **hex-lll-mathlib** — lattice = `Submodule ℤ`, short vector bound
@@ -44,6 +46,7 @@ Each library with its immediate dependencies:
 - **hex-lll** — hex-gram-schmidt
 - **hex-poly-fp** — hex-poly, hex-mod-arith
 - **hex-poly-z** — hex-poly
+- **hex-roots** — hex-poly-z
 - **hex-berlekamp** — hex-poly-fp, hex-matrix, hex-gfq-ring
 - **hex-hensel** — hex-poly-fp, hex-poly-z
 - **hex-conway** — hex-berlekamp
@@ -58,6 +61,7 @@ Mathlib bridge libraries (each also depends on Mathlib):
 - **hex-mod-arith-mathlib** — hex-mod-arith
 - **hex-poly-mathlib** — hex-poly
 - **hex-poly-z-mathlib** — hex-poly-z, hex-poly-mathlib
+- **hex-roots-mathlib** — hex-roots, hex-poly-z-mathlib
 - **hex-matrix-mathlib** — hex-matrix
 - **hex-gram-schmidt-mathlib** — hex-gram-schmidt
 - **hex-lll-mathlib** — hex-lll
@@ -120,6 +124,8 @@ hex-gfq-field   hex-conway   hex-gf2
 - [hex-gf2-mathlib.md](hex-gf2-mathlib.md) — `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
 - [hex-poly-z.md](hex-poly-z.md) — polynomials over `Z`, content/primitive part, Mignotte bound
 - [hex-poly-z-mathlib.md](hex-poly-z-mathlib.md) — Mignotte bound proof via Mathlib's Mahler measure
+- [hex-roots.md](hex-roots.md) — certified complex root isolation for `Z[x]`
+- [hex-roots-mathlib.md](hex-roots-mathlib.md) — Pellet on circles, Mahler/Mignotte separation bound, refinement and `isolate` correctness
 - [hex-berlekamp.md](hex-berlekamp.md) — Berlekamp factoring and Rabin irreducibility test
 - [hex-berlekamp-mathlib.md](hex-berlekamp-mathlib.md) — Berlekamp/Rabin correctness proofs via Euclidean domain theory
 - [hex-hensel.md](hex-hensel.md) — Hensel lifting algorithms

--- a/SPEC/Libraries/hex-roots-mathlib.md
+++ b/SPEC/Libraries/hex-roots-mathlib.md
@@ -1,0 +1,248 @@
+# hex-roots-mathlib (depends on hex-roots + hex-poly-z-mathlib + Mathlib)
+
+Proves correctness of the certified complex root isolation in
+[hex-roots](hex-roots.md): every `DyadicRootIsolation` certifies a
+unique simple complex root in its disc; every `DyadicRootCluster`
+certifies exactly `k` roots; refinement preserves roots; `isolate`
+under `Hex.HasOnlySimpleRoots` returns the full set of roots; and the
+`mahlerPrec` separation bound is correct.
+
+**Scope warning.** This bridge library is significantly heavier than
+typical `-mathlib` companions. The two foundational theorems we need —
+**Pellet's inclusion test** and the **Mahler separation bound** —
+neither exist in Mathlib at the time of writing. The first is genuinely
+hard to land because Mathlib lacks general-contour winding-number
+infrastructure (Patrick Massot, Zulip
+[#maths > Multivariate complex analysis][zulip],
+2025-12-28); we sidestep that by restricting to *circular* contours,
+which is all our algorithm needs. The second is well-supported by
+Mathlib's existing Mahler measure / discriminant / resultant API but
+the standalone separation theorem hasn't been assembled yet.
+
+The library is organised so that both developments are
+**self-contained slices upstreamable to Mathlib** as separate PRs once
+they've been battle-tested here.
+
+[zulip]: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Multivariate%20complex%20analysis
+
+## What we cite from Mathlib (no work)
+
+The following Mathlib API is used throughout. Library work is glue, not
+re-derivation:
+
+- `Complex.isAlgClosed` (`Mathlib.Analysis.Complex.Polynomial.Basic`),
+  `Polynomial.roots`, `Polynomial.Splits.natDegree_eq_card_roots` —
+  fundamental theorem of algebra; root multiset for `ℂ[X]`.
+- `Polynomial.rootMultiplicity` and the
+  `Polynomial.derivative_rootMultiplicity_*` family — characterisation
+  of simple roots via `p.eval α = 0 ∧ p.derivative.eval α ≠ 0`.
+- `Polynomial.Squarefree`,
+  `PerfectField.separable_iff_squarefree` (in `Mathlib.FieldTheory.Perfect`).
+- `Polynomial.newtonMap`,
+  `Polynomial.aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`
+  (`Mathlib.Dynamics.Newton`) — algebraic side of Newton's method.
+- `ContractingWith` and the Banach fixed-point theorem
+  (`Mathlib.Topology.MetricSpace.Contracting`) — analytic side of
+  Newton convergence.
+- `Mathlib.Analysis.Complex.CauchyIntegral` — Cauchy integral formula
+  on circles, the substrate for our argument-principle development.
+- `Polynomial.cauchyBound` and `IsRoot.norm_lt_cauchyBound`
+  (`Mathlib.Analysis.Polynomial.CauchyBound`) — cited by the
+  `cauchy` constructor's correctness theorem.
+- `Polynomial.discr` and `Polynomial.resultant_deriv`
+  (`Mathlib.RingTheory.Polynomial.Resultant.Basic`) — discriminant
+  and the `resultant(f, f') = ±lc · discr` relation.
+- `Polynomial.resultant`, `Polynomial.resultant_eq_prod_roots_sub`
+  (same file) — the full Sylvester-matrix toolkit.
+- `Polynomial.mahlerMeasure` and the suite in
+  `Mathlib.Analysis.Polynomial.MahlerMeasure`:
+  `mahlerMeasure_mul`, `mahlerMeasure_eq_leadingCoeff_mul_prod_roots`,
+  `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm` (Landau).
+- `one_le_mahlerMeasure_of_ne_zero` (`Mathlib.NumberTheory.MahlerMeasure`)
+  for nonzero integer polynomials.
+- `Polynomial.supNorm` (`Mathlib.Analysis.Polynomial.Norm`).
+
+## Discriminant / separation development
+
+This is the smaller of the two new analytic developments, and the
+one needed *first* — `isolate`'s termination story leans on
+`mahlerPrec`'s correctness, which leans on the Mahler separation
+bound.
+
+### Theorem chain
+
+1. **`Polynomial.discr ≠ 0 ↔ Squarefree`** for `ℤ[x]` (and char-zero
+   more generally). Bridge via the existing chain
+   `separable_iff_squarefree` ↔ `IsCoprime f f'` ↔ `resultant ≠ 0` ↔
+   `discr ≠ 0`. Mostly assembly from existing Mathlib pieces. Lives in
+   `HexRootsMathlib/DiscriminantSquarefree.lean`.
+
+2. **Discriminant root-product formula:**
+   `discr f = lc(f)^{2n−2} · ∏_{i<j}(αᵢ − αⱼ)²` over the splitting
+   field. Mathlib has the resultant version
+   (`resultant_eq_prod_roots_sub`); we derive the discriminant version
+   on top using `resultant_deriv`. Lives in
+   `HexRootsMathlib/DiscriminantRootProduct.lean`.
+
+3. **Mahler/Mignotte separation bound:**
+   ```
+   ∀ i ≠ j, |αᵢ − αⱼ| ≥ √3 · n^{−(n+2)/2} · |disc p|^{1/2} · M(p)^{−(n−1)}
+   ```
+   for squarefree `p ∈ ℤ[x]`. Standard textbook proof: take logs of the
+   root-product formula (item 2), bound each `|αᵢ − αⱼ| ≤ 2 · M(p)` for
+   pairs not equal to `(i, j)`, use `|disc p| ≥ 1`. Lives in
+   `HexRootsMathlib/MahlerSeparation.lean`.
+
+4. **`mahlerPrec` correctness:** the computational
+   `Hex.mahlerPrec p : Nat` (defined in `HexRoots/MahlerPrec.lean`)
+   satisfies
+   ```
+   2^{-mahlerPrec p} ≤ (min_{i ≠ j} |αᵢ − αⱼ|) / 2
+   ```
+   for squarefree `p`. Combines item 3 with Landau's
+   `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm` to eliminate
+   `M(p)` in favour of the integer `‖p‖∞`, then takes `−log₂` of the
+   resulting bound. Lives in `HexRootsMathlib/MahlerPrec.lean`.
+
+## Analytic core (Rouché-on-circles)
+
+The harder of the two developments. Used to prove the semantics of
+`DyadicRootIsolation` and `DyadicRootCluster`.
+
+### Theorem chain
+
+5. **Circle-integral lemmas** — logarithmic-derivative identities,
+   no-roots-on-boundary preservation, `(z − α)⁻¹` residue
+   computations on circles. The load-bearing intermediate layer; the
+   argument-principle proof becomes intractable without first
+   factoring this out. Lives in
+   `HexRootsMathlib/CircleIntegralLemmas.lean`.
+
+6. **Argument principle on circles:**
+   ```
+   (1/2πi) · ∮_{|z−c|=r} (p'(z) / p(z)) dz = (Polynomial.roots p).countP (· ∈ ball c r)
+   ```
+   for `p` analytic with no zeros on `|z−c| = r`. Built from Mathlib's
+   `circleIntegral` and Cauchy integral formula in
+   `Mathlib.Analysis.Complex.CauchyIntegral`. Lives in
+   `HexRootsMathlib/ArgumentPrinciple.lean`.
+
+7. **Rouché on circles** — both classical (`|f − g| < |g|` on the
+   circle implies `f`, `g` have the same number of zeros inside) and
+   symmetric (`|f − g| < |f| + |g|` ditto) forms. Derived from item 6.
+   Lives in `HexRootsMathlib/Rouche.lean`.
+
+8. **Pellet (BSSY Theorem 1):**
+   ```
+   |c_k|·r^k > Σ_{i ≠ k} |c_i|·r^i ⇒ p has exactly k roots in D(0, r)
+   ```
+   where `cᵢ = p.coeff i`. Proved by Rouché-comparing `p` against the
+   monomial `c_k · z^k`. Lives in `HexRootsMathlib/Pellet.lean`.
+
+The squared-form Pellet inequality used in `HexRoots/Pellet.lean` is
+equivalent to the standard form in item 8, via the elementary
+`a > 0 ∧ b > 0 → (a > b ↔ a² > b²)`. We prove this equivalence in the
+bridge file `HexRootsMathlib/Geometry.lean` so that the analytic core
+can stay in the standard form (more upstream-friendly) while the
+computational library uses the squared form (decidable in dyadics).
+
+## Bridge proper
+
+These files use both `HexRoots` data structures and the analytic /
+discriminant cores above.
+
+- `HexRootsMathlib/Basic.lean` — definitional bridge: a `DyadicSquare`
+  determines a centre `c : ℂ` and a radius `r : ℝ`, and a
+  circumscribed disc `Metric.ball c (r·√2)`. Core simp lemmas
+  (`DyadicSquare.center_eq`, `DyadicSquare.disc_eq`).
+- `HexRootsMathlib/Geometry.lean` — the squared-radius bridge:
+  `circumscribed_radius_squared : (r · Real.sqrt 2)² = 2 · r²`, plus
+  the `T_k` squared-form ↔ standard-form equivalence.
+- `HexRootsMathlib/HasOnlySimpleRoots.lean`:
+  `Hex.HasOnlySimpleRoots p ↔ Squarefree (toPolynomial p)`. Combines
+  the `HexRoots`-side gcd-based decision procedure with Mathlib's
+  `separable_iff_squarefree`.
+- `HexRootsMathlib/MahlerPrec.lean` — item 4 above.
+- `HexRootsMathlib/Cauchy.lean` —
+  `DyadicRootCluster.cauchy` correctness: the cluster contains all
+  `Polynomial.roots p` and the strong `T_k` witness holds at radii
+  `r`, `2r`, `4r`. Uses `Polynomial.cauchyBound` for containment, and
+  the elementary observation that the leading-term inequality
+  `|aₙ|·Rⁿ > Σ_{i<n}|aᵢ|·Rⁱ` only strengthens for `R > Cauchy bound`.
+- `HexRootsMathlib/Newton.lean` —
+  `DyadicRootIsolation.refine?` correctness: when it returns
+  `some iso'`, `iso'` certifies the same simple root and `iso'.prec >
+  iso.prec`. Bridges to `Polynomial.newtonMap` and
+  `aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`; also requires a
+  small bound on the `Dyadic.invAtPrec` rounding error, supplied by
+  `Dyadic.invAtPrec_mul_le_one` and `Dyadic.one_lt_invAtPrec_add_inc_mul`
+  in the Lean stdlib.
+- `HexRootsMathlib/Bisection.lean` —
+  `DyadicRootCluster.refine1?` correctness: when it returns
+  `some children`, the multiset of root counts in the children's
+  discs (with multiplicity) equals the parent cluster's `k`. Uses
+  Pellet (item 8) and a finite case analysis over the 4-square
+  partition + edge-connected-components glue.
+- `HexRootsMathlib/IsolateAll.lean` —
+  `isolateAll?` and `isolate` correctness theorems:
+  ```lean
+  theorem isolateAll?_eq_some_iff (p : ZPoly) (target : Nat) :
+      ∃ result, isolateAll? target [DyadicRootCluster.cauchy p] = some result ∧
+        (result.toList.bind (·.roots) : Multiset ℂ) = (toPolynomial p).roots
+
+  theorem isolate_eq_some (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Nat) :
+      ∃ atoms, isolate p h atom_prec = some atoms ∧
+        (atoms.map (·.root) : Finset ℂ) = (toPolynomial p).roots.toFinset ∧
+        ∀ a ∈ atoms, a.square.prec ≥ atom_prec
+  ```
+- `HexRootsMathlib/Conformance.lean` — the standard conformance
+  module, asserting Mathlib-side properties on a small set of
+  committed fixtures.
+
+## Layered file organisation
+
+```
+Discriminant / separation core (upstreamable):
+  HexRootsMathlib/DiscriminantSquarefree.lean
+  HexRootsMathlib/DiscriminantRootProduct.lean
+  HexRootsMathlib/MahlerSeparation.lean
+
+Analytic core (upstreamable, but depends on serious circle-integral
+work and is the harder of the two):
+  HexRootsMathlib/CircleIntegralLemmas.lean
+  HexRootsMathlib/ArgumentPrinciple.lean
+  HexRootsMathlib/Rouche.lean
+  HexRootsMathlib/Pellet.lean
+
+Bridge (depends on hex-roots data structures):
+  HexRootsMathlib/Basic.lean
+  HexRootsMathlib/Geometry.lean
+  HexRootsMathlib/HasOnlySimpleRoots.lean
+  HexRootsMathlib/MahlerPrec.lean
+  HexRootsMathlib/Cauchy.lean
+  HexRootsMathlib/Newton.lean
+  HexRootsMathlib/Bisection.lean
+  HexRootsMathlib/IsolateAll.lean
+  HexRootsMathlib/Conformance.lean
+```
+
+The two cores have no `HexRoots`-dependence and may be split into their
+own libraries (or upstreamed to Mathlib) if they grow. The bridge
+files depend on `HexRoots`'s data definitions and on whichever core
+theorems they need.
+
+## References
+
+See [hex-roots.md](hex-roots.md) for the BSSY paper, Pellet, Mahler,
+and Mignotte references. The discriminant and Mahler-measure
+infrastructure cited above is documented in:
+
+- Becker, Sagraloff, Sharma, Yap, JSC 2018 — same as before; §2 has
+  the exact form of the Pellet inequality and its derivation from
+  Rouché.
+- Mignotte, Štefănescu. *Polynomials: An Algorithmic Approach.*
+  Springer, 1999. Chapter 4 has a clean self-contained proof of the
+  Mahler/Mignotte separation bound suitable for direct
+  formalisation.
+- Yap. *Fundamental Problems of Algorithmic Algebra.* Oxford, 2000.
+  §6.6 gives an alternative derivation via Liouville-style estimates.

--- a/SPEC/Libraries/hex-roots.md
+++ b/SPEC/Libraries/hex-roots.md
@@ -1,0 +1,276 @@
+# hex-roots (complex root isolation, depends on hex-poly-z)
+
+Certified isolation of complex roots of integer-coefficient
+polynomials. A "root isolation" is a Gaussian-dyadic centre and a
+dyadic-power-of-two radius together with a witness, dischargeable by
+`cbv_decide`, that the disc contains exactly one simple root (atom) or
+exactly `k` roots with multiplicity (cluster). Refinement combines
+speculative Newton iteration (using `Dyadic.invAtPrec` from the Lean
+standard library) with subdivision-and-component-gluing as the
+bootstrap phase, following the hybrid algorithm of Becker–Sagraloff–
+Sharma–Yap, *J. Symbolic Computation* 86 (2018) 51–96 (arXiv:1509.06231;
+"BSSY" hereafter).
+
+## Witness arithmetic is exact
+
+A `ZPoly` evaluated at a Gaussian-dyadic point `(a + b·i)` yields
+Taylor coefficients
+
+```
+cₖ = Σ_{j ≥ k} binomial(j,k) · aⱼ · (a + b·i)^{j−k}
+```
+
+each term an integer times a Gaussian-dyadic power, hence
+`cₖ ∈ Dyadic[i]` *exactly*. `|cₖ|² = (Re cₖ)² + (Im cₖ)²` is then an
+exact dyadic. Every witness in this library is a strict comparison
+between two exact dyadics — `Decidable` with no error budget. The
+Newton step itself uses `Dyadic.invAtPrec` and is approximate, but the
+witness re-check after Newton uses the new exact dyadic centre and is
+again exact. This eliminates an entire category of "interval
+arithmetic" infrastructure that one might naïvely expect.
+
+## Geometry: dyadic squares, circumscribed discs, squared radii
+
+Subdivision works on dyadic squares (4-way clean partition); Pellet
+tests live on the **circumscribed disc** of each square. For a square
+of half-width `r = 2^{-prec}`, the circumscribed disc has radius `r·√2`.
+To keep all arithmetic dyadic, **every appearance of a radius in a
+witness is replaced by the squared form**. The `T_k`-inequality
+becomes `|cₖ|² · (r²·2)^k > S²` rather than `|cₖ|·(r·√2)^k > S`. The
+strong-witness `2·`-radius and `4·`-radius checks become `8r²` and
+`32r²` respectively. A single named lemma
+`circumscribed_radius_squared : (r·√2)² = 2·r²` is checked once;
+afterwards no `√2` appears.
+
+## Contents
+
+```lean
+namespace Hex
+
+structure DyadicSquare where
+  re   : Dyadic
+  im   : Dyadic
+  prec : Nat
+  -- half-width is 2^{-prec}; circumscribed disc has radius² = 2 · 4^{-prec}
+
+structure DyadicRootIsolation (p : ZPoly) where
+  square  : DyadicSquare
+  witness : witness₁ p square    -- T_1 squared form on the circumscribed disc
+
+structure DyadicRootCluster (p : ZPoly) where
+  square  : DyadicSquare
+  k       : Nat                  -- ≥ 1
+  k_pos   : 0 < k
+  witness : witnessₖ p square k  -- strong T_k on disc, on 2·-radius, on 4·-radius
+
+/-- p has only simple complex roots. Default-decidable via
+`Hex.HasOnlySimpleRoots.decide` (gcd(p, p') is a unit). The Mathlib
+companion proves equivalence with `Squarefree (toPolynomial p)`. -/
+def HasOnlySimpleRoots (p : ZPoly) : Prop := …
+instance : Decidable (HasOnlySimpleRoots p) := …
+```
+
+Both `witness₁` and `witnessₖ` are `Decidable` Props built directly
+from dyadic comparisons; the structure-level `cbv_decide` on a fully-
+elaborated `DyadicRootIsolation p` value can prove the witness
+holds. The "no roots on the boundary circle" property of every
+isolation and cluster is implicit in the strict inequality and
+exposed as a derived lemma in the Mathlib companion.
+
+## Operations
+
+```lean
+namespace DyadicRootIsolation
+def refine1?  : DyadicRootIsolation p → Option (DyadicRootIsolation p)
+def refine?   : (target : Nat) → DyadicRootIsolation p → Option (DyadicRootIsolation p)
+end DyadicRootIsolation
+
+namespace DyadicRootCluster
+def refine1? : DyadicRootCluster p → Option (Array (DyadicRootCluster p ⊕ DyadicRootIsolation p))
+def cauchy   : (p : ZPoly) → DyadicRootCluster p
+def atomize  : (c : DyadicRootCluster p) → c.k = 1 → DyadicRootIsolation p
+end DyadicRootCluster
+
+/-- Refine every cluster in the worklist until each has prec ≥ target. -/
+def isolateAll? (target : Nat) (worklist : Array (DyadicRootCluster p)) :
+    Option (Array (DyadicRootCluster p))
+
+/-- All-atoms output for polynomials with no multiple roots. Implementation:
+    take target := max atom_prec (mahlerPrec p), then atomize. -/
+def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Nat) :
+    Option (Array (DyadicRootIsolation p))
+```
+
+`refine1?` (both atom and cluster) tries a speculative Newton step
+first, then falls back to bisection on failure. Newton uses
+`Dyadic.invAtPrec` for the Gaussian inversion `1/c₁ = c̄₁ / |c₁|²`;
+**we explicitly use `invAtPrec` rather than a hypothetical
+`divAtPrec`** because both the real and imaginary components of
+`c̄₁ / |c₁|²` reuse the same real reciprocal `1/|c₁|²`, so a
+precomputed reciprocal beats two separate divisions. The new candidate
+disc is recertified by re-running the witness; on failure (witness
+fails for the candidate disc), bisection is the fallback.
+
+Bisection 4-way-partitions a square into sub-squares of one bit higher
+precision, runs the `T_0` (no-roots) and `T_1` / `T_k` (`k`-roots)
+tests on each sub-square's circumscribed disc, discards `T_0`-positive
+sub-squares, and glues the remaining undecided / positive sub-squares
+into edge-connected components (BSSY, §4). The cluster-level test
+runs on the disc circumscribing the connected-component square.
+
+`refine?` for a single isolation terminates by `target − iso.prec : Nat`
+(strictly decreasing). `isolateAll?` terminates by
+
+```
+Φ(W) := Σ_{c ∈ W, c.prec < target} (4^(target − c.prec) − 1)
+```
+
+which strictly decreases by at least 3 per `refine1?` step (a cluster
+at prec `p` is replaced by at most 4 children at prec `p+1`; the
+contribution changes from `4^(target−p) − 1` to at most
+`4 · (4^(target−p−1) − 1) = 4^(target−p) − 4`). `isolate` is a thin
+wrapper over `isolateAll?` and inherits termination.
+
+`isolate` returns `none` only if some primitive `refine1?` step has
+returned `none`. The Mathlib companion proves: under
+`Hex.HasOnlySimpleRoots`, the result is always `some` and contains
+exactly the simple-root set of `p` as atoms refined to ≥ `atom_prec`.
+
+For polynomials with multiple roots, there is no `isolate` analog.
+Use `isolateAll?` directly; multiple-root clusters never atomise (the
+`T_1` witness fails identically because `c₁ → 0` near a multiple root)
+and surface in the output with their `k ≥ 2` field.
+
+## `mahlerPrec` — termination bound for atomisation
+
+```lean
+def mahlerPrec (p : ZPoly) : Nat
+```
+
+For squarefree `p ∈ ℤ[x]` of degree `n` with sup-norm `‖p‖∞`, the
+Mahler/Mignotte separation bound says
+
+```
+min_{i ≠ j} |αᵢ − αⱼ| ≥ √3 · n^{−(n+2)/2} · |disc p|^{1/2} · M(p)^{−(n−1)}
+```
+
+Combined with `|disc p| ≥ 1` (nonzero integer for squarefree `p`) and
+Landau's `M(p) ≤ √(n+1) · ‖p‖∞`, this gives a closed-form lower bound
+on root separation in terms of `n` and `‖p‖∞` only. `mahlerPrec`
+returns a `Nat` such that bisecting to half-width `2^{-mahlerPrec p}`
+suffices to separate any two distinct roots. Pure integer arithmetic;
+no discriminant computation at runtime (we only need the lower bound
+`|disc p| ≥ 1`, not `disc p` itself). The Mathlib companion proves
+correctness — see [hex-roots-mathlib.md](hex-roots-mathlib.md).
+
+## Algorithm exposition
+
+The library implements the BSSY hybrid `subdivide → glue → speculative
+Newton` loop, restricted to simple `T_1` witnesses for atoms and `T_k`
+witnesses for clusters. Specific differences from BSSY:
+
+- **No Graeffe iteration.** Deferred as a future optimisation; without
+  it, `T_k` requires the disc to be `(2√2/3, 4/3)`-isolating, which is
+  brittle for very tight clusters but adequate for typical inputs.
+- **No squarefree preprocessing.** Honest multiple roots cannot satisfy
+  the `T_1` simplicity-implying inequality at any radius (because
+  `c₁ → 0`), so they correctly stay as `k ≥ 2` clusters. Squarefree
+  inputs atomise; non-squarefree inputs surface the multiple roots as
+  clusters.
+- **Squares for partition; circumscribed discs for tests.** Squares
+  4-way partition without overlap; circumscribed discs harmlessly
+  over-count, but discarding via `T_0` and component-gluing recovers
+  the exact root distribution. (BSSY §4.)
+- **Speculative Newton, then re-test.** No a priori `newtonReady`
+  precondition; we just take the Newton step and re-run the witness on
+  the result. If it certifies, we earned quadratic convergence; if
+  not, we fall back to bisection.
+
+## Layered file organisation
+
+- `HexRoots/Basic.lean` — types: `DyadicSquare`, `DyadicRootIsolation`,
+  `DyadicRootCluster`, `Hex.HasOnlySimpleRoots`.
+- `HexRoots/Taylor.lean` — exact Gaussian-dyadic Taylor expansion of
+  a `ZPoly` at a Gaussian-dyadic centre. Returns the array
+  `(c₀, c₁, ..., c_n) : Array (Dyadic × Dyadic)`.
+- `HexRoots/Pellet.lean` — `T_0`, `T_1`, `T_k` squared-form witness
+  predicates and their `Decidable` instances.
+- `HexRoots/MahlerPrec.lean` — the closed-form `mahlerPrec` function.
+- `HexRoots/Cauchy.lean` — `DyadicRootCluster.cauchy` constructor.
+- `HexRoots/Newton.lean` — speculative Newton step using
+  `Dyadic.invAtPrec`; `DyadicRootIsolation.refine1?` and `refine?`.
+- `HexRoots/Bisection.lean` — 4-way subdivision, component gluing,
+  `DyadicRootCluster.refine1?`.
+- `HexRoots/IsolateAll.lean` — `isolateAll?` driver and the `isolate`
+  convenience wrapper.
+- `HexRoots/Conformance.lean`, `HexRoots/Bench.lean`,
+  `HexRoots/EmitFixtures.lean` — the standard testing trio.
+
+## Conformance fixtures
+
+Per [SPEC/testing.md](../testing.md), fixtures are tiered into
+`core` / `ci` / `local`. **Adversarial deterministic families take
+precedence over random samples** because random small-coefficient
+polynomials are weak at exposing clustered-root pathologies.
+
+- *core* (Lean-only, runs on every push):
+  - Sanity polynomials with rational roots: `(x−1)(x−2)(x+3)`, `x³ − x`.
+  - Cyclotomic Φ_n for `n ∈ {5, 7, 12}` — roots are roots of unity.
+  - Chebyshev T_n for `n ∈ {5, 10}` — roots at known `cos((2k−1)π/(2n))`.
+  - Small Mignotte `xⁿ − (a·x − 1)²` for `n = 5`, `a = 100`.
+  - Multiple-root case `(x²+1)·(x−5)²` — verifies that the `k = 2`
+    cluster around `5` does not atomise.
+- *ci* (CI, with external oracle when available):
+  - 50 degree-20 polynomials with deterministic seed `0xHEC0FFEE` and
+    coefficients in `[−10, 10]`. Expected outputs serialised from
+    a local oracle run during fixture emission.
+- *local* (developer-driven):
+  - MPSolve-driven adversarial families: Mignotte `(n, a)` for
+    `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`, Wilkinson 20, Bring
+    quintics, Smale-pathological products.
+
+External oracles (in role order): MPSolve (primary, Brew-installable);
+FLINT/Arb (secondary, for cases where MPSolve precision is suspect);
+SageMath (fallback).
+
+## Complexity contract
+
+- `mahlerPrec p` runs in `O(n · log ‖p‖∞)` integer operations
+  (logarithm by repeated squaring on the closed-form bound).
+- One `T_k` witness check at squared half-width `2^{-prec}` costs
+  `O(n²)` exact-dyadic operations on coefficients of bit-length
+  `O(prec + n · log ‖p‖∞)`, i.e. `O(n²·B²)` bit operations
+  schoolbook.
+- One Newton step costs the same order as one witness check, plus a
+  single `Dyadic.invAtPrec` call.
+- `isolate` for degree `n`, well-separated roots, target precision
+  `prec`: heuristically `O(n³ · B²)` bit operations. For tight
+  clusters add a `log(1/separation)` factor, bounded by
+  `mahlerPrec p` in the worst case.
+
+## Time budgets (Phase 4 validation)
+
+These are rough first guesses, to be refined against MPSolve on the
+same fixtures during Phase 4:
+
+- Degree 10, prec 32: < 1 second.
+- Degree 50, prec 64: < 10 seconds.
+- Degree 100, prec 128: < 1 minute.
+
+## References
+
+- Becker, Sagraloff, Sharma, Yap. *A near-optimal subdivision
+  algorithm for complex root isolation based on the Pellet test and
+  Newton iteration.* J. Symbolic Computation 86 (2018) 51–96.
+  arXiv:1509.06231. **The reference**; pseudocode for everything in
+  this library traces back to this paper.
+- Imbach, Pan, Yap. *Implementation of a near-optimal complex root
+  clustering algorithm (Ccluster).* ICMS 2018, LNCS 10931. The C/Arb
+  implementation paper, with the soft-Pellet filter optimisations.
+- Pellet. *Sur un mode de séparation des racines des équations et la
+  formule de Lagrange.* Bull. Sci. Math. 5 (1881) — origin of `T_k`.
+- Mahler. *On some inequalities for polynomials in several variables.*
+  J. London Math. Soc. 37 (1962) — original separation bound.
+- Mignotte. *Some useful bounds.* Computer Algebra: Symbolic and
+  Algebraic Computation, 1982. Standard textbook simplification of
+  Mahler.

--- a/libraries.yml
+++ b/libraries.yml
@@ -176,3 +176,15 @@ libraries:
     mathlib: true
     done_through: 3
     status: active
+
+  # ---------- Planned (status: planned; SPEC ready, implementation deferred) ----------
+  HexRoots:
+    deps: [HexPolyZ]
+    mathlib: false
+    done_through: 0
+    status: planned
+  HexRootsMathlib:
+    deps: [HexRoots, HexPolyZMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned

--- a/progress/20260506T061645Z_hexroots_spec.md
+++ b/progress/20260506T061645Z_hexroots_spec.md
@@ -1,0 +1,88 @@
+# 2026-05-06 06:16 UTC — interactive session (HexRoots SPECs)
+
+## Accomplished
+
+Drafted SPEC files for a new `HexRoots` library and its Mathlib
+companion `HexRootsMathlib`, capturing a design worked out in a long
+interactive conversation:
+
+- `SPEC/Libraries/hex-roots.md` — dyadic-square + Pellet-test
+  certified complex root isolation for `Z[x]`. Atom (`DyadicRootIsolation`)
+  + cluster (`DyadicRootCluster`) types with `cbv_decide`-checkable
+  squared-form witnesses; speculative Newton via `Dyadic.invAtPrec`
+  (Lean stdlib); 4-way square subdivision with component gluing
+  (Becker–Sagraloff–Sharma–Yap, JSC 2018); `mahlerPrec` as the
+  Mathlib-free closed-form separation bound that gives `isolate` its
+  termination guarantee.
+- `SPEC/Libraries/hex-roots-mathlib.md` — bridge to `Polynomial ℤ`
+  and `ℂ`. Two self-contained analytic developments to be done
+  upstream-friendly: (a) discriminant/separation core (cite Mathlib's
+  `discr`, `resultant`, `mahlerMeasure`, prove
+  `discr ≠ 0 ↔ Squarefree` for `Z[x]`, the discriminant root-product
+  formula, and the Mahler/Mignotte separation bound); (b) Pellet-on-
+  circles core (cite `circleIntegral`, prove circle-integral lemmas,
+  argument principle on circles, Rouché on circles, Pellet).
+- Updated `SPEC/Libraries/README.md`: added `hex-roots` and
+  `hex-roots-mathlib` to all four lists (overview, mathlib bridges,
+  implementation deps, mathlib bridge deps, index).
+
+Notable design points captured in the SPECs:
+- All witness arithmetic is **exact** in dyadic — Taylor coefficients
+  of `Z[x]` polynomials at Gaussian-dyadic points are exact Gaussian
+  dyadics, so the Pellet inequality is a strict comparison between
+  exact dyadics with no error budget.
+- All radii are **squared** throughout to keep the circumscribed-disc
+  `√2` factor in dyadic form.
+- No squarefree preprocessing; multiple roots stay as clusters by
+  design (the `T_1` witness literally cannot pass for them).
+- `mahlerPrec` (Mathlib-free) gives `isolate` termination via
+  `target := max atom_prec (mahlerPrec p)` then `isolateAll?` (which
+  always terminates by the `Φ`-measure argument captured in the SPEC).
+- No Graeffe iteration in the initial scope (deferred).
+- Restricting Mathlib-side complex analysis to **circular contours**
+  sidesteps the general-contour blocker that's holding Rouché out of
+  Mathlib (per the active Zulip thread; see SPEC).
+
+## Current frontier
+
+The two SPEC files and the README update are the only changes on this
+branch. **No `libraries.yml` or `lakefile.lean` edits were committed**
+— wiring the new libraries into the build system is Phase 0 work,
+distinct from authoring the SPEC.
+
+## Next step
+
+Open a PR for these SPEC additions. Once merged, separate planner
+issues should be opened for:
+
+1. Phase 0: register `HexRoots` and `HexRootsMathlib` in
+   `libraries.yml` and `lakefile.lean`; create the empty umbrella
+   `HexRoots.lean` and `HexRootsMathlib.lean` files; verify
+   `scripts/check_dag.py` passes.
+2. Phase 1, staged per the SPEC's "implementation order" guidance:
+   types and `T_1` witness (kernel slice) → `T_k` witness + cluster
+   types + `cauchy` constructor → `mahlerPrec` → Newton refinement →
+   bisection + component gluing → drivers (`isolateAll?`, `isolate`).
+3. Phase 6: Mathlib companion, in two streams that can be parallelised:
+   discriminant/separation core (smaller, lands first to unblock
+   `isolate`'s correctness) and analytic Rouché core (larger).
+
+Out-of-tree follow-up:
+
+- Filed lean4 issue
+  [#13653](https://github.com/leanprover/lean4/issues/13653) — feat:
+  add `Dyadic.divAtPrec` for round-down dyadic division at given
+  precision. Not on the critical path for HexRoots — we use
+  `invAtPrec` for the Gaussian `1/(a²+b²)` reciprocal because the
+  result is reused for both real and imaginary parts of the complex
+  inverse.
+- Optionally: post a brief reply on the
+  [#maths > Multivariate complex analysis](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Multivariate%20complex%20analysis)
+  Zulip thread noting that we plan to land Rouché-on-circles
+  downstream and intend to upstream it.
+
+## Blockers
+
+No mechanical blocker. The Mathlib-side Rouché development is real
+work; the Mathlib-side discriminant/separation development is much
+smaller. Both are in scope per the SPEC.


### PR DESCRIPTION
Adds SPEC files for `hex-roots` (BSSY-based complex root isolation for `ℤ[x]`) and its Mathlib bridge `hex-roots-mathlib`, plus matching `libraries.yml` entries with `status: planned` (per PR #2651). The libraries are not yet active — no Lean code is created here, no Lake target, no root file. They appear in the planned-skipped footer of `scripts/status.py` and are ignored by orchestration until promoted to `status: active`.

The SPEC documents the algorithm in detail: exact Gaussian-dyadic Taylor witnesses, dyadic squares + circumscribed discs with squared-radius witnesses, speculative Newton + 4-way bisection + component gluing, Mahler/Mignotte separation bound for termination. The Mathlib bridge SPEC pairs each computational definition with its abstract correctness statement.

The `SimpleRoot p` Quotient construction and the `refine`/`out` threading-pattern extension are *not* in this PR — they land along with the HexNumberField SPEC in #2653, which depends on this PR.

🤖 Prepared with Claude Code