### PR TITLE
HexBZ Mathlib: review #4505 mask-level subsetSplits_prefix_exists_bit_diff_aux helper

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -2945,17 +2945,10 @@ private theorem subsetSplits_prefix_exists_bit_diff_aux
             -- Shape: split_S = (tailSel_S, x :: tailRest_S). Show split_S ∉ L_true.
             have hsplitS_notin_Ltrue : (tailSel_S, x :: tailRest_S) ∉ L_true := by
               intro h
-              obtain ⟨⟨a, b⟩, hab, hab_eq⟩ := List.mem_map.mp h
+              obtain ⟨⟨a, _⟩, hab, hab_eq⟩ := List.mem_map.mp h
               simp only [Prod.mk.injEq] at hab_eq
               obtain ⟨ha, _⟩ := hab_eq
-              have hx_in_tailSel_S : x ∈ tailSel_S := ha ▸ List.mem_cons_self
-              -- tailSel_S = (xs'.zip msS).filterMap selected; selected entries ⊆ xs'.
-              rw [htailSel_S_def, List.mem_filterMap] at hx_in_tailSel_S
-              obtain ⟨⟨a', b'⟩, hpair_mem, hpair_eq⟩ := hx_in_tailSel_S
-              have hax' : a' ∈ xs' := (List.of_mem_zip hpair_mem).1
-              cases b' with
-              | true => simp at hpair_eq; exact hx_notin (hpair_eq ▸ hax')
-              | false => simp at hpair_eq
+              exact hx_notin_split_sel htailSplit_S_mem (ha ▸ List.mem_cons_self)
             cases bT with
             | false =>
               -- (false, false): both splits in L_false.
@@ -3060,21 +3053,13 @@ private theorem subsetSplits_prefix_exists_bit_diff_aux
             | true =>
               -- (true, true): both splits in L_true. Recurse.
               rw [eval_sel_true, eval_rest_true] at hT_in_pre
-              -- Shape: split_S = (x :: tailSel_S, tailRest_S). Show split_S ∉ L_false.
-              have hsplitS_notin_Lfalse : (x :: tailSel_S, tailRest_S) ∉ L_false := by
-                intro h
-                obtain ⟨⟨a, b⟩, hab, hab_eq⟩ := List.mem_map.mp h
-                simp only [Prod.mk.injEq] at hab_eq
-                obtain ⟨ha, _⟩ := hab_eq
-                have hx_in_a : x ∈ a := ha ▸ List.mem_cons_self
-                exact hx_notin_split_sel hab hx_in_a
+              -- Shape: split_T = (x :: tailSel_T, tailRest_T). Show split_T ∉ L_false.
               have hsplitT_notin_Lfalse : (x :: tailSel_T, tailRest_T) ∉ L_false := by
                 intro h
-                obtain ⟨⟨a, b⟩, hab, hab_eq⟩ := List.mem_map.mp h
+                obtain ⟨⟨a, _⟩, hab, hab_eq⟩ := List.mem_map.mp h
                 simp only [Prod.mk.injEq] at hab_eq
                 obtain ⟨ha, _⟩ := hab_eq
-                have hx_in_a : x ∈ a := ha ▸ List.mem_cons_self
-                exact hx_notin_split_sel hab hx_in_a
+                exact hx_notin_split_sel hab (ha ▸ List.mem_cons_self)
               -- Decompose hsplits.
               rcases (List.append_eq_append_iff).mp hsplits with
                 ⟨e, hpre_eq, hLt_eq⟩ | ⟨e, hLf_eq, _hsuff_eq⟩

--- a/progress/20260516T160246Z_36daa9f1.md
+++ b/progress/20260516T160246Z_36daa9f1.md
@@ -1,0 +1,61 @@
+# 2026-05-16T16:02 UTC — Review #4509 (mask-level subsetSplits_prefix_exists_bit_diff_aux)
+
+## Accomplished
+
+Reviewed `subsetSplits_prefix_exists_bit_diff_aux` at
+`HexBerlekampZassenhausMathlib/Basic.lean:2813` against all five deliverables
+of #4509.
+
+- (D1) Confirmed `xs.Nodup` is load-bearing: the `x ∉ xs'` fact extracted
+  via `List.nodup_cons.mp hxs_nodup` flows into the `hx_notin_split_sel` /
+  `hx_notin_split_rest` in-proof helpers (lines 2891 / 2903), which are
+  used in the `(false, false)`, `(false, true)`, and `(true, true)` cases.
+  The `(false, true)` impossibility specifically routes through
+  `hx_notin_split_rest` to rule out matching `L_true`. The IH also
+  consumes `(List.nodup_cons.mp hxs_nodup).2`.
+- (D2) Case analysis on `(mask_S.head, mask_T.head)` is fully explicit
+  with `cases bS / bT`. Both `nil`-mask cases are ruled out by length.
+  No `omega` / `decide` is used to mask a missed sub-case — the three
+  `omega` calls are pure arithmetic (`pre = []` in the nil base case
+  and `i' + 1 < length + 1` in the two recursion sites).
+- (D3) Recursive cases lift the `L_true` / `L_false` structure equation
+  back to `Hex.subsetSplits xs'` via `List.map_eq_append_iff` correctly.
+  The `(tailSel_T, tailRest_T) ∈ preIdx` re-derivation strips the
+  cons-head `x` from L_false / L_true entries. Index bump `i ↦ i + 1`
+  matches the `(b :: msS)` / `(b :: msT)` head extension via
+  `List.getElem_cons_succ`.
+- (D4) No `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME` in
+  the helper. File sorry count unchanged at 2 (lines 162, 241,
+  both pre-existing on origin/main).
+- (D5) Two simplifications applied:
+  1. The `(false, false)` `hsplitS_notin_Ltrue` proof manually expanded
+     `htailSel_S_def` and inspected the filterMap. Replaced with the
+     existing `hx_notin_split_sel htailSplit_S_mem` (-7 lines), matching
+     the cleaner pattern used in `(false, true)` and `(true, true)`.
+  2. In the `(true, true)` case, `hsplitS_notin_Lfalse` (7 lines) was
+     declared but never used (only `hsplitT_notin_Lfalse` is referenced
+     in both rcases branches). Removed as dead code.
+
+Net diff: -20 / +5 lines on `HexBerlekampZassenhausMathlib/Basic.lean`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` → clean.
+- `lake build HexBerlekampZassenhausMathlib` → clean.
+- `python3 scripts/check_dag.py` → clean.
+- `git diff --check` → clean.
+- Sorry count: 2 → 2 (unchanged from origin/main).
+
+## Current frontier
+
+Helper is sound and minimal. Open consumer #4508 (`liftedSubsetSplit_
+prefix_exists_mem_sdiff_of_matches`) can build on it as-is; the
+signature is unchanged so no follow-up comment is needed on #4508.
+
+## Next step
+
+PR up; the wrapper at #4508 picks up from here.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4509

Session: `36daa9f1-06dc-4373-a8b5-b96536e315cb`

9c2002e2 refactor: tighten subsetSplits_prefix_exists_bit_diff_aux (#4509)

🤖 Prepared with Claude Code