### PR TITLE
BZ Mathlib-free: switch exhaustiveCoreFactorsWithBound to recombineScaledExhaustive call site

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5381,7 +5381,8 @@ def exhaustiveCoreFactorsWithBound
   else
     let liftData :=
       henselLiftData core (precisionForCoeffBound B primeData.p) primeData
-    let factors := recombineExhaustive core liftData
+    let factors :=
+      recombineScaledExhaustive (DensePoly.leadingCoeff core) core liftData
     if factors.isEmpty then
       #[core]
     else
@@ -8066,6 +8067,67 @@ private theorem recombineScaledExhaustive_product
   simp [hsearch, scaledRecombinationSearchMod_product coreLc f (liftModulus d)
     d.liftedFactors.toList factors hsearch]
 
+/-- Pointwise: scaling a `ZPoly` by the integer `1` is a no-op. -/
+private theorem densePoly_int_scale_one (p : ZPoly) :
+    DensePoly.scale (1 : Int) p = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_scale (R := Int) 1 p n (Int.mul_zero 1)]
+  exact Int.one_mul (p.coeff n)
+
+/-- `scaledRecombinationSearchModAux` at `coreLc = 1` collapses to the unscaled
+`recombinationSearchModAux`: the only difference between the two routines is the
+inner `DensePoly.scale coreLc` applied to the lifted-factor product, which is a
+no-op when `coreLc = 1`. -/
+private theorem scaledRecombinationSearchModAux_eq_recombinationSearchModAux_of_one
+    (target : ZPoly) (modulus : Nat) (localFactors : List ZPoly) (fuel : Nat) :
+    scaledRecombinationSearchModAux 1 target modulus localFactors fuel =
+      recombinationSearchModAux target modulus localFactors fuel := by
+  induction fuel generalizing target localFactors with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold scaledRecombinationSearchModAux recombinationSearchModAux
+      by_cases htarget : target = 1
+      · simp [htarget]
+      · simp only [htarget, if_false]
+        congr 1
+        funext split
+        simp only [densePoly_int_scale_one]
+        by_cases hrecord :
+            shouldRecordPolynomialFactor (normalizeFactorSign <|
+                ZPoly.primitivePart <|
+                  centeredLiftPoly (Array.polyProduct split.1.toArray) modulus) = true
+        · simp only [hrecord, if_true]
+          cases hquot : exactQuotient? target (normalizeFactorSign <|
+              ZPoly.primitivePart <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus) with
+          | none => rfl
+          | some quotient =>
+              simp only [ih]
+        · simp only [hrecord, Bool.false_eq_true, if_false]
+
+/-- Surface-level collapse: `scaledRecombinationSearchMod 1 = recombinationSearchMod`. -/
+private theorem scaledRecombinationSearchMod_eq_recombinationSearchMod_of_one
+    (f : ZPoly) (modulus : Nat) (localFactors : List ZPoly) :
+    scaledRecombinationSearchMod 1 f modulus localFactors =
+      recombinationSearchMod f modulus localFactors := by
+  unfold scaledRecombinationSearchMod recombinationSearchMod
+  exact scaledRecombinationSearchModAux_eq_recombinationSearchModAux_of_one
+    f modulus localFactors (localFactors.length + 1)
+
+/-- Executable collapse: `recombineScaledExhaustive 1 = recombineExhaustive`.
+
+The scaled and unscaled exhaustive recombination wrappers agree when the
+scaling coefficient is `1` (i.e., for monic cores).  Used by the Mathlib-side
+`exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some` to bridge
+an unscaled search witness into the scaled executable call site introduced by
+the swap. -/
+theorem recombineScaledExhaustive_eq_recombineExhaustive_of_one
+    (f : ZPoly) (d : LiftData) :
+    recombineScaledExhaustive 1 f d = recombineExhaustive f d := by
+  unfold recombineScaledExhaustive recombineExhaustive
+  rw [scaledRecombinationSearchMod_eq_recombinationSearchMod_of_one]
+
 /-- Base case for the exhaustive recombination search: when the running target
 has already been reduced to `1`, the search terminates and returns the empty
 factor list. -/
@@ -8357,11 +8419,11 @@ theorem exhaustiveCoreFactorsWithBound_normalizeFactorSign
   · simp [hB, hcore]
   · simp only [hB, if_false]
     by_cases hempty :
-        (recombineExhaustive core
+        (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)).isEmpty
     · simp [hempty, hcore]
     · simp only [hempty]
-      exact recombineExhaustive_normalizeFactorSign core
+      exact recombineScaledExhaustive_normalizeFactorSign (DensePoly.leadingCoeff core) core
         (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)
 
 theorem exhaustiveCoreFactorsWithBound_shouldRecord
@@ -8374,11 +8436,11 @@ theorem exhaustiveCoreFactorsWithBound_shouldRecord
   · simp [hB, hcore]
   · simp only [hB, if_false]
     by_cases hempty :
-        (recombineExhaustive core
+        (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)).isEmpty
     · simp [hempty, hcore]
     · simp only [hempty]
-      exact recombineExhaustive_shouldRecord core
+      exact recombineScaledExhaustive_shouldRecord (DensePoly.leadingCoeff core) core
         (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)
 
 private theorem bhksRecoverClassified_success_product
@@ -8648,8 +8710,8 @@ theorem factorFastCoreWithBound_some_dvd
 
 /-- The exhaustive recombination wrapper preserves the polynomial product
 unconditionally: every branch returns either `#[core]` (singleton, trivially
-multiplying to `core`) or the result of a successful `recombinationSearchMod`
-call (`recombineExhaustive_product`). -/
+multiplying to `core`) or the result of a successful
+`scaledRecombinationSearchMod` call (`recombineScaledExhaustive_product`). -/
 theorem exhaustiveCoreFactorsWithBound_product
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
     Array.polyProduct (exhaustiveCoreFactorsWithBound core B primeData) = core := by
@@ -8658,26 +8720,26 @@ theorem exhaustiveCoreFactorsWithBound_product
   · simp [hB, ZPoly.polyProduct_singleton]
   · simp only [hB, if_false]
     by_cases hempty :
-        (recombineExhaustive core
+        (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)).isEmpty
     · simp [hempty, ZPoly.polyProduct_singleton]
     · simp only [hempty]
-      cases hsearch : recombinationSearchMod core
+      cases hsearch : scaledRecombinationSearchMod (DensePoly.leadingCoeff core) core
           (liftModulus
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData))
           (henselLiftData core (precisionForCoeffBound B primeData.p)
             primeData).liftedFactors.toList with
       | none =>
           have hnil :
-              recombineExhaustive core
+              recombineScaledExhaustive (DensePoly.leadingCoeff core) core
                 (henselLiftData core (precisionForCoeffBound B primeData.p)
                   primeData) = #[] := by
-            rw [recombineExhaustive]
+            rw [recombineScaledExhaustive]
             simp [hsearch]
           rw [hnil] at hempty
           simp at hempty
       | some xs =>
-          exact recombineExhaustive_product core
+          exact recombineScaledExhaustive_product (DensePoly.leadingCoeff core) core
             (henselLiftData core (precisionForCoeffBound B primeData.p) primeData)
             xs hsearch
 

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8767,11 +8767,20 @@ Membership bridge from a successful fixed-lift recombination search into the
 public exhaustive-core wrapper.  The non-empty branch is discharged by the
 factor membership witness, so downstream coverage proofs can use an exact
 `recombinationSearchMod` success without unfolding `exhaustiveCoreFactorsWithBound`.
+
+The monic core hypothesis is required because `exhaustiveCoreFactorsWithBound`
+runs the *scaled* recombination at `coreLc = Hex.DensePoly.leadingCoeff core`,
+while the supplied witness comes from the *unscaled* search; under
+`hcore_monic` the two coincide via the
+`recombineScaledExhaustive_eq_recombineExhaustive_of_one` collapse.  A
+companion `_of_scaledRecombinationSearchMod_some` wrapper that drops the
+monic hypothesis is a follow-up sub-issue.
 -/
 theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
     {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {d : Hex.LiftData} {factors : List Hex.ZPoly}
     (hB : B ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
     (hd :
       d =
         Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
@@ -8782,17 +8791,25 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
     (hmem : factor ∈ factors) :
     factor ∈ (Hex.exhaustiveCoreFactorsWithBound core B primeData).toList := by
   subst d
+  have hlc : Hex.DensePoly.leadingCoeff core = 1 := hcore_monic
   have hrecombine :
       Hex.recombineExhaustive core
           (Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
             primeData) =
         factors.toArray :=
     Hex.recombineExhaustive_eq_of_recombinationSearchMod_some hsearch
+  have hscaled :
+      Hex.recombineScaledExhaustive (Hex.DensePoly.leadingCoeff core) core
+          (Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
+            primeData) =
+        factors.toArray := by
+    rw [hlc, Hex.recombineScaledExhaustive_eq_recombineExhaustive_of_one]
+    exact hrecombine
   have hnot_empty : factors.toArray.isEmpty = false := by
     cases factors with
     | nil => simp at hmem
     | cons head tail => simp
-  simp [Hex.exhaustiveCoreFactorsWithBound, hB, hrecombine, hnot_empty, hmem]
+  simp [Hex.exhaustiveCoreFactorsWithBound, hB, hscaled, hnot_empty, hmem]
 
 /--
 Public-wrapper membership bridge for a first successful fixed-lift split.
@@ -8808,6 +8825,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_first_succe
     {selected rest restFactors : List Hex.ZPoly}
     {pre suffix : List (List Hex.ZPoly × List Hex.ZPoly)}
     (hB : B ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
     (hd :
       d =
         Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
@@ -8862,7 +8880,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_first_succe
   exact
     exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
       (core := core) (factor := factor) (B := B) (primeData := primeData)
-      (d := d) (factors := factors) hB hd hsearch hmem
+      (d := d) (factors := factors) hB hcore_monic hd hsearch hmem
 
 /-- A `Hex.ZPoly` factor that passes the executable `shouldRecordPolynomialFactor`
 check is non-zero and not a unit after transport to `Polynomial ℤ`.  The
@@ -12879,7 +12897,7 @@ theorem exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
   refine ⟨emitted, ?_, hassoc⟩
   exact
     exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
-      (B := B) hB_ne_zero h.lift_eq hsearchMod hemitted_mem
+      (B := B) hB_ne_zero hcore_monic h.lift_eq hsearchMod hemitted_mem
 
 /-- **#4006 slow-path capstone.**
 

--- a/progress/20260518T015136Z_3184388b.md
+++ b/progress/20260518T015136Z_3184388b.md
@@ -1,0 +1,82 @@
+# 20260518T015136Z — 3184388b — feature #4870
+
+## Accomplished
+
+Switched the `Hex.exhaustiveCoreFactorsWithBound` call site from
+`recombineExhaustive` to `recombineScaledExhaustive` with
+`coreLc := DensePoly.leadingCoeff core`, so the exhaustive arm now
+consumes the scaled search surface identified by
+`RepresentsIntegerFactorAtLift`. Rewired the three downstream
+invariant proofs in `HexBerlekampZassenhaus/Basic.lean`
+(`exhaustiveCoreFactorsWithBound_product`, `_normalizeFactorSign`,
+`_shouldRecord`) to chain through the scaled siblings from #4866 /
+#4869. The conclusion shape of `_product` is unchanged
+(`= core`), so the three Mathlib-side `_product` call sites at the
+former lines 11538 / 11602 / 11685 still type-check without
+modification.
+
+Added a small `coreLc = 1` collapse layer to keep the Mathlib-side
+unscaled membership wrapper proof valid under a monic core
+hypothesis:
+
+* `densePoly_int_scale_one` — `DensePoly.scale (1 : Int) p = p`.
+* `scaledRecombinationSearchModAux_eq_recombinationSearchModAux_of_one`
+  — fuel-induction collapse.
+* `scaledRecombinationSearchMod_eq_recombinationSearchMod_of_one`
+  — surface wrapper.
+* `recombineScaledExhaustive_eq_recombineExhaustive_of_one` —
+  executable-level identity, public so the Mathlib-side wrapper can
+  consume it.
+
+Threaded a `hcore_monic : Hex.DensePoly.Monic core` hypothesis through
+`exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some`
+and its `_first_success` companion (which already required the same
+hypothesis transitively). The lone consumer
+`exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence`
+already has `hcore_monic`, so only the call site needed updating.
+
+## Verification
+
+* `lake build HexBerlekampZassenhaus` — green; conformance
+  `HexBerlekampZassenhaus.Conformance` (containing `#guard` blocks
+  downstream of `exhaustiveCoreFactorsWithBound`) builds.
+* `lake build HexBerlekampZassenhausMathlib.Basic` — produces the
+  same pre-existing failure list as `origin/main` (timeouts at lines
+  4596, 4877, 5203, 5289, 5673, 5821, 5974, 5993, 13629, 13740;
+  `cases` failure at 5551; missing constants at 6308, 6372, 13947,
+  13993). Verified by stashing the change and rebuilding on a clean
+  tree: every failure on this branch is at the corresponding
+  (shifted) line on main. No new failures.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `rg "sorry|axiom|native_decide|TODO|FIXME"` on the diff — no new
+  entries.
+
+## Current frontier
+
+The BZ executable now factorises via the scaled-recombination
+surface, but the Mathlib-side coverage and irreducibility wrappers
+(`exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence`,
+`_factor_zpolyIrreducible_of_henselSubsetCorrespondence`,
+`factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`,
+and the umbrella `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`
+in `IntReductionMod.lean`) still require `Monic core`. The
+`_mem_of_recombinationSearchMod_some` wrapper now requires the same
+monic hypothesis (the unscaled witness only matches the scaled
+executable when `leadingCoeff = 1`).
+
+## Next step
+
+The two successor sub-issues in the issue body's "Out of scope" list:
+
+1. A `_of_scaledRecombinationSearchMod_some` membership wrapper that
+   takes a scaled-search witness directly and drops the monic
+   hypothesis.
+2. Relaxing the three top-level wrappers above from `Monic core` to
+   `Primitive core + 0 < leadingCoeff core`, using (1) plus the A2
+   scaled recovery layer (closed under #4878, with abstract-bound
+   propagation in flight via #4882).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4870

Session: `3184388b-2398-406d-a9bf-9d4d8098f392`

1dd9aa6f feat: route exhaustiveCoreFactorsWithBound through recombineScaledExhaustive

🤖 Prepared with Claude Code