### PR TITLE
docs: review Montgomery context API

### DIFF
--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -174,16 +174,19 @@ def mk (p : UInt64) (hp : p % 2 = 1) : MontCtx p :=
       exact toNat_r2OfModulus p hp_pos }
 
 /-- View the odd-modulus assumption as a Nat-level parity fact. -/
+@[simp]
 theorem p_odd_nat (ctx : MontCtx p) : p.toNat % 2 = 1 := by
   have h := congrArg UInt64.toNat ctx.p_odd
   simpa [UInt64.toNat_mod, UInt64.toNat_ofNat, UInt64.size] using h
 
 /-- An odd `UInt64` modulus is positive at the Nat level. -/
+@[simp]
 theorem p_pos (ctx : MontCtx p) : 0 < p.toNat := by
   have hodd := ctx.p_odd_nat
   omega
 
 /-- Every `UInt64` modulus is below the Montgomery radix `R = 2^64`. -/
+@[simp]
 theorem p_lt_R (_ctx : MontCtx p) : p.toNat < UInt64.word := by
   simpa [UInt64.word, UInt64.size] using UInt64.toNat_lt_size p
 
@@ -465,6 +468,7 @@ theorem mulMont_repr (ctx : MontCtx p) (a b : UInt64)
     _ = y * UInt64.word % p.toNat := hyR_eq_mul.symm
 
 /-- Converting into Montgomery form and back is the identity on reduced inputs. -/
+@[simp]
 theorem fromMont_toMont (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
     ctx.fromMont (ctx.toMont a) = a := by
   apply UInt64.toNat_inj.mp

--- a/progress/20260511T085553Z_59308dab.md
+++ b/progress/20260511T085553Z_59308dab.md
@@ -1,0 +1,34 @@
+# 2026-05-11 08:55 UTC — review session (59308dab)
+
+## Accomplished
+
+Claimed #3314 and reviewed `HexArith/Montgomery/Context.lean` against
+`SPEC/Libraries/hex-arith.md` and `PLAN/Phase6.md`.
+
+Added small Phase 6 automation polish by marking the Nat-level context
+projections (`p_odd_nat`, `p_pos`, `p_lt_R`) and the reduced round-trip
+theorem `fromMont_toMont` as `[simp]`.
+
+Verified:
+
+- `lake build HexArith.Montgomery.Context`
+- `lake build HexArith`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- banned-marker scan of `HexArith/Montgomery/Context.lean`
+
+## Current frontier
+
+`HexArith/Montgomery/Context.lean` is Phase-6-ready for this review scope:
+the SPEC-named public API is documented, theorem statement shapes match the
+intended Montgomery context surface, and downstream users now get the basic
+context facts and round-trip normalization through `simp`.
+
+## Next step
+
+Continue the remaining HexArith Phase 6 review queue; the sibling Barrett
+context review (#3313) was claimed by another session during this turn.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3314

Session: `59308dab-f8a5-42ba-9707-2c177c47545d`

## Summary
- Reviewed `HexArith/Montgomery/Context.lean` against `SPEC/Libraries/hex-arith.md` and `PLAN/Phase6.md`.
- Marked the Nat-level Montgomery context projections (`p_odd_nat`, `p_pos`, `p_lt_R`) and reduced round-trip theorem `fromMont_toMont` as `[simp]` lemmas.

## Review result
`HexArith/Montgomery/Context.lean` is Phase-6-ready for this review scope. The SPEC-named context API is documented, theorem statements match the intended user-facing surface, namespace placement is local, and no follow-up issue is needed from this review.

## Verification
- `lake build HexArith.Montgomery.Context`
- `lake build HexArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|TODO|FIXME" HexArith/Montgomery/Context.lean` (no matches)

Commit: de61ae6 docs: review Montgomery context API