### PR TITLE
doc: HexPolyFp Quotient.lean Phase 6 docstrings for evalCoeffPowerSum/evalScalarCoeffList fold and evalDividedDifference coefficient-power-sum cluster (batch 1)

### DIFF
--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -1444,6 +1444,8 @@ private theorem reduce_C_zero :
   rw [hC0_poly]
   rfl
 
+/-- Horner-folding the evaluation step over `n` zero coefficients scales the
+accumulator by `β ^ n`. -/
 private theorem foldl_eval_replicate_zero (β : Quotient g hmonic hg_pos) :
     ∀ n (acc : Quotient g hmonic hg_pos),
       (List.replicate n (0 : ZMod64 p)).foldl
@@ -1483,6 +1485,8 @@ private def evalScalarCoeffList :
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C coeff) +
         β * evalScalarCoeffList coeffs β
 
+/-- `β * evalCoeffPowerSumFrom coeffs base β` equals the same power sum with its
+starting exponent shifted from `base` to `base + 1`. -/
 private theorem mul_evalCoeffPowerSumFrom_eq_succ
     (β : Quotient g hmonic hg_pos) :
     ∀ coeffs base,
@@ -1515,6 +1519,8 @@ private theorem mul_evalCoeffPowerSumFrom_eq_succ
                 (DensePoly.C coeff) *
               β ^ (base + 1) := by rfl
 
+/-- `evalScalarCoeffList coeffs β` equals `evalCoeffPowerSumFrom coeffs 0 β`,
+the power sum started at exponent zero. -/
 private theorem evalScalarCoeffList_eq_powerSumFrom_zero
     (β : Quotient g hmonic hg_pos) :
     ∀ coeffs,
@@ -1530,6 +1536,8 @@ private theorem evalScalarCoeffList_eq_powerSumFrom_zero
         (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β coeffs 0]
       rw [pow_zero, mul_one]
 
+/-- The Horner left-fold over the reversed coefficient list, started at zero,
+equals `evalScalarCoeffList coeffs β` on the original order. -/
 private theorem foldl_eval_reverse_eq_evalScalarCoeffList
     (β : Quotient g hmonic hg_pos) :
     ∀ coeffs,
@@ -1551,6 +1559,8 @@ private theorem foldl_eval_reverse_eq_evalScalarCoeffList
         (g := g) (hmonic := hmonic) (hg_pos := hg_pos) coeffs β) β]
       rw [add_comm]
 
+/-- `evalCoeffList` of the per-coefficient `reduce (DensePoly.C ·)` list equals
+`evalScalarCoeffList coeffs β` on the raw scalar coefficients. -/
 private theorem evalCoeffList_map_reduce_C_eq_evalScalarCoeffList
     (β : Quotient g hmonic hg_pos) :
     ∀ coeffs,
@@ -1660,6 +1670,8 @@ theorem eval_eq_sub_mul_evalDividedDifference_of_eval_eq_zero
   rw [hα, sub_zero] at h
   exact h
 
+/-- `eval f β` equals `evalCoeffPowerSumFrom` over `f`'s stored coefficient list
+started at exponent zero. -/
 private theorem eval_eq_coeff_power_sum (f : FpPoly p)
     (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β =
@@ -1673,6 +1685,8 @@ private theorem eval_eq_coeff_power_sum (f : FpPoly p)
     (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β f.toArray.toList
 
 omit [ZMod64.PrimeModulus p] in
+/-- Default-indexing `f`'s stored coefficient list returns the coefficient
+`f.coeff n`. -/
 private theorem eval_coeff_list_getD_eq_coeff (f : FpPoly p) (n : Nat) :
     f.toArray.toList.getD n (0 : ZMod64 p) = f.coeff n := by
   unfold DensePoly.toArray DensePoly.coeff
@@ -1683,6 +1697,8 @@ private theorem eval_coeff_list_getD_eq_coeff (f : FpPoly p) (n : Nat) :
   rfl
 
 omit [ZMod64.PrimeModulus p] in
+/-- Default-indexing `(List.range bound).map coeff` at `n` returns `coeff n` when
+`n < bound` and `0` otherwise. -/
 private theorem list_getD_map_range_zmod (bound n : Nat) (coeff : Nat → ZMod64 p) :
     ((List.range bound).map coeff).getD n (0 : ZMod64 p) =
       if n < bound then coeff n else 0 := by
@@ -1691,6 +1707,8 @@ private theorem list_getD_map_range_zmod (bound n : Nat) (coeff : Nat → ZMod64
   · simp [hn, List.getD]
 
 omit [ZMod64.PrimeModulus p] in
+/-- Two `ZMod64 p` lists of equal length that agree at every default-indexed
+position are equal. -/
 private theorem list_eq_of_length_eq_of_getD_eq
     {xs ys : List (ZMod64 p)}
     (hlen : xs.length = ys.length)
@@ -1717,6 +1735,7 @@ private theorem list_eq_of_length_eq_of_getD_eq
           rw [hhead, htail]
 
 omit [ZMod64.PrimeModulus p] in
+/-- `f`'s stored coefficient list equals `(List.range f.size).map f.coeff`. -/
 private theorem toArray_toList_eq_coeff_range (f : FpPoly p) :
     f.toArray.toList = (List.range f.size).map (fun i => f.coeff i) := by
   apply list_eq_of_length_eq_of_getD_eq

--- a/progress/20260614T141154Z_9a066899.md
+++ b/progress/20260614T141154Z_9a066899.md
@@ -1,0 +1,56 @@
+# Progress 20260614T141154Z (session 9a066899)
+
+Session type: feature (Phase 6 docstrings)
+Issue: #7223 — HexPolyFp/Quotient.lean evalCoeffPowerSum / evalScalarCoeffList
+fold and evalDividedDifference power-sum cluster (batch 1).
+
+## Accomplished
+
+Added one-sentence backtick-led `/-- … -/` docstrings to the 10 undocumented
+declarations in the evaluation-as-coefficient-power-sum cluster of
+`HexPolyFp/Quotient.lean`:
+
+- `foldl_eval_replicate_zero`
+- `mul_evalCoeffPowerSumFrom_eq_succ`
+- `evalScalarCoeffList_eq_powerSumFrom_zero`
+- `foldl_eval_reverse_eq_evalScalarCoeffList`
+- `evalCoeffList_map_reduce_C_eq_evalScalarCoeffList`
+- `eval_eq_coeff_power_sum`
+- `eval_coeff_list_getD_eq_coeff`
+- `list_getD_map_range_zmod`
+- `list_eq_of_length_eq_of_getD_eq`
+- `toArray_toList_eq_coeff_range`
+
+For the four `omit [ZMod64.PrimeModulus p] in` declarations the docstring goes
+*between* the `omit … in` line and `private theorem`; a docstring placed before
+`omit` fails to parse.
+
+Of the 18 declarations listed in the issue, 8 already carried docstrings and
+were skipped per the issue instructions: `evalCoeffPowerSumFrom`,
+`evalScalarCoeffList`, `eval_eq_evalCoeffList`, `evalDividedDifference`,
+`evalDividedDifferenceCoeffs`,
+`evalDividedDifferenceCoeffs_length_lt_of_coeffs_ne_nil`,
+`eval_sub_eval_eq_sub_mul_evalDividedDifference`,
+`eval_eq_sub_mul_evalDividedDifference_of_eval_eq_zero`.
+
+## Verification
+
+- `lake build HexPolyFp.Quotient` green.
+- `python3 scripts/check_dag.py` exit 0.
+- `git diff --check` clean; diff is 19 purely-additive lines, all `/-- … -/`.
+- No banned vocabulary or em-dashes on added lines.
+
+## Current frontier
+
+Batch-1 cluster done. The `evalCoeffPowerSumUpTo` bound cluster (from L1742)
+and the `C_add_eq` C/reduce arithmetic cluster remain undocumented — left for a
+later batch-2 issue per the issue's scope note.
+
+## Next step
+
+A planner can file batch-2 for the remaining undocumented clusters in
+`HexPolyFp/Quotient.lean`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7223

Session: `9a066899-6f01-4517-8522-aaad731d52c1`

3529f4d6 doc: HexPolyFp Quotient.lean Phase 6 docstrings for coefficient-power-sum evaluation cluster (batch 1)

🤖 Prepared with Claude Code