### PR TITLE
HO-44 support: remove GramSchmidt bridge bareiss_eq_det compatibility calls

### DIFF
--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -16,9 +16,9 @@ singular branch is visible only through the Leibniz determinant.
 
 Per `SPEC/Libraries/hex-gram-schmidt.md` ("Proof path governs placement,
 not just statement"), this bridge therefore lives in
-`HexGramSchmidtMathlib`. The proof consumes the bridge-side identity
-`HexMatrixMathlib.bareiss_eq_det`, which is owned by
-`hex-matrix-mathlib`.
+`HexGramSchmidtMathlib`. The proof reaches the executable determinant
+surface by composing `HexMatrixMathlib.bareiss_eq_mathlib_det` with
+`HexMatrixMathlib.det_eq.symm`, both owned by `hex-matrix-mathlib`.
 -/
 
 namespace Hex
@@ -45,8 +45,12 @@ private theorem scaledCoeffMatrix_bareiss_eq_det
           Int) : Rat) =
       ((Matrix.det
         (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj) :
-          Int) : Rat) := by
-  rw [HexMatrixMathlib.bareiss_eq_det]
+          Int) : Rat) :=
+  by exact_mod_cast
+    (HexMatrixMathlib.bareiss_eq_mathlib_det
+        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj)).trans
+      (HexMatrixMathlib.det_eq
+        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj)).symm
 
 private theorem leadingGramMatrixInt_det_nonneg_pre
     (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
@@ -990,7 +994,7 @@ private theorem gramDet_rat_eq_progressMatrix_zero_det (b : Matrix Int n m)
   have hdet_int :
       Matrix.det (GramSchmidt.leadingGramMatrixInt b k hk) =
         Int.ofNat (gramDet b k hk) := by
-    rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
+    rw [gramDet, HexMatrixMathlib.bareiss_eq_mathlib_det, ← HexMatrixMathlib.det_eq]
     exact (Int.toNat_of_nonneg (leadingGramMatrixInt_det_nonneg_pre b k hk)).symm
   have hstep1 : ((gramDet b k hk : Int) : Rat) =
       ((Matrix.det (GramSchmidt.leadingGramMatrixInt b k hk) : Int) : Rat) := by
@@ -1510,7 +1514,7 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
       have hdet_int :
           Matrix.det (GramSchmidt.leadingGramMatrixInt b (j + 1) hjsuc) =
             Int.ofNat (gramDet b (j + 1) hjsuc) := by
-        rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
+        rw [gramDet, HexMatrixMathlib.bareiss_eq_mathlib_det, ← HexMatrixMathlib.det_eq]
         exact (Int.toNat_of_nonneg
           (leadingGramMatrixInt_det_nonneg_pre b (j + 1) hjsuc)).symm
       rw [hdet_int]
@@ -1940,7 +1944,8 @@ singular step:
 - Singular branch: both sides vanish — the executable scaled coefficient is
   zero by `scaledCoeffs_eq_zero_of_singularStep_lt` (the lifted lower-column
   singular lemma from #4166), and the public Bareiss determinant of the
-  Cramer minor is zero by `HexMatrixMathlib.bareiss_eq_det` composed with
+  Cramer minor is zero by composing `HexMatrixMathlib.bareiss_eq_mathlib_det`,
+  `HexMatrixMathlib.det_eq.symm`, and
   `scaledCoeffMatrix_det_eq_zero_of_singularStep_lt`. The latter Mathlib-free
   helper internally lifts partial-pass singularity to the full
   `bareissNoPivotData` pass and applies the Cramer determinant identity.
@@ -1966,7 +1971,11 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
         scaledCoeffs_eq_zero_of_singularStep_lt b i j hji s h_sing hsj
       have h_det := scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
         b i j hji s h_sing
-      rw [h_lhs, HexMatrixMathlib.bareiss_eq_det, h_det]
+      have hbareiss_zero :
+          Hex.Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) = 0 :=
+        ((HexMatrixMathlib.bareiss_eq_mathlib_det _).trans
+          (HexMatrixMathlib.det_eq _).symm).trans h_det
+      rw [h_lhs, hbareiss_zero]
 
 
 /-- Below the diagonal, the executable integral scaled coefficient is exactly
@@ -1976,7 +1985,10 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_det
     GramSchmidt.entry (scaledCoeffs b) i j =
       Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
   rw [scaledCoeffs_eq_scaledCoeffMatrix_bareiss]
-  exact HexMatrixMathlib.bareiss_eq_det (GramSchmidt.scaledCoeffMatrix b i j hji)
+  exact
+    (HexMatrixMathlib.bareiss_eq_mathlib_det
+        (GramSchmidt.scaledCoeffMatrix b i j hji)).trans
+      (HexMatrixMathlib.det_eq (GramSchmidt.scaledCoeffMatrix b i j hji)).symm
 
 
 /-- Conditional form of the leading Gram determinant bridge. The remaining
@@ -1988,7 +2000,7 @@ theorem leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg
     (hdet : 0 ≤ Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht)) :
     Matrix.det (GramSchmidt.leadingGramMatrixInt b t ht) =
       Int.ofNat (gramDet b t ht) := by
-  rw [gramDet, HexMatrixMathlib.bareiss_eq_det]
+  rw [gramDet, HexMatrixMathlib.bareiss_eq_mathlib_det, ← HexMatrixMathlib.det_eq]
   exact (Int.toNat_of_nonneg hdet).symm
 
 /-- The public `Nat` Gram determinant casts back to the signed determinant of
@@ -2004,8 +2016,9 @@ theorem leadingGramMatrixInt_det_eq_gramDet_int
 integer matrix with strictly positive diagonal are positive.
 
 This theorem is bridge-only: its proof identifies the executable `gramDet`
-with the Leibniz determinant of the leading Gram matrix via
-`HexMatrixMathlib.bareiss_eq_det`. -/
+with the Leibniz determinant of the leading Gram matrix via the composition
+of `HexMatrixMathlib.bareiss_eq_mathlib_det` and
+`HexMatrixMathlib.det_eq.symm`. -/
 theorem gramDet_pos_of_upperTriangular_pos_diag
     {n : Nat} (M : Matrix Int n n)
     (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
@@ -2517,7 +2530,14 @@ theorem gramDet_rowAdd_earlier
   by_cases hkt : k.val < t
   · -- Inside case: bareiss = det, then det_rowAdd / det_colAdd preserve.
     rw [leadingGramMatrixInt_rowAdd_inside b j k c t ht hjk hkt]
-    rw [HexMatrixMathlib.bareiss_eq_det, HexMatrixMathlib.bareiss_eq_det]
+    -- Bridge `bareiss = det` via Mathlib's `Matrix.det ∘ matrixEquiv`, composing
+    -- `bareiss_eq_mathlib_det` with `det_eq.symm` to keep the executable
+    -- determinant surface visible to `det_colAdd` / `det_rowAdd`.
+    have hbareiss_det : ∀ (M : Hex.Matrix Int t t),
+        Hex.Matrix.bareiss M = Hex.Matrix.det M := fun M =>
+      (HexMatrixMathlib.bareiss_eq_mathlib_det M).trans
+        (HexMatrixMathlib.det_eq M).symm
+    rw [hbareiss_det, hbareiss_det]
     -- Indices and inequality between `jt` and `kt` in `Fin t`.
     have hjt_ne_kt : (⟨j.val, Nat.lt_trans hjk hkt⟩ : Fin t) ≠ ⟨k.val, hkt⟩ := by
       intro h
@@ -2695,10 +2715,11 @@ theorem scaledCoeffs_rowAdd_above_pivot (b : Matrix Int n m) (j k : Fin n)
 
 These determinant-positivity bridges for `gramDet` live in the bridge layer
 because their proofs identify `gramDet` with the Leibniz determinant of the
-leading Gram matrix via `HexMatrixMathlib.bareiss_eq_det` (packaged here as
-`leadingGramMatrixInt_det_eq_gramDet_int`). Consumers that already have a
-determinant lemma for a special matrix family can produce the public
-`independent` predicate stated over Mathlib-free computed data. -/
+leading Gram matrix via the composition of
+`HexMatrixMathlib.bareiss_eq_mathlib_det` and `HexMatrixMathlib.det_eq.symm`
+(packaged here as `leadingGramMatrixInt_det_eq_gramDet_int`). Consumers that
+already have a determinant lemma for a special matrix family can produce the
+public `independent` predicate stated over Mathlib-free computed data. -/
 
 private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
     (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.submatrix (Matrix.gramMatrix b) k))

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -7,12 +7,12 @@ Bridge-bound row-operation update theorems for `hex-gram-schmidt`.
 The theorems in this module relate `gramDet` / `scaledCoeffs` under the
 size-reduce (earlier-row-add) and adjacent-swap row operations. Their
 statements are Hex-local, but their proofs cross the Mathlib boundary by
-reaching `HexMatrixMathlib.bareiss_eq_det` through `gramDet_rowAdd_earlier`
-and the matrix-side `gramDet_adjacentSwap_of_ne` bridge respectively, so
-they live in the bridge layer per [SPEC/Libraries/hex-gram-schmidt.md
-"Proof path governs placement, not just statement"]. The size-reduce
-theorems are thin wrappers around
-`scaledCoeffs_rowAdd_pivot/lower/other_row/above_pivot` and
+composing `HexMatrixMathlib.bareiss_eq_mathlib_det` with
+`HexMatrixMathlib.det_eq.symm` through `gramDet_rowAdd_earlier` and the
+matrix-side `gramDet_adjacentSwap_of_ne` bridge respectively, so they live
+in the bridge layer per [SPEC/Libraries/hex-gram-schmidt.md "Proof path
+governs placement, not just statement"]. The size-reduce theorems are thin
+wrappers around `scaledCoeffs_rowAdd_pivot/lower/other_row/above_pivot` and
 `gramDet_rowAdd_earlier`, which live in `HexGramSchmidtMathlib/Int.lean`.
 -/
 
@@ -25,8 +25,9 @@ namespace GramSchmidt.Int
 `GramSchmidt.Int.sizeReduce b j k r` is `Matrix.rowAdd b j k (-r)` (definitional),
 so the theorems below specialise the earlier-row-add updates in
 `HexGramSchmidt/Int.lean` to the LLL size-reduce row operation. They are kept
-in this bridge module because their proof path runs through
-`HexMatrixMathlib.bareiss_eq_det`. -/
+in this bridge module because their proof path composes
+`HexMatrixMathlib.bareiss_eq_mathlib_det` with
+`HexMatrixMathlib.det_eq.symm`. -/
 
 theorem gramDet_sizeReduce (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int) (t : Nat) (ht : t ≤ n) :
@@ -408,7 +409,14 @@ theorem gramDet_adjacentSwap_of_ne (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
   congr 1
   by_cases hkt : k.val < t
   · rw [leadingGramMatrixInt_rowSwap_inside (b := b) (km1 := km1) (k := k) hkm1k t ht hkt]
-    rw [HexMatrixMathlib.bareiss_eq_det, HexMatrixMathlib.bareiss_eq_det]
+    -- Bridge `bareiss = det` via Mathlib's `Matrix.det ∘ matrixEquiv`, composing
+    -- `bareiss_eq_mathlib_det` with `det_eq.symm` to keep the executable
+    -- determinant surface visible to `det_rowSwap_transpose_rowSwap_transpose`.
+    have hbareiss_det : ∀ (M : Hex.Matrix Int t t),
+        Hex.Matrix.bareiss M = Hex.Matrix.det M := fun M =>
+      (HexMatrixMathlib.bareiss_eq_mathlib_det M).trans
+        (HexMatrixMathlib.det_eq M).symm
+    rw [hbareiss_det, hbareiss_det]
     apply det_rowSwap_transpose_rowSwap_transpose
     intro h
     have : km1.val = k.val := by

--- a/progress/20260517T114221Z_965426e2.md
+++ b/progress/20260517T114221Z_965426e2.md
@@ -1,0 +1,61 @@
+# HO-44 support: remove GramSchmidt bridge bareiss_eq_det compatibility calls
+
+Issue: #4669
+
+## Accomplished
+
+Replaced all eight `HexMatrixMathlib.bareiss_eq_det` call sites in
+`HexGramSchmidtMathlib/{Int,Update}.lean` with explicit compositions of the
+non-compatibility Mathlib-side surfaces `HexMatrixMathlib.bareiss_eq_mathlib_det`
+and `HexMatrixMathlib.det_eq.symm`. Updated the four nearby docstrings/comments
+in the two files to name the Mathlib-side composition rather than the
+compatibility theorem.
+
+Replacement patterns used:
+
+- Tactic rewrite where the chain ends with `exact ...` (sites at lines 998,
+  1517, 2004): `rw [..., bareiss_eq_mathlib_det, ← det_eq]` — the
+  `Hex.Matrix.det` instance produced by `← det_eq` matches the subsequent
+  exact term.
+- Pure term composition where the bridge surfaces are returned directly
+  (line 1989): `(bareiss_eq_mathlib_det _).trans (det_eq _).symm`.
+- `exact_mod_cast` over the composed equation where the original `rw`
+  closed via implicit `rfl` (line 49).
+- Term-mode `Eq.trans` chain to produce `bareiss M = 0` upfront where the
+  rewrite chain previously interleaved `bareiss_eq_det` with a hypothesis
+  rewrite (line 1971).
+- A local universally-quantified `have hbareiss_det` to keep `Hex.Matrix.det`'s
+  instance consistent across two rewrites followed by `det_colAdd` /
+  `det_rowAdd` (resp. `det_rowSwap_transpose_rowSwap_transpose`) applications
+  (lines 2530, 416). The split `[bareiss_eq_mathlib_det, ← det_eq]` form
+  failed the next rewrite because the produced `Hex.Matrix.det` instance did
+  not match what the row/col operation lemmas expect; the local `have`
+  packages the composition once and lets it unify cleanly.
+
+Did not delete `Hex.Matrix.bareiss_eq_det` from `HexMatrix/Bareiss.lean`
+(that is directive #3900's own deliverable).
+
+## Current frontier
+
+`rg -n 'HexMatrixMathlib\.bareiss_eq_det|Matrix\.bareiss_eq_det'
+HexGramSchmidtMathlib -g '*.lean'` returns zero hits. Remaining
+`Hex.Matrix.bareiss_eq_det` hits inside `HexMatrixMathlib/` are
+self-contained docstrings on the compatibility theorem itself
+(`Determinant.lean:24`) and on `bareissData_eq_mathlib_det`
+(`Determinant/Bareiss.lean:1532`); they are justified comments that
+explain the relationship to the Mathlib-free orphan.
+
+Builds clean: `lake build HexGramSchmidt HexGramSchmidtMathlib
+HexMatrixMathlib` succeeds. `python3 scripts/check_dag.py` passes.
+`git diff --check` clean. No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+entries.
+
+## Next step
+
+Open PR closing #4669. With this support cleanup landed, directive #3900
+can run its verification grep against `bareiss_eq_det` and proceed to
+delete the Mathlib-free orphan from `HexMatrix/Bareiss.lean`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4669

Session: `965426e2-f5fd-40bb-8dbb-b157270a20d1`

ffe07700 refactor: replace HexGramSchmidtMathlib bareiss_eq_det calls with Mathlib-side compose

🤖 Prepared with Claude Code