### PR TITLE
BZMathlib: add cover-at-min abstract-bound sibling

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -10919,6 +10919,54 @@ at `i := J.min' hne` with the forward-support containment
 single cover factor whose representing subset both contains `J.min' hne`
 and is contained in `T`.
 -/
+theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_bound
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hne : J.Nonempty)
+    (hmin_in_T : J.min' hne ∈ T)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient) :
+    ∃ (f : Hex.ZPoly) (S : LiftedFactorSubset d),
+      Irreducible (HexPolyZMathlib.toPolynomial f) ∧
+      f ∣ target ∧
+      S ⊆ J ∧ J.min' hne ∈ S ∧
+      RepresentsIntegerFactorAtLift core d f S ∧
+      S ⊆ T := by
+  obtain ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_cand, hSJ, hmin_in_S, hrep⟩ :=
+    exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_bound
+      B' hvalid hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+      hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core hTJ
+      hrecord hquot hmin_in_T
+  have hST : S ⊆ T :=
+    hpartition.support_subset_of_dvd_recombinationCandidate
+      hf_irr hf_dvd_target hTJ
+      (by
+        rw [← recombinationCandidate_eq_liftedFactorProductCandidate]
+        exact hf_dvd_cand)
+      hSJ hrep
+  exact ⟨f, S, hf_irr, hf_dvd_target, hSJ, hmin_in_S, hrep, hST⟩
+
+/-- Default-bound wrapper for
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_bound`. -/
 theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
@@ -10945,16 +10993,32 @@ theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd
       S ⊆ J ∧ J.min' hne ∈ S ∧
       RepresentsIntegerFactorAtLift core d f S ∧
       S ⊆ T := by
-  obtain ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_cand, hSJ, hmin_in_S, hrep⟩ :=
-    exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd
-      hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core
-      hTJ hrecord hquot hmin_in_T
-  have hST : S ⊆ T :=
-    representingSubset_subset_of_dvd_recombinationCandidate
-      hcore_ne hcore_monic hprecision hpartition hTJ hf_irr
-      hf_dvd_target hf_dvd_cand hSJ hrep
-  exact ⟨f, S, hf_irr, hf_dvd_target, hSJ, hmin_in_S, hrep, hST⟩
+  have hcand_dvd_target : recombinationCandidate d T ∣ target := by
+    have hmul : quotient * recombinationCandidate d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hcand_dvd_core : recombinationCandidate d T ∣ core :=
+    zpoly_dvd_trans hcand_dvd_target htarget_dvd_core
+  refine coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    (fun g hg_mem' => ?_)
+    hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core hTJ
+    hne hmin_in_T hrecord hquot
+  have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+      HexPolyZMathlib.toPolynomial (recombinationCandidate d T) :=
+    UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem'
+  have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+    rcases hg_poly_dvd with ⟨r, hr⟩
+    refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+    apply HexPolyZMathlib.equiv.injective
+    simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+      HexPolyZMathlib.toPolynomial_ofPolynomial]
+    exact hr
+  have hg_dvd_core : g ∣ core := zpoly_dvd_trans hg_dvd_cand hcand_dvd_core
+  exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core
 
 /-- Primitive + positive-leading-core variant of
 `exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd` (#4646 chain).

--- a/progress/20260518T224105Z_7d894bdb.md
+++ b/progress/20260518T224105Z_7d894bdb.md
@@ -1,0 +1,73 @@
+# 7d894bdb — HexLLL retry and BZMathlib cover-at-min (#4334, #4927)
+
+## Accomplished
+
+- Claimed feature issue #4334 after confirming the directive issues shown by
+  `coordination orient` are blocked and the only claimable unclaimed work item
+  was #4334.
+- Read the HexLLL Phase 4 issue body, `PLAN/Phase4.md`,
+  `SPEC/benchmarking.md`, `reports/hex-lll-performance.md`, and
+  `HexLLL/Bench.lean` to confirm the expected scientific benchmark evidence.
+- Ran `lake exe hexlll_bench verify`; all 52 registered HexLLL benchmarks
+  passed the smoke verifier.
+- Ran `lake exe hexlll_bench list`; all 52 registrations were listed.
+- Attempted the five affected scientific registrations on current HEAD
+  `d3b448f29b39`:
+  `runSizeReduceChecksum`, `runGramSchmidtCoeffChecksum`,
+  `runFirstShortVectorHarshCubicChecksum`, `runOfBasisHarshCubicChecksum`, and
+  `runFirstShortVectorRandomBoundedChecksum`.
+- The scientific run exited with code 2: all five registrations produced zero
+  verdict-eligible rows. Harness self-measured per-spawn floors were about
+  `1.154s` to `1.348s`, and the host load during the attempt stayed around
+  `13-15` one-minute load on `carica`.
+- Removed the failed generated artifact
+  `reports/bench-results/hex-lll-d3b448f29b39.json` and the transient
+  `.cache/oracles` setup cache.
+- Released #4334 with the concrete quiet-hardware blocker, then claimed
+  feature issue #4927 as the oldest unclaimed item and because it unblocks the
+  next BZMathlib abstract-bound tier.
+- Fast-forwarded from `d3b448f2` to `e09dfc76` so the landed #4924 dependency
+  (`exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_bound`)
+  was present locally.
+- Added
+  `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_bound`
+  in `HexBerlekampZassenhausMathlib/Basic.lean` and rewired the original
+  `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd` as the
+  default-bound wrapper.
+- Ran `lake build HexBerlekampZassenhausMathlib.Basic` and
+  `lake build HexBerlekampZassenhausMathlib`; both reached
+  `HexBerlekampZassenhausMathlib.Basic` and failed only with the known
+  pre-existing timeout / unknown-kernel-constant error set from this chain, with
+  no diagnostics at the new theorem.
+- Ran `python3 scripts/check_dag.py`, `git diff --check`, and the requested
+  grep for newly added `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`; all
+  passed.
+
+## Current frontier
+
+#4334 still needs a quiet or dedicated hardware run. This session reproduced
+the measurement-infrastructure blocker already documented in the issue: the
+spawn floor is too high for verdict-eligible rows under the current host load.
+
+#4927 deliverables are complete modulo the known ambient
+`HexBerlekampZassenhausMathlib.Basic` build failures documented in the issue
+body.
+
+## Next step
+
+Publish the #4927 PR. Retry #4334 only when the host is idle enough for a
+stable low spawn floor, or run the release-candidate benchmarking workflow on
+dedicated hardware. Then commit the successful artifact, update
+`reports/hex-lll-performance.md`, and consider the `HexLLL.done_through` Phase
+4 bump if all concerns are resolved.
+
+## Blockers
+
+- Current `carica` load is not quiet enough for the required scientific timing
+  evidence; the attempted run produced zero verdict-eligible rows for every
+  affected registration.
+- `HexBerlekampZassenhausMathlib.Basic` still has the known pre-existing
+  timeout / unknown-kernel-constant failures before and after this session's
+  #4927 change.
+- The worktree still contains a pre-existing `.claude/CLAUDE.md` modification
+  that this session did not touch.


### PR DESCRIPTION
Closes #4927

Session: `7d894bdb-6d63-4171-9954-2c935d8cc3e6`

050339aa feat: add cover-at-min abstract bound sibling

🤖 Prepared with Claude Code