### PR TITLE
BZMathlib: hoist zpoly_size_pos_of_monic above monicModularImage_modP_eq_of_monic and rewire inline 9-line by_contra proof at Basic.lean:5338

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -5324,6 +5324,20 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
   rw [hnatDeg_eq, hlift_degree_eq]
   exact hg_pos
 
+/-- Monic integer polynomials have positive stored size. -/
+private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : 0 < f.size := by
+  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
+  rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
+  · exfalso
+    have hback_none : f.coeffs.back? = none := by
+      rw [Array.back?_eq_getElem?]; simp [hcs_zero]
+    have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
+      unfold Hex.DensePoly.leadingCoeff; rw [hback_none]; rfl
+    rw [hlc_zero] at hlead
+    exact absurd hlead (by decide)
+  · exact hcs_pos
+
 /-- For a monic integer polynomial `core` and a prime modulus `p > 1`, the
 monic modular image of `modP p core` is just `modP p core` itself: the leading
 coefficient of the modular image is `1` (since `core`'s is `1` and reduces to
@@ -5335,16 +5349,7 @@ private theorem monicModularImage_modP_eq_of_monic
     (hzero : (Hex.ZPoly.modP p core).isZero = false) :
     Hex.monicModularImage (Hex.ZPoly.modP p core) = Hex.ZPoly.modP p core := by
   -- `core.size > 0` from monicness.
-  have hcore_size_pos : 0 < core.size := by
-    by_contra hneg
-    have hsize_zero : core.size = 0 := Nat.eq_zero_of_not_pos hneg
-    have hlead_zero : Hex.DensePoly.leadingCoeff core = 0 := by
-      cases core with
-      | mk coeffs normalized =>
-          simp [Hex.DensePoly.size] at hsize_zero
-          simp [Hex.DensePoly.leadingCoeff, hsize_zero]
-    have : (0 : Int) = 1 := by rw [← hlead_zero]; exact hcore_monic
-    exact (by decide : (0 : Int) ≠ 1) this
+  have hcore_size_pos : 0 < core.size := zpoly_size_pos_of_monic hcore_monic
   have hcore_lead_one : core.coeff (core.size - 1) = 1 := by
     rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last core hcore_size_pos]
     exact hcore_monic
@@ -6715,20 +6720,6 @@ theorem henselLiftData_liftedFactor_injective_of_factorsModPBerlekampForm
   exact henselLiftData_liftedFactor_injective_of_choosePrimeData
     core B primeData hcore_monic hp_prime hp hB hfactors_monic
     hproduct_mod_p hcoprime hnonempty hfactorsModP_nodup
-
-/-- Monic integer polynomials have positive stored size. -/
-private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
-    (h : Hex.DensePoly.Monic f) : 0 < f.size := by
-  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
-  rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
-  · exfalso
-    have hback_none : f.coeffs.back? = none := by
-      rw [Array.back?_eq_getElem?]; simp [hcs_zero]
-    have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
-      unfold Hex.DensePoly.leadingCoeff; rw [hback_none]; rfl
-    rw [hlc_zero] at hlead
-    exact absurd hlead (by decide)
-  · exact hcs_pos
 
 /-- Monic integer polynomials are nonzero. -/
 theorem zpoly_ne_zero_of_monic {f : Hex.ZPoly}

--- a/progress/2026-05-18T17-03-23Z_18a4c332.md
+++ b/progress/2026-05-18T17-03-23Z_18a4c332.md
@@ -1,0 +1,42 @@
+# 2026-05-18T17:03Z — feature session 18a4c332
+
+## Accomplished
+
+Closed issue #5038 (hoist `zpoly_size_pos_of_monic` + rewire line-5338
+call site). Single deviation against invariant 1 of the post-#4991
+Monic-route cluster (review #5031) is now resolved.
+
+- Hoisted the `zpoly_size_pos_of_monic` definition (docstring + 12-line
+  body) from `HexBerlekampZassenhausMathlib/Basic.lean:6719-6731` to
+  just above `monicModularImage_modP_eq_of_monic` (new line 5327).
+  Visibility unchanged (`private`); no body or signature edits.
+- Rewired the inline 9-line `by_contra`/`cases` proof at the original
+  line 5338 to `have hcore_size_pos : 0 < core.size :=
+  zpoly_size_pos_of_monic hcore_monic`.
+- Build diagnostics for `HexBerlekampZassenhausMathlib.Basic` match the
+  documented 16-error baseline byte-identically modulo line shifts
+  (11 whnf timeouts + 1 cases failure + 4 kernel unknown constants).
+- Call-site count for `zpoly_size_pos_of_monic` is now 11 (issue
+  predicted 10; it undercounted the internal use at the original
+  `zpoly_ne_zero_of_monic` body by one). `by_contra hneg` is now 2 in
+  Basic.lean, one fewer than the baseline.
+- `python3 scripts/check_dag.py` exit 0. `git diff --check` clean. No
+  new sorry/axiom/native_decide/TODO/FIXME in the additions.
+
+## Current frontier
+
+Cluster track is now exhaustive against review #5031's invariant 1
+under #5031's eight patterns. The companion review issue #5039 will
+audit forward-reference and alternative-idiom coverage with wider grep
+patterns (`Nat.pos_of_ne_zero`, `Nat.eq_zero_or_pos`, `... .1` of
+`monic_primitive_sign_normalized_of_monic`, `leadingCoeff ... = (1 :
+Int)`).
+
+## Next step
+
+`/work` next planner pulls #5039 or any newly drafted feature issues
+from that audit.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5038

Session: `18a4c332-eecf-40b0-b0ed-87d086d5caaa`

22909311 refactor: hoist zpoly_size_pos_of_monic above monicModularImage_modP_eq_of_monic and rewire inline by_contra proof

🤖 Prepared with Claude Code