### PR TITLE
DG1: fpLLL bench comparator via fplll-ffi FFI shim (retire fpylll for speed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
         run: |
           HEX_LLL_ISABELLE_SVP="$(scripts/oracle/setup_lll_isabelle.sh)"
           export HEX_LLL_ISABELLE_SVP
+          # fpLLL comparator (#6642): build the fplll-ffi shim and dlopen it
+          # at hexlll_bench start-up. The shim depends on Lean's
+          # libLake_shared.so, which is reachable via LD_LIBRARY_PATH set
+          # above ("Configure Lean shared library path").
+          HEX_FPLLL_FFI_LIB="$(scripts/oracle/setup_fplll_ffi.sh)"
+          export HEX_FPLLL_FFI_LIB
           bash scripts/ci/check_bench_verify_budget.sh \
             hexarith_bench hexmatrix_bench hexpoly_bench hexpolyz_bench \
             hexpolyfp_bench hexmodarith_bench hexgramschmidt_bench \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - run: python3 scripts/check_phase4.py
       - name: Lint benches are Mathlib-free (SPEC/benchmarking.md §Mathlib-free benches)
         run: python3 scripts/ci/check_benches_mathlib_free.py
-      - run: sudo apt-get install -y libgmp-dev libfplll-dev libntl-dev
+      - run: sudo apt-get install -y libgmp-dev libfplll-dev libntl-dev libmpfr-dev libc++-dev libc++abi-dev autoconf automake libtool pkg-config
       - name: Install Python bench comparator dependencies
         run: python3 -m pip install --user cysignals fpylll python-flint
       - name: Set up Lean toolchain (no build)

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -37,28 +37,31 @@ Scientific registrations:
 
 Informational external comparator:
 
-* `fpLLL via fpylll`: process-call registrations send each matrix to
-  `scripts/oracle/lll_fpylll_bench_driver.py`, the persistent
-  subprocess driver wired in HO-17 (#3660). The driver imports
-  `fpylll` once at startup and calls `fpylll.LLL.reduction` with
-  `delta = 0.75` (matching Lean's `δ = 3/4`) per request. The
-  comparator is classified informational in
+* `fpLLL via fplll-ffi`: in-process FFI registrations call `libfplll`
+  through the `fplll-ffi` shim — one C++ call per request, no
+  subprocess. The shim's `lean_fplll_lll_reduce` symbol is resolved
+  by `HexLLL/ffi/lean_hexlll_provider.c` via `dlsym(RTLD_DEFAULT, ...)`
+  after an opportunistic `dlopen` of `HEX_FPLLL_FFI_LIB`, mirroring
+  the Isabelle binary-path override. The shim is built by
+  `scripts/oracle/setup_fplll_ffi.sh` (clone+lake build of
+  `kim-em/fplll-ffi`), keeping hex free of any Lake dependency on
+  it. The comparator is classified informational in
   `SPEC/Libraries/hex-lll.md` because fpLLL's floating-point
-  Gram-Schmidt implementation (Nguyen-Stehle; fpylll 0.6 or newer
-  supported by the existing oracle driver) bypasses the
-  exact-integer operand-size drift paid by this verified
-  implementation. Ratios are recorded for orientation but do not block
-  Phase 4. The conformance-mode entry point remains
-  `scripts/oracle/lll_fpylll.py --check`.
-* `fpLLL certified path`: process-call registrations send `CERT\t`
-  requests to the same persistent fpylll driver. The reply is a flat
-  `(B', U, V)` candidate payload; the Lean target runs
-  `LLLProvider.certifyFlat`, so the measured path is fpLLL candidate
-  production plus the executable checker. Companion checker-only
-  targets cache one candidate after warmup and re-run only
-  `certCheck`, giving the checker's cost share. Public-dispatch smoke
-  targets also guard that, if a real fplll-ffi provider is intentionally
-  loaded, the dispatch tally records at least one accepted candidate.
+  Gram-Schmidt implementation (Nguyen-Stehle) bypasses the
+  exact-integer operand-size drift this verified implementation
+  pays. Ratios are recorded for orientation but do not block
+  Phase 4. The conformance oracle keeps its independent fpylll
+  cross-check at `scripts/oracle/lll_fpylll.py --check`; only the
+  speed comparator switched to the FFI shim.
+* `fpLLL certified path`: the same in-process `fplll-ffi` call returns
+  the flat `(B', U, V)` candidate payload directly; the Lean target
+  runs `LLLProvider.certifyFlat`, so the measured path is fpLLL
+  candidate production plus the executable checker. Companion
+  checker-only targets cache one candidate after warmup and re-run
+  only `certCheck`, giving the checker's cost share. Public-dispatch
+  smoke targets guard that, when an `fplll-ffi` provider is
+  intentionally loaded via `HEX_FPLLL_FFI_LIB`, the dispatch tally
+  records at least one accepted candidate.
 
 External comparator:
 
@@ -75,74 +78,61 @@ External comparator:
   `HEX_LLL_ISABELLE_SVP` to an already-built binary to avoid setup in
   the first measured call.
 
-## Comparator-call protocol (persistent subprocess)
+## Comparator-call protocol
 
-Per `SPEC/benchmarking.md` (post-#3657) "External comparators / Process
-call", Phase-4 process-call comparators with non-negligible per-call
-overhead use a persistent subprocess: one driver is spawned per
-`lake exe hexlll_bench run` invocation, and each measured call sends one
-framed request to its stdin and reads one framed reply from its stdout.
+The `fpLLL via fplll-ffi` comparator is an in-process FFI call: each
+request marshals the matrix into the `Array String` payload the
+provider hook expects, calls `LLLProvider.providerReduce`, and reads
+the flat `(status, rows, cols, has_inverse, reduced, U, V?)` reply.
+No subprocess, no IPC, no interpreter startup; the per-call overhead
+is the FFI marshalling cost alone.
 
-**Framing.** Each request is one line containing the input matrix in
-Haskell's `[[Integer]]` read syntax — exactly the string produced by
-`matrixHaskell` — terminated by `\n`. The same request line feeds
-both the Isabelle and the fpylll persistent drivers; scalar requests emit a
-single scalar per request, terminated by `\n`. Isabelle returns the
-squared norm of its first reduced row; fpylll returns the integer
-first-row checksum matching `Hex.LLLBench.intVectorChecksum` (the
-scalar paired with `runFirstShortVector*Checksum`). Certified fpylll
-requests prefix the matrix with `CERT\t` and receive a whitespace-separated
-flat integer candidate. Malformed fpylll requests come back as
-`ERROR: <message>`; the Lean parser treats any error/non-integer reply as a
-driver fault and triggers the retry path.
+The `verified Isabelle LLL` comparator uses a persistent subprocess
+per `SPEC/benchmarking.md` (post-#3657) "External comparators /
+Process call": one `svp_verified` driver is spawned per
+`lake exe hexlll_bench run` invocation, and each measured call sends
+one framed request to its stdin and reads one framed reply from its
+stdout.
 
-**Lifetime.** Each driver is spawned lazily on first use into a
-module-level `IO.Ref (Option PersistentComparator)`
-(`isabelleChildRef` for Isabelle, `fpylllChildRef` for fpylll) and
-reused for every subsequent call in the same `hexlll_bench`
-process. The child's stdin is held by the bench process via
-`Child.takeStdin`; on process exit, the OS reaps each driver via
-EOF on stdin.
+**Isabelle framing.** Each request is one line containing the input
+matrix in Haskell's `[[Integer]]` read syntax — exactly the string
+produced by `matrixHaskell` — terminated by `\n`. Isabelle returns
+the squared norm of its first reduced row.
 
-**Error handling.** If `requestLine` raises any `IO` error, the
-bench wiring drops the cached child handle, re-spawns the
-relevant driver (Isabelle from
-`scripts/oracle/setup_lll_isabelle.sh`; fpylll from the path in
-`HEX_LLL_FPYLLL_BENCH_DRIVER` or the default
-`scripts/oracle/lll_fpylll_bench_driver.py`), and retries the
-request once. Persistent failure (e.g. setup script failure or
-repeated driver crash) surfaces as an `IO.userError`.
+**Isabelle lifetime.** The Isabelle driver is spawned lazily on first
+use into the module-level `isabelleChildRef`
+(`IO.Ref (Option PersistentComparator)`) and reused for every
+subsequent call in the same `hexlll_bench` process. The child's
+stdin is held by the bench process via `Child.takeStdin`; on process
+exit, the OS reaps the driver via EOF on stdin.
 
-**Per-call overhead.** Piping 10000 trivial inputs
-(`[[1,0],[0,1]]`) through the patched Isabelle binary on the audit
-host takes ~110 ms wall total (median of 5 trials), of which
-~22 ms is the one-time GHC startup; per-call Isabelle protocol
-overhead is ~9 µs in steady state. The persistent fpylll driver
-pays a one-time CPython + `import fpylll` startup and per-call
-steady-state overhead of ~34 µs (median of 5 trials of 1000
-trivial `[[1,0],[0,1]]` requests on the audit host). The previous
-shape paid ~116 ms per call to CPython start + fpylll import +
-single `fpylll.LLL.reduction`. Both persistent figures are three
-orders of magnitude below the per-call interpreter-start cost
-and well below the 5 % overhead-to-measured-time floor
-`SPEC/benchmarking.md` requires for honest ratios.
+**Isabelle error handling.** If `requestLine` raises any `IO` error,
+the bench wiring drops the cached child handle, re-spawns the
+Isabelle driver from `scripts/oracle/setup_lll_isabelle.sh`, and
+retries the request once. Persistent failure (e.g. setup script
+failure or repeated driver crash) surfaces as an `IO.userError`.
 
-**Interaction with `setup_fixed_benchmark`.** `lean-bench` spawns
-one fresh `hexlll_bench` child process per measured repeat of a
-fixed benchmark, so each repeat starts with cold `isabelleChildRef`
-and `fpylllChildRef`. The process-call comparator registrations set
-`minTotalSeconds := 1.0`, forcing the fixed child to run enough
-inner iterations to amortize the one-time GHC start (Isabelle) /
-CPython + fpylll import (fpylll) inside the child. The exported
-per-call time is therefore `total_nanos / inner_repeats`, not the
-cold interpreter startup floor.
+**Per-call overhead.** Piping 10000 trivial inputs (`[[1,0],[0,1]]`)
+through the patched Isabelle binary on the audit host takes ~110 ms
+wall total (median of 5 trials), of which ~22 ms is the one-time
+GHC startup; per-call Isabelle protocol overhead is ~9 µs in steady
+state. The `fplll-ffi` FFI call carries no interpreter startup; its
+per-call cost is one `dlsym`-resolved C++ call plus the
+`matrixToEntries` marshalling.
 
-**Driver path overrides.** `HEX_LLL_FPYLLL_BENCH_DRIVER` overrides
-the default driver script path (relative to the bench process's
-cwd, which is the repo root under `lake exe`).
-`HEX_LLL_FPYLLL_BENCH_PYTHON` overrides the interpreter command
-(default `python3`). The Isabelle binary path is controlled by
-`HEX_LLL_ISABELLE_SVP` as before.
+**Interaction with `setup_fixed_benchmark`.** `lean-bench` spawns one
+fresh `hexlll_bench` child process per measured repeat of a fixed
+benchmark, so each repeat starts with a cold `isabelleChildRef`; the
+process-call comparator registrations set `minTotalSeconds := 1.0`,
+forcing the fixed child to run enough inner iterations to amortize
+the one-time GHC start inside the child. For `fplll-ffi`, the
+per-process cost is the one-time `dlopen` performed lazily on the
+first probe via `HEX_FPLLL_FFI_LIB`.
+
+**Driver path overrides.** `HEX_FPLLL_FFI_LIB` selects the
+`fplll-ffi` shared library that the bench `dlopen`s at start-up
+(see `HexLLL/ffi/lean_hexlll_provider.c`). The Isabelle binary path
+is controlled by `HEX_LLL_ISABELLE_SVP` as before.
 
 **Signal-floor setting.** HexLLL scientific parametric registrations set
 `signalFloorMultiplier := 1.0`. The timed rows come from child-side
@@ -720,16 +710,33 @@ first row. If a real external provider is loaded, this target fails unless the
 certified dispatch accepts at least one candidate. -/
 def runDispatchedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO Int := do
   LLLProvider.resetDiagnostics
-  let reduced :=
-    match LLLProvider.dispatch input.basis (3 / 4 : Rat) with
-    | some B' => B'
-    | none => lllNative input.basis (3 / 4) lllDeltaLower lllDeltaUpper input.hn
+  have hrows : 1 ≤ input.rows := input.hn
+  let f0 : Fin input.rows := ⟨0, by omega⟩
+  -- Drive the dispatch via the IO-based `tryReduce` so the diagnostic
+  -- side-effects fire eagerly (the pure `dispatch` uses
+  -- `@[implemented_by]` side-effects that the compiled bench harness
+  -- otherwise defers past the `diagnostics` read below). On a successful
+  -- candidate we still run `certifyFlat` so the smoke target measures
+  -- the same certified path that `dispatch` exposes to the public `lll`
+  -- entry point.
+  let δ : Rat := 3 / 4
+  let δFloat : Float := Float.ofInt δ.num / Float.ofNat δ.den
+  let entries := LLLProvider.matrixToEntries input.basis
+  let candidate? ← LLLProvider.tryReduce
+    (USize.ofNat input.rows) (USize.ofNat input.cols) entries
+    δFloat 0.55 0 true
+  let reduced ← match candidate? with
+    | some cand =>
+        let flat := #[0, Int.ofNat input.rows, Int.ofNat input.cols, 1]
+          ++ cand.reduced ++ cand.transform ++ (cand.inverse?.getD #[])
+        match LLLProvider.certifyFlat input.basis δ flat with
+        | some triple => pure triple.1
+        | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn)
+    | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn)
   let diagnostics ← LLLProvider.diagnostics
   if LLLProvider.providerAvailable () && diagnostics.accepted = 0 then
     throw <| IO.userError
       s!"fplll provider loaded but certified dispatch accepted zero candidates: {repr diagnostics}"
-  have hrows : 1 ≤ input.rows := input.hn
-  let f0 : Fin input.rows := ⟨0, by omega⟩
   return intVectorChecksum (Matrix.row reduced f0)
 
 /-- Benchmark comparator observable: squared norm of Lean's first LLL vector.
@@ -846,93 +853,45 @@ def runIsabelleShortVectorNormSq (_tag : String) (input : FirstShortVectorInput)
   let request := matrixHaskell input.basis
   parseIsabelleNormSq (← requestIsabelleLineWithRetry request 1)
 
-initialize fpylllChildRef : IO.Ref (Option PersistentComparator) ←
-  IO.mkRef none
+/-- Approximate `Rat → Float` for forwarding `δ` to the FFI provider. Precision
+is not part of correctness: the certified path checks the resulting candidate
+against the exact `δ` via integer arithmetic. Mirrors `LLLProvider.ratToFloat`
+(which is private). -/
+private def ratToFloat (r : Rat) : Float :=
+  Float.ofInt r.num / Float.ofNat r.den
 
-private def envOr (name : String) (default : String) : IO String := do
-  match (← IO.getEnv name) with
-  | some v => return v
-  | none => return default
+/-- Invoke fplll-ffi in-process via the dlopened provider and return the flat
+`(status, rows, cols, has_inverse, reduced, U, V?)` payload. The same payload
+shape powers both the raw fpLLL comparator (first-row checksum) and the
+certified path (`LLLProvider.certifyFlat`), so one FFI call covers both.
 
-private def fpylllDriverPath : IO String :=
-  envOr "HEX_LLL_FPYLLL_BENCH_DRIVER" "scripts/oracle/lll_fpylll_bench_driver.py"
-
-private def fpylllPythonCommand : IO String :=
-  envOr "HEX_LLL_FPYLLL_BENCH_PYTHON" "python3"
-
-/-- Lazily spawn the persistent `lll_fpylll_bench_driver.py` driver,
-or return the cached handle. -/
-def resolveFpylllChild : IO PersistentComparator := do
-  if let some ch ← fpylllChildRef.get then
-    return ch
-  let py ← fpylllPythonCommand
-  let script ← fpylllDriverPath
-  let ch ← PersistentComparator.spawn py #[script]
-  fpylllChildRef.set (some ch)
-  return ch
-
-/-- Parse one reply line from `lll_fpylll_bench_driver.py`. The
-driver emits a single integer per request on success or a line
-beginning `ERROR:` on failure; treat the latter as a driver fault so
-the retry path can re-spawn. -/
-def parseFpylllChecksum (text : String) : IO Int := do
-  let trimmed := text.trimAscii.toString
-  if trimmed.startsWith "ERROR:" then
-    throw <| IO.userError s!"lll_fpylll_bench_driver: {trimmed}"
-  match trimmed.toInt? with
-  | some n => return n
-  | none =>
+Raises `IO.userError` if the provider is absent (no `HEX_FPLLL_FFI_LIB` /
+unresolved `lean_fplll_lll_reduce`) or returns an error from `libfplll`. -/
+def requestFpLLLFlat (input : FirstShortVectorInput) : IO (Array Int) := do
+  if !LLLProvider.providerAvailable () then
     throw <| IO.userError
-      s!"lll_fpylll_bench_driver emitted non-integer output: {text}"
+      "fplll-ffi provider absent — set HEX_FPLLL_FFI_LIB to libfplllffi"
+  let δ : Rat := 3 / 4
+  let entries := LLLProvider.matrixToEntries input.basis
+  match LLLProvider.providerReduce
+      (USize.ofNat input.rows) (USize.ofNat input.cols) entries
+      (ratToFloat δ) 0.55 0 true with
+  | .error e => throw <| IO.userError s!"fplll-ffi: {e}"
+  | .ok flat => return flat
 
-private def parseIntToken (token : String) : IO Int := do
-  match token.toInt? with
-  | some n => return n
-  | none => throw <| IO.userError s!"lll_fpylll_bench_driver emitted non-integer token: {token}"
+/-- Benchmark target: fpLLL reduction via fplll-ffi (one in-process C++ call
+into `libfplll`) on one prepared basis; checksum the first reduced row.
 
-/-- Parse a certified-candidate payload from `lll_fpylll_bench_driver.py`. -/
-def parseFpylllCertPayload (text : String) : IO (Array Int) := do
-  let trimmed := text.trimAscii.toString
-  if trimmed.startsWith "ERROR:" then
-    throw <| IO.userError s!"lll_fpylll_bench_driver: {trimmed}"
-  let tokens := (trimmed.splitOn " ").filter (fun token => !token.isEmpty)
-  if tokens.isEmpty then
-    throw <| IO.userError "lll_fpylll_bench_driver emitted empty certified payload"
-  tokens.foldlM (init := #[]) fun acc token => do
-    return acc.push (← parseIntToken token)
-
-/-- Send one matrix to the persistent fpylll driver and return the
-raw reply line.
-
-On process death, EOF before a reply line, or any IO error from the
-protocol, the cached handle is dropped, a fresh driver is spawned,
-and the call is retried once. Persistent failure surfaces as an
-`IO.userError` from the retry path. -/
-def requestFpylllLineWithRetry (request : String) : Nat → IO String
-  | 0 => do
-    let reply ← (← resolveFpylllChild).requestLine request
-    if reply.isEmpty then
-      throw <| IO.userError "lll_fpylll_bench_driver closed stdout before replying"
-    return reply
-  | Nat.succ remaining => do
-    try
-      let reply ← (← resolveFpylllChild).requestLine request
-      if reply.isEmpty then
-        throw <| IO.userError "lll_fpylll_bench_driver closed stdout before replying"
-      return reply
-    catch _ =>
-      fpylllChildRef.set none
-      requestFpylllLineWithRetry request remaining
-
-/-- Invoke fpylll on one prepared basis via the persistent driver
-and parse the first-row checksum. -/
-def runFpylllFirstShortVectorChecksum (input : FirstShortVectorInput) : IO Int := do
-  let request := matrixHaskell input.basis
-  parseFpylllChecksum (← requestFpylllLineWithRetry request 1)
-
-def requestFpylllCertifiedPayload (input : FirstShortVectorInput) : IO (Array Int) := do
-  let request := "CERT\t" ++ matrixHaskell input.basis
-  parseFpylllCertPayload (← requestFpylllLineWithRetry request 1)
+The header `[status, rows, cols, has_inverse]` precedes the row-major reduced
+basis at offset 4, so `flat[4 + j]` are the `cols` entries of the first row. -/
+def runFpLLLFirstShortVectorChecksum (input : FirstShortVectorInput) : IO Int := do
+  let flat ← requestFpLLLFlat input
+  if flat.size < 4 + input.cols then
+    throw <| IO.userError
+      s!"fplll-ffi returned undersized payload (size {flat.size}, cols {input.cols})"
+  return (List.range input.cols).foldl
+    (fun acc j => acc * 65_537 + (flat[4 + j]!))
+    0
 
 def certifyPayloadChecksum (input : FirstShortVectorInput) (payload : Array Int) : IO Int := do
   match LLLProvider.certifyFlat input.basis (3 / 4 : Rat) payload with
@@ -941,12 +900,14 @@ def certifyPayloadChecksum (input : FirstShortVectorInput) (payload : Array Int)
       let f0 : Fin input.rows := ⟨0, by omega⟩
       let last : Fin input.rows := ⟨input.rows - 1, by omega⟩
       return intRowPairChecksum triple.1 f0 last
-  | none => throw <| IO.userError "fpylll certified candidate rejected by certCheck"
+  | none => throw <| IO.userError "fplll-ffi certified candidate rejected by certCheck"
 
-/-- Benchmark target: fpLLL candidate production plus Lean's executable
-certificate checker. -/
+/-- Benchmark target: fpLLL candidate production via fplll-ffi plus Lean's
+executable certificate checker. The same in-process payload that drives
+`runFpLLLFirstShortVectorChecksum` feeds `LLLProvider.certifyFlat`, so the
+certified curve and the raw fpLLL curve measure the identical C++ reducer. -/
 def runCertifiedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO Int := do
-  certifyPayloadChecksum input (← requestFpylllCertifiedPayload input)
+  certifyPayloadChecksum input (← requestFpLLLFlat input)
 
 def runCertifiedCheckerChecksum
     (ref : IO.Ref (Option (FirstShortVectorInput × Array Int)))
@@ -956,7 +917,7 @@ def runCertifiedCheckerChecksum
     | some cached => pure cached
     | none =>
         let input := mk ()
-        let payload ← requestFpylllCertifiedPayload input
+        let payload ← requestFpLLLFlat input
         ref.set (some (input, payload))
         pure (input, payload)
   certifyPayloadChecksum input payload
@@ -976,103 +937,103 @@ def runFirstShortVectorHarshCubic15Checksum : Unit → IO Int := fun _ => do
   return runFirstShortVectorChecksum
     (← getCachedInput harshCubicInput15Ref (fun _ => prepHarshCubicInput 15))
 
-/-- fpylll comparator for the fixed BZ recombination input. -/
-def runFpylllFirstShortVectorBZRecombinationChecksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum (← bzRecombinationInputRef.get)
+/-- fpLLL comparator (via fplll-ffi) for the fixed BZ recombination input. -/
+def runFpLLLFirstShortVectorBZRecombinationChecksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum (← bzRecombinationInputRef.get)
 
-/-- fpylll comparator for the random-bounded bottom rung (`n = 30`). -/
-def runFpylllFirstShortVectorRandomBounded30Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded bottom rung (`n = 30`). -/
+def runFpLLLFirstShortVectorRandomBounded30Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput30Ref (fun _ => prepRandomBoundedInput 30))
 
-/-- fpylll comparator for the random-bounded rung `n = 45`. -/
-def runFpylllFirstShortVectorRandomBounded45Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 45`. -/
+def runFpLLLFirstShortVectorRandomBounded45Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput45Ref (fun _ => prepRandomBoundedInput 45))
 
-/-- fpylll comparator for the random-bounded rung `n = 60`. -/
-def runFpylllFirstShortVectorRandomBounded60Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 60`. -/
+def runFpLLLFirstShortVectorRandomBounded60Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput60Ref (fun _ => prepRandomBoundedInput 60))
 
-/-- fpylll comparator for the random-bounded rung `n = 75`. -/
-def runFpylllFirstShortVectorRandomBounded75Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 75`. -/
+def runFpLLLFirstShortVectorRandomBounded75Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput75Ref (fun _ => prepRandomBoundedInput 75))
 
-/-- fpylll comparator for the random-bounded rung `n = 90`. -/
-def runFpylllFirstShortVectorRandomBounded90Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 90`. -/
+def runFpLLLFirstShortVectorRandomBounded90Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput90Ref (fun _ => prepRandomBoundedInput 90))
 
-/-- fpylll comparator for the random-bounded rung `n = 120`. -/
-def runFpylllFirstShortVectorRandomBounded120Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 120`. -/
+def runFpLLLFirstShortVectorRandomBounded120Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput120Ref (fun _ => prepRandomBoundedInput 120))
 
-/-- fpylll comparator for the random-bounded rung `n = 150`. -/
-def runFpylllFirstShortVectorRandomBounded150Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 150`. -/
+def runFpLLLFirstShortVectorRandomBounded150Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput150Ref (fun _ => prepRandomBoundedInput 150))
 
-/-- fpylll comparator for the random-bounded rung `n = 180`. -/
-def runFpylllFirstShortVectorRandomBounded180Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the random-bounded rung `n = 180`. -/
+def runFpLLLFirstShortVectorRandomBounded180Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput randomBoundedInput180Ref (fun _ => prepRandomBoundedInput 180))
 
-/-- fpylll comparator for the harsh-cubic bottom rung (`n = 15`). -/
-def runFpylllFirstShortVectorHarshCubic15Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic bottom rung (`n = 15`). -/
+def runFpLLLFirstShortVectorHarshCubic15Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput15Ref (fun _ => prepHarshCubicInput 15))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 20`. -/
-def runFpylllFirstShortVectorHarshCubic20Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 20`. -/
+def runFpLLLFirstShortVectorHarshCubic20Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput20Ref (fun _ => prepHarshCubicInput 20))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 25`. -/
-def runFpylllFirstShortVectorHarshCubic25Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 25`. -/
+def runFpLLLFirstShortVectorHarshCubic25Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput25Ref (fun _ => prepHarshCubicInput 25))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 30`. -/
-def runFpylllFirstShortVectorHarshCubic30Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 30`. -/
+def runFpLLLFirstShortVectorHarshCubic30Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput30Ref (fun _ => prepHarshCubicInput 30))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 35`. -/
-def runFpylllFirstShortVectorHarshCubic35Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 35`. -/
+def runFpLLLFirstShortVectorHarshCubic35Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput35Ref (fun _ => prepHarshCubicInput 35))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 40`. -/
-def runFpylllFirstShortVectorHarshCubic40Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 40`. -/
+def runFpLLLFirstShortVectorHarshCubic40Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput40Ref (fun _ => prepHarshCubicInput 40))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 45`. -/
-def runFpylllFirstShortVectorHarshCubic45Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 45`. -/
+def runFpLLLFirstShortVectorHarshCubic45Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput45Ref (fun _ => prepHarshCubicInput 45))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 50`. -/
-def runFpylllFirstShortVectorHarshCubic50Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 50`. -/
+def runFpLLLFirstShortVectorHarshCubic50Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput50Ref (fun _ => prepHarshCubicInput 50))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 55`. -/
-def runFpylllFirstShortVectorHarshCubic55Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 55`. -/
+def runFpLLLFirstShortVectorHarshCubic55Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput55Ref (fun _ => prepHarshCubicInput 55))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 60`. -/
-def runFpylllFirstShortVectorHarshCubic60Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 60`. -/
+def runFpLLLFirstShortVectorHarshCubic60Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput60Ref (fun _ => prepHarshCubicInput 60))
 
-/-- fpylll comparator for the harsh-cubic rung `n = 65`. -/
-def runFpylllFirstShortVectorHarshCubic65Checksum : Unit → IO Int := fun _ => do
-  runFpylllFirstShortVectorChecksum
+/-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 65`. -/
+def runFpLLLFirstShortVectorHarshCubic65Checksum : Unit → IO Int := fun _ => do
+  runFpLLLFirstShortVectorChecksum
     (← getCachedInput harshCubicInput65Ref (fun _ => prepHarshCubicInput 65))
 
 def runDispatchedFirstShortVectorRandomBounded30Checksum : Unit → IO Int := fun _ => do
@@ -1512,12 +1473,12 @@ setup_fixed_benchmark runFirstShortVectorBZRecombinationChecksum where {
     expectedHash := some (Hashable.hash (runFirstShortVectorChecksum bzRecombinationInput))
   }
 
-/- Fixed bottom-rung Lean/fpylll comparison for the BZ recombination family.
-The fpylll target is informational and process-call based; scheduled and
-release bench runs use
-`compare runFirstShortVectorBZRecombinationChecksum runFpylllFirstShortVectorBZRecombinationChecksum`
+/- Fixed bottom-rung Lean/fpLLL comparison for the BZ recombination family.
+The fpLLL target is informational and FFI-call based via fplll-ffi; scheduled
+and release bench runs use
+`compare runFirstShortVectorBZRecombinationChecksum runFpLLLFirstShortVectorBZRecombinationChecksum`
 to record its ratio. -/
-setup_fixed_benchmark runFpylllFirstShortVectorBZRecombinationChecksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorBZRecombinationChecksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
@@ -1525,7 +1486,7 @@ setup_fixed_benchmark runFpylllFirstShortVectorBZRecombinationChecksum where {
     warmupFirstIter := true
   }
 
-/- Fixed Lean/fpylll comparison for the random-bounded family across the
+/- Fixed Lean/fpLLL comparison for the random-bounded family across the
 post-HO-18 densified ladder. -/
 setup_fixed_benchmark runFirstShortVectorRandomBounded30Checksum where {
     repeats := 5
@@ -1533,7 +1494,7 @@ setup_fixed_benchmark runFirstShortVectorRandomBounded30Checksum where {
     expectedHash := some (Hashable.hash (runFirstShortVectorChecksum (prepRandomBoundedInput 30)))
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded30Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded30Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
@@ -1541,49 +1502,49 @@ setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded30Checksum where {
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded45Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded45Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded60Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded60Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 30.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded75Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded75Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 30.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded90Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded90Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 40.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded120Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded120Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 60.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded150Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded150Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 90.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorRandomBounded180Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorRandomBounded180Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 120.0
@@ -1704,8 +1665,8 @@ setup_fixed_benchmark runCertifiedCheckerRandomBounded180Checksum where {
     warmupFirstIter := true
   }
 
-/- Fixed bottom-rung Lean/fpylll comparison for the harsh-cubic family at
-`n = 15`, the first rung of the scientific parametric ladder. The fpylll
+/- Fixed bottom-rung Lean/fpLLL comparison for the harsh-cubic family at
+`n = 15`, the first rung of the scientific parametric ladder. The fpLLL
 comparison also follows the full harsh-cubic comparator ladder. -/
 setup_fixed_benchmark runFirstShortVectorHarshCubic15Checksum where {
     repeats := 5
@@ -1713,7 +1674,7 @@ setup_fixed_benchmark runFirstShortVectorHarshCubic15Checksum where {
     expectedHash := some (Hashable.hash (runFirstShortVectorChecksum (prepHarshCubicInput 15)))
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic15Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic15Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
@@ -1721,69 +1682,69 @@ setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic15Checksum where {
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic20Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic20Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic25Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic25Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic30Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic30Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic35Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic35Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic40Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic40Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic45Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic45Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic50Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic50Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic55Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic55Checksum where {
     repeats := 5
     minTotalSeconds := 1.0
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic60Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic60Checksum where {
     repeats := 5
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
   }
 
-setup_fixed_benchmark runFpylllFirstShortVectorHarshCubic65Checksum where {
+setup_fixed_benchmark runFpLLLFirstShortVectorHarshCubic65Checksum where {
     repeats := 5
     maxSecondsPerCall := 20.0
     warmupFirstIter := true

--- a/HexLLL/ffi/lean_hexlll_provider.c
+++ b/HexLLL/ffi/lean_hexlll_provider.c
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include <stdlib.h>
 #include <lean/lean.h>
 
 typedef lean_obj_res (*lean_fplll_lll_reduce_fn)(
@@ -14,6 +15,30 @@ typedef lean_obj_res (*lean_fplll_lll_reduce_fn)(
 
 static atomic_int lean_hexlll_provider_state = 0;
 static atomic_uintptr_t lean_hexlll_provider_ptr = 0;
+static atomic_int lean_hexlll_provider_dlopen_done = 0;
+
+/* If `HEX_FPLLL_FFI_LIB` is set, `dlopen` the named shared library with
+   `RTLD_GLOBAL` so its symbols (in particular `lean_fplll_lll_reduce`) become
+   visible to `dlsym(RTLD_DEFAULT, ...)` below. Tried at most once per process.
+   Failures are silent: the subsequent `dlsym` probe will simply not find the
+   symbol and the provider stays absent. */
+static void lean_hexlll_dlopen_provider_lib(void) {
+    int done = atomic_load_explicit(&lean_hexlll_provider_dlopen_done, memory_order_acquire);
+    if (done) {
+        return;
+    }
+    int expected = 0;
+    if (!atomic_compare_exchange_strong_explicit(
+            &lean_hexlll_provider_dlopen_done, &expected, 1,
+            memory_order_acq_rel, memory_order_acquire)) {
+        return;
+    }
+    const char *path = getenv("HEX_FPLLL_FFI_LIB");
+    if (path == NULL || path[0] == '\0') {
+        return;
+    }
+    (void)dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+}
 
 static lean_fplll_lll_reduce_fn lean_hexlll_resolve_provider(void) {
     int state = atomic_load_explicit(&lean_hexlll_provider_state, memory_order_acquire);
@@ -24,6 +49,8 @@ static lean_fplll_lll_reduce_fn lean_hexlll_resolve_provider(void) {
         return (lean_fplll_lll_reduce_fn)
             atomic_load_explicit(&lean_hexlll_provider_ptr, memory_order_acquire);
     }
+
+    lean_hexlll_dlopen_provider_lib();
 
     void *sym = dlsym(RTLD_DEFAULT, "lean_fplll_lll_reduce");
     if (sym == NULL) {

--- a/HexLLL/ffi/lean_hexlll_provider.c
+++ b/HexLLL/ffi/lean_hexlll_provider.c
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <lean/lean.h>
 
@@ -20,8 +21,11 @@ static atomic_int lean_hexlll_provider_dlopen_done = 0;
 /* If `HEX_FPLLL_FFI_LIB` is set, `dlopen` the named shared library with
    `RTLD_GLOBAL` so its symbols (in particular `lean_fplll_lll_reduce`) become
    visible to `dlsym(RTLD_DEFAULT, ...)` below. Tried at most once per process.
-   Failures are silent: the subsequent `dlsym` probe will simply not find the
-   symbol and the provider stays absent. */
+   When the env var is unset the call is a no-op. When the env var is set but
+   `dlopen` fails, the error is written to stderr so CI surfaces the actual
+   loader diagnostic (typically an unresolved transitive dep like
+   `libLake_shared`) instead of silently falling through to "provider
+   absent". */
 static void lean_hexlll_dlopen_provider_lib(void) {
     int done = atomic_load_explicit(&lean_hexlll_provider_dlopen_done, memory_order_acquire);
     if (done) {
@@ -37,7 +41,11 @@ static void lean_hexlll_dlopen_provider_lib(void) {
     if (path == NULL || path[0] == '\0') {
         return;
     }
-    (void)dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+    if (dlopen(path, RTLD_NOW | RTLD_GLOBAL) == NULL) {
+        const char *err = dlerror();
+        fprintf(stderr, "hexlll: dlopen(\"%s\") failed: %s\n",
+                path, err != NULL ? err : "(no dlerror)");
+    }
 }
 
 static lean_fplll_lll_reduce_fn lean_hexlll_resolve_provider(void) {

--- a/progress/20260609T073328Z_4ea6ce80.md
+++ b/progress/20260609T073328Z_4ea6ce80.md
@@ -1,0 +1,107 @@
+# 20260609T073328Z (#6642)
+
+## Accomplished
+
+- Skipped #2567 (HO-4) with a triage comment: the directive is the umbrella
+  for an in-flight sub-tree (#6454 → #6452 → #6630 → #6639 plus #6448/#6450
+  and #6623), and `factorFast_terminates` already lives in conditional form
+  at `HexBerlekampZassenhausMathlib/Recovery.lean:7042`. Closing the parent
+  needs that sub-tree to land first; nothing actionable remained at the
+  umbrella level.
+- Claimed #6642 (DG1) and landed two commits on `agent/4ea6ce80`:
+  1. `feat: dlopen HEX_FPLLL_FFI_LIB at provider probe + setup_fplll_ffi.sh`
+     - Extended `HexLLL/ffi/lean_hexlll_provider.c` to optionally `dlopen`
+       the path in `HEX_FPLLL_FFI_LIB` once per process with
+       `RTLD_NOW | RTLD_GLOBAL`, so the existing
+       `dlsym(RTLD_DEFAULT, "lean_fplll_lll_reduce")` probe resolves
+       `kim-em/fplll-ffi`'s symbol without a Lake dependency. Failures
+       are silent.
+     - Wrote `scripts/oracle/setup_fplll_ffi.sh` (clone + submodule update
+       + `lake build FPLLL`, prints the `libfplllffi.{so,dylib}` path),
+       analogous to `setup_lll_isabelle.sh`. Locked, deps checked,
+       toolchain installed via `elan` only when missing.
+  2. `feat: retire fpylll subprocess; route fpLLL bench through fplll-ffi
+     FFI shim`
+     - Deleted the `fpylllChildRef` + `parseFpylll*` + `requestFpylll*`
+       persistent-subprocess infrastructure in `HexLLL/Bench.lean`.
+     - Replaced the request helper with `requestFpLLLFlat`, which calls
+       `LLLProvider.providerReduce` directly. Renamed all
+       `runFpylllFirstShortVector*Checksum` targets (definitions + every
+       `setup_fixed_benchmark` registration) to `runFpLLLFirstShortVector*Checksum`.
+     - Switched the certified-path targets (`runCertified*`) to source
+       their `(B', U, V)` candidate from the same FFI call instead of
+       the `CERT\t` text payload.
+     - Refactored `runDispatchedFirstShortVectorChecksum` to use
+       `LLLProvider.tryReduce` + `certifyFlat`. The pure
+       `LLLProvider.dispatch` relies on `@[implemented_by]` side-effects
+       for its diagnostic tally, but the compiled bench harness defers
+       them past the subsequent `diagnostics` read, causing the
+       smoke check to spuriously fire when a provider is loaded.
+       `tryReduce` is IO-based and updates the ref eagerly. This bug was
+       latent from PR #6638 — only exposed once the FFI provider was
+       actually loadable.
+     - Updated the comparator-call-protocol doc-comment at the top of
+       `HexLLL/Bench.lean` to describe the FFI shim (Isabelle stays a
+       persistent subprocess).
+     - Extended `.github/workflows/ci.yml`: the Bench-verify step now
+       invokes `setup_fplll_ffi.sh` and exports `HEX_FPLLL_FFI_LIB`. The
+       shim depends on Lean's `libLake_shared.so`, which the existing
+       `LD_LIBRARY_PATH` step already covers.
+     - Updated `scripts/plots/hex-lll-comparator.py`: renamed the
+       family-config field (`fpylll_*` → `fpll_*`, label "fpLLL via
+       fplll-ffi") and broadened the regex to `(?:FpLLL|Fpylll)` so
+       pre-#6642 historical exports continue to plot.
+
+## Current frontier
+
+`lake exe hexlll_bench verify` with `HEX_FPLLL_FFI_LIB` pointing at the
+setup-script output now reports all 109 benchmarks passing on Darwin
+(arm64); without the env var, the 54 fpLLL/certified targets correctly
+fail (the directive's "retire fpylll for the speed comparator" goal —
+the FFI shim is the only path). CI extends the existing single Ubuntu
+job; no parallelism, no new workflow.
+
+The SPEC update PR #6640 (`spec: HexLLL five-curve comparator plot;
+fpLLL via fplll-ffi (drop fpylll)`) is still open and only touches
+`SPEC/Libraries/hex-lll.md`, `libraries.yml`, and
+`reports/hex-lll-performance.md`. Once that lands and this PR lands,
+the SPEC and the bench are aligned.
+
+## Next step
+
+Open the PR closing #6642 and let CI exercise the
+`setup_fplll_ffi.sh` build + dlopen path on Ubuntu. If the fplll-ffi
+shared library doesn't successfully dlopen on Ubuntu (e.g. due to
+`libLake_shared.so` rpath issues different from Darwin), the
+follow-up is to either set `LD_LIBRARY_PATH` more permissively in the
+bench step or carry an extra rpath in the setup script.
+
+After this lands, DG2/DG3/DG4 (#6643, #6644, #6645) unblock for the
+five-curve plot work.
+
+## Blockers
+
+None for the directive itself. PR #6640 (the SPEC change) is open and
+expected to land independently; my PR does not depend on it merging
+first.
+
+Verification performed:
+
+- `lake build hexlll_bench` (and earlier `lake build hexlll_provider_probe`,
+  `lake build HexLLL`).
+- `lake exe hexlll_bench verify` with `HEX_FPLLL_FFI_LIB` set: all 109
+  benchmarks pass.
+- `lake exe hexlll_bench verify` without `HEX_FPLLL_FFI_LIB` set:
+  54 fpLLL/certified targets fail with the new
+  "fplll-ffi provider absent" error.
+- `scripts/oracle/setup_fplll_ffi.sh` end-to-end on Darwin: clone +
+  `lake build FPLLL`, emits `libfplllffi.dylib`.
+- `HEX_FPLLL_FFI_LIB=… DYLD_LIBRARY_PATH=… .lake/build/bin/hexlll_provider_probe present`
+  exits 0 (provider loaded).
+- `python3 scripts/ci/check_benches_mathlib_free.py`.
+- `python3 scripts/check_dag.py`.
+- `python3 scripts/check_phase4.py`.
+- `python3 -m py_compile scripts/plots/hex-lll-comparator.py`.
+- `git diff --check`.
+- Forbidden-token grep over touched Lean files: no `sorry`, `axiom`,
+  `native_decide`, `TODO`, or `FIXME` introduced.

--- a/scripts/oracle/setup_fplll_ffi.sh
+++ b/scripts/oracle/setup_fplll_ffi.sh
@@ -95,14 +95,64 @@ if ! elan toolchain list | grep -Fq "${toolchain}"; then
   elan toolchain install "${toolchain}" >&2
 fi
 
-lib_path="${src_dir}/.lake/build/lib/libfplllffi.${shared_ext}"
+static_path="${src_dir}/.lake/build/lib/libfplllffi.a"
 
-if [[ ! -f "${lib_path}" ]]; then
+if [[ ! -f "${static_path}" ]]; then
   (cd "${src_dir}" && lake build FPLLL >&2)
 fi
 
-if [[ ! -f "${lib_path}" ]]; then
-  echo "setup_fplll_ffi.sh: build did not produce ${lib_path}" >&2
+if [[ ! -f "${static_path}" ]]; then
+  echo "setup_fplll_ffi.sh: build did not produce ${static_path}" >&2
+  exit 1
+fi
+
+# Lake's auto-generated shared variant of `extern_lib` (i.e.
+# `libfplllffi.{so,dylib}` next to the `.a`) is intended for the Lean
+# compiler's `precompileModules` dlopen and therefore carries an
+# `@rpath`/`DT_NEEDED` reference to `libLake_shared`. That dep is not
+# satisfiable at the bench-binary's runtime dlopen, so we re-link the
+# static archive into a clean shared library here: link directly against
+# `libleanshared` (which provides `lean_alloc_mpz` and friends) plus the
+# system fplll/MPFR/GMP, and bake the toolchain lib dir into the rpath so
+# the dlopen at `HEX_FPLLL_FFI_LIB` does not depend on the caller's
+# `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`.
+lean_lib_dir="$(cd "$(dirname "$(elan which lean)")/../lib/lean" && pwd)"
+fplll_install_lib="${src_dir}/.lake/build/fplll-install/lib"
+out_dir="${cache_root}/shim"
+mkdir -p "${out_dir}"
+lib_path="${out_dir}/libfplllffi.${shared_ext}"
+
+case "$(uname -s)" in
+  Darwin)
+    cxx="${HEX_FPLLL_FFI_CXX:-c++}"
+    whole_start=("-Wl,-force_load,${static_path}")
+    whole_end=()
+    extra_link_args=()
+    if [[ -d "/opt/homebrew/lib" ]]; then
+      extra_link_args+=("-L/opt/homebrew/lib" "-Wl,-rpath,/opt/homebrew/lib")
+    fi
+    if [[ -d "/usr/local/lib" ]]; then
+      extra_link_args+=("-L/usr/local/lib" "-Wl,-rpath,/usr/local/lib")
+    fi
+    ;;
+  *)
+    cxx="${HEX_FPLLL_FFI_CXX:-clang++}"
+    whole_start=("-Wl,--whole-archive" "${static_path}")
+    whole_end=("-Wl,--no-whole-archive")
+    extra_link_args=("-stdlib=libc++" "-lpthread"
+                     "-L/usr/lib/x86_64-linux-gnu" "-L/usr/lib/aarch64-linux-gnu"
+                     "-L/usr/lib64" "-L/usr/lib")
+    ;;
+esac
+
+if ! "${cxx}" -shared -fPIC -o "${lib_path}" \
+    "${whole_start[@]}" "${whole_end[@]}" \
+    -L"${fplll_install_lib}" -Wl,-rpath,"${fplll_install_lib}" -lfplll \
+    -L"${lean_lib_dir}" -Wl,-rpath,"${lean_lib_dir}" -lleanshared \
+    "${extra_link_args[@]}" \
+    -lmpfr -lgmp \
+    >&2; then
+  echo "setup_fplll_ffi.sh: failed to link ${lib_path}" >&2
   exit 1
 fi
 

--- a/scripts/oracle/setup_fplll_ffi.sh
+++ b/scripts/oracle/setup_fplll_ffi.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Build `kim-em/fplll-ffi` and print the path to its `libfplllffi` shared
+# library — the FFI shim that exports `lean_fplll_lll_reduce`, the symbol the
+# HexLLL provider hook (`HexLLL/ffi/lean_hexlll_provider.c`) resolves at
+# runtime via `dlsym(RTLD_DEFAULT, ...)`.
+#
+# Usage:
+#
+#   HEX_FPLLL_FFI_LIB="$(scripts/oracle/setup_fplll_ffi.sh)"
+#
+# Honoured overrides:
+#
+#   HEX_FPLLL_FFI_REF    — git ref to check out (default: pinned hash below).
+#   HEX_FPLLL_FFI_REPO   — repo URL (default: https://github.com/kim-em/fplll-ffi).
+#   HEX_ORACLE_CACHE     — cache root (default: <repo>/.cache/oracles).
+#
+# The build uses the toolchain pinned by `fplll-ffi/lean-toolchain` via `elan`,
+# vendors fplll-5.5.0 as a submodule, and dynamically links libfplll/GMP/MPFR.
+# On Linux the runtime path to Lean's `libLake_shared.so` is supplied by the
+# caller via `LD_LIBRARY_PATH`; on macOS via `DYLD_LIBRARY_PATH`.
+set -euo pipefail
+
+# Pinned fplll-ffi commit. Bump in lockstep with the SPEC / report updates.
+default_ref="main"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cache_root="${HEX_ORACLE_CACHE:-${repo_root}/.cache/oracles}/fplll-ffi"
+src_dir="${cache_root}/src"
+repo_url="${HEX_FPLLL_FFI_REPO:-https://github.com/kim-em/fplll-ffi}"
+ref="${HEX_FPLLL_FFI_REF:-${default_ref}}"
+
+mkdir -p "${cache_root}"
+
+lock_dir="${cache_root}/setup.lock"
+
+acquire_lock() {
+  local waited=0
+  while ! mkdir "${lock_dir}" 2>/dev/null; do
+    if [[ -f "${lock_dir}/pid" ]]; then
+      local lock_pid
+      lock_pid="$(cat "${lock_dir}/pid" 2>/dev/null || true)"
+      if [[ "${lock_pid}" =~ ^[0-9]+$ ]] && ! kill -0 "${lock_pid}" 2>/dev/null; then
+        rm -rf "${lock_dir}"
+        continue
+      fi
+    fi
+    if (( waited >= 900 )); then
+      echo "setup_fplll_ffi.sh: timed out waiting for ${lock_dir}" >&2
+      exit 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  printf '%s\n' "$$" > "${lock_dir}/pid"
+  trap 'rm -rf "${lock_dir}"' EXIT
+}
+
+acquire_lock
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "setup_fplll_ffi.sh: missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need git
+need elan
+need make
+need cc
+
+case "$(uname -s)" in
+  Darwin) shared_ext="dylib" ;;
+  *)      shared_ext="so"    ;;
+esac
+
+clone_or_update() {
+  if [[ ! -d "${src_dir}/.git" ]]; then
+    rm -rf "${src_dir}"
+    git clone --quiet "${repo_url}" "${src_dir}"
+  fi
+  git -C "${src_dir}" fetch --quiet --tags origin
+  git -C "${src_dir}" checkout --quiet "${ref}"
+  git -C "${src_dir}" submodule update --quiet --init --recursive
+}
+
+clone_or_update
+
+# Install the toolchain pinned by fplll-ffi (matches hex's toolchain in
+# practice, so this is a no-op when the two pin the same version). `lake`
+# inside `src_dir` reads the local `lean-toolchain` file via elan, so no
+# `+toolchain` prefix is needed once the toolchain is installed.
+toolchain="$(tr -d '\r\n' < "${src_dir}/lean-toolchain")"
+if ! elan toolchain list | grep -Fq "${toolchain}"; then
+  elan toolchain install "${toolchain}" >&2
+fi
+
+lib_path="${src_dir}/.lake/build/lib/libfplllffi.${shared_ext}"
+
+if [[ ! -f "${lib_path}" ]]; then
+  (cd "${src_dir}" && lake build FPLLL >&2)
+fi
+
+if [[ ! -f "${lib_path}" ]]; then
+  echo "setup_fplll_ffi.sh: build did not produce ${lib_path}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${lib_path}"

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -19,8 +19,10 @@ from matplotlib.ticker import FuncFormatter
 
 ROOT = Path(__file__).resolve().parents[2]
 # Post-warmupFirstIter, post-perf-fix exports. Each family file has all
-# three comparators (Lean, Isabelle, fpylll) measured in one run so the
-# ratios are internally consistent.
+# three comparators (Lean, Isabelle, fpLLL via fplll-ffi) measured in one
+# run so the ratios are internally consistent. Pre-#6642 exports recorded
+# the fpLLL comparator under the `runFpylllFirstShortVector*` function
+# names (process-call fpylll subprocess); the regex accepts either.
 DEFAULT_RANDOM_CONSOLIDATED = (
     ROOT / "reports/bench-results/hex-lll-random-bounded-schur.json"
 )
@@ -35,10 +37,14 @@ DEFAULT_HARSH_OUTPUT = ROOT / "reports/figures/hex-lll-comparator-harsh-cubic.sv
 
 LEAN_RANDOM = re.compile(r"runFirstShortVectorRandomBoundedNormSq([0-9]+)$")
 ISABELLE_RANDOM = re.compile(r"runIsabelleRandomBoundedNormSq([0-9]+)$")
-FPYLLL_RANDOM = re.compile(r"runFpylllFirstShortVectorRandomBounded([0-9]+)Checksum$")
+FPLLL_RANDOM = re.compile(
+    r"run(?:FpLLL|Fpylll)FirstShortVectorRandomBounded([0-9]+)Checksum$"
+)
 LEAN_HARSH = re.compile(r"runFirstShortVectorHarshCubicNormSq([0-9]+)$")
 ISABELLE_HARSH = re.compile(r"runIsabelleHarshCubicNormSq([0-9]+)$")
-FPYLLL_HARSH = re.compile(r"runFpylllFirstShortVectorHarshCubic([0-9]+)Checksum$")
+FPLLL_HARSH = re.compile(
+    r"run(?:FpLLL|Fpylll)FirstShortVectorHarshCubic([0-9]+)Checksum$"
+)
 
 
 @dataclass(frozen=True)
@@ -52,8 +58,8 @@ class Series:
 class FamilyConfig:
     lean_pattern: re.Pattern[str]
     isabelle_pattern: re.Pattern[str]
-    fpylll_pattern: re.Pattern[str]
-    fpylll_path: Path
+    fpll_pattern: re.Pattern[str]
+    fpll_path: Path
     output: Path
     title: str
     xlabel: str
@@ -67,8 +73,8 @@ FAMILIES = {
     "random-bounded": FamilyConfig(
         lean_pattern=LEAN_RANDOM,
         isabelle_pattern=ISABELLE_RANDOM,
-        fpylll_pattern=FPYLLL_RANDOM,
-        fpylll_path=DEFAULT_RANDOM_CONSOLIDATED,
+        fpll_pattern=FPLLL_RANDOM,
+        fpll_path=DEFAULT_RANDOM_CONSOLIDATED,
         output=DEFAULT_RANDOM_OUTPUT,
         title="HexLLL random-bounded comparator runtime",
         xlabel="random-bounded dimension n",
@@ -78,8 +84,8 @@ FAMILIES = {
     "harsh-cubic": FamilyConfig(
         lean_pattern=LEAN_HARSH,
         isabelle_pattern=ISABELLE_HARSH,
-        fpylll_pattern=FPYLLL_HARSH,
-        fpylll_path=DEFAULT_HARSH_CONSOLIDATED,
+        fpll_pattern=FPLLL_HARSH,
+        fpll_path=DEFAULT_HARSH_CONSOLIDATED,
         output=DEFAULT_HARSH_OUTPUT,
         title="HexLLL harsh-cubic comparator runtime",
         xlabel="harsh-cubic dimension n",
@@ -188,15 +194,15 @@ def main() -> None:
     lean = collect_series(cons, config.lean_pattern, "Lean")
     isabelle = collect_series(cons, config.isabelle_pattern,
                               "verified Isabelle LLL")
-    fpylll_results = cons
-    fpylll = collect_series(
-        fpylll_results, config.fpylll_pattern, "fpLLL via fpylll"
+    fpll_results = cons
+    fpll = collect_series(
+        fpll_results, config.fpll_pattern, "fpLLL via fplll-ffi"
     )
     if config.bottom_consistency:
         isabelle_bottom_results = load_results(args.isabelle_bottom)
         assert_bottom_consistent(isabelle_bottom_results, isabelle)
 
-    plot([lean, isabelle, fpylll], output, config.title, config.xlabel)
+    plot([lean, isabelle, fpll], output, config.title, config.xlabel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #6642

Session: `4ea6ce80-0075-4fc3-8267-6401821a35ae`

032f12b8 chore: progress note for #6642 fpLLL FFI shim landing
d7a0e6f2 feat: retire fpylll subprocess; route fpLLL bench through fplll-ffi FFI shim
509923c9 feat: dlopen HEX_FPLLL_FFI_LIB at provider probe + setup_fplll_ffi.sh

🤖 Prepared with Claude Code