### PR TITLE
review: migrate HexPolyFp/Quotient.lean and QuotientFrobenius.lean to coeff_*_ring simp wrappers

### DIFF
--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -1790,36 +1790,30 @@ private theorem eval_eq_coeff_power_sum_upTo_bound (f : FpPoly p)
     (fun i hi => DensePoly.coeff_eq_zero_of_size_le f hi) extra
 
 omit [ZMod64.PrimeModulus p] in
-private theorem zmod64_add_zero_zero_local :
-    (0 : ZMod64 p) + 0 = 0 := by grind
-
-omit [ZMod64.PrimeModulus p] in
-private theorem zmod64_sub_zero_zero_local :
-    (0 : ZMod64 p) - 0 = 0 := by grind
-
-omit [ZMod64.PrimeModulus p] in
 private theorem C_add_eq (a b : ZMod64 p) :
     (DensePoly.C (a + b) : FpPoly p) = DensePoly.C a + DensePoly.C b := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_C, DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local,
+  rw [DensePoly.coeff_C, DensePoly.coeff_add_semiring,
     DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => grind
   | succ n =>
-      exact zmod64_add_zero_zero_local.symm
+      show (0 : ZMod64 p) = 0 + 0
+      grind
 
 omit [ZMod64.PrimeModulus p] in
 private theorem C_sub_eq (a b : ZMod64 p) :
     (DensePoly.C (a - b) : FpPoly p) = DensePoly.C a - DensePoly.C b := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_C, DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local,
+  rw [DensePoly.coeff_C, DensePoly.coeff_sub_ring,
     DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => grind
   | succ n =>
-      exact zmod64_sub_zero_zero_local.symm
+      show (0 : ZMod64 p) = 0 - 0
+      grind
 
 omit [ZMod64.PrimeModulus p] in
 private theorem C_mul_C_eq (a b : ZMod64 p) :
@@ -1983,19 +1977,20 @@ private theorem eval_add_core_by_coeff_power_sum
         (fun i => (f + h).coeff i) =
           (fun i => f.coeff i + h.coeff i) := by
       funext i
-      rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+      rw [DensePoly.coeff_add_semiring]
     rw [hcoeff]
     exact evalCoeffPowerSumUpTo_add
       (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β bound 0
   · change (f + h).size ≤ max f.size h.size
     apply size_le_of_coeff_eq_zero_from_local
     intro i hi
-    rw [DensePoly.coeff_add _ _ _ zmod64_add_zero_zero_local]
+    rw [DensePoly.coeff_add_semiring]
     rw [DensePoly.coeff_eq_zero_of_size_le f
         (Nat.le_trans (Nat.le_max_left f.size h.size) hi),
       DensePoly.coeff_eq_zero_of_size_le h
         (Nat.le_trans (Nat.le_max_right f.size h.size) hi)]
-    exact zmod64_add_zero_zero_local
+    show (0 : ZMod64 p) + 0 = 0
+    grind
 
 private theorem eval_sub_core_by_coeff_power_sum
     (f h : FpPoly p) (β : Quotient g hmonic hg_pos) :
@@ -2016,19 +2011,20 @@ private theorem eval_sub_core_by_coeff_power_sum
         (fun i => (f - h).coeff i) =
           (fun i => f.coeff i - h.coeff i) := by
       funext i
-      rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+      rw [DensePoly.coeff_sub_ring]
     rw [hcoeff]
     exact evalCoeffPowerSumUpTo_sub
       (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f h β bound 0
   · change (f - h).size ≤ max f.size h.size
     apply size_le_of_coeff_eq_zero_from_local
     intro i hi
-    rw [DensePoly.coeff_sub _ _ _ zmod64_sub_zero_zero_local]
+    rw [DensePoly.coeff_sub_ring]
     rw [DensePoly.coeff_eq_zero_of_size_le f
         (Nat.le_trans (Nat.le_max_left f.size h.size) hi),
       DensePoly.coeff_eq_zero_of_size_le h
         (Nat.le_trans (Nat.le_max_right f.size h.size) hi)]
-    exact zmod64_sub_zero_zero_local
+    show (0 : ZMod64 p) - 0 = 0
+    grind
 
 private theorem eval_C_mul_core_by_coeff_power_sum
     (c : ZMod64 p) (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
@@ -2818,12 +2814,11 @@ private theorem monomial_pPow_sub_X_ne_zero {r : Nat} (hr_pos : 0 < r) :
   have hp_pow_gt_one : 1 < p ^ r := Nat.pow_lt_pow_right hp_gt_one hr_pos
   have hpow_ne_one : p ^ r ≠ 1 := by omega
   have hcoeff := congrArg (fun f : FpPoly p => f.coeff (p ^ r)) hzero
-  have hzero_sub : (0 : ZMod64 p) - 0 = 0 := by grind
   change
       (DensePoly.monomial (p ^ r) (1 : ZMod64 p) -
           DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p).coeff (p ^ r) =
         (0 : FpPoly p).coeff (p ^ r) at hcoeff
-  rw [DensePoly.coeff_sub _ _ _ hzero_sub, DensePoly.coeff_monomial,
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_monomial,
     DensePoly.coeff_monomial, DensePoly.coeff_zero] at hcoeff
   simp [hpow_ne_one] at hcoeff
   have hone_zero : (1 : ZMod64 p) = 0 := by
@@ -2847,11 +2842,10 @@ private theorem monomial_pPow_sub_X_size_sub_one_le {r : Nat} (hr_pos : 0 < r) :
     intro i hi
     have hi_ne_pow : i ≠ p ^ r := by omega
     have hi_ne_one : i ≠ 1 := by omega
-    have hzero_sub : (0 : ZMod64 p) - 0 = 0 := by grind
     change
         (DensePoly.monomial (p ^ r) (1 : ZMod64 p) -
             DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p).coeff i = 0
-    rw [DensePoly.coeff_sub _ _ _ hzero_sub, DensePoly.coeff_monomial,
+    rw [DensePoly.coeff_sub_ring, DensePoly.coeff_monomial,
       DensePoly.coeff_monomial]
     simp [hi_ne_pow, hi_ne_one]
     grind

--- a/HexPolyFp/QuotientFrobenius.lean
+++ b/HexPolyFp/QuotientFrobenius.lean
@@ -286,10 +286,9 @@ private theorem coeff_fpPolyMonoSum (f : FpPoly p) (m k : Nat) :
       rw [if_neg hk]
       rfl
   | succ m ih =>
-      have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind
       show (fpPolyMonoSum f m + DensePoly.monomial m (f.coeff m)).coeff k =
         if k < m + 1 then f.coeff k else 0
-      rw [DensePoly.coeff_add _ _ _ hzero_add]
+      rw [DensePoly.coeff_add_semiring]
       rw [ih]
       rw [DensePoly.coeff_monomial m (f.coeff m) k]
       by_cases hk_lt_m : k < m

--- a/progress/20260519T014929Z_e845f934.md
+++ b/progress/20260519T014929Z_e845f934.md
@@ -1,0 +1,54 @@
+# Migrate Quotient.lean / QuotientFrobenius.lean to coeff_*_ring wrappers
+
+## Accomplished
+
+Closed issue #5181: migrated the 9 generic
+`DensePoly.coeff_add _ _ _ <zero-law>` / `coeff_sub _ _ _ <zero-law>`
+rewrites in `HexPolyFp/Quotient.lean` and
+`HexPolyFp/QuotientFrobenius.lean` to the typeclass-specialized
+`coeff_add_semiring` / `coeff_sub_ring` simp wrappers introduced in
+#5169 and made rewrite-friendly in #5188.
+
+- `HexPolyFp/QuotientFrobenius.lean`: dropped the inline
+  `have hzero_add : (0 : ZMod64 p) + 0 = 0 := by grind`; the one
+  `rw [DensePoly.coeff_add _ _ _ hzero_add]` becomes
+  `rw [DensePoly.coeff_add_semiring]`.
+- `HexPolyFp/Quotient.lean`: replaced all 6 call sites that fed
+  `zmod64_add_zero_zero_local` / `zmod64_sub_zero_zero_local` into
+  the generic coefficient laws, deleted the two now-unreferenced
+  `private theorem` helpers, and migrated the two inline
+  `have hzero_sub` patterns in
+  `monomial_pPow_sub_X_ne_zero` /
+  `monomial_pPow_sub_X_size_sub_one_le`.
+
+Trailing `exact zmod64_..._local{.symm}` /
+`exact zmod64_..._local` leaves were replaced by a `grind` —
+but `grind` was choosing the `Int` ring on its own and needed a
+`show (0 : ZMod64 p) = 0 + 0` (resp. `+/-`) to anchor the
+type. Four `show` lines were added for this reason. Net diff:
+`+17 / -24` across the two files.
+
+The `have hzero_sub : (0 : Quotient g hmonic hg_pos) - 0 = 0`
+near line 2287 was left alone — it is the issue-flagged
+out-of-scope site (Quotient-algebra subtraction, not a
+DensePoly coefficient law).
+
+## Current frontier
+
+- `lake build` green (244 jobs).
+- `python3 scripts/check_dag.py` green.
+- `git diff --check` green.
+- `git grep 'DensePoly.coeff_add _ _ _\|DensePoly.coeff_sub _ _ _' HexPolyFp/Quotient.lean HexPolyFp/QuotientFrobenius.lean`
+  reports zero matches.
+
+## Next step
+
+PR closes #5181. Sibling issues #5180 (`Compose.lean`) and #5183
+(`SquareFree.lean`) are still open; both should adopt the same
+`show (0 : ZMod64 p) ... ; grind` anchor when `grind` picks the
+wrong ring after the coefficient-law rewrite collapses to a
+constant equation.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5181

Session: `e845f934-9193-4feb-95c3-ef61571deec1`

8ccab7ac refactor: migrate Quotient and QuotientFrobenius to coeff_*_ring wrappers

🤖 Prepared with Claude Code