### PR TITLE
spec: comparator-coverage amendment to Phase-4 doctrine

### DIFF
--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -137,6 +137,15 @@ For library `hex-foo`, Phase 4 is done when:
   phase4.comparators` is wired and the headline report records its
   measured ratio; `informational` comparators record ratios but do
   not gate;
+- the per-library SPEC's external-comparator declarations are
+  complete per
+  [SPEC/benchmarking.md §"Comparator naming"](../SPEC/benchmarking.md#comparator-naming):
+  every required comparator is named with its class (optionally
+  scoped per bench target), or the absence is declared with exactly
+  one of the five enumerated reasons (`implementation-is-extern`,
+  `structural-layer`, `input-source-only`, `mathlib-bridge`,
+  `no-comparable-surface-in-named-comparator`). Missing declarations
+  block Phase-4 completion;
 - the [Attribution rule](../SPEC/benchmarking.md#the-attribution-rule)
   is satisfied: every dominant profiled cost maps to a registered
   bench target, or the per-library SPEC documents why the cost

--- a/SPEC/Libraries/hex-arith.md
+++ b/SPEC/Libraries/hex-arith.md
@@ -471,3 +471,22 @@ externs; GMP itself is linked via
 other `@[extern]` GMP binding in Lean. If GMP is unavailable, the
 attachment falls through to `Hex.pureIntExtGcd` — correct, but
 slow on large inputs.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `implementation-is-extern` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexArith's bigint
+primitives — multiplication, addition, division, gcd, extended-gcd
+— are GMP-backed via `@[extern]` shims (`wide_arith.c`,
+`mpz_gcdext.c`). The Phase-4 surface is GMP itself; there is no
+algorithmically distinct reference implementation to compare
+against. Within-Lean alternative-implementation comparisons cover
+the surfaces where they exist: Barrett vs Montgomery modular
+multiplication is registered as a `compare` group in
+`HexArith/Bench.lean`, and the pure-Lean ExtGcd fallback is
+covered by the `compare` group against the GMP-backed
+`Hex.gmpIntExtGcd`. Those internal comparisons are the right
+shape for HexArith; an external tool would just be wrapping GMP
+again.

--- a/SPEC/Libraries/hex-berlekamp.md
+++ b/SPEC/Libraries/hex-berlekamp.md
@@ -68,3 +68,23 @@ hex-berlekamp-mathlib below for the proof strategy.
 - Isabelle AFP entry "Berlekamp_Zassenhaus"
   (Divason-Joosten-Thiemann-Yamada, 2016; JAR 2019). Browsable at
   `isa-afp.org/entries/Berlekamp_Zassenhaus.html`.
+
+## External comparators
+
+The four Phase-4 bench targets in `HexBerlekamp/Bench.lean` decompose
+into two surfaces with `gating` FLINT comparators and two surfaces
+with declared absence:
+
+| Bench target | Comparator | Class | Goal / reason |
+|---|---|---|---|
+| `runRabinTestChecksum` | FLINT `nmod_poly.is_irreducible` via python-flint | **gating** | Same boolean predicate (is `f` irreducible). FLINT may internally use square-free + distinct-degree rather than Rabin's `X^(p^k) mod f` schema; the input-output relation is identical and FLINT's speed is the right yardstick. Goal: Lean's `runRabinTestChecksum` is at least as fast as FLINT's `is_irreducible` at the largest eligible rung per `SPEC/benchmarking.md §"Headline reports" §"Comparator ratios"`. |
+| `runDistinctDegreeChecksum` | FLINT `nmod_poly.factor_distinct_deg` via python-flint | **gating** | Same operation, same standard algorithm class — the cleanest apples-to-apples bar in HexBerlekamp. Goal: Lean's `runDistinctDegreeChecksum` is at least as fast as FLINT's `factor_distinct_deg` at the largest eligible rung. |
+| `runBerlekampMatrixChecksum` | (none) | **no-comparable-surface-in-named-comparator** | The Frobenius matrix `Q_f - I` is constructed internally by FLINT's factorization pipeline but not exposed as a user-callable function. The bench target's declared-complexity verdict (`O(n²)` for fixed `p`) is its only Phase-4 evidence. |
+| `runBerlekampFactorChecksum` | (none) | **no-comparable-surface-in-named-comparator** | The split-step kernel `gcd(f, witness - c)` for `c ∈ F_p` is FLINT-internal. Same justification. |
+
+Both gating comparators are wired via a persistent-subprocess
+Python driver per `SPEC/benchmarking.md §"External comparators"
+§"Process call"`. The shared driver invocation pattern handles
+multiple FLINT comparator families.
+
+Structured metadata in `libraries.yml: HexBerlekamp.phase4.comparators`.

--- a/SPEC/Libraries/hex-conway.md
+++ b/SPEC/Libraries/hex-conway.md
@@ -142,3 +142,22 @@ determines how much of the table is committed.
 Conway polynomial is chosen automatically *when a committed entry is
 available*. For degrees outside the committed table, a separate explicit
 search API may be used.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `input-source-only` per
+`SPEC/benchmarking.md §"Comparator naming"`. The only published
+external reference for HexConway is Lübeck's Conway polynomial
+database, and that database is the **input source** rather than an
+executable comparator: HexConway verifies that committed table
+entries are irreducible (Tier 1) and additionally satisfy the
+primitivity / compatibility properties (Tier 2), and searches for
+missing entries (Tier 3). The search direction has no
+algorithmically distinct external implementation to race against —
+GAP exposes the same Lübeck data, not a separately-engineered
+search; and SageMath / FLINT either consume the same table or run
+ad-hoc search code that is not packaged as a benchmarkable API.
+The Phase-4 evidence is therefore the declared-complexity verdict
+of HexConway's own bench targets across the three tiers.

--- a/SPEC/Libraries/hex-gf2.md
+++ b/SPEC/Libraries/hex-gf2.md
@@ -136,3 +136,23 @@ The ring equivalences `GF2n ≃+* FiniteField 2 f hf hirr` and
 transferring via `GF2Poly ≃+* FpPoly 2`; that bridge library is also the
 home for `Fintype` and cardinality results about the packed
 representations.
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| NTL `GF2X` | informational | bench targets exercising packed-word GF(2)[x] arithmetic: addition, multiplication, division, GCD, modular reduction |
+
+NTL is the speed reference for hand-tuned `GF(2)[x]` arithmetic:
+its inner loops are optimised at the word level for carry-less
+multiplication, XOR-folding division, and fast GCD. Hex's
+packed-word representation is the same algorithmic shape but
+the constant factors differ. The comparator is `informational`.
+
+The wiring pattern (process-call driver vs `@[extern]` C++ shim
+vs hybrid) is an implementation choice for the HO that wires
+this comparator. The SPEC names NTL as the tool; the choice of
+integration shape is documented in the bench module docstring
+when the HO lands. Either pattern satisfies the SPEC.
+
+Structured metadata in `libraries.yml: HexGF2.phase4.comparators`.

--- a/SPEC/Libraries/hex-gfq-ring.md
+++ b/SPEC/Libraries/hex-gfq-ring.md
@@ -40,3 +40,23 @@ supports a field structure; that extension belongs to hex-gfq-field.
 - `reduceMod f (a + b) = reduceMod f (reduceMod f a + reduceMod f b)`
 - `reduceMod f (a * b) = reduceMod f (reduceMod f a * reduceMod f b)`
 - Ring axioms for `PolyQuotient p f hf`
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `fq_default` arithmetic via python-flint | informational | bench targets exercising quotient-ring arithmetic: addition, multiplication, reduction modulo `f` |
+
+FLINT's `fq_default` is the standard reference for finite-field
+quotient-ring arithmetic and covers the same operations:
+reduction modulo a fixed modulus polynomial, addition,
+multiplication. FLINT internally selects between
+representations (`fq_nmod` for word-size primes, `fq_zech` for
+small fields) via crossover heuristics that Hex does not
+replicate; the constant-factor gap is structural rather than
+algorithmic. Classification is `informational`.
+
+Wired via a persistent-subprocess Python driver per
+`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+
+Structured metadata in `libraries.yml: HexGfqRing.phase4.comparators`.

--- a/SPEC/Libraries/hex-gfq.md
+++ b/SPEC/Libraries/hex-gfq.md
@@ -42,3 +42,22 @@ writes `GF2q 8` and gets the optimized canonical `GF(2^8)` backed by
 packed bitwise arithmetic. For non-Conway models (e.g. AES's
 `x^8 + x^4 + x^3 + x + 1`), use `FiniteField` directly from
 hex-gfq-field or `GF2n`/`GF2nPoly` directly from hex-gf2.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `structural-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexGfq is a
+convenience wrapper that selects the Conway polynomial from
+HexConway and constructs `FiniteField p (conwayPoly p n) ...`
+using HexGfqField's generic quotient-field machinery (or
+`GF2q` via HexGF2's packed representation for `p = 2`). The
+runtime cost is dominated by the underlying quotient-field
+arithmetic, which is covered by HexGfqRing's external comparator
+declaration (FLINT `fq_default`, informational); the `GF2q` path
+is covered by HexGF2's external comparator declaration
+(NTL `GF2X`, informational). HexGfq itself contributes only the
+modulus-selection step, which is a Conway-table lookup and a
+constructor call — not an algorithmic surface that benefits from
+an independent external reference.

--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -160,3 +160,26 @@ Mathlib's `gramSchmidt` works over inner product spaces and does not
 track coefficients or update formulas, so it cannot be used in the
 computational core. The `hex-gram-schmidt-mathlib` bridge proves
 that `GramSchmidt.Int.basis` corresponds to Mathlib's `gramSchmidt`.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `structural-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexGramSchmidt is a
+structural layer over `HexMatrix`: the integer Gram-Schmidt
+construction is implemented via Bareiss-style fraction-free
+elimination on the Gram matrix (`Matrix.bareissNoPivotData`),
+which is HexMatrix's own architecturally-named surface and is
+covered by HexMatrix's external comparator declaration
+(`FLINT fmpz_mat_det`, scoped to the determinant surface).
+
+End-to-end coverage of the integer Gram-Schmidt construction as
+it appears in downstream consumers is via HexLLL's `gating`
+comparator (the verified Isabelle LLL Haskell extraction), which
+exercises `LLLState.ofBasis` — itself a thin wrapper around the
+GS construction — under its end-to-end ratio measurement. No
+distinct external tool exposes an integer Gram-Schmidt
+construction at the level of abstraction HexGramSchmidt operates
+on; the within-Lean linkage to HexMatrix and HexLLL covers the
+coverage gap.

--- a/SPEC/Libraries/hex-hensel.md
+++ b/SPEC/Libraries/hex-hensel.md
@@ -251,3 +251,31 @@ quadratic lifting as the hot path, under the iteration-count and
 `k`-coverage rules in the previous subsections. Treating quadratic
 lifting as "later" is incompatible with the polynomial-time complexity
 model declared for the Berlekamp–Zassenhaus pipeline.
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `nmod_poly_hensel_lift_*` via python-flint | informational | bench targets exercising single-step and iterated Hensel lifting of factor pairs over `Z_{p^k}` |
+
+FLINT exposes a family of Hensel-lift functions
+(`nmod_poly_hensel_lift_once_preinv`, `nmod_poly_hensel_lift`,
+`nmod_poly_hensel_continue_lift`) that perform the same Newton-style
+quadratic lift Hex implements. The concrete framings differ —
+FLINT exposes single-step and incremental APIs while Hex exposes
+linear / quadratic / multifactor entry points — but the underlying
+operation is the same and FLINT's tuned implementation is a useful
+speed reference.
+
+Classification is **fixed informational**, not a deferred decision.
+The constant-factor gap reflects FLINT's word-level operand
+tuning and its `preinv` precomputation that Hex doesn't currently
+exploit; a future gating upgrade requires a separate SPEC PR
+identifying a narrower comparable kernel (e.g. single-step lift
+with preinv on canonical inputs) and is not delegated to an HO
+implementer.
+
+Wired via a persistent-subprocess Python driver per
+`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+
+Structured metadata in `libraries.yml: HexHensel.phase4.comparators`.

--- a/SPEC/Libraries/hex-matrix.md
+++ b/SPEC/Libraries/hex-matrix.md
@@ -199,3 +199,29 @@ Proof strategy for `nullspace_complete`:
 
 4. **Package.** The entry-wise equality gives
    `E.nullspaceMatrix * c = v`.
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `fmpz_mat_det` via python-flint | informational | determinant-surface bench targets only (`runBareissDet` and equivalents) |
+
+FLINT's `fmpz_mat_det` is a structurally distinct reference for
+integer matrix determinant: FLINT uses multimodular reduction
+(determinant modulo many small primes, then CRT) which has
+different asymptotic and constant-factor profile from Bareiss
+fraction-free elimination. The comparator is `informational`:
+the ratio is recorded for orientation but is not a Phase-4 gate.
+Wired via a persistent-subprocess Python driver per
+`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+
+The library's other Phase-4 surfaces (matrix multiplication, row
+operations, transposition, slicing) have no external comparator
+named. They declare absence with the **structural-layer** reason
+per `SPEC/benchmarking.md §"Comparator naming"`: those surfaces
+are GMP-backed `Int` arithmetic on `Vector` / `Array` primitives,
+and the determinant comparator covers the only matrix-specific
+algorithmic surface where an external reference adds meaningful
+orientation.
+
+Structured metadata in `libraries.yml: HexMatrix.phase4.comparators`.

--- a/SPEC/Libraries/hex-mod-arith.md
+++ b/SPEC/Libraries/hex-mod-arith.md
@@ -171,3 +171,22 @@ exists to put the value in a `UInt64` and route every operation
 through native machine arithmetic, with `mul` going through the
 mandatory C extern above and the rest compiling to native UInt64
 ops in pure Lean.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `implementation-is-extern` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexModArith's modular
+operations route through GMP (for `Nat`/`Int` residue arithmetic)
+or through the dedicated `UInt64`-modular C extern (for `ZMod64`).
+The Phase-4 surface is GMP / native arithmetic; there is no
+algorithmically distinct reference implementation to compare
+against externally.
+
+The architecturally important within-Lean comparison — Barrett
+versus Montgomery modular multiplication — is registered as a
+`compare` group in `HexModArith/Bench.lean` (per
+`SPEC/benchmarking.md §"Within-Lean comparisons"`). That
+comparison is the right shape for this library; an external tool
+would just be wrapping the same underlying word-level operations.

--- a/SPEC/Libraries/hex-poly-mathlib.md
+++ b/SPEC/Libraries/hex-poly-mathlib.md
@@ -8,3 +8,20 @@ def equiv [CommRing R] [DecidableEq R] : DensePoly R ≃+* Polynomial R
 ```
 
 Also proves GCD/ExtGCD correspondence with Mathlib's `Polynomial.gcd`.
+
+## External comparators
+
+No external comparator is required.
+
+**Justification:** `mathlib-bridge` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexPolyMathlib is the
+bridge from `Hex.DensePoly` to `Mathlib.Polynomial`; the relevant
+comparison surface is the within-Lean `compare` group registering
+Hex bridge targets against Mathlib's native polynomial-arithmetic
+targets, per
+`SPEC/benchmarking.md §"Within-Lean comparisons"`. Those
+within-Lean compare groups exercise the same operations on
+matched inputs and verify hash agreement; that is the relevant
+shape of comparison for a Mathlib bridge. External tools (FLINT
+etc.) would compare against the underlying polynomial arithmetic,
+which is HexPoly's surface and is covered there.

--- a/SPEC/Libraries/hex-poly-z.md
+++ b/SPEC/Libraries/hex-poly-z.md
@@ -74,3 +74,19 @@ Used by downstream irreducibility predicates (in
 unit-ness in `ℤ[x]`. The Mathlib bridge
 `Hex.ZPoly.IsUnit f ↔ IsUnit (toPolynomial f)` lives in
 `hex-poly-z-mathlib`.
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `fmpz_poly` via python-flint | informational | bench targets exercising arithmetic on `ZPoly` (the integer-polynomial surface inherited from `HexPoly`) |
+
+Same comparator and rationale as `hex-poly` (informational because
+of FLINT's tuned Karatsuba/Toom-Cook/FFT crossovers vs Hex's
+schoolbook + Karatsuba implementation). The Mignotte / Hensel-lift
+data surfaces specific to `hex-poly-z` have no direct FLINT
+analog at the same level of abstraction; those bench targets
+declare absence with the `no-comparable-surface-in-named-comparator`
+reason per `SPEC/benchmarking.md §"Comparator naming"`.
+
+Structured metadata in `libraries.yml: HexPolyZ.phase4.comparators`.

--- a/SPEC/Libraries/hex-poly.md
+++ b/SPEC/Libraries/hex-poly.md
@@ -52,3 +52,22 @@ theorem polyCRT_mod_snd [CommRing R] [DecidableEq R]
 Given coprime `a, b` with Bezout coefficients `s, t`, constructs `h`
 with `h ≡ u (mod a)` and `h ≡ v (mod b)`. Used by hex-hensel,
 hex-gfq-ring, and hex-berlekamp-mathlib (Berlekamp correctness proof).
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `fmpz_poly` via python-flint | informational | all `setup_benchmark` registrations against integer polynomial inputs |
+
+FLINT's `fmpz_poly` is the standard reference for univariate
+integer polynomial arithmetic. The comparator is `informational`
+rather than `gating`: FLINT tunes Karatsuba/Toom-Cook/FFT
+crossovers in `fmpz_poly_mul` and uses non-recursive Newton-style
+algorithms for division and GCD; Hex's implementation is
+schoolbook with the Karatsuba crossover named in the algorithm
+table above. The constant-factor gap is structural, not
+algorithmic — the ratio is recorded for orientation but is not a
+Phase-4 gate. Wired via a persistent-subprocess Python driver per
+`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+
+Structured metadata in `libraries.yml: HexPoly.phase4.comparators`.

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -348,6 +348,39 @@ Phase 4 is blocked until every `gating` comparator is wired and
 its measured ratio recorded in the headline report ([§Headline
 reports](#headline-reports)).
 
+A comparator may be **scoped to a specific bench-target subset** — one
+comparator gates one bench target while another bench target in the
+same library declares absence — provided the per-library SPEC names
+which bench target each comparator covers. This is the common shape
+when an external tool exposes some of a library's surfaces as
+user-callable functions but not others.
+
+Where a bench target has no external comparator, the per-library
+SPEC declares the absence with a library-specific reason identifying
+exactly one of:
+
+- **implementation-is-extern** — the surface is an external library
+  via `@[extern]`; there is nothing algorithmically distinct to
+  compare against.
+- **structural-layer** — the surface is in a structural layer over a
+  named dependency library whose declared comparator already covers
+  it.
+- **input-source-only** — the only published external implementation
+  is itself the input source (e.g. a committed table), not an
+  executable comparator.
+- **mathlib-bridge** — the library is a `Hex*Mathlib` bridge whose
+  comparison surface is a within-Lean `compare` group against
+  Mathlib's native types.
+- **no-comparable-surface-in-named-comparator** — the library
+  declares a comparator for some surfaces but the named comparator
+  tool does not expose this specific surface as a callable function
+  (the tool builds it internally but doesn't surface it as user API).
+
+Generic "not applicable" is not a valid declaration. Unwired-but-
+required comparators are declared with the `blocked` state per
+[§Comparator classification](#comparator-classification-gating-vs-informational)
+and a tracking issue link, never silently omitted.
+
 ### The Attribution rule
 
 Every asymptotically significant phase of an algorithm — whether


### PR DESCRIPTION
Closes the loophole where per-library SPECs could silently declare no external comparator. Of the 14 libraries currently at `done_through ≥ 4`, only HexLLL had an external comparator wired; the other 13 declared nothing. The existing SPEC §"External comparators" wording allowed each per-library SPEC author to decide what was "architecturally important" with no obligation to record the decision; this PR makes the absence-justification mandatory.

**Generic clause** (`SPEC/benchmarking.md §"Comparator naming"`): per-library SPECs declare each external comparator with classification, optionally scoped per bench target. Any absent comparator is declared with one of five enumerated reasons: `implementation-is-extern`, `structural-layer`, `input-source-only`, `mathlib-bridge`, or `no-comparable-surface-in-named-comparator`. Silence and generic "not applicable" are not valid. The completeness of this declaration becomes a Phase-4 exit criterion in `PLAN/Phase4.md`.

**Per-library SPECs** (13 files):
- 7 declare an external comparator: HexPoly / HexPolyZ / HexMatrix / HexHensel / HexGfqRing (FLINT `fmpz_poly` / `fmpz_poly` / `fmpz_mat_det` / `nmod_poly_hensel_lift_*` / `fq_default`, all informational), HexGF2 (NTL `GF2X`, informational), and HexBerlekamp.
- HexBerlekamp is the only library gaining `gating` comparators: `runRabinTestChecksum` vs FLINT `nmod_poly.is_irreducible` and `runDistinctDegreeChecksum` vs FLINT `nmod_poly.factor_distinct_deg`. The other two HexBerlekamp surfaces (`runBerlekampMatrixChecksum`, `runBerlekampFactorChecksum`) declare absence with the new `no-comparable-surface-in-named-comparator` reason (FLINT builds the Frobenius matrix internally without exposing it).
- 6 declare absent: HexArith (`implementation-is-extern` — bigint primitives are GMP-backed), HexModArith (`implementation-is-extern` — modular operations via GMP, Barrett/Montgomery as internal `compare`), HexGramSchmidt (`structural-layer` — covered by HexMatrix and HexLLL's gating Isabelle comparator end-to-end), HexConway (`input-source-only` — Lübeck table is data, not executable), HexGfq (`structural-layer` — convenience wrapper over HexGfqRing), HexPolyMathlib (`mathlib-bridge` — within-Lean compare against `Mathlib.Polynomial`).

**Rollback consequence:** HexBerlekamp gains two `gating` comparators that are not currently wired. Per the post-#3657 exit-criterion that every gating comparator is wired before Phase 4 is claimed, HexBerlekamp must roll back from `done_through: 5` to `done_through: 3` until the comparators land and the headline report is regenerated. The Phase-5 proof work stays in the code; only the gate field moves. That rollback lands via the matching HO-21 once this PR merges.

This is a doctrine-only PR. Matching implementation work lands via human-oversight issues HO-20 (shared python-flint persistent-subprocess driver) through HO-27 (per-library wirings, HexBerlekamp rollback, headline report regenerations), depending on this PR and on #3657.

🤖 Prepared with Claude Code