### PR TITLE
HexGramSchmidtMathlib: assemble Cramer/Bareiss case-split bridge

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -1800,6 +1800,45 @@ private theorem noPivotLoop_singular_inv
         rw [Matrix.noPivotLoop_done f state hDone]
         left; exact h_init
 
+/-- When the no-pivot Bareiss loop starts from a non-singular state and records
+a singular step within `fuel` iterations, the recorded singular index is
+strictly bounded by the initial step plus the fuel. The singular branch sets
+`singularStep := some state.step` at the trigger iteration, and `state.step`
+advances by at most one per regular iteration; with `fuel` iterations available
+and at least one used for the singular trigger, the recorded index is `< start
++ fuel`. -/
+theorem noPivotLoop_singularStep_lt
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    (h_init : state.singularStep = none)
+    (s : Nat)
+    (h_sing : (Matrix.noPivotLoop fuel state).singularStep = some s) :
+    s < state.step + fuel := by
+  induction fuel generalizing state with
+  | zero =>
+      rw [Matrix.noPivotLoop_zero_fuel, h_init] at h_sing
+      nomatch h_sing
+  | succ f ih =>
+      by_cases hDone : state.step + 1 < n
+      · by_cases hp : state.matrix[state.step][state.step] = 0
+        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_sing
+          simp at h_sing
+          omega
+        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at h_sing
+          have h_ih := ih
+            { step := state.step + 1
+              matrix := Matrix.stepMatrix state.matrix state.step
+                state.matrix[state.step][state.step] state.prevPivot
+              prevPivot := state.matrix[state.step][state.step]
+              rowSwaps := state.rowSwaps
+              singularStep := none }
+            rfl h_sing
+          change s < state.step + 1 + f at h_ih
+          show s < state.step + (f + 1)
+          omega
+      · rw [Matrix.noPivotLoop_done f state hDone] at h_sing
+        rw [h_init] at h_sing
+        nomatch h_sing
+
 /-- After running `fuel` iterations of `Matrix.noPivotLoop` from a state with
 no recorded singular step, if the result also has no recorded singular step
 and the loop had at least `fuel + 1` steps of room from its starting step,
@@ -4914,6 +4953,121 @@ theorem scaledCoeffs_eq_zero_of_singularStep_lt
     (Nat.zero_le _) hji (by have := i.isLt; omega) s ?_
   rw [h_sub]
   exact h_sing
+
+/-- Cramer's rule bridge under singularity. When the no-pivot Bareiss pass over
+the Gram matrix records an early singular step before reaching column `j`, the
+Leibniz determinant of the Cramer minor `scaledCoeffMatrix b i j hji` is zero.
+Internally lifts the partial-pass singularity to the full `bareissNoPivotData`
+pass, traverses `gramDetVecEntry` to conclude `gramDet b (j+1) = 0`, and
+finishes via the Cramer determinant identity
+`scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`. -/
+theorem scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) (s : Nat)
+    (h_sing : (Matrix.noPivotLoop j.val
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
+    Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) = 0 := by
+  -- Step A: derive `s < j.val` from the partial-pass singularity.
+  have hsj : s < j.val := by
+    have h := noPivotLoop_singularStep_lt j.val
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl s h_sing
+    -- h : s < (noPivotInitialState ...).step + j.val. The init step is 0.
+    change s < 0 + j.val at h
+    omega
+  -- Step B: lift to the full `bareissNoPivotData` pass.
+  have hjn : j.val < n := Nat.lt_trans hji i.isLt
+  have hsucc : j.val + 1 ≤ n := Nat.succ_le_of_lt hjn
+  have hjle : j.val ≤ n := Nat.le_of_lt hjn
+  have h_init :
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b)).singularStep = none := rfl
+  have h_full_sing :
+      (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).singularStep = some s := by
+    -- Apply singular_inv to the j.val-fueled pass.
+    rcases noPivotLoop_singular_inv j.val
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b)) h_init
+      with h_none | ⟨k, hsk, hstk, hpk, hk⟩
+    · rw [h_none] at h_sing; nomatch h_sing
+    · -- The full pass equals the j.val pass via fixedpoint.
+      have hks : k.val = s := by
+        rw [hsk] at h_sing
+        exact Option.some.inj h_sing
+      -- Use noPivotLoop_add and noPivotLoop_id_at_singular_fixedpoint to lift.
+      have h_add : Matrix.noPivotLoop (j.val + (n - j.val))
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
+        Matrix.noPivotLoop (n - j.val)
+          (Matrix.noPivotLoop j.val
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b))) :=
+        Matrix.noPivotLoop_add j.val (n - j.val) _
+      have hn_eq : j.val + (n - j.val) = n := Nat.add_sub_cancel' hjle
+      -- The post-`j.val` state already has singularStep = some k.val, step = k.val,
+      -- and a zero pivot at column k. Extra fuel is a fixedpoint.
+      have h_step_lt : (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n := by
+        rw [hstk]; exact hk
+      have h_pivot_zero :
+          (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[
+              (⟨(Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState
+                    (Matrix.gramMatrix b))).step,
+                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)][
+              (⟨(Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState
+                    (Matrix.gramMatrix b))).step,
+                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)] = 0 := by
+        have h_fin :
+            (⟨(Matrix.noPivotLoop j.val
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step,
+              Nat.lt_of_succ_lt h_step_lt⟩ : Fin n) = k :=
+          Fin.ext hstk
+        simp only [h_fin]
+        exact hpk
+      have h_sing_step :
+          (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep =
+            some (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step := by
+        rw [hsk, hstk]
+      have h_fixed :
+          Matrix.noPivotLoop (n - j.val)
+            (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))) =
+            Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b)) :=
+        Matrix.noPivotLoop_id_at_singular_fixedpoint (n := n) (n - j.val) _
+          h_step_lt h_pivot_zero h_sing_step
+      have h_full_eq :
+          Matrix.noPivotLoop n
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
+          Matrix.noPivotLoop j.val
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
+        calc Matrix.noPivotLoop n
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))
+            = Matrix.noPivotLoop (j.val + (n - j.val))
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
+                  rw [hn_eq]
+          _ = Matrix.noPivotLoop (n - j.val)
+                (Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState (Matrix.gramMatrix b))) := h_add
+          _ = Matrix.noPivotLoop j.val
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := h_fixed
+      show (Matrix.finish (Matrix.noPivotLoop n
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b)))).singularStep = some s
+      change (Matrix.noPivotLoop n
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s
+      rw [h_full_eq, hsk, hks]
+  -- Step C: gramDet b (j+1) = 0 via gramDetVecEntry chain.
+  have h_gd_zero : gramDet b (j.val + 1) hsucc = 0 := by
+    have h_vec_gd := gramDetVecEntry_eq_gramDet (b := b) (j.val + 1) hsucc
+    have h_vec_zero :=
+      gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt b s j.val hjn h_full_sing
+        (by omega)
+    rw [← h_vec_gd, h_vec_zero]
+  -- Step D: Cramer's identity collapses to zero.
+  have h_cramer :=
+    scaledCoeffMatrix_det_eq_gramDet_mul_coeffs (b := b) i.val j.val i.isLt hji
+  rw [h_gd_zero] at h_cramer
+  simp at h_cramer
+  exact_mod_cast h_cramer
 
 private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j r : Fin n')

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -63,14 +63,42 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular
 
 /-- Cramer/Bareiss bridge: below the diagonal, the integral scaled
 Gram-Schmidt coefficient is exactly the public Bareiss determinant of the
-Cramer minor `scaledCoeffMatrix`. This is the `bareiss`-form companion of
-the existing Mathlib-free `scaledCoeffs_eq_scaledCoeffMatrix_det`. -/
+Cramer minor `scaledCoeffMatrix`. The proof splits on whether the no-pivot
+Bareiss pass over `gramMatrix b` reaches column `j` without recording a
+singular step:
+
+- Non-singular branch: defer to
+  `scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular`.
+- Singular branch: both sides vanish — the executable scaled coefficient is
+  zero by `scaledCoeffs_eq_zero_of_singularStep_lt` (the lifted lower-column
+  singular lemma from #4166), and the public Bareiss determinant of the
+  Cramer minor is zero by `Matrix.bareiss_eq_det` composed with
+  `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt`. The latter Mathlib-free
+  helper internally lifts partial-pass singularity to the full
+  `bareissNoPivotData` pass and applies the Cramer determinant identity.
+
+This case-split avoids the transitive dependency on the private sorry
+`scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` that the older chain
+proof carried via `scaledCoeffs_eq_scaledCoeffMatrix_det`. -/
 theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
     (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
     GramSchmidt.entry (scaledCoeffs b) i j =
       Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-  rw [scaledCoeffs_eq_scaledCoeffMatrix_det b i j hji,
-    Matrix.bareiss_eq_det]
+  cases h_sing : (Matrix.noPivotLoop j.val
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep with
+  | none =>
+      exact scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular b i j hji h_sing
+  | some s =>
+      have hsj : s < j.val := by
+        have h := noPivotLoop_singularStep_lt j.val
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl s h_sing
+        change s < 0 + j.val at h
+        omega
+      have h_lhs : GramSchmidt.entry (scaledCoeffs b) i j = 0 :=
+        scaledCoeffs_eq_zero_of_singularStep_lt b i j hji s h_sing hsj
+      have h_det := scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
+        b i j hji s h_sing
+      rw [h_lhs, Matrix.bareiss_eq_det, h_det]
 
 end Int
 end GramSchmidt

--- a/progress/20260515T082534Z_a81474bd.md
+++ b/progress/20260515T082534Z_a81474bd.md
@@ -1,0 +1,62 @@
+# 2026-05-15 08:25 UTC — feature session, issue #4167
+
+## Accomplished
+
+- Rewrote `Hex.GramSchmidt.Int.scaledCoeffs_eq_scaledCoeffMatrix_bareiss`
+  in `HexGramSchmidtMathlib/Int.lean` as an explicit case-split on
+  `(Matrix.noPivotLoop j.val (Matrix.noPivotInitialState (Matrix.gramMatrix
+  b))).singularStep`:
+  - `none` branch: defers to `scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular`
+    (the public successor from #4165 / PR #4168).
+  - `some s` branch: derives `s < j.val`, then closes both sides by zero —
+    LHS via `scaledCoeffs_eq_zero_of_singularStep_lt` (the public successor
+    from #4166 / PR #4178), RHS via `Matrix.bareiss_eq_det` composed with a
+    new `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt` helper.
+- Added two new public theorems in `HexGramSchmidt/Int.lean`:
+  - `noPivotLoop_singularStep_lt`: pure Mathlib-free bound `s < state.step
+    + fuel` when the no-pivot loop records `singularStep = some s` from a
+    `singularStep = none` start. Used by the bridge to discharge `s < j.val`
+    in the singular branch without exposing additional private helpers.
+  - `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt`: packages the
+    Cramer-zero chain internally — `noPivotLoop_singular_inv` to extract
+    the fixedpoint info, `noPivotLoop_add` + `noPivotLoop_id_at_singular_fixedpoint`
+    to lift partial-pass singularity to the full `bareissNoPivotData`
+    pass, `gramDetVecEntry_eq_gramDet` + `gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt`
+    to conclude `gramDet b (j+1) = 0`, and
+    `scaledCoeffMatrix_det_eq_gramDet_mul_coeffs` to collapse the Cramer
+    determinant. Statement uses `Matrix.det`, consistent with existing
+    Cramer/det-statement theorems in the same file pending HO-43 Round 3.
+- `lake build HexGramSchmidtMathlib HexGramSchmidt HexLLL HexLLLMathlib`,
+  `python3 scripts/check_dag.py`, `git diff --check` all pass.
+- The new bridge proof no longer routes through `scaledCoeffs_eq_scaledCoeffMatrix_det`
+  and therefore no longer transitively depends on the private sorry
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` for either branch.
+  No new sorries introduced.
+
+## Current frontier
+
+- The Mathlib-free private sorry
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` in
+  `HexGramSchmidt/Int.lean` is still present — it is still consumed by
+  `scaledCoeffs_eq_scaledCoeffMatrix_det` and `scaledCoeffRows_lower_eq_coeffs`
+  in the same file. Closing the public bridge alone does not eliminate
+  the underlying sorry.
+- The new helper `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt` has
+  `Matrix.det` in its statement and therefore joins the existing
+  HO-43 Round 3 relocation surface (alongside
+  `scaledCoeffs_eq_scaledCoeffMatrix_det`,
+  `leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg`, etc.). No new
+  Mathlib-free boundary violations.
+
+## Next step
+
+- Land this PR, then proceed with HO-43 Round 3
+  (`HexGramSchmidtMathlib/Int.lean` relocation of Cramer/det-statement
+  theorems) which will move the new helper alongside its siblings.
+- Separately, settle the underlying private sorry
+  `scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss` so that
+  `scaledCoeffs_eq_scaledCoeffMatrix_det` becomes sorry-free.
+
+## Blockers
+
+- None for this PR.


### PR DESCRIPTION
Closes #4167

Session: `a81474bd-27b6-4312-b366-969596c540c3`

3581da9 feat: Cramer/Bareiss bridge case-split avoids private sorry chain

🤖 Prepared with Claude Code