### PR TITLE
feat: add Yun pairwise reachability invariant

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -2296,6 +2296,39 @@ private def squareFreeFactorCoprimeRel :
     SquareFreeFactor p → SquareFreeFactor p → Prop :=
   fun a b => DensePoly.gcd a.factor b.factor = 1
 
+private inductive yunFactorsPairwiseReachable :
+    FpPoly p → FpPoly p → Nat → Prop
+  | derivativeSplit (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
+      (hdf : (DensePoly.derivative f).isZero ≠ true) :
+      yunFactorsPairwiseReachable
+        (f / DensePoly.gcd f (DensePoly.derivative f))
+        (DensePoly.gcd f (DensePoly.derivative f))
+        fuel
+  | step (c w : FpPoly p) (fuel : Nat) :
+      yunFactorsPairwiseReachable c w (fuel + 1) →
+      yunFactorsPairwiseReachable
+        (DensePoly.gcd c w)
+        (w / DensePoly.gcd c w)
+        fuel
+
+private theorem yunFactorsPairwiseReachable_of_derivative_split
+    (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
+    (hdf : (DensePoly.derivative f).isZero ≠ true) :
+    yunFactorsPairwiseReachable
+      (f / DensePoly.gcd f (DensePoly.derivative f))
+      (DensePoly.gcd f (DensePoly.derivative f))
+      fuel :=
+  yunFactorsPairwiseReachable.derivativeSplit hp f fuel hdf
+
+private theorem yunFactorsPairwiseReachable_step
+    (c w : FpPoly p) (fuel : Nat)
+    (hreachable : yunFactorsPairwiseReachable c w (fuel + 1)) :
+    yunFactorsPairwiseReachable
+      (DensePoly.gcd c w)
+      (w / DensePoly.gcd c w)
+      fuel :=
+  yunFactorsPairwiseReachable.step c w fuel hreachable
+
 private theorem pairwise_append_of_cross
     {α : Type} (r : α → α → Prop) {xs ys : List α} :
     xs.Pairwise r →

--- a/progress/20260509T165207Z_f54408ec.md
+++ b/progress/20260509T165207Z_f54408ec.md
@@ -1,0 +1,42 @@
+# 20260509T165207Z - Issue #2814
+
+## Accomplished
+
+Claimed #2814 and added the private Yun pairwise reachability predicate in
+`HexPolyFp/SquareFree.lean`:
+
+- `yunFactorsPairwiseReachable`, an inductive predicate over `(c, w, fuel)`
+  states consumed by `yunFactors`.
+- `yunFactorsPairwiseReachable_of_derivative_split`, exposing reachability for
+  the derivative-active initial split from `squareFreeAuxRev`.
+- `yunFactorsPairwiseReachable_step`, exposing preservation across one Yun
+  recursive step to `(gcd c w, w / gcd c w)`.
+
+Verification completed:
+
+- `lake build HexPolyFp`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean`
+
+The grep output still shows the four pre-existing `sorry` markers in
+`HexPolyFp/SquareFree.lean`; this session did not add new proof holes.
+
+## Current frontier
+
+The pairwise-coprime proof still needs the successor work to replace the false
+arbitrary-state Yun lemmas with reachable-state versions. The new predicate now
+records exactly the derivative-split origin and Yun-step closure needed for that
+argument.
+
+## Next step
+
+Use `yunFactorsPairwiseReachable` to narrow `yunFactors_pairwise_coprime_nil`
+and prove the reachable Yun-loop pairwise-coprime theorem, then adapt
+`squareFreeAuxRev_pairwise_coprime_nil_core` to consume it.
+
+## Blockers
+
+No environmental blockers. The remaining proof work is mathematical: proving
+the gcd/division facts that make distinct factors emitted from reachable Yun
+states coprime.


### PR DESCRIPTION
Closes #2814

Adds a private reachable-state predicate for Yun pairwise-coprime work, plus derivative-split and one-step preservation bridge theorems.

Verification:
- lake build HexPolyFp
- python3 scripts/check_dag.py
- git diff --check
- rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean