### PR TITLE
HexPolyZ: prove ceilSqrt upper-square bound from iterator invariant

### DIFF
--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -165,6 +165,33 @@ theorem binom_eq_zero_of_lt {n k : Nat} (h : n < k) : binom n k = 0 := by
 @[simp] theorem ceilSqrt_zero : ceilSqrt 0 = 0 := by
   simp [ceilSqrt]
 
+/--
+The square of `ceilSqrt n` is at least `n`.  This is the executable upper-square
+bound used by the Mignotte coefficient norm chain: in the perfect-square branch
+of `ceilSqrt`, equality holds; in the non-perfect-square branch, the bound
+follows from the Newton iterator invariant `sqrtAux_upper_succ`.
+-/
+theorem le_ceilSqrt_sq (n : Nat) : n ≤ (ceilSqrt n) ^ 2 := by
+  by_cases hn : n = 0
+  · subst hn
+    simp
+  · have hn_pos : 0 < n := Nat.pos_of_ne_zero hn
+    have hfloor : floorSqrt n = sqrtAux n (2 * n.log2 + 1) n := by
+      unfold floorSqrt
+      rw [if_neg hn]
+    have hinit : n ≤ (n + 1) ^ 2 := by
+      simp [Nat.pow_two]
+      grind
+    have hub : n ≤ (floorSqrt n + 1) ^ 2 := by
+      rw [hfloor]
+      exact sqrtAux_upper_succ n (2 * n.log2 + 1) n hn_pos hinit
+    unfold ceilSqrt
+    by_cases hsq : floorSqrt n * floorSqrt n = n
+    · rw [if_pos hsq, Nat.pow_two]
+      omega
+    · rw [if_neg hsq]
+      exact hub
+
 theorem coeffNormSq_eq_sum (f : ZPoly) :
     coeffNormSq f =
       (List.range f.size).foldl (fun acc i => acc + (f.coeff i).natAbs ^ 2) 0 := rfl

--- a/progress/20260511T053525Z_9933b6a2.md
+++ b/progress/20260511T053525Z_9933b6a2.md
@@ -1,0 +1,35 @@
+# 2026-05-11T05:35Z — session 9933b6a2 (/feature)
+
+## Accomplished
+
+- Skipped #3209 (HexPolyFp scaled Yun residual derivative-zero composition):
+  its `depends-on: #3200` was satisfied only by decomposition into #3235 /
+  #3237 / #3239, and #3237 + #3239 remain open. The unscaled derivative-active
+  witness this composition consumes does not exist yet. Added the missing
+  `depends-on: #3239` and released the claim so check-blocked tracks it.
+- Closed #3264 (HexPolyZ ceilSqrt upper-square bound): proved
+  `le_ceilSqrt_sq : n ≤ (ceilSqrt n) ^ 2` in `HexPolyZ/Mignotte.lean` by
+  composing the existing iterator invariant `sqrtAux_upper_succ` with a
+  perfect-square branch case-split. The `n = 0` case discharges by simp;
+  for `n > 0` the proof unfolds `floorSqrt`, supplies `n ≤ (n + 1)^2` as
+  the iterator's initial upper-square witness, then splits on whether
+  `floorSqrt n * floorSqrt n = n`.
+- Verified `lake build HexPolyZ.Mignotte`, `lake build HexPolyZ`,
+  `python3 scripts/check_dag.py`, and `git diff --check`. No new banned
+  markers in `HexPolyZ/Mignotte.lean`.
+
+## Current frontier
+
+- Public theorem `le_ceilSqrt_sq` is now available downstream for the
+  Mathlib-facing `l2norm_toPolynomial_le_coeffL2NormBound` bridge (#3215).
+- #3209 is correctly blocked on #3239.
+
+## Next step
+
+- A future session should close #3215 once #3239/#3237 land, completing
+  the scaled-loop derivative-zero composition for #3153 and the Mignotte
+  L2-norm bridge for #3215 respectively.
+
+## Blockers
+
+None for this session.


### PR DESCRIPTION
Closes #3264

Session: `9933b6a2-a701-4453-98ba-e9e543665275`

a234a63 feat: prove ceilSqrt upper-square bound

🤖 Prepared with Claude Code