### PR TITLE
BZMathlib: drop now-unused outer hcore_size_pos / hcore_dvd_self haves at 7 hcore_lc_bound rewire sites in Basic.lean (#5002 follow-up)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8632,21 +8632,6 @@ theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum
         (scaledRecombinationCandidate core d T)).natDegree =
       ∑ i ∈ T,
         (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -8797,23 +8782,6 @@ theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core
     (HexPolyZMathlib.toPolynomial factor).natDegree =
       ∑ i ∈ S,
         (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree := by
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -9980,23 +9948,6 @@ theorem exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core
       (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)).natDegree =
         ∑ g ∈ gs, (HexPolyZMathlib.toPolynomial g).natDegree) :
     ∀ {i : LiftedFactorIndex d}, i ∈ T → ∃ g ∈ gs, i ∈ S_of g := by
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hvalid : ∀ g ∈ gs, ∀ i,
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
@@ -11402,23 +11353,6 @@ theorem exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandi
           (scaledRecombinationCandidate core d T)).natDegree =
         ∑ g ∈ gs, (HexPolyZMathlib.toPolynomial g).natDegree) :
     ∀ {i : LiftedFactorIndex d}, i ∈ T → ∃ g ∈ gs, i ∈ S_of g := by
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hvalid : ∀ g ∈ gs, ∀ i,
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
@@ -11684,23 +11618,6 @@ theorem mem_T_iff_exists_irreducibleFactor_representingSubset_of_scaledRecombina
       g ∣ scaledRecombinationCandidate core d T ∧
       RepresentsIntegerFactorAtLift core d g S_g ∧
       S_g ⊆ J ∧ i ∈ S_g := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
@@ -11850,23 +11767,6 @@ theorem exists_representingSubset_of_mem_T_of_scaledRecombinationCandidate_dvd_o
       S ⊆ J ∧
       i ∈ S ∧
       RepresentsIntegerFactorAtLift core d f S := by
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
-  have hcore_dvd_self : core ∣ core :=
-    ⟨(1 : Hex.ZPoly), (Hex.DensePoly.mul_one_right_poly core).symm⟩
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   have hcand_dvd_target :
       scaledRecombinationCandidate core d T ∣ target := by
@@ -12371,21 +12271,6 @@ private theorem not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc
     ¬ RepresentsIntegerFactorAtLift core d factor
       (∅ : LiftedFactorSubset d) := by
   -- Bound the leading coefficient of `core` against the Mignotte half-window.
-  have hcore_size_pos : 0 < core.size := by
-    rcases Nat.eq_zero_or_pos core.size with hzero | hpos
-    · exfalso
-      have hback_none : core.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : core.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff core = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hcore_lc_pos
-      omega
-    · exact hpos
   have hcore_lc_bound := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)

--- a/progress/20260518T134214Z_f8ea0dd3.md
+++ b/progress/20260518T134214Z_f8ea0dd3.md
@@ -1,0 +1,74 @@
+# Session f8ea0dd3 — #5003 drop now-unused hcore_size_pos / hcore_dvd_self haves
+
+## Accomplished
+
+- Claimed and executed #5003: pure-deletion cleanup at the 7
+  `hcore_lc_bound` rewire sites in
+  `HexBerlekampZassenhausMathlib/Basic.lean` that #5006 (closing
+  #5002) had just collapsed to single-line invocations of
+  `defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne`.
+- Deleted 7 of the 8 outer-scope
+  `have hcore_size_pos : 0 < core.size := by …` blocks (15 lines each,
+  byte-identical at all 7 dead sites — single `replace_all` Edit). The
+  one remaining site at `Basic.lean:5338` in
+  `monicModularImage_modP_eq_of_monic` is genuinely used (consumed on
+  the next line by `leadingCoeff_eq_coeff_last core hcore_size_pos`)
+  and uses a different proof body (`by_contra` / `Nat.eq_zero_of_not_pos`
+  rather than `rcases Nat.eq_zero_or_pos`), so the keeper did not
+  match the `replace_all` pattern.
+- Deleted all 5 outer-scope
+  `have hcore_dvd_self : core ∣ core := ⟨(1 : Hex.ZPoly), …⟩` blocks
+  (2 lines each, byte-identical — single `replace_all` Edit). The
+  Pattern-A consumers (`hfactor_dvd`, `hg_dvd_core`) at those sites
+  did not reference `hcore_dvd_self`.
+- Net diff: 0 additions / 115 deletions on a single file, matching
+  the issue's prediction of ~115 lines (7 × 15 + 5 × 2 = 115).
+
+## Verification
+
+- `git grep -c "have hcore_size_pos\b"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 8 → 1 (Δ -7, only the
+  keeper at line 5338 remains, as required).
+- `git grep -c "have hcore_dvd_self\b"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 5 → 0 (Δ -5, all dead
+  sites removed).
+- `lake build HexBerlekampZassenhausMathlib.Basic`: identical 16-error
+  baseline (11 whnf timeouts + 4 kernel unknown-constant + 1
+  cases-failure), same as post-#5002 main (`57b0f04c`). No new errors.
+- `lake build HexBerlekampZassenhausMathlib`: same 16-error baseline,
+  no new errors.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- Unused-variable warning set unchanged: 5 `hcore_ne` warnings at
+  lines 4344, 8257, 8507, 8665, 10859 (same as previous session).
+- `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+   | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"`: empty
+  (pure deletion, no additions).
+- `git diff --stat origin/main`: 1 file changed, 115 deletions(-).
+
+## Current frontier
+
+PR pushed; closes #5003. With #4998 / #4999 (12 `_of_bound` thin
+wrapper rewires), #5004 (orphan `hcore_size_pos` in IntReductionMod),
+and now #5003 (7 `hcore_lc_bound` rewire sites in Basic), the cleanup
+cascade behind the `defaultFactorCoeffBound_leadingCoeff_natAbs_le`
+helper (#4991) is complete at the `hcore_lc_le` / `hcore_lc_bound`
+sites in Basic.lean.
+
+## Next step
+
+Out-of-scope follow-ups noted by the issue (a planner may pick these
+up):
+
+- Helper extraction for the `hcore_lc_pos`-from-`hcore_monic` pattern
+  at `Basic.lean:15052`, `Basic.lean:15145`,
+  `IntReductionMod.lean:3261`, `IntReductionMod.lean:3612` (#5005 is
+  the in-flight version of this for the 4 sites).
+- Investigate the 5 remaining `unused variable hcore_ne` warnings —
+  by-design now that the helper consumes it directly, but the
+  thin-wrapper signatures still accept it for symmetry with the
+  `_of_bound` siblings; harmonisation is a separate cleanup.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5003

Session: `f8ea0dd3-27c4-406f-9d28-7d1acbda2036`

65c5171c refactor: drop now-unused hcore_size_pos / hcore_dvd_self haves at 7 hcore_lc_bound rewire sites (#5003)

🤖 Prepared with Claude Code