### PR TITLE
feat: cap-specialized pointwise auxiliary bound wrappers

### DIFF
--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -4418,6 +4418,105 @@ def ofBridgeDataCorrectedAuxiliaryL2normSq
   precision_eq := hprecision
 
 /--
+Canonical projected-vector pointwise bound for the cap-lift bad-vector bridge.
+
+Choosing `vectorSquareBound := cutRadiusSq4`, the `hvectorSquareBound` shape
+consumed by `ofBridgeDataPointwiseAuxiliaryBounds*` follows from a bound on the
+projected squared-norm sum (the cut-radius membership condition for a bad
+vector), since each stored coordinate's square is at most the full sum.
+-/
+theorem projectedVector_sq_le_cutRadiusSq4
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hnorm_le :
+      (∑ i : Fin (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos).factorCount, ((v i : ℝ)) ^ 2) ≤
+        ((projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos).cutRadiusSq4 : ℝ)) :
+    ∀ i : Fin (factorFastCapLiftData f primeData).liftedFactors.size,
+      ((((badVectorWitnessOfFactorFastCapLiftData
+            f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray v).getD
+          i.val 0 : ℝ) ^ 2) ≤
+        ((projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCapLiftData f primeData)
+          rows_pos).cutRadiusSq4 : ℝ) :=
+  fun i =>
+    (badVectorWitnessOfFactorFastCapLiftData
+        f primeData rows_pos localFactorIndex localFactorDegree H).projectedVectorArray_sq_le_of_sum_le
+      v _ (Nat.cast_nonneg _) hnorm_le i
+
+/--
+Canonical weighted-correction pointwise bound for the cap-lift bad-vector
+bridge.
+
+Choosing `correctionWeightedBound := D * p ^ (2k)`, the `hcorrectionWeightedBound`
+shape consumed by `ofBridgeDataPointwiseAuxiliaryBounds*` follows from a
+coordinate square bound `D` on the diagonal-row corrections, since the
+cut-threshold weight `p ^ (2 (k − ℓ_j))` is at most `p ^ (2k)`.
+-/
+theorem correctionWeighted_le_mul_pow
+    {f : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    {rows_pos : HasPositiveDimension
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)}
+    {trueSupports : Set (Set (Fin (projectedRowsOfLiftData
+      (Hex.normalizeForFactor f).squareFreeCore
+      (factorFastCapLiftData f primeData)
+      rows_pos).factorCount))}
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hp : 1 ≤ (factorFastCapLiftData f primeData).p)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (v :
+      Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCapLiftData f primeData)
+        rows_pos).factorCount → ℤ)
+    (hin :
+      v ∈
+        BHKS.projectedRowSpanInt
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCapLiftData f primeData)
+            rows_pos))
+    (hnot :
+      v ∉ BHKS.trueFactorIndicatorLattice trueSupports)
+    (D : ℝ)
+    (hD :
+      ∀ j, j < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 →
+        (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ)) ^ 2 ≤ D) :
+    ∀ j, j < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 →
+      (((bridge.auxiliaryCorrections v hin hnot).getD j 0 : ℝ) ^ 2 *
+        (((factorFastCapLiftData f primeData).p : ℝ) ^
+          (2 *
+            ((factorFastCapLiftData f primeData).k -
+              Hex.bhksCoeffCutThreshold
+                (factorFastCapLiftData f primeData).p
+                (Hex.normalizeForFactor f).squareFreeCore j)))) ≤
+        D * ((factorFastCapLiftData f primeData).p : ℝ) ^
+          (2 * (factorFastCapLiftData f primeData).k) :=
+  fun j hj =>
+    BHKS.correctionWeighted_sq_le_of_coeff_sq_le
+      (Hex.normalizeForFactor f).squareFreeCore (factorFastCapLiftData f primeData)
+      (bridge.auxiliaryCorrections v hin hnot) D hp hD j hj
+
+/--
 Build the cap-separation input package from pointwise auxiliary-coordinate
 bounds.
 

--- a/progress/20260614T083131Z_693a7b09.md
+++ b/progress/20260614T083131Z_693a7b09.md
@@ -1,0 +1,61 @@
+# Progress
+
+**Session type**: feature (/work → /feature)
+**Issue**: #6824 — BHKS D1 residual: cap-specialized pointwise auxiliary bound wrappers
+
+## Accomplished
+
+Added the two cap-specialized wrapper theorems to
+`HexBerlekampZassenhausMathlib/Recovery.lean`, inserted before
+`FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBounds`
+(namespace `HexBerlekampZassenhausMathlib.BHKS.FactorFastCapSeparationInputs`):
+
+- `projectedVector_sq_le_cutRadiusSq4` — thin delegation to
+  `ExecutableBadVectorWitness.projectedVectorArray_sq_le_of_sum_le`
+  (BadVector.lean), canonical `vectorSquareBound := cutRadiusSq4`.
+- `correctionWeighted_le_mul_pow` — thin delegation to
+  `BHKS.correctionWeighted_sq_le_of_coeff_sq_le` (BadVectorAuxiliary.lean),
+  canonical `correctionWeightedBound := D * p^(2k)`.
+
+Source inserted verbatim from the issue's ready-wrapper block. No executable
+definitions changed; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.
+
+## Premise check
+
+Both blockers (#7036, #7037) are now CLOSED. `Basic.lean` builds green on a
+clean tree (verified before editing). Both generic lemmas the wrappers delegate
+to exist with matching signatures: `projectedVectorArray_sq_le_of_sum_le`
+(BadVector.lean:987) and `correctionWeighted_sq_le_of_coeff_sq_le`
+(BadVectorAuxiliary.lean:255).
+
+## Verification
+
+Both wrappers are verified-correct. `lake build HexBerlekampZassenhausMathlib.Recovery`
+does **not** go fully green, but the only 6 errors are **pre-existing** at lines
+1139–2180 (identical on `origin/main`; my diff is a single additive hunk at
+line 4417). They are the recovery-direction proofs left red by the in-flight
+partial migration #7060 ("partially migrate fast BHKS to monic lift"):
+`unfold RepresentsIntegerFactorAtLift scaledLiftedFactorProduct` failures
+(1139/1235), an application type mismatch (1844), and a 200k-heartbeat timeout
+in `factorFast_ne_none_of_forwardInputs_on_schedule` (2137) that cascades to an
+"unknown constant" kernel error at 2180. None reference my new lemmas.
+
+My two additions elaborate cleanly: a temporary `#check @projectedVector_sq_le_cutRadiusSq4`
+/ `#check @correctionWeighted_le_mul_pow` probe (since removed) printed both full
+types at line 4519/4520 — proving elaboration reaches my code past the pre-existing
+errors and both theorems typecheck. `Basic.lean` (the dependency named by #6824's
+own blockers #7036/#7037) builds green on a clean tree.
+
+`check_dag.py` exit 0, `git diff --check` clean, no `sorry`/`axiom`/`native_decide`/
+`TODO`/`FIXME` on added lines.
+
+## Next step
+
+Publish PR closing #6824, documenting the #7060 pre-existing breakage as
+out-of-scope (per hex-lean-mathlib-boundary skill: do not fix another
+migration's red).
+
+## Blockers
+
+None for the deliverable. Full-module green is blocked by #7060's in-flight
+migration, which is a separate issue's responsibility.


### PR DESCRIPTION
This PR adds two cap-specialized pointwise auxiliary bound wrappers to `HexBerlekampZassenhausMathlib/Recovery.lean`, completing the residual of #6787 (BHKS D1). Both are thin delegations to the generic analytic lemmas landed in https://github.com/kim-em/hex/pull/6823 (`ExecutableBadVectorWitness.projectedVectorArray_sq_le_of_sum_le` and `BHKS.correctionWeighted_sq_le_of_coeff_sq_le`), adapting them to the exact hypothesis shapes consumed by `FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBounds*`: `projectedVector_sq_le_cutRadiusSq4` fixes `vectorSquareBound := cutRadiusSq4`, and `correctionWeighted_le_mul_pow` fixes `correctionWeightedBound := D * p^(2k)`. The change is purely additive (no executable definitions touched; no `sorry`/`axiom`/`native_decide`).

Verification note: `lake build HexBerlekampZassenhausMathlib.Recovery` does not go fully green, but the only 6 errors are **pre-existing and unrelated**, at lines 1139-2180 (byte-identical on `origin/main`; this diff is a single additive hunk at line 4417). They are the recovery-direction proofs left red by the in-flight partial migration #7060 ("partially migrate fast BHKS to monic lift"): `unfold ... scaledLiftedFactorProduct` failures, an application type mismatch, and a 200k-heartbeat timeout in `factorFast_ne_none_of_forwardInputs_on_schedule` that cascades to an unknown-constant kernel error. None reference the new lemmas, and fixing them is #7060's responsibility, not this issue's.

The two additions themselves elaborate cleanly: a temporary `#check` probe (since removed) printed both full types past the pre-existing errors, confirming elaboration reaches the new code and both theorems typecheck. `Basic.lean` — the dependency named by #6824's blockers #7036/#7037 — builds green on a clean tree. `scripts/check_dag.py` exits 0 and `git diff --check` is clean.

Closes #6824.

🤖 Prepared with Claude Code