### PR TITLE
HexMatrixMathlib: package failed Bareiss column full determinant zero theorem

### DIFF
--- a/HexMatrixMathlib/Determinant/Bareiss.lean
+++ b/HexMatrixMathlib/Determinant/Bareiss.lean
@@ -1,4 +1,5 @@
 import HexMatrixMathlib.Determinant
+import Mathlib.LinearAlgebra.Matrix.ToLinearEquiv
 
 /-!
 No-pivot Bareiss loop invariant for `hex-matrix-mathlib`.
@@ -1293,5 +1294,33 @@ theorem failed_bareiss_column_dependence
   · have hrk' : k ≤ r.val := Nat.not_lt.mp hrk
     rw [← det_eq]
     exact hcol r hrk'
+
+/-- **Failed Bareiss column ⟹ source determinant is zero.**
+
+If the leading-prefix determinant of `source` at size `k` is nonzero but every
+`k`-bordered minor with trailing column `⟨k, _⟩` and trailing row at or below
+`k` vanishes, then `Hex.Matrix.det source = 0`.
+
+This is the bridge theorem consumed by the row-pivoted singular Bareiss
+packaging: failed pivot search at level `k` produces a zero pivot column,
+which the bordered-minor invariant transports to the determinant column
+hypothesis here. The proof obtains a nonzero kernel vector for
+`matrixEquiv source` from `failed_bareiss_column_dependence`, then closes the
+determinant via `Matrix.exists_mulVec_eq_zero_iff`. -/
+theorem det_eq_zero_of_bareiss_failed_column
+    (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
+    (hprev :
+      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) ≠ 0)
+    (hcol : ∀ i : Fin n, k ≤ i.val →
+      Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i ⟨k, hk⟩) = 0) :
+    Hex.Matrix.det source = 0 := by
+  obtain ⟨α, hα_ne, _hα_above, hmulvec⟩ :=
+    failed_bareiss_column_dependence source k hk hprev hcol
+  have hdet_zero : Matrix.det (matrixEquiv source) = 0 := by
+    refine Matrix.exists_mulVec_eq_zero_iff.mp ⟨α, ?_, hmulvec⟩
+    intro hα_zero
+    apply hα_ne
+    simpa using congrFun hα_zero ⟨k, hk⟩
+  exact (det_eq source).trans hdet_zero
 
 end HexMatrixMathlib

--- a/progress/2026-05-09T05-20-38Z_844632dd.md
+++ b/progress/2026-05-09T05-20-38Z_844632dd.md
@@ -1,0 +1,34 @@
+# 2026-05-09T05:20:38Z — feature 844632dd (issue #2774)
+
+## Accomplished
+
+- Added the public bridge theorem
+  `HexMatrixMathlib.det_eq_zero_of_bareiss_failed_column` to
+  `HexMatrixMathlib/Determinant/Bareiss.lean`.
+- The proof consumes the freshly-landed
+  `failed_bareiss_column_dependence` (from #2773) to obtain a nonzero
+  kernel vector for `matrixEquiv source`, then closes the determinant via
+  `Matrix.exists_mulVec_eq_zero_iff` (Mathlib).
+- Imported `Mathlib.LinearAlgebra.Matrix.ToLinearEquiv` for that lemma.
+- Verified `lake build HexMatrixMathlib.Determinant.Bareiss` and
+  `lake build HexMatrixMathlib.Determinant` both succeed with no new
+  warnings; `python3 scripts/check_dag.py` and `git diff --check` both
+  clean; no new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level
+  `sorry`.
+
+## Current frontier
+
+- The new theorem is independent of `BareissPivotInvariant` and
+  `pivotLoop`, exactly as the issue required, so the row-pivoted singular
+  packaging issue (#2769) can consume it directly.
+
+## Next step
+
+- Pick up the singular-branch packaging in #2769 once a planner re-files
+  it, or another agent claim — combining
+  `det_eq_zero_of_bareiss_failed_column` with the bordered-minor invariant
+  to discharge the row-pivoted Bareiss singular case.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #2774

Session: `844632dd-af50-47dd-810f-9fd5a46592c7`

c59a6a3 feat: package failed Bareiss column det zero theorem (#2774)

🤖 Prepared with Claude Code