### PR TITLE
feat: add determinant partial column expansion helper

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -4113,6 +4113,127 @@ private theorem det_columnSumMatrix_expand_column
   rw [hself] at hsum
   exact hsum
 
+/-- Matrix obtained during the ordered column expansion: columns with
+`choices c = some k` have already been specialized to source column `k`, while
+unassigned columns remain the finite coefficient-weighted column sum. -/
+private def columnChoiceMatrix {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) : Matrix R n n :=
+  ofFn fun r c =>
+    match choices c with
+    | some k => source[r][k]
+    | none => (List.finRange m).foldl (fun acc k => acc + coeff[c][k] * source[r][k]) 0
+
+private def setColumnChoice {n m : Nat} (choices : Fin n → Option (Fin m))
+    (dst : Fin n) (k : Fin m) : Fin n → Option (Fin m) :=
+  fun c => if c = dst then some k else choices c
+
+@[simp] private theorem columnChoiceMatrix_entry
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (r c : Fin n) :
+    (columnChoiceMatrix source coeff choices)[r][c] =
+      match choices c with
+      | some k => source[r][k]
+      | none => (List.finRange m).foldl (fun acc k => acc + coeff[c][k] * source[r][k]) 0 := by
+  simp [columnChoiceMatrix, ofFn]
+
+private theorem columnChoiceMatrix_none
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) :
+    columnChoiceMatrix source coeff (fun _ => none) = columnSumMatrix source coeff := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro c hc
+  change
+    (columnChoiceMatrix source coeff (fun _ => none))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
+      (columnSumMatrix source coeff)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
+  rw [columnChoiceMatrix_entry, columnSumMatrix_entry]
+
+private theorem colReplace_columnChoiceMatrix_none_self
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (dst : Fin n)
+    (hchoice : choices dst = none) :
+    colReplace (columnChoiceMatrix source coeff choices) dst
+        (fun r => (List.finRange m).foldl
+          (fun acc k => acc + coeff[dst][k] * source[r][k]) 0) =
+      columnChoiceMatrix source coeff choices := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro c hc
+  change
+    (colReplace (columnChoiceMatrix source coeff choices) dst
+        (fun r => (List.finRange m).foldl
+          (fun acc k => acc + coeff[dst][k] * source[r][k]) 0))[
+          (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
+      (columnChoiceMatrix source coeff choices)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
+  rw [colReplace_get]
+  by_cases hcol : (⟨c, hc⟩ : Fin n) = dst
+  · subst dst
+    rw [if_pos rfl]
+    rw [columnChoiceMatrix_entry]
+    rw [hchoice]
+  · simp [hcol]
+
+private theorem colReplace_columnChoiceMatrix_set_some
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (dst : Fin n)
+    (k : Fin m) :
+    colReplace (columnChoiceMatrix source coeff choices) dst (fun r => source[r][k]) =
+      columnChoiceMatrix source coeff (setColumnChoice choices dst k) := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro c hc
+  change
+    (colReplace (columnChoiceMatrix source coeff choices) dst (fun r => source[r][k]))[
+        (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
+      (columnChoiceMatrix source coeff (setColumnChoice choices dst k))[
+        (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
+  rw [colReplace_get]
+  by_cases hcol : (⟨c, hc⟩ : Fin n) = dst
+  · subst dst
+    rw [if_pos rfl]
+    rw [columnChoiceMatrix_entry]
+    simp [setColumnChoice]
+  · rw [if_neg hcol]
+    rw [columnChoiceMatrix_entry, columnChoiceMatrix_entry]
+    have hset : setColumnChoice choices dst k (⟨c, hc⟩ : Fin n) = choices (⟨c, hc⟩ : Fin n) := by
+      unfold setColumnChoice
+      rw [if_neg hcol]
+    rw [hset]
+
+private theorem det_columnChoiceMatrix_expand_column
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (dst : Fin n)
+    (hchoice : choices dst = none) :
+    det (columnChoiceMatrix source coeff choices) =
+      (List.finRange m).foldl
+        (fun acc k =>
+          acc + coeff[dst][k] *
+            det (columnChoiceMatrix source coeff (setColumnChoice choices dst k))) 0 := by
+  have hsum :=
+    det_colReplace_sum_list
+      (columnChoiceMatrix source coeff choices) dst (List.finRange m)
+      (fun k => coeff[dst][k]) (fun k r => source[r][k])
+  have hself := colReplace_columnChoiceMatrix_none_self source coeff choices dst hchoice
+  rw [hself] at hsum
+  have hreplace :
+      (List.finRange m).foldl
+          (fun acc k =>
+            acc + coeff[dst][k] *
+              det (colReplace (columnChoiceMatrix source coeff choices) dst
+                (fun r => source[r][k]))) 0 =
+        (List.finRange m).foldl
+          (fun acc k =>
+            acc + coeff[dst][k] *
+              det (columnChoiceMatrix source coeff (setColumnChoice choices dst k))) 0 := by
+    apply foldl_det_sum_congr
+    intro k _hmem
+    rw [colReplace_columnChoiceMatrix_set_some source coeff choices dst k]
+  rw [hreplace] at hsum
+  exact hsum
+
 /-- A determinant with two equal rows is zero. -/
 theorem det_eq_zero_of_row_eq {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (src dst : Fin n) (h : src ≠ dst)
@@ -4150,6 +4271,20 @@ def columnTupleMatrix {R : Type u} {n m : Nat}
     (A : Matrix R n m) (cols : Fin n → Fin m) (r c : Fin n) :
     (columnTupleMatrix A cols)[r][c] = A[r][cols c] := by
   simp [columnTupleMatrix, ofFn]
+
+private theorem columnChoiceMatrix_some
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (cols : Fin n → Fin m) :
+    columnChoiceMatrix source coeff (fun c => some (cols c)) = columnTupleMatrix source cols := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro c hc
+  change
+    (columnChoiceMatrix source coeff (fun c => some (cols c)))[(⟨r, hr⟩ : Fin n)][
+        (⟨c, hc⟩ : Fin n)] =
+      (columnTupleMatrix source cols)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
+  rw [columnChoiceMatrix_entry, columnTupleMatrix_entry]
 
 /-- Interpret an ordered column tuple vector as its column-selection function. -/
 def columnTupleVectorFn {n m : Nat} (cols : Vector (Fin m) n) : Fin n → Fin m :=

--- a/progress/20260510T104021Z_833ce7e7.md
+++ b/progress/20260510T104021Z_833ce7e7.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Claimed #2878 after the human-oversight issues visible in the queue all
+reported blocked dependencies. Verified PR #2879 was merged and worked in
+`HexMatrix/Determinant.lean`.
+
+Added a compiling partial-choice helper layer for the all-column determinant
+expansion:
+
+- `columnChoiceMatrix`, whose selected columns are source columns and whose
+  unselected columns remain the coefficient-weighted sums.
+- `setColumnChoice` and entry/endpoint normalization lemmas.
+- `det_columnChoiceMatrix_expand_column`, a generic one-step determinant
+  expansion for any unselected column, using `det_colReplace_sum_list`.
+- `columnChoiceMatrix_some`, identifying the fully selected endpoint with
+  `columnTupleMatrix`.
+
+Verified:
+
+- `lake build HexMatrix.Determinant`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexMatrix/Determinant.lean`
+
+The `rg` check returned no matches in `HexMatrix/Determinant.lean`.
+
+## Current frontier
+
+#2878 is partially complete. The final
+`det_columnSumMatrix_eq_sum_columnTuples` theorem is still not proved; the next
+proof should induct over `List.finRange n`, carrying a `Fin n -> Option (Fin m)`
+partial assignment and an accumulated coefficient product.
+
+The starting endpoint is `columnChoiceMatrix_none`; the recursive step is now
+`det_columnChoiceMatrix_expand_column`; the terminal endpoint is
+`columnChoiceMatrix_some`. The remaining hard part is aligning that induction
+with `columnTupleVectors`' `flatMap` enumeration and `columnTupleCoeff`.
+
+## Next step
+
+Create or replan a follow-up issue for the final ordered tuple induction after
+partial PR #2995 is reviewed. I attempted `coordination plan` for that
+follow-up, but GitHub GraphQL rate limiting prevented new issue creation in
+this session. Because `coordination create-pr --partial` was blocked by the
+same limit, I opened #2995 through the REST API, commented on #2878, and moved
+#2878 from `claimed` to `has-pr` + `replan` through REST labels.
+
+## Blockers
+
+GitHub GraphQL rate limit was exhausted after local verification. Auto-merge
+could not be enabled for #2995 until the limit resets.


### PR DESCRIPTION
Partial progress for #2878.

Adds the partial-choice matrix helper layer in HexMatrix/Determinant.lean:
- columnChoiceMatrix and setColumnChoice
- endpoint normalization lemmas for all-unassigned and fully-selected states
- det_columnChoiceMatrix_expand_column for one generic unassigned column

This does not finish det_columnSumMatrix_eq_sum_columnTuples; #2878 should be replanned for the remaining all-column induction.

Verification:
- lake build HexMatrix.Determinant
- lake build HexMatrix
- python3 scripts/check_dag.py
- git diff --check
- rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexMatrix/Determinant.lean (no matches)