### PR TITLE
feat: approximation-steered native reducer with certified output

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -1605,6 +1605,389 @@ theorem one_quarter_lt_of_eta_eleven_twentieths {δ : Rat}
     (hδ : (121 / 400 : Rat) < δ) : (1 / 4 : Rat) < δ := by
   grind
 
+/-! ## Approximation-steered native reducer
+
+The steered reducer drives the *exact* integer row operations of the native
+algorithm (`GramSchmidt.Int.sizeReduce`, `GramSchmidt.Int.adjacentSwap`) from an
+*untrusted* floating-point Gram-Schmidt approximation. The basis `b` is the only
+proof-relevant field of `SteeredState`; the `Float` fields `mu`/`bb` choose which
+row operation to apply and never enter any proof, so lattice equality of the
+output holds by construction (every step is a proven lattice-preserving basis
+operation) regardless of the approximation's numerical behaviour. The output is
+certified post hoc at `(δ, 11/20)`; on certification failure the public `lll`
+falls back to the exact `d`/`ν` reducer `lllNative`. The steered path therefore
+materializes no exact Gram-Schmidt state — exact `d`/`ν` data appears only in the
+fallback. -/
+
+/-- Untrusted floating-point Gram-Schmidt state steering the native reducer.
+`b` is the exact integer basis (the only proof-relevant field). `mu[i][j]` (for
+`j < i`) approximates the Gram-Schmidt coefficient `μ[i][j]` and `bb[i]`
+approximates `‖b*_i‖²`; both are untrusted and never enter a proof. -/
+structure SteeredState (n m : Nat) where
+  b  : Matrix Int n m
+  mu : Array (Array Float)
+  bb : Array Float
+
+namespace SteeredState
+
+/-- Round to the nearest integer (ties away from zero). Steers only; soundness
+never depends on the rounded value. -/
+@[inline] def fRound (x : Float) : Int := (Float.floor (x + 0.5)).toInt64.toInt
+
+/-- Initial state: exact integer basis `b`, with `mu`/`bb` from one float
+Cholesky pass over the exact Gram entries `⟨b_i, b_j⟩`. -/
+def init (b : Matrix Int n m) : SteeredState n m :=
+  let rows := b.toArray
+  let (mu, bb) := Id.run do
+    let mut mu : Array (Array Float) := Array.replicate n (Array.replicate 0 0.0)
+    let mut bb : Array Float := Array.replicate n 0.0
+    for i in [0:n] do
+      let mut c : Array Float := Array.replicate (i + 1) 0.0
+      let mut mui : Array Float := Array.replicate i 0.0
+      for j in [0:i+1] do
+        let mut s := Float.ofInt (Vector.dotProduct rows[i]! rows[j]!)
+        let murow := if j == i then mui else mu[j]!
+        for l in [0:j] do
+          s := s - murow[l]! * c[l]!
+        c := c.set! j s
+        if j < i then
+          let bj := bb[j]!
+          mui := mui.set! j (if bj > 0.0 then s / bj else 0.0)
+      mu := mu.set! i mui
+      bb := bb.set! i c[i]!
+    return (mu, bb)
+  { b := b, mu := mu, bb := bb }
+
+@[simp] theorem init_b (b : Matrix Int n m) : (init b).b = b := rfl
+
+/-- Recompute `mu` row `k` and `bb[k]` from the exact Gram entries `⟨b_k, b_j⟩`
+and the stored approximation of rows `< k`. The basis is unchanged. This is the
+drift-control step: each working row's coefficients are recomputed from the exact
+integer basis, so float error never accumulates across the run. -/
+def refreshRow (s : SteeredState n m) (k : Nat) : SteeredState n m :=
+  let rows := s.b.toArray
+  let (muk, bk) := Id.run do
+    let mut c : Array Float := Array.replicate (k + 1) 0.0
+    let mut muk : Array Float := Array.replicate k 0.0
+    for j in [0:k+1] do
+      let mut sm := Float.ofInt (Vector.dotProduct rows[k]! rows[j]!)
+      let murow := if j == k then muk else s.mu[j]!
+      for l in [0:j] do
+        sm := sm - murow[l]! * c[l]!
+      c := c.set! j sm
+      if j < k then
+        let bj := s.bb[j]!
+        muk := muk.set! j (if bj > 0.0 then sm / bj else 0.0)
+    return (muk, c[k]!)
+  { b := s.b, mu := s.mu.set! k muk, bb := s.bb.set! k bk }
+
+@[simp] theorem refreshRow_b (s : SteeredState n m) (k : Nat) :
+    (s.refreshRow k).b = s.b := rfl
+
+/-- Single-column size reduction `b_k ← b_k − r·b_j` with `r` the rounded float
+coefficient `μ[k][j]`. The basis update is the exact integer
+`GramSchmidt.Int.sizeReduce`; `mu` row `k` is updated incrementally. -/
+def reduceColumn (s : SteeredState n m) (j k : Fin n) (hjk : j.val < k.val) :
+    SteeredState n m :=
+  let r := fRound ((s.mu[k.val]!)[j.val]!)
+  if r = 0 then s
+  else
+    let rf := Float.ofInt r
+    let muj := s.mu[j.val]!
+    { b := GramSchmidt.Int.sizeReduce s.b j k r
+      mu := s.mu.modify k.val fun muk => Id.run do
+        let mut row := muk
+        for i in [0:j.val] do
+          row := row.set! i (row[i]! - rf * muj[i]!)
+        row := row.set! j.val (row[j.val]! - rf)
+        return row
+      bb := s.bb }
+
+/-- Size-reduce row `k` against rows `k-1, …, 0`. -/
+def sizeReduce (s : SteeredState n m) (k : Nat) : SteeredState n m :=
+  if hk : k < n then
+    let kFin : Fin n := ⟨k, hk⟩
+    ((List.finRange k).reverse).foldl
+      (fun state j =>
+        reduceColumn state ⟨j.val, Nat.lt_trans j.isLt hk⟩ kFin j.isLt)
+      s
+  else s
+
+/-- Swap adjacent rows `k-1` and `k`. The basis update is the exact integer
+`GramSchmidt.Int.adjacentSwap`; `mu`/`bb` are updated by the float swap
+formulas (Cohen 2.6.3, rational form). -/
+def swap (s : SteeredState n m) (k : Nat) : SteeredState n m :=
+  if hk : k < n then
+    if hk0 : 0 < k then
+      let kFin : Fin n := ⟨k, hk⟩
+      let km1 := k - 1
+      let (mu', bb') := Id.run do
+        let mut mu := s.mu
+        let mut bb := s.bb
+        let μ := (mu[k]!)[km1]!
+        let Bkm1 := bb[km1]!
+        let Bk := bb[k]!
+        let newBkm1 := Bk + μ * μ * Bkm1
+        let newMuKkm1 := if newBkm1 > 0.0 then μ * Bkm1 / newBkm1 else 0.0
+        let newBk := if newBkm1 > 0.0 then Bkm1 * Bk / newBkm1 else 0.0
+        for i in [k+1:n] do
+          mu := mu.modify i fun row =>
+            let t := row[k]!
+            let nK := row[km1]! - μ * t
+            let nKm1 := t + newMuKkm1 * nK
+            (row.set! k nK).set! km1 nKm1
+        let mut pKm1 : Array Float := Array.replicate km1 0.0
+        let mut pK : Array Float := Array.replicate km1 0.0
+        for j in [0:km1] do
+          pKm1 := pKm1.set! j (mu[km1]!)[j]!
+          pK := pK.set! j (mu[k]!)[j]!
+        mu := mu.modify km1 fun row => Id.run do
+          let mut r := row
+          for j in [0:km1] do r := r.set! j pK[j]!
+          return r
+        mu := mu.modify k fun row => Id.run do
+          let mut r := row
+          for j in [0:km1] do r := r.set! j pKm1[j]!
+          r := r.set! km1 newMuKkm1
+          return r
+        bb := bb.set! km1 newBkm1
+        bb := bb.set! k newBk
+        return (mu, bb)
+      { b := GramSchmidt.Int.adjacentSwap s.b kFin hk0, mu := mu', bb := bb' }
+    else s
+  else s
+
+/-- The per-iteration preparation step: optionally refresh the working row from
+the exact Gram, then size-reduce it. Factored out so the loop proof can treat the
+prepared state opaquely (only its lattice equality with `s` matters). -/
+def prep (period : Nat) (s : SteeredState n m) (k cnt : Nat) : SteeredState n m :=
+  (if period == 0 || cnt % period == 0 then s.refreshRow k else s).sizeReduce k
+
+/-- Fuel-bounded outer steered loop, mirroring `lllLoop` but driven by the float
+approximation. `period` controls how often the working row is refreshed from the
+exact Gram (`0` = every visit). `δsteer` is the (untrusted) float Lovász
+threshold; steering at a stricter `δ` than the certification target gives the
+exact certifier margin against float slop. -/
+def loop (δsteer : Float) (period : Nat) (s : SteeredState n m) (k cnt : Nat) :
+    Nat → SteeredState n m
+  | 0 => s
+  | fuel + 1 =>
+    if hk : k < n then
+      let s := prep period s k cnt
+      if 0 < k then
+        let km1 := k - 1
+        let mukk := (s.mu[k]!)[km1]!
+        if δsteer * s.bb[km1]! ≤ s.bb[k]! + mukk * mukk * s.bb[km1]! then
+          loop δsteer period s (k + 1) (cnt + 1) fuel
+        else
+          loop δsteer period (s.swap k) (max km1 1) (cnt + 1) fuel
+      else
+        loop δsteer period s (k + 1) (cnt + 1) fuel
+    else s
+
+/-- Drift-free final sweep: refresh each row from the exact Gram and size-reduce
+it, so the returned basis is genuinely size-reduced regardless of in-loop drift. -/
+def finalSweep (s : SteeredState n m) : SteeredState n m :=
+  (List.finRange n).foldl (fun st k => (st.refreshRow k.val).sizeReduce k.val) s
+
+/-- Hadamard-based integer fuel bound: `3·Σ bitlen(‖b_i‖²)` advances per level.
+Computed from the exact basis only (no Gram-determinant state). -/
+def fuel (b : Matrix Int n m) : Nat :=
+  let rows := b.toArray
+  Id.run do
+    let mut s := 0
+    for i in [0:n] do
+      s := s + (Vector.dotProduct rows[i]! rows[i]!).natAbs.log2 + 1
+    return (3 * s + 1) * (n + 1)
+
+end SteeredState
+
+/-- Run the approximation-steered reducer: init float GSO, run the fuel-bounded
+steered loop, then the drift-free final sweep, returning the exact reduced basis.
+Steers with `δsteer = (δ + 1)/2` (stricter than the certification `δ`). -/
+def steeredReduce (b : Matrix Int n m) (δ : Rat) : Matrix Int n m :=
+  let s0 := SteeredState.init b
+  let δf : Float := Float.ofInt δ.num / Float.ofNat δ.den
+  let δsteer : Float := (δf + 1.0) / 2.0
+  let s := SteeredState.loop δsteer 16 s0 1 0 (SteeredState.fuel b)
+  (SteeredState.finalSweep s).b
+
+/-! ### Lattice preservation of the steered reducer
+
+Every `SteeredState` operation either leaves `.b` unchanged or applies one of the
+proven lattice-preserving basis operations, so the steered output generates the
+same lattice as the input — by construction, with no dependence on the `Float`
+approximation. These proofs mirror the corresponding `LLLState` lemmas. -/
+
+namespace SteeredState
+
+theorem reduceColumn_memLattice_iff
+    (s : SteeredState n m) (j k : Fin n) (hjk : j.val < k.val) (v : Vector Int m) :
+    Matrix.memLattice (s.reduceColumn j k hjk).b v ↔ Matrix.memLattice s.b v := by
+  unfold reduceColumn
+  by_cases hr : fRound ((s.mu[k.val]!)[j.val]!) = 0
+  · rw [if_pos hr]
+  · rw [if_neg hr]
+    have hne : j ≠ k := fun h => Nat.lt_irrefl j.val (h ▸ hjk)
+    exact LLLState.rowAdd_memLattice_iff s.b hne _ v
+
+private theorem sizeReduce_foldl_memLattice_iff (s : SteeredState n m) (k : Nat) (hk : k < n)
+    (xs : List (Fin k)) (v : Vector Int m) :
+    Matrix.memLattice
+        (xs.foldl
+          (fun state j =>
+            reduceColumn state ⟨j.val, Nat.lt_trans j.isLt hk⟩ ⟨k, hk⟩ j.isLt)
+          s).b v ↔ Matrix.memLattice s.b v := by
+  induction xs generalizing s with
+  | nil => simp
+  | cons j js ih =>
+    simp only [List.foldl_cons]
+    rw [ih]
+    exact reduceColumn_memLattice_iff s _ _ j.isLt v
+
+theorem sizeReduce_memLattice_iff (s : SteeredState n m) (k : Nat) (v : Vector Int m) :
+    Matrix.memLattice (s.sizeReduce k).b v ↔ Matrix.memLattice s.b v := by
+  unfold sizeReduce
+  by_cases hk : k < n
+  · rw [dif_pos hk]
+    exact sizeReduce_foldl_memLattice_iff s k hk (List.finRange k).reverse v
+  · rw [dif_neg hk]
+
+theorem swap_memLattice_iff (s : SteeredState n m) (k : Nat) (v : Vector Int m) :
+    Matrix.memLattice (s.swap k).b v ↔ Matrix.memLattice s.b v := by
+  unfold swap
+  by_cases hk : k < n
+  · rw [dif_pos hk]
+    by_cases hk0 : 0 < k
+    · rw [dif_pos hk0]
+      simpa [GramSchmidt.Int.adjacentSwap] using
+        LLLState.rowSwap_memLattice_iff s.b (GramSchmidt.prevRow ⟨k, hk⟩ hk0) ⟨k, hk⟩ v
+    · rw [dif_neg hk0]
+  · rw [dif_neg hk]
+
+theorem prep_memLattice_iff (period : Nat) (s : SteeredState n m) (k cnt : Nat)
+    (v : Vector Int m) :
+    Matrix.memLattice (prep period s k cnt).b v ↔ Matrix.memLattice s.b v := by
+  unfold prep
+  rw [sizeReduce_memLattice_iff]
+  split <;> simp [refreshRow_b]
+
+-- Keep the heavy `Float` computations opaque to the loop proof; the `.b`
+-- projection is fully characterized by the `_memLattice_iff` lemmas above, so the
+-- proof never needs to reduce the approximate Gram-Schmidt arithmetic.
+attribute [irreducible] refreshRow reduceColumn sizeReduce swap prep
+
+theorem loop_memLattice_iff (δsteer : Float) (period : Nat) (s : SteeredState n m)
+    (k cnt : Nat) (fuel : Nat) (v : Vector Int m) :
+    Matrix.memLattice (loop δsteer period s k cnt fuel).b v ↔
+      Matrix.memLattice s.b v := by
+  induction fuel generalizing s k cnt with
+  | zero => rfl
+  | succ f ih =>
+    by_cases hk : k < n
+    · simp only [loop, dif_pos hk]
+      -- Replace the prepared state by a fresh variable `p`; only its lattice
+      -- equality with `s` matters, keeping the float arithmetic out of the proof.
+      have hp_lat := prep_memLattice_iff period s k cnt v
+      generalize prep period s k cnt = p at hp_lat ⊢
+      by_cases hk0 : 0 < k
+      · simp only [if_pos hk0]
+        split
+        · exact (ih p (k + 1) (cnt + 1)).trans hp_lat
+        · exact (ih (p.swap k) (max (k - 1) 1) (cnt + 1)).trans
+            ((swap_memLattice_iff p k v).trans hp_lat)
+      · simp only [if_neg hk0]
+        exact (ih p (k + 1) (cnt + 1)).trans hp_lat
+    · simp only [loop, dif_neg hk]
+
+theorem finalSweep_memLattice_iff (s : SteeredState n m) (v : Vector Int m) :
+    Matrix.memLattice (finalSweep s).b v ↔ Matrix.memLattice s.b v := by
+  unfold finalSweep
+  suffices h : ∀ (xs : List (Fin n)) (t : SteeredState n m),
+      Matrix.memLattice
+        (xs.foldl (fun st k => (st.refreshRow k.val).sizeReduce k.val) t).b v ↔
+        Matrix.memLattice t.b v by
+    exact h (List.finRange n) s
+  intro xs
+  induction xs with
+  | nil => intro t; simp
+  | cons k ks ih =>
+    intro t
+    simp only [List.foldl_cons]
+    rw [ih]
+    rw [sizeReduce_memLattice_iff, refreshRow_b]
+
+end SteeredState
+
+theorem steeredReduce_memLattice_iff (b : Matrix Int n m) (δ : Rat) (v : Vector Int m) :
+    Matrix.memLattice (steeredReduce b δ) v ↔ Matrix.memLattice b v := by
+  unfold steeredReduce
+  rw [SteeredState.finalSweep_memLattice_iff, SteeredState.loop_memLattice_iff,
+    SteeredState.init_b]
+
+/-- Outcome of one steered reduction: the steered candidate certified at
+`(δ, 11/20)`, or the run fell back to the exact `lllNative`. -/
+inductive SteeredOutcome where
+  | certified
+  | fellBack
+deriving Repr, BEq
+
+/-- Fallback-rate diagnostic for the steered reducer. `fellBack = 0` across a
+bench ladder confirms the steered path certified every rung, so the measured
+medians are honest (no exact-reducer time mixed in). -/
+structure SteeredTally where
+  certified : Nat := 0
+  fellBack : Nat := 0
+deriving Repr, BEq, Inhabited
+
+initialize steeredTallyRef : IO.Ref SteeredTally ← IO.mkRef {}
+
+def resetSteeredTally : IO Unit := steeredTallyRef.set {}
+
+def steeredTally : IO SteeredTally := steeredTallyRef.get
+
+private def bumpSteered (t : SteeredTally) : SteeredOutcome → SteeredTally
+  | .certified => { t with certified := t.certified + 1 }
+  | .fellBack => { t with fellBack := t.fellBack + 1 }
+
+/-- Side-effecting tally bump callable from pure code; definitionally the
+continuation `k`. Mirrors `withRecordCheckerOutcome`. -/
+unsafe def withRecordSteeredOutcomeImpl {α : Type} (o : SteeredOutcome) (k : α) : α :=
+  unsafeBaseIO do
+    steeredTallyRef.modify (fun t => bumpSteered t o)
+    pure k
+
+@[implemented_by withRecordSteeredOutcomeImpl]
+def withRecordSteeredOutcome {α : Type} (_o : SteeredOutcome) (k : α) : α := k
+
+/-- Dimension below which the exact `lllNative` is run directly. Steering plus
+post-hoc certification carries a fixed overhead (the certifier recomputes the
+Gram-Schmidt of the candidate), so on the smallest inputs — where the exact
+reducer is already cheap — that overhead would exceed the steering savings. A
+deterministic input-size dispatch routes those to `lllNative`, which keeps the
+small-input cost identical to the exact reducer (no regression) while the larger
+inputs that dominate the asymptotics take the steered path. -/
+def steerDimThreshold : Nat := 40
+
+/-- Approximation-steered native reducer with certified output. For inputs of
+dimension `< steerDimThreshold` it runs the exact `lllNative` directly; otherwise
+it runs the steered loop (exact integer row operations driven by an untrusted
+float Gram-Schmidt), certifies the candidate at the public `(δ, 11/20)` bound via
+`lllReducedCheck`, and falls back to the exact `lllNative` on certification
+failure. The output is therefore always a `(δ, 11/20)`-reduced basis of the same
+lattice as `b`; the exact `d`/`ν` state is materialized only on the small-input
+and fallback paths. -/
+def lllSteered (b : Matrix Int n m) (δ : Rat)
+    (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) : Matrix Int n m :=
+  if n < steerDimThreshold then
+    lllNative b δ hδ hδ' hn
+  else
+    let candidate := steeredReduce b δ
+    if lllReducedCheck candidate δ (11 / 20) then
+      withRecordSteeredOutcome .certified candidate
+    else
+      withRecordSteeredOutcome .fellBack (lllNative b δ hδ hδ' hn)
+
 namespace LLLProvider
 
 @[extern "lean_hexlll_provider_available"]
@@ -1863,14 +2246,15 @@ def lll (b : Matrix Int n m) (δ : Rat)
     Matrix Int n m :=
   match LLLProvider.dispatch b δ with
   | some B' => B'
-  | none => lllNative b δ (one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn
+  | none => lllSteered b δ (one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn
 
-/-- Proof-free executable variant of `lll.firstShortVector`. Targets the
-native body directly with the classical precondition `1/4 < δ`. -/
+/-- Proof-free executable variant of `lll.firstShortVector`. Runs the
+approximation-steered reducer with certified output (`lllSteered`); the
+classical precondition `1/4 < δ` flows to the exact fallback. -/
 def lll.firstShortVectorUnchecked (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Vector Int m :=
-  (lllNative b δ hδ hδ' hn)[0]
+  (lllSteered b δ hδ hδ' hn)[0]
 
 /-- The first row of the reduced basis (shortest vector under the LLL
 guarantee). Canonical short-vector entry point for downstream callers
@@ -1881,12 +2265,12 @@ def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
     Vector Int m :=
   (lll b δ hδ hδ' hn hind)[0]
 
-/-- Proof-free executable variant of `lll.shortVectors`. Targets the
-native body directly with the classical precondition `1/4 < δ`. -/
+/-- Proof-free executable variant of `lll.shortVectors`. Runs the
+approximation-steered reducer with certified output (`lllSteered`). -/
 def lll.shortVectorsUnchecked (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Array (Vector Int m) :=
-  (lllNative b δ hδ hδ' hn).toArray
+  (lllSteered b δ hδ hδ' hn).toArray
 
 /-- The full reduced basis viewed as an ordered array of candidate short
 vectors. -/

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -2237,9 +2237,11 @@ end LLLProvider
 /-- Top-level LLL entry point. Dispatches first to the certified-external path:
 if `LLLProvider.providerAvailable ()` is true and the candidate passes
 `certCheck B B' U V δ (11/20)`, the certified `B'` is returned; otherwise the
-native body `lllNative` runs. The two paths satisfy the identical
-post-condition (`isLLLReduced (lll …) δ (11/20)`, same lattice, the public
-short-vector bound), so dispatch is invisible to callers and to proofs. -/
+native body `lllSteered` runs (the approximation-steered reducer, which itself
+certifies its output at `(δ, 11/20)` and falls back to the exact `lllNative`).
+The paths satisfy the identical post-condition (`isLLLReduced (lll …) δ (11/20)`,
+same lattice, the public short-vector bound), so dispatch is invisible to callers
+and to proofs. -/
 def lll (b : Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (_hind : b.independent) :

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1257,6 +1257,7 @@ def runCertifiedCheckerIntervalTally : Unit → IO Int := fun _ => do
   return (Int.ofNat tally.interval * 65537 + Int.ofNat tally.exactPrimary) * 65537 +
     Int.ofNat tally.exactFallback
 
+
 def runFirstShortVectorBZRecombinationNormSq : Unit → IO Int := fun _ => do
   return runFirstShortVectorNormSq (← bzRecombinationInputRef.get)
 
@@ -1395,6 +1396,42 @@ def runFirstShortVectorHarshCubicNormSq55 : Unit → IO Int := fun _ => do
   return runFirstShortVectorNormSq
     (← getCachedInput harshCubicInput55Ref (fun _ => prepHarshCubicInput 55))
 
+
+/-- Fallback-rate diagnostic for the steered native reducer: run
+`firstShortVectorUnchecked` (i.e. `lllSteered`) once on every rung of both
+ladders, then read `Hex.steeredTally`. Fails if any steered candidate failed
+certification and fell back to the exact reducer (`fellBack ≠ 0`) — a fallback
+inside the ladder would make the steered medians dishonest. Only rungs with
+dimension `≥ Hex.steerDimThreshold` take the steered path and bump the tally;
+the smaller rungs run `lllNative` directly. The returned value encodes the tally
+as `certified · 65537 + fellBack`. -/
+def runSteeredFallbackTally : Unit → IO Int := fun _ => do
+  Hex.resetSteeredTally
+  let targets : List (Unit → IO Int) :=
+    [runFirstShortVectorRandomBoundedNormSq30,
+     runFirstShortVectorRandomBoundedNormSq45,
+     runFirstShortVectorRandomBoundedNormSq60,
+     runFirstShortVectorRandomBoundedNormSq75,
+     runFirstShortVectorRandomBoundedNormSq90,
+     runFirstShortVectorRandomBoundedNormSq120,
+     runFirstShortVectorRandomBoundedNormSq150,
+     runFirstShortVectorRandomBoundedNormSq180,
+     runFirstShortVectorHarshCubicNormSq15,
+     runFirstShortVectorHarshCubicNormSq20,
+     runFirstShortVectorHarshCubicNormSq25,
+     runFirstShortVectorHarshCubicNormSq30,
+     runFirstShortVectorHarshCubicNormSq35,
+     runFirstShortVectorHarshCubicNormSq40,
+     runFirstShortVectorHarshCubicNormSq45,
+     runFirstShortVectorHarshCubicNormSq50,
+     runFirstShortVectorHarshCubicNormSq55]
+  for t in targets do
+    discard <| t ()
+  let tally ← Hex.steeredTally
+  if tally.fellBack != 0 then
+    throw <| IO.userError
+      s!"steered reducer fell back to the exact reducer on a bench rung: {repr tally}"
+  return Int.ofNat tally.certified * 65537 + Int.ofNat tally.fellBack
 def runIsabelleHarshCubicNormSq55 : Unit → IO Int := fun _ => do
   runIsabelleShortVectorNormSq "harsh-cubic-55"
     (← getCachedInput harshCubicInput55Ref (fun _ => prepHarshCubicInput 55))
@@ -2052,6 +2089,16 @@ setup_fixed_benchmark runCertifiedCheckerIntervalTally where {
     repeats := 1
     maxSecondsPerCall := 120.0
     expectedHash := some (Hashable.hash (((7 * 65537 + 10) * 65537 : Int)))
+  }
+
+/- Fallback-rate diagnostic: the steered reducer certified on every steered rung
+of both ladders (`fellBack = 0`). The pinned hash records the `certified` count
+(11 = the rungs with dimension ≥ `Hex.steerDimThreshold`); a fallback would flip
+`fellBack` nonzero and throw before the hash is reached. -/
+setup_fixed_benchmark runSteeredFallbackTally where {
+    repeats := 1
+    maxSecondsPerCall := 120.0
+    expectedHash := some (Hashable.hash ((11 * 65537 : Int)))
   }
 
 /- Complexity derivation: random-bounded inputs have square dimension `n` and

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -2400,10 +2400,55 @@ theorem dispatch_some_property {b : Matrix Int n m} {δ : Rat}
   obtain ⟨U, V, hcheck⟩ := LLLProvider.dispatch_some_certCheck h
   exact HexLLLMathlib.certCheck_sound hcheck
 
+/-- The steered reducer preserves the generated lattice: the certified candidate
+preserves it by construction (`steeredReduce_memLattice_iff`), the fallback by
+`lllNative_memLattice_iff`. -/
+theorem lllSteered_memLattice_iff (b : Matrix Int n m) (δ : Rat)
+    (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (v : Vector Int m) :
+    Matrix.memLattice (Hex.lllSteered b δ hδ hδ' hn) v ↔ Matrix.memLattice b v := by
+  unfold Hex.lllSteered
+  simp only [Hex.withRecordSteeredOutcome]
+  split
+  · exact lllNative_memLattice_iff b δ hδ hδ' hn v
+  · split
+    · exact Hex.steeredReduce_memLattice_iff b δ v
+    · exact lllNative_memLattice_iff b δ hδ hδ' hn v
+
+/-- The steered reducer produces a `(δ, 11/20)`-reduced basis: on the small-input
+and fallback paths from `lllNative_isLLLReduced` (`η = 1/2`) lifted by
+`isLLLReduced.mono_η`, on the steered acceptance path from `lllReducedCheck_sound`. -/
+theorem lllSteered_isLLLReduced (b : Matrix Int n m) (δ : Rat)
+    (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    isLLLReduced (Hex.lllSteered b δ hδ hδ' hn) δ (11 / 20) := by
+  have hnative : isLLLReduced (Hex.lllNative b δ hδ hδ' hn) δ (11 / 20) :=
+    Hex.isLLLReduced.mono_η _ (by grind) (by grind)
+      (lllNative_isLLLReduced b δ hδ hδ' hn hind)
+  unfold Hex.lllSteered
+  simp only [Hex.withRecordSteeredOutcome]
+  split
+  · exact hnative
+  · split
+    · rename_i h
+      exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).1
+    · exact hnative
+
+/-- Independence is preserved by the steered reducer. -/
+theorem lllSteered_independent (b : Matrix Int n m) (δ : Rat)
+    (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (Hex.lllSteered b δ hδ hδ' hn).independent := by
+  unfold Hex.lllSteered
+  simp only [Hex.withRecordSteeredOutcome]
+  split
+  · exact lllNative_independent b δ hδ hδ' hn hind
+  · split
+    · rename_i h
+      exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).2
+    · exact lllNative_independent b δ hδ hδ' hn hind
+
 /-- The public LLL `lll` produces a `(δ, 11/20)`-LLL-reduced matrix. On the
-native fallback path this follows from `lllNative_isLLLReduced` (`η = 1/2`) and
-`isLLLReduced.mono_η`. On the certified-dispatch path it follows from
-`certCheck_sound` via `dispatch_some_property`. -/
+steered fallback path this follows from `lllSteered_isLLLReduced`. On the
+certified-dispatch path it follows from `certCheck_sound` via
+`dispatch_some_property`. -/
 theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) :
@@ -2411,9 +2456,8 @@ theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
-      have hred := lllNative_isLLLReduced b δ
+      exact lllSteered_isLLLReduced b δ
         (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn hind
-      exact Hex.isLLLReduced.mono_η _ (by grind) (by grind) hred
   | some B' =>
       exact (dispatch_some_property hd).2.2
 
@@ -2425,7 +2469,7 @@ theorem lll_memLattice_iff (b : Matrix Int n m) (δ : Rat)
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
-      exact lllNative_memLattice_iff b δ
+      exact lllSteered_memLattice_iff b δ
         (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn v
   | some B' =>
       exact ((dispatch_some_property hd).1 v).symm
@@ -2438,7 +2482,7 @@ theorem lll_independent (b : Matrix Int n m) (δ : Rat)
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
-      exact lllNative_independent b δ
+      exact lllSteered_independent b δ
         (Hex.one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn hind
   | some B' =>
       exact (dispatch_some_property hd).2.1

--- a/progress/20260611T055715Z_issue-6744-feasibility.md
+++ b/progress/20260611T055715Z_issue-6744-feasibility.md
@@ -1,0 +1,54 @@
+# #6744 steered reducer — feasibility validated (prototype)
+
+## Accomplished
+
+Built a standalone prototype (`HexLLL/SteeredProto.lean`, scratch, not
+shipped) of the approximation-steered reducer: exact integer row ops on the
+basis, untrusted Float Gram-Schmidt steering (Schnorr-Euchner / Cohen 2.6.3
+float swap formulas), per-row drift-free refresh of μ/B from the exact Gram
+entries `⟨b_i,b_j⟩` (recomputed from `b`, no stored Gram), a drift-free final
+size-reduction sweep, and exact (δ,11/20) certification.
+
+Baseline captured on carica (merge-base 6f347b5): harsh n=55 = 242ms,
+random n=180 = 4.76s region. Local machine ≈ carica (harsh n=55 native
+240ms, random n=180 native 4.62s).
+
+## Key results (local, ≈carica), steer δ=9/10, certify δ=3/4, refresh period 16
+
+- harsh: n=25 1.7ms, n=40 ~4ms, n=55 13.4ms vs native 240ms → ~18×,
+  fitted exponent ~2.6 (≪ 4.5). 0 swaps (diagonal-dominant); win is skipping
+  the Θ(n⁴)-bit exact determinant state. First-row NormSq UNCHANGED.
+- random: n=30 7.1ms (native 15.5 → 2.2×, NO low-rung regression),
+  n=60 48ms (3.0×), n=90 149ms (3.4×), n=180 1217ms (4624 → 3.8×).
+- ALL rungs certify (δ,11/20) exactly → fallback 0.
+
+## Critical engineering findings (must carry into production)
+
+1. In-place mutation is essential. Nested `Array (Array Float)` μ with naive
+   `set!` COWs whole rows under swap (O(n²)/swap) → random n=180 ~2.3s
+   (barely 2×). Using `Array.modify` (placeholder-swap, the same pattern as
+   the existing `LLLState.swapStep`) gives genuine in-place updates →
+   1217ms (3.8×). Production must use `Vector.modify`/`Array.modify`.
+2. Steer at a δ STRICTER than the certify δ (e.g. (δ+1)/2). Steering at the
+   certify δ=3/4 left random n=30 with a Lovász ratio that float accepted but
+   exact 3/4 rejected → certification fail. δ_steer=9/10 fixes it (margin
+   absorbs float slop). Cost: more swaps, still comfortably ≥2×.
+3. Drift-free refresh of the working row from exact Gram each visit (or every
+   K visits) + a final drift-free size-reduction sweep guarantee the output
+   is genuinely (δ,11/20)-reduced regardless of incremental float drift.
+4. Float never overflows through the ladder (norms < 2^1024).
+
+## Next step
+
+Port to HexLLL/Basic.lean as proof-carrying `lllSteered`: `SteeredState`
+(`b : Matrix Int n m` + untrusted Float μ/B), ops whose `.b` is exactly
+`GramSchmidt.Int.sizeReduce`/`adjacentSwap` so `steeredReduce_memLattice_iff`
+mirrors the existing `sizeReduce/swapStep_memLattice_iff`. Wire `lllSteered`
+into `lll`'s `none` branch (certify at (δ,11/20) via `lllReducedCheck`,
+fallback `lllNative`); rewire the 5 `lll_*` contract theorems' none branch.
+Add fallback diagnostic, bench target, update expected NormSq hashes.
+Delete the prototype. Then carica paired measurement + reports + SPEC PR.
+
+## Blockers
+
+None. Architecture validated. Margins comfortable.

--- a/progress/20260611T065053Z_issue-6744-review.md
+++ b/progress/20260611T065053Z_issue-6744-review.md
@@ -1,0 +1,30 @@
+# #6744 steered reducer — review
+
+## Accomplished
+
+Reviewed the checked-in approximation-steered reducer in `HexLLL/Basic.lean`
+and the corresponding correctness theorems in `HexLLLMathlib/Independent.lean`
+against the requested soundness questions. Checked the lattice-preservation
+chain for exact row operations, the post-hoc reducedness certification path, the
+`@[irreducible]` placement, the `@[implemented_by]` diagnostic wrapper, and the
+unchecked short-vector entry points.
+
+Ran `lake build`; it completed successfully. The only reported warnings were
+pre-existing unnecessary-`simpa` lints in `HexGFqRing/Operations.lean`.
+
+## Current frontier
+
+No implementation changes were made. The main actionable item found is a stale
+doc comment on `Hex.lll` that still says the fallback runs `lllNative`, although
+the code now runs `lllSteered`.
+
+## Next step
+
+If continuing this review, update the stale comments around the public `lll`
+fallback and optionally add a small regression theorem/example documenting that
+`lllSteered`'s accepted branch depends only on `lllReducedCheck_sound` for
+reducedness and on `steeredReduce_memLattice_iff` for lattice preservation.
+
+## Blockers
+
+None.

--- a/progress/20260611T065439Z_issue-6744-landed.md
+++ b/progress/20260611T065439Z_issue-6744-landed.md
@@ -1,0 +1,52 @@
+# #6744 steered reducer — implemented, measured, PRs open
+
+## Accomplished
+
+Implemented the approximation-steered native reducer end to end and passed
+every go/no-go threshold on carica.
+
+- `HexLLL/Basic.lean`: `SteeredState` (exact `b : Matrix Int n m` + untrusted
+  `Float` `mu`/`bb`), `init`/`refreshRow`/`reduceColumn`/`sizeReduce`/`swap`/
+  `prep`/`loop`/`finalSweep`/`fuel`/`steeredReduce`, with `.b` updates equal to
+  the proven `GramSchmidt.Int.sizeReduce`/`adjacentSwap`. Lattice preservation
+  proved Mathlib-free (`steeredReduce_memLattice_iff` via per-op
+  `_memLattice_iff` lemmas mirroring the `LLLState` ones); float ops marked
+  `@[irreducible]` after their lemmas so the fuel-loop induction stays tractable.
+  `lllSteered` = input-size dispatch (`steerDimThreshold = 40`) → exact
+  `lllNative` for small inputs, else `steeredReduce` + `lllReducedCheck` at
+  `(δ, 11/20)` with `lllNative` fallback. `SteeredOutcome`/`SteeredTally`/
+  `withRecordSteeredOutcome` fallback diagnostic. `lll` none-branch and
+  `firstShortVectorUnchecked`/`shortVectorsUnchecked` (BZ consumer) repointed to
+  `lllSteered`.
+- `HexLLLMathlib/Independent.lean`: `lllSteered_{memLattice_iff,isLLLReduced,
+  independent}` (compose `lllReducedCheck_sound` + `steeredReduce_memLattice_iff`
+  + `lllNative_*` + `mono_η`); the five `lll_*` contract theorems rewired through
+  them, preserved verbatim.
+- `HexLLL/Bench.lean`: `runSteeredFallbackTally` (fails on any in-ladder
+  fallback), pinned certified=11/fellBack=0.
+
+Go/no-go (carica M2 Ultra; before `6f347b5d`, after `8c661b0a`): harsh n=55
+5.99×; harsh exponent over 40–55 5.20→2.64; random n=180 2.36×; no rung
+regresses (n<40 routes to the unchanged exact reducer); fallback 0 on every
+rung; all conformance first-vector-norm hashes unchanged. Second opinion
+(Codex) found no soundness holes; fixed the one item it flagged (stale `lll`
+fallback doc comment).
+
+## Current frontier
+
+Two PRs open against main, both MERGEABLE (no conflicts):
+- SPEC: https://github.com/kim-em/hex/pull/6762 (merge first)
+- impl: https://github.com/kim-em/hex/pull/6763 (head 2e9267b6)
+CI (build / build-macos / conformance) running.
+
+## Next step
+
+Watch CI; the conformance job runs `hexlll_bench verify` with the fplll-ffi
+provider (the steered tally + certified/dispatched paths). Land SPEC #6762
+before impl #6763. Post-merge: refresh the committed carica native ladders,
+comparator sweeps, reports/hex-lll-performance.md and -scaling.md, and revisit
+the harsh comparator figure's certified-curve omission (per the directive).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds `lllSteered`, an approximation-steered native LLL reducer with certified output, and makes it the default native body of `lll`. A fuel-bounded Schnorr-Euchner loop drives the exact integer row operations (`GramSchmidt.Int.sizeReduce`, `adjacentSwap`) from an untrusted floating-point Gram-Schmidt approximation, recomputing the working row's coefficients from the exact integer basis to bound drift and finishing with a drift-free size-reduction sweep. The basis `b` is the only proof-relevant field of `SteeredState`; the `Float` `mu`/`bb` only choose which row operation to apply and never enter a proof, so lattice equality of the output holds by construction (`steeredReduce_memLattice_iff`) regardless of the approximation. The output is certified post hoc at the public `(δ, 11/20)` bound via `lllReducedCheck`, falling back to the exact `lllNative` on certification failure, so the steered path materializes no exact `d`/`ν` Gram-Schmidt state. A deterministic input-size dispatch runs `lllNative` directly below `steerDimThreshold`, where the exact reducer is already cheap, keeping the smallest inputs free of the certification overhead.

`lllNative` and its `η = 1/2` surface are unchanged and remain the exact fallback; the public `lll` contract (`lll_isLLLReduced`, `lll_memLattice_iff`, `lll_independent`, `lll_short_vector`) is preserved verbatim. A `withRecordSteeredOutcome` fallback-rate diagnostic and the `runSteeredFallbackTally` bench observable fail if any steered candidate falls back inside the ladder. No `sorry`, `axiom`, or `native_decide`.

Paired measurement on `carica` (M2 Ultra, quiet host); before = merge-base `6f347b5d`, after = `8c661b0a` (branch head `2e9267b6` adds only a doc-comment fix). Per-rung medians (ms):

harsh-cubic:

| n | native (before) | steered (after) | x |
|---|---|---|---|
| 15 | 0.54 | 0.53 | 1.00 (native, n<40) |
| 30 | 10.14 | 9.66 | 1.05 (native, n<40) |
| 35 | 30.14 | 20.81 | 1.45 (native, n<40) |
| 40 | 46.65 | 17.54 | 2.66 |
| 45 | 79.21 | 23.08 | 3.43 |
| 50 | 141.72 | 31.14 | 4.55 |
| 55 | 242.39 | 40.44 | **5.99** |

random-bounded:

| n | native (before) | steered (after) | x |
|---|---|---|---|
| 30 | 15.61 | 15.05 | 1.04 (native, n<40) |
| 45 | 56.55 | 17.28 | 3.27 |
| 90 | 500.28 | 168.72 | 2.97 |
| 120 | 1292.98 | 453.30 | 2.85 |
| 180 | 4544.07 | 1927.30 | **2.36** |

The fitted top-window exponent (harsh-cubic, rungs 40-55) drops from `p = 5.20` to `p = 2.64`: the steered path leaves the exact-GSO complexity class, because the Theta(n^4)-bit Gram-determinant state is never materialized. The first-vector squared norms are unchanged across every rung (all conformance hashes match), so the steered basis is a different but equally short `(delta, 11/20)`-reduced basis of the same lattice. The steered-path fallback count is 0 on every bench rung of both families (`runSteeredFallbackTally`, certified 11/11). No rung of either family regresses (rungs below the dispatch threshold run the unchanged exact reducer).

The loss avoided by the input-size dispatch is the per-call certification overhead, which on the smallest rungs (where the exact reducer is already cheap) would exceed the steering savings; this is the low-rung regression diagnosed in https://github.com/kim-em/hex/issues/6742 , and the dispatch is the deterministic input-size split that issue's resolution introduced.

🤖 Prepared with Claude Code

Spec-driven companion: the SPEC change this implements is https://github.com/kim-em/hex/pull/6762 (doc: codify the approximation-steered default reducer), which should merge immediately before this PR. Closes https://github.com/kim-em/hex/issues/6744.
