### PR TITLE
BHKS: per-candidate reduceModPow equality from bhksIndicatorCandidate? under monic hypotheses

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5021,6 +5021,51 @@ private theorem bhksIndicatorCandidate?_dvd
         simp at h
 
 /--
+The candidate returned by a successful `bhksIndicatorCandidate?` call is
+exactly the canonical normalization of the centred lift of the modular product.
+This is a Mathlib-free surface lemma that downstream Mathlib-side proofs use to
+identify the candidate against the centred lift, avoiding the need to reference
+the private `liftModulus` definition from outside this file.
+-/
+theorem bhksIndicatorCandidate?_eq_normalized_centeredLift
+    {f : ZPoly} {d : LiftData} {indicator : Array Int}
+    {candidate quotient : ZPoly} {selected : Array ZPoly}
+    (h : bhksIndicatorCandidate? f d indicator = some (candidate, quotient))
+    (hselected : bhksIndicatorSelectedFactors d.liftedFactors indicator = some selected) :
+    candidate = normalizeFactorSign (normalizeCandidateFactor
+      (centeredLiftPoly
+        (ZPoly.reduceModPow
+          (DensePoly.scale (DensePoly.leadingCoeff f) (Array.polyProduct selected))
+          d.p d.k)
+        (d.p ^ d.k))) := by
+  unfold bhksIndicatorCandidate? at h
+  rw [hselected] at h
+  let modulus := liftModulus d
+  let raw := DensePoly.scale (DensePoly.leadingCoeff f) (Array.polyProduct selected)
+  let candidate0 :=
+    normalizeCandidateFactor
+      (centeredLiftPoly (ZPoly.reduceModPow raw d.p d.k) modulus)
+  let candidate' := normalizeFactorSign candidate0
+  change
+    (if shouldRecordPolynomialFactor candidate' then
+      match exactQuotient? f candidate' with
+      | some quotient => some (candidate', quotient)
+      | none => none
+    else
+      none) = some (candidate, quotient) at h
+  by_cases hrecord : shouldRecordPolynomialFactor candidate'
+  · rw [if_pos hrecord] at h
+    cases hquot : exactQuotient? f candidate' with
+    | none => simp [hquot] at h
+    | some quotient' =>
+        simp [hquot] at h
+        rcases h with ⟨hcandidate, _hquotient⟩
+        subst candidate
+        rfl
+  · rw [if_neg hrecord] at h
+    simp at h
+
+/--
 A2 reconstruction surface for a single BHKS indicator, stated at the
 Mathlib-free executable layer. If the indicator selects `selected`, the
 scaled selected product is congruent to the expected factor modulo the Hensel

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -8411,6 +8411,148 @@ private theorem size_centeredLiftPoly_eq_of_monic
   exact le_antisymm hg'_size_le hg'_size_ge
 
 /--
+`Array.polyProduct` of an array all of whose entries are monic is monic.
+
+The base case is `Monic 1` (`zpoly_monic_one`); the inductive step chains
+`zpoly_monic_mul` through each entry along the `foldl` accumulator.
+-/
+private theorem polyProduct_monic_of_all_monic
+    {factors : Array Hex.ZPoly}
+    (hmonic : ∀ p ∈ factors.toList, Hex.DensePoly.Monic p) :
+    Hex.DensePoly.Monic (Array.polyProduct factors) := by
+  unfold Array.polyProduct
+  rw [← Array.foldl_toList]
+  suffices h : ∀ (l : List Hex.ZPoly) (acc : Hex.ZPoly),
+      Hex.DensePoly.Monic acc →
+      (∀ p ∈ l, Hex.DensePoly.Monic p) →
+      Hex.DensePoly.Monic (l.foldl (· * ·) acc) by
+    exact h factors.toList 1 zpoly_monic_one hmonic
+  intro l
+  induction l with
+  | nil =>
+    intro acc hacc _
+    simpa using hacc
+  | cons x rest ih =>
+    intro acc hacc hl
+    simp only [List.foldl_cons]
+    apply ih
+    · exact zpoly_monic_mul hacc (hl x List.mem_cons_self)
+    · intro p hp; exact hl p (List.mem_cons_of_mem _ hp)
+
+/--
+A successful `bhksIndicatorCandidate?` call yields, under monic-core and
+monic-selected-factor hypotheses, the canonical modular product equality
+`reduceModPow raw p k = reduceModPow candidate p k`.
+
+This is the per-candidate modular-product fact needed to derive the
+`RepresentsIntegerFactorAtLift` certificate from a successful candidate path
+(see issue #6455 / #6450). The proof routes through:
+
+- the centred-lift round-trip identity `centeredLiftPoly_reduceModPow_eq`,
+- `monic_centeredLiftPoly_of_monic` to push monicness through the centred lift,
+- `zpoly_primitive_of_monic` + `primitivePart_eq_self_of_primitive` to
+  collapse `normalizeCandidateFactor` to identity on monic input,
+- `zpoly_normalize_factor_sign_of_monic` to collapse `normalizeFactorSign` to
+  identity on monic input.
+-/
+theorem bhksIndicatorCandidate?_reduceModPow_eq_of_monic
+    {core : Hex.ZPoly} {d : Hex.LiftData} {indicator : Array Int}
+    {candidate quotient : Hex.ZPoly} {selected : Array Hex.ZPoly}
+    (h : Hex.bhksIndicatorCandidate? core d indicator = some (candidate, quotient))
+    (hselected :
+       Hex.bhksIndicatorSelectedFactors d.liftedFactors indicator = some selected)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hselected_monic :
+       ∀ p ∈ selected.toList, Hex.DensePoly.Monic p)
+    (hp_two_lt : 2 ≤ d.p ^ d.k) :
+    Hex.ZPoly.reduceModPow
+        (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core)
+          (Array.polyProduct selected)) d.p d.k =
+      Hex.ZPoly.reduceModPow candidate d.p d.k := by
+  -- Step 1: lc(core) = 1 since core is monic.
+  have hlc : Hex.DensePoly.leadingCoeff core = (1 : Int) := hcore_monic
+  -- Step 2: polyProduct selected is monic.
+  have hprod_monic : Hex.DensePoly.Monic (Array.polyProduct selected) :=
+    polyProduct_monic_of_all_monic hselected_monic
+  -- Step 3: raw = scale 1 (polyProduct selected) = polyProduct selected, so raw is monic.
+  set raw := Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core)
+    (Array.polyProduct selected) with hraw_def
+  have hraw_eq : raw = Array.polyProduct selected := by
+    rw [hraw_def, hlc]
+    -- scale 1 g = g (coefficient-wise): both sides equal Array.polyProduct selected.
+    apply Hex.DensePoly.ext_coeff
+    intro n
+    rw [Hex.DensePoly.coeff_scale _ _ _ (by ring : (1 : Int) * 0 = 0)]
+    ring
+  have hraw_monic : Hex.DensePoly.Monic raw := by rw [hraw_eq]; exact hprod_monic
+  -- Step 4: centeredLiftPoly raw (p^k) is monic.
+  have hcl_raw_monic : Hex.DensePoly.Monic
+      (Hex.centeredLiftPoly raw (d.p ^ d.k)) :=
+    monic_centeredLiftPoly_of_monic hraw_monic hp_two_lt
+  -- Step 5: centeredLiftPoly (reduceModPow raw p k) (p^k) = centeredLiftPoly raw (p^k).
+  have hcl_eq : Hex.centeredLiftPoly (Hex.ZPoly.reduceModPow raw d.p d.k) (d.p ^ d.k) =
+      Hex.centeredLiftPoly raw (d.p ^ d.k) :=
+    centeredLiftPoly_reduceModPow_eq raw d.p d.k d.p_pos
+  -- Step 6: The centred lift is monic, and normalize-stuff are identities on monic input.
+  set cl := Hex.centeredLiftPoly (Hex.ZPoly.reduceModPow raw d.p d.k) (d.p ^ d.k)
+    with hcl_def
+  have hcl_monic : Hex.DensePoly.Monic cl := by rw [hcl_eq]; exact hcl_raw_monic
+  have hcl_prim : Hex.ZPoly.Primitive cl := zpoly_primitive_of_monic hcl_monic
+  have hpprim : Hex.ZPoly.primitivePart cl = cl :=
+    Hex.ZPoly.primitivePart_eq_self_of_primitive cl hcl_prim
+  have hnorm_cand : Hex.normalizeCandidateFactor cl = cl := by
+    unfold Hex.normalizeCandidateFactor
+    rw [hpprim]
+    have : ¬ Hex.DensePoly.leadingCoeff cl < 0 := by
+      have : Hex.DensePoly.leadingCoeff cl = (1 : Int) := hcl_monic
+      rw [this]; decide
+    simp [this]
+  have hnorm_sign : Hex.normalizeFactorSign cl = cl :=
+    zpoly_normalize_factor_sign_of_monic hcl_monic
+  -- Step 7: candidate = cl, using the executable-layer characterization.
+  have hcand_eq : candidate = cl := by
+    have hext := Hex.bhksIndicatorCandidate?_eq_normalized_centeredLift h hselected
+    rw [hext, hcl_def, hnorm_cand, hnorm_sign]
+  -- Step 8: reduceModPow raw p k = reduceModPow cl p k via the centered lift.
+  rw [hcand_eq]
+  -- Goal: reduceModPow raw p k = reduceModPow cl p k.
+  -- cl = centeredLiftPoly (reduceModPow raw p k) (p^k).
+  -- Reducing the centred lift back recovers the canonical residue.
+  -- Key helper: centeredModNat x m ≡ x (mod m).
+  have hcenteredModNat_emod_eq :
+      ∀ (z : Int) (m : Nat), m ≠ 0 →
+        (Hex.centeredModNat z m) % (Int.ofNat m) = z % (Int.ofNat m) := by
+    intro z m hm
+    unfold Hex.centeredModNat
+    rw [if_neg hm]
+    set r := z % (Int.ofNat m) with hr_def
+    have hrmod : r % (Int.ofNat m) = r := by
+      rw [hr_def, Int.emod_emod_of_dvd _ (dvd_refl _)]
+    by_cases hc1 : 2 * r.natAbs ≤ m
+    · rw [if_pos hc1]; exact hrmod
+    · rw [if_neg hc1]
+      by_cases hc2 : r < 0
+      · rw [if_pos hc2]
+        have hrwadd : (r + Int.ofNat m) % Int.ofNat m = r % Int.ofNat m := by
+          rw [show r + Int.ofNat m = r + 1 * Int.ofNat m by ring,
+            Int.add_mul_emod_self_right]
+        rw [hrwadd, hrmod]
+      · rw [if_neg hc2]
+        have hrwsub : (r - Int.ofNat m) % Int.ofNat m = r % Int.ofNat m := by
+          rw [show r - Int.ofNat m = r + (-1) * Int.ofNat m by ring,
+            Int.add_mul_emod_self_right]
+        rw [hrwsub, hrmod]
+  apply Hex.DensePoly.ext_coeff
+  intro n
+  rw [hcl_def, Hex.ZPoly.coeff_reduceModPow_eq_emod_of_pos _ _ _ _ (Nat.pow_pos d.p_pos),
+    Hex.ZPoly.coeff_reduceModPow_eq_emod_of_pos _ _ _ _ (Nat.pow_pos d.p_pos),
+    Hex.coeff_centeredLiftPoly,
+    Hex.ZPoly.coeff_reduceModPow_eq_emod_of_pos _ _ _ _ (Nat.pow_pos d.p_pos)]
+  -- Goal: raw.coeff n % m = centeredModNat (raw.coeff n % m) m % m.
+  rw [hcenteredModNat_emod_eq _ _ (Nat.ne_of_gt (Nat.pow_pos d.p_pos))]
+  exact (Int.emod_emod_of_dvd _ (dvd_refl _)).symm
+
+/--
 The Mathlib-transported `natDegree` of the executable recombination candidate
 over a lifted-factor subset equals the sum of the Mathlib-transported
 `natDegree`s of the selected lifted factors.

--- a/progress/20260603T053629Z_a60e31d5.md
+++ b/progress/20260603T053629Z_a60e31d5.md
@@ -1,0 +1,90 @@
+# 20260603T053629Z work #6455 (split off from #6450)
+
+## Accomplished
+
+- Claimed parent issue #6450 (BHKS recovery-tail packaging:
+  per-canonical-class `RepresentsIntegerFactorAtLift` certificates).
+  Mathematical analysis of the deliverable showed that the spec is not
+  provable as stated without additional hypotheses on `core` and the
+  selected lifted factors. The centred-lift candidate
+  `normalizeFactorSign (normalizeCandidateFactor (centeredLiftPoly
+  (reduceModPow raw p k) (p^k)))` equals the input `raw` modulo `p^k`
+  only when the centred lift's content and sign are 1 mod `p^k`, which
+  requires monic-core (`scale lc(core) = identity`) and monic-selected
+  (`polyProduct selected` monic mod `p^k`).
+- Decomposed #6450 into two sub-issues:
+  - **#6455** — the technical lemma
+    `bhksIndicatorCandidate?_reduceModPow_eq_of_monic` with explicit
+    monic hypotheses (this PR).
+  - **#6456** — composition through `selectedFactorsOfMembers_polyProduct`
+    + canonical class fold + actual-cap wrapper that discharges the
+    monic hypotheses via `henselLiftData_liftedFactor_monic` and the
+    `(Hex.normalizeForFactor f).squareFreeCore` monic invariant.
+  Left a `Decomposed into #6455, #6456` breadcrumb on #6450 and
+  `coordination skip`-ed it.
+- Claimed #6455 and proved its two deliverables:
+  - `polyProduct_monic_of_all_monic` (`HexBerlekampZassenhausMathlib/Basic.lean`):
+    `Array.polyProduct` of an array of monic factors is monic. The
+    proof unfolds `Array.polyProduct = factors.foldl (· * ·) 1`,
+    converts to `List.foldl`, and inducts on the underlying list with
+    `zpoly_monic_mul` / `zpoly_monic_one`.
+  - `bhksIndicatorCandidate?_reduceModPow_eq_of_monic`
+    (`HexBerlekampZassenhausMathlib/Basic.lean`): under monic `core`,
+    monic-selected `selected.toList` factors, and `2 ≤ d.p ^ d.k`, a
+    successful `Hex.bhksIndicatorCandidate? core d indicator = some
+    (candidate, quotient)` gives
+    ```
+    reduceModPow (scale lc(core) (polyProduct selected)) p k =
+      reduceModPow candidate p k
+    ```
+    The proof chains: monic-core ⇒ raw = polyProduct selected ⇒ raw
+    monic ⇒ `monic_centeredLiftPoly_of_monic` gives a monic centred
+    lift `cl` ⇒ primitive (`zpoly_primitive_of_monic`) and
+    `normalizeFactorSign` is identity
+    (`zpoly_normalize_factor_sign_of_monic`) ⇒ candidate = cl ⇒
+    coefficient-wise `reduceModPow cl p k = reduceModPow raw p k` via
+    the elementary identity `centeredModNat z m ≡ z (mod m)` (proved
+    inline against the three `centeredModNat` branches using
+    `Int.add_mul_emod_self_right`).
+  - `Hex.bhksIndicatorCandidate?_eq_normalized_centeredLift`
+    (`HexBerlekampZassenhaus/Basic.lean`): Mathlib-free identification
+    of the candidate as the canonical normalization of the centred
+    lift. This lets the Mathlib-side proof above avoid referencing the
+    private `liftModulus` definition from outside `Basic.lean`.
+
+## Current frontier
+
+- #6455 closed by this PR. The remaining residual of #6450 is captured
+  in #6456, which composes #6455's conclusion through
+  `selectedFactorsOfMembers_polyProduct` + the canonical support
+  partition + the actual-cap wrapper.
+
+## Next step
+
+A future worker claims #6456 and:
+1. Composes `bhksIndicatorCandidate?_reduceModPow_eq_of_monic` (#6455)
+   with `selectedFactorsOfMembers_polyProduct` to produce the
+   per-candidate `RepresentsIntegerFactorAtLift` certificate against
+   `liftedFactorSubsetOfMembers d members`.
+2. Folds it across the canonical indicator array via
+   `ForwardRecoveryInputs` to produce the per-class certificate family.
+3. Discharges the monic-core + monic-lifted-factor hypotheses at the
+   actual `factorFastCapLiftData f primeData` cap using
+   `henselLiftData_liftedFactor_monic` and the
+   `(Hex.normalizeForFactor f).squareFreeCore` monic-ness invariant,
+   exposing a wrapper matching the call shape of
+   `CanonicalRecoveryTailInputs.ofCanonicalSupportRepresentations`.
+
+## Blockers
+
+None for #6456 — all its prerequisites are now landed.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus.Basic` passed.
+- `lake build HexBerlekampZassenhausMathlib.Basic` passed.
+- `lake build` passed.
+- `python3 scripts/check_dag.py` passed (exit 0).
+- `git diff --check` passed.
+- Added-line forbidden-token grep over touched Lean files found no
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #6455

Session: `a60e31d5-6ea7-4220-afd9-c74a1c1e1f8b`

b840b472 chore: progress entry for #6455 (BHKS per-candidate modular product equality)
23e0efe2 feat: prove bhksIndicatorCandidate?_reduceModPow_eq_of_monic (closes #6455)
e0969ba7 feat: expose bhksIndicatorCandidate?_eq_normalized_centeredLift (#6455 step 1/3)

🤖 Prepared with Claude Code