### PR TITLE
ci: ratchet HO-35 hard cap to 300 s (was warn-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,14 @@ jobs:
             hexconway_bench
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)
         env:
-          # Initial rollout per HO-35: collect telemetry without
-          # failing the build on the hard cap. Drop this once HO-36
-          # stabilises the slow benches and we ratchet to a real cap.
-          BENCH_VERIFY_WARN_ONLY: "1"
+          # Hard cap enforced per SPEC/benchmarking.md §CI integration
+          # "Time budget". Two consecutive main pushes after the
+          # lean-bench in-process verify fix (#3692) measured the full
+          # 16-bench verify step at 47-51 s, slowest single bench
+          # hexlll_bench at 23 s. The 300 s cap gives ~6× headroom for
+          # noise / new benches while still flagging anyone who tries
+          # to reintroduce a per-spawn-overhead regression.
+          BENCH_VERIFY_HARD_CAP_SECONDS: "300"
         run: |
           HEX_LLL_ISABELLE_SVP="$(scripts/oracle/setup_lll_isabelle.sh)"
           export HEX_LLL_ISABELLE_SVP


### PR DESCRIPTION
This PR ratchets `BENCH_VERIFY_HARD_CAP_SECONDS` from warn-only to a hard 300 s (the SPEC's long-term target) and drops the warn-only env var.

Two consecutive main pushes after the lean-bench in-process verify fix (#3692) measured the full 16-bench `Bench verify` step at 47-51 s:

| run                                                                       | total | slowest single bench  |
|---------------------------------------------------------------------------|-------|-----------------------|
| #3692 merge (run [25719761587](https://github.com/kim-em/hex/actions/runs/25719761587))  | 47 s  | hexlll_bench 19 s     |
| #3695 merge (run [25725572118](https://github.com/kim-em/hex/actions/runs/25725572118))  | 51 s  | hexlll_bench 23 s     |

Both well under the SPEC's "a few minutes" target. The 300 s cap gives ~6× headroom for hardware noise / new benches while catching anyone who reintroduces per-spawn-overhead-style regressions.

The 30 s per-library soft warning threshold (default) is unchanged, so a single slow bench still emits a `::warning::` annotation without failing the build. `hexlll_bench` is the current high-water mark at ~23 s; if it crosses 30 s the warning surface will tell us.

Closes the open follow-up from #3691 (HO-35 warn-only stage).

🤖 Prepared with Claude Code