### PR TITLE
doc: document Nat exponent geometric-sum helper

### DIFF
--- a/HexArith/Nat/Pow.lean
+++ b/HexArith/Nat/Pow.lean
@@ -11,6 +11,11 @@ namespace Hex
 
 namespace Nat
 
+/--
+Inductive content of the geometric-series identity for `1 ≤ x`: every power
+`x ^ j` is one more than a multiple of `x - 1`. The witness `k` is the partial
+geometric sum `1 + x + x^2 + ⋯ + x^(j-1)`.
+-/
 private theorem pow_eq_succ_mul_sub_one_add_one_of_one_le
     {x : Nat} (hx : 1 ≤ x) :
     ∀ j : Nat, ∃ k : Nat, x ^ j = (x - 1) * k + 1

--- a/progress/20260511T075527Z_b5a4c88f.md
+++ b/progress/20260511T075527Z_b5a4c88f.md
@@ -1,0 +1,32 @@
+# 2026-05-11 07:55 UTC — review session (b5a4c88f)
+
+## Accomplished
+
+- Claimed issue #3294 (HexArith Phase6: review Nat exponent helper API).
+- Reviewed `HexArith/Nat/Pow.lean` against `SPEC/Libraries/hex-arith.md`
+  and `PLAN/Phase6.md`.
+- Added a docstring to the non-obvious private helper
+  `pow_eq_succ_mul_sub_one_add_one_of_one_le`, naming the witness
+  `k` as the partial geometric sum.
+- Verified `lake build HexArith.Nat.Pow`, `lake build HexArith`, and
+  `python3 scripts/check_dag.py` all succeed; banned-marker scan is clean.
+
+## Current frontier
+
+- `HexArith/Nat/Pow.lean` is Phase-6-ready as a self-contained Nat-level
+  exponent helper module. Both public theorems carry docstrings, the
+  private helper now does too, and the only downstream caller
+  (`HexBerlekamp.RabinSoundness.xPowSubX_dvd_of_dvd`) uses
+  `pow_sub_one_dvd_pow_sub_one_of_dvd` directly without unfolding
+  `pow` or `Nat.sub`.
+
+## Next step
+
+- Push the branch and open the PR closing #3294.
+- Sibling Phase 6 review issues #3289 (`Nat/ModArith.lean`),
+  #3291 (`Nat/Prime.lean`), and #3296 (`ExtGcd.lean`) remain
+  unclaimed and can proceed in parallel.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR documents the non-obvious private helper
`pow_eq_succ_mul_sub_one_add_one_of_one_le` in `HexArith/Nat/Pow.lean`,
naming the existential witness `k` as the partial geometric sum
`1 + x + x^2 + ⋯ + x^(j-1)`.

Phase 6 review of `HexArith/Nat/Pow.lean` (Closes #3294):

- Both public theorems (`sub_one_dvd_pow_sub_one`,
  `pow_sub_one_dvd_pow_sub_one_of_dvd`) already carry docstrings and the
  module docstring already explains the file's role.
- No `@[simp]` candidate: the public lemmas are divisibility statements
  with no LHS reduction.
- No `@[grind]` change: HexArith does not use `@[grind]` anywhere yet,
  and the sole downstream caller
  (`HexBerlekamp.RabinSoundness.xPowSubX_dvd_of_dvd`) does not use
  `grind`. Adding it speculatively is premature.
- No missing characterising lemma: the downstream caller uses
  `pow_sub_one_dvd_pow_sub_one_of_dvd` directly without unfolding
  `pow` or `Nat.sub`.
- No new imports needed.
- Banned-marker scan clean (no `sorry`, `native_decide`, `axiom`,
  `TODO`, `FIXME`).

The module is Phase-6-ready as a self-contained Nat-level exponent
helper. Library-wide Phase-6 completion (bumping
`libraries.yml[HexArith].done_through` to `6`) remains a separate gate
covered by sibling reviews #3289, #3291, #3296 and any further
HexArith Phase-6 follow-ups.

Closes #3294

Session: \`b5a4c88f-a049-455d-bdbf-568baf55ce64\`

🤖 Prepared with Claude Code