### PR TITLE
feat: non-circular recovered-candidate equality wrapper (#7479)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -213,6 +213,26 @@ diagnose on the issue (per the CLAUDE.md "Directives are hypotheses" rule) and
 no producer as of this writing: `HenselLiftDescentHypotheses`, the
 `toMonicLiftData` modP→lift transport, and `InitialLiftedFactorSubsetPartitionEvidence`.
 
+The same check applies one level down to a "reduce X via the existing
+`*_of_recovery` lemmas" directive: the named recovery lemma existing is not
+enough — verify its *hypotheses* are obtainable from the representation predicate
+in scope. The scaled chain is the trap. `scaledRecombinationCandidate` is
+**scale-based** (`scale lc q = lc·q`) while `RepresentsIntegerFactorAtLift` /
+`RecoveredAtLift` carry only the **dilate** recovery (`dilate lc q` has
+`coeff n = lc^n·q.coeff n` — deliberately *not* `scale`, `HexPolyZ/Basic.lean:63`).
+Every `scaledRecombinationCandidate_eq_factor_of_recovery` lemma needs
+`hscaled : reduceModPow (scaledLiftedFactorProduct …) = reduceModPow factor` as a
+hypothesis, and **nothing produces it** (`grep` finds `scaledLiftedFactorProduct
+… reduceModPow` only in hypothesis position). So a non-circular scaled support
+field (`support_subset_of_dvd_scaledRecombinationCandidate`) cannot be built as a
+thin wrapper over the lifted-product support theorem — the dilate carrier feeds
+the dilate reflection (`toPolynomial_dvd_of_primitivePart_dilate_dvd`, monic-only)
+but not the scaled candidate. Mod p the obstruction is the dilation automorphism
+`σ : q(x) ↦ q(lc·x)`: `f ~ σ(lfp S)` but the scaled candidate `~ lfp T`, and the
+clean half needs the undilated `lfp S ∣ lfp T`. This was #7479 deliverable 2;
+the dilate equality/support wrappers (deliverables 1/3, #7491 / `toMonicLiftData_
+liftedRecoveryCandidate_eq`) are the unblocked ones.
+
 **But "no producer" only blocks a transport that genuinely needs a bridge
 between two concrete defs.** Before skipping a `henselLiftData → toMonicLiftData`
 (or similar) transport, check whether the consumer chain is *generic in the

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -21572,4 +21572,47 @@ theorem toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate
   exact toMonicLiftData_subset_of_liftedFactorProduct_map_dvd core B primeData
     hcore_lc_pos hcore_pos hselected hprecision hclST_map
 
+/-- **Non-circular recovered-candidate equality.** For
+`d := toMonicLiftData core B primeData` on a non-monic `core` with positive
+leading coefficient and a prime selected by the monic transform, a sign-
+normalised integer factor `f` represented by the lifted subset `S` is exactly
+the recovered recombination candidate over `S`.
+
+This is the recovery half of
+`toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate`, exposed as a standalone
+identity through `RecoveredAtLift.candidate_eq_of_monic_dvd`.  Non-circular: it
+assumes no `LiftedFactorSubsetPartition`. -/
+theorem toMonicLiftData_liftedRecoveryCandidate_eq
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    {f : Hex.ZPoly}
+    {S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData)}
+    (hfsign : Hex.normalizeFactorSign f = f)
+    (hrep :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData) f S) :
+    liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) S = f := by
+  have hp_eq : (Hex.ZPoly.toMonicLiftData core B primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hk_eq : (Hex.ZPoly.toMonicLiftData core B primeData).k =
+      Hex.precisionForCoeffBound B primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  have hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0 := by
+    intro h
+    have hlcm : Hex.DensePoly.leadingCoeff (Hex.ZPoly.toMonic core).monic = 1 :=
+      Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos hcore_pos
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hlcm
+    exact one_ne_zero hlcm.symm
+  have hprec_dk :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hbound
+  rcases hrep with ⟨hrec⟩
+  exact hrec.candidate_eq_of_monic_dvd hmonic_ne hfsign hprec_dk
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260615T161021Z_2abf30f3.md
+++ b/progress/20260615T161021Z_2abf30f3.md
@@ -1,0 +1,49 @@
+# Progress — 2026-06-15 (session 2abf30f3, feature)
+
+Issue #7479: recovered and scaled candidate support wrappers.
+
+## Accomplished
+
+- **Deliverable 3** (recovered equality wrapper): added
+  `toMonicLiftData_liftedRecoveryCandidate_eq` to
+  `HexBerlekampZassenhausMathlib/Basic.lean`. For
+  `d := toMonicLiftData core B primeData` it proves
+  `liftedRecoveryCandidate core d S = f` from
+  `RepresentsIntegerFactorAtLift core d f S` (plus the monic-transform
+  precision bound and sign-normalisation), via
+  `RecoveredAtLift.candidate_eq_of_monic_dvd`. Non-circular: assumes no
+  `LiftedFactorSubsetPartition` / `InitialLiftedFactorSubsetPartitionEvidence`.
+  It extracts the proven `hrecS` step of the predecessor
+  `toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate` (#7491).
+- Deliverable 1 was already landed by #7491.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: green (0 errors; only the
+  pre-existing `sorry` ⚠ from `HexBerlekampMathlib`/`HexHenselMathlib`). Clean-
+  tree baseline of the same module also built green before the change.
+- `git diff -U0` added lines: no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.
+- `python3 scripts/check_dag.py`: exit 0.
+- Diff: 43 additions, 0 deletions, one file.
+
+## Current frontier / Blockers
+
+**Deliverable 2** (non-circular `support_subset_of_dvd_scaledRecombinationCandidate`)
+is NOT a thin wrapper and is blocked on a genuine model gap; diagnosed on the
+issue. `scaledRecombinationCandidate` is scale-based (`scale lc q = lc·q`)
+while `RepresentsIntegerFactorAtLift` / `RecoveredAtLift` carry only the
+dilate recovery (`dilate lc q` has `coeff n = lc^n·q.coeff n`; the two ops are
+deliberately distinct — `HexPolyZ/Basic.lean:63`). No theorem produces the
+scaled congruence `reduceModPow (scaledLiftedFactorProduct …) = reduceModPow f`
+— it is only ever a `hscaled` hypothesis of the recovery lemmas. Mod p, the
+dilation `σ : q(x) ↦ q(lc·x)` is an automorphism and `f ~ σ(lfp S)` while the
+scaled candidate `~ lfp T`, so the clean half (which needs undilated
+`lfp S ∣ lfp T`) cannot be fed; the hypothesis is in fact generically
+unsatisfiable for dilate-represented `f`. Full evidence in the issue comment.
+
+## Next step
+
+A planner should re-scope deliverable 2: either introduce a scaled-representation
+carrier supplying `hscaled`, or retire the `scaledRecombinationCandidate` field
+from `InitialLiftedFactorSubsetPartitionEvidence` in favour of the dilate
+`liftedRecoveryCandidate` field (post the #6799/#6801 scale→dilate migration).


### PR DESCRIPTION
This PR adds `toMonicLiftData_liftedRecoveryCandidate_eq`, a non-circular recovered-candidate equality: for `d := toMonicLiftData core B primeData` on a non-monic `core` with positive leading coefficient and a prime selected by the monic transform, a sign-normalised integer factor `f` represented by the lifted subset `S` is exactly the recovered recombination candidate over `S`. It extracts the recovery half of `toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate` (#7491) as a standalone identity through `RecoveredAtLift.candidate_eq_of_monic_dvd`, independent of `LiftedFactorSubsetPartition` and `InitialLiftedFactorSubsetPartitionEvidence`.

This is partial progress on #7479. Deliverable 1 was already landed by #7491; this lands the recovered equality wrapper (deliverable 3). Deliverable 2 (the non-circular scaled support field) is diagnosed as blocked on a real model gap — `scaledRecombinationCandidate` is scale-based while `RepresentsIntegerFactorAtLift` carries only the dilate recovery, with no producer for the scaled congruence — and is left for a re-scoped issue (full evidence in the issue comment). The issue is marked `replan`.

Verified with `lake build HexBerlekampZassenhausMathlib.Basic` (green; only the pre-existing `sorry` warnings) and `python3 scripts/check_dag.py`. No new `sorry`/`axiom`/`native_decide` on added lines.

🤖 Prepared with Claude Code