### PR TITLE
feat: package map-to-ZMod resultant divisibility wrapper

### DIFF
--- a/HexBerlekampZassenhausMathlib/Resultant.lean
+++ b/HexBerlekampZassenhausMathlib/Resultant.lean
@@ -888,6 +888,94 @@ theorem commonFactor_dvd_resultant_of_monic_cofactor
   exact commonFactor_dvd_resultant f g q a b r s m hf_wit hg_wit hq_monic hq_deg
     hd ha hb hb_pivot
 
+/--
+Degree-controlled witness from a `ZMod n` divisibility by a *monic* `q`.
+
+Unlike `exists_witnesses_of_map_dvd_zmod`, which lifts an arbitrary modular
+quotient, this uses honest monic division: the quotient is `f /ₘ q` (so its
+degree is `f.natDegree - q.natDegree`) and the remainder `f %ₘ q` is
+coefficientwise divisible by `n`, packaged as `Polynomial.C (n : ℤ) * s`. The
+degree control is what the Sylvester column reduction in
+`commonFactor_dvd_resultant` needs.
+-/
+private theorem exists_divByMonic_witness {f q : Polynomial ℤ} {n : ℕ}
+    (hq : q.Monic)
+    (hdvd : q.map (Int.castRingHom (ZMod n)) ∣
+            f.map (Int.castRingHom (ZMod n))) :
+    ∃ s : Polynomial ℤ, f = q * (f /ₘ q) + Polynomial.C (n : ℤ) * s := by
+  have hqmap : (q.map (Int.castRingHom (ZMod n))).Monic := hq.map _
+  -- The monic-division remainder vanishes modulo `n`.
+  have hrem0 : (f %ₘ q).map (Int.castRingHom (ZMod n)) = 0 := by
+    rw [Polynomial.map_modByMonic (Int.castRingHom (ZMod n)) hq]
+    exact (Polynomial.modByMonic_eq_zero_iff_dvd hqmap).mpr hdvd
+  -- Hence each coefficient is divisible by `n`, so `C n` divides `f %ₘ q`.
+  have hCdvd : Polynomial.C (n : ℤ) ∣ (f %ₘ q) := by
+    rw [Polynomial.C_dvd_iff_dvd_coeff]
+    intro k
+    have hc : (((f %ₘ q).coeff k : ℤ) : ZMod n) = 0 := by
+      have h0 : ((f %ₘ q).map (Int.castRingHom (ZMod n))).coeff k = 0 := by
+        rw [hrem0]; simp
+      rwa [Polynomial.coeff_map] at h0
+    exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ n).mp hc
+  obtain ⟨s, hs⟩ := hCdvd
+  refine ⟨s, ?_⟩
+  have hsplit := Polynomial.modByMonic_add_div f q
+  rw [hs] at hsplit
+  linear_combination -hsplit
+
+/--
+BHKS Lemma 3.2 modular-resultant divisibility, in the form downstream
+Hensel/CLD code consumes.
+
+If a monic degree-`d` polynomial `q` divides both `f` and `g` after reduction
+modulo `p ^ k`, with `f` monic and `d` not exceeding either degree, then
+`p ^ (k * d)` divides the integer resultant of `f` and `g`.
+
+The exponent is `k * d`, not merely `k`: the monic common factor `q` contributes
+`d` independent Sylvester column directions, each carrying one factor of the
+modulus `p ^ k`, so the column reduction (`commonFactor_dvd_resultant`) turns
+those `d` directions into `(p ^ k) ^ d = p ^ (k * d)` dividing the resultant.
+Monicity of `f` supplies the unit pivot the reduction needs; the result is read
+off the swapped pair via `Polynomial.resultant_comm`.
+-/
+theorem pow_dvd_resultant_of_map_dvd
+    {p k : ℕ} {f g q : Polynomial ℤ} {d : ℕ}
+    (hq_monic : q.Monic)
+    (hq_deg : q.natDegree = d)
+    (hf_monic : f.Monic)
+    (hdf : d ≤ f.natDegree)
+    (hdg : d ≤ g.natDegree)
+    (hf_dvd : q.map (Int.castRingHom (ZMod (p ^ k))) ∣
+              f.map (Int.castRingHom (ZMod (p ^ k))))
+    (hg_dvd : q.map (Int.castRingHom (ZMod (p ^ k))) ∣
+              g.map (Int.castRingHom (ZMod (p ^ k)))) :
+    ((p ^ (k * d) : ℕ) : ℤ) ∣ Polynomial.resultant f g := by
+  -- Degree-controlled monic-division witnesses for both polynomials.
+  obtain ⟨r, hr⟩ := exists_divByMonic_witness hq_monic hg_dvd
+  obtain ⟨s, hs⟩ := exists_divByMonic_witness hq_monic hf_dvd
+  -- `q.degree ≤ f.degree`, needed for the leading-coefficient transfer.
+  have hdeg_le : q.degree ≤ f.degree := by
+    rw [Polynomial.degree_eq_natDegree hq_monic.ne_zero,
+        Polynomial.degree_eq_natDegree hf_monic.ne_zero, hq_deg]
+    exact_mod_cast hdf
+  -- The pivot cofactor `f /ₘ q` is monic because `f` is.
+  have hb_monic : (f /ₘ q).Monic := by
+    have := Polynomial.leadingCoeff_divByMonic_of_monic hq_monic hdeg_le
+    exact this.trans hf_monic
+  -- Apply the column-reduction lemma to the swapped pair `(g, f)`, so the monic
+  -- cofactor `f /ₘ q` of `f` plays the pivot role.
+  have key : ((p ^ k : ℕ) : ℤ) ^ d ∣ Polynomial.resultant g f := by
+    apply commonFactor_dvd_resultant_of_monic_cofactor g f q (g /ₘ q) (f /ₘ q)
+      r s ((p ^ k : ℕ) : ℤ) (d := d) hr hs hq_monic hq_deg hdf
+    · rw [Polynomial.natDegree_divByMonic g hq_monic, hq_deg]; omega
+    · rw [Polynomial.natDegree_divByMonic f hq_monic, hq_deg]; omega
+    · exact hb_monic
+  -- Convert `(p ^ k) ^ d` to `p ^ (k * d)` and read off `resultant f g` via comm.
+  have hcast : ((p ^ (k * d) : ℕ) : ℤ) = ((p ^ k : ℕ) : ℤ) ^ d := by
+    rw [pow_mul, Nat.cast_pow]
+  rw [hcast, Polynomial.resultant_comm]
+  exact key.mul_left _
+
 end
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260614T043000Z_b2306dd2.md
+++ b/progress/20260614T043000Z_b2306dd2.md
@@ -1,0 +1,75 @@
+# Progress: #6849 — package map-to-ZMod resultant divisibility wrapper
+
+Feature session. Implements the load-bearing BHKS Lemma 3.2-style public
+theorem (parent #6843) in `HexBerlekampZassenhausMathlib/Resultant.lean`.
+
+## Accomplished
+
+Added two declarations to `Resultant.lean`:
+
+- `exists_divByMonic_witness` (private): from a `ZMod n` divisibility of
+  mapped integer polynomials by a *monic* `q`, produces the
+  **degree-controlled** witness `f = q * (f /ₘ q) + C n * s` via honest monic
+  division (`%ₘ`/`/ₘ`), where the remainder vanishes mod `n`. This is the
+  bridge the directive's suggested `exists_witnesses_of_map_dvd_zmod` could not
+  supply: that helper lifts an *arbitrary* modular quotient with no degree or
+  monicity control, but the Sylvester column reduction in
+  `commonFactor_dvd_resultant` needs the cofactor's degree and pivot pinned.
+
+- `pow_dvd_resultant_of_map_dvd` (public): the wrapper. With `q` monic of
+  degree `d` dividing both `f` and `g` mod `p^k`, `f` monic, and
+  `d ≤ f.natDegree`, `d ≤ g.natDegree`, concludes
+  `((p^(k*d):ℕ):ℤ) ∣ Polynomial.resultant f g`. Proof builds monic-division
+  witnesses for both sides, applies `commonFactor_dvd_resultant_of_monic_cofactor`
+  to the *swapped* pair `(g, f)` so the monic cofactor `f /ₘ q` is the unit
+  pivot, then transfers across `Polynomial.resultant_comm` (the swap differs by
+  a `±1` unit, so divisibility carries through). The `(p^k)^d = p^(k*d)`
+  identity is `pow_mul` + `Nat.cast_pow`.
+
+Verified:
+- `lake build HexBerlekampZassenhausMathlib.Resultant` — succeeds, no errors,
+  no new warnings on added lines (pre-existing deprecation warnings at 677/716/844).
+- `python3 scripts/check_dag.py` — exit 0.
+- Added lines: no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.
+
+## Signature adjustment (directive deviation, documented)
+
+The directive's requested signature had **no monicity** on `f`/`g`. The proven
+infrastructure (`commonFactor_dvd_resultant`) scales the determinant by
+`(cofactor pivot)^d` and needs that pivot `= 1`. The natural cofactor's pivot
+equals the leading coefficient of the divided polynomial, so it is `1` only
+when that polynomial is monic. I therefore added `f.Monic` (the BZ input is the
+natural monic side — `inputPolynomial`) plus `d ≤ f.natDegree`, `d ≤ g.natDegree`.
+
+This does **not** weaken the conclusion (still `p^(k*d)`, not `p^k`); it adds
+hypotheses the current infra requires. The issue explicitly permitted adjusting
+the signature. The fully-general (non-monic) statement appears to be a true
+theorem but is **not reachable from current infrastructure** — it would need a
+new argument handling the `lc^d` pivot factor (degree-drop compensation, or a
+coprimality/localization argument). If downstream needs the non-monic form, that
+is a separate infrastructure issue, not a weakening of this one.
+
+## Current frontier
+
+The public theorem is in place and builds. Downstream `IsBhksBadVectorSetup`
+still stores `resultant_divisible_by_p_pow` as an assumed *field*; whoever
+discharges it can feed `pow_dvd_resultant_of_map_dvd` (with `f = inputPolynomial`
+monic + the Hensel-lifted local factor `q`).
+
+## Next step
+
+A follow-up could discharge the `resultant_divisible_by_p_pow` field in
+`BadVector.lean` using this wrapper, once the input-monicity and per-side
+`q | inputPolynomial / auxiliaryPolynomial mod p^k` facts are available from the
+Hensel lift data.
+
+## Blockers
+
+None for this issue. Note: `lake build HexBerlekampZassenhausMathlib`
+(whole-library) is **hard-red on main** at `Basic.lean:16475`
+(`normalizeFactorSign`/`centeredLiftPoly` application type mismatch). Confirmed
+pre-existing: `git diff origin/main -- Basic.lean` is empty, `Basic.lean` does
+not import `Resultant.lean`, and the failure reproduces on unmodified main. Per
+the `hex-lean-mathlib-boundary` skill, this layer is not CI-built, so the
+failure neither blocks CI nor stems from this change. My target module
+`Resultant.lean` is independent of `Basic.lean` and builds clean.


### PR DESCRIPTION
This PR adds the public BHKS Lemma 3.2-style theorem `pow_dvd_resultant_of_map_dvd` to `HexBerlekampZassenhausMathlib/Resultant.lean`: if a monic degree-`d` polynomial `q` divides both `f` and `g` after reduction modulo `p ^ k`, with `f` monic, then `p ^ (k * d)` divides the integer resultant of `f` and `g`. The exponent is `k * d` rather than `k` because the monic common factor contributes `d` independent Sylvester column directions, each carrying one factor of `p ^ k`. It also adds the private helper `exists_divByMonic_witness`, which produces degree-controlled witnesses `f = q * (f /ₘ q) + C n * s` by honest monic division, the control the existing `commonFactor_dvd_resultant` column reduction needs and which the degree-agnostic `exists_witnesses_of_map_dvd_zmod` cannot supply.

The proof builds monic-division witnesses for both sides, applies `commonFactor_dvd_resultant_of_monic_cofactor` to the swapped pair `(g, f)` so the monic cofactor `f /ₘ q` plays the unit-pivot role, and transfers the conclusion back across `Polynomial.resultant_comm` (the swap differs by a `±1` unit, so divisibility carries through).

Relative to the issue signature this adds `f.Monic` and `d ≤ f.natDegree`, `d ≤ g.natDegree`. The proven column-reduction infrastructure scales the determinant by `(cofactor pivot) ^ d` and needs the pivot to equal `1`, which holds exactly when the divided polynomial is monic; the downstream `inputPolynomial` is the natural monic side. This does not weaken the conclusion (still `p ^ (k * d)`); the fully non-monic form would require new infrastructure to handle the `lc ^ d` pivot factor and is out of scope here.

`lake build HexBerlekampZassenhausMathlib.Resultant` is green and `python3 scripts/check_dag.py` exits 0; the added lines carry no `sorry`/`axiom`/`native_decide`. The whole-library `lake build HexBerlekampZassenhausMathlib` is hard-red on main at `Basic.lean` (a pre-existing `normalizeFactorSign`/`centeredLiftPoly` type mismatch in a file this change does not touch or import); that layer is not CI-built.

Closes #6849

🤖 Prepared with Claude Code