### PR TITLE
HexGramSchmidtMathlib: prove scaledCoeffs_diag from signed core helper

### DIFF
--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -2444,7 +2444,24 @@ diagonal slot is supplied in this bridge layer. -/
 theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
       Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  sorry
+  let hk : i + 1 ≤ n := Nat.succ_le_of_lt hi
+  rcases scaledCoeffs_diag_eq_zero_or_eq_leadingPrefix_bareiss b i hi with hzero | hbareiss
+  · have hnat := scaledCoeffs_diag_toNat (b := b) i hi
+    rw [hzero] at hnat
+    simp at hnat
+    rw [hzero, ← hnat]
+    simp
+  · apply scaledCoeffs_diag_of_nonneg
+    rw [hbareiss]
+    have hbareiss_eq :
+        Matrix.bareiss
+            (Matrix.leadingPrefix (Matrix.gramMatrix b) (i + 1) hk) =
+          Matrix.det (GramSchmidt.leadingGramMatrixInt b (i + 1) hk) := by
+      rw [← GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+      exact HexMatrixMathlib.bareiss_eq_det
+        (GramSchmidt.leadingGramMatrixInt b (i + 1) hk)
+    rw [hbareiss_eq]
+    exact leadingGramMatrixInt_det_nonneg b (i + 1) hk
 
 /-- The leading executable Gram determinants of a square upper-triangular
 integer matrix with strictly positive diagonal are positive.

--- a/progress/2026-05-19T12-40-19Z_60f6b875.md
+++ b/progress/2026-05-19T12-40-19Z_60f6b875.md
@@ -1,0 +1,41 @@
+# Session 60f6b875 - HexGramSchmidtMathlib scaledCoeffs diagonal (#5453)
+
+## Accomplished
+
+- Claimed issue #5453 after confirming open directives were blocked and the
+  benchmark issue needed quieter hardware than this host currently has.
+- Removed the `sorry` from `HexGramSchmidtMathlib/Int.lean` theorem
+  `scaledCoeffs_diag`.
+- Proved the bridge theorem from the Mathlib-free signed helper
+  `scaledCoeffs_diag_eq_zero_or_eq_leadingPrefix_bareiss`:
+  - zero branch uses `scaledCoeffs_diag_toNat` to force the public `gramDet`
+    value to zero;
+  - Bareiss branch rewrites the leading prefix through
+    `GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram` and
+    `HexMatrixMathlib.bareiss_eq_det`, then applies
+    `leadingGramMatrixInt_det_nonneg`.
+- Verified:
+  - `lake build HexGramSchmidtMathlib.Int`
+  - `lake build HexGramSchmidtMathlib`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - `rg -n 'scaledCoeffs_diag|sorry' HexGramSchmidt/Int.lean HexGramSchmidtMathlib/Int.lean`
+  - diff grep for newly added `axiom`, `native_decide`, `TODO`, `FIXME`, or
+    `sorry` found no matches.
+- Quality counters after the change: repository `sorry` count 84, Lean-file
+  `axiom` occurrences 9, `native_decide` occurrences 1.
+
+## Current frontier
+
+The dependent Mathlib bridge theorem now consumes the signed core helper from
+#5452 and no longer has its local `sorry`.
+
+## Next step
+
+Push `agent/60f6b875` and open the PR closing #5453.
+
+## Blockers
+
+None for #5453. The worktree still has a pre-existing unrelated modification to
+`.claude/CLAUDE.md`; it was not touched for this issue.


### PR DESCRIPTION
Closes #5453

Session: `60f6b875-1c50-4c31-b23a-51bb5192f13f`

fd17c7c8 feat: prove scaledCoeffs diagonal bridge

🤖 Prepared with Claude Code