### PR TITLE
spec: require per-input-family comparator-runtime plots

### DIFF
--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -785,15 +785,21 @@ The report contains five subsections:
 
    - **Comparator-runtime plot (≥ 2 comparators).** A library
      whose `phase4.comparators` block declares two or more
-     comparators commits a comparator-runtime plot at
-     `reports/figures/<lib>-comparator.svg`, with one curve per
-     comparator alongside the Lean curve across the eligible
-     range, log-y wall-time per call. The generator script lives
-     at `scripts/plots/<lib>-comparator.py` and reads the same
+     comparators commits one comparator-runtime plot per
+     `phase4.input_families` entry at
+     `reports/figures/<lib>-comparator-<family>.svg`. Each plot
+     draws one curve per comparator with at least two committed
+     data points on that family, alongside the Lean curve across
+     the family's eligible range, log-y wall-time per call.
+     Comparators with fewer than two data points on the family
+     are omitted from that family's plot and listed in the
+     library's §Concerns subsection. The generator script lives
+     at `scripts/plots/<lib>-comparator.py`, takes a `--family`
+     argument selecting which family to plot, and reads the same
      committed bench-results JSONL the ratio numbers in this
-     subsection cite. The plot is regenerated with the report; a
-     plot whose curves disagree with the §"Comparator ratios"
-     values is an audit-found issue.
+     subsection cite. Each plot is regenerated with the report;
+     a plot whose curves disagree with the §"Comparator ratios"
+     values for that family is an audit-found issue.
 4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
    one representative case per `phase4.input_families`. Dominant
    inclusive costs are named and explained, with leaf cost

--- a/SPEC/benchmarking.md
+++ b/SPEC/benchmarking.md
@@ -785,21 +785,17 @@ The report contains five subsections:
 
    - **Comparator-runtime plot (≥ 2 comparators).** A library
      whose `phase4.comparators` block declares two or more
-     comparators commits one comparator-runtime plot per
-     `phase4.input_families` entry at
-     `reports/figures/<lib>-comparator-<family>.svg`. Each plot
-     draws one curve per comparator with at least two committed
-     data points on that family, alongside the Lean curve across
-     the family's eligible range, log-y wall-time per call.
-     Comparators with fewer than two data points on the family
-     are omitted from that family's plot and listed in the
-     library's §Concerns subsection. The generator script lives
-     at `scripts/plots/<lib>-comparator.py`, takes a `--family`
-     argument selecting which family to plot, and reads the same
-     committed bench-results JSONL the ratio numbers in this
-     subsection cite. Each plot is regenerated with the report;
-     a plot whose curves disagree with the §"Comparator ratios"
-     values for that family is an audit-found issue.
+     comparators commits one plot per `phase4.input_families`
+     entry at `reports/figures/<lib>-comparator-<family>.svg`,
+     log-y wall-time per call across the family's eligible
+     range. Each plot draws the Lean curve alongside one curve
+     per comparator with at least two committed data points on
+     that family; comparators below that threshold are listed
+     in §Concerns instead. The generator at
+     `scripts/plots/<lib>-comparator.py` takes a `--family`
+     argument and reads the same JSONL the ratio numbers cite.
+     Plots disagreeing with the §"Comparator ratios" values are
+     an audit-found issue.
 4. **Profile.** Per [profiling.md §Coverage requirement](profiling.md),
    one representative case per `phase4.input_families`. Dominant
    inclusive costs are named and explained, with leaf cost


### PR DESCRIPTION
This PR amends [SPEC/benchmarking.md §"Comparator ratios"](SPEC/benchmarking.md) so the comparator-runtime plot is per-input-family rather than per-library: one SVG at `reports/figures/<lib>-comparator-<family>.svg` per `phase4.input_families` entry, with the generator script taking a `--family` argument.

The current single-plot rule mandates one artefact covering "the eligible range" — but a library like HexLLL has three families (bz-recombination, random-bounded, harsh-cubic) with qualitatively different curve shapes, and the existing plot covers only random-bounded. The harsh-cubic family, where the open Lean/Isabelle gating Concern lives (Lean 1.58× slower than Isabelle at n=55, blocking `HexLLL.done_through = 4`), has no committed visualisation today.

Implementation work — renaming the existing plot, parameterising the script, adding fpylll harsh-cubic registrations, generating the new harsh-cubic SVG, embedding both in the performance report — is a separate directive issue, filed after this SPEC PR merges.

No auto-merge.

🤖 Prepared with Claude Code