### PR TITLE
feat: support-partition length equals part count for a genuine partition

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -31,6 +31,158 @@ theorem expectedIndicatorArrayOfSupports_size {r : Nat}
       (supportPartitionByMinColumn trueSupports).length := by
   simp [expectedIndicatorArrayOfSupports]
 
+/-! ### Support-partition length from a genuine partition
+
+The B8 partition-refinement hypothesis `hpartition` consumed by the fast-core
+irreducibility wrappers is an equality
+`(supportPartitionByMinColumn trueSupports).length = normalizedFactors.card`.
+The lemma below supplies the provider-agnostic combinatorial half of that
+discharge: when `trueSupports` is a genuine partition of `Fin r` into nonempty
+parts (each column lies in exactly one part), the support-equivalence partition
+has exactly one class per part, so its length is the number of parts.  A
+`trueSupports`-builder pairs this with a bijection from the parts to
+`normalizedFactors (toPolynomial core)`. -/
+
+/-- The chosen part of a covered column. -/
+private noncomputable def partOf {r : Nat} (trueSupports : Set (Set (Fin r)))
+    (hcover : ∀ i : Fin r, ∃ S ∈ trueSupports, i ∈ S) (i : Fin r) :
+    Set (Fin r) :=
+  (hcover i).choose
+
+private theorem partOf_mem {r : Nat} (trueSupports : Set (Set (Fin r)))
+    (hcover : ∀ i : Fin r, ∃ S ∈ trueSupports, i ∈ S) (i : Fin r) :
+    partOf trueSupports hcover i ∈ trueSupports :=
+  (hcover i).choose_spec.1
+
+private theorem mem_partOf {r : Nat} (trueSupports : Set (Set (Fin r)))
+    (hcover : ∀ i : Fin r, ∃ S ∈ trueSupports, i ∈ S) (i : Fin r) :
+    i ∈ partOf trueSupports hcover i :=
+  (hcover i).choose_spec.2
+
+private theorem partOf_eq_of_mem {r : Nat} (trueSupports : Set (Set (Fin r)))
+    (hcover : ∀ i : Fin r, ∃ S ∈ trueSupports, i ∈ S)
+    (hdisj : ∀ S ∈ trueSupports, ∀ T ∈ trueSupports, ∀ i : Fin r,
+      i ∈ S → i ∈ T → S = T)
+    {i : Fin r} {S : Set (Fin r)} (hS : S ∈ trueSupports) (hi : i ∈ S) :
+    partOf trueSupports hcover i = S :=
+  hdisj _ (partOf_mem trueSupports hcover i) _ hS i (mem_partOf trueSupports hcover i) hi
+
+/-- For a partition `trueSupports`, the support-equivalence partition has exactly
+one class per part: its length equals the number of parts `trueSupports.ncard`. -/
+theorem supportPartitionByMinColumn_length_eq_ncard_of_partition {r : Nat}
+    (trueSupports : Set (Set (Fin r)))
+    (hcover : ∀ i : Fin r, ∃ S ∈ trueSupports, i ∈ S)
+    (hdisj : ∀ S ∈ trueSupports, ∀ T ∈ trueSupports, ∀ i : Fin r,
+      i ∈ S → i ∈ T → S = T)
+    (hne : ∀ S ∈ trueSupports, S.Nonempty) :
+    (supportPartitionByMinColumn trueSupports).length = trueSupports.ncard := by
+  classical
+  set L := supportRepresentativeColumns trueSupports with hL
+  -- The partition length is the number of class representatives.
+  have hlen : (supportPartitionByMinColumn trueSupports).length = L.length := by
+    unfold supportPartitionByMinColumn
+    rw [List.length_map]
+  rw [hlen]
+  -- `L` is nodup (a filter of `List.range r`).
+  have hLnodup : L.Nodup := by
+    rw [hL]
+    unfold supportRepresentativeColumns
+    exact (List.nodup_range).filter _
+  -- Two columns lying in the same part are support-equivalent, and conversely.
+  have hpart_equiv : ∀ {i j : Fin r},
+      partOf trueSupports hcover i = partOf trueSupports hcover j →
+      supportEquivalent trueSupports i j := by
+    intro i j hij T hT
+    constructor
+    · intro hiT
+      have : partOf trueSupports hcover i = T :=
+        partOf_eq_of_mem trueSupports hcover hdisj hT hiT
+      have hjT : j ∈ partOf trueSupports hcover j := mem_partOf trueSupports hcover j
+      rw [← hij, this] at hjT
+      exact hjT
+    · intro hjT
+      have : partOf trueSupports hcover j = T :=
+        partOf_eq_of_mem trueSupports hcover hdisj hT hjT
+      have hiT : i ∈ partOf trueSupports hcover i := mem_partOf trueSupports hcover i
+      rw [hij, this] at hiT
+      exact hiT
+  -- The representative-to-part map.
+  let F : Nat → Set (Fin r) :=
+    fun rep => if h : rep < r then partOf trueSupports hcover ⟨rep, h⟩ else ∅
+  have hF_mem : ∀ rep ∈ L, F rep ∈ trueSupports := by
+    intro rep hrep
+    have hlt : rep < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep)
+    simp only [F, dif_pos hlt]
+    exact partOf_mem trueSupports hcover _
+  -- Bijection between the representative finset and the parts.
+  have hbij : Set.BijOn F (↑L.toFinset) trueSupports := by
+    refine ⟨?_, ?_, ?_⟩
+    · -- MapsTo
+      intro rep hrep
+      rw [Finset.mem_coe, List.mem_toFinset] at hrep
+      exact hF_mem rep hrep
+    · -- InjOn
+      intro rep1 hrep1 rep2 hrep2 hFeq
+      rw [Finset.mem_coe, List.mem_toFinset] at hrep1 hrep2
+      have hlt1 : rep1 < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep1)
+      have hlt2 : rep2 < r := supportRepresentativeColumns_lt trueSupports (hL ▸ hrep2)
+      simp only [F, dif_pos hlt1, dif_pos hlt2] at hFeq
+      have hequiv : supportEquivalent trueSupports ⟨rep1, hlt1⟩ ⟨rep2, hlt2⟩ :=
+        hpart_equiv hFeq
+      have hequivAt : supportEquivalentAt trueSupports rep1 rep2 :=
+        (supportEquivalentAt_iff trueSupports hlt1 hlt2).mpr hequiv
+      rcases lt_trichotomy rep1 rep2 with hlt | heq | hgt
+      · exact absurd hequivAt
+          (supportRepresentativeColumns_min trueSupports (hL ▸ hrep2) rep1 hlt)
+      · exact heq
+      · exact absurd (supportEquivalentAt_symm trueSupports hequivAt)
+          (supportRepresentativeColumns_min trueSupports (hL ▸ hrep1) rep2 hgt)
+    · -- SurjOn
+      intro S hS
+      obtain ⟨i, hi⟩ := hne S hS
+      -- The least column equivalent to `i` is a representative.
+      let C : Finset Nat :=
+        (Finset.range r).filter (fun k => supportEquivalentAt trueSupports k i.val)
+      have hiC : i.val ∈ C := by
+        simp only [C, Finset.mem_filter, Finset.mem_range]
+        exact ⟨i.isLt, supportEquivalentAt_refl trueSupports i.isLt⟩
+      have hCne : C.Nonempty := ⟨i.val, hiC⟩
+      set m := C.min' hCne with hm
+      have hmC : m ∈ C := C.min'_mem hCne
+      have hm_lt : m < r := by
+        simp only [C, Finset.mem_filter, Finset.mem_range] at hmC
+        exact hmC.1
+      have hm_equiv_i : supportEquivalentAt trueSupports m i.val := by
+        simp only [C, Finset.mem_filter, Finset.mem_range] at hmC
+        exact hmC.2
+      -- `m` is fresh: no smaller column is equivalent to it.
+      have hm_fresh : ∀ k, k < m → ¬ supportEquivalentAt trueSupports k m := by
+        intro k hk hke
+        have hk_equiv_i : supportEquivalentAt trueSupports k i.val :=
+          supportEquivalentAt_trans trueSupports hke hm_equiv_i
+        have hk_lt : k < r := by
+          rcases hk_equiv_i with ⟨hk_lt, _, _⟩; exact hk_lt
+        have hkC : k ∈ C := by
+          simp only [C, Finset.mem_filter, Finset.mem_range]
+          exact ⟨hk_lt, hk_equiv_i⟩
+        exact absurd (C.min'_le k hkC) (by omega)
+      have hm_rep : m ∈ L := by
+        rw [hL, mem_supportRepresentativeColumns_iff]
+        exact ⟨hm_lt, hm_fresh⟩
+      refine ⟨m, by rw [Finset.mem_coe, List.mem_toFinset]; exact hm_rep, ?_⟩
+      -- `F m = S`.
+      have hmi : supportEquivalent trueSupports ⟨m, hm_lt⟩ i :=
+        (supportEquivalentAt_iff trueSupports hm_lt i.isLt).mp
+          (by simpa using hm_equiv_i)
+      have hmS : (⟨m, hm_lt⟩ : Fin r) ∈ S := (hmi S hS).mpr hi
+      simp only [F, dif_pos hm_lt]
+      exact partOf_eq_of_mem trueSupports hcover hdisj hS hmS
+  -- Conclude via the bijection.
+  have hncard : trueSupports.ncard = L.length := by
+    rw [← hbij.image_eq, Set.InjOn.ncard_image hbij.injOn,
+      Set.ncard_coe_finset, List.toFinset_card_of_nodup hLnodup]
+  rw [hncard]
+
 namespace ForwardRecoveryInputs
 
 /-- Under an `ExpectedTrueFactors` package whose indicators are the

--- a/progress/20260612T003954Z_issue-6776.md
+++ b/progress/20260612T003954Z_issue-6776.md
@@ -1,0 +1,73 @@
+# Progress: #6776 — B-builder: trueSupports from the true factorisation
+
+## Accomplished
+
+Landed the provider-agnostic combinatorial spine of the `hpartition`
+discharge in `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+
+- `supportPartitionByMinColumn_length_eq_ncard_of_partition`: for any
+  `trueSupports : Set (Set (Fin r))` that is a genuine partition of
+  `Fin r` into nonempty parts (`hcover` — every column lies in some part,
+  `hdisj` — parts containing a common column coincide, `hne` — parts are
+  nonempty), the support-equivalence partition has exactly one class per
+  part, so `(supportPartitionByMinColumn trueSupports).length =
+  trueSupports.ncard`.
+- Supporting `private` helpers `partOf` / `partOf_mem` / `mem_partOf` /
+  `partOf_eq_of_mem` (the chosen-part map of a covered column).
+
+Proof is a `Set.BijOn` between the class representatives
+(`supportRepresentativeColumns`, nodup as a filter of `List.range r`) and
+the parts: injectivity via representative freshness
+(`supportRepresentativeColumns_min`), surjectivity by taking each part's
+least equivalent column (`Finset.min'`) as its representative. No
+`sorry`/`axiom`/`native_decide`. `lake build
+HexBerlekampZassenhausMathlib` is green (3757/3757).
+
+This is the reusable half of the B8 partition-refinement obligation
+(`hpartition`, PartitionRefinement.lean:18) consumed by
+`factorFastCoreWithBound_some_factor_zpolyIrreducible*`: it converts a
+"count the parts" obligation into a "supportPartitionByMinColumn length"
+fact, independent of where the partition comes from.
+
+## Current frontier
+
+The spine is landed. The remaining `trueSupports` builder still needs:
+
+1. **`def liftedTrueSupports core d`** — the set of representing subsets
+   `{ ↑S | ∃ f, Irreducible (toPolynomial f) ∧ f ∣ core ∧
+   RepresentsIntegerFactorAtLift core d f S }`, with the three partition
+   hypotheses (`hcover`/`hdisj`/`hne`) discharged from a
+   `LiftedFactorSubsetPartition core d Finset.univ core`
+   (`Basic.lean:2545`: `cover`, `pairwise_disjoint`,
+   `unique_up_to_associated`, plus the `HenselSubsetCorrespondenceRest`
+   exists/unique fields).
+2. **`ncard = card normalizedFactors`** — a bijection between the parts
+   and `normalizedFactors (toPolynomial core)` (associated-classes of
+   irreducible divisors), from `unique_up_to_associated` +
+   `existsUnique_liftedFactorSubset_of_henselSubsetCorrespondenceRest`.
+   Compose with the spine to get the full `hpartition` equality.
+3. **Cap wiring** — bridge `Fin d.liftedFactors.size` to
+   `Fin (projectedRowsOfLiftData f d _).factorCount` / `W.projectedRows`
+   and supply `LiftedFactorSubsetPartition` at the executable default
+   bound.
+
+## Next step
+
+Builder (1)+(2) above as a follow-up, parameterized on
+`LiftedFactorSubsetPartition` so it composes once the analytic evidence
+lands.
+
+## Blockers
+
+The *unconditional* construction at the executable cap (deliverable as
+literally stated in #6776) is gated on a **sibling analytic builder**:
+`LiftedFactorSubsetPartition core d Finset.univ core` is only constructible
+through `slowPathHenselSubstrate_of_*` /
+`liftedFactorSubsetPartition_of_choosePrimeData*`
+(`Basic.lean:17565`, `:17695`), which still require
+`InitialLiftedFactorSubsetPartitionEvidence` and the Hensel
+descent/forward-transport packages as abstract hypotheses. These are the
+other analytic builders #6771 references; the partition is not yet
+available unconditionally. The spine and the builder (1)+(2) can be
+written and landed *parameterized on the partition* before that evidence
+lands.


### PR DESCRIPTION
This PR adds the provider-agnostic combinatorial spine of the B8 partition-refinement obligation in `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`: `supportPartitionByMinColumn_length_eq_ncard_of_partition` proves that when `trueSupports : Set (Set (Fin r))` is a genuine partition of `Fin r` into nonempty parts (every column lies in some part, parts sharing a column coincide, parts nonempty), the support-equivalence partition has exactly one class per part, so `(supportPartitionByMinColumn trueSupports).length = trueSupports.ncard`. This converts the "count the parts" half of the fast-core `hpartition` hypothesis (consumed by `factorFastCoreWithBound_some_factor_zpolyIrreducible`) into a `supportPartitionByMinColumn` length fact, independent of how the partition is produced. The proof is a `Set.BijOn` between the class representatives and the parts.

Partial progress on #6776: this lands the reusable combinatorial half. The remaining `trueSupports` builder (the `liftedTrueSupports` definition from `LiftedFactorSubsetPartition`, the bijection from the parts to `normalizedFactors`, and the executable-cap wiring) is left for a follow-up and is partly gated on the sibling lifted-partition analytic evidence; see the issue comment and `progress/20260612T003954Z_issue-6776.md`.

🤖 Prepared with Claude Code