### PR TITLE
feat: HexPolyFp.Compose.compose_sub_X and witness substitution into xPowSubX 1

### DIFF
--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -2019,6 +2019,25 @@ theorem primeFieldProduct_X_eq_xPowSubX :
     primeFieldLinearProduct_monic
     xPowSubX_one_monic
 
+/-- Substituting `w` into `xPowSubX 1 = X^p - X` yields `linearPow w p - w`.
+This is deliverable 3 of issue #4187 and the missing transport step that
+takes the variable identity `primeFieldProduct_X_eq_xPowSubX` to its
+witness-substituted form. -/
+theorem compose_xPowSubX_one (w : FpPoly p) :
+    DensePoly.compose (xPowSubX (p := p) 1) w =
+      FpPoly.linearPow w p - w := by
+  have hxPow : xPowSubX (p := p) 1 = FpPoly.linearPow FpPoly.X p - FpPoly.X := by
+    unfold xPowSubX
+    show DensePoly.monomial (p ^ 1) (1 : ZMod64 p) - FpPoly.X =
+      FpPoly.linearPow FpPoly.X p - FpPoly.X
+    congr 1
+    rw [show (FpPoly.X : FpPoly p) = DensePoly.monomial 1 (1 : ZMod64 p) from rfl]
+    rw [FpPoly.linearPow_monomial_one]
+    congr 1
+    exact Nat.pow_one p
+  rw [hxPow]
+  exact FpPoly.compose_linearPow_X_sub_X w p
+
 /-! ### Structural lemmas
 
 These small consequences only use the foundational lemmas above plus

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -229,5 +229,68 @@ theorem C_mul_C_eq (a b : ZMod64 p) :
       simp
       exact hzero
 
+/-! ### Compose of `monomial k 1` and `linearPow X k`
+
+The composition `compose (linearPow X k) w = linearPow w k` follows by
+unfolding `linearPow X k` to `monomial k 1` and then reading off the
+explicit coefficient list `[0, …, 0, 1]` through the Horner power-sum
+form.
+-/
+
+private theorem composeCoeffPowerSumFrom_replicate_zero_append_one
+    [ZMod64.PrimeModulus p] (w : FpPoly p) :
+    ∀ (k base : Nat),
+      composeCoeffPowerSumFrom
+        ((List.replicate k (Zero.zero : ZMod64 p)) ++ [(1 : ZMod64 p)]) base w =
+          linearPow w (base + k)
+  | 0, base => by
+      simp only [List.replicate, List.nil_append]
+      show DensePoly.C (1 : ZMod64 p) * linearPow w base +
+          composeCoeffPowerSumFrom [] (base + 1) w = linearPow w (base + 0)
+      change (1 : FpPoly p) * linearPow w base + 0 = linearPow w (base + 0)
+      rw [FpPoly.one_mul, FpPoly.add_zero, Nat.add_zero]
+  | k + 1, base => by
+      simp only [List.replicate, List.cons_append]
+      show DensePoly.C (Zero.zero : ZMod64 p) * linearPow w base +
+          composeCoeffPowerSumFrom
+            (List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)]) (base + 1) w =
+          linearPow w (base + (k + 1))
+      have hCz : (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 := C_zero_eq_zero
+      rw [hCz, FpPoly.zero_mul, FpPoly.zero_add]
+      rw [composeCoeffPowerSumFrom_replicate_zero_append_one w k (base + 1)]
+      congr 1
+      omega
+
+private theorem monomial_one_toArray_toList_eq
+    [ZMod64.PrimeModulus p] (k : Nat) :
+    (DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).toArray.toList =
+      List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)] := by
+  have h1 : (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := one_ne_zero_of_prime
+  show ((DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).coeffs.toList :
+    List (ZMod64 p)) = _
+  unfold DensePoly.monomial
+  rw [dif_neg h1]
+  show ((Array.replicate k (Zero.zero : ZMod64 p)).push (1 : ZMod64 p)).toList =
+    List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)]
+  rw [Array.toList_push, Array.toList_replicate]
+
+private theorem compose_monomial_k_one_eq
+    [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :
+    DensePoly.compose
+        ((DensePoly.monomial k (1 : ZMod64 p)) : FpPoly p) w =
+      linearPow w k := by
+  rw [compose_eq_powerSum, monomial_one_toArray_toList_eq,
+    composeCoeffPowerSumFrom_replicate_zero_append_one]
+  rw [Nat.zero_add]
+
+/-- `compose (linearPow X k) w = linearPow w k`. -/
+theorem compose_linearPow_X
+    [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :
+    DensePoly.compose (FpPoly.linearPow FpPoly.X k) w = FpPoly.linearPow w k := by
+  show DensePoly.compose
+    (FpPoly.linearPow (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) k) w = _
+  rw [linearPow_monomial_one]
+  exact compose_monomial_k_one_eq w k
+
 end FpPoly
 end Hex

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -292,6 +292,266 @@ theorem compose_linearPow_X
   rw [linearPow_monomial_one]
   exact compose_monomial_k_one_eq w k
 
+/-! ### Coefficient-indexed power-sum form
+
+A coefficient-indexed analogue of `composeCoeffPowerSumFrom`, mirroring
+`evalCoeffPowerSumUpTo` from `HexPolyFp/Basic.lean`. The size-bounded form
+`compose_eq_coeff_power_sum_upTo_bound` lets us express
+`compose (f - h) w` and `compose f w - compose h w` over a single
+shared coefficient bound, which is the key ingredient for
+`compose_sub` distributivity. -/
+
+private theorem compose_list_getD_map_range
+    (bound n : Nat) (coeff : Nat → ZMod64 p) :
+    ((List.range bound).map coeff).getD n (0 : ZMod64 p) =
+      if n < bound then coeff n else 0 := by
+  by_cases hn : n < bound
+  · simp [hn, List.getD]
+  · simp [hn, List.getD]
+
+private theorem compose_toArray_toList_getD_eq_coeff (f : FpPoly p) (n : Nat) :
+    f.toArray.toList.getD n (0 : ZMod64 p) = f.coeff n := by
+  unfold DensePoly.toArray DensePoly.coeff
+  rw [Array.getD_eq_getD_getElem?]
+  change f.coeffs.toList[n]?.getD (0 : ZMod64 p) =
+    f.coeffs[n]?.getD (Zero.zero : ZMod64 p)
+  rw [Array.getElem?_toList]
+  rfl
+
+private theorem compose_list_eq_of_length_eq_of_getD_eq
+    {xs ys : List (ZMod64 p)}
+    (hlen : xs.length = ys.length)
+    (hget : ∀ i, i < xs.length → xs.getD i 0 = ys.getD i 0) :
+    xs = ys := by
+  induction xs generalizing ys with
+  | nil =>
+      cases ys with
+      | nil => rfl
+      | cons _ _ => simp at hlen
+  | cons x xs ih =>
+      cases ys with
+      | nil => simp at hlen
+      | cons y ys =>
+          have hhead : x = y := by
+            have h := hget 0 (by simp)
+            simpa using h
+          have hlen_tail : xs.length = ys.length := Nat.succ.inj hlen
+          have htail : xs = ys := by
+            apply ih hlen_tail
+            intro i hi
+            have h := hget (i + 1) (by simp [hi])
+            simpa using h
+          rw [hhead, htail]
+
+private theorem compose_toArray_toList_eq_coeff_range (f : FpPoly p) :
+    f.toArray.toList = (List.range f.size).map (fun i => f.coeff i) := by
+  apply compose_list_eq_of_length_eq_of_getD_eq
+  · simp [DensePoly.toArray, DensePoly.size]
+  · intro i hi
+    have hi_size : i < f.size := by
+      simpa [DensePoly.toArray, DensePoly.size] using hi
+    rw [compose_toArray_toList_getD_eq_coeff]
+    rw [compose_list_getD_map_range]
+    simp [hi_size]
+
+private def composeCoeffPowerSumUpTo
+    (coeff : Nat → ZMod64 p) :
+    Nat → Nat → FpPoly p → FpPoly p
+  | 0, _, _ => 0
+  | n + 1, base, w =>
+      DensePoly.C (coeff base) * linearPow w base +
+        composeCoeffPowerSumUpTo coeff n (base + 1) w
+
+private theorem composeCoeffPowerSumFrom_range_eq_upTo
+    (coeff : Nat → ZMod64 p) (w : FpPoly p) :
+    ∀ n base,
+      composeCoeffPowerSumFrom ((List.range n).map (fun i => coeff (base + i))) base w =
+        composeCoeffPowerSumUpTo coeff n base w
+  | 0, base => by
+      simp [composeCoeffPowerSumFrom, composeCoeffPowerSumUpTo]
+  | n + 1, base => by
+      rw [List.range_succ_eq_map]
+      simp only [List.map_cons, List.map_map]
+      simp only [composeCoeffPowerSumFrom, composeCoeffPowerSumUpTo]
+      congr 1
+      simpa [Function.comp_def, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
+        using composeCoeffPowerSumFrom_range_eq_upTo coeff w n (base + 1)
+
+private theorem compose_eq_coeff_power_sum_upTo_size (f w : FpPoly p) :
+    DensePoly.compose f w =
+      composeCoeffPowerSumUpTo (fun i => f.coeff i) f.size 0 w := by
+  rw [compose_eq_powerSum]
+  rw [compose_toArray_toList_eq_coeff_range]
+  simpa using composeCoeffPowerSumFrom_range_eq_upTo (fun i => f.coeff i) w f.size 0
+
+private theorem composeCoeffPowerSumUpTo_succ_of_next_zero
+    (coeff : Nat → ZMod64 p) (w : FpPoly p) :
+    ∀ n base,
+      coeff (base + n) = 0 →
+        composeCoeffPowerSumUpTo coeff n base w =
+          composeCoeffPowerSumUpTo coeff (n + 1) base w
+  | 0, base, hzero => by
+      have hz : coeff base = 0 := by simpa using hzero
+      show (0 : FpPoly p) =
+        DensePoly.C (coeff base) * linearPow w base +
+          composeCoeffPowerSumUpTo coeff 0 (base + 1) w
+      rw [hz]
+      rw [show (DensePoly.C (0 : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero]
+      rw [FpPoly.zero_mul]
+      show (0 : FpPoly p) = 0 + composeCoeffPowerSumUpTo coeff 0 (base + 1) w
+      rw [FpPoly.zero_add]
+      rfl
+  | n + 1, base, hzero => by
+      simp only [composeCoeffPowerSumUpTo]
+      rw [composeCoeffPowerSumUpTo_succ_of_next_zero coeff w n (base + 1) (by
+        simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hzero)]
+      simp only [composeCoeffPowerSumUpTo]
+
+private theorem composeCoeffPowerSumUpTo_le_extend_base
+    (coeff : Nat → ZMod64 p) (w : FpPoly p) {base bound : Nat}
+    (hzero : ∀ i, base + bound ≤ i → coeff i = 0) :
+    ∀ extra,
+      composeCoeffPowerSumUpTo coeff bound base w =
+        composeCoeffPowerSumUpTo coeff (bound + extra) base w
+  | 0 => by
+      simp
+  | extra + 1 => by
+      rw [composeCoeffPowerSumUpTo_le_extend_base coeff w hzero extra]
+      rw [Nat.add_succ]
+      exact composeCoeffPowerSumUpTo_succ_of_next_zero
+        coeff w (bound + extra) base (hzero (base + (bound + extra)) (by omega))
+
+private theorem composeCoeffPowerSumUpTo_le_extend
+    (coeff : Nat → ZMod64 p) (w : FpPoly p) {bound : Nat}
+    (hzero : ∀ i, bound ≤ i → coeff i = 0) :
+    ∀ extra,
+      composeCoeffPowerSumUpTo coeff bound 0 w =
+        composeCoeffPowerSumUpTo coeff (bound + extra) 0 w := by
+  intro extra
+  exact composeCoeffPowerSumUpTo_le_extend_base
+    coeff w (base := 0) (bound := bound) (by simpa using hzero) extra
+
+private theorem compose_eq_coeff_power_sum_upTo_bound (f w : FpPoly p)
+    {bound : Nat} (hbound : f.size ≤ bound) :
+    DensePoly.compose f w =
+      composeCoeffPowerSumUpTo (fun i => f.coeff i) bound 0 w := by
+  rw [compose_eq_coeff_power_sum_upTo_size]
+  obtain ⟨extra, rfl⟩ := Nat.exists_eq_add_of_le hbound
+  exact composeCoeffPowerSumUpTo_le_extend
+    (fun i => f.coeff i) w
+    (fun i hi => DensePoly.coeff_eq_zero_of_size_le f hi) extra
+
+/-! ### Distributivity of compose over subtraction
+
+The rearrangement
+`(C a - C b) * w^k + (S_a - S_b) = (C a * w^k + S_a) - (C b * w^k + S_b)`
+is the key ring step. We prove it via the coefficient-level argument:
+the multiplication `(a - b) * c = a*c - b*c` follows from `right_distrib`
+and `DensePoly.neg_mul_right_poly`; the residual identity
+`(x - y) + (u - v) = (x + u) - (y + v)` reduces to a pointwise ZMod64
+identity through `DensePoly.ext_coeff`. -/
+
+private theorem fp_sub_mul_right
+    (a b c : FpPoly p) :
+    (a - b) * c = a * c - b * c := by
+  rw [FpPoly.sub_eq_add_neg a b]
+  rw [FpPoly.right_distrib]
+  rw [FpPoly.sub_eq_add_neg (a * c) (b * c)]
+  congr 1
+  show ((0 - b : FpPoly p) * c) = 0 - b * c
+  exact DensePoly.neg_mul_right_poly b c
+
+private theorem fp_add_sub_add_sub
+    (x y u v : FpPoly p) :
+    (x - y) + (u - v) = (x + u) - (y + v) := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+  grind
+
+private theorem composeCoeffPowerSumUpTo_sub
+    (f h w : FpPoly p) :
+    ∀ n base,
+      composeCoeffPowerSumUpTo (fun i => f.coeff i - h.coeff i) n base w =
+        composeCoeffPowerSumUpTo (fun i => f.coeff i) n base w -
+          composeCoeffPowerSumUpTo (fun i => h.coeff i) n base w
+  | 0, _ => by
+      simp [composeCoeffPowerSumUpTo]
+      exact (FpPoly.sub_self 0).symm
+  | n + 1, base => by
+      simp only [composeCoeffPowerSumUpTo]
+      rw [composeCoeffPowerSumUpTo_sub f h w n (base + 1)]
+      rw [C_sub_eq]
+      rw [fp_sub_mul_right (DensePoly.C (f.coeff base))
+        (DensePoly.C (h.coeff base)) (linearPow w base)]
+      exact fp_add_sub_add_sub
+        (DensePoly.C (f.coeff base) * linearPow w base)
+        (DensePoly.C (h.coeff base) * linearPow w base)
+        (composeCoeffPowerSumUpTo (fun i => f.coeff i) n (base + 1) w)
+        (composeCoeffPowerSumUpTo (fun i => h.coeff i) n (base + 1) w)
+
+private theorem fp_size_le_of_coeff_eq_zero_from
+    (f : FpPoly p) (bound : Nat)
+    (hzero : ∀ i, bound ≤ i → f.coeff i = 0) :
+    f.size ≤ bound := by
+  by_cases hle : f.size ≤ bound
+  · exact hle
+  · have hgt : bound < f.size := Nat.lt_of_not_ge hle
+    have hpos : 0 < f.size := by omega
+    have htop_zero : f.coeff (f.size - 1) = 0 := hzero (f.size - 1) (by omega)
+    exact False.elim (DensePoly.coeff_last_ne_zero_of_pos_size f hpos htop_zero)
+
+private theorem fp_size_sub_le
+    (f h : FpPoly p) :
+    (f - h).size ≤ max f.size h.size := by
+  apply fp_size_le_of_coeff_eq_zero_from
+  intro i hi
+  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [DensePoly.coeff_eq_zero_of_size_le f
+      (Nat.le_trans (Nat.le_max_left f.size h.size) hi),
+    DensePoly.coeff_eq_zero_of_size_le h
+      (Nat.le_trans (Nat.le_max_right f.size h.size) hi)]
+  exact zmod64_sub_zero_zero_local
+
+/-- `compose` distributes over subtraction. -/
+theorem compose_sub [ZMod64.PrimeModulus p] (f h w : FpPoly p) :
+    DensePoly.compose (f - h) w = DensePoly.compose f w - DensePoly.compose h w := by
+  let bound := max f.size h.size
+  rw [compose_eq_coeff_power_sum_upTo_bound (f - h) w (bound := bound)
+      (fp_size_sub_le f h)]
+  rw [compose_eq_coeff_power_sum_upTo_bound f w (bound := bound)
+      (Nat.le_max_left f.size h.size)]
+  rw [compose_eq_coeff_power_sum_upTo_bound h w (bound := bound)
+      (Nat.le_max_right f.size h.size)]
+  have hcoeff :
+      (fun i => (f - h).coeff i) =
+        (fun i => f.coeff i - h.coeff i) := by
+    funext i
+    rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [hcoeff]
+  exact composeCoeffPowerSumUpTo_sub f h w bound 0
+
+/-- Narrow specialisation needed by the witness-substitution caller:
+substituting `w` for `X` in `a - X` yields `compose a w - w`. -/
+theorem compose_sub_X [ZMod64.PrimeModulus p] (a w : FpPoly p) :
+    DensePoly.compose (a - FpPoly.X) w = DensePoly.compose a w - w := by
+  rw [compose_sub]
+  rw [compose_X]
+
+/-- The headline `linearPow X k - X` substitution: substituting `w`
+for `X` in `linearPow X k - X` yields `linearPow w k - w`. -/
+theorem compose_linearPow_X_sub_X
+    [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :
+    DensePoly.compose (FpPoly.linearPow FpPoly.X k - FpPoly.X) w =
+      FpPoly.linearPow w k - w := by
+  rw [compose_sub]
+  rw [compose_linearPow_X, compose_X]
+
 /-! ### Substitution into `a * (X - C c)`
 
 Substituting `w` into `a * (X - FpPoly.C c)` yields

--- a/progress/20260515T074829Z_ef8e6619.md
+++ b/progress/20260515T074829Z_ef8e6619.md
@@ -1,0 +1,80 @@
+# 2026-05-15 07:48 UTC — pod work session (multiple issues)
+
+## Accomplished
+
+- **Skipped #4171** (HO-1 residual: BZ factorization uniqueness via UFD
+  partition) with a detailed counterexample analysis. The "corrected
+  statement" in the issue body still has two further counterexamples:
+  1. Constant-factor scalar ambiguity (e.g.
+     `φ = (1, [(C 2, 1)])` and `ψ = (2, [])` both have product
+     `C 2` and satisfy all sign-normalization / irreducibility
+     hypotheses, but `φ.scalar ≠ ψ.scalar`).
+  2. Multiplicity packing ambiguity (e.g.
+     `φ = (1, [(X, 1), (X, 1)])` and `ψ = (1, [(X, 2)])` both have
+     product `X²` but their `factors.toList` are not permutations).
+
+  Posted reformulation options on the issue: add `hφ_nonconst` /
+  `hψ_nonconst` plus distinctness hypotheses, or weaken the conclusion
+  to a flattened multiset of factor-with-multiplicity pairs.
+
+- **Skipped #4006** (HexBZ Mathlib bridge: exhaustive-core factor
+  irreducibility) with analysis showing the existing chain in
+  `HexBerlekampZassenhausMathlib/Basic.lean` is structurally
+  circular (`_factor_irreducible_of_irreducible` takes `hirr` to
+  return `hirr`), and the non-circular bridge through coverage is
+  exactly what #4149 is scheduled to supply. Added a
+  `depends-on: #4149` link so `check-blocked` will hold the issue.
+
+- **Decomposed #4149** (HexBZ Mathlib: assemble exhaustive coverage
+  from first-success uniqueness) into two sub-issues:
+  - #4179 — derive `recombinationCandidate d S = factor` from the
+    unscaled Mignotte recovery (the candidate-to-factor equality
+    that #4148 explicitly deferred).
+  - #4180 — combine the recovering subset with `firstSome` ordering
+    and Hensel uniqueness to assemble the full coverage theorem
+    (depends on #4179).
+
+- **Landed `compose_linearPow_X`** for #4176 (1 of 4 deliverables) in
+  `HexPolyFp/Compose.lean`:
+  ```lean
+  theorem compose_linearPow_X
+      [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :
+      DensePoly.compose (FpPoly.linearPow FpPoly.X k) w =
+        FpPoly.linearPow w k
+  ```
+  Proof goes through a direct power-sum computation on the explicit
+  coefficient list `[0, ..., 0, 1]` of `DensePoly.monomial k 1`,
+  bridged via `linearPow_monomial_one`. No `compose_mul_X` primitive
+  needed.
+
+## Current frontier
+
+`compose_sub_X`, `compose_linearPow_X_sub_X`, and
+`compose_xPowSubX_one` (the remaining 3 of 4 deliverables for #4176)
+require a `compose_sub` general distributivity lemma. The path of
+least resistance is to add a coefficient-indexed `composeCoeffPowerSumUpTo`
+mirroring `evalCoeffPowerSumUpTo` from `HexPolyFp/Basic.lean` and
+adapt the existing `evalCoeffPowerSumUpTo_sub` pattern, plus a
+locally-exposed `toArray_toList_eq_coeff_range` bridge.
+
+The infrastructure itself fits in ~150 lines but the final
+`composeCoeffPowerSumUpTo_sub` step requires manual ring arithmetic
+in `FpPoly p` (no `ring` tactic) — specifically
+`(Cf - Cg) * w^base + (Σf - Σg) = (Cf * w^base + Σf) - (Cg * w^base + Σg)`
+which decomposes through `sub_eq_add_neg`, `right_distrib`, and
+`neg_mul`-style steps. Each step is tractable but the chain is long
+enough not to fit in this session alongside the other issue triage.
+
+## Next step
+
+Partial-PR `compose_linearPow_X` and leave #4176 marked `replan` so a
+planner can either narrow the residual scope to just `compose_sub_X`
+plus the two combination/bridge corollaries, or decompose into a
+dedicated `compose_sub` infrastructure sub-issue with the three
+downstream uses as a separate composition sub-issue.
+
+## Blockers
+
+None for the partial PR. The remaining deliverables of #4176 are
+infrastructure-bound (`compose_sub` distributivity) rather than
+mathematically uncertain.

--- a/progress/20260515T093730Z_fcf78e51.md
+++ b/progress/20260515T093730Z_fcf78e51.md
@@ -1,0 +1,73 @@
+# 2026-05-15 09:37 UTC — feature session, issue #4187
+
+## Accomplished
+
+- Skipped #4076 (HexBerlekamp: compose no-kernel-split irreducibility)
+  with an explicit `depends-on: #4160` link. The composition needs
+  `f ∣ Π_c (w - C c)` from a CRT kernel witness `h` satisfying
+  `f ∣ linearPow h p - h`; the linearPow→product bridge is exactly the
+  witness substitution identity tracked by #4160.
+
+- Claimed #4187 and based the branch on PR #4184 (`agent/ef8e6619`),
+  which adds `compose_linearPow_X` (deliverable 1 from #4176).
+
+- Added a coefficient-indexed `composeCoeffPowerSumUpTo` form to
+  `HexPolyFp/Compose.lean` mirroring `evalCoeffPowerSumUpTo` from
+  `HexPolyFp/Basic.lean`, with the standard
+  `_le_extend`/`_succ_of_next_zero` bound extension machinery and the
+  size-bounded form `compose_eq_coeff_power_sum_upTo_bound`.
+
+- Proved `composeCoeffPowerSumUpTo_sub` and the headline
+  `compose_sub`: `compose (f - h) w = compose f w - compose h w`. The
+  ring step needed is
+  `(C a - C b) * w^k + (S_f - S_h) = (C a * w^k + S_f) - (C b * w^k + S_h)`,
+  factored through:
+  - `fp_sub_mul_right`:
+    `(a - b) * c = a * c - b * c` via `right_distrib` +
+    `DensePoly.neg_mul_right_poly` through `-x = 0 - x`.
+  - `fp_add_sub_add_sub`:
+    `(x - y) + (u - v) = (x + u) - (y + v)` via
+    `DensePoly.ext_coeff` + `grind` on the pointwise ZMod64 identity
+    (which is all additive, no convolution).
+
+- Derived the narrow corollaries requested by issue #4187:
+  - `compose_sub_X : compose (a - X) w = compose a w - w`
+    (deliverable 1).
+  - `compose_linearPow_X_sub_X : compose (linearPow X k - X) w =
+    linearPow w k - w` (deliverable 2).
+  - `compose_xPowSubX_one : compose (xPowSubX 1) w = linearPow w p - w`
+    (deliverable 3) in `HexBerlekamp/RabinSoundness.lean`, by
+    rewriting `xPowSubX 1 = linearPow X p - X` through
+    `linearPow_monomial_one` and `Nat.pow_one`.
+
+- `lake build HexPolyFp.Compose HexBerlekamp.RabinSoundness` is clean.
+  No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+The witness-substitution chain now unblocks #4160 (downstream of #4187
+in the orient list): with `primeFieldProduct_X_eq_xPowSubX`,
+`compose_primeFieldLinearProduct`, and `compose_xPowSubX_one` together,
+a one-line lemma in `HexBerlekamp/RabinSoundness.lean` gives
+```
+Π_c (w - C c) = compose (Π_c (X - C c)) w
+              = compose (xPowSubX 1) w
+              = linearPow w p - w
+```
+and hence the downstream divisibility corollary `f ∣ linearPow w p - w →
+f ∣ Π_c (w - C c)` consumed by
+`exists_kernelWitnessSplit?_some_of_witnessProduct_dvd_of_pos_degree`
+and ultimately by #4076.
+
+## Next step
+
+Pick up #4160 next: write `primeFieldProduct_witness_eq` and its
+divisibility corollary by composing the three substitution lemmas in
+order. Then #4076 becomes claimable.
+
+## Blockers
+
+None for this PR. The PR sits on top of PR #4184; once #4184 merges,
+this branch rebases onto main cleanly (the new theorems are purely
+additive). If PR #4184 lands first, the merge is a no-op; if not, the
+two PRs interleave additions to the same file and resolve cleanly.


### PR DESCRIPTION
This PR adds the witness-substitution chain needed to transport
`primeFieldProduct_X_eq_xPowSubX` from `X` to an arbitrary
`w : FpPoly p`, closing #4187.

depends on: #4184

The new theorems are:
- `Hex.FpPoly.compose_sub` — `DensePoly.compose` distributes over `-`
- `Hex.FpPoly.compose_sub_X` — substitute `w` for `X` in `a - X`
- `Hex.FpPoly.compose_linearPow_X_sub_X` — substitute `w` for `X` in
  `linearPow X k - X`
- `Hex.Berlekamp.compose_xPowSubX_one` — substitute `w` for `X` in
  `xPowSubX 1 = X^p - X`

Adds a coefficient-indexed `composeCoeffPowerSumUpTo` mirror of
`evalCoeffPowerSumUpTo` from `HexPolyFp/Basic.lean`, with the standard
`_le_extend`/`_succ_of_next_zero` bound extension and the size-bounded
form `compose_eq_coeff_power_sum_upTo_bound`. The single non-trivial
ring step is `(C a - C b) * w^k + (S_f - S_h) =
(C a * w^k + S_f) - (C b * w^k + S_h)`, factored through
`fp_sub_mul_right` (via `DensePoly.neg_mul_right_poly`) and
`fp_add_sub_add_sub` (pointwise `grind` on ZMod64).

Closes #4187

🤖 Prepared with Claude Code