### PR TITLE
HexPolyZMathlib: reduce derivative root product to Schmeisser radius-one

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -620,6 +620,32 @@ theorem prod_max_one_norm_roots_derivative_le_of_sum_log_le
     exact lt_of_lt_of_le zero_lt_one (le_max_left (1 : ℝ) ‖α‖)
   · simpa [Multiset.map_map, Function.comp_def] using hlog
 
+private theorem Multiset.prod_max_one_norm_eq_prod_filter_norm (s : Multiset ℂ) :
+    (s.map fun z => max (1 : ℝ) ‖z‖).prod =
+      ((s.filter fun z => 1 ≤ ‖z‖).map fun z => ‖z‖).prod := by
+  induction s using Multiset.induction_on with
+  | empty => simp
+  | cons z s ih =>
+      by_cases hz : 1 ≤ ‖z‖
+      · simp [hz, ih]
+      · have hz_le : ‖z‖ ≤ 1 := le_of_not_ge hz
+        simp [hz, max_eq_left hz_le, ih]
+
+/--
+The desired derivative root-product comparison follows from the `r = 1`
+instance of Schmeisser's de Bruijn-Springer product inequality.
+-/
+theorem prod_max_one_norm_roots_derivative_le_of_schmeisser_radius_one
+    (p : ℂ[X])
+    (hSchmeisser :
+      ((p.derivative.roots.filter fun β => 1 ≤ ‖β‖).map fun β => ‖β‖).prod ≤
+        ((p.roots.filter fun α => 1 ≤ ‖α‖).map fun α => ‖α‖).prod) :
+    (p.derivative.roots.map fun β => max (1 : ℝ) ‖β‖).prod ≤
+      (p.roots.map fun α => max (1 : ℝ) ‖α‖).prod := by
+  rw [Multiset.prod_max_one_norm_eq_prod_filter_norm,
+    Multiset.prod_max_one_norm_eq_prod_filter_norm]
+  exact hSchmeisser
+
 theorem prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le
     (p : ℂ[X])
     (hderiv : p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure) :

--- a/progress/20260519T185101Z_3f316f8b.md
+++ b/progress/20260519T185101Z_3f316f8b.md
@@ -1,0 +1,37 @@
+# 20260519T185101Z — HexPolyZMathlib Schmeisser reducer
+
+## Accomplished
+
+- Read the latest progress note, worker-flow skill, project conventions, and
+  the relevant HexPolyZ/HexPolyZMathlib SPEC files.
+- Confirmed directive issues were blocked and claimed feature issue #5521.
+- Read `reports/boyd-debruijn-derivative-comparison.md` and the existing
+  Robinson-form derivative/root-product lemmas.
+- Added `prod_max_one_norm_roots_derivative_le_of_schmeisser_radius_one` in
+  `HexPolyZMathlib/RobinsonForm.lean`, reducing the desired max-root-product
+  comparison to Schmeisser's `r = 1` filtered product inequality.
+- Created successor issue #5525 for the remaining Schmeisser/de
+  Bruijn-Springer analytic formalization.
+- Verified `lake build HexPolyZMathlib`,
+  `python3 scripts/oracle/mahler_schur_counterexample.py`, `git diff --check`,
+  and a forbidden-token grep on the touched Lean file.
+
+## Current frontier
+
+- The polynomial/root-product plumbing is now explicit: proving the `r = 1`
+  Schmeisser inequality is enough to expose the final theorem requested by
+  #5521.
+- The actual de Bruijn-Springer/Schmeisser majorization theorem is still
+  missing from Mathlib and from the project.
+
+## Next step
+
+- Execute #5525 by formalizing the `r = 1` derivative-root product inequality
+  over `Polynomial.roots` with multiplicities, then call the new reducer to
+  expose `prod_max_one_norm_roots_derivative_le_prod_max_one_norm_roots`.
+
+## Blockers
+
+- No mechanical blocker remains for this partial PR.
+- Completing the original theorem requires the source analytic majorization
+  argument; it is larger than a local reducer proof and has been split out.


### PR DESCRIPTION
Partial progress on #5521

Session: `3f316f8b-faf0-4923-adf8-02293c2ac734`

07224497 HexPolyZMathlib: reduce root product theorem to Schmeisser radius-one

🤖 Prepared with Claude Code