### PR TITLE
BZMathlib: abstract-bound sibling of factor_exhaustive_branch_entry_irreducible_of_choosePrimeData (public umbrella _of_bound)

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -4265,6 +4265,54 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
     (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
     hprecision
 
+/-- **Abstract-bound sibling of the #4561 / #4848 HO-1 exhaustive-arm umbrella.**
+
+Abstract-bound `_of_bound` companion to
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`: the
+concrete inner-form Mignotte precision on the squarefree core
+`2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore < d.p ^ d.k`
+is replaced by `2 * B' < d.p ^ d.k` against an abstract bound `B'`, paired
+with the leading-coefficient bound on the core
+(`(Hex.DensePoly.leadingCoeff core).natAbs ≤ B'`) and the universal divisor
+coefficient bound (`∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B'`).
+
+The proof body mirrors the (now-wrapper) original verbatim — the two
+forward calls to `reassemblyExpansionComplete_exhaustive_of_ne_zero` and
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux`
+become their `_of_bound` siblings, threading `B'`, `hcore_lc_le`,
+`hvalid`, `hprecision`. -/
+theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
+    (entry : Hex.ZPoly × Nat)
+    (hbranch : Hex.factorWithBoundUsesExhaustiveBranch f
+      (Hex.ZPoly.defaultFactorCoeffBound f))
+    (hentry_mem : entry ∈ (Hex.factorWithBound f
+      (Hex.ZPoly.defaultFactorCoeffBound f)).factors.toList)
+    (hchoose : Hex.choosePrimeData?
+      (Hex.normalizeForFactor f).squareFreeCore = some
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))
+    (hcore_monic : Hex.DensePoly.Monic
+      (Hex.normalizeForFactor f).squareFreeCore)
+    (B' : Nat)
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤ B')
+    (hvalid : ∀ g : Hex.ZPoly,
+        g ∣ (Hex.normalizeForFactor f).squareFreeCore →
+        ∀ i, (g.coeff i).natAbs ≤ B')
+    (hprecision :
+      2 * B' <
+        (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p ^
+          Hex.precisionForCoeffBound
+            (Hex.ZPoly.defaultFactorCoeffBound f)
+            (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
+    Hex.ZPoly.Irreducible entry.1 :=
+  factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
+    f hf_ne entry hbranch hentry_mem hchoose hcore_monic
+    (reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
+      f hf_ne hbranch hchoose hcore_monic
+      B' hcore_lc_le hvalid hprecision)
+    B' hcore_lc_le hvalid hprecision
+
 /-- **#4561 / #4848 HO-1 substrate — slow exhaustive-arm umbrella, with the
 `hcomplete` premise dropped via the #4848 discharger.**
 
@@ -4311,11 +4359,36 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
           Hex.precisionForCoeffBound
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
-    Hex.ZPoly.Irreducible entry.1 :=
-  factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux
+    Hex.ZPoly.Irreducible entry.1 := by
+  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
+    intro h0
+    have hlc : Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
+    rw [h0] at hlc
+    exact absurd hlc (by decide)
+  have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size :=
+    Hex.ZPoly.size_pos_of_ne_zero _ hcore_ne
+  have hcore_dvd_self :
+      (Hex.normalizeForFactor f).squareFreeCore ∣
+        (Hex.normalizeForFactor f).squareFreeCore :=
+    ⟨(1 : Hex.ZPoly),
+      (Hex.DensePoly.mul_one_right_poly _).symm⟩
+  have hcore_lc_le :
+      (Hex.DensePoly.leadingCoeff
+          (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
+        Hex.ZPoly.defaultFactorCoeffBound
+          (Hex.normalizeForFactor f).squareFreeCore := by
+    have hbound :=
+      defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore
+        hcore_ne (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
+        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
+    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
+    exact hbound
+  exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic
-    (reassemblyExpansionComplete_exhaustive_of_ne_zero
-      f hf_ne hbranch hchoose hcore_monic hprecision)
+    (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
+    hcore_lc_le
+    (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
     hprecision
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260518T105018Z_67fe92e6.md
+++ b/progress/20260518T105018Z_67fe92e6.md
@@ -1,0 +1,87 @@
+# 2026-05-18T10:50Z — #4976: abstract-bound sibling of `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` (public umbrella `_of_bound`)
+
+## Accomplished
+
+Claimed and executed issue #4976: added the public umbrella's
+`_of_bound` sibling in
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean` and rewired the
+existing original as a thin wrapper.
+
+Specifically:
+
+* Inserted `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
+  immediately before the existing umbrella. Its signature replaces the
+  inner-form `hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound
+  (Hex.normalizeForFactor f).squareFreeCore < d.p ^ d.k` binder with the
+  abstract-bound block `(B' : Nat) (hcore_lc_le ...) (hvalid ...)
+  (hprecision : 2 * B' < d.p ^ d.k)`, placed at the same syntactic
+  position as the original `hprecision` so the parameter ordering
+  matches the upstream `_of_bound` siblings (`...aux_of_bound`,
+  `reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound`). Body
+  is a single two-step term-mode composition that mirrors the
+  (now-wrapper) original verbatim: the two forward calls become their
+  `_of_bound` siblings, threading the four-tuple `B'` / `hcore_lc_le`
+  / `hvalid` / `hprecision` verbatim through both helper calls.
+* Rewired the existing original
+  `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData` as a
+  thin `by`-mode wrapper instantiating `B' := Hex.ZPoly.defaultFactorCoeffBound
+  (Hex.normalizeForFactor f).squareFreeCore`. Discharges:
+  - `hcore_ne` from `hcore_monic` (monic ⇒ nonzero via leading
+    coefficient = 1 ≠ 0).
+  - `hcore_size_pos` via `Hex.ZPoly.size_pos_of_ne_zero`.
+  - `hcore_lc_le` via `defaultFactorCoeffBound_valid` paired with
+    `leadingCoeff_eq_coeff_last` (matching the established #4944 /
+    #4970 / #4971 / #4974 boilerplate at adjacent layers).
+  - `hvalid` via the universal `defaultFactorCoeffBound_valid` directly.
+* The original signature, docstring, and two-step framing are
+  preserved exactly. The umbrella is the last theorem in
+  `IntReductionMod.lean` and has no in-tree consumer, so no downstream
+  type-checking is affected by the rewiring.
+
+Verification (all 6 of the issue's verification steps pass):
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — 18
+  errors / 39 warnings, identical to the `origin/main` baseline
+  (confirmed by stashing the edit and rebuilding). All errors are
+  pre-existing whnf timeouts and kernel-unknown errors in
+  `HexBerlekampZassenhausMathlib/Basic.lean`; none are in
+  `IntReductionMod.lean`.
+* `lake build HexBerlekampZassenhausMathlib` — 18 errors / 40
+  warnings, matching `origin/main` (the 40th warning is the
+  pre-existing `unused variable hne` in `HexGramSchmidtMathlib/Int.lean`).
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/IntReductionMod.lean
+   | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` — empty.
+
+Diff: 77 insertions / 4 deletions, single file.
+
+## Current frontier
+
+The A2 abstract-bound (`_of_bound`) cascade now reaches the public
+exhaustive-arm umbrella in `HexBerlekampZassenhausMathlib/IntReductionMod.lean`.
+With the four `_of_bound` siblings now in place at adjacent layers
+(`...aux_of_bound` #4970, the two `reassemblyExpansionComplete_*_of_bound`
+siblings #4974, and now this umbrella `_of_bound`), every internal
+consumer of the concrete-form Mignotte precision shim in the umbrella's
+body has an `_of_bound` sibling, and the umbrella itself exposes the
+abstract-bound surface for the HO-1 capstone (#4170 / #4819) to
+discharge `2 * defaultFactorCoeffBound f < d.p ^ d.k` directly without
+the historical `defaultFactorCoeffBound core ≤ defaultFactorCoeffBound f`
+monotonicity (#4539) detour.
+
+## Next step
+
+* Wire `factor_irreducible_of_nonUnit` (the HO-1 capstone, #4170 /
+  #4819) to consume the new umbrella `_of_bound`. Gated on directive
+  #2567 + #4680, so a separate downstream consumer work item — not
+  filable here.
+* A `_of_primitive_pos_lc_core` variant of the public umbrella is the
+  natural next abstract-bound product, but per #4976's "Out of scope"
+  note it is blocked on the #4880 directive-level rewiring of helpers
+  2/3/4 (architecturally infeasible at the present API surface per the
+  #4940 audit).
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #4976

Session: `67fe92e6-cabb-40cd-b16e-f76e6bf524d2`

dd12032e feat: abstract-bound sibling of factor_exhaustive_branch_entry_irreducible_of_choosePrimeData (public umbrella _of_bound)

🤖 Prepared with Claude Code