### PR TITLE
BZMathlib: rewire 3 inline triple-destructure sites at Basic.lean:10083/10193/13595 onto Monic-route cluster helpers

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -10087,8 +10087,10 @@ theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidat
       rw [hg_toPolynomial]
       exact hg_monic_poly
     rwa [HexPolyMathlib.leadingCoeff_toPolynomial] at hlead
-  obtain ⟨_, hg_content, hg_norm_sign⟩ :=
-    monic_primitive_sign_normalized_of_monic hg_monic_hex
+  have hg_content : Hex.ZPoly.content g = 1 :=
+    zpoly_primitive_of_monic hg_monic_hex
+  have hg_norm_sign : Hex.normalizeFactorSign g = g :=
+    zpoly_normalize_factor_sign_of_monic hg_monic_hex
   exact ⟨g, S_g, hg_toPolynomial, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
     hSrep, hSJ, hST, hg_content, hg_norm_sign⟩
 
@@ -10197,8 +10199,10 @@ theorem exists_representingSubset_of_mem_normalizedFactors_recombinationCandidat
       rw [hg_toPolynomial]
       exact hg_monic_poly
     rwa [HexPolyMathlib.leadingCoeff_toPolynomial] at hlead
-  obtain ⟨_, hg_content, hg_norm_sign⟩ :=
-    monic_primitive_sign_normalized_of_monic hg_monic_hex
+  have hg_content : Hex.ZPoly.content g = 1 :=
+    zpoly_primitive_of_monic hg_monic_hex
+  have hg_norm_sign : Hex.normalizeFactorSign g = g :=
+    zpoly_normalize_factor_sign_of_monic hg_monic_hex
   exact ⟨g, S_g, hg_toPolynomial, hg_irr_toPoly, hg_dvd_target, hg_dvd_cand,
     hSrep, hSJ, hST, hg_content, hg_norm_sign⟩
 
@@ -13599,8 +13603,10 @@ private theorem recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetP
         representsIntegerFactorAtLift_monic hcore_ne hcore_monic
           hd_liftedFactor_monic hprecision hf_cov_dvd_target htarget_dvd_core
           hS_cov_rep
-      obtain ⟨_, hf_cov_prim, hf_cov_norm⟩ :=
-        monic_primitive_sign_normalized_of_monic hf_cov_monic
+      have hf_cov_prim : Hex.ZPoly.content f_cov = 1 :=
+        zpoly_primitive_of_monic hf_cov_monic
+      have hf_cov_norm : Hex.normalizeFactorSign f_cov = f_cov :=
+        zpoly_normalize_factor_sign_of_monic hf_cov_monic
       have hrec_eq : recombinationCandidate d S_cov = f_cov :=
         recombinationCandidate_eq_factor_of_recovery_of_monic_core
           hcore_ne hcore_monic hf_cov_dvd_core hf_cov_prim hf_cov_norm

--- a/progress/20260518T160559Z_63ebe2df.md
+++ b/progress/20260518T160559Z_63ebe2df.md
@@ -1,0 +1,72 @@
+# 20260518T160559Z — session 63ebe2df (feature)
+
+## Accomplished
+
+Closed #5024: rewired the three remaining inline triple-destructure
+sites on `monic_primitive_sign_normalized_of_monic` in
+`HexBerlekampZassenhausMathlib/Basic.lean` onto the named cluster
+helpers.
+
+- Site 1 (`Basic.lean:10090-10094`, in
+  `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate`-style
+  monic theorem): `obtain ⟨_, hg_content, hg_norm_sign⟩` →
+  two `have`s typed `Hex.ZPoly.content g = 1` and
+  `Hex.normalizeFactorSign g = g`, via `zpoly_primitive_of_monic`
+  and `zpoly_normalize_factor_sign_of_monic`.
+- Site 2 (`Basic.lean:10202-10206`, primitive-pos-lc variant
+  `exists_representingSubset_of_mem_normalizedFactors_recombinationCandidate_of_primitive_pos_lc_core`):
+  identical idiom; identical rewire.
+- Site 3 (`Basic.lean:13604-13609`, reverse-coverage existence
+  theorem feeding `recombinationCandidate_eq_factor_of_recovery_of_monic_core`):
+  same pattern with names `hf_cov_prim` / `hf_cov_norm`.
+
+Diffstat: `+12 / -6` on `HexBerlekampZassenhausMathlib/Basic.lean`.
+
+Type ascriptions on the `content` `have`s use the unfolded
+`Hex.ZPoly.content _ = 1` form (rather than the helper's `Primitive _`
+return type) per the issue body's design note — the consumers in
+those `exact ⟨...⟩` tuple literals and the call to
+`recombinationCandidate_eq_factor_of_recovery_of_monic_core` occupy
+slots typed `Hex.ZPoly.content _ = 1`, and the def-eq unfold is the
+deliberate documentation of which equality is being passed.
+
+Build (`lake build HexBerlekampZassenhausMathlib.Basic` and
+`lake build HexBerlekampZassenhausMathlib`) reproduces the documented
+16-error baseline (11 whnf timeouts + 1 cases failure + 4 kernel-unknown
+constants) byte-identically — the only deltas are the expected +6
+cumulative line offsets on the four errors and two `sorry` warnings
+located after Site 3. `scripts/check_dag.py` exits 0;
+`git diff --check` is clean; no new `sorry`/`axiom`/`native_decide`/
+`TODO`/`FIXME` introduced.
+
+Verification grep counts:
+
+- `obtain ⟨_, .*, .*⟩ := monic_primitive_sign_normalized_of_monic`
+  in `Basic.lean`: 3 → 0 (target reached; call-site coverage of the
+  Monic-route triple is now 100 % at the Mathlib-bridge layer).
+- `zpoly_primitive_of_monic` refs: +3 (one `have` per site).
+- `zpoly_normalize_factor_sign_of_monic` refs: +3 (one `have` per site).
+- `monic_primitive_sign_normalized_of_monic` refs: 9 → 6 (= 1
+  declaration + 1 forward-reference doc + 2 helper-body references
+  + 2 docstring mentions; all three destructure call sites removed).
+
+## Current frontier
+
+With this issue landed (PR pending), all five inline triple-destructure
+sites of `monic_primitive_sign_normalized_of_monic` in
+`HexBerlekampZassenhausMathlib/Basic.lean` are rewired onto the
+four-helper cluster (`size_pos`, `ne_zero` / `lc_pos`, `primitive`,
+`normalize_factor_sign`). The helper-cluster cleanup track on the
+Monic-route triple at the Mathlib-bridge layer is then complete.
+
+## Next step
+
+A subsequent `/plan` cycle can decide whether to mine the remaining
+`(monic_primitive_sign_normalized_of_monic _).2.*` *inside-helper-body*
+projections (intentionally retained, per the cluster's definitions)
+or move on to a different cluster. No follow-up filed from this
+session.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5024

Session: `63ebe2df-2aba-4b73-833f-02519f76e21f`

e2803994 refactor: rewire 3 remaining inline destructure sites at Basic.lean:10090/10200/13602 onto Monic-route cluster helpers

🤖 Prepared with Claude Code