### PR TITLE
feat: promote private helpers in HexGramSchmidt/Int.lean for HO-43 Round 2 relocation

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -16,7 +16,7 @@ namespace Hex
 namespace GramSchmidt
 
 /-- Promote an index into a shorter prefix to the ambient matrix height. -/
-private def liftFinLE (i : Fin k) (hk : k ≤ n) : Fin n :=
+def liftFinLE (i : Fin k) (hk : k ≤ n) : Fin n :=
   ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
 
 /-- Leading principal Gram matrix of the first `k` rows of an integer basis. -/
@@ -97,7 +97,7 @@ private def bareissDiagNat (data : Matrix.BareissData n) (r : Nat) (hr : r < n) 
 elimination pass over the full Gram matrix. This helper is only used for Gram
 matrices: once a leading row prefix is singular, every larger leading prefix is
 also singular, so all later leading determinants are zero. -/
-private def gramDetVecEntry (data : Matrix.BareissData n) (k : Fin (n + 1)) : Nat :=
+def gramDetVecEntry (data : Matrix.BareissData n) (k : Fin (n + 1)) : Nat :=
   match hk : k.val with
   | 0 => 1
   | r + 1 =>
@@ -119,7 +119,7 @@ private theorem gramDetVecEntry_eq_zero_of_singularStep_lt
 
 /-- Specialization of the encoded zero-tail fact to the no-pivot executable
 data used by the Gram determinant vector pass. -/
-private theorem gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt
+theorem gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt
     (b : Matrix Int n m) (s r : Nat) (hr : r < n)
     (hsing : (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).singularStep = some s)
     (hs : s < r + 1) :
@@ -157,7 +157,7 @@ private theorem getArrayEntry_gramRows (b : Matrix Int n m) (i j : Fin n) :
     getArrayEntry (gramRows b) i.val j.val = (Matrix.gramMatrix b)[i][j] := by
   simp [getArrayEntry, gramRows, Matrix.gramMatrix, Matrix.dot, Matrix.ofFn]
 
-private def rowsToMatrix (rows : Array (Array Int)) (n : Nat) : Matrix Int n n :=
+def rowsToMatrix (rows : Array (Array Int)) (n : Nat) : Matrix Int n n :=
   Matrix.ofFn fun i j => getArrayEntry rows i.val j.val
 
 private theorem rowsToMatrix_gramRows (b : Matrix Int n m) :
@@ -1682,7 +1682,7 @@ private theorem noPivotLoop_id_at_done
 /-- Once the no-pivot Bareiss loop has marked the current step singular
 (`state.singularStep = some state.step` with a zero pivot at that step),
 any further fuel is a no-op. -/
-private theorem noPivotLoop_id_at_singular_fixedpoint
+theorem noPivotLoop_id_at_singular_fixedpoint
     {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)][(⟨state.step, Nat.lt_of_succ_lt hDone⟩ : Fin n)] = 0)
@@ -1701,7 +1701,7 @@ private theorem noPivotLoop_id_at_singular_fixedpoint
 
 /-- Fuel composition for the no-pivot Bareiss loop: running `a + b` units of
 fuel from `state` equals running `b` more units after `a` initial units. -/
-private theorem noPivotLoop_add
+theorem noPivotLoop_add
     {n : Nat} (a b : Nat) (state : Matrix.BareissState n) :
     Matrix.noPivotLoop (a + b) state =
       Matrix.noPivotLoop b (Matrix.noPivotLoop a state) := by
@@ -1768,7 +1768,7 @@ private theorem noPivotLoop_add
 step, the result has either no singular step, or it has a singular step
 that matches the current `step` field together with a zero pivot at that
 position. -/
-private theorem noPivotLoop_singular_inv
+theorem noPivotLoop_singular_inv
     {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
     (h_init : state.singularStep = none) :
     (Matrix.noPivotLoop fuel state).singularStep = none ∨
@@ -2900,7 +2900,7 @@ private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
 
 /-- The no-pivot Bareiss pass over the full Gram matrix records the same
 leading-prefix determinant as the public `gramDet` API at every vector slot. -/
-private theorem gramDetVecEntry_eq_gramDet
+theorem gramDetVecEntry_eq_gramDet
     (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
     gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
         ⟨k, Nat.lt_succ_of_le hk⟩ =

--- a/progress/20260516T121617Z_4ce0aefb.md
+++ b/progress/20260516T121617Z_4ce0aefb.md
@@ -1,0 +1,45 @@
+# 2026-05-16T12:16Z — #4499 private-helper promotion (HO-43 Round 2 prereq)
+
+## Accomplished
+
+Claimed #4485 (HO-43 Round 2 cluster relocation), scoped the relocation
+closure, decomposed into #4499 (this issue) and #4500 (the actual
+relocation), then executed #4499.
+
+Closure scoping: the relocation pulls in ~1850 lines across
+`HexGramSchmidt/Int.lean` lines 2927-2948, 2986-4521, 4875-4988,
+5570-5760, and `HexGramSchmidt/Update.lean` lines 226-275. An initial
+attempt at the move surfaced cascading `private`-accessibility errors:
+five private helpers in core (`liftFinLE`, `rowsToMatrix`,
+`gramDetVecEntry_eq_gramDet`, `noPivotLoop_singular_inv`,
+`gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt`) are reached by the
+moved theorems, and three more (`gramDetVecEntry`, `noPivotLoop_add`,
+`noPivotLoop_id_at_singular_fixedpoint`) surfaced under audit.
+
+A bash-based audit confirmed exactly eight `private` declarations outside
+the closure are referenced from inside it. Promoted each by removing the
+`private` keyword on the declaration; left every other `private` decl
+intact. Build passes (`lake build HexGramSchmidt HexGramSchmidtMathlib
+HexLLL HexLLLMathlib`); `scripts/check_dag.py` clean; sorry count
+unchanged at 82; no axioms, no `native_decide`, no TODO/FIXME in the
+affected files; `git diff --check` clean.
+
+## Current frontier
+
+- #4485 decomposed into #4499 + #4500, parent skipped with breadcrumb
+  comment.
+- #4499 promotion executed and ready for PR. Build green.
+- #4500 (the relocation itself) is blocked-on-#4499; after this PR lands
+  and `coordination check-blocked` unblocks it, a fresh worker session
+  can claim and execute the move.
+
+## Next step
+
+Create the PR for #4499. Then a future session claims #4500 and performs
+the actual cluster relocation, using the audit notes in #4500's body and
+the eight now-non-private helpers exposed by this PR.
+
+## Blockers
+
+None. #4500 cannot proceed until #4499's PR merges, which is its own
+dependency, not a blocker for this session.


### PR DESCRIPTION
Closes #4499

Session: `4ce0aefb-bb1a-4b8a-bb0d-86e798c61c17`

0066271d feat: promote 8 private helpers in HexGramSchmidt/Int.lean for HO-43 Round 2 relocation (#4499)

🤖 Prepared with Claude Code