### PR TITLE
HexModArith Phase 6: tag ZMod64 constructor/equality wrappers and add proof-mode conformance

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -56,6 +56,7 @@ instance : CoeOut (ZMod64 p) Nat where
   rfl
 
 /-- Extensionality for residues via their canonical Nat representatives. -/
+@[grind .]
 theorem ext_toNat {a b : ZMod64 p} (h : a.toNat = b.toNat) : a = b :=
   ext (UInt64.toNat_inj.mp h)
 
@@ -104,6 +105,7 @@ def ofNat (p n : Nat) [Bounds p] : ZMod64 p := by
   exact Nat.mod_eq_of_lt a.toNat_lt
 
 /-- Two residues are equal exactly when their canonical representatives agree. -/
+@[grind ←]
 theorem eq_iff_toNat_eq (a b : ZMod64 p) : a = b ↔ a.toNat = b.toNat :=
   ⟨fun h => h ▸ rfl, ext_toNat⟩
 
@@ -116,16 +118,19 @@ theorem eq_iff_toNat_eq (a b : ZMod64 p) : a = b ↔ a.toNat = b.toNat :=
   simp [normalize]
 
 /-- Characterise when an arbitrary representative builds a given residue. -/
+@[grind ←]
 theorem ofNat_eq_iff_toNat_eq (n : Nat) (a : ZMod64 p) :
     ofNat p n = a ↔ n % p = a.toNat := by
   rw [eq_iff_toNat_eq, toNat_ofNat]
 
 /-- Characterise when a residue is built from an arbitrary representative. -/
+@[grind ←]
 theorem eq_ofNat_iff_toNat_eq (a : ZMod64 p) (n : Nat) :
     a = ofNat p n ↔ a.toNat = n % p := by
   rw [eq_iff_toNat_eq, toNat_ofNat]
 
 /-- Equality of residues built from arbitrary Nat representatives is equality modulo `p`. -/
+@[grind ←]
 theorem ofNat_eq_ofNat_iff_mod_eq (x y : Nat) :
     ofNat p x = ofNat p y ↔ x % p = y % p := by
   rw [eq_iff_toNat_eq, toNat_ofNat, toNat_ofNat]
@@ -185,6 +190,7 @@ private theorem nodup_map_of_injective_on
         exact hinj a (by simp [ha]) b (by simp [hb]) hab
 
 /-- The canonical residue list has no duplicate entries. -/
+@[grind .]
 theorem values_nodup : (values p).Nodup := by
   unfold values
   apply nodup_map_of_injective_on (List.nodup_range : (List.range p).Nodup)

--- a/HexModArith/Conformance.lean
+++ b/HexModArith/Conformance.lean
@@ -86,6 +86,28 @@ example {a b : ZMod64 7} (h : a * b = 0) : a = 0 ∨ b = 0 := by
 
 end PrimeModulusAutomation
 
+section BasicConstructorAutomation
+
+example (n : Nat) : (ZMod64.ofNat 7 n).toNat = n % 7 := by
+  simp
+
+example (a : ZMod64 7) : ZMod64.ofNat 7 a.toNat = a := by
+  simp only [ZMod64.ofNat_toNat]
+
+example {a b : ZMod64 7} (h : a.toNat = b.toNat) : a = b := by
+  grind
+
+example (a b : ZMod64 7) : a = b ↔ a.toNat = b.toNat := by
+  grind
+
+example (x y : Nat) : ZMod64.ofNat 7 x = ZMod64.ofNat 7 y ↔ x % 7 = y % 7 := by
+  grind
+
+example (a : ZMod64 7) : a ∈ ZMod64.values 7 := by
+  simp
+
+end BasicConstructorAutomation
+
 private def oneOnly : ZMod64 1 := ofNat 1 37
 private def a2 : ZMod64 2 := ofNat 2 1
 private def b2 : ZMod64 2 := ofNat 2 1

--- a/progress/20260602T114932Z_3d7f1e52.md
+++ b/progress/20260602T114932Z_3d7f1e52.md
@@ -1,0 +1,45 @@
+# 20260602T114932Z 3d7f1e52 — Issue #6323
+
+## Accomplished
+
+- Claimed and completed issue #6323.
+- Tagged the public `ZMod64` constructor/equality wrapper facts in
+  `HexModArith/Basic.lean` with conservative `grind` attributes:
+  `ext_toNat`, `eq_iff_toNat_eq`, `ofNat_eq_iff_toNat_eq`,
+  `eq_ofNat_iff_toNat_eq`, `ofNat_eq_ofNat_iff_mod_eq`, and
+  `values_nodup`.
+- Added a separate `BasicConstructorAutomation` proof-mode cluster in
+  `HexModArith/Conformance.lean` covering normalized representatives,
+  equality from representatives, constructor equality modulo the modulus, and
+  membership in `ZMod64.values`.
+
+## Current frontier
+
+`HexModArith` now exposes the basic `ZMod64` constructor/equality API through
+the expected proof automation surface. The iff-shaped facts needed reverse
+`grind` orientation because equality-pattern and forward orientations do not
+produce valid trigger patterns for these statements.
+
+Quality metrics remain unchanged from the issue baseline:
+`sorry_count=84`, `axiom_decl_count=0`, `native_decide_count=2`.
+
+## Next step
+
+Sibling Phase 6 issue #6326 for `HexGF2` remains a viable next unblocked
+proof-polishing target.
+
+## Blockers
+
+None for this issue. The pre-existing `.claude/CLAUDE.md` worktree change was
+not touched by this session.
+
+## Verification
+
+- `lake build HexModArith.Basic` — green.
+- `lake build HexModArith.Conformance` — green.
+- `lake build HexModArith` — green.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- Forbidden-token diff grep over `HexModArith/Basic.lean` and
+  `HexModArith/Conformance.lean` found no added `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #6323

Session: `3d7f1e52-ee0b-4710-9052-f0310af83e85`

8ca6efbc feat: tag ZMod64 constructor automation

🤖 Prepared with Claude Code