### PR TITLE
HexBZ BHKS: prove expected-indicator partition count matches true factors

### DIFF
--- a/HexBerlekampZassenhausMathlib.lean
+++ b/HexBerlekampZassenhausMathlib.lean
@@ -4,6 +4,7 @@ import HexBerlekampZassenhausMathlib.BHKSBound
 import HexBerlekampZassenhausMathlib.ColumnSignature
 import HexBerlekampZassenhausMathlib.IntReductionMod
 import HexBerlekampZassenhausMathlib.Lattice
+import HexBerlekampZassenhausMathlib.PartitionRefinement
 import HexBerlekampZassenhausMathlib.Recovery
 import HexBerlekampZassenhausMathlib.Resultant
 import HexBerlekampZassenhausMathlib.SignatureClasses

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -1,0 +1,152 @@
+import HexBerlekampZassenhausMathlib.Recovery
+import HexBerlekampZassenhausMathlib.Basic
+
+/-!
+BHKS B8 partition-refinement bridge.
+
+The fast-core success branch certified by
+`factorFastCoreWithBound_some_factor_count_ge_of_irreducible` consumes an
+irreducibility witness for every emitted factor. This module derives that
+witness from the BHKS recovery side data: the support-driven canonical
+indicator array `BHKS.expectedIndicatorArrayOfSupports trueSupports` has one
+row per support-equivalence class, and
+`BHKS.ForwardRecoveryInputs.ExpectedTrueFactors` transports that class count
+to the polynomial-side factor list length. Under the B8 partition-refinement
+hypothesis (the class count matches `normalizedFactors.card`), the existing
+UFD partition bridge upgrades the count equality to factor irreducibility.
+
+The B8 partition-refinement hypothesis itself is the deeper BHKS Lemma 3.4
+obligation discharged elsewhere; this module supplies the count and
+irreducibility bridge that consumes it.
+-/
+
+namespace HexBerlekampZassenhausMathlib
+
+namespace BHKS
+
+/-- The expected indicator array has one row per support-equivalence class. -/
+theorem expectedIndicatorArrayOfSupports_size {r : Nat}
+    (trueSupports : Set (Set (Fin r))) :
+    (expectedIndicatorArrayOfSupports trueSupports).size =
+      (supportPartitionByMinColumn trueSupports).length := by
+  simp [expectedIndicatorArrayOfSupports]
+
+namespace ForwardRecoveryInputs
+
+/-- Under an `ExpectedTrueFactors` package whose indicators are the
+support-driven canonical indicator array, the expected factor count equals
+the support-equivalence partition length. -/
+theorem ExpectedTrueFactors.size_eq_supportPartitionByMinColumn_length
+    {f : Hex.ZPoly} {r : Nat} (trueSupports : Set (Set (Fin r)))
+    {expectedFactors : Array Hex.ZPoly}
+    (htrue : ExpectedTrueFactors f
+      (expectedIndicatorArrayOfSupports trueSupports) expectedFactors) :
+    expectedFactors.size =
+      (supportPartitionByMinColumn trueSupports).length := by
+  rw [htrue.size_eq, expectedIndicatorArrayOfSupports_size]
+
+/-- The polynomial-transported expected factor list has length equal to the
+support-equivalence partition length. -/
+theorem ExpectedTrueFactors.polynomial_length_eq_supportPartitionByMinColumn_length
+    {f : Hex.ZPoly} {r : Nat} (trueSupports : Set (Set (Fin r)))
+    {expectedFactors : Array Hex.ZPoly}
+    (htrue : ExpectedTrueFactors f
+      (expectedIndicatorArrayOfSupports trueSupports) expectedFactors) :
+    (expectedFactors.toList.map HexPolyZMathlib.toPolynomial).length =
+      (supportPartitionByMinColumn trueSupports).length := by
+  rw [List.length_map, Array.length_toList,
+    ExpectedTrueFactors.size_eq_supportPartitionByMinColumn_length trueSupports htrue]
+
+/-- Under the B8 partition-refinement hypothesis (the support-equivalence
+partition has the same length as `normalizedFactors`), the polynomial-
+transported expected factor list has length `normalizedFactors.card`. -/
+theorem ExpectedTrueFactors.polynomial_length_eq_normalizedFactors_card
+    {f : Hex.ZPoly} {r : Nat} (trueSupports : Set (Set (Fin r)))
+    {expectedFactors : Array Hex.ZPoly}
+    (htrue : ExpectedTrueFactors f
+      (expectedIndicatorArrayOfSupports trueSupports) expectedFactors)
+    (hpartition :
+      (supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial f)).card) :
+    (expectedFactors.toList.map HexPolyZMathlib.toPolynomial).length =
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial f)).card := by
+  rw [ExpectedTrueFactors.polynomial_length_eq_supportPartitionByMinColumn_length
+    trueSupports htrue, hpartition]
+
+/-- Under the B8 partition-refinement hypothesis, every polynomial-transported
+expected factor is irreducible. This is the B8 partition-refinement output
+the downstream fast-core irreducibility argument consumes. -/
+theorem ExpectedTrueFactors.irreducible_of_partition_count
+    {f : Hex.ZPoly} {r : Nat} (trueSupports : Set (Set (Fin r)))
+    {expectedFactors : Array Hex.ZPoly}
+    (htrue : ExpectedTrueFactors f
+      (expectedIndicatorArrayOfSupports trueSupports) expectedFactors)
+    (hf_ne : f ≠ 0)
+    (hpartition :
+      (supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial f)).card) :
+    ∀ g ∈ expectedFactors.toList,
+      Irreducible (HexPolyZMathlib.toPolynomial g) := by
+  set fpoly := HexPolyZMathlib.toPolynomial f with hf_def
+  have hfpoly_ne : fpoly ≠ 0 := by
+    intro hzero
+    apply hf_ne
+    apply HexPolyZMathlib.equiv.injective
+    simpa using hzero
+  set gs : List (Polynomial ℤ) :=
+    expectedFactors.toList.map HexPolyZMathlib.toPolynomial with hgs_def
+  have hpos_factor : ∀ g ∈ expectedFactors,
+      0 < (HexPolyZMathlib.toPolynomial g).natDegree := by
+    intro g hg
+    obtain ⟨i, hi_lt, hget⟩ := Array.mem_iff_getElem.mp hg
+    have hi_lt' : i < (expectedIndicatorArrayOfSupports trueSupports).size := by
+      rw [← htrue.size_eq]; exact hi_lt
+    have hdeg := htrue.positive_degree i hi_lt'
+    have hgetD : expectedFactors.getD i 0 = g := by
+      have := Array.getElem_eq_getD (xs := expectedFactors) (i := i) (h := hi_lt) 0
+      rw [← this]; exact hget
+    rw [HexPolyMathlib.natDegree_toPolynomial, ← hgetD]
+    exact hdeg
+  have hne_all : ∀ g ∈ gs, g ≠ 0 := by
+    intro g hg
+    rw [hgs_def, List.mem_map] at hg
+    obtain ⟨factor, hfactor_mem, hg_eq⟩ := hg
+    rw [Array.mem_toList_iff] at hfactor_mem
+    rw [← hg_eq]
+    exact Polynomial.ne_zero_of_natDegree_gt (hpos_factor factor hfactor_mem)
+  have hnonunit_all : ∀ g ∈ gs, ¬ IsUnit g := by
+    intro g hg
+    rw [hgs_def, List.mem_map] at hg
+    obtain ⟨factor, hfactor_mem, hg_eq⟩ := hg
+    rw [Array.mem_toList_iff] at hfactor_mem
+    rw [← hg_eq]
+    exact Polynomial.not_isUnit_of_natDegree_pos _ (hpos_factor factor hfactor_mem)
+  have hprod : Associated gs.prod fpoly := by
+    have hp_factor : Array.polyProduct expectedFactors = f := htrue.product_eq
+    have hp_poly :
+        (expectedFactors.toList.map HexPolyZMathlib.toPolynomial).prod =
+          HexPolyZMathlib.toPolynomial f := by
+      rw [← polyProduct_toPolynomial, hp_factor]
+    rw [hgs_def, hp_poly, hf_def]
+  have hcount :
+      gs.length =
+        (UniqueFactorizationMonoid.normalizedFactors fpoly).card := by
+    rw [hgs_def, hf_def]
+    exact ExpectedTrueFactors.polynomial_length_eq_normalizedFactors_card
+      trueSupports htrue hpartition
+  intro g hg
+  have hg_arr : g ∈ expectedFactors := Array.mem_toList_iff.mp hg
+  have hgmem : HexPolyZMathlib.toPolynomial g ∈ gs := by
+    rw [hgs_def, List.mem_map]
+    exact ⟨g, hg, rfl⟩
+  exact UFDPartition.irreducible_of_partition_card_eq_normalizedFactors_card
+    hfpoly_ne gs hne_all hnonunit_all hprod hcount _ hgmem
+
+end ForwardRecoveryInputs
+
+end BHKS
+
+end HexBerlekampZassenhausMathlib

--- a/progress/20260515T040238Z_0b95b2dd.md
+++ b/progress/20260515T040238Z_0b95b2dd.md
@@ -1,0 +1,55 @@
+# Session 0b95b2dd — work #4132
+
+## Accomplished
+
+- Claimed #4132 after verifying #4055's PR (and all other in-flight Group B/A
+  dependency PRs) had merged, leaving #4132 as the only ready-to-claim issue
+  in the queue.
+- Added `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`, exposing
+  the BHKS B8 partition-refinement bridge:
+  - `BHKS.expectedIndicatorArrayOfSupports_size`: the canonical indicator
+    array has one row per support-equivalence class.
+  - `BHKS.ForwardRecoveryInputs.ExpectedTrueFactors.size_eq_supportPartitionByMinColumn_length`
+    and its `polynomial_length_eq_supportPartitionByMinColumn_length` cousin:
+    transport the class count to the `Hex.ZPoly`-side / `Polynomial ℤ`-side
+    factor list length under an `ExpectedTrueFactors` package whose indicators
+    come from `expectedIndicatorArrayOfSupports`.
+  - `ExpectedTrueFactors.polynomial_length_eq_normalizedFactors_card`: under
+    the B8 hypothesis `(supportPartitionByMinColumn …).length = normalizedFactors.card`,
+    the polynomial-transported expected factor list has length
+    `normalizedFactors.card`.
+  - `ExpectedTrueFactors.irreducible_of_partition_count`: under the same B8
+    hypothesis, every polynomial-transported expected factor is irreducible.
+    The proof routes through the existing
+    `UFDPartition.irreducible_of_partition_card_eq_normalizedFactors_card`,
+    using `htrue.positive_degree` to discharge the non-zero / non-unit
+    obligations via `Polynomial.ne_zero_of_natDegree_gt` and
+    `Polynomial.not_isUnit_of_natDegree_pos`, and `htrue.product_eq` plus
+    `polyProduct_toPolynomial` to discharge the `Associated` obligation.
+- Registered the new module in `HexBerlekampZassenhausMathlib.lean`.
+- Verified `lake build HexBerlekampZassenhausMathlib.PartitionRefinement`,
+  `lake build HexBerlekampZassenhausMathlib`, `lake build HexBerlekampZassenhaus`,
+  `python3 scripts/check_dag.py`, `git diff --check`. No new `axiom`,
+  `native_decide`, `TODO`, `FIXME`, or theorem-level `sorry`.
+
+## Current frontier
+
+The B8 partition-refinement irreducibility output is now expressible as a
+single hypothesis `(supportPartitionByMinColumn trueSupports).length =
+normalizedFactors.card`, which downstream code can use with
+`factorFastCoreWithBound_some_factor_count_ge_of_irreducible` to close the
+fast-core lower bound.
+
+## Next step
+
+Discharge the abstract `(supportPartitionByMinColumn trueSupports).length =
+normalizedFactors.card` hypothesis from the executable recovery state: the
+"each indicator class corresponds to exactly one true factor" content of BHKS
+Lemma 3.4. This requires reasoning over how the executable factor
+reconstruction at each indicator produces a distinct integer factor when the
+overall product equals `f`.
+
+## Blockers
+
+- None for the work landed here. The deeper B8 Lemma 3.4 discharge work is a
+  separate downstream obligation.


### PR DESCRIPTION
Closes #4132

Session: `0b95b2dd-0ba8-4195-b140-6d7888d0ae29`

7ca7adc feat: add BHKS B8 partition-refinement irreducibility bridge

🤖 Prepared with Claude Code