### PR TITLE
feat: expose default factor uniqueness side-condition package

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -11701,32 +11701,16 @@ theorem exhaustiveCoreFactorsWithBound_degree_pos
     unfold shouldRecordPolynomialFactor at hq_record
     simp [hq_one] at hq_record
 
-/-- Weakened-conclusion sibling of `exhaustiveCoreFactorsWithBound_degree_pos`:
-every emitted factor of the exhaustive recombination wrapper has positive
-`degree?` when the input core is primitive with positive leading coefficient
-and `shouldRecord = true`. A size-`1` emitted factor combines
-`Primitive q` (forcing `|q.coeff 0| = 1`) with `normalizeFactorSign q = q`
-(forcing `q.coeff 0 ≥ 0`) to conclude `q = 1`, which is excluded by
-`shouldRecord`. -/
-theorem exhaustiveCoreFactorsWithBound_degree_pos_of_primitive_pos_lc_core
-    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
-    (hcore_primitive : ZPoly.Primitive core)
-    (hcore_lc_pos : 0 < DensePoly.leadingCoeff core)
-    (hcore_record : shouldRecordPolynomialFactor core = true) :
-    ∀ factor ∈ (exhaustiveCoreFactorsWithBound core B primeData).toList,
-      0 < factor.degree?.getD 0 := by
-  intro q hq
-  have hcore_norm : normalizeFactorSign core = core :=
-    normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core (by omega)
-  have hemit_norm :=
-    exhaustiveCoreFactorsWithBound_normalizeFactorSign core B primeData hcore_norm
-  have hemit_record :=
-    exhaustiveCoreFactorsWithBound_shouldRecord core B primeData hcore_record
-  have hemit_primitive :=
-    exhaustiveCoreFactorsWithBound_primitive core B primeData hcore_primitive
-  have hq_norm : normalizeFactorSign q = q := hemit_norm q hq
-  have hq_record : shouldRecordPolynomialFactor q = true := hemit_record q hq
-  have hq_primitive : ZPoly.Primitive q := hemit_primitive q hq
+/-- A primitive, sign-normalized `ZPoly` that passes `shouldRecordPolynomialFactor`
+has positive `degree?`. A size-`1` such polynomial combines `Primitive q`
+(forcing `|q.coeff 0| = 1`) with `normalizeFactorSign q = q` (forcing
+`0 ≤ q.coeff 0`) to conclude `q = 1`, which `shouldRecord` excludes. -/
+theorem degree_pos_of_primitive_norm_record
+    (q : ZPoly)
+    (hq_primitive : ZPoly.Primitive q)
+    (hq_norm : normalizeFactorSign q = q)
+    (hq_record : shouldRecordPolynomialFactor q = true) :
+    0 < q.degree?.getD 0 := by
   rcases Nat.eq_zero_or_pos (q.degree?.getD 0) with hdeg_eq | hpos
   case inr => exact hpos
   case inl =>
@@ -11771,6 +11755,28 @@ theorem exhaustiveCoreFactorsWithBound_degree_pos_of_primitive_pos_lc_core
       rfl
     unfold shouldRecordPolynomialFactor at hq_record
     simp [hq_one] at hq_record
+
+/-- Weakened-conclusion sibling of `exhaustiveCoreFactorsWithBound_degree_pos`:
+every emitted factor of the exhaustive recombination wrapper has positive
+`degree?` when the input core is primitive with positive leading coefficient
+and `shouldRecord = true`. A size-`1` emitted factor combines
+`Primitive q` (forcing `|q.coeff 0| = 1`) with `normalizeFactorSign q = q`
+(forcing `q.coeff 0 ≥ 0`) to conclude `q = 1`, which is excluded by
+`shouldRecord`. -/
+theorem exhaustiveCoreFactorsWithBound_degree_pos_of_primitive_pos_lc_core
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_primitive : ZPoly.Primitive core)
+    (hcore_lc_pos : 0 < DensePoly.leadingCoeff core)
+    (hcore_record : shouldRecordPolynomialFactor core = true) :
+    ∀ factor ∈ (exhaustiveCoreFactorsWithBound core B primeData).toList,
+      0 < factor.degree?.getD 0 := by
+  intro q hq
+  have hcore_norm : normalizeFactorSign core = core :=
+    normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core (by omega)
+  exact degree_pos_of_primitive_norm_record q
+    (exhaustiveCoreFactorsWithBound_primitive core B primeData hcore_primitive q hq)
+    (exhaustiveCoreFactorsWithBound_normalizeFactorSign core B primeData hcore_norm q hq)
+    (exhaustiveCoreFactorsWithBound_shouldRecord core B primeData hcore_record q hq)
 
 private theorem polyProduct_push (factors : Array ZPoly) (factor : ZPoly) :
     Array.polyProduct (factors.push factor) =

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -110,6 +110,57 @@ theorem factor_headline_contract_core_with_primitive
     exact Hex.factor_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
+The sign-normalization side condition for the default executable factorization:
+every recorded polynomial factor is fixed by `normalizeFactorSign`. This is the
+`hψ_norm` clause that uniqueness/checker callers would otherwise reconstruct from
+the executable `Hex.factor_entry_normalizeFactorSign_id`.
+-/
+theorem factor_entries_normalizeFactorSign (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.factor f).factors,
+      Hex.normalizeFactorSign entry.1 = entry.1 := by
+  intro entry hentry
+  exact Hex.factor_entry_normalizeFactorSign_id f entry (Array.mem_toList_iff.mpr hentry)
+
+/--
+The nonconstant side condition for the default executable factorization: every
+recorded polynomial factor has positive degree. This is the `hψ_nonconst` clause
+uniqueness/checker callers would otherwise reconstruct.
+
+Positive degree is *not* derivable from `shouldRecordPolynomialFactor` alone — a
+constant like `Hex.DensePoly.C 2` passes the recording filter, has positive
+leading coefficient, and is sign-normalized. The constant case is excluded by
+*primitivity* (content `1` forces a constant to be `±1`), so this carries the
+same raw-source primitivity hypothesis `h_raw` as `Hex.factor_entries_primitive`
+and `factor_headline_contract_core_with_primitive`. The constant-exclusion
+argument itself is `Hex.degree_pos_of_primitive_norm_record`.
+-/
+theorem factor_entries_degree_pos
+    (f : Hex.ZPoly)
+    (h_raw :
+      ∀ rawFactors : Array Hex.ZPoly,
+        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+            some rawFactors ∨
+          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            Hex.factorSlowModularFactorsWithBound f
+                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
+          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            rawFactors =
+              Hex.factorSlowTrialFactorsWithBound f
+                (Hex.ZPoly.defaultFactorCoeffBound f))) →
+        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    ∀ entry ∈ (Hex.factor f).factors, 0 < entry.1.degree?.getD 0 := by
+  intro entry hentry
+  have hmem := Array.mem_toList_iff.mpr hentry
+  exact Hex.degree_pos_of_primitive_norm_record entry.1
+    (Hex.factor_entries_primitive f h_raw entry hentry)
+    (Hex.factor_entry_normalizeFactorSign_id f entry hmem)
+    (Hex.factor_entry_shouldRecord f entry hmem)
+
+/--
 Uniqueness specialised against the default executable factorization, so callers
 only provide the competing product, irreducibility, sign-normalization, and
 nonconstant-factor facts, plus that the input is nonzero. The default
@@ -134,6 +185,44 @@ theorem factor_unique_of_product
     (factor_irreducible_of_nonUnit f)
     (by rw [hproduct]; exact hf_ne)
     (by rw [hproduct, factor_product f])
+
+/--
+Default-specialised sibling of `factor_unique_of_product` that discharges the
+default factorization's own sign-normalization and nonconstant side conditions
+internally, so callers no longer supply `hψ_norm` or `hψ_nonconst`. The
+nonconstant clause needs the raw-source primitivity hypothesis `h_raw` (the same
+hypothesis `factor_entries_degree_pos` and `Hex.factor_entries_primitive`
+require); `hψ_norm` is discharged unconditionally.
+-/
+theorem factor_unique_of_product_default
+    (f : Hex.ZPoly) (φ : Hex.Factorization) (hf_ne : f ≠ 0)
+    (hproduct : Hex.Factorization.product φ = f)
+    (hφ_norm : ∀ entry ∈ φ.factors, Hex.normalizeFactorSign entry.1 = entry.1)
+    (hφ_nonconst : ∀ entry ∈ φ.factors, 0 < entry.1.degree?.getD 0)
+    (hirr : ∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1)
+    (h_raw :
+      ∀ rawFactors : Array Hex.ZPoly,
+        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+            some rawFactors ∨
+          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            Hex.factorSlowModularFactorsWithBound f
+                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
+          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
+              none ∧
+            rawFactors =
+              Hex.factorSlowTrialFactorsWithBound f
+                (Hex.ZPoly.defaultFactorCoeffBound f))) →
+        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    φ.scalar = (Hex.factor f).scalar ∧
+      (φ.factors.toList.map (fun e => Multiset.replicate e.2 e.1)).sum =
+        ((Hex.factor f).factors.toList.map
+          (fun e => Multiset.replicate e.2 e.1)).sum :=
+  factor_unique_of_product f φ hf_ne hproduct hφ_norm
+    (factor_entries_normalizeFactorSign f) hφ_nonconst
+    (factor_entries_degree_pos f h_raw) hirr
 
 end
 

--- a/progress/2026-06-16T16-44-50Z_aa3baa0d.md
+++ b/progress/2026-06-16T16-44-50Z_aa3baa0d.md
@@ -1,0 +1,63 @@
+# Session aa3baa0d — feature #7608
+
+UTC: 2026-06-16T16:44:50Z
+Type: feature (work dispatch)
+
+## Accomplished
+
+Issue #7608: expose the default factor uniqueness side-condition package in
+`HexBerlekampZassenhausMathlib/FactorSoundness.lean`.
+
+- Extracted `Hex.degree_pos_of_primitive_norm_record` (executable
+  `HexBerlekampZassenhaus/Basic.lean`): a primitive, sign-normalized `ZPoly`
+  passing `shouldRecordPolynomialFactor` has positive `degree?`. This is the
+  constant-exclusion argument previously inlined in
+  `exhaustiveCoreFactorsWithBound_degree_pos_of_primitive_pos_lc_core`, which
+  now reuses the helper (net DRY).
+- `factor_entries_normalizeFactorSign` (FactorSoundness): unconditional
+  `hψ_norm` clause, from `Hex.factor_entry_normalizeFactorSign_id`.
+- `factor_entries_degree_pos` (FactorSoundness): the `hψ_nonconst` clause,
+  carrying the raw-source primitivity hypothesis `h_raw` (see decision below).
+- `factor_unique_of_product_default` (FactorSoundness): sibling of
+  `factor_unique_of_product` that discharges `hψ_norm`/`hψ_nonconst` internally.
+  `factor_unique_of_product` left unchanged.
+
+## Key decision
+
+Positive degree (`hψ_nonconst`) is **not** derivable from `shouldRecord` +
+`leadingCoeff_pos` + `normalizeFactorSign_id` alone: a constant `C 2` satisfies
+all three. Ruling out constants needs **primitivity** (content `1` forces a
+constant to `±1`), and primitivity of recorded factors is itself conditional on
+the raw-source hypothesis `h_raw` (exactly as `Hex.factor_entries_primitive`
+and `factor_headline_contract_core_with_primitive`). So `factor_entries_degree_pos`
+and the default wrapper carry `h_raw`. This matches the established conditional
+pattern and does not weaken `factor_unique_of_product`. The issue body assumed
+positive degree followed from `shouldRecord`; it does not, but the `h_raw`-
+conditional shape is the sound realization (deliverable 2 still removes
+`hψ_norm`/`hψ_nonconst` from the caller).
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.FactorSoundness` — 0 errors
+- `lake build HexBerlekampZassenhausMathlib` (3788 jobs) — 0 errors
+- `lake build HexBerlekampZassenhaus` (497 jobs, conformance + crosscheck) — 0 errors
+- `python3 scripts/check_dag.py` — exit 0
+- `git diff --check` — clean
+- Added-line forbidden-token scan — no new sorry/axiom/native_decide/TODO/FIXME
+  (the FactorSoundness `sorry` at line 18 is the pre-existing
+  `factor_irreducible_of_nonUnit`, untouched).
+
+## Current frontier
+
+The new package is ready for the uniqueness/checker consumers downstream of
+directive #2564. The default wrapper still routes irreducibility through the
+pre-existing `factor_irreducible_of_nonUnit` sorry (#6672 owns that), as does
+the existing `factor_unique_of_product`.
+
+## Next step
+
+None for this corner. Consumers can adopt `factor_unique_of_product_default`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7608

This PR exposes a public default-factorization side-condition package in `HexBerlekampZassenhausMathlib/FactorSoundness.lean` so uniqueness and checker callers no longer reconstruct the `Hex.factor` well-formedness conditions by hand. It adds `factor_entries_normalizeFactorSign` (the unconditional sign-normalization clause `hψ_norm`), `factor_entries_degree_pos` (the nonconstant clause `hψ_nonconst`), and `factor_unique_of_product_default`, a sibling of `factor_unique_of_product` that discharges both clauses internally; the original `factor_unique_of_product` is left unchanged.

Positive degree is not derivable from `shouldRecordPolynomialFactor` alone, contrary to the issue's framing: a constant such as `Hex.DensePoly.C 2` passes the recording filter, has positive leading coefficient, and is sign-normalized. Ruling out constants requires primitivity (content `1` forces a constant to `±1`), and primitivity of recorded factors is itself conditional on the raw-source hypothesis `h_raw`, exactly as `Hex.factor_entries_primitive` and `factor_headline_contract_core_with_primitive` are. So `factor_entries_degree_pos` and the default wrapper carry `h_raw`; this matches the established conditional pattern and does not weaken `factor_unique_of_product`. The constant-exclusion argument is factored out of the existing `exhaustiveCoreFactorsWithBound_degree_pos_of_primitive_pos_lc_core` into a reusable executable helper `Hex.degree_pos_of_primitive_norm_record`, which that lemma now reuses.

Verified with `lake build HexBerlekampZassenhaus` (497 jobs, conformance + cross-check green), `lake build HexBerlekampZassenhausMathlib` (3788 jobs), `lake build HexBerlekampZassenhausMathlib.FactorSoundness`, `python3 scripts/check_dag.py`, and `git diff --check`, all clean with no new `sorry`/`axiom`/`native_decide`. The `sorry` warning in `FactorSoundness.lean` is the pre-existing `factor_irreducible_of_nonUnit`, untouched here.

🤖 Prepared with Claude Code