### PR TITLE
chore: note stale-olean gotcha in Mathlib-boundary skill

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -408,6 +408,17 @@ all. A fresh worktree has no built Mathlib, so run `lake exe cache get` first
 (fetches prebuilt oleans in minutes; a from-scratch Mathlib compile is hours).
 Only the project's own files then rebuild.
 
+When you verify against a Mathlib-layer module with a throwaway scratch file
+(`lake env lean Scratch.lean` importing e.g. `HexBerlekampZassenhausMathlib.Lattice`),
+`lake env lean` loads that import's **prebuilt olean**, not its source. A
+reused worktree's olean can predate decls added in later commits, so a
+genuinely-present definition shows as `unknown identifier` (and autoImplicit
+then treats it as a free variable, cascading confusing errors) even though the
+source clearly declares it — fully-qualifying the name does not help. Before
+blaming a namespace, `ls -la` the module's `.olean` under `.lake/build/lib/` and
+check its mtime against the source: if stale, `lake build <Module>` to refresh
+it, then re-run the scratch verifier. Delete the scratch file before finishing.
+
 Before attributing a Mathlib-layer build failure to your own change, build the
 **unmodified** target on a clean tree to get a red/green baseline
 (`lake build HexBerlekampZassenhausMathlib.<Module>`), and `git diff origin/main

--- a/progress/20260616T114657Z_a3de178b.md
+++ b/progress/20260616T114657Z_a3de178b.md
@@ -1,0 +1,57 @@
+# Progress - 2026-06-16T11:46:57Z (session a3de178b, work)
+
+## Accomplished
+
+Claimed #7575 (feat: prove Gram-Schmidt cut soundness producing CutRetention,
+critical-path) and ran the premise check before writing any proof. Found the
+deliverable-1 producer target **unsound** and posted a kernel-checked
+counterexample, then skipped the issue for replan (no PR — correct rejection,
+not a partial landing).
+
+The directive asked for a producer of `CutRetention (bhksProjectedRows L hrows)`,
+whose field `mem_projected_of_norm_le` claims *every* integer vector with
+`‖v‖² ≤ cutRadiusSq4` lies in `projectedRowSpanInt`. Three independent problems,
+all in the issue comment:
+
+1. **Machine-checked counterexample.** `factorCount = 1`, `coeffWidth = 0`,
+   `basis = [[2]]`: the only reduced row has `‖b*₀‖² = 4`, `4·4 = 16 > 4 =
+   cutRadiusSq4`, so the cut discards it and `projectedRows = #[]` (confirmed by
+   `#eval` of the real `bhksProjectedRows`). Then `projectedRowSpanInt = ⊥` but
+   `v = ![1]` is short (`‖v‖² = 1 ≤ 4`). Kernel-checked lemma
+   `no_cutRetention_of_empty` (no sorry/axiom/native_decide) proves
+   `IsEmpty (CutRetention P)` for any empty-row `P` with `0 < factorCount ≤
+   cutRadiusSq4`.
+
+2. **Contradicts the `L' = W` goal.** `CutRetention` (all short v ∈ L')
+   contradicts `projectedRowSpan_eq_trueFactorIndicatorLattice` (`L' = W`)
+   whenever `W ⊊ ℤ^r`, i.e. whenever any true factor lifts to ≥2 local factors
+   — exactly the cases the indicator lattice exists for. Membership in a
+   sublattice never follows from a norm bound alone.
+
+3. **Never needed downstream.** The forward consumer
+   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut`
+   (`PartitionRefinement.lean:477`) takes the weak `CutProjectionHypotheses`
+   (`W ≤ L'`, instantiated only at true indicators). `CutRetention` is a pure
+   over-generalization plugged in via `cutProjectionHypotheses_of_retention`.
+
+## Current frontier
+
+#7575 is `replan`. A planner should restate deliverable 1 as a cut-soundness
+lemma **on the full lattice `L`** (retained LLL rows ℤ-span every lattice
+vector within the cut radius, via the `gramDetVec → ‖b*ᵢ‖²` correspondence
+`basis_normSq` / `gramDet_eq_prod_normSq` in `HexGramSchmidtMathlib/Int.lean`),
+producing `CutProjectionHypotheses` / `CutSurvival` directly from factorization
+data — not via the unprovable universal-over-ℤ^r `CutRetention`.
+
+## Next step
+
+Replan #7575 with the corrected statement. The `CutRetention` structure
+(`Lattice.lean:408`) and `cutProjectionHypotheses_of_retention` /
+`..._of_retention` wrappers should be retired or restated, since no producer
+for them can exist.
+
+## Blockers
+
+None. Note: the worktree carries pre-existing unrelated modifications to
+`.claude/*` (CLAUDE.md, commands, agent-worker-flow SKILL) from before this
+session; not touched or staged here.


### PR DESCRIPTION
This PR records a stale-olean gotcha in the `hex-lean-mathlib-boundary` skill and a progress note. It does not touch any Lean source: it captures the diagnosis from a premise check of #7575, whose `CutRetention` producer target was found unsound (kernel-checked counterexample plus a structural contradiction with the `L' = W` goal — full evidence posted on the issue, which is now `replan`). The skill addition warns that `lake env lean` on a scratch verifier loads a prebuilt olean, so a recently-added Mathlib-layer declaration can show as `unknown identifier` against a stale worktree olean; the fix is to rebuild the module first.

🤖 Prepared with Claude Code
