### PR TITLE
doc: HexPolyZ Mignotte.lean Phase 6 docstrings for the phase-one/full-fuel sqrtAux convergence cluster (batch 2)

### DIFF
--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -321,6 +321,9 @@ private theorem sqrtStep_gap_halves
     rw [hzero]
     simp
 
+/-- While the iterate has not yet undershot, `fuel` Newton steps shrink the gap
+by a factor `2 ^ fuel`: `2 ^ fuel * sqrtGap n (sqrtAux n fuel x) ≤ sqrtGap n x`.
+This geometric gap contraction drives phase-one convergence. -/
 private theorem sqrtAux_gap_contract_of_not_done
     (n fuel x : Nat) (hx : 0 < x)
     (hnot_sq :
@@ -367,6 +370,9 @@ private theorem sqrtAux_gap_contract_of_not_done
           _ ≤ 2 * sqrtGap n next := Nat.mul_le_mul_left 2 htail
           _ ≤ sqrtGap n x := hstep
 
+/-- After `n.log2 + 1` Newton steps from `x = n`, the iterate undershoots
+(`(sqrtAux n (n.log2 + 1) n) ^ 2 ≤ n`), since the gap cannot survive that many
+halvings while staying below `2 ^ (n.log2 + 1)`. -/
 private theorem sqrtAux_phase_one_sq_le
     (n : Nat) (hn : 0 < n) :
     (sqrtAux n (n.log2 + 1) n) * (sqrtAux n (n.log2 + 1) n) ≤ n := by
@@ -400,6 +406,9 @@ private theorem sqrtAux_phase_one_sq_le
       omega
     exact False.elim (Nat.not_lt_of_ge hpow_le hgap_lt)
 
+/-- The iteration composes over fuel:
+`sqrtAux n (fuel₁ + fuel₂) x = sqrtAux n fuel₂ (sqrtAux n fuel₁ x)`, letting a
+full-fuel run split into a phase-one prefix and a refinement tail. -/
 private theorem sqrtAux_append
     (n fuel₁ fuel₂ x : Nat) :
     sqrtAux n (fuel₁ + fuel₂) x =
@@ -436,6 +445,9 @@ private theorem sqrtAux_append
         rw [hleft, hfirst]
         exact ih next
 
+/-- If `x` already undershoots or sits in the near envelope, then so does
+`sqrtAux n fuel x` after any further fuel: the convergence predicate is
+preserved by continued iteration. -/
 private theorem sqrtAux_preserves_sq_or_near
     (n fuel x : Nat) (h : x * x ≤ n ∨ sqrtNearEnvelope n x) :
     let y := sqrtAux n fuel x
@@ -446,6 +458,8 @@ private theorem sqrtAux_preserves_sq_or_near
   | inr hnear =>
       exact sqrtAux_near_or_sq_le n fuel x hnear
 
+/-- In the very-far region `16 * n ≤ x * x`, one Newton step contracts the
+iterate by a fixed ratio: `32 * sqrtStep n x ≤ 17 * x`. -/
 private theorem sqrtStep_very_far_contracts
     (n x : Nat) (hx : 0 < x) (hfar : 16 * n ≤ x * x) :
     32 * sqrtStep n x ≤ 17 * x := by
@@ -469,6 +483,9 @@ private theorem sqrtStep_very_far_contracts
     _ ≤ 16 * x + x := Nat.add_le_add_left hq (16 * x)
     _ = 17 * x := by grind
 
+/-- In the very-far region `16 * n ≤ x * x`, one Newton step strictly decreases
+the iterate (`sqrtStep n x < x`), so the iteration cannot stall before reaching
+the near envelope. -/
 private theorem sqrtStep_very_far_lt_self
     (n x : Nat) (hx : 0 < x) (hfar : 16 * n ≤ x * x) :
     sqrtStep n x < x := by
@@ -476,10 +493,16 @@ private theorem sqrtStep_very_far_lt_self
   have hlt : 17 * x < 32 * x := by omega
   exact Nat.lt_of_mul_lt_mul_left (Nat.lt_of_le_of_lt hcontract hlt)
 
+/-- The arithmetic identity `(a ^ k * b) ^ 2 = (a * a) ^ k * b ^ 2`, used to
+square the geometric `32 ^ k` / `17 ^ k` contraction factors. -/
 private theorem sq_pow_mul (a k b : Nat) :
     (a ^ k * b) ^ 2 = (a * a) ^ k * b ^ 2 := by
   simp [Nat.pow_two, Nat.mul_pow, Nat.mul_assoc, Nat.mul_left_comm, Nat.mul_comm]
 
+/-- While the iterate has neither undershot nor entered the near envelope,
+`fuel` Newton steps contract it geometrically:
+`32 ^ fuel * sqrtAux n fuel x ≤ 17 ^ fuel * x`, carrying the very-far
+contraction across the whole run. -/
 private theorem sqrtAux_contract_of_not_done
     (n fuel x : Nat) (hx : 0 < x)
     (hnot_sq :
@@ -551,10 +574,15 @@ private theorem sqrtAux_contract_of_not_done
         | inl hsq => exact (hnot_sq hsq).elim
         | inr hnear' => exact (hnot_near hnear').elim
 
+/-- The standard bound `n < 2 ^ (n.log2 + 1)`, which fixes the fuel needed for
+phase one. -/
 private theorem log2_succ_pow_bound (n : Nat) :
     n < 2 ^ (n.log2 + 1) := by
   simpa using (Nat.lt_log2_self : n < 2 ^ (n.log2 + 1))
 
+/-- The numeric inequality `289 ^ (n.log2 + 1) * n < 16 * 1024 ^ (n.log2 + 1)`,
+the contradiction that rules out the iterate remaining very far after phase-one
+fuel. -/
 private theorem phase_one_power_contradiction (n : Nat) :
     289 ^ (n.log2 + 1) * n < 16 * 1024 ^ (n.log2 + 1) := by
   let k := n.log2 + 1
@@ -575,6 +603,9 @@ private theorem phase_one_power_contradiction (n : Nat) :
       have hpos : 0 < 1024 ^ k := Nat.pow_pos (by decide : 0 < 1024)
       omega
 
+/-- For `n ≠ 0`, after `n.log2 + 1` steps the iterate either undershoots or sits
+in the near envelope; proved by deriving a contradiction from the geometric
+contraction were it still very far. -/
 private theorem sqrtAux_phase_one_sharp_core (n : Nat) (hn : n ≠ 0) :
     let y := sqrtAux n (n.log2 + 1) n
     y * y ≤ n ∨ sqrtNearEnvelope n y := by
@@ -619,6 +650,8 @@ private theorem sqrtAux_phase_one_sharp_core (n : Nat) (hn : n ≠ 0) :
         simpa [k] using phase_one_power_contradiction n
       exact False.elim (Nat.not_lt_of_ge hlarge hsmall)
 
+/-- Phase-one termination including `n = 0`: `sqrtAux n (n.log2 + 1) n` either
+undershoots or lies in the near envelope. -/
 private theorem sqrtAux_phase_one_near_or_sq_le
     (n : Nat) :
     let y := sqrtAux n (n.log2 + 1) n
@@ -628,6 +661,9 @@ private theorem sqrtAux_phase_one_near_or_sq_le
     simp [sqrtAux]
   · exact sqrtAux_phase_one_sharp_core n hn
 
+/-- With full fuel `2 * n.log2 + 1`, the iterate undershoots or sits in the near
+envelope, obtained by appending a phase-one run to a preserving refinement
+tail. -/
 private theorem sqrtAux_full_fuel_near_or_sq_le
     (n : Nat) :
     let y := sqrtAux n (2 * n.log2 + 1) n
@@ -638,6 +674,9 @@ private theorem sqrtAux_full_fuel_near_or_sq_le
     (sqrtAux n (n.log2 + 1) n)
     (sqrtAux_phase_one_near_or_sq_le n)
 
+/-- With full fuel `2 * n.log2 + 1` and `0 < n`, the iterate undershoots
+(`(sqrtAux n (2 * n.log2 + 1) n) ^ 2 ≤ n`); the floor-square-root soundness fact
+`floorSqrt_sq_le` rests on this. -/
 private theorem sqrtAux_full_fuel_sq_le
     (n : Nat) (hn : 0 < n) :
     (sqrtAux n (2 * n.log2 + 1) n) *

--- a/progress/20260614T154755Z_3d21b3b0.md
+++ b/progress/20260614T154755Z_3d21b3b0.md
@@ -1,0 +1,20 @@
+# Session 3d21b3b0 — feature
+
+## Accomplished
+Issue #7253: added Phase 6 batch-2 docstrings to `HexPolyZ/Mignotte.lean`
+for the phase-one / full-fuel `sqrtAux` convergence cluster. All 14
+target declarations (gap/phase-one contraction, phase-one sharpness,
+full-fuel termination) now carry one-sentence backtick-led docstrings.
+Doc-only: 39 added lines, no deletions, no signature/proof changes.
+
+## Current frontier
+`lake build HexPolyZ.Mignotte` green; `check_dag.py` exits 0; diff clean;
+no banned tokens or em-dashes in added lines.
+
+## Next step
+Batch 3: the `coeffNormSq` / `coeffL2NormBound` / `mignotteCoeffBound`
+definitions and coefficient-bound fold lemmas from line ~657 onward
+(out of scope here, flagged in the issue).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7253

Session: `3d21b3b0-73a5-4e74-a0df-72db96666df0`

b069c617 doc: HexPolyZ Mignotte.lean Phase 6 docstrings for the sqrtAux convergence cluster (batch 2)

🤖 Prepared with Claude Code