### PR TITLE
feat: Mathlib-free Gauss substrate (content_mul, modP_mul, admissible modP preservation)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1011,6 +1011,108 @@ theorem isGoodPrime_modP_isZero_false
           (show (ZPoly.modP p f).size ≤ f.size - 1 by omega)
       exact hcoeff_ne hzero_coeff
 
+/-- `leadingCoeffAdmissible` forces the source polynomial to have at least one
+stored coefficient: the empty coefficient array would force
+`leadingCoeffModP` to vanish. -/
+theorem leadingCoeffAdmissible_size_pos
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hadm : leadingCoeffAdmissible f p) :
+    0 < f.size := by
+  unfold leadingCoeffAdmissible at hadm
+  rcases Nat.eq_zero_or_pos f.size with hsize_zero | hfsize
+  · exfalso
+    apply hadm
+    have hcoeffs_zero : f.coeffs.size = 0 := by simpa [DensePoly.size] using hsize_zero
+    have hlead : DensePoly.leadingCoeff f = 0 := by
+      unfold DensePoly.leadingCoeff
+      rw [Array.back?_eq_getElem?]
+      simp [hcoeffs_zero]
+    unfold ZPoly.leadingCoeffModP
+    rw [hlead]
+    show (ZMod64.ofNat p (ZPoly.intModNat 0 p) : ZMod64 p) = 0
+    rfl
+  · exact hfsize
+
+/-- The top coefficient of `ZPoly.modP p f` matches `leadingCoeffModP` and is
+nonzero precisely when admissibility holds: the modular image keeps its last
+slot populated, so no trailing trim collapses below `f.size - 1`. -/
+private theorem coeff_modP_top_eq_leadingCoeffModP
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hfsize : 0 < f.size) :
+    (ZPoly.modP p f).coeff (f.size - 1) = ZPoly.leadingCoeffModP f p := by
+  rw [ZPoly.coeff_modP]
+  rw [← DensePoly.leadingCoeff_eq_coeff_last f hfsize]
+  rfl
+
+/-- Under `leadingCoeffAdmissible`, the modular image is nonzero. Companion of
+`isGoodPrime_modP_isZero_false` but with the weaker admissibility hypothesis
+(no square-free or `3 ≤ p` requirement). -/
+theorem modP_ne_zero_of_leadingCoeffAdmissible
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hadm : leadingCoeffAdmissible f p) :
+    ZPoly.modP p f ≠ 0 := by
+  have hfsize := leadingCoeffAdmissible_size_pos f p hadm
+  have hcoeff_ne : (ZPoly.modP p f).coeff (f.size - 1) ≠ 0 := by
+    rw [coeff_modP_top_eq_leadingCoeffModP f p hfsize]
+    exact hadm
+  intro hzero
+  apply hcoeff_ne
+  rw [hzero]
+  rfl
+
+/-- Under `leadingCoeffAdmissible`, the modular image has the same size as the
+input: the top coefficient survives reduction, so the trailing-zero trim does
+nothing. -/
+theorem size_modP_eq_of_leadingCoeffAdmissible
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hadm : leadingCoeffAdmissible f p) :
+    (ZPoly.modP p f).size = f.size := by
+  have hfsize := leadingCoeffAdmissible_size_pos f p hadm
+  have hcoeff_ne : (ZPoly.modP p f).coeff (f.size - 1) ≠ 0 := by
+    rw [coeff_modP_top_eq_leadingCoeffModP f p hfsize]
+    exact hadm
+  have hge : f.size ≤ (ZPoly.modP p f).size := by
+    rcases Nat.lt_or_ge (ZPoly.modP p f).size f.size with hlt | hge
+    · exfalso
+      apply hcoeff_ne
+      exact DensePoly.coeff_eq_zero_of_size_le _ (by omega)
+    · exact hge
+  have hle : (ZPoly.modP p f).size ≤ f.size := by
+    show (ZPoly.modP p f).coeffs.size ≤ f.size
+    unfold ZPoly.modP FpPoly.ofCoeffs
+    have h := DensePoly.size_ofCoeffs_le
+      (R := ZMod64 p)
+      ((List.range f.size).map
+        (fun i => ZMod64.ofNat p (ZPoly.intModNat (f.coeff i) p))).toArray
+    have hlen : ((List.range f.size).map
+        (fun i => ZMod64.ofNat p (ZPoly.intModNat (f.coeff i) p))).toArray.size =
+          f.size := by simp
+    simpa [DensePoly.size, hlen] using h
+  omega
+
+/-- Under `leadingCoeffAdmissible`, the modular image has the same `degree?` as
+the input. -/
+theorem degree?_modP_eq_of_leadingCoeffAdmissible
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hadm : leadingCoeffAdmissible f p) :
+    (ZPoly.modP p f).degree? = f.degree? := by
+  have hsize := size_modP_eq_of_leadingCoeffAdmissible f p hadm
+  unfold DensePoly.degree?
+  rw [hsize]
+
+/-- Under `leadingCoeffAdmissible`, the leading coefficient of the modular
+image matches `leadingCoeffModP`. -/
+theorem leadingCoeff_modP_eq_leadingCoeffModP_of_admissible
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hadm : leadingCoeffAdmissible f p) :
+    DensePoly.leadingCoeff (ZPoly.modP p f) = ZPoly.leadingCoeffModP f p := by
+  have hfsize := leadingCoeffAdmissible_size_pos f p hadm
+  have hsize := size_modP_eq_of_leadingCoeffAdmissible f p hadm
+  have hmod_size_pos : 0 < (ZPoly.modP p f).size := by omega
+  rw [DensePoly.leadingCoeff_eq_coeff_last _ hmod_size_pos]
+  rw [hsize]
+  exact coeff_modP_top_eq_leadingCoeffModP f p hfsize
+
 /--
 Data produced by modular prime selection: the selected prime, the image of the
 input polynomial over that prime field, and its modular factors.

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -578,6 +578,36 @@ into manageable pieces. -/
       (ZPoly.congr_symm _ _ _ hsum))
     (FpPoly.modP_liftToZ (p := p) (ZPoly.modP p f + ZPoly.modP p g))
 
+/-- `ZPoly.modP p` distributes over multiplication: the canonical mod-`p`
+residue of a product is the product of residues. Multiplicative companion
+of `modP_add`; the Mathlib-free Gauss-transfer chain consumes this to
+expose `modP p (f * g)` in its factored form. -/
+@[simp] theorem modP_mul
+    (p : Nat) [ZMod64.Bounds p] (f g : ZPoly) :
+    ZPoly.modP p (f * g) = ZPoly.modP p f * ZPoly.modP p g := by
+  have hliftMul :
+      ZPoly.congr
+        (FpPoly.liftToZ (ZPoly.modP p f * ZPoly.modP p g))
+        (FpPoly.liftToZ (ZPoly.modP p f) * FpPoly.liftToZ (ZPoly.modP p g)) p :=
+    liftToZ_mul_congr p (ZPoly.modP p f) (ZPoly.modP p g)
+  have hpieces :
+      ZPoly.congr
+        (FpPoly.liftToZ (ZPoly.modP p f) * FpPoly.liftToZ (ZPoly.modP p g))
+        (f * g) p :=
+    ZPoly.congr_mul _ _ _ _ p
+      (FpPoly.congr_liftToZ_modP (p := p) f)
+      (FpPoly.congr_liftToZ_modP (p := p) g)
+  have hprod :
+      ZPoly.congr
+        (FpPoly.liftToZ (ZPoly.modP p f * ZPoly.modP p g))
+        (f * g) p :=
+    ZPoly.congr_trans _ _ _ p hliftMul hpieces
+  exact Eq.trans
+    (ZPoly.modP_eq_of_congr p (f * g)
+      (FpPoly.liftToZ (ZPoly.modP p f * ZPoly.modP p g))
+      (ZPoly.congr_symm _ _ _ hprod))
+    (FpPoly.modP_liftToZ (p := p) (ZPoly.modP p f * ZPoly.modP p g))
+
 /-- `modP p` reduces a `liftToZ`-on-the-left product to the `FpPoly`-side
 factor times the `modP` of the integer side: `modP p (liftToZ r · h) =
 r · modP p h`. Companion of `modP_lift_mul_right`; consumed by the linear

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -5335,6 +5335,67 @@ theorem content_mul_of_primitive (p q : DensePoly Int)
     have hr_ge : 2 ≤ r := hr.1
     omega
 
+/-- Gauss's lemma on content (multiplicative form): the content of a product
+of integer polynomials is the product of their contents. Strengthens
+`content_mul_of_primitive` to non-primitive inputs by decomposing each
+factor into its content and primitive part. -/
+theorem content_mul (p q : DensePoly Int) :
+    content (p * q) = content p * content q := by
+  by_cases hcp : content p = 0
+  · have hp_zero : p = 0 := by
+      apply ext_coeff
+      intro n
+      have hcnp : contentNat p = 0 := by
+        have h' : Int.ofNat (contentNat p) = Int.ofNat 0 := hcp
+        exact Int.ofNat_inj.mp h'
+      have hdvd : (contentNat p : Int) ∣ p.coeff n := contentNat_dvd_coeff p n
+      rw [hcnp] at hdvd
+      rcases hdvd with ⟨k, hk⟩
+      rw [coeff_zero]
+      simpa using hk
+    rw [hp_zero, zero_mul, content_zero, Int.zero_mul]
+  by_cases hcq : content q = 0
+  · have hq_zero : q = 0 := by
+      apply ext_coeff
+      intro n
+      have hcnq : contentNat q = 0 := by
+        have h' : Int.ofNat (contentNat q) = Int.ofNat 0 := hcq
+        exact Int.ofNat_inj.mp h'
+      have hdvd : (contentNat q : Int) ∣ q.coeff n := contentNat_dvd_coeff q n
+      rw [hcnq] at hdvd
+      rcases hdvd with ⟨k, hk⟩
+      rw [coeff_zero]
+      simpa using hk
+    have hpzero : p * (0 : DensePoly Int) = 0 := by
+      rw [mul_comm_poly p (0 : DensePoly Int)]
+      exact zero_mul p
+    rw [hq_zero, hpzero, content_zero, Int.mul_zero]
+  have hp_prim : content (primitivePart p) = 1 := primitivePart_primitive p hcp
+  have hq_prim : content (primitivePart q) = 1 := primitivePart_primitive q hcq
+  have hpq_prim : content (primitivePart p * primitivePart q) = 1 :=
+    content_mul_of_primitive _ _ hp_prim hq_prim
+  have hpq_eq :
+      p * q = scale (content p * content q) (primitivePart p * primitivePart q) := by
+    apply ext_coeff
+    intro n
+    have hp_decomp : p = scale (content p) (primitivePart p) :=
+      (content_mul_primitivePart p).symm
+    have hq_decomp : q = scale (content q) (primitivePart q) :=
+      (content_mul_primitivePart q).symm
+    rw [show (p * q).coeff n = ((scale (content p) (primitivePart p)) *
+          (scale (content q) (primitivePart q))).coeff n from by
+        rw [← hp_decomp, ← hq_decomp]]
+    rw [coeff_scale_mul_scale]
+    rw [coeff_scale (content p * content q) (primitivePart p * primitivePart q) n
+      (Int.mul_zero _)]
+  rw [hpq_eq, content_scale_int, hpq_prim, Int.mul_one]
+  -- The product `content p * content q` is nonneg (both are `Int.ofNat`-coerced),
+  -- so its `natAbs` round-trip equals itself.
+  show Int.ofNat (content p * content q).natAbs = content p * content q
+  show Int.ofNat (Int.ofNat (contentNat p) * Int.ofNat (contentNat q)).natAbs =
+    Int.ofNat (contentNat p) * Int.ofNat (contentNat q)
+  rfl
+
 /-- Gauss's lemma on content (divisibility form): if a natural number `d`
 divides every coefficient of `p * q`, then it divides `contentNat p *
 contentNat q`. This is the divisibility witness needed by the McCoy row

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -690,6 +690,12 @@ theorem primitive_mul (p q : ZPoly)
     Primitive (p * q) := by
   simpa [Primitive, content] using DensePoly.content_mul_of_primitive p q hp hq
 
+/-- `ZPoly`-level wrapper for `DensePoly.content_mul`: the content of a
+product of integer polynomials is the product of their contents. -/
+theorem content_mul (p q : ZPoly) :
+    content (p * q) = content p * content q := by
+  simpa [content] using DensePoly.content_mul p q
+
 /-- The top coefficient of a product of nonzero integer polynomials is the
 product of their top coefficients. -/
 theorem coeff_mul_top (p q : ZPoly)

--- a/progress/20260518T012858Z_b6950cbb.md
+++ b/progress/20260518T012858Z_b6950cbb.md
@@ -1,0 +1,88 @@
+# Session b6950cbb — #4851 Mathlib-free Gauss substrate (deliverables 1-3) and D4+D5 decomposition
+
+## Accomplished
+
+Landed the Mathlib-free substrate for the small-mod singleton Gauss
+transfer chain (sub-issues A1-A3 of the worker-led #4851 decomposition):
+
+* `HexPoly/Euclid.lean`: added `DensePoly.content_mul`
+  (`content (p * q) = content p * content q`) directly after
+  `content_mul_of_primitive`. Reduces to `content_mul_of_primitive` on
+  the primitive parts, decomposes via `content_mul_primitivePart`, and
+  closes the `Int.ofNat ⋯ .natAbs` round-trip by definitional equality.
+
+* `HexPolyZ/Basic.lean`: added `ZPoly.content_mul` as a thin wrapper.
+
+* `HexHensel/Linear.lean`: added `Hex.ZPoly.modP_mul` (`@[simp]`,
+  matching the `modP_add` companion) Mathlib-free, mirroring the
+  Mathlib-side `HexBerlekampZassenhausMathlib.modP_mul` proof but
+  consuming only Mathlib-free `liftToZ_mul_congr`, `congr_mul`,
+  `congr_liftToZ_modP`, `modP_eq_of_congr`, `modP_liftToZ`.
+
+* `HexBerlekampZassenhaus/Basic.lean`: added five `modP` preservation
+  lemmas keyed off `leadingCoeffAdmissible`:
+  - `leadingCoeffAdmissible_size_pos`
+  - `modP_ne_zero_of_leadingCoeffAdmissible`
+  - `size_modP_eq_of_leadingCoeffAdmissible`
+  - `degree?_modP_eq_of_leadingCoeffAdmissible`
+  - `leadingCoeff_modP_eq_leadingCoeffModP_of_admissible`
+
+  These give the Mathlib-free `ZPoly`/`FpPoly` analog of the
+  Mathlib-side `natDegree_map_intCast_zmod_eq_of_leadingCoeffModP_ne_zero`
+  bridge. The shared `coeff_modP_top_eq_leadingCoeffModP` private helper
+  factors out the common "modular top coefficient = leadingCoeffModP"
+  computation used by all five.
+
+The proof of `size_modP_eq_of_leadingCoeffAdmissible` derives the
+upper bound by unfolding `ZPoly.modP` to `FpPoly.ofCoeffs` of a
+`(List.range f.size).map ⋯ .toArray` and applying the existing
+`DensePoly.size_ofCoeffs_le`. The lower bound is the top-coefficient
+survives-reduction step that was already inlined in
+`isGoodPrime_modP_isZero_false`, now lifted to a reusable lemma.
+
+## Decomposition
+
+The remaining deliverables D4 (Mathlib-free Gauss reduction-mod-`p`
+transfer at `ZPoly.Irreducible` level) and D5 (small-mod singleton
+branch composition) are tightly coupled and substantially larger than
+the substrate. Decomposed into:
+
+* #4884 — Gauss reduction-mod-`p` transfer
+  `ZPoly.Irreducible_of_modP_irreducible_of_primitive_of_admissible`
+  (ports `irreducible_of_isPrimitive_of_irreducible_map_intCast_zmod`).
+* #4885 — branch-level composition
+  `squareFreeCore_irreducible_of_small_mod_singleton` (depends on
+  #4884), consumed by #4825.
+
+Parent #4851 is being marked `replan` via `coordination create-pr
+--partial` with a `Decomposed into #4884, #4885` breadcrumb.
+
+The D4 sub-issue body documents the extra `1 < f.size` non-constancy
+precondition needed because the executable `FpPoly.Irreducible` (defined
+as "every factorization has a `degree? = some 0` factor") does not
+exclude the constant case — unlike Mathlib's `Irreducible` which has
+`not_isUnit` structurally built in.
+
+## Verification
+
+* `lake build HexBerlekampZassenhaus` — passes (pre-existing
+  `sorry` warnings unchanged).
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* `git diff origin/main` filtered for `sorry|axiom|native_decide|TODO|FIXME`
+  on additions: no new entries.
+
+## Current frontier
+
+Substrate is in place. #4884 (Gauss transfer) is the next planner pick;
+once landed, #4885 unblocks and feeds #4825 the small-mod singleton
+branch theorem.
+
+## Next step
+
+A worker claims #4884 and ports the Mathlib-side Gauss transfer to the
+executable `ZPoly`/`FpPoly` layer using the substrate landed here.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Partial progress on #4851

Session: `b6950cbb-a29b-4a61-aae9-c52134287d1a`

d12ac895 chore: progress entry for #4851 substrate (deliverables 1-3 + D4/D5 decomposition)
48bf0108 feat: add modP preservation lemmas under leadingCoeffAdmissible
3587fbec feat: add Mathlib-free ZPoly.content_mul and ZPoly.modP_mul
2fa9664b feat: add Mathlib-free DensePoly.content_mul (Gauss content lemma)

🤖 Prepared with Claude Code