### PR TITLE
HexGramSchmidt: wire integer adjacent-swap basis wrappers

### DIFF
--- a/HexGramSchmidt/Basic.lean
+++ b/HexGramSchmidt/Basic.lean
@@ -3453,6 +3453,40 @@ theorem basis_rowSwap_adjacent_prev (b : Matrix Int n m) (km1 k : Fin n)
     GramSchmidt.Rat.basis_rowSwap_adjacent_prev
       (b := GramSchmidt.castIntMatrix b) (km1 := km1) (k := k) hkm1
 
+theorem basis_rowSwap_of_after (b : Matrix Int n m) (km1 k i : Fin n)
+    (hkm1 : km1.val + 1 = k.val) (hi : k.val < i.val) :
+    (basis (Matrix.rowSwap b km1 k)).row i = (basis b).row i := by
+  simpa [basis, GramSchmidt.Rat.basis, castIntMatrix_rowSwap] using
+    GramSchmidt.Rat.basis_rowSwap_of_after
+      (b := GramSchmidt.castIntMatrix b) (km1 := km1) (k := k) (i := i) hkm1 hi
+
+theorem basis_rowSwap_adjacent_curr (b : Matrix Int n m) (km1 k : Fin n)
+    (hkm1 : km1.val + 1 = k.val)
+    (hnorm :
+      Matrix.dot
+        ((basis b).row k + GramSchmidt.entry (coeffs b) k km1 • (basis b).row km1)
+        ((basis b).row k + GramSchmidt.entry (coeffs b) k km1 • (basis b).row km1) ≠ 0) :
+    let prev := (basis b).row km1
+    let curr := (basis b).row k
+    let mu := GramSchmidt.entry (coeffs b) k km1
+    let swappedPrev := curr + mu • prev
+    (basis (Matrix.rowSwap b km1 k)).row k =
+      (Matrix.dot curr curr / Matrix.dot swappedPrev swappedPrev) • prev -
+        (mu * Matrix.dot prev prev / Matrix.dot swappedPrev swappedPrev) • curr := by
+  have hnormRat :
+      Matrix.dot
+        ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row k +
+          GramSchmidt.entry (GramSchmidt.Rat.coeffs (GramSchmidt.castIntMatrix b)) k km1 •
+            (GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row km1)
+        ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row k +
+          GramSchmidt.entry (GramSchmidt.Rat.coeffs (GramSchmidt.castIntMatrix b)) k km1 •
+            (GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row km1) ≠ 0 := by
+    simpa [basis, coeffs, GramSchmidt.Rat.basis, GramSchmidt.Rat.coeffs] using hnorm
+  simpa [basis, coeffs, GramSchmidt.Rat.basis, GramSchmidt.Rat.coeffs,
+    castIntMatrix_rowSwap] using
+    GramSchmidt.Rat.basis_rowSwap_adjacent_curr
+      (b := GramSchmidt.castIntMatrix b) (km1 := km1) (k := k) hkm1 hnormRat
+
 /-- Under integer row-add with `src < dst`, lower coefficients in the
 destination row update linearly below the pivot source column. -/
 theorem coeffs_rowAdd_lower (b : Matrix Int n m) (col src dst : Fin n)

--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -299,7 +299,13 @@ theorem basis_adjacentSwap_of_lt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.va
 theorem basis_adjacentSwap_of_gt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hi : k.val < i.val) :
     (basis (adjacentSwap b k hk)).row i = (basis b).row i := by
-  sorry
+  let km1 := GramSchmidt.prevRow k hk
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]
+    omega
+  simpa [adjacentSwap, km1] using
+    GramSchmidt.Int.basis_rowSwap_of_after
+      (b := b) (km1 := km1) (k := k) (i := i) hkm1 hi
 
 theorem basis_adjacentSwap_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -327,7 +333,13 @@ theorem basis_adjacentSwap_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val
     (basis (adjacentSwap b k hk)).row k =
       (Matrix.dot curr curr / Matrix.dot swappedPrev swappedPrev) • prev -
         (μ * Matrix.dot prev prev / Matrix.dot swappedPrev swappedPrev) • curr := by
-  sorry
+  let km1 := GramSchmidt.prevRow k hk
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]
+    omega
+  simpa [adjacentSwap, km1] using
+    GramSchmidt.Int.basis_rowSwap_adjacent_curr
+      (b := b) (km1 := km1) (k := k) hkm1 hdenom
 
 theorem coeffs_adjacentSwap_lower_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (j : Fin n) (hj : j.val + 1 < k.val) :

--- a/progress/20260513T172245Z_cbf8ac49.md
+++ b/progress/20260513T172245Z_cbf8ac49.md
@@ -1,0 +1,46 @@
+# Session cbf8ac49 — wire integer adjacent-swap basis wrappers (#3554)
+
+## Accomplished
+
+Filled the two remaining `basis_adjacentSwap_*` holes in
+`HexGramSchmidt/Update.lean` by adding two integer wrappers in
+`HexGramSchmidt/Basic.lean` around `Matrix.rowSwap` and
+`GramSchmidt.castIntMatrix`:
+
+- `GramSchmidt.Int.basis_rowSwap_of_after` — wraps
+  `GramSchmidt.Rat.basis_rowSwap_of_after` through `castIntMatrix_rowSwap`.
+- `GramSchmidt.Int.basis_rowSwap_adjacent_curr` — wraps
+  `GramSchmidt.Rat.basis_rowSwap_adjacent_curr` through
+  `castIntMatrix_rowSwap`, with a small `hnorm` translation step from the
+  Int-side `(basis b)` / `(coeffs b)` to the Rat-side
+  `(GramSchmidt.Rat.basis (castIntMatrix b))` / `(GramSchmidt.Rat.coeffs ...)`.
+
+Then the two `sorry`s in `HexGramSchmidt/Update.lean` were filled:
+
+- `basis_adjacentSwap_of_gt` now calls
+  `GramSchmidt.Int.basis_rowSwap_of_after` with `km1 := prevRow k hk`.
+- `basis_adjacentSwap_curr` now calls
+  `GramSchmidt.Int.basis_rowSwap_adjacent_curr`; the user-supplied
+  `hdenom` matches the wrapper's `hnorm` shape directly.
+
+The other two `basis_adjacentSwap_*` theorems (`_of_lt` and `_prev`)
+were already proven via `basis_rowSwap_of_before` /
+`basis_rowSwap_adjacent_prev`.
+
+## Current frontier
+
+The four `basis_adjacentSwap_*` public theorems are now sorry-free.
+Remaining sorries in `HexGramSchmidt/Update.lean` are the
+out-of-scope `coeffs_adjacentSwap_*`, `gramDet_adjacentSwap_*`,
+`scaledCoeffs_adjacentSwap_*`, and `adjacentSwap_*_dvd` holes (the
+ones #3554 explicitly carved out).
+
+## Next step
+
+A follow-on issue can wire integer wrappers for the analogous
+coefficient and Gram-determinant `adjacentSwap` formulas; that work
+is out of scope for #3554.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3554

Session: `cbf8ac49-8cc0-4ae9-8a2b-b94e70eb8775`

a5b1be2 feat: wire integer adjacent-swap basis wrappers (#3554)

🤖 Prepared with Claude Code