### PR TITLE
doc: progress entry for #4678 decomposition

### DIFF
--- a/progress/20260517T115517Z_85efd009.md
+++ b/progress/20260517T115517Z_85efd009.md
@@ -1,0 +1,104 @@
+# 20260517T115517Z — feature session 85efd009 (#4678 decomposition)
+
+Session UUID prefix: 85efd009. Issue: #4678 — HO-1 substrate (#4671 sub):
+construct `ModPSubsetPartitionHypotheses` at `choosePrimeData`.
+
+## Accomplished
+
+Scope assessment of #4678 found the work too large for one session under
+the deliverable's "no new theorem-level `sorry`" constraint, and
+decomposed it into two analytic sub-issues plus a wrapper-composition
+residual.
+
+The deliverable required constructing a `ModPSubsetPartitionHypotheses
+core (Hex.choosePrimeData core) True True` value, discharging six
+fields. Three are trivial (`fModP_eq` via `choosePrimeData_fModP_eq_modP`,
+`admissible_prime` / `square_free_reduction` via `trivial`). The other
+three are substantive analytic content:
+
+* `factors_irreducible` — each `(Hex.choosePrimeData core).factorsModP[i]`
+  is irreducible after transport to `Polynomial (ZMod p)`.
+* `exists_subset` — every `Polynomial ℤ`-irreducible factor of `core` admits
+  a representing subset of the recorded modular factors.
+* `unique_subset` — that representing subset is unique.
+
+The existing analytic-obligation pattern in
+`HexBerlekampZassenhausMathlib/Basic.lean` (lines 9370, 9463) bundles
+all substantive content into a single `private theorem
+_analytic_obligation := by ... sorry` and consumes it in a sorry-free
+constructor. Deliverable item 4 ("Do not introduce ... new theorem-level
+`sorry`") explicitly rules out repeating that pattern, so each substantive
+component needs its own discharge.
+
+A complicating factor surfaced in scoping: `Hex.choosePrimeData` falls
+back to `fallbackPrimeChoiceData` (p = 3) when `choosePrimeData? core =
+none`. In the fallback case, `core` has no good small prime, so the
+square-freeness of the monic modular image isn't guaranteed and
+`irreducible_of_mem_berlekampFactor`'s square-free hypothesis cannot be
+discharged uniformly. The sub-issues flag two options: (a) strengthen the
+lemma's signature with an `isGoodPrime` premise, or (b) extract the
+analyzable branch as a `_of_some` variant. The choice is left to the
+worker since both interact with how the wrapper consumer threads
+hypotheses.
+
+### Sub-issues created
+
+* **#4686** (factors_irreducible, unblocked): land
+  `factors_irreducible_of_choosePrimeData` by composing
+  `choosePrimeData?_factorsModP_berlekamp_form`,
+  `berlekampFactor_factors_ne_zero`, `monicModularImage_eq_self_of_monic`,
+  and `HexBerlekampMathlib.irreducible_of_mem_berlekampFactor`. The
+  proof is pure plumbing through existing (already-sorry'd) lemmas in
+  dependencies — no new sorry is introduced.
+
+* **#4687** (existsUnique_modPFactorSubset, unblocked): land
+  `existsUnique_modPFactorSubset_of_choosePrimeData` by routing through
+  Mathlib's `UniqueFactorizationMonoid` machinery on `Polynomial (ZMod p)`
+  plus the Berlekamp-form bridge. This is the genuinely analytic
+  component — bundles existence and uniqueness in a single statement
+  because the proofs share the same UFD machinery.
+
+* **#4688** (wrapper composition, blocked on #4686 + #4687): assemble
+  the trivial fields and the two analytic lemmas into the original
+  `modPSubsetPartitionHypotheses_of_choosePrimeData` constructor signature.
+
+The parent #4678 was skipped via `coordination skip` with the
+`Decomposed into #4686, #4687, #4688` breadcrumb, routing to the next
+planner's replan-triage cycle.
+
+The HexLLL Phase 4 measurement-blocker issue #4334 was also re-checked
+and re-skipped: carica's load average is 9.19/11.48/12.19, within the
+same elevated range that produced the previous skip (13.65/10.40/10.04
+yielding spawn floor 1.27-1.31s), so the affected scientific benchmarks
+would again produce zero verdict-eligible rows. Needs quiet/dedicated
+hardware or the release-candidate workflow.
+
+## Current frontier
+
+The sub-issue decomposition is the deliverable for this session. The
+critical path for #4671 (the grandparent that motivates #4678) is:
+
+1. **#4686** + **#4687** can be worked in parallel — they don't depend
+   on each other. Both touch
+   `HexBerlekampZassenhausMathlib/Basic.lean` near line 1172, so workers
+   should coordinate via the existing claim mechanism to avoid stepping
+   on each other's edits.
+2. **#4688** lands the wrapper once both analytic lemmas exist.
+3. **#4679** (sibling under #4671) is the Hensel-lift transport
+   constructor — independent of this chain and can proceed in parallel.
+4. **#4680** composes #4688 + #4679 to discharge the original two
+   `sorry`s in `henselSubsetCorrespondence_analytic_obligation` and
+   `liftedFactorSubsetPartition_analytic_obligation`.
+
+## Next step
+
+A worker claims either #4686 or #4687. The two are independent; #4686 is
+the lower-risk task (pure plumbing) and good for a session with
+moderate context budget. #4687 needs more careful UFD reasoning and is
+better suited to a fresh session.
+
+## Blockers
+
+None for #4686 or #4687. #4688 is correctly blocked on its two
+predecessors via `depends-on:` lines and the `blocked` label that
+`coordination plan` auto-applied.


### PR DESCRIPTION
This PR records a worker-led decomposition of #4678 (HO-1 substrate:
construct `ModPSubsetPartitionHypotheses` at `choosePrimeData`) into three
self-contained sub-issues. No code changes were needed — the substantive
analytic content lives in the sub-issues:

- #4686 — `factors_irreducible_of_choosePrimeData` (irreducibility, plumbing)
- #4687 — `existsUnique_modPFactorSubset_of_choosePrimeData` (analytic UFD)
- #4688 — wrapper composition (blocked on #4686 + #4687)

See `progress/20260517T115517Z_85efd009.md` for the scope assessment and
the rationale: the deliverable's "no new theorem-level \`sorry\`" rule
ruled out the existing `_analytic_obligation` pattern (lines 9370/9463
of `HexBerlekampZassenhausMathlib/Basic.lean`), so each substantive
field needs its own discharge.

🤖 Prepared with Claude Code