### PR TITLE
spec: name the Isabelle certified-LLL comparator source precisely

### DIFF
--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -362,14 +362,23 @@ classification below is mirrored as structured metadata in
   dispatch*; the certified path's measured cost is the `fplll-ffi` call —
   which returns `(reduced, U, V)` directly — plus the verified checker.
 - **`verified Isabelle certified-LLL`** — `gating`. The Isabelle
-  formalisation's own certified-output configuration (a verified checker
-  over an untrusted floating-point reducer; JAR 2020 §7 and the AFP entry
-  `Modular_arithmetic_LLL_and_HNF_algorithms`) is the apples-to-apples
-  yardstick for the certified path. **Performance goal:** the hex certified
-  path (fpLLL + checker) is **at least as fast as** the Isabelle
-  certified-LLL on shared canonical inputs at the largest eligible rung of
-  each `phase4.input_families` ladder. The headline report records the
-  ratio, the checker's share of the cost, and the candidate rejection rate.
+  formalisation's own certified-output configuration (JAR 2020 §7): a
+  verified checker over an untrusted floating-point reducer. It is the
+  `svp_certified` executable of the same Zenodo 2636367 `LLL_Basis_Reduction`
+  extraction that supplies the native comparator — built from one extra
+  `make` target on that archive — which shells out to the `fplll` binary for
+  `(reduced, U, V)`, verifies the same two-transform certificate this library
+  uses (`F = U·reduced` ∧ `reduced = V·F`), and confirms reducedness by
+  re-running the verified LLL. It is the apples-to-apples yardstick for the
+  certified path. **Performance goal:** the hex certified path (fpLLL +
+  checker) is **at least as fast as** the Isabelle certified-LLL on shared
+  canonical inputs at the largest eligible rung of each
+  `phase4.input_families` ladder. The headline report records the ratio, the
+  checker's share of the cost, and the candidate rejection rate, and notes the
+  architectural asymmetries the comparison is read against — the Isabelle path
+  spawns the `fplll` binary per call (this library uses in-process `fplll-ffi`)
+  and re-runs the full verified LLL to confirm reducedness (this library runs
+  the `lllReducedInt` integer check).
 - **`verified Isabelle LLL`** — `gating`. The Bottesch–Divasón–
   Haslbeck–Joosten–Thiemann–Yamada formalisation in the Archive of
   Formal Proofs (entry `LLL_Basis_Reduction`) is the only other
@@ -431,8 +440,8 @@ classification below is mirrored as structured metadata in
      checker (`certCheck`); the certified external-dispatch path. Data comes
      from the `runCertified*` bench targets.
   5. **verified Isabelle certified-LLL** — fpLLL candidate production plus the
-     Isabelle verified checker (the `Modular_arithmetic_LLL_and_HNF_algorithms`
-     certifier).
+     Isabelle verified checker (the `svp_certified` JAR 2020 §7 configuration
+     of the Zenodo 2636367 extraction).
 
   Curves 1–3 compare the algorithms; curves 4–5 are the apples-to-apples
   verification comparison — the *same* fpLLL output certified by the Lean

--- a/libraries.yml
+++ b/libraries.yml
@@ -185,7 +185,7 @@ libraries:
         - tool: "verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)"
           class: gating
           goal: "Lean LLL is at least as fast as the verified Isabelle LLL on shared canonical inputs at the bottom of each phase4.input_families parameter ladder."
-        - tool: "verified Isabelle certified-LLL (JAR 2020 §7; AFP Modular_arithmetic_LLL_and_HNF_algorithms)"
+        - tool: "verified Isabelle certified-LLL (JAR 2020 §7; svp_certified from the Zenodo 2636367 LLL_Basis_Reduction extraction, same archive as the native comparator)"
           class: gating
           goal: "The hex certified path (fpLLL + verified checker) is at least as fast as the Isabelle certified-LLL on shared canonical inputs at the largest eligible rung of each phase4.input_families ladder; the headline report records the ratio, the checker's cost share, and the candidate rejection rate."
       input_families:

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -292,7 +292,7 @@ checksum.
 The current implemented gating comparator is `verified Isabelle LLL (AFP LLL_Basis_Reduction; Haskell extraction from Zenodo 2636367)`, declared in `SPEC/Libraries/hex-lll.md`. The persistent-subprocess harness for it was wired in HO-16 (#3676); the matching fpylll persistent driver was wired in HO-17 (#4186). The densified `random-bounded` and `harsh-cubic` ladders are the post-HO-18 fixed-benchmark schedules — `random-bounded` `n ∈ {30, 45, 60, 75, 90, 120, 150, 180}`, `harsh-cubic` `n ∈ {15, 20, 25, 30, 35, 40, 45, 50, 55}` — per the post-#3657 §"Headline reports" densification rule.
 
 The certified external-dispatch SPEC also declares the gating comparator
-`verified Isabelle certified-LLL (JAR 2020 §7; AFP Modular_arithmetic_LLL_and_HNF_algorithms)`.
+`verified Isabelle certified-LLL (JAR 2020 §7; svp_certified from the Zenodo 2636367 LLL_Basis_Reduction extraction, same archive as the native comparator)`.
 The Hex certified path is now registered as fixed process-call targets:
 `runCertifiedFirstShortVectorRandomBounded{30,45,60,75,90,120,150,180}Checksum`
 and


### PR DESCRIPTION
This PR names the `verified Isabelle certified-LLL` comparator source precisely: it is the `svp_certified` executable of the same Zenodo 2636367 `LLL_Basis_Reduction` extraction that already supplies the native comparator (JAR 2020 §7), built from one extra `make` target on that archive — not the separate 2021 AFP `Modular_arithmetic_LLL_and_HNF_algorithms` entry, which is a different and harder artifact. It also records the two architectural asymmetries the certified comparison is read against: the Isabelle path spawns the `fplll` binary per call and confirms reducedness by re-running the full verified LLL, whereas this library uses in-process `fplll-ffi` and the `lllReducedInt` integer check.

🤖 Prepared with Claude Code