### PR TITLE
doc: revert bench-verify-out-of-CI, add Mathlib-free + time-budget rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -40,14 +40,20 @@ proof — fix the proof or fix the API. For unfinished proofs use
 Before touching anything under `.github/workflows/`, read
 [SPEC/CI.md](../SPEC/CI.md). Each workflow runs in **exactly one
 ubuntu job** (`ci.yml` also has one macOS job for the dyld
-cross-check). New conformance targets and new oracles **extend the
-script** of the existing single job — they do not introduce new
-top-level jobs, `strategy.matrix` blocks, or new workflow files.
-New oracles append a tuple to `scripts/ci/run_oracles.sh` and (if
-needed) an entry to the existing apt/pip install step; see
+cross-check). New conformance targets, new oracles, and new bench
+targets **extend the script** of the existing single job — they do
+not introduce new top-level jobs, `strategy.matrix` blocks, or new
+workflow files. New oracles append a tuple to
+`scripts/ci/run_oracles.sh` and (if needed) an entry to the existing
+apt/pip install step; see
 [SPEC/testing.md § Adding a new oracle](../SPEC/testing.md).
 
-Bench targets are not added by extending CI — see §Benchmarks.
+Bench targets in particular must not import Mathlib (directly or
+transitively) and must keep the `Bench verify` step under its
+wallclock cap; see
+[SPEC/benchmarking.md §Mathlib-free benches](../SPEC/benchmarking.md)
+and the "Time budget" subsection of
+[SPEC/benchmarking.md §CI integration](../SPEC/benchmarking.md).
 
 GitHub-hosted Actions on a personal account is concurrency-capped at
 ~20 parallel ubuntu runners across all repositories the account
@@ -58,20 +64,3 @@ project, so the rule is "no parallelism in CI." Routine timing-
 sensitive runs live on a separate scheduled workflow on dedicated
 hardware (per [SPEC/benchmarking.md](../SPEC/benchmarking.md)),
 not on the merge-gating workflows.
-
-## Benchmarks
-
-`lake exe X_bench verify` runs worker-side, not in CI. Before
-publishing a PR whose diff touches non-proof Lean files under
-`Hex/*/`:
-
-1. `scripts/bench/affected_benches.sh <changed-files...>` lists
-   affected `*_bench` targets.
-2. `lake exe X_bench verify` each one.
-3. PR body must include `Affected benches: <list>` (or `none`).
-
-Failure modes and the verify→fixture-commit rule live in
-[SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md).
-A pre-merge `affected-benches-check` status check validates the PR
-body matches the computed set; a nightly workflow on `main` is the
-backstop.

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -59,53 +59,26 @@ PRs before creating new work. Downstream agents are blocked on `main`
 until merged PRs land.
 
 `main` is branch-protected: auto-merge only fires once every required
-status check (`build`, `build-macos`, `conformance`,
-`affected-benches-check`) is green. CI gating is non-negotiable —
-see [SPEC/CI.md](../SPEC/CI.md). `affected-benches-check` is a cheap
-evidence gate validating the PR body's `Affected benches:` line; see
-[§Affected-bench discipline](#affected-bench-discipline) below.
+status check (`build`, `build-macos`, `conformance`) is green. CI
+gating is non-negotiable — see [SPEC/CI.md](../SPEC/CI.md).
 
 ### CI work expansion
 
-When adding a new conformance check, oracle, or build target,
-**extend the script of the existing single ubuntu job** in the
-relevant workflow (`conformance.yml` for conformance/oracle work,
-`ci.yml` for build/check work). Do **not** add a new top-level job,
-a new `strategy.matrix`, or a new workflow file. The full rationale
-and the trigger / concurrency / Mathlib-cache rules every workflow
-must satisfy live in [SPEC/CI.md](../SPEC/CI.md); read it before
-editing any file under `.github/workflows/`.
+When adding a new conformance check, oracle, benchmark, or build
+target, **extend the script of the existing single ubuntu job** in
+the relevant workflow (`conformance.yml` for conformance/oracle work,
+`ci.yml` for build/check/benchmark work). Do **not** add a new
+top-level job, a new `strategy.matrix`, or a new workflow file. The
+full rationale and the trigger / concurrency / Mathlib-cache rules
+every workflow must satisfy live in [SPEC/CI.md](../SPEC/CI.md); read
+it before editing any file under `.github/workflows/`.
 
-Benchmark targets are not added by extending CI — they are not in
-merge-gating CI at all. See [§Affected-bench discipline](#affected-bench-discipline).
-
-### Affected-bench discipline
-
-`lake exe hexfoo_bench verify` is the bench-module smoke gate (see
-[SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md)).
-It runs **worker-side**, before publishing a PR, on libraries whose
-source files are touched by the diff. CI runs no `verify` per PR.
-
-Per-PR worker steps:
-
-1. Run `scripts/bench/affected_benches.sh <changed-files...>` to
-   enumerate affected `*_bench` targets.
-2. Run `lake exe hexfoo_bench verify` on each.
-3. In the PR body, include an `Affected benches:` line listing those
-   target names, or `none` for proof/doc/config-only PRs.
-4. If `verify` produced a legitimate fixture diff (deterministic
-   output change from the implementation), commit the regenerated
-   fixtures in the same PR. If `verify` failed for any other reason,
-   file a bench-found issue and roll back per
-   [§Rollback is a normal action](#rollback-is-a-normal-action) —
-   do not edit fixtures to make verify pass.
-
-The pre-merge `affected-benches-check` status check re-runs
-`affected_benches.sh` against the PR's diff and fails if the body's
-list disagrees with the computed set. The check runs no benches; it
-validates evidence only. The scheduled `nightly-bench-verify.yml`
-workflow against `main` runs the full `verify` sweep daily and is
-the backstop for skipped local execution.
+For benchmark targets specifically, the structural and timing rules
+in [SPEC/benchmarking.md §Mathlib-free benches](../SPEC/benchmarking.md)
+and the "Time budget" subsection of
+[SPEC/benchmarking.md §CI integration](../SPEC/benchmarking.md)
+constrain what a new bench is allowed to look like (no Mathlib in
+the link chain; per-library smoke warn at 30 s; repo-wide hard cap).
 
 ---
 

--- a/PLAN/Phase0.md
+++ b/PLAN/Phase0.md
@@ -208,10 +208,7 @@ into Phase 1 until the Phase 0 PR lands on `main`.
          - run: lake exe cache get
          - run: bash scripts/ci/check_no_mathlib_rebuild.sh
          - run: lake build
-         # No bench verify in CI — workers run `lake exe X_bench verify`
-         # locally before publishing, with a scheduled main-branch
-         # backstop (see SPEC/benchmarking.md §Worker affected-bench
-         # discipline; SPEC/CI.md §Job-count budget).
+         # plus per-library bench verify steps (see SPEC/benchmarking.md)
      build-macos:
        runs-on: macos-latest
        steps:

--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -41,15 +41,11 @@ For each library `HexFoo` advancing through Phase 4:
    `require` (per the snippet in
    [SPEC/benchmarking.md §Harness](../SPEC/benchmarking.md#harness-lean-bench)).
 
-3. **Bench-module smoke gate** — `lake exe hexfoo_bench list &&
-   lake exe hexfoo_bench verify`. `verify` is the bitrot gate; it
-   does not assert timing values. It may use reduced smoke settings,
-   but may not weaken the scientific settings used for real runs.
-   This gate runs worker-side before publishing PRs, not in
-   merge-gating CI; see
-   [SPEC/benchmarking.md §Worker affected-bench discipline](../SPEC/benchmarking.md).
-   A scheduled `nightly-bench-verify.yml` workflow against `main`
-   is the backstop.
+3. **CI smoke step** invoking
+   `lake exe hexfoo_bench list && lake exe hexfoo_bench verify`.
+   `verify` is the bitrot gate; it does not assert timing values.
+   It may use reduced smoke settings, but may not weaken the
+   scientific settings used for real runs.
 
 4. **`compare` registrations** for any pair of alternative algorithms
    the library SPEC calls out (e.g. Barrett vs Montgomery, linear vs
@@ -156,13 +152,7 @@ For library `hex-foo`, Phase 4 is done when:
   The only resolution available to the orchestrator is to act on
   the HO issue tied to the Concern until the underlying problem is
   fixed and the Concern entry is removed from the report.
-- the Phase-4 PR/report records the exact
-  `lake exe hexfoo_bench list` and `lake exe hexfoo_bench verify`
-  invocations the author ran (paired with their outcomes, the host
-  and toolchain, and the bench target names produced). CI does not
-  run `verify` per PR; this is the evidence trail in place of that
-  gate. The scheduled `nightly-bench-verify.yml` workflow against
-  `main` provides the residual backstop.
+- the CI smoke step (`list` + `verify`) runs on every PR.
 
 If any of these fail, the right action is rollback per
 [Conventions.md](Conventions.md), not a SPEC-text edit weakening

--- a/SPEC/CI.md
+++ b/SPEC/CI.md
@@ -66,23 +66,21 @@ also has one macOS job (the dyld cross-check). No other parallelism.
 
 Concretely:
 
-- `ci.yml`: one `build` ubuntu job (DAG checks, Mathlib cache fetch
-  per [§Mathlib cache is mandatory](#mathlib-cache-is-mandatory),
-  hex `lake build`) and one `build-macos` macOS job (hex `lake build`
-  only — the dyld cross-check). The macOS job exists for
-  symbol-resolution coverage; macOS runners are 10× the cost and a
-  fraction of the concurrency, so use them only for what genuinely
-  needs darwin.
+- `ci.yml`: one `build` ubuntu job (DAG checks, hex `lake build`,
+  per-library `bench verify` smoke gate per
+  [SPEC/benchmarking.md §CI integration](benchmarking.md), plus the
+  structural and timing lints named there) and one `build-macos`
+  macOS job (hex `lake build` only — the dyld cross-check).
+  **Bench verify runs on ubuntu, not macOS**: the macOS job exists
+  for symbol-resolution coverage, not benchmarking, and macOS runners
+  are 10× the cost and a fraction of the concurrency. Per
+  [SPEC/benchmarking.md §CI integration](benchmarking.md), `verify`
+  is a smoke gate (does the bench module compile and run?), not a
+  timing measurement; timing-relevant runs live on a separate
+  scheduled workflow on dedicated hardware.
 - `conformance.yml`: one ubuntu job that runs the full conformance
   matrix and every oracle (FLINT, PARI, fpLLL, Conway) sequentially
   inside that single runner.
-- `nightly-bench-verify.yml` (scheduled, not merge-gating): one
-  ubuntu job that runs the full `lake exe X_bench verify` sweep
-  across every library at `done_through ≥ 4`. Backstop for the
-  worker-side smoke gate, not a pre-merge check. Per
-  [SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md),
-  `verify` is run by workers locally before publishing a PR, not
-  by CI per PR.
 - Future workflows: one ubuntu job, period. If a second runner is
   genuinely needed (e.g. a separate macOS bench cross-check), state
   the reason in a workflow-level comment.
@@ -96,20 +94,15 @@ this project — every job re-builds the project's own Lean libraries
 on top of Mathlib, so a matrix entry that "only does one target"
 still pays the same fixed startup cost as the consolidated job.
 
-**New oracles and new conformance targets extend the script of the
-single existing job.** Add an apt step for new system deps, a pip
-step for new Python deps, and a sequential shell loop for new
-per-library checks. Do not add a new top-level job, do not add
-`strategy.matrix`, and do not split a workflow.
-
-**New bench targets do not extend CI.** Bench-module bitrot is
-caught by workers running `lake exe X_bench verify` locally before
-publishing (see [SPEC/benchmarking.md §Worker affected-bench
-discipline](benchmarking.md)) and by the scheduled
-`nightly-bench-verify.yml` backstop on `main`. Adding a new bench
-target means registering it in the per-library `Bench.lean` and
-ensuring it shows up in the nightly's enumeration — it does not
-mean editing the merge-gating workflows.
+**New oracles, new conformance targets, and new bench targets
+extend the script of the single existing job.** Add an apt step for
+new system deps, a pip step for new Python deps, and a sequential
+shell loop for new per-library checks. Do not add a new top-level
+job, do not add `strategy.matrix`, and do not split a workflow. For
+benches specifically, the structural and timing rules in
+[SPEC/benchmarking.md §Mathlib-free benches](benchmarking.md) and
+[SPEC/benchmarking.md §CI integration "Time budget"](benchmarking.md)
+constrain what a new bench is allowed to look like.
 
 ## Mathlib cache is mandatory
 
@@ -153,11 +146,6 @@ workflow files):
 - `build` (from `ci.yml`)
 - `build-macos` (from `ci.yml`)
 - `conformance` (from `conformance.yml`)
-- `affected-benches-check` (from `affected-benches-check.yml`) — a
-  cheap evidence gate that runs no `verify`, only confirms the PR
-  body's `Affected benches:` line matches the affected-benches
-  enumeration for the diff. See
-  [SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md).
 
 `required_status_checks.strict` is `false`. With `strict: true`,
 every merge to `main` flips every other open PR to `BEHIND` and
@@ -194,11 +182,11 @@ self-hosted runners explicitly rather than drifting toward them.
 
 ## How to add new CI work
 
-To add a new conformance check, oracle, or build target:
+To add a new conformance check, oracle, benchmark, or build target:
 
 1. **Default**: extend the script of the existing single job in the
    workflow that already covers this kind of work (`conformance.yml`
-   for conformance/oracle, `ci.yml` for build/check).
+   for conformance/oracle, `ci.yml` for build/check/benchmark).
 2. Add any new system dependency to the existing apt/brew step.
 3. Add any new Python or Lean dependency to the existing install
    step.
@@ -210,11 +198,13 @@ To add a new conformance check, oracle, or build target:
    `PLAN/Phase0.md` §6, `SPEC/testing.md`'s "Adding a new oracle"
    section) if the change introduces a new category of check.
 
-**Bench targets are not added via this recipe** — they do not run
-in merge-gating CI at all. See
-[SPEC/benchmarking.md §Worker affected-bench discipline](benchmarking.md)
-for how new bench registrations reach their enforcement points
-(worker-side `verify` + scheduled nightly backstop).
+**Bench targets are constrained** by the structural and timing rules
+in [SPEC/benchmarking.md §Mathlib-free benches](benchmarking.md) and
+[SPEC/benchmarking.md §CI integration "Time budget"](benchmarking.md):
+no bench may import any `Mathlib.*` module (directly or transitively),
+and the per-PR `Bench verify` total has a hard wallclock cap. Both
+are enforced by lint scripts named in those sections, invoked from
+the `build` job.
 
 A new top-level workflow is justified only by a clearly distinct
 class of CI work that genuinely cannot share a runner with existing

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -177,9 +177,8 @@ The CLI surface is `lake exe hexfoo_bench <subcommand>`:
   hashes at common parameters, plus a relative-timing summary.
 - `verify [NAMES…]` — smoke-test registration wiring: spawn each
   benchmark with a tight inner-tuning budget, check the child exits
-  cleanly and emits a hash where one is expected. Used as the smoke
-  gate workers run before publishing; see
-  [§Worker affected-bench discipline](#worker-affected-bench-discipline).
+  cleanly and emits a hash where one is expected. Used as a CI
+  gate; see [§CI integration](#ci-integration).
 
 Per-library SPECs declare the complexity for each operation in their
 API surface. The textbook model is the contract; the benchmark
@@ -457,80 +456,126 @@ medium and large primes (e.g. `(97, 127)`, `(521, 13)`,
 `(97, 128)`), and large-degree irreducibility stress tests over
 `F_2` at degrees `512`, `1024`, `2048` and beyond when feasible.
 
-## Worker affected-bench discipline
+## Mathlib-free benches
 
-The `verify` subcommand is the bench-module smoke gate: it spawns each
-registered benchmark at a tight inner-tuning budget, checks the child
-exits cleanly, and verifies hashable benchmarks emit hashes. It does
-NOT assert timing values — the gate detects bitrot of the bench module
-itself, not regressions in the implementation.
+Benchmarks measure the computational kernel. The project's
+architectural premise is the Mathlib-free split: `Hex*` libraries are
+computational and Mathlib-free; `Hex*Mathlib` libraries are
+proof-only bridges. Two invariants follow, both hard:
 
-This gate is **enforced worker-side**, not in merge-gating CI. The CI
-cost of running every library's `verify` on every PR — sequentially,
-regardless of which files the PR touched — was prohibitive at this
-repo's scale (~30 minutes per PR, saturating GitHub's hosted-runner
-concurrency cap). Workers run only the verifications their changes
-could plausibly affect, locally, before publishing.
+1. **`Hex*Mathlib` libraries do not have benchmarks.** No
+   `Hex*Mathlib/Bench.lean`, no `Hex*Mathlib/Bench/`, no
+   `lean_exe *mathlib*_bench` in `lakefile.lean`. The Mathlib bridge
+   modules are proof-only; there is nothing computational to
+   benchmark in a bridge.
+2. **No bench reaches Mathlib.** For every bench executable declared
+   as `lean_exe X_bench where root := ...` in `lakefile.lean`, the
+   root module and every module transitively reachable from it via
+   `import` must NOT name any `Mathlib.*` module. Pulling Mathlib
+   into a bench's link chain forces thousands of native-object
+   (`.c.o`) compilations per CI job (a measured 12-minute hit per
+   offending bench at this repo's scale), and silently defeats the
+   Mathlib-free split that the rest of the project rests on. The
+   constraint is on the upstream Mathlib package only; intra-project
+   `Hex*Mathlib.*` modules are not what this rule forbids — but per
+   invariant (1) above, no bench imports them either.
 
-### The worker rule
+Both invariants are enforced by
+`scripts/ci/check_benches_mathlib_free.sh`, invoked from the `build`
+job in `ci.yml`. The script:
 
-For any PR whose diff includes a non-proof Lean file under `Hex/*/`
-(implementation source, not theorems), the worker:
+- Globs `lakefile.lean` for `lean_exe *_bench where root := ...` to
+  enumerate bench exe roots (handles top-level roots like
+  `HexGF2Bench` as well as `Hex*/Bench` modules).
+- Walks each root's transitive `import` graph (Lean syntax allows
+  `import` only at file start, so a simple `^import ` line scan up
+  to the first non-import/non-comment line is sound).
+- Fails on the first reachable `Mathlib.*` import, printing the
+  offending bench root and the full chain (e.g.
+  `HexPolyMathlib.Bench → HexPolyMathlib.Euclid → Mathlib.Algebra.Polynomial.FieldDivision`).
+- Globs `Hex*Mathlib/Bench.lean` and `Hex*Mathlib/Bench/` and fails
+  if any such path exists.
 
-1. Enumerates affected `*_bench` targets via
-   `scripts/bench/affected_benches.sh <changed-files...>`. The script
-   walks the lakefile's `lean_exe *_bench` declarations and the
-   transitive `import` graph from each bench root, intersecting with
-   the changed-files set.
-2. For each affected bench target, runs
-   `lake exe hexfoo_bench verify`. Per-target budget: up to ~15 s
-   where the smallest registered input genuinely needs that long;
-   most libraries finish in a few seconds.
-3. Handles the outcome:
-   - **`verify` passes**: no fixture commit needed.
-   - **`verify` fails because committed expected output legitimately
-     changed** (a deterministic implementation tweak shifted hashes
-     or fixture bytes in a way the worker can explain): regenerate
-     fixtures via `lake build hexfoo_emit_fixtures` (and equivalent),
-     commit the fixture diff in the same PR.
-   - **`verify` fails for any other reason**: that is a bench-found
-     finding. File an issue per
-     [§verdict-as-bug-trigger](#the-verdict-as-bug-trigger-model) and
-     roll back per [PLAN/Conventions.md §Rollback is a normal action](../PLAN/Conventions.md#rollback-is-a-normal-action).
-     Do not paper over by editing fixtures.
+A bench that needs Mathlib is a category error, not an oversight to
+work around: either it's measuring through Mathlib (slow and missing
+the computational kernel) or it accidentally dragged Mathlib into a
+native link chain. Either way, the fix is structural — file the
+finding, roll back if necessary, and either remove the bench or
+move what it measures into a Mathlib-free location.
 
-A PR with no implementation diff (proof-only, doc-only, config-only)
-runs zero benches. The PR description marks this with
-`Affected benches: none`.
+## CI integration
 
-### Pre-merge enforcement
+Every library at `done_through ≥ 4` ships a CI job that runs:
 
-Every PR body must include an `Affected benches:` line listing the
-bench targets affected by the diff, or `none`. A cheap required
-status check (`affected-benches-check`) re-runs
-`scripts/bench/affected_benches.sh` against the PR's diff and fails
-if the body's list disagrees with the computed set. The check runs
-no benches itself — it only validates that the worker named the right
-targets. Verification that the targets actually ran is on trust,
-backstopped by the nightly run on `main`.
+```sh
+lake exe hexfoo_bench list
+lake exe hexfoo_bench verify
+```
 
-### Nightly backstop
+The `verify` subcommand is the smoke gate: it spawns each
+registered benchmark at a tight inner-tuning budget, checks the
+child exits cleanly, and verifies hashable benchmarks emit hashes.
+It does NOT assert timing values — the gate detects bitrot of the
+bench module itself, not regressions in the implementation.
 
-`nightly-bench-verify.yml` runs the full `verify` sweep across every
-library at `done_through ≥ 4` against `main` on a daily schedule.
-Failures open a `human-oversight` issue with the failing target and
-the offending commit. This catches the residual case where a worker
-asserts an `Affected benches:` set but skips the local execution.
+The `Bench verify` step lives in `ci.yml`'s `build` ubuntu job (per
+[SPEC/CI.md §Job-count budget](CI.md)), one sequential block, no
+matrix. New libraries at `done_through ≥ 4` append their bench
+target to that block.
+
+### Time budget
+
+The `Bench verify` step has two enforced budgets:
+
+- **Per-library soft warning at 30 s.** Any library whose `verify`
+  crosses 30 wallclock seconds is logged as a warning in the CI
+  output for visibility. This is a warning, not a fail —
+  GitHub-hosted runner perf variance is real (2-3× single-run noise
+  is normal), and a single-PR flake should not block merges.
+- **Repo-wide hard cap at 10 wallclock minutes** (transitional; see
+  below). The total time for the `Bench verify` step (build + run,
+  summed across all libraries) MUST be under the cap. Crossing it
+  fails the build with a per-library breakdown so the offender is
+  obvious. The 10-minute cap is staged: once outliers are
+  remediated, the cap ratchets to **5 wallclock minutes**, which is
+  the long-term target.
+
+When a library trips either:
+
+- If the smallest honest smoke input is fast at the bench's
+  scientific complexity model but slow at its currently-registered
+  smoke settings, tighten the smoke settings (or add a
+  smoke-specific override clause to the registration) so the smoke
+  path uses a budget appropriate for "does this module compile and
+  run". Scientific settings are unchanged.
+- If the smallest honest smoke input is genuinely minutes at any
+  setting, that's a bench-found finding per
+  [§verdict-as-bug-trigger](#the-verdict-as-bug-trigger-model):
+  file the issue, roll back `done_through`, fix the underlying
+  implementation at the rolled-back phase.
+
+**Smoke settings may be tightened to fit budget; scientific
+settings MUST NOT be weakened to dodge the budget.** That's
+verdict-laundering per [§Anti-patterns](#anti-patterns). The
+distinction matters because `verify` and `run` consume
+different settings layers — see [§Harness](#harness-lean-bench).
+
+The cap is enforced by
+`scripts/ci/check_bench_verify_budget.sh`, invoked at the tail of
+the `Bench verify` step. It wraps the per-library `lake exe X_bench
+verify` invocations (capturing wallclock per invocation), prints a
+sorted breakdown, logs the soft warnings, and exits non-zero if the
+total exceeds the hard cap.
 
 ### Scientific timing runs
 
-Full timing runs (`lake exe hexfoo_bench run NAME` with a real budget)
-are not part of merge-gating CI, the worker pre-publish step, or the
-nightly. They run on a scheduled workflow or release-candidate
-workflow, on dedicated hardware where timing comparisons are
-meaningful. Each release names the libraries whose timing runs must
-succeed; a release is blocked by an inconclusive verdict or a
-comparator divergence even when proofs are complete.
+Full timing runs (`lake exe hexfoo_bench run NAME` with a real
+budget) are not part of merge-gating CI. They run on a scheduled
+workflow or release-candidate workflow, on dedicated hardware where
+timing comparisons are meaningful. Each release names the libraries
+whose timing runs must succeed; a release is blocked by an
+inconclusive verdict or a comparator divergence even when proofs
+are complete.
 
 ## Reproducibility contract
 
@@ -644,6 +689,23 @@ state, `SPEC/` is normative and follows the immutability rules in
 These behaviours have surfaced in past benchmarking work and are
 explicitly forbidden:
 
+- **Importing `Mathlib.*` into a bench module.** See
+  [§Mathlib-free benches](#mathlib-free-benches). Bench targets
+  compile to native executables, and Mathlib's `.c.o` chain is not
+  in the upstream cache — every transitively-Mathlib bench inflates
+  the CI `Bench verify` step's wallclock by ~12 minutes per
+  uncached link chain. This is a category error to remove (delete
+  the bench, move what it measured into a Mathlib-free location),
+  not an oversight to argue around. Enforced by
+  `scripts/ci/check_benches_mathlib_free.sh`.
+- **Weakening scientific settings to fit a CI time budget.** The
+  `Bench verify` time budget is on the smoke path, which has its
+  own settings layer (see [§Harness](#harness-lean-bench)).
+  Tightening smoke settings to fit the cap is allowed; lowering the
+  scientific `setup_benchmark` parameters or `targetInnerNanos` is
+  verdict-laundering. If the smallest honest smoke input is
+  genuinely minutes, the response is a bench-found rollback at the
+  rolled-back phase, never a scientific-settings shrink.
 - **Lowering the parameter range to make a budget-skip go away
   without naming the implementation bug.** If a benchmark would
   exceed its wallclock cap at the declared range, the implementation
@@ -700,9 +762,9 @@ explicitly forbidden:
   `only 0 verdict-eligible row(s) survived…`. That is the harness
   telling you the schedule, the per-call cap, or the target inner
   nanos was set too low for the host the benchmark is supposed to
-  run on. The Phase-4/release gate treats exit 2 the same as a verdict
-  mismatch: file an issue, roll back, fix. Don't shrink scientific
-  settings to dodge the verdict.
+  run on. CI treats exit 2 the same as a verdict mismatch: file an
+  issue, roll back, fix. Don't shrink scientific settings to dodge
+  the verdict.
 - **Treating an "inconclusive" verdict as a passing scientific run.**
   Phase-4 exit criteria require either "consistent with declared
   complexity" or a tracked finding-issue explaining the mismatch


### PR DESCRIPTION
This PR reverts #3678 and replaces its worker-side discipline with two new normative rules that prevent the slow-verify class from recurring.

The previous PR was an over-correction. Diagnosis from a real 30-min CI run: `lake exe X_bench verify` itself takes ~1 s per library (matching the SPEC's promise). The wallclock was consumed by `lake exe` triggering `.c.o` (native object) compilation for each bench's link chain. `lake build` only needs `.olean`s (cached by `lake exe cache get`), but bench exes link native code, and **Mathlib's `.c.o` is not in the upstream cache**.

Two distinct sources of slowness:

1. **Three Mathlib-bridge bench files** (`HexMatrixMathlib/Bench.lean`, `HexPolyMathlib/Bench.lean`, `HexGF2Mathlib/Bench.lean`) trigger Mathlib `.c.o` compilation — ~12 min of the 30. These are category errors: `Hex*Mathlib` libs are proof-only bridges; there is no computational kernel to benchmark.
2. **Three computational benches** (`hexgf2_bench` ~6 min, `hexgfqfield_bench` ~3 min, possibly `hexlll_bench`) have `verify` execution times over the SPEC's 15 s budget, driven by `targetInnerNanos := 200000000` and large parameter schedules — scientific tuning leaking into the smoke path.

The right fix is structural: ban Mathlib in any bench's import chain (rule 1) and hard-cap the `Bench verify` step's wallclock with a clear remediation rule (rule 2).

## Reverts

- `SPEC/CI.md`: §Job-count budget restores `bench verify` in `ci.yml`'s `build` job description; §How to add new CI work restores "benchmark" in the list; §Branch protection drops `affected-benches-check` (doc-only fiction — never in branch protection).
- `SPEC/benchmarking.md`: CLI bullet reverts; §Worker affected-bench discipline renamed back to §CI integration and rewritten; §Anti-patterns "CI treats exit 2..." wording restored.
- `PLAN/Phase0.md`, `PLAN/Phase4.md`, `PLAN/Conventions.md`, `.claude/CLAUDE.md`: worker-discipline language removed, CI-side language restored.

## New rules (added to `SPEC/benchmarking.md`)

**§Mathlib-free benches** — two hard invariants:

1. No `Hex*Mathlib/Bench.lean`, `Hex*Mathlib/Bench/`, or `lean_exe *mathlib*_bench`. Bridges are proof-only.
2. No bench exe root or any module transitively reachable from it via `import` may name `Mathlib.*`.

Enforced by `scripts/ci/check_benches_mathlib_free.sh` (HO-β, follow-up). The script walks `lakefile.lean` for `lean_exe *_bench where root := ...`, recursively parses `import` lines, and fails on first `Mathlib.*` hit with the full chain.

**§CI integration → "Time budget" subsection** — per-library `verify` soft warning at 30 s; repo-wide hard cap at 10 min initially, ratcheting to 5 min once outliers fix. Smoke settings may be tightened to fit; scientific settings MUST NOT be weakened (verdict-laundering). Enforced by `scripts/ci/check_bench_verify_budget.sh` (HO-γ, follow-up).

**§Anti-patterns** — new bullets for "Importing `Mathlib.*` into a bench module" and "Weakening scientific settings to fit a CI time budget".

## Implementation follow-ups (separate HOs)

- Delete the three Mathlib-bridge bench files + lakefile entries + ci.yml lines (HO-α).
- Write the two lint scripts (HO-β, HO-γ).
- File bench-found findings against the over-budget computational benches (HO-δ).
- Triage the 66-PR backlog (existing HO-31, retargeted).

🤖 Prepared with Claude Code