### PR TITLE
feat: expose ordered cofactor row pairings

### DIFF
--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -745,6 +745,72 @@ theorem nMatrix_ordered_four_setRow_p3_row_p2 {R : Type u} {n : Nat}
   · exact nMatrix_ordered_four_row_p2 B p1 p2 p3 q h12 h23 h3q
   · exact (ordered_four_row_p2_ne_p3 p1 p2 p3 q h12 h23 h3q).symm
 
+theorem ordered_four_cofactorRowPairing_p2_p1_eq_det_setRow
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    let M := Hex.Matrix.nMatrix B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q))
+    let r2 : Fin (n + 1) := ⟨p2.val - 1, by have := q.isLt; omega⟩
+    Hex.Matrix.cofactorRowPairing M r2 B[p1] =
+      Hex.Matrix.det (Hex.Matrix.setRow M r2 B[p1]) := by
+  intro M r2
+  exact (Hex.Matrix.det_setRow_eq_cofactorRowPairing M r2 B[p1]).symm
+
+theorem ordered_four_cofactorRowPairing_p3_p1_eq_det_setRow
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    let M := Hex.Matrix.nMatrix B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q))
+    let r3 : Fin (n + 1) := ⟨p3.val - 1, by have := q.isLt; omega⟩
+    Hex.Matrix.cofactorRowPairing M r3 B[p1] =
+      Hex.Matrix.det (Hex.Matrix.setRow M r3 B[p1]) := by
+  intro M r3
+  exact (Hex.Matrix.det_setRow_eq_cofactorRowPairing M r3 B[p1]).symm
+
+theorem ordered_four_cofactorRowPairing_p2_q_eq_det_setRow
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    let M := Hex.Matrix.nMatrix B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q))
+    let r2 : Fin (n + 1) := ⟨p2.val - 1, by have := q.isLt; omega⟩
+    Hex.Matrix.cofactorRowPairing M r2 B[q] =
+      Hex.Matrix.det (Hex.Matrix.setRow M r2 B[q]) := by
+  intro M r2
+  exact (Hex.Matrix.det_setRow_eq_cofactorRowPairing M r2 B[q]).symm
+
+theorem ordered_four_cofactorRowPairing_p3_q_eq_det_setRow
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    let M := Hex.Matrix.nMatrix B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q))
+    let r3 : Fin (n + 1) := ⟨p3.val - 1, by have := q.isLt; omega⟩
+    Hex.Matrix.cofactorRowPairing M r3 B[q] =
+      Hex.Matrix.det (Hex.Matrix.setRow M r3 B[q]) := by
+  intro M r3
+  exact (Hex.Matrix.det_setRow_eq_cofactorRowPairing M r3 B[q]).symm
+
+theorem ordered_four_det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    let M := Hex.Matrix.nMatrix B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q))
+    let r2 : Fin (n + 1) := ⟨p2.val - 1, by have := q.isLt; omega⟩
+    let r3 : Fin (n + 1) := ⟨p3.val - 1, by have := q.isLt; omega⟩
+    Hex.Matrix.det M *
+        Hex.Matrix.det (Hex.Matrix.setRow (Hex.Matrix.setRow M r2 B[p1]) r3 B[q]) =
+      Hex.Matrix.cofactorRowPairing M r2 B[p1] *
+          Hex.Matrix.cofactorRowPairing M r3 B[q] -
+        Hex.Matrix.cofactorRowPairing M r3 B[p1] *
+          Hex.Matrix.cofactorRowPairing M r2 B[q] := by
+  intro M r2 r3
+  exact det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub M r2 r3 B[p1] B[q]
+    (ordered_four_row_p2_ne_p3 p1 p2 p3 q h12 h23 h3q)
+
 /-- Reindex the `(k+2) × (k+2)` bordered minor so Desnanot-Jacobi deletes the
 Bareiss pivot row/column first and the trailing row/column last.
 

--- a/progress/20260601T164658Z_52c6ab1c.md
+++ b/progress/20260601T164658Z_52c6ab1c.md
@@ -1,0 +1,30 @@
+# 52c6ab1c - work #6064
+
+## Accomplished
+
+- Checked directive issues first; all directive candidates were dependency-blocked, so no directive work was taken.
+- Claimed #6064 as the active HexMatrixMathlib frontier from the normal unclaimed queue.
+- Added ordered four-row bridge lemmas in `HexMatrixMathlib/Determinant/Core.lean` that expose:
+  - the four `cofactorRowPairing` terms for rows `p2`/`p3` against `B[p1]`/`B[q]` as concrete `setRow` determinants;
+  - the ordered instantiation of `det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub` for `M = nMatrix B p1 q`, `r2 = p2.val - 1`, and `r3 = p3.val - 1`.
+- Verified with `lake build HexMatrixMathlib`, `git diff --check`, and a forbidden-token grep over the touched Lean diff.
+
+## Current frontier
+
+#6064 is partially complete. The ordered cofactor-pairing terms and the two-row replacement identity are now available in the row-indexed shape needed by the successor Plucker assembly, but the determinant transports from the resulting `setRow` determinants to signed `nDet` minors are still open.
+
+## Next step
+
+Prove the signed row-permutation transports:
+
+- `det (setRow M r2 B[p1])` to signed `nDet B p2 q`;
+- `det (setRow M r3 B[p1])` to signed `nDet B p3 q`;
+- `det (setRow M r2 B[q])` to signed `nDet B p1 p2`;
+- `det (setRow M r3 B[q])` to signed `nDet B p1 p3`;
+- `det (setRow (setRow M r2 B[p1]) r3 B[q])` to signed `nDet B p2 p3`.
+
+## Blockers
+
+- No technical blocker for the committed partial slice.
+- I attempted a generic finite row-move equivalence for the signed transports, but it was too brittle around unconstrained numeric parameters; a narrower permutation lemma specialized to each ordered move should be the next proof shape.
+- A pre-existing `.claude/CLAUDE.md` worktree modification remains untouched and is not part of this work.


### PR DESCRIPTION
Partial progress on #6064

Session: `52c6ab1c-49da-4a1b-afc0-0896ebf5cfcb`

621c6830 feat: expose ordered cofactor row pairings

🤖 Prepared with Claude Code