### PR TITLE
feat: add pivot search zero-suffix converse

### DIFF
--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -181,6 +181,41 @@ theorem findPivot?_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
   apply findPivotAux_eq_zero_of_none M col start (n - start) hfind i hstart
   omega
 
+/-- If every entry in the bounded suffix searched by `findPivotAux` is zero,
+the search fails. -/
+theorem findPivotAux_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
+    (start fuel : Nat)
+    (hzero : ∀ i : Fin n, start ≤ i.val → i.val < start + fuel → M[i][col] = 0) :
+    findPivotAux M col start fuel = none := by
+  induction fuel generalizing start with
+  | zero =>
+      simp [findPivotAux]
+  | succ fuel ih =>
+      by_cases hstart : start < n
+      · have hentry : M[(⟨start, hstart⟩ : Fin n)][col] = 0 :=
+          hzero ⟨start, hstart⟩ (Nat.le_refl _)
+            (show (⟨start, hstart⟩ : Fin n).val < start + (fuel + 1) by
+              simp)
+        have hentryNat : M[start][col.val] = 0 := by
+          simpa using hentry
+        simp [findPivotAux, hstart, hentryNat]
+        apply ih
+        intro i hle hlt
+        exact hzero i (by omega) (by omega)
+      · simp [findPivotAux, hstart]
+
+/-- If every entry in the suffix searched by `findPivot?` is zero, pivot
+search fails. This is the converse of `findPivot?_eq_zero_of_none` and lets
+callers turn a column-zero invariant into the executable no-replacement-pivot
+condition used by `pivotLoop`. -/
+theorem findPivot?_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
+    (start : Nat)
+    (hzero : ∀ i : Fin n, start ≤ i.val → M[i][col] = 0) :
+    findPivot? M col start = none := by
+  apply findPivotAux_eq_none_of_zero M col start (n - start)
+  intro i hle _hlt
+  exact hzero i hle
+
 /-- A pivot returned by `findPivotAux` indexes a nonzero entry in the pivot
 column. -/
 theorem findPivotAux_some_ne_zero (M : Matrix Int n n) (col : Fin n)

--- a/progress/20260520T100453Z_0236af4a.md
+++ b/progress/20260520T100453Z_0236af4a.md
@@ -1,0 +1,47 @@
+# Pivot-search converse partial for Gram zero-pivot invariant
+
+Session: `0236af4a` (work, issue #5667)
+
+## Accomplished
+
+Claimed #5667 and added the executable pivot-search converse in
+`HexMatrix/Bareiss.lean`:
+
+- `Matrix.findPivotAux_eq_none_of_zero`
+- `Matrix.findPivot?_eq_none_of_zero`
+
+These lemmas turn a proved zero suffix in a pivot column into the
+`findPivot? = none` condition needed by `Matrix.pivotLoop_singular_branch_no_pivot`.
+
+## Current frontier
+
+The hard Gram-specific part of #5667 remains: prove, inside the Mathlib-free
+boundary, that a no-pivot zero diagonal in the Gram Bareiss state forces every
+candidate entry below that pivot in the same column to be zero. The existing
+bridge proof in `HexGramSchmidtMathlib/Int.lean` still routes through determinant
+invariants and cannot be copied into `HexGramSchmidt/Int.lean`. Created
+successor issue #5677 for this residual proof.
+
+## Next step
+
+Use the new `Matrix.findPivot?_eq_none_of_zero` after proving the missing
+Mathlib-free column-zero invariant for the singular Gram prefix state (#5677).
+
+## Blockers
+
+No build blocker for this partial slice. The remaining proof needs a
+Mathlib-free Gram/Bareiss positivity or dependency invariant; the current core
+file only has the determinant-bridge route in the Mathlib layer.
+
+Verification completed:
+
+- `lake build HexMatrix.Bareiss`
+- `lake build HexGramSchmidt.Int`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `git diff -- HexMatrix/Bareiss.lean | rg -n -e '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+  returned no matches
+
+Unrelated worktree state:
+
+- `.claude/CLAUDE.md` was already modified and was left untouched.


### PR DESCRIPTION
Partial progress on #5667

Session: `0236af4a-104b-4e7a-9afd-788db1a0d781`

d5645508 feat: add pivot search zero-suffix converse

🤖 Prepared with Claude Code