### PR TITLE
spec: Schur≡Bareiss singular boundary is bridge-layer; provider quantifies only over canonical witnesses

### DIFF
--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -120,12 +120,33 @@ def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
       `HexGramSchmidt/Int.lean`) is the right shape but must be
       made non-private (or wrapped by a public surface) before
       `hex-gram-schmidt-mathlib` can construct an instance.
-    - The provider's name signals scope: only the *non-singular
-      regular-step branch* requires bridge-layer provenance.
-      Singular / zero branches of the Schur kernel are handled by
-      Mathlib-free frame and cell-stability lemmas (since both
-      sides of any equivalence return `0` via array initialisation,
-      no quotient identity is in play).
+    - The provider's name signals scope: the *non-singular
+      regular-step branch* and the *singular boundary case*
+      (`j = s + 1` where the no-pivot Bareiss pass over
+      `gramMatrix b` records a singular step at column `s` with
+      the prefix up to `s` non-singular) both require bridge-layer
+      provenance. The non-singular branch needs the quotient
+      identity; the boundary case needs the PSD column-zero fact
+      (zero Bareiss pivot ⟹ rest-of-column above is zero), which
+      kills the σ-chain's final-iteration numerator
+      `rows[i][s] · rows[s+1][s]`. That product does not reduce to
+      zero from the recurrence alone (counterexample: symmetric
+      non-Gram `[[1,1,0],[1,1,1],[0,1,1]]` has singular step at
+      `s = 1` and the σ-chain returns `-1` at slot `(2, 2)` while
+      the Bareiss-side returns `0`). Only zero cases that don't go
+      through a quotient (pre-loop initialisation, upper-triangle,
+      and columns strictly beyond the recorded singular step) are
+      Mathlib-free.
+    - The provider type must quantify only over **canonical
+      (loop-constructed)** `BareissGramRowInvariant` instances,
+      not arbitrary ones. Universal quantification over arbitrary
+      `hinv` admits non-canonical coefficient witnesses for which
+      the quotient identity fails (counterexample: rows `(1,1),
+      (1,0), (-1,-1)` give two valid `hinv` at row 2 step 1
+      differing by the kernel vector, yielding numerators
+      differing by `1`, not divisible by `prevPivot = 2`). A
+      bridge-layer instance constructor derives the canonical
+      witness from Bareiss-Desnanot on the PSD Gram minors.
     - Executable kernels (`schurSigma`, `schurScaledCoeffEntry`,
       `scaledCoeffRowsSchur`) and pure cell-stability / row-frame
       lemmas that don't establish a determinant-or-noPivotLoop


### PR DESCRIPTION
This PR fixes two clauses in [SPEC/Libraries/hex-gram-schmidt.md](../tree/spec/schur-bareiss-equivalence-singular-boundary/SPEC/Libraries/hex-gram-schmidt.md) §scaledCoeffs Mathlib-bridge proof layer that three workers (sessions on #6499, #6503, #6504) had to diagnose from scratch when attempting to close the residual sorry in `HexGramSchmidt/Int.lean`.

**Clause 1: singular boundary case is bridge-layer too.** The current text says only the *non-singular regular-step branch* needs bridge-layer provenance, with singular/zero branches handled Mathlib-free *"since both sides return 0 via array initialisation, no quotient identity is in play"*. This is wrong for the `j = s + 1` boundary case where the no-pivot Bareiss pass records a singular step at `s` with non-singular prefix up to `s`: the Schur side's σ-chain returns `0` only via the PSD column-zero fact (zero Bareiss pivot ⟹ rest-of-column above is zero), not via array init. Concrete counterexample now recorded inline: symmetric non-Gram `[[1,1,0],[1,1,1],[0,1,1]]` (singular at `s = 1`) yields σ-chain output `-1` at slot `(2, 2)` while the Bareiss side returns `0`.

**Clause 2: provider must quantify only over canonical witnesses.** The provider abbrev clause didn't state the quantification soundness requirement. Universal quantification over arbitrary `BareissGramRowInvariant` admits non-canonical coefficient witnesses for which the quotient identity fails. Concrete counterexample now recorded inline: rows `(1,1), (1,0), (-1,-1)` give two valid `hinv` at row 2 step 1 differing by the kernel vector `(1,0,1)`, with numerators differing by `1`, not divisible by `prevPivot = 2`.

Both counterexamples are 3-row 3-column integer matrices that the next implementer can verify in seconds rather than rediscovering them from worker diagnostic comments.

This PR enables a refile of the previously-bounced [#6499](https://github.com/kim-em/hex/issues/6499)-style directive with the now-correct scope: redesign provider type's quantification, construct bridge-layer instance using PSD Gram minors, migrate the Schur≡Bareiss equivalence theorem to the bridge, close the residual sorry at the singular boundary via the PSD column-zero fact.

🤖 Prepared with Claude Code