### PR TITLE
feat: prove quadratic Hensel step mathlib correctness

### DIFF
--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -126,7 +126,14 @@ theorem quadraticHenselStep_factor_correct
     (HexPolyMathlib.toPolynomial r.g).map φ *
         (HexPolyMathlib.toPolynomial r.h).map φ =
       (HexPolyMathlib.toPolynomial f).map φ := by
-  sorry
+  let r := Hex.ZPoly.quadraticHenselStep m f g h s t
+  let φ := Int.castRingHom (ZMod (m * m))
+  have hcongr :
+      Hex.ZPoly.congr (r.g * r.h) f (m * m) := by
+    simpa [r] using
+      Hex.ZPoly.quadraticHenselStep_factor_spec m f g h s t hm hprod hbez hmonic
+  have hmap := zpoly_congr_toPolynomial_map_eq (r.g * r.h) f (m * m) hcongr
+  simpa [r, φ, HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul] using hmap
 
 /--
 The quadratic executable step updates Bezout witnesses modulo `m*m`.
@@ -141,11 +148,29 @@ theorem quadraticHenselStep_bezout_correct
     let r := Hex.ZPoly.quadraticHenselStep m f g h s t
     let φ := Int.castRingHom (ZMod (m * m))
     (HexPolyMathlib.toPolynomial r.s).map φ *
-          (HexPolyMathlib.toPolynomial r.g).map φ +
-        (HexPolyMathlib.toPolynomial r.t).map φ *
-          (HexPolyMathlib.toPolynomial r.h).map φ =
+        (HexPolyMathlib.toPolynomial r.g).map φ +
+      (HexPolyMathlib.toPolynomial r.t).map φ *
+        (HexPolyMathlib.toPolynomial r.h).map φ =
       (1 : Polynomial (ZMod (m * m))) := by
-  sorry
+  let r := Hex.ZPoly.quadraticHenselStep m f g h s t
+  let φ := Int.castRingHom (ZMod (m * m))
+  by_cases hm1 : 1 < m
+  · have hcongr :
+        Hex.ZPoly.congr (r.s * r.g + r.t * r.h) 1 (m * m) := by
+      simpa [r] using
+        Hex.ZPoly.quadraticHenselStep_bezout_spec m f g h s t hm1 hprod hbez hmonic
+    have hmap := zpoly_congr_toPolynomial_map_eq (r.s * r.g + r.t * r.h) 1 (m * m) hcongr
+    have hone : HexPolyMathlib.toPolynomial (1 : Hex.ZPoly) = 1 := by
+      change HexPolyMathlib.toPolynomial (Hex.DensePoly.C (1 : Int)) = 1
+      simp
+    simpa [r, φ, HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_add,
+      Polynomial.map_mul, Polynomial.map_add, Polynomial.map_one, hone] using hmap
+  · have hm_eq : m = 1 := by omega
+    subst m
+    haveI : Subsingleton (ZMod (1 * 1)) := ZMod.subsingleton_iff.mpr (by norm_num)
+    apply Polynomial.ext
+    intro n
+    exact Subsingleton.elim _ _
 
 /-- The quadratic step preserves monicity on the lifted `g` factor in Mathlib form. -/
 theorem quadraticHenselStep_monic

--- a/progress/20260511T043836Z_51c3b32c.md
+++ b/progress/20260511T043836Z_51c3b32c.md
@@ -1,0 +1,36 @@
+# 2026-05-11 04:38 UTC - work/feature session (51c3b32c)
+
+## Accomplished
+
+- Claimed #3266, verified its stated prerequisite helper was only present on
+  open PR #3267 rather than `origin/main`, and released #3266 back to replan
+  with that blocker recorded.
+- Claimed #3229 after confirming its dependency #3226 was closed.
+- Replaced the two targeted `sorry`s in
+  `HexHenselMathlib/Correctness.lean`:
+  - `quadraticHenselStep_factor_correct`
+  - `quadraticHenselStep_bezout_correct`
+- Transported the executable quadratic Hensel factor/Bezout congruence specs
+  through `zpoly_congr_toPolynomial_map_eq`; handled the `m = 1` Bezout edge
+  case coefficientwise over `ZMod 1`.
+- Verified:
+  - `lake build HexHenselMathlib.Correctness`
+  - `lake build HexHenselMathlib`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - banned-marker scan of `HexHenselMathlib/Correctness.lean`
+
+## Current frontier
+
+- #3229 is ready for PR.
+- The remaining `sorry`s in `HexHenselMathlib/Correctness.lean` are existing
+  out-of-scope theorem scaffolds tracked by separate issues.
+
+## Next step
+
+- Create the PR for #3229 and let CI/auto-merge process it.
+
+## Blockers
+
+- #3266 is blocked until PR #3267, or its equivalent helper, lands on
+  `origin/main`.


### PR DESCRIPTION
Closes #3229.

## Summary
- Proves `quadraticHenselStep_factor_correct` by transporting the executable factor spec through `zpoly_congr_toPolynomial_map_eq`.
- Proves `quadraticHenselStep_bezout_correct`, using the executable Bezout spec for `1 < m` and a coefficientwise `ZMod 1` argument for `m = 1`.

## Verification
- `lake build HexHenselMathlib.Correctness`
- `lake build HexHenselMathlib`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexHenselMathlib/Correctness.lean`