### PR TITLE
fix: drop irr/cyclo11 from BZ EmitFixtures and committed fixture (HO-40)

### DIFF
--- a/HexBerlekampZassenhaus/EmitFixtures.lean
+++ b/HexBerlekampZassenhaus/EmitFixtures.lean
@@ -176,9 +176,7 @@ private def cases_irr : List Case :=
   [ -- Φ_5(x), degree 4, irreducible.
     mk "irr/cyclo5"  #[1, 1, 1, 1, 1]
     -- Φ_7(x), degree 6, irreducible.
-  , mk "irr/cyclo7"  #[1, 1, 1, 1, 1, 1, 1]
-    -- Φ_11(x), degree 10, irreducible.
-  , mk "irr/cyclo11" #[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] ]
+  , mk "irr/cyclo7"  #[1, 1, 1, 1, 1, 1, 1] ]
 
 private def cases_irr_expected : List ExpectedCase :=
   [ -- Φ_17(x), degree 16, irreducible.

--- a/conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl
+++ b/conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl
@@ -32,8 +32,6 @@
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo5","op":"factor","value":[1,[[[1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo7","coeffs":[1,1,1,1,1,1,1],"modulus":null}
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo7","op":"factor","value":[1,[[[1,1,1,1,1,1,1],1]]]}
-{"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo11","coeffs":[1,1,1,1,1,1,1,1,1,1,1],"modulus":null}
-{"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo11","op":"factor","value":[1,[[[1,1,1,1,1,1,1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo17","coeffs":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],"modulus":null}
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo17","op":"factor","value":[1,[[[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"red/quad2_deg4","coeffs":[2,0,3,0,1],"modulus":null}

--- a/progress/20260513T051751Z_2bd73610.md
+++ b/progress/20260513T051751Z_2bd73610.md
@@ -1,0 +1,37 @@
+# HO-40: drop `irr/cyclo11` from BZ EmitFixtures (issue #3702)
+
+## Accomplished
+
+- Removed `mk "irr/cyclo11"` from `cases_irr` in
+  `HexBerlekampZassenhaus/EmitFixtures.lean`.
+- Removed the two `irr/cyclo11` JSONL records from
+  `conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl`. The issue body
+  assumed `a92b0c3` had already trimmed these from `bz.jsonl`, but that
+  commit sits on the closed PR-#3330 branch (`agent/cd928252`); it was
+  committed seconds after the squash-merge and never reached `main`.
+  Trimming both files is required to satisfy the issue's `diff -u`
+  verification step.
+- `lake exe hexbz_emit_fixtures` now completes in ~6s (down from
+  unbounded hang) and emits 52 lines that match the committed fixture
+  byte-for-byte.
+- `lake exe hexbz_emit_fixtures | python3 scripts/oracle/bz_flint.py`
+  runs end-to-end in ~4s, oracle reports 26 cases, 0 failures.
+- `lake build HexBerlekampZassenhaus` succeeds; only the pre-existing
+  `sorry` warnings appear.
+
+## Current frontier
+
+- The underlying `Hex.factor` non-termination on Φ_11 in compiled-Lean
+  remains unfixed; this issue is explicitly scoped to restoring driver
+  consistency, with the real fix called out as a separate follow-up.
+
+## Next step
+
+- Open the PR closing #3702.
+- A separate HO will need to diagnose BHKS recombination behaviour on
+  Φ_11 and, once fixed, restore `irr/cyclo11` to both `cases_irr` and
+  the committed fixture.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #3702

Session: `2bd73610-5428-4b46-84c5-491de8282a54`

3785515 fix: drop irr/cyclo11 from BZ EmitFixtures and committed fixture (HO-40)

🤖 Prepared with Claude Code