### PR TITLE
doc: repoint comparator plots at the refreshed Lean-certified export

### DIFF
--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -1457,14 +1457,14 @@ z
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 88.984091 265.426265
-L 128.852273 226.666559
-L 168.720455 199.93787
-L 208.588636 178.963999
-L 248.456818 162.357307
-L 328.193182 133.36307
-L 407.929545 112.600903
-L 487.665909 93.604207
+    <path d="M 88.984091 265.612863
+L 128.852273 229.024528
+L 168.720455 203.281063
+L 208.588636 181.146371
+L 248.456818 165.942863
+L 328.193182 137.682581
+L 407.929545 116.522319
+L 487.665909 98.229312
 " clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
@@ -1475,14 +1475,14 @@ z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="265.426265" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="226.666559" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="199.93787" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="178.963999" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="162.357307" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="133.36307" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="112.600903" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="487.665909" y="93.604207" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="88.984091" y="265.612863" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.852273" y="229.024528" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.720455" y="203.281063" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.588636" y="181.146371" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.456818" y="165.942863" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.193182" y="137.682581" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.929545" y="116.522319" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="487.665909" y="98.229312" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_93">

--- a/reports/hex-lll-scaling.md
+++ b/reports/hex-lll-scaling.md
@@ -51,6 +51,7 @@ commit) is printed above its table.
 ### random-bounded, rungs 120–180
 
 - `reports/bench-results/hex-lll-certified-443bf8fb.json` — host `carica`, commit `443bf8fb`
+- `reports/bench-results/hex-lll-certified-carica.json` — host `carica`, commit `4c708c7b`
 - `reports/bench-results/hex-lll-random-bounded-schur.json` — host `carica`, commit `56f34229`
 
 | method | exponent p | R² | C₃ (ns·n³) | × fpLLL |
@@ -58,10 +59,10 @@ commit) is printed above its table.
 | Isabelle native | 3.37 | 0.9996 | 1194 | 26.5× |
 | Lean native | 3.03 | 0.9990 | 801 | 17.8× |
 | Isabelle certified | 3.07 | 0.9977 | 407 | 9.0× |
-| Lean certified | 3.20 | 0.9997 | 169 | 3.8× |
+| Lean certified | 3.20 | 0.9997 | 171 | 3.8× |
 | fpLLL via fplll-ffi | 3.09 | 1.0000 | 45 | 1.0× |
 
-Exponents agree to within 0.34, so the five methods share one complexity
+Exponents agree to within 0.33, so the five methods share one complexity
 (empirically `~n³` on this instance family) and differ only by a constant
 factor. The headline reading:
 
@@ -125,12 +126,13 @@ tables. The exponent answers "did the change alter the complexity class"; the
 
 ## Caveats
 
-- The random-bounded native curves (Isabelle native, Lean native, fpLLL) come
-  from one committed run and the two certified curves from another — both on
-  `carica`, slightly different commits. Within each run the ratios are exact;
-  cross-run ratios (for example certified-vs-native) carry mild run-to-run
-  noise. A single consolidated five-way sweep would remove it; the exponents
-  and the ~4× certify-win are well outside that noise.
+- The random-bounded curves come from three committed runs: the native
+  curves (Isabelle native, Lean native, fpLLL) from one, the Lean-certified
+  curve from another, and the Isabelle-certified curve from a third — all on
+  `carica`, slightly different commits. Within each run the ratios are
+  exact; cross-run ratios (for example certified-vs-native) carry mild
+  run-to-run noise. A single consolidated five-way sweep would remove it;
+  the exponents and the ~4.7× certify-win are well outside that noise.
 - Exponents are fits over a finite window, not proofs. They report the slope at
   the measured rungs; a wider or higher window can shift them, especially on
   harsh-cubic where the window is narrow.

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -32,12 +32,18 @@ DEFAULT_HARSH_CONSOLIDATED = (
 DEFAULT_ISABELLE_BOTTOM = (
     ROOT / "reports/bench-results/hex-lll-isabelle-bottom-e211854d1435.json"
 )
-# Full certified ladder measured in one carica run, so all four
-# certified rungs (Lean + Isabelle, random + harsh) share a host and
-# commit and the gating ratio is internally consistent.
-DEFAULT_CERTIFIED = ROOT / "reports/bench-results/hex-lll-certified-carica.json"
-DEFAULT_ISABELLE_CERTIFIED_RANDOM = DEFAULT_CERTIFIED
-DEFAULT_ISABELLE_CERTIFIED_HARSH = DEFAULT_CERTIFIED
+# The Lean-certified and Isabelle-certified series come from separate
+# committed carica runs: the Lean-certified ladder tracks the current
+# checker, while the Isabelle-certified ladder is the full Lean+Isabelle
+# schedule (the Lean-certified export carries no Isabelle rows). Within
+# each series the rungs share a host and commit; the cross-series ratio
+# carries the cross-run caveat recorded in reports/hex-lll-scaling.md.
+DEFAULT_CERTIFIED = ROOT / "reports/bench-results/hex-lll-certified-443bf8fb.json"
+DEFAULT_ISABELLE_CERTIFIED = (
+    ROOT / "reports/bench-results/hex-lll-certified-carica.json"
+)
+DEFAULT_ISABELLE_CERTIFIED_RANDOM = DEFAULT_ISABELLE_CERTIFIED
+DEFAULT_ISABELLE_CERTIFIED_HARSH = DEFAULT_ISABELLE_CERTIFIED
 DEFAULT_RANDOM_OUTPUT = ROOT / "reports/figures/hex-lll-comparator-random-bounded.svg"
 DEFAULT_HARSH_OUTPUT = ROOT / "reports/figures/hex-lll-comparator-harsh-cubic.svg"
 


### PR DESCRIPTION
This PR repoints the comparator plot defaults at the refreshed Lean-certified bench export and regenerates the committed random-bounded figure. https://github.com/kim-em/hex/pull/6750 replaced the committed export and updated the report tables for https://github.com/kim-em/hex/issues/6741 (packed same-lattice certificate), but `scripts/plots/hex-lll-comparator.py` — whose `FAMILIES` config `scripts/plots/hex-lll-scaling.py` imports as its single source of truth — still read the superseded `hex-lll-certified-carica.json`, so the committed random-bounded figure predated the packed certificate and `python3 scripts/plots/hex-lll-scaling.py --all` did not reproduce the committed table.

Concretely: point `DEFAULT_CERTIFIED` at `hex-lll-certified-443bf8fb.json`, keep the Isabelle-certified series on `hex-lll-certified-carica.json` (the refreshed export carries no Isabelle rows), regenerate `reports/figures/hex-lll-comparator-random-bounded.svg` (the Lean-certified curve drops; the harsh-cubic figure regenerates byte-identically and is untouched), and replace the scaling report's random-bounded block with the exact regenerated output: the Lean-certified `C₃` cell becomes 171 (the committed 169 is not reproducible from the committed export), the exponent-spread sentence becomes 0.33, and the provenance list gains the Isabelle-certified source that the table's 407-row actually comes from. The cross-run caveat now names all three runs.

🤖 Prepared with Claude Code
