### PR TITLE
BZMathlib: drop now-unused hcore_dvd_self / hcore_size_pos haves at the 5 IntReductionMod _of_bound thin-wrapper rewire sites (#4991 follow-up)

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3441,11 +3441,6 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
       rw [hlc_zero] at hlc_one
       exact absurd hlc_one (by decide)
     · exact hpos
-  have hcore_dvd_self :
-      (Hex.normalizeForFactor f).squareFreeCore ∣
-        (Hex.normalizeForFactor f).squareFreeCore :=
-    ⟨(1 : Hex.ZPoly),
-      (Hex.DensePoly.mul_one_right_poly _).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic hcomplete
@@ -3721,13 +3716,6 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
         (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
     rw [hzero] at hlead
     exact absurd hlead (by decide)
-  have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size :=
-    Hex.ZPoly.size_pos_of_ne_zero _ hcore_ne
-  have hcore_dvd_self :
-      (Hex.normalizeForFactor f).squareFreeCore ∣
-        (Hex.normalizeForFactor f).squareFreeCore :=
-    ⟨(1 : Hex.ZPoly),
-      (Hex.DensePoly.mul_one_right_poly _).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -4012,13 +4000,6 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
         (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
     rw [h0] at hlc
     exact absurd hlc (by decide)
-  have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size :=
-    Hex.ZPoly.size_pos_of_ne_zero _ hcore_ne
-  have hcore_dvd_self :
-      (Hex.normalizeForFactor f).squareFreeCore ∣
-        (Hex.normalizeForFactor f).squareFreeCore :=
-    ⟨(1 : Hex.ZPoly),
-      (Hex.DensePoly.mul_one_right_poly _).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -4256,13 +4237,6 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
     rw [h0] at hcore_lc_pos
     have hzero : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := by decide
     omega
-  have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size :=
-    Hex.ZPoly.size_pos_of_ne_zero _ hcore_ne
-  have hcore_dvd_self :
-      (Hex.normalizeForFactor f).squareFreeCore ∣
-        (Hex.normalizeForFactor f).squareFreeCore :=
-    ⟨(1 : Hex.ZPoly),
-      (Hex.DensePoly.mul_one_right_poly _).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
     f hf_ne hbranch hchoose hcore_primitive hcore_lc_pos hcore_monic
@@ -4371,13 +4345,6 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
         (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
     rw [h0] at hlc
     exact absurd hlc (by decide)
-  have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size :=
-    Hex.ZPoly.size_pos_of_ne_zero _ hcore_ne
-  have hcore_dvd_self :
-      (Hex.normalizeForFactor f).squareFreeCore ∣
-        (Hex.normalizeForFactor f).squareFreeCore :=
-    ⟨(1 : Hex.ZPoly),
-      (Hex.DensePoly.mul_one_right_poly _).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic

--- a/progress/20260518T122219Z_048423b7.md
+++ b/progress/20260518T122219Z_048423b7.md
@@ -1,0 +1,55 @@
+# Session 048423b7 — drop unused hcore_dvd_self / hcore_size_pos haves at 5 IntReductionMod rewire sites
+
+Claimed and executed #4996.
+
+## Accomplished
+
+- Deleted the now-unused `have hcore_dvd_self` (5 sites) and
+  `have hcore_size_pos` (4 sites — site 3446 had only `hcore_dvd_self`)
+  bindings immediately preceding the
+  `have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne`
+  rewires in `HexBerlekampZassenhausMathlib/IntReductionMod.lean` at
+  the 5 thin-wrapper sites (pre-rebase lines 3446, 3728, 4019, 4263,
+  4388). The `exact` immediately following each rewire passes
+  `hcore_lc_le` plus `defaultFactorCoeffBound_valid …` directly; no
+  reference to the deleted witnesses survives in any of the 5 `exact`
+  bodies.
+- Net diff: 33 deletions, 0 insertions, single file.
+- Rebased onto `origin/main` (78360d9f) since claim-time HEAD
+  (ba04a689) was one commit behind a doc-only update that touched
+  unrelated docstrings in the same file.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod`: 18
+  errors, all pre-existing in `Basic.lean` (4863, 5144, 5470, 5557,
+  5604, 5866, 5988, 6136, 6308, 6289, 6623, 6687, 15786, 15897,
+  16104, 16150 + meta `Lean exited with code 1` / `build failed`);
+  matches the `origin/main` baseline at session-claim time. No new
+  errors in `IntReductionMod.lean`.
+- `grep -c "have hcore_size_pos\b" HexBerlekampZassenhausMathlib/IntReductionMod.lean`
+  → 1 (pre-existing internal positivity witness; the 4 rewire-site
+  copies all removed).
+- `grep -c "have hcore_dvd_self\b" HexBerlekampZassenhausMathlib/IntReductionMod.lean`
+  → 0 (all 5 wrapper-site copies removed).
+- `grep -c "defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne" HexBerlekampZassenhausMathlib/IntReductionMod.lean`
+  → 5 (all rewire sites intact).
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- `git diff origin/main -- HexBerlekampZassenhausMathlib/IntReductionMod.lean | grep -E '^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b'`:
+  empty.
+
+## Current frontier
+
+Closes the IntReductionMod half of the #4991 follow-up cleanup. The
+12 analogous sites in `HexBerlekampZassenhausMathlib/Basic.lean`
+remain (intentionally split per #4996 issue body).
+
+## Next step
+
+A future planner cycle can file the Basic.lean analogue once this
+lands and the deletion template is validated.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4996

Session: `048423b7-1c3c-4ed0-91e8-f8eab6190011`

154b2386 doc: progress entry for #4996 (BZMathlib unused-have cleanup)
89a8ca92 BZMathlib: drop now-unused hcore_dvd_self / hcore_size_pos haves at 5 IntReductionMod _of_bound thin-wrapper rewire sites

🤖 Prepared with Claude Code