### PR TITLE
BZMathlib: extract zpoly_lc_pos_of_monic helper and rewire 4 hcore_lc_pos derivation sites

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6737,6 +6737,12 @@ theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}
   rw [hf] at hpos
   exact absurd hpos (by simp)
 
+theorem zpoly_lc_pos_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) :
+    0 < Hex.DensePoly.leadingCoeff f := by
+  rw [show Hex.DensePoly.leadingCoeff f = (1 : Int) from h]
+  decide
+
 private theorem zpoly_monic_one : Hex.DensePoly.Monic (1 : Hex.ZPoly) := by
   show Hex.DensePoly.leadingCoeff (1 : Hex.ZPoly) = (1 : Int)
   change Hex.DensePoly.leadingCoeff (Hex.DensePoly.C (1 : Int)) = (1 : Int)
@@ -14996,11 +15002,7 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
   have hcore_primitive :
       Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
     (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
-  have hcore_lc_pos :
-      0 < Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore := by
-    rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
-      (1 : Int) from hcore_monic]
-    decide
+  have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
   have hirr_raw : Hex.ZPoly.Irreducible raw :=
     exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
       h hpartition hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
@@ -15089,9 +15091,7 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
   set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
-  have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core := by
-    rw [show Hex.DensePoly.leadingCoeff core = (1 : Int) from hcore_monic]
-    decide
+  have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
     _hbranch _hentry_mem h hpartition hcore_ne hcore_monic hcore_record hB_ne_zero

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3254,11 +3254,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
     have hcore_primitive :
         Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
       (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
-    have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore := by
-      rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
-        (1 : Int) from hcore_monic]
-      decide
+    have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
     exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
       hbranch hentry_mem
       (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f)
@@ -3597,11 +3593,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
     have hcore_primitive :
         Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
       (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
-    have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
-        (Hex.normalizeForFactor f).squareFreeCore := by
-      rw [show Hex.DensePoly.leadingCoeff (Hex.normalizeForFactor f).squareFreeCore =
-        (1 : Int) from hcore_monic]
-      decide
+    have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
     exact exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
       (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f)
       (liftedFactorSubsetPartition_outerBound_of_choosePrimeData f hf_ne)

--- a/progress/2026-05-18T13-31-17Z_8e42c28a.md
+++ b/progress/2026-05-18T13-31-17Z_8e42c28a.md
@@ -1,0 +1,50 @@
+# 2026-05-18T13:31:17Z — feature session 8e42c28a (issue #5005)
+
+## Accomplished
+
+* Added `zpoly_lc_pos_of_monic` helper in
+  `HexBerlekampZassenhausMathlib/Basic.lean`, immediately after the
+  existing sibling `zpoly_ne_zero_of_monic` (post-#5001).
+* Rewired the 4 inline `0 < leadingCoeff core`-from-`Monic`
+  derivation sites:
+  - `Basic.lean:14999-15003` (5-line block → 1 line)
+  - `Basic.lean:15091-15094` (3-line block → 1 line; `set core := ...` scope)
+  - `IntReductionMod.lean:3257-3261` (5-line block → 1 line)
+  - `IntReductionMod.lean:3600-3604` (5-line block → 1 line)
+* Net diff against `origin/main`: −18 / +10 lines across two files.
+* Build baseline preserved: `lake build
+  HexBerlekampZassenhausMathlib.IntReductionMod` reports the same 18
+  pre-existing errors as `origin/main` (`57b0f04c`); zero new errors.
+* `python3 scripts/check_dag.py` exit 0.
+* `git diff --check` clean.
+* No new `sorry`, `axiom`, `native_decide`, `TODO`, `FIXME` in diff.
+
+## Verification deviation from issue spec
+
+The issue's `git grep -c "rw \[show Hex.DensePoly.leadingCoeff"`
+verification step predicted a drop of "exactly 4". Actual drop is 3
+(5 → 2) because the helper's body itself uses the same one-line
+`rw [show ... from h]; decide` pattern by design. The four rewire
+sites are all correctly removed; the residual matches are
+(a) the new helper body at `Basic.lean:6743` and (b) the unrelated
+`scaledLiftedFactorProduct` substitution at `Basic.lean:7695`.
+`git grep -c zpoly_lc_pos_of_monic` is 5 (3 in Basic.lean = 1 def
++ 2 invocations; 2 in IntReductionMod.lean = 2 invocations), which
+matches the spec exactly.
+
+## Current frontier
+
+Helper-cluster extraction on the `Monic`-implies-everything-else
+pattern now covers `ne_zero` (#5001) and `lc_pos` (this PR). The
+next sibling in the cluster — primitivity-from-nonzero on
+`(normalizeForFactor f).squareFreeCore` — is planned in #5007 and
+out of scope here.
+
+## Next step
+
+Issue #5007 (`normalizeForFactor_squareFreeCore_primitive_of_ne_zero`,
+3 IntReductionMod rewires) is the immediate sibling and is unclaimed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5005

Session: `8e42c28a-a4ca-4262-a08b-f754f51a4425`

30ef51dc refactor: extract zpoly_lc_pos_of_monic helper and rewire 4 hcore_lc_pos derivation sites (#5005)

🤖 Prepared with Claude Code