### PR TITLE
BZ Mathlib-free: add scaled siblings of recombinationSearchMod invariant lemmas

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7788,6 +7788,127 @@ private theorem recombinationSearchMod_shouldRecord
   recombinationSearchModAux_shouldRecord
     f modulus localFactors factors (localFactors.length + 1) hsearch
 
+private theorem scaledRecombinationSearchModAux_normalizeFactorSign
+    (coreLc : Int) (target : ZPoly) (modulus : Nat)
+    (localFactors factors : List ZPoly) (fuel : Nat)
+    (hsearch :
+      scaledRecombinationSearchModAux coreLc target modulus localFactors fuel
+        = some factors) :
+    ∀ factor ∈ factors, normalizeFactorSign factor = factor := by
+  induction fuel generalizing target localFactors factors with
+  | zero =>
+      simp [scaledRecombinationSearchModAux] at hsearch
+  | succ fuel ih =>
+      unfold scaledRecombinationSearchModAux at hsearch
+      by_cases htarget : target = 1
+      · simp [htarget] at hsearch
+        cases hsearch
+        simp
+      · simp [htarget] at hsearch
+        rcases firstSome_some hsearch with ⟨split, hsplit⟩
+        let candidate :=
+          normalizeFactorSign <|
+            ZPoly.primitivePart <|
+              centeredLiftPoly
+                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
+                modulus
+        by_cases hrecord : shouldRecordPolynomialFactor candidate = true
+        · simp [candidate, hrecord] at hsplit
+          cases hquot : exactQuotient? target candidate with
+          | none =>
+              simp [candidate, hquot] at hsplit
+          | some quotient =>
+              simp [candidate, hquot] at hsplit
+              cases hrec :
+                  scaledRecombinationSearchModAux coreLc quotient modulus
+                    split.2 fuel with
+              | none =>
+                  simp [hrec] at hsplit
+              | some rest =>
+                  simp [hrec] at hsplit
+                  cases hsplit
+                  intro factor hmem
+                  simp at hmem
+                  cases hmem with
+                  | inl hfactor =>
+                      rw [hfactor]
+                      exact normalizeFactorSign_idem
+                        (ZPoly.primitivePart <|
+                          centeredLiftPoly
+                            (DensePoly.scale coreLc
+                              (Array.polyProduct split.1.toArray))
+                            modulus)
+                  | inr hrest =>
+                      exact ih quotient split.2 rest hrec factor hrest
+        · simp [candidate, hrecord] at hsplit
+
+private theorem scaledRecombinationSearchModAux_shouldRecord
+    (coreLc : Int) (target : ZPoly) (modulus : Nat)
+    (localFactors factors : List ZPoly) (fuel : Nat)
+    (hsearch :
+      scaledRecombinationSearchModAux coreLc target modulus localFactors fuel
+        = some factors) :
+    ∀ factor ∈ factors, shouldRecordPolynomialFactor factor = true := by
+  induction fuel generalizing target localFactors factors with
+  | zero =>
+      simp [scaledRecombinationSearchModAux] at hsearch
+  | succ fuel ih =>
+      unfold scaledRecombinationSearchModAux at hsearch
+      by_cases htarget : target = 1
+      · simp [htarget] at hsearch
+        cases hsearch
+        simp
+      · simp [htarget] at hsearch
+        rcases firstSome_some hsearch with ⟨split, hsplit⟩
+        let candidate :=
+          normalizeFactorSign <|
+            ZPoly.primitivePart <|
+              centeredLiftPoly
+                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
+                modulus
+        by_cases hrecord : shouldRecordPolynomialFactor candidate = true
+        · simp [candidate, hrecord] at hsplit
+          cases hquot : exactQuotient? target candidate with
+          | none =>
+              simp [candidate, hquot] at hsplit
+          | some quotient =>
+              simp [candidate, hquot] at hsplit
+              cases hrec :
+                  scaledRecombinationSearchModAux coreLc quotient modulus
+                    split.2 fuel with
+              | none =>
+                  simp [hrec] at hsplit
+              | some rest =>
+                  simp [hrec] at hsplit
+                  cases hsplit
+                  intro factor hmem
+                  simp at hmem
+                  cases hmem with
+                  | inl hfactor =>
+                      rw [hfactor]
+                      exact hrecord
+                  | inr hrest =>
+                      exact ih quotient split.2 rest hrec factor hrest
+        · simp [candidate, hrecord] at hsplit
+
+private theorem scaledRecombinationSearchMod_normalizeFactorSign
+    (coreLc : Int) (f : ZPoly) (modulus : Nat)
+    (localFactors factors : List ZPoly)
+    (hsearch :
+      scaledRecombinationSearchMod coreLc f modulus localFactors = some factors) :
+    ∀ factor ∈ factors, normalizeFactorSign factor = factor :=
+  scaledRecombinationSearchModAux_normalizeFactorSign
+    coreLc f modulus localFactors factors (localFactors.length + 1) hsearch
+
+private theorem scaledRecombinationSearchMod_shouldRecord
+    (coreLc : Int) (f : ZPoly) (modulus : Nat)
+    (localFactors factors : List ZPoly)
+    (hsearch :
+      scaledRecombinationSearchMod coreLc f modulus localFactors = some factors) :
+    ∀ factor ∈ factors, shouldRecordPolynomialFactor factor = true :=
+  scaledRecombinationSearchModAux_shouldRecord
+    coreLc f modulus localFactors factors (localFactors.length + 1) hsearch
+
 private theorem recombineExhaustive_product
     (f : ZPoly) (d : LiftData) (factors : List ZPoly)
     (hsearch :

--- a/progress/20260517T234600Z_34a042a0.md
+++ b/progress/20260517T234600Z_34a042a0.md
@@ -1,0 +1,49 @@
+# 2026-05-17 23:46Z — Scaled recombination invariant siblings
+
+## Accomplished
+
+Landed the four scaled siblings of the recombination invariant lemmas
+from issue #4863. In `HexBerlekampZassenhaus/Basic.lean`, immediately
+after the existing unscaled siblings (ending at
+`recombinationSearchMod_shouldRecord`):
+
+- `scaledRecombinationSearchModAux_normalizeFactorSign`
+- `scaledRecombinationSearchModAux_shouldRecord`
+- `scaledRecombinationSearchMod_normalizeFactorSign`
+- `scaledRecombinationSearchMod_shouldRecord`
+
+The two `_Aux` lemmas mirror the unscaled inductions line for line; the
+only structural difference is the `candidate` definition wraps
+`Array.polyProduct split.1.toArray` in `DensePoly.scale coreLc _` before
+`centeredLiftPoly`. The `normalizeFactorSign_idem` closer applies to the
+wider candidate unchanged. The two surface wrappers delegate to the
+`_Aux` lemmas with `fuel = localFactors.length + 1`.
+
+All four are `private`, matching the visibility of the unscaled
+siblings. No existing definition, theorem, or call site is changed.
+
+## Current frontier
+
+Issue #4863 deliverables are in. Verification gate:
+
+- `lake build HexBerlekampZassenhaus.Basic` — green (one pre-existing
+  `simpa` warning at line 2291; one pre-existing sorry at 6420).
+- `lake build HexBerlekampZassenhaus` — green.
+- `lake build HexBerlekampZassenhausMathlib` — green (additive change
+  did not perturb the Mathlib bridge).
+- `python3 scripts/check_dag.py` — silent (clean).
+- `git diff --check` — clean.
+- No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` introduced.
+
+## Next step
+
+Per the issue, the natural follow-up is the executable sibling
+`recombineScaledExhaustive` plus its Mathlib-bridge membership wrapper
+(`exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some`),
+which together cover step 2 of #4639's prerequisite chain. That work
+is out of scope for this issue and should be filed as a separate
+planner item if not already in flight.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4863

Session: `34a042a0-3f30-4eaa-baa8-831311608afc`

cfb58410 feat: add scaled siblings of recombinationSearchMod invariant lemmas (#4863)

🤖 Prepared with Claude Code