### PR TITLE
BZMathlib: abstract-bound sibling of factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence (inner-B pairing wrapper)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -15198,6 +15198,93 @@ theorem factor_entries_irreducible
   exact factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (Array.mem_toList_iff.mpr hentry) h_raw
 
+/--
+Abstract-bound variant of
+`factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`:
+the concrete `2 * defaultFactorCoeffBound (normalizeForFactor f).squareFreeCore
+< d.p ^ d.k` Mignotte precision is replaced by `2 * B' < d.p ^ d.k` against an
+abstract bound `B'`, paired with the leading-coefficient bound on
+`(normalizeForFactor f).squareFreeCore` and the universal divisor coefficient
+bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B'`. The proof body mirrors the
+(now-wrapper) original verbatim, except that the forward call to
+`exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence`
+becomes its `_of_bound` sibling, threading `B'`, `hcore_lc_le`, `hvalid`,
+`hprecision`.
+-/
+theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+    {f : Hex.ZPoly} {entry : Hex.ZPoly × Nat}
+    {d : Hex.LiftData} {admissiblePrime successfulLift : Prop}
+    (_hbranch :
+      Hex.factorWithBoundUsesExhaustiveBranch f
+        (Hex.ZPoly.defaultFactorCoeffBound
+          (Hex.normalizeForFactor f).squareFreeCore))
+    (_hentry_mem :
+      entry ∈ (Hex.factorWithBound f
+        (Hex.ZPoly.defaultFactorCoeffBound
+          (Hex.normalizeForFactor f).squareFreeCore)).factors.toList)
+    (h :
+      HenselSubsetCorrespondenceHypotheses
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.precisionForCoeffBound
+          (Hex.ZPoly.defaultFactorCoeffBound
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (Hex.choosePrimeData
+            (Hex.normalizeForFactor f).squareFreeCore).p)
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+        d admissiblePrime successfulLift)
+    (hpartition :
+      LiftedFactorSubsetPartition
+        (Hex.normalizeForFactor f).squareFreeCore d Finset.univ
+        (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0)
+    (hcore_monic :
+      Hex.DensePoly.Monic (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_record :
+      Hex.shouldRecordPolynomialFactor
+        (Hex.normalizeForFactor f).squareFreeCore = true)
+    (hB_ne_zero :
+      Hex.ZPoly.defaultFactorCoeffBound
+        (Hex.normalizeForFactor f).squareFreeCore ≠ 0)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hd_liftedFactor_inj : Function.Injective (liftedFactor d))
+    (B' : Nat)
+    (hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤ B')
+    (hvalid :
+      ∀ g : Hex.ZPoly, g ∣ (Hex.normalizeForFactor f).squareFreeCore →
+        ∀ i, (g.coeff i).natAbs ≤ B')
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hcore_entry :
+      ∃ raw ∈ (Hex.exhaustiveCoreFactorsWithBound
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.defaultFactorCoeffBound
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (Hex.choosePrimeData
+            (Hex.normalizeForFactor f).squareFreeCore)).toList,
+        entry.1 = Hex.normalizeFactorSign raw) :
+    Hex.ZPoly.Irreducible entry.1 := by
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
+  have hcore_primitive :
+      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+    (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+  have hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore := by
+    rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
+      (1 : Int) from hcore_monic]
+    decide
+  have hirr_raw : Hex.ZPoly.Irreducible raw :=
+    exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hd_liftedFactor_inj B' hcore_lc_le hvalid hprecision raw hraw_mem
+  rw [hentry_eq]
+  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
+
 /-- **#4006 slow-path bridge (deliverable 2).**
 
 Connects the branch-local irreducibility theorem
@@ -15217,7 +15304,14 @@ The `hbranch` and `hentry_mem` arguments are not used by the proof, but
 they document the consumer-side entry point: a typical caller threads them
 through `factorWithBound_entry_mem_exhaustive_branch_raw` and
 `exhaustiveSlowRawFactorsWithBound_mem_normalization_or_core` to obtain the
-`hcore_entry` witness. -/
+`hcore_entry` witness.
+
+Thin wrapper over
+`factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound
+(Hex.normalizeForFactor f).squareFreeCore` and discharges the abstract bound
+hypotheses via `defaultFactorCoeffBound_valid` paired with
+`leadingCoeff_eq_coeff_last`. -/
 theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence
     {f : Hex.ZPoly} {entry : Hex.ZPoly × Nat}
     {d : Hex.LiftData} {admissiblePrime successfulLift : Prop}
@@ -15270,22 +15364,40 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
             (Hex.normalizeForFactor f).squareFreeCore)).toList,
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
-  obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
-  have hcore_primitive :
-      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-    (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
-  have hcore_lc_pos :
-      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore := by
-    rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
-      (1 : Int) from hcore_monic]
+  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
+  have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core := by
+    rw [show Hex.DensePoly.leadingCoeff core = (1 : Int) from hcore_monic]
     decide
-  have hirr_raw : Hex.ZPoly.Irreducible raw :=
-    exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence
-      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
-      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
-      hd_liftedFactor_inj hprecision raw hraw_mem
-  rw [hentry_eq]
-  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+    _hbranch _hentry_mem h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero
+    hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+    hd_liftedFactor_inj (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_le (defaultFactorCoeffBound_valid core hcore_ne) hprecision hcore_entry
 
 /-- **#4536 outer-bound slow-path bridge.**
 

--- a/progress/20260518T093005Z_e542e5c6.md
+++ b/progress/20260518T093005Z_e542e5c6.md
@@ -1,0 +1,37 @@
+# Session e542e5c6 — /work → /feature
+
+## Accomplished
+
+- Skipped #4334 (HexLLL inconclusive-verdict benchmarks): host
+  `carica` was under heavy concurrent load (entry loadavg 20.65/21.10/21.02
+  on 24 CPUs, ~700× spawn-floor inflation on a steady-state
+  `lake exe hexlll_bench list` probe). Skip routes through the
+  documented audit-and-skip protocol in the issue body.
+- Claimed and executed #4963 — inner-B abstract-bound (`_of_bound`)
+  sibling of
+  `factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`
+  in `HexBerlekampZassenhausMathlib/Basic.lean`.
+- The new `_of_bound` theorem inserts before the existing wrapper
+  (Lean 4 sequential top-level resolution) and the wrapper is rewired
+  as a thin delegator instantiating `B' := defaultFactorCoeffBound
+  core` and discharging the abstract hypotheses via
+  `defaultFactorCoeffBound_valid` + `leadingCoeff_eq_coeff_last`.
+- Baseline-vs-edit `lake build HexBerlekampZassenhausMathlib.Basic`:
+  same 16 baseline errors; the 4 post-15663 errors shift by exactly
+  +112 lines (the insertion size), confirming no new errors.
+
+## Current frontier
+
+PR for #4963 open; pairing partner #4947 (outer-B) is claimed by
+another session and proceeds in parallel.
+
+## Next step
+
+- Once both #4947 and #4963 land, the `_of_bound` propagation can
+  continue inward; the `IntReductionMod.lean` umbrella (#4880) remains
+  blocked on a directive-level decision per #4940's finding.
+
+## Blockers
+
+None for this work item. #4334 remains environmentally blocked on
+quiet hardware for the HexLLL scientific benchmarks.


### PR DESCRIPTION
Closes #4963

Session: `e542e5c6-4054-4923-a642-50c106b99959`

f1cb4e2f doc: progress note for session e542e5c6 (#4963 + #4334 skip)
95e4d14b feat: abstract-bound sibling of factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence

🤖 Prepared with Claude Code