### PR TITLE
feat: named-auxiliary primed siblings for the BHKS Theorem 5.2 downstream wrappers (#2567)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -5223,6 +5223,123 @@ def ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
     hchoose hprecision
 
 /--
+Named-auxiliary sibling of
+`ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold`: the
+auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+def ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold'
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    (vectorSquareBound : ℝ)
+    (hvectorSquareBound :
+      ∀ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+        ((((badVectorWitnessOfFactorFastCapLiftData
+              f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+            i.val 0 : ℝ) ^ 2) ≤ vectorSquareBound)
+    (correctionWeightedBound : ℝ)
+    (hcorrectionWeightedBound :
+      ∀ j, j < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 →
+        (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+          (((factorFastCapLiftData f primeData).p : ℝ) ^
+            (2 *
+              ((factorFastCapLiftData f primeData).k -
+                Hex.bhksCoeffCutThreshold
+                  (factorFastCapLiftData f primeData).p
+                  (Hex.normalizeForFactor f).squareFreeCore j)))) ≤
+          correctionWeightedBound)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliaryBound_sq :
+      2 *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              vectorSquareBound) *
+          (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+            (BHKS.cldColumnNormBound
+              (Hex.normalizeForFactor f).squareFreeCore
+              (factorFastCapLiftData f primeData).p : ℝ)) +
+        2 *
+          (((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+            correctionWeightedBound) ≤
+        auxiliaryBound ^ 2)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p) :
+    FactorFastCapSeparationInputs f primeData rows_pos trueSupports :=
+  ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
+    localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
+    C hC_nonneg hC hcut bridge v hin hnot hcld
+    vectorSquareBound hvectorSquareBound correctionWeightedBound
+    hcorrectionWeightedBound hauxiliaryBound_nonneg hauxiliaryBound_sq
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    hchoose hprecision
+
+/--
 Build the cap-separation input package from the structured corrected
 auxiliary-l2-norm-squared bound combined with a paper-threshold-shape inequality
 on the canonical
@@ -5455,6 +5572,113 @@ def ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
     hchoose hprecision
 
 /--
+Named-auxiliary sibling of
+`ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold`: the
+auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+def ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold'
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliary_sq_bound :
+      2 *
+          ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+              ((((badVectorWitnessOfFactorFastCapLiftData
+                    f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                  i.val 0 : ℝ) ^ 2)) *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound
+                (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p : ℝ))) +
+        2 *
+          (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+            (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+              (((factorFastCapLiftData f primeData).p : ℝ) ^
+                (2 *
+                  ((factorFastCapLiftData f primeData).k -
+                    Hex.bhksCoeffCutThreshold
+                      (factorFastCapLiftData f primeData).p
+                      (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+        auxiliaryBound ^ 2)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p) :
+    FactorFastCapSeparationInputs f primeData rows_pos trueSupports :=
+  ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
+    localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
+    C hC_nonneg hC hcut bridge v hin hnot hcld
+    hauxiliaryBound_nonneg hauxiliary_sq_bound
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    hchoose hprecision
+
+/--
 Build the cap-separation input package from a direct `‖aux‖ ≤ auxiliaryBound`
 estimate.
 
@@ -5673,6 +5897,72 @@ def ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
     choose_eq precision_eq
 
 /--
+Named-auxiliary sibling of `ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold`:
+the auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+def ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold'
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (cap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (C_nonneg : 0 ≤ C) (C_le_two : C ≤ 2)
+    (cut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    {auxiliaryBound : ℝ}
+    (hauxiliary :
+      HexPolyZMathlib.l2norm
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial ≤
+        auxiliaryBound)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (choose_eq :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (precision_eq :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p) :
+    FactorFastCapSeparationInputs f primeData rows_pos trueSupports :=
+  ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
+    localFactorIndex localFactorDegree H hlocalFactorDegree_pos cap_le
+    C C_nonneg C_le_two cut bridge hauxiliary
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    choose_eq precision_eq
+
+/--
 Build the cap-separation input package from the bridge data alone, taking the
 auxiliary-l2 bound directly from the bridge-derived
 `Real.sqrt` of the structured corrected RHS sum, plus the paper-threshold-shape
@@ -5887,6 +6177,109 @@ noncomputable def ofBridgeDataAndFactoredPaperThreshold
     (auxiliaryBound := Real.sqrt _)
     (bridge.auxiliaryPolynomial_l2norm_le_sqrt_of_bridge_data v hin hnot hcld)
     h_coeff h_aux choose_eq precision_eq
+
+/--
+Named-auxiliary sibling of `ofBridgeDataAndFactoredPaperThreshold`: the
+auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+noncomputable def ofBridgeDataAndFactoredPaperThreshold'
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (cap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (C_nonneg : 0 ≤ C) (C_le_two : C ≤ 2)
+    (cut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      Real.sqrt
+            (2 *
+                ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+                    ((((badVectorWitnessOfFactorFastCapLiftData
+                          f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                        i.val 0 : ℝ) ^ 2)) *
+                  (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                    (BHKS.cldColumnNormBound
+                      (Hex.normalizeForFactor f).squareFreeCore
+                      (factorFastCapLiftData f primeData).p : ℝ))) +
+              2 *
+                (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+                  (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+                    (((factorFastCapLiftData f primeData).p : ℝ) ^
+                      (2 *
+                        ((factorFastCapLiftData f primeData).k -
+                          Hex.bhksCoeffCutThreshold
+                            (factorFastCapLiftData f primeData).p
+                            (Hex.normalizeForFactor f).squareFreeCore j)))))) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (choose_eq :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (precision_eq :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p) :
+    FactorFastCapSeparationInputs f primeData rows_pos trueSupports :=
+  ofBridgeDataAndFactoredPaperThreshold
+    localFactorIndex localFactorDegree H hlocalFactorDegree_pos cap_le
+    C C_nonneg C_le_two cut bridge v hin hnot hcld
+    h_coeff
+    (bhksPaperAuxiliaryFactorReal_eq_product
+      (Hex.normalizeForFactor f).squareFreeCore C ▸ h_aux)
+    choose_eq precision_eq
 
 /--
 Closed actual-cap `L' = W` identification at `factorFastCapLiftData f primeData`.
@@ -6841,6 +7234,127 @@ theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPap
     recoveryInputs
 
 /--
+Named-auxiliary sibling of
+`factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold`:
+the auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold'
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    (vectorSquareBound : ℝ)
+    (hvectorSquareBound :
+      ∀ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+        ((((badVectorWitnessOfFactorFastCapLiftData
+              f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+            i.val 0 : ℝ) ^ 2) ≤ vectorSquareBound)
+    (correctionWeightedBound : ℝ)
+    (hcorrectionWeightedBound :
+      ∀ j, j < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 →
+        (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+          (((factorFastCapLiftData f primeData).p : ℝ) ^
+            (2 *
+              ((factorFastCapLiftData f primeData).k -
+                Hex.bhksCoeffCutThreshold
+                  (factorFastCapLiftData f primeData).p
+                  (Hex.normalizeForFactor f).squareFreeCore j)))) ≤
+          correctionWeightedBound)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliaryBound_sq :
+      2 *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              vectorSquareBound) *
+          (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+            (BHKS.cldColumnNormBound
+              (Hex.normalizeForFactor f).squareFreeCore
+              (factorFastCapLiftData f primeData).p : ℝ)) +
+        2 *
+          (((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 : ℝ) *
+            correctionWeightedBound) ≤
+        auxiliaryBound ^ 2)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p)
+    (recoveryInputs :
+      CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
+    Hex.factorFast f ≠ none :=
+  factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
+    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
+    vectorSquareBound hvectorSquareBound correctionWeightedBound
+    hcorrectionWeightedBound hauxiliaryBound_nonneg hauxiliaryBound_sq
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    hchoose hprecision recoveryInputs
+
+/--
 Final HO-4 wrapper threading the structured corrected auxiliary-l2-norm-squared
 bound plus the paper-threshold-shape inequality straight to
 `Hex.factorFast f ≠ none`.
@@ -7081,6 +7595,117 @@ theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredP
     recoveryInputs
 
 /--
+Named-auxiliary sibling of
+`factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold`:
+the auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold'
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    {auxiliaryBound : ℝ}
+    (hauxiliaryBound_nonneg : 0 ≤ auxiliaryBound)
+    (hauxiliary_sq_bound :
+      2 *
+          ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+              ((((badVectorWitnessOfFactorFastCapLiftData
+                    f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                  i.val 0 : ℝ) ^ 2)) *
+            (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+              (BHKS.cldColumnNormBound
+                (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p : ℝ))) +
+        2 *
+          (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+            (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+              (((factorFastCapLiftData f primeData).p : ℝ) ^
+                (2 *
+                  ((factorFastCapLiftData f primeData).k -
+                    Hex.bhksCoeffCutThreshold
+                      (factorFastCapLiftData f primeData).p
+                      (Hex.normalizeForFactor f).squareFreeCore j))))) ≤
+        auxiliaryBound ^ 2)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p)
+    (recoveryInputs :
+      CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
+    Hex.factorFast f ≠ none :=
+  factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
+    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
+    hauxiliaryBound_nonneg hauxiliary_sq_bound
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    hchoose hprecision recoveryInputs
+
+/--
 Final HO-4 wrapper threading a direct `‖aux‖ ≤ auxiliaryBound` estimate plus
 the paper-threshold-shape inequality straight to `Hex.factorFast f ≠ none`.
 
@@ -7239,6 +7864,77 @@ theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThresho
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge hauxiliary h_coeff h_aux hchoose hprecision)
     recoveryInputs
+
+/--
+Named-auxiliary sibling of
+`factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold`:
+the auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold'
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    {auxiliaryBound : ℝ}
+    (hauxiliary :
+      HexPolyZMathlib.l2norm
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial ≤
+        auxiliaryBound)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      auxiliaryBound ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p)
+    (recoveryInputs :
+      CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
+    Hex.factorFast f ≠ none :=
+  factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
+    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge hauxiliary
+    h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
+    hchoose hprecision recoveryInputs
 
 /--
 Final HO-4 wrapper threading just the bridge data plus the paper-threshold-shape
@@ -7463,6 +8159,114 @@ theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld h_coeff h_aux hchoose hprecision)
     recoveryInputs
+
+/--
+Named-auxiliary sibling of
+`factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold`: the
+auxiliary-power sub-bound is stated against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded three-way
+product.  One-step shim that unfolds the named target and dispatches to the
+unprimed variant.
+-/
+theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold'
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData))
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hlocalFactorDegree_pos : 0 < localFactorDegree)
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (hcld :
+      ∀ (i : Nat),
+        i < (factorFastCapLiftData f primeData).liftedFactors.size →
+          ∀ (j : Nat),
+            ((Hex.cldCoeffs (Hex.normalizeForFactor f).squareFreeCore
+                (factorFastCapLiftData f primeData).p
+                (factorFastCapLiftData f primeData).k
+                ((factorFastCapLiftData f primeData).liftedFactors.getD i 0)).getD j 0).natAbs ≤
+              Hex.bhksCoeffBound (Hex.normalizeForFactor f).squareFreeCore j)
+    (h_coeff :
+      (Hex.ZPoly.coeffL2NormBound
+            (Hex.normalizeForFactor f).squareFreeCore : ℝ) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).auxiliaryPolynomial.natDegree ≤
+        bhksPaperCoeffNormFactorReal (Hex.normalizeForFactor f).squareFreeCore)
+    (h_aux :
+      Real.sqrt
+            (2 *
+                ((∑ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+                    ((((badVectorWitnessOfFactorFastCapLiftData
+                          f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+                        i.val 0 : ℝ) ^ 2)) *
+                  (((factorFastCapLiftData f primeData).liftedFactors.size : ℝ) *
+                    (BHKS.cldColumnNormBound
+                      (Hex.normalizeForFactor f).squareFreeCore
+                      (factorFastCapLiftData f primeData).p : ℝ))) +
+              2 *
+                (∑ j ∈ Finset.range ((Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0),
+                  (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+                    (((factorFastCapLiftData f primeData).p : ℝ) ^
+                      (2 *
+                        ((factorFastCapLiftData f primeData).k -
+                          Hex.bhksCoeffCutThreshold
+                            (factorFastCapLiftData f primeData).p
+                            (Hex.normalizeForFactor f).squareFreeCore j)))))) ^
+          (badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).inputPolynomial.natDegree ≤
+        bhksPaperAuxiliaryFactorReal (Hex.normalizeForFactor f).squareFreeCore C)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
+    (hprecision :
+      (factorFastCapLiftData f primeData).k =
+        Hex.precisionForCoeffBound
+          (Hex.factorFastPrecisionCap
+            (Hex.normalizeForFactor f).squareFreeCore)
+          (factorFastCapLiftData f primeData).p)
+    (recoveryInputs :
+      CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
+    Hex.factorFast f ≠ none :=
+  factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold
+    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
+    h_coeff
+    (bhksPaperAuxiliaryFactorReal_eq_product
+      (Hex.normalizeForFactor f).squareFreeCore C ▸ h_aux)
+    hchoose hprecision recoveryInputs
 
 end BHKS
 

--- a/progress/20260604T005649Z_7b32169a.md
+++ b/progress/20260604T005649Z_7b32169a.md
@@ -1,0 +1,83 @@
+# 20260604T005649Z work #2567
+
+## Accomplished
+
+Added eight primed-target downstream siblings in
+`HexBerlekampZassenhausMathlib/Recovery.lean` that state the BHKS
+Theorem 5.2 auxiliary-power sub-bound against the named
+`bhksPaperAuxiliaryFactorReal core C` target instead of the unfolded
+three-way product
+`bhksPaperDegreeFactorReal core * bhksPaperConstantFactorReal core C *
+bhksPaperLogFactorReal core`.
+
+Constructors (four `FactorFastCapSeparationInputs.ofBridgeData*'`):
+
+* `ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold'`
+* `ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold'`
+* `ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold'`
+* `ofBridgeDataAndFactoredPaperThreshold'` (noncomputable)
+
+Final wrappers (four `factorFast_terminates_*'`):
+
+* `factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold'`
+* `factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold'`
+* `factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold'`
+* `factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold'`
+
+Each primed sibling has the same signature as its unprimed
+counterpart except the `h_aux` RHS uses the named
+`bhksPaperAuxiliaryFactorReal` target.  Six of the eight implementations
+are one-step `simpa [bhksPaperAuxiliaryFactorReal] using h_aux` shims
+that dispatch to the unprimed variant.  The two siblings whose `h_aux`
+LHS contains the bridge-derived `Real.sqrt` of the structured
+corrected RHS sum (`ofBridgeDataAndFactoredPaperThreshold'` and
+`factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold'`) trip a
+whnf heartbeats timeout under `simpa`, so they use the direct rewrite
+`bhksPaperAuxiliaryFactorReal_eq_product _ _ ▸ h_aux` instead.
+
+## Current frontier
+
+The named-auxiliary target is now exposed at every downstream surface in
+the cap-separation/factor-fast chain that consumes the factored BHKS
+Theorem 5.2 sub-bounds.  Callers proving the auxiliary-power sub-bound
+directly against `bhksPaperAuxiliaryFactorReal core C` can hit any of
+the eight primed siblings without unfolding the three-way product.
+
+The genuine analytic content remaining for HO-4 is the BHKS Lemma 3.2 /
+Theorem 5.2 auxiliary-power inequality
+`auxiliaryBound ^ input.natDegree ≤
+bhksPaperAuxiliaryFactorReal core C` for the actual cap-lift bad-vector
+auxiliary polynomial (resultant + Hadamard on the bad-vector
+polynomial), and the coefficient-power sub-bound on
+`bhksPaperCoeffNormFactorReal` for non-l2-norm-shaped `h_coeff`
+hypotheses.
+
+## Next step
+
+1. The genuine BHKS Lemma 3.2 content: discharge
+   `auxiliaryBound ^ input.natDegree ≤
+   bhksPaperAuxiliaryFactorReal core C` from a Hadamard / resultant
+   argument on the bad-vector polynomial.  This is the substantial
+   analytic content that remains.
+
+2. With the named target now plumbed through all eight wrappers,
+   callers that build the auxiliary-power bound via the named
+   `bhksPaperAuxiliaryFactorReal` definition can land an end-to-end
+   `factorFast f ≠ none` consumer without the rewrite-at-callsite
+   workaround.
+
+## Blockers
+
+None.  Pure compositions over the existing unprimed wrappers and the
+`bhksPaperAuxiliaryFactorReal_eq_product` shim.
+
+## Verification
+
+* `lake build HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  passed (3780 jobs, full library green, no new warnings introduced).
+* Added-line forbidden-token grep
+  (`sorry|axiom|native_decide|TODO|FIXME`) returns nothing on the new
+  lemmas.
+* No changes to `factor`, `factorFast`, `factorSlow`, or any existing
+  theorem statement; the eight new primed siblings are strictly
+  additive.


### PR DESCRIPTION
Partial progress on #2567

Session: `7b32169a-2e99-4ce1-a5bc-afc7f517514f`

3f9ff833 feat: named-auxiliary primed siblings for BHKS Theorem 5.2 downstream wrappers (#2567)

NOTE: This PR adds more *conditional* `factorFast_terminates_of...` siblings (parameterised on BridgeData/Threshold inputs). The SPEC requires the **unconditional** form `∀ f : ZPoly, factorFast f ≠ none`. Adjusted `Closes` → `Partial progress on` to prevent premature directive closure.

🤖 Prepared with Claude Code