### PR TITLE
review: polish ZMod64 int cast API

### DIFF
--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -91,6 +91,20 @@ def zsmul (i : Int) (a : ZMod64 p) : ZMod64 p :=
   | .ofNat n => nsmul n a
   | .negSucc n => neg (nsmul (n + 1) a)
 
+@[simp] theorem intCast_ofNat (n : Nat) : intCast p (.ofNat n) = natCast p n :=
+  rfl
+
+@[simp] theorem intCast_negSucc (n : Nat) :
+    intCast p (.negSucc n) = neg (natCast p (n + 1)) :=
+  rfl
+
+@[simp] theorem zsmul_ofNat (n : Nat) (a : ZMod64 p) : zsmul (.ofNat n) a = nsmul n a :=
+  rfl
+
+@[simp] theorem zsmul_negSucc (n : Nat) (a : ZMod64 p) :
+    zsmul (.negSucc n) a = neg (nsmul (n + 1) a) :=
+  rfl
+
 instance : Neg (ZMod64 p) where
   neg := neg
 
@@ -143,6 +157,22 @@ instance : SMul Int (ZMod64 p) where
 @[simp] theorem toNat_nsmul (n : Nat) (a : ZMod64 p) :
     (nsmul n a).toNat = (n * a.toNat) % p := by
   rw [nsmul, toNat_ofNat]
+
+@[simp] theorem toNat_intCast_ofNat (n : Nat) :
+    (intCast p (.ofNat n)).toNat = n % p := by
+  rw [intCast_ofNat, toNat_natCast]
+
+@[simp] theorem toNat_intCast_negSucc (n : Nat) :
+    (intCast p (.negSucc n)).toNat = (p - (n + 1) % p) % p := by
+  rw [intCast_negSucc, toNat_neg, toNat_natCast]
+
+@[simp] theorem toNat_zsmul_ofNat (n : Nat) (a : ZMod64 p) :
+    (zsmul (.ofNat n) a).toNat = (n * a.toNat) % p := by
+  rw [zsmul_ofNat, toNat_nsmul]
+
+@[simp] theorem toNat_zsmul_negSucc (n : Nat) (a : ZMod64 p) :
+    (zsmul (.negSucc n) a).toNat = (p - ((n + 1) * a.toNat) % p) % p := by
+  rw [zsmul_negSucc, toNat_neg, toNat_nsmul]
 
 /-- Nat casts agree exactly when their representatives are congruent mod `p`. -/
 theorem natCast_eq_natCast_iff (x y : Nat) :

--- a/progress/20260511T101906Z_c8e00b86.md
+++ b/progress/20260511T101906Z_c8e00b86.md
@@ -1,0 +1,26 @@
+# 2026-05-11 10:19 UTC — work session (c8e00b86)
+
+## Accomplished
+
+- Claimed issue #3342 for HexModArith Phase 6 review of the ring/cast theorem surface.
+- Reviewed `HexModArith/Ring.lean` against `SPEC/Libraries/hex-mod-arith.md` and `PLAN/Phase6.md`.
+- Added small `[simp]` characterising lemmas for `intCast` and `zsmul`, plus representative `toNat` lemmas for their nonnegative and negative cases.
+- Verified:
+  - `lake build HexModArith.Ring`
+  - `lake build HexModArith`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '\baxiom\b|native_decide|TODO|FIXME|sorry' HexModArith/Ring.lean`
+
+## Current frontier
+
+- `HexModArith/Ring.lean` has the expected Phase 6 ring, cast, scalar multiplication, and `IsCharP` surface for downstream callers without requiring definition unfolding for Int casts or Int scalar multiplication.
+- No larger API or proof problem was found in this review scope.
+
+## Next step
+
+- Create the PR for #3342 and note that the file is Phase-6-ready in the PR body.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #3342

Session: `c8e00b86-8ded-4033-b0c9-29e8fb44b9fb`

Review conclusion: `HexModArith/Ring.lean` is Phase-6-ready for the ring, Nat/Int cast, scalar multiplication, and `IsCharP` surface. No larger follow-up issue was found in this scope.

Changes:
- Added `[simp]` characterising lemmas for `ZMod64.intCast` and `ZMod64.zsmul` by sign case.
- Added `[simp]` representative lemmas for the corresponding `toNat` values, so downstream callers do not need to unfold executable definitions.

Verification:
- `lake build HexModArith.Ring`
- `lake build HexModArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n banned-marker pattern HexModArith/Ring.lean`

f1a9777 review: polish ZMod64 int cast API

Prepared by pod session `c8e00b86`.