### PR TITLE
BZMathlib: abstract-bound sibling of representsIntegerFactorAtLift_monic

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7753,34 +7753,27 @@ theorem natDegree_toPolynomial_eq_sum_of_represents
     hpk_ge_two hd_liftedFactor_monic S
 
 /--
-Integer-factor monic capstone for the Hensel-lifted subset correspondence.
-
-Given an integer factor `factor` of `target ∣ core` that is represented at the
-Hensel lift by the subset `S`, plus monicness of the core and of every lifted
-local factor, and the Mignotte precision bound, the represented factor is
-itself monic.
-
-This is the consumer-side packaging that discharges the `Monic factor`
-hypothesis needed by `recombinationCandidate_eq_factor_of_recovery` (via
-`monic_primitive_sign_normalized_of_monic`). The proof chains
-`liftedFactorProduct_monic` with the centred-lift recovery
-(`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery`) and
-`monic_centeredLiftPoly_of_monic`; the precision hypothesis upgrades to
-`2 ≤ d.p ^ d.k` because otherwise the centred lift collapses to zero,
-contradicting `factor ∣ core` with `core ≠ 0`.
+Abstract-bound variant of `representsIntegerFactorAtLift_monic`: takes
+`B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint. All remaining
+hypotheses are unchanged; the proof mirrors
+`representsIntegerFactorAtLift_monic` with the recovery call delegated to
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`.
 -/
-theorem representsIntegerFactorAtLift_monic
+theorem representsIntegerFactorAtLift_monic_of_bound
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {S : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
     (hd_liftedFactor_monic :
       ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision :
-      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
     (hfactor_dvd_target : factor ∣ target)
     (htarget_dvd_core : target ∣ core)
-    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
     Hex.DensePoly.Monic factor := by
   have hfactor_dvd_core : factor ∣ core := by
     obtain ⟨u, hu⟩ := hfactor_dvd_target
@@ -7798,8 +7791,9 @@ theorem representsIntegerFactorAtLift_monic
     exact densePoly_scale_one_int (liftedFactorProduct d S)
   have hcenter :
       Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k) = factor := by
-    have h := centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-      hcore_ne hfactor_dvd_core hrep hprecision
+    have h :=
+      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound
+        B' hvalid hrep hprecision
     rwa [hscaled] at h
   have hfactor_ne : factor ≠ 0 := by
     intro hf
@@ -7823,6 +7817,52 @@ theorem representsIntegerFactorAtLift_monic
     · omega
   rw [← hcenter]
   exact monic_centeredLiftPoly_of_monic hprod_monic hpk_ge_two
+
+/--
+Integer-factor monic capstone for the Hensel-lifted subset correspondence.
+
+Given an integer factor `factor` of `target ∣ core` that is represented at the
+Hensel lift by the subset `S`, plus monicness of the core and of every lifted
+local factor, and the Mignotte precision bound, the represented factor is
+itself monic.
+
+This is the consumer-side packaging that discharges the `Monic factor`
+hypothesis needed by `recombinationCandidate_eq_factor_of_recovery` (via
+`monic_primitive_sign_normalized_of_monic`). The proof chains
+`liftedFactorProduct_monic` with the centred-lift recovery
+(`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery`) and
+`monic_centeredLiftPoly_of_monic`; the precision hypothesis upgrades to
+`2 ≤ d.p ^ d.k` because otherwise the centred lift collapses to zero,
+contradicting `factor ∣ core` with `core ≠ 0`.
+
+Thin wrapper over `representsIntegerFactorAtLift_monic_of_bound` that
+instantiates `B' := defaultFactorCoeffBound core` and discharges `hvalid`
+via `defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd_core`.
+-/
+theorem representsIntegerFactorAtLift_monic
+    {core target factor : Hex.ZPoly} {d : Hex.LiftData}
+    {S : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hfactor_dvd_target : factor ∣ target)
+    (htarget_dvd_core : target ∣ core)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    Hex.DensePoly.Monic factor := by
+  have hfactor_dvd_core : factor ∣ core := by
+    obtain ⟨u, hu⟩ := hfactor_dvd_target
+    obtain ⟨v, hv⟩ := htarget_dvd_core
+    refine ⟨u * v, ?_⟩
+    rw [hv, hu]
+    exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+  exact representsIntegerFactorAtLift_monic_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd_core)
+    hcore_ne hcore_monic hd_liftedFactor_monic
+    hfactor_dvd_target htarget_dvd_core hrep hprecision
 
 /--
 Bridge from the executable `Hex.ZPoly.Primitive` predicate to Mathlib's

--- a/progress/20260518T020119Z_dce06eb9.md
+++ b/progress/20260518T020119Z_dce06eb9.md
@@ -1,0 +1,63 @@
+# Session dce06eb9 — #4890 abstract-bound sibling of `representsIntegerFactorAtLift_monic`
+
+## Accomplished
+
+Added `representsIntegerFactorAtLift_monic_of_bound` in
+`HexBerlekampZassenhausMathlib/Basic.lean` immediately before the
+existing `representsIntegerFactorAtLift_monic`, and rewired the
+existing theorem as a thin wrapper that instantiates
+`B' := defaultFactorCoeffBound core` and discharges `hvalid` via
+`defaultFactorCoeffBound_valid`.
+
+The new `_of_bound` sibling takes `B' : Nat`,
+`hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`2 * defaultFactorCoeffBound core < d.p ^ d.k` constraint; all other
+hypotheses (`hcore_ne`, `hcore_monic`, `hd_liftedFactor_monic`,
+`hfactor_dvd_target`, `htarget_dvd_core`, `hrep`) are unchanged.
+Proof body mirrors the original, with the recovery call delegated to
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+(the bottom-level `_of_bound` sibling landed by #4878).
+
+The wrapper keeps the existing `representsIntegerFactorAtLift_monic`
+signature identical, so the single external call site at line 12432
+(`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`)
+needs no update.
+
+## Verification
+
+* Build baseline checked: pre-existing whnf timeouts and four
+  unknown-constant kernel errors at lines 4750, 5031, 5357, 5443,
+  5705, 5827, 5975, 6147, 6128, 6462, 6526, 13805, 13916, 14123, 14169
+  match origin/main exactly (with the 40-line offset from my addition).
+  No new errors.
+* `git diff --check` — clean.
+* `python3 scripts/check_dag.py` — passes.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean |
+  grep -E "^\+.*(sorry|axiom|native_decide|TODO|FIXME)"` — no new
+  entries.
+
+## Current frontier
+
+The abstract-bound `_of_bound` chain now extends through the
+integer-factor monic capstone. Unblocks the next-layer follow-ups:
+
+1. `natDegree_toPolynomial_eq_sum_of_represents` (line 7545
+   pre-rebase, now ~7700) abstract-bound sibling — depends on
+   #4883/#4888's `recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`
+   which has now landed.
+2. `recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`
+   (line 12117 pre-rebase, now ~12432) abstract-bound sibling —
+   depends on the `_of_bound` siblings of both
+   `representsIntegerFactorAtLift_monic` (this PR) and
+   `natDegree_toPolynomial_eq_sum_of_represents` (follow-up above).
+
+## Next step
+
+A planner files the `natDegree_toPolynomial_eq_sum_of_represents`
+abstract-bound sibling issue now that its dependency #4888 is on
+main.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4890

Session: `dce06eb9-2782-494e-af84-b0b9953860cd`

fc416440 feat: add representsIntegerFactorAtLift_monic_of_bound abstract-bound sibling

🤖 Prepared with Claude Code