### PR TITLE
doc: HexMatrix RREF.lean Phase 6 docstrings for the row-combination / pivot-column cluster (pivot_column_entry ... rowCombination_echelonCoeffs_of_rowCombination, 4 lemmas)

### DIFF
--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -2002,6 +2002,8 @@ theorem rowCombination_single {R : Type u} [Lean.Grind.CommRing R]
   have hzero : (0 : R) + M[i][jf] = M[i][jf] := by grind
   exact hpick.trans hzero
 
+/-- In an RREF, a pivot column is a standard basis vector: its entry in row `i`
+is `1` when `i` is the pivot row of `p` and `0` otherwise. -/
 private theorem pivot_column_entry [Lean.Grind.Field R] (E : IsRREF M D)
     (p : Fin D.rank) (i : Fin n) :
     D.echelon[i][D.pivotCols.get p] =
@@ -2041,6 +2043,9 @@ private theorem pivot_column_entry [Lean.Grind.Field R] (E : IsRREF M D)
     have hzero := E.toIsEchelonForm.zero_row i (by omega)
     simpa using congrArg (fun row => row[D.pivotCols.get p]) hzero
 
+/-- Reading a row combination of the echelon rows off at pivot column `p` recovers
+exactly the coefficient applied to the pivot row of `p`, since that column is a
+standard basis vector. -/
 private theorem rowCombination_pivotCoeff [Lean.Grind.Field R] (E : IsRREF M D)
     (c : Vector R n) (p : Fin D.rank) :
     (rowCombination D.echelon c)[D.pivotCols.get p] =
@@ -2069,6 +2074,9 @@ private theorem rowCombination_pivotCoeff [Lean.Grind.Field R] (E : IsRREF M D)
             grind
           exact h.trans hzero
 
+/-- Two coefficient vectors that agree on every pivot row yield the same row
+combination of the echelon rows, because the non-pivot rows are zero rows and
+contribute nothing. -/
 private theorem rowCombination_eq_of_coeffs_eq_on_rank [Lean.Grind.Field R]
     (E : IsRREF M D) {c d : Vector R n}
     (hcoeff : ∀ i : Fin D.rank,
@@ -2102,6 +2110,9 @@ private theorem rowCombination_eq_of_coeffs_eq_on_rank [Lean.Grind.Field R]
     have hright : (0 : R) * d[i] = 0 := by grind
     rw [hleft, hright]
 
+/-- For any vector in the row span of the echelon matrix, the coefficients recovered
+by `echelonCoeffs` reproduce it, so `echelonCoeffs` is a right inverse to row
+combination on the span. -/
 private theorem rowCombination_echelonCoeffs_of_rowCombination [Lean.Grind.Field R]
     (E : IsRREF M D) {v : Vector R m}
     (h : ∃ c : Vector R n, rowCombination D.echelon c = v) :

--- a/progress/2026-06-15T01-37-12Z_3964849f.md
+++ b/progress/2026-06-15T01-37-12Z_3964849f.md
@@ -1,0 +1,37 @@
+# 2026-06-15T01:37Z — feature session (3964849f)
+
+## Accomplished
+
+Issue #7418: added Phase 6 one-sentence docstrings to the four undocumented
+`private theorem`s in the RREF row-combination / pivot-column cluster of
+`HexMatrix/RREF.lean`:
+
+- `pivot_column_entry`
+- `rowCombination_pivotCoeff`
+- `rowCombination_eq_of_coeffs_eq_on_rank`
+- `rowCombination_echelonCoeffs_of_rowCombination`
+
+Doc-only change (11 additions, 0 deletions). No signatures, statements,
+proofs, declaration order, or `private` modifiers touched.
+
+`#7416` was claimed by another agent first; pivoted to `#7418`.
+
+## Current frontier
+
+`HexMatrix/RREF.lean` Phase 6 docstring coverage advanced by one cluster.
+
+## Next step
+
+Other Phase 6 docstring clusters remain across the codebase (see the
+queue). The RREF file may still have undocumented private helpers outside
+this cluster.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexMatrix.RREF` green.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean; `git diff --numstat` additions only.


### PR DESCRIPTION
Closes #7418

Session: `3964849f-7fe2-46f6-9c33-30e67703e368`

097a4fb0 doc: Phase 6 docstrings for RREF row-combination / pivot-column cluster (#7418)

🤖 Prepared with Claude Code