### PR TITLE
HO-43 Round 3: relocate row-add GramSchmidt bridge cluster

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -4587,21 +4587,6 @@ theorem scaledCoeffs_upper (b : Matrix Int n m)
       exact getArrayEntry_zeroRows n r c)
     i j hij
 
-/-- Below the diagonal, the executable integral scaled coefficient is exactly
-the Cramer determinant encoded by `scaledCoeffMatrix`. -/
-theorem scaledCoeffs_eq_scaledCoeffMatrix_det
-    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
-    GramSchmidt.entry (scaledCoeffs b) i j =
-      Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-  have h :
-      getArrayEntry (scaledCoeffRows b) i.val j.val =
-        Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-    rw [scaledCoeffRows_lower_eq_scaledCoeffMatrix_bareiss
-      (b := b) i.val j.val i.isLt hji]
-    exact Matrix.bareiss_eq_det
-      (GramSchmidt.scaledCoeffMatrix b i j hji)
-  simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using h
-
 /-- Leading integer Gram determinants are nonnegative. -/
 theorem leadingGramMatrixInt_det_nonneg
     (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
@@ -4620,27 +4605,6 @@ theorem leadingGramMatrixInt_det_nonneg
       Matrix.row, Matrix.ofFn, GramSchmidt.liftFinLE]
   rw [hgram]
   exact Matrix.det_gramMatrix_nonneg rowPrefix
-
-/-- Conditional form of the leading Gram determinant bridge. The remaining
-unconditional bridge is exactly the nonnegativity of leading Gram determinants:
-once `0 ≤ det` is available, the public `Nat`-valued `gramDet` casts back to
-the signed determinant. -/
-theorem leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg
-    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n)
-    (hdet : 0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht)) :
-    Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
-      Int.ofNat (gramDet b t ht) := by
-  rw [gramDet, Matrix.bareiss_eq_det]
-  exact (Int.toNat_of_nonneg hdet).symm
-
-/-- The public `Nat` Gram determinant casts back to the signed determinant of
-the leading integer Gram matrix. -/
-theorem leadingGramMatrixInt_det_eq_gramDet_int
-    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
-    Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
-      Int.ofNat (gramDet b t ht) :=
-  leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg b t ht
-    (leadingGramMatrixInt_det_nonneg b t ht)
 
 theorem normSq_latticeVec_ge_min_basis_normSq
     (b : Matrix Int n m) (hli : independent b)
@@ -4932,6 +4896,7 @@ theorem scaledCoeffs_eq_zero_of_singularStep_lt
     intro r c _ _
     exact getArrayEntry_zeroRows n r.val c.val
   have h_sub : j.val - (Matrix.noPivotInitialState (Matrix.gramMatrix b)).step = j.val := by
+    have : s ≤ j.val := Nat.le_of_lt hsj
     show j.val - 0 = j.val
     omega
   rw [scaledCoeffs_entry_eq_getArrayEntry]
@@ -5464,38 +5429,11 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
             (GramSchmidt.leadingGramMatrixInt b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
           rw [← hold, hgram]
 
-/-- The executable scaled-coefficient pivot entry changes predictably under
-an earlier-row addition. This packages the Cramer/Bareiss pivot identity at
-the public `scaledCoeffs` level so update consumers need not unfold the
-determinant bridge directly. -/
-theorem scaledCoeffs_rowAdd_pivot (b : Matrix Int n m) (j k : Fin n)
-    (hjk : j.val < k.val) (c : Int) :
-    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k j =
-      GramSchmidt.entry (scaledCoeffs b) k j +
-        c * Int.ofNat (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
-  have hnew := scaledCoeffs_eq_scaledCoeffMatrix_det
-    (b := Matrix.rowAdd b j k c) (i := k) (j := j) hjk
-  have hold := scaledCoeffs_eq_scaledCoeffMatrix_det (b := b) (i := k) (j := j) hjk
-  have hbridge := scaledCoeffMatrix_rowAdd_pivot_det (b := b) (j := j) (k := k) hjk c
-  have hlead := leadingGramMatrixInt_det_eq_gramDet_int
-    (b := b) (t := j.val + 1) (ht := Nat.succ_le_of_lt j.isLt)
-  calc
-    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k j =
-        Matrix.det (GramSchmidt.scaledCoeffMatrix (Matrix.rowAdd b j k c) k j hjk) := hnew
-    _ =
-        Matrix.det (GramSchmidt.scaledCoeffMatrix b k j hjk) +
-          c * Matrix.det
-            (GramSchmidt.leadingGramMatrixInt b (j.val + 1)
-              (Nat.succ_le_of_lt j.isLt)) := hbridge
-    _ =
-        GramSchmidt.entry (scaledCoeffs b) k j +
-          c * Int.ofNat (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
-      rw [← hold, hlead]
-
 /-- When the modified row index `k` lies outside the leading `t`-prefix
 (`t ≤ k.val`), the leading Gram matrix of `Matrix.rowAdd b j k c` agrees with
-that of `b`. -/
-private theorem leadingGramMatrixInt_rowAdd_outside
+that of `b`. Bridge-internal support for the row-add determinant theorem in
+`HexGramSchmidtMathlib.Int`. -/
+theorem leadingGramMatrixInt_rowAdd_outside
     (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
     (hkt : t ≤ k.val) :
     GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht =
@@ -5659,8 +5597,9 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
 /-- When the modified row index `k` lies inside the leading `t`-prefix
 (`k.val < t`), the leading Gram matrix of `Matrix.rowAdd b j k c` agrees with
 the row-and-column-add of the original leading Gram matrix at the lifted
-`Fin t` indices `jt`, `kt`. -/
-private theorem leadingGramMatrixInt_rowAdd_inside
+`Fin t` indices `jt`, `kt`. Bridge-internal support for the row-add
+determinant theorem in `HexGramSchmidtMathlib.Int`. -/
+theorem leadingGramMatrixInt_rowAdd_inside
     (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
     (hjk : j.val < k.val) (hkt : k.val < t) :
     GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht =
@@ -5674,191 +5613,6 @@ private theorem leadingGramMatrixInt_rowAdd_inside
   intro q hq
   exact leadingGramMatrixInt_rowAdd_entry_inside b j k c t ht hjk hkt
     ⟨p, hp⟩ ⟨q, hq⟩
-
-/-- Adding a multiple of an earlier row to a later row leaves the leading
-Gram determinant unchanged. The hypothesis `j.val < k.val` makes the source
-row earlier than the destination row in the basis. -/
-theorem gramDet_rowAdd_earlier
-    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
-    (hjk : j.val < k.val) :
-    gramDet (Matrix.rowAdd b j k c) t ht = gramDet b t ht := by
-  unfold gramDet
-  -- Reduce to the underlying Bareiss-determinant equality on `Int`.
-  congr 1
-  by_cases hkt : k.val < t
-  · -- Inside case: bareiss = det, then det_rowAdd / det_colAdd preserve.
-    rw [leadingGramMatrixInt_rowAdd_inside b j k c t ht hjk hkt]
-    rw [Matrix.bareiss_eq_det, Matrix.bareiss_eq_det]
-    -- Indices and inequality between `jt` and `kt` in `Fin t`.
-    have hjt_ne_kt : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t) ≠ ⟨k.val, hkt⟩ := by
-      intro h
-      have hval : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t).val =
-          (⟨k.val, hkt⟩ : Fin t).val :=
-        congrArg Fin.val h
-      exact Nat.ne_of_lt hjk hval
-    rw [Matrix.det_colAdd _ _ _ _ hjt_ne_kt]
-    rw [Matrix.det_rowAdd _ _ _ _ hjt_ne_kt]
-  · -- Outside case: leading prefix unchanged.
-    have hkt' : t ≤ k.val := Nat.le_of_not_lt hkt
-    rw [leadingGramMatrixInt_rowAdd_outside b j k c t ht hkt']
-
-/-! ### `scaledCoeffs` row-by-row updates under earlier-row addition
-
-The three theorems below package the scaled-coefficient update under
-`Matrix.rowAdd b j k c` with `j.val < k.val` at each below-diagonal column
-position (left of the pivot, the row that is unchanged when not the
-destination, and strictly between the source and the pivot column). They
-mirror the pattern of `scaledCoeffs_rowAdd_pivot` and let the
-`LLLState.sizeReduceColumn` proof-field discharges in `HexLLL/Basic.lean`
-work against `rowAdd` directly, without reaching for the bridge-bound
-`scaledCoeffs_sizeReduce_*` wrappers in `HexGramSchmidt/Update.lean`. -/
-
-private theorem intCast_rat_injective_for_rowAdd {a b : Int}
-    (h : (a : Rat) = (b : Rat)) : a = b := by
-  have hz : ((a - b : Int) : Rat) = 0 := by
-    push_cast
-    grind
-  have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
-  omega
-
-private theorem scaledCoeffs_eq_fin_of_lt (b : Matrix Int n m) (i j : Fin n)
-    (hji : j.val < i.val) :
-    ((GramSchmidt.entry (scaledCoeffs b) i j : Int) : Rat) =
-      (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt) : Rat) *
-        GramSchmidt.entry (coeffs b) i j := by
-  simpa using scaledCoeffs_eq (b := b) i.val j.val i.isLt hji
-
-/-- Under `Matrix.rowAdd b j k c` with `l.val < j.val < k.val`, the
-destination-row scaled coefficient at column `l` updates by the linear
-combination `(scaledCoeffs b)[k][l] + c * (scaledCoeffs b)[j][l]`. -/
-theorem scaledCoeffs_rowAdd_lower (b : Matrix Int n m) (l j k : Fin n)
-    (hlj : l.val < j.val) (hjk : j.val < k.val) (c : Int) :
-    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l =
-      GramSchmidt.entry (scaledCoeffs b) k l +
-        c * GramSchmidt.entry (scaledCoeffs b) j l := by
-  apply intCast_rat_injective_for_rowAdd
-  have hlk : l.val < k.val := Nat.lt_trans hlj hjk
-  have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) k l hlk
-  have holdk := scaledCoeffs_eq_fin_of_lt (b := b) k l hlk
-  have holdj := scaledCoeffs_eq_fin_of_lt (b := b) j l hlj
-  have hdet :
-      gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
-        gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
-    gramDet_rowAdd_earlier b j k c (l.val + 1)
-      (Nat.succ_le_of_lt l.isLt) hjk
-  have hcoeff := coeffs_rowAdd_lower (b := b) l j k hlj hjk c
-  calc
-    ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l : Int) : Rat)
-        =
-          (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
-              (Nat.succ_le_of_lt l.isLt) : Rat) *
-            GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) k l := hnew
-    _ =
-          (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-            (GramSchmidt.entry (coeffs b) k l +
-              (c : Rat) * GramSchmidt.entry (coeffs b) j l) := by
-          rw [hdet, hcoeff]
-    _ =
-          ((GramSchmidt.entry (scaledCoeffs b) k l +
-            c * GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
-          calc
-            (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-                (GramSchmidt.entry (coeffs b) k l +
-                  (c : Rat) * GramSchmidt.entry (coeffs b) j l)
-                =
-                  (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-                    GramSchmidt.entry (coeffs b) k l +
-                    (c : Rat) *
-                      ((gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-                        GramSchmidt.entry (coeffs b) j l) := by
-                  grind
-            _ =
-                  ((GramSchmidt.entry (scaledCoeffs b) k l : Int) : Rat) +
-                    (c : Rat) *
-                      ((GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
-                  rw [← holdk, ← holdj]
-            _ =
-                  ((GramSchmidt.entry (scaledCoeffs b) k l +
-                    c * GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
-                  grind
-
-/-- Under `Matrix.rowAdd b j k c` with `j.val < k.val`, every row of
-`scaledCoeffs` other than the destination row `k` is preserved. -/
-theorem scaledCoeffs_rowAdd_other_row (b : Matrix Int n m) (j k : Fin n)
-    (hjk : j.val < k.val) (c : Int) (i : Fin n) (hik : i ≠ k) :
-    (scaledCoeffs (Matrix.rowAdd b j k c)).row i = (scaledCoeffs b).row i := by
-  apply Vector.ext
-  intro col hcol
-  let l : Fin n := ⟨col, hcol⟩
-  change GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) i l =
-    GramSchmidt.entry (scaledCoeffs b) i l
-  by_cases hli : l.val < i.val
-  · apply intCast_rat_injective_for_rowAdd
-    have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) i l hli
-    have hold := scaledCoeffs_eq_fin_of_lt (b := b) i l hli
-    have hdet :
-        gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
-          gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
-      gramDet_rowAdd_earlier b j k c (l.val + 1)
-        (Nat.succ_le_of_lt l.isLt) hjk
-    have hrow := coeffs_rowAdd_other_row (b := b) j k c hjk i hik
-    have hcoeff :
-        GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) i l =
-          GramSchmidt.entry (coeffs b) i l := by
-      have hget := congrArg (fun row => row[l]) hrow
-      simpa [GramSchmidt.entry] using hget
-    calc
-      ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) i l : Int) : Rat)
-          =
-            (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
-                (Nat.succ_le_of_lt l.isLt) : Rat) *
-              GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) i l := hnew
-      _ =
-            (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-              GramSchmidt.entry (coeffs b) i l := by
-            rw [hdet, hcoeff]
-      _ = ((GramSchmidt.entry (scaledCoeffs b) i l : Int) : Rat) := hold.symm
-  · by_cases hil : i = l
-    · subst l
-      rw [← hil]
-      rw [scaledCoeffs_diag, scaledCoeffs_diag]
-      exact congrArg Int.ofNat
-        (gramDet_rowAdd_earlier b j k c (i.val + 1)
-          (Nat.succ_le_of_lt i.isLt) hjk)
-    · have hilv : i.val < l.val := by
-        have hle : i.val ≤ l.val := Nat.le_of_not_lt hli
-        exact Nat.lt_of_le_of_ne hle (fun h => hil (Fin.ext h))
-      rw [scaledCoeffs_upper (Matrix.rowAdd b j k c) i.val l.val i.isLt l.isLt hilv,
-        scaledCoeffs_upper b i.val l.val i.isLt l.isLt hilv]
-
-/-- Under `Matrix.rowAdd b j k c` with `j.val < l.val < k.val`, the
-destination-row scaled coefficient at column `l` between the source column
-and the pivot is preserved. -/
-theorem scaledCoeffs_rowAdd_above_pivot (b : Matrix Int n m) (j k : Fin n)
-    (hjk : j.val < k.val) (c : Int) (l : Fin n)
-    (hjl : j.val < l.val) (hlk : l.val < k.val) :
-    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l =
-      GramSchmidt.entry (scaledCoeffs b) k l := by
-  apply intCast_rat_injective_for_rowAdd
-  have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) k l hlk
-  have hold := scaledCoeffs_eq_fin_of_lt (b := b) k l hlk
-  have hdet :
-      gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
-        gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
-    gramDet_rowAdd_earlier b j k c (l.val + 1)
-      (Nat.succ_le_of_lt l.isLt) hjk
-  have hcoeff := coeffs_rowAdd_above_pivot (b := b) j l k hjl hlk c
-  calc
-    ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l : Int) : Rat)
-        =
-          (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
-              (Nat.succ_le_of_lt l.isLt) : Rat) *
-            GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) k l := hnew
-    _ =
-          (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
-            GramSchmidt.entry (coeffs b) k l := by
-          rw [hdet, hcoeff]
-    _ = ((GramSchmidt.entry (scaledCoeffs b) k l : Int) : Rat) := hold.symm
 
 /-! ### Adjacent-swap pivot Gram-determinant product
 

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -100,6 +100,255 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
         b i j hji s h_sing
       rw [h_lhs, Matrix.bareiss_eq_det, h_det]
 
+
+/-- Below the diagonal, the executable integral scaled coefficient is exactly
+the Cramer determinant encoded by `scaledCoeffMatrix`. -/
+theorem scaledCoeffs_eq_scaledCoeffMatrix_det
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
+    GramSchmidt.entry (scaledCoeffs b) i j =
+      Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
+  rw [scaledCoeffs_eq_scaledCoeffMatrix_bareiss]
+  exact Matrix.bareiss_eq_det (GramSchmidt.scaledCoeffMatrix b i j hji)
+
+
+/-- Conditional form of the leading Gram determinant bridge. The remaining
+unconditional bridge is exactly the nonnegativity of leading Gram determinants:
+once `0 ≤ det` is available, the public `Nat`-valued `gramDet` casts back to
+the signed determinant. -/
+theorem leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg
+    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n)
+    (hdet : 0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht)) :
+    Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
+      Int.ofNat (gramDet b t ht) := by
+  rw [gramDet, Matrix.bareiss_eq_det]
+  exact (Int.toNat_of_nonneg hdet).symm
+
+/-- The public `Nat` Gram determinant casts back to the signed determinant of
+the leading integer Gram matrix. -/
+theorem leadingGramMatrixInt_det_eq_gramDet_int
+    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
+    Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
+      Int.ofNat (gramDet b t ht) :=
+  leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg b t ht
+    (leadingGramMatrixInt_det_nonneg b t ht)
+
+
+/-- The executable scaled-coefficient pivot entry changes predictably under
+an earlier-row addition. This packages the Cramer/Bareiss pivot identity at
+the public `scaledCoeffs` level so update consumers need not unfold the
+determinant bridge directly. -/
+theorem scaledCoeffs_rowAdd_pivot (b : Matrix Int n m) (j k : Fin n)
+    (hjk : j.val < k.val) (c : Int) :
+    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k j =
+      GramSchmidt.entry (scaledCoeffs b) k j +
+        c * Int.ofNat (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
+  have hnew := scaledCoeffs_eq_scaledCoeffMatrix_det
+    (b := Matrix.rowAdd b j k c) (i := k) (j := j) hjk
+  have hold := scaledCoeffs_eq_scaledCoeffMatrix_det (b := b) (i := k) (j := j) hjk
+  have hbridge := scaledCoeffMatrix_rowAdd_pivot_det (b := b) (j := j) (k := k) hjk c
+  have hlead := leadingGramMatrixInt_det_eq_gramDet_int
+    (b := b) (t := j.val + 1) (ht := Nat.succ_le_of_lt j.isLt)
+  calc
+    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k j =
+        Matrix.det (GramSchmidt.scaledCoeffMatrix (Matrix.rowAdd b j k c) k j hjk) := hnew
+    _ =
+        Matrix.det (GramSchmidt.scaledCoeffMatrix b k j hjk) +
+          c * Matrix.det
+            (GramSchmidt.leadingGramMatrixInt b (j.val + 1)
+              (Nat.succ_le_of_lt j.isLt)) := hbridge
+    _ =
+        GramSchmidt.entry (scaledCoeffs b) k j +
+          c * Int.ofNat (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
+      rw [← hold, hlead]
+
+
+/-- Adding a multiple of an earlier row to a later row leaves the leading
+Gram determinant unchanged. The hypothesis `j.val < k.val` makes the source
+row earlier than the destination row in the basis. -/
+theorem gramDet_rowAdd_earlier
+    (b : Matrix Int n m) (j k : Fin n) (c : Int) (t : Nat) (ht : t ≤ n)
+    (hjk : j.val < k.val) :
+    gramDet (Matrix.rowAdd b j k c) t ht = gramDet b t ht := by
+  unfold gramDet
+  -- Reduce to the underlying Bareiss-determinant equality on `Int`.
+  congr 1
+  by_cases hkt : k.val < t
+  · -- Inside case: bareiss = det, then det_rowAdd / det_colAdd preserve.
+    rw [leadingGramMatrixInt_rowAdd_inside b j k c t ht hjk hkt]
+    rw [Matrix.bareiss_eq_det, Matrix.bareiss_eq_det]
+    -- Indices and inequality between `jt` and `kt` in `Fin t`.
+    have hjt_ne_kt : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t) ≠ ⟨k.val, hkt⟩ := by
+      intro h
+      have hval : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t).val =
+          (⟨k.val, hkt⟩ : Fin t).val :=
+        congrArg Fin.val h
+      exact Nat.ne_of_lt hjk hval
+    rw [Matrix.det_colAdd _ _ _ _ hjt_ne_kt]
+    rw [Matrix.det_rowAdd _ _ _ _ hjt_ne_kt]
+  · -- Outside case: leading prefix unchanged.
+    have hkt' : t ≤ k.val := Nat.le_of_not_lt hkt
+    rw [leadingGramMatrixInt_rowAdd_outside b j k c t ht hkt']
+
+
+/-! ### `scaledCoeffs` row-by-row updates under earlier-row addition
+
+The three theorems below package the scaled-coefficient update under
+`Matrix.rowAdd b j k c` with `j.val < k.val` at each below-diagonal column
+position (left of the pivot, the row that is unchanged when not the
+destination, and strictly between the source and the pivot column). They
+mirror the pattern of `scaledCoeffs_rowAdd_pivot` and let the
+`LLLState.sizeReduceColumn` proof-field discharges in `HexLLL/Basic.lean`
+work against `rowAdd` directly, without reaching for the bridge-bound
+`scaledCoeffs_sizeReduce_*` wrappers in `HexGramSchmidt/Update.lean`. -/
+
+private theorem intCast_rat_injective_for_rowAdd {a b : Int}
+    (h : (a : Rat) = (b : Rat)) : a = b := by
+  have hz : ((a - b : Int) : Rat) = 0 := by
+    push_cast
+    grind
+  have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
+  omega
+
+private theorem scaledCoeffs_eq_fin_of_lt (b : Matrix Int n m) (i j : Fin n)
+    (hji : j.val < i.val) :
+    ((GramSchmidt.entry (scaledCoeffs b) i j : Int) : Rat) =
+      (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt) : Rat) *
+        GramSchmidt.entry (coeffs b) i j := by
+  simpa using scaledCoeffs_eq (b := b) i.val j.val i.isLt hji
+
+/-- Under `Matrix.rowAdd b j k c` with `l.val < j.val < k.val`, the
+destination-row scaled coefficient at column `l` updates by the linear
+combination `(scaledCoeffs b)[k][l] + c * (scaledCoeffs b)[j][l]`. -/
+theorem scaledCoeffs_rowAdd_lower (b : Matrix Int n m) (l j k : Fin n)
+    (hlj : l.val < j.val) (hjk : j.val < k.val) (c : Int) :
+    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l =
+      GramSchmidt.entry (scaledCoeffs b) k l +
+        c * GramSchmidt.entry (scaledCoeffs b) j l := by
+  apply intCast_rat_injective_for_rowAdd
+  have hlk : l.val < k.val := Nat.lt_trans hlj hjk
+  have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) k l hlk
+  have holdk := scaledCoeffs_eq_fin_of_lt (b := b) k l hlk
+  have holdj := scaledCoeffs_eq_fin_of_lt (b := b) j l hlj
+  have hdet :
+      gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
+        gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
+    gramDet_rowAdd_earlier b j k c (l.val + 1)
+      (Nat.succ_le_of_lt l.isLt) hjk
+  have hcoeff := coeffs_rowAdd_lower (b := b) l j k hlj hjk c
+  calc
+    ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l : Int) : Rat)
+        =
+          (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
+              (Nat.succ_le_of_lt l.isLt) : Rat) *
+            GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) k l := hnew
+    _ =
+          (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+            (GramSchmidt.entry (coeffs b) k l +
+              (c : Rat) * GramSchmidt.entry (coeffs b) j l) := by
+          rw [hdet, hcoeff]
+    _ =
+          ((GramSchmidt.entry (scaledCoeffs b) k l +
+            c * GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
+          calc
+            (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+                (GramSchmidt.entry (coeffs b) k l +
+                  (c : Rat) * GramSchmidt.entry (coeffs b) j l)
+                =
+                  (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+                    GramSchmidt.entry (coeffs b) k l +
+                    (c : Rat) *
+                      ((gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+                        GramSchmidt.entry (coeffs b) j l) := by
+                  grind
+            _ =
+                  ((GramSchmidt.entry (scaledCoeffs b) k l : Int) : Rat) +
+                    (c : Rat) *
+                      ((GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
+                  rw [← holdk, ← holdj]
+            _ =
+                  ((GramSchmidt.entry (scaledCoeffs b) k l +
+                    c * GramSchmidt.entry (scaledCoeffs b) j l : Int) : Rat) := by
+                  grind
+
+/-- Under `Matrix.rowAdd b j k c` with `j.val < k.val`, every row of
+`scaledCoeffs` other than the destination row `k` is preserved. -/
+theorem scaledCoeffs_rowAdd_other_row (b : Matrix Int n m) (j k : Fin n)
+    (hjk : j.val < k.val) (c : Int) (i : Fin n) (hik : i ≠ k) :
+    (scaledCoeffs (Matrix.rowAdd b j k c)).row i = (scaledCoeffs b).row i := by
+  apply Vector.ext
+  intro col hcol
+  let l : Fin n := ⟨col, hcol⟩
+  change GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) i l =
+    GramSchmidt.entry (scaledCoeffs b) i l
+  by_cases hli : l.val < i.val
+  · apply intCast_rat_injective_for_rowAdd
+    have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) i l hli
+    have hold := scaledCoeffs_eq_fin_of_lt (b := b) i l hli
+    have hdet :
+        gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
+          gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
+      gramDet_rowAdd_earlier b j k c (l.val + 1)
+        (Nat.succ_le_of_lt l.isLt) hjk
+    have hrow := coeffs_rowAdd_other_row (b := b) j k c hjk i hik
+    have hcoeff :
+        GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) i l =
+          GramSchmidt.entry (coeffs b) i l := by
+      have hget := congrArg (fun row => row[l]) hrow
+      simpa [GramSchmidt.entry] using hget
+    calc
+      ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) i l : Int) : Rat)
+          =
+            (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
+                (Nat.succ_le_of_lt l.isLt) : Rat) *
+              GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) i l := hnew
+      _ =
+            (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+              GramSchmidt.entry (coeffs b) i l := by
+            rw [hdet, hcoeff]
+      _ = ((GramSchmidt.entry (scaledCoeffs b) i l : Int) : Rat) := hold.symm
+  · by_cases hil : i = l
+    · subst l
+      rw [← hil]
+      rw [scaledCoeffs_diag, scaledCoeffs_diag]
+      exact congrArg Int.ofNat
+        (gramDet_rowAdd_earlier b j k c (i.val + 1)
+          (Nat.succ_le_of_lt i.isLt) hjk)
+    · have hilv : i.val < l.val := by
+        have hle : i.val ≤ l.val := Nat.le_of_not_lt hli
+        exact Nat.lt_of_le_of_ne hle (fun h => hil (Fin.ext h))
+      rw [scaledCoeffs_upper (Matrix.rowAdd b j k c) i.val l.val i.isLt l.isLt hilv,
+        scaledCoeffs_upper b i.val l.val i.isLt l.isLt hilv]
+
+/-- Under `Matrix.rowAdd b j k c` with `j.val < l.val < k.val`, the
+destination-row scaled coefficient at column `l` between the source column
+and the pivot is preserved. -/
+theorem scaledCoeffs_rowAdd_above_pivot (b : Matrix Int n m) (j k : Fin n)
+    (hjk : j.val < k.val) (c : Int) (l : Fin n)
+    (hjl : j.val < l.val) (hlk : l.val < k.val) :
+    GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l =
+      GramSchmidt.entry (scaledCoeffs b) k l := by
+  apply intCast_rat_injective_for_rowAdd
+  have hnew := scaledCoeffs_eq_fin_of_lt (b := Matrix.rowAdd b j k c) k l hlk
+  have hold := scaledCoeffs_eq_fin_of_lt (b := b) k l hlk
+  have hdet :
+      gramDet (Matrix.rowAdd b j k c) (l.val + 1) (Nat.succ_le_of_lt l.isLt) =
+        gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) :=
+    gramDet_rowAdd_earlier b j k c (l.val + 1)
+      (Nat.succ_le_of_lt l.isLt) hjk
+  have hcoeff := coeffs_rowAdd_above_pivot (b := b) j l k hjl hlk c
+  calc
+    ((GramSchmidt.entry (scaledCoeffs (Matrix.rowAdd b j k c)) k l : Int) : Rat)
+        =
+          (gramDet (Matrix.rowAdd b j k c) (l.val + 1)
+              (Nat.succ_le_of_lt l.isLt) : Rat) *
+            GramSchmidt.entry (coeffs (Matrix.rowAdd b j k c)) k l := hnew
+    _ =
+          (gramDet b (l.val + 1) (Nat.succ_le_of_lt l.isLt) : Rat) *
+            GramSchmidt.entry (coeffs b) k l := by
+          rw [hdet, hcoeff]
+    _ = ((GramSchmidt.entry (scaledCoeffs b) k l : Int) : Rat) := hold.symm
+
+
 end Int
 end GramSchmidt
 end Hex

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -1,3 +1,4 @@
+import HexGramSchmidtMathlib.Int
 import HexGramSchmidt.Update
 
 /-!
@@ -11,8 +12,7 @@ matrix-side `gramDet_adjacentSwap_of_ne` bridge respectively, so they live
 in the bridge layer per [SPEC/Libraries/hex-gram-schmidt.md "Proof path
 governs placement, not just statement"]. The size-reduce theorems are thin
 wrappers around `scaledCoeffs_rowAdd_pivot/lower/other_row/above_pivot` and
-`gramDet_rowAdd_earlier`, which themselves still live in Mathlib-free
-`HexGramSchmidt/Int.lean` and will migrate in HO-43 Round 3 (#4153).
+`gramDet_rowAdd_earlier`, which live in `HexGramSchmidtMathlib/Int.lean`.
 -/
 
 namespace Hex

--- a/progress/20260516T053126Z_4ea15fde.md
+++ b/progress/20260516T053126Z_4ea15fde.md
@@ -1,0 +1,47 @@
+# Session 4ea15fde - HO-43 row-add bridge relocation (#4405)
+
+Session: `4ea15fde-b41b-48c6-ab34-7a0eee4ad4b8`
+Issue: `#4405`
+
+## Accomplished
+
+Relocated the row-add Gram-Schmidt bridge surface from
+`HexGramSchmidt/Int.lean` to `HexGramSchmidtMathlib/Int.lean`:
+
+- `scaledCoeffs_eq_scaledCoeffMatrix_det`
+- `leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg`
+- `leadingGramMatrixInt_det_eq_gramDet_int`
+- `scaledCoeffs_rowAdd_pivot`
+- `gramDet_rowAdd_earlier`
+- `scaledCoeffs_rowAdd_lower`
+- `scaledCoeffs_rowAdd_other_row`
+- `scaledCoeffs_rowAdd_above_pivot`
+
+Kept the purely structural leading-Gram row-add matrix identities in the
+Mathlib-free core and made the two public helpers
+`leadingGramMatrixInt_rowAdd_outside` and
+`leadingGramMatrixInt_rowAdd_inside` available to the bridge theorem, with
+docstrings marking them as bridge-internal support.
+
+Updated `HexGramSchmidtMathlib/Update.lean` to import
+`HexGramSchmidtMathlib.Int` directly for the relocated names and refreshed
+its module comment.
+
+## Current frontier
+
+The row-add cluster no longer appears in `HexGramSchmidt/Int.lean`.
+`rg -n 'Matrix\.bareiss_eq_det|gramDet_rowAdd_earlier|scaledCoeffs_rowAdd'
+HexGramSchmidt/Int.lean` still reports four `Matrix.bareiss_eq_det` hits,
+but they are the remaining non-row-add Round 3 chains called out in the
+parent directive, not this slice.
+
+## Next step
+
+Continue HO-43 Round 3 by relocating the remaining direct
+`Matrix.bareiss_eq_det` users in `HexGramSchmidt/Int.lean`, especially the
+positivity/norm/product-chain surfaces, before unblocking HO-44 (#3900).
+
+## Blockers
+
+None for #4405. The broader HO-44 deletion remains blocked on finishing
+the rest of HO-43.


### PR DESCRIPTION
Closes #4405

Session: `4ea15fde-b41b-48c6-ab34-7a0eee4ad4b8`

86ad8fe feat: relocate GramSchmidt row-add bridge cluster

🤖 Prepared with Claude Code