### PR TITLE
doc: HexPolyFp Compose.lean Phase 6 docstrings for the composeCoeffPowerSumUpTo accumulator cluster (composeCoeffPowerSumFrom_range_eq_upTo ... composeCoeffPowerSumUpTo_sub, 6 lemmas)

### DIFF
--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -326,6 +326,11 @@ theorem composeCoeffPowerSumUpTo_eq_core
       rw [composePower_eq_linearPow]
       rw [composeCoeffPowerSumUpTo_eq_core coeff n (base + 1) w]
 
+/-- The list-fed accumulator `composeCoeffPowerSumFrom` over the coefficient
+slice `[coeff base, …, coeff (base + n - 1)]` agrees with the index-fed
+`composeCoeffPowerSumUpTo coeff n base w`. This bridges the two power-sum
+representations so the explicit list form can be rewritten into the bounded
+indexed form used by the extension and subtraction lemmas. -/
 private theorem composeCoeffPowerSumFrom_range_eq_upTo
     (coeff : Nat → ZMod64 p) (w : FpPoly p) :
     ∀ n base,
@@ -341,6 +346,10 @@ private theorem composeCoeffPowerSumFrom_range_eq_upTo
       simpa [Function.comp_def, Nat.add_assoc, Nat.add_comm, Nat.add_left_comm]
         using composeCoeffPowerSumFrom_range_eq_upTo coeff w n (base + 1)
 
+/-- `compose f w` equals the bounded accumulator `composeCoeffPowerSumUpTo`
+run up to exactly `f.size` with `f`'s coefficients. This is the base
+characterization of composition as a power sum, from which the
+extend-past-the-bound variant `compose_eq_coeff_power_sum_upTo_bound` follows. -/
 private theorem compose_eq_coeff_power_sum_upTo_size (f w : FpPoly p) :
     DensePoly.compose f w =
       composeCoeffPowerSumUpTo (fun i => f.coeff i) f.size 0 w := by
@@ -348,6 +357,10 @@ private theorem compose_eq_coeff_power_sum_upTo_size (f w : FpPoly p) :
   rw [DensePoly.toArray_toList_eq_coeff_range]
   simpa using composeCoeffPowerSumFrom_range_eq_upTo (fun i => f.coeff i) w f.size 0
 
+/-- Single-step extension invariance: when the next coefficient
+`coeff (base + n)` is zero, growing the accumulator's bound from `n` to `n + 1`
+leaves its value unchanged, since the appended term contributes `C 0 * wⁱ = 0`.
+This is the inductive step behind the multi-step `_le_extend_base` lemma. -/
 private theorem composeCoeffPowerSumUpTo_succ_of_next_zero
     (coeff : Nat → ZMod64 p) (w : FpPoly p) :
     ∀ n base,
@@ -371,6 +384,10 @@ private theorem composeCoeffPowerSumUpTo_succ_of_next_zero
         simpa [Nat.add_assoc, Nat.add_comm, Nat.add_left_comm] using hzero)]
       simp only [composeCoeffPowerSumUpTo]
 
+/-- Multi-step extension invariance (general base): if every coefficient from
+index `base + bound` onward vanishes, then running the accumulator up to
+`bound + extra` gives the same value as running it up to `bound`, for any
+`extra`. Proved by iterating `_succ_of_next_zero`. -/
 private theorem composeCoeffPowerSumUpTo_le_extend_base
     (coeff : Nat → ZMod64 p) (w : FpPoly p) {base bound : Nat}
     (hzero : ∀ i, base + bound ≤ i → coeff i = 0) :
@@ -385,6 +402,10 @@ private theorem composeCoeffPowerSumUpTo_le_extend_base
       exact composeCoeffPowerSumUpTo_succ_of_next_zero
         coeff w (bound + extra) base (hzero (base + (bound + extra)) (by omega))
 
+/-- The `base = 0` specialization of `_le_extend_base`: when all coefficients
+at indices `≥ bound` vanish, the accumulator's value is unchanged by extending
+its bound to `bound + extra`. This is the form consumed by
+`compose_eq_coeff_power_sum_upTo_bound`. -/
 private theorem composeCoeffPowerSumUpTo_le_extend
     (coeff : Nat → ZMod64 p) (w : FpPoly p) {bound : Nat}
     (hzero : ∀ i, bound ≤ i → coeff i = 0) :
@@ -441,6 +462,10 @@ private theorem fp_add_sub_add_sub
   rw [DensePoly.coeff_add_semiring]
   grind
 
+/-- The accumulator is additive under coefficient subtraction: running
+`composeCoeffPowerSumUpTo` with the pointwise difference `f.coeff i - h.coeff i`
+equals the difference of the two separate accumulators. This linearity step
+feeds the `compose_sub` distributivity theorem. -/
 private theorem composeCoeffPowerSumUpTo_sub
     (f h w : FpPoly p) :
     ∀ n base,

--- a/progress/2026-06-15T01:49:33Z_3b7e1851.md
+++ b/progress/2026-06-15T01:49:33Z_3b7e1851.md
@@ -1,0 +1,25 @@
+# Session 2026-06-15T01:49:33Z (feature, 3b7e1851)
+
+## Accomplished
+- Claimed and executed #7424: Phase 6 docstrings for the
+  `composeCoeffPowerSumUpTo` accumulator cluster in `HexPolyFp/Compose.lean`.
+- Added one-sentence docstrings to all six target lemmas:
+  `composeCoeffPowerSumFrom_range_eq_upTo`,
+  `compose_eq_coeff_power_sum_upTo_size`,
+  `composeCoeffPowerSumUpTo_succ_of_next_zero`,
+  `composeCoeffPowerSumUpTo_le_extend_base`,
+  `composeCoeffPowerSumUpTo_le_extend`,
+  `composeCoeffPowerSumUpTo_sub`.
+- Doc-only change: 25 additions, 0 deletions. No signatures, statements,
+  proofs, or declaration order touched.
+- Verified: `lake build HexPolyFp.Compose` green, `check_dag.py` exit 0,
+  `git diff --check` clean, additions-only, no banned tokens.
+
+## Current frontier
+- #7424 complete; PR being opened.
+
+## Next step
+- Remaining Phase 6 doc clusters (#7423 claimed elsewhere, #7425 open).
+
+## Blockers
+- None.


### PR DESCRIPTION
Closes #7424

Session: `3b7e1851-c425-4e28-9694-d1cfaeed564b`

8710e9e2 chore: progress note for #7424 docstring session
3abe65f0 doc: Phase 6 docstrings for composeCoeffPowerSumUpTo accumulator cluster

🤖 Prepared with Claude Code