### PR TITLE
feat: prove mem_latticeSubmodule_iff (HexLLLMathlib lattice correspondence)

### DIFF
--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -58,7 +58,23 @@ def latticeSubmodule (b : Hex.Matrix Int n m) : Submodule ℤ (Fin m → ℤ) :=
 
 theorem mem_latticeSubmodule_iff (b : Hex.Matrix Int n m) (v : Vector Int m) :
     HexMatrixMathlib.vectorEquiv v ∈ latticeSubmodule b ↔ Hex.Matrix.memLattice b v := by
-  sorry
+  unfold latticeSubmodule Hex.Matrix.memLattice
+  rw [Submodule.mem_span_range_iff_exists_fun]
+  constructor
+  · rintro ⟨c, hc⟩
+    refine ⟨HexMatrixMathlib.vectorEquiv.symm c,
+      HexMatrixMathlib.vectorEquiv.injective ?_⟩
+    rw [HexMatrixMathlib.vectorEquiv_rowCombination,
+      Fintype.linearCombination_apply, Equiv.apply_symm_apply]
+    refine (Finset.sum_congr rfl fun i _ => ?_).trans hc
+    rw [HexMatrixMathlib.matrixEquiv_row]
+  · rintro ⟨c, hc⟩
+    refine ⟨HexMatrixMathlib.vectorEquiv c, ?_⟩
+    have hr := HexMatrixMathlib.vectorEquiv_rowCombination b c
+    rw [hc, Fintype.linearCombination_apply] at hr
+    rw [hr]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [HexMatrixMathlib.matrixEquiv_row]
 
 theorem memLattice_iff_mem_latticeSubmodule (b : Hex.Matrix Int n m) (v : Vector Int m) :
     Hex.Matrix.memLattice b v ↔ HexMatrixMathlib.vectorEquiv v ∈ latticeSubmodule b :=

--- a/HexMatrixMathlib/RankSpanNullspace.lean
+++ b/HexMatrixMathlib/RankSpanNullspace.lean
@@ -65,7 +65,7 @@ private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector 
   intro k _
   rfl
 
-theorem vectorEquiv_rowCombination [Field R] (M : Hex.Matrix R n m) (c : Vector R n) :
+theorem vectorEquiv_rowCombination [CommRing R] (M : Hex.Matrix R n m) (c : Vector R n) :
     vectorEquiv (Hex.Matrix.rowCombination M c) =
       Fintype.linearCombination R (_root_.Matrix.row (matrixEquiv M)) (vectorEquiv c) := by
   funext j

--- a/progress/2026-06-05T000056Z_e6c32fc7.md
+++ b/progress/2026-06-05T000056Z_e6c32fc7.md
@@ -1,0 +1,29 @@
+# Session 2026-06-05T000056Z (e6c32fc7) — close mem_latticeSubmodule_iff
+
+## Accomplished
+- Closed the `sorry` for `mem_latticeSubmodule_iff` in
+  `HexLLLMathlib/Basic.lean` (closes #6557). The proof routes
+  span-membership through `Submodule.mem_span_range_iff_exists_fun`
+  and reconciles `∑ i, c i • …` with `rowCombination` via
+  `vectorEquiv_rowCombination` and the `vectorEquiv` round-trip on
+  the coefficient witness.
+- Generalised `vectorEquiv_rowCombination` in
+  `HexMatrixMathlib/RankSpanNullspace.lean` from `[Field R]` to
+  `[CommRing R]` so it applies at `R = ℤ`. The original proof body
+  used only `Finset.sum` / `mul_comm` / `smul_eq_mul`, so the
+  generalisation was a one-character typeclass swap; all four
+  existing call sites remain in `[Field R] [DecidableEq R]`
+  contexts and compile unchanged.
+
+## Current frontier
+`HexLLLMathlib.Basic` still contains one residual `sorry` at
+`reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`
+(Basic.lean:108) — orthogonal to this issue.
+
+## Next step
+Hand off; another worker will tackle the residual
+`reduced_first_row_norm_sq_le_of_mem_latticeSubmodule` sorry on a
+fresh issue.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6557

Session: `e6c32fc7-e147-4413-b39f-9eca5edbe627`

ced65913 feat: prove mem_latticeSubmodule_iff (closes #6557)

🤖 Prepared with Claude Code