### PR TITLE
doc: HexLLL Basic.lean Phase 6 docstrings for the base-2^K packing / folded-dot-bound helper cluster (foldl_max_le_init / foldl_dot_pack / foldl_dot_natAbs_le ... two_mul_lt_width, 8 lemmas)

### DIFF
--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -89,6 +89,8 @@ def mulEqCert (M : Matrix Int n n) (A C : Matrix Int n m) : Bool :=
   (List.finRange n).all fun i =>
     Vector.dotProduct (row M i) packs == packRow K (row C i)
 
+/-- `foldl_max_le_init` shows that the initial accumulator is bounded by the
+running `Nat.max` scan used to compute entrywise absolute-value bounds. -/
 private theorem foldl_max_le_init {α : Type} (f : α → Nat) (l : List α) (acc : Nat) :
     acc ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
   induction l generalizing acc with
@@ -97,6 +99,8 @@ private theorem foldl_max_le_init {α : Type} (f : α → Nat) (l : List α) (ac
       simp only [List.foldl_cons]
       exact Nat.le_trans (Nat.le_max_left acc (f x)) (ih (Nat.max acc (f x)))
 
+/-- `le_foldl_max` bounds any listed value by the completed `Nat.max` scan used
+to justify `maxAbs` matrix entry bounds. -/
 private theorem le_foldl_max {α : Type} (f : α → Nat) (l : List α) (acc : Nat)
     {x : α} (hx : x ∈ l) :
     f x ≤ l.foldl (fun a x => Nat.max a (f x)) acc := by
@@ -155,18 +159,24 @@ theorem packRow_zipWith_muladd (K : Nat) (c : Int) (r s : Vector Int m) :
   rw [Vector.toList_zipWith]
   exact packDigits_zipWith_muladd _ c _ _ (by simp)
 
+/-- `packDigits_replicate_zero` says that packing an all-zero digit list gives
+zero, providing the base packed row for folded dot products. -/
 private theorem packDigits_replicate_zero (P : Int) (m : Nat) :
     packDigits P (List.replicate m 0) = 0 := by
   induction m with
   | zero => rfl
   | succ m ih => simp [List.replicate_succ, packDigits, ih]
 
+/-- `packRow_replicate_zero` lifts zero-list packing to rows, supplying the
+zero packed row used to start product row folds. -/
 private theorem packRow_replicate_zero (K m : Nat) :
     packRow K (Vector.replicate m (0 : Int)) = 0 := by
   unfold packRow
   rw [Vector.toList_replicate]
   exact packDigits_replicate_zero _ m
 
+/-- `foldl_dot_pack` commutes a folded dot product with packing the folded
+coefficient-times-row update. -/
 private theorem foldl_dot_pack (K : Nat) (c : Vector Int n) (A : Matrix Int n m)
     (ls : List (Fin n)) (w : Vector Int m) :
     ls.foldl (fun acc l => acc + c[l] * packRow K (row A l)) (packRow K w) =
@@ -180,6 +190,8 @@ private theorem foldl_dot_pack (K : Nat) (c : Vector Int n) (A : Matrix Int n m)
         packRow_zipWith_muladd]
       grind
 
+/-- `foldl_zipWith_getElem` identifies each entry of a folded `zipWith` row
+update with the matching folded scalar dot update. -/
 private theorem foldl_zipWith_getElem (c : Vector Int n) (A : Matrix Int n m)
     (ls : List (Fin n)) (w : Vector Int m) (j : Fin m) :
     (ls.foldl
@@ -278,6 +290,8 @@ theorem packDigits_inj (K : Nat) {xs ys : List Int}
               exact Nat.le_mul_of_pos_right _ (by omega)
             omega
 
+/-- `foldl_dot_natAbs_le` bounds the absolute value of a folded integer dot sum
+from per-entry bounds and the length of the folded index list. -/
 private theorem foldl_dot_natAbs_le (u v : Vector Int k) (Bu Bv : Nat)
     (hu : ∀ l : Fin k, u[l].natAbs ≤ Bu) (hv : ∀ l : Fin k, v[l].natAbs ≤ Bv)
     (ls : List (Fin k)) (acc : Int) :
@@ -307,6 +321,8 @@ theorem natAbs_dotProduct_le (u v : Vector Int k) (Bu Bv : Nat)
   have h := foldl_dot_natAbs_le u v Bu Bv hu hv (List.finRange k) 0
   simpa [Vector.dotProduct] using h
 
+/-- `two_mul_lt_width` turns a bound `x ≤ B` into the base-width inequality
+needed for balanced packing injectivity. -/
 private theorem two_mul_lt_width {x B : Nat} (hx : x ≤ B) :
     2 * x < 2 ^ (B.log2 + 2) := by
   have h1 : B < 2 ^ (B.log2 + 1) := Nat.lt_log2_self

--- a/progress/20260614_211221_8f516d96.md
+++ b/progress/20260614_211221_8f516d96.md
@@ -1,0 +1,37 @@
+# Progress — 2026-06-14 21:12 UTC (session 8f516d96, doc)
+
+## Accomplished
+
+Issue #7346: added Phase 6 one-sentence docstrings to the eight private
+packing and folded-dot-bound helpers in `HexLLL/Basic.lean`:
+
+- `foldl_max_le_init`, `le_foldl_max`, `packDigits_replicate_zero`,
+  `packRow_replicate_zero`, `foldl_dot_pack`, `foldl_zipWith_getElem`,
+  `foldl_dot_natAbs_le`, and `two_mul_lt_width`.
+
+The change is doc-only. No signatures, statements, proofs, declaration
+order, attributes, or simp sets were touched.
+
+## Current frontier
+
+The requested `HexLLL/Basic.lean` base-`2^K` packing / folded-dot-bound
+doc cluster is complete. The separate LLLCore rational-arithmetic cluster
+around lines 423-584 was not touched.
+
+## Next step
+
+Open the PR for issue #7346 after committing this Lean doc-only change and
+progress note.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexLLL.Basic`: green.
+- `python3 scripts/check_dag.py`: exits 0.
+- `git diff --check`: clean.
+- `git diff --numstat -- HexLLL/Basic.lean`: `16 0`.
+- Added-line hygiene grep found no `sorry`, `axiom`, `native_decide`,
+  `TODO`, `FIXME`, banned vocabulary, or em-dashes.


### PR DESCRIPTION
Closes #7346

Session: `8f516d96-7cbc-4c44-a3ef-ffe690a2d958`

35182a11 doc: document HexLLL packing helpers

🤖 Prepared with Claude Code