### PR TITLE
BZMathlib: suppress 5 unused hcore_ne warnings by underscore-prefixing at _of_bound Basic.lean signatures

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4341,7 +4341,7 @@ theorem scaledRecombinationCandidate_eq_factor_of_recovery_of_bound
     {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
     (B' : Nat)
     (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
-    (hcore_ne : core ≠ 0)
+    (_hcore_ne : core ≠ 0)
     (hfactor_prim : Hex.ZPoly.content factor = 1)
     (hfactor_norm : Hex.normalizeFactorSign factor = factor)
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
@@ -8265,7 +8265,7 @@ theorem representsIntegerFactorAtLift_primitive_of_bound
     (B' : Nat)
     (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
     (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
-    (hcore_ne : core ≠ 0)
+    (_hcore_ne : core ≠ 0)
     (hcore_primitive : Hex.ZPoly.Primitive core)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic :
@@ -8515,7 +8515,7 @@ and `zpoly_primitive_scaledRecombinationCandidate_of_bound`. -/
 theorem natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound
     {core : Hex.ZPoly} {d : Hex.LiftData}
     (B' : Nat)
-    (hcore_ne : core ≠ 0)
+    (_hcore_ne : core ≠ 0)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic :
       ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
@@ -8673,7 +8673,7 @@ theorem natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_
     (B' : Nat)
     (hvalid : ∀ i, (factor.coeff i).natAbs ≤ B')
     (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
-    (hcore_ne : core ≠ 0)
+    (_hcore_ne : core ≠ 0)
     (_hcore_primitive : Hex.ZPoly.Primitive core)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic :
@@ -10867,7 +10867,7 @@ private theorem zpoly_primitive_scaledRecombinationCandidate_of_bound
     {core : Hex.ZPoly} {d : Hex.LiftData}
     (B' : Nat)
     (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
-    (hcore_ne : core ≠ 0)
+    (_hcore_ne : core ≠ 0)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
     (hprecision : 2 * B' < d.p ^ d.k)

--- a/progress/20260518T144833Z_d33a1c47.md
+++ b/progress/20260518T144833Z_d33a1c47.md
@@ -1,0 +1,44 @@
+# Suppress 5 unused `hcore_ne` warnings at `_of_bound` Basic.lean sites
+
+## Accomplished
+
+Renamed `(hcore_ne : core ≠ 0)` → `(_hcore_ne : core ≠ 0)` at the five
+`_of_bound` theorem signatures in
+`HexBerlekampZassenhausMathlib/Basic.lean` flagged by the issue:
+
+- `scaledRecombinationCandidate_eq_factor_of_recovery_of_bound`
+- `representsIntegerFactorAtLift_primitive_of_bound`
+- `natDegree_toPolynomial_scaledRecombinationCandidate_eq_sum_of_bound`
+- `natDegree_toPolynomial_eq_sum_of_represents_of_primitive_pos_lc_core_of_bound`
+- `zpoly_primitive_scaledRecombinationCandidate_of_bound`
+
+The proof bodies do not reference `hcore_ne`; the parameter survives in
+the signature so the non-`_of_bound` wrapper siblings (which DO use it
+internally) can keep their positional invocation unchanged.
+
+Verification at the listed sites:
+
+- `git grep -c "(_hcore_ne : core ≠ 0)" …Basic.lean`: 8 → 13.
+- `git grep -c "(hcore_ne : core ≠ 0)" …Basic.lean`: 80 → 75.
+- `lake build HexBerlekampZassenhausMathlib.Basic`: 16-error baseline
+  (11 whnf timeouts + 1 cases-failure + 4 kernel-unknown constants)
+  unchanged; the 5 `unused variable hcore_ne` warnings disappear (post
+  build log shows 0 `hcore_ne` mentions).
+- `lake build HexBerlekampZassenhausMathlib`: same 16-error baseline.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- `git diff --stat`: 1 file changed, +5 / −5.
+
+## Current frontier
+
+Underscore-prefix suppression sweep for `hcore_ne` is now complete: 13
+sites prefixed, 0 `unused variable hcore_ne` warnings in `Basic.lean`.
+
+## Next step
+
+The sibling `hcore_lc_bound` → `hcore_lc_le` parameter rename is the
+queued companion cleanup (separately tracked).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5015

Session: `d33a1c47-4153-4076-bc8e-e93e3252074c`

2a027e09 BZMathlib: suppress 5 unused hcore_ne warnings by underscore-prefixing at _of_bound Basic.lean signatures (#5015)

🤖 Prepared with Claude Code