### PR TITLE
BZMathlib: drop now-unused hcore_dvd_self / hcore_size_pos haves at the 12 Basic.lean _of_bound thin-wrapper rewire sites (#4991 follow-up, #4996 sibling)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8353,21 +8353,6 @@ theorem representsIntegerFactorAtLift_primitive
     refine ⟨u * v, ?_⟩
     rw [hv, hu]
     exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact representsIntegerFactorAtLift_primitive_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -11047,21 +11032,6 @@ private theorem zpoly_primitive_scaledRecombinationCandidate
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
     (T : LiftedFactorSubset d) :
     Hex.ZPoly.Primitive (scaledRecombinationCandidate core d T) := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact zpoly_primitive_scaledRecombinationCandidate_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core) hcore_lc_le
@@ -11249,21 +11219,6 @@ theorem exists_representingSubset_of_mem_normalizedFactors_scaledRecombinationCa
       S_g ⊆ T ∧
       Hex.ZPoly.content g = 1 ∧
       Hex.normalizeFactorSign g = g := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
@@ -12158,23 +12113,6 @@ theorem coverAtMin_representingSubset_subset_of_scaledRecombinationCandidate_dvd
       S ⊆ J ∧ J.min' hne ∈ S ∧
       RepresentsIntegerFactorAtLift core d f S ∧
       S ⊆ T := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
@@ -13138,23 +13076,6 @@ theorem liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled
             | none => none
             | some r => some (candidate' :: r)
       else none) = none := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core_scaled_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -14326,23 +14247,6 @@ private theorem scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorS
               (HexPolyZMathlib.toPolynomial factor) := by
   intro target J localFactors fuel htarget_primitive htarget_lc_pos
     htarget_dvd_core hpartition hmatches hfuel
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -14489,23 +14393,6 @@ theorem scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSu
       ∃ emitted ∈ result,
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact scaledRecombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -14606,23 +14493,6 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
       ∃ emitted ∈ result,
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -14769,23 +14639,6 @@ theorem exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence
       Associated
         (HexPolyZMathlib.toPolynomial emitted)
         (HexPolyZMathlib.toPolynomial factor) := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_coverage_of_henselSubsetCorrespondence_of_bound
     h hpartition hcore_ne hcore_primitive hcore_lc_pos hB_ne_zero hd_modulus
@@ -14960,23 +14813,6 @@ theorem exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCo
     ∀ factor ∈
       (Hex.exhaustiveCoreFactorsWithBound core B primeData).toList,
       Hex.ZPoly.Irreducible factor := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
@@ -15309,23 +15145,6 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core := by
     rw [show Hex.DensePoly.leadingCoeff core = (1 : Int) from hcore_monic]
     decide
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     _hbranch _hentry_mem h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero
@@ -15506,23 +15325,6 @@ theorem factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorr
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
   set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     _hbranch _hentry_mem h hpartition hcore_ne hcore_primitive hcore_lc_pos

--- a/progress/20260518T123829Z_e032b950.md
+++ b/progress/20260518T123829Z_e032b950.md
@@ -1,0 +1,60 @@
+# Session e032b950 — #4997 Basic.lean boilerplate cleanup
+
+## Accomplished
+
+- Claimed and executed #4997: deleted now-unused `hcore_size_pos` and
+  `hcore_dvd_self` `have` blocks at the 12 `_of_bound` thin-wrapper
+  rewire sites in `HexBerlekampZassenhausMathlib/Basic.lean`.
+- 198-line pure deletion (zero additions):
+  - 12 × 15-line `hcore_size_pos` blocks (180 lines)
+  - 9 × 2-line `hcore_dvd_self` blocks at Group B sites (18 lines)
+- Group A sites (size_pos only): rewire at 8371, 11065, 11267.
+- Group B sites (size_pos + dvd_self): rewire at 12178, 13158, 14346,
+  14509, 14626, 14789, 14980, 15329, 15526.
+- Used a one-shot Python script (`/tmp/delete_haves.py`) with
+  per-site `have hcore_size_pos`/`have hcore_dvd_self` header and
+  trailing-line assertions before deleting, so site identity was
+  validated structurally rather than only by line number.
+
+## Verification
+
+- `git grep -c "have hcore_size_pos\b" HexBerlekampZassenhausMathlib/Basic.lean`
+  drops 20 → 8 (exactly −12, matches plan).
+- `git grep -c "have hcore_dvd_self\b" HexBerlekampZassenhausMathlib/Basic.lean`
+  drops 16 → 7 (exactly −9, matches plan).
+- `lake build HexBerlekampZassenhausMathlib.Basic`: 18 errors before,
+  18 errors after, identical error types (all pre-existing whnf
+  timeouts / kernel-unknown constants). Plan body's "currently 16
+  errors" was stale; actual baseline at session-claim time was 18.
+- `lake build HexBerlekampZassenhausMathlib`: same 18 errors.
+- `lake build HexBerlekampZassenhaus`: succeeds (143 jobs).
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- `git diff origin/main`: 0 additions, 198 deletions, single file.
+- No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` in diff.
+
+## Current frontier
+
+PR pushed; closes #4997.
+
+## Next step
+
+None for this corner — the IntReductionMod analogue (#4996) is in
+flight separately; with #4996 + this PR landed, the
+`defaultFactorCoeffBound_leadingCoeff_natAbs_le` boilerplate-rewire
+cleanup is complete across both files.
+
+## Blockers
+
+None.
+
+## Discrepancy notes (for planners)
+
+- The issue body's verification grep targets ("18 → 6" for
+  `hcore_size_pos`) were off by 2; the actual baseline was 20 and the
+  post-state is 8. The deletion *count* (−12) was correct. Likely an
+  earlier PR added two preserved sites between planning and execution.
+- The issue body's "16 errors" baseline for
+  `lake build HexBerlekampZassenhausMathlib.Basic` was likewise stale;
+  the actual baseline at session-claim time was 18. The
+  pre/post error sets were identical, so the cleanup is sound.


### PR DESCRIPTION
Closes #4997

Session: `e032b950-0bed-43d0-869c-f067aaab3bc5`

6e501a20 refactor: drop now-unused hcore_dvd_self / hcore_size_pos haves at 12 Basic.lean _of_bound rewire sites

🤖 Prepared with Claude Code