### PR TITLE
feat: HexGF2 Phase 6 docstrings for remaining named declarations across Basic/Field/Irreducibility

### DIFF
--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -255,6 +255,8 @@ theorem highestSetBit?_oneHot {bit : Nat} (hbit : bit < 64) :
     rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl <;>
     rfl
 
+/-- A machine word is `!= 0` exactly when its `Nat` value is `!= 0`,
+transporting the word-level boolean inequality to the `toNat` image. -/
 theorem UInt64.bne_zero_eq_toNat_bne_zero (w : UInt64) :
     (w != 0) = (w.toNat != 0) := by
   apply Bool.eq_iff_iff.mpr

--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -637,6 +637,9 @@ theorem eq_of_val_eq {a b : GF2nPoly f hirr}
   subst h
   rfl
 
+/-- Decidable equality on the quotient field `GF2nPoly f hirr`, decided on
+the underlying reduced representative `.val`; representatives with equal
+`.val` are promoted to equal field elements via `eq_of_val_eq`. -/
 instance instDecidableEq : DecidableEq (GF2nPoly f hirr) := fun a b =>
   match decEq a.val b.val with
   | isTrue h => isTrue (eq_of_val_eq h)

--- a/HexGF2/Irreducibility.lean
+++ b/HexGF2/Irreducibility.lean
@@ -34,9 +34,13 @@ instance instDecidableEq : DecidableEq GF2Poly := fun p q =>
   | isFalse hw =>
       isFalse (fun h => hw (by cases h; rfl))
 
+/-- Boolean equality on packed `GF(2)` polynomials, computed by `decide`
+on the decidable propositional equality. -/
 instance instBEq : BEq GF2Poly where
   beq p q := decide (p = q)
 
+/-- `instBEq` is lawful: its boolean equality agrees with propositional
+equality in both directions, via `of_decide_eq_true` and `decide_eq_true`. -/
 instance instLawfulBEq : LawfulBEq GF2Poly where
   eq_of_beq := by
     intro a b h

--- a/progress/20260614T073500Z_f60be91a.md
+++ b/progress/20260614T073500Z_f60be91a.md
@@ -1,0 +1,27 @@
+# Progress — 2026-06-14T07:35Z (feature session, #7092)
+
+## Accomplished
+Added Phase 6 docstrings to the four remaining undocumented public named
+declarations in `HexGF2`, completing the library's docstring-coverage
+exit criterion:
+- `HexGF2/Basic.lean` — `UInt64.bne_zero_eq_toNat_bne_zero`: word-level
+  `!= 0` transported to its `toNat` image.
+- `HexGF2/Field.lean` — `instDecidableEq`: `DecidableEq (GF2nPoly f hirr)`
+  decided on `.val` and promoted via `eq_of_val_eq`.
+- `HexGF2/Irreducibility.lean` — `instBEq`: `decide`-backed boolean
+  equality on `GF2Poly`.
+- `HexGF2/Irreducibility.lean` — `instLawfulBEq`: lawfulness witness for
+  that `BEq`.
+
+Docstring-only change; no statement/proof/attribute/import touched.
+`lake build HexGF2` clean (52 jobs); `python3 scripts/check_dag.py` exits 0.
+
+## Current frontier
+HexGF2 now has zero undocumented public named declarations. Anonymous
+instances remain undocumented by campaign scope (out of scope per #7092).
+
+## Next step
+Other Phase 6 exit criteria for HexGF2 before a `done_through: 6` bump.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7092

Session: `f60be91a-3f18-4562-8ac5-cd0f5c9f21e2`

b39f557a doc: HexGF2 Phase 6 docstrings for remaining named declarations (#7092)

🤖 Prepared with Claude Code