### PR TITLE
feat: add suffix determinant expansion endpoints

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -4596,6 +4596,21 @@ private theorem columnSumMatrixWithSuffix_nil
   rw [columnSumMatrixWithSuffix_entry, columnSumMatrix_entry]
   rw [dif_neg (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
 
+private theorem columnSumMatrixWithSuffix_eq_columnTupleMatrix
+    {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
+    (source coeff : Matrix R n m) (chosen : List (Fin m))
+    (hfull : chosen.length = n) :
+    columnSumMatrixWithSuffix source coeff chosen =
+      columnTupleMatrix source (fun j => chosen[j.val]'(by omega)) := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro c hc
+  change (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
+      (columnTupleMatrix source (fun j => chosen[j.val]'(by omega)))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
+  rw [columnSumMatrixWithSuffix_entry, dif_pos (by omega : n - chosen.length ≤ c)]
+  simp [columnTupleMatrix, ofFn, hfull]
+
 /-- Replacing the rightmost sum column of the suffix-partial matrix with a fixed
 `source` column extends the suffix by prepending that selection. -/
 private theorem colReplace_columnSumMatrixWithSuffix_extend
@@ -4692,6 +4707,50 @@ private theorem det_columnSumMatrixWithSuffix_expand
   intro c _hc
   congr 2
   exact colReplace_columnSumMatrixWithSuffix_extend source coeff chosen hk c
+
+private def assembleColumnsSuffix {n m : Nat} (chosen : List (Fin m))
+    (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n) :
+    Vector (Fin m) n :=
+  ⟨(pref.toList ++ chosen).toArray, by
+    simp [hk]⟩
+
+@[simp] private theorem assembleColumnsSuffix_left
+    {n m : Nat} (chosen : List (Fin m))
+    (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
+    (i : Fin (n - chosen.length)) :
+    (assembleColumnsSuffix chosen pref hk)[
+        (⟨i.val, by
+          have hi : i.val < n - chosen.length := i.isLt
+          omega⟩ : Fin n)] = pref[i] := by
+  simp [assembleColumnsSuffix]
+
+@[simp] private theorem assembleColumnsSuffix_right
+    {n m : Nat} (chosen : List (Fin m))
+    (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
+    (i : Fin chosen.length) :
+    (assembleColumnsSuffix chosen pref hk)[
+        (⟨n - chosen.length + i.val, by
+          have hi : i.val < chosen.length := i.isLt
+          omega⟩ : Fin n)] = chosen[i] := by
+  unfold assembleColumnsSuffix
+  simp [List.getElem_append_right]
+
+private def partialColumnTupleCoeff {R : Type u} [Mul R] [OfNat R 1] {n m : Nat}
+    (coeff : Matrix R n m) (chosen : List (Fin m))
+    (pref : Vector (Fin m) (n - chosen.length)) : R :=
+  (List.finRange (n - chosen.length)).foldl
+    (fun acc i => acc * coeff[(⟨i.val, by
+      have hi : i.val < n - chosen.length := i.isLt
+      omega⟩ : Fin n)][pref[i]]) 1
+
+private theorem partialColumnTupleCoeff_nil
+    {R : Type u} [Mul R] [OfNat R 1] {n m : Nat}
+    (coeff : Matrix R n m) (cols : Vector (Fin m) n) :
+    partialColumnTupleCoeff coeff [] cols = columnTupleCoeff coeff cols := by
+  unfold partialColumnTupleCoeff columnTupleCoeff
+  apply foldl_det_product_congr
+  intro i _hmem
+  congr 2
 
 end Matrix
 end Hex

--- a/progress/20260510T114800Z_a56f6758.md
+++ b/progress/20260510T114800Z_a56f6758.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Claimed #2878 via REST fallback because GitHub GraphQL rate limiting made
+`coordination claim` unreliable after the blocked human-oversight issues.
+
+Added a compiling suffix endpoint/helper layer in `HexMatrix/Determinant.lean`:
+
+- `columnSumMatrixWithSuffix_eq_columnTupleMatrix`, the full-suffix endpoint.
+- `assembleColumnsSuffix` plus left/right lookup lemmas.
+- `partialColumnTupleCoeff` for the unexpanded prefix columns.
+- `partialColumnTupleCoeff_nil`, connecting the empty-suffix case to
+  `columnTupleCoeff`.
+
+Verified:
+
+- `lake build HexMatrix.Determinant`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexMatrix/Determinant.lean`
+
+The banned-marker scan returned no matches in `HexMatrix/Determinant.lean`.
+
+## Current frontier
+
+#2878 remains partial. The final all-column theorem
+`det_columnSumMatrix_eq_sum_columnTuples` is still not proved.
+
+The next hard proof obligation is the dependent-index match for the suffix
+step: showing that prepending `c` to `chosen` and using a shorter prefix is the
+same full column tuple as inserting `c` at the last position of the longer
+remaining-prefix tuple, and that the prefix coefficient product gains exactly
+the `coeff[dst][c]` factor from `det_columnSumMatrixWithSuffix_expand`.
+
+## Next step
+
+Prove the two suffix step match-up lemmas:
+
+- `assembleColumnsSuffix_insertAt_last_eq`
+- `partialColumnTupleCoeff_insertAt_last`
+
+Then use them with `foldl_det_sum_swap`, `foldl_det_sum_flatMap`, and
+`det_columnSumMatrixWithSuffix_expand` to complete the parameterized suffix
+induction and specialize it at `chosen = []`.
+
+## Blockers
+
+GitHub GraphQL rate limit is exhausted. Claiming, PR creation, and label
+updates need REST fallback until the limit resets.


### PR DESCRIPTION
Partial progress for #2878.\n\nAdds the suffix endpoint/helper layer for the all-column ordered tuple determinant expansion:\n\n- full-suffix endpoint `columnSumMatrixWithSuffix_eq_columnTupleMatrix`\n- `assembleColumnsSuffix` with left/right lookup lemmas\n- `partialColumnTupleCoeff` and the empty-suffix bridge to `columnTupleCoeff`\n\nVerification run locally:\n\n- `lake build HexMatrix.Determinant`\n- `lake build HexMatrix`\n- `python3 scripts/check_dag.py`\n- `git diff --check`\n- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexMatrix/Determinant.lean`\n\nRemaining work for #2878 is the suffix step match-up lemmas and final induction.