### PR TITLE
feat: add Bench verify time-budget lint (HO-35, warn-only stage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,41 +41,20 @@ jobs:
       - name: Build hex (Mathlib must NOT rebuild from source)
         run: lake build
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)
+        env:
+          # Initial rollout per HO-35: collect telemetry without
+          # failing the build on the hard cap. Drop this once HO-36
+          # stabilises the slow benches and we ratchet to a real cap.
+          BENCH_VERIFY_WARN_ONLY: "1"
         run: |
-          lake exe hexarith_bench list
-          lake exe hexarith_bench verify
-          lake exe hexmatrix_bench list
-          lake exe hexmatrix_bench verify
-          lake exe hexpoly_bench list
-          lake exe hexpoly_bench verify
-          lake exe hexpolyz_bench list
-          lake exe hexpolyz_bench verify
-          lake exe hexpolyfp_bench list
-          lake exe hexpolyfp_bench verify
-          lake exe hexmodarith_bench list
-          lake exe hexmodarith_bench verify
-          lake exe hexgramschmidt_bench list
-          lake exe hexgramschmidt_bench verify
-          lake exe hexgf2_bench list
-          lake exe hexgf2_bench verify
-          lake exe hexgfqring_bench list
-          lake exe hexgfqring_bench verify
-          lake exe hexgfqfield_bench list
-          lake exe hexgfqfield_bench verify
-          lake exe hexgfq_bench list
-          lake exe hexgfq_bench verify
           HEX_LLL_ISABELLE_SVP="$(scripts/oracle/setup_lll_isabelle.sh)"
           export HEX_LLL_ISABELLE_SVP
-          lake exe hexlll_bench list
-          lake exe hexlll_bench verify
-          lake exe hexhensel_bench list
-          lake exe hexhensel_bench verify
-          lake exe hexberlekamp_bench list
-          lake exe hexberlekamp_bench verify
-          lake exe hexbz_bench list
-          lake exe hexbz_bench verify
-          lake exe hexconway_bench list
-          lake exe hexconway_bench verify
+          bash scripts/ci/check_bench_verify_budget.sh \
+            hexarith_bench hexmatrix_bench hexpoly_bench hexpolyz_bench \
+            hexpolyfp_bench hexmodarith_bench hexgramschmidt_bench \
+            hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench \
+            hexlll_bench hexhensel_bench hexberlekamp_bench hexbz_bench \
+            hexconway_bench
 
   build-macos:
     runs-on: macos-latest

--- a/scripts/ci/check_bench_verify_budget.sh
+++ b/scripts/ci/check_bench_verify_budget.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Time-budget wrapper enforcing SPEC/benchmarking.md §CI integration
+# "Time budget" subsection.
+#
+# Runs `lake exe X_bench list && lake exe X_bench verify` for each
+# bench-exe name passed on stdin or as args, captures wallclock per
+# invocation, prints a sorted breakdown, emits `::warning::`
+# annotations for libraries over the per-library soft threshold, and
+# exits non-zero if the total wallclock exceeds the hard cap.
+#
+# Env knobs:
+#   BENCH_VERIFY_WARN_SECONDS     per-library soft warning threshold
+#                                  (default 30; warn-only, doesn't fail)
+#   BENCH_VERIFY_HARD_CAP_SECONDS repo-wide hard cap (default 600 =
+#                                  10 min); 0 disables.
+#   BENCH_VERIFY_WARN_ONLY        if set to "1", report timings but
+#                                  never fail on the hard cap. Used
+#                                  for the initial rollout per HO-35
+#                                  so we collect telemetry before
+#                                  flipping the switch.
+#
+# Run from the repository root, after `lake build`. Intended for
+# `.github/workflows/ci.yml`'s `build` job; also safe to run locally.
+
+set -euo pipefail
+
+warn_threshold="${BENCH_VERIFY_WARN_SECONDS:-30}"
+hard_cap="${BENCH_VERIFY_HARD_CAP_SECONDS:-600}"
+warn_only="${BENCH_VERIFY_WARN_ONLY:-0}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <bench_exe_name> [<bench_exe_name> ...]" >&2
+  exit 2
+fi
+
+# `gha_warn`: emit a workflow-command warning when running under GitHub
+# Actions (where `$GITHUB_ACTIONS == true`); otherwise just print to
+# stderr.
+gha_warn() {
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::warning::$*"
+  else
+    echo "WARNING: $*" >&2
+  fi
+}
+
+# Per-bench timings, accumulated as "seconds bench_name" lines.
+results_file="$(mktemp)"
+trap 'rm -f "$results_file"' EXIT
+
+total=0
+for bench in "$@"; do
+  echo "::group::$bench"
+  start=$(date +%s)
+  # Run list + verify as a pair. `set -e` propagates failure out.
+  lake exe "$bench" list
+  lake exe "$bench" verify
+  end=$(date +%s)
+  elapsed=$((end - start))
+  total=$((total + elapsed))
+  printf '%d %s\n' "$elapsed" "$bench" >> "$results_file"
+  echo "::endgroup::"
+
+  if [ "$elapsed" -gt "$warn_threshold" ]; then
+    gha_warn "$bench verify took ${elapsed}s (> ${warn_threshold}s soft threshold). See SPEC/benchmarking.md §CI integration \"Time budget\"."
+  fi
+done
+
+# Sorted breakdown — slowest first.
+echo
+echo "=== Bench verify wallclock breakdown ==="
+sort -rn "$results_file" | awk '{ printf "  %5ds  %s\n", $1, $2 }'
+echo "  -----"
+printf '  %5ds  TOTAL\n' "$total"
+echo
+
+if [ "$hard_cap" -gt 0 ] && [ "$total" -gt "$hard_cap" ]; then
+  msg="Bench verify total ${total}s exceeded hard cap ${hard_cap}s. See SPEC/benchmarking.md §CI integration \"Time budget\"."
+  if [ "$warn_only" = "1" ]; then
+    gha_warn "$msg (warn-only stage; would fail if BENCH_VERIFY_WARN_ONLY were unset)"
+  else
+    echo "FAIL: $msg" >&2
+    echo "Per-library breakdown above. Fix the slowest contributor first:" >&2
+    echo "  - Smoke settings leaking from scientific tuning? Add a smoke override clause." >&2
+    echo "  - Genuinely slow at the smallest honest input? File a bench-found issue and roll back per SPEC/benchmarking.md §verdict-as-bug-trigger." >&2
+    echo "  - DO NOT lower scientific settings to dodge the cap (verdict-laundering per §Anti-patterns)." >&2
+    exit 1
+  fi
+fi
+
+echo "check_bench_verify_budget: OK (${total}s total, hard cap ${hard_cap}s, warn-only=${warn_only})."


### PR DESCRIPTION
Implements [SPEC/benchmarking.md §CI integration "Time budget"](../SPEC/benchmarking.md) (landed in #3684). Adds `scripts/ci/check_bench_verify_budget.sh` and refactors `ci.yml`'s `Bench verify` step to use it.

## What the wrapper does

- Runs `lake exe X_bench list && verify` for each bench-exe name passed as args.
- Captures wallclock per invocation using `date +%s`.
- Emits `::warning::` for any library over `BENCH_VERIFY_WARN_SECONDS` (default 30 s).
- Prints a sorted breakdown (slowest first).
- Exits non-zero if total exceeds `BENCH_VERIFY_HARD_CAP_SECONDS` (default 600 s = 10 min).

## Initial rollout: warn-only

The `ci.yml` step sets `BENCH_VERIFY_WARN_ONLY=1` so the wrapper reports timings without failing the build on the hard cap. This collects telemetry across real PRs before flipping the switch.

A follow-up will set `BENCH_VERIFY_WARN_ONLY=0` and ratchet `BENCH_VERIFY_HARD_CAP_SECONDS` to 300 (= 5 min) once HO-36 (#3688) stabilises the slow benches.

## Smoke tests (locally, with stubbed `lake`)

- Warn-only + over-cap: prints the warning, exits 0.
- Hard-fail + over-cap: prints actionable error message (covering all three remediation paths from the SPEC), exits 1.
- Breakdown is sorted slowest-first.

Closes #3687.

🤖 Prepared with Claude Code