### PR TITLE
BZ certificate soundness: bridge factorProduct to Mathlib modular factor product

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -561,6 +561,132 @@ theorem factor_unique_of_product
     (by rw [hproduct]; exact hf_ne)
     (by rw [hproduct, factor_product f])
 
+/-! ### Mathlib bridge for executable certificate factor-product equalities
+
+These bridges identify the executable `Hex.PrimeFactorData.factorProduct` with
+the Mathlib `Polynomial.map (Int.castRingHom (ZMod p))` image of the underlying
+integer polynomial and with the explicit product of recorded factor transports.
+Both shapes are consumed by the integer irreducibility certificate soundness
+composition.
+-/
+
+/-- Executable `FpPoly p` multiplication transports to Mathlib multiplication
+through the polynomial bridge. -/
+theorem toMathlibPolynomial_mul {p : Nat} [Hex.ZMod64.Bounds p]
+    (a b : Hex.FpPoly p) :
+    HexBerlekampMathlib.toMathlibPolynomial (a * b) =
+      HexBerlekampMathlib.toMathlibPolynomial a *
+        HexBerlekampMathlib.toMathlibPolynomial b :=
+  map_mul HexBerlekampMathlib.fpPolyEquiv a b
+
+/-- The executable `1 : FpPoly p` transports to Mathlib's `1`. -/
+theorem toMathlibPolynomial_one {p : Nat} [Hex.ZMod64.Bounds p] :
+    HexBerlekampMathlib.toMathlibPolynomial (1 : Hex.FpPoly p) = 1 := by
+  ext n
+  rw [HexBerlekampMathlib.coeff_toMathlibPolynomial, Polynomial.coeff_one]
+  show HexModArithMathlib.ZMod64.toZMod
+      ((Hex.DensePoly.C (1 : Hex.ZMod64 p)).coeff n) =
+    if n = 0 then 1 else 0
+  rw [Hex.DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · simp [hn, HexModArithMathlib.ZMod64.toZMod_one]
+  · simp only [hn, ↓reduceIte]
+    exact HexModArithMathlib.ZMod64.toZMod_zero
+
+/--
+List `foldl (· * ·)` of executable `FpPoly p` factors transports across the
+Mathlib bridge to the explicit Mathlib `List.prod` of the per-factor transports.
+-/
+theorem toMathlibPolynomial_listFoldlMul_one {p : Nat} [Hex.ZMod64.Bounds p]
+    (xs : List (Hex.FpPoly p)) :
+    HexBerlekampMathlib.toMathlibPolynomial (xs.foldl (· * ·) 1) =
+      (xs.map HexBerlekampMathlib.toMathlibPolynomial).prod := by
+  suffices h : ∀ (acc : Hex.FpPoly p),
+      HexBerlekampMathlib.toMathlibPolynomial (xs.foldl (· * ·) acc) =
+        HexBerlekampMathlib.toMathlibPolynomial acc *
+          (xs.map HexBerlekampMathlib.toMathlibPolynomial).prod by
+    have hh := h 1
+    rw [toMathlibPolynomial_one] at hh
+    simpa using hh
+  intro acc
+  induction xs generalizing acc with
+  | nil => simp
+  | cons head tail ih =>
+      rw [List.foldl_cons, ih (acc * head), List.map_cons, List.prod_cons,
+        toMathlibPolynomial_mul]
+      ring
+
+/--
+The Mathlib transport of `Hex.PrimeFactorData.factorProduct` is the Mathlib
+`List.prod` of the recorded factor transports.
+-/
+theorem toMathlibPolynomial_factorProduct (primeData : Hex.PrimeFactorData) :
+    letI := primeData.bounds
+    HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
+      (primeData.factorPolys.toList.map
+        HexBerlekampMathlib.toMathlibPolynomial).prod := by
+  letI := primeData.bounds
+  show HexBerlekampMathlib.toMathlibPolynomial
+      (primeData.factorPolys.foldl (· * ·) 1) = _
+  rw [← Array.foldl_toList]
+  exact toMathlibPolynomial_listFoldlMul_one _
+
+/--
+Coefficientwise reduction `Hex.ZPoly.modP` transports to Mathlib's coefficient
+map from `ℤ[X]` to `(ZMod p)[X]`. Mirrors `IntReductionMod` with the same
+underlying primitive, exposed in `Basic.lean` so that downstream certificate
+soundness proofs do not need to depend on the small-mod singleton branch.
+-/
+theorem toMathlibPolynomial_modP_eq_map_intCast_zmod
+    {p : Nat} [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) :
+    HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p f) =
+      (HexPolyZMathlib.toPolynomial f).map (Int.castRingHom (ZMod p)) :=
+  HexPolyZMathlib.eq_map_intCast_of_coeff_eq_toZMod_modP p f
+    (fun n => HexBerlekampMathlib.coeff_toMathlibPolynomial _ n)
+
+/--
+A successful `PrimeFactorData.checkForPolynomial` block exposes the Mathlib
+factor-product / modular-image alignment: the Mathlib transport of the
+recorded `factorProduct` equals the Mathlib `Polynomial.map (Int.castRingHom (ZMod p))`
+image of the underlying integer polynomial.
+-/
+theorem toMathlibPolynomial_factorProduct_eq_map_intCast_zmod
+    (f : Hex.ZPoly) (primeData : Hex.PrimeFactorData)
+    (hcheck : primeData.checkForPolynomial f = true) :
+    letI := primeData.bounds
+    HexBerlekampMathlib.toMathlibPolynomial primeData.factorProduct =
+      (HexPolyZMathlib.toPolynomial f).map
+        (Int.castRingHom (ZMod primeData.p)) := by
+  letI := primeData.bounds
+  have hprod : primeData.factorProduct = Hex.ZPoly.modP primeData.p f := by
+    simp [Hex.PrimeFactorData.checkForPolynomial] at hcheck
+    exact hcheck.1.2
+  rw [hprod]
+  exact toMathlibPolynomial_modP_eq_map_intCast_zmod f
+
+/--
+A successful `PrimeFactorData.checkForPolynomial` block exposes the Mathlib
+modular image of the underlying integer polynomial as the explicit product of
+recorded factor transports.
+
+This is the shape used by the integer irreducibility certificate soundness
+composition: the Mathlib `(toPolynomial f).map (Int.castRingHom (ZMod p))`
+factors through the explicit Mathlib `List.prod` of executable monic factor
+transports, enabling UFD-level identification of factor degrees against
+`factorDegrees`.
+-/
+theorem map_intCast_zmod_toPolynomial_eq_factorPolys_product
+    (f : Hex.ZPoly) (primeData : Hex.PrimeFactorData)
+    (hcheck : primeData.checkForPolynomial f = true) :
+    letI := primeData.bounds
+    (HexPolyZMathlib.toPolynomial f).map
+        (Int.castRingHom (ZMod primeData.p)) =
+      (primeData.factorPolys.toList.map
+        HexBerlekampMathlib.toMathlibPolynomial).prod := by
+  letI := primeData.bounds
+  rw [← toMathlibPolynomial_factorProduct_eq_map_intCast_zmod f primeData hcheck]
+  exact toMathlibPolynomial_factorProduct primeData
+
 /--
 The executable integer-polynomial irreducibility checker is sound after
 transport to Mathlib's polynomial model.

--- a/progress/20260515T114518Z_2bb67cad.md
+++ b/progress/20260515T114518Z_2bb67cad.md
@@ -1,0 +1,56 @@
+# Issue #4204
+
+## Accomplished
+
+- Claimed feature issue #4204.
+- Added the executable-to-Mathlib bridges in
+  `HexBerlekampZassenhausMathlib/Basic.lean` needed by the integer
+  irreducibility certificate soundness composition (#4173):
+  - `toMathlibPolynomial_mul`, `toMathlibPolynomial_one`:
+    multiplicativity helpers derived from `HexBerlekampMathlib.fpPolyEquiv`.
+    `toMathlibPolynomial_one` is proven coefficient-wise via the
+    existing `coeff_toMathlibPolynomial` and `DensePoly.coeff_C` rather
+    than through `_root_.map_one`, because `FpPoly p` has no
+    `NonAssocSemiring` instance to unlock `OneHomClass` synthesis.
+  - `toMathlibPolynomial_listFoldlMul_one`: foldl/prod transport.
+  - `toMathlibPolynomial_factorProduct`: Mathlib transport of
+    `Hex.PrimeFactorData.factorProduct` equals the explicit list product
+    of recorded factor transports.
+  - `toMathlibPolynomial_modP_eq_map_intCast_zmod`: re-derivation of the
+    `IntReductionMod` bridge inline in `Basic.lean`, so downstream
+    certificate soundness proofs in `Basic.lean` do not have to depend
+    on the small-mod singleton branch.
+  - `toMathlibPolynomial_factorProduct_eq_map_intCast_zmod`: combined
+    bridge from `checkForPolynomial` to the modular `Polynomial.map`
+    image.
+  - `map_intCast_zmod_toPolynomial_eq_factorPolys_product`: the final
+    consumer shape — `(toPolynomial f).map (Int.castRingHom (ZMod p))`
+    factored as the Mathlib `List.prod` of executable factor transports.
+- No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level
+  `sorry`. Same three pre-existing sorries in
+  `HexBerlekampZassenhausMathlib/Basic.lean` before and after.
+- Verified:
+  - `lake build HexBerlekampZassenhausMathlib.Basic`
+  - `lake build HexBerlekampMathlib HexBerlekampZassenhaus`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - Diff search for new `sorry`, `axiom`, `native_decide`, `TODO`,
+    `FIXME` in affected files.
+
+## Current frontier
+
+- The factor-product Mathlib bridges are now available for the parent
+  composition #4173 (`checkIrreducibleCert_sound`).
+- Existing equality-based consumers did not need signature changes.
+
+## Next step
+
+- Use `map_intCast_zmod_toPolynomial_eq_factorPolys_product` in #4173
+  to factor `(toPolynomial f).map (Int.castRingHom (ZMod p))` into
+  recorded factor transports, then combine with the recorded
+  irreducibility facts (#4206/#4217) to drive the UFD subset-degree
+  argument (#4205) toward the no-subset-sum obstruction.
+
+## Blockers
+
+- None for issue #4204.


### PR DESCRIPTION
Closes #4204

Session: `2bb67cad-1b00-439a-aea9-3f1c1e409c61`

331dad8 chore: progress entry for #4204
67879c4 Merge branch 'main' of github.com:kim-em/hex into agent/2bb67cad
37964ad feat: BZ certificate factor-product Mathlib bridges

🤖 Prepared with Claude Code