### PR TITLE
BZMathlib: rewire 6 inline isZero/size plumbing sites onto Hex.DensePoly.isZero_eq_false_iff (forward direction)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4902,15 +4902,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
   -- `monicModularImage modP_f ∣ modP_f`: dividing by the leading coefficient
   -- scales by a nonzero element, and a unit-scaled polynomial divides the
   -- original via `dvd_scale_self_of_ne_zero`.
-  have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP data.p f).size with hsize_zero | hsize_pos
-    · exfalso
-      have hiszero : (Hex.ZPoly.modP data.p f).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsize_zero
-      rw [hiszero] at hzero
-      contradiction
-    · exact hsize_pos
+  have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f) ≠
         (0 : Hex.ZMod64 data.p) := by
@@ -5867,15 +5860,8 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   -- `monicModularImage` divides `modP p core`, so the no-squared invariant
   -- transports through the unit scaling.
-  have hmod_size_pos : 0 < (Hex.ZPoly.modP primeData.p core).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP primeData.p core).size with hsz | hsz
-    · exfalso
-      have hiszero : (Hex.ZPoly.modP primeData.p core).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hiszero] at hzero
-      contradiction
-    · exact hsz
+  have hmod_size_pos : 0 < (Hex.ZPoly.modP primeData.p core).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hmodP_lead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠
         (0 : Hex.ZMod64 primeData.p) := by
@@ -6061,9 +6047,7 @@ private theorem gcd_monicModularImage_derivative_eq_one_local
           · exact Or.inl h
           · exact Or.inr h
       have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := by
-          simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-            Array.isEmpty_iff_size_eq_zero, Nat.pos_iff_ne_zero] using hzero
+        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
         rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
         exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
       intro hu_zero
@@ -6218,15 +6202,8 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
     hraw_irr g' hg'_mem
   have hg'_ne : g' ≠ 0 := hraw_ne g' hg'_mem
   have hg'_isZero : g'.isZero = false := Hex.isZero_false_of_ne_zero hg'_ne
-  have hg'_size_pos : 0 < g'.size := by
-    rcases Nat.eq_zero_or_pos g'.size with hsz | hsz
-    · exfalso
-      have hiszero : g'.isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hiszero] at hg'_isZero
-      exact Bool.noConfusion hg'_isZero
-    · exact hsz
+  have hg'_size_pos : 0 < g'.size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hg'_isZero
   have hg'_lead_ne :
       Hex.DensePoly.leadingCoeff g' ≠ (0 : Hex.ZMod64 primeData.p) := by
     rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred g' hg'_size_pos]

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -334,9 +334,7 @@ private theorem gcd_monicModularImage_derivative_eq_one
           · exact Or.inl h
           · exact Or.inr h
       have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := by
-          simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-            Array.isEmpty_iff_size_eq_zero, Nat.pos_iff_ne_zero] using hzero
+        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
         rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
         exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
       intro hu_zero
@@ -483,15 +481,8 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
   -- Push through the Mathlib bridge using toMathlibPolynomial_scale.
   rw [hmonicImg_eq, toMathlibPolynomial_scale] at hirr_monic
   -- The scaling constant is a unit (nonzero in the field).
-  have hfsize : 0 < (Hex.ZPoly.modP primeData.p core).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP primeData.p core).size with hsz | hsz
-    · exfalso
-      have hzero' : (Hex.ZPoly.modP primeData.p core).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hzero'] at hzero
-      exact Bool.noConfusion hzero
-    · exact hsz
+  have hfsize : 0 < (Hex.ZPoly.modP primeData.p core).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠ 0 := by
     rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred _ hfsize]

--- a/progress/20260518T182041Z_cb3a02a5.md
+++ b/progress/20260518T182041Z_cb3a02a5.md
@@ -1,0 +1,52 @@
+# 2026-05-18T18:20:41Z — feature session #5055
+
+## Accomplished
+
+Rewired all 6 inline `simpa [Hex.DensePoly.isZero, ...]` plumbing
+sites in `HexBerlekampZassenhausMathlib/` onto the existing
+`Hex.DensePoly.isZero_eq_false_iff` (forward direction):
+
+| # | File | Original lines | `have`-name | Hypothesis |
+| - | ---- | --------------:| ----------- | ---------- |
+| 1 | `Basic.lean` | 4905–4913 (Variant A) | `hmod_size_pos` | `hzero` from `obtain` at 4895 |
+| 2 | `Basic.lean` | 5870–5878 (Variant A) | `hmod_size_pos` | `hzero` from `obtain` at 5860 |
+| 3 | `Basic.lean` | 6221–6229 (Variant A) | `hg'_size_pos` | `hg'_isZero` |
+| 4 | `Basic.lean` | 6064–6066 (Variant B) | `hpos` | `hzero` |
+| 5 | `IntReductionMod.lean` | 486–494 (Variant A) | `hfsize` | `hzero` |
+| 6 | `IntReductionMod.lean` | 337–339 (Variant B) | `hpos` | `hzero` |
+
+Each site collapses to a one-liner of shape
+`have <name> : 0 < <poly>.size := (Hex.DensePoly.isZero_eq_false_iff _).mp <hyp>`.
+Preserved every `have`-name on the LHS so downstream uses
+(`hmod_size_pos`, `hg'_size_pos`, `hfsize`, `hpos`) continue to
+typecheck.
+
+## Current frontier
+
+Build verification: full `lake build HexBerlekampZassenhausMathlib`
+produces exactly the 16-error baseline confined to `Basic.lean`
+(11 whnf timeouts + 1 dependent-elimination `cases` at 5853 + 4
+kernel unknown constants), all unchanged in shape from the
+pre-rewire baseline. No new errors in `IntReductionMod.lean`.
+
+Greppable invariants after rewire (all match issue Verification §7):
+- `simpa [Hex.DensePoly.isZero,` in `HexBerlekampZassenhausMathlib/`: 7 → 1
+  (only the reverse-direction `Basic.lean:7442` `isZero = true → size = 0`
+  site survives; that site is the in-scope target of #5056's sibling).
+- `isZero_eq_false_iff` in `HexBerlekampZassenhausMathlib/`: 1 → 7
+  (6 new rewires + the existing `IntReductionMod.lean:1447` invocation).
+- `rcases Nat.eq_zero_or_pos … with h… | h…` in
+  `HexBerlekampZassenhausMathlib/`: 4 → 0.
+
+`git diff --check` clean. `python3 scripts/check_dag.py` exits 0.
+No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME`.
+`git diff --stat`: 2 files, +12 / −41, net −29 lines (vs.
+projected −32).
+
+## Next step
+
+Push branch and open PR closing #5055.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5055

Session: `cb3a02a5-b086-40e2-94cd-2c20eb2537d0`

53dd542c refactor: rewire 6 inline isZero/size plumbing sites onto Hex.DensePoly.isZero_eq_false_iff

🤖 Prepared with Claude Code