### PR TITLE
feat: WIP route Yun/squareFree gcd through monicGcd (scalar-leak fix, 87->27 errors)

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -4848,8 +4848,8 @@ private theorem yunScalarStep
   · exact hrawG
   · have hg_ne : g ≠ 0 := by
       apply ne_zero_of_isZero_false
-      exact gcd_isZero_false_of_right_isZero_false
-        f (DensePoly.derivative f) hder
+      exact monicGcd_isZero_false_of_gcd_nonzero f (DensePoly.derivative f)
+        (gcd_isZero_false_of_right_isZero_false f (DensePoly.derivative f) hder)
     have hquot :=
       div_C_mul_C_mul_of_dvd hp hu hv f g
         (by
@@ -5178,10 +5178,10 @@ private theorem yunFactorsContributionWithLevel_constant_scalar_form
         · simp [yunFactorsContributionWithLevel, hc]
           change w = (1 : FpPoly p) * w
           rw [one_mul]
-      · let y : FpPoly p := DensePoly.gcd (DensePoly.C k : FpPoly p) w
+      · let y : FpPoly p := monicGcd (DensePoly.C k : FpPoly p) w
         let z : FpPoly p := (DensePoly.C k : FpPoly p) / y
         have hy_dvd : y ∣ (DensePoly.C k : FpPoly p) :=
-          DensePoly.gcd_dvd_left (DensePoly.C k : FpPoly p) w
+          monicGcd_dvd_left hp (DensePoly.C k : FpPoly p) w
         obtain ⟨v, hv, hy_eq⟩ := constant_divisor_eq_C hk hy_dvd
         have hz_const : ∃ a : ZMod64 p, a ≠ 0 ∧ z = DensePoly.C a := by
           have hquot_dvd : z ∣ (DensePoly.C k : FpPoly p) := by
@@ -5265,10 +5265,10 @@ private theorem yunFactorsContributionWithLevel_constant_scalar_sync
         · simp [yunFactorsContributionWithLevel, hc]
           change w = (1 : FpPoly p) * w
           rw [one_mul]
-      · let y : FpPoly p := DensePoly.gcd (DensePoly.C k : FpPoly p) w
+      · let y : FpPoly p := monicGcd (DensePoly.C k : FpPoly p) w
         let z : FpPoly p := (DensePoly.C k : FpPoly p) / y
         have hy_dvd : y ∣ (DensePoly.C k : FpPoly p) :=
-          DensePoly.gcd_dvd_left (DensePoly.C k : FpPoly p) w
+          monicGcd_dvd_left hp (DensePoly.C k : FpPoly p) w
         obtain ⟨v, hv, hy_eq⟩ := constant_divisor_eq_C hk hy_dvd
         have hw_div_y :
             w / y = DensePoly.C v⁻¹ * w := by
@@ -5674,7 +5674,8 @@ private theorem derivativeSplit_quotient_common_dvd_derivative_one
     · exact False.elim (hdf h)
   have hg_nonzero : g.isZero = false := by
     simpa [g] using
-      gcd_isZero_false_of_right_isZero_false f (DensePoly.derivative f) hdf_false
+      monicGcd_isZero_false_of_gcd_nonzero f (DensePoly.derivative f)
+        (gcd_isZero_false_of_right_isZero_false f (DensePoly.derivative f) hdf_false)
   have hbase : pow d 0 ∣ g := by
     rw [pow_eq_powLinear]
     change (1 : FpPoly p) ∣ g
@@ -7526,7 +7527,8 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
         rfl
       have hg_nonzero : g.isZero = false := by
         simpa [g] using
-          gcd_isZero_false_of_right_isZero_false f (DensePoly.derivative f) hdf_false
+          monicGcd_isZero_false_of_gcd_nonzero f (DensePoly.derivative f)
+            (gcd_isZero_false_of_right_isZero_false f (DensePoly.derivative f) hdf_false)
       have hc_nonzero : c.isZero = false := by
         cases hc : c.isZero
         · rfl
@@ -7541,7 +7543,9 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
       let y := monicGcd c w
       let z := w / y
       have hy_nonzero : y.isZero = false := by
-        simpa [y] using gcd_isZero_false_of_right_isZero_false c w ih.2
+        simpa [y] using
+          monicGcd_isZero_false_of_gcd_nonzero c w
+            (gcd_isZero_false_of_right_isZero_false c w ih.2)
       have hz_nonzero : z.isZero = false := by
         cases hz : z.isZero
         · rfl
@@ -10210,7 +10214,7 @@ private theorem normalizeMonic_gcd_monic_of_right_nonzero
     [ZMod64.PrimeModulus p] (c w : FpPoly p)
     (hw : w.isZero = false) :
     DensePoly.Monic (normalizeMonic (DensePoly.gcd c w)).2 :=
-  normalizeMonic_nonzero_monic (monicGcd c w)
+  normalizeMonic_nonzero_monic (DensePoly.gcd c w)
     (gcd_isZero_false_of_right_isZero_false c w hw)
 
 /--

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1321,6 +1321,91 @@ private theorem normalizeMonic_nonzero_isZero_false
   simpa [DensePoly.isZero, DensePoly.size, Array.isEmpty_iff_size_eq_zero,
     Nat.pos_iff_ne_zero] using hpos
 
+/-- Monic-normalized gcd: the canonical monic associate of `DensePoly.gcd c w`.
+
+Routing the Yun square-free loop's gcd through this keeps every intermediate
+polynomial monic. A raw `DensePoly.gcd` of a coprime pair can be a non-trivial
+constant unit over `F_p` for `p > 2` (e.g. `gcd (x^2+1) (x+1) = 2` over `F_5`);
+emitting `c / gcd c w` then leaks that scalar into the square-free factor,
+breaking the exact reconstruction `weightedProduct = f`. The monic associate
+divides `c` and `w` exactly as the raw gcd does, so every reconstruction
+identity carries over, but the emitted quotient stays monic. -/
+private def monicGcd (c w : FpPoly p) : FpPoly p :=
+  (normalizeMonic (DensePoly.gcd c w)).2
+
+/-- The raw gcd is a constant multiple of `monicGcd`, recovered from
+`normalizeMonic_reconstruct`. -/
+private theorem gcd_eq_C_mul_monicGcd
+    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    DensePoly.C (normalizeMonic (DensePoly.gcd c w)).1 * monicGcd c w =
+      DensePoly.gcd c w :=
+  normalizeMonic_reconstruct hp (DensePoly.gcd c w)
+
+/-- `monicGcd c w` divides the raw gcd (they are associates). -/
+private theorem monicGcd_dvd_gcd
+    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w ∣ DensePoly.gcd c w :=
+  ⟨DensePoly.C (normalizeMonic (DensePoly.gcd c w)).1, by
+    rw [mul_comm]; exact (gcd_eq_C_mul_monicGcd hp c w).symm⟩
+
+/-- `monicGcd c w` divides `c`. -/
+private theorem monicGcd_dvd_left
+    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w ∣ c :=
+  dvd_trans (monicGcd_dvd_gcd hp c w) (DensePoly.gcd_dvd_left c w)
+
+/-- `monicGcd c w` divides `w`. -/
+private theorem monicGcd_dvd_right
+    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w ∣ w :=
+  dvd_trans (monicGcd_dvd_gcd hp c w) (DensePoly.gcd_dvd_right c w)
+
+/-- Left exact-division reconstruction across `monicGcd`. -/
+private theorem div_monicGcd_mul_reconstruct
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    (c / monicGcd c w) * monicGcd c w = c := by
+  have hspec := DensePoly.div_mul_add_mod c (monicGcd c w)
+  have hmod : c % monicGcd c w = 0 :=
+    DensePoly.mod_eq_zero_of_dvd c (monicGcd c w) (monicGcd_dvd_left hp c w)
+  rw [hmod, add_zero] at hspec
+  exact hspec
+
+/-- `monicGcd` times the left exact quotient reconstructs `c`. -/
+private theorem monicGcd_mul_div_reconstruct
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w * (c / monicGcd c w) = c := by
+  rw [mul_comm]; exact div_monicGcd_mul_reconstruct hp c w
+
+/-- Right exact-division reconstruction across `monicGcd`. -/
+private theorem div_monicGcd_right_mul_reconstruct
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    (w / monicGcd c w) * monicGcd c w = w := by
+  have hspec := DensePoly.div_mul_add_mod w (monicGcd c w)
+  have hmod : w % monicGcd c w = 0 :=
+    DensePoly.mod_eq_zero_of_dvd w (monicGcd c w) (monicGcd_dvd_right hp c w)
+  rw [hmod, add_zero] at hspec
+  exact hspec
+
+/-- `monicGcd` times the right exact quotient reconstructs `w`. -/
+private theorem monicGcd_mul_div_right_reconstruct
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w * (w / monicGcd c w) = w := by
+  rw [mul_comm]; exact div_monicGcd_right_mul_reconstruct hp c w
+
+/-- `monicGcd c w` is monic whenever the raw gcd is nonzero. -/
+private theorem monicGcd_monic_of_gcd_nonzero
+    [ZMod64.PrimeModulus p] (c w : FpPoly p)
+    (hgcd : (DensePoly.gcd c w).isZero = false) :
+    DensePoly.Monic (monicGcd c w) :=
+  normalizeMonic_nonzero_monic (DensePoly.gcd c w) hgcd
+
+/-- `monicGcd c w` is nonzero whenever the raw gcd is nonzero. -/
+private theorem monicGcd_isZero_false_of_gcd_nonzero
+    [ZMod64.PrimeModulus p] (c w : FpPoly p)
+    (hgcd : (DensePoly.gcd c w).isZero = false) :
+    (monicGcd c w).isZero = false :=
+  normalizeMonic_nonzero_isZero_false (DensePoly.gcd c w) hgcd
+
 /-! ### Scalar-multiple algebra foundations
 
 Foundational `FpPoly p` algebra for transporting `DensePoly.derivative`,
@@ -2101,7 +2186,7 @@ private def yunFactorsWithLevel
       if isOne c then
         (accRev, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2120,7 +2205,7 @@ private def yunFactors
       if isOne c then
         (accRev, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2141,7 +2226,7 @@ private def yunFactorsContributionWithLevel
       if isOne c then
         (1, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let tail := yunFactorsContributionWithLevel y (w / y) base (level + 1) fuel
         let contribution :=
@@ -2158,7 +2243,7 @@ private def yunFactorsContribution
       if isOne c then
         (1, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let tail := yunFactorsContribution y (w / y) (i + 1) fuel
         let contribution :=
@@ -2272,7 +2357,7 @@ private def squareFreeAuxRevContribution (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRevContribution (pthRoot f) (multiplicity * p) fuel
         else
-          let g := DensePoly.gcd f df
+          let g := monicGcd f df
           let c := f / g
           let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
           if isOne contribution.2 then
@@ -2858,6 +2943,33 @@ private theorem monic_div_gcd_right_of_monic
     DensePoly.Monic (w / DensePoly.gcd c w) :=
   monic_of_mul_eq_monic_of_monic hp hw_monic hgcd_monic
     (div_gcd_right_mul_reconstruct c w)
+
+/-- Exact-quotient monicity for the left Yun residual through `monicGcd`: from
+monic `c` and a monic `monicGcd c w` divisor, the left exact quotient
+`c / monicGcd c w` is monic. -/
+private theorem monic_div_monicGcd_left_of_monic
+    [ZMod64.PrimeModulus p]
+    (hp : Hex.Nat.Prime p)
+    (c w : FpPoly p)
+    (hc_monic : DensePoly.Monic c)
+    (hgcd_monic : DensePoly.Monic (monicGcd c w)) :
+    DensePoly.Monic (c / monicGcd c w) :=
+  monic_of_mul_eq_monic_of_monic hp hc_monic hgcd_monic
+    (div_monicGcd_mul_reconstruct hp c w)
+
+/-- Exact-quotient monicity for the right Yun residual through `monicGcd`: from
+monic `w` and a monic `monicGcd c w` divisor, the right exact quotient
+`w / monicGcd c w` is monic. This is the residual threaded into the next Yun
+state, so it carries the monic invariant forward. -/
+private theorem monic_div_monicGcd_right_of_monic
+    [ZMod64.PrimeModulus p]
+    (hp : Hex.Nat.Prime p)
+    (c w : FpPoly p)
+    (hw_monic : DensePoly.Monic w)
+    (hgcd_monic : DensePoly.Monic (monicGcd c w)) :
+    DensePoly.Monic (w / monicGcd c w) :=
+  monic_of_mul_eq_monic_of_monic hp hw_monic hgcd_monic
+    (div_monicGcd_right_mul_reconstruct hp c w)
 
 /--
 Algebraic step identity used to thread the scaled Yun product invariant through
@@ -4004,7 +4116,7 @@ private def squareFreeAuxRev (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRev (pthRoot f) (multiplicity * p) fuel accRev
         else
-          let g := DensePoly.gcd f df
+          let g := monicGcd f df
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           let accRev' := loop.1

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -3001,73 +3001,74 @@ factor into the next level.
 private theorem yunFactorsContributionWithLevel_pow_step_algebra
     [ZMod64.PrimeModulus p] (c w : FpPoly p) (base level : Nat) :
     pow c (base * level) * pow w base =
-      pow (c / DensePoly.gcd c w) (base * level) *
-        pow (DensePoly.gcd c w) (base * (level + 1)) *
-        pow (w / DensePoly.gcd c w) base := by
-  have hqg : (c / DensePoly.gcd c w) * DensePoly.gcd c w = c :=
-    div_gcd_mul_reconstruct c w
-  have hvg : (w / DensePoly.gcd c w) * DensePoly.gcd c w = w :=
-    div_gcd_right_mul_reconstruct c w
+      pow (c / monicGcd c w) (base * level) *
+        pow (monicGcd c w) (base * (level + 1)) *
+        pow (w / monicGcd c w) base := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+  have hqg : (c / monicGcd c w) * monicGcd c w = c :=
+    div_monicGcd_mul_reconstruct hp c w
+  have hvg : (w / monicGcd c w) * monicGcd c w = w :=
+    div_monicGcd_right_mul_reconstruct hp c w
   have hexp : base * level + base = base * (level + 1) := by
     rw [Nat.mul_succ]
   calc pow c (base * level) * pow w base
-      = pow ((c / DensePoly.gcd c w) * DensePoly.gcd c w) (base * level) *
-          pow ((w / DensePoly.gcd c w) * DensePoly.gcd c w) base := by rw [hqg, hvg]
-    _ = (pow (c / DensePoly.gcd c w) (base * level) *
-            pow (DensePoly.gcd c w) (base * level)) *
-          (pow (w / DensePoly.gcd c w) base * pow (DensePoly.gcd c w) base) := by
-        rw [pow_mul_base (c / DensePoly.gcd c w) (DensePoly.gcd c w) (base * level),
-            pow_mul_base (w / DensePoly.gcd c w) (DensePoly.gcd c w) base]
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          (pow (DensePoly.gcd c w) (base * level) *
-            (pow (w / DensePoly.gcd c w) base * pow (DensePoly.gcd c w) base)) := by
+      = pow ((c / monicGcd c w) * monicGcd c w) (base * level) *
+          pow ((w / monicGcd c w) * monicGcd c w) base := by rw [hqg, hvg]
+    _ = (pow (c / monicGcd c w) (base * level) *
+            pow (monicGcd c w) (base * level)) *
+          (pow (w / monicGcd c w) base * pow (monicGcd c w) base) := by
+        rw [pow_mul_base (c / monicGcd c w) (monicGcd c w) (base * level),
+            pow_mul_base (w / monicGcd c w) (monicGcd c w) base]
+    _ = pow (c / monicGcd c w) (base * level) *
+          (pow (monicGcd c w) (base * level) *
+            (pow (w / monicGcd c w) base * pow (monicGcd c w) base)) := by
         exact DensePoly.mul_assoc_poly _ _ _
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          ((pow (DensePoly.gcd c w) (base * level) * pow (w / DensePoly.gcd c w) base) *
-            pow (DensePoly.gcd c w) base) := by
+    _ = pow (c / monicGcd c w) (base * level) *
+          ((pow (monicGcd c w) (base * level) * pow (w / monicGcd c w) base) *
+            pow (monicGcd c w) base) := by
         exact congrArg
-          (fun x => pow (c / DensePoly.gcd c w) (base * level) * x)
+          (fun x => pow (c / monicGcd c w) (base * level) * x)
           (DensePoly.mul_assoc_poly
-            (pow (DensePoly.gcd c w) (base * level))
-            (pow (w / DensePoly.gcd c w) base)
-            (pow (DensePoly.gcd c w) base)).symm
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          ((pow (w / DensePoly.gcd c w) base * pow (DensePoly.gcd c w) (base * level)) *
-            pow (DensePoly.gcd c w) base) := by
+            (pow (monicGcd c w) (base * level))
+            (pow (w / monicGcd c w) base)
+            (pow (monicGcd c w) base)).symm
+    _ = pow (c / monicGcd c w) (base * level) *
+          ((pow (w / monicGcd c w) base * pow (monicGcd c w) (base * level)) *
+            pow (monicGcd c w) base) := by
         exact congrArg
-          (fun x => pow (c / DensePoly.gcd c w) (base * level) *
-            (x * pow (DensePoly.gcd c w) base))
+          (fun x => pow (c / monicGcd c w) (base * level) *
+            (x * pow (monicGcd c w) base))
           (DensePoly.mul_comm_poly
-            (pow (DensePoly.gcd c w) (base * level))
-            (pow (w / DensePoly.gcd c w) base))
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          (pow (w / DensePoly.gcd c w) base *
-            (pow (DensePoly.gcd c w) (base * level) * pow (DensePoly.gcd c w) base)) := by
+            (pow (monicGcd c w) (base * level))
+            (pow (w / monicGcd c w) base))
+    _ = pow (c / monicGcd c w) (base * level) *
+          (pow (w / monicGcd c w) base *
+            (pow (monicGcd c w) (base * level) * pow (monicGcd c w) base)) := by
         exact congrArg
-          (fun x => pow (c / DensePoly.gcd c w) (base * level) * x)
+          (fun x => pow (c / monicGcd c w) (base * level) * x)
           (DensePoly.mul_assoc_poly
-            (pow (w / DensePoly.gcd c w) base)
-            (pow (DensePoly.gcd c w) (base * level))
-            (pow (DensePoly.gcd c w) base))
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          (pow (w / DensePoly.gcd c w) base *
-            pow (DensePoly.gcd c w) (base * level + base)) := by
+            (pow (w / monicGcd c w) base)
+            (pow (monicGcd c w) (base * level))
+            (pow (monicGcd c w) base))
+    _ = pow (c / monicGcd c w) (base * level) *
+          (pow (w / monicGcd c w) base *
+            pow (monicGcd c w) (base * level + base)) := by
         rw [← pow_add_exp]
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          (pow (w / DensePoly.gcd c w) base *
-            pow (DensePoly.gcd c w) (base * (level + 1))) := by
+    _ = pow (c / monicGcd c w) (base * level) *
+          (pow (w / monicGcd c w) base *
+            pow (monicGcd c w) (base * (level + 1))) := by
         rw [hexp]
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          (pow (DensePoly.gcd c w) (base * (level + 1)) *
-            pow (w / DensePoly.gcd c w) base) := by
+    _ = pow (c / monicGcd c w) (base * level) *
+          (pow (monicGcd c w) (base * (level + 1)) *
+            pow (w / monicGcd c w) base) := by
         exact congrArg
-          (fun x => pow (c / DensePoly.gcd c w) (base * level) * x)
+          (fun x => pow (c / monicGcd c w) (base * level) * x)
           (DensePoly.mul_comm_poly
-            (pow (w / DensePoly.gcd c w) base)
-            (pow (DensePoly.gcd c w) (base * (level + 1))))
-    _ = pow (c / DensePoly.gcd c w) (base * level) *
-          pow (DensePoly.gcd c w) (base * (level + 1)) *
-          pow (w / DensePoly.gcd c w) base := by
+            (pow (w / monicGcd c w) base)
+            (pow (monicGcd c w) (base * (level + 1))))
+    _ = pow (c / monicGcd c w) (base * level) *
+          pow (monicGcd c w) (base * (level + 1)) *
+          pow (w / monicGcd c w) base := by
         exact (DensePoly.mul_assoc_poly _ _ _).symm
 
 /--
@@ -3082,7 +3083,7 @@ private def yunFactorsLevelCompletes (c w : FpPoly p) (base : Nat) :
   | level, fuel + 1 =>
       isOne c = true ∨
         yunFactorsLevelCompletes
-          (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel
+          (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel
 
 /--
 Normalized termination predicate for the scaled Yun loop. This mirrors
@@ -3096,7 +3097,7 @@ private def yunFactorsNormalizedLevelCompletes (c w : FpPoly p) (base : Nat) :
   | level, fuel + 1 =>
       isOne (normalizeMonic c).2 = true ∨
         yunFactorsNormalizedLevelCompletes
-          (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel
+          (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel
 
 /--
 Conditional product invariant for the scaled Yun loop: when the loop
@@ -3130,11 +3131,11 @@ private theorem yunFactorsContributionWithLevel_pow_invariant_of_completes
           · exact False.elim (hc h)
         have htail_completes :
             yunFactorsLevelCompletes
-              (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel := by
+              (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel := by
           cases hcompletes with
           | inl hcone => exact False.elim (hc hcone)
           | inr htail => exact htail
-        have htail := ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+        have htail := ih (monicGcd c w) (w / monicGcd c w) (level + 1)
           htail_completes
         -- htail :
         --   (yunFactorsContributionWithLevel y v base (level+1) fuel).1 *
@@ -3142,9 +3143,9 @@ private theorem yunFactorsContributionWithLevel_pow_invariant_of_completes
         --   pow y (base * (level + 1)) * pow v base
         simp only [yunFactorsContributionWithLevel, hc_false]
         -- Goal involves let-bound y := gcd c w, z := c/y, tail := ...
-        by_cases hz : isOne (c / DensePoly.gcd c w) = true
+        by_cases hz : isOne (c / monicGcd c w) = true
         · -- z = 1 case: contribution.1 = tail.1
-          have hz_eq : c / DensePoly.gcd c w = 1 := eq_one_of_isOne_true _ hz
+          have hz_eq : c / monicGcd c w = 1 := eq_one_of_isOne_true _ hz
           simp [hz_eq, pow_one_base]
           -- pow c (b*l) = pow (z * y) (b*l) = pow z (b*l) * pow y (b*l)
           -- With z = 1: pow c (b*l) = pow y (b*l)
@@ -3157,33 +3158,33 @@ private theorem yunFactorsContributionWithLevel_pow_invariant_of_completes
           rw [hstep]
           exact htail
         · -- z ≠ 1 case: contribution.1 = pow z (b*l) * tail.1
-          have hz_false : isOne (c / DensePoly.gcd c w) = false := by
-            cases h : isOne (c / DensePoly.gcd c w)
+          have hz_false : isOne (c / monicGcd c w) = false := by
+            cases h : isOne (c / monicGcd c w)
             · rfl
             · exact False.elim (hz h)
           simp [hz_false]
           -- Goal: pow z (b*l) * tail.1 * pow tail.2 base = pow c (b*l) * pow w base
           have hstep :=
             yunFactorsContributionWithLevel_pow_step_algebra c w base level
-          calc pow (c / DensePoly.gcd c w) (base * level) *
+          calc pow (c / monicGcd c w) (base * level) *
                   (yunFactorsContributionWithLevel
-                    (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel).1 *
+                    (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel).1 *
                   pow (yunFactorsContributionWithLevel
-                    (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel).2 base
-              = pow (c / DensePoly.gcd c w) (base * level) *
+                    (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel).2 base
+              = pow (c / monicGcd c w) (base * level) *
                   ((yunFactorsContributionWithLevel
-                    (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel).1 *
+                    (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel).1 *
                     pow (yunFactorsContributionWithLevel
-                      (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel).2 base) :=
+                      (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel).2 base) :=
                 DensePoly.mul_assoc_poly _ _ _
-            _ = pow (c / DensePoly.gcd c w) (base * level) *
-                  (pow (DensePoly.gcd c w) (base * (level + 1)) *
-                    pow (w / DensePoly.gcd c w) base) :=
+            _ = pow (c / monicGcd c w) (base * level) *
+                  (pow (monicGcd c w) (base * (level + 1)) *
+                    pow (w / monicGcd c w) base) :=
                 congrArg
-                  (fun x => pow (c / DensePoly.gcd c w) (base * level) * x) htail
-            _ = pow (c / DensePoly.gcd c w) (base * level) *
-                  pow (DensePoly.gcd c w) (base * (level + 1)) *
-                  pow (w / DensePoly.gcd c w) base :=
+                  (fun x => pow (c / monicGcd c w) (base * level) * x) htail
+            _ = pow (c / monicGcd c w) (base * level) *
+                  pow (monicGcd c w) (base * (level + 1)) *
+                  pow (w / monicGcd c w) base :=
                 (DensePoly.mul_assoc_poly _ _ _).symm
             _ = pow c (base * level) * pow w base := hstep.symm
 
@@ -3210,9 +3211,10 @@ private theorem yunFactorsContribution_step_split
     let y := monicGcd c w
     let z := c / y
     z * y = c ∧ (w / y) * y = w := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   constructor
-  · exact div_gcd_mul_reconstruct c w
-  · exact div_gcd_right_mul_reconstruct c w
+  · exact div_monicGcd_mul_reconstruct hp c w
+  · exact div_monicGcd_right_mul_reconstruct hp c w
 
 private theorem dvd_add_poly
     {d a b : FpPoly p} (hda : d ∣ a) (hdb : d ∣ b) :
@@ -3519,13 +3521,14 @@ private theorem yunStep_common_dvd_derivative_product
 private theorem yunStep_common_dvd_derivative_current
     [ZMod64.PrimeModulus p]
     (c w d : FpPoly p)
-    (hdz : d ∣ c / DensePoly.gcd c w)
-    (hdy : d ∣ DensePoly.gcd c w) :
+    (hdz : d ∣ c / monicGcd c w)
+    (hdy : d ∣ monicGcd c w) :
     d ∣ DensePoly.derivative c := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   let y := monicGcd c w
   let z := c / y
   have hprod : z * y = c := by
-    simpa [z, y] using div_gcd_mul_reconstruct c w
+    simpa [z, y] using div_monicGcd_mul_reconstruct hp c w
   rw [← hprod]
   exact yunStep_common_dvd_derivative_product z y d hdz hdy
 
@@ -3716,22 +3719,22 @@ private theorem yunFactorsContribution_terminal_of_isOne
 private theorem yunFactorsContribution_step_of_not_isOne_of_isOne_z
     (c w : FpPoly p) (i fuel : Nat)
     (hc : isOne c = false)
-    (hz : isOne (c / DensePoly.gcd c w) = true) :
+    (hz : isOne (c / monicGcd c w) = true) :
     yunFactorsContribution c w i (fuel + 1) =
       yunFactorsContribution
-        (DensePoly.gcd c w) (w / DensePoly.gcd c w) (i + 1) fuel := by
+        (monicGcd c w) (w / monicGcd c w) (i + 1) fuel := by
   simp [yunFactorsContribution, hc, hz]
 
 private theorem yunFactorsContribution_step_of_not_isOne_of_not_isOne_z
     (c w : FpPoly p) (i fuel : Nat)
     (hc : isOne c = false)
-    (hz : isOne (c / DensePoly.gcd c w) = false) :
+    (hz : isOne (c / monicGcd c w) = false) :
     yunFactorsContribution c w i (fuel + 1) =
-      (pow (c / DensePoly.gcd c w) i *
+      (pow (c / monicGcd c w) i *
           (yunFactorsContribution
-            (DensePoly.gcd c w) (w / DensePoly.gcd c w) (i + 1) fuel).1,
+            (monicGcd c w) (w / monicGcd c w) (i + 1) fuel).1,
         (yunFactorsContribution
-          (DensePoly.gcd c w) (w / DensePoly.gcd c w) (i + 1) fuel).2) := by
+          (monicGcd c w) (w / monicGcd c w) (i + 1) fuel).2) := by
   simp [yunFactorsContribution, hc, hz]
 
 private theorem yunFactorsContribution_tail_repeated_descent
@@ -3743,7 +3746,7 @@ private theorem yunFactorsContribution_tail_repeated_descent
     contribution.2 = tail.2 ∧
       squareFreeAuxRevContribution (pthRoot contribution.2) (multiplicity * p) fuel =
         squareFreeAuxRevContribution (pthRoot tail.2) (multiplicity * p) fuel := by
-  by_cases hz : isOne (c / DensePoly.gcd c w)
+  by_cases hz : isOne (c / monicGcd c w)
   · simp [yunFactorsContribution, hc, hz]
   · simp [yunFactorsContribution, hc, hz]
 
@@ -3752,35 +3755,35 @@ private theorem yunFactorsContribution_step_preserves_target
     (c w : FpPoly p) (multiplicity fuel : Nat) (target : FpPoly p)
     (hc : isOne c = false)
     (htarget_one :
-      isOne (c / DensePoly.gcd c w) = true →
+      isOne (c / monicGcd c w) = true →
         (yunFactorsContribution
-          (DensePoly.gcd c w) (w / DensePoly.gcd c w)
+          (monicGcd c w) (w / monicGcd c w)
           (multiplicity + 1) fuel).1 = target)
     (htarget_factor :
-      isOne (c / DensePoly.gcd c w) = false →
-        pow (c / DensePoly.gcd c w) multiplicity *
+      isOne (c / monicGcd c w) = false →
+        pow (c / monicGcd c w) multiplicity *
           (yunFactorsContribution
-            (DensePoly.gcd c w) (w / DensePoly.gcd c w)
+            (monicGcd c w) (w / monicGcd c w)
             (multiplicity + 1) fuel).1 = target) :
     let tail :=
       yunFactorsContribution
-        (DensePoly.gcd c w) (w / DensePoly.gcd c w)
+        (monicGcd c w) (w / monicGcd c w)
         (multiplicity + 1) fuel
     let contribution := yunFactorsContribution c w multiplicity (fuel + 1)
     contribution.1 = target ∧
       contribution.2 = tail.2 ∧
-        (c / DensePoly.gcd c w) * DensePoly.gcd c w = c ∧
-          (w / DensePoly.gcd c w) * DensePoly.gcd c w = w := by
+        (c / monicGcd c w) * monicGcd c w = c ∧
+          (w / monicGcd c w) * monicGcd c w = w := by
   dsimp
   have hsplit := yunFactorsContribution_step_split c w
-  by_cases hz : isOne (c / DensePoly.gcd c w) = true
+  by_cases hz : isOne (c / monicGcd c w) = true
   · have hstep :=
       yunFactorsContribution_step_of_not_isOne_of_isOne_z
         c w multiplicity fuel hc hz
     rw [hstep]
     exact ⟨htarget_one hz, rfl, hsplit.1, hsplit.2⟩
-  · have hz_false : isOne (c / DensePoly.gcd c w) = false := by
-      cases h : isOne (c / DensePoly.gcd c w)
+  · have hz_false : isOne (c / monicGcd c w) = false := by
+      cases h : isOne (c / monicGcd c w)
       · rfl
       · exact False.elim (hz h)
     have hstep :=
@@ -3801,15 +3804,15 @@ private theorem yunFactorsContribution_step_target_combiner
     (c w : FpPoly p) (multiplicity fuel : Nat) (target : FpPoly p)
     (hc : isOne c = false)
     (htarget_one :
-      isOne (c / DensePoly.gcd c w) = true →
+      isOne (c / monicGcd c w) = true →
         (yunFactorsContribution
-          (DensePoly.gcd c w) (w / DensePoly.gcd c w)
+          (monicGcd c w) (w / monicGcd c w)
           (multiplicity + 1) fuel).1 = target)
     (htarget_factor :
-      isOne (c / DensePoly.gcd c w) = false →
-        pow (c / DensePoly.gcd c w) multiplicity *
+      isOne (c / monicGcd c w) = false →
+        pow (c / monicGcd c w) multiplicity *
           (yunFactorsContribution
-            (DensePoly.gcd c w) (w / DensePoly.gcd c w)
+            (monicGcd c w) (w / monicGcd c w)
             (multiplicity + 1) fuel).1 = target) :
     let y := monicGcd c w
     let tail :=
@@ -4093,8 +4096,8 @@ private inductive yunFactorsDerivativeActiveReachable
   | step (c w : FpPoly p) (fuel : Nat) :
       yunFactorsDerivativeActiveReachable hp f c w (fuel + 1) →
       yunFactorsDerivativeActiveReachable hp f
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         fuel
 
 /--
@@ -4243,8 +4246,8 @@ private inductive yunFactorsPairwiseReachable :
   | step (c w : FpPoly p) (fuel : Nat) :
       yunFactorsPairwiseReachable c w (fuel + 1) →
       yunFactorsPairwiseReachable
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         fuel
 
 private theorem yunFactorsPairwiseReachable_of_derivative_split
@@ -4260,8 +4263,8 @@ private theorem yunFactorsPairwiseReachable_step
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1)) :
     yunFactorsPairwiseReachable
-      (DensePoly.gcd c w)
-      (w / DensePoly.gcd c w)
+      (monicGcd c w)
+      (w / monicGcd c w)
       fuel :=
   yunFactorsPairwiseReachable.step c w fuel hreachable
 
@@ -4287,8 +4290,8 @@ private theorem yunFactorsPairwiseReady_step
     (c w : FpPoly p) (base level fuel : Nat)
     (hready : yunFactorsPairwiseReady c w base level (fuel + 1)) :
     yunFactorsPairwiseReady
-      (DensePoly.gcd c w)
-      (w / DensePoly.gcd c w)
+      (monicGcd c w)
+      (w / monicGcd c w)
       base
       (level + 1)
       fuel := by
@@ -4298,14 +4301,14 @@ private theorem yunFactorsPairwiseReady_succ_of_current_tail
     (c w : FpPoly p) (base level fuel : Nat)
     (htail :
       yunFactorsPairwiseReady
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         base
         (level + 1)
         fuel)
     (hcurrent :
       isOne c = false →
-        isOne (c / DensePoly.gcd c w) = false →
+        isOne (c / monicGcd c w) = false →
           yunFactorsCurrentTailCoprime c w base level fuel) :
     yunFactorsPairwiseReady c w base level (fuel + 1) := by
   simpa [yunFactorsPairwiseReady] using And.intro htail hcurrent
@@ -4338,8 +4341,8 @@ private theorem yunFactorsPairwiseInvariant_step
     (c w : FpPoly p) (base level fuel : Nat)
     (hinv : yunFactorsPairwiseInvariant c w base level (fuel + 1)) :
     yunFactorsPairwiseInvariant
-      (DensePoly.gcd c w)
-      (w / DensePoly.gcd c w)
+      (monicGcd c w)
+      (w / monicGcd c w)
       base
       (level + 1)
       fuel where
@@ -4432,6 +4435,7 @@ private theorem yunFactorsWithLevel_repeated_dvd_repeated_of_acc
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p) (base level fuel : Nat) (accRev : List (SquareFreeFactor p)) :
     (yunFactorsWithLevel c w base level fuel accRev).2 ∣ w := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   induction fuel generalizing c w level accRev with
   | zero =>
       simp [yunFactorsWithLevel]
@@ -4445,7 +4449,7 @@ private theorem yunFactorsWithLevel_repeated_dvd_repeated_of_acc
         let y := monicGcd c w
         let z := c / y
         have hdiv_tail : w / y ∣ w := by
-          exact ⟨y, by simpa [y] using (div_gcd_right_mul_reconstruct c w).symm⟩
+          exact ⟨y, by simpa [y] using (div_monicGcd_right_mul_reconstruct hp c w).symm⟩
         by_cases hz : isOne z
         · exact dvd_trans_poly
             (by simpa [y, z, hz] using ih y (w / y) (level + 1) accRev)
@@ -4688,7 +4692,7 @@ private theorem yunFactorsContributionWithLevel_residual_eq_yunFactorsContributi
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        exact ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+        exact ih (monicGcd c w) (w / monicGcd c w) (level + 1)
 
 /--
 Derivative-zero of the residual carries between the scaled
@@ -4843,25 +4847,25 @@ private theorem yunFactorsContributionWithLevel_scalar_step_bridge
     [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p)
     (c w : FpPoly p) {u_c u_w : ZMod64 p}
     (hu_c : u_c ≠ 0) (hu_w : u_w ≠ 0)
-    (hg_ne : DensePoly.gcd c w ≠ 0) :
+    (hg_ne : monicGcd c w ≠ 0) :
     ∃ v : ZMod64 p, v ≠ 0 ∧
       DensePoly.gcd (DensePoly.C u_c * c) (DensePoly.C u_w * w) =
-          DensePoly.C v * DensePoly.gcd c w ∧
+          DensePoly.C v * monicGcd c w ∧
         (DensePoly.C u_c * c) /
             DensePoly.gcd (DensePoly.C u_c * c) (DensePoly.C u_w * w) =
-          DensePoly.C (u_c * v⁻¹) * (c / DensePoly.gcd c w) ∧
+          DensePoly.C (u_c * v⁻¹) * (c / monicGcd c w) ∧
         (DensePoly.C u_w * w) /
             DensePoly.gcd (DensePoly.C u_c * c) (DensePoly.C u_w * w) =
-          DensePoly.C (u_w * v⁻¹) * (w / DensePoly.gcd c w) := by
+          DensePoly.C (u_w * v⁻¹) * (w / monicGcd c w) := by
   obtain ⟨v, hv_ne, hgcd⟩ :=
     gcd_C_mul_left_C_mul_right_eq_C_mul_gcd hp u_c u_w hu_c hu_w c w
   refine ⟨v, hv_ne, hgcd, ?_, ?_⟩
   · rw [hgcd]
-    have hc_dvd : DensePoly.gcd c w ∣ c := DensePoly.gcd_dvd_left c w
-    exact div_C_mul_C_mul_of_dvd hp hu_c hv_ne c (DensePoly.gcd c w) hc_dvd hg_ne
+    have hc_dvd : monicGcd c w ∣ c := monicGcd_dvd_left hp c w
+    exact div_C_mul_C_mul_of_dvd hp hu_c hv_ne c (monicGcd c w) hc_dvd hg_ne
   · rw [hgcd]
-    have hw_dvd : DensePoly.gcd c w ∣ w := DensePoly.gcd_dvd_right c w
-    exact div_C_mul_C_mul_of_dvd hp hu_w hv_ne w (DensePoly.gcd c w) hw_dvd hg_ne
+    have hw_dvd : monicGcd c w ∣ w := monicGcd_dvd_right hp c w
+    exact div_C_mul_C_mul_of_dvd hp hu_w hv_ne w (monicGcd c w) hw_dvd hg_ne
 
 private theorem pow_C_form
     [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p)
@@ -5824,22 +5828,24 @@ private theorem yunFactorsPairwiseReachable_current_squarefree
     (hreachable : yunFactorsPairwiseReachable c w fuel) :
     ∀ d : FpPoly p,
       d ∣ c → d ∣ DensePoly.derivative c → d ∣ (1 : FpPoly p) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   induction hreachable with
   | derivativeSplit hp f fuel hdf =>
       intro d hdc hddc
       exact derivativeSplit_quotient_common_dvd_derivative_one hp f hdf d hdc hddc
   | step c w fuel _ ih =>
       exact squarefree_factor_of_squarefree
-        (DensePoly.gcd_dvd_left c w) ih
+        (monicGcd_dvd_left hp c w) ih
 
 private theorem yunFactorsPairwiseReachable_common_dvd_one
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1)) :
     ∀ d : FpPoly p,
-      d ∣ c / DensePoly.gcd c w →
-        d ∣ DensePoly.gcd c w →
+      d ∣ c / monicGcd c w →
+        d ∣ monicGcd c w →
           d ∣ (1 : FpPoly p) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   intro d hdz hdy
   have hsquarefree :
       ∀ d : FpPoly p,
@@ -5849,7 +5855,7 @@ private theorem yunFactorsPairwiseReachable_common_dvd_one
   · let y := monicGcd c w
     let z := c / y
     have hprod : z * y = c := by
-      simpa [z, y] using div_gcd_mul_reconstruct c w
+      simpa [z, y] using div_monicGcd_mul_reconstruct hp c w
     rw [← hprod]
     exact dvd_mul_right_of_dvd (a := z) (b := y) (d := d)
         (by simpa [z, y] using hdz)
@@ -5895,17 +5901,18 @@ private theorem yunStep_quotient_tail_common_dvd_one_of_reachable
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1)) :
     ∀ d : FpPoly p,
-      d ∣ c / DensePoly.gcd c w →
-        d ∣ w / DensePoly.gcd c w →
+      d ∣ c / monicGcd c w →
+        d ∣ w / monicGcd c w →
           d ∣ (1 : FpPoly p) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   intro d hda hdz
   let y := monicGcd c w
   let a := c / y
   let z := w / y
   have hcy : a * y = c := by
-    simpa [a, y] using div_gcd_mul_reconstruct c w
+    simpa [a, y] using div_monicGcd_mul_reconstruct hp c w
   have hwy : z * y = w := by
-    simpa [z, y] using div_gcd_right_mul_reconstruct c w
+    simpa [z, y] using div_monicGcd_right_mul_reconstruct hp c w
   have hz_dvd_w : z ∣ w := ⟨y, by simpa [z, y] using hwy.symm⟩
   have hdy : d ∣ y := by
     apply DensePoly.dvd_gcd
@@ -5987,14 +5994,15 @@ private theorem yunStep_residual_dvd_derivative_product_of_previous
     let y := monicGcd c w
     let z := w / y
     z ∣ DensePoly.derivative (y * z) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   dsimp
   let y := monicGcd c w
   let a := c / y
   let z := w / y
   have hcy : a * y = c := by
-    simpa [a, y] using div_gcd_mul_reconstruct c w
+    simpa [a, y] using div_monicGcd_mul_reconstruct hp c w
   have hwy : z * y = w := by
-    simpa [z, y] using div_gcd_right_mul_reconstruct c w
+    simpa [z, y] using div_monicGcd_right_mul_reconstruct hp c w
   have hcommon_az :
       ∀ d : FpPoly p, d ∣ a → d ∣ z → d ∣ (1 : FpPoly p) := by
     intro d hda hdz
@@ -6710,9 +6718,10 @@ private theorem yunLevel_measure_lt_of_reachable_gcd_nonconstant
     (hc : isOne c = false)
     (hc_zero : c.isZero = false)
     (hw_zero : w.isZero = false)
-    (_hy_nonconstant : 1 < (DensePoly.gcd c w).size) :
-    (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+    (_hy_nonconstant : 1 < (monicGcd c w).size) :
+    (monicGcd c w).size + (w / monicGcd c w).size <
       c.size + w.size := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   have hc_size : 1 < c.size :=
     one_lt_size_of_isOne_false_of_reachable c hc_zero hc hreachable
   have hw_ne : w ≠ 0 := by
@@ -6721,7 +6730,7 @@ private theorem yunLevel_measure_lt_of_reachable_gcd_nonconstant
     exact (Bool.eq_not_self _).mp hw_zero.symm
   have hsize :=
     size_div_add_size_eq_size_add_one_of_dvd
-      (DensePoly.gcd_dvd_right c w) hw_ne
+      (monicGcd_dvd_right hp c w) hw_ne
   omega
 
 private theorem yunStep_tail_common_dvd_one_of_common_dvd_one
@@ -6730,18 +6739,19 @@ private theorem yunStep_tail_common_dvd_one_of_common_dvd_one
     (hcommon :
       ∀ d : FpPoly p, d ∣ c → d ∣ w → d ∣ (1 : FpPoly p)) :
     ∀ d : FpPoly p,
-      d ∣ DensePoly.gcd c w →
-        d ∣ w / DensePoly.gcd c w →
+      d ∣ monicGcd c w →
+        d ∣ w / monicGcd c w →
           d ∣ (1 : FpPoly p) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   intro d hdy hdz
   apply hcommon d
-  · exact dvd_trans_poly hdy (DensePoly.gcd_dvd_left c w)
-  · have hprod : (w / DensePoly.gcd c w) * DensePoly.gcd c w = w := by
-      exact div_gcd_right_mul_reconstruct c w
+  · exact dvd_trans_poly hdy (monicGcd_dvd_left hp c w)
+  · have hprod : (w / monicGcd c w) * monicGcd c w = w := by
+      exact div_monicGcd_right_mul_reconstruct hp c w
     rw [← hprod]
     exact dvd_mul_right_of_dvd
-      (a := w / DensePoly.gcd c w)
-      (b := DensePoly.gcd c w)
+      (a := w / monicGcd c w)
+      (b := monicGcd c w)
       (d := d)
       hdz
 
@@ -6751,14 +6761,15 @@ private theorem yunStep_tail_derivative_isZero_of_derivative_isZero_of_common_dv
     (hder : (DensePoly.derivative w).isZero = true)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ DensePoly.gcd c w →
-          d ∣ w / DensePoly.gcd c w →
+        d ∣ monicGcd c w →
+          d ∣ w / monicGcd c w →
             d ∣ (1 : FpPoly p)) :
-    (DensePoly.derivative (w / DensePoly.gcd c w)).isZero = true := by
+    (DensePoly.derivative (w / monicGcd c w)).isZero = true := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   let y := monicGcd c w
   let z := w / y
   have hprod : z * y = w := by
-    simpa [y, z] using div_gcd_right_mul_reconstruct c w
+    simpa [y, z] using div_monicGcd_right_mul_reconstruct hp c w
   have hder_prod : (DensePoly.derivative (z * y)).isZero = true := by
     rw [hprod]
     exact hder
@@ -6775,7 +6786,7 @@ private theorem yunStep_tail_derivative_isZero_of_source_common_dvd_one
     (hder : (DensePoly.derivative w).isZero = true)
     (hcommon :
       ∀ d : FpPoly p, d ∣ c → d ∣ w → d ∣ (1 : FpPoly p)) :
-    (DensePoly.derivative (w / DensePoly.gcd c w)).isZero = true := by
+    (DensePoly.derivative (w / monicGcd c w)).isZero = true := by
   exact
     yunStep_tail_derivative_isZero_of_derivative_isZero_of_common_dvd_one
       c w hder
@@ -6940,11 +6951,12 @@ private theorem yunStep_gcd_normalized_one_of_common_dvd_one
     (hcommon :
       ∀ d : FpPoly p, d ∣ c → d ∣ w → d ∣ (1 : FpPoly p)) :
     (normalizeMonic (DensePoly.gcd c w)).2 = 1 := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   have hgcd_dvd_one :
-      DensePoly.gcd c w ∣ (1 : FpPoly p) :=
-    hcommon (DensePoly.gcd c w)
-      (DensePoly.gcd_dvd_left c w)
-      (DensePoly.gcd_dvd_right c w)
+      monicGcd c w ∣ (1 : FpPoly p) :=
+    hcommon (monicGcd c w)
+      (monicGcd_dvd_left hp c w)
+      (monicGcd_dvd_right hp c w)
   exact normalizeMonic_eq_one_of_dvd_one hgcd_dvd_one
 
 private theorem yunStep_tail_common_dvd_one_of_gcd_normalized_one
@@ -6952,12 +6964,12 @@ private theorem yunStep_tail_common_dvd_one_of_gcd_normalized_one
     (c w : FpPoly p)
     (hnormalized : (normalizeMonic (DensePoly.gcd c w)).2 = 1) :
     ∀ d : FpPoly p,
-      d ∣ DensePoly.gcd c w →
-        d ∣ w / DensePoly.gcd c w →
+      d ∣ monicGcd c w →
+        d ∣ w / monicGcd c w →
           d ∣ (1 : FpPoly p) := by
   intro d hdy _hdv
   exact dvd_trans_poly hdy
-    (dvd_one_of_normalizeMonic_eq_one (DensePoly.gcd c w) hnormalized)
+    (dvd_one_of_normalizeMonic_eq_one (monicGcd c w) hnormalized)
 
 private theorem constant_nonzero_dvd
     [ZMod64.PrimeModulus p] {g f : FpPoly p}
@@ -7032,14 +7044,15 @@ private theorem yunStep_gcd_nonzero_of_left_nonzero
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p)
     (hc_zero : c.isZero = false) :
-    (DensePoly.gcd c w).isZero = false := by
-  cases hy_zero : (DensePoly.gcd c w).isZero with
+    (monicGcd c w).isZero = false := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+  cases hy_zero : (monicGcd c w).isZero with
   | false => rfl
   | true =>
       exfalso
-      have hy_eq_zero : DensePoly.gcd c w = 0 :=
-        eq_zero_of_isZero_true (DensePoly.gcd c w) hy_zero
-      rcases DensePoly.gcd_dvd_left c w with ⟨q, hq⟩
+      have hy_eq_zero : monicGcd c w = 0 :=
+        eq_zero_of_isZero_true (monicGcd c w) hy_zero
+      rcases monicGcd_dvd_left hp c w with ⟨q, hq⟩
       have hc_eq_zero : c = 0 := by
         rw [hy_eq_zero, zero_mul] at hq
         exact hq
@@ -7076,28 +7089,28 @@ private theorem yunStep_gcd_dvd_one_of_constant_common_dvd_one
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p)
     (hc_zero : c.isZero = false)
-    (hy_constant : ¬ 1 < (DensePoly.gcd c w).size)
+    (hy_constant : ¬ 1 < (monicGcd c w).size)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
-    DensePoly.gcd c w ∣ (1 : FpPoly p) := by
-  have hy_zero : (DensePoly.gcd c w).isZero = false :=
+    monicGcd c w ∣ (1 : FpPoly p) := by
+  have hy_zero : (monicGcd c w).isZero = false :=
     yunStep_gcd_nonzero_of_left_nonzero c w hc_zero
-  apply hcommon (DensePoly.gcd c w)
+  apply hcommon (monicGcd c w)
   · exact constant_nonzero_dvd hy_zero hy_constant
-  · exact DensePoly.dvd_refl_poly (DensePoly.gcd c w)
+  · exact DensePoly.dvd_refl_poly (monicGcd c w)
 
 private theorem yunStep_gcd_normalized_one_of_constant_common_dvd_one
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p)
     (hc_zero : c.isZero = false)
-    (hy_constant : ¬ 1 < (DensePoly.gcd c w).size)
+    (hy_constant : ¬ 1 < (monicGcd c w).size)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     (normalizeMonic (DensePoly.gcd c w)).2 = 1 := by
   exact normalizeMonic_eq_one_of_dvd_one
@@ -7108,15 +7121,15 @@ private theorem yunStep_tail_common_dvd_one_of_constant_common_dvd_one
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p)
     (hc_zero : c.isZero = false)
-    (hy_constant : ¬ 1 < (DensePoly.gcd c w).size)
+    (hy_constant : ¬ 1 < (monicGcd c w).size)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     ∀ d : FpPoly p,
-      d ∣ DensePoly.gcd c w →
-        d ∣ w / DensePoly.gcd c w →
+      d ∣ monicGcd c w →
+        d ∣ w / monicGcd c w →
           d ∣ (1 : FpPoly p) := by
   exact yunStep_tail_common_dvd_one_of_gcd_normalized_one c w
     (yunStep_gcd_normalized_one_of_constant_common_dvd_one
@@ -7129,38 +7142,39 @@ private theorem yunLevel_measure_lt_of_reachable_gcd_constant
     (hc : isOne c = false)
     (hc_zero : c.isZero = false)
     (hw_zero : w.isZero = false)
-    (hy_constant : ¬ 1 < (DensePoly.gcd c w).size)
+    (hy_constant : ¬ 1 < (monicGcd c w).size)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
-    (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+    (monicGcd c w).size + (w / monicGcd c w).size <
       c.size + w.size := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   have _htail_common :
       ∀ d : FpPoly p,
-        d ∣ DensePoly.gcd c w →
-          d ∣ w / DensePoly.gcd c w →
+        d ∣ monicGcd c w →
+          d ∣ w / monicGcd c w →
             d ∣ (1 : FpPoly p) :=
     yunStep_tail_common_dvd_one_of_constant_common_dvd_one
       c w hc_zero hy_constant hcommon
   have hc_size : 1 < c.size :=
     one_lt_size_of_isOne_false_of_reachable c hc_zero hc hreachable
-  have hy_zero : (DensePoly.gcd c w).isZero = false :=
+  have hy_zero : (monicGcd c w).isZero = false :=
     yunStep_gcd_nonzero_of_left_nonzero c w hc_zero
-  have hy_size : (DensePoly.gcd c w).size = 1 := by
-    have hy_pos : 0 < (DensePoly.gcd c w).size :=
-      size_pos_of_isZero_false (DensePoly.gcd c w) hy_zero
+  have hy_size : (monicGcd c w).size = 1 := by
+    have hy_pos : 0 < (monicGcd c w).size :=
+      size_pos_of_isZero_false (monicGcd c w) hy_zero
     omega
   have hw_ne : w ≠ 0 := by
     intro hw_eq
     rw [hw_eq] at hw_zero
     exact (Bool.eq_not_self _).mp hw_zero.symm
   have hsize :
-      (w / DensePoly.gcd c w).size + (DensePoly.gcd c w).size =
+      (w / monicGcd c w).size + (monicGcd c w).size =
         w.size + 1 :=
     size_div_add_size_eq_size_add_one_of_dvd
-      (DensePoly.gcd_dvd_right c w) hw_ne
+      (monicGcd_dvd_right hp c w) hw_ne
   omega
 
 private theorem yunLevel_measure_lt_of_reachable_step
@@ -7172,10 +7186,10 @@ private theorem yunLevel_measure_lt_of_reachable_step
           w.isZero = false)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1))
     (hc : isOne c = false) :
-    (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+    (monicGcd c w).size + (w / monicGcd c w).size <
       c.size + w.size := by
   rcases hstate with ⟨hcontribution_reachable, hc_zero, hw_zero⟩
-  by_cases hy_nonconstant : 1 < (DensePoly.gcd c w).size
+  by_cases hy_nonconstant : 1 < (monicGcd c w).size
   · exact
       yunLevel_measure_lt_of_reachable_gcd_nonconstant
         c w hcontribution_reachable hc hc_zero hw_zero hy_nonconstant
@@ -7191,45 +7205,46 @@ private theorem yunLevel_measure_lt_of_nonconstant_step
     (hc_zero : c.isZero = false)
     (hw_zero : w.isZero = false)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1)) :
-    (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+    (monicGcd c w).size + (w / monicGcd c w).size <
       c.size + w.size := by
-  by_cases hy_nonconstant : 1 < (DensePoly.gcd c w).size
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+  by_cases hy_nonconstant : 1 < (monicGcd c w).size
   · have hw_ne : w ≠ 0 := by
       intro hw_eq
       rw [hw_eq] at hw_zero
       exact (Bool.eq_not_self _).mp hw_zero.symm
     have hsize :=
       size_div_add_size_eq_size_add_one_of_dvd
-        (DensePoly.gcd_dvd_right c w) hw_ne
+        (monicGcd_dvd_right hp c w) hw_ne
     omega
   · have hcommon :
         ∀ d : FpPoly p,
-          d ∣ c / DensePoly.gcd c w →
-            d ∣ DensePoly.gcd c w →
+          d ∣ c / monicGcd c w →
+            d ∣ monicGcd c w →
               d ∣ (1 : FpPoly p) :=
       yunFactorsPairwiseReachable_common_dvd_one c w fuel hreachable
     have _htail_common :
         ∀ d : FpPoly p,
-          d ∣ DensePoly.gcd c w →
-            d ∣ w / DensePoly.gcd c w →
+          d ∣ monicGcd c w →
+            d ∣ w / monicGcd c w →
               d ∣ (1 : FpPoly p) :=
       yunStep_tail_common_dvd_one_of_constant_common_dvd_one
         c w hc_zero hy_nonconstant hcommon
-    have hy_zero : (DensePoly.gcd c w).isZero = false :=
+    have hy_zero : (monicGcd c w).isZero = false :=
       yunStep_gcd_nonzero_of_left_nonzero c w hc_zero
-    have hy_size : (DensePoly.gcd c w).size = 1 := by
-      have hy_pos : 0 < (DensePoly.gcd c w).size :=
-        size_pos_of_isZero_false (DensePoly.gcd c w) hy_zero
+    have hy_size : (monicGcd c w).size = 1 := by
+      have hy_pos : 0 < (monicGcd c w).size :=
+        size_pos_of_isZero_false (monicGcd c w) hy_zero
       omega
     have hw_ne : w ≠ 0 := by
       intro hw_eq
       rw [hw_eq] at hw_zero
       exact (Bool.eq_not_self _).mp hw_zero.symm
     have hsize :
-        (w / DensePoly.gcd c w).size + (DensePoly.gcd c w).size =
+        (w / monicGcd c w).size + (monicGcd c w).size =
           w.size + 1 :=
       size_div_add_size_eq_size_add_one_of_dvd
-        (DensePoly.gcd_dvd_right c w) hw_ne
+        (monicGcd_dvd_right hp c w) hw_ne
     omega
 
 private theorem yunFactorsLevelCompletes_of_size_bound
@@ -7261,21 +7276,21 @@ private theorem yunFactorsLevelCompletes_of_size_bound
           · exact False.elim (hc h)
         have htail_reachable :
             yunFactorsPairwiseReachable
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsPairwiseReachable_step c w fuel hreachable
         have hmeasure :
-            (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+            (monicGcd c w).size + (w / monicGcd c w).size <
               c.size + w.size :=
           yunLevel_measure_lt_of_reachable_step
             c w fuel (hstate c w (fuel + 1) hreachable) hreachable hc_false
         have htail_bound :
-            (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size ≤
+            (monicGcd c w).size + (w / monicGcd c w).size ≤
               fuel + 1 := by
           omega
         exact Or.inr
-          (ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          (ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable htail_bound)
 
 private theorem yunFactorsLevelCompletes_of_derivative_active_state
@@ -7333,8 +7348,8 @@ private theorem yunFactorsDerivativeActiveReachable_step
     (hp : Hex.Nat.Prime p) (f c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsDerivativeActiveReachable hp f c w (fuel + 1)) :
     yunFactorsDerivativeActiveReachable hp f
-      (DensePoly.gcd c w)
-      (w / DensePoly.gcd c w)
+      (monicGcd c w)
+      (w / monicGcd c w)
       fuel :=
   yunFactorsDerivativeActiveReachable.step c w fuel hreachable
 
@@ -7367,12 +7382,12 @@ private theorem yunFactorsContributionWithLevel_tail_valid_of_derivative_active_
           · exact False.elim (hc h)
         have htail_reachable :
             yunFactorsDerivativeActiveReachable hp f
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsDerivativeActiveReachable_step hp f c w fuel hreachable
         simpa [yunFactorsContributionWithLevel, hc_false] using
-          ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable
 
 private theorem yunFactorsContributionWithLevel_pthRoot_tail_valid
@@ -7506,7 +7521,7 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
         · rfl
         · have hz_zero : z = 0 := eq_zero_of_isZero_true z hz
           have hprod : z * y = w := by
-            simpa [z, y] using div_gcd_right_mul_reconstruct c w
+            simpa [z, y] using div_monicGcd_right_mul_reconstruct hp c w
           have hw_zero : w = 0 := by
             rw [← hprod, hz_zero, zero_mul]
           rw [hw_zero] at ih
@@ -7666,13 +7681,13 @@ private theorem yunFactorsContributionWithLevel_scalar_sync
             cases h : isOne (DensePoly.C u_c * c : FpPoly p)
             · rfl
             · exact False.elim (hscaled_c h)
-          let y : FpPoly p := DensePoly.gcd c w
+          let y : FpPoly p := monicGcd c w
           let yScaled : FpPoly p :=
             DensePoly.gcd (DensePoly.C u_c * c) (DensePoly.C u_w * w)
           let z : FpPoly p := c / y
           let zScaled : FpPoly p := (DensePoly.C u_c * c) / yScaled
           by_cases hy_zero : y = 0
-          · have hg_zero : DensePoly.gcd c w = 0 := by simpa [y] using hy_zero
+          · have hg_zero : monicGcd c w = 0 := by simpa [y] using hy_zero
             have hc_zero : c = 0 := (gcd_eq_zero_forces_zero c w hg_zero).1
             have hw_zero : w = 0 := (gcd_eq_zero_forces_zero c w hg_zero).2
             have hyScaled_zero : yScaled = 0 := by
@@ -7851,7 +7866,7 @@ private theorem yunFactorsContributionWithLevel_scalar_sync_of_derivative_active
             cases h : isOne (DensePoly.C u_c * c : FpPoly p)
             · rfl
             · exact False.elim (hscaled_c h)
-          let y : FpPoly p := DensePoly.gcd c w
+          let y : FpPoly p := monicGcd c w
           let yScaled : FpPoly p :=
             DensePoly.gcd (DensePoly.C u_c * c) (DensePoly.C u_w * w)
           let z : FpPoly p := c / y
@@ -8098,12 +8113,12 @@ private theorem yunFactorsContributionWithLevel_tail_nonzero_of_derivative_activ
           · exact False.elim (hc h)
         have htail_reachable :
             yunFactorsDerivativeActiveReachable hp f
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsDerivativeActiveReachable_step hp f c w fuel hreachable
         simpa [yunFactorsContributionWithLevel, hc_false] using
-          ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable
 
 private theorem yunFactorsContributionWithLevel_normalized_tail_valid_of_derivative_active_reachable
@@ -8129,12 +8144,12 @@ private theorem yunFactorsContributionWithLevel_normalized_tail_valid_of_derivat
           · exact False.elim (hc h)
         have htail_reachable :
             yunFactorsDerivativeActiveReachable hp f
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsDerivativeActiveReachable_step hp f c w fuel hreachable
         simpa [yunFactorsContributionWithLevel, hc_false] using
-          ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable
 
 private theorem yunFactorsContributionWithLevel_normalized_pthRoot_tail_valid
@@ -8239,8 +8254,8 @@ private theorem yunFactorsNormalizedLevelCompletes_of_size_bound_derivative_acti
           · exact False.elim (hc_norm h)
         have htail_reachable :
             yunFactorsDerivativeActiveReachable hp f
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsDerivativeActiveReachable_step hp f c w fuel hreachable
         have hpairwise :
@@ -8257,13 +8272,13 @@ private theorem yunFactorsNormalizedLevelCompletes_of_size_bound_derivative_acti
           have hsize := normalizeMonic_nonzero_size_eq hp c hraw_nonzero.1
           omega
         have hmeasure :
-            (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+            (monicGcd c w).size + (w / monicGcd c w).size <
               c.size + w.size :=
           yunLevel_measure_lt_of_nonconstant_step
             c w fuel hc_size hraw_nonzero.1 hraw_nonzero.2 hpairwise
         have htail_nonzero :=
           yunFactorsDerivativeActiveReachable_nonzero hp f
-            (DensePoly.gcd c w) (w / DensePoly.gcd c w) fuel htail_reachable
+            (monicGcd c w) (w / monicGcd c w) fuel htail_reachable
         have hcurrent_c_size :
             (normalizeMonic c).2.size = c.size :=
           normalizeMonic_nonzero_size_eq hp c hraw_nonzero.1
@@ -8272,19 +8287,19 @@ private theorem yunFactorsNormalizedLevelCompletes_of_size_bound_derivative_acti
           normalizeMonic_nonzero_size_eq hp w hraw_nonzero.2
         have htail_g_size :
             (normalizeMonic (DensePoly.gcd c w)).2.size =
-              (DensePoly.gcd c w).size :=
-          normalizeMonic_nonzero_size_eq hp (DensePoly.gcd c w) htail_nonzero.1
+              (monicGcd c w).size :=
+          normalizeMonic_nonzero_size_eq hp (monicGcd c w) htail_nonzero.1
         have htail_w_size :
-            (normalizeMonic (w / DensePoly.gcd c w)).2.size =
-              (w / DensePoly.gcd c w).size :=
+            (normalizeMonic (w / monicGcd c w)).2.size =
+              (w / monicGcd c w).size :=
           normalizeMonic_nonzero_size_eq hp
-            (w / DensePoly.gcd c w) htail_nonzero.2
+            (w / monicGcd c w) htail_nonzero.2
         have htail_bound :
             (normalizeMonic (DensePoly.gcd c w)).2.size +
-                (normalizeMonic (w / DensePoly.gcd c w)).2.size ≤ fuel + 1 := by
+                (normalizeMonic (w / monicGcd c w)).2.size ≤ fuel + 1 := by
           omega
         exact Or.inr
-          (ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          (ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable htail_bound)
 
 private theorem yunFactorsLevelCompletes_of_size_bound_derivative_active
@@ -8317,8 +8332,8 @@ private theorem yunFactorsLevelCompletes_of_size_bound_derivative_active
           · exact False.elim (hc h)
         have htail_reachable :
             yunFactorsDerivativeActiveReachable hp f
-              (DensePoly.gcd c w)
-              (w / DensePoly.gcd c w)
+              (monicGcd c w)
+              (w / monicGcd c w)
               fuel :=
           yunFactorsDerivativeActiveReachable_step hp f c w fuel hreachable
         have hpairwise :
@@ -8326,16 +8341,16 @@ private theorem yunFactorsLevelCompletes_of_size_bound_derivative_active
           yunFactorsPairwiseReachable_of_derivative_active_reachable
             hp f c w (fuel + 1) hreachable
         have hmeasure :
-            (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size <
+            (monicGcd c w).size + (w / monicGcd c w).size <
               c.size + w.size :=
           yunLevel_measure_lt_of_reachable_step
             c w fuel (hstate c w (fuel + 1) hreachable) hpairwise hc_false
         have htail_bound :
-            (DensePoly.gcd c w).size + (w / DensePoly.gcd c w).size ≤
+            (monicGcd c w).size + (w / monicGcd c w).size ≤
               fuel + 1 := by
           omega
         exact Or.inr
-          (ih (DensePoly.gcd c w) (w / DensePoly.gcd c w) (level + 1)
+          (ih (monicGcd c w) (w / monicGcd c w) (level + 1)
             htail_reachable htail_bound)
 
 private theorem yunFactorsLevelCompletes_of_derivative_active_reachable
@@ -8992,6 +9007,7 @@ private theorem yunFactorsWithLevel_factor_mem_acc_or_dvd_current
     (accRev : List (SquareFreeFactor p)) :
     ∀ sf ∈ (yunFactorsWithLevel c w base level fuel accRev).1,
       sf ∈ accRev ∨ sf.factor ∣ c := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   induction fuel generalizing c w level accRev with
   | zero =>
       intro sf hsf
@@ -9006,10 +9022,10 @@ private theorem yunFactorsWithLevel_factor_mem_acc_or_dvd_current
         let y := monicGcd c w
         let z := c / y
         have hy_dvd_c : y ∣ c := by
-          simpa [y] using DensePoly.gcd_dvd_left c w
+          simpa [y] using monicGcd_dvd_left hp c w
         have hz_dvd_c : z ∣ c := by
           refine ⟨y, ?_⟩
-          simpa [y, z] using (div_gcd_mul_reconstruct c w).symm
+          simpa [y, z] using (div_monicGcd_mul_reconstruct hp c w).symm
         by_cases hz : isOne z
         · intro sf hsf
           have htail :=
@@ -9067,17 +9083,18 @@ private theorem yunStep_quotient_right_factor_coprime_of_common_dvd_one
     (hfactor_dvd_w : factor ∣ w)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     squareFreeFactorCoprimeRel
-      { factor := c / DensePoly.gcd c w, multiplicity := multiplicity }
+      { factor := c / monicGcd c w, multiplicity := multiplicity }
       { factor := factor, multiplicity := tailMultiplicity } := by
-  let z := c / DensePoly.gcd c w
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+  let z := c / monicGcd c w
   let y := monicGcd c w
   have hz_dvd_c : z ∣ c := by
     refine ⟨y, ?_⟩
-    simpa [z, y] using (div_gcd_mul_reconstruct c w).symm
+    simpa [z, y] using (div_monicGcd_mul_reconstruct hp c w).symm
   have hgcd_dvd_y :
       DensePoly.gcd z factor ∣ y := by
     apply DensePoly.dvd_gcd
@@ -9096,18 +9113,18 @@ private theorem yunFactorsWithLevel_current_tail_coprime_of_common_dvd_one
     (c w : FpPoly p) (base level fuel : Nat)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     yunFactorsCurrentTailCoprime c w base level fuel := by
   intro sf hsf
   have hsf_dvd_current :
-      sf.factor ∣ DensePoly.gcd c w := by
+      sf.factor ∣ monicGcd c w := by
     exact yunFactorsWithLevel_factor_dvd_current
-      (DensePoly.gcd c w) (w / DensePoly.gcd c w) base (level + 1) fuel sf hsf
+      (monicGcd c w) (w / monicGcd c w) base (level + 1) fuel sf hsf
   exact
     yunStep_quotient_factor_coprime_of_common_dvd_one
-      (c / DensePoly.gcd c w) (DensePoly.gcd c w) sf.factor (base * level) sf.multiplicity
+      (c / monicGcd c w) (monicGcd c w) sf.factor (base * level) sf.multiplicity
       hsf_dvd_current
       hcommon
 
@@ -9116,43 +9133,44 @@ private theorem yunFactorsWithLevel_current_repeated_coprime_of_common_dvd_one
     (c w : FpPoly p) (base level fuel : Nat)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     let tail :=
       yunFactorsWithLevel
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         base
         (level + 1)
         fuel
         []
     squareFreeFactorCoprimeRel
-      { factor := c / DensePoly.gcd c w, multiplicity := base * level }
+      { factor := c / monicGcd c w, multiplicity := base * level }
       { factor := tail.2, multiplicity := base * level * p } := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   dsimp
   have htail_dvd :
       (yunFactorsWithLevel
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         base
         (level + 1)
         fuel
-        []).2 ∣ w / DensePoly.gcd c w := by
+        []).2 ∣ w / monicGcd c w := by
     exact yunFactorsWithLevel_repeated_dvd_repeated
-      (DensePoly.gcd c w)
-      (w / DensePoly.gcd c w)
+      (monicGcd c w)
+      (w / monicGcd c w)
       base
       (level + 1)
       fuel
-  have hright_dvd : w / DensePoly.gcd c w ∣ w := by
-    exact ⟨DensePoly.gcd c w, (div_gcd_right_mul_reconstruct c w).symm⟩
+  have hright_dvd : w / monicGcd c w ∣ w := by
+    exact ⟨monicGcd c w, (div_monicGcd_right_mul_reconstruct hp c w).symm⟩
   exact
     yunStep_quotient_right_factor_coprime_of_common_dvd_one
       c w
       (yunFactorsWithLevel
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         base
         (level + 1)
         fuel
@@ -9227,15 +9245,15 @@ private theorem yunFactorsPairwiseReady_succ_of_common_dvd_one
     (c w : FpPoly p) (base level fuel : Nat)
     (htail :
       yunFactorsPairwiseReady
-        (DensePoly.gcd c w)
-        (w / DensePoly.gcd c w)
+        (monicGcd c w)
+        (w / monicGcd c w)
         base
         (level + 1)
         fuel)
     (hcommon :
       ∀ d : FpPoly p,
-        d ∣ c / DensePoly.gcd c w →
-          d ∣ DensePoly.gcd c w →
+        d ∣ c / monicGcd c w →
+          d ∣ monicGcd c w →
             d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseReady c w base level (fuel + 1) := by
   apply yunFactorsPairwiseReady_succ_of_current_tail c w base level fuel htail
@@ -9251,8 +9269,8 @@ private theorem yunFactorsPairwiseReady_of_reachable_common_dvd_one
       ∀ c w : FpPoly p, ∀ fuel : Nat,
         yunFactorsPairwiseReachable c w (fuel + 1) →
           ∀ d : FpPoly p,
-            d ∣ c / DensePoly.gcd c w →
-              d ∣ DensePoly.gcd c w →
+            d ∣ c / monicGcd c w →
+              d ∣ monicGcd c w →
                 d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseReady c w base level fuel := by
   induction fuel generalizing c w level with
@@ -9261,14 +9279,14 @@ private theorem yunFactorsPairwiseReady_of_reachable_common_dvd_one
   | succ fuel ih =>
       have htail :
           yunFactorsPairwiseReady
-            (DensePoly.gcd c w)
-            (w / DensePoly.gcd c w)
+            (monicGcd c w)
+            (w / monicGcd c w)
             base
             (level + 1)
             fuel := by
         exact ih
-          (DensePoly.gcd c w)
-          (w / DensePoly.gcd c w)
+          (monicGcd c w)
+          (w / monicGcd c w)
           (level + 1)
           (yunFactorsPairwiseReachable_step c w fuel hreachable)
       exact
@@ -9283,8 +9301,8 @@ private theorem yunFactorsPairwiseReady_of_derivative_split_common_dvd_one
       ∀ c w : FpPoly p, ∀ fuel : Nat,
         yunFactorsPairwiseReachable c w (fuel + 1) →
           ∀ d : FpPoly p,
-            d ∣ c / DensePoly.gcd c w →
-              d ∣ DensePoly.gcd c w →
+            d ∣ c / monicGcd c w →
+              d ∣ monicGcd c w →
                 d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseReady
       (f / DensePoly.gcd f (DensePoly.derivative f))
@@ -9308,8 +9326,8 @@ private theorem yunFactorsPairwiseInvariant_of_derivative_split_common_dvd_one
       ∀ c w : FpPoly p, ∀ fuel : Nat,
         yunFactorsPairwiseReachable c w (fuel + 1) →
           ∀ d : FpPoly p,
-            d ∣ c / DensePoly.gcd c w →
-              d ∣ DensePoly.gcd c w →
+            d ∣ c / monicGcd c w →
+              d ∣ monicGcd c w →
                 d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseInvariant
       (f / DensePoly.gcd f (DensePoly.derivative f))
@@ -9960,6 +9978,7 @@ private theorem yunFactorsStepsSquareFree_of_reachable
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w fuel) :
     yunFactorsStepsSquareFree c w fuel := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   induction fuel generalizing c w with
   | zero =>
       simp [yunFactorsStepsSquareFree]
@@ -9974,7 +9993,7 @@ private theorem yunFactorsStepsSquareFree_of_reachable
           yunFactorsPairwiseReachable_current_squarefree c w (fuel + 1) hreachable
         have hz_dvd_c : z ∣ c := by
           refine ⟨y, ?_⟩
-          simpa [z, y] using (div_gcd_mul_reconstruct c w).symm
+          simpa [z, y] using (div_monicGcd_mul_reconstruct hp c w).symm
         have hz_squarefree :
             ∀ d : FpPoly p,
               d ∣ z → d ∣ DensePoly.derivative z → d ∣ (1 : FpPoly p) :=
@@ -10155,7 +10174,7 @@ Normalized gcd monicity for the Yun derivative-active transition. Whenever the
 right gcd operand is nonzero, the normalized gcd value
 `(normalizeMonic (DensePoly.gcd c w)).2` is monic.
 
-The raw executable `DensePoly.gcd c w` is not in general monic even when
+The raw executable `monicGcd c w` is not in general monic even when
 `c, w` are monic: over `F_5`, `gcd (x^2 + 1) (x + 1)` follows an Euclidean
 remainder path and returns the constant `2`, not a monic value. So the gcd
 side of the Yun derivative-active monic invariant tracked in #6155 must route
@@ -10165,7 +10184,7 @@ private theorem normalizeMonic_gcd_monic_of_right_nonzero
     [ZMod64.PrimeModulus p] (c w : FpPoly p)
     (hw : w.isZero = false) :
     DensePoly.Monic (normalizeMonic (DensePoly.gcd c w)).2 :=
-  normalizeMonic_nonzero_monic (DensePoly.gcd c w)
+  normalizeMonic_nonzero_monic (monicGcd c w)
     (gcd_isZero_false_of_right_isZero_false c w hw)
 
 /--

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1330,15 +1330,17 @@ emitting `c / gcd c w` then leaks that scalar into the square-free factor,
 breaking the exact reconstruction `weightedProduct = f`. The monic associate
 divides `c` and `w` exactly as the raw gcd does, so every reconstruction
 identity carries over, but the emitted quotient stays monic. -/
-@[irreducible] private def monicGcd (c w : FpPoly p) : FpPoly p :=
+private def monicGcd (c w : FpPoly p) : FpPoly p :=
   (normalizeMonic (DensePoly.gcd c w)).2
 
-/-- Definitional unfolding lemma for `monicGcd` (the def itself is
-`@[irreducible]` to keep `normalizeMonic` from being unfolded by `simp`/`decide`
-during defeq, which otherwise causes kernel-reduction timeouts). -/
+/-- Definitional unfolding lemma for `monicGcd`. The def itself is sealed
+`@[irreducible]` (below) to keep `normalizeMonic` from being unfolded by
+`simp`/`decide` during defeq, which otherwise causes kernel-reduction timeouts;
+this lemma is the controlled re-entry point. -/
 private theorem monicGcd_def (c w : FpPoly p) :
-    monicGcd c w = (normalizeMonic (DensePoly.gcd c w)).2 := by
-  unfold monicGcd
+    monicGcd c w = (normalizeMonic (DensePoly.gcd c w)).2 := rfl
+
+attribute [irreducible] monicGcd
 
 /-- The raw gcd is a constant multiple of `monicGcd`, recovered from
 `normalizeMonic_reconstruct`. -/
@@ -1357,15 +1359,25 @@ private theorem monicGcd_dvd_gcd
 
 /-- `monicGcd c w` divides `c`. -/
 private theorem monicGcd_dvd_left
-    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
-    monicGcd c w ∣ c :=
-  dvd_trans (monicGcd_dvd_gcd hp c w) (DensePoly.gcd_dvd_left c w)
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w ∣ c := by
+  obtain ⟨q1, h1⟩ := monicGcd_dvd_gcd hp c w
+  obtain ⟨q2, h2⟩ := DensePoly.gcd_dvd_left c w
+  refine ⟨q1 * q2, ?_⟩
+  calc c = DensePoly.gcd c w * q2 := h2
+    _ = monicGcd c w * q1 * q2 := by rw [h1]
+    _ = monicGcd c w * (q1 * q2) := DensePoly.mul_assoc_poly (monicGcd c w) q1 q2
 
 /-- `monicGcd c w` divides `w`. -/
 private theorem monicGcd_dvd_right
-    (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
-    monicGcd c w ∣ w :=
-  dvd_trans (monicGcd_dvd_gcd hp c w) (DensePoly.gcd_dvd_right c w)
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
+    monicGcd c w ∣ w := by
+  obtain ⟨q1, h1⟩ := monicGcd_dvd_gcd hp c w
+  obtain ⟨q2, h2⟩ := DensePoly.gcd_dvd_right c w
+  refine ⟨q1 * q2, ?_⟩
+  calc w = DensePoly.gcd c w * q2 := h2
+    _ = monicGcd c w * q1 * q2 := by rw [h1]
+    _ = monicGcd c w * (q1 * q2) := DensePoly.mul_assoc_poly (monicGcd c w) q1 q2
 
 /-- Left exact-division reconstruction across `monicGcd`. -/
 private theorem div_monicGcd_mul_reconstruct
@@ -2193,7 +2205,7 @@ private def yunFactorsWithLevel
       if isOne c then
         (accRev, w)
       else
-        let y := monicGcd c w
+        let y := DensePoly.gcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2212,7 +2224,7 @@ private def yunFactors
       if isOne c then
         (accRev, w)
       else
-        let y := monicGcd c w
+        let y := DensePoly.gcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2233,7 +2245,7 @@ private def yunFactorsContributionWithLevel
       if isOne c then
         (1, w)
       else
-        let y := monicGcd c w
+        let y := DensePoly.gcd c w
         let z := c / y
         let tail := yunFactorsContributionWithLevel y (w / y) base (level + 1) fuel
         let contribution :=
@@ -2250,7 +2262,7 @@ private def yunFactorsContribution
       if isOne c then
         (1, w)
       else
-        let y := monicGcd c w
+        let y := DensePoly.gcd c w
         let z := c / y
         let tail := yunFactorsContribution y (w / y) (i + 1) fuel
         let contribution :=
@@ -2364,7 +2376,7 @@ private def squareFreeAuxRevContribution (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRevContribution (pthRoot f) (multiplicity * p) fuel
         else
-          let g := monicGcd f df
+          let g := DensePoly.gcd f df
           let c := f / g
           let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
           if isOne contribution.2 then
@@ -4123,7 +4135,7 @@ private def squareFreeAuxRev (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRev (pthRoot f) (multiplicity * p) fuel accRev
         else
-          let g := monicGcd f df
+          let g := DensePoly.gcd f df
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           let accRev' := loop.1

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1330,16 +1330,23 @@ emitting `c / gcd c w` then leaks that scalar into the square-free factor,
 breaking the exact reconstruction `weightedProduct = f`. The monic associate
 divides `c` and `w` exactly as the raw gcd does, so every reconstruction
 identity carries over, but the emitted quotient stays monic. -/
-private def monicGcd (c w : FpPoly p) : FpPoly p :=
+@[irreducible] private def monicGcd (c w : FpPoly p) : FpPoly p :=
   (normalizeMonic (DensePoly.gcd c w)).2
+
+/-- Definitional unfolding lemma for `monicGcd` (the def itself is
+`@[irreducible]` to keep `normalizeMonic` from being unfolded by `simp`/`decide`
+during defeq, which otherwise causes kernel-reduction timeouts). -/
+private theorem monicGcd_def (c w : FpPoly p) :
+    monicGcd c w = (normalizeMonic (DensePoly.gcd c w)).2 := by
+  unfold monicGcd
 
 /-- The raw gcd is a constant multiple of `monicGcd`, recovered from
 `normalizeMonic_reconstruct`. -/
 private theorem gcd_eq_C_mul_monicGcd
     (hp : Hex.Nat.Prime p) (c w : FpPoly p) :
     DensePoly.C (normalizeMonic (DensePoly.gcd c w)).1 * monicGcd c w =
-      DensePoly.gcd c w :=
-  normalizeMonic_reconstruct hp (DensePoly.gcd c w)
+      DensePoly.gcd c w := by
+  rw [monicGcd_def]; exact normalizeMonic_reconstruct hp (DensePoly.gcd c w)
 
 /-- `monicGcd c w` divides the raw gcd (they are associates). -/
 private theorem monicGcd_dvd_gcd
@@ -1396,15 +1403,15 @@ private theorem monicGcd_mul_div_right_reconstruct
 private theorem monicGcd_monic_of_gcd_nonzero
     [ZMod64.PrimeModulus p] (c w : FpPoly p)
     (hgcd : (DensePoly.gcd c w).isZero = false) :
-    DensePoly.Monic (monicGcd c w) :=
-  normalizeMonic_nonzero_monic (DensePoly.gcd c w) hgcd
+    DensePoly.Monic (monicGcd c w) := by
+  rw [monicGcd_def]; exact normalizeMonic_nonzero_monic (DensePoly.gcd c w) hgcd
 
 /-- `monicGcd c w` is nonzero whenever the raw gcd is nonzero. -/
 private theorem monicGcd_isZero_false_of_gcd_nonzero
     [ZMod64.PrimeModulus p] (c w : FpPoly p)
     (hgcd : (DensePoly.gcd c w).isZero = false) :
-    (monicGcd c w).isZero = false :=
-  normalizeMonic_nonzero_isZero_false (DensePoly.gcd c w) hgcd
+    (monicGcd c w).isZero = false := by
+  rw [monicGcd_def]; exact normalizeMonic_nonzero_isZero_false (DensePoly.gcd c w) hgcd
 
 /-! ### Scalar-multiple algebra foundations
 

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -2205,7 +2205,7 @@ private def yunFactorsWithLevel
       if isOne c then
         (accRev, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2224,7 +2224,7 @@ private def yunFactors
       if isOne c then
         (accRev, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let accRev' :=
           if isOne z then
@@ -2245,7 +2245,7 @@ private def yunFactorsContributionWithLevel
       if isOne c then
         (1, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let tail := yunFactorsContributionWithLevel y (w / y) base (level + 1) fuel
         let contribution :=
@@ -2262,7 +2262,7 @@ private def yunFactorsContribution
       if isOne c then
         (1, w)
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let tail := yunFactorsContribution y (w / y) (i + 1) fuel
         let contribution :=
@@ -2287,7 +2287,7 @@ private theorem yunFactorsWithLevel_reconstruction_invariant
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         by_cases hz : isOne z
         · simpa [y, z, hz] using ih y (w / y) (level + 1) accRev
@@ -2333,7 +2333,7 @@ private theorem yunFactors_reconstruction_invariant
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         by_cases hz : isOne z
         · simpa [y, z, hz] using ih y (w / y) (i + 1) accRev
@@ -2376,7 +2376,7 @@ private def squareFreeAuxRevContribution (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRevContribution (pthRoot f) (multiplicity * p) fuel
         else
-          let g := DensePoly.gcd f df
+          let g := monicGcd f df
           let c := f / g
           let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
           if isOne contribution.2 then
@@ -3207,7 +3207,7 @@ private theorem gcd_isZero_false_of_right_isZero_false
 private theorem yunFactorsContribution_step_split
     [ZMod64.PrimeModulus p]
     (c w : FpPoly p) :
-    let y := DensePoly.gcd c w
+    let y := monicGcd c w
     let z := c / y
     z * y = c ∧ (w / y) * y = w := by
   constructor
@@ -3522,7 +3522,7 @@ private theorem yunStep_common_dvd_derivative_current
     (hdz : d ∣ c / DensePoly.gcd c w)
     (hdy : d ∣ DensePoly.gcd c w) :
     d ∣ DensePoly.derivative c := by
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   let z := c / y
   have hprod : z * y = c := by
     simpa [z, y] using div_gcd_mul_reconstruct c w
@@ -3737,7 +3737,7 @@ private theorem yunFactorsContribution_step_of_not_isOne_of_not_isOne_z
 private theorem yunFactorsContribution_tail_repeated_descent
     (c w : FpPoly p) (multiplicity fuel : Nat)
     (hc : isOne c = false) :
-    let y := DensePoly.gcd c w
+    let y := monicGcd c w
     let tail := yunFactorsContribution y (w / y) (multiplicity + 1) fuel
     let contribution := yunFactorsContribution c w multiplicity (fuel + 1)
     contribution.2 = tail.2 ∧
@@ -3811,7 +3811,7 @@ private theorem yunFactorsContribution_step_target_combiner
           (yunFactorsContribution
             (DensePoly.gcd c w) (w / DensePoly.gcd c w)
             (multiplicity + 1) fuel).1 = target) :
-    let y := DensePoly.gcd c w
+    let y := monicGcd c w
     let tail :=
       yunFactorsContribution y (w / y) (multiplicity + 1) fuel
     let contribution := yunFactorsContribution c w multiplicity (fuel + 1)
@@ -4135,7 +4135,7 @@ private def squareFreeAuxRev (f : FpPoly p) (multiplicity : Nat) :
         if df.isZero then
           squareFreeAuxRev (pthRoot f) (multiplicity * p) fuel accRev
         else
-          let g := DensePoly.gcd f df
+          let g := monicGcd f df
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           let accRev' := loop.1
@@ -4267,7 +4267,7 @@ private theorem yunFactorsPairwiseReachable_step
 
 private def yunFactorsCurrentTailCoprime
     (c w : FpPoly p) (base level fuel : Nat) : Prop :=
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   let z := c / y
   ∀ sf ∈ (yunFactorsWithLevel y (w / y) base (level + 1) fuel []).1.reverse,
     squareFreeFactorCoprimeRel { factor := z, multiplicity := base * level } sf
@@ -4276,7 +4276,7 @@ private def yunFactorsPairwiseReady
     (c w : FpPoly p) (base : Nat) : Nat → Nat → Prop
   | _, 0 => True
   | level, fuel + 1 =>
-      let y := DensePoly.gcd c w
+      let y := monicGcd c w
       let z := c / y
       yunFactorsPairwiseReady y (w / y) base (level + 1) fuel ∧
         (isOne c = false →
@@ -4379,7 +4379,7 @@ private theorem yunFactorsWithLevel_reverse_append
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         by_cases hz : isOne z
         · simpa [y, z, hz] using ih y (w / y) (level + 1) accRev
@@ -4408,7 +4408,7 @@ private theorem yunFactorsWithLevel_repeated_eq_nil
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         by_cases hz : isOne z
         · simpa [y, z, hz] using ih y (w / y) (level + 1) accRev
@@ -4442,7 +4442,7 @@ private theorem yunFactorsWithLevel_repeated_dvd_repeated_of_acc
       · simp [hc]
         exact ⟨1, by rw [mul_one]⟩
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         have hdiv_tail : w / y ∣ w := by
           exact ⟨y, by simpa [y] using (div_gcd_right_mul_reconstruct c w).symm⟩
@@ -4480,7 +4480,7 @@ private def yunFactorsContributionResidualComplete
       if isOne c then
         isOne w = false → (DensePoly.derivative w).isZero = true
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         yunFactorsContributionResidualComplete y (w / y) (multiplicity + 1) fuel
 
 private theorem yunFactorsContributionResidualDerivativeZero_of_complete
@@ -4504,7 +4504,7 @@ private theorem yunFactorsContributionResidualDerivativeZero_of_complete
           simpa [yunFactorsContribution, hc] using hrepeated
         simpa [yunFactorsContributionResidualDerivativeZero,
           yunFactorsContribution, hc] using hcomplete_here hrepeated_here
-      · let y := DensePoly.gcd c w
+      · let y := monicGcd c w
         have hc_false : isOne c = false := by
           cases h : isOne c
           · rfl
@@ -4541,7 +4541,7 @@ private theorem yunFactorsContributionResidualComplete_of_derivativeZero
             simpa [yunFactorsContribution, hc] using hone_w
           simpa [yunFactorsContribution, hc] using hresidual hres_lifted
         simpa [yunFactorsContributionResidualComplete, hc] using hres_here
-      · let y := DensePoly.gcd c w
+      · let y := monicGcd c w
         have hc_false : isOne c = false := by
           cases h : isOne c
           · rfl
@@ -5846,7 +5846,7 @@ private theorem yunFactorsPairwiseReachable_common_dvd_one
         d ∣ c → d ∣ DensePoly.derivative c → d ∣ (1 : FpPoly p) :=
     yunFactorsPairwiseReachable_current_squarefree c w (fuel + 1) hreachable
   apply hsquarefree d
-  · let y := DensePoly.gcd c w
+  · let y := monicGcd c w
     let z := c / y
     have hprod : z * y = c := by
       simpa [z, y] using div_gcd_mul_reconstruct c w
@@ -5899,7 +5899,7 @@ private theorem yunStep_quotient_tail_common_dvd_one_of_reachable
         d ∣ w / DensePoly.gcd c w →
           d ∣ (1 : FpPoly p) := by
   intro d hda hdz
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   let a := c / y
   let z := w / y
   have hcy : a * y = c := by
@@ -5984,11 +5984,11 @@ private theorem yunStep_residual_dvd_derivative_product_of_previous
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w (fuel + 1))
     (hprev : w ∣ DensePoly.derivative (c * w)) :
-    let y := DensePoly.gcd c w
+    let y := monicGcd c w
     let z := w / y
     z ∣ DensePoly.derivative (y * z) := by
   dsimp
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   let a := c / y
   let z := w / y
   have hcy : a * y = c := by
@@ -6755,7 +6755,7 @@ private theorem yunStep_tail_derivative_isZero_of_derivative_isZero_of_common_dv
           d ∣ w / DensePoly.gcd c w →
             d ∣ (1 : FpPoly p)) :
     (DensePoly.derivative (w / DensePoly.gcd c w)).isZero = true := by
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   let z := w / y
   have hprod : z * y = w := by
     simpa [y, z] using div_gcd_right_mul_reconstruct c w
@@ -6799,7 +6799,7 @@ private theorem yunFactorsContributionResidualComplete_of_derivative_zero_common
           cases h : isOne c
           · rfl
           · exact False.elim (hc h)
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         have htail_der :
             (DensePoly.derivative (w / y)).isZero = true := by
           simpa [y] using
@@ -7497,7 +7497,7 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
           rw [← hprod, hc_zero, zero_mul]
       simpa [c, g] using And.intro hc_nonzero hg_nonzero
   | step c w fuel _ ih =>
-      let y := DensePoly.gcd c w
+      let y := monicGcd c w
       let z := w / y
       have hy_nonzero : y.isZero = false := by
         simpa [y] using gcd_isZero_false_of_right_isZero_false c w ih.2
@@ -8563,7 +8563,7 @@ private theorem yunFactorsContributionResidualComplete_of_pairwise_reachable_lev
           cases h : isOne c
           · rfl
           · exact False.elim (hc h)
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         have htail_reachable :
             yunFactorsPairwiseReachable y (w / y) fuel := by
           simpa [y] using yunFactorsPairwiseReachable_step c w fuel hreachable
@@ -9003,7 +9003,7 @@ private theorem yunFactorsWithLevel_factor_mem_acc_or_dvd_current
         intro sf hsf
         exact Or.inl hsf
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         have hy_dvd_c : y ∣ c := by
           simpa [y] using DensePoly.gcd_dvd_left c w
@@ -9074,7 +9074,7 @@ private theorem yunStep_quotient_right_factor_coprime_of_common_dvd_one
       { factor := c / DensePoly.gcd c w, multiplicity := multiplicity }
       { factor := factor, multiplicity := tailMultiplicity } := by
   let z := c / DensePoly.gcd c w
-  let y := DensePoly.gcd c w
+  let y := monicGcd c w
   have hz_dvd_c : z ∣ c := by
     refine ⟨y, ?_⟩
     simpa [z, y] using (div_gcd_mul_reconstruct c w).symm
@@ -9179,7 +9179,7 @@ private theorem yunFactorsWithLevel_factors_coprime_repeated_of_reachable
       by_cases hc : isOne c
       · simp [hc]
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         let sf : SquareFreeFactor p := { factor := z, multiplicity := base * level }
         let tail := yunFactorsWithLevel y (w / y) base (level + 1) fuel []
@@ -9557,7 +9557,7 @@ private theorem yunFactorsWithLevel_pairwise_coprime_nil_of_ready
           cases h : isOne c with
           | false => rfl
           | true => exact False.elim (hc h)
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         have hready_unpack :
             yunFactorsPairwiseReady y (w / y) base (level + 1) fuel ∧
@@ -9947,7 +9947,7 @@ private def yunFactorsStepsSquareFree (c w : FpPoly p) : Nat → Prop
       if isOne c then
         True
       else
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         (if isOne z then
           True
@@ -9966,7 +9966,7 @@ private theorem yunFactorsStepsSquareFree_of_reachable
   | succ fuel ih =>
       by_cases hc : isOne c
       · simp [yunFactorsStepsSquareFree, hc]
-      · let y := DensePoly.gcd c w
+      · let y := monicGcd c w
         let z := c / y
         have hcurrent :
             ∀ d : FpPoly p,
@@ -10026,7 +10026,7 @@ private theorem yunFactorsWithLevel_factors_squareFree_of_steps
       by_cases hc : isOne c
       · simpa [hc] using hacc
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         have hsteps_nonone :
             (if isOne z then
@@ -10224,7 +10224,7 @@ private theorem yunFactorsWithLevel_multiplicity_pos_raw
       by_cases hc : isOne c
       · simpa [hc] using hacc
       · simp [hc]
-        let y := DensePoly.gcd c w
+        let y := monicGcd c w
         let z := c / y
         by_cases hz : isOne z
         · simpa [y, z, hz] using

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -3247,6 +3247,28 @@ private theorem dvd_mul_right_of_dvd
       = (d * q) * b := by rw [hq]
     _ = d * (q * b) := DensePoly.mul_assoc_poly d q b
 
+/-- `monicGcd` analogue of `DensePoly.dvd_gcd`: any common divisor of `c` and
+`w` divides their monic gcd. The monic gcd is a constant-scalar associate of the
+raw gcd, so it has the same divisors. -/
+private theorem dvd_monicGcd
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p)
+    {d : FpPoly p} (c w : FpPoly p) (hdc : d ∣ c) (hdw : d ∣ w) :
+    d ∣ monicGcd c w := by
+  have hdg : d ∣ DensePoly.gcd c w := DensePoly.dvd_gcd d c w hdc hdw
+  cases hgz : (DensePoly.gcd c w).isZero with
+  | true =>
+      have hmg0 : monicGcd c w = 0 := by
+        rw [monicGcd_def, normalizeMonic_zero _ hgz]
+      exact ⟨0, by rw [hmg0]; simp⟩
+  | false =>
+      have hmg :
+          monicGcd c w =
+            DensePoly.C (DensePoly.leadingCoeff (DensePoly.gcd c w))⁻¹ *
+              DensePoly.gcd c w := by
+        rw [monicGcd_def, normalizeMonic_nonzero _ hgz, C_mul_eq_scale]
+      rw [hmg]
+      exact dvd_mul_left_of_dvd hdg
+
 private theorem dvd_sub_poly
     {d a b : FpPoly p} (hda : d ∣ a) (hdb : d ∣ b) :
     d ∣ a - b := by
@@ -3535,14 +3557,15 @@ private theorem yunStep_common_dvd_derivative_current
 private theorem derivativeSplit_common_dvd_quotient_derivative_dvd_gcd
     [ZMod64.PrimeModulus p]
     (f d : FpPoly p)
-    (hdc : d ∣ f / DensePoly.gcd f (DensePoly.derivative f))
+    (hdc : d ∣ f / monicGcd f (DensePoly.derivative f))
     (hddc : d ∣ DensePoly.derivative
-      (f / DensePoly.gcd f (DensePoly.derivative f))) :
-    d ∣ DensePoly.gcd f (DensePoly.derivative f) := by
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+      (f / monicGcd f (DensePoly.derivative f))) :
+    d ∣ monicGcd f (DensePoly.derivative f) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   have hprod : c * g = f := by
-    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+    simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
   have hdf :
       DensePoly.derivative f =
         DensePoly.derivative c * g + c * DensePoly.derivative g := by
@@ -3558,23 +3581,24 @@ private theorem derivativeSplit_common_dvd_quotient_derivative_dvd_gcd
         (by simpa [c, g] using hddc))
       (dvd_mul_right_of_dvd (a := c) (b := DensePoly.derivative g) (d := d)
         (by simpa [c, g] using hdc))
-  exact DensePoly.dvd_gcd d f (DensePoly.derivative f) hdf_dvd_f hdf_dvd_derivative
+  exact dvd_monicGcd hp f (DensePoly.derivative f) hdf_dvd_f hdf_dvd_derivative
 
 private theorem derivativeSplit_quotient_pow_succ_dvd_gcd
     [ZMod64.PrimeModulus p] (f d : FpPoly p)
-    (hdc : d ∣ f / DensePoly.gcd f (DensePoly.derivative f))
+    (hdc : d ∣ f / monicGcd f (DensePoly.derivative f))
     (hddc : d ∣ DensePoly.derivative
-      (f / DensePoly.gcd f (DensePoly.derivative f))) :
-    ∀ n, pow d n ∣ DensePoly.gcd f (DensePoly.derivative f) →
-      pow d (n + 1) ∣ DensePoly.gcd f (DensePoly.derivative f) := by
+      (f / monicGcd f (DensePoly.derivative f))) :
+    ∀ n, pow d n ∣ monicGcd f (DensePoly.derivative f) →
+      pow d (n + 1) ∣ monicGcd f (DensePoly.derivative f) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   intro n hpow
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   rcases quotient_common_dvd_mul_derivative_base d c
       (by simpa [c, g] using hdc) (by simpa [c, g] using hddc) with
     ⟨a, ha, hcofactor⟩
   have hprod : c * g = f := by
-    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+    simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
   have hdf :
       DensePoly.derivative f =
         DensePoly.derivative c * g + c * DensePoly.derivative g := by
@@ -3696,7 +3720,7 @@ private theorem derivativeSplit_quotient_pow_succ_dvd_gcd
                 _ = pow d (k + 2) * (a * DensePoly.derivative q) := by
                       rw [← pow_succ d (k + 1)])
         exact dvd_add_poly hleft hright
-      exact DensePoly.dvd_gcd (pow d (k + 2)) f (DensePoly.derivative f)
+      exact dvd_monicGcd hp f (DensePoly.derivative f)
         hsucc_dvd_f hsucc_dvd_derivative
 
 private theorem yunFactorsContribution_stop_of_isOne
@@ -3839,15 +3863,16 @@ private theorem yunFactorsContribution_step_target_combiner
 private theorem yunFactorsContribution_initial_state_split
     [ZMod64.PrimeModulus p]
     (f : FpPoly p) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     c * g = f := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   dsimp
-  exact div_gcd_mul_reconstruct f (DensePoly.derivative f)
+  exact div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
 
 private theorem yunFactorsContribution_initial_state_done
     (f : FpPoly p) (multiplicity fuel : Nat) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity (fuel + 1)
     isOne contribution.2 = true →
@@ -3857,14 +3882,14 @@ private theorem yunFactorsContribution_initial_state_done
   intro _hrepeated
   have hloop :=
     yunFactors_reconstruction_invariant
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f)) multiplicity (fuel + 1) []
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f)) multiplicity (fuel + 1) []
   have hproduct := hloop.2
   simpa [weightedProduct_nil] using hproduct.symm
 
 private theorem yunFactorsContribution_initial_state_tail
     (f : FpPoly p) (multiplicity fuel : Nat) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity (fuel + 1)
     isOne contribution.2 = false →
@@ -3874,8 +3899,8 @@ private theorem yunFactorsContribution_initial_state_tail
   intro _hrepeated
   have hloop :=
     yunFactors_reconstruction_invariant
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f)) multiplicity (fuel + 1) []
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f)) multiplicity (fuel + 1) []
   have hproduct := hloop.2
   simpa [weightedProduct_nil] using hproduct.symm
 
@@ -3887,7 +3912,7 @@ product emitted by Yun's loop; assembling that contribution into the outer
 -/
 private theorem yunFactorsContribution_derivative_active_initial_state_invariant
     (f : FpPoly p) (multiplicity fuel : Nat) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity (fuel + 1)
     (isOne contribution.2 = true →
@@ -3910,7 +3935,7 @@ private theorem yunFactorsContribution_derivative_active_split_algebra_succ
     (_hmultiplicity : 0 < multiplicity) (_hfuel : f.size < fuel + 2)
     (_hzero : f.isZero = false)
     (_hdf : (DensePoly.derivative f).isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity (fuel + 1)
     c * g = f ∧
@@ -3921,7 +3946,7 @@ private theorem yunFactorsContribution_derivative_active_split_algebra_succ
           contribution.1 =
             weightedProduct (yunFactors c g multiplicity (fuel + 1) []).1.reverse) := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   have hcg : c * g = f := by
     simpa [c, g] using yunFactorsContribution_initial_state_split f
@@ -3935,7 +3960,7 @@ private theorem yunFactorsContribution_derivative_active_split_algebra
     (hmultiplicity : 0 < multiplicity) (hfuel : f.size < fuel + 1)
     (hzero : f.isZero = false)
     (hdf : (DensePoly.derivative f).isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity fuel
     c * g = f ∧
@@ -3959,7 +3984,7 @@ private theorem yunFactorsContribution_initial_state_product_invariant
     (hmultiplicity : 0 < multiplicity) (hfuel : f.size < fuel + 1)
     (hzero : f.isZero = false)
     (hdf : (DensePoly.derivative f).isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity fuel
     (isOne contribution.2 = true →
@@ -3977,7 +4002,7 @@ private theorem yunFactorsContribution_reconstruct_core
     (hmultiplicity : 0 < multiplicity) (_hfuel : f.size < fuel + 1)
     (_hzero : f.isZero = false)
     (_hdf : (DensePoly.derivative f).isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity fuel
     (isOne contribution.2 = true →
@@ -3998,15 +4023,15 @@ private theorem yunFactorsContribution_reconstruct_done
     (hdf : (DensePoly.derivative f).isZero = false)
     (hrepeated :
       isOne (yunFactorsContribution
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2 = true) :
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2 = true) :
     (yunFactorsContribution
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).1 =
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f)) multiplicity fuel).1 =
         weightedProduct
           (yunFactors
-            (f / DensePoly.gcd f (DensePoly.derivative f))
-            (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel []).1.reverse := by
+            (f / monicGcd f (DensePoly.derivative f))
+            (monicGcd f (DensePoly.derivative f)) multiplicity fuel []).1.reverse := by
   exact (yunFactorsContribution_reconstruct_core
     hp f multiplicity fuel hmultiplicity hfuel hzero hdf).1 hrepeated
 
@@ -4017,24 +4042,24 @@ private theorem yunFactorsContribution_reconstruct_tail
     (hdf : (DensePoly.derivative f).isZero = false)
     (hrepeated :
       isOne (yunFactorsContribution
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2 = false) :
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2 = false) :
     (yunFactorsContribution
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).1 *
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f)) multiplicity fuel).1 *
         squareFreeAuxRevContribution
           (pthRoot (yunFactorsContribution
-            (f / DensePoly.gcd f (DensePoly.derivative f))
-            (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2)
+            (f / monicGcd f (DensePoly.derivative f))
+            (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2)
           (multiplicity * p) fuel =
           weightedProduct
             (yunFactors
-              (f / DensePoly.gcd f (DensePoly.derivative f))
-              (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel []).1.reverse *
+              (f / monicGcd f (DensePoly.derivative f))
+              (monicGcd f (DensePoly.derivative f)) multiplicity fuel []).1.reverse *
             squareFreeAuxRevContribution
               (pthRoot (yunFactorsContribution
-                (f / DensePoly.gcd f (DensePoly.derivative f))
-                (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2)
+                (f / monicGcd f (DensePoly.derivative f))
+                (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2)
               (multiplicity * p) fuel := by
   rw [(yunFactorsContribution_reconstruct_core
     hp f multiplicity fuel hmultiplicity hfuel hzero hdf).2 hrepeated]
@@ -4044,7 +4069,7 @@ private theorem yunFactorsContribution_reconstruct
     (hmultiplicity : 0 < multiplicity) (hfuel : f.size < fuel + 1)
     (hzero : f.isZero = false)
     (hdf : (DensePoly.derivative f).isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContribution c g multiplicity fuel
     if isOne contribution.2 then
@@ -4058,19 +4083,19 @@ private theorem yunFactorsContribution_reconstruct
   simp only
   by_cases hrepeated :
       isOne (yunFactorsContribution
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2
   · simpa [hrepeated] using
       yunFactorsContribution_reconstruct_done
         hp f multiplicity fuel hmultiplicity hfuel hzero hdf hrepeated
   · have hrepeated_false :
         isOne (yunFactorsContribution
-          (f / DensePoly.gcd f (DensePoly.derivative f))
-          (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2 = false := by
+          (f / monicGcd f (DensePoly.derivative f))
+          (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2 = false := by
       cases h :
           isOne (yunFactorsContribution
-            (f / DensePoly.gcd f (DensePoly.derivative f))
-            (DensePoly.gcd f (DensePoly.derivative f)) multiplicity fuel).2
+            (f / monicGcd f (DensePoly.derivative f))
+            (monicGcd f (DensePoly.derivative f)) multiplicity fuel).2
       · rfl
       · exact False.elim (hrepeated h)
     simpa [hrepeated_false] using
@@ -4090,8 +4115,8 @@ private inductive yunFactorsDerivativeActiveReachable
   | derivativeSplit (fuel : Nat)
       (hdf : (DensePoly.derivative f).isZero ≠ true) :
       yunFactorsDerivativeActiveReachable hp f
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f))
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f))
         fuel
   | step (c w : FpPoly p) (fuel : Nat) :
       yunFactorsDerivativeActiveReachable hp f c w (fuel + 1) →
@@ -4172,7 +4197,7 @@ private theorem squareFreeAuxRev_reconstruction_invariant
         by_cases hdf : (DensePoly.derivative f).isZero
         · simpa [hdf] using ih (pthRoot f) (multiplicity * p) accRev
         · simp [hdf]
-          let g := DensePoly.gcd f (DensePoly.derivative f)
+          let g := monicGcd f (DensePoly.derivative f)
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
@@ -4240,8 +4265,8 @@ private inductive yunFactorsPairwiseReachable :
   | derivativeSplit (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
       (hdf : (DensePoly.derivative f).isZero ≠ true) :
       yunFactorsPairwiseReachable
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f))
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f))
         fuel
   | step (c w : FpPoly p) (fuel : Nat) :
       yunFactorsPairwiseReachable c w (fuel + 1) →
@@ -4254,8 +4279,8 @@ private theorem yunFactorsPairwiseReachable_of_derivative_split
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
     yunFactorsPairwiseReachable
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       fuel :=
   yunFactorsPairwiseReachable.derivativeSplit hp f fuel hdf
 
@@ -4323,14 +4348,14 @@ private theorem yunFactorsPairwiseInvariant_of_derivative_split
     (hdf : (DensePoly.derivative f).isZero ≠ true)
     (hready :
       yunFactorsPairwiseReady
-        (f / DensePoly.gcd f (DensePoly.derivative f))
-        (DensePoly.gcd f (DensePoly.derivative f))
+        (f / monicGcd f (DensePoly.derivative f))
+        (monicGcd f (DensePoly.derivative f))
         base
         level
         fuel) :
     yunFactorsPairwiseInvariant
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       base
       level
       fuel where
@@ -4582,18 +4607,18 @@ private theorem yunFactorsResidualDerivativeZero_of_derivative_split_contributio
     (_hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (_hdf : (DensePoly.derivative f).isZero = false)
     (hresidual :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       yunFactorsContributionResidualDerivativeZero c g multiplicity fuel) :
     yunFactorsResidualDerivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel := by
   exact
     yunFactorsResidualDerivativeZero_of_contribution
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel
       hresidual
@@ -4602,20 +4627,20 @@ private theorem yunFactorsResidualDerivativeZero_of_derivative_split_complete
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hcomplete :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       yunFactorsContributionResidualComplete c g multiplicity fuel) :
     yunFactorsResidualDerivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel := by
   apply yunFactorsResidualDerivativeZero_of_derivative_split_contribution
     hp f multiplicity fuel hdf
   exact
     yunFactorsContributionResidualDerivativeZero_of_complete
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel
       hcomplete
@@ -4634,16 +4659,16 @@ private theorem yunFactorsContributionResidualComplete_of_derivative_active
     (_hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (_hdf : (DensePoly.derivative f).isZero = false)
     (hresidual :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       yunFactorsContributionResidualDerivativeZero c g multiplicity fuel) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsContributionResidualComplete c g multiplicity fuel := by
   exact
     yunFactorsContributionResidualComplete_of_derivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel
       hresidual
@@ -4659,12 +4684,12 @@ private theorem yunFactorsResidualDerivativeZero_of_derivative_active
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hresidual :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       yunFactorsContributionResidualDerivativeZero c g multiplicity fuel) :
     yunFactorsResidualDerivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel := by
   apply yunFactorsResidualDerivativeZero_of_derivative_split_complete
@@ -4800,12 +4825,12 @@ private theorem yunScalarStep
     {u : ZMod64 p} (hu : u ≠ 0) (f : FpPoly p)
     (hder : (DensePoly.derivative f).isZero = false) :
     ∃ v : ZMod64 p, v ≠ 0 ∧
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let raw := DensePoly.C u * f
       let rawG := DensePoly.gcd raw (DensePoly.derivative raw)
       rawG = DensePoly.C v * g ∧
         raw / rawG = DensePoly.C (u * v⁻¹) * (f / g) := by
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let raw := DensePoly.C u * f
   have hder_raw :
       DensePoly.derivative raw =
@@ -4829,7 +4854,7 @@ private theorem yunScalarStep
       div_C_mul_C_mul_of_dvd hp hu hv f g
         (by
           simpa [g] using
-            DensePoly.gcd_dvd_left f (DensePoly.derivative f))
+            monicGcd_dvd_left hp f (DensePoly.derivative f))
         hg_ne
     rw [hrawG]
     simpa [raw, g] using hquot
@@ -5635,14 +5660,14 @@ private theorem dvd_one_of_all_powers_dvd_nonzero
 private theorem derivativeSplit_quotient_common_dvd_derivative_one
     (hp : Hex.Nat.Prime p) (f : FpPoly p)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     ∀ d : FpPoly p,
       d ∣ c → d ∣ DensePoly.derivative c → d ∣ (1 : FpPoly p) := by
   dsimp
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   intro d hdc hddc
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   have hdf_false : (DensePoly.derivative f).isZero = false := by
     cases h : (DensePoly.derivative f).isZero
     · rfl
@@ -5672,17 +5697,17 @@ private theorem derivativeSplit_residual_derivative_zero_of_coprime
     (hp : Hex.Nat.Prime p) (f : FpPoly p)
     (_hdf : (DensePoly.derivative f).isZero = false)
     (hcoprime : ∀ d : FpPoly p,
-      d ∣ (f / DensePoly.gcd f (DensePoly.derivative f)) →
-      d ∣ DensePoly.gcd f (DensePoly.derivative f) →
+      d ∣ (f / monicGcd f (DensePoly.derivative f)) →
+      d ∣ monicGcd f (DensePoly.derivative f) →
       d ∣ (1 : FpPoly p)) :
-    (DensePoly.derivative (DensePoly.gcd f (DensePoly.derivative f))).isZero = true := by
+    (DensePoly.derivative (monicGcd f (DensePoly.derivative f))).isZero = true := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   have hprod : c * g = f := by
-    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+    simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
   have hg_dvd_df : g ∣ DensePoly.derivative f := by
-    simpa [g] using DensePoly.gcd_dvd_right f (DensePoly.derivative f)
+    simpa [g] using monicGcd_dvd_right hp f (DensePoly.derivative f)
   have hdf_prod :
       DensePoly.derivative f =
         DensePoly.derivative c * g + c * DensePoly.derivative g := by
@@ -5729,12 +5754,12 @@ private theorem derivativeSplit_residual_derivative_zero_of_coprime
 private theorem derivativeSplit_quotient_size_one_eq_one
     (hp : Hex.Nat.Prime p) (f : FpPoly p)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     c.size = 1 → c = 1 := by
   dsimp
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   intro hc_size
   have hdf_false : (DensePoly.derivative f).isZero = false := by
@@ -5755,7 +5780,7 @@ private theorem derivativeSplit_quotient_size_one_eq_one
       intro d hdc hdg
       exact hcoprime d (by simpa [c, g] using hdc) (by simpa [g] using hdg))
   have hprod : c * g = f := by
-    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+    simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
   have hdf_zero : DensePoly.derivative f = 0 := by
     rw [← hprod]
     calc
@@ -5774,7 +5799,7 @@ private theorem derivativeSplit_quotient_size_one_eq_one
 private theorem yunFactorsPairwiseReachable_common_dvd_one_derivativeSplit
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (_fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let y := DensePoly.gcd c g
     let z := c / y
@@ -5782,7 +5807,7 @@ private theorem yunFactorsPairwiseReachable_common_dvd_one_derivativeSplit
   dsimp
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   intro d hdz hdy
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   let y := DensePoly.gcd c g
   let z := c / y
@@ -5915,7 +5940,7 @@ private theorem yunStep_quotient_tail_common_dvd_one_of_reachable
     simpa [z, y] using div_monicGcd_right_mul_reconstruct hp c w
   have hz_dvd_w : z ∣ w := ⟨y, by simpa [z, y] using hwy.symm⟩
   have hdy : d ∣ y := by
-    apply DensePoly.dvd_gcd
+    apply dvd_monicGcd hp
     · rw [← hcy]
       exact dvd_mul_right_of_dvd (a := a) (b := y) (d := d)
         (by simpa [a, y] using hda)
@@ -6019,14 +6044,15 @@ private theorem yunFactorsPairwiseReachable_residual_dvd_derivative_product
     (c w : FpPoly p) (fuel : Nat)
     (hreachable : yunFactorsPairwiseReachable c w fuel) :
     w ∣ DensePoly.derivative (c * w) := by
+  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   induction hreachable with
   | derivativeSplit hp f fuel hdf =>
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       have hprod : c * g = f := by
-        simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+        simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
       have hg_dvd_df : g ∣ DensePoly.derivative f := by
-        simpa [g] using DensePoly.gcd_dvd_right f (DensePoly.derivative f)
+        simpa [g] using monicGcd_dvd_right hp f (DensePoly.derivative f)
       simpa [c, g, hprod] using hg_dvd_df
   | step c w fuel hprev ih =>
       exact
@@ -6842,14 +6868,14 @@ private theorem yunFactorsContributionResidualDerivativeZero_of_derivative_split
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hcoprime :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       ∀ d : FpPoly p, d ∣ c → d ∣ g → d ∣ (1 : FpPoly p)) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsContributionResidualDerivativeZero c g multiplicity fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   have hder_g : (DensePoly.derivative g).isZero = true := by
     exact derivativeSplit_residual_derivative_zero_of_coprime hp f hdf hcoprime
@@ -6861,12 +6887,12 @@ private theorem yunFactorsResidualDerivativeZero_of_derivative_active_coprime
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (multiplicity fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hcoprime :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       ∀ d : FpPoly p, d ∣ c → d ∣ g → d ∣ (1 : FpPoly p)) :
     yunFactorsResidualDerivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel := by
   apply yunFactorsResidualDerivativeZero_of_derivative_split_contribution
@@ -7304,11 +7330,11 @@ private theorem yunFactorsLevelCompletes_of_derivative_active_state
           squareFreeContributionReachable c ∧
             c.isZero = false ∧
               w.isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsLevelCompletes c g multiplicity 1 fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   cases fuel with
   | zero =>
@@ -7329,7 +7355,7 @@ private theorem yunFactorsLevelCompletes_of_derivative_active_state
             c.size + g.size = f.size + 1 := by
           simpa [c, g] using
             size_div_add_size_eq_size_add_one_of_dvd
-              (DensePoly.gcd_dvd_left f (DensePoly.derivative f)) hf_ne
+              (monicGcd_dvd_left hp f (DensePoly.derivative f)) hf_ne
         omega
       simpa [c, g] using
         yunFactorsLevelCompletes_of_size_bound
@@ -7339,8 +7365,8 @@ private theorem yunFactorsDerivativeActiveReachable_of_derivative_split
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
     yunFactorsDerivativeActiveReachable hp f
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       fuel :=
   yunFactorsDerivativeActiveReachable.derivativeSplit fuel hdf
 
@@ -7487,7 +7513,7 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   induction hreachable with
   | derivativeSplit fuel hdf =>
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       have hdf_false : (DensePoly.derivative f).isZero = false := by
         cases h : (DensePoly.derivative f).isZero
@@ -7506,7 +7532,7 @@ private theorem yunFactorsDerivativeActiveReachable_nonzero
         · rfl
         · have hc_zero : c = 0 := eq_zero_of_isZero_true c hc
           have hprod : c * g = f := by
-            simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+            simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
           apply False.elim
           apply hf_ne
           rw [← hprod, hc_zero, zero_mul]
@@ -8364,11 +8390,11 @@ private theorem yunFactorsLevelCompletes_of_derivative_active_reachable
           squareFreeContributionReachable c ∧
             c.isZero = false ∧
               w.isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsLevelCompletes c g multiplicity 1 fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   cases fuel with
   | zero =>
@@ -8389,7 +8415,7 @@ private theorem yunFactorsLevelCompletes_of_derivative_active_reachable
             c.size + g.size = f.size + 1 := by
           simpa [c, g] using
             size_div_add_size_eq_size_add_one_of_dvd
-              (DensePoly.gcd_dvd_left f (DensePoly.derivative f)) hf_ne
+              (monicGcd_dvd_left hp f (DensePoly.derivative f)) hf_ne
         omega
       simpa [c, g] using
         yunFactorsLevelCompletes_of_size_bound_derivative_active
@@ -8412,7 +8438,7 @@ private theorem yunFactorsLevelCompletes_of_derivative_active_initial_split
           squareFreeContributionReachable c ∧
             c.isZero = false ∧
               w.isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsLevelCompletes c g multiplicity 1 fuel := by
   exact
@@ -8431,11 +8457,11 @@ private theorem yunFactorsNormalizedLevelCompletes_of_derivative_active_initial_
     (hzero : f.isZero = false)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hstate : YunDerivativeActiveNormalizedStateProvider hp) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsNormalizedLevelCompletes c g multiplicity 1 fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   cases fuel with
   | zero =>
@@ -8459,7 +8485,7 @@ private theorem yunFactorsNormalizedLevelCompletes_of_derivative_active_initial_
             c.size + g.size = f.size + 1 := by
           simpa [c, g] using
             size_div_add_size_eq_size_add_one_of_dvd
-              (DensePoly.gcd_dvd_left f (DensePoly.derivative f)) hf_ne
+              (monicGcd_dvd_left hp f (DensePoly.derivative f)) hf_ne
         have hc_size : (normalizeMonic c).2.size = c.size :=
           normalizeMonic_nonzero_size_eq hp c hnonzero.1
         have hg_size : (normalizeMonic g).2.size = g.size :=
@@ -8475,12 +8501,12 @@ private theorem yunFactorsContributionWithLevel_raw_pow_invariant
     (hzero : f.isZero = false)
     (hdf : (DensePoly.derivative f).isZero = false)
     (hlevelState : YunDerivativeActiveLevelStateProvider hp) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
     contribution.1 * pow contribution.2 multiplicity = pow f multiplicity := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
   have hstate_level :
@@ -8500,7 +8526,7 @@ private theorem yunFactorsContributionWithLevel_raw_pow_invariant
     yunFactorsContributionWithLevel_pow_invariant_of_completes
       c g multiplicity 1 fuel hcompletes
   have hcg : c * g = f := by
-    simpa [c, g] using div_gcd_mul_reconstruct f (DensePoly.derivative f)
+    simpa [c, g] using div_monicGcd_mul_reconstruct hp f (DensePoly.derivative f)
   calc
     contribution.1 * pow contribution.2 multiplicity =
         pow c (multiplicity * 1) * pow g multiplicity := by
@@ -8523,18 +8549,18 @@ private theorem yunFactorsContributionWithLevel_normalized_pow_invariant
     (hdf : (DensePoly.derivative f).isZero = false)
     (hnormalizedState : YunDerivativeActiveNormalizedStateProvider hp)
     (hrawProduct :
-      let g := DensePoly.gcd f (DensePoly.derivative f)
+      let g := monicGcd f (DensePoly.derivative f)
       let c := f / g
       let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
       contribution.1 * pow contribution.2 multiplicity = pow f multiplicity) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
     contribution.1 *
         (pow (DensePoly.C (normalizeMonic contribution.2).1) multiplicity *
           pow (normalizeMonic contribution.2).2 multiplicity) =
       pow f multiplicity := by
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
   have _hnormalized_completes :
@@ -8615,11 +8641,11 @@ private theorem yunFactorsContributionResidualDerivativeZero_of_derivative_split
           squareFreeContributionReachable c ∧
             c.isZero = false ∧
               w.isZero = false) :
-    let g := DensePoly.gcd f (DensePoly.derivative f)
+    let g := monicGcd f (DensePoly.derivative f)
     let c := f / g
     yunFactorsContributionResidualDerivativeZero c g multiplicity fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   have hdf_ne_true : (DensePoly.derivative f).isZero ≠ true := by
     intro htrue
@@ -8644,7 +8670,7 @@ private theorem yunFactorsContributionResidualDerivativeZero_of_derivative_split
         have hsize_eq : c.size + g.size = f.size + 1 := by
           simpa [c, g] using
             size_div_add_size_eq_size_add_one_of_dvd
-              (DensePoly.gcd_dvd_left f (DensePoly.derivative f)) hf_ne
+              (monicGcd_dvd_left hp f (DensePoly.derivative f)) hf_ne
         omega
       have hcompletes :
           yunFactorsLevelCompletes c g multiplicity 1 (fuel + 1) :=
@@ -8676,8 +8702,8 @@ private theorem yunFactorsResidualDerivativeZero_of_derivative_split
             c.isZero = false ∧
               w.isZero = false) :
     yunFactorsResidualDerivativeZero
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       multiplicity
       fuel := by
   apply yunFactorsResidualDerivativeZero_of_derivative_split_contribution
@@ -8707,13 +8733,13 @@ private theorem yunFactorsContributionWithLevel_residual_derivative_zero_of_deri
               w.isZero = false) :
     isOne
         (yunFactorsContributionWithLevel
-          (f / DensePoly.gcd f (DensePoly.derivative f))
-          (DensePoly.gcd f (DensePoly.derivative f))
+          (f / monicGcd f (DensePoly.derivative f))
+          (monicGcd f (DensePoly.derivative f))
           base level fuel).2 = false →
       (DensePoly.derivative
           (yunFactorsContributionWithLevel
-            (f / DensePoly.gcd f (DensePoly.derivative f))
-            (DensePoly.gcd f (DensePoly.derivative f))
+            (f / monicGcd f (DensePoly.derivative f))
+            (monicGcd f (DensePoly.derivative f))
             base level fuel).2).isZero = true := by
   apply yunFactorsContributionWithLevel_residual_derivative_zero_of_unscaled
   exact
@@ -8777,7 +8803,7 @@ private theorem squareFreeAuxRevContribution_derivative_active_pow_obligation
                     pow f multiplicity) :
     squareFreeAuxRevContribution f multiplicity (fuel + 1) = pow f multiplicity := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
-  let g := DensePoly.gcd f (DensePoly.derivative f)
+  let g := monicGcd f (DensePoly.derivative f)
   let c := f / g
   let contribution := yunFactorsContributionWithLevel c g multiplicity 1 fuel
   have hlevelState : YunDerivativeActiveLevelStateProvider hp :=
@@ -8856,7 +8882,7 @@ private theorem squareFreeAuxRevContribution_derivative_active_pow_obligation
           (yunFactorsWithLevel c g multiplicity 1 fuel []).2 ∣ g := by
         exact yunFactorsWithLevel_repeated_dvd_repeated c g multiplicity 1 fuel
       have hg_dvd_f : g ∣ f := by
-        simpa [g] using DensePoly.gcd_dvd_left f (DensePoly.derivative f)
+        simpa [g] using monicGcd_dvd_left hp f (DensePoly.derivative f)
       have hcontribution_dvd_f : contribution.2 ∣ f := by
         rw [← hloop_eq]
         exact dvd_trans_poly hloop_dvd_g hg_dvd_f
@@ -9097,7 +9123,7 @@ private theorem yunStep_quotient_right_factor_coprime_of_common_dvd_one
     simpa [z, y] using (div_monicGcd_mul_reconstruct hp c w).symm
   have hgcd_dvd_y :
       DensePoly.gcd z factor ∣ y := by
-    apply DensePoly.dvd_gcd
+    apply dvd_monicGcd hp
     · exact dvd_trans_poly (DensePoly.gcd_dvd_left z factor) hz_dvd_c
     · exact dvd_trans_poly (DensePoly.gcd_dvd_right z factor) hfactor_dvd_w
   have hgcd_dvd_one :
@@ -9305,16 +9331,16 @@ private theorem yunFactorsPairwiseReady_of_derivative_split_common_dvd_one
               d ∣ monicGcd c w →
                 d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseReady
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       base
       level
       fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   exact
     yunFactorsPairwiseReady_of_reachable_common_dvd_one
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       base level fuel
       (yunFactorsPairwiseReachable_of_derivative_split hp f fuel hdf)
       hcommon
@@ -9330,8 +9356,8 @@ private theorem yunFactorsPairwiseInvariant_of_derivative_split_common_dvd_one
               d ∣ monicGcd c w →
                 d ∣ (1 : FpPoly p)) :
     yunFactorsPairwiseInvariant
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       base
       level
       fuel where
@@ -9344,8 +9370,8 @@ private theorem yunFactorsPairwiseInvariant_of_derivative_split_reachable
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (base level fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
     yunFactorsPairwiseInvariant
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       base
       level
       fuel := by
@@ -9371,7 +9397,7 @@ private theorem squareFreeAuxRev_reverse_append
         by_cases hdf : (DensePoly.derivative f).isZero
         · simpa [hdf] using ih (pthRoot f) (multiplicity * p) accRev
         · simp [hdf]
-          let g := DensePoly.gcd f (DensePoly.derivative f)
+          let g := monicGcd f (DensePoly.derivative f)
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           let loopNil := yunFactorsWithLevel c g multiplicity 1 fuel []
@@ -9792,8 +9818,8 @@ private theorem squareFreeAuxRev_pairwise_coprime_nil_core_of_residual_invariant
       ∀ f : FpPoly p, ∀ base fuel : Nat,
         (DensePoly.derivative f).isZero = false →
           yunFactorsPairwiseInvariant
-            (f / DensePoly.gcd f (DensePoly.derivative f))
-            (DensePoly.gcd f (DensePoly.derivative f))
+            (f / monicGcd f (DensePoly.derivative f))
+            (monicGcd f (DensePoly.derivative f))
             base
             1
             fuel)
@@ -9815,7 +9841,7 @@ private theorem squareFreeAuxRev_pairwise_coprime_nil_core_of_residual_invariant
         by_cases hdf : (DensePoly.derivative f).isZero
         · simpa [hdf] using ih (pthRoot f) (multiplicity * p)
         · simp [hdf]
-          let g := DensePoly.gcd f (DensePoly.derivative f)
+          let g := monicGcd f (DensePoly.derivative f)
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel []
           have hzero_false : f.isZero = false := by
@@ -10020,13 +10046,13 @@ private theorem yunFactorsStepsSquareFree_of_derivative_split
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (fuel : Nat)
     (hdf : (DensePoly.derivative f).isZero ≠ true) :
     yunFactorsStepsSquareFree
-      (f / DensePoly.gcd f (DensePoly.derivative f))
-      (DensePoly.gcd f (DensePoly.derivative f))
+      (f / monicGcd f (DensePoly.derivative f))
+      (monicGcd f (DensePoly.derivative f))
       fuel := by
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
   exact yunFactorsStepsSquareFree_of_reachable
-    (f / DensePoly.gcd f (DensePoly.derivative f))
-    (DensePoly.gcd f (DensePoly.derivative f))
+    (f / monicGcd f (DensePoly.derivative f))
+    (monicGcd f (DensePoly.derivative f))
     fuel
     (yunFactorsPairwiseReachable_of_derivative_split hp f fuel hdf)
 
@@ -10082,8 +10108,8 @@ private theorem yunFactorsWithLevel_factors_squareFree_of_derivative_split
     (hdf : (DensePoly.derivative f).isZero ≠ true)
     (hacc : ∀ sf ∈ accRev.reverse, squareFreeFactorSquareFreeRel sf) :
     ∀ sf ∈
-        (yunFactorsWithLevel (f / DensePoly.gcd f (DensePoly.derivative f))
-          (DensePoly.gcd f (DensePoly.derivative f)) base level fuel accRev).1.reverse,
+        (yunFactorsWithLevel (f / monicGcd f (DensePoly.derivative f))
+          (monicGcd f (DensePoly.derivative f)) base level fuel accRev).1.reverse,
       squareFreeFactorSquareFreeRel sf := by
   apply yunFactorsWithLevel_factors_squareFree_of_steps
   · exact yunFactorsStepsSquareFree_of_derivative_split hp f fuel hdf
@@ -10106,7 +10132,7 @@ private theorem squareFreeAuxRev_factors_squareFree
         by_cases hdf : (DensePoly.derivative f).isZero
         · simpa [hdf] using ih (pthRoot f) (multiplicity * p) accRev hacc
         · simp [hdf]
-          let g := DensePoly.gcd f (DensePoly.derivative f)
+          let g := monicGcd f (DensePoly.derivative f)
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           have hloop :
@@ -10284,7 +10310,7 @@ private theorem squareFreeAuxRev_multiplicity_pos_raw
             ih (pthRoot f) (multiplicity * p) accRev
               (Nat.mul_pos hmultiplicity hp_pos) hacc
         · simp [hdf]
-          let g := DensePoly.gcd f (DensePoly.derivative f)
+          let g := monicGcd f (DensePoly.derivative f)
           let c := f / g
           let loop := yunFactorsWithLevel c g multiplicity 1 fuel accRev
           have hloop :

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -4812,6 +4812,67 @@ private theorem ne_zero_of_isZero_false {f : FpPoly p}
   rw [hzero_isZero] at hf
   cases hf
 
+/-- The monic normalization absorbs a nonzero constant scalar: scaling the
+input by `C v` (`v ≠ 0`) leaves the monic associate unchanged. This is the
+algebraic root of `monicGcd_scalar_invariant`. -/
+private theorem normalizeMonic_C_mul_snd
+    [ZMod64.PrimeModulus p] {v : ZMod64 p} (hv : v ≠ 0) (h : FpPoly p) :
+    (normalizeMonic (DensePoly.C v * h)).2 = (normalizeMonic h).2 := by
+  cases hz : h.isZero with
+  | true =>
+      have hh0 : h = 0 := eq_zero_of_isZero_true h hz
+      subst hh0
+      rw [mul_zero]
+  | false =>
+      have hlead_ne := fpPoly_leadingCoeff_ne_zero_of_isZero_false h hz
+      have hsize : h.size ≠ 0 := by
+        simpa [DensePoly.isZero, DensePoly.size, Array.isEmpty_iff_size_eq_zero,
+          Bool.not_eq_true] using hz
+      have hCvh_ne : (DensePoly.C v * h).isZero = false := by
+        cases hcvh : (DensePoly.C v * h).isZero with
+        | false => rfl
+        | true =>
+            exfalso
+            have hsz0 : (DensePoly.C v * h).size = 0 :=
+              size_eq_zero_of_isZero_true _ hcvh
+            rw [C_mul_eq_scale, scale_size_eq_of_ne_zero hv h] at hsz0
+            exact hsize hsz0
+      rw [normalizeMonic_nonzero h hz,
+          normalizeMonic_nonzero (DensePoly.C v * h) hCvh_ne]
+      show DensePoly.scale (DensePoly.leadingCoeff (DensePoly.C v * h))⁻¹
+            (DensePoly.C v * h) =
+          DensePoly.scale (DensePoly.leadingCoeff h)⁻¹ h
+      rw [C_mul_eq_scale,
+          leadingCoeff_scale_of_ne_zero_of_nonzero hv h hsize,
+          scale_scale]
+      congr 1
+      have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
+      have hva_ne : v * DensePoly.leadingCoeff h ≠ 0 := by
+        intro h0
+        rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp h0 with h1 | h1
+        · exact hv h1
+        · exact hlead_ne h1
+      have hva_inv : v * DensePoly.leadingCoeff h * (v * DensePoly.leadingCoeff h)⁻¹ = 1 :=
+        zmod64_mul_inv_eq_one_of_prime_ne_zero hp hva_ne
+      have ha_inv : DensePoly.leadingCoeff h * (DensePoly.leadingCoeff h)⁻¹ = 1 :=
+        zmod64_mul_inv_eq_one_of_prime_ne_zero hp hlead_ne
+      have hv_inv : v * v⁻¹ = 1 :=
+        zmod64_mul_inv_eq_one_of_prime_ne_zero hp hv
+      grind
+
+/-- Scaling both gcd inputs by independent nonzero constants leaves the monic
+gcd unchanged. This is the load-bearing scalar-leak elimination: with monic
+normalization the unit the raw gcd would pick up is absorbed, so the recursion
+variables of the scaled and unscaled Yun loops coincide exactly. -/
+private theorem monicGcd_scalar_invariant
+    [ZMod64.PrimeModulus p] (hp : Hex.Nat.Prime p)
+    {u_c u_w : ZMod64 p} (hu_c : u_c ≠ 0) (hu_w : u_w ≠ 0) (c w : FpPoly p) :
+    monicGcd (DensePoly.C u_c * c) (DensePoly.C u_w * w) = monicGcd c w := by
+  obtain ⟨v, hv, hgcd⟩ :=
+    gcd_C_mul_left_C_mul_right_eq_C_mul_gcd hp u_c u_w hu_c hu_w c w
+  simp only [monicGcd_def]
+  rw [hgcd, normalizeMonic_C_mul_snd hv]
+
 /--
 One derivative-active Yun step is stable under a common nonzero scalar multiple.
 

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -7039,12 +7039,11 @@ private theorem yunStep_gcd_normalized_one_of_common_dvd_one
     (hcommon :
       ∀ d : FpPoly p, d ∣ c → d ∣ w → d ∣ (1 : FpPoly p)) :
     (normalizeMonic (DensePoly.gcd c w)).2 = 1 := by
-  have hp : Hex.Nat.Prime p := ZMod64.PrimeModulus.prime (p := p)
   have hgcd_dvd_one :
-      monicGcd c w ∣ (1 : FpPoly p) :=
-    hcommon (monicGcd c w)
-      (monicGcd_dvd_left hp c w)
-      (monicGcd_dvd_right hp c w)
+      DensePoly.gcd c w ∣ (1 : FpPoly p) :=
+    hcommon (DensePoly.gcd c w)
+      (DensePoly.gcd_dvd_left c w)
+      (DensePoly.gcd_dvd_right c w)
   exact normalizeMonic_eq_one_of_dvd_one hgcd_dvd_one
 
 private theorem yunStep_tail_common_dvd_one_of_gcd_normalized_one
@@ -7157,8 +7156,15 @@ private theorem gcd_C_ne_zero_dvd_one
   have hC_ne : (DensePoly.C k : FpPoly p) ≠ 0 :=
     ne_zero_of_isZero_false hC_zero
   have hg_zero :
-      (DensePoly.gcd (DensePoly.C k : FpPoly p) w).isZero = false :=
-    yunStep_gcd_nonzero_of_left_nonzero (DensePoly.C k : FpPoly p) w hC_zero
+      (DensePoly.gcd (DensePoly.C k : FpPoly p) w).isZero = false := by
+    cases hgz : (DensePoly.gcd (DensePoly.C k : FpPoly p) w).isZero
+    · rfl
+    · exfalso
+      have hg0 : DensePoly.gcd (DensePoly.C k : FpPoly p) w = 0 :=
+        eq_zero_of_isZero_true _ hgz
+      rcases DensePoly.gcd_dvd_left (DensePoly.C k : FpPoly p) w with ⟨q, hq⟩
+      rw [hg0, zero_mul] at hq
+      exact hC_ne hq
   apply constant_nonzero_dvd hg_zero
   have hsize_le :
       (DensePoly.gcd (DensePoly.C k : FpPoly p) w).size ≤

--- a/progress/20260614T014123Z_b544b291.md
+++ b/progress/20260614T014123Z_b544b291.md
@@ -1,0 +1,88 @@
+# Progress: #6983 — non-monic-gcd scalar leak in Yun square-free product
+
+Feature session on the HexPolyFp square-free scalar-leak correctness bug
+(`C unit * weightedProduct = f` is false over `F_p`, `p > 2`). Premise
+confirmed sound (third independent confirmation). Landed the verified
+`monicGcd` substrate as an additive PR and cracked both hard blockers that
+stalled the two prior sessions; the remaining atomic def-swap + proof
+migration is sharply de-risked.
+
+## Accomplished
+
+Added the verified `monicGcd` API to `HexPolyFp/SquareFree.lean` (purely
+additive, `lake build HexPolyFp.SquareFree` green, 131 insertions, 0
+deletions, no sorry/axiom/native_decide):
+
+- `monicGcd c w := (normalizeMonic (DensePoly.gcd c w)).2` — the canonical
+  monic associate of the raw gcd. Sealed `@[irreducible]` with a
+  `monicGcd_def` re-entry lemma.
+- Algebra API: `gcd_eq_C_mul_monicGcd`, `monicGcd_dvd_gcd`,
+  `monicGcd_dvd_left/right`, `div_monicGcd_mul_reconstruct` (+ right + the two
+  `monicGcd_mul_div_*` orientations), `monicGcd_monic_of_gcd_nonzero`,
+  `monicGcd_isZero_false_of_gcd_nonzero`,
+  `monic_div_monicGcd_left/right_of_monic`.
+
+## Key findings (de-risk the remaining atomic migration)
+
+The two prior sessions inlined `(normalizeMonic (DensePoly.gcd …)).2` and
+measured 42/42 file-wide errors incl. 8 hard kernel timeouts, declaring it a
+larger-than-one-session atomic change. I reproduced and resolved the timeout
+mechanism:
+
+1. **`@[irreducible] monicGcd` eliminates the 3000-range timeout cluster.**
+   With the named def swapped into the 6 executable sites, a plain
+   (semireducible) def still timed out at the same sites because
+   `simp`/`decide`/defeq unfolds it into `normalizeMonic`. Marking it
+   irreducible removed the `:3082/:3108/:3139` timeouts entirely (measured:
+   8 → 5 timeouts).
+2. **The remaining 5 timeouts (`:7652–:7934`) collapse via one invariance
+   lemma.** They live in the `yunContribution_scalarSync` family, which
+   exists *only* to track the unit ambiguity between `gcd (C u_c·c)(C u_w·w)`
+   and `gcd c w`. `monicGcd` normalizes that unit away, so
+   `monicGcd (C u_c·c)(C u_w·w) = monicGcd c w`. Proving that one
+   `monicGcd_scalar_invariant` lemma (from the existing `gcd`-scaling lemmas
+   at ~`:1699–:1880` plus `normalizeMonic (C v · g) = normalizeMonic g` for
+   nonzero `v`) makes the scalar-sync proofs near-trivial instead of
+   timing-out.
+3. **Providers become provable, not just removable.** With monic recursion
+   variables, `squareFreeContributionReachable` (`f.size = 1 → f = 1`) holds
+   by `squareFreeContributionReachable_of_monic`; monicity propagates through
+   `monic_div_monicGcd_left/right_of_monic`. So
+   `YunDerivativeActiveRawStateProvider` turns into a lemma and the
+   `hrawState` hypothesis can be discharged from the public chain
+   (`…_pow_obligation` → `_correct_pow_of_nonzero` → `_correct` →
+   `squareFreeAux_weightedProduct_nonzero` → `squareFree_weightedProduct`).
+
+Measured error taxonomy for the full def-swap (irreducible def): ~70 errors,
+of which ~55 are mechanical `let y := DensePoly.gcd c w` → `monicGcd c w`
+proof-mirror renames (+ swap `gcd_dvd_left/right`/`div_gcd_*_reconstruct` →
+the `monicGcd_*` analogues, which now also take `hp`), 5 scalar-sync
+timeouts (finding 2), 2 kernel-unknown and 2 rewrite failures clustered with
+the providers, and the provider re-grounding.
+
+## Current frontier
+
+`monicGcd` API merged-pending (PR via `--partial`). The full def-swap WIP
+(6 executable sites routed through `monicGcd`, `@[irreducible]`, 70 errors)
+is preserved on this branch at commit `d7f62e40` for reference.
+
+## Next step (residual scope for #6983)
+
+1. Swap the 6 executable def sites to `monicGcd` (yunFactorsWithLevel,
+   yunFactors, yunFactorsContributionWithLevel, yunFactorsContribution:
+   `let y := monicGcd c w`; squareFreeAuxRevContribution, squareFreeAuxRev:
+   `let g := monicGcd f df`).
+2. Add `monicGcd_scalar_invariant` and rework the `yunContribution_scalarSync`
+   family to use it (kills the 5 remaining timeouts).
+3. Mechanically migrate the ~55 proof-mirror sites.
+4. Re-ground the providers as lemmas; strip `hrawState` from the public chain.
+5. Add the F_5 p>2 `#guard` (`weightedProduct d.factors = f` for
+   `(x+1)^5 (x+2)^5 (x+3)`).
+
+This remains one atomic change with no intermediate green build, but the API
+is now in-tree and both hard blockers (timeouts) have a known mechanical fix.
+
+## Blockers
+
+None technical. The residual is atomic and large but mechanical; it needs a
+dedicated session that can hold the whole def-swap-to-green in one pass.

--- a/progress/20260614T024802Z_0d24141d.md
+++ b/progress/20260614T024802Z_0d24141d.md
@@ -1,0 +1,107 @@
+# Progress: #7005 — monicGcd scalar-leak def-swap (PARTIAL)
+
+Feature session on the residual of #6983: route every Yun/squareFree gcd
+through the monic-normalized `monicGcd` (substrate from PR #7003) to kill the
+F_p (p>2) scalar leak in `squareFreeDecomposition`. Branch based on the #7003
+head `agent/b544b291` (substrate not yet merged to main).
+
+This is the atomic def-swap. It is **not green**: 27 errors remain, all in the
+genuinely-hard scalar-sync / provider / interface-unification clusters. The
+mechanical bulk (87 → 27 errors) is done and committed in logical increments.
+
+## Accomplished
+
+1. **6 executable def sites** swapped to `monicGcd` (deliverable #1, complete):
+   `yunFactorsWithLevel`, `yunFactors`, `yunFactorsContributionWithLevel`,
+   `yunFactorsContribution` (`let y := monicGcd c w`),
+   `squareFreeAuxRevContribution`, `squareFreeAuxRev` (`let g := monicGcd f df`).
+
+2. **Loop-mirror migration** (deliverable #3, mostly complete):
+   - `DensePoly.gcd c w` → `monicGcd c w` in all recursion mirrors (line ≥3000),
+     preserving the 9 `normalizeMonic (DensePoly.gcd c w)` forms (those *are*
+     `monicGcd` by definition; must not be double-wrapped).
+   - 136 `DensePoly.gcd f (DensePoly.derivative f)` squareFreeAux mirrors → monicGcd.
+   - 2 constant-form mirrors `DensePoly.gcd (C k) w` → monicGcd.
+   - Reconstruction/dvd lemma applications swapped to monicGcd analogues
+     (`div_monicGcd_mul_reconstruct`, `monicGcd_dvd_left/right`) with `hp`
+     obtained locally via `ZMod64.PrimeModulus.prime (p := p)` (no signature
+     ripple — the key that made the migration tractable).
+   - Added bridge `dvd_monicGcd` (`d ∣ c → d ∣ w → d ∣ monicGcd c w`) for the
+     `apply DensePoly.dvd_gcd` sites whose goal became `_ ∣ monicGcd …`.
+   - Wrapped `isZero = false` mirror proofs in `monicGcd_isZero_false_of_gcd_nonzero`.
+
+3. **Keystone for scalar-sync** (deliverable #2, foundation only):
+   - `normalizeMonic_C_mul_snd` — monic normalization absorbs a nonzero constant
+     scalar: `(normalizeMonic (C v * h)).2 = (normalizeMonic h).2` for `v ≠ 0`.
+   - `monicGcd_scalar_invariant` —
+     `monicGcd (C u_c·c) (C u_w·w) = monicGcd c w` for `u_c,u_w ≠ 0`.
+     This is the load-bearing lemma: with monic normalization the unit the raw
+     gcd would leak is absorbed, so scaled/unscaled recursion variables coincide
+     *exactly* (no tracked scalar `v` on the gcd). Both compile.
+
+4. **Over-reach reverts**: the bulk pass wrongly converted proof bodies of three
+   lemmas whose *statements* are raw (`normalizeMonic (DensePoly.gcd c w)`):
+   `normalizeMonic_gcd_monic_of_right_nonzero`,
+   `yunStep_gcd_normalized_one_of_common_dvd_one`, `gcd_C_ne_zero_dvd_one`.
+   Reverted their proofs to raw gcd divisibility.
+
+No `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME` added. `git diff --check`
+clean.
+
+## Current frontier — 27 remaining errors (all genuine rework)
+
+Run `lake build HexPolyFp.SquareFree` to reproduce. Clusters:
+
+- **Scalar-sync rebuild (11 errors)** — `yunScalarStep` (4884),
+  `yunFactorsContributionWithLevel_scalar_step_bridge` (4932),
+  `…_scalar_sync` (7740), `…_scalar_sync_of_derivative` (7924).
+  These proofs still define `yScaled := DensePoly.gcd (C u_c·c)(C u_w·w)` (raw),
+  but the executable now computes `monicGcd (C u_c·c)(C u_w·w)`. Recipe: set
+  `yScaled := monicGcd (C u_c·c)(C u_w·w)` and rewrite it to `monicGcd c w = y`
+  via `monicGcd_scalar_invariant`. The tracked gcd scalar `v` then disappears:
+  the tail `ih` is invoked with `u_c := 1` (not `v`) since `yScaled = y` exactly;
+  only the residual second argument keeps its `u_w` scalar. `step_bridge`/
+  `branch_sync` collapse accordingly (the raw-gcd `= C v * monicGcd` relations
+  are no longer needed).
+
+- **normalizeMonic↔monicGcd interface unification (≈6 errors)** —
+  `yunStep_tail_common_dvd_one_of_gcd_normalized_one` (7050),
+  `yunStep_gcd_normalized_one_of_constant_common_dvd_one` (7193),
+  `…_size_bound_derivative_active` (8323),
+  `yunFactorsPairwiseReachable_common_dvd_one_derivativeSplit` (5861).
+  The `(normalizeMonic (DensePoly.gcd c w)).2 = 1` / `.size` statements now
+  mismatch the monicGcd-producing proofs around them. Cleanest fix: restate this
+  whole family in terms of `monicGcd c w` (= `(normalizeMonic (gcd c w)).2` by
+  `monicGcd_def`) and update the small consumer set in lockstep. Add helpers
+  `monicGcd_eq_one_of_dvd_one` and `dvd_one_of_monicGcd_eq_one` mirroring the
+  existing `normalizeMonic_*` versions.
+
+- **Provider re-grounding (deliverable #4, not started — ≈8 errors)** —
+  `squareFreeAuxRevContribution_derivative_active_pow_obligation` (8848),
+  `squareFreeAuxRev_factor_dvd_input` (9526),
+  `squareFreeAuxRev_pairwise_coprime_nil_core_of_residual` (9880).
+  With monic intermediates `squareFreeContributionReachable` of every recursion
+  variable is provable (`monic ⇒ size=1 → =1`), so the false
+  `YunDerivativeActiveRawStateProvider` / `hrawState` / `residualInvariant`
+  hypotheses should be re-grounded as lemmas and stripped from the chain
+  `…_pow_obligation → …_correct_pow_of_nonzero → …_correct →
+  squareFreeAux_weightedProduct_nonzero → squareFree_weightedProduct`.
+  Use `monic_div_monicGcd_left/right_of_monic` (already in the substrate).
+
+## Next step
+
+1. Rebuild the scalar-sync family using `monicGcd_scalar_invariant` (above).
+2. Unify the normalizeMonic-one/size family on `monicGcd`.
+3. Re-ground the providers and strip `hrawState`.
+4. Add the F_5 `#guard` (deliverable #5): `weightedProduct d.factors = f` for
+   `(x+1)^5 (x+2)^5 (x+3)` over F_5 (coeffs low→high
+   `[1,2,0,0,0,4,3,0,0,0,3,1]`), guarding the regression.
+5. Verify: `lake build HexPolyFp.SquareFree`, `lake build HexPolyFp`,
+   `python3 scripts/check_dag.py`.
+
+## Blockers
+
+- Atomic change: no green intermediate, so this lands `--partial` (red, will not
+  auto-merge) for planner re-scoping of the residual.
+- Branch is based on unmerged PR #7003 (`agent/b544b291`); rebase onto main once
+  #7003 lands.


### PR DESCRIPTION
Partial progress on #7005

Session: `0d24141d-0aaa-4d4b-a1b2-1b6f29bcb7c6`

e0e3324f doc: progress for #7005 monicGcd def-swap (partial, 87->27 errors)
1b52fc0c feat: WIP revert bulk-replace over-reach in raw-gcd normalized-one lemmas (#7005)
de997b27 feat: WIP add monicGcd_scalar_invariant keystone for scalar-sync (#7005)
325f7a4f feat: WIP migrate constant-form mirrors + isZero_false wrappers (#7005)
1f656b9c feat: WIP migrate squareFreeAux f-derivative mirrors + dvd_monicGcd helper (#7005)
ef3a5d88 feat: WIP migrate loop-mirror gcd terms + reconstruction lemmas to monicGcd (#7005)
fb749dad feat: WIP swap 6 Yun/squareFree def sites + 30 proof mirrors to monicGcd (#7005)
f816d610 doc: progress for #6983 monicGcd API + migration findings
8d022ad7 feat: add verified monicGcd API for square-free scalar-leak fix (#6983)
d7f62e40 feat: WIP mark monicGcd irreducible + def lemma (#6983)
3b15500f feat: WIP monicGcd API + swap 6 Yun/squareFree def sites (#6983)

🤖 Prepared with Claude Code