### PR TITLE
HO-1 substrate: drop hB_ne_zero and hd_modulus from exhaustive-arm umbrella via defaultFactorCoeffBound_pos_of_ne_zero

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -1451,14 +1451,16 @@ in `HexBerlekampZassenhausMathlib/Basic.lean`) by:
   the `choosePrimeData?_factorsModP_berlekamp_form` and
   `choosePrimeData?_isGoodPrime` provenance chains from `hchoose`;
 * deriving `hcore_ne` from `hcore_monic`, `hcore_record` from the branch
-  marker `hbranch.2.1`, and `hB_ne_zero` from `hd_modulus`;
+  marker `hbranch.2.1`, `hB_ne_zero` from
+  `defaultFactorCoeffBound_pos_of_ne_zero` (#4637), and `hd_modulus`
+  from `precisionForCoeffBound_spec` combined with `B ≥ 1`;
 * internally case-splitting via
   `factorWithBound_entry_mem_exhaustive_branch_xPower_or_core_of_reassemblyComplete`
   on whether the entry's raw source is an extracted `X`-power factor (closed
   by `xPowerFactorArray_irreducible`) or an exhaustive core factor (closed by
   the wrapper itself).
 
-The umbrella inherits five explicit substrate-shim premises that document
+The umbrella inherits three explicit substrate-shim premises that document
 genuine gaps in the discharger stack at the time of landing:
 
 * **Gap 1** — `hcore_monic`: the squarefree core is not generally monic
@@ -1473,12 +1475,7 @@ genuine gaps in the discharger stack at the time of landing:
   PR #4598) for the constant arm. The exhaustive arm's `coreFactors`
   depends on the recombination output shape rather than a fixed array, so a
   separate substrate sub-issue is required.
-* **Gap 3a** — `hd_modulus`: requires the modulus invariant
-  `2 ≤ d.p ^ d.k` at the outer-bound shape. Derivable from `primeData.p ≥ 2`
-  (via `choosePrimeData?_prime`) together with a substrate lemma asserting
-  `defaultFactorCoeffBound f ≥ 1` for `f ≠ 0` (currently absent from
-  `HexPolyZ/Mignotte.lean`).
-* **Gap 3b** — `hprecision`: requires the core-shape Mignotte invariant
+* **Gap 3** — `hprecision`: requires the core-shape Mignotte invariant
   `2 * defaultFactorCoeffBound core < d.p ^ d.k`. The closed
   `precisionForCoeffBound_spec` gives the *outer*-shape variant
   `2 * defaultFactorCoeffBound f < d.p ^ d.k`; bridging to the core shape
@@ -1486,7 +1483,11 @@ genuine gaps in the discharger stack at the time of landing:
   resolution; the recommended fix is the abstract-bound refactor of
   `centeredLift_scaledLiftedFactorProduct_eq_of_mignottePrecision`).
 
-Downstream consumers (notably the HO-1 capstone #4170) must thread the five
+(The sibling Gap 3a/3b shim premises `hB_ne_zero` / `hd_modulus` were
+discharged by #4637 via `defaultFactorCoeffBound_pos_of_ne_zero` and
+`precisionForCoeffBound_spec`.)
+
+Downstream consumers (notably the HO-1 capstone #4170) must thread the three
 shim premises until the substrate work lands. A follow-up issue can then
 drop them and recover the minimal-hypotheses umbrella signature. Until
 then, the umbrella delivers exactly the chain of substrate composition
@@ -1519,18 +1520,7 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)))
-    -- Gap 3a (substrate): explicit until `defaultFactorCoeffBound_pos_of_ne_zero`
-    -- lands; this would let `hd_modulus` and this premise both be derived from
-    -- `f ≠ 0` and `primeData.p ≥ 2` via `precisionForCoeffBound_spec`.
-    (hB_ne_zero : Hex.ZPoly.defaultFactorCoeffBound f ≠ 0)
-    -- Gap 3b (substrate): explicit until `defaultFactorCoeffBound_pos_of_ne_zero`
-    -- lands (see `hB_ne_zero`).
-    (hd_modulus :
-      2 ≤ (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
-        Hex.precisionForCoeffBound
-          (Hex.ZPoly.defaultFactorCoeffBound f)
-          (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p)
-    -- Gap 3c (substrate): explicit until the squareFreeCore-bound monotonicity
+    -- Gap 3 (substrate): explicit until the squareFreeCore-bound monotonicity
     -- (#4539, closed without resolution) is supplied by the abstract-bound
     -- refactor at the wrapper's call site.
     (hprecision :
@@ -1570,7 +1560,27 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
       Hex.isGoodPrime (Hex.normalizeForFactor f).squareFreeCore
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p = true :=
     Hex.choosePrimeData?_isGoodPrime _ _ hchoose
-  -- Derive `B ≥ 1` from `hd_modulus` (so `henselLiftData` umbrellas apply).
+  -- Mignotte-substrate positivity of the executable coefficient bound
+  -- (#4637 / `defaultFactorCoeffBound_pos_of_ne_zero`).
+  have hbound_pos : 0 < Hex.ZPoly.defaultFactorCoeffBound f :=
+    Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hf_ne
+  have hB_ne_zero : Hex.ZPoly.defaultFactorCoeffBound f ≠ 0 := hbound_pos.ne'
+  -- Mignotte side condition `2 * B < p ^ prec` from `precisionForCoeffBound_spec`.
+  have hspec :
+      2 * Hex.ZPoly.defaultFactorCoeffBound f <
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
+          Hex.precisionForCoeffBound
+            (Hex.ZPoly.defaultFactorCoeffBound f)
+            (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p :=
+    Hex.precisionForCoeffBound_spec hp_prime.two_le _
+  -- Modulus invariant `2 ≤ p ^ prec`: from `2 ≤ 2 * B < p ^ prec` (since `B ≥ 1`).
+  have hd_modulus :
+      2 ≤ (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
+        Hex.precisionForCoeffBound
+          (Hex.ZPoly.defaultFactorCoeffBound f)
+          (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p := by
+    omega
+  -- Derive `prec ≥ 1` from `hd_modulus` (so `henselLiftData` umbrellas apply).
   have hB_pos : 1 ≤ Hex.precisionForCoeffBound
       (Hex.ZPoly.defaultFactorCoeffBound f)
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p := by

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -358,5 +358,84 @@ theorem coeffL2NormBound_le_defaultFactorCoeffBound (f : ZPoly) :
     (mignotteCoeffBound_le_defaultFactorCoeffBound f
       (k := 0) (j := 0) (Nat.zero_le _) (Nat.zero_le _))
 
+/-- An additive natural-number `foldl` only increases (or preserves) its
+accumulator. -/
+private theorem le_foldl_add_self {α : Type} (xs : List α) (g : α → Nat)
+    (init : Nat) :
+    init ≤ xs.foldl (fun acc y => acc + g y) init := by
+  induction xs generalizing init with
+  | nil => simp
+  | cons y ys ih =>
+      simp only [List.foldl_cons]
+      exact Nat.le_trans (Nat.le_add_right init (g y)) (ih (init + g y))
+
+/-- For an additive natural-number `foldl`, each summand at a member index is
+bounded by the result. -/
+private theorem le_foldl_add_of_mem {α : Type} (xs : List α) (g : α → Nat)
+    {x : α} {init : Nat} (hx : x ∈ xs) :
+    g x ≤ xs.foldl (fun acc y => acc + g y) init := by
+  induction xs generalizing init with
+  | nil => cases hx
+  | cons head tail ih =>
+      simp only [List.mem_cons] at hx
+      simp only [List.foldl_cons]
+      cases hx with
+      | inl h =>
+          subst h
+          exact Nat.le_trans (Nat.le_add_left (g x) init)
+            (le_foldl_add_self tail g (init + g x))
+      | inr h => exact ih h
+
+/-- The ceiling square root is positive on positive inputs. -/
+private theorem ceilSqrt_pos_of_pos {n : Nat} (hn : 0 < n) :
+    0 < ceilSqrt n := by
+  have h : n ≤ (ceilSqrt n) ^ 2 := le_ceilSqrt_sq n
+  by_cases hpos : 0 < ceilSqrt n
+  · exact hpos
+  · exfalso
+    have hsq : ceilSqrt n = 0 := by omega
+    rw [hsq, Nat.pow_two, Nat.zero_mul] at h
+    omega
+
+/-- A nonzero integer polynomial has positive squared Euclidean coefficient
+norm: the last stored coefficient is nonzero and contributes a positive
+summand to the fold. -/
+theorem coeffNormSq_pos_of_ne_zero {f : ZPoly} (hf : f ≠ 0) :
+    0 < coeffNormSq f := by
+  have hsize : 0 < f.size := size_pos_of_ne_zero f hf
+  have hi_lt : f.size - 1 < f.size := by omega
+  have hi_mem : f.size - 1 ∈ List.range f.size := List.mem_range.mpr hi_lt
+  have hcoeff_ne : f.coeff (f.size - 1) ≠ 0 :=
+    DensePoly.coeff_last_ne_zero_of_pos_size f hsize
+  have hnatabs : 0 < (f.coeff (f.size - 1)).natAbs :=
+    Nat.pos_of_ne_zero (fun h => hcoeff_ne (Int.natAbs_eq_zero.mp h))
+  have hsq_pos : 0 < (f.coeff (f.size - 1)).natAbs ^ 2 := by
+    rw [Nat.pow_two]; exact Nat.mul_pos hnatabs hnatabs
+  unfold coeffNormSq
+  exact Nat.lt_of_lt_of_le hsq_pos
+    (le_foldl_add_of_mem (List.range f.size)
+      (fun i => (f.coeff i).natAbs ^ 2) hi_mem)
+
+/-- A nonzero integer polynomial has positive conservative Euclidean
+coefficient-norm upper bound. -/
+theorem coeffL2NormBound_pos_of_ne_zero {f : ZPoly} (hf : f ≠ 0) :
+    0 < coeffL2NormBound f := by
+  unfold coeffL2NormBound
+  exact ceilSqrt_pos_of_pos (coeffNormSq_pos_of_ne_zero hf)
+
+/--
+A nonzero integer polynomial has positive uniform default factor coefficient
+bound.
+
+This is the Mignotte-side substrate fact downstream consumers need to derive
+`B ≠ 0` and the precision-modulus invariant `2 ≤ p ^ precisionForCoeffBound B p`
+from `f ≠ 0` alone (combined with the standard `p ≥ 2` provenance from
+`choosePrimeData?_prime` and `precisionForCoeffBound_spec`).
+-/
+theorem defaultFactorCoeffBound_pos_of_ne_zero {f : ZPoly} (hf : f ≠ 0) :
+    0 < defaultFactorCoeffBound f :=
+  Nat.lt_of_lt_of_le (coeffL2NormBound_pos_of_ne_zero hf)
+    (coeffL2NormBound_le_defaultFactorCoeffBound f)
+
 end ZPoly
 end Hex

--- a/progress/20260517T103356Z_d777ba69.md
+++ b/progress/20260517T103356Z_d777ba69.md
@@ -1,0 +1,47 @@
+# Session 20260517T103356Z_d777ba69
+
+Issue #4637 — HO-1 substrate: drop `hB_ne_zero` and `hd_modulus` from the
+exhaustive-arm umbrella via `defaultFactorCoeffBound_pos_of_ne_zero`.
+
+## Accomplished
+
+* **`HexPolyZ/Mignotte.lean`**: added the Mignotte-substrate positivity
+  lemma `Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero` together with
+  its supporting chain (`coeffNormSq_pos_of_ne_zero`,
+  `coeffL2NormBound_pos_of_ne_zero`, plus local helpers
+  `le_foldl_add_self`, `le_foldl_add_of_mem`, `ceilSqrt_pos_of_pos`).
+  Proof chain: `f ≠ 0 → 0 < f.size → 0 < (f.coeff (f.size - 1)).natAbs²
+  ≤ coeffNormSq f → 0 < ceilSqrt (coeffNormSq f) = coeffL2NormBound f ≤
+  defaultFactorCoeffBound f`. Mathlib-free; no new `sorry`/`axiom`/
+  `native_decide`.
+
+* **`HexBerlekampZassenhausMathlib/IntReductionMod.lean`**: dropped
+  `hB_ne_zero` and `hd_modulus` from
+  `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`. Both
+  are now derived internally — `hB_ne_zero` via
+  `defaultFactorCoeffBound_pos_of_ne_zero` (`.ne'` on `0 < B`) and
+  `hd_modulus` via `precisionForCoeffBound_spec hp_prime.two_le` combined
+  with `B ≥ 1` (closed by `omega`). The existing `hB_pos` (i.e.
+  `1 ≤ precisionForCoeffBound B p`) derivation remains intact since it
+  consumes the now-internal `hd_modulus`. Umbrella docstring updated to
+  list three remaining shim premises (Gap 1 / Gap 2 / Gap 3 (was 3c))
+  and to note that Gap 3a / 3b were discharged here.
+
+## Current frontier
+
+`lake build` of the dependency closure (up to
+`HexBerlekampZassenhausMathlib.IntReductionMod`) is clean. No new
+`sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` introduced. All
+pre-existing sorries / warnings are upstream of this change.
+
+## Next step
+
+The capstone HO-1 issue #4170 can thread one fewer shim premise through
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`. The
+remaining shim premises (Gap 1 / #4626 `hcore_monic`, Gap 2 / #4627
+`hcomplete`, Gap 3 `hprecision`) still need substrate work before the
+umbrella can be reduced to minimal hypotheses.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4637

Session: `d777ba69-5abf-4ecd-aa86-cc82c7354145`

673de7b4 doc: progress entry for #4637 (drop two exhaustive-arm shim premises)
2f2cc93a refactor: drop hB_ne_zero and hd_modulus shim premises from exhaustive-arm umbrella
3c5f766b feat: prove defaultFactorCoeffBound_pos_of_ne_zero in HexPolyZ/Mignotte

🤖 Prepared with Claude Code