### PR TITLE
HexPolyMathlib Phase 6: add toPolynomial_one, ofPolynomial_one, toPolynomial_neg, toPolynomial_sub simp wrappers

### DIFF
--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -213,6 +213,16 @@ theorem ofPolynomial_zero [Semiring R] [DecidableEq R] :
   intro n
   simp [coeff_ofPolynomial, Hex.DensePoly.coeff_zero]
 
+/-- `ofPolynomial` sends Mathlib's polynomial `1` to the executable constant `1`. -/
+@[simp]
+theorem ofPolynomial_one [Semiring R] [DecidableEq R] :
+    ofPolynomial (1 : Polynomial R) = 1 := by
+  show ofPolynomial (1 : Polynomial R) = Hex.DensePoly.C 1
+  apply Hex.DensePoly.ext_coeff
+  intro n
+  rw [coeff_ofPolynomial, Hex.DensePoly.coeff_C, Polynomial.coeff_one]
+  rfl
+
 @[simp]
 theorem toPolynomial_zero [Semiring R] [DecidableEq R] :
     toPolynomial (0 : Hex.DensePoly R) = 0 := by
@@ -229,6 +239,13 @@ theorem toPolynomial_C [Semiring R] [DecidableEq R] (c : R) :
   · simp [hn]
     rfl
 
+/-- `toPolynomial` sends the executable constant `1` to Mathlib's polynomial `1`. -/
+@[simp]
+theorem toPolynomial_one [Semiring R] [DecidableEq R] :
+    toPolynomial (1 : Hex.DensePoly R) = 1 := by
+  show toPolynomial (Hex.DensePoly.C 1) = 1
+  rw [toPolynomial_C, Polynomial.C_1]
+
 @[simp]
 theorem toPolynomial_add [Semiring R] [DecidableEq R] (p q : Hex.DensePoly R) :
     toPolynomial (p + q) = toPolynomial p + toPolynomial q := by
@@ -236,6 +253,24 @@ theorem toPolynomial_add [Semiring R] [DecidableEq R] (p q : Hex.DensePoly R) :
   rw [coeff_toPolynomial, Polynomial.coeff_add, coeff_toPolynomial, coeff_toPolynomial]
   exact Hex.DensePoly.coeff_add p q n (by
     show (0 : R) + (0 : R) = 0
+    simp)
+
+/-- `toPolynomial` commutes with executable polynomial negation. -/
+@[simp]
+theorem toPolynomial_neg [Ring R] [DecidableEq R] (p : Hex.DensePoly R) :
+    toPolynomial (-p) = -toPolynomial p := by
+  ext n
+  rw [coeff_toPolynomial, Polynomial.coeff_neg, coeff_toPolynomial,
+      Hex.DensePoly.coeff_neg p n (by show (0 : R) - 0 = 0; simp), zero_sub]
+
+/-- `toPolynomial` commutes with executable polynomial subtraction. -/
+@[simp]
+theorem toPolynomial_sub [Ring R] [DecidableEq R] (p q : Hex.DensePoly R) :
+    toPolynomial (p - q) = toPolynomial p - toPolynomial q := by
+  ext n
+  rw [coeff_toPolynomial, Polynomial.coeff_sub, coeff_toPolynomial, coeff_toPolynomial]
+  exact Hex.DensePoly.coeff_sub p q n (by
+    show (0 : R) - (0 : R) = 0
     simp)
 
 @[simp]

--- a/progress/20260518T234410Z_b3df603b.md
+++ b/progress/20260518T234410Z_b3df603b.md
@@ -1,0 +1,59 @@
+# HexPolyMathlib Phase 6: One / Neg / Sub bridge simp wrappers
+
+Session UUID prefix `b3df603b`. Issue #5166.
+
+## Accomplished
+
+Added four `@[simp]` wrappers in `HexPolyMathlib/Basic.lean` that close
+the Ring-level surface of the `Hex.DensePoly R ↔ Polynomial R` bridge:
+
+- `ofPolynomial_one` (`Semiring R`)
+- `toPolynomial_one` (`Semiring R`)
+- `toPolynomial_neg` (`Ring R`)
+- `toPolynomial_sub` (`Ring R`)
+
+All four ship with one-line docstrings, matching the existing
+`toPolynomial_zero` / `toPolynomial_add` cluster. The proofs use the
+executable-side `Hex.DensePoly.coeff_C`, `coeff_neg`, `coeff_sub`
+lemmas and the Mathlib-side `Polynomial.C_1`, `Polynomial.coeff_one`,
+`Polynomial.coeff_neg`, `Polynomial.coeff_sub`.
+
+`toPolynomial_one`'s proof depends on `toPolynomial_C`. The issue body
+suggested placing it immediately after `toPolynomial_zero`, but
+`toPolynomial_C` sits in between. I moved `toPolynomial_one` to come
+*after* `toPolynomial_C` so the forward reference resolves; the rest
+of the file ordering is unchanged.
+
+`ofPolynomial_one`'s closing goal after the obvious rewrite chain is
+`(if n = 0 then 1 else 0) = if n = 0 then 1 else Zero.zero`. The two
+sides are definitionally equal (the `Zero.zero` literal in
+`Hex.DensePoly.coeff_C` and the `0` literal in `Polynomial.coeff_one`
+unify), so a single `rfl` closes it.
+
+## Verification
+
+- `lake build HexPolyMathlib.Basic` — clean (9.8s)
+- `lake build HexPolyMathlib` — clean
+- `python3 scripts/check_dag.py` — clean
+- `git diff --check` — clean
+- `git diff -- HexPolyMathlib/Basic.lean | rg 'sorry|axiom|native_decide|TODO|FIXME'` — no matches
+
+## Current frontier
+
+The bridge is now total at `Ring` level for the additive-group and
+unit surface. Phase 6 of HexPolyMathlib has one less outstanding
+wrapper task.
+
+## Next step
+
+Open follow-ups for the bridge (out of scope for #5166):
+
+- migrating any consumers in `HexPolyMathlib/Euclid.lean` that
+  currently take indirect paths around `(1 : DensePoly R)` /
+  subtraction;
+- a `Polynomial.coeff_one` `@[simp]` upstream may collapse parts of
+  `ofPolynomial_one`'s proof further — not pursued here.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5166

Session: `b3df603b-3fe6-4b4d-98ea-79473d948530`

26edfced feat: add HexPolyMathlib one / neg / sub bridge simp wrappers

🤖 Prepared with Claude Code