### PR TITLE
chore: drop certified curves from the harsh-cubic LLL plot

### DIFF
--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -771,8 +771,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_23">
-      <path d="M 69.05 263.267213
-L 507.6 263.267213
+      <path d="M 69.05 263.18742
+L 507.6 263.18742
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
@@ -782,12 +782,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="263.267213" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="263.18742" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1 ms -->
-      <g transform="translate(37.559375 267.066431) scale(0.1 -0.1)">
+      <g transform="translate(37.559375 266.986639) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -797,18 +797,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_25">
-      <path d="M 69.05 187.889761
-L 507.6 187.889761
+      <path d="M 69.05 187.593051
+L 507.6 187.593051
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="187.889761" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="187.593051" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 191.68898) scale(0.1 -0.1)">
+      <g transform="translate(31.196875 191.39227) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -819,18 +819,18 @@ L 507.6 187.889761
     </g>
     <g id="ytick_3">
      <g id="line2d_27">
-      <path d="M 69.05 112.51231
-L 507.6 112.51231
+      <path d="M 69.05 111.998682
+L 507.6 111.998682
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="112.51231" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="111.998682" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 116.311529) scale(0.1 -0.1)">
+      <g transform="translate(24.834375 115.7979) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -842,18 +842,18 @@ L 507.6 112.51231
     </g>
     <g id="ytick_4">
      <g id="line2d_29">
-      <path d="M 69.05 37.134859
-L 507.6 37.134859
+      <path d="M 69.05 36.404312
+L 507.6 36.404312
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="37.134859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="36.404312" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 1 s -->
-      <g transform="translate(47.3 40.934078) scale(0.1 -0.1)">
+      <g transform="translate(47.3 40.203531) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -862,8 +862,8 @@ L 507.6 37.134859
     </g>
     <g id="ytick_5">
      <g id="line2d_31">
-      <path d="M 69.05 302.68048
-L 507.6 302.68048
+      <path d="M 69.05 302.714109
+L 507.6 302.714109
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
@@ -873,367 +873,367 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="302.68048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="302.714109" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_33">
-      <path d="M 69.05 293.262916
-L 507.6 293.262916
+      <path d="M 69.05 293.269444
+L 507.6 293.269444
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="293.262916" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="293.269444" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_35">
-      <path d="M 69.05 285.958086
-L 507.6 285.958086
+      <path d="M 69.05 285.943593
+L 507.6 285.943593
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="285.958086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="285.943593" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_37">
-      <path d="M 69.05 279.989606
-L 507.6 279.989606
+      <path d="M 69.05 279.957936
+L 507.6 279.957936
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="279.989606" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="279.957936" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_39">
-      <path d="M 69.05 274.943328
-L 507.6 274.943328
+      <path d="M 69.05 274.897136
+L 507.6 274.897136
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="274.943328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="274.897136" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_41">
-      <path d="M 69.05 270.572042
-L 507.6 270.572042
+      <path d="M 69.05 270.513271
+L 507.6 270.513271
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="270.572042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="270.513271" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_43">
-      <path d="M 69.05 266.716296
-L 507.6 266.716296
+      <path d="M 69.05 266.646429
+L 507.6 266.646429
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="266.716296" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="266.646429" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_45">
-      <path d="M 69.05 240.576339
-L 507.6 240.576339
+      <path d="M 69.05 240.431247
+L 507.6 240.431247
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="240.576339" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="240.431247" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_47">
-      <path d="M 69.05 227.303028
-L 507.6 227.303028
+      <path d="M 69.05 227.11974
+L 507.6 227.11974
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="227.303028" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="227.11974" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_49">
-      <path d="M 69.05 217.885465
-L 507.6 217.885465
+      <path d="M 69.05 217.675075
+L 507.6 217.675075
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="217.885465" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="217.675075" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_51">
-      <path d="M 69.05 210.580635
-L 507.6 210.580635
+      <path d="M 69.05 210.349223
+L 507.6 210.349223
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="210.580635" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="210.349223" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_53">
-      <path d="M 69.05 204.612155
-L 507.6 204.612155
+      <path d="M 69.05 204.363567
+L 507.6 204.363567
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="204.612155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="204.363567" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_55">
-      <path d="M 69.05 199.565876
-L 507.6 199.565876
+      <path d="M 69.05 199.302767
+L 507.6 199.302767
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="199.565876" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="199.302767" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_57">
-      <path d="M 69.05 195.194591
-L 507.6 195.194591
+      <path d="M 69.05 194.918902
+L 507.6 194.918902
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="195.194591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="194.918902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_59">
-      <path d="M 69.05 191.338844
-L 507.6 191.338844
+      <path d="M 69.05 191.052059
+L 507.6 191.052059
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="191.338844" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="191.052059" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_61">
-      <path d="M 69.05 165.198888
-L 507.6 165.198888
+      <path d="M 69.05 164.836878
+L 507.6 164.836878
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="165.198888" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="164.836878" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_63">
-      <path d="M 69.05 151.925577
-L 507.6 151.925577
+      <path d="M 69.05 151.525371
+L 507.6 151.525371
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="151.925577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="151.525371" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_65">
-      <path d="M 69.05 142.508014
-L 507.6 142.508014
+      <path d="M 69.05 142.080706
+L 507.6 142.080706
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="142.508014" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="142.080706" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_67">
-      <path d="M 69.05 135.203184
-L 507.6 135.203184
+      <path d="M 69.05 134.754854
+L 507.6 134.754854
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="135.203184" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="134.754854" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_69">
-      <path d="M 69.05 129.234703
-L 507.6 129.234703
+      <path d="M 69.05 128.769198
+L 507.6 128.769198
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="129.234703" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="128.769198" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_71">
-      <path d="M 69.05 124.188425
-L 507.6 124.188425
+      <path d="M 69.05 123.708398
+L 507.6 123.708398
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="124.188425" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="123.708398" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_73">
-      <path d="M 69.05 119.81714
-L 507.6 119.81714
+      <path d="M 69.05 119.324533
+L 507.6 119.324533
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="119.81714" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="119.324533" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_75">
-      <path d="M 69.05 115.961393
-L 507.6 115.961393
+      <path d="M 69.05 115.45769
+L 507.6 115.45769
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="115.961393" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="115.45769" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_77">
-      <path d="M 69.05 89.821436
-L 507.6 89.821436
+      <path d="M 69.05 89.242509
+L 507.6 89.242509
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="89.821436" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="89.242509" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_79">
-      <path d="M 69.05 76.548126
-L 507.6 76.548126
+      <path d="M 69.05 75.931001
+L 507.6 75.931001
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="76.548126" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="75.931001" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_81">
-      <path d="M 69.05 67.130562
-L 507.6 67.130562
+      <path d="M 69.05 66.486336
+L 507.6 66.486336
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="67.130562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="66.486336" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_83">
-      <path d="M 69.05 59.825733
-L 507.6 59.825733
+      <path d="M 69.05 59.160485
+L 507.6 59.160485
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="59.825733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="59.160485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_85">
-      <path d="M 69.05 53.857252
-L 507.6 53.857252
+      <path d="M 69.05 53.174829
+L 507.6 53.174829
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="53.857252" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="53.174829" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_87">
-      <path d="M 69.05 48.810974
-L 507.6 48.810974
+      <path d="M 69.05 48.114028
+L 507.6 48.114028
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="48.810974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="48.114028" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_89">
-      <path d="M 69.05 44.439689
-L 507.6 44.439689
+      <path d="M 69.05 43.730164
+L 507.6 43.730164
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="44.439689" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="43.730164" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_91">
-      <path d="M 69.05 40.583942
-L 507.6 40.583942
+      <path d="M 69.05 39.863321
+L 507.6 39.863321
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="40.583942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="39.863321" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1341,17 +1341,17 @@ z
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 285.011623
-L 128.852273 246.454919
-L 168.720455 216.675724
-L 208.588636 189.45109
-L 248.456818 165.782879
-L 288.325 142.968173
-L 328.193182 121.571132
-L 368.061364 102.494292
-L 407.929545 84.642874
-L 447.797727 68.67599
-L 487.665909 52.714462
+    <path d="M 88.984091 284.994406
+L 128.852273 246.326745
+L 168.720455 216.461852
+L 208.588636 189.158872
+L 248.456818 165.422551
+L 288.325 142.54219
+L 328.193182 121.083573
+L 368.061364 101.951835
+L 407.929545 84.049044
+L 447.797727 68.036211
+L 487.665909 52.028749
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m7b4dcb6f5d" d="M 0 3
@@ -1367,31 +1367,31 @@ z
 " style="stroke: #1f77b4"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m7b4dcb6f5d" x="88.984091" y="285.011623" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="128.852273" y="246.454919" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="168.720455" y="216.675724" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="208.588636" y="189.45109" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="248.456818" y="165.782879" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="288.325" y="142.968173" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="328.193182" y="121.571132" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="368.061364" y="102.494292" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="407.929545" y="84.642874" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="447.797727" y="68.67599" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="487.665909" y="52.714462" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="88.984091" y="284.994406" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="128.852273" y="246.326745" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="168.720455" y="216.461852" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="208.588636" y="189.158872" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="248.456818" y="165.422551" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="288.325" y="142.54219" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="328.193182" y="121.083573" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="368.061364" y="101.951835" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="407.929545" y="84.049044" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="447.797727" y="68.036211" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#m7b4dcb6f5d" x="487.665909" y="52.028749" style="fill: #1f77b4; stroke: #1f77b4"/>
     </g>
    </g>
    <g id="line2d_94">
-    <path d="M 88.984091 272.109988
-L 128.852273 237.86845
-L 168.720455 209.087969
-L 208.588636 180.84782
-L 248.456818 155.163893
-L 288.325 131.188465
-L 328.193182 109.410202
-L 368.061364 89.97012
-L 407.929545 70.94492
-L 447.797727 53.984059
-L 487.665909 38.811177
+    <path d="M 88.984091 272.055643
+L 128.852273 237.715566
+L 168.720455 208.852262
+L 208.588636 180.530845
+L 248.456818 154.773006
+L 288.325 130.728582
+L 328.193182 108.887647
+L 368.061364 89.391621
+L 407.929545 70.31167
+L 447.797727 53.302
+L 487.665909 38.085455
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="mb5668b3afc" d="M -3 3
@@ -1402,116 +1402,51 @@ z
 " style="stroke: #ff7f0e; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#mb5668b3afc" x="88.984091" y="272.109988" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="128.852273" y="237.86845" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="168.720455" y="209.087969" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="208.588636" y="180.84782" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="248.456818" y="155.163893" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="288.325" y="131.188465" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="328.193182" y="109.410202" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="368.061364" y="89.97012" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="407.929545" y="70.94492" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="447.797727" y="53.984059" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="487.665909" y="38.811177" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="88.984091" y="272.055643" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="128.852273" y="237.715566" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="168.720455" y="208.852262" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="208.588636" y="180.530845" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="248.456818" y="154.773006" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="288.325" y="130.728582" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="328.193182" y="108.887647" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="368.061364" y="89.391621" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="407.929545" y="70.31167" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="447.797727" y="53.302" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#mb5668b3afc" x="487.665909" y="38.085455" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_95">
-    <path d="M 88.984091 267.295173
-L 128.852273 235.38624
-L 168.720455 208.170084
-L 208.588636 184.117413
-L 248.456818 161.219236
-L 288.325 138.833058
-L 328.193182 120.047076
-L 368.061364 101.472966
-L 407.929545 84.226553
+    <path d="M 88.984091 290.994545
+L 128.852273 269.338458
+L 168.720455 253.73134
+L 208.588636 240.599027
+L 248.456818 231.803759
+L 288.325 221.19462
+L 328.193182 212.294223
+L 368.061364 205.772481
+L 407.929545 197.662254
+L 447.797727 190.308338
+L 487.665909 185.140583
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m74287dc1b2" d="M -0 4.596194
-L 4.596194 0
-L 0 -4.596194
-L -4.596194 -0
+     <path id="mf7fd5a1298" d="M -0 3.5
+L 3.5 -3.5
+L -3.5 -3.5
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m74287dc1b2" x="88.984091" y="267.295173" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="128.852273" y="235.38624" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="168.720455" y="208.170084" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="208.588636" y="184.117413" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="248.456818" y="161.219236" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="288.325" y="138.833058" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="328.193182" y="120.047076" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="368.061364" y="101.472966" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="407.929545" y="84.226553" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_96">
-    <path d="M 88.984091 164.679288
-L 128.852273 159.91134
-L 168.720455 153.504926
-L 208.588636 142.680731
-L 248.456818 131.435465
-L 288.325 114.886812
-L 328.193182 99.709285
-L 368.061364 83.256917
-L 407.929545 67.100424
-L 447.797727 51.431135
-L 487.665909 38.085455
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-    <defs>
-     <path id="m31811be93e" d="M 0 -3.5
-L -3.5 3.5
-L 3.5 3.5
-z
-" style="stroke: #d62728; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m31811be93e" x="88.984091" y="164.679288" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="128.852273" y="159.91134" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="168.720455" y="153.504926" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="208.588636" y="142.680731" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="248.456818" y="131.435465" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="288.325" y="114.886812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="328.193182" y="99.709285" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="368.061364" y="83.256917" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="407.929545" y="67.100424" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="447.797727" y="51.431135" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="487.665909" y="38.085455" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_97">
-    <path d="M 88.984091 290.994545
-L 128.852273 269.4006
-L 168.720455 253.838267
-L 208.588636 240.743637
-L 248.456818 231.973607
-L 288.325 221.394911
-L 328.193182 212.520054
-L 368.061364 206.017026
-L 407.929545 197.930071
-L 447.797727 190.597257
-L 487.665909 185.444331
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
-    <defs>
-     <path id="m25acbb3ce1" d="M -0 3.5
-L 3.5 -3.5
-L -3.5 -3.5
-z
-" style="stroke: #9467bd; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="290.994545" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="269.4006" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="253.838267" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="240.743637" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="231.973607" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="288.325" y="221.394911" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="212.520054" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="368.061364" y="206.017026" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="197.930071" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="447.797727" y="190.597257" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="185.444331" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="88.984091" y="290.994545" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="128.852273" y="269.338458" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="168.720455" y="253.73134" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="208.588636" y="240.599027" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="248.456818" y="231.803759" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="288.325" y="221.19462" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="328.193182" y="212.294223" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="368.061364" y="205.772481" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="407.929545" y="197.662254" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="447.797727" y="190.308338" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#mf7fd5a1298" x="487.665909" y="185.140583" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1618,7 +1553,7 @@ z
     </g>
    </g>
    <g id="legend_1">
-    <g id="line2d_98">
+    <g id="line2d_96">
      <path d="M 78.05 38.538437
 L 88.05 38.538437
 L 98.05 38.538437
@@ -1655,7 +1590,7 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
      </g>
     </g>
-    <g id="line2d_99">
+    <g id="line2d_97">
      <path d="M 78.05 53.216562
 L 88.05 53.216562
 L 98.05 53.216562
@@ -1665,8 +1600,46 @@ L 98.05 53.216562
      </g>
     </g>
     <g id="text_20">
-     <!-- verified Isabelle native LLL -->
+     <!-- Isabelle native -->
      <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(81.591797 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(142.871094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(206.347656 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(267.871094 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(295.654297 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(384.960938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(416.748047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(480.126953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(541.40625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(580.615234 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(608.398438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_98">
+     <path d="M 78.05 67.894687
+L 88.05 67.894687
+L 98.05 67.894687
+" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#mf7fd5a1298" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- fpLLL via fplll-ffi -->
+     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
 L 2375 4384
@@ -1689,129 +1662,7 @@ Q 1241 4863 1831 4863
 L 2375 4863
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-49" d="M 628 4666
-L 1259 4666
-L 1259 0
-L 628 0
-L 628 4666
-z
-" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-76"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(59.179688 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(120.703125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(161.816406 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(189.599609 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(224.804688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(252.587891 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(314.111328 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(377.587891 0)"/>
-      <use xlink:href="#DejaVuSans-49" transform="translate(409.375 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(438.867188 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(490.966797 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(552.246094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(615.722656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(677.246094 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(705.029297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(732.8125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(794.335938 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(826.123047 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(889.501953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(950.78125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(989.990234 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(1017.773438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1076.953125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1138.476562 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1170.263672 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1225.976562 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1281.689453 0)"/>
-     </g>
-    </g>
-    <g id="line2d_100">
-     <path d="M 78.05 67.894687
-L 88.05 67.894687
-L 98.05 67.894687
-" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m74287dc1b2" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_21">
-     <!-- Lean certified -->
-     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-4c"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(271.931641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(326.912109 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(388.435547 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(429.548828 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(468.757812 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(496.541016 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(531.746094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(559.529297 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(621.052734 0)"/>
-     </g>
-    </g>
-    <g id="line2d_101">
-     <path d="M 78.05 82.572812
-L 88.05 82.572812
-L 98.05 82.572812
-" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m31811be93e" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_22">
-     <!-- verified Isabelle certified-LLL -->
-     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-76"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(59.179688 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(120.703125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(161.816406 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(189.599609 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(224.804688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(252.587891 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(314.111328 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(377.587891 0)"/>
-      <use xlink:href="#DejaVuSans-49" transform="translate(409.375 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(438.867188 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(490.966797 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(552.246094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(615.722656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(677.246094 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(705.029297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(732.8125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(794.335938 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(826.123047 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(881.103516 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(942.626953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(983.740234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1022.949219 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(1050.732422 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1085.9375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1113.720703 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(1175.244141 0)"/>
-      <use xlink:href="#DejaVuSans-2d" transform="translate(1238.720703 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1274.804688 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1330.517578 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1386.230469 0)"/>
-     </g>
-    </g>
-    <g id="line2d_102">
-     <path d="M 78.05 97.250937
-L 88.05 97.250937
-L 98.05 97.250937
-" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m25acbb3ce1" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_23">
-     <!-- fpLLL via fplll-ffi -->
-     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-66"/>
       <use xlink:href="#DejaVuSans-70" transform="translate(35.205078 0)"/>
       <use xlink:href="#DejaVuSans-4c" transform="translate(98.681641 0)"/>

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -1667,8 +1667,46 @@ L 98.05 53.216562
      </g>
     </g>
     <g id="text_17">
-     <!-- verified Isabelle native LLL -->
+     <!-- Isabelle native -->
      <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(81.591797 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(142.871094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(206.347656 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(267.871094 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(295.654297 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(384.960938 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(416.748047 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(480.126953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(541.40625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(580.615234 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(608.398438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_96">
+     <path d="M 78.05 67.894687
+L 88.05 67.894687
+L 98.05 67.894687
+" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m74287dc1b2" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Lean certified -->
+     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
 L 2375 4384
@@ -1691,56 +1729,7 @@ Q 1241 4863 1831 4863
 L 2375 4863
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-49" d="M 628 4666
-L 1259 4666
-L 1259 0
-L 628 0
-L 628 4666
-z
-" transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-76"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(59.179688 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(120.703125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(161.816406 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(189.599609 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(224.804688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(252.587891 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(314.111328 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(377.587891 0)"/>
-      <use xlink:href="#DejaVuSans-49" transform="translate(409.375 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(438.867188 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(490.966797 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(552.246094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(615.722656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(677.246094 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(705.029297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(732.8125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(794.335938 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(826.123047 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(889.501953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(950.78125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(989.990234 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(1017.773438 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1076.953125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(1138.476562 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1170.263672 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1225.976562 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1281.689453 0)"/>
-     </g>
-    </g>
-    <g id="line2d_96">
-     <path d="M 78.05 67.894687
-L 88.05 67.894687
-L 98.05 67.894687
-" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m74287dc1b2" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_18">
-     <!-- Lean certified -->
-     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1767,39 +1756,26 @@ L 98.05 82.572812
      </g>
     </g>
     <g id="text_19">
-     <!-- verified Isabelle certified-LLL -->
+     <!-- Isabelle certified -->
      <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
-      <use xlink:href="#DejaVuSans-76"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(59.179688 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(120.703125 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(161.816406 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(189.599609 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(224.804688 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(252.587891 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(314.111328 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(377.587891 0)"/>
-      <use xlink:href="#DejaVuSans-49" transform="translate(409.375 0)"/>
-      <use xlink:href="#DejaVuSans-73" transform="translate(438.867188 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(490.966797 0)"/>
-      <use xlink:href="#DejaVuSans-62" transform="translate(552.246094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(615.722656 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(677.246094 0)"/>
-      <use xlink:href="#DejaVuSans-6c" transform="translate(705.029297 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(732.8125 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(794.335938 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(826.123047 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(881.103516 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(942.626953 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(983.740234 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1022.949219 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(1050.732422 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(1085.9375 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(1113.720703 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(1175.244141 0)"/>
-      <use xlink:href="#DejaVuSans-2d" transform="translate(1238.720703 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1274.804688 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1330.517578 0)"/>
-      <use xlink:href="#DejaVuSans-4c" transform="translate(1386.230469 0)"/>
+      <use xlink:href="#DejaVuSans-49"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(81.591797 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(142.871094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(206.347656 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(267.871094 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(295.654297 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(323.4375 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(384.960938 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(416.748047 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(471.728516 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(533.251953 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(574.365234 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(613.574219 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(641.357422 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(676.5625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(704.345703 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(765.869141 0)"/>
      </g>
     </g>
     <g id="line2d_98">

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -416,11 +416,17 @@ Architectural asymmetries for this ratio:
 - Hex checks reducedness with `lllReducedInt`; Isabelle confirms reducedness by
   re-running the verified LLL reducer inside `test_certified`.
 
-The embedded comparator plots show five labelled series: Lean native,
-verified Isabelle native LLL, Lean certified, verified Isabelle certified-LLL,
-and fpLLL via fplll-ffi. All five curves span the full committed ladder.
+The random-bounded plot shows five labelled series across the full committed
+ladder: Lean native, Isabelle native, Lean certified, Isabelle certified, and
+fpLLL via fplll-ffi.
 
 ![Random-bounded comparator runtime plot](figures/hex-lll-comparator-random-bounded.svg)
+
+The harsh-cubic plot shows only the three native/fpLLL series. On this family
+the certified paths run slightly slower than their native counterparts (Lean
+certified is `1.05..1.67×` Lean native, per the ratio table above): fpLLL's
+advantage on hard instances is too small to offset the certificate checker, so
+the certified curves add no story and are omitted to keep the figure legible.
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
 

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -89,6 +89,10 @@ class FamilyConfig:
     # the densified file + the standalone Isabelle export.
     consolidated_path: Path | None = None
     bottom_consistency: bool = False
+    # On harsh-cubic the certified paths run slightly slower than their
+    # native counterparts (fpLLL's advantage is too small to offset the
+    # checker), so the certified curves are omitted from that figure.
+    include_certified: bool = True
 
 
 FAMILIES = {
@@ -120,7 +124,19 @@ FAMILIES = {
         title="HexLLL harsh-cubic comparator runtime",
         xlabel="harsh-cubic dimension n",
         consolidated_path=DEFAULT_HARSH_CONSOLIDATED,
+        include_certified=False,
     ),
+}
+
+
+# Marker style keyed by series label, so a curve keeps the same marker
+# whether or not the certified curves are present in a given figure.
+STYLE_BY_LABEL = {
+    "Lean native": {"marker": "o", "linewidth": 2.0},
+    "Isabelle native": {"marker": "s", "linewidth": 2.0},
+    "Lean certified": {"marker": "D", "linewidth": 2.0, "markersize": 6.5},
+    "Isabelle certified": {"marker": "^", "linewidth": 2.0, "markersize": 7.0},
+    "fpLLL via fplll-ffi": {"marker": "v", "linewidth": 2.0, "markersize": 7.0},
 }
 
 
@@ -168,15 +184,13 @@ def seconds_formatter(value: float, _position: int) -> str:
 
 def plot(series: list[Series], output: Path, title: str, xlabel: str) -> None:
     fig, ax = plt.subplots(figsize=(7.2, 4.8))
-    styles = [
-        {"marker": "o", "linewidth": 2.0},
-        {"marker": "s", "linewidth": 2.0},
-        {"marker": "D", "linewidth": 2.0, "markersize": 6.5},
-        {"marker": "^", "linewidth": 2.0, "markersize": 7.0},
-        {"marker": "v", "linewidth": 2.0, "markersize": 7.0},
-    ]
-    for item, style in zip(series, styles, strict=True):
-        ax.plot(item.xs, [y / 1000.0 for y in item.ys], label=item.label, **style)
+    for item in series:
+        ax.plot(
+            item.xs,
+            [y / 1000.0 for y in item.ys],
+            label=item.label,
+            **STYLE_BY_LABEL[item.label],
+        )
 
     ax.set_title(title)
     ax.set_xlabel(xlabel)
@@ -236,34 +250,31 @@ def main() -> None:
 
     cons = load_results(cons_path)
     lean = collect_series(cons, config.lean_pattern, "Lean native")
-    isabelle = collect_series(cons, config.isabelle_pattern,
-                              "verified Isabelle native LLL")
-    fpll_results = cons
-    fpll = collect_series(
-        fpll_results, config.fpll_pattern, "fpLLL via fplll-ffi"
-    )
-    certified_results = load_results(args.certified or config.certified_path)
-    certified = collect_series(
-        certified_results, config.certified_pattern, "Lean certified"
-    )
-    isabelle_certified_results = load_results(
-        args.isabelle_certified or config.isabelle_certified_path
-    )
-    isabelle_certified = collect_series(
-        isabelle_certified_results,
-        config.isabelle_certified_pattern,
-        "verified Isabelle certified-LLL",
-    )
+    isabelle = collect_series(cons, config.isabelle_pattern, "Isabelle native")
+    fpll = collect_series(cons, config.fpll_pattern, "fpLLL via fplll-ffi")
+
+    series = [lean, isabelle]
+    if config.include_certified:
+        certified_results = load_results(args.certified or config.certified_path)
+        certified = collect_series(
+            certified_results, config.certified_pattern, "Lean certified"
+        )
+        isabelle_certified_results = load_results(
+            args.isabelle_certified or config.isabelle_certified_path
+        )
+        isabelle_certified = collect_series(
+            isabelle_certified_results,
+            config.isabelle_certified_pattern,
+            "Isabelle certified",
+        )
+        series += [certified, isabelle_certified]
+    series.append(fpll)
+
     if config.bottom_consistency:
         isabelle_bottom_results = load_results(args.isabelle_bottom)
         assert_bottom_consistent(isabelle_bottom_results, isabelle)
 
-    plot(
-        [lean, isabelle, certified, isabelle_certified, fpll],
-        output,
-        config.title,
-        config.xlabel,
-    )
+    plot(series, output, config.title, config.xlabel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR drops the two certified curves from the harsh-cubic comparator figure, leaving the three native/fpLLL series, and notes why: on harsh-cubic the certified paths run slightly slower than their native counterparts (Lean certified is `1.05..1.67×` Lean native), because fpLLL's advantage on hard instances is too small to offset the certificate checker, so the certified curves add no story there. The random-bounded figure keeps all five curves, where certifying is the interesting `1.94..7.30×` win over the native paths.

It also shortens the random-bounded legend to "Lean native", "Isabelle native", "Lean certified", "Isabelle certified", "fpLLL via fplll-ffi", and keys marker styles by series label so a curve keeps the same marker whether or not the certified curves are present.

🤖 Prepared with Claude Code