### PR TITLE
BZMathlib: abstract-bound siblings of A2 scaled recovery theorems

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4122,6 +4122,33 @@ theorem recombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     hcore_ne hcore_monic hcore_record hdvd hfactor_prim hfactor_norm hirr
     hrep hprecision
 
+/-- Abstract-bound variant of
+`scaledRecombinationCandidate_eq_factor_of_recovery`: takes `B' : Nat`,
+`hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  The body mirrors
+the original but invokes the `_of_bound` centered-lift recovery theorem
+instead of the core-shape one.  The original core-shape theorem is a
+wrapper around this variant. -/
+theorem scaledRecombinationCandidate_eq_factor_of_recovery_of_bound
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
+    scaledRecombinationCandidate core d S = factor := by
+  unfold scaledRecombinationCandidate
+  rw [centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound
+        B' hvalid hrep hprecision]
+  have hprimitive : Hex.ZPoly.primitivePart factor = factor :=
+    Hex.ZPoly.primitivePart_eq_self_of_primitive factor
+      (by simpa [Hex.ZPoly.Primitive] using hfactor_prim)
+  rw [hprimitive]
+  exact hfactor_norm
+
 /--
 Primitive non-monic recovery substrate: the scaled recombination candidate
 equals the represented integer `factor` under primitive/sign-normalised
@@ -4141,6 +4168,11 @@ Downstream consumers (#4644, #4646, #4647, #4648) call this in place of the
 monic-core recovery when the core hypotheses are
 `core ≠ 0 ∧ Primitive core ∧ 0 < leadingCoeff core`; the primitive/sign
 hypotheses on `factor` are supplied by their primitive-factor packaging step.
+
+This is a thin wrapper over
+`scaledRecombinationCandidate_eq_factor_of_recovery_of_bound` that
+instantiates `B' := defaultFactorCoeffBound core` and discharges
+`hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
 -/
 theorem scaledRecombinationCandidate_eq_factor_of_recovery
     {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
@@ -4150,15 +4182,36 @@ theorem scaledRecombinationCandidate_eq_factor_of_recovery
     (hfactor_norm : Hex.normalizeFactorSign factor = factor)
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
-    scaledRecombinationCandidate core d S = factor := by
-  unfold scaledRecombinationCandidate
-  rw [centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-        hcore_ne hdvd hrep hprecision]
-  have hprimitive : Hex.ZPoly.primitivePart factor = factor :=
-    Hex.ZPoly.primitivePart_eq_self_of_primitive factor
-      (by simpa [Hex.ZPoly.Primitive] using hfactor_prim)
-  rw [hprimitive]
-  exact hfactor_norm
+    scaledRecombinationCandidate core d S = factor :=
+  scaledRecombinationCandidate_eq_factor_of_recovery_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hfactor_prim hfactor_norm hrep hprecision
+
+/-- Abstract-bound variant of
+`scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence`:
+takes `B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Body is a
+one-line delegation to
+`scaledRecombinationCandidate_eq_factor_of_recovery_of_bound`. -/
+theorem scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound
+    {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {d : Hex.LiftData} {admissiblePrime successfulLift : Prop}
+    {S : LiftedFactorSubset d}
+    (_h :
+      HenselSubsetCorrespondenceHypotheses core B primeData d
+        admissiblePrime successfulLift)
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
+    scaledRecombinationCandidate core d S = factor :=
+  scaledRecombinationCandidate_eq_factor_of_recovery_of_bound
+    B' hvalid hcore_ne hfactor_prim hfactor_norm hrep hprecision
 
 /--
 Hensel-correspondence wrapper for the primitive-core scaled recovery theorem.
@@ -4169,6 +4222,11 @@ proof-side subset is known to represent an irreducible integer divisor at the
 Hensel lift, the *scaled* recombination candidate is exactly that factor under
 the primitive/sign-normalised hypotheses required by the centered-lift
 recovery bound.
+
+This is a thin wrapper over
+`scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound`
+that instantiates `B' := defaultFactorCoeffBound core` and discharges
+`hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
 -/
 theorem scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
@@ -4184,8 +4242,10 @@ theorem scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
     scaledRecombinationCandidate core d S = factor :=
-  scaledRecombinationCandidate_eq_factor_of_recovery
-    hcore_ne hdvd hfactor_prim hfactor_norm hrep hprecision
+  scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound
+    _h (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hfactor_prim hfactor_norm hrep hprecision
 
 /--
 A monic integer polynomial automatically has primitive content and is its own

--- a/progress/20260518T014007Z_6a8207bf.md
+++ b/progress/20260518T014007Z_6a8207bf.md
@@ -1,0 +1,51 @@
+# Progress: BZMathlib A2 scaled-side `_of_bound` propagation (#4882)
+
+## Accomplished
+
+Added two abstract-bound siblings in `HexBerlekampZassenhausMathlib/Basic.lean`
+alongside their existing core-shape counterparts, and rewired the originals as
+thin wrappers:
+
+* `scaledRecombinationCandidate_eq_factor_of_recovery_of_bound` — takes
+  `B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+  `hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+  `defaultFactorCoeffBound core` precision constraint; drops `hdvd`. Body
+  mirrors the original but routes through
+  `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+  (the PR #4878 abstract-bound variant).
+* `scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence_of_bound`
+  — same shape; body is a one-line delegation to (1).
+* `scaledRecombinationCandidate_eq_factor_of_recovery` and
+  `scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence` keep
+  their signatures and statements; bodies now delegate to the new `_of_bound`
+  variants with `B' := Hex.ZPoly.defaultFactorCoeffBound core` and `hvalid`
+  discharged via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
+
+Pattern follows PR #4878 exactly. No downstream consumer signatures changed.
+No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+The unscaled sibling propagation (#4883) is the parallel issue and is
+independent of this work (it delegates to the same #4878-landed `_of_bound`
+recovery theorem, not to anything this PR introduces).
+
+## Next step
+
+Land the unscaled side (#4883). After both scaled and unscaled `_of_bound`
+sibling layers are in, the next propagation hops are
+`recombinationSearchModAux_*` / `scaledRecombinationSearchModAux_*`, then
+`exhaustiveCoreFactorsWithBound_coverage_*`, then the umbrella
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` — each its
+own follow-up issue per the #4878 precedent.
+
+## Blockers
+
+None for landing this issue. Local `lake build HexBerlekampZassenhausMathlib.Basic`
+hits pre-existing `whnf` heartbeat timeouts in declarations far below my edits
+(first failure at line 6053; my edits are at lines 4145-4225). The same errors
+appear with my edits stashed, so they're inherited from `main`. CI on `main`
+is green for commit `97b16733` and the corresponding macOS dyld cross-check
+job is also green, so the same target builds clean on CI — the local failures
+are host-specific. My new theorems elaborate without errors (the first build
+error appears well after them).


### PR DESCRIPTION
Closes #4882

Session: `6a8207bf-0960-4415-9213-f9742eba098f`

9f9054a3 feat: add abstract-bound siblings of A2 scaled recovery theorems (#4882)

🤖 Prepared with Claude Code