### PR TITLE
HexMatrixMathlib: assemble raw ordered four-row nDet Plucker kernel

### DIFF
--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -1862,6 +1862,110 @@ theorem ordered_four_signed_Plucker_p1_side
       h_double, h_p2_p1, h_p3_p1] at h_plucker
   exact h_plucker
 
+/-- Raw ordered four-row `nDet` Plucker kernel. For `p1 < p2 < p3 < q`, the
+canonical three-term Grassmann-Plucker identity holds among the six
+ordered `nDet` minors of `B`. The proof substitutes the q-side cofactor-row
+pairings in `ordered_four_signed_Plucker_p1_side` to obtain a
+fully-signed nDet identity, then cancels the common
+`(-1) ^ (p2.val - p1.val - 1 + (q.val - p3.val - 1))` factor by squaring it. -/
+theorem det_plucker_three_term_nDet_of_ordered_four
+    {R : Type u} [CommRing R] {n : Nat}
+    (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
+    (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (h3q : p3.val < q.val) :
+    Hex.Matrix.nDet B p2 p3 h23 *
+        Hex.Matrix.nDet B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)) -
+      Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) *
+          Hex.Matrix.nDet B p2 q (Nat.lt_trans h23 h3q) +
+      Hex.Matrix.nDet B p1 p2 h12 *
+        Hex.Matrix.nDet B p3 q h3q = 0 := by
+  have hp1 := ordered_four_signed_Plucker_p1_side B p1 p2 p3 q h12 h23 h3q
+  dsimp only at hp1
+  have hp2q :=
+    ordered_four_cofactorRowPairing_p2_q_eq_pow_mul_nDet B p1 p2 p3 q h12 h23 h3q
+  have hp3q :=
+    ordered_four_cofactorRowPairing_p3_q_eq_pow_mul_nDet B p1 p2 p3 q h12 h23 h3q
+  dsimp only at hp2q hp3q
+  rw [hp2q, hp3q] at hp1
+  -- After the rewrites, hp1 is
+  --   nDet p1 q * (e * nDet p2 p3) =
+  --     ((-1)^s12 * nDet p2 q) * ((-1)^s3q * nDet p1 p3) -
+  --     ((-1)^s13 * nDet p3 q) * ((-1)^s2q * nDet p1 p2)
+  -- with e := (-1)^(s12 + s3q) and s_ij := p_j.val - p_i.val - 1.
+  set s12 : Nat := p2.val - p1.val - 1 with hs12_def
+  set s13 : Nat := p3.val - p1.val - 1 with hs13_def
+  set s2q : Nat := q.val - p2.val - 1 with hs2q_def
+  set s3q : Nat := q.val - p3.val - 1 with hs3q_def
+  set e : R := (-1 : R) ^ (s12 + s3q) with he_def
+  -- Parity equivalence: (s13 + s2q) and (s12 + s3q) differ by 2 * (p3 - p2).
+  have hparity_diff : s13 + s2q = (s12 + s3q) + 2 * (p3.val - p2.val) := by
+    show (p3.val - p1.val - 1) + (q.val - p2.val - 1) =
+        ((p2.val - p1.val - 1) + (q.val - p3.val - 1)) + 2 * (p3.val - p2.val)
+    omega
+  have hparity_eq : (-1 : R) ^ (s13 + s2q) = e := by
+    rw [hparity_diff, pow_add, pow_mul, neg_one_sq, one_pow, mul_one]
+  -- (-1)^k * (-1)^k = 1.
+  have h_sq : e * e = 1 := by
+    show (-1 : R) ^ (s12 + s3q) * (-1 : R) ^ (s12 + s3q) = 1
+    rw [← pow_add, show (s12 + s3q) + (s12 + s3q) = 2 * (s12 + s3q) from
+        (Nat.two_mul (s12 + s3q)).symm, pow_mul, neg_one_sq, one_pow]
+  -- Repackage hp1 to expose `e` as a common factor on both sides.
+  -- LHS: nDet p1 q * (e * nDet p2 p3) = e * (nDet p1 q * nDet p2 p3)
+  -- RHS term 1: ((-1)^s12 * nDet p2 q) * ((-1)^s3q * nDet p1 p3)
+  --           = e * (nDet p2 q * nDet p1 p3)
+  -- RHS term 2: ((-1)^s13 * nDet p3 q) * ((-1)^s2q * nDet p1 p2)
+  --           = (-1)^(s13+s2q) * (nDet p3 q * nDet p1 p2)
+  --           = e * (nDet p3 q * nDet p1 p2)   (by hparity_eq)
+  have hp1' :
+      e *
+        (Hex.Matrix.nDet B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)) *
+          Hex.Matrix.nDet B p2 p3 h23) =
+      e *
+        (Hex.Matrix.nDet B p2 q (Nat.lt_trans h23 h3q) *
+            Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) -
+          Hex.Matrix.nDet B p3 q h3q * Hex.Matrix.nDet B p1 p2 h12) := by
+    have h_rhs_term1 :
+        ((-1 : R) ^ s12 * Hex.Matrix.nDet B p2 q (Nat.lt_trans h23 h3q)) *
+            ((-1 : R) ^ s3q *
+              Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23)) =
+          e *
+            (Hex.Matrix.nDet B p2 q (Nat.lt_trans h23 h3q) *
+              Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23)) := by
+      rw [he_def, pow_add]; ring
+    have h_rhs_term2 :
+        ((-1 : R) ^ s13 * Hex.Matrix.nDet B p3 q h3q) *
+            ((-1 : R) ^ s2q * Hex.Matrix.nDet B p1 p2 h12) =
+          e * (Hex.Matrix.nDet B p3 q h3q * Hex.Matrix.nDet B p1 p2 h12) := by
+      have : (-1 : R) ^ s13 * (-1 : R) ^ s2q = e := by
+        rw [← pow_add]; exact hparity_eq
+      calc
+        ((-1 : R) ^ s13 * Hex.Matrix.nDet B p3 q h3q) *
+            ((-1 : R) ^ s2q * Hex.Matrix.nDet B p1 p2 h12) =
+            ((-1 : R) ^ s13 * (-1 : R) ^ s2q) *
+              (Hex.Matrix.nDet B p3 q h3q * Hex.Matrix.nDet B p1 p2 h12) := by ring
+        _ = e * (Hex.Matrix.nDet B p3 q h3q * Hex.Matrix.nDet B p1 p2 h12) := by
+              rw [this]
+    have hp1_lhs :
+        Hex.Matrix.nDet B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)) *
+            (e * Hex.Matrix.nDet B p2 p3 h23) =
+          e *
+            (Hex.Matrix.nDet B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)) *
+              Hex.Matrix.nDet B p2 p3 h23) := by ring
+    rw [hp1_lhs, h_rhs_term1, h_rhs_term2, ← mul_sub] at hp1
+    exact hp1
+  -- Multiply both sides by e and use e * e = 1 to cancel.
+  have hp1_cancelled :
+      Hex.Matrix.nDet B p1 q (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)) *
+          Hex.Matrix.nDet B p2 p3 h23 =
+        Hex.Matrix.nDet B p2 q (Nat.lt_trans h23 h3q) *
+            Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) -
+          Hex.Matrix.nDet B p3 q h3q * Hex.Matrix.nDet B p1 p2 h12 := by
+    have hmul := congrArg (e * ·) hp1'
+    simp only at hmul
+    rw [← mul_assoc e e, ← mul_assoc e e, h_sq, one_mul, one_mul] at hmul
+    exact hmul
+  -- Rearrange to match the target via commutativity.
+  linear_combination hp1_cancelled
+
 /-- Reindex the `(k+2) × (k+2)` bordered minor so Desnanot-Jacobi deletes the
 Bareiss pivot row/column first and the trailing row/column last.
 

--- a/progress/20260601T213230Z_d747f670.md
+++ b/progress/20260601T213230Z_d747f670.md
@@ -1,0 +1,70 @@
+# d747f670 - work session (#5266 → #6107 → #6104 → #6012)
+
+## Accomplished
+
+- Tried claiming #5266 (HexPolyZMathlib integer transport) but skipped:
+  prerequisite #5318 was closed without delivering the unconditional
+  complex theorem `mahlerMeasure_derivative_le_natDegree_mul (p : ℂ[X])`.
+  PR #6117 (closing the replacement #6114) added only docs clarifications.
+  Left a stale-dependency replan note pointing at the missing source
+  theorem.
+- Tried claiming #6107 (HexPolyFp derivative-active Yun state provider)
+  but the requested raw 4-fact closed shape is provably false (the
+  #6115 counterexample shows the initial-split `w = gcd(f, f')` can be a
+  non-1 constant). #6116 already delivered the normalized closed
+  provider `yunFactorsDerivativeActiveReachable_normalized_stateProvider`;
+  the residual work is a consumer refactor across five private
+  provider-parametric lemmas in `HexPolyFp/SquareFree.lean`. Decomposed
+  into #6119 (scoped refactor) and skipped #6107 with the breadcrumb.
+- Tried claiming #6104 (HexMatrix ordered row-replacement transports) but
+  skipped: predecessor #6103 was decomposed into #6111 + #6112, and the
+  exact sign/order normalizations required by the transports depend on
+  #6112's wrapper shape, which is blocked on #6111 (PR #6118 still in
+  CI). Left a replan note re-blocking #6104 on #6112.
+- Claimed #6012 (HexMatrixMathlib raw ordered four-row nDet Plucker
+  kernel) and shipped the assembly: added
+  `det_plucker_three_term_nDet_of_ordered_four` to
+  `HexMatrixMathlib/Determinant/Core.lean` immediately after
+  `ordered_four_signed_Plucker_p1_side`.
+- The proof substitutes the q-side cofactor-row pairings
+  (`ordered_four_cofactorRowPairing_p2_q_eq_pow_mul_nDet`,
+  `ordered_four_cofactorRowPairing_p3_q_eq_pow_mul_nDet`) into
+  `ordered_four_signed_Plucker_p1_side` to obtain a fully-signed nDet
+  identity, then cancels the common
+  `(-1)^(p2-p1-1 + (q-p3-1))` factor by multiplying both sides by it
+  and using `((-1)^k)^2 = 1`. The parity equivalence
+  `(-1)^(s13+s2q) = (-1)^(s12+s3q)` (since they differ by `2*(p3-p2)`)
+  matches the sign on the second RHS term to the common factor.
+- Verified with `lake build HexMatrixMathlib.Determinant.Core`,
+  full `lake build`, `python3 scripts/check_dag.py`, `git diff --check`,
+  and a forbidden-token grep finding no added `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+- #6012 is ready for PR. The kernel `det_plucker_three_term_nDet_of_ordered_four`
+  is exported through `HexMatrixMathlib.Determinant` transitively via
+  `HexMatrixMathlib.Determinant.Core` (no extra re-export needed since
+  the theorem is non-private).
+- The downstream Plucker integration issue (the Hex-side bridge that
+  wires this into `det_plucker_three_term_basisVec_of_gt_p3_of_nDet`)
+  is left to a separate planner cycle; the issue notes that no
+  pre-existing bridge surface needs updating here.
+
+## Next step
+
+- A planner cycle should triage the three replan notes (#5266, #6107,
+  #6104) and the new sub-issue #6119.
+- Downstream of this PR: the canonical raw four-row nDet Plucker
+  identity is now available on `HexMatrixMathlib` for any consumer
+  that needs to instantiate the universal three-term identity from the
+  bridge layer. The basis-vector wrapping in
+  `HexMatrix/Determinant.lean` (`det_plucker_three_term_basisVec_of_gt_p3_of_nDet`)
+  is the natural next consumer once a Mathlib-free transport is
+  desired.
+
+## Blockers
+
+None for the landed #6012 work. Pre-existing unrelated
+`.claude/CLAUDE.md` worktree modification (pod's session setup) left
+untouched.


### PR DESCRIPTION
Closes #6012

Session: `d747f670-6f4c-4686-9d71-33f35e10c7c9`

15400997 HexMatrixMathlib: assemble raw ordered four-row nDet Plucker kernel

🤖 Prepared with Claude Code