### PR TITLE
fix: dispatch upper-triangle case of Schur scaledCoeffs equivalence

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -5307,6 +5307,17 @@ theorem gramDet_zero (b : Matrix Int n m) :
     gramDet b 0 (Nat.zero_le n) = 1 := by
   rfl
 
+/-- Both `scaledCoeffRows` and `scaledCoeffRowsSchur` start from `zeroRows n`
+and only write strict-lower / diagonal entries; the upper-triangle slot at
+`(i, j)` with `i < j` therefore retains its initial zero value, regardless of
+whether `i` and `j` lie inside the array bounds. -/
+private theorem getArrayEntry_scaledCoeffRows_above
+    (b : Matrix Int n m) (i j : Nat) (hij : i < j) :
+    getArrayEntry (scaledCoeffRows b) i j = 0 := by
+  unfold scaledCoeffRows
+  exact getArrayEntry_scaledCoeffArrayLoop_above n n _
+    (fun i' j' hij' => getArrayEntry_zeroRows n i' j') i j hij
+
 /-- The per-row Schur scaled-coefficient kernel and the column-major Bareiss
 array path produce identical integer values at every cell. Both arrays
 contain the leading Gram determinant `d_{j+1}` on the diagonal and
@@ -5315,12 +5326,16 @@ differ only in evaluation order. This equivalence is the bridge from the
 Schur implementation to the existing invariant infrastructure proven about
 `scaledCoeffRows`.
 
-The proof obligation is still open; see #6458. -/
+The upper-triangle case is dispatched here; the diagonal and strict-lower
+cases are still open. See #6458. -/
 private theorem getArrayEntry_scaledCoeffRowsSchur_eq
     (b : Matrix Int n m) (i j : Nat) :
     getArrayEntry (scaledCoeffRowsSchur b) i j =
       getArrayEntry (scaledCoeffRows b) i j := by
-  sorry
+  by_cases hij : i < j
+  · rw [getArrayEntry_scaledCoeffRowsSchur_upper b i j hij,
+      getArrayEntry_scaledCoeffRows_above b i j hij]
+  · sorry
 
 theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
     (gramDetVec b).get ⟨k, Nat.lt_succ_of_le hk⟩ = gramDet b k hk := by

--- a/progress/20260603T061603Z_e040946c.md
+++ b/progress/20260603T061603Z_e040946c.md
@@ -1,0 +1,64 @@
+# Dispatch upper-triangle case of Schur ≡ Bareiss equivalence
+
+Session `e040946c-3cc1-4bdb-90e5-9be7443fb5a6` continuing #6458 after the
+partial PRs #6460 and #6462.
+
+## Accomplished
+
+Narrowed the residual Schur ≡ Bareiss equivalence proof obligation to
+the diagonal + strict-lower (`j ≤ i`) case by dispatching the
+upper-triangle case in place.
+
+- Added private `getArrayEntry_scaledCoeffRows_above`: when `i < j`, the
+  Bareiss-array `scaledCoeffRows` entry is zero. Reuses
+  `getArrayEntry_scaledCoeffArrayLoop_above` with the `zeroRows n`
+  upper-zero invariant on the initial coefficient buffer.
+- Rewrote the body of `getArrayEntry_scaledCoeffRowsSchur_eq` to case
+  on `i < j`. The `i < j` branch is now closed via
+  `getArrayEntry_scaledCoeffRowsSchur_upper` and the new
+  `getArrayEntry_scaledCoeffRows_above`; the `j ≤ i` branch retains a
+  single `sorry`.
+
+## Current frontier
+
+`grep -c sorry HexGramSchmidt/Int.lean` reports 3, unchanged from the
+previous session:
+
+- Line 5030 (pre-existing doc comment about the #5655-tracked sorry).
+- Line 5043: `gramDetVecEntry_eq_leadingPrefix_bareiss` (pre-existing).
+- Line 5338: `getArrayEntry_scaledCoeffRowsSchur_eq` (now scoped to
+  `j ≤ i` only; the `i < j` branch is proven).
+
+`lake build HexGramSchmidt.Int` is clean (sorry warnings unchanged from
+prior session; no new ones).
+
+## Next step
+
+Discharge the `j ≤ i` branch of `getArrayEntry_scaledCoeffRowsSchur_eq`.
+The remaining math has two genuine sub-cases:
+
+1. **Diagonal (`i = j`)**: both arrays write the leading Gram
+   determinant `d_{j+1}`. The Bareiss side is already characterized by
+   `scaledCoeffArrayLoop_diag_matches` and
+   `scaledCoeffRows_diag_toNat_eq_gramDet`; the Schur side needs an
+   analogous characterization built from the `schurScaledCoeffEntry`
+   recurrence.
+
+2. **Strict lower (`j < i`)**: both arrays write
+   `d_{j+1} · μ_{i, j}` (when the Bareiss-step before column `j` is
+   non-singular) or zero (when it is singular). The Bareiss side is
+   characterized by `scaledCoeffArrayLoop_lower_matches_target_column`
+   and `scaledCoeffArrayLoop_lower_zero_of_singular_before_target`; the
+   Schur side needs a row-by-row matching argument that the
+   `schurSigma` chain reproduces the same bordered-minor determinant.
+
+Suggested decomposition: introduce two private Schur-side
+characterization lemmas (diag and strict-lower), then dispatch the
+remaining branch of `getArrayEntry_scaledCoeffRowsSchur_eq` by case
+on `i = j`.
+
+## Blockers
+
+None. The remaining work is bounded but requires substantive
+mathematical bridging between the two recurrences; a single one-shot
+session can plausibly close one of the two sub-cases at a time.


### PR DESCRIPTION
Partial progress on #6458

Session: `e040946c-3cc1-4bdb-90e5-9be7443fb5a6`

d7cb8fbd fix: dispatch upper-triangle case of Schur scaledCoeffs equivalence

🤖 Prepared with Claude Code