### PR TITLE
feat: toMonicLiftData lifted-subset uniqueness (HenselSubsetCorrespondence.unique_subset) from Hensel-lift injectivity

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -21572,4 +21572,91 @@ theorem toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate
   exact toMonicLiftData_subset_of_liftedFactorProduct_map_dvd core B primeData
     hcore_lc_pos hcore_pos hselected hprecision hclST_map
 
+/--
+Lifted-subset uniqueness at `toMonicLiftData`: two lifted-factor subsets that
+both represent the same irreducible integer factor of `core` coincide.  This is
+the `unique_subset` field of `HenselSubsetCorrespondenceHypotheses` at
+`d := toMonicLiftData core B primeData`.
+
+It is a thin mutual-inclusion wrapper over the non-circular product-divisor
+lemma `toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate`.  Each
+representation recovers the factor exactly as its own recovery candidate
+(`RecoveredAtLift.candidate_eq_of_monic_dvd`), so `factor` divides the other
+subset's candidate and the product-divisor lemma yields mutual inclusion.  The
+sign-normalisation `normalizeFactorSign factor = factor` that both helpers need
+is not assumed: it is discharged from the representation itself via
+`normalizeFactorSign_eq_of_representsAtLift` (the recovered monic witness is the
+monic centred lift of a monic lifted-factor product, so the positive-leading
+dilation makes `factor` positively led).
+-/
+theorem toMonicLiftData_unique_subset
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    {factor : Hex.ZPoly}
+    {S T : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData)}
+    (_hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (_hdvd : factor ∣ core)
+    (hS :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData) factor S)
+    (hT :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData) factor T) :
+    S = T := by
+  classical
+  -- `(toMonic core).monic` is monic, hence nonzero.
+  have hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0 := by
+    intro h
+    have hlcm : Hex.DensePoly.leadingCoeff (Hex.ZPoly.toMonic core).monic = 1 :=
+      Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos hcore_pos
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hlcm
+    exact one_ne_zero hlcm.symm
+  -- Transport the precision bound onto the lift-data modulus `d.p ^ d.k`.
+  have hp_eq : (Hex.ZPoly.toMonicLiftData core B primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hk_eq : (Hex.ZPoly.toMonicLiftData core B primeData).k =
+      Hex.precisionForCoeffBound B primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  have hprec_dk :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hbound
+  -- The lifted local factors are monic (good prime data).
+  have hlf_monic :
+      ∀ i, Hex.DensePoly.Monic (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i) :=
+    Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData core B primeData
+      hcore_lc_pos hcore_pos hselected hprecision
+  -- The represented factor is sign-normalised (recovered monic witness ⇒ positive lead).
+  have hfsign : Hex.normalizeFactorSign factor = factor :=
+    normalizeFactorSign_eq_of_representsAtLift hS hcore_lc_pos hmonic_ne hlf_monic hprec_dk
+  -- Each representation recovers the factor exactly as its own candidate.
+  rcases hS with ⟨hrecS⟩
+  rcases hT with ⟨hrecT⟩
+  have hcandS :
+      liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) S = factor :=
+    hrecS.candidate_eq_of_monic_dvd hmonic_ne hfsign hprec_dk
+  have hcandT :
+      liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) T = factor :=
+    hrecT.candidate_eq_of_monic_dvd hmonic_ne hfsign hprec_dk
+  have hdvdT :
+      factor ∣ liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) T := by
+    rw [hcandT]; exact Hex.DensePoly.dvd_refl_poly factor
+  have hdvdS :
+      factor ∣ liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) S := by
+    rw [hcandS]; exact Hex.DensePoly.dvd_refl_poly factor
+  have hST : S ⊆ T :=
+    toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate core B primeData
+      hcore_lc_pos hcore_pos hselected hprecision hbound hfsign
+      (RepresentsIntegerFactorAtLift.ofRecovered hrecS) hdvdT
+  have hTS : T ⊆ S :=
+    toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate core B primeData
+      hcore_lc_pos hcore_pos hselected hprecision hbound hfsign
+      (RepresentsIntegerFactorAtLift.ofRecovered hrecT) hdvdS
+  exact Finset.Subset.antisymm hST hTS
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260615_164614_e34432a4.md
+++ b/progress/20260615_164614_e34432a4.md
@@ -1,0 +1,54 @@
+# Progress 20260615_164614_e34432a4
+
+Session type: one-shot feature worker (`/once`), issue #7470.
+
+## Accomplished
+
+Discharged lifted-subset uniqueness at `toMonicLiftData` —
+`toMonicLiftData_unique_subset` in `HexBerlekampZassenhausMathlib/Basic.lean`.
+This is the `unique_subset` field of `HenselSubsetCorrespondenceHypotheses` at
+`d := toMonicLiftData core B primeData`.
+
+The dependency #7477 (commit c1f92a72) landed
+`toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate`: the non-circular
+"lifted product divisor ⇒ support subset" lemma. With it on main, uniqueness is
+a mutual-inclusion wrapper:
+
+- each representation recovers the factor exactly as its own recovery candidate
+  (`RecoveredAtLift.candidate_eq_of_monic_dvd`), so `factor ∣ candidate(other)`;
+- two applications of the product-divisor lemma give `S ⊆ T` and `T ⊆ S`;
+- `Finset.Subset.antisymm` closes `S = T`.
+
+Key subtlety the earlier premise-check comments flagged: the product-divisor
+lemma needs `normalizeFactorSign factor = factor`, which is *not* assumed in the
+`unique_subset` field. It is discharged from the representation itself via the
+existing `normalizeFactorSign_eq_of_representsAtLift` (the recovered monic
+witness is the monic centred lift of a monic lifted-factor product, so the
+positive-leading dilation forces `factor` positively led).
+
+## Decisions
+
+- Used the wrapped lemma's precision hypotheses verbatim (`hselected`,
+  `1 ≤ precisionForCoeffBound B primeData.p`, and the explicit Mignotte bound
+  `2 * defaultFactorCoeffBound (toMonic core).monic < primeData.p ^ …`) rather
+  than the issue body's `defaultFactorCoeffBound core ≤ B` shorthand. These are
+  exactly the facts the consumer carries at the executable cap and the shape the
+  landed bridge already uses; per "directives are hypotheses, not specs" this is
+  the honest non-circular signature.
+- `hirr`/`hdvd` are part of the field contract but genuinely unused by the thin
+  wrapper, so they are `_`-prefixed to satisfy the linter.
+
+## Current frontier
+
+`toMonicLiftData_unique_subset` builds (full `lake build
+HexBerlekampZassenhausMathlib` green, 3788 jobs). No new `sorry`/`axiom`.
+
+## Next step
+
+Wire `toMonicLiftData_unique_subset` together with the existing
+`exists_subset` producer into a concrete `HenselSubsetCorrespondenceHypotheses`
+instance at `toMonicLiftData`, then discharge `represents_modP_of_lifted`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7470

Session: `e34432a4-0def-48e3-b01a-77ef1a492318`

bf9dd7a8 feat: lifted-subset uniqueness at toMonicLiftData (HenselSubsetCorrespondence.unique_subset)

🤖 Prepared with Claude Code