### PR TITLE
spec: tighten Phase 4 doctrine with profiling and headline reports

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -274,21 +274,26 @@ Answer all four. One line each is enough.
 A `depends-on:` answer to any of (1)–(4) is healthy. An unanswered
 question is the failure shape.
 
-### Bench-found and conformance-found issues
+### Bench-found, conformance-found, and audit-found issues
 
-Issues filed in response to a benchmark verdict mismatch or a
-conformance failure use the [canonical issue body shape](#canonical-issue-body-shape)
-plus a **Symptom** section recording the evidence:
+Issues filed in response to a benchmark verdict mismatch, a
+conformance failure, or an **audit finding** use the [canonical
+issue body shape](#canonical-issue-body-shape) plus a **Symptom**
+section recording the evidence:
 
 - **Declared expectation.** For a bench finding: the complexity model
   declared in `setup_benchmark` (e.g. `n => n * Nat.log2 (n + 1)`).
   For a conformance finding: the property the failing `#guard` was
-  checking, or the oracle's expected output.
+  checking, or the oracle's expected output. For an audit finding:
+  the SPEC clause the audited work was claimed to satisfy.
 - **Observed result.** For a bench finding: the verdict text emitted
   by `lake exe ... run NAME` (e.g. `inconclusive (cMin=10.5,
   cMax=25.3, β=0.42)`), plus a copy of the relevant JSONL rows. For
   a conformance finding: the failing input, the Lean output, and the
-  oracle output.
+  oracle output. For an audit finding: the specific evidence (a
+  bench input the algorithm short-circuits past, a profile entry
+  showing a dominant cost not attributed to a registered target,
+  a comparator named in the per-library SPEC but not wired, etc.).
 - **Root-cause hypothesis.** One paragraph: what algorithmic shape
   produces this observation? "Quadratic on `p` because we search
   `List.range p`," "factor of `n` slower because we rebuild
@@ -302,6 +307,43 @@ The **Deliverables** section lists two PRs:
 2. The implementation PR fixing the bug at the rolled-back phase.
 
 Cross-link both PRs to this issue.
+
+#### What "audit finding" means
+
+A bench verdict mismatch and a conformance failure both fire from
+an automated check. An audit finding fires from an author writing
+a headline report, reviewing a Phase-4 claim, or otherwise
+auditing existing work, and noticing something that warrants an
+issue **even though no automated verdict fired**.
+
+Examples (illustrative, not exhaustive):
+
+- A bench input is degenerate so the algorithm short-circuits
+  past it (e.g. an LLL bench whose only end-to-end target uses
+  the identity basis, where no Lovász swap fires).
+- A comparator the per-library SPEC requires is not wired.
+- A profile shows a dominant inclusive cost the bench targets
+  do not measure (per
+  [SPEC/benchmarking.md §Attribution rule](../SPEC/benchmarking.md#the-attribution-rule)).
+- An end-to-end target's empirical slope visibly disagrees with
+  its declared complexity over the parameter ladder.
+- A per-library SPEC names no comparator for an algorithm where
+  external references obviously exist (LLL, factoring, GCD, ...)
+  and Phase 4's comparator clause is being claimed satisfied
+  vacuously.
+
+When an audit finding occurs while writing a headline report:
+
+1. File the canonical issue using the body shape above.
+2. Link the issue from the report's §Concerns subsection.
+3. Complete the rest of the report.
+
+The library cannot **remain** at `done_through: 4` while the
+Concern is unresolved (per
+[PLAN/Phase4.md §Exit criteria](Phase4.md#exit-criteria)).
+Resolution available to the orchestrator: act on the HO issue
+tied to the Concern until the underlying problem is fixed and
+the Concern entry is removed from the report.
 
 ### Decomposition is normal
 

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -59,12 +59,29 @@ For each library `HexFoo` advancing through Phase 4:
 5. **External-comparator registrations** where the library SPEC
    names an architecturally important external tool (FLINT, fpLLL,
    GMP, NTL for FFI; Sage, GAP, PARI, python-flint for process
-   calls). FFI is preferred; see
+   calls). Each named comparator carries a classification per
+   [SPEC/benchmarking.md §Comparator classification](../SPEC/benchmarking.md#comparator-classification-gating-vs-informational)
+   — `gating` (must be wired before Phase 4 is claimed) or
+   `informational` (ratio recorded, may be scheduled-only).
+   Structured metadata lives in `libraries.yml: phase4.comparators`.
+   FFI is preferred; see
    [SPEC/benchmarking.md §External comparators](../SPEC/benchmarking.md#external-comparators)
-   for the integration patterns. Each required comparator must end
-   Phase 4 as either implemented now, scheduled-only with its
-   environment stated, or blocked by a narrow issue that keeps the
-   library below completion.
+   for the integration patterns.
+
+6. **Profile coverage** per
+   [SPEC/profiling.md §Coverage requirement](../SPEC/profiling.md#coverage-requirement):
+   at least one representative case per `phase4.input_families`
+   entry in `libraries.yml`, recorded in
+   `reports/<lib>-performance.md §Profile`. Categorise leaf cost
+   across {own code, GMP, allocation, Lean runtime}; rank inclusive
+   cost; explain the dominant entries.
+
+7. **Headline report** at `reports/<lib>-performance.md` per
+   [SPEC/benchmarking.md §Headline reports](../SPEC/benchmarking.md#headline-reports).
+   Five subsections: Bench targets, Verdicts, Comparator ratios,
+   Profile, Concerns. Every numeric claim cites the bench case
+   name, command line, seed/parameter, JSONL path, profile
+   location, and comparator source.
 
 The PR description records, in one paragraph, any case where the
 declared complexity model differs from the canonical textbook
@@ -116,16 +133,41 @@ For library `hex-foo`, Phase 4 is done when:
   settings;
 - every `compare` group named by the SPEC is registered and reports
   `allAgreed` on its declared common domain;
-- every external-comparator registration named by the SPEC is wired
-  (FFI shim or process call), with its execution policy recorded in
-  the bench module docstring;
-- no registration is merely "consistent" while still orders of
-  magnitude slower than a named architectural comparator on the same
-  canonical task family;
+- every comparator declared `gating` in `libraries.yml:
+  phase4.comparators` is wired and the headline report records its
+  measured ratio; `informational` comparators record ratios but do
+  not gate;
+- the [Attribution rule](../SPEC/benchmarking.md#the-attribution-rule)
+  is satisfied: every dominant profiled cost maps to a registered
+  bench target, or the per-library SPEC documents why the cost
+  cannot be separated;
+- a profile run per
+  [SPEC/profiling.md §Coverage requirement](../SPEC/profiling.md#coverage-requirement)
+  is recorded in `reports/<lib>-performance.md §Profile`;
+- the headline report at `reports/<lib>-performance.md` exists with
+  the five mandated subsections and full artefact traceability;
+- the headline report's §Concerns subsection is empty. A library
+  cannot **remain** at `done_through: 4` while any Concern is
+  unresolved; the orchestrator rolls back if this state is detected.
+  The only resolution available to the orchestrator is to act on
+  the HO issue tied to the Concern until the underlying problem is
+  fixed and the Concern entry is removed from the report.
 - the CI smoke step (`list` + `verify`) runs on every PR.
 
 If any of these fail, the right action is rollback per
 [Conventions.md](Conventions.md), not a SPEC-text edit weakening
 the criterion.
+
+### Audit reset
+
+As of the merge of the PR introducing the new exit criteria above
+(profile coverage, headline report, gating-comparator wiring,
+Attribution rule, empty-Concerns), every library currently at
+`done_through ≥ 4` is re-evaluated under those criteria. The
+re-evaluation is queued via a single umbrella `human-oversight`
+issue with a checkbox per library; per-library follow-on issues
+are filed only when the audit identifies actual gaps. Libraries
+already passing all new criteria stay at `done_through: 4`
+unchanged.
 
 Record completion by bumping `libraries.yml[L].done_through` to `4`.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -211,6 +211,12 @@ concern:
 If a tactic's compile time matters, it's a Lean / tactic-author
 issue and goes to a different tracker.
 
+CPU profiling of compiled benchmark binaries is **in scope** and is
+a Phase-4 deliverable; see [profiling.md](profiling.md). A bench
+verdict of "consistent with declared complexity" only checks
+asymptotics; profiling is what attributes the constant factor and
+catches dominant costs that the registered targets do not measure.
+
 ## Within-Lean comparisons
 
 Where a SPEC names alternative algorithms or representations,
@@ -281,20 +287,89 @@ Where a SPEC asks for a comparison lean-bench cannot directly model,
 file the gap as a feature request against lean-bench. Do not invent
 a parallel hex-local benchmark harness; one harness is the rule.
 
-Each SPEC-required external comparator must end in exactly one of
+### Comparator classification: `gating` vs `informational`
+
+Every external comparator named by a per-library SPEC carries a
+classification that determines whether it gates Phase-4 completion:
+
+- **`gating`** — the comparator must be wired before Phase-4 can be
+  claimed, the headline report records the measured ratio, and the
+  per-library SPEC may state a performance goal against it (e.g.
+  "at least as fast as X on shared canonical inputs"). A `gating`
+  comparator is the right yardstick for the library — typically
+  another implementation of the same algorithm at the same level of
+  abstraction, where the constant-factor gap is meaningful.
+- **`informational`** — the comparator's ratio is recorded in the
+  headline report but does not gate Phase-4. Use this when the
+  comparator is structurally different (e.g. a floating-point
+  implementation versus an integer-only verified one) but still
+  useful as orientation. An `informational` comparator may be
+  scheduled-only.
+
+A comparator declared `gating` must end Phase-4 in exactly one of
 these states:
 
 - **implemented now** — registration and execution path land in the
   current Phase-4 work;
-- **scheduled-only** — registration lands now, but execution is
-  deferred to scheduled/release benchmarking, with the required
-  environment stated in the bench module docstring;
 - **blocked** — a narrow repo-local issue is filed for the missing
   capability, and the library does not claim Phase-4 completion.
+
+A comparator declared `informational` may additionally be
+**scheduled-only**: registration lands now, but execution is
+deferred to scheduled/release benchmarking, with the required
+environment stated in the bench module docstring.
 
 Do not stub comparator outputs. Do not silently omit a required
 comparator. If the blocker is a missing lean-bench feature, file
 both the upstream feature request and the repo-local blocking issue.
+
+### Comparator naming
+
+Per-library SPECs name the external comparators they require for
+Phase 4. Naming has two surfaces:
+
+- **SPEC text** in `SPEC/Libraries/<lib>.md` describes each
+  comparator with enough specificity for a clean-room re-
+  implementation to identify the same tool: project name, source
+  link, and any structural variant (e.g. "fpLLL via fpylll", "the
+  Haskell extraction of the verified Isabelle LLL from AFP entry
+  `LLL_Basis_Reduction`, Zenodo deposit 2636367"). Version pinning
+  is a per-comparator implementation choice; the SPEC names the
+  tool, not its commit hash.
+- **Structured metadata** in [`libraries.yml`](../libraries.yml)
+  carries the same comparator list under the per-library
+  `phase4.comparators` key. Each entry has `tool`, `class`, and an
+  optional `rationale` (for `informational`) or `goal` (for
+  `gating`). Mechanical scripts read this; SPEC text carries the
+  narrative.
+
+A library SPEC must not name a comparator without classifying it.
+Phase 4 is blocked until every `gating` comparator is wired and
+its measured ratio recorded in the headline report ([§Headline
+reports](#headline-reports)).
+
+### The Attribution rule
+
+Every asymptotically significant phase of an algorithm — whether
+identified by the per-library SPEC, by profiling, or by both —
+must be registered as its own `setup_benchmark` (or
+`setup_fixed_benchmark`) **if it can be separated from the
+surrounding code**. If profiling shows a dominant inclusive cost
+that is not attributable to a registered target, Phase 4 cannot be
+claimed (or must be rolled back) until either:
+
+- the cost is attributed to a new target, with a derivation
+  comment per [the cost-model derivation rule](#harness-lean-bench);
+  or
+- the per-library SPEC is amended with a written rationale for why
+  the cost cannot be separated.
+
+This is a hard rule, not discretionary. The motivation: an end-to-
+end registration whose dominant cost is hidden inside a setup or
+prep step that is itself sized non-trivially in the parameter does
+not detect a wrong-asymptotic implementation in that step. The
+attribution is what lets a future profiling finding be diagnosed
+unambiguously.
 
 ## Fixed-problem benchmarks
 
@@ -455,6 +530,70 @@ committed hard polynomial, a committed lattice basis), the same
 `setup_benchmark`-style registration carries both signals: timing
 in the JSONL output, agreement via the result hash and `compare`.
 
+## Headline reports
+
+Every library at `done_through ≥ 4` must have a headline performance
+report at `reports/<lib>-performance.md`. The report is the
+single, scannable place a reviewer can land on to see whether
+Phase-4 coverage is real and what is known about the library's
+performance shape.
+
+The report contains five subsections:
+
+1. **Bench targets.** The registered bench targets and their
+   declared complexities, copied (not paraphrased) from the
+   `setup_benchmark` registration sites.
+2. **Verdicts.** Each parametric registration's verdict at
+   scientific settings ("consistent with declared complexity",
+   "inconclusive", with the verdict text). Each fixed registration's
+   median per-call time and observed-hash agreement.
+3. **Comparator ratios.** Each comparator named in the per-library
+   SPEC ([§Comparator naming](#comparator-naming)) — `gating` and
+   `informational` alike — with a measured ratio at the bottom of
+   the parameter ladder for parametric registrations, or on the
+   canonical input for fixed registrations. A short narrative
+   paragraph interprets the ratios: what is comfortable, what is
+   not, and why.
+4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
+   one representative case per `phase4.input_families`. Dominant
+   inclusive costs are named and explained, with leaf cost
+   categorised across {own code, GMP, allocation, Lean runtime}.
+   Any inclusive cost the author cannot attribute to a registered
+   bench target is filed as an audit-found issue per
+   [Conventions.md §Bench-found, conformance-found, and audit-found
+   issues](../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues)
+   and linked from the next subsection.
+5. **Concerns.** Audit-found issues filed against this library
+   that have not yet resolved. The library cannot **remain** at
+   `done_through: 4` while any Concern is unresolved (see
+   [PLAN/Phase4.md §Exit criteria](../PLAN/Phase4.md#exit-criteria)
+   for the rollback rule). Each Concern entry is a one-line
+   summary linking the open HO issue.
+
+### Artefact traceability
+
+Every numeric claim in a headline report is traceable: the report
+cites the exact bench case name, the command line that produced
+the number, the seed or parameter, the JSONL row path or hash,
+the profile artefact location, and the comparator's source. A
+narrative without traceable artefacts does not satisfy this
+requirement.
+
+The `reports/<lib>-performance.md` file is overwrite-on-rerun:
+when the report is regenerated against a newer build, the previous
+content is replaced and `git log -- reports/<lib>-performance.md`
+is the history channel. There is one current snapshot per library
+in `reports/`.
+
+### Reports vs SPEC
+
+The headline report is observed state at a specific commit on
+specific hardware; per-library SPEC text under `SPEC/Libraries/`
+states the requirements the library must meet. They live in
+different directories deliberately: `reports/` is mutable observed
+state, `SPEC/` is normative and follows the immutability rules in
+[Conventions.md](../PLAN/Conventions.md).
+
 ## Anti-patterns
 
 These behaviours have surfaced in past benchmarking work and are
@@ -535,6 +674,30 @@ explicitly forbidden:
   harness reports "consistent" is not a fix — it is laundering the
   verdict. Inconclusive means raise the schedule or file a
   finding-issue against the implementation, never re-declare.
+- **Best-case / short-circuit inputs as sole Phase-4 evidence.**
+  Inputs the algorithm walks past in its happy path — even when
+  they don't formally fail any precondition — cannot be the sole
+  Phase-4 evidence. They may appear as supplemental smoke or fixed
+  cases, alongside at least one input family that demonstrably
+  exercises every claimed-significant phase of the algorithm.
+  Required Phase-4 input families are specified in the per-library
+  SPEC and cross-referenced as `phase4.input_families` in
+  `libraries.yml`. Exemplar to avoid: an LLL end-to-end bench whose
+  only input is the identity basis — the LLL outer loop visits every
+  k but does no row update and no swap fires, so the registration
+  measures the loop's traversal cost and nothing about size
+  reduction or Lovász swaps.
+- **Dominant profiled cost left unattributed.** A profile run
+  (per [profiling.md](profiling.md)) that finds a dominant
+  inclusive cost not attributable to a registered bench target
+  triggers the [§Attribution rule](#the-attribution-rule):
+  Phase-4 cannot be claimed (or must be rolled back) until the
+  cost is attributed to its own target, or the per-library SPEC
+  is amended explaining why it cannot be separated. Exemplar:
+  an LLL `setup_benchmark` for `lll` whose dominant cost is
+  inside an `LLLState.ofBasis` prep step that is itself
+  sized in `n` — that step is its own asymptotically significant
+  phase and needs its own registration.
 
 Every `setup_benchmark` registration must carry an adjacent comment
 deriving its `n => …` from the algorithm: which step dominates, and

--- a/SPEC/profiling.md
+++ b/SPEC/profiling.md
@@ -1,0 +1,148 @@
+# Profiling
+
+This document specifies the CPU-profiling contract for compiled
+Lean benchmarks. It complements [benchmarking.md](benchmarking.md):
+benchmarking checks declared asymptotic complexity against observed
+scaling; profiling attributes the constant factor and surfaces
+dominant costs that the registered bench targets do not measure.
+
+A bench verdict of "consistent with declared complexity" is
+asymptotic-only. A profile is what tells you whether the cost is
+landing where the algorithm says it should — or whether 90% of the
+time is being spent in a phase that no bench target ever timed.
+
+## Why profile
+
+Profiling exists because benchmark coverage is necessarily
+incomplete: a registered target measures the cost of the function
+it is registered against. If a non-trivial cost sits inside a
+prep step, an inlined helper, or an unmeasured allocation pattern,
+the bench harness cannot see it.
+
+Profiling closes that gap by giving the author a flat list of
+"where did the cycles go on this representative input." If the
+flat list disagrees with what the per-library SPEC's complexity
+analysis predicts — typically by showing a dominant cost in a
+function that the SPEC does not name as the algorithm's hot path —
+that is a finding, and it routes through the same audit-found
+issue path as a bench verdict mismatch (see
+[Conventions.md](../PLAN/Conventions.md)).
+
+## Tooling
+
+The current toolchain is:
+
+- **Sampling profiler:** [samply](https://github.com/mstange/samply)
+  on macOS and Linux. Records a CPU profile at a configurable rate
+  (1 kHz is the default and is what this contract assumes), then
+  exposes a symbolication HTTP API.
+- **Symbolication:** samply's symbolication API resolves PC
+  addresses against the binary's debug info.
+- **Lean name demangling:** Lean function names are mangled into
+  C-style identifiers in the binary; demangling restores the
+  original `Module.Namespace.fn` form. The current pipeline shells
+  out to a small Lean program importing `Lean.Compiler.NameDemangling`
+  to perform the demangling. Once the upstream `lake profile`
+  command (leanprover/lean4 #12545) lands in a Lean release the
+  project pins to, this entire pipeline collapses to a single
+  `lake profile <exe> -- <args>` invocation; until then the
+  workflow is a small shell script chaining `samply record`,
+  `samply load`, the symbolication API call, and the demangling
+  step.
+
+The profile's destination is a Firefox Profiler JSON, but the
+headline report ([benchmarking.md §Headline reports](benchmarking.md#headline-reports))
+records only an analytical summary; raw `*.json.gz` artefacts are
+not committed.
+
+## Coverage requirement
+
+Profile **at least one representative case per
+`phase4.input_families` entry** in `libraries.yml` for the library
+being audited. Within the case-per-family minimum:
+
+- Always profile the family that the per-library SPEC names as
+  the downstream hot path. For HexLLL, that is the BZ
+  recombination basis.
+- Always profile the family with the worst measured comparator
+  gap (per the headline report's Comparator-ratios subsection).
+  These two may be the same family.
+- The third (and any further) family is profiled at one
+  representative case, sized large enough that the bench-harness
+  startup cost is small compared to the algorithm's cost on that
+  case.
+
+One case per family is enough; the goal is shape-coverage, not
+microbenchmarking. A profile is a coverage-and-shape check, not
+a timing artefact.
+
+## Required output
+
+For each profiled case, the headline report's §Profile subsection
+records:
+
+- **Leaf cost categorisation.** The flat self-time budget split
+  across:
+  - **Lean own code** — functions in `Hex<Library>.*` and any
+    helper modules under the library's own namespace;
+  - **GMP big-integer arithmetic** — `__gmpn_*`, `__gmpz_*`;
+  - **Allocation / free** — `malloc`, `free`, the platform's
+    allocator (`nanov2_*`, `mi_*`, `tiny_*` on macOS), kernel
+    memory primitives (`_platform_memset` etc.);
+  - **Lean runtime** — `lean_*` functions, refcount cold paths,
+    closure dispatch (`<apply/N>`), boxing (`mpz_to_int`).
+
+  Percentages need not sum to exactly 100; the categories are
+  exhaustive enough that ≥ 90% should be classified.
+
+- **Inclusive-cost ranking** of Lean functions in the library's
+  namespace. The top entries are the hot paths according to the
+  profile.
+
+- **Dominant-cost narrative.** For each entry in the inclusive-cost
+  ranking that exceeds a clear share of total time (the threshold
+  is interpretive, not numeric), a short paragraph explaining what
+  that function is and why it is dominant. If a dominant cost is
+  not attributable to a registered bench target, this is an
+  audit-found issue per
+  [benchmarking.md §Attribution rule](benchmarking.md#the-attribution-rule)
+  and the §Concerns subsection links it.
+
+## Reproducibility
+
+The headline report's §Profile subsection records, for each
+profiled case:
+
+- the commit hash the binary was built from;
+- hardware (architecture, CPU model, OS version);
+- sampling rate (Hz);
+- input family name and parameter (e.g. `random-bounded`, `n=160`);
+- seed, where the input is randomised;
+- exact command line invoked.
+
+The raw `*.json.gz` artefact's developer-local path may be
+recorded for reference but is not committed.
+
+## Author's role
+
+The author writing the headline report is interpretive. The
+profile is data; the report's §Profile narrative is judgement
+about whether the data matches what the algorithm should be
+doing. Anything that doesn't match is filed as an audit-found
+issue per
+[Conventions.md §Bench-found, conformance-found, and audit-found
+issues](../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues),
+and the §Concerns subsection links it. The library cannot
+**remain** at `done_through: 4` while any Concern is unresolved.
+
+## Non-goals
+
+- **Microbenchmark-grade timing precision.** A profile is a
+  coverage-and-shape check, not a stopwatch. Use the bench
+  harness for timing.
+- **Cross-machine portability of percentages.** Profile shapes
+  generalise; absolute percentages do not. The headline report
+  records the hardware so a reader can read the percentages in
+  context.
+- **Production telemetry.** The profile is a Phase-4 audit step,
+  not a continuous monitoring system.

--- a/libraries.yml
+++ b/libraries.yml
@@ -23,6 +23,32 @@
 # - Phase 0 (monorepo bootstrap) is global; its completion is observable
 #   by the existence of lakefile.lean, scripts/check_dag.py, etc., not
 #   by any field in this file.
+# - phase4 (optional, for active libraries planning to reach
+#   done_through ≥ 4): structured Phase-4 metadata that mechanical
+#   checks read. SPEC text in SPEC/Libraries/<lib>.md carries the
+#   narrative; this block carries the machine-readable form.
+#     - phase4.comparators: list of named external comparators.
+#       Each entry has:
+#         tool: <string>          # human-readable tool identifier
+#         class: gating | informational
+#         goal: <string>          # required when class == gating;
+#                                 # the performance goal the headline
+#                                 # report measures against this
+#                                 # comparator (e.g. "at least as
+#                                 # fast as X on shared inputs").
+#         rationale: <string>     # required when class == informational;
+#                                 # why this comparator does not gate.
+#       See SPEC/benchmarking.md §"Comparator classification" and
+#       §"Comparator naming".
+#     - phase4.input_families: list of named non-degenerate input
+#       families the per-library SPEC requires Phase-4 benchmarking
+#       to exercise. Each entry has:
+#         name: <string>          # short identifier used in profile
+#                                 # subsection headings
+#         description: <string>   # one-line description matching the
+#                                 # per-library SPEC's narrative
+#       See SPEC/benchmarking.md §"Anti-patterns" entry on best-case
+#       inputs and SPEC/profiling.md §"Coverage requirement".
 #
 # This file is the single source of truth for the library graph.
 # lakefile.lean entries are cross-checked against active libraries.yml


### PR DESCRIPTION
This PR adds profiling and headline-reporting requirements to Phase 4 of the per-library performance contract, introduces a `gating`/`informational` classification for external comparators that replaces the conflicting `scheduled-only` allowance for required comparators, adds a hard Attribution rule ensuring every dominant profiled cost maps to a registered bench target, and extends the canonical bench/conformance issue category to cover audit findings raised during report writing.

The trigger for this rewrite was an audit of HexLLL, which is currently at `done_through: 4` despite a registered end-to-end bench that runs LLL on the identity basis (an input the algorithm walks past doing no row updates and firing no Lovász swaps), no external comparator wired despite verified Isabelle LLL and fpLLL being obvious yardsticks, and no profiling. Today's ad-hoc profile showed `Hex.LLLState.ofBasis` taking 91.5% of total time on representative input, with no dedicated bench target measuring it. The new doctrine is shaped to make each of these gaps a hard exit-criterion rather than a vacuously-satisfied clause.

The new `SPEC/profiling.md` documents the samply + symbolicate + `Lean.Compiler.NameDemangling` workflow and mandates one profile case per `phase4.input_families` entry. `SPEC/benchmarking.md` gains sections on Headline reports and Comparator naming, two new anti-patterns (best-case-input-as-sole-evidence; dominant-cost-unattributed), and removes the previous out-of-scope status of profiling. `PLAN/Phase4.md` adds deliverables 6 (profile coverage) and 7 (headline report at `reports/<lib>-performance.md`), exit criteria for gating-comparator wiring and empty-Concerns, and an Audit-reset clause queueing a re-evaluation of every library currently at `done_through ≥ 4`. `PLAN/Conventions.md` extends the Bench-found / conformance-found section to include audit-found issues with the same canonical body shape. `libraries.yml` gains a documented optional `phase4` schema for structured comparator and input-family metadata; no per-library values are populated by this PR.

This doctrine PR is normative-only — pure SPEC and PLAN content, plus a header-comment schema extension to `libraries.yml` for the structured Phase-4 metadata that mechanical checks will read. No new CI jobs are proposed; the audit-finding mechanism is review/agent-time, not CI-time. Matching repair work for HexLLL specifically (rolling its `done_through` back to 3, wiring fpLLL and verified-Isabelle comparators, replacing the identity-basis bench with non-degenerate input families, registering `LLLState.ofBasis` separately, fusing the redundant Bareiss passes, producing the inaugural `reports/hex-lll-performance.md`) and the cross-library Phase-4 audit will land via `human-oversight` issues queued separately. A second SPEC PR specific to HexLLL — naming the comparators and input families in `SPEC/Libraries/hex-lll.md` and populating its `libraries.yml: phase4` block — will follow.

🤖 Prepared with Claude Code