### PR TITLE
doc: cross-reference consumers in monic-cluster lemmas

### DIFF
--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -359,6 +359,10 @@ If a bounded nonnegative cofactor `h` satisfies a coefficientwise congruence
 `g * h ≡ f (mod m)` against monic `g` and `f`, then `h` is monic. The proof
 compares the possible top coefficient of `g * h` with the top coefficient of
 `f`; the coefficient bounds rule out wraparound modulo `m`.
+
+Consumed by `monic_reduceModPow_of_congr_mul_monic_monic`, which specialises
+this to the `reduceModPow`-canonicalised cofactor consumed by
+`henselLiftQuadratic_h_monic`.
 -/
 theorem monic_of_congr_mul_monic_monic
     {g h f : Hex.ZPoly} {m : Nat}
@@ -462,6 +466,10 @@ theorem monic_of_congr_mul_monic_monic
 Specialisation of `monic_of_congr_mul_monic_monic` for cofactors already
 canonicalised by `Hex.ZPoly.reduceModPow`; its coefficients automatically lie
 in `[0, p^k)`.
+
+Consumed by `henselLiftQuadratic_h_monic`, where the spec congruence
+`(lifted.g * lifted.h) ≡ f (mod p^k)` already supplies a `reduceModPow`-form
+cofactor.
 -/
 theorem monic_reduceModPow_of_congr_mul_monic_monic
     {g h f : Hex.ZPoly} {p k : Nat}
@@ -486,7 +494,11 @@ theorem monic_reduceModPow_of_congr_mul_monic_monic
 /-- The lifted monic factor `lifted.g` produced by `henselLiftQuadratic` is
 monic. The quadratic doubling loop preserves `Monic acc.g` via
 `quadraticHenselStep_monic`; the final `reduceModPow` cleanup preserves it via
-`reduceModPow_monic_of_monic`. -/
+`reduceModPow_monic_of_monic`.
+
+Consumed (alongside `henselLiftQuadratic_h_monic`) by
+`multifactorLiftQuadratic_each_monic` to discharge per-output monicness inside
+the sequential split tree. -/
 theorem henselLiftQuadratic_g_monic
     (p k : Nat) [ZMod64.Bounds p]
     (f g h s t : ZPoly)
@@ -512,7 +524,11 @@ theorem henselLiftQuadratic_g_monic
 /-- The lifted cofactor `lifted.h` produced by `henselLiftQuadratic` is monic
 when `f` is monic. Derived from the cofactor monic lemma
 `monic_reduceModPow_of_congr_mul_monic_monic` applied to the spec congruence
-`(lifted.g * lifted.h) ≡ f (mod p^k)` and `henselLiftQuadratic_g_monic`. -/
+`(lifted.g * lifted.h) ≡ f (mod p^k)` and `henselLiftQuadratic_g_monic`.
+
+Consumed (alongside `henselLiftQuadratic_g_monic`) by
+`multifactorLiftQuadratic_each_monic` to discharge per-output monicness inside
+the sequential split tree. -/
 theorem henselLiftQuadratic_h_monic
     (p k : Nat) [ZMod64.Bounds p]
     (f g h s t : ZPoly)
@@ -645,7 +661,11 @@ private theorem multifactorLiftQuadraticList_each_monic
 
 /-- Every output of `multifactorLiftQuadratic` is monic when the input
 polynomial `f` is monic and the quadratic multifactor lift invariant package
-holds. -/
+holds.
+
+Driven by `henselLiftQuadratic_g_monic` and `henselLiftQuadratic_h_monic`
+applied at each sequential split node. Consumed by the Mathlib-facing umbrella
+`HexBerlekampZassenhausMathlib.henselLiftData_liftedFactor_monic`. -/
 theorem multifactorLiftQuadratic_each_monic
     (p k : Nat) [ZMod64.Bounds p]
     (f : ZPoly) (factors : Array ZPoly)

--- a/progress/20260516T051310Z_b1eeb3ab.md
+++ b/progress/20260516T051310Z_b1eeb3ab.md
@@ -1,0 +1,44 @@
+# BZ monic-cluster surface review (#4401)
+
+## Accomplished
+
+- Audited the six theorems flagged by #4401 across
+  `HexHensel/QuadraticMultifactor.lean` and
+  `HexBerlekampZassenhausMathlib/Basic.lean` against the four review
+  questions in the issue body.
+- Confirmed the umbrella `henselLiftData_liftedFactor_monic`
+  (Basic.lean L3142) is a thin three-tactic delegation
+  (`letI`, `intro i`, `exact …`) to
+  `Hex.ZPoly.multifactorLiftQuadratic_each_monic` — no proof content
+  migrated into the Mathlib bridge.
+- Confirmed `HexHensel/QuadraticMultifactor.lean` adds no Mathlib
+  imports (direct or transitive): `^import Mathlib` is absent, the
+  cluster commits `c8b56fb` (#4379) and `a310556` (#4386) show no
+  `+import` lines against this file, and `lake env lean --deps`
+  reports zero Mathlib entries.
+- Landed the missing forward (consumer) cross-references on the five
+  cluster theorems that were missing them. The doc-comments now
+  describe both prerequisite and consumer for each step of the chain
+  `monic_of_congr_mul_monic_monic` → `monic_reduceModPow_…` →
+  `henselLiftQuadratic_{g,h}_monic` →
+  `multifactorLiftQuadratic_each_monic` →
+  `henselLiftData_liftedFactor_monic` → `monic_primitive_sign_…`.
+
+## Current frontier
+
+PR posted as a doc-only change closing #4401; the substantive review
+comment is the PR body and a comment on the issue.
+
+## Next step
+
+Hand back to the planner. The hypothesis-block finding (umbrella
+inverts the relative order of size/prime vs data hypotheses compared
+to the inner layer) is recorded as an observation, not a defect:
+the umbrella's order matches the consumer-side convention used by
+`representsIntegerFactorAtLift_monic` (#4399), so any future
+realignment is a layer-boundary call that belongs upstream from this
+review.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4401

Session: `b1eeb3ab-63f9-4cbc-82c4-1b0457de249c`

f75b872 doc: cross-reference consumers in monic-cluster lemmas (#4401)

🤖 Prepared with Claude Code