### PR TITLE
docs: review HexModArith hot-loop API

### DIFF
--- a/HexModArith/HotLoop.lean
+++ b/HexModArith/HotLoop.lean
@@ -19,8 +19,11 @@ The stored `UInt64` modulus must agree with the Nat-indexed `ZMod64` modulus;
 the underlying `HexArith` context then provides the small-modulus fast path.
 -/
 structure BarrettCtx (p : Nat) [ZMod64.Bounds p] where
+  /-- The executable machine-word modulus used by the underlying context. -/
   modulus : UInt64
+  /-- The stored word modulus agrees with the Nat-indexed `ZMod64` modulus. -/
   modulus_eq : modulus.toNat = p
+  /-- The underlying `UInt64` Barrett context from `HexArith`. -/
   toUInt64Ctx : _root_.BarrettCtx modulus
 
 /--
@@ -30,8 +33,11 @@ As with `BarrettCtx`, the executable context stores the machine-word modulus
 used by the underlying `HexArith` Montgomery code.
 -/
 structure MontCtx (p : Nat) [ZMod64.Bounds p] where
+  /-- The executable machine-word modulus used by the underlying context. -/
   modulus : UInt64
+  /-- The stored word modulus agrees with the Nat-indexed `ZMod64` modulus. -/
   modulus_eq : modulus.toNat = p
+  /-- The underlying `UInt64` Montgomery context from `HexArith`. -/
   toUInt64Ctx : _root_.MontCtx modulus
 
 /--
@@ -42,7 +48,9 @@ This is intentionally distinct from `ZMod64`: values are still reduced into
 canonical standard representative.
 -/
 structure MontResidue (p : Nat) [ZMod64.Bounds p] where
+  /-- Backing word for the Montgomery-form representative. -/
   val : UInt64
+  /-- The backing word remains reduced modulo `p`. -/
   isLt : val.toNat < p
 
 namespace MontResidue
@@ -63,10 +71,16 @@ instance : CoeOut (MontResidue p) UInt64 where
 instance : CoeOut (MontResidue p) Nat where
   coe := toNat
 
+/-- The `UInt64` view of a Montgomery residue is its backing word. -/
 @[simp] theorem toUInt64_eq_val (a : MontResidue p) : a.toUInt64 = a.val := rfl
+
+/-- The Nat view of a Montgomery residue is the Nat value of its backing word. -/
 @[simp] theorem toNat_eq_val (a : MontResidue p) : a.toNat = a.val.toNat := rfl
+
+/-- The Nat view of a Montgomery residue is reduced modulo its indexed modulus. -/
 @[simp] theorem toNat_lt (a : MontResidue p) : a.toNat < p := a.isLt
 
+/-- Montgomery residues are equal when their backing words are equal. -/
 @[ext] theorem ext {a b : MontResidue p} (h : a.val = b.val) : a = b := by
   cases a
   cases b
@@ -91,6 +105,10 @@ result as a `ZMod64`.
 def mulMod (ctx : BarrettCtx p) (a b : ZMod64 p) : ZMod64 p :=
   ZMod64.ofNat p ((_root_.BarrettCtx.mulMod ctx.toUInt64Ctx a.toUInt64 b.toUInt64).toNat)
 
+/--
+The `ZMod64` Barrett wrapper computes the ordinary modular product on reduced
+representatives.
+-/
 @[simp] theorem toNat_mulMod (ctx : BarrettCtx p) (a b : ZMod64 p) :
     (ctx.mulMod a b).toNat = (a.toNat * b.toNat) % p := by
   have ha := residue_lt_modulus ctx a
@@ -149,6 +167,7 @@ representation.
 def fromMont (ctx : MontCtx p) (a : MontResidue p) : ZMod64 p :=
   ZMod64.ofNat p ((_root_.MontCtx.fromMont ctx.toUInt64Ctx a.toUInt64).toNat)
 
+/-- Converting a standard residue into Montgomery form and back is the identity. -/
 @[simp] theorem fromMont_toMont (ctx : MontCtx p) (a : ZMod64 p) :
     ctx.fromMont (ctx.toMont a) = a := by
   have hnat : (ctx.fromMont (ctx.toMont a)).toNat = a.toNat := by
@@ -169,6 +188,10 @@ def fromMont (ctx : MontCtx p) (a : MontResidue p) : ZMod64 p :=
   apply UInt64.toNat_inj.mp
   simpa [ZMod64.toNat_eq_val] using hnat
 
+/--
+Multiplying two standard residues by entering Montgomery form, multiplying, and
+leaving Montgomery form computes the ordinary modular product.
+-/
 @[simp] theorem toNat_mulMont (ctx : MontCtx p) (a b : ZMod64 p) :
     (ctx.fromMont (ctx.mulMont (ctx.toMont a) (ctx.toMont b))).toNat =
       (a.toNat * b.toNat) % p := by

--- a/progress/20260511T084534Z_018da3ce.md
+++ b/progress/20260511T084534Z_018da3ce.md
@@ -1,0 +1,30 @@
+# 2026-05-11 08:45 UTC — feature session (018da3ce)
+
+## Accomplished
+
+- Claimed issue #3302 after higher-priority human-oversight issues were
+  rejected by `coordination claim` as blocked and #3303 was claimed by
+  another agent.
+- Reviewed `HexModArith/HotLoop.lean` against
+  `SPEC/Libraries/hex-mod-arith.md` and `PLAN/Phase6.md`.
+- Added docstrings to public hot-loop context fields and public
+  characterising lemmas for `MontResidue`, `BarrettCtx.mulMod`, and the
+  Montgomery conversion/multiplication wrappers.
+- Verified `lake build HexModArith.HotLoop`, `lake build HexModArith`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and a banned-marker
+  scan of `HexModArith/HotLoop.lean`.
+
+## Current frontier
+
+- `HexModArith/HotLoop.lean` is Phase-6-ready as the focused `ZMod64`
+  hot-loop wrapper boundary: executable bodies and underlying Barrett /
+  Montgomery contracts are unchanged, and callers have documented
+  `[simp]` characterising lemmas for standard use.
+
+## Next step
+
+- Push the branch and open the PR closing #3302.
+
+## Blockers
+
+- None.

--- a/progress/20260511T093122Z_77c0788e.md
+++ b/progress/20260511T093122Z_77c0788e.md
@@ -1,0 +1,36 @@
+# 2026-05-11 09:31 UTC — repair session (77c0788e)
+
+## Accomplished
+
+Claimed PR #3311 for repair after its Linux `build` check failed in the
+benchmark smoke gate.
+
+Diagnosed the failure as isolated to the Isabelle-backed `HexLLL` fixed
+benchmarks while the PR itself only changed `HexModArith/HotLoop.lean` docs
+and its feature-session progress note. The PR branch was one commit ahead of
+its old base and four commits behind current `origin/main`, so I merged
+`origin/main` into `agent/018da3ce`.
+
+Verified the repaired branch with:
+
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME' HexModArith/HotLoop.lean`
+- `lake exe hexlll_bench verify`
+
+The targeted `hexlll_bench` verification now reports all 32 benchmarks passed.
+
+## Current frontier
+
+The PR branch has the clean merge from current `main` and is ready to push
+after this progress note is committed.
+
+## Next step
+
+Push `agent/018da3ce` with `--force-with-lease` and mark PR #3311 salvaged.
+
+## Blockers
+
+None. The worktree still contains an unrelated pre-existing modification to
+`.claude/CLAUDE.md`, which this session did not touch.


### PR DESCRIPTION
Closes #3302

Session: `018da3ce-e4f2-4e70-be00-01653038c616`

## Summary

- Reviewed `HexModArith/HotLoop.lean` against `SPEC/Libraries/hex-mod-arith.md` and `PLAN/Phase6.md`.
- Added docstrings to the public hot-loop context fields and public characterising lemmas for the Barrett and Montgomery wrapper API.
- Left executable bodies and Barrett/Montgomery semantics unchanged.

## Phase 6 status

`HexModArith/HotLoop.lean` is Phase-6-ready as the focused `ZMod64` hot-loop wrapper boundary. No follow-up issue is needed for this file from this review.

## Verification

- `lake build HexModArith.HotLoop`
- `lake build HexModArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|TODO|FIXME" HexModArith/HotLoop.lean` (no matches)

Commit: 6e28e73 docs: review HexModArith hot-loop API