### PR TITLE
BZMathlib: harmonise 7 zpoly_ne_zero_of_monic IntReductionMod sites to implicit-f form

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3145,8 +3145,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
   have hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 :=
     hbranch.2.1
   -- Discharge `hcore_ne` from `hcore_monic`.
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   -- Provenance facts from `hchoose`.
   have hp_prime : Hex.Nat.Prime
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p :=
@@ -3405,8 +3404,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
     Hex.ZPoly.Irreducible entry.1 := by
   -- Discharge `hcore_ne` from `hcore_monic` (needed by the dischargers below).
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic hcomplete
@@ -3468,8 +3466,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
   -- Substrate setup mirrors `factor_exhaustive_branch_entry_irreducible_of_choosePrimeData`.
   have hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 :=
     hbranch.2.1
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hp_prime : Hex.Nat.Prime
       (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p :=
     Hex.choosePrimeData?_prime _ _ hchoose
@@ -3666,8 +3663,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)).toList,
       Hex.ZPoly.Irreducible q) := by
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -3788,8 +3784,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
   -- hypothesis + monicness.
   have hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 := hbranch.2.1
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hcore_record : Hex.shouldRecordPolynomialFactor
       (Hex.normalizeForFactor f).squareFreeCore = true := by
     have hne_one : (Hex.normalizeForFactor f).squareFreeCore ≠ 1 := by
@@ -3941,8 +3936,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) := by
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
     f hf_ne hbranch hchoose hcore_monic
@@ -4276,8 +4270,7 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p) :
     Hex.ZPoly.Irreducible entry.1 := by
-  have hcore_ne :=
-    zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+  have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem hchoose hcore_monic

--- a/progress/2026-05-18T15-36-59Z_311011b8.md
+++ b/progress/2026-05-18T15-36-59Z_311011b8.md
@@ -1,0 +1,60 @@
+# 2026-05-18T15-36-59Z — feature session 311011b8
+
+## Accomplished
+
+Closed #5023: harmonised the seven `zpoly_ne_zero_of_monic` call sites in
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean` (lines 3148, 3408,
+3471, 3669, 3791, 3944, 4279 in the pre-edit file) from the
+named-argument form
+
+```lean
+have hcore_ne :=
+  zpoly_ne_zero_of_monic (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_monic
+```
+
+to the implicit-`f` form
+
+```lean
+have hcore_ne := zpoly_ne_zero_of_monic hcore_monic
+```
+
+matching the pattern already in use at `Basic.lean:6760-6761`. Single
+`replace_all` edit; net −7 lines (each 2-line block becomes a 1-line
+block). No other files touched.
+
+## Verification
+
+* `git grep -c "zpoly_ne_zero_of_monic (f :="
+   HexBerlekampZassenhausMathlib/IntReductionMod.lean`: 7 → 0 ✓
+* `git grep -c "zpoly_ne_zero_of_monic hcore_monic"
+   HexBerlekampZassenhausMathlib/IntReductionMod.lean`: 0 → 7 ✓
+* `git grep -c "zpoly_ne_zero_of_monic"
+   HexBerlekampZassenhausMathlib/IntReductionMod.lean`: 7 → 7 ✓
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod`: the 16
+   pre-existing errors in `Basic.lean` (11 whnf timeouts + 1
+   cases-failure + 4 kernel-unknown-constants) are byte-identical to
+   the baseline described in the issue. No new errors.
+* `python3 scripts/check_dag.py`: exit 0.
+* `git diff --check`: clean.
+* `git diff --stat` shows `7 insertions(+), 14 deletions(-)`, net −7
+   lines (7 sites × −1 line each).
+* No `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` introduced.
+
+## Current frontier
+
+The Monic-route helper cluster at `Basic.lean:6720-6749` now has a
+fully consistent call-site form for `zpoly_ne_zero_of_monic`
+everywhere it's used. The other three siblings
+(`zpoly_size_pos_of_monic`, `zpoly_lc_pos_of_monic`,
+`zpoly_primitive_of_monic`) are tracked by separate consistency
+sweeps and were not touched here.
+
+## Next step
+
+None required for this issue. A separate planner cycle will queue the
+analogous harmonisation sweeps for the other three cluster siblings if
+they have similarly redundant call sites in `IntReductionMod.lean`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5023

Session: `311011b8-6ac1-4594-9a38-06b3518b0b65`

ab7b95cb refactor: harmonise 7 zpoly_ne_zero_of_monic IntReductionMod sites to implicit-f form (#5023)

🤖 Prepared with Claude Code