### PR TITLE
BZMathlib: extract zpoly_dvd_trans helper and rewire 3 inline divisor-transitivity sites in Basic.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6772,6 +6772,18 @@ private theorem zpoly_monic_mul {a b : Hex.ZPoly}
     show Hex.DensePoly.leadingCoeff b = 1 from hb]
   decide
 
+/-- Transitivity of `Hex.ZPoly`-level divisibility. Discharges the
+`core = g * (q * v)` step explicitly via `Hex.DensePoly.mul_assoc_poly`
+because `Hex.ZPoly` does not synthesise a Mathlib `Semigroup` instance
+at this layer. -/
+private theorem zpoly_dvd_trans
+    {a b c : Hex.ZPoly} (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  obtain ⟨q, hq⟩ := hab
+  obtain ⟨v, hv⟩ := hbc
+  refine ⟨q * v, ?_⟩
+  rw [hv, hq]
+  exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+
 /--
 Bridge `liftedFactorProduct d S` to a `Finset.prod` over `S` after transport to
 `Polynomial ℤ`. The executable foldl form unfolds through `toPolynomial_foldl_mul`
@@ -9790,12 +9802,7 @@ theorem exists_mem_representedSubset_of_degree_cover
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
     intro g hg i
     obtain ⟨_, hg_dvd_target, _, _, _, _, _, _⟩ := h_each g hg
-    have hg_dvd_core : g ∣ core := by
-      obtain ⟨q, hq⟩ := hg_dvd_target
-      obtain ⟨v, hv⟩ := htarget_dvd_core
-      refine ⟨q * v, ?_⟩
-      rw [hv, hq]
-      exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+    have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_target htarget_dvd_core
     exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core i
   intro i hi
   exact exists_mem_representedSubset_of_degree_cover_of_bound
@@ -9968,12 +9975,7 @@ theorem exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
     intro g hg i
     obtain ⟨_, hg_dvd_target, _, _, _, _, _, _⟩ := h_each g hg
-    have hg_dvd_core : g ∣ core := by
-      obtain ⟨q, hq⟩ := hg_dvd_target
-      obtain ⟨v, hv⟩ := htarget_dvd_core
-      refine ⟨q * v, ?_⟩
-      rw [hv, hq]
-      exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+    have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_target htarget_dvd_core
     exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core i
   intro i hi
   exact exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core_of_bound
@@ -11377,12 +11379,7 @@ theorem exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandi
       (g.coeff i).natAbs ≤ Hex.ZPoly.defaultFactorCoeffBound core := by
     intro g hg i
     obtain ⟨_, hg_dvd_target, _, _, _, _, _, _⟩ := h_each g hg
-    have hg_dvd_core : g ∣ core := by
-      obtain ⟨q, hq⟩ := hg_dvd_target
-      obtain ⟨v, hv⟩ := htarget_dvd_core
-      refine ⟨q * v, ?_⟩
-      rw [hv, hq]
-      exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+    have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_target htarget_dvd_core
     exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core i
   intro i hi
   exact exists_mem_representedSubset_of_degree_cover_of_scaledRecombinationCandidate_of_primitive_pos_lc_core_of_bound

--- a/progress/20260518T164404Z_5af0dacd.md
+++ b/progress/20260518T164404Z_5af0dacd.md
@@ -1,0 +1,52 @@
+# Feature session — extract `zpoly_dvd_trans` (issue #5035)
+
+## Accomplished
+
+Executed issue #5035: extracted a new `private theorem zpoly_dvd_trans`
+helper into `HexBerlekampZassenhausMathlib/Basic.lean` and rewired the
+three inline divisor-transitivity sites onto it.
+
+Helper placement: after `zpoly_monic_mul` (around `Basic.lean:6775`),
+as specified. Docstring copies the issue body verbatim (semantic note
+about Mathlib's `dvd_trans` not seeing through `Hex.ZPoly`'s bespoke
+`Dvd` instance derived from the executable `Mul`).
+
+Three rewire sites: each 6-line inner `by` block collapsed to a single
+`have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_target htarget_dvd_core`
+invocation. The outer
+`obtain ⟨_, hg_dvd_target, _, _, _, _, _, _⟩ := h_each g hg`
+destructure is preserved (used independently for the surrounding
+`hvalid` proof).
+
+Diffstat for `Basic.lean`: 15 insertions, 18 deletions (net −3 lines).
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.Basic` — 16 errors
+  (11 whnf timeouts + 1 `cases` + 4 kernel unknown constants),
+  matching pre-edit baseline (verified by `git stash` + rebuild).
+  3 sorry warnings in `Basic.lean` (declarations at 255 / 15226 /
+  15321; issue's "2 pre-existing sorries" was off by one — there's
+  also one at line 255 which is unrelated to this PR).
+* `lake build HexBerlekampZassenhausMathlib` — same 16 errors,
+  no new errors elsewhere in the library.
+* `python3 scripts/check_dag.py` — exit 0.
+* `git diff --check` — clean.
+* No new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` in diff.
+* Grep:
+  - `mul_assoc_poly (S := Int) _ _ _`: 10 → 8 (net −2: removed
+    3 inline sites, added 1 in helper body).
+  - `obtain ⟨q, hq⟩ := h.*_dvd_target`: 3 → 0.
+  - `zpoly_dvd_trans`: 0 → 4 (1 def + 3 uses).
+
+## Current frontier
+
+Implementation complete. Ready for PR.
+
+## Next step
+
+Push branch and create PR closing #5035.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5035

Session: `5af0dacd-5f5d-4455-9e43-62d5176f1e58`

a1a3b203 refactor: extract zpoly_dvd_trans helper and rewire 3 inline divisor-transitivity sites in Basic.lean

🤖 Prepared with Claude Code