### PR TITLE
doc: HexHensel Quadratic.lean Phase 6 docstrings for diagonalCoeffTerm fold-to-diagonal product-coefficient cluster (batch 3)

### DIFF
--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -739,9 +739,11 @@ private theorem size_le_of_coeff_zero_from
       DensePoly.coeff_last_ne_zero_of_pos_size f (by omega)
     exact False.elim (hlast_ne hlast_zero)
 
+/-- `diagonalCoeffTerm` is the index-`i` contribution `p.coeff i * q.coeff (n - i)` to the degree-`n` coefficient of `p * q`, zero when `n < i`. -/
 private def diagonalCoeffTerm (p q : ZPoly) (n i : Nat) : Int :=
   if n < i then 0 else p.coeff i * q.coeff (n - i)
 
+/-- `fold_mulCoeffStep_eq_bounded_diagonal_int` evaluates the inner `mulCoeffStep` fold over `range m` to the accumulator plus the diagonal term when `i ≤ n` and `n - i < m`, and the accumulator alone otherwise. -/
 private theorem fold_mulCoeffStep_eq_bounded_diagonal_int
     (p q : ZPoly) (n i m : Nat) (acc : Int) :
     (List.range m).foldl (DensePoly.mulCoeffStep p q n i) acc =
@@ -768,6 +770,7 @@ private theorem fold_mulCoeffStep_eq_bounded_diagonal_int
           · have hm' : ¬ n - i < m + 1 := by omega
             simp [hlt, hm, hm', heq]
 
+/-- `fold_mulCoeffStep_eq_diagonal_int` collapses the inner `mulCoeffStep` fold over the full `range q.size` to the accumulator plus `diagonalCoeffTerm p q n i`. -/
 private theorem fold_mulCoeffStep_eq_diagonal_int
     (p q : ZPoly) (n i : Nat) (acc : Int) :
     (List.range q.size).foldl (DensePoly.mulCoeffStep p q n i) acc =
@@ -782,6 +785,7 @@ private theorem fold_mulCoeffStep_eq_diagonal_int
         DensePoly.coeff_eq_zero_of_size_le q (Nat.le_of_not_gt hbound)
       simp [hlt, hbound, hcoeff]
 
+/-- `fold_mulCoeff_outer_eq_diagonal_int` rewrites the outer coefficient fold so each inner `mulCoeffStep` loop becomes a single `diagonalCoeffTerm` accumulation. -/
 private theorem fold_mulCoeff_outer_eq_diagonal_int
     (p q : ZPoly) (n : Nat) (xs : List Nat) (acc : Int) :
     xs.foldl (fun coeff i => (List.range q.size).foldl (DensePoly.mulCoeffStep p q n i) coeff) acc =
@@ -794,12 +798,14 @@ private theorem fold_mulCoeff_outer_eq_diagonal_int
       rw [fold_mulCoeffStep_eq_diagonal_int]
       exact ih (acc + diagonalCoeffTerm p q n i)
 
+/-- `mulCoeffSum_eq_diagonal_int` expresses the degree-`n` product coefficient as the fold of `diagonalCoeffTerm` over `range p.size`. -/
 private theorem mulCoeffSum_eq_diagonal_int (p q : ZPoly) (n : Nat) :
     DensePoly.mulCoeffSum p q n =
       (List.range p.size).foldl (fun acc i => acc + diagonalCoeffTerm p q n i) 0 := by
   unfold DensePoly.mulCoeffSum
   exact fold_mulCoeff_outer_eq_diagonal_int p q n (List.range p.size) 0
 
+/-- `fold_diagonal_monomial_left` collapses the diagonal fold for a degree-`k` monomial left factor to the single `k`-th term when `k < m`. -/
 private theorem fold_diagonal_monomial_left
     (k : Nat) (c : Int) (q : ZPoly) (n m : Nat) :
     (List.range m).foldl
@@ -841,6 +847,7 @@ private theorem fold_diagonal_monomial_left
               rw [Int.zero_mul]
           simp [hk, hks, hterm]
 
+/-- `coeff_monomial_mul` gives the degree-`n` coefficient of `monomial k c * q` as `c * q.coeff (n - k)`, zero when `n < k`. -/
 private theorem coeff_monomial_mul
     (k : Nat) (c : Int) (q : ZPoly) (n : Nat) :
     ((DensePoly.monomial k c : ZPoly) * q).coeff n =

--- a/progress/2026-06-14T14-30-38Z_280ff5eb.md
+++ b/progress/2026-06-14T14-30-38Z_280ff5eb.md
@@ -1,0 +1,44 @@
+# Progress — 280ff5eb (feature)
+
+## Accomplished
+
+Closed #7236: added one-sentence backtick-led docstrings to the seven
+private `diagonalCoeffTerm` fold-arithmetic declarations in
+`HexHensel/Quadratic.lean` (lines ~742-859):
+
+- `diagonalCoeffTerm` — index-`i` product contribution to the degree-`n`
+  coefficient of `p * q`.
+- `fold_mulCoeffStep_eq_bounded_diagonal_int` — bounded inner-fold rewrite.
+- `fold_mulCoeffStep_eq_diagonal_int` — full inner fold collapses to the
+  diagonal term.
+- `fold_mulCoeff_outer_eq_diagonal_int` — outer fold becomes diagonal-term
+  accumulation.
+- `mulCoeffSum_eq_diagonal_int` — product coefficient as diagonal sum.
+- `fold_diagonal_monomial_left` — monomial-left specialisation.
+- `coeff_monomial_mul` — product-coefficient formula for a monomial factor.
+
+Doc-only, additive (`git diff --numstat` = 7 insertions, 0 deletions). No
+statement, signature, proof, or ordering changes.
+
+## Current frontier
+
+Phase 6 docstring sweep of `HexHensel/Quadratic.lean` now covers through
+`coeff_monomial_mul` (L844). Next undocumented region starts at
+`coeff_mulModSquare_monomial_high` (L860, mulModSquare monomial-coefficient
+cluster), a separate later batch.
+
+## Next step
+
+Continue the Quadratic.lean Phase 6 sweep from the mulModSquare
+monomial-coefficient cluster.
+
+## Blockers
+
+None. Verified: `lake build HexHensel.Quadratic`, `check_dag.py`,
+`git diff --check` all pass; no banned tokens on added lines.
+
+## Note on queue
+
+`#6779` (B-builder finisher) is listed unclaimed but its dependency `#7188`
+closed as dead (route A' confirmed dead, re-framed in the claimed `#7232`),
+so its "after #7188 lands" premise is not yet satisfiable.


### PR DESCRIPTION
Closes #7236

Session: `280ff5eb-6b4f-4eaf-b463-725193ba3168`

fe9be888 doc: HexHensel Quadratic.lean Phase 6 docstrings for diagonalCoeffTerm fold-to-diagonal product-coefficient cluster (batch 3)

🤖 Prepared with Claude Code