### PR TITLE
BZMathlib: extract fpPoly_isZero_false_of_dvd_of_isZero_false helper and rewire 2 inline FpPoly-divisibility isZero=false derivations in Basic.lean

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1284,6 +1284,32 @@ theorem modP_dvd_modP_of_dvd
   refine ⟨Hex.ZPoly.modP p q, ?_⟩
   rw [hq, modP_mul]
 
+/-- Divisibility at the `Hex.FpPoly p` layer preserves `isZero = false`:
+if `a ∣ b` and `b.isZero = false` then `a.isZero = false`. The bespoke
+`Dvd` instance for `Hex.FpPoly p` is `instDvdOfAddOfMul`, not Mathlib's
+`semigroupDvd`, so Mathlib's `dvd`-based zero-propagation lemmas do not
+apply at this layer and the boolean-`isZero` contrapositive is rebuilt
+directly here. -/
+private theorem fpPoly_isZero_false_of_dvd_of_isZero_false
+    {p : Nat} [Hex.ZMod64.Bounds p] {a b : Hex.FpPoly p}
+    (hab : a ∣ b) (hb : b.isZero = false) : a.isZero = false := by
+  cases ha : a.isZero with
+  | false => rfl
+  | true =>
+      exfalso
+      have ha_zero : a = 0 := by
+        apply Hex.DensePoly.ext_coeff
+        intro n
+        have hsize : a.size = 0 := by
+          change a.coeffs.isEmpty = true at ha
+          simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using ha
+        rw [Hex.DensePoly.coeff_eq_zero_of_size_le a (by omega)]
+        exact Hex.DensePoly.coeff_zero n
+      rcases hab with ⟨q, hq⟩
+      rw [ha_zero, Hex.FpPoly.zero_mul] at hq
+      rw [hq] at hb
+      exact Bool.noConfusion hb
+
 theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
     {core factor : Hex.ZPoly}
     (hdvd : factor ∣ core)
@@ -1314,25 +1340,8 @@ theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
         @Hex.ZPoly.modP primeData.p primeData.bounds core :=
     modP_dvd_modP_of_dvd primeData.p hdvd
   have hfactor_iszero :
-      (@Hex.ZPoly.modP primeData.p primeData.bounds factor).isZero = false := by
-    cases hzero : (@Hex.ZPoly.modP primeData.p primeData.bounds factor).isZero with
-    | false => rfl
-    | true =>
-        exfalso
-        have hfactor_zero :
-            @Hex.ZPoly.modP primeData.p primeData.bounds factor = 0 := by
-          apply Hex.DensePoly.ext_coeff
-          intro n
-          have hsize : (@Hex.ZPoly.modP primeData.p primeData.bounds factor).size = 0 := by
-            change (@Hex.ZPoly.modP primeData.p primeData.bounds factor).coeffs.isEmpty = true at hzero
-            simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hzero
-          rw [Hex.DensePoly.coeff_eq_zero_of_size_le
-            (@Hex.ZPoly.modP primeData.p primeData.bounds factor) (by omega)]
-          exact Hex.DensePoly.coeff_zero n
-        rcases hfactor_dvd_core with ⟨q, hq⟩
-        apply hcore_mod_ne
-        rw [hfactor_zero, Hex.FpPoly.zero_mul] at hq
-        exact hq
+      (@Hex.ZPoly.modP primeData.p primeData.bounds factor).isZero = false :=
+    fpPoly_isZero_false_of_dvd_of_isZero_false hfactor_dvd_core hcore_iszero
   have hmonic_factor_dvd_factor :
       @monicModPImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds factor) ∣
@@ -15425,27 +15434,8 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     have hcore_modP_iszero :
         (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
       Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
-    cases hzero_factor :
-        (@Hex.ZPoly.modP primeData.p primeData.bounds factor).isZero with
-    | false => rfl
-    | true =>
-        exfalso
-        have hfactor_modP_zero :
-            @Hex.ZPoly.modP primeData.p primeData.bounds factor = 0 := by
-          apply Hex.DensePoly.ext_coeff
-          intro k
-          have hsize :
-              (@Hex.ZPoly.modP primeData.p primeData.bounds factor).size = 0 := by
-            change
-              (@Hex.ZPoly.modP primeData.p primeData.bounds factor).coeffs.isEmpty
-                = true at hzero_factor
-            simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero] using hzero_factor
-          rw [Hex.DensePoly.coeff_eq_zero_of_size_le _ (by omega)]
-          exact Hex.DensePoly.coeff_zero k
-        rcases hfactor_dvd_core_modP with ⟨q, hq⟩
-        rw [hfactor_modP_zero, Hex.FpPoly.zero_mul] at hq
-        rw [hq] at hcore_modP_iszero
-        exact Bool.noConfusion hcore_modP_iszero
+    exact fpPoly_isZero_false_of_dvd_of_isZero_false
+      hfactor_dvd_core_modP hcore_modP_iszero
   have hmathD_monic : mathD.Monic := by
     rw [hmathD_def]
     exact HexBerlekampMathlib.toMathlibPolynomial_monic _ hmonicModPImage_monic

--- a/progress/20260518T202313Z_d53f66d3.md
+++ b/progress/20260518T202313Z_d53f66d3.md
@@ -1,0 +1,61 @@
+# Session d53f66d3 — #5081 fpPoly_isZero_false_of_dvd_of_isZero_false rewire
+
+## Accomplished
+
+- Extracted `private theorem fpPoly_isZero_false_of_dvd_of_isZero_false`
+  in `HexBerlekampZassenhausMathlib/Basic.lean` between
+  `modP_dvd_modP_of_dvd` (line 1285) and
+  `monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`
+  (now line 1313).
+- Rewired site 1 (`Basic.lean:1318` pre-edit, `:1342` post-edit) — the
+  inline 20-line `cases (modP factor).isZero` block inside
+  `monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some`
+  collapses to a single-line term-mode application of the helper. The
+  pre-existing `hcore_iszero` binding (from
+  `Hex.isGoodPrime_modP_isZero_false`) is already in
+  `isZero = false` form, so no rename is needed and no separate
+  `Hex.isZero_false_of_ne_zero` invocation is required at this site.
+- Rewired site 2 (`Basic.lean:15442` pre-edit, `:15437` post-edit) inside
+  `existsUnique_modPFactorSubset_of_choosePrimeData_of_some` — the
+  outer `cases hzero_factor : ...` block collapses to a single
+  `exact fpPoly_isZero_false_of_dvd_of_isZero_false …` term applied to
+  the pre-existing `hfactor_dvd_core_modP` and `hcore_modP_iszero`
+  bindings.
+
+## Invariants
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` reproduces the
+  16-error baseline (11 whnf timeouts + 1 `cases` failure +
+  4 kernel unknown constants) at the expected upward-shifted line
+  numbers; no new or fewer errors.
+- `lake build HexBerlekampZassenhausMathlib` ditto.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean.
+- No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME` tokens.
+- `grep -c "fpPoly_isZero_false_of_dvd_of_isZero_false" Basic.lean` = 3
+  (1 def + 2 uses).
+- `grep -c "Array.isEmpty_iff_size_eq_zero" Basic.lean` = 1 (down from
+  2; the helper body retains one internal use via the same
+  `simpa [Hex.DensePoly.size, Array.isEmpty_iff_size_eq_zero]` step;
+  both inline uses vanish).
+- `grep -nE "apply Hex.DensePoly.ext_coeff" Basic.lean | wc -l` = 16
+  (down from 17; -2 inline + 1 in helper).
+- Diff stat: -40 / +30 net across `Basic.lean`.
+
+## Current frontier
+
+- Issue #5077's `fpPoly_dvd_trans` extraction (Shape A: FpPoly-level
+  divisor-transitivity at lines 4985, 5722, 5790) is still
+  open as of this session. The two issues are independent on the
+  implementation side; once #5077 lands, the helper docstring shape
+  for `fpPoly_dvd_trans` and `fpPoly_isZero_false_of_dvd_of_isZero_false`
+  should be reviewed together for consistency.
+- The remaining `Array.isEmpty_iff_size_eq_zero` use in
+  `Basic.lean` is now isolated to the new helper body — any future
+  cleanup of the `change … coeffs.isEmpty = true … simpa […]` idiom
+  (e.g. a smaller `size_eq_zero_iff_isZero` lemma at the FpPoly
+  layer) could fold the helper body further.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5081

Session: `d53f66d3-0212-4ff5-9f43-5013341c44c1`

457b8dd3 refactor: extract fpPoly_isZero_false_of_dvd_of_isZero_false helper and rewire 2 inline FpPoly-divisibility isZero=false derivations in Basic.lean

🤖 Prepared with Claude Code