### PR TITLE
D1: parameterize LLL reducedness by size-reduction bound η; two surfaces

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -33,16 +33,17 @@ def basisNormSq (basis : Matrix Rat n m) (i : Fin n) : Rat :=
 
 end LLLCore
 
-/-- A basis is `δ`-LLL-reduced when it is size-reduced and satisfies the
-Lovasz condition at every adjacent pair. -/
-def isLLLReduced (b : Matrix Int n m) (δ : Rat) : Prop :=
+/-- A basis is `(δ, η)`-LLL-reduced when it is size-reduced with bound `η`
+(`|μ| ≤ η` for every below-diagonal entry of the Gram-Schmidt coefficient
+matrix) and satisfies the Lovasz condition at every adjacent pair. -/
+def isLLLReduced (b : Matrix Int n m) (δ η : Rat) : Prop :=
   let basis := GramSchmidt.Int.basis b
   let coeffs := GramSchmidt.Int.coeffs b
   (∀ i j, (hi : i < n) → (hji : j < i) →
       let iFin : Fin n := ⟨i, hi⟩
       let jFin : Fin n := ⟨j, Nat.lt_trans hji hi⟩
       let μ := coeffs[iFin][jFin]
-      4 * μ * μ ≤ 1) ∧
+      μ * μ ≤ η * η) ∧
     ∀ i, (hi : i + 1 < n) →
       let iFin : Fin n := ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩
       let ip1Fin : Fin n := ⟨i + 1, hi⟩
@@ -71,21 +72,12 @@ theorem basisNormSq_nonneg (basis : Matrix Rat n m) (i : Fin n) :
   exact foldlNonneg (List.finRange m) (fun j => (basis.row i)[j] * (basis.row i)[j]) 0
     (by grind) (fun j => ratMulSelfNonneg ((basis.row i)[j]))
 
-private theorem coeffSq_le_quarter (μ : Rat) (hsize : 4 * μ * μ ≤ 1) :
-    μ * μ ≤ 1 / 4 := by
-  have hq_nonneg : (0 : Rat) ≤ 1 / 4 := by grind
-  have h := Rat.mul_le_mul_of_nonneg_left hsize hq_nonneg
-  have hleft : (1 / 4 : Rat) * (4 * μ * μ) = μ * μ := by grind
-  have hright : (1 / 4 : Rat) * 1 = 1 / 4 := by grind
-  simpa [hleft, hright] using h
-
-private theorem stepBound_arith (δ μ N Np : Rat)
-    (hN : 0 ≤ N) (hsize : 4 * μ * μ ≤ 1)
+private theorem stepBound_arith (δ η μ N Np : Rat)
+    (hN : 0 ≤ N) (hsize : μ * μ ≤ η * η)
     (hlov : δ * N ≤ Np + μ * μ * N) :
-    (δ - 1 / 4) * N ≤ Np := by
-  have hmu : μ * μ ≤ 1 / 4 := coeffSq_le_quarter μ hsize
-  have hcoef : δ - 1 / 4 ≤ δ - μ * μ := by grind
-  have hleft : (δ - 1 / 4) * N ≤ (δ - μ * μ) * N :=
+    (δ - η * η) * N ≤ Np := by
+  have hcoef : δ - η * η ≤ δ - μ * μ := by grind
+  have hleft : (δ - η * η) * N ≤ (δ - μ * μ) * N :=
     Rat.mul_le_mul_of_nonneg_right hcoef hN
   have hlov' : (δ - μ * μ) * N ≤ Np := by
     have hsub : δ * N - μ * μ * N ≤ (Np + μ * μ * N) - μ * μ * N := by
@@ -123,10 +115,10 @@ private theorem ratPow_nonneg (a : Rat) (ha : 0 ≤ a) (k : Nat) :
       exact Rat.mul_nonneg ih ha
 
 /-- Adjacent Gram-Schmidt norm bound from size reduction and Lovasz. -/
-theorem stepBound (b : Matrix Int n m) {δ : Rat}
-    (hred : isLLLReduced b δ) (_hδ : (1 / 4 : Rat) < δ)
+theorem stepBound (b : Matrix Int n m) {δ η : Rat}
+    (hred : isLLLReduced b δ η) (_hδη : η * η < δ)
     (i : Nat) (hi : i + 1 < n) :
-    (δ - 1 / 4) *
+    (δ - η * η) *
         basisNormSq (GramSchmidt.Int.basis b)
           ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ ≤
       basisNormSq (GramSchmidt.Int.basis b) ⟨i + 1, hi⟩ := by
@@ -136,40 +128,40 @@ theorem stepBound (b : Matrix Int n m) {δ : Rat}
   let ip1Fin : Fin n := ⟨i + 1, hi⟩
   let μ := coeffs[ip1Fin][iFin]
   rcases hred with ⟨hsize, hlov⟩
-  have hsize' : 4 * μ * μ ≤ 1 := by
+  have hsize' : μ * μ ≤ η * η := by
     simpa [basis, coeffs, iFin, ip1Fin, μ] using
       hsize (i + 1) i hi (Nat.lt_succ_self i)
   have hlov' :
       δ * basisNormSq basis iFin ≤
         basisNormSq basis ip1Fin + μ * μ * basisNormSq basis iFin := by
     simpa [basis, coeffs, iFin, ip1Fin, μ] using hlov i hi
-  exact stepBound_arith δ μ (basisNormSq basis iFin) (basisNormSq basis ip1Fin)
+  exact stepBound_arith δ η μ (basisNormSq basis iFin) (basisNormSq basis ip1Fin)
     (basisNormSq_nonneg basis iFin) hsize' hlov'
 
 /-- Adjacent Gram-Schmidt norm bound in reciprocal form. -/
-theorem stepAlpha (b : Matrix Int n m) {δ : Rat}
-    (hred : isLLLReduced b δ) (hδ : (1 / 4 : Rat) < δ)
+theorem stepAlpha (b : Matrix Int n m) {δ η : Rat}
+    (hred : isLLLReduced b δ η) (hδη : η * η < δ)
     (i : Nat) (hi : i + 1 < n) :
     basisNormSq (GramSchmidt.Int.basis b)
         ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ ≤
-      (1 / (δ - 1 / 4)) *
+      (1 / (δ - η * η)) *
         basisNormSq (GramSchmidt.Int.basis b) ⟨i + 1, hi⟩ := by
-  have hpos : 0 < δ - 1 / 4 := by grind
-  exact divStep_arith (δ - 1 / 4)
+  have hpos : 0 < δ - η * η := by grind
+  exact divStep_arith (δ - η * η)
     (basisNormSq (GramSchmidt.Int.basis b)
       ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩)
     (basisNormSq (GramSchmidt.Int.basis b) ⟨i + 1, hi⟩)
-    hpos (stepBound b hred hδ i hi)
+    hpos (stepBound b hred hδη i hi)
 
 /-- Telescoped Gram-Schmidt norm bound from the first vector to index `i`. -/
-theorem teleBound (b : Matrix Int n m) {δ : Rat}
-    (hred : isLLLReduced b δ) (hδ : (1 / 4 : Rat) < δ)
+theorem teleBound (b : Matrix Int n m) {δ η : Rat}
+    (hred : isLLLReduced b δ η) (hδη : η * η < δ)
     (i : Nat) (hi : i < n) :
     basisNormSq (GramSchmidt.Int.basis b)
         ⟨0, Nat.lt_of_le_of_lt (Nat.zero_le i) hi⟩ ≤
-      (1 / (δ - 1 / 4)) ^ i *
+      (1 / (δ - η * η)) ^ i *
         basisNormSq (GramSchmidt.Int.basis b) ⟨i, hi⟩ := by
-  let α : Rat := 1 / (δ - 1 / 4)
+  let α : Rat := 1 / (δ - η * η)
   induction i with
   | zero =>
       rw [Lean.Grind.Semiring.pow_zero]
@@ -186,13 +178,13 @@ theorem teleBound (b : Matrix Int n m) {δ : Rat}
             ⟨0, Nat.lt_of_le_of_lt (Nat.zero_le (i + 1)) hi⟩ :=
         Fin.ext rfl
       rw [hzero] at hih
-      have hstep := stepAlpha b hred hδ i hi
+      have hstep := stepAlpha b hred hδη i hi
       have hifin :
           (⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ : Fin n) = ⟨i, hiPrev⟩ :=
         Fin.ext rfl
       rw [hifin] at hstep
       have hα_nonneg : 0 ≤ α := by
-        have hpos : 0 < δ - 1 / 4 := by grind
+        have hpos : 0 < δ - η * η := by grind
         have hα_pos : 0 < α := by
           dsimp [α]
           rw [Rat.div_def]
@@ -246,58 +238,85 @@ private theorem ratPow_le_pow_of_one_le {α : Rat} (hα : 1 ≤ α) :
 
 end LLLCore
 
-/-- LLL short-vector core inequality: for a `δ`-LLL-reduced basis with
-`1/4 < δ ≤ 1`, the squared norm of the first row is at most
-`(1 / (δ - 1/4)) ^ (n - 1)` times the squared norm of any nonzero lattice
-vector. Combines `LLLCore.teleBound` with the lower bound on the smallest
-Gram-Schmidt vector contained in the lattice. -/
-theorem lll_short_vector (b : Matrix Int n m) {δ : Rat}
-    (hli : Matrix.independent b) (hred : isLLLReduced b δ)
-    (hδ : (1 / 4 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+/-- LLL short-vector core inequality, parameterized by the size-reduction bound
+`η`. For a `(δ, η)`-LLL-reduced basis with `1/2 ≤ η`, `η² < δ ≤ 1`, the
+squared norm of the first row is at most `(1 / (δ - η²)) ^ (n - 1)` times the
+squared norm of any nonzero lattice vector. Combines `LLLCore.teleBound` with
+the lower bound on the smallest Gram-Schmidt vector contained in the
+lattice. -/
+theorem short_vector_bound_of_size_bound (b : Matrix Int n m) {δ η : Rat}
+    (hli : Matrix.independent b) (hred : isLLLReduced b δ η)
+    (hη : (1 / 2 : Rat) ≤ η) (hδη : η * η < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
     ((Vector.normSq (b.row ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
-      (1 / (δ - 1 / 4)) ^ (n - 1) *
+      (1 / (δ - η * η)) ^ (n - 1) *
         ((Vector.normSq v : Int) : Rat) := by
   have h0n : 0 < n := Nat.lt_of_lt_of_le Nat.zero_lt_one hn
   obtain ⟨i, hi_norm⟩ :=
     GramSchmidt.Int.normSq_latticeVec_ge_min_basis_normSq b hli v hv hv'
-  have htele := LLLCore.teleBound b hred hδ i.val i.isLt
+  have htele := LLLCore.teleBound b hred hδη i.val i.isLt
   have e1 : (⟨0, Nat.lt_of_le_of_lt (Nat.zero_le i.val) i.isLt⟩ : Fin n) = ⟨0, h0n⟩ :=
     Fin.ext rfl
   have e2 : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
   rw [e1, e2, LLLCore.basisNormSq_zero b h0n] at htele
-  have hα_pos : 0 < δ - 1 / 4 := by grind
-  have hα_inv_pos : 0 < (1 / (δ - 1 / 4) : Rat) := by
+  have hα_pos : 0 < δ - η * η := by grind
+  have hα_inv_pos : 0 < (1 / (δ - η * η) : Rat) := by
     rw [Rat.div_def]
     simpa using (Rat.inv_pos.mpr hα_pos)
-  have hα_nn : (0 : Rat) ≤ 1 / (δ - 1 / 4) := by grind
-  have hα_one : (1 : Rat) ≤ 1 / (δ - 1 / 4) := by
-    have h_le : δ - 1 / 4 ≤ 1 := by grind
-    have hne : δ - 1 / 4 ≠ 0 := by grind
-    have hα_eq : (1 / (δ - 1 / 4)) * (δ - 1 / 4) = 1 := by
+  have hα_nn : (0 : Rat) ≤ 1 / (δ - η * η) := by grind
+  -- `η ≥ 1/2` implies `η² ≥ 1/4`, so `δ - η² ≤ δ - 1/4 ≤ 3/4 ≤ 1` and
+  -- `1 / (δ - η²) ≥ 1`.
+  have hηη_lb : (1 / 4 : Rat) ≤ η * η := by
+    have h2 : (0 : Rat) ≤ 1 / 2 := by grind
+    have hηnn : (0 : Rat) ≤ η := Rat.le_trans h2 hη
+    have hsq1 : (1 / 2 : Rat) * (1 / 2) ≤ (1 / 2 : Rat) * η :=
+      Rat.mul_le_mul_of_nonneg_left hη h2
+    have hsq2 : (1 / 2 : Rat) * η ≤ η * η :=
+      Rat.mul_le_mul_of_nonneg_right hη hηnn
+    have hsq : (1 / 2 : Rat) * (1 / 2) ≤ η * η := Rat.le_trans hsq1 hsq2
+    grind
+  have hα_one : (1 : Rat) ≤ 1 / (δ - η * η) := by
+    have h_le : δ - η * η ≤ 1 := by grind
+    have hne : δ - η * η ≠ 0 := by grind
+    have hα_eq : (1 / (δ - η * η)) * (δ - η * η) = 1 := by
       rw [Rat.div_def]
-      rw [show (1 : Rat) * (δ - 1 / 4)⁻¹ = (δ - 1 / 4)⁻¹ from by grind]
+      rw [show (1 : Rat) * (δ - η * η)⁻¹ = (δ - η * η)⁻¹ from by grind]
       exact Rat.inv_mul_cancel _ hne
-    have hstep : (1 / (δ - 1 / 4)) * (δ - 1 / 4) ≤ (1 / (δ - 1 / 4)) * 1 :=
+    have hstep : (1 / (δ - η * η)) * (δ - η * η) ≤ (1 / (δ - η * η)) * 1 :=
       Rat.mul_le_mul_of_nonneg_left h_le hα_nn
     rw [hα_eq] at hstep
     simpa using hstep
   have hi_le : i.val ≤ n - 1 := by omega
-  have hpow_mono : (1 / (δ - 1 / 4)) ^ i.val ≤ (1 / (δ - 1 / 4)) ^ (n - 1) :=
+  have hpow_mono : (1 / (δ - η * η)) ^ i.val ≤ (1 / (δ - η * η)) ^ (n - 1) :=
     LLLCore.ratPow_le_pow_of_one_le hα_one hi_le
   have hbasis_nn : 0 ≤ LLLCore.basisNormSq (GramSchmidt.Int.basis b) i :=
     LLLCore.basisNormSq_nonneg _ i
-  have hαpow_nn : 0 ≤ (1 / (δ - 1 / 4)) ^ (n - 1) :=
+  have hαpow_nn : 0 ≤ (1 / (δ - η * η)) ^ (n - 1) :=
     LLLCore.ratPow_nonneg _ hα_nn (n - 1)
   calc
     ((Vector.normSq (b.row ⟨0, h0n⟩) : Int) : Rat)
-        ≤ (1 / (δ - 1 / 4)) ^ i.val *
+        ≤ (1 / (δ - η * η)) ^ i.val *
             LLLCore.basisNormSq (GramSchmidt.Int.basis b) i := htele
-    _ ≤ (1 / (δ - 1 / 4)) ^ (n - 1) *
+    _ ≤ (1 / (δ - η * η)) ^ (n - 1) *
             LLLCore.basisNormSq (GramSchmidt.Int.basis b) i :=
         Rat.mul_le_mul_of_nonneg_right hpow_mono hbasis_nn
-    _ ≤ (1 / (δ - 1 / 4)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) :=
+    _ ≤ (1 / (δ - η * η)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) :=
         Rat.mul_le_mul_of_nonneg_left hi_norm hαpow_nn
+
+/-- Monotonicity of the size-reduction bound: a `(δ, η₁)`-LLL-reduced basis
+is also `(δ, η₂)`-LLL-reduced for any `η₂ ≥ η₁ ≥ 0`. The Lovász side is
+unchanged; the size-reduced side relaxes since `|μ| ≤ η₁ ≤ η₂` (in squared
+form, `μ² ≤ η₁² ≤ η₂²`). -/
+theorem isLLLReduced.mono_η (b : Matrix Int n m) {δ η₁ η₂ : Rat}
+    (hη₁ : 0 ≤ η₁) (hle : η₁ ≤ η₂) (hred : isLLLReduced b δ η₁) :
+    isLLLReduced b δ η₂ := by
+  rcases hred with ⟨hsize, hlov⟩
+  refine ⟨?_, hlov⟩
+  intro i j hi hji
+  have hη₂ : 0 ≤ η₂ := Rat.le_trans hη₁ hle
+  have hsq1 : η₁ * η₁ ≤ η₁ * η₂ := Rat.mul_le_mul_of_nonneg_left hle hη₁
+  have hsq2 : η₁ * η₂ ≤ η₂ * η₂ := Rat.mul_le_mul_of_nonneg_right hle hη₂
+  exact Rat.le_trans (hsize i j hi hji) (Rat.le_trans hsq1 hsq2)
 
 /-- Integer-only state for later LLL reduction steps. The proof-facing fields
 connect the stored Gram determinants and scaled coefficients to the executable
@@ -845,47 +864,63 @@ def lllAux (s : LLLState n m) (k : Nat) (δ : Rat)
     Matrix Int n m :=
   lllLoop s k δ hδ hδ' hk hkn (lllFuel s)
 
-/-- Proof-free executable LLL entry point. Builds the canonical integer state
-via `LLLState.ofBasisUnchecked` and dispatches to `lllAux`. Mathlib-free
-executable callers that do not need a proof-facing specification (benchmarks,
-fixture emitters, BHKS projected-row computation) use this directly. -/
-def lllUnchecked (b : Matrix Int n m) (δ : Rat)
+/-- Native (non-dispatched) executable LLL entry point. Builds the canonical
+integer state via `LLLState.ofBasisUnchecked` and dispatches to `lllAux`.
+This is the body the public `lll` runs by default; its output achieves the
+classical size-reduction bound `|μ| ≤ 1/2` (η = 1/2), so its short-vector
+guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`. -/
+def lllNative (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Matrix Int n m :=
   lllAux (LLLState.ofBasisUnchecked b) 1 δ hδ hδ' (Nat.le_refl 1) hn
 
-/-- Top-level LLL entry point. Thin wrapper over `lllUnchecked` retaining the
-proof-facing `b.independent` argument for callers that already carry it. -/
-def lll (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
-    Matrix Int n m :=
-  lllUnchecked b δ hδ hδ' hn
+/-- `121/400 < δ` implies `1/4 < δ`: relays the public `lll` (`η = 11/20`)
+precondition through to the native body (`η = 1/2`). -/
+theorem one_quarter_lt_of_eta_eleven_twentieths {δ : Rat}
+    (hδ : (121 / 400 : Rat) < δ) : (1 / 4 : Rat) < δ := by
+  grind
 
-/-- Proof-free executable variant of `lll.firstShortVector`. -/
+/-- Top-level LLL entry point. Wraps `lllNative` and carries the public
+`η = 11/20` precondition `121/400 < δ`. The proof-carrying
+`b.independent` argument supports downstream callers that already have it.
+Output guarantees are stated at `η = 11/20`; the underlying algorithm in fact
+achieves `|μ| ≤ 1/2`, so the η = 11/20 bound follows by monotonic weakening
+of the size-reduction bound. -/
+def lll (b : Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (_hind : b.independent) :
+    Matrix Int n m :=
+  lllNative b δ (one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn
+
+/-- Proof-free executable variant of `lll.firstShortVector`. Targets the
+native body directly with the classical precondition `1/4 < δ`. -/
 def lll.firstShortVectorUnchecked (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Vector Int m :=
-  (lllUnchecked b δ hδ hδ' hn)[0]
+  (lllNative b δ hδ hδ' hn)[0]
 
 /-- The first row of the reduced basis (shortest vector under the LLL
 guarantee). Canonical short-vector entry point for downstream callers
 such as `hex-berlekamp-zassenhaus` recombination. -/
 def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) :
     Vector Int m :=
-  lll.firstShortVectorUnchecked b δ hδ hδ' hn
+  (lll b δ hδ hδ' hn hind)[0]
 
-/-- Proof-free executable variant of `lll.shortVectors`. -/
+/-- Proof-free executable variant of `lll.shortVectors`. Targets the
+native body directly with the classical precondition `1/4 < δ`. -/
 def lll.shortVectorsUnchecked (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Array (Vector Int m) :=
-  (lllUnchecked b δ hδ hδ' hn).toArray
+  (lllNative b δ hδ hδ' hn).toArray
 
 /-- The full reduced basis viewed as an ordered array of candidate short
 vectors. -/
 def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (_hind : b.independent) :
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) :
     Array (Vector Int m) :=
-  lll.shortVectorsUnchecked b δ hδ hδ' hn
+  (lll b δ hδ hδ' hn hind).toArray
 
 end Hex

--- a/HexLLL/Conformance.lean
+++ b/HexLLL/Conformance.lean
@@ -214,7 +214,7 @@ private def independentCheck (b : Matrix Int n m) : Bool :=
   (List.finRange n).all fun k =>
     0 < GramSchmidt.Int.gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt)
 
-private noncomputable def lllReducedCheck (b : Matrix Int n m) (δ : Rat) : Bool :=
+private noncomputable def lllReducedCheck (b : Matrix Int n m) (δ η : Rat) : Bool :=
   let basis := GramSchmidt.Int.basis b
   let coeffs := GramSchmidt.Int.coeffs b
   let sizeReduced :=
@@ -225,7 +225,7 @@ private noncomputable def lllReducedCheck (b : Matrix Int n m) (δ : Rat) : Bool
             let iFin : Fin n := ⟨i, hi⟩
             let jFin : Fin n := ⟨j, Nat.lt_trans hji hi⟩
             let μ := coeffs[iFin][jFin]
-            4 * μ * μ ≤ 1
+            μ * μ ≤ η * η
           else
             true
       else
@@ -293,13 +293,13 @@ private def typicalState : LLLState 8 8 := stateOf typical8
 #guard (Matrix.row bzStyleBasis f1_3).get f3_4 = -1
 #guard (Matrix.row bzStyleBasis f2_3).get f3_4 = 2
 
-example (hδ : (1 / 4 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
+example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
     (hind : bzStyleBasis.independent) :
     lll.firstShortVector bzStyleBasis (3 / 4) hδ hδ' (by decide) hind =
       Matrix.row (lll bzStyleBasis (3 / 4) hδ hδ' (by decide) hind) f0_3 := by
   rfl
 
-example (hδ : (1 / 4 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
+example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
     (hind : bzStyleBasis.independent) :
     lll.shortVectors bzStyleBasis (3 / 4) hδ hδ' (by decide) hind =
       (lll bzStyleBasis (3 / 4) hδ hδ' (by decide) hind).toArray := by

--- a/HexLLL/EmitFixtures.lean
+++ b/HexLLL/EmitFixtures.lean
@@ -44,12 +44,12 @@ private theorem lll_delta_upper : (3 / 4 : Rat) ≤ 1 := by
   grind
 
 /-- Emit one `(lattice, result)` pair: serialise the input basis and
-the reduced basis Lean returns from `lllUnchecked b (3/4) ...`. -/
+the reduced basis Lean returns from `lllNative b (3/4) ...`. -/
 private def emitCase (id : String) {n m : Nat} (hn : 1 ≤ n)
     (b : Matrix Int n m) : IO Unit := do
   emitLatticeFixture lib id (basisRows b)
   let r : Matrix Int n m :=
-    lllUnchecked b (3 / 4) lll_delta_lower lll_delta_upper hn
+    lllNative b (3 / 4) lll_delta_lower lll_delta_upper hn
   emitResult lib id "lll" (latticeValue (basisRows r))
 
 /-! ## Known-reducible bases.

--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -336,20 +336,25 @@ theorem norm_sq_intVectorToEuclidean (x : Fin m → ℤ) :
   rw [heq, norm_sq_intRowToEuclidean]
 
 /-- Mathlib-Euclidean-norm formulation of the LLL short-vector guarantee for
-an already `δ`-LLL-reduced executable basis.
+an already `(δ, η)`-LLL-reduced executable basis.
 
 The input vector is assumed to lie in the Mathlib `latticeSubmodule`.  The
 proof route converts that hypothesis back through `mem_latticeSubmodule_iff`,
-applies the executable `Hex.lll_short_vector` for the rational squared-norm
-inequality, then transports both sides through the concrete Euclidean norm
-coercions above. -/
+applies the executable `Hex.short_vector_bound_of_size_bound` for the
+rational squared-norm inequality, then transports both sides through the
+concrete Euclidean norm coercions above.
+
+Consumed downstream at `η = 11/20` for the public `Hex.lll` headline
+(`α = 1/(δ − 121/400)`, precondition `121/400 < δ`); also at `η = 1/2` for
+the native `Hex.lllNative` classical statement (`α = 1/(δ − 1/4)`,
+precondition `1/4 < δ`). -/
 theorem reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
-    (b : Hex.Matrix Int n m) (δ : Rat)
-    (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
-    (hli : Hex.Matrix.independent b) (hred : Hex.isLLLReduced b δ)
+    (b : Hex.Matrix Int n m) (δ η : Rat)
+    (hη : (1 : Rat) / 2 ≤ η) (hδη : η * η < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hli : Hex.Matrix.independent b) (hred : Hex.isLLLReduced b δ η)
     (x : Fin m → ℤ) (hx : x ∈ latticeSubmodule b) (hx0 : x ≠ 0) :
     ‖intRowToEuclidean (Hex.Matrix.row b ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩)‖ ^ 2 ≤
-      (((1 / (δ - 1 / 4)) ^ (n - 1) : Rat) : ℝ) *
+      (((1 / (δ - η * η)) ^ (n - 1) : Rat) : ℝ) *
         ‖intVectorToEuclidean x‖ ^ 2 := by
   let v : Vector Int m := HexMatrixMathlib.vectorEquiv.symm x
   have hxExec : Hex.Matrix.memLattice b v := by
@@ -363,7 +368,8 @@ theorem reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
       ext j
       simp [hv]
     simpa [v] using hv'
-  have hRat := Hex.lll_short_vector b hli hred hδ hδ' hn hxExec hx0Exec
+  have hRat := Hex.short_vector_bound_of_size_bound b hli hred hη hδη hδ' hn
+    hxExec hx0Exec
   have hReal := (Rat.cast_le (K := ℝ)).mpr hRat
   rw [norm_sq_intRowToEuclidean, norm_sq_intVectorToEuclidean]
   simp only [Rat.cast_mul, Rat.cast_intCast] at hReal

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -889,12 +889,24 @@ theorem prefixLLLReduced_one (b : Matrix Int n m) (δ : Rat) :
   · intro i hi _
     omega
 
-/-- At the full prefix `k = n`, `prefixLLLReduced` is exactly `isLLLReduced`. -/
+/-- At the full prefix `k = n`, `prefixLLLReduced` upgrades to
+`isLLLReduced b δ (1/2)`: `prefixLLLReduced` always carries the algorithm's
+classical `|μ| ≤ 1/2` size-reduction guarantee, which is the
+`η = 1/2` instance of the size-reduced condition `μ² ≤ η²`. -/
 theorem prefixLLLReduced_to_isLLLReduced (b : Matrix Int n m) (δ : Rat)
-    (h : prefixLLLReduced b n δ) : isLLLReduced b δ := by
+    (h : prefixLLLReduced b n δ) : isLLLReduced b δ (1 / 2) := by
+  let coeffs := GramSchmidt.Int.coeffs b
   refine ⟨?_, ?_⟩
   · intro i j hi hji
-    exact h.1 i j hi hi hji
+    have h4 := h.1 i j hi hi hji
+    -- `h4 : 4 * μ * μ ≤ 1`. Goal: `μ * μ ≤ (1/2) * (1/2)`.
+    let iFin : Fin n := ⟨i, hi⟩
+    let jFin : Fin n := ⟨j, Nat.lt_trans hji hi⟩
+    let μ : Rat := coeffs[iFin][jFin]
+    show μ * μ ≤ (1 / 2 : Rat) * (1 / 2)
+    have h4' : 4 * μ * μ ≤ 1 := h4
+    have hhalf : (1 / 2 : Rat) * (1 / 2) = 1 / 4 := by grind
+    grind
   · intro i hi
     exact h.2 i hi hi
 
@@ -2174,7 +2186,7 @@ theorem lllLoop_isLLLReduced_of_fuel_gt_measure
     ∀ (fuel : Nat) (s : LLLState n m) (k : Nat) (hk : 1 ≤ k) (hkn : k ≤ n),
       s.Valid → s.b.independent → prefixLLLReduced s.b k δ →
       s.potential * (n + 1) + (n - k) < fuel →
-      isLLLReduced (lllLoop s k δ hδ hδ' hk hkn fuel) δ := by
+      isLLLReduced (lllLoop s k δ hδ hδ' hk hkn fuel) δ (1 / 2) := by
   intro fuel
   induction fuel with
   | zero =>
@@ -2300,19 +2312,25 @@ end LLLState
 
 /-! ### Capstones
 
-The unconditional LLL guarantees for `Hex.lll`: the output is `δ`-LLL-reduced,
-the generated lattice is preserved, and the first row of the output bounds the
-norm of any nonzero lattice vector by `(1 / (δ - 1/4))^(n - 1)`. -/
+The unconditional LLL guarantees split across two surfaces:
 
-/-- **Unconditional LLL reducedness.** For any independent integer basis `b`,
-`Hex.lll b δ ... hind` returns a `δ`-LLL-reduced matrix. Combines the fuel-
-sufficiency theorem (`lllLoop_fuel_sufficient`) with the loop invariant
+* **Native** (`Hex.lllNative`, classical bound, precondition `1/4 < δ`).
+  Carries `isLLLReduced … δ (1/2)` because the integer size-reduction step
+  inside the loop produces exact `|μ| ≤ 1/2`. The short-vector denominator
+  is `δ − 1/4`.
+* **Public** (`Hex.lll`, precondition `121/400 < δ`). Wraps `lllNative` and
+  carries `isLLLReduced … δ (11/20)` (the η = 1/2 native bound weakens to
+  η = 11/20 by `isLLLReduced.mono_η`). The short-vector denominator is
+  `δ − 121/400`. This is the uniform bound an external reducer can promise. -/
+
+/-- The native LLL body produces a `(δ, 1/2)`-LLL-reduced matrix. Combines the
+fuel-sufficiency theorem (`lllLoop_fuel_sufficient`) with the loop invariant
 induction (`lllLoop_isLLLReduced_of_fuel_gt_measure`). -/
-theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
+theorem lllNative_isLLLReduced (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
-    isLLLReduced (lll b δ hδ hδ' hn hind) δ := by
+    isLLLReduced (lllNative b δ hδ hδ' hn) δ (1 / 2) := by
   show isLLLReduced (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))) δ
+    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))) δ (1 / 2)
   set s := LLLState.ofBasisUnchecked b with hs_def
   have hs_valid : s.Valid := by
     show (LLLState.ofBasis b hind).Valid
@@ -2325,83 +2343,192 @@ theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
   have : (s.potential + 1) * (n + 1) = s.potential * (n + 1) + (n + 1) := by ring
   omega
 
-/-- The generated lattice is preserved by `Hex.lll`. -/
-theorem lll_memLattice_iff (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent)
+/-- The generated lattice is preserved by `Hex.lllNative`. -/
+theorem lllNative_memLattice_iff (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (v : Vector Int m) :
-    Matrix.memLattice (lll b δ hδ hδ' hn hind) v ↔ Matrix.memLattice b v := by
+    Matrix.memLattice (lllNative b δ hδ hδ' hn) v ↔ Matrix.memLattice b v := by
   show Matrix.memLattice (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
     (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))) v ↔ _
   exact lllLoop_memLattice_iff _ 1 δ hδ hδ' (Nat.le_refl 1) hn _ v
 
-/-- **Unconditional LLL short-vector bound.** For any independent integer
-basis `b`, the first row of `Hex.lll b δ ... hind` has squared norm at most
-`(1 / (δ - 1/4))^(n - 1)` times the squared norm of any nonzero lattice vector
-of `b`. Combines `lll_isLLLReduced`, `lll_memLattice_iff`, and the conditional
-short-vector bound `Hex.lll_short_vector`. -/
-theorem lll_first_row_norm_sq_le_unconditional
-    (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent)
-    {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
-    ((Vector.normSq ((lll b δ hδ hδ' hn hind).row
-        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
-      (1 / (δ - 1 / 4)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) := by
-  have hred : isLLLReduced (lll b δ hδ hδ' hn hind) δ :=
-    lll_isLLLReduced b δ hδ hδ' hn hind
+/-- Independence is preserved by `Hex.lllNative`. -/
+theorem lllNative_independent (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (lllNative b δ hδ hδ' hn).independent := by
   have hs_valid : (LLLState.ofBasisUnchecked b).Valid := by
     show (LLLState.ofBasis b hind).Valid
     exact HexLLLMathlib.LLLState.ofBasis_valid b hind
-  have hind' : (lll b δ hδ hδ' hn hind).independent := by
-    show (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-      (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))).independent
-    exact LLLState.lllLoop_independent δ hδ hδ' _ _ 1 (Nat.le_refl 1) hn hs_valid hind
+  show (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
+    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))).independent
+  exact LLLState.lllLoop_independent δ hδ hδ' _ _ 1
+    (Nat.le_refl 1) hn hs_valid hind
+
+/-- Classical native LLL short-vector bound at `η = 1/2`. For any independent
+integer basis `b`, the first row of `Hex.lllNative b δ ...` has squared norm
+at most `(1 / (δ − 1/4))^(n − 1)` times the squared norm of any nonzero
+lattice vector. -/
+theorem lllNative_short_vector
+    (b : Matrix Int n m) (δ : Rat)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent)
+    {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
+    ((Vector.normSq ((lllNative b δ hδ hδ' hn).row
+        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
+      (1 / (δ - 1 / 4)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) := by
+  have hred : isLLLReduced (lllNative b δ hδ hδ' hn) δ (1 / 2) :=
+    lllNative_isLLLReduced b δ hδ hδ' hn hind
+  have hind' : (lllNative b δ hδ hδ' hn).independent :=
+    lllNative_independent b δ hδ hδ' hn hind
+  have hv_lll : Matrix.memLattice (lllNative b δ hδ hδ' hn) v :=
+    (lllNative_memLattice_iff b δ hδ hδ' hn v).mpr hv
+  have hbnd := Hex.short_vector_bound_of_size_bound (lllNative b δ hδ hδ' hn) hind'
+    hred (by grind) (by grind) hδ' hn hv_lll hv'
+  -- Rewrite `(1/2) * (1/2)` as `1/4` in the resulting denominator.
+  have hηη : (1 / 2 : Rat) * (1 / 2) = 1 / 4 := by grind
+  rw [hηη] at hbnd
+  exact hbnd
+
+/-- The public LLL `lll` produces a `(δ, 11/20)`-LLL-reduced matrix.
+Obtained from `lllNative_isLLLReduced` (`η = 1/2`) by monotonic weakening
+of the size-reduction bound via `isLLLReduced.mono_η`. -/
+theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) :
+    isLLLReduced (lll b δ hδ hδ' hn hind) δ (11 / 20) := by
+  have hred := lllNative_isLLLReduced b δ
+    (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn hind
+  show isLLLReduced (lllNative b δ
+    (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn) δ (11 / 20)
+  exact Hex.isLLLReduced.mono_η _ (by grind) (by grind) hred
+
+/-- The generated lattice is preserved by `Hex.lll`. -/
+theorem lll_memLattice_iff (b : Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) (v : Vector Int m) :
+    Matrix.memLattice (lll b δ hδ hδ' hn hind) v ↔ Matrix.memLattice b v := by
+  show Matrix.memLattice (lllNative b δ
+    (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn) v ↔ _
+  exact lllNative_memLattice_iff b δ _ hδ' hn v
+
+/-- Independence is preserved by `Hex.lll`. -/
+theorem lll_independent (b : Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) :
+    (lll b δ hδ hδ' hn hind).independent := by
+  show (lllNative b δ
+    (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn).independent
+  exact lllNative_independent b δ _ hδ' hn hind
+
+/-- Public LLL short-vector bound at `η = 11/20`. For any independent
+integer basis `b`, the first row of `Hex.lll b δ ... hind` has squared norm at
+most `(1 / (δ − 121/400))^(n − 1)` times the squared norm of any nonzero
+lattice vector. -/
+theorem lll_short_vector
+    (b : Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent)
+    {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
+    ((Vector.normSq ((lll b δ hδ hδ' hn hind).row
+        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
+      (1 / (δ - 121 / 400)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) := by
+  have hred : isLLLReduced (lll b δ hδ hδ' hn hind) δ (11 / 20) :=
+    lll_isLLLReduced b δ hδ hδ' hn hind
+  have hind' : (lll b δ hδ hδ' hn hind).independent :=
+    lll_independent b δ hδ hδ' hn hind
   have hv_lll : Matrix.memLattice (lll b δ hδ hδ' hn hind) v :=
     (lll_memLattice_iff b δ hδ hδ' hn hind v).mpr hv
-  exact Hex.lll_short_vector (lll b δ hδ hδ' hn hind) hind' hred hδ hδ' hn hv_lll hv'
+  have hδη : (11 / 20 : Rat) * (11 / 20) < δ := by
+    have : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
+    grind
+  have hbnd := Hex.short_vector_bound_of_size_bound (lll b δ hδ hδ' hn hind)
+    hind' hred (by grind) hδη hδ' hn hv_lll hv'
+  have hηη : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
+  simpa [hηη] using hbnd
 
 end Hex
 
 namespace HexLLLMathlib
 
-/-- Membership in the Mathlib `latticeSubmodule` is preserved by `Hex.lll`. -/
-theorem lll_mem_latticeSubmodule_iff
+/-- Membership in the Mathlib `latticeSubmodule` is preserved by
+`Hex.lllNative`. -/
+theorem lllNative_mem_latticeSubmodule_iff
     (b : Hex.Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent)
+    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (x : Fin m → ℤ) :
-    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) ↔ x ∈ latticeSubmodule b := by
+    x ∈ latticeSubmodule (Hex.lllNative b δ hδ hδ' hn) ↔ x ∈ latticeSubmodule b := by
   let v := HexMatrixMathlib.vectorEquiv.symm x
   have hxv : x = HexMatrixMathlib.vectorEquiv v :=
     (Equiv.apply_symm_apply _ x).symm
   rw [hxv]
-  rw [mem_latticeSubmodule_iff (Hex.lll b δ hδ hδ' hn hind) v,
+  rw [mem_latticeSubmodule_iff (Hex.lllNative b δ hδ hδ' hn) v,
       mem_latticeSubmodule_iff b v]
-  exact Hex.lll_memLattice_iff b δ hδ hδ' hn hind v
+  exact Hex.lllNative_memLattice_iff b δ hδ hδ' hn v
 
-/-- **Unconditional Mathlib-Euclidean LLL short-vector bound.** Combining
-`Hex.lll_isLLLReduced` with the conditional Euclidean bound
-`reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`. -/
-theorem lll_first_row_norm_sq_le_unconditional
+/-- Membership in the Mathlib `latticeSubmodule` is preserved by `Hex.lll`. -/
+theorem lll_mem_latticeSubmodule_iff
+    (b : Hex.Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent) (x : Fin m → ℤ) :
+    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) ↔ x ∈ latticeSubmodule b := by
+  show x ∈ latticeSubmodule (Hex.lllNative b δ
+    (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn) ↔ _
+  exact lllNative_mem_latticeSubmodule_iff b δ _ hδ' hn x
+
+/-- Classical Mathlib-Euclidean LLL short-vector bound on `Hex.lllNative` at
+`η = 1/2`. Combines `Hex.lllNative_isLLLReduced` with the conditional
+Euclidean bound `reduced_first_row_norm_sq_le_of_mem_latticeSubmodule` at
+`η = 1/2`. -/
+theorem lllNative_first_row_norm_sq_le_unconditional
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)
     (x : Fin m → ℤ) (hx : x ∈ latticeSubmodule b) (hx0 : x ≠ 0) :
     ‖intRowToEuclidean
-        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn hind)
+        (Hex.Matrix.row (Hex.lllNative b δ hδ hδ' hn)
           ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩)‖ ^ 2 ≤
       (((1 / (δ - 1 / 4)) ^ (n - 1) : Rat) : ℝ) *
         ‖intVectorToEuclidean x‖ ^ 2 := by
-  have hred : Hex.isLLLReduced (Hex.lll b δ hδ hδ' hn hind) δ :=
+  have hred : Hex.isLLLReduced (Hex.lllNative b δ hδ hδ' hn) δ (1 / 2) :=
+    Hex.lllNative_isLLLReduced b δ hδ hδ' hn hind
+  have hind' : (Hex.lllNative b δ hδ hδ' hn).independent :=
+    Hex.lllNative_independent b δ hδ hδ' hn hind
+  have hx_lll : x ∈ latticeSubmodule (Hex.lllNative b δ hδ hδ' hn) :=
+    (lllNative_mem_latticeSubmodule_iff b δ hδ hδ' hn x).mpr hx
+  have hbnd := reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
+    (Hex.lllNative b δ hδ hδ' hn) δ (1 / 2) (by grind) (by grind) hδ' hn hind'
+    hred x hx_lll hx0
+  -- Rewrite `(1/2) * (1/2)` as `1/4` in the bound's denominator.
+  have hηη : (1 / 2 : Rat) * (1 / 2) = 1 / 4 := by grind
+  rw [hηη] at hbnd
+  exact hbnd
+
+/-- **Unconditional Mathlib-Euclidean LLL short-vector bound on `Hex.lll` at
+`η = 11/20`.** Combines `Hex.lll_isLLLReduced` (η = 11/20) with the
+conditional Euclidean bound `reduced_first_row_norm_sq_le_of_mem_latticeSubmodule`
+at `η = 11/20`. -/
+theorem lll_first_row_norm_sq_le_unconditional
+    (b : Hex.Matrix Int n m) (δ : Rat)
+    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
+    (hind : b.independent)
+    (x : Fin m → ℤ) (hx : x ∈ latticeSubmodule b) (hx0 : x ≠ 0) :
+    ‖intRowToEuclidean
+        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn hind)
+          ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩)‖ ^ 2 ≤
+      (((1 / (δ - 121 / 400)) ^ (n - 1) : Rat) : ℝ) *
+        ‖intVectorToEuclidean x‖ ^ 2 := by
+  have hred : Hex.isLLLReduced (Hex.lll b δ hδ hδ' hn hind) δ (11 / 20) :=
     Hex.lll_isLLLReduced b δ hδ hδ' hn hind
-  have hs_valid : (Hex.LLLState.ofBasisUnchecked b).Valid :=
-    HexLLLMathlib.LLLState.ofBasis_valid b hind
-  have hind' : (Hex.lll b δ hδ hδ' hn hind).independent := by
-    show (Hex.lllLoop (Hex.LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-      (Nat.le_refl 1) hn (Hex.lllFuel (Hex.LLLState.ofBasisUnchecked b))).independent
-    exact Hex.LLLState.lllLoop_independent δ hδ hδ' _ _ 1
-      (Nat.le_refl 1) hn hs_valid hind
+  have hind' : (Hex.lll b δ hδ hδ' hn hind).independent :=
+    Hex.lll_independent b δ hδ hδ' hn hind
   have hx_lll : x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) :=
     (lll_mem_latticeSubmodule_iff b δ hδ hδ' hn hind x).mpr hx
-  exact reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
-    (Hex.lll b δ hδ hδ' hn hind) δ hδ hδ' hn hind' hred x hx_lll hx0
+  have hδη : (11 / 20 : Rat) * (11 / 20) < δ := by
+    have : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
+    grind
+  have hbnd := reduced_first_row_norm_sq_le_of_mem_latticeSubmodule
+    (Hex.lll b δ hδ hδ' hn hind) δ (11 / 20) (by grind) hδη hδ' hn hind'
+    hred x hx_lll hx0
+  have hηη : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
+  simpa [hηη] using hbnd
 
 end HexLLLMathlib

--- a/progress/20260609T024355Z_304844c6.md
+++ b/progress/20260609T024355Z_304844c6.md
@@ -1,0 +1,43 @@
+# 20260609T024355Z (#6610)
+
+## Accomplished
+
+- Parameterized `Hex.isLLLReduced b δ η` (size-reduced condition
+  `μ² ≤ η²`); generalized `LLLCore.stepBound_arith`, `stepBound`,
+  `stepAlpha`, `teleBound`.
+- Renamed the conditional short-vector bound `Hex.lll_short_vector` to
+  `Hex.short_vector_bound_of_size_bound` and parameterized it by `η`
+  (preconditions `1/2 ≤ η`, `η² < δ`, `δ ≤ 1`).
+- Added monotonicity lemma `Hex.isLLLReduced.mono_η`.
+- Renamed `Hex.lllUnchecked` to `Hex.lllNative` (the classical native
+  body, precondition `1/4 < δ`); updated `EmitFixtures`, `reports/scratch`
+  bench callers.
+- Tightened the public `Hex.lll` precondition to `121/400 < δ`; it now
+  wraps `lllNative` via the helper `Hex.one_quarter_lt_of_eta_eleven_twentieths`.
+- Updated `Conformance` (typed examples now use `121/400 < δ`; the dead
+  `lllReducedCheck` noncomputable check is now η-parameterized).
+- Restated capstones in `HexLLLMathlib.Independent` on both surfaces:
+  `lllNative_isLLLReduced` / `lllNative_memLattice_iff` /
+  `lllNative_independent` / `lllNative_short_vector` (η = 1/2,
+  `1/4 < δ`); and `lll_isLLLReduced` / `lll_memLattice_iff` /
+  `lll_independent` / `lll_short_vector` (η = 11/20, `121/400 < δ`,
+  derived via `mono_η`).
+- Updated the Mathlib Euclidean headline
+  `reduced_first_row_norm_sq_le_of_mem_latticeSubmodule` to take `(δ, η)`
+  with the algebraic denominator `δ - η²`; pinned downstream as
+  `lllNative_first_row_norm_sq_le_unconditional` (η = 1/2) and
+  `lll_first_row_norm_sq_le_unconditional` (η = 11/20).
+- `lake build HexLLLMathlib` green; `lake build HexBerlekampZassenhaus`
+  green. Zero `sorry`, zero `axiom`.
+
+## Current frontier
+
+Issue #6610 deliverables 1–5 landed.
+
+## Next step
+
+Open the PR.
+
+## Blockers
+
+None.

--- a/reports/scratch/LLLBench.lean
+++ b/reports/scratch/LLLBench.lean
@@ -52,7 +52,7 @@ private def runOne (n : Nat) (reps : Nat) (hn : 1 ≤ n) : IO Unit := do
   let t0 ← IO.monoNanosNow
   let mut chk : UInt64 := 0
   for _ in [0:reps] do
-    let reduced := Hex.lllUnchecked basis (3 / 4) hδLow hδHigh hn
+    let reduced := Hex.lllNative basis (3 / 4) hδLow hδHigh hn
     chk := chk ^^^ matrixChecksum reduced
   let t1 ← IO.monoNanosNow
   let nanos := (t1 - t0) / reps

--- a/reports/scratch/LLLBenchTiny.lean
+++ b/reports/scratch/LLLBenchTiny.lean
@@ -46,7 +46,7 @@ private def runOne (n : Nat) (reps : Nat) (hn : 1 ≤ n) : IO Unit := do
   let t0 ← IO.monoNanosNow
   let mut chk : UInt64 := 0
   for _ in [0:reps] do
-    let reduced := Hex.lllUnchecked basis (3 / 4) hδLow hδHigh hn
+    let reduced := Hex.lllNative basis (3 / 4) hδLow hδHigh hn
     chk := chk ^^^ matrixChecksum reduced
   let t1 ← IO.monoNanosNow
   let nanos := (t1 - t0) / reps


### PR DESCRIPTION
Closes #6610

Session: `304844c6-8e3a-4e3b-a942-8063ea1d5613`

d03073e7 feat: parameterize isLLLReduced by η; pin native (1/2) and public (11/20) surfaces

🤖 Prepared with Claude Code