### PR TITLE
doc: record unsatisfiable-coverage-quantifier gotcha from #7550 diagnosis

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -249,6 +249,34 @@ de-privatising any `private` `Basic.lean` helpers it calls (visibility-only, saf
 Wiring it back up into the upstream slow-path substrate is a separate follow-up
 (the substrate cannot import downstream modules).
 
+A distinct, sharper failure mode than "no producer": the hypothesis the
+directive asks you to *produce* is not merely unproduced but **provably false**,
+so no producer can ever exist. The recurring instance is the bare lift-coverage
+quantifier `hexists_lifted` / `HenselSubsetCorrespondenceRest.exists_subset`
+(`Basic.lean:3325`, inherited by `LiftedFactorSubsetPartition` at
+`Basic.lean:3460`): `∀ {factor}, Irreducible (toPolynomial factor) → factor ∣
+core → ∃ S, RepresentsIntegerFactorAtLift core d factor S`. This universal is
+**unsatisfiable** under the standard core side conditions, because
+`normalizeFactorSign_eq_of_representsAtLift` (`Basic.lean:13646`) proves every
+*represented* factor is sign-normalized (`normalizeFactorSign factor = factor`,
+i.e. `0 ≤ leadingCoeff factor`) given `hcore_lc_pos`, monic lifted factors, and
+the precision bound — all of which are the substrate's own hypotheses
+(`hbound`/`hcore_lc_pos`, + `toMonicLiftData_liftedFactor_monic_*`). So any
+negative-leading-coefficient irreducible divisor (e.g. `1−x ∣ x²−1`, with
+`toPolynomial` `1−X` irreducible) has **no** representing subset, and the bare
+`∀`-factor existence is false for every positive-degree core. The landed
+recovery producer `toMonicLiftData_represents_lifted_of_modP` (`Basic.lean:19885`)
+matches this exactly — it only covers factors carrying
+`hsign : normalizeFactorSign factor = factor`. **Before attempting any
+"produce the coverage hypothesis from core facts" issue, sanity-check the factor
+quantifier: if it ranges over all irreducible factors with no sign guard, it is
+unsatisfiable — diagnose (counterexample + the `normalizeFactorSign_eq_of_*`
+cite) and skip.** The sound fix is a structural narrowing of the `exists_subset`
+quantifier to `normalizeFactorSign factor = factor` across the
+`HenselSubsetCorrespondence*` / `LiftedFactorSubsetPartition` structures, which
+is a shared-`Prop` refactor, not a core-facts assembly. (#7550 was skipped on
+exactly this.)
+
 The same check applies one level down to a "reduce X via the existing
 `*_of_recovery` lemmas" directive: the named recovery lemma existing is not
 enough — verify its *hypotheses* are obtainable from the representation predicate

--- a/progress/20260616T053014Z_0e90a43d.md
+++ b/progress/20260616T053014Z_0e90a43d.md
@@ -1,0 +1,53 @@
+# Progress — 2026-06-16 (session 0e90a43d, one-shot work #7550)
+
+## Accomplished
+
+Claimed #7550 ("produce toMonic Hensel recovery substrate from core facts")
+and diagnosed its premise as unsound, then skipped it (→ `replan`) with a
+concrete evidence comment rather than landing a partial/sorried PR.
+
+The blocking finding: deliverable 1's bare `hexists_lifted` —
+`∀ {factor}, Irreducible (toPolynomial factor) → factor ∣ core → ∃ S,
+RepresentsIntegerFactorAtLift core (toMonicLiftData …) factor S`
+(substrate param `Basic.lean:20721`; same shape as the inherited
+`HenselSubsetCorrespondenceRest.exists_subset`, `Basic.lean:3325`, which
+`LiftedFactorSubsetPartition` extends at `Basic.lean:3460`) — is a **false**
+proposition under the substrate's own side conditions, so it cannot be
+produced from core facts.
+
+Evidence: `normalizeFactorSign_eq_of_representsAtLift` (`Basic.lean:13646`)
+proves any represented factor is sign-normalized (under `hcore_lc_pos`, monic
+lifted factors, and the precision bound = the substrate's own `hbound`).
+`normalizeFactorSign` (`HexBerlekampZassenhaus/Basic.lean:1625`) flips negative
+leading coefficients, so negative-lc divisors are never representable.
+Counterexample: `core = x²−1` (primitive, squarefree, deg 2, lc 1 — satisfies
+all standard core side conditions) has irreducible divisor `1−x`
+(`= core · (−x−1)`, lc −1), which cannot be represented.
+
+The landed recovery producer `toMonicLiftData_represents_lifted_of_modP`
+(`Basic.lean:19885`) corroborates this: it only covers factors with
+`hsign : normalizeFactorSign factor = factor`.
+
+## Current frontier
+
+#7550 is back in the `replan` queue with a recommended corrected directive:
+narrow the `exists_subset` / `hexists_lifted` factor quantifier to
+sign-normalized factors (`Hex.normalizeFactorSign factor = factor`) across
+`HenselSubsetCorrespondenceRest` / `HenselSubsetCorrespondenceHypotheses` /
+`LiftedFactorSubsetPartition`. That is a structural change to shared `Prop`
+structures and their uniqueness/transport/cover consumers — different in scope
+from the "produce the existing bare hypotheses from core facts" framing.
+
+## Next step
+
+A planner should rewrite #7550 to the narrowed-quantifier shape. Once the
+field is narrowed, `toMonicLiftData_represents_lifted_of_modP` discharges it
+from core facts (deriving `Primitive`/positive-degree from primitive squarefree
+positive-degree core via Gauss). Secondary open piece: `hunscaled` (unscaled
+support `S ⊆ T` over `liftedFactorProductCandidate`) has no producer yet — the
+non-monic sibling of the #7479 support direction.
+
+## Blockers
+
+The directive as typed is unsatisfiable; no code change is possible without the
+quantifier narrowing above. No PR opened (diagnose-and-skip path).


### PR DESCRIPTION
This PR records, in the `hex-lean-mathlib-boundary` skill, the false-hypothesis
failure mode found while diagnosing https://github.com/kim-em/hex/issues/7550
(feat: produce toMonic Hensel recovery substrate from core facts). That issue
asks to produce the bare lift-coverage quantifier `hexists_lifted` /
`HenselSubsetCorrespondenceRest.exists_subset` from core facts, but that
universal is unsatisfiable under the substrate's own side conditions:
`normalizeFactorSign_eq_of_representsAtLift` proves every represented factor is
sign-normalized, so negative-leading-coefficient irreducible divisors (e.g.
`1−x ∣ x²−1`) can never be represented. The issue was diagnosed on-thread and
returned to the `replan` queue with the recommended quantifier narrowing; this
adds a durable pointer so the next agent recognises the pattern without
re-deriving it. No Lean sources change.

🤖 Prepared with Claude Code
