### PR TITLE
doc: HexMatrix RowEchelon.lean Phase 6 docstrings for the fold-sum algebra aux cluster (foldl_sum_congr_aux ... foldl_sum_add_aux, 4 lemmas)

### DIFF
--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -207,6 +207,9 @@ theorem row_rowAdd_of_ne [Mul R] [Add R]
     row (rowAdd M src dst c) src = row M src := by
   exact row_rowAdd_of_ne M src c hsrcdst
 
+/-- Two fold-sums over `xs` agree when their summand functions `f` and `g` agree
+pointwise on `xs`; congruence for the fold-sum under the integrand, used to rewrite
+the summand in the row-echelon sum manipulations. -/
 private theorem foldl_sum_congr_aux {R : Type u} [Add R] {α : Type v}
     (xs : List α) (f g : α → R) (acc : R)
     (h : ∀ x ∈ xs, f x = g x) :
@@ -221,6 +224,9 @@ private theorem foldl_sum_congr_aux {R : Type u} [Add R] {α : Type v}
     rw [hx]
     exact ih (acc + g x) hxs
 
+/-- Left multiplication by `c` distributes through a fold-sum, scaling each summand
+`f x` to `c * f x` and the initial accumulator to `c * acc`; pulls a left scalar
+factor through the accumulating sum in the row-echelon rewrites. -/
 private theorem foldl_sum_mul_left_aux {R : Type u} [Lean.Grind.Ring R]
     {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
     c * xs.foldl (fun acc x => acc + f x) acc =
@@ -233,6 +239,9 @@ private theorem foldl_sum_mul_left_aux {R : Type u} [Lean.Grind.Ring R]
     have hdist : c * (acc + f x) = c * acc + c * f x := by grind
     rw [hdist]
 
+/-- Right multiplication by `c` distributes through a fold-sum, scaling each summand
+`f x` to `f x * c` and the initial accumulator to `acc * c`; pulls a right scalar
+factor through the accumulating sum in the row-echelon rewrites. -/
 private theorem foldl_sum_mul_right_aux {R : Type u} [Lean.Grind.Ring R]
     {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
     xs.foldl (fun acc x => acc + f x) acc * c =
@@ -245,6 +254,9 @@ private theorem foldl_sum_mul_right_aux {R : Type u} [Lean.Grind.Ring R]
     have hdist : (acc + f x) * c = acc * c + f x * c := by grind
     rw [hdist]
 
+/-- The fold-sum of a pointwise sum `f x + g x` splits into the two separate
+fold-sums, provided the starting accumulator splits as `acc = accF + accG`;
+additivity of the fold-sum over its summand in the row-echelon rewrites. -/
 private theorem foldl_sum_add_aux {R : Type u} [Lean.Grind.Ring R]
     {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
     (h : acc = accF + accG) :

--- a/progress/2026-06-15T02:03:22Z_911469e9.md
+++ b/progress/2026-06-15T02:03:22Z_911469e9.md
@@ -1,0 +1,29 @@
+# 2026-06-15T02:03:22Z — feature session (911469e9)
+
+## Accomplished
+
+Issue #7431: added one-sentence Phase 6 docstrings to the four
+fold-sum algebra auxiliary lemmas in `HexMatrix/RowEchelon.lean`
+(`foldl_sum_congr_aux`, `foldl_sum_mul_left_aux`,
+`foldl_sum_mul_right_aux`, `foldl_sum_add_aux`). Wording kept
+consistent with the already-documented fold-sum helpers in
+`HexMatrix/Basic.lean`. Doc-only: additions only (numstat 12/0),
+no signatures/proofs/annotations touched.
+
+Verification: `lake build HexMatrix.RowEchelon` green,
+`scripts/check_dag.py` exit 0, `git diff --check` clean.
+
+## Current frontier
+
+Commit 0805ae52 on branch `agent/911469e9`. Ready to open PR for #7431.
+
+## Next step
+
+`coordination create-pr 7431`.
+
+## Blockers
+
+None. Note: tried to claim #7429 and #7430 first (both Phase 6
+doc clusters) — both already claimed by other agents; took #7431.
+Pre-existing uncommitted `.claude/` working-tree changes were left
+untouched (off-limits / not mine).


### PR DESCRIPTION
Closes #7431

Session: `911469e9-f74c-47ef-84e8-feb5485766b9`

abd71b2d chore: progress entry for #7431 (911469e9)
0805ae52 doc: Phase 6 docstrings for HexMatrix RowEchelon fold-sum algebra aux cluster (#7431)

🤖 Prepared with Claude Code