### PR TITLE
HexMatrix.RREF: prove row-span transport through echelon transform

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -531,6 +531,26 @@ theorem leadingPrefix_borderedMinor_succ_eq_borderedMinor (M : Matrix R n n)
     (1 : Matrix R n n)[i][j] = if i = j then (1 : R) else 0 := by
   simp [show (1 : Matrix R n n) = Matrix.identity from rfl, Matrix.identity, ofFn]
 
+/-- The identity matrix is its own transpose. -/
+theorem transpose_one [OfNat R 0] [OfNat R 1] {n : Nat} :
+    Matrix.transpose (1 : Matrix R n n) = (1 : Matrix R n n) := by
+  apply Vector.ext
+  intro i hi
+  apply Vector.ext
+  intro j hj
+  let ii : Fin n := ⟨i, hi⟩
+  let jj : Fin n := ⟨j, hj⟩
+  show (Matrix.transpose (1 : Matrix R n n))[ii][jj] = (1 : Matrix R n n)[ii][jj]
+  have hflip : (Matrix.transpose (1 : Matrix R n n))[ii][jj] =
+      (1 : Matrix R n n)[jj][ii] := by
+    simp [transpose, col, Vector.getElem_ofFn]
+  rw [hflip, getElem_one, getElem_one]
+  by_cases hij : ii = jj
+  · have hji : jj = ii := hij.symm
+    rw [if_pos hij, if_pos hji]
+  · have hji : jj ≠ ii := fun h => hij h.symm
+    rw [if_neg hij, if_neg hji]
+
 /-- A foldl whose every step adds `0` reduces to the initial accumulator. -/
 private theorem foldl_add_eq_acc {R : Type u} [Lean.Grind.CommRing R]
     {α : Type v} (xs : List α) (f : α → R) (acc : R)

--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -135,6 +135,46 @@ private theorem rowCombination_transform_transpose [Lean.Grind.CommRing R]
     _ = Matrix.transpose D.echelon * e := by
           rw [E.transform_mul]
 
+/-- Converse row-combination transport: an `M`-row-combination witness `c`
+yields a `D.echelon`-row-combination witness `Matrix.transpose Tinv * c`,
+where `Tinv` is any left inverse of `D.transform`. The proof reuses the
+forward transport at the candidate witness. -/
+private theorem rowCombination_transformInv_transpose [Lean.Grind.CommRing R]
+    {M : Matrix R n m} {D : RowEchelonData R n m}
+    (E : IsEchelonForm M D) {Tinv : Matrix R n n}
+    (hTinv : Tinv * D.transform = 1) (c : Vector R n) :
+    rowCombination D.echelon (Matrix.transpose Tinv * c) = rowCombination M c := by
+  have hcompose :
+      Matrix.transpose D.transform * (Matrix.transpose Tinv * c) = c := by
+    calc
+      Matrix.transpose D.transform * (Matrix.transpose Tinv * c) =
+          (Matrix.transpose D.transform * Matrix.transpose Tinv) * c := by
+            exact (Matrix.mul_assoc_vec (A := Matrix.transpose D.transform)
+              (B := Matrix.transpose Tinv) (v := c)).symm
+      _ = Matrix.transpose (Tinv * D.transform) * c := by
+            rw [← Matrix.transpose_mul_of_mul_comm Lean.Grind.CommSemiring.mul_comm]
+      _ = Matrix.transpose (1 : Matrix R n n) * c := by
+            rw [hTinv]
+      _ = (1 : Matrix R n n) * c := by
+            rw [Matrix.transpose_one]
+      _ = c := Matrix.one_mulVec c
+  have hforward := E.rowCombination_transform_transpose (e := Matrix.transpose Tinv * c)
+  rw [hcompose] at hforward
+  exact hforward.symm
+
+/-- Existential converse transport: any `v` in the row span of `M` is also in
+the row span of `D.echelon`, with an explicit witness produced from a left
+inverse of `D.transform`. -/
+private theorem exists_rowCombination_echelon_of_M [Lean.Grind.CommRing R]
+    {M : Matrix R n m} {D : RowEchelonData R n m}
+    (E : IsEchelonForm M D) {v : Vector R m}
+    (h : ∃ c : Vector R n, rowCombination M c = v) :
+    ∃ d : Vector R n, rowCombination D.echelon d = v := by
+  rcases h with ⟨c, hc⟩
+  rcases E.transform_inv with ⟨Tinv, hTinv⟩
+  refine ⟨Matrix.transpose Tinv * c, ?_⟩
+  rw [E.rowCombination_transformInv_transpose hTinv c, hc]
+
 variable [Mul R] [Add R] [OfNat R 0] [OfNat R 1]
 variable {M : Matrix R n m} {D : RowEchelonData R n m}
 

--- a/progress/20260510T132303Z_1b6b4184.md
+++ b/progress/20260510T132303Z_1b6b4184.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Claimed and completed #3006 — the converse RREF row-span transport.
+
+Added `Matrix.transpose_one` to `HexMatrix/Basic.lean` (after `getElem_one`
+to keep the dependency chain clean).
+
+Added two new private helpers in `HexMatrix/RREF.lean` inside
+`namespace IsEchelonForm`:
+
+- `rowCombination_transformInv_transpose` is the explicit-form converse
+  transport. Given any left inverse `Tinv` of `D.transform`, it states
+  `rowCombination D.echelon (transpose Tinv * c) = rowCombination M c`.
+  The proof reuses #3013's forward transport at `e := transpose Tinv * c`
+  and reduces `transpose D.transform * (transpose Tinv * c)` to `c` via
+  `mul_assoc_vec`, `transpose_mul_of_mul_comm`, `transpose_one`,
+  and `one_mulVec`.
+- `exists_rowCombination_echelon_of_M` is the existential wrapper: from
+  an `M`-row-span witness for `v`, produce an `D.echelon`-row-span
+  witness, by extracting `Tinv` from `E.transform_inv`.
+
+Verified:
+
+- `lake build HexMatrix.RREF`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexMatrix/RREF.lean
+   HexMatrix/Basic.lean` — only pre-existing sorries, none in the new
+  helpers.
+
+## Current frontier
+
+The converse transport ingredient for `spanCoeffs_complete` is now
+available. The remaining piece for #3004 is the RREF pivot-column
+reconstruction lemma, which is explicitly out of scope for this issue.
+
+## Next step
+
+A worker should pick up the RREF pivot-column reconstruction lemma
+(separately tracked) so that `spanCoeffs_complete` can be wired up
+using both the forward transport (#3013) and this converse transport.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3006

Session: `1b6b4184-fe71-4dff-904f-22ff880afba9`

fd8bbe6 chore: progress entry for #3006 (1b6b4184)
2eb29ca feat: add RREF row-span transport via transform inverse (#3006)

🤖 Prepared with Claude Code