### PR TITLE
Extend noPivotLoop_full_eq_borderedMinor_at_trailing to arbitrary off-step entries on a symmetric matrix

### DIFF
--- a/HexMatrixMathlib/Determinant/Bareiss.lean
+++ b/HexMatrixMathlib/Determinant/Bareiss.lean
@@ -1641,4 +1641,57 @@ theorem bareiss_eq_mathlib_det (M : Hex.Matrix Int n n) :
   rw [Hex.Matrix.bareiss_eq_bareissData_det M]
   exact bareissData_eq_mathlib_det M
 
+/-- Restatement of `BareissNoPivotInvariant.trailing_eq` packaged so the step
+field is given by an external equation rather than appearing inside dependent
+proof terms. Lets callers consume `trailing_eq` at an arbitrary numeric step
+value `s` known to equal `state.step` without manually transporting the
+inequality proofs. -/
+private theorem trailing_eq_at_step
+    {M : Hex.Matrix Int n n} {state : Hex.Matrix.BareissState n}
+    (hinv : BareissNoPivotInvariant M state)
+    (s : Nat) (hs : s < n) (hstep : s = state.step)
+    (a c : Fin n) (hsa : s ≤ a.val) (hsc : s ≤ c.val) :
+    state.matrix[a][c] =
+      Hex.Matrix.det (Hex.Matrix.borderedMinor M s hs a c) := by
+  subst hstep
+  exact hinv.trailing_eq hs a c hsa hsc
+
+/-- Off-step generalisation of the no-pivot Bareiss bordered-minor
+identification. After `k + 1` no-pivot Bareiss iterations on `M`, every entry
+at `(a, c)` with `k + 1 ≤ a.val, c.val` equals the determinant of the
+`(k + 2) × (k + 2)` bordered minor of `M` with trailing row `a` and column
+`c`, provided the partial loop records no singular step.
+
+Composes `noPivotLoop_invariant_of_singularStep_eq_none` (the invariant
+propagates through a non-singular partial pass), `BareissNoPivotInvariant`
+(the trailing-block entries equal bordered-minor determinants), and
+`noPivotLoop_step_eq_add_of_singularStep_none` (the partial pass advances
+`step` by exactly the fuel consumed). -/
+theorem noPivotLoop_full_eq_borderedMinor_det
+    (M : Hex.Matrix Int n n) (k : Nat) (hk : k + 1 < n)
+    (a c : Fin n) (hak : k + 1 ≤ a.val) (hck : k + 1 ≤ c.val)
+    (h_no_sing :
+      (Hex.Matrix.noPivotLoop (k + 1)
+          (Hex.Matrix.noPivotInitialState M)).singularStep = none) :
+    (Hex.Matrix.noPivotLoop (k + 1)
+        (Hex.Matrix.noPivotInitialState M)).matrix[a][c] =
+      Hex.Matrix.det (Hex.Matrix.borderedMinor M (k + 1) hk a c) := by
+  have hinv : BareissNoPivotInvariant M
+      (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)) :=
+    noPivotLoop_invariant_of_singularStep_eq_none M (k + 1)
+      (Hex.Matrix.noPivotInitialState M) (bareissNoPivotInvariant_initial M)
+      h_no_sing
+  have hstep_eq :
+      k + 1 =
+        (Hex.Matrix.noPivotLoop (k + 1) (Hex.Matrix.noPivotInitialState M)).step := by
+    have h_room : (Hex.Matrix.noPivotInitialState M).step + (k + 1) + 1 ≤ n := by
+      change 0 + (k + 1) + 1 ≤ n
+      omega
+    have h := Hex.Matrix.noPivotLoop_step_eq_add_of_singularStep_none (k + 1)
+      (Hex.Matrix.noPivotInitialState M) rfl h_room h_no_sing
+    rw [h]
+    show k + 1 = 0 + (k + 1)
+    omega
+  exact trailing_eq_at_step hinv (k + 1) hk hstep_eq a c hak hck
+
 end HexMatrixMathlib

--- a/progress/20260604T035434Z_f57ed369.md
+++ b/progress/20260604T035434Z_f57ed369.md
@@ -1,0 +1,70 @@
+# Session 20260604T035434Z_f57ed369
+
+Closes [#6515](https://github.com/kim-em/hex/issues/6515).
+
+## Accomplished
+
+Added Mathlib-side theorem
+`HexMatrixMathlib.noPivotLoop_full_eq_borderedMinor_det` to
+[HexMatrixMathlib/Determinant/Bareiss.lean](../HexMatrixMathlib/Determinant/Bareiss.lean):
+after `k + 1` no-pivot Bareiss iterations on `M`, every entry at `(a, c)` with
+`k + 1 ≤ a.val, c.val` equals
+`Hex.Matrix.det (Hex.Matrix.borderedMinor M (k + 1) hk a c)`, provided the
+partial loop records no singular step.
+
+The proof composes three existing pieces of infrastructure:
+
+- `noPivotLoop_invariant_of_singularStep_eq_none` propagates
+  `BareissNoPivotInvariant` through a non-singular partial pass.
+- `BareissNoPivotInvariant.trailing_eq` already identifies trailing-block
+  entries with bordered-minor determinants.
+- `noPivotLoop_step_eq_add_of_singularStep_none` pins the resulting `step`
+  field to `k + 1`.
+
+A small `private` helper `trailing_eq_at_step` packages
+`BareissNoPivotInvariant.trailing_eq` so the step value can be supplied as a
+free natural number with a separate equation, which `subst` then resolves —
+this is needed because `borderedMinor`'s type depends on the step value and
+the dependent inequality proof.
+
+## Why the directive's symmetry hypothesis was dropped
+
+The directive proposed a symmetry hypothesis (`M.IsSymm` or
+`M = M.transpose`) and a `(k+1) × (k+1)` bordered minor. With the
+`BareissNoPivotInvariant.trailing_eq` route, symmetry is unnecessary — the
+identity `M^{(k+1)}[a][c] = det (borderedMinor M (k+1) hk a c)` is the
+asymmetric bordered minor on rows `{0,…,k, a}` and columns `{0,…,k, c}` and
+holds without symmetry. The `(k+1) × (k+1)` size in the directive draft
+matches the size of the Bareiss state after `k+1` iterations, but the
+borderedMinor constructor takes `k+1` as its trailing-block-size parameter
+and produces a `(k+2) × (k+2)` matrix; the corner entry is
+`M[a][c]`. Permission to deviate from
+[.claude/CLAUDE.md](../.claude/CLAUDE.md) covers this.
+
+The σ-chain consumer (stage B per #6514's analysis) reads `M^{(k+1)}[a][c]`
+without symmetry as the base step; symmetry is only invoked separately via
+the existing `noPivotLoop_matrix_symm_preserve` in
+[HexGramSchmidt/Int.lean](../HexGramSchmidt/Int.lean).
+
+## Current frontier
+
+Stage A landed. The next stages per the predecessor's three-stage plan:
+- **B.** σ-chain rational closed-form invariant
+  `σ_k = D_k * G[a][c] - M^{(k+1)}[a][c]` for the Schur recurrence on the
+  non-singular Gram pass. Depends on this stage. Produces
+  `scaledCoeffs_lower_eq_det_scaledCoeffMatrix` under the non-singular
+  hypothesis.
+- **C.** Sorry-free bridge-side singular cascade for
+  `(scaledCoeffs b)[i][j] = 0` when `noPivotLoop j.val .singularStep = some s,
+  s < j`. Independent of A, B.
+
+## Verification
+
+- `lake build` clean across the whole project (244 jobs).
+- `grep -c sorry` on `HexMatrixMathlib/`, `HexGramSchmidt`,
+  `HexGramSchmidtMathlib`, `HexLLL`, `HexLLLMathlib` unchanged from main.
+- No new `axiom`. No `native_decide`. No existing signature changed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6515

Session: `f57ed369-6093-45a6-90c3-ee373414b7cd`

ac15cef3 feat: noPivotLoop_full_eq_borderedMinor_det off-step Bareiss/det bridge

🤖 Prepared with Claude Code