### PR TITLE
feat: representsModP_correspondent — mod-p representation of the monic correspondent g ∣ M from toMonicPrimeData?

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -20356,6 +20356,37 @@ theorem exists_monicCorrespondent_of_dvd
       exact ⟨h, hgh.symm⟩
   exact ⟨g, hg_monic, hdvdg, hprim⟩
 
+/-- **Mod-`p` representation of the monic correspondent (#7381, prereq of #7364).**
+
+For prime data selected by `toMonicPrimeData? core` — that is, `choosePrimeData?`
+applied to `M := (toMonic core).monic` — any irreducible integer divisor `g`
+of `M` has a representing subset of `M`'s recorded mod-`p` factors. This
+discharges the `hrepP` input of `henselLiftData_represents_lifted_of_modP`
+(instantiated at `core := M`, `factor := g`) for the monic-correspondent arm
+of the `toMonicLiftData` forward transport.
+
+The representation is read off **directly** from the `toMonicPrimeData?`
+partition, which already ranges over `M`'s mod-`p` factors via
+`modPSubsetPartitionHypotheses_of_choosePrimeData`; it is *not* transported from
+a representation of the original-core divisor. The correspondent `g` and its
+non-monic preimage differ by a dilation `X ↦ (leadingCoeff core)·X`, and
+`monicModPImage` is not dilation-invariant (the transport equality
+`monicModPImage (modP p factor) = monicModPImage (modP p g)` was refuted in
+\#7366). Consequently `g`'s representing subset is its own, so the sound
+conclusion is existential — there is no representation at a subset prescribed
+by the preimage. -/
+theorem representsModP_correspondent
+    (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    {g : Hex.ZPoly}
+    (hg_irr : Irreducible (HexPolyZMathlib.toPolynomial g))
+    (hg_dvd : g ∣ (Hex.ZPoly.toMonic core).monic) :
+    ∃ S : ModPFactorSubset primeData, RepresentsIntegerFactorModP primeData g S := by
+  have hchoose :
+      Hex.choosePrimeData? (Hex.ZPoly.toMonic core).monic = some primeData := hselected
+  exact (modPSubsetPartitionHypotheses_of_choosePrimeData
+    (Hex.ZPoly.toMonic core).monic primeData hchoose).exists_subset hg_irr hg_dvd
+
 end
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260615T011815Z_9398b2c7.md
+++ b/progress/20260615T011815Z_9398b2c7.md
@@ -1,0 +1,70 @@
+# Progress — 2026-06-15 (session 9398b2c7, feature)
+
+## Accomplished
+
+Issue #7381 (corrected prereq of #7364, replacing refuted #7366): added
+`representsModP_correspondent` to `HexBerlekampZassenhausMathlib/Basic.lean`
+(after `exists_monicCorrespondent_of_dvd`, before the section `end`).
+
+It produces the mod-`p` representation of a monic correspondent `g ∣ M`
+(`M := (toMonic core).monic`) directly from the `toMonicPrimeData?` partition:
+
+```
+representsModP_correspondent
+    (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    {g : Hex.ZPoly}
+    (hg_irr : Irreducible (HexPolyZMathlib.toPolynomial g))
+    (hg_dvd : g ∣ (Hex.ZPoly.toMonic core).monic) :
+    ∃ S : ModPFactorSubset primeData, RepresentsIntegerFactorModP primeData g S
+```
+
+Proof is a one-liner: `toMonicPrimeData? core = choosePrimeData? M`
+definitionally, so `modPSubsetPartitionHypotheses_of_choosePrimeData M primeData
+hselected` builds the M-partition and `.exists_subset hg_irr hg_dvd` projects
+the representation.
+
+## Decisions — corrected the issue's suggested signature
+
+The issue's sketched signature concluded `RepresentsIntegerFactorModP primeData
+g S` for a **given** implicit `S`, plus an `hg_monic` hypothesis and an
+unspecified `hpartition`. Three sound corrections (the issue explicitly invited
+verifying the bundle):
+
+1. **Existential conclusion, not given-`S`.** A partition hypothesis pins down
+   only `g`'s *own* representing subset; it cannot certify representation at an
+   externally-supplied `S`. The given-`S` form is unprovable, and reduces to the
+   false `monicModPImage (modP p factor) = monicModPImage (modP p g)` (the exact
+   equality refuted in #7366) when `S` is the preimage's subset. So `g`'s subset
+   is its own; the sound conclusion is `∃ S`.
+2. **Dropped `hg_monic`.** `ModPSubsetPartitionHypotheses.exists_subset` needs
+   only irreducibility + divisibility, not monicity.
+3. **No `hpartition` input.** The M-partition is derived from `hselected`
+   directly via `modPSubsetPartitionHypotheses_of_choosePrimeData`, so #7364 has
+   one fewer obligation to discharge.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: green (baseline on clean
+  origin/main also green — confirmed before editing, since the Mathlib layer is
+  not CI-built).
+- `lake build HexBerlekampZassenhausMathlib`: green (3788 jobs).
+- `python3 scripts/check_dag.py`: exit 0.
+- Added lines: 31 additions, 0 deletions; no `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+
+## Current frontier
+
+#7381 complete. #7364 is now unblocked but must consume the **existential**
+shape: `obtain ⟨S_g, hrep_g⟩ := representsModP_correspondent …` then feed
+`hrep_g` into `henselLiftData_represents_lifted_of_modP` at `core := M`,
+`factor := g`. Note `S_g` is `g`'s subset, not the original factor's `S`; the
+PR body flags this for #7364's assembly.
+
+## Next step
+
+#7364 (assembly of `toMonicLiftData_represents_lifted_of_modP`).
+
+## Blockers
+
+None for #7381.


### PR DESCRIPTION
Closes #7381

This PR adds `representsModP_correspondent` to `HexBerlekampZassenhausMathlib/Basic.lean`, the corrected prerequisite for #7364 that replaces the refuted #7366. For prime data selected by `toMonicPrimeData? core` (i.e. `choosePrimeData?` on `M := (toMonic core).monic`), it derives the mod-`p` representation of an irreducible integer divisor `g ∣ M` directly from the `toMonicPrimeData?` partition over `M`'s mod-`p` factors, ready to feed the `hrepP` input of `henselLiftData_represents_lifted_of_modP` at `core := M`, `factor := g`.

The proof is a thin projection: `toMonicPrimeData? core = choosePrimeData? M` definitionally, so `modPSubsetPartitionHypotheses_of_choosePrimeData M primeData hselected` builds the M-partition and `.exists_subset` reads off the subset.

The realized signature corrects the issue's sketch in three ways, all toward soundness and usability (the issue explicitly invited verifying the exact bundle):

- **Existential conclusion, not a prescribed `S`.** A partition hypothesis pins down only `g`'s own representing subset; it cannot certify representation at an externally-supplied `S`. Concluding `RepresentsIntegerFactorModP primeData g S` for an arbitrary `S` is unprovable, and when `S` is the non-monic preimage's subset it reduces to `monicModPImage (modP p factor) = monicModPImage (modP p g)` — the exact equality refuted in #7366 (`g` and its preimage differ by a dilation `X ↦ (leadingCoeff core)·X`, which `monicModPImage` does not collapse). So the sound conclusion is `∃ S`.
- **Dropped the monicity hypothesis.** `exists_subset` needs only irreducibility and divisibility.
- **No partition input.** The M-partition is built from `hselected` directly, so #7364 has one fewer obligation.

Note for the gated #7364 assembly: the returned `S` is `g`'s own subset, not the original factor's subset — consume it as `obtain ⟨S_g, hrep_g⟩ := representsModP_correspondent …`.

Verification: `lake build HexBerlekampZassenhausMathlib` green (3788 jobs; baseline on clean `origin/main` confirmed green before editing, since the Mathlib layer is not CI-built), `python3 scripts/check_dag.py` exit 0, added lines free of `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.

🤖 Prepared with Claude Code
