### PR TITLE
HexBerlekampMathlib + HexBerlekampZassenhausMathlib: Nodup bridge wrappers (decomposition of #4528)

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -290,6 +290,39 @@ theorem irreducible_of_mem_berlekampFactor
   sorry
 
 /--
+Bridge-surface re-export of the Mathlib-free Nodup property of the executable
+Berlekamp factor list of a monic square-free input.  Discharged from the
+polymorphic abstract loop invariant
+`Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared` plus the
+squareness-implies-unit chain `isUnitPolynomial_of_squareFree_of_squared_dvd`,
+matching the proof of the section-level `Hex.Berlekamp.berlekampFactor_factors_nodup`
+in `HexBerlekamp/RabinSoundness.lean`.  Stated polymorphic over the field
+instance so that downstream Mathlib-bridge consumers (e.g.
+`factorsModP_nodup_of_factorsModPBerlekampForm`) can apply it to the
+existentially-bound field witness carried by `factorsModPBerlekampForm`.
+-/
+theorem berlekampFactor_factors_nodup
+    (f : Hex.FpPoly p) (hmonic : Hex.DensePoly.Monic f)
+    [Lean.Grind.Field (Hex.ZMod64 p)] [Hex.ZMod64.PrimeModulus p]
+    (hsquareFree : Hex.DensePoly.gcd f (Hex.DensePoly.derivative f) = 1) :
+    (Hex.Berlekamp.berlekampFactor f hmonic).factors.Nodup := by
+  apply Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared
+  intro g hgg hpos
+  have hunit : Hex.Berlekamp.isUnitPolynomial g = true :=
+    Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsquareFree hgg
+  have hdeg : Hex.DensePoly.degree? g = some 0 := by
+    unfold Hex.Berlekamp.isUnitPolynomial at hunit
+    cases hd : Hex.DensePoly.degree? g with
+    | none => rw [hd] at hunit; simp at hunit
+    | some k =>
+        rw [hd] at hunit
+        cases k with
+        | zero => rfl
+        | succ _ => simp at hunit
+  rw [hdeg] at hpos
+  simp at hpos
+
+/--
 If executable Berlekamp factorization cannot split a monic square-free input,
 then the input itself is irreducible after transport to Mathlib.
 

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1577,7 +1577,7 @@ output for the monic modular image used by prime selection.  Phrased as an
 existential bundling the nonzero-image and field witnesses so that it
 threads through the executable prime-selection fold.
 -/
-private def factorsModPBerlekampForm
+def factorsModPBerlekampForm
     (f : ZPoly) (data : PrimeChoiceData) : Prop :=
   letI := data.bounds
   ∃ (hprime : Nat.Prime data.p)

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3967,6 +3967,99 @@ theorem henselLiftData_liftedFactor_injective
     (List.Nodup.getElem_inj_iff hfactorsModP_nodup).mp hlist_eq
   exact Fin.ext hidx_eq
 
+/-- `choosePrimeData`-shaped consumer wrapper for the Berlekamp factor `Nodup`
+property: given the `factorsModPBerlekampForm` invariant (which records that
+`primeData.factorsModP` is the Berlekamp factor array of the monic modular
+image of the input) together with a successful `isGoodPrime` check (which
+certifies the modular image is square-free), the stored factor list has no
+duplicates.
+
+Proof: extract the existential witnesses from `factorsModPBerlekampForm` to
+view `data.factorsModP.toList` as the Berlekamp factor list of
+`monicModularImage (modP data.p f)`, then apply the polymorphic abstract
+loop invariant `Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared`.
+The squareness-free hypothesis is discharged by transferring any `g * g`
+divisor through `monicModularImage modP_f ∣ modP_f` (via
+`Hex.FpPoly.dvd_scale_self_of_ne_zero`) and applying
+`Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd` to the
+modular squarefreeness obtained from `Hex.isGoodPrime_squareFreeModP`.
+
+This is the wrapper that lets a Mathlib-bridge consumer of
+`henselLiftData_liftedFactor_injective_of_choosePrimeData` (below) discharge
+the `hfactorsModP_nodup` parameter from the `choosePrimeData?` facts alone,
+without constructing the Berlekamp `Nodup` argument by hand. -/
+theorem factorsModP_nodup_of_factorsModPBerlekampForm
+    (f : Hex.ZPoly) (data : Hex.PrimeChoiceData)
+    (hform : Hex.factorsModPBerlekampForm f data)
+    (hgood :
+      letI := data.bounds
+      Hex.isGoodPrime f data.p = true) :
+    data.factorsModP.toList.Nodup := by
+  letI : Hex.ZMod64.Bounds data.p := data.bounds
+  obtain ⟨hprime, hzero, hfield, heq⟩ := hform
+  letI : Hex.ZMod64.PrimeModulus data.p := Hex.ZMod64.primeModulusOfPrime hprime
+  -- Square-free precondition on the modular image, extracted from `isGoodPrime`.
+  have hsf :
+      Hex.DensePoly.gcd (Hex.ZPoly.modP data.p f)
+          (Hex.DensePoly.derivative (Hex.ZPoly.modP data.p f)) = 1 :=
+    Hex.isGoodPrime_squareFreeModP f data.p hgood
+  -- `monicModularImage modP_f ∣ modP_f`: dividing by the leading coefficient
+  -- scales by a nonzero element, and a unit-scaled polynomial divides the
+  -- original via `dvd_scale_self_of_ne_zero`.
+  have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size := by
+    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP data.p f).size with hsize_zero | hsize_pos
+    · exfalso
+      have hiszero : (Hex.ZPoly.modP data.p f).isZero = true := by
+        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
+          Array.isEmpty_iff_size_eq_zero] using hsize_zero
+      rw [hiszero] at hzero
+      contradiction
+    · exact hsize_pos
+  have hlead_ne :
+      Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f) ≠
+        (0 : Hex.ZMod64 data.p) := by
+    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred (Hex.ZPoly.modP data.p f) hmod_size_pos]
+    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size
+      (Hex.ZPoly.modP data.p f) hmod_size_pos
+  have hinv_ne :
+      (Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f))⁻¹ ≠
+        (0 : Hex.ZMod64 data.p) :=
+    Hex.ZMod64.inv_ne_zero_of_prime hprime hlead_ne
+  have hmonicImage_dvd :
+      Hex.monicModularImage (Hex.ZPoly.modP data.p f) ∣
+        Hex.ZPoly.modP data.p f := by
+    unfold Hex.monicModularImage
+    simp only [hzero, Bool.false_eq_true, ↓reduceIte]
+    exact Hex.FpPoly.dvd_scale_self_of_ne_zero hinv_ne (Hex.ZPoly.modP data.p f)
+  -- Berlekamp factor list of the monic modular image has no duplicates.
+  have hNodup :
+      (@Hex.Berlekamp.berlekampFactor data.p data.bounds
+        (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+        (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+        hfield).factors.Nodup := by
+    apply Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared
+    intro g hgg hpos
+    have hg_dvd_mod : g * g ∣ Hex.ZPoly.modP data.p f := by
+      rcases hgg with ⟨r, hr⟩
+      rcases hmonicImage_dvd with ⟨s, hs⟩
+      exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+    have hunit : Hex.Berlekamp.isUnitPolynomial g = true :=
+      Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsf hg_dvd_mod
+    have hdeg : Hex.DensePoly.degree? g = some 0 := by
+      unfold Hex.Berlekamp.isUnitPolynomial at hunit
+      cases hd : Hex.DensePoly.degree? g with
+      | none => rw [hd] at hunit; simp at hunit
+      | some k =>
+          rw [hd] at hunit
+          cases k with
+          | zero => rfl
+          | succ _ => simp at hunit
+    rw [hdeg] at hpos
+    simp at hpos
+  -- Transport `Nodup` from the Berlekamp factor list to `data.factorsModP.toList`.
+  rw [heq]
+  simpa using hNodup
+
 /-- Composed convenience wrapper: combines
 `Hex.ZPoly.QuadraticMultifactorLiftInvariant_of_choosePrimeData` with
 `henselLiftData_liftedFactor_injective` so that a Mathlib-bridge consumer can
@@ -3981,11 +4074,11 @@ Consumed by
 `exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence` (#4274).
 
 The `factorsModP.toList.Nodup` hypothesis is the load-bearing ingredient;
-it is currently consumer-supplied because the underlying Berlekamp factor
-output `Nodup` property is not yet exposed as a `choosePrimeData` invariant
-(see follow-up issue for the discharge). The companion monicness umbrella
-`henselLiftData_liftedFactor_monic_of_choosePrimeData` lives one theorem
-above. -/
+discharge from the `choosePrimeData?` facts is provided by
+`factorsModP_nodup_of_factorsModPBerlekampForm` above (combined with
+`Hex.choosePrimeData?_factorsModP_berlekamp_form`).  The companion monicness
+umbrella `henselLiftData_liftedFactor_monic_of_choosePrimeData` lives one
+theorem above. -/
 theorem henselLiftData_liftedFactor_injective_of_choosePrimeData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hcore_monic : Hex.DensePoly.Monic core)

--- a/progress/20260516T233725Z_8e36aa64.md
+++ b/progress/20260516T233725Z_8e36aa64.md
@@ -1,0 +1,79 @@
+# 20260516T233725Z — feature session 8e36aa64 (#4530)
+
+## Accomplished
+
+Discharged both deliverables of #4530 (Nodup bridge wrappers).
+
+### Deliverable 1 — `berlekampFactor_factors_nodup`
+`HexBerlekampMathlib/Basic.lean`, adjacent to
+`irreducible_of_mem_berlekampFactor`.  Polymorphic over the
+`Lean.Grind.Field` instance so that downstream Mathlib-bridge consumers
+can apply it to an existentially-bound field witness (such as the one
+carried by `factorsModPBerlekampForm`).  Discharged by combining the
+polymorphic `Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared`
+with `Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd`,
+matching the proof structure of the Mathlib-free
+`Hex.Berlekamp.berlekampFactor_factors_nodup`.
+
+The issue body recommended a one-line re-export of the Mathlib-free
+theorem, but that approach fails: the Mathlib-free
+`berlekampFactor_factors_nodup` lives inside a section with
+`variable [ZMod64.PrimeModulus p]` and so its conclusion is locked to
+the `zmod64FieldOfPrime` field instance synthesised from
+`PrimeModulus`.  An explicit `[Lean.Grind.Field]` argument on the
+bridge cannot match that conclusion, producing the type mismatch:
+```
+has type (... Hex.zmod64FieldOfPrime).factors.Nodup
+expected (... inst✝¹).factors.Nodup
+```
+Inlining the underlying polymorphic theorem
+`berlekampFactor_factors_nodup_of_no_squared` keeps the bridge
+polymorphic over the field instance.
+
+### Deliverable 2 — `factorsModP_nodup_of_factorsModPBerlekampForm`
+`HexBerlekampZassenhausMathlib/Basic.lean`, immediately above
+`henselLiftData_liftedFactor_injective_of_choosePrimeData`.
+
+Required dropping `private` on `Hex.factorsModPBerlekampForm`
+(`HexBerlekampZassenhaus/Basic.lean:1580`) so the wrapper can name the
+invariant.  The internal helper theorems referencing the def remain
+private — only the def itself is exposed.
+
+The proof additionally needed a step the issue body did not flag:
+`factorsModPBerlekampForm` records that `data.factorsModP` is the
+Berlekamp factor array of `Hex.monicModularImage (modP data.p f)`,
+not of `modP data.p f` itself.  `Hex.isGoodPrime_squareFreeModP`
+discharges square-freeness of `modP data.p f`, but the Nodup
+hypothesis needs square-freeness of the monic image.  The proof
+bridges this by `Hex.FpPoly.dvd_scale_self_of_ne_zero`
+(`monicModularImage modP_f ∣ modP_f` because `monicModularImage` is
+multiplication by the nonzero unit `(leadingCoeff modP_f)⁻¹`),
+transferring any squared divisor of the monic image to a squared
+divisor of the modular image, then applying
+`isUnitPolynomial_of_squareFree_of_squared_dvd` to the latter.
+
+## Current frontier
+
+- `lake build HexBerlekampMathlib HexBerlekampZassenhausMathlib HexBerlekampZassenhaus`
+  ✓ (all targets pass)
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` ✓
+- Sorry inventory unchanged: 19 in `HexBerlekampMathlib/Basic.lean`
+  (lines 45, 47, 49, 51, 70, 75, 95, 101, 107, 135, 144, 155, 166,
+  227, 242, 258, 267, 278, 290) and 2 in
+  `HexBerlekampZassenhausMathlib/Basic.lean` (lines 162, 241).
+- No new `axiom`, `native_decide`, `TODO`, `FIXME`.
+
+## Next step
+
+The new wrapper unblocks the follow-up refactor of
+`henselLiftData_liftedFactor_injective_of_choosePrimeData` (and any
+related `choosePrimeData`-shaped consumer) to drop the
+`hfactorsModP_nodup` parameter in favour of constructing it from
+`Hex.choosePrimeData?_factorsModP_berlekamp_form` plus
+`factorsModP_nodup_of_factorsModPBerlekampForm`.  That refactor was
+listed as out of scope for #4530 and remains for a follow-up issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4530

Session: `8e36aa64-a03c-47a6-8fd5-265582cc73d7`

dfe17aa5 feat: Mathlib-bridge Nodup wrappers for berlekampFactor (#4530)

🤖 Prepared with Claude Code