### PR TITLE
HexMatrix: add core Bareiss exact division bridge

### DIFF
--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -307,6 +307,54 @@ theorem stepMatrix_borderedMinor_update
   rw [hpivot, hentry, hleft, htop]
   exact hexact
 
+/-- Exact-division bridge for one Bareiss bordered-minor update.
+
+Once a determinant identity supplies the numerator as `nextMinor * prevPivot`,
+this lemma packages it as the `exactDiv` premise expected by
+`stepMatrix_borderedMinor_update`. -/
+theorem bareissExactDiv_borderedMinor_of_mul_eq
+    (source : Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
+    (i j : Fin n) (hi : k < i.val) (hj : k < j.val) (prevPivot : Int)
+    (hprev_ne : prevPivot ≠ 0)
+    (hdesnanot :
+      det (borderedMinor source (k + 1) hnext i j) * prevPivot =
+        det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk i j) -
+          det (borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)) :
+    exactDiv
+        (det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+            (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk i j) -
+          det (borderedMinor source k hk
+            i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+          det (borderedMinor source k hk
+            (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
+        prevPivot =
+      det (borderedMinor source (k + 1) hnext i j) := by
+  let nextMinor := det (borderedMinor source (k + 1) hnext i j)
+  let numerator :=
+    det (borderedMinor source k hk
+        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
+        (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+      det (borderedMinor source k hk i j) -
+      det (borderedMinor source k hk
+        i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
+      det (borderedMinor source k hk
+        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)
+  have hnum : numerator = prevPivot * nextMinor := by
+    dsimp [numerator, nextMinor]
+    rw [← hdesnanot, Lean.Grind.CommRing.mul_comm]
+  have hdvd : prevPivot ∣ numerator := ⟨nextMinor, hnum⟩
+  rw [exactDiv_eq_divExact hdvd]
+  change numerator / prevPivot = nextMinor
+  exact Int.ediv_eq_of_eq_mul_right hprev_ne hnum
+
 private structure BareissArrayState where
   step : Nat
   matrix : Array (Array Int)

--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -436,23 +436,8 @@ theorem bareissExactDiv_borderedMinor_of_mul_eq
             (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j))
         prevPivot =
       Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) := by
-  let nextMinor := Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j)
-  let numerator :=
-    Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
-        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
-        (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
-      Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i j) -
-      Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
-        i (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
-      Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
-        (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n) j)
-  have hnum : numerator = prevPivot * nextMinor := by
-    dsimp [numerator, nextMinor]
-    rw [← hdesnanot, mul_comm]
-  have hdvd : prevPivot ∣ numerator := ⟨nextMinor, hnum⟩
-  rw [Hex.Matrix.exactDiv_eq_divExact hdvd]
-  change numerator / prevPivot = nextMinor
-  exact Int.ediv_eq_of_eq_mul_right hprev_ne hnum
+  exact Hex.Matrix.bareissExactDiv_borderedMinor_of_mul_eq
+    source k hk hnext i j hi hj prevPivot hprev_ne hdesnanot
 
 /-- Cyclic shift on `Fin (k + 1)` mapping `0 ↦ k`, `r ↦ r - 1` for `r ≥ 1`.
 

--- a/progress/20260511T161435Z_f621f4b0.md
+++ b/progress/20260511T161435Z_f621f4b0.md
@@ -1,0 +1,30 @@
+# 2026-05-11 16:14 UTC — work session (f621f4b0)
+
+## Accomplished
+
+- Claimed #3478 for the Mathlib-free Bareiss exact-division slice.
+- Added `Hex.Matrix.bareissExactDiv_borderedMinor_of_mul_eq` in `HexMatrix/Bareiss.lean`.
+- Updated `HexMatrixMathlib.bareissExactDiv_borderedMinor_of_mul_eq` to delegate to the new Mathlib-free core theorem.
+- Created successor issue #3484 for the remaining Mathlib-free Desnanot-Jacobi bordered-minor determinant identity.
+- Added the required `Decomposed into #3484` breadcrumb comment to #3478.
+- Verified:
+  - `lake build HexMatrix.Bareiss`
+  - `lake build HexMatrixMathlib.Determinant.Core`
+  - `lake build HexMatrix.Determinant`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^\\s*sorry\\b|^axiom\\b|native_decide|TODO|FIXME' HexMatrix HexMatrix.lean`
+
+## Current frontier
+
+- The exact-division packaging is now available from the Mathlib-free `Hex.Matrix` namespace.
+- The local determinant product identity needed to supply the bridge premise remains in #3484.
+- The worktree still has a pre-existing `.claude/CLAUDE.md` modification; this session did not touch it.
+
+## Next step
+
+- Land the partial #3478 PR, then a worker should claim #3484 and prove the Mathlib-free Desnanot-Jacobi bordered-minor identity in `HexMatrix/Determinant.lean`.
+
+## Blockers
+
+- None for the exact-division bridge.


### PR DESCRIPTION
Partial progress on #3478

Session: `f621f4b0-fa36-4156-bb6d-c30af59dbf31`

91f2363 HexMatrix: add core Bareiss exact division bridge

🤖 Prepared with Claude Code