### PR TITLE
HexBZ Mathlib: derive partition structure from successful recombination candidate quotient

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -971,7 +971,11 @@ def exactQuotient? (target candidate : ZPoly) : Option ZPoly :=
     else
       none
 
-private theorem exactQuotient?_product
+/-- Successful exact-division extracts a multiplication witness:
+`exactQuotient? target candidate = some quotient` implies
+`quotient * candidate = target`. Forward companion of
+`exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree`. -/
+theorem exactQuotient?_product
     {target candidate quotient : ZPoly}
     (hquot : exactQuotient? target candidate = some quotient) :
     quotient * candidate = target := by

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3169,6 +3169,90 @@ theorem toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord
     · exact hne_one' (by simpa using hone)
     · exact hne_neg_one' hneg_one
 
+/--
+Forward bridge from a successful executable recombination candidate quotient
+to a proof-side irreducible divisor of `target` together with its representing
+subset under a `LiftedFactorSubsetPartition`.
+
+Given a `LiftedFactorSubsetPartition core d J target` and an arbitrary lifted
+subset `T`, the hypotheses
+
+* `Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true`, and
+* `Hex.exactQuotient? target (recombinationCandidate d T) = some quotient`
+
+are the two executable facts that any "non-`none` body" of one step in the
+recombination search produces.  The lemma packages from these:
+
+* the explicit product witness `quotient * recombinationCandidate d T = target`
+  (via `Hex.exactQuotient?_product`),
+* the proof-side divisibility `recombinationCandidate d T ∣ target`, and
+* an irreducible factor `g` of the candidate (via UFD existence in
+  `Polynomial ℤ`) that, via the partition's inherited
+  `HenselSubsetCorrespondenceRest.exists_subset`, is itself an irreducible
+  divisor of `target` with representing subset `S ⊆ J`.
+
+Used by the prefix-none assembler in the recursive coverage proof for
+`Hex.recombinationSearchModAux` (#4367/#4301) to compare an earlier executable
+split's selected subset against the partition's representing subsets using
+`pairwise_disjoint` / `unique_up_to_associated`.
+-/
+theorem exists_representingSubset_dvd_recombinationCandidate_of_exactQuotient
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient) :
+    quotient * recombinationCandidate d T = target ∧
+      recombinationCandidate d T ∣ target ∧
+        ∃ (g : Hex.ZPoly) (S : LiftedFactorSubset d),
+          Irreducible (HexPolyZMathlib.toPolynomial g) ∧
+          g ∣ target ∧
+          g ∣ recombinationCandidate d T ∧
+          S ⊆ J ∧
+          RepresentsIntegerFactorAtLift core d g S := by
+  -- Quotient equation and divisibility from `exactQuotient?_product`.
+  have hmul : quotient * recombinationCandidate d T = target :=
+    Hex.exactQuotient?_product hquot
+  have hcand_dvd_target : recombinationCandidate d T ∣ target := by
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  -- Candidate is nonzero and not a unit after transport to `Polynomial ℤ`.
+  obtain ⟨hcand_poly_ne_zero, hcand_poly_nonunit⟩ :=
+    toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord hrecord
+  -- UFD existence: extract an irreducible factor of the candidate in
+  -- `Polynomial ℤ`.
+  obtain ⟨gPoly, hg_irr, hg_dvd_cand_poly⟩ :=
+    WfDvdMonoid.exists_irreducible_factor hcand_poly_nonunit hcand_poly_ne_zero
+  -- Bridge the irreducible factor back to a `Hex.ZPoly` divisor of the
+  -- candidate.
+  let g : Hex.ZPoly := HexPolyZMathlib.ofPolynomial gPoly
+  have hg_toPolynomial : HexPolyZMathlib.toPolynomial g = gPoly :=
+    HexPolyZMathlib.toPolynomial_ofPolynomial gPoly
+  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+    rcases hg_dvd_cand_poly with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    rw [hg_toPolynomial]
+    exact hr
+  have hg_dvd_target : g ∣ target := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_target with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  have hg_irr_toPoly : Irreducible (HexPolyZMathlib.toPolynomial g) := by
+    rw [hg_toPolynomial]; exact hg_irr
+  -- Apply the partition's inherited `exists_subset` to obtain the representing
+  -- subset for `g`.
+  obtain ⟨S, hSJ, hSrep⟩ :=
+    hpartition.exists_subset hg_irr_toPoly hg_dvd_target
+  exact ⟨hmul, hcand_dvd_target, g, S, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
+    hSJ, hSrep⟩
+
 /-- Algorithm-side packaging for the exhaustive core branch in the form needed
 by UFD arguments over `Polynomial ℤ`.
 

--- a/progress/20260516T025900Z_c1dbe96e.md
+++ b/progress/20260516T025900Z_c1dbe96e.md
@@ -1,0 +1,56 @@
+# Session c1dbe96e — HexBZ Mathlib partition structure from successful candidate quotient
+
+Session: `c1dbe96e`
+Branch: `agent/c1dbe96e`
+
+## Accomplished
+
+Claimed and executed issue #4366 (HexBZ Mathlib: derive partition structure
+from successful recombination candidate quotient).
+
+Added theorem `exists_representingSubset_dvd_recombinationCandidate_of_exactQuotient`
+in `HexBerlekampZassenhausMathlib/Basic.lean`, right after
+`toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord`. Given a
+`LiftedFactorSubsetPartition core d J target`, the executable hypotheses
+`shouldRecordPolynomialFactor (recombinationCandidate d T) = true` and
+`exactQuotient? target (recombinationCandidate d T) = some quotient` —
+i.e. the two facts that any non-`none` body of one recombination-search step
+produces — yield:
+
+- the explicit product witness `quotient * recombinationCandidate d T = target`,
+- the proof-side divisibility `recombinationCandidate d T ∣ target`, and
+- an irreducible factor `g` of the candidate (via UFD existence in
+  `Polynomial ℤ`) that is itself an irreducible divisor of `target` with
+  representing subset `S ⊆ J` from the partition's inherited
+  `HenselSubsetCorrespondenceRest.exists_subset`.
+
+This is the "successful-candidate bridge" consumed by #4367's prefix-none
+assembler when ruling out earlier executable splits via the partition's
+`pairwise_disjoint` / `unique_up_to_associated` fields.
+
+Also promoted `Hex.exactQuotient?_product` in `HexBerlekampZassenhaus/Basic.lean`
+from `private` to public (with a docstring stating its role as the forward
+companion to `exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree`). The
+bridge above is the first Mathlib-side consumer; keeping the private/public
+asymmetry between the forward and converse directions of `exactQuotient?` was
+incidental, not deliberate.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhausMathlib HexBerlekampZassenhaus` succeeds.
+`python3 scripts/check_dag.py` passes. `git diff --check` clean. No new
+`axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level `sorry`.
+
+## Next step
+
+#4367 is the prefix-none assembler that consumes this bridge alongside the
+order/mask information from PR #4375 (subset split mask converses). With the
+representing subset of an irreducible divisor of the candidate now available
+from a `LiftedFactorSubsetPartition` state, the assembler can compare an
+earlier executable split's selected subset against the canonical partition
+subset for `J.min'` and route contradictions through `pairwise_disjoint` /
+`unique_up_to_associated`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4366

Session: `c1dbe96e-4218-47d0-9c9f-08d833e814be`

11c83dd feat: bridge successful recombination candidate to partition representing subset

🤖 Prepared with Claude Code