### PR TITLE
HexHensel Phase 6: polish Linear.lean modP / liftToZ congruence cluster (lines 169-572)

### DIFF
--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -186,7 +186,7 @@ private theorem linearHenselStep_correction_identity
 /-- Reducing the integer `1` polynomial modulo `p` yields the `FpPoly p`
 identity. Bottom-of-recursion case for the `modP p` algebra rewrites consumed
 by the linear Hensel step's correctness chain. -/
-theorem modP_one (p : Nat) [ZMod64.Bounds p] :
+@[simp] theorem modP_one (p : Nat) [ZMod64.Bounds p] :
     ZPoly.modP p (1 : ZPoly) = (1 : FpPoly p) := by
   have hcong : ZPoly.congr (FpPoly.liftToZ (1 : FpPoly p)) (1 : ZPoly) p := by
     intro i
@@ -552,7 +552,7 @@ theorem liftToZ_mul_congr
 of a sum is the sum of residues. Standard ring-homomorphism rewrite for
 `modP p` used by the linear Hensel step proof to split `modP p (g·h + ...)`
 into manageable pieces. -/
-theorem modP_add
+@[simp] theorem modP_add
     (p : Nat) [ZMod64.Bounds p] (f g : ZPoly) :
     ZPoly.modP p (f + g) = ZPoly.modP p f + ZPoly.modP p g := by
   have hliftAdd :

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -183,6 +183,9 @@ private theorem linearHenselStep_correction_identity
     _ = eMod := by
           rw [FpPoly.one_mul]
 
+/-- Reducing the integer `1` polynomial modulo `p` yields the `FpPoly p`
+identity. Bottom-of-recursion case for the `modP p` algebra rewrites consumed
+by the linear Hensel step's correctness chain. -/
 theorem modP_one (p : Nat) [ZMod64.Bounds p] :
     ZPoly.modP p (1 : ZPoly) = (1 : FpPoly p) := by
   have hcong : ZPoly.congr (FpPoly.liftToZ (1 : FpPoly p)) (1 : ZPoly) p := by
@@ -214,6 +217,11 @@ theorem modP_one (p : Nat) [ZMod64.Bounds p] :
   exact Eq.trans (ZPoly.modP_eq_of_congr p _ _ (ZPoly.congr_symm _ _ _ hcong))
     (FpPoly.modP_liftToZ (p := p) (1 : FpPoly p))
 
+/-- A `modP p` equality converts to a `ZPoly.congr` against the lift: if
+`modP p z = u` then the lifted-back-to-`ZPoly` representative `FpPoly.liftToZ u`
+agrees with `z` coefficientwise modulo `p`. Used by the correction-proof chain
+when an `FpPoly`-side computation has produced the canonical residue and the
+caller needs to feed it back into the integer-side congruence. -/
 theorem congr_liftToZ_of_modP_eq
     (p : Nat) [ZMod64.Bounds p] (u : FpPoly p) (z : ZPoly)
     (h : ZPoly.modP p z = u) :
@@ -256,6 +264,11 @@ private theorem zmod_add_zero_zero (p : Nat) [ZMod64.Bounds p] :
     simp
   simpa [ZMod64.toNat_eq_val, ZMod64.toNat_zero] using hto
 
+/-- `FpPoly.liftToZ` is additive modulo `p`: the integer lift of a sum is
+coefficientwise congruent to the sum of the integer lifts. Together with
+`liftToZ_mul_congr` this is the bridge used by `modP_add` /
+`modP_lift_mul_left` / `modP_lift_mul_right` to push `modP p` through the
+`+`/`·` structure of the linear Hensel correction. -/
 theorem liftToZ_add_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f + g)) (FpPoly.liftToZ f + FpPoly.liftToZ g) p := by
@@ -288,6 +301,11 @@ private theorem zmod_mul_lift_congr
         simp [Int.ofNat_eq_natCast]]
   exact Int.emod_eq_zero_of_dvd hdiv
 
+/-- Per-term coefficient congruence at the lifted product diagonal: the `i`th
+diagonal contribution to the `n`th coefficient of `f * g` over `FpPoly p`,
+lifted to `Int`, agrees mod `p` with the corresponding `DensePoly.mulCoeffStep`
+contribution over `FpPoly.liftToZ f · FpPoly.liftToZ g`. Gates the diagonal
+fold underlying `liftToZ_mul_congr`. -/
 private theorem liftToZ_mulCoeffTerm_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) (n i : Nat) :
     (Int.ofNat (FpPoly.mulCoeffTerm f g n i).toNat -
@@ -366,6 +384,11 @@ private theorem fold_mulCoeff_outer_eq_diagonal_int
       rw [fold_mulCoeffStep_eq_diagonal_int]
       exact ih (acc + intDiagonalMulCoeffTerm p q n i)
 
+/-- Reifies the executable nested-fold `DensePoly.mulCoeffSum p q n` into the
+flat diagonal-sum `Σ_{i < p.size} intDiagonalMulCoeffTerm p q n i` over `Int`.
+This bridge identity is what lets `liftToZ_mul_congr` reason about the lifted
+product coefficient as an additive `Int` sum, where the per-term congruence
+from `liftToZ_mulCoeffTerm_diagonal_congr` propagates cleanly. -/
 private theorem mulCoeffSum_eq_diagonal_int (p q : ZPoly) (n : Nat) :
     DensePoly.mulCoeffSum p q n =
       (List.range p.size).foldl (fun acc i => acc + intDiagonalMulCoeffTerm p q n i) 0 := by
@@ -479,6 +502,12 @@ private theorem zmod_add_lift_congr_of_terms
       _ = (p : Int) * (k1 + k2) := by grind
   exact Int.emod_eq_zero_of_dvd htotal
 
+/-- Inductive lift transport carrying the per-term diagonal congruence
+(`liftToZ_mulCoeffTerm_diagonal_congr`) across the diagonal fold. The
+hypothesis `hacc` says the seed `acc` lifted to `Int` agrees mod `p` with the
+integer-side seed `accZ`; the conclusion says that property is preserved after
+adding the next diagonal contribution on both sides. Driver of the inductive
+step in `liftToZ_mul_congr`. -/
 private theorem fold_liftToZ_mulCoeffTerm_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) (n : Nat) (xs : List Nat)
     (acc : ZMod64 p) (accZ : Int)
@@ -500,6 +529,12 @@ private theorem fold_liftToZ_mulCoeffTerm_congr
         (intDiagonalMulCoeffTerm (FpPoly.liftToZ f) (FpPoly.liftToZ g) n i)
         hacc (liftToZ_mulCoeffTerm_diagonal_congr p f g n i)
 
+/-- `FpPoly.liftToZ` is multiplicative modulo `p`: the integer lift of a
+product is coefficientwise congruent to the product of the integer lifts.
+Multiplicative companion of `liftToZ_add_congr`; together they bridge the
+`FpPoly`-side ring operations into `ZPoly.congr` form, which the `modP` push
+lemmas (`modP_add`, `modP_lift_mul_left`, `modP_lift_mul_right`) consume to
+expose the linear Hensel correction's mod-`p` structure. -/
 theorem liftToZ_mul_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f * g)) (FpPoly.liftToZ f * FpPoly.liftToZ g) p := by
@@ -513,6 +548,10 @@ theorem liftToZ_mul_congr
     rw [ZMod64.toNat_zero]
     simp)
 
+/-- `ZPoly.modP p` distributes over addition: the canonical mod-`p` residue
+of a sum is the sum of residues. Standard ring-homomorphism rewrite for
+`modP p` used by the linear Hensel step proof to split `modP p (g·h + ...)`
+into manageable pieces. -/
 theorem modP_add
     (p : Nat) [ZMod64.Bounds p] (f g : ZPoly) :
     ZPoly.modP p (f + g) = ZPoly.modP p f + ZPoly.modP p g := by
@@ -539,6 +578,11 @@ theorem modP_add
       (ZPoly.congr_symm _ _ _ hsum))
     (FpPoly.modP_liftToZ (p := p) (ZPoly.modP p f + ZPoly.modP p g))
 
+/-- `modP p` reduces a `liftToZ`-on-the-left product to the `FpPoly`-side
+factor times the `modP` of the integer side: `modP p (liftToZ r · h) =
+r · modP p h`. Companion of `modP_lift_mul_right`; consumed by the linear
+Hensel step's correctness chain to push `modP p` past the
+`s * eMod`-shaped half of the correction product. -/
 theorem modP_lift_mul_left
     (p : Nat) [ZMod64.Bounds p] (r : FpPoly p) (h : ZPoly) :
     ZPoly.modP p (FpPoly.liftToZ r * h) = r * ZPoly.modP p h := by
@@ -559,6 +603,11 @@ theorem modP_lift_mul_left
       (ZPoly.congr_symm _ _ _ hprod))
     (FpPoly.modP_liftToZ (p := p) (r * hMod))
 
+/-- `modP p` reduces a `liftToZ`-on-the-right product to the `modP` of the
+integer side times the `FpPoly`-side factor: `modP p (g · liftToZ hCorrection)
+= modP p g · hCorrection`. Companion of `modP_lift_mul_left`; consumed by the
+linear Hensel step's correctness chain to push `modP p` past the
+`q * hMod`-shaped half of the correction product. -/
 theorem modP_lift_mul_right
     (p : Nat) [ZMod64.Bounds p] (g : ZPoly) (hCorrection : FpPoly p) :
     ZPoly.modP p (g * FpPoly.liftToZ hCorrection) =
@@ -583,6 +632,10 @@ theorem modP_lift_mul_right
       (FpPoly.liftToZ (gMod * hCorrection)) (ZPoly.congr_symm _ _ _ hprod))
     (FpPoly.modP_liftToZ (p := p) (gMod * hCorrection))
 
+/-- Combined `modP_add` + `modP_lift_mul_left` + `modP_lift_mul_right` rewrite
+in the exact `liftToZ r · h + g · liftToZ hCorrection` shape produced by the
+linear Hensel correction step. Single-rewrite entry point consumed by the
+linear-Hensel correctness chain in place of three separate `modP` pushes. -/
 theorem modP_add_lift_mul
     (p : Nat) [ZMod64.Bounds p] (g h : ZPoly) (r hCorrection : FpPoly p) :
     ZPoly.modP p (FpPoly.liftToZ r * h + g * FpPoly.liftToZ hCorrection) =

--- a/progress/20260517T201822Z_3faeea1e.md
+++ b/progress/20260517T201822Z_3faeea1e.md
@@ -1,0 +1,61 @@
+# 2026-05-17T20:18:22Z — Phase 6 polish HexHensel/Linear.lean surface 2
+
+Session UUID: `3faeea1e-1b70-42c7-9152-69344349db84`
+Branch: `agent/3faeea1e`
+Issue: #4800
+
+## Accomplished
+
+- Added caller-facing docstrings to the eight public theorems in the
+  `modP` / `liftToZ` congruence cluster of `HexHensel/Linear.lean`
+  (`modP_one`, `congr_liftToZ_of_modP_eq`, `liftToZ_add_congr`,
+  `liftToZ_mul_congr`, `modP_add`, `modP_lift_mul_left`,
+  `modP_lift_mul_right`, `modP_add_lift_mul`).
+- Added docstrings to three non-obvious private helpers gating the
+  diagonal-fold argument under `liftToZ_mul_congr`:
+  `liftToZ_mulCoeffTerm_congr`, `mulCoeffSum_eq_diagonal_int`,
+  `fold_liftToZ_mulCoeffTerm_congr`. Mechanical helpers
+  (`zmod_add_lift_congr`, `zmod_add_zero_zero`, `zmod_mul_lift_congr`,
+  `intDiagonalMulCoeffTerm_eq_zero_of_size_le`,
+  `fold_diagonal_extend_int`, etc.) left undocumented because their
+  names already telegraph the fact, per the design-principles "routine
+  private plumbing" carve-out.
+- Tagged `modP_one` and `modP_add` with `@[simp]`. Both are
+  unconditional canonical-form rewrites pushing `modP p` through the
+  ring operations.
+- Did **not** tag `modP_lift_mul_left` / `modP_lift_mul_right` /
+  `modP_add_lift_mul`. The LHS contains `FpPoly.liftToZ` on one side
+  and is not a canonical normal form; no callsite has the LHS shape
+  surviving an intervening `simp`/`simpa` call (audit ran
+  `simpa.*modP_lift_mul`, `simp.*\[.*modP_lift_mul`, etc. — zero
+  matches). Per the issue's conservative-default guidance, left as
+  explicit `rw` targets.
+- Did **not** tag the three `ZPoly.congr`-typed lemmas
+  (`liftToZ_add_congr`, `liftToZ_mul_congr`,
+  `congr_liftToZ_of_modP_eq`); they are not equations.
+- `lake build` (full project, 244 jobs) clean.
+- `python3 scripts/check_dag.py` clean.
+- `git diff --check` clean.
+- `rg "sorry|axiom|native_decide|TODO|FIXME" HexHensel/Linear.lean`:
+  zero matches.
+
+## Current frontier
+
+Surface 2 polish landed. The remaining `HexHensel/Linear.lean`
+surfaces, per #4800's decomposition note:
+
+- Surface 3 (correction-proof chain, lines 575-1117) — mostly
+  private; to be evaluated for whether it warrants a dedicated polish
+  issue.
+- Surface 4 (driver + monic-preservation + final spec, lines
+  1119-1661) — likely needs further per-section decomposition.
+
+## Next step
+
+Planner triage to decide whether surface 3 needs its own slice or
+whether the helpers are sufficiently mechanical to skip. Surface 4
+needs to be sub-decomposed before any worker claims it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4800

Session: `3faeea1e-1b70-42c7-9152-69344349db84`

a6ab0eff progress: HexHensel/Linear.lean surface 2 polish for #4800
063e3031 doc: tag modP_one and modP_add @[simp] in Linear.lean surface 2
5482e174 doc: add caller-facing docstrings to Linear.lean modP/liftToZ surface

🤖 Prepared with Claude Code