### PR TITLE
doc: record #4647 decomposition into non-monic exactQuotient precursor #4767

### DIFF
--- a/progress/20260517T175837Z_f1435114.md
+++ b/progress/20260517T175837Z_f1435114.md
@@ -1,0 +1,53 @@
+# Session f1435114 — #4647 decomposition (non-monic exactQuotient gap)
+
+## Accomplished
+
+Claimed #4647 (primitive recursive recombination coverage). Audited the
+existing monic-target capstone
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`
+and the available scaled precursors (#4717, #4736, #4737, #4738, #4652,
+#4644, #4646), then traced the recursive step's reliance on
+`exactQuotient? target candidate = some quotient` (the `hquot` argument of
+`scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none`).
+
+Identified a residual substrate gap: the cover-at-min factor `f_cov` in the
+primitive recursive coverage is primitive with positive leading coefficient
+(via `representsIntegerFactorAtLift_primitive` from #4644) but **not
+monic** for primitive non-monic cores. The existing scaled exactQuotient
+bridge `exactQuotient?_scaledRecombinationCandidate_eq_some_of_eq_factor`
+from #4717 requires `Hex.DensePoly.Monic factor`, and the underlying
+`divMod_remainder_eq_zero_of_monic_mul_eq` in `HexPolyZ/Basic.lean`
+(lines ~1124-1186) is monic-only because its proof depends on
+`∀ a : Int, a - (a / lc) * lc = 0`, which holds only when `lc = ±1`.
+
+Filed #4767 as the residual precursor for the non-monic exactQuotient
+bridge. Left a `Decomposed into #4767` breadcrumb on #4647 and skipped it
+(now `replan`-flagged; `coordination check-blocked` will reblock it on
+#4767 closure).
+
+No code changes were landed in this session.
+
+## Current frontier
+
+#4647 is now blocked on #4767. The recursive coverage assembly is ready to
+proceed once the non-monic exactQuotient bridge lands: the proof body
+mirrors the monic version structurally, swapping the recovery to
+`scaledRecombinationCandidate_eq_factor_of_recovery` (#4652), the
+prefix-none discharge to
+`liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled`
+(#4738), the step assembly to
+`scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none` (#4717),
+and the empty-J contradiction to
+`not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core`
+(#4646).
+
+## Next step
+
+A worker picks up #4767 and adds the non-monic primitive exactQuotient
+bridge in `HexPolyZ/Basic.lean` and `HexBerlekampZassenhausMathlib/Basic.lean`.
+Once that lands, #4647 unblocks and the recursive coverage capstone can be
+assembled by a subsequent worker.
+
+## Blockers
+
+- #4767 must land before #4647 can proceed.


### PR DESCRIPTION
This PR records the per-turn progress entry for worker session
\`f1435114\` on #4647 ("HO-1 substrate (#4638 sub): primitive recursive
recombination coverage").

After orienting on the existing monic recursive coverage capstone
\`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition\`
and the available scaled precursors (#4717, #4736, #4737, #4738,
#4652, #4644, #4646), the worker identified a residual substrate gap:
the recursive step lemma needs
\`exactQuotient? target f_cov = some quotient\` for the primitive cover
factor \`f_cov\`, but the scaled exactQuotient bridge from #4717 requires
\`Monic factor\`. \`representsIntegerFactorAtLift_primitive\` (#4644) only
gives primitive + positive lc — the cover factor is generically
non-monic (e.g. \`2X + 1\` per the #4652 counterexample). The underlying
\`divMod_remainder_eq_zero_of_monic_mul_eq\` in \`HexPolyZ/Basic.lean\`
relies on the cancellation invariant \`∀ a : Int, a - (a/lc) * lc = 0\`,
which is monic-only.

The progress note \`progress/20260517T084142Z_e165eed1.md\` records the
same gap from earlier substrate work.

A precursor sub-issue #4767 was filed for the non-monic exactQuotient
bridge, and #4647 was \`coordination skip\`'d with a
\`Decomposed into #4767\` breadcrumb for the next planner
replan-triage cycle. The depends-on linkage was added so #4647 stays
\`blocked\` until #4767 closes.

Session: \`f1435114-44b2-4a8a-b91b-c98f29833cbe\`

🤖 Prepared with Claude Code