### PR TITLE
doc: record #7121/#7122 scale→dilate reroute premise diagnosis

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -131,6 +131,27 @@ the new `RecoveredAtLift.dilate_eq` carries no `normalizeFactorSign`, so a
 `0 < leadingCoeff factor` conclusion is only valid for sign-normalised factors —
 the consumer must gain `hfactor_norm`, which callers do supply.
 
+When you reroute the broken scale-model consumers off the removed scale
+congruence, **do not target the `hdilated` exact-equality chain**
+(`candidatesOfDilatedCenteredLift` / `ofMignottePrecisionCandidateProducts`),
+even though the issue body may name it. That chain's `hdilated` wants the
+*exact* `dilate (lc f) (centeredLiftPoly …) = expectedFactor` with **no**
+`primitivePart`, but `RecoveredAtLift.dilate_eq` only ever gives the
+`primitivePart (dilate (lc core) monicFactor) = factor` form, and that
+`primitivePart` is load-bearing: `coeff_dilate` is `coeff n = c^n · p.coeff n`
+(`HexPolyZ/Basic.lean:70`), so `dilate 4 (x+2) = 4·x + 2` has `content = 2`.
+Hence `content (dilate (lc core) monicFactor) = 1` is **false** whenever
+`leadingCoeff core` is a non-unit — i.e. the generic non-monic-core regime the
+monic transform exists for. Reroute to the primitivePart-aware
+`liftedRecoveryCandidate` / `RecoveredAtLift.candidate_eq_of_monic_dvd`
+(`Basic.lean:2781`) path instead. And note the linchpin: there is **no base
+`RecoveredAtLift` producer** built from a successful `bhksIndicatorCandidate?`
+(every theorem concluding `RepresentsIntegerFactorAtLift` is a packer or
+hypothesis-consumer); constructing one — the `dilate_eq`/`monic_dvd` carrier
+from the executable candidate — is the monic-transform recovery direction owned
+by the fast-BHKS-monic-lift migration issue, so a scale→dilate consumer reroute
+is blocked on that producer landing first.
+
 ### "Final integration" issues: confirm the substrate *producer* exists, not just that the feeder issue closed
 
 A `feature` issue that says "instantiate `SlowPathHenselSubstrate` / `…Evidence`

--- a/progress/20260614T095420Z_b16b98ff.md
+++ b/progress/20260614T095420Z_b16b98ff.md
@@ -1,0 +1,68 @@
+# Session b16b98ff — premise-check of the scale→dilate recovery remodel (#7121)
+
+## Accomplished
+
+- Triaged the unclaimed queue. #2564 (directive) is `blocked`; #7120 was
+  claimed by another agent mid-session. Claimed #7121.
+- Routed #7122 (henselLiftData→toMonicLiftData transport) to `depends-on: #7044`
+  with an evidence comment: `toMonicLiftData core B = henselLiftData
+  (toMonic core).monic (precisionForCoeffBound B p) p`, so the transport needs a
+  `bhksRecover?`-at-`toMonicLiftData` producer that does not exist — it is the
+  in-flight #7044 monic-transform recovery remodel.
+- Established the Recovery.lean baseline on origin/main (`lake exe cache get`
+  then module build). Confirmed RED with two independent error groups:
+  - #7121 (scale→dilate): 1139 (producer `unfold scaledLiftedFactorProduct`
+    fails), 1235 (unsound `productCongruence_of_representsIntegerFactorAtLift`
+    `unfold` fails), 1844 (chain type mismatch).
+  - #7122 (henselLiftData→toMonicLiftData): 2131/2167 heartbeat timeout, 2180
+    kernel "unknown constant" cascade.
+  So even a perfect #7121 fix cannot turn the module green — the #7122 group
+  remains (correctly out of scope, blocked on #7044).
+- Premise-checked #7121 and found it blocked on #7044 plus a mis-stated reroute
+  target. Posted the diagnosis and released the claim.
+
+## Premise-check findings on #7121
+
+1. **No base `RecoveredAtLift` producer exists.** `RepresentsIntegerFactorAtLift`
+   is now `Nonempty (RecoveredAtLift …)`. Every theorem concluding it (Basic.lean
+   2327 `ofRecovered`, 2428/2505/… combinators) either packs an existing carrier
+   or takes the predicate as a hypothesis. The only producer-from-candidate is
+   the broken `bhksIndicatorCandidate?_representsIntegerFactorAtLift`
+   (Recovery.lean:1125). Re-proving it requires constructing the carrier's
+   `dilate_eq` (`primitivePart (dilate (lc core) monicFactor) = factor`) and
+   `monic_dvd` (`monicFactor ∣ (toMonic core).monic`) from the executable
+   candidate — the monic-transform recovery direction owned by in-flight #7044.
+
+2. **The issue's proposed reroute target is mismatched.** The issue says reroute
+   consumers to `candidatesOfDilatedCenteredLift` / `ofMignottePrecisionCandidateProducts`,
+   whose `hdilated` wants the EXACT equality `dilate (lc f) (centeredLiftPoly …)
+   = expectedFactor` (no primitivePart). But `RecoveredAtLift.dilate_eq` gives
+   only the `primitivePart` form, and that primitivePart is load-bearing:
+   `coeff_dilate` is `coeff n = c^n · p.coeff n`, so `dilate 4 (x+2) = 4x+2` has
+   `content = 2`. Hence `content (dilate (lc core) monicFactor) = 1` is FALSE
+   whenever `lc core` is a non-unit (the generic non-monic-core regime). The
+   correct reroute target is the primitivePart-aware `liftedRecoveryCandidate` /
+   `RecoveredAtLift.candidate_eq_of_monic_dvd` path, not the `hdilated` chain.
+
+## Current frontier
+
+#7121 released (blocked on #7044). #7122 blocked on #7044. Both wait on the
+monic-transform recovery producer landing in #7044.
+
+## Next step
+
+When #7044 lands a base `RecoveredAtLift` producer from a successful
+`bhksIndicatorCandidate?`, #7121 becomes: (a) re-prove the producer at
+Recovery.lean:1125 via `ofRecovered`, (b) remove the unsound
+`productCongruence_of_representsIntegerFactorAtLift`, (c) reroute the
+canonical-support chain (1246/1276/1306) and entry points (3580/3657/4017/4069
+plus the 6602-6826 cluster, 4098) to the primitivePart-aware recovery path, and
+(d) handle the IntReductionMod `scaled_recovery_of_bound` field (executable-
+coupled). This is a multi-PR remodel with no intermediate green state for
+Recovery.lean while #7122's group is also open.
+
+## Blockers
+
+#7121 and #7122 both blocked on #7044 (claimed, in-flight). No code landed —
+this session is a premise diagnosis per the CLAUDE.md "directives are
+hypotheses" rule and the hex-lean-mathlib-boundary skill.


### PR DESCRIPTION
This PR records the premise diagnosis of https://github.com/kim-em/hex/issues/7121 ("fix: remove unsound scale congruence and reroute recovery consumers to the dilate model") and https://github.com/kim-em/hex/issues/7122 ("fix: transport factorFast schedule recovery from henselLiftData to toMonicLiftData"), and adds a `hex-lean-mathlib-boundary` skill note that would have prevented re-deriving the dead end. It closes neither issue: both are now `depends-on: #7044` (the in-flight monic-transform recovery migration) and blocked.

The baseline (`lake exe cache get` then `lake build HexBerlekampZassenhausMathlib.Recovery` on clean origin/main) confirms Recovery.lean is red with two independent groups — scale→dilate (`1139`/`1235`/`1844`, #7121) and henselLiftData→toMonicLiftData (`2131`/`2167`/`2180`, #7122) — so neither fix can reach a green module while the other group is open. Both groups bottom out on the same missing substrate: there is no base `RecoveredAtLift` producer constructed from a successful `bhksIndicatorCandidate?`, which is the monic-transform recovery direction owned by #7044. The diagnosis also corrects #7121's proposed reroute target: the `hdilated` exact-equality chain is incompatible with `RecoveredAtLift.dilate_eq`'s load-bearing `primitivePart` (`content (dilate (lc core) g) = 1` is false for non-unit `lc core`; `dilate 4 (x+2) = 4x+2` has content 2), so consumers must reroute to the primitivePart-aware `liftedRecoveryCandidate` / `candidate_eq_of_monic_dvd` path. Full evidence is in the issue comments; this PR carries the session progress entry plus the skill addition. No Lean changed; no sorry/axiom introduced.

🤖 Prepared with Claude Code