### PR TITLE
BZMathlib: drop hcomplete premise from two small-mod singleton-arm umbrellas (discharge internally via #4956 _of_pos_lc)

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2667,9 +2667,12 @@ theorem liftedFactorSubsetPartition_outerBound_of_choosePrimeData
 Per-branch HO-1 component for the small-mod singleton arm of the capstone
 `factor_irreducible_of_nonUnit` (#4170): every entry recorded by
 `Hex.factorWithBound f B` in this fast-path branch is `Hex.ZPoly.Irreducible`,
-given only `f ≠ 0`, the branch marker hypotheses, the executable
-`choosePrimeData?` success witness `hchoose`, and the reassembly
-expansion-complete side condition.
+given only `f ≠ 0`, the branch marker hypotheses, and the executable
+`choosePrimeData?` success witness `hchoose`. The reassembly
+expansion-complete side condition is discharged internally via
+`IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
+(#4956 / PR #4961), so the umbrella no longer requires an explicit
+`hcomplete` premise.
 
 Composes:
 * `Hex.factorWithBound_entry_mem_small_mod_singleton_raw`
@@ -2683,9 +2686,17 @@ Composes:
   (`IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive`
   and `IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero`),
   which produce `hprim` and `hlc_map_ne` from `f ≠ 0` and `hchoose`;
+* `IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
+  — the non-monic primitive singleton-arm `hcomplete` discharger from
+  #4956 / PR #4961, producing the reassembly expansion-complete side
+  condition internally from `hcore_irr`,
+  `Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero`, and the positive
+  squarefree-core degree derived from the umbrella's existing `hdeg`
+  premise;
 * `Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`
   — the Mathlib-free reassembly lift turning singleton-core irreducibility
-  into raw factor irreducibility under the `hcomplete` side condition;
+  into raw factor irreducibility under the internally-discharged
+  expansion-complete side condition;
 * `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible` — the
   sign-normalisation lift from raw factor irreducibility to entry
   irreducibility.
@@ -2707,9 +2718,6 @@ theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
         Hex.quadraticIntegerRootFactors?
           (Hex.normalizeForFactor f).squareFreeCore = none)
     (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hcomplete :
-      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
-        #[(Hex.normalizeForFactor f).squareFreeCore])
     (hchoose :
       Hex.choosePrimeData?
         (Hex.normalizeForFactor f).squareFreeCore = some
@@ -2731,6 +2739,16 @@ theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
         f hf_ne)
       (IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero
         _ _ hchoose)
+  -- Discharge the reassembly expansion-complete side condition internally
+  -- using the non-monic primitive singleton-arm discharger
+  -- (#4956 / PR #4961).
+  have hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+        #[(Hex.normalizeForFactor f).squareFreeCore] :=
+    IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc
+      f hf_ne hcore_irr
+      (Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne)
+      (Nat.pos_of_ne_zero hdeg)
   -- Lift singleton-core irreducibility through the reassembly to raw factor
   -- irreducibility.
   have h_core_array :
@@ -2765,9 +2783,11 @@ sufficient) for the singleton branch to fire — when `choosePrimeData?` returns
 slow exhaustive path, so the singleton branch-shape lemma's conclusion does
 not apply in that case.
 
-The eventual capstone wiring for the small-mod singleton arm composes this
-with the `hcomplete` discharger from #4597 to produce a fully
-hypothesis-discharged per-branch component. -/
+The reassembly expansion-complete side condition is discharged internally
+by the `_of_choosePrimeData` umbrella above (via
+`IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`,
+#4956 / PR #4961), so this wrapper does not require an explicit
+`hcomplete` premise either. -/
 theorem factor_small_mod_singleton_branch_entry_irreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (B : Nat) (hB_pos : 1 ≤ B)
@@ -2783,10 +2803,7 @@ theorem factor_small_mod_singleton_branch_entry_irreducible
       B = 1 ∨
         Hex.quadraticIntegerRootFactors?
           (Hex.normalizeForFactor f).squareFreeCore = none)
-    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hcomplete :
-      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
-        #[(Hex.normalizeForFactor f).squareFreeCore]) :
+    (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList) :
     Hex.ZPoly.Irreducible entry.1 := by
   -- Derive the explicit `choosePrimeData?` equation from the `isSome` witness
   -- packed into `hsmall_chosen`.
@@ -2804,7 +2821,7 @@ theorem factor_small_mod_singleton_branch_entry_irreducible
           unfold Hex.choosePrimeData; rw [hc]
         rw [hpd]
   exact factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
-    f hf_ne B hB_pos entry hdeg hsmall_chosen.2 hquadratic hentry_mem hcomplete
+    f hf_ne B hB_pos entry hdeg hsmall_chosen.2 hquadratic hentry_mem
     hchoose
 
 /-- **#4565 HO-1 substrate — fast-path constant arm umbrella.**

--- a/progress/2026-05-18T08-50-30Z_cbc6f1f7.md
+++ b/progress/2026-05-18T08-50-30Z_cbc6f1f7.md
@@ -1,0 +1,73 @@
+# 2026-05-18T08:50:30Z (session `cbc6f1f7`)
+
+Type: `feature`. Issue #4967.
+
+## Accomplished
+
+Dropped the `hcomplete` premise from the two small-mod singleton-arm
+per-branch umbrellas in
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+
+* `factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+  (the `_of_choosePrimeData` form, line 2707 in the edited file): the
+  expansion-complete side condition is now discharged internally via
+  `IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
+  (#4956 / PR #4961), threading `hcore_irr`, the universally-available
+  `Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne`, and
+  `Nat.pos_of_ne_zero hdeg` (turning the existing `hdeg : ... ≠ 0`
+  premise into the `0 < ...` form the discharger expects).
+* `factor_small_mod_singleton_branch_entry_irreducible` (the
+  `hchoose`-free wrapper, line 2791): the `hcomplete` premise is
+  dropped by propagation — the forwarding call into the
+  `_of_choosePrimeData` umbrella above no longer needs to pass
+  `hcomplete`.
+
+Docstrings updated on both umbrellas to mirror the constant-arm
+phrasing at `factor_constant_branch_entry_irreducible_of_choosePrimeData`,
+including a new `Composes:` bullet on the `_of_choosePrimeData` umbrella
+for the discharger.
+
+After this issue lands, three of the four non-BHKS per-branch umbrellas
+(constant, singleton, both quadratic arms via in-flight #4964) discharge
+`hcomplete` internally — leaving only the slow-path exhaustive arm
+(directive-level-blocked per #4880 / #4940).
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod
+  HexBerlekampZassenhausMathlib` — diagnostics match the `origin/main`
+  baseline (verified by stashing the edits and comparing diagnostic
+  output line by line). The pre-existing whnf-timeout pile in
+  `HexBerlekampZassenhausMathlib/Basic.lean` is unaffected, and
+  `IntReductionMod.lean` itself never reaches the kernel because Basic
+  fails first — same as baseline. The only cross-build diff was a
+  transient `HexGramSchmidtMathlib/Int.lean:2097:61: unused variable
+  hne` warning that appeared on a fresh rebuild of an unrelated
+  module; not caused by this edit.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — exit 0.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/IntReductionMod.lean
+  | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` — no
+  matches.
+
+No new in-tree consumers of either umbrella exist (the only reference
+outside `IntReductionMod.lean` is a docstring mention in
+`HexBerlekampZassenhaus/Basic.lean:11866`), so no caller-side updates
+were needed.
+
+## Current frontier
+
+Issue #4967 is closed by PR (this session). The companion #4964 (drop
+`hcomplete` from the two quadratic-arm umbrellas) is in flight and
+follows the same shape with the #4747 discharger.
+
+## Next step
+
+Land #4964 (quadratic-arm dischargers). The slow-path exhaustive arm's
+`hcomplete` is already discharged internally; the remaining umbrella
+gap there is `hcore_monic` / `hprecision`, which is directive-level
+blocked per #4880 / #4940.
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #4967

Session: `cbc6f1f7-bfad-4d03-b80f-777539d17c5a`

ee5f0b81 feat: drop hcomplete premise from small-mod singleton-arm umbrellas (#4967)

🤖 Prepared with Claude Code