### PR TITLE
spec: add implementer/prover hint for the σ-chain determinant identity

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -72,6 +72,26 @@ def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
     the project requires this shape because the comparator runs
     against that implementation.
 
+    **Implementer / prover hint.** The σ-chain is the fraction-free
+    Desnanot-Jacobi (Bareiss) update for the bordered Gram minor
+    that defines `ν[i][j]`. In the code's index convention (which
+    the implementation uses, but the formula above uses the
+    shifted Isabelle convention), the equivalent statement is: for
+    code slot `(i, j)` with `0 < j ≤ i`,
+
+        σ₀     = ν[i][0] · ν[j][0]
+        σ_p    = (d_{p+1} · σ_{p-1} + ν[i][p] · ν[j][p]) / d_p
+        ν[i][j] = d_j · ⟨b_i, b_j⟩ − σ_{j-1}
+
+    where `d_p` is stored at slot `(p-1, p-1)` in the result array;
+    do not translate this to external Bareiss indexing without
+    care. The proof obligation is essentially the standard
+    fraction-free Schur-complement determinant identity
+    `nextMinor · prevPivot = pivot · currentMinor − leftMinor · topMinor`,
+    which HexMatrix already exposes via
+    `Matrix.noPivotLoop` / `Matrix.borderedMinor` and the
+    `noPivotLoop_full_eq_borderedMinor_at_trailing` bridge.
+
     Two body shapes are forbidden:
     (a) computing each below-diagonal entry independently as a
         `(j+1) × (j+1)` Bareiss determinant — `O(n^5)`;


### PR DESCRIPTION
The post-#6439 SPEC clause states the σ-recurrence shape in the shifted Isabelle index convention. The Lean implementation uses the code's convention (`d_p` stored at slot `(p-1, p-1)`). Bridging between the two costs every prover/implementer real time — four chip-away rounds on the [#6458](https://github.com/kim-em/hex/issues/6458) proof-discharge chain landed sub-linearly because workers kept getting tripped by the indexing slip and by under-specified hooks into existing infrastructure.

This adds a single "implementer/prover hint" paragraph that:

- Names the σ-chain as the **fraction-free Desnanot-Jacobi / Bareiss update** for the bordered Gram minor defining `ν[i][j]`.
- Restates the recurrence in the **code's index convention** alongside the existing shifted-convention statement.
- Explicitly flags the indexing trap ("`d_p` is stored at slot `(p-1, p-1)`; do not translate this to external Bareiss indexing without care").
- Points at the **specific existing HexMatrix infrastructure** the equivalence proof should hook into: `Matrix.noPivotLoop`, `Matrix.borderedMinor`, and the bridge lemma `noPivotLoop_full_eq_borderedMinor_at_trailing`.

The wording was reviewed by Codex on the revised proof plan (the one that drives the upcoming D1/D2/D3/D4 sub-directives against [#6458](https://github.com/kim-em/hex/issues/6458)). Codex's specific suggested addition — the "do not translate to external Bareiss indexing" sentence — is included verbatim.

Once this merges, the focused sub-directives will reference this hint and the existing infrastructure by name, so each `pod once` worker has a sharper Lean-facing target than #6458's broad mandate.

🤖 Prepared with Claude Code