### PR TITLE
chore: progress note for #6771 fast-BHKS premise check

### DIFF
--- a/progress/20260616T044022Z_34b61e19.md
+++ b/progress/20260616T044022Z_34b61e19.md
@@ -1,0 +1,45 @@
+# Progress — #6771 fast-BHKS irreducibility assembly (one-shot premise check)
+
+## Accomplished
+
+Claimed #6771 one-shot. Verified, with three independent source sweeps,
+that the unconditional fast-core irreducibility surface still cannot be
+assembled, and skipped to `replan` with an evidence-based diagnostic
+(comment: https://github.com/kim-em/hex/issues/6771#issuecomment-4715040934).
+
+No Lean changes — the issue's deliverables 3–6 require discharging two
+analytic hearts, and neither has a core-facts-only producer.
+
+## Current frontier
+
+The unblock that returned #6771 to the claimable queue was a bookkeeping
+artifact: all four `depends-on` (#7361, #7362, #7461, #7471) closed, so
+`check-blocked` cleared `blocked`, but none delivered an unconditional
+producer.
+
+- **Hensel-recovery heart (B7):** #7361 closed *refuted-as-typed* (not
+  landed), replaced by #7514 → decomposed into #7515/#7516/#7517, all of
+  which were **API restatement only**. After they landed,
+  `slowPathHenselSubstrate_of_toMonicChoosePrimeData_success_descent`
+  (Basic.lean:20707) still takes bare `MonicDescentHypotheses`,
+  `hexists_lifted` (∃ lifted-subset rep for every irreducible factor), and
+  `hunscaled`. #7362 supplied only the `InitialLiftedFactorSubsetPartitionEvidence`
+  field. So `LiftedFactorSubsetPartition core d Finset.univ core` (needed for
+  the B8 count `hpartition`) has no core-facts producer.
+- **Cut heart (B4/B5):** #7471 only reduced `CutProjectionHypotheses` to the
+  still-unbuilt `CutRetention` (Lattice.lean:441 consumes it bare).
+  `CutRetention`/`CutSurvival` have no producer; the separation content is
+  #6779 (OPEN, blocked on #2564).
+
+## Next step
+
+Planner re-pin: add `depends-on: #6779` to #6771 (else it re-surfaces
+spuriously), and scope a new issue for the Hensel-recovery *content*
+producer (discharge `hexists_lifted` + `MonicDescentHypotheses` +
+`hunscaled` from a `toMonicPrimeData?` success — #7515/16/17 were API-only,
+so this is untracked).
+
+## Blockers
+
+#6779 (→ #2564) for the cut heart; an unscoped recovery-completeness theorem
+for the Hensel heart. Both are genuine analytic theorems, not wiring.


### PR DESCRIPTION
This PR records the per-turn progress note for the one-shot premise check of https://github.com/kim-em/hex/issues/6771 (feat: fast-BHKS coverage — bhksRecoverClassified .success yields irreducible candidates). No code or skill changes.

The substantive output is the diagnostic comment on the issue itself: the assembly remains blocked because both analytic hearts still lack core-facts producers (the Hensel-recovery `hexists_lifted`/`MonicDescentHypotheses`/`hunscaled`, and the cut `CutRetention`/`CutSurvival`). The auto-unblock was a bookkeeping artifact of dependencies that closed by refutation/decomposition rather than by delivering producers; the issue was skipped to `replan`.

🤖 Prepared with Claude Code