### PR TITLE
HexBZ Mathlib: package BHKS threshold cap dominance

### DIFF
--- a/HexBerlekampZassenhausMathlib/BHKSBound.lean
+++ b/HexBerlekampZassenhausMathlib/BHKSBound.lean
@@ -368,6 +368,71 @@ theorem bhksPaperLogFactorReal_le_log2Factor (f : Hex.ZPoly) :
     pow_le_pow_left₀ hlog_nonneg hlog_le (bhksDegree f)
 
 /--
+The product-shaped BHKS paper threshold is bounded by the packaged integer
+threshold expression used by the executable cap.
+-/
+theorem bhksPaperThresholdReal_le_thresholdNatBound
+    (f : Hex.ZPoly) (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2) :
+    bhksPaperThresholdReal f C ≤ (bhksThresholdNatBound f : ℝ) := by
+  have hdegree :
+      bhksPaperDegreeFactorReal f ≤ (bhksDegreeFactor f : ℝ) := by
+    rw [bhksPaperDegreeFactorReal_eq_natCast]
+  have hconstant :=
+    bhksPaperConstantFactorReal_le_fourPowFactor f C hC_nonneg hC
+  have hcoeff := bhksPaperCoeffNormFactorReal_le_coeffNormFactor f
+  have hlog := bhksPaperLogFactorReal_le_log2Factor f
+  have hconstant_nonneg : 0 ≤ bhksPaperConstantFactorReal f C := by
+    exact pow_nonneg (mul_nonneg (by norm_num) hC_nonneg) _
+  have hcoeff_nonneg : 0 ≤ bhksPaperCoeffNormFactorReal f := by
+    exact pow_nonneg (by
+      unfold HexPolyZMathlib.l2norm
+      exact Real.sqrt_nonneg _) _
+  have hlog_nonneg : 0 ≤ bhksPaperLogFactorReal f := by
+    exact pow_nonneg (l2norm_log_nonneg f) _
+  have hdegree_bound_nonneg : 0 ≤ (bhksDegreeFactor f : ℝ) := by
+    exact_mod_cast Nat.zero_le (bhksDegreeFactor f)
+  have hdegree_constant_bound_nonneg :
+      0 ≤ (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) :=
+    mul_nonneg hdegree_bound_nonneg (by exact_mod_cast Nat.zero_le (bhksFourPowFactor f))
+  have hdegree_constant_coeff_bound_nonneg :
+      0 ≤ (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) *
+        (bhksCoeffNormFactor f : ℝ) :=
+    mul_nonneg hdegree_constant_bound_nonneg
+      (by exact_mod_cast Nat.zero_le (bhksCoeffNormFactor f))
+  have hdegree_constant :
+      bhksPaperDegreeFactorReal f * bhksPaperConstantFactorReal f C ≤
+        (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) :=
+    mul_le_mul hdegree hconstant hconstant_nonneg hdegree_bound_nonneg
+  have hdegree_constant_coeff :
+      bhksPaperDegreeFactorReal f * bhksPaperConstantFactorReal f C *
+          bhksPaperCoeffNormFactorReal f ≤
+        (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) *
+          (bhksCoeffNormFactor f : ℝ) :=
+    mul_le_mul hdegree_constant hcoeff hcoeff_nonneg hdegree_constant_bound_nonneg
+  have hproduct :
+      bhksPaperDegreeFactorReal f * bhksPaperConstantFactorReal f C *
+          bhksPaperCoeffNormFactorReal f * bhksPaperLogFactorReal f ≤
+        (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) *
+          (bhksCoeffNormFactor f : ℝ) * (bhksLog2Factor f : ℝ) :=
+    mul_le_mul hdegree_constant_coeff hlog hlog_nonneg
+      hdegree_constant_coeff_bound_nonneg
+  have hproduct_le_bound :
+      (bhksDegreeFactor f : ℝ) * (bhksFourPowFactor f : ℝ) *
+          (bhksCoeffNormFactor f : ℝ) * (bhksLog2Factor f : ℝ) ≤
+        (bhksThresholdNatBound f : ℝ) := by
+    simp [bhksThresholdNatBound]
+  exact hproduct.trans hproduct_le_bound
+
+/--
+The executable BHKS cap dominates the product-shaped BHKS paper threshold.
+-/
+theorem bhksPaperThresholdReal_le_bhksBound
+    (f : Hex.ZPoly) (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2) :
+    bhksPaperThresholdReal f C ≤ (Hex.bhksBound f : ℝ) :=
+  (bhksPaperThresholdReal_le_thresholdNatBound f C hC_nonneg hC).trans
+    (bhksThresholdNatBound_real_le_bhksBound f)
+
+/--
 The packaged BHKS cap remains available alongside the executable Mignotte
 coefficient bound through a single max expression.  This lightweight bridge is
 useful for later proofs that need one precision dominating both reconstruction

--- a/progress/20260510T032827Z_0624ab58.md
+++ b/progress/20260510T032827Z_0624ab58.md
@@ -1,0 +1,41 @@
+# 20260510T032827Z - Issue #2899
+
+## Accomplished
+
+Claimed issue #2899 and packaged the BHKS paper-threshold dominance theorem in
+`HexBerlekampZassenhausMathlib/BHKSBound.lean`.
+
+Added:
+
+- `bhksPaperThresholdReal_le_thresholdNatBound`
+- `bhksPaperThresholdReal_le_bhksBound`
+
+The proof is a product-monotonicity layer over the existing named degree,
+constant, coefficient-norm, and logarithmic factor comparisons.  The executable
+`Hex.bhksBound` corollary uses `bhksThresholdNatBound_real_le_bhksBound`, so it
+does not unfold `Hex.bhksBound`.
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhausMathlib.BHKSBound`
+- `lake build HexBerlekampZassenhausMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexBerlekampZassenhausMathlib/BHKSBound.lean HexBerlekampZassenhausMathlib.lean`
+
+## Current frontier
+
+The BHKS cap now has a named real-valued dominance theorem from the product
+paper threshold to the executable cap.  The remaining Group D work is to use
+this packaged cap theorem inside the BHKS Theorem 5.2 / bad-vector termination
+chain.
+
+## Next step
+
+Instantiate the later BHKS separation theorem with
+`bhksPaperThresholdReal_le_bhksBound`, then combine it with the Mignotte
+dominance/reconstruction side to move toward `factorFast_terminates`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2899

Session: `0624ab58-2e78-4e38-82b2-006ba19fcec0`

2051f60 feat: package BHKS threshold dominance

🤖 Prepared with Claude Code