### PR TITLE
BZMathlib: extract zpoly_ne_zero_of_monic / zpoly_ne_zero_of_pos_lc helpers and rewire 9 hcore_ne derivation sites in IntReductionMod.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6730,7 +6730,7 @@ private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
     exact absurd hlead (by decide)
   · exact hcs_pos
 
-private theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}
+theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}
     (h : Hex.DensePoly.Monic f) : f ≠ 0 := by
   intro hf
   have hpos := zpoly_size_pos_of_monic h
@@ -8107,7 +8107,7 @@ private theorem zpoly_primitive_of_toPolynomial_isPrimitive_basic
   · rw [hneg] at hcontent_nonneg
     omega
 
-private theorem zpoly_ne_zero_of_pos_lc {f : Hex.ZPoly}
+theorem zpoly_ne_zero_of_pos_lc {f : Hex.ZPoly}
     (hpos : 0 < Hex.DensePoly.leadingCoeff f) : f ≠ 0 := by
   intro hf
   rw [hf] at hpos

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3143,12 +3143,8 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
   have hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 :=
     hbranch.2.1
   -- Discharge `hcore_ne` from `hcore_monic`.
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro hzero
-    have hlead : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [hzero] at hlead
-    exact absurd hlead (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   -- Provenance facts from `hchoose`.
   have hp_prime : Hex.Nat.Prime
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p :=
@@ -3413,12 +3409,8 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
     Hex.ZPoly.Irreducible entry.1 := by
   -- Discharge `hcore_ne` from `hcore_monic` (needed by the dischargers below).
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro hzero
-    have hlead : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [hzero] at hlead
-    exact absurd hlead (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   -- `0 < core.size` so `leadingCoeff_eq_coeff_last` applies.
   have hcore_size_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.size := by
     rcases Nat.eq_zero_or_pos
@@ -3502,12 +3494,8 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
   -- Substrate setup mirrors `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`.
   have hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 :=
     hbranch.2.1
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro hzero
-    have hlead : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [hzero] at hlead
-    exact absurd hlead (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   have hp_prime : Hex.Nat.Prime
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p :=
     Hex.choosePrimeData?_prime _ _ hchoose
@@ -3710,12 +3698,8 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)).toList,
       Hex.ZPoly.Irreducible q) := by
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro hzero
-    have hlead : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [hzero] at hlead
-    exact absurd hlead (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -3836,13 +3820,8 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
   -- hypothesis + monicness.
   have hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 := hbranch.2.1
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro h0
-    have hlc : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [h0] at hlc
-    have hzero : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := by decide
-    omega
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   have hcore_record : Hex.shouldRecordPolynomialFactor
       (Hex.normalizeForFactor f).squareFreeCore = true := by
     have hne_one : (Hex.normalizeForFactor f).squareFreeCore ≠ 1 := by
@@ -3994,12 +3973,8 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) := by
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro h0
-    have hlc : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [h0] at hlc
-    exact absurd hlc (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -4053,11 +4028,8 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
   -- `hcore_lc_pos`.
   have hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 := hbranch.2.1
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro h0
-    rw [h0] at hcore_lc_pos
-    have hzero : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := by decide
-    omega
+  have hcore_ne :=
+    zpoly_ne_zero_of_pos_lc (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_lc_pos
   have hcore_record : Hex.shouldRecordPolynomialFactor
       (Hex.normalizeForFactor f).squareFreeCore = true := by
     have hne_one : (Hex.normalizeForFactor f).squareFreeCore ≠ 1 := by
@@ -4232,11 +4204,8 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) := by
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro h0
-    rw [h0] at hcore_lc_pos
-    have hzero : Hex.DensePoly.leadingCoeff (0 : Hex.ZPoly) = 0 := by decide
-    omega
+  have hcore_ne :=
+    zpoly_ne_zero_of_pos_lc (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_lc_pos
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
     f hf_ne hbranch hchoose hcore_primitive hcore_lc_pos hcore_monic
@@ -4339,12 +4308,8 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
     Hex.ZPoly.Irreducible entry.1 := by
-  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by
-    intro h0
-    have hlc : Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore = 1 := hcore_monic
-    rw [h0] at hlc
-    exact absurd hlc (by decide)
+  have hcore_ne :=
+    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic

--- a/progress/2026-05-18T12-54-53Z_290d6258.md
+++ b/progress/2026-05-18T12-54-53Z_290d6258.md
@@ -1,0 +1,47 @@
+# 2026-05-18T12:54Z — issue #5000 (feature)
+
+## Accomplished
+
+Closed the `hcore_ne` boilerplate cluster at the IntReductionMod.lean
+thin-wrapper layer.
+
+* Dropped `private` from `zpoly_ne_zero_of_monic`
+  (`HexBerlekampZassenhausMathlib/Basic.lean`) and
+  `zpoly_ne_zero_of_pos_lc` (same file). Bodies and signatures
+  unchanged.
+* Rewired all 9 `hcore_ne` derivation sites in
+  `HexBerlekampZassenhausMathlib/IntReductionMod.lean` to a single
+  `have hcore_ne := zpoly_ne_zero_of_{monic,pos_lc} (f := ...)` line:
+  - 7 monic-derived sites (entries / preconditions wrappers / inner
+    reassembly / public umbrella wrapper).
+  - 2 `lc_pos`-derived sites (`_of_primitive_pos_lc_core` and its
+    public umbrella variant).
+
+Net change: −35 lines across the two files.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — 16
+  pre-existing errors, all in `Basic.lean`; no new errors in
+  `IntReductionMod.lean`. Matches the issue's baseline expectation
+  ("all errors are pre-existing in Basic.lean").
+* `lake build HexBerlekampZassenhausMathlib` — same 16 pre-existing
+  errors, all in `Basic.lean`.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* `git diff origin/main -- ... | grep -E sorry|axiom|native_decide|TODO|FIXME`
+  — empty.
+* `git grep -n "have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 := by"`
+  in IntReductionMod.lean — 0 matches.
+
+## Current frontier
+
+Issue deliverables landed verbatim.
+
+## Next step
+
+Open PR closing #5000.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5000

Session: `290d6258-f695-4352-a12d-3428469504ce`

6a682b74 refactor: expose zpoly_ne_zero_of_monic / zpoly_ne_zero_of_pos_lc and rewire 9 IntReductionMod hcore_ne sites (#5000)

🤖 Prepared with Claude Code