### PR TITLE
HexPolyZMathlib: add narrowed derivative Mahler source

### DIFF
--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -591,6 +591,21 @@ theorem mahlerMeasure_derivative_eq_natDegree_mul_of_roots_le_one
     exact mahlerMeasure_eq_norm_leadingCoeff_of_roots_le_one hroots
   rw [hMM_deriv, hlead_deriv, norm_mul, Complex.norm_natCast, ← hMM_p, mul_comm]
 
+theorem mahlerMeasure_derivative_map_intCast_le_of_roots_le_one
+    (f : Polynomial ℤ)
+    (hroots : ∀ α ∈ (f.map (Int.castRingHom ℂ)).roots, ‖α‖ ≤ 1) :
+    (f.derivative.map (Int.castRingHom ℂ)).mahlerMeasure ≤
+      f.natDegree * (f.map (Int.castRingHom ℂ)).mahlerMeasure := by
+  have hcomplex :=
+    mahlerMeasure_derivative_eq_natDegree_mul_of_roots_le_one
+      (f.map (Int.castRingHom ℂ)) hroots
+  rw [derivative_map] at hcomplex
+  rw [hcomplex]
+  exact mul_le_mul_of_nonneg_right
+    (Nat.cast_le.mpr
+      (natDegree_map_le (p := f) (f := Int.castRingHom ℂ)))
+    (mahlerMeasure_nonneg _)
+
 theorem Multiset.prod_le_of_sum_log_le {s t : Multiset ℝ}
     (hs : ∀ x ∈ s, 0 < x) (ht : ∀ x ∈ t, 0 < x)
     (hlog : (s.map fun x => Real.log x).sum ≤ (t.map fun x => Real.log x).sum) :

--- a/progress/20260601T215810Z_aead6454.md
+++ b/progress/20260601T215810Z_aead6454.md
@@ -1,0 +1,30 @@
+# aead6454 - work #6121
+
+## Accomplished
+
+- Claimed feature issue #6121 after blocked directive claims (#2637, #2567,
+  #2564) were rejected by `coordination claim`.
+- Added
+  `Polynomial.mahlerMeasure_derivative_map_intCast_le_of_roots_le_one` in
+  `HexPolyZMathlib/RobinsonForm.lean`.
+- The theorem gives the exact integer-cast derivative shape
+  `(f.derivative.map (Int.castRingHom ℂ)).mahlerMeasure ≤
+   f.natDegree * (f.map (Int.castRingHom ℂ)).mahlerMeasure`, under the explicit
+  closed-unit-disk root hypothesis on `f.map (Int.castRingHom ℂ)`.
+- Verified with `lake build HexPolyZMathlib`, `lake build`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and a forbidden-token
+  scan over the touched Lean diff.
+
+## Current frontier
+
+#6121 is complete as a narrowed, valid source theorem. It deliberately does not
+restore the invalid unconditional global derivative Mahler bound.
+
+## Next step
+
+Use this theorem in #5266 only when the required closed-unit-disk root
+hypothesis is available, or narrow #5266 to carry that hypothesis explicitly.
+
+## Blockers
+
+None for #6121.


### PR DESCRIPTION
Closes #6121

Session: `aead6454-7ba7-4f49-84bc-4c8383d23e20`

5a0696dd HexPolyZMathlib: add narrowed derivative Mahler source

🤖 Prepared with Claude Code