### PR TITLE
feat: produce toMonicPrimeData Hensel substrate from core facts

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -252,7 +252,21 @@ there, below `Basic.lean`. Building a producer whose fields straddle this bounda
 forces it into the lowest file that sees every datum, which in turn forces
 de-privatising any `private` `Basic.lean` helpers it calls (visibility-only, safe).
 Wiring it back up into the upstream slow-path substrate is a separate follow-up
-(the substrate cannot import downstream modules).
+(the substrate cannot import downstream modules). That follow-up landed (#7584):
+`IntReductionMod.lean` now carries carrier-free toMonic producers that need only a
+`toMonicPrimeData?` selection witness plus core facts (lc>0, deg>0, primitive,
+squarefree, B≠0, the monic-correspondent bound) — `liftedFactorSubsetPartition_of_toMonicPrimeData_complete`
+and `slowPathHenselSubstrate_of_toMonicPrimeData`, both discharging `hinitial` via
+the #7362 producer above and `hcorr` via the new Basic.lean
+`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` (the carrier-free
+correspondence: at `True True`, `MonicDescentHypotheses`' only consumed fields
+`lift_eq`/`successful_lift` are `rfl`/`trivial`, so no descent carrier is needed —
+there is still no `MonicDescentHypotheses` *producer*, but the partition/substrate
+chain no longer needs one). So when wiring #6771/#7561, **do not re-derive these** —
+consume `slowPathHenselSubstrate_of_toMonicPrimeData` / `…_complete` directly. They
+have no in-tree consumer yet; the slow-exhaustive branch
+(`liftedFactorSubsetPartition_outerBound_of_choosePrimeData`) is keyed on the
+different `choosePrimeData? squareFreeCore` selection, not `toMonicPrimeData?`.
 
 A distinct, sharper failure mode than "no producer": the hypothesis the
 directive asks you to *produce* is not merely unproduced but **provably false**,

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -20770,6 +20770,51 @@ theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent
     exact toMonicLiftData_unique_subset core B primeData
       hcore_lc_pos hcore_pos hselected hprecision hbound hirr hdvd hS hT
 
+/--
+Carrier-free `toMonicPrimeData?` Hensel subset correspondence surface.
+
+Same conclusion as
+`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData_success_descent`, but
+without the `MonicDescentHypotheses` carrier: at the `True True` instantiation the
+only descent fields that constructor consumed (`lift_eq`, `successful_lift`) are
+`rfl`/`trivial`, and the existence/uniqueness fields come directly from the core
+facts via `toMonicLiftData_represents_lifted_of_modP` and
+`toMonicLiftData_unique_subset`.  This is the core-facts producer that the
+partition and slow-path substrate packages route through. -/
+theorem henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
+    (core : Hex.ZPoly) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (hB_ne_zero : B ≠ 0) :
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
+    HenselSubsetCorrespondenceHypotheses core B primeData d True True := by
+  intro d
+  have hcore0 : core ≠ 0 := zpoly_ne_zero_of_pos_lc hcore_lc_pos
+  have hdeg : 1 ≤ (Hex.ZPoly.toMonic core).degree := hcore_pos
+  refine
+    { lift_eq := rfl
+      admissible_prime := trivial
+      successful_lift := trivial
+      exists_subset := ?_
+      unique_subset := ?_ }
+  · intro factor hsign hirr hdvd
+    have hprim : Hex.ZPoly.Primitive factor :=
+      zpoly_primitive_of_dvd_primitive_basic hcore_prim hdvd
+    have hfdeg : 1 ≤ factor.degree?.getD 0 :=
+      one_le_degree_getD_of_irreducible_dvd_primitive hcore_prim hirr hdvd
+    exact toMonicLiftData_represents_lifted_of_modP core B primeData
+      hselected hcore0 hcore_lc_pos hdeg hB_ne_zero hirr hprim hsign hfdeg hdvd
+  · intro factor S T hirr hdvd hS hT
+    exact toMonicLiftData_unique_subset core B primeData
+      hcore_lc_pos hcore_pos hselected hprecision hbound hirr hdvd hS hT
+
 /-- Initial lifted subset partition for `toMonicPrimeData?` success.
 
 This composes the core-fact correspondence producer

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3080,6 +3080,114 @@ theorem initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
 
 end IntReductionMod
 
+/-- **#7584 core-facts producer (lifted-subset partition).**
+
+`LiftedFactorSubsetPartition core (toMonicLiftData core B primeData) Finset.univ
+core` from the executable `toMonicPrimeData?` selection witness and the standard
+core side conditions alone.  The embedded Hensel correspondence comes from the
+carrier-free `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` (no
+`MonicDescentHypotheses` input), and the recovered-coordinate partition evidence
+from
+`IntReductionMod.initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`,
+so the caller supplies neither the descent carrier nor a separate
+`InitialLiftedFactorSubsetPartitionEvidence`.  The monic-only unscaled support
+field stays guarded by `leadingCoeff core = 1`; the non-monic path routes through
+the recovered `liftedRecoveryCandidate` coordinate. -/
+theorem liftedFactorSubsetPartition_of_toMonicPrimeData_complete
+    (core : Hex.ZPoly) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p) :
+    let d := Hex.ZPoly.toMonicLiftData core B primeData
+    LiftedFactorSubsetPartition core d Finset.univ core := by
+  intro d
+  have hp_prime : Hex.Nat.Prime primeData.p :=
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
+  have hp2 : 2 ≤ primeData.p := hp_prime.two_le
+  have hprec_spec :
+      2 * B < primeData.p ^ Hex.precisionForCoeffBound B primeData.p :=
+    Hex.precisionForCoeffBound_spec hp2 B
+  have hB1 : 1 ≤ B := Nat.one_le_iff_ne_zero.mpr hB_ne_zero
+  have hmodulus :
+      2 ≤ primeData.p ^ Hex.precisionForCoeffBound B primeData.p := by omega
+  have hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p := by
+    by_contra hlt
+    have hzero : Hex.precisionForCoeffBound B primeData.p = 0 := by omega
+    rw [hzero, pow_zero] at hmodulus
+    omega
+  exact liftedFactorSubsetPartition_of_toMonicPrimeData core B primeData hselected
+    (henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData core B primeData
+      hselected hcore_lc_pos hcore_pos hcore_prim hprecision hbound hB_ne_zero)
+    hcore_sqfree
+    (IntReductionMod.initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
+      core B primeData hselected hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound)
+
+/-- **#7584 core-facts producer (slow-path Hensel substrate).**
+
+`SlowPathHenselSubstrate core B primeData` from the `toMonicPrimeData?` selection
+witness and standard core side conditions alone -- the slow-modular / fast-BHKS
+substrate package with no `MonicDescentHypotheses` carrier and no
+`InitialLiftedFactorSubsetPartitionEvidence` input.  The `corr` and `partition`
+fields are the carrier-free / complete `toMonicPrimeData?` producers above; the
+remaining lifted-factor monic / positive-degree / injectivity and modulus /
+precision facts discharge directly from the selection witness. -/
+theorem slowPathHenselSubstrate_of_toMonicPrimeData
+    (core : Hex.ZPoly) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p) :
+    SlowPathHenselSubstrate core B primeData := by
+  have hp_prime : Hex.Nat.Prime primeData.p :=
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
+  have hp2 : 2 ≤ primeData.p := hp_prime.two_le
+  have hprec_spec :
+      2 * B < primeData.p ^ Hex.precisionForCoeffBound B primeData.p :=
+    Hex.precisionForCoeffBound_spec hp2 B
+  have hB1 : 1 ≤ B := Nat.one_le_iff_ne_zero.mpr hB_ne_zero
+  have hmodulus :
+      2 ≤ primeData.p ^ Hex.precisionForCoeffBound B primeData.p := by omega
+  have hprec_pos : 1 ≤ Hex.precisionForCoeffBound B primeData.p := by
+    by_contra hlt
+    have hzero : Hex.precisionForCoeffBound B primeData.p = 0 := by omega
+    rw [hzero, pow_zero] at hmodulus
+    omega
+  refine
+    { corr := ?_
+      partition := ?_
+      liftedFactor_monic := ?_
+      liftedFactor_natDegree_pos := ?_
+      liftedFactor_inj := ?_
+      modulus := ?_
+      precision := ?_ }
+  · exact henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData
+      core B primeData hselected hcore_lc_pos hcore_pos hcore_prim
+      hprec_pos hbound hB_ne_zero
+  · exact liftedFactorSubsetPartition_of_toMonicPrimeData_complete
+      core B primeData hselected hcore_lc_pos hcore_pos hcore_prim
+      hcore_sqfree hB_ne_zero hbound
+  · exact Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData
+      core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
+  · exact Hex.ZPoly.toMonicLiftData_liftedFactor_natDegree_pos_of_monicPrimeData
+      core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
+  · exact Hex.ZPoly.toMonicLiftData_liftedFactor_injective_of_monicPrimeData
+      core B primeData hcore_lc_pos hcore_pos hselected hprec_pos
+  · exact hmodulus
+  · exact hprec_spec
+
 /-- **#4549 base task (HO-1), outer-bound specialisation, rewired for #4553.**
 
 Specialisation of `liftedFactorSubsetPartition_of_choosePrimeData`

--- a/progress/20260616T125450Z_c36b14d6.md
+++ b/progress/20260616T125450Z_c36b14d6.md
@@ -1,0 +1,71 @@
+# Progress - 2026-06-16T12:54:50Z (session c36b14d6, work #7584)
+
+## Accomplished
+
+Claimed #7584 (one-shot) and produced the core-facts-only toMonic Hensel
+correspondence / lifted-subset partition producer surface, the corrected
+successor to the #7550/#7569/#7573 chain.
+
+After #7550 narrowed `exists_subset` to sign-normalized factors, #7569/#7573
+removed/guarded the false non-monic unscaled support field, and #7362 supplied
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`, the last
+caller obligations on the toMonic substrate were the `MonicDescentHypotheses`
+carrier and the `InitialLiftedFactorSubsetPartitionEvidence` input. Both are now
+dischargeable, so I added three additive producers (153 lines, no deletions):
+
+- `HexBerlekampZassenhausMathlib/Basic.lean`:
+  `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` — carrier-free
+  correspondence. At the `True True` instantiation the only `MonicDescentHypotheses`
+  fields the descent variant consumed (`lift_eq`, `successful_lift`) are
+  `rfl`/`trivial`, so no descent carrier is needed; existence/uniqueness come from
+  `toMonicLiftData_represents_lifted_of_modP` / `toMonicLiftData_unique_subset`.
+- `HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+  `liftedFactorSubsetPartition_of_toMonicPrimeData_complete` — concludes
+  `LiftedFactorSubsetPartition core (toMonicLiftData …) Finset.univ core` from a
+  `toMonicPrimeData?` selection witness plus standard core facts (lc>0, deg>0,
+  primitive, squarefree, B≠0, the monic-correspondent precision bound). Discharges
+  `hcorr` via the carrier-free producer and `hinitial` via
+  `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`; derives
+  `hprecision` from the bound.
+- `HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+  `slowPathHenselSubstrate_of_toMonicPrimeData` — `SlowPathHenselSubstrate core B
+  primeData` from the same inputs alone, routing `corr`/`partition` through the two
+  producers above.
+
+The non-monic path routes through the recovered/dilated `liftedRecoveryCandidate`
+coordinate (deliverable 2); the monic-only unscaled
+`support_subset_of_dvd_recombinationCandidate` field stays guarded by
+`leadingCoeff core = 1` (deliverable 4, untouched).
+
+Verification (clean tree baseline was green before edits):
+- `lake build HexBerlekampZassenhausMathlib.Basic`
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod`
+- `lake build HexBerlekampZassenhausMathlib`
+- `python3 scripts/check_dag.py` (exit 0)
+- `git diff --check` (clean)
+- Added-line forbidden-token scan: no new `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.
+
+## Current frontier
+
+The toMonic correspondence / partition / slow-path substrate packages now have a
+thin producer from the executable `toMonicPrimeData?` selection witness and core
+facts alone, with no analytic-recovery or descent-carrier caller obligation.
+
+## Next step
+
+Deliverable 3 (wire the producer into the fast-BHKS / slow-modular capstone call
+sites) has no actionable target in the current tree: the toMonic
+`SlowPathHenselSubstrate` chain is producer-side infrastructure with no downstream
+consumer yet, and the slow-exhaustive branch (`liftedFactorSubsetPartition_outerBound_of_choosePrimeData`,
+IntReductionMod.lean:3803/4172) is keyed on `choosePrimeData? squareFreeCore`, a
+different selection than `toMonicPrimeData?`. The capstones that will consume these
+(#6771, #7561) need their consumption points built (and #6771 remains blocked on
+the separate cut heart #6779). The producers expose the exact
+`LiftedFactorSubsetPartition core d Finset.univ core` and `SlowPathHenselSubstrate
+core B primeData` shapes those capstones require, so the wiring is a thin step once
+the consumer side lands.
+
+## Blockers
+
+None for this producer surface. Downstream capstone wiring waits on the consumer
+sites (#6771 → cut heart #6779; #7561 re-key).


### PR DESCRIPTION
This PR adds a carrier-free producer surface for the toMonic Hensel correspondence, lifted-subset partition, and slow-path substrate, deriving each from a `toMonicPrimeData?` selection witness plus the standard core facts (positive leading coefficient, positive degree, primitive, squarefree, `B ≠ 0`, the monic-correspondent precision bound) alone. It is the corrected successor to the #7550/#7569/#7573 chain: with `exists_subset` narrowed to sign-normalized factors (#7550), the false non-monic unscaled support field removed/guarded (#7569/#7573), and `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData` landed (#7362), the residual caller obligations on the substrate were the `MonicDescentHypotheses` carrier and the `InitialLiftedFactorSubsetPartitionEvidence` input, both now discharged.

`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` drops the descent carrier: at the `True True` instantiation the only fields the descent variant consumed (`lift_eq`, `successful_lift`) are `rfl`/`trivial`, and existence/uniqueness come from `toMonicLiftData_represents_lifted_of_modP` / `toMonicLiftData_unique_subset`. `liftedFactorSubsetPartition_of_toMonicPrimeData_complete` and `slowPathHenselSubstrate_of_toMonicPrimeData` additionally discharge the initial-evidence input and derive the precision bound internally. The non-monic path routes through the recovered/dilated `liftedRecoveryCandidate` coordinate; the monic-only unscaled `support_subset_of_dvd_recombinationCandidate` field stays guarded by `leadingCoeff core = 1`.

The change is purely additive (153 Lean lines, no deletions). Wiring these into the fast-BHKS (#6771) and slow-modular (#7561) capstones is left for the consumer side: the toMonic `SlowPathHenselSubstrate` chain is producer-side infrastructure with no downstream consumer in tree yet, and #6771 remains blocked on the separate cut heart (#6779). The producers expose the exact `LiftedFactorSubsetPartition core d Finset.univ core` and `SlowPathHenselSubstrate core B primeData` shapes those capstones require.

Verified with `lake build HexBerlekampZassenhausMathlib.Basic`, `lake build HexBerlekampZassenhausMathlib.IntReductionMod`, `lake build HexBerlekampZassenhausMathlib`, `python3 scripts/check_dag.py`, and `git diff --check`, all from a green clean-tree baseline.

🤖 Prepared with Claude Code