### PR TITLE
doc: record /work triage of #6779, #6883, #6954

### DIFF
--- a/progress/20260614T044500Z_a63b8798.md
+++ b/progress/20260614T044500Z_a63b8798.md
@@ -1,0 +1,66 @@
+# Progress: /work meta session — queue triage (#6779, #6883, #6954)
+
+Meta `/work` session. No directives were claimable (#2564 is `blocked`).
+Worked the three unclaimed `feature` items in turn; all three proved
+blocked or unsound-as-framed, so no code landed. The value of the turn
+is three evidence-based diagnoses posted to the issues.
+
+## Accomplished
+
+- **#6779 (B-builder / B8 separation bridge assembly)** — released,
+  `depends-on: #6949` added. Its listed deps (#6834/#6835/#6844/#6846)
+  all show closed, but the *resultant divisibility* clause it must
+  package was re-scoped #6834 → #6844 (closed stale, no code) → #6945
+  (decomposed) → **#6949**, which is still open and blocked on #6947
+  (claimed) / #6948. Only the coprimality half landed (#6865, merged;
+  `coprime_input_aux_over_rat_of_forward`, `isBhksBadVectorSetup_of_forward`
+  at `BadVector.lean:1562/1582`). `resultant_divisible_by_p_pow_of_bridge_data`
+  / `_of_bhks_bad` only project the hypothesis field; nothing discharges it.
+  #6949's deliverable produces exactly the clause #6779 needs and overlaps
+  its bridge-wiring scope.
+
+- **#6883 (HexPolyFp: remove raw Yun state from square-free product)** —
+  skipped (replan) with a soundness diagnosis. The deliverable frames the
+  remaining work as a thin "scalar-aware residual bridge" after #6889, but
+  the bridge *as literally shaped* (`squareFreeAuxRevContribution_pthRoot_normalized_tail_bridge`,
+  `SquareFree.lean:6097`) is **false for a non-trivial-constant repeated
+  tail**: for `tail = C b` (b≠1, derivative-zero, isOne false),
+  `squareFreeAuxRevContribution_size_one` (:2446) collapses
+  `sfac (pthRoot tail) = 1` and `normalizeMonic (C b) = (b,1)` makes the RHS
+  `pow (C b) m * 1 = C (b^m)`, forcing `b^m = 1`. The current proof only
+  survives via `YunDerivativeActiveRawStateProvider` (:6509) asserting
+  `squareFreeContributionReachable (pthRoot tail)`, which is the #6871/#6872
+  false-provider field (false exactly for such constants). Sound discharge
+  requires *proving* the repeated-tail pthRoot is reachable (non-trivial
+  constant tails impossible / scalar folded into `contribution.1`), then a
+  size-1/size>1 case split — substantive content, not packaging. #6889
+  supplies the normalized product invariant but not this reachability fact.
+
+- **#6940** — could not claim; a concurrent agent took it (CLAIM FAILED race).
+
+- **#6954 (Mathlib-facing CLD auxiliary coeff decomposition)** — skipped
+  (replan). Deliverable 1 needs `Hex.cldQuotientMod_coeff_decomp_of_lt`,
+  absent from the tree; it lands via PR #6952, which is open (merge state
+  BLOCKED). Re-workable once #6952 merges.
+
+## Current frontier
+
+The feature queue is currently saturated with items gated on in-flight
+work: the CLD resultant chain (#6947 claimed → #6948 → #6949) and the
+executable CLD cut lemmas (PR #6952). Both unblock multiple downstream
+issues (#6779, #6954) when they land.
+
+## Next step
+
+- Once #6949 merges: #6779 is re-workable (likely a thin finisher or a
+  close-as-covered, since #6949 wires the same bridge clause).
+- Once PR #6952 merges: #6954 is re-workable.
+- #6883 needs a planner re-scope to "prove repeated-tail pthRoot
+  reachability soundly, then drop `YunDerivativeActiveRawStateProvider`",
+  with the constant case handled explicitly rather than via the literal
+  scalar bridge.
+
+## Blockers
+
+No build work attempted; baseline `lake build HexPolyFp.SquareFree`
+succeeded (88 jobs) before I concluded #6883 was unsound-as-framed.


### PR DESCRIPTION
This PR records the progress note from a `/work` triage session. All three unclaimed feature items were blocked or unsound-as-framed, so no code changed; the substantive output is three evidence-based diagnoses posted to the issues:

- #6779 is blocked on #6949 (the resultant-divisibility clause it must package was re-scoped through #6834 → #6844 → #6945 → #6949 and has not landed); `depends-on: #6949` added.
- #6883's "scalar-aware residual bridge" is unsound as literally framed — false for non-trivial-constant repeated tails (forces `b^m = 1`); sound discharge needs a repeated-tail reachability proof, not a thin packaging step.
- #6954 needs `Hex.cldQuotientMod_coeff_decomp_of_lt`, which lands via the still-open PR #6952.

🤖 Prepared with Claude Code