### PR TITLE
doc: HexPolyFp SquareFree.lean Phase 6 docstrings for the FpPoly divisibility-helper cluster (dvd_add/mul/sub_poly and pow_succ_dvd products)

### DIFF
--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -3395,6 +3395,7 @@ private theorem yunFactorsContribution_step_split
   · exact div_monicGcd_mul_reconstruct hp c w
   · exact div_monicGcd_right_mul_reconstruct hp c w
 
+/-- `dvd_add_poly`: a common divisor of `a` and `b` divides their sum `a + b`. -/
 private theorem dvd_add_poly
     {d a b : FpPoly p} (hda : d ∣ a) (hdb : d ∣ b) :
     d ∣ a + b := by
@@ -3405,6 +3406,8 @@ private theorem dvd_add_poly
       = d * qa + d * qb := by rw [hqa, hqb]
     _ = d * (qa + qb) := (DensePoly.mul_add_right_poly d qa qb).symm
 
+/-- `dvd_mul_left_of_dvd`: if `d ∣ a` then `d` divides the left-multiplied
+product `b * a`. -/
 private theorem dvd_mul_left_of_dvd
     {d a b : FpPoly p} (hda : d ∣ a) :
     d ∣ b * a := by
@@ -3417,6 +3420,8 @@ private theorem dvd_mul_left_of_dvd
           exact congrArg (fun x => x * q) (DensePoly.mul_comm_poly b d)
     _ = d * (b * q) := DensePoly.mul_assoc_poly d b q
 
+/-- `dvd_mul_right_of_dvd`: if `d ∣ a` then `d` divides the right-multiplied
+product `a * b`. -/
 private theorem dvd_mul_right_of_dvd
     {d a b : FpPoly p} (hda : d ∣ a) :
     d ∣ a * b := by
@@ -3448,11 +3453,16 @@ private theorem dvd_monicGcd
       rw [hmg]
       exact dvd_mul_left_of_dvd hdg
 
+/-- `dvd_sub_poly`: a common divisor of `a` and `b` divides their difference
+`a - b`. -/
 private theorem dvd_sub_poly
     {d a b : FpPoly p} (hda : d ∣ a) (hdb : d ∣ b) :
     d ∣ a - b := by
   exact DensePoly.dvd_sub_poly hda hdb
 
+/-- `pow_succ_dvd_mul_right_of_dvd`: the extra factor of `d` in `a * d * b` bumps
+a prime-power divisor's exponent, so `pow d (n+1) ∣ a` gives
+`pow d (n+2) ∣ a * d * b`. -/
 private theorem pow_succ_dvd_mul_right_of_dvd
     {d a b : FpPoly p} {n : Nat}
     (h : pow d (n + 1) ∣ a) :
@@ -3474,6 +3484,8 @@ private theorem pow_succ_dvd_mul_right_of_dvd
           rw [← pow_succ d (n + 1)]
           exact DensePoly.mul_assoc_poly (pow d (n + 2)) q b
 
+/-- `pow_succ_dvd_mul_of_dvd_left_of_pow_dvd_right`: combining `d ∣ a` on the left
+factor with `pow d n ∣ b` on the right gives `pow d (n+1) ∣ a * b`. -/
 private theorem pow_succ_dvd_mul_of_dvd_left_of_pow_dvd_right
     {d a b : FpPoly p} {n : Nat}
     (hda : d ∣ a) (hdb : pow d n ∣ b) :
@@ -3498,6 +3510,8 @@ private theorem pow_succ_dvd_mul_of_dvd_left_of_pow_dvd_right
                   exact DensePoly.mul_assoc_poly (pow d n * d) qa qb
     _ = pow d (n + 1) * (qa * qb) := by rw [← pow_succ d n]
 
+/-- `pow_succ_dvd_mul_of_pow_dvd_left_of_dvd_right`: combining `pow d n ∣ a` on the
+left factor with `d ∣ b` on the right gives `pow d (n+1) ∣ a * b`. -/
 private theorem pow_succ_dvd_mul_of_pow_dvd_left_of_dvd_right
     {d a b : FpPoly p} {n : Nat}
     (hda : pow d n ∣ a) (hdb : d ∣ b) :

--- a/progress/20260614T170930Z_fae8a1a2.md
+++ b/progress/20260614T170930Z_fae8a1a2.md
@@ -1,0 +1,46 @@
+# Progress — 2026-06-14 (session fae8a1a2, feature)
+
+## Accomplished
+
+Issue #7288: added one-sentence Phase 6 docstrings to the seven
+undocumented private divisibility-helper lemmas in
+`HexPolyFp/SquareFree.lean` (the `FpPoly p` `∣`-closure cluster at
+lines ~3398–3527):
+
+- `dvd_add_poly`, `dvd_mul_left_of_dvd`, `dvd_mul_right_of_dvd`,
+  `dvd_sub_poly`, `pow_succ_dvd_mul_right_of_dvd`,
+  `pow_succ_dvd_mul_of_dvd_left_of_pow_dvd_right`,
+  `pow_succ_dvd_mul_of_pow_dvd_left_of_dvd_right`.
+
+Each docstring leads with the backticked declaration name and states
+what the lemma asserts (not how it is proved). `dvd_monicGcd`
+(already documented, between the cluster lemmas) was left untouched as
+the issue required.
+
+Doc-only change: no signatures, statements, proofs, attributes,
+imports, or declaration order touched.
+
+## Verification
+
+- `lake build HexPolyFp.SquareFree`: green (88 jobs).
+- `python3 scripts/check_dag.py`: exits 0.
+- `git diff --check`: clean.
+- `git diff --numstat -- HexPolyFp/SquareFree.lean`: `14 0`
+  (additions only; every added line is inside a new `/-- … -/` block).
+
+## Current frontier
+
+This cluster is complete. The earlier
+`squareFreeContributionReachable` / reconstruction lemmas
+(~L2900–3370) and the later `quotient_common_dvd_*` /
+`derivativeSplit_*` divisibility chain (~L3528 onward) remain separate
+Phase 6 doc batches.
+
+## Next step
+
+None for this issue. Other unclaimed Phase 6 doc batches remain in the
+queue (e.g. #7289 HexPolyZ/Basic.lean).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7288

Session: `fae8a1a2-b6dd-4b92-9e5a-5a2257447a2c`

3bd6bfc5 doc: progress note for #7288 (HexPolyFp SquareFree dvd cluster)
db412ade doc: HexPolyFp SquareFree.lean Phase 6 docstrings for the FpPoly divisibility-helper cluster

🤖 Prepared with Claude Code