### PR TITLE
review: migrate HexPolyFp/SquareFree.lean to coeff_*_ring simp wrappers

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -244,9 +244,8 @@ private theorem scale_add_scalar (c d : ZMod64 p) (f : FpPoly p) :
   have hzero_cd : (c + d) * (0 : ZMod64 p) = 0 := by grind
   have hzero_c : c * (0 : ZMod64 p) = 0 := by grind
   have hzero_d : d * (0 : ZMod64 p) = 0 := by grind
-  have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind
   rw [DensePoly.coeff_scale _ _ _ hzero_cd]
-  rw [DensePoly.coeff_add _ _ _ hzero_add]
+  rw [DensePoly.coeff_add_semiring]
   rw [DensePoly.coeff_scale _ _ _ hzero_c]
   rw [DensePoly.coeff_scale _ _ _ hzero_d]
   grind
@@ -492,8 +491,7 @@ private theorem powLinearBinomSum_succ_row
       rw [← hdistL]
       apply DensePoly.ext_coeff
       intro i
-      have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind
-      repeat rw [DensePoly.coeff_add _ _ _ hzero_add]
+      repeat rw [DensePoly.coeff_add_semiring]
       grind
 
 private theorem powLinearBinomTerm_above
@@ -788,7 +786,7 @@ private theorem coeff_foldl_coeffTerm_coeff
   | cons i xs ih =>
       simp only [List.foldl_cons]
       rw [ih (acc + coeffTerm g i)]
-      rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_coeff]
+      rw [DensePoly.coeff_add_semiring]
 
 private theorem coeffFold_coeff_index_fold (g : FpPoly p) (m n : Nat) :
     (coeffFold g m).coeff n =
@@ -868,7 +866,7 @@ private theorem coeffFold_coeff (g : FpPoly p) (m n : Nat) :
       simp only [List.foldl_cons, List.foldl_nil]
       change ((List.range m).foldl (fun acc i => acc + coeffTerm g i) 0 +
           coeffTerm g m).coeff n = if n < m + 1 then g.coeff n else 0
-      rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_coeff]
+      rw [DensePoly.coeff_add_semiring]
       change (coeffFold g m).coeff n + (coeffTerm g m).coeff n =
         if n < m + 1 then g.coeff n else 0
       rw [ih, coeffTerm_coeff]
@@ -1019,7 +1017,7 @@ private theorem coeffFoldPowerCoeff_prime_coeff
         rw [List.range_succ, List.foldl_append]
         simp only [List.foldl_cons, List.foldl_nil]
       rw [hsucc, powLinear_add_prime hp,
-        DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_coeff,
+        DensePoly.coeff_add_semiring,
         ih, powLinear_coeffTerm_coeff]
       by_cases hmod : n % p = 0
       · rw [if_pos hmod, if_pos hmod]
@@ -1092,7 +1090,7 @@ private theorem powLinear_add_prime_coeff
     (powLinear (f + g) p).coeff n =
       (powLinear f p).coeff n + (powLinear g p).coeff n := by
   rw [powLinear_add_prime hp f g]
-  exact DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_coeff
+  exact DensePoly.coeff_add_semiring _ _ _
 
 /--
 Freshman's-dream coefficient support for a `p`th power over `F_p[x]`.

--- a/progress/20260519T014821Z_1e547ebd.md
+++ b/progress/20260519T014821Z_1e547ebd.md
@@ -1,0 +1,54 @@
+# 20260519T014821Z — Migrate HexPolyFp/SquareFree to coeff_add_semiring
+
+## Accomplished
+
+Claimed #5183 and migrated the six `DensePoly.coeff_add _ _ _ <hyp>`
+call sites in `HexPolyFp/SquareFree.lean` to the typeclass-specialized
+simp wrapper `DensePoly.coeff_add_semiring`:
+
+- Line 249 (`scale_add_scalar`) and line 496 (`powLinearBinomSum_succ_row`):
+  replaced the `rw` and deleted the local `have hzero_add` declaration.
+- Lines 791 (`coeff_foldl_coeffTerm_coeff`), 871 (`coeffFold_coeff`), and
+  1022 (`coeffFoldPowerCoeff_prime_coeff`): swapped the helper-threaded
+  rewrite for the wrapper. At 1022 only the offending entry in the
+  chained `rw [...]` was changed.
+- Line 1095 (`powLinear_add_prime_coeff`): rewrote
+  `exact DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_coeff` to
+  `exact DensePoly.coeff_add_semiring _ _ _` so the implicits unify
+  against the explicit arguments.
+
+The `private theorem zmod64_add_zero_zero_coeff` declaration stays in
+place because three residual leaf-uses (lines 889, 1054, 1063 after the
+edit) consume it directly as the term `(0 : ZMod64 p) + 0 = 0`, not via
+the additive-coefficient rewrite path. Those usages are out of scope
+for this migration.
+
+Verification:
+
+- `lake build HexPolyFp.SquareFree`
+- `lake build HexPolyFp`
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `git grep -c 'DensePoly\.coeff_add _ _ _' HexPolyFp/SquareFree.lean`
+  drops from 6 to 0.
+- `git grep -n 'have hzero_add' HexPolyFp/SquareFree.lean` reports
+  nothing.
+- `git diff -- HexPolyFp/SquareFree.lean | rg -n
+  'sorry|axiom|native_decide|TODO|FIXME'` produces no matches.
+
+## Current frontier
+
+`HexPolyFp/SquareFree.lean` no longer threads an explicit `0 + 0 = 0`
+hypothesis through `coeff_add`. Sibling files `Compose.lean` (#5180,
+already has-pr) and `Quotient.lean`/`QuotientFrobenius.lean` (#5181)
+still carry the same plumbing.
+
+## Next step
+
+Open the PR for #5183 and exit. The unclaimed companion issue #5181
+remains available for a follow-up session.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5183

Session: `1e547ebd-c6eb-4aa3-87f9-3fb8455dc3ab`

5a09bd2d refactor: migrate HexPolyFp/SquareFree to coeff_add_semiring

🤖 Prepared with Claude Code