### PR TITLE
feat: drop unscaled recombinationCandidate support field from initial lift evidence (#7511-style, last #7362 blocker)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -17625,13 +17625,6 @@ structure InitialLiftedFactorSubsetPartitionEvidence
                   Associated (HexPolyZMathlib.toPolynomial f)
                       (HexPolyZMathlib.toPolynomial g) →
                     S = T
-  support_subset_of_dvd_recombinationCandidate :
-    ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
-      Irreducible (HexPolyZMathlib.toPolynomial f) →
-        f ∣ core →
-          f ∣ liftedFactorProductCandidate d T →
-            RepresentsIntegerFactorAtLift core d f S →
-              S ⊆ T
   support_subset_of_dvd_liftedRecoveryCandidate :
     ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
       Irreducible (HexPolyZMathlib.toPolynomial f) →
@@ -17679,51 +17672,22 @@ private theorem liftedFactorSubsetPartition_initial_fields
           (∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
               Irreducible (HexPolyZMathlib.toPolynomial f) →
                 f ∣ core →
-                  f ∣ liftedFactorProductCandidate d T →
+                  f ∣ liftedRecoveryCandidate core d T →
                     RepresentsIntegerFactorAtLift core d f S →
-                      S ⊆ T) ∧
-            (∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
-                Irreducible (HexPolyZMathlib.toPolynomial f) →
-                  f ∣ core →
-                    f ∣ liftedRecoveryCandidate core d T →
-                      RepresentsIntegerFactorAtLift core d f S →
-                        S ⊆ T) := by
+                      S ⊆ T) := by
   exact ⟨h.cover, h.pairwise_disjoint, h.unique_up_to_associated,
-    h.support_subset_of_dvd_recombinationCandidate,
     h.support_subset_of_dvd_liftedRecoveryCandidate⟩
-
-/--
-Initial-state support containment for unscaled recombination candidates in the
-successful `choosePrimeData?` lifted-factor package.
-
-This is a named projection of the localized lifted-partition analytic
-obligation.  The constructor below consumes this theorem directly so downstream
-proof packages can refer to the unscaled support field independently of the
-cover and pairwise/uniqueness fields.
--/
-theorem liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData
-    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
-    (hinitial :
-      InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
-    let d := Hex.ZPoly.toMonicLiftData core B primeData
-    ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
-      Irreducible (HexPolyZMathlib.toPolynomial f) →
-      f ∣ core →
-      f ∣ liftedFactorProductCandidate d T →
-      RepresentsIntegerFactorAtLift core d f S →
-      S ⊆ T := by
-  intro d f S T hirr hdvd_core hdvd_candidate hrep
-  obtain ⟨_, _, _, hsupport, _⟩ :=
-    liftedFactorSubsetPartition_initial_fields hinitial
-  exact hsupport hirr hdvd_core hdvd_candidate hrep
 
 /--
 Initial-state support containment for recovered recombination candidates in the
 successful `choosePrimeData?` lifted-factor package.
 
-This is the recovered-coordinate analogue of
-`liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData`.
+This is the recovered-coordinate (dilate) support projection of the localized
+lifted-partition analytic obligation.  The unscaled `liftedFactorProductCandidate`
+sibling is not a field of `InitialLiftedFactorSubsetPartitionEvidence`: on
+non-monic cores it is the wrong coordinate and has no non-circular producer, so
+constructors that still need the unscaled `LiftedFactorSubsetPartition` field
+take it as a separate `hunscaled` hypothesis.
 -/
 theorem liftedFactorSubsetPartition_initial_support_subset_of_dvd_liftedRecoveryCandidate_of_choosePrimeData
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
@@ -17782,9 +17746,12 @@ Composes:
 * `hcore_sqfree` for `target_squarefree`;
 * `hinitial` for the recovered-coordinate analytic
   fields (`cover`, `pairwise_disjoint`, `unique_up_to_associated`,
-  `support_subset_of_dvd_recombinationCandidate`,
   `support_subset_of_dvd_liftedRecoveryCandidate`,
-  `liftedRecoveryCandidate_eq`).
+  `liftedRecoveryCandidate_eq`);
+* `hunscaled` for the still-live unscaled-candidate support field
+  (`liftedFactorProductCandidate`), which is no longer carried by `hinitial`:
+  on non-monic cores it is the wrong coordinate and has no non-circular
+  producer, so it is supplied separately by the caller.
 
 The constructor body does not manufacture correspondence or partition fields
 from arbitrary `PrimeChoiceData`; callers must supply the successful-lift
@@ -17799,10 +17766,18 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
     (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core := by
-    obtain ⟨hcover, hdisj, huniq, _, _⟩ :=
+    obtain ⟨hcover, hdisj, huniq, _⟩ :=
       liftedFactorSubsetPartition_initial_fields hinitial
     exact
       { toHenselSubsetCorrespondenceRest :=
@@ -17821,9 +17796,8 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData
             hirr_f hdvd_f hSrep hirr_g hdvd_g hTrep hassoc
         support_subset_of_dvd_recombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
-          exact
-            liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData
-              core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+          exact hunscaled (f := f) (S := S) (T := T)
+            hirr hdvd_target hdvd_cand hSrep
         support_subset_of_dvd_liftedRecoveryCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact
@@ -17853,10 +17827,18 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData
     (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core := by
-    obtain ⟨hcover, hdisj, huniq, _, _⟩ :=
+    obtain ⟨hcover, hdisj, huniq, _⟩ :=
       liftedFactorSubsetPartition_initial_fields hinitial
     exact
       { toHenselSubsetCorrespondenceRest :=
@@ -17875,9 +17857,8 @@ theorem liftedFactorSubsetPartition_of_toMonicPrimeData
             hirr_f hdvd_f hSrep hirr_g hdvd_g hTrep hassoc
         support_subset_of_dvd_recombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
-          exact
-            liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData
-              core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+          exact hunscaled (f := f) (S := S) (T := T)
+            hirr hdvd_target hdvd_cand hSrep
         support_subset_of_dvd_liftedRecoveryCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact
@@ -18747,10 +18728,18 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData_success_descent
             hdescent.factor_count_eq S))
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     let d := Hex.ZPoly.toMonicLiftData core B primeData
     LiftedFactorSubsetPartition core d Finset.univ core := by
-    obtain ⟨hcover, hdisj, huniq, _, _⟩ :=
+    obtain ⟨hcover, hdisj, huniq, _⟩ :=
       liftedFactorSubsetPartition_initial_fields hinitial
     exact
       { toHenselSubsetCorrespondenceRest :=
@@ -18771,9 +18760,8 @@ theorem liftedFactorSubsetPartition_of_choosePrimeData_success_descent
             hirr_f hdvd_f hSrep hirr_g hdvd_g hTrep hassoc
         support_subset_of_dvd_recombinationCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
-          exact
-            liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData
-              core B primeData hinitial hirr hdvd_target hdvd_cand hSrep
+          exact hunscaled (f := f) (S := S) (T := T)
+            hirr hdvd_target hdvd_cand hSrep
         support_subset_of_dvd_liftedRecoveryCandidate := by
           intro f S T hirr hdvd_target _ hdvd_cand _ hSrep
           exact
@@ -18875,7 +18863,15 @@ theorem slowPathHenselSubstrate_of_choosePrimeData
         (Hex.ZPoly.toMonicLiftData core B primeData) True True)
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     SlowPathHenselSubstrate core B primeData := by
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
     zpoly_lc_pos_of_monic hcore_monic
@@ -18910,7 +18906,7 @@ theorem slowPathHenselSubstrate_of_choosePrimeData
       precision := ?_ }
   · exact hcorr
   · exact liftedFactorSubsetPartition_of_choosePrimeData
-      core B primeData hchoose hcorr hcore_sqfree hinitial
+      core B primeData hchoose hcorr hcore_sqfree hinitial hunscaled
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
       core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
@@ -18953,7 +18949,15 @@ theorem slowPathHenselSubstrate_of_choosePrimeData_success_descent
             hdescent.factor_count_eq S))
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     SlowPathHenselSubstrate core B primeData := by
   have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
     zpoly_lc_pos_of_monic hcore_monic
@@ -18990,6 +18994,7 @@ theorem slowPathHenselSubstrate_of_choosePrimeData_success_descent
       core B primeData hchoose hdescent hlifted_of_modP
   · exact liftedFactorSubsetPartition_of_choosePrimeData_success_descent
       core B primeData hchoose hcore_sqfree hdescent hlifted_of_modP hinitial
+      hunscaled
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
       core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
@@ -19038,7 +19043,15 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData
         (Hex.ZPoly.toMonicLiftData core B primeData) True True)
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     SlowPathHenselSubstrate core B primeData := by
   have hp_prime : Hex.Nat.Prime primeData.p :=
     Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
@@ -19065,7 +19078,7 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData
       precision := ?_ }
   · exact hcorr
   · exact liftedFactorSubsetPartition_of_toMonicPrimeData
-      core B primeData hselected hcorr hcore_sqfree hinitial
+      core B primeData hselected hcorr hcore_sqfree hinitial hunscaled
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
       core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
@@ -20394,7 +20407,15 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData_success_descent
             (Hex.ZPoly.toMonicLiftData core B primeData) factor S)
     (hinitial :
       InitialLiftedFactorSubsetPartitionEvidence core
-        (Hex.ZPoly.toMonicLiftData core B primeData)) :
+        (Hex.ZPoly.toMonicLiftData core B primeData))
+    (hunscaled :
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {f : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial f) →
+        f ∣ core →
+        f ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d f S →
+        S ⊆ T) :
     SlowPathHenselSubstrate core B primeData := by
   have hp_prime : Hex.Nat.Prime primeData.p :=
     Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
@@ -20427,7 +20448,7 @@ theorem slowPathHenselSubstrate_of_toMonicChoosePrimeData_success_descent
       (henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent
         core B primeData hselected hdescent hcore_lc_pos hcore_pos hprec_pos hbound
         hexists_lifted)
-      hcore_sqfree hinitial
+      hcore_sqfree hinitial hunscaled
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
       core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
   · exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2835,7 +2835,17 @@ theorem liftedFactorSubsetPartition_outerBound_of_choosePrimeData
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
-          primeData)) :
+          primeData))
+    (hunscaled :
+      let core := (Hex.normalizeForFactor f).squareFreeCore
+      let B := Hex.ZPoly.defaultFactorCoeffBound f
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial factor) →
+        factor ∣ core →
+        factor ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d factor S →
+        S ⊆ T) :
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let B := Hex.ZPoly.defaultFactorCoeffBound f
     let d := Hex.ZPoly.toMonicLiftData core B primeData
@@ -2845,7 +2855,7 @@ theorem liftedFactorSubsetPartition_outerBound_of_choosePrimeData
       (Hex.ZPoly.defaultFactorCoeffBound f)
       primeData hchoose
       (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_squarefree f hf)
-      hdescent hlifted_of_modP hinitial
+      hdescent hlifted_of_modP hinitial hunscaled
 
 /--
 Branch-local substrate for the small-mod singleton arm, specialised to the
@@ -3373,6 +3383,16 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
           primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (hcomplete : Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
       (Hex.exhaustiveCoreFactorsWithBound
         (Hex.normalizeForFactor f).squareFreeCore
@@ -3502,7 +3522,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
         (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f
           primeData hchoose hdescent hlifted_of_modP)
         (liftedFactorSubsetPartition_outerBound_of_choosePrimeData f hf_ne
-          primeData hchoose hdescent hlifted_of_modP hinitial)
+          primeData hchoose hdescent hlifted_of_modP hinitial hunscaled)
       hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hd_liftedFactor_inj B' hcore_lc_le hvalid hprecision
@@ -3648,6 +3668,16 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (hcomplete : Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
       (Hex.exhaustiveCoreFactorsWithBound
         (Hex.normalizeForFactor f).squareFreeCore
@@ -3667,7 +3697,7 @@ private theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_au
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
     f hf_ne entry hbranch hentry_mem primeData hselected hchoose
-    hdescent hlifted_of_modP hinitial hcomplete
+    hdescent hlifted_of_modP hinitial hunscaled hcomplete
     (Hex.ZPoly.defaultFactorCoeffBound
       (Hex.normalizeForFactor f).squareFreeCore)
     hcore_lc_le
@@ -3737,6 +3767,16 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
           primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (B' : Nat)
     (hcore_lc_le : (Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤ B')
@@ -3871,7 +3911,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
         (henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData f
           primeData hchoose hdescent hlifted_of_modP)
         (liftedFactorSubsetPartition_outerBound_of_choosePrimeData f hf_ne
-          primeData hchoose hdescent hlifted_of_modP hinitial)
+          primeData hchoose hdescent hlifted_of_modP hinitial hunscaled)
       hcore_ne hcore_primitive hcore_lc_pos hcore_record hB_ne_zero
       hd_modulus hd_liftedFactor_monic hd_liftedFactor_natDegree_pos
       hd_liftedFactor_inj B' hcore_lc_le hvalid hprecision
@@ -3978,6 +4018,16 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (hprecision :
       2 * Hex.ZPoly.defaultFactorCoeffBound
         (Hex.normalizeForFactor f).squareFreeCore <
@@ -4006,7 +4056,7 @@ theorem exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeDat
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
     f hf_ne hbranch primeData hselected hchoose
-    hdescent hlifted_of_modP hinitial
+    hdescent hlifted_of_modP hinitial hunscaled
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
     hcore_lc_le
     (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
@@ -4107,7 +4157,17 @@ theorem monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
-          primeData)) :
+          primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T) :
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let B := Hex.ZPoly.defaultFactorCoeffBound f
     let d := Hex.ZPoly.toMonicLiftData core B primeData
@@ -4186,7 +4246,7 @@ theorem monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore
       liftedFactorSubsetPartition_of_choosePrimeData_success_descent
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.defaultFactorCoeffBound f)
-        primeData hchoose hsqfree hdescent hlifted_of_modP hinitial
+        primeData hchoose hsqfree hdescent hlifted_of_modP hinitial hunscaled
   · intro factor S hmonic_ne hfactor_norm hprecision hrep
     rcases hrep with ⟨hrec⟩
     exact hrec.candidate_eq_of_monic_dvd hmonic_ne hfactor_norm hprecision
@@ -4241,7 +4301,17 @@ theorem monicReductionCorrespondence_liftedFactor_facts_of_normalizeForFactor_sq
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
-            primeData)) :
+            primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T) :
     let core := (Hex.normalizeForFactor f).squareFreeCore
     let B := Hex.ZPoly.defaultFactorCoeffBound f
     let d := Hex.ZPoly.toMonicLiftData core B primeData
@@ -4253,7 +4323,7 @@ theorem monicReductionCorrespondence_liftedFactor_facts_of_normalizeForFactor_sq
   intro core B d
   have pkg :=
     monicReductionCorrespondence_of_normalizeForFactor_squareFreeCore
-      f hf_ne hdegree primeData hchoose hdescent hlifted_of_modP hinitial
+      f hf_ne hdegree primeData hchoose hdescent hlifted_of_modP hinitial hunscaled
   exact
     ⟨pkg.liftedFactor_monic_of_monicPrimeData hselected,
       pkg.liftedFactor_natDegree_pos_of_monicPrimeData hselected,
@@ -4375,6 +4445,16 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (hcore_monic : Hex.DensePoly.Monic
       (Hex.normalizeForFactor f).squareFreeCore)
     (B' : Nat)
@@ -4420,7 +4500,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
       exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
         f hf_ne hbranch
         primeData
-        hselected hchoose hdescent hlifted_of_modP hinitial
+        hselected hchoose hdescent hlifted_of_modP hinitial hunscaled
         B' hcore_lc_le hvalid hprecision
   -- New base lemma: monicness and positive-degree of every emitted factor.
   have hmonic :=
@@ -4563,6 +4643,16 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           primeData))
+    (hunscaled :
+      let core := (Hex.normalizeForFactor f).squareFreeCore
+      let B := Hex.ZPoly.defaultFactorCoeffBound f
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial factor) →
+        factor ∣ core →
+        factor ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d factor S →
+        S ⊆ T)
     (hcore_monic : Hex.DensePoly.Monic
       (Hex.normalizeForFactor f).squareFreeCore)
     (hprecision :
@@ -4581,7 +4671,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_bound
     f hf_ne hbranch primeData hselected hchoose
-    hdescent hlifted_of_modP hinitial hcore_monic
+    hdescent hlifted_of_modP hinitial hunscaled hcore_monic
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
     hcore_lc_le
     (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
@@ -4640,6 +4730,16 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (hcore_primitive : Hex.ZPoly.Primitive
       (Hex.normalizeForFactor f).squareFreeCore)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
@@ -4687,7 +4787,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
       exhaustiveCoreFactorsWithBound_expansion_preconditions_of_choosePrimeData_of_bound
         f hf_ne hbranch
         primeData
-        hselected hchoose hdescent hlifted_of_modP hinitial
+        hselected hchoose hdescent hlifted_of_modP hinitial hunscaled
         B' hcore_lc_le hvalid hprecision
   -- Weakened-input base lemmas: positive-degree from #4946 deliv 6, primitivity
   -- from #4946 deliv 5.
@@ -4857,6 +4957,16 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.defaultFactorCoeffBound f)
           primeData))
+    (hunscaled :
+      let core := (Hex.normalizeForFactor f).squareFreeCore
+      let B := Hex.ZPoly.defaultFactorCoeffBound f
+      let d := Hex.ZPoly.toMonicLiftData core B primeData
+      ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+        Irreducible (HexPolyZMathlib.toPolynomial factor) →
+        factor ∣ core →
+        factor ∣ liftedFactorProductCandidate d T →
+        RepresentsIntegerFactorAtLift core d factor S →
+        S ⊆ T)
     (hcore_primitive : Hex.ZPoly.Primitive
       (Hex.normalizeForFactor f).squareFreeCore)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff
@@ -4877,7 +4987,7 @@ theorem reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_co
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
     f hf_ne hbranch primeData hselected hchoose
-    hdescent hlifted_of_modP hinitial hcore_primitive hcore_lc_pos
+    hdescent hlifted_of_modP hinitial hunscaled hcore_primitive hcore_lc_pos
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
     hcore_lc_le
     (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)
@@ -4942,6 +5052,16 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
       (B' : Nat)
     (hcore_lc_le : (Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore).natAbs ≤ B')
@@ -4960,10 +5080,10 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
       IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
     exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_aux_of_bound
       f hf_ne entry hbranch hentry_mem primeData hselected hchoose
-      hdescent hlifted_of_modP hinitial
+      hdescent hlifted_of_modP hinitial hunscaled
       (reassemblyExpansionComplete_exhaustive_of_ne_zero_of_primitive_pos_lc_core_of_bound
         f hf_ne hbranch primeData hselected hchoose
-        hdescent hlifted_of_modP hinitial hcore_primitive hcore_lc_pos
+        hdescent hlifted_of_modP hinitial hunscaled hcore_primitive hcore_lc_pos
           B' hcore_lc_le hvalid hprecision)
         B' hcore_lc_le hvalid hprecision
 
@@ -5038,6 +5158,16 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.defaultFactorCoeffBound f)
             primeData))
+      (hunscaled :
+        let core := (Hex.normalizeForFactor f).squareFreeCore
+        let B := Hex.ZPoly.defaultFactorCoeffBound f
+        let d := Hex.ZPoly.toMonicLiftData core B primeData
+        ∀ {factor : Hex.ZPoly} {S T : LiftedFactorSubset d},
+          Irreducible (HexPolyZMathlib.toPolynomial factor) →
+          factor ∣ core →
+          factor ∣ liftedFactorProductCandidate d T →
+          RepresentsIntegerFactorAtLift core d factor S →
+          S ⊆ T)
     -- Gap 3 (base task): explicit on this wrapper; downstream callers
     -- wanting an outer-shape bound should route through the `_of_bound`
     -- sibling
@@ -5057,7 +5187,7 @@ theorem factor_exhaustive_branch_entry_irreducible_of_choosePrimeData
   have hcore_lc_le := defaultFactorCoeffBound_leadingCoeff_natAbs_le hcore_ne
   exact factor_exhaustive_branch_entry_irreducible_of_choosePrimeData_of_bound
     f hf_ne entry hbranch hentry_mem primeData hselected hchoose
-    hdescent hlifted_of_modP hinitial
+    hdescent hlifted_of_modP hinitial hunscaled
     (Hex.ZPoly.defaultFactorCoeffBound (Hex.normalizeForFactor f).squareFreeCore)
     hcore_lc_le
       (defaultFactorCoeffBound_valid (Hex.normalizeForFactor f).squareFreeCore hcore_ne)

--- a/progress/20260616T000659Z_54b8a7b9.md
+++ b/progress/20260616T000659Z_54b8a7b9.md
@@ -1,0 +1,66 @@
+# Progress — 2026-06-16 (session 54b8a7b9, feature)
+
+## Accomplished
+
+Issue #7530: dropped the unscaled support field
+`support_subset_of_dvd_recombinationCandidate` (over
+`liftedFactorProductCandidate`) from
+`InitialLiftedFactorSubsetPartitionEvidence`
+(`HexBerlekampZassenhausMathlib/Basic.lean`), the surviving sibling of the
+scaled field retired in #7511. This was the last blocker for #7362.
+
+Mirrors #7511's thread-out pattern: the unscaled obligation is no longer a
+field of the initial-evidence package (which has no producer — #7362 must
+otherwise manufacture it). Instead it is supplied as a separate `hunscaled`
+hypothesis on the constructors that still fill the target
+`LiftedFactorSubsetPartition` unscaled field. On non-monic cores
+`liftedFactorProductCandidate` differs from `liftedRecoveryCandidate` (they
+agree only when `leadingCoeff core = 1`, via
+`liftedRecoveryCandidate.eq_productCandidate_of_lc_one`), so the unscaled field
+cannot be derived from the sound dilate field — it is genuinely the wrong
+coordinate and has no non-circular producer.
+
+Concretely:
+- Removed the field from the structure (now 5 fields: `cover`,
+  `pairwise_disjoint`, `unique_up_to_associated`,
+  `support_subset_of_dvd_liftedRecoveryCandidate`, `liftedRecoveryCandidate_eq`).
+- Dropped the unscaled conjunct from the `liftedFactorSubsetPartition_initial_fields`
+  projection (5-tuple → 4-tuple) and deleted the now-unsourceable wrapper
+  `liftedFactorSubsetPartition_initial_support_subset_of_dvd_recombinationCandidate_of_choosePrimeData`.
+- Threaded `hunscaled` through the three base constructors
+  (`liftedFactorSubsetPartition_of_choosePrimeData`, `_of_toMonicPrimeData`,
+  `_of_choosePrimeData_success_descent`), the four `slowPathHenselSubstrate_of_*`
+  substrates, and the IntReductionMod chain (outerBound, the
+  `exhaustiveCoreFactorsWithBound_expansion_preconditions_*`,
+  `reassemblyExpansionComplete_exhaustive_*`,
+  `factor_exhaustive_branch_entry_irreducible_*`, and the
+  `monicReductionCorrespondence_*` theorems). `hunscaled` travels alongside
+  `hinitial` at every level, as in #7511.
+- Left the monic-only `recombinationSearchMod` coverage chain and the target
+  `LiftedFactorSubsetPartition.support_subset_of_dvd_recombinationCandidate`
+  field untouched (per the issue: off the capstone path).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic`: green.
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod`: green.
+- `lake build HexBerlekampZassenhausMathlib` (full library): green, 0 errors
+  (only the pre-existing `sorry` warnings in `HexBerlekampMathlib/Basic.lean`
+  and `HexHenselMathlib/Correctness.lean`).
+- No `axiom`/`sorry`/`native_decide` in added lines.
+
+## Current frontier
+
+#7530 complete. #7362 (producing `InitialLiftedFactorSubsetPartitionEvidence`
+itself, now 5 fields) is unblocked.
+
+## Next step
+
+None for this issue. A future #7528-style cleanup could retire the unscaled
+field from the target `LiftedFactorSubsetPartition` structure (and the threaded
+`hunscaled` hypotheses) once the monic `recombinationSearchMod` chain is
+migrated off it or dropped.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7530

Session: `54b8a7b9-e339-42d8-844c-207eefa0072c`

1bff3e5f feat: drop unscaled recombinationCandidate support from initial lift evidence

🤖 Prepared with Claude Code