### PR TITLE
HexGramSchmidtMathlib: package non-singular no-pivot Bareiss bridge

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -134,7 +134,7 @@ private structure ScaledCoeffArrayState where
   coeffs : Array (Array Int)
   prevPivot : Int
 
-@[inline] private def getArrayEntry (rows : Array (Array Int)) (row col : Nat) : Int :=
+@[inline] def getArrayEntry (rows : Array (Array Int)) (row col : Nat) : Int :=
   rows[row]![col]!
 
 private def zeroRows (n : Nat) : Array (Array Int) :=
@@ -996,7 +996,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_start_column
 
 /-- Run one no-pivot fraction-free Gram elimination and record each scaled
 coefficient column immediately before the elimination step zeroes it. -/
-private def scaledCoeffRows (b : Matrix Int n m) : Array (Array Int) :=
+def scaledCoeffRows (b : Matrix Int n m) : Array (Array Int) :=
   let state :=
     scaledCoeffArrayLoop n n
       { step := 0
@@ -1040,6 +1040,14 @@ determinant formula corresponding to `d_{j+1} * μ_{i,j}`; on the diagonal we
 store `d_{j+1}`, and entries above the diagonal are zero. -/
 def scaledCoeffs (b : Matrix Int n m) : Matrix Int n n :=
   (data b).ν
+
+/-- Entry-level packaging bridge from the public scaled-coefficient matrix
+back to the shared array pass that computes it. -/
+theorem scaledCoeffs_entry_eq_getArrayEntry
+    (b : Matrix Int n m) (i j : Fin n) :
+    GramSchmidt.entry (scaledCoeffs b) i j =
+      getArrayEntry (scaledCoeffRows b) i.val j.val := by
+  simp [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn]
 
 /-- One Bareiss update step commutes with taking the leading `K × K`
 prefix: the leading prefix of the updated full matrix equals the result
@@ -1382,7 +1390,7 @@ the full `n × n` matrix agrees with the `(Fin.last k, Fin.last k)` entry of the
 noPivot Bareiss state after `k` iterations on the `(k + 1) × (k + 1)` bordered
 minor at `row, col`. The `singularStep` bookkeeping also agrees, mirroring the
 leading-prefix sync corollary. Requires `row, col` to lie in the trailing block. -/
-private theorem noPivotLoop_full_eq_borderedMinor_at_trailing
+theorem noPivotLoop_full_eq_borderedMinor_at_trailing
     {n : Nat} (M : Matrix Int n n) (k : Nat) (hk : k < n) (row col : Fin n)
     (hrow : k ≤ row.val) (hcol : k ≤ col.val) :
     let BM := Matrix.borderedMinor M k hk row col
@@ -4542,7 +4550,7 @@ with the border row index taken to be `j` and the border column index taken
 to be `i`. This is the definitional bridge between
 `GramSchmidt.scaledCoeffMatrix` and the bordered-minor machinery in
 `HexMatrix.Bareiss`. -/
-private theorem scaledCoeffMatrix_eq_borderedMinor
+theorem scaledCoeffMatrix_eq_borderedMinor
     (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
     GramSchmidt.scaledCoeffMatrix b i j hji =
       Matrix.borderedMinor (Matrix.gramMatrix b) j.val
@@ -4688,7 +4696,7 @@ corresponding Cramer determinant matrix `scaledCoeffMatrix b i j hji`. This
 composes `scaledCoeffArrayLoop_lower_matches_target_column` (from #4103),
 `noPivotLoop_full_eq_borderedMinor_at_trailing` (from #4028), and the
 symmetry/transpose bridge `noPivotLoop_scaledCoeffMatrix_eq_borderedMinor_at_trailing`. -/
-private theorem scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix
+theorem scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix
     (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val)
     (h_nonsing :
       (Matrix.noPivotLoop j.val

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -24,6 +24,43 @@ namespace Hex
 namespace GramSchmidt
 namespace Int
 
+/-- Non-singular branch of the Cramer/Bareiss bridge: when the no-pivot
+Bareiss pass over the Gram matrix reaches column `j` without recording a
+singular step, the executable scaled coefficient agrees with the public
+row-pivoted Bareiss determinant of the Cramer minor. -/
+theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val)
+    (h_nonsing :
+      (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none) :
+    GramSchmidt.entry (scaledCoeffs b) i j =
+      Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) := by
+  have h_rows :=
+    scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix b i j hji h_nonsing
+  have h_scaled_nonsing :
+      (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState
+            (GramSchmidt.scaledCoeffMatrix b i j hji))).singularStep = none := by
+    rw [scaledCoeffMatrix_eq_borderedMinor b i j hji]
+    have h_sync :=
+      (noPivotLoop_full_eq_borderedMinor_at_trailing (Matrix.gramMatrix b) j.val
+        (Nat.lt_trans hji i.isLt)
+        (⟨j.val, Nat.lt_trans hji i.isLt⟩ : Fin n) i
+        (Nat.le_refl _) (Nat.le_of_lt hji)).2
+    exact h_sync ▸ h_nonsing
+  have h_bareiss :=
+    Matrix.bareiss_eq_noPivotLoop_last_of_no_singular
+      (GramSchmidt.scaledCoeffMatrix b i j hji) h_scaled_nonsing
+  have h_entry :
+      GramSchmidt.entry (scaledCoeffs b) i j =
+        (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState
+            (GramSchmidt.scaledCoeffMatrix b i j hji))).matrix[
+          Fin.last j.val][Fin.last j.val] := by
+    rw [scaledCoeffs_entry_eq_getArrayEntry]
+    exact h_rows
+  exact h_entry.trans h_bareiss.symm
+
 /-- Cramer/Bareiss bridge: below the diagonal, the integral scaled
 Gram-Schmidt coefficient is exactly the public Bareiss determinant of the
 Cramer minor `scaledCoeffMatrix`. This is the `bareiss`-form companion of

--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -1102,6 +1102,125 @@ theorem noPivotLoop_rowSwaps (fuel : Nat) (state : BareissState n) :
           · simpa [k] using hp
       · simp [noPivotLoop_done fuel state hDone]
 
+/-- Once a no-pivot Bareiss state is already at the terminal step boundary,
+additional fuel leaves it unchanged. -/
+theorem noPivotLoop_id_at_done
+    {n : Nat} (fuel : Nat) (state : BareissState n)
+    (hDone : ¬ state.step + 1 < n) :
+    noPivotLoop fuel state = state := by
+  induction fuel with
+  | zero => rfl
+  | succ f _ih => exact noPivotLoop_done f state hDone
+
+/-- Once a no-pivot Bareiss state has recorded a zero pivot at the current
+step, additional fuel leaves that singular fixed point unchanged. -/
+theorem noPivotLoop_id_at_singular_fixedpoint
+    {n : Nat} (fuel : Nat) (state : BareissState n)
+    (hDone : state.step + 1 < n)
+    (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][
+        (⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0)
+    (hsing : state.singularStep = some state.step) :
+    noPivotLoop fuel state = state := by
+  induction fuel with
+  | zero => rfl
+  | succ f _ih =>
+      rw [noPivotLoop_singular_branch f state hDone hp]
+      cases state
+      simp at hsing ⊢
+      exact hsing.symm
+
+/-- Fuel composition for the no-pivot Bareiss loop: running `a + b` units of
+fuel from `state` equals running `b` more units after `a` initial units. -/
+theorem noPivotLoop_add
+    {n : Nat} (a b : Nat) (state : BareissState n) :
+    noPivotLoop (a + b) state = noPivotLoop b (noPivotLoop a state) := by
+  induction a generalizing state with
+  | zero =>
+      show noPivotLoop (0 + b) state = noPivotLoop b state
+      simp
+  | succ a' ih =>
+      by_cases hDone : state.step + 1 < n
+      · let k : Fin n :=
+          ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩
+        by_cases hp : state.matrix[k][k] = 0
+        · have h_lhs :
+              noPivotLoop (a' + 1 + b) state =
+                {state with singularStep := some state.step} := by
+            have : a' + 1 + b = (a' + b) + 1 := by omega
+            rw [this]
+            exact noPivotLoop_singular_branch (a' + b) state hDone hp
+          have h_rhs_inner :
+              noPivotLoop (a' + 1) state =
+                {state with singularStep := some state.step} :=
+            noPivotLoop_singular_branch a' state hDone hp
+          rw [h_lhs, h_rhs_inner]
+          symm
+          let s' : BareissState n := {state with singularStep := some state.step}
+          have hDone_s' : s'.step + 1 < n := hDone
+          have hp_s' : s'.matrix[(⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)][
+              (⟨s'.step, Nat.lt_of_succ_lt hDone_s'⟩ : Fin n)] = 0 := hp
+          have hsing_s' : s'.singularStep = some s'.step := rfl
+          exact noPivotLoop_id_at_singular_fixedpoint b s' hDone_s' hp_s' hsing_s'
+        · have h_lhs :
+              noPivotLoop (a' + 1 + b) state =
+                noPivotLoop (a' + b)
+                  { step := state.step + 1
+                    matrix := stepMatrix state.matrix state.step
+                      state.matrix[k][k] state.prevPivot
+                    prevPivot := state.matrix[k][k]
+                    rowSwaps := state.rowSwaps
+                    singularStep := none } := by
+            have : a' + 1 + b = (a' + b) + 1 := by omega
+            rw [this]
+            exact noPivotLoop_regular_branch (a' + b) state hDone hp
+          have h_rhs_inner :
+              noPivotLoop (a' + 1) state =
+                noPivotLoop a'
+                  { step := state.step + 1
+                    matrix := stepMatrix state.matrix state.step
+                      state.matrix[k][k] state.prevPivot
+                    prevPivot := state.matrix[k][k]
+                    rowSwaps := state.rowSwaps
+                    singularStep := none } :=
+            noPivotLoop_regular_branch a' state hDone hp
+          rw [h_lhs, h_rhs_inner]
+          exact ih _
+      · rw [noPivotLoop_id_at_done (a' + 1 + b) state hDone]
+        rw [noPivotLoop_id_at_done (a' + 1) state hDone]
+        exact (noPivotLoop_id_at_done b state hDone).symm
+
+/-- When a no-pivot Bareiss run records no singular step and has enough room,
+the `step` field advances by exactly the amount of consumed fuel. -/
+theorem noPivotLoop_step_eq_add_of_singularStep_none
+    {n : Nat} (fuel : Nat) (state : BareissState n)
+    (h_init : state.singularStep = none)
+    (h_room : state.step + fuel + 1 ≤ n)
+    (h_no_sing : (noPivotLoop fuel state).singularStep = none) :
+    (noPivotLoop fuel state).step = state.step + fuel := by
+  induction fuel generalizing state with
+  | zero =>
+      show state.step = state.step + 0
+      omega
+  | succ f ih =>
+      have hDone : state.step + 1 < n := by omega
+      by_cases hp : state.matrix[state.step][state.step] = 0
+      · rw [noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+        simp at h_no_sing
+      · rw [noPivotLoop_regular_branch f state hDone hp] at h_no_sing
+        rw [noPivotLoop_regular_branch f state hDone hp]
+        have h_next_room : state.step + 1 + f + 1 ≤ n := by omega
+        have h_next_step := ih
+          { step := state.step + 1
+            matrix := stepMatrix state.matrix state.step
+              state.matrix[state.step][state.step] state.prevPivot
+            prevPivot := state.matrix[state.step][state.step]
+            rowSwaps := state.rowSwaps
+            singularStep := none }
+          rfl h_next_room h_no_sing
+        rw [h_next_step]
+        show state.step + 1 + f = state.step + (f + 1)
+        omega
+
 /-- When the no-pivot Bareiss loop completes `fuel` iterations without
 recording a singular step, the row-pivoted Bareiss loop produces an
 identical state: every diagonal pivot is nonzero, so the row search and
@@ -1190,6 +1309,34 @@ theorem bareiss_eq_bareissData_det (M : Matrix Int n n) :
         arrayLastDiag?, BareissData.lastDiag?, rowsToMatrix, Matrix.ofFn,
         arraySign, BareissData.sign]
       rfl
+
+/-- If the no-pivot Bareiss pass reaches the final pivot without recording a
+singular step, then the public row-pivoted `bareiss` determinant is exactly
+the no-pivot final diagonal entry. -/
+theorem bareiss_eq_noPivotLoop_last_of_no_singular {k : Nat}
+    (M : Matrix Int (k + 1) (k + 1))
+    (h_no_sing :
+      (noPivotLoop k (noPivotInitialState M)).singularStep = none) :
+    bareiss M =
+      (noPivotLoop k (noPivotInitialState M)).matrix[Fin.last k][Fin.last k] := by
+  let init := noPivotInitialState M
+  let stateK := noPivotLoop k init
+  have h_step : stateK.step = k := by
+    have h := noPivotLoop_step_eq_add_of_singularStep_none k init rfl
+      (by simp [init, noPivotInitialState]) h_no_sing
+    simpa [stateK, init, noPivotInitialState] using h
+  have hDone_stateK : ¬ stateK.step + 1 < k + 1 := by omega
+  have h_full_nopivot : noPivotLoop (k + 1) init = stateK := by
+    rw [noPivotLoop_add k 1 init]
+    exact noPivotLoop_id_at_done 1 stateK hDone_stateK
+  have h_full_sing : (noPivotLoop (k + 1) init).singularStep = none := by
+    rw [h_full_nopivot]
+    exact h_no_sing
+  have hpivot := pivotLoop_eq_noPivotLoop_of_no_singular (k + 1) init h_full_sing
+  rw [bareiss_eq_bareissData_det, bareissData_eq_finish_pivotLoop, hpivot, h_full_nopivot]
+  have hdet := BareissData.det_succ_eq (finish stateK) h_no_sing
+  rw [hdet]
+  simp [finish, BareissData.sign, stateK, init, noPivotInitialState, noPivotLoop_rowSwaps]
 
 /-- The Bareiss determinant agrees with the generic determinant. -/
 theorem bareiss_eq_det (M : Matrix Int n n) :

--- a/progress/20260515T062556Z_0cf2ae0c.md
+++ b/progress/20260515T062556Z_0cf2ae0c.md
@@ -1,0 +1,41 @@
+# 2026-05-15 06:25 UTC — work session, issues #4163/#4165
+
+## Accomplished
+
+- Claimed #4163, confirmed PR #4162 had merged, and decomposed the residual
+  case-split proof into #4165, #4166, and #4167.
+- Marked #4163 for replan with the required `Decomposed into #4165, #4166,
+  #4167` breadcrumb.
+- Claimed #4165 and implemented the non-singular branch package:
+  - added reusable `Matrix.noPivotLoop_*` composition/terminal-step helpers;
+  - added `Matrix.bareiss_eq_noPivotLoop_last_of_no_singular`;
+  - exposed the narrow Gram-Schmidt array/no-pivot bridge helpers needed by
+    the Mathlib bridge;
+  - added
+    `Hex.GramSchmidt.Int.scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular`.
+- Verified:
+  - `lake build HexGramSchmidtMathlib.Int`
+  - `lake build HexGramSchmidtMathlib`
+  - `lake build HexGramSchmidt`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+
+## Current frontier
+
+- #4165 is complete: the non-singular branch now avoids the private
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` sorry and goes through
+  the public no-pivot/public-Bareiss bridge.
+- The main public theorem
+  `scaledCoeffs_eq_scaledCoeffMatrix_bareiss` still uses the existing chain
+  through `scaledCoeffs_eq_scaledCoeffMatrix_det` and `Matrix.bareiss_eq_det`.
+
+## Next step
+
+- Prove #4166: lift `scaledCoeffArrayLoop_lower_singular_matches` to a
+  top-level lower-column zero lemma for earlier singular steps.
+- Then #4167 can assemble the explicit case split and replace the remaining
+  chain proof.
+
+## Blockers
+
+- None for #4165.


### PR DESCRIPTION
Closes #4165

Session: `0cf2ae0c-7db6-4237-885e-e9558b2c9e65`

2d756ae feat: package non-singular Gram-Schmidt Bareiss bridge

🤖 Prepared with Claude Code