### PR TITLE
HexMatrix Phase 6: add row operation identity wrappers

### DIFF
--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -443,6 +443,55 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
       rw [rowSwap_getElem]
       rw [if_neg hrj, if_neg hri]
 
+/-- Swapping a row with itself leaves the matrix unchanged. -/
+@[simp] theorem rowSwap_self (M : Matrix R n m) (i : Fin n) :
+    rowSwap M i i = M := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro k hk
+  let rr : Fin n := ⟨r, hr⟩
+  let kk : Fin m := ⟨k, hk⟩
+  show (rowSwap M i i)[rr][kk] = M[rr][kk]
+  rw [rowSwap_getElem]
+  by_cases hri : rr = i
+  · simp [hri]
+  · simp [hri]
+
+/-- Scaling a row by one leaves the matrix unchanged. -/
+@[simp] theorem rowScale_one [Lean.Grind.Semiring R]
+    (M : Matrix R n m) (i : Fin n) :
+    rowScale M i 1 = M := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro k hk
+  let rr : Fin n := ⟨r, hr⟩
+  let kk : Fin m := ⟨k, hk⟩
+  show (rowScale M i 1)[rr][kk] = M[rr][kk]
+  rw [rowScale_getElem]
+  by_cases hri : rr = i
+  · rw [if_pos hri]
+    grind
+  · rw [if_neg hri]
+
+/-- Adding zero times one row to another leaves the matrix unchanged. -/
+@[simp] theorem rowAdd_zero [Lean.Grind.Semiring R]
+    (M : Matrix R n m) (src dst : Fin n) :
+    rowAdd M src dst 0 = M := by
+  apply Vector.ext
+  intro r hr
+  apply Vector.ext
+  intro k hk
+  let rr : Fin n := ⟨r, hr⟩
+  let kk : Fin m := ⟨k, hk⟩
+  show (rowAdd M src dst 0)[rr][kk] = M[rr][kk]
+  rw [rowAdd_getElem]
+  by_cases hrd : rr = dst
+  · rw [if_pos hrd]
+    grind
+  · rw [if_neg hrd]
+
 /-- Scaling a row by `s` and then by `s⁻¹` restores the original matrix when
 `s` is nonzero. -/
 theorem rowScale_rowScale_inv_left [Lean.Grind.Field R]

--- a/progress/20260519T101535Z_62347d3d.md
+++ b/progress/20260519T101535Z_62347d3d.md
@@ -1,0 +1,31 @@
+# Session 62347d3d - issue #5404
+
+## Accomplished
+
+- Claimed issue #5404 after checking the unclaimed queue and confirming no unclaimed directives.
+- Added row-operation identity wrappers in `HexMatrix/RowEchelon.lean`:
+  - `rowSwap_self`
+  - `rowScale_one`
+  - `rowAdd_zero`
+- Kept `rowScale_one` and `rowAdd_zero` at `Lean.Grind.Semiring R`, weaker than the surrounding inverse lemmas' ring/field assumptions.
+- Verified with:
+  - `lake build HexMatrix.RowEchelon`
+  - `lake build HexMatrix`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'rowSwap_self|rowScale_one|rowAdd_zero' HexMatrix/RowEchelon.lean`
+  - `git diff -- HexMatrix/RowEchelon.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+- Quality metrics remained at the planner baseline: `sorry`: 85, `axiom`: 9, `native_decide`: 1.
+
+## Current frontier
+
+Issue #5404 is complete locally. The HexMatrix row-operation API now has named simp lemmas for no-op swap, scale-by-one, and add-zero operations.
+
+## Next step
+
+Create the PR for issue #5404 and let CI validate the branch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5404

Session: `62347d3d-b03e-43a6-abce-e799f232da6e`

54547324 feat: add row operation identity wrappers

🤖 Prepared with Claude Code