### PR TITLE
HexGfq Phase 6: add ofPoly reduceMod normalization lemma

### DIFF
--- a/HexGfq/Basic.lean
+++ b/HexGfq/Basic.lean
@@ -390,6 +390,13 @@ theorem ofPoly_eq_ofPoly_iff_reduceMod_eq
     apply ext
     simpa using hred
 
+@[simp] theorem ofPoly_reduceMod
+    (h : Conway.SupportedEntry p n) (f : FpPoly p) :
+    ofPoly h (GFqRing.reduceMod (modulus h) f) = ofPoly h f := by
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime h.prime
+  rw [ofPoly_eq_ofPoly_iff_reduceMod_eq]
+  exact GFqRing.reduceMod_idem (modulus h) f
+
 end GFq
 
 /-- Optimized canonical binary field for committed Conway entries that have a

--- a/progress/20260519T095713Z_c784ad67.md
+++ b/progress/20260519T095713Z_c784ad67.md
@@ -1,0 +1,26 @@
+## Accomplished
+
+- Claimed #5373 after confirming the open directive issues were blocked.
+- Added `GFq.ofPoly_reduceMod` in `HexGfq/Basic.lean`, a simp theorem normalizing `GFq.ofPoly` over an already reduced representative.
+- Kept the proof local to the existing `GFq.ofPoly_eq_ofPoly_iff_reduceMod_eq` API and `GFqRing.reduceMod_idem`.
+- Verified with:
+  - `lake build HexGfq.Basic`
+  - `lake build HexGfq`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'ofPoly_reduceMod|ofPoly_eq_ofPoly_reduceMod' HexGfq/Basic.lean`
+  - `git diff -- HexGfq/Basic.lean | rg -n '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+- Quality counts remained at `sorry=85`, `axiom=9`, `native_decide=1`, `TODO/FIXME=1`.
+
+## Current frontier
+
+#5373 is complete locally. The only code change is the new constructor-normalization theorem in `HexGfq/Basic.lean`; the optional symmetric wrapper was not added because the simp-oriented theorem directly covers the requested normalization.
+
+## Next step
+
+Review and merge the PR for #5373.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5373

Session: `c784ad67-2b5c-4ae3-ac4f-baeb70a5cf18`

f07cc4f1 feat: add GFq ofPoly reduction normalization

🤖 Prepared with Claude Code