### PR TITLE
prove Gram-Schmidt Mathlib row bridge

### DIFF
--- a/HexGramSchmidtMathlib/Basic.lean
+++ b/HexGramSchmidtMathlib/Basic.lean
@@ -116,12 +116,101 @@ theorem rat_coeffs_lower_projection_real (b : Matrix Rat n m) {i j : Fin n}
       rw [rowToEuclidean_inner]
     simp [hnorm, rowToEuclidean_inner, hnorm_real]
 
+private theorem rowToEuclidean_foldl_linear
+    {α : Type*} (xs : List α) (c : α → Rat) (v : α → Vector Rat m)
+    (acc : Vector Rat m) :
+    rowToEuclidean (xs.foldl (fun acc x => acc + c x • v x) acc) =
+      rowToEuclidean acc + (xs.map fun x => (c x : ℝ) • rowToEuclidean (v x)).sum := by
+  induction xs generalizing acc with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons, List.map_cons, List.sum_cons]
+      rw [ih (acc := acc + c x • v x)]
+      simp [rowToEuclidean_add, rowToEuclidean_smul, add_assoc]
+
+private theorem sum_fin_eq_sum_Iio {M : Type*} [AddCommMonoid M]
+    (i : Fin n) (f : Fin n → M) :
+    (∑ x : Fin i.val, f ⟨x.val, Nat.lt_trans x.isLt i.isLt⟩) =
+      ∑ x ∈ Finset.Iio i, f x := by
+  classical
+  refine Finset.sum_bij
+    (fun x _ => (⟨x.val, Nat.lt_trans x.isLt i.isLt⟩ : Fin n)) ?_ ?_ ?_ ?_
+  · intro x _
+    rw [Finset.mem_Iio]
+    exact x.isLt
+  · intro x _ y _ hxy
+    apply Fin.ext
+    exact congrArg (fun z : Fin n => z.val) hxy
+  · intro y hy
+    refine ⟨⟨y.val, ?_⟩, by simp, ?_⟩
+    · simpa using hy
+    · exact Fin.ext rfl
+  · intro x _
+    rfl
+
+private theorem rowToEuclidean_prefixCombination_eq_Iio_sum
+    (b : Matrix Rat n m) (i : Fin n)
+    (hprev :
+      ∀ j : Fin n, j.val < i.val →
+        rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j) =
+          InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j) :
+    rowToEuclidean
+        (Hex.GramSchmidt.prefixCombination
+          (Hex.GramSchmidt.Rat.coeffs b) (Hex.GramSchmidt.Rat.basis b) i.val i.isLt) =
+      ∑ j ∈ Finset.Iio i,
+        (inner ℝ (InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j) (ratRowFamily b i) /
+            (‖InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j‖ : ℝ) ^ 2) •
+          InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j := by
+  classical
+  unfold Hex.GramSchmidt.prefixCombination
+  rw [rowToEuclidean_foldl_linear]
+  simp only [rowToEuclidean_zero, zero_add]
+  rw [← List.sum_toFinset _ (List.nodup_finRange i.val)]
+  simpa [rat_coeffs_lower_projection_real, hprev, ratRowFamily] using
+    sum_fin_eq_sum_Iio (i := i)
+      (f := fun j =>
+        (inner ℝ (InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j)
+            (rowToEuclidean (b.row i)) /
+          (‖InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j‖ : ℝ) ^ 2) •
+          InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j)
+
 /-- The rational Gram-Schmidt basis agrees rowwise with Mathlib's real-valued
 `gramSchmidt` after coercing coefficients into `ℝ`. -/
 theorem rat_basis_row_eq_gramSchmidt (b : Matrix Rat n m) (i : Fin n) :
     rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row i) =
       InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) i := by
-  sorry
+  classical
+  have hstrong :
+      ∀ k : Nat, ∀ hk : k < n,
+        rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row ⟨k, hk⟩) =
+          InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) ⟨k, hk⟩ := by
+    intro k
+    induction k using Nat.strong_induction_on with
+    | h k ih =>
+        intro hk
+        let ik : Fin n := ⟨k, hk⟩
+        have hprev :
+            ∀ j : Fin n, j.val < ik.val →
+              rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j) =
+                InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j := by
+          intro j hj
+          exact ih j.val hj j.isLt
+        have hdecomp :=
+          congrArg rowToEuclidean
+            (Hex.GramSchmidt.Rat.basis_decomposition (b := b) k hk)
+        rw [rowToEuclidean_add,
+          rowToEuclidean_prefixCombination_eq_Iio_sum (b := b) (i := ik) hprev] at hdecomp
+        have hmath := InnerProductSpace.gramSchmidt_def'' ℝ (ratRowFamily b) ik
+        change rowToEuclidean (b.row ik) =
+          InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) ik +
+            ∑ j ∈ Finset.Iio ik,
+              (inner ℝ (InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j)
+                    (ratRowFamily b ik) /
+                  (‖InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j‖ : ℝ) ^ 2) •
+                InnerProductSpace.gramSchmidt ℝ (ratRowFamily b) j at hmath
+        exact add_right_cancel (by rw [← hdecomp, hmath])
+  exact hstrong i.val i.isLt
 
 /-- The integer Gram-Schmidt basis agrees rowwise with Mathlib's real-valued
 `gramSchmidt` after coercing coefficients into `ℝ`. -/

--- a/progress/20260510T002209Z_0cf09ff0.md
+++ b/progress/20260510T002209Z_0cf09ff0.md
@@ -1,0 +1,37 @@
+# 20260510T002209Z - Issue #2876
+
+## Accomplished
+
+Claimed #2876 after #2834 raced to another agent. Completed the
+`HexGramSchmidtMathlib.Basic` rational bridge by proving
+`rat_basis_row_eq_gramSchmidt`.
+
+Added private finite-sum bridge helpers in `HexGramSchmidtMathlib/Basic.lean`
+to move the executable `prefixCombination` fold through `rowToEuclidean`,
+identify the `Fin i.val` prefix sum with Mathlib's `Finset.Iio i` sum, and
+rewrite executable rational coefficients to Mathlib projection coefficients.
+The integer theorem remains a direct reduction to the rational theorem.
+
+Verification completed:
+
+- `lake build HexGramSchmidtMathlib.Basic`
+- `lake build HexGramSchmidtMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexGramSchmidtMathlib/Basic.lean`
+
+## Current frontier
+
+The Mathlib bridge theorem for rational and integer Gram-Schmidt rows is now
+proved in `HexGramSchmidtMathlib/Basic.lean`.
+
+## Next step
+
+Downstream work can build on `rat_basis_row_eq_gramSchmidt` /
+`int_basis_row_eq_gramSchmidt` directly. Remaining unrelated `sorry`s in
+`HexGramSchmidt/Basic.lean`, `HexGramSchmidt/Int.lean`, and update modules are
+outside this issue.
+
+## Blockers
+
+None for #2876.


### PR DESCRIPTION
Closes #2876

Session: `0cf09ff0-b6be-4b0a-92aa-21c47a3a5f9c`

d280f74 prove Gram-Schmidt Mathlib row bridge

🤖 Prepared with Claude Code