### PR TITLE
BZMathlib: extract normalizeForFactor_squareFreeCore_primitive_of_ne_zero helper and rewire 3 IntReductionMod sites

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -1053,6 +1053,17 @@ theorem zpoly_primitive_of_toPolynomial_isPrimitive
   · rw [hneg] at hcontent_nonneg; omega
 
 /--
+Composition of `normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive`
+and `zpoly_primitive_of_toPolynomial_isPrimitive`: from `f ≠ 0` derive
+`Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore` in one step.
+-/
+theorem normalizeForFactor_squareFreeCore_primitive_of_ne_zero
+    (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
+  zpoly_primitive_of_toPolynomial_isPrimitive
+    (normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive f hf)
+
+/--
 Helper for the coprime inductive step of
 `gcd_derivative_associated_divRadical_of_charZero`. In any `GCDMonoid`,
 divisibility into a product factors through the component gcds:
@@ -2478,10 +2489,7 @@ theorem reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
   classical
   -- Discharge prerequisites for the squareFreeCore.
   have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
-  have hcore_primitive :
-      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-    zpoly_primitive_of_toPolynomial_isPrimitive
-      (normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive f hf)
+  have hcore_primitive := normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf
   -- Per-factor invariants from the quadratic branch.
   have hirr : ∀ q ∈ coreFactors.toList, Hex.ZPoly.Irreducible q := fun q hq =>
     Hex.quadraticIntegerRootFactors?_factor_irreducible_of_primitive
@@ -2968,11 +2976,8 @@ theorem factor_quadratic_branch_entry_irreducible_of_quadraticRoots
     Hex.factorWithBound_entry_mem_quadratic_branch_raw f B entry hB_gt_one hdeg
       hquad hentry_mem
   -- Primitivity of squareFreeCore via the Mathlib bridge.
-  have hcore_primitive :
-      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-    IntReductionMod.zpoly_primitive_of_toPolynomial_isPrimitive
-      (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive
-        f hf_ne)
+  have hcore_primitive :=
+    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
   have hcore_pos :
       0 < Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore :=
@@ -3071,11 +3076,8 @@ theorem factor_slow_quadratic_branch_entry_irreducible_of_choosePrimeData
     Hex.factorWithBound_entry_mem_slow_quadratic_branch_raw f B entry hdeg
       hquad hfast_none hentry_mem
   -- Primitivity of squareFreeCore via the Mathlib bridge.
-  have hcore_primitive :
-      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-    IntReductionMod.zpoly_primitive_of_toPolynomial_isPrimitive
-      (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive
-        f hf_ne)
+  have hcore_primitive :=
+    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
   have hcore_pos :
       0 < Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore :=

--- a/progress/2026-05-18T135722Z_26ddb06b.md
+++ b/progress/2026-05-18T135722Z_26ddb06b.md
@@ -1,0 +1,43 @@
+# 2026-05-18 13:57 UTC — issue #5007 (feature)
+
+## Accomplished
+
+Extracted helper `normalizeForFactor_squareFreeCore_primitive_of_ne_zero`
+in `HexBerlekampZassenhausMathlib/IntReductionMod.lean` (immediately after
+`zpoly_primitive_of_toPolynomial_isPrimitive`, line 1055) and rewired the
+three byte-equivalent 4-5-line `hcore_primitive` derivation blocks at the
+quadratic-arm sites:
+
+- `reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero`
+  body (unqualified, `hf`).
+- `factor_quadratic_branch_entry_irreducible_of_quadraticRoots` body
+  (`IntReductionMod.`-qualified, `hf_ne`).
+- `factor_slow_quadratic_branch_entry_irreducible_of_choosePrimeData`
+  body (`IntReductionMod.`-qualified, `hf_ne`).
+
+Net diff: +16 / -14 lines in one file.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — 18 errors,
+  all in `Basic.lean`, matching the `origin/main` baseline; no errors in
+  `IntReductionMod.lean`.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git grep -c "normalizeForFactor_squareFreeCore_primitive_of_ne_zero"
+   HexBerlekampZassenhausMathlib/IntReductionMod.lean` = 4 (1 def + 3
+  invocations).
+- No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME`.
+
+## Current frontier
+
+Helper-cluster cleanup continues per planner queue; this commit follows
+the same pattern as #4991, #5001, #5005.
+
+## Next step
+
+PR creation via `coordination create-pr 5007`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5007

Session: `26ddb06b-3f36-4d3f-81f6-4088659d5b06`

4188ff0d refactor: extract normalizeForFactor_squareFreeCore_primitive_of_ne_zero helper and rewire 3 IntReductionMod sites (#5007)

🤖 Prepared with Claude Code