### PR TITLE
BZMathlib: extract defaultFactorCoeffBound_leadingCoeff_natAbs_le helper and rewire 17 hcore_lc_le boilerplate sites

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -131,6 +131,21 @@ theorem defaultFactorCoeffBound_valid
     have hgcoeff_zero : g.coeff i = 0 := hcoeff_eq ▸ hcoeff_zero
     simp [hgcoeff_zero]
 
+/-- The default factor coefficient bound dominates the natural absolute value
+of the leading coefficient of any nonzero executable polynomial. Standard
+packaging of `defaultFactorCoeffBound_valid` at
+`g := f, hgf := f ∣ f, i := f.size - 1` paired with
+`leadingCoeff_eq_coeff_last`. -/
+theorem defaultFactorCoeffBound_leadingCoeff_natAbs_le
+    {f : Hex.ZPoly} (hf : f ≠ 0) :
+    (Hex.DensePoly.leadingCoeff f).natAbs ≤
+      Hex.ZPoly.defaultFactorCoeffBound f := by
+  have hsize_pos : 0 < f.size := Hex.ZPoly.size_pos_of_ne_zero _ hf
+  have hf_dvd_self : f ∣ f :=
+    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly f).symm⟩
+  rw [Hex.DensePoly.leadingCoeff_eq_coeff_last f hsize_pos]
+  exact defaultFactorCoeffBound_valid f hf f hf_dvd_self (f.size - 1)
+
 /--
 Executable irreducibility predicate for transported integer polynomials.
 
@@ -8353,17 +8368,7 @@ theorem representsIntegerFactorAtLift_primitive
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core := by
-      refine ⟨(1 : Hex.ZPoly), ?_⟩
-      exact (Hex.DensePoly.mul_one_right_poly core).symm
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact representsIntegerFactorAtLift_primitive_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd_core)
@@ -11057,16 +11062,7 @@ private theorem zpoly_primitive_scaledRecombinationCandidate
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact zpoly_primitive_scaledRecombinationCandidate_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core) hcore_lc_le
     hcore_ne hcore_lc_pos hd_liftedFactor_monic hprecision T
@@ -11268,16 +11264,7 @@ theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCa
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
     have hmul : quotient * scaledRecombinationCandidate core d T = target :=
@@ -12188,14 +12175,7 @@ theorem coverAtMin_representingSubset_subset_of_scaledRecombinationCandidate_dvd
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
     have hmul : quotient * scaledRecombinationCandidate core d T = target :=
@@ -13175,14 +13155,7 @@ theorem liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
@@ -14370,14 +14343,7 @@ private theorem scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorS
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
@@ -14540,14 +14506,7 @@ theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSu
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
@@ -14664,14 +14623,7 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_lc_le
@@ -14831,14 +14783,7 @@ theorem exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence_of_bound
     h hpartition hcore_ne hcore_primitive hcore_lc_pos hB_ne_zero hd_modulus
     hd_liftedFactor_monic hd_liftedFactor_natDegree_pos hd_liftedFactor_inj
@@ -15029,14 +14974,7 @@ theorem exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCo
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
     hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
@@ -15385,14 +15323,7 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     _hbranch _hentry_mem h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero
     hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
@@ -15607,14 +15538,7 @@ theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorr
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     _hbranch _hentry_mem h hpartition hcore_ne hcore_primitive hcore_lc_pos
     hcore_record hB_ne_zero hd_modulus hd_liftedFactor_monic

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3421,20 +3421,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
         (Hex.normalizeForFactor f).squareFreeCore :=
     ⟨(1 : Hex.ZPoly),
       (Hex.DensePoly.mul_one_right_poly _).symm⟩
-  -- Discharge `hcore_lc_le` at the default-bound instantiation
-  -- via `defaultFactorCoeffBound_valid` paired with `leadingCoeff_eq_coeff_last`
-  -- (mirroring the rewiring pattern established by #4935 / #4936 / #4938 / #4944).
-  have hcore_lc_le : (Hex.DensePoly.leadingCoeff
-      (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound
-          (Hex.normalizeForFactor f).squareFreeCore := by
-    have hbound :=
-      defaultFactorCoeffBound_valid
-        (Hex.normalizeForFactor f).squareFreeCore hcore_ne
-        (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
-        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic hcomplete
     (Hex.ZPoly.defaultFactorCoeffBound
@@ -3716,17 +3703,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
         (Hex.normalizeForFactor f).squareFreeCore :=
     ⟨(1 : Hex.ZPoly),
       (Hex.DensePoly.mul_one_right_poly _).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff
-          (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound
-          (Hex.normalizeForFactor f).squareFreeCore := by
-    have hbound :=
-      defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore
-        hcore_ne (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
-        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
     f hf_ne hbranch hchoose hcore_monic
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
@@ -4017,17 +3994,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
         (Hex.normalizeForFactor f).squareFreeCore :=
     ⟨(1 : Hex.ZPoly),
       (Hex.DensePoly.mul_one_right_poly _).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff
-          (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound
-          (Hex.normalizeForFactor f).squareFreeCore := by
-    have hbound :=
-      defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore
-        hcore_ne (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
-        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
     f hf_ne hbranch hchoose hcore_monic
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
@@ -4271,17 +4238,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
         (Hex.normalizeForFactor f).squareFreeCore :=
     ⟨(1 : Hex.ZPoly),
       (Hex.DensePoly.mul_one_right_poly _).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff
-          (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound
-          (Hex.normalizeForFactor f).squareFreeCore := by
-    have hbound :=
-      defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore
-        hcore_ne (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
-        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
     f hf_ne hbranch hchoose hcore_primitive hcore_lc_pos hcore_monic
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
@@ -4402,17 +4359,7 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
         (Hex.normalizeForFactor f).squareFreeCore :=
     ⟨(1 : Hex.ZPoly),
       (Hex.DensePoly.mul_one_right_poly _).symm⟩
-  have hcore_lc_le :
-      (Hex.DensePoly.leadingCoeff
-          (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound
-          (Hex.normalizeForFactor f).squareFreeCore := by
-    have hbound :=
-      defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore
-        hcore_ne (Hex.normalizeForFactor f).squareFreeCore hcore_dvd_self
-        ((Hex.normalizeForFactor f).squareFreeCore.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hcore_size_pos]
-    exact hbound
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)

--- a/progress/20260518T114504Z_bb7025e2.md
+++ b/progress/20260518T114504Z_bb7025e2.md
@@ -1,0 +1,92 @@
+# 2026-05-18T11:45Z — #4987: extract `defaultFactorCoeffBound_leadingCoeff_natAbs_le` helper
+
+## Accomplished
+
+Claimed and executed issue #4987: extracted a single-purpose helper in
+`HexBerlekampZassenhausMathlib/Basic.lean` and rewired the 17
+byte-identical `hcore_lc_le` discharge sites across `Basic.lean` and
+`IntReductionMod.lean` to a one-line invocation.
+
+Specifically:
+
+* Inserted `defaultFactorCoeffBound_leadingCoeff_natAbs_le`
+  immediately after `defaultFactorCoeffBound_valid` (Basic.lean:134).
+  Signature: `{f : Hex.ZPoly} (hf : f ≠ 0) →
+  (Hex.DensePoly.leadingCoeff f).natAbs ≤
+  Hex.ZPoly.defaultFactorCoeffBound f`. Body is the standard 3-step
+  packaging: `size_pos_of_ne_zero` for `0 < f.size`, an explicit
+  `f ∣ f` witness (`⟨1, mul_one_right_poly.symm⟩` — needed because
+  `dvd_refl _` triggers a `semigroupDvd` instance mismatch against
+  the `Hex.DensePoly.instDvdOfAddOfMul` instance expected by
+  `defaultFactorCoeffBound_valid`), and the
+  `leadingCoeff_eq_coeff_last` rewrite forwarding to
+  `defaultFactorCoeffBound_valid f hf f hf_dvd_self (f.size - 1)`.
+* Rewired 12 sites in `HexBerlekampZassenhausMathlib/Basic.lean`
+  (lines 8356, 11060, 11271, 12191, 13178, 14373, 14543, 14667,
+  14834, 15032, 15388, 15610 in pre-edit numbering) to a single-line
+  `have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le
+  hcore_ne`. Three distinct body shapes existed:
+  - 1 site (8356): inline `refine ⟨..., ?_⟩` style `hcore_dvd_self`.
+  - 2 sites (11060, 11271): inline `:=` style `hcore_dvd_self`.
+  - 9 sites: `hcore_dvd_self` pre-existing from outer scope.
+* Rewired 5 sites in
+  `HexBerlekampZassenhausMathlib/IntReductionMod.lean` (lines 3417,
+  3709, 4003, 4250, 4376 in pre-edit numbering) to the same
+  single-line invocation.
+* Per the issue's explicit guidance, did not remove now-unused
+  `hcore_dvd_self` / `hcore_size_pos` `have`s preceding the rewired
+  blocks ("a follow-up cleanup can address that separately"); they
+  remain in place at sites where they are no longer consumed.
+* Rebased over two doc-normalisation commits (#4986 / #4988) that
+  landed during the session. One textual conflict at the former site
+  3417: #4986 added an explicit `hcore_dvd_self` `have` block to that
+  site (conforming it to the other 4 IntReductionMod sites) while my
+  commit deleted the surrounding discharge block. Resolved by keeping
+  both the new `hcore_dvd_self` (now an unused local, per the same
+  follow-up-cleanup guidance) and my single-line `hcore_lc_le`.
+
+Verification (all 6 of the issue's verification steps pass post-rebase):
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod` —
+  18 errors / 39 warnings (pre-existing whnf timeouts / kernel-unknown
+  errors in `Basic.lean`; none in `IntReductionMod.lean`).
+* `lake build HexBerlekampZassenhausMathlib` — 18 errors / 40
+  warnings, matching `origin/main` baseline. Error and warning
+  patterns are identical to baseline modulo line shifts of ~15 lines
+  from the inserted helper.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+   HexBerlekampZassenhausMathlib/IntReductionMod.lean
+   | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` —
+  empty.
+* `git diff --stat origin/main`: net line reduction of -129 lines
+  across the two files (Basic.lean: +21 / -87; IntReductionMod.lean:
+  +11 / -74).
+
+## Current frontier
+
+The leading-coefficient discharge boilerplate at the abstract-bound
+(`_of_bound`) cascade's thin-wrapper layer is now packaged into a
+single helper, matching the precedent established by
+`Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero` (#4637) for the
+positivity dispatch. The remaining `hcore_dvd_self` and
+`hcore_size_pos` `have`s at the 17 rewired sites are unused at all
+but the cap-layer's outer-discharge sites; their cleanup is a
+deliberate follow-up scope (per #4987's "Out of scope" note).
+
+## Next step
+
+A follow-up cleanup issue could remove the now-unused
+`hcore_dvd_self` / `hcore_size_pos` `have`s at the 17 sites
+(reducing each rewired wrapper by another 4-8 lines), but per the
+issue's scope this is explicitly deferred.
+
+The `_of_primitive_pos_lc_core` variant of the public umbrella
+remains the natural next abstract-bound product, blocked on #4880's
+directive-level rewiring of helpers 2/3/4 (architecturally
+infeasible at the present API surface per the #4940 audit).
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #4987

Session: `bb7025e2-3e1d-4691-9591-3114148d4837`

b5d40829 doc: add progress note for #4987 (defaultFactorCoeffBound_leadingCoeff_natAbs_le helper)
45e8c09a refactor: extract defaultFactorCoeffBound_leadingCoeff_natAbs_le helper

🤖 Prepared with Claude Code