### PR TITLE
BZMathlib: drop hcomplete premise from two quadratic-arm umbrellas (discharge internally via #4747)

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2900,8 +2900,10 @@ theorem factor_constant_branch_entry_irreducible_of_choosePrimeData
 Per-branch HO-1 component for the fast-path quadratic integer-root arm of the
 capstone `factor_irreducible_of_nonUnit` (#4170): every entry recorded by
 `Hex.factorWithBound f B` in this fast-path branch is `Hex.ZPoly.Irreducible`,
-given `f ≠ 0`, `1 < B`, the branch marker hypotheses (`hdeg`, `hquad`), and
-the reassembly expansion-complete side condition.
+given `f ≠ 0`, `1 < B`, and the branch marker hypotheses (`hdeg`, `hquad`).
+The reassembly expansion-complete side condition is discharged internally via
+`IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero`
+(#4747), so the umbrella no longer requires an explicit `hcomplete` premise.
 
 Composes:
 * `Hex.factorWithBound_entry_mem_quadratic_branch_raw` — the Mathlib-free
@@ -2936,10 +2938,14 @@ theorem factor_quadratic_branch_entry_irreducible_of_quadraticRoots
     (hquad :
       Hex.quadraticIntegerRootFactors?
         (Hex.normalizeForFactor f).squareFreeCore = some coreFactors)
-    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hcomplete :
-      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) coreFactors) :
+    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList) :
     Hex.ZPoly.Irreducible entry.1 := by
+  -- Discharge the reassembly expansion-complete side condition internally
+  -- using the quadratic-arm discharger (#4747).
+  have hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) coreFactors :=
+    IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
+      f hf_ne hquad
   -- Branch-shape lemma: entry = normalizeFactorSign raw for raw ∈ reassembly.
   obtain ⟨raw, hraw_mem, hentry_eq⟩ :=
     Hex.factorWithBound_entry_mem_quadratic_branch_raw f B entry hB_gt_one hdeg
@@ -2973,8 +2979,10 @@ theorem factor_quadratic_branch_entry_irreducible_of_quadraticRoots
 Per-branch HO-1 component for the slow-path **quadratic integer-root** arm of
 the capstone `factor_irreducible_of_nonUnit` (#4170): every entry recorded by
 `Hex.factorWithBound f B` in this arm is `Hex.ZPoly.Irreducible`, given the
-branch markers, the `hfast_none` slow-dispatch witness, and the reassembly
-expansion-complete side condition.
+branch markers and the `hfast_none` slow-dispatch witness. The reassembly
+expansion-complete side condition is discharged internally via
+`IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero`
+(#4747), so the umbrella no longer requires an explicit `hcomplete` premise.
 
 The slow-quadratic branch is reachable through the public `Hex.factor` entry
 exactly when `factorFastFactorsWithBound f B = none` (so the public
@@ -3033,11 +3041,14 @@ theorem factor_slow_quadratic_branch_entry_irreducible_of_choosePrimeData
       Hex.quadraticIntegerRootFactors?
         (Hex.normalizeForFactor f).squareFreeCore = some coreFactors)
     (hfast_none : Hex.factorFastFactorsWithBound f B = none)
-    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hcomplete :
-      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
-        coreFactors) :
+    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList) :
     Hex.ZPoly.Irreducible entry.1 := by
+  -- Discharge the reassembly expansion-complete side condition internally
+  -- using the quadratic-arm discharger (#4747).
+  have hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) coreFactors :=
+    IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
+      f hf_ne hquad
   -- Branch-shape lemma: entry = normalizeFactorSign raw for raw ∈ reassembly.
   obtain ⟨raw, hraw_mem, hentry_eq⟩ :=
     Hex.factorWithBound_entry_mem_slow_quadratic_branch_raw f B entry hdeg

--- a/progress/20260518T082611Z_7e8b2876.md
+++ b/progress/20260518T082611Z_7e8b2876.md
@@ -1,0 +1,54 @@
+# 2026-05-18T08:26Z — #4964: drop `hcomplete` from two quadratic-arm umbrellas
+
+## Accomplished
+
+Claimed and executed issue #4964: dropped the explicit `hcomplete`
+premise from the two quadratic-arm HO-1 umbrellas in
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean` and discharged
+it internally via the #4747 non-monic quadratic-arm discharger
+`IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero`.
+
+* `factor_quadratic_branch_entry_irreducible_of_quadraticRoots`
+  (fast-path quadratic arm, line 2929): removed the `hcomplete`
+  binder from the signature, replaced with a `have hcomplete :=
+  IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
+  f hf_ne hquad` above the existing setup. Updated the docstring
+  header to mirror the constant-arm phrasing at line 2810.
+* `factor_slow_quadratic_branch_entry_irreducible_of_choosePrimeData`
+  (slow-path quadratic arm, line 3025): identical edit shape applied
+  to the slow-quadratic umbrella. Docstring header updated.
+
+Verification:
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — same
+  error/warning set as the `origin/main` baseline (the pre-existing
+  whnf-timeout pile in `Basic.lean` is unaffected; both builds
+  produce 57 error/warning lines, only ordering differs).
+* `lake build HexBerlekampZassenhausMathlib` — same baseline.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/IntReductionMod.lean
+  | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` — empty.
+
+## Current frontier
+
+Both quadratic-arm umbrellas now match the constant-arm umbrella's
+`hcomplete`-free interface (`factor_constant_branch_entry_irreducible_of_choosePrimeData`,
+#4585 / PR #4598). The capstone wiring (#4170) when it eventually
+lands will not need to thread `hcomplete` through the quadratic arms.
+
+## Next step
+
+* Singleton-arm umbrellas (`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+  at line 2696 and `factor_small_mod_singleton_branch_entry_irreducible` at
+  line 2771) still carry an explicit `hcomplete`. Their corresponding
+  discharger `reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
+  (#4961) requires `Irreducible squareFreeCore` + `0 < leadingCoeff` +
+  positive `degree?`, which the umbrellas would have to either re-derive
+  or accept as new premises in place of `hcomplete`. The trade-off is
+  out of scope for this tidy and is a separate design decision.
+* Exhaustive-arm umbrella's Gap 1 (#4880) is directive-level blocked
+  per the #4940 audit and is unaffected by this work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4964

Session: `7e8b2876-a77e-4d45-9cab-b5f98e12f323`

a4e48035 feat: drop hcomplete from two quadratic-arm umbrellas (discharge internally via #4747) (#4964)

🤖 Prepared with Claude Code