### PR TITLE
BZMathlib: abstract-bound sibling of natDegree_toPolynomial_eq_sum_of_represents (monic)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7687,35 +7687,34 @@ theorem natDegree_toPolynomial_recombinationCandidate_eq_sum
   rw [HexPolyMathlib.leadingCoeff_toPolynomial]
   exact hd_liftedFactor_monic i
 
-/--
-The Mathlib-transported `natDegree` of a represented integer factor equals the
-sum of the Mathlib-transported `natDegree`s of the lifted factors in the
-representing subset.
-
-The proof identifies the represented factor with its recombination candidate
-by centered-lift recovery, then reuses
-`natDegree_toPolynomial_recombinationCandidate_eq_sum`.
--/
-theorem natDegree_toPolynomial_eq_sum_of_represents
+/-- Abstract-bound variant of `natDegree_toPolynomial_eq_sum_of_represents`:
+takes `B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  The proof mirrors
+the core-shape original but invokes the `_of_bound` siblings
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound` and
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`. -/
+theorem natDegree_toPolynomial_eq_sum_of_represents_of_bound
     {core factor : Hex.ZPoly} {d : Hex.LiftData}
     {S : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
     (hd_liftedFactor_monic :
       ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision :
-      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
     (hdvd : factor ∣ core)
     (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
     (hfactor_prim : Hex.ZPoly.content factor = 1)
     (hfactor_norm : Hex.normalizeFactorSign factor = factor)
-    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
     (HexPolyZMathlib.toPolynomial factor).natDegree =
       ∑ i ∈ S,
         (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
   have hrec_eq : recombinationCandidate d S = factor :=
-    recombinationCandidate_eq_factor_of_recovery_of_monic_core
-      hcore_ne hcore_monic hdvd hfactor_prim hfactor_norm hfactor_irr
+    recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound
+      B' hvalid hcore_ne hcore_monic hfactor_prim hfactor_norm hfactor_irr
       hrep hprecision
   have hlead : Hex.DensePoly.leadingCoeff core = (1 : Int) := hcore_monic
   have hscaled :
@@ -7725,8 +7724,9 @@ theorem natDegree_toPolynomial_eq_sum_of_represents
     exact densePoly_scale_one_int (liftedFactorProduct d S)
   have hcenter :
       Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k) = factor := by
-    have h := centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-      hcore_ne hdvd hrep hprecision
+    have h :=
+      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound
+        B' hvalid hrep hprecision
     rwa [hscaled] at h
   have hfactor_ne : factor ≠ 0 := by
     intro hf
@@ -7751,6 +7751,42 @@ theorem natDegree_toPolynomial_eq_sum_of_represents
   rw [← hrec_eq]
   exact natDegree_toPolynomial_recombinationCandidate_eq_sum
     hpk_ge_two hd_liftedFactor_monic S
+
+/--
+The Mathlib-transported `natDegree` of a represented integer factor equals the
+sum of the Mathlib-transported `natDegree`s of the lifted factors in the
+representing subset.
+
+The proof identifies the represented factor with its recombination candidate
+by centered-lift recovery, then reuses
+`natDegree_toPolynomial_recombinationCandidate_eq_sum`.
+
+This is a thin wrapper over `natDegree_toPolynomial_eq_sum_of_represents_of_bound`
+that instantiates `B' := defaultFactorCoeffBound core` and discharges `hvalid`
+via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`.
+-/
+theorem natDegree_toPolynomial_eq_sum_of_represents
+    {core factor : Hex.ZPoly} {d : Hex.LiftData}
+    {S : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hdvd : factor ∣ core)
+    (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    (HexPolyZMathlib.toPolynomial factor).natDegree =
+      ∑ i ∈ S,
+        (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree :=
+  natDegree_toPolynomial_eq_sum_of_represents_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_ne hcore_monic hd_liftedFactor_monic hdvd hfactor_irr
+    hfactor_prim hfactor_norm hrep hprecision
 
 /--
 Integer-factor monic capstone for the Hensel-lifted subset correspondence.

--- a/progress/20260518T022627Z_5091da8d.md
+++ b/progress/20260518T022627Z_5091da8d.md
@@ -1,0 +1,51 @@
+# Session 5091da8d — natDegree_toPolynomial_eq_sum_of_represents `_of_bound` sibling
+
+## Accomplished
+
+Claimed and executed #4895.
+
+Added `natDegree_toPolynomial_eq_sum_of_represents_of_bound` in
+`HexBerlekampZassenhausMathlib/Basic.lean` immediately before the existing
+`natDegree_toPolynomial_eq_sum_of_represents`. The new sibling takes
+`B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape precision
+constraint, mirroring the existing theorem's body with two call-site
+replacements:
+
+* `recombinationCandidate_eq_factor_of_recovery_of_monic_core` →
+  `recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`
+  (from PR #4888), passing `B' hvalid` ahead of the original arguments.
+  The `_of_bound` callee does not take `hdvd`, so `hdvd` is dropped from
+  this call (but remains a hypothesis used by the `hfactor_ne`
+  derivation later in the proof).
+* `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery` →
+  `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+  (from PR #4878), passing `B' hvalid hrep hprecision`.
+
+Rewired the existing `natDegree_toPolynomial_eq_sum_of_represents` as a
+thin term-mode wrapper that instantiates
+`B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharges `hvalid`
+via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd`. The
+existing signature is unchanged.
+
+## Current frontier
+
+PR forthcoming.
+
+## Next step
+
+Per the issue body, the next propagation layer
+(`recombinationSearchModAux_*`) is a separate follow-up — out of scope
+for this PR. The parallel primitive sibling is in flight as #4892.
+
+## Blockers
+
+Local `lake build HexBerlekampZassenhausMathlib.Basic` returns 17
+errors, but the same 17 errors appear on a stashed (no-change) baseline.
+The error set differs only by a 36-line shift below my insertion point,
+matching the inserted code length. All errors are heartbeat timeouts and
+cascading "unknown constant" reports in lines 4750–6526 and 13783–14147
+(now 13819–14183) — far from my changes at line 7697. CI on recent main
+(commit 4a581212) built `HexBerlekampZassenhausMathlib` successfully, so
+I'm treating this as a local environment issue and relying on CI to
+verify.


### PR DESCRIPTION
Closes #4895

Session: `5091da8d-94e2-477b-8e7a-8aff410a12ee`

c608ba73 feat: add natDegree_toPolynomial_eq_sum_of_represents_of_bound sibling

🤖 Prepared with Claude Code