### PR TITLE
HO-1 substrate: drop hcomplete from constant arm umbrella via reassemblyExpansionComplete_constant_of_ne_zero

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -1112,8 +1112,11 @@ theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
 Per-branch HO-1 component for the fast-path **constant square-free core** arm
 of the capstone `factor_irreducible_of_nonUnit` (#4170): every entry recorded
 by `Hex.factorWithBound f B` in the constant branch is
-`Hex.ZPoly.Irreducible`, given only `f ≠ 0`, the constant-core marker
-`hdeg`, and the reassembly expansion-complete side condition `hcomplete`.
+`Hex.ZPoly.Irreducible`, given only `f ≠ 0` and the constant-core marker
+`hdeg`. The reassembly expansion-complete side condition is discharged
+internally via `Hex.reassemblyExpansionComplete_constant_of_ne_zero` (#4585 /
+PR #4598), so the umbrella no longer requires an explicit `hcomplete`
+premise.
 
 The constant branch is the earliest dispatch in `factorFastFactorsWithBound`
 (triggered when `(normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0`)
@@ -1156,11 +1159,14 @@ theorem factor_constant_branch_entry_irreducible_of_choosePrimeData
     (entry : Hex.ZPoly × Nat)
     (hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0)
-    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hcomplete :
-      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
-        #[(Hex.normalizeForFactor f).squareFreeCore]) :
+    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList) :
     Hex.ZPoly.Irreducible entry.1 := by
+  -- Discharge the reassembly expansion-complete side condition internally
+  -- using the constant-arm discharger (#4585 / PR #4598).
+  have hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+        #[(Hex.normalizeForFactor f).squareFreeCore] :=
+    Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf_ne hdeg
   -- Branch-shape lemma: entry is the sign-normalisation of a raw factor in
   -- the singleton-core reassembly.
   obtain ⟨raw, hraw_mem, hentry_eq⟩ :=

--- a/progress/20260517T085502Z_7cee1a77.md
+++ b/progress/20260517T085502Z_7cee1a77.md
@@ -1,0 +1,46 @@
+# 20260517T085502Z — drop hcomplete from constant arm umbrella (#4612)
+
+## Accomplished
+
+- Removed the explicit `hcomplete` argument from
+  `factor_constant_branch_entry_irreducible_of_choosePrimeData`
+  in `HexBerlekampZassenhausMathlib/IntReductionMod.lean`.
+- The proof now obtains the reassembly expansion-complete witness
+  internally by calling
+  `Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf_ne hdeg`
+  (landed via PR #4598 closing #4585).
+- Updated the umbrella's docstring to drop the `hcomplete` premise
+  mention and document the internal discharge.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — green.
+- `lake build HexBerlekampZassenhausMathlib HexBerlekampZassenhaus` —
+  green.
+- `python3 scripts/check_dag.py` — OK.
+- `git diff --check` — clean.
+- Sorry inventory on `IntReductionMod.lean`: 0 (pre- and
+  post-change).
+- `factor_constant_branch_entry_irreducible_of_choosePrimeData` has
+  no callers yet outside its docstring reference in
+  `HexBerlekampZassenhaus/Basic.lean`, so no consumer updates were
+  needed.
+
+## Current frontier
+
+The fast-path constant arm umbrella now self-discharges its
+expansion-complete side condition. The sibling arms still require
+explicit `hcomplete`:
+
+- small-mod singleton (#4564) — blocked on #4597 + #4605
+- fast-path quadratic (#4571) — blocked on #4604
+- slow-path quadratic (#4575) — blocked on #4604
+
+## Next step
+
+Once the sibling-arm dischargers land, repeat this signature-drop
+pattern for each umbrella; this issue's diff is a clean template.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4612

Session: `7cee1a77-f7e2-4ae5-b085-285ce4b22781`

c8b60b80 refactor: drop hcomplete from constant arm umbrella via discharger (#4612)

🤖 Prepared with Claude Code