### PR TITLE
BZMathlib: extract zpoly_size_pos_of_pos_lc helper and rewire 2 inline pos_lc-source size_pos sites at Basic.lean:8214/8425

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8119,6 +8119,19 @@ theorem zpoly_ne_zero_of_pos_lc {f : Hex.ZPoly}
   rw [hzero_lc] at hpos
   omega
 
+/-- A `Hex.ZPoly` with positive leading coefficient has positive stored size. -/
+private theorem zpoly_size_pos_of_pos_lc {f : Hex.ZPoly}
+    (hpos : 0 < Hex.DensePoly.leadingCoeff f) : 0 < f.size := by
+  rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
+  · exfalso
+    have hback_none : f.coeffs.back? = none := by
+      rw [Array.back?_eq_getElem?]; simp [hcs_zero]
+    have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
+      unfold Hex.DensePoly.leadingCoeff; rw [hback_none]; rfl
+    rw [hlc_zero] at hpos
+    omega
+  · exact hcs_pos
+
 private theorem zpoly_eq_one_of_toPolynomial_isUnit_of_pos_lc
     {f : Hex.ZPoly}
     (hpos : 0 < Hex.DensePoly.leadingCoeff f)
@@ -8192,21 +8205,7 @@ private theorem leadingCoeff_centeredLiftPoly_of_pos_leadingCoeff_bound
     (hsep : 2 * B < m) :
     Hex.DensePoly.leadingCoeff (Hex.centeredLiftPoly g m) =
       Hex.DensePoly.leadingCoeff g := by
-  have hg_size_pos : 0 < g.size := by
-    rcases Nat.eq_zero_or_pos g.size with hzero | hpos
-    · exfalso
-      have hback_none : g.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : g.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff g = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hg_lc_pos
-      omega
-    · exact hpos
+  have hg_size_pos : 0 < g.size := zpoly_size_pos_of_pos_lc hg_lc_pos
   have hg_lead :
       g.coeff (g.size - 1) = Hex.DensePoly.leadingCoeff g := by
     rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last g hg_size_pos]
@@ -8395,21 +8394,7 @@ private theorem size_centeredLiftPoly_eq_of_pos_leadingCoeff_bound
     (hbound_lc : (Hex.DensePoly.leadingCoeff g).natAbs ≤ B)
     (hsep : 2 * B < m) :
     (Hex.centeredLiftPoly g m).size = g.size := by
-  have hg_size_pos : 0 < g.size := by
-    rcases Nat.eq_zero_or_pos g.size with hzero | hpos
-    · exfalso
-      have hback_none : g.coeffs.back? = none := by
-        rw [Array.back?_eq_getElem?]
-        have hcoeffs_size : g.coeffs.size = 0 := by
-          simpa [Hex.DensePoly.size] using hzero
-        simp [hcoeffs_size]
-      have hlc_zero : Hex.DensePoly.leadingCoeff g = (0 : Int) := by
-        unfold Hex.DensePoly.leadingCoeff
-        rw [hback_none]
-        rfl
-      rw [hlc_zero] at hg_lc_pos
-      omega
-    · exact hpos
+  have hg_size_pos : 0 < g.size := zpoly_size_pos_of_pos_lc hg_lc_pos
   have hg_lead :
       g.coeff (g.size - 1) = Hex.DensePoly.leadingCoeff g := by
     rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last g hg_size_pos]

--- a/progress/20260518T180945Z_6b95c8f4.md
+++ b/progress/20260518T180945Z_6b95c8f4.md
@@ -1,0 +1,50 @@
+# 20260518T180945Z — issue #5052 (feature, pos_lc size_pos helper)
+
+## Accomplished
+
+- Extracted `private theorem zpoly_size_pos_of_pos_lc` into
+  `HexBerlekampZassenhausMathlib/Basic.lean`, placed immediately after
+  `zpoly_ne_zero_of_pos_lc` (now at `Basic.lean:8123`). Body mirrors
+  post-#5042/#5049 `zpoly_size_pos_of_monic`: `Nat.eq_zero_or_pos
+  f.coeffs.size` split, `Array.back?_eq_getElem?` to land at `none`,
+  `Hex.DensePoly.leadingCoeff f = 0` via `back? = none` defeq, then
+  `omega` against `0 < leadingCoeff` (matching `_of_pos_lc` framing
+  rather than `_of_monic`'s `decide`).
+- Rewired site #1 (`leadingCoeff_centeredLiftPoly_of_pos_leadingCoeff_bound`,
+  `Basic.lean:8208`) and site #2
+  (`size_centeredLiftPoly_eq_of_pos_leadingCoeff_bound`,
+  `Basic.lean:8397`) onto one-liner calls.
+- Rebased onto `origin/main` after pulling in #5045, #5049, #5051.
+  Helper neighbourhood (the `_of_pos_lc` family head + immediate
+  followers) is unchanged by those PRs, so the rebase was textually
+  clean.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` — same 16-error
+  baseline as `origin/main` (11 whnf timeouts + 1 `cases` failure +
+  4 kernel unknown constants), same 31 `uses sorry` warnings.
+- `lake build HexBerlekampZassenhausMathlib` — same 16-error baseline.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git grep -n zpoly_size_pos_of_pos_lc HexBerlekampZassenhausMathlib/Basic.lean`
+  — 3 hits (1 definition + 2 call sites).
+- `git grep -nE 'rw \[Array.back\?_eq_getElem\?\]' HexBerlekampZassenhausMathlib/Basic.lean`
+  — 3 hits remain: the pre-existing `Basic.lean:4483` site,
+  `zpoly_size_pos_of_monic` (line 5311 post-rebase), and the new
+  `zpoly_size_pos_of_pos_lc` (line 8132). Both 8218 / 8429 inline
+  copies are gone.
+- No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME` in diff.
+- Diffstat: +15 / −30 lines in `Basic.lean`.
+
+## Current frontier
+
+PR for #5052 ready to publish.
+
+## Next step
+
+Push the branch, create the PR via `coordination create-pr 5052`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5052

Session: `6b95c8f4-241b-4261-a898-e1dad9647ca4`

b6c8a6d3 refactor: extract zpoly_size_pos_of_pos_lc helper and rewire 2 inline pos_lc-source size_pos sites in Basic.lean

🤖 Prepared with Claude Code