### PR TITLE
feat: transport LLL short-vector bound to EuclideanSpace (close HexLLLMathlib sorry)

### DIFF
--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -94,13 +94,48 @@ space on `Fin m`. -/
 def intVectorToEuclidean (x : Fin m → ℤ) : EuclideanSpace ℝ (Fin m) :=
   WithLp.toLp 2 (fun j : Fin m => (x j : ℝ))
 
+private theorem foldl_finRange_eq_sum {R : Type*} [AddCommMonoid R] {n : Nat}
+    (f : Fin n → R) :
+    (List.finRange n).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
+  rw [← List.foldl_map, ← List.sum_eq_foldl,
+    ← List.sum_toFinset f (List.nodup_finRange n), List.toFinset_finRange]
+
+/-- The Euclidean squared norm of an integer row embedded into
+`EuclideanSpace ℝ (Fin m)` equals the real cast of the executable integer
+squared norm. -/
+theorem norm_sq_intRowToEuclidean (row : Vector Int m) :
+    ‖intRowToEuclidean row‖ ^ 2 = ((Hex.Vector.normSq row : Int) : ℝ) := by
+  rw [EuclideanSpace.real_norm_sq_eq]
+  simp only [intRowToEuclidean, PiLp.toLp_apply]
+  unfold Hex.Vector.normSq Hex.Vector.dotProduct
+  rw [foldl_finRange_eq_sum]
+  push_cast
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  ring
+
+/-- The Euclidean squared norm of a lattice vector embedded into
+`EuclideanSpace ℝ (Fin m)` equals the real cast of the executable integer
+squared norm of its `Vector` preimage. -/
+theorem norm_sq_intVectorToEuclidean (x : Fin m → ℤ) :
+    ‖intVectorToEuclidean x‖ ^ 2 =
+      ((Hex.Vector.normSq (HexMatrixMathlib.vectorEquiv.symm x) : Int) : ℝ) := by
+  have heq :
+      intVectorToEuclidean x =
+        intRowToEuclidean (HexMatrixMathlib.vectorEquiv.symm x) := by
+    unfold intVectorToEuclidean intRowToEuclidean HexMatrixMathlib.vectorEquiv
+    ext j
+    simp [Vector.getElem_ofFn]
+  rw [heq, norm_sq_intRowToEuclidean]
+
 /-- Mathlib-Euclidean-norm formulation of the LLL short-vector guarantee for
 an already `δ`-LLL-reduced executable basis.
 
 The input vector is assumed to lie in the Mathlib `latticeSubmodule`.  The
-proof route converts that hypothesis back through `mem_latticeSubmodule_iff`;
-the remaining proof obligation is the executable LLL short-vector theorem
-transported through the concrete Euclidean norm coercions above. -/
+proof route converts that hypothesis back through `mem_latticeSubmodule_iff`,
+applies the executable `Hex.lll_short_vector` for the rational squared-norm
+inequality, then transports both sides through the concrete Euclidean norm
+coercions above. -/
 theorem reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
@@ -121,6 +156,10 @@ theorem reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
       ext j
       simp [hv]
     simpa [v] using hv'
-  sorry
+  have hRat := Hex.lll_short_vector b hli hred hδ hδ' hn hxExec hx0Exec
+  have hReal := (Rat.cast_le (K := ℝ)).mpr hRat
+  rw [norm_sq_intRowToEuclidean, norm_sq_intVectorToEuclidean]
+  simp only [Rat.cast_mul, Rat.cast_intCast] at hReal
+  exact hReal
 
 end HexLLLMathlib

--- a/progress/20260605T035351Z_92ac00cd.md
+++ b/progress/20260605T035351Z_92ac00cd.md
@@ -1,0 +1,44 @@
+# 20260605T035351Z — 92ac00cd
+
+## Accomplished
+
+Closed the last `sorry` in `HexLLLMathlib/Basic.lean`
+(`reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`, closes #6563).
+
+Added two Euclidean-norm coercion lemmas:
+
+- `norm_sq_intRowToEuclidean`: `‖intRowToEuclidean row‖² =
+  ((Hex.Vector.normSq row : Int) : ℝ)`.
+- `norm_sq_intVectorToEuclidean`: same for `intVectorToEuclidean x`,
+  routed through `vectorEquiv.symm x`.
+
+A small private helper `foldl_finRange_eq_sum` converts the
+`Hex.Vector.dotProduct` foldl form to a Mathlib `Finset.sum`, matching
+the structure used in `HexMatrixMathlib.RankSpanNullspace` (its
+namesake there is private; reproduced here to keep the bridge
+self-contained).
+
+The main proof composes `Hex.lll_short_vector` (rational squared-norm
+bound) with `Rat.cast_le` to lift to `ℝ`, then applies the two
+coercion lemmas to land on the Euclidean goal. `simp only
+[Rat.cast_mul, Rat.cast_intCast]` matches the
+`((1/(δ-1/4))^(n-1) * (Vector.normSq v) : Rat : ℝ)` form to the
+distributed Euclidean form.
+
+Updated the theorem docstring to reference `Hex.lll_short_vector`
+explicitly (was vague about which executable theorem).
+
+## Current frontier
+
+`HexLLLMathlib/Basic.lean` is now `sorry`-free. The Mathlib-side
+short-vector guarantee is complete and consumable.
+
+## Next step
+
+The lattice-bridge surface is closed; downstream Mathlib-facing LLL
+applications can now consume `reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`
+directly.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6563

Session: `92ac00cd-1e73-4122-bb86-21d579806c32`

d4fb6622 feat: transport LLL short-vector bound to EuclideanSpace (closes #6563)

🤖 Prepared with Claude Code