### PR TITLE
refactor: relocate GramSchmidt diagonal bridge

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3018,14 +3018,6 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDetVecEntry
       rw [if_neg hs_not_lt]
       exact congrArg Int.toNat h_eq
 
-private theorem scaledCoeffRows_diag_eq_gramDetVecEntry
-    (b : Matrix Int n m) (i : Nat) (hi : i < n) :
-    getArrayEntry (scaledCoeffRows b) i i =
-      Int.ofNat
-        (gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
-          ⟨i + 1, Nat.succ_lt_succ hi⟩) := by
-  sorry
-
 /-- The scaled-coefficient loop stores the next leading Gram determinant on
 the diagonal, at the executable Nat boundary. -/
 private theorem scaledCoeffRows_diag_toNat_eq_gramDet
@@ -3047,15 +3039,6 @@ private theorem scaledCoeffRows_diag_eq_gramDet_of_nonneg
   rw [← hdiag]
   exact (Int.toNat_of_nonneg hnonneg).symm
 
-/-- The scaled-coefficient loop stores the next leading Gram determinant on
-the diagonal. -/
-private theorem scaledCoeffRows_diag_eq_gramDet
-    (b : Matrix Int n m) (i : Nat) (hi : i < n) :
-    getArrayEntry (scaledCoeffRows b) i i =
-      Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  rw [scaledCoeffRows_diag_eq_gramDetVecEntry (b := b) i hi]
-  rw [gramDetVecEntry_eq_gramDet (b := b) (i + 1) (Nat.succ_le_of_lt hi)]
-
 theorem gramDet_zero (b : Matrix Int n m) :
     gramDet b 0 (Nat.zero_le n) = 1 := by
   rfl
@@ -3072,12 +3055,6 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
       have hdiag := scaledCoeffRows_diag_toNat_eq_gramDet (b := b) r hr
       simpa [gramDetVec, data, gramDetVecFromScaledCoeffRows] using hdiag
 
-
-theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
-    GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
-      Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using
-    scaledCoeffRows_diag_eq_gramDet (b := b) i hi
 
 /-- Nat-level diagonal synchronization for the public scaled-coefficient
 matrix. This is the Mathlib-free diagonal fact exposed by the shared array

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -2437,6 +2437,15 @@ theorem leadingGramMatrixInt_det_eq_gramDet_int
   leadingGramMatrixInt_det_eq_gramDet_int_of_nonneg b t ht
     (leadingGramMatrixInt_det_nonneg b t ht)
 
+/-- Bridge-layer unconditional diagonal synchronization for the public
+scaled-coefficient matrix. The Mathlib-free core exposes the Nat-level version
+and the conditional Int lift; the required nonnegativity of the Gram/Bareiss
+diagonal slot is supplied in this bridge layer. -/
+theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
+      Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
+  sorry
+
 /-- The leading executable Gram determinants of a square upper-triangular
 integer matrix with strictly positive diagonal are positive.
 

--- a/progress/20260519T095520Z_b1ccfa59.md
+++ b/progress/20260519T095520Z_b1ccfa59.md
@@ -1,0 +1,23 @@
+## Accomplished
+
+- Claimed #5385 after checking the unclaimed queue and confirming no unclaimed directive was available.
+- Narrowed `HexGramSchmidt/Int.lean` so the Mathlib-free core no longer states the unconditional Int-valued diagonal synchronization theorem.
+- Added the bridge-layer `scaledCoeffs_diag` statement in `HexGramSchmidtMathlib/Int.lean` and preserved the existing downstream rewrite site there.
+- Created successor issue #5394 for the remaining signed Gram/Bareiss diagonal-slot nonnegativity proof and added a decomposition breadcrumb on #5385.
+- Verified:
+  - `lake build HexGramSchmidt.Int`
+  - `lake build HexGramSchmidtMathlib.Int`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+
+## Current frontier
+
+#5385 is only partially complete. The API placement now respects the library split, but the unconditional bridge theorem still has a `sorry` in `HexGramSchmidtMathlib/Int.lean`; the repository `sorry` count is unchanged.
+
+## Next step
+
+Work #5394: prove the bridge-layer diagonal theorem by adding the smallest signed diagonal-slot helper needed to combine the executable loop with leading Gram determinant nonnegativity.
+
+## Blockers
+
+None for the partial relocation. Full completion needs the nonnegativity proof described in #5394.


### PR DESCRIPTION
Partial progress on #5385

Session: `b1ccfa59-f4cc-410d-8c3c-33379052ca92`

e8aa9aa9 refactor: relocate GramSchmidt diagonal bridge

🤖 Prepared with Claude Code