### PR TITLE
HexMatrix: wrap cofactor Plucker as two-row setRow determinant identity

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -11268,5 +11268,20 @@ theorem cofactorRowPairing_setRow_plucker
   rw [hpre]
   grind
 
+/-- Two-row replacement determinant Plucker identity. -/
+theorem det_setRow_setRow_mul_det
+    {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) (a b : Fin (n + 1)) (hab : a ≠ b)
+    (u v : Vector R (n + 1)) :
+    det M * det (setRow (setRow M a u) b v) =
+      det (setRow M a u) * det (setRow M b v) -
+        det (setRow M a v) * det (setRow M b u) := by
+  rw [det_setRow_eq_cofactorRowPairing (setRow M a u) b v,
+    det_setRow_eq_cofactorRowPairing M a u,
+    det_setRow_eq_cofactorRowPairing M b v,
+    det_setRow_eq_cofactorRowPairing M a v,
+    det_setRow_eq_cofactorRowPairing M b u]
+  exact cofactorRowPairing_setRow_plucker M a b hab u v
+
 end Matrix
 end Hex

--- a/progress/20260601T215220Z_efc5ce69.md
+++ b/progress/20260601T215220Z_efc5ce69.md
@@ -1,0 +1,23 @@
+# efc5ce69 - work #6112
+
+## Accomplished
+
+- Claimed and completed feature issue #6112.
+- Added `Matrix.det_setRow_setRow_mul_det` in `HexMatrix/Determinant.lean`.
+  The theorem rewrites the two-row and one-row replacement determinants to
+  `cofactorRowPairing` form and applies `cofactorRowPairing_setRow_plucker`.
+- Verified with `lake build HexMatrix`, `python3 scripts/check_dag.py`,
+  `git diff --check`, and a forbidden-token grep over the touched Lean diff.
+
+## Current frontier
+
+The public square determinant two-row replacement wrapper is now available for
+downstream Matrix Plucker specialization work.
+
+## Next step
+
+Proceed to the blocked successor issue #6104 once this PR lands.
+
+## Blockers
+
+None for #6112.


### PR DESCRIPTION
Closes #6112

Session: `efc5ce69-8dbf-4765-8c59-6fa2b7f3ff98`

783beb95 feat: add two-row replacement determinant wrapper

🤖 Prepared with Claude Code