### PR TITLE
Bareiss correction successor step for sigma-chain invariant

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -7130,6 +7130,44 @@ private theorem schurSigma_foldl_eq_noPivotCorrection_zero
     h_rows_a0, h_rows_p0]
   grind
 
+/-- Algebraic exact-division step used by the σ-chain correction successor:
+if the Bareiss update numerator is divisible by the previous pivot, the σ-body
+quotient subtracts the corresponding Bareiss quotient from `pivot * gram`. -/
+private theorem exactDiv_bareissCorrection_succ_algebra
+    (denom pivot gram entry row col : Int) (hdenom : denom ≠ 0)
+    (hdiv : denom ∣ pivot * entry - row * col) :
+    Matrix.exactDiv (pivot * (denom * gram - entry) + row * col) denom =
+      pivot * gram - Matrix.exactDiv (pivot * entry - row * col) denom := by
+  rcases hdiv with ⟨quot, hnum⟩
+  have hquot :
+      Matrix.exactDiv (pivot * entry - row * col) denom = quot := by
+    refine exactDiv_eq_of_eq_mul_right hdenom ?_
+    rw [hnum]
+    grind
+  rw [hquot]
+  refine exactDiv_eq_of_eq_mul_right hdenom ?_
+  have hrow : row * col = pivot * entry - denom * quot := by
+    grind
+  rw [hrow]
+  grind
+
+/-- Successor step for the σ-chain/Bareiss correction invariant.  Once the
+row reads in the σ-chain body have already been rewritten to a Bareiss
+trajectory, one body application advances the closed correction term from the
+current step to the next one.  The caller supplies the one-step Bareiss quotient
+for the next matrix entry. -/
+private theorem schurSigma_noPivotCorrection_succ
+    (denom pivot gram entry row col nextEntry : Int)
+    (hdenom : denom ≠ 0)
+    (h_step_dvd : denom ∣ pivot * entry - row * col)
+    (h_next :
+      nextEntry = Matrix.exactDiv (pivot * entry - row * col) denom) :
+    Matrix.exactDiv (pivot * (denom * gram - entry) + row * col) denom =
+      pivot * gram - nextEntry := by
+  rw [h_next]
+  exact exactDiv_bareissCorrection_succ_algebra
+    denom pivot gram entry row col hdenom h_step_dvd
+
 /-- Singular dual of `scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix`.
 When the no-pivot Bareiss pass over the full Gram matrix records an early
 singular step before reaching column `j`, the integral scaled Gram-Schmidt

--- a/progress/20260603T102551Z_5276191a.md
+++ b/progress/20260603T102551Z_5276191a.md
@@ -1,0 +1,44 @@
+# 20260603T102551Z work #6483
+
+## Accomplished
+
+Claimed one-shot issue #6483 and added two private helpers in
+`HexGramSchmidt/Int.lean` near
+`schurSigma_foldl_eq_noPivotCorrection_zero`:
+
+* `exactDiv_bareissCorrection_succ_algebra` proves the reusable exact-division
+  algebra for advancing the σ-chain correction term, assuming the Bareiss
+  update numerator is divisible by the previous pivot.
+* `schurSigma_noPivotCorrection_succ` packages that algebra in the successor
+  recurrence shape once row reads have already been rewritten to Bareiss scalar
+  entries and the caller supplies the one-step quotient for the next entry.
+
+## Current frontier
+
+The helper is deliberately compact rather than a fully expanded no-pivot
+trajectory theorem. The final fold-induction assembly still needs to supply the
+no-pivot `stepMatrix` rewrite, symmetry orientation, and divisibility witness
+at each successor step before applying this recurrence.
+
+## Next step
+
+Use the new successor helper in #6484 while assembling the σ-chain induction:
+rewrite the `q + 1` σ-body reads to no-pivot entries, unfold the regular
+no-pivot branch for `M_{q+2}[a][p_out]`, orient the symmetric
+`M_{q+1}[q+1][p_out]` entry, and pass the resulting quotient/divisibility data
+to `schurSigma_noPivotCorrection_succ`.
+
+## Blockers
+
+No repository blocker. A fully expanded no-pivot successor theorem was too
+expensive for Lean to elaborate in this file within the heartbeat budget, so
+the recurrence is factored at the post-rewrite scalar layer.
+
+## Verification
+
+- `lake build HexGramSchmidt` passed.
+- No new `sorry`. No `axiom`. No `native_decide`.
+- Pre-existing warnings remain in `HexGramSchmidt/Int.lean` at the existing
+  `sorry` declarations and unused `h_partial`, plus the existing dependency
+  warning in `HexGramSchmidt/Basic.lean`.
+- `/reflect` was unavailable as a command/tool in this non-interactive session.


### PR DESCRIPTION
Closes #6483

Session: `5276191a-7bca-4433-9ca8-4b6f61bf03cf`

28ba8b1a Add sigma correction successor algebra

🤖 Prepared with Claude Code