### PR TITLE
HexGF2 Phase 6: add right-zero coefficient wrapper

### DIFF
--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -1019,6 +1019,11 @@ theorem xorWords_self (xs : Array UInt64) :
     (0 + p).coeff n = p.coeff n := by
   simp
 
+/-- Adding zero on the right leaves packed `GF(2)` coefficients unchanged. -/
+@[simp] theorem coeff_add_zero_right_bool (p : GF2Poly) (n : Nat) :
+    (p + 0).coeff n = p.coeff n := by
+  simp
+
 /-- Zero is the right identity for `F_2[x]` addition. -/
 @[simp] theorem add_zero (p : GF2Poly) :
     p + 0 = p := by

--- a/progress/20260519T091758Z_8ff3cd8c.md
+++ b/progress/20260519T091758Z_8ff3cd8c.md
@@ -1,0 +1,28 @@
+# Session 8ff3cd8c - issue #5372
+
+## Accomplished
+
+- Claimed issue #5372.
+- Added `GF2Poly.coeff_add_zero_right_bool` in `HexGF2/Basic.lean`
+  next to the existing left-zero coefficient wrapper and `add_zero`.
+- Verified the change with:
+  - `lake build HexGF2.Basic`
+  - `lake build HexGF2`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'coeff_add_zero_(left|right)_bool' HexGF2/Basic.lean`
+  - `git diff -- HexGF2/Basic.lean | rg -n '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+- Issue #5372 is complete locally. The packed `GF(2)` coefficient API now has
+  symmetric named wrappers for both `(0 + p).coeff n` and `(p + 0).coeff n`.
+
+## Next step
+
+- Create the PR for issue #5372 and let CI validate the branch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5372

Session: `8ff3cd8c-1d6d-487a-acdb-39b37cfda6d6`

ba0df9f3 feat: add GF2 coefficient right-zero wrapper

🤖 Prepared with Claude Code