### PR TITLE
BZMathlib: extract zpoly_primitive_of_monic helper and rewire 3 hcore_primitive Monic-route sites

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6743,6 +6743,11 @@ theorem zpoly_lc_pos_of_monic {f : Hex.ZPoly}
   rw [show Hex.DensePoly.leadingCoeff f = (1 : Int) from h]
   decide
 
+/-- Monic integer polynomials are primitive (content 1). -/
+theorem zpoly_primitive_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : Hex.ZPoly.Primitive f :=
+  (monic_primitive_sign_normalized_of_monic h).2.1
+
 private theorem zpoly_monic_one : Hex.DensePoly.Monic (1 : Hex.ZPoly) := by
   show Hex.DensePoly.leadingCoeff (1 : Hex.ZPoly) = (1 : Int)
   change Hex.DensePoly.leadingCoeff (Hex.DensePoly.C (1 : Int)) = (1 : Int)
@@ -14884,9 +14889,7 @@ theorem factorWithBound_exhaustive_branch_entry_core_zpolyIrreducible_of_henselS
         entry.1 = Hex.normalizeFactorSign raw) :
     Hex.ZPoly.Irreducible entry.1 := by
   obtain ⟨raw, hraw_mem, hentry_eq⟩ := hcore_entry
-  have hcore_primitive :
-      Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-    (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+  have hcore_primitive := zpoly_primitive_of_monic hcore_monic
   have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
   have hirr_raw : Hex.ZPoly.Irreducible raw :=
     exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3251,9 +3251,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
       (Hex.xPowerFactorArray_irreducible (Hex.normalizeForFactor f).xPower raw hx)
   · -- Exhaustive-core case: apply the outer-bound slow-path wrapper's
     -- `_of_bound` sibling (#4947).
-    have hcore_primitive :
-        Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-      (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+    have hcore_primitive := zpoly_primitive_of_monic hcore_monic
     have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
     exact factor_exhaustive_branch_entry_core_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
       hbranch hentry_mem
@@ -3568,9 +3566,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)
       (Hex.squareFreeCore_normalizeFactorSign_of_ne_zero f hf_ne)
   · -- Irreducibility on every emitted factor.
-    have hcore_primitive :
-        Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore :=
-      (monic_primitive_sign_normalized_of_monic hcore_monic).2.1
+    have hcore_primitive := zpoly_primitive_of_monic hcore_monic
     have hcore_lc_pos := zpoly_lc_pos_of_monic hcore_monic
     exact exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound
       (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f)

--- a/progress/20260518T135606Z_fc89ed52.md
+++ b/progress/20260518T135606Z_fc89ed52.md
@@ -1,0 +1,65 @@
+# Session fc89ed52 — #5010 zpoly_primitive_of_monic helper extraction
+
+## Accomplished
+
+- Claimed and executed #5010: extracted the `zpoly_primitive_of_monic`
+  helper at `HexBerlekampZassenhausMathlib/Basic.lean:6746-6749`
+  (immediately after `zpoly_lc_pos_of_monic`, before
+  `private theorem zpoly_monic_one`), then rewired 3 named-`have`
+  derivation sites that previously composed the same `.2.1` projection
+  of `monic_primitive_sign_normalized_of_monic` inline:
+  - `Basic.lean:15002-15004` (3-line block) → 1 line
+  - `IntReductionMod.lean:3254-3256` (3-line block) → 1 line
+  - `IntReductionMod.lean:3571-3573` (3-line block) → 1 line
+- Helper signature:
+  `(h : Hex.DensePoly.Monic f) → Hex.ZPoly.Primitive f`, body
+  `(monic_primitive_sign_normalized_of_monic h).2.1`.
+- Cluster placement matches the precedent set by
+  `zpoly_size_pos_of_monic` / `zpoly_ne_zero_of_monic` (#5001) /
+  `zpoly_lc_pos_of_monic` (#5009).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib`: 16 lean errors pre-edit,
+  16 lean errors post-edit; error set byte-identical modulo a uniform
+  +3-line shift for the 4 errors past the helper-insertion point
+  (line 6744) in `Basic.lean`. Zero errors in `IntReductionMod.lean`.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- `grep -c "(monic_primitive_sign_normalized_of_monic hcore_monic).2.1"`
+  in the two touched files: 3 → 1 (the remaining occurrence is the
+  inline arg-position call at `Basic.lean:5597`, explicitly listed in
+  the issue as out of scope).
+- `grep -c "zpoly_primitive_of_monic"` in the two touched files:
+  0 → 4 (1 definition in `Basic.lean` + 1 rewire in `Basic.lean` +
+  2 rewires in `IntReductionMod.lean`).
+- No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` in the
+  diff.
+- Net change: 8 insertions, 9 deletions across 2 files.
+
+## Notes
+
+- Branch was at `origin/main` (1c331b3d) at session-claim time, the
+  exact baseline named in the issue body. No rebase needed.
+- Line numbers in the issue body (14996, 3254, 3571) for site 1
+  drifted by +6 against the actual file state because of `#5009`'s
+  helper insertion above. The pattern was unambiguous (3 occurrences
+  of the exact `.2.1` snippet outside the inline arg-position site),
+  so the rewires applied without ambiguity.
+
+## Current frontier
+
+PR pushed; closes #5010.
+
+## Next step
+
+None for this corner. The Monic-route helper cluster is now complete
+for `Primitive`, `ne_zero`, `lc_pos`, and `size_pos`. The remaining
+boilerplate-cleanup work in the queue (#5007,
+`normalizeForFactor_squareFreeCore_primitive_of_ne_zero` helper +
+3 rewires) is the `f ≠ 0`-route sibling at a different `Primitive`
+source — distinct from this cluster.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5010

Session: `fc89ed52-7691-4bcf-8435-35cfc500b1c5`

f0a58510 refactor: extract zpoly_primitive_of_monic helper and rewire 3 hcore_primitive Monic-route sites

🤖 Prepared with Claude Code