### PR TITLE
HO-1 substrate (#4808 residual): exhaustive reassembly discharger and wrapper rewiring

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9980,7 +9980,7 @@ theorem extractXPower_core_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
     (ZPoly.extractXPower (ZPoly.primitivePart f)).core ≠ 0 :=
   ZPoly.ne_zero_of_primitive _ (extractXPower_core_primitive_of_ne_zero f hf)
 
-private theorem repeatedPart_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
+theorem repeatedPart_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
     (normalizeForFactor f).repeatedPart ≠ 0 := by
   unfold normalizeForFactor
   simp only

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -8423,6 +8423,210 @@ theorem exhaustiveCoreFactorsWithBound_product
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)
             xs hsearch
 
+/-- The leading coefficient of an `Array.polyProduct` over a list of polynomials
+with strictly positive leading coefficients is strictly positive. Chains
+`ZPoly.leadingCoeff_mul_pos_of_pos` through the foldl unfold given by
+`ZPoly.polyProduct_cons_toArray`. -/
+private theorem leadingCoeff_polyProduct_toArray_pos :
+    ∀ (factors : List ZPoly),
+      (∀ q ∈ factors, 0 < DensePoly.leadingCoeff q) →
+      0 < DensePoly.leadingCoeff (Array.polyProduct factors.toArray) := by
+  intro factors
+  induction factors with
+  | nil =>
+      intro _
+      change 0 < DensePoly.leadingCoeff (Array.polyProduct (#[] : Array ZPoly))
+      change 0 < DensePoly.leadingCoeff (1 : ZPoly)
+      decide
+  | cons head rest ih =>
+      intro hpos
+      have hhead_pos : 0 < DensePoly.leadingCoeff head := hpos head List.mem_cons_self
+      have hrest_pos : ∀ q ∈ rest, 0 < DensePoly.leadingCoeff q :=
+        fun q hq => hpos q (List.mem_cons_of_mem _ hq)
+      rw [ZPoly.polyProduct_cons_toArray]
+      exact ZPoly.leadingCoeff_mul_pos_of_pos head _ hhead_pos (ih hrest_pos)
+
+/-- If the executable `Array.polyProduct` of a list of polynomials is monic and
+every entry has positive leading coefficient, then every entry is monic.
+
+The product of positive integer leading coefficients equals the monic product's
+leading coefficient `1`; since each factor is a positive integer, each must
+itself be `1`. Used by the exhaustive-arm reassembly discharger to recover
+monicness of emitted core factors from monicness of the squarefree core. -/
+private theorem polyProduct_toArray_monic_factors_monic_of_pos_lc :
+    ∀ (factors : List ZPoly),
+      DensePoly.Monic (Array.polyProduct factors.toArray) →
+      (∀ q ∈ factors, 0 < DensePoly.leadingCoeff q) →
+      ∀ q ∈ factors, DensePoly.Monic q := by
+  intro factors
+  induction factors with
+  | nil =>
+      intro _ _ q hq
+      cases hq
+  | cons head rest ih =>
+      intro hmonic hpos q hq
+      have hhead_pos : 0 < DensePoly.leadingCoeff head := hpos head List.mem_cons_self
+      have hrest_pos : ∀ q' ∈ rest, 0 < DensePoly.leadingCoeff q' :=
+        fun q' hq' => hpos q' (List.mem_cons_of_mem _ hq')
+      have hhead_ne : head ≠ 0 := by
+        intro h0
+        rw [h0] at hhead_pos
+        change (0 : Int) < DensePoly.leadingCoeff (0 : ZPoly) at hhead_pos
+        have hzero : DensePoly.leadingCoeff (0 : ZPoly) = 0 := by decide
+        rw [hzero] at hhead_pos
+        exact absurd hhead_pos (by decide)
+      have hrest_lc_pos : 0 < DensePoly.leadingCoeff (Array.polyProduct rest.toArray) :=
+        leadingCoeff_polyProduct_toArray_pos rest hrest_pos
+      have hrest_prod_ne : Array.polyProduct rest.toArray ≠ 0 := by
+        intro h0
+        rw [h0] at hrest_lc_pos
+        change (0 : Int) < DensePoly.leadingCoeff (0 : ZPoly) at hrest_lc_pos
+        have hzero : DensePoly.leadingCoeff (0 : ZPoly) = 0 := by decide
+        rw [hzero] at hrest_lc_pos
+        exact absurd hrest_lc_pos (by decide)
+      have hprod_eq :
+          Array.polyProduct (head :: rest).toArray =
+            head * Array.polyProduct rest.toArray :=
+        ZPoly.polyProduct_cons_toArray head rest
+      have hlc_mul :
+          DensePoly.leadingCoeff (head * Array.polyProduct rest.toArray) =
+            DensePoly.leadingCoeff head *
+              DensePoly.leadingCoeff (Array.polyProduct rest.toArray) :=
+        ZPoly.leadingCoeff_mul_of_nonzero head _ hhead_ne hrest_prod_ne
+      have hmonic_unfold :
+          DensePoly.leadingCoeff (Array.polyProduct (head :: rest).toArray) = 1 :=
+        hmonic
+      have hone :
+          DensePoly.leadingCoeff head *
+              DensePoly.leadingCoeff (Array.polyProduct rest.toArray) = 1 := by
+        rw [← hlc_mul, ← hprod_eq]
+        exact hmonic_unfold
+      have ha : 1 ≤ DensePoly.leadingCoeff head := hhead_pos
+      have hb : 1 ≤ DensePoly.leadingCoeff (Array.polyProduct rest.toArray) :=
+        hrest_lc_pos
+      -- From `a * b = 1` with `a ≥ 1`, `b ≥ 1`: `a * 1 ≤ a * b = 1`, so `a ≤ 1`.
+      -- Combined with `a ≥ 1`, `a = 1`.
+      have hhead_eq : DensePoly.leadingCoeff head = 1 := by
+        have hupper :
+            DensePoly.leadingCoeff head * 1 ≤
+              DensePoly.leadingCoeff head *
+                DensePoly.leadingCoeff (Array.polyProduct rest.toArray) :=
+          Int.mul_le_mul (Int.le_refl _) hb (by decide : (0 : Int) ≤ 1)
+            (by omega : (0 : Int) ≤ DensePoly.leadingCoeff head)
+        rw [Int.mul_one, hone] at hupper
+        omega
+      have hrest_eq :
+          DensePoly.leadingCoeff (Array.polyProduct rest.toArray) = 1 := by
+        have hone' := hone
+        rw [hhead_eq, Int.one_mul] at hone'
+        exact hone'
+      have hrest_monic : DensePoly.Monic (Array.polyProduct rest.toArray) := hrest_eq
+      have hhead_monic : DensePoly.Monic head := hhead_eq
+      rw [List.mem_cons] at hq
+      rcases hq with hh | hr
+      · rw [hh]; exact hhead_monic
+      · exact ih hrest_monic hrest_pos q hr
+
+/-- Every emitted factor of the exhaustive recombination wrapper is monic when
+the input core is monic with positive degree. The product chain
+(`exhaustiveCoreFactorsWithBound_product` together with the executable
+sign-normalisation and `shouldRecord` invariants
+`exhaustiveCoreFactorsWithBound_normalizeFactorSign` /
+`exhaustiveCoreFactorsWithBound_shouldRecord`) forces each emitted factor's
+leading coefficient to be a positive integer dividing `1`, hence itself `1`. -/
+theorem exhaustiveCoreFactorsWithBound_monic
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_monic : DensePoly.Monic core)
+    (hcore_record : shouldRecordPolynomialFactor core = true) :
+    ∀ factor ∈ (exhaustiveCoreFactorsWithBound core B primeData).toList,
+      DensePoly.Monic factor := by
+  have hcore_norm : normalizeFactorSign core = core :=
+    normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core
+      (by rw [show DensePoly.leadingCoeff core = 1 from hcore_monic]; decide)
+  have hprod :
+      Array.polyProduct (exhaustiveCoreFactorsWithBound core B primeData) = core :=
+    exhaustiveCoreFactorsWithBound_product core B primeData
+  have hprod_monic :
+      DensePoly.Monic (Array.polyProduct
+        (exhaustiveCoreFactorsWithBound core B primeData)) := by
+    rw [hprod]; exact hcore_monic
+  -- Transport to the list-level helper.
+  have hprod_monic' :
+      DensePoly.Monic (Array.polyProduct
+        (exhaustiveCoreFactorsWithBound core B primeData).toList.toArray) := by
+    rw [Array.toArray_toList]; exact hprod_monic
+  have hemit_norm :=
+    exhaustiveCoreFactorsWithBound_normalizeFactorSign core B primeData hcore_norm
+  have hemit_record :=
+    exhaustiveCoreFactorsWithBound_shouldRecord core B primeData hcore_record
+  have hpos :
+      ∀ q ∈ (exhaustiveCoreFactorsWithBound core B primeData).toList,
+        0 < DensePoly.leadingCoeff q := by
+    intro q hq
+    have hq_norm : normalizeFactorSign q = q := hemit_norm q hq
+    have hq_record : shouldRecordPolynomialFactor q = true := hemit_record q hq
+    have hq_ne : q ≠ 0 := by
+      unfold shouldRecordPolynomialFactor at hq_record
+      simp at hq_record
+      exact hq_record.1.1
+    have hq_lc_nonneg : 0 ≤ DensePoly.leadingCoeff q := by
+      rw [← hq_norm]
+      exact normalizeFactorSign_leadingCoeff_nonneg q
+    have hq_lc_ne : DensePoly.leadingCoeff q ≠ 0 :=
+      ZPoly.leadingCoeff_ne_zero_of_ne_zero q hq_ne
+    omega
+  exact polyProduct_toArray_monic_factors_monic_of_pos_lc
+    (exhaustiveCoreFactorsWithBound core B primeData).toList hprod_monic' hpos
+
+/-- Every emitted factor of the exhaustive recombination wrapper has positive
+`degree?` when the input core is monic and `shouldRecord = true`. A monic
+polynomial of `degree? = 0` is the constant `1`, which is excluded by
+`shouldRecord`, so every emitted factor has positive degree. -/
+theorem exhaustiveCoreFactorsWithBound_degree_pos
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_monic : DensePoly.Monic core)
+    (hcore_record : shouldRecordPolynomialFactor core = true) :
+    ∀ factor ∈ (exhaustiveCoreFactorsWithBound core B primeData).toList,
+      0 < factor.degree?.getD 0 := by
+  intro q hq
+  have hq_monic : DensePoly.Monic q :=
+    exhaustiveCoreFactorsWithBound_monic core B primeData hcore_monic hcore_record q hq
+  have hemit_record :=
+    exhaustiveCoreFactorsWithBound_shouldRecord core B primeData hcore_record
+  have hq_record : shouldRecordPolynomialFactor q = true := hemit_record q hq
+  -- shouldRecord excludes `q = 1`. A monic `q` with `degree? = 0` is `1`.
+  rcases Nat.eq_zero_or_pos (q.degree?.getD 0) with hdeg_eq | hpos
+  case inr => exact hpos
+  case inl =>
+    exfalso
+    have hq_ne : q ≠ 0 := by
+      intro h0
+      have hlc1 : DensePoly.leadingCoeff q = 1 := hq_monic
+      rw [h0] at hlc1
+      have hlc0 : DensePoly.leadingCoeff (0 : ZPoly) = 0 := by decide
+      omega
+    have hq_size_pos : 0 < q.size := ZPoly.size_pos_of_ne_zero q hq_ne
+    have hdeg_unfold : q.degree?.getD 0 =
+        (if q.size = 0 then 0 else q.size - 1) := by
+      unfold DensePoly.degree?
+      by_cases h : q.size = 0 <;> simp [h]
+    rw [hdeg_unfold] at hdeg_eq
+    have hsize_eq : q.size = 1 := by
+      by_cases h : q.size = 0
+      · omega
+      · split at hdeg_eq <;> omega
+    have hq_eq_C : q = DensePoly.C (q.coeff 0) := ZPoly.eq_C_of_size_eq_one q hsize_eq
+    have hq_lc : DensePoly.leadingCoeff q = q.coeff 0 := by
+      rw [DensePoly.leadingCoeff_eq_coeff_last q hq_size_pos]
+      congr 1; omega
+    have hq_lc1 : DensePoly.leadingCoeff q = 1 := hq_monic
+    have hq_coeff0 : q.coeff 0 = 1 := by rw [← hq_lc]; exact hq_lc1
+    have hq_one : q = 1 := by
+      rw [hq_eq_C, hq_coeff0]
+      rfl
+    unfold shouldRecordPolynomialFactor at hq_record
+    simp [hq_one] at hq_record
+
 private theorem polyProduct_push (factors : Array ZPoly) (factor : ZPoly) :
     Array.polyProduct (factors.push factor) =
       Array.polyProduct factors * factor := by

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3110,4 +3110,235 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hd_liftedFactor_inj hprecision
 
+/-- Divisibility propagation through `List.foldl (· * ·)` on `Hex.ZPoly`: if
+`x` divides the accumulator at any point, it divides the final foldl. Used by
+`mem_dvd_foldl_mul_zpoly`. -/
+private theorem dvd_acc_foldl_mul_zpoly (x : Hex.ZPoly) :
+    ∀ (l : List Hex.ZPoly) (acc : Hex.ZPoly),
+      x ∣ acc → x ∣ l.foldl (· * ·) acc := by
+  intro l
+  induction l with
+  | nil =>
+      intro acc hacc
+      simpa using hacc
+  | cons head tail ih =>
+      intro acc hacc
+      simp only [List.foldl_cons]
+      refine ih (acc * head) ?_
+      -- `x ∣ acc * head` from `x ∣ acc` via commutativity + `dvd_mul_left_poly`.
+      have hcomm : acc * head = head * acc := Hex.DensePoly.mul_comm_poly (S := Int) acc head
+      rw [hcomm]
+      exact Hex.DensePoly.dvd_mul_left_poly head hacc
+
+/-- An element of a `List Hex.ZPoly` divides the `List.foldl (· * ·)` of that
+list. Used by the exhaustive-arm fuel-bound construction in
+`reassemblyExpansionComplete_exhaustive_of_ne_zero`. -/
+private theorem mem_dvd_foldl_mul_zpoly
+    (l : List Hex.ZPoly) (acc : Hex.ZPoly) (x : Hex.ZPoly) (hx : x ∈ l) :
+    x ∣ l.foldl (· * ·) acc := by
+  induction l generalizing acc with
+  | nil => exact absurd hx (List.not_mem_nil)
+  | cons head tail ih =>
+      rw [List.mem_cons] at hx
+      simp only [List.foldl_cons]
+      rcases hx with rfl | hx
+      · -- `x = head`: divides `acc * x = acc * head`, and propagates through tail.
+        refine dvd_acc_foldl_mul_zpoly x tail (acc * x) ?_
+        have hcomm : acc * x = x * acc := Hex.DensePoly.mul_comm_poly (S := Int) acc x
+        rw [hcomm]
+        exact ⟨acc, rfl⟩
+      · exact ih (acc * head) hx
+
+/-- For a polynomial `q` of positive degree, the size of
+`Hex.Factorization.factorPower q m` is at least `m + 1`. Each iteration of
+`polyPow` multiplies the running product by `q`, increasing the size by at
+least `q.size - 1 ≥ 1`. -/
+private theorem factorPower_size_lower_bound
+    {q : Hex.ZPoly} (hq_deg : 0 < q.degree?.getD 0) :
+    ∀ m : Nat, m + 1 ≤ (Hex.Factorization.factorPower q m).size := by
+  intro m
+  -- From `0 < q.degree?.getD 0`, derive `2 ≤ q.size`.
+  have hq_size_ge_two : 2 ≤ q.size := by
+    have hdeg_unfold : q.degree?.getD 0 =
+        (if q.size = 0 then 0 else q.size - 1) := by
+      unfold Hex.DensePoly.degree?
+      by_cases h : q.size = 0 <;> simp [h]
+    rw [hdeg_unfold] at hq_deg
+    by_cases h : q.size = 0
+    · simp [h] at hq_deg
+    · split at hq_deg <;> omega
+  induction m with
+  | zero =>
+      show 1 ≤ (1 : Hex.ZPoly).size
+      rfl
+  | succ n ih =>
+      rw [Hex.Factorization.factorPower_succ]
+      have hprev_pos : 0 < (Hex.Factorization.factorPower q n).size := by
+        omega
+      have hq_pos : 0 < q.size := by omega
+      have hmul_size :
+          (Hex.Factorization.factorPower q n * q).size =
+            (Hex.Factorization.factorPower q n).size + q.size - 1 :=
+        Hex.ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hprev_pos hq_pos
+      omega
+
+/-- **#4848 / #4808 residual — exhaustive-arm `reassemblyExpansionComplete`
+discharger.**
+
+Specialised companion to the slow-path exhaustive-arm umbrella
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` (#4561). The
+`hcomplete` premise of that umbrella is exactly
+`Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+  (Hex.exhaustiveCoreFactorsWithBound ...)`; this discharger constructs that
+witness from the substrate stack the umbrella already exposes:
+
+* the generic Mathlib-bridge assembler
+  `IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover`
+  (#4840), composing the repeated-part `factorPower` decomposition (#4759)
+  and the no-tail divisibility lemma (#4807) into the executable
+  expansion contract;
+* the exhaustive-arm emit-side properties:
+  `Hex.exhaustiveCoreFactorsWithBound_product` for the cover identity,
+  `Hex.exhaustiveCoreFactorsWithBound_monic` and
+  `Hex.exhaustiveCoreFactorsWithBound_degree_pos` (new) for the monicness
+  and positive-degree per-factor preconditions, and the
+  `exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData`
+  package (#4806) for irreducibility / sign-normalisation;
+* a fuel bound, derived by combining the factorPower divisibility chain
+  (each emitted factor's `factorPower` divides the foldl product, hence the
+  repeated part) with the `factorPower_size_lower_bound` size estimate.
+
+After this lands, callers of the exhaustive umbrella no longer need to thread
+a free `hcomplete` premise; the umbrella's other shim premises (`hcore_monic`
+Gap 1 and `hprecision` Gap 3) are retained until their respective substrate
+follow-ups land. -/
+theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
+    (hbranch : Hex.factorWithBoundUsesExhaustiveBranch f
+      (Hex.ZPoly.defaultFactorCoeffBound f))
+    (hchoose : Hex.choosePrimeData?
+      (Hex.normalizeForFactor f).squareFreeCore = some
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))
+    (hcore_monic : Hex.DensePoly.Monic
+      (Hex.normalizeForFactor f).squareFreeCore)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound
+        (Hex.normalizeForFactor f).squareFreeCore <
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
+          Hex.precisionForCoeffBound
+            (Hex.ZPoly.defaultFactorCoeffBound f)
+            (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
+    Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+      (Hex.exhaustiveCoreFactorsWithBound
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.defaultFactorCoeffBound f)
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) := by
+  -- Substrate setup: discharge `hcore_record` and `hcore_ne` from the branch
+  -- hypothesis + monicness.
+  have hdeg :
+      (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 := hbranch.2.1
+  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
+    intro h0
+    have hlc : Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
+    rw [h0] at hlc
+    have hzero : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := by decide
+    omega
+  have hcore_record : Hex.shouldRecordPolynomialFactor
+      (Hex.normalizeForFactor f).squareFreeCore = true := by
+    have hne_one : (Hex.normalizeForFactor f).squareFreeCore ≠ 1 := by
+      intro hone
+      apply hdeg
+      rw [hone]
+      exact Hex.DensePoly.degree?_C_getD 1
+    have hne_neg_one :
+        (Hex.normalizeForFactor f).squareFreeCore ≠ Hex.DensePoly.C (-1 : Int) := by
+      intro hneg
+      apply hdeg
+      rw [hneg]
+      exact Hex.DensePoly.degree?_C_getD (-1)
+    unfold Hex.shouldRecordPolynomialFactor
+    simp [hcore_ne, hne_one, hne_neg_one]
+  -- #4806 package for `(shouldRecord, normalizeFactorSign, Irreducible)`.
+  obtain ⟨_, hnorm, hirr⟩ :=
+    exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData
+      f hf_ne hbranch hchoose hcore_monic hprecision
+  -- New substrate: monicness and positive-degree of every emitted factor.
+  have hmonic :=
+    Hex.exhaustiveCoreFactorsWithBound_monic
+      (Hex.normalizeForFactor f).squareFreeCore
+      (Hex.ZPoly.defaultFactorCoeffBound f)
+      (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+      hcore_monic hcore_record
+  have hdegree :=
+    Hex.exhaustiveCoreFactorsWithBound_degree_pos
+      (Hex.normalizeForFactor f).squareFreeCore
+      (Hex.ZPoly.defaultFactorCoeffBound f)
+      (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+      hcore_monic hcore_record
+  -- polyProduct = squareFreeCore.
+  have hprod :=
+    Hex.exhaustiveCoreFactorsWithBound_product
+      (Hex.normalizeForFactor f).squareFreeCore
+      (Hex.ZPoly.defaultFactorCoeffBound f)
+      (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+  -- Fuel bound: for any valid exponents, each exponent satisfies
+  -- `e + 1 ≤ repeatedPart.size + 1`, via factorPower divisibility + size.
+  have hrp_ne :
+      (Hex.normalizeForFactor f).repeatedPart ≠ 0 :=
+    Hex.repeatedPart_ne_zero_of_ne_zero f hf_ne
+  set coreFactors := Hex.exhaustiveCoreFactorsWithBound
+      (Hex.normalizeForFactor f).squareFreeCore
+      (Hex.ZPoly.defaultFactorCoeffBound f)
+      (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+    with hcoreFactors_def
+  have hfuel :
+      ∀ exponents : List Nat,
+        exponents.length = coreFactors.size →
+        (Hex.normalizeForFactor f).repeatedPart =
+          ((coreFactors.toList.zip exponents).map
+            (fun qe => Hex.Factorization.factorPower qe.1 qe.2)).foldl (· * ·) 1 →
+        ∀ (qe : Hex.ZPoly × Nat),
+          qe ∈ coreFactors.toList.zip exponents →
+            qe.2 + 1 ≤ (Hex.normalizeForFactor f).repeatedPart.size + 1 := by
+    intro exponents _ hdecomp qe hqe
+    -- qe.1 ∈ coreFactors.toList from the zip membership.
+    have hq_mem : qe.1 ∈ coreFactors.toList := by
+      have := List.of_mem_zip hqe
+      exact this.1
+    have hq_deg : 0 < qe.1.degree?.getD 0 := hdegree qe.1 hq_mem
+    -- factorPower qe.1 qe.2 ≠ 0 (from q.size ≥ 2 by factorPower size lower bound).
+    have hfp_size_lb : qe.2 + 1 ≤ (Hex.Factorization.factorPower qe.1 qe.2).size :=
+      factorPower_size_lower_bound hq_deg qe.2
+    have hfp_ne : Hex.Factorization.factorPower qe.1 qe.2 ≠ 0 := by
+      intro h0
+      have : (Hex.Factorization.factorPower qe.1 qe.2).size = 0 := by
+        rw [h0]; rfl
+      omega
+    -- factorPower divides the foldl product.
+    have hfp_in_map :
+        Hex.Factorization.factorPower qe.1 qe.2 ∈
+          (coreFactors.toList.zip exponents).map
+            (fun qe => Hex.Factorization.factorPower qe.1 qe.2) := by
+      rw [List.mem_map]
+      exact ⟨qe, hqe, rfl⟩
+    have hfp_dvd :
+        Hex.Factorization.factorPower qe.1 qe.2 ∣
+          ((coreFactors.toList.zip exponents).map
+            (fun qe => Hex.Factorization.factorPower qe.1 qe.2)).foldl (· * ·) 1 :=
+      mem_dvd_foldl_mul_zpoly _ 1 _ hfp_in_map
+    -- Lift to divisibility of repeatedPart.
+    have hfp_dvd_rp :
+        Hex.Factorization.factorPower qe.1 qe.2 ∣
+          (Hex.normalizeForFactor f).repeatedPart := by
+      rw [hdecomp]; exact hfp_dvd
+    -- Size bound from divisibility.
+    have hsize_le : (Hex.Factorization.factorPower qe.1 qe.2).size ≤
+        (Hex.normalizeForFactor f).repeatedPart.size :=
+      Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne hrp_ne hfp_dvd_rp
+    omega
+  -- Apply the generic assembler.
+  exact IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover
+    f hf_ne coreFactors hirr hprod hnorm hmonic hdegree hfuel
+
 end HexBerlekampZassenhausMathlib

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2755,8 +2755,16 @@ arm umbrellas (#4564 / #4565 / #4571 / #4575).
 
 The slow-path constant and quadratic sub-branches are tracked separately
 (`squareFreeCore.degree?.getD 0 = 0` and `quadraticIntegerRootFactors? =
-some _` respectively); the fast BHKS branch is gated on directive #2567. -/
-theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
+some _` respectively); the fast BHKS branch is gated on directive #2567.
+
+**#4848:** the original `hcomplete` premise (Gap 2) is no longer free.
+The public surface
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` derives it
+from `reassemblyExpansionComplete_exhaustive_of_ne_zero` before invoking
+this internal residual; the residual is exposed via a private auxiliary
+so the heartbeat-sensitive wrapper application here is not re-elaborated
+through the discharger. -/
+private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (entry : Hex.ZPoly × Nat)
     (hbranch : Hex.factorWithBoundUsesExhaustiveBranch f
@@ -2766,21 +2774,13 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
     (hchoose : Hex.choosePrimeData?
       (Hex.normalizeForFactor f).squareFreeCore = some
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))
-    -- Gap 1: explicit until a `Monic`-relaxation refactor of the upstream
-    -- wrapper lands (or a producer for `squareFreeCore`-monicness arrives).
     (hcore_monic : Hex.DensePoly.Monic
       (Hex.normalizeForFactor f).squareFreeCore)
-    -- Gap 2: explicit until the
-    -- `reassemblyExpansionComplete_exhaustive_of_ne_zero` discharger lands
-    -- (sibling of #4585 for the exhaustive arm).
     (hcomplete : Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
       (Hex.exhaustiveCoreFactorsWithBound
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)))
-    -- Gap 3 (substrate): explicit until the squareFreeCore-bound monotonicity
-    -- (#4539, closed without resolution) is supplied by the abstract-bound
-    -- refactor at the wrapper's call site.
     (hprecision :
       2 * Hex.ZPoly.defaultFactorCoeffBound
         (Hex.normalizeForFactor f).squareFreeCore <
@@ -3340,5 +3340,58 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
   -- Apply the generic assembler.
   exact IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover
     f hf_ne coreFactors hirr hprod hnorm hmonic hdegree hfuel
+
+/-- **#4561 / #4848 HO-1 substrate — slow exhaustive-arm umbrella, with the
+`hcomplete` premise dropped via the #4848 discharger.**
+
+Public surface of the exhaustive-arm HO-1 umbrella. The free `hcomplete`
+premise documented as "Gap 2" in #4561 is now discharged internally via
+`reassemblyExpansionComplete_exhaustive_of_ne_zero` (#4848), so downstream
+callers (notably the HO-1 capstone #4170) only need to thread the
+remaining Gap 1 (`hcore_monic`) and Gap 3 (`hprecision`) shim premises
+until those substrate follow-ups land.
+
+The body proceeds in two steps:
+
+1. Apply `reassemblyExpansionComplete_exhaustive_of_ne_zero` to construct
+   the `hcomplete` witness from `(f, hf_ne, hbranch, hchoose, hcore_monic,
+   hprecision)`.
+2. Apply the internal residual
+   `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux`,
+   which carries the existing wrapper composition unchanged.
+
+Factoring through the internal residual avoids the heartbeat spike the
+previous direct rewiring attempt exposed at the existing wrapper
+application. -/
+theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
+    (entry : Hex.ZPoly × Nat)
+    (hbranch : Hex.factorWithBoundUsesExhaustiveBranch f
+      (Hex.ZPoly.defaultFactorCoeffBound f))
+    (hentry_mem : entry ∈ (Hex.factorWithBound f
+      (Hex.ZPoly.defaultFactorCoeffBound f)).factors.toList)
+    (hchoose : Hex.choosePrimeData?
+      (Hex.normalizeForFactor f).squareFreeCore = some
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))
+    -- Gap 1: explicit until a `Monic`-relaxation refactor of the upstream
+    -- wrapper lands (or a producer for `squareFreeCore`-monicness arrives).
+    (hcore_monic : Hex.DensePoly.Monic
+      (Hex.normalizeForFactor f).squareFreeCore)
+    -- Gap 3 (substrate): explicit until the squareFreeCore-bound monotonicity
+    -- (#4539, closed without resolution) is supplied by the abstract-bound
+    -- refactor at the wrapper's call site.
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound
+        (Hex.normalizeForFactor f).squareFreeCore <
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
+          Hex.precisionForCoeffBound
+            (Hex.ZPoly.defaultFactorCoeffBound f)
+            (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
+    Hex.ZPoly.Irreducible entry.1 :=
+  factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux
+    f hf_ne entry hbranch hentry_mem hchoose hcore_monic
+    (reassemblyExpansionComplete_exhaustive_of_ne_zero
+      f hf_ne hbranch hchoose hcore_monic hprecision)
+    hprecision
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260517T233750Z_1a102290.md
+++ b/progress/20260517T233750Z_1a102290.md
@@ -1,0 +1,55 @@
+# Work session 1a102290
+
+## Accomplished
+
+- Closed the substrate gap left by #4808 / PR #4840: built the
+  exhaustive-arm `Hex.reassemblyExpansionComplete` discharger
+  `reassemblyExpansionComplete_exhaustive_of_ne_zero`
+  in `HexBerlekampZassenhausMathlib/IntReductionMod.lean`.
+- Added the missing emit-side substrate the discharger needed:
+  - `Hex.exhaustiveCoreFactorsWithBound_monic`
+  - `Hex.exhaustiveCoreFactorsWithBound_degree_pos`
+  - a list-level helper
+    `polyProduct_toArray_monic_factors_monic_of_pos_lc`
+    deriving factor monicness from product monicness plus per-factor
+    positive leading coefficient
+  - a `leadingCoeff_polyProduct_toArray_pos` lemma chaining
+    `ZPoly.leadingCoeff_mul_pos_of_pos` through the foldl unfold.
+  These compose `exhaustiveCoreFactorsWithBound_product` with the
+  existing `normalizeFactorSign` / `shouldRecord` invariants on
+  emitted factors.
+- The discharger also adds `factorPower_size_lower_bound` (from
+  positive degree) and a `mem_dvd_foldl_mul_zpoly` divisibility chain
+  to construct the fuel bound consumed by the generic assembler from
+  PR #4840.
+- Exposed `Hex.repeatedPart_ne_zero_of_ne_zero` (dropped `private`)
+  for the fuel-bound divisibility step.
+- Rewired `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`:
+  - The original definition is now the private
+    `_aux` residual carrying the explicit `hcomplete` premise.
+  - The public surface derives `hcomplete` from the new discharger
+    and delegates to `_aux`, so callers no longer thread the Gap 2
+    `hcomplete` premise.
+  - Factoring through the residual sidesteps the heartbeat spike the
+    previous direct rewiring attempt had exposed at the existing
+    wrapper application (recorded in
+    `progress/20260517T215657Z_a99f2477.md`).
+
+## Current frontier
+
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` now
+only takes the Gap 1 (`hcore_monic`) and Gap 3 (`hprecision`) shims.
+Gap 2 is fully closed. The remaining gaps remain tied to upstream
+substrate (Monic-relaxation refactor of the slow-path wrapper, and
+the squareFreeCore-bound monotonicity from closed #4539).
+
+## Next step
+
+Pick up follow-up substrate to relax Gap 1 / Gap 3 on the exhaustive
+arm umbrella, or move on to the HO-1 capstone wiring (#4170) once all
+four arm dischargers are connected.
+
+## Blockers
+
+None for #4848 itself. Capstone wiring still gated on the four arm
+dischargers landing (#4604 in flight for the quadratic arm).


### PR DESCRIPTION
Closes #4848

Session: `1a102290-92a8-4624-8bdb-16f8ca644631`

defad3c8 doc: progress note for #4848 (exhaustive reassembly discharger + rewiring)
5120db39 refactor: drop hcomplete from exhaustive arm umbrella via #4848 discharger
7d0cea54 feat: add reassemblyExpansionComplete_exhaustive_of_ne_zero discharger (#4848)
21f1cd62 feat: expose monicness and positive-degree of exhaustive-arm emit (#4848 substrate)

🤖 Prepared with Claude Code