### PR TITLE
doc: HexGF2 Field.lean Phase 6 docstrings for the GF2Poly mod-reduction ring-compatibility cluster (mod_add_mod_eq_mod_add ... dvd_of_mod_eq_zero, 4 lemmas)

### DIFF
--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -713,6 +713,9 @@ theorem reducePoly_mod_eq (p : GF2Poly) :
   exact GF2Poly.mod_eq_self_of_reduced (p % f) f
     (GF2Poly.mod_degree_lt p f hirr.1)
 
+/-- Reduction `% f` commutes with addition: reducing the sum of two remainders
+gives the same result as reducing the sum directly. This makes addition on the
+quotient `GF2nPoly f hirr` well-defined on reduced representatives. -/
 private theorem mod_add_mod_eq_mod_add (p q f : GF2Poly) :
     ((p % f) + (q % f)) % f = (p + q) % f := by
   let qp := (GF2Poly.divMod p f).1
@@ -737,6 +740,10 @@ private theorem mod_add_mod_eq_mod_add (p q f : GF2Poly) :
           exact (GF2Poly.mod_add_mul_right_eq_mod (rp + rq) (qp + qq) f).symm
     _ = (p + q) % f := by rw [hsum]
 
+/-- Reduction `% f` commutes with multiplication: reducing the product of two
+remainders gives the same result as reducing the product directly. This makes
+multiplication on the quotient `GF2nPoly f hirr` well-defined on reduced
+representatives. -/
 private theorem mod_mul_mod_eq_mod_mul (p q f : GF2Poly) :
     ((p % f) * (q % f)) % f = (p * q) % f := by
   let qp := (GF2Poly.divMod p f).1
@@ -797,6 +804,9 @@ private theorem mod_mul_mod_eq_mod_mul (p q f : GF2Poly) :
           exact (GF2Poly.mod_add_mul_right_eq_mod (rp * rq) c f).symm
     _ = (p * q) % f := by rw [hmul]
 
+/-- If `f` divides `p` then `p` reduces to `0` mod `f`: the forward direction of
+`p % f = 0 ↔ f ∣ p`, used to show a divisible polynomial collapses to the zero
+quotient class. -/
 private theorem mod_eq_zero_of_dvd {p f : GF2Poly} (hf : f ≠ 0) (h : f ∣ p) :
     p % f = 0 := by
   rcases h with ⟨c, hc⟩
@@ -827,6 +837,8 @@ private theorem mod_eq_zero_of_dvd {p f : GF2Poly} (hf : f ≠ 0) (h : f ∣ p) 
           GF2Poly.degree_le_of_dvd_nonzero hf hzero hfdvd_rem
         omega
 
+/-- If `p` reduces to `0` mod `f` then `f` divides `p`: the reverse direction of
+`p % f = 0 ↔ f ∣ p`, recovering divisibility from a vanishing remainder. -/
 private theorem dvd_of_mod_eq_zero {p f : GF2Poly} (h : p % f = 0) :
     f ∣ p := by
   let q := (GF2Poly.divMod p f).1

--- a/progress/2026-06-15T01:39:22Z_0b0dc5e6.md
+++ b/progress/2026-06-15T01:39:22Z_0b0dc5e6.md
@@ -1,0 +1,37 @@
+# 2026-06-15T01:39:22Z — feature (doc) session 0b0dc5e6
+
+## Accomplished
+
+Claimed and completed #7417: Phase 6 docstrings for the `HexGF2/Field.lean`
+GF2Poly mod-reduction ring-compatibility cluster. Added one-sentence
+docstrings to four `private theorem`s:
+
+- `mod_add_mod_eq_mod_add` — `%f` commutes with addition (well-defined
+  quotient `Add`).
+- `mod_mul_mod_eq_mod_mul` — `%f` commutes with multiplication (well-defined
+  quotient `Mul`).
+- `mod_eq_zero_of_dvd` — forward direction of `p % f = 0 ↔ f ∣ p`.
+- `dvd_of_mod_eq_zero` — reverse direction of `p % f = 0 ↔ f ∣ p`.
+
+Doc-only: no signatures, statements, proofs, declaration order, or `private`
+modifiers touched.
+
+## Verification
+
+- `lake build HexGF2.Field` green.
+- `python3 scripts/check_dag.py` exits 0.
+- `git diff --check` clean; `git diff --numstat` = 12 additions, 0 deletions.
+
+## Current frontier
+
+Directive #2564 (HO-1 van Hoeij CLD) remains `blocked` on a long dependency
+chain. Two doc tasks (#7416, #7418) and feature #7386 were claimed by other
+sessions during this turn (claim races).
+
+## Next step
+
+Next worker: claim remaining doc/feature work from `coordination list-unclaimed`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7417

Session: `0b0dc5e6-f0ec-4038-9759-63fef1a82311`

8994b611 chore: progress entry for #7417 docstring session (0b0dc5e6)
8a387dcb doc: Phase 6 docstrings for HexGF2 Field.lean mod-reduction ring-compatibility cluster (#7417)

🤖 Prepared with Claude Code