### PR TITLE
feat: add Cramer/Bareiss bridge for scaled Gram-Schmidt coefficients

### DIFF
--- a/HexGramSchmidtMathlib.lean
+++ b/HexGramSchmidtMathlib.lean
@@ -1,7 +1,10 @@
 import HexGramSchmidtMathlib.Basic
+import HexGramSchmidtMathlib.Int
 import HexGramSchmidtMathlib.Update
 
 /-!
 The `HexGramSchmidtMathlib` library states the rowwise bridge between the
-executable dense-matrix Gram-Schmidt surface and Mathlib's `gramSchmidt`.
+executable dense-matrix Gram-Schmidt surface and Mathlib's `gramSchmidt`,
+together with the Cramer/Bareiss bridge for the integral scaled
+coefficient matrix.
 -/

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -1,0 +1,40 @@
+import HexGramSchmidt.Int
+
+/-!
+Mathlib bridge lemma for the executable Cramer-style scaled coefficient
+matrix and the public Bareiss surface.
+
+The Mathlib-free file `HexGramSchmidt/Int.lean` packages the executable
+scaled-coefficient array entry as the no-pivot Bareiss trailing value on
+`GramSchmidt.scaledCoeffMatrix` (via `scaledCoeffRows_lower_eq_…`). The
+public Bareiss algorithm `Matrix.bareiss`, however, may insert a row swap
+when a diagonal pivot is zero, so the executable array entry need not
+match the public Bareiss value on the Cramer minor without crossing to
+`Matrix.bareiss_eq_det`: the geometric vanishing in the singular branch
+is visible only through the Leibniz determinant.
+
+Per `SPEC/Libraries/hex-gram-schmidt.md` ("Proof path governs placement,
+not just statement"), this bridge therefore lives in
+`HexGramSchmidtMathlib`. The proof consumes the existing
+`Matrix.bareiss_eq_det` sorry in `HexMatrix/Bareiss.lean`, which is owned
+by `hex-matrix-mathlib`.
+-/
+
+namespace Hex
+namespace GramSchmidt
+namespace Int
+
+/-- Cramer/Bareiss bridge: below the diagonal, the integral scaled
+Gram-Schmidt coefficient is exactly the public Bareiss determinant of the
+Cramer minor `scaledCoeffMatrix`. This is the `bareiss`-form companion of
+the existing Mathlib-free `scaledCoeffs_eq_scaledCoeffMatrix_det`. -/
+theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
+    GramSchmidt.entry (scaledCoeffs b) i j =
+      Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) := by
+  rw [scaledCoeffs_eq_scaledCoeffMatrix_det b i j hji,
+    Matrix.bareiss_eq_det]
+
+end Int
+end GramSchmidt
+end Hex

--- a/progress/20260515T160000Z_9d1d153d.md
+++ b/progress/20260515T160000Z_9d1d153d.md
@@ -1,0 +1,61 @@
+# 2026-05-15 16:00 UTC — feature session, issue #4145
+
+## Accomplished
+
+- Created `HexGramSchmidtMathlib/Int.lean` with the public Cramer/Bareiss
+  bridge theorem
+  `Hex.GramSchmidt.Int.scaledCoeffs_eq_scaledCoeffMatrix_bareiss`:
+  ```lean
+  theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
+      (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
+      GramSchmidt.entry (scaledCoeffs b) i j =
+        Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji)
+  ```
+- Imported `HexGramSchmidtMathlib.Int` from the top-level
+  `HexGramSchmidtMathlib.lean` library file.
+- `lake build HexGramSchmidtMathlib.Int`, `lake build
+  HexGramSchmidtMathlib`, `lake build HexGramSchmidt`,
+  `python3 scripts/check_dag.py`, `git diff --check` all pass.
+- The Mathlib-free `HexGramSchmidt.Int.scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss`
+  `sorry` is unchanged.
+
+## Current frontier
+
+- Proof shape: chain through the existing public
+  `scaledCoeffs_eq_scaledCoeffMatrix_det` and `Matrix.bareiss_eq_det`.
+  The proof transitively consumes the private
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` sorry inside
+  `scaledCoeffs_eq_scaledCoeffMatrix_det` and the `bareiss_eq_det` sorry.
+  No new sorries are introduced.
+- The substantive case-split proof requested by the issue (deliverable
+  2) is **not** implemented in this PR. That proof would split on the
+  `singularStep` of the no-pivot Bareiss pass over `gramMatrix b`:
+  - Non-singular branch: chain `scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix`
+    (#3994) with `pivotLoop_eq_noPivotLoop_of_no_singular` (#4144) and
+    the `noPivotLoop_full_eq_borderedMinor_at_trailing` /
+    `scaledCoeffMatrix_eq_borderedMinor` transport for the singular-step
+    sync.
+  - Singular branch: show the executable array entry is `0` by
+    assembling `scaledCoeffArrayLoop_lower_singular_matches` (per-step
+    splitter) into a top-level lemma, then close the right-hand side via
+    `Matrix.bareiss_eq_det` and `scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`
+    plus `gramDetVecEntry_eq_zero_of_singularStep_lt` to conclude
+    `gramDet (j+1) = 0`.
+  Both branches need several private helpers in `HexGramSchmidt/Int.lean`
+  to be de-privatized, and the singular branch needs a fresh top-level
+  "lower-column array entry is zero when an earlier singular step is
+  recorded" lemma (the existing per-step packaging is not yet lifted
+  to top level). This was too large to fit in one session.
+
+## Next step
+
+- Follow-up issue to replace the chain proof with an independent
+  case-split proof, removing the transitive dependency on the private
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` sorry. The plan
+  above gives the proof outline; the missing pieces are the lifted
+  top-level lower-singular array lemma plus de-privatizing the named
+  prerequisites.
+
+## Blockers
+
+- None for this PR. The deeper proof is a separate follow-up.


### PR DESCRIPTION
Partial progress on #4145

Session: `9d1d153d-da0b-47c8-9487-57250dd59327`

e644002 feat: add Cramer/Bareiss bridge for scaled Gram-Schmidt coefficients

🤖 Prepared with Claude Code