### PR TITLE
HexMatrix: repair echelon pivot contract before span completeness

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -121,10 +121,6 @@ namespace IsEchelonForm
 variable [Mul R] [Add R] [OfNat R 0] [OfNat R 1]
 variable {M : Matrix R n m} {D : RowEchelonData R n m}
 
-/-- View a pivot-row index as a row index of the ambient matrix. -/
-def pivotRow (E : IsEchelonForm M D) (i : Fin D.rank) : Fin n :=
-  ⟨i.val, Nat.lt_of_lt_of_le i.isLt E.rank_le_n⟩
-
 /-- Coefficients for expressing `v` in the row span, if the echelon rows solve it. -/
 def spanCoeffs [Lean.Grind.Field R] [DecidableEq R] (E : IsEchelonForm M D)
     (v : Vector R m) : Option (Vector R n) :=
@@ -148,19 +144,20 @@ def spanContains [Lean.Grind.Field R] [DecidableEq R] (E : IsEchelonForm M D)
 
 /-- `spanCoeffs` returns coefficients whose row combination equals `v`. -/
 theorem spanCoeffs_sound [Lean.Grind.Field R] [DecidableEq R]
-    (E : IsEchelonForm M D) (v : Vector R m) (c : Vector R n) :
+    (E : IsEchelonForm M D) (hpiv : E.HasNonzeroPivots) (v : Vector R m)
+    (c : Vector R n) :
     E.spanCoeffs v = some c → rowCombination M c = v := by
   sorry
 
 /-- Any vector in the row span produces some coefficients via `spanCoeffs`. -/
 theorem spanCoeffs_complete [Lean.Grind.Field R] [DecidableEq R]
-    (E : IsEchelonForm M D) (v : Vector R m) :
+    (E : IsEchelonForm M D) (hpiv : E.HasNonzeroPivots) (v : Vector R m) :
     (∃ c : Vector R n, rowCombination M c = v) → (E.spanCoeffs v).isSome := by
   sorry
 
 /-- `spanContains` is exactly row-span membership. -/
 theorem spanContains_iff [Lean.Grind.Field R] [DecidableEq R]
-    (E : IsEchelonForm M D) (v : Vector R m) :
+    (E : IsEchelonForm M D) (hpiv : E.HasNonzeroPivots) (v : Vector R m) :
     E.spanContains v = true ↔ ∃ c : Vector R n, rowCombination M c = v := by
   constructor
   · intro h
@@ -169,14 +166,25 @@ theorem spanContains_iff [Lean.Grind.Field R] [DecidableEq R]
     | none =>
         simp [hCoeffs] at h
     | some c =>
-        exact ⟨c, E.spanCoeffs_sound v c hCoeffs⟩
+        exact ⟨c, E.spanCoeffs_sound hpiv v c hCoeffs⟩
   · intro h
     unfold spanContains
-    simpa using E.spanCoeffs_complete v h
+    simpa using E.spanCoeffs_complete hpiv v h
 
 end IsEchelonForm
 
 namespace IsRREF
+
+/-- RREF data has nonzero pivots because every pivot is normalized to one. -/
+theorem hasNonzeroPivots [Lean.Grind.Field R]
+    {M : Matrix R n m} {D : RowEchelonData R n m} (E : IsRREF M D) :
+    E.toIsEchelonForm.HasNonzeroPivots := by
+  intro i
+  have hpivot :
+      D.echelon[E.toIsEchelonForm.pivotRow i][D.pivotCols.get i] = 1 := by
+    simpa [IsEchelonForm.pivotRow] using E.pivot_one i
+  intro hzero
+  exact (show (0 : R) ≠ 1 from Lean.Grind.Field.zero_ne_one) (hzero.symm.trans hpivot)
 
 variable [Mul R] [Add R] [OfNat R 0] [OfNat R 1]
 variable {M : Matrix R n m} {D : RowEchelonData R n m}

--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -112,6 +112,16 @@ namespace IsEchelonForm
 variable [Mul R] [Add R] [OfNat R 0] [OfNat R 1]
 variable {M : Matrix R n m} {D : RowEchelonData R n m}
 
+/-- View a pivot-row index as a row index of the ambient matrix. -/
+def pivotRow (E : IsEchelonForm M D) (i : Fin D.rank) : Fin n :=
+  ⟨i.val, Nat.lt_of_lt_of_le i.isLt E.rank_le_n⟩
+
+/-- The pivot entries named by `pivotCols` are nonzero. This is the extra
+proof-facing contract needed by span solving: without it, the pivot-column
+division in `spanCoeffs` can divide by zero. -/
+def HasNonzeroPivots (E : IsEchelonForm M D) : Prop :=
+  ∀ i : Fin D.rank, D.echelon[E.pivotRow i][D.pivotCols.get i] ≠ 0
+
 /-- The square row-transform has a right inverse. -/
 theorem transform_mul_inv (E : IsEchelonForm M D) :
     ∃ Tinv : Matrix R n n, D.transform * Tinv = 1 := by

--- a/progress/20260509T153140Z_edbf1ba4.md
+++ b/progress/20260509T153140Z_edbf1ba4.md
@@ -1,0 +1,44 @@
+# 20260509T153140Z - Issue #2800
+
+## Accomplished
+
+Claimed #2800 and repaired the row-echelon pivot contract surface for span
+correctness. Moved `IsEchelonForm.pivotRow` into `HexMatrix/RowEchelon.lean`
+so it is available to all echelon proof-facing APIs, added
+`IsEchelonForm.HasNonzeroPivots`, and updated the `spanCoeffs_sound`,
+`spanCoeffs_complete`, and `spanContains_iff` theorem statements in
+`HexMatrix/RREF.lean` to require that nonzero-pivot hypothesis.
+
+Added `IsRREF.hasNonzeroPivots`, proving that the stronger hypothesis follows
+from the RREF pivot-normalization contract.
+
+Verification completed:
+
+- `lake build HexMatrix.RowEchelon`
+- `lake build HexMatrix.RREF`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexMatrix/RowEchelon.lean HexMatrix/RREF.lean`
+
+The marker scan reports only the existing `sorry`s in `HexMatrix/RREF.lean`;
+this session did not add new proof holes or banned markers.
+
+## Current frontier
+
+The contract-level bug from #2666 is repaired: row-span correctness theorems no
+longer state completeness under an echelon contract that permits zero pivots.
+The actual long `spanCoeffs_sound` and `spanCoeffs_complete` proofs remain as
+follow-up Phase-5 proof work under the repaired hypotheses.
+
+The worktree still contains the pre-existing unstaged `.claude/CLAUDE.md`
+modification, which was not touched.
+
+## Next step
+
+Commit the two matrix source changes and this progress file, then create the PR
+for #2800.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2800

Session: `edbf1ba4-f754-4e8a-8ad7-aae9ce9911b3`

93ff1a5 fix: require nonzero pivots for matrix span

🤖 Prepared with Claude Code