### PR TITLE
HexMatrix.Bareiss: prove pivotLoop equals noPivotLoop when no singular step

### DIFF
--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -1102,6 +1102,42 @@ theorem noPivotLoop_rowSwaps (fuel : Nat) (state : BareissState n) :
           · simpa [k] using hp
       · simp [noPivotLoop_done fuel state hDone]
 
+/-- When the no-pivot Bareiss loop completes `fuel` iterations without
+recording a singular step, the row-pivoted Bareiss loop produces an
+identical state: every diagonal pivot is nonzero, so the row search and
+swap branches of `pivotLoop` are never entered and both loops apply the
+same `stepMatrix` updates. -/
+theorem pivotLoop_eq_noPivotLoop_of_no_singular {n : Nat}
+    (fuel : Nat) (state : BareissState n)
+    (h_no_sing : (noPivotLoop fuel state).singularStep = none) :
+    pivotLoop fuel state = noPivotLoop fuel state := by
+  induction fuel generalizing state with
+  | zero => rfl
+  | succ f ih =>
+      by_cases hDone : state.step + 1 < n
+      · by_cases hp : state.matrix[state.step][state.step] = 0
+        · -- `noPivotLoop` records `singularStep = some state.step`, contradicting
+          -- `h_no_sing`.
+          rw [noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+          simp at h_no_sing
+        · -- Regular branch in both loops; recurse on the same updated state.
+          let next : BareissState n :=
+            { step := state.step + 1
+              matrix := stepMatrix state.matrix state.step
+                state.matrix[state.step][state.step] state.prevPivot
+              prevPivot := state.matrix[state.step][state.step]
+              rowSwaps := state.rowSwaps
+              singularStep := none }
+          rw [noPivotLoop_regular_branch f state hDone hp]
+          rw [pivotLoop_regular_branch_no_swap f state hDone hp]
+          show pivotLoop f next = noPivotLoop f next
+          apply ih
+          show (noPivotLoop f next).singularStep = none
+          rw [← noPivotLoop_regular_branch f state hDone hp]
+          exact h_no_sing
+      · rw [pivotLoop_done f state hDone]
+        rw [noPivotLoop_done f state hDone]
+
 /-- Initial state used by the no-pivot Bareiss recurrence. -/
 def noPivotInitialState (M : Matrix Int n n) : BareissState n :=
   { step := 0

--- a/progress/20260515T043250Z_569ceab0.md
+++ b/progress/20260515T043250Z_569ceab0.md
@@ -1,0 +1,51 @@
+# 2026-05-15 04:32 UTC — feature session, issues #3965 / #4144
+
+## Accomplished
+
+- Audited #3965 ("HexGramSchmidt: bridge Cramer no-pivot value to
+  public Bareiss") and concluded the proof path necessarily crosses to
+  determinant correctness: the singular case (when `noPivotLoop` on
+  `gramMatrix b` records a singular step `s ≤ j - 1`) requires
+  `Matrix.bareiss_eq_det` because the Cramer minor is geometrically
+  rank-deficient but `pivotLoop` may algorithmically find a row-swap
+  pivot and end with a nonzero trailing diagonal. Per
+  `SPEC/Libraries/hex-gram-schmidt.md` "Proof path governs placement,
+  not just statement", the bridge theorem belongs in
+  `HexGramSchmidtMathlib/`.
+- Decomposed #3965 into two sub-issues:
+  - #4144 (this PR): Mathlib-free algorithmic helper
+    `pivotLoop_eq_noPivotLoop_of_no_singular` in `HexMatrix/Bareiss.lean`.
+  - #4145: bridge theorem in `HexGramSchmidtMathlib/Int.lean`,
+    depending on #4144 and consuming `Matrix.bareiss_eq_det`.
+- Left the breadcrumb `Decomposed into #4144, #4145` on #3965 and
+  released the claim via `coordination skip`.
+- Proved `pivotLoop_eq_noPivotLoop_of_no_singular` in
+  `HexMatrix/Bareiss.lean` (lines 1105-1137 of the post-commit file).
+  Inducts on fuel; the regular branch is closed by
+  `pivotLoop_regular_branch_no_swap` and `noPivotLoop_regular_branch`
+  composing on the same updated state, with the singular branch
+  contradicted by the `h_no_sing` hypothesis.
+
+## Current frontier
+
+- `lake build HexMatrix.Bareiss` ✓
+- `lake build HexMatrix` ✓
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` ✓
+- `HexMatrix/Bareiss.lean` sorry count unchanged at 1
+  (`bareiss_eq_det`, the pre-existing bridge-layer obligation).
+
+## Next step
+
+- A successor session picks up #4145 (the bridge theorem in
+  `HexGramSchmidtMathlib/Int.lean`). It combines this PR's
+  `pivotLoop_eq_noPivotLoop_of_no_singular` with #3994's
+  `scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix` for the
+  non-singular branch and uses `Matrix.bareiss_eq_det` plus
+  `scaledCoeffMatrix_det_eq_gramDet_mul_coeffs` and the
+  leading-prefix singular-tail lemmas for the singular branch.
+
+## Blockers
+
+- None for #4144.
+- #4145 is blocked on #4144 landing.


### PR DESCRIPTION
Closes #4144

Session: `569ceab0-82fd-4c65-b2f6-55714d7e8047`

9988bc5 progress: session 569ceab0 closing #4144
994c15e feat: prove pivotLoop equals noPivotLoop when no singular step

🤖 Prepared with Claude Code