### PR TITLE
doc: polish Montgomery REDC helpers

### DIFF
--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -33,6 +33,7 @@ def redc (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
   else
     addHi
 
+/-- A word-sized value plus its `R - 1` multiple vanishes modulo `R`. -/
 private theorem redc_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
     (a + (a * (UInt64.word - 1)) % UInt64.word) % UInt64.word = 0 := by
   have hword_pos : 0 < UInt64.word := by
@@ -56,6 +57,7 @@ private theorem redc_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
             rw [hs]
           rw [hmul, Nat.mul_mod_left]
 
+/-- The low-word Montgomery correction makes the adjusted low word zero modulo `R`. -/
 private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
     let m := Tlo * ctx.p'
     (Tlo.toNat + (m * p).toNat) % UInt64.word = 0 := by
@@ -95,6 +97,7 @@ private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
           rw [hpp']
           exact redc_cancel_pred_word Tlo.toNat hTlo
 
+/-- The first add-with-carry step computes an exact carry and a zero low word. -/
 private theorem redc_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
     let m := Tlo * ctx.p'
     let (lo, c1) := UInt64.addCarry Tlo (m * p) false
@@ -126,6 +129,7 @@ private theorem redc_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
             rw [hlo_zero]
             simp
 
+/-- `mulFull` returns the same high and low words as `mulHi` and wrapped multiply. -/
 private theorem mulFull_eq_mulHi_mul (a b : UInt64) :
     UInt64.mulFull a b = (UInt64.mulHi a b, a * b) := by
   cases h : UInt64.mulFull a b with
@@ -139,14 +143,17 @@ private theorem mulFull_eq_mulHi_mul (a b : UInt64) :
       · apply UInt64.toNat_inj.mp
         simpa [UInt64.toNat_mul, UInt64.word] using hfull.2
 
+/-- View the odd-modulus assumption as a Nat-level parity fact inside this file. -/
 private theorem MontCtx.p_odd_nat (ctx : MontCtx p) : p.toNat % 2 = 1 := by
   have h := congrArg UInt64.toNat ctx.p_odd
   simpa [UInt64.toNat_mod, UInt64.toNat_ofNat, UInt64.size] using h
 
+/-- An odd modulus is positive at the Nat level. -/
 private theorem MontCtx.p_pos (ctx : MontCtx p) : 0 < p.toNat := by
   have hodd := ctx.p_odd_nat
   omega
 
+/-- Every `UInt64` modulus is below the Montgomery radix `R = 2^64`. -/
 private theorem MontCtx.p_lt_word (_ctx : MontCtx p) : p.toNat < UInt64.word := by
   simpa [UInt64.word, UInt64.size] using UInt64.toNat_lt_size p
 

--- a/HexArith/Montgomery/RedcNat.lean
+++ b/HexArith/Montgomery/RedcNat.lean
@@ -15,12 +15,14 @@ def redcNat (p p' T : Nat) : Nat :=
   let u := (T + m * p) / UInt64.word
   if u < p then u else u - p
 
+/-- Reducing `T` before multiplying by `p'` does not change the correction word. -/
 private theorem redcNat_correction_eq (p' T : Nat) :
     T * p' % UInt64.word = (T % UInt64.word) * p' % UInt64.word := by
   rw [Nat.mul_mod T p' UInt64.word]
   rw [Nat.mul_mod (T % UInt64.word) p' UInt64.word]
   rw [Nat.mod_mod]
 
+/-- A word-sized value plus its `R - 1` multiple vanishes modulo `R`. -/
 private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
     (a + (a * (UInt64.word - 1)) % UInt64.word) % UInt64.word = 0 := by
   have hword_pos : 0 < UInt64.word := by
@@ -44,6 +46,7 @@ private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
             rw [hs]
           rw [hmul, Nat.mul_mod_left]
 
+/-- The Montgomery correction makes the adjusted numerator exactly divisible by `R`. -/
 private theorem redcNat_exact_dvd (p p' T : Nat)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) :
     UInt64.word ∣ T + ((T % UInt64.word) * p' % UInt64.word) * p := by
@@ -84,6 +87,7 @@ private theorem redcNat_exact_dvd (p p' T : Nat)
           exact redcNat_cancel_pred_word (T % UInt64.word)
             (Nat.mod_lt T hword_pos)
 
+/-- Core quotient bound before threading the inverse and modulus-size hypotheses. -/
 private theorem redcNat_u_lt_two_p_core (hp_pos : 0 < p)
     (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by

--- a/progress/20260511T090510Z_3372f45b.md
+++ b/progress/20260511T090510Z_3372f45b.md
@@ -1,0 +1,32 @@
+# 2026-05-11 09:05 UTC — work/review session (3372f45b)
+
+## Accomplished
+
+- Claimed #3323 (`HexArith Phase6: review Montgomery REDC layers`).
+- Reviewed `HexArith/Montgomery/RedcNat.lean` and
+  `HexArith/Montgomery/Redc.lean` against `SPEC/Libraries/hex-arith.md`
+  and `PLAN/Phase6.md`.
+- Added focused docstrings for non-obvious private REDC proof helpers:
+  Nat correction/divisibility/bound helpers, low-word carry helpers,
+  the `mulFull` bridge lemma, and local modulus facts.
+- Confirmed the REDC layers match the SPEC layout and are Phase-6-ready:
+  public theorem shapes align with the documented Nat-level and UInt64
+  bridge APIs, executable behavior is unchanged, and no follow-up issue is
+  needed for these two files.
+
+## Current frontier
+
+- `lake build HexArith.Montgomery.RedcNat`, `lake build
+  HexArith.Montgomery.Redc`, and `lake build HexArith` all succeed.
+- `python3 scripts/check_dag.py` and `git diff --check` are clean.
+- Banned-marker scan of the two REDC files found no `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.
+
+## Next step
+
+- Continue Phase 6 review on the remaining Montgomery surface outside this
+  issue, especially the separately tracked user-facing context API.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #3323

Session: `3372f45b-3cfd-4f56-b5b7-432be8e194b9`

Commit:
- 729f2fe doc: polish Montgomery REDC helpers

Review result: the Montgomery REDC layers are Phase-6-ready. `RedcNat.lean` exposes the expected Nat-level correctness, bound, and quotient lemmas; `Redc.lean` exposes the expected executable bridge lemmas and uses `mulFull` for the shared wide product as required by the SPEC. No follow-up issue is needed for these two files.

Verification:
- `lake build HexArith.Montgomery.RedcNat`
- `lake build HexArith.Montgomery.Redc`
- `lake build HexArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- banned-marker scan of the two REDC files found no `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.