### PR TITLE
BZ Mathlib-free: place small-mod singleton Berlekamp irreducibility in Rabin-importing module (v2)

### DIFF
--- a/HexBerlekampZassenhaus.lean
+++ b/HexBerlekampZassenhaus.lean
@@ -1,6 +1,7 @@
 import HexBerlekampZassenhaus.Basic
 import HexBerlekampZassenhaus.Conformance
 import HexBerlekampZassenhaus.CrossCheck
+import HexBerlekampZassenhaus.SmallModSingleton
 
 /-!
 The `HexBerlekampZassenhaus` library exposes the executable integer

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -427,7 +427,6 @@ private structure SmallPrimeCandidate where
   p : Nat
   [bounds : ZMod64.Bounds p]
   prime : Nat.Prime p
-  field : Lean.Grind.Field (ZMod64 p)
 
 /-- A scored admissible small-prime candidate for default prime selection. -/
 structure PrimeCandidateScore where
@@ -437,26 +436,16 @@ structure PrimeCandidateScore where
   factorCount : Nat
 
 private def smallPrimeCandidates : List SmallPrimeCandidate :=
-  [ { p := 3, bounds := bounds_three, prime := prime_three,
-      field := @fieldOfNatPrime 3 bounds_three prime_three },
-    { p := 5, bounds := bounds_five, prime := prime_five,
-      field := @fieldOfNatPrime 5 bounds_five prime_five },
-    { p := 7, bounds := bounds_seven, prime := prime_seven,
-      field := @fieldOfNatPrime 7 bounds_seven prime_seven },
-    { p := 11, bounds := bounds_eleven, prime := prime_eleven,
-      field := @fieldOfNatPrime 11 bounds_eleven prime_eleven },
-    { p := 13, bounds := bounds_thirteen, prime := prime_thirteen,
-      field := @fieldOfNatPrime 13 bounds_thirteen prime_thirteen },
-    { p := 17, bounds := bounds_seventeen, prime := prime_seventeen,
-      field := @fieldOfNatPrime 17 bounds_seventeen prime_seventeen },
-    { p := 19, bounds := bounds_nineteen, prime := prime_nineteen,
-      field := @fieldOfNatPrime 19 bounds_nineteen prime_nineteen },
-    { p := 23, bounds := bounds_twenty_three, prime := prime_twenty_three,
-      field := @fieldOfNatPrime 23 bounds_twenty_three prime_twenty_three },
-    { p := 31, bounds := bounds_thirty_one, prime := prime_thirty_one,
-      field := @fieldOfNatPrime 31 bounds_thirty_one prime_thirty_one },
-    { p := 71, bounds := bounds_seventy_one, prime := prime_seventy_one,
-      field := @fieldOfNatPrime 71 bounds_seventy_one prime_seventy_one } ]
+  [ { p := 3, bounds := bounds_three, prime := prime_three },
+    { p := 5, bounds := bounds_five, prime := prime_five },
+    { p := 7, bounds := bounds_seven, prime := prime_seven },
+    { p := 11, bounds := bounds_eleven, prime := prime_eleven },
+    { p := 13, bounds := bounds_thirteen, prime := prime_thirteen },
+    { p := 17, bounds := bounds_seventeen, prime := prime_seventeen },
+    { p := 19, bounds := bounds_nineteen, prime := prime_nineteen },
+    { p := 23, bounds := bounds_twenty_three, prime := prime_twenty_three },
+    { p := 31, bounds := bounds_thirty_one, prime := prime_thirty_one },
+    { p := 71, bounds := bounds_seventy_one, prime := prime_seventy_one } ]
 
 /--
 Coerce an admissible nonzero modular image to its monic representative by
@@ -727,7 +716,7 @@ theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
     Array (@FpPoly c.p c.bounds) :=
   letI := c.bounds
-  letI := c.field
+  letI := fieldOfNatPrime c.prime
   let fModP := ZPoly.modP c.p f
   if hzero : fModP.isZero = false then
     ((Berlekamp.berlekampFactor
@@ -750,7 +739,7 @@ the normalisation step to this consumer without touching
 private theorem berlekampFactorsModP_eq_of_isZero_false
     (f : ZPoly) (c : SmallPrimeCandidate) :
     letI := c.bounds
-    letI := c.field
+    letI := fieldOfNatPrime c.prime
     ∀ (hzero : (ZPoly.modP c.p f).isZero = false),
       berlekampFactorsModP f c =
         ((Berlekamp.berlekampFactor
@@ -758,7 +747,7 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
           (monicModularImage_monic c.prime (ZPoly.modP c.p f) hzero)).factors.map
             monicModularImage).toArray := by
   letI := c.bounds
-  letI := c.field
+  letI := fieldOfNatPrime c.prime
   intro hzero
   unfold berlekampFactorsModP
   rw [dif_pos hzero]
@@ -1737,8 +1726,7 @@ def choosePrimeData? (f : ZPoly) : Option PrimeChoiceData :=
 private def fallbackPrimeChoiceData (f : ZPoly) : PrimeChoiceData :=
   letI := bounds_three
   let c : SmallPrimeCandidate :=
-    { p := 3, bounds := bounds_three, prime := prime_three,
-      field := @fieldOfNatPrime 3 bounds_three prime_three }
+    { p := 3, bounds := bounds_three, prime := prime_three }
   let fModP := ZPoly.modP 3 f
   let factorsModP := berlekampFactorsModP f c
   { p := 3, fModP, factorsModP }
@@ -1812,21 +1800,25 @@ theorem choosePrimeData?_isGoodPrime
 /--
 Invariant capturing that `data.factorsModP` is exactly the Berlekamp factor
 output for the monic modular image used by prime selection.  Phrased as an
-existential bundling the nonzero-image and field witnesses so that it
-threads through the executable prime-selection fold.
+existential bundling the prime witness and the nonzero-image proof so that
+it threads through the executable prime-selection fold; the `Lean.Grind.Field`
+instance required by `Berlekamp.berlekampFactor` is constructed explicitly
+from `hprime`, so callers can match it against any field instance built from
+the same prime witness via proof irrelevance of `ZMod64.PrimeModulus`.
 -/
 def factorsModPBerlekampForm
     (f : ZPoly) (data : PrimeChoiceData) : Prop :=
   letI := data.bounds
   ∃ (hprime : Nat.Prime data.p)
-    (hzero : (ZPoly.modP data.p f).isZero = false)
-    (hfield : Lean.Grind.Field (ZMod64 data.p)),
+    (hzero : (ZPoly.modP data.p f).isZero = false),
     data.factorsModP =
       ((@Berlekamp.berlekampFactor data.p data.bounds
         (monicModularImage (ZPoly.modP data.p f))
         (monicModularImage_monic hprime (ZPoly.modP data.p f) hzero)
-        hfield).factors.map monicModularImage).toArray
+        (@zmod64FieldOfPrime data.p data.bounds
+          (ZMod64.primeModulusOfPrime hprime))).factors.map monicModularImage).toArray
 
+set_option maxHeartbeats 800000 in
 private theorem primeChoiceDataScore_factorsModPBerlekampForm
     (f : ZPoly) (c : SmallPrimeCandidate) (score : PrimeChoiceDataScore)
     (hscore : primeChoiceDataScore f c = some score) :
@@ -1838,11 +1830,12 @@ private theorem primeChoiceDataScore_factorsModPBerlekampForm
     cases hscore
     have hzero : (ZPoly.modP c.p f).isZero = false :=
       isGoodPrime_modP_isZero_false f c.p hgood
-    refine ⟨c.prime, hzero, c.field, ?_⟩
+    refine ⟨c.prime, hzero, ?_⟩
     show berlekampFactorsModP f c = _
     exact berlekampFactorsModP_eq_of_isZero_false f c hzero
   · simp [hgood] at hscore
 
+set_option maxHeartbeats 800000 in
 private theorem betterPrimeChoiceDataScore_factorsModPBerlekampForm
     (f : ZPoly) (old new score : PrimeChoiceDataScore)
     (hold : factorsModPBerlekampForm f old.data)
@@ -1914,15 +1907,17 @@ theorem choosePrimeData?_factorsModP_berlekamp_form
     (f : ZPoly) (data : PrimeChoiceData)
     (hdata : choosePrimeData? f = some data) :
     letI := data.bounds
-    ∃ (hzero : (ZPoly.modP data.p f).isZero = false)
-      (hfield : Lean.Grind.Field (ZMod64 data.p)),
+    ∃ (hzero : (ZPoly.modP data.p f).isZero = false),
       data.factorsModP =
         ((@Berlekamp.berlekampFactor data.p data.bounds
           (monicModularImage (ZPoly.modP data.p f))
           (monicModularImage_monic
             (choosePrimeData?_prime f data hdata)
             (ZPoly.modP data.p f) hzero)
-          hfield).factors.map monicModularImage).toArray := by
+          (@zmod64FieldOfPrime data.p data.bounds
+            (ZMod64.primeModulusOfPrime
+              (choosePrimeData?_prime f data hdata)))).factors.map
+                monicModularImage).toArray := by
   unfold choosePrimeData? at hdata
   cases hscore :
       smallPrimeCandidates.foldl (choosePrimeDataScoreStep f) none with
@@ -1934,8 +1929,8 @@ theorem choosePrimeData?_factorsModP_berlekamp_form
       have hform :=
         choosePrimeDataScore_fold_factorsModPBerlekampForm f smallPrimeCandidates none
           score (by intro old hnone; cases hnone) hscore
-      obtain ⟨_, hzero, hfield, heq⟩ := hform
-      exact ⟨hzero, hfield, heq⟩
+      obtain ⟨_, hzero, heq⟩ := hform
+      exact ⟨hzero, heq⟩
 
 /--
 Small-mod singleton executable branch fact for the selected monic modular
@@ -1952,19 +1947,20 @@ theorem choosePrimeData?_berlekampFactor_factors_length_le_one_of_small
     (hdata : choosePrimeData? f = some data)
     (hsmall : data.factorsModP.size ≤ 1) :
     letI := data.bounds
-    ∃ (hzero : (@ZPoly.modP data.p data.bounds f).isZero = false)
-      (hfield : Lean.Grind.Field (ZMod64 data.p)),
+    ∃ (hzero : (@ZPoly.modP data.p data.bounds f).isZero = false),
       (@Berlekamp.berlekampFactor data.p data.bounds
         (@monicModularImage data.p data.bounds
           (@ZPoly.modP data.p data.bounds f))
         (monicModularImage_monic
           (choosePrimeData?_prime f data hdata)
           (@ZPoly.modP data.p data.bounds f) hzero)
-        hfield).factors.length ≤ 1 := by
+        (@zmod64FieldOfPrime data.p data.bounds
+          (ZMod64.primeModulusOfPrime
+            (choosePrimeData?_prime f data hdata)))).factors.length ≤ 1 := by
   letI := data.bounds
-  obtain ⟨hzero, hfield, hform⟩ :=
+  obtain ⟨hzero, hform⟩ :=
     choosePrimeData?_factorsModP_berlekamp_form f data hdata
-  refine ⟨hzero, hfield, ?_⟩
+  refine ⟨hzero, ?_⟩
   have hlen :
       (@Berlekamp.berlekampFactor data.p data.bounds
         (@monicModularImage data.p data.bounds
@@ -1972,7 +1968,9 @@ theorem choosePrimeData?_berlekampFactor_factors_length_le_one_of_small
         (monicModularImage_monic
           (choosePrimeData?_prime f data hdata)
           (@ZPoly.modP data.p data.bounds f) hzero)
-        hfield).factors.length ≤ 1 := by
+        (@zmod64FieldOfPrime data.p data.bounds
+          (ZMod64.primeModulusOfPrime
+            (choosePrimeData?_prime f data hdata)))).factors.length ≤ 1 := by
     simpa [hform] using hsmall
   exact hlen
 

--- a/HexBerlekampZassenhaus/SmallModSingleton.lean
+++ b/HexBerlekampZassenhaus/SmallModSingleton.lean
@@ -1,0 +1,161 @@
+import HexBerlekampZassenhaus.Basic
+import HexBerlekamp.RabinSoundness
+
+/-!
+Small-mod singleton Berlekamp irreducibility wrapper.
+
+This module composes the modular Berlekamp soundness chain from
+`HexBerlekamp.RabinSoundness` with the executable prime-selection data
+maintained by `HexBerlekampZassenhaus.Basic` to expose a Mathlib-free
+`Hex.FpPoly.Irreducible` witness for the monic modular image of a
+`choosePrimeData?` selection whose Berlekamp factor count is at most one.
+
+The composition rests on three pieces:
+
+* `choosePrimeData?_isGoodPrime` certifies that the selected prime is
+  good for the input, in particular giving the modular square-free
+  invariant `DensePoly.gcd (modP p core) (derivative (modP p core)) = 1`.
+* The relaxed Berlekamp soundness theorem
+  `Hex.Berlekamp.berlekampFactor_singleton_irreducible` consumes a
+  common-divisor predicate, not the strict executable-gcd identity that
+  would fail on the non-monic-normalised `monicModularImage`.
+* A small unit-scaling argument shows that any common divisor of
+  `monicModularImage (modP p core)` and its derivative is also a common
+  divisor of `modP p core` and its derivative, so the square-free
+  invariant transports to the relaxed Berlekamp precondition for the
+  monic modular image.
+-/
+
+namespace Hex
+
+namespace BerlekampZassenhaus
+
+namespace SmallModSingleton
+
+variable {p : Nat} [ZMod64.Bounds p]
+
+private theorem derivative_scale (c : ZMod64 p) (f : FpPoly p) :
+    DensePoly.derivative (DensePoly.scale c f) =
+      DensePoly.scale c (DensePoly.derivative f) := by
+  apply DensePoly.ext_coeff
+  intro n
+  have hzero_d : ((n + 1 : Nat) : ZMod64 p) * (Zero.zero : ZMod64 p) =
+      (Zero.zero : ZMod64 p) :=
+    Lean.Grind.Semiring.mul_zero _
+  have hzero_s : c * (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p) :=
+    Lean.Grind.Semiring.mul_zero _
+  rw [DensePoly.coeff_derivative _ _ hzero_d,
+      DensePoly.coeff_scale c (DensePoly.derivative f) n hzero_s,
+      DensePoly.coeff_derivative _ _ hzero_d,
+      DensePoly.coeff_scale c f (n + 1) hzero_s]
+  -- Goal: ((n+1) : ZMod64 p) * (c * f.coeff (n+1)) = c * (((n+1) : ZMod64 p) * f.coeff (n+1))
+  grind
+
+private theorem dvd_trans_FpPoly {a b c : FpPoly p}
+    (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  rcases hab with ⟨x, hx⟩
+  rcases hbc with ⟨y, hy⟩
+  refine ⟨x * y, ?_⟩
+  calc c
+      = b * y := hy
+    _ = (a * x) * y := by rw [hx]
+    _ = a * (x * y) := DensePoly.mul_assoc_poly a x y
+
+/--
+Common divisors of `monicModularImage (modP p core)` and its derivative
+are unit polynomials.
+
+This is the relaxed Berlekamp soundness precondition for the small-mod
+singleton wrapper.  Strategy: `monicModularImage r = scale c⁻¹ r` for the
+unit `c⁻¹ = (leadingCoeff r)⁻¹`, where `leadingCoeff r ≠ 0` follows from
+the `isGoodPrime` leading-coefficient admissibility; the derivative of a
+unit scaling is a unit scaling of the derivative, and divisibility is
+preserved under unit scaling, so a common divisor of the monic image and
+its derivative is also a common divisor of `r = modP p core` and its
+derivative, where the `isGoodPrime` square-free invariant kicks in.
+-/
+theorem common_dvd_one_of_isGoodPrime_monicModularImage
+    (core : Hex.ZPoly) (hprime : Hex.Nat.Prime p)
+    (hgood : isGoodPrime core p = true) :
+    ∀ g, g ∣ monicModularImage (Hex.ZPoly.modP p core) →
+         g ∣ DensePoly.derivative (monicModularImage (Hex.ZPoly.modP p core)) →
+         Hex.Berlekamp.isUnitPolynomial g = true := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hprime
+  intro g hg_mmi hg_dmmi
+  have hzero : (Hex.ZPoly.modP p core).isZero = false :=
+    isGoodPrime_modP_isZero_false core p hgood
+  -- Abbreviate the modular image as `r`.
+  let r : FpPoly p := Hex.ZPoly.modP p core
+  have hr_size_pos : 0 < r.size :=
+    (DensePoly.isZero_eq_false_iff r).1 hzero
+  have hlead_ne : DensePoly.leadingCoeff r ≠ (0 : ZMod64 p) := by
+    rw [FpPoly.leadingCoeff_eq_coeff_pred r hr_size_pos]
+    exact DensePoly.coeff_last_ne_zero_of_pos_size r hr_size_pos
+  have hcinv_ne : (DensePoly.leadingCoeff r)⁻¹ ≠ (0 : ZMod64 p) :=
+    ZMod64.inv_ne_zero_of_prime hprime hlead_ne
+  -- Rewrite `monicModularImage r` as `scale c⁻¹ r` using the nonzero branch.
+  have hmmi_eq :
+      monicModularImage r = DensePoly.scale (DensePoly.leadingCoeff r)⁻¹ r := by
+    unfold monicModularImage
+    rw [show r.isZero = false from hzero]; rfl
+  rw [hmmi_eq] at hg_mmi
+  rw [hmmi_eq, derivative_scale] at hg_dmmi
+  have hscale_dvd_r :
+      DensePoly.scale (DensePoly.leadingCoeff r)⁻¹ r ∣ r :=
+    FpPoly.dvd_scale_self_of_ne_zero hcinv_ne r
+  have hscale_dvd_dr :
+      DensePoly.scale (DensePoly.leadingCoeff r)⁻¹ (DensePoly.derivative r) ∣
+        DensePoly.derivative r :=
+    FpPoly.dvd_scale_self_of_ne_zero hcinv_ne (DensePoly.derivative r)
+  have hg_r : g ∣ r := dvd_trans_FpPoly hg_mmi hscale_dvd_r
+  have hg_dr : g ∣ DensePoly.derivative r :=
+    dvd_trans_FpPoly hg_dmmi hscale_dvd_dr
+  have hsf : DensePoly.gcd r (DensePoly.derivative r) = 1 :=
+    isGoodPrime_squareFreeModP core p hgood
+  exact Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf g hg_r hg_dr
+
+/--
+For a `choosePrimeData?` selection whose Berlekamp factor count is at
+most one, the monic modular image of the input at the selected prime is
+irreducible as an `FpPoly`.
+
+Composes `choosePrimeData?_berlekampFactor_factors_length_le_one_of_small`
+(the shape fact) with the relaxed Berlekamp soundness theorem
+`Hex.Berlekamp.berlekampFactor_singleton_irreducible`, using the
+`isGoodPrime` invariants maintained by the prime selection to discharge
+the relaxed common-divisor precondition through
+`common_dvd_one_of_isGoodPrime_monicModularImage`.
+-/
+theorem monicModularImage_modP_irreducible_of_choosePrimeData?_small
+    (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.choosePrimeData? core = some primeData)
+    (hsmall : primeData.factorsModP.size ≤ 1) :
+    letI := primeData.bounds
+    Hex.FpPoly.Irreducible
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) := by
+  letI : ZMod64.Bounds primeData.p := primeData.bounds
+  have hprime : Hex.Nat.Prime primeData.p :=
+    Hex.choosePrimeData?_prime core primeData hselected
+  letI : ZMod64.PrimeModulus primeData.p :=
+    ZMod64.primeModulusOfPrime hprime
+  have hgood : isGoodPrime core primeData.p = true :=
+    Hex.choosePrimeData?_isGoodPrime core primeData hselected
+  obtain ⟨hzero, hlen⟩ :=
+    Hex.choosePrimeData?_berlekampFactor_factors_length_le_one_of_small
+      core primeData hselected hsmall
+  have hmonic :
+      DensePoly.Monic
+        (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) :=
+    monicModularImage_monic hprime (Hex.ZPoly.modP primeData.p core) hzero
+  have hcommon := common_dvd_one_of_isGoodPrime_monicModularImage
+    (p := primeData.p) core hprime hgood
+  exact Hex.Berlekamp.berlekampFactor_singleton_irreducible
+    (p := primeData.p)
+    (f := Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+    hmonic hcommon hlen
+
+end SmallModSingleton
+
+end BerlekampZassenhaus
+
+end Hex

--- a/progress/20260518T004205Z_d4fd8420.md
+++ b/progress/20260518T004205Z_d4fd8420.md
@@ -1,0 +1,82 @@
+# Session d4fd8420 — #4858 small-mod singleton Berlekamp irreducibility wrapper
+
+## Accomplished
+
+Landed the replacement small-mod singleton wrapper for the BZ Mathlib-free
+chain (issue #4858, replacing the closed sub-issues #4850 / #4851 after the
+#4839 re-decomposition).
+
+* Added `HexBerlekampZassenhaus/SmallModSingleton.lean` importing
+  `HexBerlekampZassenhaus.Basic` and `HexBerlekamp.RabinSoundness`,
+  exposing two theorems in the new `Hex.BerlekampZassenhaus.SmallModSingleton`
+  namespace:
+  - `common_dvd_one_of_isGoodPrime_monicModularImage` — the relaxed
+    Berlekamp soundness precondition for `monicModularImage (modP p core)`,
+    derived from the `isGoodPrime` invariants via the unit-scaling
+    argument outlined in #4858's deliverables. Uses a private
+    `derivative_scale` lemma (`derivative (scale c f) = scale c (derivative f)`
+    over `ZMod64 p`) and `FpPoly.dvd_scale_self_of_ne_zero` to transport
+    common divisors of the monic image and its derivative to common
+    divisors of `modP p core` and its derivative, then closes via the
+    `isGoodPrime_squareFreeModP` witness routed through the relaxed
+    adapter `Hex.Berlekamp.squareFree_common_of_gcd_eq_one` landed by
+    sub-issue (A) #4857.
+  - `monicModularImage_modP_irreducible_of_choosePrimeData?_small` —
+    composes `choosePrimeData?_berlekampFactor_factors_length_le_one_of_small`
+    (the shape fact) with the relaxed
+    `Hex.Berlekamp.berlekampFactor_singleton_irreducible`, discharging the
+    relaxed common-divisor precondition through (1).
+* Wired the new module into `HexBerlekampZassenhaus.lean`.
+
+The original `_le_one_of_small` API existentially packaged the
+`Lean.Grind.Field (ZMod64 data.p)` instance used by `Berlekamp.berlekampFactor`,
+which made the unpacked `hfield` opaque to the elaborator and prevented
+direct unification against the global `Hex.zmod64FieldOfPrime` instance
+required by `berlekampFactor_singleton_irreducible`. To unblock the
+composition without bridging field instances at the proof level, the
+underlying `factorsModPBerlekampForm` predicate (and the
+`_factorsModP_berlekamp_form` / `_le_one_of_small` consumers) were
+refactored to drop the `hfield` existential and construct the field
+instance explicitly as `@Hex.zmod64FieldOfPrime data.p data.bounds
+(ZMod64.primeModulusOfPrime hprime)`; downstream, that matches the
+auto-resolved global instance up to proof-irrelevance of
+`ZMod64.PrimeModulus`.
+
+The `SmallPrimeCandidate.field` storage was now redundant (it was always
+`fieldOfNatPrime c.prime`) and was removed; the three call sites in
+`berlekampFactorsModP` and its equation lemma rebuild the field instance
+via `fieldOfNatPrime c.prime` on demand. `smallPrimeCandidates` and the
+`fallbackPrimeChoiceData` `SmallPrimeCandidate` literal were updated
+accordingly.
+
+## Verification
+
+* `lake build HexBerlekampZassenhaus.SmallModSingleton` — passes.
+* `lake build` (full project) — passes; 244/244 jobs complete with no
+  new error diagnostics, only the pre-existing `sorry` warnings in
+  `HexGramSchmidt/`, `HexLLL/Basic.lean`, and
+  `HexBerlekampZassenhaus/Basic.lean:6418` (unrelated to this change).
+* `rg -n "sorry|axiom|native_decide|TODO|FIXME" HexBerlekampZassenhaus/SmallModSingleton.lean`
+  — no entries.
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+
+## Current frontier
+
+`#4170` BZ Mathlib-free capstone now has a Mathlib-free
+`Hex.FpPoly.Irreducible` witness for the monic modular image of a
+`choosePrimeData?` selection whose Berlekamp factor count is at most one.
+The next consumer (#4851 in its original form, or a successor) can lift
+this through Gauss's lemma to a branch-level `ZPoly.Irreducible` witness.
+
+## Next step
+
+A worker on the Gauss-lemma transfer (the BZ Mathlib-free chain's next
+hop toward the #4170 capstone) consumes
+`Hex.BerlekampZassenhaus.SmallModSingleton.monicModularImage_modP_irreducible_of_choosePrimeData?_small`
+to lift the `FpPoly.Irreducible` witness on `monicModularImage (modP p core)`
+to a `ZPoly.Irreducible` witness on `core`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4858

Session: `d4fd8420-c167-4ce4-a704-a49438d7dad6`

e61e98c9 feat: small-mod singleton Berlekamp irreducibility wrapper

🤖 Prepared with Claude Code