### PR TITLE
BZMathlib: abstract-bound sibling of coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -11079,13 +11079,99 @@ theorem exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_prim
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hprecision hpartition htarget_dvd_core hTJ hrecord hquot hi
 
-/-- Primitive + positive-leading-core variant of
+/-- Abstract-bound primitive + positive-leading-core variant of
 `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd` (#4646 chain).
 
 Routes through
-`exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_primitive_pos_lc_core`
+`exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound`
 and
-`representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core`. -/
+`representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound`. -/
+theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound
+    {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
+    {J T : LiftedFactorSubset d}
+    (B' : Nat)
+    (hvalid : ∀ g : Hex.ZPoly,
+      HexPolyZMathlib.toPolynomial g ∈
+        UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial (recombinationCandidate d T)) →
+      ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (htarget_dvd_core : target ∣ core)
+    (hTJ : T ⊆ J)
+    (hne : J.Nonempty)
+    (hmin_in_T : J.min' hne ∈ T)
+    (hrecord :
+      Hex.shouldRecordPolynomialFactor (recombinationCandidate d T) = true)
+    (hquot :
+      Hex.exactQuotient? target (recombinationCandidate d T) = some quotient) :
+    ∃ (f : Hex.ZPoly) (S : LiftedFactorSubset d),
+      Irreducible (HexPolyZMathlib.toPolynomial f) ∧
+      f ∣ target ∧
+      S ⊆ J ∧ J.min' hne ∈ S ∧
+      RepresentsIntegerFactorAtLift core d f S ∧
+      S ⊆ T := by
+  obtain ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_cand, hSJ, hmin_in_S, hrep⟩ :=
+    exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound
+      B' hvalid hcore_ne hcore_primitive hcore_lc_pos hcore_lc_le
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hprecision hpartition htarget_dvd_core hTJ hrecord hquot hmin_in_T
+  have hvalid_f : ∀ i, (f.coeff i).natAbs ≤ B' := by
+    have hcand_poly_ne_zero :
+        HexPolyZMathlib.toPolynomial (recombinationCandidate d T) ≠ 0 :=
+      (toPolynomial_ne_zero_and_not_isUnit_of_shouldRecord hrecord).1
+    have hf_poly_dvd :
+        HexPolyZMathlib.toPolynomial f ∣
+          HexPolyZMathlib.toPolynomial (recombinationCandidate d T) := by
+      rcases hf_dvd_cand with ⟨r, hr⟩
+      refine ⟨HexPolyZMathlib.toPolynomial r, ?_⟩
+      rw [← HexPolyZMathlib.toPolynomial_mul, hr]
+    obtain ⟨gPoly, hg_mem, hg_assoc⟩ :=
+      UniqueFactorizationMonoid.exists_mem_normalizedFactors_of_dvd
+        hcand_poly_ne_zero hf_irr hf_poly_dvd
+    let g : Hex.ZPoly := HexPolyZMathlib.ofPolynomial gPoly
+    have hg_toPoly : HexPolyZMathlib.toPolynomial g = gPoly :=
+      HexPolyZMathlib.toPolynomial_ofPolynomial gPoly
+    have hg_bound : ∀ i, (g.coeff i).natAbs ≤ B' :=
+      hvalid g (by rw [hg_toPoly]; exact hg_mem)
+    obtain ⟨u, hu⟩ := hg_assoc
+    obtain ⟨c, hc_unit, hcu⟩ := Polynomial.isUnit_iff.mp u.isUnit
+    have hc_abs_one : c.natAbs = 1 := Int.isUnit_iff_natAbs_eq.mp hc_unit
+    intro i
+    have hg_coeff : g.coeff i = gPoly.coeff i := by
+      have := HexPolyZMathlib.coeff_toPolynomial g i
+      rw [hg_toPoly] at this
+      exact this.symm
+    have hgPoly_coeff_f : gPoly.coeff i = f.coeff i * c := by
+      have hmul : (HexPolyZMathlib.toPolynomial f * Polynomial.C c).coeff i =
+          (HexPolyZMathlib.toPolynomial f).coeff i * c :=
+        Polynomial.coeff_mul_C _ _ _
+      rw [← hu, ← hcu, hmul, HexPolyZMathlib.coeff_toPolynomial]
+    have hbound := hg_bound i
+    rw [hg_coeff, hgPoly_coeff_f, Int.natAbs_mul, hc_abs_one,
+      Nat.mul_one] at hbound
+    exact hbound
+  have hST : S ⊆ T :=
+    representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core_of_bound
+      B' hvalid_f hcore_ne hcore_primitive hcore_lc_pos hprecision
+      hpartition hTJ hf_irr hf_dvd_target hf_dvd_cand hSJ hrep
+  exact ⟨f, S, hf_irr, hf_dvd_target, hSJ, hmin_in_S, hrep, hST⟩
+
+/-- Primitive + positive-leading-core variant of
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd` (#4646 chain).
+
+This is the `defaultFactorCoeffBound core`-instantiated thin wrapper for
+`coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound`.
+-/
 theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core
     {core target quotient : Hex.ZPoly} {d : Hex.LiftData}
     {J T : LiftedFactorSubset d}
@@ -11113,16 +11199,41 @@ theorem coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_pr
       S ⊆ J ∧ J.min' hne ∈ S ∧
       RepresentsIntegerFactorAtLift core d f S ∧
       S ⊆ T := by
-  obtain ⟨f, S, hf_irr, hf_dvd_target, hf_dvd_cand, hSJ, hmin_in_S, hrep⟩ :=
-    exists_representingSubset_of_mem_T_of_recombinationCandidate_dvd_of_primitive_pos_lc_core
-      hcore_ne hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hprecision hpartition htarget_dvd_core
-      hTJ hrecord hquot hmin_in_T
-  have hST : S ⊆ T :=
-    representingSubset_subset_of_dvd_recombinationCandidate_of_primitive_pos_lc_core
-      hcore_ne hcore_primitive hcore_lc_pos hprecision hpartition hTJ hf_irr
-      hf_dvd_target hf_dvd_cand hSJ hrep
-  exact ⟨f, S, hf_irr, hf_dvd_target, hSJ, hmin_in_S, hrep, hST⟩
+  have hcand_dvd_target : recombinationCandidate d T ∣ target := by
+    have hmul : quotient * recombinationCandidate d T = target :=
+      Hex.exactQuotient?_product hquot
+    refine ⟨quotient, ?_⟩
+    rw [Hex.DensePoly.mul_comm_poly (S := Int)]
+    exact hmul.symm
+  have hcand_dvd_core : recombinationCandidate d T ∣ core := by
+    rcases hcand_dvd_target with ⟨r₁, hr₁⟩
+    rcases htarget_dvd_core with ⟨r₂, hr₂⟩
+    refine ⟨r₁ * r₂, ?_⟩
+    rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+  exact
+    coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound
+      (Hex.ZPoly.defaultFactorCoeffBound core)
+      (fun g hg_mem' i => by
+        have hg_poly_dvd : HexPolyZMathlib.toPolynomial g ∣
+            HexPolyZMathlib.toPolynomial (recombinationCandidate d T) :=
+          UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hg_mem'
+        have hg_dvd_cand : g ∣ recombinationCandidate d T := by
+          rcases hg_poly_dvd with ⟨r, hr⟩
+          refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+          apply HexPolyZMathlib.equiv.injective
+          simp only [HexPolyZMathlib.equiv_apply, HexPolyZMathlib.toPolynomial_mul,
+            HexPolyZMathlib.toPolynomial_ofPolynomial]
+          exact hr
+        have hg_dvd_core : g ∣ core := by
+          rcases hg_dvd_cand with ⟨r₁, hr₁⟩
+          rcases hcand_dvd_core with ⟨r₂, hr₂⟩
+          refine ⟨r₁ * r₂, ?_⟩
+          rw [hr₂, hr₁, Hex.DensePoly.mul_assoc_poly (S := Int)]
+        exact defaultFactorCoeffBound_valid core hcore_ne g hg_dvd_core i)
+      hcore_ne hcore_primitive hcore_lc_pos
+      (defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne)
+      hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
+      hprecision hpartition htarget_dvd_core hTJ hne hmin_in_T hrecord hquot
 
 /-- `Hex.normalizeFactorSign` preserves the content of a `Hex.ZPoly`: it either
 returns the input or scales by `-1`, both of which leave the content (the gcd

--- a/progress/20260518T230110Z_855b13b8.md
+++ b/progress/20260518T230110Z_855b13b8.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+- Claimed feature issue #4929.
+- Added
+  `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core_of_bound`
+  in `HexBerlekampZassenhausMathlib/Basic.lean`.
+- Rewired the existing
+  `coverAtMin_representingSubset_subset_of_recombinationCandidate_dvd_of_primitive_pos_lc_core`
+  theorem as a thin `defaultFactorCoeffBound core` wrapper.
+- Reused the existing normalized-factor association bridge pattern to derive
+  the single-factor coefficient bound for the extracted cover witness `f`.
+
+Verification:
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` reached through the edited
+  cover-at-min declarations, then failed in the pre-existing
+  `HexBerlekampZassenhausMathlib/Basic.lean` health areas: whnf heartbeat
+  timeouts, the dependent-elimination failure at line 5840, and unknown kernel
+  constants around the existing choose-prime-data lemmas.
+- `lake build HexBerlekampZassenhausMathlib` failed with the same
+  `HexBerlekampZassenhausMathlib.Basic` diagnostics.
+- `python3 scripts/check_dag.py` passed.
+- `git diff --check` passed.
+- `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean | grep -E '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)' || true`
+  produced no output.
+
+## Current frontier
+
+- #4929 deliverables are implemented for the primitive positive-leading-core
+  cover-at-min layer.
+- Downstream consumers continue to call the original theorem signature.
+
+## Next step
+
+- Publish the PR for #4929.
+- Follow-on issue #4951 can then lift the
+  `liftedFactorSubsetPartition_prefix_none_of_primitive_pos_lc_core` tier to
+  the abstract-bound shape.
+
+## Blockers
+
+- Full builds of `HexBerlekampZassenhausMathlib.Basic` and
+  `HexBerlekampZassenhausMathlib` remain blocked by pre-existing large-file
+  heartbeat and dependent unknown-constant failures.


### PR DESCRIPTION
Closes #4929

Session: `855b13b8-1f66-4863-ae86-2a7e2dbd44e2`

59422c5c feat: add primitive cover-at-min abstract bound

🤖 Prepared with Claude Code