### PR TITLE
feat: derive liftedTrueSupports B8 partition count from support-factor bijection

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -14539,6 +14539,119 @@ theorem nonempty_of_partition
   exact not_represents_empty_of_irreducible_dvd_core_of_primitive_pos_lc_core
     hcore_ne hcore_primitive hcore_lc_pos hprecision hdvd hirr hrep
 
+/-- The lifted true-support family is in bijection with the normalized
+irreducible factors of `core`: its cardinality equals
+`(normalizedFactors (toPolynomial core)).card`.
+
+The forward map sends each support to the normalized irreducible polynomial it
+represents. Existence of a representing subset for every irreducible divisor
+comes from the partition's `HenselSubsetCorrespondenceRest` base
+(`exists_subset`); injectivity comes from `unique_up_to_associated`; squarefree
+`target = core` makes `normalizedFactors` `Nodup`, so its `toFinset.card`
+equals its `card`. -/
+theorem ncard_eq_normalizedFactors_card
+    {core : Hex.ZPoly} {d : Hex.LiftData}
+    (hpartition : LiftedFactorSubsetPartition core d Finset.univ core)
+    (hcore_ne : core ≠ 0) :
+    (liftedTrueSupports core d).ncard =
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial core)).card := by
+  classical
+  set X := HexPolyZMathlib.toPolynomial core with hX
+  have hX_ne : X ≠ 0 := by
+    rw [hX]
+    intro h
+    exact hcore_ne (HexPolyZMathlib.equiv.injective (by simpa using h))
+  -- The forward map: a support's representing normalized irreducible factor.
+  set φ : Set (LiftedFactorIndex d) → Polynomial ℤ :=
+    fun U => normalize (HexPolyZMathlib.toPolynomial
+      (liftedRecoveryCandidate core d (Set.toFinite U).toFinset)) with hφdef
+  -- Evaluate `φ` on a coerced representing subset.
+  have hφ : ∀ {f : Hex.ZPoly} {S : LiftedFactorSubset d},
+      Irreducible (HexPolyZMathlib.toPolynomial f) → f ∣ core →
+      RepresentsIntegerFactorAtLift core d f S →
+      φ (↑S : Set (LiftedFactorIndex d)) =
+        normalize (HexPolyZMathlib.toPolynomial f) := by
+    intro f S hirr hdvd hrep
+    have htf : (Set.toFinite (↑S : Set (LiftedFactorIndex d))).toFinset = S := by
+      apply Finset.coe_injective
+      rw [Set.Finite.coe_toFinset]
+    have hrec : liftedRecoveryCandidate core d S = f :=
+      hpartition.liftedRecoveryCandidate_eq hirr hdvd (Finset.subset_univ S) hrep
+    simp only [hφdef]
+    rw [htf, hrec]
+  -- The forward map is a bijection onto the normalized irreducible factors.
+  have hbij : Set.BijOn φ (liftedTrueSupports core d)
+      (↑((UniqueFactorizationMonoid.normalizedFactors X).toFinset) :
+        Set (Polynomial ℤ)) := by
+    refine ⟨?_, ?_, ?_⟩
+    · -- maps to: each support represents a normalized irreducible factor of `X`.
+      intro U hU
+      rcases hU with ⟨f, S, hirr, hdvd, hrep, rfl⟩
+      rw [hφ hirr hdvd hrep]
+      obtain ⟨q, hq_mem, hq_assoc⟩ :=
+        UniqueFactorizationMonoid.exists_mem_normalizedFactors_of_dvd hX_ne hirr
+          (by rw [hX]; exact HexPolyMathlib.toPolynomial_dvd hdvd)
+      have hnorm_q : normalize q = q :=
+        UniqueFactorizationMonoid.normalize_normalized_factor q hq_mem
+      have heq : normalize (HexPolyZMathlib.toPolynomial f) = q := by
+        rw [normalize_eq_normalize_iff_associated.mpr hq_assoc, hnorm_q]
+      rw [heq]
+      exact Finset.mem_coe.mpr (Multiset.mem_toFinset.mpr hq_mem)
+    · -- injective on supports: equal normalized factors force associated
+      -- divisors, hence the same representing subset.
+      intro U hU V hV hUV
+      rcases hU with ⟨f, S, hirr_f, hdvd_f, hrep_f, rfl⟩
+      rcases hV with ⟨g, T, hirr_g, hdvd_g, hrep_g, rfl⟩
+      rw [hφ hirr_f hdvd_f hrep_f, hφ hirr_g hdvd_g hrep_g] at hUV
+      have hassoc : Associated (HexPolyZMathlib.toPolynomial f)
+          (HexPolyZMathlib.toPolynomial g) :=
+        normalize_eq_normalize_iff_associated.mp hUV
+      have hST : S = T :=
+        hpartition.unique_up_to_associated hirr_f hdvd_f (Finset.subset_univ S)
+          hrep_f hirr_g hdvd_g (Finset.subset_univ T) hrep_g hassoc
+      rw [hST]
+    · -- surjective onto factors: every normalized irreducible factor of `X`
+      -- pulls back to a `ZPoly` divisor with a representing subset.
+      intro p hp
+      have hp_mem : p ∈ UniqueFactorizationMonoid.normalizedFactors X :=
+        Multiset.mem_toFinset.mp (Finset.mem_coe.mp hp)
+      have hp_irr : Irreducible p :=
+        UniqueFactorizationMonoid.irreducible_of_normalized_factor p hp_mem
+      have hp_dvd : p ∣ X :=
+        UniqueFactorizationMonoid.dvd_of_mem_normalizedFactors hp_mem
+      have hp_norm : normalize p = p :=
+        UniqueFactorizationMonoid.normalize_normalized_factor p hp_mem
+      have hf_toPoly :
+          HexPolyZMathlib.toPolynomial (HexPolyZMathlib.ofPolynomial p) = p :=
+        HexPolyZMathlib.toPolynomial_ofPolynomial p
+      have hf_irr :
+          Irreducible (HexPolyZMathlib.toPolynomial
+            (HexPolyZMathlib.ofPolynomial p)) := by
+        rw [hf_toPoly]; exact hp_irr
+      have hf_dvd : HexPolyZMathlib.ofPolynomial p ∣ core := by
+        rw [hX] at hp_dvd
+        rcases hp_dvd with ⟨r, hr⟩
+        refine ⟨HexPolyZMathlib.ofPolynomial r, ?_⟩
+        apply HexPolyZMathlib.equiv.injective
+        show HexPolyZMathlib.toPolynomial core =
+          HexPolyZMathlib.toPolynomial
+            (HexPolyZMathlib.ofPolynomial p * HexPolyZMathlib.ofPolynomial r)
+        rw [HexPolyZMathlib.toPolynomial_mul, hf_toPoly,
+          HexPolyZMathlib.toPolynomial_ofPolynomial]
+        exact hr
+      obtain ⟨S, _hSJ, hrep⟩ :=
+        hpartition.toHenselSubsetCorrespondenceRest.exists_subset hf_irr hf_dvd
+      refine ⟨(↑S : Set (LiftedFactorIndex d)),
+        ⟨HexPolyZMathlib.ofPolynomial p, S, hf_irr, hf_dvd, hrep, rfl⟩, ?_⟩
+      rw [hφ hf_irr hf_dvd hrep, hf_toPoly, hp_norm]
+  -- Conclude: bijection cardinality, then `Nodup` from squarefreeness.
+  have hnodup : (UniqueFactorizationMonoid.normalizedFactors X).Nodup :=
+    (UniqueFactorizationMonoid.squarefree_iff_nodup_normalizedFactors hX_ne).mp
+      (by rw [hX]; exact hpartition.target_squarefree)
+  rw [hbij.ncard_eq, Set.ncard_coe_finset,
+    Multiset.toFinset_card_of_nodup hnodup]
+
 end liftedTrueSupports
 
 /--

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -209,6 +209,32 @@ theorem supportPartitionByMinColumn_length_eq_liftedTrueSupports_ncard
     (liftedTrueSupports.nonempty_of_partition
       hcore_ne hcore_primitive hcore_lc_pos hprecision)
 
+/--
+B8 partition-refinement equality for the lifted true-support family: the
+support-equivalence partition length matches the number of normalized
+irreducible factors of `core`.
+
+This composes the lifted-support partition count
+(`supportPartitionByMinColumn_length_eq_liftedTrueSupports_ncard`) with the
+support-to-factor bijection (`liftedTrueSupports.ncard_eq_normalizedFactors_card`),
+exposing exactly the `hpartition` hypothesis consumed by
+`factorFastCoreWithBound_some_factor_zpolyIrreducible`.
+-/
+theorem supportPartitionByMinColumn_length_eq_normalizedFactors_card
+    {core : Hex.ZPoly} {d : Hex.LiftData}
+    (hpartition :
+      LiftedFactorSubsetPartition core d Finset.univ core)
+    (hcore_ne : core ≠ 0)
+    (hcore_primitive : Hex.ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
+    (supportPartitionByMinColumn (liftedTrueSupports core d)).length =
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial core)).card := by
+  rw [supportPartitionByMinColumn_length_eq_liftedTrueSupports_ncard
+      hpartition hcore_ne hcore_primitive hcore_lc_pos hprecision,
+    liftedTrueSupports.ncard_eq_normalizedFactors_card hpartition hcore_ne]
+
 namespace ForwardRecoveryInputs
 
 /-- Under an `ExpectedTrueFactors` package whose indicators are the

--- a/progress/2026-06-14T07-13-27Z_6177c8a9.md
+++ b/progress/2026-06-14T07-13-27Z_6177c8a9.md
@@ -1,0 +1,63 @@
+# Session 6177c8a9 — feat #6786 (B-builder: trueSupports from LiftedFactorSubsetPartition)
+
+## Accomplished
+
+Issue #6786 deliverables 3 and 4 (the remaining work; deliverables 1, 2
+already shipped, deliverable 5 is N/A — this layer stays parameterized on
+`LiftedFactorSubsetPartition`).
+
+- `HexBerlekampZassenhausMathlib/Basic.lean`:
+  `liftedTrueSupports.ncard_eq_normalizedFactors_card` — the lifted
+  true-support family is in bijection with the normalized irreducible
+  factors of `core`, so its `ncard` equals
+  `(normalizedFactors (toPolynomial core)).card`. Forward map sends a
+  support to the normalized irreducible polynomial it represents.
+  Surjectivity (every irreducible divisor is represented) comes from the
+  partition's `HenselSubsetCorrespondenceRest` base field `exists_subset`;
+  injectivity from `unique_up_to_associated`; `Nodup` of
+  `normalizedFactors` from `target_squarefree`. Built with
+  `Set.BijOn`/`BijOn.ncard_eq`, `exists_mem_normalizedFactors_of_dvd`,
+  `normalize_eq_normalize_iff_associated`,
+  `squarefree_iff_nodup_normalizedFactors`,
+  `Multiset.toFinset_card_of_nodup`.
+
+- `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+  `supportPartitionByMinColumn_length_eq_normalizedFactors_card` — composes
+  the landed support-partition spine with the new bijection to expose the
+  exact `hpartition` equality
+  `(supportPartitionByMinColumn (liftedTrueSupports core d)).length =
+  normalizedFactors.card` consumed by
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible`.
+
+## Current frontier / build state
+
+`HexBerlekampZassenhausMathlib/Basic.lean` is **hard-red on main**,
+independent of this change: 7 `Application type mismatch` errors at
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound`
+call sites (Basic.lean clean-tree lines 9846, 10338, 14285, 14407, 14630,
+16394, 16494) where callers pass `RepresentsIntegerFactorAtLift` but the
+callee now expects a raw `reduceModPow` congruence. This is the in-flight
+scaled→monic recovery remodel owned by **#7044** (claimed). A clean-tree
+build of the unmodified file reproduces exactly these 7 errors; building
+with this change reproduces the *same* 7 (3 shifted by the +113-line
+insertion) and **zero** errors inside the added range [14552, 14665].
+
+So the new declarations elaborate cleanly (differentially verified), but
+full `lake build HexBerlekampZassenhausMathlib.Basic` and any downstream
+`PartitionRefinement` build are red until #7044 lands. CI is unaffected
+(the Mathlib layer is not CI-built). Did not touch the broken scaled-
+recovery sites — that is #7044's structural remodel, not a token swap
+(per the hex-lean-mathlib-boundary skill).
+
+## Next step
+
+After #7044 lands and Basic.lean goes green, confirm a full
+`lake build HexBerlekampZassenhausMathlib.PartitionRefinement` to verify
+deliverable 4's `rw` composition end-to-end (it is a 3-line composition of
+two confirmed-signature lemmas, but was never build-elaborated because its
+import was red).
+
+## Blockers
+
+#7044 (scaled→monic recovery remodel) leaves Basic.lean red, blocking
+end-to-end build verification of this layer.


### PR DESCRIPTION
This PR proves `liftedTrueSupports.ncard_eq_normalizedFactors_card`: the lifted true-support family of a `LiftedFactorSubsetPartition core d Finset.univ core` is in bijection with the normalized irreducible factors of `core`, so its `ncard` equals `(normalizedFactors (toPolynomial core)).card`. The forward map sends each support to the normalized irreducible polynomial it represents; surjectivity comes from the partition's `HenselSubsetCorrespondenceRest` base field `exists_subset`, injectivity from `unique_up_to_associated`, and `Nodup` of `normalizedFactors` from `target_squarefree`. It then composes this with the landed support-partition spine to expose `supportPartitionByMinColumn_length_eq_normalizedFactors_card`, the exact `hpartition` equality consumed by `factorFastCoreWithBound_some_factor_zpolyIrreducible`. This closes deliverables 3 and 4 of #6786 (deliverables 1 and 2 already shipped; deliverable 5 is N/A, the layer stays parameterized on `LiftedFactorSubsetPartition`).

Build state: `HexBerlekampZassenhausMathlib/Basic.lean` is hard-red on main independent of this change. A clean-tree build of the unmodified file fails with 7 `Application type mismatch` errors at `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery_of_bound` call sites (callers pass `RepresentsIntegerFactorAtLift`; the callee now expects a raw `reduceModPow` congruence) — the in-flight scaled-to-monic recovery remodel owned by #7044. Building with this change reproduces the *same* 7 errors (3 shifted by the added lines) and zero errors inside the added range, so the new declarations elaborate cleanly (differentially verified). Full `lake build` of this layer, and downstream `PartitionRefinement`, stay red until #7044 lands; CI is unaffected since the Mathlib layer is not CI-built. The broken scaled-recovery sites are deliberately untouched — that is #7044's structural remodel, not a token swap (per the hex-lean-mathlib-boundary skill).

🤖 Prepared with Claude Code