### PR TITLE
feat: modP unit-invariance and pairwise-disjointness for the lifted cover bridge

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hex-lean-mathlib-boundary
+description: Gotchas for the Mathlib-free/Mathlib boundary in HexBerlekampZassenhausMathlib and similar *Mathlib Lean layers (ZMod64, FpPoly, DensePoly, ZPoly). Read before proving lemmas that mix the executable types with Mathlib Polynomial / ZMod algebra.
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Mathlib-free / Mathlib boundary in the hex Lean layers
+
+The executable types (`Hex.ZMod64 p`, `Hex.FpPoly p = Hex.DensePoly (ZMod64 p)`,
+`Hex.ZPoly = Hex.DensePoly Int`) carry **only `Lean.Grind` ring instances and a
+custom `Dvd`** — *not* Mathlib's `CommRing`/`Field`/`Monoid`/`AddGroup`
+typeclasses. Mathlib homomorphism lemmas therefore fail to synthesize instances
+on these types. Do arithmetic with `grind`, and cross to the Mathlib
+`Polynomial (ZMod p)` / `ZMod p` side through the project's bridges.
+
+## Concrete rules
+
+- **`grind`, not `ring`, for `ZMod64`/`FpPoly` arithmetic.** Ring lemmas
+  (`mul_one`, `neg_add_cancel`, `ring`) need Mathlib instances these types lack.
+  `grind` uses the `Lean.Grind.CommRing` instance; prime-inverse facts
+  (`ZMod64.inv_mul_eq_one_of_prime`, `mul_inv_eq_one_of_prime`) are `@[grind]`.
+- **No `map_neg` / `map_one` / `map_zero` / `map_dvd` on `ZMod64`/`FpPoly`.**
+  These need `ZeroHomClass`/`AddMonoidHomClass`/`Monoid` that the executable
+  types don't have. To compute e.g. `toZMod (-1) = -1`: prove `(-1)+1 = 0` in
+  `ZMod64` by `grind`, push through `toZMod_add`/`toZMod_one`/`toZMod_zero`
+  (the real bridge lemmas), and finish in `ZMod p` with
+  `eq_neg_of_add_eq_zero_left`.
+- **`FpPoly`/`DensePoly` `∣` is custom** (`a ∣ b := ∃ r, b = a * r`), so
+  `map_dvd` does not apply and `dvd_trans` is replaced by `fpPoly_dvd_trans`.
+  Transport divisibility to Mathlib by destructuring and re-multiplying:
+  `obtain ⟨r, hr⟩ := h; ⟨toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩`.
+  (`HexBerlekampZassenhausMathlib/Basic.lean` exposes `toMathlibPolynomial_dvd`
+  and `self_dvd_monicModPImage` for exactly this.)
+- **`ZMod64` zero has two representations** (`Zero.zero` vs `OfNat 0`); a `rw`
+  on `toZMod 0` / `(0 : FpPoly).coeff n` may report "did not find pattern" or
+  leave an unclosed `0 = 0`. Close with `exact`/`show` (defeq-tolerant), not
+  `rw`/`simp`.
+- **`HexPolyMathlib.toPolynomial` vs `HexPolyZMathlib.toPolynomial`:**
+  `HexPolyZMathlib.toPolynomial` is an `abbrev` specializing the general
+  `HexPolyMathlib.toPolynomial` to `R = Int`. They are defeq but **not
+  syntactically equal**, so `rw [hk]` fails when `hk` was produced by a
+  `HexPolyMathlib`-namespace lemma against a `HexPolyZMathlib` goal. Bind the
+  result with an explicit `HexPolyZMathlib.toPolynomial …` type ascription
+  first, then `obtain`/`rw`.
+
+## Signature gotcha
+
+A hypothesis whose type mentions `toMathlibPolynomial`/`monicModPImage`/`modP`
+at `primeData.p` is elaborated **before** any `letI := primeData.bounds`, so an
+implicit `[Bounds primeData.p]` cannot be synthesized and the type silently
+becomes `sorry`. Write the instance explicitly in such signatures:
+`@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds (…)`.
+
+## Pre-existing sorries
+
+`HexBerlekampMathlib/Basic.lean` and `HexHenselMathlib/Correctness.lean` ship
+`sorry`s (the `toMathlibPolynomial` coeff bridge etc.). Those warnings are not
+from your file; building on them is the established project state. Only check
+that *your added lines* are `sorry`/`axiom`/`native_decide`-free
+(`git diff -U0 <file> | grep '^+' | grep -iE 'sorry|axiom|native_decide'`).

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1839,6 +1839,193 @@ theorem modPFactor_irreducible_of_modPSubsetPartition
         (modPFactor primeData i)) :=
   h.factors_irreducible i
 
+/-- The project-local primality predicate implies Mathlib's `Nat.Prime`. -/
+theorem natPrime_of_hexNatPrime {p : Nat} (hp : Hex.Nat.Prime p) :
+    _root_.Nat.Prime p := by
+  refine _root_.Nat.prime_def_lt.mpr ⟨hp.two_le, ?_⟩
+  intro m hmlt hmdvd
+  rcases hp.2 m hmdvd with h | h
+  · exact h
+  · exact absurd h (Nat.ne_of_lt hmlt)
+
+/-- Multiplicative inverse cancellation modulo a prime: `(c * a)⁻¹ * c = a⁻¹`
+for nonzero residues, the field identity that lets `monicModPImage` absorb a
+unit scalar. -/
+private theorem zmod64_inv_mul_left_cancel {p : Nat} [Hex.ZMod64.Bounds p]
+    (hprime : Hex.Nat.Prime p) {a c : Hex.ZMod64 p} (ha : a ≠ 0) (hc : c ≠ 0) :
+    (c * a)⁻¹ * c = a⁻¹ := by
+  have hca : c * a ≠ 0 := by
+    intro h
+    rcases Hex.ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hprime h with h1 | h2
+    · exact hc h1
+    · exact ha h2
+  have h1 : (c * a)⁻¹ * (c * a) = 1 :=
+    Hex.ZMod64.inv_mul_eq_one_of_prime hprime hca
+  have h2 : a * a⁻¹ = 1 := Hex.ZMod64.mul_inv_eq_one_of_prime hprime ha
+  have hxa : ((c * a)⁻¹ * c) * a = 1 := by
+    have e : ((c * a)⁻¹ * c) * a = (c * a)⁻¹ * (c * a) := by grind
+    rw [e]; exact h1
+  calc (c * a)⁻¹ * c
+      = ((c * a)⁻¹ * c) * (a * a⁻¹) := by rw [h2]; grind
+    _ = (((c * a)⁻¹ * c) * a) * a⁻¹ := by grind
+    _ = 1 * a⁻¹ := by rw [hxa]
+    _ = a⁻¹ := by grind
+
+/-- **Unit-invariance of `monicModPImage`.** Scaling a modular polynomial by a
+nonzero residue (a unit modulo a prime) leaves its monic image unchanged: the
+leading-coefficient normalisation divides the unit scalar back out. -/
+theorem monicModPImage_scale {p : Nat} [Hex.ZMod64.Bounds p]
+    (hprime : Hex.Nat.Prime p) {c : Hex.ZMod64 p} (hc : c ≠ 0) (f : Hex.FpPoly p) :
+    monicModPImage (Hex.DensePoly.scale c f) = monicModPImage f := by
+  letI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hprime
+  cases hf : f.isZero with
+  | true =>
+    have hf_size : f.size = 0 := by
+      by_contra h
+      have hfalse : f.isZero = false :=
+        (Hex.DensePoly.isZero_eq_false_iff f).mpr (Nat.pos_of_ne_zero h)
+      rw [hfalse] at hf
+      exact Bool.noConfusion hf
+    have hsf_size : (Hex.DensePoly.scale c f).size = 0 := by
+      have := Hex.FpPoly.scale_size_le c f; omega
+    have hsf : (Hex.DensePoly.scale c f).isZero = true := by
+      by_contra h
+      rw [Bool.not_eq_true] at h
+      have := (Hex.DensePoly.isZero_eq_false_iff _).mp h; omega
+    unfold monicModPImage
+    simp [hf, hsf]
+  | false =>
+    have hf_pos : 0 < f.size := (Hex.DensePoly.isZero_eq_false_iff f).mp hf
+    have hf_size : f.size ≠ 0 := by omega
+    have hsf_size : (Hex.DensePoly.scale c f).size = f.size :=
+      Hex.FpPoly.scale_size_eq_of_ne_zero hc f
+    have hsf : (Hex.DensePoly.scale c f).isZero = false :=
+      (Hex.DensePoly.isZero_eq_false_iff _).mpr (by omega)
+    unfold monicModPImage
+    simp only [hf, hsf, Bool.false_eq_true, ↓reduceIte]
+    rw [Hex.FpPoly.leadingCoeff_scale_of_ne_zero_of_nonzero hc f hf_size,
+      Hex.FpPoly.scale_scale,
+      zmod64_inv_mul_left_cancel hprime
+        (fpPoly_leadingCoeff_ne_zero_of_size_pos f hf_pos) hc]
+
+/-- Transport of a `-1` integer scaling to `Polynomial ℤ` negation. -/
+private theorem toPolynomial_scale_neg_one (f : Hex.ZPoly) :
+    HexPolyZMathlib.toPolynomial (Hex.DensePoly.scale (-1 : Int) f) =
+      -HexPolyZMathlib.toPolynomial f := by
+  ext n
+  have hzero_mul : (-1 : Int) * (0 : Int) = 0 := by simp
+  rw [HexPolyZMathlib.coeff_toPolynomial,
+    Hex.DensePoly.coeff_scale (-1 : Int) f n hzero_mul,
+    Polynomial.coeff_neg, HexPolyZMathlib.coeff_toPolynomial]
+  ring
+
+/-- The `ZMod p` image of the residue `-1` is `-1`. Computed through the
+ring-hom bridge `toZMod`, keeping `ZMod64` arithmetic on the `grind` side. -/
+private theorem toZMod_neg_one {p : Nat} [Hex.ZMod64.Bounds p] :
+    HexModArithMathlib.ZMod64.toZMod (-1 : Hex.ZMod64 p) = (-1 : ZMod p) := by
+  have hzm : (-1 : Hex.ZMod64 p) + 1 = 0 := by grind
+  have h0 : HexModArithMathlib.ZMod64.toZMod ((-1 : Hex.ZMod64 p) + 1) = 0 := by
+    rw [hzm, HexModArithMathlib.ZMod64.toZMod_zero]
+  rw [HexModArithMathlib.ZMod64.toZMod_add, HexModArithMathlib.ZMod64.toZMod_one] at h0
+  exact eq_neg_of_add_eq_zero_left h0
+
+/-- Reduction modulo `p` commutes with `-1` scaling: it lands on scaling by the
+residue `-1`. Proved through the `Polynomial (ZMod p)` bridge. -/
+private theorem modP_scale_neg_one {p : Nat} [Hex.ZMod64.Bounds p] (f : Hex.ZPoly) :
+    Hex.ZPoly.modP p (Hex.DensePoly.scale (-1 : Int) f) =
+      Hex.DensePoly.scale (-1 : Hex.ZMod64 p) (Hex.ZPoly.modP p f) := by
+  apply HexBerlekampMathlib.fpPolyEquiv.injective
+  change
+    HexBerlekampMathlib.toMathlibPolynomial
+        (Hex.ZPoly.modP p (Hex.DensePoly.scale (-1 : Int) f)) =
+      HexBerlekampMathlib.toMathlibPolynomial
+        (Hex.DensePoly.scale (-1 : Hex.ZMod64 p) (Hex.ZPoly.modP p f))
+  rw [toMathlibPolynomial_modP_eq_map_intCast_zmod, toPolynomial_scale_neg_one,
+    Polynomial.map_neg, toMathlibPolynomial_scale,
+    toMathlibPolynomial_modP_eq_map_intCast_zmod, toZMod_neg_one,
+    Polynomial.C_neg, Polynomial.C_1]
+  ring
+
+/-- `-1` is a nonzero residue modulo a prime. -/
+private theorem neg_one_ne_zero_zmod {p : Nat} [Hex.ZMod64.Bounds p]
+    (hprime : Hex.Nat.Prime p) : (-1 : Hex.ZMod64 p) ≠ 0 := by
+  haveI : Fact (_root_.Nat.Prime p) := ⟨natPrime_of_hexNatPrime hprime⟩
+  intro h
+  have hz : HexModArithMathlib.ZMod64.toZMod (-1 : Hex.ZMod64 p) =
+      HexModArithMathlib.ZMod64.toZMod (0 : Hex.ZMod64 p) := by rw [h]
+  rw [HexModArithMathlib.ZMod64.toZMod_zero, toZMod_neg_one] at hz
+  exact (neg_ne_zero.mpr one_ne_zero) hz
+
+/-- An `Associated` pair in `Polynomial ℤ` differs by the unit `±1`, so the
+executable integer polynomials agree up to the canonical `-1` scaling. -/
+private theorem zpoly_eq_or_eq_scale_neg_one_of_associated {f g : Hex.ZPoly}
+    (hassoc :
+      Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
+    g = f ∨ g = Hex.DensePoly.scale (-1 : Int) f := by
+  obtain ⟨u, hu⟩ := hassoc
+  obtain ⟨c, hc_unit, hcu⟩ := Polynomial.isUnit_iff.mp u.isUnit
+  rcases Int.isUnit_iff.mp hc_unit with hc1 | hcneg1
+  · left
+    apply HexPolyZMathlib.equiv.injective
+    show HexPolyZMathlib.toPolynomial g = HexPolyZMathlib.toPolynomial f
+    rw [← hu, ← hcu, hc1, Polynomial.C_1, mul_one]
+  · right
+    apply HexPolyZMathlib.equiv.injective
+    show HexPolyZMathlib.toPolynomial g =
+      HexPolyZMathlib.toPolynomial (Hex.DensePoly.scale (-1 : Int) f)
+    rw [toPolynomial_scale_neg_one, ← hu, ← hcu, hcneg1, Polynomial.C_neg, Polynomial.C_1]
+    ring
+
+/-- **Associated factors share a monic modular image.** If two integer factors
+are associated in `Polynomial ℤ`, their reductions modulo `p` have the same
+monic image, because `monicModPImage` absorbs the unit `±1`. -/
+theorem monicModPImage_modP_eq_of_associated {p : Nat} [Hex.ZMod64.Bounds p]
+    (hprime : Hex.Nat.Prime p) {f g : Hex.ZPoly}
+    (hassoc :
+      Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
+    monicModPImage (Hex.ZPoly.modP p f) = monicModPImage (Hex.ZPoly.modP p g) := by
+  rcases zpoly_eq_or_eq_scale_neg_one_of_associated hassoc with hg | hg
+  · rw [hg]
+  · rw [hg, modP_scale_neg_one]
+    exact (monicModPImage_scale hprime (neg_one_ne_zero_zmod hprime)
+      (Hex.ZPoly.modP p f)).symm
+
+/-- `RepresentsIntegerFactorModP` depends only on the `Associated` class of the
+integer factor in `Polynomial ℤ`: a representing subset for `f` also represents
+any associate `g`. -/
+theorem representsIntegerFactorModP_of_associated
+    {primeData : Hex.PrimeChoiceData} (hprime : Hex.Nat.Prime primeData.p)
+    {f g : Hex.ZPoly} {S : ModPFactorSubset primeData}
+    (hassoc :
+      Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g))
+    (hf : RepresentsIntegerFactorModP primeData f S) :
+    RepresentsIntegerFactorModP primeData g S := by
+  letI := primeData.bounds
+  unfold RepresentsIntegerFactorModP at hf ⊢
+  rw [hf]
+  exact monicModPImage_modP_eq_of_associated hprime hassoc
+
+/-- **modP uniqueness up to association.** Associated irreducible integer
+divisors of `core` have the *same* representing subset of modular factors, not
+merely equal ones. Combines unit-invariance of `monicModPImage` with the
+package's `unique_subset` projection. -/
+theorem unique_modPFactorSubset_up_to_associated
+    {core : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {admissiblePrime squareFreeReduction : Prop}
+    (hprime : Hex.Nat.Prime primeData.p)
+    (h :
+      ModPSubsetPartitionHypotheses core primeData admissiblePrime squareFreeReduction)
+    {f g : Hex.ZPoly} {S T : ModPFactorSubset primeData}
+    (hg_irr : Irreducible (HexPolyZMathlib.toPolynomial g))
+    (hg_dvd : g ∣ core)
+    (hS : RepresentsIntegerFactorModP primeData f S)
+    (hT : RepresentsIntegerFactorModP primeData g T)
+    (hassoc :
+      Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
+    S = T :=
+  h.unique_subset hg_irr hg_dvd
+    (representsIntegerFactorModP_of_associated hprime hassoc hS) hT
+
 /-- Index type for the local factors stored in executable Hensel lift data. -/
 abbrev LiftedFactorIndex (d : Hex.LiftData) : Type :=
   Fin d.liftedFactors.size

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -2026,6 +2026,141 @@ theorem unique_modPFactorSubset_up_to_associated
   h.unique_subset hg_irr hg_dvd
     (representsIntegerFactorModP_of_associated hprime hassoc hS) hT
 
+/-- Transport executable `FpPoly` divisibility (`∃ r, b = a * r`) to Mathlib
+divisibility across `toMathlibPolynomial`. -/
+private theorem toMathlibPolynomial_dvd {p : Nat} [Hex.ZMod64.Bounds p]
+    {a b : Hex.FpPoly p} (h : a ∣ b) :
+    HexBerlekampMathlib.toMathlibPolynomial a ∣
+      HexBerlekampMathlib.toMathlibPolynomial b := by
+  obtain ⟨r, hr⟩ := h
+  exact ⟨HexBerlekampMathlib.toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩
+
+/-- A nonzero modular polynomial divides its own monic image. -/
+private theorem self_dvd_monicModPImage {p : Nat} [Hex.ZMod64.Bounds p]
+    {h : Hex.FpPoly p} (hh : h.isZero = false) :
+    h ∣ monicModPImage h := by
+  unfold monicModPImage
+  simp only [hh, Bool.false_eq_true, ↓reduceIte]
+  refine ⟨Hex.DensePoly.C (Hex.DensePoly.leadingCoeff h)⁻¹, ?_⟩
+  calc Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff h)⁻¹ h
+      = Hex.DensePoly.C (Hex.DensePoly.leadingCoeff h)⁻¹ * h := by
+        rw [Hex.FpPoly.C_mul_eq_scale]
+    _ = h * Hex.DensePoly.C (Hex.DensePoly.leadingCoeff h)⁻¹ :=
+        Hex.DensePoly.mul_comm_poly _ _
+
+/-- **modP pairwise-disjointness.** Non-associated irreducible integer divisors of
+`core` are represented by disjoint subsets of the modular factors. The genuine
+square-freeness of the modular reduction is threaded as the explicit hypothesis
+`hsqfree`; if two representing subsets shared an index, that modular factor would
+square-divide the (square-free) modular core, an impossibility. -/
+theorem modPFactorSubset_disjoint_of_not_associated
+    {core : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {admissiblePrime squareFreeReduction : Prop}
+    (hprime : Hex.Nat.Prime primeData.p)
+    (hpart :
+      ModPSubsetPartitionHypotheses core primeData admissiblePrime squareFreeReduction)
+    (hcore_modP_nz :
+      (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false)
+    (hsqfree :
+      Squarefree
+        (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
+          (@monicModPImage primeData.p primeData.bounds
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core))))
+    {f g : Hex.ZPoly} {S T : ModPFactorSubset primeData}
+    (hf_irr : Irreducible (HexPolyZMathlib.toPolynomial f)) (hf_dvd : f ∣ core)
+    (hg_irr : Irreducible (HexPolyZMathlib.toPolynomial g)) (hg_dvd : g ∣ core)
+    (hS : RepresentsIntegerFactorModP primeData f S)
+    (hT : RepresentsIntegerFactorModP primeData g T)
+    (hnotassoc :
+      ¬ Associated (HexPolyZMathlib.toPolynomial f) (HexPolyZMathlib.toPolynomial g)) :
+    Disjoint S T := by
+  classical
+  letI := primeData.bounds
+  set p := primeData.p with hp_def
+  -- `modP f`, `modP g` are nonzero because they divide the nonzero `modP core`.
+  have hf_modP_nz : (Hex.ZPoly.modP p f).isZero = false :=
+    fpPoly_isZero_false_of_dvd_of_isZero_false (modP_dvd_modP_of_dvd p hf_dvd) hcore_modP_nz
+  have hg_modP_nz : (Hex.ZPoly.modP p g).isZero = false :=
+    fpPoly_isZero_false_of_dvd_of_isZero_false (modP_dvd_modP_of_dvd p hg_dvd) hcore_modP_nz
+  -- The representing products transport to the monic modular images.
+  have hSeq : modPFactorProduct primeData S =
+      @monicModPImage p primeData.bounds (Hex.ZPoly.modP p f) := hS
+  have hTeq : modPFactorProduct primeData T =
+      @monicModPImage p primeData.bounds (Hex.ZPoly.modP p g) := hT
+  have hAf :
+      (∏ j ∈ S, HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData j)) =
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p f)) := by
+    rw [← toMathlibPolynomial_modPFactorProduct, hSeq]
+  have hAg :
+      (∏ j ∈ T, HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData j)) =
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p g)) := by
+    rw [← toMathlibPolynomial_modPFactorProduct, hTeq]
+  -- `toPoly f * toPoly g ∣ toPoly core` (distinct primes both divide the core).
+  have hfg_zdvd :
+      HexPolyZMathlib.toPolynomial f * HexPolyZMathlib.toPolynomial g ∣
+        HexPolyZMathlib.toPolynomial core := by
+    have hf_zdvd : HexPolyZMathlib.toPolynomial f ∣ HexPolyZMathlib.toPolynomial core :=
+      HexPolyMathlib.toPolynomial_dvd hf_dvd
+    have hg_zdvd : HexPolyZMathlib.toPolynomial g ∣ HexPolyZMathlib.toPolynomial core :=
+      HexPolyMathlib.toPolynomial_dvd hg_dvd
+    obtain ⟨k, hk⟩ := hg_zdvd
+    have hf_dvd_gk :
+        HexPolyZMathlib.toPolynomial f ∣ HexPolyZMathlib.toPolynomial g * k := by
+      rw [← hk]; exact hf_zdvd
+    have hf_ndvd_g :
+        ¬ HexPolyZMathlib.toPolynomial f ∣ HexPolyZMathlib.toPolynomial g := by
+      intro hd
+      exact hnotassoc (hf_irr.associated_of_dvd hg_irr hd)
+    rcases hf_irr.prime.dvd_or_dvd hf_dvd_gk with hg' | hk'
+    · exact absurd hg' hf_ndvd_g
+    · obtain ⟨m, hm⟩ := hk'
+      exact ⟨m, by rw [hk, hm]; ring⟩
+  -- Push the divisibility through `Polynomial.map (Int.castRingHom (ZMod p))`.
+  have hfg_modP :
+      HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p f) *
+          HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p g) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p core) := by
+    have hmap := Polynomial.map_dvd (Int.castRingHom (ZMod p)) hfg_zdvd
+    rw [Polynomial.map_mul, ← toMathlibPolynomial_modP_eq_map_intCast_zmod,
+      ← toMathlibPolynomial_modP_eq_map_intCast_zmod,
+      ← toMathlibPolynomial_modP_eq_map_intCast_zmod] at hmap
+    exact hmap
+  -- Assemble: the product of the two monic images divides the square-free core.
+  have hMf_dvd :
+      HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p f)) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p f) :=
+    toMathlibPolynomial_dvd (monicModPImage_dvd_self_of_ne_zero hprime hf_modP_nz)
+  have hMg_dvd :
+      HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p g)) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p g) :=
+    toMathlibPolynomial_dvd (monicModPImage_dvd_self_of_ne_zero hprime hg_modP_nz)
+  have hcore_dvd_M :
+      HexBerlekampMathlib.toMathlibPolynomial (Hex.ZPoly.modP p core) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p core)) :=
+    toMathlibPolynomial_dvd (self_dvd_monicModPImage hcore_modP_nz)
+  have hMfMg_dvd_M :
+      HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p f)) *
+          HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p g)) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p core)) :=
+    ((mul_dvd_mul hMf_dvd hMg_dvd).trans hfg_modP).trans hcore_dvd_M
+  -- A shared index would force a square factor of the square-free core.
+  rw [Finset.disjoint_left]
+  intro i hiS hiT
+  have h1 :
+      HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p f)) := by
+    rw [← hAf]; exact Finset.dvd_prod_of_mem _ hiS
+  have h2 :
+      HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p g)) := by
+    rw [← hAg]; exact Finset.dvd_prod_of_mem _ hiT
+  have hsqM :
+      HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) *
+          HexBerlekampMathlib.toMathlibPolynomial (modPFactor primeData i) ∣
+        HexBerlekampMathlib.toMathlibPolynomial (monicModPImage (Hex.ZPoly.modP p core)) :=
+    (mul_dvd_mul h1 h2).trans hMfMg_dvd_M
+  exact (hpart.factors_irreducible i).not_isUnit (hsqfree _ hsqM)
+
 /-- Index type for the local factors stored in executable Hensel lift data. -/
 abbrev LiftedFactorIndex (d : Hex.LiftData) : Type :=
   Fin d.liftedFactors.size

--- a/progress/20260612T081918Z_issue-6792.md
+++ b/progress/20260612T081918Z_issue-6792.md
@@ -1,0 +1,72 @@
+# Progress: #6792 — modP-layer cover / pairwise-disjoint / unit-invariance
+
+Session worked the modP-layer content of the lifted cover bridge (#6773).
+Three deliverables; **two landed and verified**, one decomposed.
+
+## Accomplished
+
+**Deliverable 1 — `monicModPImage` unit-invariance + uniqueness up to
+association** (commit b510a6de). In `HexBerlekampZassenhausMathlib/Basic.lean`,
+after the `ModPSubsetPartitionHypotheses` projections:
+
+- `natPrime_of_hexNatPrime` — `Hex.Nat.Prime → _root_.Nat.Prime` converter
+  (was inline-duplicated at two call sites).
+- `monicModPImage_scale` — for prime modulus and nonzero `c`,
+  `monicModPImage (scale c f) = monicModPImage f`. The leading-coeff
+  normalisation absorbs the unit; the field identity `(c*a)⁻¹*c = a⁻¹`
+  is proved by `zmod64_inv_mul_left_cancel` (grind over `Lean.Grind.CommRing`).
+- `monicModPImage_modP_eq_of_associated` — associated integer factors share a
+  monic modular image. Routed through `zpoly_eq_or_eq_scale_neg_one_of_associated`
+  (units of `ℤ[X]` are `±1`) and `modP_scale_neg_one` (reduction commutes with
+  `-1` scaling, via the `Polynomial (ZMod p)` bridge).
+- `representsIntegerFactorModP_of_associated`,
+  `unique_modPFactorSubset_up_to_associated` — upgrade the package's
+  `unique_subset` (same factor) to `S = T` for *associated* factors.
+
+**Deliverable 3 — modP pairwise-disjointness** (commit 8a808116).
+`modPFactorSubset_disjoint_of_not_associated`: non-associated irreducible
+integer divisors `f`, `g` of `core` get disjoint representing subsets. A
+shared index `i` makes the modular factor `fM i` square-divide the
+square-free modular core (`fM i ∣ ∏_S`, `fM i ∣ ∏_T`, `∏_S·∏_T ∣ modP core`
+via `f·g ∣ core`), contradicting `hsqfree`. Helpers `toMathlibPolynomial_dvd`
+(custom `FpPoly` `∣` → Mathlib `∣` via `toMathlibPolynomial_mul`) and
+`self_dvd_monicModPImage`. Genuine square-freeness and `(modP core).isZero =
+false` are threaded as explicit hypotheses (both derivable at the
+`choosePrimeData?` call site), per the directive's instruction to add the
+concrete square-free hypothesis the argument consumes.
+
+`lake build HexBerlekampZassenhausMathlib` succeeds; no `sorry`/`axiom`/
+`native_decide`/`TODO` on added lines. (Pre-existing `sorry`s live in the
+`HexBerlekampMathlib`/`HexHenselMathlib` dependencies, untouched.)
+
+## Current frontier
+
+Deliverable 2 (modP **cover**: every modP index lies in the subset
+representing some irreducible integer divisor of `core`) is decomposed to a
+follow-up issue. The proof strategy is settled (see Next step) but it is the
+heaviest of the three — `UniqueFactorizationMonoid.normalizedFactors` product
+over `ℤ[X]`, `Polynomial.map` of a multiset product, `Prime.exists_mem_multiset_dvd`,
+then a monic-associated-equal + index-injectivity step — and was scoped out to
+keep this PR's two verified deliverables landable now.
+
+## Next step
+
+Land deliverable 2 (`modPFactor_index_cover`). Strategy:
+1. `fM i ∣ M` where `M = toMathlibPolynomial (monicModPImage (modP core))`
+   (full product `∏ univ fM = M`), so `fM i ∣ (toPoly core).map ι` via
+   `monicModPImage_dvd_self`/`toMathlibPolynomial_modP_eq_map_intCast_zmod`.
+2. `Associated (toPoly core) (∏ normalizedFactors)` → map by `ι` →
+   `fM i ∣ ∏ (g.map ι)`; `fM i` prime ⇒ `∃ g ∈ normalizedFactors, fM i ∣ g.map ι`.
+3. `g' := ofPolynomial g` is an irreducible integer divisor of `core`;
+   `hpart.exists_subset` gives `S` representing `g'`.
+4. `fM i ∣ toMathlibPolynomial (modP g') ∣ ∏_S fM` (via `self_dvd_monicModPImage`),
+   `fM i` prime ⇒ `∃ k ∈ S, fM i ∣ fM k`; monic + irreducible ⇒ `fM i = fM k`
+   ⇒ `i = k ∈ S` (index injectivity).
+Reuse `toMathlibPolynomial_dvd`, `self_dvd_monicModPImage` from this PR. Thread
+the full-product, per-factor-monic, and index-injectivity facts as explicit
+hypotheses (all available at the `choosePrimeData?` boundary, mirroring how
+deliverables 1/3 are stated).
+
+## Blockers
+
+None. Deliverable 2 is tractable; it was deferred for budget, not blocked.


### PR DESCRIPTION
This PR lands the modP-layer unit-invariance and pairwise-disjointness content of the lifted cover bridge (#6792): `monicModPImage` absorbs a nonzero residue scalar, so associated integer factors share a monic modular image, upgrading the partition package's `unique_subset` to `unique_modPFactorSubset_up_to_associated` (`S = T` for associated factors); and `modPFactorSubset_disjoint_of_not_associated` shows non-associated irreducible integer divisors of `core` get disjoint representing subsets, since a shared modular factor would square-divide the square-free modular core. Both derive from prime-divides-product and square-free coprimality rather than an assumed partition; genuine square-freeness and modular-core nonvanishing are threaded as explicit hypotheses, both derivable at the `choosePrimeData?` boundary. Reusable helpers `toMathlibPolynomial_dvd`, `self_dvd_monicModPImage`, and `natPrime_of_hexNatPrime` are added alongside.

This is a partial landing of #6792: the third deliverable, the modP index-cover, is decomposed to #6796 (https://github.com/kim-em/hex/issues/6796) with the settled proof strategy, since it is the heaviest of the three and builds on the helpers introduced here.

🤖 Prepared with Claude Code