### PR TITLE
HexGfq: add proof-friendly N32 quotient-step lemmas

### DIFF
--- a/HexGfq/CrossCheck.lean
+++ b/HexGfq/CrossCheck.lean
@@ -515,39 +515,630 @@ private def genericN32Cert : Berlekamp.IrreducibilityCertificate where
     genericMod genericMod_monic genericN32SamePrimeCert
     genericN32Quotients = true
 
-private theorem genericN32_step0_prev_reduced :
-    (polyP2 #[0, 1]).degree?.getD 0 < genericMod.degree?.getD 0 := by
-  have hdegree : genericMod.degree?.getD 0 = 32 := by
-    unfold genericMod Conway.packedGF2FpPoly DensePoly.degree? DensePoly.size
-    rfl
-  apply Berlekamp.degree?_getD_lt_of_size_le
-  · decide
-  · rw [hdegree]
-    unfold polyP2 FpPoly.ofCoeffs
-    exact Nat.le_trans (DensePoly.size_ofCoeffs_le _)
-      (by simp)
+private theorem genericMod_degree_eq : genericMod.degree?.getD 0 = 32 := by
+  unfold genericMod Conway.packedGF2FpPoly DensePoly.degree? DensePoly.size
+  rfl
 
-private theorem genericN32_step0_curr_reduced :
-    (polyP2 #[0, 0, 1]).degree?.getD 0 < genericMod.degree?.getD 0 := by
-  have hdegree : genericMod.degree?.getD 0 = 32 := by
-    unfold genericMod Conway.packedGF2FpPoly DensePoly.degree? DensePoly.size
-    rfl
-  apply Berlekamp.degree?_getD_lt_of_size_le
-  · decide
-  · rw [hdegree]
-    unfold polyP2 FpPoly.ofCoeffs
-    exact Nat.le_trans (DensePoly.size_ofCoeffs_le _)
-      (by simp)
+private theorem genericMod_degree_pos : 0 < genericMod.degree?.getD 0 := by
+  rw [genericMod_degree_eq]; decide
 
-private theorem genericN32_step0_reduced_bools :
-    decide ((polyP2 #[0, 1]).degree?.getD 0 < genericMod.degree?.getD 0) = true ∧
-      decide ((polyP2 #[0, 0, 1]).degree?.getD 0 < genericMod.degree?.getD 0) = true := by
-  exact ⟨decide_eq_true genericN32_step0_prev_reduced,
-    decide_eq_true genericN32_step0_curr_reduced⟩
+private theorem polyP2_size_le_32 {arr : Array Nat} (h : arr.size ≤ 32) :
+    (polyP2 arr).size ≤ genericMod.degree?.getD 0 := by
+  rw [genericMod_degree_eq]
+  unfold polyP2 FpPoly.ofCoeffs
+  exact Nat.le_trans (DensePoly.size_ofCoeffs_le _) (by simpa using h)
 
 #guard
   Berlekamp.quotientStepCoeffCheck 65
     (polyP2 #[0, 1]) (polyP2 #[0, 0, 1]) (polyP2 #[]) genericMod = true
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step0_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 0 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1])
+    (curr := polyP2 #[0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step1_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 1 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 1])
+    (curr := polyP2 #[0, 0, 0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step2_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 2 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 0, 1])
+    (curr := polyP2 #[0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step3_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 3 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (curr := polyP2 #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step4_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 4 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 1, 1, 0, 0, 0, 1])
+    (quot := polyP2 #[1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step5_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 5 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 1, 1, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step6_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 6 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (quot := polyP2 #[])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step7_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 7 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1])
+    (quot := polyP2 #[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step8_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 8 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1])
+    (quot := polyP2 #[0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step9_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 9 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1])
+    (curr := polyP2 #[1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1])
+    (quot := polyP2 #[0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step10_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 10 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1])
+    (curr := polyP2 #[0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1])
+    (quot := polyP2 #[1, 1, 1, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step11_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 11 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1])
+    (curr := polyP2 #[1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1])
+    (quot := polyP2 #[1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step12_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 12 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1])
+    (curr := polyP2 #[1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1])
+    (quot := polyP2 #[0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step13_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 13 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1])
+    (curr := polyP2 #[0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1])
+    (quot := polyP2 #[1, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step14_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 14 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0, 1])
+    (curr := polyP2 #[1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1])
+    (quot := polyP2 #[1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step15_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 15 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1])
+    (curr := polyP2 #[0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1])
+    (quot := polyP2 #[1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step16_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 16 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 0, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1])
+    (curr := polyP2 #[0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1])
+    (quot := polyP2 #[0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step17_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 17 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1])
+    (curr := polyP2 #[0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1])
+    (quot := polyP2 #[0, 1, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step18_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 18 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1])
+    (curr := polyP2 #[0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1])
+    (quot := polyP2 #[0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step19_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 19 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 0, 1])
+    (curr := polyP2 #[0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1])
+    (quot := polyP2 #[0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step20_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 20 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 1, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 1, 1, 1, 1])
+    (curr := polyP2 #[0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1])
+    (quot := polyP2 #[0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step21_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 21 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1])
+    (curr := polyP2 #[0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1])
+    (quot := polyP2 #[0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step22_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 22 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 1])
+    (curr := polyP2 #[1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1])
+    (quot := polyP2 #[1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step23_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 23 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1])
+    (quot := polyP2 #[0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step24_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 24 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 0, 1, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1])
+    (curr := polyP2 #[1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1])
+    (quot := polyP2 #[0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step25_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 25 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1])
+    (curr := polyP2 #[1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1])
+    (quot := polyP2 #[0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step26_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 26 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1])
+    (curr := polyP2 #[1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1])
+    (quot := polyP2 #[0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step27_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 27 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 1, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1])
+    (curr := polyP2 #[1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+    (quot := polyP2 #[0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step28_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 28 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1])
+    (curr := polyP2 #[1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1])
+    (quot := polyP2 #[0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step29_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 29 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1])
+    (curr := polyP2 #[0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1])
+    (quot := polyP2 #[1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step30_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 30 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1])
+    (curr := polyP2 #[0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1])
+    (quot := polyP2 #[0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
+
+set_option maxRecDepth 65536 in
+set_option maxHeartbeats 10000000 in
+private theorem genericN32_step31_check :
+    Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep
+      genericMod genericN32SamePrimeCert genericN32Quotients 31 = true := by
+  apply Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds
+    (prev := polyP2 #[0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1])
+    (curr := polyP2 #[0, 1])
+    (quot := polyP2 #[0, 1, 0, 1, 1, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1])
+  · rfl
+  · rfl
+  · rfl
+  · exact genericMod_degree_pos
+  · exact polyP2_size_le_32 (by decide)
+  · exact polyP2_size_le_32 (by decide)
+  · simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs, genericMod,
+      Conway.packedGF2FpPoly]
+    decide
 
 #guard
   Berlekamp.checkRabinBezoutWitnesses

--- a/progress/20260514T075915Z_db1e3247.md
+++ b/progress/20260514T075915Z_db1e3247.md
@@ -1,0 +1,46 @@
+# 2026-05-14 07:59 UTC — feature session (db1e3247) on #3984
+
+## Accomplished
+
+- Claimed #3984 and added all 32 proof-friendly N32 quotient-witness step
+  lemmas (`genericN32_step0_check` … `genericN32_step31_check`) in
+  `HexGfq/CrossCheck.lean`, dispatching each through
+  `Berlekamp.checkPowChainLinearIncrementalQuotientWitnessStep_of_entry_size_bounds`.
+- Factored out three private helpers used by every step:
+  `genericMod_degree_eq`, `genericMod_degree_pos`, and
+  `polyP2_size_le_32`, replacing the earlier `genericN32_step0_*_reduced`
+  scaffolding that only covered step 0.
+- Each step proof picks concrete `prev`, `curr`, `quot` literals from the
+  existing `genericN32PowChain` / `genericN32Quotients` arrays, then
+  closes the structural premises with `rfl` and the coefficient-equation
+  obligation via `simp [polyP2, FpPoly.ofCoeffs, DensePoly.ofCoeffs,
+  genericMod, Conway.packedGF2FpPoly]; decide` under
+  `maxRecDepth 65536` / `maxHeartbeats 10000000`.
+- Verified `lake build HexBerlekamp.Irreducibility`,
+  `lake build HexGfq.CrossCheck` (≈ 275 s file build),
+  `python3 scripts/check_dag.py`, and `git diff --check`.
+- `rg -n '^\s*sorry\b|^axiom\b|native_decide|TODO|FIXME' HexBerlekamp
+  HexGfq/CrossCheck.lean` reports only the pre-existing N16 and N32
+  `generic_irr` placeholders.
+
+## Current frontier
+
+- All 32 N32 quotient-witness step lemmas are now propositional
+  theorems. The aggregate
+  `genericN32QuotientWitnesses_check` (i.e.
+  `checkPowChainLinearIncrementalQuotientWitnesses … = true`) can now be
+  assembled from these step lemmas plus the first-entry coefficient
+  check — that assembly is #3985, intentionally out of scope here.
+- Plain `decide` on a single step still does not reduce because
+  `DensePoly.mul` does not unfold cleanly in the kernel; the
+  `simp [polyP2, …]` rewrite is what makes the residual coefficient
+  array equality decidable under bounded recursion depth.
+
+## Next step
+
+- Open the PR for #3984 and let #3985 pick up the aggregate witness
+  theorem.
+
+## Blockers
+
+- None for #3984.


### PR DESCRIPTION
Closes #3984

Session: `db1e3247-d4b2-4542-8e95-94b67c6d169d`

cd3a0b6 feat: prove N32 quotient-witness step lemmas in HexGfq.CrossCheck

🤖 Prepared with Claude Code