### PR TITLE
spec: proof debt does not cross the layer boundary

### DIFF
--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -159,6 +159,25 @@ plausible. This keeps the proof graph reviewable even when the
 leaves are incomplete, and lets later workers attack foundational
 lemmas in isolation.
 
+### Proof debt does not cross the layer boundary
+
+A `*-mathlib` proof term must not depend, directly or
+transitively, on any Mathlib-free theorem whose proof contains
+`sorry`, regardless of channel (direct citation, wrapper, rename,
+helper, `simp`/`rw`/`simpa`, typeclass instance, imported chain,
+or a Mathlib-side lemma whose own proof routes through such a
+dependency). Mathlib-free definitions and Mathlib-free lemmas
+with complete proof terms are admissible.
+
+When a bridge proof needs an operational invariant from the
+Mathlib-free layer, the admissible moves are: factor the
+invariant into a sorry-free Mathlib-free lemma; close the
+Mathlib-free `sorry` first; or prove the bridge statement
+directly from Mathlib infrastructure (adjugate, cofactor,
+Desnanot–Jacobi, and the determinant equivalence the relevant
+`*-mathlib` SPEC requires). A wrapper, rename, or separate
+decomposition does not change the proof-term dependency graph.
+
 ## Naming and documentation
 
 **Namespaces.** New types, functions, and theorems introduced by this


### PR DESCRIPTION
This PR adds one clause to [SPEC/design-principles.md](SPEC/design-principles.md), right after "Push sorries earlier": a `*-mathlib` bridge theorem's proof term must not depend, directly or transitively, on any Mathlib-free theorem whose proof contains `sorry`. The general rule is sufficient; no per-library restatement is added.

Three admissible options are listed for when the bridge legitimately needs operational content (factor out a sorry-free invariant; close the Mathlib-free `sorry` first; prove the bridge statement independently from Mathlib infrastructure). Hiding the dependency behind a wrapper, a copied proof skeleton, or a follow-up decomposition issue is explicitly forbidden.

🤖 Prepared with Claude Code