### PR TITLE
spec: factorFast Group D requires unbounded prime search + choosePrimeData? totality lemma

### DIFF
--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -248,7 +248,7 @@ records inside the recombination implementation, rather than expanding
 
 Suggested stage helpers:
 ```lean
-def choosePrimeData (f : ZPoly) : PrimeChoiceData
+def choosePrimeData? (f : ZPoly) : Option PrimeChoiceData
 def henselLiftData (f : ZPoly) (B : Nat) (d : PrimeChoiceData) : LiftData
 def bhksBound (f : ZPoly) : Nat
 ```
@@ -256,6 +256,27 @@ def bhksBound (f : ZPoly) : Nat
 `bhksBound` is the precision cap used by `factorFast`'s doubling
 loop; it is the integer-arithmetic upper bound on BHKS Theorem 5.2's
 threshold (see *Precision schedule* below).
+
+`choosePrimeData?` is `Option`-valued for proof convenience (the
+implementation walks a stream of prime candidates and threads the
+search via `Option` rather than carrying termination evidence
+inline). The Mathlib-side leaf theorem (Group D obligation D2 below)
+discharges the `none` branch as unreachable on primitive
+square-free inputs — i.e. the executable always exits via `some`
+on the inputs `factorFast` calls it with. This is the
+`unreachable-by-pipeline-invariant` mode of
+[SPEC/design-principles.md §8](../design-principles.md). The
+runtime prime search is therefore unbounded as a function of `f`:
+the implementation walks `Nat`-indexed prime candidates until a
+good prime is found; termination at runtime is by an explicit
+Mignotte-style bound (smallest good prime is `O(log
+|disc(f)·lc(f)|)` for primitive square-free `f`), which the leaf
+theorem also captures. A fixed finite candidate list as a stand-in
+is a SPEC violation — it produces a runtime-reachable `none` branch
+in `choosePrimeData?`, which then makes Group D obligation D1
+literally false against the implementation (see commit history of
+`HexBerlekampZassenhaus/Basic.lean` around `finitePrimeSearchNoneQuadratic`
+for the historical witness).
 
 ## Recombination: conditional fast / unconditional slow / fallback combinator
 
@@ -456,9 +477,9 @@ per the new output-convention section above.)
 
 ### Group D — leaf performance theorem (BHKS Theorem 5.2; not on the correctness critical path)
 
-Required deliverable; structurally a leaf — no other proof obligation, public-API contract, `Decidable` instance, or theorem statement in the bridge depends on D1.
+Required deliverable; structurally a leaf — no other proof obligation, public-API contract, `Decidable` instance, or theorem statement in the bridge depends on D1 or D2.
 
-D1. **`factorFast` always succeeds: `factorFast f ≠ none`.** The theorem is about the implementation as written, with cap = `bhksBound f`. BHKS Theorem 5.2 directly gives this once the supporting lemmas are formalised; no cap extension or algorithm modification is needed (HO-1 already chose the cap correctly).
+D1. **`factorFast` always succeeds: `factorFast f ≠ none`.** The theorem is about the implementation as written, with cap = `bhksBound f`. BHKS Theorem 5.2 supplies the precision/recombination half; **D2 below supplies the prime-search half** (the implementation's `choosePrimeData?` is `Option`-valued, and the unconditional `factorFast f ≠ none` is false without D2 — see the `finitePrimeSearchNoneQuadratic` witness in `HexBerlekampZassenhaus/Basic.lean`). No cap extension is needed (HO-1 already chose the cap correctly), but `choosePrimeData?` must do an unbounded prime walk per the algorithmic-architecture clause above; D2 is what proves that walk terminates.
 
     **Pathway:**
 
@@ -466,12 +487,33 @@ D1. **`factorFast` always succeeds: `factorFast f ≠ none`.** The theorem is ab
     2. **BHKS Lemma 3.2 (bad-vector size bound).** Any vector `v ∈ L' \ W` has its associated polynomial `H_v` (built from `v`'s Φ-block) satisfying: `H_v` is divisible by some `f_i mod p^a` but not by the corresponding integer factor over ℤ, so `Res(f, H_v)` is a nonzero integer divisible by `p^(a·d)` for some `d ≥ 1`, while Hadamard bounds `|Res(f, H_v)| ≤ ‖f‖₂^(deg H_v) · ‖H_v‖₂^n`. Combining: `‖v‖₂` grows with `a`.
     3. **BHKS Theorem 5.2 (eq. 5.3 termination).** At precision satisfying `v^ℓ > c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`, the bad-vector lower bound from step 2 exceeds the LLL-cut radius `B'` from B4, so `L' \ W = ∅`. Combined with B6 (`W ⊆ L'`): `L' = W`. Read BHKS §5 (lines around eq. 5.3 and the proof following).
     4. **`bhksBound f` is a sound upper bound for the BHKS threshold.** Show that the integer-arithmetic `bhksBound f` (from the precision schedule) is `≥ ⌈log_v of the BHKS threshold⌉`. Step-by-step bounding of each factor: `n` direct; `(2C)^(n²) ≤ 4^(n²)` for `C ≥ 2` (which `hex-lll` uses); `‖f‖₂^(2n−1) ≤ (sumSquared f + 1)^n`; `(log ‖f‖₂)^n ≤ (log2 (sumSquared f + 1))^n`.
-    5. **Forward verification at precision ≥ Mignotte.** The BHKS bound dominates Mignotte for every `n ≥ 2` (a one-line inequality), so any precision sufficient for separation is also sufficient for reconstruction. With `L' = W` from step 3 and precision ≥ Mignotte: B7 produces exactly the irreducible-factor indicators (Lemma 3.3), A2 gives exact integer-coefficient lifts of each `g_{w_C}`, and exact division of `f` succeeds for every candidate. So the algorithm exits via `some _`, not `none`.
-    6. **Final theorem.** `theorem factorFast_terminates : ∀ f : ZPoly, factorFast f ≠ none`. Internal proof structure is the chain above.
+    5. **Forward verification at precision ≥ Mignotte.** The BHKS bound dominates Mignotte for every `n ≥ 2` (a one-line inequality), so any precision sufficient for separation is also sufficient for reconstruction. With `L' = W` from step 3 and precision ≥ Mignotte: B7 produces exactly the irreducible-factor indicators (Lemma 3.3), A2 gives exact integer-coefficient lifts of each `g_{w_C}`, and exact division of `f` succeeds for every candidate. So the algorithm exits via `some _`, not `none`, **conditional on `choosePrimeData? f ≠ none`**.
+    6. **Discharge the prime-search precondition via D2.** Combine step 5 with D2's `choosePrimeData?_isSome_of_primitive_squareFree` to remove the conditional.
+    7. **Final theorem.** `theorem factorFast_terminates : ∀ f : ZPoly, factorFast f ≠ none`. Internal proof structure is the chain above.
 
-    The bridge file gets one new theorem (`factorFast_terminates`) and a small handful of supporting lemmas (resultant Hadamard bound, BHKS Lemma 3.2, BHKS Theorem 5.2 instantiated at `bhksBound f`, BHKS-bound-dominates-Mignotte). Existing theorem statements (A1–A5, B1–B9, C1–C2) are unchanged.
+    The bridge file gets one new theorem (`factorFast_terminates`) and a small handful of supporting lemmas (resultant Hadamard bound, BHKS Lemma 3.2, BHKS Theorem 5.2 instantiated at `bhksBound f`, BHKS-bound-dominates-Mignotte, plus D2's prime-search-totality lemma). Existing theorem statements (A1–A5, B1–B9, C1–C2) are unchanged.
 
     *Reading list:* BHKS §3.2 (Lemma 3.2 / "bad vector"), §5 (Theorem 5.2 termination + eq. 5.3 explicit bound, lines around `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`); §4.4 (why the algorithm exits early in practice via the L'=W certificate); Hadamard's inequality in `Mathlib.LinearAlgebra.Matrix.Determinant`; resultant infrastructure in Mathlib4 (port from Mathlib3 if absent).
+
+D2. **`choosePrimeData?` always returns `some` on primitive square-free inputs.** Statement shape:
+
+    ```lean
+    theorem choosePrimeData?_isSome_of_primitive_squareFree
+        (f : ZPoly) (hp : f.IsPrimitive) (hs : f.IsSquareFree) :
+        Hex.choosePrimeData? f ≠ none
+    ```
+
+    This is the leaf theorem that lets D1 discharge the `Option`-valued prime search into the `unreachable-by-pipeline-invariant` mode of [SPEC/design-principles.md §8](../design-principles.md). The executable `choosePrimeData?` is `Option`-typed for proof convenience; D2 proves the `none` branch is unreachable on the inputs the pipeline actually feeds it.
+
+    **Pathway:**
+
+    1. **Discriminant nonvanishing.** For primitive square-free `f`, `disc(f) ≠ 0` (Mathlib: `Polynomial.discriminant`, square-free ↔ discriminant nonzero over a field, lifted to ℤ via primitive part).
+    2. **Good-prime existence.** Any prime `p` not dividing `lc(f) · disc(f)` is a good prime for `f` (no leading-coefficient drop, no repeated factor mod `p`). The product `lc(f) · disc(f)` is a nonzero integer; primes not dividing it are infinite (Mathlib: `Nat.infinite_setOf_prime` plus a finite-divisor argument). In particular at least one exists below an explicit `f`-dependent bound (Mignotte/Hadamard gives `O(log |lc(f)·disc(f)|)`).
+    3. **Unbounded prime walk terminates.** The executable `choosePrimeData?` walks `Nat`-indexed prime candidates and stops at the first good prime; by step 2 it finds one within the bound from step 1, so `choosePrimeData?` returns `some`.
+
+    The bridge file gets one new theorem (`choosePrimeData?_isSome_of_primitive_squareFree`) and any supporting good-prime-existence lemmas.
+
+    **Algorithmic precondition.** D2 presumes the unbounded prime walk (per the algorithmic-architecture clause near `choosePrimeData?` above). If the implementation ships a fixed candidate list instead, D2 is false. Any worker noticing the implementation still uses a fixed list should file the unbounded-walk fix as a prerequisite issue, not weaken D2's statement.
 
 ## Headline correctness theorem
 

--- a/SPEC/Libraries/hex-gram-schmidt.md
+++ b/SPEC/Libraries/hex-gram-schmidt.md
@@ -120,12 +120,33 @@ def gramDetVec (b : Matrix Int n m) : Vector Nat (n + 1)
       `HexGramSchmidt/Int.lean`) is the right shape but must be
       made non-private (or wrapped by a public surface) before
       `hex-gram-schmidt-mathlib` can construct an instance.
-    - The provider's name signals scope: only the *non-singular
-      regular-step branch* requires bridge-layer provenance.
-      Singular / zero branches of the Schur kernel are handled by
-      Mathlib-free frame and cell-stability lemmas (since both
-      sides of any equivalence return `0` via array initialisation,
-      no quotient identity is in play).
+    - The provider's name signals scope: the *non-singular
+      regular-step branch* and the *singular boundary case*
+      (`j = s + 1` where the no-pivot Bareiss pass over
+      `gramMatrix b` records a singular step at column `s` with
+      the prefix up to `s` non-singular) both require bridge-layer
+      provenance. The non-singular branch needs the quotient
+      identity; the boundary case needs the PSD column-zero fact
+      (zero Bareiss pivot ⟹ rest-of-column above is zero), which
+      kills the σ-chain's final-iteration numerator
+      `rows[i][s] · rows[s+1][s]`. That product does not reduce to
+      zero from the recurrence alone (counterexample: symmetric
+      non-Gram `[[1,1,0],[1,1,1],[0,1,1]]` has singular step at
+      `s = 1` and the σ-chain returns `-1` at slot `(2, 2)` while
+      the Bareiss-side returns `0`). Only zero cases that don't go
+      through a quotient (pre-loop initialisation, upper-triangle,
+      and columns strictly beyond the recorded singular step) are
+      Mathlib-free.
+    - The provider type must quantify only over **canonical
+      (loop-constructed)** `BareissGramRowInvariant` instances,
+      not arbitrary ones. Universal quantification over arbitrary
+      `hinv` admits non-canonical coefficient witnesses for which
+      the quotient identity fails (counterexample: rows `(1,1),
+      (1,0), (-1,-1)` give two valid `hinv` at row 2 step 1
+      differing by the kernel vector, yielding numerators
+      differing by `1`, not divisible by `prevPivot = 2`). A
+      bridge-layer instance constructor derives the canonical
+      witness from Bareiss-Desnanot on the PSD Gram minors.
     - Executable kernels (`schurSigma`, `schurScaledCoeffEntry`,
       `scaledCoeffRowsSchur`) and pure cell-stability / row-frame
       lemmas that don't establish a determinant-or-noPivotLoop


### PR DESCRIPTION
This PR clarifies SPEC Group D for HexBerlekampZassenhaus after diagnosis of why ~20 worker sessions on #2567 produced parameterised `factorFast_terminates_of...` shims instead of the unconditional theorem.

The shims weren't worker incompetence — D1's stated obligation `∀ f, factorFast f ≠ none` is **literally false** under the current implementation. `HexBerlekampZassenhaus/Basic.lean` ships `finitePrimeSearchNoneQuadratic` (deliberately added in #6429 to document the failure mode): `P·X² + X + 1` where `P` is the product of every prime in the candidate list, so every candidate has `lc ≡ 0 (mod p)` and `choosePrimeData?` returns `none`. The parameterised theorem's `FactorFastCapSeparationInputs.choose_eq` field requires `choosePrimeData? = some primeData`, so no unconditional provider exists for that `f`.

The fix matches the project's `unreachable-by-pipeline-invariant` mode (`SPEC/design-principles.md §8`) and Kim's vision of proof-carrying optimisation: `choosePrimeData?` stays `Option`-typed for proof convenience, but the executable does an unbounded prime walk, and a new SPEC obligation (D2) proves the `Option` is provably `some` on primitive square-free inputs.

Changes:

- `choosePrimeData (f : ZPoly) : PrimeChoiceData` → `choosePrimeData? (f : ZPoly) : Option PrimeChoiceData` in the algorithmic-architecture section, with a paragraph mandating the unbounded prime walk and citing D2 as the totality witness.
- Group D obligation D1 reworded: pathway adds an explicit step 6 composing D2 to discharge the `choosePrimeData? f ≠ none` precondition; the misleading "no algorithm modification is needed" line is gone.
- New Group D obligation D2: `choosePrimeData?_isSome_of_primitive_squareFree`, with pathway through discriminant nonvanishing + good-prime existence + unbounded-walk termination.

Follow-up issues to dispatch after merge:

- modify `choosePrimeData?` to use the unbounded walk and retire `finitePrimeSearchNoneQuadratic` (now a regression test, not a documented failure)
- prove `choosePrimeData?_isSome_of_primitive_squareFree` in `HexBerlekampZassenhausMathlib`
- update #2567 body to reflect that the parameterised shims (#6500, #6506, etc.) are stepping stones; the unconditional discharge is the composition

The parameterised theorems delivered by #6447, #6500, #6506, and ~15 other PRs remain useful — they discharge the conditional half; D2 discharges the prime-search half; their composition gives unconditional D1.

🤖 Prepared with Claude Code