### PR TITLE
HexBZ core: prove Mathlib-free ZPoly.Irreducible for X and linearFactorForRoot

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -4329,7 +4329,145 @@ theorem isIrreducible_iff (f : ZPoly) :
 instance instDecidableIrreducible (f : ZPoly) : Decidable (Irreducible f) :=
   decidable_of_iff _ (isIrreducible_iff f)
 
+/-- A polynomial of dense size `1` is the constant polynomial of its zeroth
+coefficient. The trimming invariant on `DensePoly` forces the single stored
+coefficient to be nonzero, so `coeff 0` already names the unique stored entry. -/
+private theorem eq_C_of_size_eq_one (a : ZPoly) (hsize : a.size = 1) :
+    a = DensePoly.C (a.coeff 0) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · simp [hn]
+  · simp [hn]
+    exact DensePoly.coeff_eq_zero_of_size_le a (by omega)
+
+/-- An integer factor of `1` is `±1`. Used to read off the unit factor in
+size-two monic polynomial irreducibility proofs. -/
+private theorem int_factor_one_eq_unit {x y : Int} (h : x * y = 1) :
+    x = 1 ∨ x = -1 := by
+  have hx_dvd : x ∣ (1 : Int) := ⟨y, h.symm⟩
+  have hxnat_dvd : x.natAbs ∣ (1 : Nat) := by
+    have := Int.natAbs_dvd_natAbs.mpr hx_dvd
+    simpa using this
+  have hxnat_le : x.natAbs ≤ 1 := Nat.le_of_dvd (by omega) hxnat_dvd
+  have hx_ne : x ≠ 0 := by
+    intro hzero
+    rw [hzero] at h
+    rw [Int.zero_mul] at h
+    omega
+  have hxnat_pos : 1 ≤ x.natAbs := by
+    rcases Nat.eq_zero_or_pos x.natAbs with hzero | hpos
+    · exact absurd (Int.natAbs_eq_zero.mp hzero) hx_ne
+    · exact hpos
+  have hxnat_eq : x.natAbs = 1 := by omega
+  rcases Int.natAbs_eq x with heq | heq
+  · left
+    rw [heq, hxnat_eq]
+    rfl
+  · right
+    rw [heq, hxnat_eq]
+    rfl
+
+/-- A monic integer polynomial of dense size two is irreducible. The proof
+splits any factorization `f = a * b` by dense size: degree arithmetic forces
+one factor to be a constant `±1`, so the constant factor is a `ZPoly` unit. -/
+private theorem irreducible_of_size_two_monic
+    (f : ZPoly) (hf_size : f.size = 2)
+    (hf_monic : DensePoly.leadingCoeff f = (1 : Int)) :
+    ZPoly.Irreducible f := by
+  have hf_ne : f ≠ 0 := by
+    intro hzero
+    rw [hzero] at hf_size
+    change (0 : Nat) = 2 at hf_size
+    omega
+  have hf_pos : 0 < f.size := by omega
+  refine
+    { not_zero := hf_ne
+      not_unit := ?_
+      no_factors := ?_ }
+  · intro hunit
+    rcases hunit with hone | hneg
+    · rw [hone] at hf_size
+      have h1 : (DensePoly.C (1 : Int)).size = 1 := rfl
+      omega
+    · rw [hneg] at hf_size
+      have hneg_size : (DensePoly.C (-1 : Int)).size = 1 := rfl
+      omega
+  · intro a b hf_ab
+    by_cases ha_zero : a = 0
+    · exfalso
+      apply hf_ne
+      rw [hf_ab, ha_zero, DensePoly.zero_mul]
+    by_cases hb_zero : b = 0
+    · exfalso
+      apply hf_ne
+      rw [hf_ab, hb_zero]
+      change a * (0 : ZPoly) = 0
+      rw [DensePoly.mul_comm_poly, DensePoly.zero_mul]
+    have ha_pos : 0 < a.size := ZPoly.size_pos_of_ne_zero a ha_zero
+    have hb_pos : 0 < b.size := ZPoly.size_pos_of_ne_zero b hb_zero
+    have hab_size :
+        (a * b).size = a.size + b.size - 1 :=
+      ZPoly.mul_size_eq_top_succ_of_nonzero a b ha_pos hb_pos
+    rw [← hf_ab] at hab_size
+    rw [hf_size] at hab_size
+    have hsum : a.size + b.size = 3 := by omega
+    have hlead :
+        DensePoly.leadingCoeff a * DensePoly.leadingCoeff b = (1 : Int) := by
+      have := ZPoly.leadingCoeff_mul_of_nonzero a b ha_zero hb_zero
+      rw [← hf_ab] at this
+      rw [hf_monic] at this
+      exact this.symm
+    have ha_size_le : a.size ≤ 2 := by omega
+    have hb_size_le : b.size ≤ 2 := by omega
+    have ha_size_eq_one_or_two : a.size = 1 ∨ a.size = 2 := by omega
+    rcases ha_size_eq_one_or_two with ha_one | ha_two
+    · -- a.size = 1, so a is constant; show IsUnit a
+      left
+      have ha_eq : a = DensePoly.C (a.coeff 0) := eq_C_of_size_eq_one a ha_one
+      have ha_lead : DensePoly.leadingCoeff a = a.coeff 0 := by
+        rw [DensePoly.leadingCoeff_eq_coeff_last a (by omega)]
+        congr 1
+        omega
+      rw [ha_lead] at hlead
+      have ha_coeff_unit : a.coeff 0 = 1 ∨ a.coeff 0 = -1 :=
+        int_factor_one_eq_unit hlead
+      rcases ha_coeff_unit with hone | hneg
+      · left
+        rw [ha_eq, hone]
+      · right
+        rw [ha_eq, hneg]
+    · -- a.size = 2, so b.size = 1; symmetric case
+      right
+      have hb_one : b.size = 1 := by omega
+      have hb_eq : b = DensePoly.C (b.coeff 0) := eq_C_of_size_eq_one b hb_one
+      have hb_lead : DensePoly.leadingCoeff b = b.coeff 0 := by
+        rw [DensePoly.leadingCoeff_eq_coeff_last b (by omega)]
+        congr 1
+        omega
+      rw [hb_lead] at hlead
+      rw [Int.mul_comm] at hlead
+      have hb_coeff_unit : b.coeff 0 = 1 ∨ b.coeff 0 = -1 :=
+        int_factor_one_eq_unit hlead
+      rcases hb_coeff_unit with hone | hneg
+      · left
+        rw [hb_eq, hone]
+      · right
+        rw [hb_eq, hneg]
+
+/-- The integer indeterminate `X` is irreducible. -/
+theorem irreducible_X : ZPoly.Irreducible ZPoly.X :=
+  irreducible_of_size_two_monic ZPoly.X rfl rfl
+
 end ZPoly
+
+/-- The monic linear factor `X - r` is irreducible over `ZPoly`. -/
+private theorem irreducible_linearFactorForRoot (r : Int) :
+    ZPoly.Irreducible (linearFactorForRoot r) :=
+  ZPoly.irreducible_of_size_two_monic (linearFactorForRoot r)
+    (linearFactorForRoot_size_eq_two r)
+    (leadingCoeff_linearFactorForRoot r)
 
 /--
 The primitive square-free layer in normalization reassembles the extracted

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -784,7 +784,9 @@ private theorem mul_size_le_top_succ (p q : ZPoly)
   rw [hcoeffs_size] at hle
   simpa [size, coeffs] using hle
 
-private theorem mul_size_eq_top_succ_of_nonzero (p q : ZPoly)
+/-- The size of a product of nonzero integer polynomials is one less than the
+sum of their sizes. -/
+theorem mul_size_eq_top_succ_of_nonzero (p q : ZPoly)
     (hp : 0 < p.size) (hq : 0 < q.size) :
     (p * q).size = p.size + q.size - 1 := by
   have htop := coeff_mul_top p q hp hq
@@ -808,7 +810,8 @@ private theorem mul_size_eq_top_succ_of_nonzero (p q : ZPoly)
   have hle := mul_size_le_top_succ p q hp hq
   omega
 
-private theorem size_pos_of_ne_zero (p : ZPoly) (hp : p ≠ 0) :
+/-- A nonzero integer polynomial has positive dense size. -/
+theorem size_pos_of_ne_zero (p : ZPoly) (hp : p ≠ 0) :
     0 < p.size := by
   rcases Nat.lt_or_ge 0 p.size with h | h
   · exact h

--- a/progress/20260514T092651Z_7d394b52.md
+++ b/progress/20260514T092651Z_7d394b52.md
@@ -1,0 +1,72 @@
+# 2026-05-14 09:26 UTC — work session 7d394b52 (issues #3987 → #3996)
+
+## Accomplished
+
+- **Decomposed #3987**. Worker scope assessment found the full
+  `factorWithBound_entries_irreducible` theorem requires per-emit-branch
+  core-factor irreducibility for five branches plus two foundational
+  `ZPoly.Irreducible` lemmas that don't yet exist. Some branches need
+  Group A/B Mathlib-bridge correctness per
+  `SPEC/Libraries/hex-berlekamp-zassenhaus.md`; the product-chain analog
+  #3892/#3982 needed many sessions to assemble. Created sub-issues:
+  - #3996: foundational `ZPoly.Irreducible` for `X` and `linearFactorForRoot r`
+    (Mathlib-free, claimed and completed this session).
+  - #3997: per-branch core-factor irreducibility chain in the Mathlib bridge
+    layer (blocked on #3996).
+  - Skipped #3987 with `Decomposed into #3996, #3997` breadcrumb.
+
+- **#3996 implementation**. In `HexBerlekampZassenhaus/Basic.lean`, proved
+  the two foundational `ZPoly.Irreducible` witnesses:
+  - `Hex.ZPoly.irreducible_X : ZPoly.Irreducible ZPoly.X`
+  - `Hex.irreducible_linearFactorForRoot (r : Int) :
+       ZPoly.Irreducible (linearFactorForRoot r)` (private, since
+    `linearFactorForRoot` is private).
+
+  Both reduce to a single private helper
+  `Hex.ZPoly.irreducible_of_size_two_monic` that argues by dense-size
+  arithmetic: any factorization `f = a * b` of a size-2 monic `f` with
+  nonzero `a, b` has `a.size + b.size = 3`; one side has size 1 (a constant
+  `±1` by `int_factor_one_eq_unit` on the leading-coefficient product
+  identity `leadingCoeff a * leadingCoeff b = 1`).
+
+  Two supporting helpers added:
+  - `eq_C_of_size_eq_one` — a size-1 `ZPoly` equals `C` of its zeroth
+    coefficient (via `ext_coeff`; nonzeroness of the stored coefficient is
+    forced by the `DensePoly` trimming invariant).
+  - `int_factor_one_eq_unit` — `x * y = 1` in `Int` forces `x = ±1`
+    (via `Int.natAbs_dvd_natAbs` plus `Nat.le_of_dvd`).
+
+- **Cross-file change**. Exposed two private `HexPolyZ/Basic.lean` helpers
+  for use in the irreducibility proof:
+  - `Hex.ZPoly.mul_size_eq_top_succ_of_nonzero` — size of a nonzero
+    product of integer polynomials.
+  - `Hex.ZPoly.size_pos_of_ne_zero` — positivity of dense size for
+    nonzero polynomials.
+  Both were strict-private generalizations: no proof or signature change.
+
+## Current frontier
+
+#3996 is complete and ready to PR. #3997 remains open as the natural
+successor; it requires per-branch algorithm-correctness reasoning the SPEC
+explicitly homes in the Mathlib bridge layer.
+
+## Next step
+
+Pick up #3997 once #3996 lands, or any other unblocked feature item.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus.Basic` ✓
+- `lake build HexBerlekampZassenhaus` ✓
+- `lake build HexBerlekampZassenhausMathlib.Basic` ✓ (no transitive breakage
+  from the `private` removals in `HexPolyZ/Basic.lean`)
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` ✓
+- `rg -n '^axiom\b|native_decide|TODO|FIXME' HexBerlekampZassenhaus/Basic.lean`
+  no matches
+- `rg -n '\bsorry\b' HexBerlekampZassenhaus/Basic.lean` shows only the
+  pre-existing `isIrreducible_iff` placeholder at line 4327


### PR DESCRIPTION
Closes #3996

Session: `7d394b52-f7de-41e4-b4a8-07aa2a67f356`

101a8fd feat: prove Mathlib-free ZPoly.Irreducible for X and linearFactorForRoot

🤖 Prepared with Claude Code