### PR TITLE
HO-43: move LLL triangular independence helpers to bridge layer

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -3520,7 +3520,7 @@ structure BhksProjectedRows where
   reducedRowCount : Nat
   projectedRows : Array (Array Int)
 
-private def bhksLatticeEntry
+def bhksLatticeEntry
     (r n p a : Nat) (thresholds : Array Nat) (cldRows : Array (Array Int))
     (i j : Fin (r + n)) : Int :=
   if _hi : i.val < r then
@@ -3695,40 +3695,6 @@ def bhksProjectedRows (L : BhksLatticeBasis)
     cutRadiusSq4 := bhksCutRadiusSq4 L
     reducedRowCount := reducedRows.size
     projectedRows := bhksCutProjectReducedRows L reducedBasis }
-
-/-- Constructor-produced BHKS `[ I_r | A_tilde ; 0 | diag(p^(a-l_j)) ]`
-lattice bases are linearly independent over `Int` for positive `p`. -/
-theorem bhksLatticeBasis_independent
-    (f : ZPoly) (p a : Nat) (liftedFactors : Array ZPoly) (hp : 0 < p) :
-    (bhksLatticeBasis f p a liftedFactors).basis.independent := by
-  change
-    (Matrix.ofFn
-      (bhksLatticeEntry liftedFactors.size (f.degree?.getD 0) p a
-        (bhksCutThresholds f p)
-        (liftedFactors.map (fun g => cldCoeffs f p a g)))).independent
-  apply Matrix.independent_of_upperTriangular_pos_diag
-  · intro i j hji
-    by_cases hi : i.val < liftedFactors.size
-    · have hj : j.val < liftedFactors.size := by omega
-      simp [Matrix.ofFn, bhksLatticeEntry, hi, hj]
-      omega
-    · have hi' : liftedFactors.size ≤ i.val := by omega
-      by_cases hj : j.val < liftedFactors.size
-      · simp [Matrix.ofFn, bhksLatticeEntry, hi, hj]
-      · have hj' : liftedFactors.size ≤ j.val := by omega
-        have hneq : j.val - liftedFactors.size ≠ i.val - liftedFactors.size := by omega
-        simp [Matrix.ofFn, bhksLatticeEntry, hi, hj, hneq]
-  · intro i
-    by_cases hi : i.val < liftedFactors.size
-    · simp [Matrix.ofFn, bhksLatticeEntry, hi]
-    · have hi' : liftedFactors.size ≤ i.val := by omega
-      have hpos : 0 < p ^ (a - (bhksCutThresholds f p).getD (i.val - liftedFactors.size) 0) :=
-        Nat.pow_pos hp
-      simpa [Matrix.ofFn, bhksLatticeEntry, hi] using Int.ofNat_lt.mpr hpos
-
-private theorem bhksLiftData_latticeBasis_independent (f : ZPoly) (d : LiftData) :
-    (bhksLatticeBasis f d.p d.k d.liftedFactors).basis.independent :=
-  bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos
 
 #guard psiCut 5 4 1 3 = 1
 #guard psiCut 5 4 1 3 ≠ 3 / (5 : Int)

--- a/HexBerlekampZassenhausMathlib.lean
+++ b/HexBerlekampZassenhausMathlib.lean
@@ -1,6 +1,7 @@
 import HexBerlekampZassenhausMathlib.Basic
 import HexBerlekampZassenhausMathlib.BadVector
 import HexBerlekampZassenhausMathlib.BHKSBound
+import HexBerlekampZassenhausMathlib.BHKSIndependent
 import HexBerlekampZassenhausMathlib.ColumnSignature
 import HexBerlekampZassenhausMathlib.IntReductionMod
 import HexBerlekampZassenhausMathlib.Lattice

--- a/HexBerlekampZassenhausMathlib/BHKSIndependent.lean
+++ b/HexBerlekampZassenhausMathlib/BHKSIndependent.lean
@@ -1,0 +1,52 @@
+import HexBerlekampZassenhaus
+import HexLLLMathlib.Independent
+
+/-!
+BHKS lattice-basis independence theorems.
+
+The Berlekamp-Zassenhaus BHKS lattice basis is upper-triangular with positive
+diagonal entries.  Discharging linear independence therefore goes through
+`Matrix.independent_of_upperTriangular_pos_diag`, which is a bridge-layer
+theorem (its proof factors through the determinant/Bareiss bridge).  These
+wrappers therefore live in the Mathlib bridge library, not in the
+Mathlib-free `HexBerlekampZassenhaus/Basic.lean` core.
+-/
+
+namespace Hex
+
+/-- Constructor-produced BHKS `[ I_r | A_tilde ; 0 | diag(p^(a-l_j)) ]`
+lattice bases are linearly independent over `Int` for positive `p`. -/
+theorem bhksLatticeBasis_independent
+    (f : ZPoly) (p a : Nat) (liftedFactors : Array ZPoly) (hp : 0 < p) :
+    (bhksLatticeBasis f p a liftedFactors).basis.independent := by
+  change
+    (Matrix.ofFn
+      (bhksLatticeEntry liftedFactors.size (f.degree?.getD 0) p a
+        (bhksCutThresholds f p)
+        (liftedFactors.map (fun g => cldCoeffs f p a g)))).independent
+  apply Matrix.independent_of_upperTriangular_pos_diag
+  · intro i j hji
+    by_cases hi : i.val < liftedFactors.size
+    · have hj : j.val < liftedFactors.size := by omega
+      simp [Matrix.ofFn, bhksLatticeEntry, hi, hj]
+      omega
+    · have hi' : liftedFactors.size ≤ i.val := by omega
+      by_cases hj : j.val < liftedFactors.size
+      · simp [Matrix.ofFn, bhksLatticeEntry, hi, hj]
+      · have hj' : liftedFactors.size ≤ j.val := by omega
+        have hneq : j.val - liftedFactors.size ≠ i.val - liftedFactors.size := by omega
+        simp [Matrix.ofFn, bhksLatticeEntry, hi, hj, hneq]
+  · intro i
+    by_cases hi : i.val < liftedFactors.size
+    · simp [Matrix.ofFn, bhksLatticeEntry, hi]
+    · have hi' : liftedFactors.size ≤ i.val := by omega
+      have hpos : 0 < p ^ (a - (bhksCutThresholds f p).getD (i.val - liftedFactors.size) 0) :=
+        Nat.pow_pos hp
+      simpa [Matrix.ofFn, bhksLatticeEntry, hi] using Int.ofNat_lt.mpr hpos
+
+/-- `bhksLatticeBasis_independent` packaged at a `LiftData` record. -/
+theorem bhksLiftData_latticeBasis_independent (f : ZPoly) (d : LiftData) :
+    (bhksLatticeBasis f d.p d.k d.liftedFactors).basis.independent :=
+  bhksLatticeBasis_independent f d.p d.k d.liftedFactors d.p_pos
+
+end Hex

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -23,54 +23,6 @@ executable leading Gram determinant. -/
 def independent (b : Matrix Int n m) : Prop :=
   GramSchmidt.Int.independent b
 
-/-- The identity matrix is independent: every executable leading Gram
-determinant is positive. Used by Phase 4 benchmarks of
-`lll.firstShortVector`, where the identity basis is the degenerate BZ-style
-recombination input with all-zero lift coefficients. -/
-theorem identity_independent {n : Nat} : (1 : Matrix Int n n).independent := by
-  exact GramSchmidt.Int.independent_one
-
-theorem gramMatrix_leadingRows_eq_submatrix {n : Nat} (M : Matrix Int n n) (k : Fin n) :
-    gramMatrix (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) =
-      submatrix (gramMatrix M) k := by
-  apply Vector.ext
-  intro i hi
-  apply Vector.ext
-  intro j hj
-  let iFin : Fin (k.val + 1) := ⟨i, hi⟩
-  let jFin : Fin (k.val + 1) := ⟨j, hj⟩
-  let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩
-  let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt k.isLt)⟩
-  have hrow_i :
-      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin = row M ii := by
-    apply Vector.ext
-    intro c hc
-    simp [row, leadingRows, ofFn, iFin, ii]
-  have hrow_j :
-      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin = row M jj := by
-    apply Vector.ext
-    intro c hc
-    simp [row, leadingRows, ofFn, jFin, jj]
-  have hdot :
-      Hex.Vector.dotProduct
-          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin)
-          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin) =
-        Hex.Vector.dotProduct (row M ii) (row M jj) := by
-    rw [hrow_i, hrow_j]
-  simpa [gramMatrix, submatrix, ofFn, iFin, jFin, ii, jj] using
-    hdot
-
-theorem independent_of_upperTriangular_pos_diag {n : Nat}
-    (M : Matrix Int n n)
-    (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
-    (hdiag : ∀ i : Fin n, 0 < M[i][i]) : M.independent := by
-  exact GramSchmidt.Int.independent_of_det_positive M (by
-    intro k
-    have hpos :=
-      det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
-        (k.val + 1) (Nat.succ_le_of_lt k.isLt)
-    rwa [gramMatrix_leadingRows_eq_submatrix M k] at hpos)
-
 end Matrix
 
 namespace LLLCore

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -1,10 +1,68 @@
 import HexLLL.Basic
 
 /-!
-Bridge-facing independence preservation theorems for `HexLLL`.
+Bridge-facing independence theorems for `HexLLL`.
+
+This module hosts the determinant-backed independence helpers whose proofs
+factor through `GramSchmidt.Int.independent_of_det_positive` and therefore
+ultimately depend on the Bareiss/`Matrix.det` bridge. They are kept out of
+the Mathlib-free `HexLLL/Basic.lean` so that the executable LLL core does
+not expose a proof-only surface tied to the bridge layer.
 -/
 
 namespace Hex
+
+namespace Matrix
+
+/-- The identity matrix is independent: every executable leading Gram
+determinant is positive. Used by Phase 4 benchmarks of
+`lll.firstShortVector`, where the identity basis is the degenerate BZ-style
+recombination input with all-zero lift coefficients. -/
+theorem identity_independent {n : Nat} : (1 : Matrix Int n n).independent := by
+  exact GramSchmidt.Int.independent_one
+
+theorem gramMatrix_leadingRows_eq_submatrix {n : Nat} (M : Matrix Int n n) (k : Fin n) :
+    gramMatrix (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) =
+      submatrix (gramMatrix M) k := by
+  apply Vector.ext
+  intro i hi
+  apply Vector.ext
+  intro j hj
+  let iFin : Fin (k.val + 1) := ⟨i, hi⟩
+  let jFin : Fin (k.val + 1) := ⟨j, hj⟩
+  let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩
+  let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt k.isLt)⟩
+  have hrow_i :
+      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin = row M ii := by
+    apply Vector.ext
+    intro c hc
+    simp [row, leadingRows, ofFn, iFin, ii]
+  have hrow_j :
+      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin = row M jj := by
+    apply Vector.ext
+    intro c hc
+    simp [row, leadingRows, ofFn, jFin, jj]
+  have hdot :
+      Hex.Vector.dotProduct
+          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin)
+          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin) =
+        Hex.Vector.dotProduct (row M ii) (row M jj) := by
+    rw [hrow_i, hrow_j]
+  simpa [gramMatrix, submatrix, ofFn, iFin, jFin, ii, jj] using
+    hdot
+
+theorem independent_of_upperTriangular_pos_diag {n : Nat}
+    (M : Matrix Int n n)
+    (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
+    (hdiag : ∀ i : Fin n, 0 < M[i][i]) : M.independent := by
+  exact GramSchmidt.Int.independent_of_det_positive M (by
+    intro k
+    have hpos :=
+      det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
+        (k.val + 1) (Nat.succ_le_of_lt k.isLt)
+    rwa [gramMatrix_leadingRows_eq_submatrix M k] at hpos)
+
+end Matrix
 
 namespace LLLState
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -386,7 +386,7 @@ libraries:
     done_through: 3
     status: active
   HexBerlekampZassenhausMathlib:
-    deps: [HexBerlekampZassenhaus, HexBerlekampMathlib, HexPolyZMathlib, HexMatrixMathlib]
+    deps: [HexBerlekampZassenhaus, HexBerlekampMathlib, HexPolyZMathlib, HexMatrixMathlib, HexLLLMathlib]
     mathlib: true
     done_through: 2
     status: active

--- a/progress/20260516T100157Z_41c8cce7.md
+++ b/progress/20260516T100157Z_41c8cce7.md
@@ -1,0 +1,56 @@
+# 20260516T100157Z — feature 41c8cce7
+
+Closes #4461 (HO-43 Round 1).
+
+## Accomplished
+
+- Moved the three determinant-backed LLL independence helpers
+  (`Matrix.identity_independent`, `Matrix.gramMatrix_leadingRows_eq_submatrix`,
+  `Matrix.independent_of_upperTriangular_pos_diag`) from
+  `HexLLL/Basic.lean` into `HexLLLMathlib/Independent.lean`. Names stay
+  under `Hex.Matrix` so existing call sites that import the bridge module
+  continue to resolve.
+- `HexLLL/Basic.lean` now keeps only the executable
+  `Matrix.independent` predicate plus the Mathlib-free `LLLState`
+  surface; no remaining reference to `independent_of_det_positive`,
+  `independent_one`, or `Matrix.bareiss_eq_det`.
+- The only downstream caller of `Matrix.independent_of_upperTriangular_pos_diag`
+  outside the LLL libraries was `bhksLatticeBasis_independent` (and its
+  `LiftData` wrapper) in the Mathlib-free `HexBerlekampZassenhaus/Basic.lean`.
+  Relocated both to a new `HexBerlekampZassenhausMathlib/BHKSIndependent.lean`,
+  added the new module to the umbrella, and extended
+  `HexBerlekampZassenhausMathlib` deps in `libraries.yml` with `HexLLLMathlib`.
+- Unprivated `Hex.bhksLatticeEntry` (was `private def`) so the relocated
+  proof can `change`-unfold `bhksLatticeBasis.basis`. The function is
+  computational data with no SPEC invariant; this is the smallest change
+  that lets the bridge proof move out of the file.
+- Verification: `lake build HexLLL HexLLLMathlib HexLLL.Bench
+  HexLLL.EmitFixtures HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  green; `python3 scripts/check_dag.py` green;
+  `rg -n 'independent_of_det_positive|independent_one|Matrix\.bareiss_eq_det|gramDet_pos_of_det_positive' HexLLL/Basic.lean`
+  empty; `rg -n 'import HexGramSchmidtMathlib|import HexLLLMathlib' HexLLL/Bench.lean HexLLL/EmitFixtures.lean`
+  empty.
+- No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` in the diff.
+
+## Current frontier
+
+HO-43 Round 1 is complete. Mathlib-free LLL no longer carries the
+determinant-backed independence theorem surface. The downstream
+GramSchmidt relocations (Round 2: `HexGramSchmidt/Update.lean` proofs;
+Round 3: `HexGramSchmidt/Int.lean` proofs) are unaffected and remain
+open per the directive #3899 plan.
+
+## Next step
+
+Successor work (out of scope for #4461) per directive #3899:
+
+- HO-43 Round 2: relocate `gramDet_sizeReduce`, `gramDet_adjacentSwap_of_ne`,
+  and the surrounding `scaledCoeffs_*` cluster from
+  `HexGramSchmidt/Update.lean` into a new `HexGramSchmidtMathlib/Update.lean`.
+- HO-43 Round 3: relocate the seven direct `Matrix.bareiss_eq_det` users
+  plus the transitive determinant-statement cluster from
+  `HexGramSchmidt/Int.lean` into `HexGramSchmidtMathlib/Int.lean`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4461

Session: `41c8cce7-b8f6-41c3-bad1-fd55ce18df9e`

a959e518 feat: relocate LLL triangular independence helpers to bridge layer

🤖 Prepared with Claude Code