### PR TITLE
doc: record #6824 premise check and harden Mathlib-build baseline guidance

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -132,7 +132,13 @@ Before attributing a Mathlib-layer build failure to your own change, build the
 that build with `| tee <log>`, the pipeline's exit status is `tee`'s, so a
 `run_in_background` completion notification reports **exit 0 even on a failed
 build** — judge red/green by grepping the log for `error:` / `build failed`,
-never by the reported exit code. A faster
+never by the reported exit code. Grep only *after* the build has finished: a
+still-running background build's log shows zero `error:` lines simply because
+elaboration has not yet reached the broken file, so a premature grep reads
+false-green. Wait for the `Built <target>` / process-exit signal (or an
+`error: build failed` line) before concluding, and do not launch overlapping
+`lake build`s to "confirm" — they serialize on the worktree lock and muddy
+attribution. A faster
 single-build attribution when your change is purely additive *within* the same
 file: Lean reports every per-declaration error and keeps elaborating past a
 failed declaration, so if the build log's only `error:` line numbers fall

--- a/progress/20260614T040244Z_38c908e7.md
+++ b/progress/20260614T040244Z_38c908e7.md
@@ -1,0 +1,42 @@
+# Session: feature /work — #6824 (BHKS D1 cap-specialized pointwise wrappers)
+
+## Accomplished
+- Claimed #6824. Inserted the two ready-source wrapper theorems
+  (`projectedVector_sq_le_cutRadiusSq4`, `correctionWeighted_le_mul_pow`)
+  into `HexBerlekampZassenhausMathlib/Recovery.lean` before
+  `FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBounds`.
+- Premise check failed: the wrappers cannot be machine-verified. `Recovery.lean`
+  imports `Basic.lean`, and `Basic.lean` is hard-red on `origin/main` with 13
+  `Application type mismatch` errors (lines 9544, 9555, 9654, 9961, 10453,
+  14401, 14523, 14746, 16140, 16522, 16622).
+- Root cause: commit `62d590aa` ("refactor: decouple scaled recovery congruence",
+  PR #6920) changed `recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound`
+  (Basic.lean:5295) to take `hscaled : reduceModPow (scaledLiftedFactorProduct
+  core d S) d.p d.k = reduceModPow factor d.p d.k`, but the in-file call sites
+  still pass the old `hrep : RepresentsIntegerFactorAtLift core d factor S`.
+  This is the in-flight recovery-chain migration (open cluster #7037/#7035/#7024)
+  leaving the layer mid-remodel. Not CI-built, so it merged red.
+- `depends-on: #6804` is satisfied (closed) but insufficient: #6804 advanced the
+  dilation remodel but the recovery-congruence call sites remain mismatched.
+
+## Current frontier
+- Issue skipped to `replan` with concrete evidence comment. The ready wrapper
+  source in the issue body is unchanged and still valid; it just needs
+  `Basic.lean` to elaborate first.
+
+## Next step
+- A planner re-blocks #6824 on whichever issue re-aligns the Basic.lean recovery
+  call sites (the #7037/#7035/#7024 cluster), then a worker adds the ready source
+  and verifies `lake build HexBerlekampZassenhausMathlib.Recovery`.
+
+## Blockers
+- `HexBerlekampZassenhausMathlib/Basic.lean` red on `origin/main` (recovery-chain
+  migration mid-flight). Blocks all of `Recovery.lean`.
+
+## Sibling feature queue also blocked
+- The other unclaimed feature issues #6805 and #6773 both target
+  `HexBerlekampZassenhausMathlib` and require `lake build
+  HexBerlekampZassenhausMathlib` green in their verification. They are blocked
+  by the same red `Basic.lean`. Did not claim them (would skip for the same
+  reason). The whole Mathlib-layer feature queue is gated on the recovery-chain
+  migration re-aligning the `Basic.lean` recovery call sites.


### PR DESCRIPTION
This PR records the premise check that blocked feature issue #6824 and hardens the Mathlib-layer baseline guidance that the check exposed as insufficient.

The #6824 wrappers cannot be machine-verified: `HexBerlekampZassenhausMathlib/Recovery.lean` imports `Basic.lean`, which is hard-red on `origin/main` with 13 `Application type mismatch` errors. The root cause is PR https://github.com/kim-em/hex/pull/6920 "refactor: decouple scaled recovery congruence", which changed `recombinationCandidate_eq_factor_of_recovery_of_monic_core_of_bound` (`Basic.lean:5295`) to take a `reduceModPow` equality while the in-file call sites still pass the old `RepresentsIntegerFactorAtLift` predicate. The recovery-chain migration that re-aligns them is still in flight (https://github.com/kim-em/hex/issues/7037, https://github.com/kim-em/hex/issues/7035, https://github.com/kim-em/hex/issues/7024). #6824 was skipped to `replan` with this evidence so a planner can re-block it on that migration; its `depends-on: #6804` is satisfied but insufficient.

The session also adds a wait-for-completion rule to the `hex-lean-mathlib-boundary` skill: grepping a still-running background `lake build` log reads false-green because elaboration has not yet reached the broken file, and launching overlapping builds to "confirm" just serializes on the worktree lock.

🤖 Prepared with Claude Code