### PR TITLE
BZ certificate soundness: expose integer polynomial mod-p bridge API

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -41,6 +41,60 @@ theorem toMathlibPolynomial_modP_eq_map_intCast_zmod
       (fun n => HexBerlekampMathlib.coeff_toMathlibPolynomial _ n)
 
 /--
+The Mathlib `ZMod p`-cast of the leading coefficient of a `Hex.ZPoly` agrees
+with the executable `ZMod64`-valued `leadingCoeffModP` after transport along
+`ZMod64.toZMod`. This is the integer-side companion to the modular `modP`
+bridge: it lets a downstream consumer chain the executable good-prime
+hypothesis through to the Mathlib `Polynomial.map` natural-degree lemma.
+-/
+theorem intCast_zmod_leadingCoeff_eq_toZMod_leadingCoeffModP
+    [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) :
+    (Int.castRingHom (ZMod p)) (HexPolyZMathlib.toPolynomial f).leadingCoeff =
+      HexModArithMathlib.ZMod64.toZMod (Hex.ZPoly.leadingCoeffModP f p) := by
+  rw [HexPolyMathlib.leadingCoeff_toPolynomial]
+  show ((Hex.DensePoly.leadingCoeff f : ℤ) : ZMod p) = _
+  rw [← HexPolyZMathlib.toZMod_ZMod64_ofNat_intModNat_eq_intCast p
+        (Hex.DensePoly.leadingCoeff f)]
+  rfl
+
+/--
+The Mathlib `ZMod p`-cast of the leading coefficient of a `Hex.ZPoly` is
+nonzero exactly when the executable `leadingCoeffModP` is. This packages the
+direction needed by the integer-factor degree-preservation step in
+`checkIrreducibleCert_sound`.
+-/
+theorem intCast_zmod_leadingCoeff_ne_zero_iff_leadingCoeffModP_ne_zero
+    [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) :
+    (Int.castRingHom (ZMod p)) (HexPolyZMathlib.toPolynomial f).leadingCoeff ≠ 0 ↔
+      Hex.ZPoly.leadingCoeffModP f p ≠ 0 := by
+  rw [intCast_zmod_leadingCoeff_eq_toZMod_leadingCoeffModP]
+  constructor
+  · intro h heq
+    apply h
+    rw [heq, HexModArithMathlib.ZMod64.toZMod_zero]
+  · intro h heq
+    apply h
+    have hinj := (HexModArithMathlib.ZMod64.equiv (p := p)).injective
+    apply hinj
+    simpa using heq.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
+
+/--
+Reduction modulo `p` preserves natural degree when the executable
+`leadingCoeffModP` data records a nonzero leading coefficient. This is the
+issue-spec `_of_unit_lc_mod_p` shape: the executable good-prime check supplies
+the `leadingCoeffModP ≠ 0` hypothesis, and `natDegree` is preserved along the
+Mathlib `Polynomial.map` reduction.
+-/
+theorem natDegree_map_intCast_zmod_eq_of_leadingCoeffModP_ne_zero
+    [Hex.ZMod64.Bounds p] (f : Hex.ZPoly)
+    (hadm : Hex.ZPoly.leadingCoeffModP f p ≠ 0) :
+    ((HexPolyZMathlib.toPolynomial f).map (Int.castRingHom (ZMod p))).natDegree =
+      (HexPolyZMathlib.toPolynomial f).natDegree :=
+  HexPolyZMathlib.natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero p f
+    ((intCast_zmod_leadingCoeff_ne_zero_iff_leadingCoeffModP_ne_zero
+      (p := p) (f := f)).mpr hadm)
+
+/--
 Reduction-mod-`p` Gauss lemma over `ℤ`: a primitive integer polynomial whose
 modular reduction is irreducible and whose leading coefficient is not killed
 by the reduction is itself irreducible.

--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -170,6 +170,44 @@ theorem natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero
   Polynomial.natDegree_map_of_leadingCoeff_ne_zero
     (Int.castRingHom (ZMod p)) hlc
 
+/--
+Issue-spec rename of `map_intCast_zmod_dvd_of_zpoly_dvd`: divisibility of
+executable integer polynomials transports to divisibility of their Mathlib
+reductions modulo `p`.
+-/
+theorem dvd_modP_of_dvd
+    (p : Nat) {g f : Hex.ZPoly} (hgf : g ∣ f) :
+    (toPolynomial g).map (Int.castRingHom (ZMod p)) ∣
+      (toPolynomial f).map (Int.castRingHom (ZMod p)) :=
+  map_intCast_zmod_dvd_of_zpoly_dvd p hgf
+
+/--
+Core integer-to-`ZMod p` identity underlying the `modP` bridge: pushing an
+integer through `intModNat`/`ZMod64.ofNat` and then to Mathlib's `ZMod p` via
+`toZMod` agrees with the direct integer cast.
+-/
+theorem toZMod_ZMod64_ofNat_intModNat_eq_intCast
+    (p : Nat) [Hex.ZMod64.Bounds p] (z : ℤ) :
+    HexModArithMathlib.ZMod64.toZMod
+        (Hex.ZMod64.ofNat p (Hex.ZPoly.intModNat z p)) =
+      ((z : ℤ) : ZMod p) := by
+  apply ZMod.val_injective p
+  rw [HexModArithMathlib.ZMod64.val_toZMod, Hex.ZMod64.toNat_ofNat]
+  apply Int.ofNat.inj
+  change ((Hex.ZPoly.intModNat z p % p : Nat) : ℤ) =
+    (((z : ℤ) : ZMod p).val : ℤ)
+  rw [Int.natCast_mod, ZMod.val_intCast]
+  unfold Hex.ZPoly.intModNat
+  have hp : (p : ℤ) ≠ 0 :=
+    Int.ofNat_ne_zero.mpr (Nat.ne_of_gt (Hex.ZMod64.Bounds.pPos (p := p)))
+  have hcast :
+      ((z % Int.ofNat p).toNat : ℤ) =
+        z % Int.ofNat p :=
+    Int.toNat_of_nonneg (Int.emod_nonneg _ hp)
+  rw [hcast]
+  change z % (p : ℤ) % (p : ℤ) = z % (p : ℤ)
+  rw [Int.emod_emod]
+
 end
 
 end HexPolyZMathlib

--- a/progress/20260515T111047Z_ed73fb62.md
+++ b/progress/20260515T111047Z_ed73fb62.md
@@ -1,0 +1,44 @@
+# BZ certificate soundness: integer polynomial mod-p bridge API (#4203)
+
+## Accomplished
+
+Extended the modP transport bridge introduced by #4207 with the
+named-shape and executable-side wrappers required by
+`checkIrreducibleCert_sound` (parent #4173).
+
+- `HexPolyZMathlib/Basic.lean`:
+    - `dvd_modP_of_dvd`: issue-spec named alias of
+      `map_intCast_zmod_dvd_of_zpoly_dvd`.
+    - `toZMod_ZMod64_ofNat_intModNat_eq_intCast`: factored
+      integer-to-`ZMod p` identity underlying every modP coefficient
+      transport.
+- `HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+    - `intCast_zmod_leadingCoeff_eq_toZMod_leadingCoeffModP`: Mathlib
+      `(Int.castRingHom (ZMod p))` of `(toPolynomial f).leadingCoeff`
+      agrees with `HexModArithMathlib.ZMod64.toZMod
+      (Hex.ZPoly.leadingCoeffModP f p)`.
+    - `intCast_zmod_leadingCoeff_ne_zero_iff_leadingCoeffModP_ne_zero`:
+      the two ne-zero predicates are equivalent.
+    - `natDegree_map_intCast_zmod_eq_of_leadingCoeffModP_ne_zero`:
+      directly chainable `natDegree`-preservation form for the
+      executable `isGoodPrime` good-prime hypothesis used by #4173.
+
+## Current frontier
+
+The integer mod-p API is now complete: #4173 can chain
+`Hex.isGoodPrime` (executable certificate hypothesis) through
+`isGoodPrime_leadingCoeffAdmissible` → `leadingCoeffModP ≠ 0` →
+the new `natDegree_map_intCast_zmod_eq_of_leadingCoeffModP_ne_zero`
+to get the Mathlib `Polynomial.map` natural-degree preservation, and
+use `dvd_modP_of_dvd` to transport `factor ∣ f` to the modular
+image.
+
+## Next step
+
+#4173 (parent) can resume composing `checkIrreducibleCert_sound`
+once #4204 (`factorProduct` to Mathlib modular factor product),
+#4205 (UFD subset-degree), and #4206 (`rabin_irreducible`) land.
+
+## Blockers
+
+None for this work item.


### PR DESCRIPTION
Closes #4203

Session: `ed73fb62-4e79-45f0-bc6f-eef87a0749dc`

c506e65 feat: BZ certificate integer mod-p leadingCoeff bridges

🤖 Prepared with Claude Code