### PR TITLE
feat: named non-negativity for BHKS paper-threshold factors (#2567)

### DIFF
--- a/HexBerlekampZassenhausMathlib/BHKSBound.lean
+++ b/HexBerlekampZassenhausMathlib/BHKSBound.lean
@@ -268,6 +268,50 @@ private theorem l2norm_log_nonneg (f : Hex.ZPoly) :
     simpa [abs_of_nonneg hx_nonneg] using h_abs
   exact Real.log_nonneg hx_ge_one
 
+/-- The paper degree factor `n` is non-negative as a real. -/
+theorem bhksPaperDegreeFactorReal_nonneg (f : Hex.ZPoly) :
+    0 ≤ bhksPaperDegreeFactorReal f := by
+  unfold bhksPaperDegreeFactorReal
+  exact_mod_cast Nat.zero_le (bhksDegree f)
+
+/--
+The paper `(2C)^(n^2)` factor is non-negative whenever the project constant
+`C` is non-negative.
+-/
+theorem bhksPaperConstantFactorReal_nonneg
+    (f : Hex.ZPoly) {C : ℝ} (hC_nonneg : 0 ≤ C) :
+    0 ≤ bhksPaperConstantFactorReal f C := by
+  unfold bhksPaperConstantFactorReal
+  exact pow_nonneg (by nlinarith) _
+
+/-- The paper `‖f‖₂^(2n-1)` factor is non-negative. -/
+theorem bhksPaperCoeffNormFactorReal_nonneg (f : Hex.ZPoly) :
+    0 ≤ bhksPaperCoeffNormFactorReal f := by
+  unfold bhksPaperCoeffNormFactorReal HexPolyZMathlib.l2norm
+  exact pow_nonneg (Real.sqrt_nonneg _) _
+
+/-- The paper `(log ‖f‖₂)^n` factor is non-negative. -/
+theorem bhksPaperLogFactorReal_nonneg (f : Hex.ZPoly) :
+    0 ≤ bhksPaperLogFactorReal f := by
+  unfold bhksPaperLogFactorReal
+  exact pow_nonneg (l2norm_log_nonneg f) _
+
+/--
+The product-shaped BHKS paper threshold is non-negative under the project
+`0 ≤ C` convention.
+-/
+theorem bhksPaperThresholdReal_nonneg
+    (f : Hex.ZPoly) {C : ℝ} (hC_nonneg : 0 ≤ C) :
+    0 ≤ bhksPaperThresholdReal f C := by
+  unfold bhksPaperThresholdReal
+  exact mul_nonneg
+    (mul_nonneg
+      (mul_nonneg
+        (bhksPaperDegreeFactorReal_nonneg f)
+        (bhksPaperConstantFactorReal_nonneg f hC_nonneg))
+      (bhksPaperCoeffNormFactorReal_nonneg f))
+    (bhksPaperLogFactorReal_nonneg f)
+
 /--
 The Mathlib coefficient-vector norm squared is bounded by the executable
 squared coefficient norm.
@@ -425,14 +469,12 @@ theorem bhksPaperThresholdReal_le_thresholdNatBound
     bhksPaperConstantFactorReal_le_fourPowFactor f C hC_nonneg hC
   have hcoeff := bhksPaperCoeffNormFactorReal_le_coeffNormFactor f
   have hlog := bhksPaperLogFactorReal_le_log2Factor f
-  have hconstant_nonneg : 0 ≤ bhksPaperConstantFactorReal f C := by
-    exact pow_nonneg (mul_nonneg (by norm_num) hC_nonneg) _
-  have hcoeff_nonneg : 0 ≤ bhksPaperCoeffNormFactorReal f := by
-    exact pow_nonneg (by
-      unfold HexPolyZMathlib.l2norm
-      exact Real.sqrt_nonneg _) _
-  have hlog_nonneg : 0 ≤ bhksPaperLogFactorReal f := by
-    exact pow_nonneg (l2norm_log_nonneg f) _
+  have hconstant_nonneg : 0 ≤ bhksPaperConstantFactorReal f C :=
+    bhksPaperConstantFactorReal_nonneg f hC_nonneg
+  have hcoeff_nonneg : 0 ≤ bhksPaperCoeffNormFactorReal f :=
+    bhksPaperCoeffNormFactorReal_nonneg f
+  have hlog_nonneg : 0 ≤ bhksPaperLogFactorReal f :=
+    bhksPaperLogFactorReal_nonneg f
   have hdegree_bound_nonneg : 0 ≤ (bhksDegreeFactor f : ℝ) := by
     exact_mod_cast Nat.zero_le (bhksDegreeFactor f)
   have hdegree_constant_bound_nonneg :

--- a/progress/20260603T094641Z_f0fc0e98.md
+++ b/progress/20260603T094641Z_f0fc0e98.md
@@ -1,0 +1,51 @@
+# 20260603T094641Z work #2567
+
+## Accomplished
+
+Added named non-negativity lemmas for each of the four real-valued BHKS
+paper-threshold factors and for the product threshold itself in
+`HexBerlekampZassenhausMathlib/BHKSBound.lean`:
+
+* `bhksPaperDegreeFactorReal_nonneg` — `0 ≤ n` from the Nat cast.
+* `bhksPaperConstantFactorReal_nonneg` — `0 ≤ (2C)^(n²)` under `0 ≤ C`.
+* `bhksPaperCoeffNormFactorReal_nonneg` — `0 ≤ ‖f‖₂^(2n-1)` via
+  `Real.sqrt_nonneg`.
+* `bhksPaperLogFactorReal_nonneg` — `0 ≤ (log ‖f‖₂)^n` via the existing
+  private `l2norm_log_nonneg`.
+* `bhksPaperThresholdReal_nonneg` — `0 ≤ bhksPaperThresholdReal f C` from
+  the four factor non-negativities.
+
+Refactored `bhksPaperThresholdReal_le_thresholdNatBound` to use the new
+named lemmas in place of the inline non-negativity boilerplate (three
+`have` blocks shrink from 5 lines each to 1).
+
+## Current frontier
+
+Each paper-threshold factor now has a named non-negativity lemma.
+Callers proving sub-bounds (e.g. the coeff-power vs aux-power split
+introduced by the open factored-discharge PR) can lean on these named
+helpers rather than re-deriving the non-negativity inline.
+
+The four sibling `*AndPaperThreshold` cap-separation builders remain
+the consumer surface; the genuine BHKS §5 paper-threshold analytic
+content (component bounds on `(2C)^(n²)`, `‖f‖₂^(2n-1)`,
+`(log ‖f‖₂)^n`) is the remaining HO-4 work.
+
+## Next step
+
+A natural follow-on is to discharge one of the two factored sub-bounds
+introduced by the open factored-chain PR — e.g. the coefficient-power
+sub-bound `coeffL2NormBound^aux.natDegree ≤ ‖core‖₂^(2n-1)` — using
+the new non-negativity helpers.
+
+## Blockers
+
+None. Strictly additive new lemmas plus an internal proof cleanup using
+those new names.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.BHKSBound` passed.
+- `lake build HexBerlekampZassenhausMathlib` passed (full bridge module).
+- Added-line forbidden-token grep (`sorry|axiom|native_decide|TODO|FIXME`)
+  returns nothing.


### PR DESCRIPTION
Partial progress on #2567

Session: `f0fc0e98-3cd6-45ec-a681-899921203fb8`

2cd95bd7 feat: named non-negativity for BHKS paper-threshold factors (#2567)

🤖 Prepared with Claude Code