### PR TITLE
BZMathlib: add slow-trial entry irreducibility wrapper

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -16344,6 +16344,69 @@ theorem factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (by simpa [Hex.factor_eq_factorWithBound_default] using hmem)
     h_raw
 
+/-- Slow-trial fallback entry irreducibility at an explicit coefficient bound.
+
+When both earlier tiers of `Hex.factorWithBound f B` fail, recorded entries are
+sign-normalised images of raw factors from
+`Hex.factorSlowTrialFactorsWithBound f B`.  This wrapper packages that
+dispatch and the sign-normalisation lift, while leaving the actual
+trial-core irreducibility/completeness obligation as the local `h_trial`
+hypothesis. -/
+theorem factorWithBound_slowTrial_entry_zpolyIrreducible_of_raw
+    {f : Hex.ZPoly} {B : Nat} {entry : Hex.ZPoly × Nat}
+    (hmem : entry ∈ (Hex.factorWithBound f B).factors.toList)
+    (hfast_none : Hex.factorFastFactorsWithBound f B = none)
+    (hmod_none : Hex.factorSlowModularWithBound f B = none)
+    (h_trial :
+      ∀ raw ∈ (Hex.factorSlowTrialFactorsWithBound f B).toList,
+        entry.1 = Hex.normalizeFactorSign raw →
+          Hex.ZPoly.Irreducible raw) :
+    Hex.ZPoly.Irreducible entry.1 := by
+  obtain ⟨rawFactors, hsource, raw, hraw_mem, hentry_eq⟩ :=
+    Hex.factorWithBound_entry_mem_raw_source f B entry hmem
+  have hrawFactors :
+      rawFactors = Hex.factorSlowTrialFactorsWithBound f B := by
+    rcases hsource with hfast | hslow
+    · rw [hfast_none] at hfast
+      cases hfast
+    · rcases hslow with hmod | htrial
+      · rcases hmod with ⟨_, hmod_some⟩
+        unfold Hex.factorSlowModularWithBound at hmod_none
+        rw [hmod_some] at hmod_none
+        simp at hmod_none
+      · exact htrial.2.2
+  rw [hentry_eq]
+  exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
+    (h_trial raw (by simpa [hrawFactors] using hraw_mem) hentry_eq)
+
+/-- Default-precision slow-trial fallback entry wrapper for `Hex.factor`.
+
+This is the `Hex.factor` specialisation of
+`factorWithBound_slowTrial_entry_zpolyIrreducible_of_raw`, shaped for the
+three-tier public capstone: the caller supplies the two failed predecessor
+branches and the raw trial-factor irreducibility witness for the particular
+recorded entry. -/
+theorem factor_slowTrial_entry_zpolyIrreducible_of_raw
+    {f : Hex.ZPoly} {entry : Hex.ZPoly × Nat}
+    (hmem : entry ∈ (Hex.factor f).factors.toList)
+    (hfast_none :
+      Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+        none)
+    (hmod_none :
+      Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+        none)
+    (h_trial :
+      ∀ raw ∈
+          (Hex.factorSlowTrialFactorsWithBound f
+            (Hex.ZPoly.defaultFactorCoeffBound f)).toList,
+        entry.1 = Hex.normalizeFactorSign raw →
+          Hex.ZPoly.Irreducible raw) :
+    Hex.ZPoly.Irreducible entry.1 :=
+  factorWithBound_slowTrial_entry_zpolyIrreducible_of_raw
+    (f := f) (B := Hex.ZPoly.defaultFactorCoeffBound f)
+    (by simpa [Hex.factor_eq_factorWithBound_default] using hmem)
+    hfast_none hmod_none h_trial
+
 /-- **#3987 assembled output theorem.**
 
 Every recorded entry of `Hex.factorWithBound f B` is `Hex.ZPoly.Irreducible`,

--- a/progress/20260609T163921Z_f4ad2317.md
+++ b/progress/20260609T163921Z_f4ad2317.md
@@ -1,0 +1,50 @@
+# 20260609T163921Z (#6687)
+
+## Accomplished
+
+Claimed #6687 and added slow-trial fallback entry wrappers in
+`HexBerlekampZassenhausMathlib/Basic.lean`:
+
+- `factorWithBound_slowTrial_entry_zpolyIrreducible_of_raw`
+- `factor_slowTrial_entry_zpolyIrreducible_of_raw`
+
+These wrappers package the three-tier dispatch proof for the case where both
+`factorFastFactorsWithBound` and `factorSlowModularWithBound` fail, then lift
+raw trial-factor irreducibility through `normalizeFactorSign` to the recorded
+entry.
+
+## Current frontier
+
+This is a coherent partial substrate for the trial fallback, not the full
+trial-core completeness proof requested by #6687. The remaining hard theorem is
+to prove the raw irreducibility premise for the factors emitted by
+`factorSlowTrialFactorsWithBound`, especially the standalone
+`exhaustiveIntegerTrialCoreFactorsWithBound` core residual under the
+default-bound/completeness hypotheses available to the capstone.
+
+The universal statement for arbitrary `B` is not sound: if `B` is too small,
+the trial core can leave a reducible higher-degree residual. The eventual raw
+irreducibility theorem should therefore carry the default-bound divisor
+coefficient/completeness hypotheses, or an equivalent executable branch
+package, rather than quantify over an arbitrary bare bound.
+
+## Next step
+
+Prove a raw trial-core irreducibility theorem for
+`exhaustiveIntegerTrialCoreFactorsWithBound` under the actual capstone
+hypotheses, then feed it into
+`factor_slowTrial_entry_zpolyIrreducible_of_raw`.
+
+## Blockers
+
+None for the wrapper substrate.
+
+Verification performed:
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`
+- `lake build HexBerlekampZassenhausMathlib`
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Added-line forbidden-token grep over touched Lean files: no `sorry`,
+  `axiom`, `native_decide`, `TODO`, or `FIXME`.


### PR DESCRIPTION
Partial progress on #6687

Session: `f4ad2317-97e2-4bcb-8c99-48fd247b05ab`

6e32104a BZMathlib: add slow-trial entry irreducibility wrapper

🤖 Prepared with Claude Code