### PR TITLE
fix: add missing `p_pos` field on `bhksProductMismatchRecoverLift`

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -2603,7 +2603,8 @@ private def bhksFailedDivisionRecoverLift : LiftData :=
 private def bhksProductMismatchRecoverLift : LiftData :=
   { p := 5
     k := 2
-    liftedFactors := #[DensePoly.ofCoeffs #[-2, 1]] }
+    liftedFactors := #[DensePoly.ofCoeffs #[-2, 1]]
+    p_pos := by decide }
 
 #guard bhksIndicatorCandidate? cldGuardF bhksProductMismatchRecoverLift #[1] =
   some (DensePoly.ofCoeffs #[-2, 1], DensePoly.ofCoeffs #[-3, 1])


### PR DESCRIPTION
This PR adds the missing `p_pos := by decide` field on `bhksProductMismatchRecoverLift` in `HexBerlekampZassenhaus/Basic.lean`. PR #3476 added `p_pos : 0 < p` to `LiftData` and updated three of the four literal constructions in this file but missed this one, so `main` has been failing to build since that merge with:

```
error: HexBerlekampZassenhaus/Basic.lean:2604:2: Fields missing: `p_pos`
```

That CI failure was masked while the bench-verify saturation kept `build` jobs stuck in the queue — the recent fast-pipeline drain surfaced it on every PR retrying CI. Same `by decide` proof as the three sibling sites.

🤖 Prepared with Claude Code