### PR TITLE
BZMathlib: extract zpoly_normalize_factor_sign_of_monic helper and rewire 2 inline destructure sites

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6748,6 +6748,11 @@ theorem zpoly_primitive_of_monic {f : Hex.ZPoly}
     (h : Hex.DensePoly.Monic f) : Hex.ZPoly.Primitive f :=
   (monic_primitive_sign_normalized_of_monic h).2.1
 
+/-- Monic integer polynomials are fixed by `Hex.normalizeFactorSign`. -/
+theorem zpoly_normalize_factor_sign_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : Hex.normalizeFactorSign f = f :=
+  (monic_primitive_sign_normalized_of_monic h).2.2
+
 private theorem zpoly_monic_one : Hex.DensePoly.Monic (1 : Hex.ZPoly) := by
   show Hex.DensePoly.leadingCoeff (1 : Hex.ZPoly) = (1 : Int)
   change Hex.DensePoly.leadingCoeff (Hex.DensePoly.C (1 : Int)) = (1 : Int)
@@ -7825,10 +7830,11 @@ theorem natDegree_toPolynomial_recombinationCandidate_eq_sum
   have hcl_monic := monic_centeredLiftPoly_of_monic hlp_monic hd_modulus
   set cl := Hex.centeredLiftPoly lp (d.p ^ d.k) with hcl_def
   -- A monic poly has trivial content and trivial sign normalisation.
-  obtain ⟨_, hcontent, hnorm⟩ := monic_primitive_sign_normalized_of_monic hcl_monic
+  have hnorm : Hex.normalizeFactorSign cl = cl :=
+    zpoly_normalize_factor_sign_of_monic hcl_monic
   have hprim : Hex.ZPoly.primitivePart cl = cl :=
     Hex.ZPoly.primitivePart_eq_self_of_primitive cl
-      (by simpa [Hex.ZPoly.Primitive] using hcontent)
+      (zpoly_primitive_of_monic hcl_monic)
   -- Combining, the candidate is just the centered lift of the product.
   have hrec_eq : recombinationCandidate d T = cl := by
     unfold recombinationCandidate
@@ -9531,13 +9537,14 @@ theorem recombinationCandidate_monic
   have hcl_monic :
       Hex.DensePoly.Monic (Hex.centeredLiftPoly lp (d.p ^ d.k)) :=
     monic_centeredLiftPoly_of_monic hlp_monic hd_modulus
-  obtain ⟨_, hcontent, hnorm⟩ :=
-    monic_primitive_sign_normalized_of_monic hcl_monic
+  have hnorm : Hex.normalizeFactorSign (Hex.centeredLiftPoly lp (d.p ^ d.k)) =
+      Hex.centeredLiftPoly lp (d.p ^ d.k) :=
+    zpoly_normalize_factor_sign_of_monic hcl_monic
   have hprim :
       Hex.ZPoly.primitivePart (Hex.centeredLiftPoly lp (d.p ^ d.k)) =
         Hex.centeredLiftPoly lp (d.p ^ d.k) :=
     Hex.ZPoly.primitivePart_eq_self_of_primitive _
-      (by simpa [Hex.ZPoly.Primitive] using hcontent)
+      (zpoly_primitive_of_monic hcl_monic)
   have hrec_eq :
       recombinationCandidate d T = Hex.centeredLiftPoly lp (d.p ^ d.k) := by
     unfold recombinationCandidate

--- a/progress/20260518T153811Z_244f4f1e.md
+++ b/progress/20260518T153811Z_244f4f1e.md
@@ -1,0 +1,79 @@
+# 2026-05-18 15:38 UTC — extract zpoly_normalize_factor_sign_of_monic helper (244f4f1e)
+
+Claimed feature issue #5021 and landed the fourth and final
+projection helper of the Monic-route cluster at
+`HexBerlekampZassenhausMathlib/Basic.lean:6747-6755`. Skipped
+#4334 first on host-load grounds (9.81 / 13.79 / 24.55 load on 24
+cores, above the quiet-host threshold required by
+`SPEC/benchmarking.md` for scientific verdict promotion).
+
+## Accomplished
+
+* Added `theorem zpoly_normalize_factor_sign_of_monic` returning
+  `Hex.normalizeFactorSign f = f`, paralleling the three existing
+  cluster siblings (`zpoly_ne_zero_of_monic`,
+  `zpoly_lc_pos_of_monic`, `zpoly_primitive_of_monic`). Body is
+  `(monic_primitive_sign_normalized_of_monic h).2.2`.
+* Rewired Site 1 at `Basic.lean:7828` and Site 2 at
+  `Basic.lean:9534` per the issue's per-site diffs: the `obtain
+  ⟨_, hcontent, hnorm⟩` destructure becomes a named `have hnorm :=
+  zpoly_normalize_factor_sign_of_monic …` and the
+  `simpa [Hex.ZPoly.Primitive] using hcontent` adapter becomes
+  `zpoly_primitive_of_monic …`.
+* Three remaining inline triple-destructure sites
+  (`Basic.lean:10084, 10194, 13596` post-edit) deliberately
+  unchanged — out of scope per the issue.
+
+## Verification
+
+* `git grep -c "zpoly_normalize_factor_sign_of_monic"`: 3 (1
+  definition + 2 use sites). ✓
+* `git grep -c "obtain ⟨_, hcontent, hnorm⟩"`: 0 (both Sites
+  rewired). The issue's predicted baseline of 4 was already 2 at
+  branch-off — the other two sites must have been rewired by an
+  intervening PR.
+* `git grep -c "simpa \[Hex.ZPoly.Primitive\] using hcontent"`: 0.
+* `lake build HexBerlekampZassenhausMathlib.Basic`: 16 errors,
+  byte-identical to baseline (11 whnf timeouts + 1 cases failure +
+  4 kernel unknown constants), with line shifts +0 before helper
+  insert (line 6750), +5 between helper and Site 1, +6 between
+  Site 1 and Site 2, +7 after Site 2.
+* `lake build HexBerlekampZassenhausMathlib`: same 16 errors in
+  `Basic.lean`, no new errors elsewhere.
+* `python3 scripts/check_dag.py`: exit 0.
+* `git diff --check`: clean.
+* No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` in
+  the diff.
+
+## Current frontier
+
+The Monic-route projection helper cluster at
+`Basic.lean:6720-6755` is now complete on all four fields of the
+`monic_primitive_sign_normalized_of_monic` triple:
+
+| field | helper |
+| --- | --- |
+| `.1` (Monic) | n/a — input hypothesis |
+| `.2.1` (Primitive) | `zpoly_primitive_of_monic` (#5013) |
+| `.2.2` (normalize) | `zpoly_normalize_factor_sign_of_monic` (this PR) |
+| derived (size_pos) | `zpoly_size_pos_of_monic` (private, pre-existing) |
+| derived (ne_zero) | `zpoly_ne_zero_of_monic` (#5001) |
+| derived (lc_pos) | `zpoly_lc_pos_of_monic` (#5009) |
+
+The cluster-completion ticket trail is: #5001 → #5009 → #5013 →
+this PR (closing #5021).
+
+## Next step
+
+* Out-of-scope follow-up: rewire the three remaining inline
+  triple-destructure sites at `Basic.lean:10084, 10194, 13596` to
+  use the named helpers. Each has shape-specific consumers that
+  require per-site type inspection.
+* The other unclaimed feature #5023 (harmonise 7
+  `zpoly_ne_zero_of_monic` `IntReductionMod` sites to implicit-`f`
+  form) is independent of this work and can be picked up by a
+  subsequent worker.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5021

Session: `244f4f1e-f47a-4e39-a469-db813fb83a65`

572eb156 refactor: extract zpoly_normalize_factor_sign_of_monic helper and rewire 2 inline destructure sites

🤖 Prepared with Claude Code