### PR TITLE
BZMathlib: abstract-bound sibling of monic recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -14767,6 +14767,52 @@ private theorem scaledRecombinationSearchModAux_some_and_covers_of_liftedFactorS
     htarget_primitive htarget_lc_pos htarget_dvd_core hpartition hmatches hfuel
 
 /--
+Abstract-bound variant of
+`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`:
+the concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` Mignotte
+precision is replaced by `2 * B' < d.p ^ d.k` against an abstract bound
+`B'`, paired with the leading-coefficient bound on `core` and the
+universal divisor coefficient bound `∀ g ∣ core, ∀ i, (g.coeff i).natAbs
+≤ B'`. Thin wrapper over
+`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound`
+that extracts the per-factor coverage at the supplied `factor`.
+-/
+theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+    {core target factor : Hex.ZPoly} {d : Hex.LiftData}
+    {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
+    (B' : Nat)
+    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (hvalid : ∀ g : Hex.ZPoly, g ∣ core → ∀ i, (g.coeff i).natAbs ≤ B')
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hd_modulus : 2 ≤ d.p ^ d.k)
+    (hd_liftedFactor_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hd_liftedFactor_natDegree_pos :
+      ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
+    (hd_liftedFactor_inj : Function.Injective (liftedFactor d))
+    (hprecision : 2 * B' < d.p ^ d.k)
+    (htarget_monic : Hex.DensePoly.Monic target)
+    (htarget_dvd_core : target ∣ core)
+    (hpartition : LiftedFactorSubsetPartition core d J target)
+    (hmatches : LiftedFactorListMatches d J localFactors)
+    (hfactor_irr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (hfactor_dvd_target : factor ∣ target)
+    (hfuel : J.card < fuel) :
+    ∃ result,
+      Hex.recombinationSearchModAux target (d.p ^ d.k) localFactors fuel =
+        some result ∧
+      ∃ emitted ∈ result,
+        Associated (HexPolyZMathlib.toPolynomial emitted)
+          (HexPolyZMathlib.toPolynomial factor) := by
+  obtain ⟨result, hresult, hcovers⟩ :=
+    recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound
+      B' hvalid hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+      hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
+      htarget_monic htarget_dvd_core hpartition hmatches hfuel
+  exact ⟨result, hresult, hcovers factor hfactor_irr hfactor_dvd_target⟩
+
+/--
 Recursive coverage capstone for `Hex.recombinationSearchModAux` (#4301).
 
 Given a `LiftedFactorSubsetPartition core d J target` rest-state predicate at
@@ -14774,9 +14820,12 @@ a recursive recombination level, and an irreducible integer divisor `factor`
 of `target`, the executable recombination search returns `some result` with
 `factor` (up to `Associated`) among the emitted candidates.
 
-Thin wrapper around the universally-quantified auxiliary
-`recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition`,
-which carries out the actual fuel-based induction. -/
+Thin wrapper over
+`recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`
+that instantiates `B' := Hex.ZPoly.defaultFactorCoeffBound core` and
+discharges the abstract bound hypotheses via
+`defaultFactorCoeffBound_leadingCoeff_natAbs_le` paired with
+`defaultFactorCoeffBound_valid`. -/
 theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
@@ -14802,12 +14851,15 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
       ∃ emitted ∈ result,
         Associated (HexPolyZMathlib.toPolynomial emitted)
           (HexPolyZMathlib.toPolynomial factor) := by
-  obtain ⟨result, hresult, hcovers⟩ :=
-    recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition
-      hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
-      hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
-      htarget_monic htarget_dvd_core hpartition hmatches hfuel
-  exact ⟨result, hresult, hcovers factor hfactor_irr hfactor_dvd_target⟩
+  have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
+  exact recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound core)
+    hcore_lc_le
+    (defaultFactorCoeffBound_valid core hcore_ne)
+    hcore_ne hcore_monic hd_modulus hd_liftedFactor_monic
+    hd_liftedFactor_natDegree_pos hd_liftedFactor_inj hprecision
+    htarget_monic htarget_dvd_core hpartition hmatches
+    hfactor_irr hfactor_dvd_target hfuel
 
 /--
 Abstract-bound variant of

--- a/progress/20260519T013923Z_ff10a839.md
+++ b/progress/20260519T013923Z_ff10a839.md
@@ -1,0 +1,69 @@
+# Progress: monic `_some_factor_associated_..._of_bound` public sibling
+
+Issue: #5196. Branch: `agent/ff10a839-e623-4b07-9e47-159390ef0df3`.
+
+## Accomplished
+
+- Added
+  `recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition_of_bound`
+  to `HexBerlekampZassenhausMathlib/Basic.lean`, inserted immediately
+  before the existing public monic
+  `recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`.
+  Signature mirrors the scaled `_of_bound` precedent at line 14823: the
+  concrete `2 * defaultFactorCoeffBound core < d.p ^ d.k` precision is
+  replaced by the abstract triple `B' : Nat`, `hcore_lc_le`,
+  `hvalid : ∀ g ∣ core, ∀ i, (g.coeff i).natAbs ≤ B'`, and
+  `hprecision : 2 * B' < d.p ^ d.k`. The monic-side hypotheses
+  (`hcore_monic`, `htarget_monic`) are unchanged. Body is a thin
+  wrapper over
+  `recombinationSearchModAux_some_and_covers_of_liftedFactorSubsetPartition_of_bound`
+  followed by `⟨result, hresult, hcovers factor hfactor_irr
+  hfactor_dvd_target⟩` — structurally identical to the scaled
+  `_of_bound` body. `hcore_lc_le` is carried by the signature for API
+  parallelism with the scaled and unscaled-primitive `_of_bound`
+  siblings (the underlying monic `_some_and_covers_..._of_bound` does
+  not need it).
+- Rewired the existing
+  `recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPartition`
+  as a thin delegator into the new `_of_bound` sibling, passing
+  `B' := Hex.ZPoly.defaultFactorCoeffBound core` and discharging
+  `hcore_lc_le` via `defaultFactorCoeffBound_leadingCoeff_natAbs_le
+  hcore_ne` and `hvalid` via `defaultFactorCoeffBound_valid core
+  hcore_ne`. The wrapper signature is unchanged; the existing downstream
+  consumers of the wrapper continue to type-check.
+- Updated the wrapper docstring to note its new thin-wrapper status
+  over the `_of_bound` sibling.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` — 18 errors,
+  matching baseline `origin/main` exactly. Post-insertion errors
+  shifted by +52 lines (the net insertion size); all pre-insertion
+  errors at lines 4927/5161/5469/5556/5603/5840/5939/6084/6228/6247/
+  6562/6626 are unchanged. No new errors at the new `_of_bound`
+  (line ~14778) or the rewired wrapper (line ~14829).
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git diff origin/main -- HexBerlekampZassenhausMathlib/Basic.lean
+  | grep -E "^\+.*\b(sorry|axiom|native_decide|TODO|FIXME)\b"` —
+  no matches.
+
+## Current frontier
+
+The monic-side A2 abstract-bound propagation has now climbed past the
+public per-factor-associated layer in `Basic.lean`. The trio of
+`_of_bound` `_some_factor_associated_` public siblings (monic,
+unscaled-primitive, scaled) is now complete on this surface.
+
+## Next step
+
+Continue the A2 abstract-bound propagation cycle into the
+exhaustive-coverage layer in
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean`, which consumes
+the `_some_factor_associated_` wrapper at the monic surface.
+
+## Blockers
+
+None for this issue. The broader `Basic.lean` module remains red on
+the host due to pre-existing whnf timeouts and unknown
+kernel-constant errors; CI is the authority on full typecheck.


### PR DESCRIPTION
Closes #5196

Session: `ff10a839-e623-4b07-9e47-159390ef0df3`

01b209d6 feat: add monic recombinationSearchModAux _some_factor_associated_ _of_bound sibling (#5196)

🤖 Prepared with Claude Code