### PR TITLE
HexPolyZMathlib: replace invalid Boyd derivative-bound prerequisite after counterexample

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -743,6 +743,12 @@ theorem prod_max_one_norm_roots_robinsonForm_derivative_le
   rw [hderiv_prod]
   exact one_le_prod_max_one_norm_roots p
 
+/--
+Corrected Boyd boundary-comparison source theorem. Boundary equality and the
+closed-disk root hypothesis for `q` identify the right side as
+`q.natDegree * q.mahlerMeasure`; the additional hypothesis `hpderiv` is the
+necessary replacement for the invalid unconditional derivative Mahler bound.
+-/
 theorem mahlerMeasure_derivative_le_derivative_of_boundary_norm_eq_of_roots_le_one_of_derivative_le
     {p q : ℂ[X]}
     (hpderiv : p.derivative.mahlerMeasure ≤ p.natDegree * p.mahlerMeasure)

--- a/progress/20260601T203625Z_b0ac0424.md
+++ b/progress/20260601T203625Z_b0ac0424.md
@@ -1,0 +1,25 @@
+# b0ac0424 - work #6114
+
+## Accomplished
+
+- Read the latest progress note and used the `agent-worker-flow` process.
+- Claimed #6086, found it stale, and released it: its listed dependency #6088 was closed by decomposition, but child #6107 remains open and is still required for the closed SquareFree wrapper work.
+- Attempted to claim #6101, but coordination rejected it as dependency-blocked.
+- Claimed #6114 and verified that `HexPolyZMathlib/RobinsonForm.lean` already contains the corrected Boyd boundary-comparison theorem:
+  `mahlerMeasure_derivative_le_derivative_of_boundary_norm_eq_of_roots_le_one_of_derivative_le`.
+- Added a doc comment to that theorem explicitly recording the required replacement hypothesis `hpderiv`, so the file no longer reads like it is relying on the invalid unconditional derivative Mahler bound.
+- Verified with `lake build HexPolyZMathlib`, `python3 scripts/oracle/mahler_schur_counterexample.py`, `python3 scripts/check_dag.py`, `git diff --check`, and a forbidden-token diff grep over the touched Lean file.
+
+## Current frontier
+
+#6114 is complete as a source-theorem clarification: the valid replacement theorem is the existing boundary-comparison result with the added derivative-bound hypothesis on `p`.
+
+#6086 should remain replanned/blocked until #6107 lands. #6101 remains blocked on its live `nDet` substrate dependency.
+
+## Next step
+
+Create the PR for #6114. Downstream Robinson-form issues can consume the `_of_derivative_le` theorem or plan the separate proof obligation that supplies `hpderiv` in their specific context.
+
+## Blockers
+
+None for #6114. The pre-existing `.claude/CLAUDE.md` worktree change was left untouched and unstaged.


### PR DESCRIPTION
Closes #6114

Session: `b0ac0424-c3c0-4144-806b-19e9c401186d`

95325b3c docs: clarify Boyd boundary derivative replacement

🤖 Prepared with Claude Code