### PR TITLE
feat: bridge derivative root products via Mahler bound

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -524,6 +524,43 @@ theorem prod_max_one_norm_roots_derivative_le_of_sum_log_le
     exact lt_of_lt_of_le zero_lt_one (le_max_left (1 : ℝ) ‖α‖)
   · simpa [Multiset.map_map, Function.comp_def] using hlog
 
+theorem prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le
+    (p : ℂ[X])
+    (hderiv : p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure) :
+    (p.derivative.roots.map fun β => max (1 : ℝ) ‖β‖).prod ≤
+      (p.roots.map fun α => max (1 : ℝ) ‖α‖).prod := by
+  by_cases hnatDeg : p.natDegree = 0
+  · rw [derivative_of_natDegree_zero hnatDeg, roots_zero]
+    exact one_le_prod_max_one_norm_roots p
+  have hnatpos : 0 < p.natDegree := Nat.pos_of_ne_zero hnatDeg
+  have hp_ne : p ≠ 0 := by
+    intro hp
+    exact hnatDeg (by simp [hp])
+  have hsub : p.natDegree - 1 + 1 = p.natDegree :=
+    Nat.sub_add_cancel hnatpos
+  have hdeg_deriv : p.derivative.natDegree = p.natDegree - 1 :=
+    natDegree_eq_of_degree_eq_some (degree_derivative_eq p hnatpos)
+  have hcast : ((p.natDegree - 1 : ℕ) : ℂ) + 1 = (p.natDegree : ℂ) := by
+    rw [Nat.cast_sub hnatpos, Nat.cast_one]
+    ring
+  have hlead_deriv : p.derivative.leadingCoeff =
+      p.leadingCoeff * (p.natDegree : ℂ) := by
+    unfold leadingCoeff
+    rw [hdeg_deriv, coeff_derivative, hsub, hcast]
+  rw [mahlerMeasure_eq_leadingCoeff_mul_prod_roots,
+    mahlerMeasure_eq_leadingCoeff_mul_prod_roots] at hderiv
+  rw [hlead_deriv, norm_mul, Complex.norm_natCast] at hderiv
+  have hscale_pos : 0 < (p.natDegree : ℝ) * ‖p.leadingCoeff‖ := by
+    exact mul_pos (Nat.cast_pos.mpr hnatpos)
+      (norm_pos_iff.mpr (leadingCoeff_ne_zero.mpr hp_ne))
+  have hscaled :
+      ((p.natDegree : ℝ) * ‖p.leadingCoeff‖) *
+          (p.derivative.roots.map fun β => max (1 : ℝ) ‖β‖).prod ≤
+        ((p.natDegree : ℝ) * ‖p.leadingCoeff‖) *
+          (p.roots.map fun α => max (1 : ℝ) ‖α‖).prod := by
+    convert hderiv using 1 <;> ring
+  rwa [mul_le_mul_iff_right₀ hscale_pos] at hscaled
+
 theorem mahlerMeasure_derivative_le_derivative_of_boundary_norm_eq_of_roots_le_one_of_derivative_le
     {p q : ℂ[X]}
     (hpderiv : p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure)

--- a/progress/20260519T114039Z_bd8c41eb.md
+++ b/progress/20260519T114039Z_bd8c41eb.md
@@ -1,0 +1,38 @@
+# Session bd8c41eb - issue #5424
+
+## Accomplished
+
+- Claimed issue #5424 after #5429 was concurrently claimed by another agent.
+- Added `Polynomial.prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le`
+  in `HexPolyZMathlib/RobinsonForm.lean`.
+- The new helper proves the exterior derivative-root product comparison from
+  the Mahler derivative bound by handling zero/constant cases and cancelling
+  the positive leading-coefficient scale in the positive-degree case.
+- Verified:
+  - `lake build HexPolyZMathlib.RobinsonForm`
+  - `lake build HexPolyZMathlib`
+  - `python3 scripts/oracle/mahler_schur_counterexample.py`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `git diff -- HexPolyZMathlib/RobinsonForm.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+- Quality metrics remained unchanged:
+  `sorry`: 85, `axiom`: 9, `native_decide`: 1.
+
+## Current frontier
+
+The requested de Bruijn-Springer/Boyd logarithmic radial sum comparison is not
+proved. The local and Mathlib search found no existing theorem; proving it
+still requires the missing analytic majorization argument or a non-circular
+Mahler derivative-bound route.
+
+## Next step
+
+Replan #5424 around the remaining analytic theorem. One practical successor is
+to prove either the de Bruijn-Springer log-sum comparison directly, or prove the
+Mahler derivative bound in a way that is not circular with the downstream
+root-product-to-Mahler assembly.
+
+## Blockers
+
+- The core analytic majorization theorem is absent from Mathlib and from the
+  current project files.


### PR DESCRIPTION
Partial progress on #5424

Session: `bd8c41eb-cf95-4a12-bfa5-fee4dee2f6f5`

eca5c851 feat: bridge derivative root products via Mahler bound

🤖 Prepared with Claude Code