### PR TITLE
HexPolyZMathlib: prove derivative root-deletion sum Mahler bound

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -454,6 +454,23 @@ theorem mahlerMeasure_robinsonForm_derivative (p : ℂ[X]) :
     (by intro α; exact norm_root_robinsonForm_le), natDegree_robinsonForm,
     mahlerMeasure_robinsonForm]
 
+/--
+The finite root-deletion derivative sum for the Robinson form has the same
+Mahler bound as the derivative itself.
+-/
+theorem mahlerMeasure_robinsonRootDeletionDerivativeSum_le (p : ℂ[X]) :
+    (C p.leadingCoeff *
+        (p.roots.map fun α =>
+          ((p.roots.erase α).map robinsonFactor).prod * (robinsonFactor α).derivative).sum
+      ).mahlerMeasure ≤ p.natDegree * p.mahlerMeasure := by
+  have hderiv :
+      C p.leadingCoeff *
+          (p.roots.map fun α =>
+            ((p.roots.erase α).map robinsonFactor).prod * (robinsonFactor α).derivative).sum =
+        p.robinsonForm.derivative := by
+    rw [robinsonForm, derivative_C_mul, derivative_prod]
+  rw [hderiv, mahlerMeasure_robinsonForm_derivative]
+
 end
 
 end Polynomial

--- a/progress/20260519T090033Z_ac3a0fd8.md
+++ b/progress/20260519T090033Z_ac3a0fd8.md
@@ -1,0 +1,32 @@
+# Session ac3a0fd8 - Robinson root-deletion Mahler bound
+
+## Accomplished
+
+- Confirmed directive issues #2564, #2567, and #2637 were blocked by
+  coordination and not claimable.
+- Lost claim races for #5357 and #4334, then claimed #5361.
+- Added
+  `Polynomial.mahlerMeasure_robinsonRootDeletionDerivativeSum_le` in
+  `HexPolyZMathlib/RobinsonForm.lean`, exposing the Mahler bound for the
+  finite root-deletion derivative sum of the Robinson form.
+- Verified with:
+  - `lake build HexPolyZMathlib`
+  - `python3 scripts/oracle/mahler_schur_counterexample.py`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `git diff -- HexPolyZMathlib/RobinsonForm.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+#5361 is complete as a narrow bridge theorem: later derivative-bound work can
+rewrite the #5346 root-deletion expansion to the Robinson-form derivative and
+use the existing `mahlerMeasure_robinsonForm_derivative` result through this
+new theorem.
+
+## Next step
+
+Use #5361 together with #5346 in the final combination issue #5347.
+
+## Blockers
+
+None for #5361.


### PR DESCRIPTION
Closes #5361

Session: `ac3a0fd8-ee35-448f-8329-55818e899fd1`

f37a6072 feat: add Robinson root-deletion Mahler bound

🤖 Prepared with Claude Code