### PR TITLE
HexPolyMathlib Phase 6: add @[simp] to natDegree_toPolynomial and leadingCoeff_toPolynomial

### DIFF
--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -370,6 +370,7 @@ theorem ofPolynomial_mul [CommRing R] [DecidableEq R] (p q : Polynomial R) :
     ofPolynomial (p * q) = ofPolynomial p * ofPolynomial q :=
   map_mul (equiv (R := R)).symm p q
 
+@[simp]
 theorem natDegree_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R) :
     (toPolynomial p).natDegree = p.degree?.getD 0 := by
   by_cases hsize : p.size = 0
@@ -393,6 +394,7 @@ theorem natDegree_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R
       rw [coeff_toPolynomial]
       exact Hex.DensePoly.coeff_last_ne_zero_of_pos_size p hpos
 
+@[simp]
 theorem leadingCoeff_toPolynomial [Semiring R] [DecidableEq R]
     (p : Hex.DensePoly R) :
     (toPolynomial p).leadingCoeff = p.leadingCoeff := by

--- a/progress/20260519T050630Z_e5e69aa5.md
+++ b/progress/20260519T050630Z_e5e69aa5.md
@@ -1,0 +1,37 @@
+# Session e5e69aa5 — feature worker
+
+## Accomplished
+
+- Skipped #5267 (`HexPolyMathlib Phase 6: add pow bridge simp wrappers`):
+  the deliverable as written does not typecheck. The proposed
+  `toPolynomial (p ^ n)` where `p : Hex.DensePoly R` requires an
+  `HPow (Hex.DensePoly R) Nat` instance, which does not exist under
+  `[Semiring R]` (or `[CommRing R]`). `HexPoly/Operations.lean` and
+  `HexPoly/Euclid.lean` install only `Add`, `Sub`, `Neg`, `Mul`, `One`,
+  `Div`, `Mod`, `Dvd`. `HexPolyZ/Basic.lean` explicitly works around
+  this with a private `ratPolyPow` recursion. The 2026-05-05 progress
+  note `progress/20260505T032857Z_16a6a05c.md` already flagged this and
+  listed adding `Monoid (DensePoly R)` as out of scope. Issue body's
+  "Missing infrastructure: none" assumption is wrong.
+- Closed #5270 (`HexPolyMathlib Phase 6: add @[simp] to
+  natDegree_toPolynomial and leadingCoeff_toPolynomial`): added
+  `@[simp]` attribute to the two existing theorems at
+  `HexPolyMathlib/Basic.lean` lines 373 and 396. No statement or proof
+  changes. Full `lake build` green; `scripts/check_dag.py` clean.
+
+## Current frontier
+
+- HexPolyMathlib Phase 6 simp-wrapper polish continues with #5257
+  (`ofPolynomial_monomial`), #5259 (`toPolynomial_monomial`) currently
+  in flight, plus the now-`replan` #5267.
+
+## Next step
+
+- A planner re-scopes #5267 — either as a prerequisite
+  `add Monoid (Hex.DensePoly R) instance` issue, a reformulation in
+  terms of a manually-defined `Hex.DensePoly.pow` recursion, or closure
+  if powers are not currently needed.
+
+## Blockers
+
+None for this session's deliverables.


### PR DESCRIPTION
Closes #5270

Session: `e5e69aa5-a6f7-460e-bdae-ef9c7db1a2cf`

a09a9d15 feat: mark natDegree_toPolynomial and leadingCoeff_toPolynomial as @[simp]

🤖 Prepared with Claude Code