### PR TITLE
feat: recovery sign-normalization bridge + mod-p disjointness from choosePrimeData? (#7469)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -13320,6 +13320,141 @@ private theorem leadingCoeff_liftedRecoveryCandidate_pos
     exact leadingCoeff_normalizeFactorSign_nonneg _
   omega
 
+/-- The leading coefficient of a leading-coefficient dilation of a monic
+polynomial is the dilation scalar raised to the polynomial's degree.  Dilation
+preserves the size of a monic polynomial (`size_dilate_eq_of_monic_of_ne_zero`),
+so the top coefficient is `c ^ (size - 1)` times the monic top coefficient `1`. -/
+private theorem leadingCoeff_dilate_of_monic
+    {c : Int} (hc : c ≠ 0) {m : Hex.ZPoly} (hm : Hex.DensePoly.Monic m) :
+    Hex.DensePoly.leadingCoeff (Hex.ZPoly.dilate c m) = c ^ (m.size - 1) := by
+  have hm_size_pos : 0 < m.size := zpoly_size_pos_of_monic hm
+  have hsize : (Hex.ZPoly.dilate c m).size = m.size :=
+    size_dilate_eq_of_monic_of_ne_zero hc hm
+  have hdil_size_pos : 0 < (Hex.ZPoly.dilate c m).size := by
+    rw [hsize]; exact hm_size_pos
+  have hm_lead : m.coeff (m.size - 1) = (1 : Int) := by
+    rw [← Hex.DensePoly.leadingCoeff_eq_coeff_last m hm_size_pos]
+    exact Hex.DensePoly.leadingCoeff_eq_one_of_monic hm
+  rw [Hex.DensePoly.leadingCoeff_eq_coeff_last _ hdil_size_pos, hsize,
+    Hex.ZPoly.coeff_dilate, hm_lead, Int.mul_one]
+
+/-- A nonzero integer polynomial with positive leading coefficient has a
+primitive part with positive leading coefficient: dividing out the nonnegative
+content scales the leading coefficient by a positive factor. -/
+private theorem leadingCoeff_primitivePart_pos
+    {q : Hex.ZPoly} (hq : q ≠ 0)
+    (hlc : 0 < Hex.DensePoly.leadingCoeff q) :
+    0 < Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart q) := by
+  have hcontent_ne : Hex.ZPoly.content q ≠ 0 := HexPolyZMathlib.content_ne_zero q hq
+  have hcontent_nonneg : 0 ≤ Hex.ZPoly.content q := by
+    unfold Hex.ZPoly.content Hex.DensePoly.content
+    exact Int.natCast_nonneg _
+  have hrec :
+      Hex.ZPoly.content q *
+          Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart q) =
+        Hex.DensePoly.leadingCoeff q := by
+    have h := Hex.ZPoly.content_mul_primitivePart q
+    calc
+      Hex.ZPoly.content q *
+            Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart q)
+          = Hex.DensePoly.leadingCoeff
+              (Hex.DensePoly.scale (Hex.ZPoly.content q)
+                (Hex.ZPoly.primitivePart q)) := by
+            rw [Hex.ZPoly.leadingCoeff_scale_of_nonzero
+              (Hex.ZPoly.content q) (Hex.ZPoly.primitivePart q) hcontent_ne]
+      _ = Hex.DensePoly.leadingCoeff q := by rw [h]
+  by_contra hle
+  push_neg at hle
+  have hnonpos :
+      Hex.ZPoly.content q *
+          Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart q) ≤ 0 :=
+    mul_nonpos_iff.mpr (Or.inl ⟨hcontent_nonneg, hle⟩)
+  rw [hrec] at hnonpos
+  exact absurd hlc (not_lt.mpr hnonpos)
+
+/-- **Recovery sign-normalisation bridge.**
+
+A recovered integer factor at a Hensel lift over a positive-leading-coefficient
+core, with monic lifted local factors and Mignotte-sufficient precision, is
+already sign-normalised: `Hex.normalizeFactorSign factor = factor`.
+
+The `dilate_eq` field pins `factor = primitivePart (dilate (lc core) monicFactor)`.
+Under the precision bound the monic coordinate `monicFactor` is the centred lift
+of the monic selected product (`hcl`), hence monic, so the dilation by
+`lc core > 0` has leading coefficient `(lc core) ^ deg > 0`, and primitivisation
+preserves that positive sign.
+
+The `0 < lc core`, monic-lifted-factor and precision hypotheses are genuinely
+required: the carrier alone fixes `factor` as `primitivePart (dilate (lc core)
+monicFactor)`, whose leading-coefficient sign is `sign (lc core ^ deg ·
+lc monicFactor)`, and `lc core < 0` (or a non-monic coordinate) admits a
+negative-leading-coefficient `factor` for which `normalizeFactorSign factor ≠
+factor`.  The bare `Irreducible`/`∣ core` hypotheses suggested by the directive
+do not constrain that sign. -/
+theorem RecoveredAtLift.normalizeFactorSign_eq
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hrep : RecoveredAtLift core d factor S)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0)
+    (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        d.p ^ d.k) :
+    Hex.normalizeFactorSign factor = factor := by
+  set B' := Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic
+    with hB'
+  have hvalid : ∀ i, (hrep.monicFactor.coeff i).natAbs ≤ B' :=
+    defaultFactorCoeffBound_valid (Hex.ZPoly.toMonic core).monic hmonic_ne
+      hrep.monicFactor hrep.monic_dvd
+  have hB'_pos : 0 < B' :=
+    Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hmonic_ne
+  have hmod : 2 ≤ d.p ^ d.k := by omega
+  have hlp_monic : Hex.DensePoly.Monic (liftedFactorProduct d S) :=
+    liftedFactorProduct_monic d S (fun i _ => hd_liftedFactor_monic i)
+  have hcl :
+      Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k) =
+        hrep.monicFactor := by
+    rw [← centeredLiftPoly_reduceModPow_eq (liftedFactorProduct d S) d.p d.k
+      d.p_pos, hrep.congr]
+    exact Hex.centeredLiftPoly_reduceModPow_eq_of_coeff_natAbs_le
+      hrep.monicFactor d.p d.k B' hvalid hprecision
+  have hmf_monic : Hex.DensePoly.Monic hrep.monicFactor := by
+    rw [← hcl]; exact monic_centeredLiftPoly_of_monic hlp_monic hmod
+  have hc_ne : Hex.DensePoly.leadingCoeff core ≠ 0 := ne_of_gt hcore_lc_pos
+  have hdil_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff
+        (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hrep.monicFactor) := by
+    rw [leadingCoeff_dilate_of_monic hc_ne hmf_monic]
+    exact pow_pos hcore_lc_pos _
+  have hdil_ne :
+      Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) hrep.monicFactor ≠ 0 := by
+    intro h
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hdil_lc_pos
+    exact lt_irrefl 0 hdil_lc_pos
+  have hfactor_lc_pos : 0 < Hex.DensePoly.leadingCoeff factor := by
+    rw [← hrep.dilate_eq]
+    exact leadingCoeff_primitivePart_pos hdil_ne hdil_lc_pos
+  unfold Hex.normalizeFactorSign
+  rw [if_neg (by omega : ¬ Hex.DensePoly.leadingCoeff factor < 0)]
+
+/-- `RepresentsIntegerFactorAtLift` form of the recovery sign-normalisation
+bridge `RecoveredAtLift.normalizeFactorSign_eq`: a represented integer factor
+over a positive-leading-coefficient core with monic lifted factors and
+Mignotte-sufficient precision is sign-normalised. -/
+theorem normalizeFactorSign_eq_of_representsAtLift
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0)
+    (hd_liftedFactor_monic : ∀ i, Hex.DensePoly.Monic (liftedFactor d i))
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        d.p ^ d.k) :
+    Hex.normalizeFactorSign factor = factor := by
+  rcases hrep with ⟨hrec⟩
+  exact hrec.normalizeFactorSign_eq hcore_lc_pos hmonic_ne hd_liftedFactor_monic
+    hprecision
+
 /-- One-step `shouldRecord` discharge for the corrected recovered candidate:
 when `liftedRecoveryCandidate core d S` equals an irreducible integer factor,
 the executable record check passes. -/

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -657,6 +657,105 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squ
   exact squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
     core primeData hselected hsmall hprim hlc_map_ne hsquareFree_monic
 
+/-- The Mathlib image over `ZMod p` of the monic modular reduction selected by a
+successful `choosePrimeData?` run is squarefree.
+
+The executable `isGoodPrime` check certifies `squareFreeModP core p`
+(`gcdIsUnit (gcd (modP core) (modP core)') = true`);
+`gcd_monicModularImage_derivative_eq_one` lifts this to the monic image's
+coprimality with its derivative, which is exactly `Polynomial.Separable` over the
+field `ZMod p`, hence `Squarefree`.  This is the modular squarefreeness datum the
+mod-`p` disjointness lemma `modPFactorSubset_disjoint_of_not_associated` needs but
+`modPSubsetPartitionHypotheses_of_choosePrimeData` fills with `trivial`. -/
+theorem squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData
+    (core : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.choosePrimeData? core = some primeData) :
+    Squarefree
+      (@HexBerlekampMathlib.toMathlibPolynomial primeData.p primeData.bounds
+        (@monicModPImage primeData.p primeData.bounds
+          (@Hex.ZPoly.modP primeData.p primeData.bounds core))) := by
+  letI := primeData.bounds
+  have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
+    Hex.choosePrimeData?_isGoodPrime core primeData hselected
+  have hsquareFree : Hex.squareFreeModP core primeData.p :=
+    Hex.isGoodPrime_squareFreeModP core primeData.p hgood
+  have hsquareFree_modP :
+      Hex.gcdIsUnit
+        (Hex.DensePoly.gcd (@Hex.ZPoly.modP primeData.p primeData.bounds core)
+          (Hex.DensePoly.derivative
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core))) = true := by
+    simpa [Hex.squareFreeModP] using hsquareFree
+  obtain ⟨hzero, _hfactors_eq⟩ :=
+    Hex.choosePrimeData?_factorsModP_berlekamp_form core primeData hselected
+  have hprime_hex : Hex.Nat.Prime primeData.p :=
+    Hex.choosePrimeData?_prime core primeData hselected
+  have hprime : _root_.Nat.Prime primeData.p := by
+    refine _root_.Nat.prime_def_lt.mpr ⟨hprime_hex.two_le, ?_⟩
+    intro m hmlt hmdvd
+    rcases hprime_hex.right m hmdvd with h | h
+    · exact h
+    · exact absurd h (Nat.ne_of_lt hmlt)
+  haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
+  have hsquareFree_monic :
+      Hex.DensePoly.gcd
+        (@Hex.monicModularImage primeData.p primeData.bounds
+          (@Hex.ZPoly.modP primeData.p primeData.bounds core))
+        (Hex.DensePoly.derivative
+          (@Hex.monicModularImage primeData.p primeData.bounds
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core))) = 1 :=
+    gcd_monicModularImage_derivative_eq_one
+      (p := primeData.p) (Hex.ZPoly.modP primeData.p core) hzero hsquareFree_modP
+  have hsep :
+      IsCoprime
+        (HexBerlekampMathlib.toMathlibPolynomial
+          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)))
+        (Polynomial.derivative
+          (HexBerlekampMathlib.toMathlibPolynomial
+            (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)))) :=
+    HexBerlekampMathlib.toMathlibPolynomial_squareFree_coprime
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) hsquareFree_monic
+  have hsf :
+      Squarefree
+        (HexBerlekampMathlib.toMathlibPolynomial
+          (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))) :=
+    Polynomial.Separable.squarefree hsep
+  rwa [monicModPImage_eq_monicModularImage]
+
+/-- **modP pairwise-disjointness from a `choosePrimeData?` witness.**
+
+Specialisation of `modPFactorSubset_disjoint_of_not_associated` to the executable
+`choosePrimeData?` boundary: the selected prime is `isGoodPrime`, which supplies
+both the nonzero mod-`p` core (`isGoodPrime_modP_isZero_false`) and the modular
+squarefreeness (`squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData`)
+that the bare `ModPSubsetPartitionHypotheses … True True` package fills with
+`trivial`. -/
+theorem modPFactorSubset_disjoint_of_choosePrimeData
+    {core : Hex.ZPoly} {primeData : Hex.PrimeChoiceData}
+    (hselected : Hex.choosePrimeData? core = some primeData)
+    {f g : Hex.ZPoly} {S T : ModPFactorSubset primeData}
+    (hf_irr : Irreducible (HexPolyZMathlib.toPolynomial f)) (hf_dvd : f ∣ core)
+    (hg_irr : Irreducible (HexPolyZMathlib.toPolynomial g)) (hg_dvd : g ∣ core)
+    (hS : RepresentsIntegerFactorModP primeData f S)
+    (hT : RepresentsIntegerFactorModP primeData g T)
+    (hnotassoc :
+      ¬ Associated (HexPolyZMathlib.toPolynomial f)
+        (HexPolyZMathlib.toPolynomial g)) :
+    Disjoint S T := by
+  letI := primeData.bounds
+  have hprime_hex : Hex.Nat.Prime primeData.p :=
+    Hex.choosePrimeData?_prime core primeData hselected
+  have hgood : @Hex.isGoodPrime core primeData.p primeData.bounds = true :=
+    Hex.choosePrimeData?_isGoodPrime core primeData hselected
+  have hcore_modP_nz :
+      (@Hex.ZPoly.modP primeData.p primeData.bounds core).isZero = false :=
+    Hex.isGoodPrime_modP_isZero_false core primeData.p hgood
+  exact modPFactorSubset_disjoint_of_not_associated hprime_hex
+    (modPSubsetPartitionHypotheses_of_choosePrimeData core primeData hselected)
+    hcore_modP_nz
+    (squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData core primeData
+      hselected)
+    hf_irr hf_dvd hg_irr hg_dvd hS hT hnotassoc
+
 /-! ### Base discharges for the small-mod singleton branch
 
 The two lemmas below feed `squareFreeCore_irreducible_of_small_mod_singleton`

--- a/progress/20260615_095246_b2f2f4ad.md
+++ b/progress/20260615_095246_b2f2f4ad.md
@@ -1,0 +1,63 @@
+# Progress — 2026-06-15 (session b2f2f4ad, one-shot #7469)
+
+## Accomplished
+
+Issue #7469 — both deliverables, in two commits.
+
+**Deliverable 1 (recovery sign-normalization bridge).** Added to
+`HexBerlekampZassenhausMathlib/Basic.lean`:
+- `RecoveredAtLift.normalizeFactorSign_eq` and its
+  `RepresentsIntegerFactorAtLift` wrapper
+  `normalizeFactorSign_eq_of_representsAtLift`, deriving
+  `normalizeFactorSign factor = factor`.
+- supporting `leadingCoeff_dilate_of_monic`,
+  `leadingCoeff_primitivePart_pos`.
+
+The directive's stated signature (only `Irreducible` + `∣ core`) is
+**unsound**: `dilate_eq` fixes `factor = primitivePart (dilate (lc core)
+monicFactor)`, whose leading-coefficient sign is `sign(lc core ^ deg ·
+lc monicFactor)`; a negative `lc core` admits a negative-lc `factor` with
+`normalizeFactorSign factor ≠ factor`. The bridge therefore takes the extra
+hypotheses `0 < lc core`, `(toMonic core).monic ≠ 0`, monic lifted factors,
+and Mignotte precision — all ambient in any real producer (the
+`liftedFactorSubsetPartition_*_of_bound` bundles already carry them). Under
+the precision bound `monicFactor` is the centred lift of the monic selected
+product, hence monic, so `lc (dilate (lc core) monicFactor) = (lc core)^deg
+> 0` and primitivisation keeps the positive sign.
+
+**Deliverable 2 (mod-p squarefree-disjointness).** Added to
+`HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+- `squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData`, lifting
+  the executable `isGoodPrime`/`squareFreeModP` check to Mathlib `Squarefree`
+  over `ZMod p` via `gcd_monicModularImage_derivative_eq_one` +
+  `toMathlibPolynomial_squareFree_coprime` + `Separable.squarefree`.
+- `modPFactorSubset_disjoint_of_choosePrimeData`, the `choosePrimeData?`
+  boundary wrapper of `modPFactorSubset_disjoint_of_not_associated`,
+  discharging the nonzero mod-`p` core and modular squarefreeness that
+  `modPSubsetPartitionHypotheses_of_choosePrimeData` fills with `trivial`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: green (0 errors).
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod`: green (0 errors).
+- No `sorry`/`axiom`/`native_decide` in added lines.
+- `python3 scripts/check_dag.py`: exit 0.
+
+## Current frontier
+
+Both bridges exist but `InitialLiftedFactorSubsetPartitionEvidence` /
+`LiftedFactorSubsetPartition` still have **no producer** (see
+hex-lean-mathlib-boundary skill). These bridges are the substrate a future
+producer consumes: `liftedRecoveryCandidate_eq` becomes provable via
+`candidate_eq_of_monic_dvd` once the producer supplies `normalizeFactorSign
+f = f` from `normalizeFactorSign_eq_of_representsAtLift`, and
+`pairwise_disjoint` via `modPFactorSubset_disjoint_of_choosePrimeData`.
+
+## Next step
+
+A producer issue assembling `InitialLiftedFactorSubsetPartitionEvidence` from
+the Hensel-lift evidence, now that both field-level bridges land.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR lands the two field-level bridges that issue #7469 calls for, so that a future producer of `InitialLiftedFactorSubsetPartitionEvidence` / `LiftedFactorSubsetPartition` can discharge the `liftedRecoveryCandidate_eq` and `pairwise_disjoint` fields.

Deliverable 1 adds `RecoveredAtLift.normalizeFactorSign_eq` and its `RepresentsIntegerFactorAtLift` wrapper `normalizeFactorSign_eq_of_representsAtLift`, deriving `normalizeFactorSign factor = factor`, plus supporting `leadingCoeff_dilate_of_monic` and `leadingCoeff_primitivePart_pos`. This closes the `hfactor_norm` precondition that `RecoveredAtLift.candidate_eq_of_monic_dvd` needs.

The directive's proposed signature (only `Irreducible (toPolynomial factor)` and `factor ∣ core`) is unsound and is corrected here. The carrier's `dilate_eq` field fixes `factor = primitivePart (dilate (lc core) monicFactor)`, whose leading-coefficient sign is `sign(lc core ^ deg · lc monicFactor)`; with `lc core < 0` (or a non-monic coordinate) `factor` can have a negative leading coefficient, for which `normalizeFactorSign factor ≠ factor`, and `Irreducible`/`∣ core` do not constrain that sign. The bridge therefore takes `0 < lc core`, `(toMonic core).monic ≠ 0`, monic lifted local factors, and Mignotte-sufficient precision. These are exactly the facts the existing `liftedFactorSubsetPartition_*_of_bound` machinery already carries, so any real producer supplies them. Under the precision bound `monicFactor` is the centred lift of the monic selected product, hence monic, so the dilation by `lc core > 0` has positive leading coefficient and primitivisation preserves that sign.

Deliverable 2 adds `squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData`, lifting the executable `isGoodPrime`/`squareFreeModP` check to Mathlib `Squarefree` over `ZMod p` of the monic modular image via `gcd_monicModularImage_derivative_eq_one` and `Separable.squarefree`, and `modPFactorSubset_disjoint_of_choosePrimeData`, the `choosePrimeData?`-boundary wrapper of `modPFactorSubset_disjoint_of_not_associated`. Together they discharge the nonzero mod-`p` core and modular squarefreeness that `modPSubsetPartitionHypotheses_of_choosePrimeData` currently fills with `trivial`.

`lake build HexBerlekampZassenhausMathlib.Basic` and `lake build HexBerlekampZassenhausMathlib.IntReductionMod` are both green; no `sorry`/`axiom`/`native_decide` in the added lines.

Closes #7469.

🤖 Prepared with Claude Code