### PR TITLE
HexBerlekampZassenhaus: add default factor entry filter wrappers

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -6302,6 +6302,34 @@ theorem factor_entry_leadingCoeff_pos
     factorWithBound_entry_leadingCoeff_pos
       f (ZPoly.defaultFactorCoeffBound f) entry hmem
 
+/-- Every recorded entry of the default public factorization passes the
+`shouldRecordPolynomialFactor` filter. -/
+theorem factor_entry_shouldRecord
+    (f : ZPoly) (entry : ZPoly × Nat)
+    (hmem : entry ∈ (factor f).factors.toList) :
+    shouldRecordPolynomialFactor entry.1 = true := by
+  simpa [factor_eq_factorWithBound_default] using
+    factorWithBound_entry_shouldRecord
+      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+
+/-- Any recorded entry of the default public factorization comes from the raw
+factor array selected by the fast path, or from the slow fallback when the fast
+path returns `none`, up to sign normalization. -/
+theorem factor_entry_mem_raw_source
+    (f : ZPoly) (entry : ZPoly × Nat)
+    (hmem : entry ∈ (factor f).factors.toList) :
+    ∃ rawFactors : Array ZPoly,
+      (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
+          some rawFactors ∨
+        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
+            none ∧
+          rawFactors =
+            factorSlowFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) ∧
+      ∃ raw ∈ rawFactors.toList, entry.1 = normalizeFactorSign raw := by
+  simpa [factor_eq_factorWithBound_default] using
+    factorWithBound_entry_mem_raw_source
+      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+
 /-- The default public factorization has no duplicate polynomial keys. -/
 theorem factor_pairwise_first
     (f : ZPoly) :

--- a/progress/20260520T050656Z_ec9550da.md
+++ b/progress/20260520T050656Z_ec9550da.md
@@ -1,0 +1,41 @@
+# HexBerlekampZassenhaus default factor entry wrappers
+
+Session: `ec9550da` (work, issue #5617)
+
+## Accomplished
+
+Claimed #5617 after confirming the visible directive issues were dependency
+blocked and the remaining unclaimed directive residuals were #5618 and #5617.
+
+Added the default public API wrappers:
+
+- `factor_entry_shouldRecord`
+- `factor_entry_mem_raw_source`
+
+Both specialize the existing bounded `factorWithBound` entry theorems at
+`ZPoly.defaultFactorCoeffBound f`; executable behavior is unchanged.
+
+Verification completed:
+
+- `lake build HexBerlekampZassenhaus`
+- `lake build HexBerlekampZassenhaus.Conformance`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `git diff -- HexBerlekampZassenhaus/Basic.lean | rg -n -e '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+  returned no matches
+
+## Current frontier
+
+The default `factor` API now exposes the same entry filter and raw-source facts
+that were already available for `factorWithBound`.
+
+## Next step
+
+Issue #5618 can audit the remaining #2637 residuals against the SPEC once the
+parallel scalar-wrapper work and this wrapper slice are visible.
+
+## Blockers
+
+No blockers for this slice. Builds still report pre-existing warnings,
+including existing `sorry` declarations outside this change and the existing
+`HexBerlekampZassenhaus/Basic.lean:6686` warning.


### PR DESCRIPTION
Closes #5617

Session: `ec9550da-a328-402e-a7e0-27d08dc0d035`

a19bc2e0 feat: expose default factor entry wrappers

🤖 Prepared with Claude Code