### PR TITLE
BZMathlib: extend defaultFactorCoeffBound_leadingCoeff_natAbs_le rewire to 7 hcore_lc_bound body sites in Basic.lean (#4991 follow-up)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8641,16 +8641,7 @@ theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     hcore_ne hcore_lc_pos hd_liftedFactor_monic hcore_lc_bound hprecision T
@@ -8817,14 +8808,7 @@ theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
@@ -10007,14 +9991,7 @@ theorem exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hvalid : ∀ g ∈ gs, ∀ i,
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
     intro g hg i
@@ -11436,14 +11413,7 @@ theorem exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandi
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hvalid : ∀ g ∈ gs, ∀ i,
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
     intro g hg i
@@ -11725,14 +11695,7 @@ theorem mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombina
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
     have hmul : quotient * scaledRecombinationCandidate core d T = target :=
@@ -11898,14 +11861,7 @@ theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_o
     · exact hpos
   have hcore_dvd_self : core ∣ core :=
     ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
     have hmul : quotient * scaledRecombinationCandidate core d T = target :=
@@ -12424,16 +12380,7 @@ private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc
       rw [hlc_zero] at hcore_lc_pos
       omega
     · exact hpos
-  have hcore_lc_bound :
-      (Hex.DensePoly.leadingCoeff core).natAbs ≤
-        Hex.ZPoly.defaultFactorCoeffBound core := by
-    have hcore_dvd_self : core ∣ core :=
-      ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-    have hbound :=
-      defaultFactorCoeffBound_valid core hcore_ne core hcore_dvd_self
-        (core.size - 1)
-    rw [Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
-    exact hbound
+  have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd)

--- a/progress/20260518T130810Z_ab303d05.md
+++ b/progress/20260518T130810Z_ab303d05.md
@@ -1,0 +1,65 @@
+# Session ab303d05 — #5002 hcore_lc_bound rewire
+
+## Accomplished
+
+- Claimed and executed #5002: rewired the 7 inline
+  `have hcore_lc_bound : (lc core).natAbs ≤ defaultFactorCoeffBound core := by …`
+  blocks in `HexBerlekampZassenhausMathlib/Basic.lean` to a single-line
+  invocation of `defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne`.
+  The local name `hcore_lc_bound` is preserved; downstream consumers
+  unchanged.
+- Two patterns rewired with a single text replacement each:
+  - **Pattern A** (locally-introduced `hcore_dvd_self`, 10-line block,
+    2 sites): bodies of
+    `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum` and
+    `not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core`.
+  - **Pattern B** (outer-scope `hcore_dvd_self`, 8-line block,
+    5 sites): bodies of
+    `natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core`,
+    `exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core`,
+    `exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandidate_of_primitive_pos_lc_core`,
+    `mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombinationCandidate_of_primitive_pos_lc_core`,
+    `exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_of_primitive_pos_lc_core`.
+- Net change on single file: +7 / −60 = −53 lines (issue estimated
+  −35..−45, slight undercount; the per-site arithmetic
+  `2·(10−1) + 5·(8−1) = 53` makes the actual delta self-consistent).
+
+## Verification
+
+- `git grep -n "have hcore_lc_bound :$" HexBerlekampZassenhausMathlib/Basic.lean`
+  → 0 lines (was 7).
+- `git grep -c "defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne" HexBerlekampZassenhausMathlib/Basic.lean`
+  → 19 (was 12 — increase of exactly 7, matches issue criterion).
+- `lake build HexBerlekampZassenhausMathlib.Basic`: 16 errors before,
+  16 errors after; identical error types (11 whnf timeouts +
+  1 cases-failure + 4 kernel-unknown constants), and all line-number
+  offsets at the 15xxx sites shift by exactly −53 lines, matching the
+  diff-stat delta.
+- `lake build HexBerlekampZassenhausMathlib`: same 16 errors, no new ones.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` in diff.
+- Unused-variable warning set unchanged: 5 `hcore_ne` warnings before
+  and after (line numbers shifted at sites past the deletions).
+
+## Current frontier
+
+PR pushed; closes #5002. With #4991 (17 `hcore_lc_le` sites) and #5002
+(7 `hcore_lc_bound` sites) landed, all 24 thin-wrapper
+`(lc core).natAbs ≤ defaultFactorCoeffBound core` derivation sites in
+`Basic.lean` are rewired to the helper.
+
+## Next step
+
+Out-of-scope follow-ups noted by the issue (a planner may pick these up):
+
+- Drop outer-scope `hcore_dvd_self` / `hcore_size_pos` `have`s that
+  became unused at the 5 Pattern B sites in this PR (analogue of the
+  #4996 / #4997 sequence after #4991).
+- Harmonise `hcore_lc_bound` vs `hcore_lc_le` parameter naming on the
+  `_of_bound` siblings, where the inconsistency now sits at the
+  signature layer.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5002

Session: `ab303d05-36ed-444e-9f20-8214537f1512`

d6bb6af5 refactor: rewire 7 hcore_lc_bound body sites to defaultFactorCoeffBound_leadingCoeff_natAbs_le (#4991 follow-up)

🤖 Prepared with Claude Code