### PR TITLE
HexArith Phase 6: add carry and borrow low-word projection wrappers

### DIFF
--- a/HexArith/UInt64/Wide.lean
+++ b/HexArith/UInt64/Wide.lean
@@ -91,11 +91,23 @@ theorem addCarry_eq_of_no_overflow (a b : UInt64) (cin : Bool)
   have hnot : ¬ word ≤ a.toNat + b.toNat + cin.toNat := by omega
   simp [addCarry, hnot]
 
+/-- If exact add-with-carry does not overflow, the low word is the exact sum. -/
+theorem addCarry_fst_eq_of_no_overflow (a b : UInt64) (cin : Bool)
+    (h : a.toNat + b.toNat + cin.toNat < word) :
+    (addCarry a b cin).1 = UInt64.ofNat (a.toNat + b.toNat + cin.toNat) := by
+  simpa using congrArg Prod.fst (addCarry_eq_of_no_overflow a b cin h)
+
 /-- If exact add-with-carry overflows, `addCarry` returns the wrapped low word and carry bit. -/
 theorem addCarry_eq_of_overflow (a b : UInt64) (cin : Bool)
     (h : word ≤ a.toNat + b.toNat + cin.toNat) :
     addCarry a b cin = (UInt64.ofNat (a.toNat + b.toNat + cin.toNat), true) := by
   simp [addCarry, h]
+
+/-- If exact add-with-carry overflows, the low word is the wrapped exact sum. -/
+theorem addCarry_fst_eq_of_overflow (a b : UInt64) (cin : Bool)
+    (h : word ≤ a.toNat + b.toNat + cin.toNat) :
+    (addCarry a b cin).1 = UInt64.ofNat (a.toNat + b.toNat + cin.toNat) := by
+  simpa using congrArg Prod.fst (addCarry_eq_of_overflow a b cin h)
 
 /-- Low-word projection of `subBorrow` after one-word wrapping. -/
 @[simp]
@@ -160,6 +172,13 @@ theorem subBorrow_eq_of_no_borrow (a b : UInt64) (bin : Bool)
     subBorrow a b bin = (UInt64.ofNat (a.toNat - (b.toNat + bin.toNat)), false) := by
   simp [subBorrow, h]
 
+/-- If subtraction does not borrow, the low word is the exact difference. -/
+theorem subBorrow_fst_eq_of_no_borrow (a b : UInt64) (bin : Bool)
+    (h : b.toNat + bin.toNat ≤ a.toNat) :
+    (subBorrow a b bin).1 =
+      UInt64.ofNat (a.toNat - (b.toNat + bin.toNat)) := by
+  simpa using congrArg Prod.fst (subBorrow_eq_of_no_borrow a b bin h)
+
 /-- If subtraction borrows, `subBorrow` returns the one-word wrapped difference. -/
 theorem subBorrow_eq_of_borrow (a b : UInt64) (bin : Bool)
     (h : a.toNat < b.toNat + bin.toNat) :
@@ -167,6 +186,13 @@ theorem subBorrow_eq_of_borrow (a b : UInt64) (bin : Bool)
       (UInt64.ofNat (word + a.toNat - (b.toNat + bin.toNat)), true) := by
   have hnot : ¬ b.toNat + bin.toNat ≤ a.toNat := by omega
   simp [subBorrow, hnot]
+
+/-- If subtraction borrows, the low word is the wrapped difference. -/
+theorem subBorrow_fst_eq_of_borrow (a b : UInt64) (bin : Bool)
+    (h : a.toNat < b.toNat + bin.toNat) :
+    (subBorrow a b bin).1 =
+      UInt64.ofNat (word + a.toNat - (b.toNat + bin.toNat)) := by
+  simpa using congrArg Prod.fst (subBorrow_eq_of_borrow a b bin h)
 
 private theorem toNat_ofNat_quot_mul_lt_word (a b : UInt64) :
     (UInt64.ofNat (a.toNat * b.toNat / word)).toNat =

--- a/progress/20260519T094454Z_b7b7a00c.md
+++ b/progress/20260519T094454Z_b7b7a00c.md
@@ -1,0 +1,33 @@
+# Session b7b7a00c - issue #5381
+
+## Accomplished
+
+- Checked the unclaimed queue and blocked directives.
+- Claimed issue #5378, verified the direct Nat-to-Int proof does not close without a separate Bareiss/Gram diagonal nonnegativity lemma, and released it for replanning with that blocker.
+- Claimed issue #5381.
+- Added low-word projection wrappers for `UInt64.addCarry`:
+  - `addCarry_fst_eq_of_no_overflow`
+  - `addCarry_fst_eq_of_overflow`
+- Added low-word projection wrappers for `UInt64.subBorrow`:
+  - `subBorrow_fst_eq_of_no_borrow`
+  - `subBorrow_fst_eq_of_borrow`
+- Verified with:
+  - `lake build HexArith.UInt64.Wide`
+  - `lake build HexArith`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'addCarry_fst_eq_of_(no_overflow|overflow)|subBorrow_fst_eq_of_(no_borrow|borrow)' HexArith/UInt64/Wide.lean`
+  - `git diff -- HexArith/UInt64/Wide.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+
+## Current frontier
+
+Issue #5381 is complete locally. The wide-word carry/borrow APIs now expose direct low-word branch lemmas derived from the existing pair equalities.
+
+## Next step
+
+Create the PR for issue #5381 and let CI validate the branch.
+
+## Blockers
+
+None for #5381. Issue #5378 needs a separate nonnegativity lemma for the Bareiss diagonal stored by the Gram leading-prefix pass before the Int-valued diagonal theorem can be discharged without importing bridge-layer Mathlib results into `HexGramSchmidt/Int.lean`.


### PR DESCRIPTION
Closes #5381

Session: `b7b7a00c-0a19-4028-b003-4f5a42880cc2`

390e6daf HexArith: add carry borrow fst wrappers

🤖 Prepared with Claude Code