### PR TITLE
HexArith Phase 6: tag powMod algebraic wrappers and add proof-mode conformance

### DIFF
--- a/HexArith/Conformance.lean
+++ b/HexArith/Conformance.lean
@@ -128,6 +128,48 @@ example (a b : UInt64) :
         s * Int.ofNat a.toNat + t * Int.ofNat b.toNat = Int.ofNat g.toNat) := by
   grind [HexArith.UInt64.extGcd_spec]
 
+example (a n : Nat) :
+    HexArith.powMod a n 0 = 0 := by
+  simp
+
+example (a p : Nat) (hp : p > 0) :
+    HexArith.powMod a 0 p = 1 % p := by
+  simp [hp]
+
+example (a p : Nat) (hp : p > 0) :
+    HexArith.powMod a 1 p = a % p := by
+  simp [hp]
+
+example (a n p : Nat) (hp : p > 0) :
+    HexArith.powMod (a % p) n p = HexArith.powMod a n p := by
+  simp [hp]
+
+example (a n : Nat) :
+    HexArith.powMod a n 1 = 0 := by
+  simp
+
+example (a n p : Nat) (hp : p > 0) :
+    HexArith.powMod a n p = a ^ n % p := by
+  grind
+
+example (a n p : Nat) (hp : p > 0) :
+    HexArith.powMod a (n + 1) p = (a * HexArith.powMod a n p) % p := by
+  grind
+
+example (a b n p : Nat) (hp : p > 0) :
+    HexArith.powMod (a * b) n p =
+      (HexArith.powMod a n p * HexArith.powMod b n p) % p := by
+  grind
+
+example (a m n p : Nat) (hp : p > 0) :
+    HexArith.powMod a (m + n) p =
+      (HexArith.powMod a m p * HexArith.powMod a n p) % p := by
+  grind
+
+example (a m n p : Nat) (hp : p > 0) :
+    HexArith.powMod a (m * n) p = HexArith.powMod (HexArith.powMod a m p) n p := by
+  grind
+
 end ProofMode
 
 /-- info: 2 -/

--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -955,6 +955,7 @@ def powMod (a n p : Nat) : Nat :=
       powModNat a n p
 
 /-- `powMod` agrees with ordinary modular exponentiation. -/
+@[grind =]
 theorem powMod_eq (a n p : Nat) (hp : p > 0) :
     powMod a n p = a ^ n % p := by
   unfold powMod
@@ -1023,6 +1024,7 @@ theorem powMod_modulus_one (a n : Nat) :
 
 /-- Successor-exponent expansion for `powMod`: multiply by the base on the left
 and reduce. -/
+@[grind =>]
 theorem powMod_succ (a n p : Nat) (hp : p > 0) :
     powMod a (n + 1) p = (a * powMod a n p) % p := by
   rw [powMod_eq a (n + 1) p hp, powMod_eq a n p hp, Nat.pow_succ]
@@ -1036,6 +1038,7 @@ theorem powMod_mod_base (a n p : Nat) (hp : p > 0) :
   simp [Nat.pow_mod]
 
 /-- Modular exponentiation is compatible with multiplying bases. -/
+@[grind =>]
 theorem powMod_mul_base (a b n p : Nat) (hp : p > 0) :
     powMod (a * b) n p = (powMod a n p * powMod b n p) % p := by
   rw [powMod_eq (a * b) n p hp, powMod_eq a n p hp, powMod_eq b n p hp,
@@ -1043,18 +1046,21 @@ theorem powMod_mul_base (a b n p : Nat) (hp : p > 0) :
 
 /-- Exponent-addition expansion for `powMod`: combine two exponentiation phases
 by multiplying their reduced results. -/
+@[grind =>]
 theorem powMod_add_exp (a m n p : Nat) (hp : p > 0) :
     powMod a (m + n) p = (powMod a m p * powMod a n p) % p := by
   rw [powMod_eq a (m + n) p hp, powMod_eq a m p hp, powMod_eq a n p hp,
     Nat.pow_add, Nat.mul_mod]
 
 /-- Left-oriented companion of `powMod_add_exp`. -/
+@[grind =>]
 theorem powMod_add_exp_left (a m n p : Nat) (hp : p > 0) :
     powMod a (m + n) p = (powMod a n p * powMod a m p) % p := by
   rw [powMod_add_exp a m n p hp, Nat.mul_comm]
 
 /-- Exponent-multiplication composition for `powMod`: an exponent product is a
 two-stage modular exponentiation. -/
+@[grind =>]
 theorem powMod_mul_exp (a m n p : Nat) (hp : p > 0) :
     powMod a (m * n) p = powMod (powMod a m p) n p := by
   rw [powMod_eq a (m * n) p hp, powMod_eq (powMod a m p) n p hp,
@@ -1062,6 +1068,7 @@ theorem powMod_mul_exp (a m n p : Nat) (hp : p > 0) :
   exact Nat.pow_mod (a ^ m) n p
 
 /-- Swap-oriented companion of `powMod_mul_exp`. -/
+@[grind =>]
 theorem powMod_mul_exp_swap (a m n p : Nat) (hp : p > 0) :
     powMod a (m * n) p = powMod (powMod a n p) m p := by
   rw [Nat.mul_comm m n, powMod_mul_exp a n m p hp]

--- a/progress/20260602T125733Z_a2f4aeb1.md
+++ b/progress/20260602T125733Z_a2f4aeb1.md
@@ -1,0 +1,40 @@
+# 20260602T125733Z a2f4aeb1 — Issue #6329
+
+## Accomplished
+
+- Claimed #6329 after checking the unclaimed queue and selecting the bounded
+  HexArith Phase 6 proof-polishing task.
+- Added conservative `@[grind]` attributes to the public `powMod` wrapper
+  facts in `HexArith/Montgomery/Context.lean`:
+  `powMod_eq`, `powMod_succ`, `powMod_mul_base`, `powMod_add_exp`,
+  `powMod_add_exp_left`, `powMod_mul_exp`, and `powMod_mul_exp_swap`.
+- Extended the `HexArith/Conformance.lean` `ProofMode` cluster with bare
+  `simp` examples for existing `powMod` normal forms and bare `grind`
+  examples for the public equality, successor, base-multiplication,
+  exponent-addition, and exponent-multiplication wrappers.
+
+## Current frontier
+
+#6329's requested wrapper automation and conformance examples are complete.
+The branch intentionally leaves executable definitions, theorem statements,
+FFI declarations, benchmarks, and cross-check fixtures unchanged.
+
+## Next step
+
+Review and merge the PR. Follow-on HexArith Phase 6 work can continue with
+other public theorem surfaces not covered by this narrow `powMod` task.
+
+## Blockers
+
+- None for this issue.
+
+## Verification
+
+- `lake build HexArith.Montgomery.Context` — green.
+- `lake build HexArith.Conformance` — green.
+- `lake build HexArith` — green.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- Forbidden-token diff grep over `HexArith/Montgomery/Context.lean` and
+  `HexArith/Conformance.lean` found no added `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #6329

Session: `a2f4aeb1-c0f6-45b6-8ed0-687b22cd1619`

8f42c6eb feat: tag HexArith powMod proof wrappers

🤖 Prepared with Claude Code