### PR TITLE
HexHenselMathlib: prove isUnit_one_add_C_mul and coprime_mod_p_lifts

### DIFF
--- a/HexHenselMathlib/Basic.lean
+++ b/HexHenselMathlib/Basic.lean
@@ -89,16 +89,65 @@ theorem polynomial_map_zmod_pow_succ_to_pow
 theorem isUnit_one_add_C_mul
     (p k : ℕ) (u : Polynomial (ZMod (p ^ k))) :
     IsUnit (1 + Polynomial.C (p : ZMod (p ^ k)) * u) := by
-  sorry
+  have hnil : IsNilpotent (Polynomial.C (p : ZMod (p ^ k)) * u) := by
+    refine ⟨k, ?_⟩
+    rw [mul_pow, ← Polynomial.C_pow]
+    have hp_pow : (p : ZMod (p ^ k)) ^ k = 0 := by
+      rw [← Nat.cast_pow]
+      exact ZMod.natCast_self _
+    rw [hp_pow, Polynomial.C_0, zero_mul]
+  exact hnil.isUnit_one_add
 
-/-- Coprimality modulo `p` lifts to coprimality modulo `p^k`. -/
+/-- Coprimality modulo `p` lifts to coprimality modulo `p^k`.
+
+The `0 < k` hypothesis is part of the calling convention; the proof does not
+need it (the `k = 0` case is vacuous because `ZMod 1` is the zero ring). -/
 theorem coprime_mod_p_lifts (g h : Polynomial ℤ) (p : ℕ) (k : ℕ)
-    [Fact (Nat.Prime p)] (hk : 0 < k) :
+    [Fact (Nat.Prime p)] (_hk : 0 < k) :
     IsCoprime (g.map (Int.castRingHom (ZMod p)))
               (h.map (Int.castRingHom (ZMod p))) →
     IsCoprime (g.map (Int.castRingHom (ZMod (p ^ k))))
               (h.map (Int.castRingHom (ZMod (p ^ k)))) := by
-  sorry
+  rintro ⟨a₀, b₀, hab⟩
+  obtain ⟨A, hA⟩ :=
+    Polynomial.map_surjective (Int.castRingHom (ZMod p)) ZMod.intCast_surjective a₀
+  obtain ⟨B, hB⟩ :=
+    Polynomial.map_surjective (Int.castRingHom (ZMod p)) ZMod.intCast_surjective b₀
+  have hcombo_modp : (A * g + B * h).map (Int.castRingHom (ZMod p)) = 1 := by
+    rw [Polynomial.map_add, Polynomial.map_mul, Polynomial.map_mul, hA, hB, hab]
+  have hsub_modp : (A * g + B * h - 1).map (Int.castRingHom (ZMod p)) = 0 := by
+    rw [Polynomial.map_sub, Polynomial.map_one, hcombo_modp, sub_self]
+  have hdvd : ∀ n, (p : ℤ) ∣ (A * g + B * h - 1).coeff n := by
+    intro n
+    rw [← coeff_map_intCastRingHom_eq_zero_iff_dvd]
+    have h := congr_arg (fun q : Polynomial (ZMod p) => q.coeff n) hsub_modp
+    simpa using h
+  obtain ⟨U, hU⟩ :=
+    (Polynomial.C_dvd_iff_dvd_coeff (p : ℤ) (A * g + B * h - 1)).mpr hdvd
+  set Φpk : ℤ →+* ZMod (p ^ k) := Int.castRingHom (ZMod (p ^ k)) with hΦpk_def
+  have hp_cast : Φpk (p : ℤ) = (p : ZMod (p ^ k)) := by
+    simp [hΦpk_def]
+  have hsub_pk : (A * g + B * h - 1).map Φpk =
+      Polynomial.C (p : ZMod (p ^ k)) * U.map Φpk := by
+    rw [hU, Polynomial.map_mul, Polynomial.map_C, hp_cast]
+  have hcombo_pk : A.map Φpk * g.map Φpk + B.map Φpk * h.map Φpk
+      = 1 + Polynomial.C (p : ZMod (p ^ k)) * U.map Φpk := by
+    have h := hsub_pk
+    rw [Polynomial.map_sub, Polynomial.map_add, Polynomial.map_mul, Polynomial.map_mul,
+        Polynomial.map_one] at h
+    exact sub_eq_iff_eq_add'.mp h
+  have hunit : IsUnit (1 + Polynomial.C (p : ZMod (p ^ k)) * U.map Φpk) :=
+    isUnit_one_add_C_mul p k _
+  obtain ⟨wu, hwu⟩ := hunit
+  refine ⟨(↑wu⁻¹ : Polynomial (ZMod (p ^ k))) * A.map Φpk,
+          (↑wu⁻¹ : Polynomial (ZMod (p ^ k))) * B.map Φpk, ?_⟩
+  have hregroup :
+      ((↑wu⁻¹ : Polynomial (ZMod (p ^ k))) * A.map Φpk) * g.map Φpk +
+        ((↑wu⁻¹ : Polynomial (ZMod (p ^ k))) * B.map Φpk) * h.map Φpk
+      = (↑wu⁻¹ : Polynomial (ZMod (p ^ k))) *
+        (A.map Φpk * g.map Φpk + B.map Φpk * h.map Φpk) := by ring
+  rw [hregroup, hcombo_pk, ← hwu]
+  exact Units.inv_mul wu
 
 end
 

--- a/progress/20260511T024637Z_c820f939.md
+++ b/progress/20260511T024637Z_c820f939.md
@@ -1,0 +1,58 @@
+# 2026-05-11 02:46 UTC — feature session (c820f939)
+
+## Accomplished
+
+- Claimed #3214 and discharged the two remaining `sorry`s in
+  `HexHenselMathlib/Basic.lean`:
+
+  - **`isUnit_one_add_C_mul`**: proved `IsUnit (1 + C (p : ZMod (p^k)) * u)`
+    by showing the correction term is nilpotent. The witness exponent is `k`:
+    `(C p * u)^k = C p^k * u^k = C ((p^k : ZMod (p^k))) * u^k = C 0 * u^k = 0`.
+    The reduction uses `mul_pow`, `← Polynomial.C_pow`, `← Nat.cast_pow`,
+    `ZMod.natCast_self`, and `Polynomial.C_0`. The unit conclusion is then
+    `IsNilpotent.isUnit_one_add` from `Mathlib.RingTheory.Nilpotent.Basic`.
+
+  - **`coprime_mod_p_lifts`**: lifted Bezout coefficients `(a₀, b₀)` from
+    `ZMod p` back to integer polynomials `(A, B)` via
+    `Polynomial.map_surjective` applied to `ZMod.intCast_surjective`.
+    Coefficient-wise divisibility of `A * g + B * h - 1` by `p` then gives
+    `Polynomial.C (p : ℤ) ∣ (A * g + B * h - 1)` via
+    `Polynomial.C_dvd_iff_dvd_coeff`. Extracting the witness `U` and
+    reducing modulo `p^k` produces
+    `A.map Φpk * g.map Φpk + B.map Φpk * h.map Φpk = 1 + C p * U.map Φpk`.
+    The right-hand side is a unit by `isUnit_one_add_C_mul`, and dividing
+    through by its inverse yields the Bezout combination equal to `1` that
+    `IsCoprime` requires.
+
+- The `0 < k` hypothesis is preserved in the signature (renamed to `_hk`)
+  since the proof itself does not need it — the `k = 0` case is vacuous
+  because `ZMod 1` is the zero ring. Documented this in the docstring so
+  callers do not get confused.
+
+## Verification
+
+- `lake build HexHenselMathlib.Basic` — clean.
+- `lake build HexHenselMathlib` — clean; only the three pre-existing
+  `sorry`s in `HexHenselMathlib/Correctness.lean` (out of scope per the
+  issue) remain.
+- `python3 scripts/check_dag.py` — clean.
+- `git diff --check` — clean.
+- `rg -nE '^axiom\b|native_decide|TODO|FIXME|sorry' HexHenselMathlib/Basic.lean`
+  — no markers; both target sorries are removed.
+
+## Current frontier
+
+- `HexHenselMathlib/Basic.lean` is now sorry-free. The remaining
+  Hensel-correctness work lives in `HexHenselMathlib/Correctness.lean`,
+  which has three theorem-level `sorry`s explicitly out of scope for
+  this issue.
+
+## Next step
+
+- A separate session can pick up `HexHenselMathlib/Correctness.lean` to
+  discharge the actual Hensel correctness theorems, now that the
+  infrastructure lemmas are unconditional.
+
+## Blockers
+
+- None for this slice.


### PR DESCRIPTION
Closes #3214

Session: `c820f939-c1a0-4982-9ff6-b1e63fd0a23b`

59e34d5 feat: prove HexHenselMathlib coprimality lifting and nilpotent-unit lemmas (#3214)

🤖 Prepared with Claude Code