### PR TITLE
perf: collapse swapStep row updates

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -10,6 +10,14 @@ the Gram-Schmidt norm identities stated over those predicates, and the
 all-integer `LLLState` record consumed by later algorithmic phases.
 -/
 
+namespace Vector
+
+/-- Update one vector entry using its current value. -/
+def modify (v : Vector α n) (i : Fin n) (f : α → α) : Vector α n :=
+  v.set i (f (v.get i))
+
+end Vector
+
 namespace Hex
 
 namespace Matrix
@@ -266,12 +274,14 @@ def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
       let d' : Vector Nat (n + 1) :=
         s.d.set k dk' (h := Nat.lt_succ_of_lt hk)
       let νRowsSwapped :=
-        (List.finRange km1.val).foldl
-          (fun ν j =>
-            let jFin : Fin n := ⟨j.val, Nat.lt_trans j.isLt km1.isLt⟩
-            let ν := setEntry ν km1 jFin ((s.ν.get kFin).get jFin)
-            setEntry ν kFin jFin ((s.ν.get km1).get jFin))
-          s.ν
+        let setPrefixFrom (source : Vector Int n) (row : Vector Int n) : Vector Int n :=
+          (List.finRange km1.val).foldl
+            (fun row j =>
+              let jFin : Fin n := ⟨j.val, Nat.lt_trans j.isLt km1.isLt⟩
+              row.set jFin (source.get jFin))
+            row
+        s.ν.modify km1 (setPrefixFrom (s.ν.get kFin))
+          |>.modify kFin (setPrefixFrom (s.ν.get km1))
       let νPivot := setEntry νRowsSwapped kFin km1 B
       let ν' : Matrix Int n n :=
         (List.finRange n).foldl
@@ -283,8 +293,9 @@ def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
               let curr :=
                 (Int.ofNat dkNext * (s.ν.get i).get km1 - B * (s.ν.get i).get kFin) /
                   Int.ofNat dk
-              let ν := setEntry ν i km1 prev
-              setEntry ν i kFin curr
+              ν.modify i fun row =>
+                row.set km1 prev
+                  |>.set kFin curr
             else
               ν)
           νPivot

--- a/progress/20260602T123506Z_5790a4f2.md
+++ b/progress/20260602T123506Z_5790a4f2.md
@@ -1,0 +1,35 @@
+# 20260602T123506Z 5790a4f2 — Issue #6336
+
+## Accomplished
+
+- Claimed directive issue #6336 and updated `HexLLL/Basic.lean`.
+- Added `Vector.modify` as a small `set i (f (get i))` helper for row-update COW shape.
+- Reworked `LLLState.swapStep`:
+  - prefix row swap now updates each touched row through one `modify`, with the column prefix fold inside the row update;
+  - lower-row recurrence fold now updates `km1` and `kFin` columns through one row `modify`.
+- Verified generated C for the lower-row recurrence fold: the fold body calls `Hex.Vector.modify`, whose row lambda performs two inner `lean_array_fset` calls before the outer matrix row write.
+- Re-ran the random-bounded comparator plot command; the SVG was unchanged because the script reads the existing committed ladder exports.
+- Re-benched random-bounded `n=120` on `carica`: median `1.622 s` over 3 repeats.
+
+## Current frontier
+
+The local implementation and requested verification pass. The first prefix-swap fold is row-major but cannot be represented as one per-iteration row `modify` because each prefix column update touches two different rows; the implemented shape reduces the outer matrix writes to one update per swapped row.
+
+## Next step
+
+Open the PR for #6336 with the IR finding and `n=120` median in the PR body.
+
+## Blockers
+
+- `/reflect` was not available as a callable command in this non-interactive environment, so it was skipped per the worker-flow fallback rule.
+
+## Verification
+
+- `lake build HexLLL.Basic` — passed, with existing warnings.
+- `lake build` — passed, with existing warnings.
+- `lake build HexLLL.Conformance` — passed, with existing warnings.
+- `lake exe hexlll_bench verify` — all 73 benchmark checks passed.
+- `lake exe hexlll_bench run Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120 --export-file reports/bench-results/hex-lll-5790a4f2-random-bounded-120.json` — median `1.622 s`, hash `0x8`.
+- `python3 scripts/plots/hex-lll-comparator.py --family random-bounded` — passed; no SVG diff.
+- `git diff --check` — clean.
+- Added-diff forbidden-token grep for `axiom`, `native_decide`, and `sorry` in `HexLLL/Basic.lean` — clean.


### PR DESCRIPTION
Closes #6336

Session: `5790a4f2-32f3-4eac-8f6e-f739610af3fd`

## Summary

- Added `Vector.modify` as `set i (f (get i))` for row-update COW shape.
- Reworked `LLLState.swapStep` so the lower-row recurrence updates `km1` and `kFin` through one row `modify` per affected row.
- Reworked the prefix row swap to update each swapped row through one `modify`, with the column-prefix fold inside the row update.

## IR check

Generated `.lake/build/ir/HexLLL/Basic.c` shows `swapStep`'s lower-row fold calling `lp_Hex_Vector_modify___redArg(...)` once for the affected outer row. The row lambda `lp_Hex_List_foldl___at___00Hex_LLLState_swapStep_spec__1___redArg___lam__0` performs two inner `lean_array_fset` calls before returning the updated row, which is then written back by `Vector.modify`.

For the prefix swap, generated C shows two row-level `Vector.modify` calls total, one for `km1` and one for `kFin`; each row lambda performs the prefix column fold internally.

## Benchmark

Random-bounded `n=120` on `carica`:

```text
Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120    [fixed] repeats=3
  repeat 0  1.615 s
  repeat 1  1.622 s
  repeat 2  1.629 s
  median: 1.622 s    min: 1.615 s    max: 1.629 s
  observed hash: 0x8
  expected hash: matches
```

Reran `python3 scripts/plots/hex-lll-comparator.py --family random-bounded`; the committed SVG had no diff because the script reads the existing committed ladder exports, while this PR only produced the requested one-off `n=120` timing for the PR body.

## Verification

- `lake build HexLLL.Basic`
- `lake build`
- `lake build HexLLL.Conformance`
- `lake exe hexlll_bench verify` — all 73 benchmark checks passed
- `lake exe hexlll_bench run Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120 --export-file reports/bench-results/hex-lll-5790a4f2-random-bounded-120.json`
- `python3 scripts/plots/hex-lll-comparator.py --family random-bounded`
- `git diff --check`
- Added-diff forbidden-token grep for `axiom`, `native_decide`, and `sorry` in `HexLLL/Basic.lean`