### PR TITLE
HO-42: separate Hensel precision exponent from Mignotte coefficient bound in BZ factor

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1256,6 +1256,18 @@ def ceilLogP (p target : Nat) : Nat :=
 def bhksCoeffCutThreshold (p : Nat) (f : ZPoly) (j : Nat) : Nat :=
   ceilLogP p (2 * bhksCoeffBound f j + 1)
 
+/--
+Hensel precision exponent for a Mignotte coefficient bound.
+
+For the Mignotte criterion `p^a > 2·B`, returns the smallest exponent
+`a` with `p^a ≥ 2·B + 1` (equivalently `p^a > 2·B`). The two quantities
+are different — `B` is a magnitude on integer coefficients, `a` is the
+small exponent on the Hensel modulus `p^a` — and must not be conflated.
+See SPEC/Libraries/hex-berlekamp-zassenhaus.md §"Slow path".
+-/
+def precisionForCoeffBound (B p : Nat) : Nat :=
+  ceilLogP p (2 * B + 1)
+
 private def subsetSplits : List ZPoly → List (List ZPoly × List ZPoly)
   | [] => [([], [])]
   | factor :: factors =>
@@ -2870,7 +2882,8 @@ private def exhaustiveCoreFactorsWithBound
   if B = 0 then
     #[core]
   else
-    let liftData := henselLiftData core B primeData
+    let liftData :=
+      henselLiftData core (precisionForCoeffBound B primeData.p) primeData
     let factors := recombineExhaustive core liftData
     if factors.isEmpty then
       #[core]
@@ -2910,11 +2923,12 @@ private def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPo
   else
     if B = 1 then
       let primeData := choosePrimeData normalized.squareFreeCore
+      let a := precisionForCoeffBound B primeData.p
       if primeData.factorsModP.size ≤ 1 then
         some (reassemblePolynomialFactors normalized #[normalized.squareFreeCore])
       else
-        match factorFastCoreWithBound normalized.squareFreeCore B primeData
-            (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
+        match factorFastCoreWithBound normalized.squareFreeCore a primeData
+            (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) with
         | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
         | none => none
     else
@@ -2922,11 +2936,12 @@ private def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPo
       | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
       | none =>
         let primeData := choosePrimeData normalized.squareFreeCore
+        let a := precisionForCoeffBound B primeData.p
         if primeData.factorsModP.size ≤ 1 then
           some (reassemblePolynomialFactors normalized #[normalized.squareFreeCore])
         else
-          match factorFastCoreWithBound normalized.squareFreeCore B primeData
-              (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
+          match factorFastCoreWithBound normalized.squareFreeCore a primeData
+              (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) with
           | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
           | none => none
 
@@ -2952,9 +2967,10 @@ private theorem factorFastFactorsWithBound_eq_some_of_core_success
     (hquadratic : B = 1 ∨
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
     (hcore :
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
-        primeData (initialHenselPrecision B)
-        (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors) :
+      let a := precisionForCoeffBound B primeData.p
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
+        primeData (initialHenselPrecision a)
+        (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors) :
     factorFastFactorsWithBound f B =
       some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) := by
   unfold factorFastFactorsWithBound
@@ -3061,25 +3077,28 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
     (hB_pos : 1 ≤ factorFastPrecisionCap f)
     (hnormalized :
       primeData = choosePrimeData (normalizeForFactor f).squareFreeCore)
-    (hmem : target ∈
-      henselPrecisionSchedule (factorFastPrecisionCap f)
-        (initialHenselPrecision (factorFastPrecisionCap f))
-        (ZPoly.quadraticDoublingSteps (factorFastPrecisionCap f) + 2))
+    (hmem :
+      let a := precisionForCoeffBound (factorFastPrecisionCap f) primeData.p
+      target ∈
+        henselPrecisionSchedule a
+          (initialHenselPrecision a)
+          (ZPoly.quadraticDoublingSteps a + 2))
     (hrecover :
       bhksRecover? (normalizeForFactor f).squareFreeCore
         (henselLiftData (normalizeForFactor f).squareFreeCore target primeData) =
           some coreFactors) :
     factorFast f ≠ none := by
   let B := factorFastPrecisionCap f
+  let a := precisionForCoeffBound B primeData.p
   have hB_pos' : 1 ≤ B := by
     simpa [B] using hB_pos
   have hcore_ne :
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B primeData
-          (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) ≠ none := by
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a primeData
+          (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) ≠ none := by
     exact
       factorFastCoreWithBound_ne_none_of_recovery_on_schedule
-        (normalizeForFactor f).squareFreeCore B primeData
-        (by simpa [B] using hmem) hrecover
+        (normalizeForFactor f).squareFreeCore a primeData
+        (by simpa [a, B] using hmem) hrecover
   have hfactors_ne :
       factorFastFactorsWithBound f B ≠ none := by
     unfold factorFastFactorsWithBound
@@ -3096,8 +3115,10 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
           exact Option.some_ne_none _
         · rw [if_neg hsmall]
           cases hcore :
-              factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B primeData
-                (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
+              factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
+                (precisionForCoeffBound B primeData.p) primeData
+                (initialHenselPrecision (precisionForCoeffBound B primeData.p))
+                (ZPoly.quadraticDoublingSteps (precisionForCoeffBound B primeData.p) + 2) with
           | none => exact absurd hcore hcore_ne
           | some factors =>
               simp
@@ -3113,8 +3134,11 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
               exact Option.some_ne_none _
             · rw [if_neg hsmall]
               cases hcore :
-                  factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B primeData
-                    (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
+                  factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
+                    (precisionForCoeffBound B primeData.p) primeData
+                    (initialHenselPrecision (precisionForCoeffBound B primeData.p))
+                    (ZPoly.quadraticDoublingSteps
+                      (precisionForCoeffBound B primeData.p) + 2) with
               | none => exact absurd hcore hcore_ne
               | some factors =>
                   simp
@@ -3474,20 +3498,28 @@ private theorem exhaustiveCoreFactorsWithBound_product
   · simp [hB, polyProduct_singleton]
   · simp only [hB, if_false]
     by_cases hempty :
-        (recombineExhaustive core (henselLiftData core B primeData)).isEmpty
+        (recombineExhaustive core
+            (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)).isEmpty
     · simp [hempty, polyProduct_singleton]
     · simp only [hempty]
       cases hsearch : recombinationSearchMod core
-          (liftModulus (henselLiftData core B primeData))
-          (henselLiftData core B primeData).liftedFactors.toList with
+          (liftModulus
+            (henselLiftData core (precisionForCoeffBound B primeData.p) primeData))
+          (henselLiftData core (precisionForCoeffBound B primeData.p)
+            primeData).liftedFactors.toList with
       | none =>
-          have hnil : recombineExhaustive core (henselLiftData core B primeData) = #[] := by
+          have hnil :
+              recombineExhaustive core
+                (henselLiftData core (precisionForCoeffBound B primeData.p)
+                  primeData) = #[] := by
             rw [recombineExhaustive]
             simp [hsearch]
           rw [hnil] at hempty
           simp at hempty
       | some xs =>
-          exact recombineExhaustive_product core (henselLiftData core B primeData) xs hsearch
+          exact recombineExhaustive_product core
+            (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)
+            xs hsearch
 
 theorem checkIrreducibleCert_prime_data
     (f : ZPoly) (cert : ZPolyIrreducibilityCertificate)

--- a/HexBerlekampZassenhaus/EmitFixtures.lean
+++ b/HexBerlekampZassenhaus/EmitFixtures.lean
@@ -176,7 +176,9 @@ private def cases_irr : List Case :=
   [ -- Φ_5(x), degree 4, irreducible.
     mk "irr/cyclo5"  #[1, 1, 1, 1, 1]
     -- Φ_7(x), degree 6, irreducible.
-  , mk "irr/cyclo7"  #[1, 1, 1, 1, 1, 1, 1] ]
+  , mk "irr/cyclo7"  #[1, 1, 1, 1, 1, 1, 1]
+    -- Φ_11(x), degree 10, irreducible.
+  , mk "irr/cyclo11" #[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1] ]
 
 private def cases_irr_expected : List ExpectedCase :=
   [ -- Φ_17(x), degree 16, irreducible.

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -466,10 +466,12 @@ theorem factorFast_ne_none_of_forwardInputs_on_schedule
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.henselLiftData
           (Hex.normalizeForFactor f).squareFreeCore target primeData))
-    (hmem : target ∈
-      Hex.henselPrecisionSchedule (Hex.factorFastPrecisionCap f)
-        (Hex.initialHenselPrecision (Hex.factorFastPrecisionCap f))
-        (Hex.ZPoly.quadraticDoublingSteps (Hex.factorFastPrecisionCap f) + 2)) :
+    (hmem :
+      let a := Hex.precisionForCoeffBound (Hex.factorFastPrecisionCap f) primeData.p
+      target ∈
+        Hex.henselPrecisionSchedule a
+          (Hex.initialHenselPrecision a)
+          (Hex.ZPoly.quadraticDoublingSteps a + 2)) :
     Hex.factorFast f ≠ none := by
   have hrecover :
       Hex.bhksRecover? (Hex.normalizeForFactor f).squareFreeCore

--- a/conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl
+++ b/conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl
@@ -32,6 +32,8 @@
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo5","op":"factor","value":[1,[[[1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo7","coeffs":[1,1,1,1,1,1,1],"modulus":null}
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo7","op":"factor","value":[1,[[[1,1,1,1,1,1,1],1]]]}
+{"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo11","coeffs":[1,1,1,1,1,1,1,1,1,1,1],"modulus":null}
+{"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo11","op":"factor","value":[1,[[[1,1,1,1,1,1,1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"irr/cyclo17","coeffs":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],"modulus":null}
 {"kind":"result","lib":"HexBerlekampZassenhaus","case":"irr/cyclo17","op":"factor","value":[1,[[[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],1]]]}
 {"kind":"poly","lib":"HexBerlekampZassenhaus","case":"red/quad2_deg4","coeffs":[2,0,3,0,1],"modulus":null}

--- a/progress/20260513T071352Z_2d1dec4d.md
+++ b/progress/20260513T071352Z_2d1dec4d.md
@@ -1,0 +1,41 @@
+# HO-42: separate Hensel precision exponent from Mignotte coefficient bound
+
+## Accomplished
+
+- Added `precisionForCoeffBound (B p : Nat) : Nat := ceilLogP p (2 * B + 1)`
+  in `HexBerlekampZassenhaus/Basic.lean`, returning the smallest `a` with
+  `p^a > 2·B` (Mignotte criterion).
+- Slow path: `exhaustiveCoreFactorsWithBound core B primeData` now lifts at
+  precision `precisionForCoeffBound B primeData.p` instead of `B`. The
+  matching product proof `exhaustiveCoreFactorsWithBound_product` is
+  updated accordingly.
+- Fast path: `factorFastFactorsWithBound f B` now caps the BHKS schedule at
+  `a := precisionForCoeffBound B primeData.p` (recursion variable, initial
+  precision, and doubling-steps fuel), matching `factorFastCoreWithBound`'s
+  precision-exponent semantics. The downstream theorems
+  `factorFastFactorsWithBound_eq_some_of_core_success` and
+  `factorFast_ne_none_of_core_recovery_on_schedule` carry the conversion in
+  their hypotheses.
+- Mathlib bridge: `factorFast_ne_none_of_forwardInputs_on_schedule` in
+  `HexBerlekampZassenhausMathlib/Recovery.lean` takes the schedule
+  hypothesis at the new precision-exponent cap.
+- Restored `irr/cyclo11` in `HexBerlekampZassenhaus/EmitFixtures.lean` and
+  re-emitted `conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl`. The
+  fresh emit completes in ~2 s and the FLINT oracle reports 27 checked /
+  0 failures.
+- `_diag/Phi11Trace.lean` and its `lean_exe phi11_trace` block were already
+  absent from the worktree.
+
+## Current frontier
+
+The `factor` path on `irr/cyclo11` now terminates in milliseconds via the
+fast path; the slow-path fall-through path no longer attempts a `3^1008`
+modulus.
+
+## Next step
+
+None for this issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3710

Session: `2d1dec4d-aee5-4696-833f-86843ff3d874`

c97b365 chore: progress note for HO-42
7df9e46 test: restore irr/cyclo11 to BZ conformance fixtures
5a282fc fix: separate Hensel precision exponent from Mignotte coefficient bound

🤖 Prepared with Claude Code