### PR TITLE
HexGramSchmidt: close gramDetVecEntry leading-prefix theorem

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -6140,27 +6140,107 @@ private theorem scaledCoeffArrayLoop_diag_matches
             rw [← h_step_eq]; exact Nat.lt_of_lt_of_le i.isLt hArrayStep'
           exact h_coeffs_processed i.val h_ilt i.isLt
 /-- The no-pivot Bareiss pass over the full Gram matrix records the same
-leading-prefix determinant as the public `gramDet` API at every vector slot.
-
-This sorry is the consumer side of the singular helper
-`leadingPrefix_gram_bareiss_toNat_eq_zero_of_noPivot_singular`. Discharging it
-requires propagating quotient provenance through this private theorem
-and its public consumers (`gramDetVecEntry_eq_gramDet`, `scaledCoeffs_diag_toNat`,
-`gramDetVec_eq_gramDet`, and downstream callers in
-`HexGramSchmidtMathlib` and `HexLLL`). That API surgery is tracked by #5655. -/
+leading-prefix determinant as the public `gramDet` API at every vector slot. -/
 private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
-    (b : Matrix Int n m) (r : Nat) (hr : r < n) :
+    (b : Matrix Int n m) (hquot : StepWitness b) (r : Nat) (hr : r < n) :
     gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
         ⟨r + 1, Nat.succ_lt_succ hr⟩ =
       (Matrix.bareiss
         (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
           (Nat.succ_le_of_lt hr))).toNat := by
-  sorry
+  let GM := Matrix.gramMatrix b
+  let init := Matrix.noPivotInitialState GM
+  let data := Matrix.bareissNoPivotData GM
+  let i : Fin n := ⟨r, hr⟩
+  by_cases h_prefix :
+      (Matrix.noPivotLoop r init).singularStep = none
+  · have hdiag :=
+      bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+        (b := b) r hr (by simpa [GM, init] using h_prefix)
+    have h_step_r : (Matrix.noPivotLoop r init).step = r := by
+      have h_room : init.step + r + 1 ≤ n := by
+        simp [init, Matrix.noPivotInitialState]
+        omega
+      have h := Matrix.noPivotLoop_step_eq_add_of_singularStep_none
+        r init rfl h_room h_prefix
+      simpa [init, Matrix.noPivotInitialState] using h
+    have h_entry_diag :
+        gramDetVecEntry data ⟨r + 1, Nat.succ_lt_succ hr⟩ =
+          (data.matrix[i][i]).toNat := by
+      have h_split : r + (n - r) = n := by omega
+      have h_full :
+          Matrix.noPivotLoop n init =
+            Matrix.noPivotLoop (n - r) (Matrix.noPivotLoop r init) := by
+        simpa [h_split] using Matrix.noPivotLoop_add r (n - r) init
+      rcases noPivotLoop_singular_inv (n := n) (n - r)
+          (Matrix.noPivotLoop r init) h_prefix with h_none | h_sing
+      · have hdata : data.singularStep = none := by
+          simpa [data, Matrix.bareissNoPivotData, Matrix.finish, GM, init, h_full] using h_none
+        simp [gramDetVecEntry, data, hdata, i]
+        rfl
+      · rcases h_sing with ⟨k, h_sing_full, h_step_full, h_zero_full, _hk_bound⟩
+        have hdata : data.singularStep = some k.val := by
+          simpa [data, Matrix.bareissNoPivotData, Matrix.finish, GM, init, h_full] using h_sing_full
+        have hmono := noPivotLoop_step_monotone (n - r) (Matrix.noPivotLoop r init)
+        have hr_le_k : r ≤ k.val := by
+          rw [h_step_r, h_step_full] at hmono
+          exact hmono
+        by_cases hkr : k.val = r
+        · have hlt : k.val < r + 1 := by omega
+          have hdata_matrix :
+              data.matrix[i][i] =
+                (Matrix.noPivotLoop (n - r) (Matrix.noPivotLoop r init)).matrix[i][i] := by
+            simp [data, Matrix.bareissNoPivotData, Matrix.finish, GM, init, h_full]
+          have hzero_i : data.matrix[i][i] = 0 := by
+            have hi_eq : i = k := Fin.ext hkr.symm
+            rw [hdata_matrix]
+            simpa [hi_eq] using h_zero_full
+          simp [gramDetVecEntry, data, hdata, i, hlt]
+          simpa [data, i] using (congrArg Int.toNat hzero_i).symm
+        · have hlt : ¬ k.val < r + 1 := by omega
+          simp [gramDetVecEntry, data, hdata, i, hlt]
+          rfl
+    calc
+      gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
+          ⟨r + 1, Nat.succ_lt_succ hr⟩ =
+          (data.matrix[i][i]).toNat := by
+            simpa [data, GM, i] using h_entry_diag
+      _ = (Matrix.bareiss
+            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+              (Nat.succ_le_of_lt hr))).toNat := by
+            exact congrArg Int.toNat (by simpa [data, GM, i] using hdiag)
+  · rcases noPivotLoop_singular_inv (n := n) r init rfl with h_none | h_sing
+    · exact False.elim (h_prefix h_none)
+    · rcases h_sing with ⟨k, h_sing_r, h_step_r, h_zero_r, h_klt⟩
+      have hsr : k.val < r + 1 := by
+        have h := noPivotLoop_singularStep_lt (n := n) r init rfl k.val h_sing_r
+        simp [init, Matrix.noPivotInitialState] at h
+        omega
+      have h_full_eq :
+          Matrix.noPivotLoop n init = Matrix.noPivotLoop r init := by
+        have h_split : n = r + (n - r) := by omega
+        have hext :=
+          noPivotLoop_extends_singularStep init r (n - r) k
+            h_sing_r h_step_r h_zero_r h_klt
+        exact (congrArg (fun fuel => Matrix.noPivotLoop fuel init) h_split).trans hext
+      have hdata : data.singularStep = some k.val := by
+        simpa [data, Matrix.bareissNoPivotData, Matrix.finish, GM, init, h_full_eq] using h_sing_r
+      have hleft :
+          gramDetVecEntry data ⟨r + 1, Nat.succ_lt_succ hr⟩ = 0 := by
+        simp [gramDetVecEntry, data, hdata, hsr]
+      have hright :
+          (Matrix.bareiss
+            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+              (Nat.succ_le_of_lt hr))).toNat = 0 :=
+        leadingPrefix_gram_bareiss_toNat_eq_zero_of_noPivot_singular
+          (b := b) r hr hquot k.val (by simpa [GM, init] using h_sing_r)
+      rw [hright]
+      simpa [data, GM] using hleft
 
 /-- The no-pivot Bareiss pass over the full Gram matrix records the same
 leading-prefix determinant as the public `gramDet` API at every vector slot. -/
 theorem gramDetVecEntry_eq_gramDet
-    (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
+    (b : Matrix Int n m) (hquot : StepWitness b) (k : Nat) (hk : k ≤ n) :
     gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
         ⟨k, Nat.lt_succ_of_le hk⟩ =
       gramDet b k hk := by
@@ -6179,7 +6259,7 @@ theorem gramDetVecEntry_eq_gramDet
         _ = (Matrix.bareiss
               (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
                 (Nat.succ_le_of_lt hr))).toNat :=
-              gramDetVecEntry_eq_leadingPrefix_bareiss (b := b) r hr
+              gramDetVecEntry_eq_leadingPrefix_bareiss (b := b) hquot r hr
         _ = gramDet b (r + 1) hk := by
               simp [gramDet, GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
 
@@ -6242,11 +6322,11 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDetVecEntry
 /-- The scaled-coefficient loop stores the next leading Gram determinant on
 the diagonal, at the executable Nat boundary. -/
 private theorem scaledCoeffRows_diag_toNat_eq_gramDet
-    (b : Matrix Int n m) (i : Nat) (hi : i < n) :
+    (b : Matrix Int n m) (hquot : StepWitness b) (i : Nat) (hi : i < n) :
     (getArrayEntry (scaledCoeffRows b) i i).toNat =
       gramDet b (i + 1) (Nat.succ_le_of_lt hi) := by
   rw [scaledCoeffRows_diag_toNat_eq_gramDetVecEntry (b := b) i hi]
-  rw [gramDetVecEntry_eq_gramDet (b := b) (i + 1) (Nat.succ_le_of_lt hi)]
+  rw [gramDetVecEntry_eq_gramDet (b := b) hquot (i + 1) (Nat.succ_le_of_lt hi)]
 
 /-- Signed diagonal information from the executable scaled-coefficient loop:
 the diagonal slot is either the zero tail recorded after an earlier singular
@@ -6410,11 +6490,11 @@ private theorem scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss
 diagonal synchronization can be lifted back to the corresponding Int equality.
 That nonnegativity is a Mathlib-side obligation for Gram determinants. -/
 private theorem scaledCoeffRows_diag_eq_gramDet_of_nonneg
-    (b : Matrix Int n m) (i : Nat) (hi : i < n)
+    (b : Matrix Int n m) (hquot : StepWitness b) (i : Nat) (hi : i < n)
     (hnonneg : 0 ≤ getArrayEntry (scaledCoeffRows b) i i) :
     getArrayEntry (scaledCoeffRows b) i i =
       Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
-  have hdiag := scaledCoeffRows_diag_toNat_eq_gramDet (b := b) i hi
+  have hdiag := scaledCoeffRows_diag_toNat_eq_gramDet (b := b) hquot i hi
   rw [← hdiag]
   exact (Int.toNat_of_nonneg hnonneg).symm
 
@@ -8503,7 +8583,7 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (hquot : StepWitness b)
           (getArrayEntry (scaledCoeffRowsSchur b) r r).toNat := by
       simp [gramDetVec, data, gramDetVecFromScaledCoeffRows]
     rw [hget, getArrayEntry_scaledCoeffRowsSchur_eq b hquot]
-    exact scaledCoeffRows_diag_toNat_eq_gramDet (b := b) r hr
+    exact scaledCoeffRows_diag_toNat_eq_gramDet (b := b) hquot r hr
 
 /-- Nat-level diagonal synchronization for the public scaled-coefficient
 matrix. This is the Mathlib-free diagonal fact exposed by the shared array

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -1559,121 +1559,6 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
     rw [Matrix.det_colReplace_existing_col_eq_zero _ _ _ hq_ne]
     grind
 
-/-- Cramer's rule identity under singularity. When the no-pivot Bareiss pass over
-the Gram matrix records an early singular step before reaching column `j`, the
-Leibniz determinant of the Cramer minor `scaledCoeffMatrix b i j hji` is zero.
-Internally lifts the partial-pass singularity to the full `bareissNoPivotData`
-pass, traverses `gramDetVecEntry` to conclude `gramDet b (j+1) = 0`, and
-finishes via the Cramer determinant identity
-`scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`. -/
-theorem scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
-    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) (s : Nat)
-    (h_sing : (Matrix.noPivotLoop j.val
-        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
-    Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) = 0 := by
-  -- Step A: derive `s < j.val` from the partial-pass singularity.
-  have hsj : s < j.val := by
-    have h := noPivotLoop_singularStep_lt j.val
-      (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl s h_sing
-    -- h : s < (noPivotInitialState ...).step + j.val. The init step is 0.
-    change s < 0 + j.val at h
-    omega
-  -- Step B: lift to the full `bareissNoPivotData` pass.
-  have hjn : j.val < n := Nat.lt_trans hji i.isLt
-  have hsucc : j.val + 1 ≤ n := Nat.succ_le_of_lt hjn
-  have hjle : j.val ≤ n := Nat.le_of_lt hjn
-  have h_init :
-      (Matrix.noPivotInitialState (Matrix.gramMatrix b)).singularStep = none := rfl
-  have h_full_sing :
-      (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).singularStep = some s := by
-    -- Apply singular_inv to the j.val-fueled pass.
-    rcases noPivotLoop_singular_inv j.val
-        (Matrix.noPivotInitialState (Matrix.gramMatrix b)) h_init
-      with h_none | ⟨k, hsk, hstk, hpk, hk⟩
-    · rw [h_none] at h_sing; nomatch h_sing
-    · -- The full pass equals the j.val pass via fixedpoint.
-      have hks : k.val = s := by
-        rw [hsk] at h_sing
-        exact Option.some.inj h_sing
-      -- Use noPivotLoop_add and noPivotLoop_id_at_singular_fixedpoint to lift.
-      have h_add : Matrix.noPivotLoop (j.val + (n - j.val))
-          (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
-        Matrix.noPivotLoop (n - j.val)
-          (Matrix.noPivotLoop j.val
-            (Matrix.noPivotInitialState (Matrix.gramMatrix b))) :=
-        Matrix.noPivotLoop_add j.val (n - j.val) _
-      have hn_eq : j.val + (n - j.val) = n := Nat.add_sub_cancel' hjle
-      -- The post-`j.val` state already has singularStep = some k.val, step = k.val,
-      -- and a zero pivot at column k. Extra fuel is a fixedpoint.
-      have h_step_lt : (Matrix.noPivotLoop j.val
-          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n := by
-        rw [hstk]; exact hk
-      have h_pivot_zero :
-          (Matrix.noPivotLoop j.val
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[
-              (⟨(Matrix.noPivotLoop j.val
-                  (Matrix.noPivotInitialState
-                    (Matrix.gramMatrix b))).step,
-                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)][
-              (⟨(Matrix.noPivotLoop j.val
-                  (Matrix.noPivotInitialState
-                    (Matrix.gramMatrix b))).step,
-                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)] = 0 := by
-        have h_fin :
-            (⟨(Matrix.noPivotLoop j.val
-                (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step,
-              Nat.lt_of_succ_lt h_step_lt⟩ : Fin n) = k :=
-          Fin.ext hstk
-        simp only [h_fin]
-        exact hpk
-      have h_sing_step :
-          (Matrix.noPivotLoop j.val
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep =
-            some (Matrix.noPivotLoop j.val
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step := by
-        rw [hsk, hstk]
-      have h_fixed :
-          Matrix.noPivotLoop (n - j.val)
-            (Matrix.noPivotLoop j.val
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b))) =
-            Matrix.noPivotLoop j.val
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b)) :=
-        Matrix.noPivotLoop_id_at_singular_fixedpoint (n := n) (n - j.val) _
-          h_step_lt h_pivot_zero h_sing_step
-      have h_full_eq :
-          Matrix.noPivotLoop n
-            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
-          Matrix.noPivotLoop j.val
-            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
-        calc Matrix.noPivotLoop n
-              (Matrix.noPivotInitialState (Matrix.gramMatrix b))
-            = Matrix.noPivotLoop (j.val + (n - j.val))
-                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
-                  rw [hn_eq]
-          _ = Matrix.noPivotLoop (n - j.val)
-                (Matrix.noPivotLoop j.val
-                  (Matrix.noPivotInitialState (Matrix.gramMatrix b))) := h_add
-          _ = Matrix.noPivotLoop j.val
-                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := h_fixed
-      show (Matrix.finish (Matrix.noPivotLoop n
-          (Matrix.noPivotInitialState (Matrix.gramMatrix b)))).singularStep = some s
-      change (Matrix.noPivotLoop n
-          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s
-      rw [h_full_eq, hsk, hks]
-  -- Step C: gramDet b (j+1) = 0 via gramDetVecEntry chain.
-  have h_gd_zero : gramDet b (j.val + 1) hsucc = 0 := by
-    have h_vec_gd := gramDetVecEntry_eq_gramDet (b := b) (j.val + 1) hsucc
-    have h_vec_zero :=
-      gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt b s j.val hjn h_full_sing
-        (by omega)
-    rw [← h_vec_gd, h_vec_zero]
-  -- Step D: Cramer's identity collapses to zero.
-  have h_cramer :=
-    scaledCoeffMatrix_det_eq_gramDet_mul_coeffs (b := b) i.val j.val i.isLt hji
-  rw [h_gd_zero] at h_cramer
-  simp at h_cramer
-  exact_mod_cast h_cramer
-
 /-- Substitution helper for the diagonal `(i, i)` matrix entry under a Fin
 equality. Folded out of `subst`/`rfl` so callers can rewrite the index without
 dragging the dependent proof component through the motive. -/
@@ -2417,6 +2302,122 @@ def StepWitness.ofGram (b : Matrix Int n m) :
     Fin.ext h_kA_val.symm
   simp_rw [hK] at hdj
   exact hdj.symm
+
+/-- Cramer's rule identity under singularity. When the no-pivot Bareiss pass over
+the Gram matrix records an early singular step before reaching column `j`, the
+Leibniz determinant of the Cramer minor `scaledCoeffMatrix b i j hji` is zero.
+Internally lifts the partial-pass singularity to the full `bareissNoPivotData`
+pass, traverses `gramDetVecEntry` to conclude `gramDet b (j+1) = 0`, and
+finishes via the Cramer determinant identity
+`scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`. -/
+theorem scaledCoeffMatrix_det_eq_zero_of_singularStep_lt
+    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) (s : Nat)
+    (h_sing : (Matrix.noPivotLoop j.val
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
+    Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) = 0 := by
+  -- Step A: derive `s < j.val` from the partial-pass singularity.
+  have hsj : s < j.val := by
+    have h := noPivotLoop_singularStep_lt j.val
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl s h_sing
+    -- h : s < (noPivotInitialState ...).step + j.val. The init step is 0.
+    change s < 0 + j.val at h
+    omega
+  -- Step B: lift to the full `bareissNoPivotData` pass.
+  have hjn : j.val < n := Nat.lt_trans hji i.isLt
+  have hsucc : j.val + 1 ≤ n := Nat.succ_le_of_lt hjn
+  have hjle : j.val ≤ n := Nat.le_of_lt hjn
+  have h_init :
+      (Matrix.noPivotInitialState (Matrix.gramMatrix b)).singularStep = none := rfl
+  have h_full_sing :
+      (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).singularStep = some s := by
+    -- Apply singular_inv to the j.val-fueled pass.
+    rcases noPivotLoop_singular_inv j.val
+        (Matrix.noPivotInitialState (Matrix.gramMatrix b)) h_init
+      with h_none | ⟨k, hsk, hstk, hpk, hk⟩
+    · rw [h_none] at h_sing; nomatch h_sing
+    · -- The full pass equals the j.val pass via fixedpoint.
+      have hks : k.val = s := by
+        rw [hsk] at h_sing
+        exact Option.some.inj h_sing
+      -- Use noPivotLoop_add and noPivotLoop_id_at_singular_fixedpoint to lift.
+      have h_add : Matrix.noPivotLoop (j.val + (n - j.val))
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
+        Matrix.noPivotLoop (n - j.val)
+          (Matrix.noPivotLoop j.val
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b))) :=
+        Matrix.noPivotLoop_add j.val (n - j.val) _
+      have hn_eq : j.val + (n - j.val) = n := Nat.add_sub_cancel' hjle
+      -- The post-`j.val` state already has singularStep = some k.val, step = k.val,
+      -- and a zero pivot at column k. Extra fuel is a fixedpoint.
+      have h_step_lt : (Matrix.noPivotLoop j.val
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n := by
+        rw [hstk]; exact hk
+      have h_pivot_zero :
+          (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[
+              (⟨(Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState
+                    (Matrix.gramMatrix b))).step,
+                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)][
+              (⟨(Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState
+                    (Matrix.gramMatrix b))).step,
+                Nat.lt_of_succ_lt h_step_lt⟩ : Fin n)] = 0 := by
+        have h_fin :
+            (⟨(Matrix.noPivotLoop j.val
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step,
+              Nat.lt_of_succ_lt h_step_lt⟩ : Fin n) = k :=
+          Fin.ext hstk
+        simp only [h_fin]
+        exact hpk
+      have h_sing_step :
+          (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep =
+            some (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step := by
+        rw [hsk, hstk]
+      have h_fixed :
+          Matrix.noPivotLoop (n - j.val)
+            (Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))) =
+            Matrix.noPivotLoop j.val
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b)) :=
+        Matrix.noPivotLoop_id_at_singular_fixedpoint (n := n) (n - j.val) _
+          h_step_lt h_pivot_zero h_sing_step
+      have h_full_eq :
+          Matrix.noPivotLoop n
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) =
+          Matrix.noPivotLoop j.val
+            (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
+        calc Matrix.noPivotLoop n
+              (Matrix.noPivotInitialState (Matrix.gramMatrix b))
+            = Matrix.noPivotLoop (j.val + (n - j.val))
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := by
+                  rw [hn_eq]
+          _ = Matrix.noPivotLoop (n - j.val)
+                (Matrix.noPivotLoop j.val
+                  (Matrix.noPivotInitialState (Matrix.gramMatrix b))) := h_add
+          _ = Matrix.noPivotLoop j.val
+                (Matrix.noPivotInitialState (Matrix.gramMatrix b)) := h_fixed
+      show (Matrix.finish (Matrix.noPivotLoop n
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b)))).singularStep = some s
+      change (Matrix.noPivotLoop n
+          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s
+      rw [h_full_eq, hsk, hks]
+  -- Step C: gramDet b (j+1) = 0 via gramDetVecEntry chain.
+  have h_gd_zero : gramDet b (j.val + 1) hsucc = 0 := by
+    have h_vec_gd :=
+      gramDetVecEntry_eq_gramDet (b := b) (StepWitness.ofGram b) (j.val + 1) hsucc
+    have h_vec_zero :=
+      gramDetVecEntry_noPivot_eq_zero_of_singularStep_lt b s j.val hjn h_full_sing
+        (by omega)
+    rw [← h_vec_gd, h_vec_zero]
+  -- Step D: Cramer's identity collapses to zero.
+  have h_cramer :=
+    scaledCoeffMatrix_det_eq_gramDet_mul_coeffs (b := b) i.val j.val i.isLt hji
+  rw [h_gd_zero] at h_cramer
+  simp at h_cramer
+  exact_mod_cast h_cramer
 
 /-- Unconditional rational closed form for the strictly lower entries of
 `scaledCoeffs`: the executable integer scaled coefficient agrees with the

--- a/progress/20260605T000154Z_9a26c02b.md
+++ b/progress/20260605T000154Z_9a26c02b.md
@@ -1,0 +1,45 @@
+# 2026-06-05 00:01Z — close gramDetVecEntry leading-prefix proof (#6382)
+
+## Accomplished
+
+Closed the remaining Mathlib-free `gramDetVecEntry_eq_leadingPrefix_bareiss`
+proof in `HexGramSchmidt/Int.lean`.
+
+Threaded `StepWitness b` through the private leading-prefix theorem, the
+Mathlib-free `gramDetVecEntry_eq_gramDet` wrapper, and the affected
+scaled-coefficient diagonal helpers. Existing public `gramDetVec_eq_gramDet`,
+`scaledCoeffs_diag_toNat`, and downstream public APIs already carried
+`StepWitness b`, so the remaining Mathlib-free consumer migration was small.
+
+Updated the Mathlib bridge call site to discharge the new witness with
+`StepWitness.ofGram b`. Because that witness is defined after the early
+singular Cramer theorem, moved
+`scaledCoeffMatrix_det_eq_zero_of_singularStep_lt` below `StepWitness.ofGram`;
+the theorem remains before its only downstream use.
+
+Verification:
+
+- `lake build HexGramSchmidt.Int` passed.
+- `lake build HexGramSchmidt` passed.
+- `lake build HexGramSchmidtMathlib` passed.
+- `lake build HexLLL` passed.
+- `python3 scripts/check_dag.py` passed.
+- `git diff --check` passed.
+- `git diff -- HexGramSchmidt/Int.lean HexGramSchmidtMathlib/Int.lean | rg -n '^\\+.*(sorry|axiom|native_decide|TODO|FIXME)'` returned no matches.
+
+## Current frontier
+
+Issue #6382 is complete. The Gram-Schmidt Mathlib-free leading-prefix theorem
+now uses the same StepWitness provenance path as the sibling chain from #6554.
+
+## Next step
+
+Open the PR for #6382.
+
+## Blockers
+
+None. Builds still report pre-existing linter/sorry warnings outside this
+change: `HexGramSchmidt/Basic.lean:1606`,
+`HexGramSchmidt/Int.lean:4939`, `HexGramSchmidtMathlib/Int.lean:2842`,
+`HexGramSchmidtMathlib/Update.lean:564`, `HexGramSchmidtMathlib/Update.lean:599`,
+and existing `HexLLL/Basic.lean` sorry warnings.


### PR DESCRIPTION
Closes #6382

Session: `9a26c02b-74ea-4330-bda9-92d2f4b3b7a8`

1b57c514 feat: close gram det vector prefix proof

🤖 Prepared with Claude Code