### PR TITLE
HexHensel Phase 6: polish Multifactor.lean normalizedXGCD and multifactorLift API

### DIFF
--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -84,6 +84,12 @@ theorem normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one
     congr_liftToZ_of_modP_eq p (1 : FpPoly p) (1 : ZPoly) (modP_one p)
   exact congr_trans _ _ _ p (congr_symm _ _ _ hlift_expr) hlift_one
 
+/-- Recursive list-shape worker behind `multifactorLift`. At each
+non-singleton step it lifts the head factor `g` against the running
+complementary product `Array.polyProduct rest.toArray` via `henselLift`, and
+recurses with `lifted.h` as the new target on `rest`. The singleton case
+returns the input reduced modulo `p^k`; the empty case returns the empty
+array. -/
 private def multifactorLiftList
     (p k : Nat) [ZMod64.Bounds p]
     (f : ZPoly) : List ZPoly → Array ZPoly
@@ -108,9 +114,19 @@ def multifactorLift
 /--
 Recursive preconditions required by the sequential multifactor lift.
 
-Each nontrivial split must supply exactly the invariant package consumed by
-`henselLift_spec`, and the recursive tail must satisfy the same contract for
-the lifted complementary factor.
+In the `g :: h :: tail` arm, the four conjuncts are exactly the inputs
+`henselLift_spec` consumes for the binary split of `g` against the running
+complementary product `Array.polyProduct (h :: tail).toArray`, followed by the
+recursive precondition for the lifted complement:
+
+1. `LinearLiftLoopInvariant` at `n = 1` — initial state for the linear loop;
+2. the step-degree invariant at every iteration `n ≥ 1`;
+3. the step-Bezout congruence at every iteration `n ≥ 1`;
+4. `MultifactorLiftInvariant` for the recursive tail with `lifted.h` as the
+   new target.
+
+The base cases impose the trivial obligations: `congr 1 f (p ^ k)` for the
+empty list and no preconditions for a singleton.
 -/
 def MultifactorLiftInvariant
     (p k : Nat) [ZMod64.Bounds p]
@@ -207,6 +223,10 @@ theorem polyProduct_cons_toArray (g : ZPoly) (rest : List ZPoly) :
   simpa [Array.polyProduct, one_mul_zpoly] using
     (list_foldl_mul_eq_mul_foldl_one g rest)
 
+/-- Induction-on-`factors` correctness statement feeding
+`multifactorLift_spec`: the ordered product of the lifted factors is
+congruent to `f` modulo `p^k`, provided each recursive binary split supplies
+the linear Hensel invariant package threaded by `MultifactorLiftInvariant`. -/
 private theorem multifactorLiftList_spec
     (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f : ZPoly) (factors : List ZPoly)

--- a/progress/2026-05-17T194949Z_e6a634a6.md
+++ b/progress/2026-05-17T194949Z_e6a634a6.md
@@ -1,0 +1,56 @@
+# 2026-05-17T19:49:49Z — HexHensel Phase 6 polish: Multifactor.lean normalizedXGCD/multifactorLift API (#4793)
+
+## Accomplished
+
+Polished the non-`polyProduct` API surface of `HexHensel/Multifactor.lean`
+per #4793:
+
+- Added a docstring to `Hex.ZPoly.multifactorLiftList` (private recursive
+  worker): describes the head-vs-running-complementary-product split, the
+  `henselLift` step, and the recursive descent on `lifted.h`. Documents
+  the singleton (`reduceModPow f p k`) and empty (`#[]`) base cases.
+
+- Added a docstring to `Hex.ZPoly.multifactorLiftList_spec` (private
+  recursive correctness lemma): explains it is the induction-on-`factors`
+  statement feeding `multifactorLift_spec`, threading
+  `MultifactorLiftInvariant` through each recursive binary split.
+
+- Tightened the existing `Hex.ZPoly.MultifactorLiftInvariant` docstring
+  to make the four conjuncts of the `g :: h :: tail` arm explicit, and to
+  describe the trivial base-case obligations.
+
+`@[simp]` audit: no annotation added. The `normalizedXGCD_*` lemmas carry
+typeclass/hypothesis side conditions and the `multifactorLift_*` theorems
+state `congr`-flavoured correctness statements; none are unconditional
+canonical-form rewrites.
+
+Audited the other existing public docstrings on `normalizedXGCD`,
+`normalizedXGCD_bezout`,
+`normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one`, `multifactorLift`,
+and `multifactorLift_spec` — each already characterises the result; left
+unchanged.
+
+## Current frontier
+
+`HexHensel/Multifactor.lean` Phase 6 polish is complete (this slice plus
+the `polyProduct` simp surface from #4790, both now in `Multifactor.lean`).
+
+## Next step
+
+Continue HexHensel Phase 6 on the remaining files per the issue body:
+`Linear.lean` (1661 lines, slice in flight on PR #4797), `Quadratic.lean`
+(2296 lines), `QuadraticMultifactor.lean` (1146 lines). Each is large
+enough to need its own per-section decomposition before claiming.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexHensel.Multifactor` ✅
+- `lake build HexHensel` ✅
+- `python3 scripts/check_dag.py` ✅ (no output)
+- `git diff --check` ✅ (no whitespace issues)
+- `grep -nE "sorry|axiom|native_decide|TODO|FIXME" HexHensel/Multifactor.lean`
+  on this branch = same as `origin/main` = empty.


### PR DESCRIPTION
Closes #4793

Session: `e6a634a6-a365-42e4-898b-85b3f4b80f48`

272db4fb doc: HexHensel Phase 6 — Multifactor.lean normalizedXGCD/multifactorLift API polish (#4793)

🤖 Prepared with Claude Code