### PR TITLE
HexMatrix Phase 6: add row-operation determinant docstrings and grind smoke checks

### DIFF
--- a/HexMatrix/Conformance.lean
+++ b/HexMatrix/Conformance.lean
@@ -199,6 +199,22 @@ private def emptyNullspace : Vector (Vector Rat 2) 0 :=
 #guard Matrix.det (Matrix.rowSwap pivotInt ⟨0, by decide⟩ ⟨1, by decide⟩) = -Matrix.det pivotInt
 #guard Matrix.det (Matrix.rowScale pivotInt ⟨1, by decide⟩ (-2)) = (-2) * Matrix.det pivotInt
 #guard Matrix.det (Matrix.rowAdd pivotInt ⟨0, by decide⟩ ⟨2, by decide⟩ 3) = Matrix.det pivotInt
+
+example : Matrix.det (1 : Matrix Int 2 2) = 1 := by
+  grind
+
+example (M : Matrix Int 3 3) (i j : Fin 3) (h : i ≠ j) :
+    Matrix.det (Matrix.rowSwap M i j) = -Matrix.det M := by
+  grind
+
+example (M : Matrix Int 3 3) (i : Fin 3) (c : Int) :
+    Matrix.det (Matrix.rowScale M i c) = c * Matrix.det M := by
+  grind
+
+example (M : Matrix Int 3 3) (src dst : Fin 3) (c : Int) (h : src ≠ dst) :
+    Matrix.det (Matrix.rowAdd M src dst c) = Matrix.det M := by
+  grind
+
 #guard Matrix.bareiss baseInt = Matrix.det baseInt
 #guard Matrix.bareiss singularInt = 0
 #guard Matrix.bareiss pivotInt = Matrix.det pivotInt

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -4780,20 +4780,28 @@ private theorem det_rowAdd_leibniz {R : Type u} [Lean.Grind.CommRing R] {n : Nat
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 := by
   exact permutationVectors_rowAdd_sum M src dst c h
 
+/-- The determinant of the identity matrix is one. -/
+@[grind =]
 theorem det_one {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
     det (1 : Matrix R n n) = 1 := by
   simpa [det] using (det_identity_leibniz (R := R) (n := n))
 
+/-- Swapping two distinct rows negates the determinant. -/
+@[grind =]
 theorem det_rowSwap {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (i j : Fin n) (h : i ≠ j) :
     det (rowSwap M i j) = -det M := by
   simpa [det] using det_rowSwap_leibniz M i j h
 
+/-- Scaling a row by `c` scales the determinant by `c`. -/
+@[grind =]
 theorem det_rowScale {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (i : Fin n) (c : R) :
     det (rowScale M i c) = c * det M := by
   simpa [det] using det_rowScale_leibniz M i c
 
+/-- Adding a multiple of one row to a distinct row preserves the determinant. -/
+@[grind =]
 theorem det_rowAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (src dst : Fin n) (c : R) (h : src ≠ dst) :
     det (rowAdd M src dst c) = det M := by

--- a/progress/20260602T075257Z_4084734f.md
+++ b/progress/20260602T075257Z_4084734f.md
@@ -1,0 +1,40 @@
+# Progress: HexMatrix row-operation determinant grind coverage (#6276)
+
+## Accomplished
+
+Added public docstrings to the determinant row-operation wrappers in
+`HexMatrix/Determinant.lean`: `det_one`, `det_rowSwap`, `det_rowScale`, and
+`det_rowAdd`.
+
+Registered those wrappers with focused equation-style `@[grind =]`
+annotations.
+
+Added proof-mode smoke examples in `HexMatrix/Conformance.lean` showing
+`grind` closes direct goals for the identity determinant, row swap, row scale,
+and row add determinant laws over generic `Matrix Int` inputs.
+
+Verification:
+
+- `lake build HexMatrix.Determinant`
+- `lake build HexMatrix.Conformance`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Forbidden-token diff grep over touched Lean files found no added `sorry`,
+  `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+The SPEC-approved determinant row-operation API now has public declaration
+docstrings plus focused automation coverage in the conformance surface.
+
+## Next step
+
+Continue the remaining Phase 6 follow-up issues from the review report, in
+particular infrastructure visibility classification, Bareiss comments/data
+projection coverage, and conformance fixture annotations.
+
+## Blockers
+
+None for this session. The worktree still contains an unrelated pre-existing
+local modification to `.claude/CLAUDE.md`, which was not touched or staged.


### PR DESCRIPTION
Closes #6276

Session: `4084734f-782b-4115-85b0-881af33c922d`

78e549cb feat: add determinant row-operation grind coverage

🤖 Prepared with Claude Code