### PR TITLE
spec: require comparator-runtime plot for libraries with >= 2 comparators

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -757,6 +757,18 @@ The report contains five subsections:
      eligible rung of each input family. The bottom rung is
      reported for context; it is never the rung that meets or
      fails the goal.
+
+   - **Comparator-runtime plot (≥ 2 comparators).** A library
+     whose `phase4.comparators` block declares two or more
+     comparators commits a comparator-runtime plot at
+     `reports/figures/<lib>-comparator.svg`, with one curve per
+     comparator alongside the Lean curve across the eligible
+     range, log-y wall-time per call. The generator script lives
+     at `scripts/plots/<lib>-comparator.py` and reads the same
+     committed bench-results JSONL the ratio numbers in this
+     subsection cite. The plot is regenerated with the report; a
+     plot whose curves disagree with the §"Comparator ratios"
+     values is an audit-found issue.
 4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
    one representative case per `phase4.input_families`. Dominant
    inclusive costs are named and explained, with leaf cost


### PR DESCRIPTION
Adds one bullet to SPEC/benchmarking.md §"Comparator ratios"
requiring a committed plot when two or more comparators are
declared.

The new clause:

- Plot at \`reports/figures/<lib>-comparator.svg\`, one curve per
  comparator alongside the Lean curve, log-y wall-time per call,
  across the eligible range already defined for the ratios
  subsection.
- Generator script at \`scripts/plots/<lib>-comparator.py\`,
  reads the same committed bench-results JSONL the §"Comparator
  ratios" numbers cite.
- Regenerated with the headline report; out-of-sync curves are an
  audit-found issue.

The triggering case is HexLLL (fpllll-via-fpylll + Isabelle/AFP),
where the triple plot tells the comparator story far more clearly
than the ratio table alone (Lean and Isabelle track within a few
percent across the eligible range; both are ~30x slower than
fpllll). A follow-up directive will produce the script + plot for
HexLLL per the new clause.

The general clause naturally applies to any future library that
adds a second comparator.

Net diff: +12 lines.

🤖 Prepared with Claude Code