### PR TITLE
HO-43: relocate GramSchmidt determinant-backed independence cluster

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3001,53 +3001,6 @@ private theorem leadingGramMatrixInt_det_nonneg_pre
   rw [hgram]
   exact Matrix.det_gramMatrix_nonneg rowPrefix
 
-private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) k))
-    (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
-    0 < gramDet b k hk := by
-  cases k with
-  | zero =>
-      omega
-  | succ r =>
-      have hrn : r < n := Nat.lt_of_succ_le hk
-      let last : Fin n := ⟨r, hrn⟩
-      have hsub : 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) last) :=
-        hdet last
-      have hsub_eq :
-          Matrix.submatrix (Matrix.gramMatrix b) last =
-            GramSchmidt.leadingGramMatrixInt b (r + 1) hk := by
-        rw [Matrix.submatrix_eq_leadingPrefix]
-        rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
-      have hdet_pos :
-          0 < Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) := by
-        simpa [hsub_eq] using hsub
-      have hdet_nat :
-          Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) =
-            Int.ofNat (gramDet b (r + 1) hk) := by
-        rw [gramDet, Matrix.bareiss_eq_det]
-        exact (Int.toNat_of_nonneg
-          (leadingGramMatrixInt_det_nonneg_pre b (r + 1) hk)).symm
-      have hnat_int : 0 < Int.ofNat (gramDet b (r + 1) hk) := by
-        simpa [hdet_nat] using hdet_pos
-      exact Int.ofNat_lt.mp hnat_int
-
-/-- A determinant-positive leading-Gram-prefix proof induces the executable
-`gramDet` independence predicate. This is useful for callers that already
-have determinant lemmas for special matrix families, while keeping the public
-predicate stated over Mathlib-free computed data. -/
-theorem independent_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) k)) :
-    independent b := by
-  intro k
-  exact gramDet_pos_of_det_positive b hdet (k.val + 1) (Nat.succ_le_of_lt k.isLt)
-    (Nat.succ_pos k.val)
-
-theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
-  exact independent_of_det_positive (1 : Matrix Int n n) (by
-    intro k
-    rw [Matrix.gramMatrix_one, Matrix.submatrix_one, Matrix.det_one]
-    decide)
-
 private theorem gramDet_pos_core (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -411,6 +411,61 @@ theorem scaledCoeffs_rowAdd_above_pivot (b : Matrix Int n m) (j k : Fin n)
     _ = ((GramSchmidt.entry (scaledCoeffs b) k l : Int) : Rat) := hold.symm
 
 
+/-! ### Determinant-backed independence
+
+These determinant-positivity bridges for `gramDet` live in the bridge layer
+because their proofs identify `gramDet` with the Leibniz determinant of the
+leading Gram matrix via `HexMatrixMathlib.bareiss_eq_det` (packaged here as
+`leadingGramMatrixInt_det_eq_gramDet_int`). Consumers that already have a
+determinant lemma for a special matrix family can produce the public
+`independent` predicate stated over Mathlib-free computed data. -/
+
+private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
+    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) k))
+    (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
+    0 < gramDet b k hk := by
+  cases k with
+  | zero =>
+      omega
+  | succ r =>
+      have hrn : r < n := Nat.lt_of_succ_le hk
+      let last : Fin n := ⟨r, hrn⟩
+      have hsub : 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) last) :=
+        hdet last
+      have hsub_eq :
+          Matrix.submatrix (Matrix.gramMatrix b) last =
+            GramSchmidt.leadingGramMatrixInt b (r + 1) hk := by
+        rw [Matrix.submatrix_eq_leadingPrefix]
+        rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+      have hdet_pos :
+          0 < Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) := by
+        simpa [hsub_eq] using hsub
+      have hdet_nat :
+          Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) =
+            Int.ofNat (gramDet b (r + 1) hk) :=
+        leadingGramMatrixInt_det_eq_gramDet_int b (r + 1) hk
+      have hnat_int : 0 < Int.ofNat (gramDet b (r + 1) hk) := by
+        simpa [hdet_nat] using hdet_pos
+      exact Int.ofNat_lt.mp hnat_int
+
+/-- A determinant-positive leading-Gram-prefix proof induces the executable
+`gramDet` independence predicate. This is useful for callers that already
+have determinant lemmas for special matrix families, while keeping the public
+predicate stated over Mathlib-free computed data. -/
+theorem independent_of_det_positive (b : Matrix Int n m)
+    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) k)) :
+    independent b := by
+  intro k
+  exact gramDet_pos_of_det_positive b hdet (k.val + 1) (Nat.succ_le_of_lt k.isLt)
+    (Nat.succ_pos k.val)
+
+theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
+  exact independent_of_det_positive (1 : Matrix Int n n) (by
+    intro k
+    rw [Matrix.gramMatrix_one, Matrix.submatrix_one, Matrix.det_one]
+    decide)
+
+
 end Int
 end GramSchmidt
 end Hex

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -1,4 +1,5 @@
 import HexLLL.Basic
+import HexGramSchmidtMathlib.Int
 
 /-!
 Bridge-facing independence theorems for `HexLLL`.

--- a/libraries.yml
+++ b/libraries.yml
@@ -361,7 +361,7 @@ libraries:
     done_through: 3
     status: active
   HexLLLMathlib:
-    deps: [HexLLL, HexMatrixMathlib]
+    deps: [HexLLL, HexMatrixMathlib, HexGramSchmidtMathlib]
     mathlib: true
     done_through: 3
     status: active

--- a/progress/20260516T104244Z_37bc2378.md
+++ b/progress/20260516T104244Z_37bc2378.md
@@ -1,0 +1,44 @@
+# 2026-05-16T10:42:44Z — feature session (issue #4462)
+
+## Accomplished
+
+Relocated the determinant-backed independence cluster from the Mathlib-free
+core `HexGramSchmidt/Int.lean` to the bridge `HexGramSchmidtMathlib/Int.lean`,
+per HO-43 (parent #4459, predecessor #4461).
+
+- Deleted from `HexGramSchmidt/Int.lean`: `gramDet_pos_of_det_positive` (was
+  `private`), `independent_of_det_positive`, `independent_one`. The
+  independence-from-determinant call to `Matrix.bareiss_eq_det` (formerly line
+  3027) is gone from core; the three remaining `Matrix.bareiss_eq_det` hits in
+  the core are the explicitly out-of-scope sites.
+- Kept `leadingGramMatrixInt_det_nonneg_pre` in core because two unrelated
+  out-of-scope sites (around lines 3928 and 4448) still use it; its proof is
+  Mathlib-free.
+- Added to `HexGramSchmidtMathlib/Int.lean`: the three theorems, with
+  `gramDet_pos_of_det_positive` rewritten to consume the existing bridge
+  helper `leadingGramMatrixInt_det_eq_gramDet_int` instead of unfolding
+  `gramDet` + `Matrix.bareiss_eq_det` + nonnegativity by hand.
+- Added `import HexGramSchmidtMathlib.Int` to `HexLLLMathlib/Independent.lean`
+  so its existing `GramSchmidt.Int.independent_one` and
+  `GramSchmidt.Int.independent_of_det_positive` references continue to
+  resolve.
+- Added `HexGramSchmidtMathlib` to `libraries.yml[HexLLLMathlib].deps` to
+  satisfy `scripts/check_dag.py`. Both libraries sit at `done_through: 3`,
+  so the dep-coupled phase-3 cross-lib gate is satisfied.
+
+## Current frontier
+
+`lake build HexGramSchmidt HexGramSchmidtMathlib HexLLL HexLLLMathlib` and
+`lake build HexLLL.Bench HexLLL.EmitFixtures` both pass. `python3
+scripts/check_dag.py` exits 0. `git diff --check` is clean.
+
+## Next step
+
+Commit, push, create PR for #4462. After this lands, parent #4459 can be
+re-triaged for closure or narrowed to the remaining bridge-boundary residue
+(removing `bareiss_eq_det` non-independence hits from the core; explicitly
+out of scope here).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4462

Session: `37bc2378-799a-4ab9-af29-d4874826df22`

1204a33c feat: relocate GramSchmidt determinant-backed independence cluster (#4462)

🤖 Prepared with Claude Code