### PR TITLE
HexPolyZMathlib: expose modP transport bridge for BZ certificates

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -36,29 +36,9 @@ theorem toMathlibPolynomial_modP_eq_map_intCast_zmod
     [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) :
     HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p f) =
       (HexPolyZMathlib.toPolynomial f).map (Int.castRingHom (ZMod p)) := by
-  ext n
-  rw [HexBerlekampMathlib.coeff_toMathlibPolynomial, Hex.ZPoly.coeff_modP]
-  rw [Polynomial.coeff_map, HexPolyZMathlib.coeff_toPolynomial]
-  change
-    HexModArithMathlib.ZMod64.toZMod
-        (Hex.ZMod64.ofNat p (Hex.ZPoly.intModNat (f.coeff n) p)) =
-      ((f.coeff n : ℤ) : ZMod p)
-  apply ZMod.val_injective p
-  rw [HexModArithMathlib.ZMod64.val_toZMod, Hex.ZMod64.toNat_ofNat]
-  apply Int.ofNat.inj
-  change ((Hex.ZPoly.intModNat (f.coeff n) p % p : Nat) : ℤ) =
-    (((f.coeff n : ℤ) : ZMod p).val : ℤ)
-  rw [Int.natCast_mod, ZMod.val_intCast]
-  unfold Hex.ZPoly.intModNat
-  have hp : (p : ℤ) ≠ 0 :=
-    Int.ofNat_ne_zero.mpr (Nat.ne_of_gt (Hex.ZMod64.Bounds.pPos (p := p)))
-  have hcast :
-      ((f.coeff n % Int.ofNat p).toNat : ℤ) =
-        f.coeff n % Int.ofNat p :=
-    Int.toNat_of_nonneg (Int.emod_nonneg _ hp)
-  rw [hcast]
-  change f.coeff n % (p : ℤ) % (p : ℤ) = f.coeff n % (p : ℤ)
-  rw [Int.emod_emod]
+  exact
+    HexPolyZMathlib.eq_map_intCast_of_coeff_eq_toZMod_modP p f
+      (fun n => HexBerlekampMathlib.coeff_toMathlibPolynomial _ n)
 
 /--
 Reduction-mod-`p` Gauss lemma over `ℤ`: a primitive integer polynomial whose

--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -1,6 +1,9 @@
 import HexPolyMathlib.Basic
+import HexHensel.Basic
+import HexModArithMathlib
 import Mathlib.Algebra.Polynomial.Degree.Units
 import Mathlib.Algebra.Ring.Int.Units
+import Mathlib.Data.ZMod.Basic
 import HexPolyZ
 
 /-!
@@ -96,6 +99,76 @@ theorem isUnit_iff_toPolynomial_isUnit (f : Hex.ZPoly) :
       simp [hf, hr]
     · right
       simp [hf, hr]
+
+/--
+The executable coefficientwise reduction `Hex.ZPoly.modP` agrees with
+Mathlib's coefficient map from `ℤ[X]` to `(ZMod p)[X]`, after transporting
+the executable `ZMod64 p` coefficients through the `ZMod64`/`ZMod` bridge.
+-/
+theorem coeff_toZMod_modP_eq_coeff_map_intCast
+    (p : Nat) [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) (n : Nat) :
+    HexModArithMathlib.ZMod64.toZMod ((Hex.ZPoly.modP p f).coeff n) =
+      ((toPolynomial f).map (Int.castRingHom (ZMod p))).coeff n := by
+  rw [Polynomial.coeff_map, Hex.ZPoly.coeff_modP, coeff_toPolynomial]
+  change
+    HexModArithMathlib.ZMod64.toZMod
+        (Hex.ZMod64.ofNat p (Hex.ZPoly.intModNat (f.coeff n) p)) =
+      ((f.coeff n : ℤ) : ZMod p)
+  apply ZMod.val_injective p
+  rw [HexModArithMathlib.ZMod64.val_toZMod, Hex.ZMod64.toNat_ofNat]
+  apply Int.ofNat.inj
+  change ((Hex.ZPoly.intModNat (f.coeff n) p % p : Nat) : ℤ) =
+    (((f.coeff n : ℤ) : ZMod p).val : ℤ)
+  rw [Int.natCast_mod, ZMod.val_intCast]
+  unfold Hex.ZPoly.intModNat
+  have hp : (p : ℤ) ≠ 0 :=
+    Int.ofNat_ne_zero.mpr (Nat.ne_of_gt (Hex.ZMod64.Bounds.pPos (p := p)))
+  have hcast :
+      ((f.coeff n % Int.ofNat p).toNat : ℤ) =
+        f.coeff n % Int.ofNat p :=
+    Int.toNat_of_nonneg (Int.emod_nonneg _ hp)
+  rw [hcast]
+  change f.coeff n % (p : ℤ) % (p : ℤ) = f.coeff n % (p : ℤ)
+  rw [Int.emod_emod]
+
+/--
+Extensional bridge for any Mathlib polynomial over `ZMod p` whose
+coefficients are supplied by the executable `Hex.ZPoly.modP` image.
+Downstream finite-field polynomial transports can instantiate the coefficient
+hypothesis with their own `FpPoly` bridge lemma.
+-/
+theorem eq_map_intCast_of_coeff_eq_toZMod_modP
+    (p : Nat) [Hex.ZMod64.Bounds p] (f : Hex.ZPoly)
+    {q : Polynomial (ZMod p)}
+    (hq :
+      ∀ n, q.coeff n =
+        HexModArithMathlib.ZMod64.toZMod ((Hex.ZPoly.modP p f).coeff n)) :
+    q = (toPolynomial f).map (Int.castRingHom (ZMod p)) := by
+  ext n
+  rw [hq, coeff_toZMod_modP_eq_coeff_map_intCast]
+
+/--
+Divisibility of executable integer polynomials reduces modulo `p` after
+transporting both sides to Mathlib polynomials over `ZMod p`.
+-/
+theorem map_intCast_zmod_dvd_of_zpoly_dvd
+    (p : Nat) {g f : Hex.ZPoly} (hgf : g ∣ f) :
+    (toPolynomial g).map (Int.castRingHom (ZMod p)) ∣
+      (toPolynomial f).map (Int.castRingHom (ZMod p)) := by
+  rcases hgf with ⟨q, rfl⟩
+  refine ⟨(toPolynomial q).map (Int.castRingHom (ZMod p)), ?_⟩
+  rw [toPolynomial_mul, Polynomial.map_mul]
+
+/-- Reduction modulo `p` preserves natural degree when the leading coefficient
+survives the map to `ZMod p`. -/
+theorem natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero
+    (p : Nat) (g : Hex.ZPoly)
+    (hlc :
+      (Int.castRingHom (ZMod p)) (toPolynomial g).leadingCoeff ≠ 0) :
+    ((toPolynomial g).map (Int.castRingHom (ZMod p))).natDegree =
+      (toPolynomial g).natDegree :=
+  Polynomial.natDegree_map_of_leadingCoeff_ne_zero
+    (Int.castRingHom (ZMod p)) hlc
 
 end
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -356,7 +356,7 @@ libraries:
     done_through: 3
     status: active
   HexPolyZMathlib:
-    deps: [HexPolyZ, HexPolyMathlib]
+    deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]
     mathlib: true
     done_through: 3
     status: active

--- a/progress/20260515T094143Z_b896562f.md
+++ b/progress/20260515T094143Z_b896562f.md
@@ -1,0 +1,35 @@
+# 2026-05-15 09:41 UTC — feature session, issue #4196
+
+## Accomplished
+
+- Added `HexPolyZMathlib` reduction-mod-`p` bridge lemmas:
+  - `coeff_toZMod_modP_eq_coeff_map_intCast`
+  - `eq_map_intCast_of_coeff_eq_toZMod_modP`
+  - `map_intCast_zmod_dvd_of_zpoly_dvd`
+  - `natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero`
+- Routed `HexBerlekampZassenhausMathlib.IntReductionMod.toMathlibPolynomial_modP_eq_map_intCast_zmod`
+  through the new `HexPolyZMathlib` extensional bridge instead of duplicating
+  the coefficient proof.
+- Updated `libraries.yml` so `HexPolyZMathlib` records the dependency on the
+  existing `HexHensel` `ZPoly.modP` surface and `HexModArithMathlib` `ZMod64`
+  bridge.
+- Committed the work as `b9b1d0e feat: expose zpoly modP mathlib bridge`.
+
+## Current frontier
+
+- Bridge A now has the coefficient, divisibility, and degree-preservation API
+  needed by downstream certificate-soundness work.
+- The direct `FpPoly`-as-`Polynomial (ZMod p)` transport remains owned by
+  downstream finite-field bridge modules; `HexPolyZMathlib` exposes an
+  extensional lemma that those bridges can instantiate with their coefficient
+  theorem.
+
+## Next step
+
+- Use these lemmas in the #4173 certificate proof when composing proper-factor
+  reduction modulo a recorded prime.
+
+## Blockers
+
+- None for this issue. Existing downstream `sorry` warnings in Berlekamp,
+  Gram-Schmidt, LLL, and BZ Mathlib remain unrelated proof debt.


### PR DESCRIPTION
Closes #4196

Session: `b896562f-231d-417c-abab-b82fed18d850`

dfa1637 chore: record progress for modP bridge
b9b1d0e feat: expose zpoly modP mathlib bridge

🤖 Prepared with Claude Code