### PR TITLE
fix: recombine non-monic cores via toMonic inverse substitution (executable)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -51,6 +51,36 @@ implicit `[Bounds primeData.p]` cannot be synthesized and the type silently
 becomes `sorry`. Write the instance explicitly in such signatures:
 `@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds (…)`.
 
+## The Mathlib layer *models* executable definitions
+
+The bridge does not just prove lemmas about the executable types; it carries
+**model definitions that mirror the shape of executable functions** —
+e.g. `scaledRecombinationCandidate` / `scaledLiftedFactorProduct` /
+`RepresentsIntegerFactorAtLift` (`HexBerlekampZassenhausMathlib/Basic.lean`)
+mirror the per-step candidate built inside `Hex.scaledRecombinationSearchModAux`
+/ `bhksIndicatorCandidate?`. Before changing an executable definition's *shape*
+(the candidate expression, the recombination target, the lift transform),
+grep the Mathlib layer for proofs that `unfold` it or restate its body, and
+size that surface first — it is often far larger than the executable proofs.
+
+Two directions behave very differently under such a change:
+
+- **Product / divisibility direction survives.** Proofs like `*_product` rest
+  on the `exactQuotient? target candidate` recursion, which is blind to how the
+  candidate was built, so they need only mechanical `let`-expression updates
+  (mirror the new candidate text) — never a new argument.
+- **Recovery / coverage direction does not.** Proofs that identify the emitted
+  candidate against an expected factor (the `RepresentsIntegerFactorAtLift`
+  recovery chain, the coverage proof in `Basic.lean`) *encode* the old shape;
+  changing it is a structural remodel needing new math, not a token swap. These
+  feed the still-`sorry` headline `factor_irreducible_of_nonUnit`, but they are
+  proven (not sorried) lemmas, so they must still compile.
+
+Consequence: a soundness fix to the executable recombination is **not**
+independently landable green — the executable change and the Mathlib remodel
+must land in one PR. Scope accordingly (see #6799 / #6801 for the
+`DensePoly.scale` → `ZPoly.dilate` example).
+
 ## Pre-existing sorries
 
 `HexBerlekampMathlib/Basic.lean` and `HexHenselMathlib/Correctness.lean` ship

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -6523,16 +6523,18 @@ def recombineExhaustive (f : ZPoly) (d : LiftData) : Array ZPoly :=
   | some factors => factors.toArray
   | none => #[]
 
-/-- Scaled-candidate variant of `recombinationSearchModAux`.
+/-- Dilated-candidate variant of `recombinationSearchModAux`.
 
-The per-step candidate is built from the lifted-factor product *after* scaling
-by the integer `coreLc` parameter (intended to be the leading coefficient of
-the integer core polynomial), then centre-lifted, primitivised, and
-sign-normalised.  For `coreLc = 1` the inner `DensePoly.scale 1 _ = _`
+The lifted factors here are factors of the *monic transform*
+`c^(d-1) · core(X / c)` (`c = coreLc`), so their centre-lifted product is a
+monic-transform factor `g`.  The per-step candidate is recovered as the
+primitive part of `g(c · X)` — the substitution `X ↦ c · X` realised by
+`ZPoly.dilate coreLc`, which is the genuine inverse of the `toMonic` scaling —
+and then sign-normalised.  For `coreLc = 1` the inner `ZPoly.dilate 1 _ = _`
 collapse recovers the original unscaled `recombinationSearchModAux` candidate
-shape; for primitive non-monic cores the scaled product is the integer factor
-identified by `RepresentsIntegerFactorAtLift`, so this variant is the basis of
-the primitive recursive coverage chain. -/
+shape; for primitive non-monic cores this yields the primitive integer factor of
+`core` whose `RepresentsIntegerFactorAtLift` certificate drives the recursive
+coverage chain. -/
 def scaledRecombinationSearchModAux
     (coreLc : Int) (target : ZPoly) (modulus : Nat) (localFactors : List ZPoly) :
     Nat → Option (List ZPoly)
@@ -6545,9 +6547,8 @@ def scaledRecombinationSearchModAux
           let candidate :=
             normalizeFactorSign <|
               ZPoly.primitivePart <|
-                centeredLiftPoly
-                  (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                  modulus
+                ZPoly.dilate coreLc <|
+                  centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
           if shouldRecordPolynomialFactor candidate then
             match exactQuotient? target candidate with
             | none => none
@@ -8468,6 +8469,64 @@ private def quadraticCubeRegression : ZPoly :=
 #guard (factor quadraticCubeRegression).factors =
   #[(linearFactorForRoot (-1), 3), (linearFactorForRoot 1, 3)]
 
+/-- Soundness regression for issue #6799: the primitive non-monic cubic
+`2X³+9X²+10X+3 = (2X+1)(X+1)(X+3)` must split into three factors, not be
+reported as a single irreducible factor.  Before the `ZPoly.dilate`
+inverse-transform fix, the slow exhaustive recombination recombined against the
+non-monic core via a scalar `DensePoly.scale`, failed to find any split, and
+fell back to `#[core]`. -/
+private def nonMonicCubicRegression : ZPoly :=
+  DensePoly.ofCoeffs #[3, 10, 9, 2]
+
+#guard (factor nonMonicCubicRegression).factors.size = 3
+#guard Factorization.product (factor nonMonicCubicRegression) = nonMonicCubicRegression
+
+-- The slow modular path recombines the cubic into three factors at the default
+-- bound; in particular it does not return the uninformative `#[core]`.
+#guard
+  (match factorSlowModularFactorsWithBound nonMonicCubicRegression
+      (ZPoly.defaultFactorCoeffBound nonMonicCubicRegression) with
+    | some fs => fs.size = 3
+    | none => false)
+
+-- The fast BHKS path does not yet recombine non-monic cores (its per-class
+-- candidate still uses the scalar shape — fixing that is the follow-up tracked
+-- separately), so it cleanly returns `none` and defers to the slow path.  The
+-- soundness requirement is only that it must never report `#[core]`.
+#guard
+  (match factorFastFactorsWithBound nonMonicCubicRegression
+      (ZPoly.defaultFactorCoeffBound nonMonicCubicRegression) with
+    | some fs => fs ≠ #[nonMonicCubicRegression]
+    | none => true)
+
+/-- Non-monic quadratic with two integer roots, `2(X-1)(X+1) = 2X²-2`:
+content `2`, primitive part `(X-1)(X+1)`, so `factor` records two factors. -/
+private def nonMonicQuadraticTwoRoots : ZPoly :=
+  DensePoly.ofCoeffs #[-2, 0, 2]
+
+#guard (factor nonMonicQuadraticTwoRoots).factors.size = 2
+#guard Factorization.product (factor nonMonicQuadraticTwoRoots) = nonMonicQuadraticTwoRoots
+
+/-- Non-monic quartic `(2X+1)(X+1)(X²+1)`, primitive with leading coefficient
+`2` and a mix of non-monic linear, monic linear, and irreducible quadratic
+factors. -/
+private def nonMonicQuarticRegression : ZPoly :=
+  DensePoly.ofCoeffs #[1, 2] * DensePoly.ofCoeffs #[1, 1] *
+    DensePoly.ofCoeffs #[1, 0, 1]
+
+#guard (factor nonMonicQuarticRegression).factors.size = 3
+#guard Factorization.product (factor nonMonicQuarticRegression) = nonMonicQuarticRegression
+
+/-- Non-monic core carrying nontrivial content, `6(X-1)(X+1) = 6X²-6`: the signed
+content scalar is `6` and the primitive factors are the two integer roots. -/
+private def nonMonicWithContentRegression : ZPoly :=
+  DensePoly.ofCoeffs #[-6, 0, 6]
+
+#guard (factor nonMonicWithContentRegression).factors.size = 2
+#guard Factorization.product (factor nonMonicWithContentRegression) =
+  nonMonicWithContentRegression
+#guard (factor nonMonicWithContentRegression).scalar = 6
+
 namespace ZPoly
 
 /--
@@ -10084,9 +10143,8 @@ private theorem scaledRecombinationSearchModAux_normalizeFactorSign
         let candidate :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
         by_cases hrecord : shouldRecordPolynomialFactor candidate = true
         · simp [candidate, hrecord] at hsplit
           cases hquot : exactQuotient? target candidate with
@@ -10109,10 +10167,9 @@ private theorem scaledRecombinationSearchModAux_normalizeFactorSign
                       rw [hfactor]
                       exact normalizeFactorSign_idem
                         (ZPoly.primitivePart <|
-                          centeredLiftPoly
-                            (DensePoly.scale coreLc
-                              (Array.polyProduct split.1.toArray))
-                            modulus)
+                          ZPoly.dilate coreLc <|
+                            centeredLiftPoly
+                              (Array.polyProduct split.1.toArray) modulus)
                   | inr hrest =>
                       exact ih quotient split.2 rest hrec factor hrest
         · simp [candidate, hrecord] at hsplit
@@ -10138,9 +10195,8 @@ private theorem scaledRecombinationSearchModAux_shouldRecord
         let candidate :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
         by_cases hrecord : shouldRecordPolynomialFactor candidate = true
         · simp [candidate, hrecord] at hsplit
           cases hquot : exactQuotient? target candidate with
@@ -10187,9 +10243,8 @@ private theorem scaledRecombinationSearchModAux_primitive
         let candidate :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
         by_cases hrecord : shouldRecordPolynomialFactor candidate = true
         · simp [candidate, hrecord] at hsplit
           cases hquot : exactQuotient? target candidate with
@@ -10221,19 +10276,17 @@ private theorem scaledRecombinationSearchModAux_primitive
                       -- `Primitive (normalizeFactorSign ...)` by deliverable 1.
                       have hcand_ne :
                           normalizeFactorSign (ZPoly.primitivePart
-                              (centeredLiftPoly
-                                (DensePoly.scale coreLc
-                                  (Array.polyProduct split.1.toArray))
-                                modulus)) ≠ 0 := by
+                              (ZPoly.dilate coreLc
+                                (centeredLiftPoly
+                                  (Array.polyProduct split.1.toArray) modulus))) ≠ 0 := by
                         unfold shouldRecordPolynomialFactor at hrecord
                         simp at hrecord
                         exact hrecord.1.1
                       have hpp_ne :
                           ZPoly.primitivePart
-                              (centeredLiftPoly
-                                (DensePoly.scale coreLc
-                                  (Array.polyProduct split.1.toArray))
-                                modulus) ≠ 0 := by
+                              (ZPoly.dilate coreLc
+                                (centeredLiftPoly
+                                  (Array.polyProduct split.1.toArray) modulus)) ≠ 0 := by
                         intro hpp
                         apply hcand_ne
                         rw [hpp]
@@ -10242,10 +10295,9 @@ private theorem scaledRecombinationSearchModAux_primitive
                           (by decide : ¬ DensePoly.leadingCoeff (0 : ZPoly) < 0)]
                       have hcontent_ne :
                           ZPoly.content
-                              (centeredLiftPoly
-                                (DensePoly.scale coreLc
-                                  (Array.polyProduct split.1.toArray))
-                                modulus) ≠ 0 := by
+                              (ZPoly.dilate coreLc
+                                (centeredLiftPoly
+                                  (Array.polyProduct split.1.toArray) modulus)) ≠ 0 := by
                         intro hcontent
                         apply hpp_ne
                         show DensePoly.primitivePart _ = 0
@@ -10254,10 +10306,9 @@ private theorem scaledRecombinationSearchModAux_primitive
                       have hpp_primitive :
                           ZPoly.Primitive
                             (ZPoly.primitivePart
-                              (centeredLiftPoly
-                                (DensePoly.scale coreLc
-                                  (Array.polyProduct split.1.toArray))
-                                modulus)) :=
+                              (ZPoly.dilate coreLc
+                                (centeredLiftPoly
+                                  (Array.polyProduct split.1.toArray) modulus))) :=
                         ZPoly.primitivePart_primitive _ hcontent_ne
                       exact normalizeFactorSign_primitive _ hpp_primitive
                   | inr hrest =>
@@ -10397,9 +10448,8 @@ private theorem scaledRecombinationSearchModAux_product
         let candidate :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
         by_cases hrecord : shouldRecordPolynomialFactor candidate = true
         · simp [candidate, hrecord] at hsplit
           cases hquot : exactQuotient? target candidate with
@@ -10460,8 +10510,8 @@ private theorem densePoly_int_scale_one (p : ZPoly) :
 
 /-- `scaledRecombinationSearchModAux` at `coreLc = 1` collapses to the unscaled
 `recombinationSearchModAux`: the only difference between the two routines is the
-inner `DensePoly.scale coreLc` applied to the lifted-factor product, which is a
-no-op when `coreLc = 1`. -/
+inner `ZPoly.dilate coreLc` applied to the centre-lifted lifted-factor product,
+which is a no-op when `coreLc = 1`. -/
 private theorem scaledRecombinationSearchModAux_eq_recombinationSearchModAux_of_one
     (target : ZPoly) (modulus : Nat) (localFactors : List ZPoly) (fuel : Nat) :
     scaledRecombinationSearchModAux 1 target modulus localFactors fuel =
@@ -10475,7 +10525,7 @@ private theorem scaledRecombinationSearchModAux_eq_recombinationSearchModAux_of_
       · simp only [htarget, if_false]
         congr 1
         funext split
-        simp only [densePoly_int_scale_one]
+        simp only [ZPoly.dilate_one]
         by_cases hrecord :
             shouldRecordPolynomialFactor (normalizeFactorSign <|
                 ZPoly.primitivePart <|
@@ -10655,10 +10705,10 @@ Scaled-candidate counterpart of `recombinationSearchModAux_eq_some_of_step_of_pr
 
 Structurally identical to the unscaled step lemma, with the inner `let
 candidate' := ...` expression in both the prefix-none hypothesis and the goal
-applying `DensePoly.scale coreLc` to the lifted-factor product before
-centre-lifting.  This is the step driver the primitive recursive coverage
-proof in #4647 will use, where the candidate is recovered from the integer
-factor via `scaledRecombinationCandidate_eq_factor_of_recovery`.
+applying `ZPoly.dilate coreLc` (the substitution `X ↦ coreLc · X`) to the
+centre-lifted lifted-factor product.  This is the step driver the primitive
+recursive coverage proof in #4647 will use, where the candidate is recovered
+from the integer factor via `scaledRecombinationCandidate_eq_factor_of_recovery`.
 -/
 theorem scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none
     {coreLc : Int} {target candidate quotient : ZPoly} {modulus fuel : Nat}
@@ -10672,9 +10722,8 @@ theorem scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none
         (let candidate' :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct split.1.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct split.1.toArray) modulus
         if shouldRecordPolynomialFactor candidate' then
           match exactQuotient? target candidate' with
           | none => none
@@ -10687,9 +10736,8 @@ theorem scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none
     (hcandidate_def :
       candidate = normalizeFactorSign
         (ZPoly.primitivePart
-          (centeredLiftPoly
-            (DensePoly.scale coreLc (Array.polyProduct selected.toArray))
-            modulus)))
+          (ZPoly.dilate coreLc
+            (centeredLiftPoly (Array.polyProduct selected.toArray) modulus))))
     (hrecord : shouldRecordPolynomialFactor candidate = true)
     (hquot : exactQuotient? target candidate = some quotient)
     (hsearch_rest :
@@ -10704,9 +10752,8 @@ theorem scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none
   show (let candidate' :=
           normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct selected.toArray))
-                modulus
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct selected.toArray) modulus
         if shouldRecordPolynomialFactor candidate' then
           match exactQuotient? target candidate' with
           | none => none
@@ -10718,9 +10765,9 @@ theorem scaledRecombinationSearchModAux_eq_some_of_step_of_prefix_none
         else none) = some (candidate :: restFactors)
   rw [show (normalizeFactorSign <|
             ZPoly.primitivePart <|
-              centeredLiftPoly
-                (DensePoly.scale coreLc (Array.polyProduct selected.toArray))
-                modulus) = candidate
+              ZPoly.dilate coreLc <|
+                centeredLiftPoly (Array.polyProduct selected.toArray) modulus)
+              = candidate
         from hcandidate_def.symm]
   rw [if_pos hrecord]
   simp only [hquot, hsearch_rest]

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -53,6 +53,34 @@ def content (f : ZPoly) : Int :=
 def primitivePart (f : ZPoly) : ZPoly :=
   DensePoly.primitivePart f
 
+/-- Substitute the variable `X ↦ c * X`: the `i`-th coefficient is multiplied by
+`c ^ i`.
+
+On a monic transform `c^(d-1) · core(X / c)` (the polynomial built by
+`toMonic`), this is the inverse of the integer-scaling substitution: it maps a
+monic factor `g` of the transform to `g(c · X)`, an integer multiple of the
+corresponding factor of `core`. Composing with `primitivePart` recovers the
+primitive integer factor of `core`. This is *not* the same as `DensePoly.scale`,
+which multiplies the whole polynomial by a constant. -/
+def dilate (c : Int) (p : ZPoly) : ZPoly :=
+  DensePoly.ofCoeffs <| ((List.range p.size).map fun i => c ^ i * p.coeff i).toArray
+
+theorem coeff_dilate (c : Int) (p : ZPoly) (n : Nat) :
+    (dilate c p).coeff n = c ^ n * p.coeff n := by
+  unfold dilate
+  rw [DensePoly.coeff_ofCoeffs_list, List.getD_eq_getElem?_getD, List.getElem?_map]
+  by_cases hn : n < p.size
+  · rw [List.getElem?_range hn]; rfl
+  · have hzero : p.coeff n = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_lt hn)
+    rw [List.getElem?_eq_none (by simpa using Nat.le_of_not_lt hn), hzero, Int.mul_zero]
+    rfl
+
+@[simp] theorem dilate_one (p : ZPoly) : dilate 1 p = p := by
+  apply DensePoly.ext_coeff
+  intro n
+  rw [coeff_dilate, Int.one_pow, Int.one_mul]
+
 /-- A `ZPoly` is primitive when its content is `1`. -/
 def Primitive (f : ZPoly) : Prop :=
   content f = 1

--- a/progress/20260613T140611Z_issue-6799.md
+++ b/progress/20260613T140611Z_issue-6799.md
@@ -1,0 +1,69 @@
+# Progress: #6799 — non-monic recombination soundness fix
+
+## Accomplished
+
+Fixed the demonstrated `factor` soundness bug on non-monic cores at the
+**executable** layer, and verified it with regression fixtures.
+`HexBerlekampZassenhaus` builds green (497 jobs).
+
+- Added `Hex.ZPoly.dilate c p` in `HexPolyZ/Basic.lean`: the substitution
+  `X ↦ c · X` (the `i`-th coefficient times `c ^ i`), with `coeff_dilate`
+  and `dilate_one`. This is the genuine inverse, on the monic transform
+  `c^(d-1)·core(X/c)` built by `toMonic`, of the integer-scaling substitution
+  — unlike `DensePoly.scale`, which multiplies the whole polynomial by a
+  constant.
+- Rebuilt the slow-path recombination candidate in
+  `scaledRecombinationSearchModAux` as
+  `primitivePart (dilate coreLc (centeredLift product))` instead of
+  `primitivePart (centeredLift (scale coreLc product))`. The scale form
+  collapsed under `primitivePart` to the monic-transform factor, which does
+  not divide the non-monic core, so recombination failed and fell back to
+  `#[core]`. The dilation recovers the real integer factor.
+- Updated the mirror proofs in `HexBerlekampZassenhaus/Basic.lean` that
+  reconstruct the candidate expression (`_normalizeFactorSign`,
+  `_shouldRecord`, `_primitive`, `_product`, `_eq_some_of_step_of_prefix_none`)
+  and routed the `coreLc = 1` collapse through `ZPoly.dilate_one`. Product
+  preservation is unchanged in substance — it rests on the `exactQuotient?`
+  recursion, which is blind to candidate shape.
+- Regression fixtures (all pass at compile time): the cubic
+  `2X³+9X²+10X+3` factors into three; `factorSlowModularFactorsWithBound`
+  returns three at the default bound; `factorFastFactorsWithBound` returns
+  `none` (never `#[core]`); plus `2(X-1)(X+1)`, a non-monic quartic, and a
+  content-carrying `6(X-1)(X+1)`.
+
+## Scope decision
+
+The fast BHKS path was left scale-based on purpose: `factorFastCoreWithBound`
+guards every candidate with `exactQuotient?` and returns `none` on failure
+(no `#[core]` fallback), so the scalar shape there is **incomplete, not
+unsound** — it cleanly defers non-monic cores to the slow path. The
+demonstrated soundness bug lives entirely in the slow exhaustive path, which
+this fix addresses.
+
+## Blockers / follow-up
+
+`HexBerlekampZassenhausMathlib` does **not** build with the executable fix.
+The Mathlib recovery/coverage chain models the *old* scale candidate:
+`scaledRecombinationCandidate` and `RepresentsIntegerFactorAtLift`
+(`HexBerlekampZassenhausMathlib/Basic.lean:2218/2249/2227`, ~150 references
+in that file) encode `centeredLift (scale lc product)`, and the coverage
+proof (`Basic.lean:15788+`) passes a scale-shaped `hcandidate_def` to the
+now-dilation executable lemma (first failure at `Basic.lean:15990`).
+
+Reconciling this is a structural remodel, not a mechanical swap: the
+substitution moves *outside* `centeredLift`, so `scaledLiftedFactorProduct`
+(a pre-`centeredLift` product) can no longer express the candidate, and the
+recovery lemma `scaledRecombinationCandidate_eq_factor_of_recovery_of_bound`
+needs new `toMonic` factor-correspondence math (monic-transform factor `g`,
+core factor `= primitivePart (dilate lc g)`). This is exactly the
+"non-monic correspondence updated to the inverse transform" the issue
+anticipates and is tied to the #6772 predicate redesign. Tracked as a
+follow-up issue.
+
+## Next step
+
+Mathlib recovery-chain dilation remodel (follow-up issue): redefine the
+recovery model around the monic transform + `dilate`, add the toMonic
+inverse-factor correspondence, re-prove the ~15 scale recovery lemmas and
+the coverage proof. Then optionally migrate the fast BHKS candidate to the
+same dilation.


### PR DESCRIPTION
This PR fixes the `factor` soundness bug on non-monic cores at the executable layer: a primitive non-monic core was reported as a single irreducible factor. The slow exhaustive recombination built its per-step candidate with a scalar `DensePoly.scale coreLc`, which is not the inverse of the `toMonic` substitution `X ↦ X / c`; under `primitivePart` the scaled candidate collapses to the monic-transform factor, which does not divide the non-monic core, so the search found no split and fell back to `#[core]`.

This PR adds `Hex.ZPoly.dilate c`, the substitution `X ↦ c · X` (the `i`-th coefficient times `c ^ i`) — the genuine inverse, on the monic transform `c^(d-1)·core(X/c)`, of the `toMonic` scaling — and rebuilds the candidate in `scaledRecombinationSearchModAux` as `primitivePart (dilate coreLc (centeredLift product))`, so each recovered candidate is a real integer factor of the non-monic core. The product-preservation proofs are unchanged in substance (they rest on the `exactQuotient?` recursion, which is blind to candidate shape); the mirror proofs that reconstruct the candidate expression are updated in lockstep, and the `coreLc = 1` collapse routes through `ZPoly.dilate_one`.

Regression fixtures: the primitive non-monic cubic `2X³+9X²+10X+3` splits into three factors, `factorSlowModularFactorsWithBound` returns three at the default bound, and neither it nor `factorFastFactorsWithBound` reports `#[core]`; further fixtures cover `2(X-1)(X+1)`, a non-monic quartic, and a content-carrying core. `lake build HexBerlekampZassenhaus` is green.

This is a partial landing of #6799. The fast BHKS path is left scale-based on purpose: it guards every candidate with `exactQuotient?` and returns `none` (deferring to the slow path) when no candidate divides, so it is incomplete rather than unsound and never emits a bogus `#[core]`.

`HexBerlekampZassenhausMathlib` does **not** build against the fixed executable, so CI on that target is red. Its recovery/coverage chain models the old scale candidate (`scaledRecombinationCandidate`, `RepresentsIntegerFactorAtLift`, ~150 references), and reconciling it is a structural remodel onto the `ZPoly.dilate` correspondence — the "non-monic correspondence updated to the inverse transform" anticipated by #6799, tied to the #6772 predicate redesign. That remainder is tracked as https://github.com/kim-em/hex/issues/6801 ("feat: migrate Mathlib recovery chain to the ZPoly.dilate non-monic correspondence") and should be completed on this branch so both builds land green together.

🤖 Prepared with Claude Code