### PR TITLE
doc: progress entry for #4687 decomposition

### DIFF
--- a/progress/20260517T131000Z_c2974c75.md
+++ b/progress/20260517T131000Z_c2974c75.md
@@ -1,0 +1,90 @@
+# 20260517T131000Z — feature session c2974c75 (#4687 decomposition)
+
+Session UUID prefix: c2974c75. Issue: #4687 — HO-1 substrate
+(#4678 sub): existsUnique_modPFactorSubset_of_choosePrimeData.
+
+## Accomplished
+
+Scope assessment of #4687 found the proof requires three independent
+substantive pieces with no shared infrastructure; decomposed into
+sub-issues with a clean dependency chain.
+
+The `monicModPImage` definition at
+`HexBerlekampZassenhausMathlib/Basic.lean:1145` has zero surrounding
+algebraic theory. The sibling `Hex.monicModularImage` in
+`HexBerlekampZassenhaus/Basic.lean:467` has the parallel theory
+(`monicModularImage_monic`, `_ne_zero_of_ne_zero`,
+`_eq_self_of_monic`, `_mul_of_nonzero`), but none of it is mirrored
+for `monicModPImage`. No `Hex.FpPoly p`-level divisibility bridge
+exists from `factor ∣ core` (in `Hex.ZPoly`) to
+`monicModPImage (modP p factor) ∣ monicModularImage (modP p core)`;
+only `HexPolyZMathlib.dvd_modP_of_dvd` (line 178) at the
+`Polynomial ℤ → Polynomial (ZMod p)` Mathlib level. No UFD-side
+"divisor of squarefree product = unique subset of irreducible factors"
+lemma exists in `HexBerlekampZassenhausMathlib/UFDPartition.lean`
+(which currently provides only the cardinality bounds used by the
+recombination chain). No subset-product transport bridges between
+the `Hex.FpPoly p`-indexed `ModPFactorSubset primeData` finset-fold
+and the `Polynomial (ZMod p)` `Multiset.prod` view.
+
+### Sub-issues created
+
+- **#4691** (substrate bridge, unblocked): `monicModPImage` algebraic
+  theory (zero, monic-of-nonzero, dvd_self/self_dvd via unit scalar)
+  plus the divisibility bridge
+  `monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`.
+  Routes through `Hex.monicModularImage_eq_self_of_monic`,
+  `Hex.FpPoly.dvd_scale_self_of_ne_zero`, and
+  `Hex.choosePrimeData?_isGoodPrime`.
+
+- **#4692** (UFD substrate, unblocked): abstract Mathlib lemma —
+  given a squarefree multiset of pairwise non-associated irreducibles
+  in a UFD and a divisor of their product, there's a unique
+  sub-multiset whose product equals the divisor. Routes through
+  `UniqueFactorizationMonoid.normalizedFactors`,
+  `UniqueFactorizationMonoid.squarefree_iff_nodup_normalizedFactors`,
+  and `UniqueFactorizationMonoid.dvd_iff_normalizedFactors_le` (or
+  equivalent).
+
+- **#4693** (assembly, blocked on #4691 + #4692): final composition
+  producing `existsUnique_modPFactorSubset_of_choosePrimeData_of_some`
+  plus the `_of_choosePrimeData` wrapper handling the `none` fallback.
+  Composes the `monicModPImage` divisibility bridge (#4691) with the
+  abstract UFD subset lemma (#4692) via the `Hex.FpPoly p` ↔
+  `Polynomial (ZMod p)` transport (using `toMathlibPolynomial`), plus
+  `Hex.choosePrimeData?_factorsModP_berlekamp_form`,
+  `Hex.Berlekamp.factorProduct_berlekampFactor`, and
+  `Hex.factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct`
+  to identify `factorProduct primeData.factorsModP.toList` with
+  `monicModularImage (modP p core)`.
+
+The parent #4687 was skipped via `coordination skip` with the
+`Decomposed into #4691, #4692, #4693` breadcrumb, routing to the next
+planner's replan-triage cycle.
+
+## Current frontier
+
+The two substrate sub-issues (#4691 and #4692) are independent and
+unblocked. Either can be claimed first. #4691 is the more
+project-specific piece (mirroring the existing `monicModularImage`
+theory for the new `monicModPImage` plus a divisibility bridge);
+#4692 is pure Mathlib UFD content (might live cleanly in
+`HexBerlekampZassenhausMathlib/UFDPartition.lean`). The assembly
+sub-issue #4693 is blocked until both substrate pieces land. The
+sibling `factors_irreducible_of_choosePrimeData` (#4686) lives on a
+parallel track and #4693 depends on it functionally but not via the
+`depends-on:` graph — the assembly can state any required
+irreducibility premise explicitly if #4686 has not yet landed.
+
+## Next step
+
+Workers claim #4691 and #4692 in parallel (no ordering required).
+After both land, the planner picks up #4693 via `check-blocked`.
+The parent issue #4678 remains blocked until #4693 + #4686 + the
+trivial `fModP_eq` / `admissible_prime` / `square_free_reduction`
+fields are all assembled.
+
+## Blockers
+
+None for #4691 and #4692. #4693 is blocked on its two predecessors,
+which is the intended dependency chain.


### PR DESCRIPTION
This PR records the scope assessment and decomposition of #4687 (HO-1
substrate: existsUnique_modPFactorSubset_of_choosePrimeData) into three
self-contained sub-issues:

- #4691 (\`monicModPImage\` algebra + integer-to-modular divisibility bridge, unblocked)
- #4692 (UFD subset existence + uniqueness for squarefree product divisors, unblocked)
- #4693 (final assembly, blocked on #4691 + #4692)

The parent #4687 was skipped via \`coordination skip\` with a
\`Decomposed into #4691, #4692, #4693\` breadcrumb. The progress note
documents why the proof cannot be discharged in one session: the
\`monicModPImage\` definition at line 1145 of
\`HexBerlekampZassenhausMathlib/Basic.lean\` has zero surrounding
algebraic theory (the sibling \`Hex.monicModularImage\` parallel theory
must be mirrored), no \`Hex.FpPoly p\`-level divisibility bridge from
\`factor ∣ core\` to the \`monicModPImage\`/\`monicModularImage\` pair exists
(only \`HexPolyZMathlib.dvd_modP_of_dvd\` at the Mathlib \`Polynomial ℤ\`
level), and the UFD-side "divisor of squarefree product equals unique
subset of irreducible factors" lemma is not in
\`UFDPartition.lean\` (which currently provides only the cardinality
bounds used by the recombination chain).

Each piece is independently substantial and composes cleanly via the
\`HexBerlekampMathlib.toMathlibPolynomial\` bridge plus the existing
\`Hex.choosePrimeData?_factorsModP_berlekamp_form\` /
\`factorProduct_berlekampFactor\` /
\`factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct\`
chain in the assembly sub-issue.

🤖 Prepared with Claude Code