### PR TITLE
doc: document BZ prime scoring helpers

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -971,14 +971,17 @@ private theorem berlekampFactorsModP_eq_of_isZero_false
   unfold berlekampFactorsModP
   rw [dif_pos hzero]
 
+/-- Reduce an integer coefficient to its canonical natural-number residue modulo `p` for the modular Horner evaluator. -/
 private def intCoeffModNat (z : Int) (p : Nat) : Nat :=
   Int.toNat (z % Int.ofNat p)
 
+/-- Evaluate a `ZPoly` at `x` modulo `p` by Horner-folding its coefficients through `intCoeffModNat`. -/
 private def evalZPolyModNat (f : ZPoly) (p x : Nat) : Nat :=
   f.toArray.toList.reverse.foldl
     (fun acc coeff => (intCoeffModNat coeff p + x * acc) % p)
     0
 
+/-- Detect the cheap case where `f mod p` splits completely into linear factors by counting roots modulo `p`. -/
 private def completeLinearDegreeSplit? (f : ZPoly) (p : Nat) [ZMod64.Bounds p] :
     Option (Array Nat) :=
   let degree := (ZPoly.modP p f).degree?.getD 0
@@ -1022,11 +1025,13 @@ def modularFactorDegreesAt? (f : ZPoly) (p : Nat) : Option (Array Nat) :=
             none)
     none
 
+/-- Witness polynomial used by the nearby guard that pins the modular factor-degree query at the prime `29`. -/
 private def prefixTwentyNineGuard : ZPoly :=
   DensePoly.ofCoeffs #[1, 1, 111546435]
 
 #guard (modularFactorDegreesAt? prefixTwentyNineGuard 29).isSome
 
+/-- Score one small-prime candidate by its Berlekamp factor count when it is admissible for `f`. -/
 private def scoreCandidate (f : ZPoly) (c : SmallPrimeCandidate) : Option PrimeCandidateScore :=
   letI := c.bounds
   if isGoodPrime f c.p then
@@ -1035,12 +1040,14 @@ private def scoreCandidate (f : ZPoly) (c : SmallPrimeCandidate) : Option PrimeC
   else
     none
 
+/-- Choose the lower factor-count score, keeping the incumbent score on ties for deterministic prime selection. -/
 private def betterScore (old new : PrimeCandidateScore) : PrimeCandidateScore :=
   if new.factorCount < old.factorCount then
     new
   else
     old
 
+/-- Fold one small-prime candidate into the running best score used by `choosePrimeScore?`. -/
 private def choosePrimeScoreStep
     (f : ZPoly) (best : Option PrimeCandidateScore) (c : SmallPrimeCandidate) :
     Option PrimeCandidateScore :=

--- a/progress/20260615_022818_420bfee6.md
+++ b/progress/20260615_022818_420bfee6.md
@@ -1,0 +1,31 @@
+# Progress — 2026-06-15 (session 420bfee6, feature)
+
+## Accomplished
+
+Issue #7445: added one-sentence Phase 6 docstrings to the seven
+undocumented private prime-candidate scoring and modular-evaluation
+helpers in `HexBerlekampZassenhaus/Basic.lean`:
+
+- `intCoeffModNat`, `evalZPolyModNat`, `completeLinearDegreeSplit?`,
+  `prefixTwentyNineGuard`, `scoreCandidate`, `betterScore`, and
+  `choosePrimeScoreStep`.
+
+Doc-only change: no signatures, bodies, guards, declaration order,
+imports, or private modifiers touched.
+
+## Current frontier
+
+This docstring cluster is complete and PR #7449 is open. Other Phase 6
+doc batches and the blocked HO/directive work remain separate queue
+items.
+
+## Next step
+
+Let CI run on PR #7449. Auto-merge was not enabled during this session
+because the GitHub GraphQL rate limit was exhausted after the branch
+push; the PR and issue-label handoff were completed through the REST API.
+
+## Blockers
+
+None for this issue. Directive #2564 remains blocked by dependencies, so
+the claim attempt was correctly refused before this work item was chosen.


### PR DESCRIPTION
Closes #7445.

## Summary
- add Phase 6 docstrings for the seven private prime-candidate scoring / modular-evaluation helpers in HexBerlekampZassenhaus/Basic.lean
- record session progress in progress/20260615_022818_420bfee6.md

## Verification
- lake build HexBerlekampZassenhaus.Basic
- python3 scripts/check_dag.py
- git diff --check
- git diff --numstat -- HexBerlekampZassenhaus/Basic.lean => 7 0

Note: coordination create-pr pushed the branch but could not create the PR because GraphQL rate limit was exhausted, so this PR was opened via REST fallback.