### PR TITLE
HexGramSchmidt: assemble adjacent-swap scaled coefficient quotient formulas

### DIFF
--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -224,44 +224,14 @@ theorem coeffs_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.v
       (b := b) (km1 := km1) (k := k) hkm1 hdenom
 
 
-theorem scaledCoeffs_adjacentSwap_above_prev (b : Matrix Int n m)
-    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hik : k.val < i.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
-    let km1 := GramSchmidt.prevRow k hk
-    let B : Int := GramSchmidt.entry (scaledCoeffs b) k km1
-    let dk' : Int :=
-      (((gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt) : Nat) : Int) *
-          ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) + B ^ 2) /
-        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int)
-    ((GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) i km1 : Int) : Int) =
-      (GramSchmidt.entry (scaledCoeffs b) i km1 * dk' +
-          GramSchmidt.entry (scaledCoeffs b) i k * B) /
-        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) := by
-  sorry
-
-theorem adjacentSwap_scaledCoeffAbovePrevNumerator_dvd (b : Matrix Int n m)
-    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hik : k.val < i.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
-    adjacentSwapDenom b k ∣ adjacentSwapScaledCoeffAbovePrevNumerator b k hk i := by
-  sorry
-
-theorem scaledCoeffs_adjacentSwap_above_curr (b : Matrix Int n m)
-    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hik : k.val < i.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
-    let km1 := GramSchmidt.prevRow k hk
-    let B : Int := GramSchmidt.entry (scaledCoeffs b) k km1
-    ((GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) i k : Int) : Int) =
-      (GramSchmidt.entry (scaledCoeffs b) i k *
-          ((gramDet b km1.val (Nat.le_of_lt km1.isLt) : Nat) : Int) -
-        GramSchmidt.entry (scaledCoeffs b) i km1 * B) /
-      ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) := by
-  sorry
-
-theorem adjacentSwap_scaledCoeffAboveCurrNumerator_dvd (b : Matrix Int n m)
-    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hik : k.val < i.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
-    adjacentSwapDenom b k ∣ adjacentSwapScaledCoeffAboveCurrNumerator b k hk i := by
-  sorry
+/-! The four `adjacentSwap` scaled-coefficient identities for rows above the
+pivot (`scaledCoeffs_adjacentSwap_above_prev`, `_above_curr`, and the two
+`_dvd` companions) live in `HexGramSchmidtMathlib/Update.lean`. Their proof
+path goes through `bareiss_scaledCoeffMatrix_rowSwap_above_prev` /
+`_above_curr` (the bordered-minor identities), which cross the Bareiss / det
+bridge and so cannot be proved in the Mathlib-free core per
+[SPEC/Libraries/hex-gram-schmidt.md "Proof path governs placement, not just
+statement"]. -/
 
 end GramSchmidt.Int
 

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -1006,6 +1006,74 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
   rw [hnu'_rat, hdk_rat, hdkp1_rat, hB_rat, hnuik_rat, hnuikm1_rat]
   linear_combination (G * Nkm1) * hkey
 
+/-! ### Adjacent-swap scaled-coefficient quotient formulas for rows above the pivot
+
+For `i > k`, after the adjacent swap of rows `km1, k`, the new scaled
+coefficients at the `km1` and `k` columns are integer quotients of the
+corresponding `adjacentSwapScaledCoeff*Numerator` definitions by the
+pre-swap pivot `adjacentSwapDenom b k = gramDet b k.val`. Both pairs follow
+from the bordered-minor identities `bareiss_scaledCoeffMatrix_rowSwap_above_prev`
+and `_above_curr` once we bridge `bareiss → scaledCoeffs` via
+`scaledCoeffs_eq_scaledCoeffMatrix_bareiss`. -/
+
+theorem adjacentSwap_scaledCoeffAbovePrevNumerator_dvd (b : Matrix Int n m)
+    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
+    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    adjacentSwapDenom b k ∣ adjacentSwapScaledCoeffAbovePrevNumerator b k hk i := by
+  have h := bareiss_scaledCoeffMatrix_rowSwap_above_prev b k hk i hki hdet
+  show ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ∣
+      adjacentSwapScaledCoeffAbovePrevNumerator b k hk i
+  rw [← h]
+  exact ⟨_, Int.mul_comm _ _⟩
+
+theorem adjacentSwap_scaledCoeffAboveCurrNumerator_dvd (b : Matrix Int n m)
+    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
+    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    adjacentSwapDenom b k ∣ adjacentSwapScaledCoeffAboveCurrNumerator b k hk i := by
+  have h := bareiss_scaledCoeffMatrix_rowSwap_above_curr b k hk i hki hdet
+  show ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ∣
+      adjacentSwapScaledCoeffAboveCurrNumerator b k hk i
+  rw [← h]
+  exact ⟨_, Int.mul_comm _ _⟩
+
+theorem scaledCoeffs_adjacentSwap_above_prev (b : Matrix Int n m)
+    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
+    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) i
+        (GramSchmidt.prevRow k hk) =
+      adjacentSwapScaledCoeffAbovePrevNumerator b k hk i / adjacentSwapDenom b k := by
+  have hkm1i : (GramSchmidt.prevRow k hk).val < i.val := by
+    dsimp [GramSchmidt.prevRow]; omega
+  have hdk_pos : ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ≠ 0 := by
+    intro hzero; exact hdet (Int.ofNat.inj hzero)
+  have h := bareiss_scaledCoeffMatrix_rowSwap_above_prev b k hk i hki hdet
+  have hbridge := scaledCoeffs_eq_scaledCoeffMatrix_bareiss
+    (Matrix.rowSwap b (GramSchmidt.prevRow k hk) k) i (GramSchmidt.prevRow k hk) hkm1i
+  show GramSchmidt.entry
+        (scaledCoeffs (Matrix.rowSwap b (GramSchmidt.prevRow k hk) k))
+        i (GramSchmidt.prevRow k hk) =
+      adjacentSwapScaledCoeffAbovePrevNumerator b k hk i /
+        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int)
+  rw [hbridge, ← h]
+  exact (Int.mul_ediv_cancel _ hdk_pos).symm
+
+theorem scaledCoeffs_adjacentSwap_above_curr (b : Matrix Int n m)
+    (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
+    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    GramSchmidt.entry (scaledCoeffs (adjacentSwap b k hk)) i k =
+      adjacentSwapScaledCoeffAboveCurrNumerator b k hk i / adjacentSwapDenom b k := by
+  have hdk_pos : ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int) ≠ 0 := by
+    intro hzero; exact hdet (Int.ofNat.inj hzero)
+  have h := bareiss_scaledCoeffMatrix_rowSwap_above_curr b k hk i hki hdet
+  have hbridge := scaledCoeffs_eq_scaledCoeffMatrix_bareiss
+    (Matrix.rowSwap b (GramSchmidt.prevRow k hk) k) i k hki
+  show GramSchmidt.entry
+        (scaledCoeffs (Matrix.rowSwap b (GramSchmidt.prevRow k hk) k)) i k =
+      adjacentSwapScaledCoeffAboveCurrNumerator b k hk i /
+        ((gramDet b k.val (Nat.le_of_lt k.isLt) : Nat) : Int)
+  rw [hbridge, ← h]
+  exact (Int.mul_ediv_cancel _ hdk_pos).symm
+
 end GramSchmidt.Int
 
 end Hex

--- a/progress/20260518T021439Z_e56a5fe9.md
+++ b/progress/20260518T021439Z_e56a5fe9.md
@@ -1,0 +1,85 @@
+# Progress 2026-05-18T02:14:39Z (session e56a5fe9, /work → /feature)
+
+## Accomplished
+
+Claimed and completed #4845 (HexGramSchmidt: assemble adjacent-swap
+scaled coefficient quotient formulas).
+
+Replaced the four sorried stubs in `HexGramSchmidt/Update.lean`
+(`scaledCoeffs_adjacentSwap_above_prev`,
+`adjacentSwap_scaledCoeffAbovePrevNumerator_dvd`,
+`scaledCoeffs_adjacentSwap_above_curr`,
+`adjacentSwap_scaledCoeffAboveCurrNumerator_dvd`) with proven theorems
+in `HexGramSchmidtMathlib/Update.lean`.
+
+Two findings drove the placement / signature changes:
+
+1. **Proof path is Mathlib-bridge.** The four theorems compose against
+   the landed bordered-minor identities
+   `bareiss_scaledCoeffMatrix_rowSwap_above_prev` /
+   `_above_curr` (in `HexGramSchmidtMathlib/Update.lean` per #4853 and
+   #4854) and `scaledCoeffs_eq_scaledCoeffMatrix_bareiss` (in
+   `HexGramSchmidtMathlib/Int.lean`). Per
+   `SPEC/Libraries/hex-gram-schmidt.md §"Proof path governs placement,
+   not just statement"`, the assembled theorems therefore live in the
+   bridge layer alongside their substrate, not in the Mathlib-free
+   `HexGramSchmidt/Update.lean`. The Mathlib-free file gets a comment
+   pointing to the bridge location.
+
+2. **Two quotient sorries had algebraically incorrect formulas.** The
+   original `scaledCoeffs_adjacentSwap_above_prev` stated
+   `nu'[i][km1] = (nu[i][km1] * dk' + nu[i][k] * B) / d_k`, and
+   `_above_curr` stated
+   `nu'[i][k] = (nu[i][k] * d_{km1} - nu[i][km1] * B) / d_k`. Symbolic
+   evaluation against the Gram-Schmidt decomposition (using
+   `G = gramDet b km1`, `Nkm1 = ||u_km1||²`, `Nk = ||u_k||²`,
+   `μ = c[k][km1]`) shows neither matches `nu'` in `Rat`. The
+   bordered-minor identities prove the correct integer numerators are
+   `d_{km1} * nu[i][k] + B * nu[i][km1]`
+   (= `adjacentSwapScaledCoeffAbovePrevNumerator`, def in
+   `HexGramSchmidt/Update.lean`) and
+   `d_{k+1} * nu[i][km1] - B * nu[i][k]`
+   (= `adjacentSwapScaledCoeffAboveCurrNumerator`). The new theorem
+   statements use those canonical `Numerator` / `Denom` definitions —
+   matching the issue body's prescription to "use the new adjacent-swap
+   bordered-minor identities together with existing APIs:
+   `adjacentSwapScaledCoeffAbovePrevNumerator` /
+   `adjacentSwapScaledCoeffAboveCurrNumerator`".
+
+Proofs:
+
+* `adjacentSwap_scaledCoeff{AbovePrev,AboveCurr}Numerator_dvd`: direct
+  from the bordered-minor identity (LHS = `bareiss * d_k`, so `d_k`
+  divides the numerator).
+* `scaledCoeffs_adjacentSwap_above_{prev,curr}`: bridge
+  `scaledCoeffs (rowSwap b km1 k) i j = bareiss (scaledCoeffMatrix
+  (rowSwap b km1 k) i j)` via `scaledCoeffs_eq_scaledCoeffMatrix_bareiss`,
+  then combine with the bordered-minor identity and discharge via
+  `Int.mul_ediv_cancel`.
+
+## Verification
+
+* `lake build HexGramSchmidt.Update HexGramSchmidt HexGramSchmidtMathlib` — clean.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — exit 0.
+* `rg sorry|axiom|native_decide|TODO|FIXME HexGramSchmidt/Update.lean` —
+  no matches (the four target sorries removed; no new banned constructs).
+
+## Current frontier
+
+The cluster of adjacent-swap update theorems for `scaledCoeffs` is now
+complete: lower (prev/curr), pivot, gramDet, and above (prev/curr)
+along with their `_dvd` companions. The three pre-existing sorries in
+`HexGramSchmidt/Int.lean` (lines 2930, 3021, 3115) are unrelated to
+this issue and remain (explicitly listed as out-of-scope by the issue
+body).
+
+## Next step
+
+Downstream consumers (LLL-level update lemmas) can now use the four
+new theorems against the canonical numerator definitions in
+`HexGramSchmidt/Update.lean`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4845

Session: `e56a5fe9-a536-4f7d-8486-6d2418e7e051`

9bd0b6d7 feat: assemble adjacent-swap scaled coefficient quotient formulas (#4845)

🤖 Prepared with Claude Code