### PR TITLE
spec: mandate per-row Schur recurrence for HexGramSchmidt.Int.scaledCoeffs

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -46,11 +46,45 @@ def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
 
 /-- Scaled GS coefficients (the ν-values): entry (i,j) = d_{j+1} * μ_{i,j}
     for j < i. Always integers (integrality lemma).
-    Computed in a single Bareiss-style integer pass shared across all
-    entries, reusing the same elimination scaffolding as `gramDetVec`:
-    O(n^3 + n^2 m) total. Computing each below-diagonal entry
-    independently as a (j+1) × (j+1) Bareiss determinant is forbidden —
-    that body is `O(n^5)`. -/
+
+    Computed via a per-row Schur-complement recurrence. For each
+    `(i, j)` with `j < i`, define a σ-chain of length `j + 1` with
+    one exact integer divide per step:
+
+        σ₀     := ν[i][0] * ν[j+1][0]
+        σ_l    := (d_{l+1} * σ_{l-1} + ν[i][l] * ν[j+1][l]) / d_l
+                        for 1 ≤ l ≤ j
+        ν[i][j] := d_{j+1} * ⟨b_i, b_{j+1}⟩ - σ_j
+
+    where `d_k` is the `k`-th leading-principal-minor determinant
+    of the Gram matrix (`d_0 := 1`), stored as
+    `scaledCoeffs[k-1][k-1]`. Diagonal entries
+    `scaledCoeffs[k][k] = d_{k+1}` are produced by the same
+    shape with `i = j + 1 = k`.
+
+    Total: `≈ n^3 / 3` big-int multiplications (the σ-chain
+    contributes one `+ 1` multiply per level, summed over
+    `(i, j)` to `≈ n^3 / 6`, doubled by the `*` inside the chain)
+    plus `n^2 * m` dot-product multiplications for the
+    `⟨b_i, b_{j+1}⟩` inner products. This recurrence shape is the
+    one used by the verified Isabelle LLL's `dmu_array_row` /
+    `sigma_array` (AFP `LLL_Basis_Reduction`, Bottesch et al.);
+    the project requires this shape because the comparator runs
+    against that implementation.
+
+    Two body shapes are forbidden:
+    (a) computing each below-diagonal entry independently as a
+        `(j+1) × (j+1)` Bareiss determinant — `O(n^5)`;
+    (b) column-major Bareiss elimination over the lower
+        sub-matrix that, at each pivot step k, updates every
+        `(n − k) × (n − k)` cell with a two-product fraction-free
+        Schur step (`pivot * A[i][j] − A[i][k] * A[k][j]) / prevPivot`) —
+        `≈ 2n^3 / 3` big-int multiplications per `ofBasis`,
+        roughly `2×` the per-row recurrence. The constant-factor
+        overhead is observable as a `~14%` wall-time gap against
+        the verified Isabelle comparator on HexLLL's harsh-cubic
+        ladder (per-op cost differs too: full Bareiss tends to
+        carry larger intermediate operands). -/
 def scaledCoeffs (b : Matrix Int n m) : Matrix Int n n
 
 end Hex.GramSchmidt.Int
@@ -209,11 +243,14 @@ No external comparator is required.
 **Justification:** `structural-layer` per
 `SPEC/benchmarking.md §"Comparator naming"`. HexGramSchmidt is a
 structural layer over `HexMatrix`: the integer Gram-Schmidt
-construction is implemented via Bareiss-style fraction-free
-elimination on the Gram matrix (`Matrix.bareissNoPivotData`),
-which is HexMatrix's own architecturally-named surface and is
-covered by HexMatrix's external comparator declaration
-(`FLINT fmpz_mat_det`, scoped to the determinant surface).
+construction is implemented via the per-row Schur-complement
+recurrence specified for `scaledCoeffs` above, with the diagonal
+emitted as `d_{k+1} = scaledCoeffs[k][k]` for `gramDetVec`. The
+underlying integer arithmetic and inner-product primitives come
+from HexMatrix; HexMatrix's external comparator declaration
+(`FLINT fmpz_mat_det`, scoped to the determinant surface) covers
+the determinant computation that the recurrence's diagonal
+produces.
 
 End-to-end coverage of the integer Gram-Schmidt construction as
 it appears in downstream consumers is via HexLLL's `gating`

--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -358,18 +358,20 @@ classification below is mirrored as structured metadata in
 ### `LLLState.ofBasis` is its own bench target
 
 The integer Gram–Schmidt construction in `LLLState.ofBasis` —
-implemented as a Bareiss-style fraction-free elimination over the
-Gram matrix — is asymptotically significant in its own right:
-classical analysis gives ~ n³ integer arithmetic operations with
-operand bit-width growing in `n` per Hadamard's bound. This shape
-is distinct from the LLL outer loop's ~ n² iterations × O(n) work
-on near-orthogonal random input. Per the
+implemented as a per-row Schur-complement recurrence over the
+Gram matrix (per
+[SPEC/Libraries/hex-gram-schmidt.md](hex-gram-schmidt.md)) — is
+asymptotically significant in its own right: classical analysis
+gives ~ n³ integer arithmetic operations with operand bit-width
+growing in `n` per Hadamard's bound. This shape is distinct from
+the LLL outer loop's ~ n² iterations × O(n) work on
+near-orthogonal random input. Per the
 [SPEC/benchmarking.md §Attribution rule](../benchmarking.md#the-attribution-rule),
 each must be verified by its own `setup_benchmark` so a future
 profiling finding is attributable to one phase or the other:
 
 - a `setup_benchmark` for `LLLState.ofBasis n => …` declaring the
-  Bareiss-prep complexity over the bench's input family;
+  GS-prep complexity over the bench's input family;
 - a `setup_benchmark` for `lll`/`lll.firstShortVector` (or a fixed
   benchmark on a family-specific canonical input) declaring the
   outer-loop complexity over that input family.


### PR DESCRIPTION
The existing SPEC ([SPEC/Libraries/hex-gram-schmidt.md:47-53](SPEC/Libraries/hex-gram-schmidt.md#L47-L53)) mandates Bareiss-style column-major elimination for `scaledCoeffs`. Profile evidence on the harsh-cubic LLL ladder shows that shape doing ~2× the big-int multiplications of the σ-recurrence used by the verified Isabelle LLL comparator (`dmu_array_row` / `sigma_array` in AFP `LLL_Basis_Reduction`, Bottesch et al.). That constant-factor difference is the observable ~14% wall-time gap that keeps `HexLLL.done_through` at 3 (per [reports/hex-lll-performance.md §Concerns](reports/hex-lll-performance.md#concerns)).

## What this changes

1. **`scaledCoeffs` body shape (normative)** — replaces "single Bareiss-style integer pass" with a per-row Schur-complement recurrence specified by explicit σ-chain formula in project notation:

   ```
   σ₀     := ν[i][0] * ν[j+1][0]
   σ_l    := (d_{l+1} * σ_{l-1} + ν[i][l] * ν[j+1][l]) / d_l    for 1 ≤ l ≤ j
   ν[i][j] := d_{j+1} * ⟨b_i, b_{j+1}⟩ - σ_j
   ```

   Cost target: `≈ n³/3` big-int multiplications plus `n²·m` dot-product multiplications. Two body shapes are explicitly forbidden — (a) the per-entry `(j+1)×(j+1)` Bareiss determinant (`O(n^5)`) that the old SPEC already forbade, and (b) the column-major Bareiss elimination over the trailing sub-matrix (≈ 2n³/3 multiplications per `ofBasis`).

2. **Two stale references updated** — the structural-layer justification in this file's §Comparator section, and the `LLLState.ofBasis` bench-target discussion in `SPEC/Libraries/hex-lll.md`, both previously named "Bareiss-style fraction-free elimination on the Gram matrix" as the implementation shape.

## Why this exact wording

Reviewed by OpenAI Codex. The first draft had three real issues that the current text addresses:
- **Pseudocode missing.** The σ-chain formula now appears explicitly so an implementer doesn't need to re-derive from the Isabelle source.
- **Cost claim was off.** Original draft said "3× the per-row recurrence"; Codex pointed out Bareiss column-major is ≈ 2n³/3 (not n³), making the multiplier 2×. The 14% observed gap is consistent with 2× muls plus per-op cost (Bareiss tends to carry larger intermediate operands).
- **Stale cross-references.** Two other SPEC paragraphs still named Bareiss as the implementation; if this clause landed alone, a worker would see contradictory normative text. Both are updated in this PR.

## Followups (out of scope)

- An implementation directive will be filed against this SPEC and dispatched via `pod once`. That worker rewrites `HexGramSchmidt.Int.scaledCoeffs` / `stepScaledRows` / `scaledCoeffArrayLoop` to the σ-recurrence shape, threads any new invariants through the proofs, and re-benches the harsh-cubic ladder to demonstrate the gap closes.
- If the σ-recurrence implementation also wants to publish a `Matrix.schurRecurrence` primitive in HexMatrix for re-use, that's a follow-up SPEC change — not required here.

🤖 Prepared with Claude Code