### PR TITLE
refactor: rename monicise vocabulary to toMonic and purge process jargon from BZ identifiers

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1165,22 +1165,25 @@ structure FactorNormalizationData where
   squareFreeCore : ZPoly
   repeatedPart : ZPoly
 
-/--
-Executable data for the integer monicising transform used before Hensel
-lifting a primitive positive-leading core.
+namespace ZPoly
 
-If `core` has degree `n` and leading coefficient `c`, `monicCore` is the
+/--
+Executable data for the integer scaling transform that sends a primitive
+positive-leading core to a monic integer polynomial with the same roots
+(scaled by the leading coefficient).
+
+If `core` has degree `n` and leading coefficient `c`, `monic` is the
 coefficientwise integer polynomial `c^(n-1) * core (X / c)`: lower coefficient
 `a_i` becomes `a_i * c^(n-1-i)` and the leading coefficient is normalised to
 `1`.
 -/
-structure MonicisedCoreData where
+structure ToMonicData where
   core : ZPoly
   leadingCoeff : Int
   degree : Nat
-  monicCore : ZPoly
+  monic : ZPoly
 
-namespace MonicisedCoreData
+namespace ToMonicData
 
 private def transformedCoeffs (core : ZPoly) (degree : Nat) : Array Int :=
   ((List.range degree).map fun i =>
@@ -1192,27 +1195,6 @@ private def transformedCore (core : ZPoly) (degree : Nat) : ZPoly :=
       right
       change (transformedCoeffs core degree).back? ≠ some (0 : Int)
       simp [transformedCoeffs] }
-
-/-- Monicise a core by the standard integer scaling transform. -/
-def ofCore (core : ZPoly) : MonicisedCoreData :=
-  let degree := core.degree?.getD 0
-  { core
-    leadingCoeff := DensePoly.leadingCoeff core
-    degree
-    monicCore :=
-      if DensePoly.leadingCoeff core = 1 then
-        core
-      else
-        transformedCore core degree }
-
-@[simp] theorem ofCore_core (core : ZPoly) :
-    (ofCore core).core = core := rfl
-
-@[simp] theorem ofCore_leadingCoeff (core : ZPoly) :
-    (ofCore core).leadingCoeff = DensePoly.leadingCoeff core := rfl
-
-@[simp] theorem ofCore_degree (core : ZPoly) :
-    (ofCore core).degree = core.degree?.getD 0 := rfl
 
 @[simp] theorem transformedCoeffs_size (core : ZPoly) (degree : Nat) :
     (transformedCoeffs core degree).size = degree + 1 := by
@@ -1241,51 +1223,76 @@ theorem transformedCore_monic (core : ZPoly) (degree : Nat) :
   unfold DensePoly.degree? transformedCore DensePoly.size
   simp [transformedCoeffs]
 
-/-- The transformed core is monic as soon as the source has positive degree. -/
-theorem monicCore_monic_of_pos_degree
+end ToMonicData
+
+/-- Build the `ToMonicData` packet for a core by the integer scaling transform. -/
+def toMonic (core : ZPoly) : ToMonicData :=
+  let degree := core.degree?.getD 0
+  { core
+    leadingCoeff := DensePoly.leadingCoeff core
+    degree
+    monic :=
+      if DensePoly.leadingCoeff core = 1 then
+        core
+      else
+        ToMonicData.transformedCore core degree }
+
+@[simp] theorem toMonic_core (core : ZPoly) :
+    (toMonic core).core = core := rfl
+
+@[simp] theorem toMonic_leadingCoeff (core : ZPoly) :
+    (toMonic core).leadingCoeff = DensePoly.leadingCoeff core := rfl
+
+@[simp] theorem toMonic_degree (core : ZPoly) :
+    (toMonic core).degree = core.degree?.getD 0 := rfl
+
+/-- The `monic` field of `toMonic core` is monic once the source has positive
+degree. -/
+theorem toMonic_monic_isMonic_of_pos_degree
     (core : ZPoly) (_hpos_lc : 0 < DensePoly.leadingCoeff core)
-    (_hdegree : 0 < (ofCore core).degree) :
-    DensePoly.Monic (ofCore core).monicCore := by
-  unfold ofCore
+    (_hdegree : 0 < (toMonic core).degree) :
+    DensePoly.Monic (toMonic core).monic := by
+  unfold toMonic
   by_cases hmonic : DensePoly.leadingCoeff core = 1
   · simp [hmonic, DensePoly.Monic]
-  · simp [hmonic, transformedCore_monic]
+  · simp [hmonic, ToMonicData.transformedCore_monic]
 
-/-- The monicised core preserves the recorded degree in nonconstant cases. -/
-theorem monicCore_degree_eq_of_pos_degree
+/-- The `monic` field preserves the recorded degree in nonconstant cases. -/
+theorem toMonic_monic_degree_eq_of_pos_degree
     (core : ZPoly) (_hpos_lc : 0 < DensePoly.leadingCoeff core)
-    (_hdegree : 0 < (ofCore core).degree) :
-    (ofCore core).monicCore.degree?.getD 0 = (ofCore core).degree := by
-  unfold ofCore
+    (_hdegree : 0 < (toMonic core).degree) :
+    (toMonic core).monic.degree?.getD 0 = (toMonic core).degree := by
+  unfold toMonic
   by_cases hmonic : DensePoly.leadingCoeff core = 1
   · simp [hmonic]
   · simp [hmonic]
 
-/-- Monicising an already-monic core is the identity. -/
-theorem monicCore_eq_core_of_leadingCoeff_eq_one
+/-- Applying `toMonic` to an already-monic core leaves its `monic` field equal
+to the original. -/
+theorem toMonic_monic_eq_core_of_leadingCoeff_eq_one
     (core : ZPoly) (hmonic : DensePoly.leadingCoeff core = 1) :
-    (ofCore core).monicCore = core := by
-  simp [ofCore, hmonic]
+    (toMonic core).monic = core := by
+  simp [toMonic, hmonic]
 
-private def monicisedCoreGuardMonic : MonicisedCoreData :=
-  ofCore (DensePoly.ofCoeffs #[1, 3, 1])
+private def toMonicGuardMonic : ToMonicData :=
+  toMonic (DensePoly.ofCoeffs #[1, 3, 1])
 
-#guard monicisedCoreGuardMonic.monicCore = monicisedCoreGuardMonic.core
+#guard toMonicGuardMonic.monic = toMonicGuardMonic.core
 
-private def monicisedCoreGuardQuadratic : MonicisedCoreData :=
-  ofCore (DensePoly.ofCoeffs #[1, 3, 2])
+private def toMonicGuardQuadratic : ToMonicData :=
+  toMonic (DensePoly.ofCoeffs #[1, 3, 2])
 
-#guard monicisedCoreGuardQuadratic.degree = 2
-#guard monicisedCoreGuardQuadratic.leadingCoeff = 2
-#guard monicisedCoreGuardQuadratic.monicCore = DensePoly.ofCoeffs #[2, 3, 1]
+#guard toMonicGuardQuadratic.degree = 2
+#guard toMonicGuardQuadratic.leadingCoeff = 2
+#guard toMonicGuardQuadratic.monic = DensePoly.ofCoeffs #[2, 3, 1]
 
-private def monicisedCoreGuardZero : MonicisedCoreData :=
-  ofCore 0
+private def toMonicGuardZero : ToMonicData :=
+  toMonic 0
 
-#guard monicisedCoreGuardZero.degree = 0
-#guard monicisedCoreGuardZero.monicCore = DensePoly.ofCoeffs #[1]
+#guard toMonicGuardZero.degree = 0
+#guard toMonicGuardZero.monic = DensePoly.ofCoeffs #[1]
 
-end MonicisedCoreData
+end ZPoly
 
 /--
 Public integer-polynomial factorization result.
@@ -5719,78 +5726,82 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
     (initialHenselPrecision 4) (ZPoly.quadraticDoublingSteps 4 + 2) =
   some bhksGuardFactors
 
+namespace ZPoly
+
 /--
-Build the fixed-precision Hensel lift data for the monicised copy of an
+Build the fixed-precision Hensel lift data for the monic transform of an
 integer core.  The exhaustive slow path still recombines against the original
-primitive core, but the lift stage sees the monic substrate required by the
+primitive core, but the lift stage sees the monic polynomial required by the
 Hensel pipeline.
 -/
-def monicisedCoreLiftData
+def toMonicLiftData
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : LiftData :=
-  henselLiftData (MonicisedCoreData.ofCore core).monicCore
+  henselLiftData (toMonic core).monic
     (precisionForCoeffBound B primeData.p) primeData
 
 /--
-Optional prime-choice data for the actual monic substrate sent to Hensel lifting.
+Optional prime-choice data for the monic polynomial sent to Hensel lifting.
 
 The public factoring pipeline still chooses prime data from the original core.
 This adjacent surface is for proof consumers that need Berlekamp-form modular
-factor data for `(MonicisedCoreData.ofCore core).monicCore`, the polynomial
-that `monicisedCoreLiftData` passes to `henselLiftData`.
+factor data for `(toMonic core).monic`, the polynomial that `toMonicLiftData`
+passes to `henselLiftData`.
 -/
-def monicisedCorePrimeData? (core : ZPoly) : Option PrimeChoiceData :=
-  choosePrimeData? (MonicisedCoreData.ofCore core).monicCore
+def toMonicPrimeData? (core : ZPoly) : Option PrimeChoiceData :=
+  choosePrimeData? (toMonic core).monic
 
 /--
-Total prime-choice data for the actual monic substrate sent to Hensel lifting.
+Total prime-choice data for the monic polynomial sent to Hensel lifting.
 This keeps the executable public factoring API unchanged while exposing a
 correctly aligned internal data source for downstream correctness proofs.
 -/
-def monicisedCorePrimeData (core : ZPoly) : PrimeChoiceData :=
-  choosePrimeData (MonicisedCoreData.ofCore core).monicCore
+def toMonicPrimeData (core : ZPoly) : PrimeChoiceData :=
+  choosePrimeData (toMonic core).monic
 
 /--
-Lift data for the monicised core using prime-choice data computed from that
-same monicised core.
+Lift data for the monic transform of `core` using prime-choice data computed
+from that same monic polynomial.
 -/
-def monicisedCoreLiftDataWithMonicPrime (core : ZPoly) (B : Nat) : LiftData :=
-  monicisedCoreLiftData core B (monicisedCorePrimeData core)
+def toMonicLiftDataWithMonicPrime (core : ZPoly) (B : Nat) : LiftData :=
+  toMonicLiftData core B (toMonicPrimeData core)
 
-theorem monicisedCorePrimeData?_prime
+theorem toMonicPrimeData?_prime
     (core : ZPoly) (data : PrimeChoiceData)
-    (hdata : monicisedCorePrimeData? core = some data) :
+    (hdata : toMonicPrimeData? core = some data) :
     Nat.Prime data.p := by
-  exact choosePrimeData?_prime (MonicisedCoreData.ofCore core).monicCore data hdata
+  exact choosePrimeData?_prime (toMonic core).monic data hdata
 
-theorem monicisedCorePrimeData?_isGoodPrime
+theorem toMonicPrimeData?_isGoodPrime
     (core : ZPoly) (data : PrimeChoiceData)
-    (hdata : monicisedCorePrimeData? core = some data) :
-    @isGoodPrime (MonicisedCoreData.ofCore core).monicCore data.p data.bounds = true := by
-  exact choosePrimeData?_isGoodPrime (MonicisedCoreData.ofCore core).monicCore data hdata
+    (hdata : toMonicPrimeData? core = some data) :
+    @isGoodPrime (toMonic core).monic data.p data.bounds = true := by
+  exact choosePrimeData?_isGoodPrime (toMonic core).monic data hdata
 
-theorem monicisedCorePrimeData?_factorsModP_berlekamp_form
+theorem toMonicPrimeData?_factorsModP_berlekamp_form
     (core : ZPoly) (data : PrimeChoiceData)
-    (hdata : monicisedCorePrimeData? core = some data) :
-    factorsModPBerlekampForm (MonicisedCoreData.ofCore core).monicCore data := by
+    (hdata : toMonicPrimeData? core = some data) :
+    factorsModPBerlekampForm (toMonic core).monic data := by
   obtain ⟨hzero, heq⟩ :=
     choosePrimeData?_factorsModP_berlekamp_form
-      (MonicisedCoreData.ofCore core).monicCore data hdata
-  exact ⟨monicisedCorePrimeData?_prime core data hdata, hzero, heq⟩
+      (toMonic core).monic data hdata
+  exact ⟨toMonicPrimeData?_prime core data hdata, hzero, heq⟩
 
-theorem monicisedCoreLiftDataWithMonicPrime_eq
+theorem toMonicLiftDataWithMonicPrime_eq
     (core : ZPoly) (B : Nat) :
-    monicisedCoreLiftDataWithMonicPrime core B =
-      henselLiftData (MonicisedCoreData.ofCore core).monicCore
-        (precisionForCoeffBound B (monicisedCorePrimeData core).p)
-        (monicisedCorePrimeData core) := by
+    toMonicLiftDataWithMonicPrime core B =
+      henselLiftData (toMonic core).monic
+        (precisionForCoeffBound B (toMonicPrimeData core).p)
+        (toMonicPrimeData core) := by
   rfl
+
+end ZPoly
 
 def exhaustiveCoreFactorsWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : Array ZPoly :=
   if B = 0 then
     #[core]
   else
-    let liftData := monicisedCoreLiftData core B primeData
+    let liftData := ZPoly.toMonicLiftData core B primeData
     let factors :=
       recombineScaledExhaustive (DensePoly.leadingCoeff core) core liftData
     if factors.isEmpty then
@@ -5813,7 +5824,7 @@ private def exhaustiveMonicCoreGuardPrimeData : PrimeChoiceData :=
 private def exhaustiveNonMonicQuadraticGuard : ZPoly :=
   DensePoly.ofCoeffs #[1, 0, 2]
 
-#guard (MonicisedCoreData.ofCore exhaustiveNonMonicQuadraticGuard).monicCore =
+#guard (ZPoly.toMonic exhaustiveNonMonicQuadraticGuard).monic =
   DensePoly.ofCoeffs #[2, 0, 1]
 
 #guard quadraticIntegerRootFactors? exhaustiveNonMonicQuadraticGuard = none
@@ -9333,11 +9344,11 @@ theorem exhaustiveCoreFactorsWithBound_normalizeFactorSign
   · simp only [hB, if_false]
     by_cases hempty :
         (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
-            (monicisedCoreLiftData core B primeData)).isEmpty
+            (ZPoly.toMonicLiftData core B primeData)).isEmpty
     · simp [hempty, hcore]
     · simp only [hempty]
       exact recombineScaledExhaustive_normalizeFactorSign (DensePoly.leadingCoeff core) core
-        (monicisedCoreLiftData core B primeData)
+        (ZPoly.toMonicLiftData core B primeData)
 
 theorem exhaustiveCoreFactorsWithBound_shouldRecord
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
@@ -9350,11 +9361,11 @@ theorem exhaustiveCoreFactorsWithBound_shouldRecord
   · simp only [hB, if_false]
     by_cases hempty :
         (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
-            (monicisedCoreLiftData core B primeData)).isEmpty
+            (ZPoly.toMonicLiftData core B primeData)).isEmpty
     · simp [hempty, hcore]
     · simp only [hempty]
       exact recombineScaledExhaustive_shouldRecord (DensePoly.leadingCoeff core) core
-        (monicisedCoreLiftData core B primeData)
+        (ZPoly.toMonicLiftData core B primeData)
 
 /-- Every emitted factor of the exhaustive recombination wrapper is
 primitive when the input core is primitive. The two `#[core]` short-circuit
@@ -9371,11 +9382,11 @@ theorem exhaustiveCoreFactorsWithBound_primitive
   · simp only [hB, if_false]
     by_cases hempty :
         (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
-            (monicisedCoreLiftData core B primeData)).isEmpty
+            (ZPoly.toMonicLiftData core B primeData)).isEmpty
     · simp [hempty, hcore_primitive]
     · simp only [hempty]
       exact recombineScaledExhaustive_primitive (DensePoly.leadingCoeff core) core
-        (monicisedCoreLiftData core B primeData)
+        (ZPoly.toMonicLiftData core B primeData)
 
 private theorem bhksRecoverClassified_success_product
     {f : ZPoly} {d : LiftData} {candidates : Array ZPoly}
@@ -9655,24 +9666,24 @@ theorem exhaustiveCoreFactorsWithBound_product
   · simp only [hB, if_false]
     by_cases hempty :
         (recombineScaledExhaustive (DensePoly.leadingCoeff core) core
-            (monicisedCoreLiftData core B primeData)).isEmpty
+            (ZPoly.toMonicLiftData core B primeData)).isEmpty
     · simp [hempty, Array.polyProduct]
     · simp only [hempty]
       cases hsearch : scaledRecombinationSearchMod (DensePoly.leadingCoeff core) core
           (liftModulus
-            (monicisedCoreLiftData core B primeData))
-          (monicisedCoreLiftData core B primeData).liftedFactors.toList with
+            (ZPoly.toMonicLiftData core B primeData))
+          (ZPoly.toMonicLiftData core B primeData).liftedFactors.toList with
       | none =>
           have hnil :
               recombineScaledExhaustive (DensePoly.leadingCoeff core) core
-                (monicisedCoreLiftData core B primeData) = #[] := by
+                (ZPoly.toMonicLiftData core B primeData) = #[] := by
             rw [recombineScaledExhaustive]
             simp [hsearch]
           rw [hnil] at hempty
           simp at hempty
       | some xs =>
           exact recombineScaledExhaustive_product (DensePoly.leadingCoeff core) core
-            (monicisedCoreLiftData core B primeData)
+            (ZPoly.toMonicLiftData core B primeData)
             xs hsearch
 
 /-- The leading coefficient of an `Array.polyProduct` over a list of polynomials

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1663,7 +1663,7 @@ stable executable API.
 structure HenselSubsetCorrespondenceHypotheses
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (d : Hex.LiftData) (admissiblePrime successfulLift : Prop) : Prop where
-  lift_eq : d = Hex.monicisedCoreLiftData core B primeData
+  lift_eq : d = Hex.ZPoly.toMonicLiftData core B primeData
   admissible_prime : admissiblePrime
   successful_lift : successfulLift
   exists_subset :
@@ -1787,7 +1787,7 @@ structure HenselSubsetLiftHypotheses
     (d : Hex.LiftData)
     (admissiblePrime squareFreeReduction successfulLift coprimeLift : Prop) :
     Prop where
-  lift_eq : d = Hex.monicisedCoreLiftData core B primeData
+  lift_eq : d = Hex.ZPoly.toMonicLiftData core B primeData
   factor_count_eq : d.liftedFactors.size = primeData.factorsModP.size
   admissible_prime : admissiblePrime
   square_free_reduction : squareFreeReduction
@@ -1821,7 +1821,7 @@ correspondence.
 structure HenselLiftDescentHypotheses
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (d : Hex.LiftData) (successfulLift coprimeLift : Prop) : Prop where
-  lift_eq : d = Hex.monicisedCoreLiftData core B primeData
+  lift_eq : d = Hex.ZPoly.toMonicLiftData core B primeData
   factor_count_eq : d.liftedFactors.size = primeData.factorsModP.size
   successful_lift : successfulLift
   coprime_lift : coprimeLift
@@ -4659,13 +4659,13 @@ theorem henselLiftData_liftedFactors_size_eq
   rw [Hex.ZPoly.multifactorLiftQuadratic_size_eq_input]
   simp
 
-theorem monicisedCoreLiftData_liftedFactors_size_eq
+theorem Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData) :
-    (Hex.monicisedCoreLiftData core B primeData).liftedFactors.size =
+    (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size =
       primeData.factorsModP.size := by
-  unfold Hex.monicisedCoreLiftData
+  unfold Hex.ZPoly.toMonicLiftData
   exact henselLiftData_liftedFactors_size_eq
-    (Hex.MonicisedCoreData.ofCore core).monicCore
+    (Hex.ZPoly.toMonic core).monic
     (Hex.precisionForCoeffBound B primeData.p) primeData
 
 /--
@@ -4703,31 +4703,31 @@ theorem henselLiftData_liftedFactor_monic
     hB hp hcore_monic hprime_invariant i
 
 /--
-Per-output monicness for the executable monicised-core lift data.
+Per-output monicness for the executable `Hex.ZPoly.toMonicLiftData`.
 
-This is the direct `Hex.monicisedCoreLiftData` surface over the existing
+This is the direct `Hex.ZPoly.toMonicLiftData` surface over the existing
 `henselLiftData_liftedFactor_monic` invariant: the Hensel stage runs on
-`(Hex.MonicisedCoreData.ofCore core).monicCore`, while recombination consumers
+`(Hex.ZPoly.toMonic core).monic`, while recombination consumers
 still keep representation predicates against the original `core`.
 -/
-theorem monicisedCoreLiftData_liftedFactor_monic
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_monic
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hmonic_core :
-      Hex.DensePoly.Monic (Hex.MonicisedCoreData.ofCore core).monicCore)
+      Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic)
     (hprime_invariant :
       letI := primeData.bounds
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p (Hex.precisionForCoeffBound B primeData.p)
-        (Hex.MonicisedCoreData.ofCore core).monicCore
+        (Hex.ZPoly.toMonic core).monic
         (primeData.factorsModP.map Hex.FpPoly.liftToZ).toList)
     (hp : 1 < primeData.p)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p) :
-    ∀ i : Fin (Hex.monicisedCoreLiftData core B primeData).liftedFactors.size,
+    ∀ i : Fin (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
-        (liftedFactor (Hex.monicisedCoreLiftData core B primeData) i) := by
-  unfold Hex.monicisedCoreLiftData
+        (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i) := by
+  unfold Hex.ZPoly.toMonicLiftData
   exact henselLiftData_liftedFactor_monic
-    (Hex.MonicisedCoreData.ofCore core).monicCore
+    (Hex.ZPoly.toMonic core).monic
     (Hex.precisionForCoeffBound B primeData.p) primeData
     hmonic_core hprime_invariant hp hprecision
 
@@ -4938,19 +4938,19 @@ theorem henselLiftData_liftedFactor_injective
   exact Fin.ext hidx_eq
 
 /--
-Injectivity of lifted local factors for the executable monicised-core lift
-data.  This is the `Hex.monicisedCoreLiftData` surface over
+Injectivity of lifted local factors for the executable
+`Hex.ZPoly.toMonicLiftData`.  This is the surface over
 `henselLiftData_liftedFactor_injective`.
 -/
-theorem monicisedCoreLiftData_liftedFactor_injective
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_injective
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hmonic_core :
-      Hex.DensePoly.Monic (Hex.MonicisedCoreData.ofCore core).monicCore)
+      Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic)
     (hprime_invariant :
       letI := primeData.bounds
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p (Hex.precisionForCoeffBound B primeData.p)
-        (Hex.MonicisedCoreData.ofCore core).monicCore
+        (Hex.ZPoly.toMonic core).monic
         (primeData.factorsModP.map Hex.FpPoly.liftToZ).toList)
     (hp : 1 < primeData.p)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p)
@@ -4961,13 +4961,13 @@ theorem monicisedCoreLiftData_liftedFactor_injective
       letI := primeData.bounds
       Hex.ZPoly.congr
         (Array.polyProduct (primeData.factorsModP.map Hex.FpPoly.liftToZ))
-        (Hex.MonicisedCoreData.ofCore core).monicCore primeData.p)
+        (Hex.ZPoly.toMonic core).monic primeData.p)
     (hfactorsModP_nodup : primeData.factorsModP.toList.Nodup) :
     Function.Injective
-      (liftedFactor (Hex.monicisedCoreLiftData core B primeData)) := by
-  unfold Hex.monicisedCoreLiftData
+      (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData)) := by
+  unfold Hex.ZPoly.toMonicLiftData
   exact henselLiftData_liftedFactor_injective
-    (Hex.MonicisedCoreData.ofCore core).monicCore
+    (Hex.ZPoly.toMonic core).monic
     (Hex.precisionForCoeffBound B primeData.p) primeData
     hmonic_core hprime_invariant hp hprecision hfactors_monic
     hproduct_mod_p hfactorsModP_nodup
@@ -5729,7 +5729,7 @@ theorem factorsModP_polyProduct_congr_of_factorsModPBerlekampForm
         Hex.ZPoly.modP primeData.p core :=
     monicModularImage_modP_eq_of_monic core hcore_monic hprime hp hzero
   -- Delegate to the `_of_primitive_pos_lc_core` sibling, landing at
-  -- `liftToZ (monicModularImage (modP p core))`; the monicising layer
+  -- `liftToZ (monicModularImage (modP p core))`; the monic-image layer
   -- is a no-op on monic input, so `rw [hmonicImage_eq]` collapses it.
   have hcongr_mon :=
     factorsModP_polyProduct_congr_of_factorsModPBerlekampForm_of_primitive_pos_lc_core
@@ -6628,18 +6628,18 @@ theorem henselLiftData_liftedFactor_natDegree_pos
 
 /--
 Positive natural degree of every lifted local factor for the executable
-monicised-core lift data.  This is the `Hex.monicisedCoreLiftData` surface over
+`Hex.ZPoly.toMonicLiftData`.  This is the surface over
 `henselLiftData_liftedFactor_natDegree_pos`.
 -/
-theorem monicisedCoreLiftData_liftedFactor_natDegree_pos
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hmonic_core :
-      Hex.DensePoly.Monic (Hex.MonicisedCoreData.ofCore core).monicCore)
+      Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic)
     (hprime_invariant :
       letI := primeData.bounds
       Hex.ZPoly.QuadraticMultifactorLiftInvariant
         primeData.p (Hex.precisionForCoeffBound B primeData.p)
-        (Hex.MonicisedCoreData.ofCore core).monicCore
+        (Hex.ZPoly.toMonic core).monic
         (primeData.factorsModP.map Hex.FpPoly.liftToZ).toList)
     (hp : 1 < primeData.p)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p)
@@ -6650,17 +6650,17 @@ theorem monicisedCoreLiftData_liftedFactor_natDegree_pos
       letI := primeData.bounds
       Hex.ZPoly.congr
         (Array.polyProduct (primeData.factorsModP.map Hex.FpPoly.liftToZ))
-        (Hex.MonicisedCoreData.ofCore core).monicCore primeData.p)
+        (Hex.ZPoly.toMonic core).monic primeData.p)
     (hfactors_natDegree_pos :
       letI := primeData.bounds
       ∀ g ∈ primeData.factorsModP,
         0 < (HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g)).natDegree) :
-    ∀ i : Fin (Hex.monicisedCoreLiftData core B primeData).liftedFactors.size,
+    ∀ i : Fin (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
-            (liftedFactor (Hex.monicisedCoreLiftData core B primeData) i)).natDegree := by
-  unfold Hex.monicisedCoreLiftData
+            (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i)).natDegree := by
+  unfold Hex.ZPoly.toMonicLiftData
   exact henselLiftData_liftedFactor_natDegree_pos
-    (Hex.MonicisedCoreData.ofCore core).monicCore
+    (Hex.ZPoly.toMonic core).monic
     (Hex.precisionForCoeffBound B primeData.p) primeData
     hmonic_core hprime_invariant hp hprecision hfactors_monic hproduct_mod_p
     hfactors_natDegree_pos
@@ -6838,39 +6838,40 @@ theorem henselLiftData_liftedFactor_injective_of_factorsModPBerlekampForm
     hproduct_mod_p hcoprime hnonempty hfactorsModP_nodup
 
 /--
-Per-output monicness for the monicised-core lift whose prime data is selected
-from the monicised core itself.
+Per-output monicness for the `toMonic` lift whose prime data is selected from
+the monic transform itself.
 
-This is the non-monic-core wrapper over `monicisedCoreLiftData_liftedFactor_monic`:
-the original `core` only needs positive leading coefficient and positive degree,
-which make `(Hex.MonicisedCoreData.ofCore core).monicCore` monic.
+This is the non-monic-core wrapper over
+`Hex.ZPoly.toMonicLiftData_liftedFactor_monic`: the original `core` only needs
+positive leading coefficient and positive degree, which together make
+`(Hex.ZPoly.toMonic core).monic` monic.
 -/
-theorem monicisedCoreLiftData_liftedFactor_monic_of_monicPrimeData
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hcore_pos : 0 < core.degree?.getD 0)
-    (hselected : Hex.monicisedCorePrimeData? core = some primeData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p) :
-    ∀ i : Fin (Hex.monicisedCoreLiftData core B primeData).liftedFactors.size,
+    ∀ i : Fin (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size,
       Hex.DensePoly.Monic
-        (liftedFactor (Hex.monicisedCoreLiftData core B primeData) i) := by
-  let monicCore := (Hex.MonicisedCoreData.ofCore core).monicCore
+        (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i) := by
+  let monicCore := (Hex.ZPoly.toMonic core).monic
   have hmonicCore_monic :
       Hex.DensePoly.Monic monicCore := by
     dsimp [monicCore]
-    exact Hex.MonicisedCoreData.monicCore_monic_of_pos_degree
+    exact Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree
       core hcore_lc_pos hcore_pos
   have hform : Hex.factorsModPBerlekampForm monicCore primeData := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_factorsModP_berlekamp_form
+    exact Hex.ZPoly.toMonicPrimeData?_factorsModP_berlekamp_form
       core primeData hselected
   have hgood :
       letI := primeData.bounds
       Hex.isGoodPrime monicCore primeData.p = true := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_isGoodPrime core primeData hselected
+    exact Hex.ZPoly.toMonicPrimeData?_isGoodPrime core primeData hselected
   have hp_prime : Hex.Nat.Prime primeData.p :=
-    Hex.monicisedCorePrimeData?_prime core primeData hselected
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
   have hp : 1 < primeData.p := by
     have := hp_prime.two_le
     omega
@@ -6902,48 +6903,48 @@ theorem monicisedCoreLiftData_liftedFactor_monic_of_monicPrimeData
       monicCore (Hex.precisionForCoeffBound B primeData.p) primeData
       hp_prime hp hprecision hmonicCore_monic hfactors_monic
       hproduct_mod_p hcoprime hnonempty
-  exact monicisedCoreLiftData_liftedFactor_monic
+  exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic
     core B primeData hmonicCore_monic hinv hp hprecision
 
 /--
-Positive natural degree for each output of the monicised-core lift whose prime
-data is selected from the monicised core itself.
+Positive natural degree for each output of the `toMonic` lift whose prime
+data is selected from the monic transform itself.
 -/
-theorem monicisedCoreLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hcore_pos : 0 < core.degree?.getD 0)
-    (hselected : Hex.monicisedCorePrimeData? core = some primeData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p) :
-    ∀ i : Fin (Hex.monicisedCoreLiftData core B primeData).liftedFactors.size,
+    ∀ i : Fin (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size,
       0 < (HexPolyZMathlib.toPolynomial
-            (liftedFactor (Hex.monicisedCoreLiftData core B primeData) i)).natDegree := by
-  let monicCore := (Hex.MonicisedCoreData.ofCore core).monicCore
+            (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i)).natDegree := by
+  let monicCore := (Hex.ZPoly.toMonic core).monic
   have hmonicCore_monic :
       Hex.DensePoly.Monic monicCore := by
     dsimp [monicCore]
-    exact Hex.MonicisedCoreData.monicCore_monic_of_pos_degree
+    exact Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree
       core hcore_lc_pos hcore_pos
   have hmonicCore_degree :
       monicCore.degree?.getD 0 = core.degree?.getD 0 := by
     dsimp [monicCore]
-    simpa [Hex.MonicisedCoreData.ofCore_degree] using
-      Hex.MonicisedCoreData.monicCore_degree_eq_of_pos_degree
+    simpa [Hex.ZPoly.toMonic_degree] using
+      Hex.ZPoly.toMonic_monic_degree_eq_of_pos_degree
         core hcore_lc_pos hcore_pos
   have hmonicCore_pos : 0 < monicCore.degree?.getD 0 := by
     rw [hmonicCore_degree]
     exact hcore_pos
   have hform : Hex.factorsModPBerlekampForm monicCore primeData := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_factorsModP_berlekamp_form
+    exact Hex.ZPoly.toMonicPrimeData?_factorsModP_berlekamp_form
       core primeData hselected
   have hgood :
       letI := primeData.bounds
       Hex.isGoodPrime monicCore primeData.p = true := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_isGoodPrime core primeData hselected
+    exact Hex.ZPoly.toMonicPrimeData?_isGoodPrime core primeData hselected
   have hp_prime : Hex.Nat.Prime primeData.p :=
-    Hex.monicisedCorePrimeData?_prime core primeData hselected
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
   have hp : 1 < primeData.p := by
     have := hp_prime.two_le
     omega
@@ -6981,39 +6982,39 @@ theorem monicisedCoreLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
         0 < (HexPolyZMathlib.toPolynomial (Hex.FpPoly.liftToZ g)).natDegree :=
     factorsModP_natDegree_pos_of_factorsModPBerlekampForm
       monicCore primeData hform hgood hmonicCore_pos
-  exact monicisedCoreLiftData_liftedFactor_natDegree_pos
+  exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos
     core B primeData hmonicCore_monic hinv hp hprecision
     hfactors_monic hproduct_mod_p hfactors_natDegree_pos
 
 /--
-Injectivity of lifted factors for the monicised-core lift whose prime data is
-selected from the monicised core itself.
+Injectivity of lifted factors for the `toMonic` lift whose prime data is
+selected from the monic transform itself.
 -/
-theorem monicisedCoreLiftData_liftedFactor_injective_of_monicPrimeData
+theorem Hex.ZPoly.toMonicLiftData_liftedFactor_injective_of_monicPrimeData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hcore_pos : 0 < core.degree?.getD 0)
-    (hselected : Hex.monicisedCorePrimeData? core = some primeData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
     (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p) :
     Function.Injective
-      (liftedFactor (Hex.monicisedCoreLiftData core B primeData)) := by
-  let monicCore := (Hex.MonicisedCoreData.ofCore core).monicCore
+      (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData)) := by
+  let monicCore := (Hex.ZPoly.toMonic core).monic
   have hmonicCore_monic :
       Hex.DensePoly.Monic monicCore := by
     dsimp [monicCore]
-    exact Hex.MonicisedCoreData.monicCore_monic_of_pos_degree
+    exact Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree
       core hcore_lc_pos hcore_pos
   have hform : Hex.factorsModPBerlekampForm monicCore primeData := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_factorsModP_berlekamp_form
+    exact Hex.ZPoly.toMonicPrimeData?_factorsModP_berlekamp_form
       core primeData hselected
   have hgood :
       letI := primeData.bounds
       Hex.isGoodPrime monicCore primeData.p = true := by
     dsimp [monicCore]
-    exact Hex.monicisedCorePrimeData?_isGoodPrime core primeData hselected
+    exact Hex.ZPoly.toMonicPrimeData?_isGoodPrime core primeData hselected
   have hp_prime : Hex.Nat.Prime primeData.p :=
-    Hex.monicisedCorePrimeData?_prime core primeData hselected
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
   have hp : 1 < primeData.p := by
     have := hp_prime.two_le
     omega
@@ -7047,7 +7048,7 @@ theorem monicisedCoreLiftData_liftedFactor_injective_of_monicPrimeData
       hproduct_mod_p hcoprime hnonempty
   have hfactorsModP_nodup : primeData.factorsModP.toList.Nodup :=
     factorsModP_nodup_of_factorsModPBerlekampForm monicCore primeData hform hgood
-  exact monicisedCoreLiftData_liftedFactor_injective
+  exact Hex.ZPoly.toMonicLiftData_liftedFactor_injective
     core B primeData hmonicCore_monic hinv hp hprecision
     hfactors_monic hproduct_mod_p hfactorsModP_nodup
 
@@ -9537,7 +9538,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
     (hB : B ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
     (hd :
-      d = Hex.monicisedCoreLiftData core B primeData)
+      d = Hex.ZPoly.toMonicLiftData core B primeData)
     (hsearch :
       Hex.recombinationSearchMod core (d.p ^ d.k)
         d.liftedFactors.toList = some factors)
@@ -9547,12 +9548,12 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_some
   have hlc : Hex.DensePoly.leadingCoeff core = 1 := hcore_monic
   have hrecombine :
       Hex.recombineExhaustive core
-          (Hex.monicisedCoreLiftData core B primeData) =
+          (Hex.ZPoly.toMonicLiftData core B primeData) =
         factors.toArray :=
     Hex.recombineExhaustive_eq_of_recombinationSearchMod_some hsearch
   have hscaled :
       Hex.recombineScaledExhaustive (Hex.DensePoly.leadingCoeff core) core
-          (Hex.monicisedCoreLiftData core B primeData) =
+          (Hex.ZPoly.toMonicLiftData core B primeData) =
         factors.toArray := by
     rw [hlc, Hex.recombineScaledExhaustive_eq_recombineExhaustive_of_one]
     exact hrecombine
@@ -9577,7 +9578,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some
     {core factor : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {d : Hex.LiftData} {factors : List Hex.ZPoly}
     (hB : B ≠ 0)
-    (hd : d = Hex.monicisedCoreLiftData core B primeData)
+    (hd : d = Hex.ZPoly.toMonicLiftData core B primeData)
     (hsearch :
       Hex.scaledRecombinationSearchMod (Hex.DensePoly.leadingCoeff core)
           core (d.p ^ d.k) d.liftedFactors.toList =
@@ -9587,7 +9588,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_scaledRecombinationSearchMod_some
   subst d
   have hrecombine :
       Hex.recombineScaledExhaustive (Hex.DensePoly.leadingCoeff core) core
-          (Hex.monicisedCoreLiftData core B primeData) =
+          (Hex.ZPoly.toMonicLiftData core B primeData) =
         factors.toArray :=
     Hex.recombineScaledExhaustive_eq_of_scaledRecombinationSearchMod_some hsearch
   have hnot_empty : factors.toArray.isEmpty = false := by
@@ -9611,7 +9612,7 @@ theorem exhaustiveCoreFactorsWithBound_mem_of_recombinationSearchMod_first_succe
     {pre suffix : List (List Hex.ZPoly × List Hex.ZPoly)}
     (hB : B ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
-    (hd : d = Hex.monicisedCoreLiftData core B primeData)
+    (hd : d = Hex.ZPoly.toMonicLiftData core B primeData)
     (hcore_ne_one : core ≠ 1)
     (hsplits :
       Hex.subsetSplitsWithFirst d.liftedFactors.toList =
@@ -16307,7 +16308,7 @@ useful API for the HO-1 assembly. -/
 private theorem henselSubsetCorrespondence_analytic_obligation
     (core : Hex.ZPoly) (B : Nat) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     ∀ {factor : Hex.ZPoly},
       Irreducible (HexPolyZMathlib.toPolynomial factor) →
       factor ∣ core →
@@ -16325,7 +16326,7 @@ fallback is acceptable here. -/
 theorem henselSubsetCorrespondenceHypotheses_of_choosePrimeData
     (core : Hex.ZPoly) (B : Nat) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetCorrespondenceHypotheses core B primeData d True True := by
   intro primeData d
   refine
@@ -16356,7 +16357,7 @@ theorem henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let primeData := Hex.choosePrimeData core
     let B := Hex.ZPoly.defaultFactorCoeffBound f
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetCorrespondenceHypotheses core B primeData d True True :=
   henselSubsetCorrespondenceHypotheses_of_choosePrimeData _ _
 
@@ -16401,7 +16402,7 @@ genuinely analytic in the same sense as `cover` and bundled here. -/
 private theorem liftedFactorSubsetPartition_analytic_obligation
     (core : Hex.ZPoly) (B : Nat) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     (∀ {i : LiftedFactorIndex d},
         i ∈ (Finset.univ : LiftedFactorSubset d) →
           ∃ (f : Hex.ZPoly) (S : LiftedFactorSubset d),
@@ -16478,7 +16479,7 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
     (core : Hex.ZPoly) (B : Nat)
     (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core)) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core := by
   intro primeData d
   obtain ⟨hcover, hdisj, huniq, hsup, hscaled_sup⟩ :=
@@ -16885,7 +16886,7 @@ theorem modPSubsetPartitionHypotheses_of_choosePrimeData
     exact (huniq S hS).trans (huniq T hT).symm
 
 /--
-Non-circular `choosePrimeData`/`monicisedCoreLiftData` constructor for
+Non-circular `choosePrimeData`/`Hex.ZPoly.toMonicLiftData` constructor for
 `HenselSubsetLiftHypotheses`.
 
 Unlike `henselSubsetLiftHypotheses_of_choosePrimeData_henselLiftData`, this
@@ -16896,19 +16897,19 @@ theorem henselSubsetLiftHypotheses_of_choosePrimeData_henselLiftData_descent
     (core : Hex.ZPoly) (B : Nat)
     (hdescent :
       HenselLiftDescentHypotheses core B (Hex.choosePrimeData core)
-        (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) True True)
+        (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) True True)
     (hlifted_of_modP :
       ∀ {factor : Hex.ZPoly} {S : ModPFactorSubset (Hex.choosePrimeData core)},
         Irreducible (HexPolyZMathlib.toPolynomial factor) →
         factor ∣ core →
         RepresentsIntegerFactorModP (Hex.choosePrimeData core) factor S →
         RepresentsIntegerFactorAtLift core
-          (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) factor
+          (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) factor
           (liftedSubsetOfModPSubset (Hex.choosePrimeData core)
-            (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core))
+            (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core))
             hdescent.factor_count_eq S)) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetLiftHypotheses core B primeData d True True True True := by
   intro primeData d
   exact
@@ -16946,25 +16947,25 @@ theorem henselSubsetLiftHypotheses_of_choosePrimeData_henselLiftData
       ModPSubsetPartitionHypotheses core (Hex.choosePrimeData core) True True)
     (hcorr :
       HenselSubsetCorrespondenceHypotheses core B (Hex.choosePrimeData core)
-        (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) True True)
+        (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) True True)
     (hlifted_of_modP :
       ∀ {factor : Hex.ZPoly} {S : ModPFactorSubset (Hex.choosePrimeData core)},
         Irreducible (HexPolyZMathlib.toPolynomial factor) →
         factor ∣ core →
         RepresentsIntegerFactorModP (Hex.choosePrimeData core) factor S →
         RepresentsIntegerFactorAtLift core
-          (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) factor
+          (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) factor
           (liftedSubsetOfModPSubset (Hex.choosePrimeData core)
-            (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core))
-            (monicisedCoreLiftData_liftedFactors_size_eq core B (Hex.choosePrimeData core))
+            (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core))
+            (Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B (Hex.choosePrimeData core))
             S)) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetLiftHypotheses core B primeData d True True True True := by
   intro primeData d
   refine
     { lift_eq := rfl
-      factor_count_eq := monicisedCoreLiftData_liftedFactors_size_eq core B primeData
+      factor_count_eq := Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B primeData
       admissible_prime := trivial
       square_free_reduction := trivial
       successful_lift := trivial
@@ -16975,7 +16976,7 @@ theorem henselSubsetLiftHypotheses_of_choosePrimeData_henselLiftData
     exact hlifted_of_modP hirr hdvd hrep
   · intro factor T hirr hdvd hT
     exact henselLiftData_represents_modP_of_lifted hmod hcorr
-      (monicisedCoreLiftData_liftedFactors_size_eq core B primeData)
+      (Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B primeData)
       hlifted_of_modP hirr hdvd hT
 
 /-- **#5689 substrate (HO-1 successful branch).**
@@ -16993,10 +16994,10 @@ theorem henselSubsetCorrespondenceHypotheses_of_choosePrimeData_success
     (hsome : Hex.choosePrimeData? core = some (Hex.choosePrimeData core))
     (hlift :
       HenselSubsetLiftHypotheses core B (Hex.choosePrimeData core)
-        (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core))
+        (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core))
         True True True True) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetCorrespondenceHypotheses core B primeData d True True := by
   intro primeData d
   exact
@@ -17015,19 +17016,19 @@ theorem henselSubsetCorrespondenceHypotheses_of_choosePrimeData_success_descent
     (hsome : Hex.choosePrimeData? core = some (Hex.choosePrimeData core))
     (hdescent :
       HenselLiftDescentHypotheses core B (Hex.choosePrimeData core)
-        (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) True True)
+        (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) True True)
     (hlifted_of_modP :
       ∀ {factor : Hex.ZPoly} {S : ModPFactorSubset (Hex.choosePrimeData core)},
         Irreducible (HexPolyZMathlib.toPolynomial factor) →
         factor ∣ core →
         RepresentsIntegerFactorModP (Hex.choosePrimeData core) factor S →
         RepresentsIntegerFactorAtLift core
-          (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core)) factor
+          (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core)) factor
           (liftedSubsetOfModPSubset (Hex.choosePrimeData core)
-            (Hex.monicisedCoreLiftData core B (Hex.choosePrimeData core))
+            (Hex.ZPoly.toMonicLiftData core B (Hex.choosePrimeData core))
             hdescent.factor_count_eq S)) :
     let primeData := Hex.choosePrimeData core
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     HenselSubsetCorrespondenceHypotheses core B primeData d True True := by
   intro primeData d
   exact

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2641,7 +2641,7 @@ theorem liftedFactorSubsetPartition_outerBound_of_choosePrimeData
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let primeData := Hex.choosePrimeData core
     let B := Hex.ZPoly.defaultFactorCoeffBound f
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core :=
   liftedFactorSubsetPartition_of_choosePrimeData _ _
     (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_squarefree f hf)
@@ -3182,8 +3182,8 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
     factorsModP_coprime_of_factorsModPBerlekampForm _ _ hform hgood
   have hnonempty :=
     factorsModP_ne_nil_of_factorsModPBerlekampForm _ _ hform
-  have hmonicised_eq :
-      Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+  have htoMonicLift_eq :
+      Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore) =
         Hex.henselLiftData (Hex.normalizeForFactor f).squareFreeCore
@@ -3191,11 +3191,11 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore) := by
-    unfold Hex.monicisedCoreLiftData
-    rw [Hex.MonicisedCoreData.monicCore_eq_core_of_leadingCoeff_eq_one _ hcore_monic]
+    unfold Hex.ZPoly.toMonicLiftData
+    rw [Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one _ hcore_monic]
   -- Lifted-factor monicness / natDegree positivity / injectivity transported
-  -- through the monicised lift. Under the current `hcore_monic` residual,
-  -- the monicising transform is the identity.
+  -- through the `toMonic` lift. Under the current `hcore_monic` residual,
+  -- the monic-scaling transform is the identity.
   have hd_liftedFactor_monic_old := fun i =>
     henselLiftData_liftedFactor_monic_of_choosePrimeData
       (Hex.normalizeForFactor f).squareFreeCore _ _
@@ -3215,35 +3215,35 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
       hfactors_monic hproduct_mod_p hcoprime hnonempty hform hgood
   have hd_liftedFactor_monic :
       ∀ i : LiftedFactorIndex
-        (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)),
         Hex.DensePoly.Monic
           (liftedFactor
-            (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
               (Hex.ZPoly.defaultFactorCoeffBound f)
               (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) i) := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_monic_old
   have hd_liftedFactor_natDegree_pos :
       ∀ i : LiftedFactorIndex
-        (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)),
         0 < (HexPolyZMathlib.toPolynomial
           (liftedFactor
-            (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
               (Hex.ZPoly.defaultFactorCoeffBound f)
               (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) i)).natDegree := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_natDegree_pos_old
   have hd_liftedFactor_inj :
       Function.Injective
         (liftedFactor
-          (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))) := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_inj_old
   -- Discharge `hcore_record` from positive squareFreeCore degree.
   have hcore_record : Hex.shouldRecordPolynomialFactor
@@ -3329,7 +3329,7 @@ genuine gaps in the discharger stack at the time of landing:
   coefficient via `squareFreeCore_leadingCoeff_pos_of_ne_zero` but the
   leading coefficient can exceed `1`). Removable when the wrapper's
   `Monic core` premise is relaxed to `Primitive + 0 < leadingCoeff` (or when
-  an internal monicising-by-scaling refactor lands).
+  an internal monic-scaling refactor lands).
 * **Gap 2** — `hcomplete`: no
   `reassemblyExpansionComplete_exhaustive_of_ne_zero` discharger exists
   analogous to `reassemblyExpansionComplete_constant_of_ne_zero` (#4585 /
@@ -3390,7 +3390,7 @@ sibling at the present API surface. Removal of Gap 1 from this umbrella
 requires a directive-level architectural decision per #4880
 (Option A — consumer-side recombination invariant co-redesign across
 the `_of_primitive_pos_lc_core` chain; Option B — executable-side
-monicising-by-scaling refactor of `exhaustiveCoreFactorsWithBound`
+monic-scaling refactor of `exhaustiveCoreFactorsWithBound`
 or a `henselLiftData_scaled` variant).
 
 Thin wrapper over
@@ -3541,8 +3541,8 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
     factorsModP_coprime_of_factorsModPBerlekampForm _ _ hform hgood
   have hnonempty :=
     factorsModP_ne_nil_of_factorsModPBerlekampForm _ _ hform
-  have hmonicised_eq :
-      Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+  have htoMonicLift_eq :
+      Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore) =
         Hex.henselLiftData (Hex.normalizeForFactor f).squareFreeCore
@@ -3550,8 +3550,8 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore).p)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore) := by
-    unfold Hex.monicisedCoreLiftData
-    rw [Hex.MonicisedCoreData.monicCore_eq_core_of_leadingCoeff_eq_one _ hcore_monic]
+    unfold Hex.ZPoly.toMonicLiftData
+    rw [Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one _ hcore_monic]
   have hd_liftedFactor_monic_old := fun i =>
     henselLiftData_liftedFactor_monic_of_choosePrimeData
       (Hex.normalizeForFactor f).squareFreeCore _ _
@@ -3571,35 +3571,35 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
       hfactors_monic hproduct_mod_p hcoprime hnonempty hform hgood
   have hd_liftedFactor_monic :
       ∀ i : LiftedFactorIndex
-        (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)),
         Hex.DensePoly.Monic
           (liftedFactor
-            (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
               (Hex.ZPoly.defaultFactorCoeffBound f)
               (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) i) := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_monic_old
   have hd_liftedFactor_natDegree_pos :
       ∀ i : LiftedFactorIndex
-        (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)),
         0 < (HexPolyZMathlib.toPolynomial
           (liftedFactor
-            (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
               (Hex.ZPoly.defaultFactorCoeffBound f)
               (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) i)).natDegree := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_natDegree_pos_old
   have hd_liftedFactor_inj :
       Function.Injective
         (liftedFactor
-          (Hex.monicisedCoreLiftData (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore))) := by
-    rw [hmonicised_eq]
+    rw [htoMonicLift_eq]
     exact hd_liftedFactor_inj_old
   have hcore_record : Hex.shouldRecordPolynomialFactor
       (Hex.normalizeForFactor f).squareFreeCore = true := by
@@ -3738,38 +3738,37 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
     hprecision
 
 /--
-Transport package for the monicised-core exhaustive path.
+Correspondence package between the `toMonic` lift of `core` and the
+factorization data of the original primitive positive-leading `core`.
 
-This is the consumer-facing bundle for the Option-B Gap-1 route: the Hensel
-lift is built from `(Hex.MonicisedCoreData.ofCore core).monicCore`, while the
+The Hensel lift is built from `(Hex.ZPoly.toMonic core).monic`, while the
 factor correspondence, scaled recovery theorem, and exhaustive-wrapper
-membership statement remain phrased over the original primitive
-positive-leading `core`.
+membership statement remain phrased over the original `core`.
 -/
-structure MonicisedCoreTransportPackage
+structure MonicReductionCorrespondence
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (d : Hex.LiftData) : Prop where
-  lift_eq : d = Hex.monicisedCoreLiftData core B primeData
+  lift_eq : d = Hex.ZPoly.toMonicLiftData core B primeData
   core_ne : core ≠ 0
   core_primitive : Hex.ZPoly.Primitive core
   core_lc_pos : 0 < Hex.DensePoly.leadingCoeff core
-  monicCore_monic :
-    Hex.DensePoly.Monic (Hex.MonicisedCoreData.ofCore core).monicCore
-  monicCore_nonzero :
-    (Hex.MonicisedCoreData.ofCore core).monicCore ≠ 0
-  monicCore_degree_eq :
-    (Hex.MonicisedCoreData.ofCore core).monicCore.degree?.getD 0 =
+  monic_isMonic :
+    Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic
+  monic_nonzero :
+    (Hex.ZPoly.toMonic core).monic ≠ 0
+  monic_degree_eq :
+    (Hex.ZPoly.toMonic core).monic.degree?.getD 0 =
       core.degree?.getD 0
   liftedFactor_monic_of_monicPrimeData :
-    Hex.monicisedCorePrimeData? core = some primeData →
+    Hex.ZPoly.toMonicPrimeData? core = some primeData →
       ∀ i : LiftedFactorIndex d,
         Hex.DensePoly.Monic (liftedFactor d i)
   liftedFactor_natDegree_pos_of_monicPrimeData :
-    Hex.monicisedCorePrimeData? core = some primeData →
+    Hex.ZPoly.toMonicPrimeData? core = some primeData →
       ∀ i : LiftedFactorIndex d,
         0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree
   liftedFactor_injective_of_monicPrimeData :
-    Hex.monicisedCorePrimeData? core = some primeData →
+    Hex.ZPoly.toMonicPrimeData? core = some primeData →
       Function.Injective (liftedFactor d)
   correspondence :
     HenselSubsetCorrespondenceHypotheses core B primeData d True True
@@ -3792,17 +3791,17 @@ structure MonicisedCoreTransportPackage
       factor ∈ (Hex.exhaustiveCoreFactorsWithBound core B primeData).toList
 
 /--
-Specialised monicised-core transport package for the normalized square-free
+Specialised monic-reduction correspondence for the normalized square-free
 core used by the exhaustive branch of `factorWithBound`.
 -/
-theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
+theorem monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (hdegree : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0) :
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let primeData := Hex.choosePrimeData core
     let B := Hex.ZPoly.defaultFactorCoeffBound f
-    let d := Hex.monicisedCoreLiftData core B primeData
-    MonicisedCoreTransportPackage core B primeData d := by
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
+    MonicReductionCorrespondence core B primeData d := by
   intro core primeData B d
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core := by
     simpa [core] using Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
@@ -3810,15 +3809,15 @@ theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
   have hcore_primitive : Hex.ZPoly.Primitive core := by
     simpa [core] using
       IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
-  have hmonicCore_monic :
-      Hex.DensePoly.Monic (Hex.MonicisedCoreData.ofCore core).monicCore :=
-    Hex.MonicisedCoreData.monicCore_monic_of_pos_degree core hcore_lc_pos
+  have hmonic_isMonic :
+      Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
+    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos
       (by simpa [core] using hdegree)
-  have hmonicCore_degree :
-      (Hex.MonicisedCoreData.ofCore core).monicCore.degree?.getD 0 =
+  have hmonic_degree :
+      (Hex.ZPoly.toMonic core).monic.degree?.getD 0 =
         core.degree?.getD 0 := by
-    simpa [Hex.MonicisedCoreData.ofCore_degree] using
-      Hex.MonicisedCoreData.monicCore_degree_eq_of_pos_degree core hcore_lc_pos
+    simpa [Hex.ZPoly.toMonic_degree] using
+      Hex.ZPoly.toMonic_monic_degree_eq_of_pos_degree core hcore_lc_pos
         (by simpa [core] using hdegree)
   have hsqfree :
       Squarefree (HexPolyZMathlib.toPolynomial core) := by
@@ -3827,11 +3826,11 @@ theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
   have hbound_pos : 0 < B := by
     simpa [B] using Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hf_ne
   have hprecision_of_monicPrimeData :
-      ∀ hselected : Hex.monicisedCorePrimeData? core = some primeData,
+      ∀ hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData,
         1 ≤ Hex.precisionForCoeffBound B primeData.p := by
     intro hselected
     have hp_prime : Hex.Nat.Prime primeData.p :=
-      Hex.monicisedCorePrimeData?_prime core primeData hselected
+      Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
     have hspec :
         2 * B < primeData.p ^ Hex.precisionForCoeffBound B primeData.p :=
       Hex.precisionForCoeffBound_spec hp_prime.two_le B
@@ -3846,9 +3845,9 @@ theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
       core_ne := hcore_ne
       core_primitive := hcore_primitive
       core_lc_pos := hcore_lc_pos
-      monicCore_monic := hmonicCore_monic
-      monicCore_nonzero := zpoly_ne_zero_of_monic hmonicCore_monic
-      monicCore_degree_eq := hmonicCore_degree
+      monic_isMonic := hmonic_isMonic
+      monic_nonzero := zpoly_ne_zero_of_monic hmonic_isMonic
+      monic_degree_eq := hmonic_degree
       liftedFactor_monic_of_monicPrimeData := ?_
       liftedFactor_natDegree_pos_of_monicPrimeData := ?_
       liftedFactor_injective_of_monicPrimeData := ?_
@@ -3857,15 +3856,15 @@ theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
       scaled_recovery_of_bound := ?_
       exhaustive_mem_of_scaled_search := ?_ }
   · intro hselected
-    exact monicisedCoreLiftData_liftedFactor_monic_of_monicPrimeData
+    exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
       core B primeData hcore_lc_pos (by simpa [core] using hdegree)
       hselected (hprecision_of_monicPrimeData hselected)
   · intro hselected
-    exact monicisedCoreLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
+    exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
       core B primeData hcore_lc_pos (by simpa [core] using hdegree)
       hselected (hprecision_of_monicPrimeData hselected)
   · intro hselected
-    exact monicisedCoreLiftData_liftedFactor_injective_of_monicPrimeData
+    exact Hex.ZPoly.toMonicLiftData_liftedFactor_injective_of_monicPrimeData
       core B primeData hcore_lc_pos (by simpa [core] using hdegree)
       hselected (hprecision_of_monicPrimeData hselected)
   · exact henselSubsetCorrespondenceHypotheses_of_choosePrimeData core B
@@ -3879,22 +3878,22 @@ theorem monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
       hB_ne rfl hsearch hmem
 
 /--
-Consumer-facing extraction of the monicised-core lifted-factor facts for the
+Consumer-facing extraction of the `toMonic` lifted-factor facts for the
 normalized square-free core.  The hypotheses are the non-monic branch facts:
 positive leading coefficient comes from `f ≠ 0`, positive degree is supplied by
 the caller, and the Hensel modular data is aligned through
-`Hex.monicisedCorePrimeData?`, not by rewriting the core to be monic.
+`Hex.ZPoly.toMonicPrimeData?`, not by rewriting the core to be monic.
 -/
-theorem monicisedCoreTransportPackage_liftedFactor_facts_of_normalizeForFactor_squareFreeCore
+theorem monicReductionCorrespondence_liftedFactor_facts_of_normalizeForFactor_squareFreeCore
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (hdegree : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0)
     (hselected :
-      Hex.monicisedCorePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+      Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore =
         some (Hex.choosePrimeData (Hex.normalizeForFactor f).squareFreeCore)) :
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let primeData := Hex.choosePrimeData core
     let B := Hex.ZPoly.defaultFactorCoeffBound f
-    let d := Hex.monicisedCoreLiftData core B primeData
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
     (∀ i : LiftedFactorIndex d,
       Hex.DensePoly.Monic (liftedFactor d i)) ∧
     (∀ i : LiftedFactorIndex d,
@@ -3902,7 +3901,7 @@ theorem monicisedCoreTransportPackage_liftedFactor_facts_of_normalizeForFactor_s
     Function.Injective (liftedFactor d) := by
   intro core primeData B d
   have pkg :=
-    monicisedCoreTransportPackage_of_normalizeForFactor_squareFreeCore
+    monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore
       f hf_ne hdegree
   exact
     ⟨pkg.liftedFactor_monic_of_monicPrimeData hselected,

--- a/progress/20260530T105008Z_a3c45923.md
+++ b/progress/20260530T105008Z_a3c45923.md
@@ -1,0 +1,56 @@
+# 20260530T105008Z — issue #5769 (a3c45923)
+
+## Accomplished
+
+Pure rename across `HexBerlekampZassenhaus/Basic.lean`,
+`HexBerlekampZassenhausMathlib/Basic.lean`, and
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+
+- `Hex.MonicisedCoreData` → `Hex.ZPoly.ToMonicData`; field
+  `monicCore` → `monic`; `core`/`leadingCoeff`/`degree` retained.
+- Constructor `MonicisedCoreData.ofCore` → `ZPoly.toMonic`; companion
+  lemmas (`ofCore_core`, `ofCore_leadingCoeff`, `ofCore_degree`,
+  `monicCore_monic_of_pos_degree`, `monicCore_degree_eq_of_pos_degree`,
+  `monicCore_eq_core_of_leadingCoeff_eq_one`) moved into `ZPoly` as
+  `toMonic_core`, `toMonic_leadingCoeff`, `toMonic_degree`,
+  `toMonic_monic_isMonic_of_pos_degree`,
+  `toMonic_monic_degree_eq_of_pos_degree`,
+  `toMonic_monic_eq_core_of_leadingCoeff_eq_one`.
+- `monicisedCoreLiftData`, `monicisedCoreLiftDataWithMonicPrime`,
+  `monicisedCorePrimeData?` / `monicisedCorePrimeData` and their
+  three `_prime` / `_isGoodPrime` / `_factorsModP_berlekamp_form`
+  theorems renamed to `Hex.ZPoly.toMonic…` equivalents.
+- `monicisedCoreLiftData_liftedFactors_size_eq`,
+  `monicisedCoreLiftData_liftedFactor_monic`,
+  `_natDegree_pos`, `_injective`, plus the three `_of_monicPrimeData`
+  wrappers, renamed and re-namespaced under `Hex.ZPoly` (defined via
+  fully-qualified `theorem Hex.ZPoly.toMonicLiftData_…` headings inside
+  the existing `HexBerlekampZassenhausMathlib` module).
+- `MonicisedCoreTransportPackage` → `MonicReductionCorrespondence`;
+  the three `monicCore_*` fields renamed to `monic_isMonic`,
+  `monic_nonzero`, `monic_degree_eq`; the two outer theorems renamed
+  to `monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore`
+  and `monicReductionCorrespondence_liftedFactor_facts_of_normalizeForFactor_squareFreeCore`.
+- Local hypothesis `hmonicised_eq` → `htoMonicLift_eq`; docstrings and
+  comments reworded to drop `monicised`/`monicising` prose.
+
+Verification:
+
+- `lake build HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  succeeds (only pre-existing `sorry` and unrelated linter warnings).
+- `python3 scripts/check_dag.py` exits 0.
+- `rg -n 'monicis' HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  returns nothing.
+
+## Current frontier
+
+Issue #5769 deliverables complete; PR pending.
+
+## Next step
+
+`coordination create-pr 5769` to publish the rename and close the
+directive.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5769

Session: `a3c45923-e0e5-4b50-8cc6-6a2902a817e6`

88650a5f refactor: rename monicised-core vocabulary to ZPoly.toMonic (#5769)

🤖 Prepared with Claude Code