### PR TITLE
HexGFq: expose canonical Frobenius wrapper on GFq

### DIFF
--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -410,6 +410,22 @@ theorem ofPoly_eq_ofPoly_iff_reduceMod_eq
   rw [ofPoly_eq_ofPoly_iff_reduceMod_eq]
   exact GFqRing.reduceMod_idem (modulus h) f
 
+/-- The Frobenius endomorphism on the canonical Conway-backed field, computed
+as the `p`-th power on the underlying quotient representation. -/
+def frob {h : Conway.SupportedEntry p n} (x : GFq p n h) : GFq p n h :=
+  GFqField.frob x
+
+/-- `GFq.frob` is the `p`-th power map. -/
+theorem frob_eq_pow {h : Conway.SupportedEntry p n} (x : GFq p n h) :
+    frob x = x ^ p :=
+  rfl
+
+/-- The representative of `GFq.frob` is the quotient-ring `p`-th power
+representative. -/
+@[simp] theorem repr_frob {h : Conway.SupportedEntry p n} (x : GFq p n h) :
+    repr (frob x) = GFqRing.repr (x.toQuotient ^ p) :=
+  rfl
+
 end GFq
 
 /-- Optimized canonical binary field for committed Conway entries that have a

--- a/HexGFq/Conformance.lean
+++ b/HexGFq/Conformance.lean
@@ -99,6 +99,12 @@ example : 1 < 64 :=
 #guard GFq.repr (generic #[1, 1]) =
   GFqRing.reduceMod (GFq.modulus Entry21) (polyTwo #[1, 1])
 
+-- The Frobenius wrapper matches the inherited `p`-th power on the
+-- committed `GFq 2 1` entry and produces the expected representative.
+#guard genericReprNats (GFq.frob (generic #[1])) = [1]
+#guard genericReprNats (GFq.frob (generic #[0, 1])) = [1]
+#guard GFq.frob (generic #[0, 1]) = (generic #[0, 1]) ^ (2 : Nat)
+
 #guard coeffNats (GF2q.supportedEntry (n := 1)).poly = [1, 1]
 #guard Conway.luebeckConwayPolynomial? 2 1 =
   some (GF2q.supportedEntry (n := 1)).poly

--- a/progress/20260601T200133Z_c682344e.md
+++ b/progress/20260601T200133Z_c682344e.md
@@ -1,0 +1,45 @@
+# c682344e - work #6095
+
+## Accomplished
+
+- Claimed and executed feature issue #6095 (canonical Frobenius
+  wrapper on `GFq`).
+- Added three declarations to `HexGFq/Basic.lean` in the `GFq`
+  namespace, mirroring the existing `repr_pow`/`toQuotient_pow`
+  pattern:
+  - `GFq.frob` delegates to `GFqField.frob` for `x : GFq p n h`.
+  - `GFq.frob_eq_pow` (`rfl`) identifies the wrapper with the
+    inherited `x ^ p` map.
+  - `@[simp] GFq.repr_frob` (`rfl`) projects to the underlying
+    `GFqRing.repr (x.toQuotient ^ p)` quotient power
+    representative.
+- Skipped the optional `GFq.toQuotient_frob` projection lemma: the
+  existing `GFqField.toQuotient_frob` (already `@[simp, grind =]`)
+  fires on the same definitional shape, and `GFq` does not yet
+  expose its own `toQuotient_*` API surface.
+- Added narrow conformance guards to `HexGFq/Conformance.lean`
+  exercising the committed `GFq 2 1` entry:
+  - `GFq.frob` of `generic #[1]` and `generic #[0, 1]` produce the
+    expected reduced representatives;
+  - `GFq.frob (generic #[0, 1]) = (generic #[0, 1]) ^ (2 : Nat)`
+    confirms the wrapper matches the inherited `p`-th power on the
+    canonical surface.
+- Verified with `lake build HexGFq`, `lake build HexGFq.Conformance`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and a
+  forbidden-token grep over the diff.
+
+## Current frontier
+
+#6095 is complete and ready for PR. The canonical `GFq.frob`
+wrapper closes the Phase 6 API gap so consumers can use the
+Conway-backed surface without reaching through `GFqField.frob`.
+
+## Next step
+
+Open PR for #6095. The companion review issue #6096 (audit of the
+`GF2q ↔ GFq` equivalence surface) is independent and remains
+unclaimed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6095

Session: `c682344e-ccfc-4b76-a96d-c1efd68d7b95`

0f0bb76a feat: expose canonical GFq.frob wrapper on canonical Conway-backed field

🤖 Prepared with Claude Code