### PR TITLE
doc: refresh comparator + scaling evidence for the steered reducer

### DIFF
--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -758,11 +758,23 @@ def runDispatchedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO I
   return intVectorChecksum (Matrix.row reduced f0)
 
 /-- Benchmark comparator observable: squared norm of Lean's first LLL vector.
-The verified-Isabelle Haskell extraction reports the same scalar. -/
+The verified-Isabelle Haskell extraction reports the same scalar. Runs the
+default native path (`lll.firstShortVectorUnchecked`, the approximation-steered
+reducer with certified output). -/
 def runFirstShortVectorNormSq (input : FirstShortVectorInput) : Int :=
   Vector.intNormSq
     (lll.firstShortVectorUnchecked input.basis (3 / 4)
       lllDeltaLower lllDeltaUpper input.hn)
+
+/-- Benchmark comparator observable for the exact `d`/`ν` reducer: squared norm
+of the first vector of `lllNative` run directly. This is the
+fplll-independent exact integer reducer that the steered path demotes to its
+certification fallback; measuring it directly keeps the exact-native curve of
+the comparator plot independent of the steered default. -/
+def runNativeFirstShortVectorNormSq (input : FirstShortVectorInput) : Int :=
+  Vector.intNormSq
+    ((lllNative input.basis (3 / 4) lllDeltaLower lllDeltaUpper input.hn).row
+      ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one input.hn⟩)
 
 def intRowHaskell (v : Vector Int n) : String :=
   "[" ++ String.intercalate "," ((List.finRange n).map fun j => toString v[j]) ++ "]"
@@ -1101,6 +1113,84 @@ def runFpLLLFirstShortVectorHarshCubic60Checksum : Unit → IO Int := fun _ => d
 /-- fpLLL comparator (via fplll-ffi) for the harsh-cubic rung `n = 65`. -/
 def runFpLLLFirstShortVectorHarshCubic65Checksum : Unit → IO Int := fun _ => do
   runFpLLLFirstShortVectorChecksum
+    (← getCachedInput harshCubicInput65Ref (fun _ => prepHarshCubicInput 65))
+
+-- Exact `lllNative` ladder targets for the comparator's exact-native curve
+-- (the steered default lives on the `runFirstShortVector*NormSq` targets).
+def runNativeFirstShortVectorRandomBoundedNormSq30 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput30Ref (fun _ => prepRandomBoundedInput 30))
+
+def runNativeFirstShortVectorRandomBoundedNormSq45 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput45Ref (fun _ => prepRandomBoundedInput 45))
+
+def runNativeFirstShortVectorRandomBoundedNormSq60 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput60Ref (fun _ => prepRandomBoundedInput 60))
+
+def runNativeFirstShortVectorRandomBoundedNormSq75 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput75Ref (fun _ => prepRandomBoundedInput 75))
+
+def runNativeFirstShortVectorRandomBoundedNormSq90 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput90Ref (fun _ => prepRandomBoundedInput 90))
+
+def runNativeFirstShortVectorRandomBoundedNormSq120 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput120Ref (fun _ => prepRandomBoundedInput 120))
+
+def runNativeFirstShortVectorRandomBoundedNormSq150 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput150Ref (fun _ => prepRandomBoundedInput 150))
+
+def runNativeFirstShortVectorRandomBoundedNormSq180 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput randomBoundedInput180Ref (fun _ => prepRandomBoundedInput 180))
+
+def runNativeFirstShortVectorHarshCubicNormSq15 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput15Ref (fun _ => prepHarshCubicInput 15))
+
+def runNativeFirstShortVectorHarshCubicNormSq20 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput20Ref (fun _ => prepHarshCubicInput 20))
+
+def runNativeFirstShortVectorHarshCubicNormSq25 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput25Ref (fun _ => prepHarshCubicInput 25))
+
+def runNativeFirstShortVectorHarshCubicNormSq30 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput30Ref (fun _ => prepHarshCubicInput 30))
+
+def runNativeFirstShortVectorHarshCubicNormSq35 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput35Ref (fun _ => prepHarshCubicInput 35))
+
+def runNativeFirstShortVectorHarshCubicNormSq40 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput40Ref (fun _ => prepHarshCubicInput 40))
+
+def runNativeFirstShortVectorHarshCubicNormSq45 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput45Ref (fun _ => prepHarshCubicInput 45))
+
+def runNativeFirstShortVectorHarshCubicNormSq50 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput50Ref (fun _ => prepHarshCubicInput 50))
+
+def runNativeFirstShortVectorHarshCubicNormSq55 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput55Ref (fun _ => prepHarshCubicInput 55))
+
+def runNativeFirstShortVectorHarshCubicNormSq60 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
+    (← getCachedInput harshCubicInput60Ref (fun _ => prepHarshCubicInput 60))
+
+def runNativeFirstShortVectorHarshCubicNormSq65 : Unit → IO Int := fun _ => do
+  return runNativeFirstShortVectorNormSq
     (← getCachedInput harshCubicInput65Ref (fun _ => prepHarshCubicInput 65))
 
 def runDispatchedFirstShortVectorRandomBounded30Checksum : Unit → IO Int := fun _ => do
@@ -2421,6 +2511,121 @@ setup_fixed_benchmark runFirstShortVectorHarshCubicNormSq65 where {
     maxSecondsPerCall := 60.0
     expectedHash := some (firstShortVectorHarshCubicNormSqHash 65)
   }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq30 where {
+    repeats := 3
+    maxSecondsPerCall := 20.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 30)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq45 where {
+    repeats := 3
+    maxSecondsPerCall := 20.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 45)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq60 where {
+    repeats := 3
+    maxSecondsPerCall := 30.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 60)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq75 where {
+    repeats := 3
+    maxSecondsPerCall := 30.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 75)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq90 where {
+    repeats := 3
+    maxSecondsPerCall := 40.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 90)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq120 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 120)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq150 where {
+    repeats := 3
+    maxSecondsPerCall := 90.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 150)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorRandomBoundedNormSq180 where {
+    repeats := 3
+    maxSecondsPerCall := 120.0
+    expectedHash := some (firstShortVectorRandomBoundedNormSqHash 180)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq15 where {
+    repeats := 3
+    maxSecondsPerCall := 20.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 15)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq20 where {
+    repeats := 3
+    maxSecondsPerCall := 20.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 20)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq25 where {
+    repeats := 3
+    maxSecondsPerCall := 30.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 25)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq30 where {
+    repeats := 3
+    maxSecondsPerCall := 40.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 30)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq35 where {
+    repeats := 3
+    maxSecondsPerCall := 40.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 35)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq40 where {
+    repeats := 3
+    maxSecondsPerCall := 50.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 40)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq45 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 45)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq50 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 50)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq55 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 55)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq60 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 60)
+  }
+
+setup_fixed_benchmark runNativeFirstShortVectorHarshCubicNormSq65 where {
+    repeats := 3
+    maxSecondsPerCall := 60.0
+    expectedHash := some (firstShortVectorHarshCubicNormSqHash 65)
+  }
+
 
 setup_fixed_benchmark runIsabelleHarshCubicNormSq65 where {
     repeats := 3

--- a/progress/20260611T111649Z_issue-6744-evidence.md
+++ b/progress/20260611T111649Z_issue-6744-evidence.md
@@ -1,0 +1,50 @@
+# #6744 evidence refresh — comparator + scaling reports for the steered reducer
+
+## Accomplished
+
+Refreshed the headline HexLLL evidence for the merged steered reducer and added
+the steered path as a sixth comparator curve.
+
+- `HexLLL/Bench.lean`: added `runNativeFirstShortVector{RandomBounded,
+  HarshCubic}NormSq{n}` targets calling `lllNative` directly, so the
+  comparator's exact-native curve is independent of the now-steered default
+  (`runFirstShortVector*NormSq`). Same first-vector norm → shared hash helpers,
+  conformance hashes unchanged.
+- Matched-provenance carica sweep (commit `ac0d2dcc`) of both Lean ladders
+  (steered + exact native), merged with the unchanged committed Isabelle/fpLLL
+  curves into `reports/bench-results/hex-lll-{random-bounded,harsh-cubic}-
+  steered-ac0d2dcc.json`.
+- `scripts/plots/hex-lll-comparator.py` + `hex-lll-scaling.py`: added the
+  `Lean steered` curve (repointed `LEAN_*` regex to `runNativeFirstShortVector*`,
+  added `LEAN_STEERED_*` for `runFirstShortVector*`), repointed consolidated
+  defaults. Regenerated both comparator figures.
+- `reports/hex-lll-scaling.md` + `hex-lll-performance.md` headline comparator
+  section updated; harsh-cubic certified-curve omission resolved (certified
+  curves now plotted alongside the steered native path).
+
+Result (carica, harsh-cubic rungs 40–55): Lean steered p=2.95 vs exact native
+p=5.56 — the default native path leaves the ~n^5.6 class, 5.6× ahead at n=55,
+tracking Lean certified (p=2.65). Random-bounded: steered 2.4× faster than exact
+native at n=180. Dimension dispatch visible in data (steered≡native below n=40,
+ratio 0.96–1.01; diverges to 9.66× at n=65).
+
+## Current frontier
+
+Two PRs open against main, both MERGEABLE:
+- evidence (reports/figures/scripts/data + native bench targets):
+  https://github.com/kim-em/hex/pull/6767
+- SPEC curve-enumeration sync (five→six curves):
+  https://github.com/kim-em/hex/pull/6768
+CI pending on both.
+
+## Next step
+
+Watch CI; conformance runs `hexlll_bench verify` (the new native targets share
+hashes with the steered ones, so no fixture changes). The §Verdicts micro-bench
+snapshot (commit 885431e) and the §Densified gating section are commit-stamped
+historical records of the exact reducer — unchanged by this work, gating goal
+still met (more comfortably via the steered curve) — and intentionally left.
+
+## Blockers
+
+None.

--- a/reports/bench-results/hex-lll-harsh-cubic-steered-ac0d2dcc.json
+++ b/reports/bench-results/hex-lll-harsh-cubic-steered-ac0d2dcc.json
@@ -1,0 +1,3322 @@
+{
+ "results": [
+  {
+   "points": [
+    {
+     "total_nanos": 1563209666,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1507696042,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1634822458,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x321c",
+   "min_nanos": 736179,
+   "median_nanos": 763285,
+   "max_nanos": 798253,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq15",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459463458,
+    "timestamp_iso": "2026-06-03T04:04:23Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x321c"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1063804666,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1112306500,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1147427292,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2fb2",
+   "min_nanos": 2077743,
+   "median_nanos": 2172473,
+   "max_nanos": 2241068,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq20",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459567450,
+    "timestamp_iso": "2026-06-03T04:06:07Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x2fb2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1341232833,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1339715375,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1327463083,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2b46",
+   "min_nanos": 5185402,
+   "median_nanos": 5233263,
+   "max_nanos": 5239190,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq25",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459668329,
+    "timestamp_iso": "2026-06-03T04:07:48Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x2b46"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1596602417,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1587202583,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1573700958,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x358a",
+   "min_nanos": 12294538,
+   "median_nanos": 12400020,
+   "max_nanos": 12473456,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459770967,
+    "timestamp_iso": "2026-06-03T04:09:30Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x358a"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1729697791,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1739161459,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1744290292,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5118",
+   "min_nanos": 27026527,
+   "median_nanos": 27174397,
+   "max_nanos": 27254535,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq35",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459875236,
+    "timestamp_iso": "2026-06-03T04:11:15Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x5118"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1808079250,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1814153417,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1808762375,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5b24",
+   "min_nanos": 56502476,
+   "median_nanos": 56523824,
+   "max_nanos": 56692294,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq40",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780459981171,
+    "timestamp_iso": "2026-06-03T04:13:01Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x5b24"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1762001458,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1759034292,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1732279917,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x6a96",
+   "min_nanos": 108267494,
+   "median_nanos": 109939643,
+   "max_nanos": 110125091,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780460087703,
+    "timestamp_iso": "2026-06-03T04:14:47Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x6a96"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1592749417,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1594658792,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1590930500,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x72c6",
+   "min_nanos": 198866312,
+   "median_nanos": 199093677,
+   "max_nanos": 199332349,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq50",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780460194090,
+    "timestamp_iso": "2026-06-03T04:16:34Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x72c6"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1424021542,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1430467833,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1405627416,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7776",
+   "min_nanos": 351406854,
+   "median_nanos": 356005385,
+   "max_nanos": 357616958,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq55",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780460299362,
+    "timestamp_iso": "2026-06-03T04:18:19Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7776"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 590112125,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 597680333,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 597835667,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7aa2",
+   "min_nanos": 590112125,
+   "median_nanos": 597680333,
+   "max_nanos": 597835667,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780460404146,
+    "timestamp_iso": "2026-06-03T04:20:04Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7aa2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 947081375,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 959163417,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 950081833,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xaca8",
+   "min_nanos": 947081375,
+   "median_nanos": 950081833,
+   "max_nanos": 959163417,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleHarshCubicNormSq65",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780460502860,
+    "timestamp_iso": "2026-06-03T04:21:42Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0xaca8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1879426083,
+     "status": "ok",
+     "result_hash": "0x6ccfd453f897ff98",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 4096,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1755958292,
+     "status": "ok",
+     "result_hash": "0x6ccfd453f897ff98",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 4096,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1770215541,
+     "status": "ok",
+     "result_hash": "0x6ccfd453f897ff98",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 4096,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1747161209,
+     "status": "ok",
+     "result_hash": "0x6ccfd453f897ff98",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 4096,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1686979500,
+     "status": "ok",
+     "result_hash": "0x6ccfd453f897ff98",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 4096,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x6ccfd453f897ff98",
+   "min_nanos": 411860,
+   "median_nanos": 428700,
+   "max_nanos": 458844,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic15Checksum",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411460093,
+    "timestamp_iso": "2026-06-02T14:44:20Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x6ccfd453f897ff98"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1698890083,
+     "status": "ok",
+     "result_hash": "0xea6bf20dfc3dff9e",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1679269333,
+     "status": "ok",
+     "result_hash": "0xea6bf20dfc3dff9e",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1690847125,
+     "status": "ok",
+     "result_hash": "0xea6bf20dfc3dff9e",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1698092333,
+     "status": "ok",
+     "result_hash": "0xea6bf20dfc3dff9e",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1771961541,
+     "status": "ok",
+     "result_hash": "0xea6bf20dfc3dff9e",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 2048,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xea6bf20dfc3dff9e",
+   "min_nanos": 819955,
+   "median_nanos": 829146,
+   "max_nanos": 865215,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic20Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411566154,
+    "timestamp_iso": "2026-06-02T14:46:06Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1365809000,
+     "status": "ok",
+     "result_hash": "0x9f3b9a71f4a5ff4a",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1308961667,
+     "status": "ok",
+     "result_hash": "0x9f3b9a71f4a5ff4a",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1335679875,
+     "status": "ok",
+     "result_hash": "0x9f3b9a71f4a5ff4a",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1371087042,
+     "status": "ok",
+     "result_hash": "0x9f3b9a71f4a5ff4a",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1422163625,
+     "status": "ok",
+     "result_hash": "0x9f3b9a71f4a5ff4a",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x9f3b9a71f4a5ff4a",
+   "min_nanos": 1278282,
+   "median_nanos": 1333797,
+   "max_nanos": 1388831,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic25Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411671172,
+    "timestamp_iso": "2026-06-02T14:47:51Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1028200292,
+     "status": "ok",
+     "result_hash": "0x681057ce0a040122",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1014723709,
+     "status": "ok",
+     "result_hash": "0x681057ce0a040122",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1018780584,
+     "status": "ok",
+     "result_hash": "0x681057ce0a040122",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1983136833,
+     "status": "ok",
+     "result_hash": "0x681057ce0a040122",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 2051684833,
+     "status": "ok",
+     "result_hash": "0x681057ce0a040122",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x681057ce0a040122",
+   "min_nanos": 1936657,
+   "median_nanos": 1989805,
+   "max_nanos": 2008203,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic30Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411772164,
+    "timestamp_iso": "2026-06-02T14:49:32Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1335828750,
+     "status": "ok",
+     "result_hash": "0x81a9e4a828160110",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1354071083,
+     "status": "ok",
+     "result_hash": "0x81a9e4a828160110",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1322293333,
+     "status": "ok",
+     "result_hash": "0x81a9e4a828160110",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1331768375,
+     "status": "ok",
+     "result_hash": "0x81a9e4a828160110",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1306601459,
+     "status": "ok",
+     "result_hash": "0x81a9e4a828160110",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x81a9e4a828160110",
+   "min_nanos": 2551955,
+   "median_nanos": 2601110,
+   "max_nanos": 2644670,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic35Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411873688,
+    "timestamp_iso": "2026-06-02T14:51:13Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1788444416,
+     "status": "ok",
+     "result_hash": "0xd66a70f8108400e0",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1941447333,
+     "status": "ok",
+     "result_hash": "0xd66a70f8108400e0",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1850175500,
+     "status": "ok",
+     "result_hash": "0xd66a70f8108400e0",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1810645666,
+     "status": "ok",
+     "result_hash": "0xd66a70f8108400e0",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1839804666,
+     "status": "ok",
+     "result_hash": "0xd66a70f8108400e0",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 512,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xd66a70f8108400e0",
+   "min_nanos": 3493055,
+   "median_nanos": 3593368,
+   "max_nanos": 3791889,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic40Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780411974116,
+    "timestamp_iso": "2026-06-02T14:52:54Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1177158625,
+     "status": "ok",
+     "result_hash": "0x98a99989d679fe6a",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1238725541,
+     "status": "ok",
+     "result_hash": "0x98a99989d679fe6a",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1235538333,
+     "status": "ok",
+     "result_hash": "0x98a99989d679fe6a",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1206370167,
+     "status": "ok",
+     "result_hash": "0x98a99989d679fe6a",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1201428083,
+     "status": "ok",
+     "result_hash": "0x98a99989d679fe6a",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x98a99989d679fe6a",
+   "min_nanos": 4598275,
+   "median_nanos": 4712383,
+   "max_nanos": 4838771,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic45Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780412080916,
+    "timestamp_iso": "2026-06-02T14:54:40Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1474130083,
+     "status": "ok",
+     "result_hash": "0x66fc84120bf600aa",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1469849375,
+     "status": "ok",
+     "result_hash": "0x66fc84120bf600aa",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1477168375,
+     "status": "ok",
+     "result_hash": "0x66fc84120bf600aa",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1462690708,
+     "status": "ok",
+     "result_hash": "0x66fc84120bf600aa",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1471476833,
+     "status": "ok",
+     "result_hash": "0x66fc84120bf600aa",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x66fc84120bf600aa",
+   "min_nanos": 5713635,
+   "median_nanos": 5747956,
+   "max_nanos": 5770188,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic50Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780412180289,
+    "timestamp_iso": "2026-06-02T14:56:20Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 2043034166,
+     "status": "ok",
+     "result_hash": "0xec1a02e1f8a01d2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1883820792,
+     "status": "ok",
+     "result_hash": "0xec1a02e1f8a01d2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1835518875,
+     "status": "ok",
+     "result_hash": "0xec1a02e1f8a01d2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1859020958,
+     "status": "ok",
+     "result_hash": "0xec1a02e1f8a01d2",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1984637000,
+     "status": "ok",
+     "result_hash": "0xec1a02e1f8a01d2",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xec1a02e1f8a01d2",
+   "min_nanos": 7169995,
+   "median_nanos": 7358674,
+   "max_nanos": 7980602,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic55Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780412282152,
+    "timestamp_iso": "2026-06-02T14:58:02Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 9191667,
+     "status": "ok",
+     "result_hash": "0xd532d5e227b800ca",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9466875,
+     "status": "ok",
+     "result_hash": "0xd532d5e227b800ca",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 8897500,
+     "status": "ok",
+     "result_hash": "0xd532d5e227b800ca",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9429500,
+     "status": "ok",
+     "result_hash": "0xd532d5e227b800ca",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9206209,
+     "status": "ok",
+     "result_hash": "0xd532d5e227b800ca",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xd532d5e227b800ca",
+   "min_nanos": 8897500,
+   "median_nanos": 9206209,
+   "max_nanos": 9466875,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic60Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780412390503,
+    "timestamp_iso": "2026-06-02T14:59:50Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 10796334,
+     "status": "ok",
+     "result_hash": "0xfbd21bb1cda1fe48",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 10876167,
+     "status": "ok",
+     "result_hash": "0xfbd21bb1cda1fe48",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 10651167,
+     "status": "ok",
+     "result_hash": "0xfbd21bb1cda1fe48",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 10775625,
+     "status": "ok",
+     "result_hash": "0xfbd21bb1cda1fe48",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 10770250,
+     "status": "ok",
+     "result_hash": "0xfbd21bb1cda1fe48",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xfbd21bb1cda1fe48",
+   "min_nanos": 10651167,
+   "median_nanos": 10775625,
+   "max_nanos": 10876167,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorHarshCubic65Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780412476379,
+    "timestamp_iso": "2026-06-02T15:01:16Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "af2d0a1be4eb086ad08943f03f33e17bbb0e5070",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1039625,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1120250,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1108708,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x321c",
+   "min_nanos": 519812,
+   "median_nanos": 554354,
+   "max_nanos": 560125,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq15",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175736637,
+    "timestamp_iso": "2026-06-11T11:02:16Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x321c"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1682125,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1802833,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1713666,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2fb2",
+   "min_nanos": 1682125,
+   "median_nanos": 1713666,
+   "max_nanos": 1802833,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq20",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175752801,
+    "timestamp_iso": "2026-06-11T11:02:32Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x2fb2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 4226917,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4166500,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4204459,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2b46",
+   "min_nanos": 4166500,
+   "median_nanos": 4204459,
+   "max_nanos": 4226917,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq25",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175768927,
+    "timestamp_iso": "2026-06-11T11:02:48Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x2b46"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 9749417,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9782416,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9798291,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x358a",
+   "min_nanos": 9749417,
+   "median_nanos": 9782416,
+   "max_nanos": 9798291,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175784944,
+    "timestamp_iso": "2026-06-11T11:03:04Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x358a"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 20408375,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 20709125,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 20751416,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5118",
+   "min_nanos": 20408375,
+   "median_nanos": 20709125,
+   "max_nanos": 20751416,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq35",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175801015,
+    "timestamp_iso": "2026-06-11T11:03:21Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x5118"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 16331375,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 16491333,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 16062958,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5b24",
+   "min_nanos": 16062958,
+   "median_nanos": 16331375,
+   "max_nanos": 16491333,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq40",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175817463,
+    "timestamp_iso": "2026-06-11T11:03:37Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 50,
+    "expected_hash": "0x5b24"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 22831541,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 22855417,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 22868250,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x6a96",
+   "min_nanos": 22831541,
+   "median_nanos": 22855417,
+   "max_nanos": 22868250,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175833639,
+    "timestamp_iso": "2026-06-11T11:03:53Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x6a96"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 30160041,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 30376458,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 30577959,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x72c6",
+   "min_nanos": 30160041,
+   "median_nanos": 30376458,
+   "max_nanos": 30577959,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq50",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175849911,
+    "timestamp_iso": "2026-06-11T11:04:09Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x72c6"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 42166000,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 42692417,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 40251542,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7776",
+   "min_nanos": 40251542,
+   "median_nanos": 42166000,
+   "max_nanos": 42692417,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq55",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175866204,
+    "timestamp_iso": "2026-06-11T11:04:26Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7776"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 52584208,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 53223500,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 53366708,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7aa2",
+   "min_nanos": 52584208,
+   "median_nanos": 53223500,
+   "max_nanos": 53366708,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175882446,
+    "timestamp_iso": "2026-06-11T11:04:42Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7aa2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 65940666,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 65070875,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 68882750,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xaca8",
+   "min_nanos": 65070875,
+   "median_nanos": 65940666,
+   "max_nanos": 68882750,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorHarshCubicNormSq65",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175898774,
+    "timestamp_iso": "2026-06-11T11:04:58Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0xaca8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1034833,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1061542,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1068708,
+     "status": "ok",
+     "result_hash": "0x321c",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x321c",
+   "min_nanos": 517416,
+   "median_nanos": 530771,
+   "max_nanos": 534354,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq15",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175914968,
+    "timestamp_iso": "2026-06-11T11:05:14Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x321c"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1721375,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1664042,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1742167,
+     "status": "ok",
+     "result_hash": "0x2fb2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2fb2",
+   "min_nanos": 1664042,
+   "median_nanos": 1721375,
+   "max_nanos": 1742167,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq20",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175931211,
+    "timestamp_iso": "2026-06-11T11:05:31Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x2fb2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 4375500,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4248958,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4200416,
+     "status": "ok",
+     "result_hash": "0x2b46",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x2b46",
+   "min_nanos": 4200416,
+   "median_nanos": 4248958,
+   "max_nanos": 4375500,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq25",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175947348,
+    "timestamp_iso": "2026-06-11T11:05:47Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x2b46"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 9746125,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9707875,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 9576875,
+     "status": "ok",
+     "result_hash": "0x358a",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x358a",
+   "min_nanos": 9576875,
+   "median_nanos": 9707875,
+   "max_nanos": 9746125,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175963632,
+    "timestamp_iso": "2026-06-11T11:06:03Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x358a"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 20105750,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 20270667,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 20270167,
+     "status": "ok",
+     "result_hash": "0x5118",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5118",
+   "min_nanos": 20105750,
+   "median_nanos": 20270167,
+   "max_nanos": 20270667,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq35",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175979618,
+    "timestamp_iso": "2026-06-11T11:06:19Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x5118"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 40499625,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 40685334,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 40371000,
+     "status": "ok",
+     "result_hash": "0x5b24",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x5b24",
+   "min_nanos": 40371000,
+   "median_nanos": 40499625,
+   "max_nanos": 40685334,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq40",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175995690,
+    "timestamp_iso": "2026-06-11T11:06:35Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 50,
+    "expected_hash": "0x5b24"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 76792542,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 75983291,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 76795542,
+     "status": "ok",
+     "result_hash": "0x6a96",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x6a96",
+   "min_nanos": 75983291,
+   "median_nanos": 76792542,
+   "max_nanos": 76795542,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781176011859,
+    "timestamp_iso": "2026-06-11T11:06:51Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x6a96"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 142514292,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 141428292,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 139785417,
+     "status": "ok",
+     "result_hash": "0x72c6",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x72c6",
+   "min_nanos": 139785417,
+   "median_nanos": 141428292,
+   "max_nanos": 142514292,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq50",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781176028141,
+    "timestamp_iso": "2026-06-11T11:07:08Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x72c6"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 232664125,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 235707292,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 239728916,
+     "status": "ok",
+     "result_hash": "0x7776",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7776",
+   "min_nanos": 232664125,
+   "median_nanos": 235707292,
+   "max_nanos": 239728916,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq55",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781176044797,
+    "timestamp_iso": "2026-06-11T11:07:24Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7776"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 408627083,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 397510291,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 394529209,
+     "status": "ok",
+     "result_hash": "0x7aa2",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x7aa2",
+   "min_nanos": 394529209,
+   "median_nanos": 397510291,
+   "max_nanos": 408627083,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781176061793,
+    "timestamp_iso": "2026-06-11T11:07:41Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x7aa2"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 639286209,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 636920833,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 627289666,
+     "status": "ok",
+     "result_hash": "0xaca8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0xaca8",
+   "min_nanos": 627289666,
+   "median_nanos": 636920833,
+   "max_nanos": 639286209,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorHarshCubicNormSq65",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781176079341,
+    "timestamp_iso": "2026-06-11T11:07:59Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0xaca8"
+   },
+   "budget_truncated": false
+  }
+ ],
+ "lean_bench_version": "0.1.0",
+ "export_schema_version": 1,
+ "env": {
+  "timestamp_unix_ms": 1781175428482,
+  "timestamp_iso": "2026-06-11T10:57:08Z",
+  "platform_target": "arm64-apple-darwin24.6.0",
+  "os": "macos",
+  "lean_version": "4.30.0-rc2",
+  "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+  "lean_bench_version": "0.1.0",
+  "hostname": "carica",
+  "git_dirty": false,
+  "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+  "exe_name": "hexlll_bench",
+  "cpu_model": null,
+  "cpu_cores": null,
+  "arch": "arm64"
+ }
+}

--- a/reports/bench-results/hex-lll-random-bounded-steered-ac0d2dcc.json
+++ b/reports/bench-results/hex-lll-random-bounded-steered-ac0d2dcc.json
@@ -1,0 +1,2422 @@
+{
+ "results": [
+  {
+   "points": [
+    {
+     "total_nanos": 1075697542,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1070200000,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1082521500,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 16721875,
+   "median_nanos": 16807774,
+   "max_nanos": 16914398,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457071019,
+    "timestamp_iso": "2026-06-03T03:24:31Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1855668334,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1899845834,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1900135625,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1885392708,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1853771416,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 1024,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 1810323,
+   "median_nanos": 1841203,
+   "max_nanos": 1855601,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded30Checksum",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457133416,
+    "timestamp_iso": "2026-06-03T03:25:33Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x4"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1015673833,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1046852334,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1037597916,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 63479614,
+   "median_nanos": 64849869,
+   "max_nanos": 65428270,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457273419,
+    "timestamp_iso": "2026-06-03T03:27:53Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1234222875,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1265578792,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1220454625,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1235742791,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1268757166,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 256,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 4767400,
+   "median_nanos": 4827120,
+   "max_nanos": 4956082,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded45Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457328325,
+    "timestamp_iso": "2026-06-03T03:28:48Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 20,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1392049083,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1422047833,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1415416917,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 174006135,
+   "median_nanos": 176927114,
+   "max_nanos": 177755979,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457460051,
+    "timestamp_iso": "2026-06-03T03:31:00Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1244015709,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1233919042,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1207700208,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1208810166,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1235334334,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 128,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 9435157,
+   "median_nanos": 9639992,
+   "max_nanos": 9718872,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded60Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457517451,
+    "timestamp_iso": "2026-06-03T03:31:57Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 30,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1526019292,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1537969417,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1533361458,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 381504823,
+   "median_nanos": 383340364,
+   "max_nanos": 384492354,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq75",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457649574,
+    "timestamp_iso": "2026-06-03T03:34:09Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1263753292,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1236441084,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1238819083,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1242179542,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1256980791,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 64,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 19319391,
+   "median_nanos": 19409055,
+   "max_nanos": 19746145,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded75Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457708576,
+    "timestamp_iso": "2026-06-03T03:35:08Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 30,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1367177750,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1398412416,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1383045875,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 2,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 683588875,
+   "median_nanos": 691522937,
+   "max_nanos": 699206208,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq90",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457842735,
+    "timestamp_iso": "2026-06-03T03:37:22Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1021813792,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1012370583,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1005140125,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1007954375,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1011740542,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 32,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 31410628,
+   "median_nanos": 31616891,
+   "max_nanos": 31931681,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded90Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780457900334,
+    "timestamp_iso": "2026-06-03T03:38:20Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 40,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1925517458,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1921232667,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1941133833,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 1921232667,
+   "median_nanos": 1925517458,
+   "max_nanos": 1941133833,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq120",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458034727,
+    "timestamp_iso": "2026-06-03T03:40:34Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1204620917,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1226527416,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1226216417,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1221634250,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1225722875,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 16,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 75288807,
+   "median_nanos": 76607679,
+   "max_nanos": 76657963,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded120Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458097328,
+    "timestamp_iso": "2026-06-03T03:41:37Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 60,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 4037205541,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 3984163166,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 3921512583,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 3921512583,
+   "median_nanos": 3984163166,
+   "max_nanos": 4037205541,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq150",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458238493,
+    "timestamp_iso": "2026-06-03T03:43:58Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1215469875,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1205865459,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1220164791,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1227853416,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1214375084,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 8,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 150733182,
+   "median_nanos": 151933734,
+   "max_nanos": 153481677,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded150Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458317525,
+    "timestamp_iso": "2026-06-03T03:45:17Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 90,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 7571451041,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 7548643625,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 7423966625,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 7423966625,
+   "median_nanos": 7548643625,
+   "max_nanos": 7571451041,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runIsabelleRandomBoundedNormSq180",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458468064,
+    "timestamp_iso": "2026-06-03T03:47:48Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 120,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1060074875,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1082280000,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1072922917,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1070927250,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 3,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1075496625,
+     "status": "ok",
+     "result_hash": "0x4",
+     "repeat_index": 4,
+     "peak_rss_kb": null,
+     "inner_repeats": 4,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x4",
+   "min_nanos": 265018718,
+   "median_nanos": 268230729,
+   "max_nanos": 270570000,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFpylllFirstShortVectorRandomBounded180Checksum",
+   "expected_hash_check": {
+    "status": "unset"
+   },
+   "env": {
+    "timestamp_unix_ms": 1780458577148,
+    "timestamp_iso": "2026-06-03T03:49:37Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "56f3422953ca5420fb0790231d034eca4d959c54",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": true,
+    "warmup": true,
+    "repeats": 5,
+    "min_total_seconds": 1,
+    "max_seconds_per_call": 120,
+    "expected_hash": null
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 15301166,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 15408459,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 14846291,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 14846291,
+   "median_nanos": 15301166,
+   "max_nanos": 15408459,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175428482,
+    "timestamp_iso": "2026-06-11T10:57:08Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": false,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 17863042,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 17751958,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 16927667,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 16927667,
+   "median_nanos": 17751958,
+   "max_nanos": 17863042,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175444509,
+    "timestamp_iso": "2026-06-11T10:57:24Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": false,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 44326208,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 41670250,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 42500042,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 41670250,
+   "median_nanos": 42500042,
+   "max_nanos": 44326208,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175460485,
+    "timestamp_iso": "2026-06-11T10:57:40Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": false,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 87691083,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 91342750,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 89620375,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 87691083,
+   "median_nanos": 89620375,
+   "max_nanos": 91342750,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq75",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175476686,
+    "timestamp_iso": "2026-06-11T10:57:56Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 165508833,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 156559375,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 158958250,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 156559375,
+   "median_nanos": 158958250,
+   "max_nanos": 165508833,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq90",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175493019,
+    "timestamp_iso": "2026-06-11T10:58:13Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 446442667,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 453951458,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 445736334,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 445736334,
+   "median_nanos": 446442667,
+   "max_nanos": 453951458,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq120",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175509537,
+    "timestamp_iso": "2026-06-11T10:58:29Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1012379000,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1003564250,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1012428000,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 1003564250,
+   "median_nanos": 1012379000,
+   "max_nanos": 1012428000,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq150",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175527351,
+    "timestamp_iso": "2026-06-11T10:58:47Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1900623375,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1901737167,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1912187458,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 1900623375,
+   "median_nanos": 1901737167,
+   "max_nanos": 1912187458,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runFirstShortVectorRandomBoundedNormSq180",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175547327,
+    "timestamp_iso": "2026-06-11T10:59:07Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 120,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 15264167,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 15250750,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 14202791,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 14202791,
+   "median_nanos": 15250750,
+   "max_nanos": 15264167,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq30",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175571050,
+    "timestamp_iso": "2026-06-11T10:59:31Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 54199875,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 53966250,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 53404750,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 53404750,
+   "median_nanos": 53966250,
+   "max_nanos": 54199875,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq45",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175587158,
+    "timestamp_iso": "2026-06-11T10:59:47Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 20,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 139209750,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 135144333,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 132856208,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 132856208,
+   "median_nanos": 135144333,
+   "max_nanos": 139209750,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq60",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175603409,
+    "timestamp_iso": "2026-06-11T11:00:03Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 294199125,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 279329625,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 272884083,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 272884083,
+   "median_nanos": 279329625,
+   "max_nanos": 294199125,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq75",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175620000,
+    "timestamp_iso": "2026-06-11T11:00:20Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 30,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 465466125,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 487574209,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 472331917,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 465466125,
+   "median_nanos": 472331917,
+   "max_nanos": 487574209,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq90",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175637138,
+    "timestamp_iso": "2026-06-11T11:00:37Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 40,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 1367373583,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1305050208,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 1332285167,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 1305050208,
+   "median_nanos": 1332285167,
+   "max_nanos": 1367373583,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq120",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175655042,
+    "timestamp_iso": "2026-06-11T11:00:55Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 60,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 2563748958,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 2477862708,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 2534471625,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 2477862708,
+   "median_nanos": 2534471625,
+   "max_nanos": 2563748958,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq150",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175676434,
+    "timestamp_iso": "2026-06-11T11:01:16Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 90,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  },
+  {
+   "points": [
+    {
+     "total_nanos": 4540855334,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 0,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4571501542,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 1,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    },
+    {
+     "total_nanos": 4393593208,
+     "status": "ok",
+     "result_hash": "0x8",
+     "repeat_index": 2,
+     "peak_rss_kb": null,
+     "inner_repeats": 1,
+     "error": null,
+     "alloc_bytes": null
+    }
+   ],
+   "observed_hash": "0x8",
+   "min_nanos": 4393593208,
+   "median_nanos": 4540855334,
+   "max_nanos": 4571501542,
+   "kind": "fixed",
+   "hashes_agree": true,
+   "hashable": true,
+   "function": "Hex.LLLBench.runNativeFirstShortVectorRandomBoundedNormSq180",
+   "expected_hash_check": {
+    "status": "match"
+   },
+   "env": {
+    "timestamp_unix_ms": 1781175702638,
+    "timestamp_iso": "2026-06-11T11:01:42Z",
+    "platform_target": "arm64-apple-darwin24.6.0",
+    "os": "macos",
+    "lean_version": "4.30.0-rc2",
+    "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+    "lean_bench_version": "0.1.0",
+    "hostname": "carica",
+    "git_dirty": true,
+    "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+    "exe_name": "hexlll_bench",
+    "cpu_model": null,
+    "cpu_cores": null,
+    "arch": "arm64"
+   },
+   "config": {
+    "warmup_first_iter": false,
+    "warmup": true,
+    "repeats": 3,
+    "min_total_seconds": 0.001,
+    "max_seconds_per_call": 120,
+    "expected_hash": "0x8"
+   },
+   "budget_truncated": false
+  }
+ ],
+ "lean_bench_version": "0.1.0",
+ "export_schema_version": 1,
+ "env": {
+  "timestamp_unix_ms": 1781175428482,
+  "timestamp_iso": "2026-06-11T10:57:08Z",
+  "platform_target": "arm64-apple-darwin24.6.0",
+  "os": "macos",
+  "lean_version": "4.30.0-rc2",
+  "lean_toolchain": "leanprover/lean4:4.30.0-rc2",
+  "lean_bench_version": "0.1.0",
+  "hostname": "carica",
+  "git_dirty": false,
+  "git_commit": "ac0d2dcc5aa87cbd17ffd38a898f148cd88af212",
+  "exe_name": "hexlll_bench",
+  "cpu_model": null,
+  "cpu_cores": null,
+  "arch": "arm64"
+ }
+}

--- a/reports/figures/hex-lll-comparator-harsh-cubic.svg
+++ b/reports/figures/hex-lll-comparator-harsh-cubic.svg
@@ -1376,17 +1376,17 @@ z
     </g>
    </g>
    <g id="line2d_94">
-    <path d="M 88.984091 272.554161
-L 128.852273 235.752643
-L 168.720455 207.329062
-L 208.588636 181.343753
-L 248.456818 158.752972
-L 288.325 136.976842
-L 328.193182 116.553841
-L 368.061364 98.345421
-L 407.929545 81.306639
-L 447.797727 66.066602
-L 487.665909 50.831678
+    <path d="M 88.984091 271.59146
+L 128.852273 234.829281
+L 168.720455 206.59713
+L 208.588636 180.779866
+L 248.456818 157.776311
+L 288.325 136.149767
+L 328.193182 116.158245
+L 368.061364 97.076897
+L 407.929545 81.116609
+L 447.797727 64.786616
+L 487.665909 50.056581
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
@@ -1402,17 +1402,17 @@ z
 " style="stroke: #ff7f0e"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="272.554161" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="235.752643" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="207.329062" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="181.343753" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="158.752972" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="288.325" y="136.976842" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="116.553841" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="368.061364" y="98.345421" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="81.306639" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="447.797727" y="66.066602" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="50.831678" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="88.984091" y="271.59146" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="234.829281" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="206.59713" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="180.779866" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="157.776311" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="288.325" y="136.149767" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="116.158245" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="368.061364" y="97.076897" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="81.116609" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="447.797727" y="64.786616" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="50.056581" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_95">
@@ -1450,6 +1450,49 @@ z
     </g>
    </g>
    <g id="line2d_96">
+    <path d="M 88.984091 270.233117
+L 128.852273 234.969527
+L 168.720455 206.926091
+L 208.588636 180.540864
+L 248.456818 157.106894
+L 288.325 164.527343
+L 328.193182 154.02563
+L 368.061364 145.136834
+L 407.929545 134.88989
+L 447.797727 127.613188
+L 487.665909 120.91861
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="mb8cbd0352e" d="M -1.166667 3.5
+L 1.166667 3.5
+L 1.166667 1.166667
+L 3.5 1.166667
+L 3.5 -1.166667
+L 1.166667 -1.166667
+L 1.166667 -3.5
+L -1.166667 -3.5
+L -1.166667 -1.166667
+L -3.5 -1.166667
+L -3.5 1.166667
+L -1.166667 1.166667
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#mb8cbd0352e" x="88.984091" y="270.233117" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="128.852273" y="234.969527" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="168.720455" y="206.926091" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="208.588636" y="180.540864" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="248.456818" y="157.106894" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="288.325" y="164.527343" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="328.193182" y="154.02563" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="368.061364" y="145.136834" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="407.929545" y="134.88989" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="447.797727" y="127.613188" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="487.665909" y="120.91861" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_97">
     <path d="M 88.984091 256.830216
 L 128.852273 225.773595
 L 168.720455 199.596663
@@ -1459,28 +1502,28 @@ L 288.325 166.971569
 L 328.193182 157.920832
 L 368.061364 148.76234
 L 407.929545 140.727786
-" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m633b1844ca" d="M -0 4.596194
+     <path id="m43483cdca4" d="M -0 4.596194
 L 4.596194 0
 L 0 -4.596194
 L -4.596194 -0
 z
-" style="stroke: #d62728; stroke-linejoin: miter"/>
+" style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="256.830216" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="225.773595" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="199.596663" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="188.312463" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="176.086441" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="288.325" y="166.971569" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="157.920832" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="368.061364" y="148.76234" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="140.727786" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="88.984091" y="256.830216" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="128.852273" y="225.773595" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="168.720455" y="199.596663" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="208.588636" y="188.312463" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="248.456818" y="176.086441" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="288.325" y="166.971569" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="328.193182" y="157.920832" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="368.061364" y="148.76234" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="407.929545" y="140.727786" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_97">
+   <g id="line2d_98">
     <path d="M 88.984091 278.264727
 L 128.852273 257.653785
 L 168.720455 242.799885
@@ -1492,26 +1535,26 @@ L 368.061364 197.155571
 L 407.929545 189.436753
 L 447.797727 182.437744
 L 487.665909 177.519391
-" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #8c564b; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m25acbb3ce1" d="M -0 3.5
+     <path id="mffb8de44e4" d="M -0 3.5
 L 3.5 -3.5
 L -3.5 -3.5
 z
-" style="stroke: #9467bd; stroke-linejoin: miter"/>
+" style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="278.264727" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="257.653785" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="242.799885" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="230.301351" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="221.930552" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="288.325" y="211.833421" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="203.362567" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="368.061364" y="197.155571" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="189.436753" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="447.797727" y="182.437744" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="177.519391" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="88.984091" y="278.264727" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="128.852273" y="257.653785" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="168.720455" y="242.799885" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="208.588636" y="230.301351" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="248.456818" y="221.930552" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="288.325" y="211.833421" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="328.193182" y="203.362567" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="368.061364" y="197.155571" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="407.929545" y="189.436753" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="447.797727" y="182.437744" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="487.665909" y="177.519391" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1618,7 +1661,7 @@ z
     </g>
    </g>
    <g id="legend_1">
-    <g id="line2d_98">
+    <g id="line2d_99">
      <path d="M 78.05 38.538437
 L 88.05 38.538437
 L 98.05 38.538437
@@ -1666,7 +1709,7 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
      </g>
     </g>
-    <g id="line2d_99">
+    <g id="line2d_100">
      <path d="M 78.05 53.216562
 L 88.05 53.216562
 L 98.05 53.216562
@@ -1691,7 +1734,7 @@ L 98.05 53.216562
       <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
      </g>
     </g>
-    <g id="line2d_100">
+    <g id="line2d_101">
      <path d="M 78.05 67.894687
 L 88.05 67.894687
 L 98.05 67.894687
@@ -1802,18 +1845,44 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(1332.373047 0)"/>
      </g>
     </g>
-    <g id="line2d_101">
+    <g id="line2d_102">
      <path d="M 78.05 82.572812
 L 88.05 82.572812
 L 98.05 82.572812
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m633b1844ca" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+      <use xlink:href="#mb8cbd0352e" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_22">
-     <!-- Lean certified -->
+     <!-- Lean steered -->
      <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(271.931641 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(324.03125 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(363.240234 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(424.763672 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(486.287109 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(525.150391 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(586.673828 0)"/>
+     </g>
+    </g>
+    <g id="line2d_103">
+     <path d="M 78.05 97.250937
+L 88.05 97.250937
+L 98.05 97.250937
+" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m43483cdca4" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_23">
+     <!-- Lean certified -->
+     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1830,18 +1899,18 @@ L 98.05 82.572812
       <use xlink:href="#DejaVuSans-64" transform="translate(621.052734 0)"/>
      </g>
     </g>
-    <g id="line2d_102">
-     <path d="M 78.05 97.250937
-L 88.05 97.250937
-L 98.05 97.250937
-" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <g id="line2d_104">
+     <path d="M 78.05 111.929062
+L 88.05 111.929062
+L 98.05 111.929062
+" style="fill: none; stroke: #8c564b; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m25acbb3ce1" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+      <use xlink:href="#mffb8de44e4" x="88.05" y="111.929062" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_23">
+    <g id="text_24">
      <!-- fpLLL via fplll-ffi -->
-     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
+     <g transform="translate(106.05 115.429062) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-66"/>
       <use xlink:href="#DejaVuSans-70" transform="translate(35.205078 0)"/>
       <use xlink:href="#DejaVuSans-4c" transform="translate(98.681641 0)"/>
@@ -1865,7 +1934,7 @@ L 98.05 97.250937
     </g>
    </g>
   </g>
-  <g id="text_24">
+  <g id="text_25">
    <!-- Isabelle certified is adjusted down by its ~18.8 ms per-request floor, a fixed trivial-request cost dominated by the fplll subprocess fork. -->
    <g style="fill: #595959" transform="translate(22.612031 340.688219) scale(0.07 -0.07)">
     <defs>

--- a/reports/figures/hex-lll-comparator-random-bounded.svg
+++ b/reports/figures/hex-lll-comparator-random-bounded.svg
@@ -1395,14 +1395,14 @@ z
     </g>
    </g>
    <g id="line2d_90">
-    <path d="M 88.984091 217.281267
-L 128.852273 179.663729
-L 168.720455 152.4853
-L 208.588636 131.169255
-L 248.456818 116.302232
-L 328.193182 86.47791
-L 407.929545 67.833569
-L 487.665909 50.836485
+    <path d="M 88.984091 217.068789
+L 128.852273 180.490033
+L 168.720455 153.918909
+L 208.588636 132.903366
+L 248.456818 117.698828
+L 328.193182 87.68369
+L 407.929545 69.06942
+L 487.665909 52.190676
 " clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
     <defs>
      <path id="m2451d16133" d="M 0 3
@@ -1418,14 +1418,14 @@ z
 " style="stroke: #ff7f0e"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m2451d16133" x="88.984091" y="217.281267" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="128.852273" y="179.663729" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="168.720455" y="152.4853" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="208.588636" y="131.169255" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="248.456818" y="116.302232" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="328.193182" y="86.47791" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="407.929545" y="67.833569" style="fill: #ff7f0e; stroke: #ff7f0e"/>
-     <use xlink:href="#m2451d16133" x="487.665909" y="50.836485" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="88.984091" y="217.068789" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="128.852273" y="180.490033" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="168.720455" y="153.918909" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="208.588636" y="132.903366" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="248.456818" y="117.698828" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="328.193182" y="87.68369" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="407.929545" y="69.06942" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+     <use xlink:href="#m2451d16133" x="487.665909" y="52.190676" style="fill: #ff7f0e; stroke: #ff7f0e"/>
     </g>
    </g>
    <g id="line2d_91">
@@ -1457,6 +1457,43 @@ z
     </g>
    </g>
    <g id="line2d_92">
+    <path d="M 88.984091 216.97326
+L 128.852273 212.672984
+L 168.720455 187.403672
+L 208.588636 165.808404
+L 248.456818 149.221175
+L 328.193182 119.330489
+L 407.929545 95.631793
+L 487.665909 77.382947
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+    <defs>
+     <path id="mb8cbd0352e" d="M -1.166667 3.5
+L 1.166667 3.5
+L 1.166667 1.166667
+L 3.5 1.166667
+L 3.5 -1.166667
+L 1.166667 -1.166667
+L 1.166667 -3.5
+L -1.166667 -3.5
+L -1.166667 -1.166667
+L -3.5 -1.166667
+L -3.5 1.166667
+L -1.166667 1.166667
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p57df7f6c62)">
+     <use xlink:href="#mb8cbd0352e" x="88.984091" y="216.97326" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="128.852273" y="212.672984" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="168.720455" y="187.403672" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="208.588636" y="165.808404" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="248.456818" y="149.221175" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="328.193182" y="119.330489" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="407.929545" y="95.631793" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#mb8cbd0352e" x="487.665909" y="77.382947" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_93">
     <path d="M 88.984091 254.245053
 L 128.852273 220.135753
 L 168.720455 195.040097
@@ -1465,27 +1502,27 @@ L 248.456818 159.667001
 L 328.193182 132.614579
 L 407.929545 112.71981
 L 487.665909 97.631269
-" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m633b1844ca" d="M -0 4.596194
+     <path id="m43483cdca4" d="M -0 4.596194
 L 4.596194 0
 L 0 -4.596194
 L -4.596194 -0
 z
-" style="stroke: #d62728; stroke-linejoin: miter"/>
+" style="stroke: #9467bd; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m633b1844ca" x="88.984091" y="254.245053" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="128.852273" y="220.135753" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="168.720455" y="195.040097" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="208.588636" y="175.4936" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="248.456818" y="159.667001" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="328.193182" y="132.614579" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="407.929545" y="112.71981" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
-     <use xlink:href="#m633b1844ca" x="487.665909" y="97.631269" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="88.984091" y="254.245053" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="128.852273" y="220.135753" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="168.720455" y="195.040097" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="208.588636" y="175.4936" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="248.456818" y="159.667001" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="328.193182" y="132.614579" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="407.929545" y="112.71981" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#m43483cdca4" x="487.665909" y="97.631269" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
     </g>
    </g>
-   <g id="line2d_93">
+   <g id="line2d_94">
     <path d="M 88.984091 278.264727
 L 128.852273 250.366578
 L 168.720455 230.346135
@@ -1494,23 +1531,23 @@ L 248.456818 195.966016
 L 328.193182 170.349462
 L 407.929545 150.529409
 L 487.665909 134.076943
-" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+" clip-path="url(#p57df7f6c62)" style="fill: none; stroke: #8c564b; stroke-width: 2; stroke-linecap: square"/>
     <defs>
-     <path id="m25acbb3ce1" d="M -0 3.5
+     <path id="mffb8de44e4" d="M -0 3.5
 L 3.5 -3.5
 L -3.5 -3.5
 z
-" style="stroke: #9467bd; stroke-linejoin: miter"/>
+" style="stroke: #8c564b; stroke-linejoin: miter"/>
     </defs>
     <g clip-path="url(#p57df7f6c62)">
-     <use xlink:href="#m25acbb3ce1" x="88.984091" y="278.264727" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="128.852273" y="250.366578" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="168.720455" y="230.346135" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="208.588636" y="210.089814" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="248.456818" y="195.966016" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="328.193182" y="170.349462" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="407.929545" y="150.529409" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
-     <use xlink:href="#m25acbb3ce1" x="487.665909" y="134.076943" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="88.984091" y="278.264727" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="128.852273" y="250.366578" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="168.720455" y="230.346135" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="208.588636" y="210.089814" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="248.456818" y="195.966016" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="328.193182" y="170.349462" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="407.929545" y="150.529409" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
+     <use xlink:href="#mffb8de44e4" x="487.665909" y="134.076943" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
     </g>
    </g>
    <g id="patch_3">
@@ -1620,18 +1657,18 @@ z
     </g>
    </g>
    <g id="legend_1">
-    <g id="line2d_94">
-     <path d="M 78.05 38.538437
-L 88.05 38.538437
-L 98.05 38.538437
+    <g id="line2d_95">
+     <path d="M 333.457813 202.333687
+L 343.457813 202.333687
+L 353.457813 202.333687
 " style="fill: none; stroke: #1f77b4; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m0fee27a2d2" x="88.05" y="38.538437" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
+      <use xlink:href="#m0fee27a2d2" x="343.457813" y="202.333687" style="fill: #1f77b4; stroke: #1f77b4; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_16">
      <!-- Isabelle native -->
-     <g transform="translate(106.05 42.038437) scale(0.1 -0.1)">
+     <g transform="translate(361.457813 205.833687) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-49" d="M 628 4666
 L 1259 4666
@@ -1668,18 +1705,18 @@ z
       <use xlink:href="#DejaVuSans-65" transform="translate(667.578125 0)"/>
      </g>
     </g>
-    <g id="line2d_95">
-     <path d="M 78.05 53.216562
-L 88.05 53.216562
-L 98.05 53.216562
+    <g id="line2d_96">
+     <path d="M 333.457813 217.011812
+L 343.457813 217.011812
+L 353.457813 217.011812
 " style="fill: none; stroke: #ff7f0e; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m2451d16133" x="88.05" y="53.216562" style="fill: #ff7f0e; stroke: #ff7f0e"/>
+      <use xlink:href="#m2451d16133" x="343.457813" y="217.011812" style="fill: #ff7f0e; stroke: #ff7f0e"/>
      </g>
     </g>
     <g id="text_17">
      <!-- Lean native -->
-     <g transform="translate(106.05 56.716562) scale(0.1 -0.1)">
+     <g transform="translate(361.457813 220.511812) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1693,18 +1730,18 @@ L 98.05 53.216562
       <use xlink:href="#DejaVuSans-65" transform="translate(522.761719 0)"/>
      </g>
     </g>
-    <g id="line2d_96">
-     <path d="M 78.05 67.894687
-L 88.05 67.894687
-L 98.05 67.894687
+    <g id="line2d_97">
+     <path d="M 333.457813 231.689937
+L 343.457813 231.689937
+L 353.457813 231.689937
 " style="fill: none; stroke: #2ca02c; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#ma559d3018c" x="88.05" y="67.894687" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
+      <use xlink:href="#ma559d3018c" x="343.457813" y="231.689937" style="fill: #2ca02c; stroke: #2ca02c; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_18">
      <!-- Isabelle certified (adjusted) -->
-     <g transform="translate(106.05 71.394687) scale(0.1 -0.1)">
+     <g transform="translate(361.457813 235.189937) scale(0.1 -0.1)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863
 L 2375 4384
@@ -1804,18 +1841,44 @@ z
       <use xlink:href="#DejaVuSans-29" transform="translate(1332.373047 0)"/>
      </g>
     </g>
-    <g id="line2d_97">
-     <path d="M 78.05 82.572812
-L 88.05 82.572812
-L 98.05 82.572812
+    <g id="line2d_98">
+     <path d="M 333.457813 246.368062
+L 343.457813 246.368062
+L 353.457813 246.368062
 " style="fill: none; stroke: #d62728; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m633b1844ca" x="88.05" y="82.572812" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+      <use xlink:href="#mb8cbd0352e" x="343.457813" y="246.368062" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
      </g>
     </g>
     <g id="text_19">
+     <!-- Lean steered -->
+     <g transform="translate(361.457813 249.868062) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-4c"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(176.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(240.144531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(271.931641 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(324.03125 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(363.240234 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(424.763672 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(486.287109 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(525.150391 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(586.673828 0)"/>
+     </g>
+    </g>
+    <g id="line2d_99">
+     <path d="M 333.457813 261.046187
+L 343.457813 261.046187
+L 353.457813 261.046187
+" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m43483cdca4" x="343.457813" y="261.046187" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_20">
      <!-- Lean certified -->
-     <g transform="translate(106.05 86.072812) scale(0.1 -0.1)">
+     <g transform="translate(361.457813 264.546187) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-4c"/>
       <use xlink:href="#DejaVuSans-65" transform="translate(53.962891 0)"/>
       <use xlink:href="#DejaVuSans-61" transform="translate(115.486328 0)"/>
@@ -1832,18 +1895,18 @@ L 98.05 82.572812
       <use xlink:href="#DejaVuSans-64" transform="translate(621.052734 0)"/>
      </g>
     </g>
-    <g id="line2d_98">
-     <path d="M 78.05 97.250937
-L 88.05 97.250937
-L 98.05 97.250937
-" style="fill: none; stroke: #9467bd; stroke-width: 2; stroke-linecap: square"/>
+    <g id="line2d_100">
+     <path d="M 333.457813 275.724312
+L 343.457813 275.724312
+L 353.457813 275.724312
+" style="fill: none; stroke: #8c564b; stroke-width: 2; stroke-linecap: square"/>
      <g>
-      <use xlink:href="#m25acbb3ce1" x="88.05" y="97.250937" style="fill: #9467bd; stroke: #9467bd; stroke-linejoin: miter"/>
+      <use xlink:href="#mffb8de44e4" x="343.457813" y="275.724312" style="fill: #8c564b; stroke: #8c564b; stroke-linejoin: miter"/>
      </g>
     </g>
-    <g id="text_20">
+    <g id="text_21">
      <!-- fpLLL via fplll-ffi -->
-     <g transform="translate(106.05 100.750937) scale(0.1 -0.1)">
+     <g transform="translate(361.457813 279.224312) scale(0.1 -0.1)">
       <use xlink:href="#DejaVuSans-66"/>
       <use xlink:href="#DejaVuSans-70" transform="translate(35.205078 0)"/>
       <use xlink:href="#DejaVuSans-4c" transform="translate(98.681641 0)"/>
@@ -1867,7 +1930,7 @@ L 98.05 97.250937
     </g>
    </g>
   </g>
-  <g id="text_21">
+  <g id="text_22">
    <!-- Isabelle certified is adjusted down by its ~18.8 ms per-request floor, a fixed trivial-request cost dominated by the fplll subprocess fork. -->
    <g style="fill: #595959" transform="translate(22.612031 340.688219) scale(0.07 -0.07)">
     <defs>

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -432,9 +432,15 @@ Architectural asymmetries for this ratio:
 - Hex checks reducedness with `lllReducedInt`; Isabelle confirms reducedness by
   re-running the verified LLL reducer inside `test_certified`.
 
-The random-bounded plot shows five labelled series across the full committed
-ladder: Lean native, Isabelle native, Lean certified, Isabelle certified
-(adjusted), and fpLLL via fplll-ffi.
+The random-bounded plot shows six labelled series across the full committed
+ladder: Lean native, Lean steered, Isabelle native, Lean certified, Isabelle
+certified (adjusted), and fpLLL via fplll-ffi. **Lean native** is the exact
+`d`/`ν` reducer (`lllNative`); **Lean steered** is the default native path, the
+approximation-steered reducer that drives exact integer row operations from an
+untrusted floating-point Gram–Schmidt and certifies its own output at
+`(δ, 11/20)`. The steered curve sits below exact native across the whole ladder
+(2.4× faster at `n = 180`) and above the certified path, which only checks an
+fpLLL candidate rather than reducing the basis itself.
 
 ![Random-bounded comparator runtime plot](figures/hex-lll-comparator-random-bounded.svg)
 
@@ -445,10 +451,14 @@ the `fplll` subprocess fork, taken as the audit-host figure from
 otherwise dominates its small-`n` rungs. The ratio tables above and the scaling
 fits keep the raw medians; only the plotted curve is adjusted.
 
-The harsh-cubic plot shows the same five series. On this family the
-Lean-certified curve crosses below Lean native at `n = 30` and falls to `0.15×`
-Lean native at `n = 55` (per the harsh-cubic trend above); the certified curves
-carry that crossover story, so both are plotted.
+The harsh-cubic plot shows the same six series, and this is the family where the
+steered curve matters most. The exact `d`/`ν` reducers ride the `~n^5.6` slope
+of their Θ(n⁴)-bit Gram-determinant state, while **Lean steered leaves that
+complexity class** (`p ≈ 2.95`, 5.6× ahead of exact native at `n = 55`) and
+lands within `~1.2×` of the Lean-certified curve. Both certified curves and the
+steered curve carry the crossover story on this family, so all are plotted —
+the earlier figure omitted the certified curves on harsh-cubic; they are now
+shown alongside the steered native path they are closest to.
 
 ![Harsh-cubic comparator runtime plot](figures/hex-lll-comparator-harsh-cubic.svg)
 
@@ -459,11 +469,13 @@ random-bounded figure, the ratio tables and scaling fits keep the raw medians.
 
 For the asymptotic scaling of these curves — fitted exponents and constant
 factors per method, with reproduction steps — see
-[hex-lll-scaling.md](hex-lll-scaling.md). In brief: the five random-bounded
-methods share one empirical complexity (`~n³`) and differ only by a constant
-factor (Lean certified ~4× smaller than Lean native), while on harsh-cubic the
-native reducers (`~n^5.6`) and fpLLL (`~n^2.2`) have different exponents and
-fan out.
+[hex-lll-scaling.md](hex-lll-scaling.md). In brief: on random-bounded the
+exact-native, steered, certified, and fpLLL methods are all near-`n³` and differ
+by constant factors (Lean steered 2.4× faster than exact native, Lean certified
+faster still); on harsh-cubic the exact native reducers (`~n^5.6`) fan out from
+the steered default (`~n^2.95`), the certified path (`~n^2.65`), and fpLLL
+(`~n^2.2`) — the steered reducer is the one that moved the native curve out of
+the `~n^5.6` class.
 
 ### Per-call comparator overhead
 

--- a/reports/hex-lll-scaling.md
+++ b/reports/hex-lll-scaling.md
@@ -1,7 +1,7 @@
 # HexLLL Scaling Report
 
-This report fits the asymptotic scaling of the HexLLL comparators — the five
-random-bounded curves and the three harsh-cubic curves of the comparator plot
+This report fits the asymptotic scaling of the HexLLL comparators — the six
+curves of each comparator plot
 (`reports/hex-lll-performance.md`) — so that the *exponent* (which complexity
 class a method is in) and the *constant factor* (how much slower it is than the
 fastest at the same complexity) are recorded as numbers rather than read off a
@@ -48,69 +48,81 @@ Snapshot below; regenerate with the command in [§Reproduction](#reproduction)
 and replace this block when the numbers move. Each row's data provenance (host,
 commit) is printed above its table.
 
+The comparator carries six curves. **Lean native** is the exact `d`/`ν`
+reducer (`lllNative`); **Lean steered** is the default native path, the
+approximation-steered reducer that drives exact integer row operations from an
+untrusted floating-point Gram–Schmidt and certifies its output at `(δ, 11/20)`.
+
 ### random-bounded, rungs 120–180
 
 - `reports/bench-results/hex-lll-certified-835734e7.json` — host `carica`, commit `835734e7`
 - `reports/bench-results/hex-lll-certified-carica.json` — host `carica`, commit `4c708c7b`
-- `reports/bench-results/hex-lll-random-bounded-schur.json` — host `carica`, commit `56f34229`
+- `reports/bench-results/hex-lll-random-bounded-steered-ac0d2dcc.json` — host `carica`, commit `ac0d2dcc`
 
-| method | exponent p | R² | C₃ (ns·n³) | × fpLLL |
+| method | exponent p | R² | median @ n=180 | × fastest @ n=180 |
 |---|---:|---:|---:|---:|
-| Isabelle native | 3.37 | 0.9996 | 1194 | 26.5× |
-| Lean native | 3.03 | 0.9990 | 801 | 17.8× |
-| Isabelle certified | 3.07 | 0.9977 | 407 | 9.0× |
-| Lean certified | 2.98 | 0.9996 | 164 | 3.6× |
-| fpLLL via fplll-ffi | 3.09 | 1.0000 | 45 | 1.0× |
+| Isabelle native | 3.37 | 0.9996 | 7548.6 ms | 28.1× |
+| Lean native | 3.02 | 0.9991 | 4540.9 ms | 16.9× |
+| Isabelle certified | 3.07 | 0.9977 | 2362.9 ms | 8.8× |
+| Lean steered | 3.58 | 0.9997 | 1901.7 ms | 7.1× |
+| Lean certified | 2.98 | 0.9996 | 944.8 ms | 3.5× |
+| fpLLL via fplll-ffi | 3.09 | 1.0000 | 268.2 ms | 1.0× |
 
-Exponents agree to within 0.38, so the five methods share one complexity
-(empirically `~n³` on this instance family) and differ only by a constant
-factor. The headline reading:
+The six exponents span 0.59, so the methods no longer share one complexity on
+this family and the table reports the observed ratio at `n = 180`. The headline
+reading:
 
-- **Certifying buys ~4.9× over native at matched provenance.** Lean certified
-  sits at 3.6× fpLLL against Lean native's 17.8× — the same answer for a
-  ~4.9× smaller constant, because fpLLL produces the basis and Lean only
-  checks it.
-- **Lean beats Isabelle by a constant ~1.5–2.5× on both rows.** Native
-  26.5/17.8 ≈ 1.5×; certified 9.0/3.6 ≈ 2.5×.
-- **fpLLL's raw constant is ~3.6× below even Lean certified**, the gap being
-  the checker (the packed-evaluation same-lattice clause plus the
-  fixed-precision interval Gram–Schmidt with exact fallback), which
-  `reports/hex-lll-performance.md` measures as ~62–72% of the certified
-  path.
+- **The steered default runs 2.4× faster than the exact reducer** (1901.7 vs
+  4540.9 ms at `n = 180`), even though its fitted exponent (`p ≈ 3.58`) is
+  slightly *steeper* than exact native's `p ≈ 3.02`: steering at the stricter
+  `δ` it forwards to the certifier fires more swaps, and the per-swap
+  floating-point work plus the periodic exact-Gram refresh grow with `n`. The
+  win here is constant-factor (no Θ(n⁴)-bit Gram-determinant state), not a
+  complexity-class change — random-bounded was already `~n³` for the exact
+  reducer.
+- **Certifying an fpLLL candidate still beats steering** (944.8 vs 1901.7 ms):
+  the steered path reduces the basis itself, while the certified path only
+  checks fpLLL's, so it stays the fastest verified option where an external
+  provider is present.
+- **Lean steered beats the Isabelle native extraction by ~4×** (1901.7 vs
+  7548.6 ms), and Lean certified beats it by ~8×.
 
 ### harsh-cubic, rungs 40–55
 
 - `reports/bench-results/hex-lll-certified-835734e7.json` — host `carica`, commit `835734e7`
 - `reports/bench-results/hex-lll-certified-carica.json` — host `carica`, commit `4c708c7b`
-- `reports/bench-results/hex-lll-harsh-cubic-extended-schur.json` — host `carica`, commit `56f34229`
+- `reports/bench-results/hex-lll-harsh-cubic-steered-ac0d2dcc.json` — host `carica`, commit `ac0d2dcc`
 
 | method | exponent p | R² | median @ n=55 | × fastest @ n=55 |
 |---|---:|---:|---:|---:|
 | Isabelle native | 5.76 | 0.9997 | 356.0 ms | 48.4× |
-| Lean native | 5.59 | 0.9999 | 234.3 ms | 31.8× |
+| Lean native | 5.56 | 0.9998 | 235.7 ms | 32.0× |
 | Isabelle certified | 4.59 | 0.9961 | 400.4 ms | 54.4× |
+| Lean steered | 2.95 | 0.9975 | 42.2 ms | 5.7× |
 | Lean certified | 2.65 | 0.9993 | 35.0 ms | 4.8× |
 | fpLLL via fplll-ffi | 2.21 | 0.9970 | 7.4 ms | 1.0× |
 
-The Lean-certified curve scales with a near-cubic exponent (`p ≈ 2.65` over
-the top rungs) and runs ahead of Lean native by **6.7× at `n = 55`** — the
-predicted crossover, realized. The two native reducers scale far worse
-(`~n^5.6` over this window) than fpLLL (`~n^2.2`), and the Isabelle-certified
-curve still tracks native with the same `~n^4.6` slope. The constant-factor
-framing does not apply across that mixed set — the per-method gaps grow with
-`n`, and the table reports the observed ratio at `n = 55`. The harsh-cubic
-exponents are local fits over a narrow high-`n` window; treat them as the
-slope at these rungs, not a proven asymptotic.
+This is the family the steered architecture targets. **The steered default
+leaves the `~n^5.6` complexity class** of the exact reducers, fitting
+`p ≈ 2.95` over the top rungs and running **5.6× ahead of exact native at
+`n = 55`** (42.2 vs 235.7 ms). The exact `d`/`ν` reducer carries intrinsically
+Θ(n⁴)-bit Gram-determinant state on this family — the prefix Gram determinants
+have `~6.6·n·i` bits for any basis of the lattice — so its `~n^5.6` cost cannot
+be fixed inside the exact representation; the steered path never materializes
+that state. The Isabelle-certified curve still rides the `~n^4.6` slope because
+it has no interval kernel. The constant-factor framing does not apply across
+this mixed set — the per-method gaps grow with `n`, and the table reports the
+observed ratio at `n = 55`. The harsh-cubic exponents are local fits over a
+narrow high-`n` window; treat them as the slope at these rungs, not a proven
+asymptotic.
 
-The Lean-certified path's near-cubic exponent is what the fixed-precision
-interval reducedness checker bought. The previous exact-only checker paid
-~`n^5.6` on this family (driven by `O(n²)` exact-integer Gram-Schmidt
-operations whose operand bit length grows with `n`), so its cost dominated
-the certified path's runtime. The dispatched checker now routes harsh-cubic
-above `n ≈ 25` to a sound `O(n³)` enclosure pass over fixed-width mantissas
-(with mandatory exact fallback on indecision); below that threshold the
-input-size predictor keeps the exact checker. The Isabelle-certified curve
-still rides the `~n^4.6` slope because it has no interval kernel.
+The steered default and the certified path land within `~1.2×` of each other
+here (42.2 vs 35.0 ms): once the exact-GSO state is out of the loop, the
+steered native reducer is competitive with certifying an external candidate,
+and on this family both are an order of magnitude below the exact `d`/`ν`
+reducer. fpLLL's raw float reducer is still `~5×` below either, the gap being
+the work neither verified path can skip — the steered path reduces the basis
+exactly, the certified path runs the verified reducedness checker.
 
 ## Reproduction
 
@@ -135,13 +147,15 @@ tables. The exponent answers "did the change alter the complexity class"; the
 
 ## Caveats
 
-- The random-bounded curves come from three committed runs: the native
-  curves (Isabelle native, Lean native, fpLLL) from one, the Lean-certified
-  curve from another, and the Isabelle-certified curve from a third — all on
-  `carica`, slightly different commits. Within each run the ratios are
-  exact; cross-run ratios (for example certified-vs-native) carry mild
-  run-to-run noise. A single consolidated five-way sweep would remove it;
-  the exponents and the ~4.7× certify-win are well outside that noise.
+- The curves come from three committed runs: the Lean curves (Lean native,
+  Lean steered) and the external curves (Isabelle native, fpLLL) from the
+  consolidated `…-steered-ac0d2dcc` sweep, the Lean-certified curve from
+  another, and the Isabelle-certified curve from a third — all on `carica`,
+  slightly different commits. The two Lean curves and the matched-provenance
+  Lean-steered-vs-Lean-native ratio are from one run, so the steered-win
+  numbers are exact; cross-run ratios (for example certified-vs-steered) carry
+  mild run-to-run noise. A single consolidated six-way sweep would remove it;
+  the exponents and the steered-vs-native gap are well outside that noise.
 - Exponents are fits over a finite window, not proofs. They report the slope at
   the measured rungs; a wider or higher window can shift them, especially on
   harsh-cubic where the window is narrow.

--- a/scripts/plots/hex-lll-comparator.py
+++ b/scripts/plots/hex-lll-comparator.py
@@ -24,10 +24,10 @@ ROOT = Path(__file__).resolve().parents[2]
 # the fpLLL comparator under the `runFpylllFirstShortVector*` function
 # names (process-call fpylll subprocess); the regex accepts either.
 DEFAULT_RANDOM_CONSOLIDATED = (
-    ROOT / "reports/bench-results/hex-lll-random-bounded-schur.json"
+    ROOT / "reports/bench-results/hex-lll-random-bounded-steered-ac0d2dcc.json"
 )
 DEFAULT_HARSH_CONSOLIDATED = (
-    ROOT / "reports/bench-results/hex-lll-harsh-cubic-extended-schur.json"
+    ROOT / "reports/bench-results/hex-lll-harsh-cubic-steered-ac0d2dcc.json"
 )
 DEFAULT_ISABELLE_BOTTOM = (
     ROOT / "reports/bench-results/hex-lll-isabelle-bottom-e211854d1435.json"
@@ -47,7 +47,8 @@ DEFAULT_ISABELLE_CERTIFIED_HARSH = DEFAULT_ISABELLE_CERTIFIED
 DEFAULT_RANDOM_OUTPUT = ROOT / "reports/figures/hex-lll-comparator-random-bounded.svg"
 DEFAULT_HARSH_OUTPUT = ROOT / "reports/figures/hex-lll-comparator-harsh-cubic.svg"
 
-LEAN_RANDOM = re.compile(r"runFirstShortVectorRandomBoundedNormSq([0-9]+)$")
+LEAN_RANDOM = re.compile(r"runNativeFirstShortVectorRandomBoundedNormSq([0-9]+)$")
+LEAN_STEERED_RANDOM = re.compile(r"runFirstShortVectorRandomBoundedNormSq([0-9]+)$")
 ISABELLE_RANDOM = re.compile(r"runIsabelleRandomBoundedNormSq([0-9]+)$")
 FPLLL_RANDOM = re.compile(
     r"run(?:FpLLL|Fpylll)FirstShortVectorRandomBounded([0-9]+)Checksum$"
@@ -58,7 +59,8 @@ CERTIFIED_RANDOM = re.compile(
 ISABELLE_CERTIFIED_RANDOM = re.compile(
     r"runIsabelleCertifiedRandomBoundedNormSq([0-9]+)$"
 )
-LEAN_HARSH = re.compile(r"runFirstShortVectorHarshCubicNormSq([0-9]+)$")
+LEAN_HARSH = re.compile(r"runNativeFirstShortVectorHarshCubicNormSq([0-9]+)$")
+LEAN_STEERED_HARSH = re.compile(r"runFirstShortVectorHarshCubicNormSq([0-9]+)$")
 ISABELLE_HARSH = re.compile(r"runIsabelleHarshCubicNormSq([0-9]+)$")
 FPLLL_HARSH = re.compile(
     r"run(?:FpLLL|Fpylll)FirstShortVectorHarshCubic([0-9]+)Checksum$"
@@ -81,6 +83,7 @@ class Series:
 @dataclass(frozen=True)
 class FamilyConfig:
     lean_pattern: re.Pattern[str]
+    lean_steered_pattern: re.Pattern[str]
     isabelle_pattern: re.Pattern[str]
     fpll_pattern: re.Pattern[str]
     certified_pattern: re.Pattern[str]
@@ -101,6 +104,7 @@ class FamilyConfig:
 FAMILIES = {
     "random-bounded": FamilyConfig(
         lean_pattern=LEAN_RANDOM,
+        lean_steered_pattern=LEAN_STEERED_RANDOM,
         isabelle_pattern=ISABELLE_RANDOM,
         fpll_pattern=FPLLL_RANDOM,
         certified_pattern=CERTIFIED_RANDOM,
@@ -116,6 +120,7 @@ FAMILIES = {
     ),
     "harsh-cubic": FamilyConfig(
         lean_pattern=LEAN_HARSH,
+        lean_steered_pattern=LEAN_STEERED_HARSH,
         isabelle_pattern=ISABELLE_HARSH,
         fpll_pattern=FPLLL_HARSH,
         certified_pattern=CERTIFIED_HARSH,
@@ -146,6 +151,7 @@ ISABELLE_CERTIFIED_ADJUSTED_LABEL = "Isabelle certified (adjusted)"
 # whether or not the certified curves are present in a given figure.
 STYLE_BY_LABEL = {
     "Lean native": {"marker": "o", "linewidth": 2.0},
+    "Lean steered": {"marker": "P", "linewidth": 2.0, "markersize": 7.0},
     "Isabelle native": {"marker": "s", "linewidth": 2.0},
     "Lean certified": {"marker": "D", "linewidth": 2.0, "markersize": 6.5},
     ISABELLE_CERTIFIED_ADJUSTED_LABEL: {
@@ -303,12 +309,15 @@ def main() -> None:
 
     cons = load_results(cons_path)
     lean = collect_series(cons, config.lean_pattern, "Lean native")
+    steered = collect_series(cons, config.lean_steered_pattern, "Lean steered")
     isabelle = collect_series(cons, config.isabelle_pattern, "Isabelle native")
     fpll = collect_series(cons, config.fpll_pattern, "fpLLL via fplll-ffi")
 
     # Legend follows plot order; order the series slowest-to-fastest at large
-    # n (Isabelle native, Lean native, Isabelle certified, Lean certified,
-    # fpLLL) so the legend reads top-to-bottom like the stacked curves.
+    # n (Isabelle native, Lean native, Isabelle certified, Lean steered, Lean
+    # certified, fpLLL) so the legend reads top-to-bottom like the stacked
+    # curves. `Lean native` is the exact d/ν reducer; `Lean steered` is the
+    # approximation-steered default with post-hoc certification.
     series = [isabelle, lean]
     if config.include_certified:
         certified_results = load_results(args.certified or config.certified_path)
@@ -325,7 +334,9 @@ def main() -> None:
                 "Isabelle certified",
             )
         )
-        series += [isabelle_certified, certified]
+        series += [isabelle_certified, steered, certified]
+    else:
+        series.append(steered)
     series.append(fpll)
 
     if config.bottom_consistency:

--- a/scripts/plots/hex-lll-scaling.py
+++ b/scripts/plots/hex-lll-scaling.py
@@ -70,7 +70,14 @@ def family_series(family: str) -> list[cmp.Series]:
             cmp.collect_series(ic, config.isabelle_certified_pattern,
                                "Isabelle certified")
         )
+        out.append(
+            cmp.collect_series(cons, config.lean_steered_pattern, "Lean steered")
+        )
         out.append(cmp.collect_series(c, config.certified_pattern, "Lean certified"))
+    else:
+        out.append(
+            cmp.collect_series(cons, config.lean_steered_pattern, "Lean steered")
+        )
     out.append(cmp.collect_series(cons, config.fpll_pattern, "fpLLL via fplll-ffi"))
     return out
 


### PR DESCRIPTION
This PR refreshes the HexLLL comparator figures and scaling report for the approximation-steered native reducer landed in https://github.com/kim-em/hex/pull/6763, and adds the steered path as a sixth comparator curve.

The comparator's `runFirstShortVector*NormSq` ladder now measures the steered default; a new `runNativeFirstShortVector*NormSq` ladder measures the exact `d`/`ν` reducer `lllNative` directly, so the plot keeps an exact-native curve independent of the steered default. Both Lean ladders come from one matched-provenance carica sweep (commit `ac0d2dcc`); the Isabelle-native, fpLLL, and certified curves are the unchanged committed measurements. `hex-lll-comparator.py` and `hex-lll-scaling.py` gain the `Lean steered` curve, both figures are regenerated, and `hex-lll-scaling.md` plus the headline comparator section of `hex-lll-performance.md` are updated.

Headline result — harsh-cubic, the family the steered architecture targets (carica, rungs 40–55):

| method | exponent p | median @ n=55 |
|---|---:|---:|
| Lean native (exact) | 5.56 | 235.7 ms |
| Lean steered | 2.95 | 42.2 ms |
| Lean certified | 2.65 | 35.0 ms |
| fpLLL via fplll-ffi | 2.21 | 7.4 ms |

The steered default leaves the `~n^5.6` complexity class of the exact reducer (5.6× ahead at n=55) and tracks the certified curve. On random-bounded it runs 2.4× faster than the exact reducer at n=180. The dimension dispatch is visible in the data: steered equals exact native within noise below n=40 (ratio 0.96–1.01), then diverges to 9.66× at n=65. The harsh-cubic figure now plots the certified curves alongside the steered native path, resolving the earlier certified-curve omission.

🤖 Prepared with Claude Code
