### PR TITLE
HexPolyFp: normalize Yun gcd transition for derivative-active monic invariant

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -7475,6 +7475,50 @@ private theorem yunFactorsDerivativeActiveReachable_normalized_stateProvider
   have hw := normalizeMonic_squareFreeContributionPayload hp w hnonzero.2
   exact ⟨hc.1, hc.2, hw.1, hw.2⟩
 
+/--
+Normalized gcd monicity for the Yun derivative-active transition. Whenever the
+right gcd operand is nonzero, the normalized gcd value
+`(normalizeMonic (DensePoly.gcd c w)).2` is monic.
+
+The raw executable `DensePoly.gcd c w` is not in general monic even when
+`c, w` are monic: over `F_5`, `gcd (x^2 + 1) (x + 1)` follows an Euclidean
+remainder path and returns the constant `2`, not a monic value. So the gcd
+side of the Yun derivative-active monic invariant tracked in #6155 must route
+through the normalized gcd value rather than the raw output.
+-/
+private theorem normalizeMonic_gcd_monic_of_right_nonzero
+    [ZMod64.PrimeModulus p] (c w : FpPoly p)
+    (hw : w.isZero = false) :
+    DensePoly.Monic (normalizeMonic (DensePoly.gcd c w)).2 :=
+  normalizeMonic_nonzero_monic (DensePoly.gcd c w)
+    (gcd_isZero_false_of_right_isZero_false c w hw)
+
+/--
+Normalized monicity at every Yun derivative-active reachable state. From the
+reachability hypothesis, `(normalizeMonic c).2`, `(normalizeMonic w).2`, and
+the next-step normalized gcd `(normalizeMonic (DensePoly.gcd c w)).2` are all
+monic.
+
+This is the gcd-side substrate for the residual monic invariant tracked in
+#6155. Combined with the exact-quotient lemmas from #6164
+(`monic_div_gcd_left_of_monic`, `monic_div_gcd_right_of_monic`), the
+derivative-active induction step can dispatch monicity at the normalized state
+without asserting raw executable gcd monicity.
+-/
+private theorem yunFactorsDerivativeActiveReachable_normalizeMonic_monic
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p)
+    (f c w : FpPoly p) (fuel : Nat)
+    (hreachable : yunFactorsDerivativeActiveReachable hp f c w fuel) :
+    DensePoly.Monic (normalizeMonic c).2 ∧
+      DensePoly.Monic (normalizeMonic w).2 ∧
+        DensePoly.Monic (normalizeMonic (DensePoly.gcd c w)).2 := by
+  have hnonzero :=
+    yunFactorsDerivativeActiveReachable_nonzero hp f c w fuel hreachable
+  exact
+    ⟨normalizeMonic_nonzero_monic c hnonzero.1,
+      normalizeMonic_nonzero_monic w hnonzero.2,
+      normalizeMonic_gcd_monic_of_right_nonzero c w hnonzero.2⟩
+
 private theorem normalizeMonic_zero_squareFree_weightedProduct
     (hp : Hex.Nat.Prime p) (f : FpPoly p)
     (hzero : (normalizeMonic f).2.isZero = true) :

--- a/progress/20260602T004027Z_2ab83e57.md
+++ b/progress/20260602T004027Z_2ab83e57.md
@@ -1,0 +1,46 @@
+# Phase 6: normalized gcd monicity substrate for Yun derivative-active step (issue #6170)
+
+## Accomplished
+
+- Added two private lemmas in `HexPolyFp/SquareFree.lean`, placed right
+  after `yunFactorsDerivativeActiveReachable_normalized_stateProvider`
+  (line 7476 in the pre-change file):
+  - `normalizeMonic_gcd_monic_of_right_nonzero`: from a nonzero right gcd
+    operand, the normalized gcd value `(normalizeMonic (DensePoly.gcd c w)).2`
+    is monic. Direct corollary of `normalizeMonic_nonzero_monic` and
+    `gcd_isZero_false_of_right_isZero_false`.
+  - `yunFactorsDerivativeActiveReachable_normalizeMonic_monic`: from a
+    reachable Yun derivative-active state, the normalized `c`, normalized `w`,
+    and the normalized gcd `(normalizeMonic (DensePoly.gcd c w)).2` are all
+    monic. Uses `yunFactorsDerivativeActiveReachable_nonzero` to extract the
+    nonzero hypotheses.
+
+## Current frontier
+
+- Picks up issue shape (b)/(c) from #6170's deliverable: keep the executable
+  Yun transition unchanged, supply state lemmas that introduce
+  `normalizeMonic <gcd output>` at the points #6155 needs monic gcd/divisor
+  facts. The raw `DensePoly.gcd c w` is provably not monic in general
+  (F_5 counterexample preserved by the prior #6163 skip), so the gcd side of
+  the #6155 induction routes through the normalized value instead.
+- Combined with #6164's exact-quotient lemmas
+  (`monic_div_gcd_left_of_monic`, `monic_div_gcd_right_of_monic`), the
+  normalized monicity now available at every reachable state forms the
+  Phase 6 substrate needed by the #6155 derivative-active monic invariant.
+
+## Next step
+
+#6155 (currently `blocked` on this and #6164, which has merged): a follow-up
+session can pick up #6155 and prove the derivative-active monic invariant in
+its normalized form using the new state-monicity lemma together with the
+exact-quotient lemmas. Note that the literal `yunFactorsDerivativeActiveReachable_monic`
+shape in #6155's body asserts raw monicity of `c` and `w`, which by the
+preserved F_5 counterexample cannot hold for raw values; the next planner
+or the worker on #6155 may need to refine the invariant statement to the
+normalized form before the induction goes through.
+
+## Blockers
+
+None. `lake build HexPolyFp` is green, `python3 scripts/check_dag.py` is
+clean, `git diff --check` is clean, and no forbidden tokens (`sorry`,
+`axiom`, `native_decide`, `TODO`, `FIXME`) were introduced.


### PR DESCRIPTION
Closes #6170

Session: `2ab83e57-250b-4bfe-8a53-17cc61c60fc5`

80e5fb0b feat: add normalized gcd monicity substrate for Yun derivative-active step

🤖 Prepared with Claude Code