### PR TITLE
remove stale maxHeartbeats override and fix sibling line-ref in factorFastFactorsWithBound_branch

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5414,9 +5414,8 @@ private theorem factorFastFactorsWithBound_eq_some_of_core_success
     rw [if_neg hnotsingleton]
     rw [hcore]
 
-set_option maxHeartbeats 4000000 in
 /-- Classify the raw fast-path factor array by the dispatch branch that
-emitted it. Mirrors `factorSlowFactorsWithBound_branch` (line 5043) for the
+emitted it. Mirrors `factorSlowFactorsWithBound_branch` (line 5275) for the
 fast path, which has more sub-cases due to the BHKS / quadratic-root /
 small-mod prime classification cascade.
 

--- a/progress/20260517T095639Z_90065b52.md
+++ b/progress/20260517T095639Z_90065b52.md
@@ -1,0 +1,41 @@
+# 20260517T095639Z — feature #4628
+
+Session UUID prefix: 90065b52. Issue: #4628 — remove stale
+maxHeartbeats override and fix sibling line-ref in
+`factorFastFactorsWithBound_branch`.
+
+## Accomplished
+
+- Removed `set_option maxHeartbeats 4000000 in` annotation directly
+  above `factorFastFactorsWithBound_branch` in
+  `HexBerlekampZassenhaus/Basic.lean` (was at line 5417 at session
+  start; issue had it at 5410 from an older snapshot).
+- Updated the docstring line reference `Mirrors
+  `factorSlowFactorsWithBound_branch` (line 5043)` →
+  `Mirrors `factorSlowFactorsWithBound_branch` (line 5275)`. Re-grepped
+  for the actual current location before editing; `factorSlowFactors-
+  WithBound_branch` definition sits at line 5275 (now 5275 after the
+  one-line deletion as well, since the deletion is below it).
+- `lake build HexBerlekampZassenhaus.Basic` clean at file-default
+  800000 heartbeats in 105s (in line with the 106s measurement
+  recorded in `progress/20260517T091349Z_2160de69.md`).
+- `lake build HexBerlekampZassenhaus` (umbrella) clean.
+- `python3 scripts/check_dag.py` clean.
+- `git diff --check` clean.
+- Sorry inventory on `HexBerlekampZassenhaus/Basic.lean` unchanged:
+  one remaining sorry at line 6289 (pre-existing).
+- Remaining `maxHeartbeats` lines in the file (out of scope per
+  issue): 5269 (default 800000), 5812 (default 800000), 8594
+  (`3000000 in`).
+
+## Current frontier
+
+Issue deliverables complete; PR ready.
+
+## Next step
+
+Push branch, open PR closing #4628.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4628

Session: `90065b52-b7eb-4ab9-a546-4bc560e80f0e`

953abd82 refactor: remove stale maxHeartbeats override on factorFastFactorsWithBound_branch

🤖 Prepared with Claude Code