### PR TITLE
feat: add Sylvester common-factor column-reduction step

### DIFF
--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -110,6 +110,26 @@ theorem det_dvd_of_left_cols_dvd
       (fun j : Fin d => A (σ (j.castAdd n)) (j.castAdd n))
       (fun j => hcols j (σ (j.castAdd n))))
 
+/--
+Replacing a column of a square matrix by `A.mulVec w` — the linear combination
+of all columns with coefficients `w` — multiplies the determinant by the
+coefficient `w p` of the replaced column.
+
+This is the determinant-preserving column-operation mechanism: when the
+replaced column appears in the combination with a *unit* coefficient (`w p = 1`,
+the monic-triangular case), the determinant is preserved exactly. It is the
+column-form repackaging of `Matrix.det_updateCol_sum` against `mulVec`.
+-/
+theorem det_updateCol_mulVec
+    {R : Type*} [CommRing R] {N : Nat}
+    (A : Matrix (Fin N) (Fin N) R) (p : Fin N) (w : Fin N → R) :
+    (A.updateCol p (A.mulVec w)).det = w p • A.det := by
+  have hcol : A.mulVec w = (fun k => ∑ i, w i • A k i) := by
+    funext k
+    simp only [Matrix.mulVec, dotProduct, smul_eq_mul]
+    exact Finset.sum_congr rfl (fun i _ => mul_comm _ _)
+  rw [hcol, Matrix.det_updateCol_sum]
+
 /-- Squared `l2norm` of an integer polynomial expressed as a sum of squared
 coefficients over `Finset.range (natDegree + 1)`, padding with zeros outside
 `support`. -/
@@ -471,6 +491,43 @@ theorem sylvester_mulVec_commonFactor_smul
   rw [hmat, LinearMap.toMatrix_mulVec_repr]
   rw [Polynomial.degreeLT.basis_repr, sylvesterMap_commonFactor_smul,
     Polynomial.coeff_C_mul]
+
+/--
+The monic-triangular column-reduction step for the Sylvester matrix.
+
+Write `w` for the coordinate vector of the shifted common-factor direction
+`(-a * X^t, b * X^t)`. Replacing column `p` of the Sylvester matrix `S` by the
+combination `S.mulVec w` (the syzygy column):
+
+- multiplies the determinant by the pivot coefficient `w p`
+  (`det_updateCol_mulVec`); in the monic-triangular case `w p = 1` this is a
+  determinant-*preserving* operation, and
+- produces a column whose every entry is divisible by the scalar `c`
+  (`sylvester_mulVec_commonFactor_smul`).
+
+Assembling this step over the `d = q.natDegree` shifts `t < d`, with the pivots
+chosen so each `w p = 1`, gives the matrix `A'` of the column-reduction target:
+`A'.det = S.det` with `d` columns entrywise divisible by `c`. The remaining work
+is the bookkeeping that the chosen pivots carry unit coefficients (a leading
+coefficient of the cofactor, hence `1` under the monic hypothesis) and that the
+combinations reference only as-yet-unreplaced columns.
+-/
+theorem sylvester_commonFactor_colReduceStep
+    {R : Type*} [CommRing R]
+    (q a b r s : Polynomial R) (c : R) {m n t : Nat}
+    (hleft : -a * Polynomial.X ^ t ∈ Polynomial.degreeLT R m)
+    (hright : b * Polynomial.X ^ t ∈ Polynomial.degreeLT R n)
+    (hf : (q * a + Polynomial.C c * r).natDegree ≤ m)
+    (hg : (q * b + Polynomial.C c * s).natDegree ≤ n)
+    (p : Fin (m + n)) :
+    let S := Polynomial.sylvester (q * a + Polynomial.C c * r) (q * b + Polynomial.C c * s) m n
+    let w := (Polynomial.degreeLT.basisProd R m n).repr
+      (⟨-a * Polynomial.X ^ t, hleft⟩, ⟨b * Polynomial.X ^ t, hright⟩)
+    (S.updateCol p (S.mulVec w)).det = w p • S.det ∧
+      ∀ k, c ∣ (S.mulVec w) k := by
+  refine ⟨det_updateCol_mulVec _ p _, fun k => ?_⟩
+  rw [sylvester_mulVec_commonFactor_smul q a b r s c hleft hright hf hg k]
+  exact Dvd.intro _ rfl
 
 end
 

--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -441,6 +441,37 @@ theorem sylvesterMap_commonFactor_smul
   dsimp [Polynomial.sylvesterMap]
   ring
 
+/--
+Each entry of the Sylvester column combination selected by the shifted
+common-factor direction `(-a * X^t, b * X^t)` is the scalar `c` times a fixed
+coefficient.
+
+The coordinate vector of the direction in the product basis multiplies the
+Sylvester matrix to the coordinate vector of the image
+`C c * ((r * b - s * a) * X^t)` (`sylvesterMap_commonFactor_smul`), whose
+coefficients are visibly `c`-multiples. Hence the selected column combination
+is entrywise divisible by `c`: this is the per-entry input the determinant
+column-reduction needs once the `q.natDegree` shifts are assembled.
+-/
+theorem sylvester_mulVec_commonFactor_smul
+    {R : Type*} [CommRing R]
+    (q a b r s : Polynomial R) (c : R) {m n t : Nat}
+    (hleft : -a * Polynomial.X ^ t ∈ Polynomial.degreeLT R m)
+    (hright : b * Polynomial.X ^ t ∈ Polynomial.degreeLT R n)
+    (hf : (q * a + Polynomial.C c * r).natDegree ≤ m)
+    (hg : (q * b + Polynomial.C c * s).natDegree ≤ n)
+    (i : Fin (m + n)) :
+    (Polynomial.sylvester (q * a + Polynomial.C c * r) (q * b + Polynomial.C c * s) m n).mulVec
+        ((Polynomial.degreeLT.basisProd R m n).repr
+          (⟨-a * Polynomial.X ^ t, hleft⟩, ⟨b * Polynomial.X ^ t, hright⟩)) i
+      = c * ((r * b - s * a) * Polynomial.X ^ t).coeff i := by
+  have hmat := (Polynomial.toMatrix_sylvesterMap' (q * a + Polynomial.C c * r)
+    (q * b + Polynomial.C c * s) hf hg).symm
+  rw [Polynomial.degreeLT.basisProd] at *
+  rw [hmat, LinearMap.toMatrix_mulVec_repr]
+  rw [Polynomial.degreeLT.basis_repr, sylvesterMap_commonFactor_smul,
+    Polynomial.coeff_C_mul]
+
 end
 
 end HexBerlekampZassenhausMathlib

--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -412,6 +412,35 @@ theorem sylvesterMap_commonFactor_syzygy
   dsimp [Polynomial.sylvesterMap]
   ring_nf
 
+/--
+Scalar-shifted common-factor syzygy for the Sylvester map.
+
+When `f` and `g` share the factor `q` only after reducing modulo a scalar `c`
+— recorded by the explicit witnesses `f = q * a + C c * r` and
+`g = q * b + C c * s` — the shifted pair `(-a * X^t, b * X^t)` is no longer
+killed by the Sylvester map, but its image is the *scalar multiple*
+`C c * ((r * b - s * a) * X^t)`.
+
+This is the bridge from the exact syzygy `sylvesterMap_commonFactor_syzygy`
+(the `c = 0` case) to the divisibility used by the column-reduction proof: the
+linear combination of Sylvester columns selected by `(-a * X^t, b * X^t)` is
+entrywise divisible by `c`. Taking `t < q.natDegree` shifts gives `d`
+independent such combinations.
+-/
+theorem sylvesterMap_commonFactor_smul
+    {R : Type*} [CommRing R]
+    (q a b r s : Polynomial R) (c : R) {m n t : Nat}
+    (hleft : -a * Polynomial.X ^ t ∈ Polynomial.degreeLT R m)
+    (hright : b * Polynomial.X ^ t ∈ Polynomial.degreeLT R n)
+    (hf : (q * a + Polynomial.C c * r).natDegree ≤ m)
+    (hg : (q * b + Polynomial.C c * s).natDegree ≤ n) :
+    (Polynomial.sylvesterMap (q * a + Polynomial.C c * r) (q * b + Polynomial.C c * s) hf hg
+      (⟨-a * Polynomial.X ^ t, hleft⟩,
+       ⟨b * Polynomial.X ^ t, hright⟩) : Polynomial R)
+      = Polynomial.C c * ((r * b - s * a) * Polynomial.X ^ t) := by
+  dsimp [Polynomial.sylvesterMap]
+  ring
+
 end
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260614T020000Z_15d7753f.md
+++ b/progress/20260614T020000Z_15d7753f.md
@@ -1,0 +1,83 @@
+# Progress: #6857 — Sylvester monic-triangular column transform (partial)
+
+## Accomplished
+
+Landed the complete *mechanism* for the common-factor Sylvester
+column reduction in `HexBerlekampZassenhausMathlib/Resultant.lean`, as
+four reusable lemmas over a general `CommRing R` with scalar `c`:
+
+- `sylvesterMap_commonFactor_smul` — the `c`-scaled generalization of
+  the exact syzygy `sylvesterMap_commonFactor_syzygy`. From witnesses
+  `f = q*a + C c*r`, `g = q*b + C c*s`, the image of the
+  `(-a X^t, b X^t)` direction is `C c * ((r*b - s*a) * X^t)` (the exact
+  syzygy is the `c = 0` case).
+- `sylvester_mulVec_commonFactor_smul` — multiplying the Sylvester
+  matrix by the coordinate vector of that direction gives entry `i`
+  equal to `c * ((r*b - s*a) * X^t).coeff i`. Routes through
+  `toMatrix_sylvesterMap'` + `LinearMap.toMatrix_mulVec_repr` +
+  `degreeLT.basis_repr`. So the selected column combination is
+  entrywise divisible by `c`.
+- `det_updateCol_mulVec` — general matrix fact: replacing column `p` by
+  `A.mulVec w` multiplies the determinant by the pivot coefficient
+  `w p`. Column-form repackaging of `Matrix.det_updateCol_sum`.
+- `sylvester_commonFactor_colReduceStep` — capstone: the single column
+  step. Replacing a Sylvester column by the syzygy combination scales
+  `det` by the pivot coefficient `w p` and yields a column divisible by
+  `c`. Det-preserving exactly when `w p = 1`.
+
+## Key finding (premise refinement for the assembled `A'`)
+
+The literal deliverable `A'.det = sylvester.det` with `d` divisible
+columns is achievable, but **only when each pivot coefficient is a
+unit**. The pivot coefficient `w p` at the natural pivot (top cofactor
+shift column, position `(n-d)+t` on the `f`-shift side) is the cofactor
+leading coefficient `b.coeff (n-d) = leadingCoeff b`. With a *monic*
+cofactor it is `1` and the step is determinant-preserving — this is
+exactly the "monic triangular" structure the issue title names.
+
+Without the monic/unit hypothesis the step instead scales `det` by
+`(leadingCoeff b)^d`, so the honest general statement is
+`A'.det = (leadingCoeff g)^d * sylvester.det` (given `q.Monic`,
+`leadingCoeff g = leadingCoeff b`). Either form serves #6858: the monic
+form gives `A'.det = sylvester.det` directly; the general form needs
+`#6858` to clear the `(leadingCoeff g)^d` factor by coprimality of `c`
+with the leading coefficient (the `p ∤ lc` primitivity already present
+in the BZ setting). This is the "genuinely required side condition" the
+issue invited; it is not an unsoundness — the transform exists either
+way.
+
+## Current frontier
+
+The single-column step is complete and verified. Remaining: assemble it
+over the `d = q.natDegree` shifts `t : Fin d` into the matrix `A'`.
+
+## Next step (assembly recipe)
+
+1. Set `m = f.natDegree`, `n = g.natDegree`, `d = q.natDegree`.
+2. Pivots `p_t = (⟨(n-d)+t, _⟩ : Fin n).natAdd m` (top `d` `f`-shift
+   columns). The `w_t`-coordinate at `p_t` is `b.coeff (n-d)`; under the
+   monic-cofactor side condition this is `1`.
+3. Iterate `sylvester_commonFactor_colReduceStep` over `t` in
+   **decreasing** order. The direction `w_t` is supported (on the
+   `f`-shift block) at positions `t .. t+(n-d)`, so it references pivots
+   `p_{t'}` only for `t' ≤ t`; processing decreasing `t` keeps every
+   referenced column unreplaced, so each combination stays the clean
+   `c`-divisible vector.
+4. Each step preserves `det` (unit pivot) and adds one `c`-divisible
+   column; after `d` steps `A'.det = sylvester.det` with `d` columns
+   divisible by `c`.
+5. `#6858` then feeds `A'` to `det_dvd_of_left_cols_dvd` (after a column
+   reindex moving the divisible block to the left) and rewrites the
+   Sylvester determinant to `resultant`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Resultant` succeeds.
+- `python3 scripts/check_dag.py` exits 0.
+- No `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` on added lines.
+
+## Blockers
+
+None. The assembly is mechanical given the step; the only design choice
+is whether to carry the monic-cofactor side condition (clean
+`A'.det = sylvester.det`) or the general `(leadingCoeff g)^d` factor.


### PR DESCRIPTION
This PR adds the common-factor Sylvester column-reduction step toward #6857: replacing a Sylvester column by the syzygy combination selected by the shifted direction `(-a X^t, b X^t)` scales the determinant by the pivot coefficient and produces a column entrywise divisible by the scalar `c`. It lands four reusable lemmas over a general commutative ring — `sylvesterMap_commonFactor_smul` (the `c`-scaled generalization of the exact syzygy, image `C c * ((r*b - s*a) X^t)`), `sylvester_mulVec_commonFactor_smul` (the selected column combination is entrywise `c`-divisible, via `toMatrix_sylvesterMap'` and `LinearMap.toMatrix_mulVec_repr`), `det_updateCol_mulVec` (replacing a column by `A.mulVec w` multiplies the determinant by the pivot coefficient `w p`), and the capstone `sylvester_commonFactor_colReduceStep` combining the two.

This is a partial step toward the assembled matrix `A'`. The single-column mechanism is complete and verified; the remaining work iterates it over the `d = q.natDegree` shifts. The pivot coefficient `w p` equals the cofactor leading coefficient `leadingCoeff b`, so the operation is determinant-preserving exactly in the monic-triangular case the issue title names (`A'.det = sylvester.det`); without the monic side condition it scales by `(leadingCoeff g)^d`. The assembly recipe (decreasing-shift ordering so each combination references only unreplaced columns) and side-condition analysis are recorded in the progress note and on #6857.

Closes nothing; #6857 is marked `replan` for the assembly follow-up.

🤖 Prepared with Claude Code