### PR TITLE
HexArith Phase 6: add addCarry/subBorrow branch characterisation lemmas

### DIFF
--- a/HexArith/UInt64/Wide.lean
+++ b/HexArith/UInt64/Wide.lean
@@ -69,6 +69,19 @@ theorem addCarry_snd (a b : UInt64) (cin : Bool) :
     (addCarry a b cin).2 = decide (word ≤ a.toNat + b.toNat + cin.toNat) := by
   simp [addCarry]
 
+/-- If exact add-with-carry does not overflow, `addCarry` returns the exact low word. -/
+theorem addCarry_eq_of_no_overflow (a b : UInt64) (cin : Bool)
+    (h : a.toNat + b.toNat + cin.toNat < word) :
+    addCarry a b cin = (UInt64.ofNat (a.toNat + b.toNat + cin.toNat), false) := by
+  have hnot : ¬ word ≤ a.toNat + b.toNat + cin.toNat := by omega
+  simp [addCarry, hnot]
+
+/-- If exact add-with-carry overflows, `addCarry` returns the wrapped low word and carry bit. -/
+theorem addCarry_eq_of_overflow (a b : UInt64) (cin : Bool)
+    (h : word ≤ a.toNat + b.toNat + cin.toNat) :
+    addCarry a b cin = (UInt64.ofNat (a.toNat + b.toNat + cin.toNat), true) := by
+  simp [addCarry, h]
+
 /-- Low-word projection of `subBorrow` after one-word wrapping. -/
 @[simp]
 theorem toNat_subBorrow_fst (a b : UInt64) (bin : Bool) :
@@ -110,6 +123,20 @@ theorem subBorrow_snd (a b : UInt64) (bin : Bool) :
     simp [subBorrow, hle, hnot]
   · have hlt : a.toNat < b.toNat + bin.toNat := by omega
     simp [subBorrow, hle, hlt]
+
+/-- If subtraction does not borrow, `subBorrow` returns the exact difference. -/
+theorem subBorrow_eq_of_no_borrow (a b : UInt64) (bin : Bool)
+    (h : b.toNat + bin.toNat ≤ a.toNat) :
+    subBorrow a b bin = (UInt64.ofNat (a.toNat - (b.toNat + bin.toNat)), false) := by
+  simp [subBorrow, h]
+
+/-- If subtraction borrows, `subBorrow` returns the one-word wrapped difference. -/
+theorem subBorrow_eq_of_borrow (a b : UInt64) (bin : Bool)
+    (h : a.toNat < b.toNat + bin.toNat) :
+    subBorrow a b bin =
+      (UInt64.ofNat (word + a.toNat - (b.toNat + bin.toNat)), true) := by
+  have hnot : ¬ b.toNat + bin.toNat ≤ a.toNat := by omega
+  simp [subBorrow, hnot]
 
 private theorem toNat_ofNat_quot_mul_lt_word (a b : UInt64) :
     (UInt64.ofNat (a.toNat * b.toNat / word)).toNat =

--- a/progress/20260519T082202Z_53f53a17.md
+++ b/progress/20260519T082202Z_53f53a17.md
@@ -1,0 +1,40 @@
+# Session 53f53a17 - UInt64 wide branch lemmas
+
+## Accomplished
+
+- Confirmed directive issues #2564, #2567, and #2637 were not claimable
+  because coordination reported blocked dependencies.
+- Claimed #5341, found its requested Schur-root monotonicity deliverable was
+  false, and skipped it for replan with the concrete counterexample route
+  recorded in the coordination skip reason.
+- Attempted #4334 after #5341, but coordination reported it needed replan and
+  was not claimable.
+- Claimed #5343 and added branch characterisation lemmas in
+  `HexArith/UInt64/Wide.lean`:
+  - `UInt64.addCarry_eq_of_no_overflow`
+  - `UInt64.addCarry_eq_of_overflow`
+  - `UInt64.subBorrow_eq_of_no_borrow`
+  - `UInt64.subBorrow_eq_of_borrow`
+- Verified with:
+  - `lake build HexArith.UInt64.Wide`
+  - `lake build HexArith`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n "theorem (addCarry|subBorrow)_eq_of" HexArith/UInt64/Wide.lean`
+  - `git diff -- HexArith/UInt64/Wide.lean HexArith/Montgomery/Redc.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+#5343 is complete as a local UInt64 wide-word API polish item. I did not touch
+the optional Montgomery consumer file because the new lemmas did not expose an
+obvious strictly shorter local proof without broadening the change.
+
+## Next step
+
+Review and merge the #5343 PR. A later Montgomery or Barrett cleanup can use
+the new branch lemmas where exact pair shapes are useful.
+
+## Blockers
+
+None for #5343.


### PR DESCRIPTION
Closes #5343

Session: `53f53a17-5537-4699-b3f4-623aa34cc784`

9542afee feat: add UInt64 carry branch lemmas

🤖 Prepared with Claude Code