### PR TITLE
HexPolyZMathlib: remove extra X root from Schmeisser derivative product

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -646,6 +646,27 @@ theorem prod_max_one_norm_roots_derivative_le_of_schmeisser_radius_one
     Multiset.prod_max_one_norm_eq_prod_filter_norm]
   exact hSchmeisser
 
+/--
+The Schmeisser specialization is naturally applied to `X * p.derivative`.
+The extra root contributed by `X` is `0`, hence it is removed by the
+`1 ≤ ‖β‖` filter.
+-/
+theorem roots_filter_norm_product_derivative_le_of_X_mul_derivative
+    (p : ℂ[X])
+    (h :
+      ((((X : ℂ[X]) * p.derivative).roots.filter fun β => 1 ≤ ‖β‖).map fun β => ‖β‖).prod ≤
+        ((p.roots.filter fun α => 1 ≤ ‖α‖).map fun α => ‖α‖).prod) :
+    ((p.derivative.roots.filter fun β => 1 ≤ ‖β‖).map fun β => ‖β‖).prod ≤
+      ((p.roots.filter fun α => 1 ≤ ‖α‖).map fun α => ‖α‖).prod := by
+  by_cases hpderiv : p.derivative = 0
+  · simpa [hpderiv, roots_zero] using h
+  · have hroots :
+        (((X : ℂ[X]) * p.derivative).roots.filter fun β => 1 ≤ ‖β‖) =
+          (p.derivative.roots.filter fun β => 1 ≤ ‖β‖) := by
+      rw [roots_mul (mul_ne_zero X_ne_zero hpderiv), roots_X, Multiset.filter_add]
+      simp
+    rwa [hroots] at h
+
 theorem prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le
     (p : ℂ[X])
     (hderiv : p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure) :

--- a/progress/20260519T204402Z_4cab932b.md
+++ b/progress/20260519T204402Z_4cab932b.md
@@ -1,0 +1,29 @@
+# 2026-05-19T20:44 UTC — HexPolyZMathlib extra X-root bridge
+
+## Accomplished
+
+- Claimed and completed #5547.
+- Added `Polynomial.roots_filter_norm_product_derivative_le_of_X_mul_derivative`
+  in `HexPolyZMathlib/RobinsonForm.lean`.
+- The lemma transfers the radius-one filtered root-product inequality from
+  `X * p.derivative` back to `p.derivative`, explicitly handling the
+  `p.derivative = 0` case and using `roots_mul`, `roots_X`, and
+  `Multiset.filter_add` in the nonzero case.
+
+## Current frontier
+
+- The Schmeisser/de Bruijn-Springer route now has the local adapter that removes
+  the harmless zero root introduced by multiplying the derivative by `X`.
+- The larger analytic source theorem and derivative kernel algebra remain in
+  the neighboring HexPolyZMathlib issues.
+
+## Next step
+
+- Continue with the derivative Schmeisser kernel algebra or the general
+  Schmeisser composition product theorem, depending on queue priority.
+
+## Blockers
+
+- None. `lake build HexPolyZMathlib.RobinsonForm` and `git diff --check`
+  passed, and the project-file diff introduces no new `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #5547

Session: `4cab932b-9858-468f-8340-b61a57ce4bc7`

212fd37c feat: remove derivative X root product bridge

🤖 Prepared with Claude Code