### PR TITLE
BZMathlib: abstract-bound siblings of scaled _some_factor_associated_ public wrappers (primitive + primitive_pos_lc_core)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -14430,6 +14430,56 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
   exact ⟨result, hresult, hcovers factor hfactor_irr hfactor_dvd_target⟩
 
 /--
+Abstract-bound variant of
+`scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`:
+the concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` Mignotte
+precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
+`B'`, paired with the leading-coefficient bound on `core` and the
+universal divisor coefficient bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs
+≤ B'`. Thin wrapper over
+`scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound`
+that extracts the per-factor coverage at the supplied `factor`.
+-/
+theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+    {core target factor : Hex.ZPoly} {d : Hex.LiftData}
+    {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
+    (B' : Nat)
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hvalid : ∀ g : Hex.ZPoly, g ∣ core → ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hd_liftedFactor_inj : Function.Injective (liftedFactor d))
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (htarget_primitive : Hex.ZPoly.Primitive target)
+    (htarget_lc_pos : 0 < Hex.DensePoly.leadingCoeff target)
+    (htarget_dvd_core : target ∣ core)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hmatches : LiftedFactorListMatches d J localFactors)
+    (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_dvd_target : factor ∣ target)
+    (hfuel : J.card < fuel) :
+    ∃ result,
+      Hex.scaledRecombinationSearchModAux (Hex.DensePoly.leadingCoeff core)
+          target (d.p ^ d.k) localFactors fuel =
+        some result ∧
+      ∃ emitted ∈ result,
+        Associated (HexPolyZMathlib.toPolynomial emitted)
+          (HexPolyZMathlib.toPolynomial factor) := by
+  obtain ⟨result, hresult, hcovers⟩ :=
+    scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound
+      B' hcore_lc_le hvalid hcore_ne hcore_primitive hcore_lc_pos hd_modulus
+      hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
+      hprecision htarget_primitive htarget_lc_pos htarget_dvd_core hpartition
+      hmatches hfuel
+  exact ⟨result, hresult, hcovers factor hfactor_irr hfactor_dvd_target⟩
+
+/--
 Primitive + positive-leading recursive coverage capstone for
 `Hex.scaledRecombinationSearchModAux`.
 
@@ -14438,6 +14488,12 @@ This is the scaled counterpart of
 It keeps the same fixed-factor conclusion, but the recursive target invariant is
 primitive plus positive leading coefficient, and the executable boundary is the
 scaled recombination search.
+
+Thin wrapper over
+`scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and
+discharges the abstract bound hypotheses via `defaultFactorCoeffBound_valid`
+paired with `leadingCoeff_eq_coeff_last`.
 -/
 theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
@@ -14467,13 +14523,87 @@ theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSu
       ∃ emitted ∈ result,
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
-  obtain ⟨result, hresult, hcovers⟩ :=
-    scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition
-      hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
-      htarget_primitive htarget_lc_pos htarget_dvd_core hpartition hmatches
-      hfuel
-  exact ⟨result, hresult, hcovers factor hfactor_irr hfactor_dvd_target⟩
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_le
+    (defaultFactorCoeffBound_valid core hcore_ne)
+    hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
+    htarget_primitive htarget_lc_pos htarget_dvd_core hpartition hmatches
+    hfactor_irr hfactor_dvd_target hfuel
+
+/--
+Abstract-bound variant of
+`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core`:
+the concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` Mignotte
+precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
+`B'`, paired with the leading-coefficient bound on `core` and the
+universal divisor coefficient bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs
+≤ B'`. Thin wrapper that forwards verbatim to
+`scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`.
+-/
+theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
+    {core target factor : Hex.ZPoly} {d : Hex.LiftData}
+    {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
+    (B' : Nat)
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hvalid : ∀ g : Hex.ZPoly, g ∣ core → ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hd_liftedFactor_inj : Function.Injective (liftedFactor d))
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (htarget_primitive : Hex.ZPoly.Primitive target)
+    (htarget_lc_pos : 0 < Hex.DensePoly.leadingCoeff target)
+    (htarget_dvd_core : target ∣ core)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hmatches : LiftedFactorListMatches d J localFactors)
+    (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_dvd_target : factor ∣ target)
+    (hfuel : J.card < fuel) :
+    ∃ result,
+      Hex.scaledRecombinationSearchModAux (Hex.DensePoly.leadingCoeff core)
+          target (d.p ^ d.k) localFactors fuel =
+        some result ∧
+      ∃ emitted ∈ result,
+        Associated (HexPolyZMathlib.toPolynomial emitted)
+          (HexPolyZMathlib.toPolynomial factor) := by
+  exact
+    scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+      B' hcore_lc_le hvalid hcore_ne hcore_primitive hcore_lc_pos hd_modulus
+      hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
+      hprecision htarget_primitive htarget_lc_pos htarget_dvd_core hpartition
+      hmatches hfactor_irr hfactor_dvd_target hfuel
 
 /--
 Primitive + positive-leading public wrapper for the scaled recombination
@@ -14482,6 +14612,12 @@ search.  This is the #4648 boundary form of the old monic-core
 surface: callers with a primitive positive-leading core and recursive target
 use the scaled executable search directly, while the monic wrapper remains
 available for existing unscaled callers.
+
+Thin wrapper over
+`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and
+discharges the abstract bound hypotheses via `defaultFactorCoeffBound_valid`
+paired with `leadingCoeff_eq_coeff_last`.
 -/
 theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
@@ -14511,12 +14647,39 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
       ∃ emitted ∈ result,
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
-  exact
-    scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition
-      hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
-      htarget_primitive htarget_lc_pos htarget_dvd_core hpartition hmatches
-      hfactor_irr hfactor_dvd_target hfuel
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_le
+    (defaultFactorCoeffBound_valid core hcore_ne)
+    hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
+    htarget_primitive htarget_lc_pos htarget_dvd_core hpartition hmatches
+    hfactor_irr hfactor_dvd_target hfuel
 
 /--
 Final public coverage theorem (#4274 capstone): every irreducible integer

--- a/progress/20260518T074948Z_bed10d50.md
+++ b/progress/20260518T074948Z_bed10d50.md
@@ -1,0 +1,54 @@
+# Session bed10d50 — feature: BZMathlib `_of_bound` for scaled `_some_factor_associated_*` wrappers
+
+## Accomplished
+
+Claimed #4936 and implemented the abstract-bound (`_of_bound`)
+propagation through the public scaled `_some_factor_associated_*`
+wrapper layer in `HexBerlekampZassenhausMathlib/Basic.lean`. The PR
+adds two new `_of_bound` theorems and rewires the two originals as
+thin wrappers:
+
+* `scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`
+  — forwards to `scaledRecombinationSearchModAux_some_and_covers_..._of_bound`
+  (the #4935 substrate) and specialises the per-factor coverage at the
+  supplied `factor`.
+* `recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound`
+  — single `exact` to the scaled `_of_bound`.
+* Both originals rewired to instantiate
+  `B' := Hex.ZPoly.defaultFactorCoeffBound core`, discharging
+  `hcore_lc_le` via `defaultFactorCoeffBound_valid` + `leadingCoeff_eq_coeff_last`,
+  and `hvalid` via the universal `defaultFactorCoeffBound_valid core hcore_ne`.
+
+The originals keep identical signatures; the sole in-tree consumer
+(`exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence`)
+continues to type-check via the rewired thin wrapper.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — 16 errors, all
+  pre-existing (whnf timeouts at 4848/5129/5455/5542/5589/5973/6121/6293/6274,
+  cases-failed at 5851, kernel-unknowns at 6608/6672, plus the second
+  region at 15505/15616/15823/15869 shifted +163 lines from the
+  `origin/main` baseline at 15342/15453/15660/15706). Confirmed by a
+  stashed rebuild on `origin/main` producing the identical error set.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+  | grep -E "^\+.*(sorry|axiom|native_decide|TODO|FIXME)"` — no
+  matches.
+
+## Current frontier
+
+The next `_of_bound` consumer one layer up is
+`exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence`
+(file as `#4938` per the issue's context). It is unblocked once this
+PR lands.
+
+## Next step
+
+Land the PR; the `exhaustiveCoreFactorsWithBound_coverage_*_of_bound`
+sibling is the natural next target for the A2 abstract-bound cascade.
+
+## Blockers
+
+None for this work item.


### PR DESCRIPTION
Closes #4936

Session: `bed10d50-fcfb-43cd-aaec-3d1f5cdc2331`

70ac80e5 feat: add abstract-bound siblings of scaled _some_factor_associated_ public wrappers (primitive + primitive_pos_lc_core) (#4936)

🤖 Prepared with Claude Code