### PR TITLE
HexGramSchmidt Phase 6: docstring coverage for Update.lean public theorems

### DIFF
--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -72,11 +72,22 @@ def adjacentSwapScaledCoeffAboveCurrNumerator (b : Matrix Int n m)
       GramSchmidt.entry (scaledCoeffs b) i km1 -
     B * GramSchmidt.entry (scaledCoeffs b) i k
 
+/-- Size-reducing row `k` against an earlier row `j` leaves the entire
+Gram-Schmidt basis unchanged. Subtracting an integer multiple of an earlier
+row from a later one is a unimodular operation that preserves the orthogonal
+profile, so LLL can size-reduce freely without disturbing the orthogonalised
+vectors, their norms, or the Gram determinants the swap step depends on. -/
 theorem basis_sizeReduce (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int) :
     basis (sizeReduce b j k r) = basis b := by
   simpa [sizeReduce] using basis_rowAdd (b := b) (src := j) (dst := k) (c := -r) hjk
 
+/-- The defining effect of size reduction on the pivot coefficient: the `(k, j)`
+Gram-Schmidt coefficient drops by exactly `r`. Choosing `r` to be the nearest
+integer to `μ[k][j]` is precisely how LLL brings `|μ[k][j]| ≤ 1/2`, so this is
+the identity that certifies the size-reduction step achieves its bound. The
+nondegeneracy hypothesis `hnorm` records that row `j` of the basis is nonzero,
+so its coefficient is well defined. -/
 theorem coeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int)
     (hnorm : Matrix.dot ((basis b).row j) ((basis b).row j) ≠ 0) :
@@ -86,6 +97,11 @@ theorem coeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n) (hjk : j.val 
   rw [coeffs_rowAdd_pivot (b := b) (src := j) (dst := k) hjk (c := -r) hnorm]
   grind
 
+/-- How size reduction propagates to coefficients below the pivot: for a column
+`l` earlier than `j`, the `(k, l)` coefficient decreases by `r * μ[j][l]`. A
+caller tracking the full coefficient row of `k` after a size reduction needs
+this to predict the side effect on already-reduced lower columns (and to see
+why size reduction is performed from the largest index downward). -/
 theorem coeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
     (hlj : l.val < j.val) (hjk : j.val < k.val) (r : Int) :
     GramSchmidt.entry (coeffs (sizeReduce b j k r)) k l =
@@ -95,12 +111,22 @@ theorem coeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
   rw [coeffs_rowAdd_lower (b := b) (col := l) (src := j) (dst := k) hlj hjk (c := -r)]
   grind
 
+/-- Size reduction is local to the row being reduced: every coefficient row
+other than `k` is left untouched. This is the locality guarantee LLL relies on
+to argue that reducing row `k` cannot invalidate the size-reduced or
+Lovász-ordered state of any other row. -/
 theorem coeffs_sizeReduce_other_row (b : Matrix Int n m) (j k : Fin n)
     (hjk : j.val < k.val) (r : Int) (i : Fin n) (hik : i ≠ k) :
     (coeffs (sizeReduce b j k r)).row i = (coeffs b).row i := by
   simpa [sizeReduce] using
     coeffs_rowAdd_other_row (b := b) (src := j) (dst := k) (c := -r) hjk i hik
 
+/-- Size-reducing row `k` against `j` does not touch coefficients at columns
+strictly between `j` and `k`: for `j < l < k` the `(k, l)` coefficient is
+unchanged. Together with `coeffs_sizeReduce_lower` and
+`coeffs_sizeReduce_pivot`, this pins down exactly which coefficients move, which
+is what lets LLL reduce columns one at a time without re-disturbing the columns
+above the current pivot. -/
 theorem coeffs_sizeReduce_above_pivot (b : Matrix Int n m) (j k : Fin n)
     (hjk : j.val < k.val) (r : Int) (l : Fin n)
     (hjl : j.val < l.val) (hlk : l.val < k.val) :
@@ -111,6 +137,11 @@ theorem coeffs_sizeReduce_above_pivot (b : Matrix Int n m) (j k : Fin n)
     coeffs_rowAdd_above_pivot (b := b) (src := j) (col := l) (dst := k) hjl hlk
       (c := -r)
 
+/-- An adjacent swap at `k` leaves the Gram-Schmidt basis vector of every row
+strictly before the swapped pair unchanged (`i + 1 < k`, i.e. `i < k - 1`).
+Only the orthogonalisation of the two swapped rows and the rows above them can
+change, so a caller need only recompute the basis from index `k - 1` onward
+after a Lovász swap. -/
 theorem basis_adjacentSwap_of_lt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hi : i.val + 1 < k.val) :
     (basis (adjacentSwap b k hk)).row i = (basis b).row i := by
@@ -125,6 +156,11 @@ theorem basis_adjacentSwap_of_lt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.va
     GramSchmidt.Int.basis_rowSwap_of_before
       (b := b) (km1 := km1) (k := k) (i := i) hkm1k hikm1
 
+/-- An adjacent swap at `k` leaves the Gram-Schmidt basis vector of every row
+strictly after the swapped pair unchanged. The span of the first `k + 1` rows is
+invariant under swapping rows `k - 1` and `k`, so the orthogonalisation of any
+later row, which projects against that span, is unaffected; only rows `k - 1`
+and `k` move. -/
 theorem basis_adjacentSwap_of_gt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hi : k.val < i.val) :
     (basis (adjacentSwap b k hk)).row i = (basis b).row i := by
@@ -136,6 +172,11 @@ theorem basis_adjacentSwap_of_gt (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.va
     GramSchmidt.Int.basis_rowSwap_of_after
       (b := b) (km1 := km1) (k := k) (i := i) hkm1 hi
 
+/-- The new Gram-Schmidt vector at row `k - 1` after an adjacent swap: it is the
+old projection `b_k + μ[k][k-1] • b_{k-1}` of the swapped-in row against the rows
+below it. This is the orthogonal component that becomes the new shorter pivot,
+and whose norm LLL compares to the old one to decide whether the Lovász
+condition was violated. -/
 theorem basis_adjacentSwap_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
     (basis (adjacentSwap b k hk)).row km1 =
@@ -148,6 +189,13 @@ theorem basis_adjacentSwap_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val
   simpa [adjacentSwap, km1] using
     GramSchmidt.Int.basis_rowSwap_adjacent_prev (b := b) (km1 := km1) (k := k) hkm1
 
+/-- The new Gram-Schmidt vector at row `k` after an adjacent swap, given as an
+explicit linear combination of the old vectors `b_{k-1}` (`prev`) and `b_k`
+(`curr`). After the swap, row `k` carries the residual of the old `prev` against
+the new pivot `swappedPrev`; this closed form is what lets a caller recompute the
+updated orthogonal vector and its norm without rerunning Gram-Schmidt. The
+hypothesis `hdenom` records that the new pivot is nonzero, so the dividing inner
+products are well defined. -/
 theorem basis_adjacentSwap_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (hdenom :
       let km1 := GramSchmidt.prevRow k hk
@@ -170,6 +218,12 @@ theorem basis_adjacentSwap_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val
     GramSchmidt.Int.basis_rowSwap_adjacent_curr
       (b := b) (km1 := km1) (k := k) hkm1 hdenom
 
+/-- Effect of an adjacent swap on the lower coefficients of the new row `k - 1`:
+for a column `j` below the swapped pair (`j + 1 < k`), the new `(k-1, j)`
+coefficient equals the old `(k, j)` coefficient. Because the swap moves the old
+row `k` into position `k - 1`, its coefficients against the unchanged lower rows
+come along unchanged: the bookkeeping a caller needs to update the `μ` table in
+place rather than recomputing it. -/
 theorem coeffs_adjacentSwap_lower_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (j : Fin n) (hj : j.val + 1 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -186,6 +240,11 @@ theorem coeffs_adjacentSwap_lower_prev (b : Matrix Int n m) (k : Fin n) (hk : 0 
     GramSchmidt.Int.coeffs_rowSwap_adjacent_lower_prev
       (b := b) (km1 := km1) (k := k) (j := j) hkm1 hjkm1
 
+/-- Companion to `coeffs_adjacentSwap_lower_prev` for the other swapped row: for
+a column `j` below the swapped pair (`j + 1 < k`), the new `(k, j)` coefficient
+equals the old `(k-1, j)` coefficient. The two rows exchange their lower
+coefficient vectors wholesale, so a caller can swap the corresponding `μ`-rows in
+the columns below `k - 1` instead of recomputing them. -/
 theorem coeffs_adjacentSwap_lower_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (j : Fin n) (hj : j.val + 1 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -202,6 +261,12 @@ theorem coeffs_adjacentSwap_lower_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 
     GramSchmidt.Int.coeffs_rowSwap_adjacent_lower_curr
       (b := b) (km1 := km1) (k := k) (j := j) hkm1 hjkm1
 
+/-- The updated pivot coefficient after an adjacent swap: the new `μ[k][k-1]`
+equals `μ * ⟨prev, prev⟩ / ⟨swappedPrev, swappedPrev⟩`, where `μ` is the old
+pivot coefficient and `swappedPrev` the new shorter pivot. This is the `μ'`
+entry of the standard LLL swap update; a caller uses it to refresh the pivot
+coefficient in place. The hypothesis `hdenom` records that the new pivot is
+nonzero, so the quotient is well defined. -/
 theorem coeffs_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (hdenom :
       let km1 := GramSchmidt.prevRow k hk

--- a/progress/20260614T060000Z_0f38f9b8.md
+++ b/progress/20260614T060000Z_0f38f9b8.md
@@ -1,0 +1,45 @@
+# Progress: #6986 — HexGramSchmidt Phase 6 docstring coverage (Update.lean)
+
+Feature session. Added docstrings to the 12 undocumented public theorems in
+`HexGramSchmidt/Update.lean`, closing one of the Phase 6 exit-criterion gaps
+for the library.
+
+## Accomplished
+
+Docstrings added (docstring-only; no statement, signature, or proof change):
+
+- `basis_sizeReduce`, `coeffs_sizeReduce_pivot`, `coeffs_sizeReduce_lower`,
+  `coeffs_sizeReduce_other_row`, `coeffs_sizeReduce_above_pivot`
+- `basis_adjacentSwap_of_lt`, `basis_adjacentSwap_of_gt`,
+  `basis_adjacentSwap_prev`, `basis_adjacentSwap_curr`
+- `coeffs_adjacentSwap_lower_prev`, `coeffs_adjacentSwap_lower_curr`,
+  `coeffs_adjacentSwap_pivot`
+
+Each docstring states what the theorem proves and why an LLL caller cares
+(size-reduction bound, swap-update bookkeeping, locality guarantees), matching
+the tone of the existing documented `def`s in the same file and the documented
+lemmas in `Int.lean`. Did not restate proofs.
+
+Diff is purely additive: 65 insertions, 0 deletions.
+
+## Verification
+
+- `lake build HexGramSchmidt.Update` — clean; the two warnings emitted
+  (`Basic.lean:1606` unnecessarySimpa, `Int.lean:4939` unusedVariable) are
+  pre-existing and not on `Update.lean`.
+- `python3 scripts/check_dag.py` — exit 0.
+- No `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` and no banned vocabulary
+  (replaced one em-dash with a colon) on added lines.
+
+## Current frontier
+
+#6986 complete; PR to follow.
+
+## Next step
+
+Sibling issue #6987 (Int.lean docstrings, 1 def + 7 theorems) is still
+unclaimed and concurrent-safe.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6986

Session: `0f38f9b8-859a-4e62-90f9-3344e790a544`

c861a675 doc: docstring coverage for Update.lean public theorems (#6986)

🤖 Prepared with Claude Code