### PR TITLE
feat: adjust the Isabelle-certified comparator curves for their per-request floor

### DIFF
--- a/progress/20260611T052001Z_issue-6759-review.md
+++ b/progress/20260611T052001Z_issue-6759-review.md
@@ -1,0 +1,29 @@
+# Progress: #6759 review
+
+## Accomplished
+
+Reviewed the documentation-only diff for the LLL comparator figure footnotes and
+the matching `reports/hex-lll-performance.md` prose. Checked the surrounding
+harsh-cubic ratio table and trend text, the plot-generation code, and the
+generated SVG footnote text.
+
+Verified that regenerating each comparator SVG twice into `/private/tmp`
+produces byte-identical files with the new `tight_layout` plus
+`subplots_adjust(bottom=0.16)` sequence.
+
+## Current frontier
+
+The main review concern is prose shape: the stale harsh-cubic paragraph needed
+replacement because it contradicted the five-series figure, but the new report
+footnote sentences duplicate the SVG footnote text and read more like a note
+about the footnote than report prose.
+
+## Next step
+
+Consider tightening the report text around the two figures so it states the
+same fact once per figure, directly, while preserving the corrected
+harsh-cubic five-series/crossover description.
+
+## Blockers
+
+None.

--- a/progress/20260611T052112Z_issue-6759.md
+++ b/progress/20260611T052112Z_issue-6759.md
@@ -1,0 +1,53 @@
+# Progress: #6759 — footnote the Isabelle-certified per-request fplll fork
+
+## Accomplished
+
+Documentation-only change per issue #6759.
+
+- `scripts/plots/hex-lll-comparator.py`: in `plot()`, after
+  `fig.tight_layout()`, render a one-line `fig.text` footnote below the
+  axes (italic, gray, fontsize 7) whenever the `Isabelle certified`
+  series is among the plotted series. Wording is the timeless shape the
+  issue specifies: "Isabelle certified forks an fplll subprocess per
+  request (~19 ms); this fixed cost dominates its small-n rungs." The
+  ~19 ms is sourced from the committed §Per-call comparator overhead
+  measurement (~18.8 ms), not re-measured. Reserve room with
+  `fig.subplots_adjust(bottom=0.16)`.
+- Regenerated both family SVGs (deterministic; `svg.hashsalt` pinned;
+  re-running twice is byte-identical, confirmed by Codex too).
+- `reports/hex-lll-performance.md`: a matching footnote sentence beneath
+  each embedded figure, cross-referencing §Per-call comparator overhead.
+
+Also corrected stale prose discovered next to the figures: commit #6756
+re-enabled the certified curves on the harsh-cubic figure (it now plots
+all five series, with a Lean-certified crossover story) but left the
+description claiming "the harsh-cubic plot shows only the three
+native/fpLLL series ... certified curves ... are omitted" plus a stale
+`1.05..1.67×` ratio. That prose directly contradicted both the current
+figure and the new harsh-cubic footnote, so the paragraph now describes
+the five-series figure and the crossover (below Lean native at n=30,
+0.15× at n=55), grounded in the report's own committed harsh-cubic trend
+prose and ratio table.
+
+## Current frontier
+
+Second opinion (Codex) confirmed: harsh-cubic rewrite is the right call
+(not scope creep), footnote wording is anchored without editorializing,
+no determinism concern with `subplots_adjust` after `tight_layout`. Its
+one Low note (report sentences read meta, "the figure footnote records
+that...") is addressed: both report sentences now state the fork fact
+directly and note the figure footnote in passing.
+
+Verification: both figures regenerate cleanly and deterministically;
+`git diff` touches only the two SVGs, the plot script, and the report;
+`scripts/plots/hex-lll-scaling.py --all` reproduces the scaling tables
+with no data change; `git diff --check` clean. No changes to
+measurements, eligibility, ratio tables, exports, or Lean code.
+
+## Next step
+
+Open the PR; check for merge conflicts and CI.
+
+## Blockers
+
+None.

--- a/progress/20260611T052929Z_adjusted-isabelle-review.md
+++ b/progress/20260611T052929Z_adjusted-isabelle-review.md
@@ -1,0 +1,23 @@
+# Progress: adjusted Isabelle-certified comparator review
+
+## Accomplished
+
+Reviewed the mid-PR change that subtracts a fixed `18.8 ms` Isabelle-certified
+fork overhead from plotted comparator curves. Checked the surrounding report
+text, plotting script, scaling script, regenerated-plot code path, and the
+committed certified export values.
+
+## Current frontier
+
+The review found no direct plotting bug, but identified methodological and
+provenance concerns around subtracting the whole trivial end-to-end overhead
+and around applying an audit-host measurement to carica bench curves.
+
+## Next step
+
+Use the review findings to revise the PR text/code before merge, especially by
+making the adjustment provenance explicit and guarding the adjusted series.
+
+## Blockers
+
+None.

--- a/progress/20260611T054500Z_issue-6759-adjusted.md
+++ b/progress/20260611T054500Z_issue-6759-adjusted.md
@@ -1,0 +1,51 @@
+# Progress: #6759 — adjust the Isabelle-certified comparator curves for the per-request floor
+
+## Accomplished
+
+Mid-PR, the issue author asked for more than a footnote: subtract the
+per-request overhead from the Isabelle-certified curves themselves and
+have the footnote state the adjustment amount.
+
+- `scripts/plots/hex-lll-comparator.py`: new
+  `ISABELLE_CERTIFIED_FLOOR_MS = 18.8` (the committed §Per-call
+  comparator overhead trivial-request floor, dominated by the per-request
+  `fplll` subprocess fork) and `subtract_request_floor()`, which
+  subtracts the floor from the Isabelle-certified series, relabels it
+  `Isabelle certified (adjusted)`, and raises if any rung sits at or
+  below the floor (guards against nonpositive log-scale points). The
+  footnote now states the adjustment: "Isabelle certified is adjusted
+  down by its ~18.8 ms per-request floor, a fixed trivial-request cost
+  dominated by the fplll subprocess fork."
+- Only the Isabelle-certified series is adjusted; Lean-certified and
+  fpLLL call `fplll` in process, Isabelle-native is ~9 µs.
+- Regenerated both SVGs deterministically.
+- `reports/hex-lll-performance.md`: figure prose now describes the
+  adjustment, discloses it is the audit-host trivial-request floor, and
+  states that the ratio tables and scaling fits keep the raw medians
+  (only the plotted curve is adjusted). Series enumeration updated to
+  `Isabelle certified (adjusted)`.
+
+## Current frontier
+
+Second opinion (Codex) on the adjustment flagged: (1) 18.8 ms is the
+trivial-request floor not purely the fork — reworded to "per-request
+floor ... dominated by the fplll subprocess fork"; (2) audit-host vs
+carica provenance — now disclosed in prose ("audit-host figure"); (3)
+scaling cross-ref could imply adjusted numbers — added "scaling fits
+keep the raw medians"; (4) guard nonpositive adjusted medians — added.
+All four addressed.
+
+Verification: both figures regenerate cleanly and deterministically;
+`git diff` touches only the two SVGs, the plot script, and the report;
+`scripts/plots/hex-lll-scaling.py --all` reproduces the scaling tables
+with no data change; `git diff --check` clean. Raw medians, eligibility,
+ratio tables, exports, and Lean code unchanged.
+
+## Next step
+
+Update PR title/body to reflect the adjusted-curve scope; push; re-check
+CI.
+
+## Blockers
+
+None.

--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -29,8 +29,8 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 69.05 303.64
-L 507.6 303.64
+    <path d="M 69.05 290.304
+L 507.6 290.304
 L 507.6 25.44
 L 69.05 25.44
 z
@@ -39,9 +39,9 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 88.984091 303.64
+      <path d="M 88.984091 290.304
 L 88.984091 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
@@ -50,12 +50,12 @@ L 0 3.5
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 15 -->
-      <g transform="translate(82.621591 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(82.621591 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -104,18 +104,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 128.852273 303.64
+      <path d="M 128.852273 290.304
 L 128.852273 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 20 -->
-      <g transform="translate(122.489773 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(122.489773 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-32" d="M 1228 531
 L 3431 531
@@ -170,18 +170,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 168.720455 303.64
+      <path d="M 168.720455 290.304
 L 168.720455 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 25 -->
-      <g transform="translate(162.357955 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(162.357955 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-32"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -189,18 +189,18 @@ L 168.720455 25.44
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.588636 303.64
+      <path d="M 208.588636 290.304
 L 208.588636 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 30 -->
-      <g transform="translate(202.226136 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(202.226136 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -242,18 +242,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 248.456818 303.64
+      <path d="M 248.456818 290.304
 L 248.456818 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 35 -->
-      <g transform="translate(242.094318 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(242.094318 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-33"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -261,18 +261,18 @@ L 248.456818 25.44
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 288.325 303.64
+      <path d="M 288.325 290.304
 L 288.325 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="288.325" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="288.325" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 40 -->
-      <g transform="translate(281.9625 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(281.9625 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116
 L 825 1625
@@ -301,18 +301,18 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 328.193182 303.64
+      <path d="M 328.193182 290.304
 L 328.193182 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 45 -->
-      <g transform="translate(321.830682 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(321.830682 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-34"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -320,18 +320,18 @@ L 328.193182 25.44
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 368.061364 303.64
+      <path d="M 368.061364 290.304
 L 368.061364 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="368.061364" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="368.061364" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 50 -->
-      <g transform="translate(361.698864 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(361.698864 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
       </g>
@@ -339,18 +339,18 @@ L 368.061364 25.44
     </g>
     <g id="xtick_9">
      <g id="line2d_17">
-      <path d="M 407.929545 303.64
+      <path d="M 407.929545 290.304
 L 407.929545 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 55 -->
-      <g transform="translate(401.567045 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(401.567045 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-35"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -358,18 +358,18 @@ L 407.929545 25.44
     </g>
     <g id="xtick_10">
      <g id="line2d_19">
-      <path d="M 447.797727 303.64
+      <path d="M 447.797727 290.304
 L 447.797727 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="447.797727" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="447.797727" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 60 -->
-      <g transform="translate(441.435227 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(441.435227 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
@@ -409,18 +409,18 @@ z
     </g>
     <g id="xtick_11">
      <g id="line2d_21">
-      <path d="M 487.665909 303.64
+      <path d="M 487.665909 290.304
 L 487.665909 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 65 -->
-      <g transform="translate(481.303409 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(481.303409 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-36"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
       </g>
@@ -428,7 +428,7 @@ L 487.665909 25.44
     </g>
     <g id="text_12">
      <!-- harsh-cubic dimension n -->
-     <g transform="translate(226.98125 331.916562) scale(0.1 -0.1)">
+     <g transform="translate(226.98125 318.580562) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-68" d="M 3513 2113
 L 3513 0
@@ -771,9 +771,9 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_23">
-      <path d="M 69.05 263.267213
-L 507.6 263.267213
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 251.866552
+L 507.6 251.866552
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <defs>
@@ -782,12 +782,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="263.267213" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="251.866552" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1 ms -->
-      <g transform="translate(37.559375 267.066431) scale(0.1 -0.1)">
+      <g transform="translate(37.559375 255.665771) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -797,18 +797,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_25">
-      <path d="M 69.05 187.889761
-L 507.6 187.889761
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 180.10245
+L 507.6 180.10245
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="187.889761" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="180.10245" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 191.68898) scale(0.1 -0.1)">
+      <g transform="translate(31.196875 183.901669) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -819,18 +819,18 @@ L 507.6 187.889761
     </g>
     <g id="ytick_3">
      <g id="line2d_27">
-      <path d="M 69.05 112.51231
-L 507.6 112.51231
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 108.338348
+L 507.6 108.338348
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="112.51231" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="108.338348" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 116.311529) scale(0.1 -0.1)">
+      <g transform="translate(24.834375 112.137567) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -842,18 +842,18 @@ L 507.6 112.51231
     </g>
     <g id="ytick_4">
      <g id="line2d_29">
-      <path d="M 69.05 37.134859
-L 507.6 37.134859
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 36.574246
+L 507.6 36.574246
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="37.134859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="36.574246" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 1 s -->
-      <g transform="translate(47.3 40.934078) scale(0.1 -0.1)">
+      <g transform="translate(47.3 40.373464) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -862,9 +862,9 @@ L 507.6 37.134859
     </g>
     <g id="ytick_5">
      <g id="line2d_31">
-      <path d="M 69.05 302.68048
-L 507.6 302.68048
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 289.390476
+L 507.6 289.390476
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <defs>
@@ -873,373 +873,373 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="302.68048" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="289.390476" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_33">
-      <path d="M 69.05 293.262916
-L 507.6 293.262916
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 280.42436
+L 507.6 280.42436
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="293.262916" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="280.42436" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_35">
-      <path d="M 69.05 285.958086
-L 507.6 285.958086
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 273.4697
+L 507.6 273.4697
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="285.958086" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="273.4697" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_37">
-      <path d="M 69.05 279.989606
-L 507.6 279.989606
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 267.787329
+L 507.6 267.787329
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="279.989606" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="267.787329" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_39">
-      <path d="M 69.05 274.943328
-L 507.6 274.943328
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 262.982952
+L 507.6 262.982952
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="274.943328" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="262.982952" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_41">
-      <path d="M 69.05 270.572042
-L 507.6 270.572042
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 258.821212
+L 507.6 258.821212
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="270.572042" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="258.821212" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_43">
-      <path d="M 69.05 266.716296
-L 507.6 266.716296
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 255.150297
+L 507.6 255.150297
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="266.716296" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="255.150297" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_45">
-      <path d="M 69.05 240.576339
-L 507.6 240.576339
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 230.263405
+L 507.6 230.263405
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="240.576339" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="230.263405" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_47">
-      <path d="M 69.05 227.303028
-L 507.6 227.303028
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 217.626374
+L 507.6 217.626374
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="227.303028" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="217.626374" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_49">
-      <path d="M 69.05 217.885465
-L 507.6 217.885465
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 208.660257
+L 507.6 208.660257
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="217.885465" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="208.660257" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_51">
-      <path d="M 69.05 210.580635
-L 507.6 210.580635
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 201.705597
+L 507.6 201.705597
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="210.580635" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="201.705597" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_53">
-      <path d="M 69.05 204.612155
-L 507.6 204.612155
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 196.023226
+L 507.6 196.023226
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="204.612155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="196.023226" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_55">
-      <path d="M 69.05 199.565876
-L 507.6 199.565876
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 191.21885
+L 507.6 191.21885
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="199.565876" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="191.21885" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_57">
-      <path d="M 69.05 195.194591
-L 507.6 195.194591
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 187.05711
+L 507.6 187.05711
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="195.194591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="187.05711" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_59">
-      <path d="M 69.05 191.338844
-L 507.6 191.338844
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 183.386195
+L 507.6 183.386195
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="191.338844" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="183.386195" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_61">
-      <path d="M 69.05 165.198888
-L 507.6 165.198888
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 158.499303
+L 507.6 158.499303
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="165.198888" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="158.499303" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_63">
-      <path d="M 69.05 151.925577
-L 507.6 151.925577
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 145.862272
+L 507.6 145.862272
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="151.925577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="145.862272" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_65">
-      <path d="M 69.05 142.508014
-L 507.6 142.508014
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 136.896155
+L 507.6 136.896155
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="142.508014" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="136.896155" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_67">
-      <path d="M 69.05 135.203184
-L 507.6 135.203184
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 129.941495
+L 507.6 129.941495
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="135.203184" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="129.941495" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_69">
-      <path d="M 69.05 129.234703
-L 507.6 129.234703
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 124.259124
+L 507.6 124.259124
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="129.234703" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="124.259124" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_71">
-      <path d="M 69.05 124.188425
-L 507.6 124.188425
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 119.454748
+L 507.6 119.454748
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="124.188425" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="119.454748" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_73">
-      <path d="M 69.05 119.81714
-L 507.6 119.81714
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 115.293008
+L 507.6 115.293008
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="119.81714" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="115.293008" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_75">
-      <path d="M 69.05 115.961393
-L 507.6 115.961393
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 111.622093
+L 507.6 111.622093
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="115.961393" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="111.622093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_77">
-      <path d="M 69.05 89.821436
-L 507.6 89.821436
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 86.7352
+L 507.6 86.7352
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="89.821436" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="86.7352" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_79">
-      <path d="M 69.05 76.548126
-L 507.6 76.548126
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 74.098169
+L 507.6 74.098169
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="76.548126" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="74.098169" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_81">
-      <path d="M 69.05 67.130562
-L 507.6 67.130562
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 65.132053
+L 507.6 65.132053
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="67.130562" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="65.132053" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_83">
-      <path d="M 69.05 59.825733
-L 507.6 59.825733
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 58.177393
+L 507.6 58.177393
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="59.825733" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="58.177393" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_85">
-      <path d="M 69.05 53.857252
-L 507.6 53.857252
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 52.495022
+L 507.6 52.495022
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="53.857252" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="52.495022" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_87">
-      <path d="M 69.05 48.810974
-L 507.6 48.810974
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 47.690646
+L 507.6 47.690646
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="48.810974" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="47.690646" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_89">
-      <path d="M 69.05 44.439689
-L 507.6 44.439689
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 43.528906
+L 507.6 43.528906
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="44.439689" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="43.528906" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_91">
-      <path d="M 69.05 40.583942
-L 507.6 40.583942
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 39.857991
+L 507.6 39.857991
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="40.583942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="39.857991" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_17">
      <!-- median wall time per call -->
-     <g transform="translate(18.754688 227.764219) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.754688 221.096219) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500
 L 844 3500
@@ -1341,18 +1341,18 @@ z
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 272.109988
-L 128.852273 237.86845
-L 168.720455 209.087969
-L 208.588636 180.84782
-L 248.456818 155.163893
-L 288.325 131.188465
-L 328.193182 109.410202
-L 368.061364 89.97012
-L 407.929545 70.94492
-L 447.797727 53.984059
-L 487.665909 38.811177
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 260.285434
+L 128.852273 227.685323
+L 168.720455 200.284485
+L 208.588636 173.398076
+L 248.456818 148.945353
+L 288.325 126.119229
+L 328.193182 105.384945
+L 368.061364 86.876757
+L 407.929545 68.763562
+L 447.797727 52.61575
+L 487.665909 38.170206
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m0fee27a2d2" d="M -3 3
 L 3 3
@@ -1361,33 +1361,33 @@ L -3 -3
 z
 " style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m0fee27a2d2" x="88.984091" y="272.109988" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="128.852273" y="237.86845" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="168.720455" y="209.087969" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="208.588636" y="180.84782" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="248.456818" y="155.163893" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="288.325" y="131.188465" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="328.193182" y="109.410202" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="368.061364" y="89.97012" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="407.929545" y="70.94492" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="447.797727" y="53.984059" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.811177" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m0fee27a2d2" x="88.984091" y="260.285434" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.852273" y="227.685323" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.720455" y="200.284485" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.588636" y="173.398076" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.456818" y="148.945353" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="288.325" y="126.119229" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.193182" y="105.384945" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="368.061364" y="86.876757" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.929545" y="68.763562" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="447.797727" y="52.61575" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.170206" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
-    <path d="M 88.984091 285.011623
-L 128.852273 246.454919
-L 168.720455 216.675724
-L 208.588636 189.45109
-L 248.456818 165.782879
-L 288.325 142.968173
-L 328.193182 121.571132
-L 368.061364 102.494292
-L 407.929545 84.642874
-L 447.797727 68.67599
-L 487.665909 52.714462
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 272.568607
+L 128.852273 235.860185
+L 168.720455 207.508507
+L 208.588636 181.588933
+L 248.456818 159.0553
+L 288.325 137.334256
+L 328.193182 116.96292
+L 368.061364 98.800561
+L 407.929545 81.804881
+L 447.797727 66.603397
+L 487.665909 51.407013
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
@@ -1401,33 +1401,33 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="285.011623" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="246.454919" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="216.675724" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="189.45109" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="165.782879" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="288.325" y="142.968173" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="121.571132" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="368.061364" y="102.494292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="84.642874" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="447.797727" y="68.67599" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="52.714462" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m2451d16133" x="88.984091" y="272.568607" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="235.860185" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="207.508507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="181.588933" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="159.0553" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="288.325" y="137.334256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="116.96292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="368.061364" y="98.800561" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="81.804881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="447.797727" y="66.603397" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="51.407013" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_95">
-    <path d="M 88.984091 164.679288
-L 128.852273 159.91134
-L 168.720455 153.504926
-L 208.588636 142.680731
-L 248.456818 131.435465
-L 288.325 114.886812
-L 328.193182 99.709285
-L 368.061364 83.256917
-L 407.929545 67.100424
-L 447.797727 51.431135
-L 487.665909 38.085455
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 158.004611
+L 128.852273 153.465222
+L 168.720455 147.365911
+L 208.588636 137.060593
+L 248.456818 126.354388
+L 288.325 110.599024
+L 328.193182 96.149058
+L 368.061364 80.485363
+L 407.929545 65.10336
+L 447.797727 50.185205
+L 487.665909 37.479273
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="ma559d3018c" d="M 0 -3.5
 L -3.5 3.5
@@ -1435,31 +1435,31 @@ L 3.5 3.5
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#ma559d3018c" x="88.984091" y="164.679288" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="128.852273" y="159.91134" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="153.504926" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="142.680731" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="131.435465" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="288.325" y="114.886812" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="99.709285" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="368.061364" y="83.256917" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="67.100424" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="447.797727" y="51.431135" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="487.665909" y="38.085455" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#ma559d3018c" x="88.984091" y="158.004611" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.852273" y="153.465222" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.720455" y="147.365911" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.588636" y="137.060593" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.456818" y="126.354388" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="288.325" y="110.599024" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.193182" y="96.149058" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="368.061364" y="80.485363" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.929545" y="65.10336" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="447.797727" y="50.185205" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.665909" y="37.479273" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_96">
-    <path d="M 88.984091 268.537752
-L 128.852273 235.999937
-L 168.720455 208.574541
-L 208.588636 196.75216
-L 248.456818 183.943039
-L 288.325 174.393449
-L 328.193182 164.911052
-L 368.061364 155.315761
-L 407.929545 146.898012
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 256.884439
+L 128.852273 225.906381
+L 168.720455 199.795668
+L 208.588636 188.540014
+L 248.456818 176.344921
+L 288.325 167.253106
+L 328.193182 158.225265
+L 368.061364 149.089941
+L 407.929545 141.075712
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
 L 4.596194 0
@@ -1468,31 +1468,31 @@ L -4.596194 -0
 z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="268.537752" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="235.999937" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="208.574541" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="196.75216" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="183.943039" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="288.325" y="174.393449" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="164.911052" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="368.061364" y="155.315761" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="146.898012" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m633b1844ca" x="88.984091" y="256.884439" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.852273" y="225.906381" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.720455" y="199.795668" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.588636" y="188.540014" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.456818" y="176.344921" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="288.325" y="167.253106" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.193182" y="158.225265" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="368.061364" y="149.089941" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.929545" y="141.075712" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_97">
-    <path d="M 88.984091 290.994545
-L 128.852273 269.4006
-L 168.720455 253.838267
-L 208.588636 240.743637
-L 248.456818 231.973607
-L 288.325 221.394911
-L 328.193182 212.520054
-L 368.061364 206.017026
-L 407.929545 197.930071
-L 447.797727 190.597257
-L 487.665909 185.444331
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 278.264727
+L 128.852273 257.705925
+L 168.720455 242.8896
+L 208.588636 230.422684
+L 248.456818 222.07306
+L 288.325 212.001472
+L 328.193182 203.552046
+L 368.061364 197.360752
+L 407.929545 189.66146
+L 447.797727 182.680157
+L 487.665909 177.774245
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m25acbb3ce1" d="M -0 3.5
 L 3.5 -3.5
@@ -1500,33 +1500,33 @@ L -3.5 -3.5
 z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="290.994545" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="269.4006" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="253.838267" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="240.743637" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="231.973607" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="288.325" y="221.394911" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="212.520054" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="368.061364" y="206.017026" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="197.930071" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="447.797727" y="190.597257" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="185.444331" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m25acbb3ce1" x="88.984091" y="278.264727" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="128.852273" y="257.705925" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="168.720455" y="242.8896" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="208.588636" y="230.422684" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="248.456818" y="222.07306" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="288.325" y="212.001472" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="328.193182" y="203.552046" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="368.061364" y="197.360752" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="407.929545" y="189.66146" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="447.797727" y="182.680157" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="487.665909" y="177.774245" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 69.05 303.64
+    <path d="M 69.05 290.304
 L 69.05 25.44
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 507.6 303.64
+    <path d="M 507.6 290.304
 L 507.6 25.44
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 69.05 303.64
-L 507.6 303.64
+    <path d="M 69.05 290.304
+L 507.6 290.304
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
@@ -1809,10 +1809,793 @@ L 98.05 97.250937
     </g>
    </g>
   </g>
+  <g id="text_24">
+   <!-- Isabelle certified forks an fplll subprocess per request (~19 ms); this fixed cost dominates its small-n rungs. -->
+   <g style="fill: #595959" transform="translate(69.815547 340.688219) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-Oblique-49" d="M 1081 4666
+L 1716 4666
+L 806 0
+L 172 0
+L 1081 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-73" d="M 3200 3397
+L 3091 2853
+Q 2863 2978 2609 3040
+Q 2356 3103 2088 3103
+Q 1634 3103 1373 2948
+Q 1113 2794 1113 2528
+Q 1113 2219 1719 2053
+Q 1766 2041 1788 2034
+L 1972 1978
+Q 2547 1819 2739 1644
+Q 2931 1469 2931 1166
+Q 2931 609 2489 259
+Q 2047 -91 1331 -91
+Q 1053 -91 747 -37
+Q 441 16 72 128
+L 184 722
+Q 500 559 806 475
+Q 1113 391 1394 391
+Q 1816 391 2080 572
+Q 2344 753 2344 1031
+Q 2344 1331 1650 1516
+L 1591 1531
+L 1394 1581
+Q 956 1697 753 1886
+Q 550 2075 550 2369
+Q 550 2928 970 3256
+Q 1391 3584 2113 3584
+Q 2397 3584 2667 3537
+Q 2938 3491 3200 3397
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-61" d="M 3438 1997
+L 3047 0
+L 2472 0
+L 2578 531
+Q 2325 219 2001 64
+Q 1678 -91 1281 -91
+Q 834 -91 548 182
+Q 263 456 263 884
+Q 263 1497 752 1853
+Q 1241 2209 2100 2209
+L 2900 2209
+L 2931 2363
+Q 2938 2388 2941 2417
+Q 2944 2447 2944 2509
+Q 2944 2788 2717 2942
+Q 2491 3097 2081 3097
+Q 1800 3097 1504 3025
+Q 1209 2953 897 2809
+L 997 3341
+Q 1322 3463 1633 3523
+Q 1944 3584 2234 3584
+Q 2853 3584 3176 3315
+Q 3500 3047 3500 2534
+Q 3500 2431 3484 2292
+Q 3469 2153 3438 1997
+z
+M 2816 1759
+L 2241 1759
+Q 1534 1759 1195 1570
+Q 856 1381 856 984
+Q 856 709 1029 553
+Q 1203 397 1509 397
+Q 1978 397 2328 733
+Q 2678 1069 2791 1631
+L 2816 1759
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-62" d="M 3169 2138
+Q 3169 2591 2961 2847
+Q 2753 3103 2388 3103
+Q 2122 3103 1889 2973
+Q 1656 2844 1484 2597
+Q 1303 2338 1198 1995
+Q 1094 1653 1094 1313
+Q 1094 881 1298 636
+Q 1503 391 1863 391
+Q 2134 391 2365 517
+Q 2597 644 2772 891
+Q 2950 1147 3059 1487
+Q 3169 1828 3169 2138
+z
+M 1381 2969
+Q 1594 3256 1914 3420
+Q 2234 3584 2584 3584
+Q 3122 3584 3439 3221
+Q 3756 2859 3756 2241
+Q 3756 1734 3570 1259
+Q 3384 784 3041 416
+Q 2816 172 2522 40
+Q 2228 -91 1906 -91
+Q 1566 -91 1316 65
+Q 1066 222 909 531
+L 806 0
+L 231 0
+L 1178 4863
+L 1753 4863
+L 1381 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-65" d="M 3078 2063
+Q 3088 2113 3092 2166
+Q 3097 2219 3097 2272
+Q 3097 2653 2873 2875
+Q 2650 3097 2266 3097
+Q 1838 3097 1509 2826
+Q 1181 2556 1013 2059
+L 3078 2063
+z
+M 3578 1613
+L 903 1613
+Q 884 1494 878 1425
+Q 872 1356 872 1306
+Q 872 872 1139 634
+Q 1406 397 1894 397
+Q 2269 397 2603 481
+Q 2938 566 3225 728
+L 3116 159
+Q 2806 34 2476 -28
+Q 2147 -91 1806 -91
+Q 1078 -91 686 257
+Q 294 606 294 1247
+Q 294 1794 489 2264
+Q 684 2734 1063 3103
+Q 1306 3334 1642 3459
+Q 1978 3584 2356 3584
+Q 2950 3584 3301 3228
+Q 3653 2872 3653 2272
+Q 3653 2128 3634 1964
+Q 3616 1800 3578 1613
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6c" d="M 1172 4863
+L 1747 4863
+L 800 0
+L 225 0
+L 1172 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-63" d="M 3431 3366
+L 3316 2797
+Q 3109 2947 2876 3022
+Q 2644 3097 2394 3097
+Q 2119 3097 1870 3000
+Q 1622 2903 1453 2725
+Q 1184 2453 1037 2087
+Q 891 1722 891 1331
+Q 891 859 1127 628
+Q 1363 397 1844 397
+Q 2081 397 2348 469
+Q 2616 541 2906 684
+L 2797 116
+Q 2547 13 2283 -39
+Q 2019 -91 1741 -91
+Q 1044 -91 669 257
+Q 294 606 294 1253
+Q 294 1797 489 2255
+Q 684 2713 1069 3078
+Q 1331 3328 1684 3456
+Q 2038 3584 2456 3584
+Q 2700 3584 2940 3529
+Q 3181 3475 3431 3366
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-72" d="M 2853 2969
+Q 2766 3016 2653 3041
+Q 2541 3066 2413 3066
+Q 1953 3066 1609 2717
+Q 1266 2369 1153 1784
+L 800 0
+L 225 0
+L 909 3500
+L 1484 3500
+L 1375 2956
+Q 1603 3259 1920 3421
+Q 2238 3584 2597 3584
+Q 2691 3584 2781 3573
+Q 2872 3563 2963 3538
+L 2853 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-74" d="M 2706 3500
+L 2619 3053
+L 1472 3053
+L 1100 1153
+Q 1081 1047 1072 975
+Q 1063 903 1063 863
+Q 1063 663 1183 572
+Q 1303 481 1569 481
+L 2150 481
+L 2053 0
+L 1503 0
+Q 991 0 739 200
+Q 488 400 488 806
+Q 488 878 497 964
+Q 506 1050 525 1153
+L 897 3053
+L 409 3053
+L 500 3500
+L 978 3500
+L 1172 4494
+L 1747 4494
+L 1556 3500
+L 2706 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-69" d="M 1172 4863
+L 1747 4863
+L 1606 4134
+L 1031 4134
+L 1172 4863
+z
+M 909 3500
+L 1484 3500
+L 800 0
+L 225 0
+L 909 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-66" d="M 3059 4863
+L 2969 4384
+L 2419 4384
+Q 2106 4384 1964 4261
+Q 1822 4138 1753 3809
+L 1691 3500
+L 2638 3500
+L 2553 3053
+L 1606 3053
+L 1013 0
+L 434 0
+L 1031 3053
+L 481 3053
+L 563 3500
+L 1113 3500
+L 1159 3744
+Q 1278 4363 1576 4613
+Q 1875 4863 2516 4863
+L 3059 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-64" d="M 2675 525
+Q 2444 222 2128 65
+Q 1813 -91 1428 -91
+Q 903 -91 598 267
+Q 294 625 294 1247
+Q 294 1766 478 2236
+Q 663 2706 1013 3078
+Q 1244 3325 1534 3454
+Q 1825 3584 2144 3584
+Q 2481 3584 2739 3421
+Q 2997 3259 3138 2956
+L 3513 4863
+L 4091 4863
+L 3144 0
+L 2566 0
+L 2675 525
+z
+M 891 1350
+Q 891 897 1095 644
+Q 1300 391 1663 391
+Q 1931 391 2161 520
+Q 2391 650 2566 903
+Q 2750 1166 2856 1509
+Q 2963 1853 2963 2188
+Q 2963 2622 2758 2865
+Q 2553 3109 2194 3109
+Q 1922 3109 1687 2981
+Q 1453 2853 1288 2613
+Q 1106 2353 998 2009
+Q 891 1666 891 1350
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6f" d="M 1625 -91
+Q 1009 -91 651 289
+Q 294 669 294 1325
+Q 294 1706 417 2101
+Q 541 2497 738 2766
+Q 1047 3184 1428 3384
+Q 1809 3584 2291 3584
+Q 2888 3584 3255 3212
+Q 3622 2841 3622 2241
+Q 3622 1825 3500 1412
+Q 3378 1000 3181 728
+Q 2875 309 2494 109
+Q 2113 -91 1625 -91
+z
+M 891 1344
+Q 891 869 1089 633
+Q 1288 397 1691 397
+Q 2269 397 2648 901
+Q 3028 1406 3028 2181
+Q 3028 2634 2825 2865
+Q 2622 3097 2228 3097
+Q 1903 3097 1650 2945
+Q 1397 2794 1197 2484
+Q 1050 2253 970 1956
+Q 891 1659 891 1344
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
+L 1747 4863
+L 1197 2028
+L 3169 3500
+L 3916 3500
+L 1716 1825
+L 3322 0
+L 2625 0
+L 1131 1709
+L 800 0
+L 225 0
+L 1172 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6e" d="M 3566 2113
+L 3156 0
+L 2578 0
+L 2988 2091
+Q 3016 2238 3031 2350
+Q 3047 2463 3047 2528
+Q 3047 2791 2881 2937
+Q 2716 3084 2419 3084
+Q 1956 3084 1622 2776
+Q 1288 2469 1184 1941
+L 800 0
+L 225 0
+L 903 3500
+L 1478 3500
+L 1363 2950
+Q 1603 3253 1940 3418
+Q 2278 3584 2650 3584
+Q 3113 3584 3367 3334
+Q 3622 3084 3622 2631
+Q 3622 2519 3608 2391
+Q 3594 2263 3566 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
+Q 3175 2616 2975 2859
+Q 2775 3103 2400 3103
+Q 2144 3103 1911 2972
+Q 1678 2841 1497 2591
+Q 1319 2344 1212 1994
+Q 1106 1644 1106 1300
+Q 1106 863 1306 627
+Q 1506 391 1875 391
+Q 2147 391 2380 519
+Q 2613 647 2778 891
+Q 2956 1147 3065 1494
+Q 3175 1841 3175 2156
+z
+M 1394 2969
+Q 1625 3272 1939 3428
+Q 2253 3584 2638 3584
+Q 3175 3584 3472 3232
+Q 3769 2881 3769 2247
+Q 3769 1728 3584 1258
+Q 3400 788 3053 416
+Q 2822 169 2531 39
+Q 2241 -91 1919 -91
+Q 1547 -91 1294 64
+Q 1041 219 916 525
+L 556 -1331
+L -19 -1331
+L 922 3500
+L 1497 3500
+L 1394 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-75" d="M 428 1388
+L 838 3500
+L 1416 3500
+L 1006 1409
+Q 975 1256 961 1147
+Q 947 1038 947 966
+Q 947 700 1109 554
+Q 1272 409 1569 409
+Q 2031 409 2368 721
+Q 2706 1034 2809 1563
+L 3194 3500
+L 3769 3500
+L 3091 0
+L 2516 0
+L 2631 550
+Q 2388 244 2052 76
+Q 1716 -91 1338 -91
+Q 878 -91 622 161
+Q 366 413 366 863
+Q 366 956 381 1097
+Q 397 1238 428 1388
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-71" d="M 2669 525
+Q 2438 222 2123 65
+Q 1809 -91 1428 -91
+Q 897 -91 595 267
+Q 294 625 294 1253
+Q 294 1759 480 2231
+Q 666 2703 1013 3078
+Q 1238 3322 1530 3453
+Q 1822 3584 2144 3584
+Q 2531 3584 2781 3431
+Q 3031 3278 3144 2969
+L 3244 3494
+L 3822 3494
+L 2888 -1319
+L 2309 -1319
+L 2669 525
+z
+M 891 1338
+Q 891 875 1084 633
+Q 1278 391 1644 391
+Q 2188 391 2572 911
+Q 2956 1431 2956 2175
+Q 2956 2625 2757 2864
+Q 2559 3103 2188 3103
+Q 1916 3103 1684 2976
+Q 1453 2850 1281 2606
+Q 1100 2350 995 2006
+Q 891 1663 891 1338
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-28" d="M 2731 4856
+Q 1903 3822 1495 2892
+Q 1088 1963 1088 1100
+Q 1088 606 1206 120
+Q 1325 -366 1563 -844
+L 1063 -844
+Q 775 -306 634 201
+Q 494 709 494 1197
+Q 494 2125 923 3036
+Q 1353 3947 2222 4856
+L 2731 4856
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-7e" d="M 4684 2553
+L 4684 1997
+Q 4356 1750 4076 1644
+Q 3797 1538 3494 1538
+Q 3150 1538 2694 1722
+Q 2659 1734 2644 1741
+Q 2622 1750 2575 1766
+Q 2091 1959 1797 1959
+Q 1522 1959 1253 1839
+Q 984 1719 678 1459
+L 678 2016
+Q 1006 2263 1286 2370
+Q 1566 2478 1869 2478
+Q 2213 2478 2672 2291
+Q 2703 2278 2719 2272
+Q 2744 2263 2788 2247
+Q 3272 2053 3566 2053
+Q 3834 2053 4098 2172
+Q 4363 2291 4684 2553
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 416 531
+L 1447 531
+L 2144 4122
+L 978 3897
+L 1088 4441
+L 2247 4666
+L 2881 4666
+L 2075 531
+L 3103 531
+L 3003 0
+L 313 0
+L 416 531
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-39" d="M 281 103
+L 397 678
+Q 578 559 809 496
+Q 1041 434 1306 434
+Q 1953 434 2348 843
+Q 2744 1253 2938 2119
+Q 2706 1853 2401 1714
+Q 2097 1575 1747 1575
+Q 1178 1575 842 1904
+Q 506 2234 506 2791
+Q 506 3247 672 3639
+Q 838 4031 1159 4325
+Q 1378 4531 1665 4640
+Q 1953 4750 2278 4750
+Q 2925 4750 3300 4339
+Q 3675 3928 3675 3219
+Q 3675 2559 3501 1943
+Q 3328 1328 3022 878
+Q 2697 403 2240 156
+Q 1784 -91 1228 -91
+Q 988 -91 748 -42
+Q 509 6 281 103
+z
+M 1131 2938
+Q 1131 2541 1337 2308
+Q 1544 2075 1894 2075
+Q 2378 2075 2706 2447
+Q 3034 2819 3034 3372
+Q 3034 3784 2831 4017
+Q 2628 4250 2272 4250
+Q 1788 4250 1459 3870
+Q 1131 3491 1131 2938
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6d" d="M 5747 2113
+L 5338 0
+L 4763 0
+L 5166 2094
+Q 5191 2228 5203 2325
+Q 5216 2422 5216 2491
+Q 5216 2772 5059 2928
+Q 4903 3084 4622 3084
+Q 4203 3084 3875 2770
+Q 3547 2456 3450 1953
+L 3066 0
+L 2491 0
+L 2900 2094
+Q 2925 2209 2937 2307
+Q 2950 2406 2950 2484
+Q 2950 2769 2794 2926
+Q 2638 3084 2363 3084
+Q 1938 3084 1609 2770
+Q 1281 2456 1184 1953
+L 800 0
+L 225 0
+L 909 3500
+L 1484 3500
+L 1375 2956
+Q 1609 3263 1923 3423
+Q 2238 3584 2597 3584
+Q 2978 3584 3223 3384
+Q 3469 3184 3519 2828
+Q 3781 3197 4126 3390
+Q 4472 3584 4856 3584
+Q 5306 3584 5551 3325
+Q 5797 3066 5797 2591
+Q 5797 2488 5784 2364
+Q 5772 2241 5747 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-29" d="M -397 -844
+Q 434 191 840 1120
+Q 1247 2050 1247 2913
+Q 1247 3406 1130 3892
+Q 1013 4378 775 4856
+L 1275 4856
+Q 1563 4316 1703 3812
+Q 1844 3309 1844 2822
+Q 1844 1891 1411 973
+Q 978 56 116 -844
+L -397 -844
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3b" d="M 563 794
+L 1222 794
+L 1113 256
+L 409 -744
+L 6 -744
+L 453 256
+L 563 794
+z
+M 1050 3309
+L 1709 3309
+L 1556 2516
+L 897 2516
+L 1050 3309
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-68" d="M 3566 2113
+L 3156 0
+L 2578 0
+L 2988 2091
+Q 3016 2238 3031 2350
+Q 3047 2463 3047 2528
+Q 3047 2791 2881 2937
+Q 2716 3084 2419 3084
+Q 1956 3084 1617 2771
+Q 1278 2459 1178 1941
+L 800 0
+L 225 0
+L 1172 4863
+L 1747 4863
+L 1375 2950
+Q 1594 3244 1934 3414
+Q 2275 3584 2650 3584
+Q 3113 3584 3367 3334
+Q 3622 3084 3622 2631
+Q 3622 2519 3608 2391
+Q 3594 2263 3566 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
+L 2234 1784
+L 3219 0
+L 2559 0
+L 1819 1388
+L 531 0
+L -166 0
+L 1556 1844
+L 641 3500
+L 1300 3500
+L 1972 2234
+L 3144 3500
+L 3841 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
+L 2075 2009
+L 1978 1497
+L 288 1497
+L 391 2009
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-67" d="M 3816 3500
+L 3219 434
+Q 3047 -456 2561 -893
+Q 2075 -1331 1253 -1331
+Q 950 -1331 690 -1286
+Q 431 -1241 206 -1147
+L 313 -588
+Q 525 -725 762 -790
+Q 1000 -856 1269 -856
+Q 1816 -856 2167 -557
+Q 2519 -259 2631 300
+L 2681 563
+Q 2441 288 2122 144
+Q 1803 0 1434 0
+Q 903 0 598 351
+Q 294 703 294 1319
+Q 294 1803 478 2267
+Q 663 2731 997 3091
+Q 1219 3328 1514 3456
+Q 1809 3584 2131 3584
+Q 2484 3584 2746 3420
+Q 3009 3256 3138 2956
+L 3238 3500
+L 3816 3500
+z
+M 2950 2216
+Q 2950 2641 2750 2872
+Q 2550 3103 2181 3103
+Q 1953 3103 1747 3012
+Q 1541 2922 1394 2759
+Q 1156 2491 1023 2127
+Q 891 1763 891 1375
+Q 891 944 1092 712
+Q 1294 481 1672 481
+Q 2219 481 2584 976
+Q 2950 1472 2950 2216
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 525 794
+L 1184 794
+L 1031 0
+L 372 0
+L 525 794
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-49"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(29.492188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(81.591797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(142.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(206.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(267.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(295.654297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(323.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(384.960938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(416.748047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(471.728516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(533.251953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(574.365234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(613.574219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(641.357422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(676.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(704.345703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(765.869141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(829.345703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(861.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(896.337891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(957.519531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(998.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1056.542969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1108.642578 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(1140.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1201.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1265.087891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(1296.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1332.080078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1395.556641 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1423.339844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1478.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1510.693359 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1562.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1626.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1689.648438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1753.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1794.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1855.419922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1910.400391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1971.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2024.023438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2076.123047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2107.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2171.386719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2232.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2274.023438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2305.810547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2346.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2408.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2471.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2535.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2596.826172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(2648.925781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2719.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2758.935547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2842.724609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-39" transform="translate(2906.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2969.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(3001.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3099.169922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-29" transform="translate(3151.269531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3b" transform="translate(3190.283203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3223.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3255.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(3294.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3358.349609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3386.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3438.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3470.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3505.224609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3533.007812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3592.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3653.710938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3717.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(3748.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3803.955078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3917.236328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3956.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3988.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4051.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4112.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4210.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(4238.085938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4301.464844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4362.744141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4401.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4463.476562 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4515.576172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4547.363281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4575.146484 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4614.355469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4666.455078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4698.242188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4750.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4847.753906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4909.033203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4936.816406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4964.599609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5000.683594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5064.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(5095.849609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5136.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5200.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(5263.720703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5327.197266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(5379.296875 0)"/>
+   </g>
+  </g>
  </g>
  <defs>
-  <clipPath id="p5ff047cf5c">
-   <rect x="69.05" y="25.44" width="438.55" height="278.2"/>
+  <clipPath id="p57df7f6c62">
+   <rect x="69.05" y="25.44" width="438.55" height="264.864"/>
   </clipPath>
  </defs>
 </svg>

--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -771,8 +771,8 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_23">
-      <path d="M 69.05 251.866552
-L 507.6 251.866552
+      <path d="M 69.05 251.799604
+L 507.6 251.799604
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
@@ -782,12 +782,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="251.866552" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="251.799604" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1 ms -->
-      <g transform="translate(37.559375 255.665771) scale(0.1 -0.1)">
+      <g transform="translate(37.559375 255.598822) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-6d" transform="translate(95.410156 0)"/>
@@ -797,18 +797,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_25">
-      <path d="M 69.05 180.10245
-L 507.6 180.10245
+      <path d="M 69.05 179.8535
+L 507.6 179.8535
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="180.10245" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="179.8535" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 183.901669) scale(0.1 -0.1)">
+      <g transform="translate(31.196875 183.652719) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -819,18 +819,18 @@ L 507.6 180.10245
     </g>
     <g id="ytick_3">
      <g id="line2d_27">
-      <path d="M 69.05 108.338348
-L 507.6 108.338348
+      <path d="M 69.05 107.907397
+L 507.6 107.907397
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="108.338348" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="107.907397" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 112.137567) scale(0.1 -0.1)">
+      <g transform="translate(24.834375 111.706615) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -842,18 +842,18 @@ L 507.6 108.338348
     </g>
     <g id="ytick_4">
      <g id="line2d_29">
-      <path d="M 69.05 36.574246
-L 507.6 36.574246
+      <path d="M 69.05 35.961293
+L 507.6 35.961293
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="36.574246" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="35.961293" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 1 s -->
-      <g transform="translate(47.3 40.373464) scale(0.1 -0.1)">
+      <g transform="translate(47.3 39.760512) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -862,8 +862,8 @@ L 507.6 36.574246
     </g>
     <g id="ytick_5">
      <g id="line2d_31">
-      <path d="M 69.05 289.390476
-L 507.6 289.390476
+      <path d="M 69.05 289.418692
+L 507.6 289.418692
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
@@ -873,367 +873,367 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="289.390476" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="289.418692" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_33">
-      <path d="M 69.05 280.42436
-L 507.6 280.42436
+      <path d="M 69.05 280.429837
+L 507.6 280.429837
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="280.42436" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="280.429837" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_35">
-      <path d="M 69.05 273.4697
-L 507.6 273.4697
+      <path d="M 69.05 273.457539
+L 507.6 273.457539
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="273.4697" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="273.457539" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_37">
-      <path d="M 69.05 267.787329
-L 507.6 267.787329
+      <path d="M 69.05 267.760757
+L 507.6 267.760757
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="267.787329" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="267.760757" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_39">
-      <path d="M 69.05 262.982952
-L 507.6 262.982952
+      <path d="M 69.05 262.944196
+L 507.6 262.944196
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="262.982952" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="262.944196" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_41">
-      <path d="M 69.05 258.821212
-L 507.6 258.821212
+      <path d="M 69.05 258.771902
+L 507.6 258.771902
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="258.821212" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="258.771902" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_43">
-      <path d="M 69.05 255.150297
-L 507.6 255.150297
+      <path d="M 69.05 255.091677
+L 507.6 255.091677
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="255.150297" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="255.091677" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_45">
-      <path d="M 69.05 230.263405
-L 507.6 230.263405
+      <path d="M 69.05 230.141668
+L 507.6 230.141668
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="230.263405" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="230.141668" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_47">
-      <path d="M 69.05 217.626374
-L 507.6 217.626374
+      <path d="M 69.05 217.472589
+L 507.6 217.472589
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="217.626374" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="217.472589" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_49">
-      <path d="M 69.05 208.660257
-L 507.6 208.660257
+      <path d="M 69.05 208.483733
+L 507.6 208.483733
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="208.660257" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="208.483733" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_51">
-      <path d="M 69.05 201.705597
-L 507.6 201.705597
+      <path d="M 69.05 201.511435
+L 507.6 201.511435
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="201.705597" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="201.511435" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_53">
-      <path d="M 69.05 196.023226
-L 507.6 196.023226
+      <path d="M 69.05 195.814653
+L 507.6 195.814653
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="196.023226" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="195.814653" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_55">
-      <path d="M 69.05 191.21885
-L 507.6 191.21885
+      <path d="M 69.05 190.998093
+L 507.6 190.998093
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="191.21885" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="190.998093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_57">
-      <path d="M 69.05 187.05711
-L 507.6 187.05711
+      <path d="M 69.05 186.825798
+L 507.6 186.825798
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="187.05711" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="186.825798" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_59">
-      <path d="M 69.05 183.386195
-L 507.6 183.386195
+      <path d="M 69.05 183.145573
+L 507.6 183.145573
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="183.386195" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="183.145573" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_61">
-      <path d="M 69.05 158.499303
-L 507.6 158.499303
+      <path d="M 69.05 158.195565
+L 507.6 158.195565
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="158.499303" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="158.195565" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_63">
-      <path d="M 69.05 145.862272
-L 507.6 145.862272
+      <path d="M 69.05 145.526485
+L 507.6 145.526485
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="145.862272" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="145.526485" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_65">
-      <path d="M 69.05 136.896155
-L 507.6 136.896155
+      <path d="M 69.05 136.53763
+L 507.6 136.53763
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="136.896155" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="136.53763" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_67">
-      <path d="M 69.05 129.941495
-L 507.6 129.941495
+      <path d="M 69.05 129.565332
+L 507.6 129.565332
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="129.941495" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="129.565332" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_69">
-      <path d="M 69.05 124.259124
-L 507.6 124.259124
+      <path d="M 69.05 123.86855
+L 507.6 123.86855
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="124.259124" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="123.86855" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_71">
-      <path d="M 69.05 119.454748
-L 507.6 119.454748
+      <path d="M 69.05 119.051989
+L 507.6 119.051989
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="119.454748" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="119.051989" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_73">
-      <path d="M 69.05 115.293008
-L 507.6 115.293008
+      <path d="M 69.05 114.879694
+L 507.6 114.879694
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="115.293008" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="114.879694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_75">
-      <path d="M 69.05 111.622093
-L 507.6 111.622093
+      <path d="M 69.05 111.19947
+L 507.6 111.19947
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="111.622093" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="111.19947" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_77">
-      <path d="M 69.05 86.7352
-L 507.6 86.7352
+      <path d="M 69.05 86.249461
+L 507.6 86.249461
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="86.7352" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="86.249461" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_79">
-      <path d="M 69.05 74.098169
-L 507.6 74.098169
+      <path d="M 69.05 73.580381
+L 507.6 73.580381
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="74.098169" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="73.580381" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_81">
-      <path d="M 69.05 65.132053
-L 507.6 65.132053
+      <path d="M 69.05 64.591526
+L 507.6 64.591526
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="65.132053" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="64.591526" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_83">
-      <path d="M 69.05 58.177393
-L 507.6 58.177393
+      <path d="M 69.05 57.619228
+L 507.6 57.619228
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="58.177393" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="57.619228" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_85">
-      <path d="M 69.05 52.495022
-L 507.6 52.495022
+      <path d="M 69.05 51.922446
+L 507.6 51.922446
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="52.495022" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="51.922446" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_87">
-      <path d="M 69.05 47.690646
-L 507.6 47.690646
+      <path d="M 69.05 47.105885
+L 507.6 47.105885
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="47.690646" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="47.105885" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_89">
-      <path d="M 69.05 43.528906
-L 507.6 43.528906
+      <path d="M 69.05 42.933591
+L 507.6 42.933591
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_90">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="43.528906" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="42.933591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_91">
-      <path d="M 69.05 39.857991
-L 507.6 39.857991
+      <path d="M 69.05 39.253366
+L 507.6 39.253366
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_92">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="39.857991" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="39.253366" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
@@ -1341,17 +1341,17 @@ z
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 260.285434
-L 128.852273 227.685323
-L 168.720455 200.284485
-L 208.588636 173.398076
-L 248.456818 148.945353
-L 288.325 126.119229
-L 328.193182 105.384945
-L 368.061364 86.876757
-L 407.929545 68.763562
-L 447.797727 52.61575
-L 487.665909 38.170206
+    <path d="M 88.984091 260.239837
+L 128.852273 227.557048
+L 168.720455 200.086719
+L 208.588636 173.132124
+L 248.456818 148.617386
+L 288.325 125.733372
+L 328.193182 104.946503
+L 368.061364 86.391377
+L 407.929545 68.232245
+L 447.797727 52.04348
+L 487.665909 37.561301
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m0fee27a2d2" d="M -3 3
@@ -1362,31 +1362,31 @@ z
 " style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m0fee27a2d2" x="88.984091" y="260.285434" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="128.852273" y="227.685323" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="168.720455" y="200.284485" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="208.588636" y="173.398076" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="248.456818" y="148.945353" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="288.325" y="126.119229" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="328.193182" y="105.384945" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="368.061364" y="86.876757" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="407.929545" y="68.763562" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="447.797727" y="52.61575" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.170206" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="88.984091" y="260.239837" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.852273" y="227.557048" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.720455" y="200.086719" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.588636" y="173.132124" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.456818" y="148.617386" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="288.325" y="125.733372" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.193182" y="104.946503" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="368.061364" y="86.391377" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.929545" y="68.232245" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="447.797727" y="52.04348" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.665909" y="37.561301" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_94">
-    <path d="M 88.984091 272.568607
-L 128.852273 235.860185
-L 168.720455 207.508507
-L 208.588636 181.588933
-L 248.456818 159.0553
-L 288.325 137.334256
-L 328.193182 116.96292
-L 368.061364 98.800561
-L 407.929545 81.804881
-L 447.797727 66.603397
-L 487.665909 51.407013
+    <path d="M 88.984091 272.554161
+L 128.852273 235.752643
+L 168.720455 207.329062
+L 208.588636 181.343753
+L 248.456818 158.752972
+L 288.325 136.976842
+L 328.193182 116.553841
+L 368.061364 98.345421
+L 407.929545 81.306639
+L 447.797727 66.066602
+L 487.665909 50.831678
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
@@ -1402,30 +1402,30 @@ z
 " style="stroke: #ff7f0e"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="272.568607" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="235.860185" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="207.508507" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="181.588933" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="159.0553" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="288.325" y="137.334256" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="116.96292" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="368.061364" y="98.800561" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="81.804881" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="447.797727" y="66.603397" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="51.407013" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="88.984091" y="272.554161" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="235.752643" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="207.329062" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="181.343753" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="158.752972" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="288.325" y="136.976842" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="116.553841" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="368.061364" y="98.345421" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="81.306639" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="447.797727" y="66.066602" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="50.831678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_95">
-    <path d="M 88.984091 158.004611
-L 128.852273 153.465222
-L 168.720455 147.365911
-L 208.588636 137.060593
-L 248.456818 126.354388
-L 288.325 110.599024
-L 328.193182 96.149058
-L 368.061364 80.485363
-L 407.929545 65.10336
-L 447.797727 50.185205
+    <path d="M 88.984091 238.717057
+L 128.852273 203.405324
+L 168.720455 180.526197
+L 208.588636 156.686685
+L 248.456818 138.72216
+L 288.325 117.229927
+L 328.193182 99.936246
+L 368.061364 82.484667
+L 407.929545 66.065526
+L 447.797727 50.529359
 L 487.665909 37.479273
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
@@ -1436,29 +1436,29 @@ z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#ma559d3018c" x="88.984091" y="158.004611" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="128.852273" y="153.465222" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="147.365911" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="137.060593" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="126.354388" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="288.325" y="110.599024" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="96.149058" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="368.061364" y="80.485363" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="65.10336" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="447.797727" y="50.185205" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="88.984091" y="238.717057" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.852273" y="203.405324" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.720455" y="180.526197" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.588636" y="156.686685" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.456818" y="138.72216" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="288.325" y="117.229927" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.193182" y="99.936246" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="368.061364" y="82.484667" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.929545" y="66.065526" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="447.797727" y="50.529359" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      <use xlink:href="#ma559d3018c" x="487.665909" y="37.479273" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_96">
-    <path d="M 88.984091 256.884439
-L 128.852273 225.906381
-L 168.720455 199.795668
-L 208.588636 188.540014
-L 248.456818 176.344921
-L 288.325 167.253106
-L 328.193182 158.225265
-L 368.061364 149.089941
-L 407.929545 141.075712
+    <path d="M 88.984091 256.830216
+L 128.852273 225.773595
+L 168.720455 199.596663
+L 208.588636 188.312463
+L 248.456818 176.086441
+L 288.325 166.971569
+L 328.193182 157.920832
+L 368.061364 148.76234
+L 407.929545 140.727786
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
@@ -1469,29 +1469,29 @@ z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="256.884439" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="225.906381" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="199.795668" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="188.540014" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="176.344921" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="288.325" y="167.253106" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="158.225265" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="368.061364" y="149.089941" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="141.075712" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="88.984091" y="256.830216" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.852273" y="225.773595" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.720455" y="199.596663" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.588636" y="188.312463" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.456818" y="176.086441" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="288.325" y="166.971569" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.193182" y="157.920832" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="368.061364" y="148.76234" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.929545" y="140.727786" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_97">
     <path d="M 88.984091 278.264727
-L 128.852273 257.705925
-L 168.720455 242.8896
-L 208.588636 230.422684
-L 248.456818 222.07306
-L 288.325 212.001472
-L 328.193182 203.552046
-L 368.061364 197.360752
-L 407.929545 189.66146
-L 447.797727 182.680157
-L 487.665909 177.774245
+L 128.852273 257.653785
+L 168.720455 242.799885
+L 208.588636 230.301351
+L 248.456818 221.930552
+L 288.325 211.833421
+L 328.193182 203.362567
+L 368.061364 197.155571
+L 407.929545 189.436753
+L 447.797727 182.437744
+L 487.665909 177.519391
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m25acbb3ce1" d="M -0 3.5
@@ -1502,16 +1502,16 @@ z
     </defs>
     <g clip-path="url(#p57df7f6c62)">
      <use xlink:href="#m25acbb3ce1" x="88.984091" y="278.264727" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="257.705925" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="242.8896" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="230.422684" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="222.07306" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="288.325" y="212.001472" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="203.552046" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="368.061364" y="197.360752" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="189.66146" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="447.797727" y="182.680157" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="177.774245" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="128.852273" y="257.653785" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="168.720455" y="242.799885" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="208.588636" y="230.301351" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="248.456818" y="221.930552" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="288.325" y="211.833421" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="328.193182" y="203.362567" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="368.061364" y="197.155571" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="407.929545" y="189.436753" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="447.797727" y="182.437744" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="487.665909" y="177.519391" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1701,7 +1701,7 @@ L 98.05 67.894687
      </g>
     </g>
     <g id="text_21">
-     <!-- Isabelle certified -->
+     <!-- Isabelle certified (adjusted) -->
      <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
@@ -1725,6 +1725,51 @@ Q 1241 4863 1831 4863
 L 2375 4863
 z
 " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856
+Q 1566 4138 1362 3434
+Q 1159 2731 1159 2009
+Q 1159 1288 1364 580
+Q 1569 -128 1984 -844
+L 1484 -844
+Q 1016 -109 783 600
+Q 550 1309 550 2009
+Q 550 2706 781 3412
+Q 1013 4119 1484 4856
+L 1984 4856
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6a" d="M 603 3500
+L 1178 3500
+L 1178 -63
+Q 1178 -731 923 -1031
+Q 669 -1331 103 -1331
+L -116 -1331
+L -116 -844
+L 38 -844
+Q 366 -844 484 -692
+Q 603 -541 603 -63
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856
+L 1013 4856
+Q 1481 4119 1714 3412
+Q 1947 2706 1947 2009
+Q 1947 1309 1714 600
+Q 1481 -109 1013 -844
+L 513 -844
+Q 928 -128 1133 580
+Q 1338 1288 1338 2009
+Q 1338 2731 1133 3434
+Q 928 4138 513 4856
+z
+" transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-49"/>
       <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
@@ -1744,6 +1789,17 @@ z
       <use xlink:href="#DejaVuSans-69" transform="translate(676.5625 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(704.345703 0)"/>
       <use xlink:href="#DejaVuSans-64" transform="translate(765.869141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(829.345703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(861.132812 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(900.146484 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(961.425781 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(1024.902344 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1052.685547 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1116.064453 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1168.164062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1207.373047 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1268.896484 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1332.373047 0)"/>
      </g>
     </g>
     <g id="line2d_101">
@@ -1810,8 +1866,8 @@ L 98.05 97.250937
    </g>
   </g>
   <g id="text_24">
-   <!-- Isabelle certified forks an fplll subprocess per request (~19 ms); this fixed cost dominates its small-n rungs. -->
-   <g style="fill: #595959" transform="translate(69.815547 340.688219) scale(0.07 -0.07)">
+   <!-- Isabelle certified is adjusted down by its ~18.8 ms per-request floor, a fixed trivial-request cost dominated by the fplll subprocess fork. -->
+   <g style="fill: #595959" transform="translate(22.612031 340.688219) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-Oblique-49" d="M 1081 4666
 L 1716 4666
@@ -2093,6 +2149,50 @@ Q 1106 2353 998 2009
 Q 891 1666 891 1350
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6a" d="M 928 3500
+L 1503 3500
+L 813 -63
+L 809 -78
+Q 694 -675 544 -897
+Q 403 -1106 132 -1218
+Q -138 -1331 -506 -1331
+L -722 -1331
+L -628 -844
+L -481 -844
+Q -144 -844 -1 -703
+Q 141 -563 238 -63
+L 928 3500
+z
+M 1197 4863
+L 1772 4863
+L 1631 4134
+L 1056 4134
+L 1197 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-75" d="M 428 1388
+L 838 3500
+L 1416 3500
+L 1006 1409
+Q 975 1256 961 1147
+Q 947 1038 947 966
+Q 947 700 1109 554
+Q 1272 409 1569 409
+Q 2031 409 2368 721
+Q 2706 1034 2809 1563
+L 3194 3500
+L 3769 3500
+L 3091 0
+L 2516 0
+L 2631 550
+Q 2388 244 2052 76
+Q 1716 -91 1338 -91
+Q 878 -91 622 161
+Q 366 413 366 863
+Q 366 956 381 1097
+Q 397 1238 428 1388
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6f" d="M 1625 -91
 Q 1009 -91 651 289
 Q 294 669 294 1325
@@ -2120,18 +2220,20 @@ Q 1050 2253 970 1956
 Q 891 1659 891 1344
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
-L 1747 4863
-L 1197 2028
-L 3169 3500
-L 3916 3500
-L 1716 1825
-L 3322 0
-L 2625 0
-L 1131 1709
-L 800 0
-L 225 0
-L 1172 4863
+     <path id="DejaVuSans-Oblique-77" d="M 544 3500
+L 1113 3500
+L 1259 684
+L 2566 3500
+L 3231 3500
+L 3425 684
+L 4666 3500
+L 5241 3500
+L 3641 0
+L 2969 0
+L 2797 2900
+L 1459 0
+L 781 0
+L 544 3500
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113
@@ -2157,102 +2259,21 @@ Q 3622 2519 3608 2391
 Q 3594 2263 3566 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
-Q 3175 2616 2975 2859
-Q 2775 3103 2400 3103
-Q 2144 3103 1911 2972
-Q 1678 2841 1497 2591
-Q 1319 2344 1212 1994
-Q 1106 1644 1106 1300
-Q 1106 863 1306 627
-Q 1506 391 1875 391
-Q 2147 391 2380 519
-Q 2613 647 2778 891
-Q 2956 1147 3065 1494
-Q 3175 1841 3175 2156
-z
-M 1394 2969
-Q 1625 3272 1939 3428
-Q 2253 3584 2638 3584
-Q 3175 3584 3472 3232
-Q 3769 2881 3769 2247
-Q 3769 1728 3584 1258
-Q 3400 788 3053 416
-Q 2822 169 2531 39
-Q 2241 -91 1919 -91
-Q 1547 -91 1294 64
-Q 1041 219 916 525
-L 556 -1331
-L -19 -1331
-L 922 3500
-L 1497 3500
-L 1394 2969
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-75" d="M 428 1388
-L 838 3500
-L 1416 3500
-L 1006 1409
-Q 975 1256 961 1147
-Q 947 1038 947 966
-Q 947 700 1109 554
-Q 1272 409 1569 409
-Q 2031 409 2368 721
-Q 2706 1034 2809 1563
-L 3194 3500
-L 3769 3500
-L 3091 0
-L 2516 0
-L 2631 550
-Q 2388 244 2052 76
-Q 1716 -91 1338 -91
-Q 878 -91 622 161
-Q 366 413 366 863
-Q 366 956 381 1097
-Q 397 1238 428 1388
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-71" d="M 2669 525
-Q 2438 222 2123 65
-Q 1809 -91 1428 -91
-Q 897 -91 595 267
-Q 294 625 294 1253
-Q 294 1759 480 2231
-Q 666 2703 1013 3078
-Q 1238 3322 1530 3453
-Q 1822 3584 2144 3584
-Q 2531 3584 2781 3431
-Q 3031 3278 3144 2969
-L 3244 3494
-L 3822 3494
-L 2888 -1319
-L 2309 -1319
-L 2669 525
-z
-M 891 1338
-Q 891 875 1084 633
-Q 1278 391 1644 391
-Q 2188 391 2572 911
-Q 2956 1431 2956 2175
-Q 2956 2625 2757 2864
-Q 2559 3103 2188 3103
-Q 1916 3103 1684 2976
-Q 1453 2850 1281 2606
-Q 1100 2350 995 2006
-Q 891 1663 891 1338
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-28" d="M 2731 4856
-Q 1903 3822 1495 2892
-Q 1088 1963 1088 1100
-Q 1088 606 1206 120
-Q 1325 -366 1563 -844
-L 1063 -844
-Q 775 -306 634 201
-Q 494 709 494 1197
-Q 494 2125 923 3036
-Q 1353 3947 2222 4856
-L 2731 4856
+     <path id="DejaVuSans-Oblique-79" d="M 1588 -325
+Q 1188 -997 936 -1164
+Q 684 -1331 294 -1331
+L -159 -1331
+L -63 -850
+L 269 -850
+Q 509 -850 678 -719
+Q 847 -588 1056 -206
+L 1234 128
+L 459 3500
+L 1069 3500
+L 1650 819
+L 3256 3500
+L 3859 3500
+L 1588 -325
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-7e" d="M 4684 2553
@@ -2290,38 +2311,50 @@ L 313 0
 L 416 531
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-39" d="M 281 103
-L 397 678
-Q 578 559 809 496
-Q 1041 434 1306 434
-Q 1953 434 2348 843
-Q 2744 1253 2938 2119
-Q 2706 1853 2401 1714
-Q 2097 1575 1747 1575
-Q 1178 1575 842 1904
-Q 506 2234 506 2791
-Q 506 3247 672 3639
-Q 838 4031 1159 4325
-Q 1378 4531 1665 4640
-Q 1953 4750 2278 4750
-Q 2925 4750 3300 4339
-Q 3675 3928 3675 3219
-Q 3675 2559 3501 1943
-Q 3328 1328 3022 878
-Q 2697 403 2240 156
-Q 1784 -91 1228 -91
-Q 988 -91 748 -42
-Q 509 6 281 103
+     <path id="DejaVuSans-Oblique-38" d="M 2847 1416
+Q 2847 1769 2600 1992
+Q 2353 2216 1953 2216
+Q 1466 2216 1148 1923
+Q 831 1631 831 1184
+Q 831 828 1073 618
+Q 1316 409 1728 409
+Q 2219 409 2533 693
+Q 2847 978 2847 1416
 z
-M 1131 2938
-Q 1131 2541 1337 2308
-Q 1544 2075 1894 2075
-Q 2378 2075 2706 2447
-Q 3034 2819 3034 3372
-Q 3034 3784 2831 4017
-Q 2628 4250 2272 4250
-Q 1788 4250 1459 3870
-Q 1131 3491 1131 2938
+M 3169 3591
+Q 3169 3888 2950 4069
+Q 2731 4250 2369 4250
+Q 1941 4250 1664 4009
+Q 1388 3769 1388 3406
+Q 1388 3094 1605 2903
+Q 1822 2713 2181 2713
+Q 2613 2713 2891 2961
+Q 3169 3209 3169 3591
+z
+M 2741 2456
+Q 3094 2322 3281 2050
+Q 3469 1778 3469 1394
+Q 3469 747 2969 328
+Q 2469 -91 1678 -91
+Q 1006 -91 609 239
+Q 213 569 213 1119
+Q 213 1619 553 2008
+Q 894 2397 1441 2503
+Q 1113 2616 941 2852
+Q 769 3088 769 3425
+Q 769 3991 1239 4370
+Q 1709 4750 2431 4750
+Q 3034 4750 3414 4442
+Q 3794 4134 3794 3659
+Q 3794 3247 3511 2923
+Q 3228 2600 2741 2456
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 525 794
+L 1184 794
+L 1031 0
+L 372 0
+L 525 794
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113
@@ -2360,32 +2393,107 @@ Q 5797 2488 5784 2364
 Q 5772 2241 5747 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-29" d="M -397 -844
-Q 434 191 840 1120
-Q 1247 2050 1247 2913
-Q 1247 3406 1130 3892
-Q 1013 4378 775 4856
-L 1275 4856
-Q 1563 4316 1703 3812
-Q 1844 3309 1844 2822
-Q 1844 1891 1411 973
-Q 978 56 116 -844
-L -397 -844
+     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
+Q 3175 2616 2975 2859
+Q 2775 3103 2400 3103
+Q 2144 3103 1911 2972
+Q 1678 2841 1497 2591
+Q 1319 2344 1212 1994
+Q 1106 1644 1106 1300
+Q 1106 863 1306 627
+Q 1506 391 1875 391
+Q 2147 391 2380 519
+Q 2613 647 2778 891
+Q 2956 1147 3065 1494
+Q 3175 1841 3175 2156
+z
+M 1394 2969
+Q 1625 3272 1939 3428
+Q 2253 3584 2638 3584
+Q 3175 3584 3472 3232
+Q 3769 2881 3769 2247
+Q 3769 1728 3584 1258
+Q 3400 788 3053 416
+Q 2822 169 2531 39
+Q 2241 -91 1919 -91
+Q 1547 -91 1294 64
+Q 1041 219 916 525
+L 556 -1331
+L -19 -1331
+L 922 3500
+L 1497 3500
+L 1394 2969
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-3b" d="M 563 794
-L 1222 794
-L 1113 256
-L 409 -744
-L 6 -744
-L 453 256
-L 563 794
+     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
+L 2075 2009
+L 1978 1497
+L 288 1497
+L 391 2009
 z
-M 1050 3309
-L 1709 3309
-L 1556 2516
-L 897 2516
-L 1050 3309
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-71" d="M 2669 525
+Q 2438 222 2123 65
+Q 1809 -91 1428 -91
+Q 897 -91 595 267
+Q 294 625 294 1253
+Q 294 1759 480 2231
+Q 666 2703 1013 3078
+Q 1238 3322 1530 3453
+Q 1822 3584 2144 3584
+Q 2531 3584 2781 3431
+Q 3031 3278 3144 2969
+L 3244 3494
+L 3822 3494
+L 2888 -1319
+L 2309 -1319
+L 2669 525
+z
+M 891 1338
+Q 891 875 1084 633
+Q 1278 391 1644 391
+Q 2188 391 2572 911
+Q 2956 1431 2956 2175
+Q 2956 2625 2757 2864
+Q 2559 3103 2188 3103
+Q 1916 3103 1684 2976
+Q 1453 2850 1281 2606
+Q 1100 2350 995 2006
+Q 891 1663 891 1338
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2c" d="M 575 794
+L 1234 794
+L 1131 256
+L 422 -744
+L 19 -744
+L 469 256
+L 575 794
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
+L 2234 1784
+L 3219 0
+L 2559 0
+L 1819 1388
+L 531 0
+L -166 0
+L 1556 1844
+L 641 3500
+L 1300 3500
+L 1972 2234
+L 3144 3500
+L 3841 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-76" d="M 459 3500
+L 1069 3500
+L 1581 525
+L 3256 3500
+L 3866 3500
+L 1875 0
+L 1100 0
+L 459 3500
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-68" d="M 3566 2113
@@ -2411,71 +2519,18 @@ Q 3622 2519 3608 2391
 Q 3594 2263 3566 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
-L 2234 1784
-L 3219 0
-L 2559 0
-L 1819 1388
-L 531 0
-L -166 0
-L 1556 1844
-L 641 3500
-L 1300 3500
-L 1972 2234
-L 3144 3500
-L 3841 3500
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
-L 2075 2009
-L 1978 1497
-L 288 1497
-L 391 2009
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-67" d="M 3816 3500
-L 3219 434
-Q 3047 -456 2561 -893
-Q 2075 -1331 1253 -1331
-Q 950 -1331 690 -1286
-Q 431 -1241 206 -1147
-L 313 -588
-Q 525 -725 762 -790
-Q 1000 -856 1269 -856
-Q 1816 -856 2167 -557
-Q 2519 -259 2631 300
-L 2681 563
-Q 2441 288 2122 144
-Q 1803 0 1434 0
-Q 903 0 598 351
-Q 294 703 294 1319
-Q 294 1803 478 2267
-Q 663 2731 997 3091
-Q 1219 3328 1514 3456
-Q 1809 3584 2131 3584
-Q 2484 3584 2746 3420
-Q 3009 3256 3138 2956
-L 3238 3500
-L 3816 3500
-z
-M 2950 2216
-Q 2950 2641 2750 2872
-Q 2550 3103 2181 3103
-Q 1953 3103 1747 3012
-Q 1541 2922 1394 2759
-Q 1156 2491 1023 2127
-Q 891 1763 891 1375
-Q 891 944 1092 712
-Q 1294 481 1672 481
-Q 2219 481 2584 976
-Q 2950 1472 2950 2216
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-2e" d="M 525 794
-L 1184 794
-L 1031 0
-L 372 0
-L 525 794
+     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
+L 1747 4863
+L 1197 2028
+L 3169 3500
+L 3916 3500
+L 1716 1825
+L 3322 0
+L 2625 0
+L 1131 1709
+L 800 0
+L 225 0
+L 1172 4863
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2498,98 +2553,126 @@ z
     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(704.345703 0)"/>
     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(765.869141 0)"/>
     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(829.345703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(861.132812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(896.337891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(957.519531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(998.632812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1056.542969 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1108.642578 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(1140.429688 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1201.708984 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1265.087891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(1296.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1332.080078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1395.556641 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1423.339844 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1478.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1510.693359 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1562.792969 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1626.171875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1689.648438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1753.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1794.238281 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1855.419922 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1910.400391 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1971.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2024.023438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2076.123047 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2107.910156 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2171.386719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2232.910156 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2274.023438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2305.810547 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2346.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2408.447266 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2471.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2535.302734 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2596.826172 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(2648.925781 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2688.134766 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2719.921875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2758.935547 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2842.724609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-39" transform="translate(2906.347656 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2969.970703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(3001.757812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3099.169922 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-29" transform="translate(3151.269531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3b" transform="translate(3190.283203 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3223.974609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3255.761719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(3294.970703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3358.349609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3386.132812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3438.232422 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3470.019531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3505.224609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3533.007812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3592.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3653.710938 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3717.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(3748.974609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3803.955078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3865.136719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3917.236328 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3956.445312 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3988.232422 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4051.708984 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4112.890625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4210.302734 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(4238.085938 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4301.464844 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4362.744141 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4401.953125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4463.476562 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4515.576172 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4547.363281 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4575.146484 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4614.355469 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4666.455078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4698.242188 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4750.341797 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4847.753906 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4909.033203 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4936.816406 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4964.599609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5000.683594 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5064.0625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(5095.849609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5136.962891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5200.341797 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(5263.720703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5327.197266 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(5379.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(861.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(888.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(941.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(972.802734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1034.082031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6a" transform="translate(1097.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1125.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1188.720703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1240.820312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1280.029297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1341.552734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1405.029297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1436.816406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1500.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(1561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1643.261719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1706.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1738.427734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(1801.904297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1861.083984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(1892.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1920.654297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1959.863281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2011.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2043.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2127.539062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(2191.162109 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(2254.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(2286.572266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2350.195312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(2381.982422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2479.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2531.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2563.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2626.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2688.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(2723.894531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2759.978516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2801.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2862.615234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2926.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2989.470703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3050.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3103.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3142.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3174.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(3209.294922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3237.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3298.259766 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3359.441406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(3391.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3423.216797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(3455.003906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3516.283203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3548.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3583.275391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3611.058594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3670.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3731.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3795.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3827.025391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3866.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3907.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-76" transform="translate(3935.130859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3994.310547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4022.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4083.373047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4111.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(4147.240234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4188.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(4249.876953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(4313.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4376.732422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4438.255859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4490.355469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4529.564453 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(4561.351562 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4616.332031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4677.513672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4729.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4768.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(4800.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4864.085938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4925.267578 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(5022.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5050.462891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(5113.841797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(5175.121094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5214.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(5275.853516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5339.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(5371.117188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(5434.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5493.773438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(5525.560547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(5564.769531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5628.148438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5689.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(5721.458984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(5756.664062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5820.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5847.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5875.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5903.490234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5935.277344 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5987.376953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(6050.755859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(6114.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6177.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(6218.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(6280.003906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(6334.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(6396.507812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(6448.607422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(6500.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(6532.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(6567.699219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6628.880859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(6669.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(6727.904297 0)"/>
    </g>
   </g>
  </g>

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -29,8 +29,8 @@ z
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 69.05 303.64
-L 507.6 303.64
+    <path d="M 69.05 290.304
+L 507.6 290.304
 L 507.6 25.44
 L 69.05 25.44
 z
@@ -39,9 +39,9 @@ z
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
-      <path d="M 88.984091 303.64
+      <path d="M 88.984091 290.304
 L 88.984091 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_2">
       <defs>
@@ -50,12 +50,12 @@ L 0 3.5
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="88.984091" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 30 -->
-      <g transform="translate(82.621591 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(82.621591 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-33" d="M 2597 2516
 Q 3050 2419 3304 2112
@@ -118,18 +118,18 @@ z
     </g>
     <g id="xtick_2">
      <g id="line2d_3">
-      <path d="M 128.852273 303.64
+      <path d="M 128.852273 290.304
 L 128.852273 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="128.852273" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 45 -->
-      <g transform="translate(122.489773 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(122.489773 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-34" d="M 2419 4116
 L 825 1625
@@ -183,18 +183,18 @@ z
     </g>
     <g id="xtick_3">
      <g id="line2d_5">
-      <path d="M 168.720455 303.64
+      <path d="M 168.720455 290.304
 L 168.720455 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="168.720455" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 60 -->
-      <g transform="translate(162.357955 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(162.357955 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-36" d="M 2113 2584
 Q 1688 2584 1439 2293
@@ -234,18 +234,18 @@ z
     </g>
     <g id="xtick_4">
      <g id="line2d_7">
-      <path d="M 208.588636 303.64
+      <path d="M 208.588636 290.304
 L 208.588636 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="208.588636" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 75 -->
-      <g transform="translate(202.226136 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(202.226136 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-37" d="M 525 4666
 L 3525 4666
@@ -265,18 +265,18 @@ z
     </g>
     <g id="xtick_5">
      <g id="line2d_9">
-      <path d="M 248.456818 303.64
+      <path d="M 248.456818 290.304
 L 248.456818 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="248.456818" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 90 -->
-      <g transform="translate(242.094318 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(242.094318 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-39" d="M 703 97
 L 703 672
@@ -316,18 +316,18 @@ z
     </g>
     <g id="xtick_6">
      <g id="line2d_11">
-      <path d="M 328.193182 303.64
+      <path d="M 328.193182 290.304
 L 328.193182 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="328.193182" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 120 -->
-      <g transform="translate(318.649432 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(318.649432 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
@@ -376,18 +376,18 @@ z
     </g>
     <g id="xtick_7">
      <g id="line2d_13">
-      <path d="M 407.929545 303.64
+      <path d="M 407.929545 290.304
 L 407.929545 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="407.929545" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 150 -->
-      <g transform="translate(398.385795 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(398.385795 304.902437) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -396,18 +396,18 @@ L 407.929545 25.44
     </g>
     <g id="xtick_8">
      <g id="line2d_15">
-      <path d="M 487.665909 303.64
+      <path d="M 487.665909 290.304
 L 487.665909 25.44
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.15; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="303.64" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0e4e4e6c5e" x="487.665909" y="290.304" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 180 -->
-      <g transform="translate(478.122159 318.238437) scale(0.1 -0.1)">
+      <g transform="translate(478.122159 304.902437) scale(0.1 -0.1)">
        <defs>
         <path id="DejaVuSans-38" d="M 2034 2216
 Q 1584 2216 1326 1975
@@ -457,7 +457,7 @@ z
     </g>
     <g id="text_9">
      <!-- random-bounded dimension n -->
-     <g transform="translate(212.885156 331.916562) scale(0.1 -0.1)">
+     <g transform="translate(212.885156 318.580562) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-72" d="M 2631 2963
 Q 2534 3019 2420 3045
@@ -763,9 +763,9 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_17">
-      <path d="M 69.05 239.548533
-L 507.6 239.548533
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 229.284869
+L 507.6 229.284869
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <defs>
@@ -774,12 +774,12 @@ L -3.5 0
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="239.548533" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="229.284869" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 10 ms -->
-      <g transform="translate(31.196875 243.347752) scale(0.1 -0.1)">
+      <g transform="translate(31.196875 233.084088) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -790,18 +790,18 @@ L -3.5 0
     </g>
     <g id="ytick_2">
      <g id="line2d_19">
-      <path d="M 69.05 169.544275
-L 507.6 169.544275
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 162.636387
+L 507.6 162.636387
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="169.544275" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="162.636387" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 100 ms -->
-      <g transform="translate(24.834375 173.343494) scale(0.1 -0.1)">
+      <g transform="translate(24.834375 166.435605) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
@@ -813,18 +813,18 @@ L 507.6 169.544275
     </g>
     <g id="ytick_3">
      <g id="line2d_21">
-      <path d="M 69.05 99.540017
-L 507.6 99.540017
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 95.987904
+L 507.6 95.987904
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="99.540017" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="95.987904" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1 s -->
-      <g transform="translate(47.3 103.339236) scale(0.1 -0.1)">
+      <g transform="translate(47.3 99.787123) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-73" transform="translate(95.410156 0)"/>
@@ -833,18 +833,18 @@ L 507.6 99.540017
     </g>
     <g id="ytick_4">
      <g id="line2d_23">
-      <path d="M 69.05 29.535759
-L 507.6 29.535759
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 29.339422
+L 507.6 29.339422
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m2fc5dfffec" x="69.05" y="29.535759" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m2fc5dfffec" x="69.05" y="29.339422" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 10 s -->
-      <g transform="translate(40.9375 33.334978) scale(0.1 -0.1)">
+      <g transform="translate(40.9375 33.138641) scale(0.1 -0.1)">
        <use xlink:href="#DejaVuSans-31"/>
        <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
        <use xlink:href="#DejaVuSans-20" transform="translate(127.246094 0)"/>
@@ -854,9 +854,9 @@ L 507.6 29.535759
     </g>
     <g id="ytick_5">
      <g id="line2d_25">
-      <path d="M 69.05 288.47941
-L 507.6 288.47941
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 275.870159
+L 507.6 275.870159
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <defs>
@@ -865,385 +865,385 @@ L -2 0
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="288.47941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="275.870159" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_27">
-      <path d="M 69.05 276.152272
-L 507.6 276.152272
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 264.133944
+L 507.6 264.133944
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="276.152272" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="264.133944" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_29">
-      <path d="M 69.05 267.406028
-L 507.6 267.406028
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 255.806967
+L 507.6 255.806967
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="267.406028" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="255.806967" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_31">
-      <path d="M 69.05 260.621915
-L 507.6 260.621915
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 249.348061
+L 507.6 249.348061
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="260.621915" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="249.348061" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_9">
      <g id="line2d_33">
-      <path d="M 69.05 255.07889
-L 507.6 255.07889
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 244.070752
+L 507.6 244.070752
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="255.07889" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="244.070752" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_10">
      <g id="line2d_35">
-      <path d="M 69.05 250.39233
-L 507.6 250.39233
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 239.60885
+L 507.6 239.60885
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="250.39233" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="239.60885" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_11">
      <g id="line2d_37">
-      <path d="M 69.05 246.332647
-L 507.6 246.332647
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 235.743774
+L 507.6 235.743774
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="246.332647" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="235.743774" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_12">
      <g id="line2d_39">
-      <path d="M 69.05 242.751753
-L 507.6 242.751753
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 232.334536
+L 507.6 232.334536
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="242.751753" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="232.334536" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_13">
      <g id="line2d_41">
-      <path d="M 69.05 218.475152
-L 507.6 218.475152
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 209.221677
+L 507.6 209.221677
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="218.475152" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="209.221677" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_43">
-      <path d="M 69.05 206.148014
-L 507.6 206.148014
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 197.485462
+L 507.6 197.485462
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="206.148014" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="197.485462" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_45">
-      <path d="M 69.05 197.40177
-L 507.6 197.40177
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 189.158484
+L 507.6 189.158484
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="197.40177" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="189.158484" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_47">
-      <path d="M 69.05 190.617657
-L 507.6 190.617657
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 182.699579
+L 507.6 182.699579
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="190.617657" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="182.699579" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_49">
-      <path d="M 69.05 185.074632
-L 507.6 185.074632
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 177.422269
+L 507.6 177.422269
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="185.074632" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="177.422269" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_51">
-      <path d="M 69.05 180.388072
-L 507.6 180.388072
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 172.960367
+L 507.6 172.960367
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="180.388072" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="172.960367" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_53">
-      <path d="M 69.05 176.328389
-L 507.6 176.328389
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 169.095292
+L 507.6 169.095292
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="176.328389" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="169.095292" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_55">
-      <path d="M 69.05 172.747494
-L 507.6 172.747494
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 165.686054
+L 507.6 165.686054
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="172.747494" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="165.686054" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_57">
-      <path d="M 69.05 148.470894
-L 507.6 148.470894
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 142.573194
+L 507.6 142.573194
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="148.470894" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="142.573194" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_59">
-      <path d="M 69.05 136.143756
-L 507.6 136.143756
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 130.836979
+L 507.6 130.836979
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="136.143756" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="130.836979" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_61">
-      <path d="M 69.05 127.397512
-L 507.6 127.397512
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 122.510002
+L 507.6 122.510002
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="127.397512" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="122.510002" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_63">
-      <path d="M 69.05 120.613399
-L 507.6 120.613399
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 116.051097
+L 507.6 116.051097
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="120.613399" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="116.051097" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_65">
-      <path d="M 69.05 115.070374
-L 507.6 115.070374
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 110.773787
+L 507.6 110.773787
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="115.070374" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="110.773787" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_67">
-      <path d="M 69.05 110.383814
-L 507.6 110.383814
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 106.311885
+L 507.6 106.311885
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="110.383814" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="106.311885" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_69">
-      <path d="M 69.05 106.324131
-L 507.6 106.324131
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 102.44681
+L 507.6 102.44681
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="106.324131" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="102.44681" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_71">
-      <path d="M 69.05 102.743236
-L 507.6 102.743236
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 99.037572
+L 507.6 99.037572
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="102.743236" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="99.037572" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_73">
-      <path d="M 69.05 78.466636
-L 507.6 78.466636
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 75.924712
+L 507.6 75.924712
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="78.466636" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="75.924712" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_75">
-      <path d="M 69.05 66.139498
-L 507.6 66.139498
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 64.188497
+L 507.6 64.188497
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_76">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="66.139498" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="64.188497" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_77">
-      <path d="M 69.05 57.393254
-L 507.6 57.393254
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 55.861519
+L 507.6 55.861519
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="57.393254" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="55.861519" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_79">
-      <path d="M 69.05 50.609141
-L 507.6 50.609141
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 49.402614
+L 507.6 49.402614
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_80">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="50.609141" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="49.402614" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_81">
-      <path d="M 69.05 45.066116
-L 507.6 45.066116
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 44.125304
+L 507.6 44.125304
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_82">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="45.066116" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="44.125304" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_83">
-      <path d="M 69.05 40.379556
-L 507.6 40.379556
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 39.663402
+L 507.6 39.663402
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_84">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="40.379556" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="39.663402" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_85">
-      <path d="M 69.05 36.319873
-L 507.6 36.319873
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 35.798327
+L 507.6 35.798327
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_86">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="36.319873" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="35.798327" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_87">
-      <path d="M 69.05 32.738978
-L 507.6 32.738978
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 69.05 32.389089
+L 507.6 32.389089
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.25; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_88">
       <g>
-       <use xlink:href="#m9fe0730aad" x="69.05" y="32.738978" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#m9fe0730aad" x="69.05" y="32.389089" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="text_14">
      <!-- median wall time per call -->
-     <g transform="translate(18.754688 227.764219) rotate(-90) scale(0.1 -0.1)">
+     <g transform="translate(18.754688 221.096219) rotate(-90) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-77" d="M 269 3500
 L 844 3500
@@ -1366,15 +1366,15 @@ z
     </g>
    </g>
    <g id="line2d_89">
-    <path d="M 88.984091 223.761859
-L 128.852273 182.711439
-L 168.720455 152.197613
-L 208.588636 128.690872
-L 248.456818 110.754238
-L 328.193182 79.620483
-L 407.929545 57.513863
-L 487.665909 38.085455
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 214.254956
+L 128.852273 175.172359
+L 168.720455 146.121266
+L 208.588636 123.741362
+L 248.456818 106.664552
+L 328.193182 77.023248
+L 407.929545 55.976346
+L 487.665909 37.479273
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m0fee27a2d2" d="M -3 3
 L 3 3
@@ -1383,27 +1383,27 @@ L -3 -3
 z
 " style="stroke: #1f77b4; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m0fee27a2d2" x="88.984091" y="223.761859" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="128.852273" y="182.711439" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="168.720455" y="152.197613" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="208.588636" y="128.690872" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="248.456818" y="110.754238" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="328.193182" y="79.620483" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="407.929545" y="57.513863" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
-     <use xlink:href="#m0fee27a2d2" x="487.665909" y="38.085455" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m0fee27a2d2" x="88.984091" y="214.254956" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="128.852273" y="175.172359" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="168.720455" y="146.121266" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="208.588636" y="123.741362" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="248.456818" y="106.664552" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="328.193182" y="77.023248" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="407.929545" y="55.976346" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+     <use xlink:href="#m0fee27a2d2" x="487.665909" y="37.479273" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_90">
-    <path d="M 88.984091 226.940546
-L 128.852273 187.42895
-L 168.720455 158.882078
-L 208.588636 136.492762
-L 248.456818 120.877179
-L 328.193182 89.551191
-L 407.929545 69.968101
-L 487.665909 52.115207
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 217.281267
+L 128.852273 179.663729
+L 168.720455 152.4853
+L 208.588636 131.169255
+L 248.456818 116.302232
+L 328.193182 86.47791
+L 407.929545 67.833569
+L 487.665909 50.836485
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132
@@ -1417,27 +1417,27 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #ff7f0e"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="226.940546" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="187.42895" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="158.882078" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="136.492762" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="120.877179" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="89.551191" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="69.968101" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="52.115207" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m2451d16133" x="88.984091" y="217.281267" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="179.663729" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="152.4853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="131.169255" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="116.302232" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="86.47791" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="67.833569" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="50.836485" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 88.984091 204.978752
-L 128.852273 186.89279
-L 168.720455 168.455463
-L 208.588636 150.785567
-L 248.456818 135.874929
-L 328.193182 111.18955
-L 407.929545 88.813556
-L 487.665909 73.396953
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 196.37225
+L 128.852273 179.15327
+L 168.720455 161.599769
+L 208.588636 144.776909
+L 248.456818 130.581039
+L 328.193182 107.078997
+L 407.929545 85.775634
+L 487.665909 71.098054
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="ma559d3018c" d="M 0 -3.5
 L -3.5 3.5
@@ -1445,27 +1445,27 @@ L 3.5 3.5
 z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#ma559d3018c" x="88.984091" y="204.978752" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="128.852273" y="186.89279" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="168.455463" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="150.785567" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="135.874929" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="111.18955" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="88.813556" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="487.665909" y="73.396953" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#ma559d3018c" x="88.984091" y="196.37225" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.852273" y="179.15327" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.720455" y="161.599769" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.588636" y="144.776909" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.456818" y="130.581039" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.193182" y="107.078997" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.929545" y="85.775634" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.665909" y="71.098054" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 88.984091 265.765472
-L 128.852273 229.938756
-L 168.720455 203.579525
-L 208.588636 183.048855
-L 248.456818 166.42538
-L 328.193182 138.010859
-L 407.929545 117.11438
-L 487.665909 101.266126
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 254.245053
+L 128.852273 220.135753
+L 168.720455 195.040097
+L 208.588636 175.4936
+L 248.456818 159.667001
+L 328.193182 132.614579
+L 407.929545 112.71981
+L 487.665909 97.631269
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m633b1844ca" d="M -0 4.596194
 L 4.596194 0
@@ -1474,27 +1474,27 @@ L -4.596194 -0
 z
 " style="stroke: #d62728; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="265.765472" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="229.938756" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="203.579525" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="183.048855" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="166.42538" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="138.010859" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="117.11438" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="487.665909" y="101.266126" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m633b1844ca" x="88.984091" y="254.245053" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="128.852273" y="220.135753" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="168.720455" y="195.040097" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="208.588636" y="175.4936" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="248.456818" y="159.667001" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="328.193182" y="132.614579" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="407.929545" y="112.71981" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m633b1844ca" x="487.665909" y="97.631269" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_93">
-    <path d="M 88.984091 290.994545
-L 128.852273 261.691714
-L 168.720455 240.663234
-L 208.588636 219.387
-L 248.456818 204.552063
-L 328.193182 177.645707
-L 407.929545 156.827707
-L 487.665909 139.546854
-" clip-path="url(#p5ff047cf5c)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <path d="M 88.984091 278.264727
+L 128.852273 250.366578
+L 168.720455 230.346135
+L 208.588636 210.089814
+L 248.456818 195.966016
+L 328.193182 170.349462
+L 407.929545 150.529409
+L 487.665909 134.076943
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m25acbb3ce1" d="M -0 3.5
 L 3.5 -3.5
@@ -1502,30 +1502,30 @@ L -3.5 -3.5
 z
 " style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
-    <g clip-path="url(#p5ff047cf5c)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="290.994545" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="261.691714" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="240.663234" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="219.387" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="204.552063" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="177.645707" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="156.827707" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="139.546854" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#m25acbb3ce1" x="88.984091" y="278.264727" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="128.852273" y="250.366578" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="168.720455" y="230.346135" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="208.588636" y="210.089814" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="248.456818" y="195.966016" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="328.193182" y="170.349462" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="407.929545" y="150.529409" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m25acbb3ce1" x="487.665909" y="134.076943" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 69.05 303.64
+    <path d="M 69.05 290.304
 L 69.05 25.44
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 507.6 303.64
+    <path d="M 507.6 290.304
 L 507.6 25.44
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 69.05 303.64
-L 507.6 303.64
+    <path d="M 69.05 290.304
+L 507.6 290.304
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
@@ -1811,10 +1811,793 @@ L 98.05 97.250937
     </g>
    </g>
   </g>
+  <g id="text_21">
+   <!-- Isabelle certified forks an fplll subprocess per request (~19 ms); this fixed cost dominates its small-n rungs. -->
+   <g style="fill: #595959" transform="translate(69.815547 340.688219) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-Oblique-49" d="M 1081 4666
+L 1716 4666
+L 806 0
+L 172 0
+L 1081 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-73" d="M 3200 3397
+L 3091 2853
+Q 2863 2978 2609 3040
+Q 2356 3103 2088 3103
+Q 1634 3103 1373 2948
+Q 1113 2794 1113 2528
+Q 1113 2219 1719 2053
+Q 1766 2041 1788 2034
+L 1972 1978
+Q 2547 1819 2739 1644
+Q 2931 1469 2931 1166
+Q 2931 609 2489 259
+Q 2047 -91 1331 -91
+Q 1053 -91 747 -37
+Q 441 16 72 128
+L 184 722
+Q 500 559 806 475
+Q 1113 391 1394 391
+Q 1816 391 2080 572
+Q 2344 753 2344 1031
+Q 2344 1331 1650 1516
+L 1591 1531
+L 1394 1581
+Q 956 1697 753 1886
+Q 550 2075 550 2369
+Q 550 2928 970 3256
+Q 1391 3584 2113 3584
+Q 2397 3584 2667 3537
+Q 2938 3491 3200 3397
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-61" d="M 3438 1997
+L 3047 0
+L 2472 0
+L 2578 531
+Q 2325 219 2001 64
+Q 1678 -91 1281 -91
+Q 834 -91 548 182
+Q 263 456 263 884
+Q 263 1497 752 1853
+Q 1241 2209 2100 2209
+L 2900 2209
+L 2931 2363
+Q 2938 2388 2941 2417
+Q 2944 2447 2944 2509
+Q 2944 2788 2717 2942
+Q 2491 3097 2081 3097
+Q 1800 3097 1504 3025
+Q 1209 2953 897 2809
+L 997 3341
+Q 1322 3463 1633 3523
+Q 1944 3584 2234 3584
+Q 2853 3584 3176 3315
+Q 3500 3047 3500 2534
+Q 3500 2431 3484 2292
+Q 3469 2153 3438 1997
+z
+M 2816 1759
+L 2241 1759
+Q 1534 1759 1195 1570
+Q 856 1381 856 984
+Q 856 709 1029 553
+Q 1203 397 1509 397
+Q 1978 397 2328 733
+Q 2678 1069 2791 1631
+L 2816 1759
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-62" d="M 3169 2138
+Q 3169 2591 2961 2847
+Q 2753 3103 2388 3103
+Q 2122 3103 1889 2973
+Q 1656 2844 1484 2597
+Q 1303 2338 1198 1995
+Q 1094 1653 1094 1313
+Q 1094 881 1298 636
+Q 1503 391 1863 391
+Q 2134 391 2365 517
+Q 2597 644 2772 891
+Q 2950 1147 3059 1487
+Q 3169 1828 3169 2138
+z
+M 1381 2969
+Q 1594 3256 1914 3420
+Q 2234 3584 2584 3584
+Q 3122 3584 3439 3221
+Q 3756 2859 3756 2241
+Q 3756 1734 3570 1259
+Q 3384 784 3041 416
+Q 2816 172 2522 40
+Q 2228 -91 1906 -91
+Q 1566 -91 1316 65
+Q 1066 222 909 531
+L 806 0
+L 231 0
+L 1178 4863
+L 1753 4863
+L 1381 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-65" d="M 3078 2063
+Q 3088 2113 3092 2166
+Q 3097 2219 3097 2272
+Q 3097 2653 2873 2875
+Q 2650 3097 2266 3097
+Q 1838 3097 1509 2826
+Q 1181 2556 1013 2059
+L 3078 2063
+z
+M 3578 1613
+L 903 1613
+Q 884 1494 878 1425
+Q 872 1356 872 1306
+Q 872 872 1139 634
+Q 1406 397 1894 397
+Q 2269 397 2603 481
+Q 2938 566 3225 728
+L 3116 159
+Q 2806 34 2476 -28
+Q 2147 -91 1806 -91
+Q 1078 -91 686 257
+Q 294 606 294 1247
+Q 294 1794 489 2264
+Q 684 2734 1063 3103
+Q 1306 3334 1642 3459
+Q 1978 3584 2356 3584
+Q 2950 3584 3301 3228
+Q 3653 2872 3653 2272
+Q 3653 2128 3634 1964
+Q 3616 1800 3578 1613
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6c" d="M 1172 4863
+L 1747 4863
+L 800 0
+L 225 0
+L 1172 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-63" d="M 3431 3366
+L 3316 2797
+Q 3109 2947 2876 3022
+Q 2644 3097 2394 3097
+Q 2119 3097 1870 3000
+Q 1622 2903 1453 2725
+Q 1184 2453 1037 2087
+Q 891 1722 891 1331
+Q 891 859 1127 628
+Q 1363 397 1844 397
+Q 2081 397 2348 469
+Q 2616 541 2906 684
+L 2797 116
+Q 2547 13 2283 -39
+Q 2019 -91 1741 -91
+Q 1044 -91 669 257
+Q 294 606 294 1253
+Q 294 1797 489 2255
+Q 684 2713 1069 3078
+Q 1331 3328 1684 3456
+Q 2038 3584 2456 3584
+Q 2700 3584 2940 3529
+Q 3181 3475 3431 3366
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-72" d="M 2853 2969
+Q 2766 3016 2653 3041
+Q 2541 3066 2413 3066
+Q 1953 3066 1609 2717
+Q 1266 2369 1153 1784
+L 800 0
+L 225 0
+L 909 3500
+L 1484 3500
+L 1375 2956
+Q 1603 3259 1920 3421
+Q 2238 3584 2597 3584
+Q 2691 3584 2781 3573
+Q 2872 3563 2963 3538
+L 2853 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-74" d="M 2706 3500
+L 2619 3053
+L 1472 3053
+L 1100 1153
+Q 1081 1047 1072 975
+Q 1063 903 1063 863
+Q 1063 663 1183 572
+Q 1303 481 1569 481
+L 2150 481
+L 2053 0
+L 1503 0
+Q 991 0 739 200
+Q 488 400 488 806
+Q 488 878 497 964
+Q 506 1050 525 1153
+L 897 3053
+L 409 3053
+L 500 3500
+L 978 3500
+L 1172 4494
+L 1747 4494
+L 1556 3500
+L 2706 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-69" d="M 1172 4863
+L 1747 4863
+L 1606 4134
+L 1031 4134
+L 1172 4863
+z
+M 909 3500
+L 1484 3500
+L 800 0
+L 225 0
+L 909 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-66" d="M 3059 4863
+L 2969 4384
+L 2419 4384
+Q 2106 4384 1964 4261
+Q 1822 4138 1753 3809
+L 1691 3500
+L 2638 3500
+L 2553 3053
+L 1606 3053
+L 1013 0
+L 434 0
+L 1031 3053
+L 481 3053
+L 563 3500
+L 1113 3500
+L 1159 3744
+Q 1278 4363 1576 4613
+Q 1875 4863 2516 4863
+L 3059 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-64" d="M 2675 525
+Q 2444 222 2128 65
+Q 1813 -91 1428 -91
+Q 903 -91 598 267
+Q 294 625 294 1247
+Q 294 1766 478 2236
+Q 663 2706 1013 3078
+Q 1244 3325 1534 3454
+Q 1825 3584 2144 3584
+Q 2481 3584 2739 3421
+Q 2997 3259 3138 2956
+L 3513 4863
+L 4091 4863
+L 3144 0
+L 2566 0
+L 2675 525
+z
+M 891 1350
+Q 891 897 1095 644
+Q 1300 391 1663 391
+Q 1931 391 2161 520
+Q 2391 650 2566 903
+Q 2750 1166 2856 1509
+Q 2963 1853 2963 2188
+Q 2963 2622 2758 2865
+Q 2553 3109 2194 3109
+Q 1922 3109 1687 2981
+Q 1453 2853 1288 2613
+Q 1106 2353 998 2009
+Q 891 1666 891 1350
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6f" d="M 1625 -91
+Q 1009 -91 651 289
+Q 294 669 294 1325
+Q 294 1706 417 2101
+Q 541 2497 738 2766
+Q 1047 3184 1428 3384
+Q 1809 3584 2291 3584
+Q 2888 3584 3255 3212
+Q 3622 2841 3622 2241
+Q 3622 1825 3500 1412
+Q 3378 1000 3181 728
+Q 2875 309 2494 109
+Q 2113 -91 1625 -91
+z
+M 891 1344
+Q 891 869 1089 633
+Q 1288 397 1691 397
+Q 2269 397 2648 901
+Q 3028 1406 3028 2181
+Q 3028 2634 2825 2865
+Q 2622 3097 2228 3097
+Q 1903 3097 1650 2945
+Q 1397 2794 1197 2484
+Q 1050 2253 970 1956
+Q 891 1659 891 1344
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
+L 1747 4863
+L 1197 2028
+L 3169 3500
+L 3916 3500
+L 1716 1825
+L 3322 0
+L 2625 0
+L 1131 1709
+L 800 0
+L 225 0
+L 1172 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6e" d="M 3566 2113
+L 3156 0
+L 2578 0
+L 2988 2091
+Q 3016 2238 3031 2350
+Q 3047 2463 3047 2528
+Q 3047 2791 2881 2937
+Q 2716 3084 2419 3084
+Q 1956 3084 1622 2776
+Q 1288 2469 1184 1941
+L 800 0
+L 225 0
+L 903 3500
+L 1478 3500
+L 1363 2950
+Q 1603 3253 1940 3418
+Q 2278 3584 2650 3584
+Q 3113 3584 3367 3334
+Q 3622 3084 3622 2631
+Q 3622 2519 3608 2391
+Q 3594 2263 3566 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
+Q 3175 2616 2975 2859
+Q 2775 3103 2400 3103
+Q 2144 3103 1911 2972
+Q 1678 2841 1497 2591
+Q 1319 2344 1212 1994
+Q 1106 1644 1106 1300
+Q 1106 863 1306 627
+Q 1506 391 1875 391
+Q 2147 391 2380 519
+Q 2613 647 2778 891
+Q 2956 1147 3065 1494
+Q 3175 1841 3175 2156
+z
+M 1394 2969
+Q 1625 3272 1939 3428
+Q 2253 3584 2638 3584
+Q 3175 3584 3472 3232
+Q 3769 2881 3769 2247
+Q 3769 1728 3584 1258
+Q 3400 788 3053 416
+Q 2822 169 2531 39
+Q 2241 -91 1919 -91
+Q 1547 -91 1294 64
+Q 1041 219 916 525
+L 556 -1331
+L -19 -1331
+L 922 3500
+L 1497 3500
+L 1394 2969
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-75" d="M 428 1388
+L 838 3500
+L 1416 3500
+L 1006 1409
+Q 975 1256 961 1147
+Q 947 1038 947 966
+Q 947 700 1109 554
+Q 1272 409 1569 409
+Q 2031 409 2368 721
+Q 2706 1034 2809 1563
+L 3194 3500
+L 3769 3500
+L 3091 0
+L 2516 0
+L 2631 550
+Q 2388 244 2052 76
+Q 1716 -91 1338 -91
+Q 878 -91 622 161
+Q 366 413 366 863
+Q 366 956 381 1097
+Q 397 1238 428 1388
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-71" d="M 2669 525
+Q 2438 222 2123 65
+Q 1809 -91 1428 -91
+Q 897 -91 595 267
+Q 294 625 294 1253
+Q 294 1759 480 2231
+Q 666 2703 1013 3078
+Q 1238 3322 1530 3453
+Q 1822 3584 2144 3584
+Q 2531 3584 2781 3431
+Q 3031 3278 3144 2969
+L 3244 3494
+L 3822 3494
+L 2888 -1319
+L 2309 -1319
+L 2669 525
+z
+M 891 1338
+Q 891 875 1084 633
+Q 1278 391 1644 391
+Q 2188 391 2572 911
+Q 2956 1431 2956 2175
+Q 2956 2625 2757 2864
+Q 2559 3103 2188 3103
+Q 1916 3103 1684 2976
+Q 1453 2850 1281 2606
+Q 1100 2350 995 2006
+Q 891 1663 891 1338
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-28" d="M 2731 4856
+Q 1903 3822 1495 2892
+Q 1088 1963 1088 1100
+Q 1088 606 1206 120
+Q 1325 -366 1563 -844
+L 1063 -844
+Q 775 -306 634 201
+Q 494 709 494 1197
+Q 494 2125 923 3036
+Q 1353 3947 2222 4856
+L 2731 4856
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-7e" d="M 4684 2553
+L 4684 1997
+Q 4356 1750 4076 1644
+Q 3797 1538 3494 1538
+Q 3150 1538 2694 1722
+Q 2659 1734 2644 1741
+Q 2622 1750 2575 1766
+Q 2091 1959 1797 1959
+Q 1522 1959 1253 1839
+Q 984 1719 678 1459
+L 678 2016
+Q 1006 2263 1286 2370
+Q 1566 2478 1869 2478
+Q 2213 2478 2672 2291
+Q 2703 2278 2719 2272
+Q 2744 2263 2788 2247
+Q 3272 2053 3566 2053
+Q 3834 2053 4098 2172
+Q 4363 2291 4684 2553
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 416 531
+L 1447 531
+L 2144 4122
+L 978 3897
+L 1088 4441
+L 2247 4666
+L 2881 4666
+L 2075 531
+L 3103 531
+L 3003 0
+L 313 0
+L 416 531
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-39" d="M 281 103
+L 397 678
+Q 578 559 809 496
+Q 1041 434 1306 434
+Q 1953 434 2348 843
+Q 2744 1253 2938 2119
+Q 2706 1853 2401 1714
+Q 2097 1575 1747 1575
+Q 1178 1575 842 1904
+Q 506 2234 506 2791
+Q 506 3247 672 3639
+Q 838 4031 1159 4325
+Q 1378 4531 1665 4640
+Q 1953 4750 2278 4750
+Q 2925 4750 3300 4339
+Q 3675 3928 3675 3219
+Q 3675 2559 3501 1943
+Q 3328 1328 3022 878
+Q 2697 403 2240 156
+Q 1784 -91 1228 -91
+Q 988 -91 748 -42
+Q 509 6 281 103
+z
+M 1131 2938
+Q 1131 2541 1337 2308
+Q 1544 2075 1894 2075
+Q 2378 2075 2706 2447
+Q 3034 2819 3034 3372
+Q 3034 3784 2831 4017
+Q 2628 4250 2272 4250
+Q 1788 4250 1459 3870
+Q 1131 3491 1131 2938
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6d" d="M 5747 2113
+L 5338 0
+L 4763 0
+L 5166 2094
+Q 5191 2228 5203 2325
+Q 5216 2422 5216 2491
+Q 5216 2772 5059 2928
+Q 4903 3084 4622 3084
+Q 4203 3084 3875 2770
+Q 3547 2456 3450 1953
+L 3066 0
+L 2491 0
+L 2900 2094
+Q 2925 2209 2937 2307
+Q 2950 2406 2950 2484
+Q 2950 2769 2794 2926
+Q 2638 3084 2363 3084
+Q 1938 3084 1609 2770
+Q 1281 2456 1184 1953
+L 800 0
+L 225 0
+L 909 3500
+L 1484 3500
+L 1375 2956
+Q 1609 3263 1923 3423
+Q 2238 3584 2597 3584
+Q 2978 3584 3223 3384
+Q 3469 3184 3519 2828
+Q 3781 3197 4126 3390
+Q 4472 3584 4856 3584
+Q 5306 3584 5551 3325
+Q 5797 3066 5797 2591
+Q 5797 2488 5784 2364
+Q 5772 2241 5747 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-29" d="M -397 -844
+Q 434 191 840 1120
+Q 1247 2050 1247 2913
+Q 1247 3406 1130 3892
+Q 1013 4378 775 4856
+L 1275 4856
+Q 1563 4316 1703 3812
+Q 1844 3309 1844 2822
+Q 1844 1891 1411 973
+Q 978 56 116 -844
+L -397 -844
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3b" d="M 563 794
+L 1222 794
+L 1113 256
+L 409 -744
+L 6 -744
+L 453 256
+L 563 794
+z
+M 1050 3309
+L 1709 3309
+L 1556 2516
+L 897 2516
+L 1050 3309
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-68" d="M 3566 2113
+L 3156 0
+L 2578 0
+L 2988 2091
+Q 3016 2238 3031 2350
+Q 3047 2463 3047 2528
+Q 3047 2791 2881 2937
+Q 2716 3084 2419 3084
+Q 1956 3084 1617 2771
+Q 1278 2459 1178 1941
+L 800 0
+L 225 0
+L 1172 4863
+L 1747 4863
+L 1375 2950
+Q 1594 3244 1934 3414
+Q 2275 3584 2650 3584
+Q 3113 3584 3367 3334
+Q 3622 3084 3622 2631
+Q 3622 2519 3608 2391
+Q 3594 2263 3566 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
+L 2234 1784
+L 3219 0
+L 2559 0
+L 1819 1388
+L 531 0
+L -166 0
+L 1556 1844
+L 641 3500
+L 1300 3500
+L 1972 2234
+L 3144 3500
+L 3841 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
+L 2075 2009
+L 1978 1497
+L 288 1497
+L 391 2009
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-67" d="M 3816 3500
+L 3219 434
+Q 3047 -456 2561 -893
+Q 2075 -1331 1253 -1331
+Q 950 -1331 690 -1286
+Q 431 -1241 206 -1147
+L 313 -588
+Q 525 -725 762 -790
+Q 1000 -856 1269 -856
+Q 1816 -856 2167 -557
+Q 2519 -259 2631 300
+L 2681 563
+Q 2441 288 2122 144
+Q 1803 0 1434 0
+Q 903 0 598 351
+Q 294 703 294 1319
+Q 294 1803 478 2267
+Q 663 2731 997 3091
+Q 1219 3328 1514 3456
+Q 1809 3584 2131 3584
+Q 2484 3584 2746 3420
+Q 3009 3256 3138 2956
+L 3238 3500
+L 3816 3500
+z
+M 2950 2216
+Q 2950 2641 2750 2872
+Q 2550 3103 2181 3103
+Q 1953 3103 1747 3012
+Q 1541 2922 1394 2759
+Q 1156 2491 1023 2127
+Q 891 1763 891 1375
+Q 891 944 1092 712
+Q 1294 481 1672 481
+Q 2219 481 2584 976
+Q 2950 1472 2950 2216
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 525 794
+L 1184 794
+L 1031 0
+L 372 0
+L 525 794
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-49"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(29.492188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(81.591797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(142.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(206.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(267.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(295.654297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(323.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(384.960938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(416.748047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(471.728516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(533.251953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(574.365234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(613.574219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(641.357422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(676.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(704.345703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(765.869141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(829.345703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(861.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(896.337891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(957.519531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(998.632812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1056.542969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1108.642578 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(1140.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1201.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1265.087891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(1296.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1332.080078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1395.556641 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1423.339844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1451.123047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1478.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1510.693359 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1562.792969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1626.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1689.648438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1753.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1794.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1855.419922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1910.400391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1971.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2024.023438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2076.123047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2107.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2171.386719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2232.910156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2274.023438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2305.810547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2346.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2408.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2471.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2535.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2596.826172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(2648.925781 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2688.134766 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2719.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2758.935547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2842.724609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-39" transform="translate(2906.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2969.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(3001.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3099.169922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-29" transform="translate(3151.269531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3b" transform="translate(3190.283203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3223.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3255.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(3294.970703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3358.349609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3386.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3438.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3470.019531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3505.224609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3533.007812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3592.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3653.710938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3717.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(3748.974609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3803.955078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3865.136719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3917.236328 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3956.445312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3988.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4051.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4112.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4210.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(4238.085938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4301.464844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4362.744141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4401.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4463.476562 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4515.576172 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4547.363281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4575.146484 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4614.355469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4666.455078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4698.242188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4750.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4847.753906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4909.033203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4936.816406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4964.599609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5000.683594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5064.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(5095.849609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5136.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5200.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(5263.720703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5327.197266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(5379.296875 0)"/>
+   </g>
+  </g>
  </g>
  <defs>
-  <clipPath id="p5ff047cf5c">
-   <rect x="69.05" y="25.44" width="438.55" height="278.2"/>
+  <clipPath id="p57df7f6c62">
+   <rect x="69.05" y="25.44" width="438.55" height="264.864"/>
   </clipPath>
  </defs>
 </svg>

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -1429,14 +1429,14 @@ z
     </g>
    </g>
    <g id="line2d_91">
-    <path d="M 88.984091 196.37225
-L 128.852273 179.15327
-L 168.720455 161.599769
-L 208.588636 144.776909
-L 248.456818 130.581039
-L 328.193182 107.078997
-L 407.929545 85.775634
-L 487.665909 71.098054
+    <path d="M 88.984091 223.113929
+L 128.852273 190.859538
+L 168.720455 167.392919
+L 208.588636 147.8728
+L 248.456818 132.437226
+L 328.193182 107.88847
+L 407.929545 86.160573
+L 487.665909 71.329269
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="ma559d3018c" d="M 0 -3.5
@@ -1446,14 +1446,14 @@ z
 " style="stroke: #2ca02c; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#ma559d3018c" x="88.984091" y="196.37225" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="128.852273" y="179.15327" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="168.720455" y="161.599769" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="208.588636" y="144.776909" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="248.456818" y="130.581039" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="328.193182" y="107.078997" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="407.929545" y="85.775634" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
-     <use xlink:href="#ma559d3018c" x="487.665909" y="71.098054" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="88.984091" y="223.113929" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="128.852273" y="190.859538" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="168.720455" y="167.392919" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="208.588636" y="147.8728" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="248.456818" y="132.437226" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="328.193182" y="107.88847" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="407.929545" y="86.160573" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+     <use xlink:href="#ma559d3018c" x="487.665909" y="71.329269" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="line2d_92">
@@ -1703,7 +1703,7 @@ L 98.05 67.894687
      </g>
     </g>
     <g id="text_18">
-     <!-- Isabelle certified -->
+     <!-- Isabelle certified (adjusted) -->
      <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
@@ -1727,6 +1727,51 @@ Q 1241 4863 1831 4863
 L 2375 4863
 z
 " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856
+Q 1566 4138 1362 3434
+Q 1159 2731 1159 2009
+Q 1159 1288 1364 580
+Q 1569 -128 1984 -844
+L 1484 -844
+Q 1016 -109 783 600
+Q 550 1309 550 2009
+Q 550 2706 781 3412
+Q 1013 4119 1484 4856
+L 1984 4856
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6a" d="M 603 3500
+L 1178 3500
+L 1178 -63
+Q 1178 -731 923 -1031
+Q 669 -1331 103 -1331
+L -116 -1331
+L -116 -844
+L 38 -844
+Q 366 -844 484 -692
+Q 603 -541 603 -63
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856
+L 1013 4856
+Q 1481 4119 1714 3412
+Q 1947 2706 1947 2009
+Q 1947 1309 1714 600
+Q 1481 -109 1013 -844
+L 513 -844
+Q 928 -128 1133 580
+Q 1338 1288 1338 2009
+Q 1338 2731 1133 3434
+Q 928 4138 513 4856
+z
+" transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-49"/>
       <use xlink:href="#DejaVuSans-73" transform="translate(29.492188 0)"/>
@@ -1746,6 +1791,17 @@ z
       <use xlink:href="#DejaVuSans-69" transform="translate(676.5625 0)"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(704.345703 0)"/>
       <use xlink:href="#DejaVuSans-64" transform="translate(765.869141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(829.345703 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(861.132812 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(900.146484 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(961.425781 0)"/>
+      <use xlink:href="#DejaVuSans-6a" transform="translate(1024.902344 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1052.685547 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1116.064453 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1168.164062 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1207.373047 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1268.896484 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1332.373047 0)"/>
      </g>
     </g>
     <g id="line2d_97">
@@ -1812,8 +1868,8 @@ L 98.05 97.250937
    </g>
   </g>
   <g id="text_21">
-   <!-- Isabelle certified forks an fplll subprocess per request (~19 ms); this fixed cost dominates its small-n rungs. -->
-   <g style="fill: #595959" transform="translate(69.815547 340.688219) scale(0.07 -0.07)">
+   <!-- Isabelle certified is adjusted down by its ~18.8 ms per-request floor, a fixed trivial-request cost dominated by the fplll subprocess fork. -->
+   <g style="fill: #595959" transform="translate(22.612031 340.688219) scale(0.07 -0.07)">
     <defs>
      <path id="DejaVuSans-Oblique-49" d="M 1081 4666
 L 1716 4666
@@ -2095,6 +2151,50 @@ Q 1106 2353 998 2009
 Q 891 1666 891 1350
 z
 " transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-6a" d="M 928 3500
+L 1503 3500
+L 813 -63
+L 809 -78
+Q 694 -675 544 -897
+Q 403 -1106 132 -1218
+Q -138 -1331 -506 -1331
+L -722 -1331
+L -628 -844
+L -481 -844
+Q -144 -844 -1 -703
+Q 141 -563 238 -63
+L 928 3500
+z
+M 1197 4863
+L 1772 4863
+L 1631 4134
+L 1056 4134
+L 1197 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-75" d="M 428 1388
+L 838 3500
+L 1416 3500
+L 1006 1409
+Q 975 1256 961 1147
+Q 947 1038 947 966
+Q 947 700 1109 554
+Q 1272 409 1569 409
+Q 2031 409 2368 721
+Q 2706 1034 2809 1563
+L 3194 3500
+L 3769 3500
+L 3091 0
+L 2516 0
+L 2631 550
+Q 2388 244 2052 76
+Q 1716 -91 1338 -91
+Q 878 -91 622 161
+Q 366 413 366 863
+Q 366 956 381 1097
+Q 397 1238 428 1388
+z
+" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6f" d="M 1625 -91
 Q 1009 -91 651 289
 Q 294 669 294 1325
@@ -2122,18 +2222,20 @@ Q 1050 2253 970 1956
 Q 891 1659 891 1344
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
-L 1747 4863
-L 1197 2028
-L 3169 3500
-L 3916 3500
-L 1716 1825
-L 3322 0
-L 2625 0
-L 1131 1709
-L 800 0
-L 225 0
-L 1172 4863
+     <path id="DejaVuSans-Oblique-77" d="M 544 3500
+L 1113 3500
+L 1259 684
+L 2566 3500
+L 3231 3500
+L 3425 684
+L 4666 3500
+L 5241 3500
+L 3641 0
+L 2969 0
+L 2797 2900
+L 1459 0
+L 781 0
+L 544 3500
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6e" d="M 3566 2113
@@ -2159,102 +2261,21 @@ Q 3622 2519 3608 2391
 Q 3594 2263 3566 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
-Q 3175 2616 2975 2859
-Q 2775 3103 2400 3103
-Q 2144 3103 1911 2972
-Q 1678 2841 1497 2591
-Q 1319 2344 1212 1994
-Q 1106 1644 1106 1300
-Q 1106 863 1306 627
-Q 1506 391 1875 391
-Q 2147 391 2380 519
-Q 2613 647 2778 891
-Q 2956 1147 3065 1494
-Q 3175 1841 3175 2156
-z
-M 1394 2969
-Q 1625 3272 1939 3428
-Q 2253 3584 2638 3584
-Q 3175 3584 3472 3232
-Q 3769 2881 3769 2247
-Q 3769 1728 3584 1258
-Q 3400 788 3053 416
-Q 2822 169 2531 39
-Q 2241 -91 1919 -91
-Q 1547 -91 1294 64
-Q 1041 219 916 525
-L 556 -1331
-L -19 -1331
-L 922 3500
-L 1497 3500
-L 1394 2969
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-75" d="M 428 1388
-L 838 3500
-L 1416 3500
-L 1006 1409
-Q 975 1256 961 1147
-Q 947 1038 947 966
-Q 947 700 1109 554
-Q 1272 409 1569 409
-Q 2031 409 2368 721
-Q 2706 1034 2809 1563
-L 3194 3500
-L 3769 3500
-L 3091 0
-L 2516 0
-L 2631 550
-Q 2388 244 2052 76
-Q 1716 -91 1338 -91
-Q 878 -91 622 161
-Q 366 413 366 863
-Q 366 956 381 1097
-Q 397 1238 428 1388
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-71" d="M 2669 525
-Q 2438 222 2123 65
-Q 1809 -91 1428 -91
-Q 897 -91 595 267
-Q 294 625 294 1253
-Q 294 1759 480 2231
-Q 666 2703 1013 3078
-Q 1238 3322 1530 3453
-Q 1822 3584 2144 3584
-Q 2531 3584 2781 3431
-Q 3031 3278 3144 2969
-L 3244 3494
-L 3822 3494
-L 2888 -1319
-L 2309 -1319
-L 2669 525
-z
-M 891 1338
-Q 891 875 1084 633
-Q 1278 391 1644 391
-Q 2188 391 2572 911
-Q 2956 1431 2956 2175
-Q 2956 2625 2757 2864
-Q 2559 3103 2188 3103
-Q 1916 3103 1684 2976
-Q 1453 2850 1281 2606
-Q 1100 2350 995 2006
-Q 891 1663 891 1338
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-28" d="M 2731 4856
-Q 1903 3822 1495 2892
-Q 1088 1963 1088 1100
-Q 1088 606 1206 120
-Q 1325 -366 1563 -844
-L 1063 -844
-Q 775 -306 634 201
-Q 494 709 494 1197
-Q 494 2125 923 3036
-Q 1353 3947 2222 4856
-L 2731 4856
+     <path id="DejaVuSans-Oblique-79" d="M 1588 -325
+Q 1188 -997 936 -1164
+Q 684 -1331 294 -1331
+L -159 -1331
+L -63 -850
+L 269 -850
+Q 509 -850 678 -719
+Q 847 -588 1056 -206
+L 1234 128
+L 459 3500
+L 1069 3500
+L 1650 819
+L 3256 3500
+L 3859 3500
+L 1588 -325
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-7e" d="M 4684 2553
@@ -2292,38 +2313,50 @@ L 313 0
 L 416 531
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-39" d="M 281 103
-L 397 678
-Q 578 559 809 496
-Q 1041 434 1306 434
-Q 1953 434 2348 843
-Q 2744 1253 2938 2119
-Q 2706 1853 2401 1714
-Q 2097 1575 1747 1575
-Q 1178 1575 842 1904
-Q 506 2234 506 2791
-Q 506 3247 672 3639
-Q 838 4031 1159 4325
-Q 1378 4531 1665 4640
-Q 1953 4750 2278 4750
-Q 2925 4750 3300 4339
-Q 3675 3928 3675 3219
-Q 3675 2559 3501 1943
-Q 3328 1328 3022 878
-Q 2697 403 2240 156
-Q 1784 -91 1228 -91
-Q 988 -91 748 -42
-Q 509 6 281 103
+     <path id="DejaVuSans-Oblique-38" d="M 2847 1416
+Q 2847 1769 2600 1992
+Q 2353 2216 1953 2216
+Q 1466 2216 1148 1923
+Q 831 1631 831 1184
+Q 831 828 1073 618
+Q 1316 409 1728 409
+Q 2219 409 2533 693
+Q 2847 978 2847 1416
 z
-M 1131 2938
-Q 1131 2541 1337 2308
-Q 1544 2075 1894 2075
-Q 2378 2075 2706 2447
-Q 3034 2819 3034 3372
-Q 3034 3784 2831 4017
-Q 2628 4250 2272 4250
-Q 1788 4250 1459 3870
-Q 1131 3491 1131 2938
+M 3169 3591
+Q 3169 3888 2950 4069
+Q 2731 4250 2369 4250
+Q 1941 4250 1664 4009
+Q 1388 3769 1388 3406
+Q 1388 3094 1605 2903
+Q 1822 2713 2181 2713
+Q 2613 2713 2891 2961
+Q 3169 3209 3169 3591
+z
+M 2741 2456
+Q 3094 2322 3281 2050
+Q 3469 1778 3469 1394
+Q 3469 747 2969 328
+Q 2469 -91 1678 -91
+Q 1006 -91 609 239
+Q 213 569 213 1119
+Q 213 1619 553 2008
+Q 894 2397 1441 2503
+Q 1113 2616 941 2852
+Q 769 3088 769 3425
+Q 769 3991 1239 4370
+Q 1709 4750 2431 4750
+Q 3034 4750 3414 4442
+Q 3794 4134 3794 3659
+Q 3794 3247 3511 2923
+Q 3228 2600 2741 2456
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 525 794
+L 1184 794
+L 1031 0
+L 372 0
+L 525 794
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-6d" d="M 5747 2113
@@ -2362,32 +2395,107 @@ Q 5797 2488 5784 2364
 Q 5772 2241 5747 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-29" d="M -397 -844
-Q 434 191 840 1120
-Q 1247 2050 1247 2913
-Q 1247 3406 1130 3892
-Q 1013 4378 775 4856
-L 1275 4856
-Q 1563 4316 1703 3812
-Q 1844 3309 1844 2822
-Q 1844 1891 1411 973
-Q 978 56 116 -844
-L -397 -844
+     <path id="DejaVuSans-Oblique-70" d="M 3175 2156
+Q 3175 2616 2975 2859
+Q 2775 3103 2400 3103
+Q 2144 3103 1911 2972
+Q 1678 2841 1497 2591
+Q 1319 2344 1212 1994
+Q 1106 1644 1106 1300
+Q 1106 863 1306 627
+Q 1506 391 1875 391
+Q 2147 391 2380 519
+Q 2613 647 2778 891
+Q 2956 1147 3065 1494
+Q 3175 1841 3175 2156
+z
+M 1394 2969
+Q 1625 3272 1939 3428
+Q 2253 3584 2638 3584
+Q 3175 3584 3472 3232
+Q 3769 2881 3769 2247
+Q 3769 1728 3584 1258
+Q 3400 788 3053 416
+Q 2822 169 2531 39
+Q 2241 -91 1919 -91
+Q 1547 -91 1294 64
+Q 1041 219 916 525
+L 556 -1331
+L -19 -1331
+L 922 3500
+L 1497 3500
+L 1394 2969
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-3b" d="M 563 794
-L 1222 794
-L 1113 256
-L 409 -744
-L 6 -744
-L 453 256
-L 563 794
+     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
+L 2075 2009
+L 1978 1497
+L 288 1497
+L 391 2009
 z
-M 1050 3309
-L 1709 3309
-L 1556 2516
-L 897 2516
-L 1050 3309
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-71" d="M 2669 525
+Q 2438 222 2123 65
+Q 1809 -91 1428 -91
+Q 897 -91 595 267
+Q 294 625 294 1253
+Q 294 1759 480 2231
+Q 666 2703 1013 3078
+Q 1238 3322 1530 3453
+Q 1822 3584 2144 3584
+Q 2531 3584 2781 3431
+Q 3031 3278 3144 2969
+L 3244 3494
+L 3822 3494
+L 2888 -1319
+L 2309 -1319
+L 2669 525
+z
+M 891 1338
+Q 891 875 1084 633
+Q 1278 391 1644 391
+Q 2188 391 2572 911
+Q 2956 1431 2956 2175
+Q 2956 2625 2757 2864
+Q 2559 3103 2188 3103
+Q 1916 3103 1684 2976
+Q 1453 2850 1281 2606
+Q 1100 2350 995 2006
+Q 891 1663 891 1338
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2c" d="M 575 794
+L 1234 794
+L 1131 256
+L 422 -744
+L 19 -744
+L 469 256
+L 575 794
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
+L 2234 1784
+L 3219 0
+L 2559 0
+L 1819 1388
+L 531 0
+L -166 0
+L 1556 1844
+L 641 3500
+L 1300 3500
+L 1972 2234
+L 3144 3500
+L 3841 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-76" d="M 459 3500
+L 1069 3500
+L 1581 525
+L 3256 3500
+L 3866 3500
+L 1875 0
+L 1100 0
+L 459 3500
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-68" d="M 3566 2113
@@ -2413,71 +2521,18 @@ Q 3622 2519 3608 2391
 Q 3594 2263 3566 2113
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-78" d="M 3841 3500
-L 2234 1784
-L 3219 0
-L 2559 0
-L 1819 1388
-L 531 0
-L -166 0
-L 1556 1844
-L 641 3500
-L 1300 3500
-L 1972 2234
-L 3144 3500
-L 3841 3500
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-2d" d="M 391 2009
-L 2075 2009
-L 1978 1497
-L 288 1497
-L 391 2009
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-67" d="M 3816 3500
-L 3219 434
-Q 3047 -456 2561 -893
-Q 2075 -1331 1253 -1331
-Q 950 -1331 690 -1286
-Q 431 -1241 206 -1147
-L 313 -588
-Q 525 -725 762 -790
-Q 1000 -856 1269 -856
-Q 1816 -856 2167 -557
-Q 2519 -259 2631 300
-L 2681 563
-Q 2441 288 2122 144
-Q 1803 0 1434 0
-Q 903 0 598 351
-Q 294 703 294 1319
-Q 294 1803 478 2267
-Q 663 2731 997 3091
-Q 1219 3328 1514 3456
-Q 1809 3584 2131 3584
-Q 2484 3584 2746 3420
-Q 3009 3256 3138 2956
-L 3238 3500
-L 3816 3500
-z
-M 2950 2216
-Q 2950 2641 2750 2872
-Q 2550 3103 2181 3103
-Q 1953 3103 1747 3012
-Q 1541 2922 1394 2759
-Q 1156 2491 1023 2127
-Q 891 1763 891 1375
-Q 891 944 1092 712
-Q 1294 481 1672 481
-Q 2219 481 2584 976
-Q 2950 1472 2950 2216
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-2e" d="M 525 794
-L 1184 794
-L 1031 0
-L 372 0
-L 525 794
+     <path id="DejaVuSans-Oblique-6b" d="M 1172 4863
+L 1747 4863
+L 1197 2028
+L 3169 3500
+L 3916 3500
+L 1716 1825
+L 3322 0
+L 2625 0
+L 1131 1709
+L 800 0
+L 225 0
+L 1172 4863
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -2500,98 +2555,126 @@ z
     <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(704.345703 0)"/>
     <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(765.869141 0)"/>
     <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(829.345703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(861.132812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(896.337891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(957.519531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(998.632812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1056.542969 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1108.642578 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(1140.429688 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1201.708984 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1265.087891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(1296.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1332.080078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1395.556641 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1423.339844 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(1451.123047 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1478.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1510.693359 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1562.792969 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1626.171875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(1689.648438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(1753.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1794.238281 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(1855.419922 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1910.400391 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1971.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2024.023438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2076.123047 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2107.910156 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2171.386719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2232.910156 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2274.023438 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2305.810547 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2346.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2408.447266 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2471.923828 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2535.302734 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2596.826172 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(2648.925781 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2688.134766 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2719.921875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2758.935547 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2842.724609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-39" transform="translate(2906.347656 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2969.970703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(3001.757812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3099.169922 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-29" transform="translate(3151.269531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3b" transform="translate(3190.283203 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3223.974609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3255.761719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(3294.970703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3358.349609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3386.132812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3438.232422 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3470.019531 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3505.224609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3533.007812 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3592.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3653.710938 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3717.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(3748.974609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3803.955078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3865.136719 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3917.236328 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3956.445312 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3988.232422 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4051.708984 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4112.890625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4210.302734 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(4238.085938 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4301.464844 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4362.744141 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4401.953125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4463.476562 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4515.576172 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(4547.363281 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4575.146484 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4614.355469 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4666.455078 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4698.242188 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4750.341797 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4847.753906 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4909.033203 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4936.816406 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4964.599609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5000.683594 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5064.0625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(5095.849609 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5136.962891 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5200.341797 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-67" transform="translate(5263.720703 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5327.197266 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(5379.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(861.132812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(888.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(941.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(972.802734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1034.082031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6a" transform="translate(1097.558594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(1125.341797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1188.720703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1240.820312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(1280.029297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1341.552734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1405.029297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(1436.816406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(1500.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-77" transform="translate(1561.474609 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(1643.261719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1706.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(1738.427734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(1801.904297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(1861.083984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(1892.871094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(1920.654297 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(1959.863281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2011.962891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-7e" transform="translate(2043.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2127.539062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(2191.162109 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(2254.785156 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(2286.572266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2350.195312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(2381.982422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(2479.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(2531.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(2563.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2626.757812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2688.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(2723.894531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(2759.978516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2801.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(2862.615234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(2926.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(2989.470703 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(3050.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3103.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3142.302734 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3174.089844 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(3209.294922 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3237.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(3298.259766 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3359.441406 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(3391.429688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3423.216797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(3455.003906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3516.283203 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(3548.070312 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3583.275391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-78" transform="translate(3611.058594 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(3670.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(3731.761719 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(3795.238281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(3827.025391 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(3866.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3907.347656 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-76" transform="translate(3935.130859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(3994.310547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(4022.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(4083.373047 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2d" transform="translate(4111.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(4147.240234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4188.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-71" transform="translate(4249.876953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(4313.353516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(4376.732422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4438.255859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4490.355469 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4529.564453 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(4561.351562 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4616.332031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(4677.513672 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(4729.613281 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(4768.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(4800.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(4864.085938 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6d" transform="translate(4925.267578 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-69" transform="translate(5022.679688 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6e" transform="translate(5050.462891 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-61" transform="translate(5113.841797 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(5175.121094 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5214.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-64" transform="translate(5275.853516 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5339.330078 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(5371.117188 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-79" transform="translate(5434.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5493.773438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-74" transform="translate(5525.560547 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-68" transform="translate(5564.769531 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(5628.148438 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5689.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(5721.458984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(5756.664062 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5820.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5847.923828 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6c" transform="translate(5875.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(5903.490234 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(5935.277344 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-75" transform="translate(5987.376953 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-62" transform="translate(6050.755859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-70" transform="translate(6114.232422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6177.708984 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(6218.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-63" transform="translate(6280.003906 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-65" transform="translate(6334.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(6396.507812 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-73" transform="translate(6448.607422 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-20" transform="translate(6500.707031 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-66" transform="translate(6532.494141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6f" transform="translate(6567.699219 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-72" transform="translate(6628.880859 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-6b" transform="translate(6669.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(6727.904297 0)"/>
    </g>
   </g>
  </g>

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -438,13 +438,20 @@ fpLLL via fplll-ffi.
 
 ![Random-bounded comparator runtime plot](figures/hex-lll-comparator-random-bounded.svg)
 
-The harsh-cubic plot shows only the three native/fpLLL series. On this family
-the certified paths run slightly slower than their native counterparts (Lean
-certified is `1.05..1.67×` Lean native, per the ratio table above): fpLLL's
-advantage on hard instances is too small to offset the certificate checker, so
-the certified curves add no story and are omitted to keep the figure legible.
+The Isabelle-certified series forks an `fplll` subprocess per request (~19 ms);
+this fixed cost dominates its small-`n` rungs, and the figure footnotes it
+accordingly (see [§Per-call comparator overhead](#per-call-comparator-overhead)).
+
+The harsh-cubic plot shows the same five series. On this family the
+Lean-certified curve crosses below Lean native at `n = 30` and falls to `0.15×`
+Lean native at `n = 55` (per the harsh-cubic trend above); the certified curves
+carry that crossover story, so both are plotted.
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
+
+Here too the Isabelle-certified series forks an `fplll` subprocess per request
+(~19 ms), a fixed cost that dominates its small-`n` rungs; the figure carries the
+same footnote (see [§Per-call comparator overhead](#per-call-comparator-overhead)).
 
 For the asymptotic scaling of these curves — fitted exponents and constant
 factors per method, with reproduction steps — see

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -433,14 +433,17 @@ Architectural asymmetries for this ratio:
   re-running the verified LLL reducer inside `test_certified`.
 
 The random-bounded plot shows five labelled series across the full committed
-ladder: Lean native, Isabelle native, Lean certified, Isabelle certified, and
-fpLLL via fplll-ffi.
+ladder: Lean native, Isabelle native, Lean certified, Isabelle certified
+(adjusted), and fpLLL via fplll-ffi.
 
 ![Random-bounded comparator runtime plot](figures/hex-lll-comparator-random-bounded.svg)
 
-The Isabelle-certified series forks an `fplll` subprocess per request (~19 ms);
-this fixed cost dominates its small-`n` rungs, and the figure footnotes it
-accordingly (see [§Per-call comparator overhead](#per-call-comparator-overhead)).
+The plotted Isabelle-certified curve is adjusted down by ~18.8 ms, its
+per-request `svp_certified` floor: the fixed trivial-request cost dominated by
+the `fplll` subprocess fork, taken as the audit-host figure from
+[§Per-call comparator overhead](#per-call-comparator-overhead). This floor
+otherwise dominates its small-`n` rungs. The ratio tables above and the scaling
+fits keep the raw medians; only the plotted curve is adjusted.
 
 The harsh-cubic plot shows the same five series. On this family the
 Lean-certified curve crosses below Lean native at `n = 30` and falls to `0.15×`
@@ -449,9 +452,10 @@ carry that crossover story, so both are plotted.
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
 
-Here too the Isabelle-certified series forks an `fplll` subprocess per request
-(~19 ms), a fixed cost that dominates its small-`n` rungs; the figure carries the
-same footnote (see [§Per-call comparator overhead](#per-call-comparator-overhead)).
+Here too the plotted Isabelle-certified curve is adjusted down by ~18.8 ms, its
+per-request `svp_certified` floor (see
+[§Per-call comparator overhead](#per-call-comparator-overhead)); as on the
+random-bounded figure, the ratio tables and scaling fits keep the raw medians.
 
 For the asymptotic scaling of these curves — fitted exponents and constant
 factors per method, with reproduction steps — see

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -204,6 +204,23 @@ def plot(series: list[Series], output: Path, title: str, xlabel: str) -> None:
     ax.grid(True, which="major", axis="x", alpha=0.15)
     ax.legend(frameon=False)
     fig.tight_layout()
+    # The Isabelle-certified pipeline forks an `fplll` subprocess per request
+    # (~19 ms, from reports/hex-lll-performance.md §Per-call comparator
+    # overhead). This fixed cost dominates its small-n rungs, so footnote it
+    # whenever that series is plotted.
+    if any(item.label == "Isabelle certified" for item in series):
+        fig.subplots_adjust(bottom=0.16)
+        fig.text(
+            0.5,
+            0.01,
+            "Isabelle certified forks an fplll subprocess per request "
+            "(~19 ms); this fixed cost dominates its small-n rungs.",
+            ha="center",
+            va="bottom",
+            fontsize=7,
+            style="italic",
+            color="0.35",
+        )
     output.parent.mkdir(parents=True, exist_ok=True)
     fig.savefig(output, format="svg", metadata={"Date": None})
     svg = output.read_text(encoding="utf-8")

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -131,13 +131,28 @@ FAMILIES = {
 }
 
 
+# Fixed per-request floor of the Isabelle-certified pipeline, taken from
+# reports/hex-lll-performance.md §Per-call comparator overhead (~18.8 ms
+# for a trivial end-to-end `svp_certified` request, dominated by the
+# per-request `fplll` subprocess fork). The plotted Isabelle-certified
+# curve subtracts this constant so its small-n rungs show n-dependent
+# work rather than the fixed floor; the committed ratio tables keep the
+# raw medians.
+ISABELLE_CERTIFIED_FLOOR_MS = 18.8
+ISABELLE_CERTIFIED_ADJUSTED_LABEL = "Isabelle certified (adjusted)"
+
+
 # Marker style keyed by series label, so a curve keeps the same marker
 # whether or not the certified curves are present in a given figure.
 STYLE_BY_LABEL = {
     "Lean native": {"marker": "o", "linewidth": 2.0},
     "Isabelle native": {"marker": "s", "linewidth": 2.0},
     "Lean certified": {"marker": "D", "linewidth": 2.0, "markersize": 6.5},
-    "Isabelle certified": {"marker": "^", "linewidth": 2.0, "markersize": 7.0},
+    ISABELLE_CERTIFIED_ADJUSTED_LABEL: {
+        "marker": "^",
+        "linewidth": 2.0,
+        "markersize": 7.0,
+    },
     "fpLLL via fplll-ffi": {"marker": "v", "linewidth": 2.0, "markersize": 7.0},
 }
 
@@ -162,6 +177,25 @@ def collect_series(results: list[dict], pattern: re.Pattern[str], label: str) ->
         raise ValueError(f"no results found for {label}")
     xs = sorted(values)
     return Series(label=label, xs=xs, ys=[values[x] for x in xs])
+
+
+def subtract_request_floor(series: Series) -> Series:
+    """Subtract the fixed per-request floor from the Isabelle-certified series
+    and relabel it so the legend marks the adjustment. Raise if any rung sits
+    at or below the floor, which would push the log-scale curve nonpositive."""
+    too_low = [
+        x for x, y in zip(series.xs, series.ys) if y <= ISABELLE_CERTIFIED_FLOOR_MS
+    ]
+    if too_low:
+        raise ValueError(
+            f"Isabelle-certified rungs {too_low} are at or below the "
+            f"{ISABELLE_CERTIFIED_FLOOR_MS} ms request floor; cannot adjust"
+        )
+    return Series(
+        label=ISABELLE_CERTIFIED_ADJUSTED_LABEL,
+        xs=series.xs,
+        ys=[y - ISABELLE_CERTIFIED_FLOOR_MS for y in series.ys],
+    )
 
 
 def assert_bottom_consistent(bottom_results: list[dict], isabelle: Series) -> None:
@@ -204,17 +238,17 @@ def plot(series: list[Series], output: Path, title: str, xlabel: str) -> None:
     ax.grid(True, which="major", axis="x", alpha=0.15)
     ax.legend(frameon=False)
     fig.tight_layout()
-    # The Isabelle-certified pipeline forks an `fplll` subprocess per request
-    # (~19 ms, from reports/hex-lll-performance.md §Per-call comparator
-    # overhead). This fixed cost dominates its small-n rungs, so footnote it
-    # whenever that series is plotted.
-    if any(item.label == "Isabelle certified" for item in series):
+    # The plotted Isabelle-certified curve has its fixed per-request floor
+    # subtracted (see ISABELLE_CERTIFIED_FLOOR_MS). Footnote the adjustment,
+    # stating how much, whenever that series is plotted.
+    if any(item.label == ISABELLE_CERTIFIED_ADJUSTED_LABEL for item in series):
         fig.subplots_adjust(bottom=0.16)
         fig.text(
             0.5,
             0.01,
-            "Isabelle certified forks an fplll subprocess per request "
-            "(~19 ms); this fixed cost dominates its small-n rungs.",
+            "Isabelle certified is adjusted down by its "
+            f"~{ISABELLE_CERTIFIED_FLOOR_MS:g} ms per-request floor, a fixed "
+            "trivial-request cost dominated by the fplll subprocess fork.",
             ha="center",
             va="bottom",
             fontsize=7,
@@ -284,10 +318,12 @@ def main() -> None:
         isabelle_certified_results = load_results(
             args.isabelle_certified or config.isabelle_certified_path
         )
-        isabelle_certified = collect_series(
-            isabelle_certified_results,
-            config.isabelle_certified_pattern,
-            "Isabelle certified",
+        isabelle_certified = subtract_request_floor(
+            collect_series(
+                isabelle_certified_results,
+                config.isabelle_certified_pattern,
+                "Isabelle certified",
+            )
         )
         series += [isabelle_certified, certified]
     series.append(fpll)


### PR DESCRIPTION
This PR adjusts the Isabelle-certified comparator curves on both HexLLL family figures for the fixed per-request cost that otherwise distorts their small-`n` rungs. The `verified Isabelle certified-LLL` pipeline forks an `fplll` subprocess per request; at small `n` this fixed floor dominates the measurement (at harsh-cubic n=15 the Isabelle-certified median is roughly 93 % subprocess fork), so a reader sees what looks like an asymptotic disadvantage where most of the gap is a fixed process cost. The plotted Isabelle-certified curve now subtracts ~18.8 ms, its committed per-request `svp_certified` floor (the fixed trivial-request cost dominated by the `fplll` subprocess fork, from reports/hex-lll-performance.md §Per-call comparator overhead), is relabelled `Isabelle certified (adjusted)`, and carries a figure footnote stating the adjustment amount. Only that series is adjusted: Lean-certified and fpLLL call `fplll` in process, and Isabelle-native is ~9 µs.

The raw medians, eligibility, ratio tables, exports, and scaling fits are untouched: only the plotted curve is adjusted, and the report prose discloses that the floor is an audit-host figure and that the tables and scaling fits keep the raw medians. `subtract_request_floor` raises if any rung sits at or below the floor, guarding against nonpositive log-scale points.

This also corrects stale prose discovered next to the figures: https://github.com/kim-em/hex/pull/6756 re-enabled the certified curves on the harsh-cubic plot (now five series, with a Lean-certified crossover) but left a description claiming only three series were plotted.

Verification: `python3 scripts/plots/hex-lll-comparator.py --family random-bounded` and `--family harsh-cubic` regenerate cleanly and deterministically; `git diff` touches only the two SVGs, the plot script, and reports/hex-lll-performance.md; `python3 scripts/plots/hex-lll-scaling.py --all` reproduces the scaling tables with no data change; `git diff --check` clean.

Closes https://github.com/kim-em/hex/issues/6759.

🤖 Prepared with Claude Code