### PR TITLE
fix: correct HexBZ normalization product target

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1597,35 +1597,37 @@ theorem factor_product_of_bound (f : ZPoly) (B : Nat)
   sorry
 
 /--
-The normalization prefix and square-free core reassemble to the original
-input. This is the proof-facing invariant connecting content extraction,
-`X`-power extraction, and primitive square-free reduction.
+The normalization prefix and square-free core reassemble to the sign-normalized
+input. The signed scalar in `Factorization` carries the original leading sign;
+the polynomial factor array is normalized to positive leading sign.
 -/
 theorem normalizeForFactor_reassembles (f : ZPoly) :
     let normalized := normalizeForFactor f
-    Array.polyProduct (normalizationPrefixFactors normalized ++ #[normalized.squareFreeCore]) = f := by
+    Array.polyProduct (normalizationPrefixFactors normalized ++ #[normalized.squareFreeCore]) =
+      normalizeFactorSign f := by
   sorry
 
 /--
 Replacing the square-free core by a product-equivalent factor array preserves
-the original normalized input.
+the sign-normalized input.
 -/
 theorem reassembleNormalizedFactors_product
     (f : ZPoly) (normalized : FactorNormalizationData) (coreFactors : Array ZPoly)
     (hnormalized : normalizeForFactor f = normalized)
     (hcore : Array.polyProduct coreFactors = normalized.squareFreeCore) :
-    Array.polyProduct (reassembleNormalizedFactors normalized coreFactors) = f := by
+    Array.polyProduct (reassembleNormalizedFactors normalized coreFactors) =
+      normalizeFactorSign f := by
   sorry
 
 /--
-For constant square-free cores, the normalization-only factor array preserves
-the original input.
+For constant square-free cores, the normalization-only factor array preserves the
+sign-normalized input.
 -/
 theorem normalizedConstantFactors_product
     (f : ZPoly) (normalized : FactorNormalizationData)
     (hnormalized : normalizeForFactor f = normalized)
     (hconst : normalized.squareFreeCore.degree?.getD 0 = 0) :
-    Array.polyProduct (normalizedConstantFactors normalized) = f := by
+    Array.polyProduct (normalizedConstantFactors normalized) = normalizeFactorSign f := by
   sorry
 
 /-- A successful exhaustive recombination search preserves the target product. -/

--- a/progress/20260508T212731Z_97427c95.md
+++ b/progress/20260508T212731Z_97427c95.md
@@ -1,0 +1,23 @@
+## Accomplished
+
+- Checked the human-oversight queue first; each visible item was blocked, already claimed, or marked for replan, so no human-oversight work was claimable.
+- Claimed #2758, assessed the requested product-preservation proof cluster, and decomposed it into #2762, #2763, and #2764 with dependencies.
+- Marked #2758 for replan with the required `Decomposed into #2762, #2763, #2764` breadcrumb.
+- Claimed #2762 and found the existing normalization theorem statements were false for negative-leading inputs such as `-3 * X^2`: the executable polynomial factor prefix reconstructs the sign-normalized input, while the sign is carried by `signedContentScalar`.
+- Updated the normalization theorem statements and docstrings in `HexBerlekampZassenhaus/Basic.lean` to target `normalizeFactorSign f`.
+- Verified `lake build HexBerlekampZassenhaus.Basic`, `lake build HexBerlekampZassenhausMathlib.Basic`, `python3 scripts/check_dag.py`, and `git diff --check`.
+
+## Current frontier
+
+- #2762 is partially advanced: the false theorem targets are corrected, but the normalization proofs still need to replace their existing `sorry`s.
+- #2763 covers recombination product preservation.
+- #2764 is blocked on #2762 and #2763 and should prove the final `Factorization.product` capstone.
+
+## Next step
+
+- Continue #2762 by proving array product helper lemmas and then proving the corrected `normalizeForFactor_reassembles`, `reassembleNormalizedFactors_product`, and `normalizedConstantFactors_product` statements.
+
+## Blockers
+
+- The old parent issue #2758 was too broad for one session and mixed three separate proof surfaces.
+- Existing unrelated modification to `.claude/CLAUDE.md` remains unstaged.


### PR DESCRIPTION
Partial progress on #2762

Session: `97427c95-442b-402b-821e-39cb77a19273`

2b973cc fix: correct HexBZ normalization product target

🤖 Prepared with Claude Code