### PR TITLE
feat: add RecoveredAtLift monic-coordinate bound producer

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -2281,6 +2281,13 @@ lift.  The selected lifted product represents a monic-coordinate factor modulo
 `p^k`; dilating that monic factor by `leadingCoeff core` and taking primitive
 part recovers the integer factor of `core`.
 
+The `monic_dvd` field pins the monic coordinate down to the canonical bounded
+representative: it must divide `(toMonic core).monic`, the monic polynomial the
+Hensel lift is actually built on.  This forces a Mignotte coefficient bound on
+`monicFactor` (via `defaultFactorCoeffBound_valid`), which is what makes the
+exact-recovery lemma `candidate_eq_of_bound` applicable; without it the residue
+link alone admits non-canonical witnesses.
+
 This is the data-bearing carrier behind the public proof-level
 `RepresentsIntegerFactorAtLift` predicate.
 -/
@@ -2295,6 +2302,8 @@ structure RecoveredAtLift
     Hex.ZPoly.primitivePart
         (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) monicFactor) =
       factor
+  monic_dvd :
+    monicFactor ∣ (Hex.ZPoly.toMonic core).monic
 
 /--
 An integer factor is represented by a subset of the lifted local factors when
@@ -2758,6 +2767,32 @@ theorem candidate_eq_of_bound
     liftedRecoveryCandidate core d S = factor :=
   liftedRecoveryCandidate_eq_factor_of_congruence_of_bound
     B' hvalid hrep.congr hrep.dilate_eq hfactor_norm hprecision
+
+/--
+Exact recovery driven directly by the carrier's `monic_dvd` field.
+
+This is the producer half of the recovery contract: the `monic_dvd` field
+forces `monicFactor ∣ (toMonic core).monic`, so `defaultFactorCoeffBound_valid`
+discharges the Mignotte coefficient bound at
+`B' := defaultFactorCoeffBound (toMonic core).monic` with no separate validity
+obligation on the caller.  The only remaining precision hypothesis is that the
+Hensel modulus clears twice that bound.
+-/
+theorem candidate_eq_of_monic_dvd
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hrep : RecoveredAtLift core d factor S)
+    (hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0)
+    (hfactor_norm : Hex.normalizeFactorSign factor = factor)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        d.p ^ d.k) :
+    liftedRecoveryCandidate core d S = factor :=
+  hrep.candidate_eq_of_bound
+    (Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic)
+    (fun i =>
+      defaultFactorCoeffBound_valid (Hex.ZPoly.toMonic core).monic hmonic_ne
+        hrep.monicFactor hrep.monic_dvd i)
+    hfactor_norm hprecision
 
 end RecoveredAtLift
 
@@ -8765,61 +8800,6 @@ private theorem congr_of_reduceModPow_eq
     (Hex.ZPoly.congr_symm _ _ _ hf) hg
 
 /--
-Compatibility wrapper for multiplicative closure of
-`RepresentsIntegerFactorAtLift` along a disjoint decomposition `S ∪ T` of
-representing subsets under a monic core. The public predicate now packages a
-recovered monic-coordinate witness, so the proof constructs the product
-witness directly; the monic-core hypothesis is retained for existing callers.
--/
-theorem representsIntegerFactorAtLift_mul_of_monic_core
-    {core f g : Hex.ZPoly} {d : Hex.LiftData}
-    {S T : LiftedFactorSubset d}
-    (_hcore_monic : Hex.DensePoly.Monic core)
-    (hdisj : Disjoint S T)
-    (hf_rep : RepresentsIntegerFactorAtLift core d f S)
-    (hg_rep : RepresentsIntegerFactorAtLift core d g T) :
-    RepresentsIntegerFactorAtLift core d (f * g) (S ∪ T) := by
-  rcases hf_rep with ⟨hf⟩
-  rcases hg_rep with ⟨hg⟩
-  have hpk_pos : 0 < d.p ^ d.k := Nat.pow_pos d.p_pos
-  exact RepresentsIntegerFactorAtLift.ofRecovered
-    { monicFactor := hf.monicFactor * hg.monicFactor
-      congr := by
-        have hcongr_f :
-            Hex.ZPoly.congr (liftedFactorProduct d S) hf.monicFactor
-              (d.p ^ d.k) :=
-          congr_of_reduceModPow_eq _ _ _ _ hpk_pos hf.congr
-        have hcongr_g :
-            Hex.ZPoly.congr (liftedFactorProduct d T) hg.monicFactor
-              (d.p ^ d.k) :=
-          congr_of_reduceModPow_eq _ _ _ _ hpk_pos hg.congr
-        have hcongr_mul :
-            Hex.ZPoly.congr
-              (liftedFactorProduct d S * liftedFactorProduct d T)
-              (hf.monicFactor * hg.monicFactor) (d.p ^ d.k) :=
-          Hex.ZPoly.congr_mul _ _ _ _ _ hcongr_f hcongr_g
-        rw [liftedFactorProduct_union_of_disjoint hdisj]
-        exact Hex.ZPoly.reduceModPow_eq_of_congr _ _ _ _ hcongr_mul
-      dilate_eq := by
-        calc
-          Hex.ZPoly.primitivePart
-              (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core)
-                (hf.monicFactor * hg.monicFactor))
-              =
-            Hex.ZPoly.primitivePart
-              (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hf.monicFactor *
-                Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hg.monicFactor) := by
-              rw [HexPolyZMathlib.dilate_mul]
-          _ =
-            Hex.ZPoly.primitivePart
-                (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hf.monicFactor) *
-              Hex.ZPoly.primitivePart
-                (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hg.monicFactor) := by
-              rw [Hex.ZPoly.primitivePart_mul]
-          _ = f * g := by
-              rw [hf.dilate_eq, hg.dilate_eq] }
-
-/--
 Multiplicative closure of the recovered/monic-coordinate representation carrier
 `RecoveredAtLift` along a disjoint decomposition `S ∪ T`. If `S` recovers the
 integer factor `f` and `T` (disjoint from `S`) recovers `g`, then `S ∪ T`
@@ -8833,13 +8813,23 @@ no monicity hypothesis is needed. The witness monic coordinate is the product of
 the two witnesses; the `congr` field combines
 `liftedFactorProduct_union_of_disjoint` with `Hex.ZPoly.congr_mul`, and the
 `dilate_eq` field combines `HexPolyZMathlib.dilate_mul` (dilation is
-multiplicative) with `Hex.ZPoly.primitivePart_mul` (Gauss's lemma). -/
+multiplicative) with `Hex.ZPoly.primitivePart_mul` (Gauss's lemma).
+
+The `monic_dvd` field is **not** closed under the helper unconditionally: the
+two component divisibilities `hf.monicFactor ∣ (toMonic core).monic` and
+`hg.monicFactor ∣ (toMonic core).monic` do not give
+`hf.monicFactor * hg.monicFactor ∣ (toMonic core).monic` without coprimality of
+the two coordinates.  The product divisibility is therefore taken as an explicit
+premise `hmul_dvd`, supplied by the squarefree-lift context where it genuinely
+holds. -/
 def RecoveredAtLift.mul
     {core f g : Hex.ZPoly} {d : Hex.LiftData}
     {S T : LiftedFactorSubset d}
     (hdisj : Disjoint S T)
     (hf : RecoveredAtLift core d f S)
-    (hg : RecoveredAtLift core d g T) :
+    (hg : RecoveredAtLift core d g T)
+    (hmul_dvd :
+      hf.monicFactor * hg.monicFactor ∣ (Hex.ZPoly.toMonic core).monic) :
     RecoveredAtLift core d (f * g) (S ∪ T) where
   monicFactor := hf.monicFactor * hg.monicFactor
   congr := by
@@ -8859,6 +8849,31 @@ def RecoveredAtLift.mul
   dilate_eq := by
     rw [HexPolyZMathlib.dilate_mul, Hex.ZPoly.primitivePart_mul,
       hf.dilate_eq, hg.dilate_eq]
+  monic_dvd := hmul_dvd
+
+/--
+Multiplicative closure of `RepresentsIntegerFactorAtLift` along a disjoint
+decomposition `S ∪ T`, packaged from the recovered carriers.  Thin wrapper over
+`RecoveredAtLift.mul` returning the public predicate.
+
+Inputs are the data-bearing `RecoveredAtLift` carriers (not the
+`Nonempty`-erased predicate) because the product-divisibility premise `hmul_dvd`
+the carrier's `monic_dvd` field now demands must reference the component monic
+coordinates, which are not nameable through the erased predicate.  The
+monic-core hypothesis is retained for signature compatibility with the prior
+wrapper.
+-/
+theorem representsIntegerFactorAtLift_mul_of_monic_core
+    {core f g : Hex.ZPoly} {d : Hex.LiftData}
+    {S T : LiftedFactorSubset d}
+    (_hcore_monic : Hex.DensePoly.Monic core)
+    (hdisj : Disjoint S T)
+    (hf : RecoveredAtLift core d f S)
+    (hg : RecoveredAtLift core d g T)
+    (hmul_dvd :
+      hf.monicFactor * hg.monicFactor ∣ (Hex.ZPoly.toMonic core).monic) :
+    RepresentsIntegerFactorAtLift core d (f * g) (S ∪ T) :=
+  RepresentsIntegerFactorAtLift.ofRecovered (RecoveredAtLift.mul hdisj hf hg hmul_dvd)
 
 /--
 Monic-product closure for `liftedFactorProduct`: when every selected lifted
@@ -9217,7 +9232,11 @@ theorem henselLiftData_represents_lifted_of_modP
         rw [show Hex.DensePoly.leadingCoeff core = (1 : Int) from hcore_monic,
           Hex.ZPoly.dilate_one]
         exact Hex.ZPoly.primitivePart_eq_self_of_primitive factor
-          (zpoly_primitive_of_monic hfactor_monic) }
+          (zpoly_primitive_of_monic hfactor_monic)
+      monic_dvd := by
+        rw [Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one core
+          (show Hex.DensePoly.leadingCoeff core = (1 : Int) from hcore_monic)]
+        exact ⟨q, hcoreq⟩ }
 
 /-- `centeredModNat 1 m = 1` when `m ≥ 2`: the value `1` lies in the centred
 half-window and is preserved by the centred-reduction operation. -/

--- a/progress/20260614T043048Z_dd1e997e.md
+++ b/progress/20260614T043048Z_dd1e997e.md
@@ -1,0 +1,66 @@
+# Progress: #7024 — RecoveredAtLift monic-coordinate bound producer (piece 1)
+
+## Accomplished
+
+Landed piece 1 of #7024 (the producer half), as the permitted additive
+compiling seam, in `HexBerlekampZassenhausMathlib/Basic.lean`:
+
+- Enriched the recovery carrier `RecoveredAtLift` with a divisibility field
+  `monic_dvd : monicFactor ∣ (Hex.ZPoly.toMonic core).monic`. This pins the
+  monic coordinate to the canonical bounded representative.
+- Added the producer lemma `RecoveredAtLift.candidate_eq_of_monic_dvd`: it
+  discharges the Mignotte bound `candidate_eq_of_bound` needs for free, with
+  `B' := defaultFactorCoeffBound (toMonic core).monic` via
+  `defaultFactorCoeffBound_valid`, leaving only the precision hypothesis on the
+  caller. This is the genuinely missing producer (the #6990 orphan mistake was
+  landing the *consumer* `candidate_eq_of_bound` with no producer).
+- Discharged the new field at all three constructor sites:
+  - `henselLiftData_represents_lifted_of_modP` (monic-core cover): trivial via
+    `toMonic_monic_eq_core_of_leadingCoeff_eq_one` + the `factor ∣ core`
+    hypothesis (rebuilt from its already-destructured `⟨q, hcoreq⟩`).
+  - `RecoveredAtLift.mul`: added the explicit product-divisibility premise
+    `hmul_dvd : hf.monicFactor * hg.monicFactor ∣ (toMonic core).monic` (the
+    obstruction #6990 flagged — not closed under the helper without
+    coprimality), discharging the field directly from it.
+  - `representsIntegerFactorAtLift_mul_of_monic_core`: re-pointed to take the
+    `RecoveredAtLift` carriers (not the `Nonempty`-erased predicate, which
+    cannot name the witnesses the premise references) and delegate to
+    `RecoveredAtLift.mul`. Both `mul` helpers had **zero** callers across the
+    repo, so the contract change threads through no existing use sites.
+
+## Verification
+
+- Baseline (clean tree, `lake exe cache get` first): the Mathlib layer is not
+  CI-built and is red on main with exactly 11 elaboration errors at the piece-3
+  consumer sites (9544, 9555, 9654, 9961, 10453, 14401, 14523, 14746, 16140,
+  16522, 16622), matching the issue's premise check.
+- After piece 1: `lake build HexBerlekampZassenhausMathlib.Basic` shows the
+  *same* 11 errors (shifted to 9563…16641 by the additions) and **no new
+  errors before them** — every piece-1 declaration elaborates green. Per the
+  boundary-skill attribution rule (additive within one file; error lines all
+  outside the added ranges), piece 1 compiled.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+  and no em-dashes on added lines.
+- Executable target `HexBerlekampZassenhaus` is unaffected (Mathlib layer
+  imports the executable, not vice versa) and built green in the baseline.
+
+## Current frontier
+
+Piece 1 (producer field + constructor discharges) is green. The 11 residual
+errors are the piece-2/3 consumer migration, which has no compiling partial
+seam and was explicitly deferred by the issue's permitted staging.
+
+## Next step
+
+Pieces 2 + 3 (one follow-up PR, gated on this one merging):
+- Piece 2: re-thread precision from `defaultFactorCoeffBound core` to
+  `defaultFactorCoeffBound (toMonic core).monic` at the ~48 instantiations.
+- Piece 3: migrate the 11 consumer sites + prefix-none onto
+  `liftedRecoveryCandidate`, using `candidate_eq_of_monic_dvd` as the new
+  recovery driver.
+
+## Blockers
+
+None for piece 1. Pieces 2+3 need the planner to scope a successor issue
+(this PR lands `--partial`).


### PR DESCRIPTION
This PR adds the producer half of the recovered-lift coordinate bound (piece 1 of https://github.com/kim-em/hex/issues/7024, "BZ recovery: enrich RecoveredAtLift with bounded monic field"). It enriches the recovery carrier `RecoveredAtLift` with a divisibility field `monic_dvd : monicFactor ∣ (toMonic core).monic`, pinning the monic coordinate to the canonical bounded representative, and adds the producer lemma `RecoveredAtLift.candidate_eq_of_monic_dvd`, which discharges the Mignotte bound that `candidate_eq_of_bound` needs for free (`B' := defaultFactorCoeffBound (toMonic core).monic`, via `defaultFactorCoeffBound_valid`), leaving only the precision hypothesis on the caller. This is the genuinely missing producer whose absence made the `candidate_eq_of_bound` consumer API an orphan.

The new field is discharged at all three constructor sites: the monic-core cover provider `henselLiftData_represents_lifted_of_modP` (trivial via `toMonic_monic_eq_core_of_leadingCoeff_eq_one`), and both `RecoveredAtLift.mul` helpers, which now take an explicit product-divisibility premise `hmul_dvd` (the coprimality obstruction noted in the parent decomposition, since the two component divisibilities do not give the product divisibility without coprimality). The Prop wrapper `representsIntegerFactorAtLift_mul_of_monic_core` now takes the `RecoveredAtLift` carriers directly so the premise can name the component witnesses; both `mul` helpers have zero callers across the repo, so the contract change threads through no existing use sites.

The `HexBerlekampZassenhausMathlib` layer is not CI-built and is red on `main` at the 11 piece-3 consumer-migration sites. This additive seam leaves exactly those 11 pre-existing errors and introduces no new ones; every added declaration elaborates green against a `lake exe cache get` baseline. Pieces 2 (precision re-thread) and 3 (consumer migration onto `liftedRecoveryCandidate`) follow in a separate PR.

🤖 Prepared with Claude Code