### PR TITLE
Partial: package Schur-Szego source inequality

### DIFF
--- a/HexPolyZMathlib/SchurSzego.lean
+++ b/HexPolyZMathlib/SchurSzego.lean
@@ -140,6 +140,29 @@ theorem rootsRadiusProduct_eq_div_pow_card {r : ℝ} (s : Multiset ℂ) :
   rw [Multiset.prod_map_mul]
   simp
 
+/--
+Radius-one packaging for Schmeisser's Lemma 9 / de Bruijn-Springer
+composition-polynomial theorem.
+
+The hard analytic source theorem supplies `hsource` from the degree and
+closed-unit-disk hypotheses. This lemma keeps the coefficient-form API used by
+downstream derivative adapters separate from that analytic proof.
+-/
+theorem roots_filter_norm_product_le_of_schmeisserComposition_radius_one_of_source
+    {n : ℕ} {f g h : ℂ[X]}
+    (_hfg_degree : f.natDegree ≤ n ∧ g.natDegree ≤ n)
+    (hh_degree : h.natDegree ≤ n)
+    (hh_coeff : ∀ k ≤ n,
+      h.coeff k = f.coeff k * (g.coeff k / (Nat.choose n k : ℂ)))
+    (_hg_roots : ∀ z ∈ g.roots, ‖z‖ ≤ 1)
+    (hsource :
+      (((schmeisserComposition n f g).roots.filter fun ζ => 1 ≤ ‖ζ‖).map fun ζ => ‖ζ‖).prod ≤
+        ((f.roots.filter fun z => 1 ≤ ‖z‖).map fun z => ‖z‖).prod) :
+    ((h.roots.filter fun ζ => 1 ≤ ‖ζ‖).map fun ζ => ‖ζ‖).prod ≤
+      ((f.roots.filter fun z => 1 ≤ ‖z‖).map fun z => ‖z‖).prod := by
+  rw [eq_schmeisserComposition_of_natDegree_le_of_coeff hh_degree hh_coeff]
+  exact hsource
+
 end
 
 end Polynomial

--- a/progress/20260520T013536Z_45b36d3f.md
+++ b/progress/20260520T013536Z_45b36d3f.md
@@ -1,0 +1,53 @@
+# HexPolyZMathlib Schur-Szego source packaging
+
+Session: `45b36d3f` (work, issue #5576)
+
+## Accomplished
+
+Claimed #5576 after all open directives were rejected by `coordination claim`
+as dependency-blocked. Confirmed the #5575 prerequisite landed as
+`HexPolyZMathlib/SchurSzego.lean`.
+
+Added
+`Polynomial.roots_filter_norm_product_le_of_schmeisserComposition_radius_one_of_source`,
+a proved radius-one coefficient-form packaging lemma for the
+Schmeisser/de Bruijn-Springer source inequality. The lemma preserves
+`Polynomial.roots` multiplicities and keeps the final coefficient API separate
+from the hard analytic source proof.
+
+Verification run:
+
+- `lake build HexPolyZMathlib.SchurSzego` - pass.
+- `lake build HexPolyZMathlib` - pass.
+- `python3 scripts/oracle/mahler_schur_counterexample.py` - pass, prints the
+  expected counterexample route failure.
+- `python3 scripts/check_dag.py` - pass.
+- `git diff --check` - pass.
+- `git diff -- HexPolyZMathlib/SchurSzego.lean | rg -n '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'` - empty.
+
+## Current frontier
+
+The actual analytic Schmeisser Lemma 9 / de Bruijn-Springer
+composition-polynomial inequality is still unformalized. Mathlib does not
+appear to expose this theorem under the obvious `Schmeisser`,
+`deBruijn`/`Bruijn`, `Springer`, or Schur-Szego search terms, so the remaining
+work is a genuine hard source-theorem formalization rather than an adapter.
+
+## Next step
+
+Formalize the source inequality for `schmeisserComposition n f g`:
+
+```lean
+(((Polynomial.schmeisserComposition n f g).roots.filter fun z => 1 <= norm z).map fun z => norm z).prod <=
+  ((f.roots.filter fun z => 1 <= norm z).map fun z => norm z).prod
+```
+
+from the degree hypotheses and the closed-unit-disk root hypothesis on `g`,
+then feed it to the new packaging lemma to discharge #5576's exact
+coefficient-form theorem.
+
+## Blockers
+
+No build blocker for this partial slice. The remaining blocker is mathematical
+scope: proving the de Bruijn-Springer/Schmeisser source theorem itself is much
+larger than the local coefficient and multiset plumbing already present.


### PR DESCRIPTION
Partial progress on #5576

Session: `45b36d3f-9d73-44fe-9183-0e44f421f815`

b5563b27 Add Schur-Szego source packaging

🤖 Prepared with Claude Code