### PR TITLE
HO-43: add proof-free LLL executable entrypoints for benchmark/core callers

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -3685,10 +3685,9 @@ The result is the executable `L'` row data consumed by the later RREF /
 equivalence-class recovery stage.
 -/
 def bhksProjectedRows (L : BhksLatticeBasis)
-    (hrows : 1 ≤ L.factorCount + L.coeffWidth)
-    (hind : L.basis.independent) : BhksProjectedRows :=
+    (hrows : 1 ≤ L.factorCount + L.coeffWidth) : BhksProjectedRows :=
   let reducedRows :=
-    lll.shortVectors L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows hind
+    lll.shortVectorsUnchecked L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows
   let reducedBasis :=
     bhksRowsArrayToMatrix (L.factorCount + L.coeffWidth) reducedRows
   { factorCount := L.factorCount
@@ -4542,7 +4541,7 @@ and accepts only when the verified candidates multiply back to `f`.
 private def bhksRecoverClassified (f : ZPoly) (d : LiftData) : BhksRecoveryResult :=
   let L := bhksLatticeBasis f d.p d.k d.liftedFactors
   if hrows : 1 ≤ L.factorCount + L.coeffWidth then
-    let projected := bhksProjectedRows L hrows (bhksLiftData_latticeBasis_independent f d)
+    let projected := bhksProjectedRows L hrows
     let indicators := bhksEquivalenceClassIndicators projected
     if bhksDegenerateIndicatorPartition projected indicators then
       .degenerate
@@ -4573,18 +4572,15 @@ theorem bhksRecover?_eq_some_of_checks
       (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth)
     (hnondeg :
       bhksDegenerateIndicatorPartition
-          (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
-            hrows (bhksLiftData_latticeBasis_independent f d))
+          (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows
-              (bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (bhksLiftData_latticeBasis_independent f d))) = false)
+              (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) = false)
     (hcand :
       bhksIndicatorCandidates? f d
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows
-              (bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (bhksLiftData_latticeBasis_independent f d))) =
+              (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) =
         some candidates)
     (hprod : Array.polyProduct candidates = f) :
     bhksRecover? f d = some candidates := by
@@ -6828,17 +6824,16 @@ private theorem bhksRecoverClassified_success_product
   · rw [dif_pos hrows] at hrecover
     by_cases hdeg :
         bhksDegenerateIndicatorPartition
-          (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows
-            (bhksLiftData_latticeBasis_independent f d))
+          (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (bhksLiftData_latticeBasis_independent f d))) = true
+              hrows)) = true
     · simp [hdeg] at hrecover
     · simp only [hdeg, Bool.false_eq_true, if_false] at hrecover
       cases hcand : bhksIndicatorCandidates? f d
           (bhksEquivalenceClassIndicators
             (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (bhksLiftData_latticeBasis_independent f d))) with
+              hrows)) with
       | none => simp [hcand] at hrecover
       | some cands =>
           simp only [hcand] at hrecover
@@ -6866,7 +6861,6 @@ private theorem bhksRecoverClassified_success_all_of_candidates
   · rw [dif_pos hrows] at hrecover
     let projected :=
       bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows
-        (bhksLiftData_latticeBasis_independent f d)
     let indicators := bhksEquivalenceClassIndicators projected
     by_cases hdeg : bhksDegenerateIndicatorPartition projected indicators = true
     · simp [projected, indicators, hdeg] at hrecover
@@ -6914,7 +6908,6 @@ private theorem bhksRecoverClassified_success_dvd
   · rw [dif_pos hrows] at hrecover
     let projected :=
       bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows
-        (bhksLiftData_latticeBasis_independent f d)
     let indicators := bhksEquivalenceClassIndicators projected
     by_cases hdeg : bhksDegenerateIndicatorPartition projected indicators = true
     · simp [projected, indicators, hdeg] at hrecover

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -256,7 +256,6 @@ abbrev HasPositiveDimension (f : Hex.ZPoly) (d : Hex.LiftData) : Prop :=
 def projectedRowsOfLiftData (f : Hex.ZPoly) (d : Hex.LiftData)
     (hrows : HasPositiveDimension f d) : Hex.BhksProjectedRows :=
   Hex.bhksProjectedRows (latticeBasisOfLiftData f d) hrows
-    (Hex.bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos)
 
 /-- Executable bad-vector witness whose lattice and projected rows are the
 ones used by the forward-recovery package at the given lift data.  The
@@ -444,19 +443,16 @@ theorem bhksRecover_eq_some_of_recovery
       (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth := h.rows_pos
   have hnondeg :
       Hex.bhksDegenerateIndicatorPartition
-          (Hex.bhksProjectedRows (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors)
-            hrows (Hex.bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos))
+          (Hex.bhksProjectedRows (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
           (Hex.bhksEquivalenceClassIndicators
             (Hex.bhksProjectedRows
-              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (Hex.bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos))) = false :=
+              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) = false :=
     h.nondegenerate
   have hcand :
       Hex.bhksIndicatorCandidates? f d
           (Hex.bhksEquivalenceClassIndicators
             (Hex.bhksProjectedRows
-              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors)
-              hrows (Hex.bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos))) =
+              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) =
         some h.expectedFactors :=
     h.candidates_eq
   have hprod := h.product_eq

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -452,14 +452,21 @@ theorem potential_eq_gramDetProduct (s : LLLState n m) (hvalid : s.Valid) :
         1 := by
   simp [potential, hvalid.d_eq]
 
-/-- Initial `LLLState` constructor: build the integer state directly from a
-basis matrix. The `ν` field is the integral scaled Gram-Schmidt coefficient
-matrix and the `d` field is the leading Gram-determinant vector. -/
-def ofBasis (b : Matrix Int n m) (_hind : b.independent) : LLLState n m :=
+/-- Proof-free executable `LLLState` constructor. Mathlib-free callers that
+only need executable output (benchmarks, fixture emitters, BHKS projected-row
+computation) can use this directly without manufacturing a `b.independent`
+proof. The proof-carrying `ofBasis` is a thin wrapper. -/
+def ofBasisUnchecked (b : Matrix Int n m) : LLLState n m :=
   let gs := GramSchmidt.Int.data b
   { b
     ν := gs.ν
     d := gs.d }
+
+/-- Initial `LLLState` constructor: build the integer state directly from a
+basis matrix. The `ν` field is the integral scaled Gram-Schmidt coefficient
+matrix and the `d` field is the leading Gram-determinant vector. -/
+def ofBasis (b : Matrix Int n m) (_hind : b.independent) : LLLState n m :=
+  ofBasisUnchecked b
 
 /-- The canonical constructor packages the executable Gram-Schmidt data. -/
 theorem ofBasis_valid (b : Matrix Int n m) (hind : b.independent) :
@@ -467,9 +474,9 @@ theorem ofBasis_valid (b : Matrix Int n m) (hind : b.independent) :
   let gs := GramSchmidt.Int.data b
   constructor
   · intro i j hi hj hji
-    simp [ofBasis, GramSchmidt.Int.scaledCoeffs]
+    simp [ofBasis, ofBasisUnchecked, GramSchmidt.Int.scaledCoeffs]
   · intro i hi
-    simpa [ofBasis, GramSchmidt.Int.gramDetVec, gs] using
+    simpa [ofBasis, ofBasisUnchecked, GramSchmidt.Int.gramDetVec, gs] using
       GramSchmidt.Int.gramDetVec_eq_gramDet b i (Nat.le_of_lt_succ hi)
 
 end LLLState
@@ -513,26 +520,47 @@ termination_by (s.potential, n - k)
 decreasing_by
   all_goals sorry
 
-/-- Top-level LLL entry point. Builds the canonical integer state via
-`LLLState.ofBasis` and dispatches to `lllAux`. -/
-def lll (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+/-- Proof-free executable LLL entry point. Builds the canonical integer state
+via `LLLState.ofBasisUnchecked` and dispatches to `lllAux`. Mathlib-free
+executable callers that do not need a proof-facing specification (benchmarks,
+fixture emitters, BHKS projected-row computation) use this directly. -/
+def lllUnchecked (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Matrix Int n m :=
-  lllAux (LLLState.ofBasis b hind) 1 δ hδ hδ' (Nat.le_refl 1) hn
+  lllAux (LLLState.ofBasisUnchecked b) 1 δ hδ hδ' (Nat.le_refl 1) hn
+
+/-- Top-level LLL entry point. Thin wrapper over `lllUnchecked` retaining the
+proof-facing `b.independent` argument for callers that already carry it. -/
+def lll (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
+    Matrix Int n m :=
+  lllUnchecked b δ hδ hδ' hn
+
+/-- Proof-free executable variant of `lll.firstShortVector`. -/
+def lll.firstShortVectorUnchecked (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
+    Vector Int m :=
+  (lllUnchecked b δ hδ hδ' hn)[0]
 
 /-- The first row of the reduced basis (shortest vector under the LLL
 guarantee). Canonical short-vector entry point for downstream consumers
 such as `hex-berlekamp-zassenhaus` recombination. -/
 def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
     Vector Int m :=
-  (lll b δ hδ hδ' hn hind)[0]
+  lll.firstShortVectorUnchecked b δ hδ hδ' hn
+
+/-- Proof-free executable variant of `lll.shortVectors`. -/
+def lll.shortVectorsUnchecked (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
+    Array (Vector Int m) :=
+  (lllUnchecked b δ hδ hδ' hn).toArray
 
 /-- The full reduced basis viewed as an ordered array of candidate short
 vectors. -/
 def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
     Array (Vector Int m) :=
-  (lll b δ hδ hδ' hn hind).toArray
+  lll.shortVectorsUnchecked b δ hδ hδ' hn
 
 end Hex

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -160,12 +160,11 @@ instance : Hashable StateInput where
   hash input :=
     hash (input.rows, input.cols, input.j.val, input.k.val)
 
-/-- Matrix input for benchmarking `LLLState.ofBasis` itself. -/
+/-- Matrix input for benchmarking `LLLState.ofBasisUnchecked` itself. -/
 structure OfBasisInput where
   rows : Nat
   cols : Nat
   basis : Matrix Int rows cols
-  hind : basis.independent
   j : Fin rows
   k : Fin rows
   hjk : j.val < k.val
@@ -174,13 +173,12 @@ instance : Hashable OfBasisInput where
   hash input :=
     hash (input.rows, input.cols, input.j.val, input.k.val)
 
-/-- Prepared basis for `lll.firstShortVector` benchmarks. -/
+/-- Prepared basis for `lll.firstShortVectorUnchecked` benchmarks. -/
 structure FirstShortVectorInput where
   rows : Nat
   cols : Nat
   basis : Matrix Int rows cols
   hn : 1 ≤ rows
-  hind : basis.independent
 
 instance : Hashable FirstShortVectorInput where
   hash input := hash (input.rows, input.cols)
@@ -221,18 +219,9 @@ def matrixOfFlat (input : IntBasisInput) : Matrix Int input.rows input.cols :=
 def generatedBasis (rows salt : Nat) : Matrix Int rows rows :=
   Matrix.ofFn fun i j => entryValue rows rows i.val j.val salt
 
-private theorem generatedBasis_independent (rows salt : Nat) :
-    (generatedBasis rows salt).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [generatedBasis, Matrix.ofFn, Vector.getElem_ofFn, entryValue, hij]
-  · intro i
-    simp [generatedBasis, Matrix.ofFn, Vector.getElem_ofFn, entryValue]
-    omega
-
-/-- Build the certified executable LLL state for a deterministic matrix. -/
-def stateOf (b : Matrix Int n m) (hind : b.independent) : LLLState n m :=
-  LLLState.ofBasis b hind
+/-- Build the executable LLL state for a deterministic matrix. -/
+def stateOf (b : Matrix Int n m) : LLLState n m :=
+  LLLState.ofBasisUnchecked b
 
 /-- Per-parameter fixture: a prepared `(n + 3) x (n + 3)` LLL state. -/
 def prepStateInput (n : Nat) : StateInput :=
@@ -243,7 +232,7 @@ def prepStateInput (n : Nat) : StateInput :=
   let k : Fin rows := ⟨n + 2, by simp [rows]⟩
   { rows := rows
     cols := cols
-    state := stateOf basis (generatedBasis_independent rows 197)
+    state := stateOf basis
     j := j
     k := k
     hjk := by
@@ -272,9 +261,7 @@ def bzRecombinationInput : FirstShortVectorInput :=
   { rows := 3
     cols := 3
     basis := bzRecombinationBasis
-    hn := by decide
-    hind := by
-      apply Matrix.independent_of_upperTriangular_pos_diag <;> decide }
+    hn := by decide }
 
 instance : Nonempty FirstShortVectorInput :=
   ⟨bzRecombinationInput⟩
@@ -305,14 +292,6 @@ def randomBoundedBasis (n seed : Nat) : Matrix Int n n :=
     else
       randomBoundedEntry (lcgIterate seed (i.val * n + j.val + 1))
 
-private theorem randomBoundedBasis_independent (n seed : Nat) :
-    (randomBoundedBasis n seed).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [randomBoundedBasis, Matrix.ofFn, Vector.getElem_ofFn, hij]
-  · intro i
-    simp [randomBoundedBasis, Matrix.ofFn, Vector.getElem_ofFn]
-
 /-- Committed seed for the random-bounded family. The `#guard` below checks
 that after size-reducing row 1 against row 0, the first Lovasz comparison
 fails, so the next LLL outer-loop step performs a swap. -/
@@ -327,14 +306,13 @@ def prepRandomBoundedInput (n : Nat) : FirstShortVectorInput :=
     cols := rows
     basis := basis
     hn := by
-      exact Nat.le_max_right n 1
-    hind := randomBoundedBasis_independent rows randomBoundedSwapSeed }
+      exact Nat.le_max_right n 1 }
 
 /-- Check that the first Lovasz comparison fails after the first
 size-reduction pass, forcing at least one swap in the subsequent LLL step. -/
 def firstLovaszCheckForcesSwap (input : FirstShortVectorInput) : Bool :=
   if hrows : 2 < input.rows then
-    let sReduced := (LLLState.ofBasis input.basis input.hind).sizeReduce 1
+    let sReduced := (LLLState.ofBasisUnchecked input.basis).sizeReduce 1
     let f0 : Fin input.rows := ⟨0, by omega⟩
     let f1 : Fin input.rows := ⟨1, by omega⟩
     let d0 : Fin (input.rows + 1) := ⟨0, by omega⟩
@@ -371,17 +349,6 @@ def harshCubicBasis (n : Nat) : Matrix Int n n :=
     else
       noise
 
-private theorem harshCubicBasis_independent (n : Nat) :
-    (harshCubicBasis n).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [harshCubicBasis, Matrix.ofFn, Vector.getElem_ofFn, hij]
-  · intro i
-    have hscale : (0 : Int) < harshCubicScale n := by
-      dsimp [harshCubicScale]
-      exact_mod_cast Nat.pow_pos (by decide : 0 < 2)
-    simpa [harshCubicBasis, Matrix.ofFn, Vector.getElem_ofFn] using hscale
-
 /-- Parametric harsh-cubic input family. The scientific ladder is densified at
 `n in {15, 20, 25, 30, 35, 40, 45, 50, 55}`. -/
 def prepHarshCubicInput (n : Nat) : FirstShortVectorInput :=
@@ -391,8 +358,7 @@ def prepHarshCubicInput (n : Nat) : FirstShortVectorInput :=
     cols := rows
     basis := basis
     hn := by
-      exact Nat.le_max_right n 1
-    hind := harshCubicBasis_independent rows }
+      exact Nat.le_max_right n 1 }
 
 def getCachedInput (ref : IO.Ref (Option FirstShortVectorInput))
     (mk : Unit → FirstShortVectorInput) : IO FirstShortVectorInput := do
@@ -483,46 +449,21 @@ def ofBasisHarshCubicEntry (rows row col salt : Nat) : Int :=
 def ofBasisRandomBoundedBasis (rows salt : Nat) : Matrix Int rows rows :=
   Matrix.ofFn fun i j => ofBasisRandomBoundedEntry rows i.val j.val salt
 
-private theorem ofBasisRandomBoundedBasis_independent (rows salt : Nat) :
-    (ofBasisRandomBoundedBasis rows salt).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [ofBasisRandomBoundedBasis, Matrix.ofFn, Vector.getElem_ofFn,
-      ofBasisRandomBoundedEntry, hij]
-  · intro i
-    simp [ofBasisRandomBoundedBasis, Matrix.ofFn, Vector.getElem_ofFn,
-      ofBasisRandomBoundedEntry]
-    omega
-
 /-- Deterministic row-major square basis for the harsh-cubic family. -/
 def ofBasisHarshCubicBasis (rows salt : Nat) : Matrix Int rows rows :=
   Matrix.ofFn fun i j => ofBasisHarshCubicEntry rows i.val j.val salt
 
-private theorem ofBasisHarshCubicBasis_independent (rows salt : Nat) :
-    (ofBasisHarshCubicBasis rows salt).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [ofBasisHarshCubicBasis, Matrix.ofFn, Vector.getElem_ofFn,
-      ofBasisHarshCubicEntry, hij]
-  · intro i
-    have hpos : (0 : Int) <
-        Int.ofNat (2 ^ (3 * rows + ((i.val + 2 * i.val + salt) % 5))) := by
-      exact Int.ofNat_lt.mpr (Nat.pow_pos (by decide : 0 < 2))
-    simpa [ofBasisHarshCubicBasis, Matrix.ofFn, Vector.getElem_ofFn,
-      ofBasisHarshCubicEntry] using hpos
-
-/-- General constructor for an `LLLState.ofBasis` benchmark fixture.
+/-- General constructor for an `LLLState.ofBasisUnchecked` benchmark fixture.
 The benchmark parameter maps to `rows = n + 3`, so the final two row indices
 are always available for the result checksum. -/
-def prepOfBasisInput (n cols : Nat) (basis : Matrix Int (n + 3) cols)
-    (hind : basis.independent) : OfBasisInput :=
+def prepOfBasisInput (n cols : Nat) (basis : Matrix Int (n + 3) cols) :
+    OfBasisInput :=
   let rows := n + 3
   let j : Fin rows := ⟨n + 1, by simp [rows]⟩
   let k : Fin rows := ⟨n + 2, by simp [rows]⟩
   { rows := rows
     cols := cols
     basis := basis
-    hind := hind
     j := j
     k := k
     hjk := by
@@ -533,19 +474,19 @@ def prepOfBasisInput (n cols : Nat) (basis : Matrix Int (n + 3) cols)
 def prepOfBasisBzRecombinationInput (n : Nat) : OfBasisInput :=
   let rows := n + 3
   let basis := generatedBasis rows 311
-  prepOfBasisInput n rows basis (generatedBasis_independent rows 311)
+  prepOfBasisInput n rows basis
 
 /-- Per-parameter fixture for the random-bounded input family. -/
 def prepOfBasisRandomBoundedInput (n : Nat) : OfBasisInput :=
   let rows := n + 3
   let basis := ofBasisRandomBoundedBasis rows 509
-  prepOfBasisInput n rows basis (ofBasisRandomBoundedBasis_independent rows 509)
+  prepOfBasisInput n rows basis
 
 /-- Per-parameter fixture for the harsh-cubic input family. -/
 def prepOfBasisHarshCubicInput (n : Nat) : OfBasisInput :=
   let rows := n + 3
   let basis := ofBasisHarshCubicBasis rows 887
-  prepOfBasisInput n rows basis (ofBasisHarshCubicBasis_independent rows 887)
+  prepOfBasisInput n rows basis
 
 /-- Stable checksum for integer vectors. -/
 def intVectorChecksum (v : Vector Int n) : Int :=
@@ -637,7 +578,7 @@ def ofBasisHarshCubicComplexity (n : Nat) : Nat :=
 
 /-- Benchmark target: construct the initial integer LLL state for a basis. -/
 def runOfBasisChecksum (input : OfBasisInput) : Int :=
-  let s := LLLState.ofBasis input.basis input.hind
+  let s := LLLState.ofBasisUnchecked input.basis
   stateUpdateChecksum s input.j input.k
 
 /-- Benchmark target for the BZ recombination input family. -/
@@ -692,15 +633,15 @@ private theorem lllDeltaUpper : (3 / 4 : Rat) ≤ 1 := by
 /-- Benchmark target: run LLL on one prepared basis and checksum the first row. -/
 def runFirstShortVectorChecksum (input : FirstShortVectorInput) : Int :=
   intVectorChecksum
-    (lll.firstShortVector input.basis (3 / 4)
-      lllDeltaLower lllDeltaUpper input.hn input.hind)
+    (lll.firstShortVectorUnchecked input.basis (3 / 4)
+      lllDeltaLower lllDeltaUpper input.hn)
 
 /-- Benchmark comparator observable: squared norm of Lean's first LLL vector.
 The verified-Isabelle Haskell extraction reports the same scalar. -/
 def runFirstShortVectorNormSq (input : FirstShortVectorInput) : Int :=
   Vector.intNormSq
-    (lll.firstShortVector input.basis (3 / 4)
-      lllDeltaLower lllDeltaUpper input.hn input.hind)
+    (lll.firstShortVectorUnchecked input.basis (3 / 4)
+      lllDeltaLower lllDeltaUpper input.hn)
 
 def intRowHaskell (v : Vector Int n) : String :=
   "[" ++ String.intercalate "," ((List.finRange n).map fun j => toString v[j]) ++ "]"

--- a/HexLLL/EmitFixtures.lean
+++ b/HexLLL/EmitFixtures.lean
@@ -44,18 +44,13 @@ private theorem lll_delta_upper : (3 / 4 : Rat) ≤ 1 := by
   grind
 
 /-- Emit one `(lattice, result)` pair: serialise the input basis and
-the reduced basis Lean returns from `lll b (3/4) ...`. -/
+the reduced basis Lean returns from `lllUnchecked b (3/4) ...`. -/
 private def emitCase (id : String) {n m : Nat} (hn : 1 ≤ n)
-    (b : Matrix Int n m) (hind : b.independent) : IO Unit := do
+    (b : Matrix Int n m) : IO Unit := do
   emitLatticeFixture lib id (basisRows b)
   let r : Matrix Int n m :=
-    lll b (3 / 4) lll_delta_lower lll_delta_upper hn hind
+    lllUnchecked b (3 / 4) lll_delta_lower lll_delta_upper hn
   emitResult lib id "lll" (latticeValue (basisRows r))
-
-private theorem squareUpperIndependent {n : Nat} (b : Matrix Int n n)
-    (hzero : ∀ i j : Fin n, j.val < i.val -> b[i][j] = 0)
-    (hdiag : ∀ i : Fin n, 0 < b[i][i]) : b.independent :=
-  Matrix.independent_of_upperTriangular_pos_diag b hzero hdiag
 
 /-! ## Known-reducible bases.
 
@@ -117,18 +112,6 @@ private def reducible5 : Matrix Int 5 5 :=
     | 4, 4 => 1
     | _, _ => 0
 
-private theorem reducible2_independent : reducible2.independent := by
-  apply squareUpperIndependent <;> decide
-
-private theorem reducible3_independent : reducible3.independent := by
-  apply squareUpperIndependent <;> decide
-
-private theorem reducible4_independent : reducible4.independent := by
-  apply squareUpperIndependent <;> decide
-
-private theorem reducible5_independent : reducible5.independent := by
-  apply squareUpperIndependent <;> decide
-
 /-! ## BZ-shaped triangular lattice basis.
 
 Rows index lifted local factors and retain a small upper-triangular coefficient
@@ -147,9 +130,6 @@ private def bzCoeff (factor col : Nat) : Int :=
 private def bzBasis : Matrix Int 3 3 :=
   Matrix.ofFn fun i j =>
     bzCoeff i.val j.val
-
-private theorem bzBasis_independent : bzBasis.independent := by
-  apply squareUpperIndependent <;> decide
 
 /-! ## Random integer bases.
 
@@ -181,41 +161,21 @@ private def randomBasis (n : Nat) (seed window : Nat) : Matrix Int n n :=
     else
       foldEntry (lcgIterate seed (i.val * n + j.val + 1)) window
 
-private theorem randomBasis_independent (n seed window : Nat) :
-    (randomBasis n seed window).independent := by
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hij
-    simp [randomBasis, Matrix.ofFn, Vector.getElem_ofFn, hij]
-  · intro i
-    simp [randomBasis, Matrix.ofFn, Vector.getElem_ofFn]
-
 private def random4 : Matrix Int 4 4 := randomBasis 4 1 30
 private def random6 : Matrix Int 6 6 := randomBasis 6 7 30
 private def random8 : Matrix Int 8 8 := randomBasis 8 13 30
 private def random10 : Matrix Int 10 10 := randomBasis 10 23 30
 
-private theorem random4_independent : random4.independent :=
-  randomBasis_independent 4 1 30
-
-private theorem random6_independent : random6.independent :=
-  randomBasis_independent 6 7 30
-
-private theorem random8_independent : random8.independent :=
-  randomBasis_independent 8 13 30
-
-private theorem random10_independent : random10.independent :=
-  randomBasis_independent 10 23 30
-
 end Hex.LLLEmit
 
 open Hex.LLLEmit in
 def main : IO Unit := do
-  emitCase "reducible/d2" (by decide) reducible2 reducible2_independent
-  emitCase "reducible/d3" (by decide) reducible3 reducible3_independent
-  emitCase "reducible/d4" (by decide) reducible4 reducible4_independent
-  emitCase "reducible/d5" (by decide) reducible5 reducible5_independent
-  emitCase "bz/p5k2/3factors" (by decide) bzBasis bzBasis_independent
-  emitCase "random/d4" (by decide) random4 random4_independent
-  emitCase "random/d6" (by decide) random6 random6_independent
-  emitCase "random/d8" (by decide) random8 random8_independent
-  emitCase "random/d10" (by decide) random10 random10_independent
+  emitCase "reducible/d2" (by decide) reducible2
+  emitCase "reducible/d3" (by decide) reducible3
+  emitCase "reducible/d4" (by decide) reducible4
+  emitCase "reducible/d5" (by decide) reducible5
+  emitCase "bz/p5k2/3factors" (by decide) bzBasis
+  emitCase "random/d4" (by decide) random4
+  emitCase "random/d6" (by decide) random6
+  emitCase "random/d8" (by decide) random8
+  emitCase "random/d10" (by decide) random10

--- a/progress/20260516T085500Z_1a6c3a7b.md
+++ b/progress/20260516T085500Z_1a6c3a7b.md
@@ -1,0 +1,78 @@
+# Session 1a6c3a7b — HO-43 proof-free LLL entrypoints (#4460)
+
+Session: `1a6c3a7b-4405-4800-8253-20bb61cee6d6`
+Issue: `#4460`
+
+## Accomplished
+
+Claimed `#4460` and split the LLL executable entrypoints in
+`HexLLL/Basic.lean` so Mathlib-free callers no longer manufacture a
+`b.independent` proof:
+
+- Added `LLLState.ofBasisUnchecked`, `lllUnchecked`,
+  `lll.firstShortVectorUnchecked`, and `lll.shortVectorsUnchecked`.
+- Redefined the proof-carrying `LLLState.ofBasis`, `lll`,
+  `lll.firstShortVector`, and `lll.shortVectors` as thin wrappers that
+  call the `Unchecked` variants, with the `b.independent` argument now
+  named `_hind`. Runtime behaviour is unchanged; the existing
+  `ofBasis_valid` proof still goes through after pulling
+  `ofBasisUnchecked` into its `simp` set.
+
+Rewired the Mathlib-free executable callers off
+`Matrix.independent_of_upperTriangular_pos_diag`:
+
+- `HexLLL/Bench.lean`: dropped the `hind` field from `OfBasisInput` and
+  `FirstShortVectorInput`, deleted the per-fixture
+  `generatedBasis_independent`, `randomBoundedBasis_independent`,
+  `harshCubicBasis_independent`, `ofBasisRandomBoundedBasis_independent`,
+  and `ofBasisHarshCubicBasis_independent` helpers, and switched
+  `stateOf`, `runOfBasisChecksum`, `firstLovaszCheckForcesSwap`,
+  `runFirstShortVectorChecksum`, and `runFirstShortVectorNormSq` to the
+  `Unchecked` entrypoints. `bzRecombinationInput`'s `<;> decide`
+  triangular independence proof is gone too.
+- `HexLLL/EmitFixtures.lean`: deleted `squareUpperIndependent`,
+  `reducible{2,3,4,5}_independent`, `bzBasis_independent`,
+  `randomBasis_independent`, and the per-`random{4,6,8,10}` independence
+  theorems. `emitCase` no longer takes an `hind` argument and now calls
+  `lllUnchecked`. The `main` driver passes only the basis matrices.
+- `HexBerlekampZassenhaus/Basic.lean`: dropped the `hind` argument from
+  `bhksProjectedRows`; the body now calls `lll.shortVectorsUnchecked`.
+  Updated `bhksRecoverClassified`,
+  `bhksRecover?_eq_some_of_checks`, `bhksRecoverClassified_success_product`,
+  `bhksRecoverClassified_success_all_of_candidates`, and
+  `bhksRecoverClassified_success_dvd` to call the new two-argument
+  `bhksProjectedRows`.
+
+Mathlib bridge follow-up: updated `HexBerlekampZassenhausMathlib/Recovery.lean`
+(`projectedRowsOfLiftData` and `bhksRecover_eq_some_of_recovery`) to the
+new signature.
+
+The proof-only theorems `bhksLatticeBasis_independent` and
+`bhksLiftData_latticeBasis_independent` are kept in
+`HexBerlekampZassenhaus/Basic.lean` as standalone spec lemmas; the issue
+flags moving them as out of scope.
+
+Verification:
+
+- `lake build HexLLL HexLLL.Bench HexLLL.EmitFixtures HexBerlekampZassenhaus HexBerlekampZassenhausMathlib` — success; pre-existing `sorry` warnings only.
+- `python3 scripts/check_dag.py` — success.
+- `git diff --check` — clean.
+- `rg -n 'import HexGramSchmidtMathlib|import HexLLLMathlib' HexLLL/Bench.lean HexLLL/EmitFixtures.lean HexBerlekampZassenhaus/Basic.lean` — empty.
+- No new `axiom`, `native_decide`, `TODO`, `FIXME`, or theorem-level `sorry`.
+
+## Current frontier
+
+`#4460` is complete. With executable callers now off
+`Matrix.independent_of_upperTriangular_pos_diag`, a successor can move
+that proof route into a bridge module without touching benchmark or BHKS
+core code.
+
+## Next step
+
+Successor work mentioned in the issue's "Out of scope": relocate the
+bridge-backed `bhksLatticeBasis_independent` and
+`bhksLiftData_latticeBasis_independent` theorem names themselves.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4460

Session: `1a6c3a7b-4405-4800-8253-20bb61cee6d6`

9c577278 feat: HO-43 proof-free LLL executable entrypoints

🤖 Prepared with Claude Code