### PR TITLE
fix: align BZ mathlib factorization surface

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -115,26 +115,31 @@ theorem factor_product (f : Hex.ZPoly) :
   sorry
 
 /--
-Every factor emitted by the default executable factorization is irreducible
-after transport to Mathlib's polynomial model.
+The Mathlib-free executable irreducibility predicate agrees with Mathlib's
+irreducibility predicate after transport to `Polynomial ℤ`.
 -/
-theorem factor_irreducible (f : Hex.ZPoly) :
-    ∀ entry ∈ (Hex.factor f).factors,
-      Irreducible (HexPolyZMathlib.toPolynomial entry.1) := by
+theorem Hex.ZPoly.Irreducible_iff_polynomialIrreducible (f : Hex.ZPoly) :
+    Hex.ZPoly.Irreducible f ↔ Irreducible (HexPolyZMathlib.toPolynomial f) := by
+  sorry
+
+/--
+Every polynomial factor emitted by the default executable factorization is
+irreducible in the executable `Hex.ZPoly` sense.
+-/
+theorem factor_irreducible_of_nonUnit (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
   sorry
 
 /--
 Two irreducible executable factorizations of the same polynomial have the same
-transported Mathlib factors up to units and permutation.
+signed scalar and the same polynomial factors with multiplicities.
 -/
-theorem factor_unique (f : Hex.ZPoly) (gs hs : Array Hex.ZPoly) :
-    Array.foldl (· * ·) 1 gs = f →
-    Array.foldl (· * ·) 1 hs = f →
-    (∀ g ∈ gs, Irreducible (HexPolyZMathlib.toPolynomial g)) →
-    (∀ h ∈ hs, Irreducible (HexPolyZMathlib.toPolynomial h)) →
-    List.Perm
-      (gs.toList.map fun g => Associates.mk (HexPolyZMathlib.toPolynomial g))
-      (hs.toList.map fun h => Associates.mk (HexPolyZMathlib.toPolynomial h)) := by
+theorem factor_unique (f : Hex.ZPoly) (φ ψ : Hex.Factorization) :
+    Hex.Factorization.product φ = f →
+    Hex.Factorization.product ψ = f →
+    (∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1) →
+    (∀ entry ∈ ψ.factors, Hex.ZPoly.Irreducible entry.1) →
+    φ.scalar = ψ.scalar ∧ List.Perm φ.factors.toList ψ.factors.toList := by
   sorry
 
 /--

--- a/progress/20260508T211457Z_904c613d.md
+++ b/progress/20260508T211457Z_904c613d.md
@@ -1,0 +1,22 @@
+## Accomplished
+
+- Claimed feature issue #2662 after higher-priority human-oversight issues were unavailable, claimed, blocked, or marked for replan.
+- Updated `HexBerlekampZassenhausMathlib/Basic.lean` to expose the SPEC-shaped `Factorization` bridge surface:
+  - added `Hex.ZPoly.Irreducible_iff_polynomialIrreducible`;
+  - replaced the false flat-array `factor_irreducible` statement with `factor_irreducible_of_nonUnit`;
+  - changed `factor_unique` from `Array ZPoly`/`Array.foldl` to `Hex.Factorization` values.
+- Verified `lake build HexBerlekampZassenhausMathlib`, `python3 scripts/check_dag.py`, and `git diff --check`.
+- Decomposed the remaining proof obligations into #2758, #2759, and #2760.
+
+## Current frontier
+
+- The public theorem statement surface now matches the post-`Factorization` SPEC shape, but the proofs remain as the existing theorem-level `sorry` obligations.
+- #2758 is the first remaining blocker: discharge the executable `Factorization.product` reassembly chain in `HexBerlekampZassenhaus/Basic.lean`.
+
+## Next step
+
+- Land this partial PR for #2662, then work #2758 before returning to the Mathlib irreducibility and uniqueness bridges.
+
+## Blockers
+
+- Full completion of #2662 is too broad for one session because it combines executable product reassembly, Hex-to-Mathlib irreducibility transport, and UFD uniqueness.


### PR DESCRIPTION
Partial progress on #2662

Session: `904c613d-0642-4ad2-991c-9abd155fe120`

6b8d30e fix: align BZ mathlib factorization surface

🤖 Prepared with Claude Code