### PR TITLE
HO-1 substrate: assemble fast-path quadratic arm umbrella for factor_irreducible_of_nonUnit

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5642,6 +5642,35 @@ theorem factorWithBound_entry_mem_constant_branch_raw
   simpa only [factorWithBound, factorFastWithBound, hfast, Option.map_some,
     Option.getD_some] using hmem
 
+/-- In the fast-path quadratic integer-root branch, every recorded
+`factorWithBound` entry comes from the normalization reassembly whose core array
+is the `quadraticIntegerRootFactors?` output for the square-free core. This is
+the branch-shape lemma needed by Mathlib-side quadratic-branch irreducibility
+proofs; it leaves the mathematical proof that each core factor is irreducible
+to the bridge layer. The `B > 1` hypothesis is required to enter the quadratic
+dispatch (the `B = 1` arm of `factorFastFactorsWithBound` does not consult
+`quadraticIntegerRootFactors?`). -/
+theorem factorWithBound_entry_mem_quadratic_branch_raw
+    (f : ZPoly) (B : Nat) (entry : ZPoly × Nat)
+    (hB_gt_one : 1 < B)
+    (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    {coreFactors : Array ZPoly}
+    (hquad :
+      quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore
+        = some coreFactors)
+    (hmem : entry ∈ (factorWithBound f B).factors.toList) :
+    ∃ raw ∈
+        (reassemblePolynomialFactors (normalizeForFactor f) coreFactors).toList,
+      entry.1 = normalizeFactorSign raw := by
+  have hfast :
+      factorFastFactorsWithBound f B =
+        some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) := by
+    unfold factorFastFactorsWithBound
+    rw [if_neg hdeg, if_neg (by omega : B ≠ 0), if_neg (by omega : B ≠ 1), hquad]
+  apply factorizationOfFactors_entry_mem_normalized_raw
+  simpa only [factorWithBound, factorFastWithBound, hfast, Option.map_some,
+    Option.getD_some] using hmem
+
 /-- In the fast-path BHKS fast-core success branch, every recorded
 `factorWithBound` entry comes from the normalization reassembly whose core array
 is the successful `factorFastCoreWithBound` output for the chosen prime data.

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7754,6 +7754,230 @@ theorem quadraticIntegerRootFactors?_factor_irreducible_of_ne_residual
         · simp [roots, split, hres_deg] at hquad
   · simp [hdeg] at hquad
 
+/-- The optional final residual of the quadratic integer-root branch is
+irreducible whenever the core is primitive with positive leading coefficient.
+The function's degree filter forces the residual's `degree?.getD 0` to be at
+most `1`; primitivity rules out degree-`0` residuals (which would be non-unit
+constants dividing every coefficient of the primitive core); hence the
+residual, when emitted, has size two and is irreducible by the
+`irreducible_of_size_two_primitive` companion of `_monic`, applied to the
+residual's own primitivity inherited from the product `split.2 *
+polyProduct split.1 = core`. -/
+private theorem quadraticIntegerRootFactors?_residual_irreducible
+    {core : ZPoly} {factors : Array ZPoly}
+    (hcore_pos : 0 < DensePoly.leadingCoeff core)
+    (hcore_primitive : ZPoly.Primitive core)
+    (hquad : quadraticIntegerRootFactors? core = some factors)
+    {factor : ZPoly}
+    (hmem : factor ∈ factors.toList)
+    (hres : factor =
+      (splitIntegerRootFactorsAux core (integerRootCandidates core)
+        (integerRootCandidates core).length).2) :
+    ZPoly.Irreducible factor := by
+  unfold quadraticIntegerRootFactors? at hquad
+  by_cases hdeg : core.degree?.getD 0 = 2
+  · simp only [hdeg, if_true] at hquad
+    let roots := integerRootCandidates core
+    let split := splitIntegerRootFactorsAux core roots roots.length
+    by_cases hsize : split.1.size = 0
+    · simp [roots, split, hsize] at hquad
+    · simp only [roots, split, hsize, if_false] at hquad
+      by_cases hres_one : split.2 = 1
+      · -- split.2 = 1: factor = 1 from hres. But hmem : factor ∈ split.1.toList,
+        -- and every element of split.1 is irreducible.
+        rw [if_pos hres_one] at hquad
+        cases hquad
+        exact splitIntegerRootFactorsAux_factor_irreducible
+          (target := core) (roots := roots) (fuel := roots.length)
+          (factors := split.1) (residual := split.2) rfl hmem
+      · rw [if_neg hres_one] at hquad
+        by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
+        · rw [if_pos hres_deg] at hquad
+          cases hquad
+          have hsplit_prod :
+              split.2 * Array.polyProduct split.1 = core := by
+            simpa [split, roots] using
+              splitIntegerRootFactorsAux_product core roots roots.length
+                split.1 split.2 rfl
+          have hsplit_lc_pos :
+              0 < DensePoly.leadingCoeff (Array.polyProduct split.1) := by
+            simpa [split, roots] using
+              splitIntegerRootFactorsAux_polyProduct_leadingCoeff_pos core roots
+                roots.length split.1 split.2 rfl
+          have hsplit_poly_ne : Array.polyProduct split.1 ≠ 0 := by
+            intro hzero
+            rw [hzero] at hsplit_lc_pos
+            change 0 < (0 : Int) at hsplit_lc_pos
+            omega
+          have hcore_ne : core ≠ 0 := by
+            intro hzero
+            rw [hzero] at hcore_pos
+            change 0 < (0 : Int) at hcore_pos
+            omega
+          -- factor = split.2 from hres. Need: Irreducible split.2.
+          rw [hres]
+          have hres_ne_zero : split.2 ≠ 0 := by
+            intro hzero
+            apply hcore_ne
+            rw [← hsplit_prod, hzero, DensePoly.zero_mul]
+          have hres_size_pos : 0 < split.2.size :=
+            ZPoly.size_pos_of_ne_zero split.2 hres_ne_zero
+          have hres_size_le : split.2.size ≤ 2 := by
+            unfold DensePoly.degree? at hres_deg
+            have hnz : split.2.size ≠ 0 := by omega
+            simp [hnz] at hres_deg
+            omega
+          have hcore_lc :
+              DensePoly.leadingCoeff core =
+                DensePoly.leadingCoeff split.2 *
+                  DensePoly.leadingCoeff (Array.polyProduct split.1) := by
+            rw [← hsplit_prod]
+            exact ZPoly.leadingCoeff_mul_of_nonzero
+              split.2 (Array.polyProduct split.1) hres_ne_zero hsplit_poly_ne
+          -- size = 1 case: derive contradiction via primitivity.
+          rcases (by omega : split.2.size = 1 ∨ split.2.size = 2) with h_one_size | h_two_size
+          · exfalso
+            have hres_eq : split.2 = DensePoly.C (split.2.coeff 0) :=
+              ZPoly.eq_C_of_size_eq_one split.2 h_one_size
+            have hcore_expand :
+                core = DensePoly.C (split.2.coeff 0) * Array.polyProduct split.1 := by
+              rw [← hsplit_prod]
+              exact congrArg (· * Array.polyProduct split.1) hres_eq
+            have hcoeff_core : ∀ n, core.coeff n =
+                split.2.coeff 0 * (Array.polyProduct split.1).coeff n := by
+              intro n
+              rw [hcore_expand, ZPoly.C_mul_eq_scale,
+                DensePoly.coeff_scale (R := Int) (split.2.coeff 0) _ n (Int.mul_zero _)]
+            have hc_dvd : ∀ n, ((split.2.coeff 0).natAbs : Int) ∣ core.coeff n := by
+              intro n
+              rw [hcoeff_core]
+              exact Int.natAbs_dvd.mpr ⟨_, rfl⟩
+            have hc_dvd_content :
+                ((split.2.coeff 0).natAbs : Int) ∣ ZPoly.content core :=
+              ZPoly.dvd_content_of_nat_dvd_coeff core _ hc_dvd
+            rw [show ZPoly.content core = 1 from hcore_primitive] at hc_dvd_content
+            have hc_ne : split.2.coeff 0 ≠ 0 := by
+              intro h
+              apply hres_ne_zero
+              rw [hres_eq, h]; rfl
+            have hres_lc : DensePoly.leadingCoeff split.2 = split.2.coeff 0 := by
+              rw [DensePoly.leadingCoeff_eq_coeff_last split.2 (by omega)]
+              congr 1; omega
+            rw [hres_lc] at hcore_lc
+            have hc_pos : 0 < split.2.coeff 0 := by
+              rcases Int.lt_or_lt_of_ne hc_ne with hlt | hgt
+              · exfalso
+                have : DensePoly.leadingCoeff core < 0 := by
+                  rw [hcore_lc]
+                  exact Int.mul_neg_of_neg_of_pos hlt hsplit_lc_pos
+                omega
+              · exact hgt
+            have hnat_dvd : (split.2.coeff 0).natAbs ∣ (1 : Nat) :=
+              Int.ofNat_dvd.mp (by simpa using hc_dvd_content)
+            have hnat_le : (split.2.coeff 0).natAbs ≤ 1 := Nat.le_of_dvd (by omega) hnat_dvd
+            have hnat_pos : 1 ≤ (split.2.coeff 0).natAbs := by
+              rcases Nat.eq_zero_or_pos (split.2.coeff 0).natAbs with hz | hp
+              · exact absurd (Int.natAbs_eq_zero.mp hz) hc_ne
+              · exact hp
+            have hnat_eq : (split.2.coeff 0).natAbs = 1 := by omega
+            have hc_eq_one : split.2.coeff 0 = 1 := by
+              rcases Int.natAbs_eq (split.2.coeff 0) with hpos | hneg
+              · rw [hpos, hnat_eq]; rfl
+              · exfalso
+                have : split.2.coeff 0 = -1 := by rw [hneg, hnat_eq]; rfl
+                omega
+            apply hres_one
+            rw [hres_eq, hc_eq_one]
+            rfl
+          · -- size = 2 case: prove irreducibility directly.
+            -- We mirror irreducible_of_size_two_primitive but use core's primitivity
+            -- (rather than split.2's own primitivity, which we'd otherwise need to
+            -- derive from `core = split.2 * polyProduct split.1`).
+            refine
+              { not_zero := hres_ne_zero
+                not_unit := ?_
+                no_factors := ?_ }
+            · intro hunit
+              rcases hunit with hone | hneg_unit
+              · rw [hone] at h_two_size
+                have h1 : (DensePoly.C (1 : Int)).size = 1 := rfl
+                omega
+              · rw [hneg_unit] at h_two_size
+                have hneg_size : (DensePoly.C (-1 : Int)).size = 1 := rfl
+                omega
+            · intro a b hab
+              by_cases ha_zero : a = 0
+              · exfalso; apply hres_ne_zero
+                rw [hab, ha_zero, DensePoly.zero_mul]
+              by_cases hb_zero : b = 0
+              · exfalso; apply hres_ne_zero
+                rw [hab, hb_zero]
+                change a * (0 : ZPoly) = 0
+                rw [DensePoly.mul_comm_poly, DensePoly.zero_mul]
+              have ha_pos : 0 < a.size := ZPoly.size_pos_of_ne_zero a ha_zero
+              have hb_pos : 0 < b.size := ZPoly.size_pos_of_ne_zero b hb_zero
+              have hab_size :
+                  (a * b).size = a.size + b.size - 1 :=
+                ZPoly.mul_size_eq_top_succ_of_nonzero a b ha_pos hb_pos
+              rw [← hab] at hab_size
+              rw [h_two_size] at hab_size
+              have hsum : a.size + b.size = 3 := by omega
+              -- The constant-factor argument: if a = C c (size 1), then
+              --   core = split.2 * polyProduct split.1 = a * b * polyProduct split.1
+              --        = C c * (b * polyProduct split.1).
+              -- c divides every coeff of core, so c.natAbs ∣ content core = 1, so c = ±1.
+              have const_factor_to_unit :
+                  ∀ (u v : ZPoly), u.size = 1 → split.2 = u * v →
+                    ZPoly.IsUnit u := by
+                intro u v hu_one hsplit_uv
+                have hu_eq : u = DensePoly.C (u.coeff 0) :=
+                  ZPoly.eq_C_of_size_eq_one u hu_one
+                have hu_ne : u ≠ 0 := by
+                  intro hzero
+                  apply hres_ne_zero
+                  rw [hsplit_uv, hzero, DensePoly.zero_mul]
+                have huc_ne : u.coeff 0 ≠ 0 := by
+                  intro hzero
+                  apply hu_ne
+                  rw [hu_eq, hzero]; rfl
+                have hcore_eq : core =
+                    DensePoly.C (u.coeff 0) * (v * Array.polyProduct split.1) := by
+                  rw [← hsplit_prod, hsplit_uv]
+                  rw [show u * v * Array.polyProduct split.1 =
+                        DensePoly.C (u.coeff 0) * v * Array.polyProduct split.1 from
+                      congrArg (· * v * Array.polyProduct split.1) hu_eq]
+                  rw [DensePoly.mul_assoc_poly]
+                have hu_dvd : ∀ n, ((u.coeff 0).natAbs : Int) ∣ core.coeff n := by
+                  intro n
+                  rw [hcore_eq, ZPoly.C_mul_eq_scale,
+                    DensePoly.coeff_scale (R := Int) (u.coeff 0) _ n (Int.mul_zero _)]
+                  exact Int.natAbs_dvd.mpr ⟨_, rfl⟩
+                have hu_dvd_content :
+                    ((u.coeff 0).natAbs : Int) ∣ ZPoly.content core :=
+                  ZPoly.dvd_content_of_nat_dvd_coeff core _ hu_dvd
+                rw [show ZPoly.content core = 1 from hcore_primitive] at hu_dvd_content
+                have hnat_dvd : (u.coeff 0).natAbs ∣ (1 : Nat) :=
+                  Int.ofNat_dvd.mp (by simpa using hu_dvd_content)
+                have hnat_le : (u.coeff 0).natAbs ≤ 1 := Nat.le_of_dvd (by omega) hnat_dvd
+                have hnat_pos : 1 ≤ (u.coeff 0).natAbs := by
+                  rcases Nat.eq_zero_or_pos (u.coeff 0).natAbs with hz | hp
+                  · exact absurd (Int.natAbs_eq_zero.mp hz) huc_ne
+                  · exact hp
+                have hnat_eq : (u.coeff 0).natAbs = 1 := by omega
+                rcases Int.natAbs_eq (u.coeff 0) with heq | heq
+                · left; rw [hu_eq, heq, hnat_eq]; rfl
+                · right; rw [hu_eq, heq, hnat_eq]; rfl
+              have ha_size_eq : a.size = 1 ∨ a.size = 2 := by omega
+              rcases ha_size_eq with ha_one | ha_two
+              · left
+                exact const_factor_to_unit a b ha_one hab
+              · right
+                have hb_one : b.size = 1 := by omega
+                exact const_factor_to_unit b a hb_one
+                  (hab.trans (DensePoly.mul_comm_poly a b))
+        · simp [roots, split, hres_deg] at hquad
+  · simp [hdeg] at hquad
+
 /-- Membership classifier for a reassembled quadratic-root branch. A raw factor
 is either one of the already-proved irreducible normalization/root factors, the
 normalization repeated-part fallback, or the optional residual appended by the

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7762,7 +7762,12 @@ constants dividing every coefficient of the primitive core); hence the
 residual, when emitted, has size two and is irreducible by the
 `irreducible_of_size_two_primitive` companion of `_monic`, applied to the
 residual's own primitivity inherited from the product `split.2 *
-polyProduct split.1 = core`. -/
+polyProduct split.1 = core`.
+
+This helper exists for `_factor_irreducible_of_primitive` (the public
+combined wrapper); consumers outside this file should prefer the wrapper
+because its signature avoids referencing the file-`private`
+`splitIntegerRootFactorsAux` and `integerRootCandidates`. -/
 private theorem quadraticIntegerRootFactors?_residual_irreducible
     {core : ZPoly} {factors : Array ZPoly}
     (hcore_pos : 0 < DensePoly.leadingCoeff core)
@@ -7977,6 +7982,36 @@ private theorem quadraticIntegerRootFactors?_residual_irreducible
                   (hab.trans (DensePoly.mul_comm_poly a b))
         · simp [roots, split, hres_deg] at hquad
   · simp [hdeg] at hquad
+
+/-- Every factor emitted by the quadratic integer-root branch is irreducible
+when the core is primitive with positive leading coefficient. Non-residual
+factors come from the integer-root splitter (linear, hence irreducible);
+the optional final residual is also irreducible because primitivity rules
+out degree-`0` residuals (non-unit constants would divide every coefficient
+of the primitive core) and the function's degree filter restricts residuals
+to size two, where the `irreducible_of_size_two_primitive` companion of
+`_monic` applies via the constant-factor argument on `core`.
+
+This is the public wrapper consumed by Mathlib-bridge consumers: its
+signature avoids referencing the file-`private` `splitIntegerRootFactorsAux`
+and `integerRootCandidates` (the residual is identified internally via
+case analysis). -/
+theorem quadraticIntegerRootFactors?_factor_irreducible_of_primitive
+    {core : ZPoly} {factors : Array ZPoly}
+    (hcore_pos : 0 < DensePoly.leadingCoeff core)
+    (hcore_primitive : ZPoly.Primitive core)
+    (hquad : quadraticIntegerRootFactors? core = some factors)
+    {factor : ZPoly}
+    (hmem : factor ∈ factors.toList) :
+    ZPoly.Irreducible factor := by
+  by_cases hres :
+      factor =
+        (splitIntegerRootFactorsAux core (integerRootCandidates core)
+          (integerRootCandidates core).length).2
+  · exact quadraticIntegerRootFactors?_residual_irreducible
+      hcore_pos hcore_primitive hquad hmem hres
+  · exact quadraticIntegerRootFactors?_factor_irreducible_of_ne_residual
+      hquad hmem hres
 
 /-- Membership classifier for a reassembled quadratic-root branch. A raw factor
 is either one of the already-proved irreducible normalization/root factors, the
@@ -8352,7 +8387,7 @@ private theorem squareFreeCore_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
   rw [hzero]
   exact DensePoly.zero_mul _
 
-private theorem squareFreeCore_leadingCoeff_pos_of_ne_zero
+theorem squareFreeCore_leadingCoeff_pos_of_ne_zero
     (f : ZPoly) (hf : f ≠ 0) :
     0 < DensePoly.leadingCoeff (normalizeForFactor f).squareFreeCore := by
   have hne := squareFreeCore_ne_zero_of_ne_zero f hf

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5899,6 +5899,127 @@ private theorem irreducible_of_size_two_monic
 theorem irreducible_X : ZPoly.Irreducible ZPoly.X :=
   irreducible_of_size_two_monic ZPoly.X rfl rfl
 
+/-- A primitive integer polynomial of dense size two is irreducible. Mirrors
+`irreducible_of_size_two_monic` but uses primitivity (`content f = 1`) instead
+of monicness to derive that a degree-zero factor must be `±1`: if `f = C c * b`
+then `c` divides every coefficient of `f`, hence `c` divides `content f = 1`,
+forcing `c ∈ {±1}`. -/
+private theorem irreducible_of_size_two_primitive
+    (f : ZPoly) (hf_size : f.size = 2)
+    (hf_prim : ZPoly.Primitive f) :
+    ZPoly.Irreducible f := by
+  have hf_ne : f ≠ 0 := by
+    intro hzero
+    rw [hzero] at hf_size
+    change (0 : Nat) = 2 at hf_size
+    omega
+  refine
+    { not_zero := hf_ne
+      not_unit := ?_
+      no_factors := ?_ }
+  · intro hunit
+    rcases hunit with hone | hneg
+    · rw [hone] at hf_size
+      have h1 : (DensePoly.C (1 : Int)).size = 1 := rfl
+      omega
+    · rw [hneg] at hf_size
+      have hneg_size : (DensePoly.C (-1 : Int)).size = 1 := rfl
+      omega
+  · intro a b hf_ab
+    by_cases ha_zero : a = 0
+    · exfalso
+      apply hf_ne
+      rw [hf_ab, ha_zero, DensePoly.zero_mul]
+    by_cases hb_zero : b = 0
+    · exfalso
+      apply hf_ne
+      rw [hf_ab, hb_zero]
+      change a * (0 : ZPoly) = 0
+      rw [DensePoly.mul_comm_poly, DensePoly.zero_mul]
+    have ha_pos : 0 < a.size := ZPoly.size_pos_of_ne_zero a ha_zero
+    have hb_pos : 0 < b.size := ZPoly.size_pos_of_ne_zero b hb_zero
+    have hab_size :
+        (a * b).size = a.size + b.size - 1 :=
+      ZPoly.mul_size_eq_top_succ_of_nonzero a b ha_pos hb_pos
+    rw [← hf_ab] at hab_size
+    rw [hf_size] at hab_size
+    have hsum : a.size + b.size = 3 := by omega
+    have ha_size_le : a.size ≤ 2 := by omega
+    have hb_size_le : b.size ≤ 2 := by omega
+    have ha_size_eq_one_or_two : a.size = 1 ∨ a.size = 2 := by omega
+    -- Helper: if `g = C c * h`, then `c` divides every coefficient of `g`,
+    -- so `(c.natAbs : Int)` divides `content g`.
+    have const_dvd_content :
+        ∀ (g h : ZPoly) (c : Int),
+          g = DensePoly.C c * h → ((c.natAbs : Int) : Int) ∣ ZPoly.content g := by
+      intro g h c hg_eq
+      apply ZPoly.dvd_content_of_nat_dvd_coeff
+      intro n
+      have hcoeff : g.coeff n = c * h.coeff n := by
+        rw [hg_eq, C_mul_eq_scale,
+          DensePoly.coeff_scale (R := Int) c h n (Int.mul_zero _)]
+      refine Int.natAbs_dvd.mpr ?_
+      rw [hcoeff]
+      exact ⟨h.coeff n, rfl⟩
+    -- Helper: if `c.natAbs` divides `1` and `c ≠ 0`, then `c ∈ {1, -1}`.
+    have nat_factor_one :
+        ∀ (c : Int), c ≠ 0 → ((c.natAbs : Int) : Int) ∣ (1 : Int) →
+          c = 1 ∨ c = -1 := by
+      intro c hc_ne hdvd
+      have hnat_dvd : c.natAbs ∣ (1 : Nat) := by
+        have := Int.ofNat_dvd.mp (by simpa using hdvd)
+        exact this
+      have hnat_le : c.natAbs ≤ 1 := Nat.le_of_dvd (by omega) hnat_dvd
+      have hnat_pos : 1 ≤ c.natAbs := by
+        rcases Nat.eq_zero_or_pos c.natAbs with hzero | hpos
+        · exact absurd (Int.natAbs_eq_zero.mp hzero) hc_ne
+        · exact hpos
+      have hnat_eq : c.natAbs = 1 := by omega
+      rcases Int.natAbs_eq c with heq | heq
+      · left; rw [heq, hnat_eq]; rfl
+      · right; rw [heq, hnat_eq]; rfl
+    rcases ha_size_eq_one_or_two with ha_one | ha_two
+    · -- a.size = 1, so a is constant; show IsUnit a
+      left
+      have ha_eq : a = DensePoly.C (a.coeff 0) := eq_C_of_size_eq_one a ha_one
+      have hf_eq : f = DensePoly.C (a.coeff 0) * b :=
+        hf_ab.trans (congrArg (· * b) ha_eq)
+      have hac_ne_zero : a.coeff 0 ≠ 0 := by
+        intro h
+        apply ha_zero
+        rw [ha_eq, h]
+        rfl
+      have hcontent_one : ZPoly.content f = 1 := hf_prim
+      have hac_dvd_content :
+          ((a.coeff 0).natAbs : Int) ∣ ZPoly.content f :=
+        const_dvd_content f b (a.coeff 0) hf_eq
+      rw [hcontent_one] at hac_dvd_content
+      rcases nat_factor_one (a.coeff 0) hac_ne_zero hac_dvd_content with
+        hone | hneg
+      · left; rw [ha_eq, hone]
+      · right; rw [ha_eq, hneg]
+    · -- a.size = 2, so b.size = 1; symmetric case via commutativity
+      right
+      have hb_one : b.size = 1 := by omega
+      have hb_eq : b = DensePoly.C (b.coeff 0) := eq_C_of_size_eq_one b hb_one
+      have hf_eq : f = DensePoly.C (b.coeff 0) * a :=
+        (hf_ab.trans (DensePoly.mul_comm_poly a b)).trans
+          (congrArg (· * a) hb_eq)
+      have hbc_ne_zero : b.coeff 0 ≠ 0 := by
+        intro h
+        apply hb_zero
+        rw [hb_eq, h]
+        rfl
+      have hcontent_one : ZPoly.content f = 1 := hf_prim
+      have hbc_dvd_content :
+          ((b.coeff 0).natAbs : Int) ∣ ZPoly.content f :=
+        const_dvd_content f a (b.coeff 0) hf_eq
+      rw [hcontent_one] at hbc_dvd_content
+      rcases nat_factor_one (b.coeff 0) hbc_ne_zero hbc_dvd_content with
+        hone | hneg
+      · left; rw [hb_eq, hone]
+      · right; rw [hb_eq, hneg]
+
 end ZPoly
 
 /-- Every factor emitted by the extracted `X`-power normalization array is

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -957,6 +957,36 @@ theorem choosePrimeData?_leadingCoeff_castRingHom_ne_zero
     leadingCoeff_castRingHom_ne_zero_of_isGoodPrime f
       (Hex.choosePrimeData?_isGoodPrime f primeData hselected)
 
+/--
+Reverse bridge from Mathlib's `Polynomial.IsPrimitive` on the transported
+polynomial to the executable `Hex.ZPoly.Primitive` predicate.
+
+Apply `IsPrimitive` at the constant polynomial `C (content f)` (which divides
+`toPolynomial f` because `content f` divides every integer coefficient), to
+conclude `IsUnit (content f)` in `ℤ`. Combined with the non-negativity of
+`Hex.ZPoly.content` (it is `Int.ofNat` of `DensePoly.contentNat`), this forces
+`content f = 1`.
+-/
+theorem zpoly_primitive_of_toPolynomial_isPrimitive
+    {f : Hex.ZPoly}
+    (hprim : (HexPolyZMathlib.toPolynomial f).IsPrimitive) :
+    Hex.ZPoly.Primitive f := by
+  show Hex.ZPoly.content f = 1
+  have hC_dvd :
+      Polynomial.C (Hex.ZPoly.content f) ∣ HexPolyZMathlib.toPolynomial f := by
+    rw [Polynomial.C_dvd_iff_dvd_coeff]
+    intro n
+    rw [HexPolyZMathlib.coeff_toPolynomial]
+    exact Hex.ZPoly.content_dvd_coeff f n
+  have hIsUnit : IsUnit (Hex.ZPoly.content f) := hprim _ hC_dvd
+  have hcontent_nonneg : 0 ≤ Hex.ZPoly.content f := by
+    show 0 ≤ Hex.DensePoly.content f
+    unfold Hex.DensePoly.content
+    exact Int.natCast_nonneg _
+  rcases Int.isUnit_iff.mp hIsUnit with hone | hneg
+  · exact hone
+  · rw [hneg] at hcontent_nonneg; omega
+
 end IntReductionMod
 
 /-- **#4549 substrate (HO-1), outer-bound specialisation, rewired for #4553.**
@@ -1166,5 +1196,78 @@ theorem factor_constant_branch_entry_irreducible_of_choosePrimeData
     rw [hentry_one] at hrecord
     unfold Hex.shouldRecordPolynomialFactor at hrecord
     simp at hrecord
+
+/-- **#4571 HO-1 substrate — fast-path quadratic arm umbrella.**
+
+Per-branch HO-1 component for the fast-path quadratic integer-root arm of the
+capstone `factor_irreducible_of_nonUnit` (#4170): every entry recorded by
+`Hex.factorWithBound f B` in this fast-path branch is `Hex.ZPoly.Irreducible`,
+given `f ≠ 0`, `1 < B`, the branch marker hypotheses (`hdeg`, `hquad`), and
+the reassembly expansion-complete side condition.
+
+Composes:
+* `Hex.factorWithBound_entry_mem_quadratic_branch_raw` — the Mathlib-free
+  branch-shape lemma identifying each recorded entry as the
+  sign-normalisation of a raw factor in the quadratic-branch reassembly;
+* `Hex.quadraticIntegerRootFactors?_factor_irreducible_of_primitive` — the
+  Mathlib-free executable irreducibility of every coreFactor, residual or
+  not, under primitivity;
+* `IntReductionMod.zpoly_primitive_of_toPolynomial_isPrimitive` +
+  `IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive`
+  (from #4545) — the primitivity bridge for the squarefree core;
+* `Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero` — the positive-leading-
+  coefficient invariant for the squarefree core;
+* `Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`
+  — the Mathlib-free reassembly lift turning per-core-factor irreducibility
+  into raw factor irreducibility under the `hcomplete` side condition;
+* `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible` — the
+  sign-normalisation lift from raw factor irreducibility to entry
+  irreducibility.
+
+The slow-path exhaustive arm (#4561), the fast-path constant arm
+(#4565 / #4572, landed), the small-mod singleton arm (#4562 / #4564, landed),
+and the fast BHKS arm (gated on #2567) are separate concerns and out of scope
+here. -/
+theorem factor_quadratic_branch_entry_irreducible_of_quadraticRoots
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
+    (B : Nat) (hB_gt_one : 1 < B)
+    (entry : Hex.ZPoly × Nat)
+    (hdeg :
+      (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    {coreFactors : Array Hex.ZPoly}
+    (hquad :
+      Hex.quadraticIntegerRootFactors?
+        (Hex.normalizeForFactor f).squareFreeCore = some coreFactors)
+    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
+    (hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) coreFactors) :
+    Hex.ZPoly.Irreducible entry.1 := by
+  -- Branch-shape lemma: entry = normalizeFactorSign raw for raw ∈ reassembly.
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ :=
+    Hex.factorWithBound_entry_mem_quadratic_branch_raw f B entry hB_gt_one hdeg
+      hquad hentry_mem
+  -- Primitivity of squareFreeCore via the Mathlib bridge.
+  have hcore_primitive :
+      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+    IntReductionMod.zpoly_primitive_of_toPolynomial_isPrimitive
+      (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive
+        f hf_ne)
+  have hcore_pos :
+      0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore :=
+    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
+  -- Every coreFactor is irreducible.
+  have hcore_factors_irr :
+      ∀ cf ∈ coreFactors.toList, Hex.ZPoly.Irreducible cf := fun cf hcf_mem =>
+    Hex.quadraticIntegerRootFactors?_factor_irreducible_of_primitive
+      hcore_pos hcore_primitive hquad hcf_mem
+  -- Reassembly lift: every raw factor is irreducible when reassembly is
+  -- expansion-complete and every core factor is irreducible.
+  have hraw_irr : Hex.ZPoly.Irreducible raw :=
+    Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+      (Hex.normalizeForFactor f) coreFactors hcomplete hcore_factors_irr hraw_mem
+  -- Sign-normalisation lifts to entry irreducibility.
+  rw [hentry_eq]
+  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hraw_irr
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260517T130000Z_36ebb892.md
+++ b/progress/20260517T130000Z_36ebb892.md
@@ -1,0 +1,107 @@
+# 20260517T130000Z — feature session 36ebb892 (#4561 skip → #4571)
+
+## Accomplished
+
+**#4561 (HO-1 substrate, exhaustive-branch arm)** — skipped with replan.
+The `check-blocked` auto-unblock from #4563 closure was premature: #4563
+was decomposed and only the `factorsModP_ne_nil` discharger landed via
+#4570; the other three (`_monic` / `_polyProduct_congr` / `_coprime`)
+tracked as #4567 / #4568 / #4569 remain open with non-trivial
+complications. Added explicit `depends-on:` lines for #4567, #4568,
+#4569 via `coordination add-dep`, then `coordination skip 4561`.
+(During this session #4573 / #4574 landed, clearing #4568 / #4569;
+the remaining substrate gap for #4561 is #4567 — `factorsModP_monic`
+needs Berlekamp-level monic normalisation work, separate scope.)
+
+**#4571 (HO-1 substrate, fast-path quadratic arm umbrella)** — resolved.
+Added three layers, two files:
+
+1. `HexBerlekampZassenhaus/Basic.lean`:
+   - `factorWithBound_entry_mem_quadratic_branch_raw` (branch-shape
+     lemma): identifies each recorded entry as the sign-normalisation
+     of a raw factor in the quadratic-branch reassembly, given the
+     dispatch hypotheses (`hB_gt_one`, `hdeg`, `hquad`).
+   - `ZPoly.irreducible_of_size_two_primitive` (private inside
+     `namespace ZPoly`): a primitive ZPoly of dense size two is
+     irreducible. Mirrors `_of_size_two_monic` but uses primitivity
+     (content = 1) instead of monicness to bound constant factors via
+     the `C c * h` divisibility argument.
+   - `quadraticIntegerRootFactors?_residual_irreducible` (`private`,
+     uses file-local `splitIntegerRootFactorsAux` / `integerRootCandidates`
+     in its signature): under `hcore_pos` and `hcore_primitive`, the
+     optional residual is irreducible. Casework on residual size:
+     size 1 is impossible (primitivity + positive lc forces residual
+     = 1, contradicting the `hres_one` filter); size 2 directly via
+     the size-two-primitive helper applied to the residual's own
+     primitivity (extracted from `core`'s primitivity via the
+     `C (a.coeff 0) * (v * polyProduct split.1)` decomposition).
+   - `quadraticIntegerRootFactors?_factor_irreducible_of_primitive`
+     (public wrapper): combines the residual and non-residual cases via
+     `by_cases` internally so its signature avoids the file-`private`
+     names. This is the wrapper consumed by the Mathlib bridge.
+   - Un-private`d squareFreeCore_leadingCoeff_pos_of_ne_zero` so the
+     bridge layer can discharge the `hcore_pos` premise.
+
+2. `HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+   - `IntReductionMod.zpoly_primitive_of_toPolynomial_isPrimitive`
+     (reverse primitivity bridge): from Mathlib's `IsPrimitive`-applied-
+     at-`C (content f)` plus the non-negativity of
+     `Hex.DensePoly.content = Int.ofNat ∘ contentNat`, conclude
+     executable `Hex.ZPoly.Primitive f`.
+   - `factor_quadratic_branch_entry_irreducible_of_quadraticRoots`
+     (#4571 umbrella): composes the branch-shape lemma, the
+     residual-aware core-factor irreducibility (via the public
+     `_of_primitive` wrapper), the reassembly lift
+     `_factor_irreducible_of_complete_and_core_irreducible`, and
+     `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible`.
+
+### Discrepancy resolution
+
+The issue's deliverable signature for the residual helper referenced
+`splitIntegerRootFactorsAux` and `integerRootCandidates` directly. Both
+are `private def` in `HexBerlekampZassenhaus/Basic.lean`, so a public
+helper with that signature is not addressable from the Mathlib bridge
+layer. Resolved by introducing the public
+`_factor_irreducible_of_primitive` wrapper that performs the residual
+case-split internally; the underlying `_residual_irreducible` remains
+`private`, satisfying the issue's "private" annotation while keeping
+the umbrella callable.
+
+### Build state
+
+- `lake build HexBerlekampZassenhaus.Basic` ✓
+- `lake build HexBerlekampZassenhaus` ✓
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod` ✓
+- `lake build HexBerlekampZassenhausMathlib` ✓
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` clean
+- Sorry inventory in touched files: `HexBerlekampZassenhaus/Basic.lean`
+  remains at 1 sorry (the pre-existing one in the Mathlib-free body that
+  predates this work); `IntReductionMod.lean` remains at 0. No new
+  `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+#4571 resolves with the umbrella in place. The HO-1 capstone
+`factor_irreducible_of_nonUnit` (#4170) can now apply the quadratic-arm
+umbrella for its fast-path quadratic dispatch branch. Three of the four
+fast/slow arm umbrellas have landed (small-mod singleton #4564, constant
+#4572, quadratic this PR); the slow-path exhaustive arm #4561 is the
+remaining open arm (blocked on #4567).
+
+## Next step
+
+Either (a) work on `factorsModP_monic` discharger (#4567), which would
+fully unblock #4561, or (b) start the HO-1 capstone assembly wiring
+together the now-landed singleton / constant / quadratic arm umbrellas
+into `factor_irreducible_of_nonUnit` (#4170), leaving only the
+exhaustive arm and BHKS arm behind sorries. Option (b) gives a partial
+HO-1 deliverable visible to downstream consumers.
+
+## Blockers
+
+None for #4571. The rebase against the latest main resolved cleanly
+(one structural conflict each in `HexBerlekampZassenhaus/Basic.lean`
+and `HexBerlekampZassenhausMathlib/IntReductionMod.lean` from #4565 /
+#4572 landing the constant arm at the same insertion points; resolved
+by sequencing both arms).


### PR DESCRIPTION
Closes #4571

Session: `36ebb892-d06c-40e3-a77c-4696ab6c83b1`

bb6035d8 docs: progress note for #4571 quadratic arm umbrella session
4d4cdee8 feat: assemble fast-path quadratic arm umbrella (#4571, 3/3)
fde7902b feat: residual irreducibility for quadratic arm (#4571, 2b/3)
bcbab15a feat: irreducible_of_size_two_primitive helper (#4571, 2a/3)
5a982f05 feat: branch-shape lemma for fast-path quadratic arm (#4571, 1/3)

🤖 Prepared with Claude Code