### PR TITLE
HexMatrix Phase 6: remove unnecessary pivot hypothesis from span soundness

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -1824,8 +1824,7 @@ def spanContains [Lean.Grind.Field R] [DecidableEq R] (E : IsEchelonForm M D)
 
 /-- `spanCoeffs` returns coefficients whose row combination equals `v`. -/
 theorem spanCoeffs_sound [Lean.Grind.Field R] [DecidableEq R]
-    (E : IsEchelonForm M D) (_hpiv : E.HasNonzeroPivots) (v : Vector R m)
-    (c : Vector R n) :
+    (E : IsEchelonForm M D) (v : Vector R m) (c : Vector R n) :
     E.spanCoeffs v = some c → rowCombination M c = v := by
   intro h
   unfold spanCoeffs at h
@@ -1839,7 +1838,7 @@ theorem spanCoeffs_sound [Lean.Grind.Field R] [DecidableEq R]
 
 /-- If `spanContains` succeeds, the vector is in the row span. -/
 theorem spanContains_sound [Lean.Grind.Field R] [DecidableEq R]
-    (E : IsEchelonForm M D) (hpiv : E.HasNonzeroPivots) (v : Vector R m) :
+    (E : IsEchelonForm M D) (v : Vector R m) :
     E.spanContains v = true → ∃ c : Vector R n, rowCombination M c = v := by
   intro h
   unfold spanContains at h
@@ -1847,7 +1846,7 @@ theorem spanContains_sound [Lean.Grind.Field R] [DecidableEq R]
   | none =>
       simp [hCoeffs] at h
   | some c =>
-      exact ⟨c, E.spanCoeffs_sound hpiv v c hCoeffs⟩
+      exact ⟨c, E.spanCoeffs_sound v c hCoeffs⟩
 
 end IsEchelonForm
 
@@ -2128,7 +2127,7 @@ theorem spanContains_iff [Lean.Grind.Field R] [DecidableEq R]
     E.toIsEchelonForm.spanContains v = true ↔
       ∃ c : Vector R n, rowCombination M c = v := by
   constructor
-  · exact E.toIsEchelonForm.spanContains_sound E.hasNonzeroPivots v
+  · exact E.toIsEchelonForm.spanContains_sound v
   · intro h
     unfold IsEchelonForm.spanContains
     simpa using E.spanCoeffs_complete v h

--- a/progress/20260601T144321Z_fc47a660.md
+++ b/progress/20260601T144321Z_fc47a660.md
@@ -1,0 +1,27 @@
+# fc47a660 - work #6029
+
+## Accomplished
+
+- Claimed #6029 after #5980 was lost to a claim race.
+- Weakened `IsEchelonForm.spanCoeffs_sound` so it no longer requires
+  `E.HasNonzeroPivots`.
+- Also weakened `IsEchelonForm.spanContains_sound`, since it only unwraps
+  `spanCoeffs` and uses the same direct checked equality.
+- Updated the RREF `spanContains_iff` caller to use the weaker theorem.
+- Verified with `lake build HexMatrix`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and the forbidden-token diff grep for
+  `HexMatrix/RREF.lean`.
+
+## Current frontier
+
+#6029 is implemented in `HexMatrix/RREF.lean`. One-way span soundness now
+applies to general echelon data without a pivot nonzero proof.
+
+## Next step
+
+Open the PR for #6029.
+
+## Blockers
+
+No blocker for #6029. The pre-existing `.claude/CLAUDE.md` worktree
+modification was left untouched and excluded from this session's commits.


### PR DESCRIPTION
Closes #6029

Session: `fc47a660-f552-408d-a1d3-2a95fa6e2974`

c75a83a3 chore: record progress for 6029
29f3ce61 fix: weaken RREF span soundness hypotheses

🤖 Prepared with Claude Code