### PR TITLE
review: migrate residual coeff_neg / coeff_add sites in Compose.lean and HexGfqRing/Operations.lean

### DIFF
--- a/HexGfqRing/Operations.lean
+++ b/HexGfqRing/Operations.lean
@@ -684,22 +684,6 @@ nsmul's representative and `repr x`. -/
     repr (nsmul (n + 1) x) = reduceMod f (repr (nsmul n x) + repr x) := by
   rw [nsmul_succ, repr_add]
 
-private theorem zmod64_zero_add (a : ZMod64 p) : (0 : ZMod64 p) + a = a := by
-  change ZMod64.add 0 a = a
-  apply ZMod64.ext
-  apply UInt64.toNat_inj.mp
-  change (ZMod64.add 0 a).toNat = a.toNat
-  have h := ZMod64.toNat_add (0 : ZMod64 p) a
-  have hmod : a.val.toNat % p = a.val.toNat := Nat.mod_eq_of_lt a.isLt
-  have hz : (ZMod64.val (0 : ZMod64 p)).toNat = 0 := by
-    simpa [ZMod64.toNat_eq_val] using (ZMod64.toNat_zero (p := p))
-  rw [h]
-  rw [ZMod64.toNat_eq_val, ZMod64.toNat_eq_val, hz, Nat.zero_add, hmod]
-
-private theorem zmod64_zero_add_zero :
-    (Zero.zero : ZMod64 p) + (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p) :=
-  zmod64_zero_add Zero.zero
-
 private theorem fpPoly_C_add (a b : ZMod64 p) :
     FpPoly.C (a + b) = (FpPoly.C a + FpPoly.C b : FpPoly p) := by
   apply DensePoly.ext_coeff
@@ -708,15 +692,16 @@ private theorem fpPoly_C_add (a b : ZMod64 p) :
   · subst i
     change DensePoly.coeff (DensePoly.C (a + b)) 0 =
       DensePoly.coeff (DensePoly.C a + DensePoly.C b) 0
-    rw [DensePoly.coeff_add _ _ _ zmod64_zero_add_zero, DensePoly.coeff_C,
+    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
       DensePoly.coeff_C, DensePoly.coeff_C]
     simp
   · change DensePoly.coeff (DensePoly.C (a + b)) i =
       DensePoly.coeff (DensePoly.C a + DensePoly.C b) i
-    rw [DensePoly.coeff_add _ _ _ zmod64_zero_add_zero, DensePoly.coeff_C,
+    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
       DensePoly.coeff_C, DensePoly.coeff_C]
     simp [hi]
-    exact (zmod64_zero_add (p := p) (0 : ZMod64 p)).symm
+    show (0 : ZMod64 p) = 0 + 0
+    grind
 
 private theorem const_add (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a b : ZMod64 p) :
     const f hf (a + b) = const f hf a + const f hf b := by

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -790,7 +790,6 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
       DensePoly.ofCoeffs (mulXSubCList c a.toArray.toList).toArray := by
   apply DensePoly.ext_coeff
   intro n
-  have hzero_sub : (0 : ZMod64 p) - 0 = 0 := by grind
   have hzero_mul_c : c * (0 : ZMod64 p) = 0 := by grind
   -- LHS computation
   have hLHS : (a * (FpPoly.X - FpPoly.C c)).coeff n =
@@ -802,7 +801,7 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
     rw [sub_eq_add_neg, right_distrib]
     rw [DensePoly.coeff_add_semiring]
     rw [hneg_mul]
-    rw [DensePoly.coeff_neg _ _ hzero_sub]
+    rw [DensePoly.coeff_neg_ring]
     rw [show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl]
     rw [coeff_monomial_mul]
     have hCmul : FpPoly.C c * a = DensePoly.scale c a := FpPoly.C_mul_eq_scale c a

--- a/progress/20260519T022251Z_f51e3e9f.md
+++ b/progress/20260519T022251Z_f51e3e9f.md
@@ -1,0 +1,44 @@
+# Migrate residual coeff_neg / coeff_add sites — issue #5209
+
+Session: f51e3e9f-b62c-40bc-a7ef-83c5c3b70b27, type review/feature
+worker.
+
+## Accomplished
+
+- `HexPolyFp/Compose.lean`: replaced `DensePoly.coeff_neg _ _
+  hzero_sub` at the single residual call site (inside
+  `mul_X_sub_C_eq_ofCoeffs_mulXSubCList`) with the `coeff_neg_ring`
+  simp wrapper; deleted the now-unused `have hzero_sub : (0 : ZMod64 p)
+  - 0 = 0 := by grind`. Left `hzero_mul_c` intact — it still feeds
+  `coeff_scale` at the next rewrite.
+- `HexGfqRing/Operations.lean`: migrated both `coeff_add` call sites
+  in `fpPoly_C_add` to `coeff_add_semiring`. The post-`simp [hi]`
+  residual goal at the `i ≠ 0` branch had previously been closed by
+  `exact (zmod64_zero_add (p := p) 0).symm`; now closed by `show
+  (0 : ZMod64 p) = 0 + 0; grind` (the anchor pattern from #5203
+  — `grind` without the anchor picked the wrong ring, as expected).
+  Deleted both private helpers `zmod64_zero_add` and
+  `zmod64_zero_add_zero`; `git grep zmod64_zero_add HexGfqRing/`
+  empty.
+- `lake build` 244/244 green; `python3 scripts/check_dag.py` exit
+  0; `git diff --check` clean; net diff 5 ins / 21 del across the
+  two files; no `sorry` / `axiom` / `native_decide` introduced;
+  no remaining `DensePoly.coeff_(add|sub|neg) _ _ _` shape rewrites
+  in either file.
+
+## Current frontier
+
+Per the issue's framing, after this PR the only file still carrying
+generic-shape `coeff_*` rewrites is `HexHensel/Linear.lean`, which
+uses `ZPoly = DensePoly Int` and requires separate `AddZeroLaw Int`
+/ `SubZeroLaw Int` instance work (explicitly out of scope here).
+
+## Next step
+
+Hand off to the auto-merge queue. If a planner wants the
+`HexHensel/Linear.lean` migration to follow this series, the
+instance work for `Int` is the prerequisite.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5209

Session: `f51e3e9f-b62c-40bc-a7ef-83c5c3b70b27`

26cc9094 refactor: migrate residual coeff_neg / coeff_add sites in Compose.lean and Operations.lean (#5209)

🤖 Prepared with Claude Code