### PR TITLE
HexGfq Phase 6: add GF2q repr_zero and repr_one wrappers

### DIFF
--- a/HexGfq/Basic.lean
+++ b/HexGfq/Basic.lean
@@ -372,6 +372,60 @@ agree. -/
         (hirr := h.packed_irreducible) w).val :=
   rfl
 
+/-- The packed representative of `0` in `GF2q` is the zero word. -/
+@[simp] theorem repr_zero :
+    repr (0 : GF2q n) = 0 :=
+  rfl
+
+/-- The packed representative of `1` in `GF2q` is the one word. -/
+@[simp] theorem repr_one :
+    repr (1 : GF2q n) = 1 := by
+  show GF2Poly.canonicalWordLT n h.degree_lt_word
+      (GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1)) = 1
+  have hn1 : 1 < 2 ^ n :=
+    calc 1 = 2 ^ 0 := by decide
+      _ < 2 ^ n := Nat.pow_lt_pow_right (by decide) h.degree_pos
+  -- `ofUInt64 1 = (1 : GF2Poly)`, and `1 % modulus = 1` since `1.degree < modulus.degree = n`.
+  have hmod : (1 : GF2Poly) % GF2Poly.ofUInt64Monic h.lower n = 1 :=
+    GF2Poly.mod_eq_self_of_reduced 1 _ <| Or.inr <| by
+      rw [GF2Poly.degree_ofUInt64Monic_of_lt_64 h.lower h.degree_lt_word]
+      exact h.degree_pos
+  -- Hence `ofUInt64 (packedReduceWord ... (ofUInt64 1)) = 1` as polynomials.
+  have hpoly :
+      GF2Poly.ofUInt64
+          (GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1)) = 1 := by
+    rw [GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt
+      h.degree_lt_word (GF2Poly.ofUInt64 1) (Or.inr ?_)]
+    · show (1 : GF2Poly) % GF2Poly.ofUInt64Monic h.lower n = 1
+      exact hmod
+    · show ((1 : GF2Poly) % GF2Poly.ofUInt64Monic h.lower n).degree < n
+      rw [hmod]; exact h.degree_pos
+  -- Compare the single stored words: both `ofUInt64 _` and `ofUInt64 1` equal `ofWords #[1]`.
+  have hword :
+      GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1) = 1 := by
+    by_cases hw0 :
+        GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1) = 0
+    · exfalso
+      have hbad : GF2Poly.ofUInt64 0 = (1 : GF2Poly) := hw0 ▸ hpoly
+      have : (GF2Poly.ofUInt64 0).words = (1 : GF2Poly).words := congrArg GF2Poly.words hbad
+      revert this; decide
+    · have hwords :
+          (#[GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1)] :
+            Array UInt64) = #[1] := by
+        have hwords' := congrArg GF2Poly.words hpoly
+        rw [show GF2Poly.ofUInt64
+            (GF2Poly.packedReduceWord n h.lower (GF2Poly.ofUInt64 1)) =
+              GF2Poly.ofWords #[GF2Poly.packedReduceWord n h.lower
+                (GF2Poly.ofUInt64 1)] from rfl,
+          GF2Poly.words_ofWords_single_nonzero hw0] at hwords'
+        exact hwords'
+      have h0 := congrArg (fun a => a[0]?) hwords
+      simpa using h0
+  rw [hword]
+  -- Finally: `canonicalWordLT n hn64 1 = 1` since `1.toNat < 2 ^ n`.
+  apply UInt64.toNat_inj.mp
+  simp [GF2Poly.canonicalWordLT, Nat.mod_eq_of_lt hn1]
+
 end GF2q
 
 end Hex

--- a/progress/20260519T041227Z_347ff594.md
+++ b/progress/20260519T041227Z_347ff594.md
@@ -1,0 +1,33 @@
+# Session 347ff594 — feature work on #5241
+
+## Accomplished
+
+- Closed issue #5241: added `Hex.GF2q.repr_zero` and `Hex.GF2q.repr_one`
+  simp wrappers in `HexGfq/Basic.lean`, after the existing `repr_ofWord`
+  declaration.
+- `repr_zero` is `rfl`; `(0 : GF2q n).val` reduces directly through
+  `Zero.zero = GF2n.zero = ⟨0, _⟩`.
+- `repr_one` required a longer proof. `(1 : GF2q n)` elaborates via
+  `One.one = GF2n.one = GF2n.reduce 1`, whose `.val` is
+  `canonicalWordLT n hn64 (packedReduceWord n irr (ofUInt64 1))`. The
+  private `GF2Poly.canonicalWordLT_eq_self_of_lt` and
+  `GF2Poly.ofUInt64_injective` cannot be reused, so the proof inlines the
+  equivalents: routes through the public
+  `ofUInt64_packedReduceWord_eq_of_degree_lt` to get a polynomial-level
+  equality, then peels back to a single-word `Array UInt64` equality via
+  `words_ofWords_single_nonzero`.
+- `lake build HexGfq.Basic`, full `lake build`, `python3
+  scripts/check_dag.py`, and `git diff --check` all pass; the grep
+  verifying both `@[simp] theorem repr_(zero|one)` declarations succeeds.
+
+## Current frontier
+
+PR for #5241 ready to push.
+
+## Next step
+
+Push branch `agent/347ff594` and `coordination create-pr 5241`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5241

Session: `347ff594-e9a4-4b2f-8e17-ce91e56bf0f7`

d4aa741d feat: add GF2q repr_zero and repr_one simp wrappers

🤖 Prepared with Claude Code