### PR TITLE
feat: add CLMUL right-linearity API

### DIFF
--- a/HexGF2/Clmul.lean
+++ b/HexGF2/Clmul.lean
@@ -81,6 +81,8 @@ private theorem foldl_clmul_xor_left (bits : List Nat)
       · simp [hbit]
         simpa using ih accX accY
 
+/-- The pure carry-less multiplier is linear in its left word argument over
+bitwise XOR. -/
 theorem pureClmul_xor_left (x y z : UInt64) :
     pureClmul (x ^^^ y) z =
       ((pureClmul x z).1 ^^^ (pureClmul y z).1,
@@ -94,6 +96,7 @@ private theorem foldl_keep {α β : Type} (xs : List β) (acc : α) :
   | nil => simp
   | cons _ xs ih => simp [ih]
 
+/-- The pure carry-less multiplier returns zero when the left word is zero. -/
 theorem pureClmul_zero_left (x : UInt64) : pureClmul 0 x = (0, 0) := by
   simp [pureClmul, clmulAccumulateBit_zero_left, foldl_keep]
 
@@ -501,6 +504,8 @@ theorem clmul_oneHot (a : UInt64) {bit : Nat} (hbit : bit < 64) :
       if bit = 0 then (0, a) else (a >>> (64 - bit).toUInt64, a <<< bit.toUInt64) := by
   rw [clmul, pureClmul_oneHot a hbit]
 
+/-- Runtime `clmul`, under its trusted reference contract, is linear in its
+left word argument over bitwise XOR. -/
 theorem clmul_xor_left (x y z : UInt64) :
     clmul (x ^^^ y) z =
       ((clmul x z).1 ^^^ (clmul y z).1, (clmul x z).2 ^^^ (clmul y z).2) := by
@@ -727,5 +732,17 @@ theorem clmul_comm (x y : UInt64) :
         exact List.mem_range.mp hmem)]
     _ = clmul y x := by
       rw [← clmul_eq_right_bits x y]
+
+/-- Runtime `clmul`, under its trusted reference contract, is linear in its
+right word argument over bitwise XOR. -/
+theorem clmul_xor_right (x y z : UInt64) :
+    clmul x (y ^^^ z) =
+      ((clmul x y).1 ^^^ (clmul x z).1, (clmul x y).2 ^^^ (clmul x z).2) := by
+  calc
+    clmul x (y ^^^ z) = clmul (y ^^^ z) x := clmul_comm x (y ^^^ z)
+    _ = ((clmul y x).1 ^^^ (clmul z x).1, (clmul y x).2 ^^^ (clmul z x).2) := by
+      rw [clmul_xor_left]
+    _ = ((clmul x y).1 ^^^ (clmul x z).1, (clmul x y).2 ^^^ (clmul x z).2) := by
+      rw [clmul_comm y x, clmul_comm z x]
 
 end Hex

--- a/progress/20260511T084703Z_29f8e50d.md
+++ b/progress/20260511T084703Z_29f8e50d.md
@@ -1,0 +1,37 @@
+# 2026-05-11 08:47 UTC — work session (29f8e50d)
+
+## Accomplished
+
+- Claimed issue #3308, verified that its prerequisite
+  `yunStep_tail_derivative_isZero_*` lemmas are not on `main`, and skipped it
+  as stale/blocked because they currently live only in open PR #3309.
+- Claimed issue #3303 (HexGF2 Phase6: review carry-less multiply API).
+- Reviewed `HexGF2/Clmul.lean` against `SPEC/Libraries/hex-gf2.md` and
+  `PLAN/Phase6.md`.
+- Added docstrings for public CLMUL characterising lemmas that lacked them:
+  `pureClmul_xor_left`, `pureClmul_zero_left`, and `clmul_xor_left`.
+- Added the missing public `clmul_xor_right` theorem, derived from
+  `clmul_comm` and `clmul_xor_left`, so downstream users have both left and
+  right XOR-linearity APIs without unfolding `clmul`.
+- Verified `lake build HexGF2.Clmul`, `lake build HexGF2`,
+  `python3 scripts/check_dag.py`, and `git diff --check`.
+- Confirmed the banned-marker scan of `HexGF2/Clmul.lean` reports no
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+- `HexGF2/Clmul.lean` is Phase-6-ready as the carry-less multiply API boundary:
+  the executable/reference definitions are unchanged, the trusted extern symbol
+  is unchanged, and the proof-facing API now includes both XOR-linearity
+  directions plus the existing one-hot and commutativity lemmas.
+
+## Next step
+
+- Commit `HexGF2/Clmul.lean` and this progress note, then open the PR closing
+  #3303.
+- The skipped Yun issue #3308 should be replanned or blocked on PR #3309
+  landing.
+
+## Blockers
+
+- None for #3303.

--- a/progress/20260511T093407Z_repair_3312.md
+++ b/progress/20260511T093407Z_repair_3312.md
@@ -1,0 +1,34 @@
+# 2026-05-11 09:34 UTC — repair session (#3312)
+
+## Accomplished
+
+Claimed PR #3312 and diagnosed the failed Linux build check. The PR was
+mergeable, and the only failed check was the benchmark smoke gate; the failing
+entries were Isabelle-backed `HexLLL` benchmarks, unrelated to the CLMUL
+right-linearity API change in `HexGF2/Clmul.lean`.
+
+Merged current `origin/main` into `agent/29f8e50d`. The merge was clean and
+pulled in the latest shared benchmark/oracle state.
+
+Verified with:
+
+- `lake build HexGF2.Clmul`
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexGF2/Clmul.lean`
+- `export HEX_LLL_ISABELLE_SVP="$(scripts/oracle/setup_lll_isabelle.sh)"; lake exe hexlll_bench verify`
+
+The local benchmark verification passed all 32 `HexLLL` benchmark checks.
+
+## Current frontier
+
+PR #3312 is ready to push with the clean merge from `main`.
+
+## Next step
+
+Push `agent/29f8e50d` with `--force-with-lease` and mark PR #3312 salvaged.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3303

Session: `29f8e50d-d134-4835-b0c8-61702d73411a`

## Summary

- Reviewed `HexGF2/Clmul.lean` against `SPEC/Libraries/hex-gf2.md` and `PLAN/Phase6.md`.
- Added docstrings for public CLMUL characterising lemmas that lacked them.
- Added `Hex.clmul_xor_right`, derived from `clmul_comm` and `clmul_xor_left`, so the API exposes both XOR-linearity directions without unfolding `clmul`.

## Phase 6 readiness

`HexGF2/Clmul.lean` is Phase-6-ready for the carry-less multiply API boundary. The executable/reference definitions and `@[extern "lean_hex_clmul_u64"]` symbol are unchanged; the public proof-facing API now covers the expected one-hot, commutativity, and left/right XOR-linearity lemmas. No follow-up issue is needed for this file.

## Verification

- `lake build HexGF2.Clmul`
- `lake build HexGF2`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexGF2/Clmul.lean` reports no matches\n\n26ed560 feat: add CLMUL right-linearity API