### PR TITLE
fix HexPoly coeff_add_semiring / coeff_sub_ring / coeff_neg_ring wrappers to fire as rw/simp lemmas

### DIFF
--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -145,6 +145,18 @@ def neg [Sub R] (p : DensePoly R) : DensePoly R :=
 instance [Sub R] : Neg (DensePoly R) where
   neg := neg
 
+/-- Compatibility law for caller-facing `Zero`/`Add` instances used by semiring wrappers. -/
+class AddZeroLaw (S : Type u) [Zero S] [Add S] : Prop where
+  add_zero_zero : (Zero.zero : S) + (Zero.zero : S) = (Zero.zero : S)
+
+/-- Compatibility law for caller-facing `Zero`/`Sub` instances used by ring wrappers. -/
+class SubZeroLaw (S : Type u) [Zero S] [Sub S] : Prop where
+  sub_zero_zero : (Zero.zero : S) - (Zero.zero : S) = (Zero.zero : S)
+
+/-- Compatibility law for caller-facing `Zero`/`Sub`/`Neg` instances used by negation wrappers. -/
+class ZeroSubNegLaw (S : Type u) [Zero S] [Sub S] [Neg S] : Prop where
+  zero_sub_eq_neg : ∀ a : S, (Zero.zero : S) - a = -a
+
 /-- Schoolbook dense polynomial multiplication by direct coefficient convolution. -/
 def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
   if p.isZero || q.isZero then 0 else
@@ -354,10 +366,10 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
 
 /-- Semiring-specialized coefficient law for addition. -/
 @[simp] theorem coeff_add_semiring {S : Type u}
-    [Lean.Grind.Semiring S] [DecidableEq S]
+    [Zero S] [Add S] [Lean.Grind.Semiring S] [DecidableEq S] [AddZeroLaw S]
     (p q : DensePoly S) (n : Nat) :
     (p + q).coeff n = p.coeff n + q.coeff n :=
-  coeff_add p q n (by grind)
+  coeff_add p q n AddZeroLaw.add_zero_zero
 
 /-- Coefficient law for subtraction. The explicit zero law is needed because the generic
 `Sub`/`Zero` interface does not imply `0 - 0 = 0`. -/
@@ -377,10 +389,10 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
 
 /-- Ring-specialized coefficient law for subtraction. -/
 @[simp] theorem coeff_sub_ring {S : Type u}
-    [Lean.Grind.Ring S] [DecidableEq S]
+    [Zero S] [Sub S] [Lean.Grind.Ring S] [DecidableEq S] [SubZeroLaw S]
     (p q : DensePoly S) (n : Nat) :
     (p - q).coeff n = p.coeff n - q.coeff n :=
-  coeff_sub p q n (by grind)
+  coeff_sub p q n SubZeroLaw.sub_zero_zero
 
 /-- The zero polynomial has coefficient `0` at every index. -/
 @[simp] theorem coeff_zero (n : Nat) :
@@ -397,12 +409,13 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
 
 /-- Ring-specialized coefficient law for negation. -/
 @[simp] theorem coeff_neg_ring {S : Type u}
-    [Lean.Grind.Ring S] [DecidableEq S]
+    [Zero S] [Sub S] [Neg S] [Lean.Grind.Ring S] [DecidableEq S] [SubZeroLaw S]
+    [ZeroSubNegLaw S]
     (p : DensePoly S) (n : Nat) :
     (-p).coeff n = -(p.coeff n) := by
-  have h := coeff_neg p n (by grind : (0 : S) - 0 = 0)
+  have h := coeff_neg p n SubZeroLaw.sub_zero_zero
   rw [h]
-  grind
+  exact ZeroSubNegLaw.zero_sub_eq_neg (p.coeff n)
 
 /-- Horner evaluation sends the zero dense polynomial to `0`. -/
 @[simp] theorem eval_zero [Add R] [Mul R] (x : R) :

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -49,6 +49,58 @@ instance : DecidableEq (ZMod64 p) := by
       apply h
       exact congrArg ZMod64.val hab)
 
+instance : DensePoly.AddZeroLaw (ZMod64 p) where
+  add_zero_zero := by
+    rw [eq_iff_toNat_eq]
+    change (ZMod64.add ZMod64.zero ZMod64.zero).toNat = ZMod64.zero.toNat
+    rw [toNat_add, toNat_zero]
+    exact Nat.zero_mod p
+
+instance : DensePoly.SubZeroLaw (ZMod64 p) where
+  sub_zero_zero := by
+    rw [eq_iff_toNat_eq]
+    change (ZMod64.sub ZMod64.zero ZMod64.zero).toNat = ZMod64.zero.toNat
+    rw [toNat_sub, toNat_zero]
+    simp
+
+instance : DensePoly.ZeroSubNegLaw (ZMod64 p) where
+  zero_sub_eq_neg := by
+    intro a
+    rw [eq_iff_toNat_eq]
+    change (ZMod64.sub ZMod64.zero a).toNat = (ZMod64.neg a).toNat
+    rw [toNat_sub, toNat_neg, toNat_zero]
+    simp [Nat.zero_add]
+
+private theorem coeff_add_semiring_rw_smoke (a b : ZMod64 p) (n : Nat) :
+    (DensePoly.C a + DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
+      (DensePoly.C a).coeff n + (DensePoly.C b).coeff n := by
+  rw [DensePoly.coeff_add_semiring]
+
+private theorem coeff_add_semiring_simp_smoke (a b : ZMod64 p) (n : Nat) :
+    (DensePoly.C a + DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
+      (DensePoly.C a).coeff n + (DensePoly.C b).coeff n := by
+  simp
+
+private theorem coeff_sub_ring_rw_smoke (a b : ZMod64 p) (n : Nat) :
+    (DensePoly.C a - DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
+      (DensePoly.C a).coeff n - (DensePoly.C b).coeff n := by
+  rw [DensePoly.coeff_sub_ring]
+
+private theorem coeff_sub_ring_simp_smoke (a b : ZMod64 p) (n : Nat) :
+    (DensePoly.C a - DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
+      (DensePoly.C a).coeff n - (DensePoly.C b).coeff n := by
+  simp
+
+private theorem coeff_neg_ring_rw_smoke (a : ZMod64 p) (n : Nat) :
+    (-DensePoly.C a : DensePoly (ZMod64 p)).coeff n =
+      -((DensePoly.C a).coeff n) := by
+  rw [DensePoly.coeff_neg_ring]
+
+private theorem coeff_neg_ring_simp_smoke (a : ZMod64 p) (n : Nat) :
+    (-DensePoly.C a : DensePoly (ZMod64 p)).coeff n =
+      -((DensePoly.C a).coeff n) := by
+  simp
+
 private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
     let qr := DensePoly.divMod f g
     qr.1 * g + qr.2 = f := by

--- a/progress/20260519T005253Z_3e692a3a.md
+++ b/progress/20260519T005253Z_3e692a3a.md
@@ -1,0 +1,33 @@
+# 2026-05-19T00:52Z — feature session, issue #5184
+
+## Accomplished
+
+- Reworked the `DensePoly.coeff_add_semiring`, `coeff_sub_ring`, and
+  `coeff_neg_ring` wrappers so their left-hand sides use the caller-facing
+  `Zero` / `Add` / `Sub` / `Neg` instances rather than only the operation
+  projections supplied by `Lean.Grind.Semiring` / `Lean.Grind.Ring`.
+- Added small compatibility typeclasses in `HexPoly/Operations.lean` for the
+  zero/add, zero/sub, and zero/sub/neg laws needed by those wrappers.
+- Added the corresponding `ZMod64 p` compatibility instances in
+  `HexPolyFp/Basic.lean`.
+- Added private build-time smoke theorems in `HexPolyFp/Basic.lean` proving
+  that `rw [DensePoly.coeff_add_semiring]`,
+  `rw [DensePoly.coeff_sub_ring]`, and
+  `rw [DensePoly.coeff_neg_ring]` fire on the concrete `FpPoly`-style
+  constant-polynomial goals that exposed the issue.
+- Added matching `simp` smoke theorems for the same three wrappers.
+
+## Current frontier
+
+The wrapper-level issue is fixed and verified. The downstream call-site
+migration issues can now use the wrappers as `rw` lemmas.
+
+## Next step
+
+Resume the queued `HexPolyFp` migrations, starting with the blocked
+`Compose.lean`, `Quotient.lean`, `QuotientFrobenius.lean`, `Basic.lean`, and
+`SquareFree.lean` issues.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5184

Session: `3e692a3a-eb19-4077-b769-14b344f62339`

b01e1ed2 fix: make coeff wrappers rewrite over caller instances

🤖 Prepared with Claude Code