### PR TITLE
HexBZ Mathlib: assemble cover-at-min containment from recombination-candidate support

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4876,6 +4876,56 @@ theorem exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd
     rw [hr, hq, Hex.DensePoly.mul_assoc_poly (S := Int)]
   exact ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_candidate, hSJ, hiS, hrep⟩
 
+/--
+Cover-at-min containment from recombination-candidate support: when the
+recorded candidate at `T ⊆ J` exactly divides `target`, the cover witness at
+`J.min'` has its representing subset contained in `T`.
+
+This is the form consumed by the prefix-none recombination-search assembler:
+it combines the reverse-support coverage packaging
+(`exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd`) applied
+at `i := J.min' hne` with the forward-support containment
+(`representingSubset_subset_of_dvd_recombinationCandidate`) to obtain the
+single cover factor whose representing subset both contains `J.min' hne`
+and is contained in `T`.
+-/
+theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hne : J.Nonempty)
+    (hmin_in_T : J.min' hne ∈ T)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient) :
+    ∃ (f : Hex.ZPoly) (S : LiftedFactorSubset d),
+      Irreducible (HexPolyZMathlib.toPolynomial f) ∧
+      f ∣ target ∧
+      S ⊆ J ∧ J.min' hne ∈ S ∧
+      RepresentsIntegerFactorAtLift core d f S ∧
+      S ⊆ T := by
+  obtain ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_cand, hSJ, hmin_in_S, hrep⟩ :=
+    exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd
+      hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+      hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core
+      hTJ hrecord hquot hmin_in_T
+  have hST : S ⊆ T :=
+    representingSubset_subset_of_dvd_recombinationCandidate
+      hcore_ne hcore_monic hprecision hpartition hTJ hf_irr
+      hf_dvd_target hf_dvd_cand hSJ hrep
+  exact ⟨f, S, hf_irr, hf_dvd_target, hSJ, hmin_in_S, hrep, hST⟩
+
 /-- Algorithm-side packaging for the exhaustive core branch in the form needed
 by UFD arguments over `Polynomial ℤ`.
 

--- a/progress/20260516T114633Z_fd088942.md
+++ b/progress/20260516T114633Z_fd088942.md
@@ -1,0 +1,54 @@
+# 20260516T114633Z fd088942 — feature
+
+## Accomplished
+
+Closed #4395: added
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd`
+to `HexBerlekampZassenhausMathlib/Basic.lean`, right after the
+reverse-support packaging theorem
+`exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd`
+(its #4412 prerequisite).
+
+The proof is the thin assembly the issue asked for:
+
+- apply `exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd`
+  at `i := J.min' hne` using `hmin_in_T` to discharge `i ∈ T`,
+  obtaining `f` with `f ∣ recombinationCandidate d T` and
+  `J.min' hne ∈ S`;
+- chain through the forward-support field
+  `representingSubset_subset_of_dvd_recombinationCandidate` to derive
+  `S ⊆ T`;
+- repackage as the cover-at-min tuple the prefix-none assembler in
+  #4367 expects.
+
+The hypothesis list is the union of what the coverage theorem
+demands (`hd_modulus`, `hd_liftedFactor_monic`,
+`hd_liftedFactor_natDegree_pos`, `htarget_dvd_core`) and what the
+issue's suggested shape stipulated (`hne`, `hmin_in_T`).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` — green.
+- `lake build HexBerlekampZassenhausMathlib` — green.
+- `python3 scripts/check_dag.py` — green.
+- `git diff --check` — clean.
+- No new `axiom`, `native_decide`, `TODO`, `FIXME`, or
+  theorem-level `sorry` introduced (file `sorry` count stays at 2,
+  both pre-existing at lines 160 and 239).
+
+## Current frontier
+
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd`
+is the packaging piece of the parent #4392. The remaining downstream
+consumer is the prefix-none assembler in #4367; the recursive
+coverage proof (#4301) is the larger context.
+
+## Next step
+
+Hand off to the prefix-none assembler issue (#4367) or the parent
+recursive-coverage issue (#4301); both can now consume the new
+cover-at-min containment theorem directly.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4395

Session: `fd088942-8e19-4668-abce-1358db39248e`

d07acff5 feat: assemble cover-at-min containment from recombination-candidate support (#4395)

🤖 Prepared with Claude Code