### PR TITLE
HexGfq: prove N32 irreducibility certificate

### DIFF
--- a/HexGfq/CrossCheck.lean
+++ b/HexGfq/CrossCheck.lean
@@ -111,6 +111,7 @@ private def polyP2 (coeffs : Array Nat) : FpPoly 2 :=
 
 private theorem maxProperDiv_4 : Berlekamp.maximalProperDivisors 4 = [2] := by decide
 private theorem maxProperDiv_8 : Berlekamp.maximalProperDivisors 8 = [4] := by decide
+private theorem maxProperDiv_32 : Berlekamp.maximalProperDivisors 32 = [16] := by decide
 
 private def genericN4Cert : Berlekamp.IrreducibilityCertificate where
   p := 2
@@ -1210,6 +1211,17 @@ private theorem genericN32PowChain_check :
   Berlekamp.checkRabinBezoutWitnesses
     genericMod genericMod_monic genericN32SamePrimeCert = true
 
+set_option maxRecDepth 65536 in
+private theorem genericN32_bezout :
+  Berlekamp.checkRabinBezoutWitnesses
+    genericMod genericMod_monic genericN32SamePrimeCert = true := by
+  unfold Berlekamp.checkRabinBezoutWitnesses Berlekamp.checkRabinBezoutWitness
+    Berlekamp.certifiedFrobeniusDiffMod
+  rw [genericMod_modByMonic_X]
+  simp [genericN32SamePrimeCert, genericN32PowChain, maxProperDiv_32,
+    genericMod, Conway.packedGF2FpPoly, lower, n, polyP2]
+  decide
+
 private theorem genericN32_basisSize :
     genericN32SamePrimeCert.n = Berlekamp.basisSize genericMod := by
   decide
@@ -1224,11 +1236,23 @@ private theorem genericN32_finalEntry :
   rw [← polyP2_zero_one_eq_X]
   rfl
 
+private theorem genericN32Cert_check :
+    Berlekamp.checkIrreducibilityCertificateLinearIncremental
+      genericMod genericMod_monic genericN32Cert = true := by
+  simp [Berlekamp.checkIrreducibilityCertificateLinearIncremental,
+    genericN32Cert, Berlekamp.IrreducibilityCertificate.toAmbient?]
+  exact ⟨⟨⟨genericN32_basisSize,
+    by simpa [genericN32SamePrimeCert] using genericN32PowChain_check⟩,
+    by simpa [genericN32SamePrimeCert] using genericN32_finalEntry⟩,
+    by simpa [genericN32SamePrimeCert] using genericN32_bezout⟩
+
 private theorem generic_pos : 0 < FpPoly.degree genericMod := by
   decide
 
 private theorem generic_irr : FpPoly.Irreducible genericMod := by
-  sorry
+  exact Berlekamp.rabinTest_imp_irreducible genericMod genericMod_monic
+    (Berlekamp.checkIrreducibilityCertificateLinearIncremental_rabinTest
+      genericMod genericMod_monic genericN32Cert genericN32Cert_check)
 
 private abbrev Packed : Type :=
   GF2n n lower (by decide) (by decide) packed_irr

--- a/progress/20260514T190048Z_82c2544b.md
+++ b/progress/20260514T190048Z_82c2544b.md
@@ -1,0 +1,27 @@
+# Session 82c2544b — work #4069
+
+## Accomplished
+
+- Claimed feature issue #4069.
+- Added the N32 maximal-proper-divisor fact and proved
+  `genericN32_bezout` in `HexGfq/CrossCheck.lean`.
+- Added `genericN32Cert_check` for the incremental Rabin certificate.
+- Replaced the N32 `generic_irr` placeholder with the standard
+  `Berlekamp.rabinTest_imp_irreducible` composition.
+- Verified `lake build HexGfq.CrossCheck`, `lake build HexGfq`,
+  `python3 scripts/status.py HexGfq`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and the affected-file forbidden-marker grep.
+
+## Current frontier
+
+`HexGfq/CrossCheck.lean` now has only the pre-existing N16
+`generic_irr` `sorry`. The N32 placeholder is gone.
+
+## Next step
+
+The remaining cross-check proof debt is the out-of-scope N16
+irreducibility placeholder.
+
+## Blockers
+
+None for #4069.


### PR DESCRIPTION
Closes #4069

Session: `82c2544b-8413-454e-a315-921bfd1908e3`

8fb8333 prove HexGfq N32 irreducibility certificate

🤖 Prepared with Claude Code