### PR TITLE
doc: record #4767 decomposition into substrate sub-issues

### DIFF
--- a/progress/20260517T182300Z_d5c8e8bb.md
+++ b/progress/20260517T182300Z_d5c8e8bb.md
@@ -1,0 +1,61 @@
+# Decompose #4767 non-monic exactQuotient bridge
+
+## Accomplished
+
+Claimed #4767 (non-monic exactQuotient bridge for primitive cover factors).
+After orienting through `HexPoly/Euclid.lean` (divModArrayAux structure,
+existing `divModArrayAux_reconstruction`, `subtractScaledShift_*` helpers,
+`ofCoeffs_subtractScaledShift_eq_sub_monomial_mul`,
+`ofCoeffs_set!_eq_add_monomial`) and the existing monic-only proofs
+`divMod_remainder_eq_zero_of_monic_mul_eq` /
+`divMod_eq_of_monic_mul_eq` in `HexPolyZ/Basic.lean`, concluded the work
+naturally splits into a substantial array-level substrate piece and two
+trivial downstream wrappers.
+
+Decomposed into:
+
+* #4773 — non-monic divMod reconstruction lemma in `HexPoly/Euclid.lean`
+  plus `divMod_eq_of_pos_lc_pos_degree_mul_eq` in `HexPolyZ/Basic.lean`.
+  The substrate is a parallel of `divModArrayAux_reconstruction` but
+  parameterised over a polynomial-multiple invariant
+  (`ofCoeffs rem = m * ofCoeffs q`) instead of the global cancellation
+  hypothesis `∀ a, a - (a/lc) * lc = 0` (which fails for non-monic
+  integer divisors). Each step of the algorithm peels off the top of
+  `m`; the polynomial invariant guarantees the leading coefficient of
+  `rem` is `m.leadingCoeff * lc`, so `scaleLead = (· / lc)` is exact on
+  that value and `subtractScaledShift` lands on `m_new * q` for
+  `m_new = m - monomial (m.size - 1) m.leadingCoeff`. The proof is
+  expected to be in the ballpark of the existing reconstruction (~100
+  lines) plus polynomial-level bookkeeping.
+
+* #4774 — non-monic exactQuotient bridge wrappers in
+  `HexBerlekampZassenhaus/Basic.lean` and
+  `HexBerlekampZassenhausMathlib/Basic.lean`. Trivial follow-on once
+  #4773 lands: `shouldRecordPolynomialFactor candidate = true` is
+  discharged from positive degree, then the existing
+  `exactQuotient?_eq_some_of_divMod_eq_of_shouldRecord` packaging
+  consumes the new divMod result. The scaled bridge mirrors the monic
+  `exactQuotient?_scaledRecombinationCandidate_eq_some_of_eq_factor`
+  via the new wrapper. `depends-on: #4773` is recorded on #4774.
+
+Skipped #4767 with `Decomposed into #4773, #4774` breadcrumb so that a
+future planner closes the parent forward-linked to the sub-issues.
+
+## Current frontier
+
+#4773 is the unblocked sub-issue; #4774 is blocked on it. After both
+land, #4647's recursive coverage proof can call the scaled bridge from
+#4774, completing one of the three open HO-1 substrate sub-chains noted
+in the recent summarize narrative.
+
+## Next step
+
+A subsequent worker claims #4773 and writes the parallel non-monic
+reconstruction in `HexPoly/Euclid.lean`. Induction on `m.size` (with the
+algorithm's fuel ≥ `m.size`) is the recommended structure; reuses
+existing `subtractScaledShift_*` and `ofCoeffs_*` helpers throughout.
+
+## Blockers
+
+None for the decomposition itself. The implicit blocker on #4773 is the
+substantive proof effort (estimated ~150-200 lines).


### PR DESCRIPTION
This PR records the per-turn progress entry for worker session
\`d5c8e8bb\` on #4767 (\"HO-1 substrate (#4647 precursor): non-monic
exactQuotient bridge for primitive cover factors\").

After orienting on the existing monic divMod machinery in
\`HexPoly/Euclid.lean\` (\`divModArrayAux\`, \`divModArrayAux_reconstruction\`,
the \`subtractScaledShift_*\` helpers, and the polynomial-level bridges
\`ofCoeffs_subtractScaledShift_eq_sub_monomial_mul\` /
\`ofCoeffs_set!_eq_add_monomial\`) and the existing monic-only proofs
\`divMod_remainder_eq_zero_of_monic_mul_eq\` / \`divMod_eq_of_monic_mul_eq\`
in \`HexPolyZ/Basic.lean\`, the worker determined that the central
\`divMod_eq_of_pos_lc_pos_degree_mul_eq\` deliverable requires a parallel
non-monic reconstruction in \`HexPoly/Euclid.lean\` parameterised over a
polynomial-multiple invariant (\`ofCoeffs rem = m * ofCoeffs q\`) in
place of the global cancellation hypothesis \`∀ a, a - (a/lc) * lc = 0\`
that fails for non-monic integer divisors.

Two sequential sub-issues were created — #4773 (the divMod substrate,
\`divModArrayAux_eq_of_polynomial_mul\` + \`divMod_eq_of_pos_lc_pos_degree_mul_eq\`)
and #4774 (the thin \`exactQuotient?\` and scaled bridge wrappers, depends
on #4773) — and #4767 was \`coordination skip\`'d with a
\`Decomposed into #4773, #4774\` breadcrumb for the next planner
replan-triage cycle.

Session: \`d5c8e8bb\`

🤖 Prepared with Claude Code