### PR TITLE
review: polish Barrett context API

### DIFF
--- a/HexArith/Barrett/Context.lean
+++ b/HexArith/Barrett/Context.lean
@@ -109,4 +109,22 @@ theorem mulMod_eq (ctx : BarrettCtx p) (a b : UInt64)
     ((a.toNat * b.toNat) % p.toNat) % UInt64.size
   simpa [UInt64.size, UInt64.word] using (Nat.mod_eq_of_lt hmod_word).symm
 
+/-- Zero is a left absorbing element for Barrett modular multiplication. -/
+@[simp]
+theorem mulMod_zero_left (ctx : BarrettCtx p) (b : UInt64) (hb : b < p) :
+    ctx.mulMod 0 b = 0 := by
+  have hzero : (0 : UInt64) < p := by
+    rw [UInt64.lt_iff_toNat_lt]
+    exact Nat.lt_trans (by decide : 0 < 1) ctx.p_gt
+  simpa using mulMod_eq ctx 0 b hzero hb
+
+/-- Zero is a right absorbing element for Barrett modular multiplication. -/
+@[simp]
+theorem mulMod_zero_right (ctx : BarrettCtx p) (a : UInt64) (ha : a < p) :
+    ctx.mulMod a 0 = 0 := by
+  have hzero : (0 : UInt64) < p := by
+    rw [UInt64.lt_iff_toNat_lt]
+    exact Nat.lt_trans (by decide : 0 < 1) ctx.p_gt
+  simpa using mulMod_eq ctx a 0 ha hzero
+
 end BarrettCtx

--- a/progress/20260511T110429Z_99296ec8.md
+++ b/progress/20260511T110429Z_99296ec8.md
@@ -1,0 +1,27 @@
+# 2026-05-11 11:04 UTC — work session (99296ec8)
+
+## Accomplished
+
+- Attempted the unclaimed human-oversight queue first; the coordinator rejected each claim as dependency-blocked.
+- Claimed issue #3364 for HexArith Phase 6 review of the Barrett context API.
+- Reviewed `HexArith/Barrett/Context.lean` against `SPEC/Libraries/hex-arith.md`, `PLAN/Phase6.md`, and the Barrett reducer layers.
+- Added public `[simp]` lemmas `BarrettCtx.mulMod_zero_left` and `BarrettCtx.mulMod_zero_right` so callers can normalize zero products through the public `mulMod` contract without unfolding the reducer.
+- Verified:
+  - `lake build HexArith.Barrett.Context`
+  - `lake build HexArith`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexArith/Barrett/Context.lean`
+
+## Current frontier
+
+- `HexArith/Barrett/Context.lean` has the expected public Phase 6 theorem surface for `mulMod`, including canonical residue, Nat projection, encoded equality, and zero normalization lemmas.
+- Executable Barrett definitions were left unchanged.
+
+## Next step
+
+- Create the PR for #3364 and note in the PR body that no separate Barrett follow-up is needed from this review.
+
+## Blockers
+
+- Human-oversight issues #2564, #2565, #2566, #2567, and #2637 remain dependency-blocked according to `coordination claim`.


### PR DESCRIPTION
Closes #3364

Session: `99296ec8-de18-4929-95e8-88bdaf296350`

## Review result

Reviewed `HexArith/Barrett/Context.lean` against the Barrett API requirements in `SPEC/Libraries/hex-arith.md` and the Phase 6 proof-polishing criteria. The existing `mulMod`, `toNat_mulMod`, `mulMod_lt`, and `mulMod_eq` surface already lets callers use the public Barrett contract without unfolding `barrettReduce`.

This PR adds small public `[simp]` zero-normalization lemmas for `BarrettCtx.mulMod` so downstream proofs can simplify zero products through the public API. Executable Barrett definitions are unchanged.

No separate Barrett follow-up issue is needed from this review.

## Verification

- `lake build HexArith.Barrett.Context`
- `lake build HexArith`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `rg -n '^axiom\\b|native_decide|TODO|FIXME|sorry' HexArith/Barrett/Context.lean`