### PR TITLE
HexGramSchmidt: prove integer adjacent-swap pivot gramDet formula and divisibility

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -2569,6 +2569,198 @@ theorem gramDet_rowAdd_earlier
     have hkt' : t ≤ k.val := Nat.le_of_not_lt hkt
     rw [leadingGramMatrixInt_rowAdd_outside b j k c t ht hkt']
 
+/-! ### Adjacent-swap pivot Gram-determinant product
+
+Swapping adjacent rows `km1, k` (with `km1 + 1 = k`) of `b` changes only the
+leading `k × k` Gram determinant within `0 ≤ t ≤ k + 1`. The new pivot Gram
+determinant `gramDet (rowSwap b km1 k) k` satisfies the integer product
+identity
+
+    gramDet b' k · gramDet b k = gramDet b (k+1) · gramDet b km1 + B²
+
+where `B = (scaledCoeffs b)[k][km1]`. This is the fraction-free form of the
+standard rational adjacent-swap update used by integer LLL. -/
+
+/-- If two integers cast to equal rationals, they are equal. -/
+private theorem intCast_rat_injective_int_eq {a b : Int} (h : (a : Rat) = (b : Rat)) :
+    a = b := by
+  have hz : ((a - b : Int) : Rat) = 0 := by
+    push_cast
+    grind
+  have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
+  omega
+
+private theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
+    Matrix.dot (u + v) w = Matrix.dot u w + Matrix.dot v w := by
+  rw [dot_comm_rat (u := u + v) (v := w)]
+  rw [dot_add_right_rat (u := w) (v := u) (w := v)]
+  rw [dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
+
+private theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
+    Matrix.dot (s • u) v = s * Matrix.dot u v := by
+  rw [dot_comm_rat (u := s • u) (v := v)]
+  rw [dot_smul_right_rat (s := s) (u := v) (v := u)]
+  rw [dot_comm_rat (u := v) (v := u)]
+
+/-- Pythagoras: if `curr ⊥ prev`, then the squared norm of `curr + μ • prev`
+splits as `‖curr‖² + μ² · ‖prev‖²`. -/
+private theorem normSq_add_smul_orthogonal_rat {m' : Nat}
+    (curr prev : Vector Rat m') (μ : Rat)
+    (horth : Matrix.dot curr prev = 0) :
+    Vector.normSq (curr + μ • prev) =
+      Vector.normSq curr + μ ^ 2 * Vector.normSq prev := by
+  show Matrix.dot (curr + μ • prev) (curr + μ • prev) =
+    Matrix.dot curr curr + μ ^ 2 * Matrix.dot prev prev
+  rw [dot_add_left_rat (u := curr) (v := μ • prev) (w := curr + μ • prev)]
+  rw [dot_add_right_rat (u := curr) (v := curr) (w := μ • prev)]
+  rw [dot_add_right_rat (u := μ • prev) (v := curr) (w := μ • prev)]
+  rw [dot_smul_right_rat (s := μ) (u := curr) (v := prev)]
+  rw [dot_smul_left_rat (s := μ) (u := prev) (v := curr)]
+  rw [dot_smul_left_rat (s := μ) (u := prev) (v := μ • prev)]
+  rw [dot_smul_right_rat (s := μ) (u := prev) (v := prev)]
+  have horth_swap : Matrix.dot prev curr = 0 := by
+    rw [dot_comm_rat]; exact horth
+  rw [horth, horth_swap]
+  grind
+
+/-- For `j < km1.val`, the Gram-Schmidt basis row is unchanged by the swap
+of rows `km1, k`. The norm-square product over indices `< km1.val` therefore
+agrees on `b` and `Matrix.rowSwap b km1 k`. -/
+private theorem gramSchmidtNormProduct_rowSwap_below
+    (b : Matrix Int n m) (km1 k : Fin n) (hkm1k : km1.val < k.val) :
+    gramSchmidtNormProduct (Matrix.rowSwap b km1 k) km1.val
+        (Nat.le_of_lt km1.isLt) =
+      gramSchmidtNormProduct b km1.val (Nat.le_of_lt km1.isLt) := by
+  unfold gramSchmidtNormProduct
+  apply foldl_mul_congr_simple
+  intro j _hj
+  have hj_lt_km1 : j.val < km1.val := j.isLt
+  congr 1
+  exact basis_rowSwap_of_before b km1 k
+    ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.le_of_lt km1.isLt)⟩ hkm1k hj_lt_km1
+
+/-- Unconditional version of `gramDet_eq_prod_normSq`: the leading Gram
+determinant casts to the rational `gramSchmidtNormProduct` without requiring
+linear independence. The `independent` hypothesis in the public theorem is
+not actually used by the proof. -/
+private theorem gramDet_eq_prod_normSq_uncond (b : Matrix Int n m)
+    (k : Nat) (hk : k ≤ n) :
+    (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
+  rw [gramDet_rat_eq_progressMatrix_zero_det b k hk]
+  rw [← progressMatrix_det_invariant b k hk k (Nat.le_refl k)]
+  rw [progressMatrix_full_eq_auxMatrix]
+  exact auxMatrix_det_eq_prod_normSq b k hk
+
+/-- `gramDet` is independent of the propositional `≤ n` proof, and depends only
+on the Nat value `k`. Two `gramDet` calls with equal `Nat` arguments produce
+equal values. -/
+private theorem gramDet_subst_val
+    (b : Matrix Int n m) (j₁ j₂ : Nat) (h₁ : j₁ ≤ n) (h₂ : j₂ ≤ n)
+    (he : j₁ = j₂) :
+    gramDet b j₁ h₁ = gramDet b j₂ h₂ := by
+  subst he
+  rfl
+
+/-- Same as `gramDet_subst_val` for `gramSchmidtNormProduct`. -/
+private theorem gramSchmidtNormProduct_subst_val
+    (b : Matrix Int n m) (j₁ j₂ : Nat) (h₁ : j₁ ≤ n) (h₂ : j₂ ≤ n)
+    (he : j₁ = j₂) :
+    gramSchmidtNormProduct b j₁ h₁ = gramSchmidtNormProduct b j₂ h₂ := by
+  subst he
+  rfl
+
+/-- Integer fraction-free identity for the leading pivot Gram determinant
+after swapping adjacent rows `km1, k` with `km1.val + 1 = k.val`:
+
+    gramDet b' k · gramDet b k = gramDet b (k+1) · gramDet b km1 + B²
+
+where `B = (scaledCoeffs b)[k][km1]`. This is the algebraic heart of the
+integer LLL adjacent-swap update. -/
+theorem gramDet_rowSwap_adjacent_pivot_product
+    (b : Matrix Int n m) (km1 k : Fin n) (hkm1 : km1.val + 1 = k.val) :
+    let B : Int := GramSchmidt.entry (scaledCoeffs b) k km1
+    ((gramDet (Matrix.rowSwap b km1 k) k.val (Nat.le_of_lt k.isLt) : Nat) : Int) *
+        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) =
+      ((gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt) : Nat) : Int) *
+          ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) +
+        B ^ 2 := by
+  intro B
+  have hkm1k : km1.val < k.val := by omega
+  have hkm1_le_n : km1.val ≤ n := Nat.le_of_lt km1.isLt
+  have hk_le_n : k.val ≤ n := Nat.le_of_lt k.isLt
+  have hk1_le_n : k.val + 1 ≤ n := Nat.succ_le_of_lt k.isLt
+  have hkm1_succ_le : km1.val + 1 ≤ n := Nat.succ_le_of_lt km1.isLt
+  -- Local abbreviations on the rational side.
+  let μ : Rat := GramSchmidt.entry (coeffs b) k km1
+  let prev : Vector Rat m := (basis b).row km1
+  let curr : Vector Rat m := (basis b).row k
+  let G : Rat := gramSchmidtNormProduct b km1.val hkm1_le_n
+  let Nkm1 : Rat := Vector.normSq prev
+  let Nk : Rat := Vector.normSq curr
+  -- Rational expressions for each Gram determinant we touch.
+  have hdkm1_rat : (gramDet b km1.val hkm1_le_n : Rat) = G :=
+    gramDet_eq_prod_normSq_uncond b km1.val hkm1_le_n
+  -- gramDet b k.val = gramDet b (km1.val + 1) = G * Nkm1.
+  have hdk_rat : (gramDet b k.val hk_le_n : Rat) = G * Nkm1 := by
+    have h_succ := gramDet_succ_rat b km1.val hkm1_succ_le
+    have hgd_eq :
+        gramDet b (km1.val + 1) hkm1_succ_le = gramDet b k.val hk_le_n :=
+      gramDet_subst_val b _ _ _ _ hkm1
+    rw [← hgd_eq, h_succ]
+  -- gramDet b (k.val + 1) = G * Nkm1 * Nk.
+  have hdkp1_rat : (gramDet b (k.val + 1) hk1_le_n : Rat) = G * Nkm1 * Nk := by
+    have h_succ := gramDet_succ_rat b k.val hk1_le_n
+    have hgnp_k_eq :
+        gramSchmidtNormProduct b k.val hk_le_n =
+          gramSchmidtNormProduct b (km1.val + 1) hkm1_succ_le :=
+      gramSchmidtNormProduct_subst_val b _ _ _ _ hkm1.symm
+    rw [h_succ, hgnp_k_eq,
+        gramSchmidtNormProduct_succ b km1.val hkm1_succ_le]
+  -- Basis orthogonality between curr and prev.
+  have horth : Matrix.dot curr prev = 0 :=
+    basis_orthogonal b k.val km1.val k.isLt km1.isLt (by omega)
+  -- New basis row at km1 of the swapped matrix is `curr + μ • prev`.
+  have hbasis_swap :
+      (basis (Matrix.rowSwap b km1 k)).row km1 = curr + μ • prev :=
+    basis_rowSwap_adjacent_prev b km1 k hkm1
+  -- gramDet (rowSwap b km1 k) k.val = G * (Nk + μ^2 * Nkm1).
+  have hdprime_rat :
+      (gramDet (Matrix.rowSwap b km1 k) k.val hk_le_n : Rat) =
+        G * (Nk + μ ^ 2 * Nkm1) := by
+    have h_succ :=
+      gramDet_succ_rat (Matrix.rowSwap b km1 k) km1.val hkm1_succ_le
+    have hgd_eq :
+        gramDet (Matrix.rowSwap b km1 k) (km1.val + 1) hkm1_succ_le =
+          gramDet (Matrix.rowSwap b km1 k) k.val hk_le_n :=
+      gramDet_subst_val (Matrix.rowSwap b km1 k) _ _ _ _ hkm1
+    rw [← hgd_eq, h_succ,
+        gramSchmidtNormProduct_rowSwap_below b km1 k hkm1k]
+    show G * Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
+        ⟨km1.val, km1.isLt⟩) = G * (Nk + μ ^ 2 * Nkm1)
+    have hbasis_row :
+        (basis (Matrix.rowSwap b km1 k)).row ⟨km1.val, km1.isLt⟩ =
+          curr + μ • prev := hbasis_swap
+    rw [hbasis_row, normSq_add_smul_orthogonal_rat curr prev μ horth]
+  -- Rational expression for B.
+  have hB_rat : ((B : Int) : Rat) = G * Nkm1 * μ := by
+    show ((GramSchmidt.entry (scaledCoeffs b) k km1 : Int) : Rat) =
+        G * Nkm1 * μ
+    rw [scaledCoeffs_eq b k.val km1.val k.isLt hkm1k]
+    have hgd_eq :
+        gramDet b (km1.val + 1)
+            (Nat.succ_le_of_lt (Nat.lt_trans hkm1k k.isLt)) =
+          gramDet b k.val hk_le_n :=
+      gramDet_subst_val b _ _ _ _ hkm1
+    show (gramDet b (km1.val + 1) _ : Rat) *
+        GramSchmidt.entry (coeffs b) ⟨k.val, k.isLt⟩
+          ⟨km1.val, Nat.lt_trans hkm1k k.isLt⟩ = G * Nkm1 * μ
+    rw [hgd_eq, hdk_rat]
+  -- Promote to Rat and discharge.
+  apply intCast_rat_injective_int_eq
+  push_cast
+  rw [hdprime_rat, hdk_rat, hdkp1_rat, hdkm1_rat, hB_rat]
+  grind
+
 end GramSchmidt.Int
 
 namespace GramSchmidt.Rat

--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -770,13 +770,48 @@ theorem gramDet_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
       (((gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt) : Nat) : Int) *
           ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) + B ^ 2) /
         ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) := by
-  sorry
+  let km1 := GramSchmidt.prevRow k hk
+  let B : Int := GramSchmidt.entry (scaledCoeffs b) k km1
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]; omega
+  have hprod :=
+    GramSchmidt.Int.gramDet_rowSwap_adjacent_pivot_product
+      (b := b) (km1 := km1) (k := k) hkm1
+  -- `hprod` is in terms of `Matrix.rowSwap`; `adjacentSwap` is exactly that.
+  have hdk_pos :
+      ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ≠ 0 := by
+    intro h
+    apply hdet
+    exact Int.ofNat.inj h
+  -- From dprime_int * dk_int = (rhs) and dk_int ≠ 0, deduce dprime_int = rhs / dk_int.
+  -- Goal: ((gramDet (adjacentSwap b k hk) k.val ...) : Int) = (rhs) / dk_int.
+  show ((gramDet (Matrix.rowSwap b km1 k) k.val (Nat.le_of_lt k.isLt) : Nat) : Int) =
+      (((gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt) : Nat) : Int) *
+          ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) + B ^ 2) /
+        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int)
+  rw [← hprod]
+  exact (Int.mul_ediv_cancel _ hdk_pos).symm
 
 theorem adjacentSwap_gramDetNumerator_dvd (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
     adjacentSwapDenom b k ∣ adjacentSwapGramDetNumerator b k hk := by
-  sorry
+  let km1 := GramSchmidt.prevRow k hk
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]; omega
+  have hprod :=
+    GramSchmidt.Int.gramDet_rowSwap_adjacent_pivot_product
+      (b := b) (km1 := km1) (k := k) hkm1
+  -- The numerator equals dprime_int * dk_int, hence dk_int divides it.
+  show ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ∣
+      adjacentSwapGramDetNumerator b k hk
+  show ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ∣
+      ((gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt) : Nat) : Int) *
+          ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) +
+        (GramSchmidt.entry (scaledCoeffs b) k km1) ^ 2
+  rw [← hprod]
+  exact ⟨((gramDet (Matrix.rowSwap b km1 k) k.val (Nat.le_of_lt k.isLt) : Nat) : Int),
+    Int.mul_comm _ _⟩
 
 private theorem intCast_rat_injective_local {a b : Int} (h : (a : Rat) = (b : Rat)) :
     a = b := by

--- a/progress/20260514T013822Z_edb61f7c.md
+++ b/progress/20260514T013822Z_edb61f7c.md
@@ -1,0 +1,61 @@
+# 2026-05-14 01:38 UTC — feature session edb61f7c (issue #3886)
+
+## Accomplished
+
+Closed the two adjacent-swap pivot sorries in `HexGramSchmidt/Update.lean`
+called out by issue #3886:
+
+- `gramDet_adjacentSwap_pivot`: the integer division formula
+  `gramDet b' k = (gramDet b (k+1) · gramDet b km1 + B²) / gramDet b k`.
+- `adjacentSwap_gramDetNumerator_dvd`: the matching divisibility that
+  justifies the exact integer division.
+
+Both follow from a new public theorem in `HexGramSchmidt/Int.lean`:
+`gramDet_rowSwap_adjacent_pivot_product`, the fraction-free integer
+product identity `gramDet b' k · gramDet b k = gramDet b (k+1) · gramDet
+b km1 + B²` where `b' = Matrix.rowSwap b km1 k` and `B = (scaledCoeffs
+b)[k][km1]`. The proof goes via the rational `gramSchmidtNormProduct`
+decomposition: it expresses each `gramDet` as a product of `‖basis i‖²`,
+uses Pythagoras for the swapped pivot vector (Gram-Schmidt orthogonality
+of `basis k ⊥ basis km1`), and discharges the resulting polynomial
+identity over `Rat` with `grind`.
+
+Supporting helpers added in `Int.lean` (all `private`):
+
+- `gramDet_eq_prod_normSq_uncond`: the unconditional rational
+  `gramDet = gramSchmidtNormProduct` (the `independent` hypothesis on
+  the existing public theorem is not actually used by its proof body).
+- `gramDet_subst_val`, `gramSchmidtNormProduct_subst_val`: `Nat`-value
+  congruences that bridge the `(km1.val + 1)` form of
+  `gramDet_succ_rat` to the `k.val` form requested by the theorem
+  statements.
+- `intCast_rat_injective_int_eq`: integer injectivity through the
+  rational cast.
+- `dot_add_left_rat`, `dot_smul_left_rat`: left-distribution / left-
+  scalar versions derived from the existing right-side privates plus
+  `dot_comm_rat`.
+- `normSq_add_smul_orthogonal_rat`: Pythagoras for `curr + μ • prev`
+  when `dot curr prev = 0`.
+- `gramSchmidtNormProduct_rowSwap_below`: the norm-square product over
+  indices `< km1.val` is invariant under swapping rows `km1, k`, via
+  `basis_rowSwap_of_before` and `foldl_mul_congr_simple`.
+
+## Current frontier
+
+The remaining five adjacent-swap sorries in `HexGramSchmidt/Update.lean`
+(the `above_prev` / `above_curr` `scaledCoeffs` formulas and their two
+divisibility partners, plus `scaledCoeffs_adjacentSwap_pivot`) are
+out of scope for this issue. Sibling issues #3890 and the eventual
+follow-up will pick them up; #3890 in particular now becomes a clean
+target since the algebraic `dk'` form is exposed.
+
+## Next step
+
+Land this PR; the `above_prev` / `above_curr` divisibility lemmas
+should reuse the same product-equation pattern with the
+`adjacentSwapScaledCoeffAbove{Prev,Curr}Numerator` integer
+expressions.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3886

Session: `edb61f7c-a92b-4185-bf3d-19094744ce63`

71fd50b feat: prove integer adjacent-swap pivot gramDet formula and divisibility

🤖 Prepared with Claude Code