### PR TITLE
BZMathlib: abstract-bound sibling of factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence (public bridge)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -15287,6 +15287,83 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
 
+/--
+Abstract-bound variant of
+`factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`:
+the concrete
+`2 * defaultFactorCoeffBound (normalizeForFactor f).squareFreeCore < d.p ^ d.k`
+Mignotte precision on the square-free core is replaced by `2 * B' < d.p ^ d.k`
+against an abstract bound `B'`, paired with the leading-coefficient bound on
+the core and the universal divisor coefficient bound
+`∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B'`. The proof body mirrors the
+(now-wrapper) original verbatim, except that the forward call to the
+slow-path capstone
+`exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence`
+becomes its `_of_bound` sibling, threading `B'`, `hcore_lc_le`, `hvalid`,
+`hprecision`.
+-/
+theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+    {f : Hex.ZPoly} {entry : Hex.ZPoly × Nat}
+    {d : Hex.LiftData} {admissiblePrime successfulLift : Prop}
+    (_hbranch :
+      Hex.factorWithBoundUsesExhaustiveBranch f
+        (Hex.ZPoly.defaultFactorCoeffBound f))
+    (_hentry_mem :
+      entry ∈ (Hex.factorWithBound f
+        (Hex.ZPoly.defaultFactorCoeffBound f)).factors.toList)
+    (h :
+      HenselSubsetCorrespondenceHypotheses
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.precisionForCoeffBound
+          (Hex.ZPoly.defaultFactorCoeffBound f)
+          (Hex.choosePrimeData
+            (Hex.normalizeForFactor f).squareFreeCore).p)
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
+        d admissiblePrime successfulLift)
+    (hpartition :
+      LiftedFactorSubsetPartition
+        (Hex.normalizeForFactor f).squareFreeCore d Finset.univ
+        (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0)
+    (hcore_primitive :
+      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore)
+    (hcore_record :
+      Hex.shouldRecordPolynomialFactor
+        (Hex.normalizeForFactor f).squareFreeCore = true)
+    (hB_ne_zero : Hex.ZPoly.defaultFactorCoeffBound f ≠ 0)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hd_liftedFactor_inj : Function.Injective (liftedFactor d))
+    (B' : Nat)
+    (hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤ B')
+    (hvalid :
+      ∀ g : Hex.ZPoly, g ∣ (Hex.normalizeForFactor f).squareFreeCore →
+        ∀ i, (g.coeff i).natAbs ≤ B')
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hcore_entry :
+      ∃ raw ∈ (Hex.exhaustiveCoreFactorsWithBound
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.defaultFactorCoeffBound f)
+          (Hex.choosePrimeData
+            (Hex.normalizeForFactor f).squareFreeCore)).toList,
+        entry.1 = Hex.normalizeFactorSign raw) :
+    Hex.ZPoly.Irreducible entry.1 := by
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
+  have hirr_raw : Hex.ZPoly.Irreducible raw :=
+    exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hd_liftedFactor_inj B' hcore_lc_le hvalid hprecision raw hraw_mem
+  rw [hentry_eq]
+  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
+
 /-- **#4536 outer-bound slow-path bridge.**
 
 The consumer-facing variant of
@@ -15400,14 +15477,39 @@ theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorr
             (Hex.normalizeForFactor f).squareFreeCore)).toList,
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
-  obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
-  have hirr_raw : Hex.ZPoly.Irreducible raw :=
-    exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence
-      h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
-      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
-      hd_liftedFactor_inj hprecision raw hraw_mem
-  rw [hentry_eq]
-  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hirr_raw
+  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
+  have hcore_size_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
+    · exfalso
+      have hback_none : core.coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]
+        have hcoeffs_size : core.coeffs.size = 0 := by
+          simpa [Hex.DensePoly.size] using hzero
+        simp [hcoeffs_size]
+      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
+        unfold Hex.DensePoly.leadingCoeff
+        rw [hback_none]
+        rfl
+      rw [hlc_zero] at hcore_lc_pos
+      omega
+    · exact hpos
+  have hcore_dvd_self : core ∣ core :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff core).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound core := by
+    have hbound :=
+      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
+        (core.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
+    exact hbound
+  exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
+    _hbranch _hentry_mem h hpartition hcore_ne hcore_primitive hcore_lc_pos
+    hcore_record hB_ne_zero hd_modulus hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_le (defaultFactorCoeffBound_valid core hcore_ne) hprecision
+    hcore_entry
 
 /-- **#4543 substrate (HO-1).**
 

--- a/progress/20260518T093014Z_42a15ea1.md
+++ b/progress/20260518T093014Z_42a15ea1.md
@@ -1,0 +1,77 @@
+# 2026-05-18T09:30Z — #4947: abstract-bound sibling of public-bridge slow-path wrapper
+
+## Accomplished
+
+Claimed and executed issue #4947: added the public-bridge `_of_bound`
+sibling of
+`factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence`
+in `HexBerlekampZassenhausMathlib/Basic.lean` and rewired the existing
+original as a thin delegator.
+
+Specifically:
+
+* Inserted
+  `factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound`
+  (line 15305 onwards, before the existing wrapper at line 15432). The
+  signature replaces
+  `hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore < d.p ^ d.k`
+  with the four-parameter abstract-bound block
+  `(B' : Nat) (hcore_lc_le ...) (hvalid : ∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B') (hprecision : 2 * B' < d.p ^ d.k)`,
+  placed at the same syntactic position as the original `hprecision`.
+  The proof body mirrors the original verbatim: destructure
+  `hcore_entry`, forward into the substrate
+  `exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound`
+  (from #4944) threading `B'`, `hcore_lc_le`, `hvalid`, `hprecision`,
+  then `rw [hentry_eq]` and close with
+  `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible`.
+* Rewired the existing wrapper (now line 15432) to delegate into the
+  new `_of_bound` sibling with
+  `B' := Hex.ZPoly.defaultFactorCoeffBound core` (where
+  `core := (Hex.normalizeForFactor f).squareFreeCore`), discharging
+  `hcore_lc_le` via `defaultFactorCoeffBound_valid core hcore_ne core
+  hcore_dvd_self (core.size - 1)` paired with `leadingCoeff_eq_coeff_last`,
+  and `hvalid` via `defaultFactorCoeffBound_valid core hcore_ne` directly.
+  The wrapper's signature is preserved exactly, so the sole downstream
+  consumer
+  `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`
+  in `IntReductionMod.lean` continues to type-check unchanged.
+
+Verification:
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — same 18 errors /
+  39 warnings as `origin/main` baseline. The pre-existing whnf
+  timeouts and kernel-unknown errors in lines 4848-6672 are unaffected;
+  the post-insertion errors in lines 15663-16027 shift by exactly 102
+  lines (the insertion size), to 15765-16129.
+* `lake build HexBerlekampZassenhausMathlib` — same 18 errors / 40
+  warnings as `origin/main` baseline (the 40th warning is the
+  pre-existing `unused variable hne` in `HexGramSchmidtMathlib/Int.lean`).
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+  | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` — empty.
+
+Diff: 110 insertions / 8 deletions, single file.
+
+## Current frontier
+
+The A2 abstract-bound (`_of_bound`) propagation has now reached the
+public-bridge layer. With the public wrapper's `_of_bound` sibling
+in place, the abstract-bound API sits one step from the public
+umbrella
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`
+(`IntReductionMod.lean:3123`) — which gets its `_of_bound` sibling
+in the blocked-on-this-issue #4970 follow-up.
+
+## Next step
+
+* #4963 (inner-B pairing wrapper
+  `factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound`,
+  the `_of_squareFreeCore_bound` variant) is now actionable since its
+  `depends-on: #4944` is closed. Same shape as this issue but at the
+  `factorWithBound` inner-B coefficient bound surface.
+* #4970 (umbrella aux `_of_bound`) is currently `blocked` on #4947 and
+  becomes actionable once this lands.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4947

Session: `42a15ea1-9771-4e25-9836-f2daefdaba4b`

e9201b54 chore: progress entry for #4947
38fe6e68 feat: abstract-bound sibling of factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence (#4947)

🤖 Prepared with Claude Code