### PR TITLE
HexHenselMathlib Correctness: prove zpoly_congr ↔ toPolynomial.map bridge

### DIFF
--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -78,7 +78,12 @@ theorem zpoly_congr_toPolynomial_map_eq
     let φ := Int.castRingHom (ZMod m)
     (HexPolyMathlib.toPolynomial f).map φ =
       (HexPolyMathlib.toPolynomial g).map φ := by
-  sorry
+  apply Polynomial.ext
+  intro n
+  rw [coeff_map_intCastRingHom_eq_iff_dvd_sub,
+      HexPolyMathlib.coeff_toPolynomial,
+      HexPolyMathlib.coeff_toPolynomial]
+  exact Int.dvd_of_emod_eq_zero (hcongr n)
 
 /--
 Equality of Mathlib polynomial reductions modulo `m` gives the executable
@@ -91,7 +96,12 @@ theorem zpoly_congr_of_toPolynomial_map_eq
       (HexPolyMathlib.toPolynomial f).map φ =
         (HexPolyMathlib.toPolynomial g).map φ) :
     Hex.ZPoly.congr f g m := by
-  sorry
+  intro n
+  have hcoeff := Polynomial.ext_iff.mp hmap n
+  rw [coeff_map_intCastRingHom_eq_iff_dvd_sub,
+      HexPolyMathlib.coeff_toPolynomial,
+      HexPolyMathlib.coeff_toPolynomial] at hcoeff
+  exact Int.emod_eq_zero_of_dvd hcoeff
 
 /-- The executable monic predicate transfers to Mathlib's polynomial monic predicate. -/
 theorem toPolynomial_monic_of_dense_monic

--- a/progress/20260511T023752Z_2db582aa.md
+++ b/progress/20260511T023752Z_2db582aa.md
@@ -1,0 +1,57 @@
+# 2026-05-11 02:37 UTC — feature session (2db582aa)
+
+## Accomplished
+
+- Claimed #3226 and discharged both foundational
+  `Hex.ZPoly.congr ↔ Polynomial.map` bridges in
+  `HexHenselMathlib/Correctness.lean`:
+  - `zpoly_congr_toPolynomial_map_eq`: `Polynomial.ext` to reduce to
+    coefficientwise equality, rewrite both sides via
+    `coeff_map_intCastRingHom_eq_iff_dvd_sub` and
+    `HexPolyMathlib.coeff_toPolynomial`, then close with
+    `Int.dvd_of_emod_eq_zero` applied to the executable `congr`
+    hypothesis.
+  - `zpoly_congr_of_toPolynomial_map_eq`: unpack `Polynomial.ext_iff`
+    coefficientwise, rewrite the resulting equation through the same
+    pair of lemmas, then convert the divisibility back to
+    `(... ) % (m : Int) = 0` via `Int.emod_eq_zero_of_dvd`.
+- Both directions reuse the existing infrastructure in
+  `HexHenselMathlib/Basic.lean` (`coeff_map_intCastRingHom_eq_iff_dvd_sub`)
+  and `HexPolyMathlib/Basic.lean` (`coeff_toPolynomial`); no new helpers
+  were needed.
+
+## Verification
+
+- `lake build HexHenselMathlib.Correctness` — clean; only the
+  out-of-scope sorries from the issue's exclusion list remain.
+- `lake build HexHenselMathlib` — clean.
+- `python3 scripts/check_dag.py` — clean.
+- `git diff --check` — clean.
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry'
+  HexHenselMathlib/Correctness.lean` — both target sorries removed;
+  remaining sorries match the issue's out-of-scope list
+  (`hensel_correct`, `hensel_extends`, `hensel_degree`,
+  `toPolynomial_monic_of_dense_monic`,
+  `quadraticHenselStep_factor_correct`,
+  `quadraticHenselStep_bezout_correct`,
+  `quadraticHenselStep_monic`,
+  `quadraticHenselStep_unique_mod_pow_two_mul`, `hensel_unique`,
+  `multifactorLift_eq_multifactorLiftQuadratic`).
+
+## Current frontier
+
+- The remaining 10 correctness/uniqueness sorries in
+  `Correctness.lean` are now unblocked at the foundational layer:
+  every theorem that needs to convert between `Hex.ZPoly.congr` and
+  `Polynomial.map` equalities can rewrite through these two bridges.
+
+## Next step
+
+- A follow-on session can pick up the `hensel_correct` /
+  `hensel_extends` / `hensel_degree` cluster, or the `quadratic*`
+  cluster, knowing the executable-to-Mathlib congruence transport is
+  now a one-liner.
+
+## Blockers
+
+- None for this slice.


### PR DESCRIPTION
Closes #3226

Session: `2db582aa-0ce3-43a2-9b1f-521b557ded3e`

efb0bb7 feat: prove zpoly_congr ↔ toPolynomial.map bridges (#3226)

🤖 Prepared with Claude Code