### PR TITLE
doc: HexPoly Euclid.lean Phase 6 docstrings for the xgcdAux Bezout-identity and gcd-divisibility cluster (batch 1)

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -2915,6 +2915,8 @@ theorem dvd_sub_poly {S : Type _}
   refine ⟨a + (0 - b), ?_⟩
   rw [sub_eq_add_neg_poly, ha, hb, mul_add_right_poly, mul_sub_zero_comm, mul_comm_poly b d]
 
+/-- `xgcdAux` base case: when the right input `r₁` is zero, the returned gcd
+equals the left input `r₀`. -/
 private theorem xgcdAux_gcd_eq_left_of_right_zero {S : Type _}
     [Zero S] [DecidableEq S] [One S] [Add S] [Sub S] [Mul S] [Div S]
     (r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly S) (fuel : Nat) (hr₁ : r₁ = 0) :
@@ -2925,6 +2927,9 @@ private theorem xgcdAux_gcd_eq_left_of_right_zero {S : Type _}
   | succ fuel =>
       simp [xgcdAux, hr₁, isZero_zero]
 
+/-- `xgcd_bezout_step` is the single recursion step of the Bezout coefficients:
+pairing `(s₀ - a * s₁, t₀ - a * t₁)` with `p, q` equals
+`(s₀ * p + t₀ * q) - a * (s₁ * p + t₁ * q)`. -/
 private theorem xgcd_bezout_step {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (a s₀ t₀ s₁ t₁ p q : DensePoly S) :
@@ -2950,6 +2955,8 @@ private theorem xgcd_bezout_step {S : Type _}
   rw [coeff_add (a * (s₁ * p)) (a * (t₁ * q)) n hzero_add]
   grind
 
+/-- `xgcdAux` satisfies the Bezout identity: the returned `left * p + right * q`
+equals the returned `gcd`. -/
 private theorem xgcdAux_bezout {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (p q r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly S) (fuel : Nat)
@@ -3003,6 +3010,8 @@ theorem xgcd_bezout_of_divModLaws {S : Type _}
   · rw [mul_comm_poly (1 : DensePoly S) p, mul_one_right_poly, zero_mul, add_zero_poly]
   · rw [zero_mul, mul_comm_poly (1 : DensePoly S) q, mul_one_right_poly, zero_add]
 
+/-- Common-divisor direction: any `d` dividing both `r₀` and `r₁` divides the
+gcd returned by `xgcdAux`. -/
 private theorem xgcdAux_common_dvd_gcd {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (d r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly S) (fuel : Nat)
@@ -3037,6 +3046,8 @@ private theorem xgcdAux_common_dvd_gcd {S : Type _}
           rw [hrem]
           exact dvd_sub_poly hr₀ (dvd_mul_left_poly qr.1 hr₁)
 
+/-- gcd-divides-inputs direction: the gcd returned by `xgcdAux` divides both
+inputs `r₀` and `r₁`. -/
 private theorem xgcdAux_gcd_dvd_inputs {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (hsmall :

--- a/progress/20260614T144852Z_bad79ca0.md
+++ b/progress/20260614T144852Z_bad79ca0.md
@@ -1,0 +1,30 @@
+# doc session (issue #7248)
+
+## Accomplished
+
+Phase 6 docstring batch 1 for `HexPoly/Euclid.lean`: added a one-sentence,
+backtick-led `/-- … -/` docstring to all five undocumented private theorems
+in the `xgcdAux` Bezout-identity and gcd-divisibility cluster (lines
+~2918-3040): `xgcdAux_gcd_eq_left_of_right_zero` (base case, right input
+zero), `xgcd_bezout_step` (single recursion step of the Bezout
+coefficients), `xgcdAux_bezout` (full Bezout identity), `xgcdAux_common_dvd_gcd`
+(common-divisor direction), and `xgcdAux_gcd_dvd_inputs` (gcd-divides-inputs
+direction).
+
+The public wrapper `xgcd_bezout_of_divModLaws` (L2995) inside this range was
+already documented and left untouched.
+
+## Current frontier
+
+Doc-only diff, 11 insertions, 0 deletions, no signature/proof/order changes.
+`lake build HexPoly.Euclid` green, `scripts/check_dag.py` exits 0,
+`git diff --check` clean, no banned vocabulary or em-dashes on added lines.
+
+## Next step
+
+Remaining Phase 6 docstring batches across the other `HexPoly`/`Hex*` files
+named in the sibling unclaimed issues (#7246, #7247).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7248

Session: `bad79ca0-4bb0-4c72-96cd-294b0d4ff47e`

b343da44 chore: progress entry for #7248 doc session
00959289 doc: HexPoly Euclid.lean Phase 6 docstrings for the xgcdAux Bezout-identity and gcd-divisibility cluster (batch 1) (#7248)

🤖 Prepared with Claude Code