### PR TITLE
doc: forbid coined words and process jargon in identifiers

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -148,6 +148,14 @@ acronyms. Do not silently introduce a mixed-case spelling.
 > identifiers in isolation. New libraries should follow the acronym
 > rule from the start.
 
+### Process vocabulary stops at the issue boundary
+
+Issue and PR titles may use scheduling shorthand ("HO-1 Gap 1
+consumer"); the Lean identifiers a worker creates name the
+**mathematics**, never the issue's process words — `ZPoly.toMonic`,
+not `monicisedCoreTransportPackage`. See
+[design-principles.md §Naming and documentation](../SPEC/design-principles.md).
+
 ### FFI
 
 Libraries that use `@[extern]` (e.g. `hex-arith` for GMP wrappers,

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -16,7 +16,11 @@ its Mathlib bridge; every theorem has a real proof.
 
 The public API accepts arbitrary input polynomials and normalizes
 internally: extract content, remove powers of `X`, and reduce to the
-primitive square-free case before running the recombination pipeline.
+primitive square-free case — then make that square-free core monic via
+the integral-normalisation transform `ZPoly.toMonic`
+(`c^(deg−1)·core(X/c)`, `c = leadingCoeff`), so Hensel lifting and
+recombination see a monic polynomial and factors are scaled back
+afterward — before running the recombination pipeline.
 The output is a **`Factorization` record** explicitly separating the
 signed scalar (sign · content) from the polynomial-factor multiset
 with explicit multiplicities. Factor order in the polynomial-factor

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -125,3 +125,13 @@ specification — also carry one. Routine private plumbing (unfolding
 lemmas, `_aux` helpers, trivial getters) is exempt. Every theorem
 another file could reasonably import carries a docstring stating what
 it proves and why the caller cares.
+
+**Coined words.** Don't invent vocabulary. Name things with a standard
+mathematical term, a standard programming term, or a plain description
+of what they do — check Mathlib and the literature first. Two failure
+modes: invented `-ise`/`-ify` verbs for operations that already have a
+name (the transform making a polynomial monic is `ZPoly.toMonic`, not
+`monicise`), and issue/PR process words as identifiers ("umbrella",
+"transport package", "consumer", "Gap N", "HO-N") — these record how a
+proof was scheduled, not what it is. A name a reader can't decode
+without finding its originating issue is a defect.


### PR DESCRIPTION
This PR adds a naming rule to the project doctrine forbidding invented vocabulary (such as `monicise`) and the leakage of issue/PR scheduling words (`umbrella`, `transport package`, `consumer`, `Gap N`, `HO-N`) into Lean identifiers. Names must be a standard mathematical term, a standard programming term, or a plain description of what the thing does. The rule is recorded in both `SPEC/design-principles.md` (the principle) and `PLAN/Conventions.md` (the worker-facing "process vocabulary stops at the issue boundary" rule), and the previously-unspecified monic-reduction step of the Berlekamp–Zassenhaus pipeline is documented as `ZPoly.toMonic` in the BZ library SPEC.

A follow-up issue will rename the existing `monicise`/`MonicisedCoreData` family to `toMonic` and purge the leaked process jargon from BZ identifiers.

🤖 Prepared with Claude Code