### PR TITLE
doc: HexPolyFp Basic.lean Phase 6 docstrings for the modular-remainder congruence cluster (mod_eq_mod_of_congr core and helpers)

### DIFF
--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -510,6 +510,7 @@ private theorem canonical_remainder_unique_of_pos_degree
     have hmk_eq_rs : (m * k).size = (r - s).size := by rw [← hk]
     omega
 
+/-- `mod_remainders_congr_of_congr` shows that congruent inputs have congruent remainders modulo the same modulus, providing the general remainder-congruence step. -/
 private theorem mod_remainders_congr_of_congr [PrimeModulus p]
     (f g m : DensePoly (ZMod64 p))
     (hcongr : DensePoly.Congr f g m) :
@@ -550,6 +551,7 @@ private theorem mod_remainders_congr_of_congr [PrimeModulus p]
       exact (DensePoly.mul_add_right_poly m (q + rf)
         ((0 : DensePoly (ZMod64 p)) - rg)).symm
 
+/-- `mod_eq_mod_of_congr_pos_degree` turns congruence modulo a positive-degree modulus into equality of canonical remainders. -/
 private theorem mod_eq_mod_of_congr_pos_degree
     [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hdegree : 0 < m.degree?.getD 0)
@@ -560,12 +562,14 @@ private theorem mod_eq_mod_of_congr_pos_degree
   · exact mod_remainder_degree_lt_core g m hdegree
   · exact mod_remainders_congr_of_congr f g m hcongr
 
+/-- `mod_zero_right_of_size_zero` identifies remainder by a size-zero modulus with the original polynomial for the degenerate modulus case. -/
 private theorem mod_zero_right_of_size_zero (f m : DensePoly (ZMod64 p))
     (hm : m.size = 0) :
     f % m = f := by
   simpa [DensePoly.mod] using
     DensePoly.divMod_remainder_eq_self_of_size_zero_core f m hm
 
+/-- `eq_of_sub_eq_zero` recovers equality of dense polynomials from a zero difference, supplying the algebraic cancellation used in the degenerate case. -/
 private theorem eq_of_sub_eq_zero (f g : DensePoly (ZMod64 p))
     (hsub : f - g = 0) :
     f = g := by
@@ -576,6 +580,7 @@ private theorem eq_of_sub_eq_zero (f g : DensePoly (ZMod64 p))
   rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero] at hcoeff
   grind
 
+/-- `mod_eq_mod_of_congr_not_pos_degree` handles the zero and constant modulus cases of remainder congruence when the modulus has no positive degree. -/
 private theorem mod_eq_mod_of_congr_not_pos_degree
     [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hdegree : ¬ 0 < m.degree?.getD 0)
@@ -627,6 +632,7 @@ private theorem mod_eq_mod_of_congr_not_pos_degree
           (fun a => zmod_div_mul_cancel_of_ne a m.leadingCoeff hlead_ne)
     rw [hfmod, hgmod]
 
+/-- `mod_eq_mod_of_congr_core` combines the positive-degree and non-positive-degree branches into the core equality of congruent remainders. -/
 private theorem mod_eq_mod_of_congr_core
     [PrimeModulus p] (f g m : DensePoly (ZMod64 p))
     (hcongr : DensePoly.Congr f g m) :
@@ -635,6 +641,7 @@ private theorem mod_eq_mod_of_congr_core
   · exact mod_eq_mod_of_congr_pos_degree f g m hdegree hcongr
   · exact mod_eq_mod_of_congr_not_pos_degree f g m hdegree hcongr
 
+/-- `sub_zero_poly` simplifies subtraction of zero for dense polynomials, feeding divisibility into the congruence form. -/
 private theorem sub_zero_poly (f : DensePoly (ZMod64 p)) :
     f - 0 = f := by
   apply DensePoly.ext_coeff
@@ -642,6 +649,7 @@ private theorem sub_zero_poly (f : DensePoly (ZMod64 p)) :
   rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
   grind
 
+/-- `mod_eq_zero_of_dvd_core` converts divisibility by the modulus into a zero remainder using the core remainder-congruence theorem. -/
 private theorem mod_eq_zero_of_dvd_core
     [PrimeModulus p] (f g : DensePoly (ZMod64 p)) (hdiv : g ∣ f) :
     f % g = 0 := by

--- a/progress/2026-06-14T18-09-30Z_55176559.md
+++ b/progress/2026-06-14T18-09-30Z_55176559.md
@@ -1,0 +1,38 @@
+# Progress — 2026-06-14T18:09:30Z (session 55176559, work)
+
+## Accomplished
+
+Claimed issue #7310 after the higher-priority directive #2564 was reported blocked by `coordination claim` and the oldest doc issue #7309 raced to another agent.
+
+Added one-sentence Phase 6 docstrings to the eight private modular-remainder congruence helpers in `HexPolyFp/Basic.lean`:
+
+- `mod_remainders_congr_of_congr`
+- `mod_eq_mod_of_congr_pos_degree`
+- `mod_zero_right_of_size_zero`
+- `eq_of_sub_eq_zero`
+- `mod_eq_mod_of_congr_not_pos_degree`
+- `mod_eq_mod_of_congr_core`
+- `sub_zero_poly`
+- `mod_eq_zero_of_dvd_core`
+
+The change is doc-only: no signatures, statements, proofs, annotations, declaration order, or imports were touched.
+
+Verification:
+
+- `lake build HexPolyFp.Basic`: green.
+- `python3 scripts/check_dag.py`: exits 0.
+- `git diff --check`: clean.
+- `git diff --numstat -- HexPolyFp/Basic.lean`: `8 0`.
+- Added lines contain no em dashes or banned progress-history wording.
+
+## Current frontier
+
+Issue #7310 is complete and ready for PR. The unrelated pre-existing `.claude/CLAUDE.md` modification remains uncommitted and untouched.
+
+## Next step
+
+Create the PR for #7310.
+
+## Blockers
+
+None for #7310. Directive #2564 remains blocked by dependencies, so this session did not work on it.


### PR DESCRIPTION
Closes #7310

Session: `55176559-3769-49b5-afae-a68738fcafbb`

7eec7975 doc: document HexPolyFp remainder congruence helpers

🤖 Prepared with Claude Code