### PR TITLE
HexGfq Phase 6: add GF2q repr_add and repr_mul wrappers

### DIFF
--- a/HexGfq/Basic.lean
+++ b/HexGfq/Basic.lean
@@ -438,6 +438,28 @@ agree. -/
   apply UInt64.toNat_inj.mp
   simp [GF2Poly.canonicalWordLT, Nat.mod_eq_of_lt hn1]
 
+/-- The packed representative of a sum is the reduced XOR of representatives. -/
+@[simp] theorem repr_add (x y : GF2q n) :
+    repr (x + y) =
+      (GF2n.reduce
+        (n := n) (irr := h.lower)
+        (hn := h.degree_pos) (hn64 := h.degree_lt_word)
+        (hirr := h.packed_irreducible)
+        (repr x ^^^ repr y)).val :=
+  rfl
+
+/-- The packed representative of a product is the reduced carry-less product
+of representatives. -/
+@[simp] theorem repr_mul (x y : GF2q n) :
+    repr (x * y) =
+      (let product := Hex.clmul (repr x) (repr y)
+       GF2n.reduceWide
+        (n := n) (irr := h.lower)
+        (hn := h.degree_pos) (hn64 := h.degree_lt_word)
+        (hirr := h.packed_irreducible)
+        product.1 product.2).val := by
+  rfl
+
 end GF2q
 
 end Hex

--- a/progress/20260519T044854Z_05b1fb3f.md
+++ b/progress/20260519T044854Z_05b1fb3f.md
@@ -1,0 +1,32 @@
+# Session 05b1fb3f — GF2q representative wrappers
+
+## Accomplished
+
+Claimed issue #5258 and added `Hex.GF2q.repr_add` and
+`Hex.GF2q.repr_mul` to `HexGfq/Basic.lean`.  The new simp lemmas expose the
+packed representative of GF(2^n) addition as reduced XOR and multiplication as
+reduced carry-less product, matching the underlying `GF2n` executable backend.
+
+Verification completed:
+
+- `lake build HexGfq.Basic`
+- `lake build HexGfq`
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `rg -n '^@\[simp\] theorem repr_(add|mul)\b' HexGfq/Basic.lean`
+- `git diff -- HexGfq/Basic.lean | rg -n '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+`GF2q` now has add/mul representative normalization.  The sibling neg/sub
+wrappers from issue #5260 are the natural next API polish step and can build on
+the same local shape.
+
+## Next step
+
+Claim #5260 and add `GF2q.repr_neg` / `GF2q.repr_sub` near the new wrappers.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5258

Session: `05b1fb3f-e69a-4bd9-a685-a350724bacf9`

fde73525 HexGfq: add GF2q repr add/mul wrappers

🤖 Prepared with Claude Code