### PR TITLE
doc: progress entry for #4695 decomposition

### DIFF
--- a/progress/20260517T123303Z_a6012018.md
+++ b/progress/20260517T123303Z_a6012018.md
@@ -1,0 +1,49 @@
+# Session a6012018 — #4695 scope assessment + decomposition
+
+## Accomplished
+
+- Claimed #4695 (forward Hensel transport
+  `henselLiftData_represents_lifted_of_modP`).
+- Verified the issue's stated preconditions:
+  - `HexHenselMathlib.hensel_unique`
+    (`HexHenselMathlib/Correctness.lean:228`) is still a theorem-level
+    `sorry`. The issue body directs to decompose in that case.
+  - `henselLiftData_liftedFactors_size_eq`, listed in the issue body as
+    "landed in #4679 partial PR ~line 3835", has not landed on `main`
+    yet — it is in open PR #4698 (mergeable, awaiting auto-merge).
+    Confirmed via `grep` against the current tree.
+- Filed precursor issue #4700: "HO-1 substrate (#4695/#4696 precursor):
+  discharge `HexHenselMathlib.hensel_unique`". The body restates the
+  current sorry signature, sketches the standard induction-on-`k` proof
+  strategy, lists Mathlib references, and notes the optional bonus of
+  also discharging the other sorried statements in
+  `HexHenselMathlib/Correctness.lean` (`quadraticHenselStep_monic`,
+  `quadraticHenselStep_unique_mod_pow_two_mul`,
+  `multifactorLift_eq_multifactorLiftQuadratic`, `hensel_correct`,
+  `hensel_extends`, `hensel_degree`).
+- Linked the precursor: `coordination add-dep 4695 4700` and
+  `coordination add-dep 4696 4700`. Both transport sub-issues now carry
+  the `blocked` label.
+- Released the claim via `coordination skip 4695` with a breadcrumb
+  noting both the `hensel_unique` precursor and the still-open
+  `henselLiftData_liftedFactors_size_eq` PR.
+
+## Current frontier
+
+#4695 and #4696 are now both blocked on #4700 (the analytic Hensel
+uniqueness statement) and indirectly on #4698 (the size-equality lemma
+in partial PR for #4679). Once #4698 merges and #4700 lands, a worker
+session can pick up either transport direction.
+
+## Next step
+
+A planner picks up #4700 (the precursor); or a worker with appropriate
+context claims it directly. The Hensel-uniqueness proof is itself a
+substantial piece of work and may decompose further (a coprime-lifting
+helper, a `ZMod (p^k)` quotient bridge, or stepping through `Padic`
+machinery).
+
+## Blockers
+
+None for this session — the decomposition path is the correct outcome
+per the issue body's explicit guidance.


### PR DESCRIPTION
This PR records the progress note from feature session a6012018,
which scope-assessed #4695 (forward Hensel transport
henselLiftData_represents_lifted_of_modP) and decomposed it by
filing precursor #4700 for the HexHenselMathlib.hensel_unique sorry
that #4695 (and sibling #4696) both consume. Both transport sub-issues
now carry depends-on: #4700 and the blocked label.

Independently, henselLiftData_liftedFactors_size_eq — listed in the
#4695 body as already landed — is still in open PR #4698 (partial for
#4679), so #4695 also waits on that to merge before it can be
implemented.

🤖 Prepared with Claude Code