### PR TITLE
doc: HexMatrix Bareiss.lean Phase 6 docstrings for the array-backed determinant driver cluster (pivotArrayLoop / bareissArrayState / bareissArrayDet)

### DIFF
--- a/HexMatrix/Bareiss.lean
+++ b/HexMatrix/Bareiss.lean
@@ -833,6 +833,8 @@ def stepArray (rows : Array (Array Int)) (n k : Nat) (pivot prevPivot : Int) :
     else
       rows[i]!
 
+/-- `getEntry_rangeMap₂` proves that reading entry `(i, j)` from the matrix
+materialised by the doubly-ranged `Array.range` map of `f` recovers `f i j`. -/
 private theorem getEntry_rangeMap₂ (f : Nat → Nat → Int) (i j : Fin n) :
     getEntry ((Array.range n).map fun row => (Array.range n).map fun col => f row col)
       i.val j.val = f i.val j.val := by
@@ -912,6 +914,9 @@ theorem rowsToMatrix_stepArray {n : Nat} (rows : Array (Array Int)) (k : Nat)
     getEntry_stepArray_matches rows (rowsToMatrix rows n) hentry k pivot prevPivot
       ⟨i, hi⟩ ⟨j, hj⟩
 
+/-- `pivotArrayLoop` runs the fuelled main elimination loop over the
+array-backed state, pivoting at each step, recording a singular column when no
+nonzero pivot exists, and otherwise applying `stepArray` before recursing. -/
 private def pivotArrayLoop (n fuel : Nat) (state : BareissArrayState) :
     BareissArrayState :=
   match fuel with
@@ -1044,6 +1049,9 @@ theorem pivotLoop_regular_branch_swap (fuel : Nat) (state : BareissState n)
           singularStep := none } := by
   simp [pivotLoop, hDone, hp0, hfind, hp]
 
+/-- `bareissArrayState` runs the matrix-level Bareiss elimination via `pivotLoop`
+and repackages the reduced result as a `BareissArrayState`, storing the matrix
+row-by-row via `matrixToRows`. -/
 private def bareissArrayState (M : Matrix Int n n) : BareissArrayState :=
   let state := pivotLoop n
     { step := 0
@@ -1057,14 +1065,21 @@ private def bareissArrayState (M : Matrix Int n n) : BareissArrayState :=
     rowSwaps := state.rowSwaps
     singularStep := state.singularStep }
 
+/-- `arraySign` is the determinant sign contributed by `rowSwaps` recorded row
+swaps, `1` for an even count and `-1` for an odd count. -/
 private def arraySign (rowSwaps : Nat) : Int :=
   if rowSwaps % 2 = 0 then 1 else -1
 
+/-- `arrayLastDiag?` reads the last diagonal entry `(n-1, n-1)` of the reduced
+rows, returning `none` when `n = 0`. -/
 private def arrayLastDiag? (rows : Array (Array Int)) (n : Nat) : Option Int :=
   match n with
   | 0 => none
   | k + 1 => some (getEntry rows k k)
 
+/-- `bareissArrayDet` assembles the determinant value from the final array
+state, returning `0` when elimination recorded a singular column and the signed
+last diagonal entry otherwise. -/
 private def bareissArrayDet (state : BareissArrayState) (n : Nat) : Int :=
   match state.singularStep with
   | some _ => 0

--- a/progress/2026-06-14T203517Z_44b64056.md
+++ b/progress/2026-06-14T203517Z_44b64056.md
@@ -1,0 +1,32 @@
+# 2026-06-14T20:35:17Z — feature session (44b64056)
+
+## Accomplished
+
+Issue #7336: added one-sentence backtick-led docstrings to the six
+private declarations of the array-backed Bareiss determinant driver
+cluster in `HexMatrix/Bareiss.lean`:
+
+- `getEntry_rangeMap₂`
+- `pivotArrayLoop`
+- `bareissArrayState`
+- `arraySign`
+- `arrayLastDiag?`
+- `bareissArrayDet`
+
+Doc-only change (15 additions, 0 deletions). `lake build
+HexMatrix.Bareiss` green, `scripts/check_dag.py` exits 0, `git diff
+--check` clean, no banned vocabulary or em-dashes on added lines.
+
+## Current frontier
+
+#7336 complete; PR pending.
+
+## Next step
+
+Remaining unclaimed Phase 6 doc items: #7339 (HexPolyZ Basic.lean
+rational-poly arithmetic helpers), #7342 (HexMatrix Determinant.lean
+moveColumnToLastValues cluster).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7336

Session: `44b64056-e51d-4bc4-86b2-cccaba295615`

8a939018 chore: progress entry for #7336 Bareiss array driver docstrings
548124ae doc: HexMatrix Bareiss.lean Phase 6 docstrings for the array-backed determinant driver cluster

🤖 Prepared with Claude Code