### PR TITLE
review: polish Montgomery context API

### DIFF
--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -259,7 +259,8 @@ private theorem cancel_word_mod_of_lt (ctx : MontCtx p) {x y : Nat}
   · exact hle_case hx hy h hxy
   · exact (hle_case hy hx h.symm (Nat.le_of_not_ge hxy)).symm
 
-private theorem fromMont_lt (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
+/-- Converting a reduced Montgomery residue back to standard form is canonical. -/
+theorem fromMont_lt (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
     ctx.fromMont a < p := by
   rw [UInt64.lt_iff_toNat_lt]
   have haNat : a.toNat < p.toNat := by
@@ -277,7 +278,11 @@ private theorem fromMont_lt (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   rw [toNat_redc ctx 0 a hT]
   exact redcNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
 
-private theorem fromMont_repr (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
+/--
+`fromMont` removes one Montgomery radix factor from a reduced Montgomery
+residue.
+-/
+theorem fromMont_repr (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
     (ctx.fromMont a).toNat * UInt64.word % p.toNat = a.toNat := by
   have haNat : a.toNat < p.toNat := by
     simpa [UInt64.lt_iff_toNat_lt] using ha
@@ -295,7 +300,9 @@ private theorem fromMont_repr (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   have hredc := redcNat_eq_mod ctx.p_pos ctx.p_lt_R hpp' hT
   simpa [Nat.mod_eq_of_lt haNat] using hredc
 
-private theorem toMont_eq_mod_word (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
+/-- The `Nat` value of `toMont` is multiplication by the Montgomery radix. -/
+@[simp]
+theorem toNat_toMont (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
     (ctx.toMont a).toNat = (a.toNat * UInt64.word) % p.toNat := by
   have haNat : a.toNat < p.toNat := by
     simpa [UInt64.lt_iff_toNat_lt] using ha
@@ -482,9 +489,10 @@ theorem fromMont_toMont (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   calc
     (ctx.fromMont (ctx.toMont a)).toNat * UInt64.word % p.toNat
         = (ctx.toMont a).toNat := fromMont_repr ctx (ctx.toMont a) hto_lt
-    _ = a.toNat * UInt64.word % p.toNat := toMont_eq_mod_word ctx a ha
+    _ = a.toNat * UInt64.word % p.toNat := toNat_toMont ctx a ha
 
 /-- Montgomery multiplication computes modular multiplication after conversion. -/
+@[simp]
 theorem toNat_mulMont (ctx : MontCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     (ctx.fromMont (ctx.mulMont (ctx.toMont a) (ctx.toMont b))).toNat =

--- a/progress/20260511T110338Z_8e62d6cd.md
+++ b/progress/20260511T110338Z_8e62d6cd.md
@@ -1,0 +1,32 @@
+# 2026-05-11 11:03 UTC — work session (8e62d6cd)
+
+## Accomplished
+
+- Followed worker-flow priority: attempted the open human-oversight queue first; all visible human-oversight issues were dependency-blocked by `coordination claim`.
+- Claimed issue #3362 for HexArith Phase 6 review of the Montgomery context API.
+- Reviewed `HexArith/Montgomery/Context.lean` against the Montgomery section of `SPEC/Libraries/hex-arith.md` and `PLAN/Phase6.md`.
+- Exposed conversion characterising lemmas for downstream callers:
+  - `MontCtx.fromMont_lt`
+  - `MontCtx.fromMont_repr`
+  - `MontCtx.toNat_toMont`
+- Added `[simp]` to `MontCtx.toNat_toMont` and `MontCtx.toNat_mulMont`, matching the Barrett API style for public Nat-value characterisation.
+- Verified:
+  - `lake build HexArith.Montgomery.Context`
+  - `lake build HexArith`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexArith/Montgomery/Context.lean HexArith/Montgomery/InvNat.lean`
+
+## Current frontier
+
+- The public Montgomery context API now exposes conversion facts for `fromMont` and `toMont` without requiring callers to unfold `redc`.
+- Executable Montgomery definitions were unchanged.
+- The known `InvNat` proof-performance risk did not affect this review build.
+
+## Next step
+
+- Create the PR for #3362 and note in the PR body that no separate `InvNat` follow-up is needed from this review.
+
+## Blockers
+
+- Human-oversight issues #2564, #2565, #2566, #2567, and #2637 were listed but rejected by `coordination claim` as dependency-blocked.


### PR DESCRIPTION
Closes #3362

Session: `8e62d6cd-a0fb-40a6-a47a-5da73e46949c`

## Review result

Phase 6 Montgomery context API review found one concrete caller-facing gap: conversion facts for `fromMont` and raw `toMont` representation were private, so downstream users had the multiplication theorem surface but not enough public conversion lemmas to avoid unfolding `redc`.

This PR exposes `MontCtx.fromMont_lt`, `MontCtx.fromMont_repr`, and `MontCtx.toNat_toMont`, and marks `toNat_toMont` / `toNat_mulMont` as `[simp]` in line with the Barrett API style. Executable Montgomery definitions are unchanged.

The known `HexArith/Montgomery/InvNat.lean` proof-performance risk did not reproduce as a blocker in this review: both the target module and full `HexArith` build completed. I do not see a separate follow-up issue needed from this pass.

## Verification

- `lake build HexArith.Montgomery.Context`
- `lake build HexArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexArith/Montgomery/Context.lean HexArith/Montgomery/InvNat.lean`

Commit:

- ac9a475 review: polish Montgomery context API