### PR TITLE
doc: HexLLL Basic.lean Phase 6 docstrings for the LLLCore rational-arithmetic step-bound helpers (stepBound_arith / divStep_arith / ratPow_*)

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -150,6 +150,17 @@ Check that the plan's assumptions still hold:
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
 
+**Closed dependency ≠ delivered dependency.** When the issue says to
+compose a bound/lemma/API "from #N", do not trust `#N` being closed. The
+replan-triage step closes a *skipped* issue as `COMPLETED` while forwarding
+its real scope to a successor (`#N` -> `#N'` -> `#N''`), so a chain of
+`CLOSED COMPLETED` issues can all be premise-skips with the deliverable
+still unbuilt. Before deep-reading consumer code, check the named
+dependency's closing comments (`gh issue view #N --json comments`) and grep
+the codebase for the actual artifact (a *proof* concluding the bound, not a
+hypothesis of the same shape). If the artifact is absent, the premise is
+stale: comment with evidence, `add-dep` on the live successor, and skip.
+
 If stale:
 ```
 coordination skip <issue-number> "reason: <what changed>"

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -420,9 +420,14 @@ def isLLLReduced (b : Matrix Int n m) (δ η : Rat) : Prop :=
 
 namespace LLLCore
 
+/-- `ratMulSelfNonneg` states that a rational square `x * x` is nonnegative, the
+per-entry fact underlying every sum-of-squares norm bound in this file. -/
 private theorem ratMulSelfNonneg (x : Rat) : 0 ≤ x * x := by
   simpa [Lean.Grind.Semiring.pow_two] using (Lean.Grind.OrderedRing.sq_nonneg (a := x))
 
+/-- `foldlNonneg` states that a left fold accumulating nonnegative summands
+`f x` onto a nonnegative accumulator stays nonnegative, the inductive step
+behind `basisNormSq_nonneg`. -/
 private theorem foldlNonneg {α : Type} (xs : List α) (f : α → Rat)
     (acc : Rat) (hacc : 0 ≤ acc) (hf : ∀ x, 0 ≤ f x) :
     0 ≤ xs.foldl (fun sum x => sum + f x) acc := by
@@ -441,6 +446,9 @@ theorem basisNormSq_nonneg (basis : Matrix Rat n m) (i : Fin n) :
   exact foldlNonneg (List.finRange m) (fun j => (basis.row i)[j] * (basis.row i)[j]) 0
     (by grind) (fun j => ratMulSelfNonneg ((basis.row i)[j]))
 
+/-- `stepBound_arith` rearranges the Lovasz condition `δ * N ≤ Np + μ² * N`
+together with the size-reduced bound `μ² ≤ η²` into the adjacent norm bound
+`(δ - η²) * N ≤ Np`. -/
 private theorem stepBound_arith (δ η μ N Np : Rat)
     (hN : 0 ≤ N) (hsize : μ * μ ≤ η * η)
     (hlov : δ * N ≤ Np + μ * μ * N) :
@@ -457,6 +465,8 @@ private theorem stepBound_arith (δ η μ N Np : Rat)
       _ = Np := by grind
   exact Rat.le_trans hleft hlov'
 
+/-- `divStep_arith` divides the step bound `d * N ≤ Np` (with `0 < d`) through
+by `d` to yield the reciprocal form `N ≤ (1 / d) * Np`. -/
 private theorem divStep_arith (d N Np : Rat) (hd : 0 < d)
     (h : d * N ≤ Np) :
     N ≤ (1 / d) * Np := by
@@ -473,6 +483,9 @@ private theorem divStep_arith (d N Np : Rat) (hd : 0 < d)
     grind
   simpa [hleft] using hmul
 
+/-- `ratPow_nonneg` states that a nonnegative rational `a` raised to a natural
+power `k` stays nonnegative, used when bounding the geometric `α ^ i` factors of
+the step bounds. -/
 private theorem ratPow_nonneg (a : Rat) (ha : 0 ≤ a) (k : Nat) :
     0 ≤ a ^ k := by
   induction k with
@@ -581,6 +594,9 @@ theorem basisNormSq_zero (b : Matrix Int n m) (hn : 0 < n) :
   rw [GramSchmidt.Int.basis_zero b hn]
   exact GramSchmidt.Int.normSq_map_intCast (b.row ⟨0, hn⟩)
 
+/-- `ratPow_le_pow_of_one_le` states that for `1 ≤ α` the power `α ^ i` is
+monotone in the exponent, so a larger index gives a larger geometric step
+factor. -/
 private theorem ratPow_le_pow_of_one_le {α : Rat} (hα : 1 ≤ α) :
     ∀ {i j : Nat}, i ≤ j → α ^ i ≤ α ^ j := by
   intro i j hij

--- a/progress/2026-06-14T20-08-15Z_edb9eb19.md
+++ b/progress/2026-06-14T20-08-15Z_edb9eb19.md
@@ -1,0 +1,26 @@
+# Session edb9eb19 — feature worker
+
+## Accomplished
+- Premise-checked #6777 (l2norm_upper_lt_divisor at the executable cap) and
+  found its stated dependency stale: the auxiliary-power bound attributed to
+  #6783 was never delivered. Supersession chain #6783 -> #7330 -> #7332, the
+  last still in progress and unmerged. No proof of
+  `l2norm aux ^ deg ≤ bhksPaperAuxiliaryFactorReal` exists in the codebase;
+  only the coefficient-side bound is proved. Posted an evidence comment,
+  added `depends-on: #7332`, and skipped #6777 for replan.
+- Completed #7335: added one-sentence backtick-led docstrings to the six
+  private LLLCore rational-arithmetic helpers in `HexLLL/Basic.lean`
+  (`ratMulSelfNonneg`, `foldlNonneg`, `stepBound_arith`, `divStep_arith`,
+  `ratPow_nonneg`, `ratPow_le_pow_of_one_le`). Doc-only, additions only.
+
+## Current frontier
+- `HexLLL/Basic.lean` Phase 6 docstring coverage advanced by one cluster.
+
+## Next step
+- #7336 (HexMatrix Bareiss array determinant driver docstrings) remains
+  unclaimed and is the obvious next doc item.
+- #6777 stays blocked until #7332 + the follow-on tight-coefficient-bound /
+  paper-threshold-consumer issue land.
+
+## Blockers
+- None for #7335. #6777 blocked on #7332 (upstream, in progress).


### PR DESCRIPTION
Closes #7335

Session: `edb9eb19-40e2-4dc9-a0d6-a129fd23dee7`

dead4123 chore: worker-flow note that a CLOSED dependency may be a premise-skip, not a delivered artifact
f6b3b571 doc: HexLLL Basic.lean Phase 6 docstrings for the LLLCore rational-arithmetic step-bound helpers (#7335)

🤖 Prepared with Claude Code