### PR TITLE
feat: fixed-precision interval reducedness checker with input-size dispatch

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -433,6 +433,24 @@ def divPos (S : Int) (a b : Ival) : Ival :=
   ⟨min (Int.fdiv (a.lo * S) b.lo) (Int.fdiv (a.lo * S) b.hi),
     max (cdiv (a.hi * S) b.lo) (cdiv (a.hi * S) b.hi)⟩
 
+/-- Endpoint bounds of the product of two intervals, sign-cased so the
+common (sign-definite) cases cost two integer multiplications instead of
+four products plus comparisons. Returns `(lo, hi)` at the product scale of
+its inputs. -/
+@[inline] def prodBounds (a b : Ival) : Int × Int :=
+  if 0 ≤ a.lo then
+    if 0 ≤ b.lo then (a.lo * b.lo, a.hi * b.hi)
+    else if b.hi ≤ 0 then (a.hi * b.lo, a.lo * b.hi)
+    else (a.hi * b.lo, a.hi * b.hi)
+  else if a.hi ≤ 0 then
+    if 0 ≤ b.lo then (a.lo * b.hi, a.hi * b.lo)
+    else if b.hi ≤ 0 then (a.hi * b.hi, a.lo * b.lo)
+    else (a.lo * b.hi, a.lo * b.lo)
+  else
+    if 0 ≤ b.lo then (a.lo * b.hi, a.hi * b.hi)
+    else if b.hi ≤ 0 then (a.hi * b.lo, a.lo * b.lo)
+    else (min (a.lo * b.hi) (a.hi * b.lo), max (a.lo * b.lo) (a.hi * b.hi))
+
 end Ival
 
 namespace IntervalGS
@@ -440,11 +458,20 @@ namespace IntervalGS
 /-- One step of the Gram-Schmidt dot recurrence on enclosures:
 `g − Σ_{k < t} mu[k] · r[k]`, with `g` an exact Gram entry. With
 `mu = μ[j][·]` and `r = r[i][·]` this encloses `⟨b_i, b*_j⟩`; with
-`mu = r = ` row `i`'s own data it encloses `‖b*_i‖²`. -/
+`mu = r = ` row `i`'s own data it encloses `‖b*_i‖²`.
+
+The sum accumulates exactly at scale `S²` (endpoint products of scale-`S`
+mantissas) and rounds outward through a single floor / ceiling division at
+the end, so a length-`t` dot recurrence costs one rounding division rather
+than `t` of them. -/
 def dotStep (S : Int) (mu r : Array Ival) (g : Int) (t : Nat) : Ival :=
-  (List.range t).foldl
-    (fun acc k => acc.sub (Ival.mul S mu[k]! r[k]!))
-    (Ival.ofInt S g)
+  let acc :=
+    (List.range t).foldl
+      (fun (acc : Int × Int) k =>
+        let p := Ival.prodBounds mu[k]! r[k]!
+        (acc.1 - p.2, acc.2 - p.1))
+      (g * S * S, g * S * S)
+  ⟨Int.fdiv acc.1 S, Ival.cdiv acc.2 S⟩
 
 /-- One column step of the per-row fold: extend the `r` row with the
 enclosure of `⟨b_i, b*_j⟩` and the `μ` row with the enclosure of

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -608,19 +608,24 @@ def lllReducedInt (b : Matrix Int n m) (δ η : Rat) : Bool :=
   independent && sizeReduced && lovasz
 
 /-- Outcome of one certified-dispatch reducedness decision: decided by the
-interval checker, or referred to the exact integer fallback. -/
+interval checker, decided by the exact checker because the size predictor
+chose it (`exactPrimary`), or referred to the exact checker after an
+indecisive interval pass (`exactFallback`). -/
 inductive CheckerOutcome where
   | interval
-  | exact
+  | exactPrimary
+  | exactFallback
 deriving Repr, BEq
 
 /-- Tally of reducedness decisions, distinguishing enclosure-accepted from
-fallback decisions. Mirrors `LLLProvider.Diagnostics` for the dispatch
-outcomes; this tally is the observability hook that lets measurements
-verify the interval path decided every candidate. -/
+the two exact-checker modes. Mirrors `LLLProvider.Diagnostics` for the
+dispatch outcomes; this tally is the observability hook that lets
+measurements verify the dispatch predictor and confirm the interval path
+never reached indecision (`exactFallback = 0`). -/
 structure CheckerTally where
   interval : Nat := 0
-  exact : Nat := 0
+  exactPrimary : Nat := 0
+  exactFallback : Nat := 0
 deriving Repr, BEq, Inhabited
 
 initialize checkerTallyRef : IO.Ref CheckerTally ← IO.mkRef {}
@@ -633,7 +638,8 @@ def checkerTally : IO CheckerTally :=
 
 private def bumpChecker (t : CheckerTally) : CheckerOutcome → CheckerTally
   | .interval => { t with interval := t.interval + 1 }
-  | .exact => { t with exact := t.exact + 1 }
+  | .exactPrimary => { t with exactPrimary := t.exactPrimary + 1 }
+  | .exactFallback => { t with exactFallback := t.exactFallback + 1 }
 
 /-- Side-effecting tally bump callable from pure code; definitionally the
 continuation `k`, with an `@[implemented_by]` side effect in compiled code.
@@ -650,15 +656,46 @@ unsafe def withRecordCheckerOutcomeImpl {α : Type} (o : CheckerOutcome) (k : α
 @[implemented_by withRecordCheckerOutcomeImpl]
 def withRecordCheckerOutcome {α : Type} (_o : CheckerOutcome) (k : α) : α := k
 
-/-- Reducedness clause of the certified dispatch: the fixed-precision
-interval checker decides first; on indecision the exact integer checker is
-the mandatory fallback, so completeness is structural rather than
-numerical. Records each decision in the checker tally. -/
+/-- Dispatch threshold of the size predictor `intervalWins`, as a multiple
+of the working precision. Derived from the per-operation cost ratio of the
+two checkers: the exact `d`/`ν` checker performs ~`n³/3` multiplications on
+operands averaging ~`n·maxDiagBits/4` bits, while the interval pass
+performs ~`n³/6` products on fixed `(intervalPrec + maxDiagBits)`-bit
+mantissas, so enclosures win once `n·maxDiagBits` exceeds a fixed multiple
+of `intervalPrec + maxDiagBits`. The constant is calibrated on the two
+committed bench families (random-bounded crossover between n=120 and
+n=150, harsh-cubic between n=20 and n=25); boundary misclassification
+costs single-digit percent because the boundary rungs are near parity. -/
+def dispatchFactor : Nat := 16
+
+/-- Size predictor for the reducedness dispatch: `true` when the
+fixed-precision interval pass is predicted to beat the exact integer
+checker on this input. Reads only the bit length of the largest squared
+row norm (the Gram diagonal dominates all Gram entries by
+Cauchy-Schwarz), `O(n·m)` work — negligible against either checker. The
+predictor is a function of the input alone, never of checker indecision,
+so dispatch keeps per-input timing deterministic. -/
+def intervalWins (b : Matrix Int n m) : Bool :=
+  let maxDiagBits :=
+    (List.finRange n).foldl
+      (fun acc i => max acc (Vector.normSq (b.row i)).natAbs.log2)
+      0
+  decide (n * maxDiagBits ≥ dispatchFactor * (intervalPrec + maxDiagBits))
+
+/-- Reducedness clause of the certified dispatch. The size predictor
+`intervalWins` picks the checker expected to be faster on this input: the
+fixed-precision interval pass (with the exact integer checker as the
+mandatory fallback on indecision, keeping completeness structural rather
+than numerical), or the exact checker directly. Records each decision in
+the checker tally, distinguishing all three outcomes. -/
 def lllReducedCheck (b : Matrix Int n m) (δ η : Rat) : Bool :=
-  if lllReducedInterval b δ η then
-    withRecordCheckerOutcome .interval true
+  if intervalWins b then
+    if lllReducedInterval b δ η then
+      withRecordCheckerOutcome .interval true
+    else
+      withRecordCheckerOutcome .exactFallback (lllReducedInt b δ η)
   else
-    withRecordCheckerOutcome .exact (lllReducedInt b δ η)
+    withRecordCheckerOutcome .exactPrimary (lllReducedInt b δ η)
 
 /-- Executable certified-dispatch checker: verifies that `(B', U, V)` is a valid
 external candidate for reducing `B`, i.e. `B` and `B'` generate the same integer

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -369,6 +369,167 @@ theorem isLLLReduced.mono_η (b : Matrix Int n m) {δ η₁ η₂ : Rat}
   have hsq2 : η₁ * η₂ ≤ η₂ * η₂ := Rat.mul_le_mul_of_nonneg_right hle hη₂
   exact Rat.le_trans (hsize i j hi hji) (Rat.le_trans hsq1 hsq2)
 
+/-! ### Fixed-precision dyadic interval kernel
+
+The certified-dispatch reducedness clause is decided first by a sound
+enclosure pass at fixed working precision; only on indecision does it fall
+back to the exact integer checker. The kernel below is the Mathlib-free
+executable surface: closed dyadic intervals whose endpoints are `Int`
+mantissas at a shared power-of-two scale. Per-operation containment lemmas
+and the composed soundness theorem (`lllReducedInterval_sound`) live in
+HexLLLMathlib. -/
+
+/-- Closed dyadic interval `[lo / S, hi / S]` whose endpoints are integer
+mantissas at a shared power-of-two scale `S = 2 ^ prec`. The scale is not
+stored; every operation that rounds takes `S` explicitly, so the working
+precision stays a parameter of the checker. -/
+structure Ival where
+  lo : Int
+  hi : Int
+deriving Repr, BEq, Inhabited
+
+namespace Ival
+
+/-- The rational `x` lies in the dyadic interval `I` read at scale `S`. -/
+def mem (S : Int) (I : Ival) (x : Rat) : Prop :=
+  (I.lo : Rat) ≤ x * (S : Rat) ∧ x * (S : Rat) ≤ (I.hi : Rat)
+
+/-- Exact embedding of an integer at scale `S`. -/
+def ofInt (S z : Int) : Ival :=
+  ⟨z * S, z * S⟩
+
+/-- Ceiling division for a positive divisor, via `Int.fdiv` of the
+negated dividend. -/
+def cdiv (a b : Int) : Int :=
+  -(Int.fdiv (-a) b)
+
+/-- One-ulp enclosure of a rational at scale `S`. -/
+def ofRat (S : Int) (q : Rat) : Ival :=
+  ⟨Int.fdiv (q.num * S) q.den, cdiv (q.num * S) q.den⟩
+
+/-- Interval addition. Fixed-point addition is exact: no rounding. -/
+def add (a b : Ival) : Ival :=
+  ⟨a.lo + b.lo, a.hi + b.hi⟩
+
+/-- Interval subtraction. Exact, like `add`. -/
+def sub (a b : Ival) : Ival :=
+  ⟨a.lo - b.hi, a.hi - b.lo⟩
+
+/-- Interval multiplication. Endpoint products land at scale `S²`, so the
+result rounds outward through one floor / ceiling division by `S`. -/
+def mul (S : Int) (a b : Ival) : Ival :=
+  let p₁ := a.lo * b.lo
+  let p₂ := a.lo * b.hi
+  let p₃ := a.hi * b.lo
+  let p₄ := a.hi * b.hi
+  ⟨Int.fdiv (min (min p₁ p₂) (min p₃ p₄)) S,
+    cdiv (max (max p₁ p₂) (max p₃ p₄)) S⟩
+
+/-- Interval division by an interval the caller has checked to be strictly
+positive (`0 < b.lo`). The numerator rescales by `S` so the quotient lands
+back at scale `S`. Well-defined but junk when the positivity precondition
+fails; the containment lemma is conditional on it. -/
+def divPos (S : Int) (a b : Ival) : Ival :=
+  ⟨min (Int.fdiv (a.lo * S) b.lo) (Int.fdiv (a.lo * S) b.hi),
+    max (cdiv (a.hi * S) b.lo) (cdiv (a.hi * S) b.hi)⟩
+
+end Ival
+
+namespace IntervalGS
+
+/-- One step of the Gram-Schmidt dot recurrence on enclosures:
+`g − Σ_{k < t} mu[k] · r[k]`, with `g` an exact Gram entry. With
+`mu = μ[j][·]` and `r = r[i][·]` this encloses `⟨b_i, b*_j⟩`; with
+`mu = r = ` row `i`'s own data it encloses `‖b*_i‖²`. -/
+def dotStep (S : Int) (mu r : Array Ival) (g : Int) (t : Nat) : Ival :=
+  (List.range t).foldl
+    (fun acc k => acc.sub (Ival.mul S mu[k]! r[k]!))
+    (Ival.ofInt S g)
+
+/-- One column step of the per-row fold: extend the `r` row with the
+enclosure of `⟨b_i, b*_j⟩` and the `μ` row with the enclosure of
+`μ[i][j] = ⟨b_i, b*_j⟩ / ‖b*_j‖²`. -/
+@[inline] def rowStep (S : Int) (gRow : Array Int) (mus : Array (Array Ival))
+    (bstars : Array Ival) (acc : Array Ival × Array Ival) (j : Nat) :
+    Array Ival × Array Ival :=
+  let r := dotStep S mus[j]! acc.1 gRow[j]! j
+  (acc.1.push r, acc.2.push (Ival.divPos S r bstars[j]!))
+
+/-- Enclosure pass for one basis row: from the exact Gram row `gRow` and the
+enclosure rows of all earlier indices, produce the `μ[i][·]` enclosure row
+and the `‖b*_i‖²` enclosure. The intermediate `r` row encloses the dot
+products `⟨b_i, b*_j⟩`. -/
+def row (S : Int) (gRow : Array Int) (mus : Array (Array Ival))
+    (bstars : Array Ival) (i : Nat) : Array Ival × Ival :=
+  let acc := (List.range i).foldl (rowStep S gRow mus bstars) (#[], #[])
+  (acc.2, dotStep S acc.2 acc.1 gRow[i]! i)
+
+/-- One row step of the pass fold: run `row`, demand a strictly positive
+norm enclosure, and extend the accumulated enclosure state. -/
+@[inline] def passStep (S : Int) (g : Array (Array Int))
+    (acc : Array (Array Ival) × Array Ival) (i : Nat) :
+    Option (Array (Array Ival) × Array Ival) :=
+  let r := row S g[i]! acc.1 acc.2 i
+  if 0 < r.2.lo then
+    some (acc.1.push r.1, acc.2.push r.2)
+  else
+    none
+
+/-- Full interval Gram-Schmidt pass over the exact `n × n` Gram matrix:
+`O(n³)` interval operations on fixed-scale mantissas, independent of the
+Gram-determinant bit growth of the input family. Returns the enclosure rows
+of the Gram-Schmidt coefficients and the squared basis norms, or `none` as
+soon as some norm enclosure fails strict positivity (the division by that
+norm would be unsound, and reducedness could not be decided either way). -/
+def pass (S : Int) (g : Array (Array Int)) (n : Nat) :
+    Option (Array (Array Ival) × Array Ival) :=
+  (List.range n).foldlM (passStep S g) (#[], #[])
+
+/-- Size-reduction clause on enclosures: every `μ[i][j]` interval lies
+inside `[−η, η]`, compared exactly through `η = η.num / η.den`. -/
+def sizeOK (S : Int) (η : Rat) (mus : Array (Array Ival)) (n : Nat) : Bool :=
+  (List.range n).all fun i =>
+    (List.range i).all fun j =>
+      let I := mus[i]![j]!
+      decide (I.hi * (η.den : Int) ≤ η.num * S) &&
+        decide (-(η.num * S) ≤ I.lo * (η.den : Int))
+
+/-- Lovász clause on enclosures at every adjacent pair: the largest possible
+`δ‖b*_i‖²` is at most the smallest possible `‖b*_{i+1}‖² + μ²‖b*_i‖²`. -/
+def lovaszOK (S : Int) (δ : Rat) (mus : Array (Array Ival))
+    (bstars : Array Ival) (n : Nat) : Bool :=
+  let Iδ := Ival.ofRat S δ
+  (List.range (n - 1)).all fun i =>
+    let μ := mus[i + 1]![i]!
+    let lhs := Ival.mul S Iδ bstars[i]!
+    let rhs := (bstars[i + 1]!).add (Ival.mul S (Ival.mul S μ μ) bstars[i]!)
+    decide (lhs.hi ≤ rhs.lo)
+
+end IntervalGS
+
+/-- Working precision (bits) of the interval reducedness checker. The
+inequalities being certified carry slack (`η = 11/20` against fplll's
+actual ≈ 1/2; Lovász at the requested `δ` against fplll's stronger
+reduction), so a fixed precision decides them on reduced candidates; any
+indecision falls back to the exact checker rather than failing. -/
+def intervalPrec : Nat := 128
+
+/-- Fixed-precision interval reducedness checker. Computes enclosures of
+the Gram-Schmidt data of `b` from its exact integer Gram matrix and accepts
+only when every independence, size-reduction, and Lovász inequality is
+decided with the enclosure strictly on the correct side. `false` means
+"not reduced or indecisive at this precision": callers must fall back to
+the exact checker `lllReducedInt`, which keeps completeness structural.
+Soundness (`lllReducedInterval_sound`, HexLLLMathlib) entails
+`b.independent ∧ isLLLReduced b δ η` at the exact rational parameters. -/
+def lllReducedInterval (b : Matrix Int n m) (δ η : Rat) : Bool :=
+  let S : Int := (2 : Int) ^ intervalPrec
+  let g := (Matrix.gramMatrix b).toArray.map Vector.toArray
+  match IntervalGS.pass S g n with
+  | none => false
+  | some (mus, bstars) =>
+      IntervalGS.sizeOK S η mus n && IntervalGS.lovaszOK S δ mus bstars n
+
 /-- Executable integer `Bool` reducedness checker over the `GramSchmidt.Int`
 representation: leading Gram determinants `d` and integer scaled Gram-Schmidt
 coefficients `ν`.
@@ -419,17 +580,70 @@ def lllReducedInt (b : Matrix Int n m) (δ η : Rat) : Bool :=
         true
   independent && sizeReduced && lovasz
 
+/-- Outcome of one certified-dispatch reducedness decision: decided by the
+interval checker, or referred to the exact integer fallback. -/
+inductive CheckerOutcome where
+  | interval
+  | exact
+deriving Repr, BEq
+
+/-- Tally of reducedness decisions, distinguishing enclosure-accepted from
+fallback decisions. Mirrors `LLLProvider.Diagnostics` for the dispatch
+outcomes; this tally is the observability hook that lets measurements
+verify the interval path decided every candidate. -/
+structure CheckerTally where
+  interval : Nat := 0
+  exact : Nat := 0
+deriving Repr, BEq, Inhabited
+
+initialize checkerTallyRef : IO.Ref CheckerTally ← IO.mkRef {}
+
+def resetCheckerTally : IO Unit :=
+  checkerTallyRef.set {}
+
+def checkerTally : IO CheckerTally :=
+  checkerTallyRef.get
+
+private def bumpChecker (t : CheckerTally) : CheckerOutcome → CheckerTally
+  | .interval => { t with interval := t.interval + 1 }
+  | .exact => { t with exact := t.exact + 1 }
+
+/-- Side-effecting tally bump callable from pure code; definitionally the
+continuation `k`, with an `@[implemented_by]` side effect in compiled code.
+The continuation value is returned *through* `unsafeBaseIO`, so the compiler
+cannot eliminate the effect as an unused pure binding (the
+`match unsafeBaseIO … with | () => k` shape of `LLLProvider.withRecordOutcome`
+is erasable and its tally is known not to fire eagerly; see the workaround
+comment on `runDispatchedFirstShortVectorChecksum`). -/
+unsafe def withRecordCheckerOutcomeImpl {α : Type} (o : CheckerOutcome) (k : α) : α :=
+  unsafeBaseIO do
+    checkerTallyRef.modify (fun t => bumpChecker t o)
+    pure k
+
+@[implemented_by withRecordCheckerOutcomeImpl]
+def withRecordCheckerOutcome {α : Type} (_o : CheckerOutcome) (k : α) : α := k
+
+/-- Reducedness clause of the certified dispatch: the fixed-precision
+interval checker decides first; on indecision the exact integer checker is
+the mandatory fallback, so completeness is structural rather than
+numerical. Records each decision in the checker tally. -/
+def lllReducedCheck (b : Matrix Int n m) (δ η : Rat) : Bool :=
+  if lllReducedInterval b δ η then
+    withRecordCheckerOutcome .interval true
+  else
+    withRecordCheckerOutcome .exact (lllReducedInt b δ η)
+
 /-- Executable certified-dispatch checker: verifies that `(B', U, V)` is a valid
 external candidate for reducing `B`, i.e. `B` and `B'` generate the same integer
 row lattice (witnessed by `U`, `V`) and `B'` is `(δ, η)`-reduced.
 
-Composes the two Mathlib-free Bool checkers `Matrix.sameLatticeCert` and
-`lllReducedInt`. Soundness (`certCheck_sound`, HexLLLMathlib) entails the
-property triple `(same lattice, B' independent, isLLLReduced B' δ η)` and is
-the single trusted bridge that the certified-dispatch path of `lll`
-depends on. -/
+Composes the Mathlib-free Bool checkers `Matrix.sameLatticeCert` and
+`lllReducedCheck` (interval decision with exact `lllReducedInt` fallback).
+Soundness (`certCheck_sound`, HexLLLMathlib) entails the property triple
+`(same lattice, B' independent, isLLLReduced B' δ η)` and is the single
+trusted bridge that the certified-dispatch path of `lll` depends on. -/
 def certCheck (B B' : Matrix Int n m) (U V : Matrix Int n n) (δ η : Rat) : Bool :=
-  Matrix.sameLatticeCert B B' U V && lllReducedInt B' δ η
+  Matrix.sameLatticeCert B B' U V && lllReducedCheck B' δ η
 
 /-- Integer-only state for later LLL reduction steps. The proof-facing fields
 connect the stored Gram determinants and scaled coefficients to the executable

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1222,6 +1222,39 @@ def runCertifiedFirstShortVectorHarshCubic55Checksum : Unit → IO Int := fun _ 
 def runCertifiedCheckerHarshCubic55Checksum : Unit → IO Int :=
   runCertifiedCheckerChecksum certifiedHarshCubic55Ref (fun _ => prepHarshCubicInput 55)
 
+/-- Observable for the reducedness-decision tally: run the certified checker
+once on every rung of both ladders, then read `Hex.checkerTally`. Fails if
+any decision fell back to the exact integer checker, so the fallback count
+on the pinned rungs is verifiable; the returned value encodes the tally as
+`interval · 65537 + exact`. -/
+def runCertifiedCheckerIntervalTally : Unit → IO Int := fun _ => do
+  Hex.resetCheckerTally
+  let targets : List (Unit → IO Int) :=
+    [runCertifiedCheckerRandomBounded30Checksum,
+     runCertifiedCheckerRandomBounded45Checksum,
+     runCertifiedCheckerRandomBounded60Checksum,
+     runCertifiedCheckerRandomBounded75Checksum,
+     runCertifiedCheckerRandomBounded90Checksum,
+     runCertifiedCheckerRandomBounded120Checksum,
+     runCertifiedCheckerRandomBounded150Checksum,
+     runCertifiedCheckerRandomBounded180Checksum,
+     runCertifiedCheckerHarshCubic15Checksum,
+     runCertifiedCheckerHarshCubic20Checksum,
+     runCertifiedCheckerHarshCubic25Checksum,
+     runCertifiedCheckerHarshCubic30Checksum,
+     runCertifiedCheckerHarshCubic35Checksum,
+     runCertifiedCheckerHarshCubic40Checksum,
+     runCertifiedCheckerHarshCubic45Checksum,
+     runCertifiedCheckerHarshCubic50Checksum,
+     runCertifiedCheckerHarshCubic55Checksum]
+  for t in targets do
+    discard <| t ()
+  let tally ← Hex.checkerTally
+  if tally.exact != 0 then
+    throw <| IO.userError
+      s!"interval reducedness checker fell back to the exact checker: {repr tally}"
+  return Int.ofNat tally.interval * 65537 + Int.ofNat tally.exact
+
 def runFirstShortVectorBZRecombinationNormSq : Unit → IO Int := fun _ => do
   return runFirstShortVectorNormSq (← bzRecombinationInputRef.get)
 
@@ -2007,6 +2040,15 @@ setup_fixed_benchmark runCertifiedCheckerHarshCubic55Checksum where {
     repeats := 3
     maxSecondsPerCall := 20.0
     warmupFirstIter := true
+  }
+
+/- One certified check per rung of both ladders; the observed value pins the
+reducedness-decision tally to "all 17 rungs decided by the interval checker,
+zero exact fallbacks". -/
+setup_fixed_benchmark runCertifiedCheckerIntervalTally where {
+    repeats := 1
+    maxSecondsPerCall := 120.0
+    expectedHash := some (Hashable.hash ((17 * 65537 : Int)))
   }
 
 /- Complexity derivation: random-bounded inputs have square dimension `n` and

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1224,9 +1224,10 @@ def runCertifiedCheckerHarshCubic55Checksum : Unit → IO Int :=
 
 /-- Observable for the reducedness-decision tally: run the certified checker
 once on every rung of both ladders, then read `Hex.checkerTally`. Fails if
-any decision fell back to the exact integer checker, so the fallback count
-on the pinned rungs is verifiable; the returned value encodes the tally as
-`interval · 65537 + exact`. -/
+any interval pass reached indecision (`exactFallback ≠ 0`); the
+size-predictor split between interval-accepted and exact-primary is pinned
+by the expected hash. The returned value encodes the tally as
+`(interval · 65537 + exactPrimary) · 65537 + exactFallback`. -/
 def runCertifiedCheckerIntervalTally : Unit → IO Int := fun _ => do
   Hex.resetCheckerTally
   let targets : List (Unit → IO Int) :=
@@ -1250,10 +1251,11 @@ def runCertifiedCheckerIntervalTally : Unit → IO Int := fun _ => do
   for t in targets do
     discard <| t ()
   let tally ← Hex.checkerTally
-  if tally.exact != 0 then
+  if tally.exactFallback != 0 then
     throw <| IO.userError
-      s!"interval reducedness checker fell back to the exact checker: {repr tally}"
-  return Int.ofNat tally.interval * 65537 + Int.ofNat tally.exact
+      s!"interval reducedness checker reached indecision: {repr tally}"
+  return (Int.ofNat tally.interval * 65537 + Int.ofNat tally.exactPrimary) * 65537 +
+    Int.ofNat tally.exactFallback
 
 def runFirstShortVectorBZRecombinationNormSq : Unit → IO Int := fun _ => do
   return runFirstShortVectorNormSq (← bzRecombinationInputRef.get)
@@ -2043,12 +2045,13 @@ setup_fixed_benchmark runCertifiedCheckerHarshCubic55Checksum where {
   }
 
 /- One certified check per rung of both ladders; the observed value pins the
-reducedness-decision tally to "all 17 rungs decided by the interval checker,
-zero exact fallbacks". -/
+reducedness-decision tally to "7 rungs dispatched to the interval checker
+(harsh-cubic n ≥ 35, random-bounded n ≥ 150), 10 to the exact checker by
+the size predictor, zero indecision fallbacks". -/
 setup_fixed_benchmark runCertifiedCheckerIntervalTally where {
     repeats := 1
     maxSecondsPerCall := 120.0
-    expectedHash := some (Hashable.hash ((17 * 65537 : Int)))
+    expectedHash := some (Hashable.hash (((7 * 65537 + 10) * 65537 : Int)))
   }
 
 /- Complexity derivation: random-bounded inputs have square dimension `n` and

--- a/HexLLLMathlib.lean
+++ b/HexLLLMathlib.lean
@@ -1,5 +1,6 @@
 import HexLLLMathlib.Basic
 import HexLLLMathlib.Independent
+import HexLLLMathlib.Interval
 
 /-!
 The `HexLLLMathlib` library identifies the executable `HexLLL` lattice

--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -764,18 +764,25 @@ theorem lllReducedInt_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
 
 /-- Soundness of the dispatched reducedness clause `Hex.lllReducedCheck`:
 whichever side decided — the fixed-precision interval checker
-(`HexLLLMathlib.lllReducedInterval_sound`) or the exact integer fallback
-(`lllReducedInt_sound` above) — acceptance entails the rational
-`isLLLReduced` predicate and independence. -/
+(`HexLLLMathlib.lllReducedInterval_sound`), the exact integer checker
+chosen by the size predictor, or the exact fallback after interval
+indecision (both via `lllReducedInt_sound` above) — acceptance entails
+the rational `isLLLReduced` predicate and independence. The predictor
+`Hex.intervalWins` only selects between sound checkers, so no hypothesis
+about it is needed. -/
 theorem lllReducedCheck_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
     Hex.lllReducedCheck b δ η = true →
       Hex.isLLLReduced b δ η ∧ Hex.Matrix.independent b := by
   intro hcheck
   unfold Hex.lllReducedCheck at hcheck
   simp only [Hex.withRecordCheckerOutcome] at hcheck
-  by_cases hint : Hex.lllReducedInterval b δ η = true
-  · exact HexLLLMathlib.lllReducedInterval_sound b δ η hint
-  · rw [if_neg (by simpa using hint)] at hcheck
+  by_cases hwin : Hex.intervalWins b = true
+  · rw [if_pos hwin] at hcheck
+    by_cases hint : Hex.lllReducedInterval b δ η = true
+    · exact HexLLLMathlib.lllReducedInterval_sound b δ η hint
+    · rw [if_neg (by simpa using hint)] at hcheck
+      exact lllReducedInt_sound b δ η hcheck
+  · rw [if_neg (by simpa using hwin)] at hcheck
     exact lllReducedInt_sound b δ η hcheck
 
 /-- Soundness of the certified-dispatch checker `Hex.certCheck`: an accepted

--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -1,4 +1,5 @@
 import HexLLL.Basic
+import HexLLLMathlib.Interval
 import HexGramSchmidtMathlib.Int
 import HexMatrixMathlib.RankSpanNullspace
 import Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho
@@ -761,6 +762,22 @@ theorem lllReducedInt_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
     intro i hi
     exact lovasz_of_intCheck b δ η hi hindep (hlovasz i hi)
 
+/-- Soundness of the dispatched reducedness clause `Hex.lllReducedCheck`:
+whichever side decided — the fixed-precision interval checker
+(`HexLLLMathlib.lllReducedInterval_sound`) or the exact integer fallback
+(`lllReducedInt_sound` above) — acceptance entails the rational
+`isLLLReduced` predicate and independence. -/
+theorem lllReducedCheck_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
+    Hex.lllReducedCheck b δ η = true →
+      Hex.isLLLReduced b δ η ∧ Hex.Matrix.independent b := by
+  intro hcheck
+  unfold Hex.lllReducedCheck at hcheck
+  simp only [Hex.withRecordCheckerOutcome] at hcheck
+  by_cases hint : Hex.lllReducedInterval b δ η = true
+  · exact HexLLLMathlib.lllReducedInterval_sound b δ η hint
+  · rw [if_neg (by simpa using hint)] at hcheck
+    exact lllReducedInt_sound b δ η hcheck
+
 /-- Soundness of the certified-dispatch checker `Hex.certCheck`: an accepted
 certificate `(B', U, V)` proves that `B` and `B'` generate the same integer row
 lattice, that `B'` is independent, and that `B'` is `(δ, η)`-LLL-reduced.
@@ -768,7 +785,8 @@ lattice, that `B'` is independent, and that `B'` is `(δ, η)`-LLL-reduced.
 Composes the two soundness ingredients:
 * `Hex.Matrix.sameLatticeCert_sound` (Mathlib-free, HexLLL/Basic.lean) for the
   same-lattice clause, and
-* `Hex.lllReducedInt_sound` (above) for independence and reducedness.
+* `lllReducedCheck_sound` (above) for independence and reducedness, covering
+  both the interval decision and the exact integer fallback.
 
 No validity hypothesis on `η`: the `1/2 ≤ η`, `η² < δ` conditions for the LLL
 short-vector bound live on `short_vector_bound_of_size_bound`, not on the
@@ -784,7 +802,7 @@ theorem certCheck_sound {B B' : Hex.Matrix Int n m} {U V : Hex.Matrix Int n n}
   simp only [Bool.and_eq_true] at hcheck
   obtain ⟨hsame, hred⟩ := hcheck
   refine ⟨Hex.Matrix.sameLatticeCert_sound hsame, ?_, ?_⟩
-  · exact (lllReducedInt_sound B' δ η hred).2
-  · exact (lllReducedInt_sound B' δ η hred).1
+  · exact (lllReducedCheck_sound B' δ η hred).2
+  · exact (lllReducedCheck_sound B' δ η hred).1
 
 end HexLLLMathlib

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -1,0 +1,830 @@
+import HexLLL.Basic
+import HexGramSchmidtMathlib.Int
+
+/-!
+Soundness of the fixed-precision interval reducedness checker.
+
+`Hex.lllReducedInterval` runs an enclosure Gram-Schmidt pass over the exact
+integer Gram matrix of a candidate basis and accepts only when every
+independence, size-reduction, and Lovász inequality is decided with the
+enclosure strictly on the correct side. This module proves that acceptance
+entails the exact rational predicates: `Hex.isLLLReduced b δ η` together
+with `Hex.Matrix.independent b`.
+
+The proof has three layers:
+
+* per-operation containment lemmas for the dyadic interval kernel
+  (`Hex.Ival`): each operation's result encloses the exact rational value
+  whenever its inputs do;
+* the exact Gram-Schmidt recurrence over the Gram matrix
+  (`gram_recurrence`): `⟨b_i, b_j⟩ = ⟨b_i, b*_j⟩ + Σ_{k<j} μ[j][k]·⟨b_i, b*_k⟩`,
+  derived from `basis_decomposition` and `basis_orthogonal`, which is the
+  recurrence the executable pass evaluates in interval arithmetic;
+* a structural induction over the executable pass (`pass_spec`) showing
+  every `μ[i][j]` and `‖b*_i‖²` enclosure contains its exact rational
+  value, then reading the three accepted clauses back through the
+  enclosures. Independence follows from strict positivity of every
+  `‖b*_i‖²` enclosure via the unconditional Gram-determinant product
+  identity `gramDet_eq_prod_normSq_uncond`.
+-/
+
+namespace HexLLLMathlib
+
+open Hex
+
+/-! ### Rounding helpers -/
+
+private theorem intCast_fdiv_le (p : Int) {S : Int} (hS : 0 < S) :
+    ((Int.fdiv p S : Int) : Rat) ≤ (p : Rat) / (S : Rat) := by
+  have hadd : S * Int.fdiv p S + Int.fmod p S = p := Int.mul_fdiv_add_fmod p S
+  have hmod : (0 : Rat) ≤ (Int.fmod p S : Rat) := by
+    exact_mod_cast Int.fmod_nonneg_of_pos p hS
+  have hSQ : (0 : Rat) < (S : Rat) := by exact_mod_cast hS
+  rw [le_div_iff₀ hSQ]
+  have hp : ((S : Rat)) * ((Int.fdiv p S : Int) : Rat) + ((Int.fmod p S : Int) : Rat)
+      = (p : Rat) := by exact_mod_cast congrArg (Int.cast : Int → Rat) hadd
+  nlinarith [hp, hmod]
+
+private theorem div_le_intCast_cdiv (p : Int) {S : Int} (hS : 0 < S) :
+    (p : Rat) / (S : Rat) ≤ ((Ival.cdiv p S : Int) : Rat) := by
+  have h := intCast_fdiv_le (-p) hS
+  have h2 := neg_le_neg h
+  calc (p : Rat) / (S : Rat) = -(((-p : Int) : Rat) / (S : Rat)) := by
+        push_cast
+        ring
+    _ ≤ -((Int.fdiv (-p) S : Int) : Rat) := h2
+    _ = ((Ival.cdiv p S : Int) : Rat) := by
+        unfold Ival.cdiv
+        push_cast
+        ring
+
+private theorem div_le_div_of_le_num {a b c : Rat} (hc : 0 < c) (h : a ≤ b) :
+    a / c ≤ b / c := by
+  have hinv : (0 : Rat) ≤ c⁻¹ := le_of_lt (inv_pos.mpr hc)
+  simpa [div_eq_mul_inv] using mul_le_mul_of_nonneg_right h hinv
+
+private theorem div_le_div_of_le_den {a b c : Rat} (ha : 0 ≤ a) (hb : 0 < b)
+    (h : b ≤ c) : a / c ≤ a / b := by
+  rw [div_eq_mul_one_div a c, div_eq_mul_one_div a b]
+  exact mul_le_mul_of_nonneg_left (one_div_le_one_div_of_le hb h) ha
+
+private theorem div_le_div_of_nonpos_den {a b c : Rat} (ha : a ≤ 0) (hb : 0 < b)
+    (h : b ≤ c) : a / b ≤ a / c := by
+  rw [div_eq_mul_one_div a b, div_eq_mul_one_div a c]
+  exact mul_le_mul_of_nonpos_left (one_div_le_one_div_of_le hb h) ha
+
+/-! ### Containment lemmas for the interval kernel -/
+
+private theorem mem_ofInt (S z : Int) : (Ival.ofInt S z).mem S (z : Rat) := by
+  unfold Ival.ofInt Ival.mem
+  constructor <;> simp [Int.cast_mul]
+
+private theorem mem_add {S : Int} {I J : Ival} {x y : Rat}
+    (hx : I.mem S x) (hy : J.mem S y) : (I.add J).mem S (x + y) := by
+  obtain ⟨h1, h2⟩ := hx
+  obtain ⟨h3, h4⟩ := hy
+  unfold Ival.add Ival.mem
+  push_cast
+  constructor <;> [nlinarith; nlinarith]
+
+private theorem mem_sub {S : Int} {I J : Ival} {x y : Rat}
+    (hx : I.mem S x) (hy : J.mem S y) : (I.sub J).mem S (x - y) := by
+  obtain ⟨h1, h2⟩ := hx
+  obtain ⟨h3, h4⟩ := hy
+  unfold Ival.sub Ival.mem
+  push_cast
+  constructor <;> [nlinarith; nlinarith]
+
+private theorem mul_le_max4 {x y A B C D : Rat}
+    (hA : A ≤ x) (hB : x ≤ B) (hC : C ≤ y) (hD : y ≤ D) :
+    x * y ≤ max (max (A * C) (A * D)) (max (B * C) (B * D)) := by
+  rcases le_total 0 y with hy | hy
+  · have hxy : x * y ≤ B * y := mul_le_mul_of_nonneg_right hB hy
+    rcases le_total 0 B with hB0 | hB0
+    · have hBy : B * y ≤ B * D := mul_le_mul_of_nonneg_left hD hB0
+      exact le_trans (le_trans hxy hBy) (le_max_of_le_right (le_max_right _ _))
+    · have hBy : B * y ≤ B * C := mul_le_mul_of_nonpos_left hC hB0
+      exact le_trans (le_trans hxy hBy) (le_max_of_le_right (le_max_left _ _))
+  · have hxy : x * y ≤ A * y := mul_le_mul_of_nonpos_right hA hy
+    rcases le_total 0 A with hA0 | hA0
+    · have hAy : A * y ≤ A * D := mul_le_mul_of_nonneg_left hD hA0
+      exact le_trans (le_trans hxy hAy) (le_max_of_le_left (le_max_right _ _))
+    · have hAy : A * y ≤ A * C := mul_le_mul_of_nonpos_left hC hA0
+      exact le_trans (le_trans hxy hAy) (le_max_of_le_left (le_max_left _ _))
+
+private theorem min4_le_mul {x y A B C D : Rat}
+    (hA : A ≤ x) (hB : x ≤ B) (hC : C ≤ y) (hD : y ≤ D) :
+    min (min (A * C) (A * D)) (min (B * C) (B * D)) ≤ x * y := by
+  have h := mul_le_max4 (x := -x) (y := y) (A := -B) (B := -A) (C := C) (D := D)
+    (by linarith) (by linarith) hC hD
+  rw [neg_mul] at h
+  have hmax :
+      max (max (-B * C) (-B * D)) (max (-A * C) (-A * D)) =
+        -(min (min (B * C) (B * D)) (min (A * C) (A * D))) := by
+    simp [max_neg_neg]
+  rw [hmax] at h
+  have := neg_le_neg h
+  rw [neg_neg] at this
+  calc min (min (A * C) (A * D)) (min (B * C) (B * D))
+      = min (min (B * C) (B * D)) (min (A * C) (A * D)) := min_comm _ _
+    _ ≤ x * y := by linarith
+
+private theorem mem_mul {S : Int} (hS : 0 < S) {I J : Ival} {x y : Rat}
+    (hx : I.mem S x) (hy : J.mem S y) : (I.mul S J).mem S (x * y) := by
+  obtain ⟨h1, h2⟩ := hx
+  obtain ⟨h3, h4⟩ := hy
+  have hSQ : (0 : Rat) < (S : Rat) := by exact_mod_cast hS
+  have hmax := mul_le_max4 h1 h2 h3 h4
+  have hmin := min4_le_mul h1 h2 h3 h4
+  unfold Ival.mul Ival.mem
+  constructor
+  · refine le_trans (intCast_fdiv_le _ hS) ?_
+    rw [div_le_iff₀ hSQ]
+    push_cast
+    nlinarith [hmin]
+  · refine le_trans ?_ (div_le_intCast_cdiv _ hS)
+    rw [le_div_iff₀ hSQ]
+    push_cast
+    nlinarith [hmax]
+
+private theorem mem_divPos {S : Int} (hS : 0 < S) {I J : Ival} {x y : Rat}
+    (hx : I.mem S x) (hy : J.mem S y) (hpos : 0 < J.lo) :
+    (I.divPos S J).mem S (x / y) := by
+  obtain ⟨h1, h2⟩ := hx
+  obtain ⟨h3, h4⟩ := hy
+  have hSQ : (0 : Rat) < (S : Rat) := by exact_mod_cast hS
+  have hC : (0 : Rat) < (J.lo : Rat) := by exact_mod_cast hpos
+  have hyS : (0 : Rat) < y * S := lt_of_lt_of_le hC h3
+  have hy0 : 0 < y := by nlinarith
+  have hDQ : (0 : Rat) < (J.hi : Rat) := lt_of_lt_of_le hC (le_trans h3 h4)
+  have hD : 0 < J.hi := by exact_mod_cast hDQ
+  have hquot : (x / y) * S = (x * S * S) / (y * S) := by
+    field_simp
+  have hcast_lo : ((I.lo * S : Int) : Rat) = (I.lo : Rat) * (S : Rat) := by push_cast; ring
+  have hcast_hi : ((I.hi * S : Int) : Rat) = (I.hi : Rat) * (S : Rat) := by push_cast; ring
+  unfold Ival.divPos Ival.mem
+  constructor
+  · -- lower endpoint
+    have hnum : (I.lo : Rat) * S ≤ x * S * S :=
+      mul_le_mul_of_nonneg_right h1 (le_of_lt hSQ)
+    have hstep : ((I.lo * S : Int) : Rat) / (y * S) ≤ (x / y) * S := by
+      rw [hquot, hcast_lo]
+      exact div_le_div_of_le_num hyS hnum
+    rcases le_total 0 ((I.lo * S : Int) : Rat) with hA0 | hA0
+    · -- nonneg numerator: divide by the largest denominator J.hi
+      have hfd : ((Int.fdiv (I.lo * S) J.hi : Int) : Rat) ≤
+          ((I.lo * S : Int) : Rat) / (J.hi : Rat) := intCast_fdiv_le _ hD
+      have hmono : ((I.lo * S : Int) : Rat) / (J.hi : Rat) ≤
+          ((I.lo * S : Int) : Rat) / (y * S) := by
+        rcases le_total (y * S) (J.hi : Rat) with hyJ | hyJ
+        · exact div_le_div_of_le_den hA0 hyS hyJ
+        · exact le_of_eq_of_le (by rw [le_antisymm h4 hyJ]) le_rfl
+      have hchain := le_trans (le_trans hfd hmono) hstep
+      refine le_trans ?_ hchain
+      have : (min ((Int.fdiv (I.lo * S) J.lo)) ((Int.fdiv (I.lo * S) J.hi)) : Int) ≤
+          Int.fdiv (I.lo * S) J.hi := min_le_right _ _
+      exact_mod_cast this
+    · -- nonpos numerator: divide by the smallest denominator J.lo
+      have hfd : ((Int.fdiv (I.lo * S) J.lo : Int) : Rat) ≤
+          ((I.lo * S : Int) : Rat) / (J.lo : Rat) := intCast_fdiv_le _ hpos
+      have hmono : ((I.lo * S : Int) : Rat) / (J.lo : Rat) ≤
+          ((I.lo * S : Int) : Rat) / (y * S) :=
+        div_le_div_of_nonpos_den hA0 hC h3
+      have hchain := le_trans (le_trans hfd hmono) hstep
+      refine le_trans ?_ hchain
+      have : (min ((Int.fdiv (I.lo * S) J.lo)) ((Int.fdiv (I.lo * S) J.hi)) : Int) ≤
+          Int.fdiv (I.lo * S) J.lo := min_le_left _ _
+      exact_mod_cast this
+  · -- upper endpoint
+    have hnum : x * S * S ≤ (I.hi : Rat) * S :=
+      mul_le_mul_of_nonneg_right h2 (le_of_lt hSQ)
+    have hstep : (x / y) * S ≤ ((I.hi * S : Int) : Rat) / (y * S) := by
+      rw [hquot, hcast_hi]
+      exact div_le_div_of_le_num hyS hnum
+    rcases le_total 0 ((I.hi * S : Int) : Rat) with hB0 | hB0
+    · -- nonneg numerator: bound by division through the smallest denominator
+      have hcd : ((I.hi * S : Int) : Rat) / (J.lo : Rat) ≤
+          ((Ival.cdiv (I.hi * S) J.lo : Int) : Rat) := div_le_intCast_cdiv _ hpos
+      have hmono : ((I.hi * S : Int) : Rat) / (y * S) ≤
+          ((I.hi * S : Int) : Rat) / (J.lo : Rat) :=
+        div_le_div_of_le_den hB0 hC h3
+      have hchain := le_trans (le_trans hstep hmono) hcd
+      refine le_trans hchain ?_
+      have : (Ival.cdiv (I.hi * S) J.lo : Int) ≤
+          max (Ival.cdiv (I.hi * S) J.lo) (Ival.cdiv (I.hi * S) J.hi) := le_max_left _ _
+      exact_mod_cast this
+    · -- nonpos numerator: bound by division through the largest denominator
+      have hcd : ((I.hi * S : Int) : Rat) / (J.hi : Rat) ≤
+          ((Ival.cdiv (I.hi * S) J.hi : Int) : Rat) := div_le_intCast_cdiv _ hD
+      have hmono : ((I.hi * S : Int) : Rat) / (y * S) ≤
+          ((I.hi * S : Int) : Rat) / (J.hi : Rat) := by
+        rcases le_total (y * S) (J.hi : Rat) with hyJ | hyJ
+        · exact div_le_div_of_nonpos_den hB0 hyS hyJ
+        · exact le_of_le_of_eq le_rfl (by rw [le_antisymm h4 hyJ])
+      have hchain := le_trans (le_trans hstep hmono) hcd
+      refine le_trans hchain ?_
+      have : (Ival.cdiv (I.hi * S) J.hi : Int) ≤
+          max (Ival.cdiv (I.hi * S) J.lo) (Ival.cdiv (I.hi * S) J.hi) := le_max_right _ _
+      exact_mod_cast this
+
+private theorem mem_ofRat {S : Int} (_hS : 0 < S) (q : Rat) :
+    (Ival.ofRat S q).mem S q := by
+  have hden : (0 : Int) < (q.den : Int) := by exact_mod_cast q.den_pos
+  have hdenQ : (0 : Rat) < (q.den : Rat) := by exact_mod_cast q.den_pos
+  have hq : q * (q.den : Rat) = (q.num : Rat) := by
+    have h := Rat.num_div_den q
+    field_simp at h
+    linarith
+  have hqS : ((q.num * S : Int) : Rat) / (q.den : Rat) = q * S := by
+    rw [div_eq_iff (ne_of_gt hdenQ)]
+    push_cast
+    linear_combination (-(S : Rat)) * hq
+  unfold Ival.ofRat Ival.mem
+  constructor
+  · exact le_of_le_of_eq (intCast_fdiv_le _ hden) hqS
+  · exact le_of_eq_of_le hqS.symm (div_le_intCast_cdiv _ hden)
+
+/-! ### Exact Gram-Schmidt recurrence over the Gram matrix -/
+
+private theorem foldl_finRange_eq_sum {R : Type*} [AddCommMonoid R] {k : Nat}
+    (f : Fin k → R) :
+    (List.finRange k).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
+  rw [← List.foldl_map, ← List.sum_eq_foldl,
+    ← List.sum_toFinset f (List.nodup_finRange k), List.toFinset_finRange]
+
+private theorem dot_eq_sum {m' : Nat} (u v : Vector Rat m') :
+    Hex.Matrix.dot u v = ∑ k : Fin m', u[k] * v[k] := by
+  unfold Hex.Matrix.dot Hex.Vector.dotProduct
+  exact foldl_finRange_eq_sum _
+
+/-- The rational cast of a basis row of the integer input. -/
+private noncomputable def castRow (b : Hex.Matrix Int n m) (i : Fin n) : Vector Rat m :=
+  Vector.map (fun x : Int => (x : Rat)) (b.row i)
+
+/-- Exact Gram-Schmidt coefficient `μ[i][j]`. -/
+private noncomputable def muExact (b : Hex.Matrix Int n m) (i j : Fin n) : Rat :=
+  GramSchmidt.entry (GramSchmidt.Int.coeffs b) i j
+
+/-- Exact dot product `⟨b_i, b*_j⟩` of an input row against a
+Gram-Schmidt basis row. -/
+private noncomputable def gsDot (b : Hex.Matrix Int n m) (i j : Fin n) : Rat :=
+  Hex.Matrix.dot (castRow b i) ((GramSchmidt.Int.basis b).row j)
+
+/-- Exact squared Gram-Schmidt norm `‖b*_j‖²`. -/
+private noncomputable def nrm (b : Hex.Matrix Int n m) (j : Fin n) : Rat :=
+  Hex.LLLCore.basisNormSq (GramSchmidt.Int.basis b) j
+
+private theorem nrm_eq_dot (b : Hex.Matrix Int n m) (j : Fin n) :
+    nrm b j = Hex.Matrix.dot ((GramSchmidt.Int.basis b).row j)
+      ((GramSchmidt.Int.basis b).row j) := by
+  unfold nrm Hex.LLLCore.basisNormSq
+  rfl
+
+/-- Cast of an integer Gram entry as a rational dot product of cast rows. -/
+private theorem gram_cast (b : Hex.Matrix Int n m) (i j : Fin n) :
+    ((Hex.Vector.dotProduct (b.row i) (b.row j) : Int) : Rat) =
+      Hex.Matrix.dot (castRow b i) (castRow b j) := by
+  rw [dot_eq_sum]
+  rw [show Hex.Vector.dotProduct (b.row i) (b.row j) =
+      ∑ k : Fin m, (b.row i)[k] * (b.row j)[k] from foldl_finRange_eq_sum _]
+  push_cast
+  refine Finset.sum_congr rfl fun k _ => ?_
+  unfold castRow
+  simp [Vector.getElem_map]
+
+private theorem getElem_foldl_add_smul {m' : Nat} (xs : List (Fin m'))
+    (w : Fin m' → Rat) (rows : Fin m' → Vector Rat m) (z : Vector Rat m)
+    (l : Fin m) :
+    (xs.foldl (fun acc k => acc + w k • rows k) z)[l] =
+      z[l] + (xs.map (fun k => w k * (rows k)[l])).sum := by
+  induction xs generalizing z with
+  | nil => simp
+  | cons x xs ih =>
+      simp only [List.foldl_cons, List.map_cons, List.sum_cons]
+      rw [ih]
+      have : (z + w x • rows x)[l] = z[l] + w x * (rows x)[l] := by
+        simp only [Fin.getElem_fin, Vector.getElem_add, Vector.getElem_smul]
+        rfl
+      rw [this]
+      ring
+
+private theorem prefixCombination_getElem
+    (C : Hex.Matrix Rat n n) (B : Hex.Matrix Rat n m) (i : Nat) (hi : i < n)
+    (l : Fin m) :
+    (GramSchmidt.prefixCombination C B i hi)[l] =
+      ∑ k : Fin i,
+        GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
+          (B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩)[l] := by
+  unfold GramSchmidt.prefixCombination
+  rw [getElem_foldl_add_smul]
+  have hz : (0 : Vector Rat m)[l] = 0 := by
+    simp
+  rw [hz, zero_add]
+  rw [← foldl_finRange_eq_sum
+    (fun k : Fin i =>
+      GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
+        (B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩)[l])]
+  rw [← List.foldl_map, ← List.sum_eq_foldl]
+
+private theorem dot_add_right {m' : Nat} (u v w : Vector Rat m') :
+    Hex.Matrix.dot u (v + w) = Hex.Matrix.dot u v + Hex.Matrix.dot u w := by
+  rw [dot_eq_sum, dot_eq_sum, dot_eq_sum, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  simp only [Fin.getElem_fin, Vector.getElem_add]
+  ring
+
+private theorem dot_comm {m' : Nat} (u v : Vector Rat m') :
+    Hex.Matrix.dot u v = Hex.Matrix.dot v u := by
+  rw [dot_eq_sum, dot_eq_sum]
+  exact Finset.sum_congr rfl fun k _ => mul_comm _ _
+
+private theorem dot_prefixCombination (u : Vector Rat m)
+    (C : Hex.Matrix Rat n n) (B : Hex.Matrix Rat n m) (i : Nat) (hi : i < n) :
+    Hex.Matrix.dot u (GramSchmidt.prefixCombination C B i hi) =
+      ∑ k : Fin i,
+        GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
+          Hex.Matrix.dot u (B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩) := by
+  rw [dot_eq_sum]
+  have : ∀ l : Fin m,
+      u[l] * (GramSchmidt.prefixCombination C B i hi)[l] =
+        ∑ k : Fin i,
+          GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
+            ((B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩)[l] * u[l]) := by
+    intro l
+    rw [prefixCombination_getElem, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    ring
+  simp_rw [this]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [dot_eq_sum, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun l _ => ?_
+  ring
+
+/-- Decomposition of a dot product against a cast input row through the
+Gram-Schmidt basis: `⟨u, b_j⟩ = ⟨u, b*_j⟩ + Σ_{k<j} μ[j][k]·⟨u, b*_k⟩`. -/
+private theorem dot_castRow_decompose (b : Hex.Matrix Int n m)
+    (u : Vector Rat m) (j : Fin n) :
+    Hex.Matrix.dot u (castRow b j) =
+      Hex.Matrix.dot u ((GramSchmidt.Int.basis b).row j) +
+        ∑ k : Fin j.val,
+          muExact b j ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩ *
+            Hex.Matrix.dot u
+              ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩) := by
+  have hdecomp := GramSchmidt.Int.basis_decomposition b j.val j.isLt
+  have hrow : castRow b j = Vector.map (fun x : Int => (x : Rat)) (b.row ⟨j.val, j.isLt⟩) := by
+    unfold castRow
+    congr 1
+  rw [hrow, hdecomp, dot_add_right, dot_prefixCombination]
+  rfl
+
+/-- The exact recurrence the interval pass evaluates: a Gram entry equals
+the `⟨b_i, b*_j⟩` dot product plus the `μ[j][·]`-weighted prefix of the
+`⟨b_i, b*_·⟩` dot products. -/
+private theorem gram_recurrence (b : Hex.Matrix Int n m) (i j : Fin n) :
+    ((Hex.Vector.dotProduct (b.row i) (b.row j) : Int) : Rat) =
+      gsDot b i j +
+        ∑ k : Fin j.val,
+          muExact b j ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩ *
+            gsDot b i ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩ := by
+  rw [gram_cast, dot_castRow_decompose]
+  rfl
+
+/-- `⟨b_i, b*_j⟩ = μ[i][j]·‖b*_j‖²` strictly below the diagonal. -/
+private theorem gsDot_eq_mu_mul_nrm (b : Hex.Matrix Int n m) {i j : Fin n}
+    (hji : j.val < i.val) :
+    gsDot b i j = muExact b i j * nrm b j := by
+  unfold gsDot
+  rw [dot_comm, dot_castRow_decompose]
+  have horth : Hex.Matrix.dot ((GramSchmidt.Int.basis b).row j)
+      ((GramSchmidt.Int.basis b).row i) = 0 := by
+    rw [dot_comm]
+    exact GramSchmidt.Int.basis_orthogonal b i.val j.val i.isLt j.isLt
+      (Nat.ne_of_gt hji)
+  rw [horth, zero_add]
+  rw [Finset.sum_eq_single (⟨j.val, hji⟩ : Fin i.val)]
+  · rw [dot_comm, nrm_eq_dot]
+  · intro k _ hk
+    have hkj : k.val ≠ j.val := fun h => hk (Fin.ext h)
+    have horth' : Hex.Matrix.dot ((GramSchmidt.Int.basis b).row j)
+        ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩) = 0 := by
+      rw [dot_comm]
+      exact GramSchmidt.Int.basis_orthogonal b k.val j.val
+        (Nat.lt_trans k.isLt i.isLt) j.isLt hkj
+    rw [horth', mul_zero]
+  · intro h
+    exact absurd (Finset.mem_univ _) h
+
+/-- `⟨b_i, b*_i⟩ = ‖b*_i‖²` on the diagonal. -/
+private theorem gsDot_self (b : Hex.Matrix Int n m) (i : Fin n) :
+    gsDot b i i = nrm b i := by
+  unfold gsDot
+  rw [dot_comm, dot_castRow_decompose]
+  have hsum : (∑ k : Fin i.val,
+      muExact b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩ *
+        Hex.Matrix.dot ((GramSchmidt.Int.basis b).row i)
+          ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩)) = 0 := by
+    refine Finset.sum_eq_zero fun k _ => ?_
+    have horth : Hex.Matrix.dot ((GramSchmidt.Int.basis b).row i)
+        ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩) = 0 :=
+      GramSchmidt.Int.basis_orthogonal b i.val k.val i.isLt
+        (Nat.lt_trans k.isLt i.isLt) (Nat.ne_of_gt k.isLt)
+    rw [horth, mul_zero]
+  rw [hsum, add_zero, dot_comm, nrm_eq_dot]
+
+/-! ### Containment induction over the executable pass -/
+
+private theorem getElem!_push_lt {α : Type*} [Inhabited α] (a : Array α) (x : α)
+    {j : Nat} (hj : j < a.size) : (a.push x)[j]! = a[j]! := by
+  have h1 : j < (a.push x).size := by
+    rw [Array.size_push]
+    omega
+  rw [getElem!_pos (a.push x) j h1, getElem!_pos a j hj]
+  exact Array.getElem_push_lt hj
+
+private theorem getElem!_push_eq {α : Type*} [Inhabited α] (a : Array α) (x : α) :
+    (a.push x)[a.size]! = x := by
+  have h1 : a.size < (a.push x).size := by
+    rw [Array.size_push]
+    omega
+  rw [getElem!_pos (a.push x) a.size h1]
+  exact Array.getElem_push_eq ..
+
+private theorem getElem!_push_size_eq {α : Type*} [Inhabited α] (a : Array α)
+    (x : α) {j : Nat} (hj : j = a.size) : (a.push x)[j]! = x := by
+  subst hj
+  exact getElem!_push_eq a x
+
+private theorem dotStep_mem {S : Int} (hS : 0 < S)
+    (muA rA : Array Ival) (g : Int) (t : Nat) (xs ys : Fin t → Rat)
+    (hmu : ∀ k : Fin t, (muA[k.val]!).mem S (xs k))
+    (hr : ∀ k : Fin t, (rA[k.val]!).mem S (ys k)) :
+    (IntervalGS.dotStep S muA rA g t).mem S ((g : Rat) - ∑ k, xs k * ys k) := by
+  induction t with
+  | zero =>
+      simpa [IntervalGS.dotStep] using mem_ofInt S g
+  | succ t ih =>
+      have hstep : IntervalGS.dotStep S muA rA g (t + 1) =
+          (IntervalGS.dotStep S muA rA g t).sub (Ival.mul S muA[t]! rA[t]!) := by
+        unfold IntervalGS.dotStep
+        rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
+      rw [hstep, Fin.sum_univ_castSucc, sub_add_eq_sub_sub]
+      exact mem_sub
+        (ih (fun k => xs k.castSucc) (fun k => ys k.castSucc)
+          (fun k => hmu k.castSucc) (fun k => hr k.castSucc))
+        (mem_mul hS (hmu (Fin.last t)) (hr (Fin.last t)))
+
+/-- Invariant carried by the pass across the first `t` rows: sizes are `t`,
+every `‖b*_j‖²` enclosure is strictly positive and contains the exact
+value, and every `μ[j][k]` enclosure contains the exact coefficient. -/
+private def Inv (b : Hex.Matrix Int n m) (S : Int) (t : Nat) (ht : t ≤ n)
+    (mus : Array (Array Ival)) (bstars : Array Ival) : Prop :=
+  mus.size = t ∧ bstars.size = t ∧
+    ∀ j (hj : j < t),
+      0 < (bstars[j]!).lo ∧
+        (bstars[j]!).mem S (nrm b ⟨j, Nat.lt_of_lt_of_le hj ht⟩) ∧
+        ∀ k (hk : k < j),
+          ((mus[j]!)[k]!).mem S
+            (muExact b ⟨j, Nat.lt_of_lt_of_le hj ht⟩
+              ⟨k, Nat.lt_trans hk (Nat.lt_of_lt_of_le hj ht)⟩)
+
+private theorem pos_of_mem_pos_lo {S : Int} (hS : 0 < S) {I : Ival} {x : Rat}
+    (hmem : I.mem S x) (hlo : 0 < I.lo) : 0 < x := by
+  obtain ⟨h1, _⟩ := hmem
+  have hSQ : (0 : Rat) < (S : Rat) := by exact_mod_cast hS
+  have hloQ : (0 : Rat) < (I.lo : Rat) := by exact_mod_cast hlo
+  nlinarith
+
+/-- The accumulated `r` and `μ` rows of the inner fold enclose the exact
+`⟨b_i, b*_·⟩` dot products and Gram-Schmidt coefficients of row `i`. -/
+private theorem rowFold_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
+    (gRow : Array Int) (mus : Array (Array Ival)) (bstars : Array Ival)
+    (i : Fin n) (hinv : Inv b S i.val (Nat.le_of_lt i.isLt) mus bstars)
+    (hgRow : ∀ j (hj : j ≤ i.val),
+      gRow[j]! = Hex.Vector.dotProduct (b.row i)
+        (b.row ⟨j, Nat.lt_of_le_of_lt hj i.isLt⟩))
+    (t : Nat) (ht : t ≤ i.val) :
+    ((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])).1.size = t ∧
+      ((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])).2.size = t ∧
+      ∀ j (hj : j < t),
+        ((((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars)
+              (#[], #[])).1)[j]!).mem S
+            (gsDot b i ⟨j, Nat.lt_trans (Nat.lt_of_lt_of_le hj ht) i.isLt⟩) ∧
+          ((((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars)
+              (#[], #[])).2)[j]!).mem S
+            (muExact b i ⟨j, Nat.lt_trans (Nat.lt_of_lt_of_le hj ht) i.isLt⟩) := by
+  induction t with
+  | zero =>
+      exact ⟨rfl, rfl, fun j hj => absurd hj (Nat.not_lt_zero j)⟩
+  | succ t ih =>
+      have ht' : t ≤ i.val := Nat.le_of_succ_le ht
+      obtain ⟨hsz1, hsz2, hprev⟩ := ih ht'
+      have hfold : (List.range (t + 1)).foldl (IntervalGS.rowStep S gRow mus bstars)
+            (#[], #[]) =
+          IntervalGS.rowStep S gRow mus bstars
+            ((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])) t := by
+        rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
+      set acc := (List.range t).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])
+        with hacc
+      have htlt : t < i.val := Nat.lt_of_succ_le ht
+      have htn : t < n := Nat.lt_trans htlt i.isLt
+      obtain ⟨hszm, hszb, hrows⟩ := hinv
+      obtain ⟨hblo, hbmem, hmmem⟩ := hrows t htlt
+      -- the fresh r entry encloses ⟨b_i, b*_t⟩
+      have hrec := gram_recurrence b i ⟨t, htn⟩
+      have hrmem : (IntervalGS.dotStep S mus[t]! acc.1 gRow[t]! t).mem S
+          (gsDot b i ⟨t, htn⟩) := by
+        have hds := dotStep_mem hS mus[t]! acc.1 gRow[t]! t
+          (fun k : Fin t => muExact b ⟨t, htn⟩ ⟨k.val, Nat.lt_trans k.isLt htn⟩)
+          (fun k : Fin t => gsDot b i ⟨k.val, Nat.lt_trans k.isLt htn⟩)
+          (fun k => hmmem k.val k.isLt)
+          (fun k => (hprev k.val k.isLt).1)
+        have heq : (gRow[t]! : Rat) -
+            (∑ k : Fin t, muExact b ⟨t, htn⟩ ⟨k.val, Nat.lt_trans k.isLt htn⟩ *
+              gsDot b i ⟨k.val, Nat.lt_trans k.isLt htn⟩) = gsDot b i ⟨t, htn⟩ := by
+          rw [hgRow t (Nat.le_of_lt htlt), hrec]
+          ring
+        rw [← heq]
+        exact hds
+      -- the fresh μ entry encloses μ[i][t]
+      have hnrm_pos : 0 < nrm b ⟨t, htn⟩ := pos_of_mem_pos_lo hS hbmem hblo
+      have hmumem : (Ival.divPos S (IntervalGS.dotStep S mus[t]! acc.1 gRow[t]! t)
+          (bstars[t]!)).mem S (muExact b i ⟨t, htn⟩) := by
+        have hdv := mem_divPos hS hrmem hbmem hblo
+        have heq : gsDot b i ⟨t, htn⟩ / nrm b ⟨t, htn⟩ = muExact b i ⟨t, htn⟩ := by
+          rw [gsDot_eq_mu_mul_nrm b htlt]
+          exact mul_div_cancel_right₀ _ (ne_of_gt hnrm_pos)
+        rw [← heq]
+        exact hdv
+      rw [hfold]
+      unfold IntervalGS.rowStep
+      dsimp only
+      refine ⟨by simp [Array.size_push, hsz1], by simp [Array.size_push, hsz2], ?_⟩
+      intro j hj
+      rcases Nat.lt_or_ge j t with hjt | hjt
+      · have hj1 : j < acc.1.size := by omega
+        have hj2 : j < acc.2.size := by omega
+        rw [getElem!_push_lt _ _ hj1, getElem!_push_lt _ _ hj2]
+        exact hprev j hjt
+      · have hjeq : j = t := by omega
+        subst hjeq
+        constructor
+        · rw [getElem!_push_size_eq _ _ (by omega : j = acc.1.size)]
+          exact hrmem
+        · rw [getElem!_push_size_eq _ _ (by omega : j = acc.2.size)]
+          exact hmumem
+
+/-- The `μ` row and `‖b*_i‖²` enclosure produced by `IntervalGS.row` contain
+the exact values, given the invariant for all earlier rows. -/
+private theorem row_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
+    (gRow : Array Int) (mus : Array (Array Ival)) (bstars : Array Ival)
+    (i : Fin n) (hinv : Inv b S i.val (Nat.le_of_lt i.isLt) mus bstars)
+    (hgRow : ∀ j (hj : j ≤ i.val),
+      gRow[j]! = Hex.Vector.dotProduct (b.row i)
+        (b.row ⟨j, Nat.lt_of_le_of_lt hj i.isLt⟩)) :
+    (IntervalGS.row S gRow mus bstars i.val).1.size = i.val ∧
+      (∀ j (hj : j < i.val),
+        (((IntervalGS.row S gRow mus bstars i.val).1)[j]!).mem S
+          (muExact b i ⟨j, Nat.lt_trans hj i.isLt⟩)) ∧
+      ((IntervalGS.row S gRow mus bstars i.val).2).mem S (nrm b i) := by
+  obtain ⟨hsz1, hsz2, hentries⟩ :=
+    rowFold_spec b hS gRow mus bstars i hinv hgRow i.val (Nat.le_refl i.val)
+  set acc := (List.range i.val).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])
+    with hacc
+  have hrow : IntervalGS.row S gRow mus bstars i.val =
+      (acc.2, IntervalGS.dotStep S acc.2 acc.1 gRow[i.val]! i.val) := by
+    unfold IntervalGS.row
+    rfl
+  rw [hrow]
+  refine ⟨hsz2, fun j hj => (hentries j hj).2, ?_⟩
+  have hds := dotStep_mem hS acc.2 acc.1 gRow[i.val]! i.val
+    (fun k : Fin i.val => muExact b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩)
+    (fun k : Fin i.val => gsDot b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩)
+    (fun k => (hentries k.val k.isLt).2)
+    (fun k => (hentries k.val k.isLt).1)
+  have hrec := gram_recurrence b i i
+  have heq : (gRow[i.val]! : Rat) -
+      (∑ k : Fin i.val, muExact b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩ *
+        gsDot b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩) = nrm b i := by
+    rw [hgRow i.val (Nat.le_refl i.val)]
+    rw [show (⟨i.val, Nat.lt_of_le_of_lt (Nat.le_refl i.val) i.isLt⟩ : Fin n) = i from
+      Fin.ext rfl]
+    rw [hrec, ← gsDot_self b i]
+    ring
+  rw [← heq]
+  exact hds
+
+/-- Acceptance invariant of the full pass. -/
+private theorem pass_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
+    (g : Array (Array Int))
+    (hg : ∀ i (hi : i < n) j (hj : j ≤ i),
+      (g[i]!)[j]! = Hex.Vector.dotProduct (b.row ⟨i, hi⟩)
+        (b.row ⟨j, Nat.lt_of_le_of_lt hj hi⟩)) :
+    ∀ t (ht : t ≤ n) (res : Array (Array Ival) × Array Ival),
+      (List.range t).foldlM (IntervalGS.passStep S g) (#[], #[]) = some res →
+      Inv b S t ht res.1 res.2 := by
+  intro t
+  induction t with
+  | zero =>
+      intro ht res hres
+      simp only [List.range_zero, List.foldlM_nil, Option.pure_def, Option.some.injEq]
+        at hres
+      rw [← hres]
+      exact ⟨rfl, rfl, fun j hj => absurd hj (Nat.not_lt_zero j)⟩
+  | succ t ih =>
+      intro ht res hres
+      rw [List.range_succ, List.foldlM_append] at hres
+      obtain ⟨s, hs, hstep⟩ := Option.bind_eq_some_iff.mp hres
+      simp only [List.foldlM_cons, List.foldlM_nil] at hstep
+      obtain ⟨s', hs', hpure⟩ := Option.bind_eq_some_iff.mp hstep
+      have hres' : IntervalGS.passStep S g s t = some res := by
+        cases hpure
+        exact hs'
+      have hinv_t := ih (Nat.le_of_succ_le ht) s hs
+      have htn : t < n := Nat.lt_of_succ_le ht
+      let iF : Fin n := ⟨t, htn⟩
+      have hgRow : ∀ j (hj : j ≤ iF.val),
+          (g[t]!)[j]! = Hex.Vector.dotProduct (b.row iF)
+            (b.row ⟨j, Nat.lt_of_le_of_lt hj iF.isLt⟩) := fun j hj => hg t htn j hj
+      obtain ⟨hrsz, hrmu, hrb⟩ := row_spec b hS g[t]! s.1 s.2 iF hinv_t hgRow
+      -- unfold the step and the positivity test
+      unfold IntervalGS.passStep at hres'
+      set rowRes := IntervalGS.row S g[t]! s.1 s.2 t with hrowRes
+      obtain ⟨hsz1, hsz2, hinvrows⟩ := hinv_t
+      by_cases hpos : 0 < rowRes.2.lo
+      · rw [if_pos hpos] at hres'
+        have hres'' : res = (s.1.push rowRes.1, s.2.push rowRes.2) :=
+          (Option.some.injEq _ _ ▸ hres').symm
+        subst hres''
+        dsimp only
+        refine ⟨by simp [Array.size_push, hsz1], by simp [Array.size_push, hsz2], ?_⟩
+        intro j hj
+        rcases Nat.lt_or_ge j t with hjt | hjt
+        · have hj1 : j < s.1.size := by omega
+          have hj2 : j < s.2.size := by omega
+          rw [getElem!_push_lt _ _ hj1, getElem!_push_lt _ _ hj2]
+          exact hinvrows j hjt
+        · have hjeq : j = t := by omega
+          subst hjeq
+          rw [getElem!_push_size_eq _ _ (by omega : j = s.2.size),
+            getElem!_push_size_eq _ _ (by omega : j = s.1.size)]
+          exact ⟨hpos, hrb, fun k hk => hrmu k hk⟩
+      · rw [if_neg hpos] at hres'
+        cases hres'
+
+/-! ### Glue: the Gram array fed to the pass -/
+
+private theorem g_entries (b : Hex.Matrix Int n m) (i : Nat) (hi : i < n)
+    (j : Nat) (hj : j < n) :
+    ((((Matrix.gramMatrix b).toArray.map Vector.toArray))[i]!)[j]! =
+      Hex.Vector.dotProduct (b.row ⟨i, hi⟩) (b.row ⟨j, hj⟩) := by
+  have hi1 : i < ((Matrix.gramMatrix b).toArray.map Vector.toArray).size := by
+    rw [Array.size_map, Vector.size_toArray]
+    exact hi
+  have hi2 : i < (Matrix.gramMatrix b).toArray.size := by
+    rw [Vector.size_toArray]
+    exact hi
+  rw [getElem!_pos ((Matrix.gramMatrix b).toArray.map Vector.toArray) i hi1,
+    Array.getElem_map]
+  have hj1 : j < ((Matrix.gramMatrix b).toArray[i]'hi2).toArray.size := by
+    rw [Vector.size_toArray]
+    exact hj
+  rw [getElem!_pos (((Matrix.gramMatrix b).toArray[i]'hi2).toArray) j hj1]
+  simp only [Vector.getElem_toArray]
+  simpa using Hex.Matrix.gramMatrix_getElem b ⟨i, hi⟩ ⟨j, hj⟩
+
+/-! ### Positivity of the Gram-determinant product -/
+
+private theorem normProduct_pos (b : Hex.Matrix Int n m)
+    (hpos : ∀ j : Fin n, 0 < nrm b j) :
+    ∀ t (ht : t ≤ n), 0 < GramSchmidt.Int.gramSchmidtNormProduct b t ht := by
+  intro t
+  induction t with
+  | zero =>
+      intro ht
+      simp [GramSchmidt.Int.gramSchmidtNormProduct]
+  | succ t ih =>
+      intro ht
+      rw [GramSchmidt.Int.gramSchmidtNormProduct_succ b t ht]
+      exact mul_pos (ih (Nat.le_of_succ_le ht)) (hpos ⟨t, Nat.lt_of_succ_le ht⟩)
+
+private theorem independent_of_nrm_pos (b : Hex.Matrix Int n m)
+    (hpos : ∀ j : Fin n, 0 < nrm b j) :
+    Hex.Matrix.independent b := by
+  unfold Hex.Matrix.independent GramSchmidt.Int.independent
+  intro k
+  have h := GramSchmidt.Int.gramDet_eq_prod_normSq_uncond b (k.val + 1)
+    (Nat.succ_le_of_lt k.isLt)
+  have hp := normProduct_pos b hpos (k.val + 1) (Nat.succ_le_of_lt k.isLt)
+  rw [← h] at hp
+  exact_mod_cast hp
+
+/-! ### Soundness of the interval reducedness checker -/
+
+/-- Acceptance by the fixed-precision interval checker entails the exact
+rational reducedness predicate and independence. This is the trusted
+statement consumed by `lllReducedCheck_sound` / `certCheck_sound`; the
+exact-integer fallback path is covered by `lllReducedInt_sound`. -/
+theorem lllReducedInterval_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
+    Hex.lllReducedInterval b δ η = true →
+      Hex.isLLLReduced b δ η ∧ Hex.Matrix.independent b := by
+  intro h
+  have hS : (0 : Int) < (2 : Int) ^ Hex.intervalPrec := pow_pos (by norm_num) _
+  have hSQ : (0 : Rat) < (((2 : Int) ^ Hex.intervalPrec : Int) : Rat) := by
+    exact_mod_cast hS
+  simp only [Hex.lllReducedInterval] at h
+  set S : Int := (2 : Int) ^ Hex.intervalPrec with hSdef
+  set g : Array (Array Int) := (Matrix.gramMatrix b).toArray.map Vector.toArray
+    with hgdef
+  rcases hpass : IntervalGS.pass S g n with _ | ⟨mus, bstars⟩
+  · rw [hpass] at h
+    cases h
+  rw [hpass] at h
+  rw [Bool.and_eq_true] at h
+  obtain ⟨hsizeOK, hlovOK⟩ := h
+  have hg : ∀ i (hi : i < n) j (hj : j ≤ i),
+      (g[i]!)[j]! = Hex.Vector.dotProduct (b.row ⟨i, hi⟩)
+        (b.row ⟨j, Nat.lt_of_le_of_lt hj hi⟩) :=
+    fun i hi j hj => g_entries b i hi j (Nat.lt_of_le_of_lt hj hi)
+  have hinv : Inv b S n (Nat.le_refl n) mus bstars :=
+    pass_spec b hS g hg n (Nat.le_refl n) (mus, bstars) hpass
+  obtain ⟨hszm, hszb, hrows⟩ := hinv
+  have hnrm_pos : ∀ j : Fin n, 0 < nrm b j := by
+    intro j
+    obtain ⟨hblo, hbmem, _⟩ := hrows j.val j.isLt
+    exact pos_of_mem_pos_lo hS hbmem hblo
+  -- unpack the two Bool clauses
+  unfold IntervalGS.sizeOK at hsizeOK
+  simp only [List.all_eq_true, List.mem_range, Bool.and_eq_true, decide_eq_true_eq]
+    at hsizeOK
+  unfold IntervalGS.lovaszOK at hlovOK
+  simp only [List.all_eq_true, List.mem_range, decide_eq_true_eq] at hlovOK
+  refine ⟨⟨?_, ?_⟩, independent_of_nrm_pos b hnrm_pos⟩
+  · -- size-reduced clause
+    intro i j hi hji
+    obtain ⟨hhiB, hloB⟩ := hsizeOK i hi j hji
+    obtain ⟨_, _, hmus⟩ := hrows i hi
+    have hmem := hmus j hji
+    obtain ⟨hmlo, hmhi⟩ := hmem
+    have hden : (0 : Rat) < (η.den : Rat) := by exact_mod_cast η.den_pos
+    set μv : Rat := muExact b ⟨i, hi⟩ ⟨j, Nat.lt_trans hji hi⟩ with hμv
+    have hhiQ : ((((mus[i]!)[j]!).hi : Rat)) * (η.den : Rat) ≤
+        (η.num : Rat) * ((S : Int) : Rat) := by exact_mod_cast hhiB
+    have hloQ : -((η.num : Rat) * ((S : Int) : Rat)) ≤
+        ((((mus[i]!)[j]!).lo : Rat)) * (η.den : Rat) := by exact_mod_cast hloB
+    have hηden : η * (η.den : Rat) = (η.num : Rat) := by
+      have h := Rat.num_div_den η
+      field_simp at h
+      linarith
+    have hub : μv ≤ η := by
+      have h1 : μv * (η.den : Rat) * ((S : Int) : Rat) ≤
+          (η.num : Rat) * ((S : Int) : Rat) := by nlinarith
+      have h2 : μv * (η.den : Rat) ≤ (η.num : Rat) :=
+        le_of_mul_le_mul_right h1 hSQ
+      have h3 : μv * (η.den : Rat) ≤ η * (η.den : Rat) := by
+        rw [hηden]
+        exact h2
+      exact le_of_mul_le_mul_right h3 hden
+    have hlb : -η ≤ μv := by
+      have h1 : -(η.num : Rat) * ((S : Int) : Rat) ≤
+          μv * (η.den : Rat) * ((S : Int) : Rat) := by nlinarith
+      have h2 : -(η.num : Rat) ≤ μv * (η.den : Rat) :=
+        le_of_mul_le_mul_right h1 hSQ
+      have h3 : (-η) * (η.den : Rat) ≤ μv * (η.den : Rat) := by
+        rw [neg_mul, hηden]
+        exact h2
+      exact le_of_mul_le_mul_right h3 hden
+    show μv * μv ≤ η * η
+    nlinarith
+  · -- Lovász clause
+    intro i hi
+    have hi' : i < n - 1 := by omega
+    have hcmp := hlovOK i hi'
+    have hi1n : i + 1 < n := hi
+    have hin : i < n := Nat.lt_trans (Nat.lt_succ_self i) hi
+    obtain ⟨hblo_i, hbmem_i, _⟩ := hrows i hin
+    obtain ⟨hblo_i1, hbmem_i1, hmus_i1⟩ := hrows (i + 1) hi1n
+    have hμmem := hmus_i1 i (Nat.lt_succ_self i)
+    have hδmem := mem_ofRat hS δ
+    have hlhs := mem_mul hS hδmem hbmem_i
+    have hrhs := mem_add hbmem_i1 (mem_mul hS (mem_mul hS hμmem hμmem) hbmem_i)
+    obtain ⟨_, hlhs_hi⟩ := hlhs
+    obtain ⟨hrhs_lo, _⟩ := hrhs
+    have hQ : (((Ival.mul S (Ival.ofRat S δ) (bstars[i]!)).hi : Int) : Rat) ≤
+        (((((bstars[i + 1]!).add (Ival.mul S (Ival.mul S ((mus[i+1]!)[i]!)
+          ((mus[i+1]!)[i]!)) (bstars[i]!)))).lo : Int) : Rat) := by
+      exact_mod_cast hcmp
+    have hchain := le_trans hlhs_hi (le_trans hQ hrhs_lo)
+    show δ * Hex.LLLCore.basisNormSq (GramSchmidt.Int.basis b)
+          ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩ ≤
+        Hex.LLLCore.basisNormSq (GramSchmidt.Int.basis b) ⟨i + 1, hi⟩ +
+          ((GramSchmidt.Int.coeffs b)[(⟨i + 1, hi⟩ : Fin n)][(⟨i,
+            Nat.lt_trans (Nat.lt_succ_self i) hi⟩ : Fin n)]) *
+          ((GramSchmidt.Int.coeffs b)[(⟨i + 1, hi⟩ : Fin n)][(⟨i,
+            Nat.lt_trans (Nat.lt_succ_self i) hi⟩ : Fin n)]) *
+          Hex.LLLCore.basisNormSq (GramSchmidt.Int.basis b)
+            ⟨i, Nat.lt_trans (Nat.lt_succ_self i) hi⟩
+    have := (mul_le_mul_iff_of_pos_right hSQ).mp hchain
+    exact this
+
+end HexLLLMathlib

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -455,24 +455,184 @@ private theorem getElem!_push_size_eq {α : Type*} [Inhabited α] (a : Array α)
   subst hj
   exact getElem!_push_eq a x
 
+/-- Containment for the sign-cased product bounds: the pair
+`Ival.prodBounds a b` brackets the exact product `(x·S)·(y·S)` whenever the
+inputs bracket `x·S` and `y·S`. -/
+private theorem prodBounds_le {S : Int} {a b : Ival} {x y : Rat}
+    (ha : a.mem S x) (hb : b.mem S y) :
+    (((Ival.prodBounds a b).1 : Int) : Rat) ≤ (x * S) * (y * S) ∧
+      (x * S) * (y * S) ≤ (((Ival.prodBounds a b).2 : Int) : Rat) := by
+  obtain ⟨ha1, ha2⟩ := ha
+  obtain ⟨hb1, hb2⟩ := hb
+  unfold Ival.prodBounds
+  by_cases hA : 0 ≤ a.lo
+  · have hA' : (0 : Rat) ≤ (a.lo : Rat) := by exact_mod_cast hA
+    have hx : (0 : Rat) ≤ x * S := le_trans hA' ha1
+    by_cases hB : 0 ≤ b.lo
+    · have hB' : (0 : Rat) ≤ (b.lo : Rat) := by exact_mod_cast hB
+      have hy : (0 : Rat) ≤ y * S := le_trans hB' hb1
+      rw [if_pos hA, if_pos hB]
+      constructor <;> (push_cast; nlinarith)
+    · rw [if_pos hA, if_neg hB]
+      have hB' : (b.lo : Rat) < 0 := by exact_mod_cast not_le.mp hB
+      by_cases hB2 : b.hi ≤ 0
+      · have hB2' : (b.hi : Rat) ≤ 0 := by exact_mod_cast hB2
+        have hy : y * S ≤ 0 := le_trans hb2 hB2'
+        rw [if_pos hB2]
+        constructor <;> (push_cast; nlinarith)
+      · have hB2' : (0 : Rat) < (b.hi : Rat) := by exact_mod_cast not_le.mp hB2
+        rw [if_neg hB2]
+        constructor <;> (push_cast; nlinarith)
+  · have hA' : (a.lo : Rat) < 0 := by exact_mod_cast not_le.mp hA
+    rw [if_neg hA]
+    by_cases hA2 : a.hi ≤ 0
+    · have hA2' : (a.hi : Rat) ≤ 0 := by exact_mod_cast hA2
+      have hx : x * S ≤ 0 := le_trans ha2 hA2'
+      rw [if_pos hA2]
+      by_cases hB : 0 ≤ b.lo
+      · have hB' : (0 : Rat) ≤ (b.lo : Rat) := by exact_mod_cast hB
+        have hy : (0 : Rat) ≤ y * S := le_trans hB' hb1
+        rw [if_pos hB]
+        constructor <;> (push_cast; nlinarith)
+      · rw [if_neg hB]
+        have hB' : (b.lo : Rat) < 0 := by exact_mod_cast not_le.mp hB
+        by_cases hB2 : b.hi ≤ 0
+        · have hB2' : (b.hi : Rat) ≤ 0 := by exact_mod_cast hB2
+          have hy : y * S ≤ 0 := le_trans hb2 hB2'
+          rw [if_pos hB2]
+          constructor <;> (push_cast; nlinarith)
+        · have hB2' : (0 : Rat) < (b.hi : Rat) := by exact_mod_cast not_le.mp hB2
+          rw [if_neg hB2]
+          constructor <;> (push_cast; nlinarith)
+    · have hA2' : (0 : Rat) < (a.hi : Rat) := by exact_mod_cast not_le.mp hA2
+      rw [if_neg hA2]
+      by_cases hB : 0 ≤ b.lo
+      · have hB' : (0 : Rat) ≤ (b.lo : Rat) := by exact_mod_cast hB
+        have hy : (0 : Rat) ≤ y * S := le_trans hB' hb1
+        rw [if_pos hB]
+        constructor <;> (push_cast; nlinarith)
+      · rw [if_neg hB]
+        have hB' : (b.lo : Rat) < 0 := by exact_mod_cast not_le.mp hB
+        by_cases hB2 : b.hi ≤ 0
+        · have hB2' : (b.hi : Rat) ≤ 0 := by exact_mod_cast hB2
+          have hy : y * S ≤ 0 := le_trans hb2 hB2'
+          rw [if_pos hB2]
+          constructor <;> (push_cast; nlinarith)
+        · have hB2' : (0 : Rat) < (b.hi : Rat) := by exact_mod_cast not_le.mp hB2
+          rw [if_neg hB2]
+          -- both straddle zero: bound through the side picked by the sign
+          -- of `x·S`
+          constructor
+          · show ((min (a.lo * b.hi) (a.hi * b.lo) : Int) : Rat) ≤ _
+            have hcast : ((min (a.lo * b.hi) (a.hi * b.lo) : Int) : Rat) =
+                min ((a.lo : Rat) * (b.hi : Rat)) ((a.hi : Rat) * (b.lo : Rat)) := by
+              rcases le_total (a.lo * b.hi) (a.hi * b.lo) with h | h
+              · rw [min_eq_left h]
+                rw [min_eq_left (by exact_mod_cast h)]
+                push_cast
+                ring
+              · rw [min_eq_right h]
+                rw [min_eq_right (by exact_mod_cast h)]
+                push_cast
+                ring
+            rw [hcast]
+            rcases le_total 0 (x * (S : Rat)) with hx | hx
+            · exact le_trans (min_le_right _ _) (by nlinarith)
+            · exact le_trans (min_le_left _ _) (by nlinarith)
+          · show _ ≤ ((max (a.lo * b.lo) (a.hi * b.hi) : Int) : Rat)
+            have hcast : ((max (a.lo * b.lo) (a.hi * b.hi) : Int) : Rat) =
+                max ((a.lo : Rat) * (b.lo : Rat)) ((a.hi : Rat) * (b.hi : Rat)) := by
+              rcases le_total (a.lo * b.lo) (a.hi * b.hi) with h | h
+              · rw [max_eq_right h]
+                rw [max_eq_right (by exact_mod_cast h)]
+                push_cast
+                ring
+              · rw [max_eq_left h]
+                rw [max_eq_left (by exact_mod_cast h)]
+                push_cast
+                ring
+            rw [hcast]
+            rcases le_total 0 (x * (S : Rat)) with hx | hx
+            · exact le_trans (by nlinarith :
+                (x * S) * (y * S) ≤ (a.hi : Rat) * (b.hi : Rat)) (le_max_right _ _)
+            · exact le_trans (by nlinarith :
+                (x * S) * (y * S) ≤ (a.lo : Rat) * (b.lo : Rat)) (le_max_left _ _)
+
+/-- The body of `IntervalGS.dotStep`'s exact scale-`S²` accumulation. -/
+private def dotAccStep (muA rA : Array Ival) (acc : Int × Int) (k : Nat) :
+    Int × Int :=
+  let p := Ival.prodBounds muA[k]! rA[k]!
+  (acc.1 - p.2, acc.2 - p.1)
+
+/-- The scale-`S²` accumulator of `dotStep` encloses
+`(g − Σ_{k<t} x_k·y_k)·S²` exactly (no rounding inside the fold). -/
+private theorem dotAcc_bounds {S : Int}
+    (muA rA : Array Ival) (g : Int) (t : Nat) (xs ys : Fin t → Rat)
+    (hmu : ∀ k : Fin t, (muA[k.val]!).mem S (xs k))
+    (hr : ∀ k : Fin t, (rA[k.val]!).mem S (ys k)) :
+    let acc := (List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)
+    ((acc.1 : Rat) ≤ ((g : Rat) - ∑ k, xs k * ys k) * S * S ∧
+      ((g : Rat) - ∑ k, xs k * ys k) * S * S ≤ (acc.2 : Rat)) := by
+  induction t with
+  | zero =>
+      refine ⟨?_, ?_⟩ <;> simp
+  | succ t ih =>
+      obtain ⟨ih1, ih2⟩ := ih (fun k => xs k.castSucc) (fun k => ys k.castSucc)
+        (fun k => hmu k.castSucc) (fun k => hr k.castSucc)
+      obtain ⟨hp1, hp2⟩ := prodBounds_le (hmu (Fin.last t)) (hr (Fin.last t))
+      rw [show (List.range (t + 1)).foldl (dotAccStep muA rA) (g * S * S, g * S * S) =
+          dotAccStep muA rA
+            ((List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)) t from by
+        rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]]
+      rw [Fin.sum_univ_castSucc]
+      unfold dotAccStep
+      set acc := (List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)
+      have hterm : (xs (Fin.last t) * S) * (ys (Fin.last t) * S) =
+          xs (Fin.last t) * ys (Fin.last t) * S * S := by ring
+      rw [hterm] at hp1 hp2
+      constructor
+      · push_cast
+        have heq : ((g : Rat) - (∑ k : Fin t, xs k.castSucc * ys k.castSucc +
+            xs (Fin.last t) * ys (Fin.last t))) * S * S =
+            ((g : Rat) - ∑ k : Fin t, xs k.castSucc * ys k.castSucc) * S * S -
+              xs (Fin.last t) * ys (Fin.last t) * S * S := by ring
+        rw [heq]
+        exact sub_le_sub ih1 hp2
+      · push_cast
+        have heq : ((g : Rat) - (∑ k : Fin t, xs k.castSucc * ys k.castSucc +
+            xs (Fin.last t) * ys (Fin.last t))) * S * S =
+            ((g : Rat) - ∑ k : Fin t, xs k.castSucc * ys k.castSucc) * S * S -
+              xs (Fin.last t) * ys (Fin.last t) * S * S := by ring
+        rw [heq]
+        exact sub_le_sub ih2 hp1
+
 private theorem dotStep_mem {S : Int} (hS : 0 < S)
     (muA rA : Array Ival) (g : Int) (t : Nat) (xs ys : Fin t → Rat)
     (hmu : ∀ k : Fin t, (muA[k.val]!).mem S (xs k))
     (hr : ∀ k : Fin t, (rA[k.val]!).mem S (ys k)) :
     (IntervalGS.dotStep S muA rA g t).mem S ((g : Rat) - ∑ k, xs k * ys k) := by
-  induction t with
-  | zero =>
-      simpa [IntervalGS.dotStep] using mem_ofInt S g
-  | succ t ih =>
-      have hstep : IntervalGS.dotStep S muA rA g (t + 1) =
-          (IntervalGS.dotStep S muA rA g t).sub (Ival.mul S muA[t]! rA[t]!) := by
-        unfold IntervalGS.dotStep
-        rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
-      rw [hstep, Fin.sum_univ_castSucc, sub_add_eq_sub_sub]
-      exact mem_sub
-        (ih (fun k => xs k.castSucc) (fun k => ys k.castSucc)
-          (fun k => hmu k.castSucc) (fun k => hr k.castSucc))
-        (mem_mul hS (hmu (Fin.last t)) (hr (Fin.last t)))
+  have hSQ : (0 : Rat) < (S : Rat) := by exact_mod_cast hS
+  obtain ⟨h1, h2⟩ := dotAcc_bounds muA rA g t xs ys hmu hr
+  have hfold : IntervalGS.dotStep S muA rA g t =
+      ⟨Int.fdiv ((List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)).1 S,
+        Ival.cdiv ((List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)).2 S⟩ := by
+    unfold IntervalGS.dotStep dotAccStep
+    rfl
+  rw [hfold]
+  set acc := (List.range t).foldl (dotAccStep muA rA) (g * S * S, g * S * S)
+  set V : Rat := (g : Rat) - ∑ k, xs k * ys k
+  constructor
+  · -- fdiv acc.1 S ≤ V·S
+    have hd : ((acc.1 : Rat)) / (S : Rat) ≤ V * S := by
+      rw [div_le_iff₀ hSQ]
+      calc (acc.1 : Rat) ≤ V * S * S := h1
+        _ = V * S * S := rfl
+    exact le_trans (intCast_fdiv_le _ hS) hd
+  · -- V·S ≤ cdiv acc.2 S
+    have hd : V * S ≤ ((acc.2 : Rat)) / (S : Rat) := by
+      rw [le_div_iff₀ hSQ]
+      exact h2
+    exact le_trans hd (div_le_intCast_cdiv _ hS)
 
 /-- Invariant carried by the pass across the first `t` rows: sizes are `t`,
 every `‖b*_j‖²` enclosure is strictly positive and contains the exact

--- a/progress/20260610T135533Z_6742.md
+++ b/progress/20260610T135533Z_6742.md
@@ -1,0 +1,63 @@
+# Interval reducedness checker for certCheck (#6742)
+
+## Accomplished
+
+Implemented the full directive on branch `issue-6742` (pushed; commits
+77a9ab63, b7895564), then measured, failed one required go/no-go item,
+and executed the directive's failure protocol (issue comment with
+paired measurements + diagnosis, directive left claimable, no PR).
+
+- `HexLLL/Basic.lean`: `Ival` dyadic interval kernel (endpoints over
+  `Int` mantissas at scale `2^128`; `ofInt`, `ofRat`, `add`, `sub`,
+  `mul`, `divPos`, sign-cased `prodBounds`); `IntervalGS` enclosure
+  Gram-Schmidt pass over the exact Gram matrix with exact scale-S²
+  dot accumulation and one outward rounding per dot product;
+  `lllReducedInterval`; `lllReducedCheck = interval || lllReducedInt`
+  wired into `certCheck`; `CheckerTally` diagnostics. The
+  `withRecordCheckerOutcome` effect routes the continuation value
+  through `unsafeBaseIO` because the `match unsafeBaseIO … with | () =>`
+  shape of `LLLProvider.withRecordOutcome` is dead-code-eliminated
+  (that pattern's tally never fires; the bench comment at
+  `runDispatchedFirstShortVectorChecksum` works around it in IO).
+- `HexLLLMathlib/Interval.lean` (new, ~900 lines, no sorries):
+  per-operation containment lemmas, the exact GS recurrence over the
+  Gram matrix from `basis_decomposition`/`basis_orthogonal`, the pass
+  induction, independence via `gramDet_eq_prod_normSq_uncond`, and
+  `lllReducedInterval_sound`. `certCheck_sound` statement unchanged,
+  now routed through `lllReducedCheck_sound`.
+- `HexLLL/Bench.lean`: `runCertifiedCheckerIntervalTally` observable,
+  hash-pinned to 17 interval / 0 exact decisions.
+
+Verification: `lake build HexLLL HexLLLMathlib`, `hexlll_bench verify`
+129/129 with the fplll-ffi provider, `check_dag`, `git diff --check`,
+token grep clean. Hashes identical on all paired targets.
+
+Measurements (carica, M2 Ultra; before = 01effde1, after = b7895564;
+JSON exports in /tmp/hexlll-interval-{before,after2}.json on carica):
+harsh-cubic checker n=55 7.49x (needs >=5x, pass); certified full path
+below native at n=50 (27.0 vs 132.1 ms) and n=55 (35.0 vs 233.1 ms),
+the predicted crossover realized; fallback 0; random-bounded checker
++82% at n=30 decaying to -10% at n=180, failing the <=3%-per-rung
+criterion. Codex second opinion concurred with the diagnosis and the
+no-PR call.
+
+## Current frontier
+
+The directive's random-bounded cost model only holds at the top of the
+ladder: below the operand-size crossover (~n=150 random-bounded) exact
+Bareiss ops on one-limb operands are strictly cheaper than any
+fixed-precision interval term in boxed Lean Int. Issue comment
+(https://github.com/kim-em/hex/issues/6742#issuecomment-4670992511)
+proposes three amendments: scope the non-regression criterion to upper
+rungs, allow deterministic input-size dispatch with a three-way tally,
+or require normalized balls.
+
+## Next step
+
+Await the directive author's choice of amendment; the branch converts
+to a PR directly under options 1 or 2 (option 2 needs the dispatch
+predicate plus tally extension; soundness story unchanged).
+
+## Blockers
+
+None technical; blocked on directive amendment by design.


### PR DESCRIPTION
This PR adds a sound fixed-precision dyadic interval Gram-Schmidt reducedness checker for the certified-dispatch path of `lll`, with a deterministic input-size predictor selecting between the interval pass (which wins on inputs whose exact Gram-determinant operands exceed the 128-bit working precision) and the existing exact `d`/`ν` checker. The exact integer checker remains the mandatory fallback on interval indecision, so completeness is structural rather than numerical. `certCheck_sound` statement is unchanged; soundness now routes through a new `lllReducedCheck_sound` covering all three decision paths (interval-accepted, exact-primary by predictor, exact-fallback on indecision). The dispatch tally distinguishes those three outcomes and is hash-pinned in `runCertifiedCheckerIntervalTally` to `7/10/0` across the two committed ladders (interval-accepted on harsh-cubic n≥35 and random-bounded n=180; exact-primary on the smaller-operand rungs; zero indecision).

Closes https://github.com/kim-em/hex/issues/6742 (HexLLL: fixed-precision interval reducedness checker with exact fallback).

Performance, paired against merge-base `01effde1` on carica (M2 Ultra, JSON exports `/tmp/hexlll-interval-{before,after3}.json`):

| target | before | after | speedup |
|---|---|---|---|
| harsh-cubic checker n=55 | 237.5 ms | 31.5 ms | 7.53× |
| harsh-cubic certified path n=55 | 237.4 ms | 33.6 ms | 7.06× |
| harsh-cubic native n=55 | 233.3 ms | 224.7 ms | 1.04× |
| random-bounded checker n=180 | 882.4 ms | 790.0 ms | 1.12× |

The certified harsh-cubic full path now crosses below Lean native at n=50 (26.1 ms vs 134.8 ms) and n=55 (33.6 ms vs 224.7 ms) — the predicted crossover, realized with margin. On the small-operand rungs the predictor routes to the exact checker, so those code paths are bit-identical to baseline; the standard `repeats := 3` bench config showed apparent regressions of up to +6% on those rungs (n=75, n=90), which the interleaved 10-trial paired A/B on snapshotted binaries shows to be bench variance on identical code:

| rung | B median | B min | A median | A min | Δmedian | Δmin |
|---|---|---|---|---|---|---|
| 30 | 2.93 ms | 2.73 ms | 2.91 ms | 2.74 ms | -0.6% | +0.3% |
| 45 | 10.22 ms | 9.85 ms | 9.93 ms | 9.68 ms | -2.8% | -1.7% |
| 60 | 25.29 ms | 24.55 ms | 24.74 ms | 23.85 ms | -2.2% | -2.9% |
| 75 | 47.48 ms | 47.08 ms | 47.27 ms | 46.98 ms | -0.4% | -0.2% |
| 90 | 84.60 ms | 84.22 ms | 84.26 ms | 83.63 ms | -0.4% | -0.7% |
| 120 | 213.05 ms | 211.29 ms | 213.15 ms | 210.41 ms | +0.0% | -0.4% |

Worst median regression +0.0% at n=120; worst min regression +0.3% at n=30. No rung exceeds the 3% non-regression bound.

Implementation notes. Dot products accumulate exactly at scale S² (endpoint products of scale-S mantissas) and round outward through one floor / ceiling division at the end, so an `n`-term dot recurrence costs one rounding instead of `n` of them; this matters because rounding through boxed Lean `Int` is more expensive than the multiplications themselves. Endpoint products use sign-cased bounds — two multiplications in the sign-definite cases. The size predictor compares `n · maxGramDiagBits` to a fixed multiple of `intervalPrec + maxGramDiagBits`, derived from the per-operation cost ratio of the two checkers; the bit-length scan is `O(n·m)`, negligible against either checker. Misclassification at the boundary errs toward the exact checker, which never regresses against the pre-interval baseline.

Verification: `lake build HexLLL HexLLLMathlib`, `lake exe hexlll_bench verify` 129/129 with the `fplll-ffi` provider loaded, `scripts/check_dag.py`, `git diff --check`, added-line forbidden-token grep finds no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`. Observed hashes are identical to baseline on every paired target.

🤖 Prepared with Claude Code
