### PR TITLE
BZMathlib: rewire 6 inline isZero/size plumbing sites onto Hex.DensePoly.isZero_eq_false_iff (forward direction)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4902,15 +4902,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
   -- `monicModularImage modP_f ∣ modP_f`: dividing by the leading coefficient
   -- scales by a nonzero element, and a unit-scaled polynomial divides the
   -- original via `dvd_scale_self_of_ne_zero`.
-  have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP data.p f).size with hsize_zero | hsize_pos
-    · exfalso
-      have hiszero : (Hex.ZPoly.modP data.p f).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsize_zero
-      rw [hiszero] at hzero
-      contradiction
-    · exact hsize_pos
+  have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f) ≠
         (0 : Hex.ZMod64 data.p) := by
@@ -5867,15 +5860,8 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
     Hex.isGoodPrime_squareFreeModP core primeData.p hgood
   -- `monicModularImage` divides `modP p core`, so the no-squared invariant
   -- transports through the unit scaling.
-  have hmod_size_pos : 0 < (Hex.ZPoly.modP primeData.p core).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP primeData.p core).size with hsz | hsz
-    · exfalso
-      have hiszero : (Hex.ZPoly.modP primeData.p core).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hiszero] at hzero
-      contradiction
-    · exact hsz
+  have hmod_size_pos : 0 < (Hex.ZPoly.modP primeData.p core).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hmodP_lead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠
         (0 : Hex.ZMod64 primeData.p) := by
@@ -6061,9 +6047,7 @@ private theorem gcd_monicModularImage_derivative_eq_one_local
           · exact Or.inl h
           · exact Or.inr h
       have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := by
-          simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-            Array.isEmpty_iff_size_eq_zero, Nat.pos_iff_ne_zero] using hzero
+        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
         rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
         exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
       intro hu_zero
@@ -6218,15 +6202,8 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
     hraw_irr g' hg'_mem
   have hg'_ne : g' ≠ 0 := hraw_ne g' hg'_mem
   have hg'_isZero : g'.isZero = false := Hex.isZero_false_of_ne_zero hg'_ne
-  have hg'_size_pos : 0 < g'.size := by
-    rcases Nat.eq_zero_or_pos g'.size with hsz | hsz
-    · exfalso
-      have hiszero : g'.isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hiszero] at hg'_isZero
-      exact Bool.noConfusion hg'_isZero
-    · exact hsz
+  have hg'_size_pos : 0 < g'.size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hg'_isZero
   have hg'_lead_ne :
       Hex.DensePoly.leadingCoeff g' ≠ (0 : Hex.ZMod64 primeData.p) := by
     rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred g' hg'_size_pos]

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -334,9 +334,7 @@ private theorem gcd_monicModularImage_derivative_eq_one
           · exact Or.inl h
           · exact Or.inr h
       have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := by
-          simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-            Array.isEmpty_iff_size_eq_zero, Nat.pos_iff_ne_zero] using hzero
+        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
         rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
         exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
       intro hu_zero
@@ -483,15 +481,8 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
   -- Push through the Mathlib bridge using toMathlibPolynomial_scale.
   rw [hmonicImg_eq, toMathlibPolynomial_scale] at hirr_monic
   -- The scaling constant is a unit (nonzero in the field).
-  have hfsize : 0 < (Hex.ZPoly.modP primeData.p core).size := by
-    rcases Nat.eq_zero_or_pos (Hex.ZPoly.modP primeData.p core).size with hsz | hsz
-    · exfalso
-      have hzero' : (Hex.ZPoly.modP primeData.p core).isZero = true := by
-        simpa [Hex.DensePoly.isZero, Hex.DensePoly.size,
-          Array.isEmpty_iff_size_eq_zero] using hsz
-      rw [hzero'] at hzero
-      exact Bool.noConfusion hzero
-    · exact hsz
+  have hfsize : 0 < (Hex.ZPoly.modP primeData.p core).size :=
+    (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠ 0 := by
     rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred _ hfsize]

--- a/progress/2026-05-18T18-24-06Z_a65aa1b3.md
+++ b/progress/2026-05-18T18-24-06Z_a65aa1b3.md
@@ -1,0 +1,65 @@
+# Session a65aa1b3 — rewire 6 isZero/size sites onto `isZero_eq_false_iff`
+
+## Accomplished
+
+Resolved issue #5055. Rewired 6 inline `0 < f.size`
+derivations from `f.isZero = false` hypotheses onto
+`Hex.DensePoly.isZero_eq_false_iff` in
+`HexBerlekampZassenhausMathlib/{Basic,IntReductionMod}.lean`:
+
+- `Basic.lean` sites at `factorsModP_nodup_of_factorsModPBerlekampForm`
+  (hmod_size_pos), `factorsModP_coprime_of_factorsModPBerlekampForm`
+  (hmod_size_pos), `gcd_monicModularImage_derivative_eq_one_local`
+  (hpos), `factors_irreducible_of_factorsModPBerlekampForm`
+  (hg'_size_pos).
+- `IntReductionMod.lean` sites at
+  `gcd_monicModularImage_derivative_eq_one` (hpos) and
+  `squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData`
+  (hfsize).
+
+Each ~9-line `rcases`/`exfalso` block (Variant A, 4 sites) and each
+~3-line `simpa` block (Variant B, 2 sites) collapses to a one-line
+`(Hex.DensePoly.isZero_eq_false_iff _).mp <hyp>` term-mode proof.
+
+`git diff --stat`: 2 files, +10/-42 = **net -32 lines**, matching
+issue projection.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib`: 16-error baseline
+  preserved (11 whnf timeouts + 1 `cases` + 4 kernel unknown
+  constants, all in `Basic.lean`, line numbers shifted by the
+  removed lines; no new errors).
+- Greppable invariants all match:
+  - `simpa [Hex.DensePoly.isZero, …]`: 1 match (the reverse-direction
+    `Basic.lean:7442` site, out of scope per the issue).
+  - `rcases Nat.eq_zero_or_pos … with h_ | h_`: 0 matches (the four
+    Variant-A blocks removed).
+  - `isZero_eq_false_iff`: 7 matches (4 in Basic + 3 in
+    IntReductionMod, including the pre-existing site at
+    `IntReductionMod.lean:1456`).
+- `python3 scripts/check_dag.py` exit 0.
+- `git diff --check` clean; no new `sorry` / `axiom` /
+  `native_decide` / `TODO` / `FIXME`.
+
+## Current frontier
+
+PR for #5055 ready to land. The remaining cascade siblings still
+open:
+
+- #5056 (reverse-direction sibling: route
+  `IntReductionMod.lean:1455` reverse-direction block onto
+  `Hex.isZero_false_of_ne_zero`).
+- #5053 (post-#5046 review).
+
+Also skipped #4334 (HexLLL Phase 4 inconclusive benchmark verdicts)
+because host `carica` is under heavy load (load average 15.37);
+same skip condition repeatedly recorded on the issue.
+
+## Next step
+
+Land PR for #5055; next worker picks up #5056 or the review #5053.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5055

Session: `a65aa1b3-937b-4776-b6ce-d9a71188cadf`

905b15a0 refactor: rewire 6 inline isZero/size plumbing sites onto Hex.DensePoly.isZero_eq_false_iff (#5055)

🤖 Prepared with Claude Code