### PR TITLE
feat: HexMatrix Basic.lean Phase 6 docstrings for matrix-slice entry simp lemmas

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -614,6 +614,10 @@ def leadingRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
     let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
     M[ii][j]
 
+/-- Entry formula for the `k × k` leading prefix: the `(i, j)` entry resolves to
+the source entry `M[i][j]` at the same coordinates, reembedded into `Fin n`. This
+is the `simp` normalization that rewrites a prefix lookup back to a source lookup
+in determinant expansions. -/
 @[simp] theorem leadingPrefix_entry (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
     (i j : Fin k) :
     (leadingPrefix M k hk)[i][j] =
@@ -622,6 +626,10 @@ def leadingRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
        M[ii][jj]) := by
   simp [leadingPrefix, ofFn]
 
+/-- Entry formula for the first-`k`-rows slice: the `(i, j)` entry resolves to the
+source entry `M[i][j]` with the row index reembedded into `Fin n` and the column
+index `j` retained unchanged. This is the `simp` normalization a determinant
+expansion relies on to rewrite a row-slice lookup back to a source lookup. -/
 @[simp] theorem leadingRows_entry (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) (j : Fin m) :
     (leadingRows M k hk)[i][j] =
@@ -629,6 +637,10 @@ def leadingRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
        M[ii][j]) := by
   simp [leadingRows, ofFn]
 
+/-- Entry formula for the `(k + 1)` leading submatrix: the `(i, j)` entry resolves
+to the source entry `M[i][j]` at the same coordinates, reembedded into `Fin n` via
+`k.val + 1 ≤ n`. This is the `simp` normalization that rewrites a submatrix lookup
+back to a source lookup in determinant expansions. -/
 @[simp] theorem submatrix_entry (M : Matrix R n n) (k : Fin n)
     (i j : Fin (k.val + 1)) :
     (submatrix M k)[i][j] =
@@ -666,6 +678,10 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
         j
     M[rr][cc]
 
+/-- Interior-block case of the bordered-minor entry formula: when both `r.val < k`
+and `c.val < k`, the `(r, c)` entry resolves to the source entry `M[r][c]` at the
+reembedded leading-block coordinates, independent of the border row `i` and column
+`j`. This is the `simp` normalization for the top-left `k × k` block. -/
 @[simp] theorem borderedMinor_entry_lt_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (r c : Fin (k + 1)) (hr : r.val < k) (hc : c.val < k) :
     (borderedMinor M k hk i j)[r][c] =
@@ -674,6 +690,10 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
        M[rr][cc]) := by
   simp [borderedMinor, ofFn, hr, hc]
 
+/-- Border-column case of the bordered-minor entry formula: at the final column
+`Fin.last k` with `r.val < k`, the `(r, last)` entry resolves to the source entry
+`M[r][j]`, taking the border column `j` and the reembedded leading-block row. This
+is the `simp` normalization for the appended border column. -/
 @[simp] theorem borderedMinor_entry_lt_last (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (r : Fin (k + 1)) (hr : r.val < k) :
     (borderedMinor M k hk i j)[r][Fin.last k] =
@@ -681,6 +701,10 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
        M[rr][j]) := by
   simp [borderedMinor, ofFn, hr]
 
+/-- Border-row case of the bordered-minor entry formula: at the final row
+`Fin.last k` with `c.val < k`, the `(last, c)` entry resolves to the source entry
+`M[i][c]`, taking the border row `i` and the reembedded leading-block column. This
+is the `simp` normalization for the appended border row. -/
 @[simp] theorem borderedMinor_entry_last_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (c : Fin (k + 1)) (hc : c.val < k) :
     (borderedMinor M k hk i j)[Fin.last k][c] =
@@ -688,6 +712,10 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
        M[i][cc]) := by
   simp [borderedMinor, ofFn, hc]
 
+/-- Corner case of the bordered-minor entry formula: at the bottom-right corner
+`(Fin.last k, Fin.last k)`, the entry resolves to the source entry `M[i][j]` formed
+from the border row `i` and border column `j`. This is the `simp` normalization for
+the corner that a determinant expansion isolates last. -/
 @[simp] theorem borderedMinor_entry_last_last (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) :
     (borderedMinor M k hk i j)[Fin.last k][Fin.last k] = M[i][j] := by

--- a/progress/20260614T084305Z_be2456c2.md
+++ b/progress/20260614T084305Z_be2456c2.md
@@ -1,0 +1,53 @@
+# Progress — 2026-06-14 (work/feature session, #6949 + #7098)
+
+## Accomplished
+
+**#6949 (CLD resultant valuation into BadVector bridge) — diagnosed unsound,
+skipped.** Premise-checked the directive end-to-end before writing code. The
+proposed route (deliverable-1 identification `aux ≡ cldQuotientMod_q (mod p^k)`
+→ deliverable-3 via `cld_syzygy_pow_dvd_resultant_of_congr`) cannot close:
+
+- `W.auxiliaryPolynomial` is the **cut, down-scaled** CLD short vector, not
+  `cldQuotientMod`. `cldCoeffs[j] = psiCut p a ℓ_j (cldQuotientMod.coeff j)`
+  divides by `p^{ℓ_j}` (`Basic.lean:4588,4617,4750`), so even for the single
+  selected factor `e_{i₀}` with no corrections, `aux ≢ cldQuotientMod_{i₀}
+  (mod p^k)`. Deliverable 1 asks to prove a false statement.
+- The #7075 producer concludes `p^(k·d) ∣ Res(input, cldQuotientMod_q)` — the
+  wrong polynomial. `auxCutBridge` is coefficient-level, not a polynomial
+  syzygy for the cut combination, so it doesn't feed the producer either.
+- The clause is needed for arbitrary bad vectors (`bad_setup_of_projected_not_indicator
+  : ∀ v, …`, `BadVector.lean:1537`), not a single basis vector.
+
+Posted full evidence as a comment and `coordination skip`-ed → `replan`. The
+genuine remaining math is a resultant valuation for the cut/scaled CLD short
+vector, not a wiring of the existing producer.
+
+**#7098 (HexMatrix/Basic.lean Phase 6 docstrings) — completed.** Added `/-- … -/`
+docstrings to the seven public `@[simp]` entry-characterization theorems:
+`leadingPrefix_entry`, `leadingRows_entry`, `submatrix_entry`, and the four
+`borderedMinor_entry_*` cases (lt_lt / lt_last / last_lt / last_last). Each
+states which source entry the slice resolves to and the `simp` normalization
+role, matching the already-documented `submatrix_eq_leadingPrefix` sibling
+style. Docstrings only: 28 insertions, 0 deletions.
+
+## Current frontier
+
+`HexMatrix/Basic.lean` slice-constructor entry lemmas are now fully documented.
+
+## Next step
+
+#6949 awaits a re-authored directive whose deliverable 1 is the correct lever
+(resultant valuation for the cut/scaled CLD combination). No further HexMatrix
+docstring work outstanding from this issue.
+
+## Blockers
+
+None for #7098. #6949 is blocked on a corrected directive premise (not a code
+dependency).
+
+## Verification (#7098)
+
+- `lake build HexMatrix` clean (389 jobs, no new warnings)
+- `python3 scripts/check_dag.py` exits 0
+- `git diff --numstat`: 28/0 (insertions only); `git diff --check` clean
+- No sorry/axiom/native_decide/em-dash on added lines


### PR DESCRIPTION
Closes #7098

Session: `be2456c2-42de-4be8-abd8-509d3d955e0d`

46304f9d feat: HexMatrix Basic.lean Phase 6 docstrings for matrix-slice entry simp lemmas (#7098)

🤖 Prepared with Claude Code