### PR TITLE
HO-1 fast-core: prove irreducibility from explicit BHKS recovery inputs

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -245,4 +245,41 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible
     (factorFastCoreWithBound_some_factor_count_eq trueSupports hcore_ne h
       htrue hpartition)
 
+/-- Forward-recovery-input form of the fast-core irreducibility wrapper.
+
+This is the proof-facing API for fast-branch callers that already carry the
+BHKS recovery package at the successful lift.  The executable success equation
+is still required to identify the returned factors, but the BHKS data are
+explicit hypotheses; in particular this theorem does not try to reconstruct
+`ExpectedTrueFactors` or the support-partition count from a bare
+`factorFastCoreWithBound = some _` premise. -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat}
+    (hcore_ne : core ≠ 0)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hinputs :
+      BHKS.ForwardRecoveryInputs core (Hex.henselLiftData core k primeData))
+    (h :
+      Hex.factorFastCoreWithBound core B primeData k fuel =
+        some hinputs.expectedFactors)
+    (hindicators :
+      hinputs.expectedIndicators =
+        BHKS.expectedIndicatorArrayOfSupports hinputs.trueSupports)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn hinputs.trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ hinputs.expectedFactors.toList,
+      Hex.ZPoly.Irreducible factor := by
+  have htrue :
+      BHKS.ForwardRecoveryInputs.ExpectedTrueFactors core
+        (BHKS.expectedIndicatorArrayOfSupports hinputs.trueSupports)
+        hinputs.expectedFactors := by
+    rw [← hindicators]
+    exact BHKS.ForwardRecoveryInputs.expectedTrueFactors_of_monic hcore_monic hinputs
+  exact
+    factorFastCoreWithBound_some_factor_zpolyIrreducible hinputs.trueSupports
+      hcore_ne h htrue hpartition
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260609T135733Z_4ee541ed.md
+++ b/progress/20260609T135733Z_4ee541ed.md
@@ -1,0 +1,40 @@
+# 20260609T135733Z (#6676)
+
+## Accomplished
+
+Claimed #6676 and added
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs` in
+`HexBerlekampZassenhausMathlib/PartitionRefinement.lean`.
+
+The new wrapper consumes explicit `BHKS.ForwardRecoveryInputs` at the
+successful lift, plus the support-indicator equality and B8 partition-count
+hypothesis, then packages `ExpectedTrueFactors` through
+`expectedTrueFactors_of_monic` before reusing the existing
+partition-refinement irreducibility theorem.  This keeps the fast-core
+irreducibility API on the sound side: the theorem does not infer BHKS recovery
+data from a bare `factorFastCoreWithBound = some _` premise.
+
+## Current frontier
+
+Fast-core branch callers that already carry forward-recovery data now have a
+direct `Hex.ZPoly.Irreducible` wrapper for the returned `expectedFactors`.
+The theorem still requires callers to identify the executable success result
+with `hinputs.expectedFactors`, and to supply the support-partition count.
+
+## Next step
+
+Use this wrapper from the HO-1 branch assembly issue once the surrounding API
+split exposes the successful fast-branch data at the capstone declaration
+site.
+
+## Blockers
+
+None for this issue.  Verification performed:
+
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement`
+- `lake build HexBerlekampZassenhausMathlib.Recovery`
+- `lake build HexBerlekampZassenhausMathlib.Basic`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Added-line forbidden-token grep over the touched Lean file found no
+  `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Closes #6676

Session: `4ee541ed-2395-46c0-8784-5a0453973abb`

185655ee feat: expose forward-input fast-core irreducibility

🤖 Prepared with Claude Code