### PR TITLE
doc: HexMatrix Determinant.lean Phase 6 docstrings for the column-replacement multilinearity cluster (detProduct_colReplace_add ... det_colReplace_zero, 5 lemmas)

### DIFF
--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -5243,6 +5243,8 @@ theorem colReplace_get {R : Type u} {n : Nat} (M : Matrix R n n) (dst r c : Fin 
     (colReplace M dst v)[r][c] = if c = dst then v r else M[r][c] := by
   simp [colReplace, Matrix.ofFn]
 
+/-- The per-permutation product `detProduct` is additive in the replaced
+column: splitting that column's entries as `v + w` splits the product as a sum. -/
 private theorem detProduct_colReplace_add {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Matrix R n n) (dst : Fin n) (v w : Fin n → R)
     (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
@@ -5337,6 +5339,8 @@ private theorem detProduct_colReplace_add {R : Type u} [Lean.Grind.CommRing R]
           (fun acc x => acc * (colReplace M dst w)[x][perm[x]]) 1 := by
         grind
 
+/-- The per-permutation product `detProduct` is homogeneous in the replaced
+column: scaling that column's entries by `c` scales the product by `c`. -/
 private theorem detProduct_colReplace_smul {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Matrix R n n) (dst : Fin n) (c : R) (v : Fin n → R)
     (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
@@ -5391,6 +5395,8 @@ private theorem detProduct_colReplace_smul {R : Type u} [Lean.Grind.CommRing R]
             (fun x => (colReplace M dst v)[x][perm[x]])
             1 (List.mem_finRange pivot) (List.nodup_finRange n)
 
+/-- The signed Leibniz term `detTerm` is additive in the replaced column:
+splitting that column's entries as `v + w` splits the term as a sum. -/
 private theorem detTerm_colReplace_add {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Matrix R n n) (dst : Fin n) (v w : Fin n → R)
     (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
@@ -5400,6 +5406,8 @@ private theorem detTerm_colReplace_add {R : Type u} [Lean.Grind.CommRing R]
   rw [detProduct_colReplace_add M dst v w perm hnodup]
   grind
 
+/-- The signed Leibniz term `detTerm` is homogeneous in the replaced column:
+scaling that column's entries by `c` scales the term by `c`. -/
 private theorem detTerm_colReplace_smul {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Matrix R n n) (dst : Fin n) (c : R) (v : Fin n → R)
     (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
@@ -5455,6 +5463,7 @@ theorem det_colReplace_smul {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         exact foldl_det_sum_mul_left_zero
           (permutationVectors n) c (detTerm (colReplace M dst v))
 
+/-- The assembled determinant `det` vanishes when the replaced column is zero. -/
 private theorem det_colReplace_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (dst : Fin n) :
     det (colReplace M dst (fun _ => (0 : R))) = 0 := by

--- a/progress/2026-06-15T020348Z_b0a48637.md
+++ b/progress/2026-06-15T020348Z_b0a48637.md
@@ -1,0 +1,33 @@
+# 2026-06-15T02:03:48Z — feature session (b0a48637)
+
+## Accomplished
+
+Issue #7430: added one-sentence Phase 6 docstrings to the five lemmas of
+the column-replacement multilinearity cluster in
+`HexMatrix/Determinant.lean`:
+
+- `detProduct_colReplace_add` — per-permutation product additive in the
+  replaced column.
+- `detProduct_colReplace_smul` — per-permutation product homogeneous in
+  the replaced column.
+- `detTerm_colReplace_add` — signed Leibniz term additive in the replaced
+  column.
+- `detTerm_colReplace_smul` — signed Leibniz term homogeneous in the
+  replaced column.
+- `det_colReplace_zero` — assembled `det` vanishes on a zero column.
+
+Doc-only change; no signatures, statements, proofs, or order touched.
+
+## Current frontier
+
+`lake build HexMatrix.Determinant` green, `scripts/check_dag.py` exits 0,
+`git diff --numstat` shows 9/0 (additions only).
+
+## Next step
+
+PR for #7430. Adjacent docstring clusters (`columnChoiceMatrix`,
+`colReplace_columnSumMatrix`) remain as separate batches.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7430

Session: `b0a48637-223d-4666-81a5-737d41a27279`

b0f94ba7 doc: Phase 6 docstrings for HexMatrix Determinant column-replacement multilinearity cluster (#7430)

🤖 Prepared with Claude Code