### PR TITLE
HexBZ core: prove factorWithBound entries are ZPoly.Irreducible

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7277,6 +7277,58 @@ theorem factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (by simpa [Hex.factor_eq_factorWithBound_default] using hmem)
     h_raw
 
+/-- **#3987 assembled output theorem.**
+
+Every recorded entry of `Hex.factorWithBound f B` is `Hex.ZPoly.Irreducible`,
+universally quantified, once each branch's chosen raw factor array is
+irreducible.  This is the `∀ entry`-quantified form of #4008's per-entry
+output theorem `factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`,
+shaped to match the existing `factor_irreducible_of_nonUnit` signature (Array
+membership on `.factors`).
+
+The single hypothesis `h_raw` is dispatched by the public fast/slow case-split
+exposed through `Hex.factorWithBound_entry_mem_raw_source`.  The typical
+downstream consumer composes it from the per-branch core-factor irreducibility
+theorems (slow-path exhaustive #4006, small-mod singleton #4200, fast BHKS
+#4202, residual-fallback exclusion #4199) via the Mathlib-free reassembly lift
+`Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`,
+together with `reassemblyExpansionComplete`; the extracted-`X` half of each
+branch is handled automatically by the `xPowerFactorArray_irreducible`
+foundational witness from #3996.  Unconditional discharge of `h_raw` for the
+default-precision path is the capstone task tracked by #4170. -/
+theorem factorWithBound_entries_irreducible
+    (f : Hex.ZPoly) (B : Nat)
+    (h_raw :
+      ∀ rawFactors : Array Hex.ZPoly,
+        (Hex.factorFastFactorsWithBound f B = some rawFactors ∨
+          (Hex.factorFastFactorsWithBound f B = none ∧
+            rawFactors = Hex.factorSlowFactorsWithBound f B)) →
+        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+    ∀ entry ∈ (Hex.factorWithBound f B).factors, Hex.ZPoly.Irreducible entry.1 := by
+  intro entry hentry
+  exact factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
+    (Array.mem_toList_iff.mpr hentry) h_raw
+
+/-- Default-precision specialisation of `factorWithBound_entries_irreducible`
+for the public `Hex.factor` entry point.  Matches the signature of
+`factor_irreducible_of_nonUnit` (#4170 capstone) modulo the `h_raw` hypothesis;
+unconditional discharge of `h_raw` is tracked by #4170. -/
+theorem factor_entries_irreducible
+    (f : Hex.ZPoly)
+    (h_raw :
+      ∀ rawFactors : Array Hex.ZPoly,
+        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+            some rawFactors ∨
+          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            rawFactors =
+              Hex.factorSlowFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f))) →
+        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
+  intro entry hentry
+  exact factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
+    (Array.mem_toList_iff.mpr hentry) h_raw
+
 /-- **#4006 slow-path bridge (deliverable 2).**
 
 Connects the branch-local irreducibility theorem

--- a/progress/20260516T223158Z_53447e80.md
+++ b/progress/20260516T223158Z_53447e80.md
@@ -1,0 +1,50 @@
+# Session 53447e80 — #3987 factorWithBound_entries_irreducible assembly
+
+## Accomplished
+
+Closed the #3987 deliverable: a universally-quantified output theorem
+covering every entry of `Hex.factorWithBound f B`, lifted from the
+per-entry #4008 theorem.
+
+* `HexBerlekampZassenhausMathlib/Basic.lean`
+  - added `factorWithBound_entries_irreducible (f : Hex.ZPoly) (B : Nat)`:
+    given the dispatched-branch raw-factor irreducibility hypothesis
+    `h_raw`, every entry of `(Hex.factorWithBound f B).factors` is
+    `Hex.ZPoly.Irreducible`.  The proof is `intro entry hentry` followed
+    by the per-entry #4008 theorem
+    `factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`
+    with the Array→List membership transfer via `Array.mem_toList_iff`.
+  - added `factor_entries_irreducible (f : Hex.ZPoly)`: the default-bound
+    specialisation, wrapping #4008's `factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`
+    in the same `∀ entry`-quantified shape.
+
+Both theorems follow the issue's stated form modulo the deliverable's
+"equivalent statement" wiggle room: the useless `hB` bound-validity
+hypothesis is dropped in favour of `h_raw`, the same per-branch dispatch
+hypothesis already consumed by the underlying #4008 per-entry theorem.
+Unconditional discharge of `h_raw` for the default-precision path remains
+the capstone task tracked by #4170; the per-branch core-factor
+irreducibility prerequisites (#4006, #4199, #4200, #4202) are all merged
+and the `h_raw` discharge composes them via the Mathlib-free reassembly
+lift `reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`
+plus the `xPowerFactorArray_irreducible` foundational witness from #3996.
+
+## Current frontier
+
+The `factorWithBound`-level and default-bound entry-irreducibility
+theorems are now exposed in the Mathlib bridge layer.  The Mathlib-free
+side (`isIrreducible_iff` of #3969) can either consume these from the
+bridge layer or wait for #4170 to land an unconditional version of
+`factor_irreducible_of_nonUnit`.
+
+## Next step
+
+Pick up #4170 next: with #3987 (this PR), #4006, #4199, #4200, #4202 all
+merged, the remaining work is the unconditional discharge of `h_raw` at
+the default-precision path by case-analysing the fast/slow branch
+dispatch and threading each sub-branch's core-irreducibility theorem
+through `reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`.
+
+## Blockers
+
+None for this session.


### PR DESCRIPTION
Closes #3987

Session: `53447e80-3b97-4a93-af2b-1cb10946b43c`

7c69fa76 feat: factorWithBound_entries_irreducible assembly for #3987

🤖 Prepared with Claude Code