### PR TITLE
Partial #4647: add primitive target helpers for scaled recombination coverage

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7641,6 +7641,60 @@ private theorem zpoly_primitive_of_toPolynomial_isPrimitive_basic
   · rw [hneg] at hcontent_nonneg
     omega
 
+private theorem zpoly_ne_zero_of_pos_lc {f : Hex.ZPoly}
+    (hpos : 0 < Hex.DensePoly.leadingCoeff f) : f ≠ 0 := by
+  intro hf
+  rw [hf] at hpos
+  have hzero_lc : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := rfl
+  rw [hzero_lc] at hpos
+  omega
+
+private theorem zpoly_eq_one_of_toPolynomial_isUnit_of_pos_lc
+    {f : Hex.ZPoly}
+    (hpos : 0 < Hex.DensePoly.leadingCoeff f)
+    (hunit : IsUnit (HexPolyZMathlib.toPolynomial f)) :
+    f = 1 := by
+  have hunit_z : Hex.ZPoly.IsUnit f :=
+    (HexPolyZMathlib.isUnit_iff_toPolynomial_isUnit f).mpr hunit
+  rcases hunit_z with hunit_one | hunit_neg
+  · rw [hunit_one]
+    rfl
+  · exfalso
+    rw [hunit_neg] at hpos
+    change 0 < Hex.DensePoly.leadingCoeff (Hex.DensePoly.C (-1 : Int)) at hpos
+    simp [Hex.DensePoly.leadingCoeff, Hex.DensePoly.coeffs_C_of_ne_zero] at hpos
+
+private theorem zpoly_primitive_of_dvd_primitive_basic
+    {factor target : Hex.ZPoly}
+    (htarget_primitive : Hex.ZPoly.Primitive target)
+    (hfactor_dvd_target : factor ∣ target) :
+    Hex.ZPoly.Primitive factor := by
+  apply zpoly_primitive_of_toPolynomial_isPrimitive_basic
+  exact isPrimitive_of_dvd
+    (toPolynomial_isPrimitive_of_zpoly_primitive_basic htarget_primitive)
+    (HexPolyMathlib.toPolynomial_dvd hfactor_dvd_target)
+
+private theorem zpoly_left_pos_lc_of_mul_eq_of_pos_lc
+    {left right target : Hex.ZPoly}
+    (hmul : left * right = target)
+    (hright_pos : 0 < Hex.DensePoly.leadingCoeff right)
+    (htarget_pos : 0 < Hex.DensePoly.leadingCoeff target) :
+    0 < Hex.DensePoly.leadingCoeff left := by
+  have hright_ne : right ≠ 0 := zpoly_ne_zero_of_pos_lc hright_pos
+  have htarget_ne : target ≠ 0 := zpoly_ne_zero_of_pos_lc htarget_pos
+  have hleft_ne : left ≠ 0 := by
+    intro hleft
+    apply htarget_ne
+    rw [← hmul, hleft, Hex.DensePoly.zero_mul]
+  have hlc :=
+    Hex.ZPoly.leadingCoeff_mul_of_nonzero left right hleft_ne hright_ne
+  have hprod_pos :
+      0 < Hex.DensePoly.leadingCoeff left *
+        Hex.DensePoly.leadingCoeff right := by
+    rw [← hlc, hmul]
+    exact htarget_pos
+  nlinarith
+
 private theorem centeredModNat_eq_of_pos_natAbs_le
     {z : Int} {m B : Nat}
     (hz_pos : 0 < z) (hbound : z.natAbs ≤ B) (hsep : 2 * B < m) :

--- a/progress/20260517T204008Z_d9dcf430.md
+++ b/progress/20260517T204008Z_d9dcf430.md
@@ -1,0 +1,46 @@
+# Primitive target invariant substrate for #4647
+
+## Accomplished
+
+In `HexBerlekampZassenhausMathlib/Basic.lean`, added four private helper
+lemmas needed by the scaled recursive recombination coverage induction:
+
+* `zpoly_ne_zero_of_pos_lc`
+* `zpoly_eq_one_of_toPolynomial_isUnit_of_pos_lc`
+* `zpoly_primitive_of_dvd_primitive_basic`
+* `zpoly_left_pos_lc_of_mul_eq_of_pos_lc`
+
+These package the target-state facts that replace monicity in the old
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`
+proof: positive leading coefficient gives nonzero/unit collapse, primitivity
+descends along divisibility, and positive leading coefficient descends to the
+left cofactor of an exact product.
+
+Verification run:
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — passes, with only
+  pre-existing warnings/sorries elsewhere in the project.
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* Additions contain no new `sorry`, `axiom`, `native_decide`, `TODO`, or
+  `FIXME`.
+
+## Current frontier
+
+Issue #4647 still needs the scaled recursive coverage theorem itself. The
+remaining proof should copy the structure of
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`,
+but use `Hex.scaledRecombinationSearchModAux`, the scaled prefix-none lemma,
+`scaledRecombinationCandidate_eq_factor_of_recovery`, and the new primitive /
+positive-leading target helpers above.
+
+## Next step
+
+State and prove a private scaled auxiliary with recursive target hypotheses
+`Hex.ZPoly.Primitive target` and `0 < Hex.DensePoly.leadingCoeff target`, then
+expose the fixed-factor wrapper requested by #4647.
+
+## Blockers
+
+None. This session stopped at a verified substrate layer because the remaining
+fuel-based induction is large enough to warrant a focused follow-up.


### PR DESCRIPTION
Partial progress on #4647

Session: `d9dcf430-d3ba-4b73-ac34-054cdf961264`

9187c007 Add primitive target helpers for scaled recombination coverage

🤖 Prepared with Claude Code