### PR TITLE
feat: toMonic inverse-factor recovery — dilate_transformedCore keystone and Gauss bridge

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -43,6 +43,26 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   result with an explicit `HexPolyZMathlib.toPolynomial …` type ascription
   first, then `obtain`/`rw`.
 
+## Proving *inside* the Mathlib-free files
+
+Lemmas that live in the executable files themselves (`HexPoly/*`,
+`HexPolyZ/*`, `HexBerlekampZassenhaus/Basic.lean`) cannot use Mathlib tactics
+or `Monoid`/`CommRing` lemmas — those modules don't import Mathlib.
+
+- **`by_contra`, `ring`, `omega`-via-Mathlib are out.** `by_contra` reports
+  "unknown tactic"; replace with `rcases Nat.eq_zero_or_pos n` or
+  `rcases Nat.lt_trichotomy a b`. `omega`/`simp`/`rcases`/`conv` are core and
+  available.
+- **Integer `^` has no `pow_add`/`pow_succ`/`pow_one`/`one_pow` (Mathlib).**
+  Use `Lean.Grind.Semiring.pow_succ` (`a^(n+1) = a^n * a`) and
+  `Lean.Grind.Semiring.pow_zero`; `Int.one_pow`, `Int.mul_assoc`,
+  `Int.mul_comm`, `Int.mul_zero`, `Int.one_mul` are core and fine. For
+  `a^(m+k) = a^m * a^k`, write a one-line induction on `k` with `pow_succ`.
+- **Array/List core lemma names differ from intuition:** the lemma for
+  `(l.toArray).toList = l` is `List.toList_toArray` (not `Array.toList_toArray`).
+  For `(xs.push a).getD`, `HexBerlekampZassenhaus/Basic.lean` already has
+  `array_getD_push_lt`/`array_getD_push_size`/`array_toList_getD` — reuse them.
+
 ## Signature gotcha
 
 A hypothesis whose type mentions `toMathlibPolynomial`/`monicModPImage`/`modP`

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -6288,6 +6288,36 @@ theorem dilate_transformedCore (core : ZPoly) (degree : Nat)
 
 end ZPoly.ToMonicData
 
+namespace ZPoly
+
+/-- Public face of the inverse-recovery keystone, stated on the `toMonic` monic
+field rather than the private `transformedCore`. For a core of degree `≥ 1`,
+dilating `(toMonic core).monic` by the leading coefficient recovers `core`
+scaled by `leadingCoeff core ^ (degree - 1)`. Holds in both the already-monic
+and the genuine transform branch. -/
+theorem dilate_monic_toMonic (core : ZPoly)
+    (hdeg : 1 ≤ (toMonic core).degree) :
+    Hex.ZPoly.dilate (DensePoly.leadingCoeff core) ((toMonic core).monic) =
+      DensePoly.C (DensePoly.leadingCoeff core ^ ((toMonic core).degree - 1)) *
+        core := by
+  by_cases hmonic : DensePoly.leadingCoeff core = 1
+  · have hmon : (toMonic core).monic = core :=
+      toMonic_monic_eq_core_of_leadingCoeff_eq_one core hmonic
+    rw [hmon, hmonic, Hex.ZPoly.dilate_one, Int.one_pow, Hex.ZPoly.C_mul_eq_scale]
+    symm
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_scale_semiring, Int.one_mul]
+  · have hmon : (toMonic core).monic =
+        ToMonicData.transformedCore core (core.degree?.getD 0) := by
+      simp [toMonic, hmonic]
+    have hdeg' : 1 ≤ core.degree?.getD 0 := by
+      rw [toMonic_degree] at hdeg; exact hdeg
+    rw [hmon, toMonic_degree]
+    exact ToMonicData.dilate_transformedCore core (core.degree?.getD 0) hdeg' rfl
+
+end ZPoly
+
 private theorem bhksIndicatorCandidatesStep_fold_preserves_prefix
     (f : ZPoly) (d : LiftData)
     (indicators : List (Array Int)) (acc candidates : Array ZPoly)

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -6208,6 +6208,86 @@ private theorem array_getD_push_size {α : Type}
   rw [hsize]
   simp
 
+/-- Powers of an integer add their exponents. The executable layer is
+Mathlib-free, so the generic `pow_add` is unavailable; this small induction
+stands in for it. -/
+private theorem int_pow_add (a : Int) (m k : Nat) :
+    a ^ (m + k) = a ^ m * a ^ k := by
+  induction k with
+  | zero => rw [Nat.add_zero, Lean.Grind.Semiring.pow_zero, Int.mul_one]
+  | succ k ih =>
+      rw [Nat.add_succ, Lean.Grind.Semiring.pow_succ, ih,
+        Lean.Grind.Semiring.pow_succ, Int.mul_assoc]
+
+namespace ZPoly.ToMonicData
+
+/-- General coefficient law for the monic transform `transformedCore`. Below the
+top degree the coefficient is `core.coeff n` scaled by a power of the leading
+coefficient; the top coefficient is `1`; higher coefficients vanish. -/
+theorem transformedCore_coeff (core : ZPoly) (degree n : Nat) :
+    (transformedCore core degree).coeff n =
+      if n < degree then
+        core.coeff n * DensePoly.leadingCoeff core ^ (degree - 1 - n)
+      else if n = degree then 1 else 0 := by
+  rcases Nat.lt_trichotomy n degree with h | h | h
+  · rw [if_pos h]
+    change (transformedCoeffs core degree).getD n (0 : Int) = _
+    unfold transformedCoeffs
+    rw [array_getD_push_lt ((List.range degree).map
+          (fun i => core.coeff i * DensePoly.leadingCoeff core ^ (degree - 1 - i))).toArray
+        1 0 (by simpa using h)]
+    rw [← array_toList_getD, List.toList_toArray, List.getD_eq_getElem?_getD,
+      List.getElem?_map, List.getElem?_range h]
+    simp
+  · subst h
+    rw [if_neg (Nat.lt_irrefl _), if_pos rfl]
+    exact transformedCore_coeff_top core n
+  · rw [if_neg (by omega), if_neg (by omega)]
+    exact DensePoly.coeff_eq_zero_of_size_le _ (by rw [transformedCore_size]; omega)
+
+/-- **Keystone for `toMonic` inverse recovery.** Dilating the monic transform
+`transformedCore core degree` by the leading coefficient recovers `core` scaled
+by `leadingCoeff core ^ (degree - 1)`. The `1 ≤ degree` hypothesis is essential:
+for a constant `core` the identity fails unless the leading coefficient is `1`.
+Composed with `dilate_mul`, this is the inverse-factor correspondence the
+recombination recovery proof rests on. -/
+theorem dilate_transformedCore (core : ZPoly) (degree : Nat)
+    (hdeg : 1 ≤ degree) (hcore : core.degree?.getD 0 = degree) :
+    Hex.ZPoly.dilate (DensePoly.leadingCoeff core) (transformedCore core degree) =
+      DensePoly.C (DensePoly.leadingCoeff core ^ (degree - 1)) * core := by
+  have hsize_pos : 0 < core.size := by
+    rcases Nat.eq_zero_or_pos core.size with hz | hpos
+    · rw [show core.degree?.getD 0 = 0 by simp [DensePoly.degree?, hz]] at hcore
+      omega
+    · exact hpos
+  have hsize : core.size = degree + 1 := by
+    have hne : core.size ≠ 0 := by omega
+    have hdeg' : core.degree?.getD 0 = core.size - 1 := by
+      simp [DensePoly.degree?, hne]
+    omega
+  apply DensePoly.ext_coeff
+  intro n
+  rw [Hex.ZPoly.coeff_dilate, transformedCore_coeff, Hex.ZPoly.C_mul_eq_scale,
+    DensePoly.coeff_scale_semiring]
+  rcases Nat.lt_trichotomy n degree with h | h | h
+  · rw [if_pos h]
+    have hexp : n + (degree - 1 - n) = degree - 1 := by omega
+    rw [← Int.mul_assoc,
+      Int.mul_comm (DensePoly.leadingCoeff core ^ n) (core.coeff n),
+      Int.mul_assoc, ← int_pow_add, hexp, Int.mul_comm]
+  · rw [h, if_neg (Nat.lt_irrefl _), if_pos rfl, Int.mul_one]
+    have hcoeff : core.coeff degree = DensePoly.leadingCoeff core := by
+      rw [DensePoly.leadingCoeff_eq_coeff_last core hsize_pos, hsize, Nat.add_sub_cancel]
+    rw [hcoeff, ← Lean.Grind.Semiring.pow_succ]
+    congr 1
+    omega
+  · have hz : core.coeff n = 0 :=
+      DensePoly.coeff_eq_zero_of_size_le core (by omega)
+    rw [if_neg (by omega), if_neg (by omega), hz]
+    simp
+
+end ZPoly.ToMonicData
+
 private theorem bhksIndicatorCandidatesStep_fold_preserves_prefix
     (f : ZPoly) (d : LiftData)
     (indicators : List (Array Int)) (acc candidates : Array ZPoly)

--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -277,6 +277,79 @@ theorem isPrimitive_toPolynomial_of_primitive (f : Hex.ZPoly)
   rw [Polynomial.isPrimitive_iff_content_eq_one, toPolynomial_content]
   exact hf
 
+/-- A nonzero executable polynomial has nonzero content. -/
+theorem content_ne_zero (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.ZPoly.content f ≠ 0 := by
+  intro hz
+  apply hf
+  have hz' : (toPolynomial f).content = 0 := by rw [toPolynomial_content]; exact hz
+  rw [Polynomial.content_eq_zero_iff] at hz'
+  rw [← ofPolynomial_toPolynomial f, hz', ofPolynomial_zero]
+
+/-- **Packaged recombination recovery.** Given the keystone product identity
+`C (lc^(d-1)) * core = dilate lc g * dilate lc h` (the executable keystone
+`dilate_transformedCore` combined with `dilate_mul`), with `lc ≠ 0` and a nonzero
+`core`, the primitive part of `dilate lc g` divides `core`, is primitive, and has
+the same degree as `g`. This is the inverse-factor correspondence the
+recombination recovery proof consumes. -/
+theorem dilate_recovery (core g h : Hex.ZPoly) (lc : ℤ) (d : ℕ)
+    (hlc0 : lc ≠ 0) (hcore0 : core ≠ 0)
+    (hkey : Hex.DensePoly.C (lc ^ (d - 1)) * core =
+              Hex.ZPoly.dilate lc g * Hex.ZPoly.dilate lc h) :
+    toPolynomial (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate lc g)) ∣
+        toPolynomial core ∧
+      Hex.ZPoly.Primitive (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate lc g)) ∧
+      (toPolynomial (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate lc g))).natDegree =
+        (toPolynomial g).natDegree := by
+  -- Transport the keystone identity into `Polynomial ℤ`.
+  have hkeyP : Polynomial.C (lc ^ (d - 1)) * toPolynomial core =
+      toPolynomial (Hex.ZPoly.dilate lc g) *
+        toPolynomial (Hex.ZPoly.dilate lc h) := by
+    have h := congrArg toPolynomial hkey
+    rwa [toPolynomial_mul, toPolynomial_mul, toPolynomial_C] at h
+  set G := toPolynomial (Hex.ZPoly.dilate lc g) with hG
+  set K := toPolynomial core with hK
+  set pg := Hex.ZPoly.primitivePart (Hex.ZPoly.dilate lc g) with hpg
+  -- Nonvanishing facts.
+  have hk0 : lc ^ (d - 1) ≠ 0 := pow_ne_zero _ hlc0
+  have hK0 : K ≠ 0 := by
+    rw [hK]; intro hz
+    exact hcore0 (by rw [← ofPolynomial_toPolynomial core, hz, ofPolynomial_zero])
+  have hlhs0 : Polynomial.C (lc ^ (d - 1)) * K ≠ 0 :=
+    mul_ne_zero (Polynomial.C_ne_zero.mpr hk0) hK0
+  have hG0 : G ≠ 0 := left_ne_zero_of_mul (hkeyP ▸ hlhs0)
+  have hdg0 : Hex.ZPoly.dilate lc g ≠ 0 := by
+    intro hz; exact hG0 (by rw [hG, hz, toPolynomial_zero])
+  -- (b) primitivity.
+  have hb : Hex.ZPoly.Primitive pg :=
+    Hex.ZPoly.primitivePart_primitive _ (content_ne_zero _ hdg0)
+  have hPgPrim : (toPolynomial pg).IsPrimitive :=
+    isPrimitive_toPolynomial_of_primitive pg hb
+  -- Decompose `G` through its content and primitive part.
+  have hGdecomp : G = Polynomial.C (Hex.ZPoly.content (Hex.ZPoly.dilate lc g)) *
+      toPolynomial pg := by
+    rw [hG, hpg]; exact toPolynomial_eq_C_content_mul_primitivePart _
+  -- (a) divisibility.
+  have hPg_dvd_G : toPolynomial pg ∣ G := by
+    rw [hGdecomp]; exact dvd_mul_left _ _
+  have hG_dvd : G ∣ Polynomial.C (lc ^ (d - 1)) * K := by
+    rw [hkeyP]; exact dvd_mul_right _ _
+  have hPg_dvd_CkK : toPolynomial pg ∣ Polynomial.C (lc ^ (d - 1)) * K :=
+    hPg_dvd_G.trans hG_dvd
+  have ha : toPolynomial pg ∣ K := by
+    rw [← hPgPrim.dvd_primPart_iff_dvd hK0]
+    have hkpp := (hPgPrim.dvd_primPart_iff_dvd hlhs0).mpr hPg_dvd_CkK
+    rw [Polynomial.primPart_mul hlhs0] at hkpp
+    exact ((Polynomial.isUnit_primPart_C (lc ^ (d - 1))).dvd_mul_left).mp hkpp
+  -- (c) degree.
+  have hc : (toPolynomial pg).natDegree = (toPolynomial g).natDegree := by
+    have hcontent0 : Hex.ZPoly.content (Hex.ZPoly.dilate lc g) ≠ 0 :=
+      content_ne_zero _ hdg0
+    have hGdeg : G.natDegree = (toPolynomial pg).natDegree := by
+      rw [hGdecomp, Polynomial.natDegree_C_mul hcontent0]
+    rw [← hGdeg, hG, natDegree_toPolynomial_dilate lc hlc0]
+  exact ⟨ha, hb, hc⟩
+
 end
 
 end HexPolyZMathlib

--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -250,7 +250,7 @@ theorem toPolynomial_content (f : Hex.ZPoly) :
     (toPolynomial f).content = Hex.ZPoly.content f := by
   have hnonneg : 0 ≤ Hex.ZPoly.content f := by
     unfold Hex.ZPoly.content Hex.DensePoly.content
-    exact Int.ofNat_nonneg _
+    exact Int.natCast_nonneg _
   refine dvd_antisymm_of_normalize_eq Polynomial.normalize_content
     (Int.normalize_of_nonneg hnonneg) ?_ ?_
   · rw [← Int.natAbs_dvd]

--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -4,6 +4,8 @@ import HexModArithMathlib
 import Mathlib.Algebra.Polynomial.Degree.Units
 import Mathlib.Algebra.Ring.Int.Units
 import Mathlib.Data.ZMod.Basic
+import Mathlib.RingTheory.Polynomial.Content
+import Mathlib.Algebra.GCDMonoid.Nat
 import HexPolyZ
 
 /-!
@@ -233,6 +235,47 @@ theorem natDegree_toPolynomial_dilate (c : ℤ) (hc : c ≠ 0) (g : Hex.ZPoly) :
       (toPolynomial g).natDegree := by
   rw [toPolynomial_dilate, Polynomial.natDegree_comp,
     Polynomial.natDegree_C_mul_X c hc, mul_one]
+
+/-! ### Gauss content/primitive-part correspondence
+
+The executable `Hex.ZPoly.content`/`primitivePart` carry their own Gauss theory
+(`content_mul`, `content_mul_primitivePart`, `primitivePart_primitive`). These
+lemmas relate that theory to Mathlib's `Polynomial.content`/`primPart`, so the
+recombination recovery proof can lean on Mathlib's Gauss lemma machinery. -/
+
+/-- The Mathlib content of the embedded polynomial agrees with the executable
+integer content. Both are the normalized (nonnegative) gcd of the coefficients,
+so this is the Gauss bridge between the two content theories. -/
+theorem toPolynomial_content (f : Hex.ZPoly) :
+    (toPolynomial f).content = Hex.ZPoly.content f := by
+  have hnonneg : 0 ≤ Hex.ZPoly.content f := by
+    unfold Hex.ZPoly.content Hex.DensePoly.content
+    exact Int.ofNat_nonneg _
+  refine dvd_antisymm_of_normalize_eq Polynomial.normalize_content
+    (Int.normalize_of_nonneg hnonneg) ?_ ?_
+  · rw [← Int.natAbs_dvd]
+    refine Hex.ZPoly.dvd_content_of_nat_dvd_coeff f _ (fun n => ?_)
+    rw [Int.natAbs_dvd, ← coeff_toPolynomial]
+    exact Polynomial.content_dvd_coeff n
+  · rw [Polynomial.dvd_content_iff_C_dvd, Polynomial.C_dvd_iff_dvd_coeff]
+    intro n
+    rw [coeff_toPolynomial]
+    exact Hex.ZPoly.content_dvd_coeff f n
+
+/-- Gauss content decomposition transported to Mathlib: the embedded polynomial
+is its content times the embedded primitive part. -/
+theorem toPolynomial_eq_C_content_mul_primitivePart (f : Hex.ZPoly) :
+    toPolynomial f =
+      Polynomial.C (Hex.ZPoly.content f) *
+        toPolynomial (Hex.ZPoly.primitivePart f) := by
+  conv_lhs => rw [← Hex.ZPoly.content_mul_primitivePart f]
+  rw [← Hex.ZPoly.C_mul_eq_scale, toPolynomial_mul, toPolynomial_C]
+
+/-- A primitive executable polynomial embeds to a Mathlib-primitive polynomial. -/
+theorem isPrimitive_toPolynomial_of_primitive (f : Hex.ZPoly)
+    (hf : Hex.ZPoly.Primitive f) : (toPolynomial f).IsPrimitive := by
+  rw [Polynomial.isPrimitive_iff_content_eq_one, toPolynomial_content]
+  exact hf
 
 end
 

--- a/progress/20260613T150000Z_issue-6807.md
+++ b/progress/20260613T150000Z_issue-6807.md
@@ -1,0 +1,57 @@
+# Progress: #6807 — toMonic inverse-factor recovery (keystone + Gauss bridge)
+
+## Accomplished
+
+Landed all three deliverables of #6807, each building green.
+
+- **D1 (executable keystone)** in `HexBerlekampZassenhaus/Basic.lean`:
+  `ToMonicData.dilate_transformedCore` —
+  `dilate (leadingCoeff core) (transformedCore core d) = C (lc^(d-1)) * core`
+  for `d ≥ 1` — plus the general coefficient law `transformedCore_coeff`
+  and a Mathlib-free `int_pow_add` helper. Placed near the existing array
+  `getD`/`push` helpers so it can reuse them. Also added the public face
+  `ZPoly.dilate_monic_toMonic`, stated on `(toMonic core).monic` (covering
+  both the already-monic and transform branches) so a Mathlib-side consumer
+  can produce the product identity without naming the private
+  `transformedCore`.
+
+- **D2 (Gauss content/primPart bridge)** in `HexPolyZMathlib/Basic.lean`:
+  `toPolynomial_content` (the executable nonneg-gcd content equals Mathlib's
+  `Polynomial.content`), `toPolynomial_eq_C_content_mul_primitivePart`
+  (decomposition), `isPrimitive_toPolynomial_of_primitive`, and
+  `content_ne_zero`. This is the "main missing prerequisite" the issue flags.
+
+- **D3 (packaged recovery)** in `HexPolyZMathlib/Basic.lean`:
+  `dilate_recovery` — from `C(lc^(d-1)) * core = dilate lc g * dilate lc h`
+  with `lc ≠ 0`, `core ≠ 0`, concludes
+  `toPolynomial (primitivePart (dilate lc g)) ∣ toPolynomial core`, that the
+  primitive part is `Primitive`, and that its `natDegree` matches `g`. Routes
+  through the D2 bridge and Mathlib's `IsPrimitive.dvd_primPart_iff_dvd`,
+  `primPart_mul`, `isUnit_primPart_C`, `natDegree_C_mul`.
+
+## Decisions
+
+- Put D2/D3 in `HexPolyZMathlib` rather than `HexBerlekampZassenhausMathlib`
+  (the issue's tentative location). HexPolyZMathlib is the proper home for a
+  reusable Gauss bridge — lower in the import DAG, builds completely clean,
+  and avoids the pre-existing `HexBerlekampZassenhausMathlib/Basic.lean:15990`
+  error owned by the #6801 remodel. The consumer
+  (`HexBerlekampZassenhausMathlib`) imports both `HexBerlekampZassenhaus` and
+  `HexPolyZMathlib.Basic`, so all pieces are visible to #6801.
+- D3 is stated abstractly on the product identity (not on the private
+  `transformedCore`). #6801 supplies that identity via
+  `ZPoly.dilate_monic_toMonic` + `HexPolyZMathlib.dilate_mul`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus` green.
+- `lake build HexPolyZMathlib` green.
+- No `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` introduced.
+- `HexBerlekampZassenhausMathlib` is untouched; its pre-existing 15990 error
+  (owned by #6801) is unchanged, and the new lemmas are now importable there.
+
+## Next step
+
+#6801's recovery/coverage remodel consumes `dilate_recovery` +
+`dilate_monic_toMonic` to replace the old scale-based recovery model and
+clear the `Basic.lean:15990` seam.


### PR DESCRIPTION
This PR adds the `toMonic` inverse-factor recovery API that the #6801 recombination remodel consumes. It lands the executable keystone `ToMonicData.dilate_transformedCore` (dilating the monic transform by the leading coefficient recovers `core` scaled by `leadingCoeff core ^ (degree - 1)`, for `degree ≥ 1`) together with the general coefficient law `transformedCore_coeff` and a Mathlib-free `int_pow_add` helper, and exposes the public face `ZPoly.dilate_monic_toMonic` on the `(toMonic core).monic` field so a Mathlib-side consumer can build the product identity without naming the private `transformedCore`. On the Mathlib side it adds the reusable Gauss bridge between the executable `Hex.ZPoly.content`/`primitivePart` and Mathlib's `Polynomial.content`/`primPart` (`toPolynomial_content`, `toPolynomial_eq_C_content_mul_primitivePart`, `isPrimitive_toPolynomial_of_primitive`, `content_ne_zero`), and the packaged `dilate_recovery` lemma: from `C(lc^(d-1)) * core = dilate lc g * dilate lc h` with `lc ≠ 0` and nonzero `core`, the primitive part of `dilate lc g` divides `core`, is primitive, and matches the degree of `g`.

The Gauss bridge and recovery lemma live in `HexPolyZMathlib` rather than `HexBerlekampZassenhausMathlib` (the issue's tentative location): it is the proper home for a reusable content/primitive-part correspondence, sits lower in the import DAG, and builds completely clean while `HexBerlekampZassenhausMathlib` still carries the pre-existing `Basic.lean:15990` seam owned by #6801. The consumer imports both `HexBerlekampZassenhaus` and `HexPolyZMathlib.Basic`, so every piece is visible to the remodel.

Closes #6807.

🤖 Prepared with Claude Code