### PR TITLE
style: order the LLL comparator legend to match the curves at large n

### DIFF
--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -1341,46 +1341,6 @@ z
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 284.994406
-L 128.852273 246.326745
-L 168.720455 216.461852
-L 208.588636 189.158872
-L 248.456818 165.422551
-L 288.325 142.54219
-L 328.193182 121.083573
-L 368.061364 101.951835
-L 407.929545 84.049044
-L 447.797727 68.036211
-L 487.665909 52.028749
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
-    <defs>
-     <path id="m7b4dcb6f5d" d="M 0 3
-C 0.795609 3 1.55874 2.683901 2.12132 2.12132
-C 2.683901 1.55874 3 0.795609 3 0
-C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
-C 1.55874 -2.683901 0.795609 -3 0 -3
-C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
-C -2.683901 -1.55874 -3 -0.795609 -3 0
-C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
-C -1.55874 2.683901 -0.795609 3 0 3
-z
-" style="stroke: #1f77b4"/>
-    </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m7b4dcb6f5d" x="88.984091" y="284.994406" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="128.852273" y="246.326745" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="168.720455" y="216.461852" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="208.588636" y="189.158872" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="248.456818" y="165.422551" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="288.325" y="142.54219" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="328.193182" y="121.083573" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="368.061364" y="101.951835" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="407.929545" y="84.049044" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="447.797727" y="68.036211" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="487.665909" y="52.028749" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
-   </g>
-   <g id="line2d_94">
     <path d="M 88.984091 272.055643
 L 128.852273 237.715566
 L 168.720455 208.852262
@@ -1392,27 +1352,67 @@ L 368.061364 89.391621
 L 407.929545 70.31167
 L 447.797727 53.302
 L 487.665909 38.085455
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="mb5668b3afc" d="M -3 3
+     <path id="m0fee27a2d2" d="M -3 3
 L 3 3
 L 3 -3
 L -3 -3
 z
-" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
+" style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#mb5668b3afc" x="88.984091" y="272.055643" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="128.852273" y="237.715566" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="168.720455" y="208.852262" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="208.588636" y="180.530845" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="248.456818" y="154.773006" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="288.325" y="130.728582" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="328.193182" y="108.887647" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="368.061364" y="89.391621" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="407.929545" y="70.31167" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="447.797727" y="53.302" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="487.665909" y="38.085455" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="88.984091" y="272.055643" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.852273" y="237.715566" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.720455" y="208.852262" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.588636" y="180.530845" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.456818" y="154.773006" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="288.325" y="130.728582" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.193182" y="108.887647" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="368.061364" y="89.391621" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.929545" y="70.31167" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="447.797727" y="53.302" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.085455" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_94">
+    <path d="M 88.984091 284.994406
+L 128.852273 246.326745
+L 168.720455 216.461852
+L 208.588636 189.158872
+L 248.456818 165.422551
+L 288.325 142.54219
+L 328.193182 121.083573
+L 368.061364 101.951835
+L 407.929545 84.049044
+L 447.797727 68.036211
+L 487.665909 52.028749
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m2451d16133" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #ff7f0e"/>
+    </defs>
+    <g clip-path="url(#p5ff047cf5c)">
+     <use xlink:href="#m2451d16133" x="88.984091" y="284.994406" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="246.326745" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="216.461852" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="189.158872" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="165.422551" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="288.325" y="142.54219" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="121.083573" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="368.061364" y="101.951835" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="84.049044" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="447.797727" y="68.036211" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="52.028749" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_95">
@@ -1559,13 +1559,20 @@ L 88.05 38.538437
 L 98.05 38.538437
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7b4dcb6f5d" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m0fee27a2d2" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
-     <!-- Lean native -->
+     <!-- Isabelle native -->
      <g transform="translate(106.05 42.038437) scale(0.1 -0.1)">
       <defs>
+       <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-76" d="M 191 3500
 L 800 3500
 L 1894 563
@@ -1574,40 +1581,6 @@ L 3597 3500
 L 2284 0
 L 1503 0
 L 191 3500
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4c"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(271.931641 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(335.310547 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(396.589844 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(435.798828 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(463.582031 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
-     </g>
-    </g>
-    <g id="line2d_97">
-     <path d="M 78.05 53.216562
-L 88.05 53.216562
-L 98.05 53.216562
-" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mb5668b3afc" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_20">
-     <!-- Isabelle native -->
-     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-49" d="M 628 4666
-L 1259 4666
-L 1259 0
-L 628 0
-L 628 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
@@ -1626,6 +1599,31 @@ z
       <use xlink:href="#DejaVuSans-69" transform="translate(580.615234 0)"/>
       <use xlink:href="#DejaVuSans-76" transform="translate(608.398438 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
+     </g>
+    </g>
+    <g id="line2d_97">
+     <path d="M 78.05 53.216562
+L 88.05 53.216562
+L 98.05 53.216562
+" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m2451d16133" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     </g>
+    </g>
+    <g id="text_20">
+     <!-- Lean native -->
+     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(271.931641 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(335.310547 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(396.589844 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(435.798828 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(463.582031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
      </g>
     </g>
     <g id="line2d_98">

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -1366,6 +1366,35 @@ z
     </g>
    </g>
    <g id="line2d_89">
+    <path d="M 88.984091 223.761859
+L 128.852273 182.711439
+L 168.720455 152.197613
+L 208.588636 128.690872
+L 248.456818 110.754238
+L 328.193182 79.620483
+L 407.929545 57.513863
+L 487.665909 38.085455
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m0fee27a2d2" d="M -3 3
+L 3 3
+L 3 -3
+L -3 -3
+z
+" style="stroke: #1f77b4; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p5ff047cf5c)">
+     <use xlink:href="#m0fee27a2d2" x="88.984091" y="223.761859" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.852273" y="182.711439" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.720455" y="152.197613" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.588636" y="128.690872" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.456818" y="110.754238" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.193182" y="79.620483" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.929545" y="57.513863" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.085455" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_90">
     <path d="M 88.984091 226.940546
 L 128.852273 187.42895
 L 168.720455 158.882078
@@ -1374,9 +1403,9 @@ L 248.456818 120.877179
 L 328.193182 89.551191
 L 407.929545 69.968101
 L 487.665909 52.115207
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m7b4dcb6f5d" d="M 0 3
+     <path id="m2451d16133" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
 C 2.683901 1.55874 3 0.795609 3 0
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
@@ -1386,78 +1415,20 @@ C -2.683901 -1.55874 -3 -0.795609 -3 0
 C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
 C -1.55874 2.683901 -0.795609 3 0 3
 z
-" style="stroke: #1f77b4"/>
+" style="stroke: #ff7f0e"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m7b4dcb6f5d" x="88.984091" y="226.940546" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="128.852273" y="187.42895" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="168.720455" y="158.882078" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="208.588636" y="136.492762" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="248.456818" y="120.877179" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="328.193182" y="89.551191" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="407.929545" y="69.968101" style="fill: #1f77b4; stroke: #1f77b4"/>
-     <use xlink:href="#m7b4dcb6f5d" x="487.665909" y="52.115207" style="fill: #1f77b4; stroke: #1f77b4"/>
-    </g>
-   </g>
-   <g id="line2d_90">
-    <path d="M 88.984091 223.761859
-L 128.852273 182.711439
-L 168.720455 152.197613
-L 208.588636 128.690872
-L 248.456818 110.754238
-L 328.193182 79.620483
-L 407.929545 57.513863
-L 487.665909 38.085455
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
-    <defs>
-     <path id="mb5668b3afc" d="M -3 3
-L 3 3
-L 3 -3
-L -3 -3
-z
-" style="stroke: #ff7f0e; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#mb5668b3afc" x="88.984091" y="223.761859" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="128.852273" y="182.711439" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="168.720455" y="152.197613" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="208.588636" y="128.690872" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="248.456818" y="110.754238" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="328.193182" y="79.620483" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="407.929545" y="57.513863" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     <use xlink:href="#mb5668b3afc" x="487.665909" y="38.085455" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
+     <use xlink:href="#m2451d16133" x="88.984091" y="226.940546" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="187.42895" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="158.882078" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="136.492762" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="120.877179" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="89.551191" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="69.968101" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="52.115207" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 88.984091 265.426265
-L 128.852273 226.666559
-L 168.720455 199.93787
-L 208.588636 178.963999
-L 248.456818 162.357307
-L 328.193182 133.36307
-L 407.929545 112.600903
-L 487.665909 93.604207
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
-    <defs>
-     <path id="m74287dc1b2" d="M -0 4.596194
-L 4.596194 0
-L 0 -4.596194
-L -4.596194 -0
-z
-" style="stroke: #2ca02c; stroke-linejoin: miter"/>
-    </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m74287dc1b2" x="88.984091" y="265.426265" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="128.852273" y="226.666559" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="168.720455" y="199.93787" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="208.588636" y="178.963999" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="248.456818" y="162.357307" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="328.193182" y="133.36307" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="407.929545" y="112.600903" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#m74287dc1b2" x="487.665909" y="93.604207" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-    </g>
-   </g>
-   <g id="line2d_92">
     <path d="M 88.984091 204.978752
 L 128.852273 186.89279
 L 168.720455 168.455463
@@ -1466,23 +1437,52 @@ L 248.456818 135.874929
 L 328.193182 111.18955
 L 407.929545 88.813556
 L 487.665909 73.396953
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m31811be93e" d="M 0 -3.5
+     <path id="ma559d3018c" d="M 0 -3.5
 L -3.5 3.5
 L 3.5 3.5
+z
+" style="stroke: #2ca02c; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p5ff047cf5c)">
+     <use xlink:href="#ma559d3018c" x="88.984091" y="204.978752" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.852273" y="186.89279" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.720455" y="168.455463" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.588636" y="150.785567" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.456818" y="135.874929" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.193182" y="111.18955" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.929545" y="88.813556" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.665909" y="73.396953" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_92">
+    <path d="M 88.984091 265.426265
+L 128.852273 226.666559
+L 168.720455 199.93787
+L 208.588636 178.963999
+L 248.456818 162.357307
+L 328.193182 133.36307
+L 407.929545 112.600903
+L 487.665909 93.604207
+" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="m633b1844ca" d="M -0 4.596194
+L 4.596194 0
+L 0 -4.596194
+L -4.596194 -0
 z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m31811be93e" x="88.984091" y="204.978752" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="128.852273" y="186.89279" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="168.720455" y="168.455463" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="208.588636" y="150.785567" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="248.456818" y="135.874929" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="328.193182" y="111.18955" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="407.929545" y="88.813556" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m31811be93e" x="487.665909" y="73.396953" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="88.984091" y="265.426265" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.852273" y="226.666559" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.720455" y="199.93787" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.588636" y="178.963999" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.456818" y="162.357307" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.193182" y="133.36307" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.929545" y="112.600903" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="487.665909" y="93.604207" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_93">
@@ -1626,13 +1626,20 @@ L 88.05 38.538437
 L 98.05 38.538437
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m7b4dcb6f5d" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4"/>
+      <use xlink:href="#m0fee27a2d2" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
-     <!-- Lean native -->
+     <!-- Isabelle native -->
      <g transform="translate(106.05 42.038437) scale(0.1 -0.1)">
       <defs>
+       <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-76" d="M 191 3500
 L 800 3500
 L 1894 563
@@ -1641,40 +1648,6 @@ L 3597 3500
 L 2284 0
 L 1503 0
 L 191 3500
-z
-" transform="scale(0.015625)"/>
-      </defs>
-      <use xlink:href="#DejaVuSans-4c"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(271.931641 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(335.310547 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(396.589844 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(435.798828 0)"/>
-      <use xlink:href="#DejaVuSans-76" transform="translate(463.582031 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
-     </g>
-    </g>
-    <g id="line2d_95">
-     <path d="M 78.05 53.216562
-L 88.05 53.216562
-L 98.05 53.216562
-" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#mb5668b3afc" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_17">
-     <!-- Isabelle native -->
-     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
-      <defs>
-       <path id="DejaVuSans-49" d="M 628 4666
-L 1259 4666
-L 1259 0
-L 628 0
-L 628 4666
 z
 " transform="scale(0.015625)"/>
       </defs>
@@ -1695,17 +1668,42 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
      </g>
     </g>
+    <g id="line2d_95">
+     <path d="M 78.05 53.216562
+L 88.05 53.216562
+L 98.05 53.216562
+" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m2451d16133" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     </g>
+    </g>
+    <g id="text_17">
+     <!-- Lean native -->
+     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(271.931641 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(335.310547 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(396.589844 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(435.798828 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(463.582031 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
+     </g>
+    </g>
     <g id="line2d_96">
      <path d="M 78.05 67.894687
 L 88.05 67.894687
 L 98.05 67.894687
 " style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m74287dc1b2" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+      <use xlink:href="#ma559d3018c" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
-     <!-- Lean certified -->
+     <!-- Isabelle certified -->
      <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
@@ -1730,34 +1728,6 @@ L 2375 4863
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-4c"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
-      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
-      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
-      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
-      <use xlink:href="#DejaVuSans-63" transform="translate(271.931641 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(326.912109 0)"/>
-      <use xlink:href="#DejaVuSans-72" transform="translate(388.435547 0)"/>
-      <use xlink:href="#DejaVuSans-74" transform="translate(429.548828 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(468.757812 0)"/>
-      <use xlink:href="#DejaVuSans-66" transform="translate(496.541016 0)"/>
-      <use xlink:href="#DejaVuSans-69" transform="translate(531.746094 0)"/>
-      <use xlink:href="#DejaVuSans-65" transform="translate(559.529297 0)"/>
-      <use xlink:href="#DejaVuSans-64" transform="translate(621.052734 0)"/>
-     </g>
-    </g>
-    <g id="line2d_97">
-     <path d="M 78.05 82.572812
-L 88.05 82.572812
-L 98.05 82.572812
-" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
-     <g>
-      <use xlink:href="#m31811be93e" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     </g>
-    </g>
-    <g id="text_19">
-     <!-- Isabelle certified -->
-     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-49"/>
       <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(81.591797 0)"/>
@@ -1776,6 +1746,34 @@ L 98.05 82.572812
       <use xlink:href="#DejaVuSans-69" transform="translate(676.5625 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(704.345703 0)"/>
       <use xlink:href="#DejaVuSans-64" transform="translate(765.869141 0)"/>
+     </g>
+    </g>
+    <g id="line2d_97">
+     <path d="M 78.05 82.572812
+L 88.05 82.572812
+L 98.05 82.572812
+" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m633b1844ca" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_19">
+     <!-- Lean certified -->
+     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(271.931641 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(326.912109 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(388.435547 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(429.548828 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(468.757812 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(496.541016 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(531.746094 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(559.529297 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(621.052734 0)"/>
      </g>
     </g>
     <g id="line2d_98">

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -253,7 +253,10 @@ def main() -> None:
     isabelle = collect_series(cons, config.isabelle_pattern, "Isabelle native")
     fpll = collect_series(cons, config.fpll_pattern, "fpLLL via fplll-ffi")
 
-    series = [lean, isabelle]
+    # Legend follows plot order; order the series slowest-to-fastest at large
+    # n (Isabelle native, Lean native, Isabelle certified, Lean certified,
+    # fpLLL) so the legend reads top-to-bottom like the stacked curves.
+    series = [isabelle, lean]
     if config.include_certified:
         certified_results = load_results(args.certified or config.certified_path)
         certified = collect_series(
@@ -267,7 +270,7 @@ def main() -> None:
             config.isabelle_certified_pattern,
             "Isabelle certified",
         )
-        series += [certified, isabelle_certified]
+        series += [isabelle_certified, certified]
     series.append(fpll)
 
     if config.bottom_consistency:


### PR DESCRIPTION
This PR reorders the HexLLL comparator legend so it reads top-to-bottom in the same order the curves stack at large n — Isabelle native, Lean native, Isabelle certified, Lean certified, fpLLL — by plotting the series slowest-to-fastest. An earlier attempt at this reordering was pushed to a branch that had already auto-merged, so it never reached main; this reapplies the change and regenerates both figures.

🤖 Prepared with Claude Code