### PR TITLE
feat: packed single-point evaluation for the same-lattice certificate

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -71,17 +71,38 @@ def maxAbs (M : Matrix Int n m) : Nat :=
 def packWidth (M : Matrix Int n n) (A C : Matrix Int n m) : Nat :=
   (n * maxAbs M * maxAbs A + maxAbs C).log2 + 2
 
+/-- Every entry fits in a machine word. Comparison-only scan (no `natAbs`
+allocation) with short-circuit, so matrices with wide entries bail out at the
+first wide entry. -/
+private def wordScale (M : Matrix Int n m) : Bool :=
+  M.toList.all fun row => row.toList.all fun x =>
+    -(2 ^ 62 : Int) < x && x < 2 ^ 62
+
 /-- Packed product-equality certificate: decides `M * A = C` without forming
 the product. Each row of `A` and of `C` is packed into one integer in
 balanced base `2^K` at the width `packWidth M A C`, and row `i` of the
 (unformed) product is compared via the single packed dot product
 `Σ_l M[i][l] · packA[l]`: `n` big-integer dot products in place of the
-`n · m` entry dot products of a materialized `Matrix.mul`. -/
+`n · m` entry dot products of a materialized `Matrix.mul`.
+
+The packed evaluation pays only when the multiplications are big-by-small,
+i.e. when all entries involved are word-scale; on wide entries the packed
+dot products cost the same bit operations as the materialized product while
+the bound scan and the Horner repacking of wide rows add overhead. The
+certificate therefore gates on `wordScale` (a short-circuiting comparison
+scan, so a wide input bails out at its first wide entry) plus a dimension
+floor (below it the fixed cost of the bound scan and packing exceeds the
+whole sub-millisecond comparison) and falls back to the materialized
+comparison otherwise; both branches decide exactly `M * A = C`
+(`mulEqCert_iff`). -/
 def mulEqCert (M : Matrix Int n n) (A C : Matrix Int n m) : Bool :=
-  let K := packWidth M A C
-  let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
-  (List.finRange n).all fun i =>
-    Vector.dotProduct (row M i) packs == packRow K (row C i)
+  if 32 ≤ n && wordScale M && wordScale A && wordScale C then
+    let K := packWidth M A C
+    let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
+    (List.finRange n).all fun i =>
+      Vector.dotProduct (row M i) packs == packRow K (row C i)
+  else
+    M * A == C
 
 private theorem foldl_max_le_init {α : Type} (f : α → Nat) (l : List α) (acc : Nat) :
     acc ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
@@ -323,8 +344,11 @@ complete (`M * A = C` implies `= true`, by congruence through
 `dotProduct_packRow`). -/
 theorem mulEqCert_iff {M : Matrix Int n n} {A C : Matrix Int n m} :
     mulEqCert M A C = true ↔ M * A = C := by
-  simp only [mulEqCert, packWidth, List.all_eq_true, beq_iff_eq,
-    dotProduct_packRow]
+  unfold mulEqCert
+  split
+  case isFalse => exact beq_iff_eq
+  case isTrue _ =>
+  simp only [packWidth, List.all_eq_true, beq_iff_eq, dotProduct_packRow]
   constructor
   · intro h
     apply Vector.ext

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -50,10 +50,324 @@ theorem memLattice_iff_of_mul_eq {B B' : Matrix Int n m} {U V : Matrix Int n n}
   · exact memLattice_of_mul_eq hV
   · exact memLattice_of_mul_eq hU
 
+/-- Horner evaluation of an integer digit list at base `P`. -/
+def packDigits (P : Int) : List Int → Int
+  | [] => 0
+  | x :: xs => x + P * packDigits P xs
+
+/-- Pack the entries of a row as one integer in balanced base `2^K`. -/
+def packRow (K : Nat) (v : Vector Int m) : Int :=
+  packDigits ((2 : Int) ^ K) v.toList
+
+/-- Maximum absolute value of the entries of an integer matrix. -/
+def maxAbs (M : Matrix Int n m) : Nat :=
+  M.toList.foldl
+    (fun acc row => Nat.max acc (row.toList.foldl (fun a x => Nat.max a x.natAbs) 0))
+    0
+
+/-- Digit width at which every entry of `M * A` and of `C` packs injectively:
+`2 · |entry| < 2^K` for all entries, since each is bounded by
+`n · maxAbs M · maxAbs A + maxAbs C`. -/
+def packWidth (M : Matrix Int n n) (A C : Matrix Int n m) : Nat :=
+  (n * maxAbs M * maxAbs A + maxAbs C).log2 + 2
+
+/-- Packed product-equality certificate: decides `M * A = C` without forming
+the product. Each row of `A` and of `C` is packed into one integer in
+balanced base `2^K` at the width `packWidth M A C`, and row `i` of the
+(unformed) product is compared via the single packed dot product
+`Σ_l M[i][l] · packA[l]`: `n` big-integer dot products in place of the
+`n · m` entry dot products of a materialized `Matrix.mul`. -/
+def mulEqCert (M : Matrix Int n n) (A C : Matrix Int n m) : Bool :=
+  let K := packWidth M A C
+  let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
+  (List.finRange n).all fun i =>
+    Vector.dotProduct (row M i) packs == packRow K (row C i)
+
+private theorem foldl_max_le_init {α : Type} (f : α → Nat) (l : List α) (acc : Nat) :
+    acc ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
+  induction l generalizing acc with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      exact Nat.le_trans (Nat.le_max_left acc (f x)) (ih (Nat.max acc (f x)))
+
+private theorem le_foldl_max {α : Type} (f : α → Nat) (l : List α) (acc : Nat)
+    {x : α} (hx : x ∈ l) :
+    f x ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
+  induction l generalizing acc with
+  | nil => cases hx
+  | cons y ys ih =>
+      simp only [List.foldl_cons]
+      rcases List.mem_cons.mp hx with rfl | hmem
+      · exact Nat.le_trans (Nat.le_max_right acc (f x))
+          (foldl_max_le_init f ys (Nat.max acc (f x)))
+      · exact ih (Nat.max acc (f y)) hmem
+
+/-- Every entry of an integer matrix is bounded by the `maxAbs` scan. -/
+theorem natAbs_le_maxAbs (M : Matrix Int n m) (i : Fin n) (j : Fin m) :
+    M[i][j].natAbs ≤ maxAbs M := by
+  have hrow : M[i] ∈ M.toList := by
+    have h : M.toList[i.val]'(by simp) = M[i] := by simp
+    rw [← h]
+    exact List.getElem_mem _
+  have hentry : M[i][j] ∈ M[i].toList := by
+    have h : M[i].toList[j.val]'(by simp) = M[i][j] := by simp
+    rw [← h]
+    exact List.getElem_mem _
+  have hinner : M[i][j].natAbs ≤
+      M[i].toList.foldl (fun a x => Nat.max a x.natAbs) 0 :=
+    le_foldl_max (fun x => x.natAbs) _ 0 hentry
+  have houter :=
+    le_foldl_max
+      (fun row : Vector Int m => row.toList.foldl (fun a x => Nat.max a x.natAbs) 0)
+      M.toList 0 hrow
+  exact Nat.le_trans hinner houter
+
+/-- Packing is linear over a coefficient-times-row update. -/
+theorem packDigits_zipWith_muladd (P c : Int) (r s : List Int)
+    (h : r.length = s.length) :
+    packDigits P (List.zipWith (fun a b => c * a + b) r s) =
+      c * packDigits P r + packDigits P s := by
+  induction r generalizing s with
+  | nil =>
+      cases s with
+      | nil => simp [packDigits]
+      | cons y ys => simp at h
+  | cons x xs ih =>
+      cases s with
+      | nil => simp at h
+      | cons y ys =>
+          simp only [List.zipWith_cons_cons, packDigits]
+          rw [ih ys (by simpa using h)]
+          grind
+
+/-- Row-level form of `packDigits_zipWith_muladd`. -/
+theorem packRow_zipWith_muladd (K : Nat) (c : Int) (r s : Vector Int m) :
+    packRow K (Vector.zipWith (fun a b => c * a + b) r s) =
+      c * packRow K r + packRow K s := by
+  unfold packRow
+  rw [Vector.toList_zipWith]
+  exact packDigits_zipWith_muladd _ c _ _ (by simp)
+
+private theorem packDigits_replicate_zero (P : Int) (m : Nat) :
+    packDigits P (List.replicate m 0) = 0 := by
+  induction m with
+  | zero => rfl
+  | succ m ih => simp [List.replicate_succ, packDigits, ih]
+
+private theorem packRow_replicate_zero (K m : Nat) :
+    packRow K (Vector.replicate m (0 : Int)) = 0 := by
+  unfold packRow
+  rw [Vector.toList_replicate]
+  exact packDigits_replicate_zero _ m
+
+private theorem foldl_dot_pack (K : Nat) (c : Vector Int n) (A : Matrix Int n m)
+    (ls : List (Fin n)) (w : Vector Int m) :
+    ls.foldl (fun acc l => acc + c[l] * packRow K (row A l)) (packRow K w) =
+      packRow K (ls.foldl
+        (fun w l => Vector.zipWith (fun a b => c[l] * a + b) (row A l) w) w) := by
+  induction ls generalizing w with
+  | nil => rfl
+  | cons l ls ih =>
+      simp only [List.foldl_cons]
+      rw [← ih (Vector.zipWith (fun a b => c[l] * a + b) (row A l) w),
+        packRow_zipWith_muladd]
+      grind
+
+private theorem foldl_zipWith_getElem (c : Vector Int n) (A : Matrix Int n m)
+    (ls : List (Fin n)) (w : Vector Int m) (j : Fin m) :
+    (ls.foldl
+        (fun w l => Vector.zipWith (fun a b => c[l] * a + b) (row A l) w) w)[j] =
+      ls.foldl (fun acc l => acc + c[l] * A[l][j]) w[j] := by
+  induction ls generalizing w with
+  | nil => rfl
+  | cons l ls ih =>
+      simp only [List.foldl_cons]
+      rw [ih]
+      have hentry : (Vector.zipWith (fun a b => c[l] * a + b) (row A l) w)[j] =
+          w[j] + c[l] * A[l][j] := by
+        simp only [row]
+        grind
+      rw [hentry]
+
+/-- The packed dot product evaluates to the pack of the corresponding row of
+the (unformed) product `M * A`. -/
+theorem dotProduct_packRow (K : Nat) (M : Matrix Int n n) (A : Matrix Int n m)
+    (i : Fin n) :
+    Vector.dotProduct (row M i) (Vector.ofFn fun l => packRow K (row A l)) =
+      packRow K (row (M * A) i) := by
+  have hstart :
+      Vector.dotProduct (row M i) (Vector.ofFn fun l => packRow K (row A l)) =
+        (List.finRange n).foldl
+          (fun acc l => acc + (row M i)[l] * packRow K (row A l))
+          (packRow K (Vector.replicate m (0 : Int))) := by
+    rw [packRow_replicate_zero]
+    unfold Vector.dotProduct
+    simp only [Fin.getElem_fin, Vector.getElem_ofFn]
+  rw [hstart, foldl_dot_pack]
+  congr 1
+  apply Vector.ext
+  intro j hj
+  have hentry := foldl_zipWith_getElem (row M i) A (List.finRange n)
+    (Vector.replicate m (0 : Int)) ⟨j, hj⟩
+  have htarget : (row (M * A) i)[(⟨j, hj⟩ : Fin m)] =
+      (List.finRange n).foldl
+        (fun acc l => acc + (row M i)[l] * A[l][(⟨j, hj⟩ : Fin m)])
+        ((Vector.replicate m (0 : Int))[(⟨j, hj⟩ : Fin m)]) := by
+    simp only [row_getElem, mul_getElem]
+    unfold dot Vector.dotProduct
+    simp only [col_getElem, row_getElem]
+    simp only [Fin.getElem_fin, Vector.getElem_replicate]
+  exact hentry.trans htarget.symm
+
+/-- Uniqueness of the balanced base-`2^K` representation: digit lists of equal
+length whose digits all satisfy `2 · |digit| < 2^K` pack injectively. -/
+theorem packDigits_inj (K : Nat) {xs ys : List Int}
+    (hlen : xs.length = ys.length)
+    (hxs : ∀ x ∈ xs, 2 * x.natAbs < 2 ^ K)
+    (hys : ∀ y ∈ ys, 2 * y.natAbs < 2 ^ K)
+    (h : packDigits ((2 : Int) ^ K) xs = packDigits ((2 : Int) ^ K) ys) :
+    xs = ys := by
+  induction xs generalizing ys hys with
+  | nil =>
+      cases ys with
+      | nil => rfl
+      | cons y ys => simp at hlen
+  | cons x xs ih =>
+      cases ys with
+      | nil => simp at hlen
+      | cons y ys =>
+          have hx : 2 * x.natAbs < 2 ^ K := hxs x (by simp)
+          have hy : 2 * y.natAbs < 2 ^ K := hys y (by simp)
+          have hPabs : ((2 : Int) ^ K).natAbs = 2 ^ K := by
+            rw [Int.natAbs_pow]
+            rfl
+          simp only [packDigits] at h
+          have hdiff : x - y =
+              (2 : Int) ^ K *
+                (packDigits ((2 : Int) ^ K) ys - packDigits ((2 : Int) ^ K) xs) := by
+            grind
+          have habs : (x - y).natAbs =
+              2 ^ K *
+                (packDigits ((2 : Int) ^ K) ys -
+                  packDigits ((2 : Int) ^ K) xs).natAbs := by
+            rw [hdiff, Int.natAbs_mul, hPabs]
+          by_cases hts :
+              packDigits ((2 : Int) ^ K) ys - packDigits ((2 : Int) ^ K) xs = 0
+          · have hxy : x = y := by
+              rw [hts, Int.mul_zero] at hdiff
+              omega
+            have htail : xs = ys :=
+              ih (by simpa using hlen)
+                (fun a ha => hxs a (List.mem_cons_of_mem _ ha))
+                (fun b hb => hys b (List.mem_cons_of_mem _ hb))
+                (by omega)
+            rw [hxy, htail]
+          · exfalso
+            have h1 : 1 ≤ (packDigits ((2 : Int) ^ K) ys -
+                packDigits ((2 : Int) ^ K) xs).natAbs := by
+              omega
+            have h2 : 2 ^ K ≤ (x - y).natAbs := by
+              rw [habs]
+              exact Nat.le_mul_of_pos_right _ (by omega)
+            omega
+
+private theorem foldl_dot_natAbs_le (u v : Vector Int k) (Bu Bv : Nat)
+    (hu : ∀ l : Fin k, u[l].natAbs ≤ Bu) (hv : ∀ l : Fin k, v[l].natAbs ≤ Bv)
+    (ls : List (Fin k)) (acc : Int) :
+    (ls.foldl (fun acc l => acc + u[l] * v[l]) acc).natAbs ≤
+      acc.natAbs + ls.length * (Bu * Bv) := by
+  induction ls generalizing acc with
+  | nil => simp
+  | cons l ls ih =>
+      simp only [List.foldl_cons, List.length_cons]
+      have hstep : (acc + u[l] * v[l]).natAbs ≤ acc.natAbs + Bu * Bv := by
+        have hmul : (u[l] * v[l]).natAbs ≤ Bu * Bv := by
+          rw [Int.natAbs_mul]
+          exact Nat.mul_le_mul (hu l) (hv l)
+        have htri := Int.natAbs_add_le acc (u[l] * v[l])
+        omega
+      have := ih (acc + u[l] * v[l])
+      have hgoal : acc.natAbs + Bu * Bv + ls.length * (Bu * Bv) =
+          acc.natAbs + (ls.length + 1) * (Bu * Bv) := by
+        rw [Nat.succ_mul]
+        omega
+      omega
+
+/-- Entrywise bound on an integer dot product. -/
+theorem natAbs_dotProduct_le (u v : Vector Int k) (Bu Bv : Nat)
+    (hu : ∀ l : Fin k, u[l].natAbs ≤ Bu) (hv : ∀ l : Fin k, v[l].natAbs ≤ Bv) :
+    (Vector.dotProduct u v).natAbs ≤ k * (Bu * Bv) := by
+  have h := foldl_dot_natAbs_le u v Bu Bv hu hv (List.finRange k) 0
+  simpa [Vector.dotProduct] using h
+
+private theorem two_mul_lt_width {x B : Nat} (hx : x ≤ B) :
+    2 * x < 2 ^ (B.log2 + 2) := by
+  have h1 : B < 2 ^ (B.log2 + 1) := Nat.lt_log2_self
+  have h2 : 2 ^ (B.log2 + 2) = 2 * 2 ^ (B.log2 + 1) := by
+    rw [Nat.pow_succ, Nat.mul_comm]
+  omega
+
+/-- Every entry of the product `M * A` is bounded by the `maxAbs` scans. -/
+theorem natAbs_mul_entry_le (M : Matrix Int n n) (A : Matrix Int n m)
+    (i : Fin n) (j : Fin m) :
+    (M * A)[i][j].natAbs ≤ n * (maxAbs M * maxAbs A) := by
+  rw [mul_getElem]
+  exact natAbs_dotProduct_le _ _ _ _
+    (fun l => natAbs_le_maxAbs M i l)
+    (fun l => by rw [col_getElem]; exact natAbs_le_maxAbs A l j)
+
+/-- The packed certificate decides product equality: sound (`= true` implies
+`M * A = C`, by balanced-digit uniqueness at width `packWidth M A C`) and
+complete (`M * A = C` implies `= true`, by congruence through
+`dotProduct_packRow`). -/
+theorem mulEqCert_iff {M : Matrix Int n n} {A C : Matrix Int n m} :
+    mulEqCert M A C = true ↔ M * A = C := by
+  simp only [mulEqCert, packWidth, List.all_eq_true, beq_iff_eq,
+    dotProduct_packRow]
+  constructor
+  · intro h
+    apply Vector.ext
+    intro i hi
+    have hi' := h ⟨i, hi⟩ (List.mem_finRange _)
+    simp only [packRow] at hi'
+    have hB : ∀ j : Fin m,
+        (M * A)[(⟨i, hi⟩ : Fin n)][j].natAbs ≤
+          n * maxAbs M * maxAbs A + maxAbs C := by
+      intro j
+      have hassoc : n * (maxAbs M * maxAbs A) = n * maxAbs M * maxAbs A :=
+        (Nat.mul_assoc _ _ _).symm
+      have := natAbs_mul_entry_le M A ⟨i, hi⟩ j
+      omega
+    have hrow := packDigits_inj ((n * maxAbs M * maxAbs A + maxAbs C).log2 + 2)
+      (xs := (row (M * A) ⟨i, hi⟩).toList) (ys := (row C ⟨i, hi⟩).toList)
+      (by simp) ?_ ?_ hi'
+    · exact Vector.toList_inj.mp hrow
+    · intro x hx
+      obtain ⟨j, hj, hxe⟩ := List.mem_iff_getElem.mp hx
+      have hjm : j < m := by simpa using hj
+      have hxv : x = (M * A)[(⟨i, hi⟩ : Fin n)][(⟨j, hjm⟩ : Fin m)] := by
+        rw [← hxe]
+        simp [row]
+      rw [hxv]
+      exact two_mul_lt_width (hB ⟨j, hjm⟩)
+    · intro x hx
+      obtain ⟨j, hj, hxe⟩ := List.mem_iff_getElem.mp hx
+      have hjm : j < m := by simpa using hj
+      have hxv : x = C[(⟨i, hi⟩ : Fin n)][(⟨j, hjm⟩ : Fin m)] := by
+        rw [← hxe]
+        simp [row]
+      rw [hxv]
+      exact two_mul_lt_width
+        (Nat.le_trans (natAbs_le_maxAbs C ⟨i, hi⟩ ⟨j, hjm⟩) (by omega))
+  · intro h i _
+    rw [h]
+
 /-- Executable same-lattice certificate: two integer transforms that multiply
-the bases into each other. -/
+the bases into each other. Each product equality is verified by the packed
+certificate `mulEqCert`, so neither product matrix is ever formed. -/
 def sameLatticeCert (B B' : Matrix Int n m) (U V : Matrix Int n n) : Bool :=
-  (U * B == B') && (V * B' == B)
+  mulEqCert U B B' && mulEqCert V B' B
 
 /-- Soundness of `sameLatticeCert`: accepted certificates prove identical
 integer row lattices. -/
@@ -62,12 +376,8 @@ theorem sameLatticeCert_sound {B B' : Matrix Int n m} {U V : Matrix Int n n} :
       ∀ v, B.memLattice v ↔ B'.memLattice v := by
   intro h v
   unfold sameLatticeCert at h
-  simp only [Bool.and_eq_true, beq_iff_eq] at h
-  have hUB : U * B = B' := by
-    exact h.1
-  have hVB : V * B' = B := by
-    exact h.2
-  exact memLattice_iff_of_mul_eq hUB hVB v
+  simp only [Bool.and_eq_true, mulEqCert_iff] at h
+  exact memLattice_iff_of_mul_eq h.1 h.2 v
 
 /-- The rows of `b` are linearly independent, witnessed by positivity of each
 executable leading Gram determinant. -/

--- a/progress/20260610T091250Z_review-6741.md
+++ b/progress/20260610T091250Z_review-6741.md
@@ -1,0 +1,32 @@
+# 20260610T091250Z (#6741 review)
+
+## Accomplished
+
+Reviewed the packed `mulEqCert` replacement in `HexLLL/Basic.lean` for
+soundness, executable-path performance, and reviewer-facing maintainability.
+
+Verification performed:
+
+- `lake build HexLLL.Basic`
+- `lake build HexLLL.Conformance`
+- Forbidden-token grep over the touched Lean files for `sorry`, `axiom`, and
+  `native_decide`
+
+Both builds passed. The only warnings were existing replayed warnings in
+`HexGramSchmidt/Basic.lean` and `HexGramSchmidt/Int.lean`.
+
+## Current frontier
+
+No soundness blocker found in the packed-product certificate. The notable
+review concerns are performance polish in the hot executable path and missing
+direct conformance guards for the new `mulEqCert` helper/edge dimensions.
+
+## Next step
+
+If changing the implementation, prioritize hoisting the packed base
+`(2 : Int) ^ K` out of per-row packing and adding direct conformance guards for
+empty-row/empty-column and negative-entry packed product checks.
+
+## Blockers
+
+No blocker.

--- a/progress/20260610T092824Z_issue-6741.md
+++ b/progress/20260610T092824Z_issue-6741.md
@@ -1,0 +1,61 @@
+# 20260610T092824Z (#6741)
+
+## Accomplished
+
+Claimed #6741, implemented the packed same-lattice certificate, ran the
+paired measurement protocol on carica, and reported a **no-go**: the
+directive's harsh-cubic thresholds cannot be met, so per the go/no-go
+rule no PR was opened. Full comment with the paired table and diagnosis:
+https://github.com/kim-em/hex/issues/6741#issuecomment-4668615524.
+The issue is unassigned and claimable again.
+
+Implementation (branch `issue-6741`, commit c58fb2a7, pushed for
+reference; complete and verified):
+
+- `Matrix.packDigits` / `packRow` (balanced base-`2^K` Horner packing),
+  `maxAbs` (entry-bound scan), `packWidth` (digit width from
+  `n·maxAbs M·maxAbs A + maxAbs C`, `log2 + 2`), `mulEqCert` (the `n`
+  packed dot products), all in `HexLLL/Basic.lean`.
+- `mulEqCert_iff : mulEqCert M A C = true ↔ M * A = C`. Soundness via
+  `packDigits_inj` (balanced-digit uniqueness, `2·|digit| < 2^K`),
+  completeness via `dotProduct_packRow` (pack linearity through the
+  unformed product row). Supporting lemmas: `natAbs_le_maxAbs`,
+  `natAbs_dotProduct_le`, `natAbs_mul_entry_le`,
+  `packDigits_zipWith_muladd` / `packRow_zipWith_muladd`.
+- `sameLatticeCert` rewired to `mulEqCert`; statements of
+  `sameLatticeCert_sound` and `certCheck_sound` unchanged.
+
+Verification: `lake build HexLLL HexLLLMathlib`, `lake exe hexlll_bench
+verify` (128/128), `python3 scripts/check_dag.py`, `git diff --check`,
+forbidden-token grep clean. Codex second opinion: no soundness gap; its
+performance suggestions (hoisting `2^K`, tail-recursive pack) were
+measured immaterial (sub-ms against 100+ ms rungs).
+
+Measurement (before = 01effde1, after = c58fb2a7, both on carica, JSON
+exports at `/tmp/hexlll-packed-{before,after}.json`):
+
+- random-bounded checker improves on every rung, 10.6-18.7%; n=180 full
+  path 1.210 s -> 1.053 s; all hashes identical.
+- harsh-cubic n=55 checker improves only 1.9% (threshold 15%); n=15 and
+  n=30 regress 9.1% / 4.7% (threshold 3%). The same-lattice clause is
+  only ~5 ms of the 240 ms harsh-cubic n=55 checker (the exact
+  Gram-Schmidt clause dominates, per the #6742 diagnosis), so the 15%
+  threshold is unreachable by any same-lattice change.
+
+## Current frontier
+
+The packed certificate is proved sound and complete and sits on branch
+`issue-6741`, unmerged. The directive's hypothesis fails only on the
+harsh-cubic ladder, where `lllReducedInt` dominates the checker.
+
+## Next step
+
+Re-issue #6741 sequenced after #6742: once the reducedness clause drops
+to ms-scale on harsh-cubic, the packed clause's win at n=55 becomes a
+large relative share and thresholds of this shape become meetable. The
+branch can be rebased and re-measured as-is at that point.
+
+## Blockers
+
+None for the project; this directive itself is blocked on its
+thresholds, as reported on the issue.

--- a/progress/20260610T134801Z_followup-review-6741.md
+++ b/progress/20260610T134801Z_followup-review-6741.md
@@ -1,0 +1,27 @@
+# 20260610T134801Z (#6741 follow-up review)
+
+## Accomplished
+
+Reviewed the follow-up gate on `mulEqCert` in `HexLLL/Basic.lean`.
+
+Verification performed:
+
+- `lake build HexLLL.Basic`
+
+The build passed. The only warnings were existing replayed warnings in
+`HexGramSchmidt/Basic.lean` and `HexGramSchmidt/Int.lean`.
+
+## Current frontier
+
+No correctness issue found with branching between packed evaluation and
+materialized matrix equality. The Boolean gate compiles as intended and the
+proof separates the fallback path through `beq_iff_eq`.
+
+## Next step
+
+If polishing before PR, consider naming the threshold constants instead of
+leaving `32` and `2 ^ 62` inline.
+
+## Blockers
+
+No blocker.

--- a/progress/20260610T140256Z_issue-6741-gate.md
+++ b/progress/20260610T140256Z_issue-6741-gate.md
@@ -1,0 +1,58 @@
+# 20260610T140256Z (#6741, word-scale gate)
+
+## Accomplished
+
+Following Kim's direction to relax the harsh-cubic 15% threshold and
+eliminate the small-rung regressions, confirmed those regressions are
+real and removed them with a regime gate, then re-measured and opened
+the sequenced PRs.
+
+- Interleaved A/B (base vs packed binaries, alternating runs, quiet
+  host) reproduced the small harsh-cubic regressions (+1% to +7.5% on
+  every rung n=15..40), ruling out noise.
+- Diagnosis: harsh-cubic entries are `2^(3.3n)`, so from n=20 the
+  packed dot products are big-by-big (same bit operations as the
+  materialized product) while the bound scan and Horner repacking add
+  overhead; at n=15 everything is word-scale but the dimension is too
+  small to amortize the fixed costs.
+- Gate (commit 2d6e45c1): `mulEqCert` takes the packed path only when
+  `32 ≤ n` and every entry of `M`, `A`, `C` is word-scale (`wordScale`,
+  a short-circuiting comparison scan, no `natAbs` allocation);
+  otherwise it falls back to the materialized `M * A == C`. Both
+  branches decide exactly `M * A = C`; `mulEqCert_iff` now goes
+  through `unfold mulEqCert; split` with the fallback closed by
+  `beq_iff_eq`. Codex follow-up review: no issues (its suggestion to
+  name the two inline constants was declined; each appears once,
+  beside the docstring that explains it).
+- Gated A/B: harsh-cubic rungs within noise (+1.8% worst, sub-0.1 ms),
+  random-bounded n=45/60 keep -11.5%/-14.2%; n=30 and harsh-cubic
+  n=15 now run code identical to base modulo one Nat comparison.
+- Full paired ladder (before = 01effde1, after = 2d6e45c1, carica):
+  random-bounded n=45..180 checkers -15.2% to -20.2%, n=180 full path
+  1.210 s to 1.024 s; every harsh-cubic rung ≤ 0; all 19 hashes
+  identical. Caveat recorded in the PR: the baseline window carried
+  ambient load from a concurrent agent bench session, so the
+  controlled interleaved A/Bs are the noise-checked evidence for the
+  materialized-path rungs.
+- Verification at head: `lake build HexLLL HexLLLMathlib`,
+  `lake exe hexlll_bench verify` (128/128), `scripts/check_dag.py`,
+  `git diff --check`, forbidden-token grep all clean.
+- SPEC PR opened first per sequencing:
+  https://github.com/kim-em/hex/pull/6745 (doc: pin the packed
+  same-lattice certificate in the hex-lll SPEC), written timelessly
+  with the word-scale regime and materialized fallback required.
+
+## Current frontier
+
+Implementation PR opened from `issue-6741` immediately after this
+file's commit; it depends on #6745 merging first.
+
+## Next step
+
+After both PRs merge: refresh the committed carica certified ladders
+and update reports/hex-lll-performance.md and
+reports/hex-lll-scaling.md per SPEC/benchmarking.md §Headline reports.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR replace the two materialized `Matrix.mul` equalities inside `Matrix.sameLatticeCert` with a packed single-point evaluation. Each product equality `M·A = C` is decided by `mulEqCert`: in the word-scale regime (every entry of `M`, `A`, `C` fits in a machine word and `32 ≤ n`) the rows of `A` and `C` are packed into single integers in balanced base `2^K` (`packRow`, width from the entry-bound scan `packWidth`) and the `n` packed dot products `Σ_l M[i][l]·packA[l]` are compared against `packC[i]`; outside the regime (detected by `wordScale`, a short-circuiting comparison scan) it falls back to the materialized comparison, since big-by-big packing costs the same bit operations as the product and the overhead is pure loss. Soundness is balanced-digit uniqueness (`packDigits_inj`), completeness is linearity of packing (`dotProduct_packRow`), combined in `mulEqCert_iff : mulEqCert M A C = true ↔ M * A = C`, so both branches decide exactly the same predicate, `certCheck` accepts exactly the same candidates, and the statement of `certCheck_sound` is unchanged. All new proofs are Mathlib-free (`HexLLL/Basic.lean`).

Depends on https://github.com/kim-em/hex/pull/6745 (doc: pin the packed same-lattice certificate in the hex-lll SPEC), which merges first per the spec-leads-implementation sequencing of https://github.com/kim-em/hex/issues/6741.

Paired measurement on carica (M2 Ultra, macOS), before = 01effde1 (merge-base), after = 2d6e45c1, identical commands, all 19 observed hashes identical, `hexlll_bench verify` 128/128 at head:

| checker rung | before | after | delta |
|---|---:|---:|---:|
| random-bounded n=30 | 3.07 ms | 3.17 ms | +3.1% |
| random-bounded n=45 | 10.36 ms | 8.79 ms | -15.2% |
| random-bounded n=60 | 25.41 ms | 20.61 ms | -18.9% |
| random-bounded n=75 | 49.12 ms | 39.48 ms | -19.6% |
| random-bounded n=90 | 88.87 ms | 72.72 ms | -18.2% |
| random-bounded n=120 | 215.53 ms | 174.11 ms | -19.2% |
| random-bounded n=150 | 450.40 ms | 359.29 ms | -20.2% |
| random-bounded n=180 | 851.17 ms | 691.04 ms | -18.8% |
| harsh-cubic n=15..55 | | | -0.1% to -7.3% |
| full path, random-bounded n=180 | 1209.73 ms | 1023.83 ms | -15.4% |
| full path, harsh-cubic n=55 | 240.95 ms | 229.01 ms | -5.0% |

The original 15%-everywhere go/no-go was relaxed by the issue author after the [no-go report](https://github.com/kim-em/hex/issues/6741#issuecomment-4668615524): the same-lattice clause is only ~2% of the harsh-cubic checker (the exact Gram-Schmidt clause dominates, per https://github.com/kim-em/hex/issues/6742), so no same-lattice change can reach 15% there; the requirement became the random-bounded wins plus no regressions.

Measurement caveats, in the interest of honesty: the baseline window carried ambient load from a concurrent agent bench session while the after window was quiet, which flatters the cross-window harsh-cubic deltas. The controlled evidence for the no-regression claim is interleaved A/B runs (alternating binaries, three rounds, quiet host): the ungated packed path regressed every small harsh-cubic rung by +1% to +7.5%, and with the gate every rung that leaves the packed regime runs code identical to the baseline modulo one Nat comparison, measuring within the ±3% noise band of those sub-3 ms rungs (the random-bounded n=30 +3.1% above is that noise; quiet A/Bs put it at ±1%). Harsh-cubic entries are `2^(3.3n)`, so n=15 is the only harsh-cubic rung in the word-scale regime, and the dimension floor routes it to the materialized path. Baseline metadata notes: the two full-path baseline rows are tagged `01effde-dirty` because in-progress edits entered the worktree while the already-built merge-base binary was running.

Codex reviews (initial and gate follow-up) found no soundness gap; the suggested hoisting of `2^K` and naming of the gate constants were measured or judged immaterial and declined.

After merge: refresh the committed carica certified ladders and update reports/hex-lll-performance.md and reports/hex-lll-scaling.md per SPEC/benchmarking.md §Headline reports.

🤖 Prepared with Claude Code