### PR TITLE
HexMatrix: prove cofactor-row two-row Plucker kernel

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -11010,5 +11010,263 @@ private theorem det_plucker_three_term_of_basisVec
     have hq := hbasis q
     grind
 
+/-! ### Two-row replacement determinant Plucker kernel
+
+The square-matrix two-row determinant Plucker identity: replacing distinct
+rows `a` and `b` of an `(n+1) × (n+1)` matrix `M` by vectors `u` and `v` is
+controlled by the cofactor-row pairings of `u` and `v` against the original
+cofactors of rows `a` and `b`. The proof routes through the single-column
+adjugate identity, computed by expanding the `(c, s)` entry of
+`adjugate (setRow M r u) * (setRow M r u * adjugate M)` in two ways. -/
+
+/-- Entry formula for matrix multiplication: the `(i, j)` entry of `A * B`
+is the `foldl`-sum of `A[i][l] * B[l][j]` over `l`. -/
+private theorem mul_apply_foldl
+    {R : Type u} [Lean.Grind.CommRing R] {n m k : Nat}
+    (A : Matrix R n m) (B : Matrix R m k) (i : Fin n) (j : Fin k) :
+    (A * B)[i][j] =
+      (List.finRange m).foldl
+        (fun acc l => acc + A[i][l] * B[l][j]) 0 := by
+  change (Matrix.mul A B)[i][j] = _
+  unfold Matrix.mul
+  rw [getElem_ofFn]
+  unfold Matrix.dot Hex.Vector.dotProduct
+  apply foldl_acc_congr
+  intro acc l _hmem
+  rw [row_getElem, col_getElem]
+
+/-- Row decomposition of `setRow M r u * adjugate M`: the `(i, s)` entry is
+the `cofactor-row pairing` of `M`'s row `s` against the (possibly replaced)
+row of `setRow M r u` at position `i`. -/
+private theorem setRow_mul_adjugate_apply_row
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) (r : Fin (n + 1)) (u : Vector R (n + 1))
+    (i s : Fin (n + 1)) :
+    (setRow M r u * adjugate M)[i][s] =
+      cofactorRowPairing M s ((setRow M r u)[i]) := by
+  rw [mul_apply_foldl]
+  unfold cofactorRowPairing
+  apply foldl_acc_congr
+  intro acc l _hmem
+  rw [adjugate_get]
+
+/-- The replaced row contributes the cofactor-row pairing of `u` against the
+`s`-row cofactors of the original matrix. -/
+private theorem setRow_mul_adjugate_apply_self
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) (r : Fin (n + 1)) (u : Vector R (n + 1))
+    (s : Fin (n + 1)) :
+    (setRow M r u * adjugate M)[r][s] = cofactorRowPairing M s u := by
+  rw [setRow_mul_adjugate_apply_row, setRow_get_self]
+
+/-- Non-replaced rows of `setRow M r u * adjugate M` reproduce the
+`M * adjugate M` structure: `det M` on the diagonal, zero off-diagonal. -/
+private theorem setRow_mul_adjugate_apply_ne
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) (r : Fin (n + 1)) (u : Vector R (n + 1))
+    (i s : Fin (n + 1)) (hir : i ≠ r) :
+    (setRow M r u * adjugate M)[i][s] = if i = s then det M else 0 := by
+  rw [setRow_mul_adjugate_apply_row, setRow_row_ne M r i u hir]
+  by_cases his : i = s
+  · subst his
+    rw [if_pos rfl]
+    exact cofactorRowPairing_self M i
+  · rw [if_neg his]
+    exact cofactorRowPairing_alien_eq_zero M i s his
+
+/-- Lift a bilinear "`det · f = a · g - b · h`" pointwise identity over a
+`foldl`-pairing against an arbitrary row weighting. This is the generic
+column-summation lemma used to assemble the two-row Plucker identity from
+the single-column adjugate identity. -/
+private theorem foldl_pairing_mul_sub
+    {R : Type u} [Lean.Grind.CommRing R] {β : Type v} (xs : List β)
+    (det a b accF accG accH : R) (row f g h : β → R)
+    (hacc : det * accF = a * accG - b * accH)
+    (hpoint : ∀ x, det * f x = a * g x - b * h x) :
+    det * xs.foldl (fun acc x => acc + row x * f x) accF =
+      a * xs.foldl (fun acc x => acc + row x * g x) accG -
+        b * xs.foldl (fun acc x => acc + row x * h x) accH := by
+  induction xs generalizing accF accG accH with
+  | nil => simpa using hacc
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      apply ih
+      have hx := hpoint x
+      calc
+        det * (accF + row x * f x) =
+            det * accF + row x * (det * f x) := by grind
+        _ = a * (accG + row x * g x) - b * (accH + row x * h x) := by
+            rw [hacc, hx]; grind
+
+/-- Single-column adjugate identity for a one-row replacement.
+
+For matrix `M`, distinct rows `r` and `s`, replacement row `u`, and column
+`c`, the determinant of `M` paired with the row-replaced cofactor at `(s, c)`
+decomposes as a bilinear difference of cofactor-row pairings against the
+original cofactors at rows `s` and `r`.
+
+The proof computes the `(c, s)` entry of
+`adjugate (setRow M r u) * (setRow M r u * adjugate M)` two ways: directly,
+by isolating the `i = r` and `i = s` terms, and via `mul_assoc` plus
+`adjugate_mul_apply`. -/
+private theorem det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1))
+    (r s c : Fin (n + 1)) (u : Vector R (n + 1)) (hrs : s ≠ r) :
+    det M * cofactor (setRow M r u) s c =
+      cofactorRowPairing M r u * cofactor M s c -
+        cofactorRowPairing M s u * cofactor M r c := by
+  -- Way 1: by `mul_assoc`, the `(c, s)` entry of
+  -- `adjugate (setRow M r u) * (setRow M r u * adjugate M)` equals the entry of
+  -- `(adjugate (setRow M r u) * setRow M r u) * adjugate M`. Then
+  -- `adjugate_mul_apply` reduces the inner factor to `if c = l then det
+  -- (setRow M r u) else 0`, and the remaining `foldl` extracts the `l = c` term.
+  have hway1 :
+      (adjugate (setRow M r u) * (setRow M r u * adjugate M))[c][s] =
+        det (setRow M r u) * cofactor M s c := by
+    rw [show adjugate (setRow M r u) * (setRow M r u * adjugate M) =
+            (adjugate (setRow M r u) * setRow M r u) * adjugate M
+            from (Hex.Matrix.mul_assoc (adjugate (setRow M r u)) (setRow M r u)
+              (adjugate M)).symm]
+    rw [mul_apply_foldl (adjugate (setRow M r u) * setRow M r u) (adjugate M) c s]
+    have hcongr :
+        (List.finRange (n + 1)).foldl
+            (fun acc l =>
+              acc + (adjugate (setRow M r u) * setRow M r u)[c][l] *
+                (adjugate M)[l][s]) 0 =
+          (List.finRange (n + 1)).foldl
+            (fun acc l =>
+              acc + if l = c then
+                det (setRow M r u) * cofactor M s l else 0) 0 := by
+      apply foldl_acc_congr
+      intro acc l _hmem
+      congr 1
+      rw [adjugate_mul_apply, adjugate_get]
+      by_cases hcl : c = l
+      · subst hcl
+        rw [if_pos rfl, if_pos rfl]
+      · have hlc : l ≠ c := fun h => hcl h.symm
+        rw [if_neg hcl, if_neg hlc]
+        grind
+    rw [hcongr]
+    have hmatch :=
+      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) c
+        (fun l => det (setRow M r u) * cofactor M s l)
+        (List.mem_finRange c) (List.nodup_finRange (n + 1))
+    rw [hmatch]
+    grind
+  -- Way 2: compute the same entry by unfolding the matrix product into a sum
+  -- over `i`. Decompose the body via `setRow_mul_adjugate_apply_self` / `_ne`
+  -- into two single-extract terms.
+  have hway2 :
+      (adjugate (setRow M r u) * (setRow M r u * adjugate M))[c][s] =
+        cofactor M r c * cofactorRowPairing M s u +
+          det M * cofactor (setRow M r u) s c := by
+    rw [mul_apply_foldl (adjugate (setRow M r u)) (setRow M r u * adjugate M) c s]
+    have hbody :
+        (List.finRange (n + 1)).foldl
+            (fun acc i =>
+              acc + (adjugate (setRow M r u))[c][i] *
+                (setRow M r u * adjugate M)[i][s]) 0 =
+          (List.finRange (n + 1)).foldl
+            (fun acc i =>
+              acc +
+                ((if i = r then
+                    (adjugate (setRow M r u))[c][i] *
+                      cofactorRowPairing M s u
+                  else 0) +
+                 (if i = s then
+                    (adjugate (setRow M r u))[c][i] * det M
+                  else 0))) 0 := by
+      apply foldl_acc_congr
+      intro acc i _hmem
+      congr 1
+      by_cases hir : i = r
+      · subst hir
+        have his_ne : i ≠ s := fun h => hrs h.symm
+        rw [setRow_mul_adjugate_apply_self M i u s, if_pos rfl, if_neg his_ne,
+          Lean.Grind.AddCommMonoid.add_zero]
+      · rw [setRow_mul_adjugate_apply_ne M r u i s hir, if_neg hir]
+        by_cases his : i = s
+        · subst his
+          rw [if_pos rfl, if_pos rfl, Lean.Grind.AddCommMonoid.zero_add]
+        · rw [if_neg his, if_neg his, Lean.Grind.Semiring.mul_zero,
+            Lean.Grind.AddCommMonoid.add_zero]
+    rw [hbody]
+    rw [foldl_det_sum_add_zero]
+    have hr_extract :=
+      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) r
+        (fun i => (adjugate (setRow M r u))[c][i] * cofactorRowPairing M s u)
+        (List.mem_finRange r) (List.nodup_finRange (n + 1))
+    have hs_extract :=
+      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) s
+        (fun i => (adjugate (setRow M r u))[c][i] * det M)
+        (List.mem_finRange s) (List.nodup_finRange (n + 1))
+    rw [hr_extract, hs_extract]
+    -- Beta-reduce the extracted lambdas.
+    show (0 : R) +
+        (adjugate (setRow M r u))[c][r] * cofactorRowPairing M s u +
+        ((0 : R) + (adjugate (setRow M r u))[c][s] * det M) =
+        cofactor M r c * cofactorRowPairing M s u +
+          det M * cofactor (setRow M r u) s c
+    rw [adjugate_get (setRow M r u) c r, adjugate_get (setRow M r u) c s]
+    have hcof_r : cofactor (setRow M r u) r c = cofactor M r c := by
+      unfold cofactor
+      rw [deleteRowCol_setRow_self M r c u]
+    rw [hcof_r]
+    rw [Lean.Grind.AddCommMonoid.zero_add, Lean.Grind.AddCommMonoid.zero_add,
+        Lean.Grind.CommSemiring.mul_comm (cofactor (setRow M r u) s c) (det M)]
+  -- Combine: hway1 = hway2 gives the desired identity after rearranging.
+  have hcombined :
+      det (setRow M r u) * cofactor M s c =
+        cofactor M r c * cofactorRowPairing M s u +
+          det M * cofactor (setRow M r u) s c :=
+    hway1.symm.trans hway2
+  rw [det_setRow_eq_cofactorRowPairing M r u] at hcombined
+  -- Rearrange `hcombined` to extract `det M * cofactor (setRow M r u) s c`.
+  -- From `Y = Z + X` derive `X = Y - Z`, where the subtracted term carries the
+  -- expected `cofactorRowPairing M s u * cofactor M r c` ordering via mul_comm.
+  rw [Lean.Grind.CommSemiring.mul_comm (cofactor M r c)
+        (cofactorRowPairing M s u)] at hcombined
+  -- hcombined: cofactorRowPairing M r u * cofactor M s c =
+  --   cofactorRowPairing M s u * cofactor M r c + det M * cofactor (setRow M r u) s c
+  rw [show
+      cofactorRowPairing M r u * cofactor M s c -
+        cofactorRowPairing M s u * cofactor M r c =
+      det M * cofactor (setRow M r u) s c from ?_]
+  rw [hcombined]
+  rw [Lean.Grind.AddCommMonoid.add_comm (cofactorRowPairing M s u * cofactor M r c)
+        (det M * cofactor (setRow M r u) s c)]
+  exact Lean.Grind.AddCommGroup.add_sub_cancel
+
+/-- Two-row replacement determinant Plucker kernel.
+
+For matrix `M : Matrix R (n+1) (n+1)`, distinct rows `a` and `b`, and
+replacement vectors `u`, `v`, the determinant of `M` paired with the
+two-row-replaced cofactor-row pairing satisfies the quadratic Sylvester
+relation against the four one-row cofactor-row pairings of `u` and `v`. -/
+theorem cofactorRowPairing_setRow_plucker
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)
+    (u v : Vector R (n + 1)) :
+    det M * cofactorRowPairing (setRow M a u) b v =
+      cofactorRowPairing M a u * cofactorRowPairing M b v -
+        cofactorRowPairing M a v * cofactorRowPairing M b u := by
+  -- The natural shape from `foldl_pairing_mul_sub` has `cofactorRowPairing M
+  -- b u * cofactorRowPairing M a v` for the subtracted product; commute to the
+  -- issue's stated form via `mul_comm` afterwards.
+  have hpre :
+      det M * cofactorRowPairing (setRow M a u) b v =
+        cofactorRowPairing M a u * cofactorRowPairing M b v -
+          cofactorRowPairing M b u * cofactorRowPairing M a v := by
+    unfold cofactorRowPairing
+    apply foldl_pairing_mul_sub
+    · grind
+    · intro c
+      exact det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub M a b c u
+        (fun h => hab h.symm)
+  rw [hpre]
+  grind
+
 end Matrix
 end Hex

--- a/progress/20260601T210449Z_aae58bd0.md
+++ b/progress/20260601T210449Z_aae58bd0.md
@@ -1,0 +1,56 @@
+# aae58bd0 - work #6111
+
+## Accomplished
+
+- Claimed and executed feature issue #6111 (cofactor-row two-row
+  Plucker kernel) after losing #6094 to a concurrent claimer.
+- Added the square-matrix two-row replacement determinant Plucker
+  kernel to `HexMatrix/Determinant.lean` with five new declarations:
+  - `mul_apply_foldl` — generic `foldl`-form entry formula for
+    matrix multiplication.
+  - `setRow_mul_adjugate_apply_row` — row-decomposition entry
+    formula for `setRow M r u * adjugate M` in
+    `cofactorRowPairing` form.
+  - `setRow_mul_adjugate_apply_self` — the replaced-row entry
+    carries `cofactorRowPairing M s u`.
+  - `setRow_mul_adjugate_apply_ne` — non-replaced rows behave like
+    `M * adjugate M` (`det M` on diagonal, `0` off-diagonal).
+  - `foldl_pairing_mul_sub` — generic foldl-lift for bilinear
+    `det · f = a · g - b · h` identities.
+  - `det_mul_cofactor_setRow_eq_cofactorRowPairing_mul_sub` — the
+    single-column adjugate identity (private), the hard proof
+    layer for the kernel.
+  - `cofactorRowPairing_setRow_plucker` — the issue's deliverable,
+    the bilinear two-row Plucker kernel.
+- Routed the proof through computing
+  `(adjugate (setRow M r u) * (setRow M r u * adjugate M))[c][s]`
+  two ways: via `mul_assoc` (reducing through
+  `adjugate_mul_apply N`) and via direct row decomposition using
+  `setRow_mul_adjugate_apply_self` and `_ne`. Equating the two
+  yields the single-column identity; the two-row foldl-lift then
+  delivers the kernel.
+- Verified with `lake build HexMatrix`, full `lake build`, and a
+  forbidden-token grep over the diff finding no added `sorry`,
+  `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+#6111 is complete and ready for PR. The kernel is the hard proof
+layer for parent #6103; a separate determinant wrapper can now
+consume the kernel via `det_setRow_eq_cofactorRowPairing` rewrites
+without re-doing the adjugate/associativity argument.
+
+## Next step
+
+Open PR for #6111. Successor for #6103 should be able to assemble
+the final determinant wrapper as a short composition.
+
+## Blockers
+
+- `grind` with linarith fails on `Vector.instIntModule.toZero ≠
+  instZeroOfOfNatOfNatNat` for several CommRing-only identities
+  (`0 + a`, `a + 0`, `a * 0`, `(a + b) - a`); explicit
+  `Lean.Grind.AddCommMonoid.{add,zero}_add`,
+  `Lean.Grind.Semiring.mul_zero`,
+  `Lean.Grind.AddCommGroup.add_sub_cancel`, and
+  `Lean.Grind.CommSemiring.mul_comm` rewrites work around it.


### PR DESCRIPTION
Closes #6111

Session: `aae58bd0-f00a-4346-b9d9-180a861464e9`

f0f6df4c feat: add two-row replacement determinant Plucker kernel (#6111)

🤖 Prepared with Claude Code