### PR TITLE
BZMathlib: abstract-bound sibling of exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -11789,11 +11789,80 @@ theorem mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombina
     rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
   exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
 
+/-- Abstract-bound variant of
+`exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core`:
+takes `B' : Nat`, the leading-coefficient bound `hcore_lc_bound`, the
+universal coefficient bound `hvalid` over the candidate's normalised
+factors, and `hprecision : 2 * B' < d.p ^ d.k` in place of the
+core-shape `defaultFactorCoeffBound core` precision constraint. The
+proof body mirrors the original (now-wrapper) with one call-site
+substitution: the per-T membership-equivalence lemma
+`mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+is threaded with `B'`, `hcore_lc_bound`, `hvalid`, and `hprecision`. -/
+theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hcore_lc_bound : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (scaledRecombinationCandidate core d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor
+          (scaledRecombinationCandidate core d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (scaledRecombinationCandidate core d T) =
+        some quotient)
+    {i : LiftedFactorIndex d} (hi : i ∈ T) :
+    ∃ (f : Hex.ZPoly) (S : LiftedFactorSubset d),
+      Irreducible (HexPolyZMathlib.toPolynomial f) ∧
+      f ∣ target ∧
+      f ∣ scaledRecombinationCandidate core d T ∧
+      S ⊆ J ∧
+      i ∈ S ∧
+      RepresentsIntegerFactorAtLift core d f S := by
+  obtain ⟨f, S, hf_irr, hf_dvd_candidate, hrep, hSJ, hiS⟩ :=
+    mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound
+      B' hcore_lc_bound hvalid hcore_ne hcore_primitive hcore_lc_pos
+      hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hprecision hpartition
+      htarget_dvd_core hTJ hrecord hquot hi
+  have hcand_dvd_target :
+      scaledRecombinationCandidate core d T ∣ target := by
+    have hmul : quotient * scaledRecombinationCandidate core d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hf_dvd_target : f ∣ target := by
+    rcases hf_dvd_candidate with ⟨q, hq⟩
+    rcases hcand_dvd_target with ⟨r, hr⟩
+    refine ⟨q * r, ?_⟩
+    rw [hr, hq, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_candidate, hSJ, hiS, hrep⟩
+
 /-- Scaled-candidate counterpart of
 `exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_primitive_pos_lc_core`.
 
-Routes through
-`mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core`. -/
+This is the `defaultFactorCoeffBound core`-instantiated thin wrapper for
+`exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound`:
+the universal coefficient bound is discharged from the divisor chain
+`g ∣ candidate ∣ target ∣ core`, and the leading-coefficient bound is
+discharged via the self-divisibility instance of
+`defaultFactorCoeffBound_valid` combined with `leadingCoeff_eq_coeff_last`. -/
 theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
@@ -11822,11 +11891,31 @@ theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_o
       S ⊆ J ∧
       i ∈ S ∧
       RepresentsIntegerFactorAtLift core d f S := by
-  obtain ⟨f, S, hf_irr, hf_dvd_candidate, hrep, hSJ, hiS⟩ :=
-    mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core
-      hcore_ne hcore_primitive hcore_lc_pos hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core hTJ
-      hrecord hquot hi
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_lc_bound :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
     have hmul : quotient * scaledRecombinationCandidate core d T = target :=
@@ -11834,12 +11923,43 @@ theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_o
     refine ⟨quotient, ?_⟩
     rw [Hex.DensePoly.mul_comm_poly (S := Int)]
     exact hmul.symm
-  have hf_dvd_target : f ∣ target := by
-    rcases hf_dvd_candidate with ⟨q, hq⟩
-    rcases hcand_dvd_target with ⟨r, hr⟩
-    refine ⟨q * r, ?_⟩
-    rw [hr, hq, Hex.DensePoly.mul_assoc_poly (S := Int)]
-  exact ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_candidate, hSJ, hiS, hrep⟩
+  have hcand_dvd_core :
+      scaledRecombinationCandidate core d T ∣ core := by
+    rcases hcand_dvd_target with ⟨r₁, hr₁⟩
+    rcases htarget_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    -- Restrict the rewrite to the LHS so the `core` argument inside
+    -- `scaledRecombinationCandidate core d T` is not recursively
+    -- re-expanded (same scaled-cascade gotcha as the prerequisite wrapper).
+    conv_lhs => rw [hr₂, hr₁]
+    rw [Hex.DensePoly.mul_assoc_poly (S := Int)]
+  refine exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_bound
+    (fun g hg_mem => ?_)
+    hcore_ne hcore_primitive hcore_lc_pos hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core hTJ
+    hrecord hquot hi
+  -- Discharge `hvalid` for arbitrary normalised factor `g` of the
+  -- scaled candidate by chaining `g ∣ candidate ∣ core` and invoking
+  -- `defaultFactorCoeffBound_valid`.
+  have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+      HexPolyZMathlib.toPolynomial
+        (scaledRecombinationCandidate core d T) :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem
+  have hg_dvd_cand : g ∣ scaledRecombinationCandidate core d T := by
+    rcases hg_poly_dvd with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    exact hr
+  have hg_dvd_core : g ∣ core := by
+    rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+    rcases hcand_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
 
 /-- Scaled-candidate counterpart of
 `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core`.

--- a/progress/20260518T051855Z_a4b43227.md
+++ b/progress/20260518T051855Z_a4b43227.md
@@ -1,0 +1,83 @@
+# 2026-05-18 05:18 UTC — `exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound` (a4b43227)
+
+Claimed feature issue #4926 and landed the scaled-side cover-extraction
+`_of_bound` sibling of
+`exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core`
+in `HexBerlekampZassenhausMathlib/Basic.lean`.
+
+## What landed
+
+* **New sibling**
+  `exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound`
+  taking `(B' : Nat)`, the leading-coefficient bound
+  `(hcore_lc_bound : (DensePoly.leadingCoeff core).natAbs ≤ B')`, the
+  universal coefficient bound
+  `(hvalid : ∀ g, toPolynomial g ∈ normalizedFactors (toPolynomial (scaledRecombinationCandidate core d T)) → ∀ i, (g.coeff i).natAbs ≤ B')`,
+  and `(hprecision : 2 * B' < d.p ^ d.k)` in place of the core-shape
+  `defaultFactorCoeffBound core` precision constraint. The proof body
+  mirrors the original (now-wrapper) with a single call-site
+  substitution: the per-T membership-equivalence call to
+  `mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound`
+  (from #4923) threads `B'`, `hcore_lc_bound`, `hvalid`, and
+  `hprecision`. The remainder of the proof (the `hcand_dvd_target`
+  `exactQuotient?_product` unfolding, the `hf_dvd_target` algebra step,
+  and the final repack) is precision-agnostic and carries over verbatim.
+
+* **Wrapper rewiring** of the original
+  `exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core`
+  as a thin delegator. The wrapper:
+  - derives `hcore_size_pos` from `hcore_lc_pos`,
+  - derives `hcore_lc_bound` from
+    `defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self (core.size - 1)`
+    + `leadingCoeff_eq_coeff_last`,
+  - builds `hcand_dvd_target` from `Hex.exactQuotient?_product hquot`,
+  - builds `hcand_dvd_core` by chaining `cand ∣ target ∣ core` (with the
+    same `conv_lhs => rw [hr₂, hr₁]` LHS-only rewrite used by the
+    prerequisite wrapper to dodge the scaled-cascade gotcha — `core`
+    appears both bare on the LHS and inside the candidate's `core`
+    argument on the RHS),
+  - delegates into the new `_of_bound` sibling with
+    `B' := defaultFactorCoeffBound core`, discharging `hvalid` for an
+    arbitrary normalised factor `g` by lifting to `g ∣ core` via the
+    `g ∣ cand ∣ core` chain and invoking
+    `defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core`.
+
+The wrapper preserves the existing signature exactly; the downstream
+consumer
+`coverAtMin_representingSubset_subset_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core`
+continues to type-check unchanged.
+
+## Layout note
+
+Following the precedent set by the prerequisite #4923 (and the earlier
+substrate `_of_bound` pairs), the `_of_bound` sibling sits *before* the
+wrapper in the file — necessary because Lean 4 top-level definitions
+are sequential and the wrapper forward-references `_of_bound`. The
+issue text said "immediately following" but the precedent and
+dependency direction both require the `_of_bound` to come first.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — 15 errors,
+  identical set to `origin/main` baseline: the 8 whnf timeouts in lines
+  4848–6245, the `cases`-nested failure at 5803, the two
+  kernel-unknown errors at 6560 / 6624, and the four timeouts /
+  kernel-unknown errors at 14870 / 14981 / 15188 / 15234. The upper
+  four correspond to baseline lines 14750 / 14861 / 15068 / 15114
+  shifted by exactly +120 — the net line addition from this PR
+  (`git diff --stat`: +131 / -11). No errors in the edit's line range
+  (~11792–~11960).
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean |
+   grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` —
+  no new entries.
+
+## Carryover
+
+* The scaled-side cover-extraction `_of_bound` is now in place. The
+  pending `coverAtMin_*_of_bound` (scaled flavour) at the next layer up
+  can now consume it directly.
+* The monic flavour #4924 (blocked on #4918) and the unscaled
+  primitive flavour #4925 (blocked on #4919) of the
+  `exists_representingSubset_of_mem_T_of_*_dvd_*` family still pending.


### PR DESCRIPTION
Closes #4926

Session: `a4b43227-bfda-4f27-84b7-d40024e7abb5`

5e4afbbb feat: add abstract-bound sibling of exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core (#4926)

🤖 Prepared with Claude Code