### PR TITLE
HexPolyZMathlib: add counterexample guard for false degree-two Schur one-exterior count

### DIFF
--- a/progress/20260601T150336Z_07bc3f6c.md
+++ b/progress/20260601T150336Z_07bc3f6c.md
@@ -1,0 +1,29 @@
+# 07bc3f6c - work #6045
+
+## Accomplished
+
+- Claimed #6045 as a feature task after checking the unclaimed queue.
+- Extended `scripts/oracle/mahler_schur_counterexample.py` with an exact
+  degree-two Schur-Szego one-exterior counterexample guard.
+- The guard checks the closed-unit hypotheses for `c,d`, the exact Vieta
+  orientation from `Polynomial.schmeisserComposition_two_eq`, and the strict
+  exterior-card failure for `r = 1`, `(a,b) = (1,4)`, `(c,d) = (1,-1)`,
+  `(zeta1,zeta2) = (2,-2)`.
+- Verified with `python3 scripts/oracle/mahler_schur_counterexample.py` and
+  `git diff --check`.
+
+## Current frontier
+
+#6045 is complete without Lean changes. The false one-exterior root-count
+shape is now guarded by the existing Schur counterexample oracle.
+
+## Next step
+
+Open the PR for #6045. A planner should treat #5948 as stale or dependent on a
+corrected theorem shape because it inherits the false #5947 comparison.
+
+## Blockers
+
+- None for #6045.
+- A pre-existing `.claude/CLAUDE.md` worktree modification remains untouched and
+  is not part of this work.

--- a/scripts/oracle/mahler_schur_counterexample.py
+++ b/scripts/oracle/mahler_schur_counterexample.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Check the Schur-reflection derivative-Mahler counterexample.
+"""Check narrow Schur-route counterexamples.
 
-This is a narrow regression artifact for the failed route toward the
+This is a narrow regression artifact for failed routes toward the
 Mahler/Boyd derivative bound.  It verifies that both the scaled endpoint
 comparison and the direct Schur-reflection derivative-Mahler comparison from
-issue #5303 are false without additional hypotheses.
+issue #5303 are false without additional hypotheses, and that the degree-two
+Schur-Szego one-exterior root-count exclusion is false.
 
 Counterexample in ``C[X]`` with real coefficients:
 
@@ -89,6 +90,52 @@ class Counterexample:
         return (1, -self.alpha)
 
 
+@dataclass(frozen=True)
+class DegreeTwoSchurCounterexample:
+    r: int = 1
+    a: int = 1
+    b: int = 4
+    c: int = 1
+    d: int = -1
+    zeta1: int = 2
+    zeta2: int = -2
+
+
+def strict_exterior_count_real(values: tuple[int, ...], r: int) -> int:
+    return sum(1 for value in values if r < abs(value))
+
+
+def check_degree_two_schur_one_exterior_counterexample() -> None:
+    case = DegreeTwoSchurCounterexample()
+
+    if abs(case.c) > 1 or abs(case.d) > 1:
+        raise AssertionError("Schur factor roots must lie in the closed unit disk")
+
+    source_exterior = strict_exterior_count_real((case.a, case.b), case.r)
+    schur_exterior = strict_exterior_count_real((case.zeta1, case.zeta2), case.r)
+    if source_exterior != 1:
+        raise AssertionError(f"source exterior count mismatch: {source_exterior}")
+    if schur_exterior != 2:
+        raise AssertionError(f"Schur exterior count mismatch: {schur_exterior}")
+
+    # For f = (X - a) (X - b) and g = (X - c) (X - d), the degree-two
+    # Schmeisser composition has coefficients
+    #   X^2 + ((a + b) * (c + d) / 2) X + a * b * c * d.
+    # Hence the exact Vieta orientation used by
+    # Polynomial.schmeisserComposition_two_eq is:
+    #   zeta1 + zeta2 = -((a + b) * (c + d) / 2)
+    #   zeta1 * zeta2 = a * b * c * d.
+    expected_sum = -Fraction((case.a + case.b) * (case.c + case.d), 2)
+    expected_product = case.a * case.b * case.c * case.d
+    if Fraction(case.zeta1 + case.zeta2) != expected_sum:
+        raise AssertionError("degree-two Schur Vieta sum orientation mismatch")
+    if case.zeta1 * case.zeta2 != expected_product:
+        raise AssertionError("degree-two Schur Vieta product mismatch")
+
+    if not (source_exterior < schur_exterior):
+        raise AssertionError("expected strict exterior-card comparison to fail")
+
+
 def main() -> int:
     getcontext().prec = 50
     case = Counterexample()
@@ -138,6 +185,17 @@ def main() -> int:
         "failure: scaled endpoint inequality would require "
         f"{left_measure_formula} <= {right_measure}"
     )
+
+    check_degree_two_schur_one_exterior_counterexample()
+    degree_two_case = DegreeTwoSchurCounterexample()
+    print(
+        "counterexample: degree-two Schur one-exterior count with "
+        f"r = {degree_two_case.r}, "
+        f"(a, b) = ({degree_two_case.a}, {degree_two_case.b}), "
+        f"(c, d) = ({degree_two_case.c}, {degree_two_case.d}), "
+        f"(zeta1, zeta2) = ({degree_two_case.zeta1}, {degree_two_case.zeta2})"
+    )
+    print("failure: source exterior count is 1 while Schur exterior count is 2")
     return 0
 
 


### PR DESCRIPTION
Closes #6045

Session: `07bc3f6c-868e-423f-8eef-01f2477e5fe8`

0964ef92 test: guard degree-two Schur counterexample

🤖 Prepared with Claude Code