### PR TITLE
feat: add squareFreeAuxRev recursive residual invariant predicate and divisibility helper

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -4419,6 +4419,123 @@ private def squareFreeAuxRevResidualSatisfied
             squareFreeAuxRevResidualSatisfied
               (pthRoot loop.2) (m * p) fuel)
 
+/--
+Under the recursive residual derivative-zero invariant, every output factor
+of `squareFreeAuxRev g m fuel []` divides `g`. The proof tracks the loop
+through both the `pthRoot`-direct branch and the Yun-then-`pthRoot` branch,
+relying on `pthRoot_dvd_self_of_derivative_zero` for the `pthRoot` steps and
+on `yunFactorsWithLevel_factor_dvd_current` /
+`yunFactorsWithLevel_repeated_dvd_repeated` for the Yun steps.
+-/
+private theorem squareFreeAuxRev_factor_dvd_input
+    (hp : Hex.Nat.Prime p) (g : FpPoly p) (m fuel : Nat)
+    (hresidual : squareFreeAuxRevResidualSatisfied g m fuel) :
+    ∀ b ∈ (squareFreeAuxRev g m fuel []).reverse, b.factor ∣ g := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  induction fuel generalizing g m with
+  | zero =>
+      intro b hb
+      simp [squareFreeAuxRev] at hb
+  | succ fuel ih =>
+      intro b hb
+      simp only [squareFreeAuxRev] at hb
+      by_cases hzero : g.isZero = true
+      · simp [hzero] at hb
+      · have hzero_false : g.isZero = false := by
+          cases h : g.isZero
+          · rfl
+          · exact False.elim (hzero h)
+        rw [if_neg (by simp [hzero_false])] at hb
+        by_cases hdf : (DensePoly.derivative g).isZero = true
+        · rw [if_pos hdf] at hb
+          have hres_pth :
+              squareFreeAuxRevResidualSatisfied (pthRoot g) (m * p) fuel := by
+            have h := hresidual
+            simp only [squareFreeAuxRevResidualSatisfied] at h
+            rw [if_neg (by simp [hzero_false]), if_pos hdf] at h
+            exact h
+          have hb_pth : b.factor ∣ pthRoot g :=
+            ih (pthRoot g) (m * p) hres_pth b hb
+          have hpth_dvd_g : pthRoot g ∣ g :=
+            pthRoot_dvd_self_of_derivative_zero hp g hzero_false hdf
+          exact dvd_trans_poly hb_pth hpth_dvd_g
+        · have hdf_false : (DensePoly.derivative g).isZero = false := by
+            cases h : (DensePoly.derivative g).isZero
+            · rfl
+            · exact False.elim (hdf h)
+          rw [if_neg (by simp [hdf_false])] at hb
+          let g_inner := DensePoly.gcd g (DensePoly.derivative g)
+          let c_inner := g / g_inner
+          let loop := yunFactorsWithLevel c_inner g_inner m 1 fuel []
+          have hres_unpack :
+              ((isOne loop.2 = true) ∨ (DensePoly.derivative loop.2).isZero = true) ∧
+                ((isOne loop.2 = false) →
+                  squareFreeAuxRevResidualSatisfied
+                    (pthRoot loop.2) (m * p) fuel) := by
+            have h := hresidual
+            simp only [squareFreeAuxRevResidualSatisfied] at h
+            rw [if_neg (by simp [hzero_false]), if_neg (by simp [hdf_false])] at h
+            exact h
+          have hg_inner_dvd_g : g_inner ∣ g :=
+            DensePoly.gcd_dvd_left g (DensePoly.derivative g)
+          have hloop_dvd_g_inner : loop.2 ∣ g_inner := by
+            simpa [loop] using
+              yunFactorsWithLevel_repeated_dvd_repeated c_inner g_inner m 1 fuel
+          have hloop_dvd_g : loop.2 ∣ g :=
+            dvd_trans_poly hloop_dvd_g_inner hg_inner_dvd_g
+          have hc_inner_dvd_g : c_inner ∣ g := by
+            refine ⟨g_inner, ?_⟩
+            simpa [c_inner, g_inner] using
+              (div_gcd_mul_reconstruct g (DensePoly.derivative g)).symm
+          have hg_inner_ne : g_inner.isZero = false :=
+            gcd_isZero_false_of_right_isZero_false g
+              (DensePoly.derivative g) hdf_false
+          have hloop_ne : loop.2.isZero = false := by
+            cases hl : loop.2.isZero
+            · rfl
+            · exfalso
+              have hloop_zero : loop.2 = 0 :=
+                eq_zero_of_isZero_true loop.2 hl
+              rcases hloop_dvd_g_inner with ⟨q, hq⟩
+              have hg_inner_zero : g_inner = 0 := by
+                rw [hq, hloop_zero, zero_mul]
+              have hg_inner_isZero : g_inner.isZero = true := by
+                rw [hg_inner_zero]; rfl
+              rw [hg_inner_isZero] at hg_inner_ne
+              cases hg_inner_ne
+          by_cases hrep : isOne loop.2 = true
+          · have hb_loop : b ∈ loop.1.reverse := by
+              simpa [g_inner, c_inner, loop, hrep] using hb
+            have hb_dvd_c : b.factor ∣ c_inner :=
+              yunFactorsWithLevel_factor_dvd_current
+                c_inner g_inner m 1 fuel b hb_loop
+            exact dvd_trans_poly hb_dvd_c hc_inner_dvd_g
+          · have hrep_false : isOne loop.2 = false := by
+              cases h : isOne loop.2
+              · rfl
+              · exact False.elim (hrep h)
+            have hres_inner :
+                squareFreeAuxRevResidualSatisfied
+                  (pthRoot loop.2) (m * p) fuel := hres_unpack.2 hrep_false
+            have hb' :
+                b ∈ (squareFreeAuxRev (pthRoot loop.2) (m * p) fuel loop.1).reverse := by
+              simpa [g_inner, c_inner, loop, hrep_false] using hb
+            rw [squareFreeAuxRev_reverse_append] at hb'
+            rcases List.mem_append.mp hb' with hb_loop | hb_rec
+            · have hb_dvd_c : b.factor ∣ c_inner :=
+                yunFactorsWithLevel_factor_dvd_current
+                  c_inner g_inner m 1 fuel b hb_loop
+              exact dvd_trans_poly hb_dvd_c hc_inner_dvd_g
+            · have hb_pth : b.factor ∣ pthRoot loop.2 :=
+                ih (pthRoot loop.2) (m * p) hres_inner b hb_rec
+              have hdf_loop : (DensePoly.derivative loop.2).isZero = true := by
+                rcases hres_unpack.1 with h | h
+                · rw [h] at hrep_false; cases hrep_false
+                · exact h
+              have hpth_dvd_loop : pthRoot loop.2 ∣ loop.2 :=
+                pthRoot_dvd_self_of_derivative_zero hp loop.2 hloop_ne hdf_loop
+              exact dvd_trans_poly hb_pth (dvd_trans_poly hpth_dvd_loop hloop_dvd_g)
+
 private theorem yunFactorsWithLevel_pairwise_coprime_nil_of_ready
     (c w : FpPoly p) (base level fuel : Nat)
     (hready : yunFactorsPairwiseReady c w base level fuel) :

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -4536,6 +4536,23 @@ private theorem squareFreeAuxRev_factor_dvd_input
                 pthRoot_dvd_self_of_derivative_zero hp loop.2 hloop_ne hdf_loop
               exact dvd_trans_poly hb_pth (dvd_trans_poly hpth_dvd_loop hloop_dvd_g)
 
+/--
+Coprime-transfer corollary of `squareFreeAuxRev_factor_dvd_input`: any common
+divisor of `a` and an output factor of `squareFreeAuxRev g m fuel []` is a
+common divisor of `a` and `g`, and thus divides `1` if `a` and `g` are
+coprime.
+-/
+private theorem squareFreeAuxRev_factors_coprime_of_input_coprime
+    (hp : Hex.Nat.Prime p) (g a : FpPoly p) (m fuel : Nat)
+    (hcoprime : ∀ d : FpPoly p, d ∣ a → d ∣ g → d ∣ (1 : FpPoly p))
+    (hresidual : squareFreeAuxRevResidualSatisfied g m fuel) :
+    ∀ b ∈ (squareFreeAuxRev g m fuel []).reverse,
+      ∀ d : FpPoly p, d ∣ a → d ∣ b.factor → d ∣ (1 : FpPoly p) := by
+  intro b hb d hda hdb
+  have hbg : b.factor ∣ g :=
+    squareFreeAuxRev_factor_dvd_input hp g m fuel hresidual b hb
+  exact hcoprime d hda (dvd_trans_poly hdb hbg)
+
 private theorem yunFactorsWithLevel_pairwise_coprime_nil_of_ready
     (c w : FpPoly p) (base level fuel : Nat)
     (hready : yunFactorsPairwiseReady c w base level fuel) :

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -4397,6 +4397,28 @@ private theorem squareFreeAuxRev_reverse_append
                       (squareFreeAuxRev (pthRoot loopNil.2) (multiplicity * p) fuel loopNil.1).reverse := by
                       rw [hrec_nil])
 
+/--
+Recursive residual derivative-zero invariant for the `squareFreeAuxRev`
+loop. At each non-trivial step the residual `loop.2` is either trivial
+(`isOne`) or has zero derivative, and the recursion into `pthRoot loop.2`
+continues to satisfy the same invariant.
+-/
+private def squareFreeAuxRevResidualSatisfied
+    (g : FpPoly p) (m : Nat) : Nat → Prop
+  | 0 => True
+  | fuel + 1 =>
+      if g.isZero then True
+      else if (DensePoly.derivative g).isZero then
+        squareFreeAuxRevResidualSatisfied (pthRoot g) (m * p) fuel
+      else
+        let g_inner := DensePoly.gcd g (DensePoly.derivative g)
+        let c_inner := g / g_inner
+        let loop := yunFactorsWithLevel c_inner g_inner m 1 fuel []
+        ((isOne loop.2 = true) ∨ (DensePoly.derivative loop.2).isZero = true) ∧
+          ((isOne loop.2 = false) →
+            squareFreeAuxRevResidualSatisfied
+              (pthRoot loop.2) (m * p) fuel)
+
 private theorem yunFactorsWithLevel_pairwise_coprime_nil_of_ready
     (c w : FpPoly p) (base level fuel : Nat)
     (hready : yunFactorsPairwiseReady c w base level fuel) :

--- a/progress/20260511T013131Z_23940a36.md
+++ b/progress/20260511T013131Z_23940a36.md
@@ -1,0 +1,76 @@
+# 2026-05-11 01:31 UTC — work session (23940a36)
+
+## Accomplished
+
+- Triaged the two unclaimed `feature` issues:
+  - **#3153** (scaled square-free weighted product reconstruction):
+    skipped — its declared dependencies #3196 and #3197 are
+    technically closed, but both closed as
+    *partial-progress superseded* with the actual unconditional
+    invariants tracked in still-open issues #3208 (termination
+    + unconditional scaled Yun product invariant) and #3209
+    (composition with unscaled witness, depending on #3200/#3199).
+    Bridge PR #3204 also still open. The "routine combination"
+    described in the issue body is not yet possible.
+  - **#3122** (pthRoot tail cross-coprimality): too large for one
+    session as stated. Decomposed into:
+    - **#3217** — add the recursive residual derivative-zero
+      predicate plus the structural divisibility helper
+      "every output factor of `squareFreeAuxRev g m fuel []`
+      divides `g`".
+    - **#3218** — restate the tail-cross theorem with the new
+      hypotheses, prove it, and cascade the residual provider
+      through the consumer chain.
+- Claimed and landed **#3217** in `HexPolyFp/SquareFree.lean`:
+  - Added `squareFreeAuxRevResidualSatisfied : FpPoly p → Nat → Nat → Prop`
+    capturing the residual derivative-zero invariant at every
+    recursive depth of `squareFreeAuxRev` (`pthRoot` branches and
+    Yun-loop branches alike).
+  - Proved `squareFreeAuxRev_factor_dvd_input`: under the recursive
+    invariant, every output factor divides the input. Induction on
+    `fuel`, case-splitting on `g.isZero`, derivative-zero, and
+    `isOne loop.2`. Uses `pthRoot_dvd_self_of_derivative_zero`,
+    `yunFactorsWithLevel_factor_dvd_current`,
+    `yunFactorsWithLevel_repeated_dvd_repeated`,
+    `gcd_isZero_false_of_right_isZero_false`, and a small inline
+    nonzero-from-divisibility argument.
+  - Proved the coprime-transfer corollary
+    `squareFreeAuxRev_factors_coprime_of_input_coprime` as a
+    one-liner composing the divisibility helper with the input
+    coprimality hypothesis.
+- Verified:
+  - `lake build HexPolyFp.SquareFree`
+  - `lake build HexPolyFp`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexPolyFp/SquareFree.lean`
+    shows only the two pre-existing proof holes (lines 2960 and
+    4632 — `_pow_obligation` and the unchanged tail-cross sorry).
+    No new banned markers introduced.
+
+## Current frontier
+
+- The new helper + predicate stand alone as reusable infrastructure
+  for #3218 and ultimately #2917. They capture the recursive
+  residual derivative-zero invariant that the tail-cross
+  cross-coprimality argument needs to thread through the
+  `squareFreeAuxRev` recursion.
+
+## Next step
+
+- A successor agent picks up **#3218**: restate
+  `yunFactorsWithLevel_squareFreeAuxRev_tail_cross_coprime` with
+  hypotheses `hreachable : yunFactorsPairwiseReachable c w fuel`
+  and `hresidual : (...) ∧ squareFreeAuxRevResidualSatisfied
+  (pthRoot loop.2) (base * level * p) fuel`, prove it using
+  `yunFactorsWithLevel_factors_coprime_repeated_of_reachable`,
+  `pthRoot_dvd_self_of_derivative_zero`, and the new
+  `squareFreeAuxRev_factors_coprime_of_input_coprime`. Then
+  cascade the residual provider through `_core_of_yun_invariant`,
+  `_core`, and the rest of the pairwise-coprime consumer chain.
+
+## Blockers
+
+- None for this slice; the deep math (the residual provider for
+  derivative-active inputs) is tracked in #3199 / #3200 / #3209
+  → #2917 and is out of scope for #3217.


### PR DESCRIPTION
Closes #3217

Session: `23940a36-04a8-4df3-b173-b6a3bb461d2a`

fdc7e52 doc: progress note for session 23940a36 (#3217 landed, #3218 follow-up)
4e39e12 feat: add coprime-transfer corollary squareFreeAuxRev_factors_coprime_of_input_coprime
bf03ab4 feat: prove squareFreeAuxRev_factor_dvd_input under recursive residual invariant
ea4c4b3 feat: add squareFreeAuxRev recursive residual derivative-zero predicate

🤖 Prepared with Claude Code