### PR TITLE
spec: forbid `precompileModules := true`

### DIFF
--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -74,7 +74,9 @@
 
 ## Lakefile
 
-Don't use `precompileModules := true`. It isn't necessary.
+Use `precompileModules := true` only on libraries that export
+`@[extern]` functions. Don't use it otherwise, and in particular
+libraries importing Mathlib must not use `precompileModules`.
 
 ## Fully autonomous execution
 

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -72,6 +72,10 @@
    applies to a benchmark-discovered scaffolding `def` applies to a
    proof a refactor would silently axiomatise.
 
+## Lakefile
+
+Don't use `precompileModules := true`. It isn't necessary.
+
 ## Fully autonomous execution
 
 The project runs without human interaction after launch. Lean, Mathlib,


### PR DESCRIPTION
This PR forbids `precompileModules := true` in the lakefile.

The package-level default plus inherited setting on the 10 `Hex*Mathlib` libraries currently forces native-C compilation of every transitively-imported Mathlib module on every CI run. Per HO-37 experiment A (#3693), HexBerlekampMathlib alone accounts for ~12 min wallclock of the conformance build (40% of total), almost entirely Mathlib `.c.o` compilation. The native code has no runtime consumer inside the project (verified: no `#eval` / `native_decide` references any `Hex*Mathlib` symbol), so the cost buys nothing.

Paired with HO-38 (issue), which removes the existing uses from `lakefile.lean`.

🤖 Prepared with Claude Code