### PR TITLE
BZMathlib: abstract-bound siblings of representingSubset_subset_of_dvd_recombinationCandidate*

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3904,6 +3904,39 @@ theorem representingSubset_subset_of_dvd_recombinationCandidate
   · exact hSJ
   · exact hrep
 
+/-- Abstract-bound variant of
+`representingSubset_subset_of_dvd_recombinationCandidate`: takes
+`_B' : Nat`, `_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B'`, and
+`_hprecision : 2 * _B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Both the
+abstract bound and the precision hypothesis are vestigial here (the
+proof body delegates to the structural support field of
+`LiftedFactorSubsetPartition`, which never consumes precision); they
+are threaded purely for API parity with the broader `_of_bound`
+propagation chain. -/
+theorem representingSubset_subset_of_dvd_recombinationCandidate_of_bound
+    {core target f : Hex.ZPoly} {d : Hex.LiftData}
+    {J T S : LiftedFactorSubset d}
+    (_B' : Nat)
+    (_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B')
+    (_hcore_ne : core ≠ 0)
+    (_hcore_monic : Hex.DensePoly.Monic core)
+    (_hprecision : 2 * _B' < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hTJ : T ⊆ J)
+    (hirr : Irreducible (HexPolyZMathlib.toPolynomial f))
+    (hfactor_dvd_target : f ∣ target)
+    (hfactor_dvd_candidate : f ∣ recombinationCandidate d T)
+    (hSJ : S ⊆ J)
+    (hrep : RepresentsIntegerFactorAtLift core d f S) :
+    S ⊆ T := by
+  apply hpartition.support_subset_of_dvd_recombinationCandidate
+    hirr hfactor_dvd_target hTJ
+  · rw [← recombinationCandidate_eq_liftedFactorProductCandidate]
+    exact hfactor_dvd_candidate
+  · exact hSJ
+  · exact hrep
+
 /-- Primitive + positive-leading-core variant of
 `representingSubset_subset_of_dvd_recombinationCandidate` (#4646 chain).
 
@@ -3918,6 +3951,38 @@ theorem representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos
     (_hcore_primitive : Hex.ZPoly.Primitive core)
     (_hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (_hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hTJ : T ⊆ J)
+    (hirr : Irreducible (HexPolyZMathlib.toPolynomial f))
+    (hfactor_dvd_target : f ∣ target)
+    (hfactor_dvd_candidate : f ∣ recombinationCandidate d T)
+    (hSJ : S ⊆ J)
+    (hrep : RepresentsIntegerFactorAtLift core d f S) :
+    S ⊆ T := by
+  apply hpartition.support_subset_of_dvd_recombinationCandidate
+    hirr hfactor_dvd_target hTJ
+  · rw [← recombinationCandidate_eq_liftedFactorProductCandidate]
+    exact hfactor_dvd_candidate
+  · exact hSJ
+  · exact hrep
+
+/-- Abstract-bound variant of
+`representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core`:
+takes `_B' : Nat`, `_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B'`, and
+`_hprecision : 2 * _B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Both the
+abstract bound and the precision hypothesis are vestigial here; they
+are threaded purely for API parity with the broader `_of_bound`
+propagation chain. -/
+theorem representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound
+    {core target f : Hex.ZPoly} {d : Hex.LiftData}
+    {J T S : LiftedFactorSubset d}
+    (_B' : Nat)
+    (_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B')
+    (_hcore_ne : core ≠ 0)
+    (_hcore_primitive : Hex.ZPoly.Primitive core)
+    (_hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (_hprecision : 2 * _B' < d.p ^ d.k)
     (hpartition : LiftedFactorSubsetPartition core d J target)
     (hTJ : T ⊆ J)
     (hirr : Irreducible (HexPolyZMathlib.toPolynomial f))
@@ -3950,6 +4015,39 @@ theorem representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primiti
     (_hcore_primitive : Hex.ZPoly.Primitive core)
     (_hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (_hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (_htarget_dvd_core : target ∣ core)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hTJ : T ⊆ J)
+    (hirr : Irreducible (HexPolyZMathlib.toPolynomial f))
+    (hfactor_dvd_target : f ∣ target)
+    (_hfactor_prim : Hex.ZPoly.content f = 1)
+    (_hfactor_norm : Hex.normalizeFactorSign f = f)
+    (hfactor_dvd_candidate : f ∣ scaledRecombinationCandidate core d T)
+    (hSJ : S ⊆ J)
+    (hrep : RepresentsIntegerFactorAtLift core d f S) :
+    S ⊆ T := by
+  exact hpartition.support_subset_of_dvd_scaledRecombinationCandidate
+    hirr hfactor_dvd_target hTJ hfactor_dvd_candidate hSJ hrep
+
+/-- Abstract-bound variant of
+`representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core`:
+takes `_B' : Nat`, `_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B'`, and
+`_hprecision : 2 * _B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.  Both the
+abstract bound and the precision hypothesis are vestigial here (the
+proof body delegates to the scaled support field of
+`LiftedFactorSubsetPartition`, which never consumes precision); they
+are threaded purely for API parity with the broader `_of_bound`
+propagation chain. -/
+theorem representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound
+    {core target f : Hex.ZPoly} {d : Hex.LiftData}
+    {J T S : LiftedFactorSubset d}
+    (_B' : Nat)
+    (_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B')
+    (_hcore_ne : core ≠ 0)
+    (_hcore_primitive : Hex.ZPoly.Primitive core)
+    (_hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (_hprecision : 2 * _B' < d.p ^ d.k)
     (_htarget_dvd_core : target ∣ core)
     (hpartition : LiftedFactorSubsetPartition core d J target)
     (hTJ : T ⊆ J)

--- a/progress/20260518T024737Z_0482400a.md
+++ b/progress/20260518T024737Z_0482400a.md
@@ -1,0 +1,57 @@
+# 2026-05-18T02:47Z — feature session 0482400a (issue #4901)
+
+## Accomplished
+
+Landed three abstract-bound (`_of_bound`) siblings of the
+support-containment lemmas at
+`HexBerlekampZassenhausMathlib/Basic.lean:3886` / `:3914` / `:3946`,
+following the issue spec verbatim:
+
+* `representingSubset_subset_of_dvd_recombinationCandidate_of_bound`
+* `representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound`
+* `representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+
+Each sibling takes `_B' : Nat`, `_hvalid : ∀ i, (f.coeff i).natAbs ≤ _B'`,
+and `_hprecision : 2 * _B' < d.p ^ d.k` in place of the core-shape
+`2 * defaultFactorCoeffBound core < d.p ^ d.k` precision constraint.
+Both the abstract bound and the precision hypothesis are vestigial
+(underscored): the proof body in each case is identical to its
+unsuffixed sibling — a structural delegation to a
+`LiftedFactorSubsetPartition` field that never consumes precision.
+
+Each sibling sits immediately after its corresponding original, with
+a brief doc-comment naming the underscore convention. The three
+existing originals are untouched.
+
+Total diff: +98 lines, purely additive.
+
+## Current frontier
+
+The bottom-layer support-containment substrate now has its `_of_bound`
+siblings. The propagation chain continues at:
+
+* `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate*`
+  (unscaled side closed via #4902; scaled side deferred pending
+  #4905 / `zpoly_primitive_scaledRecombinationCandidate_of_bound`).
+* `mem_T_iff_exists_irreducibleFactor_representingSubset_*` — separate
+  follow-on issue, not yet filed.
+* `coverAtMin_*`, `liftedFactorSubsetPartition_prefix_none_*`,
+  `recombinationSearchModAux_*` — higher layers, all separate
+  follow-on issues per the propagation chain.
+
+## Next step
+
+Available unclaimed siblings of the propagation chain:
+
+* #4905 — `zpoly_primitive_scaledRecombinationCandidate_of_bound`
+  (non-vestigial precision consumer; unblocks the deferred scaled-side
+  `exists_representingSubset_*_of_bound`).
+
+## Blockers
+
+Local `lake build HexBerlekampZassenhausMathlib.Basic` is running in
+the background; prior progress notes from #4891 / #4890 document
+pre-existing heartbeat timeouts on this file that are environment-
+specific (CI succeeds for the parent commit). The three new siblings
+are purely additive thin wrappers with bodies identical to their
+unsuffixed counterparts, so no fresh proof obligations are introduced.


### PR DESCRIPTION
Closes #4901

Session: `0482400a-4fdb-4954-bd67-f20dde3899d8`

f1947860 feat: add abstract-bound siblings of representingSubset_subset_of_dvd_recombinationCandidate* (#4901)

🤖 Prepared with Claude Code