### PR TITLE
doc: note executable-layer scratch #eval extern gotcha in boundary skill

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -558,3 +558,22 @@ running its tail jobs — they serialize on lake's per-worktree build lock, so t
 second just blocks and looks "stuck". (This machine also runs concurrent builds
 from *other* pod worktrees; `pgrep lake` showing many processes is normal and
 not your build.)
+
+**Numerically checking executable behavior in a scratch file: `#eval`/`#guard`
+inside a lake-built module, not `lake env lean Scratch.lean`.** To sanity-check a
+premise by *running* the executable functions (e.g. comparing
+`defaultFactorCoeffBound f` against `defaultFactorCoeffBound (toMonic core).monic`
+to test a precision claim), be aware that any code path touching the `@[extern]`
+arithmetic (`Hex.ZMod64.mul`, anything pulling in `choosePrimeData?` /
+`factorSlowModularFactorsWithBound` / mod-`p` work) fails under the interpreter
+with `Could not find native implementation of external declaration
+'Hex.ZMod64.mul'`. The `--load-dynlib=.lake/build/lib/*.dylib` workaround then
+dies on flat-namespace symbol errors (`symbol not found '_lp_Hex_Hex_ZMod64_mul'`)
+— do not sink time into it. Two reliable routes: (1) restrict the scratch to the
+*pure-integer* `ZPoly`/`Nat` ops (`defaultFactorCoeffBound`, `toMonic`,
+`precisionForCoeffBound`, `coeffNormSq`), which need no extern and run fine under
+`lake env lean Scratch.lean` — for a primitive squarefree `f`, `squareFreeCore f`
+is `f`, so you can take `core := f` and avoid the modular `normalizeForFactor`
+path entirely; (2) if you genuinely need the ZMod64 path, put the `#eval`/`#guard`
+in a module the package builds (`precompileModules := true` is set, so build-time
+`#eval` resolves the native symbols) rather than running a standalone file.

--- a/progress/20260616T154109Z_dca6c873.md
+++ b/progress/20260616T154109Z_dca6c873.md
@@ -1,0 +1,57 @@
+# Progress - 2026-06-16T15:41:09Z (session dca6c873, feature #7604)
+
+## Accomplished
+
+Claimed #7604 ("discharge slow-modular raw irreducibility from toMonic
+substrate"), diagnosed it as resting on a false premise, and **skipped it for
+replan** with a concrete diagnostic comment
+(https://github.com/kim-em/hex/issues/7604#issuecomment-4720576208) rather than
+landing a `sorry`/added-hypothesis workaround.
+
+The obstruction (premise check per the "directives are hypotheses" rule):
+
+- The slow-modular exhaustive arm `factorSlowModularFactorsWithBound f
+  (defaultFactorCoeffBound f)` lifts the **monic transform** `(toMonic
+  core).monic` at fixed precision `precisionForCoeffBound (defaultFactorCoeffBound
+  f) primeData.p` (`HexBerlekampZassenhaus/Basic.lean:7227/7150/6811`).
+- The only landed `toMonicPrimeData?` partition/substrate producer
+  (`IntReductionMod.lean:3096/3141`) requires `hbound : 2 *
+  defaultFactorCoeffBound (toMonic core).monic < primeData.p ^
+  precisionForCoeffBound B primeData.p`.
+- `precisionForCoeffBound_spec` only gives `2 * defaultFactorCoeffBound f <
+  p^prec`, so `hbound` needs `defaultFactorCoeffBound (toMonic core).monic ≤
+  defaultFactorCoeffBound f`, which is **false** — the monic transform's
+  coefficients grow like `lc(core)^(deg-1)`. Numerically (executable `#eval`,
+  primitive squarefree f so squareFreeCore = f): 78 vs 18, 2148 vs 54, 12970 vs
+  70; `hbound` is false for all small primes for 7x⁴+… and 6x⁵+1.
+- `Recovery.lean:1434` confirms this precision is dischargeable **only** for
+  monic cores (`leadingCoeff core = 1` ⇒ `(toMonic core).monic = core`). The
+  re-key runs on general non-monic cores. Across the layer this fact appears 20×,
+  always as an open hypothesis; nothing produces it.
+
+So deliverable 1's no-precision-hypothesis theorem is not provable, and "Missing
+infrastructure: none known" is incorrect. Real fix is executable-layer
+(size the exhaustive-arm precision to the monic bound, or escalate like the fast
+path) plus the matching Mathlib recovery-direction remodel — out of scope for a
+token-swap composition issue.
+
+## Current frontier
+
+No code changed. Verified the executable layer builds clean (`lake build
+HexBerlekampZassenhaus.Basic`, 491 jobs, exit 0) while checking bounds via a
+throwaway scratch `#eval` (removed). Quality metrics unchanged.
+
+## Next step
+
+A planner should re-scope #7604: either (a) restate with `hbound` as an explicit
+hypothesis (but deliverable 2 forbids it and #6672 cannot consume that shape),
+or (b) first fix the non-monic-core precision provisioning in
+`factorSlowModularFactorsWithBound`/`exhaustiveCoreFactorsWithBound` and remodel
+the recovery-direction proofs, then re-issue this composition. This is the same
+non-monic monic-transform recovery gap that blocks the slow-modular toMonic
+capstone (#7561 / #6672 chain).
+
+## Blockers
+
+Premise of #7604 is unsound as written (false precision obligation for non-monic
+cores). Skipped for replan; no PR.


### PR DESCRIPTION
This PR records, in the `hex-lean-mathlib-boundary` skill, that running executable-layer functions which touch the `@[extern]` ZMod64 arithmetic (`choosePrimeData?`, `factorSlowModularFactorsWithBound`, any mod-`p` path) from a standalone `lake env lean Scratch.lean` fails with "Could not find native implementation of external declaration 'Hex.ZMod64.mul'", and that the `--load-dynlib` workaround dies on flat-namespace symbol errors. It points future agents at the two reliable routes: restrict the scratch to pure-integer `ZPoly`/`Nat` ops (taking `core := f` for primitive squarefree `f`), or place the `#eval`/`#guard` in a lake-built module where `precompileModules` resolves the native symbols.

Discovered while diagnosing #7604, whose premise check needed a numeric comparison of `defaultFactorCoeffBound f` against `defaultFactorCoeffBound (toMonic core).monic`. The session's progress note rides along.

🤖 Prepared with Claude Code