### PR TITLE
HexHensel: expose normalizedXGCD Bezout congruence for quadratic multifactor splits

### DIFF
--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -166,7 +166,7 @@ private theorem linearHenselStep_correction_identity
     _ = eMod := by
           rw [FpPoly.one_mul]
 
-private theorem modP_one (p : Nat) [ZMod64.Bounds p] :
+theorem modP_one (p : Nat) [ZMod64.Bounds p] :
     ZPoly.modP p (1 : ZPoly) = (1 : FpPoly p) := by
   have hcong : ZPoly.congr (FpPoly.liftToZ (1 : FpPoly p)) (1 : ZPoly) p := by
     intro i
@@ -197,7 +197,7 @@ private theorem modP_one (p : Nat) [ZMod64.Bounds p] :
   exact Eq.trans (ZPoly.modP_eq_of_congr p _ _ (ZPoly.congr_symm _ _ _ hcong))
     (FpPoly.modP_liftToZ (p := p) (1 : FpPoly p))
 
-private theorem congr_liftToZ_of_modP_eq
+theorem congr_liftToZ_of_modP_eq
     (p : Nat) [ZMod64.Bounds p] (u : FpPoly p) (z : ZPoly)
     (h : ZPoly.modP p z = u) :
     ZPoly.congr (FpPoly.liftToZ u) z p := by
@@ -239,7 +239,7 @@ private theorem zmod_add_zero_zero (p : Nat) [ZMod64.Bounds p] :
     simp
   simpa [ZMod64.toNat_eq_val, ZMod64.toNat_zero] using hto
 
-private theorem liftToZ_add_congr
+theorem liftToZ_add_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f + g)) (FpPoly.liftToZ f + FpPoly.liftToZ g) p := by
   intro i
@@ -483,7 +483,7 @@ private theorem fold_liftToZ_mulCoeffTerm_congr
         (intDiagonalMulCoeffTerm (FpPoly.liftToZ f) (FpPoly.liftToZ g) n i)
         hacc (liftToZ_mulCoeffTerm_diagonal_congr p f g n i)
 
-private theorem liftToZ_mul_congr
+theorem liftToZ_mul_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f * g)) (FpPoly.liftToZ f * FpPoly.liftToZ g) p := by
   intro n
@@ -496,7 +496,7 @@ private theorem liftToZ_mul_congr
     rw [ZMod64.toNat_zero]
     simp)
 
-private theorem modP_add
+theorem modP_add
     (p : Nat) [ZMod64.Bounds p] (f g : ZPoly) :
     ZPoly.modP p (f + g) = ZPoly.modP p f + ZPoly.modP p g := by
   have hliftAdd :
@@ -522,7 +522,7 @@ private theorem modP_add
       (ZPoly.congr_symm _ _ _ hsum))
     (FpPoly.modP_liftToZ (p := p) (ZPoly.modP p f + ZPoly.modP p g))
 
-private theorem modP_lift_mul_left
+theorem modP_lift_mul_left
     (p : Nat) [ZMod64.Bounds p] (r : FpPoly p) (h : ZPoly) :
     ZPoly.modP p (FpPoly.liftToZ r * h) = r * ZPoly.modP p h := by
   let hMod := ZPoly.modP p h
@@ -542,7 +542,7 @@ private theorem modP_lift_mul_left
       (ZPoly.congr_symm _ _ _ hprod))
     (FpPoly.modP_liftToZ (p := p) (r * hMod))
 
-private theorem modP_lift_mul_right
+theorem modP_lift_mul_right
     (p : Nat) [ZMod64.Bounds p] (g : ZPoly) (hCorrection : FpPoly p) :
     ZPoly.modP p (g * FpPoly.liftToZ hCorrection) =
       ZPoly.modP p g * hCorrection := by
@@ -566,7 +566,7 @@ private theorem modP_lift_mul_right
       (FpPoly.liftToZ (gMod * hCorrection)) (ZPoly.congr_symm _ _ _ hprod))
     (FpPoly.modP_liftToZ (p := p) (gMod * hCorrection))
 
-private theorem modP_add_lift_mul
+theorem modP_add_lift_mul
     (p : Nat) [ZMod64.Bounds p] (g h : ZPoly) (r hCorrection : FpPoly p) :
     ZPoly.modP p (FpPoly.liftToZ r * h + g * FpPoly.liftToZ hCorrection) =
       r * ZPoly.modP p h + ZPoly.modP p g * hCorrection := by

--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -33,6 +33,57 @@ def normalizedXGCD
     left := DensePoly.scale unitInv raw.left
     right := DensePoly.scale unitInv raw.right }
 
+/-- The normalised xgcd witnesses still satisfy the Bezout identity, now for
+the normalised gcd component. -/
+theorem normalizedXGCD_bezout
+    (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (g h : ZPoly) :
+    let xgcd := normalizedXGCD p g h
+    xgcd.left * modP p g + xgcd.right * modP p h = xgcd.gcd := by
+  unfold normalizedXGCD
+  let raw := DensePoly.xgcd (modP p g) (modP p h)
+  let unitInv := (DensePoly.leadingCoeff raw.gcd)⁻¹
+  have hraw : raw.left * modP p g + raw.right * modP p h = raw.gcd := by
+    simpa [raw] using DensePoly.xgcd_bezout (modP p g) (modP p h)
+  change
+    DensePoly.scale unitInv raw.left * modP p g +
+        DensePoly.scale unitInv raw.right * modP p h =
+      DensePoly.scale unitInv raw.gcd
+  rw [← FpPoly.scale_mul_left, ← FpPoly.scale_mul_left,
+    ← FpPoly.scale_add, hraw]
+
+/-- If the normalised xgcd component is `1`, its lifted witnesses give the
+integer-polynomial Bezout congruence needed to initialise a Hensel split. -/
+theorem normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one
+    (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (g h : ZPoly)
+    (hgcd :
+      let xgcd := normalizedXGCD p g h
+      xgcd.gcd = (1 : FpPoly p)) :
+    let xgcd := normalizedXGCD p g h
+    congr
+      (FpPoly.liftToZ xgcd.left * g + FpPoly.liftToZ xgcd.right * h)
+      1 p := by
+  let xgcd := normalizedXGCD p g h
+  have hmod :
+      modP p (FpPoly.liftToZ xgcd.left * g + FpPoly.liftToZ xgcd.right * h) =
+        (1 : FpPoly p) := by
+    rw [modP_add, modP_lift_mul_left, modP_lift_mul_left]
+    calc
+      xgcd.left * modP p g + xgcd.right * modP p h = xgcd.gcd := by
+        simpa [xgcd] using normalizedXGCD_bezout p g h
+      _ = 1 := by
+        simpa [xgcd] using hgcd
+  have hlift_expr :
+      congr (FpPoly.liftToZ (1 : FpPoly p))
+        (FpPoly.liftToZ xgcd.left * g + FpPoly.liftToZ xgcd.right * h) p :=
+    congr_liftToZ_of_modP_eq p (1 : FpPoly p)
+      (FpPoly.liftToZ xgcd.left * g + FpPoly.liftToZ xgcd.right * h) hmod
+  have hlift_one :
+      congr (FpPoly.liftToZ (1 : FpPoly p)) (1 : ZPoly) p :=
+    congr_liftToZ_of_modP_eq p (1 : FpPoly p) (1 : ZPoly) (modP_one p)
+  exact congr_trans _ _ _ p (congr_symm _ _ _ hlift_expr) hlift_one
+
 private def multifactorLiftList
     (p k : Nat) [ZMod64.Bounds p]
     (f : ZPoly) : List ZPoly → Array ZPoly

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -86,6 +86,16 @@ def QuadraticLiftLoopInvariant
     ZPoly.congr (acc.s * acc.g + acc.t * acc.h) 1 m ∧
     DensePoly.Monic acc.g
 
+/-- Constructor for the initial quadratic split invariant from the three
+proof obligations supplied by factor-product, Bezout, and monicness facts. -/
+theorem QuadraticLiftLoopInvariant.of_product_bezout_monic
+    {m : Nat} {f g h s t : ZPoly}
+    (hprod : ZPoly.congr (g * h) f m)
+    (hbezout : ZPoly.congr (s * g + t * h) 1 m)
+    (hg_monic : DensePoly.Monic g) :
+    QuadraticLiftLoopInvariant m f { g, h, s, t } :=
+  ⟨hprod, hbezout, hg_monic⟩
+
 /--
 One quadratic step preserves the loop invariant while replacing `m` by `m*m`.
 

--- a/progress/20260516T071113Z_b0b37b91.md
+++ b/progress/20260516T071113Z_b0b37b91.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+Checked the directive queue first. The reported directive issues were not
+claimable because they were blocked or marked for replan, so I moved to the
+general unclaimed queue.
+
+Claimed #4412, found its assumptions stale, and skipped it: #4410 had been
+decomposed into #4423/#4424, and the reverse-support theorem #4412 depends on
+has not landed.
+
+Claimed #4413, assessed it as too large for one session, and decomposed it into:
+
+- #4432: expose normalizedXGCD Bezout congruence for quadratic multifactor splits
+- #4433: prove `QuadraticMultifactorLiftInvariant` from lifted factor data
+- #4434: wrap `QuadraticMultifactorLiftInvariant` for `choosePrimeData`
+
+Claimed #4432 and completed it. The implementation:
+
+- made existing lift/modP transport helpers in `HexHensel/Linear.lean` public,
+- added `Hex.ZPoly.normalizedXGCD_bezout`,
+- added `Hex.ZPoly.normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one`,
+- added `Hex.ZPoly.QuadraticLiftLoopInvariant.of_product_bezout_monic`.
+
+Verification run:
+
+- `lake build HexHensel.QuadraticMultifactor`
+- `lake build HexHensel`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n 'axiom |native_decide|TODO|FIXME|sorry' HexHensel/Linear.lean HexHensel/Multifactor.lean HexHensel/QuadraticMultifactor.lean`
+
+No new `axiom`, `native_decide`, `TODO`, `FIXME`, or `sorry` was introduced.
+
+## Current frontier
+
+#4432 is complete. The next proof slice is #4433, which should use the new
+normalized-xgcd Bezout congruence together with product congruence and monicness
+to recursively construct `QuadraticMultifactorLiftInvariant`.
+
+The new normalized-xgcd theorem necessarily requires `ZMod64.PrimeModulus p`
+because `DensePoly.xgcd_bezout` depends on `DensePoly.GcdLaws`, which the repo
+provides for prime finite-field moduli.
+
+## Next step
+
+Work #4433. The important proof ingredients are:
+
+- `Hex.ZPoly.normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one`,
+- `Hex.ZPoly.QuadraticLiftLoopInvariant.of_product_bezout_monic`,
+- `Hex.FpPoly.monic_liftToZ_of_monic`,
+- `Hex.ZPoly.henselLiftQuadratic_h_congr_mod_base`,
+- `Hex.ZPoly.henselLiftQuadratic_h_monic`.
+
+## Blockers
+
+None for #4432. For #4433, the remaining design choice is the exact
+Mathlib-free hypothesis that should expose split coprimality as
+`(normalizedXGCD p g h).gcd = 1` at every recursive tail split.


### PR DESCRIPTION
Closes #4432

Session: `b0b37b91-21a7-4f02-a44f-f7bc35959126`

2cf0e1c feat: expose quadratic xgcd Bezout split helpers

🤖 Prepared with Claude Code