### PR TITLE
doc: pin the packed same-lattice certificate in the hex-lll SPEC

### DIFF
--- a/SPEC/Libraries/hex-lll.md
+++ b/SPEC/Libraries/hex-lll.md
@@ -505,9 +505,28 @@ different `(δ, 11/20)`-reduced bases of the same lattice.
 the executable checker `certCheck B B' U V δ η : Bool` returns `true`, where
 `certCheck` verifies, over integer arithmetic only:
 
-- `U.mul B = B'` and `V.mul B' = B` (each a `Matrix.mul` equality), which
-  together give `lattice B = lattice B'` by row-combination composition — no
-  determinant and no matrix-inverse reasoning;
+- `U.mul B = B'` and `V.mul B' = B`, which together give `lattice B =
+  lattice B'` by row-combination composition (no determinant and no
+  matrix-inverse reasoning). In the word-scale regime (every entry of the
+  operands fits in a machine word, and the dimension is large enough to
+  amortize the scans) each product equality `M·A = C` is verified without
+  forming the matrix product: every row of `A` and of `C` is packed into a
+  single integer in balanced base `2^K`, and row `i` of the unformed
+  product is compared as the packed big-integer dot product
+  `Σ_l M[i][l]·packA[l]` against `packC[i]`. The digit width `K` is
+  computed from an entry bound covering both sides (`n · max|M| · max|A| +
+  max|C|`, or any provably sufficient bound) so that every digit `x` of
+  either side satisfies `2·|x| < 2^K`; that bound makes the balanced
+  base-`2^K` representation injective, which is the soundness argument.
+  The packed comparison is complete as well as sound: by linearity of
+  packing it accepts exactly when the products are equal. In this regime
+  the same-lattice clause costs `O(n²)` big-by-small multiplications
+  rather than the `O(n²·m)` entry products of a materialized `Matrix.mul`.
+  Outside the regime packing buys nothing (the packed dot products cost
+  the same bit operations as the materialized product) and the checker
+  falls back to the materialized comparison; the regime test is a
+  short-circuiting comparison scan, and both branches decide exactly
+  `M·A = C`, so acceptance is independent of the regime;
 - `B'` independent and `(δ, η)`-size-reduced and Lovász, read off the integer
   `d`/`ν` representation (`GramSchmidt.Int.data B'`): all `d` positive,
   `η.den·(ν[i][j]).natAbs ≤ η.num·d[j+1]` (the integer form of `|μ| ≤ η`), and


### PR DESCRIPTION
This PR amend SPEC/Libraries/hex-lll.md §Certified external dispatch so the same-lattice certificate is required to be checked by packed single-point evaluation in the word-scale regime: rows of each product equality's right-hand sides packed in balanced base `2^K` at a width derived from an entry bound (the injectivity of the balanced representation is the stated soundness argument), the `n` packed dot products replacing the `O(n²·m)` entry products of a materialized `Matrix.mul`, completeness by linearity of packing, and a materialized-comparison fallback outside the regime so acceptance is independent of the regime.

Sequenced to merge immediately before the implementation PR from https://github.com/kim-em/hex/issues/6741 (HexLLL: replace sameLatticeCert matmul equalities with packed single-point evaluation).

🤖 Prepared with Claude Code