### PR TITLE
feat: forward W⊆L' refinement count core for fast-core irreducibility

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -378,6 +378,40 @@ theorem factorFastCoreWithBound_some_factor_count_ge
     (BHKS.ForwardRecoveryInputs.ExpectedTrueFactors.irreducible_of_partition_count
       trueSupports htrue hcore_ne hpartition)
 
+/-- Forward-inclusion lower count bound for a successful fast-core branch.
+
+This derives the `count_ge` half from the *forward* inclusion `W ⊆ L'`
+(`CutProjectionHypotheses`) through the partition-refinement argument
+(`supportPartitionByMinColumn_length_le_bhksEquivalenceClassIndicators_size`),
+with no reverse `L' = W` separation and hence no bad-vector resultant valuation.
+Unlike `factorFastCoreWithBound_some_factor_count_ge`, it does not route through
+an `ExpectedTrueFactors` package (whose construction needs the full `L' = W`).
+
+The two executable-success facts it consumes isolate the remaining plumbing: the
+emitted factor count equals the equivalence-class count (`hsize`) and the
+support-partition length equals the integer-factor count (`hpartition`).  The
+successful-branch premise `_h` is retained to mark the eventual source of those
+facts once the executable recovery wiring discharges them. -/
+theorem factorFastCoreWithBound_some_factor_count_ge_of_cut
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksProjectedRows}
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (_h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hcut : BHKS.CutProjectionHypotheses L trueSupports)
+    (hsize : coreFactors.size = (Hex.bhksEquivalenceClassIndicators L).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    (UniqueFactorizationMonoid.normalizedFactors
+      (HexPolyZMathlib.toPolynomial core)).card ≤
+        (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length := by
+  rw [List.length_map, Array.length_toList, hsize, ← hpartition]
+  exact
+    BHKS.supportPartitionByMinColumn_length_le_bhksEquivalenceClassIndicators_size
+      L trueSupports hcut
+
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`
 with `factorFastCoreWithBound_some_factor_count_ge`, exposing the count

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -130,6 +130,79 @@ private theorem partitionByMinColumn_eq_supportPartitionByMinColumn_of_iff
   · have hsup : ¬ supportEquivalentAt trueSupports j rep := fun h => hsig (hprop.mpr h)
     simp [hsig, hsup]
 
+/-- The least column `≤ j` sharing column `j`'s signature: the canonical
+signature representative of `j`.  It is always `≤ j`, so it stays in range. -/
+private def sigRep (sig : Nat → Array Rat) (j : Nat) : Nat :=
+  Nat.find (p := fun k => k ≤ j ∧ sig k = sig j) ⟨j, le_refl j, rfl⟩
+
+private theorem sigRep_le (sig : Nat → Array Rat) (j : Nat) : sigRep sig j ≤ j :=
+  (Nat.find_spec (p := fun k => k ≤ j ∧ sig k = sig j) ⟨j, le_refl j, rfl⟩).1
+
+private theorem sigRep_sig (sig : Nat → Array Rat) (j : Nat) :
+    sig (sigRep sig j) = sig j :=
+  (Nat.find_spec (p := fun k => k ≤ j ∧ sig k = sig j) ⟨j, le_refl j, rfl⟩).2
+
+private theorem sigRep_min (sig : Nat → Array Rat) {j k : Nat}
+    (hk : k < sigRep sig j) : ¬ (k ≤ j ∧ sig k = sig j) :=
+  Nat.find_min (p := fun k => k ≤ j ∧ sig k = sig j) ⟨j, le_refl j, rfl⟩ hk
+
+/-- Forward refinement of the support partition by the signature partition.
+
+If equal column signatures force support-equivalence — the *forward* direction,
+available from the inclusion `W ⊆ L'` alone (no reverse `L' = W` separation) —
+then every signature class is contained in one support-equivalence class, so the
+signature partition refines the support partition and therefore has at least as
+many classes.  The map sending each support representative `q` to its signature
+representative `sigRep sig q` is the witnessing injection. -/
+theorem supportPartitionByMinColumn_length_le_partitionByMinColumn_length
+    {r : Nat} (trueSupports : Set (Set (Fin r))) (sig : Nat → Array Rat)
+    (hrefine :
+      ∀ j k, (hj : j < r) → (hk : k < r) →
+        sig j = sig k → supportEquivalent trueSupports ⟨j, hj⟩ ⟨k, hk⟩) :
+    (supportPartitionByMinColumn trueSupports).length ≤
+      (partitionByMinColumn r sig).length := by
+  classical
+  rw [supportPartitionByMinColumn, partitionByMinColumn, List.length_map,
+    List.length_map]
+  have hnodup_supp : (supportRepresentativeColumns trueSupports).Nodup := by
+    unfold supportRepresentativeColumns
+    exact (List.nodup_range).filter _
+  have hnodup_sig : (representativeColumns r sig).Nodup := by
+    unfold representativeColumns
+    exact (List.nodup_range).filter _
+  rw [← List.toFinset_card_of_nodup hnodup_supp,
+    ← List.toFinset_card_of_nodup hnodup_sig]
+  refine Finset.card_le_card_of_injOn (sigRep sig) ?_ ?_
+  · -- `sigRep sig q` is a signature representative for each support rep `q`.
+    intro q hq
+    simp only [Finset.mem_coe, List.mem_toFinset] at hq ⊢
+    have hq_lt : q < r := supportRepresentativeColumns_lt trueSupports hq
+    rw [mem_representativeColumns_iff]
+    refine ⟨lt_of_le_of_lt (sigRep_le sig q) hq_lt, ?_⟩
+    intro k hk hsigk
+    have hk_le_q : k ≤ q := le_trans (Nat.le_of_lt hk) (sigRep_le sig q)
+    have hsig_q : sig k = sig q := by rw [hsigk, sigRep_sig sig q]
+    exact sigRep_min sig hk ⟨hk_le_q, hsig_q⟩
+  · -- `sigRep sig` is injective on support representatives.
+    intro q₁ hq₁ q₂ hq₂ heq
+    rw [Finset.mem_coe, List.mem_toFinset] at hq₁ hq₂
+    have hq₁_lt : q₁ < r := supportRepresentativeColumns_lt trueSupports hq₁
+    have hq₂_lt : q₂ < r := supportRepresentativeColumns_lt trueSupports hq₂
+    have hsig_eq : sig q₁ = sig q₂ := by
+      rw [← sigRep_sig sig q₁, ← sigRep_sig sig q₂, heq]
+    have hsupp : supportEquivalent trueSupports ⟨q₁, hq₁_lt⟩ ⟨q₂, hq₂_lt⟩ :=
+      hrefine q₁ q₂ hq₁_lt hq₂_lt hsig_eq
+    rcases lt_trichotomy q₁ q₂ with hlt | heq' | hgt
+    · exact absurd
+        ((supportEquivalentAt_iff trueSupports hq₁_lt hq₂_lt).mpr hsupp)
+        (supportRepresentativeColumns_min trueSupports hq₂ q₁ hlt)
+    · exact heq'
+    · refine absurd
+        ((supportEquivalentAt_iff trueSupports hq₂_lt hq₁_lt).mpr ?_)
+        (supportRepresentativeColumns_min trueSupports hq₁ q₂ hgt)
+      intro S hS
+      exact (hsupp S hS).symm
+
 /-- The RREF column signature expression used by
 `Hex.bhksEquivalenceClassIndicators`, exposed as a proof-facing definition. -/
 def projectedRowsRrefColumnSignature (L : Hex.BhksProjectedRows) (j : Nat) :
@@ -192,6 +265,50 @@ theorem projectedRowsRrefColumnSignature_eq_iff_forall_mem_projectedRowSpaceRat_
     (Hex.bhksProjectedRowsAsRatMatrix
       L.projectedRows L.projectedRows.size L.factorCount) ⟨j, hj⟩ ⟨k, hk⟩
 
+/-- Forward column-signature implication from the cut inclusion `W ⊆ L'`.
+
+This is the one-directional half of
+`projectedRowsRrefColumnSignature_eq_iff_supportEquivalent_of_projectedRowSpan_eq`
+that needs only the forward inclusion supplied by `CutProjectionHypotheses`
+(each true-support indicator lies in `L'`), not the reverse `L' = W`
+separation.  Equal RREF column signatures mean every vector of the rational row
+space agrees on those two columns; since each support indicator lies in `L'`
+(hence in the rational row space), the two columns lie in exactly the same true
+supports. -/
+theorem projectedRowsRrefColumnSignature_eq_imp_supportEquivalent_of_cut
+    (L : Hex.BhksProjectedRows)
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (hcut : CutProjectionHypotheses L trueSupports)
+    {j k : Nat} (hj : j < L.factorCount) (hk : k < L.factorCount)
+    (hsig :
+      projectedRowsRrefColumnSignature L j = projectedRowsRrefColumnSignature L k) :
+    supportEquivalent trueSupports ⟨j, hj⟩ ⟨k, hk⟩ := by
+  have hcoord :=
+    (projectedRowsRrefColumnSignature_eq_iff_forall_mem_projectedRowSpaceRat_coord_eq
+      L hj hk).mp hsig
+  intro S hS
+  have hmem_int :
+      indicatorVector (S : Set (Fin L.factorCount)) ∈ projectedRowSpanInt L :=
+    hcut.indicator_mem_projected ⟨S, hS⟩
+  have hmem_rat :
+      intVectorToRat (indicatorVector S) ∈ projectedRowSpaceRat L := by
+    have h := intVectorToRat_mem_span_rat_of_mem_span_int
+      (S := Set.range fun i : Fin L.projectedRows.size =>
+        Matrix.row (projectedRowsIntMatrix L) i) hmem_int
+    unfold projectedRowSpaceRat
+    rw [range_row_projectedRowsRatMatrix_eq_image]
+    exact h
+  have heq := hcoord _ hmem_rat
+  by_cases hjS : (⟨j, hj⟩ : Fin L.factorCount) ∈ S
+  · by_cases hkS : (⟨k, hk⟩ : Fin L.factorCount) ∈ S
+    · exact iff_of_true hjS hkS
+    · exfalso
+      simp [intVectorToRat, indicatorVector, hjS, hkS] at heq
+  · by_cases hkS : (⟨k, hk⟩ : Fin L.factorCount) ∈ S
+    · exfalso
+      simp [intVectorToRat, indicatorVector, hjS, hkS] at heq
+    · exact iff_of_false hjS hkS
+
 theorem projectedRowsRrefColumnSignature_eq_iff_supportEquivalent_of_projectedRowSpan_eq
     (L : Hex.BhksProjectedRows)
     (trueSupports : Set (Set (Fin L.factorCount)))
@@ -237,6 +354,50 @@ theorem bhksEquivalenceClassIndicators_eq_expectedIndicatorArrayOfSupports
       ((supportPartitionByMinColumn trueSupports).map
         (fun members => classIndicatorArray L.factorCount members)).toArray
   rw [hfold]
+
+/-- The number of executable equivalence-class indicators equals the length of
+the signature partition `partitionByMinColumn` over the RREF column signatures.
+This is a pure restatement of the executable fold semantics, independent of any
+lattice hypothesis. -/
+theorem bhksEquivalenceClassIndicators_size_eq (L : Hex.BhksProjectedRows) :
+    (Hex.bhksEquivalenceClassIndicators L).size =
+      (partitionByMinColumn L.factorCount
+        (projectedRowsRrefColumnSignature L)).length := by
+  let sig := projectedRowsRrefColumnSignature L
+  have hfold :
+      ((List.range L.factorCount).foldl
+        (fun acc j => Hex.bhksInsertSignatureClass (sig j) j acc) []).map Prod.snd =
+        partitionByMinColumn L.factorCount sig :=
+    bhksInsertSignatureClass_fold_eq_partitionByMinColumn L.factorCount sig
+  unfold Hex.bhksEquivalenceClassIndicators
+  change
+    (((((List.range L.factorCount).foldl
+      (fun acc j => Hex.bhksInsertSignatureClass (sig j) j acc) []).map Prod.snd).map
+        (fun cls => classIndicatorArray L.factorCount cls)).toArray).size =
+      (partitionByMinColumn L.factorCount sig).length
+  rw [hfold]
+  simp
+
+/-- Forward count bound: the executable equivalence-class partition emits at
+least one class per true-support-equivalence class.
+
+This is the forward-only `count_ge` core: from the cut inclusion `W ⊆ L'`
+(`CutProjectionHypotheses`, certified by the closed cut-survival argument) the
+emitted partition refines the true-support partition, so the emitted class count
+is at least the support-partition length.  It needs no reverse `L' = W`
+separation — and hence no bad-vector resultant valuation — establishing the
+lower count bound from the forward inclusion alone. -/
+theorem supportPartitionByMinColumn_length_le_bhksEquivalenceClassIndicators_size
+    (L : Hex.BhksProjectedRows)
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (hcut : CutProjectionHypotheses L trueSupports) :
+    (supportPartitionByMinColumn trueSupports).length ≤
+      (Hex.bhksEquivalenceClassIndicators L).size := by
+  rw [bhksEquivalenceClassIndicators_size_eq]
+  apply supportPartitionByMinColumn_length_le_partitionByMinColumn_length
+  intro j k hj hk hsig
+  exact projectedRowsRrefColumnSignature_eq_imp_supportEquivalent_of_cut
+    L trueSupports hcut hj hk hsig
 
 /-- The executable BHKS lattice basis at the abstract Hensel-lift data.
 

--- a/progress/20260615T050914Z_7934ab1f.md
+++ b/progress/20260615T050914Z_7934ab1f.md
@@ -1,0 +1,75 @@
+# Progress — 2026-06-15 (session 7934ab1f, one-shot #7461)
+
+## Accomplished
+
+Issue #7461 (forward `W ⊆ L'` count bound, retire bad-vector resultant from
+the correctness path) — landed the **mathematical core** of the forward
+refinement count argument, sorry/axiom-free, purely additive Mathlib-layer
+changes (no executable change).
+
+New lemmas in `HexBerlekampZassenhausMathlib/Recovery.lean`:
+
+- `sigRep` / `sigRep_le` / `sigRep_sig` / `sigRep_min` (private): the
+  least-column signature representative, the witnessing injection.
+- `supportPartitionByMinColumn_length_le_partitionByMinColumn_length`: the
+  combinatorial refinement-count lemma. From the *one-directional* implication
+  `sig j = sig k → supportEquivalent j k`, the signature partition refines the
+  support partition, so it has at least as many classes. Proved via the
+  injection `q ↦ sigRep sig q` on representative columns
+  (`Finset.card_le_card_of_injOn`).
+- `projectedRowsRrefColumnSignature_eq_imp_supportEquivalent_of_cut`: the
+  forward-only half of the existing IFF
+  (`..._of_projectedRowSpan_eq`). Uses only `CutProjectionHypotheses`
+  (`W ⊆ L'`, each support indicator lies in `L'`), not the reverse `L' = W`.
+  Routes through the sorry-free RREF coordinate lemma
+  (`..._coord_eq`) and `intVectorToRat_mem_span_rat_of_mem_span_int`.
+- `bhksEquivalenceClassIndicators_size_eq`: `(bhksEquivalenceClassIndicators
+  L).size = (partitionByMinColumn L.factorCount sig).length` (pure fold
+  semantics, no lattice hypothesis).
+- `supportPartitionByMinColumn_length_le_bhksEquivalenceClassIndicators_size`:
+  the assembled forward count core — from `CutProjectionHypotheses`,
+  `#supports ≤ #emitted-classes`, no resultant.
+
+New wrapper in `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+
+- `factorFastCoreWithBound_some_factor_count_ge_of_cut`: realizes `count_ge`
+  for the actually-emitted `coreFactors` from the forward cut + two
+  executable-success facts (`hsize`, `hpartition`) held as explicit
+  hypotheses. Does *not* route through `ExpectedTrueFactors`/`L' = W`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Recovery`: green (0 errors).
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement`: green.
+- `git diff -U0 | grep -iE 'sorry|axiom|native_decide|TODO|FIXME'` on added
+  lines: empty. No executable files touched. Additive only (0 deletions).
+
+## Current frontier
+
+The forward `count_ge` math is in place. What remains (deliverable 3 + the
+discharge of the wrapper's hypotheses) is the executable-recovery-direction
+plumbing the boundary skill flags as a structural remodel:
+
+- Discharge `hsize : coreFactors.size = (bhksEquivalenceClassIndicators
+  (projectedRowsOfLiftData ...)).size` from a raw
+  `factorFastCoreWithBound _ = some coreFactors` (unfold
+  `factorFastCoreWithBound` → `bhksRecoverClassified` →
+  `bhksIndicatorCandidates?` and use the option-fold size equality, cf.
+  `bhksIndicatorCandidates?_size_eq`).
+- Produce the `CutProjectionHypotheses` instance at the actual lift
+  (cut-survival, #6778) and the support family `trueSupports` /
+  `hpartition = normalizedFactors.card`.
+- Reroute `factorFastCoreWithBound_some_factor_zpolyIrreducible` (and the
+  `_of_forwardInputs` consumer) to go through the forward count, dropping the
+  `ForwardRecoveryInputs.lattice_eq_indicators` field dependency.
+
+## Next step
+
+Follow-up sub-issue created for the executable wiring + reroute (deliverable
+3). The forward count core landed here is its precise consumption target.
+
+## Blockers
+
+None for the landed core. The remaining reroute needs the executable recovery
+plumbing (separate, larger piece — see boundary skill warnings on the
+recovery/coverage direction).


### PR DESCRIPTION
Partial progress on #7461

Session: `7934ab1f-e877-46ab-b4bf-608809fc39a2`

fed1c1af feat: forward W⊆L' refinement count core for fast-core irreducibility (#7461)

🤖 Prepared with Claude Code