### PR TITLE
doc: record #4747 decomposition into #4778, #4779

### DIFF
--- a/progress/20260517T183451Z_68ff9d09.md
+++ b/progress/20260517T183451Z_68ff9d09.md
@@ -1,0 +1,82 @@
+# Session 68ff9d09 — decompose #4747 quadratic discharger
+
+## Accomplished
+
+Claimed #4747 (HO-1 substrate: quadratic `repeatedPart` expansion-complete
+discharger) and assessed scope. The issue body assumed the public discharger
+composes from #4759 (`normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover`,
+landed) plus the existing array-level expansion helper
+`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`
+(`HexBerlekampZassenhaus/Basic.lean:9200`). The composition does not work as
+written: the array-level helper requires `DensePoly.Monic` on every core
+factor (transitively via
+`consumeExactPower_pow_mul_of_not_dvd` →
+`exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree`), and
+`quadraticIntegerRootFactors?` can produce a non-monic degree-1 residual
+whenever the primitive `squareFreeCore` is non-monic.
+
+Concrete counter-example: `(X-1)(2X+3) = 2X^2 + X - 3` is primitive,
+squarefree, has positive leading coefficient `2`, and is a valid
+`squareFreeCore`. `quadraticIntegerRootFactors?` returns
+`some #[(X-1), (2X+3)]`; the residual `2X+3` is irreducible and primitive but
+not monic.
+
+The progress entry for #4603 (`progress/20260517T084142Z_e165eed1.md`)
+already documents the non-monic gap: "Generalising to non-monic factors would
+need a new `divMod_eq_of_mul_eq_of_ne_zero` substrate, which is out of scope
+for this sub-issue."
+
+The companion non-monic divMod chain is already in flight for the scaled
+recombination path:
+
+* #4773 (claimed, in progress):
+  `divMod_eq_of_pos_lc_pos_degree_mul_eq` in `HexPolyZ/Basic.lean`.
+* #4774 (blocked on #4773):
+  `exactQuotient?_eq_some_of_pos_lc_pos_degree_mul_eq` in
+  `HexBerlekampZassenhaus/Basic.lean`.
+
+Decomposed #4747 by filing two precursor sub-issues:
+
+* **#4778** — non-monic versions of `consumeExactPower_pow_mul_of_not_dvd`
+  (private), `expandRepeatedPartFactorsAux_residual_eq_one_of_pow_decomposition`
+  (private), and `expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`
+  (public). Depends on #4774. Each one is a line-by-line parallel of its
+  monic counterpart, with the divisibility-extraction step swapped for
+  #4774's non-monic surface.
+* **#4779** — `quadraticIntegerRootFactors?_pairwise_not_associated`, the
+  pairwise non-association lemma already specified in #4604 deliverable 2
+  but never landed. Required to discharge the `hnot_dvd_tail` side condition
+  of the expansion helper.
+
+Left a breadcrumb on #4747 (`gh issue comment 4747 …`) and released the
+claim via `coordination skip 4747`. The planner's replan triage will either
+close #4747 once #4778 and #4779 land (residual scope becomes a thin
+assembly using #4759 + #4778 + #4779) or narrow #4747 to that assembly
+scope.
+
+## Current frontier
+
+Critical-path chain into the quadratic-arm discharger:
+
+```
+#4773 (in flight)
+  → #4774 (blocked)
+    → #4778 (new, blocked on #4774)
+       ↘ #4747 residual assembly (needs #4778 + #4779 + #4759)
+#4779 (new, independent — can be landed now)
+```
+
+Sibling #4604 (assembly umbrella) also depends on #4747 and lists the
+#4779 lemma as its own deliverable 2; planner triage should consolidate.
+
+## Next step
+
+A worker on #4779 can land the pairwise non-association lemma immediately
+(no dependencies). A worker on #4778 can land the non-monic expansion chain
+once #4774 (in turn #4773) lands. Both must land before the residual #4747
+assembly is workable.
+
+## Blockers
+
+None on this session — the decomposition is the deliverable. The downstream
+chain is blocked on the in-flight #4773 / #4774 substrate work.


### PR DESCRIPTION
This PR records the per-turn progress entry for worker session
\`68ff9d09\` on #4747 ("HO-1 substrate (#4611 sub): quadratic repeatedPart
expansion-complete discharger").

After orienting on the existing monic expansion helper
\`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition\`
(\`HexBerlekampZassenhaus/Basic.lean:9200\`) and the landed
\`normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover\`
(#4759), the worker identified a substrate gap: the array-level expansion
helper requires \`DensePoly.Monic\` on every core factor (transitively via
\`consumeExactPower_pow_mul_of_not_dvd\` →
\`exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree\`). However,
\`quadraticIntegerRootFactors?\` can produce a non-monic degree-1 residual
when the primitive \`squareFreeCore\` is non-monic — e.g. for
\`(X-1)(2X+3) = 2X^2 + X - 3\` the residual factor \`2X+3\` is irreducible,
primitive, has positive leading coefficient, but is not monic.

This is the same monic-only restriction documented in the #4603 progress
entry (\`progress/20260517T084142Z_e165eed1.md\`).

Two precursor sub-issues were filed:

* **#4778** — non-monic versions of \`consumeExactPower_pow_mul_of_not_dvd\`
  (private), \`expandRepeatedPartFactorsAux_residual_eq_one_of_pow_decomposition\`
  (private), and \`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition\`
  (public). Each parallels its monic counterpart line-by-line, swapping
  the divisibility-extraction step for the non-monic surface from #4774
  (depends on #4774 → #4773, both already in flight for the scaled
  recombination path).
* **#4779** — \`quadraticIntegerRootFactors?_pairwise_not_associated\`, the
  pairwise non-association lemma already specified in #4604's deliverable
  2 but never landed; required to discharge \`hnot_dvd_tail\` in the
  expansion helper. Independent of #4778; can be landed now.

\`#4747\` was \`coordination skip\`'d with a \`Decomposed into #4778, #4779\`
breadcrumb for the next planner replan-triage cycle. Residual #4747 scope
after both precursors land: a thin assembly using #4759 + #4778 + #4779.

Session: \`68ff9d09-e0de-4fef-8e94-be34c78adf04\`

🤖 Prepared with Claude Code