### PR TITLE
spec: add hex-real-roots and hex-sturm (status: planned)

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -9,6 +9,8 @@
 - **hex-gf2** — packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
 - **hex-poly-z** — polynomials over `Z`, content/primitive part, Mignotte bound
 - **hex-roots** — certified complex root isolation for `Z[x]` via dyadic squares + Pellet test + speculative Newton
+- **hex-real-roots** — certified real root isolation for `Z[x]` via Sturm + bisection (subresultant-based integer Sturm sequence)
+- **hex-sturm** — Lean tactic providing a complete decision procedure for univariate real-closed-field formulas (Boolean combinations of polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation backed by `hex-real-roots`. `mathlib: true` (the tactic targets `ℝ`)
 - **hex-resultant** — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
 - **hex-number-field** — `NumberField p x` (`ℚ(α)` element indexed by a complex root) and canonical `AlgebraicNumber` (any `α ∈ ℂ_alg`)
 - **hex-berlekamp** — Berlekamp factoring and Rabin irreducibility test over `F_p`
@@ -29,6 +31,7 @@ proving correspondence with Mathlib's mathematical definitions):
 - **hex-gram-schmidt-mathlib** — `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib** — `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib** — Pellet on circles (built from `circleIntegral`) + Mahler/Mignotte separation bound; correctness of refinement and `isolate`
+- **hex-real-roots-mathlib** — Sturm's theorem (integer Sturm count = real-root count); Cauchy bound + Mahler/Mignotte real-root separation; correctness of `isolate`
 - **hex-resultant-mathlib** — "subresultant zero ↔ common root" property (scope-limited; full bridge to `Polynomial.resultant` deferred)
 - **hex-number-field-mathlib** — `NumberField p x ≃+* AdjoinRoot p`, bijection of `AlgebraicNumber` with `ℂ_alg`, arithmetic correctness
 - **hex-berlekamp-mathlib** — `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
@@ -51,6 +54,8 @@ Each library with its immediate dependencies:
 - **hex-poly-fp** — hex-poly, hex-mod-arith
 - **hex-poly-z** — hex-poly
 - **hex-roots** — hex-poly-z
+- **hex-real-roots** — hex-poly-z, hex-resultant
+- **hex-sturm** — hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant** — hex-poly
 - **hex-number-field** — hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus
 - **hex-berlekamp** — hex-poly-fp, hex-matrix, hex-gfq-ring
@@ -68,6 +73,7 @@ Mathlib bridge libraries (each also depends on Mathlib):
 - **hex-poly-mathlib** — hex-poly
 - **hex-poly-z-mathlib** — hex-poly-z, hex-poly-mathlib
 - **hex-roots-mathlib** — hex-roots, hex-poly-z-mathlib
+- **hex-real-roots-mathlib** — hex-real-roots, hex-poly-z-mathlib, hex-resultant-mathlib
 - **hex-resultant-mathlib** — hex-resultant, hex-poly-mathlib
 - **hex-number-field-mathlib** — hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
 - **hex-matrix-mathlib** — hex-matrix
@@ -134,6 +140,9 @@ hex-gfq-field   hex-conway   hex-gf2
 - [hex-poly-z-mathlib.md](hex-poly-z-mathlib.md) — Mignotte bound proof via Mathlib's Mahler measure
 - [hex-roots.md](hex-roots.md) — certified complex root isolation for `Z[x]`
 - [hex-roots-mathlib.md](hex-roots-mathlib.md) — Pellet on circles, Mahler/Mignotte separation bound, refinement and `isolate` correctness
+- [hex-real-roots.md](hex-real-roots.md) — certified real root isolation for `Z[x]` via Sturm + bisection
+- [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md) — Sturm's theorem; Cauchy bound; Mahler/Mignotte real-root separation; `isolate` correctness
+- [hex-sturm.md](hex-sturm.md) — Lean tactic for univariate real-closed-field decision (Boolean polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation, `mathlib: true`
 - [hex-resultant.md](hex-resultant.md) — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
 - [hex-resultant-mathlib.md](hex-resultant-mathlib.md) — "subresultant zero ↔ common root"; discriminant non-vanishing under squarefreeness
 - [hex-number-field.md](hex-number-field.md) — `NumberField p x` and canonical `AlgebraicNumber` for arbitrary `α ∈ ℂ_alg`

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -9,8 +9,8 @@
 - **hex-gf2** — packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
 - **hex-poly-z** — polynomials over `Z`, content/primitive part, Mignotte bound
 - **hex-roots** — certified complex root isolation for `Z[x]` via dyadic squares + Pellet test + speculative Newton
-- **hex-real-roots** — certified real root isolation for `Z[x]` via Sturm + bisection (subresultant-based integer Sturm sequence)
-- **hex-sturm** — Lean tactic providing a complete decision procedure for univariate real-closed-field formulas (Boolean combinations of polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation backed by `hex-real-roots`. `mathlib: true` (the tactic targets `ℝ`)
+- **hex-real-roots** — certified real root isolation for `Z[x]` via Uspensky's algorithm (Descartes' rule of signs + Möbius bisection) with LMQ bounds
+- **hex-rcf** — Lean tactic `rcf` providing a complete decision procedure for univariate real-closed-field formulas (Boolean combinations of polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation backed by `hex-real-roots`. `mathlib: true` (the tactic targets `ℝ`)
 - **hex-resultant** — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
 - **hex-number-field** — `NumberField p x` (`ℚ(α)` element indexed by a complex root) and canonical `AlgebraicNumber` (any `α ∈ ℂ_alg`)
 - **hex-berlekamp** — Berlekamp factoring and Rabin irreducibility test over `F_p`
@@ -31,7 +31,7 @@ proving correspondence with Mathlib's mathematical definitions):
 - **hex-gram-schmidt-mathlib** — `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib** — `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib** — Pellet on circles (built from `circleIntegral`) + Mahler/Mignotte separation bound; correctness of refinement and `isolate`
-- **hex-real-roots-mathlib** — Sturm's theorem (integer Sturm count = real-root count); Cauchy bound + Mahler/Mignotte real-root separation; correctness of `isolate`
+- **hex-real-roots-mathlib** — Möbius-transform-Descartes correspondence (Mathlib's `signVariations` + parity); Cauchy + LMQ bounds; Mahler/Mignotte real-root separation; correctness of `isolate`
 - **hex-resultant-mathlib** — "subresultant zero ↔ common root" property (scope-limited; full bridge to `Polynomial.resultant` deferred)
 - **hex-number-field-mathlib** — `NumberField p x ≃+* AdjoinRoot p`, bijection of `AlgebraicNumber` with `ℂ_alg`, arithmetic correctness
 - **hex-berlekamp-mathlib** — `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
@@ -54,8 +54,8 @@ Each library with its immediate dependencies:
 - **hex-poly-fp** — hex-poly, hex-mod-arith
 - **hex-poly-z** — hex-poly
 - **hex-roots** — hex-poly-z
-- **hex-real-roots** — hex-poly-z, hex-resultant
-- **hex-sturm** — hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
+- **hex-real-roots** — hex-poly-z
+- **hex-rcf** — hex-real-roots, hex-real-roots-mathlib, hex-poly-z, hex-poly-z-mathlib (mathlib: true)
 - **hex-resultant** — hex-poly
 - **hex-number-field** — hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus
 - **hex-berlekamp** — hex-poly-fp, hex-matrix, hex-gfq-ring
@@ -73,7 +73,7 @@ Mathlib bridge libraries (each also depends on Mathlib):
 - **hex-poly-mathlib** — hex-poly
 - **hex-poly-z-mathlib** — hex-poly-z, hex-poly-mathlib
 - **hex-roots-mathlib** — hex-roots, hex-poly-z-mathlib
-- **hex-real-roots-mathlib** — hex-real-roots, hex-poly-z-mathlib, hex-resultant-mathlib
+- **hex-real-roots-mathlib** — hex-real-roots, hex-poly-z-mathlib
 - **hex-resultant-mathlib** — hex-resultant, hex-poly-mathlib
 - **hex-number-field-mathlib** — hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
 - **hex-matrix-mathlib** — hex-matrix
@@ -140,9 +140,9 @@ hex-gfq-field   hex-conway   hex-gf2
 - [hex-poly-z-mathlib.md](hex-poly-z-mathlib.md) — Mignotte bound proof via Mathlib's Mahler measure
 - [hex-roots.md](hex-roots.md) — certified complex root isolation for `Z[x]`
 - [hex-roots-mathlib.md](hex-roots-mathlib.md) — Pellet on circles, Mahler/Mignotte separation bound, refinement and `isolate` correctness
-- [hex-real-roots.md](hex-real-roots.md) — certified real root isolation for `Z[x]` via Sturm + bisection
-- [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md) — Sturm's theorem; Cauchy bound; Mahler/Mignotte real-root separation; `isolate` correctness
-- [hex-sturm.md](hex-sturm.md) — Lean tactic for univariate real-closed-field decision (Boolean polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation, `mathlib: true`
+- [hex-real-roots.md](hex-real-roots.md) — certified real root isolation for `Z[x]` via Uspensky (Descartes + Möbius bisection) with LMQ bounds
+- [hex-real-roots-mathlib.md](hex-real-roots-mathlib.md) — Möbius-transform-Descartes correspondence; Cauchy + LMQ; Mahler/Mignotte real-root separation; `isolate` correctness
+- [hex-rcf.md](hex-rcf.md) — Lean tactic `rcf` for univariate real-closed-field decision (Boolean polynomial inequalities + ∀/∃ over `ℝ`); reflective implementation, `mathlib: true`
 - [hex-resultant.md](hex-resultant.md) — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
 - [hex-resultant-mathlib.md](hex-resultant-mathlib.md) — "subresultant zero ↔ common root"; discriminant non-vanishing under squarefreeness
 - [hex-number-field.md](hex-number-field.md) — `NumberField p x` and canonical `AlgebraicNumber` for arbitrary `α ∈ ℂ_alg`

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -267,7 +267,7 @@ For a p-adic factor `g | f`, the CLD of `g` is the polynomial
 
 ### Coefficient bound
 
-Pinned: **BHKS Lemma 5.1 with Landau's inequality**. For `g ∈ ℤ[x]` a true factor of `f` and `j ∈ {0, …, deg f − 1}`,
+The coefficient bound is **BHKS Lemma 5.1 with Landau's inequality**. For `g ∈ ℤ[x]` a true factor of `f` and `j ∈ {0, …, deg f − 1}`,
 
     |[x^j] Φ(g)|  ≤  B_j  :=  C(n − 1, j) · n · ‖f‖₂
 
@@ -309,7 +309,7 @@ where `Ã[i, j] := Ψ^a_{ℓ_j}([x^j] Φ(g_i))` for `i ∈ {1,…,r}, j ∈ {0,�
 
 ### Precision schedule
 
-Pinned: start at `a = 4`, double on lattice/verification failure, cap at `bhksBound f` (a Lean-computable integer upper bound for the BHKS Theorem 5.2 threshold `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`; an explicit choice is given below). The cap is the BHKS bound rather than the Mignotte coefficient bound because BHKS dominates Mignotte for every `n ≥ 2` (BHKS §5.3 explicitly: "an annoying extra factor of `n` … coming from a resultant upper bound"); a smaller cap would leave `factorFast f = none` reachable on inputs the algorithm could in principle solve. The constant `4` start is what the current pipeline already does and continues to work.
+The schedule starts at `a = 4`, doubles on lattice/verification failure, and caps at `bhksBound f` (a Lean-computable integer upper bound for the BHKS Theorem 5.2 threshold `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`; an explicit choice is given below). The cap is the BHKS bound rather than the Mignotte coefficient bound because BHKS dominates Mignotte for every `n ≥ 2` (BHKS §5.3 explicitly: "an annoying extra factor of `n` … coming from a resultant upper bound"); a smaller cap would leave `factorFast f = none` reachable on inputs the algorithm could in principle solve.
 
 The `bhksBound : ZPoly → Nat` helper is one of HO-1's deliverables. A safe explicit choice (sound integer upper bound for BHKS eq. 5.3): `bhksBound f := 1 + n · 4^(n²) · (sumSquared f + 1)^n · (log2 (sumSquared f + 1))^n` where `n := deg f` and `sumSquared f := Σ |a_i|²`. Pure `Nat` arithmetic; the upper-bound argument is straightforward (each factor of (5.3) bounded by the corresponding piece of `bhksBound`).
 

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -244,7 +244,7 @@ Goal: `∀ f, factorSlow f = irreducibleFactorisationOf f` (up to ordering and u
 
 Argument:
 
-1. **Hensel correspondence.** Every irreducible integer factor `g | f` over ℤ corresponds to a unique subset `S ⊆ {1, …, r}` such that `g ≡ ∏_{i ∈ S} g_i (mod p^a)`. Mathlib has `hensels_lemma` in `Mathlib.NumberTheory.Padics.Hensel`; the explicit subset-correspondence form may need a small wrapper lemma but follows directly.
+1. **Hensel correspondence.** Every irreducible integer factor `g | f` over ℤ corresponds to a unique subset `S ⊆ {1, …, r}` such that `g ≡ ∏_{i ∈ S} g_i (mod p^a)`. Mathlib has `hensels_lemma` in `Mathlib.NumberTheory.Padics.Hensel`; the explicit subset-correspondence form may need a wrapper lemma but follows directly.
 2. **Mignotte recoverability.** At precision `a` such that `p^a > 2 · defaultFactorCoeffBound f`, the centred-residue lift in `(−p^a/2, p^a/2]` of `(∏_{i ∈ S} g_i mod p^a)` exactly recovers `g`'s integer coefficients. Mathlib has `Polynomial.mahlerMeasure_le_sqrt_sum_sq_coeff` (Landau); the repo wraps it as `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean).
 3. **Exhaustive search soundness.** The search enumerates all `2^r` subsets, accepts only those whose product reconstructs to a true integer factor (verified by exact division). By (1) and (2) every irreducible factor is found.
 4. **Uniqueness.** ℤ[x] is a UFD (Mathlib: `Polynomial.UniqueFactorizationMonoid` over `Int`). The output array contains exactly one representative of each associate class.
@@ -342,7 +342,7 @@ deliverables of HO-1's bridge work; Group D is HO-4's leaf theorem
 ### Group A — slow-path correctness (gives full mathematical guarantee for `factorSlow`)
 
 A1. **Hensel-correspondence subset bijection (squarefree case).** For `f ∈ ℤ[x]` squarefree primitive, `p` an admissible prime, `g_1, …, g_r ∈ (ℤ/p^a)[x]` the Hensel-lifted mod-`p` factorisation: every irreducible integer factor `g | f` over ℤ has a unique subset `S ⊆ {1, …, r}` with `g ≡ ∏_{i ∈ S} g_i (mod p^a)`.
-    *Sketch:* `g mod p` factorises into a unique subset of `{g_i mod p}` (irreducible mod-`p` decomposition), and Hensel's lemma uniquely lifts that subset to mod `p^a`. Mathlib's `hensels_lemma` covers the analytic version; the explicit subset-correspondence form needs a small wrapper. Read BHKS §3 + Mathlib `Mathlib.NumberTheory.Padics.Hensel` before attempting.
+    *Sketch:* `g mod p` factorises into a unique subset of `{g_i mod p}` (irreducible mod-`p` decomposition), and Hensel's lemma uniquely lifts that subset to mod `p^a`. Mathlib's `hensels_lemma` covers the analytic version; the explicit subset-correspondence form needs a wrapper. Read BHKS §3 + Mathlib `Mathlib.NumberTheory.Padics.Hensel` before attempting.
 
 A2. **Mignotte recoverability (modulus form).** Let `B := defaultFactorCoeffBound f`. At precision `a` such that `p^a > 2 B`, the centred-residue lift in `(−p^a/2, p^a/2]` of `(∏_{i ∈ S} g_i mod p^a)` exactly recovers `g`'s integer coefficients.
     *Sketch:* Mignotte's bound (the existing executable `defaultFactorCoeffBound` in [HexPolyZ/Mignotte.lean](../../HexPolyZ/Mignotte.lean), which Mathlib-side `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean) already establishes via Landau) gives `|coeff(g, j)| ≤ B`; the centred residue is then unique. Implementation note: `factorSlow` uses exponent `a := B` as a sufficient choice because `p ≥ 3` ⟹ `p^a ≥ 3^B > 2B`; this is a corollary, not the abstract statement.

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -160,12 +160,12 @@ The tactic implements 1-dimensional CAD:
    real root of some subset of the `pⱼ`s (those for which `pⱼ` has
    that real root).
 
-   Concrete test points: midpoint of `(bᵢ, aᵢ₊₁]` for the central
-   open cells; `aᵢ` for the root-point `RootPoint Iᵢ` cell (so the
-   adjacent open cells use `(bᵢ₋₁, aᵢ]` and `(bᵢ, aᵢ₊₁]`); `−M − 1`
-   for `OpenLeftTail`, `M + 1` for `OpenRightTail`. (Test points
-   are not the cells themselves; they are dyadic rationals at which
-   we evaluate `pⱼ` to determine the cell's sign assignment.)
+   Concrete test points for **open** cells: midpoint of
+   `(bᵢ, aᵢ₊₁]` for the central open cells; `−M − 1` for
+   `OpenLeftTail`; `M + 1` for `OpenRightTail`. **`RootPoint Iᵢ`
+   cells have no test point** — they represent an unknown root
+   `rᵢ ∈ (aᵢ, bᵢ]`, and step 6 determines their sign assignments
+   via the `gⱼ := gcd(pⱼ, P)` mechanism instead of point evaluation.
 
 6. **Sign matrix.** For each cell, determine `sign pⱼ` on the cell:
    - Open-interval cells (and tails): evaluate `pⱼ` at the dyadic

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -137,38 +137,51 @@ The tactic implements 1-dimensional CAD:
    where the bridge guarantees `some`) and retry. The result is a
    pairwise-disjoint array of `RealRootIsolation P`.
 
-5. **Build the cell decomposition.** Use the `isolate?` output for
-   `P` directly. Sort isolations by lower endpoint; the cells are:
+5. **Build the cell decomposition.** Sort the `isolate? P`
+   isolations `I₁, …, Iₖ` (each `Iᵢ = (aᵢ, bᵢ]`) by lower endpoint,
+   and let `M := max(lmqBound P, lmqBound (P(−x)))` be the
+   `±M`-bound from `hex-real-roots`. The cells are represented
+   computationally by:
 
    ```
-   (−∞, root₁), {root₁}, (root₁, root₂), {root₂}, …, (rootₖ, +∞)
+   Cell = OpenLeftTail        -- (−∞, a₁]; semantic: sign-constant on (−∞, r₁)
+        | RootPoint    Iᵢ     -- semantic: the unique real root rᵢ of P inside Iᵢ
+        | OpenInterval Iᵢ Iᵢ₊₁ -- (bᵢ, aᵢ₊₁]; semantic: sign-constant on (rᵢ, rᵢ₊₁)
+        | OpenRightTail       -- (bₖ, +∞); semantic: sign-constant on (rₖ, +∞)
    ```
 
-   Each "open interval" cell has a sign-constant interior for
-   *every* `pⱼ` (an interior point cannot be a root of any `pⱼ`,
-   else it would be a root of `P`). Each "root point" cell is a
-   root of some subset of the `pⱼ`s (those `pⱼ` having that real
-   root). Test points: any dyadic rational in the open-interval
-   cell (e.g. midpoint of consecutive isolation upper/lower
-   bounds); for root-point cells, the cell *is* the root.
+   No exact root values are needed at runtime — the cells are
+   defined by isolations of `P`, and dyadic test points within each
+   open-interval cell suffice for sign evaluation.
 
-6. **Sign matrix.** For each cell, evaluate the integer sign of
-   each `pⱼ` at the cell's representative point.
-   - Open-interval cells: evaluate `pⱼ` at the dyadic test point.
-     The result is in `{−1, +1}` (never zero: a zero would mean
-     the test point is a root of `pⱼ`, hence of `P`, hence not
-     interior to the cell).
-   - Root-point cells: the cell is a real root `r` of `P`. The
-     relevant `pⱼ`s with `pⱼ(r) = 0` are determined at the
-     polynomial level: `pⱼ(r) = 0` iff `r` is a root of
-     `gcd(pⱼ, P)`. Precompute `gⱼ := gcd(pⱼ, P)` for each `j`,
-     and isolate the roots of each `gⱼ`; root-point cell `r` has
-     `sign pⱼ(r) = 0` iff some isolation of `gⱼ` contains the
-     same `RealRoot P`-equivalence-class as `r`. For `pⱼ` with
-     `pⱼ(r) ≠ 0`, the sign at `r` equals `sign pⱼ` on either of
-     the two adjacent open-interval cells (which agree because no
-     root of `pⱼ` lies between them other than possibly `r`
-     itself).
+   Open-interval cells have sign-constant interior for *every* `pⱼ`
+   (an interior point cannot be a root of any `pⱼ`, else it would
+   be a root of `P`). Root-point cells correspond semantically to a
+   real root of some subset of the `pⱼ`s (those for which `pⱼ` has
+   that real root).
+
+   Concrete test points: midpoint of `(bᵢ, aᵢ₊₁]` for the central
+   open cells; `aᵢ` for the root-point `RootPoint Iᵢ` cell (so the
+   adjacent open cells use `(bᵢ₋₁, aᵢ]` and `(bᵢ, aᵢ₊₁]`); `−M − 1`
+   for `OpenLeftTail`, `M + 1` for `OpenRightTail`. (Test points
+   are not the cells themselves; they are dyadic rationals at which
+   we evaluate `pⱼ` to determine the cell's sign assignment.)
+
+6. **Sign matrix.** For each cell, determine `sign pⱼ` on the cell:
+   - Open-interval cells (and tails): evaluate `pⱼ` at the dyadic
+     test point. The result is in `{−1, +1}` (never zero: a zero
+     would make the test point a root of `pⱼ`, hence of `P`, hence
+     not interior to the cell).
+   - Root-point cells `RootPoint Iᵢ` representing `rᵢ`: precompute
+     `gⱼ := gcd(pⱼ, P)`. Then `pⱼ(rᵢ) = 0` iff `gⱼ` has a real
+     root in the isolation interval `Iᵢ`. Decide this by computing
+     `signVariations` of `gⱼ`'s Möbius transform on `Iᵢ`: if `≥ 1`,
+     `gⱼ` has a root in `Iᵢ` (it is `rᵢ`, since `gⱼ ∣ P` and `Iᵢ`
+     contains exactly one `P`-root); if `= 0`, no root, so
+     `pⱼ(rᵢ) ≠ 0`. When `pⱼ(rᵢ) ≠ 0`, the sign at `rᵢ` equals
+     `sign pⱼ` on either of the two adjacent open-interval cells
+     (which agree, because no root of `pⱼ` lies between them other
+     than possibly `rᵢ` itself).
 
    The result is a `m × k` matrix of signs `{−1, 0, +1}`.
 
@@ -210,12 +223,15 @@ genuine proof of the corresponding `ℝ`-Prop. The proof factors
 through:
 
 - **Sign-matrix correctness.** For each cell, the signs are correct
-  at *every* point in the cell (not just the representative). This
+  at *every* point in the cell (not just the test point). This
   follows because each `pⱼ` is sign-constant on cell interiors (no
   `pⱼ` has a root strictly between consecutive `P`-roots, since
-  every real root of every `pⱼ` is a real root of `P`), and the
-  zero-detection at root-point cells is correct by definition of
-  `gⱼ := gcd(pⱼ, P)`.
+  every real root of every `pⱼ` is a real root of `P`); the
+  zero-detection at root-point cells is correct because
+  `gⱼ := gcd(pⱼ, P)` has the same real roots as the intersection
+  of `pⱼ`'s and `P`'s real roots, and the
+  `mobiusTransform_root_correspondence` + Descartes corollaries
+  certify the "root in `Iᵢ`?" check.
 - **Cell-decomposition completeness.** Every real number lies in
   exactly one cell of the `P`-decomposition. Follows from
   `isolate?_correct` applied to `P`: every real root of `P` is

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -7,7 +7,8 @@ real variable, with universal/existential quantifiers over `ℝ` or
 over bounded dyadic intervals.
 
 Reflective implementation: reify the goal to a `Formula` AST,
-isolate roots of every polynomial appearing in the formula via
+form the squarefree product of every polynomial appearing in the
+formula, isolate its roots via
 [hex-real-roots](hex-real-roots.md), build the **sign matrix** over
 the resulting cell decomposition of `ℝ`, evaluate the Boolean on
 each cell, check the quantifier, and close the goal via a
@@ -30,7 +31,7 @@ Goal forms:
 ∃ x : ℝ,                             …
 ∀ x : ℝ, q(x) ≥ 0 →                  p(x) > 0
 ∀ x ∈ Set.Ioc a b,                   p(x) ⊳ 0           -- a, b : Dyadic
-∃ x ∈ Set.Icc a b,                   p(x) = 0           -- root in interval
+∃ x ∈ Set.Ioc a b,                   p(x) = 0           -- root in interval
 ```
 
 The atoms `pᵢ ⊳ᵢ 0` use `pᵢ ∈ ℤ[x]` (or `ℚ[x]`, cleared to `ℤ[x]`)
@@ -63,6 +64,13 @@ loop forever) on any goal it cannot decide. Cases:
 - **Goals with an unprovable conclusion.** The tactic only emits
   "yes" answers; it does not produce a counterexample-style
   rejection. On unprovable goals, it falls through silently.
+- **Bounded quantifiers over `Set.Icc` or `Set.Ioo`.** The tactic
+  natively decides only `Set.Ioc a b` quantification (matching
+  `hex-real-roots`'s half-open isolation convention). Users with
+  closed- or open-interval goals reduce to half-open by evaluating
+  endpoints — e.g. `∃ x ∈ Set.Icc a b, p(x) = 0` becomes
+  `p(a) = 0 ∨ ∃ x ∈ Set.Ioc a b, p(x) = 0`. Future work could
+  encode endpoint-closure in the AST; out of scope for v1.
 
 Falling through is implemented as the tactic raising
 `MetaM`-failure with a clear message; downstream tactics
@@ -97,6 +105,8 @@ The tactic implements 1-dimensional CAD:
       -- is the bound x.
       | forallReal     (φ : Formula)
       | existsReal     (φ : Formula)
+      -- Bounded quantifiers range over `Set.Ioc a b`, matching
+      -- `hex-real-roots`'s half-open isolation convention.
       | forallInterval (a b : Dyadic) (φ : Formula)
       | existsInterval (a b : Dyadic) (φ : Formula)
 
@@ -114,29 +124,53 @@ The tactic implements 1-dimensional CAD:
 3. **Collect atoms' polynomials.** Walk `formula` and gather every
    `pᵢ ∈ ZPoly` appearing in an `Atom.poly pᵢ cmpᵢ`.
 
-4. **Isolate roots** of each `pᵢ` via
-   `Hex.isolate pᵢ ⟨HasOnlySimpleRealRoots pᵢ proof⟩ prec`. For
-   `pᵢ` with multiple real roots, squarefree-ify first
-   (`pᵢ_sf := pᵢ / gcd(pᵢ, pᵢ')`) — multiplicities don't affect
-   sign analysis.
+4. **Form the squarefree product** `P := squarefreePart (∏ᵢ pᵢ)`,
+   computed as `(∏ᵢ pᵢ) / gcd(∏ᵢ pᵢ, (∏ᵢ pᵢ)')`. The real roots of
+   `P` are precisely the union of the real roots of all `pᵢ`, with
+   multiplicity 1 each (shared roots across atoms collapse into a
+   single root of `P`; multiplicities within a single `pᵢ` are
+   killed by the squarefree quotient). Then call
+   `Hex.isolate? P hP_simple targetPrecision`, where
+   `hP_simple : Hex.HasOnlySimpleRealRoots P` is automatic from the
+   squarefree-by-construction `P`. If the call returns `none`,
+   raise `targetPrecision` (e.g. to `Hex.realRootSeparation P`,
+   where the bridge guarantees `some`) and retry. The result is a
+   pairwise-disjoint array of `RealRootIsolation P`.
 
-5. **Build the cell decomposition.** Take the union of all root-
-   isolating intervals; sort by lower endpoint; refine until all
-   intervals are pairwise disjoint and ordered. The result is a
-   finite sequence of dyadic test points
-   `t₀ < t₁ < … < tₘ` where each `tᵢ` is interior to a unique cell:
+5. **Build the cell decomposition.** Use the `isolate?` output for
+   `P` directly. Sort isolations by lower endpoint; the cells are:
 
    ```
    (−∞, root₁), {root₁}, (root₁, root₂), {root₂}, …, (rootₖ, +∞)
    ```
 
-   Each "open interval" cell has a sign-constant interior (no root
-   of any `pⱼ` lies in it). Each "root point" cell has a known
-   sign (zero) for the relevant `pⱼ`s.
+   Each "open interval" cell has a sign-constant interior for
+   *every* `pⱼ` (an interior point cannot be a root of any `pⱼ`,
+   else it would be a root of `P`). Each "root point" cell is a
+   root of some subset of the `pⱼ`s (those `pⱼ` having that real
+   root). Test points: any dyadic rational in the open-interval
+   cell (e.g. midpoint of consecutive isolation upper/lower
+   bounds); for root-point cells, the cell *is* the root.
 
 6. **Sign matrix.** For each cell, evaluate the integer sign of
-   each `pⱼ` at the cell's representative point. The result is a
-   `m × k` matrix of signs `{−1, 0, +1}`.
+   each `pⱼ` at the cell's representative point.
+   - Open-interval cells: evaluate `pⱼ` at the dyadic test point.
+     The result is in `{−1, +1}` (never zero: a zero would mean
+     the test point is a root of `pⱼ`, hence of `P`, hence not
+     interior to the cell).
+   - Root-point cells: the cell is a real root `r` of `P`. The
+     relevant `pⱼ`s with `pⱼ(r) = 0` are determined at the
+     polynomial level: `pⱼ(r) = 0` iff `r` is a root of
+     `gcd(pⱼ, P)`. Precompute `gⱼ := gcd(pⱼ, P)` for each `j`,
+     and isolate the roots of each `gⱼ`; root-point cell `r` has
+     `sign pⱼ(r) = 0` iff some isolation of `gⱼ` contains the
+     same `RealRoot P`-equivalence-class as `r`. For `pⱼ` with
+     `pⱼ(r) ≠ 0`, the sign at `r` equals `sign pⱼ` on either of
+     the two adjacent open-interval cells (which agree because no
+     root of `pⱼ` lies between them other than possibly `r`
+     itself).
+
+   The result is a `m × k` matrix of signs `{−1, 0, +1}`.
 
 7. **Boolean evaluation.** For each cell, substitute the per-`pⱼ`
    sign into each `Atom.poly pⱼ cmpⱼ`'s comparison, getting `True`
@@ -177,21 +211,27 @@ through:
 
 - **Sign-matrix correctness.** For each cell, the signs are correct
   at *every* point in the cell (not just the representative). This
-  follows because each `pⱼ` is sign-constant on cell interiors
-  (between consecutive roots) by IVT, and sign-zero at cell-points
-  (which are roots).
+  follows because each `pⱼ` is sign-constant on cell interiors (no
+  `pⱼ` has a root strictly between consecutive `P`-roots, since
+  every real root of every `pⱼ` is a real root of `P`), and the
+  zero-detection at root-point cells is correct by definition of
+  `gⱼ := gcd(pⱼ, P)`.
 - **Cell-decomposition completeness.** Every real number lies in
-  exactly one cell. Follows from the union-of-isolations being a
-  partition of `ℝ`.
+  exactly one cell of the `P`-decomposition. Follows from
+  `isolate?_correct` applied to `P`: every real root of `P` is
+  isolated by exactly one interval, the intervals are pairwise
+  disjoint, and the open-interval cells between consecutive
+  isolations (plus the two tails) partition `ℝ ∖ {real roots of P}`.
 - **Boolean evaluation correctness.** Substituting signs into atoms
   gives the correct truth value at every point in the cell.
 - **Quantifier correctness.** ∀/∃ on cells lifts to ∀/∃ on `ℝ`
   because cells partition `ℝ` and the inner Prop is constant on
   each cell.
 
-Imports: `hex-real-roots-mathlib`'s `isolate_correct` and the
+Imports: `hex-real-roots-mathlib`'s `isolate?_correct` and the
 Möbius-transform-correspondence theorem; Mathlib's IVT,
-`Polynomial.aeval`, ordered-field structure on `ℝ`.
+`Polynomial.aeval`, ordered-field structure on `ℝ`,
+`Polynomial.gcd` over `ℤ[x]`.
 
 The library does **not** prove completeness (that every valid
 univariate ℝ-CF formula is decided correctly). Tarski–Seidenberg
@@ -274,9 +314,12 @@ For a goal with `k` distinct polynomials of total degree `n` and
 sup-norm `‖·‖∞`:
 
 - **Reification:** linear in goal size.
-- **Root isolation** of all `k` polynomials: `O(k · n^4 · log² ‖·‖∞)`
-  bit operations (Uspensky's worst case, per `hex-real-roots.isolate`).
-- **Cell decomposition:** `O(k · n)` cells; sort `O(k·n log(k·n))`.
+- **Squarefree product** `P := squarefreePart (∏ pⱼ)`: degree `≤ k·n`,
+  computation dominated by polynomial gcd.
+- **Root isolation** of `P`: `O((k·n)^4 · log² ‖P‖∞)` bit operations
+  (Uspensky's worst case, per `hex-real-roots.isolate?`).
+- **Cell decomposition:** `O(k·n)` cells (one per real root of `P`,
+  plus open-interval cells between them).
 - **Sign matrix:** `O(k · n²)` polynomial evaluations.
 - **Boolean evaluation:** `O(k · |formula|)` per cell.
 - **Total:** dominated by root isolation, roughly

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -213,24 +213,24 @@ the tactic name does not commit to which root-isolation algorithm
 
 ## Layered file organisation
 
-- `HexRcf/Formula.lean` — the AST (`Atom`, `Formula`,
+- `HexRCF/Formula.lean` — the AST (`Atom`, `Formula`,
   `AtomCmp`); `Formula.toProp` Prop semantics; `decide_rcf`
   driver.
-- `HexRcf/CellDecomposition.lean` — union-of-isolations cell
+- `HexRCF/CellDecomposition.lean` — union-of-isolations cell
   construction; representative-point selection; cell-set invariants.
-- `HexRcf/SignMatrix.lean` — per-cell, per-atom sign evaluation;
+- `HexRCF/SignMatrix.lean` — per-cell, per-atom sign evaluation;
   Boolean evaluation of `Formula` against the sign matrix.
-- `HexRcf/QuantifierCheck.lean` — ∀/∃ checks (full ℝ + bounded
+- `HexRCF/QuantifierCheck.lean` — ∀/∃ checks (full ℝ + bounded
   intervals); cell-intersection logic.
-- `HexRcf/Soundness.lean` — `rcf_decide_sound` and supporting
+- `HexRCF/Soundness.lean` — `rcf_decide_sound` and supporting
   lemmas (sign-matrix correctness, cell-decomposition completeness,
   Boolean and quantifier soundness).
-- `HexRcf/Reflect.lean` — `MetaM`/`Qq` reification; tactic
+- `HexRCF/Reflect.lean` — `MetaM`/`Qq` reification; tactic
   driver; `MetaM`-failure paths for out-of-fragment input.
-- `HexRcf/Tactic.lean` — the user-facing `rcf` tactic
+- `HexRCF/Tactic.lean` — the user-facing `rcf` tactic
   registration.
-- `HexRcf/Conformance.lean`, `HexRcf/Bench.lean`,
-  `HexRcf/EmitFixtures.lean` — standard testing trio.
+- `HexRCF/Conformance.lean`, `HexRCF/Bench.lean`,
+  `HexRCF/EmitFixtures.lean` — standard testing trio.
 
 ## Conformance fixtures
 

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -1,4 +1,4 @@
-# hex-sturm (Sturm-based decision procedure for univariate ℝ-formulas, depends on hex-real-roots + hex-real-roots-mathlib + hex-poly-z + hex-poly-z-mathlib + Mathlib)
+# hex-rcf (decision procedure for univariate real-closed-field formulas, depends on hex-real-roots + hex-real-roots-mathlib + hex-poly-z + hex-poly-z-mathlib + Mathlib)
 
 A Lean tactic providing a **complete decision procedure** for the
 univariate fragment of real-closed-field arithmetic. Closes goals
@@ -12,15 +12,16 @@ isolate roots of every polynomial appearing in the formula via
 the resulting cell decomposition of `ℝ`, evaluate the Boolean on
 each cell, check the quantifier, and close the goal via a
 soundness-of-reflection lemma proved in this same library. No
-separate Mathlib bridge — `hex-sturm` is `mathlib: true` because
-the tactic targets `ℝ`.
+separate Mathlib bridge — `hex-rcf` is `mathlib: true` because the
+tactic targets `ℝ`.
 
 This is the user-facing payoff of the algebraic-numbers stack:
 neither `polyrith` nor `nlinarith` is complete on this fragment,
-and `decide` is unavailable for `ℝ`-quantifiers. `sturm` decides
-the entire univariate fragment of the theory of real-closed fields.
+and `decide` is unavailable for `ℝ`-quantifiers. `hex-rcf` decides
+the entire univariate fragment of the theory of real-closed fields
+(per Tarski 1948).
 
-## What `sturm` decides
+## What `rcf` decides
 
 Goal forms:
 
@@ -44,10 +45,9 @@ Concrete examples the tactic closes:
 ∀ x : ℝ, 0 < x →                          x + 1/x ≥ 2
 ∀ x : ℝ, x² ≤ 1 →                         x⁴ − x² ≤ 0
 ∃ x : ℝ, x³ − x − 1 = 0   ∧   1 < x ∧ x < 2
-∀ x : ℝ, p(x) ≠ 0    -- for any specific squarefree p
 ```
 
-## What `sturm` does NOT decide (and how it falls through)
+## What `rcf` does NOT decide (and how it falls through)
 
 The tactic must **fall through** (not produce a wrong proof, not
 loop forever) on any goal it cannot decide. Cases:
@@ -153,7 +153,7 @@ The tactic implements 1-dimensional CAD:
 
 9. **Reflection.** The decision result `true`/`false` is reflected
    back to the original goal via the soundness lemma
-   `sturm_decide_sound` (below). On `true`, the tactic emits a
+   `rcf_decide_sound` (below). On `true`, the tactic emits a
    proof. On `false`, the tactic emits no proof and falls through —
    it does not negate the goal.
 
@@ -164,11 +164,11 @@ def Formula.toProp : Formula → Prop
   -- Evaluate the AST against ℝ-valued atoms, with quantifiers
   -- ranging over ℝ (or the specified Dyadic interval).
 
-def decide_sturm : Formula → Bool
+def decide_rcf : Formula → Bool
   -- Run the algorithm above; return whether the formula is valid.
 
-theorem sturm_decide_sound :
-    ∀ (φ : Formula), decide_sturm φ = true → φ.toProp
+theorem rcf_decide_sound :
+    ∀ (φ : Formula), decide_rcf φ = true → φ.toProp
 ```
 
 This is the **soundness lemma**: every "yes" answer produces a
@@ -189,49 +189,48 @@ through:
   because cells partition `ℝ` and the inner Prop is constant on
   each cell.
 
-Imports: `hex-real-roots-mathlib`'s `isolate_correct` and
-`sturm_count_eq_real_root_count`; Mathlib's `IVT`,
+Imports: `hex-real-roots-mathlib`'s `isolate_correct` and the
+Möbius-transform-correspondence theorem; Mathlib's IVT,
 `Polynomial.aeval`, ordered-field structure on `ℝ`.
 
 The library does **not** prove completeness (that every valid
 univariate ℝ-CF formula is decided correctly). Tarski–Seidenberg
-and the completeness of Sturm's theorem give this for free, but
-the tactic only ever emits "yes" answers; "no" answers are never
-emitted as Lean proofs (the tactic falls through). So soundness is
-sufficient for tactic correctness.
+gives this for free, but the tactic only ever emits "yes" answers;
+"no" answers are never emitted as Lean proofs (the tactic falls
+through). So soundness is sufficient for tactic correctness.
 
 ## Tactic surface
 
 ```lean
-example : ∀ x : ℝ, x^2 + 1 > 0 := by sturm
-example : ∀ x : ℝ, 0 < x → x + 1/x ≥ 2 := by sturm
-example : ∃ x : ℝ, x^3 - x - 1 = 0 ∧ 1 < x ∧ x < 2 := by sturm
+example : ∀ x : ℝ, x^2 + 1 > 0 := by rcf
+example : ∀ x : ℝ, 0 < x → x + 1/x ≥ 2 := by rcf
+example : ∃ x : ℝ, x^3 - x - 1 = 0 ∧ 1 < x ∧ x < 2 := by rcf
 ```
 
-The exact tactic name (`sturm`, `decide_sturm`, or another) is
-chosen at implementation time per Mathlib's tactic-naming
-conventions.
+Tactic name: `rcf` (for "real-closed field"). Algorithm-neutral —
+the tactic name does not commit to which root-isolation algorithm
+`hex-real-roots` uses internally.
 
 ## Layered file organisation
 
-- `HexSturm/Formula.lean` — the AST (`Atom`, `Formula`,
-  `AtomCmp`); `Formula.toProp` Prop semantics; `decide_sturm`
+- `HexRcf/Formula.lean` — the AST (`Atom`, `Formula`,
+  `AtomCmp`); `Formula.toProp` Prop semantics; `decide_rcf`
   driver.
-- `HexSturm/CellDecomposition.lean` — union-of-isolations cell
+- `HexRcf/CellDecomposition.lean` — union-of-isolations cell
   construction; representative-point selection; cell-set invariants.
-- `HexSturm/SignMatrix.lean` — per-cell, per-atom sign evaluation;
+- `HexRcf/SignMatrix.lean` — per-cell, per-atom sign evaluation;
   Boolean evaluation of `Formula` against the sign matrix.
-- `HexSturm/QuantifierCheck.lean` — ∀/∃ checks (full ℝ + bounded
+- `HexRcf/QuantifierCheck.lean` — ∀/∃ checks (full ℝ + bounded
   intervals); cell-intersection logic.
-- `HexSturm/Soundness.lean` — `sturm_decide_sound` and supporting
+- `HexRcf/Soundness.lean` — `rcf_decide_sound` and supporting
   lemmas (sign-matrix correctness, cell-decomposition completeness,
   Boolean and quantifier soundness).
-- `HexSturm/Reflect.lean` — `MetaM`/`Qq` reification; tactic
+- `HexRcf/Reflect.lean` — `MetaM`/`Qq` reification; tactic
   driver; `MetaM`-failure paths for out-of-fragment input.
-- `HexSturm/Tactic.lean` — the user-facing `sturm` tactic
+- `HexRcf/Tactic.lean` — the user-facing `rcf` tactic
   registration.
-- `HexSturm/Conformance.lean`, `HexSturm/Bench.lean`,
-  `HexSturm/EmitFixtures.lean` — standard testing trio.
+- `HexRcf/Conformance.lean`, `HexRcf/Bench.lean`,
+  `HexRcf/EmitFixtures.lean` — standard testing trio.
 
 ## Conformance fixtures
 
@@ -259,7 +258,11 @@ Per [SPEC/testing.md](../testing.md):
   formula evaluation, or Mathematica's `Reduce`.
 - *local* (developer-driven): high-degree adversarial families
   (Mignotte-near-zero polynomials, polynomials with extremely close
-  roots requiring high-precision sign matrix).
+  roots requiring high-precision sign matrix). Note: these stress
+  `hex-real-roots`'s Uspensky algorithm, which has known
+  performance pathologies on tight clusters; bench-driven
+  validation that the tactic still terminates within budget on
+  these cases.
 
 External oracles: SageMath (`Reduce`-equivalent via
 `QQbar`-based real-root analysis); Mathematica (`Reduce`,
@@ -271,16 +274,19 @@ For a goal with `k` distinct polynomials of total degree `n` and
 sup-norm `‖·‖∞`:
 
 - **Reification:** linear in goal size.
-- **Root isolation** of all `k` polynomials: `O(k · n³ · log ‖·‖∞)`
-  bit operations (`hex-real-roots.isolate` per polynomial).
+- **Root isolation** of all `k` polynomials: `O(k · n^4 · log² ‖·‖∞)`
+  bit operations (Uspensky's worst case, per `hex-real-roots.isolate`).
 - **Cell decomposition:** `O(k · n)` cells; sort `O(k·n log(k·n))`.
 - **Sign matrix:** `O(k · n²)` polynomial evaluations.
 - **Boolean evaluation:** `O(k · |formula|)` per cell.
 - **Total:** dominated by root isolation, roughly
-  `O(k · n³ · log ‖·‖∞)`.
+  `O(k · n^4 · log² ‖·‖∞)`.
 
 For typical user goals (`k ≤ 5`, `n ≤ 10`, small coefficients) the
-tactic should complete in under a second.
+tactic should complete in under a second. Mignotte-cluster
+adversarial cases are bounded by `hex-real-roots`'s
+`realRootSeparation` — sub-second for moderate inputs but degrades
+gracefully on high-degree pathological clusters.
 
 ## Time budgets (Phase 4 validation)
 
@@ -294,8 +300,9 @@ tactic should complete in under a second.
   Geometry.* RAND Corp, 1948 (republished by Univ. California
   Press, 1951). The foundational decidability result for the
   theory of real-closed fields.
-- Sturm 1829, Marden 1966 — see [hex-real-roots](hex-real-roots.md)
-  §"References".
+- Descartes 1637 / Uspensky 1948 / Akritas–Strzeboński 2008 — see
+  [hex-real-roots](hex-real-roots.md) §"References" for the
+  underlying root-isolation algorithm.
 - Basu, S.; Pollack, R.; Roy, M.-F. *Algorithms in Real Algebraic
   Geometry.* Springer, 2nd ed., 2006. Algorithm 10.13 (Sign
   Determination at the Roots) and Chapter 13 (CAD) cover the

--- a/SPEC/Libraries/hex-rcf.md
+++ b/SPEC/Libraries/hex-rcf.md
@@ -160,28 +160,27 @@ The tactic implements 1-dimensional CAD:
    real root of some subset of the `pⱼ`s (those for which `pⱼ` has
    that real root).
 
-   Concrete test points for **open** cells: midpoint of
+   Open cells carry an explicit dyadic test point: midpoint of
    `(bᵢ, aᵢ₊₁]` for the central open cells; `−M − 1` for
-   `OpenLeftTail`; `M + 1` for `OpenRightTail`. **`RootPoint Iᵢ`
-   cells have no test point** — they represent an unknown root
-   `rᵢ ∈ (aᵢ, bᵢ]`, and step 6 determines their sign assignments
-   via the `gⱼ := gcd(pⱼ, P)` mechanism instead of point evaluation.
+   `OpenLeftTail`; `M + 1` for `OpenRightTail`. `RootPoint Iᵢ`
+   cells represent the unknown root `rᵢ ∈ (aᵢ, bᵢ]`; their sign
+   assignments come from the `gⱼ := gcd(pⱼ, P)` mechanism in
+   step 6.
 
 6. **Sign matrix.** For each cell, determine `sign pⱼ` on the cell:
    - Open-interval cells (and tails): evaluate `pⱼ` at the dyadic
-     test point. The result is in `{−1, +1}` (never zero: a zero
-     would make the test point a root of `pⱼ`, hence of `P`, hence
-     not interior to the cell).
+     test point. The result is in `{−1, +1}`: every root of `pⱼ`
+     is a root of `P`, and the test point is interior to the cell.
    - Root-point cells `RootPoint Iᵢ` representing `rᵢ`: precompute
      `gⱼ := gcd(pⱼ, P)`. Then `pⱼ(rᵢ) = 0` iff `gⱼ` has a real
      root in the isolation interval `Iᵢ`. Decide this by computing
-     `signVariations` of `gⱼ`'s Möbius transform on `Iᵢ`: if `≥ 1`,
-     `gⱼ` has a root in `Iᵢ` (it is `rᵢ`, since `gⱼ ∣ P` and `Iᵢ`
-     contains exactly one `P`-root); if `= 0`, no root, so
-     `pⱼ(rᵢ) ≠ 0`. When `pⱼ(rᵢ) ≠ 0`, the sign at `rᵢ` equals
-     `sign pⱼ` on either of the two adjacent open-interval cells
-     (which agree, because no root of `pⱼ` lies between them other
-     than possibly `rᵢ` itself).
+     `signVariations` of `gⱼ`'s Möbius transform on `Iᵢ`: `≥ 1`
+     means `gⱼ` has a root in `Iᵢ` (which equals `rᵢ`, since
+     `gⱼ ∣ P` and `Iᵢ` contains exactly one `P`-root); `= 0`
+     means `pⱼ(rᵢ) ≠ 0`. When `pⱼ(rᵢ) ≠ 0`, the sign at `rᵢ`
+     equals `sign pⱼ` on either of the two adjacent open-interval
+     cells (which agree, since `pⱼ`'s only possible root between
+     them is `rᵢ` itself).
 
    The result is a `m × k` matrix of signs `{−1, 0, +1}`.
 

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -59,41 +59,54 @@ interval.
     denominators. -/
 def mobiusTransform (p : ZPoly) (a b : Dyadic) : ZPoly := …
 
-/-- Möbius transform sends positive reals to (a, b) bijectively
-    (preserving multiplicity for polynomial roots). -/
+/-- Möbius transform sends positive reals to (a, b) bijectively, with
+    multiplicities. Stated as a multiset equality on real roots: the
+    positive real roots of `p_M` (with multiplicity) correspond, via
+    `s ↦ (b − s)/(s − a)`, to the real roots of `p` in `(a, b)` (with
+    multiplicity). -/
 theorem mobiusTransform_root_correspondence
     (p : ZPoly) (a b : Dyadic) (hab : a < b) :
-    ∀ r : ℝ,
-      (toPolynomial (mobiusTransform p a b)).aeval r = 0 ∧ 0 < r
-        ↔ ∃ s : ℝ, (a : ℝ) < s ∧ s < (b : ℝ) ∧
-                   (toPolynomial p).aeval s = 0
-                   -- with multiplicity preserved
+    let pℝ  := (toPolynomial p).map (Int.castRingHom ℝ)
+    let pMℝ := (toPolynomial (mobiusTransform p a b)).map (Int.castRingHom ℝ)
+    pMℝ.roots.filter (0 < ·)
+      = (pℝ.roots.filter (fun s => (a : ℝ) < s ∧ s < (b : ℝ))).map
+          (fun s => ((b : ℝ) - s) / (s - (a : ℝ)))
 ```
 
 ### Descartes count → exact-1 corollary
 
-Mathlib's `roots_countP_pos_le_signVariations` gives `≤`; we need
-the parity argument to derive `signVariations = 1 ⟹ count = 1`.
+Mathlib's `roots_countP_pos_le_signVariations` is stated for
+`Polynomial R` over a linearly ordered ring `R`; instantiated at
+`R = ℤ` it counts integer roots, but for the bridge we need real
+roots. The corollaries are stated over `q.map (Int.castRingHom ℝ)`:
 
 ```lean
-theorem signVariations_eq_one_implies_one_positive_root
+theorem signVariations_eq_one_implies_one_positive_real_root
     (q : Polynomial ℤ) (hsv : q.signVariations = 1) :
-    q.roots.countP (0 < ·) = 1
-  -- Proof: count ≤ 1 (Mathlib), count ≡ 1 (mod 2) (parity, also
-  -- in `roots_countP_pos_le_signVariations`'s context), so count = 1.
+    ((q.map (Int.castRingHom ℝ)).roots.filter (0 < ·)).card = 1
+  -- Proof: signVariations is preserved by the cast (auxiliary
+  -- lemma below), so `(q.map ...).signVariations = 1`. Mathlib's
+  -- `roots_countP_pos_le_signVariations` over ℝ gives count ≤ 1.
+  -- The parity strengthening (count ≡ signVariations mod 2) gives
+  -- count = 1.
 
-theorem signVariations_eq_zero_implies_no_positive_roots
+theorem signVariations_eq_zero_implies_no_positive_real_roots
     (q : Polynomial ℤ) (hsv : q.signVariations = 0) :
-    q.roots.countP (0 < ·) = 0
-  -- Mathlib: count ≤ 0.
+    ((q.map (Int.castRingHom ℝ)).roots.filter (0 < ·)).card = 0
+  -- Mathlib over ℝ: count ≤ 0, plus signVariations cast-invariance.
 ```
 
-The parity lemma `count ≡ signVariations (mod 2)` is the standard
-strengthening of Descartes' rule; if Mathlib's
-`RuleOfSigns.lean` has it, cite directly; otherwise this is a small
-local lemma (~30 lines) building on
-`roots_countP_pos_le_signVariations` and standard parity arguments
-on sign sequences.
+Two auxiliary lemmas these depend on:
+
+- **`signVariations` cast-invariance**: `(q.map (Int.castRingHom ℝ)).signVariations = q.signVariations`.
+  `signVariations` reads off the sign sequence of nonzero
+  coefficients; `Int.castRingHom ℝ` is sign-preserving and
+  injective, so the two sequences agree. If Mathlib has a generic
+  `signVariations_map` for sign-preserving ring homs, cite directly;
+  otherwise local lemma.
+- **Parity strengthening**: `count ≡ signVariations (mod 2)`. The
+  standard companion to Descartes' rule; if Mathlib's
+  `RuleOfSigns.lean` has it, cite directly, otherwise local.
 
 ### LMQ bound correctness
 
@@ -164,7 +177,7 @@ the minimum gap between distinct real roots, so each interval can
 contain at most one root, so `signVariations ≤ 1` for each, so the
 worklist drains. The second follows from
 `mobiusTransform_root_correspondence` +
-`signVariations_eq_one_implies_one_positive_root` (and the
+`signVariations_eq_one_implies_one_positive_real_root` (and the
 zero-variations corollary) + the bisection driver's invariants.
 
 ### Refinement correctness
@@ -194,8 +207,11 @@ theorem out_real_eq (s : SimpleRealRoot p) (prec₁ prec₂ : Nat) :
 - The Möbius-transform-correspondence theorem
   (`mobiusTransform_root_correspondence`). Uses `Polynomial.comp`
   and standard substitution machinery.
-- The exact-1-from-signVariations parity corollary if not already
-  in Mathlib.
+- `signVariations` cast-invariance: `(q.map (Int.castRingHom ℝ)).signVariations = q.signVariations`.
+  Local lemma if Mathlib lacks a generic
+  sign-preserving-ring-hom version.
+- The exact-1-from-signVariations parity corollary, stated over the
+  real-cast polynomial.
 - `lmqBound_bounds_positive_real_roots`. New theorem (Mathlib has
   Cauchy but not LMQ).
 - `realRootSeparation_bounds_min_gap`. Wraps Mahler measure

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -1,35 +1,43 @@
-# hex-real-roots-mathlib (depends on hex-real-roots + hex-poly-z-mathlib + hex-resultant-mathlib + Mathlib)
+# hex-real-roots-mathlib (depends on hex-real-roots + hex-poly-z-mathlib + Mathlib)
 
 Mathlib bridge for [hex-real-roots](hex-real-roots.md). Proves
-correctness of the certified real root isolation against Mathlib's
-`Polynomial ℤ` and `ℝ`-root semantics.
+correctness of the certified real-root isolation against Mathlib's
+`Polynomial ℤ` and `ℝ`-root semantics. Uspensky's algorithm
+(Descartes + Möbius bisection) — the bridge rides on Mathlib's
+existing `Polynomial.signVariations` infrastructure rather than
+formalising Sturm's theorem from scratch.
 
 ## What we cite from Mathlib (no work)
 
 - `Polynomial.IsRoot`, `Polynomial.roots`, `Polynomial.aroots`.
 - `Polynomial.derivative`, `Polynomial.gcd`, `Polynomial.Squarefree`.
-- The cast `Polynomial.eval₂` from `Polynomial ℤ` to `ℝ`-valued
-  evaluation.
-- `Real`'s ordered-field structure (signs, comparisons,
-  Intermediate Value Theorem).
-- `EuclideanDomain.gcd` over `ℤ[x]`.
+- `Polynomial.eval₂` for `Polynomial ℤ → ℝ`-valued evaluation.
+- `Polynomial.cauchyBound` and `Polynomial.IsRoot.norm_lt_cauchyBound`
+  from `Mathlib.Analysis.Polynomial.CauchyBound`.
+- `Polynomial.signVariations` and the main theorem
+  `Polynomial.roots_countP_pos_le_signVariations` from
+  `Mathlib.Algebra.Polynomial.RuleOfSigns`.
+- `Polynomial.comp` for polynomial composition (used to express
+  Möbius transforms).
+- `Polynomial.mahlerMeasure_le_sqrt_sum_sq_norm_coeff` (Landau)
+  and `Polynomial.norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure`
+  (Mignotte) from `Mathlib.Analysis.Polynomial.MahlerMeasure`.
+- `Real`'s ordered-field structure and Intermediate Value Theorem
+  (`intermediate_value_Icc` etc.).
 
 ## Bridging theorems
 
 ### `SimpleRealRoot p` semantics
 
 ```lean
-/-- The real number corresponding to a real-root isolation: any
-    point in the interval, made canonical by refinement to a target
-    precision and centred-residue choice. The Mathlib version does
-    *not* depend on the specific refinement; it picks out the
-    unique real root in the isolation's interval. -/
+/-- The real number corresponding to a real-root isolation. The
+    Mathlib version does *not* depend on the specific refinement; it
+    picks out the unique real root in the isolation's interval. -/
 def SimpleRealRoot.toReal {p : ZPoly} (s : SimpleRealRoot p) : ℝ
 
 theorem SimpleRealRoot.toReal_isRoot {p : ZPoly} (s : SimpleRealRoot p)
     (hp : Hex.HasOnlySimpleRealRoots p) :
     (toPolynomial p).aeval s.toReal = 0
-  -- s.toReal is a real root of (toPolynomial p)
 
 theorem SimpleRealRoot.toReal_in_interval
     {p : ZPoly} (s : SimpleRealRoot p) (prec : Nat) :
@@ -41,41 +49,69 @@ theorem SimpleRealRoot.injective_to_real
     Function.Injective (SimpleRealRoot.toReal (p := p))
 ```
 
-### Sturm's theorem
+### Descartes' rule of signs on Möbius transforms
 
-If Mathlib already has Sturm's theorem in a usable form, cite it.
-Otherwise, prove it inline (with attribution to any open Mathlib
-PR that's in flight). The contract:
+The core bridge theorem connecting `signVariations` of the
+Möbius-transformed polynomial to the real-root count of `p` in the
+interval.
 
 ```lean
-theorem sturm_count_eq_real_root_count
-    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p)
-    (a b : Dyadic) (ha : (toPolynomial p).aeval (a : ℝ) ≠ 0)
-    (hb : (toPolynomial p).aeval (b : ℝ) ≠ 0) (hab : a < b) :
-    sturmCount p ⟨a, b, hab⟩ =
-      ((toPolynomial p).roots.filter
-          (fun r => (a : ℝ) < r ∧ r ≤ (b : ℝ))).card
-  -- The integer Sturm count over (a, b] equals the number of real
-  -- roots in (a, b], counted with multiplicity (which is 1 for
-  -- squarefree p).
+/-- The integer Möbius transform of p relative to (a, b]:
+    p_M(x) := (1+x)^(deg p) · p(a + (b-a)/(1+x)) cleared of dyadic
+    denominators. -/
+def mobiusTransform (p : ZPoly) (a b : Dyadic) : ZPoly := …
+
+/-- Möbius transform sends positive reals to (a, b) bijectively
+    (preserving multiplicity for polynomial roots). -/
+theorem mobiusTransform_root_correspondence
+    (p : ZPoly) (a b : Dyadic) (hab : a < b) :
+    ∀ r : ℝ,
+      (toPolynomial (mobiusTransform p a b)).aeval r = 0 ∧ 0 < r
+        ↔ ∃ s : ℝ, (a : ℝ) < s ∧ s < (b : ℝ) ∧
+                   (toPolynomial p).aeval s = 0
+                   -- with multiplicity preserved
 ```
 
-Status of Mathlib's existing Sturm infrastructure should be checked
-at activation time. If absent, port inline per
-[PLAN/Conventions.md §"Library placement"](../../PLAN/Conventions.md)'s
-"inline with attribution" rule.
+### Descartes count → exact-1 corollary
 
-### `cauchyBound` correctness
+Mathlib's `roots_countP_pos_le_signVariations` gives `≤`; we need
+the parity argument to derive `signVariations = 1 ⟹ count = 1`.
+
+```lean
+theorem signVariations_eq_one_implies_one_positive_root
+    (q : Polynomial ℤ) (hsv : q.signVariations = 1) :
+    q.roots.countP (0 < ·) = 1
+  -- Proof: count ≤ 1 (Mathlib), count ≡ 1 (mod 2) (parity, also
+  -- in `roots_countP_pos_le_signVariations`'s context), so count = 1.
+
+theorem signVariations_eq_zero_implies_no_positive_roots
+    (q : Polynomial ℤ) (hsv : q.signVariations = 0) :
+    q.roots.countP (0 < ·) = 0
+  -- Mathlib: count ≤ 0.
+```
+
+The parity lemma `count ≡ signVariations (mod 2)` is the standard
+strengthening of Descartes' rule; if Mathlib's
+`RuleOfSigns.lean` has it, cite directly; otherwise this is a small
+local lemma (~30 lines) building on
+`roots_countP_pos_le_signVariations` and standard parity arguments
+on sign sequences.
+
+### Cauchy bound + LMQ bound correctness
 
 ```lean
 theorem cauchyBound_bounds_real_roots (p : ZPoly) :
     ∀ r : ℝ, (toPolynomial p).aeval r = 0 →
         |r| ≤ (Hex.cauchyBound p : ℝ)
-  -- |any real root of p| ≤ cauchyBound p
-```
+  -- Wraps Mathlib's `Polynomial.IsRoot.norm_lt_cauchyBound`.
 
-Standard Cauchy-bound proof: if `|r| > 1 + max|a_i|/|a_n|`, the
-leading term dominates and `p(r) ≠ 0`.
+theorem lmqBound_bounds_positive_real_roots (p : ZPoly) :
+    ∀ r : ℝ, (toPolynomial p).aeval r = 0 → 0 < r →
+        r ≤ (Hex.lmqBound p : ℝ)
+  -- Akritas-Strzeboński 2008 LMQ bound, stated for positive reals.
+  -- A new theorem (Mathlib has Cauchy but not LMQ); the proof is
+  -- a couple of pages following the original paper.
+```
 
 ### `realRootSeparation` correctness
 
@@ -87,9 +123,11 @@ theorem realRootSeparation_bounds_min_gap
         (2 : ℝ)^(-(Hex.realRootSeparation p : ℝ)) ≤ |r₁ - r₂|
 ```
 
-Mahler/Mignotte bound applied to real roots. Mathlib has Mahler
-measure infrastructure in `Mathlib.Analysis.Polynomial.MahlerMeasure`;
-Landau's inequality wraps as `mahlerMeasure_le_l2norm`.
+Mahler/Mignotte bound applied to real roots. Mathlib has the Mahler
+infrastructure (`mahlerMeasure_le_sqrt_sum_sq_norm_coeff`,
+`norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure`);
+the real-root specialisation needs a small wrapper combining Mahler
+with the discriminant/resultant lower bound. Days-to-week wrapper.
 
 ### `isolate` correctness
 
@@ -110,8 +148,10 @@ theorem isolate_correct
 ```
 
 Bijection between the isolation array and the (finite) set of real
-roots of `p`. Follows from `sturm_count_eq_real_root_count` plus the
-bisection-driver's invariants.
+roots of `p`. Follows from `mobiusTransform_root_correspondence` +
+`signVariations_eq_one_implies_one_positive_root` (and the
+zero-variations corollary) + the bisection driver's invariants +
+`realRootSeparation_bounds_min_gap` for termination.
 
 ### Refinement correctness
 
@@ -128,30 +168,44 @@ theorem out_real_eq (s : SimpleRealRoot p) (prec₁ prec₂ : Nat) :
 
 ## Mathlib gap analysis
 
-To verify when drafting; first-cut estimate from the theorem
-statements above:
-
 **Cite directly (no work expected):**
 - `Polynomial.IsRoot`, `Polynomial.roots` over `ℝ` and `ℤ`.
-- `Polynomial.derivative`, `Polynomial.gcd`.
-- Mahler measure infrastructure (`mahlerMeasure_le_l2norm`).
+- `Polynomial.derivative`, `Polynomial.gcd`, `Polynomial.comp`.
+- `Polynomial.cauchyBound` + bound-on-roots theorem.
+- `Polynomial.signVariations` + `roots_countP_pos_le_signVariations`
+  (Descartes' rule).
+- Mahler measure infrastructure (Landau + Mignotte coefficient bound).
 
-**Possibly build (verify status at activation time):**
-- A direct version of Sturm's theorem connecting integer-Sturm-
-  sequence sign counts to real-root counts. Mathlib may have
-  fragments; full theorem may need assembly.
-- The `realRootSeparation` bound: like `mahlerPrec` in
-  `hex-roots-mathlib`, this is a paper result (Mahler 1962 /
-  Mignotte 1982) restricted to real roots; Mathlib likely doesn't
-  have the closed form; port inline with attribution.
+**Build (verify status at activation time):**
+- The Möbius-transform-correspondence theorem
+  (`mobiusTransform_root_correspondence`). Likely a few pages of
+  proof; uses `Polynomial.comp` and standard substitution machinery.
+- The exact-1-from-signVariations parity corollary if not already
+  in Mathlib. Small wrapper.
+- `lmqBound_bounds_positive_real_roots`. New theorem (Mahlib has
+  Cauchy but not LMQ). Few pages.
+- `realRootSeparation_bounds_min_gap`. Small wrapper on Mahler
+  measure infrastructure.
+- `isolate_correct`. The main bridge theorem, assembled from the
+  above components plus the bisection driver's invariants.
+
+**Deliberately not built:**
+- Sturm's theorem and the Sturm sequence. Mathlib has neither;
+  formalising would be a multi-month side quest. Avoided by the
+  algorithm choice (Uspensky uses Descartes, which Mathlib does
+  have).
+- Vincent's theorem (would be needed for VCA/VAS algorithm
+  variants, which are out of scope).
 
 ## Layered file organisation
 
 ```
 HexRealRootsMathlib/
   Basic.lean        — toReal, Quotient bridge
-  Sturm.lean        — sturm_count_eq_real_root_count
-  Cauchy.lean       — cauchyBound_bounds_real_roots
+  Mobius.lean       — mobiusTransform_root_correspondence
+  Descartes.lean    — exact-1 parity corollary; sign-variation count
+                      ↔ root count theorems
+  Bounds.lean       — cauchyBound + lmqBound correctness
   Separation.lean   — realRootSeparation_bounds_min_gap
   Isolate.lean      — isolate_correct
   Conformance.lean  — fixture-based checks
@@ -159,7 +213,7 @@ HexRealRootsMathlib/
 
 ## References
 
-- Sturm 1829, Marden 1966, Basu-Pollack-Roy 2006 — see
+- Descartes, Uspensky, Akritas–Strzeboński 2008 (LMQ) — see
   [hex-real-roots](hex-real-roots.md) §"References".
 - For the Mahler/Mignotte bounds restricted to real roots: same
   sources as [hex-roots-mathlib](hex-roots-mathlib.md)'s `mahlerPrec`

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -1,0 +1,166 @@
+# hex-real-roots-mathlib (depends on hex-real-roots + hex-poly-z-mathlib + hex-resultant-mathlib + Mathlib)
+
+Mathlib bridge for [hex-real-roots](hex-real-roots.md). Proves
+correctness of the certified real root isolation against Mathlib's
+`Polynomial ℤ` and `ℝ`-root semantics.
+
+## What we cite from Mathlib (no work)
+
+- `Polynomial.IsRoot`, `Polynomial.roots`, `Polynomial.aroots`.
+- `Polynomial.derivative`, `Polynomial.gcd`, `Polynomial.Squarefree`.
+- The cast `Polynomial.eval₂` from `Polynomial ℤ` to `ℝ`-valued
+  evaluation.
+- `Real`'s ordered-field structure (signs, comparisons,
+  Intermediate Value Theorem).
+- `EuclideanDomain.gcd` over `ℤ[x]`.
+
+## Bridging theorems
+
+### `SimpleRealRoot p` semantics
+
+```lean
+/-- The real number corresponding to a real-root isolation: any
+    point in the interval, made canonical by refinement to a target
+    precision and centred-residue choice. The Mathlib version does
+    *not* depend on the specific refinement; it picks out the
+    unique real root in the isolation's interval. -/
+def SimpleRealRoot.toReal {p : ZPoly} (s : SimpleRealRoot p) : ℝ
+
+theorem SimpleRealRoot.toReal_isRoot {p : ZPoly} (s : SimpleRealRoot p)
+    (hp : Hex.HasOnlySimpleRealRoots p) :
+    (toPolynomial p).aeval s.toReal = 0
+  -- s.toReal is a real root of (toPolynomial p)
+
+theorem SimpleRealRoot.toReal_in_interval
+    {p : ZPoly} (s : SimpleRealRoot p) (prec : Nat) :
+    let iso := s.out prec
+    (iso.interval.lower : ℝ) < s.toReal ∧ s.toReal ≤ (iso.interval.upper : ℝ)
+
+theorem SimpleRealRoot.injective_to_real
+    {p : ZPoly} (hp : Hex.HasOnlySimpleRealRoots p) :
+    Function.Injective (SimpleRealRoot.toReal (p := p))
+```
+
+### Sturm's theorem
+
+If Mathlib already has Sturm's theorem in a usable form, cite it.
+Otherwise, prove it inline (with attribution to any open Mathlib
+PR that's in flight). The contract:
+
+```lean
+theorem sturm_count_eq_real_root_count
+    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p)
+    (a b : Dyadic) (ha : (toPolynomial p).aeval (a : ℝ) ≠ 0)
+    (hb : (toPolynomial p).aeval (b : ℝ) ≠ 0) (hab : a < b) :
+    sturmCount p ⟨a, b, hab⟩ =
+      ((toPolynomial p).roots.filter
+          (fun r => (a : ℝ) < r ∧ r ≤ (b : ℝ))).card
+  -- The integer Sturm count over (a, b] equals the number of real
+  -- roots in (a, b], counted with multiplicity (which is 1 for
+  -- squarefree p).
+```
+
+Status of Mathlib's existing Sturm infrastructure should be checked
+at activation time. If absent, port inline per
+[PLAN/Conventions.md §"Library placement"](../../PLAN/Conventions.md)'s
+"inline with attribution" rule.
+
+### `cauchyBound` correctness
+
+```lean
+theorem cauchyBound_bounds_real_roots (p : ZPoly) :
+    ∀ r : ℝ, (toPolynomial p).aeval r = 0 →
+        |r| ≤ (Hex.cauchyBound p : ℝ)
+  -- |any real root of p| ≤ cauchyBound p
+```
+
+Standard Cauchy-bound proof: if `|r| > 1 + max|a_i|/|a_n|`, the
+leading term dominates and `p(r) ≠ 0`.
+
+### `realRootSeparation` correctness
+
+```lean
+theorem realRootSeparation_bounds_min_gap
+    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p) :
+    ∀ r₁ r₂ : ℝ, (toPolynomial p).aeval r₁ = 0 →
+                 (toPolynomial p).aeval r₂ = 0 → r₁ ≠ r₂ →
+        (2 : ℝ)^(-(Hex.realRootSeparation p : ℝ)) ≤ |r₁ - r₂|
+```
+
+Mahler/Mignotte bound applied to real roots. Mathlib has Mahler
+measure infrastructure in `Mathlib.Analysis.Polynomial.MahlerMeasure`;
+Landau's inequality wraps as `mahlerMeasure_le_l2norm`.
+
+### `isolate` correctness
+
+```lean
+theorem isolate_correct
+    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p) (prec : Nat) :
+    let isolations := Hex.isolate p hp prec
+    -- (1) every real root of p has exactly one isolation:
+    (∀ r : ℝ, (toPolynomial p).aeval r = 0 →
+        ∃! iso ∈ isolations.toList,
+          (iso.interval.lower : ℝ) < r ∧ r ≤ (iso.interval.upper : ℝ)) ∧
+    -- (2) every isolation contains a real root of p:
+    (∀ iso ∈ isolations.toList,
+      ∃ r : ℝ, (toPolynomial p).aeval r = 0 ∧
+               (iso.interval.lower : ℝ) < r ∧ r ≤ (iso.interval.upper : ℝ)) ∧
+    -- (3) isolations are pairwise disjoint:
+    isolations.toList.Pairwise (fun a b => Disjoint a.interval b.interval)
+```
+
+Bijection between the isolation array and the (finite) set of real
+roots of `p`. Follows from `sturm_count_eq_real_root_count` plus the
+bisection-driver's invariants.
+
+### Refinement correctness
+
+```lean
+theorem refine_eq (s : SimpleRealRoot p) (target : Nat) :
+    s.refine target = s
+  -- propositional equality; the underlying representative changes
+  -- but the abstract identity is unchanged.
+
+theorem out_real_eq (s : SimpleRealRoot p) (prec₁ prec₂ : Nat) :
+    s.toReal = s.toReal
+  -- toReal does not depend on the precision used by out.
+```
+
+## Mathlib gap analysis
+
+To verify when drafting; first-cut estimate from the theorem
+statements above:
+
+**Cite directly (no work expected):**
+- `Polynomial.IsRoot`, `Polynomial.roots` over `ℝ` and `ℤ`.
+- `Polynomial.derivative`, `Polynomial.gcd`.
+- Mahler measure infrastructure (`mahlerMeasure_le_l2norm`).
+
+**Possibly build (verify status at activation time):**
+- A direct version of Sturm's theorem connecting integer-Sturm-
+  sequence sign counts to real-root counts. Mathlib may have
+  fragments; full theorem may need assembly.
+- The `realRootSeparation` bound: like `mahlerPrec` in
+  `hex-roots-mathlib`, this is a paper result (Mahler 1962 /
+  Mignotte 1982) restricted to real roots; Mathlib likely doesn't
+  have the closed form; port inline with attribution.
+
+## Layered file organisation
+
+```
+HexRealRootsMathlib/
+  Basic.lean        — toReal, Quotient bridge
+  Sturm.lean        — sturm_count_eq_real_root_count
+  Cauchy.lean       — cauchyBound_bounds_real_roots
+  Separation.lean   — realRootSeparation_bounds_min_gap
+  Isolate.lean      — isolate_correct
+  Conformance.lean  — fixture-based checks
+```
+
+## References
+
+- Sturm 1829, Marden 1966, Basu-Pollack-Roy 2006 — see
+  [hex-real-roots](hex-real-roots.md) §"References".
+- For the Mahler/Mignotte bounds restricted to real roots: same
+  sources as [hex-roots-mathlib](hex-roots-mathlib.md)'s `mahlerPrec`
+  proof, applied to the real subset.

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -124,12 +124,28 @@ infrastructure (`mahlerMeasure_le_sqrt_sum_sq_norm_coeff`,
 the real-root specialisation combines Mahler with the
 discriminant/resultant lower bound.
 
-### `isolate` correctness
+### `isolate?` correctness and termination
+
+Two theorems. `isolate?` is the executable, `Option`-returning
+driver from `hex-real-roots`; the bridge proves both that it
+returns `some` at sufficient precision and that the `some` payload
+is the correct isolation set.
 
 ```lean
-theorem isolate_correct
-    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p) (prec : Nat) :
-    let isolations := Hex.isolate p hp prec
+/-- At `targetPrecision ≥ realRootSeparation p`, `isolate?` always
+    succeeds. Bisection cannot stall at signVariations ≥ 2 once the
+    interval width drops below the real-root separation bound. -/
+theorem isolate?_succeeds_at_separation_precision
+    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p) :
+    Hex.isolate? p hp (Hex.realRootSeparation p) ≠ none
+
+/-- Every real root of p is isolated by exactly one returned
+    interval, every returned interval contains a real root, and the
+    intervals are pairwise disjoint. -/
+theorem isolate?_correct
+    (p : ZPoly) (hp : Hex.HasOnlySimpleRealRoots p)
+    (targetPrecision : Nat) (isolations : Array (RealRootIsolation p))
+    (hsome : Hex.isolate? p hp targetPrecision = some isolations) :
     -- (1) every real root of p has exactly one isolation:
     (∀ r : ℝ, (toPolynomial p).aeval r = 0 →
         ∃! iso ∈ isolations.toList,
@@ -142,11 +158,14 @@ theorem isolate_correct
     isolations.toList.Pairwise (fun a b => Disjoint a.interval b.interval)
 ```
 
-Bijection between the isolation array and the (finite) set of real
-roots of `p`. Follows from `mobiusTransform_root_correspondence` +
+The first follows from `realRootSeparation_bounds_min_gap`: at
+precision `realRootSeparation p`, every interval is narrower than
+the minimum gap between distinct real roots, so each interval can
+contain at most one root, so `signVariations ≤ 1` for each, so the
+worklist drains. The second follows from
+`mobiusTransform_root_correspondence` +
 `signVariations_eq_one_implies_one_positive_root` (and the
-zero-variations corollary) + the bisection driver's invariants +
-`realRootSeparation_bounds_min_gap` for termination.
+zero-variations corollary) + the bisection driver's invariants.
 
 ### Refinement correctness
 
@@ -181,8 +200,9 @@ theorem out_real_eq (s : SimpleRealRoot p) (prec₁ prec₂ : Nat) :
   Cauchy but not LMQ).
 - `realRootSeparation_bounds_min_gap`. Wraps Mahler measure
   infrastructure with the discriminant/resultant lower bound.
-- `isolate_correct`. The main bridge theorem, assembled from the
-  above components plus the bisection driver's invariants.
+- `isolate?_correct` and `isolate?_succeeds_at_separation_precision`.
+  The main bridge theorems, assembled from the above components
+  plus the bisection driver's invariants.
 
 **Deliberately not built:**
 - Sturm's theorem and the Sturm sequence. Mathlib has neither.
@@ -201,7 +221,7 @@ HexRealRootsMathlib/
                       ↔ root count theorems
   Bounds.lean       — cauchyBound + lmqBound correctness
   Separation.lean   — realRootSeparation_bounds_min_gap
-  Isolate.lean      — isolate_correct
+  Isolate.lean      — isolate?_correct + isolate?_succeeds_at_separation_precision
   Conformance.lean  — fixture-based checks
 ```
 

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -12,8 +12,6 @@ formalising Sturm's theorem from scratch.
 - `Polynomial.IsRoot`, `Polynomial.roots`, `Polynomial.aroots`.
 - `Polynomial.derivative`, `Polynomial.gcd`, `Polynomial.Squarefree`.
 - `Polynomial.eval₂` for `Polynomial ℤ → ℝ`-valued evaluation.
-- `Polynomial.cauchyBound` and `Polynomial.IsRoot.norm_lt_cauchyBound`
-  from `Mathlib.Analysis.Polynomial.CauchyBound`.
 - `Polynomial.signVariations` and the main theorem
   `Polynomial.roots_countP_pos_le_signVariations` from
   `Mathlib.Algebra.Polynomial.RuleOfSigns`.
@@ -97,21 +95,20 @@ local lemma (~30 lines) building on
 `roots_countP_pos_le_signVariations` and standard parity arguments
 on sign sequences.
 
-### Cauchy bound + LMQ bound correctness
+### LMQ bound correctness
 
 ```lean
-theorem cauchyBound_bounds_real_roots (p : ZPoly) :
-    ∀ r : ℝ, (toPolynomial p).aeval r = 0 →
-        |r| ≤ (Hex.cauchyBound p : ℝ)
-  -- Wraps Mathlib's `Polynomial.IsRoot.norm_lt_cauchyBound`.
-
 theorem lmqBound_bounds_positive_real_roots (p : ZPoly) :
     ∀ r : ℝ, (toPolynomial p).aeval r = 0 → 0 < r →
         r ≤ (Hex.lmqBound p : ℝ)
-  -- Akritas-Strzeboński 2008 LMQ bound, stated for positive reals.
-  -- A new theorem (Mathlib has Cauchy but not LMQ); the proof is
-  -- a couple of pages following the original paper.
+  -- Akritas–Strzeboński 2008 LMQ bound, stated for positive reals.
+  -- The proof follows the original paper; a couple of pages of
+  -- elementary algebra.
 ```
+
+Mathlib's `Polynomial.IsRoot.norm_lt_cauchyBound` is the closest
+upstream analogue; LMQ is independent of it (sharper, with a
+different proof) and the bridge does not factor through Cauchy.
 
 ### `realRootSeparation` correctness
 

--- a/SPEC/Libraries/hex-real-roots-mathlib.md
+++ b/SPEC/Libraries/hex-real-roots-mathlib.md
@@ -102,8 +102,6 @@ theorem lmqBound_bounds_positive_real_roots (p : ZPoly) :
     ∀ r : ℝ, (toPolynomial p).aeval r = 0 → 0 < r →
         r ≤ (Hex.lmqBound p : ℝ)
   -- Akritas–Strzeboński 2008 LMQ bound, stated for positive reals.
-  -- The proof follows the original paper; a couple of pages of
-  -- elementary algebra.
 ```
 
 Mathlib's `Polynomial.IsRoot.norm_lt_cauchyBound` is the closest
@@ -123,8 +121,8 @@ theorem realRootSeparation_bounds_min_gap
 Mahler/Mignotte bound applied to real roots. Mathlib has the Mahler
 infrastructure (`mahlerMeasure_le_sqrt_sum_sq_norm_coeff`,
 `norm_coeff_le_choose_mul_mahlerMeasure_of_one_le_mahlerMeasure`);
-the real-root specialisation needs a small wrapper combining Mahler
-with the discriminant/resultant lower bound. Days-to-week wrapper.
+the real-root specialisation combines Mahler with the
+discriminant/resultant lower bound.
 
 ### `isolate` correctness
 
@@ -175,22 +173,21 @@ theorem out_real_eq (s : SimpleRealRoot p) (prec₁ prec₂ : Nat) :
 
 **Build (verify status at activation time):**
 - The Möbius-transform-correspondence theorem
-  (`mobiusTransform_root_correspondence`). Likely a few pages of
-  proof; uses `Polynomial.comp` and standard substitution machinery.
+  (`mobiusTransform_root_correspondence`). Uses `Polynomial.comp`
+  and standard substitution machinery.
 - The exact-1-from-signVariations parity corollary if not already
-  in Mathlib. Small wrapper.
-- `lmqBound_bounds_positive_real_roots`. New theorem (Mahlib has
-  Cauchy but not LMQ). Few pages.
-- `realRootSeparation_bounds_min_gap`. Small wrapper on Mahler
-  measure infrastructure.
+  in Mathlib.
+- `lmqBound_bounds_positive_real_roots`. New theorem (Mathlib has
+  Cauchy but not LMQ).
+- `realRootSeparation_bounds_min_gap`. Wraps Mahler measure
+  infrastructure with the discriminant/resultant lower bound.
 - `isolate_correct`. The main bridge theorem, assembled from the
   above components plus the bisection driver's invariants.
 
 **Deliberately not built:**
-- Sturm's theorem and the Sturm sequence. Mathlib has neither;
-  formalising would be a multi-month side quest. Avoided by the
-  algorithm choice (Uspensky uses Descartes, which Mathlib does
-  have).
+- Sturm's theorem and the Sturm sequence. Mathlib has neither.
+  Avoided by the algorithm choice (Uspensky uses Descartes, which
+  Mathlib does have).
 - Vincent's theorem (would be needed for VCA/VAS algorithm
   variants, which are out of scope).
 

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -140,14 +140,19 @@ def lmqBound    (p : ZPoly) : Dyadic   -- upper bound on positive real roots
 def realRootSeparation (p : ZPoly) : Nat
 ```
 
-`refine1` bisects at the dyadic midpoint, runs Möbius+Descartes on
-each half, and returns the half containing the root. The function
-is total: by the parent's witness invariant the interval contains
-exactly one root, so after bisection one half has `signVariations =
-1` (root strictly inside) and the other has `signVariations = 0`,
-or the root sits exactly at the midpoint and the half-open
-convention `(a, b]` places it in the left half. `refine` and
-`refineTo` iterate.
+`refine1` bisects at the dyadic midpoint `m := (a + b)/2` and uses
+sign evaluation (not Descartes) to pick the half containing the
+root: evaluate `p(m)` as an integer sign, and combine with `p(a)`,
+`p(b)` via IVT.
+
+- If `p(m) = 0`, the root is `m`; return `(a, m]` (half-open
+  includes `m`).
+- If `p(a)` and `p(m)` have opposite signs, the root is in
+  `(a, m]`; return that half.
+- Otherwise the root is in `(m, b]`; return that half.
+
+This is total integer-sign computation, no Descartes recursion, no
+possibility of failure. `refine` and `refineTo` iterate.
 
 `isolate?` runs the Uspensky bisection driver: starting from the
 worklist `[(−M, M]]` with `M := max(lmqBound p, lmqBound (p(−x)))`,

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -243,17 +243,15 @@ approaches are deliberately *not* used here:
 - **Sturm's theorem + bisection.** Theoretically more robust on
   clustered roots (Sturm gives exact interval counts; Descartes
   only bounds them). Mathlib has no Sturm sequence, no Sturm
-  theorem, and no subresultant pseudo-remainder chain, so the
-  bridge proof would require multi-month formalisation work.
-  Mathlib *does* have Descartes' rule of signs
+  theorem, and no subresultant pseudo-remainder chain. Mathlib
+  *does* have Descartes' rule of signs
   (`Polynomial.signVariations` in
   `Mathlib.Algebra.Polynomial.RuleOfSigns`); Uspensky's bridge
   rides on existing infrastructure.
 - **Vincent's theorem / VCA / VAS** (continued-fraction-based
   isolation). Faster than Uspensky in practice (used by FLINT,
   Mathematica, SageMath). Vincent's theorem is absent from
-  Mathlib; formalising it is a multi-month side quest before any
-  tactic-level payoff.
+  Mathlib.
 - **Speculative Newton refinement** (quadratic convergence on top
   of any bisection driver). Out of scope for this library.
 

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -17,9 +17,10 @@ Pellet tests).
 
 ## Algorithm: Descartes' rule of signs + Möbius bisection (Uspensky)
 
-Pinned: **Uspensky's algorithm**. For each candidate dyadic interval
-`(a, b]` ⊆ ℝ, transform `p` by the Möbius map `x ↦ a + (b − a)/(1 + x)`
-which sends `(0, ∞)` bijectively onto `(a, b)`. The transformed
+Recombination is **Uspensky's algorithm**. For each candidate dyadic
+interval `(a, b]` ⊆ ℝ, transform `p` by the Möbius map
+`x ↦ a + (b − a)/(1 + x)` which sends `(0, ∞)` bijectively onto
+`(a, b)`. The transformed
 polynomial `p_M(x) := (1 + x)^(deg p) · p(a + (b − a)/(1 + x))` has
 positive real roots in bijection (with multiplicity) with `p`'s real
 roots in `(a, b)`. Apply Descartes' rule of signs:
@@ -57,14 +58,10 @@ integer arithmetic, no floats, no rationals, fully `Decidable`.
 Every isolation witness in this library is a strict comparison
 between integer sign-variation counts.
 
-## Bounds: Cauchy and LMQ
-
-The **Cauchy bound** `M_C := 1 + max_i |a_i| / |a_n|` (rounded up to
-a dyadic) bounds every real root of `p` in `[−M_C, M_C]` and is
-the conservative starting interval for the worklist.
+## Bound: LMQ
 
 The **Local Max Quadratic (LMQ) bound** of Akritas–Strzeboński
-gives a tighter upper bound on positive real roots:
+gives an upper bound on positive real roots of `p ∈ ℤ[x]`:
 
 ```
 M_LMQ(p) := 2 · max_{i : a_i < 0} (
@@ -74,11 +71,14 @@ M_LMQ(p) := 2 · max_{i : a_i < 0} (
 ```
 
 with the appropriate integer-arithmetic ceiling. LMQ is often an
-order of magnitude tighter than Cauchy on adversarial inputs
-(Mignotte clusters, polynomials with very negative leading
-coefficients in low-degree slots). The library uses LMQ for the
-positive-root upper bound (and `−LMQ(p(−x))` for the negative-root
-lower bound), with Cauchy as the fallback / sanity bound.
+order of magnitude tighter than the classical Cauchy bound
+`1 + max_i |a_i| / |a_n|` on adversarial inputs (Mignotte clusters,
+polynomials with very negative leading coefficients in low-degree
+slots), which is what makes the bisection driver competitive with
+Sturm-based isolation. The starting interval for the isolation
+worklist is `(−M, M]` where `M := max(lmqBound p, lmqBound (p(−x)))`
+— LMQ on `p` bounds positive real roots, LMQ on `p(−x)` bounds the
+absolute value of negative real roots.
 
 ## Geometry: dyadic intervals on the real line
 
@@ -122,9 +122,9 @@ instance : Decidable (HasOnlySimpleRealRoots p) := …
 
 ```lean
 namespace RealRootIsolation
-def refine1?  : RealRootIsolation p → Option (RealRootIsolation p)
-def refine?   : (target : Nat) → RealRootIsolation p →
-                Option (RealRootIsolation p)
+def refine1   : RealRootIsolation p → RealRootIsolation p
+def refine    : (target : Nat) → RealRootIsolation p →
+                RealRootIsolation p
 def refineTo  : RealRootIsolation p → (target : Nat) →
                 RealRootIsolation p
 end RealRootIsolation
@@ -133,33 +133,24 @@ end RealRootIsolation
 def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRealRoots p)
     (atom_prec : Nat) : Array (RealRootIsolation p)
 
-def cauchyBound (p : ZPoly) : Dyadic
 def lmqBound    (p : ZPoly) : Dyadic   -- upper bound on positive real roots
 def realRootSeparation (p : ZPoly) : Nat
 ```
 
-`refine1?` bisects at the dyadic midpoint, runs Möbius+Descartes on
-each half, and returns the half whose `signVariations` is odd
-(typically `1`; the case of `≥ 3` cannot occur on a
-`RealRootIsolation` by the witness invariant — the existing witness
-guarantees the parent interval contained exactly one root).
-`refine?` and `refineTo` iterate.
+`refine1` bisects at the dyadic midpoint, runs Möbius+Descartes on
+each half, and returns the half containing the root. The function
+is total: by the parent's witness invariant the interval contains
+exactly one root, so after bisection one half has `signVariations =
+1` (root strictly inside) and the other has `signVariations = 0`,
+or the root sits exactly at the midpoint and the half-open
+convention `(a, b]` places it in the left half. `refine` and
+`refineTo` iterate.
 
 `isolate` runs the Uspensky bisection driver: starting from the
-worklist `[(−M, M]]` with `M := max(lmqBound, cauchyBound)`, repeat:
+worklist `[(−M, M]]` with `M := max(lmqBound p, lmqBound (p(−x)))`, repeat:
 pop an interval; compute `signVariations(p_M)`; if 0, discard; if 1,
 emit; if ≥ 2, bisect. Termination by `realRootSeparation p`
 (Mahler/Mignotte real-root bound).
-
-### Midpoint hits a root
-
-If the dyadic midpoint `m` happens to satisfy `p(m) = 0`, the
-half-open interval convention `(a, b]` places that root in
-`(a, m]` (left half) by inclusion of the right endpoint. `p(m) = 0`
-is an integer-arithmetic check, so this case is detected exactly
-and resolved deterministically. (For squarefree `p` this happens
-only at finitely many dyadic points, so refinement always makes
-progress.)
 
 ## SimpleRealRoot quotient and the threading pattern
 
@@ -215,12 +206,12 @@ restricted to the real case.
 
 The Uspensky bisection algorithm:
 
-1. **Squarefree-ify.** `p_sf := p / gcd(p, p')`. Provided as a
-   precondition via `HasOnlySimpleRealRoots`; not mutated by the
-   algorithm itself. (Internally `isolate` may call the gcd routine
-   defensively; the SPEC contract requires squarefree input.)
-2. **Bounds.** Compute `M := max(lmqBound p, cauchyBound p)` —
-   conservative outer bound on real-root locations.
+1. **Squarefree input.** Squarefreeness is a precondition,
+   discharged by the `HasOnlySimpleRealRoots p` argument. `isolate`
+   does not squarefree-ify internally; callers with non-squarefree
+   input compute `p_sf := p / gcd(p, p')` themselves before calling.
+2. **Bound.** Compute `M := max(lmqBound p, lmqBound (p(−x)))` —
+   outer bound on real-root locations.
 3. **Worklist.** Initialise with `[(−M, M]]`. For each interval,
    apply Möbius transform `x ↦ a + (b − a)/(1 + x)` to get `p_M`,
    compute `signVariations(p_M)`, and dispatch:
@@ -245,31 +236,26 @@ squarefree-ifies first.
 
 ## Why Uspensky / Descartes, not Sturm
 
-Pinned: Uspensky (Descartes + Möbius bisection). Deliberately *not*
-implemented in this round:
+The library uses Uspensky (Descartes + Möbius bisection) rather
+than the classical Sturm-sequence alternative. Several known
+approaches are deliberately *not* used here:
 
-- **Sturm's theorem + bisection.** The classical alternative.
-  Theoretically more robust on clustered roots (Sturm gives exact
-  interval counts; Descartes only bounds them). Rejected because
-  Mathlib has no Sturm sequence, no Sturm theorem, and no
-  subresultant pseudo-remainder chain — the bridge would require
-  multi-month formalisation work. Mathlib *does* have Descartes'
-  rule of signs (`Polynomial.signVariations` in
-  `Mathlib.Algebra.Polynomial.RuleOfSigns`), so Uspensky's bridge
-  proof rides on existing infrastructure.
+- **Sturm's theorem + bisection.** Theoretically more robust on
+  clustered roots (Sturm gives exact interval counts; Descartes
+  only bounds them). Mathlib has no Sturm sequence, no Sturm
+  theorem, and no subresultant pseudo-remainder chain, so the
+  bridge proof would require multi-month formalisation work.
+  Mathlib *does* have Descartes' rule of signs
+  (`Polynomial.signVariations` in
+  `Mathlib.Algebra.Polynomial.RuleOfSigns`); Uspensky's bridge
+  rides on existing infrastructure.
 - **Vincent's theorem / VCA / VAS** (continued-fraction-based
   isolation). Faster than Uspensky in practice (used by FLINT,
-  Mathematica, SageMath). Rejected because Vincent's theorem is
-  absent from Mathlib; formalising it is a multi-month side quest
-  before any tactic-level payoff.
+  Mathematica, SageMath). Vincent's theorem is absent from
+  Mathlib; formalising it is a multi-month side quest before any
+  tactic-level payoff.
 - **Speculative Newton refinement** (quadratic convergence on top
-  of any bisection driver). Worth considering as a future
-  refinement; not in this SPEC.
-
-If a future library or tactic needs reusable interval-root-count
-primitives (which Sturm provides natively but Uspensky does not),
-Sturm could be added then with full formalisation cost. Until that
-demand exists, Uspensky's narrower payoff is the right scope.
+  of any bisection driver). Out of scope for this library.
 
 ## Layered file organisation
 
@@ -283,9 +269,9 @@ demand exists, Uspensky's narrower payoff is the right scope.
 - `HexRealRoots/Descartes.lean` — `descartesCount p interval` =
   `signVariations(mobiusTransform p ...)`; `descartesIsolatesOne`
   predicate and `Decidable` infrastructure.
-- `HexRealRoots/Bounds.lean` — `cauchyBound`, `lmqBound`.
+- `HexRealRoots/Bounds.lean` — `lmqBound`.
 - `HexRealRoots/Separation.lean` — `realRootSeparation`.
-- `HexRealRoots/Refine.lean` — `refine1?`, `refine?`, `refineTo`,
+- `HexRealRoots/Refine.lean` — `refine1`, `refine`, `refineTo`,
   `refineTo_respects_equiv`, `SimpleRealRoot.refine`. Threading-
   pattern guidance on `SimpleRealRoot.refine`'s docstring.
 - `HexRealRoots/Isolate.lean` — `isolate` driver.
@@ -329,7 +315,6 @@ External oracles: SageMath
 For Uspensky's algorithm on degree-`n` squarefree `p` with sup-norm
 `‖p‖∞`:
 
-- `cauchyBound p`: `O(n)` integer comparisons.
 - `lmqBound p`: `O(n²)` integer operations (the double-max).
 - Möbius transform of `p` to a candidate interval: `O(n²)` integer
   multiplications; intermediate coefficient size `O(n · log ‖p‖∞)`

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -5,10 +5,8 @@ A "real root isolation" is a dyadic interval `(a, b]` together with a
 witness, dischargeable by `cbv_decide`, that exactly one simple real
 root of `p ∈ ℤ[x]` lies in the interval. Initial isolation uses
 Descartes' rule of signs on Möbius transforms (Uspensky's algorithm);
-once isolated, refinement bisects the interval and uses sign
-evaluation at the midpoint plus IVT to follow the half containing
-the root — no further Descartes computation is needed past initial
-isolation.
+refinement bisects the interval and uses sign evaluation at the
+midpoint plus IVT to follow the half containing the root.
 
 The companion to [hex-roots](hex-roots.md) (complex root isolation
 via BSSY): same project conventions for dyadic centres, the
@@ -143,9 +141,8 @@ def realRootSeparation (p : ZPoly) : Nat
 ```
 
 `refine1` bisects at the dyadic midpoint `m := (a + b)/2` and uses
-sign evaluation (not Descartes) to pick the half containing the
-root: evaluate `p(m)` as an integer sign, and combine with `p(a)`,
-`p(b)` via IVT.
+integer sign evaluation at endpoints + IVT to pick the half
+containing the root:
 
 - If `p(m) = 0`, the root is `m`; return `(a, m]` (half-open
   includes `m`).
@@ -153,20 +150,19 @@ root: evaluate `p(m)` as an integer sign, and combine with `p(a)`,
   `(a, m]`; return that half.
 - Otherwise the root is in `(m, b]`; return that half.
 
-This is total integer-sign computation, no Descartes recursion, no
-possibility of failure. `refine` and `refineTo` iterate.
+`refine` and `refineTo` iterate `refine1`.
 
 `isolate?` runs the Uspensky bisection driver: starting from the
 worklist `[(−M, M]]` with `M := max(lmqBound p, lmqBound (p(−x)))`,
 repeat: pop an interval; compute `signVariations(p_M)`; if 0,
 discard; if 1, emit; if ≥ 2 and current precision < targetPrecision,
 bisect; if ≥ 2 and precision = targetPrecision, abort with `none`.
-The function terminates structurally (`targetPrecision − currentPrecision : ℕ`
-strictly decreases at each bisection). The Mathlib bridge proves
-that `isolate? p h (realRootSeparation p)` is never `none` (every
-remaining interval at that precision has `signVariations ≤ 1` by
-the Mahler/Mignotte real-root separation bound), but that
-guarantee lives in `hex-real-roots-mathlib`, not in this library.
+The function terminates structurally
+(`targetPrecision − currentPrecision : ℕ` strictly decreases at each
+bisection). The "always-`some` at `realRootSeparation p`" guarantee
+lives in `hex-real-roots-mathlib`, where the
+Mahler/Mignotte real-root separation bound establishes that every
+remaining interval has `signVariations ≤ 1` at that precision.
 
 ## SimpleRealRoot quotient and the threading pattern
 
@@ -201,17 +197,13 @@ Equivalent isolations (same root) produce the same canonical
 interval; non-equivalent isolations (different roots) produce
 different ones.
 
-Caution against the obvious-but-wrong shortcut: "intervals overlap
-iff same root" is *not* a decidable characterisation, even after
-refinement. The half-open `(a, b]` convention permits two
-isolations of distinct roots `r₁ < r₂` to overlap without either
-root sitting in the overlap region — e.g. `iso₁ = (0.4, 0.55]`
-holding `r₁ = 0.5` and `iso₂ = (0.5, 0.6]` holding `r₂ = 0.6`
-overlap at `(0.5, 0.55]`, with `0.5 ∉ iso₂` (left-excluded) and
-`0.6 ∉ iso₁` (out of range). Refining to a precision strictly
-less than `(root gap)/2` would close this loophole, but the
-canonicalisation route avoids the precision-bookkeeping subtlety
-entirely.
+Note that under the half-open `(a, b]` convention, two isolations
+of *distinct* roots `r₁ < r₂` can have overlapping intervals: e.g.
+`iso₁ = (0.4, 0.55]` holding `r₁ = 0.5` and `iso₂ = (0.5, 0.6]`
+holding `r₂ = 0.6` overlap at `(0.5, 0.55]`, with `0.5 ∉ iso₂`
+(left-excluded) and `0.6 ∉ iso₁` (out of range). Equivalence is
+therefore characterised by the canonicalised representatives, not
+by interval overlap.
 
 The **threading pattern** is the same as in `hex-roots`: callers
 holding a `SimpleRealRoot p` should refine once and forward the
@@ -234,9 +226,9 @@ not the discriminant value itself).
 `realRootSeparation p` is computed by the executable library so
 callers can pass it as `targetPrecision` to `isolate?`. The
 guarantee that `isolate? p h (realRootSeparation p) ≠ none` is a
-Mathlib-bridge theorem (`isolate?_succeeds_at_separation_precision`
-in `hex-real-roots-mathlib`); the executable library makes no
-such claim.
+Mathlib-bridge theorem
+(`isolate?_succeeds_at_separation_precision` in
+`hex-real-roots-mathlib`).
 
 This is the analogue of [hex-roots](hex-roots.md)'s `mahlerPrec`
 restricted to the real case.
@@ -264,8 +256,7 @@ The Uspensky bisection algorithm:
 4. **Refinement.** A `RealRootIsolation` at precision `prec` is
    refined to `prec + 1` by bisecting at the midpoint `m`, evaluating
    `sign(p(m))`, and selecting the half containing the root via IVT
-   (see `refine1` in §"Operations" for the decision rules). No
-   further Möbius+Descartes computation past initial isolation.
+   (see `refine1` in §"Operations" for the decision rules).
 
 `isolate?` terminates structurally on `targetPrecision − currentPrecision`,
 which strictly decreases at each bisection; once it reaches zero, the

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -129,9 +129,12 @@ def refineTo  : RealRootIsolation p → (target : Nat) →
                 RealRootIsolation p
 end RealRootIsolation
 
-/-- Isolate every simple real root of p (for squarefree p). -/
-def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRealRoots p)
-    (atom_prec : Nat) : Array (RealRootIsolation p)
+/-- Isolate every simple real root of p (for squarefree p), bisecting
+    until each interval reaches signVariations ≤ 1 or until the
+    targetPrecision bound is hit. Returns `none` if any interval
+    still has signVariations ≥ 2 at targetPrecision. -/
+def isolate? (p : ZPoly) (h : Hex.HasOnlySimpleRealRoots p)
+    (targetPrecision : Nat) : Option (Array (RealRootIsolation p))
 
 def lmqBound    (p : ZPoly) : Dyadic   -- upper bound on positive real roots
 def realRootSeparation (p : ZPoly) : Nat
@@ -146,11 +149,17 @@ or the root sits exactly at the midpoint and the half-open
 convention `(a, b]` places it in the left half. `refine` and
 `refineTo` iterate.
 
-`isolate` runs the Uspensky bisection driver: starting from the
-worklist `[(−M, M]]` with `M := max(lmqBound p, lmqBound (p(−x)))`, repeat:
-pop an interval; compute `signVariations(p_M)`; if 0, discard; if 1,
-emit; if ≥ 2, bisect. Termination by `realRootSeparation p`
-(Mahler/Mignotte real-root bound).
+`isolate?` runs the Uspensky bisection driver: starting from the
+worklist `[(−M, M]]` with `M := max(lmqBound p, lmqBound (p(−x)))`,
+repeat: pop an interval; compute `signVariations(p_M)`; if 0,
+discard; if 1, emit; if ≥ 2 and current precision < targetPrecision,
+bisect; if ≥ 2 and precision = targetPrecision, abort with `none`.
+The function terminates structurally (`targetPrecision − currentPrecision : ℕ`
+strictly decreases at each bisection). The Mathlib bridge proves
+that `isolate? p h (realRootSeparation p)` is never `none` (every
+remaining interval at that precision has `signVariations ≤ 1` by
+the Mahler/Mignotte real-root separation bound), but that
+guarantee lives in `hex-real-roots-mathlib`, not in this library.
 
 ## SimpleRealRoot quotient and the threading pattern
 
@@ -177,9 +186,25 @@ end SimpleRealRoot
 end Hex
 ```
 
-Decidability of equivalence: refine both isolations to precision
-`realRootSeparation p`; then either intervals overlap (→ same
-root) or they're disjoint (→ different roots).
+Decidability of equivalence is via canonical-representative
+equality, mirroring [hex-roots](hex-roots.md): canonicalise both
+isolations to a fixed grid at precision `realRootSeparation p +
+canonOverhead p` and compare the resulting intervals for equality.
+Equivalent isolations (same root) produce the same canonical
+interval; non-equivalent isolations (different roots) produce
+different ones.
+
+Caution against the obvious-but-wrong shortcut: "intervals overlap
+iff same root" is *not* a decidable characterisation, even after
+refinement. The half-open `(a, b]` convention permits two
+isolations of distinct roots `r₁ < r₂` to overlap without either
+root sitting in the overlap region — e.g. `iso₁ = (0.4, 0.55]`
+holding `r₁ = 0.5` and `iso₂ = (0.5, 0.6]` holding `r₂ = 0.6`
+overlap at `(0.5, 0.55]`, with `0.5 ∉ iso₂` (left-excluded) and
+`0.6 ∉ iso₁` (out of range). Refining to a precision strictly
+less than `(root gap)/2` would close this loophole, but the
+canonicalisation route avoids the precision-bookkeeping subtlety
+entirely.
 
 The **threading pattern** is the same as in `hex-roots`: callers
 holding a `SimpleRealRoot p` should refine once and forward the
@@ -187,7 +212,7 @@ refined value rather than re-refining at each `out` call. See
 [hex-roots.md §"The threading pattern"](hex-roots.md) for the
 canonical exposition.
 
-## `realRootSeparation` — termination bound
+## `realRootSeparation` — sufficient `targetPrecision` for `isolate?`
 
 ```lean
 def realRootSeparation (p : ZPoly) : Nat
@@ -199,6 +224,13 @@ finite minimum gap between any two distinct real roots. Closed-form
 integer arithmetic (uses `|disc p| ≥ 1` for squarefree integer `p`,
 not the discriminant value itself).
 
+`realRootSeparation p` is computed by the executable library so
+callers can pass it as `targetPrecision` to `isolate?`. The
+guarantee that `isolate? p h (realRootSeparation p) ≠ none` is a
+Mathlib-bridge theorem (`isolate?_succeeds_at_separation_precision`
+in `hex-real-roots-mathlib`); the executable library makes no
+such claim.
+
 This is the analogue of [hex-roots](hex-roots.md)'s `mahlerPrec`
 restricted to the real case.
 
@@ -207,7 +239,7 @@ restricted to the real case.
 The Uspensky bisection algorithm:
 
 1. **Squarefree input.** Squarefreeness is a precondition,
-   discharged by the `HasOnlySimpleRealRoots p` argument. `isolate`
+   discharged by the `HasOnlySimpleRealRoots p` argument. `isolate?`
    does not squarefree-ify internally; callers with non-squarefree
    input compute `p_sf := p / gcd(p, p')` themselves before calling.
 2. **Bound.** Compute `M := max(lmqBound p, lmqBound (p(−x)))` —
@@ -226,12 +258,16 @@ The Uspensky bisection algorithm:
    refined to `prec + 1` by bisecting and re-running Möbius+Descartes
    on the half containing the root.
 
-Termination by `realRootSeparation p` plus interval-halving: any
-two distinct real roots are eventually placed in disjoint intervals
-once interval width drops below `2^{-realRootSeparation p}`, after
-which each interval has `signVariations ≤ 1`.
+`isolate?` terminates structurally on `targetPrecision − currentPrecision`,
+which strictly decreases at each bisection; once it reaches zero, the
+worklist is abandoned and the function returns `none`. Soundness of
+the `some`-payload (when one is returned) is independent of the
+precision budget. The Mathlib bridge separately proves that calling
+`isolate?` at `targetPrecision := realRootSeparation p` is sufficient
+for the worklist to drain — i.e. the result is never `none` at that
+precision.
 
-Multiple-real-root case: not supported by `isolate`. Caller
+Multiple-real-root case: not supported by `isolate?`. Caller
 squarefree-ifies first.
 
 ## Why Uspensky / Descartes, not Sturm
@@ -272,7 +308,9 @@ approaches are deliberately *not* used here:
 - `HexRealRoots/Refine.lean` — `refine1`, `refine`, `refineTo`,
   `refineTo_respects_equiv`, `SimpleRealRoot.refine`. Threading-
   pattern guidance on `SimpleRealRoot.refine`'s docstring.
-- `HexRealRoots/Isolate.lean` — `isolate` driver.
+- `HexRealRoots/Isolate.lean` — `isolate?` driver (Option-returning,
+  parametrised by `targetPrecision`; structural termination by
+  precision-budget descent).
 - `HexRealRoots/Conformance.lean`, `HexRealRoots/Bench.lean`,
   `HexRealRoots/EmitFixtures.lean` — standard testing trio.
 
@@ -288,7 +326,7 @@ Per [SPEC/testing.md](../testing.md), tiered:
   - `x³ − x − 1` (one real root, ≈ 1.3247).
   - Chebyshev `T_5(x) = 16x⁵ − 20x³ + 5x` (5 roots in `[−1, 1]`).
   - Cyclotomic `Φ_5` (deg 4, no real roots).
-  - `(x − 1)²(x + 1)` — multiple root: `isolate` rejects via
+  - `(x − 1)²(x + 1)` — multiple root: `isolate?` rejects via
     `HasOnlySimpleRealRoots = false`.
 - *ci* (CI, with external oracle): 30 degree-15 polynomials with
   small random integer coefficients; expected outputs from SageMath
@@ -320,7 +358,7 @@ For Uspensky's algorithm on degree-`n` squarefree `p` with sup-norm
 - `signVariations` on the transformed polynomial: `O(n)` integer
   sign comparisons.
 - `realRootSeparation p`: `O(n · log ‖p‖∞)` integer operations.
-- `isolate p` worst case: `O(n · realRootSeparation p)` Möbius+
+- `isolate? p h (realRootSeparation p)` worst case: `O(n · realRootSeparation p)` Möbius+
   Descartes evaluations, dominated by the Möbius transform per
   step. Concretely, `Õ(n^4 · log² ‖p‖∞)` bit operations on benign
   inputs; potentially `Õ(n^4 · realRootSeparation²)` on Mignotte

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -1,0 +1,308 @@
+# hex-real-roots (real root isolation, depends on hex-poly-z + hex-resultant)
+
+Certified isolation of real roots of integer-coefficient polynomials.
+A "real root isolation" is a dyadic interval `(a, b]` together with a
+witness, dischargeable by `cbv_decide`, that exactly one simple real
+root of `p ∈ ℤ[x]` lies in the interval. Refinement bisects the
+interval at the dyadic midpoint, recomputes the Sturm count on each
+half, and follows the half containing the root.
+
+The companion to [hex-roots](hex-roots.md) (complex root isolation
+via BSSY): same project conventions for dyadic centres, the
+`SimpleRealRoot` Quotient, the threading pattern, and Mahler/Mignotte
+separation bounds — adapted for the real case (sign-separation
+instead of disc-separation, bisection instead of subdivision-and-
+gluing).
+
+## Witness arithmetic is exact
+
+Sturm's theorem: for squarefree `p ∈ ℤ[x]`, the **Sturm sequence**
+`s_0 := p, s_1 := p', s_{i+1} := −rem(s_{i−1}, s_i)` evaluated at
+real `a` yields a sequence of values whose sign-change count
+`V(a)` satisfies
+
+```
+V(a) − V(b)  =  #{ real roots of p in the interval (a, b] }
+```
+
+for any `a < b` such that `p(a) ≠ 0`, `p(b) ≠ 0`. Every `V(a) − V(b)`
+in this library is computed by evaluating the Sturm sequence at
+exact dyadic points and counting integer sign changes — `Decidable`
+with no error budget.
+
+## Sturm sequence via subresultants (integer arithmetic throughout)
+
+The sequence is computed via the **subresultant pseudo-remainder
+sequence** from [hex-resultant](hex-resultant.md)'s
+`subresultantChain`, with Sylvester–Habicht sign-flip bookkeeping so
+the chain delivers the Sturm sequence's sign-change behaviour. This
+keeps every intermediate coefficient in ℤ — no rational arithmetic,
+no denominator clearing, no floating point. Computing
+`V(a)` reduces to evaluating each `s_i` at the dyadic point `a` (an
+integer multiplied by a power of two), reading off the integer sign,
+and counting flips.
+
+Rationale: ordinary remainder Sturm sequences over ℚ require
+denominator tracking; the subresultant variant absorbs the
+pseudo-division blow-up into tracked scale factors with sharp bounds
+(the "fundamental theorem of subresultants"), giving better
+asymptotic coefficient size than naive integer pseudo-division. The
+machinery exists in `hex-resultant`; the dependency is natural.
+
+## Geometry: dyadic intervals on the real line
+
+Bisection works on **dyadic intervals** `(lower, upper]` with
+`lower, upper : Dyadic`, `lower < upper`. Splitting at the dyadic
+midpoint `m := (lower + upper) / 2` produces two sub-intervals at
+half-width.
+
+The **Cauchy bound** `M := 1 + max_i |a_i| / |a_n|` (rounded up to a
+dyadic) bounds every real root of `p` in `[−M, M]`; the worklist
+starts with `(−M, M]`.
+
+## Contents
+
+```lean
+namespace Hex
+
+structure DyadicInterval where
+  lower : Dyadic
+  upper : Dyadic
+  ordered : lower < upper := by decide
+
+structure SimpleRealRootIsolation (p : ZPoly) where
+  interval : DyadicInterval
+  witness  : sturmCount p interval = 1
+  -- sturmCount: ZPoly → DyadicInterval → ℕ; computed via integer
+  -- subresultant chain + dyadic evaluation. The witness type is
+  -- `Decidable Prop`, dischargeable by cbv_decide on a fully-
+  -- elaborated SimpleRealRootIsolation value.
+
+/-- p has only simple real roots. Default-decidable via
+    Hex.HasOnlySimpleRealRoots.decide (gcd(p, p') is a unit, so p
+    is squarefree, hence has only simple roots in any extension —
+    in particular, no multiple real roots). The Mathlib companion
+    proves equivalence with the ℝ-coefficient version. -/
+def HasOnlySimpleRealRoots (p : ZPoly) : Prop := …
+instance : Decidable (HasOnlySimpleRealRoots p) := …
+```
+
+`SimpleRealRootIsolation p` carries one *simple* real root in its
+interval — `Simple` because the witness pins the Sturm count at 1
+(not 0, not ≥ 2). For inputs with multiple roots the bisection never
+satisfies the witness around the multiple root, and `isolate`
+refuses such inputs (see Operations).
+
+## Operations
+
+```lean
+namespace SimpleRealRootIsolation
+def refine1?  : SimpleRealRootIsolation p → Option (SimpleRealRootIsolation p)
+def refine?   : (target : Nat) → SimpleRealRootIsolation p →
+                Option (SimpleRealRootIsolation p)
+def refineTo  : SimpleRealRootIsolation p → (target : Nat) →
+                SimpleRealRootIsolation p
+end SimpleRealRootIsolation
+
+/-- Isolate every simple real root of p (for squarefree p). -/
+def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRealRoots p)
+    (atom_prec : Nat) : Array (SimpleRealRootIsolation p)
+
+def cauchyBound (p : ZPoly) : Dyadic
+def realRootSeparation (p : ZPoly) : Nat
+```
+
+`refine1?` bisects the current interval at the dyadic midpoint, runs
+the Sturm count on each half, and returns the half whose count is 1
+(the other half has count 0; the case of count 2 cannot occur on a
+SimpleRealRootIsolation by the witness invariant, modulo tie-cases
+at the midpoint — see "midpoint hits a root" below). `refine?` and
+`refineTo` iterate to a target precision.
+
+`isolate` runs the Sturm bisection driver: starting with the Cauchy
+interval `(−M, M]`, repeatedly split intervals whose Sturm count
+exceeds 1; emit intervals with count 1; discard intervals with count
+0. Termination by `realRootSeparation p` (Mahler/Mignotte real-root
+bound).
+
+### Midpoint hits a root
+
+If the dyadic midpoint `m` happens to satisfy `p(m) = 0`, the
+half-open interval convention `(a, b]` places that root in
+`(a, m]` (left half) by inclusion of the right endpoint. `p(m) = 0`
+is an integer-arithmetic check, so this case is detected exactly
+and resolved deterministically. (For squarefree `p` this happens
+only at finitely many dyadic points, so refinement always makes
+progress.)
+
+## SimpleRealRoot quotient and the threading pattern
+
+Mirroring [hex-roots](hex-roots.md):
+
+```lean
+namespace Hex
+def SimpleRealRoot (p : ZPoly) :=
+    Quotient (SimpleRealRootIsolation.setoid p)
+
+instance SimpleRealRootIsolation.setoid (p : ZPoly) :
+    Setoid (SimpleRealRootIsolation p) := …
+
+instance : DecidableEq (SimpleRealRoot p) := Quotient.decidableEq
+
+namespace SimpleRealRoot
+def mk (iso : SimpleRealRootIsolation p) : SimpleRealRoot p :=
+    Quotient.mk _ iso
+
+def out (s : SimpleRealRoot p) (prec : Nat) : SimpleRealRootIsolation p
+
+def refine (s : SimpleRealRoot p) (target : Nat) : SimpleRealRoot p
+end SimpleRealRoot
+end Hex
+```
+
+Decidability of equivalence: refine both isolations to precision
+`realRootSeparation p`; then either intervals overlap (→ same
+root) or they're disjoint (→ different roots).
+
+The **threading pattern** is the same as in `hex-roots`: callers
+holding a `SimpleRealRoot p` should refine once and forward the
+refined value rather than re-refining at each `out` call. See
+[hex-roots.md §"The threading pattern"](hex-roots.md) for the
+canonical exposition; the rules here are identical with `Real` /
+`SimpleRealRoot` substituted for the complex names.
+
+## `realRootSeparation` — termination bound
+
+```lean
+def realRootSeparation (p : ZPoly) : Nat
+```
+
+For squarefree `p ∈ ℤ[x]` of degree `n` with sup-norm `‖p‖∞`, the
+Mahler/Mignotte separation bound applied to *real* roots gives a
+finite minimum gap between any two distinct real roots. Closed-form
+integer arithmetic (uses `|disc p| ≥ 1` for squarefree integer `p`,
+not the discriminant value itself).
+
+This is the analogue of [hex-roots](hex-roots.md)'s `mahlerPrec`
+restricted to the real case.
+
+## Algorithm exposition
+
+The Sturm bisection algorithm:
+
+1. **Squarefree-ify.** `p_sf := p / gcd(p, p')`. Provided as a
+   precondition via `HasOnlySimpleRealRoots`; not mutated by the
+   algorithm itself. (Internally `isolate` may call the gcd routine
+   defensively; the SPEC contract requires squarefree input.)
+2. **Sturm sequence.** Compute the integer Sturm sequence via
+   `subresultantChain` from `hex-resultant`, with Sylvester–Habicht
+   sign-flip applied so the resulting sequence has the sign-change
+   semantics of the classical Sturm sequence. Pre-computed once.
+3. **Cauchy bound.** Compute `M := cauchyBound p` (a dyadic).
+4. **Total root count.** Compute `N := V(−M) − V(M)`.
+5. **Bisection driver.** Worklist initialised with `(−M, M]`. Loop:
+   pop an interval `(a, b]`; compute `n := V(a) − V(b)`; if `n = 0`,
+   discard; if `n = 1`, emit a `SimpleRealRootIsolation`; if `n > 1`,
+   bisect at `m := (a + b) / 2` and push both halves. Terminates
+   when worklist is empty.
+6. **Refinement.** A `SimpleRealRootIsolation` at precision `prec`
+   can be refined to `prec + 1` by bisecting and re-running the
+   Sturm count on the half containing the root.
+
+Only-simple-roots check via `HasOnlySimpleRealRoots`: `gcd(p, p')`
+is a unit. Squarefree `p` ⟹ no multiple roots in any field ⟹ in
+particular no multiple real roots. The converse fails (squarefree
+in ℂ but with double real roots is impossible, so the converse
+holds for ℝ-roots; mathlib companion makes this precise).
+
+Multiple-real-root case: not supported by `isolate`. The bisection
+would never reduce a count-2 interval below 2 around a real double
+root. Caller squarefree-ifies first.
+
+## Layered file organisation
+
+- `HexRealRoots/Basic.lean` — types: `DyadicInterval`,
+  `SimpleRealRootIsolation`, `Hex.HasOnlySimpleRealRoots`. Setoid +
+  Quotient `SimpleRealRoot p` + decidable equality. `mk` and `out`.
+- `HexRealRoots/Sturm.lean` — `sturmSequence` (subresultant-based
+  with Sylvester–Habicht sign flip), `sturmCount` (sign-change
+  difference at a dyadic interval's endpoints), and the Sturm
+  count's Decidable infrastructure.
+- `HexRealRoots/Cauchy.lean` — `cauchyBound`.
+- `HexRealRoots/Separation.lean` — `realRootSeparation`.
+- `HexRealRoots/Refine.lean` — `refine1?`, `refine?`, `refineTo`,
+  `refineTo_respects_equiv`, `SimpleRealRoot.refine`. Threading-
+  pattern guidance on `SimpleRealRoot.refine`'s docstring.
+- `HexRealRoots/Isolate.lean` — `isolate` driver.
+- `HexRealRoots/Conformance.lean`, `HexRealRoots/Bench.lean`,
+  `HexRealRoots/EmitFixtures.lean` — standard testing trio.
+
+## Conformance fixtures
+
+Per [SPEC/testing.md](../testing.md), tiered:
+
+- *core* (Lean-only, runs on every push):
+  - Linear: `x − 5` (one root at 5).
+  - `x² − 1` (roots at ±1).
+  - `x² + 1` (no real roots).
+  - `x³ − x` (roots at −1, 0, 1).
+  - `x³ − x − 1` (one real root, ≈ 1.3247).
+  - Chebyshev `T_5(x) = 16x⁵ − 20x³ + 5x` (5 roots in `[−1, 1]`).
+  - Cyclotomic `Φ_5` (deg 4, no real roots).
+  - `(x − 1)²(x + 1)` — multiple root: `isolate` rejects via
+    `HasOnlySimpleRealRoots = false`.
+- *ci* (CI, with external oracle): 30 degree-15 polynomials with
+  small random integer coefficients; expected outputs from SageMath
+  or python-flint.
+- *local* (developer-driven): adversarial families — Mignotte
+  `xⁿ − (a·x − 1)²` for `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`,
+  Wilkinson 20, Chebyshev `T_n` for `n ∈ {20, 50}`.
+
+External oracles: SageMath
+(`R.<x> = ZZ[]; (p).real_roots()`), python-flint
+(`fmpz_poly` real-root API), FLINT/Arb (`arb_poly_isolate_real_roots`).
+
+## Complexity contract
+
+- `cauchyBound p`: `O(n)` integer comparisons + one division.
+- `sturmSequence p`: `O(n)` polynomial pseudo-division steps via
+  `hex-resultant.subresultantChain`; coefficient size bounded by
+  the subresultant theorem's `O(n · log ‖p‖∞)`.
+- `sturmCount p (a, b)`: `O(n)` polynomial evaluations at two
+  dyadic points + `O(n)` integer sign comparisons.
+- `realRootSeparation p`: `O(n · log ‖p‖∞)` integer operations.
+- `isolate p (atom_prec)` for degree-`n` squarefree `p` with
+  well-separated roots: heuristically `O(n³ · atom_prec)` integer
+  operations. Worst case bounded by `realRootSeparation`, which is
+  exponential in `n` for arbitrary-coefficient inputs but
+  polynomial in `‖p‖∞` for fixed `n`.
+
+## Time budgets (Phase 4 validation)
+
+Rough first guesses, refined against SageMath / Arb on the same
+fixtures during Phase 4:
+
+- Degree 10, prec 32: < 1 second.
+- Degree 50, prec 64: < 10 seconds.
+- Degree 100, prec 128: < 1 minute.
+
+## References
+
+- Sturm, J. C. F. *Mémoire sur la résolution des équations
+  numériques.* Bull. Sci. Math. 11 (1829) 419–425. The original
+  theorem.
+- Sylvester, J. J. *On a theory of the syzygetic relations of two
+  rational integral functions.* Phil. Trans. R. Soc. London 143
+  (1853) 407–548. Sign-modified subresultant chain.
+- Habicht, W. *Eine Verallgemeinerung des Sturmschen
+  Wurzelzählverfahrens.* Comment. Math. Helv. 21 (1948) 99–116.
+  Generalises Sturm to subresultant-based chains.
+- Marden, M. *Geometry of Polynomials.* AMS Math. Surveys 3, 2nd
+  ed., 1966. Modern textbook treatment of Sturm.
+- Basu, S.; Pollack, R.; Roy, M.-F. *Algorithms in Real Algebraic
+  Geometry.* Springer, 2nd ed., 2006. Comprehensive: Sturm + sign
+  matrices + cylindrical decomposition. **The reference** for this
+  library and its sibling `hex-sturm`.
+- Geddes, K. O.; Czapor, S. R.; Labahn, G. *Algorithms for Computer
+  Algebra.* Kluwer, 1992. §8 covers Sturm with subresultants and
+  the standard root-isolation drivers.

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -3,10 +3,12 @@
 Certified isolation of real roots of integer-coefficient polynomials.
 A "real root isolation" is a dyadic interval `(a, b]` together with a
 witness, dischargeable by `cbv_decide`, that exactly one simple real
-root of `p ∈ ℤ[x]` lies in the interval. Refinement bisects the
-interval at the dyadic midpoint, recomputes the Descartes
-sign-variation count after a Möbius transform, and follows the half
-containing the root.
+root of `p ∈ ℤ[x]` lies in the interval. Initial isolation uses
+Descartes' rule of signs on Möbius transforms (Uspensky's algorithm);
+once isolated, refinement bisects the interval and uses sign
+evaluation at the midpoint plus IVT to follow the half containing
+the root — no further Descartes computation is needed past initial
+isolation.
 
 The companion to [hex-roots](hex-roots.md) (complex root isolation
 via BSSY): same project conventions for dyadic centres, the
@@ -260,8 +262,10 @@ The Uspensky bisection algorithm:
      Emit `(a, b]` as an isolation; ensure subsequent intervals
      start strictly above `b`.
 4. **Refinement.** A `RealRootIsolation` at precision `prec` is
-   refined to `prec + 1` by bisecting and re-running Möbius+Descartes
-   on the half containing the root.
+   refined to `prec + 1` by bisecting at the midpoint `m`, evaluating
+   `sign(p(m))`, and selecting the half containing the root via IVT
+   (see `refine1` in §"Operations" for the decision rules). No
+   further Möbius+Descartes computation past initial isolation.
 
 `isolate?` terminates structurally on `targetPrecision − currentPrecision`,
 which strictly decreases at each bisection; once it reaches zero, the

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -1,53 +1,84 @@
-# hex-real-roots (real root isolation, depends on hex-poly-z + hex-resultant)
+# hex-real-roots (real root isolation, depends on hex-poly-z)
 
 Certified isolation of real roots of integer-coefficient polynomials.
 A "real root isolation" is a dyadic interval `(a, b]` together with a
 witness, dischargeable by `cbv_decide`, that exactly one simple real
 root of `p ∈ ℤ[x]` lies in the interval. Refinement bisects the
-interval at the dyadic midpoint, recomputes the Sturm count on each
-half, and follows the half containing the root.
+interval at the dyadic midpoint, recomputes the Descartes
+sign-variation count after a Möbius transform, and follows the half
+containing the root.
 
 The companion to [hex-roots](hex-roots.md) (complex root isolation
 via BSSY): same project conventions for dyadic centres, the
 `SimpleRealRoot` Quotient, the threading pattern, and Mahler/Mignotte
-separation bounds — adapted for the real case (sign-separation
-instead of disc-separation, bisection instead of subdivision-and-
-gluing).
+separation bounds — adapted for the real case (sign-variation
+counting on a Möbius-transformed polynomial instead of disc-based
+Pellet tests).
+
+## Algorithm: Descartes' rule of signs + Möbius bisection (Uspensky)
+
+Pinned: **Uspensky's algorithm**. For each candidate dyadic interval
+`(a, b]` ⊆ ℝ, transform `p` by the Möbius map `x ↦ a + (b − a)/(1 + x)`
+which sends `(0, ∞)` bijectively onto `(a, b)`. The transformed
+polynomial `p_M(x) := (1 + x)^(deg p) · p(a + (b − a)/(1 + x))` has
+positive real roots in bijection (with multiplicity) with `p`'s real
+roots in `(a, b)`. Apply Descartes' rule of signs:
+
+```
+#{ positive real roots of p_M, counted with multiplicity }
+  ≤ signVariations(p_M)
+
+#{ positive real roots of p_M, counted with multiplicity }
+  ≡ signVariations(p_M)   (mod 2)
+```
+
+Reading off the count:
+
+- `signVariations(p_M) = 0` ⟹ no real roots in `(a, b)`. Discard.
+- `signVariations(p_M) = 1` ⟹ exactly one real root in `(a, b)`
+  (parity argument: `0 < count ≤ 1` and `count ≡ 1 (mod 2)`).
+  Emit a `RealRootIsolation`.
+- `signVariations(p_M) ≥ 2` ⟹ uncertain count; bisect at the dyadic
+  midpoint `m := (a + b) / 2` and recurse on `(a, m]` and `(m, b]`.
+
+The half-open interval boundary is handled by checking `p(b) = 0`
+explicitly; if `p(b) = 0`, emit `(a, b]` as an isolation with the
+endpoint root, then move to subsequent intervals starting strictly
+above `b`.
 
 ## Witness arithmetic is exact
 
-Sturm's theorem: for squarefree `p ∈ ℤ[x]`, the **Sturm sequence**
-`s_0 := p, s_1 := p', s_{i+1} := −rem(s_{i−1}, s_i)` evaluated at
-real `a` yields a sequence of values whose sign-change count
-`V(a)` satisfies
+For squarefree `p ∈ ℤ[x]`, the Möbius transform of `p` to the
+positive ray of an integer-endpoint dyadic interval is a polynomial
+in ℤ[x] (after clearing the dyadic denominators by multiplying by
+`2^k · (1+x)^(deg p)`), and `signVariations` is a count of integer
+sign changes through the transformed coefficient list — pure
+integer arithmetic, no floats, no rationals, fully `Decidable`.
+Every isolation witness in this library is a strict comparison
+between integer sign-variation counts.
+
+## Bounds: Cauchy and LMQ
+
+The **Cauchy bound** `M_C := 1 + max_i |a_i| / |a_n|` (rounded up to
+a dyadic) bounds every real root of `p` in `[−M_C, M_C]` and is
+the conservative starting interval for the worklist.
+
+The **Local Max Quadratic (LMQ) bound** of Akritas–Strzeboński
+gives a tighter upper bound on positive real roots:
 
 ```
-V(a) − V(b)  =  #{ real roots of p in the interval (a, b] }
+M_LMQ(p) := 2 · max_{i : a_i < 0} (
+              max_{j > i, a_j > 0}
+                (−a_i / max-power-of-a_j)^{1/(j − i)}
+            )
 ```
 
-for any `a < b` such that `p(a) ≠ 0`, `p(b) ≠ 0`. Every `V(a) − V(b)`
-in this library is computed by evaluating the Sturm sequence at
-exact dyadic points and counting integer sign changes — `Decidable`
-with no error budget.
-
-## Sturm sequence via subresultants (integer arithmetic throughout)
-
-The sequence is computed via the **subresultant pseudo-remainder
-sequence** from [hex-resultant](hex-resultant.md)'s
-`subresultantChain`, with Sylvester–Habicht sign-flip bookkeeping so
-the chain delivers the Sturm sequence's sign-change behaviour. This
-keeps every intermediate coefficient in ℤ — no rational arithmetic,
-no denominator clearing, no floating point. Computing
-`V(a)` reduces to evaluating each `s_i` at the dyadic point `a` (an
-integer multiplied by a power of two), reading off the integer sign,
-and counting flips.
-
-Rationale: ordinary remainder Sturm sequences over ℚ require
-denominator tracking; the subresultant variant absorbs the
-pseudo-division blow-up into tracked scale factors with sharp bounds
-(the "fundamental theorem of subresultants"), giving better
-asymptotic coefficient size than naive integer pseudo-division. The
-machinery exists in `hex-resultant`; the dependency is natural.
+with the appropriate integer-arithmetic ceiling. LMQ is often an
+order of magnitude tighter than Cauchy on adversarial inputs
+(Mignotte clusters, polynomials with very negative leading
+coefficients in low-degree slots). The library uses LMQ for the
+positive-root upper bound (and `−LMQ(p(−x))` for the negative-root
+lower bound), with Cauchy as the fallback / sanity bound.
 
 ## Geometry: dyadic intervals on the real line
 
@@ -56,9 +87,8 @@ Bisection works on **dyadic intervals** `(lower, upper]` with
 midpoint `m := (lower + upper) / 2` produces two sub-intervals at
 half-width.
 
-The **Cauchy bound** `M := 1 + max_i |a_i| / |a_n|` (rounded up to a
-dyadic) bounds every real root of `p` in `[−M, M]`; the worklist
-starts with `(−M, M]`.
+The worklist starts with `(−M, M]` where `M` is the LMQ-derived
+bound (positive part) plus the symmetric mirror (negative part).
 
 ## Contents
 
@@ -70,13 +100,14 @@ structure DyadicInterval where
   upper : Dyadic
   ordered : lower < upper := by decide
 
-structure SimpleRealRootIsolation (p : ZPoly) where
+structure RealRootIsolation (p : ZPoly) where
   interval : DyadicInterval
-  witness  : sturmCount p interval = 1
-  -- sturmCount: ZPoly → DyadicInterval → ℕ; computed via integer
-  -- subresultant chain + dyadic evaluation. The witness type is
-  -- `Decidable Prop`, dischargeable by cbv_decide on a fully-
-  -- elaborated SimpleRealRootIsolation value.
+  witness  : descartesIsolatesOne p interval
+  -- descartesIsolatesOne: ZPoly → DyadicInterval → Prop, decidable.
+  -- True when the Möbius-transformed polynomial p_M(x) has
+  -- signVariations(p_M) = 1, OR the witness extends to handle the
+  -- right-endpoint case p(upper) = 0 with the strict-positive case
+  -- having signVariations = 0.
 
 /-- p has only simple real roots. Default-decidable via
     Hex.HasOnlySimpleRealRoots.decide (gcd(p, p') is a unit, so p
@@ -87,43 +118,38 @@ def HasOnlySimpleRealRoots (p : ZPoly) : Prop := …
 instance : Decidable (HasOnlySimpleRealRoots p) := …
 ```
 
-`SimpleRealRootIsolation p` carries one *simple* real root in its
-interval — `Simple` because the witness pins the Sturm count at 1
-(not 0, not ≥ 2). For inputs with multiple roots the bisection never
-satisfies the witness around the multiple root, and `isolate`
-refuses such inputs (see Operations).
-
 ## Operations
 
 ```lean
-namespace SimpleRealRootIsolation
-def refine1?  : SimpleRealRootIsolation p → Option (SimpleRealRootIsolation p)
-def refine?   : (target : Nat) → SimpleRealRootIsolation p →
-                Option (SimpleRealRootIsolation p)
-def refineTo  : SimpleRealRootIsolation p → (target : Nat) →
-                SimpleRealRootIsolation p
-end SimpleRealRootIsolation
+namespace RealRootIsolation
+def refine1?  : RealRootIsolation p → Option (RealRootIsolation p)
+def refine?   : (target : Nat) → RealRootIsolation p →
+                Option (RealRootIsolation p)
+def refineTo  : RealRootIsolation p → (target : Nat) →
+                RealRootIsolation p
+end RealRootIsolation
 
 /-- Isolate every simple real root of p (for squarefree p). -/
 def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRealRoots p)
-    (atom_prec : Nat) : Array (SimpleRealRootIsolation p)
+    (atom_prec : Nat) : Array (RealRootIsolation p)
 
 def cauchyBound (p : ZPoly) : Dyadic
+def lmqBound    (p : ZPoly) : Dyadic   -- upper bound on positive real roots
 def realRootSeparation (p : ZPoly) : Nat
 ```
 
-`refine1?` bisects the current interval at the dyadic midpoint, runs
-the Sturm count on each half, and returns the half whose count is 1
-(the other half has count 0; the case of count 2 cannot occur on a
-SimpleRealRootIsolation by the witness invariant, modulo tie-cases
-at the midpoint — see "midpoint hits a root" below). `refine?` and
-`refineTo` iterate to a target precision.
+`refine1?` bisects at the dyadic midpoint, runs Möbius+Descartes on
+each half, and returns the half whose `signVariations` is odd
+(typically `1`; the case of `≥ 3` cannot occur on a
+`RealRootIsolation` by the witness invariant — the existing witness
+guarantees the parent interval contained exactly one root).
+`refine?` and `refineTo` iterate.
 
-`isolate` runs the Sturm bisection driver: starting with the Cauchy
-interval `(−M, M]`, repeatedly split intervals whose Sturm count
-exceeds 1; emit intervals with count 1; discard intervals with count
-0. Termination by `realRootSeparation p` (Mahler/Mignotte real-root
-bound).
+`isolate` runs the Uspensky bisection driver: starting from the
+worklist `[(−M, M]]` with `M := max(lmqBound, cauchyBound)`, repeat:
+pop an interval; compute `signVariations(p_M)`; if 0, discard; if 1,
+emit; if ≥ 2, bisect. Termination by `realRootSeparation p`
+(Mahler/Mignotte real-root bound).
 
 ### Midpoint hits a root
 
@@ -142,18 +168,18 @@ Mirroring [hex-roots](hex-roots.md):
 ```lean
 namespace Hex
 def SimpleRealRoot (p : ZPoly) :=
-    Quotient (SimpleRealRootIsolation.setoid p)
+    Quotient (RealRootIsolation.setoid p)
 
-instance SimpleRealRootIsolation.setoid (p : ZPoly) :
-    Setoid (SimpleRealRootIsolation p) := …
+instance RealRootIsolation.setoid (p : ZPoly) :
+    Setoid (RealRootIsolation p) := …
 
 instance : DecidableEq (SimpleRealRoot p) := Quotient.decidableEq
 
 namespace SimpleRealRoot
-def mk (iso : SimpleRealRootIsolation p) : SimpleRealRoot p :=
+def mk (iso : RealRootIsolation p) : SimpleRealRoot p :=
     Quotient.mk _ iso
 
-def out (s : SimpleRealRoot p) (prec : Nat) : SimpleRealRootIsolation p
+def out (s : SimpleRealRoot p) (prec : Nat) : RealRootIsolation p
 
 def refine (s : SimpleRealRoot p) (target : Nat) : SimpleRealRoot p
 end SimpleRealRoot
@@ -168,8 +194,7 @@ The **threading pattern** is the same as in `hex-roots`: callers
 holding a `SimpleRealRoot p` should refine once and forward the
 refined value rather than re-refining at each `out` call. See
 [hex-roots.md §"The threading pattern"](hex-roots.md) for the
-canonical exposition; the rules here are identical with `Real` /
-`SimpleRealRoot` substituted for the complex names.
+canonical exposition.
 
 ## `realRootSeparation` — termination bound
 
@@ -188,47 +213,77 @@ restricted to the real case.
 
 ## Algorithm exposition
 
-The Sturm bisection algorithm:
+The Uspensky bisection algorithm:
 
 1. **Squarefree-ify.** `p_sf := p / gcd(p, p')`. Provided as a
    precondition via `HasOnlySimpleRealRoots`; not mutated by the
    algorithm itself. (Internally `isolate` may call the gcd routine
    defensively; the SPEC contract requires squarefree input.)
-2. **Sturm sequence.** Compute the integer Sturm sequence via
-   `subresultantChain` from `hex-resultant`, with Sylvester–Habicht
-   sign-flip applied so the resulting sequence has the sign-change
-   semantics of the classical Sturm sequence. Pre-computed once.
-3. **Cauchy bound.** Compute `M := cauchyBound p` (a dyadic).
-4. **Total root count.** Compute `N := V(−M) − V(M)`.
-5. **Bisection driver.** Worklist initialised with `(−M, M]`. Loop:
-   pop an interval `(a, b]`; compute `n := V(a) − V(b)`; if `n = 0`,
-   discard; if `n = 1`, emit a `SimpleRealRootIsolation`; if `n > 1`,
-   bisect at `m := (a + b) / 2` and push both halves. Terminates
-   when worklist is empty.
-6. **Refinement.** A `SimpleRealRootIsolation` at precision `prec`
-   can be refined to `prec + 1` by bisecting and re-running the
-   Sturm count on the half containing the root.
+2. **Bounds.** Compute `M := max(lmqBound p, cauchyBound p)` —
+   conservative outer bound on real-root locations.
+3. **Worklist.** Initialise with `[(−M, M]]`. For each interval,
+   apply Möbius transform `x ↦ a + (b − a)/(1 + x)` to get `p_M`,
+   compute `signVariations(p_M)`, and dispatch:
+   - `signVariations = 0`: discard.
+   - `signVariations = 1`: emit a `RealRootIsolation`.
+   - `signVariations ≥ 2`: bisect at `m := (a + b)/2`; push both
+     halves.
+   - Special case: `p(b) = 0` (right endpoint is a root of `p`).
+     Emit `(a, b]` as an isolation; ensure subsequent intervals
+     start strictly above `b`.
+4. **Refinement.** A `RealRootIsolation` at precision `prec` is
+   refined to `prec + 1` by bisecting and re-running Möbius+Descartes
+   on the half containing the root.
 
-Only-simple-roots check via `HasOnlySimpleRealRoots`: `gcd(p, p')`
-is a unit. Squarefree `p` ⟹ no multiple roots in any field ⟹ in
-particular no multiple real roots. The converse fails (squarefree
-in ℂ but with double real roots is impossible, so the converse
-holds for ℝ-roots; mathlib companion makes this precise).
+Termination by `realRootSeparation p` plus interval-halving: any
+two distinct real roots are eventually placed in disjoint intervals
+once interval width drops below `2^{-realRootSeparation p}`, after
+which each interval has `signVariations ≤ 1`.
 
-Multiple-real-root case: not supported by `isolate`. The bisection
-would never reduce a count-2 interval below 2 around a real double
-root. Caller squarefree-ifies first.
+Multiple-real-root case: not supported by `isolate`. Caller
+squarefree-ifies first.
+
+## Why Uspensky / Descartes, not Sturm
+
+Pinned: Uspensky (Descartes + Möbius bisection). Deliberately *not*
+implemented in this round:
+
+- **Sturm's theorem + bisection.** The classical alternative.
+  Theoretically more robust on clustered roots (Sturm gives exact
+  interval counts; Descartes only bounds them). Rejected because
+  Mathlib has no Sturm sequence, no Sturm theorem, and no
+  subresultant pseudo-remainder chain — the bridge would require
+  multi-month formalisation work. Mathlib *does* have Descartes'
+  rule of signs (`Polynomial.signVariations` in
+  `Mathlib.Algebra.Polynomial.RuleOfSigns`), so Uspensky's bridge
+  proof rides on existing infrastructure.
+- **Vincent's theorem / VCA / VAS** (continued-fraction-based
+  isolation). Faster than Uspensky in practice (used by FLINT,
+  Mathematica, SageMath). Rejected because Vincent's theorem is
+  absent from Mathlib; formalising it is a multi-month side quest
+  before any tactic-level payoff.
+- **Speculative Newton refinement** (quadratic convergence on top
+  of any bisection driver). Worth considering as a future
+  refinement; not in this SPEC.
+
+If a future library or tactic needs reusable interval-root-count
+primitives (which Sturm provides natively but Uspensky does not),
+Sturm could be added then with full formalisation cost. Until that
+demand exists, Uspensky's narrower payoff is the right scope.
 
 ## Layered file organisation
 
 - `HexRealRoots/Basic.lean` — types: `DyadicInterval`,
-  `SimpleRealRootIsolation`, `Hex.HasOnlySimpleRealRoots`. Setoid +
+  `RealRootIsolation`, `Hex.HasOnlySimpleRealRoots`. Setoid +
   Quotient `SimpleRealRoot p` + decidable equality. `mk` and `out`.
-- `HexRealRoots/Sturm.lean` — `sturmSequence` (subresultant-based
-  with Sylvester–Habicht sign flip), `sturmCount` (sign-change
-  difference at a dyadic interval's endpoints), and the Sturm
-  count's Decidable infrastructure.
-- `HexRealRoots/Cauchy.lean` — `cauchyBound`.
+- `HexRealRoots/Mobius.lean` — Möbius transformation of polynomials:
+  `mobiusTransform p a b` returns the integer polynomial
+  `(1+x)^(deg p) · p(a + (b−a)/(1+x))` (after clearing dyadic
+  denominators).
+- `HexRealRoots/Descartes.lean` — `descartesCount p interval` =
+  `signVariations(mobiusTransform p ...)`; `descartesIsolatesOne`
+  predicate and `Decidable` infrastructure.
+- `HexRealRoots/Bounds.lean` — `cauchyBound`, `lmqBound`.
 - `HexRealRoots/Separation.lean` — `realRootSeparation`.
 - `HexRealRoots/Refine.lean` — `refine1?`, `refine?`, `refineTo`,
   `refineTo_respects_equiv`, `SimpleRealRoot.refine`. Threading-
@@ -254,28 +309,45 @@ Per [SPEC/testing.md](../testing.md), tiered:
 - *ci* (CI, with external oracle): 30 degree-15 polynomials with
   small random integer coefficients; expected outputs from SageMath
   or python-flint.
-- *local* (developer-driven): adversarial families — Mignotte
-  `xⁿ − (a·x − 1)²` for `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`,
-  Wilkinson 20, Chebyshev `T_n` for `n ∈ {20, 50}`.
+- *local* (developer-driven): adversarial families designed to
+  stress Uspensky's known weak spot — clustered-root cases:
+  - **Mignotte** `xⁿ − (a·x − 1)²` for `n ∈ {10, 20}` and
+    `a ∈ {1000, 10⁶}` (close real roots near `1/a`). Uspensky pays
+    extra here because Descartes' bound is loose on tight clusters.
+  - **Wilkinson 20** (roots at `1, 2, …, 20`; condition number
+    explodes, but distinct roots so Uspensky terminates).
+  - **Chebyshev** `T_n` for `n ∈ {20, 50}` (real roots cluster near
+    `±1`).
 
 External oracles: SageMath
 (`R.<x> = ZZ[]; (p).real_roots()`), python-flint
-(`fmpz_poly` real-root API), FLINT/Arb (`arb_poly_isolate_real_roots`).
+(`fmpz_poly` real-root API), FLINT/Arb
+(`arb_poly_isolate_real_roots`).
 
 ## Complexity contract
 
-- `cauchyBound p`: `O(n)` integer comparisons + one division.
-- `sturmSequence p`: `O(n)` polynomial pseudo-division steps via
-  `hex-resultant.subresultantChain`; coefficient size bounded by
-  the subresultant theorem's `O(n · log ‖p‖∞)`.
-- `sturmCount p (a, b)`: `O(n)` polynomial evaluations at two
-  dyadic points + `O(n)` integer sign comparisons.
+For Uspensky's algorithm on degree-`n` squarefree `p` with sup-norm
+`‖p‖∞`:
+
+- `cauchyBound p`: `O(n)` integer comparisons.
+- `lmqBound p`: `O(n²)` integer operations (the double-max).
+- Möbius transform of `p` to a candidate interval: `O(n²)` integer
+  multiplications; intermediate coefficient size `O(n · log ‖p‖∞)`
+  per transform.
+- `signVariations` on the transformed polynomial: `O(n)` integer
+  sign comparisons.
 - `realRootSeparation p`: `O(n · log ‖p‖∞)` integer operations.
-- `isolate p (atom_prec)` for degree-`n` squarefree `p` with
-  well-separated roots: heuristically `O(n³ · atom_prec)` integer
-  operations. Worst case bounded by `realRootSeparation`, which is
-  exponential in `n` for arbitrary-coefficient inputs but
-  polynomial in `‖p‖∞` for fixed `n`.
+- `isolate p` worst case: `O(n · realRootSeparation p)` Möbius+
+  Descartes evaluations, dominated by the Möbius transform per
+  step. Concretely, `Õ(n^4 · log² ‖p‖∞)` bit operations on benign
+  inputs; potentially `Õ(n^4 · realRootSeparation²)` on Mignotte
+  clusters where Descartes' bound is loose.
+
+This is the same asymptotic class as Sturm + bisection (both are
+`Õ(n^4 · h^2)`). Uspensky's actual constants are typically
+*better* on benign inputs because Möbius transforms are simpler
+than Sturm-sequence evaluations, but *worse* on tight clusters
+because Descartes' bound stays > 1 for longer.
 
 ## Time budgets (Phase 4 validation)
 
@@ -286,23 +358,25 @@ fixtures during Phase 4:
 - Degree 50, prec 64: < 10 seconds.
 - Degree 100, prec 128: < 1 minute.
 
+Adversarial Mignotte clusters may exceed these; bench will surface
+the actual constants.
+
 ## References
 
-- Sturm, J. C. F. *Mémoire sur la résolution des équations
-  numériques.* Bull. Sci. Math. 11 (1829) 419–425. The original
-  theorem.
-- Sylvester, J. J. *On a theory of the syzygetic relations of two
-  rational integral functions.* Phil. Trans. R. Soc. London 143
-  (1853) 407–548. Sign-modified subresultant chain.
-- Habicht, W. *Eine Verallgemeinerung des Sturmschen
-  Wurzelzählverfahrens.* Comment. Math. Helv. 21 (1948) 99–116.
-  Generalises Sturm to subresultant-based chains.
-- Marden, M. *Geometry of Polynomials.* AMS Math. Surveys 3, 2nd
-  ed., 1966. Modern textbook treatment of Sturm.
+- Descartes, R. *La Géométrie* (1637) — original sign-variation
+  rule.
+- Vincent, A. J. H. *Sur la résolution des équations numériques*
+  (1834) — Vincent's theorem (used as the termination story for
+  classical Uspensky variants; not formalised here, where
+  Mignotte separation provides termination instead).
+- Uspensky, J. V. *Theory of Equations* (1948) — the
+  Möbius-bisection real-root isolation algorithm bears his name.
+- Akritas, A. G. *Elements of Computer Algebra with Applications*
+  (1989) — modern presentation of Uspensky and refinements.
+- Akritas, A. G.; Strzeboński, A. W.; Vigklas, P. S. *Improving
+  the performance of the continued fractions method using new
+  bounds of positive roots.* Nonlinear Analysis 13 (2008) — the
+  LMQ bound used here.
 - Basu, S.; Pollack, R.; Roy, M.-F. *Algorithms in Real Algebraic
-  Geometry.* Springer, 2nd ed., 2006. Comprehensive: Sturm + sign
-  matrices + cylindrical decomposition. **The reference** for this
-  library and its sibling `hex-sturm`.
-- Geddes, K. O.; Czapor, S. R.; Labahn, G. *Algorithms for Computer
-  Algebra.* Kluwer, 1992. §8 covers Sturm with subresultants and
-  the standard root-isolation drivers.
+  Geometry.* Springer, 2nd ed., 2006. Chapter 10 covers Uspensky
+  and Descartes-based isolation in detail.

--- a/SPEC/Libraries/hex-sturm.md
+++ b/SPEC/Libraries/hex-sturm.md
@@ -1,0 +1,304 @@
+# hex-sturm (Sturm-based decision procedure for univariate ℝ-formulas, depends on hex-real-roots + hex-real-roots-mathlib + hex-poly-z + hex-poly-z-mathlib + Mathlib)
+
+A Lean tactic providing a **complete decision procedure** for the
+univariate fragment of real-closed-field arithmetic. Closes goals
+that are Boolean combinations of polynomial (in)equalities in one
+real variable, with universal/existential quantifiers over `ℝ` or
+over bounded dyadic intervals.
+
+Reflective implementation: reify the goal to a `Formula` AST,
+isolate roots of every polynomial appearing in the formula via
+[hex-real-roots](hex-real-roots.md), build the **sign matrix** over
+the resulting cell decomposition of `ℝ`, evaluate the Boolean on
+each cell, check the quantifier, and close the goal via a
+soundness-of-reflection lemma proved in this same library. No
+separate Mathlib bridge — `hex-sturm` is `mathlib: true` because
+the tactic targets `ℝ`.
+
+This is the user-facing payoff of the algebraic-numbers stack:
+neither `polyrith` nor `nlinarith` is complete on this fragment,
+and `decide` is unavailable for `ℝ`-quantifiers. `sturm` decides
+the entire univariate fragment of the theory of real-closed fields.
+
+## What `sturm` decides
+
+Goal forms:
+
+```lean
+∀ x : ℝ,                             p₁(x) ⊳₁ 0 ∨ p₂(x) ⊳₂ 0 ∧ ¬ p₃(x) ⊳₃ 0 …
+∃ x : ℝ,                             …
+∀ x : ℝ, q(x) ≥ 0 →                  p(x) > 0
+∀ x ∈ Set.Ioc a b,                   p(x) ⊳ 0           -- a, b : Dyadic
+∃ x ∈ Set.Icc a b,                   p(x) = 0           -- root in interval
+```
+
+The atoms `pᵢ ⊳ᵢ 0` use `pᵢ ∈ ℤ[x]` (or `ℚ[x]`, cleared to `ℤ[x]`)
+and `⊳ᵢ ∈ {<, ≤, =, ≥, >, ≠}`. Boolean connectives `∧`, `∨`, `¬`
+nest freely.
+
+Concrete examples the tactic closes:
+
+```
+∀ x : ℝ,                                  x² + 1 > 0
+∀ x : ℝ, 0 ≤ x →                          x³ + x ≥ 0
+∀ x : ℝ, 0 < x →                          x + 1/x ≥ 2
+∀ x : ℝ, x² ≤ 1 →                         x⁴ − x² ≤ 0
+∃ x : ℝ, x³ − x − 1 = 0   ∧   1 < x ∧ x < 2
+∀ x : ℝ, p(x) ≠ 0    -- for any specific squarefree p
+```
+
+## What `sturm` does NOT decide (and how it falls through)
+
+The tactic must **fall through** (not produce a wrong proof, not
+loop forever) on any goal it cannot decide. Cases:
+
+- **Multivariate** goals (free variables ≠ 1 in the
+  reified formula). `∀ a x, ax² + 1 > 0` has two free variables;
+  the tactic refuses.
+- **Transcendental** terms: `sin`, `exp`, `log`, etc. The tactic
+  recognises these as non-polynomial atoms and refuses.
+- **Parameterised** atoms where coefficients are not concrete
+  integers: `∀ x : ℝ, x² + a > 0` (where `a` is a free variable)
+  reduces to multivariate.
+- **Goals with an unprovable conclusion.** The tactic only emits
+  "yes" answers; it does not produce a counterexample-style
+  rejection. On unprovable goals, it falls through silently.
+
+Falling through is implemented as the tactic raising
+`MetaM`-failure with a clear message; downstream tactics
+(`decide`, `nlinarith`, etc.) can take over.
+
+Multivariate generalisation is *Cylindrical Algebraic
+Decomposition* (CAD), which is exponentially expensive; explicitly
+out of scope. Univariate is the practical sweet spot.
+
+## Algorithm (reflective)
+
+The tactic implements 1-dimensional CAD:
+
+1. **Reify** the goal to a `Formula` AST:
+
+    ```lean
+    inductive AtomCmp where
+      | lt | le | eq | ge | gt | ne
+
+    inductive Atom where
+      | poly (p : ZPoly) (cmp : AtomCmp)   -- represents `p(x) ⊳ 0`
+
+    inductive Formula where
+      | atom    (a : Atom)
+      | tt
+      | ff
+      | not     (φ : Formula)
+      | and     (φ ψ : Formula)
+      | or      (φ ψ : Formula)
+      | implies (φ ψ : Formula)
+      -- Quantifiers wrap a Formula whose only free atom-variable
+      -- is the bound x.
+      | forallReal     (φ : Formula)
+      | existsReal     (φ : Formula)
+      | forallInterval (a b : Dyadic) (φ : Formula)
+      | existsInterval (a b : Dyadic) (φ : Formula)
+
+    structure ReifiedGoal where
+      formula : Formula
+      -- plus the proof obligation: `formula.toProp` is the original
+      -- Lean Prop the user asked us to prove.
+    ```
+
+   The reification machinery lives alongside the tactic in this
+   library; it uses Lean's `Qq` / `Lean.Meta` infrastructure.
+
+2. **Reject out-of-fragment input** (bail with `MetaM` failure).
+
+3. **Collect atoms' polynomials.** Walk `formula` and gather every
+   `pᵢ ∈ ZPoly` appearing in an `Atom.poly pᵢ cmpᵢ`.
+
+4. **Isolate roots** of each `pᵢ` via
+   `Hex.isolate pᵢ ⟨HasOnlySimpleRealRoots pᵢ proof⟩ prec`. For
+   `pᵢ` with multiple real roots, squarefree-ify first
+   (`pᵢ_sf := pᵢ / gcd(pᵢ, pᵢ')`) — multiplicities don't affect
+   sign analysis.
+
+5. **Build the cell decomposition.** Take the union of all root-
+   isolating intervals; sort by lower endpoint; refine until all
+   intervals are pairwise disjoint and ordered. The result is a
+   finite sequence of dyadic test points
+   `t₀ < t₁ < … < tₘ` where each `tᵢ` is interior to a unique cell:
+
+   ```
+   (−∞, root₁), {root₁}, (root₁, root₂), {root₂}, …, (rootₖ, +∞)
+   ```
+
+   Each "open interval" cell has a sign-constant interior (no root
+   of any `pⱼ` lies in it). Each "root point" cell has a known
+   sign (zero) for the relevant `pⱼ`s.
+
+6. **Sign matrix.** For each cell, evaluate the integer sign of
+   each `pⱼ` at the cell's representative point. The result is a
+   `m × k` matrix of signs `{−1, 0, +1}`.
+
+7. **Boolean evaluation.** For each cell, substitute the per-`pⱼ`
+   sign into each `Atom.poly pⱼ cmpⱼ`'s comparison, getting `True`
+   or `False` for each atom. Evaluate the Formula's Boolean
+   structure recursively to get a per-cell truth value.
+
+8. **Quantifier check.**
+   - `∀ x : ℝ, φ`: every cell evaluates true.
+   - `∃ x : ℝ, φ`: some cell evaluates true.
+   - `∀ x ∈ Set.Ioc a b, φ`: every cell *intersecting* `(a, b]`
+     evaluates true.
+   - `∃ x ∈ Set.Ioc a b, φ`: some cell *intersecting* `(a, b]`
+     evaluates true.
+
+9. **Reflection.** The decision result `true`/`false` is reflected
+   back to the original goal via the soundness lemma
+   `sturm_decide_sound` (below). On `true`, the tactic emits a
+   proof. On `false`, the tactic emits no proof and falls through —
+   it does not negate the goal.
+
+## Soundness theorem (in this library; no separate Mathlib bridge)
+
+```lean
+def Formula.toProp : Formula → Prop
+  -- Evaluate the AST against ℝ-valued atoms, with quantifiers
+  -- ranging over ℝ (or the specified Dyadic interval).
+
+def decide_sturm : Formula → Bool
+  -- Run the algorithm above; return whether the formula is valid.
+
+theorem sturm_decide_sound :
+    ∀ (φ : Formula), decide_sturm φ = true → φ.toProp
+```
+
+This is the **soundness lemma**: every "yes" answer produces a
+genuine proof of the corresponding `ℝ`-Prop. The proof factors
+through:
+
+- **Sign-matrix correctness.** For each cell, the signs are correct
+  at *every* point in the cell (not just the representative). This
+  follows because each `pⱼ` is sign-constant on cell interiors
+  (between consecutive roots) by IVT, and sign-zero at cell-points
+  (which are roots).
+- **Cell-decomposition completeness.** Every real number lies in
+  exactly one cell. Follows from the union-of-isolations being a
+  partition of `ℝ`.
+- **Boolean evaluation correctness.** Substituting signs into atoms
+  gives the correct truth value at every point in the cell.
+- **Quantifier correctness.** ∀/∃ on cells lifts to ∀/∃ on `ℝ`
+  because cells partition `ℝ` and the inner Prop is constant on
+  each cell.
+
+Imports: `hex-real-roots-mathlib`'s `isolate_correct` and
+`sturm_count_eq_real_root_count`; Mathlib's `IVT`,
+`Polynomial.aeval`, ordered-field structure on `ℝ`.
+
+The library does **not** prove completeness (that every valid
+univariate ℝ-CF formula is decided correctly). Tarski–Seidenberg
+and the completeness of Sturm's theorem give this for free, but
+the tactic only ever emits "yes" answers; "no" answers are never
+emitted as Lean proofs (the tactic falls through). So soundness is
+sufficient for tactic correctness.
+
+## Tactic surface
+
+```lean
+example : ∀ x : ℝ, x^2 + 1 > 0 := by sturm
+example : ∀ x : ℝ, 0 < x → x + 1/x ≥ 2 := by sturm
+example : ∃ x : ℝ, x^3 - x - 1 = 0 ∧ 1 < x ∧ x < 2 := by sturm
+```
+
+The exact tactic name (`sturm`, `decide_sturm`, or another) is
+chosen at implementation time per Mathlib's tactic-naming
+conventions.
+
+## Layered file organisation
+
+- `HexSturm/Formula.lean` — the AST (`Atom`, `Formula`,
+  `AtomCmp`); `Formula.toProp` Prop semantics; `decide_sturm`
+  driver.
+- `HexSturm/CellDecomposition.lean` — union-of-isolations cell
+  construction; representative-point selection; cell-set invariants.
+- `HexSturm/SignMatrix.lean` — per-cell, per-atom sign evaluation;
+  Boolean evaluation of `Formula` against the sign matrix.
+- `HexSturm/QuantifierCheck.lean` — ∀/∃ checks (full ℝ + bounded
+  intervals); cell-intersection logic.
+- `HexSturm/Soundness.lean` — `sturm_decide_sound` and supporting
+  lemmas (sign-matrix correctness, cell-decomposition completeness,
+  Boolean and quantifier soundness).
+- `HexSturm/Reflect.lean` — `MetaM`/`Qq` reification; tactic
+  driver; `MetaM`-failure paths for out-of-fragment input.
+- `HexSturm/Tactic.lean` — the user-facing `sturm` tactic
+  registration.
+- `HexSturm/Conformance.lean`, `HexSturm/Bench.lean`,
+  `HexSturm/EmitFixtures.lean` — standard testing trio.
+
+## Conformance fixtures
+
+Per [SPEC/testing.md](../testing.md):
+
+- *core* (Lean-only):
+  - **Provable, simple polynomials:**
+    - `∀ x : ℝ, x² + 1 > 0`
+    - `∀ x : ℝ, 0 ≤ x → x³ + x ≥ 0`
+    - `∀ x : ℝ, 0 < x → x + 1/x ≥ 2`  *(after `field_simp`-style
+      preprocessing or stated as `∀ x > 0, x² + 1 ≥ 2x`)*
+    - `∀ x : ℝ, x² ≤ 1 → x⁴ − x² ≤ 0`
+  - **Existential with explicit witness location:**
+    - `∃ x : ℝ, x³ − x − 1 = 0 ∧ 1 < x ∧ x < 2`
+  - **Squarefree polynomial root absence:**
+    - `∀ x : ℝ, x² + 2x + 2 ≠ 0`
+  - **Fall-through cases (tactic must refuse, not produce a wrong proof):**
+    - Multivariate: `∀ a x : ℝ, a*x² + 1 > 0` — refused
+      (multivariate).
+    - Transcendental: `∀ x : ℝ, sin x ≤ 1` — refused
+      (non-polynomial atom).
+- *ci* (CI, with external oracle when available): 30 deterministic
+  univariate goals constructed from random small-coefficient
+  polynomials. Oracle: SageMath's `QQbar.real_roots` + manual
+  formula evaluation, or Mathematica's `Reduce`.
+- *local* (developer-driven): high-degree adversarial families
+  (Mignotte-near-zero polynomials, polynomials with extremely close
+  roots requiring high-precision sign matrix).
+
+External oracles: SageMath (`Reduce`-equivalent via
+`QQbar`-based real-root analysis); Mathematica (`Reduce`,
+`Resolve`); Wolfram Alpha for one-off cross-checks.
+
+## Complexity contract
+
+For a goal with `k` distinct polynomials of total degree `n` and
+sup-norm `‖·‖∞`:
+
+- **Reification:** linear in goal size.
+- **Root isolation** of all `k` polynomials: `O(k · n³ · log ‖·‖∞)`
+  bit operations (`hex-real-roots.isolate` per polynomial).
+- **Cell decomposition:** `O(k · n)` cells; sort `O(k·n log(k·n))`.
+- **Sign matrix:** `O(k · n²)` polynomial evaluations.
+- **Boolean evaluation:** `O(k · |formula|)` per cell.
+- **Total:** dominated by root isolation, roughly
+  `O(k · n³ · log ‖·‖∞)`.
+
+For typical user goals (`k ≤ 5`, `n ≤ 10`, small coefficients) the
+tactic should complete in under a second.
+
+## Time budgets (Phase 4 validation)
+
+- Linear or quadratic goal, `k = 1`, `n ≤ 4`: < 100 ms.
+- Polynomial goal of degree ≤ 10, `k ≤ 3`: < 1 second.
+- Adversarial degree-50, `k = 1`: < 30 seconds.
+
+## References
+
+- Tarski, A. *A Decision Method for Elementary Algebra and
+  Geometry.* RAND Corp, 1948 (republished by Univ. California
+  Press, 1951). The foundational decidability result for the
+  theory of real-closed fields.
+- Sturm 1829, Marden 1966 — see [hex-real-roots](hex-real-roots.md)
+  §"References".
+- Basu, S.; Pollack, R.; Roy, M.-F. *Algorithms in Real Algebraic
+  Geometry.* Springer, 2nd ed., 2006. Algorithm 10.13 (Sign
+  Determination at the Roots) and Chapter 13 (CAD) cover the
+  univariate sign-matrix construction this library implements.
+- Cohen, A. M. (ed.) *A Mathematical Companion to Computer
+  Algebra.* Springer, 2002. §3 (Real Algebraic Geometry).

--- a/libraries.yml
+++ b/libraries.yml
@@ -218,7 +218,7 @@ libraries:
     mathlib: true
     done_through: 0
     status: planned
-  HexRcf:
+  HexRCF:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
     done_through: 0

--- a/libraries.yml
+++ b/libraries.yml
@@ -209,16 +209,16 @@ libraries:
     done_through: 0
     status: planned
   HexRealRoots:
-    deps: [HexPolyZ, HexResultant]
+    deps: [HexPolyZ]
     mathlib: false
     done_through: 0
     status: planned
   HexRealRootsMathlib:
-    deps: [HexRealRoots, HexPolyZMathlib, HexResultantMathlib]
+    deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true
     done_through: 0
     status: planned
-  HexSturm:
+  HexRcf:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true
     done_through: 0

--- a/libraries.yml
+++ b/libraries.yml
@@ -208,3 +208,18 @@ libraries:
     mathlib: true
     done_through: 0
     status: planned
+  HexRealRoots:
+    deps: [HexPolyZ, HexResultant]
+    mathlib: false
+    done_through: 0
+    status: planned
+  HexRealRootsMathlib:
+    deps: [HexRealRoots, HexPolyZMathlib, HexResultantMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned
+  HexSturm:
+    deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
+    mathlib: true
+    done_through: 0
+    status: planned

--- a/progress/20260508T032431Z.md
+++ b/progress/20260508T032431Z.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+- Added three new SPEC files for the real-roots / sturm pipeline,
+  all `status: planned`:
+  - `SPEC/Libraries/hex-real-roots.md` — certified real root
+    isolation for `ℤ[x]` via Sturm's theorem + bisection. Sturm
+    sequence computed via the subresultant pseudo-remainder chain
+    from `hex-resultant` (Sylvester–Habicht sign-flip), keeping all
+    coefficients in ℤ. Mirrors `hex-roots`'s conventions
+    (`SimpleRealRoot p` Quotient, threading pattern, Mahler/Mignotte
+    separation bound) for the real case. Cauchy-bound + bisection
+    driver; refinement + threading. ~270 lines.
+  - `SPEC/Libraries/hex-real-roots-mathlib.md` — Mathlib bridge:
+    `SimpleRealRoot.toReal`, `sturm_count_eq_real_root_count`
+    (Sturm's theorem), `cauchyBound_bounds_real_roots`,
+    `realRootSeparation_bounds_min_gap`, `isolate_correct`. Notes
+    that Sturm's theorem may need to be ported inline if Mathlib
+    lacks it. ~140 lines.
+  - `SPEC/Libraries/hex-sturm.md` — Lean tactic for the univariate
+    fragment of real-closed-field arithmetic. Reflective
+    implementation: reify Formula AST → reject out-of-fragment →
+    isolate atoms' polynomial roots → cell decomposition → sign
+    matrix → Boolean evaluation → quantifier check → reflection
+    soundness lemma. `mathlib: true` because the tactic targets `ℝ`;
+    soundness theorem lives in this same library, no separate
+    Mathlib bridge. Lists what falls through (multivariate,
+    transcendental). ~300 lines.
+
+- Added three `libraries.yml` entries: `HexRealRoots`,
+  `HexRealRootsMathlib`, `HexSturm`. All `status: planned`.
+  `HexRealRoots` deps on `HexResultant` (subresultant Sturm chain).
+  `HexSturm` is `mathlib: true` and depends on both
+  `HexRealRoots` + `HexRealRootsMathlib`.
+
+- Updated `SPEC/Libraries/README.md` with three entries (one per
+  new library) in the descriptive list, the dependency list, and
+  the index.
+
+- Verified: `python3 scripts/check_dag.py` exit 0;
+  `python3 scripts/status.py` shows all 9 planned libraries in the
+  Planned (skipped) footer.
+
+## Current frontier
+
+- Branch `spec/real-roots-and-sturm` carries the changes.
+- Ready to commit + push + open PR with auto-merge.
+
+## Next step
+
+- Commit, push, open the PR with `gh pr merge --auto --squash`.
+
+## Blockers
+
+- None.

--- a/progress/20260508T035548Z.md
+++ b/progress/20260508T035548Z.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+Pivoted `hex-real-roots` (and renamed `hex-sturm` → `hex-rcf`) per
+review. The previous SPEC had pinned Sturm's theorem + subresultant
+chains; a Mathlib audit found neither is in Mathlib (Sturm's
+theorem is listed as a "1000 theorems" target with no proof, no
+subresultant chain) while Descartes' rule of signs *is* present
+(`Polynomial.signVariations` in
+`Mathlib.Algebra.Polynomial.RuleOfSigns`). Codex agreed the
+Descartes/Uspensky path has dramatically lower formalisation cost.
+
+Changes:
+
+- `SPEC/Libraries/hex-real-roots.md` rewritten for Uspensky's
+  algorithm (Descartes + Möbius bisection) with LMQ bounds. Drops
+  the dep on `hex-resultant` (no subresultant chain needed). Adds
+  a "Why Uspensky / Descartes, not Sturm" section explicitly
+  listing what's *not* implemented (Sturm, VCA, VAS) and why.
+- `SPEC/Libraries/hex-real-roots-mathlib.md` rewritten: bridge now
+  rides on Mathlib's `signVariations` + `roots_countP_pos_le_signVariations`.
+  Headline obligations: Möbius-transform-correspondence, the
+  exact-1 parity corollary, `cauchyBound` + `lmqBound` correctness,
+  Mignotte real-root separation, `isolate_correct`. No Sturm
+  theorem to formalise.
+- `SPEC/Libraries/hex-sturm.md` renamed (via `git mv`) to
+  `SPEC/Libraries/hex-rcf.md` and rewritten throughout: tactic name
+  changes from `sturm` to `rcf` (real-closed field, algorithm-
+  neutral); references to "Sturm-based" decision procedure removed;
+  module names updated `HexSturm/*` → `HexRcf/*`. Algorithm body
+  (sign-matrix construction over the cell decomposition) is
+  unchanged — `hex-rcf` consumes whatever isolation algorithm
+  `hex-real-roots` happens to use.
+- `libraries.yml`: `HexRealRoots` deps reduced to `[HexPolyZ]`
+  (drops `HexResultant`); `HexRealRootsMathlib` deps reduced to
+  `[HexRealRoots, HexPolyZMathlib]` (drops `HexResultantMathlib`);
+  `HexSturm` renamed to `HexRcf` with same deps.
+- `SPEC/Libraries/README.md`: descriptions, deps lists, and index
+  all updated to reflect Uspensky/LMQ + the rename.
+
+Verified: `python3 scripts/check_dag.py` exit 0;
+`python3 scripts/status.py` footer now lists `HexRcf` (not
+`HexSturm`); 9 planned libraries total.
+
+## Current frontier
+
+- Branch `spec/real-roots-and-sturm` carries the changes
+  (force-pushable to PR #2656, currently in draft).
+- Ready to commit + push.
+
+## Next step
+
+- Commit, push, surface to user. PR #2656 stays in draft per user
+  preference; un-drafting is a user decision.
+
+## Blockers
+
+- None.

--- a/scripts/libgraph.py
+++ b/scripts/libgraph.py
@@ -309,7 +309,7 @@ def pascal_to_spec_path(name: str) -> str:
     i = 0
     while i < len(tail):
         matched = None
-        for token in ("GF2", "GFq", "LLL", "Fp", "CRT", "Mathlib"):
+        for token in ("GF2", "GFq", "LLL", "Fp", "CRT", "RCF", "Mathlib"):
             if tail.startswith(token, i):
                 matched = token
                 break
@@ -328,6 +328,7 @@ def pascal_to_spec_path(name: str) -> str:
         "LLL": "lll",
         "Fp": "fp",
         "CRT": "crt",
+        "RCF": "rcf",
         "Mathlib": "mathlib",
         "Z": "z",
     }


### PR DESCRIPTION
This PR adds three speculative SPECs that together deliver the highest-payoff tactic on the table from earlier planning: a complete decision procedure for the univariate fragment of real-closed-field arithmetic. All three are `status: planned` per PR #2651's convention — SPEC files land on `main`, no Lean code, no Lake target, no root file, ignored by orchestration until promoted to `active`.

`hex-real-roots` specifies certified real root isolation for `ℤ[x]` via Sturm's theorem + bisection. The Sturm sequence is the integer subresultant pseudo-remainder chain from `hex-resultant` (Sylvester–Habicht sign-flip), keeping all coefficients in `ℤ` throughout — no rational arithmetic, no float. Conventions mirror `hex-roots` (the complex BSSY library): `SimpleRealRoot p` Quotient, threading pattern, Mahler/Mignotte separation bound. Cauchy bound + bisection driver + refinement.

`hex-real-roots-mathlib` specifies the bridge to `Polynomial ℤ` and `ℝ`-root semantics: `SimpleRealRoot.toReal`, Sturm's theorem (`sturm_count_eq_real_root_count`), `cauchyBound_bounds_real_roots`, `realRootSeparation_bounds_min_gap`, `isolate_correct`. Notes that Sturm's theorem may need to be ported inline if Mathlib lacks it (per `PLAN/Conventions.md`'s "inline with attribution" rule).

`hex-sturm` specifies a Lean tactic for the univariate fragment of real-closed-field arithmetic — Boolean combinations of polynomial (in)equalities in one real variable with `∀x:ℝ` / `∃x:ℝ` quantifiers (and bounded-interval variants). Reflective implementation: reify the goal to a `Formula` AST, reject out-of-fragment input, isolate roots of all polynomial atoms via `hex-real-roots`, build the cell decomposition of `ℝ`, compute the sign matrix, evaluate the Boolean per cell, check the quantifier, and close the goal via a soundness-of-reflection lemma. `mathlib: true` (the tactic targets `ℝ`); the soundness theorem lives in the same library — no separate `hex-sturm-mathlib`. The library lists what falls through (multivariate, transcendental, parameterised) so unprovable goals don't loop.

Three new `libraries.yml` entries with `status: planned`. `HexRealRoots` depends on `HexPolyZ + HexResultant`. `HexSturm` is `mathlib: true` and depends on `HexRealRoots + HexRealRootsMathlib + HexPolyZ + HexPolyZMathlib`. Plus README updates: descriptive list, dependency list, and index, all extended with the three new entries.

🤖 Prepared with Claude Code