### PR TITLE
feat: HexLLL short-vector Step 3 — executable lll_short_vector assembly

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -7076,7 +7076,7 @@ private theorem exists_highest_nonzero_coeff
     ⟨k, _hk_mem, hck, hmax⟩
   exact ⟨k, hck, fun j hj => hmax j (List.mem_finRange j) hj⟩
 
-private theorem normSq_map_intCast (v : Vector Int m) :
+theorem normSq_map_intCast (v : Vector Int m) :
     Vector.normSq (Vector.map (fun x : Int => (x : Rat)) v) =
       ((Vector.normSq v : Int) : Rat) := by
   simpa [Vector.normSq, Hex.Vector.normSq, Matrix.dot, Hex.Vector.dotProduct]

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -211,7 +211,93 @@ theorem teleBound (b : Matrix Int n m) {δ : Rat}
             rw [Lean.Grind.Semiring.pow_succ]
             grind
 
+/-- First Gram-Schmidt basis vector identity: the 0-th Gram-Schmidt vector
+coincides with the 0-th input row, so their squared norms agree. -/
+theorem basisNormSq_zero (b : Matrix Int n m) (hn : 0 < n) :
+    basisNormSq (GramSchmidt.Int.basis b) ⟨0, hn⟩ =
+      ((Vector.normSq (b.row ⟨0, hn⟩) : Int) : Rat) := by
+  unfold basisNormSq
+  rw [GramSchmidt.Int.basis_zero b hn]
+  exact GramSchmidt.Int.normSq_map_intCast (b.row ⟨0, hn⟩)
+
+private theorem ratPow_le_pow_of_one_le {α : Rat} (hα : 1 ≤ α) :
+    ∀ {i j : Nat}, i ≤ j → α ^ i ≤ α ^ j := by
+  intro i j hij
+  induction j with
+  | zero =>
+      have hi : i = 0 := Nat.le_zero.mp hij
+      subst hi
+      exact Rat.le_refl
+  | succ k ih =>
+      by_cases hi : i ≤ k
+      · have hih := ih hi
+        have hα_nn : (0 : Rat) ≤ α := by grind
+        have hpow_k : 0 ≤ α ^ k := ratPow_nonneg α hα_nn k
+        have hstep : α ^ k ≤ α ^ (k + 1) := by
+          rw [Lean.Grind.Semiring.pow_succ]
+          have h1 : α ^ k * 1 ≤ α ^ k * α :=
+            Rat.mul_le_mul_of_nonneg_left hα hpow_k
+          simpa using h1
+        exact Rat.le_trans hih hstep
+      · have hi' : i = k + 1 :=
+          Nat.le_antisymm hij (Nat.succ_le_of_lt (Nat.lt_of_not_ge hi))
+        subst hi'
+        exact Rat.le_refl
+
 end LLLCore
+
+/-- LLL short-vector core inequality: for a `δ`-LLL-reduced basis with
+`1/4 < δ ≤ 1`, the squared norm of the first row is at most
+`(1 / (δ - 1/4)) ^ (n - 1)` times the squared norm of any nonzero lattice
+vector. Combines `LLLCore.teleBound` with the lower bound on the smallest
+Gram-Schmidt vector contained in the lattice. -/
+theorem lll_short_vector (b : Matrix Int n m) {δ : Rat}
+    (hli : Matrix.independent b) (hred : isLLLReduced b δ)
+    (hδ : (1 / 4 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
+    ((Vector.normSq (b.row ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
+      (1 / (δ - 1 / 4)) ^ (n - 1) *
+        ((Vector.normSq v : Int) : Rat) := by
+  have h0n : 0 < n := Nat.lt_of_lt_of_le Nat.zero_lt_one hn
+  obtain ⟨i, hi_norm⟩ :=
+    GramSchmidt.Int.normSq_latticeVec_ge_min_basis_normSq b hli v hv hv'
+  have htele := LLLCore.teleBound b hred hδ i.val i.isLt
+  have e1 : (⟨0, Nat.lt_of_le_of_lt (Nat.zero_le i.val) i.isLt⟩ : Fin n) = ⟨0, h0n⟩ :=
+    Fin.ext rfl
+  have e2 : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
+  rw [e1, e2, LLLCore.basisNormSq_zero b h0n] at htele
+  have hα_pos : 0 < δ - 1 / 4 := by grind
+  have hα_inv_pos : 0 < (1 / (δ - 1 / 4) : Rat) := by
+    rw [Rat.div_def]
+    simpa using (Rat.inv_pos.mpr hα_pos)
+  have hα_nn : (0 : Rat) ≤ 1 / (δ - 1 / 4) := by grind
+  have hα_one : (1 : Rat) ≤ 1 / (δ - 1 / 4) := by
+    have h_le : δ - 1 / 4 ≤ 1 := by grind
+    have hne : δ - 1 / 4 ≠ 0 := by grind
+    have hα_eq : (1 / (δ - 1 / 4)) * (δ - 1 / 4) = 1 := by
+      rw [Rat.div_def]
+      rw [show (1 : Rat) * (δ - 1 / 4)⁻¹ = (δ - 1 / 4)⁻¹ from by grind]
+      exact Rat.inv_mul_cancel _ hne
+    have hstep : (1 / (δ - 1 / 4)) * (δ - 1 / 4) ≤ (1 / (δ - 1 / 4)) * 1 :=
+      Rat.mul_le_mul_of_nonneg_left h_le hα_nn
+    rw [hα_eq] at hstep
+    simpa using hstep
+  have hi_le : i.val ≤ n - 1 := by omega
+  have hpow_mono : (1 / (δ - 1 / 4)) ^ i.val ≤ (1 / (δ - 1 / 4)) ^ (n - 1) :=
+    LLLCore.ratPow_le_pow_of_one_le hα_one hi_le
+  have hbasis_nn : 0 ≤ LLLCore.basisNormSq (GramSchmidt.Int.basis b) i :=
+    LLLCore.basisNormSq_nonneg _ i
+  have hαpow_nn : 0 ≤ (1 / (δ - 1 / 4)) ^ (n - 1) :=
+    LLLCore.ratPow_nonneg _ hα_nn (n - 1)
+  calc
+    ((Vector.normSq (b.row ⟨0, h0n⟩) : Int) : Rat)
+        ≤ (1 / (δ - 1 / 4)) ^ i.val *
+            LLLCore.basisNormSq (GramSchmidt.Int.basis b) i := htele
+    _ ≤ (1 / (δ - 1 / 4)) ^ (n - 1) *
+            LLLCore.basisNormSq (GramSchmidt.Int.basis b) i :=
+        Rat.mul_le_mul_of_nonneg_right hpow_mono hbasis_nn
+    _ ≤ (1 / (δ - 1 / 4)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) :=
+        Rat.mul_le_mul_of_nonneg_left hi_norm hαpow_nn
 
 /-- Integer-only state for later LLL reduction steps. The proof-facing fields
 connect the stored Gram determinants and scaled coefficients to the executable

--- a/progress/20260605T003711Z_a9243316.md
+++ b/progress/20260605T003711Z_a9243316.md
@@ -1,0 +1,55 @@
+# 2026-06-05 00:37Z — HexLLL short-vector Step 3 assembly (#6562)
+
+## Accomplished
+
+Closed issue #6562 by adding the executable `lll_short_vector` core
+inequality in `HexLLL/Basic.lean` plus the first Gram-Schmidt vector
+identity that supports it.
+
+In `HexGramSchmidt/Int.lean`, removed `private` from `normSq_map_intCast`
+so the squared-norm cast lemma is reachable from `HexLLL`. No proof
+change.
+
+In `HexLLL/Basic.lean`, added:
+
+- `LLLCore.basisNormSq_zero`: the squared norm of the 0-th Gram-Schmidt
+  vector equals the cast of the integer squared norm of the 0-th input
+  row. Proof is one rewrite via `GramSchmidt.Int.basis_zero` followed by
+  `GramSchmidt.Int.normSq_map_intCast`.
+- `LLLCore.ratPow_le_pow_of_one_le` (private helper): for `1 ≤ α`,
+  `i ≤ j → α^i ≤ α^j`, by induction on `j` using the existing
+  `ratPow_nonneg` and `Rat.mul_le_mul_of_nonneg_left`.
+- `Hex.lll_short_vector`: from `independent b`, `isLLLReduced b δ`,
+  `1/4 < δ`, `δ ≤ 1`, `1 ≤ n`, `memLattice b v`, `v ≠ 0`, conclude
+  `((Vector.normSq (b.row 0) : Int) : Rat) ≤ (1/(δ - 1/4))^(n-1) *
+  ((Vector.normSq v : Int) : Rat)`. Proof: pick `i` from Step 2,
+  telescope from `0` to `i` via `LLLCore.teleBound`, rewrite the LHS
+  through `basisNormSq_zero`, bound `α^i ≤ α^(n-1)` using `α ≥ 1` (from
+  `δ - 1/4 ≤ 3/4 ≤ 1`), then chain with Step 2 via `Rat.mul_le_mul_of_*`.
+
+Verification:
+
+- `lake build HexLLL` passed.
+- `lake build HexLLLMathlib` passed (downstream still has its
+  pre-existing `sorry` at `HexLLLMathlib/Basic.lean:104`, the planned
+  Mathlib transport).
+- `python3 scripts/check_dag.py` passed (no output).
+- `git diff --check` passed.
+- `git diff HexLLL/Basic.lean HexGramSchmidt/Int.lean |
+  grep -nE '^\+.*(sorry|axiom|native_decide|TODO|FIXME)'` empty.
+
+## Current frontier
+
+`Hex.lll_short_vector` is the algebraic core inequality. The downstream
+Mathlib `EuclideanSpace`-side transport (`HexLLLMathlib/Basic.lean:104`)
+remains open as a separate issue, as instructed by #6562.
+
+## Next step
+
+Open the PR for #6562.
+
+## Blockers
+
+None. Pre-existing warnings outside this change:
+`HexLLL/Basic.lean:682,687` (existing `sorry` in `lllAux` decreasing_by),
+`HexGramSchmidt/Basic.lean:1606`, `HexGramSchmidt/Int.lean:4939`.


### PR DESCRIPTION
Closes #6562

Session: `a9243316-91a2-48fc-b14d-13ccd0fda5e1`

676d6ab5 feat: prove lll_short_vector core inequality (closes #6562)

🤖 Prepared with Claude Code