### PR TITLE
fix: rebuild bhksIndicatorCandidate?_representsIntegerFactorAtLift as a RecoveredAtLift witness

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -144,13 +144,26 @@ Hence `content (dilate (lc core) monicFactor) = 1` is **false** whenever
 `leadingCoeff core` is a non-unit — i.e. the generic non-monic-core regime the
 monic transform exists for. Reroute to the primitivePart-aware
 `liftedRecoveryCandidate` / `RecoveredAtLift.candidate_eq_of_monic_dvd`
-(`Basic.lean:2781`) path instead. And note the linchpin: there is **no base
-`RecoveredAtLift` producer** built from a successful `bhksIndicatorCandidate?`
-(every theorem concluding `RepresentsIntegerFactorAtLift` is a packer or
-hypothesis-consumer); constructing one — the `dilate_eq`/`monic_dvd` carrier
-from the executable candidate — is the monic-transform recovery direction owned
-by the fast-BHKS-monic-lift migration issue, so a scale→dilate consumer reroute
-is blocked on that producer landing first.
+(`Basic.lean:2781`) path instead. Note the linchpin: the base `RecoveredAtLift`
+producer from a successful `bhksIndicatorCandidate?` is the carrier the whole
+reroute consumes. For the **monic-core** case it now exists and compiles —
+`bhksIndicatorCandidate?_representsIntegerFactorAtLift` (`Recovery.lean:1125`,
+landed by #7121 deliverable 1 / PR #7196): with `leadingCoeff core = 1` it sets
+`monicFactor := candidate` and closes all four fields from
+`bhksIndicatorCandidate?_reduceModPow_eq_of_monic` (`congr`, via `scale 1 = id`),
+`dilate_one` + `Hex.bhksIndicatorCandidate?_primitive` (`dilate_eq`), and
+`Hex.bhksIndicatorCandidate?_dvd` + `toMonic_monic_eq_core_of_leadingCoeff_eq_one`
+(`monic_dvd`). The two executable lemmas were `private`; #7196 drops that. So a
+scale→dilate **consumer** reroute is no longer blocked on a missing producer —
+it is blocked on the cascade work itself (rerouting
+`productCongruence_of_representsIntegerFactorAtLift` and the `productCongruences*`
+chain consumed at `Recovery.lean:4075`, the `hproduct`/`product_congr`
+scale-congruence in `ForwardRecoveryInputs.ofMignottePrecision…` /
+`CanonicalRecoveryInputs`, and IntReductionMod's `scaled_recovery_of_bound`, all
+of which force `hmonic_ne`/`hfactor_norm`/`hprecision` up to the top driver).
+The **non-monic-core** producer (where `primitivePart`/`dilate` do not collapse)
+is still the harder monic-transform recovery direction owned by the
+fast-BHKS-monic-lift migration issue.
 
 ### "Final integration" issues: confirm the substrate *producer* exists, not just that the feeder issue closed
 

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5466,7 +5466,7 @@ A successful BHKS indicator candidate divides `f`. The executable
 `exactQuotient? f candidate` succeeds, so the candidate is a verified
 integer divisor of `f`.
 -/
-private theorem bhksIndicatorCandidate?_dvd
+theorem bhksIndicatorCandidate?_dvd
     {f : ZPoly} {d : LiftData} {indicator : Array Int}
     {candidate quotient : ZPoly}
     (h : bhksIndicatorCandidate? f d indicator = some (candidate, quotient)) :
@@ -5567,7 +5567,7 @@ private theorem bhksIndicatorCandidate?_leadingCoeff_nonneg
 /-- A successful BHKS indicator candidate is primitive: the candidate equals
 `normalizeFactorSign (normalizeCandidateFactor _)`, and `shouldRecord = true`
 forces the inner factor to be nonzero, hence primitive. -/
-private theorem bhksIndicatorCandidate?_primitive
+theorem bhksIndicatorCandidate?_primitive
     {f : ZPoly} {d : LiftData} {indicator : Array Int}
     {candidate quotient : ZPoly}
     (h : bhksIndicatorCandidate? f d indicator = some (candidate, quotient)) :

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -1136,15 +1136,40 @@ theorem bhksIndicatorCandidate?_representsIntegerFactorAtLift
     (hp_two_lt : 2 < d.p ^ d.k) :
       RepresentsIntegerFactorAtLift core d candidate
         (liftedFactorSubsetOfMembers d members) := by
-  unfold RepresentsIntegerFactorAtLift scaledLiftedFactorProduct
-  rw [← selectedFactorsOfMembers_polyProduct d members]
-  exact bhksIndicatorCandidate?_reduceModPow_eq_of_monic h hselected hcore_monic
-    (by
-      intro factor hfactor
-      rw [selectedFactorsOfMembers_toList] at hfactor
-      rcases List.mem_map.mp hfactor with ⟨i, hi, rfl⟩
-      exact hliftedFactor_monic i (List.mem_range.mp (List.mem_filter.mp hi).1))
-    (Nat.le_of_lt hp_two_lt)
+  have hsel_monic :
+      ∀ p ∈ (selectedFactorsOfMembers d.liftedFactors members).toList,
+        Hex.DensePoly.Monic p := by
+    intro factor hfactor
+    rw [selectedFactorsOfMembers_toList] at hfactor
+    rcases List.mem_map.mp hfactor with ⟨i, hi, rfl⟩
+    exact hliftedFactor_monic i (List.mem_range.mp (List.mem_filter.mp hi).1)
+  have hlc : Hex.DensePoly.leadingCoeff core = (1 : Int) := hcore_monic
+  have hscale_one :
+      Hex.DensePoly.scale (1 : Int)
+          (Array.polyProduct (selectedFactorsOfMembers d.liftedFactors members)) =
+        Array.polyProduct (selectedFactorsOfMembers d.liftedFactors members) := by
+    apply Hex.DensePoly.ext_coeff
+    intro n
+    rw [Hex.DensePoly.coeff_scale_semiring]
+    ring
+  -- The monic-coordinate witness is the BHKS candidate itself: with a monic
+  -- core (`leadingCoeff core = 1`) the dilation collapses and the candidate is
+  -- already primitive, while the verified exact-division check gives `candidate
+  -- ∣ core = (toMonic core).monic`.
+  refine RepresentsIntegerFactorAtLift.ofRecovered ?_
+  exact
+    { monicFactor := candidate
+      congr := by
+        have h0 := bhksIndicatorCandidate?_reduceModPow_eq_of_monic h hselected
+          hcore_monic hsel_monic (Nat.le_of_lt hp_two_lt)
+        rwa [hlc, hscale_one, selectedFactorsOfMembers_polyProduct] at h0
+      dilate_eq := by
+        rw [hlc, Hex.ZPoly.dilate_one]
+        exact Hex.ZPoly.primitivePart_eq_self_of_primitive candidate
+          (Hex.bhksIndicatorCandidate?_primitive h)
+      monic_dvd := by
+        rw [Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one core hlc]
+        exact Hex.bhksIndicatorCandidate?_dvd h }
 
 /--
 The BHKS selected-factor operation succeeds on a nonempty class indicator whose

--- a/progress/2026-06-14T124535Z_4006120f.md
+++ b/progress/2026-06-14T124535Z_4006120f.md
@@ -1,0 +1,75 @@
+# 2026-06-14T12:45Z — feature/fix session (4006120f)
+
+Session type: `/work` → claimed `fix` issue #7121 (remove unsound scale
+congruence and reroute recovery consumers to the dilate model).
+
+## Accomplished
+
+Deliverable 1 of #7121: rebuilt the base producer
+`bhksIndicatorCandidate?_representsIntegerFactorAtLift`
+(`HexBerlekampZassenhausMathlib/Recovery.lean`) as a genuine `RecoveredAtLift`
+witness under the new dilate model. Commit `8b91ebc5`.
+
+Key insight: in this producer the BHKS candidate is checked against `core`
+itself (`Hex.bhksIndicatorCandidate? core d indicator = some (candidate, _)`),
+so with a monic core (`leadingCoeff core = 1`) all four `RecoveredAtLift`
+fields close from existing facts, with `monicFactor := candidate`:
+- `congr`: `bhksIndicatorCandidate?_reduceModPow_eq_of_monic` + `scale 1 = id`
+  + `selectedFactorsOfMembers_polyProduct`.
+- `dilate_eq`: `dilate_one` (monic core) + `primitivePart_eq_self_of_primitive`
+  from `Hex.bhksIndicatorCandidate?_primitive`.
+- `monic_dvd`: `Hex.bhksIndicatorCandidate?_dvd` (gives `candidate ∣ core`) +
+  `toMonic_monic_eq_core_of_leadingCoeff_eq_one`.
+
+Exposed two executable lemmas (`Hex.bhksIndicatorCandidate?_dvd`,
+`Hex.bhksIndicatorCandidate?_primitive`) by dropping `private` in
+`HexBerlekampZassenhaus/Basic.lean` — purely additive; the executable target
+rebuilds clean (exit 0).
+
+This removes one of the four failing sites the issue lists
+(`Recovery.lean:1139`). The producer compiles: a Recovery module build now
+reports its first error at `:1260` (productCongruence, below the producer),
+confirming the producer at `:1125–1175` elaborated. `check_dag` passes.
+
+## Current frontier
+
+Recovery.lean is still red (it was red on `main`). Remaining errors and owners:
+- `Recovery.lean:1260` — `productCongruence_of_representsIntegerFactorAtLift`
+  (`unfold scaledLiftedFactorProduct` fails). #7121 deliverable 2.
+- `Recovery.lean:1869` — application type mismatch at the
+  `ofMignottePrecisionCanonicalIndicatorsExpectedFactorsAtPrecisionForCoeffBound`
+  consumer. #7121 deliverable 3.
+- `IntReductionMod.lean` `scaled_recovery_of_bound` field (~`:4065`). #7121
+  deliverable 4.
+- `Recovery.lean:2156/2192/2205` — heartbeat timeouts + unknown constant
+  `factorFast_ne_none_of_forwardInputs_on_schedule`. **Out of scope**: this is
+  the separate #7122 migration group (the #7121 body says so explicitly).
+
+## Next step (deliverables 2–4 — a real scale→dilate cascade)
+
+The scale-congruence model is still consumed end-to-end:
+`productCongruence_of_representsIntegerFactorAtLift` →
+`productCongruencesOfSelectedRepresentations` →
+`...CanonicalSupportRepresentations` →
+`...CanonicalSupportMemberRepresentations` (Recovery.lean ~1250–1353), which is
+used at `Recovery.lean:4075` to build the `hproduct` scale congruence fed to
+the Mignotte recovery driver, and stored as the `product_congr` field of
+`CanonicalRecoveryInputs` / `CanonicalRecoveryTailInputs` and the `hproduct`
+arg of `ForwardRecoveryInputs.ofMignottePrecision…AtPrecisionForCoeffBound`
+(Recovery.lean ~1830).
+
+Rerouting these to the primitivePart-aware path
+(`liftedRecoveryCandidate` / `RecoveredAtLift.candidate_eq_of_monic_dvd`,
+Basic.lean ~2781) forces the new hypotheses `hmonic_ne`, `hfactor_norm`,
+`hprecision` to enter at the productCongruence layer and cascade up through the
+`factorFast_ne_none_of_…` chain to the top driver at ~4075 and into
+IntReductionMod's `scaled_recovery_of_bound`. Per
+`hex-lean-mathlib-boundary` this is the recovery-direction structural remodel
+with no intermediate green state — multi-session. Do **not** target the
+`hdilated` exact-equality chain (no `primitivePart`); it is unsound for
+non-unit leading coefficients.
+
+## Blockers
+
+None for deliverable 1 (landed). Deliverables 2–4 are a multi-session cascade,
+not a token swap; marked `--partial` for planner triage.


### PR DESCRIPTION
This PR rebuilds the base producer `bhksIndicatorCandidate?_representsIntegerFactorAtLift` as a genuine `RecoveredAtLift` witness, landing deliverable 1 of #7121's scale-to-dilate recovery remodel. In this producer the BHKS candidate is checked against `core` itself, so with a monic core (`leadingCoeff core = 1`) all four `RecoveredAtLift` fields close with `monicFactor := candidate`: `congr` from `bhksIndicatorCandidate?_reduceModPow_eq_of_monic` with `scale 1 = id`; `dilate_eq` from `dilate_one` and primitivity of the candidate; `monic_dvd` from the verified exact-division divisor fact and `toMonic_monic_eq_core_of_leadingCoeff_eq_one`. It exposes the two executable lemmas `Hex.bhksIndicatorCandidate?_dvd` and `Hex.bhksIndicatorCandidate?_primitive` (dropping `private`) so the Mathlib layer can build the witness; the executable target rebuilds clean.

This is a partial completion of #7121. Deliverable 1 (the producer, previously failing at `Recovery.lean:1139`) now compiles: a `HexBerlekampZassenhausMathlib.Recovery` build reports its first error at `:1260`, below the producer at `:1125–1175`, confirming it elaborated. `scripts/check_dag.py` passes and no `sorry`/`axiom`/`native_decide` is added.

Deliverables 2-4 remain and are a genuine multi-session scale-to-dilate cascade with no intermediate green state (per the `hex-lean-mathlib-boundary` skill): `productCongruence_of_representsIntegerFactorAtLift` and its `productCongruences*` wrappers (`Recovery.lean:1250–1353`, consumed at `:4075`), the `hproduct` / `product_congr` scale-congruence carried by `ForwardRecoveryInputs.ofMignottePrecision…AtPrecisionForCoeffBound` and `CanonicalRecoveryInputs` / `CanonicalRecoveryTailInputs`, and the `scaled_recovery_of_bound` field in `IntReductionMod.lean`. Rerouting them to the primitivePart-aware `liftedRecoveryCandidate` / `RecoveredAtLift.candidate_eq_of_monic_dvd` path forces `hmonic_ne` / `hfactor_norm` / `hprecision` to cascade up to the top driver. The heartbeat-timeout / unknown-constant group around `factorFast_ne_none_of_forwardInputs_on_schedule` (`Recovery.lean:2156/2192/2205`) is the separate #7122 migration, not in scope here.

🤖 Prepared with Claude Code
