### PR TITLE
HO-43 residual: relocate GramSchmidt determinant surface

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -2982,25 +2982,6 @@ theorem scaledCoeffs_upper (b : Matrix Int n m)
       exact getArrayEntry_zeroRows n r c)
     i j hij
 
-/-- Leading integer Gram determinants are nonnegative. -/
-theorem leadingGramMatrixInt_det_nonneg
-    (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
-    0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) := by
-  let rowPrefix : Matrix Int t m :=
-    Matrix.ofFn fun i j =>
-      (b.row ⟨i.val, Nat.lt_of_lt_of_le i.isLt ht⟩)[j]
-  have hgram :
-      GramSchmidt.leadingGramMatrixInt b t ht =
-        Matrix.gramMatrix rowPrefix := by
-    apply Vector.ext
-    intro i hi
-    apply Vector.ext
-    intro j hj
-    simp [GramSchmidt.leadingGramMatrixInt, rowPrefix, Matrix.gramMatrix, Matrix.dot,
-      Matrix.row, Matrix.ofFn, GramSchmidt.liftFinLE]
-  rw [hgram]
-  exact Matrix.det_gramMatrix_nonneg rowPrefix
-
 theorem normSq_latticeVec_ge_min_basis_normSq
     (b : Matrix Int n m) (hli : independent b)
     (v : Vector Int m) (hv : memLattice b v) (hv' : v ≠ 0) :
@@ -3503,7 +3484,11 @@ end GramSchmidt.Int
 
 namespace GramSchmidt.Rat
 
-/-- The `k`-th Gram determinant for a rational input matrix. -/
+/-- The `k`-th Gram determinant for a rational input matrix.
+
+This remains Mathlib-free API: it is the direct Hex determinant definition used
+by rational Gram-Schmidt consumers, not a theorem identifying an executable Hex
+output with a Leibniz determinant. -/
 def gramDet (b : Matrix Rat n m) (k : Nat) (hk : k ≤ n) : Rat :=
   Matrix.det (GramSchmidt.leadingGramMatrixRat b k hk)
 

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -48,7 +48,8 @@ private theorem scaledCoeffMatrix_bareiss_eq_det
           Int) : Rat) := by
   rw [HexMatrixMathlib.bareiss_eq_det]
 
-private theorem leadingGramMatrixInt_det_nonneg_pre
+/-- Leading integer Gram determinants are nonnegative. -/
+theorem leadingGramMatrixInt_det_nonneg
     (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
     0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) := by
   let rowPrefix : Matrix Int t m :=
@@ -986,12 +987,12 @@ private theorem gramDet_rat_eq_progressMatrix_zero_det (b : Matrix Int n m)
     (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = Matrix.det (progressMatrix b k hk 0) := by
   -- (gramDet b k hk : Rat) = ((Matrix.det leadingGramMatrixInt b k hk : Int) : Rat)
-  -- via leadingGramMatrixInt_det_nonneg_pre + bareiss_eq_det.
+  -- via leadingGramMatrixInt_det_nonneg + bareiss_eq_det.
   have hdet_int :
       Matrix.det (GramSchmidt.leadingGramMatrixInt b k hk) =
         Int.ofNat (gramDet b k hk) := by
     rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
-    exact (Int.toNat_of_nonneg (leadingGramMatrixInt_det_nonneg_pre b k hk)).symm
+    exact (Int.toNat_of_nonneg (leadingGramMatrixInt_det_nonneg b k hk)).symm
   have hstep1 : ((gramDet b k hk : Int) : Rat) =
       ((Matrix.det (GramSchmidt.leadingGramMatrixInt b k hk) : Int) : Rat) := by
     rw [hdet_int]
@@ -1512,7 +1513,7 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
             Int.ofNat (gramDet b (j + 1) hjsuc) := by
         rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
         exact (Int.toNat_of_nonneg
-          (leadingGramMatrixInt_det_nonneg_pre b (j + 1) hjsuc)).symm
+          (leadingGramMatrixInt_det_nonneg b (j + 1) hjsuc)).symm
       rw [hdet_int]
       rfl
     rw [hdetG]

--- a/progress/20260517T113607Z_c4b0dd4b.md
+++ b/progress/20260517T113607Z_c4b0dd4b.md
@@ -1,0 +1,41 @@
+# 20260517T113607Z — feature session c4b0dd4b (#4665)
+
+## Accomplished
+
+Claimed #4665 after all directive issues in FIFO order refused claims as needing
+replan or dependency-blocked. Verified #4661 is closed and PR #4653 is merged.
+
+Relocated `leadingGramMatrixInt_det_nonneg` out of `HexGramSchmidt/Int.lean` by
+exposing the existing bridge proof in `HexGramSchmidtMathlib/Int.lean` under the
+same public theorem name. Updated bridge-local references that used the former
+private helper name.
+
+Audited `GramSchmidt.Rat.gramDet` and retained it as Mathlib-free API with a
+short docstring explaining that it is a direct Hex determinant definition, not a
+bridge theorem equating executable output with Leibniz determinant surface.
+
+Verification passed:
+
+- `lake build HexGramSchmidt.Int`
+- `lake build HexGramSchmidtMathlib.Int`
+- `lake build HexGramSchmidt HexGramSchmidtMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n 'Matrix\\.det|Matrix\\.bareiss_eq_det|bareiss_eq_det' HexGramSchmidt/Int.lean`
+
+The final grep reports only the retained rational `gramDet` definition.
+
+## Current frontier
+
+The HO-43 residual determinant surface in `HexGramSchmidt/Int.lean` is reduced
+to the intentionally retained rational API definition.
+
+## Next step
+
+Open the PR for #4665 and let the normal review/merge flow close the support
+issue.
+
+## Blockers
+
+None. Existing unrelated warnings remain in the verified targets, including
+pre-existing `sorry` declarations.


### PR DESCRIPTION
Closes #4665

Session: `c4b0dd4b-4063-4d85-b950-33bfdfa9d793`

07ec4612 Relocate GramSchmidt determinant surface

🤖 Prepared with Claude Code