### PR TITLE
fix: revert #7100 bad-vector resultant bridge to an honest assumption

### DIFF
--- a/HexBerlekampZassenhausMathlib/BadVector.lean
+++ b/HexBerlekampZassenhausMathlib/BadVector.lean
@@ -1286,35 +1286,20 @@ structure BadVectorBridgeData
       (W.inputPolynomial.map (Int.castRingHom ℚ))
       (W.auxiliaryPolynomial.map (Int.castRingHom ℚ))
   /--
-  The selected lifted factor is monic after transport to Mathlib polynomials.
+  BHKS Lemma 3.2 modular divisibility clause: the resultant of the input and the
+  cut, down-scaled CLD auxiliary polynomial is divisible by `p ^ (k * d)`.
+
+  This is an honest assumed field. A genuine resultant valuation for the cut
+  auxiliary polynomial is still open: the single-factor CLD syzygy
+  `H · g ≡ input · g' (mod p^k)` that would discharge it is unsatisfiable in the
+  bad-vector regime (the cut zeroes the leading CLD coefficient, which the monic
+  quotient needs to be a unit, and `corrections` shift only by multiples of
+  `p^(k-ℓ_j)`), so the bound is carried as a named hypothesis rather than derived
+  through that dead route.
   -/
-  selectedLiftedFactor_monic :
-    (HexPolyMathlib.toPolynomial W.selectedLiftedFactor).Monic
-  /--
-  The executable local-factor degree agrees with the transported selected
-  lifted factor's Mathlib degree.
-  -/
-  selectedLiftedFactor_natDegree :
-    (HexPolyMathlib.toPolynomial W.selectedLiftedFactor).natDegree =
-      W.localFactorDegree
-  /--
-  The witness auxiliary polynomial satisfies the selected-factor CLD syzygy
-  modulo the Hensel precision.
-  -/
-  auxiliary_selected_congr :
-    Hex.ZPoly.congr (W.H * W.selectedLiftedFactor)
-      (W.input * Hex.DensePoly.derivative W.selectedLiftedFactor)
-      (W.liftData.p ^ W.liftData.k)
-  /--
-  Degree room for the input side of the CLD resultant valuation.
-  -/
-  input_degree_bound :
-    2 * W.localFactorDegree ≤ W.inputPolynomial.natDegree
-  /--
-  Degree room for the auxiliary side of the CLD resultant valuation.
-  -/
-  auxiliary_degree_bound :
-    2 * W.localFactorDegree ≤ W.auxiliaryPolynomial.natDegree + 1
+  resultant_divisible_by_p_pow :
+    ((W.liftData.p ^ (W.liftData.k * W.localFactorDegree) : Nat) : ℤ) ∣
+      Polynomial.resultant W.inputPolynomial W.auxiliaryPolynomial
 
 namespace BadVectorBridgeData
 
@@ -1540,35 +1525,7 @@ theorem resultant_divisible_by_p_pow_of_bridge_data
     (D : BadVectorBridgeData W trueSupports) :
     ((W.liftData.p ^ (W.liftData.k * W.localFactorDegree) : Nat) : ℤ) ∣
       Polynomial.resultant W.inputPolynomial W.auxiliaryPolynomial := by
-  have hdvd : Polynomial.C ((W.liftData.p ^ W.liftData.k : Nat) : ℤ) ∣
-      (HexPolyMathlib.toPolynomial (W.H * W.selectedLiftedFactor)
-        - HexPolyMathlib.toPolynomial
-          (W.input * Hex.DensePoly.derivative W.selectedLiftedFactor)) := by
-    rw [Polynomial.C_dvd_iff_dvd_coeff]
-    intro j
-    rw [Polynomial.coeff_sub, HexPolyMathlib.coeff_toPolynomial,
-      HexPolyMathlib.coeff_toPolynomial]
-    exact Int.dvd_of_emod_eq_zero (D.auxiliary_selected_congr j)
-  obtain ⟨z, hz⟩ := hdvd
-  have hsyz :
-      HexPolyMathlib.toPolynomial W.H * HexPolyMathlib.toPolynomial W.selectedLiftedFactor
-        - HexPolyMathlib.toPolynomial W.input
-          * Polynomial.derivative (HexPolyMathlib.toPolynomial W.selectedLiftedFactor)
-        = Polynomial.C ((W.liftData.p ^ W.liftData.k : Nat) : ℤ) * z := by
-    rw [← HexPolyMathlib.toPolynomial_mul, ← HexPolyMathlib.toPolynomial_derivative,
-      ← HexPolyMathlib.toPolynomial_mul]
-    exact hz
-  simpa [inputPolynomial, auxiliaryPolynomial] using
-    cld_syzygy_pow_dvd_resultant
-      (HexPolyMathlib.toPolynomial W.input)
-      (HexPolyMathlib.toPolynomial W.H)
-      (HexPolyMathlib.toPolynomial W.selectedLiftedFactor)
-      z
-      D.selectedLiftedFactor_monic
-      D.selectedLiftedFactor_natDegree
-      hsyz
-      D.input_degree_bound
-      D.auxiliary_degree_bound
+  exact D.resultant_divisible_by_p_pow
 
 /--
 Forget the project-level bridge data to the compact callback package consumed

--- a/progress/20260614T112359Z_02cf9e99.md
+++ b/progress/20260614T112359Z_02cf9e99.md
@@ -1,0 +1,63 @@
+# 20260614T112359Z — feature session (02cf9e99)
+
+Issue #7120: resultant valuation for the cut CLD short-vector aux polynomial
+(decide #7100 field fate, re-derive exponent).
+
+## Accomplished
+
+- **Premise check (verified independently, not just trusted from #7116/#7109).**
+  - `BadVectorBridgeData` is only ever consumed as a parameter; it is never
+    constructed with fields discharged anywhere in the library.
+  - `auxiliary_selected_congr` appears at exactly two sites: its declaration
+    (`BadVector.lean:1304`) and its single consumption in
+    `resultant_divisible_by_p_pow_of_bridge_data` (`:1551`). No producer.
+  - The five fields #7100 added (`selectedLiftedFactor_monic`,
+    `selectedLiftedFactor_natDegree`, `auxiliary_selected_congr`,
+    `input_degree_bound`, `auxiliary_degree_bound`) are used only inside that one
+    theorem, so the revert is fully isolated.
+  - Read `auxiliaryPolynomialWithCorrections` (`BadVector.lean:300`): the cut
+    coefficient is `cldSum_j - corrections_j · p^(k-ℓ_j)`, confirming corrections
+    shift only the top bits by multiples of `p^(k-ℓ_j)`. The monic CLD quotient
+    needs a unit leading coefficient that the cut zeroes, so the syzygy
+    `H·g ≡ input·g' (mod p^k)` is unsatisfiable in the bad-vector regime.
+
+- **Field-fate decision executed (deliverable 1):** reverted #7100's restructure.
+  Restored the single honest `resultant_divisible_by_p_pow` field on
+  `BadVectorBridgeData`; `resultant_divisible_by_p_pow_of_bridge_data` now
+  projects it (`exact D.resultant_divisible_by_p_pow`) instead of deriving it
+  through the dead/vacuous `auxiliary_selected_congr` syzygy. Net −57/+14.
+
+- Established a clean-tree baseline first (the Mathlib layer is not CI-built):
+  unmodified `BadVector` builds green. After the change and a rebase onto latest
+  `origin/main` (#7124 etc. had merged mid-session),
+  `lake build HexBerlekampZassenhausMathlib.BadVector` is green, `check_dag.py`
+  passes, diff is `sorry`/`axiom`/`native_decide`-free.
+
+## Current frontier
+
+The genuine resultant valuation for the cut, down-scaled CLD aux polynomial
+(the headline deliverable) is **not** delivered — it is research-level. The
+clean `k·d` exponent is not establishable via any in-library route for the cut
+aux in the bad-vector regime (syzygy route dead by the leading-coefficient
+obstruction; the per-coordinate `p^(ℓ_j)` weight is not a column scaling
+reachable by `colReduceTransform`/`pow_dvd_resultant_of_sylvester_cols`). I did
+not invent a corrected closed-form exponent.
+
+## Next step
+
+A fresh research issue for the genuine valuation: either a determinant/Newton-
+polygon identity tying `Res(input, H)` to the lattice valuation under the
+per-coordinate cut, or sourcing the bound from the van Hoeij correspondence.
+Neither candidate route is a token-swap.
+
+## Blockers
+
+None for the landed change. The genuine valuation is blocked on new mathematics,
+not on infrastructure.
+
+## Note
+
+`Recovery.lean` is red on main from a separate mid-flight migration
+(`factorFast_ne_none_of_forwardInputs_on_schedule` unknown constant, the #7122
+group named in #7121's body) — pre-existing, unrelated to this change, and not in
+#7120's verification list.


### PR DESCRIPTION
This PR reverts #7100's `BadVectorBridgeData` restructure back to a single honest, named `resultant_divisible_by_p_pow` assumption, and proves `resultant_divisible_by_p_pow_of_bridge_data` by projecting it instead of "deriving" it through the assumed `auxiliary_selected_congr` CLD syzygy field. That field has no producer anywhere in the library and is unsatisfiable in the bad-vector regime it is needed for: `auxiliaryPolynomialWithCorrections` cuts the leading CLD coefficient to zero while the monic quotient requires it to be a unit, and `corrections` shift only by multiples of `p^(k-ℓ_j)`, so `H·g ≡ input·g' (mod p^k)` is impossible for every `vec` and every `corrections` array. A visibly-unproven named assumption is preferable to one buried in a vacuous "derived" field while the genuine BHKS Lemma 3.2 valuation for the cut, down-scaled CLD auxiliary polynomial remains open.

This is the deliverable-1 ("decide #7100 field fate") half of #7120; the genuine resultant valuation (re-derive the exponent, select a route surviving the cut) is research-level and left for a fresh issue, so this PR is partial. See the premise-check findings on #7120 for the full diagnosis.

`lake build HexBerlekampZassenhausMathlib.BadVector` is green (clean-tree baseline established first, since this layer is not CI-built) and `python3 scripts/check_dag.py` passes.

🤖 Prepared with Claude Code