### PR TITLE
feat: add correction auxiliary support range

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -719,6 +719,33 @@ theorem auxiliaryPolynomial_l2norm_sq_le
     _ = (∑ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2)) *
         ((r : ℝ) * (BHKS.cldColumnNormBound input liftData.p : ℝ)) := by rw [hcldcol]
 
+/--
+The transported correction-aware BHKS auxiliary polynomial has no support above
+`input.degree?.getD 0`.
+
+This isolates the support-range step needed when summing the
+coefficientwise correction bound into an l2-norm estimate.
+-/
+theorem auxiliaryPolynomialWithCorrections_support_subset_range
+    (input : Hex.ZPoly) (liftData : Hex.LiftData)
+    (vec corrections : Array Int) :
+    (HexPolyZMathlib.toPolynomial
+      (BHKS.auxiliaryPolynomialWithCorrections
+        input liftData vec corrections)).support ⊆
+      Finset.range (input.degree?.getD 0) := by
+  intro j hj
+  by_contra hjn
+  have hge : input.degree?.getD 0 ≤ j := by
+    simpa [Finset.mem_range] using hjn
+  have hcoeff_zero :
+      (HexPolyZMathlib.toPolynomial
+        (BHKS.auxiliaryPolynomialWithCorrections
+          input liftData vec corrections)).coeff j = 0 := by
+    rw [HexPolyZMathlib.coeff_toPolynomial,
+      auxiliaryPolynomialWithCorrections_coeff_eq]
+    rw [if_neg (by omega)]
+  exact (Polynomial.mem_support_iff.mp hj) hcoeff_zero
+
 end BHKS
 
 namespace ExecutableBadVectorWitness

--- a/progress/20260602T233239Z_46786eb6.md
+++ b/progress/20260602T233239Z_46786eb6.md
@@ -1,0 +1,47 @@
+# 20260602T233239Z work #6392
+
+## Accomplished
+
+- Claimed #6392 and worked on the correction-aware BHKS auxiliary-polynomial
+  l2norm lift in `HexBerlekampZassenhausMathlib/BadVector.lean`.
+- Added
+  `BHKS.auxiliaryPolynomialWithCorrections_support_subset_range`, proving that
+  the transported `auxiliaryPolynomialWithCorrections` has support contained in
+  `Finset.range (input.degree?.getD 0)`.
+- Attempted the full direct finite-sum squared-l2norm lift from
+  `auxiliaryPolynomialWithCorrections_coeff_sq_le`, but the proof shape caused
+  severe build-time/resource pressure in this large module.  The landed support
+  theorem isolates the first reusable summation step for the successor proof.
+
+## Current frontier
+
+The coefficientwise correction bound and the support-range theorem are now
+available.  The remaining local step is to prove the summed squared-l2norm
+bound using those two facts, preferably with smaller helper lemmas to keep
+elaboration and artifact generation manageable.
+
+## Next step
+
+Prove a lightweight generic helper for `HexPolyZMathlib.l2norm` that sums over
+an externally supplied support range, then instantiate it with
+`auxiliaryPolynomialWithCorrections_support_subset_range` and
+`auxiliaryPolynomialWithCorrections_coeff_sq_le`.  After that, factor the
+uncorrected coefficient-bound sum through `BHKS.cldColumnNormBound` and continue
+with the actual-cap diagonal-correction estimate.
+
+## Blockers
+
+No correctness blocker.  The only blocker encountered was resource pressure
+from an overly large one-shot l2norm proof term in `BadVector.lean`; splitting
+the proof should avoid it.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.BadVector:olean` passed.
+- `lake build HexBerlekampZassenhausMathlib.BadVector` passed.
+- `lake build HexBerlekampZassenhausMathlib` passed.
+- `python3 scripts/check_dag.py` passed.
+- `git diff --check` passed.
+- Added-line forbidden-token grep over
+  `HexBerlekampZassenhausMathlib/BadVector.lean` found no `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Partial progress on #6392

Session: `46786eb6-36ad-4349-9204-b8dd56823435`

00d00297 feat: add correction auxiliary support range

🤖 Prepared with Claude Code