### PR TITLE
audit: roll back HexGfqField phase 4 claim

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -134,7 +134,7 @@ libraries:
   HexGfqField:
     deps: [HexGfqRing, HexBerlekamp]
     mathlib: false
-    done_through: 4
+    done_through: 3
     status: active
 
   # ---------- Factoring pipeline ----------

--- a/progress/20260508T153455Z_a5897cba.md
+++ b/progress/20260508T153455Z_a5897cba.md
@@ -1,0 +1,21 @@
+## Accomplished
+
+- Claimed human-oversight issue #2714 for the HexGfqField Phase-4 audit reset follow-up.
+- Re-evaluated `SPEC/Libraries/hex-gfq-field.md` and `HexGfqField/Bench.lean` against the post-#2687 Phase-4 criteria in `PLAN/Phase4.md`, `SPEC/benchmarking.md`, and `SPEC/profiling.md`.
+- Confirmed `hexgfqfield_bench` has 8 existing registrations and that `lake exe hexgfqfield_bench list` plus `lake exe hexgfqfield_bench verify` pass.
+- Rolled `HexGfqField.done_through` from 4 to 3 in `libraries.yml` because the required headline report, `phase4.input_families` metadata, scientific verdict traceability, profile evidence, and empty Concerns section are absent.
+- Filed re-promotion follow-up #2743 and marked it blocked on #2698.
+- Linked the #2714 audit result from umbrella audit #2690.
+
+## Current frontier
+
+- `HexGfqField` is no longer claiming Phase 4 without the new evidence package.
+- Existing benchmark registrations are still wired and smoke-check successfully, so #2743 can focus on structured metadata, scientific runs, profiling, headline reporting, and re-promotion if Concerns are empty.
+
+## Next step
+
+- Complete #2698 so structured `phase4` metadata is parsed consistently, then work #2743 to generate the HexGfqField Phase-4 evidence package and re-promote only if the report satisfies every exit criterion.
+
+## Blockers
+
+- #2743 is blocked on #2698 for structured `phase4.input_families` metadata support.


### PR DESCRIPTION
Closes #2714.

## Summary

- Re-audited `HexGfqField` against the post-#2687 Phase-4 requirements.
- Rolled `HexGfqField.done_through` from 4 to 3 because the headline performance report, structured input-family metadata, scientific verdict traceability, profile evidence, and empty Concerns section are missing.
- Filed re-promotion follow-up #2743, blocked on #2698.

## Verification

- `python3 scripts/check_dag.py`
- `lake exe hexgfqfield_bench list`
- `lake exe hexgfqfield_bench verify`