### PR TITLE
fix: steered float-drift margin and unified n>=30 steering dispatch

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -1798,11 +1798,24 @@ end SteeredState
 
 /-- Run the approximation-steered reducer: init float GSO, run the fuel-bounded
 steered loop, then the drift-free final sweep, returning the exact reduced basis.
-Steers with `δsteer = (δ + 1)/2` (stricter than the certification `δ`). -/
+Steers with `δsteer = (δ + 2)/3` (stricter than the certification `δ`), `4/3` the
+`(δ + 1)/2` margin: the wider gap absorbs more of the float `bb`/`mu` drift that
+the periodic refresh leaves between exact recomputations, widening the slack the
+final size-reduced basis has against the public-`δ` certification. This is a
+best-effort heuristic, not a guarantee — `lllSteered` still certifies the output
+and falls back to the exact reducer if it misses. Empirically (issue #6806)
+`(δ + 2)/3` certifies the committed random-bounded and harsh-cubic ladders and
+random-bounded n=30 across seeds 1..12, with one off-ladder residual at rb
+n=65/seed=9 (where `(δ + 1)/2` also fails). It is the cheapest measured margin
+that both certifies that binding set and keeps the extra-swap cost on the
+already-steered rungs within 3% (the larger `(δ + 3)/4` is equally robust but
+costs ~5% on random-bounded n=45). A stricter `δsteer` does not monotonically
+help robustness or cost, because it steers a different swap trajectory through
+different float-rounding boundaries. -/
 def steeredReduce (b : Matrix Int n m) (δ : Rat) : Matrix Int n m :=
   let s0 := SteeredState.init b
   let δf : Float := Float.ofInt δ.num / Float.ofNat δ.den
-  let δsteer : Float := (δf + 1.0) / 2.0
+  let δsteer : Float := (δf + 2.0) / 3.0
   let s := SteeredState.loop δsteer 16 s0 1 0 (SteeredState.fuel b)
   (SteeredState.finalSweep s).b
 
@@ -1954,59 +1967,42 @@ unsafe def withRecordSteeredOutcomeImpl {α : Type} (o : SteeredOutcome) (k : α
 @[implemented_by withRecordSteeredOutcomeImpl]
 def withRecordSteeredOutcome {α : Type} (_o : SteeredOutcome) (k : α) : α := k
 
-/-- Dimension threshold of the steering dispatch for narrow-operand inputs.
-Steering plus post-hoc certification carries a fixed overhead, so below this
-dimension the exact `lllNative` is cheaper and runs directly. Small-operand
-families (e.g. random-bounded, entries `|·| ≤ 30`) cross over here. -/
-def steerDimThreshold : Nat := 40
-
-/-- Lower dimension threshold of the steering dispatch for wide-operand inputs.
-The certifier recomputes the candidate's Gram-Schmidt, whose reduced operands
-stay as wide as the input's (the determinant is preserved). On wide-operand
-families that exact post-hoc pass is cheap relative to the *exact reducer's*
-repeated wide-integer Gram-Schmidt, so steering already repays its overhead at a
-lower dimension. This is the minimum steering dimension across all operand
-widths: nothing below it is ever steered, which keeps the smallest inputs —
-above all the µs-scale bz-recombination production family, whose recombination
-operands can be wide at small dimension — on the exact path with no regression. -/
-def steerWideDimThreshold : Nat := 30
-
-/-- Operand width (bits of the largest squared row norm) at or above which an
-input uses the lower `steerWideDimThreshold` rather than `steerDimThreshold`.
-Harsh-cubic (entries `~2^{3.3n}`, so `maxDiagBits ≈ 6.6·n`) clears this at n≈28;
-random-bounded (`maxDiagBits ≤ 16` across the whole ladder) never does. -/
-def steerBitThreshold : Nat := 180
+/-- Dimension floor of the steering dispatch, calibrated on the committed
+benchmark families. Steering plus post-hoc certification carries a fixed
+overhead, so below this dimension the exact `lllNative` is cheaper and runs
+directly; at or above it the steered loop's float Gram-Schmidt repays that
+overhead against the exact reducer's repeated wide-integer Gram-Schmidt. The
+lowest committed rung is 30 and bz-recombination is n=3, so this floor keeps the
+smallest inputs — including the µs-scale bz-recombination production family — on
+the exact path with no regression. Routing only affects performance, never
+output: `lllSteered` certifies every steered candidate and falls back to the
+exact reducer if it does not certify. -/
+def steerDimThreshold : Nat := 30
 
 /-- Size predictor for the steering dispatch: `true` when the steered reducer plus
-certification is predicted to beat the exact `lllNative` on this input. The
-dimension threshold is operand-adjusted — wide operands
-(`maxDiagBits ≥ steerBitThreshold`) steer from `steerWideDimThreshold`, narrow
-operands only from the higher `steerDimThreshold`.
+certification is predicted to beat the exact `lllNative` on this input. A single
+dimension floor places both committed families once the steered reducer certifies
+robustly at n=30 (issue #6806): the measured crossover for both the wide-operand
+harsh-cubic family and the narrow-operand random-bounded family sits at n=30, so
+no operand-width branch is needed. A deterministic function of the input
+dimension alone.
 
-A deterministic function of the input alone. A single dimension-only constant
-could not place both committed families: at `steerDimThreshold = 40` the steered
-curve was non-monotone on harsh-cubic (n=35 held exact at 20.7 ms while n=40
-steered ran 16.3 ms — a larger problem finishing faster). Lowering the threshold
-for wide operands pulls harsh-cubic in at n=30 (paired bench on `carica`: n=30
-steered 8.0 ms vs exact 9.7 ms, n=35 11.4 ms vs 20.4 ms) without touching
-random-bounded, whose operands never reach `steerBitThreshold`, so it keeps the
-`steerDimThreshold` routing verbatim. The `intervalWins`-shaped *product*
-`n · maxDiagBits` cannot achieve this separation (the #6757 entanglement): it
-orders harsh-cubic n=20 (product 2640) above random-bounded n=45 (630), so any
-constant that steers the latter also steers the former, a 26% regression. An
-operand-adjusted dimension threshold does separate them.
+Earlier the random-bounded crossover looked like it sat above 40 because the
+steered output at n=30 failed certification (a float-drift swap miss) and fell
+back to the exact reducer, so steering it regressed; that pushed the dispatch to
+a narrow `steerDimThreshold = 40` arm and a separate wide `= 30` arm gated on
+`maxDiagBits`. Fixing the drift (the `(δ + 3)/4` steering margin in
+`steeredReduce`) makes random-bounded n=30 certify, dropping its measured
+crossover to 30 and collapsing the two arms into one. The collapse newly steers
+narrow-operand inputs at `30 ≤ n < 40`; this is calibrated for the committed
+families, and certification with exact-reducer fallback keeps it correct on any
+other input.
 
 Realized routing on the committed ladders: harsh-cubic exact at n ≤ 25, steered
-at n ≥ 30 (wide arm); random-bounded exact at n=30, steered at n ≥ 45 (narrow arm
-— unchanged from the dimension-only dispatch); bz-recombination (n=3) exact.
-Residual misroute: random-bounded n=30 is held exact even though steering it would
-be cheaper *if it certified* — but the steered float reduction of that
-swap-forcing fixture is not `(δ, 11/20)`-reduced, so it would fall back to the
-exact reducer (measured 19.2 ms vs the exact 14.8 ms, a regression); keeping it on
-the narrow arm correctly leaves it exact. -/
-def steerWins (b : Matrix Int n m) : Bool :=
-  decide (n ≥ if maxDiagBits b ≥ steerBitThreshold then steerWideDimThreshold
-              else steerDimThreshold)
+at n ≥ 30; random-bounded steered at n ≥ 30 (n=30 included); bz-recombination
+(n=3) exact. -/
+def steerWins (_b : Matrix Int n m) : Bool :=
+  decide (n ≥ steerDimThreshold)
 
 /-- Approximation-steered native reducer with certified output. When `steerWins`
 holds it runs the steered loop (exact integer row operations driven by an

--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1541,7 +1541,7 @@ def runIsabelleHarshCubicNormSq65 : Unit → IO Int := fun _ => do
 ladders, then read `Hex.steeredTally`. Fails if any steered candidate failed
 certification and fell back to the exact reducer (`fellBack ≠ 0`) — a fallback
 inside the ladder would make the steered medians dishonest. Only rungs the
-operand-aware `Hex.steerWins` predictor routes to steering bump the tally; the
+`Hex.steerWins` predictor routes to steering (n ≥ 30) bump the tally; the
 smaller rungs run `lllNative` directly. The returned value encodes the tally
 as `certified · 65537 + fellBack`. -/
 def runSteeredFallbackTally : Unit → IO Int := fun _ => do
@@ -2241,13 +2241,14 @@ setup_fixed_benchmark runCertifiedCheckerIntervalTally where {
 
 /- Fallback-rate diagnostic: the steered reducer certified on every steered rung
 of both ladders (`fellBack = 0`). The pinned hash records the `certified` count
-(15 = the rungs `Hex.steerWins` routes to steering: harsh-cubic n ≥ 30 via the
-wide-operand arm and random-bounded n ≥ 45 via the narrow arm); a fallback would
+(16 = the rungs `Hex.steerWins` routes to steering under the unified `n ≥ 30`
+floor: harsh-cubic n ≥ 30 — 8 rungs — and random-bounded n ≥ 30 — 8 rungs,
+n=30 now included after the `(δ + 3)/4` steering-margin fix); a fallback would
 flip `fellBack` nonzero and throw before the hash is reached. -/
 setup_fixed_benchmark runSteeredFallbackTally where {
     repeats := 1
     maxSecondsPerCall := 120.0
-    expectedHash := some (Hashable.hash ((15 * 65537 : Int)))
+    expectedHash := some (Hashable.hash ((16 * 65537 : Int)))
   }
 
 /- Complexity derivation: random-bounded inputs have square dimension `n` and

--- a/progress/20260613T140321Z_issue-6806.md
+++ b/progress/20260613T140321Z_issue-6806.md
@@ -1,0 +1,64 @@
+# Progress: #6806 — steered float-drift fix + dispatch-threshold unification
+
+## Accomplished
+
+Implemented both coupled changes from the directive, chose the margin by
+measurement, and validated correctness + timing.
+
+- `HexLLL/Basic.lean steeredReduce`: steering margin `(δf+1)/2` → `(δf+2)/3`
+  (=0.91667). A fresh probe margin-sweep (rungs 15..90 × seeds 1..12) shows
+  robustness is NOT monotone in the margin: old `(δ+1)/2` = 3 grid failures,
+  `(2δ+3)/5` = 3, `(3δ+5)/8` = 2, `(δ+2)/3` = 1, `(δ+3)/4` = 1. `(δ+2)/3` and
+  the directive's suggested `(δ+3)/4` are equally robust (both leave only the
+  off-ladder rb n=65/seed=9, where the old margin also fails), but paired
+  interleaved A/B timing shows `(δ+3)/4` costs ~5.4% on rb n=45 (over the 3%
+  go/no-go bound) while `(δ+2)/3` costs +2.99% there — the cheapest measured
+  margin that both certifies the binding set and stays within 3%. The extra-swap
+  cost is quantized (one extra swap ≈ +3%), so ~3% on rb n=45 is intrinsic to
+  fixing the drift, not further tunable.
+- `HexLLL/Basic.lean steerWins`: collapsed the two-arm operand-width dispatch
+  to a single `decide (n ≥ steerDimThreshold)` with `steerDimThreshold = 30`.
+  Removed `steerWideDimThreshold`, `steerBitThreshold`, and the `maxDiagBits`
+  branch (`maxDiagBits` kept — `intervalWins` still uses it). Param `b` → `_b`.
+- `HexLLL/Bench.lean`: fallback tally hash `15*65537` → `16*65537` (rb n=30 now
+  steers: 8 rb rungs + 8 hc rungs = 16 certified), comments refreshed.
+
+## Validation
+
+- `lake build HexLLL HexLLLMathlib`: green.
+- `lake exe hexlll_bench verify`: runSteeredFallbackTally [ok] @ 16*65537
+  (16 steer, 0 fallback); all NormSq targets [ok]. Only failures are the
+  environmental `fplll-ffi provider absent` (external lib not installed locally).
+- `python3 scripts/check_dag.py`: exit 0. `git diff --check`: clean.
+- Added-line forbidden-token grep: none.
+- rb n=30 certifies across seeds 1..12; both committed ladders certify.
+- First-vector normSq at rb n=30/seed=8 = 4 under BOTH exact (main route) and
+  steered (branch route): shortest-vector norm unchanged, no increase to flag.
+
+### Paired timing (carica, interleaved A/B `(δ+1)/2` vs `(δ+2)/3`)
+
+- rb n=30 elbow GONE: 14.20 → 4.51 ms (−68%); dispatched rb curve monotone, no
+  kink at the 30→45 segment.
+- Worst non-bz regression: rb n=45 +2.99% (15-round median, 45 samples), under
+  the 3% bound. rb n=60/75 ≈ +2.0%. All harsh-cubic within ±1.5% (routing
+  unchanged, steer from n=30). bz-recombination unchanged (same exact path).
+
+## Directive premise checks
+
+1. Margin: the directive's `(δ+3)/4` is robust but violates its own 3% bound on
+   rb n=45 (~5.4%, matching its "point 4" ~1.05× steered-loop cost claim — the
+   bound and that cost claim are mutually inconsistent). Picked the cheaper
+   `(δ+2)/3` with equal robustness and within-bound cost, per Kim's "try a
+   cheaper margin" decision.
+2. Robustness: the directive's "eliminates EVERY failure across 15..65 × 1..12"
+   over-claims; one off-ladder residual remains at rb n=65/seed=9 (old margin
+   fails there too — not a regression). Binding go/no-go passes.
+
+## Next step
+
+Open PR; check merge conflicts + CI. Scratch `SteeredProbe.lean` + its lakefile
+exe entry stay untracked (lakefile reverted).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR widens the steered Lovász margin to `δsteer = (δ+2)/3` and collapses the steering dispatch to a single `n ≥ 30` floor, removing the random-bounded n=30 elbow on the Lean-steered comparator curve. Closes #6806.

At random-bounded n=30 the steered float reducer missed a swap to float drift, so its output failed `(3/4, 11/20)` certification and the dispatch fell back to the exact reducer (~14 ms) instead of the steered loop (~4 ms), kinking the curve. Widening the steering margin gives the certifier enough slack that n=30 certifies across seeds 1..12 and both committed ladders, with zero fallbacks. With n=30 certifying, its crossover drops to 30, matching the wide-operand crossover, so `steerWins` collapses from an operand-width-gated two-arm dispatch to `decide (n ≥ steerDimThreshold)`; `steerWideDimThreshold`, `steerBitThreshold`, and the `maxDiagBits` branch are removed, and the steered fallback tally rises from 15 to 16 certified rungs.

The two changes land together by necessity: the margin fix alone changes outputs without removing the elbow, and the threshold change alone would route n=30 to a still-failing steered path and regress it.

**Margin chosen by measurement, not by the directive.** The directive suggested `(δ+3)/4`, but a fresh re-measurement showed two problems with its premise. First, its robustness claim ("eliminates every failure across rungs 15..65 and seeds 1..12") over-claims: a probe margin-sweep over rungs 15..90 × seeds 1..12 leaves one residual at random-bounded n=65/seed=9 under `(δ+3)/4` — off both committed ladders, off the committed seed 8, and a fixture where the old `(δ+1)/2` margin also fails (so not a regression). Second, `(δ+3)/4` violates the directive's own 3%-per-rung go/no-go bound: a paired interleaved A/B on carica measures it at ~5.4% on random-bounded n=45, which matches the directive's "point 4" estimate of ~1.05× steered-loop cost — the 3% bound and that 1.05× claim are mutually inconsistent. Robustness is not monotone in the margin (the float reduction steers a different swap trajectory through different rounding boundaries), so a sweep of pure-`δ` candidates found `(δ+2)/3` = 0.91667: equally robust to `(δ+3)/4` (same single off-ladder residual) but +2.99% on random-bounded n=45 — the cheapest margin that both certifies the binding set and stays within 3%. The extra-swap cost is quantized (~3% per swap), so ~3% on n=45 is intrinsic to fixing the drift at all.

Paired interleaved A/B on carica (`(δ+1)/2` vs `(δ+2)/3`, common-mode contention cancelled):

| rung | before | after | Δ |
|---|---|---|---|
| random-bounded n=30 | 14.20 ms | 4.51 ms | **−68%** (elbow gone) |
| random-bounded n=45 | 16.21 ms | 16.69 ms | +2.99% |
| random-bounded n=60 | 41.16 ms | 41.99 ms | +2.0% |
| random-bounded n=75 | 87.9 ms | 89.7 ms | +2.0% |
| harsh-cubic n=30..65 | — | — | within ±1.5% (routing unchanged) |
| bz-recombination | 3.3 µs | 3.1 µs | unchanged (same exact path) |

The dispatched random-bounded curve is monotone with no kink at the 30→45 segment. The random-bounded n=30 first-vector norm is unchanged (4) — a different but equally short `(δ, 11/20)` basis.

Verification: `lake build HexLLL HexLLLMathlib` green; `lake exe hexlll_bench verify` shows `runSteeredFallbackTally` ok at `16·65537` (16 steered rungs, zero fallbacks) and all NormSq targets ok (the only local failures are `fplll-ffi provider absent`, an unrelated external dependency); `python3 scripts/check_dag.py` exit 0; `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` on added lines.

🤖 Prepared with Claude Code