### PR TITLE
HexGfqField Phase 6: add repr_one and toQuotient_neg/sub simp wrappers

### DIFF
--- a/HexGfqField/Operations.lean
+++ b/HexGfqField/Operations.lean
@@ -612,6 +612,21 @@ theorem natCast_eq_natCast_iff_mod_eq
       x.toQuotient * y.toQuotient :=
   rfl
 
+/-- Negation projects to the quotient-ring additive inverse. -/
+@[simp] theorem toQuotient_neg
+    {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
+    (x : FiniteField f hf hp hirr) :
+    (-x : FiniteField f hf hp hirr).toQuotient = -x.toQuotient :=
+  rfl
+
+/-- Subtraction projects to the quotient-ring difference. -/
+@[simp] theorem toQuotient_sub
+    {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
+    (x y : FiniteField f hf hp hirr) :
+    (x - y : FiniteField f hf hp hirr).toQuotient =
+      x.toQuotient - y.toQuotient :=
+  rfl
+
 @[simp] theorem toQuotient_nsmul
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (n : Nat) (x : FiniteField f hf hp hirr) :
@@ -708,6 +723,12 @@ theorem inv_mul_cancel
 @[simp] theorem repr_zero
     (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p) (hirr : FpPoly.Irreducible f) :
     repr (0 : FiniteField f hf hp hirr) = GFqRing.reduceMod f 0 :=
+  rfl
+
+/-- The multiplicative-identity representative is the reduced form of `1`. -/
+@[simp] theorem repr_one
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p) (hirr : FpPoly.Irreducible f) :
+    repr (1 : FiniteField f hf hp hirr) = GFqRing.reduceMod f 1 :=
   rfl
 
 @[simp] theorem repr_add

--- a/progress/20260518T231548Z_e8e99259.md
+++ b/progress/20260518T231548Z_e8e99259.md
@@ -1,0 +1,39 @@
+# 2026-05-18T23:15Z — feature session, issue #5158
+
+## Accomplished
+
+- Added three `@[simp]` canonical-form wrappers to
+  `HexGfqField/Operations.lean`:
+  - `repr_one` (placed after `repr_zero`)
+  - `toQuotient_neg` and `toQuotient_sub` (placed after
+    `toQuotient_mul`, before `toQuotient_nsmul`)
+- All three are `rfl` proofs symmetric with the existing
+  `toQuotient_add`/`toQuotient_mul`/`repr_zero` wrappers, made
+  possible by `Neg`/`Sub` instances pointing directly at `neg`/`sub`
+  (which themselves wrap `ofQuotient (-x.toQuotient)` /
+  `ofQuotient (x.toQuotient - y.toQuotient)`) and `toQuotient_ofQuotient`
+  being definitionally an `rfl`.
+- Verified `lake build HexGfqField.Operations`, full `lake build`,
+  `python3 scripts/check_dag.py`, and `git diff --check` all clean.
+  No new warnings introduced; the existing `unnecessarySimpa` warning
+  at the `mul_inv_cancel` `hmulReduce` block is pre-existing on
+  master (verified by stash-build comparison) and merely shifted line
+  number due to the inserted lemmas.
+
+## Current frontier
+
+`HexGfqField/Operations.lean` now mirrors the `repr_*` / `toQuotient_*`
+surface of its sibling `HexGfqRing/Operations.lean` for the
+unconditional operations. Conditional inverse wrappers
+(`toQuotient_inv_of_ne_zero`) remain the only non-uniform case, as
+expected.
+
+## Next step
+
+None for this issue. Future Phase 6 polish on this file might
+collapse the existing `simpa [hxrepr]` at line 686 to a plain `simp`,
+but that's a separate cleanup outside the issue scope.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5158

Session: `e8e99259-12ce-47fa-98e1-c0dd7135daec`

bf44baa1 feat: add HexGfqField repr_one and toQuotient_neg/sub simp wrappers

🤖 Prepared with Claude Code