### PR TITLE
doc: carve out the replan worker type in the /once claim step

### DIFF
--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -25,10 +25,20 @@ immediately with `ABORT: no issue number provided`.
    `coordination claim <N> --label <type>`. Do **NOT** use
    `coordination list-unclaimed` — you are not picking from the
    queue.
+   **Exception — `replan` worker type.** `replan` issues are
+   deliberately *unclaimable*: `coordination claim <N> --label replan`
+   returns `CLAIM FAILED: Issue #<N> needs replan`. Do **not** treat
+   this as an abort. Replan triages issues directly (edit body/labels,
+   close with forward links) via the `replan` skill — there is no
+   claim and no PR. Skip the claim, read the `replan` skill, and triage
+   `#<N>` per its disposition rules. If `#<N>` no longer carries the
+   `replan` label (already triaged by a concurrent session), confirm
+   the disposition is correct and exit without further edits.
 4. **If the claim fails** (issue already claimed by another agent,
-   issue closed, issue not labelled with the worker type, etc.),
-   exit immediately. Print `ABORT: claim failed for #<N>` and do
-   nothing else. No worktree commits, no branches, no PR.
+   issue closed, issue not labelled with the worker type, etc.) — and
+   the worker type is **not** `replan` — exit immediately. Print
+   `ABORT: claim failed for #<N>` and do nothing else. No worktree
+   commits, no branches, no PR.
 5. Once the claim succeeds, **execute the issue end-to-end**
    following the standard worker flow for the matched type
    (implementation, build, tests, commit, push, open PR).


### PR DESCRIPTION
This PR documents that `replan` issues are deliberately unclaimable, so a one-shot `/once` dispatch with `WORKER TYPE: replan` must skip `coordination claim` and triage directly via the `replan` skill rather than aborting on the claim-guard failure. Surfaced while running `pod once 7364` (a replan dispatch): `coordination claim 7364 --label replan` returns `CLAIM FAILED: Issue #7364 needs replan`, which a literal reading of the existing step 4 would treat as a fatal abort, wasting the dispatch. The added carve-out also handles the already-triaged case, where the `replan` label is gone because a concurrent session reached the issue first.

🤖 Prepared with Claude Code