### PR TITLE
feat: add HexPoly operation grind annotations

### DIFF
--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -72,20 +72,21 @@ theorem coeff_scale [Mul R] (c : R) (p : DensePoly R) (n : Nat)
   rw [coeff_ofCoeffs_list]
   simpa [coeff] using list_getD_map_mul_zero (R := R) c p.toArray.toList n hzero
 
-@[simp] theorem scale_zero_right [Mul R] (c : R) :
+@[simp, grind =] theorem scale_zero_right [Mul R] (c : R) :
     scale c (0 : DensePoly R) = 0 := by
   unfold scale toArray
   rfl
 
 /-- Semiring-specialized coefficient law for scalar multiplication, registered as a normalizing
 rewrite because the required `c * 0 = 0` law is available from the semiring structure. -/
-@[simp] theorem coeff_scale_semiring {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+@[simp, grind =] theorem coeff_scale_semiring {S : Type u}
+    [Lean.Grind.Semiring S] [DecidableEq S]
     (c : S) (p : DensePoly S) (n : Nat) :
     (scale c p).coeff n = c * p.coeff n :=
   coeff_scale c p n (Lean.Grind.Semiring.mul_zero c)
 
 /-- Semiring-specialized left zero law for scalar multiplication. -/
-@[simp] theorem scale_zero_left_semiring {S : Type u}
+@[simp, grind =] theorem scale_zero_left_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S]
     (p : DensePoly S) :
     scale (0 : S) p = 0 := by
@@ -98,7 +99,7 @@ rewrite because the required `c * 0 = 0` law is available from the semiring stru
 
 /-- Coefficient law for shifting by `x^n`: coefficients below `n` are zero and later
 coefficients are read from the original polynomial with the index shifted down. -/
-@[simp] theorem coeff_shift (n : Nat) (p : DensePoly R) (k : Nat) :
+@[simp, grind =] theorem coeff_shift (n : Nat) (p : DensePoly R) (k : Nat) :
     (shift n p).coeff k =
       if k < n then (Zero.zero : R) else p.coeff (k - n) := by
   unfold shift
@@ -119,12 +120,12 @@ coefficients are read from the original polynomial with the index shifted down. 
     rw [coeff_ofCoeffs_list]
     simpa [coeff] using list_getD_replicate_append_zero (R := R) n k p.toArray.toList
 
-@[simp] theorem shift_zero_right (n : Nat) :
+@[simp, grind =] theorem shift_zero_right (n : Nat) :
     shift n (0 : DensePoly R) = 0 := by
   unfold shift isZero
   rfl
 
-@[simp] theorem shift_zero_left (p : DensePoly R) :
+@[simp, grind =] theorem shift_zero_left (p : DensePoly R) :
     shift 0 p = p := by
   apply ext_coeff
   intro k
@@ -143,7 +144,7 @@ theorem coeff_shift_scale [Mul R] (i : Nat) (c : R) (p : DensePoly R) (k : Nat)
 
 /-- Semiring-specialized coefficient law for a scaled shift, registered as a normalizing rewrite
 for the common algebraic setting. -/
-@[simp] theorem coeff_shift_scale_semiring
+@[simp, grind =] theorem coeff_shift_scale_semiring
     {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
     (i : Nat) (c : S) (p : DensePoly S) (k : Nat) :
     (shift i (scale c p)).coeff k =
@@ -376,7 +377,7 @@ def compose [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
   p.toArray.toList.reverse.foldl (fun acc coeff => acc * q + C coeff) (0 : DensePoly R)
 
 /-- Left-composition by the zero polynomial is zero. -/
-@[simp] theorem compose_zero_left [Add R] [Mul R] (q : DensePoly R) :
+@[simp, grind =] theorem compose_zero_left [Add R] [Mul R] (q : DensePoly R) :
     compose (0 : DensePoly R) q = 0 := by
   rfl
 
@@ -422,7 +423,8 @@ theorem compose_C [Add R] [Mul R] (c : R) (q : DensePoly R)
 
 /-- Semiring-specialized composition law for constants. This packages the zero-addition
 law needed by the generic `compose_C`. -/
-@[simp] theorem compose_C_semiring {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+@[simp, grind =] theorem compose_C_semiring {S : Type u}
+    [Lean.Grind.Semiring S] [DecidableEq S]
     (c : S) (q : DensePoly S) :
     compose (C c) q = C c :=
   compose_C c q (by grind)
@@ -449,7 +451,7 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
     simp [hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Semiring-specialized coefficient law for addition. -/
-@[simp] theorem coeff_add_semiring {S : Type u}
+@[simp, grind =] theorem coeff_add_semiring {S : Type u}
     [Zero S] [Add S] [Lean.Grind.Semiring S] [DecidableEq S]
     (p q : DensePoly S) (n : Nat)
     (hzero : AddZeroLaw S := by infer_instance) :
@@ -473,7 +475,7 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
     simp [hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Ring-specialized coefficient law for subtraction. -/
-@[simp] theorem coeff_sub_ring {S : Type u}
+@[simp, grind =] theorem coeff_sub_ring {S : Type u}
     [Zero S] [Sub S] [Lean.Grind.Ring S] [DecidableEq S]
     (p q : DensePoly S) (n : Nat)
     (hzero : SubZeroLaw S := by infer_instance) :
@@ -481,7 +483,7 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
   coeff_sub p q n hzero.sub_zero_zero
 
 /-- The zero polynomial has coefficient `0` at every index. -/
-@[simp] theorem coeff_zero (n : Nat) :
+@[simp, grind =] theorem coeff_zero (n : Nat) :
     (0 : DensePoly R).coeff n = (0 : R) := by
   exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)
 
@@ -494,7 +496,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   simp [neg, coeff_sub, hzero]
 
 /-- Ring-specialized coefficient law for negation. -/
-@[simp] theorem coeff_neg_ring {S : Type u}
+@[simp, grind =] theorem coeff_neg_ring {S : Type u}
     [Zero S] [Sub S] [Neg S] [Lean.Grind.Ring S] [DecidableEq S]
     (p : DensePoly S) (n : Nat)
     (hsub : SubZeroLaw S := by infer_instance)
@@ -505,7 +507,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   exact hneg.zero_sub_eq_neg (p.coeff n)
 
 /-- Semiring-specialized right zero law for dense polynomial addition. -/
-@[simp] theorem add_zero_semiring {S : Type u}
+@[simp, grind =] theorem add_zero_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S]
     (p : DensePoly S) :
     p + 0 = p := by
@@ -515,7 +517,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   grind
 
 /-- Semiring-specialized left zero law for dense polynomial addition. -/
-@[simp] theorem zero_add_semiring {S : Type u}
+@[simp, grind =] theorem zero_add_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S]
     (p : DensePoly S) :
     0 + p = p := by
@@ -525,7 +527,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   grind
 
 /-- Ring-specialized right zero law for dense polynomial subtraction. -/
-@[simp] theorem sub_zero_ring {S : Type u}
+@[simp, grind =] theorem sub_zero_ring {S : Type u}
     [Lean.Grind.Ring S] [DecidableEq S]
     (p : DensePoly S) :
     p - 0 = p := by
@@ -535,7 +537,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   grind
 
 /-- Ring-specialized left zero law for dense polynomial subtraction. -/
-@[simp] theorem zero_sub_ring {S : Type u}
+@[simp, grind =] theorem zero_sub_ring {S : Type u}
     [Lean.Grind.Ring S] [DecidableEq S]
     (p : DensePoly S) :
     0 - p = -p := by
@@ -545,7 +547,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   grind
 
 /-- Ring-specialized negation of the zero dense polynomial. -/
-@[simp] theorem neg_zero_ring {S : Type u}
+@[simp, grind =] theorem neg_zero_ring {S : Type u}
     [Lean.Grind.Ring S] [DecidableEq S] :
     -(0 : DensePoly S) = 0 := by
   apply ext_coeff
@@ -554,7 +556,7 @@ theorem coeff_neg [Sub R] (p : DensePoly R) (n : Nat)
   grind
 
 /-- Horner evaluation sends the zero dense polynomial to `0`. -/
-@[simp] theorem eval_zero [Add R] [Mul R] (x : R) :
+@[simp, grind =] theorem eval_zero [Add R] [Mul R] (x : R) :
     eval (0 : DensePoly R) x = 0 := by
   rfl
 
@@ -577,7 +579,8 @@ theorem eval_C [Add R] [Mul R] (c x : R)
 
 /-- Semiring-specialized evaluation law for constants. This packages the
 zero-multiplication and zero-addition laws needed by the generic `eval_C`. -/
-@[simp] theorem eval_C_semiring {S : Type u} [Lean.Grind.Semiring S] [DecidableEq S]
+@[simp, grind =] theorem eval_C_semiring {S : Type u}
+    [Lean.Grind.Semiring S] [DecidableEq S]
     (c x : S) :
     eval (C c) x = c :=
   eval_C c x (Lean.Grind.Semiring.zero_mul x) (by grind)
@@ -611,7 +614,7 @@ private theorem eval_replicate_zero_semiring {S : Type u} [Lean.Grind.Semiring S
         semiring_mul_pow_left]
 
 /-- Semiring-specialized evaluation law for monomials. -/
-@[simp] theorem eval_monomial_semiring {S : Type u}
+@[simp, grind =] theorem eval_monomial_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S]
     (n : Nat) (c x : S) :
     eval (monomial n c) x = c * x ^ n := by
@@ -630,7 +633,7 @@ private theorem eval_replicate_zero_semiring {S : Type u} [Lean.Grind.Semiring S
     exact eval_replicate_zero_semiring n c x
 
 /-- The formal derivative of the zero polynomial is zero. -/
-@[simp] theorem derivative_zero [NatCast R] [Mul R] :
+@[simp, grind =] theorem derivative_zero [NatCast R] [Mul R] :
     derivative (0 : DensePoly R) = 0 := by
   rfl
 
@@ -653,13 +656,13 @@ attribute [local instance 1100] Lean.Grind.Semiring.natCast
 /-- Semiring-specialized coefficient law for the formal derivative, registered
 as a normalizing rewrite because semirings provide the required `a * 0 = 0`
 law. -/
-@[simp] theorem coeff_derivative_semiring {S : Type u}
+@[simp, grind =] theorem coeff_derivative_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S] (p : DensePoly S) (n : Nat) :
     (derivative p).coeff n = ((n + 1 : Nat) : S) * p.coeff (n + 1) := by
   exact coeff_derivative p n (Lean.Grind.Semiring.mul_zero _)
 
 /-- The formal derivative of a constant polynomial is zero over a semiring. -/
-@[simp] theorem derivative_C_semiring {S : Type u}
+@[simp, grind =] theorem derivative_C_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S] (c : S) :
     derivative (C c : DensePoly S) = 0 := by
   apply ext_coeff
@@ -670,7 +673,7 @@ law. -/
   exact Lean.Grind.Semiring.mul_zero _
 
 /-- The formal derivative of a degree-zero monomial is zero over a semiring. -/
-@[simp] theorem derivative_monomial_zero_semiring {S : Type u}
+@[simp, grind =] theorem derivative_monomial_zero_semiring {S : Type u}
     [Lean.Grind.Semiring S] [DecidableEq S] (c : S) :
     derivative (monomial 0 c : DensePoly S) = 0 := by
   apply ext_coeff

--- a/progress/20260601T130845Z_5873f0a6.md
+++ b/progress/20260601T130845Z_5873f0a6.md
@@ -1,0 +1,31 @@
+# 5873f0a6 - feature #5971
+
+## Accomplished
+
+- Claimed #5971 after confirming no claimable directive issue was returned.
+- Audited `HexPoly/Operations.lean` for conservative `grind =` coverage on
+  operation characterising lemmas.
+- Added `@[simp, grind =]` to coefficient laws for scale, shift, shifted scale,
+  add, sub, negation, zero coefficients, and derivative.
+- Added `@[simp, grind =]` to small zero/constant wrappers for scale, shift,
+  compose, add, sub, negation, eval, and derivative.
+- Left the schoolbook multiplication coefficient theorem unannotated because it
+  exposes the nested fold representation and is a poor global grind rule.
+- Verified with `lake build HexPoly`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and the forbidden-token diff grep.
+
+## Current frontier
+
+#5971 is implemented. The HexPoly operation surface now has conservative grind
+characterisation on the same normalization lemmas downstream proofs already use
+with `simp`.
+
+## Next step
+
+Open the PR for #5971 and mention that `coeff_mul` remains intentionally
+unannotated due to fold expansion/search risk.
+
+## Blockers
+
+None for this issue. A pre-existing `.claude/CLAUDE.md` worktree modification
+was left untouched.


### PR DESCRIPTION
Closes #5971

Session: `5873f0a6-3a1b-463f-9659-97d6a4e43957`

Summary:
- Adds conservative `@[simp, grind =]` annotations to HexPoly operation coefficient laws and small zero/constant wrappers.
- Covers scale, shift, shifted scale, add, sub, negation, zero coefficients, eval, compose, and derivative normalization lemmas.
- Leaves `coeff_mul` unannotated intentionally: it exposes the nested schoolbook fold representation and would be a risky global grind rule for search size.

Verification:
- `lake build HexPoly`
- `python3 scripts/check_dag.py`
- `git diff --check`
- `git diff -- HexPoly/Operations.lean | rg -n -e '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'` (no matches)\n\na960cc4f feat: add HexPoly operation grind annotations