### PR TITLE
prove quotient derivative power divisibility helpers

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1826,6 +1826,142 @@ private theorem dvd_mul_right_of_dvd
       = (d * q) * b := by rw [hq]
     _ = d * (q * b) := DensePoly.mul_assoc_poly d q b
 
+private theorem dvd_sub_poly
+    {d a b : FpPoly p} (hda : d ∣ a) (hdb : d ∣ b) :
+    d ∣ a - b := by
+  exact DensePoly.dvd_sub_poly hda hdb
+
+private theorem pow_succ_dvd_mul_right_of_dvd
+    {d a b : FpPoly p} {n : Nat}
+    (h : pow d (n + 1) ∣ a) :
+    pow d (n + 2) ∣ a * d * b := by
+  rcases h with ⟨q, hq⟩
+  refine ⟨q * b, ?_⟩
+  calc a * d * b
+      = (pow d (n + 1) * q) * d * b := by rw [hq]
+    _ = (pow d (n + 1) * (q * d)) * b := by
+          exact congrArg (fun x => x * b)
+            (DensePoly.mul_assoc_poly (pow d (n + 1)) q d)
+    _ = (pow d (n + 1) * (d * q)) * b := by
+          exact congrArg (fun x => (pow d (n + 1) * x) * b)
+            (DensePoly.mul_comm_poly q d)
+    _ = (pow d (n + 1) * d) * q * b := by
+          exact congrArg (fun x => x * b)
+            (DensePoly.mul_assoc_poly (pow d (n + 1)) d q).symm
+    _ = pow d (n + 2) * (q * b) := by
+          rw [← pow_succ d (n + 1)]
+          exact DensePoly.mul_assoc_poly (pow d (n + 2)) q b
+
+private theorem quotient_common_dvd_mul_derivative_base
+    [ZMod64.PrimeModulus p] (d c : FpPoly p)
+    (hdc : d ∣ c)
+    (hddc : d ∣ DensePoly.derivative c) :
+    ∃ q, c = d * q ∧ d ∣ q * DensePoly.derivative d := by
+  rcases hdc with ⟨q, hq⟩
+  refine ⟨q, hq, ?_⟩
+  have hderiv :
+      DensePoly.derivative c =
+        DensePoly.derivative d * q + d * DensePoly.derivative q := by
+    rw [hq]
+    exact DensePoly.derivative_mul d q
+  have hd_second : d ∣ d * DensePoly.derivative q := ⟨DensePoly.derivative q, rfl⟩
+  have hd_first : d ∣ DensePoly.derivative d * q := by
+    have hsub : d ∣ DensePoly.derivative c - d * DensePoly.derivative q :=
+      dvd_sub_poly hddc hd_second
+    have hfirst_eq :
+        DensePoly.derivative c - d * DensePoly.derivative q =
+          DensePoly.derivative d * q := by
+      rw [hderiv]
+      rw [sub_eq_add_neg]
+      calc
+        (DensePoly.derivative d * q + d * DensePoly.derivative q) +
+            -(d * DensePoly.derivative q)
+            = DensePoly.derivative d * q +
+                (d * DensePoly.derivative q + -(d * DensePoly.derivative q)) := by
+              exact DensePoly.add_assoc_poly
+                (DensePoly.derivative d * q) (d * DensePoly.derivative q)
+                (-(d * DensePoly.derivative q))
+        _ = DensePoly.derivative d * q + 0 := by rw [add_right_neg]
+        _ = DensePoly.derivative d * q := add_zero _
+    simpa [hfirst_eq] using hsub
+  exact (DensePoly.mul_comm_poly q (DensePoly.derivative d)).symm ▸ hd_first
+
+private theorem quotient_common_dvd_pow_derivative_factor
+    [ZMod64.PrimeModulus p] (d c h : FpPoly p)
+    (hdc : d ∣ c)
+    (hddc : d ∣ DensePoly.derivative c) :
+    ∀ n : Nat,
+      pow d (n + 2) ∣ c * (pow d n * DensePoly.derivative d * h) := by
+  rcases quotient_common_dvd_mul_derivative_base d c hdc hddc with ⟨q, hq, hdqd⟩
+  rcases hdqd with ⟨r, hr⟩
+  intro n
+  refine ⟨r * h, ?_⟩
+  calc c * (pow d n * DensePoly.derivative d * h)
+      = (d * q) * (pow d n * DensePoly.derivative d * h) := by rw [hq]
+    _ = (pow d n * d * (q * DensePoly.derivative d)) * h := by
+          calc
+            (d * q) * (pow d n * DensePoly.derivative d * h)
+                = ((d * q) * (pow d n * DensePoly.derivative d)) * h := by
+                  exact (DensePoly.mul_assoc_poly (d * q)
+                    (pow d n * DensePoly.derivative d) h).symm
+            _ = ((pow d n * DensePoly.derivative d) * (d * q)) * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_comm_poly (d * q) (pow d n * DensePoly.derivative d))
+            _ = (pow d n * (DensePoly.derivative d * (d * q))) * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_assoc_poly (pow d n) (DensePoly.derivative d) (d * q))
+            _ = (pow d n * ((DensePoly.derivative d * d) * q)) * h := by
+                  exact congrArg (fun x => (pow d n * x) * h)
+                    (DensePoly.mul_assoc_poly (DensePoly.derivative d) d q).symm
+            _ = (pow d n * ((d * DensePoly.derivative d) * q)) * h := by
+                  exact congrArg (fun x => (pow d n * (x * q)) * h)
+                    (DensePoly.mul_comm_poly (DensePoly.derivative d) d)
+            _ = (pow d n * (d * (DensePoly.derivative d * q))) * h := by
+                  exact congrArg (fun x => (pow d n * x) * h)
+                    (DensePoly.mul_assoc_poly d (DensePoly.derivative d) q)
+            _ = ((pow d n * d) * (DensePoly.derivative d * q)) * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_assoc_poly (pow d n) d (DensePoly.derivative d * q)).symm
+            _ = ((pow d n * d) * (q * DensePoly.derivative d)) * h := by
+                  exact congrArg (fun x => ((pow d n * d) * x) * h)
+                    (DensePoly.mul_comm_poly (DensePoly.derivative d) q)
+    _ = (pow d n * d * (d * r)) * h := by rw [hr]
+    _ = (pow d (n + 1) * d) * (r * h) := by
+          rw [← pow_succ d n]
+          calc
+            pow d (n + 1) * (d * r) * h
+                = (pow d (n + 1) * d) * r * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_assoc_poly (pow d (n + 1)) d r).symm
+            _ = (pow d (n + 1) * d) * (r * h) := by
+                  exact DensePoly.mul_assoc_poly (pow d (n + 1) * d) r h
+    _ = pow d (n + 2) * (r * h) := by rw [← pow_succ d (n + 1)]
+
+private theorem quotient_common_dvd_pow_tail_factor
+    [ZMod64.PrimeModulus p] (d c h : FpPoly p)
+    (hdc : d ∣ c) :
+    ∀ n : Nat,
+      pow d (n + 2) ∣ c * (pow d (n + 1) * h) := by
+  rcases hdc with ⟨q, hq⟩
+  intro n
+  refine ⟨q * h, ?_⟩
+  calc c * (pow d (n + 1) * h)
+      = (d * q) * (pow d (n + 1) * h) := by rw [hq]
+    _ = (pow d (n + 1) * d) * (q * h) := by
+          calc
+            (d * q) * (pow d (n + 1) * h)
+                = ((d * q) * pow d (n + 1)) * h := by
+                  exact (DensePoly.mul_assoc_poly (d * q) (pow d (n + 1)) h).symm
+            _ = (pow d (n + 1) * (d * q)) * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_comm_poly (d * q) (pow d (n + 1)))
+            _ = ((pow d (n + 1) * d) * q) * h := by
+                  exact congrArg (fun x => x * h)
+                    (DensePoly.mul_assoc_poly (pow d (n + 1)) d q).symm
+            _ = (pow d (n + 1) * d) * (q * h) := by
+                  exact DensePoly.mul_assoc_poly (pow d (n + 1) * d) q h
+    _ = pow d (n + 2) * (q * h) := by rw [← pow_succ d (n + 1)]
+
 private theorem yunStep_common_dvd_derivative_product
     (z y d : FpPoly p)
     (hdz : d ∣ z) (hdy : d ∣ y) :

--- a/progress/20260510T114653Z_79743c93.md
+++ b/progress/20260510T114653Z_79743c93.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Claimed #2996 and worked in `HexPolyFp/SquareFree.lean`.
+
+Added private divisibility helpers for the Yun/square-free section:
+
+- `dvd_sub_poly`, a local wrapper around polynomial subtraction divisibility.
+- `pow_succ_dvd_mul_right_of_dvd`, for lifting a power divisibility witness through one extra right `d` factor.
+- `quotient_common_dvd_mul_derivative_base`, extracting `d ∣ q * derivative d` from `c = d * q` and `d ∣ derivative c`.
+- `quotient_common_dvd_pow_derivative_factor` and `quotient_common_dvd_pow_tail_factor`, the two power-product term divisibility facts needed by the quotient-power successor expansion.
+
+Verified:
+
+- `lake build HexPolyFp.SquareFree`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean`
+
+The `rg` check reports only the four pre-existing `sorry`s in
+`HexPolyFp/SquareFree.lean`; this session did not add any.
+
+## Current frontier
+
+#2996 now has the local derivative-product divisibility components needed for
+the successor issue to assemble the full
+`derivativeSplit_quotient_pow_succ_dvd_gcd` proof. The helpers stop at the
+term-level expansion rather than proving that final gcd theorem, which was out
+of scope for this issue.
+
+## Next step
+
+Use the new term helpers to expand
+`c * DensePoly.derivative (pow d n * h)` in the successor proof and combine the
+three divisible summands with `dvd_add_poly`, then feed the result into the
+existing `DensePoly.dvd_gcd` assembly.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2996.

## Summary
- add local subtraction and power-lift divisibility helpers in `HexPolyFp/SquareFree.lean`
- prove the quotient derivative base fact `d ∣ q * derivative d`
- prove term-level power-product divisibility helpers for the derivative-factor and tail-factor cases

## Verification
- `lake build HexPolyFp.SquareFree`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean` (reports only pre-existing sorries)