### PR TITLE
Audit quadratic reassembly classifiers in Basic.lean (sub-issue of #4584)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -8057,39 +8057,6 @@ theorem quadraticIntegerRootFactors?_factor_irreducible_of_primitive
   · exact quadraticIntegerRootFactors?_factor_irreducible_of_ne_residual
       hquad hmem hres
 
-/-- Membership classifier for a reassembled quadratic-root branch. A raw factor
-is either one of the already-proved irreducible normalization/root factors, the
-normalization repeated-part fallback, or the optional residual appended by the
-quadratic splitter. -/
-theorem reassemblePolynomialFactors_quadratic_irreducible_or_repeated_or_residual
-    (d : FactorNormalizationData) {coreFactors : Array ZPoly} {factor : ZPoly}
-    (hquad : quadraticIntegerRootFactors? d.squareFreeCore = some coreFactors)
-    (hmem : factor ∈ (reassemblePolynomialFactors d coreFactors).toList) :
-    ZPoly.Irreducible factor ∨
-      factor ∈ (repeatedPartFactorArray d.repeatedPart).toList ∨
-      factor =
-        (splitIntegerRootFactorsAux d.squareFreeCore
-          (integerRootCandidates d.squareFreeCore)
-          (integerRootCandidates d.squareFreeCore).length).2 := by
-  rcases reassemblePolynomialFactors_mem d coreFactors factor hmem with hprefix | hcore
-  · unfold polynomialNormalizationPrefixFactors at hprefix
-    rw [Array.toList_append] at hprefix
-    simp only [List.mem_append] at hprefix
-    cases hprefix with
-    | inl hx =>
-        exact Or.inl (xPowerFactorArray_irreducible d.xPower factor hx)
-    | inr hrep =>
-        exact Or.inr (Or.inl hrep)
-  · by_cases hres :
-        factor =
-          (splitIntegerRootFactorsAux d.squareFreeCore
-            (integerRootCandidates d.squareFreeCore)
-            (integerRootCandidates d.squareFreeCore).length).2
-    · exact Or.inr (Or.inr hres)
-    · exact Or.inl
-        (quadraticIntegerRootFactors?_factor_irreducible_of_ne_residual
-          hquad hcore hres)
-
 private theorem quadraticIntegerRootFactors?_product
     {core : ZPoly} {factors : Array ZPoly}
     (hquad : quadraticIntegerRootFactors? core = some factors) :

--- a/progress/20260517T081850Z_5c04b2fa.md
+++ b/progress/20260517T081850Z_5c04b2fa.md
@@ -1,0 +1,73 @@
+# 20260517T081850Z — feature session 5c04b2fa (#4588)
+
+## Accomplished
+
+**#4588 (audit quadratic reassembly classifiers in Basic.lean)** —
+resolved via Option C of the issue.
+
+When the issue was filed, two reassembly classifiers for the quadratic
+integer-root branch coexisted in `HexBerlekampZassenhaus/Basic.lean`:
+
+1. `reassemblePolynomialFactors_quadratic_irreducible_or_repeated_or_residual`
+   — the unconditional 3-way classifier.
+2. `reassemblePolynomialFactors_quadratic_irreducible_or_residual_of_expansionComplete`
+   — the `hcomplete`-conditional 2-way classifier added by #4580.
+
+The dependency #4587 has since landed (commit `340ec6c4`, "refactor:
+rewrite slow-quadratic umbrella onto `_of_primitive` (#4587) (#4596)").
+That commit already deleted classifier (2) as part of the slow-quadratic
+umbrella rewrite, since the umbrella now consumes
+`quadraticIntegerRootFactors?_factor_irreducible_of_primitive` directly.
+
+Classifier (1) was therefore the only one left, and `rg` confirmed it
+had zero callers anywhere in the source tree (only historical mentions
+in `progress/`). Per Option C of the issue — "the arm umbrellas no
+longer need a residual-aware classifier when each core factor's
+irreducibility is proved at the `quadraticIntegerRootFactors?` layer"
+— I deleted the unconditional classifier.
+
+Deletion span: 33 lines in `HexBerlekampZassenhaus/Basic.lean` (the
+docstring at lines 8060-8063, the theorem body at lines 8064-8091, and
+the trailing blank line). No other source file referenced the deleted
+name. The neighbouring `quadraticIntegerRootFactors?_factor_irreducible_of_primitive`
+(the helper used by both fast-quadratic #4571 and slow-quadratic
+#4587 umbrellas) is untouched.
+
+### Build state
+
+- `lake build HexBerlekampZassenhaus.Basic` ✓
+- `lake build HexBerlekampZassenhaus` ✓
+- `lake build HexBerlekampZassenhausMathlib` ✓
+- `python3 scripts/check_dag.py` ✓
+- `git diff --check` clean
+- Sorry inventory in `HexBerlekampZassenhaus/Basic.lean` unchanged at 1
+  (the pre-existing sorry, now at line 5810 after the deletion shifted
+  no lines above it — the absolute position is unchanged; the
+  `Basic.lean:5808:8` warning from the build is the declaration line,
+  not the sorry token). No new `sorry`, `axiom`, `native_decide`,
+  `TODO`, or `FIXME`.
+
+## Current frontier
+
+The quadratic reassembly classifier audit is closed. The slow-quadratic
+arm umbrella (#4587) and fast-quadratic arm umbrella (#4571) both run
+on `quadraticIntegerRootFactors?_factor_irreducible_of_primitive` plus
+the generic reassembly lift, with no intermediate classifier in the
+call chain.
+
+## Next step
+
+Remaining unclaimed HO-1 substrate work after this PR:
+
+- #4602: Mathlib structural radical-relation between squareFreeCore and
+  repeatedPart (substantive UFD/`divRadical` work).
+- #4603: Mathlib-free expansion helper
+  (`expandRepeatedPartFactorArray_residual_eq_one_of_pow_decomposition`).
+- #4605: discharge small-mod singleton arm `hchoose` premise for
+  capstone wiring (either restrict dispatcher or augment umbrella).
+
+#4603 is the most tractable next pick (pure Mathlib-free induction).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4588

Session: `5c04b2fa-ce02-47e4-96b2-508a850c553f`

f485780a refactor: delete dead quadratic reassembly classifier (#4588)

🤖 Prepared with Claude Code