### PR TITLE
feat: extract fpPoly_dvd_trans helper and rewire 8 FpPoly-level transitivity sites in Basic.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1354,19 +1354,8 @@ theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
   have hmonic_factor_dvd_core :
       @monicModPImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds factor) ∣
-        @Hex.ZPoly.modP primeData.p primeData.bounds core := by
-    rcases hmonic_factor_dvd_factor with ⟨q₁, hq₁⟩
-    rcases hfactor_dvd_core with ⟨q₂, hq₂⟩
-    refine ⟨q₁ * q₂, ?_⟩
-    calc
-      @Hex.ZPoly.modP primeData.p primeData.bounds core
-          = (@Hex.ZPoly.modP primeData.p primeData.bounds factor) * q₂ := hq₂
-      _ = ((@monicModPImage primeData.p primeData.bounds
-              (@Hex.ZPoly.modP primeData.p primeData.bounds factor)) * q₁) * q₂ :=
-            congrArg (fun x => x * q₂) hq₁
-      _ = (@monicModPImage primeData.p primeData.bounds
-              (@Hex.ZPoly.modP primeData.p primeData.bounds factor)) * (q₁ * q₂) :=
-            Hex.DensePoly.mul_assoc_poly _ _ _
+        @Hex.ZPoly.modP primeData.p primeData.bounds core :=
+    fpPoly_dvd_trans hmonic_factor_dvd_factor hfactor_dvd_core
   have hcore_dvd_monic :
       @Hex.ZPoly.modP primeData.p primeData.bounds core ∣
         Hex.monicModularImage
@@ -1391,18 +1380,7 @@ theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
               (Hex.DensePoly.leadingCoeff
                 (@Hex.ZPoly.modP primeData.p primeData.bounds core))⁻¹ :=
             Hex.DensePoly.mul_comm_poly _ _
-  rcases hmonic_factor_dvd_core with ⟨q₁, hq₁⟩
-  rcases hcore_dvd_monic with ⟨q₂, hq₂⟩
-  refine ⟨q₁ * q₂, ?_⟩
-  calc
-    Hex.monicModularImage (@Hex.ZPoly.modP primeData.p primeData.bounds core)
-        = (@Hex.ZPoly.modP primeData.p primeData.bounds core) * q₂ := hq₂
-    _ = ((@monicModPImage primeData.p primeData.bounds
-            (@Hex.ZPoly.modP primeData.p primeData.bounds factor)) * q₁) * q₂ :=
-          congrArg (fun x => x * q₂) hq₁
-    _ = (@monicModPImage primeData.p primeData.bounds
-            (@Hex.ZPoly.modP primeData.p primeData.bounds factor)) * (q₁ * q₂) :=
-          Hex.DensePoly.mul_assoc_poly _ _ _
+  exact fpPoly_dvd_trans hmonic_factor_dvd_core hcore_dvd_monic
 
 /--
 An integer factor is represented modulo the selected prime by a subset of the
@@ -4934,10 +4912,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
         hfield).factors.Nodup := by
     apply Hex.Berlekamp.berlekampFactor_factors_nodup_of_no_squared
     intro g hgg hpos
-    have hg_dvd_mod : g * g ∣ Hex.ZPoly.modP data.p f := by
-      rcases hgg with ⟨r, hr⟩
-      rcases hmonicImage_dvd with ⟨s, hs⟩
-      exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+    have hg_dvd_mod : g * g ∣ Hex.ZPoly.modP data.p f :=
+      fpPoly_dvd_trans hgg hmonicImage_dvd
     have hunit : Hex.Berlekamp.isUnitPolynomial g = true :=
       Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
         (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf) hg_dvd_mod
@@ -4992,14 +4968,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
       Hex.Berlekamp.mul_dvd_factorProduct_of_mem_of_ne hNodup hg₁ hg₂ hne
     -- Hence g₁ * g₂ ∣ monicImage modP_f.
     rw [hprod] at hg₁_dvd_g₂
-    -- Hence g₁ * g₂ ∣ modP_f.  Construct the dvd witness manually because the
-    -- `dvd` instance for `FpPoly p` is `instDvdOfAddOfMul`, not the default
-    -- `semigroupDvd`, and `dvd_trans` doesn't see through that.
-    have hg₁g₂_dvd_modP :
-        g₁ * g₂ ∣ Hex.ZPoly.modP data.p f := by
-      rcases hg₁_dvd_g₂ with ⟨r, hr⟩
-      rcases hmonicImage_dvd with ⟨s, hs⟩
-      exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+    have hg₁g₂_dvd_modP : g₁ * g₂ ∣ Hex.ZPoly.modP data.p f :=
+      fpPoly_dvd_trans hg₁_dvd_g₂ hmonicImage_dvd
     -- From `monicModularImage g₁ = monicModularImage g₂`, both being nonzero,
     -- we get `g₁ = scale u g₂` for some nonzero `u`.  Use this to conclude
     -- `g₂² ∣ modP_f`, contradicting square-freeness.
@@ -5085,9 +5055,7 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
               Hex.DensePoly.mul_comm_poly _ _
       have hg₂sq_dvd_modP : g₂ * g₂ ∣ Hex.ZPoly.modP data.p f := by
         rw [hg₁g₂_eq] at hg₁g₂_dvd_modP
-        rcases hg₂sq_dvd with ⟨r, hr⟩
-        rcases hg₁g₂_dvd_modP with ⟨s, hs⟩
-        exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+        exact fpPoly_dvd_trans hg₂sq_dvd hg₁g₂_dvd_modP
       -- Square-freeness implies g₂ is a unit polynomial (degree 0).
       have hunit : Hex.Berlekamp.isUnitPolynomial g₂ = true :=
         Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
@@ -5713,10 +5681,7 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
               (Hex.Berlekamp.factorProduct_cons g (h :: tail)).symm
             have hrawGcd_sq_dvd_X : rawGcd * rawGcd ∣ X := by
               rw [hcons_prod] at hrawGcd_sq_dvd_prod
-              rcases hrawGcd_sq_dvd_prod with ⟨k, hk⟩
-              rcases h_dvd with ⟨q, hq⟩
-              refine ⟨k * q, ?_⟩
-              rw [hq, hk]; exact Hex.DensePoly.mul_assoc_poly _ _ _
+              exact fpPoly_dvd_trans hrawGcd_sq_dvd_prod h_dvd
             -- Step 2: rawGcd has degree ≤ 0 by no-squared on X.
             have hrawGcd_not_pos :
                 ¬ (0 < rawGcd.degree?.getD 0) :=
@@ -5790,10 +5755,7 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
                     Hex.Berlekamp.factorProduct (g :: h :: tail) := by
                 refine ⟨g, ?_⟩
                 rw [hcons_eq]; exact Hex.DensePoly.mul_comm_poly _ _
-              rcases htail_dvd_cons with ⟨k, hk⟩
-              rcases h_dvd with ⟨q, hq⟩
-              refine ⟨k * q, ?_⟩
-              rw [hq, hk]; exact Hex.DensePoly.mul_assoc_poly _ _ _
+              exact fpPoly_dvd_trans htail_dvd_cons h_dvd
             exact ih hrest_dvd
 
 set_option maxHeartbeats 400000 in
@@ -5869,10 +5831,8 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
         d * d ∣ Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) →
           ¬ (0 < d.degree?.getD 0) := by
     intro d hdd hpos
-    have hd_dvd_mod : d * d ∣ Hex.ZPoly.modP primeData.p core := by
-      rcases hdd with ⟨r, hr⟩
-      rcases hmonicImage_dvd with ⟨s, hs⟩
-      exact ⟨r * s, by rw [hs, hr, Hex.FpPoly.mul_assoc]⟩
+    have hd_dvd_mod : d * d ∣ Hex.ZPoly.modP primeData.p core :=
+      fpPoly_dvd_trans hdd hmonicImage_dvd
     have hunit : Hex.Berlekamp.isUnitPolynomial d = true :=
       Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd
         (Hex.Berlekamp.squareFree_common_of_gcd_eq_one hsf) hd_dvd_mod

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1284,6 +1284,19 @@ theorem modP_dvd_modP_of_dvd
   refine ⟨Hex.ZPoly.modP p q, ?_⟩
   rw [hq, modP_mul]
 
+/-- Transitivity of `Hex.FpPoly p`-level divisibility. Discharges the
+`c = a * (q * v)` step explicitly via `Hex.FpPoly.mul_assoc` because the
+`Dvd` instance on `Hex.FpPoly p` is the bespoke `instDvdOfAddOfMul`
+(witness shape `b = a * r`), and `dvd_trans` does not see through that. -/
+private theorem fpPoly_dvd_trans
+    {p : Nat} [Hex.ZMod64.Bounds p]
+    {a b c : Hex.FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) : a ∣ c := by
+  obtain ⟨q, hq⟩ := hab
+  obtain ⟨v, hv⟩ := hbc
+  refine ⟨q * v, ?_⟩
+  rw [hv, hq]
+  exact Hex.FpPoly.mul_assoc _ _ _
+
 theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
     {core factor : Hex.ZPoly}
     (hdvd : factor ∣ core)

--- a/progress/20260518T200730Z_6a8c0ac8.md
+++ b/progress/20260518T200730Z_6a8c0ac8.md
@@ -1,0 +1,70 @@
+# 6a8c0ac8 — fpPoly_dvd_trans extraction + 8-site rewire (issue #5077)
+
+## Accomplished
+
+- Extracted `private theorem fpPoly_dvd_trans` in
+  `HexBerlekampZassenhausMathlib/Basic.lean` (FpPoly-`p`-level analogue
+  of `zpoly_dvd_trans`). Hoisted above
+  `monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`
+  (line 1287) so it covers the calc-form transitivity sites near the
+  top of the file as well as the rcases-form sites lower down.
+- Helper body uses `Hex.FpPoly.mul_assoc` as the witness step (over
+  `Hex.DensePoly.mul_assoc_poly`); both typecheck given
+  `Hex.FpPoly p = Hex.DensePoly (Hex.ZMod64 p)`.
+- Rewired **8** inline FpPoly-level divisor-transitivity sites onto
+  the helper:
+  - The 3 confirmed sites from the planner audit
+    (`hg₁g₂_dvd_modP`, `hrawGcd_sq_dvd_X`, `hrest_dvd`).
+  - The 2 calc-form candidates inside
+    `monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`
+    — both classified as transitivity-shape.
+  - 3 sites of identical shape that the audit's Invariant 1 sweep
+    missed (`hg_dvd_mod` in `berlekampFactor_factors_nodup_of_no_squared`,
+    `hg₂sq_dvd_modP` in the scale-witness branch of the square-free
+    contradiction lemma, and `hd_dvd_mod` inside the no-squared
+    invariant of `factorsModP_coprime_of_factorsModPBerlekampForm`).
+- Inline workaround comment at `Basic.lean:4972` (about
+  `instDvdOfAddOfMul` vs `dvd_trans`) collapsed at all sites; the
+  rationale now lives in `fpPoly_dvd_trans`'s docstring.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: same 16 baseline
+  errors in `Basic.lean` (all timeout/`whnf` and unknown-constant
+  errors unrelated to this work).
+- `lake build HexBerlekampZassenhausMathlib`: baseline preserved.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- Diff introduces no `sorry` / `axiom` / `native_decide` / `TODO` /
+  `FIXME` (33 pre-existing sorry warnings unchanged).
+- Greppable invariants:
+  - `git grep -nE "(private theorem|theorem) fpPoly_dvd_trans"` →
+    exactly one match (the declaration at line 1291).
+  - `git grep -c "fpPoly_dvd_trans" HexBerlekampZassenhausMathlib/Basic.lean`
+    → 9 (1 def + 8 uses).
+  - No remaining inline `Hex.FpPoly.mul_assoc` uses in `Basic.lean`
+    outside the helper body.
+  - No remaining `exact Hex.DensePoly.mul_assoc_poly _ _ _` uses in
+    `Basic.lean` outside `zpoly_dvd_trans` and the elaborate
+    `(rawGcd * ka) * (rawGcd * kb)` calc-chain (not transitivity-shape).
+- Diffstat: 12 insertions, 52 deletions in `Basic.lean` (−40 net).
+
+## Current frontier
+
+`fpPoly_dvd_trans` cluster covers all `Hex.FpPoly p`-level
+divisor-transitivity sites in `Basic.lean` of the
+`a ∣ b ∧ b ∣ c → a ∣ c` shape. The only remaining `mul_assoc_poly`
+appearances are inside `zpoly_dvd_trans` itself and the
+non-transitivity calc-chain at `Basic.lean:5666-5677` that pushes
+`rawGcd` factors together via `mul_assoc + mul_comm`.
+
+## Next step
+
+Follow-up audit issue (analogous to #5048 → #5069 for ZPoly) can
+verify cluster closure with the three-invariant pattern (call-site
+coverage / docstring / cross-file consistency). Per the issue, that
+is the next planner cycle's call.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5077

This PR extracts `private theorem fpPoly_dvd_trans` in
`HexBerlekampZassenhausMathlib/Basic.lean` (the FpPoly-`p`-level
analogue of `zpoly_dvd_trans`) and rewires eight inline FpPoly-level
divisor-transitivity sites onto it. The `Dvd` instance for `Hex.FpPoly p`
is the bespoke `instDvdOfAddOfMul` (`DensePoly` instance with witness
shape `b = a * r`), and `dvd_trans` does not see through it, so the
helper discharges the `c = a * (q * v)` step explicitly via
`Hex.FpPoly.mul_assoc`.

Helper placement: above
`monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`
(line 1287), which is the highest hoist position needed to cover all
rewire sites — the two calc-form sites inside that theorem at
`Basic.lean:1347` / `1383` (Deliverable 3) both match the
`a ∣ b ∧ b ∣ c → a ∣ c` shape and are rewired.

The eight rewired sites:

1. `hmonic_factor_dvd_core` (calc-form, `Basic.lean:1347`) — Deliverable 3.
2. Final `monic ∣ monicModularImage core` step (calc-form, `Basic.lean:1383`) — Deliverable 3.
3. `hg_dvd_mod` in `berlekampFactor_factors_nodup_of_no_squared` — audit-missed.
4. `hg₁g₂_dvd_modP` (issue's Site 1, `Basic.lean:4985`).
5. `hg₂sq_dvd_modP` in the scale-witness branch of the square-free contradiction lemma — audit-missed.
6. `hrawGcd_sq_dvd_X` (issue's Site 2, `Basic.lean:5722` neighbourhood) — keeps the `rw [hcons_prod] at ...` alignment step.
7. `hrest_dvd` (issue's Site 3, `Basic.lean:5790` neighbourhood) — keeps the `htail_dvd_cons` construction.
8. `hd_dvd_mod` inside `factorsModP_coprime_of_factorsModPBerlekampForm` — audit-missed.

Sites 3, 5, 8 were not in the planner audit's table but match the
exact transitivity shape (`(g*g) ∣ monicImage ∧ monicImage ∣ modP → (g*g) ∣ modP`,
etc.); rewiring them keeps the cluster idiom uniform.

Inline workaround comment at `Basic.lean:4972` (about
`instDvdOfAddOfMul` vs `dvd_trans`) is collapsed; the rationale now
lives in `fpPoly_dvd_trans`'s docstring.

Verification:

- `lake build HexBerlekampZassenhausMathlib.Basic`: 16-baseline error
  pattern in `Basic.lean` preserved (same set of `whnf` timeouts and
  unknown-constant errors as `origin/main`).
- `lake build HexBerlekampZassenhausMathlib`: baseline preserved.
- `python3 scripts/check_dag.py`: exit 0.
- `git diff --check`: clean.
- No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME`.
- Greppable invariants:
  - `git grep -nE "(private theorem|theorem) fpPoly_dvd_trans" HexBerlekampZassenhausMathlib/` → one declaration.
  - `git grep -c "fpPoly_dvd_trans" HexBerlekampZassenhausMathlib/Basic.lean` → 9 (1 def + 8 uses; exceeds the issue's "at least 4" floor).
  - No inline `Hex.FpPoly.mul_assoc` uses in `Basic.lean` outside the helper body.
  - No `exact Hex.DensePoly.mul_assoc_poly _ _ _` uses outside `zpoly_dvd_trans` and the non-transitivity calc-chain at `Basic.lean:5666-5677`.
- Diffstat: 12 insertions, 52 deletions in `Basic.lean` (−40 net),
  exceeding the issue's "−4 or better" target.

Session: \`6a8c0ac8-91a0-40e1-a0ea-8a2250ab2d3a\`

🤖 Prepared with Claude Code