### PR TITLE
HexBerlekamp: dedupe basisSize/degree? plumbing in matrix-action proof

### DIFF
--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -20,6 +20,20 @@ variable {p : Nat} [ZMod64.Bounds p]
 def basisSize (f : FpPoly p) : Nat :=
   f.degree?.getD 0
 
+private theorem size_pos_of_basisSize_pos (f : FpPoly p)
+    (h : 0 < basisSize f) : 0 < f.size := by
+  by_cases hfz : 0 < f.size
+  · exact hfz
+  · exfalso
+    have hfsize : f.size = 0 := Nat.eq_zero_of_not_pos hfz
+    unfold basisSize DensePoly.degree? at h
+    simp [hfsize] at h
+
+private theorem basisSize_eq_size_sub_one (f : FpPoly p)
+    (h : 0 < f.size) : basisSize f = f.size - 1 := by
+  unfold basisSize DensePoly.degree?
+  simp [Nat.ne_of_gt h]
+
 /-- Read a polynomial's first `degree f` coefficients as a vector. -/
 def coeffVector (f g : FpPoly p) : Vector (ZMod64 p) (basisSize f) :=
   Vector.ofFn fun i => g.coeff i.val
@@ -297,20 +311,10 @@ private theorem powModMonic_column_size_le
     (FpPoly.powModMonic (FpPoly.frobeniusXMod f hmonic) f hmonic j.val).size ≤
       basisSize f := by
   have hbasis_pos : 0 < basisSize f := Nat.lt_of_le_of_lt (Nat.zero_le _) j.isLt
-  have hf_size_pos : 0 < f.size := by
-    by_cases hfz : 0 < f.size
-    · exact hfz
-    · exfalso
-      have hfsize : f.size = 0 := Nat.eq_zero_of_not_pos hfz
-      unfold basisSize DensePoly.degree? at hbasis_pos
-      simp [hfsize] at hbasis_pos
-  have hf_deg_eq : f.degree?.getD 0 = f.size - 1 := by
-    unfold DensePoly.degree?
-    have hne : f.size ≠ 0 := Nat.ne_of_gt hf_size_pos
-    simp [hne]
-  have hbasis_eq : basisSize f = f.size - 1 := by
-    show f.degree?.getD 0 = f.size - 1
-    exact hf_deg_eq
+  have hf_size_pos : 0 < f.size := size_pos_of_basisSize_pos f hbasis_pos
+  have hbasis_eq : basisSize f = f.size - 1 :=
+    basisSize_eq_size_sub_one f hf_size_pos
+  have hf_deg_eq : f.degree?.getD 0 = f.size - 1 := hbasis_eq
   -- Case split on whether the column is the constant-1 column (j.val = 0)
   -- or a positive power.
   by_cases hj_zero : j.val = 0
@@ -352,8 +356,8 @@ private theorem powModMonic_column_size_le
         unfold DensePoly.degree?
         simp [Nat.ne_of_gt hsize_pos]
       rw [hdeg_eq, hf_deg_eq] at h_deg
-      -- Note: avoid `rw [hbasis_eq]` because it captures `Fin (basisSize f)`
-      -- in `j`'s type, breaking the motive.
+      -- Note: avoid rewriting `basisSize f` here because it captures
+      -- `Fin (basisSize f)` in `j`'s type, breaking the motive.
       omega
 
 /-- `composeCoeffPowerSumUpTo` written with the last term appended on the
@@ -585,17 +589,10 @@ private theorem matrixActionPolySum_eq_linearPow_mod
       exact DensePoly.zero_mod_eq_zero_core (S := ZMod64 p) f
     · apply DensePoly.mod_eq_self_of_degree_lt
       have hbasis_pos : 0 < basisSize f := Nat.pos_of_ne_zero h_basis_zero
-      have hf_size_pos : 0 < f.size := by
-        by_cases hfz : 0 < f.size
-        · exact hfz
-        · exfalso
-          have hfsize : f.size = 0 := Nat.eq_zero_of_not_pos hfz
-          unfold basisSize DensePoly.degree? at hbasis_pos
-          simp [hfsize] at hbasis_pos
-      have hf_deg_eq : f.degree?.getD 0 = f.size - 1 := by
-        unfold DensePoly.degree?
-        simp [Nat.ne_of_gt hf_size_pos]
-      have hbasis_eq : basisSize f = f.size - 1 := hf_deg_eq
+      have hf_size_pos : 0 < f.size := size_pos_of_basisSize_pos f hbasis_pos
+      have hbasis_eq : basisSize f = f.size - 1 :=
+        basisSize_eq_size_sub_one f hf_size_pos
+      have hf_deg_eq : f.degree?.getD 0 = f.size - 1 := hbasis_eq
       by_cases h_poly_size : (matrixActionPolySum f hmonic w).size = 0
       · have h_poly_deg :
             (matrixActionPolySum f hmonic w).degree?.getD 0 = 0 := by

--- a/progress/20260515T211919Z_6f3bbdbc.md
+++ b/progress/20260515T211919Z_6f3bbdbc.md
@@ -1,0 +1,42 @@
+# HexBerlekamp.Basic basisSize/degree? plumbing dedupe
+
+## Accomplished
+
+- Claimed feature issue #4307.
+- Added two private helpers near the `basisSize` definition in
+  `HexBerlekamp/Basic.lean`:
+  - `size_pos_of_basisSize_pos : 0 < basisSize f → 0 < f.size`
+  - `basisSize_eq_size_sub_one : 0 < f.size → basisSize f = f.size - 1`
+- Replaced the two ~10-line duplicated plumbing blocks at
+  `powModMonic_column_size_le` and the Step 3 case of
+  `matrixActionPolySum_eq_linearPow_mod` with calls to the helpers.
+- Found that the `have hbasis_eq : basisSize f = f.size - 1` lines the
+  issue marked as "dead" are in fact used implicitly by `omega` to
+  bridge `basisSize f` and `f.size - 1`. Without them, omega fails
+  the size-bound goals at lines 358, 600, and 609. Kept the
+  `hbasis_eq` lines but reduced each to a one-line application of
+  `basisSize_eq_size_sub_one`; documented the necessity by leaving
+  the helper-call form rather than a deletion.
+- Updated the existing comment on the in-place note "avoid rw
+  hbasis_eq … motive capture" to phrase the constraint as "avoid
+  rewriting `basisSize f` here" so it stays accurate after the
+  variable name churn.
+- Verified `lake build HexBerlekamp.Basic`, `lake build HexBerlekamp`,
+  and `lake build HexBerlekamp.RabinSoundness` all pass.
+
+## Current frontier
+
+#4307 closed by this PR. Remaining unclaimed issues at the start of
+the session were #4157 (HO-43 Round 2 residual, now unblocked per
+the previous progress note since #3916 closed) and #4318
+(thirty-third Phase 4/5 checkpoint summary).
+
+## Next step
+
+A follow-up worker should pick up #4157 to perform the Round 2
+relocation now that the consumer-side refactor has landed, and/or
+claim #4318 to refresh the project state checkpoint.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4307

Session: `6f3bbdbc-d07c-41a4-a9a6-0146ce9d4d2a`

71b4f30 refactor: dedupe basisSize/degree? plumbing in HexBerlekamp.Basic

🤖 Prepared with Claude Code