### PR TITLE
refactor: remove the packed-certificate word-scale regime gate

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -71,13 +71,6 @@ def maxAbs (M : Matrix Int n m) : Nat :=
 def packWidth (M : Matrix Int n n) (A C : Matrix Int n m) : Nat :=
   (n * maxAbs M * maxAbs A + maxAbs C).log2 + 2
 
-/-- Every entry fits in a machine word. Comparison-only scan (no `natAbs`
-allocation) with short-circuit, so matrices with wide entries bail out at the
-first wide entry. -/
-private def wordScale (M : Matrix Int n m) : Bool :=
-  M.toList.all fun row => row.toList.all fun x =>
-    -(2 ^ 62 : Int) < x && x < 2 ^ 62
-
 /-- Packed product-equality certificate: decides `M * A = C` without forming
 the product. Each row of `A` and of `C` is packed into one integer in
 balanced base `2^K` at the width `packWidth M A C`, and row `i` of the
@@ -85,24 +78,16 @@ balanced base `2^K` at the width `packWidth M A C`, and row `i` of the
 `Σ_l M[i][l] · packA[l]`: `n` big-integer dot products in place of the
 `n · m` entry dot products of a materialized `Matrix.mul`.
 
-The packed evaluation pays only when the multiplications are big-by-small,
-i.e. when all entries involved are word-scale; on wide entries the packed
-dot products cost the same bit operations as the materialized product while
-the bound scan and the Horner repacking of wide rows add overhead. The
-certificate therefore gates on `wordScale` (a short-circuiting comparison
-scan, so a wide input bails out at its first wide entry) plus a dimension
-floor (below it the fixed cost of the bound scan and packing exceeds the
-whole sub-millisecond comparison) and falls back to the materialized
-comparison otherwise; both branches decide exactly `M * A = C`
-(`mulEqCert_iff`). -/
+When the entries are word-scale the multiplications are big-by-small and the
+same-lattice clause costs `O(n²)` big-by-small multiplications; on wide
+entries the packed dot products cost the same bit operations as the
+materialized product. Either way the single packed comparison decides exactly
+`M * A = C` (`mulEqCert_iff`). -/
 def mulEqCert (M : Matrix Int n n) (A C : Matrix Int n m) : Bool :=
-  if 32 ≤ n && wordScale M && wordScale A && wordScale C then
-    let K := packWidth M A C
-    let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
-    (List.finRange n).all fun i =>
-      Vector.dotProduct (row M i) packs == packRow K (row C i)
-  else
-    M * A == C
+  let K := packWidth M A C
+  let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
+  (List.finRange n).all fun i =>
+    Vector.dotProduct (row M i) packs == packRow K (row C i)
 
 private theorem foldl_max_le_init {α : Type} (f : α → Nat) (l : List α) (acc : Nat) :
     acc ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
@@ -345,9 +330,6 @@ complete (`M * A = C` implies `= true`, by congruence through
 theorem mulEqCert_iff {M : Matrix Int n n} {A C : Matrix Int n m} :
     mulEqCert M A C = true ↔ M * A = C := by
   unfold mulEqCert
-  split
-  case isFalse => exact beq_iff_eq
-  case isTrue _ =>
   simp only [packWidth, List.all_eq_true, beq_iff_eq, dotProduct_packRow]
   constructor
   · intro h

--- a/progress/20260612T050000Z_issue-6782.md
+++ b/progress/20260612T050000Z_issue-6782.md
@@ -1,0 +1,59 @@
+# Progress: #6782 — remove the packed-certificate word-scale regime gate
+
+## Outcome: go/no-go passes, PR opened
+
+The gate is removed and `mulEqCert` packs unconditionally. Correctness is
+fully verified and the paired carica measurement is within the blessed
+bounds, so this lands.
+
+## Implementation
+
+Deleted the private `wordScale` predicate and the `if 32 ≤ n && wordScale …`
+gate in `HexLLL/Basic.lean` so the packed product-equality evaluation runs
+unconditionally; collapsed `mulEqCert_iff` to the single packed branch
+(dropped the `split` and the `isFalse`/materialized-comparison case),
+statement unchanged. `sameLatticeCert`, `certCheck`, `certCheck_sound`, and
+acceptance unchanged. The SPEC §Certified external dispatch amendment landed
+separately in #6789 (the directive's timeless SPEC-first deliverable), so
+this PR carries only the implementation plus the corrected stale prose in
+reports/hex-lll-performance.md.
+
+## Verification
+
+`lake build HexLLL HexLLLMathlib` clean; with the fplll FFI provider on
+carica, `lake exe hexlll_bench verify` **153/153** — observed hashes
+bit-identical before/after, rejection 0/22, interval tally untouched.
+`check_dag.py`, `git diff --check`, forbidden-token grep all clean. Codex
+second opinion: no correctness issue with the proof collapse, the packed-only
+def, or the n=0/m=0 edge cases; one SPEC wording precision tweak applied.
+
+## Measurement (the saga)
+
+before `f07ab141` vs after `80fa63c3`, checker-only medians. The wide-entry
+harsh-cubic mid rungs (n=35/40/45) carry a small real overhead (bound scan +
+Horner repacking). Establishing its size needed care because carica was
+intermittently contended (the #6781 steered-dispatch session, then a
+HexBerlekampZassenhaus build) and back-to-back sweeps are noise-dominated at
+the 3 % scale — their flagged set reshuffled between runs (n=40/45 flipped
+sign). The trustworthy order-swapped interleaved A/B (alternating which
+binary runs first each round) settles it: **n=35 +1.6 %, n=40 +1.8 %,
+n=45 +1.4 %**, all under the 3 % bound, sub-0.3 ms absolute. Word-scale
+random-bounded rungs and the large wide-entry rungs (n=50–65) are neutral.
+
+An earlier "confirmed breach" call (since corrected on the issue) was built
+on drift/contention-inflated back-to-back numbers plus one high interleaved
+run on n=40; the redo Kim asked for overturned it.
+
+## Coordination issue surfaced
+
+carica has no bench-host lock; multiple sessions/builds contended with these
+paired sweeps. Flagged on the issue — a lock would make 3 % go/no-go
+measurements reliable instead of forcing the interleaved workaround.
+
+## Next step
+
+PR open; watch CI and merge conflicts.
+
+## Blockers
+
+None.

--- a/reports/hex-lll-performance.md
+++ b/reports/hex-lll-performance.md
@@ -370,9 +370,10 @@ fixed-precision enclosure pass (which costs `O(n³)` on fixed-width
 mantissas, independent of the `~2^(3.3n)` Gram-determinant bit growth
 on this family); at `n ∈ {15, 20, 25}` the predictor still picks the exact
 `d`/`ν` checker, where the small absolute cost difference is the
-checker-share figure. The harsh-cubic entries are `2^(3.3n)` wide, so
-every rung leaves the word-scale regime of the packed product-equality
-certificate and the same-lattice clause runs the materialized comparison.
+checker-share figure. The harsh-cubic entries are `2^(3.3n)` wide, so the
+same-lattice clause runs the packed product-equality certificate on wide
+entries, where the packed dot products cost the same bit operations as a
+materialized comparison.
 
 The external `verified Isabelle certified-LLL` executable is now wired from the
 same Zenodo 2636367 archive as the native comparator:


### PR DESCRIPTION
This PR removes the packed-certificate word-scale regime gate from
`mulEqCert` so the packed product-equality evaluation runs unconditionally:
delete the `wordScale` predicate and the `if 32 ≤ n && wordScale …` branch,
and collapse `mulEqCert_iff` to the single packed branch (`mulEqCert_iff`
statement unchanged). `sameLatticeCert`, `certCheck`, `certCheck_sound`, and
acceptance are unchanged; the packed comparison is complete, so identical
candidates accept identically and every observed hash is preserved. Amend
SPEC/Libraries/hex-lll.md §Certified external dispatch to state the packed
single-point evaluation unconditionally (the "same bit operations as the
materialized product" parity attributed to the packed dot-product
multiplications), and correct the now-stale mechanism prose in
reports/hex-lll-performance.md.

Closes #6782.

Correctness, on `carica` with the fplll FFI provider: `lake build HexLLL
HexLLLMathlib` clean; `lake exe hexlll_bench verify` **153/153** — observed
hashes bit-identical before/after, rejection 0/22, the interval tally
untouched; `scripts/check_dag.py`, `git diff --check`, and the added-line
forbidden-token grep all clean.

Paired checker-only medians, before = merge-base `f07ab141`, after =
`80fa63c3` (this branch's implementation commit). Word-scale random-bounded
rungs and the large wide-entry rungs are neutral. The wide-entry harsh-cubic
mid rungs (n=35/40/45) carry a small real overhead (the bound scan and
Horner repacking the gate previously skipped); the gold-standard
order-swapped interleaved A/B (12 rounds, alternating which binary runs
first each round, which cancels host drift and is robust to the intermittent
bench-host contention that makes back-to-back sweeps unreliable at this
scale) places it under the blessed `3 %` bound:

| rung (≥10 ms) | before | after | Δ% | Δ ms |
|---|---|---|---|---|
| CheckerHarshCubic35 | 10.110 ms | 10.275 ms | +1.6% | +0.165 |
| CheckerHarshCubic40 | 13.630 ms | 13.869 ms | +1.8% | +0.239 |
| CheckerHarshCubic45 | 18.239 ms | 18.494 ms | +1.4% | +0.255 |

All sub-0.3 ms absolute, before/after ranges overlapping. Per the
directive's relaxed go/no-go these wide-entry rungs are within bounds; the
random-bounded ladder and harsh-cubic n=50–65 are neutral. The full
discussion, including why the back-to-back method's flagged set reshuffles
between runs and the carica contention encountered, is on the issue.

🤖 Prepared with Claude Code
