### PR TITLE
spec: name Mathlib-bridge layer for Schur ≡ Bareiss equivalence proof

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -92,6 +92,45 @@ def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
     `Matrix.noPivotLoop` / `Matrix.borderedMinor` and the
     `noPivotLoop_full_eq_borderedMinor_at_trailing` bridge.
 
+    **Mathlib-bridge proof layer.** `Matrix.exactDiv` is
+    executable and takes no Lean divisibility argument at
+    runtime; what needs proof is the *proof-side quotient
+    provenance* — any theorem that identifies a `Matrix.exactDiv`
+    invocation with the intended quotient or determinant value.
+    For the σ-chain on Gram matrices, this provenance is
+    Bareiss-Desnanot integrality, which per
+    [hex-matrix.md §Mathlib-free vs. Mathlib-bridge proof
+    surface](hex-matrix.md) lives exclusively in the
+    `*-mathlib` bridge layer.
+
+    Concretely:
+
+    - Any Schur-side characterization that pins
+      `getArrayEntry (scaledCoeffRowsSchur b) i j` to a
+      bordered-minor determinant, **or to the corresponding
+      `Matrix.noPivotLoop` trailing update** (the operational
+      shape that avoids spelling `det` but carries the same
+      quotient identity), is bridge-layer work. Both formulations
+      are equivalently affected — operationally re-deriving the
+      Schur ≡ Bareiss step is the same SPEC violation as
+      explicitly rederiving Desnanot-Jacobi.
+    - Such characterizations take a public quotient-provider API
+      as a hypothesis. The current private abbrev
+      `BareissGramInitialRegularStepQuotientProvider` (in
+      `HexGramSchmidt/Int.lean`) is the right shape but must be
+      made non-private (or wrapped by a public surface) before
+      `hex-gram-schmidt-mathlib` can construct an instance.
+    - The provider's name signals scope: only the *non-singular
+      regular-step branch* requires bridge-layer provenance.
+      Singular / zero branches of the Schur kernel are handled by
+      Mathlib-free frame and cell-stability lemmas (since both
+      sides of any equivalence return `0` via array initialisation,
+      no quotient identity is in play).
+    - Executable kernels (`schurSigma`, `schurScaledCoeffEntry`,
+      `scaledCoeffRowsSchur`) and pure cell-stability / row-frame
+      lemmas that don't establish a determinant-or-noPivotLoop
+      equivalence remain Mathlib-free.
+
     Two body shapes are forbidden:
     (a) computing each below-diagonal entry independently as a
         `(j+1) × (j+1)` Bareiss determinant — `O(n^5)`;


### PR DESCRIPTION
**Diagnosis.** After 9 chip-iteration PRs (#6460, #6462, #6463, #6464, #6472, #6480, #6485, #6486, #6488), pod-once workers chasing the residual `getArrayEntry_scaledCoeffRowsSchur_eq` proof obligation kept bailing with the same root cause: they needed quotient/divisibility provenance that doesn't exist as a Mathlib-free packaged lemma — and on inspection, that provenance **is** Bareiss-Desnanot integrality on Gram matrices, which [hex-matrix.md §Mathlib-free vs. Mathlib-bridge proof surface](SPEC/Libraries/hex-matrix.md#L119-L159) already explicitly forbids in the Mathlib-free layer.

The existing private `BareissGramInitialRegularStepQuotientProvider` abbrev in [HexGramSchmidt/Int.lean:3251](HexGramSchmidt/Int.lean#L3251) was designed to be the bridge hook for exactly this case, but: (1) it's never instantiated; (2) it's private, so no bridge file can construct it; and (3) no SPEC clause pointed workers at this abstraction.

## What this adds

A "Mathlib-bridge proof layer" paragraph to the `scaledCoeffs` SPEC clause. Concretely:

- Distinguishes executable `Matrix.exactDiv` (no Lean witness at runtime) from proof-side quotient provenance (the witness for any *theorem* that pins an exactDiv invocation to a determinant or noPivotLoop entry).
- Names the architectural rule: characterizations of `scaledCoeffRowsSchur` cells against bordered-minor determinants **or against the corresponding `Matrix.noPivotLoop` trailing update** (Codex caught the escape hatch — operationally re-deriving the Schur step without spelling `det` is the same SPEC violation) are bridge-layer work.
- Names the API gap: the existing private `BareissGramInitialRegularStepQuotientProvider` abbrev must be made public (or wrapped) before `hex-gram-schmidt-mathlib` can construct an instance.
- Scopes the rule to non-singular regular branches; singular branches stay Mathlib-free because both kernels return `0` and no quotient identity is at play.

## Why this is the right hint

The previous SPEC additions ([#6439](https://github.com/kim-em/hex/pull/6439), [#6465](https://github.com/kim-em/hex/pull/6465)) named the algorithm shape, the determinant identity, and the indexing convention — all useful — but didn't address the **layering** question. Workers correctly identified the missing divisibility, but didn't know that re-deriving it in `HexGramSchmidt/Int.lean` is precisely the cross-cutting violation `hex-matrix.md` already flags. This clause closes that loop.

## Implementation follow-up

A new directive (to be filed after this merges) will:
1. Make `BareissGramInitialRegularStepQuotientProvider` public (or wrap with a public surface in `HexGramSchmidt/Int.lean`).
2. Migrate the residual `getArrayEntry_scaledCoeffRowsSchur_eq` proof — and any new Schur characterizations against `noPivotLoop` — to `HexGramSchmidtMathlib/Int.lean`, taking the provider as a hypothesis.
3. Construct a concrete provider instance in `HexGramSchmidtMathlib` using its Bareiss-Desnanot infrastructure.

Reviewed by Codex on the substance (diagnosis right) and on five precision points (API gap, `Matrix.exactDiv` vs proof-side provenance wording, escape-hatch in "to a bordered-minor determinant", singular vs regular branch scope, missing provider public-API requirement) — all incorporated in this version.

🤖 Prepared with Claude Code