### PR TITLE
HexModArith Phase6: characterize ZMod64 canonical representatives

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -83,6 +83,17 @@ def ofNat (p n : Nat) [Bounds p] : ZMod64 p := by
 @[simp] theorem val_toNat_ofNat (n : Nat) : (ofNat p n).val.toNat = n % p := by
   simpa using toNat_ofNat (p := p) n
 
+/-- Constructing a residue from its canonical representative is the identity. -/
+@[simp] theorem ofNat_toNat (a : ZMod64 p) : ofNat p a.toNat = a := by
+  apply ext
+  apply UInt64.toNat_inj.mp
+  rw [val_toNat_ofNat]
+  exact Nat.mod_eq_of_lt a.toNat_lt
+
+/-- Two residues are equal exactly when their canonical representatives agree. -/
+theorem eq_iff_toNat_eq (a b : ZMod64 p) : a = b ↔ a.toNat = b.toNat :=
+  ⟨fun h => h ▸ rfl, fun h => ext (UInt64.toNat_inj.mp h)⟩
+
 /-- All canonical residues modulo `p`, listed in representative order. -/
 def values (p : Nat) [Bounds p] : List (ZMod64 p) :=
   (List.range p).map fun n => ofNat p n

--- a/progress/20260511T072100Z_5823c34c.md
+++ b/progress/20260511T072100Z_5823c34c.md
@@ -1,0 +1,29 @@
+# 2026-05-11T07:21Z — session 5823c34c (/feature)
+
+## Accomplished
+
+- Claimed #3290 and added two characterising lemmas to `HexModArith/Basic.lean`
+  immediately after `val_toNat_ofNat`:
+  - `@[simp] ofNat_toNat (a : ZMod64 p) : ofNat p a.toNat = a` — canonical
+    roundtrip; safe `@[simp]` because `a` does not match `(ofNat _ _).toNat`,
+    so it pairs with `toNat_ofNat` without looping.
+  - `eq_iff_toNat_eq (a b : ZMod64 p) : a = b ↔ a.toNat = b.toNat` — left
+    without `@[simp]` to avoid aggressively rewriting every residue equality
+    in downstream proofs.
+- Verified `lake build HexModArith.Basic`, `lake build HexModArith`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and the banned-marker
+  grep on `HexModArith/Basic.lean`.
+
+## Current frontier
+
+- #3290 ready for PR.
+
+## Next step
+
+- Land #3290; the new lemmas unblock downstream Phase 6 polish that wants to
+  move between residues and their `Nat` representatives without unfolding
+  `ofNat` or `toNat`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3290

Session: `5823c34c-1b66-48ca-a05c-5bcff0271649`

da0126b feat: add ZMod64 canonical representative characterising lemmas (closes #3290)

🤖 Prepared with Claude Code