### PR TITLE
HexGramSchmidt: above-prev bordered-minor identity for adjacent swap

### DIFF
--- a/HexGramSchmidt/Basic.lean
+++ b/HexGramSchmidt/Basic.lean
@@ -138,7 +138,7 @@ private theorem dot_self_eq_zero_get (v : Vector Rat m)
   exact foldl_dot_self_eq_zero_of_mem (xs := List.finRange m) (v := v)
     (acc := 0) (by decide) (by simpa [Matrix.dot, Hex.Vector.dotProduct] using hzero) i hmem
 
-private theorem dot_zero_of_dot_self_zero (row v : Vector Rat m)
+theorem dot_zero_of_dot_self_zero (row v : Vector Rat m)
     (hzero : Matrix.dot v v = 0) :
     Matrix.dot row v = 0 := by
   unfold Matrix.dot Hex.Vector.dotProduct

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -206,7 +206,7 @@ private theorem det_intCast {k : Nat} (M : Matrix Int k k) :
   exact detTerm_intCast M perm
 
 /-- Right-side dot product distributes over vector addition. -/
-private theorem dot_add_right_rat {m' : Nat} (u v w : Vector Rat m') :
+theorem dot_add_right_rat {m' : Nat} (u v w : Vector Rat m') :
     Matrix.dot u (v + w) = Matrix.dot u v + Matrix.dot u w := by
   unfold Matrix.dot Hex.Vector.dotProduct
   have h :
@@ -234,7 +234,7 @@ private theorem dot_add_right_rat {m' : Nat} (u v w : Vector Rat m') :
   simpa [hzero] using h (List.finRange m') 0 0
 
 /-- Right-side dot product distributes over scalar multiplication. -/
-private theorem dot_smul_right_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
+theorem dot_smul_right_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
     Matrix.dot u (s • v) = s * Matrix.dot u v := by
   unfold Matrix.dot Hex.Vector.dotProduct
   have h :
@@ -1068,7 +1068,7 @@ theorem gramDet_pos (b : Matrix Int n m)
 factor multiplies the `k`-fold product by `Vector.normSq ((basis b).row ⟨k, _⟩)`.
 This is a `List.finRange` cancellation lemma; positivity of the leading Gram
 determinant is handled separately by `gramDet_pos`. -/
-private theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
+theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
     (k : Nat) (hk : k + 1 ≤ n) :
     gramSchmidtNormProduct b (k + 1) hk =
       gramSchmidtNormProduct b k (Nat.le_of_succ_le hk) *
@@ -1390,7 +1390,7 @@ private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
 
 /-- The Gram-determinant succession: `(gramDet (j+1) : Rat)` factors as
 `(gramSchmidtNormProduct j) * normSq(basis[j])`. -/
-private theorem gramDet_succ_rat
+theorem gramDet_succ_rat
     (b : Matrix Int n m) (j : Nat) (hjsuc : j + 1 ≤ n) :
     (gramDet b (j + 1) hjsuc : Rat) =
       gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
@@ -1746,13 +1746,13 @@ private theorem intCast_rat_injective_int_eq {a b : Int} (h : (a : Rat) = (b : R
   have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
   omega
 
-private theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
+theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
     Matrix.dot (u + v) w = Matrix.dot u w + Matrix.dot v w := by
   rw [dot_comm_rat (u := u + v) (v := w)]
   rw [dot_add_right_rat (u := w) (v := u) (w := v)]
   rw [dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
 
-private theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
+theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
     Matrix.dot (s • u) v = s * Matrix.dot u v := by
   rw [dot_comm_rat (u := s • u) (v := v)]
   rw [dot_smul_right_rat (s := s) (u := v) (v := u)]
@@ -1760,7 +1760,7 @@ private theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
 
 /-- Pythagoras: if `curr ⊥ prev`, then the squared norm of `curr + μ • prev`
 splits as `‖curr‖² + μ² · ‖prev‖²`. -/
-private theorem normSq_add_smul_orthogonal_rat {m' : Nat}
+theorem normSq_add_smul_orthogonal_rat {m' : Nat}
     (curr prev : Vector Rat m') (μ : Rat)
     (horth : Matrix.dot curr prev = 0) :
     Vector.normSq (curr + μ • prev) =
@@ -1782,7 +1782,7 @@ private theorem normSq_add_smul_orthogonal_rat {m' : Nat}
 /-- For `j < km1.val`, the Gram-Schmidt basis row is unchanged by the swap
 of rows `km1, k`. The norm-square product over indices `< km1.val` therefore
 agrees on `b` and `Matrix.rowSwap b km1 k`. -/
-private theorem gramSchmidtNormProduct_rowSwap_below
+theorem gramSchmidtNormProduct_rowSwap_below
     (b : Matrix Int n m) (km1 k : Fin n) (hkm1k : km1.val < k.val) :
     gramSchmidtNormProduct (Matrix.rowSwap b km1 k) km1.val
         (Nat.le_of_lt km1.isLt) =
@@ -1799,7 +1799,7 @@ private theorem gramSchmidtNormProduct_rowSwap_below
 determinant casts to the rational `gramSchmidtNormProduct` without requiring
 linear independence. The `independent` hypothesis in the public theorem is
 not actually used by the proof. -/
-private theorem gramDet_eq_prod_normSq_uncond (b : Matrix Int n m)
+theorem gramDet_eq_prod_normSq_uncond (b : Matrix Int n m)
     (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
   rw [gramDet_rat_eq_progressMatrix_zero_det b k hk]
@@ -1810,7 +1810,7 @@ private theorem gramDet_eq_prod_normSq_uncond (b : Matrix Int n m)
 /-- `gramDet` is independent of the propositional `≤ n` proof, and depends only
 on the Nat value `k`. Two `gramDet` calls with equal `Nat` arguments produce
 equal values. -/
-private theorem gramDet_subst_val
+theorem gramDet_subst_val
     (b : Matrix Int n m) (j₁ j₂ : Nat) (h₁ : j₁ ≤ n) (h₂ : j₂ ≤ n)
     (he : j₁ = j₂) :
     gramDet b j₁ h₁ = gramDet b j₂ h₂ := by
@@ -1818,7 +1818,7 @@ private theorem gramDet_subst_val
   rfl
 
 /-- Same as `gramDet_subst_val` for `gramSchmidtNormProduct`. -/
-private theorem gramSchmidtNormProduct_subst_val
+theorem gramSchmidtNormProduct_subst_val
     (b : Matrix Int n m) (j₁ j₂ : Nat) (h₁ : j₁ ≤ n) (h₂ : j₂ ≤ n)
     (he : j₁ = j₂) :
     gramSchmidtNormProduct b j₁ h₁ = gramSchmidtNormProduct b j₂ h₂ := by
@@ -1917,6 +1917,102 @@ theorem gramDet_rowSwap_adjacent_pivot_product
   rw [hdprime_rat, hdk_rat, hdkp1_rat, hdkm1_rat, hB_rat]
   grind
 
+/-- All-zero foldl: when every term in the foldl is zero, the result equals
+the initial accumulator. -/
+private theorem foldl_add_zero_of_all_zero_rat {α : Type}
+    (f : α → Rat) (xs : List α) (h : ∀ x ∈ xs, f x = 0) (acc : Rat) :
+    xs.foldl (fun acc' x => acc' + f x) acc = acc := by
+  induction xs generalizing acc with
+  | nil => rfl
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      have hx : f x = 0 := h x (by simp)
+      rw [hx, Rat.add_zero]
+      exact ih (fun y hy => h y (by simp [hy])) acc
+
+/-- Foldl isolation: when every term except the `j`-th vanishes, the foldl
+over `List.finRange i` collapses to `f ⟨j, hj⟩`. -/
+private theorem foldl_finRange_isolate_rat :
+    ∀ (i : Nat) (j : Nat) (hj : j < i) (f : Fin i → Rat),
+      (∀ q : Fin i, q.val ≠ j → f q = 0) →
+      (List.finRange i).foldl (fun acc q => acc + f q) 0 = f ⟨j, hj⟩
+  | 0, _, hj, _, _ => absurd hj (Nat.not_lt_zero _)
+  | i + 1, j, hj, f, h_zero => by
+      rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
+      simp only [List.foldl_cons, List.foldl_nil]
+      by_cases hj_eq : j = i
+      · -- j = i: the `Fin.last i` term contributes `f ⟨j, hj⟩`.
+        subst hj_eq
+        have hzero_pre : ∀ q : Fin j, f (Fin.castSucc q) = 0 := by
+          intro q
+          apply h_zero
+          have : (Fin.castSucc q).val = q.val := rfl
+          rw [this]
+          exact Nat.ne_of_lt q.isLt
+        have hmem_zero : ∀ q ∈ List.finRange j, f (Fin.castSucc q) = 0 := by
+          intro q _
+          exact hzero_pre q
+        have hfold_zero :
+            (List.finRange j).foldl
+                (fun (acc : Rat) (q : Fin j) => acc + f (Fin.castSucc q)) 0 = 0 :=
+          foldl_add_zero_of_all_zero_rat (fun q => f (Fin.castSucc q))
+            (List.finRange j) hmem_zero 0
+        rw [hfold_zero, Rat.zero_add]
+        rfl
+      · -- j < i: recurse on the smaller range.
+        have hjlt : j < i := by omega
+        have hlast_zero : f (Fin.last i) = 0 := by
+          apply h_zero
+          have : (Fin.last i).val = i := rfl
+          rw [this]
+          omega
+        rw [hlast_zero, Rat.add_zero]
+        have hzero_pre : ∀ q : Fin i, q.val ≠ j → f (Fin.castSucc q) = 0 := by
+          intro q hq_ne
+          apply h_zero
+          have : (Fin.castSucc q).val = q.val := rfl
+          rw [this]
+          exact hq_ne
+        have hih := foldl_finRange_isolate_rat i j hjlt
+          (fun q => f (Fin.castSucc q)) hzero_pre
+        rw [hih]
+        rfl
+
+/-- Dotting the `j`-th Gram-Schmidt basis row with the integer-cast `i`-th
+input row picks out the `(i, j)` Gram-Schmidt coefficient weighted by the
+squared norm of the basis row. Holds unconditionally: when the basis row is
+zero, both sides vanish (orthogonality + the `if`-branch in
+`coeffs_lower_projection`). -/
+theorem dot_basis_castRow_eq_coeffs_mul_normSq
+    (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
+    Matrix.dot ((basis b).row ⟨j, Nat.lt_trans hj hi⟩)
+        (Vector.map (fun x : Int => (x : Rat)) (b.row ⟨i, hi⟩)) =
+      GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ *
+        Vector.normSq ((basis b).row ⟨j, Nat.lt_trans hj hi⟩) := by
+  have hjlt : j < n := Nat.lt_trans hj hi
+  -- Expand `castIntRow b i` via `basis_decomposition`.
+  have hrow := castIntRow_decomposition b i hi
+  show Matrix.dot ((basis b).row ⟨j, hjlt⟩) (castIntRow b ⟨i, hi⟩) = _
+  rw [hrow]
+  rw [dot_add_right_rat]
+  -- First term: `dot basis[j] basis[i] = 0` by orthogonality (j ≠ i).
+  rw [basis_orthogonal b j i hjlt hi (Nat.ne_of_lt hj)]
+  rw [Rat.zero_add]
+  -- Second term: linearise the prefixCombination, then isolate the j-th index.
+  rw [dot_prefixCombination_right_rat (coeffs := coeffs b) (basisM := basis b)
+      (i := i) (hi := hi) (u := (basis b).row ⟨j, hjlt⟩)]
+  have h_zero_term : ∀ q : Fin i, q.val ≠ j →
+      GramSchmidt.entry (coeffs b) ⟨i, hi⟩
+            ⟨q.val, Nat.lt_trans q.isLt hi⟩ *
+          Matrix.dot ((basis b).row ⟨j, hjlt⟩)
+            ((basis b).row ⟨q.val, Nat.lt_trans q.isLt hi⟩) = 0 := by
+    intro q hqj
+    have hq_lt_n : q.val < n := Nat.lt_trans q.isLt hi
+    rw [basis_orthogonal b j q.val hjlt hq_lt_n fun h => hqj h.symm]
+    grind
+  rw [foldl_finRange_isolate_rat i j hj _ h_zero_term]
+  -- After isolation: c[i][j] * dot basis[j] basis[j] = c[i][j] * normSq basis[j].
+  rfl
 
 /-- Non-singular branch of the Cramer/Bareiss bridge: when the no-pivot
 Bareiss pass over the Gram matrix reaches column `j` without recording a

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -578,6 +578,225 @@ theorem adjacentSwap_gramDetNumerator_dvd (b : Matrix Int n m)
   exact ⟨((gramDet (Matrix.rowSwap b km1 k) k.val (Nat.le_of_lt k.isLt) : Nat) : Int),
     Int.mul_comm _ _⟩
 
+/-! ### Adjacent-swap scaled-coefficient identity for rows above the pivot
+
+For `i > k`, after swapping adjacent rows `km1, k` (with `km1.val + 1 = k.val`),
+the executable Bareiss determinant of the scaled-coefficient Cramer minor
+`scaledCoeffMatrix (rowSwap b km1 k) i km1` times the pivot Gram determinant
+`d_k = gramDet b k.val` equals the integer numerator
+
+  `d_{km1} * nu[i][k] + B * nu[i][km1]`
+
+where `B = nu[k][km1]`. The proof linearises `nu'[i][km1]` (as a `Rat`) through
+the basis identity `basis (rowSwap b km1 k) [km1] = basis b [k] + μ * basis b [km1]`
+(via `basis_rowSwap_adjacent_prev`), bridges `bareiss → nu'` via
+`scaledCoeffs_eq_scaledCoeffMatrix_bareiss`, and discharges with `ring`. -/
+theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
+    (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
+    (i : Fin n) (hki : k.val < i.val)
+    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    let km1 := GramSchmidt.prevRow k hk
+    let hkm1i : km1.val < i.val := by
+      dsimp [km1, GramSchmidt.prevRow]; omega
+    Hex.Matrix.bareiss (GramSchmidt.scaledCoeffMatrix
+        (Matrix.rowSwap b km1 k) i km1 hkm1i) *
+      ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) =
+      adjacentSwapScaledCoeffAbovePrevNumerator b k hk i := by
+  intro km1 hkm1i
+  -- Bridge bareiss → scaledCoeffs via the Mathlib-side identification.
+  rw [← scaledCoeffs_eq_scaledCoeffMatrix_bareiss
+      (Matrix.rowSwap b km1 k) i km1 hkm1i]
+  -- The remaining Int goal: `scaledCoeffs b' i km1 * d_k = numerator`.
+  -- Reduce to a rational identity.
+  apply intCast_rat_injective_local
+  -- Local abbreviations on the rational side.
+  have hkm1 : km1.val + 1 = k.val := by
+    dsimp [km1, GramSchmidt.prevRow]; omega
+  have hkm1k : km1.val < k.val := by omega
+  have hkm1_lt_i : km1.val < i.val := hkm1i
+  have hk_le_n : k.val ≤ n := Nat.le_of_lt k.isLt
+  have hkm1_le_n : km1.val ≤ n := Nat.le_of_lt km1.isLt
+  have hk1_le_n : k.val + 1 ≤ n := Nat.succ_le_of_lt k.isLt
+  have hkm1_succ_le : km1.val + 1 ≤ n := Nat.succ_le_of_lt km1.isLt
+  -- Rational shorthand: G, Nkm1, Nk, μ on the original basis.
+  set μ : Rat := GramSchmidt.entry (coeffs b) k km1 with hμ_def
+  set prev : Vector Rat m := (basis b).row km1 with hprev_def
+  set curr : Vector Rat m := (basis b).row k with hcurr_def
+  set G : Rat := gramSchmidtNormProduct b km1.val hkm1_le_n with hG_def
+  set Nkm1 : Rat := Vector.normSq prev with hNkm1_def
+  set Nk : Rat := Vector.normSq curr with hNk_def
+  -- Rational expressions for the Gram determinants.
+  have hdkm1_rat : (gramDet b km1.val hkm1_le_n : Rat) = G :=
+    gramDet_eq_prod_normSq_uncond b km1.val hkm1_le_n
+  have hdk_rat : (gramDet b k.val hk_le_n : Rat) = G * Nkm1 := by
+    have h_succ := gramDet_succ_rat b km1.val hkm1_succ_le
+    have hgd_eq :
+        gramDet b (km1.val + 1) hkm1_succ_le = gramDet b k.val hk_le_n :=
+      gramDet_subst_val b _ _ _ _ hkm1
+    rw [← hgd_eq, h_succ]
+  have hdkp1_rat : (gramDet b (k.val + 1) hk1_le_n : Rat) = G * Nkm1 * Nk := by
+    have h_succ := gramDet_succ_rat b k.val hk1_le_n
+    have hgnp_k_eq :
+        gramSchmidtNormProduct b k.val hk_le_n =
+          gramSchmidtNormProduct b (km1.val + 1) hkm1_succ_le :=
+      gramSchmidtNormProduct_subst_val b _ _ _ _ hkm1.symm
+    rw [h_succ, hgnp_k_eq,
+        gramSchmidtNormProduct_succ b km1.val hkm1_succ_le]
+  -- Basis orthogonality between curr and prev.
+  have horth : Matrix.dot curr prev = 0 :=
+    basis_orthogonal b k.val km1.val k.isLt km1.isLt (by omega)
+  -- New basis row at km1 of the swapped matrix.
+  have hbasis_swap :
+      (basis (Matrix.rowSwap b km1 k)).row km1 = curr + μ • prev :=
+    basis_rowSwap_adjacent_prev b km1 k hkm1
+  -- normSq of the new basis row at km1.
+  have hN'_eq : Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row km1) =
+      Nk + μ ^ 2 * Nkm1 := by
+    rw [hbasis_swap]
+    exact normSq_add_smul_orthogonal_rat curr prev μ horth
+  -- gramDet (rowSwap b km1 k) k.val = G * (Nk + μ^2 * Nkm1).
+  have hdprime_rat :
+      (gramDet (Matrix.rowSwap b km1 k) k.val hk_le_n : Rat) =
+        G * (Nk + μ ^ 2 * Nkm1) := by
+    have h_succ :=
+      gramDet_succ_rat (Matrix.rowSwap b km1 k) km1.val hkm1_succ_le
+    have hgd_eq :
+        gramDet (Matrix.rowSwap b km1 k) (km1.val + 1) hkm1_succ_le =
+          gramDet (Matrix.rowSwap b km1 k) k.val hk_le_n :=
+      gramDet_subst_val (Matrix.rowSwap b km1 k) _ _ _ _ hkm1
+    rw [← hgd_eq, h_succ,
+        gramSchmidtNormProduct_rowSwap_below b km1 k hkm1k]
+    show G * Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
+        ⟨km1.val, km1.isLt⟩) = G * (Nk + μ ^ 2 * Nkm1)
+    rw [hN'_eq]
+  -- B = d_k * μ.
+  have hB_rat :
+      ((GramSchmidt.entry (scaledCoeffs b) k km1 : Int) : Rat) = G * Nkm1 * μ := by
+    rw [scaledCoeffs_eq b k.val km1.val k.isLt hkm1k]
+    have hgd_eq :
+        gramDet b (km1.val + 1)
+            (Nat.succ_le_of_lt (Nat.lt_trans hkm1k k.isLt)) =
+          gramDet b k.val hk_le_n :=
+      gramDet_subst_val b _ _ _ _ hkm1
+    show (gramDet b (km1.val + 1) _ : Rat) *
+        GramSchmidt.entry (coeffs b) ⟨k.val, k.isLt⟩
+          ⟨km1.val, Nat.lt_trans hkm1k k.isLt⟩ = G * Nkm1 * μ
+    rw [hgd_eq, hdk_rat]
+  -- nu[i][k] = d_{k+1} * c[i][k] = G * Nkm1 * Nk * c[i][k]
+  have hnuik_rat :
+      ((GramSchmidt.entry (scaledCoeffs b) i k : Int) : Rat) =
+        G * Nkm1 * Nk * GramSchmidt.entry (coeffs b) i k := by
+    have heq := scaledCoeffs_eq b i.val k.val i.isLt hki
+    show ((GramSchmidt.entry (scaledCoeffs b) ⟨i.val, i.isLt⟩
+        ⟨k.val, Nat.lt_trans hki i.isLt⟩ : Int) : Rat) = _
+    rw [heq, hdkp1_rat]
+  -- nu[i][km1] = d_k * c[i][km1] = G * Nkm1 * c[i][km1]
+  have hnuikm1_rat :
+      ((GramSchmidt.entry (scaledCoeffs b) i km1 : Int) : Rat) =
+        G * Nkm1 * GramSchmidt.entry (coeffs b) i km1 := by
+    have heq := scaledCoeffs_eq b i.val km1.val i.isLt hkm1_lt_i
+    have hgd_eq :
+        gramDet b (km1.val + 1)
+            (Nat.succ_le_of_lt (Nat.lt_trans hkm1_lt_i i.isLt)) =
+          gramDet b k.val hk_le_n :=
+      gramDet_subst_val b _ _ _ _ hkm1
+    show ((GramSchmidt.entry (scaledCoeffs b) ⟨i.val, i.isLt⟩
+        ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ : Int) : Rat) = _
+    rw [heq, hgd_eq, hdk_rat]
+  -- For i > k, the i-th row of b' = rowSwap b km1 k equals the i-th row of b.
+  have hrow_b'_i : (Matrix.rowSwap b km1 k)[i] = b[i] := by
+    have hi_ne_km1 : (i : Fin n) ≠ km1 := fun h => by
+      have : i.val = km1.val := congrArg Fin.val h
+      omega
+    have hi_ne_k : (i : Fin n) ≠ k := fun h => by
+      have : i.val = k.val := congrArg Fin.val h
+      omega
+    exact rowSwap_row_eq_of_ne_int b km1 k i hi_ne_km1 hi_ne_k
+  have hcastRow_b'i :
+      Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k).row i) =
+        Vector.map (fun x : Int => (x : Rat)) (b.row i) := by
+    show Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k)[i]) = _
+    rw [hrow_b'_i]
+    rfl
+  -- Inner products of basis(b)[k] and basis(b)[km1] with cast(b.row i).
+  have hdotk : Matrix.dot curr
+        (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
+      GramSchmidt.entry (coeffs b) i k * Nk := by
+    have h := dot_basis_castRow_eq_coeffs_mul_normSq b i.val k.val i.isLt hki
+    show Matrix.dot ((basis b).row ⟨k.val, k.isLt⟩) _ = _
+    rw [h]
+  have hdotkm1 : Matrix.dot prev
+        (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
+      GramSchmidt.entry (coeffs b) i km1 * Nkm1 := by
+    have h := dot_basis_castRow_eq_coeffs_mul_normSq b i.val km1.val i.isLt hkm1_lt_i
+    show Matrix.dot ((basis b).row ⟨km1.val, km1.isLt⟩) _ = _
+    rw [h]
+  -- Inner product of basis(b')[km1] with cast(b'.row i) = c[i][k] * Nk + μ * c[i][km1] * Nkm1.
+  have hdot_b'_km1 :
+      Matrix.dot ((basis (Matrix.rowSwap b km1 k)).row km1)
+          (Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k).row i)) =
+        GramSchmidt.entry (coeffs b) i k * Nk +
+          μ * (GramSchmidt.entry (coeffs b) i km1 * Nkm1) := by
+    rw [hcastRow_b'i, hbasis_swap]
+    -- dot (curr + μ • prev) (cast b.row i)
+    --   = dot curr (cast b.row i) + μ * dot prev (cast b.row i)
+    rw [dot_add_left_rat, dot_smul_left_rat]
+    rw [hdotk, hdotkm1]
+  -- Key Rat identity: nu'[i][km1] = G * <basis(b')[km1], cast(b'.row i)>.
+  -- The proof uses scaledCoeffs_eq for b', plus dot_basis_castRow on b', plus
+  -- the fact that d_k(b') = G * |basis(b')[km1]|^2 so the cancellation is clean.
+  have hnu'_rat :
+      ((GramSchmidt.entry (scaledCoeffs (Matrix.rowSwap b km1 k)) i km1 : Int) : Rat) =
+        G * (GramSchmidt.entry (coeffs b) i k * Nk +
+            μ * (GramSchmidt.entry (coeffs b) i km1 * Nkm1)) := by
+    -- nu'[i][km1] = d_k(b') * c'[i][km1] = G * |basis(b')[km1]|^2 * c'[i][km1]
+    -- And c'[i][km1] * |basis(b')[km1]|^2 = dot basis(b')[km1] (cast b'.row i)
+    have hcoeff_normSq :
+        GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) i km1 *
+          Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row km1) =
+        Matrix.dot ((basis (Matrix.rowSwap b km1 k)).row km1)
+          (Vector.map (fun x : Int => (x : Rat))
+            ((Matrix.rowSwap b km1 k).row i)) := by
+      have h := dot_basis_castRow_eq_coeffs_mul_normSq
+        (Matrix.rowSwap b km1 k) i.val km1.val i.isLt hkm1_lt_i
+      show GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) ⟨i.val, i.isLt⟩
+            ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ *
+          Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
+            ⟨km1.val, km1.isLt⟩) = _
+      exact h.symm
+    -- Apply scaledCoeffs_eq for b'.
+    have heq := scaledCoeffs_eq (Matrix.rowSwap b km1 k) i.val km1.val i.isLt hkm1_lt_i
+    show ((GramSchmidt.entry (scaledCoeffs (Matrix.rowSwap b km1 k)) ⟨i.val, i.isLt⟩
+            ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ : Int) : Rat) = _
+    rw [heq]
+    -- The exponent km1.val + 1 in scaledCoeffs_eq matches k.val via hkm1.
+    have hgd_eq :
+        gramDet (Matrix.rowSwap b km1 k) (km1.val + 1)
+            (Nat.succ_le_of_lt (Nat.lt_trans hkm1_lt_i i.isLt)) =
+          gramDet (Matrix.rowSwap b km1 k) k.val hk_le_n :=
+      gramDet_subst_val (Matrix.rowSwap b km1 k) _ _ _ _ hkm1
+    rw [hgd_eq, hdprime_rat]
+    -- Now goal: G * (Nk + μ^2 * Nkm1) * c'[i][km1] = G * inner
+    -- Use: c'[i][km1] * (Nk + μ^2 * Nkm1) = inner  (via hcoeff_normSq + hN'_eq).
+    have hcoeff_inner :
+        GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k))
+            ⟨i.val, i.isLt⟩
+            ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ *
+          (Nk + μ ^ 2 * Nkm1) =
+        GramSchmidt.entry (coeffs b) i k * Nk +
+          μ * (GramSchmidt.entry (coeffs b) i km1 * Nkm1) := by
+      rw [← hN'_eq]
+      rw [hcoeff_normSq]
+      exact hdot_b'_km1
+    linear_combination G * hcoeff_inner
+  -- Combine all rational identities and discharge by ring.
+  -- Goal: ↑(nu'[i][km1] * d_k) = ↑(numerator)
+  -- numerator = d_{km1} * nu[i][k] + B * nu[i][km1]
+  unfold adjacentSwapScaledCoeffAbovePrevNumerator adjacentSwapPivotCoeff
+  push_cast
+  rw [hnu'_rat, hdk_rat, hdkm1_rat, hnuik_rat, hnuikm1_rat, hB_rat]
+  ring
+
 end GramSchmidt.Int
 
 end Hex

--- a/progress/20260518T001636Z_94af7fdf.md
+++ b/progress/20260518T001636Z_94af7fdf.md
@@ -1,0 +1,60 @@
+# Session 94af7fdf — HexGramSchmidt above-prev bordered-minor identity
+
+## Accomplished
+
+Closed #4853 by proving
+`Hex.GramSchmidt.Int.bareiss_scaledCoeffMatrix_rowSwap_above_prev` in
+`HexGramSchmidtMathlib/Update.lean`. The deliverable identity
+
+```
+bareiss(scaledCoeffMatrix (rowSwap b km1 k) i km1) * d_k = numerator
+```
+
+is the integer fraction-free shape for the `nu'[i][km1]` quotient update
+when `i > k`, where `numerator = d_{km1} * nu[i][k] + B * nu[i][km1]`
+and `B = nu[k][km1]`.
+
+The proof avoids the Desnanot-Jacobi route from the issue's outline.
+Instead it linearises `nu'[i][km1]` (as a `Rat`) by composing
+`scaledCoeffs_eq_scaledCoeffMatrix_bareiss` (bridge bareiss → scaledCoeffs),
+`scaledCoeffs_eq` (scaledCoeffs → gramDet * coeffs), the rational basis
+identity `basis (rowSwap b km1 k) [km1] = basis b [k] + μ * basis b [km1]`
+from `basis_rowSwap_adjacent_prev`, and the unconditional inner-product
+identity `<basis(b)[j], cast b.row i> = c[i][j] * |basis(b)[j]|^2` for
+`j < i`. The integer `hdet : gramDet b k ≠ 0` hypothesis is preserved in
+the signature but not used in the proof, because the rational-basis route
+discharges all branches uniformly (the `if`-branch in
+`coeffs_lower_projection_comm` is absorbed via the
+`d_k(b') = G * |basis(b')[km1]|^2` cancellation).
+
+Added one new public helper in `HexGramSchmidtMathlib/Int.lean`:
+
+- `dot_basis_castRow_eq_coeffs_mul_normSq`: for `j < i`,
+  `<basis(b)[j], cast b.row i> = c[i][j] * |basis(b)[j]|^2`
+  unconditionally. Uses `basis_decomposition` to expand the cast row, then
+  isolates the `r = j` term from the prefix-combination foldl via a new
+  private `foldl_finRange_isolate_rat` lemma.
+
+Exposed (removed `private` from) these general-utility helpers in
+`HexGramSchmidtMathlib/Int.lean` so the new theorem in Update can use them:
+`dot_add_left_rat`, `dot_smul_left_rat`, `dot_add_right_rat`,
+`dot_smul_right_rat`, `gramDet_eq_prod_normSq_uncond`, `gramDet_succ_rat`,
+`gramDet_subst_val`, `gramSchmidtNormProduct_succ`,
+`gramSchmidtNormProduct_subst_val`, `gramSchmidtNormProduct_rowSwap_below`,
+`normSq_add_smul_orthogonal_rat`. Also removed `private` from
+`GramSchmidt.dot_zero_of_dot_self_zero` in `HexGramSchmidt/Basic.lean`
+(unused in the final proof but exposed during exploration).
+
+## Current frontier
+
+`#4853` is done; the sibling above-curr case is `#4854` (still blocked on
+this PR).
+
+## Next step
+
+Land this PR, then a successor session can take `#4854` (above-curr) and
+`#4845` (assemble adjacent-swap scaled coefficient quotient formulas).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4853

Session: `94af7fdf-4e2a-48a7-b0d7-79a269e66c43`

dcef1192 feat: above-prev bordered-minor identity for adjacent swap

🤖 Prepared with Claude Code