### PR TITLE
doc: decompose #4261 into refactor + bridge sub-issues

### DIFF
--- a/progress/20260515T205920Z_eac025aa.md
+++ b/progress/20260515T205920Z_eac025aa.md
@@ -1,0 +1,70 @@
+# Session eac025aa — feature, issue #4261 (decomposed)
+
+## Accomplished
+
+- Claimed #4261 ("HexBerlekamp: prove fixed-space polynomial kernel iff").
+- Decomposed it into two sub-issues after diagnosing the blocking obstacle:
+  - #4313 — refactor `IsFixedSpaceKernelVector` / `IsFixedSpaceKernelPolynomial`
+    / `fixedSpaceMatrix` / `isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq`
+    to use default `Matrix.mulVec` instances on `ZMod64 p` (drop the
+    `inst.toCommSemiring.toMul` form).
+  - #4314 — prove the polynomial bridge iff (depends on #4313, becomes a
+    straightforward `rw` chain after the refactor).
+- Skipped #4261 with a `Decomposed into #4313, #4314` breadcrumb comment.
+
+## Diagnosis
+
+The planner's intended composition was:
+
+1. `rw [isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq]` to translate
+   the kernel predicate to a matrix-vector equation.
+2. `rw [berlekampMatrix_mulVec_coeffVector_eq f hmonic w hw]` (from #4260) to
+   rewrite the LHS to `coeffVector f (FpPoly.linearPow w p % f)`.
+
+This does not type-check because the two lemmas use different `Matrix.mulVec`
+instance forms:
+
+- `isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq` produces
+  `@Matrix.mulVec _ _ _ inst.toCommSemiring.toMul inst.toCommSemiring.toAdd
+  (inst.toCommSemiring.toSemiring.ofNat 0) ...` (the inst-projected form
+  from the `[inst : Lean.Grind.Field (ZMod64 p)]` hypothesis).
+- `berlekampMatrix_mulVec_coeffVector_eq` was declared with only
+  `[ZMod64.PrimeModulus p]` in scope, so its `Matrix.mulVec` baked in the
+  directly-registered `ZMod64.instMul_hexPolyFp` / `ZMod64.instAdd_hexPolyFp`
+  / `ZMod64.instOfNat 0`.
+
+For an arbitrary parametric `inst`, `inst.toCommSemiring.toMul` does not
+reduce to `instMul_hexPolyFp`. I verified this with:
+
+- A `have hbmv : <inst-form type> := berlekampMatrix_mulVec_coeffVector_eq ...`
+  type-mismatch error (Lean shows the two pretty-printed Matrix.mulVec terms
+  side by side, differing only in their instance arguments).
+- A `Vector.ext` + `rfl` entry-wise bridge attempt — `rfl` failed because
+  the foldl entries `Σ Q[i][j] *_inst v[j]` vs `Σ Q[i][j] *_direct v[j]`
+  are not definitionally equal (inst's `mul` doesn't reduce).
+
+The existing iff `isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq`
+proof works around this only because it applies `Matrix.sub_identity_mulVec`,
+which is declared for a *generic* `R` with `[Lean.Grind.Ring R]`. That
+genericity forces the lemma's type to express `Mul R` via the Ring
+projection `Lean.Grind.Ring.toMul inferInstance`; at the call site Lean
+re-resolves the Ring to `inst.toRing` (via `letI`) and the projection chain
+is defeq to `inst.toCommSemiring.toMul`. `berlekampMatrix_mulVec_coeffVector_eq`
+is ZMod64-specific, so this trick does not apply.
+
+## Current frontier
+
+#4313 (the refactor) is now the binding step. Once it lands, #4314 (the
+polynomial bridge) is mechanical — the helpers drafted during this session
+and noted in #4314's deliverables (coeffVector injectivity for size-bounded
+polynomials, the `linearPow w p % f` size bound, `w % f = w` under size ≤
+basisSize, and the `linearPow 0 n = 0` edge-case helper) are short and
+self-contained.
+
+## Next step
+
+Pick up #4313, then #4314. Alternatively a separate session takes #4313.
+
+## Blockers
+
+None — the decomposition fully describes the remaining work.


### PR DESCRIPTION
This PR records the diagnosis and decomposition of #4261. No source-code changes; the substantive work moves to #4313 (refactor `IsFixedSpaceKernelVector` and friends to default-instance `Matrix.mulVec` form) and #4314 (the polynomial kernel iff, after #4313).

The planner's intended composition for #4261 (`rw [isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq]` then `rw [berlekampMatrix_mulVec_coeffVector_eq]`) does not type-check because the two lemmas use different `Matrix.mulVec` instance forms on `ZMod64 p` — inst-projected (`inst.toCommSemiring.toMul` etc.) vs the directly-registered `ZMod64.instMul_hexPolyFp`. The two are not definitionally equal for an arbitrary parametric `[Lean.Grind.Field (ZMod64 p)]`; a `Vector.ext + rfl` entry-wise bridge also fails because `inst.toCommSemiring.toMul.mul a b` does not reduce to `ZMod64.mul a b` without knowing `inst` concretely.

Parent issue #4261 is in \`replan\` for planner triage; this PR does not auto-close it.

🤖 Prepared with Claude Code