### PR TITLE
HexPolyZMathlib: add boundary Mahler equality lemmas

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -193,6 +193,25 @@ theorem norm_eval_robinsonForm_eq_norm_eval
         rw [(IsAlgClosed.splits p).eval_eq_prod_roots z]
         simp
 
+theorem logMahlerMeasure_eq_of_boundary_norm_eq {p q : ℂ[X]}
+    (hboundary : ∀ {z : ℂ}, ‖z‖ = 1 → ‖q.eval z‖ = ‖p.eval z‖) :
+    q.logMahlerMeasure = p.logMahlerMeasure := by
+  rw [logMahlerMeasure_def, logMahlerMeasure_def]
+  apply Real.circleAverage_congr_sphere
+  intro z hz
+  have hz_norm : ‖z‖ = 1 := by
+    simpa [Metric.mem_sphere, dist_zero_right] using hz
+  simpa using congrArg Real.log (hboundary hz_norm)
+
+theorem mahlerMeasure_eq_of_boundary_norm_eq_of_ne_zero {p q : ℂ[X]}
+    (hboundary : ∀ {z : ℂ}, ‖z‖ = 1 → ‖q.eval z‖ = ‖p.eval z‖)
+    (hp : p ≠ 0) (hq : q ≠ 0) :
+    q.mahlerMeasure = p.mahlerMeasure := by
+  have hlog := logMahlerMeasure_eq_of_boundary_norm_eq hboundary
+  rw [logMahlerMeasure_def, logMahlerMeasure_def] at hlog
+  rw [mahlerMeasure_def_of_ne_zero hq, mahlerMeasure_def_of_ne_zero hp]
+  exact congrArg Real.exp hlog
+
 theorem mahlerMeasure_robinsonFactor (α : ℂ) :
     (robinsonFactor α).mahlerMeasure = max 1 ‖α‖ := by
   by_cases hα : ‖α‖ ≤ 1

--- a/progress/20260519T075649Z_02d9b36e.md
+++ b/progress/20260519T075649Z_02d9b36e.md
@@ -1,0 +1,39 @@
+# Session 02d9b36e - partial #5321
+
+## Accomplished
+
+- Claimed #5321 after confirming directive issues #2564, #2567, and #2637
+  were blocked by `coordination claim`.
+- Restored #5321 from an accidental transient `replan` label before
+  reclaiming it.
+- Added reusable boundary-modulus Mahler lemmas in
+  `HexPolyZMathlib/RobinsonForm.lean`:
+  - `logMahlerMeasure_eq_of_boundary_norm_eq`
+  - `mahlerMeasure_eq_of_boundary_norm_eq_of_ne_zero`
+- Verified with:
+  - `lake build HexPolyZMathlib.RobinsonForm`
+  - `lake build HexPolyZMathlib`
+  - `lake build`
+  - `python3 scripts/oracle/mahler_schur_counterexample.py`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n "\\bsorry\\b|\\baxiom\\b|native_decide|TODO|FIXME" HexPolyZMathlib/RobinsonForm.lean || true`
+
+## Current frontier
+
+#5321 remains a genuine Boyd/de Bruijn-Springer derivative comparison task.
+The full theorem is larger than a single worker slice because this checkout has
+no existing Mathlib theorem for the global derivative inequality.
+
+## Next step
+
+Prove the analytic derivative comparison from boundary norm equality:
+`p.derivative.mahlerMeasure ≤ q.derivative.mahlerMeasure` when `q` has all
+roots in the closed unit disk and `q.natDegree = p.natDegree`, using the new
+boundary-Mahler equality lemmas as infrastructure.
+
+## Blockers
+
+None for the partial infrastructure. The remaining proof needs a formal
+Boyd/de Bruijn-Springer argument, not another single-factor Schur endpoint
+route.


### PR DESCRIPTION
Partial progress on #5321

Session: `02d9b36e-00f8-4c3e-82bb-6ba714f908b1`

5cca5feb HexPolyZMathlib: add boundary Mahler equality lemmas

🤖 Prepared with Claude Code