### PR TITLE
BZMathlib: reframe normalizeForFactor_squareFreeCore_primitive_of_ne_zero docstring and drop (#4611) PR-metadata leak from helper-3 docstring in IntReductionMod.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -682,7 +682,7 @@ The repeated part extracted by `normalizeForFactor` is primitive over
 This is the companion Gauss-descent input to
 `normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive` for the
 structural divisibility theorem consumed by the exponent-extraction
-successor (#4611).
+successor.
 -/
 theorem normalizeForFactor_repeatedPart_toPolynomial_isPrimitive
     (f : Hex.ZPoly) (hf : f ≠ 0) :
@@ -1042,9 +1042,12 @@ theorem zpoly_primitive_of_toPolynomial_isPrimitive
   · rw [hneg] at hcontent_nonneg; omega
 
 /--
-Composition of `normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive`
-and `zpoly_primitive_of_toPolynomial_isPrimitive`: from `f ≠ 0` derive
-`Hex.ZPoly.Primitive (Hex.normalizeForFactor f).squareFreeCore` in one step.
+The square-free core extracted by `normalizeForFactor` is executably
+primitive whenever the input integer polynomial is nonzero.
+
+The proof transports
+`normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive` back to
+`Hex.ZPoly` via `zpoly_primitive_of_toPolynomial_isPrimitive`.
 -/
 theorem normalizeForFactor_squareFreeCore_primitive_of_ne_zero
     (f : Hex.ZPoly) (hf : f ≠ 0) :

--- a/progress/20260518T175035Z_c7dd4bb2.md
+++ b/progress/20260518T175035Z_c7dd4bb2.md
@@ -1,0 +1,60 @@
+# Feature session — reframe helper #4 docstring and drop (#4611) leak (issue #5047)
+
+## Accomplished
+
+Executed issue #5047 doc-only cleanup against
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+
+* Dropped the `(#4611)` parenthetical from helper #3's docstring
+  (`normalizeForFactor_repeatedPart_toPolynomial_isPrimitive`) —
+  `exponent-extraction successor (#4611)` → `exponent-extraction
+  successor`. PR-number leak removed; the reference to the
+  downstream consumer survives without it.
+* Reframed helper #4's docstring
+  (`normalizeForFactor_squareFreeCore_primitive_of_ne_zero`) so the
+  leading sentence states the contract — "The square-free core
+  extracted by `normalizeForFactor` is executably primitive
+  whenever the input integer polynomial is nonzero." — with the
+  composition recipe moved to a second paragraph ("The proof
+  transports … back to `Hex.ZPoly` via
+  `zpoly_primitive_of_toPolynomial_isPrimitive`."). Matches the
+  contract-first opening used by helpers #1 / #2 / #3.
+
+No proof or signature change to any of the four cluster helpers;
+no edits outside the two docstring blocks.
+
+## Verification
+
+* `lake build HexBerlekampZassenhausMathlib.IntReductionMod`:
+  16-error baseline in `Basic.lean` unchanged; no new errors in
+  `IntReductionMod.lean`. Two pre-existing `sorry` warnings at
+  `Basic.lean:15217`/`15312` carry over (the issue cited 15226 /
+  15321; the lines have shifted slightly from intervening merges).
+* `lake build HexBerlekampZassenhausMathlib`: same 16 errors, all
+  confined to `Basic.lean` — no new errors elsewhere in the
+  module.
+* `python3 scripts/check_dag.py`: exit 0.
+* `git diff --check`: clean.
+* `git grep -c "(#4611)" HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+  1 → 0.
+* `git grep -nE "Combines|Composition of" HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+  0 matches (helper #4 was the only cluster sibling with a
+  "Composition of"-style opening).
+* `git diff --stat origin/main`: 1 file changed, 6 insertions(+),
+  3 deletions(−) — all in two docstring blocks, no proof or
+  signature lines.
+
+## Current frontier
+
+Doc-only diff landed locally; ready to push and open PR closing
+#5047. No further follow-up issues drafted — the Monic-route
+docstring framing work is tracked separately under #5030 /
+#5031 / #5039 / #5040 and is out of scope here.
+
+## Next step
+
+`coordination create-pr 5047`, then exit.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5047

Session: `c7dd4bb2-6ebd-4bdb-81fc-e556276292f3`

ee534c91 doc: reframe normalizeForFactor_squareFreeCore_primitive_of_ne_zero docstring and drop (#4611) PR-metadata leak from helper-3 docstring in IntReductionMod.lean (#5047)

🤖 Prepared with Claude Code