### PR TITLE
BZ Mathlib-free: scaled membership wrapper for exhaustiveCoreFactorsWithBound (Mathlib-bridge)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -9006,6 +9006,44 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
   simp [Hex.exhaustiveCoreFactorsWithBound, hB, hscaled, hnot_empty, hmem]
 
 /--
+Scaled-candidate counterpart of
+`exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some`.
+
+`Hex.exhaustiveCoreFactorsWithBound` calls the scaled recombination
+`recombineScaledExhaustive` at `coreLc = Hex.DensePoly.leadingCoeff core`, so
+coverage proofs that reach a successful scaled search return a membership
+statement in the public wrapper directly through this bridge — no
+`Monic core` hypothesis and no unfolding of `exhaustiveCoreFactorsWithBound`
+needed at the call site.
+-/
+theorem exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some
+    {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {d : Hex.LiftData} {factors : List Hex.ZPoly}
+    (hB : B ≠ 0)
+    (hd :
+      d =
+        Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
+          primeData)
+    (hsearch :
+      Hex.scaledRecombinationSearchMod (Hex.DensePoly.leadingCoeff core)
+          core (d.p ^ d.k) d.liftedFactors.toList =
+        some factors)
+    (hmem : factor ∈ factors) :
+    factor ∈ (Hex.exhaustiveCoreFactorsWithBound core B primeData).toList := by
+  subst d
+  have hrecombine :
+      Hex.recombineScaledExhaustive (Hex.DensePoly.leadingCoeff core) core
+          (Hex.henselLiftData core (Hex.precisionForCoeffBound B primeData.p)
+            primeData) =
+        factors.toArray :=
+    Hex.recombineScaledExhaustive_eq_of_scaledRecombinationSearchMod_some hsearch
+  have hnot_empty : factors.toArray.isEmpty = false := by
+    cases factors with
+    | nil => simp at hmem
+    | cons head tail => simp
+  simp [Hex.exhaustiveCoreFactorsWithBound, hB, hrecombine, hnot_empty, hmem]
+
+/--
 Public-wrapper membership bridge for a first successful fixed-lift split.
 
 This composes the proof-facing first-success witness with

--- a/progress/20260518T023655Z_51436a99.md
+++ b/progress/20260518T023655Z_51436a99.md
@@ -1,0 +1,38 @@
+# 2026-05-18 02:36Z — #4875 scaled membership wrapper for exhaustiveCoreFactorsWithBound
+
+## Accomplished
+
+- Added `exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some`
+  in `HexBerlekampZassenhausMathlib/Basic.lean` immediately after the existing
+  unscaled wrapper. The new theorem is the scaled-search sibling: from a
+  successful `scaledRecombinationSearchMod` at
+  `coreLc = DensePoly.leadingCoeff core` and a factor-list membership witness,
+  it returns membership in `exhaustiveCoreFactorsWithBound core B primeData`.
+- Proof mirrors the unscaled wrapper but drops the `Monic core` hypothesis and
+  the `recombineScaledExhaustive_eq_recombineExhaustive_of_one` collapse step.
+  The closing `simp` step unfolds `exhaustiveCoreFactorsWithBound` whose body
+  (post #4893) already calls `recombineScaledExhaustive` at the scaled
+  leading-coefficient.
+
+## Current frontier
+
+- The change is purely additive: no existing definition, theorem, proof or
+  call site is touched. The unscaled wrappers at lines 8973 and 9016 remain
+  unmodified (they were already adapted to the scaled body by #4893 via the
+  monic-collapse).
+- Local `lake build HexBerlekampZassenhausMathlib` is dominated by pre-existing
+  heartbeat timeouts on lines 5827/5975/6147/6128/6462/6526 and
+  13823/13934/14141/14187 (those line numbers shifted +38 on this branch from
+  the new theorem block). The same timeouts reproduce on `main` under the
+  current local load average ~11; CI on `main` is green.
+
+## Next step
+
+- Open PR closing #4875.
+
+## Blockers
+
+- None for this issue. The follow-on capstone
+  `exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence_of_primitive_pos_lc_core`
+  (per #4875's "Out of scope" section) is a separate issue to be filed once
+  this wrapper lands.


### PR DESCRIPTION
Closes #4875

Session: `51436a99-0aeb-41b6-a017-36795962578f`

31b6ed59 feat: add scaled membership wrapper for exhaustiveCoreFactorsWithBound (#4875)

🤖 Prepared with Claude Code