### PR TITLE
refactor: relocate Hex.ZPoly.isIrreducible_iff + Decidable instance to the BZ Mathlib bridge

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7376,13 +7376,6 @@ def isIrreducible (f : ZPoly) : Bool :=
       | [entry] => decide (entry.2 = 1)
       | _ => false
 
-theorem isIrreducible_iff (f : ZPoly) :
-    isIrreducible f = true ↔ Irreducible f := by
-  sorry
-
-instance instDecidableIrreducible (f : ZPoly) : Decidable (Irreducible f) :=
-  decidable_of_iff _ (isIrreducible_iff f)
-
 /-- A polynomial of dense size `1` is the constant polynomial of its zeroth
 coefficient. The trimming invariant on `DensePoly` forces the single stored
 coefficient to be nonzero, so `coeff 0` already names the unique stored entry. -/

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -215,6 +215,30 @@ theorem Hex.ZPoly.polynomialIrreducible_iff_irreducible (f : Hex.ZPoly) :
   (Hex.ZPoly.Irreducible_iff_polynomialIrreducible f).symm
 
 /--
+The Mathlib-free executable irreducibility checker `Hex.ZPoly.isIrreducible`
+agrees with the `Hex.ZPoly.Irreducible` class.
+
+The biconditional is equivalent to full forward correctness of `factor`
+(Group C in `hex-berlekamp-zassenhaus.md`), which is bridge-side: it cites
+`Polynomial.UniqueFactorizationMonoid`, `hensels_lemma`, and
+`Polynomial.Gauss`, and therefore cannot be stated in a Mathlib-free file.
+This is the sole route to `decide`-ing `Hex.ZPoly.Irreducible` for concrete
+inputs; Mathlib-free consumers must thread `[Hex.ZPoly.Irreducible p]` as an
+instance argument instead.
+
+Pending the C1 obligation (`factor f` is the irreducible factorisation; see
+the existing bridge correctness chain tracked by #4170/#4819), this is a
+single localised `sorry`.
+-/
+theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
+    Hex.ZPoly.isIrreducible f = true ↔ Hex.ZPoly.Irreducible f := by
+  sorry
+
+instance Hex.ZPoly.instDecidableIrreducible (f : Hex.ZPoly) :
+    Decidable (Hex.ZPoly.Irreducible f) :=
+  decidable_of_iff _ (Hex.ZPoly.isIrreducible_iff f)
+
+/--
 The executable factorization predicate agrees with Mathlib irreducibility over
 `Polynomial ℤ`.
 -/

--- a/progress/20260602T004701Z_55744121.md
+++ b/progress/20260602T004701Z_55744121.md
@@ -1,0 +1,39 @@
+# 20260602T004701Z — relocate isIrreducible_iff and Decidable instance (issue #6176)
+
+## Accomplished
+
+- Removed `theorem Hex.ZPoly.isIrreducible_iff` (was a `sorry`) and
+  `instance instDecidableIrreducible` from the Mathlib-free
+  `HexBerlekampZassenhaus/Basic.lean` (lines 7378–7384).
+- Added both to `HexBerlekampZassenhausMathlib/Basic.lean`, immediately
+  after `Hex.ZPoly.polynomialIrreducible_iff_irreducible`, matching the
+  bridge SPEC §"Correctness of the executable checker".
+- The relocated theorem keeps a single localised `sorry` pending the C1
+  obligation, as the issue authorises ("leave a single localised `sorry`
+  tracked by the existing bridge correctness chain — #4170/#4819").
+- Existing bridge references to `Hex.ZPoly.isIrreducible_iff` (used inside
+  `irreducibleByFactorization_iff`) resolve to the new location with no
+  source change required.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  succeeds. (`HexNumberField` from the issue's verify list does not yet
+  exist as a Lake library, so it was skipped.)
+- `python3 scripts/check_dag.py` exits 0.
+- Mathlib-free `HexBerlekampZassenhaus/Basic.lean` now has zero `sorry`s
+  (was 1). The bridge file's actual-proof sorry count went from 3 to 4 —
+  net total across the two files is unchanged.
+
+## Current frontier
+
+Issue #6176 deliverables are complete. The relocated `sorry` is the
+standing C1 obligation already tracked elsewhere; nothing new to file.
+
+## Next step
+
+Commit, push, open PR closing #6176.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6176

Session: `55744121-cd1c-4e78-ad82-0f7ed4ff52ed`

1d518851 refactor: relocate isIrreducible_iff and Decidable instance to BZ Mathlib bridge

🤖 Prepared with Claude Code