### PR TITLE
BZMathlib: rewire 6 remaining inline divisor-transitivity sites in Basic.lean onto zpoly_dvd_trans (#5036 follow-up)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7994,12 +7994,8 @@ theorem representsIntegerFactorAtLift_monic_of_bound
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * B' < d.p ^ d.k) :
     Hex.DensePoly.Monic factor := by
-  have hfactor_dvd_core : factor ∣ core := by
-    obtain ⟨u, hu⟩ := hfactor_dvd_target
-    obtain ⟨v, hv⟩ := htarget_dvd_core
-    refine ⟨u * v, ?_⟩
-    rw [hv, hu]
-    exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+  have hfactor_dvd_core : factor ∣ core :=
+    zpoly_dvd_trans hfactor_dvd_target htarget_dvd_core
   have hprod_monic : Hex.DensePoly.Monic (liftedFactorProduct d S) :=
     liftedFactorProduct_monic d S (fun i _ => hd_liftedFactor_monic i)
   have hlead : Hex.DensePoly.leadingCoeff core = (1 : Int) := hcore_monic
@@ -8071,12 +8067,8 @@ theorem representsIntegerFactorAtLift_monic
     (htarget_dvd_core : target ∣ core)
     (hrep : RepresentsIntegerFactorAtLift core d factor S) :
     Hex.DensePoly.Monic factor := by
-  have hfactor_dvd_core : factor ∣ core := by
-    obtain ⟨u, hu⟩ := hfactor_dvd_target
-    obtain ⟨v, hv⟩ := htarget_dvd_core
-    refine ⟨u * v, ?_⟩
-    rw [hv, hu]
-    exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+  have hfactor_dvd_core : factor ∣ core :=
+    zpoly_dvd_trans hfactor_dvd_target htarget_dvd_core
   exact representsIntegerFactorAtLift_monic_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
     (defaultFactorCoeffBound_valid core hcore_ne factor hfactor_dvd_core)
@@ -8287,12 +8279,8 @@ theorem representsIntegerFactorAtLift_primitive_of_bound
     (hrep : RepresentsIntegerFactorAtLift core d factor S)
     (hprecision : 2 * B' < d.p ^ d.k) :
     Hex.ZPoly.Primitive factor ∧ 0 < Hex.DensePoly.leadingCoeff factor := by
-  have hfactor_dvd_core : factor ∣ core := by
-    obtain ⟨u, hu⟩ := hfactor_dvd_target
-    obtain ⟨v, hv⟩ := htarget_dvd_core
-    refine ⟨u * v, ?_⟩
-    rw [hv, hu]
-    exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+  have hfactor_dvd_core : factor ∣ core :=
+    zpoly_dvd_trans hfactor_dvd_target htarget_dvd_core
   have hfactor_poly_primitive :
       (HexPolyZMathlib.toPolynomial factor).IsPrimitive := by
     have hcore_poly_primitive :
@@ -8370,12 +8358,8 @@ theorem representsIntegerFactorAtLift_primitive
     (htarget_dvd_core : target ∣ core)
     (hrep : RepresentsIntegerFactorAtLift core d factor S) :
     Hex.ZPoly.Primitive factor ∧ 0 < Hex.DensePoly.leadingCoeff factor := by
-  have hfactor_dvd_core : factor ∣ core := by
-    obtain ⟨u, hu⟩ := hfactor_dvd_target
-    obtain ⟨v, hv⟩ := htarget_dvd_core
-    refine ⟨u * v, ?_⟩
-    rw [hv, hu]
-    exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+  have hfactor_dvd_core : factor ∣ core :=
+    zpoly_dvd_trans hfactor_dvd_target htarget_dvd_core
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact representsIntegerFactorAtLift_primitive_of_bound
     (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -12362,11 +12346,8 @@ theorem representedFactor_dvd_recombinationCandidate_of_subset
   rcases hfactor_prime.dvd_or_dvd hpoly_factor_dvd_target with hp_dvd_q | hp_dvd_c
   · -- Case B: `toPolynomial factor ∣ toPolynomial quotient` — derive contradiction.
     exfalso
-    have hfactor_dvd_core : factor ∣ core := by
-      obtain ⟨u, hu⟩ := hfactor_dvd_target
-      obtain ⟨v, hv⟩ := htarget_dvd_core
-      refine ⟨u * v, ?_⟩
-      rw [hv, hu, Hex.DensePoly.mul_assoc_poly (S := Int)]
+    have hfactor_dvd_core : factor ∣ core :=
+      zpoly_dvd_trans hfactor_dvd_target htarget_dvd_core
     -- Derive `2 ≤ d.p^d.k` from `factor ≠ 0` and the centered-lift recovery,
     -- matching the pattern used in `representsIntegerFactorAtLift_monic`.
     have hd_modulus : 2 ≤ d.p ^ d.k := by
@@ -12411,11 +12392,8 @@ theorem representedFactor_dvd_recombinationCandidate_of_subset
           hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
           hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core
           hTJ hrecord hquot hiT
-      have hg_dvd_target : g ∣ target := by
-        obtain ⟨r₁, hr₁⟩ := hg_dvd_cand
-        obtain ⟨r₂, hr₂⟩ := hcand_dvd_target
-        refine ⟨r₁ * r₂, ?_⟩
-        rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+      have hg_dvd_target : g ∣ target :=
+        zpoly_dvd_trans hg_dvd_cand hcand_dvd_target
       -- `i ∈ S ∩ S_g`, so `S` and `S_g` are not disjoint.
       have hnot_disjoint : ¬ Disjoint S S_g := by
         intro hdisj

--- a/progress/2026-05-18T17-27-16Z_3127df32.md
+++ b/progress/2026-05-18T17-27-16Z_3127df32.md
@@ -1,0 +1,68 @@
+# 2026-05-18T17:27Z — feature session, agent/3127df32
+
+## Accomplished
+
+Closes #5044. Rewired the six remaining inline divisor-transitivity
+sites in `HexBerlekampZassenhausMathlib/Basic.lean` onto the
+`zpoly_dvd_trans` private helper extracted by PR #5036:
+
+| # | Pre-edit lines | Enclosing theorem | Shape |
+|---|---|---|---|
+| 1 | 8006–8011 | `representsIntegerFactorAtLift_monic_of_bound` | 6-line |
+| 2 | 8083–8088 | `representsIntegerFactorAtLift_monic` | 6-line |
+| 3 | 8299–8304 | `representsIntegerFactorAtLift_primitive_of_bound` | 6-line |
+| 4 | 8382–8387 | `representsIntegerFactorAtLift_primitive` | 6-line |
+| 5 | 12374–12378 | `representedFactor_dvd_recombinationCandidate_of_subset` Case B | 5-line |
+| 6 | 12423–12427 | same theorem, Subcase B1 (`g ∣ target` from `hg_dvd_cand`/`hcand_dvd_target`) | 5-line |
+
+Each site collapses to a two-line `have := zpoly_dvd_trans _ _`.
+Diffstat: `Basic.lean` only, `+12 / -34` (matches issue prediction).
+
+Branch was based on `108899e3`; rebased onto `a0658896` (which
+includes #5042 hoisting `zpoly_size_pos_of_monic`) with no conflicts
+in the touched line ranges.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: reproduces the
+  documented baseline — 16 errors (11 whnf timeouts + 1 `cases`
+  failure + 4 kernel unknown constants) and 3 pre-existing `sorry`
+  warnings in `Basic.lean`. (Issue body listed 2 sorries, but
+  baseline pre-rebase actually had 3 at lines 255 / 15226 / 15321.
+  Post-rebase line offsets shifted; same three declarations are
+  still flagged.)
+- `lake build HexBerlekampZassenhausMathlib`: no new errors outside
+  `Basic.lean`; identical 16-error file count.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- Grep counts (final):
+  - `obtain ⟨u, hu⟩ := hfactor_dvd_target` in `Basic.lean`: 0
+    (was 5: sites 1–5).
+  - `obtain ⟨r₁, hr₁⟩ := hg_dvd_cand` in `Basic.lean`: 0
+    (was 1: site 6).
+  - `zpoly_dvd_trans` refs in `Basic.lean`: 10
+    (= 1 def + 3 pre-existing sites + 6 new sites).
+- Line-offset check on errors after the change region: post-12427
+  errors and sorries shifted by exactly `-4*4 + -3*2 = -22` lines
+  relative to the pre-edit (post-rebase) baseline, matching the
+  formula in the issue's verification section.
+
+## Current frontier
+
+The `zpoly_dvd_trans` invariant-1 (call-site coverage) sweep is
+complete in `Basic.lean`. The `IntReductionMod.lean` side was
+already checked clean by the planner.
+
+## Next step
+
+Open: invariants 2 (framing/docstring consistency) and 3 (cross-file
+consistency) for `zpoly_dvd_trans` have not been audited as a
+separate exercise. The helper has a docstring noting the
+`Hex.DensePoly.mul_assoc_poly` reason and a single definition, so
+both probably pass trivially — but the post-#4991 cleanup pattern
+sometimes uses a dedicated audit issue (cf. #5031, #5041 for the
+primitivity micro-cluster).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5044

Session: `3127df32-4919-4bcf-9822-d884d92b19ff`

694ad47b refactor: rewire 6 remaining inline divisor-transitivity sites in Basic.lean onto zpoly_dvd_trans

🤖 Prepared with Claude Code