### PR TITLE
review: polish GF2 Euclid API

### DIFF
--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -296,6 +296,22 @@ theorem divMod_spec (p q : GF2Poly) :
   unfold divMod
   simpa using divModAux_reconstruct q (p.degree + 1) 0 p
 
+/-- The first component of `divMod` is the public quotient operation. -/
+@[simp] theorem divMod_fst (p q : GF2Poly) :
+    (divMod p q).1 = p / q :=
+  rfl
+
+/-- The second component of `divMod` is the public remainder operation. -/
+@[simp] theorem divMod_snd (p q : GF2Poly) :
+    (divMod p q).2 = p % q :=
+  rfl
+
+/-- Quotient/remainder reconstruction through the public `/` and `%`
+operations. -/
+theorem div_mul_add_mod (p q : GF2Poly) :
+    (p / q) * q + p % q = p := by
+  simpa using divMod_spec p q
+
 private theorem one_eq_monomial_zero : (1 : GF2Poly) = monomial 0 := by
   change one = monomial 0
   simp [one, monomial]

--- a/progress/20260511T103009Z_ad62a60c.md
+++ b/progress/20260511T103009Z_ad62a60c.md
@@ -1,0 +1,40 @@
+# 2026-05-11 10:30 UTC — review session (ad62a60c)
+
+## Accomplished
+
+Claimed #3348 and reviewed the packed `GF2Poly` Euclidean algorithm API in
+`HexGF2/Euclid.lean` against `SPEC/Libraries/hex-gf2.md` and
+`PLAN/Phase6.md`.
+
+Added a narrow public theorem surface for callers that use division notation:
+
+- `@[simp] divMod_fst`
+- `@[simp] divMod_snd`
+- `div_mul_add_mod`
+
+These lemmas let downstream code move between `divMod` and the public `/` and
+`%` operations, and use quotient/remainder reconstruction without unfolding the
+private `divModAux`.
+
+Verified:
+
+- `lake build HexGF2.Euclid`
+- `lake build HexGF2`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '\baxiom\b|native_decide|TODO|FIXME|sorry' HexGF2/Euclid.lean`
+
+## Current frontier
+
+`HexGF2/Euclid.lean` is Phase-6-ready for the reviewed division/gcd/xgcd API
+surface. Larger algorithmic rewrites or Rabin soundness work were not needed
+for this issue.
+
+## Next step
+
+Create the PR for #3348 and state in the PR body that the Euclidean API review
+found no larger follow-up gap.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3348

Session: `ad62a60c-bff4-4fa3-b743-d28c97fa1803`

Summary:
- Reviewed `HexGF2/Euclid.lean` against `SPEC/Libraries/hex-gf2.md` and `PLAN/Phase6.md`.
- Added public `divMod` projection lemmas and `/`/`%` reconstruction theorem so downstream callers do not need to unfold `divModAux`.
- `HexGF2/Euclid.lean` is Phase-6-ready for the reviewed division/gcd/xgcd API surface; no larger follow-up issue is needed from this review.

Verification:
- `lake build HexGF2.Euclid`
- `lake build HexGF2`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '\baxiom\b|native_decide|TODO|FIXME|sorry' HexGF2/Euclid.lean` produced no matches

Commit:
- 3483f65 review: polish GF2 Euclid API
