### PR TITLE
BZMathlib: extract fpPoly_leadingCoeff_ne_zero_of_size_pos helper and rewire 9 inline leadingCoeff ≠ 0 derivations (7 in Basic.lean, 2 in IntReductionMod.lean)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1219,6 +1219,18 @@ theorem monicModPImage_monic_of_ne_zero
   rw [monicModPImage_eq_monicModularImage]
   exact Hex.monicModularImage_monic hprime f hf
 
+/-- Nonvanishing of the leading coefficient for a positive-size
+`Hex.FpPoly p`. Composes `Hex.FpPoly.leadingCoeff_eq_coeff_pred`, which
+rewrites the leading coefficient to `f.coeff (f.size - 1)`, with
+`Hex.DensePoly.coeff_last_ne_zero_of_pos_size`, the invariant that the
+size-pred coefficient of a positive-size `Hex.DensePoly` is nonzero. -/
+theorem fpPoly_leadingCoeff_ne_zero_of_size_pos
+    {p : Nat} [Hex.ZMod64.Bounds p] (f : Hex.FpPoly p)
+    (hf_size_pos : 0 < f.size) :
+    Hex.DensePoly.leadingCoeff f ≠ (0 : Hex.ZMod64 p) := by
+  rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hf_size_pos]
+  exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hf_size_pos
+
 theorem monicModPImage_dvd_self_of_ne_zero
     {p : Nat} [Hex.ZMod64.Bounds p]
     (hprime : Hex.Nat.Prime p) {f : Hex.FpPoly p} (hf : f.isZero = false) :
@@ -1231,9 +1243,8 @@ theorem monicModPImage_dvd_self_of_ne_zero
     subst hzero
     contradiction
   have hf_size_pos : 0 < f.size := Hex.FpPoly.size_pos_of_ne_zero hf_ne
-  have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ (0 : Hex.ZMod64 p) := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hf_size_pos]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hf_size_pos
+  have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ (0 : Hex.ZMod64 p) :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos f hf_size_pos
   have hinv_ne : (Hex.DensePoly.leadingCoeff f)⁻¹ ≠ (0 : Hex.ZMod64 p) :=
     Hex.ZMod64.inv_ne_zero_of_prime hprime hlead_ne
   exact Hex.FpPoly.dvd_scale_self_of_ne_zero hinv_ne f
@@ -4896,10 +4907,8 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
     (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f) ≠
-        (0 : Hex.ZMod64 data.p) := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred (Hex.ZPoly.modP data.p f) hmod_size_pos]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size
-      (Hex.ZPoly.modP data.p f) hmod_size_pos
+        (0 : Hex.ZMod64 data.p) :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos (Hex.ZPoly.modP data.p f) hmod_size_pos
   have hinv_ne :
       (Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f))⁻¹ ≠
         (0 : Hex.ZMod64 data.p) :=
@@ -5172,10 +5181,8 @@ theorem factorsModP_natDegree_pos_of_factorsModPBerlekampForm
   have hmod_size_pos : 0 < (Hex.ZPoly.modP data.p f).size := by omega
   have hmodP_lead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f) ≠
-        (0 : Hex.ZMod64 data.p) := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred (Hex.ZPoly.modP data.p f) hmod_size_pos]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size
-      (Hex.ZPoly.modP data.p f) hmod_size_pos
+        (0 : Hex.ZMod64 data.p) :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos (Hex.ZPoly.modP data.p f) hmod_size_pos
   have hinv_ne :
       (Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP data.p f))⁻¹ ≠
         (0 : Hex.ZMod64 data.p) :=
@@ -5719,9 +5726,8 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
               rw [hdeg_form]; simp; omega
             -- Step 5: lc rawGcd ≠ 0.
             have hlc_ne :
-                Hex.DensePoly.leadingCoeff rawGcd ≠ (0 : Hex.ZMod64 p) := by
-              rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred rawGcd hrawGcd_size_pos]
-              exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size rawGcd hrawGcd_size_pos
+                Hex.DensePoly.leadingCoeff rawGcd ≠ (0 : Hex.ZMod64 p) :=
+              fpPoly_leadingCoeff_ne_zero_of_size_pos rawGcd hrawGcd_size_pos
             -- Step 6: rawGcd.coeff 0 = lc rawGcd.
             have hrawGcd_coeff_zero :
                 rawGcd.coeff 0 = Hex.DensePoly.leadingCoeff rawGcd := by
@@ -5817,9 +5823,9 @@ theorem factorsModP_coprime_of_factorsModPBerlekampForm
     (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hmodP_lead_ne :
       Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠
-        (0 : Hex.ZMod64 primeData.p) := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred _ hmod_size_pos]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size _ hmod_size_pos
+        (0 : Hex.ZMod64 primeData.p) :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos
+      (Hex.ZPoly.modP primeData.p core) hmod_size_pos
   have hinv_ne :
       (Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core))⁻¹ ≠
         (0 : Hex.ZMod64 primeData.p) :=
@@ -5997,10 +6003,9 @@ private theorem gcd_monicModularImage_derivative_eq_one_local
           rcases (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hmdvd with h | h
           · exact Or.inl h
           · exact Or.inr h
-      have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
-        rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
-        exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
+      have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 :=
+        fpPoly_leadingCoeff_ne_zero_of_size_pos f
+          ((Hex.DensePoly.isZero_eq_false_iff _).mp hzero)
       intro hu_zero
       have hone_hex : u * Hex.DensePoly.leadingCoeff f = (1 : Hex.ZMod64 p) := by
         simpa [u] using Hex.ZMod64.inv_mul_eq_one_of_prime hp_hex hlead_ne
@@ -6156,9 +6161,8 @@ theorem factors_irreducible_of_factorsModPBerlekampForm
   have hg'_size_pos : 0 < g'.size :=
     (Hex.DensePoly.isZero_eq_false_iff _).mp hg'_isZero
   have hg'_lead_ne :
-      Hex.DensePoly.leadingCoeff g' ≠ (0 : Hex.ZMod64 primeData.p) := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred g' hg'_size_pos]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size g' hg'_size_pos
+      Hex.DensePoly.leadingCoeff g' ≠ (0 : Hex.ZMod64 primeData.p) :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos g' hg'_size_pos
   have hg'_inv_ne :
       (Hex.DensePoly.leadingCoeff g')⁻¹ ≠ (0 : Hex.ZMod64 primeData.p) := by
     intro hinv

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -333,10 +333,9 @@ private theorem gcd_monicModularImage_derivative_eq_one
           rcases (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hmdvd with h | h
           · exact Or.inl h
           · exact Or.inr h
-      have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 := by
-        have hpos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
-        rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred f hpos]
-        exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size f hpos
+      have hlead_ne : Hex.DensePoly.leadingCoeff f ≠ 0 :=
+        fpPoly_leadingCoeff_ne_zero_of_size_pos f
+          ((Hex.DensePoly.isZero_eq_false_iff _).mp hzero)
       intro hu_zero
       have hone_hex : u * Hex.DensePoly.leadingCoeff f = (1 : Hex.ZMod64 p) := by
         simpa [u] using Hex.ZMod64.inv_mul_eq_one_of_prime hp_hex hlead_ne
@@ -484,9 +483,8 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
   have hfsize : 0 < (Hex.ZPoly.modP primeData.p core).size :=
     (Hex.DensePoly.isZero_eq_false_iff _).mp hzero
   have hlead_ne :
-      Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠ 0 := by
-    rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred _ hfsize]
-    exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size _ hfsize
+      Hex.DensePoly.leadingCoeff (Hex.ZPoly.modP primeData.p core) ≠ 0 :=
+    fpPoly_leadingCoeff_ne_zero_of_size_pos (Hex.ZPoly.modP primeData.p core) hfsize
   have h_one_ne_zero : (1 : Hex.ZMod64 primeData.p) ≠ 0 := by
     intro h
     have htoNat : (1 : Hex.ZMod64 primeData.p).toNat =

--- a/progress/20260518T205537Z_afaefe5d.md
+++ b/progress/20260518T205537Z_afaefe5d.md
@@ -1,0 +1,64 @@
+# Extract `fpPoly_leadingCoeff_ne_zero_of_size_pos` helper and rewire 9 sites
+
+Issue: https://github.com/kim-em/hex/issues/5088
+
+## Accomplished
+
+- Added `theorem fpPoly_leadingCoeff_ne_zero_of_size_pos` to
+  `HexBerlekampZassenhausMathlib/Basic.lean`, hoisted between
+  `monicModPImage_monic_of_ne_zero` and the lowest call site
+  `monicModPImage_dvd_self_of_ne_zero`. Declared as `theorem` (not
+  `private`) so the two `IntReductionMod.lean` sites can reach it.
+- Rewired all 9 inline `leadingCoeff X ≠ 0` derivations onto the helper:
+  - 7 in `Basic.lean` at the previously-identified sites under
+    `monicModPImage_dvd_self_of_ne_zero` (1234), the two
+    `factorsModP*_of_factorsModPBerlekampForm` sites (4894, 5170),
+    `quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared`
+    (5717), `factorsModP_coprime_of_factorsModPBerlekampForm` (5815),
+    `gcd_monicModularImage_derivative_eq_one_local` (5996, inline-hpos
+    form), and `factors_irreducible_of_factorsModPBerlekampForm` (6154).
+  - 2 in `IntReductionMod.lean` at
+    `gcd_monicModularImage_derivative_eq_one` (338, inline-hpos form)
+    and `squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData`
+    (488).
+- For the two inline-hpos sites (Basic.lean:5996, IntReductionMod.lean:338),
+  inlined the `(isZero_eq_false_iff _).mp hzero` derivation into the
+  helper call to keep the result one term-mode line per site.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` and `lake build
+  HexBerlekampZassenhausMathlib` produce the same 16-error baseline as
+  pre-change `main` (timeout/whnf, dependent-elim `cases`, and
+  unknown-constant errors at the same theorem-level positions; line
+  numbers shift by the helper's +12 lines minus the per-site net
+  removals, which is the expected mechanical drift).
+- `git grep -nE "(private theorem|theorem) fpPoly_leadingCoeff_ne_zero_of_size_pos"` →
+  1 match (the declaration at Basic.lean:1227).
+- `git grep -c "fpPoly_leadingCoeff_ne_zero_of_size_pos"
+  HexBerlekampZassenhausMathlib/Basic.lean` → 8 (1 decl + 7 uses).
+- `git grep -c "fpPoly_leadingCoeff_ne_zero_of_size_pos"
+  HexBerlekampZassenhausMathlib/IntReductionMod.lean` → 2.
+- Residual `Hex.DensePoly.coeff_last_ne_zero_of_pos_size` references in
+  the BZMathlib tree: helper docstring + helper body (Basic.lean:1225,
+  1232), plus `Basic.lean:5245` and `IntReductionMod.lean:842`, which
+  use the lemma for purposes other than the `leadingCoeff X ≠ 0`
+  conclusion (out-of-scope per the issue body).
+- `python3 scripts/check_dag.py` exit 0; `git diff --check` clean.
+- No new `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME` tokens.
+
+## Current frontier
+
+The `fpPoly_leadingCoeff_ne_zero_of_size_pos` cluster is closed. A
+follow-up audit issue applying the three-invariant pattern (call-site
+coverage / framing-docstring-hoist / cross-file consistency) is
+expected from the next planner cycle, mirroring the audit chain that
+followed `fpPoly_dvd_trans` (#5077 → #5082 audit).
+
+## Next step
+
+Open PR closing #5088.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5088

Session: `afaefe5d-9169-4783-92c7-044b05a97036`

fa0861a6 feat: extract fpPoly_leadingCoeff_ne_zero_of_size_pos helper and rewire 9 inline leadingCoeff ≠ 0 sites

🤖 Prepared with Claude Code