### PR TITLE
doc: proof path governs placement, not just statement

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -189,6 +189,19 @@ through `Matrix.bareiss_eq_det`. Such a theorem belongs in
 `HexGramSchmidtMathlib/Int.lean` (or the analogous bridge file),
 not in the Mathlib-free core.
 
+**Proof path governs placement, not just statement.** Theorems
+whose *statement* is purely Hex-local but whose only realistic
+proof goes through `Matrix.bareiss_eq_det` (directly, or via a
+renamed `bareiss`-invariance lemma that secretly re-derives
+Desnanot–Jacobi) also belong in `hex-gram-schmidt-mathlib`.
+Concretely, `gramDet_sizeReduce`,
+`scaledCoeffs_sizeReduce_pivot`, and `gramDet_rowAdd_earlier` state
+equalities between Hex computational outputs — Hex-local by
+statement — but their natural proofs cross to the bridge. They
+live in the bridge layer. See
+[hex-matrix.md "Proof path governs placement, not just statement"](hex-matrix.md)
+for the analogous rule on the matrix side.
+
 ## External comparators
 
 No external comparator is required.

--- a/SPEC/Libraries/hex-matrix.md
+++ b/SPEC/Libraries/hex-matrix.md
@@ -143,6 +143,30 @@ Row-operation lemmas (`det_rowSwap`, `det_rowScale`, `det_rowAdd`)
 and equalities purely between Hex-local definitions remain in
 `hex-matrix` and are unaffected by this list.
 
+**Proof path governs placement, not just statement.** A theorem
+whose *statement* is purely Hex-local (e.g. `bareiss (rowAdd M
+i j c) = bareiss M`, with `det` nowhere mentioned) still belongs in
+`hex-matrix-mathlib` if its only realistic Mathlib-free proof
+requires re-deriving an entry from the forbidden list above —
+re-deriving Desnanot–Jacobi by hand, restating the no-pivot
+bordered-minor invariant under a renamed lemma, or threading
+`bareiss_eq_det` through twice while hiding it behind a wrapper.
+The shortest-path test in
+[PLAN/Conventions.md §Library placement is a hard precondition
+question 2](../../PLAN/Conventions.md) governs **proof
+obligations**, not statement surface. A Hex-local statement with a
+bridge-only proof is the same SPEC violation as a bridge-typed
+statement, dressed up.
+
+Symptom this addendum exists to catch: an issue titled
+"Mathlib-free `bareiss`-invariance for row-add" whose deliverable
+is to prove an `Int`-only `bareiss → bareiss` equation by induction
+on the executable Bareiss recurrence. The induction works because
+Desnanot–Jacobi (or its `Int`-narrowed shadow) is being secretly
+re-derived inline. The repair is to relocate the *consumer*
+theorem (`gramDet_sizeReduce`, `scaledCoeffs_sizeReduce_pivot`, or
+similar) to the bridge layer, not to add the secret re-derivation.
+
 **Proof that `bareiss M = det M`:** Via the bordered-minor invariant.
 Define `μ(k; i, j) := det M[rows 0..k-1 ∪ {i} | cols 0..k-1 ∪ {j}]`.
 The invariant `a^{(k)}_{ij} = μ(k; i, j)` holds by induction, where


### PR DESCRIPTION
Follow-up to PR #3887.

Today's parallel HO-43 cleanup attempt (#3905 → #3917, #3919) revealed a loophole in the placement tables added by #3887: the tables governed theorem **statements**, but a theorem whose statement is purely Hex-local (e.g. \`bareiss (rowAdd M i j c) = bareiss M\`) can still have a proof obligation that only the bridge layer can discharge — by re-deriving Desnanot–Jacobi inline on the executable Bareiss recurrence, or by threading \`bareiss_eq_det\` through twice behind a wrapper.

[SPEC/Libraries/hex-matrix.md](SPEC/Libraries/hex-matrix.md) and [SPEC/Libraries/hex-gram-schmidt.md](SPEC/Libraries/hex-gram-schmidt.md) each gain a "Proof path governs placement, not just statement" addendum. The shortest-path test in [PLAN/Conventions.md Q2](PLAN/Conventions.md) — "Mathlib-free libraries cannot host a proof whose shortest path goes through \`MvPolynomial\`, or similar" — governs proof obligations, not statement surface. A Hex-local statement with a bridge-only proof is the same SPEC violation as a bridge-typed statement, dressed up.

The hex-gram-schmidt addendum names \`gramDet_sizeReduce\`, \`scaledCoeffs_sizeReduce_pivot\`, and \`gramDet_rowAdd_earlier\` specifically. Their statements are Hex-output = Hex-output equalities (allowed by the original table) but their natural proofs cross the bridge; they belong in \`hex-gram-schmidt-mathlib\`.

This unblocks closing #3917 and #3919, and lets HO-43 (#3899) expand to relocate the named theorems rather than the parallel HO-43 chain trying to manufacture Mathlib-free proofs for them.

🤖 Prepared with Claude Code