### PR TITLE
HexModArith Phase 6: add hot-loop associativity wrappers

### DIFF
--- a/HexModArith/HotLoop.lean
+++ b/HexModArith/HotLoop.lean
@@ -1,6 +1,7 @@
 import HexArith.Barrett.Context
 import HexArith.Montgomery.Context
 import HexModArith.Basic
+import HexModArith.Ring
 
 /-!
 Hot-loop optimization wrappers for `hex-mod-arith`.
@@ -196,6 +197,12 @@ theorem mulMod_comm (ctx : BarrettCtx p) (a b : ZMod64 p) :
   change (ZMod64.mul a b).toNat = (ZMod64.mul b a).toNat
   rw [ZMod64.toNat_mul, ZMod64.toNat_mul]
   exact Nat.mul_comm a.toNat b.toNat ▸ rfl
+
+/-- Barrett hot-loop multiplication is associative on standard residues. -/
+theorem mulMod_assoc (ctx : BarrettCtx p) (a b c : ZMod64 p) :
+    ctx.mulMod (ctx.mulMod a b) c = ctx.mulMod a (ctx.mulMod b c) := by
+  rw [mulMod_eq_mul, mulMod_eq_mul, mulMod_eq_mul, mulMod_eq_mul]
+  exact Lean.Grind.Semiring.mul_assoc a b c
 
 end BarrettCtx
 
@@ -422,6 +429,21 @@ theorem fromMont_mulMont_toMont_comm (ctx : MontCtx p) (a b : ZMod64 p) :
   change (ZMod64.mul a b).toNat = (ZMod64.mul b a).toNat
   rw [ZMod64.toNat_mul, ZMod64.toNat_mul]
   exact Nat.mul_comm a.toNat b.toNat ▸ rfl
+
+/--
+The Montgomery round trip for wrapped products is associative on standard
+residue inputs.
+-/
+theorem fromMont_mulMont_toMont_assoc (ctx : MontCtx p) (a b c : ZMod64 p) :
+    ctx.fromMont (ctx.mulMont (ctx.toMont
+        (ctx.fromMont (ctx.mulMont (ctx.toMont a) (ctx.toMont b))))
+      (ctx.toMont c)) =
+    ctx.fromMont (ctx.mulMont (ctx.toMont a)
+      (ctx.toMont
+        (ctx.fromMont (ctx.mulMont (ctx.toMont b) (ctx.toMont c))))) := by
+  rw [fromMont_mulMont_toMont, fromMont_mulMont_toMont,
+    fromMont_mulMont_toMont, fromMont_mulMont_toMont]
+  exact Lean.Grind.Semiring.mul_assoc a b c
 
 end MontCtx
 

--- a/progress/20260519T155914Z_eba609c6.md
+++ b/progress/20260519T155914Z_eba609c6.md
@@ -1,0 +1,39 @@
+# 20260519T155914Z — work session eba609c6
+
+## Accomplished
+
+- Claimed and completed issue #5498.
+- Added `BarrettCtx.mulMod_assoc` to `HexModArith/HotLoop.lean`, adjacent to
+  the existing Barrett hot-loop commutativity wrapper.
+- Added `MontCtx.fromMont_mulMont_toMont_assoc` to
+  `HexModArith/HotLoop.lean`, adjacent to the existing Montgomery round-trip
+  commutativity wrapper.
+- Imported `HexModArith.Ring` so both wrappers reuse the existing
+  `ZMod64` semiring associativity proof instead of duplicating Nat-level
+  modular arithmetic.
+- Verified:
+  - `lake build HexModArith.HotLoop`
+  - `lake build HexModArith`
+  - `lake build`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - added-line grep for `sorry` / `axiom` / `native_decide` / `TODO` /
+    `FIXME`
+- Quality counters unchanged at 84 sorries / 9 axiom occurrences / 1
+  `native_decide`.
+
+## Current frontier
+
+- Hot-loop multiplication wrapper surface now includes associativity for both
+  Barrett and the explicit Montgomery round-trip product spelling requested by
+  the issue.
+
+## Next step
+
+- Possible follow-up: add a separate Montgomery-domain chained-product wrapper
+  only if downstream callers need associativity without round-tripping between
+  products.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #5498

Session: `eba609c6-11f0-4464-8a38-6e6c978224b4`

5bc98317 feat: add hot-loop associativity wrappers

🤖 Prepared with Claude Code