### PR TITLE
doc: add docstrings to 3 undocumented Monic-route cluster helpers

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6730,6 +6730,7 @@ private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
     exact absurd hlead (by decide)
   · exact hcs_pos
 
+/-- Monic integer polynomials are nonzero. -/
 theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}
     (h : Hex.DensePoly.Monic f) : f ≠ 0 := by
   intro hf
@@ -6737,6 +6738,7 @@ theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}
   rw [hf] at hpos
   exact absurd hpos (by simp)
 
+/-- Monic integer polynomials have positive leading coefficient. -/
 theorem zpoly_lc_pos_of_monic {f : Hex.ZPoly}
     (h : Hex.DensePoly.Monic f) :
     0 < Hex.DensePoly.leadingCoeff f := by
@@ -8124,6 +8126,7 @@ private theorem zpoly_primitive_of_toPolynomial_isPrimitive_basic
   · rw [hneg] at hcontent_nonneg
     omega
 
+/-- A `Hex.ZPoly` with positive leading coefficient is nonzero. -/
 theorem zpoly_ne_zero_of_pos_lc {f : Hex.ZPoly}
     (hpos : 0 < Hex.DensePoly.leadingCoeff f) : f ≠ 0 := by
   intro hf

--- a/progress/20260518T162106Z_472812b3.md
+++ b/progress/20260518T162106Z_472812b3.md
@@ -1,0 +1,69 @@
+# 2026-05-18 16:21 UTC — docstrings on 3 Monic-route cluster helpers (472812b3)
+
+Claimed feature issue #5030 and inserted one-line docstrings on the
+three undocumented helpers in the post-#4991 cascade. Pure
+documentation-only edit: no signature, body, or call-site change.
+
+## Accomplished
+
+* `HexBerlekampZassenhausMathlib/Basic.lean:6732` — added
+  `/-- Monic integer polynomials are nonzero. -/` above
+  `theorem zpoly_ne_zero_of_monic`.
+* `HexBerlekampZassenhausMathlib/Basic.lean:6739` — added
+  `/-- Monic integer polynomials have positive leading coefficient. -/`
+  above `theorem zpoly_lc_pos_of_monic` (post-edit line numbers
+  reflect the previous +1 insertion).
+* `HexBerlekampZassenhausMathlib/Basic.lean:8126` — added
+  `/-- A `Hex.ZPoly` with positive leading coefficient is nonzero. -/`
+  above `theorem zpoly_ne_zero_of_pos_lc`. Framing differs from
+  the two Monic siblings because the input hypothesis is
+  `0 < Hex.DensePoly.leadingCoeff f`, not `Hex.DensePoly.Monic f`.
+
+This brings the Monic-route cluster's docstring coverage to 100%:
+the four cluster heads
+(`zpoly_size_pos_of_monic`, `zpoly_ne_zero_of_monic`,
+`zpoly_lc_pos_of_monic`, `zpoly_primitive_of_monic`,
+`zpoly_normalize_factor_sign_of_monic`) plus the pos_lc sibling
+(`zpoly_ne_zero_of_pos_lc`) all carry a one-line docstring.
+
+## Verification
+
+* `git grep -c "^/-- Monic integer polynomials are nonzero. -/$"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 1 ✓
+* `git grep -c "^/-- Monic integer polynomials have positive leading coefficient. -/$"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 1 ✓
+* `git grep -c "^/-- A .Hex.ZPoly. with positive leading coefficient is nonzero. -/$"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 1 ✓
+* `git grep -c "theorem zpoly_ne_zero_of_monic|theorem zpoly_lc_pos_of_monic|theorem zpoly_ne_zero_of_pos_lc"
+   HexBerlekampZassenhausMathlib/Basic.lean`: 3 (unchanged).
+* `lake build HexBerlekampZassenhausMathlib.Basic`: 16 errors,
+  same type-set as baseline (11 whnf timeouts at 4863, 5144,
+  5470, 5557, 5604, 5988, 6136, 6308, 6289, 15433, 15544 + 1
+  `cases` failure at 5866 + 4 kernel unknown constants at 6623,
+  6687, 15751, 15797), plus 2 pre-existing `sorry` warnings at
+  15223 / 15318. All errors after line 8127 are shifted +3 from
+  pre-edit baseline (15430→15433, 15541→15544, 15748→15751,
+  15794→15797, 15220→15223, 15315→15318).
+* `lake build HexBerlekampZassenhausMathlib`: same 16 errors, no
+  new errors elsewhere.
+* `python3 scripts/check_dag.py`: exit 0.
+* `git diff --check`: clean.
+* `git diff origin/main`: 1 file changed, +3 / −0.
+* No new `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` in
+  the diff.
+
+## Current frontier
+
+The Monic-route cluster documentation tail is closed. The next
+natural step in this corner is the review issue #5031, which
+audits the post-#4991 cascade for call-site coverage, framing,
+and duplicates — this PR's three new docstrings are part of
+that audit's invariant 2 scope.
+
+## Next step
+
+Review issue #5031 is now ready to claim once this PR lands.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5030

Session: `472812b3-7784-4312-9177-b3bcf20df0f7`

430f5319 doc: add docstrings to 3 undocumented Monic-route cluster helpers in Basic.lean (#5030)

🤖 Prepared with Claude Code