### PR TITLE
BZMathlib: abstract-bound siblings of exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate (monic + primitive unscaled)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -9788,26 +9788,33 @@ theorem exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core
     exact Finset.notMem_empty _ h_in_sdiff
   exact Finset.mem_biUnion.mp hi_in_bU
 
-/--
-Package a normalized irreducible factor of a recombination candidate as an
-executable `Hex.ZPoly` factor with the represented subset facts needed by the
-reverse-coverage degree argument.
+/-- Abstract-bound variant of
+`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate`:
+takes a universal bound `B'` valid on every normalised `Polynomial ℤ` factor
+of the recombination candidate, together with the precision hypothesis
+`2 * B' < d.p ^ d.k`, in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.
 
-The normalized-factor membership supplies an irreducible divisor of
-`toPolynomial (recombinationCandidate d T)`. Since the candidate is monic, that
-normalized divisor is monic too. Transporting the divisor back through
-`HexPolyZMathlib.ofPolynomial` gives a `Hex.ZPoly` divisor of the candidate and
-hence of `target`; the partition then provides its representing subset, and the
-support-containment field forces that subset to lie in `T`.
--/
-theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate
+The abstract bound is consumed only at the call to the abstract-bound
+support-containment lemma
+`representingSubset_subset_of_dvd_recombinationCandidate_of_bound`, which is
+vestigial in precision (the structural support field of the partition does
+not depend on it). The bound is threaded purely for API parity with the
+broader `_of_bound` propagation chain. -/
+theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_bound
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
     (hd_modulus : 2 ≤ d.p ^ d.k)
     (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hprecision : 2 * B' < d.p ^ d.k)
     (hpartition : LiftedFactorSubsetPartition core d J target)
     (_htarget_dvd_core : target ∣ core)
     (hTJ : T ⊆ J)
@@ -9863,9 +9870,213 @@ theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidat
   obtain ⟨S_g, hSJ, hSrep⟩ :=
     hpartition.exists_subset hg_irr_toPoly hg_dvd_target
   have hST : S_g ⊆ T :=
-    representingSubset_subset_of_dvd_recombinationCandidate
+    representingSubset_subset_of_dvd_recombinationCandidate_of_bound
+      B' (hvalid g (by rw [hg_toPolynomial]; exact hg_mem))
       hcore_ne hcore_monic hprecision hpartition hTJ hg_irr_toPoly
       hg_dvd_target hg_dvd_cand hSJ hSrep
+  have hcand_monic_poly :
+      (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)).Monic :=
+    toPolynomial_recombinationCandidate_monic hd_modulus hd_liftedFactor_monic T
+  have hg_monic_poly : gPoly.Monic := by
+    rcases hg_dvd_cand_poly with ⟨r, hr⟩
+    have hr_ne : r ≠ 0 := by
+      intro hr_zero
+      apply hcand_monic_poly.ne_zero
+      rw [hr, hr_zero, mul_zero]
+    have hlead_mul : gPoly.leadingCoeff * r.leadingCoeff = (1 : Int) := by
+      have hlead := Polynomial.leadingCoeff_mul gPoly r
+      rw [← hr, hcand_monic_poly.leadingCoeff] at hlead
+      simpa using hlead.symm
+    have hlead_normalized :
+        normalize gPoly.leadingCoeff = gPoly.leadingCoeff := by
+      have hlead := congrArg Polynomial.leadingCoeff hg_normalized
+      rwa [Polynomial.leadingCoeff_normalize] at hlead
+    have hlead_nonneg : 0 ≤ gPoly.leadingCoeff :=
+      Int.nonneg_of_normalize_eq_self hlead_normalized
+    rcases Int.mul_eq_one_iff_eq_one_or_neg_one.mp hlead_mul with hpos | hneg
+    · exact hpos.1
+    · exfalso
+      rw [hneg.1] at hlead_nonneg
+      omega
+  have hg_monic_hex : Hex.DensePoly.Monic g := by
+    have hlead : (HexPolyZMathlib.toPolynomial g).leadingCoeff = 1 := by
+      rw [hg_toPolynomial]
+      exact hg_monic_poly
+    rwa [HexPolyMathlib.leadingCoeff_toPolynomial] at hlead
+  obtain ⟨_, hg_content, hg_norm_sign⟩ :=
+    monic_primitive_sign_normalized_of_monic hg_monic_hex
+  exact ⟨g, S_g, hg_toPolynomial, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
+    hSrep, hSJ, hST, hg_content, hg_norm_sign⟩
+
+/--
+Package a normalized irreducible factor of a recombination candidate as an
+executable `Hex.ZPoly` factor with the represented subset facts needed by the
+reverse-coverage degree argument.
+
+The normalized-factor membership supplies an irreducible divisor of
+`toPolynomial (recombinationCandidate d T)`. Since the candidate is monic, that
+normalized divisor is monic too. Transporting the divisor back through
+`HexPolyZMathlib.ofPolynomial` gives a `Hex.ZPoly` divisor of the candidate and
+hence of `target`; the partition then provides its representing subset, and the
+support-containment field forces that subset to lie in `T`.
+
+This is the `defaultFactorCoeffBound core`-instantiated thin wrapper for
+`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_bound`:
+each normalised factor `g` of the candidate divides the candidate, which
+divides `target` (via `hquot`), which divides `core` (via `htarget_dvd_core`),
+so `defaultFactorCoeffBound_valid` discharges the universal bound hypothesis.
+-/
+theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient)
+    {gPoly : Polynomial ℤ}
+    (hg_mem : gPoly ∈ UniqueFactorizationMonoid.normalizedFactors
+      (HexPolyZMathlib.toPolynomial (recombinationCandidate d T))) :
+    ∃ (g : Hex.ZPoly) (S_g : LiftedFactorSubset d),
+      HexPolyZMathlib.toPolynomial g = gPoly ∧
+      Irreducible (HexPolyZMathlib.toPolynomial g) ∧
+      g ∣ target ∧
+      g ∣ recombinationCandidate d T ∧
+      RepresentsIntegerFactorAtLift core d g S_g ∧
+      S_g ⊆ J ∧
+      S_g ⊆ T ∧
+      Hex.ZPoly.content g = 1 ∧
+      Hex.normalizeFactorSign g = g := by
+  have hcand_dvd_target : recombinationCandidate d T ∣ target := by
+    have hmul : quotient * recombinationCandidate d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hcand_dvd_core : recombinationCandidate d T ∣ core := by
+    rcases hcand_dvd_target with ⟨r₁, hr₁⟩
+    rcases htarget_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  refine exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (fun g hg_mem' => ?_)
+    hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic hprecision
+    hpartition htarget_dvd_core hTJ hrecord hquot hg_mem
+  -- Discharge `hvalid` for arbitrary normalised factor `g` of the candidate
+  -- by chaining `g ∣ candidate ∣ target ∣ core` and invoking
+  -- `defaultFactorCoeffBound_valid`.
+  have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+      HexPolyZMathlib.toPolynomial (recombinationCandidate d T) :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem'
+  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+    rcases hg_poly_dvd with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    exact hr
+  have hg_dvd_core : g ∣ core := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
+
+/-- Abstract-bound variant of
+`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core`:
+takes a universal bound `B'` valid on every normalised `Polynomial ℤ` factor
+of the recombination candidate, together with the precision hypothesis
+`2 * B' < d.p ^ d.k`, in place of the core-shape `defaultFactorCoeffBound core`
+precision constraint.
+
+As in the support-containment chain, the abstract bound is consumed only at
+the call to
+`representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound`,
+which is vestigial in precision (the structural support field of the
+partition does not depend on it). The bound is threaded purely for API parity
+with the broader `_of_bound` propagation chain. -/
+theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core_of_bound
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (_htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient)
+    {gPoly : Polynomial ℤ}
+    (hg_mem : gPoly ∈ UniqueFactorizationMonoid.normalizedFactors
+      (HexPolyZMathlib.toPolynomial (recombinationCandidate d T))) :
+    ∃ (g : Hex.ZPoly) (S_g : LiftedFactorSubset d),
+      HexPolyZMathlib.toPolynomial g = gPoly ∧
+      Irreducible (HexPolyZMathlib.toPolynomial g) ∧
+      g ∣ target ∧
+      g ∣ recombinationCandidate d T ∧
+      RepresentsIntegerFactorAtLift core d g S_g ∧
+      S_g ⊆ J ∧
+      S_g ⊆ T ∧
+      Hex.ZPoly.content g = 1 ∧
+      Hex.normalizeFactorSign g = g := by
+  obtain ⟨hcand_poly_ne_zero, _hcand_poly_nonunit⟩ :=
+    toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord hrecord
+  have hg_norm :=
+    (UniqueFactorizationMonoid.mem_normalizedFactors_iff'
+      (p := gPoly) (x := HexPolyZMathlib.toPolynomial (recombinationCandidate d T))
+      hcand_poly_ne_zero).mp hg_mem
+  rcases hg_norm with ⟨hg_irr, hg_normalized, hg_dvd_cand_poly⟩
+  let g : Hex.ZPoly := HexPolyZMathlib.ofPolynomial gPoly
+  have hg_toPolynomial : HexPolyZMathlib.toPolynomial g = gPoly :=
+    HexPolyZMathlib.toPolynomial_ofPolynomial gPoly
+  have hg_irr_toPoly : Irreducible (HexPolyZMathlib.toPolynomial g) := by
+    rw [hg_toPolynomial]
+    exact hg_irr
+  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+    rcases hg_dvd_cand_poly with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    rw [hg_toPolynomial]
+    exact hr
+  have hcand_dvd_target : recombinationCandidate d T ∣ target := by
+    have hmul : quotient * recombinationCandidate d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hg_dvd_target : g ∣ target := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_target with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  obtain ⟨S_g, hSJ, hSrep⟩ :=
+    hpartition.exists_subset hg_irr_toPoly hg_dvd_target
+  have hST : S_g ⊆ T :=
+    representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound
+      B' (hvalid g (by rw [hg_toPolynomial]; exact hg_mem))
+      hcore_ne hcore_primitive hcore_lc_pos hprecision hpartition hTJ
+      hg_irr_toPoly hg_dvd_target hg_dvd_cand hSJ hSrep
   have hcand_monic_poly :
       (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)).Monic :=
     toPolynomial_recombinationCandidate_monic hd_modulus hd_liftedFactor_monic T
@@ -9908,7 +10119,13 @@ The monic-core hypothesis is threaded only through
 `representingSubset_subset_of_dvd_recombinationCandidate` (vestigial there);
 all essential algebra runs on the always-monic recombination candidate, so
 the proof body is identical to the monic version except for the routing
-through the primitive-core variants of the helpers. -/
+through the primitive-core variants of the helpers.
+
+This is the `defaultFactorCoeffBound core`-instantiated thin wrapper for
+`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core_of_bound`:
+each normalised factor `g` of the candidate divides the candidate, which
+divides `target` (via `hquot`), which divides `core` (via `htarget_dvd_core`),
+so `defaultFactorCoeffBound_valid` discharges the universal bound hypothesis. -/
 theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
@@ -9919,7 +10136,7 @@ theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidat
     (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
     (hpartition : LiftedFactorSubsetPartition core d J target)
-    (_htarget_dvd_core : target ∣ core)
+    (htarget_dvd_core : target ∣ core)
     (hTJ : T ⊆ J)
     (hrecord :
       Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
@@ -9938,77 +10155,41 @@ theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidat
       S_g ⊆ T ∧
       Hex.ZPoly.content g = 1 ∧
       Hex.normalizeFactorSign g = g := by
-  obtain ⟨hcand_poly_ne_zero, _hcand_poly_nonunit⟩ :=
-    toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord hrecord
-  have hg_norm :=
-    (UniqueFactorizationMonoid.mem_normalizedFactors_iff'
-      (p := gPoly) (x := HexPolyZMathlib.toPolynomial (recombinationCandidate d T))
-      hcand_poly_ne_zero).mp hg_mem
-  rcases hg_norm with ⟨hg_irr, hg_normalized, hg_dvd_cand_poly⟩
-  let g : Hex.ZPoly := HexPolyZMathlib.ofPolynomial gPoly
-  have hg_toPolynomial : HexPolyZMathlib.toPolynomial g = gPoly :=
-    HexPolyZMathlib.toPolynomial_ofPolynomial gPoly
-  have hg_irr_toPoly : Irreducible (HexPolyZMathlib.toPolynomial g) := by
-    rw [hg_toPolynomial]
-    exact hg_irr
-  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
-    rcases hg_dvd_cand_poly with ⟨r, hr⟩
-    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
-    apply HexPolyZMathlib.equiv.injective
-    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
-      HexPolyZMathlib.toPolynomial_ofPolynomial]
-    rw [hg_toPolynomial]
-    exact hr
   have hcand_dvd_target : recombinationCandidate d T ∣ target := by
     have hmul : quotient * recombinationCandidate d T = target :=
       Hex.exactQuotient?_product hquot
     refine ⟨quotient, ?_⟩
     rw [Hex.DensePoly.mul_comm_poly (S := Int)]
     exact hmul.symm
-  have hg_dvd_target : g ∣ target := by
-    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
-    rcases hcand_dvd_target with ⟨r₂, hr₂⟩
+  have hcand_dvd_core : recombinationCandidate d T ∣ core := by
+    rcases hcand_dvd_target with ⟨r₁, hr₁⟩
+    rcases htarget_dvd_core with ⟨r₂, hr₂⟩
     refine ⟨r₁ * r₂, ?_⟩
     rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
-  obtain ⟨S_g, hSJ, hSrep⟩ :=
-    hpartition.exists_subset hg_irr_toPoly hg_dvd_target
-  have hST : S_g ⊆ T :=
-    representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core
-      hcore_ne hcore_primitive hcore_lc_pos hprecision hpartition hTJ
-      hg_irr_toPoly hg_dvd_target hg_dvd_cand hSJ hSrep
-  have hcand_monic_poly :
-      (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)).Monic :=
-    toPolynomial_recombinationCandidate_monic hd_modulus hd_liftedFactor_monic T
-  have hg_monic_poly : gPoly.Monic := by
-    rcases hg_dvd_cand_poly with ⟨r, hr⟩
-    have hr_ne : r ≠ 0 := by
-      intro hr_zero
-      apply hcand_monic_poly.ne_zero
-      rw [hr, hr_zero, mul_zero]
-    have hlead_mul : gPoly.leadingCoeff * r.leadingCoeff = (1 : Int) := by
-      have hlead := Polynomial.leadingCoeff_mul gPoly r
-      rw [← hr, hcand_monic_poly.leadingCoeff] at hlead
-      simpa using hlead.symm
-    have hlead_normalized :
-        normalize gPoly.leadingCoeff = gPoly.leadingCoeff := by
-      have hlead := congrArg Polynomial.leadingCoeff hg_normalized
-      rwa [Polynomial.leadingCoeff_normalize] at hlead
-    have hlead_nonneg : 0 ≤ gPoly.leadingCoeff :=
-      Int.nonneg_of_normalize_eq_self hlead_normalized
-    rcases Int.mul_eq_one_iff_eq_one_or_neg_one.mp hlead_mul with hpos | hneg
-    · exact hpos.1
-    · exfalso
-      rw [hneg.1] at hlead_nonneg
-      omega
-  have hg_monic_hex : Hex.DensePoly.Monic g := by
-    have hlead : (HexPolyZMathlib.toPolynomial g).leadingCoeff = 1 := by
-      rw [hg_toPolynomial]
-      exact hg_monic_poly
-    rwa [HexPolyMathlib.leadingCoeff_toPolynomial] at hlead
-  obtain ⟨_, hg_content, hg_norm_sign⟩ :=
-    monic_primitive_sign_normalized_of_monic hg_monic_hex
-  exact ⟨g, S_g, hg_toPolynomial, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
-    hSrep, hSJ, hST, hg_content, hg_norm_sign⟩
+  refine exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (fun g hg_mem' => ?_)
+    hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
+    hprecision hpartition htarget_dvd_core hTJ hrecord hquot hg_mem
+  -- Discharge `hvalid` for arbitrary normalised factor `g` of the candidate
+  -- by chaining `g ∣ candidate ∣ target ∣ core` and invoking
+  -- `defaultFactorCoeffBound_valid`.
+  have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+      HexPolyZMathlib.toPolynomial (recombinationCandidate d T) :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem'
+  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+    rcases hg_poly_dvd with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    exact hr
+  have hg_dvd_core : g ∣ core := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
 
 /-- Reverse-coverage existence theorem for the recombination candidate.
 

--- a/progress/20260518T033141Z_8a4738a1.md
+++ b/progress/20260518T033141Z_8a4738a1.md
@@ -1,0 +1,58 @@
+# Session 8a4738a1 — abstract-bound siblings of `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate*`
+
+Closes #4902.
+
+## Accomplished
+
+* Added `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_bound`
+  (monic-flavour abstract-bound sibling) in `HexBerlekampZassenhausMathlib/Basic.lean`.
+  Takes universal `B' : Nat` plus `hvalid : ∀ g, toPolynomial g ∈ normalizedFactors candidate → ∀ i, (g.coeff i).natAbs ≤ B'`
+  and precision `2 * B' < d.p ^ d.k`; routes through
+  `representingSubset_subset_of_dvd_recombinationCandidate_of_bound`.
+* Added `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core_of_bound`
+  (primitive + positive-leading unscaled flavour) with the analogous universal
+  bound shape; routes through
+  `representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound`.
+* Rewired both originals (`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate`
+  and `..._of_primitive_pos_lc_core`) as thin wrappers that instantiate
+  `B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharge `hvalid` by
+  chaining `g ∣ candidate ∣ target ∣ core` and invoking
+  `defaultFactorCoeffBound_valid`. The vestigial `_htarget_dvd_core`
+  parameter became non-vestigial as `htarget_dvd_core` in the wrappers
+  (consumers already passed it positionally).
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib`: failures match `origin/main`
+  exactly (same error identities, shifted by the inserted 181 lines). No
+  new errors in the 9500–11300 line range of `HexBerlekampZassenhausMathlib/Basic.lean`
+  that contains my edits.
+* `python3 scripts/check_dag.py`: clean.
+* `git diff --check`: clean.
+* No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` on the diff against
+  `origin/main`.
+
+## Current frontier
+
+Layer 1 abstract-bound siblings now cover the unscaled-side
+per-normalised-factor bridge layer (monic + primitive). The scaled-side
+bridge (`exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core`)
+still lacks its `_of_bound` sibling and depends on
+`zpoly_primitive_scaledRecombinationCandidate_of_bound`, which is the
+next prerequisite. Layers above this (`mem_T_iff_*`, `coverAtMin_*`,
+`recombinationSearchModAux_*`) remain pending.
+
+## Next step
+
+A planner can open follow-on issues for:
+* `zpoly_primitive_scaledRecombinationCandidate_of_bound` (Mignotte-style
+  primitivity bridge that actually consumes precision; this is the
+  blocker for the scaled-flavour sibling).
+* `exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+  (gated on the above).
+* Continuing the `_of_bound` propagation chain into `mem_T_iff_*` and
+  beyond.
+
+## Blockers
+
+None for this session.


### PR DESCRIPTION
Closes #4902

Session: `8a4738a1-de6d-4799-8bef-cf9103e7ba1b`

7b4f9ee9 feat: add abstract-bound siblings of exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate* (#4902)

🤖 Prepared with Claude Code