### PR TITLE
feat: wire precision-local Isabelle ratio surface as ninth BZ comparator pairing

### DIFF
--- a/HexBerlekampZassenhaus/Bench.lean
+++ b/HexBerlekampZassenhaus/Bench.lean
@@ -106,6 +106,14 @@ Gating external comparator:
   verified-Isabelle pairs for the cascade-trigger fallback-probe schedule. The
   `expectedHash` field is `none` on these registrations to keep elaboration off
   the cascade-affected Lean `factor` call path; see the per-`def` doc comment.
+* `runIsabellePrecisionLocalRung{1..6}Checksum`: per-rung verified-Isabelle
+  pairs for the precision/local-factor schedule. The Lean target measures
+  fast-path setup (multifactor lifting + modular split profile) rather than
+  full factorisation, so the resulting `Lean_setup / Isabelle_full` ratio is
+  asymmetric and reported as a lower bound on the implied full-factor ratio;
+  see the per-`def` doc comment and
+  `reports/hex-berlekamp-zassenhaus-performance.md` §"Precision-local
+  asymmetric ratio ladder".
 -/
 
 namespace Hex
@@ -780,6 +788,59 @@ def runIsabelleFallbackProbeN24Checksum : Unit → IO UInt64 := fun _ => do
   let (scalar, factors) ← requestIsabelleBZFactorization (prepFallbackProbeInput 24)
   return checksumCanonicalFactorization scalar factors
 
+/--
+Per-rung verified-Isabelle BZ comparator targets on the
+`prepPrecisionLocalInput param` polynomial at each rung of
+`precisionLocalSchedule`. Each pairs with the corresponding rung of the
+parametric Lean `runFastPathPrecisionLocalChecksum` registration.
+
+The Lean target measures *fast-path setup* (multifactor lifting at the
+precision axis plus the modular split profile), not full factorisation, so
+the ratio `Lean_setup / Isabelle_full` is asymmetric: the operations
+differ on the same input. The recorded number is therefore a strict
+lower bound on the equivalent `factorFast`/`factor`-vs-Isabelle full-factor
+ratio on that input — useful as a "setup alone exceeds Isabelle full
+factor" tripwire rather than a full gating verdict. See
+`reports/hex-berlekamp-zassenhaus-performance.md` §"Precision-local
+asymmetric ratio ladder" for the methodology and interpretation.
+
+`expectedHash` is `none` because the Lean precision-local checksum
+records a mix of intermediate-state hashes (lifted factors, precision
+cap, modular split profile), not a canonical factorisation, so the
+two checksums are not directly comparable. Multiset agreement against
+the constructed split factorisation `splitPrecisionLocalFactors` is
+established post-hoc.
+-/
+def runIsabellePrecisionLocalRung1Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 2 2 4 2)).poly
+  return checksumCanonicalFactorization scalar factors
+
+def runIsabellePrecisionLocalRung2Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 2 2 16 2)).poly
+  return checksumCanonicalFactorization scalar factors
+
+def runIsabellePrecisionLocalRung3Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 4 4 16 4)).poly
+  return checksumCanonicalFactorization scalar factors
+
+def runIsabellePrecisionLocalRung4Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 4 16 64 4)).poly
+  return checksumCanonicalFactorization scalar factors
+
+def runIsabellePrecisionLocalRung5Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 6 16 64 6)).poly
+  return checksumCanonicalFactorization scalar factors
+
+def runIsabellePrecisionLocalRung6Checksum : Unit → IO UInt64 := fun _ => do
+  let (scalar, factors) ← requestIsabelleBZFactorization
+    (prepPrecisionLocalInput (encodePrecisionLocalParam 8 32 128 8)).poly
+  return checksumCanonicalFactorization scalar factors
+
 def scheduledHardwareTag : String :=
   "scheduled-hardware"
 
@@ -1326,6 +1387,53 @@ setup_fixed_benchmark runIsabelleFallbackProbeN22Checksum where {
   }
 
 setup_fixed_benchmark runIsabelleFallbackProbeN24Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+/- Per-rung verified-Isabelle comparator registrations on
+`prepPrecisionLocalInput param` for each rung of `precisionLocalSchedule`.
+Pairs with `runFastPathPrecisionLocalChecksum` at the same rung. The
+ratio is asymmetric (Lean measures setup only, Isabelle measures full
+factor on the same input) and is reported as a lower bound on the
+implied full-factor ratio — see the per-`def` doc comment for the
+methodology and tripwire interpretation. `expectedHash` is `none` because
+the Lean checksum mixes intermediate-state hashes, not a canonical
+factorisation; multiset agreement against the constructed split
+factorisation is established post-hoc. Tagged `scheduled-hardware` so
+CI's `verify` does not invoke the AFP-extracted comparator. -/
+setup_fixed_benchmark runIsabellePrecisionLocalRung1Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+setup_fixed_benchmark runIsabellePrecisionLocalRung2Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+setup_fixed_benchmark runIsabellePrecisionLocalRung3Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+setup_fixed_benchmark runIsabellePrecisionLocalRung4Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+setup_fixed_benchmark runIsabellePrecisionLocalRung5Checksum where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    tags := #[scheduledHardwareTag]
+  }
+
+setup_fixed_benchmark runIsabellePrecisionLocalRung6Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     tags := #[scheduledHardwareTag]

--- a/progress/20260530T164027Z_8a84e793.md
+++ b/progress/20260530T164027Z_8a84e793.md
@@ -1,0 +1,129 @@
+# Progress — 2026-05-30T16:40Z — session 8a84e793 (#5773 partial)
+
+## Accomplished
+
+Worked on directive #5773 (HO-5b): "rewrite
+hex-berlekamp-zassenhaus-performance.md against hex/isabelle ratio
+verdicts". Six prior partial PRs (#5822, #5826, #5832, #5833, #5834,
+#5837) had landed per-rung Isabelle comparator registrations and
+ratio ladders for the split-family, degree/height matrix, HO-2
+singletons, and fallback-probe surfaces. Eight of the nine registered
+scientific bench-target groups had ratio verdicts; the prior session
+left `runFastPathPrecisionLocalChecksum` as a documented exclusion
+("semantic-mismatch case") in §Concerns and a "Next step" handing
+the precision-local closure question to orchestrator judgement.
+
+This session wires the precision/local-factor surface as the ninth
+comparator pairing rather than leaving it excluded. The change is
+source-code + report scaffolding only — no comparator sweep has yet
+exported a `bz_isabelle`-paired JSON for these rungs (this worktree
+has no `bz_isabelle` binary built and `carica` load is `5.51` at
+session start, above the SPEC-recommended quiet-hardware threshold).
+
+- Added six per-rung
+  `setup_fixed_benchmark runIsabellePrecisionLocalRung{1..6}Checksum`
+  registrations on the inputs `prepPrecisionLocalInput`'s polynomial
+  constructs at each rung of `precisionLocalSchedule`. The polynomial
+  on each rung is a deterministic linear split
+  `(X − (h+1)·1)…(X − (h+1)·r)` of degree `r`; the Isabelle
+  full-factor cost on these small-degree inputs is expected to
+  dominate the persistent-subprocess overhead (consistent with the
+  other surfaces' stable-Isabelle-median observation). All six
+  registrations carry `expectedHash := none` because the Lean
+  precision-local checksum mixes intermediate-state hashes (lifted
+  factors, precision cap, modular split profile) rather than a
+  canonical factorisation. Tagged `scheduled-hardware` to keep CI's
+  `verify` from invoking the AFP-extracted comparator. Commit
+  `63e5a5c0`.
+- Updated `HexBerlekampZassenhaus/Bench.lean`'s header doc-comment
+  to document the new surface alongside the existing five group
+  descriptions.
+- Added §"Precision-local asymmetric ratio ladder" to
+  `reports/hex-berlekamp-zassenhaus-performance.md` between the
+  fallback-probe ladder and the prior `outer-trials=1` comparison.
+  The new section explains the "Asymmetric operation caveat"
+  (Lean measures fast-path setup, Isabelle measures full factor) and
+  the resulting tripwire interpretation: the recorded ratio is a
+  strict lower bound on the implied `factorFast`/Isabelle ratio, so
+  `≤ 1×` carries no gating conclusion but `> 1×` is a hard fail. The
+  ladder table is `pending` on every rung. Commit `be75f707`.
+- Replaced the §Concerns "semantic-mismatch case" bullet with a
+  "wired but not yet measured" bullet that points at the new
+  ladder section.
+- Updated the §"Comparator Ratios" overview paragraph from "eight
+  parallel ladders" to "nine" and added the precision-local
+  registrations to the comparator surface enumeration.
+
+Verification:
+
+- `lake build HexBerlekampZassenhaus.Bench` succeeds (164 jobs);
+  only pre-existing `sorry` warnings on `HexBerlekampZassenhaus.Basic`,
+  `HexGramSchmidt.Int`, and `HexLLL.Basic`. No new warnings or errors
+  from the precision-local additions.
+- `lake exe hexbz_bench verify` passes all 18 smoke targets — the
+  new registrations are correctly excluded from `verify` via the
+  `scheduled-hardware` tag.
+- `lake exe hexbz_bench list` shows all six
+  `runIsabellePrecisionLocalRung{1..6}Checksum` registrations under
+  `[fixed] repeats=3 [scheduled-hardware]`.
+
+## Current frontier
+
+All nine registered scientific bench-target groups now have wired
+comparator pairings:
+
+- split family (public, fast, slow) — met
+- degree/height matrix (public, fast, slow) — met
+- HO-2 adversarial singletons (per-input fixed rungs) — met
+- fallback-probe family (cascade trigger) — **not met**
+- precision/local-factor family — **wired but pending sweep**
+
+The precision-local ladder table records `pending` on every rung.
+The first quiet-`carica` sweep slot can run the pairing with:
+
+```sh
+HEX_BZ_ISABELLE="$PWD/.cache/oracles/bz-isabelle/wrapper/bz_isabelle" \
+lake exe hexbz_bench run \
+    Hex.BerlekampZassenhausBench.runFastPathPrecisionLocalChecksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung1Checksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung2Checksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung3Checksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung4Checksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung5Checksum \
+    Hex.BerlekampZassenhausBench.runIsabellePrecisionLocalRung6Checksum \
+    --outer-trials 3 \
+    --export-file reports/bench-results/hex-berlekamp-zassenhaus-<sha>-precision-local-pairing.json
+```
+
+Building the `bz_isabelle` wrapper on a clean machine costs an
+AFP archive download (~1GB) plus the `Berlekamp_Zassenhaus`
+session-heap build (potentially 30 minutes to a few hours on first
+run) plus the GHC compile (~2 minutes once the heap is cached).
+
+## Next step
+
+A future session on quiet `carica` with the `bz_isabelle` wrapper
+built can run the precision-local pairing sweep and fill in the
+table. The expected outcome is `Lean_setup / Isabelle_full ≪ 1×` at
+every rung (a 20-30 ns setup-only Lean wall versus 800 ms+ Isabelle
+full-factor wall mirrors the HO-2 fast-path setup measurements in
+§"HO-2 adversarial singletons"), so the tripwire is unlikely to
+fire — the ladder will document a passing tripwire rather than a
+gating verdict, matching the methodology declaration.
+
+With that sweep done, every registered scientific bench-target
+group has a ratio verdict (gating or tripwire) and the directive's
+verification criterion ("Each registered scientific bench target
+has at least one ratio verdict, even if 'not met'") is met. The
+remaining concerns (cascade-trigger fallback-probe not-met verdict,
+Phase 4 dependency gate, internal-model verdicts inconclusive) are
+all out of scope for HO-5b and tracked on HO-1 / HO-5d / HO-3.
+
+## Blockers
+
+No technical blockers for the source-code piece in this PR — the
+build is clean and `verify` still passes. The actual comparator
+sweep is gated on (a) building the `bz_isabelle` wrapper in a
+worktree where it isn't already present and (b) finding a quiet-load
+window on `carica`. Neither is a blocker for the next session if
+they have access to a worktree with the wrapper built.

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -59,19 +59,23 @@ deterministic degree/height matrix
 `slowDegreeHeightSchedule`); three per-input registrations on the
 HO-2 adversarial singletons not already covered by
 `runIsabelleFactorChecksum`
-(`runIsabelleAdv{X4Plus1,Phi15,SwinnertonDyerSD3}Checksum`); and seven
+(`runIsabelleAdv{X4Plus1,Phi15,SwinnertonDyerSD3}Checksum`); seven
 per-rung registrations on the cascade-trigger fallback-probe family
-(`runIsabelleFallbackProbeN{11,12,13,15,18,22,24}Checksum`). Each
-per-rung Isabelle median pairs with the corresponding Lean medians from
-one of the parametric Lean targets (`runFactorChecksum`,
+(`runIsabelleFallbackProbeN{11,12,13,15,18,22,24}Checksum`); and six
+per-rung registrations on the precision/local-factor schedule
+(`runIsabellePrecisionLocalRung{1..6}Checksum`) — see §"Precision-local
+asymmetric ratio ladder" for the methodology caveat. Each per-rung
+Isabelle median pairs with the corresponding Lean medians from one of
+the parametric Lean targets (`runFactorChecksum`,
 `runFactorFastChecksum`, `runFactorSlowChecksum` on the split family;
 `runFactorDegreeHeightChecksum`, `runFactorFastDegreeHeightChecksum`,
 `runFactorSlowDegreeHeightChecksum` on the degree/height matrix;
 `runFactorAdv*Checksum` on the HO-2 singletons;
-`runFactorFallbackProbeChecksum` on the fallback-probe family) — eight
-parallel `hex/isabelle` ladders against the AFP-extracted comparator,
-replacing the prior single-rung canonical-fixed verdict with the
-scaling-ladder trends below.
+`runFactorFallbackProbeChecksum` on the fallback-probe family;
+`runFastPathPrecisionLocalChecksum` on the precision/local-factor
+family) — nine parallel `hex/isabelle` ladders against the
+AFP-extracted comparator, replacing the prior single-rung
+canonical-fixed verdict with the scaling-ladder trends below.
 
 ### Per-call comparator overhead
 
@@ -550,6 +554,80 @@ rewrite to van Hoeij CLD) and HO-5d
 [#5819](https://github.com/kim-em/hex/issues/5819) /
 [#5831](https://github.com/kim-em/hex/issues/5831); tactical
 discharge of the `fallbackPrimeChoiceData` silent-fallback path).
+
+### Precision-local asymmetric ratio ladder
+
+The six per-rung `runIsabellePrecisionLocalRung{1..6}Checksum` targets
+pair with the corresponding rungs of
+`runFastPathPrecisionLocalChecksum` on the precision/local-factor
+schedule
+`precisionLocalSchedule = #[encodePrecisionLocalParam (d, h, k, r) for
+(d, h, k, r) ∈ {(2,2,4,2), (2,2,16,2), (4,4,16,4), (4,16,64,4),
+(6,16,64,6), (8,32,128,8)}]`. The Isabelle target on each rung runs
+the verified-Isabelle full-factor extraction on
+`prepPrecisionLocalInput`'s polynomial — concretely
+`(X - (h+1)·1)(X - (h+1)·2)…(X - (h+1)·r)`, a deterministic
+linear-split polynomial of degree `r`.
+
+**Asymmetric operation caveat.** The Lean target measures *fast-path
+setup* on the polynomial:
+`multifactorLiftQuadratic 31 k poly localFactors`, plus
+`modularFactorDegreesAt? poly 31`, plus the precision cap
+`factorFastPrecisionCap poly`. It does *not* call
+`factorFast`/`factor` end-to-end. The Lean target's documented
+purpose (in `HexBerlekampZassenhaus/Bench.lean §"Stable checksum for
+verify-budget-safe fast-path setup …"`) is to keep the
+`k`-and-`r`-axes visible to the bench harness while sidestepping the
+`verify` budget that a full `factorFast` call would blow through on
+the larger rungs.
+
+Pairing a setup-only Lean median against a full-factor Isabelle
+median therefore yields an asymmetric ratio
+`Lean_setup / Isabelle_full` on the same input. This ratio is *a
+strict lower bound on the equivalent
+`Lean_factorFast` / `Isabelle_full` ratio* on that input, since
+`factorFast` runs the same setup work as a subroutine and then does
+additional recombination work on top. The asymmetric ratio's value
+is as a tripwire:
+
+- `Lean_setup / Isabelle_full ≤ 1×` is *no conclusion* about gating
+  (Lean's full factor could still be much slower than Isabelle's
+  full factor — only the setup-only subroutine is bounded).
+- `Lean_setup / Isabelle_full > 1×` is a *hard fail* on the gating
+  goal: Lean's setup work alone exceeds Isabelle's full-factor wall
+  on the same input, so any path through `factorFast`/`factor` is
+  necessarily worse.
+
+Because of the asymmetry, the §"Concerns" gating-goal headline does
+not cite the precision-local rungs as headline evidence; they are
+informational tripwires that pass through the same
+`scheduled-hardware` tagging as the other Isabelle pairings.
+
+**Comparator run status.** The six per-rung Isabelle registrations
+are wired in
+[HexBerlekampZassenhaus/Bench.lean](../HexBerlekampZassenhaus/Bench.lean)
+but no comparator sweep has yet exported a `bz_isabelle`-paired
+JSON for these rungs. The first available sweep slot on quiet
+`carica` hardware (load average below the SPEC-recommended
+benchmarking threshold) will fill in the ladder table here. Until
+then, the §Concerns bullet records the precision-local ratio as
+"pending" rather than "excluded".
+
+| Rung `(d, h, k, r)` | Lean median (`runFastPathPrecisionLocalChecksum`) | Isabelle median | overhead share | raw ratio | adjusted ratio | tripwire status |
+|:---|---:|---:|---:|---:|---:|:---|
+| `(d=2, h=2, k=4, r=2)` | pending | pending | pending | pending | pending | not yet measured |
+| `(d=2, h=2, k=16, r=2)` | pending | pending | pending | pending | pending | not yet measured |
+| `(d=4, h=4, k=16, r=4)` | pending | pending | pending | pending | pending | not yet measured |
+| `(d=4, h=16, k=64, r=4)` | pending | pending | pending | pending | pending | not yet measured |
+| `(d=6, h=16, k=64, r=6)` | pending | pending | pending | pending | pending | not yet measured |
+| `(d=8, h=32, k=128, r=8)` | pending | pending | pending | pending | pending | not yet measured |
+
+The Lean per-rung medians at commit `454066c-dirty` from the prior
+`hex-berlekamp-zassenhaus-issue3527-precision-local.json` export
+remain available as internal-complexity-model evidence in the
+§Appendix; once the comparator sweep is run, the headline table here
+will record both raw and adjusted ratios against fresh Lean medians
+collected in the same sweep.
 
 ### Comparison to prior outer-trials=1 ladder
 
@@ -1081,7 +1159,7 @@ record on each adversarial polynomial.
 - `runFactorSlowDegreeHeightChecksum` is now explicit and reproducible on
   a completing small subset; it remains diagnostic evidence only, not a
   Phase 4 completion verdict for the full slow path.
-- The verified-Isabelle BZ comparator now covers eight parametric or
+- The verified-Isabelle BZ comparator now covers nine parametric or
   per-input Lean target groups. The split family
   (`runFactorChecksum`, `runFactorFastChecksum`,
   `runFactorSlowChecksum` at `n ∈ {2, 3, 4, 5}`), the degree/height
@@ -1106,20 +1184,30 @@ record on each adversarial polynomial.
   ([#2564](https://github.com/kim-em/hex/issues/2564)) and HO-5d
   ([#5817](https://github.com/kim-em/hex/issues/5817) /
   [#5819](https://github.com/kim-em/hex/issues/5819) /
-  [#5831](https://github.com/kim-em/hex/issues/5831)).
-- `runFastPathPrecisionLocalChecksum` remains the only registered
-  scientific bench target without an Isabelle ratio verdict.
-  The Lean target measures *fast-path setup* cost
+  [#5831](https://github.com/kim-em/hex/issues/5831)). The ninth
+  surface, the precision/local-factor family
+  (`runFastPathPrecisionLocalChecksum` paired with
+  `runIsabellePrecisionLocalRung{1..6}Checksum`), is wired but not
+  yet measured — see the next bullet.
+- `runFastPathPrecisionLocalChecksum`'s Isabelle pairing is *wired
+  but not yet measured*. Six per-rung
+  `runIsabellePrecisionLocalRung{1..6}Checksum` registrations are
+  present in
+  [HexBerlekampZassenhaus/Bench.lean](../HexBerlekampZassenhaus/Bench.lean)
+  on the inputs `prepPrecisionLocalInput`'s polynomial constructs at
+  each rung of `precisionLocalSchedule`. The pairing is asymmetric:
+  Lean measures *fast-path setup* cost
   (`multifactorLiftQuadratic`, local-factor mixing,
-  `factorFastPrecisionCap`, modular split profile) rather than full
-  factorisation — see the `runFastPathPrecisionLocalChecksum` doc
-  comment in `HexBerlekampZassenhaus/Bench.lean` ("the timed target
-  avoids full `factorFast` on adversarial cases"). Pairing a
-  full-factor Isabelle median against a setup-only Lean median would
-  be a semantic mismatch (different operations on the same input),
-  so no `runIsabellePrecisionLocal*` registrations are wired. The
-  precision/local-factor surface remains covered as an
-  internal-model verdict in the §Appendix.
+  `factorFastPrecisionCap`, modular split profile) on the polynomial
+  while Isabelle measures *full factorisation* of the same
+  polynomial. The recorded ratio is therefore a strict lower bound
+  on the implied `Lean_factorFast / Isabelle_full` ratio — useful as
+  a "setup alone exceeds Isabelle full factor" tripwire rather than
+  a gating verdict (see §"Precision-local asymmetric ratio ladder"
+  for the methodology). No comparator sweep has exported the paired
+  medians yet; the table in that section is `pending` on every rung.
+  Until the sweep runs, the precision/local-factor surface remains
+  covered as an internal-model verdict in the §Appendix.
 - The split-family `splitScientificSchedule` continues to be capped
   at `n = 5` by the `maxSecondsPerCall = 8.0s` budget. With the
   warm-iterated per-call medians recorded above (`n = 5` at


### PR DESCRIPTION
Partial progress on #5773

Session: `8a84e793-09a6-41a9-a115-aa14ff583653`

157020ab chore: progress entry for #5773 partial — precision-local Isabelle pairing
be75f707 doc: extend BZ Isabelle ratio surface to precision-local schedule
63e5a5c0 feat: register precision-local Isabelle BZ comparator targets

🤖 Prepared with Claude Code