### PR TITLE
doc: HexMatrix RREF.lean Phase 6 docstrings for the RREF shape-invariant and final-shape/no-pivot-zero cluster

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -748,6 +748,8 @@ private structure RrefShapeInvariant (col : Nat) (state : RrefState R n m) : Pro
   pivots_lt_col : ∀ p ∈ state.pivots, p.val < col
 
 omit [Lean.Grind.Field R] [DecidableEq R] in
+/-- `RrefShapeInvariant.mono_col`: the shape invariant at column bound `col`
+continues to hold at any larger bound `col' ≥ col`. -/
 private theorem RrefShapeInvariant.mono_col {col col' : Nat} {state : RrefState R n m}
     (hcol : col ≤ col') (h : RrefShapeInvariant (R := R) (n := n) (m := m) col state) :
     RrefShapeInvariant (R := R) (n := n) (m := m) col' state where
@@ -767,6 +769,9 @@ private structure RrefCanonicalInvariant (state : RrefState R n m) : Prop where
     r.val ≠ i → state.echelon[r][state.pivots[i]] = 0
 
 omit [Lean.Grind.Field R] [DecidableEq R] in
+/-- `list_sorted_get_concat_of_lt`: appending a column index `col` that exceeds
+every entry of a strictly sorted pivot list keeps the concatenated list
+strictly increasing by index. -/
 private theorem list_sorted_get_concat_of_lt {ps : List (Fin m)} {col : Nat}
     (hsorted : ∀ (i j : Nat) (hi : i < ps.length) (hj : j < ps.length),
       i < j → ps[i] < ps[j])
@@ -808,6 +813,9 @@ private theorem list_sorted_get_concat_of_lt {ps : List (Fin m)} {col : Nat}
     exact hlt ps[i] (List.getElem_mem hiOld)
 
 omit [Lean.Grind.Field R] [DecidableEq R] in
+/-- `rrefShapeInvariant_concat`: recording a new pivot at column `col`, which
+advances the row counter and appends `col` to the pivot list, preserves the
+shape invariant at the raised column bound `col + 1`. -/
 private theorem rrefShapeInvariant_concat {col : Nat} {state : RrefState R n m}
     (h : RrefShapeInvariant (R := R) (n := n) (m := m) col state)
     (hRow : state.row < n) (hCol : col < m)
@@ -1034,6 +1042,8 @@ private theorem rrefCanonicalInvariant_pivot_step
         rw [hval, ← hshape.row_eq_length]
       exact hnew.2 r hr_ne_target
 
+/-- `rrefLoop_shape`: running `rrefLoop` for `fuel` steps preserves the shape
+invariant, advancing the column bound from `col` to `col + fuel`. -/
 private theorem rrefLoop_shape :
     ∀ (fuel col : Nat) (state : RrefState R n m),
       RrefShapeInvariant (R := R) (n := n) (m := m) col state →
@@ -1082,6 +1092,9 @@ private theorem rrefLoop_shape :
         exact h.mono_col (by omega)
 
 omit [DecidableEq R] in
+/-- `rrefLoop_initial_shape`: the initial RREF state for matrix `M` (zero row
+counter, identity transform, empty pivot list) satisfies the shape invariant at
+column bound `0`. -/
 private theorem rrefLoop_initial_shape (M : Matrix R n m) :
     RrefShapeInvariant (R := R) (n := n) (m := m) 0
       { row := 0
@@ -1098,6 +1111,8 @@ private theorem rrefLoop_initial_shape (M : Matrix R n m) :
     intro p hp
     cases hp
 
+/-- `rref_final_shape`: the state produced by the full `rrefLoop 0 m` run on `M`
+satisfies the shape invariant at column bound `m`. -/
 private theorem rref_final_shape (M : Matrix R n m) :
     RrefShapeInvariant (R := R) (n := n) (m := m) m
       (rrefLoop 0 m
@@ -1170,6 +1185,8 @@ private theorem rrefLoop_canonical :
       · rw [dif_neg hRow]
         exact hcanon
 
+/-- `rref_final_canonical`: the state produced by the full `rrefLoop 0 m` run on
+`M` satisfies the canonical-column invariant. -/
 private theorem rref_final_canonical (M : Matrix R n m) :
     RrefCanonicalInvariant (R := R) (n := n) (m := m)
       (rrefLoop 0 m
@@ -1276,6 +1293,8 @@ private structure RrefNoPivotZero (col : Nat) (state : RrefState R n m) : Prop w
       ∀ (r : Fin n), state.row ≤ r.val → state.echelon[r][c] = 0
 
 omit [DecidableEq R] in
+/-- `rrefNoPivotZero_initial`: the initial RREF state for matrix `M` satisfies
+the no-pivot-zero invariant at column bound `0`. -/
 private theorem rrefNoPivotZero_initial (M : Matrix R n m) :
     RrefNoPivotZero (R := R) (n := n) (m := m) 0
       { row := 0
@@ -1308,6 +1327,8 @@ private theorem RrefNoPivotZero.widen_col_at_n {col col' : Nat}
     have hge : n ≤ r.val := Nat.le_trans hrow hr
     exact absurd r.isLt (Nat.not_lt_of_ge hge)
 
+/-- `rrefLoop_no_pivot_zero`: running `rrefLoop` for `fuel` steps preserves the
+no-pivot-zero invariant, advancing the column bound from `col` to `col + fuel`. -/
 private theorem rrefLoop_no_pivot_zero :
     ∀ (fuel col : Nat) (state : RrefState R n m),
       RrefNoPivotZero col state →
@@ -1405,6 +1426,8 @@ private theorem rrefLoop_no_pivot_zero :
       · rw [dif_neg hRow]
         exact h.widen_col_at_n (by omega)
 
+/-- `rref_final_no_pivot_zero`: the state produced by the full `rrefLoop 0 m` run
+on `M` satisfies the no-pivot-zero invariant at column bound `m`. -/
 private theorem rref_final_no_pivot_zero (M : Matrix R n m) :
     RrefNoPivotZero (R := R) (n := n) (m := m) m
       (rrefLoop 0 m

--- a/progress/20260615T034500Z_1b5b9f64.md
+++ b/progress/20260615T034500Z_1b5b9f64.md
@@ -1,0 +1,53 @@
+# Progress — 2026-06-15 (session 1b5b9f64, feature)
+
+## Accomplished
+
+Issue #7284: added one-sentence Phase 6 docstrings to the 10
+undocumented private theorems in the RREF shape-invariant /
+final-shape / no-pivot-zero cluster of `HexMatrix/RREF.lean`:
+
+- `RrefShapeInvariant.mono_col`, `list_sorted_get_concat_of_lt`,
+  `rrefShapeInvariant_concat` (monotonicity and concat-step blocks),
+- `rrefLoop_shape`, `rrefLoop_initial_shape`, `rref_final_shape`
+  (shape invariant propagated through the loop to the final matrix),
+- `rref_final_canonical` (canonical form),
+- `rrefNoPivotZero_initial`, `rrefLoop_no_pivot_zero`,
+  `rref_final_no_pivot_zero` (no pivot column is zero).
+
+Doc-only: +23 lines, no deletions; no statements, proofs, signatures,
+names, attributes, imports, or namespaces touched.
+
+## Decisions
+
+The issue's placement note said the docstring should go *above* each
+`omit … in` modifier line. That is wrong: a `/-- … -/` doc comment
+placed before `omit … in` is a parse error ("unexpected token
+'omit'"), since the doc comment must attach directly to a declaration.
+The working convention already in this file (e.g.
+`rowSwap_zero_column_preserve` ~L1184) puts the docstring *between*
+`omit … in` and `private theorem`. I followed that, which compiles.
+
+## Verification
+
+- `lake build HexMatrix.RREF`: green.
+- `python3 scripts/check_dag.py`: exits 0.
+- `git diff --check`: clean.
+- `git diff --numstat -- HexMatrix/RREF.lean`: `23 0` (additions only).
+- No banned vocabulary or em-dashes on added lines.
+
+## Current frontier
+
+This cluster is complete. Per the issue, the nullspace-soundness
+cluster (`nullspace_get` … `nullspace_echelon_sound`, ~L2269–2438)
+and the `foldl_*` ring-sum helpers / public `*_sound` theorems remain
+as separate Phase 6 batches.
+
+## Next step
+
+None for this issue. Other unclaimed Phase 6 doc batches remain in the
+queue (e.g. #7286 HexBerlekamp/Factor.lean).
+
+## Blockers
+
+None.
+</content>


### PR DESCRIPTION
Closes #7284

Session: `1b5b9f64-f275-47ce-b506-84dbb6932484`

45c72f64 chore: progress note for #7284
b774ebd6 doc: HexMatrix RREF.lean Phase 6 docstrings for the RREF shape-invariant and final-shape/no-pivot-zero cluster (#7284)

🤖 Prepared with Claude Code