### PR TITLE
doc: progress entry for #4611 skip

### DIFF
--- a/progress/20260517T131000Z_6dba48b2.md
+++ b/progress/20260517T131000Z_6dba48b2.md
@@ -1,0 +1,43 @@
+# 20260517T131000Z — feature session 6dba48b2 (#4611 skip)
+
+Session UUID prefix: 6dba48b2. Issue: #4611 — HO-1 substrate (#4602
+sub): exponent-extraction `repeatedPart = ∏ q^{e_q}` from divisibility
++ irreducible cover.
+
+## Accomplished
+
+Skipped #4611 with a `replan` reason. Its declared dependency #4618 is
+closed only via decomposition into #4674, #4675, #4676; the structural
+divisibility lemma it consumes
+(`normalizeForFactor_repeatedPart_toPolynomial_dvd_squareFreeCore_pow`)
+lands in #4676. #4676 is blocked on #4675, which is blocked on #4674
+(open PR). `coordination check-blocked` does not look through
+decomposition chains, so the issue surfaced as unclaimed even though
+the lemma it needs has not landed.
+
+The skip comment asked the next planner to add
+`depends-on: #4676` so the issue stays blocked until the lemma is
+actually present in `IntReductionMod.lean`.
+
+No code changes; no commits.
+
+## Current frontier
+
+Feature queue is empty after the skip — remaining items #4334
+(HexLLL benchmark verdicts, repeatedly skipped for host contention),
+#4646 (HO-1 primitive helpers), and #4611 itself are now all in
+`replan`; #4670 (HO-4 BHKS bridge) and #4678 (HO-1
+ModPSubsetPartitionHypotheses) are claimed by other sessions.
+
+## Next step
+
+Next planner cycle should:
+- Triage the three `replan` items. For #4611 specifically, add
+  `depends-on: #4676` rather than re-floating it.
+- Continue replenishing HO-1 substrate work as #4674 → #4675 → #4676
+  lands, which then unblocks #4611 → #4627/#4604/#4597.
+
+## Blockers
+
+Nothing for me. The HO-1 critical path needs #4676 (and its
+predecessors) to land before #4611 becomes workable.


### PR DESCRIPTION
This PR records the progress note from feature session `6dba48b2`,
which skipped #4611 because its declared dependency #4618 closed via
decomposition into #4674/#4675/#4676. The structural divisibility
lemma #4611 consumes
(`normalizeForFactor_repeatedPart_toPolynomial_dvd_squareFreeCore_pow`)
lands in #4676, which is blocked on #4675 → #4674 (open PR), so #4611
is functionally not workable until that chain lands.

Skip comment on #4611 asks the next planner to add
`depends-on: #4676` so the issue stays blocked rather than re-surfacing
in the unclaimed queue.

🤖 Prepared with Claude Code