### PR TITLE
doc: correct the dispatchFactor calibration to the realized routing

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -998,10 +998,15 @@ two checkers: the exact `d`/`ν` checker performs ~`n³/3` multiplications on
 operands averaging ~`n·maxDiagBits/4` bits, while the interval pass
 performs ~`n³/6` products on fixed `(intervalPrec + maxDiagBits)`-bit
 mantissas, so enclosures win once `n·maxDiagBits` exceeds a fixed multiple
-of `intervalPrec + maxDiagBits`. The constant is calibrated on the two
-committed bench families (random-bounded crossover between n=120 and
-n=150, harsh-cubic between n=20 and n=25); boundary misclassification
-costs single-digit percent because the boundary rungs are near parity. -/
+of `intervalPrec + maxDiagBits`. On the two committed bench families this
+crosses over between n=25 and n=30 for harsh-cubic and between n=150 and
+n=180 for random-bounded (paired bench on `carica`). The boundary rungs are
+entangled: lowering the constant to pull harsh-cubic n=25 (where the
+interval pass runs ~10% faster, about 0.5 ms) onto the interval side also
+pulls random-bounded n=150 there, where the exact checker runs ~2% faster.
+On that ~360 ms rung the ~7 ms cost outweighs the harsh-cubic saving, so the
+constant stays at the value that keeps random-bounded n=150 on the exact
+side and minimizes total absolute misroute cost across both families. -/
 def dispatchFactor : Nat := 16
 
 /-- Size predictor for the reducedness dispatch: `true` when the

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -2181,7 +2181,7 @@ setup_fixed_benchmark runCertifiedCheckerHarshCubic55Checksum where {
 
 /- One certified check per rung of both ladders; the observed value pins the
 reducedness-decision tally to "7 rungs dispatched to the interval checker
-(harsh-cubic n ≥ 35, random-bounded n ≥ 150), 10 to the exact checker by
+(harsh-cubic n ≥ 30, random-bounded n ≥ 180), 10 to the exact checker by
 the size predictor, zero indecision fallbacks". -/
 setup_fixed_benchmark runCertifiedCheckerIntervalTally where {
     repeats := 1

--- a/progress/20260611T054419Z_issue-6757.md
+++ b/progress/20260611T054419Z_issue-6757.md
@@ -1,0 +1,67 @@
+# Progress: #6757 — reducedness dispatch threshold (doc-only outcome)
+
+## Accomplished
+
+Investigated whether `dispatchFactor` (the `intervalWins` reducedness-
+dispatch threshold) should drop from 16 to route harsh-cubic n=25 to the
+faster interval checker. **Outcome: doc-only.** Keep `dispatchFactor = 16`;
+fix the docstring's (wrong) calibration sentence and the `Bench.lean` tally
+comment's (wrong) rung list to match the realized F=16 routing. No
+functional change; the pinned interval tally stays 7/10/0.
+
+### Why not F=14
+
+A probe + paired bench on `carica` (drift-free per-rung pairing; controls
+clean at ±0.7%), **re-baselined at `579cca1c`** (includes #6765/#6769,
+which changed every certified candidate, per the issue's coordination
+note):
+
+| re-routed rung | F=16 → F=14 | % | absolute |
+|---|---|---:|---:|
+| harsh-cubic n=25 (exact→interval) | 4.634 → 4.179 ms | −9.8% | −0.46 ms |
+| random-bounded n=150 (exact→interval) | 359.6 → 367.0 ms | +2.1% | +7.40 ms |
+| net over both re-routed rungs | | | **+6.94 ms (F=14 slower)** |
+
+These two rungs are the only ones that change routing (tally 7/10/0 →
+9/8/0). They are entangled: the linear predictor cannot route harsh n=25
+to interval without also routing random n=150 there (`F ≤ 14` vs `F ≥ 16`).
+At the re-baselined candidates random n=150's faster checker is now the
+exact one (~2%), so F=14 trades a 0.46 ms harsh saving for a 7.4 ms random
+cost: a net absolute regression, and it trips the directive's "helps one
+family but regresses the other" veto. At the *old* base random n=150 was
+−0.8% (parity), which is why the first paired run (since discarded) looked
+like a clean two-rung win; the re-baseline reversed it.
+
+F=16 is the better uniform constant: its only misroute (harsh n=25,
+0.46 ms) is far cheaper than F=14's (random n=150, 7.4 ms). Isolating harsh
+n=25 would need a per-family or formula-level predictor change (the two
+rungs differ enormously in maxDiagBits, ~164 vs ~15), which is a design
+discussion, not a constant tweak — left claimable.
+
+### Doc fixes (the productive outcome)
+
+- `HexLLL/Basic.lean` `dispatchFactor` docstring: calibration sentence now
+  states the realized F=16 crossovers (harsh-cubic 25↔30, random-bounded
+  150↔180) and documents the entanglement + absolute-ms tradeoff so the
+  next reader does not re-attempt the naive constant drop.
+- `HexLLL/Bench.lean` tally comment: rung list corrected from
+  "harsh n ≥ 35, random n ≥ 150" to "harsh n ≥ 30, random n ≥ 180"
+  (the 7/10/0 count was right; the attribution was off by one rung).
+
+Kim chose this outcome after I surfaced the reversed re-baselined data.
+
+## Current frontier
+
+PR #6766 converted from the F=14 perf change to this doc-only fix
+(branch reset to origin/main, force-push-with-lease). Verifying build +
+`hexlll_bench verify` (expect unchanged 7/10/0), then CI, then merge.
+
+## Next step
+
+Issue comment posted with the re-baselined entanglement + absolute-ms
+numbers and the doc-only conclusion. No ladder/report refresh needed
+(no candidate or routing change).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR corrects the `dispatchFactor` docstring's calibration sentence and the
`runCertifiedCheckerIntervalTally` comment so both describe the routing the
constant actually realizes. The docstring claimed the harsh-cubic crossover sat
between n=20 and n=25 and the random-bounded crossover between n=120 and n=150;
the realized F=16 routing crosses over between n=25 and n=30 for harsh-cubic and
between n=150 and n=180 for random-bounded. The tally comment's rung attribution
was likewise off by one (it read "harsh n ≥ 35, random n ≥ 150" where the
realized split is "harsh n ≥ 30, random n ≥ 180"; the 7/10/0 count was already
correct). No functional change: the constant, both checkers, `certCheck`, and
the pinned 7/10/0 tally are unchanged.

This started as a perf change lowering `dispatchFactor` to 14 to route
harsh-cubic n=25 to the faster interval checker. A direct probe and paired bench
on `carica`, re-baselined to include the stronger requested reduction parameters
(#6765/#6769, which changed every certified candidate), showed the constant
cannot be improved. The two re-routed rungs are entangled: any value that pulls
harsh-cubic n=25 onto the interval side (`F ≤ 14`) also pulls random-bounded
n=150 there (`F ≥ 16` to keep it exact). With drift-free per-rung pairing
(controls clean at ±0.7%):

| re-routed rung | F=16 → F=14 | % | absolute |
|---|---|---:|---:|
| harsh-cubic n=25 (exact→interval) | 4.634 → 4.179 ms | −9.8 % | −0.46 ms |
| random-bounded n=150 (exact→interval) | 359.6 → 367.0 ms | +2.1 % | +7.40 ms |
| net over both re-routed rungs | | | **+6.94 ms (F=14 slower)** |

At the re-baselined candidates the exact checker is the faster one at
random-bounded n=150, so F=14 trades a 0.46 ms harsh-cubic saving for a 7.4 ms
random-bounded cost: a net absolute regression that also trips the directive's
"helps one family but regresses the other" stop condition. F=16 is the better
uniform constant; its only misroute (harsh-cubic n=25, 0.46 ms) is far cheaper
than F=14's. Isolating harsh-cubic n=25 would need a per-family or formula-level
predictor change (the two rungs differ enormously in `maxDiagBits`, ~164 vs
~15), which is a design discussion left for a follow-up. The docstring now
records the entanglement and the absolute-millisecond tradeoff so the constant
drop is not re-attempted naively.

Verification: `lake build HexLLL HexLLLMathlib`, `lake exe hexlll_bench verify`
(tally unchanged at 7/10/0), `python3 scripts/check_dag.py`, `git diff --check`,
and an added-line forbidden-token grep all pass.

🤖 Prepared with Claude Code
