### PR TITLE
BZMathlib: harmonise 2 zpoly_ne_zero_of_pos_lc IntReductionMod sites to implicit-f form

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3990,8 +3990,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
   -- `hcore_lc_pos`.
   have hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 := hbranch.2.1
-  have hcore_ne :=
-    zpoly_ne_zero_of_pos_lc (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_lc_pos
+  have hcore_ne := zpoly_ne_zero_of_pos_lc hcore_lc_pos
   have hcore_record : Hex.shouldRecordPolynomialFactor
       (Hex.normalizeForFactor f).squareFreeCore = true := by
     have hne_one : (Hex.normalizeForFactor f).squareFreeCore ≠ 1 := by
@@ -4166,8 +4165,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
         (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) := by
-  have hcore_ne :=
-    zpoly_ne_zero_of_pos_lc (f := (Hex.normalizeForFactor f).squareFreeCore) hcore_lc_pos
+  have hcore_ne := zpoly_ne_zero_of_pos_lc hcore_lc_pos
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
     f hf_ne hbranch hchoose hcore_primitive hcore_lc_pos hcore_monic

--- a/progress/20260518T160233Z_e3f7c032.md
+++ b/progress/20260518T160233Z_e3f7c032.md
@@ -1,0 +1,31 @@
+# Harmonise 2 `zpoly_ne_zero_of_pos_lc` IntReductionMod sites (#5027)
+
+## Accomplished
+
+Dropped the `(f := (Hex.normalizeForFactor f).squareFreeCore)` named
+argument and collapsed the two-line `have hcore_ne := …` block onto
+one line at both `IntReductionMod.lean` sites
+(`3993-3994`, `4169-4170`). Lean unifies `?f` from
+`hcore_lc_pos`'s type without the hint.
+
+`grep -c "zpoly_ne_zero_of_pos_lc (f := "
+HexBerlekampZassenhausMathlib/IntReductionMod.lean`: 2 → 0.
+
+After this lands, all five Monic-route cluster helpers are called in
+implicit-`f` form across both `Basic.lean` and `IntReductionMod.lean`.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhausMathlib.IntReductionMod` runs the
+16-error baseline from `Basic.lean` (11 whnf timeouts + 1 cases
+failure + 4 kernel-unknown constants); no new errors in
+`IntReductionMod.lean`. `git diff --check` clean; `git diff --stat
+origin/main` = 1 file, +2/−4.
+
+## Next step
+
+Open PR closing #5027.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5027

Session: `e3f7c032-b256-477b-be0f-564fa5ad458c`

1e3728bb refactor: harmonise 2 zpoly_ne_zero_of_pos_lc IntReductionMod sites to implicit-f form (#5027)

🤖 Prepared with Claude Code