### PR TITLE
HexGramSchmidtMathlib: add Gram determinant Bareiss bridge

### DIFF
--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -25,6 +25,27 @@ namespace Hex
 namespace GramSchmidt
 namespace Int
 
+/-- Bridge-layer capstone for the Gram determinant vector: the no-pivot
+Bareiss pass over the full Gram matrix records, at slot `r + 1`, the same
+leading-prefix determinant as the public row-pivoted Bareiss surface on that
+prefix.
+
+This theorem lives in `HexGramSchmidtMathlib` because the proof path for the
+underlying `gramDet`/Bareiss identification crosses the matrix determinant
+bridge. Mathlib-free consumers should use the executable `gramDet` API
+instead of depending on this Bareiss-facing statement. -/
+theorem gramDetVecEntry_eq_leadingPrefix_bareiss
+    (b : Matrix Int n m) (r : Nat) (hr : r < n) :
+    gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
+        ⟨r + 1, Nat.succ_lt_succ hr⟩ =
+      (Matrix.bareiss
+        (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+          (Nat.succ_le_of_lt hr))).toNat := by
+  have hentry :=
+    gramDetVecEntry_eq_gramDet (b := b) (k := r + 1)
+      (hk := Nat.succ_le_of_lt hr)
+  simpa [gramDet, GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram] using hentry
+
 /-- The fraction-free scaled-coefficient loop records, below the diagonal, the
 Bareiss determinant of the Cramer matrix for the corresponding
 Gram-Schmidt coefficient. This is the executable-array invariant needed to

--- a/progress/20260517T135131Z_9743ce07.md
+++ b/progress/20260517T135131Z_9743ce07.md
@@ -1,0 +1,38 @@
+# 20260517T135131Z — work session 9743ce07 (#4053)
+
+## Accomplished
+
+Claimed #4053 after all unclaimed directives were unavailable to this worker
+(`needs replan` or dependency-blocked). Added the bridge-layer capstone
+`Hex.GramSchmidt.Int.gramDetVecEntry_eq_leadingPrefix_bareiss` in
+`HexGramSchmidtMathlib/Int.lean`, exposing the no-pivot Gram determinant
+vector slot equality against the public row-pivoted Bareiss surface on the
+leading prefix.
+
+Verified:
+
+- `lake build HexGramSchmidtMathlib.Int`
+- `lake build HexGramSchmidt HexGramSchmidtMathlib`
+- `lake build HexMatrixMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+
+The requested banned-token grep still reports only pre-existing hits in
+`HexGramSchmidt/Int.lean` and `HexGramSchmidtMathlib/Int.lean`; no new
+`sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` was introduced.
+
+## Current frontier
+
+#4053 now has the bridge theorem requested by the downstream Gram-Schmidt
+assembly issue. The Mathlib-free file still contains the existing
+`gramDetVecEntry` / diagonal `sorry` holes tracked by #3977.
+
+## Next step
+
+Open the PR for #4053. Once it merges, #3977 can proceed with the
+Mathlib-free diagonal assembly without needing to add bridge imports.
+
+## Blockers
+
+None for this session. The worktree had a pre-existing unstaged
+`.claude/CLAUDE.md` change; it was not touched or staged.


### PR DESCRIPTION
Closes #4053

Session: `9743ce07-3e24-493b-b82d-658c850a5fca`

a35fd1dd Add Gram determinant Bareiss bridge

🤖 Prepared with Claude Code