### PR TITLE
HexModArith: add simp characterisation for ZMod64 values

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -116,6 +116,10 @@ theorem mem_values (a : ZMod64 p) : a ∈ values p := by
   rw [val_toNat_ofNat]
   exact (Nat.mod_eq_of_lt a.toNat_lt).trans (by rfl)
 
+/-- Membership in the canonical residue list is automatic for every residue. -/
+@[simp] theorem mem_values_iff (a : ZMod64 p) : a ∈ values p ↔ True :=
+  iff_true_intro (mem_values a)
+
 /-- Reduced representatives below `p` construct the same residue exactly when
 the representatives are equal. -/
 theorem ofNat_eq_ofNat_iff_of_lt {x y : Nat} (hx : x < p) (hy : y < p) :

--- a/progress/2026-05-11T12-52-10Z_77038390.md
+++ b/progress/2026-05-11T12-52-10Z_77038390.md
@@ -1,0 +1,20 @@
+# 2026-05-11 12:52 UTC — work/feature session (77038390)
+
+## Accomplished
+
+- Claimed #3424 after confirming there were no unclaimed `human-oversight` issues.
+- Added `ZMod64.mem_values_iff` in `HexModArith/Basic.lean` as a documented `@[simp]` characterisation for membership in the canonical residue list.
+- Verified the change with the issue's requested checks.
+
+## Current frontier
+
+- `simp` can now close goals of the form `a ∈ ZMod64.values p` without unfolding `values` or manually applying `mem_values`.
+
+## Next step
+
+- Continue HexModArith Phase 6 API polish on the next narrow theorem surface; no follow-up is required for #3424.
+
+## Blockers
+
+- None.
+- The pre-existing `.claude/CLAUDE.md` worktree modification remains untouched.


### PR DESCRIPTION
Closes #3424

Session: `77038390-1c7a-4409-b684-9a7423b0f1da`

4d416d0 feat: add ZMod64 values membership simp lemma

🤖 Prepared with Claude Code