### PR TITLE
doc: HexPolyZ Mignotte.lean Phase 6 docstrings for the coefficient-bound fold-monotonicity cluster

### DIFF
--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -863,6 +863,8 @@ theorem mignotteCoeffBound_eq_zero_of_lt (f : ZPoly) (k j : Nat) (h : k < j) :
     mignotteCoeffBound f k j = 0 := by
   simp [mignotteCoeffBound, binom_eq_zero_of_lt h]
 
+/-- A maximizing natural-number `foldl` only increases (or preserves) its
+accumulator, so the initial value bounds the fold result. -/
 private theorem le_foldl_max_left {α : Type} (xs : List α) (g : α → Nat) (init : Nat) :
     init ≤ xs.foldl (fun acc x => max acc (g x)) init := by
   induction xs generalizing init with
@@ -872,6 +874,8 @@ private theorem le_foldl_max_left {α : Type} (xs : List α) (g : α → Nat) (i
       simp only [List.foldl_cons]
       exact Nat.le_trans (Nat.le_max_left init (g x)) (ih (max init (g x)))
 
+/-- For a maximizing natural-number `foldl`, the value `g x` at any member index
+`x ∈ xs` is bounded by the fold result. -/
 private theorem le_foldl_max_of_mem {α : Type} (xs : List α) (g : α → Nat)
     {x : α} {init : Nat} (hx : x ∈ xs) :
     g x ≤ xs.foldl (fun acc y => max acc (g y)) init := by
@@ -889,6 +893,8 @@ private theorem le_foldl_max_of_mem {α : Type} (xs : List α) (g : α → Nat)
       | inr h =>
           exact ih h
 
+/-- The inner `max`-fold over `j ∈ range (k+1)` dominates each
+`mignotteCoeffBound f k j` at an in-range index, by `le_foldl_max_of_mem`. -/
 private theorem mignotteCoeffBound_le_degree_innerFold
     (f : ZPoly) (k : Nat) {j init : Nat} (hj : j ≤ k) :
     mignotteCoeffBound f k j ≤
@@ -899,6 +905,9 @@ private theorem mignotteCoeffBound_le_degree_innerFold
     (fun j => mignotteCoeffBound f k j)
     (List.mem_range.mpr (Nat.lt_succ_of_le hj))
 
+/-- The outer degree `max`-fold (each step running the inner `j`-fold) only
+increases (or preserves) its accumulator, so the initial value bounds the
+result. -/
 private theorem defaultFactorCoeffBound_outerFold_preserves
     (f : ZPoly) (ks : List Nat) (init : Nat) :
     init ≤
@@ -919,6 +928,9 @@ private theorem defaultFactorCoeffBound_outerFold_preserves
         (ih ((List.range (k + 1)).foldl
           (fun acc j => max acc (mignotteCoeffBound f k j)) init))
 
+/-- For any degree `k ∈ ks` and in-range index `j ≤ k`, `mignotteCoeffBound f k j`
+is bounded by the full nested degree/index `max`-fold, combining the inner-fold
+and outer-fold monotonicity lemmas. -/
 private theorem mignotteCoeffBound_le_defaultFactorCoeffBound_fold
     (f : ZPoly) (ks : List Nat) {k j init : Nat} (hk : k ∈ ks) (hj : j ≤ k) :
     mignotteCoeffBound f k j ≤

--- a/progress/2026-06-14T16-07-15Z_911454e3.md
+++ b/progress/2026-06-14T16-07-15Z_911454e3.md
@@ -1,0 +1,36 @@
+# Progress: 2026-06-14T16:07Z (feature, 911454e3)
+
+## Accomplished
+
+Closed #7260: added Phase 6 one-sentence docstrings to the 5 undocumented
+private declarations in the Mignotte coefficient-bound fold-monotonicity
+cluster of `HexPolyZ/Mignotte.lean` (L866–946):
+
+- `le_foldl_max_left`
+- `le_foldl_max_of_mem`
+- `mignotteCoeffBound_le_degree_innerFold`
+- `defaultFactorCoeffBound_outerFold_preserves`
+- `mignotteCoeffBound_le_defaultFactorCoeffBound_fold`
+
+Doc-only: no signature, statement, simp set, or proof touched.
+
+## Verification
+
+- `lake build HexPolyZ.Mignotte` green.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean; `git diff --numstat` shows 12 additions, 0 deletions.
+- Added-line scan: no banned tokens or em-dashes.
+
+## Current frontier
+
+The `le_foldl_add_*` / `ceilSqrt_pos_of_pos` cluster (L970 onward) remains
+a separate later docstring batch.
+
+## Next step
+
+Pick up the remaining Mignotte additive-fold docstring batch when a planner
+files it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7260

Session: `911454e3-7d51-42a2-ae7d-e378e5e82e87`

7ac4e7e3 doc: HexPolyZ Mignotte.lean Phase 6 docstrings for the coefficient-bound fold-monotonicity cluster

🤖 Prepared with Claude Code