### PR TITLE
refactor: trim unused returns from exists_tail_indices (#4517)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3166,17 +3166,15 @@ theorem liftedSubsetSplit_prefix_mem_of_matches
 
 Given that `localFactors` matches `J` and `J` is nonempty, `localFactors`
 decomposes as `liftedFactor d (J.min' hne) :: ys.map (liftedFactor d)` for
-some `ys` that is `Nodup`, missing `J.min' hne`, and contained in `J`. For
-any `S ⊆ J` containing `J.min' hne`, the `(S, J \ S)` partition has the
-canonical mask form indexed by `ys.map (· ∈ S)`. -/
+some `ys` contained in `J`. For any `S ⊆ J` containing `J.min' hne`, the
+`(S, J \ S)` partition has the canonical mask form indexed by
+`ys.map (· ∈ S)`. -/
 private theorem LiftedFactorListMatches.exists_tail_indices
     {d : Hex.LiftData} {J : LiftedFactorSubset d}
     {localFactors : List Hex.ZPoly}
     (hmatches : LiftedFactorListMatches d J localFactors)
     (hne : J.Nonempty) :
     ∃ (ys : List (LiftedFactorIndex d)),
-      ys.Nodup ∧
-      J.min' hne ∉ ys ∧
       (∀ y ∈ ys, y ∈ J) ∧
       localFactors = liftedFactor d (J.min' hne) :: ys.map (liftedFactor d) ∧
       ∀ (S : LiftedFactorSubset d), S ⊆ J → J.min' hne ∈ S →
@@ -3203,15 +3201,7 @@ private theorem LiftedFactorListMatches.exists_tail_indices
         rw [hxsIdx_case] at hxsIdx_head
         simp only [List.head?_cons, Option.some.injEq] at hxsIdx_head
         exact ⟨ys, by rw [hxsIdx_head]⟩
-  refine ⟨ys, ?_, ?_, ?_, ?_, ?_⟩
-  · -- Nodup ys
-    have hxsIdx_nodup : xsIdx.Nodup := (List.nodup_finRange _).filter _
-    rw [hxsIdx_eq] at hxsIdx_nodup
-    exact (List.nodup_cons.mp hxsIdx_nodup).2
-  · -- J.min' hne ∉ ys
-    have hxsIdx_nodup : xsIdx.Nodup := (List.nodup_finRange _).filter _
-    rw [hxsIdx_eq] at hxsIdx_nodup
-    exact (List.nodup_cons.mp hxsIdx_nodup).1
+  refine ⟨ys, ?_, ?_, ?_⟩
   · -- ∀ y ∈ ys, y ∈ J
     intro y hy
     have hy_xsIdx : y ∈ xsIdx := by rw [hxsIdx_eq]; exact List.mem_cons_of_mem _ hy
@@ -3312,7 +3302,7 @@ theorem liftedSubsetSplit_prefix_exists_mem_sdiff_of_matches
     liftedSubsetSplit_prefix_mem_of_matches hmatches hne hsplits hsplit
   refine ⟨T, hTJ, hmin_in_T, hsplit_eq, ?_⟩
   -- Step 2: decompose localFactors and obtain canonical mask equations.
-  obtain ⟨ys, hys_nodup, hmin_notin_ys, hys_in_J, hloc_eq, hS_eqs⟩ :=
+  obtain ⟨ys, hys_in_J, hloc_eq, hS_eqs⟩ :=
     hmatches.exists_tail_indices hne
   obtain ⟨hS_sel_cons, hS_rest_eq⟩ := hS_eqs S hSJ hmin
   obtain ⟨hT_sel_cons, hT_rest_eq⟩ := hS_eqs T hTJ hmin_in_T

--- a/progress/20260516T163927Z_b538989a.md
+++ b/progress/20260516T163927Z_b538989a.md
@@ -1,0 +1,69 @@
+# Review #4517 — `liftedSubsetSplit_prefix_exists_mem_sdiff_of_matches`
+
+## Accomplished
+
+Reviewed the wrapper `liftedSubsetSplit_prefix_exists_mem_sdiff_of_matches`
+and its private helper `LiftedFactorListMatches.exists_tail_indices` at
+`HexBerlekampZassenhausMathlib/Basic.lean:3172-3418`, plus the chained
+`liftedSubsetSplit_prefix_mem_of_matches` and
+`subsetSplits_prefix_exists_bit_diff_aux`.
+
+Findings:
+
+- **Wrapper hypotheses.** All seven hypotheses (`hlocal_nodup`,
+  `hmatches`, `hSJ`, `hne`, `hmin`, `hsplits`, `hsplit`) are consumed.
+  `hlocal_nodup` is genuinely necessary: `hmatches` only gives that
+  `localFactors` is the `liftedFactor d`-image of a `Nodup` index list,
+  but `liftedFactor d` needs a Hensel-coprimality fact to be injective,
+  so `localFactors.Nodup` cannot be derived from `hmatches` alone.
+
+- **Helper API surface.** Of the six fields the helper returned, two
+  (`ys.Nodup` and `J.min' hne ∉ ys`) were never consumed by the wrapper.
+  Trimmed both — the helper is `private` with a single consumer and
+  `hlocal_nodup` already supplies the tail-`Nodup` fact the wrapper
+  needs at line 3328. The other four fields (`∀ y ∈ ys, y ∈ J`,
+  the head-cons equation, and the per-`S` mask equations) are all used,
+  with the per-`S` mask equations invoked twice (once for `S`, once for
+  the recovered `T`) as the docstring claims. Diff: `-14 / +1`.
+
+- **No new sorry / axiom / native_decide / TODO.** The two pre-existing
+  `sorry`s at lines 160 and 239 are unchanged.
+
+- **Proof shape.** The wrapper proceeds via `List.map_eq_append_iff`,
+  case-splits on `suffIdx`, closes `nil` by `List.cons_ne_nil`, threads
+  through `subsetSplits_prefix_exists_bit_diff_aux`, and translates `i'`
+  back through `ys[i']`. No `omega` or `decide` papering over missing
+  cases.
+
+- **Docstring accuracy.** Both docstrings name role, consumer (#4367),
+  and the Nodup-from-Hensel-coprimality rationale. The "canonical mask
+  form indexed by `ys.map (· ∈ S)`" claim matches the returned
+  equations.
+
+- **Naming consistency.** `_prefix_exists_mem_sdiff_of_matches` parallels
+  `_prefix_mem_of_matches`, and `LiftedFactorListMatches.exists_tail_indices`
+  uses the namespaced method form for the dot-call site.
+
+Verification:
+
+- `lake build HexBerlekampZassenhausMathlib` clean before and after.
+- `python3 scripts/check_dag.py` exit 0.
+- `git diff --check` exit 0.
+- Sorry count unchanged from `origin/main` (2 in `Basic.lean` at lines
+  160 / 239).
+
+## Current frontier
+
+Wrapper #4511 and its cluster (mask-level helper #4505, prefix-mem
+companion) form the prefix-side discharge for the prefix-none case of
+the recombination-search assembler (#4367, PR #4516 in flight). No
+further review-side work in this cluster.
+
+## Next step
+
+Land the polish PR and close #4517. The downstream BZ Mathlib chain
+(#4367 → #4301 → #4274 → #4006 → ...) is unaffected by this trim.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4517

Session: `b538989a-9d55-4cea-adf8-cabc038c7650`

882cb566 refactor: trim unused returns from exists_tail_indices (#4517 review)

🤖 Prepared with Claude Code