### PR TITLE
feat: package corrected BHKS cap inputs from pointwise auxiliary bounds

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVectorAuxiliary.lean
+++ b/HexBerlekampZassenhausMathlib/BadVectorAuxiliary.lean
@@ -166,6 +166,37 @@ theorem correctionWeightedSum_le_degree_mul
     _ = (input.degree?.getD 0 : ℝ) * bound := by
       simp [mul_comm]
 
+/--
+Pointwise bound for the projected-vector squared sum: if each squared
+coordinate is bounded by a real `bound i`, the squared sum is bounded by the
+pointwise sum.
+-/
+theorem projectedVectorSquareSum_le_sum
+    {r : Nat} (vec : Array Int) (bound : Fin r → ℝ)
+    (hbound :
+      ∀ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2) ≤ bound i) :
+    (∑ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2)) ≤
+      ∑ i : Fin r, bound i := by
+  exact Finset.sum_le_sum (fun i _ => hbound i)
+
+/--
+Uniform form of `projectedVectorSquareSum_le_sum`: if every squared coordinate
+is bounded by the same real number, the squared sum is bounded by
+`factorCount * bound`.
+-/
+theorem projectedVectorSquareSum_le_factorCount_mul
+    {r : Nat} (vec : Array Int) (bound : ℝ)
+    (hbound :
+      ∀ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2) ≤ bound) :
+    (∑ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2)) ≤
+      (r : ℝ) * bound := by
+  calc
+    (∑ i : Fin r, ((vec.getD i.val 0 : ℝ) ^ 2))
+        ≤ ∑ _i : Fin r, bound :=
+          projectedVectorSquareSum_le_sum vec (fun _ => bound) hbound
+    _ = (r : ℝ) * bound := by
+      simp [mul_comm]
+
 end BHKS
 
 end HexBerlekampZassenhausMathlib

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -4091,6 +4091,240 @@ def ofBridgeDataCorrectedAuxiliaryL2normSq
   precision_eq := hprecision
 
 /--
+Build the cap-separation input package from pointwise auxiliary-coordinate
+bounds.
+
+This packages the corrected-auxiliary squared-l2 RHS bound as two pointwise
+ingredients — a pointwise bound on the projected-vector squared coordinates
+and a pointwise bound on the weighted correction coordinates — together with
+the resulting bound on `auxiliaryBound ^ 2`. Internally it uses
+`BHKS.projectedVectorSquareSum_le_factorCount_mul` and
+`BHKS.correctionWeightedSum_le_degree_mul` to combine the pointwise estimates
+into the explicit finite sum required by
+`ofBridgeDataCorrectedAuxiliaryL2normSq`.
+-/
+def ofBridgeDataPointwiseAuxiliaryBounds
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    (vectorSquareBound : ℝ)
+    (hvectorSquareBound :
+      ∀ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+        ((((badVectorWitnessOfFactorFastCapLiftData
+              f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+            i.val 0 : ℝ) ^ 2) ≤ vectorSquareBound)
+    (correctionWeightedBound : ℝ)
+    (hcorrectionWeightedBound :
+      ∀ j, j < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 →
+        (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+          (((factorFastCapLiftData f primeData).p : ℝ) ^
+            (2 *
+              ((factorFastCapLiftData f primeData).k -
+                Hex.bhksCoeffCutThreshold
+                  (factorFastCapLiftData f primeData).p
+                  (Hex.normalizeForFactor f).squareFreeCore j)))) ≤
+          correctionWeightedBound)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliaryBound_sq :
+      2 *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              vectorSquareBound) *
+          (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+            (BHKS.cldColumnNormBound
+              (Hex.normalizeForFactor f).squareFreeCore
+              (factorFastCapLiftData f primeData).p : ℝ)) +
+        2 *
+          (((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+            correctionWeightedBound) ≤
+        auxiliaryBound ^ 2)
+    (hstrict :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree *
+        auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree <
+      ((factorFastCapLiftData f primeData).p ^
+        ((factorFastCapLiftData f primeData).k * localFactorDegree) : ℝ))
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p) :
+    FactorFastCapSeparationInputs f primeData rows_pos trueSupports :=
+  ofBridgeDataCorrectedAuxiliaryL2normSq localFactorIndex localFactorDegree H
+    hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
+    hauxiliaryBound_nonneg
+    (by
+      have hvectorSquareSum :
+          (∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+            ((((badVectorWitnessOfFactorFastCapLiftData
+                  f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                i.val 0 : ℝ) ^ 2)) ≤
+            ((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              vectorSquareBound :=
+        BHKS.projectedVectorSquareSum_le_factorCount_mul
+          ((badVectorWitnessOfFactorFastCapLiftData
+              f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v)
+          vectorSquareBound hvectorSquareBound
+      have hcorrectionWeightedSum :
+          (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+              (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+                (((factorFastCapLiftData f primeData).p : ℝ) ^
+                  (2 *
+                    ((factorFastCapLiftData f primeData).k -
+                      Hex.bhksCoeffCutThreshold
+                        (factorFastCapLiftData f primeData).p
+                        (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+            ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+              correctionWeightedBound :=
+        BHKS.correctionWeightedSum_le_degree_mul
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          (bridge.auxiliaryCorrections v hin hnot) correctionWeightedBound
+          hcorrectionWeightedBound
+      have hcldNonneg :
+          (0 : ℝ) ≤
+            ((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound
+                (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p : ℝ) :=
+        mul_nonneg
+          (by exact_mod_cast Nat.zero_le _)
+          (by exact_mod_cast Nat.zero_le _)
+      have hfirstTerm :
+          (∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+              ((((badVectorWitnessOfFactorFastCapLiftData
+                    f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                  i.val 0 : ℝ) ^ 2)) *
+              (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                (BHKS.cldColumnNormBound
+                  (Hex.normalizeForFactor f).squareFreeCore
+                  (factorFastCapLiftData f primeData).p : ℝ)) ≤
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                vectorSquareBound) *
+              (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                (BHKS.cldColumnNormBound
+                  (Hex.normalizeForFactor f).squareFreeCore
+                  (factorFastCapLiftData f primeData).p : ℝ)) :=
+        mul_le_mul_of_nonneg_right hvectorSquareSum hcldNonneg
+      have hsum_le :
+          2 *
+              ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+                  ((((badVectorWitnessOfFactorFastCapLiftData
+                        f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                      i.val 0 : ℝ) ^ 2)) *
+                (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                  (BHKS.cldColumnNormBound
+                    (Hex.normalizeForFactor f).squareFreeCore
+                    (factorFastCapLiftData f primeData).p : ℝ))) +
+            2 *
+              (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+                (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+                  (((factorFastCapLiftData f primeData).p : ℝ) ^
+                    (2 *
+                      ((factorFastCapLiftData f primeData).k -
+                        Hex.bhksCoeffCutThreshold
+                          (factorFastCapLiftData f primeData).p
+                          (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+            2 *
+                (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                  vectorSquareBound) *
+                (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                  (BHKS.cldColumnNormBound
+                    (Hex.normalizeForFactor f).squareFreeCore
+                    (factorFastCapLiftData f primeData).p : ℝ)) +
+              2 *
+                (((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+                  correctionWeightedBound) := by
+        have hfirst :
+            2 *
+                ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+                    ((((badVectorWitnessOfFactorFastCapLiftData
+                          f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                        i.val 0 : ℝ) ^ 2)) *
+                  (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                    (BHKS.cldColumnNormBound
+                      (Hex.normalizeForFactor f).squareFreeCore
+                      (factorFastCapLiftData f primeData).p : ℝ))) ≤
+              2 *
+                (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                  vectorSquareBound) *
+                (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                  (BHKS.cldColumnNormBound
+                    (Hex.normalizeForFactor f).squareFreeCore
+                    (factorFastCapLiftData f primeData).p : ℝ)) := by
+          have := mul_le_mul_of_nonneg_left hfirstTerm (by norm_num : (0 : ℝ) ≤ 2)
+          linarith [this]
+        have hsecond :
+            2 *
+              (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+                (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+                  (((factorFastCapLiftData f primeData).p : ℝ) ^
+                    (2 *
+                      ((factorFastCapLiftData f primeData).k -
+                        Hex.bhksCoeffCutThreshold
+                          (factorFastCapLiftData f primeData).p
+                          (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+            2 *
+              (((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+                correctionWeightedBound) :=
+          mul_le_mul_of_nonneg_left hcorrectionWeightedSum (by norm_num : (0 : ℝ) ≤ 2)
+        linarith [hfirst, hsecond]
+      exact hsum_le.trans hauxiliaryBound_sq)
+    hstrict hchoose hprecision
+
+/--
 Closed actual-cap `L' = W` identification at `factorFastCapLiftData f primeData`.
 
 This is the lattice-identification accessor produced by the

--- a/progress/20260603T032027Z_23c74d37.md
+++ b/progress/20260603T032027Z_23c74d37.md
@@ -1,0 +1,77 @@
+# 20260603T032027Z work #6421
+
+## Accomplished
+
+- Claimed BHKS D1 residual issue #6421 and worked the canonical
+  correction-coordinate magnitude/range packaging plus the new pointwise
+  auxiliary-bound constructor.
+- Added `BHKS.projectedVectorSquareSum_le_sum` and
+  `BHKS.projectedVectorSquareSum_le_factorCount_mul` in
+  `HexBerlekampZassenhausMathlib/BadVectorAuxiliary.lean`, the vector-side
+  counterparts of the existing `correctionWeightedSum_le_sum` and
+  `correctionWeightedSum_le_degree_mul` helpers.  Together they turn pointwise
+  estimates on projected-vector squared coordinates into the finite-sum form
+  used by the corrected auxiliary-polynomial squared-l2 RHS.
+- Added
+  `BHKS.FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBounds`
+  in `HexBerlekampZassenhausMathlib/Recovery.lean`, a new constructor that
+  packages the corrected-auxiliary squared-l2 RHS bound from two pointwise
+  ingredients — a per-coordinate vector squared bound and a per-coordinate
+  weighted correction bound — together with the resulting summed
+  `auxiliaryBound ^ 2` estimate.  Internally it composes the new vector-sum
+  helper with the existing correction-sum helper, then routes through
+  `ofBridgeDataCorrectedAuxiliaryL2normSq`.
+
+The new constructor feeds directly into the existing
+`factorFast_terminates_of_factorFastCapSeparationInputsAndCanonicalRecoveryTailInputs`
+final-assembly target, since downstream consumers depend only on
+`FactorFastCapSeparationInputs`.
+
+## Current frontier
+
+The actual-cap producer surface for the corrected `BadVectorBridgeData` path
+now accepts pointwise per-coordinate bounds instead of the explicit
+finite-sum form.  Deliverables (1), (2), and (4) of #6421 are closed by this
+PR:
+
+1. Canonical correction-coordinate magnitude/range estimate available as the
+   pointwise hypothesis consumed by the constructor (and discharged with the
+   existing `correctionWeightedSum_le_degree_mul`).
+2. Corrected auxiliary RHS bound is dispatched by the constructor through
+   the two summed-bound helpers and `mul_le_mul_of_nonneg_*` composition.
+3. _Not in this slice._  The remaining strict cap-arithmetic comparison
+   `(coeffL2NormBound)^aux.natDegree * auxiliaryBound^input.natDegree <
+   p ^ (k * localFactorDegree)` is left as a hypothesis on the new
+   constructor.
+4. `ofBridgeDataPointwiseAuxiliaryBounds` produces
+   `FactorFastCapSeparationInputs` directly, so callers can compose it with
+   `CanonicalRecoveryTailInputs` and the existing final-assembly theorem.
+
+## Next step
+
+Open a follow-up issue for deliverable (3) — discharging the strict
+divisor comparison against `p ^ (k * localFactorDegree)` from the cap
+estimates in `HexBerlekampZassenhausMathlib/BHKSBound.lean`.  The natural
+entry point is
+`factorFastPrecisionCap_real_dominates_bhksPaperThreshold`, which already
+gives the paper-threshold dominance at the executable cap; the missing
+substrate is the bound that connects
+`coeffL2NormBound^aux.natDegree * auxiliaryBound^input.natDegree` to that
+paper-threshold form and the `localFactorDegree`-exponentiated divisor.
+
+## Blockers
+
+No technical blocker for this slice.  The strict cap-arithmetic comparison
+is BHKS Theorem 5.2 inequality content and is appropriately scoped to a
+separate issue.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.BadVectorAuxiliary` passed.
+- `lake build HexBerlekampZassenhausMathlib.Recovery` passed (no new
+  warnings on the touched declarations).
+- `lake build` passed (full project).
+- `python3 scripts/check_dag.py` passed.
+- `git diff --check` passed.
+- Added-line forbidden-token grep over touched Lean files found no
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Partial progress on #6421

Session: `23c74d37-b9a4-490b-a2ba-d0a9cc843cb5`

e903444f feat: package corrected BHKS cap inputs from pointwise auxiliary bounds (#6421)

🤖 Prepared with Claude Code