### PR TITLE
doc: HexPoly Euclid.lean Phase 6 docstrings for the polynomial-mod congruence and CRT subtraction cluster (batch 4)

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -4986,6 +4986,8 @@ def Congr {S : Type _} [Zero S] [DecidableEq S] [Add S] [Sub S] [Mul S]
     (p q m : DensePoly S) : Prop :=
   m ∣ (p - q)
 
+/-- Expresses the gap `p % m - p` as the explicit multiple `m * (0 - p / m)`, the witness
+underlying the congruence `m ∣ (p % m - p)`. -/
 private theorem mod_sub_self_eq_mul_neg_div {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (p m : DensePoly S) :
@@ -5003,6 +5005,8 @@ private theorem mod_sub_self_eq_mul_neg_div {S : Type _}
   rw [coeff_zero]
   grind
 
+/-- Packages `mod_sub_self_eq_mul_neg_div` as the divisibility `m ∣ (p % m - p)`, the core
+fact behind the public `congr_mod`. -/
 private theorem congr_mod_core {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (p m : DensePoly S) :
@@ -5017,6 +5021,8 @@ theorem congr_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
     Congr (p % m) p m := by
   exact congr_mod_core p m
 
+/-- Rearranges a difference-as-multiple `p - q = m * r` into the additive form
+`p = q + m * r`. -/
 private theorem eq_add_mul_of_sub_eq_mul {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     {p q m r : DensePoly S} :
@@ -5032,6 +5038,7 @@ private theorem eq_add_mul_of_sub_eq_mul {S : Type _}
   rw [coeff_add q (m * r) n hzero_add]
   grind
 
+/-- Right identity of polynomial addition, `p + 0 = p`. -/
 private theorem add_zero_right {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
@@ -5043,6 +5050,7 @@ private theorem add_zero_right {S : Type _}
   simp
   grind
 
+/-- Left absorption of the zero polynomial under multiplication, `0 * p = 0`. -/
 private theorem zero_mul_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p : DensePoly S) :
@@ -5051,12 +5059,14 @@ private theorem zero_mul_left {S : Type _}
   have hzero : (0 : DensePoly S).coeffs = #[] := rfl
   simp [mul, isZero, hzero]
 
+/-- A modulus reduces to `0` against itself, `m % m = 0`. -/
 private theorem mod_self_eq_zero {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m : DensePoly S) :
     m % m = 0 := by
   exact DivModLaws.mod_self_eq_zero m
 
+/-- The zero polynomial reduces to `0` modulo any `m`, `0 % m = 0`. -/
 private theorem zero_mod_eq_zero {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m : DensePoly S) :
@@ -5073,6 +5083,8 @@ private theorem zero_mod_eq_zero {S : Type _}
     unfold divModArray
     simp [hzero, isZero, size, toArray, divModArrayAux]
 
+/-- Divisibility of a difference `m ∣ (p - q)` forces equal canonical remainders
+`p % m = q % m`. -/
 private theorem mod_eq_mod_of_dvd_sub {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     {p q m : DensePoly S} :
@@ -5153,6 +5165,7 @@ theorem mod_mul_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [Div S]
     (p * q) % m = ((p % m) * (q % m)) % m := by
   exact DivModLaws.mod_mul_mod p q m
 
+/-- Any multiple of `m` reduces to `0` modulo `m`, `(m * r) % m = 0`. -/
 private theorem mod_mul_self_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m r : DensePoly S) :
@@ -5162,6 +5175,8 @@ private theorem mod_mul_self_left {S : Type _}
   rw [zero_mul_left]
   rw [zero_mod_eq_zero]
 
+/-- Adding a multiple of `m` leaves the canonical remainder unchanged,
+`(q + m * r) % m = q % m`. -/
 private theorem mod_add_mul_self {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (q m r : DensePoly S) :
@@ -5177,6 +5192,9 @@ private theorem mod_add_mul_self {S : Type _}
     rw [coeff_mul]
     grind⟩
 
+/-- Under the Bezout hypothesis `s * a + t * b = 1`, exhibits `polyCRT a b u v s t - u` as
+the explicit multiple `a * (v * s + (0 - u * s))`, the witness for congruence to `u`
+modulo `a`. -/
 private theorem polyCRT_sub_left_factor {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (a b u v s t : DensePoly S) :
@@ -5201,6 +5219,9 @@ private theorem polyCRT_sub_left_factor {S : Type _}
     _ = a * (v * s + (0 - u * s)) := by
           rw [mul_comm_poly]
 
+/-- Under the Bezout hypothesis `s * a + t * b = 1`, exhibits `polyCRT a b u v s t - v` as
+the explicit multiple `b * (u * t + (0 - v * t))`, the witness for congruence to `v`
+modulo `b`. -/
 private theorem polyCRT_sub_right_factor {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (a b u v s t : DensePoly S) :

--- a/progress/20260614T161930Z_f74e9074.md
+++ b/progress/20260614T161930Z_f74e9074.md
@@ -1,0 +1,42 @@
+# 2026-06-14T16:19:30Z — feature session (f74e9074)
+
+## Accomplished
+
+Closed #7271: added Phase 6 docstrings to the twelve undocumented
+private declarations in `HexPoly/Euclid.lean`'s generic
+polynomial-mod congruence / CRT subtraction-factor cluster:
+`mod_sub_self_eq_mul_neg_div`, `congr_mod_core`,
+`eq_add_mul_of_sub_eq_mul`, `add_zero_right`, `zero_mul_left`,
+`mod_self_eq_zero`, `zero_mod_eq_zero`, `mod_eq_mod_of_dvd_sub`,
+`mod_mul_self_left`, `mod_add_mul_self`, `polyCRT_sub_left_factor`,
+`polyCRT_sub_right_factor`.
+
+Each got a one-sentence, backtick-led `/-- … -/` docstring stating
+what it proves and its role in the CRT reconstruction reasoning.
+Doc-only: no signature, statement, proof, or ordering changes.
+
+## Verification
+
+- `lake build HexPoly.Euclid` green.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean.
+- `git diff --numstat` shows 21 additions, 0 deletions.
+- Added-line scan: no banned tokens or em-dashes.
+
+## Current frontier
+
+Worker queue was nearly empty this session: directive #2564 (HO-1
+capstone) is `blocked` on its dependency tree; all other issues
+listed by `coordination orient` are blocked or claimed. #7271 was
+the only actionable feature issue.
+
+## Next step
+
+Next worker: re-run `coordination orient`; if the queue is empty,
+the gating item is repair of PR #7126 / issue #7122 (factorFast
+schedule recovery), which unblocks a large fraction of the HO-1
+tree.
+
+## Blockers
+
+None for this task.


### PR DESCRIPTION
Closes #7271

Session: `f74e9074-c8ee-4570-818d-235030cfd32f`

bf0bf955 chore: progress entry for #7271 (HexPoly Euclid docstrings batch 4)
bf514afe doc: HexPoly Euclid.lean Phase 6 docstrings for the polynomial-mod congruence and CRT subtraction cluster (batch 4)

🤖 Prepared with Claude Code