### PR TITLE
HexBZ: add fast-core count upper bound

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -415,8 +415,61 @@ theorem factorFastCoreWithBound_some_factor_irreducible_of_count
     rw [hgs_def, List.mem_map]
     exact ⟨factor, hfactor_mem, rfl⟩
   exact
-    HexBerlekampZassenhausMathlib.UFDPartition.irreducible_of_partition_card_eq_normalizedFactors_card
+      HexBerlekampZassenhausMathlib.UFDPartition.irreducible_of_partition_card_eq_normalizedFactors_card
       hf_ne gs hne_all hnonunit_all hprod hcount _ hpolyfactor_mem
+
+/-- Upper cardinality bound for a successful BHKS fast-core branch.
+
+The emitted factor list consists of non-zero non-units whose product is
+associated to `core`, so the abstract UFD partition bound applies after
+transporting the executable factors to `Polynomial ℤ`. -/
+theorem factorFastCoreWithBound_some_factor_count_le
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length ≤
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial core)).card := by
+  set f := HexPolyZMathlib.toPolynomial core with hf_def
+  have hf_ne : f ≠ 0 := by
+    intro hzero
+    apply hcore_ne
+    apply HexPolyZMathlib.equiv.injective
+    simpa using hzero
+  set gs : List (Polynomial ℤ) :=
+    coreFactors.toList.map HexPolyZMathlib.toPolynomial with hgs_def
+  have hprod : Associated gs.prod f := by
+    have hp_core : Array.polyProduct coreFactors = core :=
+      Hex.factorFastCoreWithBound_product core B primeData k fuel coreFactors h
+    have hp_poly :
+        (coreFactors.toList.map HexPolyZMathlib.toPolynomial).prod =
+          HexPolyZMathlib.toPolynomial core := by
+      rw [← polyProduct_toPolynomial, hp_core]
+    rw [hgs_def, hp_poly, hf_def]
+  have hrecord_all :
+      ∀ factor ∈ coreFactors.toList,
+        Hex.shouldRecordPolynomialFactor factor = true :=
+    Hex.factorFastCoreWithBound_some_shouldRecord h
+  have hne_all : ∀ g ∈ gs, g ≠ 0 := by
+    intro g hg
+    rw [hgs_def, List.mem_map] at hg
+    obtain ⟨factor, hfactor_mem, hg_eq⟩ := hg
+    rw [← hg_eq]
+    exact
+      (toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord
+        (hrecord_all factor hfactor_mem)).1
+  have hnonunit_all : ∀ g ∈ gs, ¬ IsUnit g := by
+    intro g hg
+    rw [hgs_def, List.mem_map] at hg
+    obtain ⟨factor, hfactor_mem, hg_eq⟩ := hg
+    rw [← hg_eq]
+    exact
+      (toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord
+        (hrecord_all factor hfactor_mem)).2
+  exact
+    HexBerlekampZassenhausMathlib.UFDPartition.length_le_normalizedFactors_card
+      hf_ne gs hne_all hnonunit_all hprod
 
 /-- Branch-local fast-core success irreducibility, expressed in the Mathlib-free
 `Hex.ZPoly.Irreducible` predicate. This is the `Hex.ZPoly` transport of

--- a/HexBerlekampZassenhausMathlib/UFDPartition.lean
+++ b/HexBerlekampZassenhausMathlib/UFDPartition.lean
@@ -75,6 +75,62 @@ private lemma eq_one_of_one_le_of_sum_eq_card {M : Multiset ℕ}
       · exact ih hcs_ge hcs_sum c' h
 
 /--
+Upper cardinality bound for a product partition in a UFD.
+
+If a non-zero element `f` is associated to the product of a list of non-zero
+non-unit factors, then that list cannot have more entries than the multiset of
+normalized irreducible factors of `f`. Each list entry contributes at least one
+normalized factor.
+-/
+theorem length_le_normalizedFactors_card
+    {α : Type*} [CommMonoidWithZero α] [NormalizationMonoid α]
+    [UniqueFactorizationMonoid α]
+    {f : α} (_hf : f ≠ 0)
+    (gs : List α)
+    (hne : ∀ g ∈ gs, g ≠ 0)
+    (hnonunit : ∀ g ∈ gs, ¬ IsUnit g)
+    (hprod : Associated gs.prod f) :
+    gs.length ≤ (normalizedFactors f).card := by
+  let s : Multiset α := (gs : Multiset α)
+  have hszero : (0 : α) ∉ s := by
+    intro h
+    exact hne 0 (Multiset.mem_coe.mp h) rfl
+  have hs_prod : s.prod = gs.prod := by
+    simp [s, Multiset.prod_coe]
+  have hsum_factors :
+      (normalizedFactors gs.prod) = (s.map normalizedFactors).sum := by
+    rw [← hs_prod]
+    exact normalizedFactors_multiset_prod s hszero
+  have heq : (normalizedFactors f) = (s.map normalizedFactors).sum := by
+    rw [← hsum_factors]
+    exact hprod.normalizedFactors_eq.symm
+  have hcard_sum :
+      (normalizedFactors f).card =
+        ((s.map normalizedFactors).map Multiset.card).sum := by
+    rw [heq, card_multiset_sum]
+  have hge_one :
+      ∀ c ∈ (s.map normalizedFactors).map Multiset.card, 1 ≤ c := by
+    intro c hc
+    rcases Multiset.mem_map.mp hc with ⟨m, hm, rfl⟩
+    rcases Multiset.mem_map.mp hm with ⟨g, hg, rfl⟩
+    have hg_mem_gs : g ∈ gs := Multiset.mem_coe.mp hg
+    have hne_g : g ≠ 0 := hne g hg_mem_gs
+    have hnonunit_g : ¬ IsUnit g := hnonunit g hg_mem_gs
+    have hfactors_ne : normalizedFactors g ≠ 0 :=
+      (normalizedFactors_eq_zero_iff hne_g).not.mpr hnonunit_g
+    rw [Nat.one_le_iff_ne_zero]
+    intro hzero
+    exact hfactors_ne (Multiset.card_eq_zero.mp hzero)
+  have hM_card :
+      ((s.map normalizedFactors).map Multiset.card).card = gs.length := by
+    simp [s]
+  calc
+    gs.length = ((s.map normalizedFactors).map Multiset.card).card := hM_card.symm
+    _ ≤ ((s.map normalizedFactors).map Multiset.card).sum :=
+      card_le_sum_of_one_le hge_one
+    _ = (normalizedFactors f).card := hcard_sum.symm
+
+/--
 **Group B partition-cardinality bound (Mathlib-only UFD argument).**
 
 In any unique factorization monoid, a non-zero element `f` admitting a list of

--- a/progress/20260514T162909Z_f3f47801.md
+++ b/progress/20260514T162909Z_f3f47801.md
@@ -1,0 +1,40 @@
+# Session f3f47801 — work #4030
+
+## Accomplished
+
+- Claimed feature issue #4030.
+- Added `HexBerlekampZassenhausMathlib.UFDPartition.length_le_normalizedFactors_card`,
+  an abstract UFD upper-bound lemma showing that a list of non-zero non-unit
+  factors whose product is associated to `f` has length at most
+  `(normalizedFactors f).card`.
+- Added
+  `HexBerlekampZassenhausMathlib.factorFastCoreWithBound_some_factor_count_le`,
+  applying the UFD upper bound to a successful `Hex.factorFastCoreWithBound`
+  branch via the existing product and `shouldRecordPolynomialFactor`
+  invariants.
+- Created successor issue #4055 for the remaining BHKS/B8 lower-bound
+  partition-refinement obligation and commented `Decomposed into #4055` on
+  #4030.
+- Verified `lake build HexBerlekampZassenhausMathlib.Basic`,
+  `lake build HexBerlekampZassenhausMathlib`,
+  `lake build HexBerlekampZassenhaus`, `python3 scripts/check_dag.py`, and
+  `git diff --check`. The diff adds no `axiom`, `native_decide`, `TODO`,
+  `FIXME`, or `sorry`.
+
+## Current frontier
+
+#4030 is partially complete: the count equality now has its UFD/product upper
+bound as a reusable theorem, but the lower bound remains the load-bearing B8
+argument connecting BHKS lattice partition refinement, reconstruction, and true
+factor supports.
+
+## Next step
+
+Work #4055: prove the fast-core count lower bound and then assemble the
+original equality by antisymmetry with
+`factorFastCoreWithBound_some_factor_count_le`.
+
+## Blockers
+
+None for this partial PR. The pre-existing `.claude/CLAUDE.md` worktree
+modification was not touched.


### PR DESCRIPTION
Partial progress on #4030

Session: `f3f47801-7ac9-4c84-9a8c-58fe3027f8f2`

12bf354 HexBZ: add fast-core count upper bound

🤖 Prepared with Claude Code