### PR TITLE
spec: BZ Phase-4 requires AFP comparator, headline correctness theorem, no-fallback discipline

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -58,6 +58,37 @@ scaffolded `def` is fully implemented; only its proofs may be
 "scaffold for the eventual <X> bridge", "honest placeholder", and
 "for now ..." are forbidden in committed code.
 
+### Fallback discipline for total forms of partial helpers
+
+A close relative of the placeholder rule, applying when a partial
+helper (`f : T → Option U`) is wrapped into a total form
+(`f' : T → U`) via a fallback in the `none` branch. Allowed only
+when the per-library SPEC classifies the fallback under exactly
+one of two modes: `unreachable-by-pipeline-invariant` (the bridge
+proves a `_isSome` theorem and the SPEC text cites it by name) or
+`audited-emergency-value` (rare; the SPEC text documents the
+rationale and the call sites that accept the fallback). No third
+mode. *"Refactor later"* is not admissible. The full rule lives
+at [design-principles.md §8](../SPEC/design-principles.md). The
+rollback path that applies to a benchmark-discovered scaffolding
+`def` applies here too.
+
+### Headline correctness theorem (per-library, `done_through ≥ 4`)
+
+Every library that bumps `done_through` past Phase 4 must carry, in
+its Mathlib bridge, a single headline correctness theorem stating
+the end-to-end post-condition of its public API. The per-library
+SPEC names the theorem (typically in a `## Headline correctness
+theorem` section) and the semantic clauses it must establish.
+Intermediate lemmas are admissible when they are either
+(a) load-bearing for some proof of the headline theorem, or
+(b) independently justified as public API, executable checker, or
+regression guard with stated rationale; collections of intermediate
+lemmas that don't compose into the headline theorem are dead
+weight and block the `done_through` bump. The orchestrator
+dispatches the headline theorem as the critical-path artefact, not
+arbitrary bags of per-function obligations that contribute to it.
+
 ### Read the SPEC, not just the issue body
 
 When you pick up an issue, re-read every SPEC file linked in its

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -450,9 +450,44 @@ D1. **`factorFast` always succeeds: `factorFast f ≠ none`.** The theorem is ab
 
     *Reading list:* BHKS §3.2 (Lemma 3.2 / "bad vector"), §5 (Theorem 5.2 termination + eq. 5.3 explicit bound, lines around `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`); §4.4 (why the algorithm exits early in practice via the L'=W certificate); Hadamard's inequality in `Mathlib.LinearAlgebra.Matrix.Determinant`; resultant infrastructure in Mathlib4 (port from Mathlib3 if absent).
 
+## Headline correctness theorem
+
+`HexBerlekampZassenhausMathlib` must carry, and the `done_through ≥ 4` bump is blocked on, an end-to-end theorem with the following **semantic shape**:
+
+> For every nonzero `f : Hex.ZPoly`, the public-API output `φ := Hex.factor f : Hex.Factorization` satisfies all five clauses:
+>
+> 1. **Product preservation.** `Hex.Factorization.product φ = f`.
+> 2. **Primitive irreducibility.** Every `entry ∈ φ.factors` is primitive and `Polynomial.Irreducible (HexPolyZMathlib.toPolynomial entry.1)` holds in the Mathlib sense.
+> 3. **Positive multiplicities.** Every `entry ∈ φ.factors` has `entry.2 > 0`.
+> 4. **No factor associates.** For any two distinct positions in `φ.factors`, the underlying polynomials are not associates of each other.
+> 5. **Scalar carries sign and content.** `φ.scalar` equals the signed integer content of `f` (sign × content per `ZPoly.content` and `ZPoly.leadingCoeff` conventions).
+
+The final Lean name (e.g. `factor_correct`, `factor_irreducible_factorisation`) may differ from this prose, and intermediate predicates such as `IsIrreducibleFactorization` may abbreviate the conjunction, but the five-clause shape is binding.
+
+This is the post-condition of the public API and the contract the combinator advertises in its docstring. **The headline theorem is the critical-path artefact for `done_through ≥ 4`.** Intermediate lemmas are admissible when they are either
+
+- (a) load-bearing for some proof of the headline theorem, or
+- (b) independently justified as public API, executable checker, or regression guard with stated rationale.
+
+Lemmas that satisfy neither are dead weight and should be removed or refactored until they earn their place.
+
+A bridge file that proves an arbitrary collection of intermediate lemmas but does not prove the headline correctness theorem is incomplete by SPEC: the orchestrator must not bump `done_through` to 4 in that state. The local realisation of this clause for the open BZ architectural directive is rewritten in the dispatched rollback issue.
+
 ## Conformance fixtures
 
 Core-tier conformance must include at least one input where true integer factors require a non-trivial subset product of lifted mod-p factors, and at least one input that splits heavily (≥ 4 distinct mod-p factors) over a small admissible prime. Concrete fixture instances live in [HexBerlekampZassenhaus/Conformance.lean](../../HexBerlekampZassenhaus/Conformance.lean) and the JSONL fixture file, not in this spec.
+
+## External comparators
+
+Phase 4 for `hex-berlekamp-zassenhaus` declares one **gating** external comparator:
+
+- **`verified Isabelle BZ (AFP Berlekamp_Zassenhaus; Haskell extraction of factor_int_poly via Factorization_External_Interface.thy)`**. Build via a sibling of [scripts/oracle/setup_lll_isabelle.sh](../../scripts/oracle/setup_lll_isabelle.sh) that targets the AFP `Berlekamp_Zassenhaus` session instead of the Zenodo LLL deposit. Set-up: `isabelle build -b Berlekamp_Zassenhaus` using the AFP release matching the pinned Isabelle, then `isabelle export -d <wrapper-session> -x '*:code/**'` on a wrapper theory that re-exports `factor_int_poly` to Haskell. The generated module is compiled with `ghc -O2` against a persistent stdin/stdout driver per [SPEC/benchmarking.md §External comparators — Process call](../benchmarking.md#external-comparators).
+
+  **Gating goal: `hex/isabelle ≤ 1×` at the largest eligible scaling rung of every registered scientific bench target.** Justification: both implementations are pure-functional verified code extracted to a strict runtime with native integer arithmetic. The `hex-lll` row in [reports/hex-lll-performance.md](../../reports/hex-lll-performance.md) already demonstrates parity is achievable across the dimension ladder against the analogous AFP-extracted LLL binary (hex within ±10%, faster at small `n`). There is no architectural reason hex should require concessional headroom against the BZ comparator.
+
+  *Algorithm-class caveat.* The 1× gate presumes the comparator implements an algorithm of the same class or weaker than hex's. Isabelle's `Berlekamp_Zassenhaus.berlekamp_zassenhaus_factorization` uses classical exhaustive lifted-factor recombination; hex's spec mandates the BHKS van Hoeij CLD construction (see §"Fast path: van Hoeij CLD lattice"), which is strictly more sophisticated and asymptotically better on adversarial inputs, so parity holds without algorithmic-class concession. If a future comparator implements a fundamentally stronger algorithm, this clause must be explicitly amended to loosen the goal or reclassify the comparator.
+
+The fpLLL/python-flint comparators that adjacent libraries declare for their LLL or polynomial-arithmetic surfaces are *informational only* at the BZ level; the verified-Isabelle path is the only same-class (verified-to-verified) comparator and so is the only one classified as gating here.
 
 ## References
 

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -72,6 +72,55 @@
    applies to a benchmark-discovered scaffolding `def` applies to a
    proof a refactor would silently axiomatise.
 
+8. **Fallback discipline for total forms of partial helpers.** A
+   close relative of principle 7. Pipelines sometimes contain a
+   helper of shape
+
+   ```lean
+   def helper (f : T) : U :=
+     match helperOpt f with
+     | some x => x
+     | none => fallback f
+   ```
+
+   where the `Option`-returning `helperOpt` is the natural
+   mathematical object and `helper`'s total form exists for
+   downstream type-signature convenience. The `none` branch is a
+   **fallback**.
+
+   A total form of a partial helper is admissible **only** when
+   the SPEC text classifies the fallback under exactly one of the
+   following:
+
+   - **`unreachable-by-pipeline-invariant`** — the bridge file
+     proves a theorem `helperOpt?_isSome_of_<precondition>`
+     showing the `none` branch is unreachable on inputs that the
+     public API passes downstream. The SPEC text cites the theorem
+     by name and states the pipeline invariant it relies on. The
+     `none` branch may then return an arbitrary value;
+     semantically it is dead code.
+   - **`audited-emergency-value`** — the fallback's behaviour is
+     mathematically safer than crashing (e.g. a verifiable
+     identity element, an explicit failure record that downstream
+     consumers inspect), every call site explicitly audits this,
+     and the SPEC text states the rationale and lists the call
+     sites that accept the fallback. This mode is rare.
+
+   A total form of a partial helper without one of these two
+   classifications is a SPEC violation. The remedy is to either
+   prove the unreachability theorem, document the audit (and pass
+   each call site's audit), or **remove the total form** by
+   propagating the `Option` upward through the pipeline until the
+   public API takes explicit responsibility for the `none` case.
+   *"Refactor later"* is not an admissible classification; it is
+   principle 7 restated.
+
+   This rule applies retroactively: existing total forms of
+   partial helpers must be either proved unreachable, documented
+   and audited, or removed before any `done_through` bump past
+   the phase in which the helper lives. The same rollback path
+   that applies under principle 7 applies here.
+
 ## Lakefile
 
 Use `precompileModules := true` only on libraries that export

--- a/libraries.yml
+++ b/libraries.yml
@@ -308,6 +308,10 @@ libraries:
     done_through: 0
     status: active
     phase4:
+      comparators:
+        - tool: "verified Isabelle BZ (AFP Berlekamp_Zassenhaus; Haskell extraction of factor_int_poly via Factorization_External_Interface)"
+          class: gating
+          goal: "Lean BZ is at least as fast as the verified Isabelle BZ on shared canonical inputs at the largest eligible scaling rung of every registered scientific bench target. Algorithm-class caveat per SPEC/Libraries/hex-berlekamp-zassenhaus.md §External comparators: the 1× gate presumes the comparator implements an algorithm of the same class or weaker than hex's; Isabelle's classical exhaustive recombination is weaker than hex's BHKS van Hoeij CLD."
       input_families:
         - name: public-factor-combinator
           description: Public `factor` combinator on deterministic split integer-polynomial smoke inputs, covering the fast-with-slow-fallback API surface.

--- a/progress/20260530T095354Z_bz-spec-comparator-headline-theorem.md
+++ b/progress/20260530T095354Z_bz-spec-comparator-headline-theorem.md
@@ -1,0 +1,72 @@
+**Accomplished**
+
+- Investigated `HexBerlekampZassenhaus.factor` against Isabelle/AFP's
+  extracted-Haskell `factor_int_poly` and identified a live regression:
+  hex BZ returns mathematically wrong factorisations on
+  `(x-1)(x-2)…(x-n)` for several `n ∈ [11, 24]` and is 200–2,400×
+  slower than the AFP comparator even when correct. Root cause is
+  `isGoodPrime`'s `gcd == 1` check rejecting square-free polynomials
+  whose `DensePoly.gcd` returns a non-monic unit, which then triggers
+  the silent `fallbackPrimeChoiceData → p = 3` cascade. Full diagnosis
+  + five orchestration gaps in
+  [reports/bz-vs-isabelle-investigation.md](../reports/bz-vs-isabelle-investigation.md).
+- Produced this SPEC-clarification PR per the
+  `spec-driven-development` skill discipline (SPEC PR first, worker
+  issues against the new SPEC second). The PR codifies four
+  orchestration requirements that the project did not have when BZ's
+  Phase-4 bench scaffolding landed under HO-3 (#2566):
+  - `SPEC/Libraries/hex-berlekamp-zassenhaus.md`: new
+    `## External comparators` section declaring the verified-Isabelle
+    BZ comparator as `gating` with goal `hex/isabelle ≤ 1×` and an
+    explicit algorithm-class caveat, and new
+    `## Headline correctness theorem` section pinning the semantic
+    shape of `factor`'s post-condition (five clauses: product
+    preservation, primitive irreducibility, positive multiplicities,
+    no factor associates, scalar carries sign × content).
+  - `libraries.yml`: `HexBerlekampZassenhaus.phase4.comparators` entry
+    matching the SPEC clause.
+  - `SPEC/design-principles.md`: new principle 8 ("Fallback discipline
+    for total forms of partial helpers"), sibling of principle 7, with
+    exactly two admissible classifications
+    (`unreachable-by-pipeline-invariant` /
+    `audited-emergency-value`). `refactor-pending` is not admissible;
+    existing total forms must be proved unreachable or removed before
+    the next `done_through` bump past their phase.
+  - `PLAN/Conventions.md`: cross-reference paragraphs making both new
+    SPEC rules discoverable from the per-session conventions read.
+- Drafted dispatched worker artefacts (file these after the SPEC PR
+  merges):
+  [reports/bz-spec-comparator-pr-draft.md](../reports/bz-spec-comparator-pr-draft.md)
+  (the PR body itself, in long form),
+  [reports/bz-rollback-issue-draft.md](../reports/bz-rollback-issue-draft.md)
+  (HO-5 + four children HO-5a/b/c/d), and a separate tactical
+  `isGoodPrime` fix issue bundled with the failing-conformance
+  fixtures.
+- Moved the investigation's diagnostic Lean files + Python
+  comparators + plotting scripts to
+  [reports/scratch/](../reports/scratch/) with a README documenting
+  what each one probes, so the evidence persists alongside the
+  reports rather than as orphaned working-tree state.
+
+**Current frontier**
+
+- This PR is SPEC text + metadata only. It does not touch Lean code.
+- After merge, the dispatched worker issues land: HO-1 (#2564)
+  reframed in place to name the headline correctness theorem as its
+  deliverable (preserving the existing additive-vs-multiplicative
+  lattice diagnosis); HO-5 coordination issue + four children
+  (HO-5a wires the comparator with an acceptance matrix, HO-5b
+  rewrites the perf report against ratios, HO-5c extends the bench
+  schedules, HO-5d removes `fallbackPrimeChoiceData`); a bundled
+  tactical `isGoodPrime`-fix-plus-fixtures issue.
+
+**Next step**
+
+- Kim reviews and (per spec-driven-development doctrine) merges this
+  PR. After merge, the worker issues above are filed; HO-1 is
+  edited in place.
+
+**Blockers**
+
+- None for this PR. The PR is dispatchable on its own; downstream
+  work blocks on merge.

--- a/reports/bz-rollback-issue-draft.md
+++ b/reports/bz-rollback-issue-draft.md
@@ -1,0 +1,195 @@
+# Draft issue: rollback BZ Phase-4 bench scaffolding pending new SPEC clauses
+
+**Purpose of this draft.** Captures the rollback work that the SPEC
+update PR ([reports/bz-spec-comparator-pr-draft.md](bz-spec-comparator-pr-draft.md))
+dispatches. The Phase-4 bench scaffolding shipped under HO-3
+([#2566](https://github.com/kim-em/hex/issues/2566)) does not satisfy
+the new SPEC clauses (no comparator, no headline correctness theorem,
+unaudited fallbacks), so the scaffolding must be re-executed against
+the new rules before any future Phase-4 work on BZ proceeds.
+
+Four related but separable worker issues follow this one (HO-5a/b/c/d).
+They are filed once the SPEC PR merges; this issue is the orchestrator's
+coordination point.
+
+---
+
+## Title
+
+```
+HO-5: rollback BZ Phase-4 bench scaffolding, re-run against verified Isabelle BZ comparator
+```
+
+## Labels
+
+`directive`
+
+(The SPEC PR's `blocked` state resolves on merge. By the time this
+issue is filed the dependency is satisfied; it is *open and
+dispatchable*, not blocked.)
+
+## Body
+
+### Current state
+
+After merging the SPEC update PR
+([drafted at reports/bz-spec-comparator-pr-draft.md](../reports/bz-spec-comparator-pr-draft.md)),
+the existing BZ Phase-4 bench scaffolding shipped under HO-3
+([#2566](https://github.com/kim-em/hex/issues/2566)) no longer
+satisfies the SPEC. Specifically:
+
+1. `phase4.comparators` is empty for `HexBerlekampZassenhaus` in
+   [libraries.yml](../blob/main/libraries.yml). The new SPEC clause
+   `## External comparators` requires a `verified Isabelle BZ` entry
+   classified `gating` with goal `hex/isabelle ≤ 1×`.
+2. [reports/hex-berlekamp-zassenhaus-performance.md](../blob/main/reports/hex-berlekamp-zassenhaus-performance.md)
+   records Phase-4 verdicts against an internal complexity model only,
+   with no external-comparator ratio. Without the ratio there is no
+   way to distinguish "schedule too short" from "algorithm doing wrong
+   work", which is exactly the failure mode that masked the
+   `isGoodPrime` cascade documented in
+   [reports/bz-vs-isabelle-investigation.md](../blob/main/reports/bz-vs-isabelle-investigation.md).
+3. [HexBerlekampZassenhausMathlib/](../blob/main/HexBerlekampZassenhausMathlib/)
+   does not state the headline correctness theorem mandated by the new
+   SPEC clause `## Headline correctness theorem`. The clause blocks
+   `done_through ≥ 4` until the theorem is proved.
+4. `fallbackPrimeChoiceData` at
+   [HexBerlekampZassenhaus/Basic.lean#L1966](../blob/main/HexBerlekampZassenhaus/Basic.lean#L1966)
+   is a total form of a partial helper in the sense of the new
+   `SPEC/design-principles.md §"Fallback discipline for total forms of
+   partial helpers"` clause. It has neither an
+   `unreachable-by-pipeline-invariant` theorem nor an
+   `audited-emergency-value` rationale; per the new clause it is a
+   SPEC violation and must be either proved unreachable or removed.
+
+### Deliverables
+
+This is a coordination issue. Four child issues do the actual work
+and are dispatched alongside this issue:
+
+1. **HO-5a — wire `verified Isabelle BZ` Phase-4 comparator.**
+   Add `scripts/oracle/setup_bz_isabelle.sh` mirroring the existing
+   [scripts/oracle/setup_lll_isabelle.sh](../blob/main/scripts/oracle/setup_lll_isabelle.sh)
+   as the starting template. The worker must satisfy the following
+   **acceptance matrix** before the issue closes — without it, the
+   comparator's numbers may be incomparable to hex's and the gate
+   becomes meaningless:
+
+   1. `isabelle build -b Berlekamp_Zassenhaus` against the pinned AFP
+      release completes with the session heap cached on the CI runner.
+   2. A wrapper theory under `scripts/oracle/` exports
+      `factor_int_poly` (or chosen equivalent) to Haskell via
+      `export_code …`; `ghc -O2` produces a runnable binary.
+   3. The persistent-subprocess driver accepts polynomials in a
+      canonical wire format (e.g. JSON `{"coeffs":[…]}`, leading-
+      coefficient convention fixed in the SPEC text) and emits
+      factor lists in a matching format.
+   4. **Correctness gate before timing.** On a small fixture set whose
+      true factorisation is hand-verifiable (e.g. `(x-1)(x-2)`, `Φ₅`,
+      `(x²-2)(x²-3)`), hex's `Factorization.factors` and Isabelle's
+      output produce the **same factor multiset** under a stated
+      canonical ordering (e.g. sort by leading coefficient then lex on
+      coefficient vector; monic representatives; positive
+      multiplicities). Multiset equality, not list equality.
+   5. Per-call process startup overhead is measured separately and
+      reported as the "subtracted baseline" of the ratio computation.
+      Subprocess startup dominates small-`n` measurements otherwise
+      (as observed for the AFP LLL `svp_verified` binary during the
+      investigation).
+   6. The driver respects persistent-subprocess semantics per
+      [SPEC/benchmarking.md §"External comparators — Process call"](../blob/main/SPEC/benchmarking.md):
+      the process stays alive across inputs in a measurement window,
+      so warm-up does not bleed into the first measurement of each new
+      sample.
+
+2. **HO-5b — rewrite [reports/hex-berlekamp-zassenhaus-performance.md](../blob/main/reports/hex-berlekamp-zassenhaus-performance.md)
+   against the new comparator.** Re-run every existing scientific
+   bench target with the comparator wired. Record `hex/isabelle`
+   ratios. Replace internal-model verdicts with ratio-based verdicts
+   per the new SPEC clause. Existing inconclusive internal-model
+   verdicts become informational appendix entries; the headline
+   report runs on the comparator ratios with the 1× gate.
+
+   Label: `feature, directive`. `depends-on: HO-5a`.
+
+3. **HO-5c — extend the bench schedules.** Per the post-mortem
+   §"Gap 3", the existing `splitScientificSchedule = #[2, 3, 4, 5]`
+   cannot exercise the bug class that the new comparator's existence
+   is meant to detect. Extend the schedule to at least `n ∈ [11, 24]`
+   on the deterministic split family, and add a `fallback-probe`
+   family that constructs inputs known to exercise the prime-search
+   cascade. This is *bench-only* — failing-conformance fixtures are
+   a separate, bundled-with-fix issue (see the tactical `isGoodPrime`
+   fix issue, filed independently).
+
+   Label: `feature, directive`. `depends-on: HO-5a`.
+
+4. **HO-5d — remove `fallbackPrimeChoiceData`.** The new SPEC clause
+   `SPEC/design-principles.md §"Fallback discipline for total forms of
+   partial helpers"` admits exactly two classifications, and
+   `refactor-pending` is not one of them. The fallback must be either
+   proved unreachable or removed. Two acceptable resolutions, worker
+   chooses:
+
+   - (a) **Prove unreachability.** Add
+     `choosePrimeData?_isSome_of_<sf-primitive-input>` to
+     `HexBerlekampZassenhausMathlib`, citing the precondition that
+     the public `factor` pipeline already establishes via
+     `normalizeForFactor`. Reshape `choosePrimeData` to consume the
+     theorem at the match site so the `none` branch becomes literally
+     dead code. Add the SPEC text citing the theorem and the
+     pipeline invariant per Change 4 of the SPEC PR.
+   - (b) **Propagate `Option` upward.** Change `choosePrimeData`'s
+     return type to `Option PrimeChoiceData` and update every
+     production caller (`factorFastFactorsWithBound`,
+     `factorSlowWithBound`, …) so the public `factor` itself
+     short-circuits on `none`. This option surfaces the question
+     "what should `factor` do when no candidate prime works?" rather
+     than masking it. The natural long-term answer is to extend the
+     prime search à la Isabelle's `find_prime`; the
+     prime-search-extension issue is filed as part of HO-5d's
+     deliverables regardless of which resolution this issue picks.
+
+   Label: `bug, directive`. `depends-on: HO-5a` (so the comparator
+   informs whether the removal regresses performance).
+
+HO-5a is the upstream bottleneck; HO-5b/c/d block on it.
+
+### Out of scope
+
+- The `isGoodPrime` correctness fix itself. It is dispatched as a
+  separate tactical issue (bundled with the failing conformance
+  fixtures that exercise it, since CI cannot accept failing fixtures
+  without the fix landing in the same PR).
+- HO-1 ([#2564](https://github.com/kim-em/hex/issues/2564))'s
+  architectural rewrite to BHKS van Hoeij CLD. HO-1 is reframed in
+  place to name the headline correctness theorem as its deliverable;
+  this rollback does not duplicate that work.
+- Wider orchestrator changes for other libraries' total-of-`Option`
+  helpers. The new `SPEC/design-principles.md` clause applies
+  prospectively across the project, but per-library audits land as
+  separate issues per library.
+
+### Verification
+
+This issue closes when HO-5a, HO-5b, HO-5c, HO-5d are all closed
+*and* `reports/hex-berlekamp-zassenhaus-performance.md` runs verdicts
+on `hex/isabelle` ratios per the new SPEC clause. The Phase-3 work
+(conformance fixtures, cross-check oracle, JSONL corpus) stays;
+only the Phase-4 bench scaffolding is rolled forward against the
+new comparator and ratio verdicts.
+
+`status.py HexBerlekampZassenhaus` should report HO-5 as the
+critical-path Phase-4 blocker until then. HO-1 (#2564) remains the
+critical-path Phase-1 blocker independently.
+
+### Context
+
+- Post-mortem driving this rollback:
+  [reports/bz-vs-isabelle-investigation.md](../blob/main/reports/bz-vs-isabelle-investigation.md)
+- SPEC PR that dispatches this issue (merged):
+  [reports/bz-spec-comparator-pr-draft.md](../blob/main/reports/bz-spec-comparator-pr-draft.md)
+- Related (the architectural directive, now reframed): #2564
+- Related (the closed Phase-4 bench scaffolding being rolled forward): #2566
+
+🤖 Prepared with Claude Code

--- a/reports/bz-spec-comparator-pr-draft.md
+++ b/reports/bz-spec-comparator-pr-draft.md
@@ -1,0 +1,276 @@
+# Draft PR: hex-berlekamp-zassenhaus SPEC — comparator, headline
+correctness theorem, no-fallback discipline
+
+**Purpose of this draft.** Captures the SPEC-level changes that
+[reports/bz-vs-isabelle-investigation.md](bz-vs-isabelle-investigation.md)
+identifies as the orchestration gaps that allowed the `isGoodPrime` /
+`fallbackPrimeChoiceData` cascade to ship. The draft is structured as a
+single PR (four coupled changes); review notes at the bottom flag
+which clauses are load-bearing for the post-mortem and which are
+project-hygiene cleanup.
+
+This is an *interactive-Claude SPEC-clarification PR* per the
+[`spec-driven-development`](../../../.claude/skills/spec-driven-development/SKILL.md)
+skill — the clauses introduced here resolve orchestration gaps that
+worker agents (per
+[`PLAN/Conventions.md §"SPEC immutability"`](../PLAN/Conventions.md))
+cannot address on their own. Human review by Kim is the merge gate.
+
+This PR is **SPEC text + libraries.yml metadata only**. It does not
+touch Lean code. The rollback issue
+([reports/bz-rollback-issue-draft.md](bz-rollback-issue-draft.md))
+dispatches the implementation work the new SPEC clauses require.
+
+---
+
+## Title
+
+```
+spec: BZ Phase-4 requires AFP comparator, headline correctness theorem, no-fallback discipline
+```
+
+## Body
+
+This PR codifies four orchestration requirements for
+`hex-berlekamp-zassenhaus` that the project did not have when the
+current Phase-4 bench scaffolding landed under HO-3 (#2566). All four
+trace to a single live regression — hex BZ's `factor` returns
+mathematically wrong output on `(x-1)…(x-n)` for several `n ∈ [11, 24]`
+and is 200–2,400× slower than the AFP Isabelle BZ extracted-Haskell
+binary even when correct — investigated in
+[reports/bz-vs-isabelle-investigation.md](../reports/bz-vs-isabelle-investigation.md).
+The investigation traces the bug to:
+
+1. No external comparator was declared for BZ, so the wall-time blow-up
+   could not be distinguished from "schedule too short".
+2. The Mathlib bridge proved per-function soundness lemmas but no
+   end-to-end pipeline theorem, so the wrong-output bug had nowhere to
+   surface.
+3. `choosePrimeData` fell through to a hard-coded `p = 3` via
+   `fallbackPrimeChoiceData` when no candidate prime passed an overly
+   strict `isGoodPrime`, with no theorem guarding the fallback.
+
+This PR is the spec change. Worker issues for the implementation work
+land separately (see linked issues below).
+
+### Change 1: `SPEC/Libraries/hex-berlekamp-zassenhaus.md` — add a
+`## External comparators` section
+
+Add the following section between the existing `## Conformance
+fixtures` and `## References` sections:
+
+```markdown
+## External comparators
+
+Phase 4 for `hex-berlekamp-zassenhaus` declares one **gating** external
+comparator:
+
+- **`verified Isabelle BZ (AFP Berlekamp_Zassenhaus; Haskell extraction
+  of `factor_int_poly` via `Factorization_External_Interface.thy`)`**.
+  Build via a sibling of
+  [scripts/oracle/setup_lll_isabelle.sh](../../scripts/oracle/setup_lll_isabelle.sh)
+  that targets the AFP `Berlekamp_Zassenhaus` session instead of the
+  Zenodo LLL deposit. Set-up: `isabelle build -b Berlekamp_Zassenhaus`
+  using the AFP release matching the pinned Isabelle, then
+  `isabelle export -d <wrapper-session> -x '*:code/**'` on a
+  wrapper theory that re-exports `factor_int_poly` to Haskell. The
+  generated module is compiled with `ghc -O2` against a persistent
+  stdin/stdout driver per
+  [SPEC/benchmarking.md §External comparators — Process call](../benchmarking.md#external-comparators).
+
+  **Gating goal: `hex/isabelle ≤ 1×` at the largest eligible scaling
+  rung of every registered scientific bench target.** Justification:
+  both implementations are pure-functional verified code extracted to
+  a strict runtime with native integer arithmetic. The
+  `hex-lll` row in [reports/hex-lll-performance.md](../../reports/hex-lll-performance.md)
+  already demonstrates parity is achievable across the dimension
+  ladder against the analogous AFP-extracted LLL binary (hex within
+  ±10%, faster at small `n`). There is no architectural reason hex
+  should require concessional headroom against the BZ comparator.
+
+  *Algorithm-class caveat.* The 1× gate presumes the comparator
+  implements an algorithm of the same class or weaker than hex's.
+  Isabelle's `Berlekamp_Zassenhaus.berlekamp_zassenhaus_factorization`
+  uses classical exhaustive lifted-factor recombination; hex's spec
+  mandates the BHKS van Hoeij CLD construction (see §"Recombination"),
+  which is strictly more sophisticated and asymptotically better on
+  adversarial inputs, so parity holds without algorithmic-class
+  concession. If a future comparator implements a fundamentally
+  stronger algorithm, this clause must be explicitly amended to
+  loosen the goal or reclassify the comparator.
+
+The fpLLL/python-flint comparators that adjacent libraries declare for
+their LLL or polynomial-arithmetic surfaces are *informational only*
+at the BZ level; the verified-Isabelle path is the only same-class
+(verified-to-verified) comparator and so is the only one classified
+as gating here.
+```
+
+### Change 2: `libraries.yml` — add `phase4.comparators`
+
+In the `HexBerlekampZassenhaus` block, add:
+
+```yaml
+      comparators:
+        - tool: "verified Isabelle BZ (AFP Berlekamp_Zassenhaus, Haskell extraction of factor_int_poly via Factorization_External_Interface)"
+          class: gating
+          goal: "wallclock ratio hex/isabelle ≤ 1× at the largest eligible scaling rung of every registered scientific bench target; algorithm-class caveat per the SPEC §External comparators clause"
+```
+
+This is structurally identical to `HexLLL`'s `verified Isabelle LLL`
+entry except for the tool/source pointer and the tighter 1× goal.
+
+### Change 3: `SPEC/Libraries/hex-berlekamp-zassenhaus.md` — add a `##
+Headline correctness theorem` section after the existing `## Proof
+obligations Group C` section
+
+```markdown
+## Headline correctness theorem
+
+`HexBerlekampZassenhausMathlib` must carry, and the `done_through ≥ 4`
+bump is blocked on, an end-to-end theorem with the following
+**semantic shape**:
+
+> For every nonzero `f : Hex.ZPoly`, the public-API output
+> `φ := Hex.factor f : Hex.Factorization` satisfies all five clauses:
+>
+> 1. **Product preservation.** `Hex.Factorization.product φ = f`.
+> 2. **Primitive irreducibility.** Every `entry ∈ φ.factors` is
+>    primitive and `Polynomial.Irreducible
+>    (HexPolyZMathlib.toPolynomial entry.1)` holds in the Mathlib sense.
+> 3. **Positive multiplicities.** Every `entry ∈ φ.factors` has
+>    `entry.2 > 0`.
+> 4. **No factor associates.** For any two distinct positions in
+>    `φ.factors`, the underlying polynomials are not associates of
+>    each other.
+> 5. **Scalar carries sign and content.** `φ.scalar` equals the signed
+>    integer content of `f` (sign × content per `ZPoly.content` and
+>    `ZPoly.leadingCoeff` conventions).
+
+The final Lean name (e.g. `factor_correct`,
+`factor_irreducible_factorisation`) may differ from this prose, and
+intermediate predicates such as `IsIrreducibleFactorization` may
+abbreviate the conjunction, but the five-clause shape is binding.
+
+This is the post-condition of the public API and the contract the
+combinator advertises in its docstring. **The headline theorem is
+the critical-path artefact for `done_through ≥ 4`.** Intermediate
+lemmas are admissible when they are either
+
+- (a) load-bearing for some proof of the headline theorem, or
+- (b) independently justified as public API, executable checker, or
+  regression guard with stated rationale.
+
+Lemmas that satisfy neither are dead weight and should be removed
+or refactored until they earn their place.
+
+A bridge file that proves an arbitrary collection of intermediate
+lemmas but does not prove the headline correctness theorem is
+incomplete by SPEC: the orchestrator must not bump `done_through` to
+4 in that state. The local realisation of this clause for the open
+BZ architectural directive is rewritten in the dispatched rollback
+issue.
+```
+
+### Change 4: `SPEC/design-principles.md` — add a `### Fallback
+discipline for total forms of partial helpers` clause **next to
+§"Placeholders are for proofs only"**
+
+Insert immediately after the existing §"Placeholders are for proofs
+only":
+
+```markdown
+### Fallback discipline for total forms of partial helpers
+
+A close relative of the no-placeholder rule. Pipelines sometimes
+contain a helper of shape
+
+```lean
+def helper (f : T) : U :=
+  match helperOpt f with
+  | some x => x
+  | none => fallback f
+```
+
+where the `Option`-returning `helperOpt` is the natural mathematical
+object and `helper`'s total form exists for downstream
+type-signature convenience. The `none` branch is a **fallback**.
+
+A total form of a partial helper is admissible **only** when the SPEC
+text classifies the fallback under exactly one of the following:
+
+- **`unreachable-by-pipeline-invariant`**: the bridge file proves a
+  theorem `helperOpt?_isSome_of_<precondition>` showing the `none`
+  branch is unreachable on inputs that the public API passes
+  downstream. The SPEC text cites the theorem by name and states the
+  pipeline invariant it relies on. The `none` branch may then return
+  an arbitrary value; semantically it is dead code.
+- **`audited-emergency-value`**: the fallback's behaviour is
+  mathematically safer than crashing (e.g. a verifiable identity
+  element, an explicit failure record that downstream consumers
+  inspect), every call site explicitly audits this, and the SPEC text
+  states the rationale and lists the call sites that accept the
+  fallback. This mode is rare.
+
+A total form of a partial helper without one of these two
+classifications is a SPEC violation. The remedy is to either prove
+the unreachability theorem, document the audit (and pass each call
+site's audit), or **remove the total form** by propagating the
+`Option` upward through the pipeline until the public API takes
+explicit responsibility for the `none` case. *"Refactor later"* is
+not an admissible classification; it is the no-placeholder rule
+restated.
+
+This rule applies retroactively: existing total forms of partial
+helpers must be either proved unreachable, documented and audited,
+or removed before any `done_through` bump past the phase in which
+the helper lives.
+```
+
+### Change 5: `PLAN/Conventions.md` — append cross-reference paragraph
+
+In the §"Hard rules" section, after the existing §"Placeholders are
+for proofs only" subsection, append a one-paragraph cross-reference
+to the two new SPEC clauses, modelled on the existing reference to
+`design-principles.md §7` for the placeholder rule. The wording
+points workers at:
+
+1. `SPEC/design-principles.md` §"Fallback discipline for total forms
+   of partial helpers" — sibling of the placeholder rule, applies
+   project-wide.
+2. The per-library `## Headline correctness theorem` requirement —
+   per-library SPECs at `done_through ≥ 4` must state and discharge
+   such a theorem; intermediate lemmas earn their place by being
+   load-bearing for it or independently justified per the
+   admissibility test in the per-library SPEC clause.
+
+---
+
+## Review notes
+
+- **Change 1 + Change 2 are the post-mortem critical-path.** Without
+  them the comparator gap (gap 1 of the investigation report) is not
+  closed and the wallclock regression can re-occur on any future BZ
+  rewrite.
+- **Change 3 is the deeper fix.** Per-function soundness lemmas don't
+  compose into end-to-end correctness on their own; the orchestrator
+  needs to dispatch the headline theorem as the critical-path
+  artefact, with intermediate lemmas as consequences of the proof's
+  decomposition (or independently justified as public-API surface).
+- **Change 4 generalises the fallback-smell post-mortem** and lives
+  in `SPEC/design-principles.md`, not benchmarking — it is a
+  data-body coding rule, sibling to the no-placeholder rule.
+  Project-wide, prospective and retroactive.
+- **Change 5 is hygiene** — workers re-read `PLAN/Conventions.md`
+  every session; both new rules need to be findable from there or
+  they don't actually constrain behaviour.
+
+## Related
+
+- Post-mortem: [reports/bz-vs-isabelle-investigation.md](../reports/bz-vs-isabelle-investigation.md)
+- Rollback issue (drafted): [reports/bz-rollback-issue-draft.md](../reports/bz-rollback-issue-draft.md)
+- HO-1 (open): https://github.com/kim-em/hex/issues/2564
+- HO-2 (closed): https://github.com/kim-em/hex/issues/2565
+- HO-3 (closed): https://github.com/kim-em/hex/issues/2566
+
+🤖 Prepared with Claude Code

--- a/reports/bz-vs-isabelle-investigation.md
+++ b/reports/bz-vs-isabelle-investigation.md
@@ -1,0 +1,517 @@
+# HexBerlekampZassenhaus vs Isabelle/AFP: investigation
+
+This report documents what was found while comparing hex's
+`HexBerlekampZassenhaus.factor` against the Isabelle/AFP
+`Berlekamp_Zassenhaus.factorize_int_poly` extracted-Haskell binary
+([scripts/oracle/setup_lll_isabelle.sh](../scripts/oracle/setup_lll_isabelle.sh)
+sets up the LLL deposit; for BZ I built the AFP session locally and exported
+`factor_int_poly` to Haskell). All measurements on `Apple M2`, May 2026.
+
+## 1. Headline
+
+On the deterministic split family $(x-1)(x-2)\cdots(x-n)$ at $n \in \{2, \ldots, 24\}$,
+hex's public `factor` combinator is **200–2,400× slower** than Isabelle/AFP's
+extracted `factor_int_poly` AND **returns mathematically incorrect output**
+on roughly half the inputs.
+
+| n | hex (Lean) | Isabelle/AFP | hex/Isa | hex result |
+|---|----------:|-------------:|--------:|------------|
+| 8 | 64 ms | 0.27 ms | 240× | 8 linears (correct) |
+| 10 | 167 ms | 0.36 ms | 460× | 10 linears (correct) |
+| 14 | 742 ms | 0.86 ms | 860× | 14 linears (correct) |
+| 16 | 1.42 s | 1.21 ms | 1180× | 16 linears (correct) |
+| 20 | 4.43 s | 1.78 ms | 2490× | 20 linears (correct) |
+| 11 | 4.8 ms | 0.58 ms | 8× | **3 reducible factors (wrong)** |
+| 12 | 5.7 ms | 0.66 ms | 9× | **3 reducible factors (wrong)** |
+| 13 | 11 ms | 0.74 ms | 15× | **3 reducible factors (wrong)** |
+| 15 | 19 ms | 1.04 ms | 18× | **3 reducible factors (wrong)** |
+| 22 | 1.42 s | 2.40 ms | 590× | **3 reducible factors (wrong)** |
+| 24 | 6.09 s | 2.97 ms | 2050× | **3 reducible factors (wrong)** |
+
+The plot is at [/tmp/bz-lean-vs-isabelle.png](/tmp/bz-lean-vs-isabelle.png).
+
+"Wrong" means: hex returns 3 polynomials whose product equals the input,
+but each is itself reducible (i.e. they aren't irreducible integer factors).
+This violates the documented `Factorization` contract.
+
+## 2. What the repo already tracks
+
+- **Issue [#2564](https://github.com/kim-em/hex/issues/2564) (open, "HO-1")**: *"BZ recombination implements wrong lattice — rollback and rewrite to van Hoeij CLD."* Open since Apr 2026. Describes the additive-vs-multiplicative-lattice error in `recombineLLL?`/`recombinationLattice?`. Mandates a rewrite to BHKS CLD with `factorSlow` + `factorFast` + `factor := factorFast.getD factorSlow`. The current code reflects a *partial* implementation of the new architecture: the `factorSlow`/`factorFast`/`factor` combinator at [HexBerlekampZassenhaus/Basic.lean#L5903](../HexBerlekampZassenhaus/Basic.lean#L5903) was added, but the underlying recombination still has the failure modes described below.
+- **Issue [#2565](https://github.com/kim-em/hex/issues/2565) (closed, "HO-2")**: added adversarial conformance fixtures (Φ₁₅, SD₃, X⁴+1, (X²−2)(X²−3)). These pass in current `main` — the failure modes in this report are not in the fixture corpus.
+- **Issue [#2566](https://github.com/kim-em/hex/issues/2566) (closed, "HO-3")**: added `HexBerlekampZassenhaus/Bench.lean`. Phase-4 schedules cover the `splitScientificSchedule = #[2, 3, 4, 5]` and a degree/height matrix, none of which reach `n` large enough to expose the failure.
+- **[reports/hex-berlekamp-zassenhaus-performance.md](hex-berlekamp-zassenhaus-performance.md)**: every scaling verdict is *inconclusive* (`cMin=2.6, cMax=349` for `runFactorChecksum`). No external comparator is declared in [libraries.yml](../libraries.yml) for `HexBerlekampZassenhaus.phase4`. The §"Concerns" closing notes explicitly flag that "final Phase 4 coverage should add or explicitly justify comparator metadata before bumping `done_through`." So the repo has no Isabelle-vs-hex BZ baseline yet.
+- **[reports/hex-lll-performance.md](hex-lll-performance.md)** *does* have an Isabelle LLL comparator and reports hex 10.88× faster at `n=25` trending down to 1.49× slower at `n=55`. That's where the "we were faster" intuition comes from — but it's the LLL line of work, not BZ.
+
+## 3. Root cause: `isGoodPrime` rejects all candidate primes, then `fallbackPrimeChoiceData` silently uses `p = 3`
+
+### 3.1 The chain
+
+[HexBerlekampZassenhaus/Basic.lean:67-71](../HexBerlekampZassenhaus/Basic.lean#L67) defines:
+
+```lean
+def isGoodPrime (f : ZPoly) (p : Nat) [ZMod64.Bounds p] : Bool :=
+  let fModP := ZPoly.modP p f
+  3 <= p &&
+    ZPoly.leadingCoeffModP f p != 0 &&
+    DensePoly.gcd fModP (DensePoly.derivative fModP) == 1
+```
+
+The intended predicate is *"f is square-free mod p"*. The third conjunct
+checks that `gcd(f, f')` is **structurally equal to the polynomial 1**.
+
+But [HexPoly/Euclid.lean:832](../HexPoly/Euclid.lean#L832) defines `gcd`
+as the value returned by the **Euclidean algorithm** (`xgcd p q`), which
+over a field returns an associate of the true gcd — *not* a monic
+representative.
+
+So when `f` is genuinely square-free mod `p`, the gcd returned is a
+**non-zero constant other than 1** (a unit in `Fp`, but not the
+polynomial `1`). `isGoodPrime` rejects it.
+
+Concrete probe: for $f = (x-1)(x-2)\cdots(x-11)$ at $p = 13$,
+`DensePoly.gcd (f mod 13) (f' mod 13)` returns the constant polynomial
+`[4]`. In $\mathbb{F}_{13}$, $4$ is a unit (it has inverse $10$), so the gcd
+is *mathematically* a unit and $f$ is square-free mod 13. But the
+executable check `== 1` returns `false`, so `isGoodPrime f 13 = false`.
+
+### 3.2 `choosePrimeData?` returns `none` everywhere — fallback to p=3
+
+`choosePrimeData?` ([Basic.lean#L1962](../HexBerlekampZassenhaus/Basic.lean#L1962))
+folds over `smallPrimeCandidates = [3, 5, 7, 11, 13, 17, 19, 23, 31, 71]`,
+scoring each via `primeChoiceDataScore` ([Basic.lean#L1704](../HexBerlekampZassenhaus/Basic.lean#L1704)),
+which short-circuits on `isGoodPrime`. When every candidate prime is
+rejected, the fold returns `none`.
+
+`choosePrimeData` then falls through to `fallbackPrimeChoiceData`
+([Basic.lean#L1966](../HexBerlekampZassenhaus/Basic.lean#L1966)):
+
+```lean
+private def fallbackPrimeChoiceData (f : ZPoly) : PrimeChoiceData :=
+  letI := bounds_three
+  let c : SmallPrimeCandidate :=
+    { p := 3, bounds := bounds_three, prime := prime_three }
+  let fModP := ZPoly.modP 3 f
+  let factorsModP := berlekampFactorsModP f c
+  { p := 3, fModP, factorsModP }
+```
+
+It unconditionally uses `p = 3`, with **no check that 3 is actually good
+for this input.**
+
+For $f = (x-1)\cdots(x-n)$ with $n \ge 24$, every prime in
+`smallPrimeCandidates` is rejected by `isGoodPrime` for two reasons that
+compound:
+
+1. Genuine non-square-free-ness for the small primes (the integer roots
+   $\{1, \ldots, n\}$ collide modulo $p$ when $p \le n$).
+2. The `gcd == 1` mis-comparison for the primes where the polynomial *is*
+   square-free (here, $p \in \{29, 31, 71\}$ ⊆ candidate list at $n = 24$
+   give a true square-free image but a non-canonical gcd).
+
+So $p = 3$ is chosen even though $f$ is *highly* non-square-free mod 3
+(each residue class $0, 1, 2$ appears 8 times among the roots).
+
+Probe ([scratch/PrimeProbe.lean](scratch/PrimeProbe.lean)) confirms
+`isGoodPrime` returns `false` for every candidate prime in the input list,
+for every "wrong-output" case from §1:
+
+```
+n=11: p=3:false 5:false 7:false 11:false 13:false 17:false 19:false 23:false 31:false 71:false
+n=24: p=3:false 5:false 7:false 11:false 13:false 17:false 19:false 23:false 31:false 71:false
+```
+
+### 3.3 What happens downstream
+
+With $p = 3$ and $f \bmod 3$ non-square-free, the Berlekamp factorisation
+of $f \bmod 3$ returns the *square-free part*, which has 3 distinct
+linear factors over $\mathbb{F}_3$ (one per residue class). The fast-path
+combinator lifts these via Hensel to mod $3^k$ (with $k$ large enough to
+recover Mignotte-bounded factors), reconstructs them as integer
+polynomials of degree $n/3$ each, and returns them as if they were
+irreducible factors.
+
+[scratch/FactorTrace.lean](scratch/FactorTrace.lean) confirms this
+directly. For $n = 24$, the fast path returns three monic integer
+polynomials of degree 8 each. Their product is the input, so the
+`Factorization.product` invariant holds — but each is itself a degree-8
+product of distinct linears, not an irreducible.
+
+The hex `Factorization` type doesn't carry an irreducibility witness; the
+combinator just accepts whatever the fast path returns. Issue
+[#2564](https://github.com/kim-em/hex/issues/2564) calls for `factorFast`
+to have a `factorFast f = some gs ⟹ gs is the irreducible factorisation`
+proof obligation in the Mathlib bridge — that obligation, if discharged,
+would force the implementation to reject this case (return `none`),
+which would route control to `factorSlow`, which is at least
+unconditionally correct (though exponentially slow in the number of
+mod-$p$ factors).
+
+## 4. Why hex is also slow when it *is* correct
+
+At $n = 16$ and $n = 20$, `choosePrime` selects $p = 19$ and $p = 23$
+respectively (both square-free for those inputs, and the gcd bug
+happens to not bite because of how the residues land). Hex returns the
+correct full factorisation — but takes **1.4 s** and **4.4 s**
+respectively, against Isabelle's **1.2 ms** and **1.8 ms**.
+
+The slowdown is concentrated in the Hensel-lift / BHKS-recombination
+loop, not in prime selection. Direct timing of `Hex.factorFast` at
+`factorFastPrecisionCap` (which is the *higher*, BHKS-doubling cap
+rather than the Mignotte-tight `defaultFactorCoeffBound`):
+
+| n | fastCap precision (digits) | Hex.factorFast wall |
+|---|---------------------------:|---------------------:|
+| 8 | 138 | 64 ms |
+| 10 | 230 | 172 ms |
+| 14 | 480 | 797 ms |
+| 16 | 614 | 1.52 s |
+| 20 | 968 | 4.71 s |
+
+The headline cost is multi-precision Hensel arithmetic at the BHKS-doubling
+precision cap, plus the lattice construction / LLL reduction that follows.
+Even the *successful* runs are spending most of their time doing
+arithmetic at much higher precision than the inputs require, and an LLL
+reduction whose lattice (per #2564) doesn't actually encode the
+multiplicative-product structure of the factorisation.
+
+The closest sibling comparator is the LLL line, where hex is *roughly
+equal* to the same AFP-extracted Haskell at large $n$ (within ±10%).
+That suggests the slowdown is not "Lean is slow at integer arithmetic"
+— the same Lean LLL kernel matches AFP. It is concentrated in the BZ
+glue: prime selection, Hensel-lift precision schedule, and recombination
+strategy.
+
+## 5. Verifying the diagnosis
+
+[scratch/GcdProbe.lean](scratch/GcdProbe.lean) shows the
+gcd-not-monic behaviour. [scratch/PrimeProbe.lean](scratch/PrimeProbe.lean)
+confirms every candidate prime is rejected for every wrong-output input.
+[scratch/FactorTrace.lean](scratch/FactorTrace.lean) confirms the
+output structure (3 reducible factors of degree $n/3$ when $p_{\text{chosen}} = 3$).
+
+The diagnosis predicts that any patch to `isGoodPrime` that accepts the
+"gcd is a unit" case (rather than "gcd is literally the polynomial 1")
+would (a) make `choosePrimeData?` succeed on these inputs by selecting
+the smallest *actually-square-free* prime, and (b) restore correct
+factorisation output. I have *not* attempted that patch here because the
+predicate has downstream lemma callers; verifying that those still go
+through is part of the fix PR.
+
+## 6. Recommendations
+
+In priority order:
+
+1. **Fix `isGoodPrime`.** Either normalise the gcd to monic at the
+   `DensePoly.gcd` level, or change the predicate at
+   [Basic.lean:71](../HexBerlekampZassenhaus/Basic.lean#L71) to check
+   "gcd has degree 0 and is non-zero" (i.e. *is a unit* in $\mathbb{F}_p[x]$).
+   Normalising at the `gcd` level is cleaner mathematically — a
+   field-gcd that isn't monic is a footgun for every other caller — but
+   it touches more existing proofs.
+
+2. **Remove the silent `p = 3` fallback.** `fallbackPrimeChoiceData`
+   masks bugs like §3 by always returning a definite answer. After
+   exhausting `smallPrimeCandidates`, the right move is to *extend the
+   search* to larger primes (à la Isabelle's unbounded `find_prime`),
+   not to silently use a known-bad prime. Until extension lands,
+   `fallbackPrimeChoiceData` should `panic!`/throw rather than silently
+   succeed — better an exception than a wrong factorisation.
+
+3. **Add an irreducibility witness to `factorFast`'s contract.** Per
+   issue [#2564](https://github.com/kim-em/hex/issues/2564), the spec
+   already says `factorFast f = some gs ⟹ gs is the irreducible
+   factorisation`. If that obligation is enforced by the implementation
+   (e.g. each factor must pass a trial-division check against every
+   other lifted local factor's product), the wrong-output path collapses
+   to a `none` from `factorFast`, and `factorSlow` takes over.
+
+4. **Wire Isabelle/AFP BZ as a Phase-4 comparator in
+   [libraries.yml](../libraries.yml).** The `setup_lll_isabelle.sh`
+   skill is the right template — an analogous `setup_bz_isabelle.sh`
+   that builds the AFP `Berlekamp_Zassenhaus` session and exports
+   `factor_int_poly` to Haskell would give a permanent ratio baseline.
+   The plot at [/tmp/bz-lean-vs-isabelle.png](/tmp/bz-lean-vs-isabelle.png)
+   becomes a regression bar once we have the comparator in CI.
+
+5. **Add wrong-output fixtures to `HexBerlekampZassenhaus/Conformance.lean`.**
+   $(x-1)(x-2)\cdots(x-11)$ is the smallest input in the deterministic
+   split family that triggers the bug; if it had been in the fixture
+   corpus the current behaviour would have been a build-time failure.
+   $(x-1)\cdots(x-24)$ exhibits the worst-case wall time. Both belong
+   in the corpus alongside the HO-2 adversarials.
+
+6. **Even with §1 fixed, ~200–1,000× to Isabelle remains.** That gap is
+   in BHKS-precision Hensel arithmetic + lattice construction; closing
+   it is the substance of the actual #2564 rewrite to van Hoeij CLD.
+   The numbers here suggest the rewrite is worth doing — Isabelle's
+   classical exhaustive recombination handles all of these inputs in
+   single-digit milliseconds, so the verified algorithm is not the
+   constraint; the implementation strategy is.
+
+## 7. Artefacts
+
+- [scratch/BZBench.lean](scratch/BZBench.lean): Lean factor timings on the split-product ladder.
+- [scratch/FactorTrace.lean](scratch/FactorTrace.lean): per-input trace of `factorFast` vs `factor`, prime choice, precision cap.
+- [scratch/PrimeProbe.lean](scratch/PrimeProbe.lean): direct `isGoodPrime` probe across every candidate prime per input.
+- [scratch/GcdProbe.lean](scratch/GcdProbe.lean): single-case demonstration of the non-monic gcd at $n=11, p=13$.
+- [scratch/bz_flint_times.py](scratch/bz_flint_times.py), [scratch/plot_bz.py](scratch/plot_bz.py): FLINT timings + plot (informational).
+- [scratch/plot_bz_isa.py](scratch/plot_bz_isa.py): Lean vs Isabelle plot.
+- `/tmp/hex-isabelle/` (recreate per §8): AFP code-export wrapper theory + Haskell driver for `factor_int_poly`.
+
+## 8. Post-mortem: why didn't the orchestrator catch this?
+
+The `isGoodPrime` bug affects both **correctness** (wrong output
+returned as if it were the irreducible factorisation) and
+**performance** (multi-second wall time at degrees where Isabelle is
+sub-millisecond). It should have been caught in two independent
+places — conformance and benchmarking — *and* in a third (Mathlib
+bridge). It was caught in zero. Four orchestration gaps:
+
+### 8.1 Gap 1 — SPEC has no comparator requirement for BZ
+
+[SPEC/benchmarking.md §"Comparator naming"](../SPEC/benchmarking.md)
+requires every Phase-4 library to either name a comparator or
+explicitly declare absence with a reason from a closed list. BZ's SPEC
+([SPEC/Libraries/hex-berlekamp-zassenhaus.md](../SPEC/Libraries/hex-berlekamp-zassenhaus.md))
+does **neither**. [libraries.yml](../libraries.yml) records
+`phase4.input_families` for `HexBerlekampZassenhaus` but no
+`phase4.comparators` key.
+
+The current state is admissible because `done_through: 0` — Phase 4 is
+not yet claimed, so the comparator-absence-declaration requirement
+hasn't activated. But [reports/hex-berlekamp-zassenhaus-performance.md](hex-berlekamp-zassenhaus-performance.md)
+*does* write a Phase-4 performance report with verdicts. The bench
+schedule runs, reports inconclusive verdicts, and the gap is recorded
+in §"Concerns" of the report — but as a TODO, not a blocker. There is
+no mechanism that ties "wallclock surprise vs comparator" to
+"orchestrator pauses dispatch".
+
+**Direct consequence:** the only signal that BZ was slow was an
+internal-model verdict (`cMin / cMax` of the declared
+`n^9 + n^7 log²(n+2)` model), which is unitless. The hex Phase-4 run
+recorded `cMax=349` at `n=4` and **interpreted this as "schedule too
+short"**, not "the algorithm is doing wrong work". An Isabelle/AFP
+comparator would have shown `lean/isabelle ≈ 240×` even at `n=4` and
+flagged the gap immediately.
+
+### 8.2 Gap 2 — conformance fixtures intentionally avoid prime-cascade adversarials
+
+The current fixture corpus
+([conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl](../conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl), 27 fixtures)
+covers degree 0–4 edge cases, irreducible cyclotomics Φ₅/Φ₇/Φ₁₁/Φ₁₇,
+the HO-2 adversarials (X⁴+1, (x²−2)(x²−3), SD₃, Φ₁₅), two
+reducible products at degree 4 and 20, and two content-cyclotomic
+combos. **Largest degree: 20. No deterministic split linear product
+of degree > 2.**
+
+HO-2 ([#2565](https://github.com/kim-em/hex/issues/2565)) explicitly
+calls out that pre-HO-2 fixtures had "true factors that coincide with
+single mod-p factors" and adds adversarials for the recombination
+logic — but the adversarials it adds (X⁴+1 etc.) are all small-degree
+and all happen to pick a good prime in the first few candidates. The
+prime-selection cascade (`isGoodPrime` rejects everything → silent
+fallback to `p=3`) is a *different* adversarial axis that the HO-2
+corpus does not stress.
+
+`$(x-1)(x-2)\cdots(x-n)$` for $n \in \{11, 12, 13, 15\}$ is the
+smallest input family that exercises the cascade. None of these are
+in the corpus.
+
+**Direct consequence:** the python-flint oracle DOES re-check that every
+hex-reported factor is irreducible per flint
+([HexBerlekampZassenhaus/EmitFixtures.lean#L56-L60](../HexBerlekampZassenhaus/EmitFixtures.lean#L56)),
+so any reducible output in a fixture would fail conformance. But the
+corpus doesn't include any input that *produces* reducible output, so
+the oracle's irreducibility check is dead weight against this bug
+class. **The check exists but the corpus is constructed to avoid
+exercising it.**
+
+### 8.3 Gap 3 — bench schedule too short
+
+`splitScientificSchedule = #[2, 3, 4, 5]` for `runFactorChecksum` runs
+the public combinator on $(x-1)(x-2)\cdots(x-(n+1))$ for
+$n \in \{2, 3, 4, 5\}$ — degrees 3, 4, 5, 6. At every one of those
+degrees, the smallest square-free candidate prime $\le 7$ satisfies
+`isGoodPrime` and the cascade never fires. The bench *cannot* catch
+this bug at its current schedule.
+
+[reports/hex-berlekamp-zassenhaus-performance.md §"Concerns"](hex-berlekamp-zassenhaus-performance.md)
+already notes the issue obliquely: "an exploratory run with the same
+eight-second cap reached n = 5 and hit the cap at n = 6, so larger
+split inputs require either algorithmic improvement or a dedicated
+longer scheduled run." Without a comparator the right interpretation
+("the algorithm is doing wrong work") is indistinguishable from the
+wrong one ("we need a longer schedule").
+
+### 8.4 Gap 4 — pipeline-level invariants are not stated, so per-step soundness lemmas don't compose into pipeline correctness
+
+[HexBerlekampZassenhaus/Basic.lean:965](../HexBerlekampZassenhaus/Basic.lean#L965)
+states:
+
+```lean
+theorem isGoodPrime_squareFreeModP
+    (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
+    (hgood : isGoodPrime f p = true) :
+    squareFreeModP f p := by ...
+```
+
+But `squareFreeModP` itself is defined ([Basic.lean:57](../HexBerlekampZassenhaus/Basic.lean#L57))
+as `DensePoly.gcd fModP (DensePoly.derivative fModP) = 1` — the
+*same* boolean condition `isGoodPrime` checks. The theorem is
+near-tautological. It doesn't connect `squareFreeModP` to the
+Mathlib concept `Polynomial.Squarefree`. So no bridge theorem *would
+have failed to prove* in the presence of this bug — every claim about
+`squareFreeModP` is downstream of the same boolean expression that
+the executable evaluates.
+
+This is a symptom of a deeper pattern. **The bridge file carries
+many per-step "if the executable check passes, then the Prop form
+holds" lemmas, but no end-to-end theorem about the pipeline.** What
+should exist is something like:
+
+```lean
+theorem factor_returns_irreducible_factorisation
+    (f : ZPoly) (hf : f ≠ 0) :
+    let φ := Hex.factor f
+    Factorization.product φ = f ∧
+      ∀ (g : ZPoly) (_ : g ∈ φ.factors.map Prod.fst),
+        Polynomial.Irreducible (HexPolyZMathlib.toPolynomial g)
+```
+
+A theorem of that shape would not be provable today.
+
+The orchestrator currently dispatches **per-function proof
+obligations** (e.g. issue [#2564](https://github.com/kim-em/hex/issues/2564)
+asks for "A1–A5", "B1–B9", "C1–C2" as a *bag* of obligations) and not
+the end-to-end pipeline theorem. The right relationship is the
+opposite of how that's structured: **the end-to-end theorem is the
+specification, and per-function lemmas are consequences of it that
+emerge from how the proof factors.** Stating a bag of per-function
+obligations without naming the global theorem they exist to support
+is performative — it produces lemmas that are checkable in isolation
+but need not actually compose. When the lemmas don't compose (as
+here: `isGoodPrime_squareFreeModP` is true but tautological, so its
+"discharge" does not constrain the implementation), the bag is
+discharged and the global property is still wrong.
+
+The corollary: a per-function obligation that does not appear as a
+step in some proof of the global theorem is dead weight. It should
+either be removed, or the proof structure should be revised until
+the lemma is load-bearing. The SPEC must dispatch the global theorem
+as the critical-path artefact, and let the proof's actual
+decomposition determine which intermediate lemmas earn their place.
+
+This is the meta-gap, and it generalises beyond `isGoodPrime`. The
+correct change is at the SPEC level: every `done_through ≥ 4` library
+must carry a "headline correctness theorem" in its Mathlib bridge
+stating the end-to-end invariant of its public API, and *that
+theorem* is the critical-path artefact the orchestrator dispatches.
+Intermediate lemmas land alongside the headline theorem and exist
+only because the headline-theorem proof factors through them.
+
+### 8.5 Gap 5 — `fallbackPrimeChoiceData` is an unprotected total-function smell
+
+[HexBerlekampZassenhaus/Basic.lean:1982](../HexBerlekampZassenhaus/Basic.lean#L1982):
+
+```lean
+def choosePrimeData (f : ZPoly) : PrimeChoiceData :=
+  match choosePrimeData? f with
+  | some data => data
+  | none => fallbackPrimeChoiceData f
+```
+
+with `fallbackPrimeChoiceData` returning `{p := 3, …}` unconditionally.
+This is the proximate cause of the wrong-output bug: when
+`choosePrimeData?` returns `none` (because `isGoodPrime` rejected
+every candidate due to gap 4), `choosePrimeData` silently returns the
+$p = 3$ branch without any guard. Every production caller in the
+factor pipeline uses `choosePrimeData` (the total form), not
+`choosePrimeData?`, so the `none` branch flows into the executable
+result without any check.
+
+There is **no theorem anywhere in the repo** of the form
+`choosePrimeData?_isSome` (the Option always inhabits `some`), and no
+documentation rationalising the fallback choice of $p = 3$. The
+fallback exists for purely syntactic reasons (the type system wanted
+a total function), with no mathematical safety net.
+
+This is a code smell with a precise resolution. Fallbacks in
+total-of-Option helpers are admissible **only** when one of these is
+the case, and the SPEC must enforce the discipline:
+
+- The caller proves the fallback is unreachable on the intended
+  inputs (a theorem `_isSome_of_<precondition>`).
+- The fallback itself is a verified emergency value that callers
+  *audit*, with a rationale in the SPEC text.
+- Or the function is re-architected to not need a fallback (here:
+  use `choosePrimeData?` throughout the pipeline, or replace the
+  bounded `smallPrimeCandidates` list with an unbounded prime
+  search, à la Isabelle's `find_prime`, plus a Mathlib bridge
+  theorem that termination is guaranteed for sf primitive input
+  via the existence-of-good-primes lemma).
+
+Without any of these, the fallback is a silent rewrite of the
+algorithm's mathematical contract: "BZ on a polynomial without a good
+small prime" becomes "BZ at $p=3$", which is a different algorithm
+with a different output. The SPEC must forbid this without a stated
+rationale.
+
+### 8.6 Summary of orchestration changes needed
+
+1. **SPEC PR (drafted at [reports/bz-spec-comparator-pr-draft.md](bz-spec-comparator-pr-draft.md)):**
+   - Add an AFP `Berlekamp_Zassenhaus` extracted-Haskell comparator
+     classified as `gating` to `hex-berlekamp-zassenhaus.md` and
+     `libraries.yml`. Symmetric with the existing LLL comparator setup.
+   - Add a SPEC clause requiring the headline correctness theorem for
+     `factor` to be discharged in `HexBerlekampZassenhausMathlib`
+     before any `done_through` bump past Phase 4. The theorem must
+     state irreducibility of every entry in `φ.factors`, not just
+     `Factorization.product φ = f`.
+   - Add a SPEC clause on fallback discipline: any total-of-`Option`
+     helper in the pipeline must carry either an `_isSome` theorem
+     proving the `none` branch is unreachable on the intended inputs,
+     or a documented rationale for the fallback value. Pre-existing
+     fallbacks must be audited under the new rule.
+
+2. **Rollback issue (drafted at [reports/bz-rollback-issue-draft.md](bz-rollback-issue-draft.md)):**
+   roll back the BZ Phase-4 bench scaffolding for re-execution against
+   the new comparator. The bench artefact in the perf report becomes
+   informational-only until the comparator gate is closed *and* the
+   headline correctness theorem is in place.
+
+3. **HO-2 corpus extension (separate issue):** require at least one
+   `(x-1)(x-2)…(x-n)` instance with $n$ chosen large enough that
+   `isGoodPrime` would reject every prime in `smallPrimeCandidates`
+   even after the gcd-monic fix (i.e. $n > 71$ so even mod 71 isn't
+   square-free). This forces the prime-search-extension fix rather
+   than allowing the gcd-monic fix alone to ship.
+
+4. **Pipeline correctness theorem (separate issue, Mathlib bridge):**
+   state and prove `factor_returns_irreducible_factorisation` as the
+   end-to-end public-API theorem. Per-function obligations from
+   [#2564](https://github.com/kim-em/hex/issues/2564) compose toward
+   this; the issue tracks the composition itself, not any new
+   per-function proof.
+
+5. **Fallback audit (separate issue):** grep
+   [HexBerlekampZassenhaus/Basic.lean](../HexBerlekampZassenhaus/Basic.lean)
+   for every `match … | none => …` pattern that defaults to a concrete
+   value. Each must either grow an `_isSome` theorem or a SPEC
+   rationale, or be re-architected to not need a default.
+
+## 9. Reproducing the Isabelle side
+
+```sh
+brew install --cask isabelle
+curl -sL https://www.isa-afp.org/release/afp-current.tar.gz \
+  -o /tmp/isabelle-afp.tar.gz
+mkdir -p /tmp/isabelle-afp
+tar -xzf /tmp/isabelle-afp.tar.gz -C /tmp/isabelle-afp --strip-components=1
+isabelle components -u /tmp/isabelle-afp/thys
+
+# Build the AFP BZ session (one-time, ~7 min):
+isabelle build -b -v Berlekamp_Zassenhaus
+
+# Then the wrapper theory and Haskell export driver are at
+# /tmp/hex-isabelle/{bz/Hex_BZ_Export.thy, driver/Main.hs}; see §7.
+```

--- a/reports/scratch/BZBench.lean
+++ b/reports/scratch/BZBench.lean
@@ -1,0 +1,50 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+/-- (x-1)(x-2)...(x-n) -/
+private def splitProduct (n : Nat) : ZPoly := Id.run do
+  let mut acc : ZPoly := 1
+  for i in [1:n+1] do
+    acc := acc * (zp #[-(Int.ofNat i), 1])
+  return acc
+
+/-- Encode integer list as compact JSON. -/
+private def encodeInts (xs : List Int) : String :=
+  "[" ++ String.intercalate "," (xs.map toString) ++ "]"
+
+/-- A hash that depends on every coefficient of every factor — guarantees the
+factorization is fully evaluated before we stop the clock. -/
+private def factorChecksum (φ : Factorization) : UInt64 :=
+  let h0 : UInt64 := hash φ.scalar
+  φ.factors.foldl (init := h0) fun acc (g, m) =>
+    let gh := g.toArray.foldl (init := (0 : UInt64)) (fun a c => mixHash a (hash c))
+    mixHash (mixHash acc gh) (hash m)
+
+private def factorTimed (degree : Nat) (f : ZPoly) : IO Unit := do
+  -- Repeat enough that even fast cases give a meaningful reading.
+  let reps : Nat := if degree ≤ 6 then 50 else if degree ≤ 10 then 10 else 3
+  let t0 ← IO.monoNanosNow
+  let mut chk : UInt64 := 0
+  let mut nFactors : Nat := 0
+  for _ in [0:reps] do
+    let φ := Hex.factor f
+    chk := chk ^^^ factorChecksum φ
+    nFactors := φ.factors.size
+  let t1 ← IO.monoNanosNow
+  let nanos := (t1 - t0) / reps
+  let coeffs := f.toArray.toList
+  let line := "{" ++ s!"\"degree\":{degree},\"factors\":{nFactors},\"reps\":{reps},\"lean_nanos\":{nanos},\"checksum\":{chk},\"coeffs\":{encodeInts coeffs}" ++ "}"
+  IO.println line
+
+def main (argv : List String) : IO Unit := do
+  let degrees :=
+    match argv with
+    | [] => [2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,18,20,22,24]
+    | _  => argv.filterMap (fun (s : String) => String.toNat? s)
+  -- warm up
+  let _ := Hex.factor (zp #[-1,1])
+  for d in degrees do
+    factorTimed d (splitProduct d)

--- a/reports/scratch/FactorDemo.lean
+++ b/reports/scratch/FactorDemo.lean
@@ -1,0 +1,20 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+private def showF (name : String) (f : ZPoly) : IO Unit := do
+  let φ : Factorization := Hex.factor f
+  IO.println s!"--- {name}"
+  IO.println s!"  scalar: {φ.scalar}"
+  for (g, m) in φ.factors do
+    IO.println s!"  factor^{m}: {g.toArray.toList}"
+
+def main : IO Unit := do
+  showF "x^5 - 1" (zp #[-1,0,0,0,0,1])
+  showF "x^4 + 1" (zp #[1,0,0,0,1])
+  showF "(x^2-2)(x^2-3)" (zp #[6,0,-5,0,1])
+  showF "Phi_15" (zp #[1,-1,0,1,-1,1,0,-1,1])
+  let prod5 := (zp #[-1,1]) * (zp #[-2,1]) * (zp #[-3,1]) * (zp #[-4,1]) * (zp #[-5,1])
+  showF "(x-1)..(x-5)" prod5

--- a/reports/scratch/FactorTrace.lean
+++ b/reports/scratch/FactorTrace.lean
@@ -1,0 +1,54 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+private def splitProduct (n : Nat) : ZPoly := Id.run do
+  let mut acc : ZPoly := 1
+  for i in [1:n+1] do
+    acc := acc * (zp #[-(Int.ofNat i), 1])
+  return acc
+
+private def encodeInts (xs : List Int) : String :=
+  "[" ++ String.intercalate "," (xs.map toString) ++ "]"
+
+/-- Force evaluation of a Factorization by hashing every coefficient. -/
+private def fingerprint (φ : Factorization) : UInt64 :=
+  let h0 : UInt64 := hash φ.scalar
+  φ.factors.foldl (init := h0) fun acc (g, m) =>
+    let gh := g.toArray.foldl (init := (0 : UInt64)) (fun a c => mixHash a (hash c))
+    mixHash (mixHash acc gh) (hash m)
+
+private def report (label : String) (f : ZPoly) : IO Unit := do
+  let prime := Hex.choosePrime f
+  let dataPrime := (Hex.choosePrimeData f).p
+  let primeOk := (Hex.choosePrimeData? f).isSome
+  let coeffBound := ZPoly.defaultFactorCoeffBound f
+  IO.println s!"--- {label} (deg {f.degree?.getD 0}, choosePrime={prime}, dataPrime={dataPrime}, dataOk={primeOk}, B={coeffBound})"
+
+  -- Time factorFastWithBound at the default bound used by factor combinator
+  let mut chk : UInt64 := 0
+  let tA ← IO.monoNanosNow
+  let mFastB := Hex.factorFast f
+  chk := chk ^^^ (fingerprint (mFastB.getD ({ scalar := 0, factors := #[] } : Factorization)))
+  let tB ← IO.monoNanosNow
+  let fastBms := Float.ofInt (Int.ofNat (tB - tA)) / 1e6
+  match mFastB with
+  | none => IO.println s!"  factorFast (at fastCap): none  ({fastBms} ms, chk={chk})"
+  | some φ =>
+      let degs := φ.factors.toList.map (fun e => e.1.degree?.getD 0)
+      IO.println s!"  factorFast (at fastCap): {φ.factors.size} factors degrees={degs}  ({fastBms} ms, chk={chk})"
+
+  -- Time the public combinator
+  let tC ← IO.monoNanosNow
+  let φFull := Hex.factor f
+  chk := chk ^^^ (fingerprint φFull)
+  let tD ← IO.monoNanosNow
+  let fullMs := Float.ofInt (Int.ofNat (tD - tC)) / 1e6
+  let degs := φFull.factors.toList.map (fun e => e.1.degree?.getD 0)
+  IO.println s!"  factor   (combinator): {φFull.factors.size} factors degrees={degs}  ({fullMs} ms, chk={chk})"
+
+def main : IO Unit := do
+  for n in [3, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24] do
+    report s!"(x-1)..(x-{n})" (splitProduct n)

--- a/reports/scratch/GcdMatrix.lean
+++ b/reports/scratch/GcdMatrix.lean
@@ -1,0 +1,49 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+private def splitProduct (n : Nat) : ZPoly := Id.run do
+  let mut acc : ZPoly := 1
+  for i in [1:n+1] do
+    acc := acc * (zp #[-(Int.ofNat i), 1])
+  return acc
+
+private instance b3  : ZMod64.Bounds 3  := ⟨by decide, by decide⟩
+private instance b5  : ZMod64.Bounds 5  := ⟨by decide, by decide⟩
+private instance b7  : ZMod64.Bounds 7  := ⟨by decide, by decide⟩
+private instance b11 : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
+private instance b13 : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
+private instance b17 : ZMod64.Bounds 17 := ⟨by decide, by decide⟩
+private instance b19 : ZMod64.Bounds 19 := ⟨by decide, by decide⟩
+private instance b23 : ZMod64.Bounds 23 := ⟨by decide, by decide⟩
+private instance b31 : ZMod64.Bounds 31 := ⟨by decide, by decide⟩
+private instance b71 : ZMod64.Bounds 71 := ⟨by decide, by decide⟩
+
+structure Row where
+  p : Nat
+  toNat : ZMod64 p → Nat
+  inst : ZMod64.Bounds p
+
+private def row (p : Nat) (inst : ZMod64.Bounds p) (f : ZPoly) : (Nat × Nat × Nat × Bool × Bool) :=
+  let fModP := @ZPoly.modP p inst f
+  let fp' := DensePoly.derivative fModP
+  let g := DensePoly.gcd fModP fp'
+  let gIs1 := g == 1
+  let lead : ZMod64 p := g.toArray[0]?.getD 0
+  let gDegZero := g.toArray.size > 0 && lead != 0
+  (p, g.toArray.size, lead.toNat, gIs1, gDegZero)
+
+def main : IO Unit := do
+  for n in [3, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 22, 24] do
+    let f := splitProduct n
+    let r11 := row 11 b11 f
+    let r13 := row 13 b13 f
+    let r17 := row 17 b17 f
+    let r23 := row 23 b23 f
+    let r31 := row 31 b31 f
+    let r71 := row 71 b71 f
+    IO.println s!"n={n}"
+    for (p, sz, c0, is1, deg0) in [r11, r13, r17, r23, r31, r71] do
+      IO.println s!"  p={p}: gcd size={sz} leading={c0} ==1?{is1} (degree-zero-and-nonzero={deg0})"

--- a/reports/scratch/GcdProbe.lean
+++ b/reports/scratch/GcdProbe.lean
@@ -1,0 +1,28 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+private def splitProduct (n : Nat) : ZPoly := Id.run do
+  let mut acc : ZPoly := 1
+  for i in [1:n+1] do
+    acc := acc * (zp #[-(Int.ofNat i), 1])
+  return acc
+
+private instance b13 : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
+
+def main : IO Unit := do
+  let f := splitProduct 11
+  let fModP := @ZPoly.modP 13 b13 f
+  let fp' := DensePoly.derivative fModP
+  let g := DensePoly.gcd fModP fp'
+  let toNat (x : ZMod64 13) : Nat := x.toNat
+  IO.println s!"f mod 13 size={fModP.toArray.size}, vals={fModP.toArray.toList.map toNat}"
+  IO.println s!"f' mod 13 size={fp'.toArray.size}, vals={fp'.toArray.toList.map toNat}"
+  IO.println s!"gcd size={g.toArray.size}, vals={g.toArray.toList.map toNat}"
+  IO.println s!"gcd == 1? {g == 1}"
+  let one : DensePoly (ZMod64 13) := 1
+  IO.println s!"(1 : Fp13Poly).toArray vals = {one.toArray.toList.map toNat}"
+  IO.println s!"isGoodPrime f 13 = {@Hex.isGoodPrime f 13 b13}"
+  IO.println s!"f mod 13 leading {toNat (DensePoly.leadingCoeff fModP)}"

--- a/reports/scratch/LLLBench.lean
+++ b/reports/scratch/LLLBench.lean
@@ -1,0 +1,76 @@
+import HexLLL.Basic
+
+open Hex
+
+namespace LLLBenchScratch
+
+/-! Inlined random-bounded basis family from `HexLLL/Bench.lean`. -/
+
+def lcgStep (x : Nat) : Nat :=
+  (1103515245 * x + 12345) % 2147483648
+
+def lcgIterate (seed : Nat) : Nat → Nat
+  | 0 => seed
+  | k + 1 => lcgIterate (lcgStep seed) k
+
+def randomBoundedEntry (raw : Nat) : Int :=
+  Int.ofNat (raw % 61) - 30
+
+def randomBoundedBasis (n seed : Nat) : Matrix Int n n :=
+  Matrix.ofFn fun i j =>
+    if j.val < i.val then
+      0
+    else if i = j then
+      Int.ofNat (n - i.val + 1)
+    else
+      randomBoundedEntry (lcgIterate seed (i.val * n + j.val + 1))
+
+/-- Match `HexLLL.Bench.randomBoundedSwapSeed`. -/
+def randomBoundedSwapSeed : Nat := 8
+
+end LLLBenchScratch
+
+open LLLBenchScratch
+
+/-- Encode an `n × m` integer matrix as JSON array-of-arrays. -/
+private def encodeMatrix {n m : Nat} (M : Matrix Int n m) : String :=
+  let rows := M.toArray.toList.map fun row =>
+    "[" ++ String.intercalate "," (row.toArray.toList.map toString) ++ "]"
+  "[" ++ String.intercalate "," rows ++ "]"
+
+private def matrixChecksum {n m : Nat} (M : Matrix Int n m) : UInt64 :=
+  M.toArray.foldl (init := (0 : UInt64)) fun acc row =>
+    row.toArray.foldl (init := acc) fun a c => mixHash a (hash c)
+
+private theorem hδLow : (1 / 4 : Rat) < 3 / 4 := by grind
+private theorem hδHigh : (3 / 4 : Rat) ≤ 1 := by grind
+
+private def runOne (n : Nat) (reps : Nat) (hn : 1 ≤ n) : IO Unit := do
+  let basis : Matrix Int n n := randomBoundedBasis n randomBoundedSwapSeed
+  -- Warm-touch the basis.
+  let _ := matrixChecksum basis
+  let t0 ← IO.monoNanosNow
+  let mut chk : UInt64 := 0
+  for _ in [0:reps] do
+    let reduced := Hex.lllUnchecked basis (3 / 4) hδLow hδHigh hn
+    chk := chk ^^^ matrixChecksum reduced
+  let t1 ← IO.monoNanosNow
+  let nanos := (t1 - t0) / reps
+  let basisJson := encodeMatrix basis
+  let line := "{" ++
+    s!"\"n\":{n},\"reps\":{reps},\"lean_nanos\":{nanos},\"checksum\":{chk},\"basis\":{basisJson}"
+    ++ "}"
+  IO.println line
+
+def main : IO Unit := do
+  runOne 10 20 (by decide)
+  runOne 15 10 (by decide)
+  runOne 20 6  (by decide)
+  runOne 25 4  (by decide)
+  runOne 30 3  (by decide)
+  runOne 40 2  (by decide)
+  runOne 50 2  (by decide)
+  runOne 60 1  (by decide)
+  runOne 75 1  (by decide)
+  runOne 90 1  (by decide)
+  runOne 120 1 (by decide)

--- a/reports/scratch/LLLBenchTiny.lean
+++ b/reports/scratch/LLLBenchTiny.lean
@@ -1,0 +1,68 @@
+import HexLLL.Basic
+
+open Hex
+
+namespace LLLBenchTinyScratch
+
+def lcgStep (x : Nat) : Nat :=
+  (1103515245 * x + 12345) % 2147483648
+
+def lcgIterate (seed : Nat) : Nat → Nat
+  | 0 => seed
+  | k + 1 => lcgIterate (lcgStep seed) k
+
+/-- Small entries in [-3, 3] to keep Isabelle LLL within reach. -/
+def tinyEntry (raw : Nat) : Int :=
+  Int.ofNat (raw % 7) - 3
+
+def tinyBasis (n seed : Nat) : Matrix Int n n :=
+  Matrix.ofFn fun i j =>
+    if j.val < i.val then
+      0
+    else if i = j then
+      Int.ofNat (n - i.val + 1)
+    else
+      tinyEntry (lcgIterate seed (i.val * n + j.val + 1))
+
+end LLLBenchTinyScratch
+
+open LLLBenchTinyScratch
+
+private def encodeMatrix {n m : Nat} (M : Matrix Int n m) : String :=
+  let rows := M.toArray.toList.map fun row =>
+    "[" ++ String.intercalate "," (row.toArray.toList.map toString) ++ "]"
+  "[" ++ String.intercalate "," rows ++ "]"
+
+private def matrixChecksum {n m : Nat} (M : Matrix Int n m) : UInt64 :=
+  M.toArray.foldl (init := (0 : UInt64)) fun acc row =>
+    row.toArray.foldl (init := acc) fun a c => mixHash a (hash c)
+
+private theorem hδLow : (1 / 4 : Rat) < 3 / 4 := by grind
+private theorem hδHigh : (3 / 4 : Rat) ≤ 1 := by grind
+
+private def runOne (n : Nat) (reps : Nat) (hn : 1 ≤ n) : IO Unit := do
+  let basis : Matrix Int n n := tinyBasis n 8
+  let _ := matrixChecksum basis
+  let t0 ← IO.monoNanosNow
+  let mut chk : UInt64 := 0
+  for _ in [0:reps] do
+    let reduced := Hex.lllUnchecked basis (3 / 4) hδLow hδHigh hn
+    chk := chk ^^^ matrixChecksum reduced
+  let t1 ← IO.monoNanosNow
+  let nanos := (t1 - t0) / reps
+  let basisJson := encodeMatrix basis
+  let line := "{" ++
+    s!"\"n\":{n},\"reps\":{reps},\"lean_nanos\":{nanos},\"checksum\":{chk},\"basis\":{basisJson}"
+    ++ "}"
+  IO.println line
+
+def main : IO Unit := do
+  runOne 3  200 (by decide)
+  runOne 4  200 (by decide)
+  runOne 5  200 (by decide)
+  runOne 6  100 (by decide)
+  runOne 7  50  (by decide)
+  runOne 8  30  (by decide)
+  runOne 10 20  (by decide)
+  runOne 12 10  (by decide)
+  runOne 15 5   (by decide)

--- a/reports/scratch/PrimeProbe.lean
+++ b/reports/scratch/PrimeProbe.lean
@@ -1,0 +1,37 @@
+import HexBerlekampZassenhaus.Basic
+
+open Hex
+
+private def zp (cs : Array Int) : ZPoly := DensePoly.ofCoeffs cs
+
+private def splitProduct (n : Nat) : ZPoly := Id.run do
+  let mut acc : ZPoly := 1
+  for i in [1:n+1] do
+    acc := acc * (zp #[-(Int.ofNat i), 1])
+  return acc
+
+private instance b3  : ZMod64.Bounds 3  := ⟨by decide, by decide⟩
+private instance b5  : ZMod64.Bounds 5  := ⟨by decide, by decide⟩
+private instance b7  : ZMod64.Bounds 7  := ⟨by decide, by decide⟩
+private instance b11 : ZMod64.Bounds 11 := ⟨by decide, by decide⟩
+private instance b13 : ZMod64.Bounds 13 := ⟨by decide, by decide⟩
+private instance b17 : ZMod64.Bounds 17 := ⟨by decide, by decide⟩
+private instance b19 : ZMod64.Bounds 19 := ⟨by decide, by decide⟩
+private instance b23 : ZMod64.Bounds 23 := ⟨by decide, by decide⟩
+private instance b31 : ZMod64.Bounds 31 := ⟨by decide, by decide⟩
+private instance b71 : ZMod64.Bounds 71 := ⟨by decide, by decide⟩
+
+def main : IO Unit := do
+  for n in [11, 12, 13, 15, 18, 22, 24] do
+    let f := splitProduct n
+    let r3  := @Hex.isGoodPrime f 3 b3
+    let r5  := @Hex.isGoodPrime f 5 b5
+    let r7  := @Hex.isGoodPrime f 7 b7
+    let r11 := @Hex.isGoodPrime f 11 b11
+    let r13 := @Hex.isGoodPrime f 13 b13
+    let r17 := @Hex.isGoodPrime f 17 b17
+    let r19 := @Hex.isGoodPrime f 19 b19
+    let r23 := @Hex.isGoodPrime f 23 b23
+    let r31 := @Hex.isGoodPrime f 31 b31
+    let r71 := @Hex.isGoodPrime f 71 b71
+    IO.println s!"n={n}: p=3:{r3} 5:{r5} 7:{r7} 11:{r11} 13:{r13} 17:{r17} 19:{r19} 23:{r23} 31:{r31} 71:{r71}"

--- a/reports/scratch/README.md
+++ b/reports/scratch/README.md
@@ -1,0 +1,56 @@
+# Scratch evidence for the BZ-vs-Isabelle investigation
+
+Evidence artefacts supporting `../bz-vs-isabelle-investigation.md`.
+None of these compile or run as part of the project build; they live
+here for reproducibility of the post-mortem rather than as durable
+project surfaces.
+
+To exercise any of the Lean files, add the corresponding
+`lean_exe scratch_<name>` stanza to `lakefile.lean` temporarily, then
+revert after running.
+
+## Lean diagnostics (executable on demand)
+
+- `BZBench.lean` — times `Hex.factor` on the split-linear product
+  ladder `(x-1)(x-2)…(x-n)` for `n ∈ [2, 24]`. Forces evaluation via
+  a coefficient-hash checksum so DCE doesn't elide the call.
+- `FactorDemo.lean` — runs `Hex.factor` on a small fixture set and
+  prints results, used to confirm the wrong-output bug on
+  `(x-1)…(x-5)` first.
+- `FactorTrace.lean` — per-input trace of `factorFast` vs `factor`
+  (combinator), `choosePrime` vs `choosePrimeData`, the precision
+  cap, and the per-call wall time. Source of the
+  "factor takes 6s, returns 3 reducible factors" data point at
+  degree 24.
+- `PrimeProbe.lean` — direct `@Hex.isGoodPrime f p _` probe for every
+  prime in `smallPrimeCandidates`, across the same input ladder.
+  Confirms every candidate is rejected for the wrong-output cases.
+- `GcdProbe.lean` — single-case demonstration of the root cause:
+  `DensePoly.gcd (f mod 13) (f' mod 13) = [4]` for
+  `f = (x-1)…(x-11)`, a unit in F₁₃ but not equal to the literal
+  polynomial `1`, so `gcd == 1` fails.
+- `GcdMatrix.lean` — same probe broadened to `n × p` matrix.
+- `LLLBench.lean`, `LLLBenchTiny.lean` — `Hex.lllUnchecked` timing
+  on the random-bounded LLL ladder; produces the basis stream that
+  the fpylll and Isabelle/AFP comparators consume.
+
+## Python comparators (used by the plots)
+
+- `bz_flint_times.py` — re-runs each BZ Lean fixture through
+  `python-flint`'s `fmpz_poly.factor()`. Produces
+  `/tmp/bz-merged.jsonl`.
+- `lll_fpylll_times.py` — re-runs each LLL Lean basis through
+  `fpylll.LLL.reduction`. Produces `/tmp/lll-merged.jsonl`.
+- `lll_isabelle_times.py` — pipes each LLL Lean basis through the
+  AFP-extracted `svp_verified` binary (set up by
+  `scripts/oracle/setup_lll_isabelle.sh`) with adaptive subprocess-
+  startup overhead amortisation. Produces
+  `/tmp/lll-isabelle-times.jsonl`.
+
+## Plots
+
+- `plot_bz.py` — hex vs FLINT BZ ladder (log-y).
+- `plot_bz_isa.py` — hex vs Isabelle/AFP BZ ladder (log-y); the
+  headline plot of the investigation.
+- `plot_lll.py` — hex vs fpylll LLL.
+- `plot_lll_triple.py` — hex vs Isabelle vs fpylll LLL.

--- a/reports/scratch/bz_flint_times.py
+++ b/reports/scratch/bz_flint_times.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Read /tmp/bz-lean-times.jsonl, factor each poly with FLINT, write merged JSONL."""
+import json
+import sys
+import time
+from pathlib import Path
+
+import flint
+
+LEAN = Path("/tmp/bz-lean-times.jsonl")
+OUT = Path("/tmp/bz-merged.jsonl")
+
+
+def time_flint(coeffs, target_seconds: float = 0.3):
+    """Adaptive repeat: keep doubling until total wall >= target_seconds, return per-call seconds."""
+    p = flint.fmpz_poly(coeffs)
+    reps = 1
+    while True:
+        t0 = time.perf_counter()
+        last = None
+        for _ in range(reps):
+            last = p.factor()
+        elapsed = time.perf_counter() - t0
+        if elapsed >= target_seconds or reps >= 4096:
+            return elapsed / reps, last, reps
+        reps *= 4
+
+
+rows = []
+for line in LEAN.read_text().splitlines():
+    line = line.strip()
+    if not line or not line.startswith("{"):
+        continue
+    rec = json.loads(line)
+    coeffs = rec["coeffs"]
+    per_call, fac, reps = time_flint(coeffs)
+    n_irr = sum(1 for _, _ in fac[1])  # fac is (content, [(poly, mult)...])
+    merged = {
+        "degree": rec["degree"],
+        "lean_seconds": rec["lean_nanos"] / 1e9,
+        "lean_factors": rec["factors"],
+        "flint_seconds": per_call,
+        "flint_factors": n_irr,
+        "flint_reps": reps,
+    }
+    rows.append(merged)
+    print(
+        f"deg {rec['degree']:>3} | "
+        f"lean {rec['lean_nanos']/1e9:>10.6f}s ({rec['factors']} factors) | "
+        f"flint {per_call*1e6:>10.2f} µs ({n_irr} factors)",
+    )
+
+OUT.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+print(f"\nWrote {OUT}")

--- a/reports/scratch/lll_fpylll_times.py
+++ b/reports/scratch/lll_fpylll_times.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""For each basis emitted by /tmp/lll-lean-times.jsonl, run fpylll LLL on the
+same basis and write merged JSONL with timings."""
+import json
+import time
+from pathlib import Path
+
+from fpylll import IntegerMatrix, LLL
+
+LEAN = Path("/tmp/lll-lean-times.jsonl")
+OUT = Path("/tmp/lll-merged.jsonl")
+
+
+def time_fpylll(basis, target_seconds: float = 0.4):
+    reps = 1
+    while True:
+        t0 = time.perf_counter()
+        last = None
+        for _ in range(reps):
+            # IntegerMatrix from Python list-of-lists. LLL.reduction mutates,
+            # so make a fresh copy each rep.
+            M = IntegerMatrix.from_matrix(basis)
+            last = LLL.reduction(M, delta=0.75)
+        elapsed = time.perf_counter() - t0
+        if elapsed >= target_seconds or reps >= 256:
+            return elapsed / reps, last, reps
+        reps *= 2
+
+
+rows = []
+for line in LEAN.read_text().splitlines():
+    line = line.strip()
+    if not line or not line.startswith("{"):
+        continue
+    rec = json.loads(line)
+    basis = rec["basis"]
+    per_call, _, reps = time_fpylll(basis)
+    merged = {
+        "n": rec["n"],
+        "lean_seconds": rec["lean_nanos"] / 1e9,
+        "fpylll_seconds": per_call,
+        "fpylll_reps": reps,
+    }
+    rows.append(merged)
+    print(
+        f"n {rec['n']:>4} | lean {rec['lean_nanos']/1e9:>10.6f}s | "
+        f"fpylll {per_call*1e6:>10.2f} µs  (ratio {rec['lean_nanos']/1e9 / per_call:>10.0f}x)",
+    )
+
+OUT.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+print(f"\nWrote {OUT}")

--- a/reports/scratch/lll_isabelle_times.py
+++ b/reports/scratch/lll_isabelle_times.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""For each LLL basis in /tmp/lll-lean-times.jsonl, time the verified
+extracted-Haskell `svp_verified` binary. Each measurement launches the
+binary ONCE and pipes R copies of the same basis through stdin to
+amortize the ~20ms process startup cost."""
+import json
+import subprocess
+import time
+from pathlib import Path
+
+LEAN = Path("/tmp/lll-lean-times.jsonl")
+OUT = Path("/tmp/lll-isabelle-times.jsonl")
+BIN = Path("/Users/kim/projects/lean/hex/.cache/oracles/lll-isabelle/src/experiments/svp_verified")
+
+
+def measure_overhead(reps=20):
+    """How long does it take to launch the binary and pipe `reps`
+    one-row trivial inputs through it. Subtract this from per-input cost."""
+    trivial = "[[1,0,0],[0,1,0],[0,0,1]]\n" * reps
+    t0 = time.perf_counter()
+    subprocess.run([str(BIN)], input=trivial, capture_output=True, text=True, check=True, timeout=60)
+    return (time.perf_counter() - t0) / reps  # per-input on a trivial basis
+
+
+def time_one(basis, target_seconds: float = 0.6, min_reps: int = 4, max_reps: int = 64):
+    basis_line = repr(basis)
+    reps = min_reps
+    while True:
+        input_data = (basis_line + "\n") * reps
+        t0 = time.perf_counter()
+        r = subprocess.run(
+            [str(BIN)], input=input_data, capture_output=True, text=True, check=True, timeout=300,
+        )
+        elapsed = time.perf_counter() - t0
+        per_call = elapsed / reps
+        if elapsed >= target_seconds or reps >= max_reps:
+            sq = r.stdout.strip().splitlines()[-1].strip()
+            return per_call, sq, reps
+        reps *= 2
+
+
+# Establish a "trivial input" baseline that includes process start +
+# the parser + JIT warmup.  We subtract it from each measurement,
+# clamping to zero.
+overhead = measure_overhead()
+print(f"[svp_verified startup baseline: {overhead*1e3:.2f} ms / input on trivial 3x3]")
+
+rows = []
+for line in LEAN.read_text().splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    rec = json.loads(line)
+    basis = rec["basis"]
+    per_call, sq, reps = time_one(basis)
+    adjusted = max(per_call - overhead, 0.0)
+    rows.append({
+        "n": rec["n"],
+        "lean_seconds": rec["lean_nanos"] / 1e9,
+        "isa_seconds_raw": per_call,
+        "isa_seconds": adjusted,
+        "isa_overhead_seconds": overhead,
+        "isa_sq_norm": sq,
+        "isa_reps": reps,
+    })
+    print(
+        f"n {rec['n']:>4} | lean {rec['lean_nanos']/1e9:>10.6f}s | "
+        f"isabelle raw {per_call*1e3:>8.2f}ms  → minus startup = {adjusted*1e3:>8.2f}ms  (sq={sq})",
+        flush=True,
+    )
+
+OUT.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+print(f"\nWrote {OUT}")

--- a/reports/scratch/plot_bz.py
+++ b/reports/scratch/plot_bz.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Plot Lean vs FLINT factorization times on the split linear ladder."""
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+rows = [json.loads(l) for l in Path("/tmp/bz-merged.jsonl").read_text().splitlines() if l.strip()]
+rows.sort(key=lambda r: r["degree"])
+
+deg = [r["degree"] for r in rows]
+lean_full = [(r["degree"], r["lean_seconds"]) for r in rows if r["lean_factors"] == r["degree"]]
+lean_part = [(r["degree"], r["lean_seconds"]) for r in rows if r["lean_factors"] != r["degree"]]
+flint = [(r["degree"], r["flint_seconds"]) for r in rows]
+
+fig, ax = plt.subplots(figsize=(9, 6))
+
+if lean_full:
+    xs, ys = zip(*lean_full)
+    ax.plot(xs, ys, "o-", color="C0", label="hex (fully refined)", markersize=7)
+if lean_part:
+    xs, ys = zip(*lean_part)
+    ax.plot(xs, ys, "x", color="C0", label="hex (under-refined, fewer factors)", markersize=9, mew=2)
+
+xs, ys = zip(*flint)
+ax.plot(xs, ys, "s-", color="C1", label="FLINT (fmpz_poly.factor)", markersize=6)
+
+ax.set_yscale("log")
+ax.set_xlabel("input degree  (input is $(x-1)(x-2)\\cdots(x-n)$)")
+ax.set_ylabel("wall time per factorization (seconds, log scale)")
+ax.set_title("Integer poly factorization: hex (Lean) vs FLINT")
+ax.grid(True, which="both", linestyle="--", linewidth=0.4, alpha=0.5)
+ax.legend(loc="upper left")
+
+out = Path("/tmp/bz-lean-vs-flint.png")
+fig.tight_layout()
+fig.savefig(out, dpi=140)
+print(f"wrote {out}")

--- a/reports/scratch/plot_bz_isa.py
+++ b/reports/scratch/plot_bz_isa.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Plot hex (Lean) vs Isabelle (verified Haskell extraction) on the
+split-linear BZ ladder.  Optionally also overlay FLINT for context."""
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+lean = {
+    json.loads(l)["degree"]: json.loads(l)
+    for l in Path("/tmp/bz-merged.jsonl").read_text().splitlines()
+    if l.strip()
+}
+isa = {
+    json.loads(l)["degree"]: json.loads(l)
+    for l in Path("/tmp/bz-isabelle-times.jsonl").read_text().splitlines()
+    if l.strip()
+}
+
+degrees = sorted(set(lean) & set(isa))
+
+fig, ax = plt.subplots(figsize=(9, 6))
+
+lean_full = [(d, lean[d]["lean_seconds"]) for d in degrees if lean[d]["lean_factors"] == d]
+lean_part = [(d, lean[d]["lean_seconds"]) for d in degrees if lean[d]["lean_factors"] != d]
+isa_pts   = [(d, isa[d]["isa_nanos"] / 1e9) for d in degrees]
+
+if lean_full:
+    xs, ys = zip(*lean_full)
+    ax.plot(xs, ys, "o-", color="C0", label="hex (Lean), fully refined", markersize=7)
+if lean_part:
+    xs, ys = zip(*lean_part)
+    ax.plot(xs, ys, "x", color="C0", label="hex (Lean), under-refined (fewer factors)", markersize=9, mew=2)
+
+xs, ys = zip(*isa_pts)
+ax.plot(xs, ys, "D-", color="C2", label="Isabelle/AFP (extracted Haskell, GHC -O2)", markersize=6)
+
+ax.set_yscale("log")
+ax.set_xlabel("input degree  (input is $(x-1)(x-2)\\cdots(x-n)$)")
+ax.set_ylabel("wall time per factorization (seconds, log scale)")
+ax.set_title("Integer poly factorization: hex (Lean) vs Isabelle/AFP")
+ax.grid(True, which="both", linestyle="--", linewidth=0.4, alpha=0.5)
+ax.legend(loc="upper left")
+
+out = Path("/tmp/bz-lean-vs-isabelle.png")
+fig.tight_layout()
+fig.savefig(out, dpi=140)
+print(f"wrote {out}")

--- a/reports/scratch/plot_lll.py
+++ b/reports/scratch/plot_lll.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Plot Lean LLL vs fpylll on the random-bounded ladder."""
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+rows = [
+    json.loads(l)
+    for l in Path("/tmp/lll-merged.jsonl").read_text().splitlines()
+    if l.strip()
+]
+rows.sort(key=lambda r: r["n"])
+
+dim = [r["n"] for r in rows]
+lean = [r["lean_seconds"] for r in rows]
+fpyl = [r["fpylll_seconds"] for r in rows]
+ratio = [a / b for a, b in zip(lean, fpyl)]
+
+fig, ax = plt.subplots(figsize=(9, 6))
+
+ax.plot(dim, lean, "o-", color="C0", label="hex (Lean, lllUnchecked)", markersize=7)
+ax.plot(dim, fpyl, "s-", color="C1", label="fpylll (LLL.reduction, δ=0.75)", markersize=6)
+
+ax.set_yscale("log")
+ax.set_xlabel("lattice dimension n  (n×n random-bounded triangular basis, entries in [-30,30])")
+ax.set_ylabel("wall time per LLL reduction (seconds, log scale)")
+ax.set_title("LLL: hex (Lean) vs fpylll")
+ax.grid(True, which="both", linestyle="--", linewidth=0.4, alpha=0.5)
+ax.legend(loc="upper left")
+
+out = Path("/tmp/lll-lean-vs-fpylll.png")
+fig.tight_layout()
+fig.savefig(out, dpi=140)
+print(f"wrote {out}")
+print(f"ratio range: {min(ratio):.0f}× to {max(ratio):.0f}×")

--- a/reports/scratch/plot_lll_triple.py
+++ b/reports/scratch/plot_lll_triple.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""LLL triple comparison: hex (Lean) vs Isabelle (AFP svp_verified) vs fpylll."""
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+lean = {
+    json.loads(l)["n"]: json.loads(l)
+    for l in Path("/tmp/lll-merged.jsonl").read_text().splitlines()
+    if l.strip()
+}
+isa = {
+    json.loads(l)["n"]: json.loads(l)
+    for l in Path("/tmp/lll-isabelle-times.jsonl").read_text().splitlines()
+    if l.strip() and json.loads(l).get("isa_seconds") is not None
+}
+
+dims = sorted(set(lean) & set(isa))
+
+xs       = dims
+lean_y   = [lean[n]["lean_seconds"] for n in xs]
+fpyl_y   = [lean[n]["fpylll_seconds"] for n in xs]
+isa_y    = [isa[n]["isa_seconds_raw"] for n in xs]
+
+fig, ax = plt.subplots(figsize=(9, 6))
+
+ax.plot(xs, lean_y, "o-", color="C0", label="hex (Lean, lllUnchecked)", markersize=7)
+ax.plot(xs, isa_y,  "D-", color="C2", label="Isabelle/AFP (svp_verified, extracted Haskell)", markersize=6)
+ax.plot(xs, fpyl_y, "s-", color="C1", label="fpylll (LLL.reduction)", markersize=6)
+
+ax.set_yscale("log")
+ax.set_xlabel("lattice dimension n  (n×n random-bounded triangular basis, entries in [-30,30])")
+ax.set_ylabel("wall time per LLL reduction (seconds, log scale)")
+ax.set_title("LLL: hex (Lean) vs Isabelle/AFP vs fpylll")
+ax.grid(True, which="both", linestyle="--", linewidth=0.4, alpha=0.5)
+ax.legend(loc="upper left")
+
+out = Path("/tmp/lll-triple.png")
+fig.tight_layout()
+fig.savefig(out, dpi=140)
+print(f"wrote {out}")
+
+# Print pairwise ratios so we can sanity-check.
+print("\nratios (isa / lean, fpylll / lean):")
+for n, L, I, F in zip(xs, lean_y, isa_y, fpyl_y):
+    print(f"  n={n:>4}: isa/lean={I/L:.2f}x, lean/fpylll={L/F:.1f}x")


### PR DESCRIPTION
This PR codifies four orchestration requirements for `hex-berlekamp-zassenhaus` that the project did not have when BZ's Phase-4 bench scaffolding landed under HO-3 (#2566). All four trace to a live regression — hex BZ's `factor` returns mathematically wrong output on `(x-1)…(x-n)` for several `n ∈ [11, 24]` and is 200–2,400× slower than the AFP Isabelle BZ extracted-Haskell binary even when correct — investigated in [reports/bz-vs-isabelle-investigation.md](https://github.com/kim-em/hex/blob/spec/bz-comparator-headline-theorem-no-fallback/reports/bz-vs-isabelle-investigation.md).

This is an interactive-Claude SPEC-clarification PR per the `spec-driven-development` skill (SPEC PR first, worker issues against the new SPEC second). It is SPEC text + `libraries.yml` metadata only; no Lean code changes. Worker issues filed after merge:

- HO-1 (#2564) reframed in place to name the headline correctness theorem as its deliverable, preserving the existing additive-vs-multiplicative lattice diagnosis.
- HO-5 rollback coordination issue + four children (HO-5a comparator wiring with acceptance matrix, HO-5b perf-report rewrite against ratios, HO-5c bench schedule extension, HO-5d remove `fallbackPrimeChoiceData`).
- A bundled tactical `isGoodPrime`-fix-plus-fixtures issue.

## Changes

- `SPEC/Libraries/hex-berlekamp-zassenhaus.md`: new `## Headline correctness theorem` (semantic shape: product preservation, primitive irreducibility, positive multiplicities, no factor associates, scalar carries sign × content) and `## External comparators` (verified-Isabelle BZ, gating, goal `hex/isabelle ≤ 1×` with algorithm-class caveat) sections.
- `libraries.yml`: `HexBerlekampZassenhaus.phase4.comparators` entry matching the SPEC clause.
- `SPEC/design-principles.md`: new principle 8 *"Fallback discipline for total forms of partial helpers"*, sibling of principle 7. Exactly two admissible classifications (`unreachable-by-pipeline-invariant`, `audited-emergency-value`). `refactor-pending` is not admissible. Applies retroactively: existing total forms must be proved unreachable or removed before the next `done_through` bump past their phase.
- `PLAN/Conventions.md`: cross-reference paragraphs making both new SPEC rules discoverable from the per-session conventions read.

## Reports and evidence

- `reports/bz-vs-isabelle-investigation.md` — the post-mortem (diagnosis + five orchestration gaps).
- `reports/bz-spec-comparator-pr-draft.md` — this PR's body in long form, kept as durable rationale.
- `reports/bz-rollback-issue-draft.md` — HO-5 + children, filed after merge.
- `reports/scratch/` — Lean diagnostic probes + Python comparators that produced the data.

## Related

- HO-1 (open): #2564
- HO-2 (closed): #2565
- HO-3 (closed): #2566

🤖 Prepared with Claude Code