### PR TITLE
doc: extract Boyd derivative comparison route

### DIFF
--- a/progress/20260519T180245Z_cac3156e.md
+++ b/progress/20260519T180245Z_cac3156e.md
@@ -1,0 +1,54 @@
+# 20260519T180245Z — HexLLL Phase 4 benchmark retry
+
+## Accomplished
+
+- Read the current worker-flow instructions, latest progress note, Phase 4 benchmarking/profiling requirements, HexLLL SPEC, `HexLLL/Bench.lean`, and the HexLLL performance report.
+- Confirmed unblocked directive issues were not available; claimed feature issue #4334.
+- Ran `lake exe hexlll_bench list`; it built the benchmark executable and listed all 52 registrations.
+- Ran `lake exe hexlll_bench verify`; all 52 registrations passed.
+- Attempted the five affected scientific registrations from #4334:
+  - `Hex.LLLBench.runSizeReduceChecksum`
+  - `Hex.LLLBench.runGramSchmidtCoeffChecksum`
+  - `Hex.LLLBench.runFirstShortVectorHarshCubicChecksum`
+  - `Hex.LLLBench.runOfBasisHarshCubicChecksum`
+  - `Hex.LLLBench.runFirstShortVectorRandomBoundedChecksum`
+- Released #4334 with a measurement-blocker comment after the retry produced
+  zero verdict-eligible rows.
+- Claimed #5516 after #5514 merged, fast-forwarded to `origin/main`, and
+  confirmed the Jensen helper is present.
+- Inspected `HexPolyZMathlib/RobinsonForm.lean` and found that the nearby
+  theorem `mahlerMeasure_derivative_le_derivative_of_boundary_norm_eq_of_roots_le_one_of_derivative_le`
+  is circular for #5506 because it assumes the global derivative Mahler bound.
+- Searched local Mathlib/Hex sources for an existing derivative/Mahler/Boyd
+  theorem and did not find a reusable non-circular theorem.
+- Decomposed #5516 into #5518 (source-backed theorem-shape extraction) and
+  #5519 (implementation after #5518), then released #5516 for planner triage.
+- Claimed #5518 and completed the theorem-shape extraction in
+  `reports/boyd-debruijn-derivative-comparison.md`.
+- Identified the root-product/log-majorization de Bruijn-Springer comparison
+  as the non-circular route, rather than the false one-root Schur endpoint
+  monotonicity route.
+- Verified `python3 scripts/oracle/mahler_schur_counterexample.py`,
+  `git diff --check`, and grep for banned tokens in the touched report plus
+  `HexPolyZMathlib/RobinsonForm.lean`.
+
+## Current frontier
+
+- The scientific retry was not usable for Phase 4 promotion. The harness measured a per-spawn floor around 1.29-1.34s and all five affected registrations produced zero verdict-eligible rows.
+- The host load was still non-quiet during the attempt (`uptime` near the run showed load averages around 9/13/13 initially and 8/9/10 afterward on a 24-core Apple M2 Ultra).
+- No report or benchmark-code change was made because the run adds no clean evidence.
+- #5516 is now decomposed. #5518 is the next unblocked step; #5519 is blocked
+  on #5518.
+- #5518 has a local report artifact ready for PR creation.
+
+## Next step
+
+- Re-run #4334 on dedicated or demonstrably quiet hardware, or use the release-candidate benchmarking workflow, so the spawn floor is stable enough to produce verdict-eligible rows.
+- For the Boyd derivative chain, merge #5518, then execute #5519 to formalize
+  the root-product/log-majorization theorem and derive the Mahler derivative
+  bound for #5506.
+
+## Blockers
+
+- Measurement environment: current host contention/spawn-floor behavior makes the affected scientific registrations inconclusive for infrastructure reasons.
+- #5519 intentionally depends on #5518.

--- a/reports/boyd-debruijn-derivative-comparison.md
+++ b/reports/boyd-debruijn-derivative-comparison.md
@@ -1,0 +1,105 @@
+# Boyd/de Bruijn-Springer Derivative Comparison
+
+## Source Route
+
+The non-circular route for the Robinson-form derivative chain should use the
+de Bruijn-Springer critical-point product comparison, preferably through the
+weak log-majorization/root-product formulation rather than through one-root
+Schur endpoint monotonicity.
+
+Primary source:
+
+- N. G. de Bruijn and T. A. Springer, "On the zeros of a polynomial and of its
+  derivative II", Proceedings of the Section of Sciences of the Koninklijke
+  Nederlandse Akademie van Wetenschappen te Amsterdam 50(5), 264-270, 1947.
+  The Eindhoven portal records the article metadata and published PDF:
+  <https://research.tue.nl/en/publications/on-the-zeros-of-a-polynomial-and-of-its-derivative-ii>
+
+Readable later formulation:
+
+- G. Schmeisser, "Majorization of the Critical Points of a Polynomial by Its
+  Zeros", Computational Methods and Function Theory 3(1), 95-103, 2003.
+  Its proof cites de Bruijn-Springer and states the product inequality in a
+  form directly aligned with Mahler root products.
+
+Schmeisser's Lemma 9 gives, for a polynomial with zeros `z_ν` and derivative
+zeros `ζ_ν`, the product comparison
+
+```text
+∏_{|ζ_ν| ≥ r} |ζ_ν| / r ≤ ∏_{|z_ν| ≥ r} |z_ν| / r
+```
+
+for every `r > 0`. With `r = 1`, this is exactly the derivative root-product
+comparison needed downstream:
+
+```lean
+theorem prod_max_one_norm_roots_derivative_le_natDegree_mul_prod_max_one_norm_roots
+    (p : ℂ[X]) :
+    (p.derivative.roots.map (fun β => max (1 : ℝ) ‖β‖)).prod ≤
+      (p.roots.map (fun α => max (1 : ℝ) ‖α‖)).prod
+```
+
+The theorem name currently used by #5506 includes `natDegree_mul`, but the
+right-hand side has no extra `natDegree` factor; the degree factor enters only
+when translating this root-product statement into Mahler measure:
+
+```lean
+theorem mahlerMeasure_derivative_le_natDegree_mul_mahlerMeasure
+    (p : ℂ[X]) :
+    p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure
+```
+
+because `p.derivative.leadingCoeff = p.leadingCoeff * p.natDegree` when
+`0 < p.natDegree`.
+
+## Lean Shape
+
+The implementation issue should not try to prove a monotonicity statement for
+`derivativeMahlerAlongLinearFactor` along `schurRootPath`; the committed
+counterexample script shows that the direct and scaled one-step endpoint
+comparisons are false in the needed generality.
+
+The best local theorem target is a root-product/log-majorization theorem over
+the roots of `p.derivative`, independent of Robinson form:
+
+```lean
+theorem prod_max_one_norm_roots_derivative_le_prod_max_one_norm_roots
+    (p : ℂ[X]) :
+    (p.derivative.roots.map (fun β => max (1 : ℝ) ‖β‖)).prod ≤
+      (p.roots.map (fun α => max (1 : ℝ) ‖α‖)).prod
+```
+
+An equivalent logarithmic formulation is also acceptable and may be easier to
+compose with existing local reducers:
+
+```lean
+theorem sum_log_max_one_norm_roots_derivative_le_sum_log_max_one_norm_roots
+    (p : ℂ[X]) :
+    (p.derivative.roots.map fun β => Real.log (max (1 : ℝ) ‖β‖)).sum ≤
+      (p.roots.map fun α => Real.log (max (1 : ℝ) ‖α‖)).sum
+```
+
+`prod_max_one_norm_roots_derivative_le_of_sum_log_le` already converts the
+logarithmic version to the root-product version.
+
+## Implementation Notes
+
+The source theorem is stronger than the Robinson endpoint comparison: it
+directly controls derivative roots by original roots. This means #5506 can
+derive both requested results without reflecting roots one at a time.
+
+For the Mahler inequality, use the same leading-coefficient calculation already
+present in `prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le`,
+but in the forward direction:
+
+1. Split `p.natDegree = 0`, where `p.derivative = 0`.
+2. For positive degree, rewrite both Mahler measures with
+   `mahlerMeasure_eq_leadingCoeff_mul_prod_roots`.
+3. Rewrite `p.derivative.leadingCoeff` as
+   `p.leadingCoeff * (p.natDegree : ℂ)`.
+4. Multiply the root-product theorem by
+   `(p.natDegree : ℝ) * ‖p.leadingCoeff‖`.
+
+The Jensen helper `Polynomial.mahlerMeasure_le_circleAverage_norm` remains a
+valid analytic ingredient, but it is not the shortest path to #5506 once the
+de Bruijn-Springer product comparison is used directly.


### PR DESCRIPTION
Closes #5518

Session: `cac3156e-186a-4cc5-981e-eeadfb463219`

e34648ed doc: extract Boyd derivative comparison route

🤖 Prepared with Claude Code