### PR TITLE
HexMatrix Phase 6: annotate Bareiss fixture claims in conformance

### DIFF
--- a/HexMatrix/Conformance.lean
+++ b/HexMatrix/Conformance.lean
@@ -17,7 +17,9 @@ Covered properties:
 - transpose is involutive on committed fixtures
 - identity matrices act as left and right multiplicative identities
 - row operations satisfy the determinant laws promised by the SPEC
-- `bareiss` agrees with `det` on committed nonsingular and singular inputs
+- committed Bareiss fixtures match their expected executable determinant values;
+  the `bareiss = det` guards below are value-level fixture checks only, not a
+  general theorem in the Mathlib-free `hex-matrix` layer
 - `rref` returns data whose transform matrix multiplies the input to the reported echelon form
 - `spanCoeffs` witnesses row-span membership on a committed dependent-row example
 - the committed nullspace basis vectors are annihilated by the source matrix
@@ -200,6 +202,8 @@ private def emptyNullspace : Vector (Vector Rat 2) 0 :=
 #guard Matrix.det (Matrix.rowScale pivotInt ⟨1, by decide⟩ (-2)) = (-2) * Matrix.det pivotInt
 #guard Matrix.det (Matrix.rowAdd pivotInt ⟨0, by decide⟩ ⟨2, by decide⟩ 3) = Matrix.det pivotInt
 
+/- Determinant row-operation proof-mode automation examples. -/
+
 example : Matrix.det (1 : Matrix Int 2 2) = 1 := by
   grind
 
@@ -215,11 +219,20 @@ example (M : Matrix Int 3 3) (src dst : Fin 3) (c : Int) (h : src ≠ dst) :
     Matrix.det (Matrix.rowAdd M src dst c) = Matrix.det M := by
   grind
 
+/- Bareiss fixture equality guards.
+
+These evaluate committed examples against `Matrix.det` to catch runtime
+regressions on representative nonsingular, singular, and pivoting inputs. They
+do not expose or imply a general Mathlib-free bridge theorem of the forbidden
+shape `Matrix.bareiss M = Matrix.det M`. -/
+
 #guard Matrix.bareiss baseInt = Matrix.det baseInt
 #guard Matrix.bareiss singularInt = 0
 #guard Matrix.bareiss pivotInt = Matrix.det pivotInt
 #guard (Matrix.bareissData singularInt).det = 0
 #guard (Matrix.bareissData pivotInt).rowSwaps = 1
+
+/- RREF, span, and nullspace executable conformance guards. -/
 
 #guard let D := Matrix.rref dependentRat; D.rank = 1
 #guard let D := Matrix.rref dependentRat; D.echelon = dependentRref
@@ -275,6 +288,11 @@ private def bigPivotInt : Matrix Int 6 6 :=
 
 #guard Matrix.transpose (Matrix.transpose bigInt) = bigInt
 #guard (1 : Matrix Int 6 6) * bigInt = bigInt
+
+/- Bareiss executable-value guards for 6×6 fixtures.
+
+These compare against known fixture values rather than stating any general
+relationship between the Bareiss algorithm and Leibniz determinant. -/
 
 #guard Matrix.bareiss bigInt = 1
 #guard Matrix.bareiss bigZeroInt = 0

--- a/progress/20260602T082519Z_8fbfaf3c.md
+++ b/progress/20260602T082519Z_8fbfaf3c.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+Selected #6269 first because it was the older unclaimed feature and would
+unblock downstream Gram-Schmidt consumers, then found its assumptions stale:
+#6268 was closed by decomposition into #6280, #6281, and #6282, with #6280
+still open and claimed. Released #6269 with a replan note explaining that the
+clean no-pivot wiring cannot proceed yet.
+
+Claimed #6283 and updated `HexMatrix/Conformance.lean` commentary so the
+Bareiss-vs-det guards are explicitly described as value-level fixture checks
+over committed examples, not a general Mathlib-free `bareiss = det` theorem.
+Added local section comments separating determinant row-operation automation,
+Bareiss fixture equality guards, and RREF/span/nullspace conformance guards.
+
+Verification:
+
+- `lake build HexMatrix.Conformance`
+- `lake build HexMatrix`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Forbidden-token diff grep over `HexMatrix/Conformance.lean` found no added
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+`HexMatrix/Conformance.lean` now makes the SPEC placement distinction clear for
+Bareiss fixture checks without changing executable guards or adding theorem
+surface.
+
+## Next step
+
+Finish the remaining Phase 6 follow-ups, especially Bareiss module/data
+projection commentary and determinant proof-infrastructure visibility. The
+Gram-Schmidt clean no-pivot API should wait for #6280/#6281/#6282 to land.
+
+## Blockers
+
+#6269 is blocked by the still-open provenance substrate chain (#6280, #6281,
+#6282). The worktree still has an unrelated pre-existing local modification to
+`.claude/CLAUDE.md`, which was not touched or staged.


### PR DESCRIPTION
Closes #6283

Session: `8fbfaf3c-8973-435d-a590-b5c2271b05d7`

eb50d0d3 doc: clarify Bareiss conformance fixture guards

🤖 Prepared with Claude Code