### PR TITLE
refactor: migrate HexPolyFp/Compose.lean to coeff_*_ring simp wrappers

### DIFF
--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -189,33 +189,27 @@ Small `C` homomorphism laws for `+`, `-`, `*` and `Neg` are needed to
 manipulate the coefficients of products like `f * (X - C c)`.
 -/
 
-private theorem zmod64_add_zero_zero_local :
-    (0 : ZMod64 p) + 0 = 0 := by grind
-
-private theorem zmod64_sub_zero_zero_local :
-    (0 : ZMod64 p) - 0 = 0 := by grind
-
 theorem C_add_eq (a b : ZMod64 p) :
     (DensePoly.C (a + b) : FpPoly p) = DensePoly.C a + DensePoly.C b := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_C, DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local,
+  rw [DensePoly.coeff_C, DensePoly.coeff_add_semiring,
     DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => grind
   | succ n =>
-      exact zmod64_add_zero_zero_local.symm
+      exact (by grind : (0 : ZMod64 p) + 0 = 0).symm
 
 theorem C_sub_eq (a b : ZMod64 p) :
     (DensePoly.C (a - b) : FpPoly p) = DensePoly.C a - DensePoly.C b := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_C, DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local,
+  rw [DensePoly.coeff_C, DensePoly.coeff_sub_ring,
     DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => grind
   | succ n =>
-      exact zmod64_sub_zero_zero_local.symm
+      exact (by grind : (0 : ZMod64 p) - 0 = 0).symm
 
 theorem C_mul_C_eq (a b : ZMod64 p) :
     (DensePoly.C (a * b) : FpPoly p) = DensePoly.C a * DensePoly.C b := by
@@ -477,12 +471,12 @@ private theorem fp_add_sub_add_sub
     (x - y) + (u - v) = (x + u) - (y + v) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
-  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
-  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
-  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
-  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
-  rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_add_semiring]
   grind
 
 private theorem composeCoeffPowerSumUpTo_sub
@@ -522,12 +516,12 @@ private theorem fp_size_sub_le
     (f - h).size ≤ max f.size h.size := by
   apply fp_size_le_of_coeff_eq_zero_from
   intro i hi
-  rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+  rw [DensePoly.coeff_sub_ring]
   rw [DensePoly.coeff_eq_zero_of_size_le f
       (Nat.le_trans (Nat.le_max_left f.size h.size) hi),
     DensePoly.coeff_eq_zero_of_size_le h
       (Nat.le_trans (Nat.le_max_right f.size h.size) hi)]
-  exact zmod64_sub_zero_zero_local
+  exact (by grind : (0 : ZMod64 p) - 0 = 0)
 
 /-- `compose` distributes over subtraction. -/
 theorem compose_sub [ZMod64.PrimeModulus p] (f h w : FpPoly p) :
@@ -543,7 +537,7 @@ theorem compose_sub [ZMod64.PrimeModulus p] (f h w : FpPoly p) :
       (fun i => (f - h).coeff i) =
         (fun i => f.coeff i - h.coeff i) := by
     funext i
-    rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+    rw [DensePoly.coeff_sub_ring]
   rw [hcoeff]
   exact composeCoeffPowerSumUpTo_sub f h w bound 0
 
@@ -797,7 +791,6 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
   apply DensePoly.ext_coeff
   intro n
   have hzero_sub : (0 : ZMod64 p) - 0 = 0 := by grind
-  have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind
   have hzero_mul_c : c * (0 : ZMod64 p) = 0 := by grind
   -- LHS computation
   have hLHS : (a * (FpPoly.X - FpPoly.C c)).coeff n =
@@ -807,7 +800,7 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
       show (0 - FpPoly.C c) * a = 0 - FpPoly.C c * a
       exact DensePoly.neg_mul_right_poly (FpPoly.C c) a
     rw [sub_eq_add_neg, right_distrib]
-    rw [DensePoly.coeff_add _ _ _ hzero_add]
+    rw [DensePoly.coeff_add_semiring]
     rw [hneg_mul]
     rw [DensePoly.coeff_neg _ _ hzero_sub]
     rw [show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl]
@@ -936,7 +929,7 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
       rfl
   | n + 1, base, k => by
       simp only [composeCoeffPowerSumUpTo]
-      rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+      rw [DensePoly.coeff_add_semiring]
       rw [composeCoeffPowerSumUpTo_X_coeff coeff n (base + 1) k]
       rw [show FpPoly.linearPow (FpPoly.X : FpPoly p) base
               = DensePoly.monomial base (1 : ZMod64 p) from
@@ -952,8 +945,8 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
         rw [hzz]; grind
       rw [DensePoly.coeff_scale _ _ _ hmul_zero]
       rw [DensePoly.coeff_monomial]
-      have hzz_add : (Zero.zero : ZMod64 p) + Zero.zero = Zero.zero :=
-        zmod64_add_zero_zero_local
+      have hzz_add : (Zero.zero : ZMod64 p) + Zero.zero = Zero.zero := by
+        grind
       by_cases hk_base : k = base
       · rw [if_pos hk_base]
         have hneg' : ¬ (base + 1 ≤ k ∧ k < base + 1 + n) := by

--- a/progress/20260519T013837Z_377e6030.md
+++ b/progress/20260519T013837Z_377e6030.md
@@ -1,0 +1,78 @@
+# Progress: migrate HexPolyFp/Compose.lean to coeff_*_ring simp wrappers
+
+Issue: #5180. Branch: `agent/377e6030`.
+
+## Accomplished
+
+- Replaced all 12 explicit-zero-law `rw` call sites in
+  `HexPolyFp/Compose.lean` with the typeclass-specialized simp
+  wrappers from `HexPoly/Operations.lean` (`coeff_add_semiring`,
+  `coeff_sub_ring`):
+  - `coeff_add` → `coeff_add_semiring`: 6 sites (lines previously
+    202, 480, 484, 485, 810, 939).
+  - `coeff_sub` → `coeff_sub_ring`: 6 sites (lines previously 213,
+    481, 482, 483, 525, 546).
+- Re-proved the three non-`rw` leaves that were `exact
+  zmod64_(add|sub)_zero_zero_local(.symm)?` as inline
+  `(by grind : (0 : ZMod64 p) ± 0 = 0)(.symm)?` proofs. The inline
+  form is necessary because, after the `coeff_*_ring` rewrites, the
+  residual goal is in `Zero.zero` form rather than `OfNat.ofNat 0`
+  form, and `grind` does not propagate the typeclass `Zero.zero`
+  through the ring's additive structure. Stating the inline fact
+  with notation-level `0` lets the standard `grind` discharge fire,
+  and the `.symm` (where needed) is the same as the original.
+- Rewrote the standalone `hzz_add : (Zero.zero : ZMod64 p) +
+  Zero.zero = Zero.zero` fact in `composeCoeffPowerSumUpTo_X_coeff`
+  to use `by grind` directly (no inline `(0 : ZMod64 p)` form
+  needed, since this `have` is at notation-level `Zero.zero`
+  throughout).
+- Deleted the two `private theorem zmod64_(add|sub)_zero_zero_local`
+  helpers near the top of the namespace; no references remain.
+- Deleted the now-unused local
+  `have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind` in
+  `mul_X_sub_C_eq_ofCoeffs_mulXSubCList` (the only consumer was the
+  migrated line-810 `rw`). `hzero_sub` and `hzero_mul_c` remain in
+  place; they still service the unchanged `coeff_neg` and
+  `coeff_scale` call sites.
+
+## Verification
+
+- `lake build HexPolyFp.Compose` — 88/88 jobs, no errors, no
+  warnings.
+- `lake build HexPolyFp` — 94/94 jobs, no errors, no warnings.
+- `lake build` (full) — 244/244 jobs, no errors, no warnings.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git diff -- HexPolyFp/Compose.lean | rg -nE
+  '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'` — no matches.
+- `git grep -c 'DensePoly.coeff_add _ _ _\|DensePoly.coeff_sub _ _ _'
+  HexPolyFp/Compose.lean` — 0 (all generic-shape `coeff_(add|sub)`
+  call sites in this file are gone).
+- `git grep -n 'zmod64_add_zero_zero_local\|zmod64_sub_zero_zero_local'
+  HexPolyFp/Compose.lean` — empty.
+- Diff stat: 17 lines added / 24 lines removed (net −7 lines), well
+  within the issue's expected ~50/~12 envelope. The smaller delta
+  reflects that the issue's allowance for retaining the helpers
+  ("if any reference remains that genuinely needs the generic-`Add`
+  form") was not needed — all 12 `rw` sites and all 3 `exact`
+  leaves migrated cleanly.
+
+## Current frontier
+
+The HexPolyFp call-site migration to `coeff_*_ring` wrappers is now
+complete for `Compose.lean`. The three sibling review issues —
+`#5181` (Quotient.lean + QuotientFrobenius.lean), `#5182`
+(Basic.lean), and `#5183` (SquareFree.lean) — remain unclaimed.
+
+## Next step
+
+A follow-up worker can claim any of `#5181`, `#5182`, `#5183` for
+the same wrapper migration on the remaining HexPolyFp files. The
+`Zero.zero`-form residual-goal pattern surfaced in this PR (which
+required inline `(0 : ZMod64 p) ± 0 = 0` for leaves after rewriting)
+is likely to recur in those files and is worth noting up front for
+the next session.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5180

Session: `377e6030-2a57-404f-9741-f9031dd41786`

f047d62d refactor: migrate HexPolyFp/Compose.lean to coeff_*_ring simp wrappers (#5180)

🤖 Prepared with Claude Code