### PR TITLE
HexPoly Phase 6: docstring coverage for Euclid.lean and Operations.lean theorems

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -21,6 +21,9 @@ variable {R : Type u} [Zero R] [DecidableEq R]
 def leadingCoeff (p : DensePoly R) : R :=
   p.coeffs.back?.getD 0
 
+/-- The zero polynomial has leading coefficient `0`. Registered as a `simp`
+normal form so callers reasoning about `leadingCoeff` discharge the zero case
+automatically. -/
 @[simp] theorem leadingCoeff_zero : (0 : DensePoly R).leadingCoeff = 0 := by
   rfl
 
@@ -28,6 +31,9 @@ def leadingCoeff (p : DensePoly R) : R :=
 instance [One R] : One (DensePoly R) where
   one := C 1
 
+/-- The leading coefficient of the constant polynomial `C c` is `c` itself,
+covering both `c = 0` (the empty backing array) and `c ≠ 0`. The `simp` form
+lets callers read the leading coefficient off any constant. -/
 @[simp] theorem leadingCoeff_C (c : R) : (C c).leadingCoeff = c := by
   by_cases hc : c = (0 : R)
   · rw [hc]
@@ -38,6 +44,9 @@ instance [One R] : One (DensePoly R) where
     rw [coeffs_C_of_ne_zero hc]
     rfl
 
+/-- The constant polynomial `1` has leading coefficient `1`, hence is monic.
+Specialises `leadingCoeff_C` and feeds the monicity facts about `1` that the
+division and gcd routines rely on. -/
 @[simp] theorem leadingCoeff_one [One R] : (1 : DensePoly R).leadingCoeff = 1 := by
   change (C (1 : R)).leadingCoeff = 1
   rw [leadingCoeff_C]
@@ -1529,6 +1538,8 @@ theorem add_assoc_poly {S : Type _}
   rw [coeff_add q r n hzero_add]
   grind
 
+/-- Right identity for polynomial addition over a commutative ring: `p + 0 = p`.
+A `grind` normalization lemma so downstream proofs cancel trailing zero summands. -/
 @[grind =] theorem add_zero_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
@@ -2336,6 +2347,9 @@ theorem mul_add_left_poly {S : Type _}
   rw [mul_comm_poly (p + q) r, mul_add_right_poly r p q,
     mul_comm_poly r p, mul_comm_poly r q]
 
+/-- Right identity for polynomial multiplication over a commutative ring:
+`p * 1 = p`. A `grind` normalization lemma; the Bézout and division routines
+cancel multiplications by the unit polynomial through it. -/
 @[grind =] theorem mul_one_right_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
@@ -2525,6 +2539,9 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
     rw [hzero_fold]
     rfl
 
+/-- Negation passes through the left multiplicand: `(0 - p) * q = 0 - p * q`.
+A `grind` normalization lemma that lets sign manipulations in the extended-gcd
+recursion move the negation out to the product. -/
 @[grind =] theorem neg_mul_right_poly {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p q : DensePoly S) :
@@ -2680,6 +2697,9 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
     rw [if_neg hand]
     grind
 
+/-- Left absorption for polynomial multiplication: `0 * p = 0`. A `grind`
+normalization lemma so that products with a vanished factor collapse during
+the division and gcd proofs. -/
 @[grind =] theorem zero_mul {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
@@ -2690,6 +2710,8 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
   simp [mulCoeffSum]
   rfl
 
+/-- Left identity for polynomial addition over a commutative ring: `0 + p = p`.
+A `grind` normalization lemma so downstream proofs cancel leading zero summands. -/
 @[grind =] theorem zero_add {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -72,6 +72,9 @@ theorem coeff_scale [Mul R] (c : R) (p : DensePoly R) (n : Nat)
   rw [coeff_ofCoeffs_list]
   simpa [coeff] using list_getD_map_mul_zero (R := R) c p.toArray.toList n hzero
 
+/-- Scaling the zero polynomial yields the zero polynomial: `scale c 0 = 0`.
+A `simp`/`grind` normal form, so callers need no `c * 0 = 0` hypothesis to
+discharge the scaled-zero case. -/
 @[simp, grind =] theorem scale_zero_right [Mul R] (c : R) :
     scale c (0 : DensePoly R) = 0 := by
   unfold scale toArray
@@ -120,11 +123,15 @@ coefficients are read from the original polynomial with the index shifted down. 
     rw [coeff_ofCoeffs_list]
     simpa [coeff] using list_getD_replicate_append_zero (R := R) n k p.toArray.toList
 
+/-- Shifting the zero polynomial by any power leaves it zero: `shift n 0 = 0`.
+A `simp`/`grind` normal form for the degenerate input to `shift`. -/
 @[simp, grind =] theorem shift_zero_right (n : Nat) :
     shift n (0 : DensePoly R) = 0 := by
   unfold shift isZero
   rfl
 
+/-- Shifting by `x^0` is the identity: `shift 0 p = p`. A `simp`/`grind` normal
+form so a trivial shift drops out of multiplication and division proofs. -/
 @[simp, grind =] theorem shift_zero_left (p : DensePoly R) :
     shift 0 p = p := by
   apply ext_coeff

--- a/progress/20260614T032053Z_10980d9e.md
+++ b/progress/20260614T032053Z_10980d9e.md
@@ -1,0 +1,45 @@
+# Progress: #7027 — HexPoly Phase 6 docstring coverage (Euclid.lean + Operations.lean)
+
+Feature session (`/work` → `/feature`). Added docstrings to eleven
+undocumented public `DensePoly` theorems across two core `HexPoly` files,
+per the Phase 6 docstring-coverage exit criterion.
+
+## Accomplished
+
+Purely additive (`+29 -0`), docstring-only. No statement, signature,
+attribute, proof body, or import changed.
+
+`HexPoly/Euclid.lean` (8 theorems):
+- `leadingCoeff_zero`, `leadingCoeff_C`, `leadingCoeff_one` —
+  leading-coefficient identities, `simp` normal forms.
+- `add_zero_poly`, `mul_one_right_poly`, `neg_mul_right_poly`,
+  `zero_mul`, `zero_add` — `grind`-normalizing ring arithmetic identities.
+
+`HexPoly/Operations.lean` (3 theorems):
+- `scale_zero_right`, `shift_zero_right`, `shift_zero_left` —
+  `simp`/`grind` zero/identity laws for `scale` and `shift`.
+
+Each docstring states what the theorem proves and why a downstream caller
+cares (normalization role, division/gcd/Bézout use), matching the tone of
+already-documented neighbours (`leadingCoeff`, `coeff_scale`, etc.).
+
+## Verification
+
+- `lake build HexPoly.Euclid HexPoly.Operations` — clean (4 jobs).
+- `python3 scripts/check_dag.py` — exit 0.
+- No `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`, no banned vocabulary,
+  no em-dashes on added lines. Diff is purely docstring additions.
+
+## Current frontier
+
+#7027 deliverables complete. All eleven named theorems now carry docstrings.
+
+## Next step
+
+None for this issue. Remaining unclaimed: #7026 (HexModArith Basic.lean
+ZMod64 docstrings), #7024 (BZ RecoveredAtLift enrichment — large coupled
+single-PR structural change, lacks a worker label).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7027

Session: `10980d9e-8a30-41b5-a788-f99fab671396`

08e88119 doc: docstring coverage for HexPoly Euclid and Operations theorems (#7027)

🤖 Prepared with Claude Code