### PR TITLE
feat: discharge forward count_ge plumbing and reroute fast-core irreducibility off lattice_eq_indicators

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -412,6 +412,86 @@ theorem factorFastCoreWithBound_some_factor_count_ge_of_cut
     BHKS.supportPartitionByMinColumn_length_le_bhksEquivalenceClassIndicators_size
       L trueSupports hcut
 
+/-- Forward-cut cardinality equality for a successful BHKS fast-core branch.
+
+Pairs the executable upper bound `factorFastCoreWithBound_some_factor_count_le`
+with the forward-inclusion lower bound
+`factorFastCoreWithBound_some_factor_count_ge_of_cut`, so the count equality is
+established from the forward inclusion `W ⊆ L'`
+(`BHKS.CutProjectionHypotheses`) alone.  Unlike
+`factorFastCoreWithBound_some_factor_count_eq`, it routes through no
+`ExpectedTrueFactors` package, and hence through no reverse `L' = W` separation
+or bad-vector resultant valuation.  The two executable-success facts `hsize`
+and `hpartition` isolate the remaining plumbing. -/
+theorem factorFastCoreWithBound_some_factor_count_eq_of_cut
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksProjectedRows}
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hcut : BHKS.CutProjectionHypotheses L trueSupports)
+    (hsize : coreFactors.size = (Hex.bhksEquivalenceClassIndicators L).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial core)).card := by
+  apply le_antisymm
+  · exact factorFastCoreWithBound_some_factor_count_le hcore_ne h
+  · exact factorFastCoreWithBound_some_factor_count_ge_of_cut trueSupports h hcut
+      hsize hpartition
+
+/-- Irreducibility of every emitted factor from the forward-cut count equality.
+
+This is the forward-inclusion analogue of
+`factorFastCoreWithBound_some_factor_irreducible`: it feeds the forward count
+equality `factorFastCoreWithBound_some_factor_count_eq_of_cut` into the UFD
+partition scaffold `factorFastCoreWithBound_some_factor_irreducible_of_count`,
+with no dependency on the reverse `L' = W` separation. -/
+theorem factorFastCoreWithBound_some_factor_irreducible_of_cut
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksProjectedRows}
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hcut : BHKS.CutProjectionHypotheses L trueSupports)
+    (hsize : coreFactors.size = (Hex.bhksEquivalenceClassIndicators L).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ coreFactors.toList,
+      Irreducible (HexPolyZMathlib.toPolynomial factor) :=
+  factorFastCoreWithBound_some_factor_irreducible_of_count hcore_ne h
+    (factorFastCoreWithBound_some_factor_count_eq_of_cut trueSupports hcore_ne h
+      hcut hsize hpartition)
+
+/-- `Hex.ZPoly`-predicate form of
+`factorFastCoreWithBound_some_factor_irreducible_of_cut`: the forward-inclusion
+irreducibility wrapper used by fast-core callers that already carry a forward
+cut certificate. -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksProjectedRows}
+    (trueSupports : Set (Set (Fin L.factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hcut : BHKS.CutProjectionHypotheses L trueSupports)
+    (hsize : coreFactors.size = (Hex.bhksEquivalenceClassIndicators L).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ coreFactors.toList, Hex.ZPoly.Irreducible factor :=
+  factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count hcore_ne h
+    (factorFastCoreWithBound_some_factor_count_eq_of_cut trueSupports hcore_ne h
+      hcut hsize hpartition)
+
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`
 with `factorFastCoreWithBound_some_factor_count_ge`, exposing the count
@@ -483,41 +563,48 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible
     (factorFastCoreWithBound_some_factor_count_eq trueSupports hcore_ne h
       htrue hpartition)
 
-/-- Forward-recovery-input form of the fast-core irreducibility wrapper.
+/-- Forward-recovery-input form of the fast-core irreducibility wrapper, routed
+through the forward inclusion `W ⊆ L'`.
 
-This is the proof-facing API for fast-branch callers that already carry the
-BHKS recovery package at the successful lift.  The executable success equation
-is still required to identify the returned factors, but the BHKS data are
-explicit hypotheses; in particular this theorem does not try to reconstruct
-`ExpectedTrueFactors` or the support-partition count from a bare
-`factorFastCoreWithBound = some _` premise. -/
+This is the proof-facing API for fast-branch callers that carry the BHKS
+recovery package at the successful lift together with a forward cut certificate.
+It obtains the lower count bound through
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut`, so it depends only
+on the forward `BHKS.CutProjectionHypotheses` (certified by the cut-survival
+argument) — not on the `ForwardRecoveryInputs.lattice_eq_indicators` field, the
+reverse `L' = W` separation that requires the bad-vector resultant valuation.
+The recovery package supplies only the executable identification: the
+`hsize` plumbing fact is discharged from its `candidates_eq` / `indicators_match`
+fields, with no appeal to the lattice separation. -/
 theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat}
     (hcore_ne : core ≠ 0)
-    (hcore_monic : Hex.DensePoly.Monic core)
     (hinputs :
       BHKS.ForwardRecoveryInputs core (Hex.ZPoly.toMonicLiftData core k primeData))
     (h :
       Hex.factorFastCoreWithBound core B primeData k fuel =
         some hinputs.expectedFactors)
-    (hindicators :
-      hinputs.expectedIndicators =
-        BHKS.expectedIndicatorArrayOfSupports hinputs.trueSupports)
+    (hcut :
+      BHKS.CutProjectionHypotheses
+        (BHKS.projectedRowsOfLiftData core
+          (Hex.ZPoly.toMonicLiftData core k primeData) hinputs.rows_pos)
+        hinputs.trueSupports)
     (hpartition :
       (BHKS.supportPartitionByMinColumn hinputs.trueSupports).length =
         (UniqueFactorizationMonoid.normalizedFactors
           (HexPolyZMathlib.toPolynomial core)).card) :
     ∀ factor ∈ hinputs.expectedFactors.toList,
       Hex.ZPoly.Irreducible factor := by
-  have htrue :
-      BHKS.ForwardRecoveryInputs.ExpectedTrueFactors core
-        (BHKS.expectedIndicatorArrayOfSupports hinputs.trueSupports)
-        hinputs.expectedFactors := by
-    rw [← hindicators]
-    exact BHKS.ForwardRecoveryInputs.expectedTrueFactors_of_monic hcore_monic hinputs
+  have hsize :
+      hinputs.expectedFactors.size =
+        (Hex.bhksEquivalenceClassIndicators
+          (BHKS.projectedRowsOfLiftData core
+            (Hex.ZPoly.toMonicLiftData core k primeData) hinputs.rows_pos)).size := by
+    rw [Hex.bhksIndicatorCandidates?_size_eq hinputs.candidates_eq]
+    exact congrArg Array.size hinputs.indicators_match.symm
   exact
-    factorFastCoreWithBound_some_factor_zpolyIrreducible hinputs.trueSupports
-      hcore_ne h htrue hpartition
+    factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut
+      hinputs.trueSupports hcore_ne h hcut hsize hpartition
 
 end HexBerlekampZassenhausMathlib

--- a/progress/20260615T060135Z_5c76af9f.md
+++ b/progress/20260615T060135Z_5c76af9f.md
@@ -1,0 +1,90 @@
+# Progress — 2026-06-15 (session 5c76af9f, one-shot feature #7464)
+
+## Accomplished
+
+Issue #7464: rerouted the fast-core irreducibility wrappers off the
+reverse `L' = W` separation onto the forward inclusion `W ⊆ L'`,
+building on the forward count core landed by #7461 / PR #7465 (merged
+05:51Z, mid-session).
+
+In `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+
+- Added the forward-cut count→irreducibility chain:
+  - `factorFastCoreWithBound_some_factor_count_eq_of_cut` — pairs the
+    executable upper bound `..._count_le` with the substrate forward
+    lower bound `..._count_ge_of_cut`, giving the count equality from
+    `BHKS.CutProjectionHypotheses` alone (no `ExpectedTrueFactors`, no
+    reverse separation / bad-vector resultant valuation).
+  - `factorFastCoreWithBound_some_factor_irreducible_of_cut` (Polynomial
+    form) and `..._zpolyIrreducible_of_cut` (`Hex.ZPoly.Irreducible`
+    form), feeding that count equality into the existing UFD scaffold
+    `..._irreducible_of_count` / `..._zpolyIrreducible_of_count`.
+- Rerouted `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs`
+  to obtain `count_ge` through `..._zpolyIrreducible_of_cut`. It now
+  takes a forward `BHKS.CutProjectionHypotheses` at the lift
+  `projectedRowsOfLiftData core (toMonicLiftData core k primeData)
+  hinputs.rows_pos` instead of `hcore_monic` + `hindicators`, and its
+  proof no longer touches `hinputs.lattice_eq_indicators` (the reverse
+  `L' = W` field). The `hsize` plumbing fact is discharged directly from
+  the recovery package's executable fields
+  (`bhksIndicatorCandidates?_size_eq hinputs.candidates_eq` composed with
+  `hinputs.indicators_match`, the latter holding by the defeq
+  `equivalenceClassIndicatorsOfLiftData = bhksEquivalenceClassIndicators
+  ∘ projectedRowsOfLiftData`).
+
+Net: `PartitionRefinement.lean` +107/−20, additive plus the one reroute.
+No executable change; no `Recovery.lean` change. Sorry/axiom/native_decide
+free.
+
+## Decisions
+
+- Deliverable 1 (`hsize`): the issue suggested unfolding
+  `factorFastCoreWithBound → bhksRecoverClassified → bhksIndicatorCandidates?`.
+  The cleaner route discharges `hsize` from the `ForwardRecoveryInputs`
+  fields the consumer already carries (`candidates_eq` + `indicators_match`),
+  with no raw executable-loop unfold. Per the "Directives are hypotheses"
+  rule, took the simpler equivalent.
+- Deliverable 2 (`hcut`): the forward `CutProjectionHypotheses` is threaded
+  as the (resultant-free) forward hypothesis replacing
+  `lattice_eq_indicators`. Its producer (the cut-survival certificate from
+  Gram-Schmidt soundness, `CutSurvival → .toCut`) is the B4/B5 obligation
+  explicitly out of scope per the issue. `hpartition` is threaded as the
+  partition hypothesis (dischargeable via the existing
+  `supportPartitionByMinColumn_length_eq_normalizedFactors_card` when the
+  lifted-support family is supplied).
+- Kept the existing `ExpectedTrueFactors`-route theorems
+  (`..._count_eq`, `..._irreducible`, `..._zpolyIrreducible`) intact —
+  they are a valid alternative API and deleting proven infrastructure was
+  out of scope; the forward `_of_cut` route is the new resultant-free path
+  for the headline driver.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement`: green
+  (full target, 3757 jobs, against the merged-main substrate).
+- `git diff origin/main` additions: sorry/axiom/native_decide free.
+- The substrate `Recovery.lean` is unchanged by this PR.
+
+## Current frontier
+
+The forward-cut irreducibility API is in place and consumed by
+`_of_forwardInputs`. The `ExpectedTrueFactors`/reverse-separation route is
+no longer on the consumer's correctness path.
+
+## Next step
+
+- A forward-cut producer: discharge `BHKS.CutProjectionHypotheses` at the
+  actual lift from the Gram-Schmidt cut-survival argument (B4/B5,
+  #5204/#5216), which would make the forward route fully unconditional.
+- Discharge `hpartition` at the lifted-support family inside
+  `_of_forwardInputs` (compose
+  `supportPartitionByMinColumn_length_eq_normalizedFactors_card` with a
+  `LiftedFactorSubsetPartition` instance) so the consumer threads fewer
+  raw hypotheses.
+- Fully remove the `lattice_eq_indicators` field from
+  `ForwardRecoveryInputs` once no theorem consumes it (a structure-level
+  cascade, larger scope).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7464

This PR reroutes the fast-core irreducibility wrappers off the reverse `L' = W` separation onto the forward inclusion `W ⊆ L'`, retiring the bad-vector resultant valuation from the count derivation. Building on the forward count core from #7461, it adds the forward-cut count-to-irreducibility chain `factorFastCoreWithBound_some_factor_count_eq_of_cut` / `_irreducible_of_cut` / `_zpolyIrreducible_of_cut`, which pairs the executable upper bound `_count_le` with the forward lower bound `_count_ge_of_cut` and feeds the result through the existing UFD scaffold, depending only on `BHKS.CutProjectionHypotheses`. It then reroutes `_zpolyIrreducible_of_forwardInputs` to obtain `count_ge` through the forward cut: the theorem now takes a forward `CutProjectionHypotheses` at the lift `projectedRowsOfLiftData core (toMonicLiftData core k primeData)` in place of `hcore_monic` and `hindicators`, its proof no longer touches `lattice_eq_indicators`, and the `hsize` plumbing fact is discharged from the recovery package's `candidates_eq` / `indicators_match` fields.

The change is additive plus the one reroute, with no executable change and no `Recovery.lean` change; `lake build HexBerlekampZassenhausMathlib.PartitionRefinement` is green and the added lines are `sorry`/`axiom`/`native_decide`-free.

Session: \`5c76af9f-fff3-41e6-ac74-5c8475435c54\`

🤖 Prepared with Claude Code