### PR TITLE
spec: relayer FLINT fq_default from HexGfqRing to HexGfqField

### DIFF
--- a/SPEC/Libraries/hex-gfq-field.md
+++ b/SPEC/Libraries/hex-gfq-field.md
@@ -43,3 +43,33 @@ cardinality, and correspondence with Mathlib's abstract finite fields.
 - `a / b = a * b⁻¹`
 - `frob(a) = a ^ p`
 - Field axioms for `FiniteField p f hf hirr`
+
+## External comparators
+
+| Comparator | Class | Scope |
+|---|---|---|
+| FLINT `fq_default` arithmetic via python-flint | informational | bench targets exercising finite-field arithmetic: addition, multiplication, reduction modulo `f`, inversion, division, exponentiation, Frobenius |
+
+FLINT's `fq_default` is the standard reference for finite-field
+arithmetic and covers the same operations as HexGfqField:
+reduction modulo a fixed irreducible modulus polynomial, addition,
+multiplication, inversion, division, and exponentiation. FLINT
+internally selects between representations (`fq_nmod` for word-size
+primes, `fq_zech` for small fields) via crossover heuristics that
+Hex does not replicate; the constant-factor gap is structural rather
+than algorithmic. Classification is `informational`.
+
+The irreducibility precondition `hirr : Irreducible f` carried by
+`FiniteField p f hf hirr` matches the precondition `fq_default`
+imposes at `ctx` construction time — bench fixtures generated from
+the field type satisfy this automatically. This is the layer at
+which the FLINT primitive's contract aligns with Hex's; the
+underlying quotient-ring arithmetic in HexGfqRing handles the
+general (reducible-modulus) case for which no clean FLINT primitive
+exists, and is covered transitively through this declaration on
+fixtures whose moduli are irreducible.
+
+Wired via a persistent-subprocess Python driver per
+`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+
+Structured metadata in `libraries.yml: HexGfqField.phase4.comparators`.

--- a/SPEC/Libraries/hex-gfq-ring.md
+++ b/SPEC/Libraries/hex-gfq-ring.md
@@ -43,20 +43,29 @@ supports a field structure; that extension belongs to hex-gfq-field.
 
 ## External comparators
 
-| Comparator | Class | Scope |
-|---|---|---|
-| FLINT `fq_default` arithmetic via python-flint | informational | bench targets exercising quotient-ring arithmetic: addition, multiplication, reduction modulo `f` |
+No external comparator is required.
 
-FLINT's `fq_default` is the standard reference for finite-field
-quotient-ring arithmetic and covers the same operations:
-reduction modulo a fixed modulus polynomial, addition,
-multiplication. FLINT internally selects between
-representations (`fq_nmod` for word-size primes, `fq_zech` for
-small fields) via crossover heuristics that Hex does not
-replicate; the constant-factor gap is structural rather than
-algorithmic. Classification is `informational`.
+**Justification:** `structural-layer` per
+`SPEC/benchmarking.md §"Comparator naming"`. HexGfqRing's semantic
+domain is `F_p[x]/(f)` for *any* nonconstant `f`, including reducible
+moduli (see the contents section: "This does NOT require `f` to be
+irreducible — the quotient is always a ring"). The natural FLINT
+primitive `fq_default` rejects reducible moduli at `ctx` construction
+time (FLINT internally selects between `fq_nmod` and `fq_zech`
+representations, both of which assume a field), so it cannot serve as
+a reference implementation for HexGfqRing's actual scope.
 
-Wired via a persistent-subprocess Python driver per
-`SPEC/benchmarking.md §"External comparators" §"Process call"`.
+Other FLINT primitives (`nmod_poly` with explicit `nmod_poly_divrem`
+per multiplication) cover the general quotient case but do not measure
+the comparison HexGfqRing's design point is targeting — they pay
+reduction overhead on every operation and do not exploit the
+fixed-modulus structure, so the ratio carries no information about
+quotient-ring constant-factor parity.
 
-Structured metadata in `libraries.yml: HexGfqRing.phase4.comparators`.
+Coverage at the finite-field subset of HexGfqRing's domain is provided
+upstream by HexGfqField's external comparator declaration (FLINT
+`fq_default`, informational), which exercises HexGfqRing's quotient
+arithmetic transitively through `FiniteField p f hf hirr`'s thin
+wrapper over `PolyQuotient p f hf`. The irreducibility precondition
+that breaks the declaration at this layer is naturally satisfied at
+the field layer.

--- a/SPEC/Libraries/hex-gfq.md
+++ b/SPEC/Libraries/hex-gfq.md
@@ -54,7 +54,7 @@ HexConway and constructs `FiniteField p (conwayPoly p n) ...`
 using HexGfqField's generic quotient-field machinery (or
 `GF2q` via HexGF2's packed representation for `p = 2`). The
 runtime cost is dominated by the underlying quotient-field
-arithmetic, which is covered by HexGfqRing's external comparator
+arithmetic, which is covered by HexGfqField's external comparator
 declaration (FLINT `fq_default`, informational); the `GF2q` path
 is covered by HexGF2's external comparator declaration
 (NTL `GF2X`, informational). HexGfq itself contributes only the


### PR DESCRIPTION
HO-26 (#3674) surfaced an audit finding: HexGfqRing's declared external comparator (FLINT \`fq_default\`) rejects the library's actual bench inputs at FLINT-ctx construction time, because HexGfqRing's semantic domain is \`F_p[x]/(f)\` for arbitrary nonconstant \`f\` (the SPEC explicitly says *"This does NOT require f to be irreducible — the quotient is always a ring"*), while \`fq_default\` internally selects between \`fq_nmod\` and \`fq_zech\` representations, both of which assume a field. The skip comment on #3674 documents the precise failure mode.

The mismatch is structural: there is no clean FLINT primitive matching HexGfqRing's general quotient-ring scope, and the substitute primitive (\`nmod_poly\` with explicit \`nmod_poly_divrem\` per multiplication) measures something other than the constant-factor parity question the declaration was trying to answer.

This PR moves the FLINT \`fq_default\` comparator declaration to its correct semantic layer:

- [SPEC/Libraries/hex-gfq-ring.md](SPEC/Libraries/hex-gfq-ring.md) drops the declaration with a \`structural-layer\` rationale pointing at the field layer for coverage. The semantic-domain mismatch is named so a future audit doesn't re-add the broken declaration.
- [SPEC/Libraries/hex-gfq-field.md](SPEC/Libraries/hex-gfq-field.md), where the type carries \`hirr : Irreducible f\` and bench fixtures naturally satisfy \`fq_default\`'s precondition, gains the comparator declaration. HexGfqField is at \`done_through: 3\`, so this lands before its Phase 4 starts.
- [SPEC/Libraries/hex-gfq.md](SPEC/Libraries/hex-gfq.md)'s structural-layer justification re-points its FLINT coverage argument at HexGfqField instead of HexGfqRing.

No code or \`libraries.yml\` changes — SPEC only. Two HO follow-ups will land separately:

1. HexGfqRing's \`done_through: 5\` was claimed against the now-removed declaration. That's an audit-finding rollback under [PLAN/Conventions.md §"Bench-found, conformance-found, and audit-found issues"](PLAN/Conventions.md): a small rollback PR setting \`HexGfqRing.done_through: 5 → 3\`.
2. HexGfqField's Phase 4 wires the relayed comparator, regenerates the headline report, and re-promotes to \`done_through: 4\`.

🤖 Prepared with Claude Code