### PR TITLE
HexArith Phase 6: add Barrett proof-mode automation coverage

### DIFF
--- a/HexArith/Barrett/Context.lean
+++ b/HexArith/Barrett/Context.lean
@@ -167,6 +167,7 @@ theorem mulMod_one_right (ctx : BarrettCtx p) (a : UInt64) (ha : a < p) :
   simp [Nat.mod_eq_of_lt ha']
 
 /-- Barrett modular multiplication is commutative on reduced residues. -/
+@[grind =]
 theorem mulMod_comm (ctx : BarrettCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     ctx.mulMod a b = ctx.mulMod b a := by

--- a/HexArith/Conformance.lean
+++ b/HexArith/Conformance.lean
@@ -170,6 +170,26 @@ example (a m n p : Nat) (hp : p > 0) :
     HexArith.powMod a (m * n) p = HexArith.powMod (HexArith.powMod a m p) n p := by
   grind
 
+example {p : UInt64} (ctx : BarrettCtx p) (a b : UInt64)
+    (ha : a < p) (hb : b < p) :
+    (ctx.mulMod a b).toNat = (a.toNat * b.toNat) % p.toNat := by
+  simp [ha, hb]
+
+example {p : UInt64} (ctx : BarrettCtx p) (a b : UInt64)
+    (ha : a < p) (hb : b < p) :
+    ctx.mulMod a b < p := by
+  grind
+
+example {p : UInt64} (ctx : BarrettCtx p) (a : UInt64) (ha : a < p) :
+    ctx.mulMod 0 a = 0 ∧ ctx.mulMod a 0 = 0 ∧
+      ctx.mulMod 1 a = a ∧ ctx.mulMod a 1 = a := by
+  simp [ha]
+
+example {p : UInt64} (ctx : BarrettCtx p) (a b : UInt64)
+    (ha : a < p) (hb : b < p) :
+    ctx.mulMod a b = ctx.mulMod b a := by
+  grind
+
 end ProofMode
 
 /-- info: 2 -/

--- a/progress/20260602T162713Z_4f35751e.md
+++ b/progress/20260602T162713Z_4f35751e.md
@@ -1,0 +1,41 @@
+# 20260602T162713Z 4f35751e — Issue #6355
+
+## Accomplished
+
+- Claimed feature issue #6355 after checking the unclaimed queue; selected it as
+  the unblocked, localized HexArith Phase 6 item.
+- Added `@[grind =]` to `BarrettCtx.mulMod_comm` in
+  `HexArith/Barrett/Context.lean` so the public commutativity fact is available
+  to bare proof-mode automation.
+- Extended `namespace ProofMode` in `HexArith/Conformance.lean` with Barrett
+  multiplication examples for Nat equality, residue bounds, zero/one
+  simplifications, and commutativity using bare `simp` or bare `grind`.
+
+## Current frontier
+
+HexArith remains in Phase 6 proof polishing. The Barrett modular
+multiplication public API now has conformance coverage matching the recent
+`powMod` proof-mode examples, without changing executable definitions.
+
+Quality metrics checked during this session: repo-wide `sorry` text count was
+83, repo-wide `native_decide` text count was 2, and the touched-file diff added
+no `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Next step
+
+Continue Phase 6 proof-mode coverage for other public HexArith APIs if new
+issues identify missing automation surfaces. No follow-up issue is needed for
+the Barrett slice from #6355.
+
+## Blockers
+
+None for this issue.
+
+## Verification
+
+- `lake build HexArith.Barrett.Context` — green.
+- `lake build HexArith.Conformance` — green.
+- `lake build HexArith` — green.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- `git diff -- HexArith/Barrett/Context.lean HexArith/Conformance.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'` — no matches.


### PR DESCRIPTION
Closes #6355

Session: `4f35751e-f3db-4d60-9b45-e6c909aeae0a`

34e06875 test: add Barrett proof-mode coverage

🤖 Prepared with Claude Code