### PR TITLE
feat: add ordered q row nMatrix transport

### DIFF
--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -711,6 +711,64 @@ theorem nMatrix_ordered_four_row_p3 {R : Type u} {n : Nat}
   have hrow := skipIndex2_ordered_four_row_p3 p1 p2 p3 q h12 h23 h3q
   simp [hrow]
 
+theorem skipIndex2_ordered_four_p1_p2_row_q {n : Nat}
+    (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    Hex.Matrix.skipIndex2 p1 p2 h12
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1)) = q := by
+  apply Fin.ext
+  have hnot_lt : ¬ q.val - 2 < p1.val := by omega
+  have hnot_between : ¬ (q.val - 2) + 1 < p2.val := by omega
+  rw [Hex.Matrix.skipIndex2_val_of_ge_q p1 p2 h12
+    (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1)) hnot_lt hnot_between]
+  simp
+  omega
+
+theorem skipIndex2_ordered_four_p1_p3_row_q {n : Nat}
+    (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    Hex.Matrix.skipIndex2 p1 p3 (Nat.lt_trans h12 h23)
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1)) = q := by
+  apply Fin.ext
+  have hnot_lt : ¬ q.val - 2 < p1.val := by omega
+  have hnot_between : ¬ (q.val - 2) + 1 < p3.val := by omega
+  rw [Hex.Matrix.skipIndex2_val_of_ge_q p1 p3 (Nat.lt_trans h12 h23)
+    (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1)) hnot_lt hnot_between]
+  simp
+  omega
+
+theorem nMatrix_ordered_four_p1_p2_row_q {R : Type u} {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    (Hex.Matrix.nMatrix B p1 p2 h12)[
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))] = B[q] := by
+  apply Vector.ext
+  intro j hj
+  let jj : Fin (n + 1) := ⟨j, hj⟩
+  change (Hex.Matrix.nMatrix B p1 p2 h12)[
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))][jj] = B[q][jj]
+  rw [Hex.Matrix.nMatrix_entry]
+  have hrow := skipIndex2_ordered_four_p1_p2_row_q p1 p2 p3 q h12 h23 h3q
+  simp [hrow]
+
+theorem nMatrix_ordered_four_p1_p3_row_q {R : Type u} {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
+    (h3q : p3.val < q.val) :
+    (Hex.Matrix.nMatrix B p1 p3 (Nat.lt_trans h12 h23))[
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))] = B[q] := by
+  apply Vector.ext
+  intro j hj
+  let jj : Fin (n + 1) := ⟨j, hj⟩
+  change (Hex.Matrix.nMatrix B p1 p3 (Nat.lt_trans h12 h23))[
+        (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))][jj] = B[q][jj]
+  rw [Hex.Matrix.nMatrix_entry]
+  have hrow := skipIndex2_ordered_four_p1_p3_row_q p1 p2 p3 q h12 h23 h3q
+  simp [hrow]
+
 theorem ordered_four_row_p2_ne_p3 {n : Nat}
     (p1 p2 p3 q : Fin (n + 2)) (h12 : p1.val < p2.val)
     (h23 : p2.val < p3.val) (h3q : p3.val < q.val) :

--- a/progress/20260601T183541Z_816541a3.md
+++ b/progress/20260601T183541Z_816541a3.md
@@ -1,0 +1,25 @@
+# 816541a3 - work #6075 partial
+
+## Accomplished
+
+- Followed the worker flow and checked unclaimed directives first; all directive items were blocked.
+- Claimed #5413, verified that its prerequisite #5506 had been closed as stale, and released #5413 for replan because the unparameterized Schmeisser/de Bruijn-Springer source theorem expected by the issue is still absent.
+- Claimed #6075 after identifying it as the live predecessor for the #6076/#6012 Plucker bridge chain.
+- Added ordered `q`-row transport substrate in `HexMatrixMathlib/Determinant/Core.lean`:
+  - `skipIndex2_ordered_four_p1_p2_row_q`;
+  - `skipIndex2_ordered_four_p1_p3_row_q`;
+  - `nMatrix_ordered_four_p1_p2_row_q`;
+  - `nMatrix_ordered_four_p1_p3_row_q`.
+- Verified the partial change with `lake build HexMatrixMathlib`, `git diff --check`, and a forbidden-token grep over the touched Lean diff.
+
+## Current frontier
+
+#6075 is only partially complete. The remaining deliverable is the determinant-level cyclic row-permutation transport from `setRow (nMatrix B p1 q) ... B[q]` to the signed `nDet B p1 p2` and `nDet B p1 p3` minors.
+
+## Next step
+
+Prove the cyclic row permutation comparison using the new `q`-row lemmas plus the existing `matrixEquiv_setRow`, `det_eq`, and Mathlib determinant permutation lemmas.
+
+## Blockers
+
+No external blocker for the remaining #6075 proof. The main open work is the local sign-normalized determinant transport.


### PR DESCRIPTION
Partial progress on #6075

Session: `816541a3-c1ac-477f-8bec-b0356eee5894`

92342cd5 feat: add ordered q row nMatrix transport

🤖 Prepared with Claude Code