### PR TITLE
feat: add highest GS coordinate identity for lattice combinations

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3479,6 +3479,118 @@ private theorem foldl_finRange_eq_prefix_of_zero_above
           acc + f ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩) 0 :=
   foldl_finRange_eq_prefix_of_zero_above_from k f 0 hzero
 
+/-- A `List.finRange (k + 1)` fold whose addend vanishes on every strict
+predecessor of `k` reduces to the contribution at the last index. -/
+private theorem foldl_finRange_succ_eq_last_of_zero_below
+    (k : Nat) (f : Fin (k + 1) → Rat) (acc : Rat)
+    (hzero : ∀ j : Fin (k + 1), j.val < k → f j = 0) :
+    (List.finRange (k + 1)).foldl (fun acc j => acc + f j) acc =
+      acc + f ⟨k, Nat.lt_succ_self k⟩ := by
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
+  have hprefix :
+      (List.finRange k).foldl
+          (fun acc i => acc + f (Fin.castSucc i)) acc = acc := by
+    refine foldl_add_eq_acc_rat_int (List.finRange k)
+      (fun i => f (Fin.castSucc i)) acc ?_
+    intro i _hi
+    apply hzero
+    change i.val < k
+    exact i.isLt
+  rw [hprefix]
+  show acc + f (Fin.last k) = acc + f ⟨k, Nat.lt_succ_self k⟩
+  rfl
+
+/-- The `k`-th entry of the row combination of the Gram-Schmidt coefficient
+matrix with a cast integer coefficient vector, when all later integer
+coefficients vanish, equals the cast `k`-th coefficient.
+
+This is the top Gram-Schmidt coordinate specialization consumed by the lattice
+norm lower bound: rows below `k` contribute zero by upper-triangularity,
+row `k` contributes one by the diagonal lemma, and rows above `k` contribute
+zero because the corresponding integer coefficient vanishes. -/
+theorem rowCombination_coeffs_apply_eq_of_zero_above
+    (b : Matrix Int n m) (c : Vector Int n) (k : Fin n)
+    (hzero_above : ∀ j : Fin n, k.val < j.val → c[j] = 0) :
+    (Matrix.rowCombination (coeffs b)
+        (Vector.map (fun x : Int => (x : Rat)) c))[k]
+      = ((c[k] : Int) : Rat) := by
+  let castc : Vector Rat n := Vector.map (fun x : Int => (x : Rat)) c
+  have hcastc_get : ∀ i : Fin n, castc[i] = ((c[i] : Int) : Rat) := by
+    intro i
+    show (Vector.map (fun x : Int => (x : Rat)) c)[i.val]'i.isLt
+        = ((c[i.val]'i.isLt : Int) : Rat)
+    rw [Vector.getElem_map]
+  -- Embed indices from the truncated prefix back into `Fin n`.
+  let liftj : Fin (k.val + 1) → Fin n := fun j =>
+    ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
+  rw [show
+      (Matrix.rowCombination (coeffs b)
+          (Vector.map (fun x : Int => (x : Rat)) c))[k]
+        = (Matrix.rowCombination (coeffs b) castc)[k] from rfl]
+  -- Step 1: rewrite the row-combination entry as a fold over the `k`-th column.
+  have hcol :
+      (Matrix.rowCombination (coeffs b) castc)[k]
+        = (List.finRange n).foldl
+            (fun acc i => acc + (coeffs b)[i][k] * castc[i]) 0 := by
+    show ((coeffs b).transpose * castc)[k] = _
+    rw [Matrix.mulVec_getElem]
+    show Matrix.dot (((coeffs b).transpose).row k) castc = _
+    show (List.finRange n).foldl
+        (fun acc i =>
+          acc + (((coeffs b).transpose).row k)[i] * castc[i]) 0 = _
+    simp only [Matrix.row_getElem, Matrix.transpose_getElem]
+  rw [hcol]
+  -- Step 2: drop the tail above `k` via the zero-above truncation helper.
+  let f : Fin n → Rat := fun i => (coeffs b)[i][k] * castc[i]
+  have habove : ∀ j : Fin n, k.val < j.val → f j = 0 := by
+    intro j hj
+    show (coeffs b)[j][k] * castc[j] = 0
+    rw [hcastc_get j]
+    have hcj : c[j] = 0 := hzero_above j hj
+    rw [hcj]
+    show (coeffs b)[j][k] * (((0 : Int) : Rat)) = 0
+    grind
+  have htrunc :
+      (List.finRange n).foldl (fun acc j => acc + f j) 0
+        = (List.finRange (k.val + 1)).foldl
+            (fun acc j => acc + f (liftj j)) 0 :=
+    foldl_finRange_eq_prefix_of_zero_above k f habove
+  show (List.finRange n).foldl (fun acc j => acc + f j) 0
+      = ((c[k] : Int) : Rat)
+  rw [htrunc]
+  -- Step 3: isolate the contribution at `j = k`, using `coeffs_upper` for the
+  -- entries strictly below `k`.
+  let g : Fin (k.val + 1) → Rat := fun j => f (liftj j)
+  have hbelow : ∀ j : Fin (k.val + 1), j.val < k.val → g j = 0 := by
+    intro j hj
+    show (coeffs b)[liftj j][k] * castc[liftj j] = 0
+    have hentry :
+        GramSchmidt.entry (coeffs b) (liftj j) k = 0 := by
+      have h := coeffs_upper b j.val k.val
+        (Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)) k.isLt hj
+      have hkeq : (⟨k.val, k.isLt⟩ : Fin n) = k := Fin.ext rfl
+      change GramSchmidt.entry (coeffs b) (liftj j) ⟨k.val, k.isLt⟩ = 0 at h
+      rwa [hkeq] at h
+    have : (coeffs b)[liftj j][k] = 0 := hentry
+    rw [this]
+    grind
+  have hisolate :
+      (List.finRange (k.val + 1)).foldl (fun acc j => acc + g j) 0
+        = 0 + g ⟨k.val, Nat.lt_succ_self k.val⟩ :=
+    foldl_finRange_succ_eq_last_of_zero_below k.val g 0 hbelow
+  rw [hisolate]
+  -- Step 4: evaluate `g` at the last index using `coeffs_diag`.
+  change 0 + (coeffs b)[k][k] * castc[k] = ((c[k] : Int) : Rat)
+  rw [hcastc_get k]
+  have hdiag :
+      GramSchmidt.entry (coeffs b) k k = 1 := by
+    have h := coeffs_diag b k.val k.isLt
+    have hkeq : (⟨k.val, k.isLt⟩ : Fin n) = k := Fin.ext rfl
+    rwa [hkeq] at h
+  have hkk : (coeffs b)[k][k] = 1 := hdiag
+  rw [hkk]
+  grind
+
 /-! ### Dot-product symmetry support -/
 
 private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))

--- a/progress/20260520T110258Z_9f058805.md
+++ b/progress/20260520T110258Z_9f058805.md
@@ -1,0 +1,67 @@
+# Highest GS coordinate identity
+
+Session: `9f058805` (work, issue #5657)
+
+## Accomplished
+
+Skipped #5649 first: its `depends-on` listed the parent #5647 which had been
+decomposed into still-open #5657 and #5660. The GS-coordinate decomposition
+API #5649 expects to consume does not yet exist, so the integration proof
+isn't feasible until #5660 (claimed, PR #5682 in CI) and #5657 land.
+
+Claimed #5657 and landed the coefficient-matrix specialization
+(deliverables 1-2 of the issue):
+
+- `rowCombination_coeffs_apply_eq_of_zero_above`: under
+  `∀ j : Fin n, k.val < j.val → c[j] = 0`, the `k`-th entry of
+  `Matrix.rowCombination (coeffs b) (Vector.map (fun x : Int => (x : Rat)) c)`
+  equals `((c[k] : Int) : Rat)`.
+- Private helper `foldl_finRange_succ_eq_last_of_zero_below`: a
+  `List.finRange (k + 1)` fold whose addend vanishes on every strict
+  predecessor of `k` reduces to the contribution at the last index.
+
+The proof uses `Matrix.mulVec_getElem` to expose the column-`k` fold,
+the existing `foldl_finRange_eq_prefix_of_zero_above` to drop the tail
+above `k` (rows above `k` contribute zero because `c[j] = 0`), then the
+new `foldl_finRange_succ_eq_last_of_zero_below` together with
+`coeffs_upper` to isolate the diagonal `(coeffs b)[k][k] = 1` contribution
+from `coeffs_diag`.
+
+## Current frontier
+
+Deliverable 3 of #5657 ("connect to the prefix-span witness from #5656")
+depends on still-open #5660 (PR #5682 in CI). That packaging step needs the
+`Vector.map (...) (Matrix.rowCombination b c) = Matrix.rowCombination (prefixRows ...) c_prefix`
+identity from #5660 to lift the coefficient identity into a prefix-span
+witness on `basis b`. Shipping the coefficient identity as a `--partial`
+PR; the next planner can re-narrow #5657 to the remaining
+prefix-span-connection scope once #5682 merges.
+
+## Next step
+
+Once #5682 merges, the residual #5657 work is purely structural: combine
+this coefficient identity with the prefix-span witness to expose
+`(v : Rat) = Matrix.rowCombination (basis b) d` with `d[k] = (c[k] : Rat)`,
+and use that together with the already-landed
+`rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one` (PR #5658) to
+finally discharge `normSq_latticeVec_ge_min_basis_normSq` from #5649.
+
+## Blockers
+
+None for the landed coefficient identity. Deliverable 3 of #5657 needs
+#5660/#5682 to merge first.
+
+Verification:
+
+- `lake build HexGramSchmidt.Int`
+- `lake build HexGramSchmidt`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- `git diff HexGramSchmidt/Int.lean | rg -nE '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'`
+  returned no matches
+
+Unrelated worktree state:
+
+- `.claude/CLAUDE.md` was already modified and was left untouched.
+- `.claude/commands/` and `.claude/skills/` were already untracked and
+  were left untouched.

--- a/progress/20260520T113517Z_2aea5e7c_repair_5684.md
+++ b/progress/20260520T113517Z_2aea5e7c_repair_5684.md
@@ -1,0 +1,24 @@
+# 2026-05-20T11:35Z — repair session 2aea5e7c for PR #5684
+
+## Accomplished
+
+Claimed PR #5684 and repaired its merge conflict against `origin/main`.
+The conflict was confined to `HexGramSchmidt/Int.lean`; the resolution keeps
+both the PR's highest Gram-Schmidt coordinate identity and the newer
+prefix-span row-combination helpers from `main`.
+
+Ran `lake build HexGramSchmidt` and full `lake build`; both completed
+successfully with only pre-existing `sorry` and linter warnings.
+
+## Current frontier
+
+PR #5684 is locally mergeable after the merge commit and awaits force-push
+plus repair-salvaged marking.
+
+## Next step
+
+Push `agent/9f058805` with `--force-with-lease` and mark PR #5684 salvaged.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Partial progress on #5657

Session: `9f058805-ef1a-4402-801f-957935da492a`

0699e98f chore: add session progress entry for #5657
c66ef6c0 feat: add highest GS coordinate identity for lattice combinations

🤖 Prepared with Claude Code