### PR TITLE
HO-1 substrate: discharge reassemblyExpansionComplete for the small-mod singleton arm (Mathlib-bridge variant, supersedes #4593)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9424,7 +9424,13 @@ theorem reassemblyExpansionComplete_constant_of_ne_zero
   rw [hcore_one, expandRepeatedPartFactorArray_singleton_one]
   exact hrep_one
 
-private theorem squareFreeCore_normalizeFactorSign_of_ne_zero
+/-- The normalized square-free core has positive leading coefficient
+(`squareFreeCore_leadingCoeff_pos_of_ne_zero`), so its sign-normalisation
+is the identity. Exposed publicly for HO-1 substrate consumers in the
+Mathlib bridge (notably the small-mod singleton arm specialisation of
+`normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover`,
+which discharges its `hnorm` precondition with this lemma). -/
+theorem squareFreeCore_normalizeFactorSign_of_ne_zero
     (f : ZPoly) (hf : f ≠ 0) :
     normalizeFactorSign (normalizeForFactor f).squareFreeCore =
       (normalizeForFactor f).squareFreeCore := by

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9222,6 +9222,103 @@ theorem expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decompositi
     simpa [Factorization.factorPower] using hnot_dvd_tail pre q e suf hsplit
   · simpa [Factorization.factorPower] using hdecomp
 
+/-- An irreducible `ZPoly` does not divide the unit `1`. Used by the small-mod
+singleton arm specialisation `expandRepeatedPartFactorArray_pow_singleton`
+(#4597 deliverable 2) to discharge the wrapper's tail-non-divisibility
+precondition for the singleton case, where the suffix product collapses to
+`1` and the only obligation is `¬ q ∣ 1`. The proof is a direct size argument:
+`size_le_of_dvd_nonzero` would force `q.size ≤ 1`, but irreducibility (via the
+non-zero, non-unit conditions on the leading coefficient) forces `q.size ≥ 2`. -/
+private theorem irreducible_not_dvd_one {q : ZPoly}
+    (hq_irr : ZPoly.Irreducible q) : ¬ q ∣ (1 : ZPoly) := by
+  intro hdvd
+  have hq_ne : q ≠ 0 := hq_irr.not_zero
+  have hone_ne : (1 : ZPoly) ≠ 0 := by
+    intro h
+    have : (1 : ZPoly).size = 1 := rfl
+    rw [h] at this
+    exact absurd this (by decide)
+  have hq_size_le : q.size ≤ (1 : ZPoly).size :=
+    ZPoly.size_le_of_dvd_nonzero hq_ne hone_ne hdvd
+  have h1 : (1 : ZPoly).size = 1 := rfl
+  have hq_pos : 0 < q.size := ZPoly.size_pos_of_ne_zero q hq_ne
+  have hq_one : q.size = 1 := by omega
+  -- A `q` of size 1 is constant, hence the leading coefficient appears at
+  -- index 0; combined with `q ∣ 1` forcing the leading coefficient to be a
+  -- unit in `ℤ`, this contradicts `not_unit`.
+  have hq_eq : q = DensePoly.C (q.coeff 0) := ZPoly.eq_C_of_size_eq_one q hq_one
+  rcases hdvd with ⟨w, hw⟩
+  -- hw : (1 : ZPoly) = q * w
+  have hw_ne : w ≠ 0 := by
+    intro hw_zero
+    rw [hw_zero] at hw
+    -- (1 : ZPoly) = q * 0 = 0, contradicting hone_ne
+    rw [DensePoly.mul_comm_poly, DensePoly.zero_mul] at hw
+    exact hone_ne hw
+  have hw_pos : 0 < w.size := ZPoly.size_pos_of_ne_zero w hw_ne
+  have hqw_size : (q * w).size = q.size + w.size - 1 :=
+    ZPoly.mul_size_eq_top_succ_of_nonzero q w hq_pos hw_pos
+  rw [← hw, h1] at hqw_size
+  have hw_one : w.size = 1 := by omega
+  have hlead :
+      DensePoly.leadingCoeff q * DensePoly.leadingCoeff w = (1 : Int) := by
+    have := ZPoly.leadingCoeff_mul_of_nonzero q w hq_ne hw_ne
+    rw [← hw] at this
+    have : DensePoly.leadingCoeff q * DensePoly.leadingCoeff w =
+        DensePoly.leadingCoeff (1 : ZPoly) := this.symm
+    rw [this]
+    rfl
+  have hq_lead : DensePoly.leadingCoeff q = q.coeff 0 := by
+    rw [DensePoly.leadingCoeff_eq_coeff_last q (by omega)]
+    congr 1; omega
+  rw [hq_lead] at hlead
+  have hcoeff_unit : q.coeff 0 = 1 ∨ q.coeff 0 = -1 :=
+    ZPoly.int_factor_one_eq_unit hlead
+  apply hq_irr.not_unit
+  rcases hcoeff_unit with h | h
+  · left; rw [hq_eq, h]
+  · right; rw [hq_eq, h]
+
+/-- **#4597 HO-1 substrate — small-mod singleton arm expansion specialisation.**
+Singleton specialisation of
+`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`:
+when the repeated part `rp` is the `k`-th `Hex.Factorization.factorPower` of an
+irreducible monic positive-degree `q`, expanding against the singleton core
+`#[q]` consumes the repeated part exactly, emitting `k` copies of `q` and
+reporting residual `1`. Consumed by the small-mod singleton arm umbrella
+`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+(#4564 / PR #4581) via the public discharger
+`Hex.reassemblyExpansionComplete_singleton_of_irreducible` (#4597
+deliverable 3). Sibling specialisations: constant arm
+`reassemblyExpansionComplete_constant_of_ne_zero` (#4585 / PR #4598);
+quadratic arm tracked by #4747. -/
+private theorem expandRepeatedPartFactorArray_pow_singleton
+    (q : ZPoly) (k : Nat)
+    (hq_monic : DensePoly.Monic q)
+    (hq_degree : 0 < q.degree?.getD 0)
+    (hq_irr : ZPoly.Irreducible q)
+    (rp : ZPoly) (hrp : rp = Factorization.factorPower q k)
+    (hfuel : k + 1 ≤ rp.size + 1) :
+    expandRepeatedPartFactorArray rp #[q] =
+      ((List.replicate k q).toArray, 1) := by
+  have hnot_dvd : ¬ q ∣ (1 : ZPoly) := irreducible_not_dvd_one hq_irr
+  have hmul : rp = Factorization.polyPow q k * 1 := by
+    rw [hrp]; exact (DensePoly.mul_one_right_poly _).symm
+  have hcep : consumeExactPower rp q (rp.size + 1) = (1, k) := by
+    rw [hmul]
+    apply consumeExactPower_pow_mul_of_not_dvd q 1 k hq_monic hq_degree hnot_dvd
+    rw [← hmul]; exact hfuel
+  unfold expandRepeatedPartFactorArray
+  show expandRepeatedPartFactorsAux [q] rp (rp.size + 1) = _
+  unfold expandRepeatedPartFactorsAux
+  rw [hcep]
+  show ((List.replicate k q).toArray ++
+      (expandRepeatedPartFactorsAux [] (1 : ZPoly) (rp.size + 1)).1,
+      (expandRepeatedPartFactorsAux [] (1 : ZPoly) (rp.size + 1)).2) =
+    ((List.replicate k q).toArray, 1)
+  unfold expandRepeatedPartFactorsAux
+  simp
+
 /-- The reassembled output for a single-`1` core list is exactly the
 normalization prefix followed by `1`. Both branches of `reassemblePolynomialFactors`
 collapse to this shape because the expansion never extracts anything when the

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9292,7 +9292,7 @@ reporting residual `1`. Consumed by the small-mod singleton arm umbrella
 deliverable 3). Sibling specialisations: constant arm
 `reassemblyExpansionComplete_constant_of_ne_zero` (#4585 / PR #4598);
 quadratic arm tracked by #4747. -/
-private theorem expandRepeatedPartFactorArray_pow_singleton
+theorem expandRepeatedPartFactorArray_pow_singleton
     (q : ZPoly) (k : Nat)
     (hq_monic : DensePoly.Monic q)
     (hq_degree : 0 < q.degree?.getD 0)

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -1968,6 +1968,87 @@ theorem normalizeForFactor_repeatedPart_isFactorPower_squareFreeCore_of_irreduci
             Hex.ZPoly.one_mul_zpoly] at hdecomp
           exact hdecomp
 
+/-- **#4597 HO-1 substrate — small-mod singleton arm `hcomplete` discharger
+(Mathlib bridge, deliverable 3).** When the normalized square-free core is
+itself irreducible, the singleton-core reassembly is expansion-complete:
+the `repeatedPart` of `normalizeForFactor f` is exactly a
+`Hex.Factorization.factorPower` of the square-free core (deliverable 1),
+and that factorPower is consumed completely by
+`Hex.expandRepeatedPartFactorArray` (deliverable 2). Consumed by the
+small-mod singleton arm umbrella
+`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+(#4564 / PR #4581) so callers can drop the explicit `hcomplete` premise
+once the eventual capstone wiring (#4170) lands.
+
+**Substrate gap (Gap 1):** the explicit `hmonic` premise on the
+square-free core mirrors the same gap labelled "Gap 1" in the exhaustive
+arm umbrella `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`
+(#4561). The underlying executable extraction
+(`consumeExactPower_pow_mul_of_not_dvd` and the
+`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`
+wrapper) currently requires monicness of the core factor; dropping the
+hypothesis would require a non-monic divMod/exactQuotient generalisation
+in `HexPolyZ/Basic.lean`. The premise is documented as an explicit shim
+so downstream consumers thread it consistently until the substrate work
+lands.
+
+Sibling dischargers: constant arm
+`Hex.reassemblyExpansionComplete_constant_of_ne_zero` (#4585 / PR #4598);
+quadratic arm tracked by #4747. -/
+theorem reassemblyExpansionComplete_singleton_of_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    (hirr : Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore)
+    (hmonic : Hex.DensePoly.Monic (Hex.normalizeForFactor f).squareFreeCore)
+    (hdeg :
+      0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0) :
+    Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+      #[(Hex.normalizeForFactor f).squareFreeCore] := by
+  obtain ⟨k, hk⟩ :=
+    normalizeForFactor_repeatedPart_isFactorPower_squareFreeCore_of_irreducible
+      f hf hirr
+  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
+  -- Size of `core` is at least 2 from positive degree.
+  have hcore_size_ge_two : 2 ≤ core.size := by
+    have hdeg_unfold : core.degree?.getD 0 =
+        (if core.size = 0 then 0 else core.size - 1) := by
+      unfold Hex.DensePoly.degree?
+      by_cases h : core.size = 0 <;> simp [h]
+    rw [hdeg_unfold] at hdeg
+    by_cases h : core.size = 0
+    · simp [h] at hdeg
+    · split at hdeg <;> omega
+  -- For monic `core` with `core.size ≥ 2`, the executable `factorPower` of
+  -- order `m` has size at least `m + 1`. This gives the fuel bound
+  -- `k + 1 ≤ (factorPower core k).size + 1` consumed by deliverable 2.
+  have hfactorPower_size_ge :
+      ∀ m, m + 1 ≤ (Hex.Factorization.factorPower core m).size := by
+    intro m
+    induction m with
+    | zero =>
+        show 1 ≤ (1 : Hex.ZPoly).size
+        rfl
+    | succ n ih =>
+        rw [Hex.Factorization.factorPower_succ]
+        have hprev_pos : 0 < (Hex.Factorization.factorPower core n).size := by
+          omega
+        have hcore_pos : 0 < core.size := by omega
+        have hmul_size :
+            (Hex.Factorization.factorPower core n * core).size =
+              (Hex.Factorization.factorPower core n).size + core.size - 1 :=
+          Hex.ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hprev_pos hcore_pos
+        omega
+  have hfuel :
+      k + 1 ≤ (Hex.normalizeForFactor f).repeatedPart.size + 1 := by
+    have := hfactorPower_size_ge k
+    rw [hk]
+    omega
+  -- Apply deliverable 2 to conclude residual = 1.
+  unfold Hex.reassemblyExpansionComplete
+  have hexpand :=
+    Hex.expandRepeatedPartFactorArray_pow_singleton
+      core k hmonic hdeg hirr (Hex.normalizeForFactor f).repeatedPart hk hfuel
+  rw [hexpand]
+
 end IntReductionMod
 
 /-- **#4549 substrate (HO-1), outer-bound specialisation, rewired for #4553.**

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -1914,6 +1914,60 @@ theorem normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible
     (coreFactors.toList.map HexPolyZMathlib.toPolynomial).toFinset
     (by intro r hr; rw [Multiset.mem_toFinset] at hr; exact hsubset r hr)
 
+/-- **#4597 HO-1 substrate — small-mod singleton arm `factorPower` shape of
+the repeated part.** Singleton specialisation of
+`normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover`
+(#4759, the final-assembly successor of the decomposed #4746): when the
+normalized square-free core is itself irreducible, the repeated part is
+exactly a `Hex.Factorization.factorPower` of the square-free core. The
+`hnorm` precondition of the general theorem is discharged by
+`Hex.squareFreeCore_normalizeFactorSign_of_ne_zero` (the normalized
+square-free core has positive leading coefficient, hence its
+sign-normalisation is the identity). Consumed by the public discharger
+`Hex.reassemblyExpansionComplete_singleton_of_irreducible` (#4597
+deliverable 3) to dispatch the singleton expansion specialisation
+`Hex.expandRepeatedPartFactorArray_pow_singleton` (#4597 deliverable 2).
+Sibling dischargers: constant arm
+`Hex.reassemblyExpansionComplete_constant_of_ne_zero` (#4585 / PR #4598);
+quadratic arms tracked by #4747. -/
+theorem normalizeForFactor_repeatedPart_isFactorPower_squareFreeCore_of_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    (hirr : Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore) :
+    ∃ k : Nat,
+      (Hex.normalizeForFactor f).repeatedPart =
+        Hex.Factorization.factorPower (Hex.normalizeForFactor f).squareFreeCore k := by
+  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
+  have hirr_arr :
+      ∀ q ∈ (#[core] : Array Hex.ZPoly).toList, Hex.ZPoly.Irreducible q := by
+    intro q hq
+    have hq_eq : q = core := by simpa using hq
+    exact hq_eq ▸ hirr
+  have hprod : Array.polyProduct (#[core] : Array Hex.ZPoly) = core :=
+    Hex.ZPoly.polyProduct_singleton core
+  have hnorm :
+      ∀ q ∈ (#[core] : Array Hex.ZPoly).toList, Hex.normalizeFactorSign q = q := by
+    intro q hq
+    have hq_eq : q = core := by simpa using hq
+    subst hq_eq
+    exact Hex.squareFreeCore_normalizeFactorSign_of_ne_zero f hf
+  obtain ⟨exponents, hlen, hdecomp⟩ :=
+    normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover
+      f hf #[core] hirr_arr hprod hnorm
+  -- Singleton `coreFactors` collapses the exponent list to `[k]` for some `k`.
+  have hsize : (#[core] : Array Hex.ZPoly).size = 1 := rfl
+  rw [hsize] at hlen
+  cases exponents with
+  | nil => simp at hlen
+  | cons k es =>
+      cases es with
+      | cons _ _ => simp at hlen
+      | nil =>
+          refine ⟨k, ?_⟩
+          simp only [List.zip_cons_cons, List.zip_nil_right, List.map_cons,
+            List.map_nil, List.foldl_cons, List.foldl_nil,
+            Hex.ZPoly.one_mul_zpoly] at hdecomp
+          exact hdecomp
+
 end IntReductionMod
 
 /-- **#4549 substrate (HO-1), outer-bound specialisation, rewired for #4553.**

--- a/progress/20260517T190739Z_ebe594c0.md
+++ b/progress/20260517T190739Z_ebe594c0.md
@@ -1,0 +1,72 @@
+# Progress 2026-05-17T19:07Z — small-mod singleton arm dischargers (#4597)
+
+## Accomplished
+
+Landed all three deliverables of #4597:
+
+* **Deliverable 2** (Mathlib-free, `HexBerlekampZassenhaus/Basic.lean`):
+  `expandRepeatedPartFactorArray_pow_singleton`. Specialises
+  `expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`
+  (#4767 / PR #4767) to the singleton-core case: when the repeated part
+  `rp` is `Hex.Factorization.factorPower q k` for monic positive-degree
+  irreducible `q`, the executable expansion against `#[q]` consumes the
+  repeated part exactly and emits `((List.replicate k q).toArray, 1)`.
+  Supporting helper `irreducible_not_dvd_one` discharges the singleton
+  tail-non-divisibility (`¬ q ∣ 1`) from irreducibility via the
+  `size_le_of_dvd_nonzero` + `eq_C_of_size_eq_one` +
+  `int_factor_one_eq_unit` chain.
+
+* **Deliverable 1** (Mathlib bridge,
+  `HexBerlekampZassenhausMathlib/IntReductionMod.lean`):
+  `normalizeForFactor_repeatedPart_isFactorPower_squareFreeCore_of_irreducible`.
+  Singleton specialisation of #4759: when the normalized square-free
+  core is irreducible, the repeated part is exactly a
+  `Hex.Factorization.factorPower` of the core. The general theorem's
+  `hnorm` precondition is discharged by promoting
+  `Hex.squareFreeCore_normalizeFactorSign_of_ne_zero` from `private` to
+  public (its proof was unchanged).
+
+* **Deliverable 3** (Mathlib bridge):
+  `reassemblyExpansionComplete_singleton_of_irreducible`. Composes
+  deliverables 1 and 2 with an inline size bound on
+  `(factorPower core k).size` from `mul_size_eq_top_succ_of_nonzero` to
+  discharge the `rp.size + 1`-fuel premise of deliverable 2.
+
+## Signature deviation: explicit `hmonic` premise
+
+Deliverable 3 takes an extra `hmonic : Hex.DensePoly.Monic squareFreeCore`
+premise vs. the issue's exact signature. This mirrors the same substrate
+gap ("Gap 1") already threaded through the exhaustive arm umbrella
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` (#4561).
+The underlying Mathlib-free executable extraction
+(`consumeExactPower_pow_mul_of_not_dvd` and the
+`expandRepeatedPartFactorArray_residual_eq_one_of_factorPower_decomposition`
+wrapper) currently requires monicness of the core factor; dropping the
+hypothesis would require a non-monic divMod / exactQuotient generalisation
+in `HexPolyZ/Basic.lean` (the same substrate work flagged for the
+exhaustive arm). The docstring documents this explicitly so downstream
+consumers thread `hmonic` consistently with the existing precedent.
+
+The slow-quadratic / fast-quadratic / quadratic-root arms already supply
+monic core factors by construction (the lifted Hensel factors are monic);
+only the small-mod singleton arm needs `hmonic` threaded because the core
+factor is the square-free core itself.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhausMathlib HexBerlekampZassenhaus` is
+green. `python3 scripts/check_dag.py` passes. No new `sorry`, `axiom`,
+`native_decide`, `TODO`, or `FIXME` introduced (the pre-existing `sorry`
+at `HexBerlekampZassenhaus/Basic.lean:6337` is unchanged).
+
+## Next step
+
+Open PR closing #4597. The downstream HO-1 capstone wiring for the
+small-mod singleton arm (#4170) is the natural successor; it will need
+to thread `hmonic` alongside the existing `hcomplete` shim until the
+non-monic substrate extension lands as a separate issue.
+
+## Blockers
+
+None for #4597. The `hmonic` deviation is documented and consistent with
+the project's existing substrate-gap precedent.


### PR DESCRIPTION
Closes #4597

Session: `ebe594c0-1cd4-4ec4-9094-ae3ce183936c`

1452a13e doc: progress entry for #4597 small-mod singleton dischargers
c80dfca6 feat: small-mod singleton hcomplete discharger (#4597 deliverable 3)
8c5f50dd feat: small-mod singleton factorPower bridge (#4597 deliverable 1)
730aaf89 feat: small-mod singleton expansion specialisation (#4597 deliverable 2)

🤖 Prepared with Claude Code