### PR TITLE
HO-1 substrate: factorsModP_monic discharger from factorsModPBerlekampForm

### DIFF
--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -481,7 +481,8 @@ product of the returned factors for square-free monic inputs.
 theorem prod_berlekampFactor
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     [Lean.Grind.Field (ZMod64 p)]
-    [ZMod64.PrimeModulus p] :
+    [ZMod64.PrimeModulus p]
+    (_hsquareFree : DensePoly.gcd f (DensePoly.derivative f) = 1) :
     (berlekampFactor f hmonic).product = f := by
   simp only [Factorization.product_def]
   exact factorProduct_berlekampFactor f hmonic

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -481,8 +481,7 @@ product of the returned factors for square-free monic inputs.
 theorem prod_berlekampFactor
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
     [Lean.Grind.Field (ZMod64 p)]
-    [ZMod64.PrimeModulus p]
-    (_hsquareFree : DensePoly.gcd f (DensePoly.derivative f) = 1) :
+    [ZMod64.PrimeModulus p] :
     (berlekampFactor f hmonic).product = f := by
   simp only [Factorization.product_def]
   exact factorProduct_berlekampFactor f hmonic
@@ -1343,6 +1342,49 @@ theorem berlekampFactor_factors_pos_degree
     (f.size + 1) [f], 0 < g.degree?.getD 0
   exact berlekampFactorLoop_pos_invariant ((fixedSpaceKernel f hmonic).toList)
     (f.size + 1) [f] h_init_pos
+
+/-- For a monic input of size ≤ 1, the executable Berlekamp factor list is
+exactly the singleton `[f]`.  The Berlekamp loop only adds entries via
+nontrivial splits (which require positive-degree gcd outputs), and a polynomial
+of size ≤ 1 has no positive-degree divisors, so the loop preserves the initial
+singleton `[f]`. -/
+theorem berlekampFactor_factors_eq_singleton_of_size_le_one
+    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    (hsize : f.size ≤ 1) :
+    (berlekampFactor f hmonic).factors = [f] := by
+  have h_no_split : ∀ w ∈ ((fixedSpaceKernel f hmonic).toList),
+      kernelWitnessSplit? f w = none := by
+    intro w _hw
+    cases hopt : kernelWitnessSplit? f w with
+    | none => rfl
+    | some r =>
+        exfalso
+        have hsize_lt := kernelWitnessSplit_size_lt f w r hopt
+        have hnt := kernelWitnessSplit_nontrivial f w r hopt
+        -- r.factor.size < f.size ≤ 1, so r.factor.size = 0, so r.factor = 0.
+        have hfac_size_zero : r.factor.size = 0 := by omega
+        have hfac_iszero : r.factor.isZero = true := by
+          change r.factor.coeffs.isEmpty = true
+          simpa [DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hfac_size_zero
+        rw [hfac_iszero] at hnt
+        simp at hnt
+  have h_loop : ∀ fuel,
+      berlekampFactorLoop ((fixedSpaceKernel f hmonic).toList) fuel [f] = [f] := by
+    intro fuel
+    induction fuel with
+    | zero => rfl
+    | succ fuel _ih_fuel =>
+        rw [berlekampFactorLoop]
+        have h_sff_none :
+            splitFirstFactor? ((fixedSpaceKernel f hmonic).toList) [f] = none := by
+          rw [splitFirstFactor?_singleton_none_iff,
+              splitWithWitnesses?_none_iff_forall]
+          exact h_no_split
+        rw [h_sff_none]
+  change berlekampFactorLoop _ _ [f] = [f]
+  exact h_loop _
 
 end Berlekamp
 

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -815,6 +815,51 @@ private theorem dvd_factorProduct_of_mem
             congrArg (fun y => y * k) (DensePoly.mul_comm_poly x g)
         _ = g * (x * k) := DensePoly.mul_assoc_poly g x k
 
+/-- Two distinct elements of a `Nodup` list of `FpPoly p` have a product that
+divides the list's product. -/
+theorem mul_dvd_factorProduct_of_mem_of_ne
+    [ZMod64.PrimeModulus p]
+    {xs : List (FpPoly p)} (h_nodup : xs.Nodup)
+    {a b : FpPoly p} (ha : a ∈ xs) (hb : b ∈ xs) (hab : a ≠ b) :
+    a * b ∣ factorProduct xs := by
+  induction xs with
+  | nil => exact absurd ha List.not_mem_nil
+  | cons x rest ih =>
+    have h_rest_nodup : rest.Nodup := (List.nodup_cons.mp h_nodup).2
+    rw [factorProduct_cons]
+    rcases List.mem_cons.mp ha with hax | har
+    · -- a = x
+      subst hax
+      rcases List.mem_cons.mp hb with hbx | hbr
+      · subst hbx; exact absurd rfl hab
+      · -- a = x, b ∈ rest. factorProduct (x :: rest) = a * factorProduct rest.
+        rcases dvd_factorProduct_of_mem rest hbr with ⟨q, hq⟩
+        refine ⟨q, ?_⟩
+        rw [hq]
+        exact (DensePoly.mul_assoc_poly a b q).symm
+    · -- a ∈ rest
+      rcases List.mem_cons.mp hb with hbx | hbr
+      · -- a ∈ rest, b = x. factorProduct (x :: rest) = b * factorProduct rest.
+        subst hbx
+        rcases dvd_factorProduct_of_mem rest har with ⟨q, hq⟩
+        refine ⟨q, ?_⟩
+        rw [hq]
+        -- Goal: b * (a * q) = a * b * q
+        calc b * (a * q)
+            = (b * a) * q := (DensePoly.mul_assoc_poly _ _ _).symm
+          _ = (a * b) * q :=
+              congrArg (· * q) (DensePoly.mul_comm_poly _ _)
+      · -- both a, b ∈ rest
+        rcases ih h_rest_nodup har hbr with ⟨q, hq⟩
+        refine ⟨x * q, ?_⟩
+        rw [hq]
+        -- Goal: x * (a * b * q) = a * b * (x * q)
+        calc x * (a * b * q)
+            = (x * (a * b)) * q := (DensePoly.mul_assoc_poly _ _ _).symm
+          _ = ((a * b) * x) * q :=
+              congrArg (· * q) (DensePoly.mul_comm_poly _ _)
+          _ = (a * b) * (x * q) := DensePoly.mul_assoc_poly _ _ _
+
 /-- A polynomial that divides both `a` and `b` squares-divides `a * b`. -/
 private theorem squared_dvd_of_dvd_dvd
     [ZMod64.PrimeModulus p]

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -1386,6 +1386,46 @@ theorem berlekampFactor_factors_eq_singleton_of_size_le_one
   change berlekampFactorLoop _ _ [f] = [f]
   exact h_loop _
 
+/-- Every factor in the Berlekamp factor list is nonzero.  Splits the positive-
+degree case (where every factor has positive degree via
+`berlekampFactor_factors_pos_degree`) from the size-≤-1 case (where the factor
+list is the singleton `[f]` and `f` is monic, hence nonzero). -/
+theorem berlekampFactor_factors_ne_zero
+    [Lean.Grind.Field (ZMod64 p)]
+    [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    ∀ g ∈ (berlekampFactor f hmonic).factors, g ≠ 0 := by
+  by_cases hf_pos : 0 < f.degree?.getD 0
+  · intro g hg
+    have hg_pos := berlekampFactor_factors_pos_degree f hmonic hf_pos g hg
+    intro h
+    rw [h] at hg_pos
+    simp [DensePoly.degree?] at hg_pos
+  · -- f.size ≤ 1: factors = [f], which is monic hence nonzero.
+    have hf_size_le : f.size ≤ 1 := by
+      rcases Nat.lt_or_ge f.size 2 with hlt | hge
+      · omega
+      · exfalso
+        apply hf_pos
+        have hsize_ne : f.size ≠ 0 := by omega
+        have hdeg_eq : f.degree? = some (f.size - 1) := by
+          unfold DensePoly.degree?
+          simp [hsize_ne]
+        rw [hdeg_eq]
+        simp
+        omega
+    have hfactors_eq := berlekampFactor_factors_eq_singleton_of_size_le_one f hmonic hf_size_le
+    rw [hfactors_eq]
+    intro g hg
+    rw [List.mem_singleton] at hg
+    subst hg
+    intro h
+    subst h
+    have hlead_zero : DensePoly.leadingCoeff (0 : FpPoly p) = 0 := rfl
+    unfold DensePoly.Monic at hmonic
+    rw [hlead_zero] at hmonic
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hmonic.symm
+
 end Berlekamp
 
 end Hex

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -344,7 +344,7 @@ theorem irreducible_of_berlekampFactor_factors_length_le_one
       cases rest with
       | nil =>
           have hg_eq : g = f := by
-            have hprod := Hex.Berlekamp.prod_berlekampFactor f hmonic hsquareFree
+            have hprod := Hex.Berlekamp.prod_berlekampFactor f hmonic
             rw [Hex.Berlekamp.Factorization.product_def] at hprod
             simp [hfactors, Hex.Berlekamp.factorProduct_cons] at hprod
             exact hprod

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -344,7 +344,7 @@ theorem irreducible_of_berlekampFactor_factors_length_le_one
       cases rest with
       | nil =>
           have hg_eq : g = f := by
-            have hprod := Hex.Berlekamp.prod_berlekampFactor f hmonic
+            have hprod := Hex.Berlekamp.prod_berlekampFactor f hmonic hsquareFree
             rw [Hex.Berlekamp.Factorization.product_def] at hprod
             simp [hfactors, Hex.Berlekamp.factorProduct_cons] at hprod
             exact hprod

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -493,6 +493,237 @@ theorem monicModularImage_monic
   rw [FpPoly.leadingCoeff_scale_of_ne_zero_of_nonzero (p := p) hinv_ne f hfsize]
   exact ZMod64.inv_mul_eq_one_of_prime hp hlead_ne
 
+/-- A nonzero `FpPoly p` translates to `isZero = false`. -/
+private theorem isZero_false_of_ne_zero
+    {p : Nat} [ZMod64.Bounds p] {f : FpPoly p} (hf : f ≠ 0) :
+    f.isZero = false := by
+  cases hz : f.isZero with
+  | false => rfl
+  | true =>
+      exfalso
+      apply hf
+      apply DensePoly.ext_coeff
+      intro n
+      have hsize : f.size = 0 := by
+        change f.coeffs.isEmpty = true at hz
+        simpa [DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hz
+      rw [DensePoly.coeff_eq_zero_of_size_le f (by omega)]
+      exact DensePoly.coeff_zero n
+
+/-- `monicModularImage` of a nonzero polynomial is nonzero (it's a unit scalar of
+the original). -/
+theorem monicModularImage_ne_zero_of_ne_zero
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) {f : FpPoly p} (hf : f ≠ 0) :
+    monicModularImage f ≠ 0 := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  have hf_iszero : f.isZero = false := isZero_false_of_ne_zero hf
+  unfold monicModularImage
+  simp only [hf_iszero, Bool.false_eq_true, ↓reduceIte]
+  have hf_size_pos : 0 < f.size := FpPoly.size_pos_of_ne_zero hf
+  have hlead_ne : DensePoly.leadingCoeff f ≠ (0 : ZMod64 p) := by
+    rw [FpPoly.leadingCoeff_eq_coeff_pred f hf_size_pos]
+    exact DensePoly.coeff_last_ne_zero_of_pos_size f hf_size_pos
+  have hinv_ne : (DensePoly.leadingCoeff f)⁻¹ ≠ (0 : ZMod64 p) :=
+    ZMod64.inv_ne_zero_of_prime hp hlead_ne
+  intro h
+  have hsize_zero : (DensePoly.scale (DensePoly.leadingCoeff f)⁻¹ f).size = 0 := by
+    rw [h]; rfl
+  rw [FpPoly.scale_size_eq_of_ne_zero (p := p) hinv_ne f] at hsize_zero
+  exact (Nat.pos_iff_ne_zero.mp hf_size_pos) hsize_zero
+
+/-- `monicModularImage` is the identity on monic polynomials: dividing by a
+leading coefficient of `1` is a no-op. -/
+theorem monicModularImage_eq_self_of_monic
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) (f : FpPoly p)
+    (hmonic : DensePoly.Monic f) :
+    monicModularImage f = f := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  -- Monic forces `f` to be nonzero: otherwise `leadingCoeff f = 0` but `Monic`
+  -- says `leadingCoeff f = 1`.
+  have hf_ne : f ≠ 0 := by
+    intro h
+    subst h
+    have hlead_zero : DensePoly.leadingCoeff (0 : FpPoly p) = 0 := rfl
+    unfold DensePoly.Monic at hmonic
+    rw [hlead_zero] at hmonic
+    exact ZMod64.one_ne_zero_of_prime hp hmonic.symm
+  have hf_iszero : f.isZero = false := isZero_false_of_ne_zero hf_ne
+  unfold monicModularImage
+  simp only [hf_iszero, Bool.false_eq_true, ↓reduceIte]
+  unfold DensePoly.Monic at hmonic
+  rw [hmonic]
+  -- (1 : ZMod64 p)⁻¹ = 1
+  have hone_ne : (1 : ZMod64 p) ≠ 0 :=
+    fun h => ZMod64.one_ne_zero_of_prime hp h
+  have hone_inv : (1 : ZMod64 p)⁻¹ = (1 : ZMod64 p) := by
+    have hleft : (1 : ZMod64 p)⁻¹ * (1 : ZMod64 p) = 1 :=
+      ZMod64.inv_mul_eq_one_of_prime hp hone_ne
+    grind
+  show DensePoly.scale ((1 : ZMod64 p)⁻¹) f = f
+  rw [hone_inv, FpPoly.scale_one_left]
+
+/-- Multiplicativity of `monicModularImage` on nonzero polynomials.  The leading
+coefficient of a product is the product of leading coefficients (no-zero-divisors
+over a prime field), so dividing both sides by their leading coefficients agrees
+with dividing the product by its leading coefficient. -/
+theorem monicModularImage_mul_of_nonzero
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) {a b : FpPoly p}
+    (ha : a ≠ 0) (hb : b ≠ 0) :
+    monicModularImage (a * b) = monicModularImage a * monicModularImage b := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  have hab : a * b ≠ 0 := FpPoly.mul_ne_zero_of_ne_zero ha hb
+  have ha_iszero : a.isZero = false := isZero_false_of_ne_zero ha
+  have hb_iszero : b.isZero = false := isZero_false_of_ne_zero hb
+  have hab_iszero : (a * b).isZero = false := isZero_false_of_ne_zero hab
+  have ha_size_pos : 0 < a.size := FpPoly.size_pos_of_ne_zero ha
+  have hb_size_pos : 0 < b.size := FpPoly.size_pos_of_ne_zero hb
+  have hlead_a : DensePoly.leadingCoeff a ≠ (0 : ZMod64 p) := by
+    rw [FpPoly.leadingCoeff_eq_coeff_pred a ha_size_pos]
+    exact DensePoly.coeff_last_ne_zero_of_pos_size a ha_size_pos
+  have hlead_b : DensePoly.leadingCoeff b ≠ (0 : ZMod64 p) := by
+    rw [FpPoly.leadingCoeff_eq_coeff_pred b hb_size_pos]
+    exact DensePoly.coeff_last_ne_zero_of_pos_size b hb_size_pos
+  have hlead_ab :
+      DensePoly.leadingCoeff (a * b) = DensePoly.leadingCoeff a * DensePoly.leadingCoeff b :=
+    FpPoly.leadingCoeff_mul a b ha hb
+  have hlead_ab_ne : DensePoly.leadingCoeff (a * b) ≠ (0 : ZMod64 p) := by
+    rw [hlead_ab]
+    intro h
+    rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp h with h | h
+    · exact hlead_a h
+    · exact hlead_b h
+  -- `((lc a) * (lc b))⁻¹ = (lc a)⁻¹ * (lc b)⁻¹`: standard field fact, proven
+  -- via `(x⁻¹ * y⁻¹) * (x * y) = 1` plus uniqueness of inverse via cancellation.
+  have hinv_distrib :
+      (DensePoly.leadingCoeff a * DensePoly.leadingCoeff b)⁻¹ =
+        (DensePoly.leadingCoeff a)⁻¹ * (DensePoly.leadingCoeff b)⁻¹ := by
+    -- Show the candidate is a left inverse.
+    have hleft :
+        ((DensePoly.leadingCoeff a)⁻¹ * (DensePoly.leadingCoeff b)⁻¹) *
+          (DensePoly.leadingCoeff a * DensePoly.leadingCoeff b) = 1 := by
+      have ha_inv : (DensePoly.leadingCoeff a)⁻¹ * DensePoly.leadingCoeff a = 1 :=
+        ZMod64.inv_mul_eq_one_of_prime hp hlead_a
+      have hb_inv : (DensePoly.leadingCoeff b)⁻¹ * DensePoly.leadingCoeff b = 1 :=
+        ZMod64.inv_mul_eq_one_of_prime hp hlead_b
+      grind
+    -- Show the canonical inverse is also a left inverse.
+    have habinv_ne :
+        DensePoly.leadingCoeff a * DensePoly.leadingCoeff b ≠ (0 : ZMod64 p) := by
+      rw [← hlead_ab]; exact hlead_ab_ne
+    have hcanon :
+        (DensePoly.leadingCoeff a * DensePoly.leadingCoeff b)⁻¹ *
+          (DensePoly.leadingCoeff a * DensePoly.leadingCoeff b) = 1 :=
+      ZMod64.inv_mul_eq_one_of_prime hp habinv_ne
+    -- Cancellation: `(c - d) * x = 0` and `x ≠ 0` ⇒ `c = d`.
+    have hdiff :
+        ((DensePoly.leadingCoeff a * DensePoly.leadingCoeff b)⁻¹ -
+          ((DensePoly.leadingCoeff a)⁻¹ * (DensePoly.leadingCoeff b)⁻¹)) *
+          (DensePoly.leadingCoeff a * DensePoly.leadingCoeff b) = 0 := by
+      grind
+    rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp hdiff with hz | hz
+    · grind
+    · exact False.elim (habinv_ne hz)
+  -- LHS computation.
+  unfold monicModularImage
+  simp only [ha_iszero, hb_iszero, hab_iszero, Bool.false_eq_true, ↓reduceIte]
+  rw [hlead_ab, hinv_distrib]
+  -- Goal: scale ((lc a)⁻¹ * (lc b)⁻¹) (a * b) = scale (lc a)⁻¹ a * scale (lc b)⁻¹ b
+  -- Calc through scale_scale + scale_mul_left + mul_comm to align both sides.
+  calc DensePoly.scale ((DensePoly.leadingCoeff a)⁻¹ * (DensePoly.leadingCoeff b)⁻¹) (a * b)
+      = DensePoly.scale (DensePoly.leadingCoeff a)⁻¹
+          (DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ (a * b)) := by
+        rw [← FpPoly.scale_scale]
+    _ = DensePoly.scale (DensePoly.leadingCoeff a)⁻¹
+          (DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ (b * a)) := by
+        rw [FpPoly.mul_comm a b]
+    _ = DensePoly.scale (DensePoly.leadingCoeff a)⁻¹
+          (DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ b * a) := by
+        rw [FpPoly.scale_mul_left]
+    _ = DensePoly.scale (DensePoly.leadingCoeff a)⁻¹
+          (a * DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ b) := by
+        rw [FpPoly.mul_comm (DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ b) a]
+    _ = DensePoly.scale (DensePoly.leadingCoeff a)⁻¹ a *
+          DensePoly.scale (DensePoly.leadingCoeff b)⁻¹ b := by
+        rw [FpPoly.scale_mul_left]
+
+/-- The constant polynomial `1` over a prime modulus is nonzero. -/
+private theorem fpPoly_one_ne_zero
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) : (1 : FpPoly p) ≠ 0 := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  intro h
+  have hcoeff := congrArg (fun f : FpPoly p => f.coeff 0) h
+  change (1 : FpPoly p).coeff 0 = (0 : FpPoly p).coeff 0 at hcoeff
+  rw [DensePoly.coeff_zero] at hcoeff
+  have hone_coeff : (1 : FpPoly p).coeff 0 = (1 : ZMod64 p) := by
+    change (DensePoly.C (1 : ZMod64 p)).coeff 0 = (1 : ZMod64 p)
+    rw [DensePoly.coeff_C]
+    simp
+  rw [hone_coeff] at hcoeff
+  exact ZMod64.one_ne_zero_of_prime hp hcoeff
+
+/-- The constant polynomial `1` over a prime modulus is monic. -/
+private theorem fpPoly_one_monic
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p) :
+    DensePoly.Monic (1 : FpPoly p) := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  have hsize : (1 : FpPoly p).size = 1 := by
+    have h_le : (1 : FpPoly p).size ≤ 1 := by
+      change (DensePoly.C (1 : ZMod64 p) : FpPoly p).size ≤ 1
+      exact DensePoly.size_C_le_one (1 : ZMod64 p)
+    have h_ge : 1 ≤ (1 : FpPoly p).size :=
+      FpPoly.size_pos_of_ne_zero (fpPoly_one_ne_zero hp)
+    omega
+  unfold DensePoly.Monic
+  rw [DensePoly.leadingCoeff_eq_coeff_last (1 : FpPoly p) (by omega)]
+  rw [hsize]
+  change (DensePoly.C (1 : ZMod64 p)).coeff (1 - 1) = 1
+  rw [DensePoly.coeff_C]
+  simp
+
+/-- `Hex.Berlekamp.factorProduct` of a list whose elements are all nonzero is
+itself nonzero (over a prime field). -/
+private theorem factorProduct_ne_zero_of_forall_ne_zero
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p)
+    (l : List (FpPoly p)) (hne : ∀ g ∈ l, g ≠ 0) :
+    Hex.Berlekamp.factorProduct l ≠ 0 := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  induction l with
+  | nil => exact fpPoly_one_ne_zero hp
+  | cons h tail ih =>
+      rw [Hex.Berlekamp.factorProduct_cons]
+      exact FpPoly.mul_ne_zero_of_ne_zero
+        (hne h List.mem_cons_self)
+        (ih (fun g hg => hne g (List.mem_cons_of_mem _ hg)))
+
+/-- `monicModularImage` is multiplicative across `Hex.Berlekamp.factorProduct`
+on lists of nonzero factors: pulling each factor through `monicModularImage`
+before taking the product agrees with applying `monicModularImage` to the raw
+product.  Inductive consequence of `monicModularImage_mul_of_nonzero` plus
+`monicModularImage_eq_self_of_monic` at the base case `factorProduct [] = 1`. -/
+theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
+    {p : Nat} [ZMod64.Bounds p] (hp : Nat.Prime p)
+    (l : List (FpPoly p)) (hne : ∀ g ∈ l, g ≠ 0) :
+    Hex.Berlekamp.factorProduct (l.map monicModularImage) =
+      monicModularImage (Hex.Berlekamp.factorProduct l) := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  induction l with
+  | nil =>
+      simp only [List.map_nil]
+      rw [Hex.Berlekamp.factorProduct_nil]
+      -- Goal: 1 = monicModularImage 1
+      rw [monicModularImage_eq_self_of_monic hp 1 (fpPoly_one_monic hp)]
+  | cons head tail ih =>
+      have hhead_ne : head ≠ 0 := hne head List.mem_cons_self
+      have htail_ne : ∀ g ∈ tail, g ≠ 0 :=
+        fun g hg => hne g (List.mem_cons_of_mem _ hg)
+      have htail_prod_ne : Hex.Berlekamp.factorProduct tail ≠ 0 :=
+        factorProduct_ne_zero_of_forall_ne_zero hp tail htail_ne
+      have ih_eq := ih htail_ne
+      simp only [List.map_cons]
+      rw [Hex.Berlekamp.factorProduct_cons, Hex.Berlekamp.factorProduct_cons]
+      rw [ih_eq]
+      rw [monicModularImage_mul_of_nonzero hp hhead_ne htail_prod_ne]
+
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
     Array (@FpPoly c.p c.bounds) :=
   letI := c.bounds

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -494,7 +494,7 @@ theorem monicModularImage_monic
   exact ZMod64.inv_mul_eq_one_of_prime hp hlead_ne
 
 /-- A nonzero `FpPoly p` translates to `isZero = false`. -/
-private theorem isZero_false_of_ne_zero
+theorem isZero_false_of_ne_zero
     {p : Nat} [ZMod64.Bounds p] {f : FpPoly p} (hf : f ≠ 0) :
     f.isZero = false := by
   cases hz : f.isZero with

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -499,16 +499,22 @@ private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
   letI := c.field
   let fModP := ZPoly.modP c.p f
   if hzero : fModP.isZero = false then
-    (Berlekamp.berlekampFactor
+    ((Berlekamp.berlekampFactor
       (monicModularImage fModP)
-      (monicModularImage_monic c.prime fModP hzero)).factors.toArray
+      (monicModularImage_monic c.prime fModP hzero)).factors.map
+        monicModularImage).toArray
   else
     #[]
 
 /--
 Defining equation for `berlekampFactorsModP` on a candidate whose modular image
-is nonzero: the factor array is exactly the executable Berlekamp factor list
-applied to the candidate's monic modular image.
+is nonzero: the factor array is the executable Berlekamp factor list applied to
+the candidate's monic modular image, with each factor post-processed through
+`monicModularImage` to normalise it to its monic associate.  The EEA-based
+`DensePoly.gcd` returns each Berlekamp split factor up to a unit scalar, so the
+extraction layer applies the leading-coefficient inverse scaling here, isolating
+the normalisation step to this consumer without touching
+`HexBerlekamp/Factor.lean`.
 -/
 private theorem berlekampFactorsModP_eq_of_isZero_false
     (f : ZPoly) (c : SmallPrimeCandidate) :
@@ -516,9 +522,10 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
     letI := c.field
     ∀ (hzero : (ZPoly.modP c.p f).isZero = false),
       berlekampFactorsModP f c =
-        (Berlekamp.berlekampFactor
+        ((Berlekamp.berlekampFactor
           (monicModularImage (ZPoly.modP c.p f))
-          (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.toArray := by
+          (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.map
+            monicModularImage).toArray := by
   letI := c.bounds
   letI := c.field
   intro hzero
@@ -1584,10 +1591,10 @@ def factorsModPBerlekampForm
     (hzero : (ZPoly.modP data.p f).isZero = false)
     (hfield : Lean.Grind.Field (ZMod64 data.p)),
     data.factorsModP =
-      (@Berlekamp.berlekampFactor data.p data.bounds
+      ((@Berlekamp.berlekampFactor data.p data.bounds
         (monicModularImage (ZPoly.modP data.p f))
         (monicModularImage_monic hprime (ZPoly.modP data.p f) hzero)
-        hfield).factors.toArray
+        hfield).factors.map monicModularImage).toArray
 
 private theorem primeChoiceDataScore_factorsModPBerlekampForm
     (f : ZPoly) (c : SmallPrimeCandidate) (score : PrimeChoiceDataScore)
@@ -1679,12 +1686,12 @@ theorem choosePrimeData?_factorsModP_berlekamp_form
     ∃ (hzero : (ZPoly.modP data.p f).isZero = false)
       (hfield : Lean.Grind.Field (ZMod64 data.p)),
       data.factorsModP =
-        (@Berlekamp.berlekampFactor data.p data.bounds
+        ((@Berlekamp.berlekampFactor data.p data.bounds
           (monicModularImage (ZPoly.modP data.p f))
           (monicModularImage_monic
             (choosePrimeData?_prime f data hdata)
             (ZPoly.modP data.p f) hzero)
-          hfield).factors.toArray := by
+          hfield).factors.map monicModularImage).toArray := by
   unfold choosePrimeData? at hdata
   cases hscore :
       smallPrimeCandidates.foldl (choosePrimeDataScoreStep f) none with

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4074,19 +4074,17 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
     rw [hdeg] at hpos
     simp at hpos
   -- The product of the Berlekamp factors equals the monic modular image
-  -- (by `prod_berlekampFactor`; the unused `_hsquareFree` parameter was
-  -- removed from `prod_berlekampFactor`'s signature).
+  -- (by `factorProduct_berlekampFactor`).
   have hprod :
       Hex.Berlekamp.factorProduct
           (@Hex.Berlekamp.berlekampFactor data.p data.bounds
             (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
             (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
             hfield).factors =
-        Hex.monicModularImage (Hex.ZPoly.modP data.p f) := by
-    have := Hex.Berlekamp.prod_berlekampFactor
+        Hex.monicModularImage (Hex.ZPoly.modP data.p f) :=
+    Hex.Berlekamp.factorProduct_berlekampFactor
       (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
       (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
-    simpa [Hex.Berlekamp.Factorization.product] using this
   -- Now show that `monicModularImage` is injective on the Berlekamp factor list:
   -- two distinct factors that agree under `monicModularImage` would be unit
   -- multiples, contradicting square-freeness of the monic image.
@@ -4640,13 +4638,11 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
   have hprod_eq_raw :
       Hex.Berlekamp.factorProduct raw =
         Hex.ZPoly.modP primeData.p core := by
-    have hp_berlekamp :=
-      Hex.Berlekamp.prod_berlekampFactor (p := primeData.p)
-        (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-        hmonicImage_monic
-    rw [Hex.Berlekamp.Factorization.product_def] at hp_berlekamp
-    show Hex.Berlekamp.factorProduct _ = _
-    rw [hp_berlekamp, hmonicImage_eq]
+    show Hex.Berlekamp.factorProduct
+        (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
+          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+          hmonicImage_monic hfield).factors = _
+    rw [Hex.Berlekamp.factorProduct_berlekampFactor, hmonicImage_eq]
   -- Each raw factor is nonzero (positive degree in the typical case; singleton
   -- `[monicImg]` in the degenerate size-≤-1 case, and `monicImg` is monic).
   have hraw_ne : ∀ g ∈ raw, g ≠ 0 :=

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -5063,6 +5063,51 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
   rw [heq]
   simpa using hcps
 
+/-- Discharge of the per-modular-factor monicness premise on
+`henselLiftData_liftedFactor_monic_of_choosePrimeData` (and the two other
+umbrellas at lines 5136 and 5200) from the `factorsModPBerlekampForm` invariant
+alone.
+
+`primeData.factorsModP` is, under the Option-3 wrap in `berlekampFactorsModP`,
+exactly `((berlekampFactor monicImg).factors.map monicModularImage).toArray`.
+Every entry is therefore the `monicModularImage` of some raw Berlekamp factor,
+which is monic by `monicModularImage_monic` provided the raw factor is nonzero.
+The raw-factor nonzeroness is `berlekampFactor_factors_ne_zero` (positive-degree
+case via `berlekampFactor_factors_pos_degree`, degenerate `[monicImg]` case
+because `monicImg` is monic).
+
+No `hgood` or `hcore_monic` premise is needed: the discharge follows from the
+shape of `factorsModPBerlekampForm` and Berlekamp-output structural facts
+alone.  This is the fourth and last of the
+`QuadraticMultifactorLiftInvariant` boundary dischargers (together with
+`factorsModP_ne_nil_*`, `factorsModP_polyProduct_congr_*`, and
+`factorsModP_coprime_*`) that the umbrellas consume via
+`QuadraticMultifactorLiftInvariant_of_choosePrimeData`. -/
+theorem factorsModP_monic_of_factorsModPBerlekampForm
+    (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hform : Hex.factorsModPBerlekampForm core primeData) :
+    letI := primeData.bounds
+    ∀ g ∈ primeData.factorsModP, Hex.DensePoly.Monic g := by
+  letI : Hex.ZMod64.Bounds primeData.p := primeData.bounds
+  obtain ⟨hprime, hzero, hfield, heq⟩ := hform
+  letI : Hex.ZMod64.PrimeModulus primeData.p :=
+    Hex.ZMod64.primeModulusOfPrime hprime
+  have hmonicImage_monic :
+      Hex.DensePoly.Monic (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
+    Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
+  -- Each entry of `factorsModP` is `monicModularImage g'` for some `g'` in the
+  -- raw Berlekamp output, and each such `g'` is nonzero.
+  intro g hg
+  rw [heq] at hg
+  rw [List.mem_toArray, List.mem_map] at hg
+  obtain ⟨g', hg'_mem, hg'_eq⟩ := hg
+  have hg'_ne : g' ≠ 0 :=
+    Hex.Berlekamp.berlekampFactor_factors_ne_zero
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+      hmonicImage_monic g' hg'_mem
+  rw [← hg'_eq]
+  exact Hex.monicModularImage_monic hprime g' (Hex.isZero_false_of_ne_zero hg'_ne)
+
 /-- Composed convenience wrapper: combines
 `Hex.ZPoly.QuadraticMultifactorLiftInvariant_of_choosePrimeData` with
 `henselLiftData_liftedFactor_injective` so that a Mathlib-bridge consumer can

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4489,7 +4489,7 @@ theorem factorsModP_ne_nil_of_factorsModPBerlekampForm
       (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
       (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero)
   rw [heq]
-  simpa using hbl_ne
+  simpa [List.map_eq_nil_iff] using hbl_ne
 
 /-- Generalized inductive helper for the `factorsModP_coprime` discharger.
 

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4608,7 +4608,7 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hcore_monic : Hex.DensePoly.Monic core)
     (hform : Hex.factorsModPBerlekampForm core primeData)
-    (hgood :
+    (_hgood :
       letI := primeData.bounds
       Hex.isGoodPrime core primeData.p = true) :
     letI := primeData.bounds
@@ -4629,35 +4629,43 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
   have hmonicImage_monic :
       Hex.DensePoly.Monic (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
     Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
-  -- Square-freeness of `monicModularImage (modP p core)` follows from
-  -- `isGoodPrime`'s square-freeness of `modP p core`, transported through
-  -- `hmonicImage_eq`.
-  have hsf_monic :
-      Hex.DensePoly.gcd (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-          (Hex.DensePoly.derivative
-            (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))) = 1 := by
-    rw [hmonicImage_eq]
-    exact Hex.isGoodPrime_squareFreeModP core primeData.p hgood
-  -- `(berlekampFactor monicImg).product = monicImg = modP p core`.
-  have hprod_eq :
-      Hex.Berlekamp.factorProduct
-        (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
-          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-          hmonicImage_monic hfield).factors =
+  -- Raw Berlekamp factor list: under the Option-3 wrap, `primeData.factorsModP`
+  -- is `raw.map monicModularImage` (then `.toArray`), so the bridge lemma must
+  -- apply to the mapped list, not `raw`.
+  let raw :=
+      (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
+        (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+        hmonicImage_monic hfield).factors
+  -- `factorProduct raw = monicImg = modP p core` (the latter because `core` is monic).
+  have hprod_eq_raw :
+      Hex.Berlekamp.factorProduct raw =
         Hex.ZPoly.modP primeData.p core := by
     have hp_berlekamp :=
       Hex.Berlekamp.prod_berlekampFactor (p := primeData.p)
         (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-        hmonicImage_monic hsf_monic
+        hmonicImage_monic
     rw [Hex.Berlekamp.Factorization.product_def] at hp_berlekamp
+    show Hex.Berlekamp.factorProduct _ = _
     rw [hp_berlekamp, hmonicImage_eq]
-  -- Apply the bridge lemma at the Berlekamp factor list.
+  -- Each raw factor is nonzero (positive degree in the typical case; singleton
+  -- `[monicImg]` in the degenerate size-≤-1 case, and `monicImg` is monic).
+  have hraw_ne : ∀ g ∈ raw, g ≠ 0 :=
+    Hex.Berlekamp.berlekampFactor_factors_ne_zero
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+      hmonicImage_monic
+  -- Push `monicModularImage` through `factorProduct`:
+  -- `factorProduct (raw.map monicModularImage) = monicModularImage (factorProduct raw)
+  --   = monicModularImage (modP p core) = modP p core`.
+  have hprod_eq_mapped :
+      Hex.Berlekamp.factorProduct (raw.map Hex.monicModularImage) =
+        Hex.ZPoly.modP primeData.p core := by
+    rw [Hex.factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
+        hprime raw hraw_ne, hprod_eq_raw, hmonicImage_eq]
+  -- Apply the bridge lemma at the *mapped* Berlekamp factor list.
   have hbridge :=
     polyProduct_map_liftToZ_congr_factorProduct (p := primeData.p)
-      (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
-        (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-        hmonicImage_monic hfield).factors
-  rw [hprod_eq] at hbridge
+      (raw.map Hex.monicModularImage)
+  rw [hprod_eq_mapped] at hbridge
   -- Combine the bridge with `congr_liftToZ_modP` to land at `core` (mod p).
   have hmodP_congr :
       Hex.ZPoly.congr
@@ -4895,6 +4903,7 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
               rw [hq, hk]; exact Hex.DensePoly.mul_assoc_poly _ _ _
             exact ih hrest_dvd
 
+set_option maxHeartbeats 400000 in
 /-- Discharge of the coprime-splits boundary premise on
 `Hex.ZPoly.QuadraticMultifactorLiftInvariant_of_choosePrimeData`: given the
 `factorsModPBerlekampForm` invariant (which records that `primeData.factorsModP`
@@ -4917,7 +4926,12 @@ This is the third in the chain of `factorsModP`-side dischargers
 mapping the abstract `factorsModPBerlekampForm` invariant plus an
 `isGoodPrime` certificate to a piece of the four-tuple
 `(hfactors_monic, hproduct_mod_p, hcoprime, hnonempty)` that the umbrella
-`QuadraticMultifactorLiftInvariant_of_choosePrimeData` consumes. -/
+`QuadraticMultifactorLiftInvariant_of_choosePrimeData` consumes.
+
+The Option-3 wrap of `berlekampFactorsModP` (apply `monicModularImage` per
+factor) lifts the helper application from the raw Berlekamp factor list to
+the mapped list via the multiplicativity bridge
+`factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct`. -/
 theorem factorsModP_coprime_of_factorsModPBerlekampForm
     (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hform : Hex.factorsModPBerlekampForm core primeData)
@@ -4986,21 +5000,22 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
           | succ _ => simp at hunit
     rw [hdeg] at hpos
     simp at hpos
+  -- Monic image is monic (consumed by Berlekamp's signature and idempotence).
+  have hmonicImage_monic :
+      Hex.DensePoly.Monic (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
+    Hex.monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
+  -- Raw Berlekamp factor list: under the Option-3 wrap, `primeData.factorsModP`
+  -- is `raw.map monicModularImage` (then `.toArray`), so the helper must be
+  -- applied at the mapped list.
+  let raw :=
+      (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
+        (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+        hmonicImage_monic hfield).factors
   -- The Berlekamp factor list has product equal to the monic modular image.
   have h_factorProduct :
-      Hex.Berlekamp.factorProduct
-        (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
-          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-          (Hex.monicModularImage_monic hprime _ hzero) hfield).factors =
+      Hex.Berlekamp.factorProduct raw =
         Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) :=
     Hex.Berlekamp.factorProduct_berlekampFactor _ _
-  -- Pull out positivity of each Berlekamp factor: relies on positivity of the
-  -- modular image, which holds when its size is ≥ 2.  We unconditionally have
-  -- size ≥ 1 (nonzero); for size = 1 the Berlekamp list is `[f]` itself, and
-  -- the recursive predicate is trivial on a singleton list, so positivity is
-  -- only required when there are ≥ 2 factors.  We sidestep this by using the
-  -- `factorProduct ∣ X` chain directly: the helper does not require positivity,
-  -- only the no-squared invariant on `X`.
   -- Monic modular image is nonzero (it's a nonzero scalar of a nonzero poly).
   have hmonicImage_ne :
       Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) ≠ 0 := by
@@ -5016,23 +5031,34 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
       rw [h0]; rfl
     rw [hmon_size] at hsize_zero
     omega
-  -- Apply the generalized helper.
-  have h_dvd_X :
-      Hex.Berlekamp.factorProduct
-        (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
-          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-          (Hex.monicModularImage_monic hprime _ hzero) hfield).factors ∣
+  -- Each raw Berlekamp factor is nonzero (positive degree typically, singleton
+  -- [monicImg] in the degenerate size-≤-1 case).
+  have hraw_ne : ∀ g ∈ raw, g ≠ 0 :=
+    Hex.Berlekamp.berlekampFactor_factors_ne_zero
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+      hmonicImage_monic
+  -- Push `monicModularImage` through `factorProduct`: the mapped product
+  -- equals `monicModularImage (factorProduct raw) = monicModularImage (monicImg)
+  -- = monicImg` (the last step uses that `monicImg` is already monic).
+  have hprod_mapped :
+      Hex.Berlekamp.factorProduct (raw.map Hex.monicModularImage) =
         Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) := by
+    rw [Hex.factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
+        hprime raw hraw_ne]
     rw [h_factorProduct]
+    exact Hex.monicModularImage_eq_self_of_monic hprime _ hmonicImage_monic
+  -- Apply the generalized helper at the mapped list.
+  have h_dvd_X_mapped :
+      Hex.Berlekamp.factorProduct (raw.map Hex.monicModularImage) ∣
+        Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) := by
+    rw [hprod_mapped]
     exact Hex.DensePoly.dvd_refl_poly _
   have hcps :
       Hex.ZPoly.QuadraticMultifactorCoprimeSplits primeData.p
-        (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
-          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-          (Hex.monicModularImage_monic hprime _ hzero) hfield).factors :=
+        (raw.map Hex.monicModularImage) :=
     quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
       (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
-      hmonicImage_ne h_no_squared _ h_dvd_X
+      hmonicImage_ne h_no_squared _ h_dvd_X_mapped
   -- Transport to the `factorsModP.toList` view.
   rw [heq]
   simpa using hcps

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4073,9 +4073,197 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
           | succ _ => simp at hunit
     rw [hdeg] at hpos
     simp at hpos
-  -- Transport `Nodup` from the Berlekamp factor list to `data.factorsModP.toList`.
+  -- The product of the Berlekamp factors equals the monic modular image
+  -- (by `prod_berlekampFactor`; the unused `_hsquareFree` parameter was
+  -- removed from `prod_berlekampFactor`'s signature).
+  have hprod :
+      Hex.Berlekamp.factorProduct
+          (@Hex.Berlekamp.berlekampFactor data.p data.bounds
+            (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+            (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+            hfield).factors =
+        Hex.monicModularImage (Hex.ZPoly.modP data.p f) := by
+    have := Hex.Berlekamp.prod_berlekampFactor
+      (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+      (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+    simpa [Hex.Berlekamp.Factorization.product] using this
+  -- Now show that `monicModularImage` is injective on the Berlekamp factor list:
+  -- two distinct factors that agree under `monicModularImage` would be unit
+  -- multiples, contradicting square-freeness of the monic image.
+  set factors :=
+      (@Hex.Berlekamp.berlekampFactor data.p data.bounds
+        (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+        (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+        hfield).factors with hfactors_def
+  have hinj_on :
+      ∀ g₁ ∈ factors, ∀ g₂ ∈ factors,
+        Hex.monicModularImage g₁ = Hex.monicModularImage g₂ → g₁ = g₂ := by
+    intro g₁ hg₁ g₂ hg₂ heqm
+    by_contra hne
+    -- Both factors are nonzero: their monic images agree, and a zero factor
+    -- has `monicModularImage = 0` while a nonzero factor has nonzero
+    -- `monicModularImage` (positive leading coefficient).  But we use a
+    -- more direct argument via square-freeness, so we just extract
+    -- nonzero-ness from positive degree.
+    -- Factors of a monic square-free polynomial have positive degree, so are
+    -- nonzero.  However, the discharger does not assume input positive degree,
+    -- so we handle the degenerate `factors = [1]` case via length.
+    -- If factors has fewer than 2 distinct elements, hg₁/hg₂/hne contradict.
+    -- Use `mul_dvd_factorProduct_of_mem_of_ne` to extract `g₁ * g₂ ∣ factorProduct`.
+    have hg₁_dvd_g₂ :
+        g₁ * g₂ ∣ Hex.Berlekamp.factorProduct factors :=
+      Hex.Berlekamp.mul_dvd_factorProduct_of_mem_of_ne hNodup hg₁ hg₂ hne
+    -- Hence g₁ * g₂ ∣ monicImage modP_f.
+    rw [hprod] at hg₁_dvd_g₂
+    -- Hence g₁ * g₂ ∣ modP_f.  Construct the dvd witness manually because the
+    -- `dvd` instance for `FpPoly p` is `instDvdOfAddOfMul`, not the default
+    -- `semigroupDvd`, and `dvd_trans` doesn't see through that.
+    have hg₁g₂_dvd_modP :
+        g₁ * g₂ ∣ Hex.ZPoly.modP data.p f := by
+      rcases hg₁_dvd_g₂ with ⟨r, hr⟩
+      rcases hmonicImage_dvd with ⟨s, hs⟩
+      exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+    -- From `monicModularImage g₁ = monicModularImage g₂`, both being nonzero,
+    -- we get `g₁ = scale u g₂` for some nonzero `u`.  Use this to conclude
+    -- `g₂² ∣ modP_f`, contradicting square-freeness.
+    -- First we need positive degree of g₁, g₂ to know they're nonzero.
+    -- For this, we case on whether `monicImage modP_f` has positive degree.
+    by_cases hpos_image :
+        0 < (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).degree?.getD 0
+    · -- Positive-degree input: every Berlekamp factor has positive degree.
+      have hg_pos :
+          ∀ g ∈ factors, 0 < g.degree?.getD 0 :=
+        Hex.Berlekamp.berlekampFactor_factors_pos_degree
+          (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+          (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+          hpos_image
+      have hg₁_pos : 0 < g₁.degree?.getD 0 := hg_pos g₁ hg₁
+      have hg₂_pos : 0 < g₂.degree?.getD 0 := hg_pos g₂ hg₂
+      have hg₁_size_pos : 0 < g₁.size := by
+        unfold Hex.DensePoly.degree? at hg₁_pos
+        by_cases hsz : g₁.size = 0
+        · simp [hsz] at hg₁_pos
+        · exact Nat.pos_of_ne_zero hsz
+      have hg₂_size_pos : 0 < g₂.size := by
+        unfold Hex.DensePoly.degree? at hg₂_pos
+        by_cases hsz : g₂.size = 0
+        · simp [hsz] at hg₂_pos
+        · exact Nat.pos_of_ne_zero hsz
+      -- Show g₁ = scale u g₂ for u = lc g₁ · (lc g₂)⁻¹ ≠ 0.
+      have hg₁_lead_ne :
+          Hex.DensePoly.leadingCoeff g₁ ≠ (0 : Hex.ZMod64 data.p) :=
+        Hex.FpPoly.leadingCoeff_ne_zero_of_pos_degree g₁ hg₁_pos
+      have hg₂_lead_ne :
+          Hex.DensePoly.leadingCoeff g₂ ≠ (0 : Hex.ZMod64 data.p) :=
+        Hex.FpPoly.leadingCoeff_ne_zero_of_pos_degree g₂ hg₂_pos
+      have hg₁_isZero : g₁.isZero = false := by
+        cases hz : g₁.isZero with
+        | false => rfl
+        | true =>
+          exfalso
+          have hsize_zero : g₁.size = 0 := by
+            change g₁.coeffs.isEmpty = true at hz
+            simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hz
+          omega
+      have hg₂_isZero : g₂.isZero = false := by
+        cases hz : g₂.isZero with
+        | false => rfl
+        | true =>
+          exfalso
+          have hsize_zero : g₂.size = 0 := by
+            change g₂.coeffs.isEmpty = true at hz
+            simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hz
+          omega
+      -- Express both monicModularImages explicitly: `scale (lc gᵢ)⁻¹ gᵢ`.
+      have hmm₁_eq :
+          Hex.monicModularImage g₁ =
+            Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₁)⁻¹ g₁ := by
+        unfold Hex.monicModularImage
+        simp [hg₁_isZero]
+      have hmm₂_eq :
+          Hex.monicModularImage g₂ =
+            Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₂)⁻¹ g₂ := by
+        unfold Hex.monicModularImage
+        simp [hg₂_isZero]
+      rw [hmm₁_eq, hmm₂_eq] at heqm
+      -- Apply `scale (lc g₁)` to both sides to recover `g₁` on the LHS.
+      have hscaled :
+          Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₁)
+            (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₁)⁻¹ g₁) =
+          Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₁)
+            (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff g₂)⁻¹ g₂) := by
+        rw [heqm]
+      rw [Hex.FpPoly.scale_scale,
+          show Hex.DensePoly.leadingCoeff g₁ *
+            (Hex.DensePoly.leadingCoeff g₁)⁻¹ = (1 : Hex.ZMod64 data.p) from
+              Hex.ZMod64.mul_inv_eq_one_of_prime hprime hg₁_lead_ne,
+          Hex.FpPoly.scale_one_left g₁,
+          Hex.FpPoly.scale_scale] at hscaled
+      -- Now `hscaled : g₁ = scale (lc g₁ * (lc g₂)⁻¹) g₂`.
+      set u := Hex.DensePoly.leadingCoeff g₁ *
+                 (Hex.DensePoly.leadingCoeff g₂)⁻¹ with hu_def
+      have hu_ne : u ≠ (0 : Hex.ZMod64 data.p) := by
+        intro h0
+        rw [hu_def] at h0
+        rcases Hex.ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero
+            (Hex.ZMod64.PrimeModulus.prime (p := data.p)) h0 with h1 | h2
+        · exact hg₁_lead_ne h1
+        · exact (Hex.ZMod64.inv_ne_zero_of_prime hprime hg₂_lead_ne) h2
+      have hg₁_eq_scale : g₁ = Hex.DensePoly.scale u g₂ := hscaled
+      -- Then g₁ * g₂ = scale u (g₂²), and g₂² ∣ scale u (g₂²) since u ≠ 0.
+      have hg₁g₂_eq : g₁ * g₂ = Hex.DensePoly.scale u (g₂ * g₂) := by
+        rw [hg₁_eq_scale, Hex.FpPoly.scale_mul_left]
+      have hg₂sq_dvd : g₂ * g₂ ∣ Hex.DensePoly.scale u (g₂ * g₂) := by
+        refine ⟨Hex.DensePoly.C u, ?_⟩
+        -- Goal: scale u (g₂ * g₂) = g₂ * g₂ * C u
+        calc Hex.DensePoly.scale u (g₂ * g₂)
+            = Hex.DensePoly.C u * (g₂ * g₂) := (Hex.FpPoly.C_mul_eq_scale u (g₂ * g₂)).symm
+          _ = (g₂ * g₂) * Hex.DensePoly.C u :=
+              Hex.DensePoly.mul_comm_poly _ _
+      have hg₂sq_dvd_modP : g₂ * g₂ ∣ Hex.ZPoly.modP data.p f := by
+        rw [hg₁g₂_eq] at hg₁g₂_dvd_modP
+        rcases hg₂sq_dvd with ⟨r, hr⟩
+        rcases hg₁g₂_dvd_modP with ⟨s, hs⟩
+        exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+      -- Square-freeness implies g₂ is a unit polynomial (degree 0).
+      have hunit : Hex.Berlekamp.isUnitPolynomial g₂ = true :=
+        Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsf hg₂sq_dvd_modP
+      have hdeg_zero : Hex.DensePoly.degree? g₂ = some 0 := by
+        unfold Hex.Berlekamp.isUnitPolynomial at hunit
+        cases hd : Hex.DensePoly.degree? g₂ with
+        | none => rw [hd] at hunit; simp at hunit
+        | some k =>
+            rw [hd] at hunit
+            cases k with
+            | zero => rfl
+            | succ _ => simp at hunit
+      rw [hdeg_zero] at hg₂_pos
+      simp at hg₂_pos
+    · -- Degenerate case: the monic image has degree 0.  Then it has size ≤ 1,
+      -- and the Berlekamp factor list is the singleton `[monicImage modP_f]`.
+      -- Hence `g₁ = g₂` (both equal to the unique factor), contradicting `hne`.
+      have hsize_le_one : (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).size ≤ 1 := by
+        by_contra h
+        push_neg at h
+        apply hpos_image
+        have hsize_ne : (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).size ≠ 0 := by
+          omega
+        unfold Hex.DensePoly.degree?
+        simp [hsize_ne]
+        omega
+      have hfactors_eq :
+          factors = [Hex.monicModularImage (Hex.ZPoly.modP data.p f)] :=
+        Hex.Berlekamp.berlekampFactor_factors_eq_singleton_of_size_le_one
+          (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
+          (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
+          hsize_le_one
+      rw [hfactors_eq] at hg₁ hg₂
+      rw [List.mem_singleton] at hg₁ hg₂
+      exact hne (hg₁.trans hg₂.symm)
+  -- Transport `Nodup` from the post-mapped Berlekamp factor list to
+  -- `data.factorsModP.toList`.
   rw [heq]
-  simpa using hNodup
+  simpa using List.Nodup.map_on hinj_on hNodup
 
 /-- Discharge of the per-modular-factor natural-degree positivity premise on
 `henselLiftData_liftedFactor_natDegree_pos`: given the `factorsModPBerlekampForm`
@@ -4181,15 +4369,39 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
       hmonicImage_pos
   -- Step C: transport positivity from FpPoly factors to integer-side `toPolynomial`.
   intro g hg
-  -- Membership: g ∈ data.factorsModP corresponds to g ∈ berlekampFactor.factors via heq.
-  have hg_factors :
-      g ∈ (@Hex.Berlekamp.berlekampFactor data.p data.bounds
-            (Hex.monicModularImage (Hex.ZPoly.modP data.p f))
-            (Hex.monicModularImage_monic hprime (Hex.ZPoly.modP data.p f) hzero)
-            hfield).factors := by
-    rw [heq] at hg
-    simpa using hg
-  have hg_pos : 0 < g.degree?.getD 0 := hFactorsPos g hg_factors
+  -- Membership: g ∈ data.factorsModP corresponds to g = monicModularImage h for
+  -- some h ∈ berlekampFactor.factors via heq.
+  rw [heq] at hg
+  simp only [List.mem_toArray, List.mem_map] at hg
+  obtain ⟨h, hh_mem, rfl⟩ := hg
+  -- Positivity of `h`.
+  have hh_pos : 0 < h.degree?.getD 0 := hFactorsPos h hh_mem
+  -- Show `monicModularImage h` has positive degree (preserved by nonzero scaling).
+  have hh_size_pos : 0 < h.size := by
+    unfold Hex.DensePoly.degree? at hh_pos
+    by_cases hsz : h.size = 0
+    · simp [hsz] at hh_pos
+    · exact Nat.pos_of_ne_zero hsz
+  have hh_lead_ne : Hex.DensePoly.leadingCoeff h ≠ (0 : Hex.ZMod64 data.p) :=
+    Hex.FpPoly.leadingCoeff_ne_zero_of_pos_degree h hh_pos
+  have hh_isZero : h.isZero = false := by
+    cases hz : h.isZero with
+    | false => rfl
+    | true =>
+      exfalso
+      have hsize_zero : h.size = 0 := by
+        change h.coeffs.isEmpty = true at hz
+        simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hz
+      omega
+  have hg_degree_eq :
+      (Hex.monicModularImage h).degree? = h.degree? := by
+    unfold Hex.monicModularImage
+    simp only [hh_isZero, Bool.false_eq_true, ↓reduceIte]
+    exact Hex.FpPoly.scale_degree?_eq_of_ne_zero
+      (Hex.ZMod64.inv_ne_zero_of_prime hprime hh_lead_ne) h
+  have hg_pos : 0 < (Hex.monicModularImage h).degree?.getD 0 := by
+    rw [hg_degree_eq]; exact hh_pos
+  set g := Hex.monicModularImage h with hg_def
   -- Show 0 < g.size from hg_pos.
   have hg_size_pos : 0 < g.size := by
     unfold Hex.DensePoly.degree? at hg_pos

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -456,10 +456,10 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
         (@Hex.Berlekamp.berlekampFactor primeData.p primeData.bounds
           (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
           (Hex.monicModularImage_monic hprime_hex (Hex.ZPoly.modP primeData.p core) hzero)
-          hfield).factors.toArray.size =
+          hfield).factors.length =
           primeData.factorsModP.size := by
       rw [hfactors_eq]
-    simp at hsize
+      simp [List.length_map]
     omega
   -- Apply the no-split bridge to obtain Mathlib irreducibility of the monic image.
   have hirr_monic :

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -3018,6 +3018,26 @@ theorem mul_ne_zero_of_ne_zero
   have habsize : (a * b).size = 0 := by rw [hmul]; rfl
   omega
 
+/-- Leading coefficient of a product equals the product of leading coefficients
+on nonzero `FpPoly p` factors: the top-coefficient lemma `coeff_mul_at_top` plus
+the size identity `size_mul_eq_add_sub_one` give this directly. -/
+theorem leadingCoeff_mul
+    [ZMod64.PrimeModulus p] (a b : FpPoly p)
+    (ha : a ≠ 0) (hb : b ≠ 0) :
+    DensePoly.leadingCoeff (a * b)
+      = DensePoly.leadingCoeff a * DensePoly.leadingCoeff b := by
+  have ha_pos : 0 < a.size := size_pos_of_ne_zero ha
+  have hb_pos : 0 < b.size := size_pos_of_ne_zero hb
+  have hab_ne : a * b ≠ 0 := mul_ne_zero_of_ne_zero ha hb
+  have hab_pos : 0 < (a * b).size := size_pos_of_ne_zero hab_ne
+  have hsize := size_mul_eq_add_sub_one a b ha hb
+  have hindex : (a * b).size - 1 = a.size - 1 + (b.size - 1) := by omega
+  rw [DensePoly.leadingCoeff_eq_coeff_last (a * b) hab_pos]
+  rw [hindex]
+  rw [DensePoly.leadingCoeff_eq_coeff_last a ha_pos]
+  rw [DensePoly.leadingCoeff_eq_coeff_last b hb_pos]
+  exact ZMod64.coeff_mul_at_top a b ha_pos hb_pos
+
 /-- Right cancellation for multiplication by a nonzero `FpPoly p` polynomial. -/
 theorem mul_right_cancel_of_ne_zero
     [ZMod64.PrimeModulus p] {a b c : FpPoly p}

--- a/progress/20260517T080050Z_b022d8b8.md
+++ b/progress/20260517T080050Z_b022d8b8.md
@@ -1,0 +1,82 @@
+# 20260517T080050Z — feature session b022d8b8 (#4567)
+
+## Accomplished
+
+Closed out the fourth and final `QuadraticMultifactorLiftInvariant` boundary
+discharger from #4563.  Picked Option 3 (wrap `berlekampFactorsModP` with
+`monicModularImage` per factor), continuing the partial work on the prior
+session's `agent/8abf8773` branch and adding the remaining cascade.
+
+### Branch contents (rebased onto `origin/main`)
+
+* **`a86d86f1`** *(cherry-pick of `7b627ac9`)*: wrap `berlekampFactorsModP`
+  with per-factor `monicModularImage`; update `factorsModPBerlekampForm` and
+  `choosePrimeData?_factorsModP_berlekamp_form` to record the new
+  `(factors.map monicModularImage).toArray` shape.
+* **`7a462078`** *(cherry-pick of `c57cbd2d`)*: update `factorsModP_nodup_*`,
+  `factorsModP_natDegree_pos_*`, `factorsModP_ne_nil_*`, the
+  `squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData`
+  consumer in `IntReductionMod.lean`, plus Berlekamp-side helpers
+  `mul_dvd_factorProduct_of_mem_of_ne` and
+  `berlekampFactor_factors_eq_singleton_of_size_le_one`.
+* **`65200a98`**: new helpers in `HexBerlekampZassenhaus/Basic.lean`
+  (`isZero_false_of_ne_zero`, `monicModularImage_ne_zero_of_ne_zero`,
+  `monicModularImage_eq_self_of_monic`, `monicModularImage_mul_of_nonzero`,
+  `factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct`)
+  plus `FpPoly.leadingCoeff_mul` in `HexPolyFp/Basic.lean` (extracted from
+  the private `Hex.Berlekamp.leadingCoeff_mul_fpoly`).
+* **`b32fea43`**: update `factorsModP_polyProduct_congr_*` and
+  `factorsModP_coprime_*` for the Option-3 wrap, threading the new
+  multiplicativity bridge.  `coprime`'s `let raw := ...` exceeds the default
+  `maxHeartbeats` ceiling under the new structure; locally bumped to 400k.
+  Also adds Berlekamp-level `berlekampFactor_factors_ne_zero` in
+  `HexBerlekamp/Factor.lean`, needed to satisfy the bridge's
+  nonzero-factor premise.
+* **`00ca64d1`**: the actual new
+  `factorsModP_monic_of_factorsModPBerlekampForm` discharger
+  (~25 lines).  Takes no `hgood` or `hcore_monic` premise: every entry of
+  `primeData.factorsModP` is `monicModularImage g'` for some raw factor
+  `g'`, and `g' ≠ 0` from `berlekampFactor_factors_ne_zero`.
+* **`ef23aeab`**: restore `_hsquareFree` premise on `prod_berlekampFactor`
+  to match the deliberate signature in `origin/main`'s #4589 review.
+  Switch my discharger callers to use the (squarefree-free)
+  `factorProduct_berlekampFactor` directly.
+
+### Verification
+
+* `lake build` — clean.
+* `lake build HexBerlekampZassenhausMathlib` — clean.
+* `python3 scripts/check_dag.py` — clean.
+* `git diff --check` — clean.
+* `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` counts in touched files
+  match `origin/main` exactly (no new entries):
+  * `HexBerlekamp/Factor.lean`: 0
+  * `HexBerlekampZassenhaus/Basic.lean`: 1 (pre-existing)
+  * `HexBerlekampZassenhausMathlib/Basic.lean`: 10 (pre-existing)
+  * `HexBerlekampMathlib/Basic.lean`: 19 (pre-existing)
+  * `HexPolyFp/Basic.lean`: 0
+
+## Current frontier
+
+The HO-1 capstone `factor_irreducible_of_nonUnit` (#4170) now has all four
+`QuadraticMultifactorLiftInvariant` boundary dischargers:
+
+* `factorsModP_ne_nil_*` — #4570, landed.
+* `factorsModP_polyProduct_congr_*` — #4573, landed, updated in this PR.
+* `factorsModP_coprime_*` — #4574, landed, updated in this PR.
+* `factorsModP_monic_*` — this PR.
+
+The slow-path exhaustive arm umbrella #4561 is now unblocked; once it lands,
+the capstone can be assembled from the four arm umbrellas (constant/quadratic
+fast and slow, and exhaustive).
+
+## Next step
+
+After this PR lands, the next session should pick up #4561 (slow-path
+exhaustive arm umbrella) which now has all its substrate dischargers.
+A worker for the capstone assembly itself (#4170) will follow once all four
+arms have landed.
+
+## Blockers
+
+None.  All deliverables met and verified.


### PR DESCRIPTION
Closes #4567

Session: `b022d8b8-b11b-40f5-8240-ca3b92795cbf`

b05cf747 chore: progress note for #4567 (factorsModP_monic discharger)
ef23aeab fixup: restore prod_berlekampFactor _hsquareFree premise to match main
00ca64d1 feat: factorsModP_monic discharger from factorsModPBerlekampForm
b32fea43 feat: update polyProduct_congr and coprime dischargers for monic-mapped factorsModP
65200a98 feat: monicModularImage multiplicativity helpers for Option 3 discharger cascade
7a462078 feat: update Nodup + natDegree_pos dischargers for monic-mapped factorsModP
a86d86f1 feat: wip wrap berlekampFactorsModP with per-factor monicModularImage

🤖 Prepared with Claude Code