### PR TITLE
spec: bench-timed-region profile filtering amendment

### DIFF
--- a/SPEC/profiling.md
+++ b/SPEC/profiling.md
@@ -55,6 +55,15 @@ headline report ([benchmarking.md §Headline reports](benchmarking.md#headline-r
 records only an analytical summary; raw `*.json.gz` artefacts are
 not committed.
 
+Sample data presented to the report's author is automatically
+filtered by `lake exe foo_bench profile` to retain only samples
+from the bench thread during the bench library's timed regions —
+the same monotonic-clock boundaries that define the bench
+verdict's timing. Prep, autotune overhead between probes, result
+hashing, and process exit are excluded by construction. The
+filtering postprocessor emits a diagnostics block per run; see
+[§Required output](#required-output).
+
 ## Coverage requirement
 
 Profile **at least one representative case per
@@ -108,6 +117,16 @@ records:
   [benchmarking.md §Attribution rule](benchmarking.md#the-attribution-rule)
   and the §Concerns subsection links it.
 
+- **Diagnostics block** quoted from the filtering postprocessor:
+  calibration residual, total timed duration, retained sample
+  count, and sensitivity-check verdict. A profile the
+  postprocessor flags as low-confidence (residual above the
+  configured threshold, retained samples below the configured
+  minimum, or the sensitivity check disagreeing on the top
+  frames) does not satisfy the Phase-4 deliverable; the case must
+  be re-run with a larger per-probe duration or the profile
+  replaced with one that does pass.
+
 ## Reproducibility
 
 The headline report's §Profile subsection records, for each
@@ -118,7 +137,10 @@ profiled case:
 - sampling rate (Hz);
 - input family name and parameter (e.g. `random-bounded`, `n=160`);
 - seed, where the input is randomised;
-- exact command line invoked.
+- exact command line invoked;
+- lean-bench version (the postprocessor's filtering logic is
+  version-specific);
+- samply version (sample timestamp format depends on it).
 
 The raw `*.json.gz` artefact's developer-local path may be
 recorded for reference but is not committed.

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -15,7 +15,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "8e6cd425b196f14452a9dfd66dc9f3d2ab57753e",
+   "rev": "91412dba8350c29ddf52c9ace56f8a3d2240b6c7",
    "name": "«lean-bench»",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",

--- a/scripts/profile/run_profile.sh
+++ b/scripts/profile/run_profile.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/profile/run_profile.sh — profile a hex bench target under
+# samply, filtered to the bench library's timed regions.
+#
+# This is a thin wrapper around the lean-bench-samply orchestrator
+# (https://github.com/kim-em/lean-bench-samply). It assumes:
+#
+#   - lean-bench-samply is checked out at $LEAN_BENCH_SAMPLY_HOME,
+#     or at the default location ~/projects/lean-bench-samply.
+#   - samply >= 0.13.1 is on PATH, and on macOS `samply setup` has
+#     been run once to codesign the binary (see SPEC/profiling.md).
+#   - The bench exe was built against a lean-bench version that
+#     includes the `LeanBench.TimedRegions` module (the env-var
+#     handshake the postprocessor depends on).
+#
+# Usage:
+#   scripts/profile/run_profile.sh BENCH_EXE BENCH_NAME [PARAM [TARGET_NANOS]]
+#
+# Example:
+#   scripts/profile/run_profile.sh \
+#       .lake/build/bin/hexlll_bench \
+#       Hex.LLLBench.runFirstShortVectorRandomBoundedChecksum \
+#       120 5000000000
+#
+# Writes the filtered profile to:
+#   /tmp/hex-profile-<bench-name>-<param>.json.gz
+# and prints a diagnostics block (retained sample count,
+# off-thread noise, calibration anchors). Load the resulting
+# *.json.gz in the Firefox Profiler at https://profiler.firefox.com,
+# or feed it to _scratch/profile_categories.py for a leaf-cost
+# categorisation.
+set -euo pipefail
+
+BENCH_EXE="${1:?usage: run_profile.sh BENCH_EXE BENCH_NAME [PARAM [TARGET_NANOS]]}"
+BENCH_NAME="${2:?usage: run_profile.sh BENCH_EXE BENCH_NAME [PARAM [TARGET_NANOS]]}"
+PARAM="${3:-0}"
+TARGET_NANOS="${4:-1000000000}"
+
+LEAN_BENCH_SAMPLY_HOME="${LEAN_BENCH_SAMPLY_HOME:-$HOME/projects/lean-bench-samply}"
+ORCHESTRATOR="$LEAN_BENCH_SAMPLY_HOME/scripts/profile_bench.py"
+
+if [[ ! -f "$ORCHESTRATOR" ]]; then
+  echo "error: lean-bench-samply orchestrator not found at $ORCHESTRATOR" >&2
+  echo "       set LEAN_BENCH_SAMPLY_HOME or clone https://github.com/kim-em/lean-bench-samply" >&2
+  exit 1
+fi
+
+SHORT_NAME="${BENCH_NAME##*.}"
+OUT="/tmp/hex-profile-${SHORT_NAME}-${PARAM}.json.gz"
+
+exec python3 "$ORCHESTRATOR" \
+  --bench-exe "$BENCH_EXE" \
+  --bench-name "$BENCH_NAME" \
+  --param "$PARAM" \
+  --target-nanos "$TARGET_NANOS" \
+  --out "$OUT" \
+  --samply-args "--rate 999 --unstable-presymbolicate"


### PR DESCRIPTION
This PR amends the Phase-4 profiling doctrine so that profile data
presented to the report's author and to the dominant-cost
narrative is structurally restricted to samples taken inside the
bench library's *timed* regions on the *bench* thread. Prep,
autotune overhead between probes, result hashing, and process
exit are excluded by construction. The misleading-attribution
failure mode that produced "43% in `lcgStep`/`lcgIterate`" on the
last recorded HexLLL `random-bounded` profile is closed at the
SPEC level, and a real hot-spot (the `Hex.LLLState.setEntry` COW
pattern at ~6% of bench-thread self time) becomes visible.

## SPEC clauses (three small additions, no new vocabulary)

1. §Tooling — the harness post-filters samply samples to the
   bench thread's samples during the bench library's timed
   regions, using the same monotonic-clock boundaries the bench
   verdict already uses.
2. §Required output — the report's §Profile narrative must quote
   the postprocessor's diagnostics summary; a profile flagged
   low-confidence by the postprocessor does not satisfy the
   Phase-4 deliverable.
3. §Reproducibility — lean-bench and samply versions are recorded
   alongside the existing reproducibility metadata.

The Attribution rule
([SPEC/benchmarking.md](SPEC/benchmarking.md)) stays as-is: it
continues to fire on any dominant cost not attributable to a
registered bench target. The amendment just narrows the input
that "dominant cost" is computed from.

## Implementation

The filtering pipeline is two upstream packages this PR depends
on:

- **lean-bench** PR
  [#63](https://github.com/kim-em/lean-bench/pull/63) — merged at
  `91412db`. Adds a profiler-agnostic
  `LeanBench/TimedRegions.lean` module that emits a sidecar JSONL
  with monotonic-clock anchors per autotune probe when the env
  var `LEAN_BENCH_TIMED_REGIONS_SIDECAR` is set. This PR's
  `lake-manifest.json` bump consumes the new version.
- **lean-bench-samply** at
  https://github.com/kim-em/lean-bench-samply — a samply-specific
  orchestrator + Python postprocessor that pairs the sidecar with
  samply's profile JSON and produces a filtered JSON. Identifies
  the bench thread by samples-in-region dominance, drops
  non-bench threads, and emits a diagnostics block.

This PR adds a thin shell wrapper at
[scripts/profile/run_profile.sh](scripts/profile/run_profile.sh)
that invokes the lean-bench-samply orchestrator with the right
defaults for hex bench exes.

## Verified end-to-end on HexLLL random-bounded n=120

The lean-bench-samply orchestrator was run end-to-end against
this hex's `hexlll_bench`
`Hex.LLLBench.runFirstShortVectorRandomBoundedChecksum` at param
120, target-nanos 5 000 000 000, with the new lean-bench pin:

```
=== lean-bench-samply filter diagnostics ===
bench thread:       name='Thread <…>' tid=…
regions:            2, total timed = 4973.4 ms
expected samples:   ~4968 on bench thread
retained samples:   4969 on bench thread (129 rejected outside windows)
other-thread noise: 2 samples on non-bench threads within timed windows
```

Filtered profile leaf-cost categorisation:

- allocator 37.1% (`_nanov2_free` 12.5%)
- GMP big-int 33.4% (`__gmpn_addmul_1` 7.8%, `__gmpn_submul_1` 7.5%)
- Lean refcount/box 19.9%
  (`lean_dec_ref_cold` 8.8%, **`lean_copy_expand_array` 6.3%** — the COW finding)
- Hex.LLL 1.5%, Hex.Matrix/Array 0.8%, Hex.GramSchmidt 0.5%

The 6.3% `lean_copy_expand_array` cost is the finding that was
buried under the 43% LCG-prep noise in the last recorded
unfiltered random-bounded profile. The Attribution rule will fire
on it correctly under the amended doctrine.

## Companion regeneration

Each library at `done_through ≥ 4` has a
`reports/<lib>-performance.md §Profile` section captured under
the old wrap-whole-child mechanism; these are now superseded but
not blocking. A follow-up handoff issue will dispatch
regeneration per library; the existing profile sections stay in
place until each HO lands and the report author confirms the new
profile is well-formed.

🤖 Prepared with Claude Code