### PR TITLE
doc: characterize residual Schur scaledCoeffs eq sub-cases

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -5326,8 +5326,23 @@ differ only in evaluation order. This equivalence is the bridge from the
 Schur implementation to the existing invariant infrastructure proven about
 `scaledCoeffRows`.
 
-The upper-triangle case is dispatched here; the diagonal and strict-lower
-cases are still open. See #6458. -/
+The upper-triangle case (`i < j`) is dispatched here. The residual obligation
+is the `j ≤ i` case, which splits into two algebraically distinct sub-cases:
+
+* Diagonal (`i = j`). Both kernels store the leading Gram determinant
+  `d_{j+1}` (as a nonnegative integer) at slot `(i, i)`. The Bareiss side is
+  characterized by `scaledCoeffRows_diag_toNat_eq_gramDet`; the Schur side
+  needs an analogous characterization built directly from the
+  `schurScaledCoeffEntry`/`schurSigma` recurrence.
+* Strict lower (`j < i`). Both kernels store `d_{j+1} · μ_{i, j}` when the
+  Bareiss-step before column `j` is non-singular and `0` when it is singular.
+  The Bareiss side is characterized by
+  `scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix` and
+  `scaledCoeffRows_eq_zero_of_singularStep_lt`; the Schur side needs a
+  row-by-row matching argument that the `schurSigma` chain reproduces the
+  same bordered-minor determinant.
+
+See #6458. -/
 private theorem getArrayEntry_scaledCoeffRowsSchur_eq
     (b : Matrix Int n m) (i j : Nat) :
     getArrayEntry (scaledCoeffRowsSchur b) i j =

--- a/progress/20260603T064339Z_bd85cb06.md
+++ b/progress/20260603T064339Z_bd85cb06.md
@@ -1,0 +1,73 @@
+# Characterize residual Schur ≡ Bareiss obligation sub-cases
+
+Session `bd85cb06` continuing #6458 after the partial PRs #6460, #6462, and
+#6463.
+
+## Accomplished
+
+Rewrote the docstring of `getArrayEntry_scaledCoeffRowsSchur_eq` in
+`HexGramSchmidt/Int.lean` to explicitly characterize the residual `j ≤ i`
+obligation as two algebraically distinct sub-cases (diagonal and
+strict-lower), and to point follow-up workers at the existing Bareiss-side
+characterizations they can mirror on the Schur side
+(`scaledCoeffRows_diag_toNat_eq_gramDet`,
+`scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix`, and
+`scaledCoeffRows_eq_zero_of_singularStep_lt`).
+
+No proof advance landed. The proof body still contains the single residual
+`sorry` for the entire `j ≤ i` case.
+
+## Current frontier
+
+`grep -c sorry HexGramSchmidt/Int.lean` reports 3, unchanged from the
+previous session:
+
+- Line 5030 (pre-existing doc comment about the #5655-tracked sorry).
+- Line 5043: `gramDetVecEntry_eq_leadingPrefix_bareiss` (pre-existing).
+- Line 5353: `getArrayEntry_scaledCoeffRowsSchur_eq` (`j ≤ i` case).
+
+`lake build HexGramSchmidt.Int HexGramSchmidt.Conformance` is clean.
+
+## Next step
+
+The cleanest concrete next step that does **not** add sorries is to
+discharge the `j = 0` slice of the `j ≤ i` case. For column 0 the math
+content collapses to a structural fact: both kernels write `gram[i][0]` at
+slot `(i, 0)` and never revisit column 0 afterwards.
+
+Suggested decomposition:
+
+1. New Bareiss-side characterization
+   `getArrayEntry_scaledCoeffRows_col_zero : i < n → getArrayEntry
+   (scaledCoeffRows b) i 0 = getArrayEntry (gramRows b) i 0`.
+   - For `i = 0`: `getArrayEntry_writeScaledColumn_diag` writes
+     `gram[0][0]`; subsequent loop iterations preserve column 0 via
+     `getArrayEntry_scaledCoeffArrayLoop_preserve_col_before_step`.
+   - For `0 < i < n`: combine
+     `getArrayEntry_scaledCoeffArrayLoop_capture_current_col` at step 0
+     with `getArrayEntry_writeScaledColumn_below` (already does this
+     internally).
+
+2. New Schur-side characterization
+   `getArrayEntry_scaledCoeffRowsSchur_col_zero : i < n → getArrayEntry
+   (scaledCoeffRowsSchur b) i 0 = getArrayEntry (gramRows b) i 0`.
+   Mirror the upper-triangle helpers (`getArrayEntry_schurColumnLoop_upper`,
+   `getArrayEntry_schurRowLoop_upper`) for the col-0 preservation
+   invariant: writes at columns `> 0` never touch column 0, and writes on
+   later rows never touch row `i`.
+
+3. Refine `getArrayEntry_scaledCoeffRowsSchur_eq` to dispatch the `j = 0`
+   slice via (1) and (2). The remaining sorry would then cover only
+   `0 < j ≤ i`.
+
+The genuinely hard math (Schur complement equals Bareiss-pivoted minor)
+remains for the `0 < j ≤ i` case and is the natural multi-session work
+item beyond this proposed slice.
+
+## Blockers
+
+None for the proposed col-0 advance; it is a structural narrowing.
+
+The deeper `0 < j ≤ i` case requires substantive new infrastructure
+matching `schurSigma` to bordered-minor determinants. That obligation is
+unchanged from previous sessions.


### PR DESCRIPTION
Partial progress on #6458

Session: `bd85cb06-73c8-476e-80e0-8d20dcc255e8`

6d747013 doc: characterize residual Schur scaledCoeffs eq sub-cases (partial #6458)

🤖 Prepared with Claude Code