### PR TITLE
HexHensel Phase 6: add linear multifactor invariant constructor or document proof-internal status

### DIFF
--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -127,6 +127,31 @@ recursive precondition for the lifted complement:
 
 The base cases impose the trivial obligations: `congr 1 f (p ^ k)` for the
 empty list and no preconditions for a singleton.
+
+This invariant is **proof-internal**: it is the correctness substrate consumed
+by `multifactorLift_spec` and by the Mathlib-side lift-uniqueness statement
+`HexHenselMathlib.multifactorLift_eq_multifactorLiftQuadratic`, and is not
+intended to be constructed directly by external callers. Unlike the quadratic
+path, no `multifactorLiftInvariant_of_factorsModP` smart constructor is
+provided: the four-conjunct shape mentions per-iteration `LinearLiftLoopInvariant`
+and `LinearLiftStepDegreeInvariant` quantifications that would require
+substrate lemmas (an `of_product_bezout_monic` constructor for
+`LinearLiftLoopInvariant`, plus `henselLift_h_congr_mod_base` and
+`henselLift_h_monic` analogues of the quadratic recursive bridge) that
+`HexHensel/Linear.lean` does not currently expose.
+
+Callers wanting a consumer-facing Hensel-lift correctness surface should use
+the quadratic flavour `QuadraticMultifactorLiftInvariant`, constructed from
+natural mod-`p` factorisation facts by
+`quadraticMultifactorLiftInvariant_of_factorsModP` (with the
+`QuadraticMultifactorLiftInvariant_of_choosePrimeData` wrapper at the
+Berlekamp-Zassenhaus boundary). The executable Berlekamp-Zassenhaus pipeline
+already uses the quadratic invariant exclusively
+(`HexBerlekampZassenhaus/Basic.lean`). A Mathlib-side downstream caller that
+needs the linear-path lifted factors modulo `p^k` should obtain them via
+`HexHenselMathlib.multifactorLift_eq_multifactorLiftQuadratic`, which equates
+the two paths under the Mathlib `Polynomial.map (Int.castRingHom (ZMod (p^k)))`
+canonicalisation.
 -/
 def MultifactorLiftInvariant
     (p k : Nat) [ZMod64.Bounds p]

--- a/progress/20260602T025825Z_e62110bc.md
+++ b/progress/20260602T025825Z_e62110bc.md
@@ -1,0 +1,100 @@
+# BHKS Lemma 5.1 executable bound (#5224) + HexHensel Phase 6 linear invariant (#6215)
+
+## Accomplished
+
+### #5224 — skipped with replan analysis
+
+Claimed `BHKS Lemma 5.1 executable: bound cldCoeffs by bhksCoeffBound`,
+investigated the executable surface (`cldQuotientMod`, `psiCut`,
+`centeredResiduePow`, `cldCoeffs`, `bhksCoeffBound`,
+`bhksCoeffCutThreshold`), and found that the literal theorem
+`(Int.natAbs (cldCoeffs.getD j 0) : ℝ) ≤ (bhksCoeffBound input j : ℝ)`
+is **false** for typical BHKS precisions.
+
+Empirical counterexample (`#eval` against the live executable):
+`f = x² − 5x + 6`, `g = x − 2` (monic, `f = g · h` with `h = x − 3`),
+`p = 5`, `j = 0`, `B_0 = 16`, `b_0 = 3`, `Phi(g).coeff 0 = −3`:
+
+| k | `cldCoeffs.getD 0` | bound `≤ B_0 = 16` |
+|---|---|---|
+| 2 | 0 | ✓ |
+| 4 | 5 | ✓ |
+| 6 | 125 | ✗ |
+
+Mechanism: `cldQuotientMod` returns the positive residue in `[0, p^k)`;
+for `Phi(g).coeff j < 0`, that residue is `Phi.coeff + p^k`. The cut
+`psiCut p k b` (with `b = bhksCoeffCutThreshold p f j` and `_a` unused)
+gives `(Phi.coeff + p^k − Phi.coeff) / p^b = p^(k−b)`. The actual
+unconditional bound is `|cldCoeffs.getD j 0| ≤ p^(k − b_j)`.
+
+Posted the full analysis on the issue and skipped with `coordination
+skip 5224 …`, listing three possible resolutions for the planner (fix
+the executable to center at precision `k` before applying the cut;
+reformulate the bound to the actually-true `p^(k−b_j)` form and
+adjust #5204; per-coordinate precision constraint). The skip also
+flags a deeper gap: `BHKS.auxiliaryPolynomial` uses `cldCoeffs`
+without subtracting the BHKS basis's diagonal-row corrections, so
+true-factor indicator vectors do not give `H = 0` despite the BHKS
+Lemma 3.1 additivity that says they should.
+
+### #6215 — Branch B (document as proof-internal)
+
+Reviewed `HexHensel/Multifactor.lean:131` `MultifactorLiftInvariant`,
+the parallel `quadraticMultifactorLiftInvariant_of_factorsModP`
+constructor in `HexHensel/QuadraticMultifactor.lean`, the consumers
+(`multifactorLift_spec` only; the executable BZ pipeline uses
+`QuadraticMultifactorLiftInvariant` exclusively;
+`HexHenselMathlib/Correctness.lean:429`
+`multifactorLift_eq_multifactorLiftQuadratic` is the only Mathlib-side
+linear-path consumer, currently `sorry`), and the underlying linear
+loop machinery in `HexHensel/Linear.lean`.
+
+Branch A (add a `multifactorLiftInvariant_of_factorsModP`
+constructor) requires substrate lemmas that do not exist in
+`HexHensel/Linear.lean`: an `of_product_bezout_monic` smart
+constructor for `LinearLiftLoopInvariant`, plus
+`henselLift_h_congr_mod_base` and `henselLift_h_monic` analogues of
+the quadratic recursive bridge. Per the issue's Branch A instruction
+("If a strict mirror of the quadratic proof requires new step-level
+lemmas that do not already exist in `HexHensel/Linear.lean`, **stop**
+and …"), Branch B is the chosen route.
+
+Expanded the docstring on `MultifactorLiftInvariant`
+(`HexHensel/Multifactor.lean:131`) to:
+
+- name `MultifactorLiftInvariant` as proof-internal;
+- name `QuadraticMultifactorLiftInvariant` as the consumer-facing
+  invariant, with `quadraticMultifactorLiftInvariant_of_factorsModP`
+  and `QuadraticMultifactorLiftInvariant_of_choosePrimeData` as its
+  constructors;
+- cite `HexHenselMathlib.multifactorLift_eq_multifactorLiftQuadratic`
+  as the Mathlib-side route a downstream caller would use to obtain
+  the linear-path output via the quadratic path;
+- list the specific substrate lemmas a Branch A constructor would
+  require, so a future planner can decide whether to invest in them.
+
+No executable behaviour, theorem signature, or other file is touched.
+
+## Current frontier
+
+- #5224 is now `replan`-labelled with a counterexample-grounded note;
+  the planner can either narrow the bound, fix the executable, or
+  re-route the downstream consumer (#5204).
+- #6215 is delivered as Branch B; the linear-multifactor surface is
+  now explicitly documented as proof-internal, and the path to a
+  Branch A follow-up is enumerated by named missing substrate.
+
+## Next step
+
+- Land the #6215 PR; the next worker can pick up whichever of
+  (#5224 planner output, #6086 `replan`, #6199, or new issues) is at
+  the head of the unclaimed queue.
+
+## Blockers
+
+- `lake build HexHensel.Multifactor`, `lake build HexHensel`,
+  `python3 scripts/check_dag.py`, `git diff --check`, and the
+  forbidden-token diff grep are all clean for the #6215 deliverable.
+- #5224 is genuinely blocked on a SPEC/executable reconciliation that
+  no single feature session can land; the skip routes it back through
+  the planner.


### PR DESCRIPTION
Closes #6215

Session: `e62110bc-d65a-4910-b842-63a0441545f3`

1f06c622 doc: document MultifactorLiftInvariant as proof-internal (#6215)

🤖 Prepared with Claude Code