### PR TITLE
feat: add general triangular determinant theorems

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -510,22 +510,81 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
       have hdiag := scaledCoeffRows_diag_eq_gramDet (b := b) r hr
       simpa [gramDetVec, data, gramDetVecFromScaledCoeffRows] using congrArg Int.toNat hdiag
 
-theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
+private theorem gramDet_eq_prod_normSq_core (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
   sorry
 
+private theorem leadingGramMatrixInt_det_nonneg_pre
+    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
+    0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) := by
+  let rowPrefix : Matrix Int t m :=
+    Matrix.ofFn fun i j =>
+      (b.row ⟨i.val, Nat.lt_of_lt_of_le i.isLt ht⟩)[j]
+  have hgram :
+      GramSchmidt.leadingGramMatrixInt b t ht =
+        Matrix.gramMatrix rowPrefix := by
+    apply Vector.ext
+    intro i hi
+    apply Vector.ext
+    intro j hj
+    simp [GramSchmidt.leadingGramMatrixInt, rowPrefix, Matrix.gramMatrix, Matrix.dot,
+      Matrix.row, Matrix.ofFn, GramSchmidt.liftFinLE]
+  rw [hgram]
+  exact Matrix.det_gramMatrix_nonneg rowPrefix
+
+private theorem gramDet_pos_core (b : Matrix Int n m)
+    (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
+    0 < gramDet b k hk := by
+  cases k with
+  | zero =>
+      omega
+  | succ r =>
+      have hrn : r < n := Nat.lt_of_succ_le hk
+      let last : Fin n := ⟨r, hrn⟩
+      have hsub : 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) last) :=
+        hli last
+      have hsub_eq :
+          Matrix.submatrix (Matrix.gramMatrix b) last =
+            GramSchmidt.leadingGramMatrixInt b (r + 1) hk := by
+        rw [Matrix.submatrix_eq_leadingPrefix]
+        rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+      have hdet_pos :
+          0 < Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) := by
+        simpa [hsub_eq] using hsub
+      have hdet_nat :
+          Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) =
+            Int.ofNat (gramDet b (r + 1) hk) := by
+        rw [gramDet, Matrix.bareiss_eq_det]
+        exact (Int.toNat_of_nonneg
+          (leadingGramMatrixInt_det_nonneg_pre b (r + 1) hk)).symm
+      have hnat_int : 0 < Int.ofNat (gramDet b (r + 1) hk) := by
+        simpa [hdet_nat] using hdet_pos
+      exact Int.ofNat_lt.mp hnat_int
+
+private theorem basis_normSq_core (b : Matrix Int n m)
+    (hli : independent b) (k : Nat) (hk : k < n) :
+    Vector.normSq ((basis b).row ⟨k, hk⟩) =
+      (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
+        (gramDet b k (Nat.le_of_lt hk) : Rat) := by
+  sorry
+
+theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
+    (hli : independent b) (k : Nat) (hk : k ≤ n) :
+    (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
+  exact gramDet_eq_prod_normSq_core b hli k hk
+
 theorem gramDet_pos (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by
-  sorry
+  exact gramDet_pos_core b hli k hk hk'
 
 theorem basis_normSq (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k < n) :
     Vector.normSq ((basis b).row ⟨k, hk⟩) =
       (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
         (gramDet b k (Nat.le_of_lt hk) : Rat) := by
-  sorry
+  exact basis_normSq_core b hli k hk
 
 theorem scaledCoeffs_eq (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < i) :

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -1966,6 +1966,60 @@ theorem det_upperTriangular_pos_diag
       exact Int.mul_pos (ih (leadingPrefix M n (Nat.le_succ n)) hprefixZero hprefixDiag)
         (hdiag (Fin.last n))
 
+/-- The determinant of an upper-triangular square matrix (entries below the
+diagonal are zero) over a commutative ring is the product of its diagonal
+entries, expressed via a `Fin.foldl` over the diagonal indices. -/
+theorem det_upperTriangular_eq_finFoldl_diag
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
+    (hzero : ∀ i j : Fin n, j.val < i.val → M[i][j] = 0) :
+    det M = Fin.foldl n (fun acc i => acc * M[i][i]) 1 := by
+  induction n with
+  | zero =>
+      simp only [Fin.foldl_zero]
+      simp [det, permutationVectors, detTerm, detSign, detProduct, emptyVec,
+        inversionCount]
+      grind
+  | succ n ih =>
+      have hrow : ∀ j : Fin (n + 1), j.val < n → M[Fin.last n][j] = 0 := by
+        intro j hj
+        exact hzero (Fin.last n) j hj
+      rw [det_eq_det_leadingPrefix_mul_last_of_last_row_zero M hrow]
+      have hprefixZero :
+          ∀ i j : Fin n, j.val < i.val →
+            (leadingPrefix M n (Nat.le_succ n))[i][j] = 0 := by
+        intro i j hij
+        let ii : Fin (n + 1) := ⟨i.val, by omega⟩
+        let jj : Fin (n + 1) := ⟨j.val, by omega⟩
+        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][j] = M[ii][jj] := by
+          simp [leadingPrefix, ofFn, ii, jj]
+        rw [hentry]
+        exact hzero ii jj hij
+      rw [ih (leadingPrefix M n (Nat.le_succ n)) hprefixZero]
+      -- The (n+1)-length Fin.foldl over diagonals splits as the n-length foldl
+      -- times the last diagonal entry.
+      rw [Fin.foldl_succ_last]
+      -- Rewrite the leading prefix diagonal entries as M[i.castSucc][i.castSucc].
+      have hcongr :
+          Fin.foldl n
+              (fun acc i => acc * (leadingPrefix M n (Nat.le_succ n))[i][i]) 1 =
+            Fin.foldl n (fun acc i => acc * M[i.castSucc][i.castSucc]) 1 := by
+        rw [Fin.foldl_eq_foldl_finRange, Fin.foldl_eq_foldl_finRange]
+        apply foldl_acc_congr
+        intro acc i _hmem
+        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][i] = M[i.castSucc][i.castSucc] :=
+          by simp [leadingPrefix, ofFn, Fin.castSucc]
+        rw [hentry]
+      rw [hcongr]
+
+/-- The determinant of an upper-triangular square matrix as a `List.foldl`
+product over the diagonal indices in `Fin.finRange`. -/
+theorem det_upperTriangular_eq_foldl_diag
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
+    (hzero : ∀ i j : Fin n, j.val < i.val → M[i][j] = 0) :
+    det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
+  rw [det_upperTriangular_eq_finFoldl_diag M hzero]
+  rw [Fin.foldl_eq_foldl_finRange]
+
 private theorem detTerm_identity_insertAt_last {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) :
     detTerm (1 : Matrix R (n + 1) (n + 1))

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -4602,6 +4602,40 @@ theorem det_transpose {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 := by
         exact permutationVectors_inverseVector_sum (R := R) (n := n) (fun perm => detTerm M perm)
 
+/-- Diagonal-product formula for the determinant of a lower-triangular matrix
+(entries above the diagonal are zero). Derived from the upper-triangular form
+via `det_transpose`. -/
+theorem det_lowerTriangular_eq_finFoldl_diag
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
+    (hzero : ∀ i j : Fin n, i.val < j.val → M[i][j] = 0) :
+    det M = Fin.foldl n (fun acc i => acc * M[i][i]) 1 := by
+  rw [← det_transpose M]
+  have htransposeZero :
+      ∀ i j : Fin n, j.val < i.val → M.transpose[i][j] = 0 := by
+    intro i j hij
+    have hentry : M.transpose[i][j] = M[j][i] := by
+      simp [transpose, col]
+    rw [hentry]
+    exact hzero j i hij
+  rw [det_upperTriangular_eq_finFoldl_diag M.transpose htransposeZero]
+  have hdiag : ∀ i : Fin n, M.transpose[i][i] = M[i][i] := by
+    intro i
+    simp [transpose, col]
+  -- Rewrite the foldl over `M.transpose[i][i]` to `M[i][i]`.
+  rw [Fin.foldl_eq_foldl_finRange, Fin.foldl_eq_foldl_finRange]
+  apply foldl_acc_congr
+  intro acc i _hmem
+  rw [hdiag]
+
+/-- The determinant of a lower-triangular square matrix as a `List.foldl`
+product over the diagonal indices in `Fin.finRange`. -/
+theorem det_lowerTriangular_eq_foldl_diag
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
+    (hzero : ∀ i j : Fin n, i.val < j.val → M[i][j] = 0) :
+    det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
+  rw [det_lowerTriangular_eq_finFoldl_diag M hzero]
+  rw [Fin.foldl_eq_foldl_finRange]
+
 /-- Permuting columns multiplies the determinant by the sign of the column permutation. -/
 theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (sigma : Vector (Fin n) n)

--- a/progress/2026-05-11T18-18-43Z_46d10b68.md
+++ b/progress/2026-05-11T18-18-43Z_46d10b68.md
@@ -1,0 +1,23 @@
+# Work session 46d10b68 — issue #3542
+
+## Accomplished
+
+- Claimed issue #3542 after all visible human-oversight directives were blocked or marked for replan.
+- Read the HexGramSchmidt/HexLLL SPEC context and Phase 5 conventions.
+- Refactored the three public Gram determinant/norm bridge holes through private prerequisite lemmas.
+- Discharged `GramSchmidt.Int.gramDet_pos` by transporting `independent` from `Matrix.submatrix` to the leading Gram matrix and casting the nonnegative Bareiss determinant back to `Nat`.
+- Verified `lake build HexGramSchmidt.Int`, `lake build HexGramSchmidt`, `python3 scripts/check_dag.py`, `git diff --check`, and the targeted banned-marker scan.
+
+## Current frontier
+
+- `GramSchmidt.Int.gramDet_pos` is now proved.
+- The remaining core proof boundary is the leading Gram determinant/product-of-squared-norms identity and the norm-ratio theorem depending on it.
+
+## Next step
+
+- Prove `gramDet_eq_prod_normSq_core` by adding the triangular change-of-basis determinant bridge between the leading integer Gram matrix and the orthogonal Gram-Schmidt basis Gram matrix.
+- Then derive `basis_normSq_core` from the product identity at `k` and `k + 1`.
+
+## Blockers
+
+- None technical; the issue is only partially completed because the determinant/product bridge is a larger algebra lemma than fit this session.

--- a/progress/20260511T185634Z_c3afc9bf.md
+++ b/progress/20260511T185634Z_c3afc9bf.md
@@ -1,0 +1,36 @@
+# Work session c3afc9bf — issue #3565 (partial)
+
+## Accomplished
+
+- Claimed #3565 (HexGramSchmidt: prove triangular GS determinant product bridge).
+- Cherry-picked predecessor PR #3551's `gramDet_pos` refactor onto this branch.
+- Added foundational triangular-determinant theorems over a general
+  `CommRing` to `HexMatrix/Determinant.lean`:
+  - `Matrix.det_upperTriangular_eq_finFoldl_diag` and
+    `Matrix.det_upperTriangular_eq_foldl_diag` for matrices with zero
+    entries below the diagonal.
+  - `Matrix.det_lowerTriangular_eq_finFoldl_diag` and
+    `Matrix.det_lowerTriangular_eq_foldl_diag`, derived from the
+    upper-triangular form via `det_transpose`.
+- Created sub-issue #3575 owning the residual proof of
+  `gramDet_eq_prod_normSq_core`.
+
+## Current frontier
+
+- The triangular determinant helpers compile cleanly and are immediately
+  usable downstream.
+- The main bridge theorem `gramDet_eq_prod_normSq_core` remains `sorry`;
+  #3575 owns it with a concrete proof strategy (column-op reduction to
+  the lower-triangular auxiliary matrix `M_final[i][j] = ⟨b_i, b*_j⟩`).
+
+## Next step
+
+- A worker claims #3575 and writes the col-op reduction proof using
+  the new `det_lowerTriangular` lemma.
+
+## Blockers
+
+- None technical; the issue is partially completed because the
+  remaining matrix-level algebra (iterated column-replacement
+  invariance and the cast bridge from `Int` Gram determinant to `Rat`)
+  is substantial enough to warrant its own focused session.

--- a/progress/20260511T211415Z_3f7954f1.md
+++ b/progress/20260511T211415Z_3f7954f1.md
@@ -1,0 +1,20 @@
+# Work session 3f7954f1 — repair PR #3576
+
+## Accomplished
+
+- Claimed PR #3576 for repair after `coordination list-pr-repair` reported it as a stuck PR.
+- Checked out `agent/c3afc9bf` and diagnosed the PR as mergeable, with `build` and `build-macos` passing and only `conformance` stuck in progress.
+- Verified `lake build HexMatrix HexGramSchmidt`, `lake build`, `python3 scripts/status.py HexMatrix`, `python3 scripts/status.py HexGramSchmidt`, `python3 scripts/check_dag.py`, `python3 scripts/conformance_targets.py --check`, `git diff --check`, and a targeted banned-marker scan over the touched Lean libraries.
+
+## Current frontier
+
+- PR #3576 is locally verified and only needs a fresh pushed commit to retrigger the stuck conformance workflow.
+- The only session-authored source change is this progress entry; the pre-existing `.claude/CLAUDE.md` worktree modification was left untouched.
+
+## Next step
+
+- Commit this progress entry, push `agent/c3afc9bf` with `--force-with-lease`, and mark PR #3576 salvaged.
+
+## Blockers
+
+- None.

--- a/progress/20260512T010449Z_repair3576.md
+++ b/progress/20260512T010449Z_repair3576.md
@@ -1,0 +1,29 @@
+# Work session 8a9069e2 — repair PR #3576
+
+## Accomplished
+
+- Claimed PR #3576 for repair after `coordination list-pr-repair` reported it
+  as the top stuck candidate.
+- Checked out `agent/c3afc9bf` and confirmed the PR is mergeable, with remote
+  CI still stuck on old queued/in-progress jobs rather than a reported project
+  failure.
+- Re-ran local verification:
+  - `python3 scripts/check_dag.py`
+  - `python3 scripts/conformance_targets.py --check`
+  - `git diff --check`
+  - `lake build HexMatrix HexGramSchmidt`
+  - `lake build`
+
+## Current frontier
+
+- PR #3576 remains locally verified and mergeable.
+- The repair action is a fresh progress/retry commit to retrigger the stuck
+  GitHub Actions run.
+
+## Next step
+
+- Push `agent/c3afc9bf` with `--force-with-lease` and mark PR #3576 salvaged.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Partial progress on #3565

Session: `c3afc9bf-bba5-41a3-a446-d0e2012afe8c`

48b15b3 chore: add progress entry for partial c3afc9bf session
726e40b feat: add det_lowerTriangular_eq_foldl_diag over CommRing
aa5d695 feat: add general det_upperTriangular over CommRing
ee5b7cc feat: prove GramSchmidt gramDet positivity

🤖 Prepared with Claude Code