### PR TITLE
test: pin BZ Factorization edge cases

### DIFF
--- a/HexBerlekampZassenhaus/Conformance.lean
+++ b/HexBerlekampZassenhaus/Conformance.lean
@@ -211,6 +211,51 @@ private def phi22 : ZPoly :=
 private def cyclo11Times22 : ZPoly :=
   phi11 * phi22
 
+private structure FactorizationCase where
+  input : ZPoly
+  expected : Factorization
+
+private def expectedFactorization
+    (scalar : Int) (factors : Array (ZPoly × Nat)) : Factorization :=
+  { scalar, factors }
+
+private def factorizationEdgeCases : List FactorizationCase :=
+  [ { input := 0
+      expected := expectedFactorization 0 #[] }
+  , { input := 1
+      expected := expectedFactorization 1 #[] }
+  , { input := -1
+      expected := expectedFactorization (-1) #[] }
+  , { input := DensePoly.C (2 : Int)
+      expected := expectedFactorization 2 #[] }
+  , { input := DensePoly.C (-2 : Int)
+      expected := expectedFactorization (-2) #[] }
+  , { input := DensePoly.C (6 : Int)
+      expected := expectedFactorization 6 #[] }
+  , { input := DensePoly.C (-6 : Int)
+      expected := expectedFactorization (-6) #[] }
+  , { input := ZPoly.X
+      expected := expectedFactorization 1 #[(ZPoly.X, 1)] }
+  , { input := DensePoly.scale (-1 : Int) ZPoly.X
+      expected := expectedFactorization (-1) #[(ZPoly.X, 1)] }
+  , { input := ZPoly.X * ZPoly.X
+      expected := expectedFactorization 1 #[(ZPoly.X, 2)] }
+  , { input := zpoly #[1, 0, -1]
+      expected := expectedFactorization (-1) #[(linear (-1), 1), (linear 1, 1)] }
+  , { input := repeatedRootPoly
+      expected := expectedFactorization 1 #[(linear 1, 2)] }
+  , { input := DensePoly.scale (-1 : Int) repeatedRootPoly
+      expected := expectedFactorization (-1) #[(linear 1, 2)] }
+  , { input := zpoly #[-2, 0, 2]
+      expected := expectedFactorization 2 #[(linear (-1), 1), (linear 1, 1)] }
+  , { input := negativeRepeatedRootWithContent
+      expected := expectedFactorization (-2) #[(linear 1, 2)] } ]
+
+#guard
+  factorizationEdgeCases.all fun c =>
+    let φ := factor c.input
+    φ == c.expected && Factorization.product φ == c.input
+
 #guard !isGoodPrime repeatedRootPoly 5
 #guard !isGoodPrime leadingCoeffDivisibleByFive 5
 #guard !isGoodPrime (0 : ZPoly) 5

--- a/progress/20260509T174550Z_a42732d2.md
+++ b/progress/20260509T174550Z_a42732d2.md
@@ -1,0 +1,53 @@
+# 20260509T174550Z - Issue #2637
+
+## Accomplished
+
+Claimed human-oversight issue #2637. Confirmed the prerequisite Factorization
+SPEC PR #2636 is merged and that the current branch already has the
+Factorization-typed BZ API, signed scalar handling, multiplicity collection,
+and regenerated JSONL edge fixtures.
+
+Added a Lean-side conformance table in `HexBerlekampZassenhaus/Conformance.lean`
+covering the signed-scalar and multiplicity edge cases from the SPEC: zero,
+units, constant content, `X`, `-X`, `X^2`, `-X^2 + 1`, repeated roots, signed
+repeated roots, and content-scaled products. The guard checks both exact
+`Factorization` shape and product reconstruction.
+
+Created follow-up issue #2836 for the remaining mathlib-free Basic.lean
+Factorization proof chain. Existing overlapping blocked follow-ups already
+cover the bounded-product and Mathlib capstones. Opened partial PR #2837 via
+the REST API and mirrored the coordination partial-PR state on #2637
+(`has-pr` + `replan`, `claimed` removed).
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/oracle/bz_flint.py --check`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide' HexBerlekampZassenhaus/Conformance.lean HexBerlekampZassenhaus/Basic.lean`
+
+The first attempted oracle command used the issue body's stale CLI form
+(`--check <path>`) and failed because the current script takes either
+`--check` or a positional path, not both. The corrected `--check` invocation
+passed.
+
+## Current frontier
+
+The executable API and fixture/conformance surface now pin the signed scalar
+and multiplicity behavior, but #2637 is still not fully discharged. The
+remaining work is proof-heavy: replacing the factorization product and
+irreducibility `sorry`s in `HexBerlekampZassenhaus/Basic.lean` and
+`HexBerlekampZassenhausMathlib/Basic.lean`.
+
+## Next step
+
+Let #2837 run CI, then continue with the proof-chain follow-ups (#2836 and the
+pre-existing blocked capstone issues).
+
+## Blockers
+
+GitHub GraphQL rate limit was exceeded near the end of the session, so
+`coordination create-pr` could not run. REST API quota remained available and
+was used to create PR #2837 and update #2637 labels/comments manually. Auto-merge
+was not enabled because the coordination command could not complete.


### PR DESCRIPTION
Partial work for #2637.\n\nThis pins the executable Factorization edge-case surface for signed scalar and multiplicity behavior in HexBerlekampZassenhaus conformance. Remaining proof-heavy obligations are left for replan/follow-up work, including #2836 and the existing blocked capstone issues.\n\nVerification:\n- lake build HexBerlekampZassenhaus\n- python3 scripts/oracle/bz_flint.py --check\n- python3 scripts/check_dag.py\n- git diff --check\n- rg -n '^axiom\\b|native_decide' HexBerlekampZassenhaus/Conformance.lean HexBerlekampZassenhaus/Basic.lean