### PR TITLE
feat: prove integer Gram determinant nonnegative

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -6937,5 +6937,29 @@ theorem det_gramMatrix_eq_sum_minors_sq
         (fun acc cols => acc + det (columnTupleMatrix A (columnTupleVectorFn cols)) ^ 2) 0 := by
         exact columnTupleExpansion_selectedPerm_collapse A
 
+private theorem foldl_int_sum_sq_nonneg_start {β : Type v}
+    (xs : List β) (f : β → Int) (acc : Int) (hacc : 0 ≤ acc) :
+    0 ≤ xs.foldl (fun acc x => acc + f x ^ 2) acc := by
+  induction xs generalizing acc with
+  | nil => simpa using hacc
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      have hx : 0 ≤ f x ^ 2 := by
+        simpa [Lean.Grind.Semiring.pow_two] using
+          (Lean.Grind.OrderedRing.sq_nonneg (a := f x))
+      exact ih (acc + f x ^ 2) (Int.add_nonneg hacc hx)
+
+private theorem foldl_int_sum_sq_nonneg {β : Type v} (xs : List β) (f : β → Int) :
+    0 ≤ xs.foldl (fun acc x => acc + f x ^ 2) 0 :=
+  foldl_int_sum_sq_nonneg_start xs f 0 (by simp)
+
+/-- Integer row Gram determinants are nonnegative, by Cauchy-Binet as a finite
+sum of integer squares. -/
+theorem det_gramMatrix_nonneg {n m : Nat} (A : Matrix Int n m) :
+    0 ≤ det (gramMatrix A) := by
+  rw [det_gramMatrix_eq_sum_minors_sq A]
+  exact foldl_int_sum_sq_nonneg (selectedColumnTuples n m)
+    (fun cols => det (columnTupleMatrix A (columnTupleVectorFn cols)))
+
 end Matrix
 end Hex

--- a/progress/20260511T111920Z_2989170f.md
+++ b/progress/20260511T111920Z_2989170f.md
@@ -1,0 +1,23 @@
+# 2026-05-11 11:19 UTC — work/feature session (2989170f)
+
+## Accomplished
+
+- Confirmed all human-oversight directives were blocked by coordination claim checks.
+- Claimed #2841 (`HexMatrix: prove integer Gram determinant nonnegative`).
+- Added `Matrix.det_gramMatrix_nonneg` in `HexMatrix/Determinant.lean`, using the existing Cauchy-Binet sum-of-squares theorem.
+- Added private integer fold helpers showing a finite `List.foldl` sum of squares from a nonnegative accumulator remains nonnegative.
+- Verified the touched determinant cluster has no new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level `sorry`.
+
+## Current frontier
+
+- The general integer row-Gram determinant nonnegativity theorem is available for downstream specialization.
+- `HexGramSchmidt.Int` can now consume `Matrix.det_gramMatrix_nonneg` in #2679 to discharge leading-prefix determinant nonnegativity.
+
+## Next step
+
+- Create the PR for #2841.
+- Next worker should use `Matrix.det_gramMatrix_nonneg` to prove the `HexGramSchmidt.Int` leading-prefix specialization tracked by #2679.
+
+## Blockers
+
+- None for #2841.


### PR DESCRIPTION
Closes #2841

Session: `2989170f-0498-4124-8ba5-0de6c2a7d0c7`

f6beb01 feat: prove integer Gram determinant nonnegative

🤖 Prepared with Claude Code