### PR TITLE
BZMathlib: drop stale two-step body paragraph and bare-line refs on exhaustive-arm umbrella

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3337,9 +3337,10 @@ discharged by #4637 via `defaultFactorCoeffBound_pos_of_ne_zero` and
 `precisionForCoeffBound_spec`.)
 
 Downstream consumers (notably the HO-1 capstone #4170 / #4819)
-currently route through the public umbrella's
-`_of_bound` sibling at line 4328 (which discharges Gap 3 against an
-abstract bound) and supply `hcore_monic` directly. Closing the
+currently route through the public umbrella's `_of_bound` sibling
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
+(which discharges Gap 3 against an abstract bound) and supply
+`hcore_monic` directly. Closing the
 remaining Gap 1 requires a directive-level decision per #4880; see
 the **#4880 / #4940** addendum below.
 
@@ -3358,7 +3359,9 @@ through the discharger.
 **#4982:** the original `hprecision` shim (Gap 3) now has an
 abstract-bound route. The sibling
 `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
-(landed in PR #4982 at line 4328) replaces the core-shape
+(landed in PR #4982 as
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`)
+replaces the core-shape
 `hprecision` with the abstract triple `(B', hcore_lc_le, hvalid,
 hprecision : 2 * B' < d.p ^ d.k)`. Downstream consumers wanting
 to discharge `hprecision` against an outer-shape Mignotte witness
@@ -4323,23 +4326,11 @@ Public surface of the exhaustive-arm HO-1 umbrella. Gap 2
 (`hprecision`) is exposed in this wrapper's signature against the
 core-shape Mignotte threshold; downstream consumers wanting the
 abstract-bound surface (notably the HO-1 capstone #4170 / #4819)
-should route through the `_of_bound` sibling at line 4328 (PR
-#4982). Gap 1 (`hcore_monic`) remains directive-level blocked per
+should route through the `_of_bound` sibling
+`factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
+(PR #4982). Gap 1 (`hcore_monic`) remains directive-level blocked per
 #4880 / #4940 audit; see the `_aux` docstring above for the full
 architectural finding.
-
-The body proceeds in two steps:
-
-1. Apply `reassemblyExpansionComplete_exhaustive_of_ne_zero` to construct
-   the `hcomplete` witness from `(f, hf_ne, hbranch, hchoose, hcore_monic,
-   hprecision)`.
-2. Apply the internal residual
-   `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux`,
-   which carries the existing wrapper composition unchanged.
-
-Factoring through the internal residual avoids the heartbeat spike the
-previous direct rewiring attempt exposed at the existing wrapper
-application.
 
 Thin wrapper over
 `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
@@ -4363,7 +4354,9 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
       (Hex.normalizeForFactor f).squareFreeCore)
     -- Gap 3 (substrate): explicit on this wrapper; downstream consumers
     -- wanting an outer-shape bound should route through the `_of_bound`
-    -- sibling at line 4328 (PR #4982).
+    -- sibling
+    -- `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`
+    -- (PR #4982).
     (hprecision :
       2 * Hex.ZPoly.defaultFactorCoeffBound
         (Hex.normalizeForFactor f).squareFreeCore <

--- a/progress/2026-05-18T12-03-08Z_9e005cf9.md
+++ b/progress/2026-05-18T12-03-08Z_9e005cf9.md
@@ -1,0 +1,49 @@
+# 2026-05-18T12:03Z — feature session 9e005cf9 — #4993
+
+## Accomplished
+
+Discharged #4993 (BZMathlib docstring cleanup on the exhaustive-arm
+public umbrella `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`):
+
+* **Edit 1** — Dropped the stale "body proceeds in two steps"
+  paragraph (12 lines) on the public umbrella docstring. The paragraph
+  described the pre-#4982 body composition (route via
+  `reassemblyExpansionComplete_exhaustive_of_ne_zero` + the `_aux`
+  residual + heartbeat-spike framing); the actual body now forwards
+  directly to `_of_bound` in a single `exact`. The "Thin wrapper over
+  `..._of_bound`" addendum immediately following already describes the
+  current composition.
+* **Edit 2** — Replaced four stale `line 4328` references
+  (`:3341`, `:3361`, `:4326`, `:4366`) with the bare theorem name
+  `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound`.
+  Line numbers had drifted by ~43 lines after PR #4991's helper-extraction
+  pass; name-based references won't rot on future file shifts.
+
+Net diff: 13 insertions / 20 deletions across one file, well under the
+25-line cap.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — same
+  18-error baseline as `origin/main`@`89ac1f67`; all errors confined to
+  `Basic.lean`, zero in `IntReductionMod.lean`.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main … | grep -E '\b(sorry|axiom|native_decide|TODO|FIXME)\b'`
+  on `+` lines — empty.
+* `git grep -n 'line 4328' HexBerlekampZassenhausMathlib/IntReductionMod.lean`
+  — empty.
+* `git grep -n 'body proceeds in two steps|Factoring through the internal
+  residual|heartbeat spike the previous direct rewiring' …` — empty.
+
+## Current frontier
+
+Issue #4993 ready for PR.
+
+## Next step
+
+`coordination create-pr 4993`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4993

Session: `9e005cf9-e75a-4aaf-8035-64ba83e49ce7`

40f373bd doc: drop stale two-step body paragraph and bare-line refs on exhaustive-arm umbrella (#4993)

🤖 Prepared with Claude Code