### PR TITLE
HexBerlekampZassenhausMathlib: add projected vector array access lemmas

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -369,6 +369,23 @@ theorem projectedVectorFn_projectedVectorArray
   funext i
   simp [projectedVectorFn, projectedVectorArray]
 
+/-- The executable representative of a projected vector has exactly the
+projected factor count as its array size. -/
+theorem projectedVectorArray_size
+    (W : ExecutableBadVectorWitness)
+    (v : Fin W.projectedRows.factorCount → ℤ) :
+    (W.projectedVectorArray v).size = W.projectedRows.factorCount := by
+  simp [projectedVectorArray]
+
+/-- Reading the executable representative at an in-bounds projected-factor
+index recovers the original projected vector entry. -/
+theorem projectedVectorArray_getD
+    (W : ExecutableBadVectorWitness)
+    (v : Fin W.projectedRows.factorCount → ℤ)
+    (i : Fin W.projectedRows.factorCount) :
+    (W.projectedVectorArray v).getD i.val 0 = v i := by
+  simpa [projectedVectorFn] using congrFun (projectedVectorFn_projectedVectorArray W v) i
+
 /--
 Bad-vector evidence for an executable BHKS bad-vector witness.
 

--- a/progress/2026-05-19T08-50-59Z_6ad30116.md
+++ b/progress/2026-05-19T08-50-59Z_6ad30116.md
@@ -1,0 +1,31 @@
+# Session 6ad30116 - projected vector array lemmas
+
+## Accomplished
+
+- Claimed #5353 after confirming no claimable directive issue was available.
+- Added `ExecutableBadVectorWitness.projectedVectorArray_size` and
+  `ExecutableBadVectorWitness.projectedVectorArray_getD` in
+  `HexBerlekampZassenhausMathlib/BadVector.lean`.
+- Verified the local target with `lake build HexBerlekampZassenhausMathlib.BadVector`.
+- Confirmed the requested lemma names are discoverable with
+  `git grep -nE 'projectedVectorArray_(size|getD)'`.
+- Confirmed the local diff adds no `sorry`, `axiom`, `native_decide`, `TODO`,
+  or `FIXME`, and `git diff --check` is clean.
+
+## Current frontier
+
+#5353 is complete locally. The broader
+`lake build HexBerlekampZassenhausMathlib` target fails in pre-existing
+`HexBerlekampZassenhausMathlib.Basic` declarations with heartbeat timeouts and
+unknown constants, before reaching the edited `BadVector` module.
+
+## Next step
+
+Review and merge the #5353 PR. Separately repair the existing
+`HexBerlekampZassenhausMathlib.Basic` diagnostics so the aggregate Mathlib
+bridge target can be used as a verification gate again.
+
+## Blockers
+
+Aggregate verification is blocked by existing
+`HexBerlekampZassenhausMathlib.Basic` errors unrelated to this local change.


### PR DESCRIPTION
Closes #5353

Session: `6ad30116-8e36-4760-9c5f-d0c692d5153a`

2928829f feat: add projected vector array lemmas

🤖 Prepared with Claude Code