### PR TITLE
doc: HexMatrix Determinant.lean Phase 6 docstrings for the permutation-vector insertion helper cluster (insertAt_last_castSucc_injective ... permutationVectors_flatMap_nodup, 4 lemmas)

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -1863,6 +1863,10 @@ private theorem insertAt_last_castSucc_idxOf {n : Nat}
     exact insertAt_get_self (Fin.last n) (v.map Fin.castSucc) i
   simpa [hget] using hins.idxOf_getElem i.val hlen
 
+/-- `insertAt_last_castSucc_injective` states that inserting `Fin.last n` into the
+`castSucc`-lifted nodup vectors `v` and `w` at positions `i` and `j` yields equal
+results only when `i = j` and `v = w`, the injectivity that keeps the inserted
+permutation vectors distinct in the recursive enumeration. -/
 private theorem insertAt_last_castSucc_injective {n : Nat}
     {v w : Vector (Fin n) n} {i j : Fin (n + 1)}
     (hv : v.toList.Nodup) (hw : w.toList.Nodup)
@@ -1894,6 +1898,9 @@ private theorem insertAt_last_castSucc_injective {n : Nat}
   apply Array.toList_inj.mp
   simpa [Vector.toList] using hvwList
 
+/-- `permutationVectorInsertions_nodup` states that, for a fixed nodup vector `v`,
+the list of insertions of `Fin.last n` at each position has no duplicates, so the
+size-`n+1` vectors built from a single size-`n` permutation stay distinct. -/
 private theorem permutationVectorInsertions_nodup {n : Nat}
     (v : Vector (Fin n) n) (hnodup : v.toList.Nodup) :
     ((List.finRange (n + 1)).map fun i =>
@@ -1902,6 +1909,9 @@ private theorem permutationVectorInsertions_nodup {n : Nat}
     (fun i j h => (insertAt_last_castSucc_injective hnodup hnodup h).1)
     (List.nodup_finRange (n + 1))
 
+/-- `permutationVectorInsertions_disjoint` states that distinct nodup vectors `v`
+and `w` produce insertion lists sharing no element, the cross-vector disjointness
+that prevents collisions when the per-vector insertions are concatenated. -/
 private theorem permutationVectorInsertions_disjoint {n : Nat}
     {v w : Vector (Fin n) n}
     (hv : v.toList.Nodup) (hw : w.toList.Nodup) (hvw : v ≠ w) :
@@ -1916,6 +1926,10 @@ private theorem permutationVectorInsertions_disjoint {n : Nat}
   rcases hb with ⟨j, _hj, hb⟩
   exact hvw (insertAt_last_castSucc_injective hv hw (hab.trans hb.symm)).2
 
+/-- `permutationVectors_flatMap_nodup` states that flat-mapping the per-vector
+insertion lists over a nodup list `vs` of nodup vectors yields a nodup list,
+combining the per-vector and cross-vector facts into the no-duplicates property of
+the size-`n+1` permutation enumeration. -/
 private theorem permutationVectors_flatMap_nodup {n : Nat}
     (vs : List (Vector (Fin n) n))
     (hvs : vs.Nodup) (hperm : ∀ v, v ∈ vs → v.toList.Nodup) :

--- a/progress/2026-06-15T00-43-57Z_c663c82c.md
+++ b/progress/2026-06-15T00-43-57Z_c663c82c.md
@@ -1,0 +1,37 @@
+# Session c663c82c — feature (Phase 6 docstrings)
+
+## Accomplished
+
+- Queue housekeeping: issue #6779 (B-builder fast-BHKS finisher) was
+  listed as unclaimed but is structurally blocked on directive #2564
+  (van Hoeij CLD lattice rollback). Its body states the modular
+  resultant-divisibility clause is false as typed on the current
+  cut-aux object and the finisher can only be re-derived after #2564
+  restructures the lattice. Added `depends-on: #2564` via
+  `coordination add-dep 6779 2564`, marking it `blocked` so workers
+  stop repeatedly picking it up.
+- Claimed and completed #7388: added one-sentence `/-- -/` docstrings
+  to four private helper lemmas in `HexMatrix/Determinant.lean`
+  supporting the permutation-vector insertion step of the Laplace
+  determinant expansion:
+  - `insertAt_last_castSucc_injective`
+  - `permutationVectorInsertions_nodup`
+  - `permutationVectorInsertions_disjoint`
+  - `permutationVectors_flatMap_nodup`
+
+## Current frontier
+
+Doc-only PR for #7388. `lake build HexMatrix.Determinant` green,
+`check_dag` exit 0, `git diff --numstat` shows 14/0 (additions only),
+no banned tokens.
+
+## Next step
+
+Sibling docstring issues #7389 (inversePermutationValues cluster) and
+#7390 (HexGramSchmidt Int cluster) remain unclaimed for the next
+worker.
+
+## Blockers
+
+None. Note #7364 (forward modP->lift transport) is blocked on the
+still-open #7381.


### PR DESCRIPTION
Closes #7388

Session: `c663c82c-8a27-49f4-af7b-4ca475abe48a`

71ca7353 doc: Phase 6 docstrings for permutation-vector insertion helpers (#7388)

🤖 Prepared with Claude Code