### PR TITLE
doc: forbid Mathlib-free consumers from forcing bridge proofs into the core

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -14,6 +14,29 @@ once per session.
 agents may fix SPEC clauses that are internally contradictory or
 mathematically impossible, with rationale in the PR description.
 
+### Reports do not override SPEC
+
+Files under `reports/` are research outputs, not policy. When a
+report identifies a contradiction between existing code and SPEC,
+its only valid follow-up issues are:
+
+(a) a SPEC-clarification issue tagged for human adjudication, or
+(b) a rollback issue removing the contradicting code.
+
+A worker or replan triage may not file an implementation issue that
+closes the gap by working *against* SPEC wording — regardless of
+how "smaller a path" it appears to be, regardless of how many
+consumers the offending surface has accumulated, and regardless of
+how authoritative the report sounds. The contradiction itself is
+evidence that someone wrote code outside the SPEC; the intervention
+is to either align the SPEC with intent (option a) or align the
+code with the SPEC (option b).
+
+Symptom this rule exists to catch: a report flagging "existing
+consumers depend on a Mathlib-free surface the SPEC assigns to the
+bridge layer; the smaller path is to prove it Mathlib-free anyway."
+That is the failure mode, not a planning strategy.
+
 ### Placeholders are for proofs only
 
 `sorry` is permitted in proofs (`theorem` bodies, propositional
@@ -280,6 +303,28 @@ Answer all four. One line each is enough.
 
 A `depends-on:` answer to any of (1)–(4) is healthy. An unanswered
 question is the failure shape.
+
+### Replan loops are a SPEC-violation signal
+
+If three or more `depends-on:` generations in a chain share a
+single recurring deliverable shape — e.g. "Mathlib-free
+Desnanot–Jacobi", "Mathlib-free `bareiss_eq_det`", "Mathlib-free
+adjugate identity" — and at least one worker has filed a
+"needs replan" skip on that shape, the chain is paused. Triage
+must file a SPEC-clarification issue tagged for human adjudication
+before any further decomposition.
+
+Replan-loop diagnostic shape: the same phrase ("Mathlib-free X")
+appears in successive skip comments across child issues. Each
+child looks reasonable in isolation; the chain as a whole is the
+SPEC telling you "the result you are decomposing toward does not
+exist at this layer." Cutting it thinner does not change that.
+
+This is a hard procedural stop, not a soft preference. Continuing
+to decompose past it is the failure mode this rule catches; see
+[Reports do not override SPEC](#reports-do-not-override-spec) for
+the analogous rule covering the report-driven entry into the same
+trap.
 
 ### Bench-found, conformance-found, and audit-found issues
 

--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -161,6 +161,34 @@ track coefficients or update formulas, so it cannot be used in the
 computational core. The `hex-gram-schmidt-mathlib` bridge proves
 that `GramSchmidt.Int.basis` corresponds to Mathlib's `gramSchmidt`.
 
+**Mathlib-free vs. Mathlib-bridge proof surface.** Theorems in
+`hex-gram-schmidt` (the Mathlib-free integer/rational GS core) may
+state equalities between:
+
+- Hex-local recurrences and their executable implementations
+  (e.g. `scaledCoeffRows_diag_eq_gramDetVecEntry` — diagonal writes
+  of the shared Bareiss pass agreeing with `gramDetVecEntry`);
+- Hex computational outputs and other Hex computational outputs
+  (e.g. `scaledCoeffs` and `scaledCoeffMatrix` as packagings of the
+  same Bareiss data).
+
+They may **not** state equalities between Hex computational outputs
+and the Leibniz `det` of any (sub)matrix. That includes `gramDet`,
+`scaledCoeffs`, the executable Bareiss output, the leading
+principal minor determinants, and any update formula expressed at
+the level of `Hex.det`. Theorems of that shape live in
+`hex-gram-schmidt-mathlib`, because their shortest proof goes
+through `Matrix.bareiss_eq_det` (see
+[hex-matrix.md "Mathlib-free vs. Mathlib-bridge proof surface"](hex-matrix.md)),
+which itself lives in `hex-matrix-mathlib`.
+
+Symptom this boundary exists to catch: a Mathlib-free
+`HexGramSchmidt/Int.lean` theorem of the form
+`<Hex computational output> = Matrix.det <matrix>` that chains
+through `Matrix.bareiss_eq_det`. Such a theorem belongs in
+`HexGramSchmidtMathlib/Int.lean` (or the analogous bridge file),
+not in the Mathlib-free core.
+
 ## External comparators
 
 No external comparator is required.

--- a/SPEC/Libraries/hex-matrix.md
+++ b/SPEC/Libraries/hex-matrix.md
@@ -116,6 +116,33 @@ a_{ij}^{(k)} = (a_{kk}^{(k-1)} · a_{ij}^{(k-1)} - a_{ik}^{(k-1)} · a_{kj}^{(k-
 where `/` is `Int.divExact` (GMP-backed `mpz_divexact`) — the division is
 always exact, and the divisibility proof is carried.
 
+**Mathlib-free vs. Mathlib-bridge proof surface.** The following
+theorems live exclusively in `hex-matrix-mathlib` and **must not**
+be restated, reproven, or specialized inside `hex-matrix`,
+regardless of how convenient that would be for a downstream
+Mathlib-free consumer:
+
+| Theorem (or theorem family) | Mathlib-free layer obligation |
+|---|---|
+| `bareiss_eq_det` — any equation of the form `bareiss M = det M` over the Leibniz `det` | forbidden in `hex-matrix` |
+| `det_eq` — `Hex.det M = Matrix.det (matrixEquiv M)` | forbidden in `hex-matrix` |
+| Desnanot–Jacobi in any form (unscaled, scaled, bordered-minor) that connects `Hex.det` of submatrices through an adjugate identity | forbidden in `hex-matrix` |
+| `NonzeroBareissPivots`, `BareissNoPivotInvariant`, and the no-pivot bordered-minor invariant proof chain culminating in `bareissNoPivot_eq_det` | forbidden in `hex-matrix` |
+
+A Mathlib-free consumer that *appears to require* a theorem on
+this list is the failure mode caught by
+[PLAN/Conventions.md §Library placement is a hard precondition
+question 2](../../PLAN/Conventions.md). The repair is to relocate
+the consumer's bridging theorem to the sibling `*-mathlib` layer
+(or to redesign the consumer's proof surface so it does not need
+to connect Hex computation to Leibniz `det` at the Mathlib-free
+layer at all). It is **not** to manufacture a Mathlib-free proof
+of the listed theorem.
+
+Row-operation lemmas (`det_rowSwap`, `det_rowScale`, `det_rowAdd`)
+and equalities purely between Hex-local definitions remain in
+`hex-matrix` and are unaffected by this list.
+
 **Proof that `bareiss M = det M`:** Via the bordered-minor invariant.
 Define `μ(k; i, j) := det M[rows 0..k-1 ∪ {i} | cols 0..k-1 ∪ {j}]`.
 The invariant `a^{(k)}_{ij} = μ(k; i, j)` holds by induction, where


### PR DESCRIPTION
This PR adds three SPEC/PLAN guardrails against a class of planning failure observed in the #3473 → #3878/#3879/#3479 cascade, where a single "Mathlib-free consumer needs this" claim caused six generations of issue decomposition trying to manufacture Mathlib-free proofs of theorems the SPEC explicitly assigns to the bridge layer.

[PLAN/Conventions.md](PLAN/Conventions.md) gains two rules.

"Reports do not override SPEC" restricts the follow-up issues a report under `reports/` may produce when it identifies a contradiction between code and SPEC to either a SPEC-clarification issue or a rollback issue — never an implementation issue that closes the gap by working against the SPEC. This is the rule that should have killed the `reports/bareiss-dependency-review.md` → #3473 step.

"Replan loops are a SPEC-violation signal" pauses any `depends-on:` chain in which three or more generations share a single "Mathlib-free X" deliverable shape and at least one `needs replan` skip cites that shape; further decomposition requires a SPEC-clarification issue first. This is the rule that should have killed the #3478 → #3492 → #3490/#3491/#3484 → #3800/#3801/#3802 → #3878/#3879/#3479 chain at the second hop.

[SPEC/Libraries/hex-matrix.md](SPEC/Libraries/hex-matrix.md) and [SPEC/Libraries/hex-gram-schmidt.md](SPEC/Libraries/hex-gram-schmidt.md) each gain an explicit "Mathlib-free vs. Mathlib-bridge proof surface" subsection listing the theorems that are forbidden to appear in the Mathlib-free layer. For hex-matrix this includes `bareiss_eq_det`, `det_eq`, every form of Desnanot–Jacobi, and the `NonzeroBareissPivots` / `BareissNoPivotInvariant` chain. For hex-gram-schmidt it forbids any equality between Hex computational outputs and the Leibniz `det` of a (sub)matrix.

The placement rule for these theorems was already present in the SPEC — but as a single sentence in a Bareiss subsection, easy to miss when reading an issue body in isolation. Promoting it to a named subsection with a list makes it grep-able and citable by triage.

Follow-up HO issues will use the new rules to clean up the existing cascade: close #3878 / #3879 / #3479, and either redesign HexGramSchmidt.Int's proof surface or relocate its `Matrix.bareiss_eq_det`-consuming theorems to HexGramSchmidtMathlib.

🤖 Prepared with Claude Code