### PR TITLE
Wire corrected BHKS auxiliary norm into cap comparison

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -1225,6 +1225,46 @@ theorem precision_separation_of_bridge_data
     2 * Hex.bhksCoeffBound W.input j < W.liftData.p ^ W.liftData.k := by
   exact D.precision_separation j hj
 
+/--
+Corrected auxiliary-polynomial squared-l2 bound supplied by
+`BadVectorBridgeData`.
+
+This instantiates `BHKS.auxiliaryPolynomialWithCorrections_l2norm_sq_le` with
+the bridge package's canonical projected-vector array and correction accessor,
+then rewrites the witness auxiliary polynomial through `auxiliary_eq'`.
+-/
+theorem auxiliaryPolynomial_l2norm_sq_le_of_bridge_data
+    {W : ExecutableBadVectorWitness}
+    {trueSupports : Set (Set (Fin W.projectedRows.factorCount))}
+    (D : BadVectorBridgeData W trueSupports)
+    (v : Fin W.projectedRows.factorCount → ℤ)
+    (hin : v ∈ BHKS.projectedRowSpanInt W.projectedRows)
+    (hnot : v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (h :
+      ∀ (i : Nat), i < W.liftData.liftedFactors.size → ∀ (j : Nat),
+        ((Hex.cldCoeffs W.input W.liftData.p W.liftData.k
+            (W.liftData.liftedFactors.getD i 0)).getD j 0).natAbs ≤
+          Hex.bhksCoeffBound W.input j) :
+    (HexPolyZMathlib.l2norm W.auxiliaryPolynomial) ^ 2 ≤
+      2 *
+          ((∑ i : Fin W.liftData.liftedFactors.size,
+              (((W.projectedVectorArray v).getD i.val 0 : ℝ) ^ 2)) *
+            ((W.liftData.liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound W.input W.liftData.p : ℝ))) +
+        2 *
+          (∑ j ∈ Finset.range (W.input.degree?.getD 0),
+            (((D.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+              ((W.liftData.p : ℝ) ^
+                (2 *
+                  (W.liftData.k -
+                    Hex.bhksCoeffCutThreshold W.liftData.p W.input j))))) := by
+  unfold ExecutableBadVectorWitness.auxiliaryPolynomial
+  rw [D.auxiliary_eq' v hin hnot]
+  exact
+    BHKS.auxiliaryPolynomialWithCorrections_l2norm_sq_le
+      W.input W.liftData (W.projectedVectorArray v)
+      (D.auxiliaryCorrections v hin hnot) h
+
 end BadVectorBridgeData
 
 /--

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2361,6 +2361,80 @@ theorem factorFastCapLift_resultant_divisible_by_p_pow_of_bridge_data
   ExecutableBadVectorWitness.resultant_divisible_by_p_pow_of_bridge_data bridge
 
 /--
+Actual-cap corrected auxiliary-polynomial squared-l2 bound supplied by
+`BadVectorBridgeData`.
+
+This is the factor-fast cap-lift specialization of
+`ExecutableBadVectorWitness.BadVectorBridgeData.auxiliaryPolynomial_l2norm_sq_le_of_bridge_data`.
+It exposes the corrected diagonal-row contribution through the bridge
+correction accessor, so later cap-separation code can bound the real
+auxiliary norm without falling back to the zero-correction auxiliary theorem.
+-/
+theorem factorFastCapLift_auxiliaryPolynomial_l2norm_sq_le_of_bridge_data
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j) :
+    (HexPolyZMathlib.l2norm
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial) ^ 2 ≤
+      2 *
+          ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+              ((((badVectorWitnessOfFactorFastCapLiftData
+                    f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                  i.val 0 : ℝ) ^ 2)) *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound
+                (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p : ℝ))) +
+        2 *
+          (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+            (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+              (((factorFastCapLiftData f primeData).p : ℝ) ^
+                (2 *
+                  ((factorFastCapLiftData f primeData).k -
+                    Hex.bhksCoeffCutThreshold
+                      (factorFastCapLiftData f primeData).p
+                      (Hex.normalizeForFactor f).squareFreeCore j))))) :=
+  ExecutableBadVectorWitness.BadVectorBridgeData.auxiliaryPolynomial_l2norm_sq_le_of_bridge_data
+    bridge v hin hnot hcld
+
+/--
 The remaining analytic comparison needed by cap separation at the actual
 `factorFast` cap lift.
 
@@ -2521,6 +2595,110 @@ theorem FactorFastCapLiftAnalyticComparison.ofL2normBounds
       (badVectorWitnessOfFactorFastCapLiftData
         f primeData rows_pos localFactorIndex localFactorDegree H)
       hinput hauxiliary hstrict
+
+/--
+Actual-cap analytic comparison from the corrected auxiliary-polynomial
+squared-l2 bound supplied by `BadVectorBridgeData`.
+
+The theorem plugs the corrected auxiliary l2 estimate into the cap-lift
+Hadamard comparison.  Callers provide the remaining arithmetic step bounding
+the explicit corrected RHS by `auxiliaryBound ^ 2`, plus the strict divisor
+comparison for that `auxiliaryBound`.
+-/
+theorem FactorFastCapLiftAnalyticComparison.ofBridgeDataCorrectedAuxiliaryL2normSq
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliary_sq_bound :
+      2 *
+          ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+              ((((badVectorWitnessOfFactorFastCapLiftData
+                    f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                  i.val 0 : ℝ) ^ 2)) *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound
+                (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p : ℝ))) +
+        2 *
+          (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+            (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+              (((factorFastCapLiftData f primeData).p : ℝ) ^
+                (2 *
+                  ((factorFastCapLiftData f primeData).k -
+                    Hex.bhksCoeffCutThreshold
+                      (factorFastCapLiftData f primeData).p
+                      (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+        auxiliaryBound ^ 2)
+    (hstrict :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree *
+        auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree <
+      ((factorFastCapLiftData f primeData).p ^
+        ((factorFastCapLiftData f primeData).k * localFactorDegree) : ℝ)) :
+    FactorFastCapLiftAnalyticComparison
+      f primeData rows_pos localFactorIndex localFactorDegree H := by
+  have hauxiliary_sq :
+      (HexPolyZMathlib.l2norm
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial) ^ 2 ≤
+        auxiliaryBound ^ 2 :=
+    (factorFastCapLift_auxiliaryPolynomial_l2norm_sq_le_of_bridge_data
+      f primeData rows_pos localFactorIndex localFactorDegree H trueSupports
+      bridge v hin hnot hcld).trans hauxiliary_sq_bound
+  have hauxiliary :
+      HexPolyZMathlib.l2norm
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial ≤
+        auxiliaryBound := by
+    exact le_of_sq_le_sq hauxiliary_sq hauxiliaryBound_nonneg
+  exact
+    FactorFastCapLiftAnalyticComparison.ofL2normBounds
+      f primeData rows_pos localFactorIndex localFactorDegree H
+      (factorFastCapLift_inputPolynomial_l2norm_le_coeffL2NormBound
+        f primeData rows_pos localFactorIndex localFactorDegree H)
+      hauxiliary hstrict
 
 /--
 Actual-cap bad-vector contradiction from the named cap-lift analytic

--- a/progress/20260603T002429Z_749b47c2.md
+++ b/progress/20260603T002429Z_749b47c2.md
@@ -1,0 +1,29 @@
+# 20260603T002429Z work #2567
+
+## Accomplished
+
+- Added `ExecutableBadVectorWitness.BadVectorBridgeData.auxiliaryPolynomial_l2norm_sq_le_of_bridge_data` in `HexBerlekampZassenhausMathlib/BadVector.lean`, instantiating the corrected auxiliary-polynomial squared-l2 theorem through the bridge package's projected vector and correction accessor.
+- Added the factor-fast cap-lift specialization `factorFastCapLift_auxiliaryPolynomial_l2norm_sq_le_of_bridge_data` in `HexBerlekampZassenhausMathlib/Recovery.lean`.
+- Added `FactorFastCapLiftAnalyticComparison.ofBridgeDataCorrectedAuxiliaryL2normSq`, which converts the corrected squared-l2 bound plus the remaining cap arithmetic into the packaged actual-cap analytic comparison.
+
+## Current frontier
+
+The corrected auxiliary l2-norm bound is now wired into the actual-cap comparison surface.  The next HO-4 step can focus on bounding the explicit corrected RHS by a concrete `auxiliaryBound ^ 2`, including the diagonal-row correction sum, and then discharging the strict divisor comparison.
+
+## Next step
+
+Prove the arithmetic estimate for the correction-sum term in `Recovery.lean`, then instantiate `FactorFastCapLiftAnalyticComparison.ofBridgeDataCorrectedAuxiliaryL2normSq` inside the `FactorFastCapSeparationInputs` assembly path.
+
+## Blockers
+
+No new technical blocker in this slice.  Full `factorFast_terminates` still needs the correction-sum arithmetic, the final cap-separation input provider, and the canonical recovery package to be assembled.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.BadVector` passed.
+- `lake build HexBerlekampZassenhausMathlib.Recovery` passed.
+- `lake build HexBerlekampZassenhausMathlib` passed.
+- `lake build HexBerlekampZassenhaus` passed.
+- `python3 scripts/check_dag.py` passed.
+- `git diff --check` passed.
+- Added-line forbidden-token grep over touched Lean files found no `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Refs #2567

Partial HO-4 slice: wires the corrected auxiliary-polynomial squared-l2 bound from `BadVectorBridgeData` into the actual-cap `FactorFastCapLiftAnalyticComparison` constructor surface.

Remaining scope is recorded in `progress/20260603T002429Z_749b47c2.md`: prove the correction-sum arithmetic bound, instantiate this constructor in the cap-separation input provider, and continue the final `factorFast_terminates` assembly.

Session: `749b47c2-4d8b-4d54-9d50-0511dc7db74d`

c145296e Wire corrected BHKS auxiliary norm into cap comparison