### PR TITLE
HexGramSchmidt: preserve processed coeff columns

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -778,6 +778,37 @@ private theorem getArrayEntry_scaledCoeffArrayLoop_above
       · simp only [hstep, ↓reduceIte]
         exact hcoeffs i j hij
 
+/-- Once a coefficient column lies strictly before the current loop step, later
+`scaledCoeffArrayLoop` iterations do not rewrite that column. -/
+private theorem getArrayEntry_scaledCoeffArrayLoop_preserve_col_before_step
+    (n fuel : Nat) (state : ScaledCoeffArrayState) (i j : Nat)
+    (hj : j < state.step) :
+    getArrayEntry (scaledCoeffArrayLoop n fuel state).coeffs i j =
+      getArrayEntry state.coeffs i j := by
+  induction fuel generalizing state with
+  | zero =>
+      rfl
+  | succ fuel ih =>
+      rw [scaledCoeffArrayLoop]
+      by_cases hstep : state.step < n
+      · simp only [hstep, ↓reduceIte]
+        by_cases hnext : state.step + 1 < n
+        · simp only [hnext, ↓reduceIte]
+          by_cases hpivot : getArrayEntry state.matrix state.step state.step = 0
+          · simp only [hpivot, ↓reduceIte]
+            rw [getArrayEntry_writeScaledColumn_of_col_ne]
+            omega
+          · simp only [hpivot, ↓reduceIte]
+            rw [ih]
+            · rw [getArrayEntry_writeScaledColumn_of_col_ne]
+              omega
+            · show j < state.step + 1
+              omega
+        · simp only [hnext, ↓reduceIte]
+          rw [getArrayEntry_writeScaledColumn_of_col_ne]
+          omega
+      · simp only [hstep, ↓reduceIte]
+
 /-- Run one no-pivot fraction-free Gram elimination and record each scaled
 coefficient column immediately before the elimination step zeroes it. -/
 private def scaledCoeffRows (b : Matrix Int n m) : Array (Array Int) :=

--- a/progress/20260514T145252Z_cc286ee5.md
+++ b/progress/20260514T145252Z_cc286ee5.md
@@ -1,0 +1,34 @@
+# Session cc286ee5 — partial #4027
+
+## Accomplished
+
+- Claimed #3977, found it was stale/blocked because
+  `gramDetVecEntry_eq_leadingPrefix_bareiss` is still an open prerequisite
+  tracked by #3974 / #4002, added the missing dependency on #3974, and
+  released #3977 for replan/blocked handling.
+- Claimed #4027 and added the private loop-bookkeeping helper
+  `getArrayEntry_scaledCoeffArrayLoop_preserve_col_before_step` in
+  `HexGramSchmidt/Int.lean`.
+- Verified the helper with:
+  - `lake build HexGramSchmidt.Int`
+  - `lake build HexGramSchmidt`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexGramSchmidt/Int.lean HexMatrix/Bareiss.lean`
+
+## Current frontier
+
+#4027 still needs the main lower-triangle capture relation. The new helper
+covers the preservation half: once a coefficient column is strictly before the
+current array-loop step, later iterations leave that column unchanged.
+
+## Next step
+
+Prove the complementary write/capture helper for the current column
+`state.step = j`, then combine it with the preservation helper to state the
+full off-diagonal sync against the `Matrix.noPivotLoop` state at the capture
+step.
+
+## Blockers
+
+None for #4027. #3977 is blocked on #3974 / #4002.


### PR DESCRIPTION
Partial progress on #4027

Session: `cc286ee5-b9a2-4ec1-acbc-469b553f64de`

c52f00b HexGramSchmidt: preserve processed coeff columns

🤖 Prepared with Claude Code