### PR TITLE
HexPoly: add diagonal coefficient divisibility isolation helpers

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -3248,6 +3248,98 @@ private theorem list_foldl_add_int (xs : List Int) (z : Int) :
       rw [ih (z + x), ih (0 + x)]
       grind
 
+private theorem dvd_list_foldl_add_int_of_forall
+    (d : Int) (xs : List Int) (h : ∀ x ∈ xs, d ∣ x) :
+    d ∣ xs.foldl (fun s t => s + t) 0 := by
+  induction xs with
+  | nil =>
+      simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      rw [list_foldl_add_int xs (0 + x)]
+      simpa using Int.dvd_add (h x List.mem_cons_self)
+        (ih (fun y hy => h y (List.mem_cons_of_mem x hy)))
+
+private theorem dvd_list_foldl_add_term_of_forall
+    (d : Int) (xs : List Nat) (term : Nat → Int)
+    (h : ∀ x ∈ xs, d ∣ term x) :
+    d ∣ xs.foldl (fun s x => s + term x) 0 := by
+  have hmap : ∀ y ∈ xs.map term, d ∣ y := by
+    intro y hy
+    rw [List.mem_map] at hy
+    rcases hy with ⟨x, hx, rfl⟩
+    exact h x hx
+  simpa [List.foldl_map] using dvd_list_foldl_add_int_of_forall d (xs.map term) hmap
+
+private theorem dvd_term_of_dvd_foldl_add_of_dvd_others
+    (d : Int) :
+    ∀ (xs : List Nat) (term : Nat → Int) (idx : Nat),
+      xs.Nodup →
+      idx ∈ xs →
+      d ∣ xs.foldl (fun s x => s + term x) 0 →
+      (∀ r, r ∈ xs → r ≠ idx → d ∣ term r) →
+      d ∣ term idx
+  | [], _term, _idx, _hnodup, hmem, _hsum, _hothers => by
+      cases hmem
+  | x :: xs, term, idx, hnodup, hmem, hsum, hothers => by
+      simp only [List.foldl_cons] at hsum
+      have hfold :
+          xs.foldl (fun s x => s + term x) (0 + term x) =
+            term x + xs.foldl (fun s x => s + term x) 0 := by
+        simpa [List.foldl_map] using list_foldl_add_int (xs.map term) (0 + term x)
+      rw [hfold] at hsum
+      have hnodup_tail : xs.Nodup := hnodup.tail
+      have hx_not_mem : x ∉ xs := by
+        rw [List.nodup_cons] at hnodup
+        exact hnodup.1
+      by_cases hxidx : x = idx
+      · subst idx
+        have htail : d ∣ xs.foldl (fun s x => s + term x) 0 := by
+          apply dvd_list_foldl_add_term_of_forall
+          intro y hy
+          exact hothers y (List.mem_cons_of_mem x hy) (by
+            intro hyx
+            exact hx_not_mem (by simpa [hyx] using hy))
+        have hdiff := Int.dvd_sub hsum htail
+        simpa using hdiff
+      · have hxdiv : d ∣ term x :=
+          hothers x List.mem_cons_self hxidx
+        have htail_sum : d ∣ xs.foldl (fun s x => s + term x) 0 := by
+          have hdiff := Int.dvd_sub hsum hxdiv
+          have heq :
+              term x + xs.foldl (fun s x => s + term x) 0 - term x =
+                xs.foldl (fun s x => s + term x) 0 := by
+            grind
+          rwa [heq] at hdiff
+        have hidx_mem_tail : idx ∈ xs := by
+          rcases List.mem_cons.mp hmem with hidx | htail
+          · exact False.elim (hxidx hidx.symm)
+          · exact htail
+        exact dvd_term_of_dvd_foldl_add_of_dvd_others d xs term idx
+          hnodup_tail hidx_mem_tail htail_sum
+          (fun r hr hri => hothers r (List.mem_cons_of_mem x hr) hri)
+
+private theorem dvd_diagonalMulCoeffTerm_of_dvd_mul_coeff_of_dvd_other_diagonal_terms
+    (p q : DensePoly Int) (d n i : Nat)
+    (hprod : (d : Int) ∣ (p * q).coeff n)
+    (hothers : ∀ r, r ≠ i → (d : Int) ∣ diagonalMulCoeffTerm p q n r) :
+    (d : Int) ∣ diagonalMulCoeffTerm p q n i := by
+  by_cases hi : i < n + 1
+  · have hsum :
+        (d : Int) ∣ (List.range (n + 1)).foldl
+          (fun s r => s + diagonalMulCoeffTerm p q n r) 0 := by
+      rw [← diagonalSum_eq_degree_bound p q n]
+      rw [← mulCoeffSum_eq_diagonal p q n]
+      rw [← coeff_mul p q n]
+      exact hprod
+    exact dvd_term_of_dvd_foldl_add_of_dvd_others (d : Int) (List.range (n + 1))
+      (fun r => diagonalMulCoeffTerm p q n r) i
+      List.nodup_range (List.mem_range.mpr hi) hsum
+      (fun r _hr hri => hothers r hri)
+  · have hni : n < i := by omega
+    rw [diagonalMulCoeffTerm_eq_zero_of_degree_lt p q n i hni]
+    simp
+
 private theorem list_natAbs_gcd_bezout_aux (xs : List Int) (acc : Nat) :
     ∃ a : Int, ∃ weights : List Int,
       weights.length = xs.length ∧

--- a/progress/20260511T064456Z_d764d293.md
+++ b/progress/20260511T064456Z_d764d293.md
@@ -1,0 +1,33 @@
+# 2026-05-11T06:44Z — session d764d293 (/work)
+
+## Accomplished
+
+- Claimed #3127, found its dependency assumption stale, added `depends-on: #3252`,
+  and skipped it for replan because #3169 had been closed after decomposition
+  rather than by landing the final generic coefficient-divisibility wrapper.
+- Claimed #3266, confirmed the McCoy annihilator proof needs a diagonal
+  coefficient isolation layer plus a separate lexicographic descent, decomposed it
+  into #3277 and #3278, and skipped the parent with the required breadcrumb.
+- Claimed #3277 and added private diagonal-sum divisibility isolation helpers in
+  `HexPoly/Euclid.lean`, culminating in
+  `dvd_diagonalMulCoeffTerm_of_dvd_mul_coeff_of_dvd_other_diagonal_terms`.
+- Verified `lake build HexPoly.Euclid`, `lake build HexPoly`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and the banned-marker grep
+  for `HexPoly/Euclid.lean`.
+
+## Current frontier
+
+- #3277 is ready for PR.
+- #3278 is blocked on #3277 and should consume the new isolation helper to prove
+  the full McCoy annihilator by lexicographic descent.
+- #3127 is now correctly blocked on #3252 rather than the decomposed/closed #3169.
+
+## Next step
+
+- Land #3277, then work #3278 to expose
+  `exists_scalar_annihilator_of_mul_coeff_dvd_of_exists_not_dvd_coeff`; #3252 can
+  then assemble the primitive-product coefficient-divisibility wrapper.
+
+## Blockers
+
+None for #3277.


### PR DESCRIPTION
Closes #3277

Session: `d764d293-0e24-48d5-8cf0-45a9c184b8d8`

8bf5443 prove diagonal divisibility isolation helpers

🤖 Prepared with Claude Code