### PR TITLE
HexPolyFp: prove scalar linearPow evaluation

### DIFF
--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -3568,6 +3568,16 @@ theorem linearPow_add (f : FpPoly p) (m n : Nat) :
         _ = linearPow f m * (linearPow f n * f) := mul_assoc _ _ _
         _ = linearPow f m * linearPow f (n + 1) := rfl
 
+/-- Scalar evaluation distributes over `linearPow`: `eval (f^n) x = (eval f x)^n`. -/
+theorem eval_linearPow (f : FpPoly p) (n : Nat) (x : ZMod64 p) :
+    DensePoly.eval (linearPow f n) x = (DensePoly.eval f x) ^ n := by
+  induction n with
+  | zero =>
+      rw [linearPow_zero, Lean.Grind.Semiring.pow_zero]
+      exact eval_one x
+  | succ n ih =>
+      rw [linearPow_succ, eval_mul, ih, Lean.Grind.Semiring.pow_succ]
+
 /-- `linearPow (monomial k 1) n = monomial (k * n) 1`. -/
 theorem linearPow_monomial (k n : Nat) :
     linearPow (DensePoly.monomial k (1 : ZMod64 p)) n =

--- a/progress/20260515T034304Z_2a6a3e15.md
+++ b/progress/20260515T034304Z_2a6a3e15.md
@@ -1,0 +1,32 @@
+# 2026-05-15 03:43 UTC — feature session, issue #4105
+
+## Accomplished
+
+- Added `FpPoly.eval_linearPow` in `HexPolyFp/Basic.lean`: scalar
+  evaluation distributes over `linearPow`, i.e.
+  `DensePoly.eval (linearPow f n) x = (DensePoly.eval f x) ^ n`.
+- Proof by induction on `n`, using `linearPow_zero` / `linearPow_succ`,
+  `eval_one` (private, same file), `eval_mul`, and
+  `Lean.Grind.Semiring.pow_zero` / `pow_succ` (available via the
+  `Lean.Grind.Semiring (ZMod64 p)` instance).
+
+## Current frontier
+
+- `lake build HexPolyFp.Basic` ✓
+- `lake build HexBerlekamp.RabinSoundness` ✓
+- `lake build HexBerlekamp` ✓
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` ✓
+- No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level
+  `sorry` introduced.
+
+## Next step
+
+- Downstream: issue #4085 (variable prime-field product identity) can
+  now use `eval_linearPow` together with the scalar
+  evaluation/root-divisibility API from #4104, #4106 to assemble
+  `primeFieldProduct_X_eq_xPowSubX`.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #4105

Session: `2a6a3e15-d18c-45d6-a769-76ab7bc116bb`

f425fc6 feat: prove eval distributes over FpPoly.linearPow

🤖 Prepared with Claude Code