### PR TITLE
BZ Mathlib-free: preserve ZPoly.Irreducible under normalizeFactorSign

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -6633,6 +6633,100 @@ private theorem irreducible_of_size_two_primitive
 
 end ZPoly
 
+/-- `Hex.normalizeFactorSign` preserves `Hex.ZPoly.Irreducible`: the
+sign-normalised polynomial equals either the original or its `-1` scaling,
+and `-1` is a `ZPoly` unit, so the no-proper-factorization predicate
+transfers. Mathlib-free counterpart of the Mathlib-side
+`zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible`
+(`HexBerlekampZassenhausMathlib/Basic.lean:12543`).  Consumed by the
+Mathlib-free `factor_factors_irreducible` assembly (#4825). -/
+theorem zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
+    {f : ZPoly} (hirr : ZPoly.Irreducible f) :
+    ZPoly.Irreducible (normalizeFactorSign f) := by
+  unfold normalizeFactorSign
+  by_cases hlc : DensePoly.leadingCoeff f < 0
+  · rw [if_pos hlc]
+    -- Sign-flipped branch: `DensePoly.scale (-1) f`.
+    have hmulzero : (-1 : Int) * (0 : Int) = 0 := by decide
+    -- `scale (-1)` is an involution on `ZPoly`.
+    have hinvol : ∀ g : ZPoly,
+        DensePoly.scale (-1 : Int) (DensePoly.scale (-1 : Int) g) = g := by
+      intro g
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_scale (R := Int) (-1) _ n hmulzero,
+          DensePoly.coeff_scale (R := Int) (-1) g n hmulzero]
+      omega
+    have hscale_C_one : DensePoly.scale (-1 : Int) (DensePoly.C (1 : Int)) =
+        DensePoly.C (-1 : Int) := by
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_scale (R := Int) (-1) _ n hmulzero,
+          DensePoly.coeff_C, DensePoly.coeff_C]
+      by_cases hn : n = 0
+      · simp [hn]
+      · rw [if_neg hn, if_neg hn]; omega
+    have hscale_C_neg_one : DensePoly.scale (-1 : Int) (DensePoly.C (-1 : Int)) =
+        DensePoly.C (1 : Int) := by
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_scale (R := Int) (-1) _ n hmulzero,
+          DensePoly.coeff_C, DensePoly.coeff_C]
+      by_cases hn : n = 0
+      · simp [hn]
+      · rw [if_neg hn, if_neg hn]; omega
+    have hscale_mul_left : ∀ a b : ZPoly,
+        DensePoly.scale (-1 : Int) (a * b) = DensePoly.scale (-1 : Int) a * b := by
+      intro a b
+      rw [← ZPoly.C_mul_eq_scale, ← ZPoly.C_mul_eq_scale,
+          DensePoly.mul_assoc_poly (S := Int)]
+    refine
+      { not_zero := ?_
+        not_unit := ?_
+        no_factors := ?_ }
+    · -- `scale (-1) f ≠ 0`.
+      intro h
+      apply hirr.not_zero
+      have hcong := congrArg (DensePoly.scale (-1 : Int)) h
+      rw [hinvol, DensePoly.scale_neg_one_zero] at hcong
+      exact hcong
+    · -- `scale (-1) f` is not a unit.
+      intro hunit
+      apply hirr.not_unit
+      rcases hunit with h1 | hnegone
+      · -- `scale (-1) f = C 1` ⟹ `f = C (-1)`, which is a unit.
+        right
+        have hcong := congrArg (DensePoly.scale (-1 : Int)) h1
+        rw [hinvol, hscale_C_one] at hcong
+        exact hcong
+      · -- `scale (-1) f = C (-1)` ⟹ `f = C 1`, which is a unit.
+        left
+        have hcong := congrArg (DensePoly.scale (-1 : Int)) hnegone
+        rw [hinvol, hscale_C_neg_one] at hcong
+        exact hcong
+    · -- Factor preservation.
+      intro a b hab
+      have hf_eq : f = DensePoly.scale (-1 : Int) a * b := by
+        have hcong := congrArg (DensePoly.scale (-1 : Int)) hab
+        rw [hinvol, hscale_mul_left] at hcong
+        exact hcong
+      rcases hirr.no_factors _ _ hf_eq with hsa | hb
+      · left
+        rcases hsa with h1 | hnegone
+        · -- `scale (-1) a = C 1` ⟹ `a = C (-1)`, a unit.
+          right
+          have hcong := congrArg (DensePoly.scale (-1 : Int)) h1
+          rw [hinvol, hscale_C_one] at hcong
+          exact hcong
+        · -- `scale (-1) a = C (-1)` ⟹ `a = C 1`, a unit.
+          left
+          have hcong := congrArg (DensePoly.scale (-1 : Int)) hnegone
+          rw [hinvol, hscale_C_neg_one] at hcong
+          exact hcong
+      · exact Or.inr hb
+  · rw [if_neg hlc]
+    exact hirr
+
 /-- Every factor emitted by the extracted `X`-power normalization array is
 irreducible. -/
 theorem xPowerFactorArray_irreducible

--- a/progress/20260517T212845Z_fb7ade11.md
+++ b/progress/20260517T212845Z_fb7ade11.md
@@ -1,0 +1,72 @@
+# 2026-05-17 21:28 UTC — work session (fb7ade11)
+
+## Accomplished
+
+- Skipped #4821 (`BZMathlib: discharge executable Hensel subset analytic
+  obligation`) with a detailed technical blocker comment: the residual is the
+  analytic Hensel correspondence, gated on #2567 (HO-4 BHKS Theorem 5.2) or a
+  classical square-free Hensel transport ported to `Hex.ZPoly`. Existing
+  `modPSubsetPartitionHypotheses_of_choosePrimeData` cannot bridge the
+  `choosePrimeData? = none` fallback, and the forward-transport prerequisites
+  of `henselLiftData_represents_lifted_of_modP` (`hcore_monic`,
+  `hfactor_monic`, `hprime_invariant`) are not yet discharged at the
+  `choosePrimeData` boundary for general core/factor. The "no net increase in
+  `sorry` count" deliverable rules out splitting into two sub-`sorry`s.
+
+- Skipped #4825 (`BZ Mathlib-free: prove ZPoly.Irreducible for every
+  factor.factors entry`) with a multi-precursor blocker comment identifying
+  five missing pieces: (1) #4824 constant-`C` irreducibility (open);
+  (2) Mathlib-free small-mod singleton irreducibility witness (not built);
+  (3) Mathlib-free fast-core success irreducibility witness (gated on
+  #2567); (4) Mathlib-free slow-exhaustive irreducibility witness (gated on
+  the same analytic content as #4821/#4822); (5) Mathlib-free
+  `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible` (only the
+  Mathlib-routed version exists in `HexBerlekampZassenhausMathlib/Basic.lean`).
+  The planner created #4826 and #4827 in response to this comment.
+
+- Skipped directive #2637 (`HexBerlekampZassenhaus: implement Factorization
+  record API…`) and #2564 (`HO-1: BZ recombination implements wrong
+  lattice…`) with status comments showing the deliverables are essentially
+  complete in current `main`: the `Factorization` record, signed-scalar
+  normalisation, multiplicity collection, factor/factorWithBound/factorSlow/
+  factorFast surfaces, `Hex.ZPoly.IsUnit`/`Hex.ZPoly.Irreducible` class,
+  `isIrreducible`, the bridge `Irreducible_iff_polynomialIrreducible`, and
+  the conformance fixtures are all in place. The residual is exactly the
+  four `sorry`s in `HexBerlekampZassenhaus/Basic.lean:6377` (#4818),
+  `HexBerlekampZassenhausMathlib/Basic.lean:242` (#4819), `:12916` (#4821),
+  `:13046` (#4822), all gated on #2567 or its precursor sub-issues.
+
+- Claimed #4827 (`BZ Mathlib-free: preserve ZPoly.Irreducible under
+  normalizeFactorSign`) and landed
+  `Hex.zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible` in
+  `HexBerlekampZassenhaus/Basic.lean`, right after the `end ZPoly` for the
+  class definition (line ~6643). The proof handles two cases keyed on the
+  leading-coefficient sign:
+
+  - `lc f ≥ 0`: `normalizeFactorSign f = f`, conclusion is `hirr`.
+  - `lc f < 0`: `normalizeFactorSign f = DensePoly.scale (-1) f`. Three
+    local helpers package the involution `scale (-1) ∘ scale (-1) = id`,
+    the two-step computations `scale (-1) (C 1) = C (-1)` and
+    `scale (-1) (C (-1)) = C 1`, and the factorisation-respecting identity
+    `scale (-1) (a * b) = scale (-1) a * b` (routed through
+    `ZPoly.C_mul_eq_scale` and `DensePoly.mul_assoc_poly`). The
+    `not_zero` / `not_unit` / `no_factors` fields then transfer by
+    applying `scale (-1)` to the hypothetical contradicting equation
+    and rewriting via the involution.
+
+## Current frontier
+
+- `HexBerlekampZassenhaus.Basic` builds cleanly. Only pre-existing `sorry`
+  on line 6377 (`isIrreducible_iff`, #4818) remains in the file. No new
+  `axiom`, `native_decide`, or `TODO`/`FIXME`. `python3 scripts/check_dag.py`
+  passes.
+
+## Next step
+
+- Push branch and open PR closing #4827.
+
+## Blockers
+
+- None for #4827. The four BZ `sorry`s remain blocked on #2567 (HO-4) and
+  its precursor chain (#4819, #4821, #4822 directly; #4818 indirectly via
+  the Mathlib-free per-branch irreducibility witnesses #4825/#4826/#4827).


### PR DESCRIPTION
Closes #4827

Session: `fb7ade11-8526-4127-9c60-85d8b3e85be6`

f6af7234 feat: preserve ZPoly.Irreducible under normalizeFactorSign

🤖 Prepared with Claude Code