### PR TITLE
Fill 3 bridge-layer Cramer/Bareiss sorries (HexGramSchmidtMathlib/Int.lean: 1688, 1740, 1752)

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -6025,7 +6025,7 @@ is the `j ≤ i` case, which splits into two algebraically distinct sub-cases:
   same bordered-minor determinant.
 
 See #6458. -/
-private theorem getArrayEntry_scaledCoeffRowsSchur_eq
+theorem getArrayEntry_scaledCoeffRowsSchur_eq
     (b : Matrix Int n m) (i j : Nat) :
     getArrayEntry (scaledCoeffRowsSchur b) i j =
       getArrayEntry (scaledCoeffRows b) i j := by
@@ -7190,6 +7190,24 @@ theorem scaledCoeffs_eq_zero_of_singularStep_lt
     GramSchmidt.entry (scaledCoeffs b) i j = 0 := by
   rw [scaledCoeffs_entry_eq_getArrayEntry, getArrayEntry_scaledCoeffRowsSchur_eq]
   exact scaledCoeffRows_eq_zero_of_singularStep_lt (b := b) i j hji s h_sing
+
+/-- Non-singular companion of `scaledCoeffs_eq_zero_of_singularStep_lt`: when the
+no-pivot Bareiss pass over the full Gram matrix reaches column `j` without
+recording a singular step, the integral scaled Gram-Schmidt coefficient below
+the diagonal at `(i, j)` matches the trailing entry of the no-pivot Bareiss-style
+loop on the corresponding Cramer minor `scaledCoeffMatrix b i j hji`. -/
+theorem scaledCoeffs_lower_eq_noPivotLoop_scaledCoeffMatrix
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val)
+    (h_nonsing :
+      (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none) :
+    GramSchmidt.entry (scaledCoeffs b) i j =
+      (Matrix.noPivotLoop j.val
+        (Matrix.noPivotInitialState
+          (GramSchmidt.scaledCoeffMatrix b i j hji))).matrix[
+        Fin.last j.val][Fin.last j.val] := by
+  rw [scaledCoeffs_entry_eq_getArrayEntry, getArrayEntry_scaledCoeffRowsSchur_eq]
+  exact scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix b i j hji h_nonsing
 
 
 private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -1685,7 +1685,27 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular
           (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none) :
     GramSchmidt.entry (scaledCoeffs b) i j =
       Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-  sorry
+  have hjn : j.val < n := Nat.lt_trans hji i.isLt
+  -- Convert the LHS to the trailing entry of the no-pivot loop on `scaledCoeffMatrix`.
+  rw [scaledCoeffs_lower_eq_noPivotLoop_scaledCoeffMatrix b i j hji h_nonsing]
+  -- Propagate non-singularity from `gramMatrix b` to `scaledCoeffMatrix b i j hji`
+  -- via the bordered-minor identification.
+  have h_sync :=
+    noPivotLoop_full_eq_borderedMinor_at_trailing (Matrix.gramMatrix b) j.val hjn
+      ⟨j.val, hjn⟩ i (Nat.le_refl j.val) (Nat.le_of_lt hji)
+  have h_bm_nonsing :
+      (Matrix.noPivotLoop j.val
+        (Matrix.noPivotInitialState
+          (Matrix.borderedMinor (Matrix.gramMatrix b) j.val hjn
+            ⟨j.val, hjn⟩ i))).singularStep = none := by
+    rw [← h_sync.2]; exact h_nonsing
+  have h_sc_nonsing :
+      (Matrix.noPivotLoop j.val
+        (Matrix.noPivotInitialState
+          (GramSchmidt.scaledCoeffMatrix b i j hji))).singularStep = none := by
+    rw [scaledCoeffMatrix_eq_borderedMinor]; exact h_bm_nonsing
+  exact (Matrix.bareiss_eq_noPivotLoop_last_of_no_singular
+    (GramSchmidt.scaledCoeffMatrix b i j hji) h_sc_nonsing).symm
 
 /-- Cramer/Bareiss identity: below the diagonal, the integral scaled
 Gram-Schmidt coefficient is exactly the public Bareiss determinant of the
@@ -1704,8 +1724,8 @@ singular step:
   helper internally lifts partial-pass singularity to the full
   `bareissNoPivotData` pass and applies the Cramer determinant identity.
 
-This case-split is sorry-free; the private `scaledCoeffRows_lower_eq_coeffs`
-helper below reroutes through it instead of the older chain proof. -/
+The private `scaledCoeffRows_lower_eq_coeffs` helper below reroutes through
+this case-split identity instead of the older chain proof. -/
 theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
     (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
     GramSchmidt.entry (scaledCoeffs b) i j =
@@ -1737,19 +1757,32 @@ private theorem scaledCoeffRows_lower_eq_coeffs
     ((getArrayEntry (scaledCoeffRows b) i j : Int) : Rat) =
       (gramDet b (j + 1) (Nat.succ_le_of_lt (Nat.lt_trans hj hi)) : Rat) *
         GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ := by
-  sorry
+  have hjlt : j < n := Nat.lt_trans hj hi
+  have h_array :
+      getArrayEntry (scaledCoeffRows b) i j =
+        GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩ := by
+    rw [scaledCoeffs_entry_eq_getArrayEntry, getArrayEntry_scaledCoeffRowsSchur_eq]
+  rw [h_array,
+    scaledCoeffs_eq_scaledCoeffMatrix_bareiss b ⟨i, hi⟩ ⟨j, hjlt⟩ hj,
+    scaledCoeffMatrix_bareiss_eq_det b i j hi hj]
+  exact scaledCoeffMatrix_det_eq_gramDet_mul_coeffs b i j hi hj
 
 /-- Below the diagonal, the rational image of the integer scaled
 Gram-Schmidt coefficient factors as `gramDet b (j+1) * coeffs[i,j]`. The
-proof routes through the sorry-free `scaledCoeffs_eq_scaledCoeffMatrix_bareiss`
-case-split identity (via `scaledCoeffRows_lower_eq_coeffs`) instead of the older
-chain proof that depended on `scaledCoeffs_eq_scaledCoeffMatrix_det`. -/
+proof routes through `scaledCoeffs_eq_scaledCoeffMatrix_bareiss` (via
+`scaledCoeffRows_lower_eq_coeffs`) instead of the older chain proof that
+depended on `scaledCoeffs_eq_scaledCoeffMatrix_det`. -/
 theorem scaledCoeffs_eq (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < i) :
     ((GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ : Int) : Rat) =
       (gramDet b (j + 1) (Nat.succ_le_of_lt (Nat.lt_trans hj hi)) : Rat) *
         GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ := by
-  sorry
+  have h_array :
+      GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ =
+        getArrayEntry (scaledCoeffRows b) i j := by
+    rw [scaledCoeffs_entry_eq_getArrayEntry, getArrayEntry_scaledCoeffRowsSchur_eq]
+  rw [h_array]
+  exact scaledCoeffRows_lower_eq_coeffs b i j hi hj
 
 /-! ### Adjacent-swap pivot Gram-determinant product
 

--- a/progress/2026-06-03T22-52-21Z_d7cc0279.md
+++ b/progress/2026-06-03T22-52-21Z_d7cc0279.md
@@ -1,0 +1,68 @@
+# 2026-06-03T22:52:21Z — d7cc0279 — work / issue #6501
+
+## Accomplished
+
+Filled the three coupled `sorry`s in `HexGramSchmidtMathlib/Int.lean`
+identified by [#6501](https://github.com/kim-em/hex/issues/6501):
+
+- Line 1688 `scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular`
+  (non-singular branch of the Cramer/Bareiss identity)
+- Line 1755 `scaledCoeffRows_lower_eq_coeffs`
+  (rational form: array entry = `d[j+1] · μ[i,j]` below diagonal)
+- Line 1775 `scaledCoeffs_eq`
+  (public rational-form wrapper)
+
+`grep -c sorry HexGramSchmidtMathlib/Int.lean` is now `0`. The full
+project `lake build` is clean across `HexGramSchmidt`,
+`HexGramSchmidtMathlib`, `HexLLL`, `HexLLLMathlib`, and all
+`*.Conformance` targets. Public signatures of the three theorems are
+unchanged.
+
+## Proof routes
+
+The non-singular branch composes pre-existing executable infrastructure
+rather than the Cramer determinant identity:
+
+1. `scaledCoeffs_entry_eq_getArrayEntry` +
+   `getArrayEntry_scaledCoeffRowsSchur_eq` reduce the LHS to
+   `getArrayEntry (scaledCoeffRows b) i j`. Wrapped into a new public
+   bridge `scaledCoeffs_lower_eq_noPivotLoop_scaledCoeffMatrix` in
+   `HexGramSchmidt/Int.lean` so the Mathlib-side proof can reach it.
+2. `scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix` (from
+   `HexGramSchmidt/Int.lean`) identifies the array entry with the
+   trailing entry of `noPivotLoop j.val` on
+   `GramSchmidt.scaledCoeffMatrix b i j hji`.
+3. `noPivotLoop_full_eq_borderedMinor_at_trailing` lifts the no-singular
+   hypothesis on `gramMatrix b` to a no-singular hypothesis on the
+   bordered minor; `scaledCoeffMatrix_eq_borderedMinor` re-expresses
+   that as a no-singular hypothesis on `scaledCoeffMatrix b i j hji`.
+4. `Matrix.bareiss_eq_noPivotLoop_last_of_no_singular` closes the gap
+   to `Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji)`.
+
+The rational-form wrappers then route through the case-split identity
+`scaledCoeffs_eq_scaledCoeffMatrix_bareiss` (now sorry-free), the
+existing `scaledCoeffMatrix_bareiss_eq_det`, and the Cramer determinant
+identity `scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`.
+
+## API changes
+
+- `HexGramSchmidt/Int.lean`: dropped `private` from
+  `getArrayEntry_scaledCoeffRowsSchur_eq` (the existing sorry inside it
+  is unchanged — the lemma is needed across files now).
+- `HexGramSchmidt/Int.lean`: added
+  `scaledCoeffs_lower_eq_noPivotLoop_scaledCoeffMatrix` as the
+  non-singular companion to `scaledCoeffs_eq_zero_of_singularStep_lt`.
+
+## Current frontier
+
+Unblocks [#6499](https://github.com/kim-em/hex/issues/6499) (umbrella
+[#6458](https://github.com/kim-em/hex/issues/6458) follow-up) per the
+directive.
+
+## Next step
+
+Open the PR and exit.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6501

Session: `d7cc0279-5dfe-4f86-9831-f8fc8b1b5dc2`

7c5c3da8 feat: fill non-singular Cramer/Bareiss bridge in HexGramSchmidtMathlib/Int.lean

🤖 Prepared with Claude Code