### PR TITLE
doc: HexHensel Linear.lean Phase 6 docstrings for liftScaled/mulCoeffStep divisibility and linearHenselStep product-expansion congruence cluster (batch 2)

### DIFF
--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -703,6 +703,8 @@ private theorem scale_congr_of_congr_mod_base
   change (Int.ofNat (p ^ k) * Int.ofNat p) * w = Int.ofNat (p ^ k * p) * w
   rfl
 
+/-- Any product of a coefficient of `liftScaledIncrement p k r` with a coefficient
+of `liftScaledIncrement p k hCorrection` is divisible by `p ^ (k + 1)`. -/
 private theorem liftScaledCoeff_product_dvd_next
     (p k : Nat) [ZMod64.Bounds p]
     (r hCorrection : FpPoly p) (_hk : 1 ≤ k) (i j : Nat) :
@@ -734,6 +736,8 @@ private theorem liftScaledCoeff_product_dvd_next
             Int.ofNat (p ^ k0 * (r.coeff i).toNat * (hCorrection.coeff j).toNat) := by
           grind
 
+/-- One `DensePoly.mulCoeffStep` of the two lifted-scaled increments preserves
+divisibility of the accumulator by `p ^ (k + 1)`. -/
 private theorem mulCoeffStep_liftScaled_dvd_next
     (p k : Nat) [ZMod64.Bounds p]
     (r hCorrection : FpPoly p) (_hk : 1 ≤ k)
@@ -762,6 +766,8 @@ private theorem mulCoeffStep_liftScaled_dvd_next
       _ = ((p ^ (k + 1) : Nat) : Int) * (a + c) := by grind
   · simpa [DensePoly.mulCoeffStep, hij] using hacc
 
+/-- Folding `DensePoly.mulCoeffStep` of the two lifted-scaled increments over any
+index list preserves divisibility of the accumulator by `p ^ (k + 1)`. -/
 private theorem foldl_mulCoeffStep_liftScaled_dvd_next
     (p k : Nat) [ZMod64.Bounds p]
     (r hCorrection : FpPoly p) (_hk : 1 ≤ k)
@@ -785,6 +791,8 @@ private theorem foldl_mulCoeffStep_liftScaled_dvd_next
           n i acc j)
           (mulCoeffStep_liftScaled_dvd_next p k r hCorrection _hk n i acc j hacc)
 
+/-- Folding the full nested `mulCoeffSum` of the two lifted-scaled increments over
+any index list preserves divisibility of the accumulator by `p ^ (k + 1)`. -/
 private theorem foldl_mulCoeffSum_liftScaled_dvd_next
     (p k : Nat) [ZMod64.Bounds p]
     (r hCorrection : FpPoly p) (_hk : 1 ≤ k)
@@ -822,6 +830,8 @@ private theorem foldl_mulCoeffSum_liftScaled_dvd_next
             n i)
           acc) hinner
 
+/-- The product of the two lifted-scaled increments is coefficientwise zero
+modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_product_expansion_cross_congr
     (p k : Nat) [ZMod64.Bounds p]
     (r hCorrection : FpPoly p)
@@ -839,6 +849,8 @@ private theorem linearHenselStep_product_expansion_cross_congr
     foldl_mulCoeffSum_liftScaled_dvd_next p k r hCorrection _hk i
       (List.range (LinearLiftResult.liftScaledIncrement p k r).size) 0 ⟨0, by simp⟩
 
+/-- Scaling the left factor by `c` factors that constant out of one
+`DensePoly.mulCoeffStep` when the accumulator is itself scaled by `c`. -/
 private theorem mulCoeffStep_scale_left_int
     (c : Int) (f g : ZPoly) (n i : Nat) (acc : Int) (j : Nat) :
     DensePoly.mulCoeffStep (DensePoly.scale c f) g n i (c * acc) j =
@@ -850,6 +862,8 @@ private theorem mulCoeffStep_scale_left_int
     grind
   · rw [if_neg hij, if_neg hij]
 
+/-- Scaling the left factor by `c` factors that constant out of a
+`DensePoly.mulCoeffStep` fold over any index list. -/
 private theorem foldl_mulCoeffStep_scale_left_int
     (c : Int) (f g : ZPoly) (n i : Nat) (xs : List Nat) (acc : Int) :
     xs.foldl (DensePoly.mulCoeffStep (DensePoly.scale c f) g n i) (c * acc) =
@@ -862,6 +876,8 @@ private theorem foldl_mulCoeffStep_scale_left_int
       rw [mulCoeffStep_scale_left_int]
       exact ih (DensePoly.mulCoeffStep f g n i acc j)
 
+/-- Scaling the left factor by `c` factors that constant out of the full nested
+`mulCoeffSum` fold over any index list. -/
 private theorem foldl_mulCoeffSum_scale_left_int
     (c : Int) (f g : ZPoly) (n : Nat) (xs : List Nat) (acc : Int) :
     xs.foldl
@@ -882,6 +898,7 @@ private theorem foldl_mulCoeffSum_scale_left_int
       exact ih
         ((List.range g.size).foldl (DensePoly.mulCoeffStep f g n i) acc)
 
+/-- Scaling a polynomial by a nonzero integer `c` leaves its `size` unchanged. -/
 private theorem dense_size_scale_int_of_ne_zero
     (c : Int) (hc : c ≠ 0) (f : ZPoly) :
     (DensePoly.scale c f).size = f.size := by
@@ -914,6 +931,8 @@ private theorem dense_size_scale_int_of_ne_zero
       rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)] at hscale_zero
       exact (Int.mul_ne_zero hc hf_ne) hscale_zero
 
+/-- Scaling the left factor by a nonzero integer `c` commutes with multiplication:
+`scale c f * g = scale c (f * g)`. -/
 private theorem dense_scale_mul_left_int
     (c : Int) (hc : c ≠ 0) (f g : ZPoly) :
     DensePoly.scale c f * g = DensePoly.scale c (f * g) := by
@@ -926,6 +945,8 @@ private theorem dense_scale_mul_left_int
   simpa [Zero.zero] using
     (foldl_mulCoeffSum_scale_left_int c f g n (List.range f.size) 0)
 
+/-- Scaling the right factor by a nonzero integer `c` commutes with multiplication:
+`f * scale c g = scale c (f * g)`. -/
 private theorem dense_scale_mul_right_int
     (c : Int) (hc : c ≠ 0) (f g : ZPoly) :
     f * DensePoly.scale c g = DensePoly.scale c (f * g) := by
@@ -933,6 +954,8 @@ private theorem dense_scale_mul_right_int
   rw [dense_scale_mul_left_int c hc]
   rw [DensePoly.mul_comm_poly g f]
 
+/-- Scaling by `c` distributes over addition:
+`scale c (f + g) = scale c f + scale c g`. -/
 private theorem dense_scale_add_int
     (c : Int) (f g : ZPoly) :
     DensePoly.scale c (f + g) = DensePoly.scale c f + DensePoly.scale c g := by
@@ -945,6 +968,8 @@ private theorem dense_scale_add_int
   rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
   grind
 
+/-- When the cross term is zero modulo `m`, the regrouping
+`base + a + (b + cross)` is congruent to `base + (a + b)` modulo `m`. -/
 private theorem add_cross_congr
     (m : Nat) (base a b cross : ZPoly)
     (hcross : ZPoly.congr cross 0 m) :
@@ -965,6 +990,8 @@ private theorem add_cross_congr
   rw [hdiff]
   simpa using hx
 
+/-- The product of the corrected factors is congruent modulo `p ^ (k + 1)` to
+`g * h` plus the `p ^ k`-scaled first-order term `r * h + g * hCorrection`. -/
 private theorem linearHenselStep_product_expansion_identity_congr_core
     (p k : Nat) [ZMod64.Bounds p]
     (g h : ZPoly) (r hCorrection : FpPoly p)
@@ -1005,6 +1032,8 @@ private theorem linearHenselStep_product_expansion_identity_congr_core
       (DensePoly.scale (Int.ofNat (p ^ k)) (g * FpPoly.liftToZ hCorrection))
       cross hcross
 
+/-- The same product expansion as the `_core` lemma, stated for the `let`-bound
+corrected factors `g'` and `h'`. -/
 private theorem linearHenselStep_product_expansion_identity_congr
     (p k : Nat) [ZMod64.Bounds p]
     (g h : ZPoly) (r hCorrection : FpPoly p)
@@ -1021,6 +1050,8 @@ private theorem linearHenselStep_product_expansion_identity_congr
   simpa [g', h'] using
     linearHenselStep_product_expansion_identity_congr_core p k g h r hCorrection _hk
 
+/-- The recombination `g * h + (f - g * h)` is congruent to `f` modulo
+`p ^ (k + 1)`. -/
 private theorem linearHenselStep_recombine_error_congr
     (p k : Nat) (f g h : ZPoly) :
     ZPoly.congr (g * h + (f - g * h)) f (p ^ (k + 1)) := by
@@ -1032,6 +1063,9 @@ private theorem linearHenselStep_recombine_error_congr
   rw [hzero]
   simp
 
+/-- Given the mod-`p` correction equation, the first-order term
+`r * h + g * hCorrection` is congruent modulo `p` to the coefficientwise quotient
+`(f - g * h) / p ^ k`. -/
 private theorem linearHenselStep_first_order_congr
     (p k : Nat) [ZMod64.Bounds p]
     (f g h : ZPoly) (r hCorrection : FpPoly p)
@@ -1074,6 +1108,8 @@ private theorem linearHenselStep_first_order_congr
     (ZPoly.congr_symm _ _ _ hlift)
     (ZPoly.congr_trans _ _ _ p hcorr' he)
 
+/-- If `first` is congruent to `e` modulo `p` and `p ^ k * e = f - g * h`, then
+`p ^ k * first` is congruent to `f - g * h` modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_scaled_first_order_congr
     (p k : Nat) [ZMod64.Bounds p]
     (f g h first e : ZPoly)
@@ -1087,6 +1123,8 @@ private theorem linearHenselStep_scaled_first_order_congr
   rw [← hbase]
   exact scale_congr_of_congr_mod_base p k first e _hk hfirst
 
+/-- Combining the product expansion with the scaled first-order congruence, the
+corrected factors `g'` and `h'` multiply to `f` modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_product_expansion_congr
     (p k : Nat) [ZMod64.Bounds p]
     (f g h : ZPoly) (r hCorrection : FpPoly p)
@@ -1124,6 +1162,8 @@ private theorem linearHenselStep_product_expansion_congr
     (ZPoly.congr_trans _ _ _ _
       hsum (linearHenselStep_recombine_error_congr p k f g h))
 
+/-- From a mod-`p` correction identity for `r` and `hCorrection`, the corrected
+factors `g'` and `h'` multiply to `f` modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_raw_factor_congr_from_correction
     (p k : Nat) [ZMod64.Bounds p]
     (f g h : ZPoly) (r hCorrection _e : FpPoly p)
@@ -1152,6 +1192,9 @@ private theorem linearHenselStep_raw_factor_congr_from_correction
   simpa [g', h', first] using
     linearHenselStep_product_expansion_congr p k f g h r hCorrection hk hprod hscaled
 
+/-- With Bezout cofactors `s`, `t` and a monic `g`, the linear-step corrected
+factors `g'` and `h'` built from the `divMod`-reduced correction multiply to `f`
+modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_raw_factor_congr
     (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
@@ -1188,6 +1231,8 @@ private theorem linearHenselStep_raw_factor_congr
     linearHenselStep_raw_factor_congr_from_correction
       p k f g h r hCorrection eMod hk hprod hcorr
 
+/-- The corrected factors reduced via `reduceModPow` to precision `p ^ (k + 1)`
+still multiply to `f` modulo `p ^ (k + 1)`. -/
 private theorem linearHenselStep_reduced_factor_congr
     (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
     (f g h : ZPoly) (s t : FpPoly p)
@@ -1223,6 +1268,8 @@ private theorem linearHenselStep_reduced_factor_congr
       simpa [e, gMod, hMod, eMod, qr, q, r, g', hCorrection, h'] using
         linearHenselStep_raw_factor_congr p k f g h s t hk hprod hbez hmonic)
 
+/-- Iterates `linearHenselStep` for `steps` rounds starting at precision
+`p ^ current`, returning the accumulated lifted factor pair. -/
 private def henselLiftLoop
     (p : Nat) [ZMod64.Bounds p]
     (steps current : Nat)

--- a/progress/2026-06-14T140552Z_3df94474.md
+++ b/progress/2026-06-14T140552Z_3df94474.md
@@ -1,0 +1,40 @@
+# 2026-06-14T14:05Z — work/feature session (3df94474)
+
+## Accomplished
+
+Closed #7220: added one-sentence backtick-led `/-- … -/` docstrings to
+all 23 undocumented declarations in the `HexHensel/Linear.lean`
+`liftScaled`/`mulCoeffStep` divisibility and `linearHenselStep`
+product-expansion congruence cluster (batch 2), declarations
+`liftScaledCoeff_product_dvd_next` through `henselLiftLoop`.
+
+Diff is purely additive: 47 insertions, 0 deletions, docstrings only,
+no statement/signature/proof changes. Matched batch-1 house style
+(noun-first "what", no "how", no banned vocabulary, no em-dashes).
+
+## Verification
+
+- `lake build HexHensel.Linear` green (105 jobs).
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean; numstat `47 0`.
+- No `smoke`/`gate`/`bridge`/em-dash tokens on added lines.
+
+## Current frontier
+
+The monic/degree? helper cluster below this block (`monic_g` L1271
+onward through L1646) remains undocumented and is explicitly out of
+scope for this batch; it is the candidate batch-3 issue for this file.
+
+## Next step
+
+A planner can file the batch-3 docstring issue for the
+`HexHensel/Linear.lean` monicity/degree cluster.
+
+## Blockers
+
+None.
+
+## Notes
+
+Initial claim attempts on #7188 (research) and #7217 (doc) lost claim
+races to other agents; landed on #7220.


### PR DESCRIPTION
Closes #7220

Session: `3df94474-656c-4904-9abe-22921b0a8c08`

47980e37 chore: progress entry for #7220 (3df94474)
f2d4b22d doc: HexHensel Linear.lean Phase 6 docstrings for liftScaled/mulCoeffStep divisibility and linearHenselStep product-expansion congruence cluster (batch 2) (#7220)

🤖 Prepared with Claude Code