### PR TITLE
feat: make BHKS Gram-Schmidt cut a prefix cut

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5028,15 +5028,34 @@ theorem lll_delta_lower : (1 / 4 : Rat) < 3 / 4 := by
 theorem lll_delta_upper : (3 / 4 : Rat) ≤ 1 := by
   grind
 
+/--
+Length of the BHKS Lemma 5.7 *prefix* cut: one past the last Gram-Schmidt
+index whose squared length is within the radius (`0` if none passes).  Because
+the fold runs in increasing index order, the accumulator ends at
+`(max { i : ‖b*_i‖² ≤ radius }) + 1`, so retaining indices `< t` keeps the
+contiguous prefix `b_0 … b_t` in original order — including earlier rows whose
+own Gram-Schmidt norm exceeds the radius.
+-/
+def bhksCutPrefixCount
+    (L : BhksLatticeBasis)
+    (reduced : Matrix Int (L.factorCount + L.coeffWidth)
+        (L.factorCount + L.coeffWidth)) :
+    Nat :=
+  let dets := GramSchmidt.Int.gramDetVec reduced
+  (List.finRange (L.factorCount + L.coeffWidth)).foldl
+    (fun acc i =>
+      if bhksWithinGramSchmidtCut L dets i then i.val + 1 else acc)
+    0
+
 def bhksCutProjectReducedRows
     (L : BhksLatticeBasis)
     (reduced : Matrix Int (L.factorCount + L.coeffWidth)
         (L.factorCount + L.coeffWidth)) :
     Array (Array Int) :=
-  let dets := GramSchmidt.Int.gramDetVec reduced
+  let t := bhksCutPrefixCount L reduced
   (List.finRange (L.factorCount + L.coeffWidth)).foldl
     (fun acc i =>
-      if bhksWithinGramSchmidtCut L dets i then
+      if i.val < t then
         acc.push (bhksProjectIndicator L.factorCount L.coeffWidth (reduced.row i))
       else
         acc)
@@ -5047,10 +5066,10 @@ def bhksRetainedRowIndices
     (reduced : Matrix Int (L.factorCount + L.coeffWidth)
         (L.factorCount + L.coeffWidth)) :
     Array (Fin (L.factorCount + L.coeffWidth)) :=
-  let dets := GramSchmidt.Int.gramDetVec reduced
+  let t := bhksCutPrefixCount L reduced
   (List.finRange (L.factorCount + L.coeffWidth)).foldl
     (fun acc i =>
-      if bhksWithinGramSchmidtCut L dets i then
+      if i.val < t then
         acc.push i
       else
         acc)

--- a/progress/20260617_aad44673.md
+++ b/progress/20260617_aad44673.md
@@ -1,0 +1,78 @@
+# Progress - 2026-06-17 (session aad44673, one-shot #7592)
+
+## Accomplished
+
+Claimed #7592 (feat: add BHKS cut-separation prefix certificate, critical-path)
+via `pod once`. Split into its two staged deliverables: the executable prefix
+cut ("lands first") and the `CutRetention` proof. **Landed the executable
+prefix cut; rejected the `CutRetention` proof half as an unsound target** (same
+defect #7575 already diagnosed, invariant under the prefix change), with a
+machine-checked comment on the issue.
+
+### Executable prefix cut (landed)
+
+`HexBerlekampZassenhaus/Basic.lean`: added `bhksCutPrefixCount` (computes
+`t = (max passing GS index) + 1` by an increasing-order fold) and rewired
+`bhksCutProjectReducedRows` / `bhksRetainedRowIndices` to retain the contiguous
+prefix `b_0 … b_t` in original order, including earlier rows whose own GS norm
+exceeds the radius. This is the genuine BHKS Lemma 5.7 prefix and fixes the
+non-prefix defect diagnosed on #7578 (per-row survivor set was not a GS-norm
+prefix under LLL).
+
+Verification:
+- `lake build HexBerlekampZassenhaus` — clean.
+- `lake build HexBerlekampZassenhausMathlib.Lattice` — clean (proof layer intact;
+  nothing constructs `CutRetention`, so the runtime change breaks no proof).
+- Regenerated `conformance-fixtures/HexBerlekampZassenhaus/bz.jsonl` via
+  `hexbz_emit_fixtures` — **byte-identical** to the committed flint-verified
+  ground truth. Factorization output is unchanged (survivor set only grows;
+  final factor multisets match flint).
+- Added-line forbidden-token scan: no sorry/axiom/native_decide/TODO/FIXME.
+
+### `CutRetention` proof half (rejected as unsound — premise defect)
+
+`CutRetention.mem_projected_of_norm_le` (`Lattice.lean:424`) quantifies over
+**arbitrary** `v : Fin r → ℤ` with only a norm bound and concludes membership in
+the **projected** span `projectedRowSpanInt`. This is unsatisfiable — the same
+defect #7575 posted (kernel-checked `IsEmpty (CutRetention P)`) — and the prefix
+change does **not** repair it. Machine-checked under the new prefix code:
+`factorCount=1, coeffWidth=0, reduced=[[2]]` gives `cutRadiusSq4=4`,
+`bhksCutPrefixCount=0`, `bhksCutProjectReducedRows=#[]`, so
+`projectedRowSpanInt=⊥`, yet `v=![1]` has `‖v‖²=1 ≤ 4`. Membership in a
+sublattice never follows from a norm bound alone.
+
+The issue's *Proof section* states the SOUND fact correctly ("any
+**original-lattice** vector v with `‖v‖²≤radius` lies in the integer span of the
+retained prefix rows"). The defect is only the packaging: the sound statement is
+about lattice vectors of the `(r+n)`-dim reduced basis, not arbitrary `ℤ^r`
+vectors, and not the projected span. `CutRetention` drops the lattice hypothesis
+and projects — that is where soundness is lost.
+
+## Current frontier
+
+Executable prefix cut is the substrate any sound survivor-span proof needs.
+Landed via `create-pr --partial` (issue → `replan`). Comment on #7592 gives the
+corrected target.
+
+## Next step (for the replan)
+
+Prove the full-lattice survivor-span lemma directly into `CutProjectionHypotheses`
+(NOT `CutRetention`, which should be retired along with
+`cutProjectionHypotheses_of_retention` / `..._of_retention`):
+- For `v` with `memLattice reducedMatrix v` and `‖v‖² ≤ R`, `v ∈` ℤ-span of the
+  prefix rows `b_0 … b_t`, via `basis_normSq` (gramDetVec ↔ `‖b*_i‖²`,
+  `HexGramSchmidtMathlib/Int.lean:1070`) and the integer-top-coefficient /
+  orthogonality lemmas (`normSq_latticeVec_ge_min_basis_normSq`,
+  `rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one`,
+  `HexGramSchmidt/Int.lean`).
+- Then the factorization→lattice bridge #7578 listed as absent: true-support
+  indicators are projections of genuine short lattice vectors (CLD-vanishing for
+  true factors), so `CutProjectionHypotheses` holds at exactly the indicators it
+  is consumed at (`PartitionRefinement.lean:484`).
+
+## Blockers
+
+None for the landed change. The proof half is blocked on a corrected,
+non-`CutRetention` target (premise defect), routed to replan.
+Note: the worktree carries pre-existing unrelated `.claude/*` modifications from
+before this session; not touched or staged.


### PR DESCRIPTION
This PR makes the BHKS Gram-Schmidt cut a prefix cut (BHKS Lemma 5.7): a new `bhksCutPrefixCount` computes `t = (max passing Gram-Schmidt index) + 1`, and `bhksCutProjectReducedRows` / `bhksRetainedRowIndices` retain the contiguous prefix `b_0 … b_t` in original order, including earlier rows whose own Gram-Schmidt norm exceeds the radius. This fixes the non-prefix defect diagnosed on #7578 (the per-row survivor set was not a Gram-Schmidt-norm prefix under LLL) and is the substrate the survivor-span argument needs. Regenerated bz conformance fixtures are byte-identical to the committed flint-verified ground truth, so factorization output is unchanged.

Partial completion of #7592: this lands the executable prefix cut ("lands first"). The proof half, exposing the survivor-span fact "in the form consumed by `CutRetention`", is left for replan because `CutRetention` is an unsound target — it quantifies over arbitrary `ℤ^r` vectors and concludes projected-span membership, which fails on the (still-applicable under the prefix) empty-projection counterexample. See the issue comment for the machine-checked evidence and the corrected `CutProjectionHypotheses` target.

🤖 Prepared with Claude Code
