### PR TITLE
doc: HexGFqField Bench.lean Phase 6 docstrings for the FLINT fq_default comparator-wrapper cluster (runFlintAddChecksum ... runFlintFrobChecksum, 7 wrappers)

### DIFF
--- a/HexGFqField/Bench.lean
+++ b/HexGFqField/Bench.lean
@@ -592,6 +592,9 @@ def runFlintOfPolyReprChecksum (input : OfPolyInput) : IO UInt64 := do
       ("a", fpPolySevenToFlintJson input.poly)]
   checksumFlintCoeffReply result
 
+/-- Drive FLINT `fq_default` `add` on a `BinaryInput` (shared modulus plus the
+two operands `lhs`, `rhs`) and return a checksum of the FLINT reply, for
+comparison against the native `runAddChecksum` target at the same rung. -/
 def runFlintAddChecksum (input : BinaryInput) : IO UInt64 := do
   let result ← Hex.BenchOracle.Flint.runOp "fq_default" "add"
     #[("p", (7 : Lean.Json)),
@@ -600,6 +603,9 @@ def runFlintAddChecksum (input : BinaryInput) : IO UInt64 := do
       ("b", fpPolySevenToFlintJson (repr input.rhs))]
   checksumFlintCoeffReply result
 
+/-- Drive FLINT `fq_default` `mul` on a `BinaryInput` (shared modulus plus the
+two operands `lhs`, `rhs`) and return a checksum of the FLINT reply, for
+comparison against the native `runMulChecksum` target at the same rung. -/
 def runFlintMulChecksum (input : BinaryInput) : IO UInt64 := do
   let result ← Hex.BenchOracle.Flint.runOp "fq_default" "mul"
     #[("p", (7 : Lean.Json)),
@@ -608,6 +614,10 @@ def runFlintMulChecksum (input : BinaryInput) : IO UInt64 := do
       ("b", fpPolySevenToFlintJson (repr input.rhs))]
   checksumFlintCoeffReply result
 
+/-- Drive two FLINT `fq_default` operations on a `BinaryInput` — `neg` on `lhs`
+and `sub` on `lhs - rhs` over the shared modulus — and return the `mixHash` of
+their two reply checksums, for comparison against the native target at the same
+rung. -/
 def runFlintNegSubChecksum (input : BinaryInput) : IO UInt64 := do
   let negResult ← Hex.BenchOracle.Flint.runOp "fq_default" "neg"
     #[("p", (7 : Lean.Json)),
@@ -620,6 +630,9 @@ def runFlintNegSubChecksum (input : BinaryInput) : IO UInt64 := do
       ("b", fpPolySevenToFlintJson (repr input.rhs))]
   return mixHash (← checksumFlintCoeffReply negResult) (← checksumFlintCoeffReply subResult)
 
+/-- Drive FLINT `fq_default` `pow` on a `PowInput` (modulus, base `value`, and a
+natural-number `exponent`) and return a checksum of the FLINT reply, for
+comparison against the native `runPowChecksum` target at the same rung. -/
 def runFlintPowChecksum (input : PowInput) : IO UInt64 := do
   let result ← Hex.BenchOracle.Flint.runOp "fq_default" "pow"
     #[("p", (7 : Lean.Json)),
@@ -628,6 +641,10 @@ def runFlintPowChecksum (input : PowInput) : IO UInt64 := do
       ("exponent", Lean.Json.num (Lean.JsonNumber.fromNat input.exponent))]
   checksumFlintCoeffReply result
 
+/-- Drive two FLINT `fq_default` operations on a `BinaryInput` — `inv` on `lhs`
+and `div` on `lhs / rhs` over the shared modulus — and return the `mixHash` of
+their two reply checksums, for comparison against the native target at the same
+rung. -/
 def runFlintInvDivChecksum (input : BinaryInput) : IO UInt64 := do
   let invResult ← Hex.BenchOracle.Flint.runOp "fq_default" "inv"
     #[("p", (7 : Lean.Json)),
@@ -640,6 +657,9 @@ def runFlintInvDivChecksum (input : BinaryInput) : IO UInt64 := do
       ("b", fpPolySevenToFlintJson (repr input.rhs))]
   return mixHash (← checksumFlintCoeffReply invResult) (← checksumFlintCoeffReply divResult)
 
+/-- Drive FLINT `fq_default` `pow` on a `ZPowInput` (modulus, base `value`, and a
+signed integer `exponent`) and return a checksum of the FLINT reply, for
+comparison against the native `runZPowChecksum` target at the same rung. -/
 def runFlintZPowChecksum (input : ZPowInput) : IO UInt64 := do
   let result ← Hex.BenchOracle.Flint.runOp "fq_default" "pow"
     #[("p", (7 : Lean.Json)),
@@ -648,6 +668,10 @@ def runFlintZPowChecksum (input : ZPowInput) : IO UInt64 := do
       ("exponent", Lean.Json.num (Lean.JsonNumber.fromInt input.exponent))]
   checksumFlintCoeffReply result
 
+/-- Drive the Frobenius map as FLINT `fq_default` `pow` with the fixed exponent
+`p = 7` on a `UnaryInput` (modulus and base `value`) and return a checksum of the
+FLINT reply, for comparison against the native `runFrobChecksum` target at the
+same rung. -/
 def runFlintFrobChecksum (input : UnaryInput) : IO UInt64 := do
   let result ← Hex.BenchOracle.Flint.runOp "fq_default" "pow"
     #[("p", (7 : Lean.Json)),

--- a/progress/2026-06-15T01-09-48Z_e6da1d9b.md
+++ b/progress/2026-06-15T01-09-48Z_e6da1d9b.md
@@ -1,0 +1,33 @@
+# Session e6da1d9b — doc #7402
+
+**Type:** feature (Phase 6 docstring batch)
+
+## Accomplished
+
+Added `/-- ... -/` docstrings to the 7 undocumented FLINT `fq_default`
+comparator-wrapper functions in `HexGFqField/Bench.lean`
+(`runFlintAddChecksum`, `runFlintMulChecksum`, `runFlintNegSubChecksum`,
+`runFlintPowChecksum`, `runFlintInvDivChecksum`, `runFlintZPowChecksum`,
+`runFlintFrobChecksum`). Each states the FLINT op driven, the input
+shape consumed, and that it returns a checksum of the FLINT reply for
+comparison against the native target at the same rung. The two
+combined-op wrappers (neg+sub, inv+div) note the `mixHash` of two reply
+checksums.
+
+Doc-only: no signature, body, ordering, or `private` changes.
+
+## Current frontier
+
+`lake build HexGFqField.Bench` green; `scripts/check_dag.py` exit 0;
+`git diff --check` clean; numstat `24 0` (additions only); no banned
+tokens in added lines.
+
+## Next step
+
+Sibling batch #7403 (HexLLL Bench native exact ladder) remains
+unclaimed. The per-rung paired wrappers (`runFooN`/`runFlintFooN`,
+~line 659+) are a separate future batch.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7402

Session: `e6da1d9b-c2b1-47a0-ad42-e867ec3ece0d`

dee3e704 doc: Phase 6 docstrings for HexGFqField FLINT fq_default comparator wrappers (#7402)

🤖 Prepared with Claude Code