### PR TITLE
doc: HexGramSchmidt Int.lean Phase 6 docstrings for the integer rowSwap row-access cluster (rowSwap_row_eq_of_ne_int ... rowSwap_getRow_right_val_int, 6 lemmas)

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -8769,6 +8769,9 @@ theorem scaledCoeffs_lower_eq_noPivotLoop_scaledCoeffMatrix
   exact scaledCoeffRows_lower_eq_noPivotLoop_scaledCoeffMatrix b i j hji h_nonsing
 
 
+/-- For a `Matrix Int`, a row swap leaves any `Fin`-indexed row other than the
+two swapped row indices unchanged. This is the row-access companion to
+`Matrix.rowSwap` for the unchanged-row case. -/
 private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j r : Fin n')
     (hri : r.val ≠ i.val) (hrj : r.val ≠ j.val) :
@@ -8781,6 +8784,9 @@ private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
   rw [if_neg hr_ne_j, if_neg hr_ne_i] at hget
   simpa [Matrix.row] using hget
 
+/-- For a `Matrix Int`, the `Fin`-indexed left swap row `i` becomes the old row
+`j`. This is the direct row-access form of `Matrix.rowSwap` for the first
+swapped row. -/
 private theorem rowSwap_row_left_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j : Fin n') :
     (Matrix.rowSwap M i j)[i] = M[j] := by
@@ -8795,6 +8801,9 @@ private theorem rowSwap_row_left_int {n' m' : Nat}
     rw [if_neg hij, if_pos rfl] at hget
     simpa [Matrix.row] using hget
 
+/-- For a `Matrix Int`, the `Fin`-indexed right swap row `j` becomes the old row
+`i`. This is the companion row-access form of `Matrix.rowSwap` for the second
+swapped row. -/
 private theorem rowSwap_row_right_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j : Fin n') :
     (Matrix.rowSwap M i j)[j] = M[i] := by
@@ -8804,6 +8813,9 @@ private theorem rowSwap_row_right_int {n' m' : Nat}
   rw [if_pos rfl] at hget
   simpa [Matrix.row] using hget
 
+/-- Raw-`Nat` row-access version of `rowSwap_row_eq_of_ne_int`: with a bound
+proof for row `r`, a `Matrix Int` row swap leaves that row unchanged when its
+value is distinct from both swapped indices. -/
 private theorem rowSwap_getRow_eq_of_ne_val_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j : Fin n') (r : Nat) (hr : r < n')
     (hri : r ≠ i.val) (hrj : r ≠ j.val) :
@@ -8812,6 +8824,9 @@ private theorem rowSwap_getRow_eq_of_ne_val_int {n' m' : Nat}
   change (Matrix.rowSwap M i j)[rf] = M[rf]
   exact rowSwap_row_eq_of_ne_int M i j rf hri hrj
 
+/-- Raw-`Nat` row-access version of `rowSwap_row_left_int`: after swapping rows
+`i` and `j` in a `Matrix Int`, reading row `i.val` with an explicit bound proof
+returns the old row `j`. -/
 private theorem rowSwap_getRow_left_val_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j : Fin n') (hr : i.val < n') :
     (Matrix.rowSwap M i j)[i.val]'hr = M[j] := by
@@ -8830,6 +8845,9 @@ private theorem rowSwap_getRow_left_val_int {n' m' : Nat}
     rw [if_neg hij, if_pos hii] at hget
     simpa [Matrix.row] using hget
 
+/-- Raw-`Nat` row-access version of `rowSwap_row_right_int`: after swapping rows
+`i` and `j` in a `Matrix Int`, reading row `j.val` with an explicit bound proof
+returns the old row `i`. -/
 private theorem rowSwap_getRow_right_val_int {n' m' : Nat}
     (M : Matrix Int n' m') (i j : Fin n') (hr : j.val < n') :
     (Matrix.rowSwap M i j)[j.val]'hr = M[i] := by

--- a/progress/20260615_132330_bdb4d07e.md
+++ b/progress/20260615_132330_bdb4d07e.md
@@ -1,0 +1,33 @@
+# Progress - 2026-06-15 (session bdb4d07e, work)
+
+## Accomplished
+
+- Checked directive #2564 first; coordination rejected the claim because the
+  issue remains dependency-blocked.
+- Claimed #6771, sanity-checked the premise, and released it for replan. The
+  forward-cut fast-core irreducibility surface already exists as
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs` in
+  `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`; the remaining
+  top-level `h_raw`/public factorization assembly still needs separate
+  producer and reassembly-completeness facts before it can be closed.
+- Claimed #7438 and added docstrings to the six private integer row-swap
+  row-access lemmas in `HexGramSchmidt/Int.lean`:
+  `rowSwap_row_eq_of_ne_int`, `rowSwap_row_left_int`,
+  `rowSwap_row_right_int`, `rowSwap_getRow_eq_of_ne_val_int`,
+  `rowSwap_getRow_left_val_int`, and `rowSwap_getRow_right_val_int`.
+
+## Current frontier
+
+#7438 is complete as a doc-only Phase 6 batch. The skipped #6771 needs planner
+re-scoping around the already-landed forward-cut theorem and the still-missing
+capstone producer/assembly facts.
+
+## Next step
+
+Open the PR for #7438 after committing the docstrings and this progress file.
+
+## Blockers
+
+#6771 could not be executed as written: `Hex.reassemblePolynomialFactors` is a
+private executable helper, and the public top-level fast raw-factor dispatch
+still needs additional producer/reassembly-completeness infrastructure.


### PR DESCRIPTION
Closes #7438

Session: `bdb4d07e-fd82-401c-8b67-57eb456b4719`

0ef36c93 doc: document integer row-swap row access helpers (#7438, progress 20260615_132330_bdb4d07e)

🤖 Prepared with Claude Code