### PR TITLE
BZ recovery: add lifted candidate equality evidence

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3131,6 +3131,13 @@ structure LiftedFactorSubsetPartition
       S ⊆ J →
       RepresentsIntegerFactorAtLift core d f S →
       S ⊆ T
+  liftedRecoveryCandidate_eq :
+    ∀ {f : Hex.ZPoly} {S : LiftedFactorSubset d},
+      Irreducible (HexPolyZMathlib.toPolynomial f) →
+      f ∣ target →
+      S ⊆ J →
+      RepresentsIntegerFactorAtLift core d f S →
+      liftedRecoveryCandidate core d S = f
   support_subset_of_dvd_scaledRecombinationCandidate :
     ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
       Irreducible (HexPolyZMathlib.toPolynomial f) →
@@ -3309,6 +3316,7 @@ theorem liftedFactorSubsetPartition_transport
       unique_up_to_associated := ?_
       support_subset_of_dvd_recombinationCandidate := ?_
       support_subset_of_dvd_liftedRecoveryCandidate := ?_
+      liftedRecoveryCandidate_eq := ?_
       support_subset_of_dvd_scaledRecombinationCandidate := ?_ }
   -- Cover for the new state at any `i ∈ J \ S`.
   · intro i hi_sdiff
@@ -3399,6 +3407,12 @@ theorem liftedFactorSubsetPartition_transport
         hfactor_dvd_candidate hUJ_orig hUrep
     intro i hiU
     exact hUT hiU
+  -- Recovered-candidate equality for represented factors in the transported state.
+  · intro f U hirr hdvd_quot hUJ hUrep
+    have hUJ_orig : U ⊆ J :=
+      fun i hi => (Finset.mem_sdiff.mp (hUJ hi)).1
+    exact h.liftedRecoveryCandidate_eq hirr
+      (dvd_target_of_dvd_quotient hdvd_quot) hUJ_orig hUrep
   -- Scaled-support containment for candidates in the transported state.
   · intro f U T hirr hdvd_quot hTJ hfactor_dvd_candidate hUJ hUrep
     have hTJ_orig : T ⊆ J :=
@@ -17743,6 +17757,12 @@ structure InitialLiftedFactorSubsetPartitionEvidence
           f ∣ liftedRecoveryCandidate core d T →
             RepresentsIntegerFactorAtLift core d f S →
               S ⊆ T
+  liftedRecoveryCandidate_eq :
+    ∀ {f : Hex.ZPoly} {S : LiftedFactorSubset d},
+      Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+          RepresentsIntegerFactorAtLift core d f S →
+            liftedRecoveryCandidate core d S = f
   support_subset_of_dvd_scaledRecombinationCandidate :
     ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
       Irreducible (HexPolyZMathlib.toPolynomial f) →
@@ -17848,6 +17868,24 @@ theorem liftedFactorSubsetPartition_initial_support_subset_of_dvd_liftedRecovery
     hirr hdvd_core hdvd_candidate hrep
 
 /--
+Initial-state recovered-candidate equality for represented factors in the
+successful `choosePrimeData?` lifted-factor package.
+-/
+theorem liftedFactorSubsetPartition_initial_liftedRecoveryCandidate_eq_of_choosePrimeData
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hinitial :
+      InitialLiftedFactorSubsetPartitionEvidence core
+        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
+    ∀ {f : Hex.ZPoly} {S : LiftedFactorSubset d},
+      Irreducible (HexPolyZMathlib.toPolynomial f) →
+      f ∣ core →
+      RepresentsIntegerFactorAtLift core d f S →
+      liftedRecoveryCandidate core d S = f := by
+  intro d f S hirr hdvd_core hrep
+  exact hinitial.liftedRecoveryCandidate_eq hirr hdvd_core hrep
+
+/--
 Initial-state support containment for scaled recombination candidates in the
 successful `choosePrimeData?` lifted-factor package.
 
@@ -17940,6 +17978,11 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
           exact
             liftedFactorSubsetPartition_initial_support_subset_of_dvd_liftedRecoveryCandidate_of_choosePrimeData
               core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+        liftedRecoveryCandidate_eq := by
+          intro f S hirr hdvd_target _ hSrep
+          exact
+            liftedFactorSubsetPartition_initial_liftedRecoveryCandidate_eq_of_choosePrimeData
+              core B primeData hinitial hirr hdvd_target hSrep
         support_subset_of_dvd_scaledRecombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact
@@ -17994,6 +18037,11 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData
           exact
             liftedFactorSubsetPartition_initial_support_subset_of_dvd_liftedRecoveryCandidate_of_choosePrimeData
               core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+        liftedRecoveryCandidate_eq := by
+          intro f S hirr hdvd_target _ hSrep
+          exact
+            liftedFactorSubsetPartition_initial_liftedRecoveryCandidate_eq_of_choosePrimeData
+              core B primeData hinitial hirr hdvd_target hSrep
         support_subset_of_dvd_scaledRecombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact
@@ -18962,6 +19010,11 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData_success_descent
           exact
             liftedFactorSubsetPartition_initial_support_subset_of_dvd_liftedRecoveryCandidate_of_choosePrimeData
               core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+        liftedRecoveryCandidate_eq := by
+          intro f S hirr hdvd_target _ hSrep
+          exact
+            liftedFactorSubsetPartition_initial_liftedRecoveryCandidate_eq_of_choosePrimeData
+              core B primeData hinitial hirr hdvd_target hSrep
         support_subset_of_dvd_scaledRecombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact

--- a/progress/20260614T034945Z_a9574a88.md
+++ b/progress/20260614T034945Z_a9574a88.md
@@ -1,0 +1,55 @@
+# Progress: #7030 decomposition / #7035 partition equality evidence
+
+## Accomplished
+
+Claimed #7030 after the blocked directive #2564 could not be claimed
+(`coordination claim 2564` failed because dependencies are open).
+
+Re-baselined `lake build HexBerlekampZassenhausMathlib.Basic`; the first run
+was killed without diagnostics after a long elaboration. Direct inspection
+showed #7030 spans multiple proof regions rather than one local consumer.
+Decomposed #7030 into:
+
+- #7035: add lifted candidate equality evidence to partition packages.
+- #7036: migrate monic partition consumers to lifted candidate equality.
+- #7037: migrate primitive scaled search to `liftedRecoveryCandidate`.
+
+Left the required `Decomposed into #7035, #7036, #7037` breadcrumb on #7030
+and marked it `replan`, then claimed #7035.
+
+Implemented the #7035 API slice in `HexBerlekampZassenhausMathlib/Basic.lean`:
+
+- Added `LiftedFactorSubsetPartition.liftedRecoveryCandidate_eq`.
+- Transported that field through `liftedFactorSubsetPartition_transport`.
+- Added `InitialLiftedFactorSubsetPartitionEvidence.liftedRecoveryCandidate_eq`.
+- Added the initial projection
+  `liftedFactorSubsetPartition_initial_liftedRecoveryCandidate_eq_of_choosePrimeData`.
+- Threaded the field through the choose-prime, to-monic-prime, and
+  success-descent initial partition constructors.
+
+Verification completed:
+
+- `python3 scripts/check_dag.py` passes.
+- `git diff --check` passes.
+- Added diff contains no `sorry`, `axiom`, `native_decide`, `TODO`, or `FIXME`.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhausMathlib.Basic` now reaches the known #7030
+consumer failures and reports no missing-field errors from the #7035 structure
+extension. The remaining failures are the old-shape consumers assigned to
+#7036/#7037, for example calls passing `RepresentsIntegerFactorAtLift` where a
+scaled-product modular equality is expected around lines 9558, 9569, 9668,
+9975, 10467, 14415, 14537, 14760, 16154, and 16536, plus the prefix-none
+candidate-shape mismatch around 16636.
+
+## Next step
+
+Open a PR for the #7035 evidence-threading slice if partial verification
+against the currently red bridge target is acceptable, then continue with
+#7036 to consume the new field in the monic recursive search path.
+
+## Blockers
+
+Full `lake build HexBerlekampZassenhausMathlib.Basic` is still blocked by the
+downstream consumer migrations now split into #7036 and #7037.


### PR DESCRIPTION
Partial progress on #7035

Session: `a9574a88-c451-4f79-a7a2-8c2f5848deeb`

c4718115 Add lifted recovery equality partition evidence

🤖 Prepared with Claude Code