### PR TITLE
HexBZ: prove normalizeCandidateFactor identity for primitive sign-normalized polynomials

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -2245,12 +2245,33 @@ private def liftModulus (d : LiftData) : Nat :=
 private def centeredLiftPoly (f : ZPoly) (m : Nat) : ZPoly :=
   DensePoly.ofCoeffs <| f.toArray.map fun coeff => centeredModNat coeff m
 
-private def normalizeCandidateFactor (candidate : ZPoly) : ZPoly :=
+/-- Normalize a candidate integer factor by extracting its primitive part and
+flipping sign so the leading coefficient is non-negative.  Used by
+`bhksIndicatorCandidate?` to produce a canonical witness from the centred
+lift of a scaled lifted-factor product. -/
+def normalizeCandidateFactor (candidate : ZPoly) : ZPoly :=
   let primitive := ZPoly.primitivePart candidate
   if DensePoly.leadingCoeff primitive < 0 then
     DensePoly.scale (-1 : Int) primitive
   else
     primitive
+
+/--
+`normalizeCandidateFactor g = g` when `g` is already primitive (content `1`)
+and has non-negative leading coefficient.  This is the A2 reconstruction step
+that asserts the canonical witness produced by `bhksIndicatorCandidate?`
+agrees with the expected true factor under those normalization assumptions.
+-/
+theorem normalizeCandidateFactor_eq_of_primitive_nonneg_leading
+    (g : ZPoly) (hprim : ZPoly.Primitive g)
+    (hsign : 0 ≤ DensePoly.leadingCoeff g) :
+    normalizeCandidateFactor g = g := by
+  unfold normalizeCandidateFactor
+  have hpart : ZPoly.primitivePart g = g :=
+    ZPoly.primitivePart_eq_self_of_primitive g hprim
+  rw [hpart]
+  have hnot_neg : ¬ DensePoly.leadingCoeff g < 0 := Int.not_lt.mpr hsign
+  rw [if_neg hnot_neg]
 
 private def bhksIndicatorSelectedFactors
     (liftedFactors : Array ZPoly) (indicator : Array Int) : Option (Array ZPoly) :=

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -3913,6 +3913,21 @@ theorem primitivePart_eq_zero_of_content_eq_zero (p : DensePoly Int) (h : conten
     simpa [content] using h
   simp [primitivePart, hc]
 
+/-- A polynomial whose content is `1` equals its primitive part. -/
+theorem primitivePart_eq_self_of_content_eq_one
+    (p : DensePoly Int) (h : content p = 1) :
+    primitivePart p = p := by
+  have hscale : scale (content p) (primitivePart p) = p :=
+    content_mul_primitivePart p
+  apply ext_coeff
+  intro n
+  have hcoeff :
+      (scale (content p) (primitivePart p)).coeff n = p.coeff n := by
+    rw [hscale]
+  rw [coeff_scale (content p) (primitivePart p) n (Int.mul_zero _)] at hcoeff
+  rw [h] at hcoeff
+  simpa using hcoeff
+
 /-- The primitive part of a polynomial with nonzero content has content `1`. -/
 theorem primitivePart_primitive (p : DensePoly Int) (h : content p ≠ 0) :
     content (primitivePart p) = 1 := by

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -681,6 +681,10 @@ theorem primitivePart_primitive (f : ZPoly) (h : content f ≠ 0) :
     Primitive (primitivePart f) := by
   simpa [Primitive, content, primitivePart] using DensePoly.primitivePart_primitive f h
 
+theorem primitivePart_eq_self_of_primitive (f : ZPoly) (h : Primitive f) :
+    primitivePart f = f :=
+  DensePoly.primitivePart_eq_self_of_content_eq_one f (by simpa [Primitive, content] using h)
+
 theorem primitiveSquareFreeDecomposition_primitive (f : ZPoly) :
     (primitiveSquareFreeDecomposition f).primitive = primitivePart f := by
   by_cases hzero : (primitivePart f).isZero = true

--- a/progress/2026-05-13T17-35-39_2dce2d11.md
+++ b/progress/2026-05-13T17-35-39_2dce2d11.md
@@ -1,0 +1,39 @@
+# 2026-05-13T17:35 UTC — feature/2dce2d11
+
+## Accomplished
+
+- Claimed #3758 (A2 centred-lift candidate reconstruction lemmas) and
+  determined the scope (four substantive proof artifacts plus a composing
+  capstone) was too large for one session.
+- Decomposed #3758 into four sub-issues:
+  - #3786 — `exactQuotient?_eq_some_of_mul_eq` (success lemma)
+  - #3787 — `normalizeCandidateFactor` identity for primitive non-neg-leading inputs
+  - #3788 — `centeredLiftPoly` Mignotte recovery under coefficient bound
+  - #3790 — composing capstone `bhksIndicatorCandidate?_eq_some_of_mignottePrecision`
+  - Dep edges: #3790 depends on #3786, #3787, #3788.
+- Skipped #3758 via `coordination skip` with breadcrumb comment.
+- Claimed #3787 and landed it:
+  - Added `DensePoly.primitivePart_eq_self_of_content_eq_one` in
+    `HexPoly/Euclid.lean`.
+  - Added `ZPoly.primitivePart_eq_self_of_primitive` wrapper in
+    `HexPolyZ/Basic.lean`.
+  - Promoted `normalizeCandidateFactor` from `private` to public in
+    `HexBerlekampZassenhaus/Basic.lean` (issue explicitly permits this).
+  - Added `normalizeCandidateFactor_eq_of_primitive_nonneg_leading`.
+- Build clean (`lake build HexBerlekampZassenhaus`); only pre-existing sorries
+  remain (lines 3380, 3395). DAG check clean. No banned tokens introduced.
+
+## Current frontier
+
+Sub-issues #3786, #3788 are unclaimed foundations for #3790. The capstone
+#3790 is blocked until all three foundations land.
+
+## Next step
+
+Next worker can claim #3786 (exactQuotient? success), #3788 (centeredLiftPoly
+Mignotte recovery), or other unclaimed feature work. The decomposed parent
+#3758 is in `replan` state awaiting a planner.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3787

Session: `2dce2d11-b714-4839-b7c7-ed98b1886dd0`

6220c0d feat: expose normalizeCandidateFactor identity for primitive sign-normalized polynomials

🤖 Prepared with Claude Code