### PR TITLE
BZ Mathlib-free: relax three exhaustive-coverage wrappers to primitive + pos-leading core

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -13416,7 +13416,8 @@ theorem exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
     (hpartition :
       LiftedFactorSubsetPartition core d Finset.univ core)
     (hcore_ne : core ≠ 0)
-    (hcore_monic : Hex.DensePoly.Monic core)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hB_ne_zero : B ≠ 0)
     (hd_modulus : 2 ≤ d.p ^ d.k)
     (hd_liftedFactor_monic :
@@ -13441,21 +13442,23 @@ theorem exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
     rw [← LiftedFactorListMatches.length_eq_card hmatches]
     exact Nat.lt_succ_self _
   obtain ⟨result, hsearchAux, emitted, hemitted_mem, hassoc⟩ :=
-    recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition
+    recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core
       (J := Finset.univ)
       (fuel := d.liftedFactors.toList.length + 1)
-      hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+      hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
       hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
-      hcore_monic (Hex.DensePoly.dvd_refl_poly core) hpartition hmatches hirr hdvd hfuel
+      hcore_primitive hcore_lc_pos (Hex.DensePoly.dvd_refl_poly core)
+      hpartition hmatches hirr hdvd hfuel
   have hsearchMod :
-      Hex.recombinationSearchMod core (d.p ^ d.k) d.liftedFactors.toList =
+      Hex.scaledRecombinationSearchMod (Hex.DensePoly.leadingCoeff core) core
+          (d.p ^ d.k) d.liftedFactors.toList =
         some result := by
-    unfold Hex.recombinationSearchMod
+    unfold Hex.scaledRecombinationSearchMod
     exact hsearchAux
   refine ⟨emitted, ?_, hassoc⟩
   exact
-    exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
-      (B := B) hB_ne_zero hcore_monic h.lift_eq hsearchMod hemitted_mem
+    exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some
+      (B := B) hB_ne_zero h.lift_eq hsearchMod hemitted_mem
 
 /-- **#4006 slow-path capstone.**
 
@@ -13494,7 +13497,8 @@ theorem exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCo
     (hpartition :
       LiftedFactorSubsetPartition core d Finset.univ core)
     (hcore_ne : core ≠ 0)
-    (hcore_monic : Hex.DensePoly.Monic core)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hcore_record : Hex.shouldRecordPolynomialFactor core = true)
     (hB_ne_zero : B ≠ 0)
     (hd_modulus : 2 ≤ d.p ^ d.k)
@@ -13543,7 +13547,7 @@ theorem exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCo
       exact hr
     obtain ⟨emitted, hemitted_mem, hassoc⟩ :=
       exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
-        h hpartition hcore_ne hcore_monic hB_ne_zero hd_modulus
+        h hpartition hcore_ne hcore_primitive hcore_lc_pos hB_ne_zero hd_modulus
         hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
         hfactor_irr hfactor_dvd hprecision
     refine ⟨HexPolyZMathlib.toPolynomial emitted, ?_, ?_⟩
@@ -13805,11 +13809,19 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
   obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
+  have hcore_primitive :
+      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+    (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+  have hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore := by
+    rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
+      (1 : Int) from hcore_monic]
+    decide
   have hirr_raw : Hex.ZPoly.Irreducible raw :=
     exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence
-      h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero hd_modulus
-      hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
-      hprecision raw hraw_mem
+      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hd_liftedFactor_inj hprecision raw hraw_mem
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
 
@@ -13901,8 +13913,10 @@ theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorr
         (Hex.normalizeForFactor f).squareFreeCore d Finset.univ
         (Hex.normalizeForFactor f).squareFreeCore)
     (hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0)
-    (hcore_monic :
-      Hex.DensePoly.Monic (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_primitive :
+      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore)
     (hcore_record :
       Hex.shouldRecordPolynomialFactor
         (Hex.normalizeForFactor f).squareFreeCore = true)
@@ -13927,9 +13941,9 @@ theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorr
   obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
   have hirr_raw : Hex.ZPoly.Irreducible raw :=
     exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence
-      h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero hd_modulus
-      hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
-      hprecision raw hraw_mem
+      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hd_liftedFactor_inj hprecision raw hraw_mem
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
 

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3112,11 +3112,19 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
     exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
       (Hex.xPowerFactorArray_irreducible (Hex.normalizeForFactor f).xPower raw hx)
   · -- Exhaustive-core case: apply the outer-bound slow-path wrapper.
+    have hcore_primitive :
+        Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+      (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+    have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore := by
+      rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
+        (1 : Int) from hcore_monic]
+      decide
     exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence
       hbranch hentry_mem
       (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f)
       (liftedFactorSubsetPartition_outerBound_of_choosePrimeData f hf_ne)
-      hcore_ne hcore_monic hcore_record hB_ne_zero
+      hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hd_liftedFactor_inj hprecision ⟨raw, hcore_mem, hentry_eq⟩
 
@@ -3310,10 +3318,18 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
       (Hex.squareFreeCore_normalizeFactorSign_of_ne_zero f hf_ne)
   · -- Irreducibility on every emitted factor.
+    have hcore_primitive :
+        Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+      (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+    have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore := by
+      rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
+        (1 : Int) from hcore_monic]
+      decide
     exact exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence
       (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f)
       (liftedFactorSubsetPartition_outerBound_of_choosePrimeData f hf_ne)
-      hcore_ne hcore_monic hcore_record hB_ne_zero
+      hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hd_liftedFactor_inj hprecision
 

--- a/progress/20260518T032456Z_7b5d6e1e.md
+++ b/progress/20260518T032456Z_7b5d6e1e.md
@@ -1,0 +1,82 @@
+# BZ Mathlib-free: relax three exhaustive-coverage wrappers to primitive + pos-leading core
+
+Closes #4879.
+
+## Accomplished
+
+Relaxed the three top-level exhaustive-coverage wrappers in
+`HexBerlekampZassenhausMathlib/Basic.lean` from `(hcore_monic :
+Hex.DensePoly.Monic core)` to the pair `(hcore_primitive :
+Hex.ZPoly.Primitive core) (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
+core)`:
+
+1. `exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence`
+   (now line 13414): rewired through the relaxed substrate
+   `recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core`
+   (line 13184, landed via #4849) and the scaled membership wrapper
+   `exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some`
+   (line 9122, landed via #4875). The `recombinationSearchMod`
+   →`scaledRecombinationSearchMod` bridge is the unfolding-of-definition
+   pattern at the scaled flavour.
+2. `exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence`
+   (now line 13495): forwards `hcore_primitive` / `hcore_lc_pos` to the
+   relaxed wrapper 1.
+3. `factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`
+   (now line 13902): forwards `hcore_primitive` / `hcore_lc_pos` to the
+   relaxed wrapper 2.
+
+Consumer-side handling (issue gave us the choice; chose the local
+derivation approach to keep the diff tight):
+
+* `HexBerlekampZassenhausMathlib/IntReductionMod.lean` lines 3115 and
+  3313 (the two `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux`
+  and `exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData`
+  call sites): derive `hcore_primitive` from `hcore_monic` via
+  `monic_primitive_sign_normalized_of_monic`, and `hcore_lc_pos` from
+  `Hex.DensePoly.leadingCoeff core = 1` (the monicness definition).
+* The sibling intermediate wrapper
+  `factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`
+  in `Basic.lean` (line 13777, not one of the three in scope, no
+  consumers in-tree) uses the same local derivation.
+
+## Current frontier
+
+The umbrella drop of `hcore_monic` Gap 1 from
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` in
+`IntReductionMod.lean` (refile of #4640) is the natural next successor
+— it is now unblocked because every wrapper it transitively calls
+accepts `(hcore_primitive, hcore_lc_pos)`.
+
+## Next step
+
+Out of scope here. The wrapper-relaxation chain from #4639 is now
+fully landed (#4866 → #4869 → #4870 → #4875 → here).
+
+## Blockers
+
+None for the deliverable. Local verification note: `lake build
+HexBerlekampZassenhausMathlib.Basic` fails on `origin/main`
+(commit `dc7da010`) with pre-existing `whnf` heartbeat timeouts at
+several theorems (around lines 4848, 5129, 5455, 5541, 5803, 5925,
+6073, 6226, 6245, plus cascading kernel "unknown constant" errors and
+two later `whnf` timeouts at 14187/14298 in this branch's pre-edit
+state). My diff does not change the count, kind, or structural
+locations of these errors — same theorem names and same shape. CI on
+`origin/main` does not build `HexBerlekampZassenhausMathlib.Basic` as
+part of any merge-gating job (the default `lean_lib` target is
+`HexManual`; the merge-gating step builds only the `*_bench`
+executables, none of which transitively import this file).
+
+## Verification
+
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — exit 0.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+  HexBerlekampZassenhausMathlib/IntReductionMod.lean | grep -iE
+  "sorry|axiom|native_decide|TODO|FIXME"` on the `+` lines — no new
+  matches.
+* `lake build HexBerlekampZassenhausMathlib.Basic` — fails with the
+  pre-existing error set described above; structural error set is
+  identical to `origin/main` baseline (both 17 errors of the same shape
+  at structurally-equivalent theorems; only line numbers shift by the
+  expected delta from the relaxed wrappers' added hypothesis lines).


### PR DESCRIPTION
Closes #4879

Session: `7b5d6e1e-5b8a-4b55-b487-ac2e1ab7892d`

9a31b059 feat: relax three exhaustive-coverage wrappers to primitive + pos-leading core

🤖 Prepared with Claude Code