### PR TITLE
spec: certified external-dispatch LLL with η-parameterized reducedness

### DIFF
--- a/SPEC/Libraries/hex-lll-mathlib.md
+++ b/SPEC/Libraries/hex-lll-mathlib.md
@@ -3,3 +3,18 @@
 Connects hex-lll to Mathlib's linear algebra:
 - Lattice corresponds to a `Submodule ℤ`
 - Short vector bound holds with respect to Mathlib's `norm`
+
+## Headline correctness theorem
+
+`reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`: the Euclidean
+short-vector bound for the public `lll`, stated with Mathlib's
+`EuclideanSpace` norm and `Submodule ℤ` membership. For a `(δ, 11/20)`-reduced
+output and any nonzero lattice vector `x`,
+
+    ‖row 0 of (lll b δ …)‖² ≤ (1/(δ − 121/400))^(n-1) · ‖x‖² .
+
+The theorem holds regardless of which path the dispatched `lll` took (native
+or certified external), since both establish the `(δ, 11/20)`-reduced and
+same-lattice post-condition that the bound consumes. The native entry
+`lllNative` carries the corresponding classical statement at the tighter
+constant `1/(δ − 1/4)`.

--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -35,45 +35,77 @@ def Vector.normSq (v : Vector Int m) : Int := v.dotProduct v
 `dotProduct`, `normSq`, and `gramMatrix` live in hex-matrix.
 `memLattice`, `independent`, and `isLLLReduced` live in hex-lll.
 
-**delta-LLL-reduced.** A basis b is delta-LLL-reduced (for
-delta in (1/4, 1]) if it satisfies two conditions:
+**delta-LLL-reduced.** Reducedness is parameterized by a size-reduction
+bound `η`. A basis `b` is `(δ, η)`-LLL-reduced (for `η ≥ 1/2` and
+`η² < δ ≤ 1`) if it satisfies two conditions:
 
-1. **Size-reduced:** |(coeffs b)[i][j]| <= 1/2 for all 0 <= j < i < n.
+1. **Size-reduced:** |(coeffs b)[i][j]| <= η for all 0 <= j < i < n.
 
 2. **Lovász condition:** For all 0 <= i < n-1:
        delta * ||(basis b)[i]||^2 <= ||(basis b)[i+1]||^2 + (coeffs b)[i+1][i]^2 * ||(basis b)[i]||^2
 
    Equivalently: (delta - (coeffs b)[i+1][i]^2) * ||(basis b)[i]||^2 <= ||(basis b)[i+1]||^2
 
-**Key properties.** All theorems require
-`hδ : 1/4 < δ`, `hδ' : δ ≤ 1`, `hn : 1 ≤ n`, and
-`hli : b.independent`.
+The predicate is `isLLLReduced b δ η`. Two values of `η` are pinned:
 
-`δ > 1/4` so that `α = 1/(δ - 1/4)` is well-defined and positive.
-`δ ≤ 1` for termination (the Lovász failure condition is strict, so
-each swap gives `gramDet b' k < δ · gramDet b k ≤ gramDet b k`,
-strictly decreasing the potential even at `δ = 1`). Linear
-independence ensures all Gram determinants `gramDet b k > 0`, which
-is needed for the GS orthogonalization to exist and for the
-scaledCoeffs denominators to be nonzero.
+- **`η = 1/2`** (the classical bound), carried by the native algorithm
+  `lllNative`, which produces exact-integer `|μ| ≤ 1/2`.
+- **`η = 11/20`**, carried by the public `lll`. This is the bound any
+  function that may route through an external reducer can guarantee
+  uniformly; it is reached either by `lllNative` (whose `|μ| ≤ 1/2` is
+  stronger) or by certifying an external candidate (see *Certified external
+  dispatch*).
+
+**Key properties.** Theorems require `hη : 1/2 ≤ η`, `hδη : η² < δ`,
+`hδ' : δ ≤ 1`, `hn : 1 ≤ n`, and `hli : b.independent`.
+
+`η² < δ` so that `α = 1/(δ − η²)` is well-defined and positive (at `η = 1/2`
+this is `δ > 1/4`). `δ ≤ 1` for termination (the Lovász failure condition is
+strict, so each swap gives `gramDet b' k < δ · gramDet b k ≤ gramDet b k`,
+strictly decreasing the potential even at `δ = 1`). Linear independence
+ensures all Gram determinants `gramDet b k > 0`, which is needed for the GS
+orthogonalization to exist and for the scaledCoeffs denominators to be
+nonzero.
+
+The short-vector bound is factored through one lemma over the size-reduction
+bound:
+
+```lean
+theorem short_vector_bound_of_size_bound (b : Matrix Int n m) {δ η : Rat}
+    (hη : 1/2 ≤ η) (hδη : η² < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hli : b.independent) (hred : isLLLReduced b δ η)
+    (v : Vector Int m) :
+    b.memLattice v → v ≠ 0 →
+    (b.row 0).normSq ≤ (1/(δ - η²))^(n-1) * v.normSq
+```
+
+The public `lll` (η = 11/20) and the native `lllNative` (η = 1/2) instantiate
+it:
 
 ```lean
 theorem lll_same_lattice (b : Matrix Int n m) (δ : Rat) ... :
     (lll b δ ...).memLattice v ↔ b.memLattice v
 
 theorem lll_reduced (b : Matrix Int n m) (δ : Rat) ... :
-    isLLLReduced (lll b δ ...) δ
+    isLLLReduced (lll b δ ...) δ (11/20)
 
 theorem lll_short_vector (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1)
+    (hδ : 121/400 < δ) (hδ' : δ ≤ 1)
     (hn : 1 ≤ n) (hli : b.independent)
     (v : Vector Int m) :
     b.memLattice v → v ≠ 0 →
-    (lll b δ hδ hδ' hn hli).row 0 |>.normSq ≤ α^(n-1) * v.normSq
-  where α := 1 / (δ - 1/4)
+    (lll b δ hδ hδ' hn hli).row 0 |>.normSq ≤ (1/(δ - 121/400))^(n-1) * v.normSq
+
+theorem lllNative_short_vector (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hli : b.independent)
+    (v : Vector Int m) :
+    b.memLattice v → v ≠ 0 →
+    (lllNative b δ hδ hδ' hn hli).row 0 |>.normSq ≤ (1/(δ - 1/4))^(n-1) * v.normSq
 ```
 
-The short vector guarantee with `δ = 3/4` gives `‖b₁‖ ≤ 2^{(n-1)/2} · λ₁`.
+The classical bound and the wide `δ > 1/4` range live on `lllNative`: at
+`δ = 3/4` it gives `‖b₁‖ ≤ 2^{(n-1)/2} · λ₁`. The public `lll` carries the
+`η = 11/20` bound (`α = 1/(δ − 121/400)`, precondition `δ > 121/400`).
 
 ## LLLState and algorithm
 
@@ -308,7 +340,7 @@ loop's traversal cost and nothing about size reduction or swaps.
 
 ### External comparators
 
-Two external comparators are required for HexLLL Phase 4. The
+Three external comparators are required for HexLLL Phase 4. The
 classification below is mirrored as structured metadata in
 [`libraries.yml`](../../libraries.yml) under `HexLLL.phase4.comparators`:
 
@@ -319,6 +351,18 @@ classification below is mirrored as structured metadata in
   algorithmic, so the ratio is recorded for orientation but does
   not gate Phase 4. See
   [SPEC/benchmarking.md §Comparator classification](../benchmarking.md#comparator-classification-gating-vs-informational).
+  fpLLL also serves as the external reducer behind *Certified external
+  dispatch*; the certified path's measured cost is fpLLL plus the
+  verified checker.
+- **`verified Isabelle certified-LLL`** — `gating`. The Isabelle
+  formalisation's own certified-output configuration (a verified checker
+  over an untrusted floating-point reducer; JAR 2020 §7 and the AFP entry
+  `Modular_arithmetic_LLL_and_HNF_algorithms`) is the apples-to-apples
+  yardstick for the certified path. **Performance goal:** the hex certified
+  path (fpLLL + checker) is **at least as fast as** the Isabelle
+  certified-LLL on shared canonical inputs at the largest eligible rung of
+  each `phase4.input_families` ladder. The headline report records the
+  ratio, the checker's share of the cost, and the candidate rejection rate.
 - **`verified Isabelle LLL`** — `gating`. The Bottesch–Divasón–
   Haslbeck–Joosten–Thiemann–Yamada formalisation in the Archive of
   Formal Proofs (entry `LLL_Basis_Reduction`) is the only other
@@ -397,6 +441,61 @@ but must not by itself erase the fixed Phase-4 ladder.
 The swap bound `potential_initial ≤ (maxNormSq b)^{n*(n-1)/2}` follows
 from Hadamard's inequality: `gramDet b k ≤ prod_{i<k} ||b[i]||^2 ≤
 (maxNormSq b)^k`.
+
+## Certified external dispatch
+
+The public `lll` runs the native algorithm `lllNative` by default, and when
+an optional external reducer is present in the process it instead certifies
+that reducer's output, falling back to `lllNative` whenever the candidate is
+absent or fails certification. The two paths satisfy the identical
+post-condition (`isLLLReduced (lll …) δ (11/20)`, same lattice, the
+`lll_short_vector` bound), so dispatch is invisible to callers and to proofs.
+`lll`'s guarantee is property-level, not value-level: two calls may return
+different `(δ, 11/20)`-reduced bases of the same lattice.
+
+**Certificate and checker.** An external candidate is a triple
+`(B', U, V)` — a reduced basis with integer transforms. It is accepted iff
+the executable checker `certCheck B B' U V δ : Bool` returns `true`, where
+`certCheck` verifies, over integer arithmetic only:
+
+- `U.mul B = B'` and `V.mul B' = B` (each a `Matrix.mul` equality), which
+  together give `lattice B = lattice B'` by row-combination composition — no
+  determinant and no matrix-inverse reasoning;
+- `B'` independent and `(δ, 11/20)`-size-reduced and Lovász, read off the
+  integer `d`/`ν` representation (`GramSchmidt.Int.data B'`): all `d` positive,
+  `20·(ν[i][j]).natAbs ≤ 11·d[j+1]`, and
+  `δ.den·(d[i+2]·d[i] + ν[i+1][i]²) ≥ δ.num·d[i+1]²`.
+
+The single trusted theorem is
+
+```lean
+theorem certCheck_sound (B B' U V : Matrix Int n m) (δ : Rat) :
+    certCheck B B' U V δ = true →
+      (∀ v, B.memLattice v ↔ B'.memLattice v) ∧
+      B'.independent ∧ isLLLReduced B' δ (11/20)
+```
+
+The dispatch's correctness depends only on `certCheck_sound`; the checker
+internals are not relied on elsewhere.
+
+**Provider hook.** `lll` consults an `opaque @[extern]` hook that supplies a
+candidate when an external reducer is registered and signals absence
+otherwise (governed by the *untrusted dispatch hooks* clause in
+[SPEC/SPEC.md](../SPEC.md)). The hook is process-stable (availability is fixed
+at first probe and cached), returns only a candidate, and is queried for
+availability *before* any input marshalling, so the native path pays at most a
+single cached probe. The hook's C body probes for the provider's versioned
+public symbol at runtime; the provider is an independent package that this
+library neither depends on nor names in its build, and which has no knowledge
+of this library. The candidate's shape (dimensions, array lengths) is
+validated in Lean before use; a malformed candidate is a rejection.
+
+**Reliability is empirical, soundness is not.** A candidate whose exact
+`|μ|` exceeds `11/20` is rejected and the native path runs; the `11/20` bound
+carries enough margin over a floating-point reducer's size-reduction
+threshold that acceptance is the common case, but correctness never depends on
+the reducer's numerical behaviour. The dispatch records an
+`absent / provider-error / rejected / accepted` tally for diagnostics.
 
 ## Loop invariant
 

--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -455,28 +455,33 @@ different `(δ, 11/20)`-reduced bases of the same lattice.
 
 **Certificate and checker.** An external candidate is a triple
 `(B', U, V)` — a reduced basis with integer transforms. It is accepted iff
-the executable checker `certCheck B B' U V δ : Bool` returns `true`, where
+the executable checker `certCheck B B' U V δ η : Bool` returns `true`, where
 `certCheck` verifies, over integer arithmetic only:
 
 - `U.mul B = B'` and `V.mul B' = B` (each a `Matrix.mul` equality), which
   together give `lattice B = lattice B'` by row-combination composition — no
   determinant and no matrix-inverse reasoning;
-- `B'` independent and `(δ, 11/20)`-size-reduced and Lovász, read off the
-  integer `d`/`ν` representation (`GramSchmidt.Int.data B'`): all `d` positive,
-  `20·(ν[i][j]).natAbs ≤ 11·d[j+1]`, and
+- `B'` independent and `(δ, η)`-size-reduced and Lovász, read off the integer
+  `d`/`ν` representation (`GramSchmidt.Int.data B'`): all `d` positive,
+  `η.den·(ν[i][j]).natAbs ≤ η.num·d[j+1]` (the integer form of `|μ| ≤ η`), and
   `δ.den·(d[i+2]·d[i] + ν[i+1][i]²) ≥ δ.num·d[i+1]²`.
 
-The single trusted theorem is
+The checker is generic in the size-reduction bound, matching the
+`isLLLReduced`/`short_vector_bound_of_size_bound` layer; the pin lives at the
+call site, not inside the mechanism. The single trusted theorem is
 
 ```lean
-theorem certCheck_sound (B B' U V : Matrix Int n m) (δ : Rat) :
-    certCheck B B' U V δ = true →
+theorem certCheck_sound (B B' U V : Matrix Int n m) (δ η : Rat) :
+    certCheck B B' U V δ η = true →
       (∀ v, B.memLattice v ↔ B'.memLattice v) ∧
-      B'.independent ∧ isLLLReduced B' δ (11/20)
+      B'.independent ∧ isLLLReduced B' δ η
 ```
 
-The dispatch's correctness depends only on `certCheck_sound`; the checker
-internals are not relied on elsewhere.
+No validity hypothesis on `η` is needed here (the bound's `1/2 ≤ η`, `η² < δ`
+conditions live on `short_vector_bound_of_size_bound`, not on the checker).
+The dispatched `lll` calls `certCheck … (11/20)`; the dispatch's correctness
+depends only on `certCheck_sound`, and the checker internals are not relied on
+elsewhere.
 
 **Provider hook.** `lll` consults an `opaque @[extern]` hook that supplies a
 candidate when an external reducer is registered and signals absence

--- a/SPEC/SPEC.md
+++ b/SPEC/SPEC.md
@@ -51,6 +51,20 @@ Until the C side performs work native to C (GMP call, CLMUL intrinsic,
 `__uint128_t` arithmetic, etc.), ship only the pure-Lean definition
 without `@[extern]`.
 
+**Untrusted dispatch hooks.** A second admissible category of `@[extern]`
+is a hook that supplies an *untrusted candidate* from an optional external
+provider, where correctness never depends on the candidate. Such a hook is
+`opaque` (so the kernel never reduces it; the `native_decide` ban above
+keeps this airtight), returns only a candidate value — never a
+proof-relevant fact, and no lemma may mention its availability — and is used
+only through a verified checker whose named soundness theorem establishes the
+post-condition, with the native algorithm running on absence or rejection.
+The hook's own C work — probing for the provider's symbol (`dlsym`), or
+adapting its ABI — is native to C and so satisfies the property above. The
+provider's symbol is versioned and its returned data is shape-validated in
+Lean before use; a mismatch is a rejection, not a fault. The per-library
+SPEC names the checker soundness theorem and the provider contract.
+
 ## Applications
 
 **Cryptographic field construction:** To build `GF(2^128)` for AES, you

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -28,9 +28,21 @@
    dependency.
 
 4. **Lean algorithms from the start.** All algorithms are implemented and
-   run in Lean natively. No external CAS in the loop. Certificate
-   structures exist for compact proof witnesses, but the algorithms that
-   generate and check certificates are both in Lean.
+   run in Lean natively, and the native algorithm is always the default and
+   carries the correctness guarantee. No *trusted* external CAS in the loop:
+   no result whose correctness the project relies on may come from outside
+   Lean. Certificate structures exist for compact proof witnesses, and the
+   algorithms that generate and check certificates are both in Lean.
+
+   A *checked* external oracle is admissible and is not "external CAS in the
+   loop" in the sense this rule forbids. An untrusted external implementation
+   may propose a candidate result, provided a verified Lean checker validates
+   it on every call and the native algorithm runs whenever the candidate is
+   absent or rejected. Correctness then depends only on the verified checker
+   and the native fallback, never on the external oracle, so the trusted
+   computing base is unchanged. The checker's soundness theorem, the
+   fallback, and the dispatch are all in Lean; the external oracle supplies
+   only a hint.
 
 5. **Clear DAG structure.** Libraries can be developed in parallel. LLL has
    no dependency on polynomial arithmetic. Hensel lifting is independent of

--- a/libraries.yml
+++ b/libraries.yml
@@ -185,6 +185,9 @@ libraries:
         - tool: "verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)"
           class: gating
           goal: "Lean LLL is at least as fast as the verified Isabelle LLL on shared canonical inputs at the bottom of each phase4.input_families parameter ladder."
+        - tool: "verified Isabelle certified-LLL (JAR 2020 §7; AFP Modular_arithmetic_LLL_and_HNF_algorithms)"
+          class: gating
+          goal: "The hex certified path (fpLLL + verified checker) is at least as fast as the Isabelle certified-LLL on shared canonical inputs at the largest eligible rung of each phase4.input_families ladder; the headline report records the ratio, the checker's cost share, and the candidate rejection rate."
       input_families:
         - name: bz-recombination
           description: "Berlekamp-Zassenhaus recombination basis at the documented (p, k, factors) configurations; the downstream hot path."

--- a/progress/20260609T013743Z_6604_repair.md
+++ b/progress/20260609T013743Z_6604_repair.md
@@ -1,0 +1,40 @@
+# PR #6604 repair
+
+## Accomplished
+
+Claimed PR #6604 for repair and diagnosed the failed Linux CI `build` job.
+The PR was mergeable; the failure reproduced locally in
+`python3 scripts/check_phase4.py` because `HexLLL.phase4.comparators` gained
+`verified Isabelle certified-LLL (JAR 2020 §7; AFP Modular_arithmetic_LLL_and_HNF_algorithms)`
+without a matching mention in `reports/hex-lll-performance.md`.
+
+Applied the minimal report repair by adding the certified external-dispatch
+comparator to the HexLLL comparator-ratio section, explicitly noting that
+certified-path benchmark rows are not recorded yet and naming the future ratio
+fields required by the SPEC.
+
+Verification passed:
+
+- `python3 scripts/check_phase4.py`
+- `python3 scripts/check_dag.py`
+- `python3 scripts/ci/check_benches_mathlib_free.py`
+- `git diff --check`
+- `lake build`
+
+Existing warning output remains limited to the known `HexGFqRing.Operations`
+`unnecessarySimpa` lints.
+
+## Current frontier
+
+PR #6604 is ready to push after committing the report repair and this progress
+note. The pre-existing local `.claude/CLAUDE.md` modification was left
+unstaged and untouched.
+
+## Next step
+
+Commit the repair, push the PR branch with `--force-with-lease`, then mark
+PR #6604 salvaged through coordination.
+
+## Blockers
+
+None.

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -283,7 +283,14 @@ checksum.
 
 ## Comparator Ratios
 
-The gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `SPEC/Libraries/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the matching fpylll persistent driver was wired in HO-17 (#4186). The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55}` — per the post-#3657 §"Headline reports" densification rule.
+The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `SPEC/Libraries/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the matching fpylll persistent driver was wired in HO-17 (#4186). The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55}` — per the post-#3657 §"Headline reports" densification rule.
+
+The certified external-dispatch SPEC also declares the gating comparator
+`verified Isabelle certified-LLL (JAR 2020 §7; AFP Modular_arithmetic_LLL_and_HNF_algorithms)`.
+No certified-path benchmark rows are recorded here yet. Once that dispatch is
+implemented, this report must record the hex certified-path ratio against that
+comparator, the verified checker's cost share, and the candidate rejection
+rate at the largest eligible rung of each headline ladder.
 
 ![Random-bounded comparator runtime plot](figures/hex-lll-comparator-random-bounded.svg)
 


### PR DESCRIPTION
This PR specifies a certified external-dispatch path for `hex-lll`: the public `lll` runs the native algorithm by default and, when an optional external reducer is present in the process, instead certifies that reducer's output with a verified Lean checker, falling back to native on absence or rejection. Both paths satisfy the identical post-condition (same lattice, `(δ, 11/20)`-reducedness, the short-vector bound), so dispatch is invisible to callers and to proofs, and `lll`'s guarantee is property-level rather than value-level.

To accommodate a floating-point reducer's size-reduction threshold without a post-pass, reducedness is parameterized by a size-reduction bound η. The native entry `lllNative` carries the classical η = 1/2 contract (α = 1/(δ − 1/4), δ > 1/4), and the public `lll` carries η = 11/20 (α = 1/(δ − 121/400)), the bound any externally-routed function can guarantee uniformly. The short-vector bound is factored through one lemma over η, instantiated for both surfaces.

Design-principles §4 and the `@[extern]` policy gain carve-outs for a checked external oracle and an untrusted dispatch hook: correctness depends only on the verified checker and the native fallback, never on the external reducer, so the trusted computing base is unchanged. The certificate is `(B', U, V)` with `U·B = B'` and `V·B' = B` for same-lattice (no determinant, no inverse lemma) plus an executable integer reducedness check over the `d`/`ν` representation; `certCheck_sound` is the single trusted bridge the dispatch depends on.

🤖 Prepared with Claude Code