### PR TITLE
audit HexPolyMathlib phase4 reset

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -160,8 +160,18 @@ libraries:
   HexPolyMathlib:
     deps: [HexPoly]
     mathlib: true
-    done_through: 4
+    done_through: 3
     status: active
+    phase4:
+      input_families:
+        - name: dense-to-mathlib-conversion
+          description: Normalized dense integer polynomials converted to Mathlib polynomial finite-support payloads.
+        - name: mathlib-to-dense-conversion
+          description: Mathlib integer polynomials rebuilt as normalized dense-polynomial values.
+        - name: bridge-round-trip
+          description: Paired dense-origin and Mathlib-origin conversion round trips over bounded-degree generated inputs.
+        - name: euclidean-bridge
+          description: Fibonacci quotient-chain rational-polynomial fixtures for gcd and extended-gcd bridge transport.
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true

--- a/progress/20260508T143454Z_e3e6bc1f.md
+++ b/progress/20260508T143454Z_e3e6bc1f.md
@@ -1,0 +1,21 @@
+## Accomplished
+
+- Claimed human-oversight issue #2708 for the HexPolyMathlib Phase-4 audit reset.
+- Re-audited `SPEC/Libraries/hex-poly-mathlib.md`, `HexPolyMathlib/Bench.lean`, `PLAN/Phase4.md`, `SPEC/benchmarking.md`, and `SPEC/profiling.md`.
+- Confirmed `hexpolymathlib_bench` has five existing registrations: dense-to-Mathlib conversion, Mathlib-to-dense conversion, bridge round trip, gcd bridge, and extended-gcd bridge.
+- Rolled `HexPolyMathlib.done_through` from 4 to 3 in `libraries.yml` because the required scientific verdicts, profile evidence, and empty-Concerns headline report were absent.
+- Added `HexPolyMathlib.phase4.input_families` metadata and `reports/hex-poly-mathlib-performance.md` documenting the current evidence gap.
+- Filed re-promotion follow-up #2730 for the scientific verdict, profile, and final empty-Concerns evidence package.
+
+## Current frontier
+
+- `HexPolyMathlib` no longer claims Phase 4 without the new evidence package.
+- The existing benchmark executable still lists and smoke-verifies successfully, so #2730 can focus on scientific runs, profile coverage, and any findings from those runs.
+
+## Next step
+
+- Work #2730 to regenerate HexPolyMathlib Phase-4 evidence and re-promote only if the report has complete traceability and empty Concerns.
+
+## Blockers
+
+- None for the rollback. Re-promotion remains blocked on missing scientific benchmark verdicts and representative profiles.

--- a/reports/hex-poly-mathlib-performance.md
+++ b/reports/hex-poly-mathlib-performance.md
@@ -1,0 +1,44 @@
+# HexPolyMathlib Performance Report
+
+## Bench Targets
+
+- `HexPolyMathlib.PolyBench.runToPolynomialChecksum`: `n`
+- `HexPolyMathlib.PolyBench.runOfPolynomialChecksum`: `n`
+- `HexPolyMathlib.PolyBench.runRoundTripChecksum`: `n`
+- `HexPolyMathlib.PolyBench.runGcdBridgeChecksum`: `n * n`
+- `HexPolyMathlib.PolyBench.runXGcdBridgeChecksum`: `n * n`
+
+## Verdicts
+
+Scientific verdicts are not yet recorded for this report snapshot.
+`lake exe hexpolymathlib_bench list` and
+`lake exe hexpolymathlib_bench verify` were run at commit
+`bd9162100839336b60ca5180a45eb8cf07f02613`; `verify` passed all 5
+registered benchmarks. Those commands verify wiring only and do not satisfy
+the Phase-4 scientific verdict requirement.
+
+## Comparator Ratios
+
+`SPEC/Libraries/hex-poly-mathlib.md` does not name an external Phase-4
+comparator for `HexPolyMathlib`, so there are no comparator ratios to record
+in this snapshot.
+
+## Profile
+
+Profile coverage is not yet recorded for the
+`HexPolyMathlib.phase4.input_families` entries in `libraries.yml`:
+
+- `dense-to-mathlib-conversion`
+- `mathlib-to-dense-conversion`
+- `bridge-round-trip`
+- `euclidean-bridge`
+
+#2730 tracks the representative profile runs, leaf-cost
+categorisation, inclusive-cost ranking, attribution review, and scientific
+benchmark verdicts required before `HexPolyMathlib` can return to
+`done_through: 4`.
+
+## Concerns
+
+- #2730: Re-promote `HexPolyMathlib` Phase 4 with traceable scientific
+  verdicts, profile coverage, and an empty final Concerns section.


### PR DESCRIPTION
Closes #2708.

## Summary

- roll `HexPolyMathlib.done_through` back from 4 to 3 under the post-#2687 Phase-4 audit contract
- add `HexPolyMathlib.phase4.input_families` metadata for the existing benchmark families
- add `reports/hex-poly-mathlib-performance.md` documenting the current evidence gap and linking re-promotion follow-up #2730
- record this session in `progress/20260508T143454Z_e3e6bc1f.md`

## Verification

- `lake exe hexpolymathlib_bench list`
- `lake exe hexpolymathlib_bench verify`
- `python3 scripts/check_dag.py`
- `git diff --check`

Note: normal `coordination create-pr` / auto-merge setup could not be used because the account's GraphQL quota is exhausted; this PR was created through the REST API.