### PR TITLE
HexGfq Phase 6: add GFq.repr_inv_of_ne_zero simp wrapper

### DIFF
--- a/HexGfq/Basic.lean
+++ b/HexGfq/Basic.lean
@@ -314,6 +314,21 @@ quotient-ring integer-cast representative. -/
         ((i : GFqRing.PolyQuotient (modulus h) (modulus_nonconstant h))) :=
   rfl
 
+/-- The canonical representative of a nonzero inverse in `GFq` is the inverse
+polynomial representative reduced through the selected Conway modulus. -/
+@[simp] theorem repr_inv_of_ne_zero {h : Conway.SupportedEntry p n}
+    {x : GFq p n h} (hx : x ≠ 0) :
+    repr (x⁻¹ : GFq p n h) =
+      GFqRing.repr
+        (GFqRing.ofPoly (modulus h) (modulus_nonconstant h)
+          (GFqField.invPoly x.toQuotient)) := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime h.prime
+  simpa using
+    (GFqField.repr_inv_of_ne_zero
+      (f := modulus h) (hf := modulus_nonconstant h)
+      (hp := modulus_prime h) (hirr := modulus_irreducible h)
+      (x := x) hx)
+
 /-- Two `GFq.ofPoly` constructors produce the same field element exactly when
 their inputs have the same reduced representative modulo the selected Conway
 polynomial. -/

--- a/HexGfqField/Operations.lean
+++ b/HexGfqField/Operations.lean
@@ -75,9 +75,12 @@ def zsmul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f
     (i : Int) (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (i • x.toQuotient)
 
-/-- Normalize an extended-GCD witness by the gcd's constant-unit factor so the
-left coefficient becomes a genuine inverse candidate modulo `f`. -/
-private def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+/-- The inverse polynomial representative for a quotient element.
+
+This normalizes the extended-GCD left coefficient by the gcd's constant-unit
+factor, producing a polynomial whose residue is the multiplicative inverse
+whenever the quotient element is nonzero. -/
+def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : GFqRing.PolyQuotient f hf) : FpPoly p :=
   let r := DensePoly.xgcd (GFqRing.repr x) f
   let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹

--- a/progress/20260519T062801Z_93d2d09c.md
+++ b/progress/20260519T062801Z_93d2d09c.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+Claimed #5282 and added the `Hex.GFq.repr_inv_of_ne_zero` simp wrapper in
+`HexGfq/Basic.lean`, delegating to the generic `GFqField.repr_inv_of_ne_zero`
+lemma. Made `GFqField.invPoly` public in `HexGfqField/Operations.lean` with an
+API-facing docstring because the existing public inverse-representative theorem
+and the new canonical `GFq` wrapper both expose it in their result type.
+Rebased over current `origin/main`, resolving the local `GFq.repr_*` block by
+keeping the newly landed `repr_natCast` / `repr_intCast` wrappers and placing
+`repr_inv_of_ne_zero` after them.
+
+Verification completed:
+
+- `lake build HexGfq.Basic`
+- `lake build HexGfq`
+- `lake build`
+- `python3 scripts/check_dag.py`
+- `git diff --check -- HexGfq/Basic.lean HexGfqField/Operations.lean`
+- Scoped forbidden-token check on the changed Lean diff
+
+## Current frontier
+
+The requested wrapper is implemented on a branch current with `origin/main`, and
+the full project build is green.
+The worktree still contains a pre-existing unrelated `.claude/CLAUDE.md`
+modification, which this session did not touch.
+
+## Next step
+
+Create the PR for #5282.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5282

Session: `93d2d09c-6c73-4ab6-9bb0-e86b00163f4f`

60a34d27 feat: add GFq inverse representative wrapper

🤖 Prepared with Claude Code