### PR TITLE
ci: drop merge-queue config (unavailable on this plan)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-  # GitHub merge queue dispatches workflow runs on a synthetic
-  # `gh-readonly-queue/main/...` ref; without this trigger the
-  # required status checks never report and the queue stalls.
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch:
-  # GitHub merge queue dispatches workflow runs on a synthetic
-  # `gh-readonly-queue/main/...` ref; without this trigger the
-  # required status checks never report and the queue stalls.
-  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -32,18 +32,13 @@ PR commit fire each workflow exactly once.
 `workflow_dispatch:` is allowed wherever an ad-hoc manual run is
 useful (currently `conformance.yml`).
 
-`merge_group:` is required on every workflow whose status check is
-in the required-contexts list for `main` (see Branch protection
-below). GitHub's merge queue dispatches workflow runs on a synthetic
-`gh-readonly-queue/main/...` ref; without `merge_group:` the
-required checks never report on the queue's candidate ref and the
-queue stalls. The merge queue runs the same single ubuntu (+ macOS
-for `ci.yml`) job as `pull_request:`, so this does not breach the
-job-count budget.
-
-Other triggers (`schedule:`, `repository_dispatch:`, `release:`) are
-case-by-case; they must be documented in the workflow file with a
-comment explaining why they're justified.
+Other triggers (`schedule:`, `repository_dispatch:`, `release:`,
+`merge_group:`) are case-by-case; they must be documented in the
+workflow file with a comment explaining why they're justified.
+`merge_group:` is **not** in use on this repo: GitHub's merge queue
+is unavailable on the personal-account plan that owns the repo, so
+adding a `merge_group:` trigger would just be dead configuration.
+Revisit if the account ever moves to a plan that supports the queue.
 
 ## Concurrency
 
@@ -136,12 +131,9 @@ cache step, not to silently rebuild.
 ## Branch protection
 
 `main` requires every status check produced by `ci.yml` and
-`conformance.yml` to pass before merge, and merges go through
-GitHub's **merge queue**. The pod auto-merger (`gh pr merge --auto`)
-hands a PR to the queue once its own checks are green; the queue
-then serially rebases each PR onto `main`, re-runs the required
-checks against the rebased candidate (the `merge_group:` trigger,
-see Triggers above), and merges only if they pass.
+`conformance.yml` to pass before merge. The pod auto-merger
+(`gh pr merge --auto`) respects branch protection, so this is the
+mechanism that gates merges on CI.
 
 Required contexts (kept in sync with the actual job names in the
 workflow files):
@@ -150,12 +142,18 @@ workflow files):
 - `build-macos` (from `ci.yml`)
 - `conformance` (from `conformance.yml`)
 
-`required_status_checks.strict` is `false`. The merge queue is the
-mechanism that guarantees each merged commit was tested against the
-current tip of `main`; layering `strict: true` on top forces every
-PR to be manually rebased before the queue will even accept it,
-which (with N PRs in flight) reduces to the pre-queue stall this
-configuration exists to fix.
+`required_status_checks.strict` is `false`. With `strict: true`,
+every merge to `main` flips every other open PR to `BEHIND` and
+auto-merge will not fire on a behind branch — without a merge queue
+to serially rebase the queue (see Triggers above; the queue is
+unavailable on this account's plan), this serialises the whole repo
+on a manual "Update branch" click per PR per merge, which in
+practice means PRs sit forever. Accepting `strict: false` means a
+merged commit was tested against the tip of `main` *as of when its
+PR's CI last ran*, not the current tip — for this repo's workload
+(largely orthogonal proof additions on top of a green tree), that
+trade-off is acceptable. Reconsider if a future change makes
+cross-PR conflicts more likely.
 
 `enforce_admins: false` is acceptable — humans occasionally need to
 override (e.g. a known-good revert during incident response). PR


### PR DESCRIPTION
This PR reverts the `merge_group:` workflow triggers and the merge-queue paragraphs in SPEC/CI.md that landed in #2654. GitHub's merge queue is unavailable on the personal-account plan that owns this repo, so the bootstrap config is dead.

`required_status_checks.strict` stays at `false` (set out-of-band via the API). The rationale and trade-off are now documented in SPEC/CI.md's Branch protection section: without a queue, leaving `strict: true` deadlocks on manual "Update branch" clicks every time anything merges; accepting `strict: false` means a merged commit was tested against `main` as-of-its-last-CI-run rather than the current tip.

🤖 Prepared with Claude Code