### PR TITLE
refactor: relocate adjacent-swap pivot bridge

### DIFF
--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -441,30 +441,6 @@ theorem adjacentSwap_gramDetNumerator_dvd (b : Matrix Int n m)
   exact ⟨((gramDet (Matrix.rowSwap b km1 k) k.val (Nat.le_of_lt k.isLt) : Nat) : Int),
     Int.mul_comm _ _⟩
 
-theorem scaledCoeffs_adjacentSwap_pivot (b : Matrix Int n m)
-    (k : Fin n) (hk : 0 < k.val) :
-    let km1 := GramSchmidt.prevRow k hk
-    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) k km1 =
-      GramSchmidt.entry (scaledCoeffs b) k km1 := by
-  intro km1
-  have hkm1 : km1.val + 1 = k.val := by
-    dsimp [km1, GramSchmidt.prevRow]
-    omega
-  have hkm1k : km1.val < k.val := by omega
-  calc
-    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) k km1
-        = Matrix.det
-            (GramSchmidt.scaledCoeffMatrix (Matrix.rowSwap b km1 k) k km1 hkm1k) := by
-          rw [scaledCoeffs_eq_scaledCoeffMatrix_det]
-          rfl
-    _ = Matrix.det ((GramSchmidt.scaledCoeffMatrix b k km1 hkm1k).transpose) := by
-          rw [GramSchmidt.Int.scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
-            (b := b) (km1 := km1) (k := k) hkm1 hkm1k]
-    _ = Matrix.det (GramSchmidt.scaledCoeffMatrix b k km1 hkm1k) := by
-          rw [Matrix.det_transpose]
-    _ = GramSchmidt.entry (scaledCoeffs b) k km1 := by
-          rw [← scaledCoeffs_eq_scaledCoeffMatrix_det]
-
 theorem scaledCoeffs_adjacentSwap_above_prev (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hik : k.val < i.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -454,6 +454,30 @@ theorem scaledCoeffs_adjacentSwap_lower_curr (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) km1 j : Int) : Rat) := hRHS.symm
 
+theorem scaledCoeffs_adjacentSwap_pivot (b : Matrix Int n m)
+    (k : Fin n) (hk : 0 < k.val) :
+    let km1 := GramSchmidt.prevRow k hk
+    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) k km1 =
+      GramSchmidt.entry (scaledCoeffs b) k km1 := by
+  intro km1
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]
+    omega
+  have hkm1k : km1.val < k.val := by omega
+  calc
+    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) k km1
+        = Matrix.det
+            (GramSchmidt.scaledCoeffMatrix (Matrix.rowSwap b km1 k) k km1 hkm1k) := by
+          rw [scaledCoeffs_eq_scaledCoeffMatrix_det]
+          rfl
+    _ = Matrix.det ((GramSchmidt.scaledCoeffMatrix b k km1 hkm1k).transpose) := by
+          rw [GramSchmidt.Int.scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
+            (b := b) (km1 := km1) (k := k) hkm1 hkm1k]
+    _ = Matrix.det (GramSchmidt.scaledCoeffMatrix b k km1 hkm1k) := by
+          rw [Matrix.det_transpose]
+    _ = GramSchmidt.entry (scaledCoeffs b) k km1 := by
+          rw [← scaledCoeffs_eq_scaledCoeffMatrix_det]
+
 end GramSchmidt.Int
 
 end Hex

--- a/progress/2026-05-15T08-02-19Z_aaf8d114.md
+++ b/progress/2026-05-15T08-02-19Z_aaf8d114.md
@@ -1,0 +1,42 @@
+# 2026-05-15 08:02 UTC — work session, issue #3899
+
+## Accomplished
+
+- Claimed HO-43 (#3899) and audited the current relocation state.
+- Moved `Hex.GramSchmidt.Int.scaledCoeffs_adjacentSwap_pivot` from
+  `HexGramSchmidt/Update.lean` to `HexGramSchmidtMathlib/Update.lean`
+  without changing its namespace or statement.
+- Verified that `HexGramSchmidt/Update.lean` no longer contains an active
+  `Matrix.det` proof reference; the only remaining `Matrix.bareiss_eq_det`
+  hit there is explanatory text for the blocked size-reduce block.
+- Ran:
+  - `lake build HexGramSchmidt.Update HexGramSchmidtMathlib.Update`
+  - `lake build HexGramSchmidt HexGramSchmidtMathlib HexLLL HexLLLMathlib`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+
+## Current frontier
+
+- This is partial progress on HO-43. The major remaining violations are still
+  in `HexGramSchmidt/Int.lean`, including direct `Matrix.bareiss_eq_det`
+  users around the Cramer/scaled-coefficient determinant chain, leading Gram
+  determinant bridges, and row-add determinant invariance.
+- `HexGramSchmidt/Update.lean` still intentionally keeps the size-reduce
+  theorem block because current Mathlib-free `HexLLL.Basic` consumers call it
+  directly; the file comment records the #3916 consumer-side refactor needed
+  before that block can move cleanly.
+
+## Next step
+
+- Continue HO-43 by relocating the `HexGramSchmidt/Int.lean` bridge-bound
+  theorem chain into `HexGramSchmidtMathlib/Int.lean`, or first break the
+  `HexLLL.Basic` size-reduce consumer cycle so the remaining Update block can
+  move.
+
+## Blockers
+
+- No blocker for this partial PR.
+- Full closure of HO-43 remains larger than this session because the Int
+  relocation requires moving multiple mutually dependent private helpers and
+  public theorem surfaces without importing bridge modules back into
+  Mathlib-free files.


### PR DESCRIPTION
Partial progress on #3899

Session: `aaf8d114-8d6e-48b4-9411-fac1aaad985b`

9681828 refactor: relocate adjacent-swap pivot bridge

🤖 Prepared with Claude Code