### PR TITLE
BZMathlib: invert monic_primitive_sign_normalized_of_monic cluster — first-class proofs for zpoly_primitive_of_monic and zpoly_normalize_factor_sign_of_monic, collapse umbrella body

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -4452,6 +4452,36 @@ private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
     exact absurd hlead (by decide)
   · exact hcs_pos
 
+/-- Monic integer polynomials are primitive (content 1). -/
+theorem zpoly_primitive_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : Hex.ZPoly.Primitive f := by
+  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
+  have hcs_pos : 0 < f.coeffs.size := zpoly_size_pos_of_monic h
+  have hsize_pos : 0 < f.size := hcs_pos
+  have hcoeff_last : f.coeff (f.size - 1) = (1 : Int) := by
+    rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last f hsize_pos]
+    exact hlead
+  have hdvd_one : Hex.ZPoly.content f ∣ (1 : Int) := by
+    have := Hex.DensePoly.content_dvd_coeff f (f.size - 1)
+    rwa [hcoeff_last] at this
+  have hcontent_nonneg : (0 : Int) ≤ Hex.ZPoly.content f := by
+    unfold Hex.ZPoly.content Hex.DensePoly.content
+    exact Int.natCast_nonneg _
+  rcases Int.isUnit_iff.mp (isUnit_of_dvd_one hdvd_one) with hpos | hneg
+  · exact hpos
+  · exfalso
+    rw [hneg] at hcontent_nonneg
+    exact absurd hcontent_nonneg (by decide)
+
+/-- Monic integer polynomials are fixed by `Hex.normalizeFactorSign`. -/
+theorem zpoly_normalize_factor_sign_of_monic {f : Hex.ZPoly}
+    (h : Hex.DensePoly.Monic f) : Hex.normalizeFactorSign f = f := by
+  have hlead : Hex.DensePoly.leadingCoeff f = (1 : Int) := h
+  unfold Hex.normalizeFactorSign
+  have hnot_neg : ¬ Hex.DensePoly.leadingCoeff f < 0 := by
+    rw [hlead]; decide
+  simp [hnot_neg]
+
 /--
 A monic integer polynomial automatically has primitive content and is its own
 sign-normalisation. This packages the two normalisation hypotheses required
@@ -4472,34 +4502,10 @@ theorem monic_primitive_sign_normalized_of_monic
     {factor : Hex.ZPoly} (hfactor_monic : Hex.DensePoly.Monic factor) :
     Hex.DensePoly.Monic factor ∧
       Hex.ZPoly.content factor = 1 ∧
-        Hex.normalizeFactorSign factor = factor := by
-  have hlead : Hex.DensePoly.leadingCoeff factor = (1 : Int) := hfactor_monic
-  have hcs_pos : 0 < factor.coeffs.size :=
-    zpoly_size_pos_of_monic hfactor_monic
-  have hsize_pos : 0 < factor.size := hcs_pos
-  have hcoeff_last : factor.coeff (factor.size - 1) = (1 : Int) := by
-    rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last factor hsize_pos]
-    exact hlead
-  refine ⟨hfactor_monic, ?_, ?_⟩
-  · -- content factor = 1: content divides every coefficient, including the
-    --   leading coefficient 1, and content is non-negative, so content = 1.
-    have hdvd_one : Hex.ZPoly.content factor ∣ (1 : Int) := by
-      have := Hex.DensePoly.content_dvd_coeff factor (factor.size - 1)
-      rwa [hcoeff_last] at this
-    have hcontent_nonneg : (0 : Int) ≤ Hex.ZPoly.content factor := by
-      unfold Hex.ZPoly.content Hex.DensePoly.content
-      exact Int.natCast_nonneg _
-    rcases Int.isUnit_iff.mp (isUnit_of_dvd_one hdvd_one) with hpos | hneg
-    · exact hpos
-    · exfalso
-      rw [hneg] at hcontent_nonneg
-      exact absurd hcontent_nonneg (by decide)
-  · -- normalizeFactorSign factor = factor: leadingCoeff = 1 ≥ 0, so the sign
-    --   normaliser is the identity branch.
-    unfold Hex.normalizeFactorSign
-    have hnot_neg : ¬ Hex.DensePoly.leadingCoeff factor < 0 := by
-      rw [hlead]; decide
-    simp [hnot_neg]
+        Hex.normalizeFactorSign factor = factor :=
+  ⟨hfactor_monic,
+    zpoly_primitive_of_monic hfactor_monic,
+    zpoly_normalize_factor_sign_of_monic hfactor_monic⟩
 
 /--
 Size of the lifted-factor array equals the size of the modular-factor array.
@@ -6646,16 +6652,6 @@ theorem zpoly_lc_pos_of_monic {f : Hex.ZPoly}
     0 < Hex.DensePoly.leadingCoeff f := by
   rw [show Hex.DensePoly.leadingCoeff f = (1 : Int) from h]
   decide
-
-/-- Monic integer polynomials are primitive (content 1). -/
-theorem zpoly_primitive_of_monic {f : Hex.ZPoly}
-    (h : Hex.DensePoly.Monic f) : Hex.ZPoly.Primitive f :=
-  (monic_primitive_sign_normalized_of_monic h).2.1
-
-/-- Monic integer polynomials are fixed by `Hex.normalizeFactorSign`. -/
-theorem zpoly_normalize_factor_sign_of_monic {f : Hex.ZPoly}
-    (h : Hex.DensePoly.Monic f) : Hex.normalizeFactorSign f = f :=
-  (monic_primitive_sign_normalized_of_monic h).2.2
 
 private theorem zpoly_monic_one : Hex.DensePoly.Monic (1 : Hex.ZPoly) := by
   show Hex.DensePoly.leadingCoeff (1 : Hex.ZPoly) = (1 : Int)

--- a/progress/20260518T204232Z_cbac28a9.md
+++ b/progress/20260518T204232Z_cbac28a9.md
@@ -1,0 +1,83 @@
+# cbac28a9 — invert monic_primitive_sign_normalized_of_monic cluster (issue #5084)
+
+## Accomplished
+
+- Hoisted `zpoly_primitive_of_monic` and
+  `zpoly_normalize_factor_sign_of_monic` in
+  `HexBerlekampZassenhausMathlib/Basic.lean` from their post-umbrella
+  cluster location (old lines 6651-6658) to immediately above the
+  umbrella `monic_primitive_sign_normalized_of_monic`, sitting between
+  the existing `zpoly_size_pos_of_monic` hoist target (line 4442) and
+  the umbrella docstring (now line 4485).
+- Converted both helpers to first-class proofs. The inline content-1
+  case body of the umbrella moved into `zpoly_primitive_of_monic`
+  (local `hlead`, `hcs_pos := zpoly_size_pos_of_monic h`, `hsize_pos`,
+  `hcoeff_last` via `leadingCoeff_eq_coeff_last`, then
+  `content_dvd_coeff` + `Int.isUnit_iff` + content-nonneg chain). The
+  inline normalizeFactorSign case moved into
+  `zpoly_normalize_factor_sign_of_monic` (local `hlead := h`,
+  `unfold Hex.normalizeFactorSign`, `hnot_neg`, `simp [hnot_neg]`).
+- Collapsed the umbrella body from ~28 tactic lines to a 3-line
+  anonymous-constructor term
+  `⟨hfactor_monic, zpoly_primitive_of_monic hfactor_monic,
+   zpoly_normalize_factor_sign_of_monic hfactor_monic⟩`. The umbrella
+  signature, docstring, and external surface are unchanged.
+- `zpoly_ne_zero_of_monic` and `zpoly_lc_pos_of_monic` stay in the
+  post-6655 cluster, per the issue (their bodies are self-contained).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: same 16-error
+  baseline in `Basic.lean` (11 whnf timeouts at 4856/5106/5416/5503/
+  5550/5919/6065/6230/6211/15165/15276, 1 `cases` failure at 5806, 4
+  kernel unknown constants at 6545/6609/15483/15529). 34 warnings,
+  unchanged. The cluster restructure is body-internal at three
+  theorems well away from the known-failing sites; line offsets at
+  the failing sites shifted by +6 lines, matching the net +5 lines
+  added above their positions (helpers moved up, body shrank).
+- `lake build HexBerlekampZassenhausMathlib`: same baseline; only
+  `Basic` fails for the pre-existing reasons.
+- `python3 scripts/check_dag.py`: exit 0.
+- `git diff --check`: clean.
+- Diff introduces no new `sorry` / `axiom` / `native_decide` / `TODO`
+  / `FIXME` (pre-existing sorry warnings unchanged).
+- Diffstat on `Basic.lean`: 34 insertions, 38 deletions (−4 net).
+  The issue projected ~−8 net; the difference is approximation in the
+  audit's body-length estimates (helper docstrings and blank-line
+  separation count as +2 each).
+- Greppable invariants:
+  - `grep -c "monic_primitive_sign_normalized_of_monic"
+      HexBerlekampZassenhausMathlib/Basic.lean` → 4 (1 def + 3
+    docstring mentions at 4541 / 7934 / 9384). The two corollary
+    call sites at the old 6653/6658 are gone.
+  - `grep -c "zpoly_primitive_of_monic"
+      HexBerlekampZassenhausMathlib/Basic.lean` → 9 (1 def + 1 use
+    in the umbrella body + 7 external uses at 5543 / 7730 / 9406 /
+    9926 / 10034 / 13344 / 14634). External use set unchanged.
+  - `grep -c "zpoly_normalize_factor_sign_of_monic"
+      HexBerlekampZassenhausMathlib/Basic.lean` → 7 (1 def + 1 use
+    in the umbrella body + 5 external uses at 7727 / 9401 / 9928 /
+    10036 / 13346). External use set unchanged.
+
+## Current frontier
+
+The Monic-route cluster now has four first-class helpers
+(`zpoly_size_pos_of_monic`, `zpoly_primitive_of_monic`,
+`zpoly_normalize_factor_sign_of_monic`, plus
+`zpoly_ne_zero_of_monic` / `zpoly_lc_pos_of_monic` further down).
+The umbrella is now a 3-line aggregator with no proof body of its
+own — every conclusion in the conjunction routes through a named
+first-class lemma.
+
+## Next step
+
+Follow-up audit issue (analogous to #5069 / #5082 for ZPoly /
+FpPoly clusters) can verify the inversion's cluster closure with
+the three-invariant pattern (call-site coverage / docstring /
+cross-file consistency). The umbrella's residual docstring
+references at 4541 / 7934 / 9384 may warrant the same audit step
+that confirmed downstream consumers go through the helpers.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5084

Session: `cbac28a9-171c-461b-879e-9dca6e9bf6bc`

36c60202 refactor: invert monic_primitive_sign_normalized_of_monic cluster — first-class proofs for zpoly_primitive_of_monic and zpoly_normalize_factor_sign_of_monic, umbrella collapsed (#5084)

🤖 Prepared with Claude Code