### PR TITLE
HexGramSchmidt: add regular-step quotient provenance package

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -2448,6 +2448,89 @@ private def bareissGramRowInvariantStepCoeff
         state.matrix[i][k] * (hinv.coeff k)[a])
       state.prevPivot
 
+/-- Coefficient-level exact-division provenance for one regular Gram-row
+Bareiss step.  The quotient vector is kept separate from
+`bareissGramRowInvariantStepCoeff` so later row-entry proofs can consume the
+integer divisibility witness before projecting back to the existing exact-div
+coefficient API. -/
+private structure BareissGramRegularStepQuotient
+    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    (hinv : BareissGramRowInvariant b state)
+    (hnext : state.step + 1 < n) (i : Fin n) (_hi : state.step + 1 ≤ i.val) where
+  q : Fin n → Int
+  coeff_num_eq_mul :
+    let k : Fin n := ⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hnext⟩
+    ∀ a : Fin n,
+      state.matrix[k][k] * (hinv.coeff i)[a] -
+        state.matrix[i][k] * (hinv.coeff k)[a] =
+          q a * state.prevPivot
+
+/-- Initial no-pivot Gram trajectory specialization of the regular-step
+coefficient quotient package. -/
+private abbrev BareissGramInitialRegularStepQuotient
+    (b : Matrix Int n m) (fuel : Nat)
+    (hinv : BareissGramRowInvariant b
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))))
+    (hnext :
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n)
+    (i : Fin n)
+    (hi :
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 ≤ i.val) :
+    Type :=
+  BareissGramRegularStepQuotient hinv hnext i hi
+
+private theorem bareissGramRegularStepQuotient_stepCoeff_get
+    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {hinv : BareissGramRowInvariant b state}
+    {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
+    (hprev : state.prevPivot ≠ 0)
+    (hq : BareissGramRegularStepQuotient hinv hnext i hi) (a : Fin n) :
+    (bareissGramRowInvariantStepCoeff hinv hnext i hi)[a] = hq.q a := by
+  dsimp [bareissGramRowInvariantStepCoeff]
+  rw [Vector.getElem_ofFn]
+  exact exactDiv_eq_of_eq_mul_right hprev (hq.coeff_num_eq_mul a)
+
+private theorem bareissGramRegularStepQuotient_stepCoeff_eq
+    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {hinv : BareissGramRowInvariant b state}
+    {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
+    (hprev : state.prevPivot ≠ 0)
+    (hq : BareissGramRegularStepQuotient hinv hnext i hi) :
+    bareissGramRowInvariantStepCoeff hinv hnext i hi = Vector.ofFn hq.q := by
+  apply Vector.ext
+  intro a ha
+  let af : Fin n := ⟨a, ha⟩
+  simpa [af] using
+    bareissGramRegularStepQuotient_stepCoeff_get
+      (hinv := hinv) (hnext := hnext) (i := i) (hi := hi) hprev hq af
+
+private theorem rowCombination_bareissGramRegularStepQuotient
+    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {hinv : BareissGramRowInvariant b state}
+    {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
+    (hprev : state.prevPivot ≠ 0)
+    (hq : BareissGramRegularStepQuotient hinv hnext i hi) :
+    Matrix.rowCombination b (bareissGramRowInvariantStepCoeff hinv hnext i hi) =
+      Matrix.rowCombination b (Vector.ofFn hq.q) := by
+  rw [bareissGramRegularStepQuotient_stepCoeff_eq hprev hq]
+
+private theorem dot_rowCombination_bareissGramRegularStepQuotient
+    {b : Matrix Int n m} {state : Matrix.BareissState n}
+    {hinv : BareissGramRowInvariant b state}
+    {hnext : state.step + 1 < n} {i : Fin n} {hi : state.step + 1 ≤ i.val}
+    (hprev : state.prevPivot ≠ 0)
+    (hq : BareissGramRegularStepQuotient hinv hnext i hi)
+    (w : Vector Int m) :
+    Matrix.dot
+        (Matrix.rowCombination b
+          (bareissGramRowInvariantStepCoeff hinv hnext i hi))
+        w =
+      Matrix.dot (Matrix.rowCombination b (Vector.ofFn hq.q)) w := by
+  rw [rowCombination_bareissGramRegularStepQuotient hprev hq]
+
 private theorem bareissGramRowInvariantStepCoeff_support
     {b : Matrix Int n m} {state : Matrix.BareissState n}
     (hinv : BareissGramRowInvariant b state)

--- a/progress/20260602T082424Z_86a93853.md
+++ b/progress/20260602T082424Z_86a93853.md
@@ -1,0 +1,42 @@
+# Progress: HexGramSchmidt regular-step quotient provenance (#6280)
+
+## Accomplished
+
+Claimed #6280 after both open directives failed claim checks because they are
+blocked.
+
+Added a private coefficient-level exact-division provenance package in
+`HexGramSchmidt/Int.lean`:
+
+- `BareissGramRegularStepQuotient`
+- `BareissGramInitialRegularStepQuotient`
+- coefficient, row-combination, and dot projection lemmas back to
+  `bareissGramRowInvariantStepCoeff` when `state.prevPivot ≠ 0`
+
+The change is private, does not alter executable definitions or public APIs,
+and adds no `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+Verification:
+
+- `lake build HexGramSchmidt.Int`
+- `lake build HexGramSchmidt`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Forbidden-token diff grep over `HexGramSchmidt/Int.lean`
+
+## Current frontier
+
+The regular Gram row step now has a private quotient provenance substrate that
+successor proofs can consume before projecting back to the existing exact-div
+coefficient vector.
+
+## Next step
+
+Use this package in the successor row-entry proof slice, then remove the
+remaining `hentry_regular` plumbing from the initial no-pivot row-invariant
+consumer chain.
+
+## Blockers
+
+None for this session. The worktree still contains an unrelated pre-existing
+local modification to `.claude/CLAUDE.md`, which was not touched or staged.


### PR DESCRIPTION
Closes #6280

Session: `86a93853-b227-4efe-8eeb-4f9941369166`

537ed9e1 feat: add Gram quotient provenance package

🤖 Prepared with Claude Code