### PR TITLE
BZMathlib: normalise _of_bound 'sibling of' → 'variant of' framing in Basic.lean and umbrella cap

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8495,7 +8495,7 @@ private theorem size_primitivePart_eq_of_ne_zero {f : Hex.ZPoly} (hf : f ≠ 0) 
           (Hex.ZPoly.primitivePart f)).size := h_scale_size.symm
     _ = f.size := by rw [h_rec]
 
-/-- Abstract-bound sibling of
+/-- Abstract-bound variant of
 `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum`: takes
 `B' : Nat`, `hcore_lc_bound : (lc core).natAbs ≤ B'`, and
 `hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape
@@ -10926,7 +10926,7 @@ private theorem normalizeFactorSign_scaledRecombinationCandidate_eq
     omega
   rw [if_neg hnot]
 
-/-- Abstract-bound sibling of `zpoly_primitive_scaledRecombinationCandidate`:
+/-- Abstract-bound variant of `zpoly_primitive_scaledRecombinationCandidate`:
 takes `B' : Nat`,
 `hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B'`, and
 `hprecision : 2 * B' < d.p ^ d.k` in place of the core-shape

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -4265,9 +4265,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
     (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
     hprecision
 
-/-- **Abstract-bound sibling of the #4561 / #4848 HO-1 exhaustive-arm umbrella.**
-
-Abstract-bound `_of_bound` companion to
+/-- Abstract-bound variant of
 `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`: the
 concrete inner-form Mignotte precision on the squarefree core
 `2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore < d.p ^ d.k`
@@ -4334,7 +4332,14 @@ The body proceeds in two steps:
 
 Factoring through the internal residual avoids the heartbeat spike the
 previous direct rewiring attempt exposed at the existing wrapper
-application. -/
+application.
+
+Thin wrapper over
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound
+(Hex.normalizeForFactor f).squareFreeCore` and discharges the abstract
+bound hypotheses via `defaultFactorCoeffBound_valid` paired with
+`leadingCoeff_eq_coeff_last`. -/
 theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (entry : Hex.ZPoly × Nat)

--- a/progress/20260518T112134Z_79721bab.md
+++ b/progress/20260518T112134Z_79721bab.md
@@ -1,0 +1,69 @@
+# Session 79721bab — BZMathlib: normalise `_of_bound` "sibling of" → "variant of" framing (#4985)
+
+## Accomplished
+
+Pure-textual docstring normalisation pass closing the framing gaps that
+companion issue #4984 carved out when it filed ahead of the public
+umbrella `_of_bound` sibling landing (#4982 closing #4976). Three
+`Abstract-bound sibling of` outliers eliminated against the canonical
+`Abstract-bound variant of` opening:
+
+1. `HexBerlekampZassenhausMathlib/Basic.lean:8498` —
+   `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound`
+   opening rewritten.
+2. `HexBerlekampZassenhausMathlib/Basic.lean:10929` —
+   `zpoly_primitive_scaledRecombinationCandidate_of_bound` opening
+   rewritten.
+3. `HexBerlekampZassenhausMathlib/IntReductionMod.lean:4268` — public
+   umbrella cap
+   `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`:
+   collapsed the `**…sibling of…**` header line and the `companion to`
+   paragraph into a single canonical `variant of` opening.
+
+Edit 3 added the canonical "Thin wrapper over `..._of_bound`" addendum
+to the rewired public umbrella original at
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean:4316`, mirroring
+the template at `:3659-3664` verbatim.
+
+Diff: ~15 lines across two files, well under the issue's ≤ 25-line cap.
+No proof bodies, signatures, or parameter orderings touched.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic`: same 4-error baseline
+  as `origin/main` (`bbe4df78`); errors at `:15877`, `:15988`, `:16195`,
+  `:16241` are pre-existing.
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod`: same
+  18-error baseline as `origin/main`. All errors are pre-existing
+  upstream heartbeat timeouts / cascading unknown-constants in
+  `Basic.lean`; no IntReductionMod-side errors are introduced.
+* `python3 scripts/check_dag.py` exits 0.
+* `git diff --check` clean.
+* `git grep "sorry|axiom|native_decide|TODO|FIXME"` on the diff shows
+  no new entries.
+* `git grep -n "Abstract-bound sibling of" HexBerlekampZassenhausMathlib/Basic.lean
+  HexBerlekampZassenhausMathlib/IntReductionMod.lean` returns only the
+  four IntReductionMod entries at `:3098`, `:3438`, `:3799`, `:4021`
+  that are #4984's scope.
+
+## Current frontier
+
+With this PR landed and #4984's PR landed, every `_of_bound` sibling
+across Basic.lean and IntReductionMod will share a single canonical
+docstring framing (`Abstract-bound variant of <original>:` opening
+plus the rewired-wrapper "Thin wrapper over `..._of_bound`" addendum),
+simplifying the next layer of `_of_bound` propagation (the monic outer
+chain
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound`,
+#4934, blocked on PR #4917).
+
+## Next step
+
+Per the issue's "Out of scope" section: (a) #4984 needs to land (it is
+claimed but not yet merged at session start), (b) the monic outer
+chain #4934 is gated on PR #4917, (c) the `_of_primitive_pos_lc_core`
+umbrella variant remains directive-blocked per #4880.
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #4985

Session: `79721bab-8e42-4803-815b-b356cabfc2e7`

25c69368 doc: normalise `_of_bound` 'sibling of' → 'variant of' framing in Basic.lean and umbrella cap (#4985)

🤖 Prepared with Claude Code