### PR TITLE
BZMathlib: hoist zpoly_dvd_trans and rewire 3 calc-form divisor-transitivity sites in Basic.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -2062,6 +2062,18 @@ theorem existsUnique_liftedFactorSubset_of_henselSubsetCorrespondenceRest
   intro T hT
   exact h.unique_subset hirr hdvd hT.1 hSJ hT.2 hS
 
+/-- Transitivity of `Hex.ZPoly`-level divisibility. Discharges the
+`core = g * (q * v)` step explicitly via `Hex.DensePoly.mul_assoc_poly`
+because `Hex.ZPoly` does not synthesise a Mathlib `Semigroup` instance
+at this layer. -/
+private theorem zpoly_dvd_trans
+    {a b c : Hex.ZPoly} (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  obtain ⟨q, hq⟩ := hab
+  obtain ⟨v, hv⟩ := hbc
+  refine ⟨q * v, ?_⟩
+  rw [hv, hq]
+  exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
+
 /--
 Transport an induced Hensel subset correspondence through one emitted
 recombination factor.
@@ -2088,14 +2100,8 @@ theorem henselSubsetCorrespondenceRest_transport_of_disjoint
     HenselSubsetCorrespondenceRest core d (J \ S) quotient where
   exists_subset := by
     intro factor hirr hdvd_quot
-    have hdvd_target : factor ∣ target := by
-      rcases hdvd_quot with ⟨q, hq⟩
-      refine ⟨q * emitted, ?_⟩
-      calc
-        target = quotient * emitted := hquot.symm
-        _ = (factor * q) * emitted := by rw [hq]
-        _ = factor * (q * emitted) := by
-          rw [Hex.DensePoly.mul_assoc_poly (S := Int)]
+    have hdvd_target : factor ∣ target :=
+      zpoly_dvd_trans hdvd_quot ⟨emitted, hquot.symm⟩
     rcases h.exists_subset hirr hdvd_target with ⟨T, hTJ, hTrep⟩
     have hTS : Disjoint T S := hdisjoint hirr hdvd_quot hTJ hTrep
     refine ⟨T, ?_, hTrep⟩
@@ -2104,14 +2110,8 @@ theorem henselSubsetCorrespondenceRest_transport_of_disjoint
       ⟨hTJ hi, fun hiS => (Finset.disjoint_left.mp hTS) hi hiS⟩
   unique_subset := by
     intro factor T U hirr hdvd_quot hTJU hUJU hTrep hUrep
-    have hdvd_target : factor ∣ target := by
-      rcases hdvd_quot with ⟨q, hq⟩
-      refine ⟨q * emitted, ?_⟩
-      calc
-        target = quotient * emitted := hquot.symm
-        _ = (factor * q) * emitted := by rw [hq]
-        _ = factor * (q * emitted) := by
-          rw [Hex.DensePoly.mul_assoc_poly (S := Int)]
+    have hdvd_target : factor ∣ target :=
+      zpoly_dvd_trans hdvd_quot ⟨emitted, hquot.symm⟩
     apply h.unique_subset hirr hdvd_target
     · intro i hi
       exact (Finset.mem_sdiff.mp (hTJU hi)).1
@@ -2273,15 +2273,8 @@ theorem liftedFactorSubsetPartition_transport
       (h.target_squarefree _ h_sq_dvd)
   -- Lift `· ∣ quotient` to `· ∣ target = quotient * emitted`.
   have dvd_target_of_dvd_quotient :
-      ∀ {factor : Hex.ZPoly}, factor ∣ quotient → factor ∣ target := by
-    intro factor hdvd
-    rcases hdvd with ⟨q, hq⟩
-    refine ⟨q * emitted, ?_⟩
-    calc
-      target = quotient * emitted := hquot.symm
-      _ = (factor * q) * emitted := by rw [hq]
-      _ = factor * (q * emitted) := by
-        rw [Hex.DensePoly.mul_assoc_poly (S := Int)]
+      ∀ {factor : Hex.ZPoly}, factor ∣ quotient → factor ∣ target :=
+    fun hdvd => zpoly_dvd_trans hdvd ⟨emitted, hquot.symm⟩
   -- Disjointness obligation for `henselSubsetCorrespondenceRest_transport_of_disjoint`.
   have hdisj :
       ∀ {factor : Hex.ZPoly} {T : LiftedFactorSubset d},
@@ -6751,18 +6744,6 @@ private theorem zpoly_monic_mul {a b : Hex.ZPoly}
     show Hex.DensePoly.leadingCoeff a = 1 from ha,
     show Hex.DensePoly.leadingCoeff b = 1 from hb]
   decide
-
-/-- Transitivity of `Hex.ZPoly`-level divisibility. Discharges the
-`core = g * (q * v)` step explicitly via `Hex.DensePoly.mul_assoc_poly`
-because `Hex.ZPoly` does not synthesise a Mathlib `Semigroup` instance
-at this layer. -/
-private theorem zpoly_dvd_trans
-    {a b c : Hex.ZPoly} (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
-  obtain ⟨q, hq⟩ := hab
-  obtain ⟨v, hv⟩ := hbc
-  refine ⟨q * v, ?_⟩
-  rw [hv, hq]
-  exact Hex.DensePoly.mul_assoc_poly (S := Int) _ _ _
 
 /--
 Bridge `liftedFactorProduct d S` to a `Finset.prod` over `S` after transport to

--- a/progress/20260518T185615Z_2c3f3b15.md
+++ b/progress/20260518T185615Z_2c3f3b15.md
@@ -1,0 +1,71 @@
+# 20260518T185615Z — issues #5056 (skipped, replan) and #5065 (feature, hoist zpoly_dvd_trans)
+
+## Accomplished
+
+- **#5056 skipped → replan.** The plan asks to rewire
+  `HexBerlekampZassenhausMathlib/IntReductionMod.lean:1455` onto
+  `Hex.isZero_false_of_ne_zero` (at `HexBerlekampZassenhaus/Basic.lean:486`),
+  but that helper has signature `{p : Nat} [ZMod64.Bounds p] {f : FpPoly p}`
+  — strictly FpPoly-bound. The target value is `Hex.ZPoly.primitivePart core`,
+  a `Hex.ZPoly = DensePoly Int`. Unification cannot succeed (`Int` vs
+  `ZMod64 p`). Skip comment suggests an alternative composition using the
+  ZPoly-applicable helpers `Hex.ZPoly.size_pos_of_ne_zero` +
+  `Hex.DensePoly.isZero_eq_false_iff` that achieves the same 11→2 line collapse.
+
+- **#5065 implemented.** Hoisted `private theorem zpoly_dvd_trans` from
+  `Basic.lean:6759` (immediately after `zpoly_monic_mul`) to immediately
+  before `henselSubsetCorrespondenceRest_transport_of_disjoint` at the new
+  `Basic.lean:2069` neighbourhood (after the end of
+  `existsUnique_liftedFactorSubset_of_henselSubsetCorrespondenceRest`).
+  Body, docstring, and `private` visibility preserved verbatim.
+
+  Rewired the three calc-form `factor ∣ target` derivations onto
+  `zpoly_dvd_trans`:
+  - `henselSubsetCorrespondenceRest_transport_of_disjoint.exists_subset`
+    (post-hoist `Basic.lean:2103`)
+  - `henselSubsetCorrespondenceRest_transport_of_disjoint.unique_subset`
+    (post-hoist `Basic.lean:2113`)
+  - `liftedFactorSubsetPartition_transport.dvd_target_of_dvd_quotient`
+    (post-hoist `Basic.lean:2275`)
+
+  Each calc chain becomes a one-line
+  `zpoly_dvd_trans hdvd_quot ⟨emitted, hquot.symm⟩` (site 3 uses `fun hdvd =>`
+  because of the `∀ {factor}` quantifier).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: same 16-error baseline
+  as `origin/main` (11 whnf timeouts + 1 `cases` failure + 4 kernel unknown
+  constants). Error line numbers shift down by the file delta (rewires
+  removed lines above the existing errors), but the error count, kinds,
+  and identities are unchanged.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git diff` introduces no new `sorry` / `axiom` / `native_decide` / `TODO` /
+  `FIXME`.
+- Greppable invariants:
+  - `git grep -nE "(theorem|private theorem) zpoly_dvd_trans" \
+       HexBerlekampZassenhausMathlib/Basic.lean` — 1 hit at the new
+    `Basic.lean:2069` (vs the prior `Basic.lean:6759`).
+  - `git grep -cE "Hex\.DensePoly\.mul_assoc_poly \(S := Int\)" \
+       HexBerlekampZassenhausMathlib/Basic.lean` — 30 → 27 (helper-internal
+    + 26 rcases-form siblings remain; the sibling rewire issue is independent).
+  - `git grep -cE "calc\\s*$" HexBerlekampZassenhausMathlib/Basic.lean` —
+    drops by 3.
+- Diffstat: 1 file changed, +18 / −37 (net −19 lines, within the issue's
+  projected −15 to −25 range).
+
+## Current frontier
+
+PR for #5065 ready to publish. Issue #5056 is back in the planner queue
+with a `replan` label and a clear technical comment.
+
+## Next step
+
+Push the branch and create the PR via `coordination create-pr 5065`.
+
+## Blockers
+
+None for #5065. Issue #5056 needs planner re-scoping per the skip
+comment (use ZPoly-applicable helpers, not the FpPoly-bound
+`Hex.isZero_false_of_ne_zero`).


### PR DESCRIPTION
Closes #5065

Session: `2c3f3b15-02c5-4586-aa12-6ba871ebda39`

1a80bd1a chore: progress entry for session 2c3f3b15 (#5056 skipped, #5065 implemented)
f977f0c6 refactor: hoist zpoly_dvd_trans and rewire 3 calc-form divisor-transitivity sites in Basic.lean

🤖 Prepared with Claude Code