### PR TITLE
feat: expose pinned BZ modular degrees

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -199,6 +199,31 @@ private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
   else
     #[]
 
+/--
+Return the sorted degrees of the Berlekamp factors of `f mod p` at an
+explicit small prime supported by the executable prime-selection list.
+
+This testing-facing surface deliberately reuses the production small-prime
+pipeline. It returns `none` if `p` is unsupported or fails the admissibility
+checks for `f`.
+-/
+def modularFactorDegreesAt? (f : ZPoly) (p : Nat) : Option (Array Nat) :=
+  smallPrimeCandidates.foldl
+    (fun found (c : SmallPrimeCandidate) =>
+      match found with
+      | some degrees => some degrees
+      | none =>
+          if c.p == p then
+            letI : ZMod64.Bounds c.p := c.bounds
+            if isGoodPrime f c.p then
+              some ((berlekampFactorsModP f c).map (fun factor =>
+                factor.degree?.getD 0) |>.qsort (· ≤ ·))
+            else
+              none
+          else
+            none)
+    none
+
 private def scoreCandidate (f : ZPoly) (c : SmallPrimeCandidate) : Option PrimeCandidateScore :=
   letI := c.bounds
   if isGoodPrime f c.p then

--- a/HexBerlekampZassenhaus/Conformance.lean
+++ b/HexBerlekampZassenhaus/Conformance.lean
@@ -134,6 +134,9 @@ private def negativeRepeatedRootWithContent : ZPoly :=
 private def leadingCoeffDivisibleByFive : ZPoly :=
   zpoly #[1, 1, 5]
 
+private def x4Plus1 : ZPoly :=
+  zpoly #[1, 0, 0, 0, 1]
+
 private def recombineFactors3 : Array ZPoly :=
   #[linear (-1), linear 2, linear 4]
 
@@ -259,6 +262,10 @@ private def factorizationEdgeCases : List FactorizationCase :=
 #guard !isGoodPrime repeatedRootPoly 5
 #guard !isGoodPrime leadingCoeffDivisibleByFive 5
 #guard !isGoodPrime (0 : ZPoly) 5
+
+#guard modularFactorDegreesAt? x4Plus1 5 = some #[2, 2]
+#guard modularFactorDegreesAt? x4Plus1 23 = none
+#guard modularFactorDegreesAt? leadingCoeffDivisibleByFive 5 = none
 
 #guard choosePrime squareFreeTypical = 2
 #guard isGoodPrime squareFreeTypical 2

--- a/progress/20260509T225307Z_abec8efb.md
+++ b/progress/20260509T225307Z_abec8efb.md
@@ -1,0 +1,41 @@
+# 20260509T225307Z - Issue #2890
+
+## Accomplished
+
+Claimed feature issue #2890 after confirming the open human-oversight items
+were dependency-blocked. Added `modularFactorDegreesAt?` in
+`HexBerlekampZassenhaus/Basic.lean`, reusing the existing supported small-prime
+Berlekamp factorization pipeline and returning `none` for unsupported or
+inadmissible primes.
+
+Added Lean-side conformance smoke checks in
+`HexBerlekampZassenhaus/Conformance.lean` for `X^4 + 1` at `p = 5`, confirming
+the pinned modular factor degrees `[2, 2]`, plus `none` checks for unsupported
+and inadmissible prime paths.
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhaus.Conformance`
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Basic.lean HexBerlekampZassenhaus/Conformance.lean`
+
+The marker grep reports only pre-existing `sorry`s in
+`HexBerlekampZassenhaus/Basic.lean`; this session did not add new `sorry`,
+`axiom`, or `native_decide`.
+
+## Current frontier
+
+The conformance layer can now assert pinned modular split degrees through the
+same executable small-prime path used by production prime selection.
+
+## Next step
+
+Use the new helper in #2893 / HO-2 follow-up work to check the remaining
+adversarial pinned modular-degree fixtures once their primes and fixture corpus
+are ready.
+
+## Blockers
+
+None for #2890.


### PR DESCRIPTION
Closes #2890

Implements the pinned modular-degree helper and conformance smoke checks for `X^4 + 1` at `p = 5`.

Verification:
- `lake build HexBerlekampZassenhaus.Conformance`
- `lake build HexBerlekampZassenhaus`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Basic.lean HexBerlekampZassenhaus/Conformance.lean` (pre-existing `sorry`s only)