### PR TITLE
ci: drop conformance from PR triggers (run on push-to-main only)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -3,8 +3,13 @@ name: Conformance
 on:
   push:
     branches: [main]
-  pull_request:
   workflow_dispatch:
+  # Intentionally NO `pull_request` trigger: conformance currently
+  # takes ~30-60 min (24 min Lean compile + 5-30 min oracle runs)
+  # and saturates the 20-runner pool, blocking the gating `CI`
+  # workflow on every PR. Until HO-37 (#3693) ships a fix
+  # (`.lake/build` cache or trimmed target set), conformance runs
+  # only on push-to-`main` and via manual `workflow_dispatch`.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR drops the `pull_request` trigger from `conformance.yml`. Conformance currently takes ~30-60 min per PR (24 min Lean compile + 5-30 min oracle runs); with a 20-runner concurrency cap, every PR's conformance run saturated the pool and blocked the gating `CI` workflow — both directly and via the cancel-and-retry race GitHub uses to refresh runs as slots free.

Until #3693 (HO-37) ships a structural fix (a `.lake/build` cache across PRs, or a trimmed target set), conformance runs only on push-to-`main` and via manual `workflow_dispatch`. That keeps the post-merge coverage signal on `main` (regressions surface there, just one PR later than before) while letting PR CI drain without contention.

`conformance` was already removed from `main` branch protection's required-status-checks earlier today, so this change is purely about runner-pool budgeting — not gating semantics.

🤖 Prepared with Claude Code