### PR TITLE
HexPolyFp: prove derivative-split quotient cannot be non-one scalar

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -5591,6 +5591,51 @@ private theorem derivativeSplit_residual_derivative_zero_of_coprime
         exact hcoprime d (by simpa [c, g] using hdc) (by simpa [g] using hdg))
   exact derivative_isZero_true_of_dvd_self_derivative g hg_dvd_dg
 
+private theorem derivativeSplit_quotient_size_one_eq_one
+    (hp : Hex.Nat.Prime p) (f : FpPoly p)
+    (hdf : (DensePoly.derivative f).isZero ≠ true) :
+    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let c := f / g
+    c.size = 1 → c = 1 := by
+  dsimp
+  letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
+  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let c := f / g
+  intro hc_size
+  have hdf_false : (DensePoly.derivative f).isZero = false := by
+    cases h : (DensePoly.derivative f).isZero
+    · rfl
+    · exact False.elim (hdf h)
+  have hc_der : (DensePoly.derivative c).isZero = true :=
+    derivative_isZero_true_of_size_one c hc_size
+  have hcoprime :
+      ∀ d : FpPoly p, d ∣ c → d ∣ g → d ∣ (1 : FpPoly p) := by
+    intro d hdc _hdg
+    exact derivativeSplit_quotient_common_dvd_derivative_one hp f hdf d hdc
+      (by
+        refine ⟨0, ?_⟩
+        rw [mul_zero, eq_zero_of_isZero_true (DensePoly.derivative c) hc_der])
+  have hg_der : (DensePoly.derivative g).isZero = true :=
+    derivativeSplit_residual_derivative_zero_of_coprime hp f hdf_false (by
+      intro d hdc hdg
+      exact hcoprime d (by simpa [c, g] using hdc) (by simpa [g] using hdg))
+  have hprod : c * g = f := by
+    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+  have hdf_zero : DensePoly.derivative f = 0 := by
+    rw [← hprod]
+    calc
+      DensePoly.derivative (c * g) =
+          DensePoly.derivative c * g + c * DensePoly.derivative g := by
+            exact DensePoly.derivative_mul c g
+      _ = 0 * g + c * 0 := by
+            rw [eq_zero_of_isZero_true (DensePoly.derivative c) hc_der]
+            rw [eq_zero_of_isZero_true (DensePoly.derivative g) hg_der]
+      _ = 0 := by simp
+  exfalso
+  apply hdf
+  rw [hdf_zero]
+  rfl
+
 private theorem yunFactorsPairwiseReachable_common_dvd_one_derivativeSplit
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (_fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :

--- a/progress/20260613T183218Z_0826fbba.md
+++ b/progress/20260613T183218Z_0826fbba.md
@@ -1,0 +1,32 @@
+## Accomplished
+
+Claimed #6903 after the blocked directive #2564 was rejected by
+`coordination claim`.
+
+Added `derivativeSplit_quotient_size_one_eq_one` in
+`HexPolyFp/SquareFree.lean`. The proof uses the derivative-active split:
+if the quotient `c = f / gcd f f'` has size one, then `c' = 0`; the
+existing quotient/common-divisor lemma gives the coprime premise needed to
+force the residual gcd derivative to zero, and the product rule then
+contradicts the derivative-active hypothesis.
+
+Verified:
+
+- `lake build HexPolyFp.SquareFree`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Added-line scan for `sorry`, `axiom`, `native_decide`, `TODO`, `FIXME`
+
+## Current frontier
+
+The base case requested by #6903 is proved as a private lemma. No executable
+definitions were changed.
+
+## Next step
+
+Use this lemma in the dependent Yun provider work tracked by #6904.
+
+## Blockers
+
+None for #6903. The repository had a pre-existing uncommitted modification to
+`.claude/CLAUDE.md`; this session left it untouched.


### PR DESCRIPTION
Closes #6903

Session: `0826fbba-60fc-466a-8f9c-88ac56e5c98e`

fa1f0c9c feat: prove derivative split size-one quotient base

🤖 Prepared with Claude Code