### PR TITLE
HO-44: replace HexGramSchmidtMathlib bareiss_eq_det bridge calls

### DIFF
--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -1,4 +1,5 @@
 import HexGramSchmidt.Int
+import HexMatrixMathlib.Determinant
 
 /-!
 Mathlib bridge lemma for the executable Cramer-style scaled coefficient
@@ -9,15 +10,15 @@ scaled-coefficient array entry as the no-pivot Bareiss trailing value on
 `GramSchmidt.scaledCoeffMatrix` (via `scaledCoeffRows_lower_eq_…`). The
 public Bareiss algorithm `Matrix.bareiss`, however, may insert a row swap
 when a diagonal pivot is zero, so the executable array entry need not
-match the public Bareiss value on the Cramer minor without crossing to
-`Matrix.bareiss_eq_det`: the geometric vanishing in the singular branch
-is visible only through the Leibniz determinant.
+match the public Bareiss value on the Cramer minor without crossing the
+Bareiss/Leibniz determinant identity: the geometric vanishing in the
+singular branch is visible only through the Leibniz determinant.
 
 Per `SPEC/Libraries/hex-gram-schmidt.md` ("Proof path governs placement,
 not just statement"), this bridge therefore lives in
-`HexGramSchmidtMathlib`. The proof consumes the existing
-`Matrix.bareiss_eq_det` sorry in `HexMatrix/Bareiss.lean`, which is owned
-by `hex-matrix-mathlib`.
+`HexGramSchmidtMathlib`. The proof consumes the bridge-side identity
+`HexMatrixMathlib.bareiss_eq_det`, which is owned by
+`hex-matrix-mathlib`.
 -/
 
 namespace Hex
@@ -72,7 +73,7 @@ singular step:
 - Singular branch: both sides vanish — the executable scaled coefficient is
   zero by `scaledCoeffs_eq_zero_of_singularStep_lt` (the lifted lower-column
   singular lemma from #4166), and the public Bareiss determinant of the
-  Cramer minor is zero by `Matrix.bareiss_eq_det` composed with
+  Cramer minor is zero by `HexMatrixMathlib.bareiss_eq_det` composed with
   `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt`. The latter Mathlib-free
   helper internally lifts partial-pass singularity to the full
   `bareissNoPivotData` pass and applies the Cramer determinant identity.
@@ -98,7 +99,7 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
         scaledCoeffs_eq_zero_of_singularStep_lt b i j hji s h_sing hsj
       have h_det := scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
         b i j hji s h_sing
-      rw [h_lhs, Matrix.bareiss_eq_det, h_det]
+      rw [h_lhs, HexMatrixMathlib.bareiss_eq_det, h_det]
 
 
 /-- Below the diagonal, the executable integral scaled coefficient is exactly
@@ -108,7 +109,7 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_det
     GramSchmidt.entry (scaledCoeffs b) i j =
       Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
   rw [scaledCoeffs_eq_scaledCoeffMatrix_bareiss]
-  exact Matrix.bareiss_eq_det (GramSchmidt.scaledCoeffMatrix b i j hji)
+  exact HexMatrixMathlib.bareiss_eq_det (GramSchmidt.scaledCoeffMatrix b i j hji)
 
 
 /-- Conditional form of the leading Gram determinant bridge. The remaining
@@ -120,7 +121,7 @@ theorem leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg
     (hdet : 0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht)) :
     Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
       Int.ofNat (gramDet b t ht) := by
-  rw [gramDet, Matrix.bareiss_eq_det]
+  rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
   exact (Int.toNat_of_nonneg hdet).symm
 
 /-- The public `Nat` Gram determinant casts back to the signed determinant of
@@ -137,7 +138,7 @@ integer matrix with strictly positive diagonal are positive.
 
 This theorem is bridge-only: its proof identifies the executable `gramDet`
 with the Leibniz determinant of the leading Gram matrix via
-`Matrix.bareiss_eq_det`. -/
+`HexMatrixMathlib.bareiss_eq_det`. -/
 theorem gramDet_pos_of_upperTriangular_pos_diag
     {n : Nat} (M : Matrix Int n n)
     (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
@@ -236,7 +237,7 @@ theorem gramDet_rowAdd_earlier
   by_cases hkt : k.val < t
   · -- Inside case: bareiss = det, then det_rowAdd / det_colAdd preserve.
     rw [leadingGramMatrixInt_rowAdd_inside b j k c t ht hjk hkt]
-    rw [Matrix.bareiss_eq_det, Matrix.bareiss_eq_det]
+    rw [HexMatrixMathlib.bareiss_eq_det, HexMatrixMathlib.bareiss_eq_det]
     -- Indices and inequality between `jt` and `kt` in `Fin t`.
     have hjt_ne_kt : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t) ≠ ⟨k.val, hkt⟩ := by
       intro h

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -7,11 +7,12 @@ Bridge-bound row-operation update theorems for `hex-gram-schmidt`.
 The theorems in this module relate `gramDet` / `scaledCoeffs` under the
 size-reduce (earlier-row-add) and adjacent-swap row operations. Their
 statements are Hex-local, but their proofs cross the Mathlib boundary by
-reaching `Matrix.bareiss_eq_det` through `gramDet_rowAdd_earlier` and the
-matrix-side `gramDet_adjacentSwap_of_ne` bridge respectively, so they live
-in the bridge layer per [SPEC/Libraries/hex-gram-schmidt.md "Proof path
-governs placement, not just statement"]. The size-reduce theorems are thin
-wrappers around `scaledCoeffs_rowAdd_pivot/lower/other_row/above_pivot` and
+reaching `HexMatrixMathlib.bareiss_eq_det` through `gramDet_rowAdd_earlier`
+and the matrix-side `gramDet_adjacentSwap_of_ne` bridge respectively, so
+they live in the bridge layer per [SPEC/Libraries/hex-gram-schmidt.md
+"Proof path governs placement, not just statement"]. The size-reduce
+theorems are thin wrappers around
+`scaledCoeffs_rowAdd_pivot/lower/other_row/above_pivot` and
 `gramDet_rowAdd_earlier`, which live in `HexGramSchmidtMathlib/Int.lean`.
 -/
 
@@ -25,7 +26,7 @@ namespace GramSchmidt.Int
 so the theorems below specialise the earlier-row-add updates in
 `HexGramSchmidt/Int.lean` to the LLL size-reduce row operation. They are kept
 in this bridge module because their proof path runs through
-`Matrix.bareiss_eq_det`. -/
+`HexMatrixMathlib.bareiss_eq_det`. -/
 
 theorem gramDet_sizeReduce (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int) (t : Nat) (ht : t ≤ n) :
@@ -407,7 +408,7 @@ theorem gramDet_adjacentSwap_of_ne (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
   congr 1
   by_cases hkt : k.val < t
   · rw [leadingGramMatrixInt_rowSwap_inside (b := b) (km1 := km1) (k := k) hkm1k t ht hkt]
-    rw [Matrix.bareiss_eq_det, Matrix.bareiss_eq_det]
+    rw [HexMatrixMathlib.bareiss_eq_det, HexMatrixMathlib.bareiss_eq_det]
     apply det_rowSwap_transpose_rowSwap_transpose
     intro h
     have : km1.val = k.val := by
@@ -423,9 +424,7 @@ theorem gramDet_adjacentSwap_of_ne (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
 
 private theorem intCast_rat_injective_local {a b : Int} (h : (a : Rat) = (b : Rat)) :
     a = b := by
-  have hz : ((a - b : Int) : Rat) = 0 := by
-    simp [h]
-    grind
+  have hz : ((a - b : Int) : Rat) = 0 := by simp [h]
   have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
   omega
 

--- a/HexMatrixMathlib/Determinant.lean
+++ b/HexMatrixMathlib/Determinant.lean
@@ -20,4 +20,14 @@ theorem bareissDet_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M) :=
   bareiss_eq_mathlib_det M
 
+/-- Bridge-side companion to the Mathlib-free orphan
+`Hex.Matrix.bareiss_eq_det` (sorry-bound in `HexMatrix/Bareiss.lean`): the
+row-pivoted Bareiss determinant equals the executable Leibniz determinant
+on integer square matrices. Proven by composing `bareiss_eq_mathlib_det`
+with `det_eq`, so it carries no dependency on the Mathlib-free orphan and
+is the preferred consumer surface for downstream bridge layers. -/
+theorem bareiss_eq_det (M : Hex.Matrix Int n n) :
+    Hex.Matrix.bareiss M = Hex.Matrix.det M :=
+  (bareiss_eq_mathlib_det M).trans (det_eq M).symm
+
 end HexMatrixMathlib

--- a/libraries.yml
+++ b/libraries.yml
@@ -351,7 +351,7 @@ libraries:
     done_through: 3
     status: active
   HexGramSchmidtMathlib:
-    deps: [HexGramSchmidt]
+    deps: [HexGramSchmidt, HexMatrixMathlib]
     mathlib: true
     done_through: 3
     status: active

--- a/progress/2026-05-16T082001Z_490aee5e.md
+++ b/progress/2026-05-16T082001Z_490aee5e.md
@@ -1,0 +1,48 @@
+# 2026-05-16T08:20Z — 490aee5e feature session (HO-44 bridge unwiring)
+
+## Accomplished
+
+- Claimed #4447 (HO-44: replace HexGramSchmidtMathlib bareiss_eq_det
+  bridge calls).
+- Added a bridge-side wrapper
+  `HexMatrixMathlib.bareiss_eq_det : Hex.Matrix.bareiss M = Hex.Matrix.det M`
+  in `HexMatrixMathlib/Determinant.lean`, proven by composing
+  `bareiss_eq_mathlib_det` with `det_eq` so the wrapper carries no
+  dependency on the Mathlib-free orphan
+  `Hex.Matrix.bareiss_eq_det` in `HexMatrix/Bareiss.lean`.
+- Replaced all five direct uses of `Matrix.bareiss_eq_det` in
+  `HexGramSchmidtMathlib/Int.lean` (lines 101, 111, 123, 239) and
+  `HexGramSchmidtMathlib/Update.lean` (line 410) with the new wrapper.
+  Updated the module-level docstrings and inline comments in both files
+  to point at `HexMatrixMathlib.bareiss_eq_det` rather than the orphan.
+- Added the necessary `HexMatrixMathlib` dependency edge to
+  `HexGramSchmidtMathlib` in `libraries.yml` so `scripts/check_dag.py`
+  accepts the new import.
+- Removed a now-redundant `grind` in
+  `intCast_rat_injective_local` (Update.lean): with `HexMatrixMathlib`
+  pulled in, `simp [h]` closes the rational subtraction goal on its own
+  and `grind` becomes "no goals to be solved".
+
+## Current frontier
+
+`rg 'Matrix\.bareiss_eq_det|Hex\.Matrix\.bareiss_eq_det'
+HexGramSchmidtMathlib -g '*.lean'` returns no matches in code or
+comments. All bridge proof obligations that previously chained through
+`HexMatrix.Bareiss`'s `sorry` now go through the bridge surface.
+
+## Next step
+
+The orphan `Hex.Matrix.bareiss_eq_det` in `HexMatrix/Bareiss.lean` still
+exists. Deleting it is the HO-44 / #3900 blocker once the remaining
+Mathlib-free consumer relocations under HO-43 / #4445 / #3899 land.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexGramSchmidt HexGramSchmidtMathlib HexMatrix HexMatrixMathlib HexLLL HexLLLMathlib` ✓
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` ✓
+- `rg -n 'Matrix\.bareiss_eq_det|Hex\.Matrix\.bareiss_eq_det' HexGramSchmidtMathlib -g '*.lean'` returns no matches.


### PR DESCRIPTION
Closes #4447

Session: `490aee5e-1fd0-4fac-afaf-d45d90da7cff`

51495c1 refactor: route HexGramSchmidtMathlib bareiss bridge through HexMatrixMathlib

🤖 Prepared with Claude Code