### PR TITLE
HexGF2 Phase 6: expose ofUInt64 coefficient API

### DIFF
--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -508,6 +508,51 @@ def coeff (p : GF2Poly) (n : Nat) : Bool :=
     (ofWords words).coeff n = coeffWords words n := by
   simp [ofWords, coeff, coeffWords_normalizeWords]
 
+/-- Coefficients of a single-word polynomial are the corresponding machine-word bits. -/
+theorem coeff_ofUInt64_eq_testBit (w : UInt64) {i : Nat} (hi : i < 64) :
+    (ofUInt64 w).coeff i = w.toNat.testBit i := by
+  unfold ofUInt64
+  rw [coeff_ofWords]
+  have hiword : i / 64 = 0 := Nat.div_eq_of_lt hi
+  simp [coeffWords, hiword, UInt64.bne_zero_eq_toNat_bne_zero,
+    UInt64.toNat_shiftRight, UInt64.toNat_and, Nat.mod_eq_of_lt hi,
+    bit_eq_one_eq_testBit]
+
+/-- Coefficients above the low machine word vanish for a single-word polynomial. -/
+theorem coeff_ofUInt64_eq_false_of_ge_64 (w : UInt64) {i : Nat} (hi : 64 ≤ i) :
+    (ofUInt64 w).coeff i = false := by
+  unfold ofUInt64
+  rw [coeff_ofWords]
+  have hiword_pos : 0 < i / 64 := Nat.div_pos (by omega) (by decide : 0 < 64)
+  cases hidx : i / 64 with
+  | zero =>
+      omega
+  | succ _ =>
+      simp [coeffWords, hidx]
+
+/-- The packed single-word constructor preserves the underlying machine word. -/
+theorem ofUInt64_injective : Function.Injective ofUInt64 := by
+  intro a b h
+  apply UInt64.toNat_inj.mp
+  apply Nat.eq_of_testBit_eq
+  intro i
+  by_cases hi : i < 64
+  · have hcoeff := congrArg (fun p : GF2Poly => p.coeff i) h
+    simpa [coeff_ofUInt64_eq_testBit _ hi] using hcoeff
+  · have hge : 64 ≤ i := Nat.le_of_not_gt hi
+    rw [show a.toNat.testBit i = false by
+        apply Nat.testBit_eq_false_of_lt
+        have ha64 : a.toNat < 2 ^ 64 := by
+          simpa [UInt64.size] using a.toNat_lt_size
+        exact Nat.lt_of_lt_of_le ha64
+          (Nat.pow_le_pow_right (by decide : 0 < 2) hge),
+      show b.toNat.testBit i = false by
+        apply Nat.testBit_eq_false_of_lt
+        have hb64 : b.toNat < 2 ^ 64 := by
+          simpa [UInt64.size] using b.toNat_lt_size
+        exact Nat.lt_of_lt_of_le hb64
+          (Nat.pow_le_pow_right (by decide : 0 < 2) hge)]
+
 /-- The degree of a nonzero polynomial, if any. -/
 def degree? (p : GF2Poly) : Option Nat :=
   match p.words.back? with

--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -672,13 +672,6 @@ private theorem canonicalWordLT_eq_self_of_lt {n : Nat} (hn64 : n < 64)
   apply UInt64.toNat_inj.mp
   simp [canonicalWordLT, Nat.mod_eq_of_lt hw]
 
-private theorem bit_eq_one_eq_testBit (x i : Nat) :
-    (x >>> i % 2 == 1) = x.testBit i := by
-  rw [Nat.testBit_eq_decide_div_mod_eq]
-  rw [Nat.shiftRight_eq_div_pow]
-  apply decide_eq_decide.mpr
-  exact Iff.rfl
-
 private theorem nat_testBit_eq_false_of_lt_two_pow {x k i : Nat}
     (hx : x < 2 ^ k) (hki : k ≤ i) :
     x.testBit i = false := by
@@ -688,46 +681,6 @@ private theorem nat_testBit_eq_false_of_lt_two_pow {x k i : Nat}
   have hnot : ¬ i < k := Nat.not_lt_of_ge hki
   simp [hnot] at hbit
   exact hbit
-
-private theorem coeff_ofUInt64_eq_testBit (w : UInt64) {i : Nat} (hi : i < 64) :
-    (ofUInt64 w).coeff i = w.toNat.testBit i := by
-  unfold ofUInt64
-  rw [coeff_ofWords]
-  have hiword : i / 64 = 0 := Nat.div_eq_of_lt hi
-  simp [coeffWords, hiword, UInt64.bne_zero_eq_toNat_bne_zero,
-    UInt64.toNat_shiftRight, UInt64.toNat_and, Nat.mod_eq_of_lt hi,
-    bit_eq_one_eq_testBit]
-
-private theorem coeff_ofUInt64_eq_false_of_ge_64 (w : UInt64) {i : Nat} (hi : 64 ≤ i) :
-    (ofUInt64 w).coeff i = false := by
-  unfold ofUInt64
-  rw [coeff_ofWords]
-  have hiword_pos : 0 < i / 64 := Nat.div_pos (by omega) (by decide : 0 < 64)
-  cases hidx : i / 64 with
-  | zero =>
-      omega
-  | succ k =>
-      simp [coeffWords, hidx]
-
-private theorem ofUInt64_injective : Function.Injective ofUInt64 := by
-  intro a b h
-  apply UInt64.toNat_inj.mp
-  apply Nat.eq_of_testBit_eq
-  intro i
-  by_cases hi : i < 64
-  · have hcoeff := congrArg (fun p : GF2Poly => p.coeff i) h
-    simpa [coeff_ofUInt64_eq_testBit _ hi] using hcoeff
-  · have hge : 64 ≤ i := Nat.le_of_not_gt hi
-    rw [show a.toNat.testBit i = false by
-        have ha64 : a.toNat < 2 ^ 64 := by
-          simpa [UInt64.size] using a.toNat_lt_size
-        exact nat_testBit_eq_false_of_lt_two_pow
-          (k := 64) ha64 hge,
-      show b.toNat.testBit i = false by
-        have hb64 : b.toNat < 2 ^ 64 := by
-          simpa [UInt64.size] using b.toNat_lt_size
-        exact nat_testBit_eq_false_of_lt_two_pow
-          (k := 64) hb64 hge]
 
 private theorem coeff_ofUInt64_and_lowerMask (w : UInt64) {n i : Nat} (hn64 : n < 64) :
     (ofUInt64 (w &&& lowerMask n)).coeff i =

--- a/progress/20260519T120446Z_e18c1a1a.md
+++ b/progress/20260519T120446Z_e18c1a1a.md
@@ -1,0 +1,35 @@
+# Session e18c1a1a - HexGF2 ofUInt64 coefficient API (#5455)
+
+## Accomplished
+
+- Claimed issue #5455.
+- Added public `GF2Poly.ofUInt64` characterising lemmas in `HexGF2/Basic.lean`:
+  - `coeff_ofUInt64_eq_testBit`
+  - `coeff_ofUInt64_eq_false_of_ge_64`
+  - `ofUInt64_injective`
+- Removed the private duplicate `ofUInt64` lemmas from `HexGF2/Euclid.lean`, so
+  Euclid now consumes the public Basic-level API.
+- Verified:
+  - `lake build HexGF2.Basic`
+  - `lake build HexGF2.Euclid`
+  - `lake build HexGF2`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `git diff -- HexGF2/Basic.lean HexGF2/Euclid.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'` prints nothing.
+- Quality metrics remain at the recorded baseline: 85 `sorry`, 9 Lean `axiom`
+  word occurrences, 1 `native_decide`.
+
+## Current frontier
+
+`HexGF2.Basic` now exposes the single-word packed constructor API needed by
+downstream code without unfolding `ofUInt64` or depending on Euclid-private
+implementation facts.
+
+## Next step
+
+Push branch `agent/e18c1a1a` and open the PR closing #5455.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5455

Session: `e18c1a1a-44f0-4cb1-b2bd-a39b47ee9528`

43c55ce8 feat: expose GF2 ofUInt64 coefficient API

🤖 Prepared with Claude Code