### PR TITLE
feat: request stronger reduction parameters than certCheck certifies

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -869,10 +869,12 @@ def lovaszOK (S : Int) (δ : Rat) (mus : Array (Array Ival))
 end IntervalGS
 
 /-- Working precision (bits) of the interval reducedness checker. The
-inequalities being certified carry slack (`η = 11/20` against fplll's
-actual ≈ 1/2; Lovász at the requested `δ` against fplll's stronger
-reduction), so a fixed precision decides them on reduced candidates; any
-indecision falls back to the exact checker rather than failing. -/
+inequalities being certified carry slack by design: the dispatch requests a
+`(requestedDelta δ, requestedEta)`-reduced basis but certifies it against the
+weaker `(δ, 11/20)`, so size reduction clears `11/20` by `11/20 − requestedEta`
+and Lovász clears `δ` by `(requestedDelta δ − δ)·d[i+1]²`. A fixed precision
+decides them on a correctly-reduced candidate; any indecision falls back to
+the exact checker rather than failing. -/
 def intervalPrec : Nat := 128
 
 /-- Fixed-precision interval reducedness checker. Computes enclosures of
@@ -1748,6 +1750,62 @@ exact `δ`. -/
 private def ratToFloat (r : Rat) : Float :=
   Float.ofInt r.num / Float.ofNat r.den
 
+/-- Size-reduction bound *requested* from the external reducer, strictly
+stronger than the `η = 11/20` the checker certifies.
+
+The dispatch asks the reducer for a `(requestedDelta δ, requestedEta)`-reduced
+basis but certifies it against the public `(δ, 11/20)`. The two differ on
+purpose. `certCheck`'s reducedness clause is decided by a fixed-precision
+enclosure pass that resolves open inequalities only by *margin*; a candidate
+whose `|μ|` sits arbitrarily close to `11/20` would leave the enclosure
+straddling its threshold and force the exact fallback. Requesting
+`requestedEta < 11/20` instead guarantees a correctly-functioning reducer
+lands every size-reduction inequality a macroscopic `11/20 − requestedEta`
+clear of the certified bound, so the enclosure decides it.
+
+`requestedEta` must stay `> 1/2` (the reducer's hard floor) and `< 11/20`.
+Its exact value is untrusted: certification is against the exact `(δ, 11/20)`,
+so the requested bound is outside the trusted story entirely (the
+"reliability is empirical, soundness is not" clause). Varying it within
+`(1/2, 11/20)` only trades reducer work against enclosure margin; it cannot
+make a non-reduced basis certify. The value `107/200` sits a gap of `3/200`
+below `11/20` and `7/200` above `1/2`: a narrow gap from the certified bound
+keeps the small amount of extra work the stronger request costs the reducer
+inside measurement noise, while still clearing the bound by a margin the
+enclosure resolves. It is a `Rat`, forwarded to the reducer through
+`ratToFloat` like `requestedDelta`, so the design constant and the certified
+bound are comparable rationals. -/
+def requestedEta : Rat := 107 / 200
+
+/-- Lovász parameter *requested* from the external reducer: a fixed `1/100`
+margin above the caller's `δ`, but never past the midpoint `(δ + 1)/2`
+between `δ` and `1`.
+
+Mirrors `requestedEta`: the dispatch certifies the candidate against the
+caller's exact `δ` but asks the reducer for the stronger `requestedDelta δ`,
+so a correctly-functioning reducer clears every Lovász inequality by a
+positive margin `(requestedDelta δ − δ)·d[i+1]²` and the enclosure decides it
+rather than straddling.
+
+The midpoint cap is what keeps the request strictly between `δ` and `1` over
+the whole public surface `δ ≤ 1`. For `δ ≤ 49/50` the `1/100` term wins and
+the margin is the full `1/100`; for `49/50 < δ < 1` the midpoint wins and the
+margin is `(1 − δ)/2`, still positive, so `δ < requestedDelta δ < 1` holds for
+every `δ < 1`. At the boundary `δ = 1` the midpoint is `1`: no value is both
+`> δ` and `< 1`, so the request equals the certified `δ` and the prophylactic
+gap is unavoidably lost — a candidate the reducer cannot strengthen there
+falls back through certification to the native path, which stays sound.
+
+The Lovász condition governs how many swaps the reducer performs, so the
+requested `δ` drives the extra work the stronger request costs; the small
+`1/100` margin keeps that cost inside measurement noise while still giving the
+enclosure a decisive gap.
+
+Untrusted, exactly as `requestedEta`: the certificate is checked against the
+exact `δ`, never against this value, so the margin may vary without touching
+soundness. -/
+def requestedDelta (δ : Rat) : Rat := min (δ + 1 / 100) ((δ + 1) / 2)
+
 /-- Row-major marshalling of an integer matrix into the `Array String` payload
 the external provider expects. -/
 def matrixToEntries (B : Hex.Matrix Int n m) : Array String :=
@@ -1821,7 +1879,7 @@ def dispatch (B : Hex.Matrix Int n m) (δ : Rat) :
     withRecordOutcome .absent none
   else
     match providerReduce (USize.ofNat n) (USize.ofNat m) (matrixToEntries B)
-        (ratToFloat δ) 0.55 0 true with
+        (ratToFloat (requestedDelta δ)) (ratToFloat requestedEta) 0 true with
     | .error _ => withRecordOutcome .providerError none
     | .ok flat =>
         match certifyFlat B δ flat with

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -725,31 +725,36 @@ def runDispatchedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO I
   LLLProvider.resetDiagnostics
   have hrows : 1 ≤ input.rows := input.hn
   let f0 : Fin input.rows := ⟨0, by omega⟩
-  -- Drive the dispatch via the IO-based `tryReduce` so the diagnostic
-  -- side-effects fire eagerly (the pure `dispatch` uses
+  -- Drive the dispatch via the IO-based `tryReduce` so the provider call
+  -- (and its diagnostic side-effects) fire eagerly (the pure `dispatch` uses
   -- `@[implemented_by]` side-effects that the compiled bench harness
-  -- otherwise defers past the `diagnostics` read below). On a successful
-  -- candidate we still run `certifyFlat` so the smoke target measures
-  -- the same certified path that `dispatch` exposes to the public `lll`
-  -- entry point.
+  -- otherwise defers). Request the same stronger `(requestedDelta δ,
+  -- requestedEta)` the public dispatch asks of the reducer; certification
+  -- stays against `(δ, 11/20)`, exactly the path `dispatch` exposes to `lll`.
   let δ : Rat := 3 / 4
-  let δFloat : Float := Float.ofInt δ.num / Float.ofNat δ.den
+  let δFloat : Float := Float.ofInt (LLLProvider.requestedDelta δ).num
+    / Float.ofNat (LLLProvider.requestedDelta δ).den
+  let ηFloat : Float := Float.ofInt LLLProvider.requestedEta.num
+    / Float.ofNat LLLProvider.requestedEta.den
   let entries := LLLProvider.matrixToEntries input.basis
   let candidate? ← LLLProvider.tryReduce
     (USize.ofNat input.rows) (USize.ofNat input.cols) entries
-    δFloat 0.55 0 true
-  let reduced ← match candidate? with
+    δFloat ηFloat 0 true
+  -- Track whether `certCheck` itself accepted, not merely whether the payload
+  -- was shape-valid: `tryReduce`'s `accepted` tally counts shape validation,
+  -- so guarding on it would pass even if certification rejected and we fell
+  -- back to native. The smoke target must fail iff the certified path does.
+  let (reduced, certified) ← match candidate? with
     | some cand =>
         let flat := #[0, Int.ofNat input.rows, Int.ofNat input.cols, 1]
           ++ cand.reduced ++ cand.transform ++ (cand.inverse?.getD #[])
         match LLLProvider.certifyFlat input.basis δ flat with
-        | some triple => pure triple.1
-        | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn)
-    | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn)
-  let diagnostics ← LLLProvider.diagnostics
-  if LLLProvider.providerAvailable () && diagnostics.accepted = 0 then
+        | some triple => pure (triple.1, true)
+        | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn, false)
+    | none => pure (lllNative input.basis δ lllDeltaLower lllDeltaUpper input.hn, false)
+  if LLLProvider.providerAvailable () && !certified then
     throw <| IO.userError
-      s!"fplll provider loaded but certified dispatch accepted zero candidates: {repr diagnostics}"
+      "fplll provider loaded but the certified path rejected its candidate"
   return intVectorChecksum (Matrix.row reduced f0)
 
 /-- Benchmark comparator observable: squared norm of Lean's first LLL vector.
@@ -932,9 +937,12 @@ def requestFpLLLFlat (input : FirstShortVectorInput) : IO (Array Int) := do
       "fplll-ffi provider absent — set HEX_FPLLL_FFI_LIB to libfplllffi"
   let δ : Rat := 3 / 4
   let entries := LLLProvider.matrixToEntries input.basis
+  -- Request the same stronger `(requestedDelta δ, requestedEta)` the public
+  -- dispatch asks of the reducer, so the certified curve measures the exact
+  -- reducer call production makes; certification stays against `(δ, 11/20)`.
   match LLLProvider.providerReduce
       (USize.ofNat input.rows) (USize.ofNat input.cols) entries
-      (ratToFloat δ) 0.55 0 true with
+      (ratToFloat (LLLProvider.requestedDelta δ)) (ratToFloat LLLProvider.requestedEta) 0 true with
   | .error e => throw <| IO.userError s!"fplll-ffi: {e}"
   | .ok flat => return flat
 

--- a/progress/20260611T065344Z_issue-6743.md
+++ b/progress/20260611T065344Z_issue-6743.md
@@ -1,0 +1,62 @@
+# Progress: #6743 — request stronger (δ, η) from the external reducer
+
+## Accomplished
+
+Implemented the prophylactic margin for the certified external dispatch:
+the dispatch now asks the reducer for a strictly stronger `(δ', η')` than the
+`(δ, 11/20)` it certifies, so a correctly-functioning reducer lands every
+interval-checker inequality clear of the certified bound instead of possibly
+straddling it.
+
+- New `LLLProvider` design constants in `HexLLL/Basic.lean`:
+  `requestedEta : Rat := 107/200` and
+  `requestedDelta δ : Rat := min (δ + 1/100) ((δ + 1)/2)`. The midpoint cap
+  keeps `δ < δ' < 1` over the whole `δ ≤ 1` public surface (the constant
+  `99/100` ceiling the directive sketched only holds `δ < δ'` for `δ < 99/100`).
+  `dispatch` forwards `(ratToFloat (requestedDelta δ)) (ratToFloat requestedEta)`.
+- Routed the benchmark's `requestFpLLLFlat` and `runDispatched…` through the
+  same constants so the certified curve measures the production reducer call.
+- `certifyFlat` / `certCheck` / `certCheck_sound` unchanged: certification is
+  against the exact `(δ, 11/20)`, so the requested params stay untrusted.
+
+## Measurement (carica, paired before/after, fplll-ffi)
+
+The directive's example margin (`δ+1/50`, `η'=0.52`) regressed the
+RandomBounded family +2.26 % geomean median (RB30/RB90 +3.8 %), failing the
+`≤3 %`/`≤2 %` timing gate. Per the directive ("halve the margin and
+re-measure") I halved to `δ+1/100`, `η'=107/200`. Clean re-measure:
+
+- RandomBounded geomean median **−0.64 %**, worst rung **+2.8 %** (RB90, min
+  delta only +0.6 %); HarshCubic candidates are unchanged at any margin, so
+  zero real cost (geomean −0.57 %).
+- interval-checker fallback **0** on every rung (tally pinned `7/10/0`,
+  hash identical before/after).
+- candidate rejection **0** (every certified target accepts; stronger
+  reduction certifies more easily).
+
+Raw exports: `/tmp/hexlll-6743-c-{before,after}.json` (clean RB ladder),
+`/tmp/hexlll-6743-margin-{before,after}.json` (full-margin run),
+`/tmp/hexlll-6743-h-{before,after}.json` (halved-margin full ladder).
+
+## Current frontier
+
+Second opinion (Codex) confirmed accepted-certificate soundness is untouched
+and flagged four issues, all addressed: the `δ→1` clamp (now the midpoint
+form), two overclaiming docstrings, the dispatched smoke guard (now checks the
+real `certifyFlat` verdict, not `tryReduce`'s shape-only `accepted` tally),
+and `requestedEta` as a `Rat` for auditability. The δ=3/4 forwarded floats are
+bit-identical after these changes, so the measurement still stands.
+
+Verification: `lake build HexLLL HexLLLMathlib hexlll_bench`,
+`hexlll_bench verify` (129/129), `check_dag.py`, `git diff --check`,
+forbidden-token grep — all clean.
+
+## Next step
+
+SPEC PR (`SPEC/Libraries/hex-lll.md §Certified external dispatch`) sequenced to
+merge immediately before this implementation PR. After both land, refresh the
+committed carica certified ladders per `SPEC/benchmarking.md §Headline reports`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR asks the external reducer for a strictly stronger `(δ', η')` than the `(δ, 11/20)` the dispatch certifies, so a correctly-functioning reducer lands every interval-checker inequality clear of the certified bound rather than straddling it and forcing the exact fallback. The requested parameters are named design constants in `LLLProvider` — `requestedEta = 107/200` and `requestedDelta δ = min (δ + 1/100) ((δ + 1)/2)`, the latter keeping `δ < δ' < 1` across the whole `δ ≤ 1` public surface — and the benchmark's `requestFpLLLFlat` and dispatched targets request the same pair so the certified curve measures the production reducer call. Certification stays against the exact `(δ, 11/20)`: `certCheck`, `certCheck_sound`, and every public contract are unchanged, and the requested parameters remain outside the trusted story (the "reliability is empirical, soundness is not" clause).

Closes https://github.com/kim-em/hex/issues/6743. The SPEC half is https://github.com/kim-em/hex/pull/6764 (doc: demand strictly stronger requested reduction parameters); this implementation must merge after that SPEC PR, never ahead of it.

A paired carica measurement drove the go/no-go. The directive's example margin (`δ + 1/50`, `η' = 0.52`) regressed the RandomBounded family +2.26 % geomean median (RB30/RB90 +3.8 %), exceeding the gate; per the directive's "halve the margin and re-measure" path this PR uses `δ + 1/100`, `η' = 107/200`. The clean re-measure gives RandomBounded geomean median −0.64 % (worst rung +2.8 %, min delta +0.6 %); HarshCubic candidates are unchanged at any margin, so zero real cost. The interval-checker fallback count stays `0` on every rung (tally pinned `7/10/0`) and candidate rejection stays `0`.

🤖 Prepared with Claude Code