### PR TITLE
feat: add GramSchmidt Nat diagonal sync

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -841,6 +841,44 @@ private theorem getArrayEntry_zeroRows (n i j : Nat) :
   · by_cases hj : j < n <;> simp [zeroRows, getArrayEntry, hi, hj]
   · simp [zeroRows, getArrayEntry, hi, getArrayEntry_default_row]
 
+/-- Outer-array length of the initial Gram row buffer. -/
+private theorem gramRows_size (b : Matrix Int n m) : (gramRows b).size = n := by
+  simp [gramRows, Array.size_map, Array.size_range]
+
+/-- Inner-row length of each row of the initial Gram row buffer. -/
+private theorem gramRows_row_size (b : Matrix Int n m) (r : Nat) (hr : r < n) :
+    (gramRows b)[r]!.size = n := by
+  show ((Array.range n).map fun row =>
+      (Array.range n).map fun col =>
+        if hrow : row < n then
+          if hcol : col < n then
+            let i : Fin n := ⟨row, hrow⟩
+            let j : Fin n := ⟨col, hcol⟩
+            Matrix.dot (b.row i) (b.row j)
+          else
+            0
+        else
+          0)[r]!.size = n
+  rw [Array.getElem!_eq_getD]
+  unfold Array.getD
+  simp only [Array.size_map, Array.size_range]
+  rw [dif_pos hr]
+  simp [Array.size_map, Array.size_range]
+
+/-- Outer-array length of the initial coefficient buffer. -/
+private theorem zeroRows_size (n : Nat) : (zeroRows n).size = n := by
+  simp [zeroRows, Array.size_map, Array.size_range]
+
+/-- Inner-row length of each row of the initial coefficient buffer. -/
+private theorem zeroRows_row_size (n : Nat) (r : Nat) (hr : r < n) :
+    (zeroRows n)[r]!.size = n := by
+  show ((Array.range n).map fun _ => (Array.range n).map fun _ : Nat => (0 : Int))[r]!.size = n
+  rw [Array.getElem!_eq_getD]
+  unfold Array.getD
+  simp only [Array.size_map, Array.size_range]
+  rw [dif_pos hr]
+  simp [Array.size_map, Array.size_range]
+
 private theorem getArrayEntry_scaledCoeffArrayLoop_above
     (n fuel : Nat) (state : ScaledCoeffArrayState)
     (hcoeffs : ∀ i j, i < j → getArrayEntry state.coeffs i j = 0)
@@ -2928,22 +2966,78 @@ theorem gramDetVecEntry_eq_gramDet
 /-- The scaled-coefficient array loop writes the same diagonal determinant
 values as `gramDetVecEntry`, including the zero tail after an early singular
 no-pivot Bareiss step. -/
-private theorem scaledCoeffRows_diag_eq_gramDetVecEntry
+private theorem scaledCoeffRows_diag_toNat_eq_gramDetVecEntry
     (b : Matrix Int n m) (i : Nat) (hi : i < n) :
-    getArrayEntry (scaledCoeffRows b) i i =
-      Int.ofNat
-        (gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
-          ⟨i + 1, Nat.succ_lt_succ hi⟩) := by
-  sorry
+    (getArrayEntry (scaledCoeffRows b) i i).toNat =
+      gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
+        ⟨i + 1, Nat.succ_lt_succ hi⟩ := by
+  let iFin : Fin n := ⟨i, hi⟩
+  have hdiag :=
+    scaledCoeffArrayLoop_diag_matches
+      (state_array :=
+        { step := 0
+          matrix := gramRows b
+          coeffs := zeroRows n
+          prevPivot := 1 })
+      (state_matrix := Matrix.noPivotInitialState (Matrix.gramMatrix b))
+      (by rfl) (rowsToMatrix_gramRows b) (by rfl) (by rfl)
+      (gramRows_size b) (gramRows_row_size b)
+      (zeroRows_size n) (zeroRows_row_size n)
+      (by
+        intro j hjs _hjn
+        simp [Matrix.noPivotInitialState] at hjs)
+      (by
+        intro j _hjs _hjn
+        exact getArrayEntry_zeroRows n j j)
+      n iFin (by
+        left
+        simp [Matrix.noPivotInitialState, iFin, hi])
+  show (getArrayEntry
+      (scaledCoeffArrayLoop n n
+        { step := 0
+          matrix := gramRows b
+          coeffs := zeroRows n
+          prevPivot := 1 }).coeffs i i).toNat =
+    gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
+      ⟨i + 1, Nat.succ_lt_succ hi⟩
+  rcases hdiag with ⟨h_sing, h_eq⟩ | ⟨s, h_sing, h_cases⟩
+  · simp only [Matrix.bareissNoPivotData, gramDetVecEntry, Matrix.finish,
+      bareissDiagNat, h_sing]
+    exact congrArg Int.toNat h_eq
+  · simp only [Matrix.bareissNoPivotData, gramDetVecEntry, Matrix.finish,
+      bareissDiagNat, h_sing]
+    rcases h_cases with ⟨hsi, h_zero⟩ | ⟨his, h_eq⟩
+    · have hsi' : s ≤ i := by
+        simpa [iFin] using hsi
+      have hs_lt : s < i + 1 := by omega
+      rw [if_pos hs_lt]
+      exact congrArg Int.toNat h_zero
+    · have his' : i < s := by
+        simpa [iFin] using his
+      have hs_not_lt : ¬ s < i + 1 := by omega
+      rw [if_neg hs_not_lt]
+      exact congrArg Int.toNat h_eq
 
 /-- The scaled-coefficient loop stores the next leading Gram determinant on
-the diagonal. -/
-private theorem scaledCoeffRows_diag_eq_gramDet
+the diagonal, at the executable Nat boundary. -/
+private theorem scaledCoeffRows_diag_toNat_eq_gramDet
     (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    (getArrayEntry (scaledCoeffRows b) i i).toNat =
+      gramDet b (i + 1) (Nat.succ_le_of_lt hi) := by
+  rw [scaledCoeffRows_diag_toNat_eq_gramDetVecEntry (b := b) i hi]
+  rw [gramDetVecEntry_eq_gramDet (b := b) (i + 1) (Nat.succ_le_of_lt hi)]
+
+/-- If the diagonal executable entry is known nonnegative, the Nat-level
+diagonal synchronization can be lifted back to the corresponding Int equality.
+That nonnegativity is a bridge-layer obligation for Gram determinants. -/
+private theorem scaledCoeffRows_diag_eq_gramDet_of_nonneg
+    (b : Matrix Int n m) (i : Nat) (hi : i < n)
+    (hnonneg : 0 ≤ getArrayEntry (scaledCoeffRows b) i i) :
     getArrayEntry (scaledCoeffRows b) i i =
       Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  rw [scaledCoeffRows_diag_eq_gramDetVecEntry (b := b) i hi]
-  rw [gramDetVecEntry_eq_gramDet (b := b) (i + 1) (Nat.succ_le_of_lt hi)]
+  have hdiag := scaledCoeffRows_diag_toNat_eq_gramDet (b := b) i hi
+  rw [← hdiag]
+  exact (Int.toNat_of_nonneg hnonneg).symm
 
 theorem gramDet_zero (b : Matrix Int n m) :
     gramDet b 0 (Nat.zero_le n) = 1 := by
@@ -2958,15 +3052,28 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
       simp [gramDetVec, data, gramDetVecFromScaledCoeffRows]
   | succ r =>
       have hr : r < n := Nat.lt_of_succ_le hk
-      have hdiag := scaledCoeffRows_diag_eq_gramDet (b := b) r hr
-      simpa [gramDetVec, data, gramDetVecFromScaledCoeffRows] using congrArg Int.toNat hdiag
+      have hdiag := scaledCoeffRows_diag_toNat_eq_gramDet (b := b) r hr
+      simpa [gramDetVec, data, gramDetVecFromScaledCoeffRows] using hdiag
 
 
-theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+/-- Nat-level diagonal synchronization for the public scaled-coefficient
+matrix. This is the Mathlib-free diagonal fact exposed by the shared array
+pass; the stronger Int-valued diagonal statement additionally needs a
+nonnegativity bridge for the Bareiss/Gram determinant slot. -/
+theorem scaledCoeffs_diag_toNat (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    (GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩).toNat =
+      gramDet b (i + 1) (Nat.succ_le_of_lt hi) := by
+  simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using
+    scaledCoeffRows_diag_toNat_eq_gramDet (b := b) i hi
+
+theorem scaledCoeffs_diag_of_nonneg
+    (b : Matrix Int n m) (i : Nat) (hi : i < n)
+    (hnonneg : 0 ≤ GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩) :
     GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
       Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using
-    scaledCoeffRows_diag_eq_gramDet (b := b) i hi
+  have hdiag := scaledCoeffs_diag_toNat (b := b) i hi
+  rw [← hdiag]
+  exact (Int.toNat_of_nonneg hnonneg).symm
 
 theorem scaledCoeffs_upper (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
@@ -3151,20 +3258,6 @@ private theorem noPivotLoop_scaledCoeffMatrix_eq_borderedMinor_at_trailing
     j.val (Nat.lt_trans hji i.isLt)
     ⟨j.val, Nat.lt_trans hji i.isLt⟩ i
     (Nat.le_refl _) (Nat.le_of_lt hji)
-
-/-- Outer-array length of the initial coefficient buffer. -/
-private theorem zeroRows_size (n : Nat) : (zeroRows n).size = n := by
-  simp [zeroRows, Array.size_map, Array.size_range]
-
-/-- Inner-row length of each row of the initial coefficient buffer. -/
-private theorem zeroRows_row_size (n : Nat) (r : Nat) (hr : r < n) :
-    (zeroRows n)[r]!.size = n := by
-  show ((Array.range n).map fun _ => (Array.range n).map fun _ : Nat => (0 : Int))[r]!.size = n
-  rw [Array.getElem!_eq_getD]
-  unfold Array.getD
-  simp only [Array.size_map, Array.size_range]
-  rw [dif_pos hr]
-  simp [Array.size_map, Array.size_range]
 
 /-- Non-singular top-level composite: when the no-pivot Bareiss pass over the
 full Gram matrix has not recorded a singular step before reaching column `j`,

--- a/progress/20260517T152245Z_69a756df.md
+++ b/progress/20260517T152245Z_69a756df.md
@@ -1,0 +1,56 @@
+# 20260517T152245Z — work session 69a756df (#3977)
+
+## Accomplished
+
+Claimed #3977 after the open directive issues were either blocked or marked
+for replan. Added the Mathlib-free Nat-level diagonal synchronization in
+`HexGramSchmidt/Int.lean`:
+
+* `scaledCoeffRows_diag_toNat_eq_gramDetVecEntry`, instantiating
+  `scaledCoeffArrayLoop_diag_matches` at the initial Gram-row/no-pivot state.
+* `scaledCoeffRows_diag_toNat_eq_gramDet`, composing the Nat-level array fact
+  with `gramDetVecEntry_eq_gramDet`.
+* `scaledCoeffs_diag_toNat`, the public packaging theorem for the diagonal of
+  `scaledCoeffs`.
+
+Removed the unconditional Mathlib-free dependency on the old Int-valued
+`scaledCoeffRows_diag_eq_gramDetVecEntry` capstone and rewired
+`gramDetVec_eq_gramDet` through the Nat-level theorem. Added conditional
+`_of_nonneg` Int-lift variants to make the remaining bridge obligation
+explicit instead of hiding it in the Mathlib-free layer.
+
+Also moved the existing `zeroRows_size` / `zeroRows_row_size` helpers earlier
+and added matching `gramRows_size` / `gramRows_row_size` helpers so the top-level
+initial-state instantiation is local and reusable.
+
+Verified:
+
+* `lake build HexGramSchmidt.Int`
+* `lake build HexGramSchmidt`
+* `python3 scripts/check_dag.py`
+* `git diff --check`
+* `rg -n '^axiom\b|native_decide|TODO|FIXME|sorry' HexGramSchmidt/Int.lean HexMatrix/Bareiss.lean`
+
+The forbidden-token scan still reports only the pre-existing `sorry`s:
+`HexGramSchmidt/Int.lean` prefix bridge and lattice norm theorem, plus
+`HexMatrix/Bareiss.lean` determinant bridge.
+
+## Current frontier
+
+#3977's Mathlib-free Nat-level deliverable is complete. The unconditional
+Int-valued diagonal statement is no longer claimed in `HexGramSchmidt/Int.lean`;
+the file now exposes the exact nonnegativity hypothesis needed to recover it.
+
+## Next step
+
+Plan a bridge-layer follow-up for `HexGramSchmidtMathlib/Int.lean` to recover
+the unconditional Int-valued `scaledCoeffs_diag` theorem from determinant
+nonnegativity / Bareiss determinant correctness, then update the existing
+bridge row-add proof that still refers to that old theorem name.
+
+## Blockers
+
+Directly building `HexGramSchmidtMathlib` now fails at its stale reference to
+`scaledCoeffs_diag`. That bridge work is deliberately outside this
+Mathlib-free issue: proving the needed nonnegativity of the Gram no-pivot
+diagonal slot crosses the determinant correctness boundary.


### PR DESCRIPTION
Closes #3977

Session: `69a756df-8dce-4d58-a1ad-175c6b19f2f4`

a0c69798 feat: add GramSchmidt Nat diagonal sync

🤖 Prepared with Claude Code