### PR TITLE
BZMathlib: abstract-bound sibling of natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8352,51 +8352,57 @@ theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
   rw [HexPolyMathlib.leadingCoeff_toPolynomial]
   exact hd_liftedFactor_monic i
 
-/--
-Primitive + positive-leading-core variant of
-`natDegree_toPolynomial_eq_sum_of_represents` (#4646).
+/-- Abstract-bound variant of
+`natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core`:
+takes `B' : Nat`, `hvalid : ∀ i, (factor.coeff i).natAbs ≤ B'`,
+`hcore_lc_bound : (lc core).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.
 
-For primitive non-monic `core`, the represented factor's natDegree equals the
-sum of natDegrees of the selected lifted factors. The proof routes through the
-scaled recovery identity `scaledRecombinationCandidate core d S = factor`
-(#4652) and the size identities
-`factor.size = (scaledLiftedFactorProduct core d S).size =
- (liftedFactorProduct d S).size`. Scaling by `C (lc core)` and the centred lift
-both preserve stored size under the Mignotte half-window bound on `lc core`,
-so the sum decomposition `natDegree_prod_of_monic` over `liftedFactorProduct`
-applies unchanged. The `hcore_primitive` and `hfactor_irr` hypotheses are
-threaded for API uniformity with the monic variant but are not used by the
-proof; the natDegree extraction depends only on the leading-coefficient bound
-and the primitive/sign-normalised facts on `factor` consumed by #4652.
+The unscaled `_hrec_scaled` step from the existing proof is dropped
+entirely — its result was never consumed — and the centred-lift
+recovery call is routed through
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+in place of the core-shape recovery. Both changes make this sibling
+independent of `scaledRecombinationCandidate_eq_factor_of_recovery`
+and hence of the scaled recovery-candidate `_of_bound` chain (#4882).
+
+Note: this sibling needs `hcore_lc_bound` in addition to `hvalid`
+because the size-preservation step
+`size_centeredLiftPoly_eq_of_pos_leadingCoeff_bound` consumes a
+leading-coefficient bound on `scaledLiftedFactorProduct core d S`,
+whose leading coefficient is `lc core`. Without a `B'`-shape bound
+on `lc core` itself, the abstract-precision hypothesis cannot
+discharge that lemma's separation requirement. The existing
+core-shape wrapper supplies this from
+`defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self`.
 -/
-theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
+theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound
     {core factor : Hex.ZPoly} {d : Hex.LiftData}
     {S : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
+    (hcore_lc_bound : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (_hcore_primitive : Hex.ZPoly.Primitive core)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic :
       ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision :
-      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
-    (hdvd : factor ∣ core)
+    (_hdvd : factor ∣ core)
     (_hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
-    (hfactor_prim : Hex.ZPoly.content factor = 1)
-    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
-    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    (_hfactor_prim : Hex.ZPoly.content factor = 1)
+    (_hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision : 2 * B' < d.p ^ d.k) :
     (HexPolyZMathlib.toPolynomial factor).natDegree =
       ∑ i ∈ S,
         (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
-  -- The scaled recovery identifies the scaled recombination candidate with `factor`.
-  have _hrec_scaled : scaledRecombinationCandidate core d S = factor :=
-    scaledRecombinationCandidate_eq_factor_of_recovery
-      hcore_ne hdvd hfactor_prim hfactor_norm hrep hprecision
-  -- Centred-lift form of the recovery.
+  -- Centred-lift form of the recovery, abstract-bound variant.
   have hcenter :
       Hex.centeredLiftPoly (scaledLiftedFactorProduct core d S) (d.p ^ d.k) =
         factor :=
-    centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-      hcore_ne hdvd hrep hprecision
+    centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound
+      B' hvalid hrep hprecision
   -- Monic lifted-factor product.
   set lp := liftedFactorProduct d S with hlp_def
   have hlp_monic : Hex.DensePoly.Monic lp :=
@@ -8419,35 +8425,9 @@ theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
   have hslp_lc_pos :
       0 < Hex.DensePoly.leadingCoeff (scaledLiftedFactorProduct core d S) := by
     rw [hslp_lc]; exact hcore_lc_pos
-  -- Bound on `lc core` against the Mignotte half-window.
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
   have hslp_lc_bound :
       (Hex.DensePoly.leadingCoeff (scaledLiftedFactorProduct core d S)).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
+        B' := by
     rwa [hslp_lc]
   -- Centred lift preserves the size of the scaled product.
   have hcl_size :
@@ -8474,6 +8454,79 @@ theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
   show (HexPolyZMathlib.toPolynomial (liftedFactor d i)).leadingCoeff = 1
   rw [HexPolyMathlib.leadingCoeff_toPolynomial]
   exact hd_liftedFactor_monic i
+
+/--
+Primitive + positive-leading-core variant of
+`natDegree_toPolynomial_eq_sum_of_represents` (#4646).
+
+For primitive non-monic `core`, the represented factor's natDegree equals the
+sum of natDegrees of the selected lifted factors. The proof routes through the
+scaled recovery identity `scaledRecombinationCandidate core d S = factor`
+(#4652) and the size identities
+`factor.size = (scaledLiftedFactorProduct core d S).size =
+ (liftedFactorProduct d S).size`. Scaling by `C (lc core)` and the centred lift
+both preserve stored size under the Mignotte half-window bound on `lc core`,
+so the sum decomposition `natDegree_prod_of_monic` over `liftedFactorProduct`
+applies unchanged. The `hcore_primitive` and `hfactor_irr` hypotheses are
+threaded for API uniformity with the monic variant but are not used by the
+proof; the natDegree extraction depends only on the leading-coefficient bound
+and the primitive/sign-normalised facts on `factor` consumed by #4652.
+
+This is a thin wrapper over
+`natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharges
+`hvalid` via `defaultFactorCoeffBound_valid core hcore_ne factor hdvd` and the
+leading-coefficient bound via
+`defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self`.
+-/
+theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
+    {core factor : Hex.ZPoly} {d : Hex.LiftData}
+    {S : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hdvd : factor ∣ core)
+    (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_prim : Hex.ZPoly.content factor = 1)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    (HexPolyZMathlib.toPolynomial factor).natDegree =
+      ∑ i ∈ S,
+        (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_lc_bound :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
+    hcore_lc_bound hcore_ne hcore_primitive hcore_lc_pos hd_liftedFactor_monic
+    hdvd hfactor_irr hfactor_prim hfactor_norm hrep hprecision
 
 /-- Converse to `toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord`: if the
 transported polynomial is non-zero and a non-unit, then the executable

--- a/progress/20260518T023853Z_18843b55.md
+++ b/progress/20260518T023853Z_18843b55.md
@@ -1,0 +1,76 @@
+# 2026-05-18 02:38 UTC — `/work` session 18843b55
+
+## Accomplished
+
+Closes #4892 (`BZMathlib: abstract-bound sibling of
+natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core`).
+
+Added `natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound`
+alongside the existing theorem in `HexBerlekampZassenhausMathlib/Basic.lean`
+and rewired the existing theorem as a thin wrapper.
+
+The new sibling routes through
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+(from #4878) instead of the core-shape recovery, and the dead
+`_hrec_scaled` line (an unconsumed call to
+`scaledRecombinationCandidate_eq_factor_of_recovery`) is dropped. This
+makes the sibling independent of #4882's scaled recovery-candidate
+`_of_bound` chain.
+
+## Deviation from issue spec
+
+The issue's deliverables call for the new theorem to mirror the existing
+signature with only `B'`, `hvalid`, `hprecision` swapped in. I added
+**one extra hypothesis**:
+
+```
+(hcore_lc_bound : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+```
+
+Reason: the existing proof's `hcl_size` step calls
+`size_centeredLiftPoly_eq_of_pos_leadingCoeff_bound`, which needs a
+single `B` such that both `(lc(scaledLiftedFactorProduct …)).natAbs ≤ B`
+and `2 * B < d.p ^ d.k`. In the core-shape proof, `B =
+defaultFactorCoeffBound core` and both bounds match. In the
+abstract-bound proof, `hprecision : 2 * B' < d.p ^ d.k` only fits if
+`(lc core).natAbs ≤ B'` (since `lc(scaledLiftedFactorProduct …) = lc
+core`). The issue's claim that "all remaining proof steps carry over
+unchanged" misses this precision-bound match.
+
+The wrapper discharges the new hypothesis using exactly the same
+`defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self` +
+`leadingCoeff_eq_coeff_last` derivation that appeared inline in the
+original proof, so no external API surface changes.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — pre-existing
+  errors in unrelated parts of the file (heartbeat timeouts at
+  4750/5031/…/13929 and kernel-unknown-constant errors at
+  6462/6526/14136/14182, all present on `origin/main`). The new theorem
+  and rewired wrapper both elaborate successfully; the only new
+  diagnostic in the edit region is a single `unused variable hcore_ne`
+  warning at line 8386, matching the convention used by existing
+  `_of_bound` siblings landed by #4878 / #4888 / #4889 (e.g.
+  `scaledRecombinationCandidate_eq_factor_of_recovery_of_bound` has
+  the same warning at line 4231 on `origin/main`).
+* `python3 scripts/check_dag.py` — passes.
+* `git diff --check` — clean.
+* `git diff … | rg sorry|axiom|native_decide|TODO|FIXME` on added
+  lines — none.
+
+## Current frontier
+
+Issue #4892 closed by the new theorem and wrapper. The remaining
+recursive workhorse
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`
+abstract-bound sibling (called out as out-of-scope by #4892) is the
+natural follow-up but is blocked on #4890.
+
+## Next step
+
+Push branch and open PR closing #4892.
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #4892

Session: `18843b55-945a-4680-a365-4cb85c36deac`

4bf6846a feat: add abstract-bound sibling of A2 natDegree-sum recovery theorem (primitive non-monic) (#4892)

🤖 Prepared with Claude Code