### PR TITLE
Rollback HexArith Phase 4 audit state

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -60,7 +60,7 @@ libraries:
   HexArith:
     deps: []
     mathlib: false
-    done_through: 4
+    done_through: 3
     status: active
   HexPoly:
     deps: []

--- a/progress/20260508T113756Z_7065cb43.md
+++ b/progress/20260508T113756Z_7065cb43.md
@@ -1,0 +1,22 @@
+## Accomplished
+
+- Claimed human-oversight issue #2701 for the HexArith Phase-4 audit reset follow-up.
+- Re-audited `HexArith` against the current Phase-4 evidence requirements and confirmed the missing report/profile/input-family metadata described in #2701.
+- Rolled `HexArith.done_through` back from 4 to 3 in `libraries.yml`.
+- Filed follow-up issue #2716 to restore HexArith Phase-4 performance evidence.
+- Linked the rollback/follow-up path from #2701 and parent audit #2690.
+- Opened rollback PR #2717 via the REST API and swapped #2701 from `claimed` to `has-pr`.
+- Verified `python3 scripts/check_dag.py`, `lake exe hexarith_bench list && lake exe hexarith_bench verify`, and `git diff --check`.
+
+## Current frontier
+
+- Rollback PR #2717 is open for #2701.
+- Existing HexArith benchmark smoke coverage still passes; #2716 should focus on Phase-4 metadata, profile coverage, headline report evidence, and any comparator decision needed by the SPEC.
+
+## Next step
+
+- Let PR #2717 run through normal review/merge handling, then work #2716 to restore HexArith Phase-4 evidence.
+
+## Blockers
+
+- `coordination` was blocked during the session by exhausted GitHub GraphQL quota; REST API calls were still available and were used for issue claim/comment/follow-up creation.


### PR DESCRIPTION
Closes #2701.

This is the dedicated rollback PR for the HexArith Phase-4 audit reset follow-up. The audit confirmed the post-#2687 evidence requirements are not currently met: no `reports/hex-arith-performance.md`, no `HexArith.phase4.input_families` metadata, and no recorded profile/empty-concerns evidence.

Changes:
- roll `HexArith.done_through` from 4 to 3 in `libraries.yml`
- add session progress note `progress/20260508T113756Z_7065cb43.md`
- file restoration follow-up #2716 for the missing Phase-4 evidence

Verification:
- `python3 scripts/check_dag.py`
- `lake exe hexarith_bench list && lake exe hexarith_bench verify`
- `git diff --check`

Note: the normal `coordination create-pr` path was unavailable during the session because authenticated GitHub GraphQL quota was exhausted; REST API publishing was used instead.