### PR TITLE
HexModArith Phase 6: add arithmetic identity wrappers

### DIFF
--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -395,6 +395,50 @@ instance : Lean.Grind.Semiring (ZMod64 p) := by
     rw [toNat_natCast]
     simp [Nat.mul_mod]
 
+theorem add_zero (a : ZMod64 p) : a + 0 = a := by
+  apply ext_toNat
+  rw [show a + 0 = ZMod64.add a ZMod64.zero from rfl]
+  change (ZMod64.add a ZMod64.zero).toNat = a.toNat
+  rw [toNat_add, toNat_zero, Nat.add_zero]
+  exact Nat.mod_eq_of_lt a.isLt
+
+theorem zero_add (a : ZMod64 p) : 0 + a = a := by
+  apply ext_toNat
+  rw [show 0 + a = ZMod64.add ZMod64.zero a from rfl]
+  change (ZMod64.add ZMod64.zero a).toNat = a.toNat
+  rw [toNat_add, toNat_zero]
+  simpa using Nat.mod_eq_of_lt a.isLt
+
+theorem mul_zero (a : ZMod64 p) : a * 0 = 0 := by
+  apply ext_toNat
+  change (ZMod64.mul a ZMod64.zero).toNat = (ZMod64.zero : ZMod64 p).toNat
+  rw [toNat_mul, toNat_zero]
+  simp
+
+theorem zero_mul (a : ZMod64 p) : 0 * a = 0 := by
+  apply ext_toNat
+  change (ZMod64.mul ZMod64.zero a).toNat = (ZMod64.zero : ZMod64 p).toNat
+  rw [toNat_mul, toNat_zero]
+  simp
+
+theorem mul_one (a : ZMod64 p) : a * 1 = a := by
+  apply ext_toNat
+  change (ZMod64.mul a ZMod64.one).toNat = a.toNat
+  rw [toNat_mul, toNat_one]
+  simp [Nat.mod_eq_of_lt a.isLt]
+
+theorem one_mul (a : ZMod64 p) : 1 * a = a := by
+  apply ext_toNat
+  change (ZMod64.mul ZMod64.one a).toNat = a.toNat
+  rw [toNat_mul, toNat_one]
+  simp [Nat.mod_eq_of_lt a.isLt]
+
+theorem pow_zero (a : ZMod64 p) : a ^ 0 = 1 := by
+  apply ext_toNat
+  change (ZMod64.pow a 0).toNat = (ZMod64.one : ZMod64 p).toNat
+  rw [toNat_pow, toNat_one]
+  simp
+
 instance : Lean.Grind.Ring (ZMod64 p) where
   neg_add_cancel := by
     intro a

--- a/progress/20260519T104122Z_eee73363.md
+++ b/progress/20260519T104122Z_eee73363.md
@@ -1,0 +1,21 @@
+## Accomplished
+
+- Loaded the worker flow and checked the current queue.
+- Attempted the highest-priority directive path, but #2637 was blocked by dependencies and the coordination claim correctly failed.
+- Claimed #5409, verified its prerequisite theorem `mahlerMeasure_derivative_le_natDegree_mul` was absent on current `main`, and skipped it with a blocker note because successor #5412 remains open/claimed.
+- Claimed #5416 and added named `ZMod64` identity wrappers in `HexModArith/Ring.lean`:
+  `add_zero`, `zero_add`, `mul_zero`, `zero_mul`, `mul_one`, `one_mul`, and `pow_zero`.
+- Verified with `lake build HexModArith.Ring`, `lake build HexModArith`, full `lake build`, `python3 scripts/check_dag.py`, `git diff --check`, wrapper-name grep, and a forbidden-token grep over the diff.
+
+## Current frontier
+
+#5416 is implemented and verified locally. The wrappers are exported as named theorems proved from the existing `toNat_*`/`ext_toNat` API.
+
+## Next step
+
+Commit the code and this progress file, then create the PR for #5416.
+
+## Blockers
+
+- #5409 remains blocked on the unresolved analytic core from #5412.
+- A pre-existing `.claude/CLAUDE.md` worktree modification was present before this work and was left unstaged.


### PR DESCRIPTION
Closes #5416

Session: `eee73363-5a93-4119-8c94-0480af8dab64`

e1147fc1 feat: add HexModArith identity wrappers

🤖 Prepared with Claude Code