### PR TITLE
feat: add triangular gramDet positivity helper

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3031,6 +3031,55 @@ private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
         simpa [hdet_nat] using hdet_pos
       exact Int.ofNat_lt.mp hnat_int
 
+/-- The leading executable Gram determinants of a square upper-triangular
+integer matrix with strictly positive diagonal are positive. -/
+theorem gramDet_pos_of_upperTriangular_pos_diag
+    {n : Nat} (M : Matrix Int n n)
+    (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
+    (hdiag : ∀ i : Fin n, 0 < M[i][i])
+    (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
+    0 < gramDet M k hk := by
+  exact gramDet_pos_of_det_positive M (by
+    intro r
+    have hpos :=
+      Matrix.det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
+        (r.val + 1) (Nat.succ_le_of_lt r.isLt)
+    have hgram :
+        Matrix.gramMatrix
+            (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt)) =
+          Matrix.submatrix (Matrix.gramMatrix M) r := by
+      apply Vector.ext
+      intro i hi
+      apply Vector.ext
+      intro j hj
+      let iFin : Fin (r.val + 1) := ⟨i, hi⟩
+      let jFin : Fin (r.val + 1) := ⟨j, hj⟩
+      let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt r.isLt)⟩
+      let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt r.isLt)⟩
+      have hrow_i :
+          Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
+              iFin = Matrix.row M ii := by
+        apply Vector.ext
+        intro c hc
+        simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, iFin, ii]
+      have hrow_j :
+          Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
+              jFin = Matrix.row M jj := by
+        apply Vector.ext
+        intro c hc
+        simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, jFin, jj]
+      have hdot :
+          Matrix.dot
+              (Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
+                iFin)
+              (Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
+                jFin) =
+            Matrix.dot (Matrix.row M ii) (Matrix.row M jj) := by
+        rw [hrow_i, hrow_j]
+      simpa [Matrix.gramMatrix, Matrix.submatrix, Matrix.ofFn, iFin, jFin, ii, jj] using
+        hdot
+    rwa [hgram] at hpos) k hk hk'
+
 /-- A determinant-positive leading-Gram-prefix proof induces the executable
 `gramDet` independence predicate. This is useful for callers that already
 have determinant lemmas for special matrix families, while keeping the public

--- a/progress/20260516T063646Z_19fe923f.md
+++ b/progress/20260516T063646Z_19fe923f.md
@@ -1,0 +1,56 @@
+# 20260516T063646Z — session 19fe923f (feature, partial)
+
+## Accomplished
+
+Claimed issue #4425 and added the downstream-facing theorem
+`GramSchmidt.Int.gramDet_pos_of_upperTriangular_pos_diag` in
+`HexGramSchmidt/Int.lean`.
+
+The theorem has the requested shape for a square upper-triangular integer
+matrix with strictly positive diagonal and proves positivity of executable
+`gramDet M k hk` for `0 < k`.
+
+Verification run:
+
+- `lake build HexGramSchmidt`
+- `lake build HexGramSchmidt HexLLL`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n 'Matrix\.bareiss_eq_det|independent_of_det_positive|gramDet_pos_of_det_positive' HexLLL/Basic.lean`
+- `rg -n 'Matrix\.bareiss_eq_det' HexGramSchmidt/Int.lean`
+- `rg -n 'axiom |native_decide|sorry|TODO|FIXME' HexGramSchmidt/Int.lean HexLLL/Basic.lean`
+
+No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level `sorry`
+was introduced.
+
+## Current frontier
+
+This is partial progress only. The new helper currently packages the desired
+API surface but still proves it through the existing determinant-positive
+bridge `gramDet_pos_of_det_positive`, which in turn depends on the
+`Matrix.bareiss_eq_det` path. Therefore it does not yet satisfy #4425's core
+requirement to prove the result by a Mathlib-free no-pivot/scaled-coefficient
+route.
+
+`HexLLL/Basic.lean` was intentionally not rewired in this session, matching
+#4425's out-of-scope note for the successor issue. Its dependency on
+`GramSchmidt.Int.independent_of_det_positive` remains unchanged.
+
+## Next step
+
+Replace the body of `gramDet_pos_of_upperTriangular_pos_diag` with a genuine
+Mathlib-free proof. The likely route is to prove positivity of the relevant
+no-pivot/scaled-coefficient diagonal entries for leading Gram matrices of
+upper-triangular positive-diagonal bases, then use the existing
+`scaledCoeffRows_diag_eq_gramDet` bridge to conclude executable `gramDet`
+positivity without going through `Matrix.det` or `Matrix.bareiss_eq_det`.
+
+Once that proof is in place, the successor can rewire
+`Matrix.independent_of_upperTriangular_pos_diag` and `Matrix.identity_independent`
+in `HexLLL/Basic.lean`.
+
+## Blockers
+
+The missing mathematical/API blocker is a core lemma connecting the executable
+no-pivot/scaled-coefficient diagonal computation to positivity for triangular
+positive-diagonal inputs, without using determinant equality.


### PR DESCRIPTION
Partial progress on #4425

Session: `19fe923f-85e4-4baa-8946-0d5426438a0a`

41694d0 feat: add triangular gramDet positivity helper

🤖 Prepared with Claude Code