### PR TITLE
review: compose bhks_bad_vector_resultant_lower_bound from badVector_resultant_bounds_of_bhks_bad

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -617,6 +617,25 @@ theorem badVector_resultant_bounds_of_bhks_bad
     (coprime_input_aux_over_rat_of_bhks_bad W h_bad)
     (resultant_divisible_by_p_pow_of_bhks_bad W h_bad)
 
+/-- BHKS Lemma 3.2, resultant chain form: the modular divisor lower bound and
+the Hadamard upper bound combine to a single real-valued inequality on
+`(p ^ (k · d) : ℝ)` and the BHKS l2-norm product, with the integer resultant
+absent from the conclusion.
+
+Used by the BHKS Theorem 5.2 separation argument; the auxiliary polynomial's
+`l2norm` side is controlled separately by `auxiliaryPolynomial_l2norm_sq_le`. -/
+theorem bhks_bad_vector_resultant_lower_bound
+    (W : ExecutableBadVectorWitness)
+    (h_bad : IsBhksBadVectorSetup W)
+    (hp : 0 < W.liftData.p) :
+    (W.liftData.p ^ (W.liftData.k * W.localFactorDegree) : ℝ) ≤
+      (HexPolyZMathlib.l2norm W.inputPolynomial) ^
+          W.auxiliaryPolynomial.natDegree *
+        (HexPolyZMathlib.l2norm W.auxiliaryPolynomial) ^
+          W.inputPolynomial.natDegree := by
+  exact (W.badVector_resultant_bounds_of_bhks_bad h_bad hp).1.trans
+    (W.badVector_resultant_bounds_of_bhks_bad h_bad hp).2
+
 /--
 Combined BHKS Lemma 3.2 contradiction: an executable bad-vector witness whose
 `H` field is the canonical BHKS auxiliary polynomial of a vector in `L' \ W`

--- a/progress/20260519T020727Z_8af6586c.md
+++ b/progress/20260519T020727Z_8af6586c.md
@@ -1,0 +1,40 @@
+# 2026-05-19 02:07 UTC — review session
+
+Session UUID: 8af6586c-36c8-445d-a650-7abe31266871
+Claimed issue: #5201
+Branch: agent/8af6586c
+
+## Accomplished
+
+- Added `ExecutableBadVectorWitness.bhks_bad_vector_resultant_lower_bound`
+  in `HexBerlekampZassenhausMathlib/BadVector.lean` between
+  `badVector_resultant_bounds_of_bhks_bad` and
+  `no_bhks_bad_setup_of_l2norm_upper_lt_divisor`. The new theorem composes
+  the two halves of the existing conjunction into a chained inequality
+  `(p ^ (k * d) : ℝ) ≤ ‖f‖₂ ^ deg H_v · ‖H_v‖₂ ^ deg f`, with the integer
+  resultant cancelled from the conclusion. Proof body matches the
+  issue's proposal verbatim; the double invocation of
+  `badVector_resultant_bounds_of_bhks_bad` typechecks directly with no
+  `let`-sharing needed.
+- `lake build HexBerlekampZassenhausMathlib.BadVector` succeeds.
+
+## Current frontier
+
+Step 1 of the three-issue prerequisite split from
+`reports/bhks-bad-vector-theorem-shape.md §3` is now landed. Steps 2-4
+(`auxiliaryPolynomial_l2norm_sq_le`,
+`bhks_bad_vector_norm_sq_gt_cutRadiusSq4_of_paperThreshold_le`,
+`factorFast_terminates`) remain on the BHKS D1 critical path.
+
+## Next step
+
+A planner can spin up the feature issue for step 2
+(`auxiliaryPolynomial_l2norm_sq_le` Cauchy-Schwarz bound) now that
+step 1 has landed.
+
+## Blockers
+
+Pre-existing breakage on `HexBerlekampZassenhausMathlib.Basic.lean`
+(whnf timeouts at lines 16142/16253, kernel unknown-constant errors at
+lines 16441/16487) reproduced from origin/main both with and without
+this change. Not introduced by this session and not in scope.


### PR DESCRIPTION
Closes #5201

Session: `8af6586c-36c8-445d-a650-7abe31266871`

8a321750 feat: compose bhks_bad_vector_resultant_lower_bound from BHKS Lemma 3.2 bounds

🤖 Prepared with Claude Code