### PR TITLE
HexMatrix.RREF: lift canonical-column helpers into rrefLoop invariant

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -1111,6 +1111,76 @@ private theorem rref_final_shape (M : Matrix R n m) :
       transform := 1
       pivots := [] } (rrefLoop_initial_shape M)
 
+/-- The canonical-column invariant is preserved through `rrefLoop`. -/
+private theorem rrefLoop_canonical :
+    ∀ (fuel col : Nat) (state : RrefState R n m),
+      RrefShapeInvariant (R := R) (n := n) (m := m) col state →
+      RrefCanonicalInvariant (R := R) (n := n) (m := m) state →
+      RrefCanonicalInvariant (R := R) (n := n) (m := m)
+        (rrefLoop (R := R) (n := n) (m := m) col fuel state) := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro col state _hshape hcanon
+      simpa [rrefLoop] using hcanon
+  | succ fuel ih =>
+      intro col state hshape hcanon
+      unfold rrefLoop
+      by_cases hRow : state.row < n
+      · rw [dif_pos hRow]
+        by_cases hCol : col < m
+        · rw [dif_pos hCol]
+          cases hpivot : findPivot? state.echelon ⟨col, hCol⟩ state.row with
+          | none =>
+              simpa [hpivot] using
+                ih (col + 1) state (hshape.mono_col (Nat.le_succ col)) hcanon
+          | some pivot =>
+              let colFin : Fin m := ⟨col, hCol⟩
+              let target : Fin n := ⟨state.row, hRow⟩
+              let swappedEchelon := rowSwap state.echelon target pivot
+              let swappedTransform := rowSwap state.transform target pivot
+              let pivotVal := swappedEchelon[target][colFin]
+              let scaledEchelon := rowScale swappedEchelon target pivotVal⁻¹
+              let scaledTransform := rowScale swappedTransform target pivotVal⁻¹
+              let eliminated := eliminateColumn scaledEchelon scaledTransform target colFin
+              let nextState : RrefState R n m :=
+                { row := state.row + 1
+                  echelon := eliminated.1
+                  transform := eliminated.2
+                  pivots := state.pivots.concat colFin }
+              have hnext_shape :
+                  RrefShapeInvariant (R := R) (n := n) (m := m) (col + 1) nextState := by
+                simpa [nextState, colFin] using
+                  rrefShapeInvariant_concat (R := R) (n := n) (m := m)
+                    (col := col) (state := state) hshape hRow hCol
+                    eliminated.1 eliminated.2
+              have hnext_canon :
+                  RrefCanonicalInvariant (R := R) (n := n) (m := m) nextState := by
+                simpa [nextState, colFin, target, swappedEchelon,
+                  swappedTransform, pivotVal, scaledEchelon, scaledTransform,
+                  eliminated] using
+                  rrefCanonicalInvariant_pivot_step (R := R) (n := n) (m := m)
+                    (col := col) (state := state) hshape hcanon hRow hCol hpivot
+              simpa [hpivot, nextState, colFin, target, swappedEchelon,
+                swappedTransform, pivotVal, scaledEchelon, scaledTransform,
+                eliminated] using
+                ih (col + 1) nextState hnext_shape hnext_canon
+        · rw [dif_neg hCol]
+          exact hcanon
+      · rw [dif_neg hRow]
+        exact hcanon
+
+private theorem rref_final_canonical (M : Matrix R n m) :
+    RrefCanonicalInvariant (R := R) (n := n) (m := m)
+      (rrefLoop 0 m
+        { row := 0
+          echelon := M
+          transform := 1
+          pivots := [] }) := by
+  exact rrefLoop_canonical (R := R) (n := n) (m := m) m 0
+    { row := 0, echelon := M, transform := 1, pivots := [] }
+    (rrefLoop_initial_shape M) (rrefLoop_initial_canonical M)
+
 /-- `rrefLoop` preserves existence of a left inverse for the transform. -/
 private theorem rrefLoop_left_inverse_preserve (col fuel : Nat)
     (state : RrefState R n m)
@@ -1336,6 +1406,19 @@ private theorem rref_transform_mul (M : Matrix R n m) :
 
 /-- The computed `rref` data satisfies the `IsRREF` contract. -/
 theorem rref_isRREF (M : Matrix R n m) : IsRREF M (rref M) := by
+  let final := rrefLoop 0 m
+    { row := 0, echelon := M, transform := 1, pivots := [] }
+  have hcanon : RrefCanonicalInvariant (R := R) (n := n) (m := m) final := by
+    simpa [final] using rref_final_canonical M
+  have hshape : RrefShapeInvariant (R := R) (n := n) (m := m) m final := by
+    simpa [final] using rref_final_shape M
+  have hrank_eq : (rref M).rank = final.pivots.length := by simp [rref, final]
+  have hechelon_eq : (rref M).echelon = final.echelon := by simp [rref, final]
+  have hpivotCol_get : ∀ (i : Fin (rref M).rank)
+      (hi : i.val < final.pivots.length),
+      ((rref M).pivotCols.get i).val = (final.pivots[i.val]'hi).val := by
+    intro i _hi
+    simp [rref, final, Vector.get, List.getElem_toArray]
   refine
     { toIsEchelonForm :=
         { transform_mul := rref_transform_mul M
@@ -1344,11 +1427,50 @@ theorem rref_isRREF (M : Matrix R n m) : IsRREF M (rref M) := by
           rank_le_n := rref_rank_le_n M
           rank_le_m := rref_rank_le_m M
           pivotCols_sorted := rref_pivotCols_sorted M
-          below_pivot_zero := ?_
-          zero_row := ?_ }
-      pivot_one := ?_
-      above_pivot_zero := ?_ }
-  all_goals sorry
+          below_pivot_zero := ?bpz
+          zero_row := ?zr }
+      pivot_one := ?po
+      above_pivot_zero := ?apz }
+  case po =>
+    intro i
+    have hi_lt_len : i.val < final.pivots.length := hrank_eq ▸ i.isLt
+    have hin : i.val < n := by
+      have hrow_le : final.row ≤ n := hshape.row_le_n
+      have hrow_eq : final.row = final.pivots.length := hshape.row_eq_length
+      omega
+    have hentry := hcanon.pivot_entry_one i.val hi_lt_len hin
+    have hcol_eq : (rref M).pivotCols.get i = final.pivots[i.val] :=
+      Fin.ext (hpivotCol_get i hi_lt_len)
+    have hech : (rref M).echelon[i][(rref M).pivotCols.get i] =
+        final.echelon[(⟨i.val, hin⟩ : Fin n)][final.pivots[i.val]] := by
+      simp only [hechelon_eq, hcol_eq]
+      rfl
+    rw [hech]
+    exact hentry
+  case apz =>
+    intro i j hji
+    have hi_lt_len : i.val < final.pivots.length := hrank_eq ▸ i.isLt
+    have hentry := hcanon.other_entry_zero i.val hi_lt_len j (Nat.ne_of_lt hji)
+    have hcol_eq : (rref M).pivotCols.get i = final.pivots[i.val] :=
+      Fin.ext (hpivotCol_get i hi_lt_len)
+    have hech : (rref M).echelon[j][(rref M).pivotCols.get i] =
+        final.echelon[j][final.pivots[i.val]] := by
+      simp only [hcol_eq, hechelon_eq]
+    rw [hech]
+    exact hentry
+  case bpz =>
+    intro i j hij
+    have hi_lt_len : i.val < final.pivots.length := hrank_eq ▸ i.isLt
+    have hentry := hcanon.other_entry_zero i.val hi_lt_len j (Nat.ne_of_gt hij)
+    have hcol_eq : (rref M).pivotCols.get i = final.pivots[i.val] :=
+      Fin.ext (hpivotCol_get i hi_lt_len)
+    have hech : (rref M).echelon[j][(rref M).pivotCols.get i] =
+        final.echelon[j][final.pivots[i.val]] := by
+      simp only [hcol_eq, hechelon_eq]
+    rw [hech]
+    exact hentry
+  case zr =>
+    sorry
 
 end FieldAlgorithms
 

--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -757,6 +757,15 @@ private theorem RrefShapeInvariant.mono_col {col col' : Nat} {state : RrefState 
   pivots_sorted := h.pivots_sorted
   pivots_lt_col := fun p hp => Nat.lt_of_lt_of_le (h.pivots_lt_col p hp) hcol
 
+/-- Proof-only invariant for `rrefLoop`: every processed pivot column is
+canonical — the pivot row has entry `1`, and every other row has entry `0`.
+The pivot row of the `i`-th pivot is row `i` of the echelon matrix. -/
+private structure RrefCanonicalInvariant (state : RrefState R n m) : Prop where
+  pivot_entry_one : ∀ (i : Nat) (hi : i < state.pivots.length) (hin : i < n),
+    state.echelon[(⟨i, hin⟩ : Fin n)][state.pivots[i]] = 1
+  other_entry_zero : ∀ (i : Nat) (hi : i < state.pivots.length) (r : Fin n),
+    r.val ≠ i → state.echelon[r][state.pivots[i]] = 0
+
 omit [Lean.Grind.Field R] [DecidableEq R] in
 private theorem list_sorted_get_concat_of_lt {ps : List (Fin m)} {col : Nat}
     (hsorted : ∀ (i j : Nat) (hi : i < ps.length) (hj : j < ps.length),
@@ -823,6 +832,207 @@ private theorem rrefShapeInvariant_concat {col : Nat} {state : RrefState R n m}
     · simp at hpLast
       subst hpLast
       exact Nat.lt_succ_self col
+
+omit [DecidableEq R] in
+/-- The empty-pivot initial state trivially satisfies the canonical-column
+invariant. -/
+private theorem rrefLoop_initial_canonical (M : Matrix R n m) :
+    RrefCanonicalInvariant (R := R) (n := n) (m := m)
+      { row := 0, echelon := M, transform := 1, pivots := [] } where
+  pivot_entry_one := by intro i hi _; exact absurd hi (by simp)
+  other_entry_zero := by intro i hi _ _; exact absurd hi (by simp)
+
+/-- One pivot iteration of `rrefLoop` preserves the canonical-column
+invariant: every previously processed pivot column remains canonical, and
+the newly added pivot column is canonical with the just-discovered pivot
+row. -/
+private theorem rrefCanonicalInvariant_pivot_step
+    {col : Nat} {state : RrefState R n m}
+    (hshape : RrefShapeInvariant (R := R) (n := n) (m := m) col state)
+    (hcanon : RrefCanonicalInvariant (R := R) (n := n) (m := m) state)
+    (hRow : state.row < n) (hCol : col < m) {pivot : Fin n}
+    (hpivot : findPivot? state.echelon ⟨col, hCol⟩ state.row = some pivot) :
+    let colFin : Fin m := ⟨col, hCol⟩
+    let target : Fin n := ⟨state.row, hRow⟩
+    let swappedEchelon := rowSwap state.echelon target pivot
+    let swappedTransform := rowSwap state.transform target pivot
+    let pivotVal := swappedEchelon[target][colFin]
+    let scaledEchelon := rowScale swappedEchelon target pivotVal⁻¹
+    let scaledTransform := rowScale swappedTransform target pivotVal⁻¹
+    let eliminated := eliminateColumn scaledEchelon scaledTransform target colFin
+    RrefCanonicalInvariant (R := R) (n := n) (m := m)
+      { row := state.row + 1
+        echelon := eliminated.1
+        transform := eliminated.2
+        pivots := state.pivots.concat colFin } := by
+  -- Set up names.
+  intro colFin target swappedEchelon swappedTransform pivotVal scaledEchelon
+    scaledTransform eliminated
+  -- The pivot row of an old pivot at index `i` is below the new pivot row `target`.
+  have hpivots_lt_row : ∀ (i : Nat), i < state.pivots.length → i < state.row := by
+    intro i hi
+    rw [hshape.row_eq_length]; exact hi
+  -- The pivot row `pivot` returned by `findPivot?` is ≥ state.row.
+  have hpivot_ge : state.row ≤ pivot.val :=
+    findPivot?_some_ge state.echelon colFin hpivot
+  -- The pivot column is nonzero.
+  have hpivotVal_ne : pivotVal ≠ 0 := by
+    have hentry : pivotVal = state.echelon[pivot][colFin] := by
+      simpa [pivotVal, swappedEchelon] using
+        rowSwap_target_pivot_entry state.echelon target pivot colFin
+    rw [hentry]
+    exact findPivot?_some_nonzero state.echelon colFin hpivot
+  -- Step A: for each OLD pivot index `i`, canonical column is preserved by
+  -- the rowSwap → rowScale → eliminateColumn chain at column `state.pivots[i]`.
+  have hold : ∀ (i : Nat) (hi : i < state.pivots.length) (hin : i < n),
+      eliminated.1[(⟨i, hin⟩ : Fin n)][state.pivots[i]] = 1 ∧
+      ∀ r : Fin n, r.val ≠ i →
+        eliminated.1[r][state.pivots[i]] = 0 := by
+    intro i hi hin
+    let pivotRow : Fin n := ⟨i, hin⟩
+    have hi_lt_row : i < state.row := hpivots_lt_row i hi
+    have hpivotRow_ne_target : pivotRow ≠ target := by
+      intro hEq
+      have hval : i = state.row := congrArg Fin.val hEq
+      omega
+    have hpivotRow_ne_pivot : pivotRow ≠ pivot := by
+      intro hEq
+      have hval : i = pivot.val := congrArg Fin.val hEq
+      omega
+    -- Original canonical at oldCol = state.pivots[i].
+    have hOne₀ :
+        state.echelon[pivotRow][state.pivots[i]] = 1 :=
+      hcanon.pivot_entry_one i hi hin
+    have hZero₀ :
+        ∀ r : Fin n, r.val ≠ i →
+          state.echelon[r][state.pivots[i]] = 0 :=
+      hcanon.other_entry_zero i hi
+    have hZero₀_fin :
+        ∀ r : Fin n, r ≠ pivotRow →
+          state.echelon[r][state.pivots[i]] = 0 := by
+      intro r hr
+      apply hZero₀ r
+      intro hval
+      apply hr
+      apply Fin.ext
+      exact hval
+    have hTarget₀ : state.echelon[target][state.pivots[i]] = 0 :=
+      hZero₀_fin target hpivotRow_ne_target.symm
+    have hPivot₀ : state.echelon[pivot][state.pivots[i]] = 0 :=
+      hZero₀_fin pivot hpivotRow_ne_pivot.symm
+    -- After rowSwap.
+    have hSwap :=
+      rowSwap_preserve_canonical_column state.echelon pivotRow target pivot
+        state.pivots[i] hTarget₀ hPivot₀ hpivotRow_ne_target hpivotRow_ne_pivot
+        hOne₀ hZero₀_fin
+    have hSwap_one : swappedEchelon[pivotRow][state.pivots[i]] = 1 := hSwap.1
+    have hSwap_zero :
+        ∀ r : Fin n, r ≠ pivotRow → swappedEchelon[r][state.pivots[i]] = 0 :=
+      hSwap.2
+    have hTarget₁ : swappedEchelon[target][state.pivots[i]] = 0 :=
+      hSwap_zero target hpivotRow_ne_target.symm
+    -- After rowScale.
+    have hScale :=
+      rowScale_preserve_canonical_column swappedEchelon pivotRow target
+        state.pivots[i] pivotVal⁻¹ hTarget₁ hpivotRow_ne_target hSwap_one
+        hSwap_zero
+    have hScale_one : scaledEchelon[pivotRow][state.pivots[i]] = 1 := hScale.1
+    have hScale_zero :
+        ∀ r : Fin n, r ≠ pivotRow → scaledEchelon[r][state.pivots[i]] = 0 :=
+      hScale.2
+    have hTarget₂ : scaledEchelon[target][state.pivots[i]] = 0 :=
+      hScale_zero target hpivotRow_ne_target.symm
+    -- After eliminateColumn.
+    have hElim :=
+      eliminateColumn_preserve_canonical_column scaledEchelon scaledTransform
+        pivotRow target state.pivots[i] colFin hpivotRow_ne_target hTarget₂
+        hScale_one hScale_zero
+    refine ⟨hElim.1, ?_⟩
+    intro r hrval
+    apply hElim.2 r
+    intro hEq
+    apply hrval
+    exact congrArg Fin.val hEq
+  -- Step B: for the NEW pivot at column colFin, the canonical property holds
+  -- with pivot row = target.
+  have hnew :
+      eliminated.1[target][colFin] = 1 ∧
+      ∀ r : Fin n, r ≠ target → eliminated.1[r][colFin] = 0 := by
+    -- After rowScale, target's entry in colFin is 1.
+    have hScaled_pivot : scaledEchelon[target][colFin] = 1 := by
+      have hEntry : scaledEchelon[target][colFin] = pivotVal⁻¹ * pivotVal := by
+        simpa [scaledEchelon, pivotVal] using
+          rowScale_getElem swappedEchelon target target pivotVal⁻¹ colFin
+      rw [hEntry]
+      exact Lean.Grind.Field.inv_mul_cancel hpivotVal_ne
+    -- eliminateColumn_pivotRow: target's row is unchanged at colFin.
+    have hElim_pivot : eliminated.1[target][colFin] = 1 := by
+      have := eliminateColumn_pivotRow scaledEchelon scaledTransform target colFin colFin
+      change eliminated.1[target][colFin] = scaledEchelon[target][colFin] at this
+      rw [this, hScaled_pivot]
+    -- eliminateColumn_zero: every other row is 0 at colFin.
+    have hElim_zero :
+        ∀ r : Fin n, r ≠ target → eliminated.1[r][colFin] = 0 := by
+      intro r hr
+      exact eliminateColumn_zero scaledEchelon scaledTransform target colFin
+        hScaled_pivot r hr
+    exact ⟨hElim_pivot, hElim_zero⟩
+  -- Concat indexing helper: for i ≤ state.pivots.length, get the i-th pivot.
+  have hconcat_get_old : ∀ (i : Nat) (_hi : i < state.pivots.length)
+      (_hi' : i < (state.pivots.concat colFin).length),
+      (state.pivots.concat colFin)[i] = state.pivots[i] := by
+    intro i hi _hi'
+    simp [List.concat_eq_append, List.getElem_append_left hi]
+  have hconcat_get_new :
+      ∀ (_hi : state.pivots.length < (state.pivots.concat colFin).length),
+        (state.pivots.concat colFin)[state.pivots.length] = colFin := by
+    intro _hi
+    simp [List.concat_eq_append]
+  -- Length of concat:
+  have hconcat_len : (state.pivots.concat colFin).length = state.pivots.length + 1 := by
+    simp
+  -- Build the invariant.
+  refine { pivot_entry_one := ?_, other_entry_zero := ?_ }
+  · -- pivot_entry_one
+    intro i hi hin
+    have hi' : i < state.pivots.length + 1 := by
+      rw [hconcat_len] at hi; exact hi
+    rcases Nat.lt_or_eq_of_le (Nat.le_of_lt_succ hi') with hlt | heq
+    · -- Old pivot
+      have hget := hconcat_get_old i hlt hi
+      simp only [hget]
+      exact (hold i hlt hin).1
+    · -- New pivot
+      subst heq
+      have hget := hconcat_get_new hi
+      simp only [hget]
+      -- Pivot row index = state.pivots.length = state.row = target.val.
+      have htarget_eq : (⟨state.pivots.length, hin⟩ : Fin n) = target := by
+        apply Fin.ext
+        change state.pivots.length = state.row
+        exact hshape.row_eq_length.symm
+      simp only [htarget_eq]
+      exact hnew.1
+  · -- other_entry_zero
+    intro i hi r hrval
+    have hi' : i < state.pivots.length + 1 := by
+      rw [hconcat_len] at hi; exact hi
+    rcases Nat.lt_or_eq_of_le (Nat.le_of_lt_succ hi') with hlt | heq
+    · -- Old pivot column
+      have hget := hconcat_get_old i hlt hi
+      simp only [hget]
+      exact (hold i hlt (Nat.lt_trans (hpivots_lt_row i hlt) hRow)).2 r hrval
+    · -- New pivot column
+      subst heq
+      have hget := hconcat_get_new hi
+      simp only [hget]
+      have hr_ne_target : r ≠ target := by
+        intro hEq
+        apply hrval
+        change r.val = state.pivots.length
+        have hval : r.val = state.row := congrArg Fin.val hEq
+        rw [hval, ← hshape.row_eq_length]
+      exact hnew.2 r hr_ne_target
 
 private theorem rrefLoop_shape :
     ∀ (fuel col : Nat) (state : RrefState R n m),

--- a/progress/20260510T232521Z_1577fc90.md
+++ b/progress/20260510T232521Z_1577fc90.md
@@ -1,0 +1,46 @@
+# Session 1577fc90 — RREF canonical-column lift
+
+## Accomplished
+
+- Closed #3163: lifted the operation-level canonical-column preservation
+  helpers from #3164 into a `rrefLoop` proof-only invariant and exposed
+  three of the four `IsRREF` corollaries.
+- Added `RrefCanonicalInvariant` in `HexMatrix/RREF.lean`: every
+  processed pivot column has its pivot row entry equal to `1` and every
+  other row entry equal to `0`.
+- Proved `rrefCanonicalInvariant_pivot_step`, which threads the
+  canonical property through one `rrefLoop` iteration:
+  - Old pivots survive `rowSwap → rowScale → eliminateColumn` via the
+    `*_preserve_canonical_column` helpers from #3164.
+  - The new pivot column becomes canonical via
+    `eliminateColumn_pivotRow` (for the pivot row) and
+    `eliminateColumn_zero` (for the other rows).
+- Added `rrefLoop_canonical` (fuel induction, parallel to
+  `rrefLoop_shape`) and `rref_final_canonical` (top-level corollary).
+- Discharged `pivot_one`, `above_pivot_zero`, and `below_pivot_zero`
+  inside `rref_isRREF`. The remaining `zero_row` sorry is the work
+  reserved for #3157.
+
+Verification: `lake build HexMatrix.RREF` clean (one expected
+`zero_row` sorry); `lake build HexMatrix` clean; `python3
+scripts/check_dag.py` exit 0; banned-marker grep shows exactly the one
+pre-existing `zero_row` sorry.
+
+Also skipped two stale issues earlier in the session: #3171 (depends on
+unmerged PR #3172) and #3127 (depends on unmerged #3133 work split
+across #3167/#3168/#3169).
+
+## Current frontier
+
+`rref_isRREF` is now one `zero_row` step away from full discharge. The
+canonical invariant infrastructure is reusable by any future work that
+needs to assert canonical pivot columns in proof.
+
+## Next step
+
+#3157 (claimed by another session) fills in the final `zero_row` sorry
+using the dual no-pivot-zero-column invariant.
+
+## Blockers
+
+None.

--- a/progress/20260511T001437Z_4112a7d2.md
+++ b/progress/20260511T001437Z_4112a7d2.md
@@ -1,0 +1,38 @@
+# Repair PR #3181 — bring up to current main; close duplicate PR #3187
+
+## Accomplished
+
+- Compared the two competing PRs for issue #3163:
+  - PR #3181 (`agent/1577fc90`): adds `RrefCanonicalInvariant`,
+    `rrefCanonicalInvariant_pivot_step`, `rrefLoop_canonical`,
+    `rref_final_canonical`, and uses them inside `rref_isRREF` to
+    discharge `pivot_one`, `above_pivot_zero`, and `below_pivot_zero`.
+    Only the `zero_row` field remains `sorry` (reserved for #3157).
+  - PR #3187 (`agent/34cd9a5a`): adds an overlapping canonical
+    invariant plus single-step lemmas and exposes `rref_pivot_one`
+    and `rref_pivot_other_zero` corollaries, but `rref_isRREF` is
+    still `all_goals sorry`.
+- PR #3181 is the better salvage target: it discharges 3 of 4 IsRREF
+  field sorries instead of just exposing helpers.
+- Merged current `origin/main` (commits 984ba32, 6c53f1a) into
+  `agent/1577fc90`. Clean merge — the new main commits only touch
+  `HexPolyFp/SquareFree.lean` and `HexPoly/Euclid.lean`, which the
+  PR does not modify.
+- Verified `lake build HexMatrix.RREF` (1 expected `sorry` warning
+  for `zero_row`), `lake build HexMatrix`, and `python3
+  scripts/check_dag.py`. `git diff --check` clean. The only `sorry`
+  in `HexMatrix/RREF.lean` is the pre-existing `zero_row` hole.
+
+## Current frontier
+
+PR #3181 now contains the latest main. PR #3187 is closed as
+superseded. Issue #3163 is closed by PR #3181 once linux CI passes.
+
+## Next step
+
+Linux build/conformance still in progress on PR #3181. CI will
+auto-merge on green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3163

Session: `1577fc90-12a2-44cc-949c-316f69df8ee7`

bbe1d69 doc: progress note for #3163 session
e3fc5a8 feat: discharge RREF pivot_one and above/below_pivot_zero via canonical invariant
b9b920d feat: add RREF canonical-column invariant and pivot-step preservation

🤖 Prepared with Claude Code