### PR TITLE
feat: bridge executable nullspace to Mathlib kernel

### DIFF
--- a/HexMatrixMathlib/RankSpanNullspace.lean
+++ b/HexMatrixMathlib/RankSpanNullspace.lean
@@ -44,6 +44,43 @@ def vectorEquiv : Vector R n ≃ (Fin n → R) where
   funext j
   simp [Hex.Matrix.row]
 
+private theorem foldl_finRange_eq_sum [AddCommMonoid R] {n : Nat} (f : Fin n → R) :
+    (List.finRange n).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
+  rw [← List.foldl_map]
+  rw [← List.sum_eq_foldl]
+  rw [← List.sum_toFinset f (List.nodup_finRange n)]
+  rw [List.toFinset_finRange]
+
+private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector R m) :
+    vectorEquiv (M * v) = (matrixEquiv M).mulVec (vectorEquiv v) := by
+  funext i
+  simp only [vectorEquiv_apply]
+  change (Hex.Matrix.mulVec M v)[i.val] = (matrixEquiv M).mulVec (vectorEquiv v) i
+  unfold Hex.Matrix.mulVec Hex.Matrix.dot Hex.Matrix.row Hex.Vector.dotProduct
+  rw [Vector.getElem_ofFn i.isLt]
+  rw [foldl_finRange_eq_sum]
+  unfold _root_.Matrix.mulVec dotProduct
+  apply Finset.sum_congr rfl
+  intro k _
+  rfl
+
+private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
+    {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
+    (E : Hex.Matrix.IsRREF M D) (c : Vector R (m - D.rank)) :
+    vectorEquiv (E.nullspaceMatrix * c) =
+      ∑ k : Fin (m - D.rank), c[k] • vectorEquiv (E.nullspace.get k) := by
+  funext j
+  simp only [vectorEquiv_apply, Pi.smul_apply, Finset.sum_apply]
+  change (Hex.Matrix.mulVec E.nullspaceMatrix c)[j.val] =
+    ∑ k : Fin (m - D.rank), c[k] * (E.nullspace.get k)[j]
+  unfold Hex.Matrix.mulVec Hex.Matrix.dot Hex.Matrix.row Hex.Vector.dotProduct
+  rw [Vector.getElem_ofFn j.isLt]
+  rw [foldl_finRange_eq_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  unfold Hex.Matrix.IsRREF.nullspace Hex.Matrix.col
+  simp [mul_comm]
+
 theorem rank_eq [Field R] (M : Hex.Matrix R n m)
     (D : Hex.Matrix.RowEchelonData R n m) (E : Hex.Matrix.IsEchelonForm M D) :
     D.rank = _root_.Matrix.rank (matrixEquiv M) := by
@@ -69,13 +106,49 @@ theorem nullspace_mem_ker [Field R]
     (E : Hex.Matrix.IsRREF M D) (k : Fin (m - D.rank)) :
     vectorEquiv (E.nullspace.get k) ∈
       LinearMap.ker ((_root_.Matrix.mulVecLin (matrixEquiv M))) := by
-  sorry
+  rw [LinearMap.mem_ker, _root_.Matrix.mulVecLin_apply]
+  have hsound := Hex.Matrix.IsRREF.nullspace_sound E k
+  have hbridge := vectorEquiv_mulVec (M := M) (v := E.nullspace.get k)
+  rw [hsound] at hbridge
+  have hzero : vectorEquiv (0 : Vector R n) = 0 := by
+    ext i
+    simp
+  rw [hzero] at hbridge
+  exact hbridge.symm
 
 theorem nullspace_span_eq_ker [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) :
     Submodule.span R (Set.range fun k : Fin (m - D.rank) => vectorEquiv (E.nullspace.get k)) =
       LinearMap.ker (_root_.Matrix.mulVecLin (matrixEquiv M)) := by
-  sorry
+  apply le_antisymm
+  · rw [Submodule.span_le]
+    rintro x ⟨k, rfl⟩
+    exact nullspace_mem_ker E k
+  · intro x hx
+    rw [LinearMap.mem_ker, _root_.Matrix.mulVecLin_apply] at hx
+    let v : Vector R m := vectorEquiv.symm x
+    have hMv : M * v = 0 := by
+      have hbridge := vectorEquiv_mulVec (M := M) (v := v)
+      have hxv : vectorEquiv v = x := by
+        simp [v]
+      rw [hxv] at hbridge
+      have hzero : (matrixEquiv M).mulVec x = 0 := hx
+      rw [hzero] at hbridge
+      have hzeroVec : vectorEquiv (M * v) = vectorEquiv (0 : Vector R n) := by
+        simpa [vectorEquiv] using hbridge
+      exact Equiv.injective vectorEquiv hzeroVec
+    rcases Hex.Matrix.IsRREF.nullspace_complete E v hMv with ⟨c, hc⟩
+    have hxsum :
+        x = ∑ k : Fin (m - D.rank), c[k] • vectorEquiv (E.nullspace.get k) := by
+      have hlin := vectorEquiv_nullspaceMatrix_mulVec E c
+      rw [hc] at hlin
+      have hxv : vectorEquiv v = x := by
+        simp [v]
+      rw [hxv] at hlin
+      exact hlin
+    rw [hxsum]
+    exact Submodule.sum_mem _ fun k _ =>
+      Submodule.smul_mem _ c[k] (Submodule.subset_span ⟨k, rfl⟩)
 
 end HexMatrixMathlib

--- a/progress/20260510T191547Z_8dc070aa.md
+++ b/progress/20260510T191547Z_8dc070aa.md
@@ -1,0 +1,35 @@
+# 20260510T191547Z — feature session 8dc070aa
+
+## Accomplished
+
+Claimed issue #3049 and proved the two nullspace bridge theorems in
+`HexMatrixMathlib/RankSpanNullspace.lean`:
+
+- `nullspace_mem_ker`, by translating local executable
+  `Hex.Matrix.IsRREF.nullspace_sound` through `matrixEquiv`, `vectorEquiv`,
+  and Mathlib `Matrix.mulVecLin`.
+- `nullspace_span_eq_ker`, by using local
+  `Hex.Matrix.IsRREF.nullspace_complete` for the reverse inclusion and
+  rewriting executable nullspace-matrix multiplication as a Mathlib finite
+  linear combination of the computed basis vectors.
+
+Added private bridge helpers in the same file:
+
+- `foldl_finRange_eq_sum`
+- `vectorEquiv_mulVec`
+- `vectorEquiv_nullspaceMatrix_mulVec`
+
+## Current frontier
+
+`HexMatrixMathlib/RankSpanNullspace.lean` still has the pre-existing
+non-nullspace `sorry`s for `rank_eq`, `spanCoeffs_eq_linearCombination`, and
+`spanContains_iff_mem_span`.
+
+## Next step
+
+Open the PR for #3049, then continue with the remaining rank/span bridge
+issues if they are available.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3049

Session: `8dc070aa-d305-4f2d-85bf-f9abd045953d`

5a80bab feat: bridge nullspace basis to Mathlib kernel

🤖 Prepared with Claude Code