### PR TITLE
HexPolyFp: add Yun factor divisor helper

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -2460,6 +2460,75 @@ private theorem yunFactors_repeated_eq_nil
           have hsingle := ih y (w / y) (i + 1) [sf]
           simpa [y, z, hz, sf] using hacc.trans hsingle.symm
 
+private theorem dvd_trans_poly
+    {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨x, hx⟩
+  rcases hbc with ⟨y, hy⟩
+  refine ⟨x * y, ?_⟩
+  calc c
+      = b * y := hy
+    _ = (a * x) * y := by rw [hx]
+    _ = a * (x * y) := DensePoly.mul_assoc_poly a x y
+
+private theorem yunFactors_factor_mem_acc_or_dvd_current
+    [ZMod64.PrimeModulus p]
+    (c w : FpPoly p) (multiplicity fuel : Nat)
+    (accRev : List (SquareFreeFactor p)) :
+    ∀ sf ∈ (yunFactors c w multiplicity fuel accRev).1,
+      sf ∈ accRev ∨ sf.factor ∣ c := by
+  induction fuel generalizing c w multiplicity accRev with
+  | zero =>
+      intro sf hsf
+      exact Or.inl hsf
+  | succ fuel ih =>
+      simp only [yunFactors]
+      by_cases hc : isOne c
+      · simp [hc]
+        intro sf hsf
+        exact Or.inl hsf
+      · simp [hc]
+        let y := DensePoly.gcd c w
+        let z := c / y
+        have hy_dvd_c : y ∣ c := by
+          simpa [y] using DensePoly.gcd_dvd_left c w
+        have hz_dvd_c : z ∣ c := by
+          refine ⟨y, ?_⟩
+          simpa [y, z] using (div_gcd_mul_reconstruct c w).symm
+        by_cases hz : isOne z
+        · intro sf hsf
+          have htail :=
+            ih y (w / y) (multiplicity + 1) accRev sf (by
+              simpa [y, z, hz] using hsf)
+          rcases htail with hacc | hsf_y
+          · exact Or.inl hacc
+          · exact Or.inr (dvd_trans_poly hsf_y hy_dvd_c)
+        · let current : SquareFreeFactor p :=
+            { factor := z, multiplicity := multiplicity }
+          intro sf hsf
+          have htail :=
+            ih y (w / y) (multiplicity + 1) (current :: accRev) sf (by
+              simpa [y, z, hz, current] using hsf)
+          rcases htail with hacc | hsf_y
+          · simp only [List.mem_cons] at hacc
+            rcases hacc with hcurrent | haccRev
+            · subst sf
+              exact Or.inr hz_dvd_c
+            · exact Or.inl haccRev
+          · exact Or.inr (dvd_trans_poly hsf_y hy_dvd_c)
+
+private theorem yunFactors_factor_dvd_current
+    [ZMod64.PrimeModulus p]
+    (c w : FpPoly p) (multiplicity fuel : Nat) :
+    ∀ sf ∈ (yunFactors c w multiplicity fuel []).1.reverse,
+      sf.factor ∣ c := by
+  intro sf hsf
+  have hsf' : sf ∈ (yunFactors c w multiplicity fuel []).1 :=
+    List.mem_reverse.mp hsf
+  have h := yunFactors_factor_mem_acc_or_dvd_current
+    c w multiplicity fuel [] sf hsf'
+  simpa using h
+
 private theorem squareFreeAuxRev_reverse_append
     (f : FpPoly p) (multiplicity fuel : Nat) (accRev : List (SquareFreeFactor p)) :
     (squareFreeAuxRev f multiplicity fuel accRev).reverse =

--- a/progress/20260509T185051Z_f77edc1b.md
+++ b/progress/20260509T185051Z_f77edc1b.md
@@ -1,0 +1,41 @@
+# 20260509T185051Z - Issue #2848
+
+## Accomplished
+
+Claimed feature issue #2848. Added checked Yun divisor helpers in
+`HexPolyFp/SquareFree.lean`:
+
+- `dvd_trans_poly`
+- `yunFactors_factor_mem_acc_or_dvd_current`
+- `yunFactors_factor_dvd_current`
+
+These prove that every factor emitted by `yunFactors c w multiplicity fuel []`
+divides the current `c`, which is a prerequisite for the derivative-split
+current-tail coprimality proof.
+
+Verification completed:
+
+- `lake build HexPolyFp`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean`
+
+The grep still reports the four pre-existing `sorry`s in `SquareFree.lean`;
+this session did not add a new proof hole.
+
+## Current frontier
+
+The full #2848 payload is not yet proved. The remaining algebra is to show
+that, along the derivative-split/reachable Yun chain, the quotient
+`c / DensePoly.gcd c w` is coprime with every tail-emitted divisor.
+
+## Next step
+
+Create or continue the follow-up that proves the square-free
+quotient/divisor gcd-one lemma and uses it to supply
+`yunFactorsCurrentTailCoprime`.
+
+## Blockers
+
+GitHub GraphQL rate limit is currently exceeded, so `coordination plan` failed.
+REST API remained available and was used to create follow-up issue #2851.


### PR DESCRIPTION
Partial progress for #2848.

This PR adds checked Yun divisor helpers in `HexPolyFp/SquareFree.lean`, proving that every factor emitted by `yunFactors c w multiplicity fuel []` divides the current `c`.

Follow-up #2851 covers the remaining derivative-split current-tail coprimality theorem.

Verification:
- `lake build HexPolyFp`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean`