### PR TITLE
HexHensel Phase 6: add positive-precision modP wrapper

### DIFF
--- a/HexHensel/Basic.lean
+++ b/HexHensel/Basic.lean
@@ -188,6 +188,15 @@ theorem modP_eq_of_congr (p : Nat) [ZMod64.Bounds p] (f g : ZPoly)
     congr_pow_of_le p 1 (k + 1) (reduceModPow f p (k + 1)) f (by omega) hred
   simpa using hred₁
 
+/-- Reducing modulo any positive power of `p` does not change the reduction modulo `p`. -/
+@[simp] theorem modP_reduceModPow_of_pos
+    (p k : Nat) [ZMod64.Bounds p] (f : ZPoly) (hk : 0 < k) :
+    modP p (reduceModPow f p k) = modP p f := by
+  cases k with
+  | zero => cases hk
+  | succ k =>
+      simp
+
 end ZPoly
 
 namespace FpPoly

--- a/progress/20260519T092249Z_1243f946.md
+++ b/progress/20260519T092249Z_1243f946.md
@@ -1,0 +1,24 @@
+## Accomplished
+
+- Claimed #5374 after confirming unblocked directives were unavailable and #5373 had been claimed by another session.
+- Added `ZPoly.modP_reduceModPow_of_pos` in `HexHensel/Basic.lean`, a positive-precision simp wrapper around the existing successor-shaped `modP_reduceModPow`.
+- Verified with:
+  - `lake build HexHensel.Basic`
+  - `lake build HexHensel`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'modP_reduceModPow(_of_pos)?|congr_modP_reduceModPow_of_pos' HexHensel/Basic.lean`
+  - `git diff -- HexHensel/Basic.lean | rg -n '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+#5374 is complete locally. The change is confined to `HexHensel/Basic.lean` and leaves the optional congruence-level sibling out because the requested simp theorem is a direct wrapper.
+
+## Next step
+
+Review and merge the PR for #5374.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5374

Session: `1243f946-cd52-4f43-ac79-8c92053f3c3f`

7e1befbd HexHensel: add positive reduceModPow modP wrapper

🤖 Prepared with Claude Code