### PR TITLE
review: polish GF2 CLMUL API

### DIFF
--- a/HexGF2/Clmul.lean
+++ b/HexGF2/Clmul.lean
@@ -497,6 +497,21 @@ intrinsic-backed implementations are an optimization only. -/
 def clmul (a b : @& UInt64) : UInt64 × UInt64 :=
   pureClmul a b
 
+/-- The trusted extern-backed multiplier has `pureClmul` as its logical
+reference semantics. -/
+theorem clmul_eq_pureClmul (a b : UInt64) : clmul a b = pureClmul a b := by
+  rw [clmul]
+
+/-- Carry-less multiplication by zero on the left returns the zero product. -/
+@[simp]
+theorem clmul_zero_left (x : UInt64) : clmul 0 x = (0, 0) := by
+  rw [clmul_eq_pureClmul, pureClmul_zero_left]
+
+/-- Carry-less multiplication by zero on the right returns the zero product. -/
+@[simp]
+theorem clmul_zero_right (x : UInt64) : clmul x 0 = (0, 0) := by
+  simp [clmul, pureClmul, foldl_keep]
+
 /-- Runtime `clmul`, under its trusted reference contract, agrees with the
 one-hot pure carry-less multiplication split. -/
 theorem clmul_oneHot (a : UInt64) {bit : Nat} (hbit : bit < 64) :
@@ -566,9 +581,6 @@ private theorem xorPair_assoc (x y z : UInt64 × UInt64) :
   cases z
   simp [xorPair]
   constructor <;> bv_decide
-
-private theorem clmul_zero_left (x : UInt64) : clmul 0 x = (0, 0) := by
-  rw [clmul, pureClmul_zero_left]
 
 private def wordBitXorStep (w acc : UInt64) (bit : Nat) : UInt64 :=
   if (((w >>> bit.toUInt64) &&& 1) != 0) then

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -164,9 +164,6 @@ private theorem foldl_keep {α β : Type} (xs : List β) (acc : α) :
   | nil => simp
   | cons _ xs ih => simp [ih]
 
-private theorem clmul_zero_right (x : UInt64) : clmul x 0 = (0, 0) := by
-  simp [clmul, pureClmul, foldl_keep]
-
 private theorem Array.setIfInBounds_getElem! (xs : Array UInt64) (idx : Nat) :
     xs.setIfInBounds idx xs[idx]! = xs := by
   unfold Array.setIfInBounds
@@ -176,7 +173,7 @@ private theorem Array.setIfInBounds_getElem! (xs : Array UInt64) (idx : Nat) :
 
 private theorem xorClmulAt_zero_right (acc : Array UInt64) (idx : Nat) (x : UInt64) :
     xorClmulAt acc idx x 0 = acc := by
-  simp [xorClmulAt, clmul_zero_right, Array.setIfInBounds_getElem!]
+  simp [xorClmulAt, Array.setIfInBounds_getElem!]
 
 private theorem coeffWords_xorClmulAt_zero_right (acc : Array UInt64) (idx n : Nat)
     (x : UInt64) :
@@ -748,12 +745,9 @@ private theorem foldl_xorClmulAt_monomial_ne
     (hnLow := hLow) (hnHigh := hHigh)]
   rw [foldl_xorClmulAt_monomial_zero_prefix_coeff]
 
-private theorem clmul_zero_left (x : UInt64) : clmul 0 x = (0, 0) := by
-  rw [clmul, pureClmul_zero_left]
-
 private theorem xorClmulAt_zero_left (acc : Array UInt64) (idx : Nat) (x : UInt64) :
     xorClmulAt acc idx 0 x = acc := by
-  simp [xorClmulAt, clmul_zero_left, Array.setIfInBounds_getElem!]
+  simp [xorClmulAt, Array.setIfInBounds_getElem!]
 
 private theorem coeffWords_xorClmulAt_zero_left (acc : Array UInt64) (idx n : Nat)
     (x : UInt64) :

--- a/progress/20260511T103737Z_0936e089.md
+++ b/progress/20260511T103737Z_0936e089.md
@@ -1,0 +1,39 @@
+# 2026-05-11 10:37 UTC — review session (0936e089)
+
+## Accomplished
+
+Claimed #3252 first, found it stale, and skipped it: #3316 had been
+decomposed into #3345/#3346, and #3252 still depends on the public wrapper
+that now belongs to blocked issue #3346.
+
+Claimed #3347 and reviewed the `HexGF2/Clmul.lean` theorem surface against the
+Phase 6 API-polish target. Added:
+
+- `clmul_eq_pureClmul`, documenting the trusted extern boundary as a theorem.
+- public `[simp]` lemmas `clmul_zero_left` and `clmul_zero_right`.
+
+Removed the now-shadowing private zero lemmas in `HexGF2/Multiply.lean` so
+downstream proofs use the public `HexGF2.Clmul` surface directly.
+
+Verified:
+
+- `lake build HexGF2.Clmul`
+- `lake build HexGF2`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '\baxiom\b|native_decide|TODO|FIXME|sorry' HexGF2/Clmul.lean`
+
+## Current frontier
+
+`HexGF2/Clmul.lean` is Phase-6-ready for the reviewed surface: downstream code
+has named lemmas for the extern contract, zero cases, one-hot multiplication,
+commutativity, and XOR-linearity without unfolding `pureClmul`.
+
+## Next step
+
+Open the PR for #3347 and state in the PR body that no larger CLMUL follow-up
+issue is needed from this review.
+
+## Blockers
+
+None for #3347. #3252 remains blocked in practice until #3346 lands.


### PR DESCRIPTION
Closes #3347

Session: `0936e089-cea7-4bb1-9671-bd35af2de0d6`

## Summary

- Added `clmul_eq_pureClmul` as the named theorem for the trusted extern/reference-semantics boundary.
- Promoted zero-product facts to public `[simp]` lemmas: `clmul_zero_left` and `clmul_zero_right`.
- Removed private downstream zero lemmas in `HexGF2/Multiply.lean` so packed multiplication proofs use the public CLMUL surface.

## Phase 6 review result

`HexGF2/Clmul.lean` is Phase-6-ready for this reviewed surface. Downstream callers now have named lemmas for the extern contract, zero cases, one-hot multiplication, commutativity, and XOR-linearity without unfolding `pureClmul`. No larger CLMUL follow-up issue is needed from this review.

## Verification

- `lake build HexGF2.Clmul`
- `lake build HexGF2`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '\\baxiom\\b|native_decide|TODO|FIXME|sorry' HexGF2/Clmul.lean`