### PR TITLE
doc: HexLLL Bench.lean Phase 6 docstrings for the native exact lllNative random-bounded ladder cluster (runNativeFirstShortVectorRandomBoundedNormSq30 ... 180, 8 targets)

### DIFF
--- a/HexLLL/Bench.lean
+++ b/HexLLL/Bench.lean
@@ -1160,34 +1160,58 @@ def runFpLLLFirstShortVectorHarshCubic65Checksum : Unit → IO Int := fun _ => d
 
 -- Exact `lllNative` ladder targets for the comparator's exact-native curve
 -- (the steered default lives on the `runFirstShortVector*NormSq` targets).
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 30`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq30 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput30Ref (fun _ => prepRandomBoundedInput 30))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 45`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq45 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput45Ref (fun _ => prepRandomBoundedInput 45))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 60`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq60 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput60Ref (fun _ => prepRandomBoundedInput 60))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 75`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq75 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput75Ref (fun _ => prepRandomBoundedInput 75))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 90`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq90 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput90Ref (fun _ => prepRandomBoundedInput 90))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 120`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq120 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput120Ref (fun _ => prepRandomBoundedInput 120))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 150`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq150 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput150Ref (fun _ => prepRandomBoundedInput 150))
 
+/-- Exact native `runNativeFirstShortVectorNormSq` on the `random-bounded`
+fixture at the rung `n = 180`, returning the first short vector's squared norm
+for the exact-native ladder curve. -/
 def runNativeFirstShortVectorRandomBoundedNormSq180 : Unit → IO Int := fun _ => do
   return runNativeFirstShortVectorNormSq
     (← getCachedInput randomBoundedInput180Ref (fun _ => prepRandomBoundedInput 180))

--- a/progress/20260615T010942Z_a4837957.md
+++ b/progress/20260615T010942Z_a4837957.md
@@ -1,0 +1,30 @@
+# Phase 6 docstrings: native exact lllNative random-bounded ladder cluster
+
+Session type: feature (#7403)
+
+## Accomplished
+
+Added one-`/-- ... -/` docstrings to the 8 native exact-`lllNative`
+random-bounded ladder targets in `HexLLL/Bench.lean`
+(`runNativeFirstShortVectorRandomBoundedNormSq{30,45,60,75,90,120,150,180}`,
+~lines 1163–1193). Each states it runs `runNativeFirstShortVectorNormSq`
+on the cached `random-bounded` fixture at its dimension rung, returning
+the first short vector's squared norm for the exact-native ladder curve.
+Doc-only: signatures, bodies, rung values, cached-input refs, order, and
+`private` modifiers untouched.
+
+## Current frontier
+
+Verified: `lake build HexLLL.Bench` green; `scripts/check_dag.py` exit 0;
+`git diff --check` clean; `git diff --numstat` shows `24 0` (additions
+only); no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` in added lines.
+
+## Next step
+
+The sibling `runNativeFirstShortVectorHarshCubicNormSq*` family (~line
+1195 onward) is the harsh-cubic input variant and remains an undocumented
+future Phase 6 batch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7403

Session: `a4837957-8cf9-42b4-aa32-71084af86a6a`

cd87eca1 doc: Phase 6 docstrings for native exact lllNative random-bounded ladder cluster (#7403)

🤖 Prepared with Claude Code