### PR TITLE
plan: require visual inspection of rendered artefact deliverables

### DIFF
--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -430,6 +430,14 @@ A worker that finds its claimed issue already carries one or more
 reason, `coordination add-dep` on a concrete open blocker, or
 decompose. A second `coordination skip` is not permitted.
 
+### Visual artefacts require visual verification
+
+When the deliverable is a rendered artefact for a human reader
+(plot, diagram, screenshot, typeset document), open the artefact
+and inspect it. Data-level verification (the script runs, the
+numbers match, the output is byte-stable) does not catch failures
+visible only at the rendered layer.
+
 ### Directives never enter the replan queue
 
 `directive`-labelled issues encode SPEC/PLAN-mandated outcomes whose


### PR DESCRIPTION
Adds one section to PLAN/Conventions.md (8 lines):

> ### Visual artefacts require visual verification
>
> When the deliverable is a rendered artefact for a human reader
> (plot, diagram, screenshot, typeset document), open the artefact
> and inspect it. Data-level verification (the script runs, the
> numbers match, the output is byte-stable) does not catch failures
> visible only at the rendered layer.

## Why

PR #5881 (HexLLL comparator plot) shipped with the fpylll series
rendering as a single triangle marker rather than a curve, because
the committed fpylll bench data only contains bottom-rung points.
The worker's verification list included script-runs, byte-stability
across two regens, median-equality with the report's ratio table,
and `lake build`. It did not include opening the SVG. Three lines
were passed to \`ax.plot()\`, one of which had a single entry; the
visual outcome was invisible to every check the worker actually
ran.

This is a general failure mode for visual artefacts: data-level
verification passes while the rendered output is wrong. The fix
is a one-line worker doctrine that says inspect the rendered
artefact.

No auto-merge on this PR.

🤖 Prepared with Claude Code