### PR TITLE
feat: derive content and sign-normalisation from Monic factor

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -2614,6 +2614,66 @@ theorem recombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     hcore_ne hcore_monic hcore_record hdvd hfactor_prim hfactor_norm hirr
     hrep hprecision
 
+/--
+A monic integer polynomial automatically has primitive content and is its own
+sign-normalisation. This packages the two normalisation hypotheses required
+by `recombinationCandidate_eq_factor_of_recovery` (`content factor = 1` and
+`normalizeFactorSign factor = factor`) into one consequence of `Monic factor`,
+together with restating the monic hypothesis itself.
+
+Intended use by the recursive coverage proof for `Hex.recombinationSearchModAux`
+(#4301): once the proof obtains a monic integer divisor of the current target
+via the Hensel-lift partition, this helper discharges the primitive and
+sign-normalised hypotheses of `recombinationCandidate_eq_factor_of_recovery`
+for that factor. Monicness itself is taken as a hypothesis here because the
+`LiftedFactorSubsetPartition.cover` field does not constrain the integer
+factor's leading-coefficient sign; the recursive coverage proof supplies it
+from a separate Hensel-lift normalisation argument.
+-/
+theorem monic_primitive_sign_normalized_of_monic
+    {factor : Hex.ZPoly} (hfactor_monic : Hex.DensePoly.Monic factor) :
+    Hex.DensePoly.Monic factor ∧
+      Hex.ZPoly.content factor = 1 ∧
+        Hex.normalizeFactorSign factor = factor := by
+  have hlead : Hex.DensePoly.leadingCoeff factor = (1 : Int) := hfactor_monic
+  have hcs_pos : 0 < factor.coeffs.size := by
+    rcases Nat.eq_zero_or_pos factor.coeffs.size with hcs_zero | hcs_pos
+    · exfalso
+      have hback_none : factor.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        simp [hcs_zero]
+      have hlc_zero : Hex.DensePoly.leadingCoeff factor = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hlead
+      exact absurd hlead (by decide)
+    · exact hcs_pos
+  have hsize_pos : 0 < factor.size := hcs_pos
+  have hcoeff_last : factor.coeff (factor.size - 1) = (1 : Int) := by
+    rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last factor hsize_pos]
+    exact hlead
+  refine ⟨hfactor_monic, ?_, ?_⟩
+  · -- content factor = 1: content divides every coefficient, including the
+    --   leading coefficient 1, and content is non-negative, so content = 1.
+    have hdvd_one : Hex.ZPoly.content factor ∣ (1 : Int) := by
+      have := Hex.DensePoly.content_dvd_coeff factor (factor.size - 1)
+      rwa [hcoeff_last] at this
+    have hcontent_nonneg : (0 : Int) ≤ Hex.ZPoly.content factor := by
+      unfold Hex.ZPoly.content Hex.DensePoly.content
+      exact Int.natCast_nonneg _
+    rcases Int.isUnit_iff.mp (isUnit_of_dvd_one hdvd_one) with hpos | hneg
+    · exact hpos
+    · exfalso
+      rw [hneg] at hcontent_nonneg
+      exact absurd hcontent_nonneg (by decide)
+  · -- normalizeFactorSign factor = factor: leadingCoeff = 1 ≥ 0, so the sign
+    --   normaliser is the identity branch.
+    unfold Hex.normalizeFactorSign
+    have hnot_neg : ¬ Hex.DensePoly.leadingCoeff factor < 0 := by
+      rw [hlead]; decide
+    simp [hnot_neg]
+
 /-- Converse to `toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord`: if the
 transported polynomial is non-zero and a non-unit, then the executable
 `shouldRecordPolynomialFactor` check passes.  Used to package executable

--- a/progress/20260516T014649Z_5d6790a9.md
+++ b/progress/20260516T014649Z_5d6790a9.md
@@ -1,0 +1,56 @@
+# 2026-05-16T01:46Z — `/work` session, claimed #4355
+
+## Accomplished
+
+Added `HexBerlekampZassenhausMathlib.monic_primitive_sign_normalized_of_monic`
+in `HexBerlekampZassenhausMathlib/Basic.lean`. From `Hex.DensePoly.Monic
+factor` alone the lemma produces the three normalisation facts demanded by
+`recombinationCandidate_eq_factor_of_recovery` for #4301's recursive coverage
+proof:
+
+- `Hex.DensePoly.Monic factor` (restated),
+- `Hex.ZPoly.content factor = 1`,
+- `Hex.normalizeFactorSign factor = factor`.
+
+`content = 1` falls out of `content_dvd_coeff` at the leading position plus
+non-negativity of `Int.ofNat`; sign-normalisation falls out of the `< 0`
+branch of `normalizeFactorSign` being unreachable when `leadingCoeff = 1`.
+
+## Current frontier
+
+The issue's intended signature additionally promised to derive `Monic factor`
+itself from `RepresentsIntegerFactorAtLift` + the Mignotte precision bound +
+`Monic core`. That derivation requires either:
+- monicness of each `liftedFactor d i` (not currently proved anywhere — the
+  issue body suggests it exists, but a repo-wide search for
+  `liftedFactor.*Monic` / `Monic.*liftedFactor` / `leadingCoeff.*liftedFactor`
+  turns up nothing), or
+- a strengthening of `LiftedFactorSubsetPartition.cover` to commit to a
+  canonical (positive-leading-coefficient) representative, which the issue
+  explicitly puts out of scope.
+
+The slim helper covers the part of the issue that is actually provable
+against the landed API. The issue body authorises this kind of scope
+adjustment ("Adjust the exact hypothesis list and theorem name to the proof
+that lands. ... a normalisation hypothesis on `factor` may be needed.").
+
+## Next step
+
+The recursive coverage proof in #4301 will need a separate `Monic factor`
+witness at each `cover_at_min` application. The natural follow-up is either
+(a) a Hensel-lift normalisation lemma proving
+`∀ i, Monic (liftedFactor d i)` for `d = henselLiftData …` (so the subset
+product is also monic, and the centered lift recovers a monic factor), or
+(b) strengthening the partition predicate's `cover` field to require monic
+`f`. Both are larger than this issue and belong in a separate planner step.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` — succeeds; no new `sorry`
+  / `axiom` / `TODO` / `FIXME` in `HexBerlekampZassenhausMathlib/Basic.lean`.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.


### PR DESCRIPTION
Closes #4355

Session: `5d6790a9-9463-4927-82ba-8f80645b7683`

7fa5ee3 feat: derive content and sign-normalisation from Monic factor

🤖 Prepared with Claude Code