### PR TITLE
HexMatrix Phase 6: add public Matrix.spanCoeffs_sound wrapper

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -2936,6 +2936,13 @@ def spanCoeffs [Lean.Grind.Field R] [DecidableEq R] (M : Matrix R n m) (v : Vect
   let E := (rref_isRREF M).toIsEchelonForm
   E.spanCoeffs v
 
+/-- Wrapper-layer soundness contract for `Matrix.spanCoeffs`. -/
+theorem spanCoeffs_sound [Lean.Grind.Field R] [DecidableEq R]
+    (M : Matrix R n m) (v : Vector R m) (c : Vector R n) :
+    spanCoeffs M v = some c → rowCombination M c = v := by
+  intro h
+  exact (rref_isRREF M).toIsEchelonForm.spanCoeffs_sound v c h
+
 /-- Convenience wrapper: decide row-span membership using `rref` internally. -/
 def spanContains [Lean.Grind.Field R] [DecidableEq R] (M : Matrix R n m) (v : Vector R m) :
     Bool :=

--- a/progress/20260601T221248Z_41d39ce9.md
+++ b/progress/20260601T221248Z_41d39ce9.md
@@ -1,0 +1,27 @@
+# 41d39ce9 - work #6131
+
+## Accomplished
+
+- Claimed feature issue #6131.
+- Added public theorem `Matrix.spanCoeffs_sound` in `HexMatrix/RREF.lean`,
+  forwarding the wrapper-level `Matrix.spanCoeffs M v = some c` result to
+  `(rref_isRREF M).toIsEchelonForm.spanCoeffs_sound`.
+- Confirmed there were no current consumers routing through the internal
+  `IsEchelonForm.spanCoeffs_sound` theorem for this wrapper case.
+- Verified with `lake build HexMatrix`, `lake build`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and a forbidden-token
+  diff grep over `HexMatrix/RREF.lean`.
+
+## Current frontier
+
+#6131 is complete. `Matrix.spanCoeffs` now has a named public soundness
+contract matching the natural caller-facing theorem shape.
+
+## Next step
+
+Create the PR for #6131. The remaining Phase 6 RREF wrapper follow-up in the
+current unclaimed queue is #6132.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6131

Session: `41d39ce9-fd83-4c8e-aa5a-7019d626f24b`

433be86a feat: add spanCoeffs soundness wrapper

🤖 Prepared with Claude Code