### PR TITLE
HexMatrix: normalize final cofactor minors

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -299,6 +299,11 @@ theorem skipIndex_ne {n : Nat} (skip : Fin (n + 1)) (i : Fin n) :
   · rw [skipIndex_val_of_not_lt skip i hlt] at hval
     omega
 
+@[simp] theorem skipIndex_last {n : Nat} (i : Fin n) :
+    skipIndex (Fin.last n) i = i.castSucc := by
+  apply Fin.ext
+  simp [skipIndex, Fin.last, i.isLt]
+
 /-- Delete one row and one column from an `(n + 1) × (n + 1)` matrix. -/
 def deleteRowCol {R : Type u} {n : Nat} (M : Matrix R (n + 1) (n + 1))
     (row col : Fin (n + 1)) : Matrix R n n :=
@@ -308,6 +313,21 @@ def deleteRowCol {R : Type u} {n : Nat} (M : Matrix R (n + 1) (n + 1))
     (M : Matrix R (n + 1) (n + 1)) (row col : Fin (n + 1)) (i j : Fin n) :
     (deleteRowCol M row col)[i][j] = M[skipIndex row i][skipIndex col j] := by
   simp [deleteRowCol, ofFn]
+
+@[simp] theorem deleteRowCol_last_last {R : Type u} {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) :
+    deleteRowCol M (Fin.last n) (Fin.last n) =
+      leadingPrefix M n (Nat.le_succ n) := by
+  apply Vector.ext
+  intro i hi
+  apply Vector.ext
+  intro j hj
+  let ii : Fin n := ⟨i, hi⟩
+  let jj : Fin n := ⟨j, hj⟩
+  change (deleteRowCol M (Fin.last n) (Fin.last n))[ii][jj] =
+    (leadingPrefix M n (Nat.le_succ n))[ii][jj]
+  rw [deleteRowCol_entry]
+  simp [leadingPrefix, ofFn]
 
 /-- The alternating sign used in signed cofactors. -/
 def cofactorSign {R : Type u} [OfNat R 1] [Neg R] {n : Nat}
@@ -342,6 +362,14 @@ def cofactor {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     cofactor M row col = -det (deleteRowCol M row col) := by
   simp [cofactor, h]
   grind
+
+@[simp] theorem cofactor_last_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) :
+    cofactor M (Fin.last n) (Fin.last n) =
+      det (leadingPrefix M n (Nat.le_succ n)) := by
+  rw [cofactor_of_even]
+  · simp
+  · omega
 
 /-- The determinant of the empty leading prefix is the Bareiss previous-pivot
 convention `1`. -/

--- a/progress/20260511T172625Z_c7719c20.md
+++ b/progress/20260511T172625Z_c7719c20.md
@@ -1,0 +1,21 @@
+# Work session c7719c20 — HexMatrix Laplace decomposition
+
+## Accomplished
+
+- Claimed #3497, read the determinant/cofactor context, and decomposed the arbitrary Laplace scope into #3517 and #3518.
+- Claimed #3517 and added final-index cofactor helper lemmas in `HexMatrix/Determinant.lean`:
+  `skipIndex_last`, `deleteRowCol_last_last`, and `cofactor_last_last`.
+- Verified `lake build HexMatrix.Determinant`, `python3 scripts/check_dag.py`, `git diff --check`, and the requested banned-marker scan.
+
+## Current frontier
+
+- The final row/final column deletion-minor normalization now reduces to `leadingPrefix`, which is the local API used by the existing last-row determinant lemma.
+- The full last-column Laplace expansion remains to be proved from the recursive `permutationVectors` insertion machinery.
+
+## Next step
+
+- Continue #3517 by proving the inserted-last-column Leibniz term/product helper for arbitrary insertion row, then fold it over `permutationVectors`.
+
+## Blockers
+
+- None.

--- a/progress/20260511T194434Z_911cda8f.md
+++ b/progress/20260511T194434Z_911cda8f.md
@@ -1,0 +1,28 @@
+# Work session 911cda8f - repair PR #3521
+
+## Accomplished
+
+- Claimed PR #3521 for repair.
+- Diagnosed the PR as mergeable with passing CI build jobs and a stuck
+  `conformance` check.
+- Added an empty repair commit to refresh CI for the PR.
+- Verified `lake build HexMatrix.Determinant`, `lake build HexMatrix`,
+  `python3 scripts/status.py HexMatrix`, `python3 scripts/check_dag.py`,
+  `python3 scripts/conformance_targets.py --check`, `git diff --check
+  origin/main..HEAD`, and a targeted banned-marker scan of
+  `HexMatrix/Determinant.lean`.
+
+## Current frontier
+
+- PR #3521 branch `agent/c7719c20` is locally verified and ready to push.
+- `HexMatrix` still has the pre-existing `sorry` warning in
+  `HexMatrix/Bareiss.lean`; this repair did not touch it.
+
+## Next step
+
+- Push `agent/c7719c20` with `--force-with-lease` and mark PR #3521
+  salvaged.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Partial progress on #3517

Session: `c7719c20-03bf-4603-9c07-d37072a017df`

9b762a5 HexMatrix: normalize final cofactor minors

🤖 Prepared with Claude Code