### PR TITLE
doc: progress entry for #4779 counterexample triage

### DIFF
--- a/progress/20260517T185906Z_7ef5ff71.md
+++ b/progress/20260517T185906Z_7ef5ff71.md
@@ -1,0 +1,66 @@
+# Session 7ef5ff71 — triage-only, no code landed
+
+## Accomplished
+
+`/work` session. Claim attempts and triage:
+
+1. **#4697** (HenselSubsetLiftHypotheses constructor assembly) — tried to
+   claim, lost the race to a concurrent agent.
+
+2. **#4779** (`quadraticIntegerRootFactors?_pairwise_not_associated`) —
+   claimed and analyzed. The theorem as stated in the issue body is
+   **provably false**. Concrete counterexample posted on the issue:
+
+   For `core = (X-1)^2 = X^2 - 2X + 1`, the input satisfies all listed
+   hypotheses (`Primitive`, `0 < leadingCoeff`, `degree = 2`), but
+   `quadraticIntegerRootFactors?` returns `some #[X-1, X-1]` (the
+   splitter extracts the first `(X-1)`, then the recursive call with
+   the tail `[-1]` fails to extract `(X+1)`, leaving the residual as
+   `(X-1)`; the residual case `split.2.degree ≤ 1` pushes the residual
+   into the output). The pair `(X-1), (X-1)` is `Associated` via the
+   unit `DensePoly.C 1`, so `Pairwise (¬ Associated · ·)` fails.
+
+   The issue body's claim "core is squarefree by primitive-quadratic
+   structure" is incorrect — primitivity plus degree-2 does not imply
+   squarefree. The fix is to add a squarefree hypothesis; the natural
+   candidate is `ZPoly.SquareFreeRat core` (defined in
+   `HexPolyZ/Basic.lean:442`), which the downstream caller in #4747 can
+   discharge from `ZPoly.primitiveSquareFreeDecomposition_squareFreeCore`
+   (`HexPolyZ/Basic.lean:3017`) since they have
+   `core = (normalizeForFactor f).squareFreeCore`.
+
+   Skipped (`replan`) so a planner can refile with the corrected
+   signature. Sibling issue #4604 deliverable 2 cites the same lemma
+   and will need the same correction.
+
+3. **#4334** (HexLLL Phase 4 inconclusive benchmarks) — skipped
+   (`replan`). Host load average 11.55 / 11.02 / 11.86, firmly above
+   the contention threshold the issue body itself documents (prior
+   skips at 3.7-10+). Issue body explicitly requires quiet/dedicated
+   hardware for re-dispatch; this is a shared pod host with multiple
+   concurrent worker sessions.
+
+After these three actions, `coordination list-unclaimed` reports no
+remaining feature work; all other open feature issues are either
+blocked, claimed by other agents, or have open PRs. No directives are
+unclaimed.
+
+## Current frontier
+
+No code changes landed this session. The blocking item for HO-1 forward
+progress that this session touched is #4779 — needs planner refile with
+a squarefree hypothesis before any worker can usefully claim it.
+
+## Next step
+
+Planner picks up the `replan` queue:
+
+* #4779: refile with `ZPoly.SquareFreeRat core` (or equivalent) added
+  to the hypothesis list. Update sibling #4604 deliverable 2 to match.
+* #4334: needs scheduled execution on dedicated hardware per
+  `SPEC/benchmarking.md`, not on the shared pod host.
+
+## Blockers
+
+None for this session — both skips have detailed reasons posted as
+issue comments / skip comments for the planner to act on.


### PR DESCRIPTION
This PR records the per-turn progress entry for `/work` session
`7ef5ff71`. The session claimed #4779
(`quadraticIntegerRootFactors?_pairwise_not_associated`) and
discovered the planned theorem statement is provably false.

Concrete counterexample: take `core = (X-1)^2 = X^2 - 2X + 1`.

* `Primitive core` holds (`content = gcd(1, 2, 1) = 1`).
* `0 < leadingCoeff core` holds (`leadingCoeff = 1`).
* `core.degree?.getD 0 = 2`.
* `integerRootCandidates core = [1, -1]`.
* `splitIntegerRootFactorsAux` extracts `(X-1)`, then the recursive
  call with tail `[-1]` and quotient `(X-1)` finds that `(X+1)` does
  not divide `(X-1)`, leaving the residual as `(X-1)`.
* So `split.1 = #[X-1]`, `split.2 = X-1`, and the residual branch
  pushes the residual into the output:
  `quadraticIntegerRootFactors? core = some #[X-1, X-1]`.

The output pair `(X-1), (X-1)` is `ZPoly.Associated` via the unit
`DensePoly.C 1`, so `Pairwise (¬ Associated · ·)` is false. The
issue body's claim "core is squarefree by primitive-quadratic
structure" is incorrect — primitivity plus degree-2 does not imply
squarefree.

The fix is to add `Hex.ZPoly.SquareFreeRat core` to the hypothesis
list. The downstream caller in #4747 has
`core = (normalizeForFactor f).squareFreeCore` and can discharge
this via `ZPoly.primitiveSquareFreeDecomposition_squareFreeCore`
(`HexPolyZ/Basic.lean:3017`). Sibling #4604 deliverable 2 cites the
same lemma and needs the same correction.

#4779 was skipped (`replan`) with the full counterexample posted as
an issue comment.

The session also skipped #4334 (HexLLL inconclusive scientific
benchmarks) — host load average 11.55 / 11.02 / 11.86 on the shared
pod host, well above the contention threshold the issue body
documents for prior skips. Re-dispatch needs the scheduled
release-candidate benchmarking workflow on dedicated hardware per
`SPEC/benchmarking.md`.

Session: `7ef5ff71-434e-4e98-83a1-1424c92887d2`

🤖 Prepared with Claude Code