### PR TITLE
HexHenselMathlib Correctness: prove toPolynomial_monic_of_dense_monic

### DIFF
--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -97,7 +97,9 @@ theorem zpoly_congr_of_toPolynomial_map_eq
 theorem toPolynomial_monic_of_dense_monic
     (f : Hex.ZPoly) (hmonic : Hex.DensePoly.Monic f) :
     (HexPolyMathlib.toPolynomial f).Monic := by
-  sorry
+  show (HexPolyMathlib.toPolynomial f).leadingCoeff = 1
+  rw [HexPolyMathlib.leadingCoeff_toPolynomial]
+  exact hmonic
 
 /--
 The quadratic executable step gives a Mathlib factorization modulo `m*m`.

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -313,6 +313,31 @@ theorem natDegree_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R
       rw [coeff_toPolynomial]
       exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size p hpos
 
+theorem leadingCoeff_toPolynomial [Semiring R] [DecidableEq R]
+    (p : Hex.DensePoly R) :
+    (toPolynomial p).leadingCoeff = p.leadingCoeff := by
+  rw [Polynomial.leadingCoeff, natDegree_toPolynomial, coeff_toPolynomial]
+  by_cases hsize : p.size = 0
+  · have hp_zero : p = 0 := by
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      rw [Hex.DensePoly.coeff_zero]
+      exact Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega)
+    rw [hp_zero]
+    rfl
+  · have hpos : 0 < p.size := Nat.pos_of_ne_zero hsize
+    have hdegree_some : p.degree? = some (p.size - 1) := by
+      simp [Hex.DensePoly.degree?, hsize]
+    rw [hdegree_some, Option.getD_some]
+    show p.coeff (p.size - 1) = p.leadingCoeff
+    unfold Hex.DensePoly.coeff Hex.DensePoly.leadingCoeff
+    have hidx : p.coeffs.size - 1 < p.coeffs.size := by
+      have hs : p.size = p.coeffs.size := rfl
+      omega
+    rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx, Option.getD_some]
+    rw [show p.size = p.coeffs.size from rfl]
+    exact (Array.getElem_eq_getD (Zero.zero : R)).symm
+
 theorem toPolynomial_dvd [CommRing R] [DecidableEq R] {p q : Hex.DensePoly R}
     (hdvd : p ∣ q) :
     toPolynomial p ∣ toPolynomial q := by

--- a/progress/20260511T023801Z_db5b8c18.md
+++ b/progress/20260511T023801Z_db5b8c18.md
@@ -1,0 +1,57 @@
+# 2026-05-11 02:38 UTC — feature session (db5b8c18)
+
+## Accomplished
+
+- Picked #3228 (HexHenselMathlib `toPolynomial_monic_of_dense_monic`)
+  via `/work` after #3214 turned out to be already claimed by another
+  agent and #3100 was stale (PR #3090 already merged).
+- Added the reusable bridge fact
+  `HexPolyMathlib.leadingCoeff_toPolynomial (p : Hex.DensePoly R) :
+    (toPolynomial p).leadingCoeff = p.leadingCoeff` in
+  `HexPolyMathlib/Basic.lean`. The proof case-splits on `p.size = 0`:
+  the zero polynomial gives `rfl` after rewriting through the existing
+  `natDegree_toPolynomial` / `coeff_toPolynomial` bridges; the positive
+  branch unfolds the executable `coeff` / `leadingCoeff` to
+  `Array.getD` / `Array.back?`, rewrites both sides through
+  `Array.back?_eq_getElem?` and `Array.getElem?_eq_getElem` at the
+  shared index `p.coeffs.size - 1`, and closes with
+  `Array.getElem_eq_getD`.
+- Discharged `toPolynomial_monic_of_dense_monic` in
+  `HexHenselMathlib/Correctness.lean` in three lines: unfold
+  `Polynomial.Monic` via `show ... = 1`, rewrite through the new
+  `leadingCoeff_toPolynomial`, and close with the executable
+  `Hex.DensePoly.Monic` hypothesis.
+
+## Verification
+
+- `lake build HexPolyMathlib.Basic` — clean.
+- `lake build HexHenselMathlib.Correctness` — clean; only the
+  out-of-scope sorries from the issue's exclusion list remain.
+- `lake build HexHenselMathlib HexPolyMathlib` — clean.
+- `python3 scripts/check_dag.py` — clean.
+- `git diff --check` — clean.
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexPolyMathlib/Basic.lean`
+  — no matches.
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexHenselMathlib/Correctness.lean`
+  — remaining 11 sorries match the issue's out-of-scope list
+  exactly (`hensel_correct`, `hensel_extends`, `hensel_degree`,
+  `zpoly_congr_*` ×2, `quadraticHenselStep_*` ×4, `hensel_unique`,
+  `multifactorLift_eq_multifactorLiftQuadratic`).
+
+## Current frontier
+
+- The remaining 11 `Correctness.lean` sorries are tracked separately
+  (e.g. #3226 for the `zpoly_congr ↔ toPolynomial.map` bridge).
+- The two `HexHenselMathlib/Basic.lean` capstones
+  (`isUnit_one_add_C_mul`, `coprime_mod_p_lifts`) are tracked in
+  #3214 (currently claimed).
+
+## Next step
+
+- A separate session can pick up #3226 to discharge the
+  `zpoly_congr` ↔ `toPolynomial.map` bridge facts that several other
+  `Correctness.lean` sorries (`hensel_correct`, etc.) consume.
+
+## Blockers
+
+- None for this slice.


### PR DESCRIPTION
Closes #3228

Session: `db5b8c18-49a7-40dc-a076-a389228cca04`

d92ac96 feat: prove toPolynomial_monic_of_dense_monic via leadingCoeff bridge

🤖 Prepared with Claude Code