### PR TITLE
BZMathlib: abstract-bound sibling of exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -10982,28 +10982,39 @@ private theorem zpoly_primitive_scaledRecombinationCandidate
     (Hex.ZPoly.defaultFactorCoeffBound core) hcore_lc_le
     hcore_ne hcore_lc_pos hd_liftedFactor_monic hprecision T
 
-/-- Scaled-candidate counterpart of
-`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core`.
+/-- Abstract-bound variant of
+`exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core`:
+takes a universal bound `B'` valid on every normalised `Polynomial ℤ`
+factor of the scaled recombination candidate, the leading-coefficient
+bound `hcore_lc_le : (DensePoly.leadingCoeff core).natAbs ≤ B'`, and the
+precision hypothesis `2 * B' < d.p ^ d.k`, in place of the core-shape
+`defaultFactorCoeffBound core` precision constraint.
 
-The scaled recombination candidate is not monic but is primitive with
-nonnegative leading coefficient by construction
-(`normalizeFactorSign ∘ primitivePart`), so its `Polynomial ℤ` transport is
-`IsPrimitive` and `normalize`-fixed. Each normalized irreducible factor `gPoly`
-of the transport inherits primitivity (every divisor of a primitive
-polynomial is primitive over `Polynomial ℤ`) and has nonnegative leading
-coefficient (from `normalize_normalized_factor`), yielding `content g = 1` and
-`normalizeFactorSign g = g` for the reified `Hex.ZPoly` factor
-`g := ofPolynomial gPoly`. -/
-theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core
+Unlike the unscaled siblings, the abstract bound is consumed at two
+call sites here: at
+`zpoly_primitive_scaledRecombinationCandidate_of_bound` (precision is
+non-vestigial — the centred-lift size machinery for the scaled lifted
+product is keyed off `hprecision`) and at
+`representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+(precision is vestigial there, threaded purely for API parity). -/
+theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (scaledRecombinationCandidate core d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (hcore_primitive : Hex.ZPoly.Primitive core)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hprecision : 2 * B' < d.p ^ d.k)
     (hpartition : LiftedFactorSubsetPartition core d J target)
-    (_htarget_dvd_core : target ∣ core)
+    (htarget_dvd_core : target ∣ core)
     (hTJ : T ⊆ J)
     (hrecord :
       Hex.shouldRecordPolynomialFactor
@@ -11061,8 +11072,9 @@ theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCa
   -- propagates to every divisor, including `gPoly`.
   have hcand_primitive : Hex.ZPoly.Primitive
       (scaledRecombinationCandidate core d T) :=
-    zpoly_primitive_scaledRecombinationCandidate hcore_ne hcore_lc_pos
-      hd_liftedFactor_monic hprecision T
+    zpoly_primitive_scaledRecombinationCandidate_of_bound
+      B' hcore_lc_le hcore_ne hcore_lc_pos hd_liftedFactor_monic
+      hprecision T
   have hcand_poly_primitive :
       (HexPolyZMathlib.toPolynomial
         (scaledRecombinationCandidate core d T)).IsPrimitive :=
@@ -11094,12 +11106,133 @@ theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCa
   obtain ⟨S_g, hSJ, hSrep⟩ :=
     hpartition.exists_subset hg_irr_toPoly hg_dvd_target
   have hST : S_g ⊆ T :=
-    representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core
-      hcore_ne hcore_primitive hcore_lc_pos hprecision _htarget_dvd_core
+    representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound
+      B' (hvalid g (by rw [hg_toPolynomial]; exact hg_mem))
+      hcore_ne hcore_primitive hcore_lc_pos hprecision htarget_dvd_core
       hpartition hTJ hg_irr_toPoly hg_dvd_target hg_content hg_norm_sign
       hg_dvd_cand hSJ hSrep
   exact ⟨g, S_g, hg_toPolynomial, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
     hSrep, hSJ, hST, hg_content, hg_norm_sign⟩
+
+/-- Scaled-candidate counterpart of
+`exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core`.
+
+The scaled recombination candidate is not monic but is primitive with
+nonnegative leading coefficient by construction
+(`normalizeFactorSign ∘ primitivePart`), so its `Polynomial ℤ` transport is
+`IsPrimitive` and `normalize`-fixed. Each normalized irreducible factor `gPoly`
+of the transport inherits primitivity (every divisor of a primitive
+polynomial is primitive over `Polynomial ℤ`) and has nonnegative leading
+coefficient (from `normalize_normalized_factor`), yielding `content g = 1` and
+`normalizeFactorSign g = g` for the reified `Hex.ZPoly` factor
+`g := ofPolynomial gPoly`.
+
+This is the `defaultFactorCoeffBound core`-instantiated thin wrapper for
+`exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`:
+each normalised factor `g` of the candidate divides the candidate, which
+divides `target` (via `hquot`), which divides `core` (via
+`htarget_dvd_core`), so `defaultFactorCoeffBound_valid` discharges the
+universal bound hypothesis; the core leading-coefficient bound is
+discharged via the self-divisibility instance of the same lemma. -/
+theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor
+          (scaledRecombinationCandidate core d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (scaledRecombinationCandidate core d T) =
+        some quotient)
+    {gPoly : Polynomial ℤ}
+    (hg_mem : gPoly ∈ UniqueFactorizationMonoid.normalizedFactors
+      (HexPolyZMathlib.toPolynomial (scaledRecombinationCandidate core d T))) :
+    ∃ (g : Hex.ZPoly) (S_g : LiftedFactorSubset d),
+      HexPolyZMathlib.toPolynomial g = gPoly ∧
+      Irreducible (HexPolyZMathlib.toPolynomial g) ∧
+      g ∣ target ∧
+      g ∣ scaledRecombinationCandidate core d T ∧
+      RepresentsIntegerFactorAtLift core d g S_g ∧
+      S_g ⊆ J ∧
+      S_g ⊆ T ∧
+      Hex.ZPoly.content g = 1 ∧
+      Hex.normalizeFactorSign g = g := by
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hcore_dvd_self : core ∣ core :=
+      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  have hcand_dvd_target :
+      scaledRecombinationCandidate core d T ∣ target := by
+    have hmul : quotient * scaledRecombinationCandidate core d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hcand_dvd_core :
+      scaledRecombinationCandidate core d T ∣ core := by
+    rcases hcand_dvd_target with ⟨r₁, hr₁⟩
+    rcases htarget_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    -- `core` appears both bare on the LHS and inside the
+    -- `scaledRecombinationCandidate core d T` term on the RHS; restrict
+    -- the rewrite chain to the LHS so the candidate's `core` argument
+    -- stays untouched.
+    conv_lhs => rw [hr₂, hr₁]
+    rw [Hex.DensePoly.mul_assoc_poly (S := Int)]
+  refine exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (fun g hg_mem' => ?_)
+    hcore_lc_le hcore_ne hcore_primitive hcore_lc_pos
+    hd_liftedFactor_monic hprecision hpartition htarget_dvd_core hTJ
+    hrecord hquot hg_mem
+  -- Discharge `hvalid` for arbitrary normalised factor `g` of the
+  -- scaled candidate by chaining `g ∣ candidate ∣ target ∣ core` and
+  -- invoking `defaultFactorCoeffBound_valid`.
+  have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+      HexPolyZMathlib.toPolynomial
+        (scaledRecombinationCandidate core d T) :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem'
+  have hg_dvd_cand : g ∣ scaledRecombinationCandidate core d T := by
+    rcases hg_poly_dvd with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    exact hr
+  have hg_dvd_core : g ∣ core := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
 
 /-- Scaled-candidate counterpart of
 `exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core`.

--- a/progress/20260518T035027Z_184d5454.md
+++ b/progress/20260518T035027Z_184d5454.md
@@ -1,0 +1,104 @@
+# 2026-05-18 03:50 UTC — scaled `_of_primitive_pos_lc_core_of_bound` per-normalised-factor bridge (184d5454)
+
+Claimed feature issue #4907 and landed the scaled-side `_of_bound`
+sibling of
+`exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core`
+in `HexBerlekampZassenhausMathlib/Basic.lean`, mirroring #4902's
+structure for the unscaled monic and primitive flavours.
+
+## What landed
+
+* **New sibling**
+  `exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`,
+  taking `(B' : Nat)`, the universal coefficient bound
+  `(hvalid : ∀ g, toPolynomial g ∈ normalizedFactors (toPolynomial (scaledRecombinationCandidate core d T)) → ∀ i, (g.coeff i).natAbs ≤ B')`,
+  the leading-coefficient bound
+  `(hcore_lc_le : (DensePoly.leadingCoeff core).natAbs ≤ B')`, and the
+  precision hypothesis `(hprecision : 2 * B' < d.p ^ d.k)` in place of
+  the core-shape `defaultFactorCoeffBound core` constraint.
+* The proof body mirrors the original (now-wrapper) with two
+  call-site substitutions:
+  - `zpoly_primitive_scaledRecombinationCandidate_of_bound` (from
+    #4905) in place of `zpoly_primitive_scaledRecombinationCandidate`,
+    threading `B'`, `hcore_lc_le`, and `hprecision`.
+  - `representingSubset_subset_of_dvd_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+    (from #4901) in place of the un-bounded version, with `hvalid g`
+    instantiated via the `hg_mem` translation
+    `hvalid g (by rw [hg_toPolynomial]; exact hg_mem)`.
+* The previously vestigial `_htarget_dvd_core` binder is renamed to
+  `htarget_dvd_core` (non-vestigial — it is still positionally
+  required by the `_of_bound` support-containment substrate, even
+  though that substrate marks its own copy vestigial).
+
+* **Wrapper rewiring** of the original
+  `exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core`
+  as a thin delegator. The wrapper:
+  - derives `hcore_size_pos` from `hcore_lc_pos` (no zero-size core),
+  - derives `hcore_lc_le` from
+    `defaultFactorCoeffBound_valid core hcore_ne core (dvd_refl)`
+    paired with `leadingCoeff_eq_coeff_last`,
+  - builds `hcand_dvd_target` from `Hex.exactQuotient?_product hquot`,
+  - builds `hcand_dvd_core` by chaining `cand ∣ target ∣ core` (see
+    "Scaled-cascade gotcha" below),
+  - delegates into the new `_of_bound` sibling with
+    `B' := defaultFactorCoeffBound core`, discharging `hvalid` for an
+    arbitrary normalised factor `g` by lifting to `g ∣ core` and
+    invoking `defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core`.
+  - Renames the original's vestigial `_htarget_dvd_core` binder to
+    non-vestigial `htarget_dvd_core` (the two existing consumers at
+    the former lines 10806 / 10886 already pass it positionally).
+
+## Scaled-cascade gotcha (not in #4902)
+
+In the unscaled per-normalised-factor wrapper landed by #4902, the
+`cand ∣ core` chain uses plain `rw [hr₂, hr₁, mul_assoc_poly]` because
+`recombinationCandidate d T` is syntactically independent of `core`.
+For the scaled candidate this naive rewrite cascades: `hr₂` is
+`core = target * r₂`, and `rw [hr₂]` rewrites *every* `core` in the
+goal — including the `core` argument inside the goal's
+`scaledRecombinationCandidate core d T`. The recursive substitution
+produces
+
+```
+scaledRecombinationCandidate core d T * (r₁ * r₂) =
+  scaledRecombinationCandidate (scaledRecombinationCandidate core d T * (r₁ * r₂)) d T * (r₁ * r₂)
+```
+
+which obviously cannot close. The fix is to restrict the rewrite to
+the LHS via `conv_lhs => rw [hr₂, hr₁]` and then close the residual
+associativity with `Hex.DensePoly.mul_assoc_poly (S := Int)`. A short
+comment in the proof flags this so future scaled-side wrappers don't
+repeat the trip.
+
+The inner `g ∣ core` chain inside the wrapper's `hvalid` discharger
+does *not* hit the same trap because its goal `core = g * (r₁ * r₂)`
+has `core` only on the LHS — there is no `scaledRecombinationCandidate
+core d T` on the RHS to recursively re-expand.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — 15 errors,
+  identical set to `origin/main` baseline (rebuilt fresh from
+  `bf703d1e` to confirm): the seven whnf timeouts in lines 4848–6245,
+  the two kernel-unknown errors at 6560 / 6624, the cases-nested
+  failure at 5803, two more whnf timeouts at 14501 / 14612, and two
+  kernel-unknown errors at 14819 / 14865. No errors at the edit's
+  line range (~10982–11253).
+* `lake build HexBerlekampZassenhausMathlib` — same 15-error set,
+  unchanged.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean |
+   grep -E "^\+.*(sorry|axiom|native_decide|TODO|FIXME)"` — no new
+  entries.
+
+## Carryover
+
+* The `_of_bound` layer is now complete up to the
+  `recombinationCandidate` and `scaledRecombinationCandidate`
+  per-normalised-factor surfaces (`#4902` + this PR).
+* Next concerns up the chain are caller-side instantiations on the
+  abstract-bound interface (`mem_T_iff_*`, `coverAtMin_*`,
+  `liftedFactorSubsetPartition_prefix_none_*`,
+  `recombinationSearchModAux_*`), each a separate atomic issue per
+  the out-of-scope section of #4907.


### PR DESCRIPTION
Closes #4907

Session: `184d5454-5bfb-4c87-8983-76e042ad4dfa`

ea7d3b12 feat: add abstract-bound sibling of exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCandidate_of_primitive_pos_lc_core (#4907)

🤖 Prepared with Claude Code