### PR TITLE
spec: comparator-fairness and trend-anchoring amendment

### DIFF
--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -326,13 +326,34 @@ classification below is mirrored as structured metadata in
   gap is the right yardstick for Phase 4.
 
   **Performance goal:** Lean LLL is **at least as fast as the
-  verified Isabelle LLL** on shared canonical inputs at the bottom
-  of each `phase4.input_families` parameter ladder. The headline
-  report at `reports/hex-lll-performance.md` records the measured
-  ratios per family and states whether the goal is met; failure
-  to meet the goal is an audit-found Concern per
+  verified Isabelle LLL** on shared canonical inputs, evaluated at
+  the largest eligible rung of each `phase4.input_families` parameter
+  ladder per
+  [SPEC/benchmarking.md §Headline reports — Comparator ratios](../benchmarking.md#headline-reports).
+  "Eligible" is the rung range between the comparator-overhead-
+  dominance floor and the per-call wallclock ceiling (10 s hard,
+  1 s soft) defined there. The headline report at
+  `reports/hex-lll-performance.md` records measured ratios across
+  the full ladder, with raw and overhead-adjusted values; bottom-rung
+  ratios are reported for context but do not constitute the verdict.
+  An adverse trend (Lean steadily losing ground as the parameter
+  grows) is itself an audit-found Concern per
   [PLAN/Conventions.md §Bench-found, conformance-found, and
-  audit-found issues](../../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues).
+  audit-found issues](../../PLAN/Conventions.md#bench-found-conformance-found-and-audit-found-issues),
+  even when the highest-rung verdict happens to pass.
+
+  **Comparator-call protocol.** Both `fpLLL via fpylll` and
+  `verified Isabelle LLL` are wired as persistent subprocesses per
+  [SPEC/benchmarking.md §External comparators — Process call](../benchmarking.md#external-comparators):
+  one subprocess per comparator per `lake exe hexlll_bench run`,
+  looping on stdin. Per-call overhead is measured for each
+  comparator and recorded in
+  `reports/hex-lll-performance.md §"Comparator ratios"`. Ratios
+  are reported across the full (potentially densified) parameter
+  ladder of each input family, with both raw and overhead-adjusted
+  values where the thresholds in
+  [§Headline reports — Comparator ratios](../benchmarking.md#headline-reports)
+  apply.
 
 ### `LLLState.ofBasis` is its own bench target
 

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -269,19 +269,46 @@ Two integration patterns:
   produces no extern resolution. The same `@[extern]` boundary
   rules from [Conventions.md](../PLAN/Conventions.md) apply.
 - **Process call, acceptable when FFI isn't viable.** The external
-  tool is scripted (Sage, python-flint, GAP, PARI) or the per-call
-  cost is large enough that process-spawn overhead is negligible.
-  Use `setup_fixed_benchmark` with an `IO α` body that shells out,
-  parses the output, and returns it. This covers both single
-  canonical-input comparisons *and* "swept" process-call
-  comparisons, by registering one `setup_fixed_benchmark` per
-  parameter value (e.g. `Hex.LLL.fpLLL.dim10`,
-  `Hex.LLL.fpLLL.dim20`, `Hex.LLL.fpLLL.dim30`) — the parametric
-  `setup_benchmark` form itself takes `Nat → α`, not `Nat → IO α`,
-  so the per-rung-fixed pattern is the canonical workaround. If a
-  true `Nat → IO α` parametric form matters more than the
-  per-rung-fixed encoding, file an issue against lean-bench rather
-  than rolling a hex-local harness.
+  tool is scripted (Sage, python-flint, GAP, PARI) or has a foreign
+  runtime that doesn't interop cleanly with Lean's RTS. Use
+  `setup_fixed_benchmark` with an `IO α` body that drives the
+  comparator. This covers both single canonical-input comparisons
+  *and* "swept" process-call comparisons, by registering one
+  `setup_fixed_benchmark` per parameter value (e.g.
+  `Hex.LLL.fpLLL.dim10`, `Hex.LLL.fpLLL.dim20`,
+  `Hex.LLL.fpLLL.dim30`) — the parametric `setup_benchmark` form
+  itself takes `Nat → α`, not `Nat → IO α`, so the per-rung-fixed
+  pattern is the canonical workaround. If a true `Nat → IO α`
+  parametric form matters more than the per-rung-fixed encoding,
+  file an issue against lean-bench rather than rolling a hex-local
+  harness.
+
+  Process-call comparator wiring carries three contract clauses:
+
+  - **Measure overhead.** Every process-call comparator records a
+    per-call overhead measurement in
+    `reports/<lib>-performance.md §"Comparator ratios"`. Methodology:
+    time the comparator binary on a trivial input whose algorithmic
+    work is sub-millisecond; report the median across enough runs to
+    be stable. This figure is subtracted from per-call wall times
+    before reporting ratios per
+    [§Headline reports — Comparator ratios](#headline-reports).
+  - **Persistent-subprocess is the preferred shape when overhead is
+    non-negligible.** Wrap the comparator in a driver that loops on
+    stdin (one problem per request, length- or delimiter-framed)
+    and emits answers on stdout. The bench harness spawns the
+    driver once per `lake exe hexfoo_bench run` invocation and
+    reuses the file descriptors across calls, amortising one process
+    startup across all comparator calls in that registration.
+    Document the protocol in the bench module docstring.
+  - **Per-call process spawn is acceptable only as a last resort.**
+    FFI is preferred when feasible; persistent-subprocess is the
+    fallback when FFI isn't viable. Per-call process spawn (the
+    pattern where each `setup_fixed_benchmark` body shells out
+    afresh) is acceptable only when both above are infeasible *and*
+    the per-call algorithmic work is large enough that the measured
+    per-call overhead falls below the adjustment threshold defined
+    in [§Headline reports — Comparator ratios](#headline-reports).
 
 Where a SPEC asks for a comparison lean-bench cannot directly model,
 file the gap as a feature request against lean-bench. Do not invent
@@ -549,11 +576,64 @@ The report contains five subsections:
    median per-call time and observed-hash agreement.
 3. **Comparator ratios.** Each comparator named in the per-library
    SPEC ([§Comparator naming](#comparator-naming)) — `gating` and
-   `informational` alike — with a measured ratio at the bottom of
-   the parameter ladder for parametric registrations, or on the
-   canonical input for fixed registrations. A short narrative
-   paragraph interprets the ratios: what is comfortable, what is
-   not, and why.
+   `informational` alike — with measured ratios across the full
+   parameter ladder (parametric registrations) or every canonical
+   input (fixed-benchmark families), and a narrative paragraph
+   naming the trend across rungs. A single number anchored at the
+   bottom is structurally flattering to whichever side has the
+   better startup characteristics; what's needed is a curve across
+   the eligible range. Five clauses, all binding on the report:
+
+   - **Define eligible range.** A rung is *eligible* for the
+     gating-goal verdict when both: (a) the comparator's per-call
+     overhead is ≤ 50% of measured wall time on that rung — below
+     this floor the rung is a process-startup measurement, not an
+     algorithm one; and (b) per-call wall time is ≤ 10 s hard /
+     ≤ 1 s soft — exceed the soft target only when needed to give
+     the trend enough range to read cleanly, and never exceed the
+     hard ceiling. The eligible range for a `gating` verdict is the
+     intersection of these floor and ceiling constraints.
+
+   - **Ratios across the full ladder, with adjusted values inside
+     the eligible range.** The §"Comparator ratios" subsection
+     records the measured ratio at every shared rung of the
+     parametric schedule (or every canonical input for
+     fixed-benchmark families). Per-call overhead is measured once
+     per process-call comparator per
+     [§External comparators — Process call](#external-comparators)
+     and shown as one line per comparator. On any rung where overhead
+     exceeds 5% of measured wall time, both the raw ratio and the
+     overhead-adjusted ratio (comparator wall time minus overhead,
+     then divide) are recorded. Rungs outside the eligible range
+     are reported for completeness only.
+
+   - **Enough rungs inside the eligible range to see a trend.** Two
+     or three points are at best a single slope; the ratio's shape
+     across the eligible range — flat, climbing, accelerating,
+     decelerating — must be unambiguous from the data alone. A
+     doubling-only parameter schedule typically does not provide
+     enough eligible rungs; the ladder is densified with in-fill
+     rungs between existing points, never extended past the
+     wallclock ceiling. The headline report records the actual
+     ladder (including in-fill) so a reader sees what was measured,
+     not just the family's default.
+
+   - **Trend narrative and adverse-trend Concerns.** The
+     §"Comparator ratios" subsection includes a paragraph naming
+     the trend, with reference to the rungs that establish it. The
+     baseline shape is a ratio that converges to a small constant
+     past the regime where startup or fixed costs dominate; a
+     diverging trend (one side steadily losing ground as the
+     parameter grows) is itself an audit-found Concern even when
+     the highest-rung verdict happens to pass, linked from the
+     §"Concerns" subsection.
+
+   - **Gating-goal verdict at the top eligible rung.** When the
+     per-library SPEC states a performance goal against a `gating`
+     comparator, the verdict is computed at the largest-parameter
+     eligible rung of each input family. The bottom rung is
+     reported for context; it is never the rung that meets or
+     fails the goal.
 4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
    one representative case per `phase4.input_families`. Dominant
    inclusive costs are named and explained, with leaf cost
@@ -698,6 +778,28 @@ explicitly forbidden:
   inside an `LLLState.ofBasis` prep step that is itself
   sized in `n` — that step is its own asymptotically significant
   phase and needs its own registration.
+- **Comparator process overhead reported as algorithmic difference.**
+  Per-call subprocess on inputs small enough that startup dominates
+  the comparator's wall time is a measurement-shape problem, not an
+  algorithmic one. Recognisable in a headline report by a comparator
+  ratio of multiple orders of magnitude at the smallest rungs that
+  collapses to a small constant factor at larger rungs — the
+  small-rung gap is process startup, not algorithm. Fix per
+  [§External comparators — Process call](#external-comparators) and
+  [§Headline reports — Comparator ratios](#headline-reports):
+  persistent-subprocess (or FFI) protocol, or explicit per-call
+  overhead subtraction. The raw ratio is never published without that
+  adjustment when overhead is non-negligible.
+- **Bottom-rung-only comparator evaluation.** Declaring a `gating`
+  comparator goal met on the basis of the bottom-of-ladder ratio
+  alone hides asymptotic shape: two same-algorithm implementations
+  can show wildly different bottom-rung ratios driven by startup and
+  constant-factor differences while diverging steadily at larger
+  parameters; the bottom rung is the rung most flattering to
+  whichever side has the better warm-up. The verdict is evaluated
+  at the largest eligible rung across enough in-fill rungs to see
+  the trend, per
+  [§Headline reports — Comparator ratios](#headline-reports).
 
 Every `setup_benchmark` registration must carry an adjacent comment
 deriving its `n => …` from the algorithm: which step dominates, and


### PR DESCRIPTION
This PR amends the Phase-4 doctrine to close two compounding bugs surfaced by an audit of HexLLL's headline report.

**Bug 1 — process-spawn overhead inflates small-n comparator ratios.** The Isabelle comparator in HexLLL is wired via per-call subprocess; GHC startup + file parse is ~22 ms fixed, while the Lean side is in-process. On sub-millisecond inputs the comparator ratio measures "Lean function call vs Isabelle subprocess invocation", not "Lean LLL vs Isabelle LLL". The existing §"Process call" caveat ("the per-call cost is large enough that process-spawn overhead is negligible") wasn't operationalised; a clean-room re-implementation would make the same mistake. This PR turns the caveat into a contract: process-call comparators measure and record per-call overhead, persistent-subprocess is the preferred shape when overhead is non-negligible, and per-call process spawn is a last resort acceptable only when measured overhead is below the headline report's adjustment threshold.

**Bug 2 — gating-goal verdicts anchored at the wrong rung.** The previous §"Headline reports" specified "a measured ratio at the bottom of the parameter ladder", and the per-library SPEC echoed it. The bottom rung is structurally the most flattering rung to whichever side has the better startup, and same-algorithm implementations can show wildly different bottom-rung ratios while diverging steadily at larger parameters. The amendment rewrites §"Comparator ratios" to require ratios across the full ladder, defines an explicit eligible range (per-call overhead ≤ 50% of measured wall time, per-call wall time ≤ 10 s hard / 1 s soft), mandates enough rungs inside the eligible range to read the trend unambiguously (in-fill rungs between doublings when needed, never past the ceiling), and evaluates the gating-goal verdict at the largest eligible rung. Adverse trends are themselves audit-found Concerns even when the highest-rung verdict passes.

Two new anti-patterns are added: "Comparator process overhead reported as algorithmic difference" and "Bottom-rung-only comparator evaluation". `SPEC/Libraries/hex-lll.md`'s performance goal is rewritten to evaluate at the largest eligible rung per the new generic rule and to wire both `fpLLL via fpylll` and `verified Isabelle LLL` as persistent subprocesses.

This is a doctrine-only PR. Matching repair work for HexLLL — rolling back `done_through`, switching to persistent-subprocess comparators, regenerating the headline report with the densified ladder — lands via human-oversight issues HO-15..HO-19 queued separately. Today's re-measurement (n=120 random-bounded shows Lean already ~1.12× slower than Isabelle inside the eligible range; harsh-cubic trend climbs 0.04 → 0.48 → 1.14 over {15, 30, 45}) suggests HexLLL's gating-goal claim is likely not met at the top eligible rung of either family; HO-18 confirms once the persistent-subprocess harness is in place.

Cross-library audit conducted during planning: of the 15 libraries currently at `done_through: 4`, only HexLLL has any external comparator wired. The other 14 deliberately have no external comparator named in their per-library SPEC, so Bug 1 and Bug 2 structurally cannot apply to them. The HO-19 umbrella confirms this and will close with no per-library rollbacks; one minor secondary note recommends a trend-narrative refresh for `reports/hex-matrix-mathlib-performance.md`'s internal `compare` ratios.

🤖 Prepared with Claude Code