### PR TITLE
doc: record #4647 decomposition into scaled-candidate substrate sub-issues

### DIFF
--- a/progress/20260517T140658Z_869031b6.md
+++ b/progress/20260517T140658Z_869031b6.md
@@ -1,0 +1,80 @@
+# 20260517T140658Z — work session 869031b6 (#4647 decomposition)
+
+## Accomplished
+
+Claimed #4647 "HO-1 substrate (#4638 sub): primitive recursive
+recombination coverage" and oriented on the recursive coverage proof
+shape against the scaled executable `Hex.scaledRecombinationSearchModAux`
+(landed by #4717).
+
+Read the existing monic recursive coverage theorem
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`
+(`HexBerlekampZassenhausMathlib/Basic.lean:9956–10233`, ~280 lines) and
+the scaled-substrate landings from #4717:
+`Hex.scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none`,
+`shouldRecord_scaledRecombinationCandidate_of_eq_factor`,
+`exactQuotient?_scaledRecombinationCandidate_eq_some_of_eq_factor`,
+plus the recovery identity `scaledRecombinationCandidate_eq_factor_of_recovery`
+from #4652 and the primitive-core helpers landed by #4644 / #4646
+(`representsIntegerFactorAtLift_primitive`,
+`natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core`,
+`not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core`,
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core`,
+`liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core`).
+
+Found that the existing primitive-core "support / cover-at-min /
+prefix-none" helper chain is uniformly stated against the **unscaled**
+`recombinationCandidate d T`. For non-monic primitive cores, the
+integer factor recovery identity is against the **scaled**
+`scaledRecombinationCandidate core d T`; the two candidate polynomials
+genuinely differ whenever `Hex.DensePoly.leadingCoeff core ≠ 1`, since
+`scaledRecombinationCandidate = primitivePart(centeredLift(coreLc·prod))`
+vs `recombinationCandidate = primitivePart(centeredLift(prod))` —
+`primitivePart` does not commute past `centeredLift` to recover the
+scaling factor for non-monic cores. The partition's
+`support_subset_of_dvd_recombinationCandidate` field is therefore not
+directly applicable to a scaled-candidate divisor, and the scaled
+recursive coverage proof needs scaled-candidate analogues of three
+primitive-core helpers before the assembly can be written.
+
+Per the issue's explicit decomposition allowance, created three
+precursor sub-issues with the explicit dependency chain:
+
+* **#4736** — `representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core`
+  (foundational scaled support direction).
+* **#4737** — scaled `mem_T_iff_*`, `exists_representingSubset_of_mem_T_*`,
+  and `coverAtMin_representingSubset_subset_of_*` cover-at-min chain
+  (`depends-on: #4736`).
+* **#4738** — `liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled`
+  (`depends-on: #4737`).
+
+Posted the `Decomposed into #4736, #4737, #4738` breadcrumb comment on
+#4647 with the reason, then `coordination skip`ped #4647 so the next
+planner replan-triage cycle either narrows the parent to the residual
+recursive coverage assembly or closes it.
+
+No code changes were made — the decomposition is purely on the GitHub
+side, so no commit and no PR.
+
+## Current frontier
+
+The recursive coverage capstone of #4647 is intentionally blocked on
+the new precursor chain. #4736 is unblocked and is the next entry
+point. The remaining `sorry`s on the HexBerlekampZassenhaus /
+HexBerlekampZassenhausMathlib surface are unaffected by this session.
+
+## Next step
+
+A worker should claim #4736 with a fresh context and design the scaled
+support direction proof — either via a small new scaled-to-unscaled
+divisibility bridge that feeds the existing partition field, or via a
+direct re-derivation using the partition's `pairwise_disjoint` /
+`unique_up_to_associated` / `cover` fields combined with the recovery
+identity from #4652. The choice will inform how invasive the cover-at-min
+chain in #4737 needs to be.
+
+## Blockers
+
+#4647 is now `replan` pending closure or narrowing by the next planner
+after #4738 lands. #4737 is blocked on #4736. #4738 is blocked on #4737.
+No blocker for #4736 itself.


### PR DESCRIPTION
This PR records the per-turn progress entry for worker session
\`869031b6\` on #4647 ("HO-1 substrate (#4638 sub): primitive recursive
recombination coverage").

After orienting on the existing monic recursive coverage template and
the scaled substrate from #4717 / #4652, the worker determined that the
recursive coverage proof requires scaled-candidate analogues of the
primitive-core support / cover-at-min / prefix-none helper chain, which
currently only exists against the unscaled \`recombinationCandidate\`.
For non-monic primitive cores the scaled and unscaled candidates
genuinely differ, so the unscaled chain does not transport directly.

Three sequential precursor sub-issues were created — #4736 (scaled
support direction), #4737 (scaled cover-at-min chain, depends on #4736),
and #4738 (scaled prefix-none, depends on #4737) — and #4647 was
\`coordination skip\`'d with a \`Decomposed into #4736, #4737, #4738\`
breadcrumb for the next planner replan-triage cycle.

Session: \`869031b6-17b9-45b2-9de4-69c1403669ca\`

🤖 Prepared with Claude Code