### PR TITLE
HexGramSchmidt: prove prevPivot nonzero on nonsingular initial no-pivot trajectory

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -1916,6 +1916,36 @@ private theorem noPivotLoop_step_eq_add_of_singularStep_none
         show state.step + 1 + f = state.step + (f + 1)
         omega
 
+/-- A no-pivot Bareiss pass that never records a singular step preserves the
+nonzero status of the previous pivot. Regular branches replace `prevPivot` by
+the current nonzero pivot; singular branches contradict the final
+`singularStep = none` hypothesis. -/
+private theorem noPivotLoop_prevPivot_ne_zero_of_singularStep_none
+    {n : Nat} (fuel : Nat) (state : Matrix.BareissState n)
+    (hprev : state.prevPivot ≠ 0)
+    (h_no_sing : (Matrix.noPivotLoop fuel state).singularStep = none) :
+    (Matrix.noPivotLoop fuel state).prevPivot ≠ 0 := by
+  induction fuel generalizing state with
+  | zero =>
+      simpa [Matrix.noPivotLoop_zero_fuel] using hprev
+  | succ f ih =>
+      by_cases hDone : state.step + 1 < n
+      · by_cases hp : state.matrix[state.step][state.step] = 0
+        · rw [Matrix.noPivotLoop_singular_branch f state hDone hp] at h_no_sing
+          simp at h_no_sing
+        · rw [Matrix.noPivotLoop_regular_branch f state hDone hp] at h_no_sing
+          rw [Matrix.noPivotLoop_regular_branch f state hDone hp]
+          exact ih
+            { step := state.step + 1
+              matrix := Matrix.stepMatrix state.matrix state.step
+                state.matrix[state.step][state.step] state.prevPivot
+              prevPivot := state.matrix[state.step][state.step]
+              rowSwaps := state.rowSwaps
+              singularStep := none }
+            hp h_no_sing
+      · rw [Matrix.noPivotLoop_done f state hDone] at h_no_sing ⊢
+        exact hprev
+
 /-- The `step` field of a no-pivot Bareiss state never decreases under further
 loop iterations. -/
 theorem noPivotLoop_step_monotone
@@ -2725,6 +2755,29 @@ private theorem noPivotLoop_initial_gram_step_eq_of_prefix_none
     Matrix.noPivotLoop_step_eq_add_of_singularStep_none s
       (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl h_room h_prefix_none
   simpa [Matrix.noPivotInitialState] using h_step
+
+/-- On a nonsingular initial no-pivot Gram trajectory, any current state that is
+ready for a regular next step has a nonzero previous pivot. -/
+private theorem noPivotLoop_initial_gram_prevPivot_ne_zero_of_regular_prefix
+    (b : Matrix Int n m) (fuel : Nat)
+    (h_prefix_none :
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none)
+    (_hnext :
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n)
+    (_hp :
+      (Matrix.noPivotLoop fuel
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[
+          (Matrix.noPivotLoop fuel
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step][
+          (Matrix.noPivotLoop fuel
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step] ≠ 0) :
+    (Matrix.noPivotLoop fuel
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b))).prevPivot ≠ 0 := by
+  apply noPivotLoop_prevPivot_ne_zero_of_singularStep_none
+  · simp [Matrix.noPivotInitialState]
+  · exact h_prefix_none
 
 /-- Package a proved zero suffix in the current Gram pivot column into the
 executable row-pivot search failure expected by `Matrix.pivotLoop`. -/

--- a/progress/20260602T095123Z_eb798bf0.md
+++ b/progress/20260602T095123Z_eb798bf0.md
@@ -1,0 +1,42 @@
+# 20260602T095123Z eb798bf0 — Issue #6300
+
+## Accomplished
+
+Proved the previous-pivot nonzero bridge needed for the initial Gram no-pivot
+regular trajectory in `HexGramSchmidt/Int.lean`:
+
+- Added `noPivotLoop_prevPivot_ne_zero_of_singularStep_none`, a private generic
+  loop-control lemma showing that a no-pivot Bareiss pass ending with
+  `singularStep = none` preserves nonzero `prevPivot` from the starting state.
+- Added
+  `noPivotLoop_initial_gram_prevPivot_ne_zero_of_regular_prefix`, the private
+  initial Gram trajectory wrapper exposing
+  `state.prevPivot ≠ 0` for a reachable no-singular current state ready for a
+  regular next step.
+
+## Current frontier
+
+The local previous-pivot denominator obligation is now available for the next
+regular Gram row-entry proof. The quotient-backed algebra subtask can use this
+wrapper before applying the exact-division quotient lemmas.
+
+## Next step
+
+Continue with #6301: use the previous-pivot nonzero wrapper together with the
+existing `BareissGramRegularStepQuotient` package to prove the regular
+row-entry algebra.
+
+## Blockers
+
+None. Verification passed with existing warnings in `HexGramSchmidt.Basic` and
+`HexGramSchmidt.Int` unchanged, including the pre-existing `sorry` warning in
+`HexGramSchmidt/Int.lean`.
+
+## Verification
+
+- `lake build HexGramSchmidt.Int`
+- `lake build HexGramSchmidt`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Forbidden-token diff grep over `HexGramSchmidt/Int.lean` found no added
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #6300

Session: `eb798bf0-4432-463e-a0c5-10645b2f56dc`

52a316d8 feat: prove Gram no-pivot prevPivot nonzero

🤖 Prepared with Claude Code