### PR TITLE
review: polish RowEchelon column-add API

### DIFF
--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -1021,6 +1021,23 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
     grind
   · rw [if_neg hjd]
 
+/-- Adding one column times zero to another leaves the matrix unchanged. -/
+@[simp] theorem colAddRight_zero [Lean.Grind.Semiring R]
+    (M : Matrix R n m) (src dst : Fin m) :
+    colAddRight M src dst 0 = M := by
+  apply Vector.ext
+  intro i hi
+  apply Vector.ext
+  intro j hj
+  let ii : Fin n := ⟨i, hi⟩
+  let jj : Fin m := ⟨j, hj⟩
+  show (colAddRight M src dst 0)[ii][jj] = M[ii][jj]
+  rw [colAddRight_getElem]
+  by_cases hjd : jj = dst
+  · rw [if_pos hjd]
+    grind
+  · rw [if_neg hjd]
+
 /-- Pure data produced by an echelon-form algorithm. -/
 structure RowEchelonData (R : Type u) (n m : Nat) where
   rank : Nat

--- a/progress/20260519T184920Z_ebcd0527.md
+++ b/progress/20260519T184920Z_ebcd0527.md
@@ -1,0 +1,35 @@
+# 20260519T184920Z — HexMatrix RowEchelon column-add API audit
+
+## Accomplished
+
+- Read the latest progress note, worker-flow instructions, HexMatrix Phase 6
+  criteria, the HexMatrix SPEC, and the row/column operation cluster in
+  `HexMatrix/RowEchelon.lean`.
+- Confirmed unblocked directive issues were not claimable; claim attempts for
+  #5521 and #5523 raced with other agents, then claimed review issue #5522.
+- Audited the `colAdd` / `colAddRight` declarations against the adjacent row
+  operation API.
+- Added the missing `@[simp] theorem colAddRight_zero`, matching the existing
+  `rowAdd_zero` and `colAdd_zero` normalization surface for zero column-adds.
+- Verified:
+  - `lake build HexMatrix.RowEchelon`
+  - `lake build HexMatrix`
+  - `python3 scripts/check_dag.py`
+  - `git diff --check`
+  - scoped banned-token grep on `HexMatrix/RowEchelon.lean`
+
+## Current frontier
+
+- `colAddRight` now has the same zero-add simplification coverage as the
+  commutative `colAdd` helper.
+- The existing worktree had a pre-existing `.claude/CLAUDE.md` modification;
+  this session did not touch or commit it.
+
+## Next step
+
+- Open the PR for #5522 with the audit note that no broader determinant, RREF,
+  span/nullspace, or Bareiss follow-up was needed from this pass.
+
+## Blockers
+
+- None for #5522.


### PR DESCRIPTION
Closes #5522

Session: `ebcd0527-caa2-44cd-9405-337c3a48408a`

Audit note: the `colAdd` / `colAddRight` theorem cluster is coherent with the adjacent row-operation API. The only narrow cleanup found was the missing zero-add simplification for `colAddRight`; no determinant, RREF, span/nullspace, or Bareiss follow-up is needed from this pass.

Verification:
- `lake build HexMatrix.RowEchelon`
- `lake build HexMatrix`
- `python3 scripts/check_dag.py`
- `git diff --check`
- scoped banned-token grep on `HexMatrix/RowEchelon.lean`

a8730364 review: polish colAddRight zero simplification