### PR TITLE
perf: hoist s.ν reads out of swapStep outer foldl to enable in-place row update

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -280,16 +280,23 @@ def swapStep (s : LLLState n m) (k : Nat) : LLLState n m :=
         s.ν.modify km1 (setPrefixFrom (s.ν.get kFin))
           |>.modify kFin (setPrefixFrom (s.ν.get km1))
       let νPivot := setEntry νRowsSwapped kFin km1 B
+      -- Hoist (oldNu[i].kFin, oldNu[i].km1) reads out of the foldl lambda
+      -- so the closure does not hold a reference to s.ν across iterations.
+      -- With s.ν kept alive only for this precompute, the row-level rc on
+      -- post-pivot rows drops to 1 by the time `ν.modify i` runs, letting
+      -- the two-`set` body inside the modify mutate in place instead of
+      -- COW'ing the row on every iteration.
+      let pairs : Vector (Int × Int) n :=
+        Vector.ofFn fun i =>
+          if _ : k < i.val then ((s.ν.get i).get kFin, (s.ν.get i).get km1)
+          else (0, 0)
       let ν' : Matrix Int n n :=
         (List.finRange n).foldl
           (fun ν i =>
             if _ : k < i.val then
-              let prev :=
-                (Int.ofNat dkPrev * (s.ν.get i).get kFin + B * (s.ν.get i).get km1) /
-                  Int.ofNat dk
-              let curr :=
-                (Int.ofNat dkNext * (s.ν.get i).get km1 - B * (s.ν.get i).get kFin) /
-                  Int.ofNat dk
+              let (a, b) := pairs.get i
+              let prev := (Int.ofNat dkPrev * a + B * b) / Int.ofNat dk
+              let curr := (Int.ofNat dkNext * b - B * a) / Int.ofNat dk
               ν.modify i fun row =>
                 row.set km1 prev
                   |>.set kFin curr


### PR DESCRIPTION
This PR eliminates the row-COW that profile-analysis attributed to ~3-5% wall time on random-bounded LLL runs.

The outer foldl in [Hex.LLLState.swapStep](HexLLL/Basic.lean#L259) re-read \`(s.ν.get i).get kFin\` and \`(s.ν.get i).get km1\` twice per iteration inside its lambda. Those captures kept \`s.ν\` alive across the whole foldl, so each post-pivot row \`i\` was reference-shared between \`s.ν\` and the accumulator \`ν\`. When the lambda then called \`ν.modify i fun row => row.set km1 prev |>.set kFin curr\`, the row's rc was ≥ 2 and both \`.set\` calls forced \`lean_copy_expand_array\`.

Profile (samply 1 kHz, 3000 samples on random-bounded n=180, single LLL call) attributed **90% of \`lean_copy_expand_array\`** (158 samples, 3.8% of bench-thread wall time) to this lambda, plus 69% of \`lean_dec_ref_cold\` to the surrounding \`swapStep\` frame.

The fix precomputes \`((s.ν.get i).get kFin, (s.ν.get i).get km1)\` for every \`i\` into a fresh \`Vector (Int × Int) n\`. The fold lambda then references only this precomputed pairs vector and primitive locals (\`kFin\`, \`km1\`, the determinant values, \`B\`); \`s.ν\` is dead by the time the fold starts, so each post-pivot row's rc drops to 1 and the two \`.set\` calls inside the modify mutate in place.

## Measurements

Same-session A/B on carica (Apple M2 Ultra, macOS), median of 3 repeats per target:

| target | baseline | after | delta |
|---|---|---|---|
| harsh-cubic n=50 | 132.57 ms | 128.60 ms | -3.0% |
| harsh-cubic n=55 | 223.09 ms | 225.34 ms | +1.0% |
| harsh-cubic n=60 | 367.07 ms | 367.96 ms | +0.2% |
| random-bounded n=120 | 1.293 s | 1.258 s | -2.7% |
| random-bounded n=150 | 2.556 s | 2.418 s | **-5.4%** |

Post-fix profile (same run):

| metric | baseline | after |
|---|---|---|
| \`lean_copy_expand_array\` | 3.8% (158 samples) | **0.2%** (7) |
| \`lean_dec_ref_cold\` | 4.6% (191) | 1.9% (74) |
| Lean refcount/box total | 10.3% | **3.9%** |

The harsh-cubic family sees little change because those calls are GMP-bound (>90% of wall time is in \`__gmpn_*\` arithmetic; the Lean-side COW was never on the critical path). Random-bounded sees the full win because integers are short and Lean-side overhead is proportionally larger.

## Correctness

\`swapStep_memLattice_iff\`, \`swapStep_ν_eq\`, \`swapStep_d_eq\`, and the downstream \`HexLLLMathlib\` proofs all replay without modification. The pairs precompute is a body-only restructure that preserves \`(s.swapStep k).b\`, \`.ν\`, \`.d\` identically; the correctness proofs reason via the high-level \`LLLState.Valid\` invariants and don't unfold the foldl shape.

Bench hashes match expected at every measured rung.

🤖 Prepared with Claude Code