### PR TITLE
spec: relocate isIrreducible_iff and Decidable instance to the BZ Mathlib bridge

### DIFF
--- a/SPEC/Libraries/hex-berlekamp-zassenhaus-mathlib.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus-mathlib.md
@@ -57,6 +57,30 @@ Mathlib's) are propositionally identical when phrased over the
 respective unit predicates; the bridge unfolds both sides and
 rewrites `IsUnit` and `(· * ·)` through `toPolynomial`.
 
+**Correctness of the executable checker.** The biconditional linking
+the Mathlib-free `isIrreducible` *checker* to the `Irreducible`
+*class* lives here, not in `hex-berlekamp-zassenhaus`, because it is
+equivalent to the full forward correctness of `factor` (Group C; see
+that library's §`Mathlib-free Hex.ZPoly.Irreducible class` for why a
+Mathlib-free file cannot state it):
+
+```lean
+theorem Hex.ZPoly.isIrreducible_iff (f : ZPoly) :
+    Hex.ZPoly.isIrreducible f = true ↔ Hex.ZPoly.Irreducible f
+
+instance (f : ZPoly) : Decidable (Hex.ZPoly.Irreducible f) :=
+  decidable_of_iff _ (Hex.ZPoly.isIrreducible_iff f)
+```
+
+The forward direction follows from C1 (`factor f` is the irreducible
+factorisation): a single primitive unit-scalar factor of multiplicity
+one is `f` itself up to a unit, and completeness of `factor` rules out
+any finer decomposition. The backward direction is the converse. The
+constant case reduces to `Nat.Prime` decidability. This is the only
+route to `decide`-ing `Hex.ZPoly.Irreducible` for concrete inputs;
+Mathlib-free consumers (e.g. `HexNumberField`) must instead thread
+`[Hex.ZPoly.Irreducible p]` as an instance argument.
+
 Also connects to Mathlib's `Polynomial ℤ` and provides
 `Decidable (Irreducible f)` for `f : Polynomial ℤ`.
 

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -176,14 +176,33 @@ def isIrreducible (f : ZPoly) : Bool :=
     φ.factors.size == 1 &&
     decide ((φ.factors.get! 0).snd = 1)
 
-theorem isIrreducible_iff (f : ZPoly) :
-    isIrreducible f = true ↔ Irreducible f
-
-instance (f : ZPoly) : Decidable (Irreducible f) :=
-  decidable_of_iff _ (isIrreducible_iff f)
-
 end Hex.ZPoly
 ```
+
+This library provides the `Irreducible` *class* and the executable
+`isIrreducible` *checker* only. It deliberately does **not** state
+`isIrreducible f = true ↔ Irreducible f`, nor derive
+`Decidable (Irreducible f)` from it.
+
+The reason is a library-layering fact, not an oversight: that
+biconditional is logically equivalent to the full forward
+correctness of `factor` (its forward direction asserts the checker's
+single-factor verdict implies genuine irreducibility — i.e. `factor`
+found *every* factor; its backward direction asserts an irreducible
+input yields exactly one factor). That correctness is the Group A/B/C
+capstone, and the SPEC assigns those proofs to the Mathlib bridge
+(they cite `Polynomial.UniqueFactorizationMonoid`, `hensels_lemma`,
+and `Polynomial.Gauss`; see `Slow-path correctness sketch (in-bridge
+proof)` and the Group C obligations below). A Mathlib-free file
+cannot import the bridge, so the biconditional cannot be proved here.
+
+Therefore `Hex.ZPoly.isIrreducible_iff` and the
+`Decidable (Hex.ZPoly.Irreducible f)` instance it backs live in
+`hex-berlekamp-zassenhaus-mathlib`. This library exposes the class
+(so downstream Mathlib-free APIs such as `NumberField.Inv` can take
+`[Hex.ZPoly.Irreducible p]` as an instance argument) and the
+executable checker (pure computation, no proof obligation); it does
+not claim the checker is *correct*.
 
 `Irreducible 0 = False` is explicit by the `not_zero` clause; the
 boolean checker returns `false` on zero input. The constant-case
@@ -423,7 +442,7 @@ B9. **Conditional correctness of `factorFast`.** `factorFast f = some gs ⟹ gs 
 C1. **`factor` unconditional correctness.** `factor f = irreducibleFactorisationOf f`.
     *Sketch:* `factor f` unfolds to `factorWithBound f (defaultFactorCoeffBound f) = (factorFastWithBound f B₀).getD (factorSlowWithBound f B₀)` for `B₀ := defaultFactorCoeffBound f`. Case analysis on the fast attempt at bound `B₀`: when it returns `some gs`, B9 (specialised to the bounded variant) gives the irreducible factorisation; when it returns `none`, A5 (via A4 squarefree-core) gives `factorSlowWithBound f B₀ = irreducibleFactorisationOf f`. The unboundedly-correct entry point `factorFast f := factorFastWithBound f (factorFastPrecisionCap f)` is not on `factor`'s correctness path; its conditional-correctness theorem is a separate Group B obligation (B9 above).
 
-C2. **Public-API contracts** (`factor_product_of_bound`, `checkIrreducibleCert_sound`, `Decidable (Irreducible f)`) follow from C1.
+C2. **Public-API contracts** (`factor_product_of_bound`, `checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`).
 
 The conditional correctness contract `factor_product_of_bound`:
 ```lean

--- a/SPEC/Libraries/hex-number-field.md
+++ b/SPEC/Libraries/hex-number-field.md
@@ -112,9 +112,16 @@ instance [Hex.ZPoly.Irreducible p] : Field (NumberField p x) := ...
 ```
 
 Users with a specific irreducibility proof `h : Hex.ZPoly.Irreducible
-myPoly` register it once via `haveI := h` (or `decide` for concrete
-polynomials), and `x⁻¹` notation works on subsequent `NumberField myPoly y`
-values.
+myPoly` register it once via `haveI := h`, and `x⁻¹` notation works on
+subsequent `NumberField myPoly y` values. Discharging the instance by
+`decide` requires the `Decidable (Hex.ZPoly.Irreducible f)` instance,
+which is Mathlib-grade (it is backed by `Hex.ZPoly.isIrreducible_iff`,
+equivalent to full `factor` correctness) and so lives in
+`hex-berlekamp-zassenhaus-mathlib`. The `decide` shortcut is therefore
+available only when that bridge is imported — i.e. in
+`HexNumberFieldMathlib`, not in this Mathlib-free library. Here the
+instance must be supplied as a threaded `[Hex.ZPoly.Irreducible p]`
+argument.
 
 Numerical evaluation uses the threading pattern from `hex-roots.md`:
 

--- a/progress/20260602T001519Z.md
+++ b/progress/20260602T001519Z.md
@@ -1,0 +1,42 @@
+# Relocate isIrreducible_iff to the Mathlib bridge
+
+## Accomplished
+Diagnosed why directive #2637 (a Mathlib-free `HexBerlekampZassenhaus`
+issue) has been stuck under `blocked` indefinitely: its residual
+`isIrreducible_iff` proof obligation was specified in the Mathlib-free
+library SPEC, but that biconditional is equivalent to full `factor`
+correctness (Group C), which the SPEC itself assigns to the Mathlib
+bridge. The dependency chain #2637 → #4818 → #4825 → {#4680, #2567}
+therefore had a Mathlib-free issue (#4825) declaring `depends-on` on
+bridge issues — an impossible edge, since a Mathlib-free Lean file
+cannot import the bridge.
+
+SPEC PR (3 files) relocating the obligation to where it can legally be
+proved:
+- `hex-berlekamp-zassenhaus.md`: dropped `isIrreducible_iff` +
+  `Decidable` from the Mathlib-free block; kept the `Irreducible`
+  class and `isIrreducible` checker; documented the layering reason.
+  Updated C2 to name the bridge as the home of the instance.
+- `hex-berlekamp-zassenhaus-mathlib.md`: added `isIrreducible_iff` +
+  `Decidable (Hex.ZPoly.Irreducible f)`, derived from C1.
+- `hex-number-field.md`: re-qualified the `decide`-for-concrete
+  shortcut as a `HexNumberFieldMathlib`-only capability.
+
+Confirmed the relocation breaks no Mathlib-free call site: the sole
+Mathlib-free reference to `Decidable (Irreducible f)` is the instance
+definition itself (`HexBerlekampZassenhaus/Basic.lean:7383`).
+
+## Current frontier
+SPEC PR pushed. Implementation issue filed (code move:
+`isIrreducible_iff` + `instDecidableIrreducible` from
+`HexBerlekampZassenhaus/Basic.lean:7378-7384` into the bridge).
+Graph cleanup: #4818/#4825 re-homed to the bridge; #2637 closed as
+superseded.
+
+## Next step
+Land the SPEC PR, then do the code move under the implementation
+issue. `choosePrimeData?_isSome` (Basic.lean:2063) remains a genuinely
+Mathlib-free residual, separate from this work.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR moves the `Hex.ZPoly.isIrreducible_iff` biconditional and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs out of the Mathlib-free `hex-berlekamp-zassenhaus` SPEC and into the `hex-berlekamp-zassenhaus-mathlib` bridge, where they belong. The biconditional is logically equivalent to the full forward correctness of `factor` (the Group A/B/C capstone), and the SPEC already assigns that correctness to the bridge — it cites `Polynomial.UniqueFactorizationMonoid`, `hensels_lemma`, and `Polynomial.Gauss`. A Mathlib-free file cannot import the bridge, so the obligation was unprovable where it was stated.

This mis-placement was not harmless: it produced an impossible dependency edge. The chain #2637 → #4818 → #4825 → {#4680, #2567} had a Mathlib-free issue (#4825, editing a file with zero Mathlib imports) declaring `depends-on` on bridge issues. Because that edge can never clear, directive #2637 (about a Mathlib-free library) sat under `blocked` indefinitely on Mathlib work — the dependency inversion that should be structurally impossible.

The Mathlib-free library keeps exactly what it can support: the `Irreducible` class (so `NumberField.Inv` can take `[Hex.ZPoly.Irreducible p]` as an instance argument) and the executable `isIrreducible` checker (pure computation, no proof obligation). It no longer claims the checker is correct. The `decide`-for-concrete-polynomials shortcut in `hex-number-field` is re-qualified as a `HexNumberFieldMathlib`-only capability, since deciding irreducibility is Mathlib-grade.

The companion implementation issue moves the corresponding `theorem`/`instance` in code (`HexBerlekampZassenhaus/Basic.lean:7378-7384` → the bridge file), and the issue graph is re-homed so the inverted edges become legal bridge→bridge edges.

🤖 Prepared with Claude Code