### PR TITLE
spec: rename `human-oversight` label to `directive`

### DIFF
--- a/PLAN/Phase4.md
+++ b/PLAN/Phase4.md
@@ -173,7 +173,7 @@ As of the merge of the PR introducing the new exit criteria above
 (profile coverage, headline report, gating-comparator wiring,
 Attribution rule, empty-Concerns), every library currently at
 `done_through ≥ 4` is re-evaluated under those criteria. The
-re-evaluation is queued via a single umbrella `human-oversight`
+re-evaluation is queued via a single umbrella `directive`
 issue with a checkbox per library; per-library follow-on issues
 are filed only when the audit identifies actual gaps. Libraries
 already passing all new criteria stay at `done_through: 4`

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -150,7 +150,7 @@ the library at `done_through ≤ 2`.
 
 3. **Explicit non-coverage is a tracking obligation.** An emitted
    operation that has no external oracle (whether deferred or
-   genuinely blocked) must be paired with an open `human-oversight`
+   genuinely blocked) must be paired with an open `directive`
    issue, linked from both `EmitFixtures.lean` and the corresponding
    oracle script's docstring. The library's `Conformance.lean`
    docstring must not claim the operation as covered. Self-consistency


### PR DESCRIPTION
This PR updates the two SPEC/PLAN references to the renamed label, following upstream pod rename FormalFrontier/pod#69.

The label name `human-oversight` inverted the directionality these issues encode — work flowing *down* from the project owner to the agents, not work awaiting human attention. Combined with the "owner-closes-only" framing in the prompt corpus, this trained agents to leave directives open with notes like

> leaving this human-oversight directive open for owner closure

(verbatim on #2637 May 9 17:38 and 18:22 UTC, plus several others). The pod-side PR renames the label, rewords the closure policy, and bumps the TUI cache schema. This PR is the matching downstream rename for SPEC/testing.md and PLAN/Phase4.md.

The prompt corpus under `.claude/commands/` and `.claude/skills/` is installed by pod from its `data/agent-config/` tree and will auto-sync to the renamed versions on the first pod run after the upstream PR lands (the `_agent_config_sync_check` checksum-tracked auto-overwrite path), so no `.claude/` files are touched here.

Existing `HO-N:` issue title prefixes and `HO-N` references in Lean files / scripts / reports are deliberately left as-is — they reference durable issue numbers, not the label name, and renaming would break grep against git history.

The actual GitHub label rename + per-issue migration runs after both PRs land.

🤖 Prepared with Claude Code