### PR TITLE
HexGfq Phase 6: add GFq repr_zero and repr_one wrappers

### DIFF
--- a/HexGfq/Basic.lean
+++ b/HexGfq/Basic.lean
@@ -254,6 +254,18 @@ representatives agree. -/
     repr (ofPoly h g) = GFqRing.reduceMod (modulus h) g :=
   rfl
 
+/-- The canonical representative of `0` in `GFq` is reduction of `0` modulo
+the selected Conway polynomial. -/
+@[simp] theorem repr_zero (h : Conway.SupportedEntry p n) :
+    repr (0 : GFq p n h) = GFqRing.reduceMod (modulus h) 0 :=
+  rfl
+
+/-- The canonical representative of `1` in `GFq` is reduction of `1` modulo
+the selected Conway polynomial. -/
+@[simp] theorem repr_one (h : Conway.SupportedEntry p n) :
+    repr (1 : GFq p n h) = GFqRing.reduceMod (modulus h) 1 :=
+  rfl
+
 /-- Two `GFq.ofPoly` constructors produce the same field element exactly when
 their inputs have the same reduced representative modulo the selected Conway
 polynomial. -/

--- a/progress/20260519T035857Z_1006d85f.md
+++ b/progress/20260519T035857Z_1006d85f.md
@@ -1,0 +1,33 @@
+# GFq neutral representative wrappers — issue #5242
+
+Session: 1006d85f-368f-4dee-b9b0-966edb92345a, type work/feature worker.
+
+## Accomplished
+
+- Claimed #5242 after confirming no unclaimed directive issue preempted it.
+- Added `GFq.repr_zero` and `GFq.repr_one` in `HexGfq/Basic.lean`, immediately
+  after `GFq.repr_ofPoly`, as `@[simp]` wrappers over the selected Conway
+  modulus.
+- Verified:
+  - `lake build HexGfq.Basic`
+  - `lake build HexGfq`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n '^@\[simp\] theorem repr_(zero|one)\b' HexGfq/Basic.lean`
+  - Scoped forbidden-token diff check for `HexGfq/Basic.lean`
+
+## Current frontier
+
+The generic `GFq` convenience layer now exposes neutral-element representative
+normalization lemmas matching the underlying `HexGfqField` API.
+
+## Next step
+
+Open the PR for #5242. The sibling packed-binary `GF2q` wrappers in #5241 remain
+available as independent follow-up work.
+
+## Blockers
+
+None for this issue. The worktree still contains a pre-existing unrelated
+modification to `.claude/CLAUDE.md`; this session did not touch it.


### PR DESCRIPTION
Closes #5242

Session: `1006d85f-368f-4dee-b9b0-966edb92345a`

d2cba47d feat: add GFq neutral repr wrappers

🤖 Prepared with Claude Code