### PR TITLE
HexGramSchmidt.Int: expose signed scaledCoeffs diagonal loop helper

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3027,6 +3027,59 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDet
   rw [scaledCoeffRows_diag_toNat_eq_gramDetVecEntry (b := b) i hi]
   rw [gramDetVecEntry_eq_gramDet (b := b) (i + 1) (Nat.succ_le_of_lt hi)]
 
+/-- Signed diagonal information from the executable scaled-coefficient loop:
+the diagonal slot is either the zero tail recorded after an earlier singular
+no-pivot step, or the signed diagonal entry in the final no-pivot Bareiss
+matrix for the full Gram matrix. -/
+private theorem scaledCoeffRows_diag_eq_zero_or_eq_noPivotData_diag
+    (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    getArrayEntry (scaledCoeffRows b) i i = 0 ∨
+      getArrayEntry (scaledCoeffRows b) i i =
+        (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).matrix[
+          (⟨i, hi⟩ : Fin n)][(⟨i, hi⟩ : Fin n)] := by
+  let iFin : Fin n := ⟨i, hi⟩
+  have hdiag :=
+    scaledCoeffArrayLoop_diag_matches
+      (state_array :=
+        { step := 0
+          matrix := gramRows b
+          coeffs := zeroRows n
+          prevPivot := 1 })
+      (state_matrix := Matrix.noPivotInitialState (Matrix.gramMatrix b))
+      (by rfl) (rowsToMatrix_gramRows b) (by rfl) (by rfl)
+      (gramRows_size b) (gramRows_row_size b)
+      (zeroRows_size n) (zeroRows_row_size n)
+      (by
+        intro j hjs _hjn
+        simp [Matrix.noPivotInitialState] at hjs)
+      (by
+        intro j _hjs _hjn
+        exact getArrayEntry_zeroRows n j j)
+      n iFin (by
+        left
+        simp [Matrix.noPivotInitialState, iFin, hi])
+  show getArrayEntry
+      (scaledCoeffArrayLoop n n
+        { step := 0
+          matrix := gramRows b
+          coeffs := zeroRows n
+          prevPivot := 1 }).coeffs i i = 0 ∨
+    getArrayEntry
+      (scaledCoeffArrayLoop n n
+        { step := 0
+          matrix := gramRows b
+          coeffs := zeroRows n
+          prevPivot := 1 }).coeffs i i =
+        (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).matrix[iFin][iFin]
+  rcases hdiag with ⟨_h_sing, h_eq⟩ | ⟨s, _h_sing, h_cases⟩
+  · right
+    simpa [Matrix.bareissNoPivotData, Matrix.finish, iFin] using h_eq
+  · rcases h_cases with ⟨_hsi, h_zero⟩ | ⟨_his, h_eq⟩
+    · left
+      simpa [iFin] using h_zero
+    · right
+      simpa [Matrix.bareissNoPivotData, Matrix.finish, iFin] using h_eq
+
 /-- If the diagonal executable entry is known nonnegative, the Nat-level
 diagonal synchronization can be lifted back to the corresponding Int equality.
 That nonnegativity is a bridge-layer obligation for Gram determinants. -/
@@ -3065,6 +3118,19 @@ theorem scaledCoeffs_diag_toNat (b : Matrix Int n m) (i : Nat) (hi : i < n) :
       gramDet b (i + 1) (Nat.succ_le_of_lt hi) := by
   simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using
     scaledCoeffRows_diag_toNat_eq_gramDet (b := b) i hi
+
+/-- Signed diagonal information for the public scaled-coefficient matrix.
+The diagonal slot is either the zero tail recorded after an earlier singular
+no-pivot step, or the signed diagonal entry in the final no-pivot Bareiss
+matrix for the full Gram matrix. -/
+theorem scaledCoeffs_diag_eq_zero_or_eq_noPivotData_diag
+    (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 0 ∨
+      GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
+        (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).matrix[
+          (⟨i, hi⟩ : Fin n)][(⟨i, hi⟩ : Fin n)] := by
+  simpa [scaledCoeffs, data, rowsToMatrix, GramSchmidt.entry, Matrix.row, Matrix.ofFn] using
+    scaledCoeffRows_diag_eq_zero_or_eq_noPivotData_diag (b := b) i hi
 
 theorem scaledCoeffs_diag_of_nonneg
     (b : Matrix Int n m) (i : Nat) (hi : i < n)

--- a/progress/20260519T104534Z_a4ded3d8.md
+++ b/progress/20260519T104534Z_a4ded3d8.md
@@ -1,0 +1,31 @@
+# Session a4ded3d8 - issue #5420
+
+## Accomplished
+
+- Claimed issue #5420 after confirming no unclaimed directives and choosing it over the hardware-sensitive HexLLL benchmark issue.
+- Added a Mathlib-free signed diagonal helper in `HexGramSchmidt/Int.lean`:
+  - private row-array theorem `scaledCoeffRows_diag_eq_zero_or_eq_noPivotData_diag`
+  - public theorem `scaledCoeffs_diag_eq_zero_or_eq_noPivotData_diag`
+- The helper keeps the core API weaker than unconditional `scaledCoeffs_diag`: the diagonal entry is either the zero tail after an earlier no-pivot singular step, or the signed final no-pivot Bareiss diagonal slot for the full Gram matrix.
+- Verified with:
+  - `lake build HexGramSchmidt.Int`
+  - `lake build HexGramSchmidt`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `git diff -- HexGramSchmidt/Int.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)' || true`
+  - `rg -n '\\bsorry\\b' HexGramSchmidt/Int.lean | wc -l`
+  - `rg -n '\\baxiom\\b' HexGramSchmidt/Int.lean | wc -l`
+  - `rg -n '\\bnative_decide\\b' HexGramSchmidt/Int.lean | wc -l`
+- Quality metrics for `HexGramSchmidt/Int.lean` after the change: `sorry`: 2, `axiom`: 0, `native_decide`: 0; no new placeholders were added.
+
+## Current frontier
+
+Issue #5420 is complete locally. The Mathlib bridge follow-up can consume the new signed diagonal dichotomy instead of relying only on `Int.toNat`.
+
+## Next step
+
+Open the PR for issue #5420 and let CI validate the branch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5420

Session: `a4ded3d8-4f10-4ead-97b4-68a19a3af9b5`

5e0cc32a feat: expose scaled coeff diagonal signed helper

🤖 Prepared with Claude Code