### PR TITLE
Berlekamp soundness: relax hsquareFree precondition to non-normalized form

### DIFF
--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -810,7 +810,8 @@ private theorem isUnitPolynomial_gcd_quotient_of_squareFree_divisor
             _ = g * (g * (e * a)) := by
                 exact congrArg (g * ·) (DensePoly.mul_assoc_poly g e a)
             _ = (g * g) * (e * a) := (DensePoly.mul_assoc_poly g g (e * a)).symm
-  exact isUnitPolynomial_of_squareFree_of_squared_dvd hsf
+  exact isUnitPolynomial_of_squareFree_of_squared_dvd
+    (squareFree_common_of_gcd_eq_one hsf)
     (dvd_trans_poly hg2_dvd_r hrf)
 
 private theorem distinctDegreePowerLoop_bucket_dvd_diff_of_squareFree_divisor

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -2375,9 +2375,26 @@ private theorem dvd_derivative_of_squared_dvd
     _ = g * (k * h + g * DensePoly.derivative h) :=
         (DensePoly.mul_add_right_poly g (k * h) (g * DensePoly.derivative h)).symm
 
+/-- Adapter from the strict executable-gcd form of square-freeness
+(`DensePoly.gcd r r' = 1`) to the relaxed common-divisor form
+(`∀ d, d ∣ r → d ∣ r' → isUnitPolynomial d`).  The relaxed form is the
+shape the soundness chain culminating in `berlekampFactor_singleton_irreducible`
+consumes; the strict form is what existing in-tree callers carry, so this
+adapter lets them feed the chain unchanged. -/
+theorem squareFree_common_of_gcd_eq_one
+    {r : FpPoly p}
+    (hsf : DensePoly.gcd r (DensePoly.derivative r) = 1) :
+    ∀ d, d ∣ r → d ∣ DensePoly.derivative r → isUnitPolynomial d = true := by
+  intro d hda hdb
+  have hd_dvd_gcd : d ∣ DensePoly.gcd r (DensePoly.derivative r) :=
+    DensePoly.dvd_gcd d r (DensePoly.derivative r) hda hdb
+  rw [hsf] at hd_dvd_gcd
+  exact isUnitPolynomial_of_dvd_isUnitPolynomial hd_dvd_gcd isUnitPolynomial_one_FpPoly
+
+omit [ZMod64.PrimeModulus p] in
 theorem isUnitPolynomial_of_squareFree_of_squared_dvd
     {r g : FpPoly p}
-    (hsf : DensePoly.gcd r (DensePoly.derivative r) = 1)
+    (hsf : ∀ d, d ∣ r → d ∣ DensePoly.derivative r → isUnitPolynomial d = true)
     (hgg : g * g ∣ r) :
     isUnitPolynomial g = true := by
   have hgr : g ∣ r := by
@@ -2386,10 +2403,7 @@ theorem isUnitPolynomial_of_squareFree_of_squared_dvd
     rw [hb]
     exact DensePoly.mul_assoc_poly g g b
   have hgr' : g ∣ DensePoly.derivative r := dvd_derivative_of_squared_dvd hgg
-  have hg_dvd_one : g ∣ (1 : FpPoly p) := by
-    rw [← hsf]
-    exact DensePoly.dvd_gcd g r (DensePoly.derivative r) hgr hgr'
-  exact isUnitPolynomial_of_dvd_isUnitPolynomial hg_dvd_one isUnitPolynomial_one_FpPoly
+  exact hsf g hgr hgr'
 
 /-- Helper: `c ∣ r → r = c * (r / c)` for FpPoly. -/
 private theorem fp_eq_mul_div_of_dvd
@@ -2430,7 +2444,8 @@ private theorem fp_swap_left_mul (c g a : FpPoly p) :
 
 theorem common_dvd_one_of_squareFree_mul
     {a b d : FpPoly p}
-    (hsquareFree : DensePoly.gcd (a * b) (DensePoly.derivative (a * b)) = 1)
+    (hsquareFree : ∀ e, e ∣ (a * b) → e ∣ DensePoly.derivative (a * b) →
+      isUnitPolynomial e = true)
     (hda : d ∣ a) (hdb : d ∣ b) :
     d ∣ (1 : FpPoly p) := by
   have hdd_dvd_ab : d * d ∣ a * b := by
@@ -2454,7 +2469,8 @@ theorem exists_reduced_crtZeroOne_kernelWitness_of_squareFree_split
     (a b : FpPoly p)
     (ha : DensePoly.Monic a) (hb : DensePoly.Monic b)
     (ha_pos : 0 < a.degree?.getD 0) (hb_pos : 0 < b.degree?.getD 0)
-    (hsquareFree : DensePoly.gcd (a * b) (DensePoly.derivative (a * b)) = 1)
+    (hsquareFree : ∀ d, d ∣ (a * b) → d ∣ DensePoly.derivative (a * b) →
+      isUnitPolynomial d = true)
     (hgcd_monic : DensePoly.Monic (DensePoly.gcd a b)) :
     ∃ h : FpPoly p,
       h = crtZeroOneXGCDCandidate a b % (a * b) ∧
@@ -2517,7 +2533,8 @@ theorem isUnitPolynomial_gcd_quotient_of_squareFree
       exact h
     exact hr_eq.trans (hstep2.trans
       (fp_swap_inner_mul (DensePoly.gcd (r / DensePoly.gcd r d) d) e a))
-  exact isUnitPolynomial_of_squareFree_of_squared_dvd hsf hg2_dvd_r
+  exact isUnitPolynomial_of_squareFree_of_squared_dvd
+    (squareFree_common_of_gcd_eq_one hsf) hg2_dvd_r
 
 /-! ### Square-free divisor distribution across kernel-witness gcds
 
@@ -2884,7 +2901,8 @@ private theorem exists_reduced_crtZeroOne_kernelWitness_of_squareFree_monic_spli
     (a b : FpPoly p)
     (ha : DensePoly.Monic a) (hb : DensePoly.Monic b)
     (ha_pos : 0 < a.degree?.getD 0) (hb_pos : 0 < b.degree?.getD 0)
-    (hsf : DensePoly.gcd (a * b) (DensePoly.derivative (a * b)) = 1) :
+    (hsf : ∀ d, d ∣ (a * b) → d ∣ DensePoly.derivative (a * b) →
+      isUnitPolynomial d = true) :
     ∃ h : FpPoly p,
       (a * b) ∣ (FpPoly.linearPow h p - h) ∧
       (∀ c : ZMod64 p, ¬ DensePoly.Congr h (DensePoly.C c) (a * b)) ∧
@@ -3002,7 +3020,8 @@ produces `kernelWitnessSplit? f w = some _`, contradicting `hno_split`.
 -/
 theorem irreducible_of_no_kernelWitnessSplit_squareFree
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    (hsquareFree : DensePoly.gcd f (DensePoly.derivative f) = 1)
+    (hsquareFree : ∀ d, d ∣ f → d ∣ DensePoly.derivative f →
+      isUnitPolynomial d = true)
     (hno_split : ∀ w ∈ (fixedSpaceKernel f hmonic).toList,
       kernelWitnessSplit? f w = none) :
     FpPoly.Irreducible f := by
@@ -3080,7 +3099,8 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree
     unfold basisSize at hg_lt_f
     omega
   -- Square-freeness on `g * b' = f`.
-  have hsf' : DensePoly.gcd (g * b') (DensePoly.derivative (g * b')) = 1 := by
+  have hsf' : ∀ d, d ∣ (g * b') → d ∣ DensePoly.derivative (g * b') →
+      isUnitPolynomial d = true := by
     rw [hf_eq]; exact hsquareFree
   -- Reduced zero-one CRT witness `h`.
   obtain ⟨h, h_dvd, h_nonconst, h_size⟩ :=
@@ -3329,7 +3349,8 @@ algebraic completeness theorem
 -/
 theorem berlekampFactor_singleton_irreducible
     (f : FpPoly p) (hmonic : DensePoly.Monic f)
-    (hsquareFree : DensePoly.gcd f (DensePoly.derivative f) = 1)
+    (hsquareFree : ∀ d, d ∣ f → d ∣ DensePoly.derivative f →
+      isUnitPolynomial d = true)
     (hsmall : (berlekampFactor f hmonic).factors.length ≤ 1) :
     FpPoly.Irreducible f :=
   irreducible_of_no_kernelWitnessSplit_squareFree
@@ -3351,7 +3372,8 @@ theorem berlekampFactor_factors_nodup
   apply berlekampFactor_factors_nodup_of_no_squared
   intro g hgg hpos
   have hunit : isUnitPolynomial g = true :=
-    isUnitPolynomial_of_squareFree_of_squared_dvd hsquareFree hgg
+    isUnitPolynomial_of_squareFree_of_squared_dvd
+      (squareFree_common_of_gcd_eq_one hsquareFree) hgg
   have hdeg : g.degree? = some 0 := by
     unfold isUnitPolynomial at hunit
     cases hd : g.degree? with

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -309,7 +309,8 @@ theorem berlekampFactor_factors_nodup
   apply Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared
   intro g hgg hpos
   have hunit : Hex.Berlekamp.isUnitPolynomial g = true :=
-    Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsquareFree hgg
+    Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
+      (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsquareFree) hgg
   have hdeg : Hex.DensePoly.degree? g = some 0 := by
     unfold Hex.Berlekamp.isUnitPolynomial at hunit
     cases hd : Hex.DensePoly.degree? g with

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4598,7 +4598,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
       rcases hmonicImage_dvd with ⟨s, hs⟩
       exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
     have hunit : Hex.Berlekamp.isUnitPolynomial g = true :=
-      Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsf hg_dvd_mod
+      Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
+        (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf) hg_dvd_mod
     have hdeg : Hex.DensePoly.degree? g = some 0 := by
       unfold Hex.Berlekamp.isUnitPolynomial at hunit
       cases hd : Hex.DensePoly.degree? g with
@@ -4762,7 +4763,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
         exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
       -- Square-freeness implies g₂ is a unit polynomial (degree 0).
       have hunit : Hex.Berlekamp.isUnitPolynomial g₂ = true :=
-        Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsf hg₂sq_dvd_modP
+        Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
+          (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf) hg₂sq_dvd_modP
       have hdeg_zero : Hex.DensePoly.degree? g₂ = some 0 := by
         unfold Hex.Berlekamp.isUnitPolynomial at hunit
         cases hd : Hex.DensePoly.degree? g₂ with
@@ -5520,7 +5522,8 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
       rcases hmonicImage_dvd with ⟨s, hs⟩
       exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
     have hunit : Hex.Berlekamp.isUnitPolynomial d = true :=
-      Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd hsf hd_dvd_mod
+      Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
+        (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf) hd_dvd_mod
     have hdeg : Hex.DensePoly.degree? d = some 0 := by
       unfold Hex.Berlekamp.isUnitPolynomial at hunit
       cases hd : Hex.DensePoly.degree? d with

--- a/progress/20260518T013300Z_e320e19d.md
+++ b/progress/20260518T013300Z_e320e19d.md
@@ -1,0 +1,76 @@
+# Session e320e19d — #4857 relaxed Berlekamp squareFree precondition
+
+## Accomplished
+
+Replaced the strict executable-gcd squareness hypothesis
+`DensePoly.gcd r (DensePoly.derivative r) = 1` in the Berlekamp soundness
+chain with the relaxed common-divisor form
+`∀ d, d ∣ r → d ∣ DensePoly.derivative r → isUnitPolynomial d = true`.
+This is the form a #4858 consumer can supply directly from
+`isGoodPrime`-style invariants, without proving a false executable-gcd
+equality (`monicModularImage` is not monic-normalised, so the strict
+form fails after unit scaling).
+
+In `HexBerlekamp/RabinSoundness.lean`:
+
+* Added `squareFree_common_of_gcd_eq_one`: public adapter from the strict
+  `gcd = 1` form to the relaxed common-divisor form, used by every
+  in-tree caller that still carries the strict hypothesis.
+* Relaxed the six chain theorems to the new predicate:
+  - `isUnitPolynomial_of_squareFree_of_squared_dvd`
+  - `common_dvd_one_of_squareFree_mul`
+  - `exists_reduced_crtZeroOne_kernelWitness_of_squareFree_split`
+  - `exists_reduced_crtZeroOne_kernelWitness_of_squareFree_monic_split`
+    (private)
+  - `irreducible_of_no_kernelWitnessSplit_squareFree`
+  - `berlekampFactor_singleton_irreducible`
+* Added `omit [ZMod64.PrimeModulus p]` on the relaxed
+  `isUnitPolynomial_of_squareFree_of_squared_dvd` since its new proof
+  (`hsf g hgr hgr'`) no longer needs the prime modulus.
+* `isUnitPolynomial_gcd_quotient_of_squareFree` (not in the chain) kept
+  its strict precondition; its internal call to the relaxed
+  `isUnitPolynomial_of_squareFree_of_squared_dvd` now threads through
+  the adapter.
+* `berlekampFactor_factors_nodup` (line 3347) kept its strict precondition
+  per the issue's item 4; its internal call to the relaxed theorem
+  threads through the adapter.
+
+Updated four in-tree callers to wrap their strict `gcd = 1` hypothesis
+through `squareFree_common_of_gcd_eq_one`:
+
+* `HexBerlekamp/DistinctDegree.lean`: `isUnitPolynomial_gcd_quotient_of_squareFree_divisor`.
+* `HexBerlekampMathlib/Basic.lean`: `berlekampFactor_factors_nodup`
+  (bridge-surface re-export).
+* `HexBerlekampZassenhausMathlib/Basic.lean`: three call sites in the
+  monic-modular-image squareness consumers.
+
+## Verification
+
+* `lake build HexBerlekamp` — passes.
+* `lake build HexBerlekampZassenhaus` — passes (pre-existing `sorry`
+  warnings only).
+* `lake build HexBerlekampMathlib HexBerlekampZassenhausMathlib` — passes
+  (pre-existing warnings only).
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* `git diff f009dce8` for `sorry|axiom|native_decide|TODO|FIXME` on
+  additions: 0 new entries.
+
+## Current frontier
+
+The Rabin soundness chain now consumes the relaxed common-divisor
+predicate, exactly the form the #4858 wrapper can derive from
+`isGoodPrime_squareFreeModP` at the small-mod singleton call site
+without needing a false executable `monicModularImage` gcd identity.
+
+## Next step
+
+A worker on #4858 picks up the relaxed
+`berlekampFactor_singleton_irreducible` signature and supplies the
+common-divisor predicate from the `isGoodPrime` invariants maintained
+at the small-mod singleton Berlekamp call site, then assembles the
+`FpPoly.Irreducible` witness for the Rabin-importing wrapper.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4857

Session: `e320e19d-b2d3-48d1-9ae8-28f8dbcd3f63`

59f0aa8a refactor: relax Berlekamp soundness squareFree precondition to non-normalized form

🤖 Prepared with Claude Code