### PR TITLE
BZMathlib: abstract-bound sibling of natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8447,28 +8447,31 @@ private theorem size_primitivePart_eq_of_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) 
           (Hex.ZPoly.primitivePart f)).size := h_scale_size.symm
     _ = f.size := by rw [h_rec]
 
-/-- The Mathlib-transported `natDegree` of the scaled recombination candidate
-over a lifted-factor subset equals the sum of the Mathlib-transported
-`natDegree`s of the selected lifted factors, given primitive + positive-leading
-`core` and the Mignotte precision bound.
+/-- Abstract-bound sibling of
+`natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum`: takes
+`B' : Nat`, `hcore_lc_bound : (lc core).natAbs ≤ B'`, and
+`hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.
 
-The candidate goes through `centeredLiftPoly ∘ primitivePart ∘ normalizeFactorSign`
-on top of `scaledLiftedFactorProduct = scale (lc core) (liftedFactorProduct)`.
-Each step preserves stored size: scaling by the nonzero leading coefficient,
-centred-lift under the positive-leading bound, primitive part on a nonzero
-input, and sign normalisation. Combined with `lp.size = ∑ + 1` for the monic
-lifted-factor product, the candidate's natDegree decomposes as a sum.
+The single precision consumer in the proof body is
+`size_centeredLiftPoly_eq_of_pos_leadingCoeff_bound`, which requires a
+leading-coefficient bound on `scaledLiftedFactorProduct core d T`. That
+leading coefficient is `lc core`, so the hypothesis-supplied
+`hcore_lc_bound` discharges the precondition directly.
 
-Companion scaled variant of `natDegree_toPolynomial_recombinationCandidate_eq_sum`.
-Consumed by the scaled cover-at-min chain for the primitive recursive
-recombination coverage proof (#4647 / #4737). -/
-theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
+Follows the `(B', hcore_lc_bound, hprecision)` parameter ordering
+established by `representsIntegerFactorAtLift_primitive_of_bound`,
+`natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound`,
+and `zpoly_primitive_scaledRecombinationCandidate_of_bound`. -/
+theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound
     {core : Hex.ZPoly} {d : Hex.LiftData}
+    (B' : Nat)
     (hcore_ne : core ≠ 0)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic :
       ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hcore_lc_bound : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hprecision : 2 * B' < d.p ^ d.k)
     (T : LiftedFactorSubset d) :
     (HexPolyZMathlib.toPolynomial
         (scaledRecombinationCandidate core d T)).natDegree =
@@ -8495,34 +8498,9 @@ theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
   have hslp_lc_pos :
       0 < Hex.DensePoly.leadingCoeff (scaledLiftedFactorProduct core d T) := by
     rw [hslp_lc]; exact hcore_lc_pos
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
   have hslp_lc_bound :
       (Hex.DensePoly.leadingCoeff (scaledLiftedFactorProduct core d T)).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
+        B' := by
     rwa [hslp_lc]
   have hcl_size :
       (Hex.centeredLiftPoly (scaledLiftedFactorProduct core d T)
@@ -8575,6 +8553,69 @@ theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
   show (HexPolyZMathlib.toPolynomial (liftedFactor d i)).leadingCoeff = 1
   rw [HexPolyMathlib.leadingCoeff_toPolynomial]
   exact hd_liftedFactor_monic i
+
+/-- The Mathlib-transported `natDegree` of the scaled recombination candidate
+over a lifted-factor subset equals the sum of the Mathlib-transported
+`natDegree`s of the selected lifted factors, given primitive + positive-leading
+`core` and the Mignotte precision bound.
+
+The candidate goes through `centeredLiftPoly ∘ primitivePart ∘ normalizeFactorSign`
+on top of `scaledLiftedFactorProduct = scale (lc core) (liftedFactorProduct)`.
+Each step preserves stored size: scaling by the nonzero leading coefficient,
+centred-lift under the positive-leading bound, primitive part on a nonzero
+input, and sign normalisation. Combined with `lp.size = ∑ + 1` for the monic
+lifted-factor product, the candidate's natDegree decomposes as a sum.
+
+Thin wrapper over
+`natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound` that
+instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharges
+`hcore_lc_bound` via `defaultFactorCoeffBound_valid core hcore_ne core
+hcore_dvd_self` at index `core.size - 1`, converted to the leading
+coefficient via `leadingCoeff_eq_coeff_last`.
+
+Companion scaled variant of `natDegree_toPolynomial_recombinationCandidate_eq_sum`.
+Consumed by the scaled cover-at-min chain for the primitive recursive
+recombination coverage proof (#4647 / #4737). -/
+theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
+    {core : Hex.ZPoly} {d : Hex.LiftData}
+    (hcore_ne : core ≠ 0)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (T : LiftedFactorSubset d) :
+    (HexPolyZMathlib.toPolynomial
+        (scaledRecombinationCandidate core d T)).natDegree =
+      ∑ i ∈ T,
+        (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_lc_bound :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hcore_dvd_self : core ∣ core :=
+      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_ne hcore_lc_pos hd_liftedFactor_monic hcore_lc_bound hprecision T
 
 /-- Abstract-bound variant of
 `natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core`:

--- a/progress/20260518T034405Z_d1e63d44.md
+++ b/progress/20260518T034405Z_d1e63d44.md
@@ -1,0 +1,64 @@
+# Progress: BZMathlib `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound`
+
+Issue: #4916. Branch: `agent/d1e63d44`.
+
+## Accomplished
+
+- Added `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound`
+  in `HexBerlekampZassenhausMathlib/Basic.lean` as the abstract-bound
+  sibling of `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum`.
+  Takes `(B' : Nat)`, `hcore_lc_bound : (lc core).natAbs ≤ B'`, and
+  `hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
+  `defaultFactorCoeffBound core` precision constraint, mirroring the
+  parameter ordering of `representsIntegerFactorAtLift_primitive_of_bound`
+  / `natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound`
+  / `zpoly_primitive_scaledRecombinationCandidate_of_bound`.
+- Dropped the inline `hcore_size_pos` and `hcore_lc_bound` derivations from
+  the sibling's proof body (no longer needed once `hcore_lc_bound` is a
+  hypothesis); rewrote the `hslp_lc_bound` step so its right-hand bound is
+  `B'`. All other steps and call shapes are unchanged.
+- Rewired the existing `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum`
+  as a thin wrapper that instantiates `B' := defaultFactorCoeffBound core`
+  and discharges `hcore_lc_bound` via `defaultFactorCoeffBound_valid core
+  hcore_ne core hcore_dvd_self (core.size - 1)` followed by
+  `leadingCoeff_eq_coeff_last`. The wrapper preserves the existing
+  signature exactly; the single downstream consumer at line ~10986 (the
+  scaled cover theorem) continues to type-check unchanged.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` — no new errors
+  relative to `origin/main`. Pre-existing environment-specific failures
+  (whnf timeouts at lines 5925/6073/6226/6245/14228/14339, kernel
+  unknown-constant errors at 6560/6624/14546/14592, and the
+  `cases failed`/`Dependent elimination failed` at 5803) are unchanged
+  (line offsets shift +41 from baseline due to the added sibling, which
+  is consistent with the diff).
+- `lake build HexBerlekampZassenhausMathlib` — same pre-existing
+  failures, no new errors.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean |
+   grep -E "^\+.*(sorry|axiom|native_decide|TODO|FIXME)"` — empty.
+
+## Current frontier
+
+The scaled-side substrate `_of_bound` lift is now landed. The next
+follow-on (out of scope here) is the scaled-side cover theorem
+`exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+at line ~10945, which needs both this substrate **and** #4907 (the
+per-factor scaled bridge `_of_bound`, currently unclaimed).
+
+## Next step
+
+The cover `_of_bound` lift is gated on #4907 landing; once that and
+this PR are merged, the scaled-side cover sibling can be filed as a
+new atomic issue.
+
+## Blockers
+
+None for this issue. Note: the broader Basic.lean module remains
+red on the host due to the pre-existing whnf timeouts and unknown
+kernel-constant errors. CI is the authority on whether the file
+typechecks fully; per agent CLAUDE.md doctrine these are
+environment-specific and tracked separately.


### PR DESCRIPTION
Closes #4916

Session: `d1e63d44-ce70-418f-bfef-4673eb9ef600`

57edc45a feat: add natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound sibling

🤖 Prepared with Claude Code