### PR TITLE
bench: add tractable BZ adversarial smoke cases

### DIFF
--- a/HexBerlekampZassenhaus/Bench.lean
+++ b/HexBerlekampZassenhaus/Bench.lean
@@ -14,6 +14,8 @@ Smoke registrations:
 * `runFactorChecksum`: public `factor` combinator on small split inputs.
 * `runFactorFastChecksum`: CLD fast path on the same inputs, preserving `none`.
 * `runFactorSlowChecksum`: exhaustive backstop on the same inputs.
+* HO-2 adversarial polynomial constants plus singleton `factor` / `factorFast`
+  targets for the smoke-tractable recombination surfaces.
 -/
 
 namespace Hex
@@ -31,6 +33,22 @@ def smokeInput (n : Nat) : ZPoly :=
   (Array.range (n + 1)).foldl
     (fun acc i => acc * linearZFactor (Int.ofNat (i + 1)))
     (1 : ZPoly)
+
+/-- HO-2 adversarial input `X^4 + 1`, irreducible over `Z` but split mod `5`. -/
+def advX4Plus1 : ZPoly :=
+  DensePoly.ofCoeffs #[1, 0, 0, 0, 1]
+
+/-- HO-2 adversarial input `(X^2 - 2)(X^2 - 3)`. -/
+def advQuadSqrt2Sqrt3 : ZPoly :=
+  DensePoly.ofCoeffs #[6, 0, -5, 0, 1]
+
+/-- HO-2 Swinnerton-Dyer `SD_3` input. -/
+def advSwinnertonDyerSD3 : ZPoly :=
+  DensePoly.ofCoeffs #[576, 0, -960, 0, 352, 0, -40, 0, 1]
+
+/-- HO-2 cyclotomic `Phi_15` input. -/
+def advPhi15 : ZPoly :=
+  DensePoly.ofCoeffs #[1, -1, 0, 1, -1, 1, 0, -1, 1]
 
 /-- Stable checksum for integer-polynomial benchmark results. -/
 def checksumZPoly (f : ZPoly) : UInt64 :=
@@ -61,6 +79,45 @@ def runFactorFastChecksum (f : ZPoly) : UInt64 :=
 /-- Benchmark target: public exhaustive slow backstop. -/
 def runFactorSlowChecksum (f : ZPoly) : UInt64 :=
   checksumFactorization (factorSlow f)
+
+/-- Singleton benchmark target: public factorization on `X^4 + 1`. -/
+@[noinline]
+def runFactorAdvX4Plus1Checksum (f : ZPoly) : UInt64 :=
+  runFactorChecksum f
+
+/-- Singleton benchmark target: fast path on `X^4 + 1`, preserving `none`. -/
+@[noinline]
+def runFactorFastAdvX4Plus1Checksum (f : ZPoly) : UInt64 :=
+  runFactorFastChecksum f
+
+/-- Singleton benchmark target: public factorization on `(X^2 - 2)(X^2 - 3)`. -/
+@[noinline]
+def runFactorAdvQuadSqrt2Sqrt3Checksum (f : ZPoly) : UInt64 :=
+  runFactorChecksum f
+
+/-- Singleton benchmark target: fast path on `(X^2 - 2)(X^2 - 3)`, preserving `none`. -/
+@[noinline]
+def runFactorFastAdvQuadSqrt2Sqrt3Checksum (f : ZPoly) : UInt64 :=
+  runFactorFastChecksum f
+
+/-- Singleton benchmark target: public factorization on `Phi_15`. -/
+@[noinline]
+def runFactorAdvPhi15Checksum (f : ZPoly) : UInt64 :=
+  runFactorChecksum f
+
+/-- Singleton benchmark target: fast path on `Phi_15`, preserving `none`. -/
+@[noinline]
+def runFactorFastAdvPhi15Checksum (f : ZPoly) : UInt64 :=
+  runFactorFastChecksum f
+
+def prepAdvX4Plus1 (_ : Nat) : ZPoly :=
+  advX4Plus1
+
+def prepAdvQuadSqrt2Sqrt3 (_ : Nat) : ZPoly :=
+  advQuadSqrt2Sqrt3
+
+def prepAdvPhi15 (_ : Nat) : ZPoly :=
+  advPhi15
 
 /-- HO-3's classical-arithmetic BHKS model over the smoke degree parameter. -/
 def bzClassicalSmokeComplexity (n : Nat) : Nat :=
@@ -115,6 +172,89 @@ setup_benchmark runFactorSlowChecksum n => 2 ^ n * bzClassicalSmokeComplexity n
     paramCeiling := 4
     paramSchedule := .custom #[1, 2, 3, 4]
     maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial target: `X^4 + 1`. The declared cost model is
+`n + 1` because the schedule pins `n = 0`; this constant smoke bound records a
+canonical recombination shape where the integer polynomial is irreducible but
+splits modulo `5` without widening this PR into the full Phase-4 matrix. -/
+setup_benchmark runFactorAdvX4Plus1Checksum n => n + 1
+  with prep := prepAdvX4Plus1
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial fast-path target for `X^4 + 1`. The declared cost
+model is the same constant `n + 1` singleton bound, with `none` distinguished so
+fast-path misses remain visible until the BHKS completion work succeeds. -/
+setup_benchmark runFactorFastAdvX4Plus1Checksum n => n + 1
+  with prep := prepAdvX4Plus1
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial target: `(X^2 - 2)(X^2 - 3)`. The declared cost
+model is `n + 1`, a constant bound; at the pinned fixture prime this splits into
+four local linear factors and recombines into two true quadratics. -/
+setup_benchmark runFactorAdvQuadSqrt2Sqrt3Checksum n => n + 1
+  with prep := prepAdvQuadSqrt2Sqrt3
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial fast-path target for `(X^2 - 2)(X^2 - 3)`. The
+declared cost model is the same constant `n + 1` singleton bound. -/
+setup_benchmark runFactorFastAdvQuadSqrt2Sqrt3Checksum n => n + 1
+  with prep := prepAdvQuadSqrt2Sqrt3
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial target: `Phi_15`. The declared cost model is
+`n + 1`, a constant bound for the pinned singleton schedule; the degree-eight
+cyclotomic case exercises the recombination hot path without a wider matrix. -/
+setup_benchmark runFactorAdvPhi15Checksum n => n + 1
+  with prep := prepAdvPhi15
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 6.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton HO-2 adversarial fast-path target for `Phi_15`. The declared cost
+model is the same constant `n + 1` singleton bound. -/
+setup_benchmark runFactorFastAdvPhi15Checksum n => n + 1
+  with prep := prepAdvPhi15
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 6.0
     targetInnerNanos := 100000000
     signalFloorMultiplier := 1.0
   }

--- a/progress/20260510T014821Z_fda7b7b3.md
+++ b/progress/20260510T014821Z_fda7b7b3.md
@@ -1,0 +1,46 @@
+# 20260510T014821Z - Issues #2919, #2925, #2907
+
+## Accomplished
+
+Claimed #2919 and found the requested raw `DensePoly.gcd` monicity provider
+false for the current executable gcd normalization; skipped it for replan with
+a concrete `F_5` counterexample.
+
+Claimed #2925 and found the requested exact Mathlib gcd correspondence false
+for the same raw-gcd normalization reason; skipped it for replan with a
+`Rat[x]` counterexample.
+
+Claimed #2907 and added HO-2 adversarial benchmark inputs to
+`HexBerlekampZassenhaus/Bench.lean`. Registered singleton smoke benchmarks for
+`factor` and `factorFast` on the smoke-tractable adversarial cases:
+
+- `adv/x4_plus_1`
+- `adv/quad_sqrt2_sqrt3`
+- `adv/phi15`
+
+Verification run:
+
+- `lake build hexbz_bench`
+- `.lake/build/bin/hexbz_bench list`
+- `.lake/build/bin/hexbz_bench verify`
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Bench.lean`
+
+## Current frontier
+
+The Swinnerton-Dyer `SD_3` adversarial input is present as a constant but is
+not registered as a smoke benchmark. Both `factorFast` and public `factor` on
+that input exceeded a 60 second per-call cap in the current implementation.
+
+## Next step
+
+Replan the remaining SD3 benchmark coverage separately, either after the fast
+path is improved enough to make SD3 smoke-tractable or with a different
+scheduled-only benchmark strategy that does not gate `verify`.
+
+## Blockers
+
+`SD_3` factorization is currently too slow for the lean-bench smoke path.

--- a/progress/20260510T031132Z_fda7b7b3_repair2931.md
+++ b/progress/20260510T031132Z_fda7b7b3_repair2931.md
@@ -1,0 +1,34 @@
+# 20260510T031132Z - PR #2931 repair
+
+## Accomplished
+
+Claimed PR #2931 after PR #2930 was already repair-claimed. Diagnosed the
+Linux `build` failure as `scripts/check_phase4.py` rejecting the new
+adversarial `setup_benchmark` registrations in
+`HexBerlekampZassenhaus/Bench.lean`.
+
+Repaired the PR by adding explicit adjacent cost-model derivation language to
+the six singleton adversarial benchmark comments and amending the PR commit
+message to include the required cost-model derivation wording.
+
+Verification completed:
+
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/check_dag.py`
+- `lake build`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Bench.lean`
+
+## Current frontier
+
+PR #2931 is locally repaired and ready for a force-with-lease push followed by
+`coordination mark-pr-salvaged 2931`.
+
+## Next step
+
+Push `agent/fda7b7b3` with `--force-with-lease` and mark PR #2931 salvaged.
+
+## Blockers
+
+None. The worktree still has an unrelated pre-existing `.claude/CLAUDE.md`
+modification, which was not touched.

--- a/progress/20260510T045221Z_pr2931-repair.md
+++ b/progress/20260510T045221Z_pr2931-repair.md
@@ -1,0 +1,31 @@
+# 20260510T045221Z - PR #2931 repair
+
+## Accomplished
+
+Claimed PR #2931 and repaired its merge conflict against `origin/main`.
+The conflict was isolated to `HexBerlekampZassenhaus/Bench.lean`, where the
+PR's HO-2 adversarial singleton benchmark targets overlapped with main's
+degree/height benchmark matrix additions.  The merge resolution preserves both
+sets of fixtures, checksum wrappers, complexity models, and `setup_benchmark`
+registrations.
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhaus.Bench`
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check HEAD`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Bench.lean`
+
+## Current frontier
+
+PR #2931 is rebased by merge onto current `origin/main` and has a passing local
+build/check suite.  The branch was pushed after the merge repair.
+
+## Next step
+
+Mark PR #2931 salvaged so remote CI can re-run on the updated branch.
+
+## Blockers
+
+None.

--- a/progress/20260510T052339Z_603767de.md
+++ b/progress/20260510T052339Z_603767de.md
@@ -1,0 +1,40 @@
+# 20260510T052339Z - Issue #2939
+
+## Accomplished
+
+Claimed #2939 and inspected PR #2931 (`agent/fda7b7b3`) after fetching
+current `origin/main`.  The branch already contained the merge from current
+main and GitHub now reports the PR as `MERGEABLE`; the remaining PR state was
+the in-progress `build` check rather than a merge conflict.
+
+Verified the repaired PR branch from a separate worktree so the pre-existing
+`.claude/CLAUDE.md` modification in the session worktree stayed untouched.
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhaus.Bench`
+- `lake exe hexbz_bench list`
+- `lake exe hexbz_bench verify`
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhaus/Bench.lean`
+
+The grep reported no matches in `HexBerlekampZassenhaus/Bench.lean`.
+
+## Current frontier
+
+PR #2931 is mergeable from the branch side and preserves the tractable
+adversarial benchmark registrations.  SD3 remains out of scope for this PR and
+is still the residual work tracked by #2934.
+
+## Next step
+
+Let the in-progress GitHub `build` check on PR #2931 finish; once it is green,
+the PR should be able to merge and unblock #2934.
+
+## Blockers
+
+None in the branch repair itself.  PR #2931 was still waiting on its GitHub
+`build` check at verification time.


### PR DESCRIPTION
Partial progress on #2907

Session: `fda7b7b3-6e13-4cca-80d9-4fdf9ad43a81`

1fac5eb bench: add tractable BZ adversarial smoke cases

SD3 remains for replan: current factorFast/public factor on the SD3 adversarial input exceeded a 60s per-call cap, so this PR registers the smoke-tractable adversarial cases only.

🤖 Prepared with Claude Code

Closes #2939