### PR TITLE
BZMathlib: hoist zpoly_size_pos_of_monic above monic_primitive_sign_normalized_of_monic and rewire 13-line hcs_pos inline proof at Basic.lean:4479

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4454,6 +4454,20 @@ theorem scaledRecombinationCandidate_eq_factor_of_henselSubsetCorrespondence
     (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
     hcore_ne hfactor_prim hfactor_norm hrep hprecision
 
+/-- Monic integer polynomials have positive stored size. -/
+private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : 0 < f.size := by
+  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
+  rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
+  · exfalso
+    have hback_none : f.coeffs.back? = none := by
+      rw [Array.back?_eq_getElem?]; simp [hcs_zero]
+    have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
+      unfold Hex.DensePoly.leadingCoeff; rw [hback_none]; rfl
+    rw [hlc_zero] at hlead
+    exact absurd hlead (by decide)
+  · exact hcs_pos
+
 /--
 A monic integer polynomial automatically has primitive content and is its own
 sign-normalisation. This packages the two normalisation hypotheses required
@@ -4476,19 +4490,8 @@ theorem monic_primitive_sign_normalized_of_monic
       Hex.ZPoly.content factor = 1 ∧
         Hex.normalizeFactorSign factor = factor := by
   have hlead : Hex.DensePoly.leadingCoeff factor = (1 : Int) := hfactor_monic
-  have hcs_pos : 0 < factor.coeffs.size := by
-    rcases Nat.eq_zero_or_pos factor.coeffs.size with hcs_zero | hcs_pos
-    · exfalso
-      have hback_none : factor.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        simp [hcs_zero]
-      have hlc_zero : Hex.DensePoly.leadingCoeff factor = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hlead
-      exact absurd hlead (by decide)
-    · exact hcs_pos
+  have hcs_pos : 0 < factor.coeffs.size :=
+    zpoly_size_pos_of_monic hfactor_monic
   have hsize_pos : 0 < factor.size := hcs_pos
   have hcoeff_last : factor.coeff (factor.size - 1) = (1 : Int) := by
     rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last factor hsize_pos]
@@ -5323,20 +5326,6 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
     HexPolyMathlib.natDegree_toPolynomial _
   rw [hnatDeg_eq, hlift_degree_eq]
   exact hg_pos
-
-/-- Monic integer polynomials have positive stored size. -/
-private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
-    (h : Hex.DensePoly.Monic f) : 0 < f.size := by
-  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
-  rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
-  · exfalso
-    have hback_none : f.coeffs.back? = none := by
-      rw [Array.back?_eq_getElem?]; simp [hcs_zero]
-    have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
-      unfold Hex.DensePoly.leadingCoeff; rw [hback_none]; rfl
-    rw [hlc_zero] at hlead
-    exact absurd hlead (by decide)
-  · exact hcs_pos
 
 /-- For a monic integer polynomial `core` and a prime modulus `p > 1`, the
 monic modular image of `modP p core` is just `modP p core` itself: the leading

--- a/progress/20260518T174735Z_529defc7.md
+++ b/progress/20260518T174735Z_529defc7.md
@@ -1,0 +1,39 @@
+# Session 529defc7 — feature #5046
+
+## Accomplished
+
+Hoisted `zpoly_size_pos_of_monic` from its post-#5042 location at
+`HexBerlekampZassenhausMathlib/Basic.lean:5327` to immediately above the
+`monic_primitive_sign_normalized_of_monic` theorem (now at
+`Basic.lean:4458`, theorem at `Basic.lean:4487`). Rewired the inline
+13-line `hcs_pos` rcases block at the old `Basic.lean:4479-4491` site to
+the one-liner `zpoly_size_pos_of_monic hfactor_monic`. Visibility,
+signature, and proof body of the helper are unchanged.
+
+## Current frontier
+
+Build matches the documented 16-error / 3-sorry baseline byte-identically
+modulo the +13 line shift between the new helper site and the old (lines
+4866 → 4866 etc.; all 16 errors in Basic.lean preserved). `check_dag.py`
+exit 0; `git diff --check` clean; no new sorry/axiom/native_decide.
+
+Verification grep deltas (as predicted in the issue body):
+- `:= zpoly_size_pos_of_monic`: 10 → 11 (new rewire site)
+- `rcases Nat.eq_zero_or_pos factor.coeffs.size`: 1 → 0 (inline block gone;
+  helper body uses `f.coeffs.size`, not `factor.coeffs.size`)
+
+`git diff --stat origin/main`: 1 file changed, +16 / −27 (net −11; one
+block moved, one block collapsed 13→2).
+
+## Next step
+
+PR is the deliverable. The follow-on hoists discussed in #5040's audit
+(content-1 inline block at the post-rewire equivalent of 4497-4509,
+`normalizeFactorSign` block at 4510-4515) remain deferred — they require
+inverting the cluster's proof direction (verdict (c)). The `_lc_pos`
+sibling helper is hoistable in principle but has no rewire site in this
+theorem's body.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5046

Session: `529defc7-3832-474b-b596-f72b2c148b91`

d5e7c467 refactor: hoist zpoly_size_pos_of_monic above monic_primitive_sign_normalized_of_monic and rewire 13-line hcs_pos inline proof

🤖 Prepared with Claude Code