### PR TITLE
HexMatrix: canonical sort and orbit factorization for injective column tuples

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -5452,5 +5452,342 @@ theorem selectedColumnTuples_nodup {n m : Nat} :
     (selectedColumnTuples n m).Nodup :=
   selectedColumnTuplesUpTo_nodup m n m
 
+/-! ### Canonical sort and orbit factorization for injective column tuples
+
+For the Cauchy-Binet orbit-grouping argument we need, for every injective
+ordered column tuple `cols : Vector (Fin m) n`, a canonical factorization
+
+```
+cols[i] = (sortInjTuple cols)[(sortInjPerm cols)[i]]
+```
+
+where `sortInjTuple cols` is strictly increasing (i.e. lives in
+`selectedColumnTuples n m`) and `sortInjPerm cols` is a permutation of
+`Fin n` (i.e. lives in `permutationVectors n`). This gives a bijection
+between injective `columnTupleVectors n m` entries and the product
+`selectedColumnTuples n m × permutationVectors n`, which lets the orbit
+sum group ordered minors by their canonical sorted column choice.
+
+The implementation is rank-based: `sortInjPerm cols i` is the number of
+columns in `cols` strictly smaller in value than `cols[i]`. For any
+`cols`, this is `< n` because `cols[i]` is never strictly less than
+itself; for *injective* `cols`, the rank is moreover a bijection on
+`Fin n`. -/
+
+/-- Count of indices whose `cols`-image has strictly smaller `Fin.val`
+than that at `i`. This is the natural-number form of the rank. -/
+private def columnRankNat {m n : Nat} (cols : Vector (Fin m) n) (i : Fin n) : Nat :=
+  ((List.finRange n).filter fun j => decide (cols[j].val < cols[i].val)).length
+
+/-- The rank is always strictly less than `n`: index `i` itself is never
+in the filter, so the filter is a strict sublist of `finRange n`. -/
+private theorem columnRankNat_lt {m n : Nat} (cols : Vector (Fin m) n) (i : Fin n) :
+    columnRankNat cols i < n := by
+  have hwit :
+      ∃ x ∈ List.finRange n, ¬ (decide (cols[x].val < cols[i].val) = true) := by
+    refine ⟨i, List.mem_finRange i, ?_⟩
+    simp
+  have hlt :=
+    (List.length_filter_lt_length_iff_exists
+      (p := fun j => decide (cols[j].val < cols[i].val))
+      (l := List.finRange n)).mpr hwit
+  simpa [columnRankNat, List.length_finRange] using hlt
+
+/-- Canonical sorting permutation: for each index `i`, output the rank of
+`cols[i]` (number of strictly smaller positions). For an injective `cols`
+this is genuinely a permutation of `Fin n`; for a non-injective `cols` it
+is still well-defined but may have repeated values. -/
+def sortInjPerm {m n : Nat} (cols : Vector (Fin m) n) : Vector (Fin n) n :=
+  Vector.ofFn fun i => ⟨columnRankNat cols i, columnRankNat_lt cols i⟩
+
+@[simp] theorem sortInjPerm_getElem_val {m n : Nat}
+    (cols : Vector (Fin m) n) (i : Fin n) :
+    (sortInjPerm cols)[i].val = columnRankNat cols i := by
+  simp [sortInjPerm]
+
+/-- The canonical sorted version of `cols`: read `cols` through the inverse
+of `sortInjPerm`. For an injective `cols` this is strictly increasing; for
+a non-injective `cols` the value is well-defined but not meaningful. -/
+def sortInjTuple {m n : Nat} (cols : Vector (Fin m) n) : Vector (Fin m) n :=
+  Vector.ofFn fun r => cols[(inversePermutationVector (sortInjPerm cols))[r]]
+
+/-- Strict version of `List.countP_mono_left`: a single witness where
+`q` holds but `p` doesn't forces strict inequality. -/
+private theorem countP_lt_countP_of_witness {α : Type u}
+    (p q : α → Bool)
+    (hle_all : ∀ (xs : List α) (x : α), x ∈ xs → p x = true → q x = true) :
+    ∀ (xs : List α) (k : α), k ∈ xs → q k = true → p k = false →
+      xs.countP p < xs.countP q
+  | [], _k, hkmem, _, _ => by exact absurd hkmem List.not_mem_nil
+  | x :: xs, k, hkmem, hqk, hpk => by
+      simp only [List.mem_cons] at hkmem
+      rcases hkmem with heq | hk_in_xs
+      · -- x = k: at the head, `p k = false` and `q k = true`.
+        subst heq
+        have hxs_le : xs.countP p ≤ xs.countP q :=
+          List.countP_mono_left
+            (fun y hy => hle_all _ y (List.mem_cons_of_mem k hy))
+        simp [hqk, hpk]
+        omega
+      · -- k ∈ xs: recurse on the tail.
+        have ih :=
+          countP_lt_countP_of_witness p q hle_all xs k hk_in_xs hqk hpk
+        by_cases hpx : p x = true
+        · have hqx : q x = true := hle_all (x :: xs) x List.mem_cons_self hpx
+          simp [hpx, hqx]; omega
+        · have hpx' : p x = false := by
+            cases hpe : p x with
+            | true => exact absurd hpe hpx
+            | false => rfl
+          by_cases hqx : q x = true
+          · simp [hpx', hqx]; omega
+          · have hqx' : q x = false := by
+              cases hqe : q x with
+              | true => exact absurd hqe hqx
+              | false => rfl
+            simp [hpx', hqx']; exact ih
+
+/-- Monotonicity of the rank: if `cols[i].val < cols[j].val` then the
+rank strictly increases from `i` to `j`. Holds for any `cols`, no
+injectivity assumption needed. -/
+private theorem columnRankNat_strictMono {m n : Nat} (cols : Vector (Fin m) n)
+    {i j : Fin n} (hij : cols[i].val < cols[j].val) :
+    columnRankNat cols i < columnRankNat cols j := by
+  -- Switch from `length filter` to `countP`.
+  have hlen_eq_p :
+      ((List.finRange n).filter fun k => decide (cols[k].val < cols[i].val)).length
+        = (List.finRange n).countP (fun k => decide (cols[k].val < cols[i].val)) := by
+    rw [List.countP_eq_length_filter]
+  have hlen_eq_q :
+      ((List.finRange n).filter fun k => decide (cols[k].val < cols[j].val)).length
+        = (List.finRange n).countP (fun k => decide (cols[k].val < cols[j].val)) := by
+    rw [List.countP_eq_length_filter]
+  unfold columnRankNat
+  rw [hlen_eq_p, hlen_eq_q]
+  -- Strict comparison via element `i`.
+  refine countP_lt_countP_of_witness
+    (fun k => decide (cols[k].val < cols[i].val))
+    (fun k => decide (cols[k].val < cols[j].val))
+    ?_ (List.finRange n) i (List.mem_finRange i)
+    (decide_eq_true hij) ?_
+  · intro _ k _hkmem hpk
+    have hkk : cols[k].val < cols[i].val := by simpa using hpk
+    exact decide_eq_true (Nat.lt_trans hkk hij)
+  · simp
+
+/-- For an injective `cols`, the rank function is itself injective: two
+positions with the same rank must agree as `Fin n`. -/
+private theorem columnRankNat_injective_of_injective {m n : Nat}
+    (cols : Vector (Fin m) n) (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    Function.Injective (columnRankNat cols) := by
+  intro i j hrank
+  rcases Nat.lt_trichotomy cols[i].val cols[j].val with hlt | heq | hgt
+  · exact absurd (columnRankNat_strictMono cols hlt) (by omega)
+  · -- cols[i].val = cols[j].val ⇒ cols[i] = cols[j] ⇒ i = j by injectivity.
+    have hcol_eq : cols[i] = cols[j] := Fin.ext heq
+    exact hinj hcol_eq
+  · exact absurd (columnRankNat_strictMono cols hgt) (by omega)
+
+/-- For an injective `cols`, `sortInjPerm cols` is a permutation as a list. -/
+private theorem sortInjPerm_toList_nodup_of_injective {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    (sortInjPerm cols).toList.Nodup := by
+  rw [vector_toList_eq_finRange_map_get]
+  apply list_nodup_map_of_injective ?_ (List.nodup_finRange n)
+  intro i j hij
+  have hval : columnRankNat cols i = columnRankNat cols j := by
+    have := congrArg Fin.val hij
+    simpa [sortInjPerm] using this
+  exact columnRankNat_injective_of_injective cols hinj hval
+
+/-- For an injective `cols`, `sortInjPerm cols ∈ permutationVectors n`. -/
+theorem sortInjPerm_mem_permutationVectors {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    sortInjPerm cols ∈ permutationVectors n :=
+  permutationVectors_complete (sortInjPerm_toList_nodup_of_injective cols hinj)
+
+/-- Converse of `columnRankNat_strictMono` for injective `cols`: a strict
+rank comparison implies the underlying value comparison. -/
+private theorem cols_val_lt_of_rank_lt_of_injective {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols))
+    {i j : Fin n} (hij : columnRankNat cols i < columnRankNat cols j) :
+    cols[i].val < cols[j].val := by
+  rcases Nat.lt_trichotomy cols[i].val cols[j].val with hlt | heq | hgt
+  · exact hlt
+  · have hcol_eq : cols[i] = cols[j] := Fin.ext heq
+    have hij' : i = j := hinj hcol_eq
+    subst hij'
+    omega
+  · have := columnRankNat_strictMono cols hgt
+    omega
+
+/-- `Vector.ofFn`-indexed access at a `Fin n` argument, packaged so that
+the result is the function applied to the original `Fin n` index rather
+than to its repackaged Nat-value form. -/
+private theorem vector_ofFn_getElem_fin {α : Type u} {n : Nat}
+    (f : Fin n → α) (k : Fin n) :
+    (Vector.ofFn f)[k] = f k := by
+  rw [show ((Vector.ofFn f)[k] : α) = (Vector.ofFn f)[k.val]'(by simpa using k.isLt) from rfl]
+  rw [Vector.getElem_ofFn]
+
+/-- Factorization equation: each entry of `cols` is recovered through the
+canonical sort/permutation pair. Requires injectivity of `cols`. -/
+theorem cols_getElem_eq_sortInjTuple_sortInjPerm {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols))
+    (i : Fin n) :
+    cols[i] = (sortInjTuple cols)[(sortInjPerm cols)[i]] := by
+  have hnodup := sortInjPerm_toList_nodup_of_injective cols hinj
+  have hidx :=
+    inversePermutationValues_get_index (sortInjPerm cols) hnodup i
+  have hinv_eq : inversePermutationVector (sortInjPerm cols)
+                   = inversePermutationValues (sortInjPerm cols) hnodup :=
+    inversePermutationVector_eq (sortInjPerm cols) hnodup
+  have hstep :
+      (inversePermutationVector (sortInjPerm cols))[(sortInjPerm cols)[i]]
+        = (inversePermutationValues (sortInjPerm cols) hnodup)[(sortInjPerm cols)[i]] :=
+    congrArg (fun v : Vector (Fin n) n => v[(sortInjPerm cols)[i]]) hinv_eq
+  have hcompose :
+      (inversePermutationVector (sortInjPerm cols))[(sortInjPerm cols)[i]] = i :=
+    hstep.trans hidx
+  rw [sortInjTuple, vector_ofFn_getElem_fin]
+  exact (congrArg (fun k : Fin n => cols[k]) hcompose).symm
+
+/-- For an injective `cols`, applying `sortInjPerm` after the inverse
+returns the input rank. -/
+private theorem sortInjPerm_inv_apply {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) (r : Fin n) :
+    (sortInjPerm cols)[(inversePermutationVector (sortInjPerm cols))[r]] = r := by
+  have hnodup := sortInjPerm_toList_nodup_of_injective cols hinj
+  have hval := inversePermutationValues_get_value (sortInjPerm cols) hnodup r
+  have hinv_eq : inversePermutationVector (sortInjPerm cols)
+                   = inversePermutationValues (sortInjPerm cols) hnodup :=
+    inversePermutationVector_eq (sortInjPerm cols) hnodup
+  have hstep :
+      (sortInjPerm cols)[(inversePermutationVector (sortInjPerm cols))[r]]
+        = (sortInjPerm cols)[(inversePermutationValues (sortInjPerm cols) hnodup)[r]] :=
+    congrArg (fun v : Vector (Fin n) n => (sortInjPerm cols)[v[r]]) hinv_eq
+  exact hstep.trans hval
+
+/-- For an injective `cols`, the column-rank at the inverse-perm image
+of `r` is exactly `r.val`. -/
+private theorem columnRankNat_inv_apply {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) (r : Fin n) :
+    columnRankNat cols (inversePermutationVector (sortInjPerm cols))[r] = r.val := by
+  have hval' := sortInjPerm_inv_apply cols hinj r
+  have := congrArg Fin.val hval'
+  simpa [sortInjPerm] using this
+
+/-- For an injective `cols`, the canonical sorted tuple is strictly
+increasing. -/
+theorem isStrictlyIncreasingColumnTuple_sortInjTuple {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    IsStrictlyIncreasingColumnTuple (sortInjTuple cols) := by
+  intro r r' hrr'
+  have hrank_r := columnRankNat_inv_apply cols hinj r
+  have hrank_r' := columnRankNat_inv_apply cols hinj r'
+  have hrank_lt :
+      columnRankNat cols (inversePermutationVector (sortInjPerm cols))[r] <
+        columnRankNat cols (inversePermutationVector (sortInjPerm cols))[r'] := by
+    rw [hrank_r, hrank_r']; exact hrr'
+  have hval_lt :
+      cols[(inversePermutationVector (sortInjPerm cols))[r]].val <
+        cols[(inversePermutationVector (sortInjPerm cols))[r']].val :=
+    cols_val_lt_of_rank_lt_of_injective cols hinj hrank_lt
+  show (sortInjTuple cols)[r].val < (sortInjTuple cols)[r'].val
+  rw [sortInjTuple, vector_ofFn_getElem_fin, vector_ofFn_getElem_fin]
+  exact hval_lt
+
+/-- For an injective `cols`, the canonical sorted tuple is enumerated by
+`selectedColumnTuples n m`. -/
+theorem sortInjTuple_mem_selectedColumnTuples {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    sortInjTuple cols ∈ selectedColumnTuples n m :=
+  (mem_selectedColumnTuples_iff (sortInjTuple cols)).mpr
+    (isStrictlyIncreasingColumnTuple_sortInjTuple cols hinj)
+
+/-! ### Forward injectivity of the sort/permutation pair -/
+
+/-- Pairwise distinctness: two injective column tuples that map to the
+same `(sortInjTuple, sortInjPerm)` pair must be equal. -/
+theorem sortInj_pair_injective {m n : Nat} {cols cols' : Vector (Fin m) n}
+    (hinj : Function.Injective (columnTupleVectorFn cols))
+    (hinj' : Function.Injective (columnTupleVectorFn cols'))
+    (hsort : sortInjTuple cols = sortInjTuple cols')
+    (hperm : sortInjPerm cols = sortInjPerm cols') :
+    cols = cols' := by
+  apply Vector.ext
+  intro k hk
+  let i : Fin n := ⟨k, hk⟩
+  show cols[i] = cols'[i]
+  rw [cols_getElem_eq_sortInjTuple_sortInjPerm cols hinj i,
+      cols_getElem_eq_sortInjTuple_sortInjPerm cols' hinj' i]
+  -- Use congrArg to swap `sortInjPerm cols` for `sortInjPerm cols'`.
+  have hperm_apply :
+      (sortInjPerm cols)[i] = (sortInjPerm cols')[i] :=
+    congrArg (fun v : Vector (Fin n) n => v[i]) hperm
+  -- And use hsort to swap `sortInjTuple cols` for `sortInjTuple cols'`.
+  rw [hsort]
+  exact congrArg (fun k : Fin n => (sortInjTuple cols')[k]) hperm_apply
+
+/-! ### Reconstruction from `selectedColumnTuples × permutationVectors`
+
+For a strictly-increasing `sel` and a permutation `perm`, the
+"reconstruction" `Vector.ofFn (fun i => sel[perm[i]])` is itself
+injective, and its canonical sort/permutation pair recovers
+`(sel, perm)`. This is the inverse map of `sortInjTuple`/`sortInjPerm`. -/
+
+/-- Reconstruction map: given a sorted choice and a permutation, build
+an ordered column tuple. -/
+def reconstructInjTuple {m n : Nat}
+    (sel : Vector (Fin m) n) (perm : Vector (Fin n) n) : Vector (Fin m) n :=
+  Vector.ofFn fun i => sel[perm[i]]
+
+@[simp] theorem reconstructInjTuple_getElem {m n : Nat}
+    (sel : Vector (Fin m) n) (perm : Vector (Fin n) n) (i : Fin n) :
+    (reconstructInjTuple sel perm)[i] = sel[perm[i]] := by
+  rw [reconstructInjTuple, vector_ofFn_getElem_fin]
+
+/-- A permutation as a `Vector` acts as an injective function on `Fin n`. -/
+private theorem permutationVectors_getElem_injective {n : Nat}
+    {perm : Vector (Fin n) n} (hmem : perm ∈ permutationVectors n) :
+    Function.Injective (fun i : Fin n => perm[i]) := by
+  intro i j hij
+  have hnodup := permutationVectors_nodup hmem
+  -- Apply the inverse-permutation to both sides.
+  have hstep :
+      (inversePermutationValues perm hnodup)[perm[i]]
+        = (inversePermutationValues perm hnodup)[perm[j]] :=
+    congrArg (fun k : Fin n => (inversePermutationValues perm hnodup)[k]) hij
+  have hi := inversePermutationValues_get_index perm hnodup i
+  have hj := inversePermutationValues_get_index perm hnodup j
+  exact hi.symm.trans (hstep.trans hj)
+
+/-- The reconstructed column tuple is itself injective when `sel` is
+strictly increasing and `perm` is a permutation. -/
+theorem reconstructInjTuple_injective {m n : Nat}
+    {sel : Vector (Fin m) n} {perm : Vector (Fin n) n}
+    (hsel : IsStrictlyIncreasingColumnTuple sel)
+    (hperm : perm ∈ permutationVectors n) :
+    Function.Injective (columnTupleVectorFn (reconstructInjTuple sel perm)) := by
+  intro i j hij
+  have hsel_inj := isStrictlyIncreasingColumnTuple_injective hsel
+  have hperm_inj := permutationVectors_getElem_injective hperm
+  -- `hij` is equality of reconstructed entries; extract `sel[perm[i]] = sel[perm[j]]`.
+  have hval : sel[perm[i]] = sel[perm[j]] := by
+    have hi := reconstructInjTuple_getElem sel perm i
+    have hj := reconstructInjTuple_getElem sel perm j
+    have hij' :
+        (reconstructInjTuple sel perm)[i] = (reconstructInjTuple sel perm)[j] := hij
+    exact hi.symm.trans (hij'.trans hj)
+  exact hperm_inj (hsel_inj hval)
+
 end Matrix
 end Hex

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -5630,7 +5630,7 @@ than to its repackaged Nat-value form. -/
 private theorem vector_ofFn_getElem_fin {α : Type u} {n : Nat}
     (f : Fin n → α) (k : Fin n) :
     (Vector.ofFn f)[k] = f k := by
-  rw [show ((Vector.ofFn f)[k] : α) = (Vector.ofFn f)[k.val]'(by simpa using k.isLt) from rfl]
+  rw [show ((Vector.ofFn f)[k] : α) = (Vector.ofFn f)[k.val]'(by simp [k.isLt]) from rfl]
   rw [Vector.getElem_ofFn]
 
 /-- Factorization equation: each entry of `cols` is recovered through the
@@ -5755,6 +5755,28 @@ def reconstructInjTuple {m n : Nat}
     (reconstructInjTuple sel perm)[i] = sel[perm[i]] := by
   rw [reconstructInjTuple, vector_ofFn_getElem_fin]
 
+/-- Counting how many entries of `List.finRange n` have value `< k`. -/
+private theorem countP_finRange_val_lt :
+    ∀ (n k : Nat), (List.finRange n).countP (fun x : Fin n => decide (x.val < k)) = min n k
+  | 0, k => by simp
+  | n + 1, k => by
+      rw [List.finRange_succ_last, List.countP_append, List.countP_map]
+      -- The induction hypothesis applies to the `map Fin.castSucc` part.
+      -- `(castSucc x).val = x.val`, so the composed predicate matches.
+      have ih := countP_finRange_val_lt n k
+      have hmap_eq :
+          (List.finRange n).countP ((fun x : Fin (n + 1) => decide (x.val < k)) ∘ Fin.castSucc) =
+            (List.finRange n).countP (fun x : Fin n => decide (x.val < k)) := rfl
+      rw [hmap_eq, ih]
+      -- Singleton contribution.
+      simp only [List.countP_singleton, Fin.last]
+      -- Goal: min n k + (if decide (n < k) then 1 else 0) = min (n+1) k.
+      by_cases hnk : n < k
+      · rw [if_pos (by simpa using hnk)]
+        omega
+      · rw [if_neg (by simpa using hnk)]
+        omega
+
 /-- A permutation as a `Vector` acts as an injective function on `Fin n`. -/
 private theorem permutationVectors_getElem_injective {n : Nat}
     {perm : Vector (Fin n) n} (hmem : perm ∈ permutationVectors n) :
@@ -5788,6 +5810,230 @@ theorem reconstructInjTuple_injective {m n : Nat}
         (reconstructInjTuple sel perm)[i] = (reconstructInjTuple sel perm)[j] := hij
     exact hi.symm.trans (hij'.trans hj)
   exact hperm_inj (hsel_inj hval)
+
+/-- For a strictly-increasing `sel`, value comparison agrees with index
+comparison. -/
+private theorem isStrictlyIncreasingColumnTuple_val_lt_iff {m n : Nat}
+    {sel : Vector (Fin m) n} (hsel : IsStrictlyIncreasingColumnTuple sel)
+    (a b : Fin n) :
+    sel[a].val < sel[b].val ↔ a.val < b.val := by
+  refine ⟨?_, hsel a b⟩
+  intro hlt
+  rcases Nat.lt_trichotomy a.val b.val with hltab | heqab | hgtab
+  · exact hltab
+  · have : a = b := Fin.ext heqab
+    subst this; omega
+  · have := hsel b a hgtab; omega
+
+/-- For a permutation `perm`, the `toList` is a `List.Perm` of `List.finRange n`. -/
+private theorem permutationVectors_toList_perm_finRange {n : Nat}
+    {perm : Vector (Fin n) n} (hmem : perm ∈ permutationVectors n) :
+    perm.toList.Perm (List.finRange n) := by
+  have hnodup := permutationVectors_nodup hmem
+  apply (List.perm_ext_iff_of_nodup hnodup (List.nodup_finRange n)).mpr
+  intro x
+  refine ⟨fun _ => List.mem_finRange x, fun _ => ?_⟩
+  exact fin_mem_of_full_nodup x (by simp [Vector.length_toList]) hnodup
+
+/-- Count of indices `j` for which `perm[j].val < k.val` is exactly `k.val`
+when `perm` is a permutation. -/
+private theorem permutationVectors_count_val_lt {n : Nat}
+    {perm : Vector (Fin n) n} (hmem : perm ∈ permutationVectors n) (k : Fin n) :
+    (List.finRange n).countP (fun j : Fin n => decide (perm[j].val < k.val)) = k.val := by
+  -- Reduce to counting on perm.toList via `countP_map`.
+  have hmap :
+      (List.finRange n).countP (fun j : Fin n => decide (perm[j].val < k.val)) =
+        ((List.finRange n).map fun j : Fin n => perm[j]).countP
+          (fun x : Fin n => decide (x.val < k.val)) := by
+    rw [List.countP_map]
+    rfl
+  have htoList : perm.toList = (List.finRange n).map (fun j : Fin n => perm[j]) :=
+    vector_toList_eq_finRange_map_get perm
+  rw [hmap, ← htoList]
+  rw [List.Perm.countP_eq _ (permutationVectors_toList_perm_finRange hmem)]
+  rw [countP_finRange_val_lt]
+  exact Nat.min_eq_right (Nat.le_of_lt k.isLt)
+
+/-- For a strictly-increasing `sel` and a permutation `perm`, the column
+rank of the reconstruction at index `i` agrees with `perm[i].val`. -/
+private theorem columnRankNat_reconstructInjTuple {m n : Nat}
+    {sel : Vector (Fin m) n} {perm : Vector (Fin n) n}
+    (hsel : IsStrictlyIncreasingColumnTuple sel)
+    (hperm : perm ∈ permutationVectors n) (i : Fin n) :
+    columnRankNat (reconstructInjTuple sel perm) i = (perm[i]).val := by
+  unfold columnRankNat
+  -- Convert filter to countP, replace predicate using strict monotonicity, then
+  -- apply the permutation count lemma.
+  rw [← List.countP_eq_length_filter]
+  have hpred :
+      (fun j : Fin n => decide ((reconstructInjTuple sel perm)[j].val
+                                   < (reconstructInjTuple sel perm)[i].val)) =
+        (fun j : Fin n => decide ((perm[j]).val < (perm[i]).val)) := by
+    funext j
+    rw [reconstructInjTuple_getElem, reconstructInjTuple_getElem]
+    exact decide_eq_decide.mpr (isStrictlyIncreasingColumnTuple_val_lt_iff hsel _ _)
+  rw [hpred]
+  exact permutationVectors_count_val_lt hperm (perm[i])
+
+/-- `sortInjPerm` of a reconstructed tuple recovers the original permutation. -/
+theorem sortInjPerm_reconstructInjTuple {m n : Nat}
+    {sel : Vector (Fin m) n} {perm : Vector (Fin n) n}
+    (hsel : IsStrictlyIncreasingColumnTuple sel)
+    (hperm : perm ∈ permutationVectors n) :
+    sortInjPerm (reconstructInjTuple sel perm) = perm := by
+  apply Vector.ext
+  intro k hk
+  let i : Fin n := ⟨k, hk⟩
+  show (sortInjPerm (reconstructInjTuple sel perm))[i] = perm[i]
+  apply Fin.ext
+  rw [sortInjPerm_getElem_val]
+  exact columnRankNat_reconstructInjTuple hsel hperm i
+
+/-- `sortInjTuple` of a reconstructed tuple recovers the original selection. -/
+theorem sortInjTuple_reconstructInjTuple {m n : Nat}
+    {sel : Vector (Fin m) n} {perm : Vector (Fin n) n}
+    (hsel : IsStrictlyIncreasingColumnTuple sel)
+    (hperm : perm ∈ permutationVectors n) :
+    sortInjTuple (reconstructInjTuple sel perm) = sel := by
+  -- Use the factorization equation on the reconstructed tuple, which is injective.
+  have hinj : Function.Injective (columnTupleVectorFn (reconstructInjTuple sel perm)) :=
+    reconstructInjTuple_injective hsel hperm
+  apply Vector.ext
+  intro k hk
+  let r : Fin n := ⟨k, hk⟩
+  show (sortInjTuple (reconstructInjTuple sel perm))[r] = sel[r]
+  -- The reconstruction at index `inv perm [r]` equals sel[perm[(inv perm) r]] = sel[r].
+  -- And by the factorization equation, this equals sortInjTuple cols at sortInjPerm cols [(inv perm) r]
+  -- which is just r by the permutation identity. Hmm, this is circular.
+  -- Direct: sortInjTuple cols [r] = cols[inv (sortInjPerm cols) [r]]
+  --                                = cols[inv perm [r]]                    -- by sortInjPerm_reconstructInjTuple
+  --                                = sel[perm[(inv perm) r]]               -- by reconstruction defn
+  --                                = sel[r]                                -- by perm ∘ inv perm = id
+  have hsortPerm := sortInjPerm_reconstructInjTuple hsel hperm
+  -- Substitute sortInjPerm with perm in the sortInjTuple definition.
+  rw [sortInjTuple, vector_ofFn_getElem_fin]
+  -- Goal: cols[inv (sortInjPerm cols) [r]] = sel[r]
+  -- where cols := reconstructInjTuple sel perm.
+  have hinv_eq : inversePermutationVector (sortInjPerm (reconstructInjTuple sel perm))
+                   = inversePermutationVector perm :=
+    congrArg inversePermutationVector hsortPerm
+  have hstep :
+      (reconstructInjTuple sel perm)[(inversePermutationVector
+                                        (sortInjPerm (reconstructInjTuple sel perm)))[r]]
+        = (reconstructInjTuple sel perm)[(inversePermutationVector perm)[r]] :=
+    congrArg
+      (fun v : Vector (Fin n) n => (reconstructInjTuple sel perm)[v[r]])
+      hinv_eq
+  rw [hstep]
+  -- Now: reconstruction at (inv perm)[r] = sel[perm[(inv perm)[r]]] = sel[r].
+  rw [reconstructInjTuple_getElem]
+  -- Use that perm ∘ inv perm = id (i.e., perm[(inv perm)[r]] = r).
+  have hnodup := permutationVectors_nodup hperm
+  have hinv_perm : inversePermutationVector perm
+                     = inversePermutationValues perm hnodup :=
+    inversePermutationVector_eq perm hnodup
+  have hval := inversePermutationValues_get_value perm hnodup r
+  -- hval : perm[(inv perm) [r]] = r (where inv perm = inversePermutationValues perm hnodup)
+  have hstep' :
+      perm[(inversePermutationVector perm)[r]]
+        = perm[(inversePermutationValues perm hnodup)[r]] :=
+    congrArg (fun v : Vector (Fin n) n => perm[v[r]]) hinv_perm
+  have hperm_apply : perm[(inversePermutationVector perm)[r]] = r := hstep'.trans hval
+  -- Therefore: sel[perm[(inv perm)[r]]] = sel[r] via congrArg.
+  exact congrArg (fun k : Fin n => sel[k]) hperm_apply
+
+/-! ### Bijection wrappers -/
+
+/-- Forward-then-backward identity: reconstruction inverts the canonical
+sort/permutation pair on injective column tuples. -/
+theorem reconstructInjTuple_sortInj {m n : Nat}
+    (cols : Vector (Fin m) n)
+    (hinj : Function.Injective (columnTupleVectorFn cols)) :
+    reconstructInjTuple (sortInjTuple cols) (sortInjPerm cols) = cols := by
+  apply Vector.ext
+  intro k hk
+  let i : Fin n := ⟨k, hk⟩
+  show (reconstructInjTuple (sortInjTuple cols) (sortInjPerm cols))[i] = cols[i]
+  rw [reconstructInjTuple_getElem]
+  exact (cols_getElem_eq_sortInjTuple_sortInjPerm cols hinj i).symm
+
+/-- For each fixed `sel`, the inner `map (reconstructInjTuple sel)` list
+is `Nodup` over `permutationVectors n`. -/
+private theorem permutationVectors_map_reconstruct_nodup {m n : Nat}
+    {sel : Vector (Fin m) n} (hsel : IsStrictlyIncreasingColumnTuple sel) :
+    ((permutationVectors n).map (reconstructInjTuple sel)).Nodup := by
+  apply list_nodup_map_on permutationVectors_nodup_list
+  intro a ha b hb hab
+  -- Apply sortInjPerm to both sides to recover the permutation.
+  have := congrArg sortInjPerm hab
+  rw [sortInjPerm_reconstructInjTuple hsel ha,
+      sortInjPerm_reconstructInjTuple hsel hb] at this
+  exact this
+
+/-- The flat list of reconstructed column tuples, indexed by
+`selectedColumnTuples × permutationVectors`, has no duplicates. -/
+theorem selPerm_reconstructed_list_nodup {m n : Nat} :
+    ((selectedColumnTuples n m).flatMap fun sel =>
+      (permutationVectors n).map (reconstructInjTuple sel)).Nodup := by
+  -- Generalize so we can induct on the outer list (selectedColumnTuples).
+  suffices h : ∀ (sels : List (Vector (Fin m) n)), sels.Nodup →
+      (∀ sel ∈ sels, IsStrictlyIncreasingColumnTuple sel) →
+      (sels.flatMap fun sel =>
+        (permutationVectors n).map (reconstructInjTuple sel)).Nodup by
+    exact h _ selectedColumnTuples_nodup
+      (fun sel hmem => (mem_selectedColumnTuples_iff sel).mp hmem)
+  intro sels hsels_nodup hsels_inc
+  induction sels with
+  | nil => simp
+  | cons s ss ih =>
+      simp only [List.flatMap_cons]
+      rw [List.nodup_append]
+      simp only [List.nodup_cons] at hsels_nodup
+      refine ⟨?_, ?_, ?_⟩
+      · -- Inner head list is Nodup.
+        exact permutationVectors_map_reconstruct_nodup (hsels_inc s (by simp))
+      · -- Tail Nodup by IH.
+        exact ih hsels_nodup.2 (fun sel' hsel' => hsels_inc sel' (List.mem_cons_of_mem s hsel'))
+      · -- Disjointness: a reconstruction with `sel = s` and a reconstruction
+        -- with `sel = s' ∈ ss` agree only if `s = s'` by `sortInjTuple`.
+        intro a ha_head b hb_suffix hab
+        rcases List.mem_map.mp ha_head with ⟨perm, hperm_mem, rfl⟩
+        rcases List.mem_flatMap.mp hb_suffix with ⟨s', hs'_mem, hb_in⟩
+        rcases List.mem_map.mp hb_in with ⟨perm', hperm'_mem, hb_eq⟩
+        -- hab : (reconstructInjTuple s perm) = b; hb_eq : reconstructInjTuple s' perm' = b
+        have hrec_eq : reconstructInjTuple s perm = reconstructInjTuple s' perm' :=
+          hab.trans hb_eq.symm
+        have hs_inc := hsels_inc s (by simp)
+        have hs'_inc := hsels_inc s' (List.mem_cons_of_mem s hs'_mem)
+        have hsort := congrArg sortInjTuple hrec_eq
+        rw [sortInjTuple_reconstructInjTuple hs_inc hperm_mem,
+            sortInjTuple_reconstructInjTuple hs'_inc hperm'_mem] at hsort
+        subst hsort
+        exact hsels_nodup.1 hs'_mem
+
+/-- A column tuple is injective iff it is enumerated by the
+`selectedColumnTuples × permutationVectors` reconstruction. This is the
+bijection statement in membership form. -/
+theorem mem_selPerm_reconstructed_iff {m n : Nat} (cols : Vector (Fin m) n) :
+    cols ∈ ((selectedColumnTuples n m).flatMap fun sel =>
+      (permutationVectors n).map (reconstructInjTuple sel)) ↔
+      Function.Injective (columnTupleVectorFn cols) := by
+  refine ⟨?_, ?_⟩
+  · -- Backward: every reconstruction is injective.
+    intro hmem
+    rcases List.mem_flatMap.mp hmem with ⟨sel, hsel_mem, hinner⟩
+    rcases List.mem_map.mp hinner with ⟨perm, hperm_mem, rfl⟩
+    have hsel_inc : IsStrictlyIncreasingColumnTuple sel :=
+      (mem_selectedColumnTuples_iff sel).mp hsel_mem
+    exact reconstructInjTuple_injective hsel_inc hperm_mem
+  · -- Forward: every injective tuple is in the reconstruction list, via
+    -- (sortInjTuple cols, sortInjPerm cols).
+    intro hinj
+    rw [List.mem_flatMap]
+    refine ⟨sortInjTuple cols, sortInjTuple_mem_selectedColumnTuples cols hinj, ?_⟩
+    rw [List.mem_map]
+    refine ⟨sortInjPerm cols, sortInjPerm_mem_permutationVectors cols hinj, ?_⟩
+    exact reconstructInjTuple_sortInj cols hinj
 
 end Matrix
 end Hex

--- a/progress/20260511T012946Z_f40da335.md
+++ b/progress/20260511T012946Z_f40da335.md
@@ -1,0 +1,46 @@
+# HexMatrix Determinant: canonical sort + orbit factorization (#3179)
+
+## Accomplished
+
+Implemented and proved the canonical sort/permutation factorization for
+injective column tuples in `HexMatrix/Determinant.lean`, in support of
+the Cauchy-Binet orbit-grouping lemma `det_gramMatrix_eq_sum_minors_sq`
+(#3180). The added API is:
+
+- `sortInjPerm cols : Vector (Fin n) n` (rank-based permutation, total).
+- `sortInjTuple cols : Vector (Fin m) n` (canonical sorted version, total).
+- `reconstructInjTuple sel perm : Vector (Fin m) n` (inverse map).
+- Membership theorems: `sortInjPerm_mem_permutationVectors`,
+  `sortInjTuple_mem_selectedColumnTuples`,
+  `isStrictlyIncreasingColumnTuple_sortInjTuple`.
+- Factorization equation `cols_getElem_eq_sortInjTuple_sortInjPerm`.
+- Forward injectivity (pairwise distinctness): `sortInj_pair_injective`.
+- Reconstruction-side: `reconstructInjTuple_injective`,
+  `sortInjPerm_reconstructInjTuple`, `sortInjTuple_reconstructInjTuple`,
+  `reconstructInjTuple_sortInj`.
+- List-form bijection: `selPerm_reconstructed_list_nodup` and
+  `mem_selPerm_reconstructed_iff`. These pair to give the
+  flat-list-Perm characterization that #3180 can consume directly.
+
+Implementation chose the rank-based encoding (count of strictly-smaller
+positions) for `sortInjPerm`; this keeps the proofs structural and
+avoids introducing an insertion-sort routine. `sortInjTuple` is defined
+through the existing `inversePermutationVector` so it is total without
+classical choice.
+
+## Current frontier
+
+Issue #3179 deliverables are all met; banned-marker check is clean.
+`lake build HexMatrix` and `python3 scripts/check_dag.py` both pass.
+
+## Next step
+
+Hand off to #3180 (`HexMatrix: prove det_gramMatrix_eq_sum_minors_sq via
+orbit grouping`), which can now consume the list-Perm pair
+(`selPerm_reconstructed_list_nodup`, `mem_selPerm_reconstructed_iff`)
+plus the inversion identities to re-fold the ordered-tuple Gram
+expansion into the squared-minor sum.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3179

Session: `f40da335-d6a0-4c52-82ef-78b4010ebf7d`

8260028 chore: progress note for HexMatrix sort/orbit factorization
ced73ee feat: prove bijection identities for sort/perm orbit grouping
29e2f86 feat: add canonical sort/perm scaffolding for injective column tuples

🤖 Prepared with Claude Code