### PR TITLE
feat: add the ZPoly.dilate Mathlib correspondence

### DIFF
--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -208,6 +208,32 @@ theorem toZMod_ZMod64_ofNat_intModNat_eq_intCast
   change z % (p : ℤ) % (p : ℤ) = z % (p : ℤ)
   rw [Int.emod_emod]
 
+/-- The executable variable-dilation `X ↦ c · X` corresponds to Mathlib
+composition with `C c * X`. -/
+@[simp]
+theorem toPolynomial_dilate (c : ℤ) (g : Hex.ZPoly) :
+    toPolynomial (Hex.ZPoly.dilate c g) =
+      (toPolynomial g).comp (Polynomial.C c * Polynomial.X) := by
+  ext n
+  rw [coeff_toPolynomial, Hex.ZPoly.coeff_dilate, Polynomial.comp_C_mul_X_coeff,
+    coeff_toPolynomial, mul_comm]
+
+/-- Variable dilation is multiplicative: substituting `X ↦ c · X` is a ring
+homomorphism, so it distributes over products. -/
+theorem dilate_mul (c : ℤ) (g h : Hex.ZPoly) :
+    Hex.ZPoly.dilate c (g * h) =
+      Hex.ZPoly.dilate c g * Hex.ZPoly.dilate c h := by
+  apply equiv.injective
+  simp only [equiv_apply, toPolynomial_dilate, toPolynomial_mul, Polynomial.mul_comp]
+
+/-- For a nonzero dilation factor, variable dilation preserves natural degree:
+`C c * X` has degree `1` with a unit leading coefficient over the integers. -/
+theorem natDegree_toPolynomial_dilate (c : ℤ) (hc : c ≠ 0) (g : Hex.ZPoly) :
+    (toPolynomial (Hex.ZPoly.dilate c g)).natDegree =
+      (toPolynomial g).natDegree := by
+  rw [toPolynomial_dilate, Polynomial.natDegree_comp,
+    Polynomial.natDegree_C_mul_X c hc, mul_one]
+
 end
 
 end HexPolyZMathlib

--- a/progress/20260613T033300Z_issue-6803.md
+++ b/progress/20260613T033300Z_issue-6803.md
@@ -1,0 +1,46 @@
+# Progress: #6803 — ZPoly.dilate Mathlib correspondence (deliverables 1-3)
+
+## Accomplished
+
+Landed the `Hex.ZPoly.dilate` Mathlib correspondence (deliverables 1-3 of
+#6803) in `HexPolyZMathlib/Basic.lean`, verified green
+(`lake build HexPolyZMathlib`, 3408 jobs).
+
+- `toPolynomial_dilate` (`@[simp]`): the executable variable-dilation
+  `X ↦ c · X` corresponds to Mathlib composition with `C c * X`. Proved
+  coeff-wise via Mathlib's `Polynomial.comp_C_mul_X_coeff` against
+  `Hex.ZPoly.coeff_dilate`.
+- `dilate_mul`: multiplicativity `dilate c (g * h) = dilate c g * dilate c h`,
+  via `equiv.injective` + `Polynomial.mul_comp`.
+- `natDegree_toPolynomial_dilate` (for `c ≠ 0`): degree preservation, via
+  `Polynomial.natDegree_comp` + `natDegree_C_mul_X`.
+
+## Current frontier
+
+Deliverable 4 (the `toMonic` inverse-factor recovery lemma) split out as
+#6807 (blocked on #6803). It is genuinely a separate session:
+
+- It needs a new executable keystone identity
+  `dilate lc (transformedCore core d) = C (lc^(d-1)) * core` (for
+  `d = degree?.getD 0 ≥ 1`). I derived it coeff-wise and recorded the full
+  derivation + boundary analysis in #6807. `transformedCore` is `private`
+  in `HexBerlekampZassenhaus/Basic.lean`, so the keystone must live there.
+- It needs a `primitivePart`/`content` ↔ `Polynomial.primPart` Gauss
+  correspondence that does **not** exist anywhere yet — the main missing
+  prerequisite.
+- It lands in `HexBerlekampZassenhausMathlib/Basic.lean`, which carries the
+  pre-existing #6801 recovery-seam error at `Basic.lean:15990` (the chain
+  still models the old `scale`-shaped candidate while the executable
+  `scaledRecombinationSearchModAux` now produces the `dilate`-shaped one).
+  Confirmed: exactly one real source error, at 15990, unrelated to this
+  work.
+
+## Next step
+
+Execute #6807: prove the executable keystone, build the Gauss
+`primitivePart`/`primPart` bridge, then package the recovery lemma
+(divides `core` + primitive + degree `= deg g`).
+
+## Blockers
+
+None for 1-3 (shipped). #6807 is correctly blocked on #6803.


### PR DESCRIPTION
This PR adds the `Hex.ZPoly.dilate` Mathlib correspondence in `HexPolyZMathlib/Basic.lean`: `toPolynomial_dilate` shows the executable variable-dilation `X ↦ c · X` corresponds to Mathlib composition with `C c * X` (proved coeff-wise via `Polynomial.comp_C_mul_X_coeff`), `dilate_mul` gives multiplicativity through `Polynomial.mul_comp`, and `natDegree_toPolynomial_dilate` gives degree preservation for a nonzero dilation factor via `Polynomial.natDegree_comp`. These are the foundation the `toMonic` inverse-factor recovery builds on.

This lands deliverables 1-3 of #6803; `lake build HexPolyZMathlib` is green. Deliverable 4 (the packaged `toMonic` inverse-factor recovery lemma) is split into #6807: it needs a new executable keystone identity plus a `primitivePart`/`primPart` Gauss-content correspondence that does not yet exist, and it lands in `HexBerlekampZassenhausMathlib/Basic.lean` which carries the pre-existing #6801 recovery-seam error at line 15990. The issue anticipated this split ("land 1-3 first and split 4 out").

🤖 Prepared with Claude Code