### PR TITLE
plan: forbid skipping a previously-skipped issue

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -455,6 +455,13 @@ Worker-created follow-up issues are encouraged when they improve
 queue quality. Do not require a separate planning round-trip just
 to split an issue that is clearly too large.
 
+### Skipping a previously-skipped issue is forbidden
+
+A worker that finds its claimed issue already carries one or more
+`Skipped by session ...` comments must escalate — close with a
+specific reason, `coordination add-dep` on a concrete open
+blocker, or decompose — and may not `coordination skip` again.
+
 ### Directives never enter the replan queue
 
 `directive`-labelled issues encode SPEC/PLAN-mandated outcomes whose

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -458,9 +458,9 @@ to split an issue that is clearly too large.
 ### Skipping a previously-skipped issue is forbidden
 
 A worker that finds its claimed issue already carries one or more
-`Skipped by session ...` comments must escalate — close with a
-specific reason, `coordination add-dep` on a concrete open
-blocker, or decompose — and may not `coordination skip` again.
+`Skipped by session ...` comments must close it with a specific
+reason, `coordination add-dep` on a concrete open blocker, or
+decompose. A second `coordination skip` is not permitted.
 
 ### Directives never enter the replan queue
 


### PR DESCRIPTION
The first skip on an issue is the legitimate one-shot signal to
triage: decompose-with-breadcrumb, or "premise of the claim is
wrong, please re-scope". Subsequent skips by independent workers
re-deriving the same condition is the loop pathology. This PR
caps at the second worker. A worker that finds a prior
`Skipped by session ...` comment must close (with a specific
reason), `coordination add-dep` (on a concrete open blocker), or
decompose, rather than skip again.

The `coordination skip` command itself is unchanged. The
constraint is on the worker's *decision*.

## Why

Sample of recent `replan`-tagged issues shows the legitimate uses
are one-shot signals to triage (decompose, or premise-wrong). The
pathological case is when a *stable* condition (environment,
infrastructure) causes every successive claimant to re-derive the
same skip. See the skip history of #4334 for the worst-case
example. The rule's bite is at the *second* skip, not the first.

## Companion implementation

Surface-level enforcement lives outside this repo:

- `agent-worker-flow` skill distributed by the dev-pod package
  needs Step 4 ("Verify Assumptions") rewritten so workers check
  for prior-skip comments before invoking `coordination skip`.
- `coordination skip` could refuse with an error when the issue
  already has a `Skipped by session ...` comment.

Tracker for the dev-pod side to follow.

🤖 Prepared with Claude Code