### PR TITLE
refactor: move triangular gramDet positivity to bridge

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3031,55 +3031,6 @@ private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
         simpa [hdet_nat] using hdet_pos
       exact Int.ofNat_lt.mp hnat_int
 
-/-- The leading executable Gram determinants of a square upper-triangular
-integer matrix with strictly positive diagonal are positive. -/
-theorem gramDet_pos_of_upperTriangular_pos_diag
-    {n : Nat} (M : Matrix Int n n)
-    (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
-    (hdiag : ∀ i : Fin n, 0 < M[i][i])
-    (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
-    0 < gramDet M k hk := by
-  exact gramDet_pos_of_det_positive M (by
-    intro r
-    have hpos :=
-      Matrix.det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
-        (r.val + 1) (Nat.succ_le_of_lt r.isLt)
-    have hgram :
-        Matrix.gramMatrix
-            (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt)) =
-          Matrix.submatrix (Matrix.gramMatrix M) r := by
-      apply Vector.ext
-      intro i hi
-      apply Vector.ext
-      intro j hj
-      let iFin : Fin (r.val + 1) := ⟨i, hi⟩
-      let jFin : Fin (r.val + 1) := ⟨j, hj⟩
-      let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt r.isLt)⟩
-      let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt r.isLt)⟩
-      have hrow_i :
-          Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
-              iFin = Matrix.row M ii := by
-        apply Vector.ext
-        intro c hc
-        simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, iFin, ii]
-      have hrow_j :
-          Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
-              jFin = Matrix.row M jj := by
-        apply Vector.ext
-        intro c hc
-        simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, jFin, jj]
-      have hdot :
-          Matrix.dot
-              (Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
-                iFin)
-              (Matrix.row (Matrix.leadingRows M (r.val + 1) (Nat.succ_le_of_lt r.isLt))
-                jFin) =
-            Matrix.dot (Matrix.row M ii) (Matrix.row M jj) := by
-        rw [hrow_i, hrow_j]
-      simpa [Matrix.gramMatrix, Matrix.submatrix, Matrix.ofFn, iFin, jFin, ii, jj] using
-        hdot
-    rwa [hgram] at hpos) k hk hk'
-
 /-- A determinant-positive leading-Gram-prefix proof induces the executable
 `gramDet` independence predicate. This is useful for callers that already
 have determinant lemmas for special matrix families, while keeping the public

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -132,6 +132,67 @@ theorem leadingGramMatrixInt_det_eq_gramDet_int
   leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg b t ht
     (leadingGramMatrixInt_det_nonneg b t ht)
 
+/-- The leading executable Gram determinants of a square upper-triangular
+integer matrix with strictly positive diagonal are positive.
+
+This theorem is bridge-only: its proof identifies the executable `gramDet`
+with the Leibniz determinant of the leading Gram matrix via
+`Matrix.bareiss_eq_det`. -/
+theorem gramDet_pos_of_upperTriangular_pos_diag
+    {n : Nat} (M : Matrix Int n n)
+    (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
+    (hdiag : ∀ i : Fin n, 0 < M[i][i])
+    (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
+    0 < gramDet M k hk := by
+  cases k with
+  | zero =>
+      omega
+  | succ r =>
+      have hrn : r < n := Nat.lt_of_succ_le hk
+      have hlead :
+          Matrix.gramMatrix (Matrix.leadingRows M (r + 1) hk) =
+            Matrix.leadingPrefix (Matrix.gramMatrix M) (r + 1) hk := by
+        apply Vector.ext
+        intro i hi
+        apply Vector.ext
+        intro j hj
+        let iFin : Fin (r + 1) := ⟨i, hi⟩
+        let jFin : Fin (r + 1) := ⟨j, hj⟩
+        let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi hk⟩
+        let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj hk⟩
+        have hrow_i :
+            Matrix.row (Matrix.leadingRows M (r + 1) hk) iFin =
+              Matrix.row M ii := by
+          apply Vector.ext
+          intro c hc
+          simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, iFin, ii]
+        have hrow_j :
+            Matrix.row (Matrix.leadingRows M (r + 1) hk) jFin =
+              Matrix.row M jj := by
+          apply Vector.ext
+          intro c hc
+          simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, jFin, jj]
+        have hdot :
+            Matrix.dot (Matrix.row (Matrix.leadingRows M (r + 1) hk) iFin)
+                (Matrix.row (Matrix.leadingRows M (r + 1) hk) jFin) =
+              Matrix.dot (Matrix.row M ii) (Matrix.row M jj) := by
+          rw [hrow_i, hrow_j]
+        simpa [Matrix.gramMatrix, Matrix.leadingPrefix, Matrix.ofFn, iFin, jFin, ii, jj]
+          using hdot
+      have hdet_pos :
+          0 < Matrix.det (GramSchmidt.leadingGramMatrixInt M (r + 1) hk) := by
+        have hpos :=
+          Matrix.det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
+            (r + 1) hk
+        rwa [hlead, ← GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram] at hpos
+      have hdet_nat :
+          Matrix.det (GramSchmidt.leadingGramMatrixInt M (r + 1) hk) =
+            Int.ofNat (gramDet M (r + 1) hk) :=
+        leadingGramMatrixInt_det_eq_gramDet_int M (r + 1) hk
+      have hnat_int : 0 < Int.ofNat (gramDet M (r + 1) hk) := by
+        simpa [hdet_nat] using hdet_pos
+      exact Int.ofNat_lt.mp hnat_int
+
 
 /-- The executable scaled-coefficient pivot entry changes predictably under
 an earlier-row addition. This packages the Cramer/Bareiss pivot identity at

--- a/progress/20260516T072710Z_feb0b4c3.md
+++ b/progress/20260516T072710Z_feb0b4c3.md
@@ -1,0 +1,53 @@
+# Session feb0b4c3 — HO-43 triangular gramDet boundary (#4437)
+
+Session: `feb0b4c3-026f-4995-b1cb-fcf7835231a5`
+Issue: `#4437`
+
+## Accomplished
+
+Moved `GramSchmidt.Int.gramDet_pos_of_upperTriangular_pos_diag` out of
+`HexGramSchmidt/Int.lean` and into `HexGramSchmidtMathlib/Int.lean`,
+preserving the fully qualified theorem name under `Hex.GramSchmidt.Int`.
+The bridge-side theorem now documents that its proof identifies executable
+`gramDet` with the Leibniz determinant through the Bareiss/determinant bridge.
+
+This makes the HO-43 boundary explicit: triangular executable-Gram-determinant
+positivity is not currently a Mathlib-free helper, because the viable proof
+route depends on determinant/Bareiss reasoning.
+
+Left `HexLLL/Basic.lean` unchanged. Added a breadcrumb comment on `#4426`
+noting that its current core-helper rewire plan needs re-triage or a revised
+LLL-facing design after this boundary lands.
+
+Verification run:
+
+- `lake build HexGramSchmidt HexLLL`
+- `lake build HexGramSchmidtMathlib`
+- `python3 scripts/check_dag.py`
+- `rg -n 'Matrix\\.bareiss_eq_det|independent_of_det_positive|gramDet_pos_of_det_positive' HexLLL/Basic.lean`
+- `rg -n 'Matrix\\.bareiss_eq_det' HexGramSchmidt/Int.lean`
+- `rg -n 'gramDet_pos_of_upperTriangular_pos_diag' HexGramSchmidt/Int.lean HexGramSchmidtMathlib/Int.lean`
+- `rg -n '\\baxiom\\b|native_decide|TODO|FIXME' HexGramSchmidt/Int.lean HexGramSchmidtMathlib/Int.lean`
+- `git diff --check`
+
+The builds still report existing warnings from prior `sorry` declarations and
+one existing linter warning; no new theorem-level `sorry` was introduced.
+
+## Current frontier
+
+`#4426` should not consume `gramDet_pos_of_upperTriangular_pos_diag` from the
+Mathlib-free LLL layer as originally planned, because the theorem now lives in
+`HexGramSchmidtMathlib`. The remaining HO-43 design question is how to provide
+or avoid a Mathlib-free triangular independence surface for `HexLLL/Basic.lean`.
+
+## Next step
+
+Re-triage `#4426` into a design-compatible successor: either find a genuinely
+Mathlib-free LLL independence route that does not reproduce the Bareiss/det
+bridge, or move the affected independence surface/callers to an explicit bridge
+boundary.
+
+## Blockers
+
+No blockers for `#4437`. The second-opinion wrapper was attempted but did not
+return in a useful time window, so it was stopped and skipped for this session.


### PR DESCRIPTION
Closes #4437

Session: `feb0b4c3-026f-4995-b1cb-fcf7835231a5`

dc48598 refactor: move triangular gramDet positivity to bridge

🤖 Prepared with Claude Code