### PR TITLE
feat: add two-column determinant substrate

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -10096,6 +10096,59 @@ def nDet {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hpq : p.val < q.val) : R :=
   det (nMatrix B p q hpq)
 
+/-- The square matrix `[B | u | v]` formed by appending two vector columns to
+`B : Matrix R (n + 2) n`. The original `B` columns occupy positions
+`0..n-1`; `u` occupies column `n`; `v` occupies the last column. -/
+def twoColMatrix {R : Type u} {n : Nat}
+    (B : Matrix R (n + 2) n) (u v : Vector R (n + 2)) :
+    Matrix R (n + 2) (n + 2) :=
+  ofFn fun i j =>
+    if hj : j.val < n then
+      B[i][(⟨j.val, hj⟩ : Fin n)]
+    else if hju : j.val = n then
+      u[i]
+    else
+      v[i]
+
+theorem twoColMatrix_entry_lt {R : Type u} {n : Nat}
+    (B : Matrix R (n + 2) n) (u v : Vector R (n + 2))
+    (i j : Fin (n + 2)) (h : j.val < n) :
+    (twoColMatrix B u v)[i][j] = B[i][(⟨j.val, h⟩ : Fin n)] := by
+  unfold twoColMatrix
+  rw [getElem_ofFn]
+  exact dif_pos h
+
+theorem twoColMatrix_entry_penultimate {R : Type u} {n : Nat}
+    (B : Matrix R (n + 2) n) (u v : Vector R (n + 2))
+    (i : Fin (n + 2)) :
+    (twoColMatrix B u v)[i][(⟨n, by omega⟩ : Fin (n + 2))] = u[i] := by
+  unfold twoColMatrix
+  rw [getElem_ofFn]
+  have hnlt : ¬ (⟨n, by omega⟩ : Fin (n + 2)).val < n := by
+    simp
+  have hneq : (⟨n, by omega⟩ : Fin (n + 2)).val = n := by
+    simp
+  rw [dif_neg hnlt]
+  rw [dif_pos hneq]
+
+theorem twoColMatrix_entry_last {R : Type u} {n : Nat}
+    (B : Matrix R (n + 2) n) (u v : Vector R (n + 2))
+    (i : Fin (n + 2)) :
+    (twoColMatrix B u v)[i][Fin.last (n + 1)] = v[i] := by
+  unfold twoColMatrix
+  rw [getElem_ofFn]
+  have hlast_lt : ¬ (Fin.last (n + 1) : Fin (n + 2)).val < n := by
+    simp [Fin.last]
+  have hlast_ne : ¬ (Fin.last (n + 1) : Fin (n + 2)).val = n := by
+    simp [Fin.last]
+  rw [dif_neg hlast_lt]
+  rw [dif_neg hlast_ne]
+
+/-- The determinant of `[B | u | v]`. -/
+def twoColDet {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (B : Matrix R (n + 2) n) (u v : Vector R (n + 2)) : R :=
+  det (twoColMatrix B u v)
+
 /-- `mMatrix B v p` exposed as a `colReplace` on its last column: the
 other columns come from `B` and are independent of `v`, while the last
 column carries `fun i => v[skipIndex p i]`. -/

--- a/progress/20260601T150335Z_ad2a3c41.md
+++ b/progress/20260601T150335Z_ad2a3c41.md
@@ -1,0 +1,40 @@
+# 20260601T150335Z — ad2a3c41: #6040 two-column determinant substrate
+
+## Accomplished
+
+Checked the directive queue first. All directive claims failed as blocked, so
+they were not worked. Claimed #5805 and marked it stale because it still depends
+on #6031, which is open and blocked. Claimed #5947 and marked it for replan
+because the requested one-exterior statement is false as written: with
+`r = 1`, `a = 1`, `b = 4`, `c = 1`, `d = -1`, the source strict-exterior count
+is `1`, while Vieta roots `2` and `-2` have strict-exterior count `2`. Claimed
+#6030 and marked it stale/decomposed because #6036 closed forward and #6037 is
+the active claimed q-between subcase.
+
+Claimed #6040 and added a compiling Mathlib-free two-appended-column substrate
+in `HexMatrix/Determinant.lean`:
+`twoColMatrix`, entry lemmas for original/penultimate/last columns, and
+`twoColDet`.
+
+## Current frontier
+
+#6040 is only partially complete. The matrix/determinant object now exists, but
+the requested signed ordered-pair Laplace expansion remains to be proved.
+
+## Next step
+
+Extend `twoColMatrix` with column-replacement or direct Laplace helpers for the
+two appended columns, then prove the ordered-pair expansion whose terms contain
+`u[a] * v[b] - u[b] * v[a]` times `nDet B a b hab`.
+
+## Blockers
+
+No technical blocker for #6040, but the remaining determinant expansion is
+larger than the stable substrate landed in this session.
+
+## Verification
+
+* `lake build HexMatrix` — green.
+* `python3 scripts/check_dag.py` — green.
+* `git diff --check` — green.
+* `git diff -- HexMatrix/Determinant.lean | rg -n -e '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)' || true` — no matches.


### PR DESCRIPTION
Partial progress on #6040

Session: `ad2a3c41-bffb-4cc9-9e5f-b363151d8e29`

4869fe29 feat: add two-column determinant substrate

🤖 Prepared with Claude Code