### PR TITLE
HexPolyMathlib: certify Phase 5 completion and bump

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -289,7 +289,7 @@ libraries:
   HexPolyMathlib:
     deps: [HexPoly]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
     phase4:
       input_families:

--- a/progress/20260512T004649Z_40c1e07a.md
+++ b/progress/20260512T004649Z_40c1e07a.md
@@ -1,0 +1,23 @@
+# Work session 40c1e07a — HexPolyMathlib Phase 5 certification
+
+## Accomplished
+
+- Claimed issue #3645.
+- Re-read the governing HexPolyMathlib/HexPoly SPEC files and Phase 5 conventions.
+- Verified `HexPolyMathlib` has no `axiom`, `native_decide`, `TODO`, `FIXME`, or `sorry` matches under the requested scan.
+- Verified `lake build HexPolyMathlib`, `python3 scripts/check_dag.py`, and `git diff --check`.
+- Advanced `libraries.yml` `HexPolyMathlib.done_through` from `4` to `5`.
+- Confirmed `python3 scripts/status.py HexPolyMathlib` now reports Phase 6.
+
+## Current frontier
+
+- `HexPolyMathlib` is certified complete through Phase 5 and ready for Phase 6 proof polishing.
+- No bridge theorem statements, conformance files, benchmark registrations, or executable DensePoly semantics were changed.
+
+## Next step
+
+- Create the PR for issue #3645.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #3645

Session: `40c1e07a-0405-4933-a2fa-cce240ce700b`

3b5c6c1 chore: certify HexPolyMathlib phase 5

🤖 Prepared with Claude Code