### PR TITLE
HO-1 substrate (#4785 precursor): SquareFreeRat ⇒ no linear factor squared divides core

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -8878,6 +8878,87 @@ private theorem quadraticIntegerRootFactors?_product
           contradiction
   · simp [hdeg] at hquad
 
+private theorem toRatPoly_linearFactorForRoot_size (r : Int) :
+    (ZPoly.toRatPoly (linearFactorForRoot r)).size = 2 := by
+  rw [ZPoly.size_toRatPoly]
+  exact linearFactorForRoot_size_eq_two r
+
+private theorem toRatPoly_linearFactorForRoot_ne_zero (r : Int) :
+    ZPoly.toRatPoly (linearFactorForRoot r) ≠ 0 :=
+  ZPoly.toRatPoly_ne_zero_of_ne_zero (linearFactorForRoot r)
+    (linearFactorForRoot_ne_zero r)
+
+private theorem toRatPoly_dvd {p q : ZPoly} (h : p ∣ q) :
+    ZPoly.toRatPoly p ∣ ZPoly.toRatPoly q := by
+  rcases h with ⟨k, hk⟩
+  exact ⟨ZPoly.toRatPoly k, by rw [hk, ZPoly.toRatPoly_mul]⟩
+
+/-- A polynomial that is square-free over `Rat` (in the `Hex.ZPoly.SquareFreeRat`
+sense) is not divisible by `(X - r)²` for any integer root `r`.
+
+This is consumed by the pairwise non-association proof for
+`quadraticIntegerRootFactors? core` (#4785, downstream of the
+`reassemblyExpansionComplete` discharger #4747): if the residual final
+factor were associated to an extracted linear factor `linearFactorForRoot r`,
+then `linearFactorForRoot r * linearFactorForRoot r` would divide `core`,
+which this lemma rules out under squarefreeness. The `(X - r)` shape of
+`linearFactorForRoot r` lets us avoid a generic
+`p² ∣ f → ¬ SquareFreeRat f` lemma: we work directly with the rational
+derivative product rule, the divisor argument is reduced to
+`(X - r).size = 2 ≤ gcd.size` after lifting to `DensePoly Rat`. -/
+private theorem linearFactor_squared_not_dvd_of_squareFreeRat
+    {core : ZPoly} (hne : core ≠ 0) (hsq : Hex.ZPoly.SquareFreeRat core)
+    {r : Int} :
+    ¬ (linearFactorForRoot r * linearFactorForRoot r) ∣ core := by
+  intro hdvd
+  rcases hdvd with ⟨g, hg⟩
+  -- Lift the witness equation `core = L * L * g` to `DensePoly Rat`.
+  let L' := ZPoly.toRatPoly (linearFactorForRoot r)
+  let g' := ZPoly.toRatPoly g
+  let coreRat := ZPoly.toRatPoly core
+  have hcoreRat_eq : coreRat = L' * (L' * g') := by
+    show ZPoly.toRatPoly core = _
+    rw [hg, ZPoly.toRatPoly_mul, ZPoly.toRatPoly_mul, DensePoly.mul_assoc_poly]
+  -- Divisibilities of `coreRat` and `derivative coreRat` by `L'`.
+  have hL'_dvd_L'g' : L' ∣ L' * g' := ⟨g', rfl⟩
+  have hL'_dvd_coreRat : L' ∣ coreRat := by
+    rw [hcoreRat_eq]; exact ⟨L' * g', rfl⟩
+  have hL'_dvd_deriv : L' ∣ DensePoly.derivative coreRat := by
+    rw [hcoreRat_eq, DensePoly.derivative_mul L' (L' * g')]
+    apply DensePoly.dvd_add_poly
+    · exact DensePoly.dvd_mul_left_poly (DensePoly.derivative L') hL'_dvd_L'g'
+    · exact ⟨DensePoly.derivative (L' * g'), rfl⟩
+  -- Combine into divisibility of the gcd.
+  have hL'_dvd_gcd : L' ∣ DensePoly.gcd coreRat (DensePoly.derivative coreRat) :=
+    DensePoly.dvd_gcd L' _ _ hL'_dvd_coreRat hL'_dvd_deriv
+  -- Size argument: `L'.size = 2 ≤ gcd.size`, but squarefreeness says `gcd.size ≤ 1`.
+  have hL'_size : L'.size = 2 := toRatPoly_linearFactorForRoot_size r
+  have hL'_size_ne : L'.size ≠ 0 := by omega
+  have hcoreRat_ne : coreRat ≠ 0 :=
+    ZPoly.toRatPoly_ne_zero_of_ne_zero core hne
+  have hgcd_dvd_coreRat :=
+    DensePoly.gcd_dvd_left coreRat (DensePoly.derivative coreRat)
+  have hgcd_ne :
+      DensePoly.gcd coreRat (DensePoly.derivative coreRat) ≠ 0 := by
+    intro h
+    apply hcoreRat_ne
+    rcases hgcd_dvd_coreRat with ⟨k, hk⟩
+    rw [h, DensePoly.zero_mul] at hk
+    exact hk
+  have hgcd_size_ne :
+      (DensePoly.gcd coreRat (DensePoly.derivative coreRat)).size ≠ 0 := by
+    intro hsize
+    apply hgcd_ne
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega)]
+    exact (DensePoly.coeff_zero n).symm
+  have hsize_le :=
+    ZPoly.rat_size_le_of_dvd_nonzero hL'_size_ne hgcd_size_ne hL'_dvd_gcd
+  have hsq' :
+      (DensePoly.gcd coreRat (DensePoly.derivative coreRat)).size ≤ 1 := hsq
+  omega
+
 private theorem factorSlowFactorsWithBound_polyProduct
     (f : ZPoly) (B : Nat) :
     DensePoly.C (signedContentScalar f) *

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -108,7 +108,7 @@ theorem toRatPoly_scale_int (c : Int) (f : ZPoly) :
   rw [coeff_toRatPoly]
   simp
 
-private theorem size_toRatPoly (f : ZPoly) :
+theorem size_toRatPoly (f : ZPoly) :
     (toRatPoly f).size = f.size := by
   apply Nat.le_antisymm
   · by_cases hle : (toRatPoly f).size ≤ f.size
@@ -142,7 +142,7 @@ private theorem size_toRatPoly (f : ZPoly) :
         exact hrat_zero
       exact Rat.intCast_eq_zero_iff.mp hcast_zero
 
-private theorem toRatPoly_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
+theorem toRatPoly_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
     toRatPoly f ≠ 0 := by
   intro hrat
   apply hf
@@ -2132,7 +2132,7 @@ private theorem rat_size_le_one_of_mul_dvd_self
       have hcontr : r.size ≤ (d * r).size - 1 + (k.size - 1) := by omega
       omega
 
-private theorem rat_size_le_of_dvd_nonzero
+theorem rat_size_le_of_dvd_nonzero
     {d r : DensePoly Rat} (hd : d.size ≠ 0) (hr : r.size ≠ 0) :
     d ∣ r → d.size ≤ r.size := by
   intro hdiv

--- a/progress/20260517T202621Z_dcc80d51.md
+++ b/progress/20260517T202621Z_dcc80d51.md
@@ -1,0 +1,71 @@
+# Session dcc80d51 — #4791 SquareFreeRat ⇒ no linear-squared
+
+## Accomplished
+
+Claimed #4791 (HO-1 substrate: `SquareFreeRat ⇒ no linear factor squared
+divides core`) and landed the deliverable.
+
+Added in `HexBerlekampZassenhaus/Basic.lean` (immediately after
+`quadraticIntegerRootFactors?_product` ~line 8840):
+
+* `toRatPoly_linearFactorForRoot_size` (private): the rational-side size
+  of `linearFactorForRoot r` is `2`, via `size_toRatPoly` and the
+  existing `linearFactorForRoot_size_eq_two`.
+* `toRatPoly_linearFactorForRoot_ne_zero` (private): rational-side
+  nonzeroness via `toRatPoly_ne_zero_of_ne_zero` and the existing
+  `linearFactorForRoot_ne_zero`.
+* `toRatPoly_dvd` (private): divisibility transports across
+  `ZPoly.toRatPoly` via `ZPoly.toRatPoly_mul`.
+* `linearFactor_squared_not_dvd_of_squareFreeRat` (private, main
+  deliverable): under `core ≠ 0` and `Hex.ZPoly.SquareFreeRat core`,
+  `¬ (linearFactorForRoot r * linearFactorForRoot r) ∣ core`. Proof
+  lifts the witness `core = L * L * g` to `DensePoly Rat`, derives
+  `L' ∣ coreRat` and `L' ∣ derivative coreRat` (the latter via
+  `DensePoly.derivative_mul` plus `dvd_mul_left_poly` / `dvd_add_poly`),
+  combines through `DensePoly.dvd_gcd`, and closes via
+  `ZPoly.rat_size_le_of_dvd_nonzero` against `L'.size = 2` and the
+  `gcd.size ≤ 1` content of `SquareFreeRat`.
+
+The added `(hne : core ≠ 0)` hypothesis is required: `SquareFreeRat 0`
+is vacuously `0 ≤ 1`, and `(L * L) ∣ 0` is trivially true. The
+downstream `quadraticIntegerRootFactors?` consumer always has
+`core.degree?.getD 0 = 2`, which forces `core ≠ 0`, so this matches
+the IntReductionMod.lean:800 convention of carrying `(hf : f ≠ 0)`
+alongside `(hsf : Hex.ZPoly.SquareFreeRat f)`.
+
+Support changes in `HexPolyZ/Basic.lean` (de-private only, no
+statement changes):
+
+* `size_toRatPoly` (line 111).
+* `toRatPoly_ne_zero_of_ne_zero` (line 145).
+* `rat_size_le_of_dvd_nonzero` (line 2135).
+
+These three are now part of the `Hex.ZPoly` public surface; all existing
+call sites within `HexPolyZ/Basic.lean` continue to work unchanged.
+
+## Verification
+
+* `lake build HexPolyZ.Basic` — passes.
+* `lake build HexBerlekampZassenhaus.Basic` — passes.
+* `lake build HexBerlekampZassenhaus` — passes (incl. Conformance).
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* `rg -n "sorry|axiom|native_decide|TODO|FIXME"` on additions: 0 new
+  entries vs `origin/main`.
+
+## Current frontier
+
+`linearFactor_squared_not_dvd_of_squareFreeRat` is now available for
+#4785 (pairwise non-association of `quadraticIntegerRootFactors?`
+output), which in turn feeds the `reassemblyExpansionComplete` quadratic
+discharger #4747 via `irreducible_not_dvd_of_not_associated` (#4603).
+
+## Next step
+
+A follow-up worker on #4785 can apply this substrate together with the
+splitter distinct-roots invariant (#4795, landed) to assemble the
+pairwise non-association proof for `quadraticIntegerRootFactors? core`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4791

Session: `dcc80d51-3c91-49cb-90a8-c36c03cd1d76`

ec7c71f0 feat: SquareFreeRat ⇒ no linear factor squared divides core (#4791)

🤖 Prepared with Claude Code