### PR TITLE
doc: record #7110 premise diagnosis and set_option placement gotcha

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -206,11 +206,18 @@ restructure around the reported line first; it is usually a cheap `omega` or
 `exact` that simply ran last.
 
 - First remedy: `set_option maxHeartbeats 400000 in` on the declaration (the
-  common Mathlib value; raise further only if needed). Once the budget is large
-  enough, the *real* error often surfaces (e.g. an inline `by omega` whose
-  target type wasn't yet determined because it sat under `lt_of_le_of_lt _ (by
-  omega)` — fix by giving the bound an explicitly-typed `have h2 : … := by
-  omega` so its goal is fully concrete before `omega` runs).
+  common Mathlib value; raise further only if needed). Place the
+  `set_option … in` **before** the `/-- … -/` docstring, not between the
+  docstring and the `theorem` — the docstring binds to the declaration, so
+  splitting them gives `unexpected token 'set_option'; expected 'lemma'`. Once
+  the budget is large enough, the *real* error often surfaces (e.g. an inline
+  `by omega` whose target type wasn't yet determined because it sat under
+  `lt_of_le_of_lt _ (by omega)` — fix by giving the bound an explicitly-typed
+  `have h2 : … := by omega` so its goal is fully concrete before `omega` runs).
+  A timeout can also mask a genuine type mismatch the unifier is churning on
+  (e.g. `isDefEq` trying to unify two distinct `LiftData`s over large terms);
+  raising the budget lets the real `Application type mismatch` appear, so don't
+  assume a timeout means "just needs more heartbeats."
 - Keep the capstone thin: factor heavy sub-steps (column-formula computations,
   `repr` evaluations) into their own lemmas. Each gets a fresh budget, and the
   capstone only pays for delegating.

--- a/progress/20260614T092454Z_ab8baa32.md
+++ b/progress/20260614T092454Z_ab8baa32.md
@@ -1,0 +1,58 @@
+# Diagnosis of #7110: scale→dilate propagation premise is wrong
+
+session type: feature (#7110, skipped → replan)
+
+## Accomplished
+Premise-checked #7110 ("propagate scale→dilate recovery remodel into
+Recovery.lean and IntReductionMod.lean") against the live build on the same
+`47feec12` baseline. Reproduced the 7 errors, then traced each to root cause
+and found the issue's premise materially wrong in three ways. Posted a
+detailed evidence comment
+(https://github.com/kim-em/hex/issues/7110#issuecomment-4701322596) and
+`coordination skip`ped the issue for re-scoping. No Lean changed (the one
+experimental `maxHeartbeats` edit was reverted); the diagnosis is the
+deliverable, per `.claude/CLAUDE.md` "Directives are hypotheses".
+
+## Key findings
+- The 7 errors are **two independent migrations**, not one scale→dilate
+  propagation:
+  1. **scale→dilate** (stated scope): Recovery 1139/1235/1844,
+     IntReductionMod 4097.
+  2. **henselLiftData→toMonicLiftData** transport:
+     `factorFast_ne_none_of_forwardInputs_on_schedule` (Recovery 2137) builds
+     `hrecover` at `henselLiftData` but the executable
+     `factorFast_ne_none_of_core_recovery_on_schedule` (Basic 7708) now
+     expects `toMonicLiftData` (distinct `LiftData` defs at Basic 2707 vs
+     6778).
+- The 2131/2167 timeout + 2180 unknown-constant are a **cascade** of group 2,
+  not separate #6454 factorFast-termination work as the issue guessed:
+  `isDefEq` churns unifying the two `LiftData`s until heartbeats exhaust;
+  the theorem never enters the env so the next decl can't find it. Bumping
+  `maxHeartbeats` to 4000000 replaces the timeout with the real
+  `Application type mismatch` (henselLiftData vs toMonicLiftData) and 2180
+  vanishes.
+- `productCongruence_of_representsIntegerFactorAtLift` (Recovery 1225) is
+  **unsound as stated** against the new `RecoveredAtLift` predicate: it
+  concludes a `scale`-based reduceModPow congruence, but `scale c p`
+  (coeff `c·pₙ`, Operations 21) ≠ `dilate c p` (coeff `cⁿ·pₙ`, coeff_dilate
+  HexPolyZ/Basic 70; dilate docstring says so explicitly). Must be removed +
+  rerouted to the dilate chain, not patched.
+
+## Current frontier
+#7110 is `replan`. The scale-model chain (productCongruence* →
+ofMignottePrecision*AtPrecisionForCoeffBound) feeds the alternate assembly
+entry points at Recovery 3642/4050, which are NOT on the main `ofCapSeparation`
+path (that routes through `ofIndicatorCandidateFacts`, Recovery 1888).
+
+## Next step
+A planner re-scopes into: (a) scale→dilate removal/reroute across Recovery +
+IntReductionMod 4097 (with the `content (dilate (lc f) monicFactor) = 1` gap
+and the public-signature ripple from 3642/4050 called out); (b) the
+henselLiftData→toMonicLiftData transport, gated on confirming the
+`toMonicLiftData` producer exists (boundary skill flags it as one of "the big
+three with no producer").
+
+## Blockers
+None for the diagnosis. The remodel itself is blocked on the two re-scoped
+issues; group (b) may be further blocked on missing `toMonicLiftData`
+transport infrastructure.


### PR DESCRIPTION
This PR records the diagnosis of issue https://github.com/kim-em/hex/issues/7110 ("propagate scale→dilate recovery remodel into Recovery.lean and IntReductionMod.lean") and adds a boundary-skill note that prevented re-deriving it. It does not close #7110, which has been skipped to `replan`: the premise check found the issue bundles two independent migrations (scale→dilate and henselLiftData→toMonicLiftData), misattributes the `2180` unknown-constant to separate #6454 work when it is a timeout cascade, and frames `productCongruence_of_representsIntegerFactorAtLift` as a token-swap when it is unsound-as-stated against the new dilate-model predicate. The full evidence is in the issue comment; this PR carries the session progress entry plus a `hex-lean-mathlib-boundary` skill addition noting that `set_option … in` must precede the docstring and that a heartbeat timeout can mask a genuine type mismatch the unifier is churning on.

🤖 Prepared with Claude Code