### PR TITLE
chore: progress note for #7561 premise check (skipped to replan)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -302,6 +302,26 @@ clean half needs the undilated `lfp S ∣ lfp T`. This was #7479 deliverable 2;
 the dilate equality/support wrappers (deliverables 1/3, #7491 / `toMonicLiftData_
 liftedRecoveryCandidate_eq`) are the unblocked ones.
 
+The same #7479 gap is what currently blocks the **whole slow-modular toMonic
+capstone** (#7561 / `factorSlowModularFactorsWithBound_factor_irreducible_of_fast_none`):
+its irreducibility producer needs a `LiftedFactorSubsetPartition core d Finset.univ
+core`, whose required field `support_subset_of_dvd_recombinationCandidate`
+(`Basic.lean:3547`) is the **unscaled** support `S ⊆ T` over
+`liftedFactorProductCandidate` (`Basic.lean:2527`). *Every* partition producer
+(`Basic.lean:17918/19131/20790`, `IntReductionMod.lean:3102`) takes it as the
+open `hunscaled` hypothesis; the only landed `S ⊆ T` lemma
+(`toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate`) is over the **scaled**
+`liftedRecoveryCandidate` (`Basic.lean:2540`), which coincides with the unscaled
+one **only at `leadingCoeff core = 1`** (`liftedRecoveryCandidate.eq_productCandidate_of_lc_one`)
+— and the re-key runs on non-monic cores. Disambiguation for #7561's Notes: the
+`MonicDescentHypotheses` / `hexists_lifted` adapter is **not** the blocker — `hcorr`
+and `hinitial` are producible from core facts now
+(`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent`,
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`), and the
+heavy `descends` field is not consumed when building the correspondence (only
+`lift_eq = rfl` / `successful_lift = trivial`). Land the unscaled-support
+producer first, then #7561 is the thin composition.
+
 **But "no producer" only blocks a transport that genuinely needs a bridge
 between two concrete defs.** Before skipping a `henselLiftData → toMonicLiftData`
 (or similar) transport, check whether the consumer chain is *generic in the

--- a/progress/20260616T104012Z_eba35266.md
+++ b/progress/20260616T104012Z_eba35266.md
@@ -1,0 +1,60 @@
+# Progress — 2026-06-16T10:40:12Z (session eba35266, one-shot work #7561)
+
+## Accomplished
+
+Claimed one-shot issue #7561 ("discharge slow-modular raw irreducibility after
+toMonic re-key") and diagnosed its premise as blocked on a separate missing
+producer, then skipped it (→ `replan`) with a concrete-evidence comment rather
+than landing an assumption-padded or sorried PR.
+
+The blocking finding: deliverable 4's final irreducibility theorem routes
+through
+`exhaustiveCoreFactorsWithBound_factor_zpolyIrreducible_of_henselSubsetCorrespondence_of_bound`
+(`Basic.lean:17164`), which requires a
+`LiftedFactorSubsetPartition core d Finset.univ core`. That structure
+(`Basic.lean:3509`) has a required field
+`support_subset_of_dvd_recombinationCandidate` (`Basic.lean:3547`) — the
+**unscaled** support `S ⊆ T` over `liftedFactorProductCandidate`. Every
+partition producer in the tree (`Basic.lean:17918/19131/20790`,
+`IntReductionMod.lean:3102`) takes this as an explicit open `hunscaled`
+hypothesis; none discharge it.
+
+`hunscaled` is a separate missing producer, not a small extraction: the only
+landed `S ⊆ T` recovery lemma `toMonicLiftData_subset_of_dvd_liftedRecoveryCandidate`
+is over the **scaled** `liftedRecoveryCandidate` (`Basic.lean:2540`, carries
+`dilate (leadingCoeff core)`), which coincides with the unscaled
+`liftedFactorProductCandidate` (`Basic.lean:2527`) **only when
+`leadingCoeff core = 1`** (`liftedRecoveryCandidate.eq_productCandidate_of_lc_one`).
+The #7560 re-key deliberately runs the slow-modular branch on non-monic
+square-free cores, so the scaled lemma does not bridge.
+
+Notably, the descent adapter named in the issue's Notes
+(`MonicDescentHypotheses` / `hexists_lifted`) is **not** the blocker: `hcorr`
+and `hinitial` are both producible from core facts now (#7550/#7556 narrowing +
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`), and the
+heavy `descends` field is not consumed when building the correspondence (only its
+`lift_eq = rfl` / `successful_lift = trivial` fields are).
+
+## Current frontier
+
+#7561 is back in the `replan` queue. The recommended corrected directive: split
+off a predecessor that produces the non-monic unscaled-support lemma (the #7479
+sibling bridging `dilate (leadingCoeff core)` between `liftedFactorProductCandidate`
+and `liftedRecoveryCandidate`). Once it lands,
+`slowPathHenselSubstrate_of_toMonicChoosePrimeData` is fully fed and #7561
+becomes the thin composition it was framed as, mirroring
+`factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`
+(`IntReductionMod.lean:5792`).
+
+## Next step
+
+A planner should create the unscaled-support producer issue, link #7561 to
+depend on it, and renarrow #7561 to the residual composition.
+
+## Blockers
+
+`hunscaled` unscaled-support producer is unimplemented and is the same gap
+flagged open by #7550 and #7565. No code change is sound without it. No PR
+opened (diagnose-and-skip path). The worktree still carries unrelated
+pre-existing modifications to `.claude/` files; this session did not touch or
+stage them.


### PR DESCRIPTION
This PR records the premise-check progress note for #7561, which was diagnosed as blocked on the still-open `hunscaled` unscaled-support producer (the non-monic sibling of the #7479 support direction) and skipped to `replan` rather than landing an assumption-padded or sorried proof. The final slow-modular irreducibility theorem routes through `LiftedFactorSubsetPartition`, whose required `support_subset_of_dvd_recombinationCandidate` field has no producer for non-monic cores; the only landed `S ⊆ T` recovery lemma is over the scaled `liftedRecoveryCandidate`, which coincides with the unscaled `liftedFactorProductCandidate` only when `leadingCoeff core = 1`. Full evidence is in the issue comment.

🤖 Prepared with Claude Code