### PR TITLE
doc: record HexLLL comparator scaling exponents and constants

### DIFF
--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -430,6 +430,14 @@ the certified curves add no story and are omitted to keep the figure legible.
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
 
+For the asymptotic scaling of these curves — fitted exponents and constant
+factors per method, with reproduction steps — see
+[hex-lll-scaling.md](hex-lll-scaling.md). In brief: the five random-bounded
+methods share one empirical complexity (`~n³`) and differ only by a constant
+factor (Lean certified ~4× smaller than Lean native), while on harsh-cubic the
+native reducers (`~n^5.6`) and fpLLL (`~n^2.2`) have different exponents and
+fan out.
+
 ### Per-call comparator overhead
 
 Both gating and informational comparators are wired through the persistent-subprocess protocol described at the top of `HexLLL/Bench.lean`. The per-call protocol overhead, measured on the audit host, is:

--- a/reports/hex-lll-scaling.md
+++ b/reports/hex-lll-scaling.md
@@ -1,0 +1,136 @@
+# HexLLL Scaling Report
+
+This report fits the asymptotic scaling of the HexLLL comparators — the five
+random-bounded curves and the three harsh-cubic curves of the comparator plot
+(`reports/hex-lll-performance.md`) — so that the *exponent* (which complexity
+class a method is in) and the *constant factor* (how much slower it is than the
+fastest at the same complexity) are recorded as numbers rather than read off a
+log axis by eye. Regenerate it whenever the implementation changes; the
+procedure below is exact and the script reuses the committed bench data the
+plot is built from.
+
+## Model
+
+Each comparator's median wall time is modelled as a power law in the dimension
+`n`,
+
+```
+t(n) = C · n^p
+```
+
+so on a log-log axis the curve is a straight line of slope `p`. Two methods
+with the *same* `p` are parallel there and differ only by the ratio of their
+`C`; two methods with *different* `p` fan out, and no single constant describes
+their gap — only the observed ratio at a stated `n`, which then grows with `n`.
+
+`scripts/plots/hex-lll-scaling.py` fits `p` by ordinary least squares on
+`(log n, log t)` over an asymptotic window of top rungs, and reports:
+
+- **exponent `p`** and the fit **R²** per method;
+- when the family's exponents agree (spread `≤ 0.5`), a **cubic-pinned constant
+  `C₃`** — the geometric mean of `t(n) / n³` over the window, in nanoseconds —
+  and its ratio to the fastest method. `C₃` is scale-invariant exactly when
+  `p ≈ 3`, so it is only emitted for families that share that exponent;
+- when the exponents disagree, the **median at the top rung** and the observed
+  **ratio to the fastest there** instead, with a note that the ratio grows
+  with `n`.
+
+The asymptotic window matters: the small-`n` rungs carry fixed per-call
+overhead (subprocess fork for the Isabelle oracles, GHC start-up, the
+certificate checker's constant term) that bends the fit below the true
+exponent. The defaults are the top rungs of each ladder — random-bounded
+`120–180`, harsh-cubic `40–55` — chosen so the fit sees the asymptote, not the
+warm-up. Both windows fit with R² ≥ 0.997.
+
+## Results
+
+Snapshot below; regenerate with the command in [§Reproduction](#reproduction)
+and replace this block when the numbers move. Each row's data provenance (host,
+commit) is printed above its table.
+
+### random-bounded, rungs 120–180
+
+- `reports/bench-results/hex-lll-certified-carica.json` — host `carica`, commit `4c708c7b`
+- `reports/bench-results/hex-lll-random-bounded-schur.json` — host `carica`, commit `56f34229`
+
+| method | exponent p | R² | C₃ (ns·n³) | × fpLLL |
+|---|---:|---:|---:|---:|
+| Isabelle native | 3.37 | 0.9996 | 1194 | 26.5× |
+| Lean native | 3.03 | 0.9990 | 801 | 17.8× |
+| Isabelle certified | 3.07 | 0.9977 | 407 | 9.0× |
+| Lean certified | 3.22 | 0.9989 | 197 | 4.4× |
+| fpLLL via fplll-ffi | 3.09 | 1.0000 | 45 | 1.0× |
+
+Exponents agree to within 0.33, so the five methods share one complexity
+(empirically `~n³` on this instance family) and differ only by a constant
+factor. The headline reading:
+
+- **Certifying buys ~4× over native at matched provenance.** Lean certified
+  sits at 4.4× fpLLL against Lean native's 17.8× — the same answer for a
+  ~4× smaller constant, because fpLLL produces the basis and Lean only checks
+  it.
+- **Lean beats Isabelle by a constant ~1.5–2× on both rows.** Native
+  26.5/17.8 ≈ 1.5×; certified 9.0/4.4 ≈ 2.0×.
+- **fpLLL's raw constant is ~4× below even Lean certified**, the gap being the
+  checker (two big-integer matmuls plus a small-basis integer Gram–Schmidt),
+  which `reports/hex-lll-performance.md` measures as ~65–73% of the certified
+  path.
+
+### harsh-cubic, rungs 40–55
+
+- `reports/bench-results/hex-lll-harsh-cubic-extended-schur.json` — host `carica`, commit `56f34229`
+
+| method | exponent p | R² | median @ n=55 | × fastest @ n=55 |
+|---|---:|---:|---:|---:|
+| Isabelle native | 5.76 | 0.9997 | 356.0 ms | 48.4× |
+| Lean native | 5.59 | 0.9999 | 234.3 ms | 31.8× |
+| fpLLL via fplll-ffi | 2.21 | 0.9970 | 7.4 ms | 1.0× |
+
+Here the exponents span 3.55: the native reducers scale far worse (`~n^5.6`
+over this window) than fpLLL (`~n^2.2`), so the curves fan out rather than run
+parallel. The constant-factor framing does not apply — the 31.8× / 48.4× gaps
+are the observed ratios at `n=55` and grow with `n`. The harsh-cubic exponents
+are local fits over a narrow high-`n` window; treat them as the slope at these
+rungs, not a proven asymptotic.
+
+This is why the harsh-cubic comparator figure shows only the three
+native/fpLLL curves: the certified path's cost is dominated by its checker at
+the measured rungs (`n ≤ 55`), where it runs slightly slower than native (see
+the ratio tables in `reports/hex-lll-performance.md`). But the diverging
+exponents predict a crossover — because fpLLL pulls away from the natives as
+`n` grows, the certified path (fpLLL + checker) must eventually overtake native
+on harsh-cubic at some `n` beyond the current ladder. Locating that crossover
+is a candidate for a future densified run.
+
+## Reproduction
+
+From the repository root:
+
+```sh
+python3 scripts/plots/hex-lll-scaling.py --all
+```
+
+`--family random-bounded` / `--family harsh-cubic` report a single family;
+`--window-lo` / `--window-hi` override the fit window (for example, to confirm
+the exponent is stable as you widen it, or to fit a freshly added top rung).
+The script reads the same committed exports and bench function-name regexes as
+`scripts/plots/hex-lll-comparator.py`, so its numbers always match the figure.
+
+To refresh the underlying data after an implementation change, re-run the
+HexLLL bench ladders on the bench host (`carica`) per
+`reports/hex-lll-performance.md` and `SPEC/benchmarking.md`, commit the new
+exports, then re-run the command above and update the [§Results](#results)
+tables. The exponent answers "did the change alter the complexity class"; the
+`C₃` / observed-ratio columns answer "by what constant factor did it move."
+
+## Caveats
+
+- The random-bounded native curves (Isabelle native, Lean native, fpLLL) come
+  from one committed run and the two certified curves from another — both on
+  `carica`, slightly different commits. Within each run the ratios are exact;
+  cross-run ratios (for example certified-vs-native) carry mild run-to-run
+  noise. A single consolidated five-way sweep would remove it; the exponents
+  and the ~4× certify-win are well outside that noise.
+- Exponents are fits over a finite window, not proofs. They report the slope at
+  the measured rungs; a wider or higher window can shift them, especially on
+  harsh-cubic where the window is narrow.

--- a/scripts/plots/hex-lll-scaling.py
+++ b/scripts/plots/hex-lll-scaling.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Fit the asymptotic scaling of the HexLLL comparator runtimes.
+
+Each comparator's median wall time is modelled as a power law in the
+dimension `n`,
+
+    t(n)  =  C * n**p ,
+
+so on a log-log axis the curve is a straight line of slope `p`. This script
+re-reads the same committed bench exports the comparator plot uses (so the
+numbers track the figure), fits `p` over an asymptotic window of rungs by
+ordinary least squares on `(log n, log t)`, and reports both the free-fit
+exponent and a cubic-pinned leading constant `C3` that makes the methods'
+constant factors directly comparable.
+
+`C3` is the geometric mean of `t(n) / n**3` over the window, expressed in
+nanoseconds; under the empirical `p ~ 3` it is the per-`n**3` cost, and the
+ratio of two methods' `C3` is their constant-factor gap. The `x fpLLL` column
+normalises `C3` to the fastest method.
+
+Run `--family random-bounded` (default) or `--family harsh-cubic`, or `--all`.
+The data sources, function-name regexes, and family definitions are imported
+from `hex-lll-comparator.py`; this script only fits and tabulates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+
+# Import the sibling comparator module by path (its filename has hyphens, so a
+# normal `import` will not work). Reusing it keeps one source of truth for the
+# committed data files and the bench function-name regexes.
+_spec = importlib.util.spec_from_file_location(
+    "hex_lll_comparator", HERE / "hex-lll-comparator.py"
+)
+cmp = importlib.util.module_from_spec(_spec)
+# Register before exec so the module's @dataclass can resolve its own
+# __module__ (required on Python 3.14+).
+sys.modules["hex_lll_comparator"] = cmp
+_spec.loader.exec_module(cmp)
+
+# Default asymptotic window per family: the top rungs where the curves are
+# straight on a log-log axis. Widen at your peril -- the small-n rungs carry
+# fixed per-call overhead (subprocess fork, GHC start-up) that bends the fit.
+DEFAULT_WINDOW = {
+    "random-bounded": (120, 180),
+    "harsh-cubic": (40, 55),
+}
+
+
+def family_series(family: str) -> list[cmp.Series]:
+    """Reconstruct the plotted series for a family, in slowest-to-fastest order."""
+    config = cmp.FAMILIES[family]
+    cons = cmp.load_results(config.consolidated_path)
+    out = [
+        cmp.collect_series(cons, config.isabelle_pattern, "Isabelle native"),
+        cmp.collect_series(cons, config.lean_pattern, "Lean native"),
+    ]
+    if config.include_certified:
+        ic = cmp.load_results(config.isabelle_certified_path)
+        c = cmp.load_results(config.certified_path)
+        out.append(
+            cmp.collect_series(ic, config.isabelle_certified_pattern,
+                               "Isabelle certified")
+        )
+        out.append(cmp.collect_series(c, config.certified_pattern, "Lean certified"))
+    out.append(cmp.collect_series(cons, config.fpll_pattern, "fpLLL via fplll-ffi"))
+    return out
+
+
+def window_points(series: cmp.Series, lo: int, hi: int) -> tuple[list[int], list[float]]:
+    pts = [(n, y) for n, y in zip(series.xs, series.ys) if lo <= n <= hi]
+    if len(pts) < 2:
+        raise ValueError(
+            f"{series.label}: need >=2 rungs in [{lo}, {hi}], got {[n for n, _ in pts]}"
+        )
+    return [n for n, _ in pts], [y for _, y in pts]
+
+
+def fit_power_law(xs: list[int], ys_ms: list[float]) -> tuple[float, float, float]:
+    """OLS on (log n, log t). Returns (exponent p, intercept logC, R^2)."""
+    lx = [math.log(n) for n in xs]
+    ly = [math.log(y) for y in ys_ms]
+    k = len(xs)
+    mx = sum(lx) / k
+    my = sum(ly) / k
+    sxx = sum((v - mx) ** 2 for v in lx)
+    sxy = sum((a - mx) * (b - my) for a, b in zip(lx, ly))
+    syy = sum((v - my) ** 2 for v in ly)
+    p = sxy / sxx
+    log_c = my - p * mx
+    r2 = (sxy * sxy) / (sxx * syy) if syy > 0 else 1.0
+    return p, log_c, r2
+
+
+def cubic_constant_ns(xs: list[int], ys_ms: list[float]) -> float:
+    """Geometric mean of t(n)/n**3 over the window, in nanoseconds."""
+    logs = [math.log(y * 1_000_000.0) - 3 * math.log(n) for n, y in zip(xs, ys_ms)]
+    return math.exp(sum(logs) / len(logs))
+
+
+def provenance(family: str) -> list[str]:
+    config = cmp.FAMILIES[family]
+    paths = {config.consolidated_path}
+    if config.include_certified:
+        paths.add(config.certified_path)
+        paths.add(config.isabelle_certified_path)
+    lines = []
+    for path in sorted(paths):
+        import json
+
+        env = json.loads(path.read_text())["env"]
+        rel = path.relative_to(ROOT)
+        lines.append(
+            f"- `{rel}` — host `{env.get('hostname')}`, commit "
+            f"`{env.get('git_commit', '?')[:8]}`"
+        )
+    return lines
+
+
+# Exponent spread (max p - min p) below this counts as "a shared exponent":
+# the curves are parallel and a single pinned constant describes the gaps.
+# Above it the curves fan out and only the observed ratio at a fixed rung is
+# meaningful.
+SHARED_EXPONENT_SPREAD = 0.5
+
+
+def report(family: str, lo: int, hi: int) -> str:
+    series = family_series(family)
+    rows = []
+    for s in series:
+        xs, ys = window_points(s, lo, hi)
+        p, _, r2 = fit_power_law(xs, ys)
+        rows.append((s.label, p, r2, cubic_constant_ns(xs, ys), dict(zip(xs, ys))))
+    spread = max(p for _, p, *_ in rows) - min(p for _, p, *_ in rows)
+    shared = spread <= SHARED_EXPONENT_SPREAD
+
+    out = [f"### {family}, rungs {lo}–{hi}", ""]
+    out += provenance(family)
+    out.append("")
+    if shared:
+        fastest = min(c3 for *_, c3, _ in rows)
+        out += [
+            "| method | exponent p | R² | C₃ (ns·n³) | × fpLLL |",
+            "|---|---:|---:|---:|---:|",
+        ]
+        for label, p, r2, c3, _ in rows:
+            out.append(f"| {label} | {p:.2f} | {r2:.4f} | {c3:.0f} | {c3 / fastest:.1f}× |")
+        out += [
+            "",
+            f"Exponents agree to within {spread:.2f}, so the methods share one "
+            "complexity and differ only by a constant factor. `t(n) ≈ C₃·n³` "
+            "nanoseconds; `× fpLLL` is the constant-factor gap to the fastest method.",
+        ]
+    else:
+        fastest_at_hi = min(ys[hi] for *_, ys in rows)
+        out += [
+            "| method | exponent p | R² | median @ n=%d | × fastest @ n=%d |" % (hi, hi),
+            "|---|---:|---:|---:|---:|",
+        ]
+        for label, p, r2, _, ys in rows:
+            out.append(
+                f"| {label} | {p:.2f} | {r2:.4f} | {ys[hi]:.1f} ms "
+                f"| {ys[hi] / fastest_at_hi:.1f}× |"
+            )
+        out += [
+            "",
+            f"Exponents span {spread:.2f} (no shared complexity): the curves fan "
+            "out, so a single constant does not describe the gaps and the ratio is "
+            "the observed one at `n=%d`, growing with `n`." % hi,
+        ]
+    return "\n".join(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--family", choices=sorted(cmp.FAMILIES), default="random-bounded")
+    parser.add_argument("--all", action="store_true", help="Report every family.")
+    parser.add_argument("--window-lo", type=int, default=None)
+    parser.add_argument("--window-hi", type=int, default=None)
+    args = parser.parse_args()
+
+    families = sorted(cmp.FAMILIES) if args.all else [args.family]
+    blocks = []
+    for fam in families:
+        lo = args.window_lo or DEFAULT_WINDOW[fam][0]
+        hi = args.window_hi or DEFAULT_WINDOW[fam][1]
+        blocks.append(report(fam, lo, hi))
+    print("\n\n".join(blocks))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a scaling report (`reports/hex-lll-scaling.md`) and a reproduction script (`scripts/plots/hex-lll-scaling.py`) that fit each HexLLL comparator's runtime to `t = C·n^p` over an asymptotic window, so the complexity class (exponent) and the constant factor between methods are recorded as numbers rather than read off a log axis by eye, and regenerate as the implementation improves. The script reuses the comparator plot's committed exports and bench function-name regexes, so its numbers always track the figure; the report documents the model, the cubic-pinned constant `C₃`, the shared-versus-fanning-exponent distinction, and how to refresh the tables after a bench run.

The headline findings: on random-bounded all five methods share one empirical complexity (`~n³`, R² ≥ 0.998) and differ only by a constant factor — Lean certified sits ~4× below Lean native for the same answer, and Lean beats Isabelle by ~1.5–2× on both the native and certified rows. On harsh-cubic the native reducers (`~n^5.6`) and fpLLL (`~n^2.2`) have different exponents and fan out, which is why that figure carries only the three native/fpLLL curves and why a fpLLL-driven certified crossover is expected at larger `n`.

🤖 Prepared with Claude Code