### PR TITLE
review: polish UInt64 wide arithmetic API

### DIFF
--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -126,19 +126,6 @@ private theorem redc_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
             rw [hlo_zero]
             simp
 
-private theorem mulFull_eq_mulHi_mul (a b : UInt64) :
-    UInt64.mulFull a b = (UInt64.mulHi a b, a * b) := by
-  cases h : UInt64.mulFull a b with
-  | mk hi lo =>
-      have hfull := UInt64.toNat_mulFull a b
-      simp [h] at hfull
-      apply Prod.ext
-      · apply UInt64.toNat_inj.mp
-        rw [UInt64.toNat_mulHi]
-        exact hfull.1
-      · apply UInt64.toNat_inj.mp
-        simpa [UInt64.toNat_mul, UInt64.word] using hfull.2
-
 private theorem MontCtx.p_odd_nat (ctx : MontCtx p) : p.toNat % 2 = 1 := by
   have h := congrArg UInt64.toNat ctx.p_odd
   simpa [UInt64.toNat_mod, UInt64.toNat_ofNat, UInt64.size] using h
@@ -206,7 +193,7 @@ theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
       redcNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word) := by
   let m := Tlo * ctx.p'
   have hfull : UInt64.mulFull m p = (UInt64.mulHi m p, m * p) :=
-    mulFull_eq_mulHi_mul m p
+    UInt64.mulFull_eq_mulHi_mul m p
   have hTmod :
       (Tlo.toNat + Thi.toNat * UInt64.word) % UInt64.word = Tlo.toNat := by
     have hTlo : Tlo.toNat < UInt64.word := by

--- a/HexArith/UInt64/Wide.lean
+++ b/HexArith/UInt64/Wide.lean
@@ -76,6 +76,24 @@ theorem toNat_mulFull (a b : UInt64) :
   · simp [word]
 
 /--
+`mulFull` returns the same high word as `mulHi` and the same low word as
+ordinary wrapped `UInt64` multiplication, while computing both halves in one
+extern call.
+-/
+theorem mulFull_eq_mulHi_mul (a b : UInt64) :
+    mulFull a b = (mulHi a b, a * b) := by
+  cases h : mulFull a b with
+  | mk hi lo =>
+      have hfull := toNat_mulFull a b
+      simp [h] at hfull
+      apply Prod.ext
+      · apply UInt64.toNat_inj.mp
+        rw [toNat_mulHi]
+        exact hfull.1
+      · apply UInt64.toNat_inj.mp
+        simpa [UInt64.toNat_mul, word] using hfull.2
+
+/--
 Splitting the product into high and low words reconstructs the original
 Nat-level product.
 -/

--- a/progress/20260511T090333Z_3a4f18e8.md
+++ b/progress/20260511T090333Z_3a4f18e8.md
@@ -1,0 +1,36 @@
+# 2026-05-11 09:03 UTC — work/review session (3a4f18e8)
+
+## Accomplished
+
+- Human-oversight queue was checked first; each listed directive rejected
+  claim attempts as blocked by dependencies, so no blocked work was started.
+- Claimed #3322 (`HexArith Phase6: review UInt64 wide arithmetic API`).
+- Reviewed `SPEC/Libraries/hex-arith.md`, `PLAN/Phase6.md`,
+  `PLAN/Conventions.md`, `HexArith/UInt64/Wide.lean`, and
+  `HexArith/ffi/wide_arith.c`.
+- Promoted the duplicated Montgomery-local
+  `mulFull_eq_mulHi_mul` characterisation into
+  `HexArith/UInt64/Wide.lean`, documenting that `mulFull` returns the same
+  high word as `mulHi` and the same low word as wrapped multiplication while
+  using one extern call.
+- Updated `HexArith/Montgomery/Redc.lean` to use
+  `UInt64.mulFull_eq_mulHi_mul` and removed the private duplicate.
+
+## Current frontier
+
+- `HexArith/UInt64/Wide.lean` is Phase-6-ready for this review slice: public
+  declarations have docstrings, the FFI contract matches
+  `HexArith/ffi/wide_arith.c`, and downstream callers no longer need a local
+  proof to relate `mulFull` to its high/low projections.
+- A pre-existing `.claude/CLAUDE.md` worktree modification was present before
+  this session's edits and was intentionally left untouched.
+
+## Next step
+
+- Continue with the remaining HexArith Phase 6 review queue, especially the
+  Barrett and Montgomery reduction layer reviews that consume this shared
+  wide-arithmetic API.
+
+## Blockers
+
+- None for #3322.

--- a/progress/20260511T101116Z_1d9c9d43.md
+++ b/progress/20260511T101116Z_1d9c9d43.md
@@ -1,0 +1,35 @@
+# 2026-05-11 10:11 UTC — work session (1d9c9d43)
+
+## Accomplished
+
+Claimed #3335 for PR #3324 repair follow-up. Confirmed PR #3324 is now
+mergeable on branch `agent/3a4f18e8` at `d91c516` and that the previous
+failing conformance log was a `HexArith.Montgomery.InvNat` SAT-solver
+timeout at `HexArith/Montgomery/InvNat.lean:20`.
+
+Verified locally:
+
+- `lake build HexArith.UInt64.Wide`
+- `lake build HexArith.Montgomery.Redc`
+- `lake build HexArith`
+- `python3 scripts/check_dag.py`
+- `git diff --check origin/main...HEAD`
+- `rg -n '\baxiom\b|native_decide|TODO|FIXME|sorry' HexArith/UInt64/Wide.lean HexArith/Montgomery/Redc.lean`
+
+The forbidden-token scan had no matches. The only pre-existing unstaged
+worktree change remains `.claude/CLAUDE.md`.
+
+## Current frontier
+
+PR #3324's new GitHub `build` and `conformance` checks are still in progress;
+`build-macos` is already green. No additional source change was needed in the
+touched HexArith files during this session.
+
+## Next step
+
+Wait for PR #3324's in-progress GitHub checks to finish, then let auto-merge
+land the PR if they pass.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3322
Closes #3335

Session: `3a4f18e8-8396-434c-ab9a-c99c07aefd8f`

## Review result

`HexArith/UInt64/Wide.lean` is Phase-6-ready for this review slice. The public API has docstrings, the Lean-side logical bodies match `HexArith/ffi/wide_arith.c`, and downstream callers can now use `UInt64.mulFull_eq_mulHi_mul` instead of carrying a local proof relating `mulFull`, `mulHi`, and wrapped multiplication.

No follow-up issues are needed from this review.

## Repair follow-up

Repair issue #3335 confirmed the branch is mergeable and locally rebuilt the previously failing `HexArith.Montgomery.InvNat` dependency through `HexArith.Montgomery.Redc`; the old conformance failure was a SAT-solver timeout at `HexArith/Montgomery/InvNat.lean:20` that did not reproduce locally.

## Verification

- `lake build HexArith.UInt64.Wide`
- `lake build HexArith.Montgomery.Redc`
- `lake build HexArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|TODO|FIXME" HexArith/UInt64/Wide.lean` (no matches)
- `rg -n "\\baxiom\\b|native_decide|TODO|FIXME|sorry" HexArith/UInt64/Wide.lean HexArith/Montgomery/Redc.lean` (no matches)

Commits: e2847be `review: polish UInt64 wide arithmetic API`, 91f7f6e `docs: record 3335 repair verification progress`