### PR TITLE
HexPolyZMathlib: isolate Schur-Szego composition interface

### DIFF
--- a/HexPolyZMathlib.lean
+++ b/HexPolyZMathlib.lean
@@ -1,5 +1,6 @@
 import HexPolyZMathlib.Basic
 import HexPolyZMathlib.Mignotte
+import HexPolyZMathlib.SchurSzego
 import HexPolyZMathlib.RobinsonForm
 
 /-!

--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -1,4 +1,4 @@
-import HexPolyZMathlib.Basic
+import HexPolyZMathlib.SchurSzego
 import Mathlib.Analysis.Polynomial.MahlerMeasure
 import Mathlib.Analysis.Complex.Polynomial.GaussLucas
 import Mathlib.Analysis.Normed.Module.Convex
@@ -630,91 +630,6 @@ private theorem Multiset.prod_max_one_norm_eq_prod_filter_norm (s : Multiset ℂ
       · simp [hz, ih]
       · have hz_le : ‖z‖ ≤ 1 := le_of_not_ge hz
         simp [hz, max_eq_left hz_le, ih]
-
-/--
-Schmeisser's binomial-normalized composition polynomial at degree bound `n`.
-Its `k`th coefficient is `f_k * g_k / choose n k` for `k ≤ n`, and zero
-above `n`.
--/
-def schmeisserComposition (n : ℕ) (f g : ℂ[X]) : ℂ[X] :=
-  ∑ k ∈ Finset.range (n + 1),
-    monomial k (f.coeff k * (g.coeff k / (Nat.choose n k : ℂ)))
-
-@[simp]
-theorem coeff_schmeisserComposition_of_le
-    (n : ℕ) (f g : ℂ[X]) {k : ℕ} (hk : k ≤ n) :
-    (schmeisserComposition n f g).coeff k =
-      f.coeff k * (g.coeff k / (Nat.choose n k : ℂ)) := by
-  rw [schmeisserComposition, finset_sum_coeff]
-  rw [Finset.sum_eq_single_of_mem k (Finset.mem_range.mpr (Nat.lt_succ_of_le hk))]
-  · simp
-  · intro j hj hne
-    simp [coeff_monomial, hne]
-
-@[simp]
-theorem coeff_schmeisserComposition_of_lt
-    (n : ℕ) (f g : ℂ[X]) {k : ℕ} (hk : n < k) :
-    (schmeisserComposition n f g).coeff k = 0 := by
-  rw [schmeisserComposition, finset_sum_coeff]
-  apply Finset.sum_eq_zero
-  intro j hj
-  have hj_le : j ≤ n := Nat.le_of_lt_succ (Finset.mem_range.mp hj)
-  have hne : j ≠ k := by omega
-  simp [coeff_monomial, hne]
-
-theorem support_schmeisserComposition_subset
-    (n : ℕ) (f g : ℂ[X]) :
-    (schmeisserComposition n f g).support ⊆ Finset.range (n + 1) := by
-  intro k hk
-  by_contra hmem
-  have hk_gt : n < k := by
-    have hle : n + 1 ≤ k := Nat.le_of_not_gt (by simpa using hmem)
-    omega
-  exact (Polynomial.mem_support_iff.mp hk) (coeff_schmeisserComposition_of_lt n f g hk_gt)
-
-theorem natDegree_schmeisserComposition_le
-    (n : ℕ) (f g : ℂ[X]) :
-    (schmeisserComposition n f g).natDegree ≤ n := by
-  rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
-  intro k hk
-  exact coeff_schmeisserComposition_of_lt n f g hk
-
-@[simp]
-theorem schmeisserComposition_zero_left (n : ℕ) (g : ℂ[X]) :
-    schmeisserComposition n 0 g = 0 := by
-  ext k
-  by_cases hk : k ≤ n
-  · simp [coeff_schmeisserComposition_of_le n 0 g hk]
-  · have hk' : n < k := by omega
-    simp [coeff_schmeisserComposition_of_lt n 0 g hk']
-
-@[simp]
-theorem schmeisserComposition_zero_right (n : ℕ) (f : ℂ[X]) :
-    schmeisserComposition n f 0 = 0 := by
-  ext k
-  by_cases hk : k ≤ n
-  · simp [coeff_schmeisserComposition_of_le n f 0 hk]
-  · have hk' : n < k := by omega
-    simp [coeff_schmeisserComposition_of_lt n f 0 hk']
-
-@[simp]
-theorem schmeisserComposition_zero (f g : ℂ[X]) :
-    schmeisserComposition 0 f g = C (f.coeff 0 * g.coeff 0) := by
-  ext k
-  rcases k with _ | k
-  · simp [coeff_schmeisserComposition_of_le 0 f g (Nat.le_refl 0)]
-  · simp [coeff_schmeisserComposition_of_lt 0 f g (Nat.succ_pos k)]
-
-@[simp]
-theorem schmeisserComposition_C_C (n : ℕ) (a b : ℂ) :
-    schmeisserComposition n (C a) (C b) = C (a * b) := by
-  ext k
-  rcases k with _ | k
-  · simp [coeff_schmeisserComposition_of_le n (C a) (C b) (Nat.zero_le n)]
-  · by_cases hk : k.succ ≤ n
-    · simp [coeff_schmeisserComposition_of_le n (C a) (C b) hk]
-    · have hk' : n < k.succ := by omega
-      simp [coeff_schmeisserComposition_of_lt n (C a) (C b) hk']
 
 /--
 The binomial-normalized Schmeisser kernel for the derivative specialization:

--- a/HexPolyZMathlib/SchurSzego.lean
+++ b/HexPolyZMathlib/SchurSzego.lean
@@ -1,0 +1,145 @@
+import HexPolyZMathlib.Basic
+import Mathlib.Analysis.Polynomial.MahlerMeasure
+
+/-!
+Schur-Szego composition plumbing for Schmeisser's root-product theorem.
+
+This file contains only the algebraic and multiset bookkeeping around the
+binomial-normalized composition polynomial.  The analytic
+de Bruijn-Springer/Schmeisser root theorem is proved separately.
+-/
+
+open scoped BigOperators
+
+namespace Polynomial
+
+noncomputable section
+
+/--
+Schmeisser's binomial-normalized composition polynomial at degree bound `n`.
+Its `k`th coefficient is `f_k * g_k / choose n k` for `k ≤ n`, and zero
+above `n`.
+-/
+def schmeisserComposition (n : ℕ) (f g : ℂ[X]) : ℂ[X] :=
+  ∑ k ∈ Finset.range (n + 1),
+    monomial k (f.coeff k * (g.coeff k / (Nat.choose n k : ℂ)))
+
+@[simp]
+theorem coeff_schmeisserComposition_of_le
+    (n : ℕ) (f g : ℂ[X]) {k : ℕ} (hk : k ≤ n) :
+    (schmeisserComposition n f g).coeff k =
+      f.coeff k * (g.coeff k / (Nat.choose n k : ℂ)) := by
+  rw [schmeisserComposition, finset_sum_coeff]
+  rw [Finset.sum_eq_single_of_mem k (Finset.mem_range.mpr (Nat.lt_succ_of_le hk))]
+  · simp
+  · intro j hj hne
+    simp [coeff_monomial, hne]
+
+@[simp]
+theorem coeff_schmeisserComposition_of_lt
+    (n : ℕ) (f g : ℂ[X]) {k : ℕ} (hk : n < k) :
+    (schmeisserComposition n f g).coeff k = 0 := by
+  rw [schmeisserComposition, finset_sum_coeff]
+  apply Finset.sum_eq_zero
+  intro j hj
+  have hj_le : j ≤ n := Nat.le_of_lt_succ (Finset.mem_range.mp hj)
+  have hne : j ≠ k := by omega
+  simp [coeff_monomial, hne]
+
+theorem support_schmeisserComposition_subset
+    (n : ℕ) (f g : ℂ[X]) :
+    (schmeisserComposition n f g).support ⊆ Finset.range (n + 1) := by
+  intro k hk
+  by_contra hmem
+  have hk_gt : n < k := by
+    have hle : n + 1 ≤ k := Nat.le_of_not_gt (by simpa using hmem)
+    omega
+  exact (Polynomial.mem_support_iff.mp hk) (coeff_schmeisserComposition_of_lt n f g hk_gt)
+
+theorem natDegree_schmeisserComposition_le
+    (n : ℕ) (f g : ℂ[X]) :
+    (schmeisserComposition n f g).natDegree ≤ n := by
+  rw [Polynomial.natDegree_le_iff_coeff_eq_zero]
+  intro k hk
+  exact coeff_schmeisserComposition_of_lt n f g hk
+
+theorem complex_nat_choose_ne_zero {n k : ℕ} (hk : k ≤ n) :
+    (Nat.choose n k : ℂ) ≠ 0 := by
+  exact_mod_cast (Nat.choose_pos hk).ne'
+
+theorem real_nat_choose_pos {n k : ℕ} (hk : k ≤ n) :
+    0 < (Nat.choose n k : ℝ) := by
+  exact_mod_cast Nat.choose_pos hk
+
+theorem eq_schmeisserComposition_of_natDegree_le_of_coeff
+    {n : ℕ} {f g h : ℂ[X]}
+    (hdeg : h.natDegree ≤ n)
+    (hcoeff : ∀ k ≤ n,
+      h.coeff k = f.coeff k * (g.coeff k / (Nat.choose n k : ℂ))) :
+    h = schmeisserComposition n f g := by
+  ext k
+  by_cases hk : k ≤ n
+  · rw [hcoeff k hk, coeff_schmeisserComposition_of_le n f g hk]
+  · have hk_gt : n < k := Nat.lt_of_not_ge hk
+    rw [coeff_eq_zero_of_natDegree_lt (lt_of_le_of_lt hdeg hk_gt),
+      coeff_schmeisserComposition_of_lt n f g hk_gt]
+
+@[simp]
+theorem schmeisserComposition_zero_left (n : ℕ) (g : ℂ[X]) :
+    schmeisserComposition n 0 g = 0 := by
+  ext k
+  by_cases hk : k ≤ n
+  · simp [coeff_schmeisserComposition_of_le n 0 g hk]
+  · have hk' : n < k := by omega
+    simp [coeff_schmeisserComposition_of_lt n 0 g hk']
+
+@[simp]
+theorem schmeisserComposition_zero_right (n : ℕ) (f : ℂ[X]) :
+    schmeisserComposition n f 0 = 0 := by
+  ext k
+  by_cases hk : k ≤ n
+  · simp [coeff_schmeisserComposition_of_le n f 0 hk]
+  · have hk' : n < k := by omega
+    simp [coeff_schmeisserComposition_of_lt n f 0 hk']
+
+@[simp]
+theorem schmeisserComposition_zero (f g : ℂ[X]) :
+    schmeisserComposition 0 f g = C (f.coeff 0 * g.coeff 0) := by
+  ext k
+  rcases k with _ | k
+  · simp [coeff_schmeisserComposition_of_le 0 f g (Nat.le_refl 0)]
+  · simp [coeff_schmeisserComposition_of_lt 0 f g (Nat.succ_pos k)]
+
+@[simp]
+theorem schmeisserComposition_C_C (n : ℕ) (a b : ℂ) :
+    schmeisserComposition n (C a) (C b) = C (a * b) := by
+  ext k
+  rcases k with _ | k
+  · simp [coeff_schmeisserComposition_of_le n (C a) (C b) (Nat.zero_le n)]
+  · by_cases hk : k.succ ≤ n
+    · simp [coeff_schmeisserComposition_of_le n (C a) (C b) hk]
+    · have hk' : n < k.succ := by omega
+      simp [coeff_schmeisserComposition_of_lt n (C a) (C b) hk']
+
+/-- Roots outside the radius, weighted by `‖z‖ / r` with multiplicity. -/
+def rootsRadiusProduct (r : ℝ) (s : Multiset ℂ) : ℝ :=
+  ((s.filter fun z => r ≤ ‖z‖).map fun z => ‖z‖ / r).prod
+
+@[simp]
+theorem rootsRadiusProduct_one (s : Multiset ℂ) :
+    rootsRadiusProduct 1 s =
+      ((s.filter fun z => 1 ≤ ‖z‖).map fun z => ‖z‖).prod := by
+  simp [rootsRadiusProduct]
+
+theorem rootsRadiusProduct_eq_div_pow_card {r : ℝ} (s : Multiset ℂ) :
+    rootsRadiusProduct r s =
+      ((s.filter fun z => r ≤ ‖z‖).map fun z => ‖z‖).prod /
+        r ^ (s.filter fun z => r ≤ ‖z‖).card := by
+  rw [rootsRadiusProduct]
+  simp_rw [div_eq_mul_inv]
+  rw [Multiset.prod_map_mul]
+  simp
+
+end
+
+end Polynomial

--- a/progress/20260520T000331Z_0aff7185.md
+++ b/progress/20260520T000331Z_0aff7185.md
@@ -1,0 +1,22 @@
+# 2026-05-20T00:03 UTC — Schur-Szego composition interface
+
+## Accomplished
+
+- Inspected unclaimed work and found blocked directives plus actionable feature #5569.
+- Claimed #5569, determined it was the hard de Bruijn-Springer/Schmeisser source theorem rather than a local API task, decomposed it into #5575 and #5576, and released #5569 for replan.
+- Claimed #5575 and introduced `HexPolyZMathlib/SchurSzego.lean` as the reusable Schur-Szego/Schmeisser composition interface.
+- Moved the existing `schmeisserComposition` coefficient, support, degree, zero, and constant lemmas out of `RobinsonForm.lean` without changing their public names.
+- Added proved plumbing lemmas for nonzero complex binomial denominators, positive real binomial denominators, coefficient extensionality, and radius-product normalization.
+
+## Current frontier
+
+- `RobinsonForm.lean` now imports the isolated Schur-Szego interface and retains the derivative-kernel and extra-root adapters.
+- The analytic radius-one Schur-Szego filtered product theorem remains isolated in #5576, depending on #5575.
+
+## Next step
+
+- Open the PR for #5575. After it lands, #5576 can prove the radius-one source theorem against the new interface, and #5570 can package it for the derivative inequality.
+
+## Blockers
+
+- None for #5575. Verified with `lake build HexPolyZMathlib.SchurSzego`, `lake build HexPolyZMathlib`, `python3 scripts/oracle/mahler_schur_counterexample.py`, `python3 scripts/check_dag.py`, `git diff --check`, and a scoped forbidden-placeholder diff scan.


### PR DESCRIPTION
Closes #5575

Session: `0aff7185-2c07-4947-98e8-515a8e6225f2`

e9ae77a9 HexPolyZMathlib: isolate Schur-Szego composition interface

🤖 Prepared with Claude Code