### PR TITLE
HexMatrixMathlib: assemble two-row adjugate replacement determinant identity

### DIFF
--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -607,6 +607,46 @@ theorem det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub
   rw [Hex.Matrix.det_setRow_eq_cofactorRowPairing] at h
   exact h
 
+private theorem foldl_pairing_mul_sub
+    [CommRing R] {β : Type v} (xs : List β)
+    (det a b accF accG accH : R) (row f g h : β → R)
+    (hacc : det * accF = a * accG - b * accH)
+    (hpoint : ∀ x, det * f x = a * g x - b * h x) :
+    det * xs.foldl (fun acc x => acc + row x * f x) accF =
+      a * xs.foldl (fun acc x => acc + row x * g x) accG -
+        b * xs.foldl (fun acc x => acc + row x * h x) accH := by
+  induction xs generalizing accF accG accH with
+  | nil =>
+      simpa using hacc
+  | cons x xs ih =>
+      apply ih
+      have hx := hpoint x
+      dsimp
+      calc
+        det * (accF + row x * f x) =
+            det * accF + row x * (det * f x) := by ring
+        _ = a * (accG + row x * g x) - b * (accH + row x * h x) := by
+            rw [hacc, hx]
+            ring
+
+/-- Two-row replacement determinant identity in the Hex matrix API.
+
+Replacing distinct rows `r` and `s` by `u` and `v` satisfies the adjugate
+two-row determinant relation, stated entirely in terms of Hex determinants
+and cofactor-row pairings. -/
+theorem det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub
+    [CommRing R] (M : Hex.Matrix R (n + 1) (n + 1))
+    (r s : Fin (n + 1)) (u v : Vector R (n + 1)) (hrs : s ≠ r) :
+    Hex.Matrix.det M * Hex.Matrix.det (Hex.Matrix.setRow (Hex.Matrix.setRow M r u) s v) =
+      Hex.Matrix.cofactorRowPairing M r u * Hex.Matrix.cofactorRowPairing M s v -
+        Hex.Matrix.cofactorRowPairing M s u * Hex.Matrix.cofactorRowPairing M r v := by
+  rw [Hex.Matrix.det_setRow_eq_cofactorRowPairing]
+  unfold Hex.Matrix.cofactorRowPairing
+  apply foldl_pairing_mul_sub
+  · ring
+  · intro col
+    exact det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub M r s col u hrs
+
 /-- Reindex the `(k+2) × (k+2)` bordered minor so Desnanot-Jacobi deletes the
 Bareiss pivot row/column first and the trailing row/column last.
 

--- a/progress/20260601T150559Z_75b99bd2.md
+++ b/progress/20260601T150559Z_75b99bd2.md
@@ -1,0 +1,20 @@
+# 75b99bd2 - work #5999
+
+## Accomplished
+
+- Claimed #5999 after checking the directive queue and current unclaimed work.
+- Added `HexMatrixMathlib.det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub` in `HexMatrixMathlib/Determinant/Core.lean`.
+- Proved the two-row replacement identity by expanding the second replacement row through `cofactorRowPairing` and folding #5998's one-row cofactor bridge over the Laplace sum.
+- Verified with `lake build HexMatrixMathlib`, `git diff --check`, and a forbidden-token grep over the touched Lean diff.
+
+## Current frontier
+
+#5999 is complete. The new bridge-layer theorem is stated for arbitrary `M : Hex.Matrix R (n + 1) (n + 1)`, distinct rows `r s`, and replacement rows `u v`, with the `setRow (setRow M r u) s v` orientation needed by the Plucker chain.
+
+## Next step
+
+Open the PR for #5999. Downstream issue #6006 can then transport ordered `nMatrix` row replacements to `nDet` minors using this identity.
+
+## Blockers
+
+- A pre-existing `.claude/CLAUDE.md` worktree modification remains untouched and is not part of this work.


### PR DESCRIPTION
Closes #5999

Session: `75b99bd2-dfbc-4791-b1e0-61e88d6c6def`

6b057f40 feat: add two-row replacement determinant bridge

🤖 Prepared with Claude Code