### PR TITLE
BZMathlib: abstract-bound siblings of A2 unscaled recovery theorems

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4033,23 +4033,25 @@ private theorem densePoly_scale_one_int (f : Hex.ZPoly) :
   rw [Hex.DensePoly.coeff_scale (1 : Int) f n (by simp)]
   simp
 
-/--
-Under a monic core hypothesis, the scaled recovery theorem identifies the
-unscaled executable recombination candidate with the represented integer
-factor.  This is the core recovery statement; the older
-`recombinationCandidate_eq_factor_of_recovery` wrapper also accepts the
-executable record-filter hypothesis needed by some callers.
--/
-theorem recombinationCandidate_eq_factor_of_recovery_of_monic_core
+/-- Abstract-bound variant of
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core`: takes
+`B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  The proof mirrors
+the core-shape original but invokes
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+in place of the core-shape recovery theorem. -/
+theorem recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound
     {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
-    (hcore_ne : core ≠ 0)
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (_hcore_ne : core ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
-    (hdvd : factor ∣ core)
     (hfactor_prim : Hex.ZPoly.content factor = 1)
     (hfactor_norm : Hex.normalizeFactorSign factor = factor)
     (_hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
+    (hprecision : 2 * B' < d.p ^ d.k) :
     recombinationCandidate d S = factor := by
   have hlead : Hex.DensePoly.leadingCoeff core = (1 : Int) := by
     simpa [Hex.DensePoly.Monic] using hcore_monic
@@ -4061,8 +4063,8 @@ theorem recombinationCandidate_eq_factor_of_recovery_of_monic_core
   have hcenter :
       Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k) = factor := by
     have h :=
-      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-        hcore_ne hdvd hrep hprecision
+      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound
+        B' hvalid hrep hprecision
     rwa [hscaled] at h
   unfold recombinationCandidate
   rw [polyProduct_liftedSubsetSelectedList_eq_liftedFactorProduct, hcenter]
@@ -4076,7 +4078,62 @@ theorem recombinationCandidate_eq_factor_of_recovery_of_monic_core
 /--
 Under a monic core hypothesis, the scaled recovery theorem identifies the
 unscaled executable recombination candidate with the represented integer
+factor.  This is the core recovery statement; the older
+`recombinationCandidate_eq_factor_of_recovery` wrapper also accepts the
+executable record-filter hypothesis needed by some callers.
+
+This is a thin wrapper over
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`
+that instantiates `B' := defaultFactorCoeffBound core` and discharges
+`hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
+-/
+theorem recombinationCandidate_eq_factor_of_recovery_of_monic_core
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hdvd : factor ∣ core)
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (_hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
+    recombinationCandidate d S = factor :=
+  recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hcore_monic hfactor_prim hfactor_norm _hirr hrep hprecision
+
+/-- Abstract-bound variant of
+`recombinationCandidate_eq_factor_of_recovery`: takes `B' : Nat`,
+`hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Delegates to
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`. -/
+theorem recombinationCandidate_eq_factor_of_recovery_of_bound
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (_hcore_record : Hex.shouldRecordPolynomialFactor core = true)
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (_hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
+    recombinationCandidate d S = factor :=
+  recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound
+    B' hvalid hcore_ne hcore_monic hfactor_prim hfactor_norm _hirr hrep hprecision
+
+/--
+Under a monic core hypothesis, the scaled recovery theorem identifies the
+unscaled executable recombination candidate with the represented integer
 factor.
+
+This is a thin wrapper over
+`recombinationCandidate_eq_factor_of_recovery_of_bound` that instantiates
+`B' := defaultFactorCoeffBound core` and discharges `hvalid` via
+`defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
 -/
 theorem recombinationCandidate_eq_factor_of_recovery
     {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
@@ -4090,8 +4147,38 @@ theorem recombinationCandidate_eq_factor_of_recovery
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
     recombinationCandidate d S = factor :=
-  recombinationCandidate_eq_factor_of_recovery_of_monic_core
-    hcore_ne hcore_monic hdvd hfactor_prim hfactor_norm _hirr hrep hprecision
+  recombinationCandidate_eq_factor_of_recovery_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hcore_monic _hcore_record hfactor_prim hfactor_norm _hirr hrep hprecision
+
+/-- Abstract-bound variant of
+`recombinationCandidate_eq_factor_of_henselSubsetCorrespondence`: takes
+`B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Delegates to
+`recombinationCandidate_eq_factor_of_recovery_of_bound`. -/
+theorem recombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound
+    {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {d : Hex.LiftData} {admissiblePrime successfulLift : Prop}
+    {S : LiftedFactorSubset d}
+    (_h :
+      HenselSubsetCorrespondenceHypotheses core B primeData d
+        admissiblePrime successfulLift)
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hcore_record : Hex.shouldRecordPolynomialFactor core = true)
+    (hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
+    recombinationCandidate d S = factor :=
+  recombinationCandidate_eq_factor_of_recovery_of_bound
+    B' hvalid hcore_ne hcore_monic hcore_record hfactor_prim hfactor_norm hirr
+    hrep hprecision
 
 /--
 Hensel-correspondence wrapper for the monic-core recovery theorem.
@@ -4100,6 +4187,11 @@ Once a proof-side subset is known to represent an irreducible integer divisor
 at the Hensel lift, the executable recombination candidate is exactly that
 factor under the monic/primitive/sign-normalised hypotheses required by the
 centered-lift recovery bound.
+
+This is a thin wrapper over
+`recombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound`
+that instantiates `B' := defaultFactorCoeffBound core` and discharges
+`hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
 -/
 theorem recombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
@@ -4118,9 +4210,11 @@ theorem recombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
     recombinationCandidate d S = factor :=
-  recombinationCandidate_eq_factor_of_recovery
-    hcore_ne hcore_monic hcore_record hdvd hfactor_prim hfactor_norm hirr
-    hrep hprecision
+  recombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound
+    _h
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hcore_monic hcore_record hirr hfactor_prim hfactor_norm hrep hprecision
 
 /--
 Primitive non-monic recovery substrate: the scaled recombination candidate

--- a/progress/20260518T013926Z_3d51c3a6.md
+++ b/progress/20260518T013926Z_3d51c3a6.md
@@ -1,0 +1,74 @@
+# Session 3d51c3a6 — #4883 BZMathlib unscaled abstract-bound recovery siblings
+
+## Accomplished
+
+Added the three `_of_bound` siblings of the unscaled A2 recovery chain to
+`HexBerlekampZassenhausMathlib/Basic.lean`, each taking an abstract bound
+`B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape precision
+constraint:
+
+* `recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`
+  — proof mirrors the original, invoking
+  `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+  (landed in #4878) in place of the core-shape recovery theorem. The
+  `hcore_ne` parameter is preserved in the signature for API symmetry
+  with downstream wrappers, underscored as unused per project convention.
+* `recombinationCandidate_eq_factor_of_recovery_of_bound` — one-line
+  delegation to (1), keeping the `_hcore_record` shim.
+* `recombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound`
+  — one-line delegation to (2).
+
+The three existing
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core`,
+`recombinationCandidate_eq_factor_of_recovery`, and
+`recombinationCandidate_eq_factor_of_henselSubsetCorrespondence` are
+rewired as thin wrappers that instantiate
+`B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharge `hvalid`
+via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`. Existing
+signatures and statements are unchanged; only bodies and docstrings
+are updated.
+
+This closes Gap 3 for the monic-core path that the recursive coverage
+proof for `recombinationSearchModAux_*` still reaches in the interim
+before the call-site swap chain (#4870 / #4881) retires the unscaled
+chain from the exhaustive arm.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — fails with the same
+  15 errors present on `origin/main`, all shifted by +94 lines (matching
+  the insertion size). My insertion area (lines 4036–4220) compiles
+  cleanly; the first error in my branch is at line 4690 (= main's 4596
+  + 94). No new failures introduced.
+* `lake build HexBerlekampZassenhausMathlib` — same set of pre-existing
+  failures only.
+* `lake build HexBerlekampZassenhaus` — passes (pre-existing `sorry` at
+  line 6434 and `simpa` lint at line 2289 only).
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean`
+  filtered for `sorry|axiom|native_decide|TODO|FIXME` on additions:
+  no new entries.
+
+## Current frontier
+
+The scaled siblings of the same recovery chain are tracked by #4882
+(claimed by a parallel agent). After both #4882 and #4883 land, the
+follow-up issues will propagate the `_of_bound` abstraction into
+`recombinationSearchModAux_*` and `scaledRecombinationSearchModAux_*`,
+then `exhaustiveCoreFactorsWithBound_coverage_*`, then the umbrella
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` —
+mirroring the single-layer-at-a-time pattern established by #4873 /
+#4878.
+
+## Next step
+
+A planner picks up the next propagation layer (recursive coverage
+proofs) once both sibling issues for the recovery layer have merged.
+
+## Blockers
+
+None for this scope. The pre-existing `Basic.lean` build failures on
+`origin/main` (timeouts, two `cases` failures, four unknown-constant
+kernel errors, two `sorry`s) are out of scope for this issue.


### PR DESCRIPTION
Closes #4883

Session: `3d51c3a6-737d-4702-ac55-4203b14d295b`

021fee1a feat: add abstract-bound siblings of A2 unscaled recovery theorems (#4883)

🤖 Prepared with Claude Code