### PR TITLE
doc: take bench verify out of merge-gating CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,13 +40,14 @@ proof — fix the proof or fix the API. For unfinished proofs use
 Before touching anything under `.github/workflows/`, read
 [SPEC/CI.md](../SPEC/CI.md). Each workflow runs in **exactly one
 ubuntu job** (`ci.yml` also has one macOS job for the dyld
-cross-check). New conformance targets, new oracles, and new bench
-targets **extend the script** of the existing single job — they do
-not introduce new top-level jobs, `strategy.matrix` blocks, or new
-workflow files. New oracles append a tuple to
-`scripts/ci/run_oracles.sh` and (if needed) an entry to the existing
-apt/pip install step; see
+cross-check). New conformance targets and new oracles **extend the
+script** of the existing single job — they do not introduce new
+top-level jobs, `strategy.matrix` blocks, or new workflow files.
+New oracles append a tuple to `scripts/ci/run_oracles.sh` and (if
+needed) an entry to the existing apt/pip install step; see
 [SPEC/testing.md § Adding a new oracle](../SPEC/testing.md).
+
+Bench targets are not added by extending CI — see §Benchmarks.
 
 GitHub-hosted Actions on a personal account is concurrency-capped at
 ~20 parallel ubuntu runners across all repositories the account
@@ -57,3 +58,20 @@ project, so the rule is "no parallelism in CI." Routine timing-
 sensitive runs live on a separate scheduled workflow on dedicated
 hardware (per [SPEC/benchmarking.md](../SPEC/benchmarking.md)),
 not on the merge-gating workflows.
+
+## Benchmarks
+
+`lake exe X_bench verify` runs worker-side, not in CI. Before
+publishing a PR whose diff touches non-proof Lean files under
+`Hex/*/`:
+
+1. `scripts/bench/affected_benches.sh <changed-files...>` lists
+   affected `*_bench` targets.
+2. `lake exe X_bench verify` each one.
+3. PR body must include `Affected benches: <list>` (or `none`).
+
+Failure modes and the verify→fixture-commit rule live in
+[SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md).
+A pre-merge `affected-benches-check` status check validates the PR
+body matches the computed set; a nightly workflow on `main` is the
+backstop.

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -59,19 +59,53 @@ PRs before creating new work. Downstream agents are blocked on `main`
 until merged PRs land.
 
 `main` is branch-protected: auto-merge only fires once every required
-status check (`build`, `build-macos`, `conformance`) is green. CI
-gating is non-negotiable — see [SPEC/CI.md](../SPEC/CI.md).
+status check (`build`, `build-macos`, `conformance`,
+`affected-benches-check`) is green. CI gating is non-negotiable —
+see [SPEC/CI.md](../SPEC/CI.md). `affected-benches-check` is a cheap
+evidence gate validating the PR body's `Affected benches:` line; see
+[§Affected-bench discipline](#affected-bench-discipline) below.
 
 ### CI work expansion
 
-When adding a new conformance check, oracle, benchmark, or build
-target, **extend the script of the existing single ubuntu job** in
-the relevant workflow (`conformance.yml` for conformance/oracle work,
+When adding a new conformance check, oracle, or build target,
+**extend the script of the existing single ubuntu job** in the
+relevant workflow (`conformance.yml` for conformance/oracle work,
 `ci.yml` for build/check work). Do **not** add a new top-level job,
 a new `strategy.matrix`, or a new workflow file. The full rationale
 and the trigger / concurrency / Mathlib-cache rules every workflow
 must satisfy live in [SPEC/CI.md](../SPEC/CI.md); read it before
 editing any file under `.github/workflows/`.
+
+Benchmark targets are not added by extending CI — they are not in
+merge-gating CI at all. See [§Affected-bench discipline](#affected-bench-discipline).
+
+### Affected-bench discipline
+
+`lake exe hexfoo_bench verify` is the bench-module smoke gate (see
+[SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md)).
+It runs **worker-side**, before publishing a PR, on libraries whose
+source files are touched by the diff. CI runs no `verify` per PR.
+
+Per-PR worker steps:
+
+1. Run `scripts/bench/affected_benches.sh <changed-files...>` to
+   enumerate affected `*_bench` targets.
+2. Run `lake exe hexfoo_bench verify` on each.
+3. In the PR body, include an `Affected benches:` line listing those
+   target names, or `none` for proof/doc/config-only PRs.
+4. If `verify` produced a legitimate fixture diff (deterministic
+   output change from the implementation), commit the regenerated
+   fixtures in the same PR. If `verify` failed for any other reason,
+   file a bench-found issue and roll back per
+   [§Rollback is a normal action](#rollback-is-a-normal-action) —
+   do not edit fixtures to make verify pass.
+
+The pre-merge `affected-benches-check` status check re-runs
+`affected_benches.sh` against the PR's diff and fails if the body's
+list disagrees with the computed set. The check runs no benches; it
+validates evidence only. The scheduled `nightly-bench-verify.yml`
+workflow against `main` runs the full `verify` sweep daily and is
+the backstop for skipped local execution.
 
 ---
 

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -208,7 +208,10 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - run: lake exe cache get
          - run: bash scripts/ci/check_no_mathlib_rebuild.sh
          - run: lake build
-         # plus per-library bench verify steps (see SPEC/benchmarking.md)
+         # No bench verify in CI — workers run `lake exe X_bench verify`
+         # locally before publishing, with a scheduled main-branch
+         # backstop (see SPEC/benchmarking.md §Worker affected-bench
+         # discipline; SPEC/CI.md §Job-count budget).
      build-macos:
        runs-on: macos-latest
        steps:

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -41,11 +41,15 @@ For each library `HexFoo` advancing through Phase 4:
    `require` (per the snippet in
    [SPEC/benchmarking.md §Harness](../SPEC/benchmarking.md#harness-lean-bench)).
 
-3. **CI smoke step** invoking
-   `lake exe hexfoo_bench list && lake exe hexfoo_bench verify`.
-   `verify` is the bitrot gate; it does not assert timing values.
-   It may use reduced smoke settings, but may not weaken the
-   scientific settings used for real runs.
+3. **Bench-module smoke gate** — `lake exe hexfoo_bench list &&
+   lake exe hexfoo_bench verify`. `verify` is the bitrot gate; it
+   does not assert timing values. It may use reduced smoke settings,
+   but may not weaken the scientific settings used for real runs.
+   This gate runs worker-side before publishing PRs, not in
+   merge-gating CI; see
+   [SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md).
+   A scheduled `nightly-bench-verify.yml` workflow against `main`
+   is the backstop.
 
 4. **`compare` registrations** for any pair of alternative algorithms
    the library SPEC calls out (e.g. Barrett vs Montgomery, linear vs
@@ -152,7 +156,13 @@ For library `hex-foo`, Phase 4 is done when:
   The only resolution available to the orchestrator is to act on
   the HO issue tied to the Concern until the underlying problem is
   fixed and the Concern entry is removed from the report.
-- the CI smoke step (`list` + `verify`) runs on every PR.
+- the Phase-4 PR/report records the exact
+  `lake exe hexfoo_bench list` and `lake exe hexfoo_bench verify`
+  invocations the author ran (paired with their outcomes, the host
+  and toolchain, and the bench target names produced). CI does not
+  run `verify` per PR; this is the evidence trail in place of that
+  gate. The scheduled `nightly-bench-verify.yml` workflow against
+  `main` provides the residual backstop.
 
 If any of these fail, the right action is rollback per
 [Conventions.md](Conventions.md), not a SPEC-text edit weakening

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -66,20 +66,23 @@ also has one macOS job (the dyld cross-check). No other parallelism.
 
 Concretely:
 
-- `ci.yml`: one `build` ubuntu job (DAG checks, hex `lake build`,
-  per-library `bench verify` smoke gate per
-  [SPEC/benchmarking.md §CI integration](benchmarking.md)) and one
-  `build-macos` macOS job (hex `lake build` only — the dyld
-  cross-check). **Bench verify runs on ubuntu, not macOS**: the
-  macOS job exists for symbol-resolution coverage, not benchmarking,
-  and macOS runners are 10× the cost and a fraction of the
-  concurrency. Per [SPEC/benchmarking.md §CI integration](benchmarking.md),
-  `verify` is a smoke gate (does the bench module compile and run?),
-  not a timing measurement; timing-relevant runs live on a separate
-  scheduled workflow on dedicated hardware.
+- `ci.yml`: one `build` ubuntu job (DAG checks, Mathlib cache fetch
+  per [§Mathlib cache is mandatory](#mathlib-cache-is-mandatory),
+  hex `lake build`) and one `build-macos` macOS job (hex `lake build`
+  only — the dyld cross-check). The macOS job exists for
+  symbol-resolution coverage; macOS runners are 10× the cost and a
+  fraction of the concurrency, so use them only for what genuinely
+  needs darwin.
 - `conformance.yml`: one ubuntu job that runs the full conformance
   matrix and every oracle (FLINT, PARI, fpLLL, Conway) sequentially
   inside that single runner.
+- `nightly-bench-verify.yml` (scheduled, not merge-gating): one
+  ubuntu job that runs the full `lake exe X_bench verify` sweep
+  across every library at `done_through ≥ 4`. Backstop for the
+  worker-side smoke gate, not a pre-merge check. Per
+  [SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md),
+  `verify` is run by workers locally before publishing a PR, not
+  by CI per PR.
 - Future workflows: one ubuntu job, period. If a second runner is
   genuinely needed (e.g. a separate macOS bench cross-check), state
   the reason in a workflow-level comment.
@@ -93,11 +96,20 @@ this project — every job re-builds the project's own Lean libraries
 on top of Mathlib, so a matrix entry that "only does one target"
 still pays the same fixed startup cost as the consolidated job.
 
-**New oracles, new conformance targets, and new bench targets
-extend the script of the single existing job.** Add an apt step
-for new system deps, a pip step for new Python deps, and a sequential
-shell loop for new per-library checks. Do not add a new top-level
-job, do not add `strategy.matrix`, and do not split a workflow.
+**New oracles and new conformance targets extend the script of the
+single existing job.** Add an apt step for new system deps, a pip
+step for new Python deps, and a sequential shell loop for new
+per-library checks. Do not add a new top-level job, do not add
+`strategy.matrix`, and do not split a workflow.
+
+**New bench targets do not extend CI.** Bench-module bitrot is
+caught by workers running `lake exe X_bench verify` locally before
+publishing (see [SPEC/benchmarking.md §Worker affected-bench
+discipline](benchmarking.md)) and by the scheduled
+`nightly-bench-verify.yml` backstop on `main`. Adding a new bench
+target means registering it in the per-library `Bench.lean` and
+ensuring it shows up in the nightly's enumeration — it does not
+mean editing the merge-gating workflows.
 
 ## Mathlib cache is mandatory
 
@@ -141,6 +153,11 @@ workflow files):
 - `build` (from `ci.yml`)
 - `build-macos` (from `ci.yml`)
 - `conformance` (from `conformance.yml`)
+- `affected-benches-check` (from `affected-benches-check.yml`) — a
+  cheap evidence gate that runs no `verify`, only confirms the PR
+  body's `Affected benches:` line matches the affected-benches
+  enumeration for the diff. See
+  [SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md).
 
 `required_status_checks.strict` is `false`. With `strict: true`,
 every merge to `main` flips every other open PR to `BEHIND` and
@@ -177,7 +194,7 @@ self-hosted runners explicitly rather than drifting toward them.
 
 ## How to add new CI work
 
-To add a new conformance check, oracle, benchmark, or build target:
+To add a new conformance check, oracle, or build target:
 
 1. **Default**: extend the script of the existing single job in the
    workflow that already covers this kind of work (`conformance.yml`
@@ -192,6 +209,12 @@ To add a new conformance check, oracle, benchmark, or build target:
 6. Update the relevant SPEC and PLAN cross-references (this file,
    `PLAN/Phase0.md` §6, `SPEC/testing.md`'s "Adding a new oracle"
    section) if the change introduces a new category of check.
+
+**Bench targets are not added via this recipe** — they do not run
+in merge-gating CI at all. See
+[SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md)
+for how new bench registrations reach their enforcement points
+(worker-side `verify` + scheduled nightly backstop).
 
 A new top-level workflow is justified only by a clearly distinct
 class of CI work that genuinely cannot share a runner with existing

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -177,8 +177,9 @@ The CLI surface is `lake exe hexfoo_bench <subcommand>`:
   hashes at common parameters, plus a relative-timing summary.
 - `verify [NAMES…]` — smoke-test registration wiring: spawn each
   benchmark with a tight inner-tuning budget, check the child exits
-  cleanly and emits a hash where one is expected. Used as a CI
-  gate; see [§CI integration](#ci-integration).
+  cleanly and emits a hash where one is expected. Used as the smoke
+  gate workers run before publishing; see
+  [§Worker affected-bench discipline](#worker-affected-bench-discipline).
 
 Per-library SPECs declare the complexity for each operation in their
 API surface. The textbook model is the contract; the benchmark
@@ -456,36 +457,80 @@ medium and large primes (e.g. `(97, 127)`, `(521, 13)`,
 `(97, 128)`), and large-degree irreducibility stress tests over
 `F_2` at degrees `512`, `1024`, `2048` and beyond when feasible.
 
-## CI integration
+## Worker affected-bench discipline
 
-Every library at `done_through ≥ 4` ships a CI job that runs:
+The `verify` subcommand is the bench-module smoke gate: it spawns each
+registered benchmark at a tight inner-tuning budget, checks the child
+exits cleanly, and verifies hashable benchmarks emit hashes. It does
+NOT assert timing values — the gate detects bitrot of the bench module
+itself, not regressions in the implementation.
 
-```sh
-lake exe hexfoo_bench list
-lake exe hexfoo_bench verify
-```
+This gate is **enforced worker-side**, not in merge-gating CI. The CI
+cost of running every library's `verify` on every PR — sequentially,
+regardless of which files the PR touched — was prohibitive at this
+repo's scale (~30 minutes per PR, saturating GitHub's hosted-runner
+concurrency cap). Workers run only the verifications their changes
+could plausibly affect, locally, before publishing.
 
-The `verify` subcommand is the smoke gate: it spawns each
-registered benchmark at a tight inner-tuning budget, checks the
-child exits cleanly, and verifies hashable benchmarks emit hashes.
-It does NOT assert timing values — the gate detects bitrot of the
-bench module itself, not regressions in the implementation.
+### The worker rule
 
-Per-library `verify` budget is up to ~15 s for libraries whose
-smallest registered input genuinely needs that long; most libraries
-should run in a few seconds. The repo-wide CI step's total budget is
-the sum, with a soft target of a few minutes — not a hard cap. A
-library exceeding 15 s on `verify` needs either tighter
-smoke settings or a closer look at why its tiniest invocation is
-slow. It is not a license to weaken the scientific settings.
+For any PR whose diff includes a non-proof Lean file under `Hex/*/`
+(implementation source, not theorems), the worker:
 
-Full timing runs (`lake exe hexfoo_bench run NAME` with a real
-budget) are not part of merge-gating CI. They run on a scheduled
-workflow or release-candidate workflow, on dedicated hardware where
-timing comparisons are meaningful. Each release names the libraries
-whose timing runs must succeed; a release is blocked by an
-inconclusive verdict or a comparator divergence even when proofs
-are complete.
+1. Enumerates affected `*_bench` targets via
+   `scripts/bench/affected_benches.sh <changed-files...>`. The script
+   walks the lakefile's `lean_exe *_bench` declarations and the
+   transitive `import` graph from each bench root, intersecting with
+   the changed-files set.
+2. For each affected bench target, runs
+   `lake exe hexfoo_bench verify`. Per-target budget: up to ~15 s
+   where the smallest registered input genuinely needs that long;
+   most libraries finish in a few seconds.
+3. Handles the outcome:
+   - **`verify` passes**: no fixture commit needed.
+   - **`verify` fails because committed expected output legitimately
+     changed** (a deterministic implementation tweak shifted hashes
+     or fixture bytes in a way the worker can explain): regenerate
+     fixtures via `lake build hexfoo_emit_fixtures` (and equivalent),
+     commit the fixture diff in the same PR.
+   - **`verify` fails for any other reason**: that is a bench-found
+     finding. File an issue per
+     [§verdict-as-bug-trigger](#the-verdict-as-bug-trigger-model) and
+     roll back per [PLAN/Conventions.md §Rollback is a normal action](../PLAN/Conventions.md#rollback-is-a-normal-action).
+     Do not paper over by editing fixtures.
+
+A PR with no implementation diff (proof-only, doc-only, config-only)
+runs zero benches. The PR description marks this with
+`Affected benches: none`.
+
+### Pre-merge enforcement
+
+Every PR body must include an `Affected benches:` line listing the
+bench targets affected by the diff, or `none`. A cheap required
+status check (`affected-benches-check`) re-runs
+`scripts/bench/affected_benches.sh` against the PR's diff and fails
+if the body's list disagrees with the computed set. The check runs
+no benches itself — it only validates that the worker named the right
+targets. Verification that the targets actually ran is on trust,
+backstopped by the nightly run on `main`.
+
+### Nightly backstop
+
+`nightly-bench-verify.yml` runs the full `verify` sweep across every
+library at `done_through ≥ 4` against `main` on a daily schedule.
+Failures open a `human-oversight` issue with the failing target and
+the offending commit. This catches the residual case where a worker
+asserts an `Affected benches:` set but skips the local execution.
+
+### Scientific timing runs
+
+Full timing runs (`lake exe hexfoo_bench run NAME` with a real budget)
+are not part of merge-gating CI, the worker pre-publish step, or the
+nightly. They run on a scheduled workflow or release-candidate
+workflow, on dedicated hardware where timing comparisons are
+meaningful. Each release names the libraries whose timing runs must
+succeed; a release is blocked by an inconclusive verdict or a
+comparator divergence even when proofs are complete.
 
 ## Reproducibility contract
 
@@ -655,9 +700,9 @@ explicitly forbidden:
   `only 0 verdict-eligible row(s) survived…`. That is the harness
   telling you the schedule, the per-call cap, or the target inner
   nanos was set too low for the host the benchmark is supposed to
-  run on. CI treats exit 2 the same as a verdict mismatch: file an
-  issue, roll back, fix. Don't shrink scientific settings to dodge
-  the verdict.
+  run on. The Phase-4/release gate treats exit 2 the same as a verdict
+  mismatch: file an issue, roll back, fix. Don't shrink scientific
+  settings to dodge the verdict.
 - **Treating an "inconclusive" verdict as a passing scientific run.**
   Phase-4 exit criteria require either "consistent with declared
   complexity" or a tracked finding-issue explaining the mismatch


### PR DESCRIPTION
This PR updates SPEC/, PLAN/, and `.claude/CLAUDE.md` to move the `lake exe X_bench verify` smoke gate from per-PR CI to worker responsibility, with a scheduled `main`-branch backstop and a pre-merge evidence check on the PR body.

The proximate problem is that `Bench verify` sequentially executes every library's bench `verify` on every PR, taking ~30 minutes of the 32-minute `build` job regardless of which files the PR touches. At hex's scale this saturates GitHub's 20-runner cap on the personal account (observed median queued-run age 185 minutes, worst 418 minutes). The deeper problem is that `verify`'s purpose is bench-module bitrot detection — running every library's smoke on every PR is structural over-cost for what is, by SPEC, a smoke gate.

## What the new doctrine says

- Workers identify affected `*_bench` targets via a (to-be-written) `scripts/bench/affected_benches.sh` and run `lake exe X_bench verify` locally before publishing.
- The PR body lists those targets in an `Affected benches:` line (or `none` for proof/doc/config-only diffs).
- A new `affected-benches-check` required status check (cheap, runs no benches) re-runs the affected-benches script against the diff and fails if the PR body disagrees.
- A scheduled `nightly-bench-verify.yml` workflow against `main` is the backstop: full `verify` sweep daily, opens a `human-oversight` issue on failure.
- Required-status-check contexts are now `build`, `build-macos`, `conformance`, `affected-benches-check`.

## What changes here

Doc-only PR across six files:

- `SPEC/CI.md` — §Job-count budget describes the new lightweight `build` job and the nightly. §New oracles, §How to add new CI work, and §Branch protection updated.
- `SPEC/benchmarking.md` — CLI bullet, the renamed §Worker affected-bench discipline (formerly §CI integration), and the §Anti-patterns "exit 2" wording.
- `PLAN/Phase0.md` — workflow-shape comment.
- `PLAN/Phase4.md` — deliverable 3 wording + exit-criteria replacement.
- `PLAN/Conventions.md` — required-contexts list, CI work expansion, new §Affected-bench discipline.
- `.claude/CLAUDE.md` — strikes bench targets from the CI extend-list, adds a tight §Benchmarks pointer (~5 lines, enters every worker context).

## Implementation work follows

Slim CI workflow, the `affected_benches.sh` script, the `affected-benches-check` workflow, and the 66-PR-backlog triage land as separate `human-oversight` issues after this PR merges, per the spec-driven-development pairing rule (doctrine first).

## Verification

Read [SPEC/benchmarking.md §Worker affected-bench discipline](https://github.com/kim-em/hex/blob/spec/bench-verify-out-of-ci/SPEC/benchmarking.md). Imagine the next from-scratch implementation reading only that section: it should steer them to worker-side verify + nightly backstop, not back to per-PR CI. Confirm the new §Benchmarks in `.claude/CLAUDE.md` is short enough to belong in every worker context.

🤖 Prepared with Claude Code