### PR TITLE
feat: prove BHKS prefix survivor-span lemma (#7620 deliverable 1)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -127,6 +127,19 @@ theorem hex_choose_eq (n k : Nat) : Hex.Nat.choose n k = Nat.choose n k := by
 then `simp_rw [hex_choose_eq]` before reaching for any Mathlib `Nat.choose`
 lemma (`Nat.sum_range_choose`, etc.). Same pattern for `Hex.Nat.Prime`.
 
+## `Matrix` / `Vector` resolve to Mathlib's inside the Mathlib layer
+
+The mirror of the shadow above. In a Mathlib-layer file (namespace
+`HexBerlekampZassenhausMathlib.*`, importing Mathlib), bare `Matrix`/`Vector`
+resolve to **Mathlib's** `Matrix` (index *types*) / `Vector`, NOT the
+executable `Hex.Matrix Int n m` (Nat-indexed dense rows) / `Hex.Vector`. When a
+lemma signature must name an executable matrix — e.g. the reduced BHKS basis
+fed to `Hex.bhksCutPrefixCount` — write `Hex.Matrix Int n m` and
+`Hex.Vector.normSq` explicitly. Symptom of getting it wrong: a type-mismatch on
+the dimension argument, `L.factorCount + L.coeffWidth` "has type ℕ … of sort
+outParam Type but is expected to have type Type", because Mathlib's `Matrix`
+wants its first two arguments to be index types, not `Nat`.
+
 ## The Mathlib layer *models* executable definitions
 
 The bridge does not just prove lemmas about the executable types; it carries

--- a/HexBerlekampZassenhausMathlib/Lattice.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice.lean
@@ -835,6 +835,94 @@ theorem bhksWithinGramSchmidtCut_lt_prefixCount
     (fun i => Hex.bhksWithinGramSchmidtCut L (Hex.GramSchmidt.Int.gramDetVec reduced) i)
     k (List.finRange _) 0 (List.pairwise_lt_finRange _) (List.mem_finRange k) hk
 
+/-- The executable cut test passes at index `i` once the stored leading
+Gram determinant at `i` is nonzero and the radius inequality on the consecutive
+determinant ratio holds. -/
+theorem bhksWithinGramSchmidtCut_eq_true_of_le
+    (L : Hex.BhksLatticeBasis)
+    (dets : Vector Nat (L.factorCount + L.coeffWidth + 1))
+    (i : Fin (L.factorCount + L.coeffWidth))
+    (hne : dets.get ⟨i.val, by omega⟩ ≠ 0)
+    (hle : 4 * ((dets.get ⟨i.val + 1, by omega⟩ : ℚ) /
+        (dets.get ⟨i.val, by omega⟩ : ℚ)) ≤ (Hex.bhksCutRadiusSq4 L : ℚ)) :
+    Hex.bhksWithinGramSchmidtCut L dets i = true := by
+  unfold Hex.bhksWithinGramSchmidtCut
+  rw [if_neg hne]
+  exact decide_eq_true hle
+
+/--
+**BHKS prefix survivor-span (Lemma 5.7, forward).**
+
+Any lattice vector `v` of the reduced BHKS basis whose squared length passes the
+cut test (`4·‖v‖² ≤ bhksCutRadiusSq4`) lies in the integer span of the retained
+prefix rows `b_0 … b_{t-1}`, where `t = bhksCutPrefixCount`.
+
+The cut keeps a row `i` iff `4·‖b*_i‖² ≤ bhksCutRadiusSq4`, i.e.
+`‖b*_i‖² ≤ bhksCutRadiusSq4 / 4`; the hypothesis is the matching tight bound on
+`v` (four times its squared norm within the radius), *not* the loose
+`‖v‖² ≤ bhksCutRadiusSq4`.
+-/
+theorem mem_prefixSubmodule_of_normSq_le
+    (L : Hex.BhksLatticeBasis)
+    (reduced : Hex.Matrix Int (L.factorCount + L.coeffWidth)
+        (L.factorCount + L.coeffWidth))
+    (hind : Hex.GramSchmidt.Int.independent reduced)
+    (v : Vector Int (L.factorCount + L.coeffWidth))
+    (hv : Hex.Matrix.memLattice reduced v)
+    (hnorm : 4 * ((Hex.Vector.normSq v : Int) : ℚ) ≤ (Hex.bhksCutRadiusSq4 L : ℚ)) :
+    HexMatrixMathlib.vectorEquiv v ∈
+      HexLLLMathlib.prefixSubmodule reduced (Hex.bhksCutPrefixCount L reduced) := by
+  by_cases hv0 : v = 0
+  · subst hv0
+    have hz : HexMatrixMathlib.vectorEquiv (0 : Vector Int (L.factorCount + L.coeffWidth))
+        = (0 : Fin (L.factorCount + L.coeffWidth) → ℤ) := by
+      funext i
+      simp [HexMatrixMathlib.vectorEquiv]
+    rw [hz]
+    exact Submodule.zero_mem _
+  · obtain ⟨k, c, hcv, hck, hzero_above, hbasis_norm⟩ :=
+      Hex.GramSchmidt.Int.exists_top_index_normSq_le_of_memLattice reduced hind v hv hv0
+    -- The top index `k` passes the cut test.
+    set dets := Hex.GramSchmidt.Int.gramDetVec reduced with hdets
+    have sw := Hex.GramSchmidt.Int.StepWitness.ofGram reduced
+    have hd0 : dets.get ⟨k.val, by omega⟩
+        = Hex.GramSchmidt.Int.gramDet reduced k.val (Nat.le_of_lt k.isLt) :=
+      Hex.GramSchmidt.Int.gramDetVec_eq_gramDet reduced sw k.val (Nat.le_of_lt k.isLt)
+    have hd1 : dets.get ⟨k.val + 1, by omega⟩
+        = Hex.GramSchmidt.Int.gramDet reduced (k.val + 1) k.isLt :=
+      Hex.GramSchmidt.Int.gramDetVec_eq_gramDet reduced sw (k.val + 1) k.isLt
+    have hd0pos : 0 < Hex.GramSchmidt.Int.gramDet reduced k.val (Nat.le_of_lt k.isLt) := by
+      rcases Nat.eq_zero_or_pos k.val with hk0 | hkpos
+      · simp only [hk0]
+        rw [Hex.GramSchmidt.Int.gramDet_zero]
+        exact Nat.one_pos
+      · exact Hex.GramSchmidt.Int.gramDet_pos reduced hind k.val (Nat.le_of_lt k.isLt) hkpos
+    have hne : dets.get ⟨k.val, by omega⟩ ≠ 0 := by
+      rw [hd0]; omega
+    -- `‖b*_k‖² = gramDet(k+1)/gramDet(k)`.
+    have hbnsq := Hex.GramSchmidt.Int.basis_normSq reduced hind k.val k.isLt
+    have hpass : Hex.bhksWithinGramSchmidtCut L dets k = true := by
+      refine bhksWithinGramSchmidtCut_eq_true_of_le L dets k hne ?_
+      rw [hd0, hd1]
+      -- goal: 4 * (gramDet(k+1)/gramDet(k)) ≤ radius
+      rw [← hbnsq]
+      -- goal: 4 * ‖b*_k‖² ≤ radius, with ‖b*_k‖² ≤ ‖v‖²
+      calc 4 * Hex.Vector.normSq ((Hex.GramSchmidt.Int.basis reduced).row ⟨k.val, k.isLt⟩)
+          ≤ 4 * ((Hex.Vector.normSq v : Int) : ℚ) := by
+            have := hbasis_norm
+            nlinarith [hbasis_norm]
+        _ ≤ (Hex.bhksCutRadiusSq4 L : ℚ) := hnorm
+    have hklt : k.val < Hex.bhksCutPrefixCount L reduced :=
+      bhksWithinGramSchmidtCut_lt_prefixCount L reduced k (by rw [← hdets]; exact hpass)
+    -- `c` vanishes at and above the retained prefix length.
+    have hc : ∀ i : Fin (L.factorCount + L.coeffWidth),
+        Hex.bhksCutPrefixCount L reduced ≤ i.val → c[i] = 0 := by
+      intro i hi
+      exact hzero_above i (by omega)
+    have := HexLLLMathlib.rowCombination_mem_prefixSubmodule_of_vector
+      reduced c (Hex.bhksCutPrefixCount L reduced) hc
+    rwa [hcv] at this
+
 /--
 Cut hypotheses needed to connect the executable projected rows to the abstract
 true-factor supports.  Later B4/B5 work discharges `indicator_mem_projected`

--- a/HexBerlekampZassenhausMathlib/Lattice.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice.lean
@@ -772,6 +772,69 @@ theorem liftedFactorIndicator_mem_liftedFactorIndicatorLattice
     liftedFactorIndicator L S.1 ∈ liftedFactorIndicatorLattice L trueSupports := by
   exact indicatorVector_mem_trueFactorIndicatorLattice trueSupports S
 
+/-! ### BHKS prefix survivor-span
+
+The executable Gram-Schmidt cut (`Hex.bhksCutPrefixCount`) retains the
+contiguous prefix `b_0 … b_{t-1}` of the reduced basis, where `t` is one past
+the largest Gram-Schmidt index whose squared length passes the cut test
+`4·‖b*_i‖² ≤ bhksCutRadiusSq4`.  We show that any lattice vector short enough to
+pass the cut test at its own top nonzero index lands in that retained prefix. -/
+
+/-- A lower bound on the cut fold is preserved while folding a tail whose
+indices all satisfy the bound. -/
+private theorem foldl_cut_ge_of_bound {N : Nat} (g : Fin N → Bool) (bound : Nat) :
+    ∀ (l : List (Fin N)) (init : Nat),
+      bound ≤ init → (∀ i ∈ l, bound ≤ i.val + 1) →
+      bound ≤ l.foldl (fun acc i => if g i then i.val + 1 else acc) init := by
+  intro l
+  induction l with
+  | nil => intro init hinit _; simpa using hinit
+  | cons a tl ih =>
+      intro init hinit hbnd
+      apply ih
+      · by_cases hga : g a
+        · simp only [hga, if_true]; exact hbnd a (by simp)
+        · simp only [hga, Bool.false_eq_true, if_false]; exact hinit
+      · intro i hi; exact hbnd i (List.mem_cons_of_mem a hi)
+
+/-- The cut fold over a strictly increasing index list reaches at least
+`k.val + 1` once a passing index `k` has been processed. -/
+private theorem foldl_cut_ge {N : Nat} (g : Fin N → Bool) (k : Fin N) :
+    ∀ (l : List (Fin N)) (init : Nat),
+      l.Pairwise (· < ·) → k ∈ l → g k = true →
+      k.val + 1 ≤ l.foldl (fun acc i => if g i then i.val + 1 else acc) init := by
+  intro l
+  induction l with
+  | nil => intro init _ hk _; simp at hk
+  | cons a tl ih =>
+      intro init hpw hk hgk
+      rw [List.pairwise_cons] at hpw
+      obtain ⟨hahead, htl⟩ := hpw
+      rw [List.foldl_cons]
+      rcases List.mem_cons.mp hk with rfl | hktl
+      · have hstep : (if g k then k.val + 1 else init) = k.val + 1 := by simp [hgk]
+        rw [hstep]
+        refine foldl_cut_ge_of_bound g (k.val + 1) tl (k.val + 1) (le_refl _) ?_
+        intro i hi
+        have hlt : k.val < i.val := hahead i hi
+        omega
+      · exact ih _ htl hktl hgk
+
+/-- A Gram-Schmidt index that passes the executable cut test lies strictly below
+the retained prefix length `bhksCutPrefixCount`, so its row is kept. -/
+theorem bhksWithinGramSchmidtCut_lt_prefixCount
+    (L : Hex.BhksLatticeBasis)
+    (reduced : Hex.Matrix Int (L.factorCount + L.coeffWidth)
+        (L.factorCount + L.coeffWidth))
+    (k : Fin (L.factorCount + L.coeffWidth))
+    (hk : Hex.bhksWithinGramSchmidtCut L
+        (Hex.GramSchmidt.Int.gramDetVec reduced) k = true) :
+    k.val < Hex.bhksCutPrefixCount L reduced := by
+  unfold Hex.bhksCutPrefixCount
+  exact foldl_cut_ge
+    (fun i => Hex.bhksWithinGramSchmidtCut L (Hex.GramSchmidt.Int.gramDetVec reduced) i)
+    k (List.finRange _) 0 (List.pairwise_lt_finRange _) (List.mem_finRange k) hk
+
 /--
 Cut hypotheses needed to connect the executable projected rows to the abstract
 true-factor supports.  Later B4/B5 work discharges `indicator_mem_projected`

--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -7218,6 +7218,71 @@ theorem normSq_latticeVec_ge_min_basis_normSq
   rw [← hnorm]
   exact hle
 
+/-- Strengthening of `normSq_latticeVec_ge_min_basis_normSq` that exposes the
+highest nonzero coefficient index `k` of a nonzero lattice vector together with
+the integer coefficients that witness it, the fact that those coefficients
+vanish above `k`, and the matching basis-row length bound `‖b*_k‖² ≤ ‖v‖²`.
+
+This is the survivor-span entry point: the vanishing-above-`k` data localizes
+`v` to the prefix `b_0 … b_k`, and the length bound feeds a Gram-Schmidt cut
+test on the top index `k`. -/
+theorem exists_top_index_normSq_le_of_memLattice
+    (b : Matrix Int n m) (_hli : independent b)
+    (v : Vector Int m) (hv : memLattice b v) (hv' : v ≠ 0) :
+    ∃ (k : Fin n) (c : Vector Int n),
+      Matrix.rowCombination b c = v ∧
+      c[k] ≠ 0 ∧
+      (∀ j : Fin n, k.val < j.val → c[j] = 0) ∧
+      Vector.normSq ((basis b).row k) ≤ ((Vector.normSq v : Int) : Rat) := by
+  rcases hv with ⟨c, hcv⟩
+  have hc_nonzero : ∃ i : Fin n, c[i] ≠ 0 := by
+    by_cases h : ∃ i : Fin n, c[i] ≠ 0
+    · exact h
+    · have hc_zero : c = 0 := by
+        apply Vector.ext
+        intro i hi
+        let ii : Fin n := ⟨i, hi⟩
+        by_cases hci : c[ii] = 0
+        · simpa [ii] using hci
+        · exact False.elim (h ⟨ii, hci⟩)
+      have hv_zero : v = 0 := by
+        rw [← hcv, hc_zero]
+        simp [Matrix.rowCombination]
+      exact False.elim (hv' hv_zero)
+  rcases exists_highest_nonzero_coeff c hc_nonzero with ⟨k, hck, hzero_above⟩
+  refine ⟨k, c, hcv, hck, hzero_above, ?_⟩
+  let d : Vector Rat n :=
+    Matrix.rowCombination (coeffs b) (Vector.map (fun x : Int => (x : Rat)) c)
+  have hcoeff_sq : (1 : Rat) ≤ d[k] * d[k] := by
+    have htop : d[k] = (c[k] : Rat) := by
+      dsimp [d]
+      exact rowCombination_coeffs_apply_eq_of_zero_above b c k hzero_above
+    rw [htop]
+    exact GramSchmidt.one_le_intCast_mul_self_of_ne_zero c[k] hck
+  have horth : ∀ i j : Fin n, i ≠ j →
+      Matrix.dot ((basis b).row i) ((basis b).row j) = 0 := by
+    intro i j hij
+    exact basis_orthogonal b i.val j.val i.isLt j.isLt (by
+      intro hval
+      exact hij (Fin.ext hval))
+  have hle :
+      Vector.normSq ((basis b).row k) ≤
+        Vector.normSq (Matrix.rowCombination (basis b) d) :=
+    GramSchmidt.rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one
+      (rows := basis b) (coeffs := d) (k := k) horth hcoeff_sq
+  have hrec :
+      Vector.map (fun x : Int => (x : Rat)) v =
+        Matrix.rowCombination (basis b) d := by
+    rw [← hcv]
+    dsimp [d]
+    exact rowCombination_basis_coeffs_reconstruction b c
+  have hnorm :
+      Vector.normSq (Matrix.rowCombination (basis b) d) =
+        ((Vector.normSq v : Int) : Rat) := by
+    rw [← hrec, normSq_map_intCast]
+  rw [← hnorm]
+  exact hle
+
 /-! ### Dot-product symmetry support -/
 
 private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))

--- a/progress/20260616T200844Z_86ef02ed.md
+++ b/progress/20260616T200844Z_86ef02ed.md
@@ -1,0 +1,96 @@
+# Progress - 2026-06-16 (session 86ef02ed, one-shot #7620)
+
+## Accomplished
+
+Claimed #7620 (feat: route BHKS prefix survivor span into
+CutProjectionHypotheses) via `pod once`. Landed **deliverable 1**: the BHKS
+prefix survivor-span lemma, with the factor-of-4-correct hypothesis the prior
+worker's skip comment identified. Three commits, all proofs closing, no
+sorry/axiom/native_decide.
+
+### `HexGramSchmidt/Int.lean`
+
+`exists_top_index_normSq_le_of_memLattice`: strengthening of
+`normSq_latticeVec_ge_min_basis_normSq` that returns the highest nonzero
+coefficient index `k`, the witnessing integer coefficients `c`, the
+vanishing-above-`k` property, and the basis-row length bound
+`‖b*_k‖² ≤ ‖v‖²`. This is the Gram-Schmidt entry point for the survivor-span
+argument.
+
+### `HexBerlekampZassenhausMathlib/Lattice.lean`
+
+- `bhksWithinGramSchmidtCut_lt_prefixCount`: a Gram-Schmidt index that passes
+  the executable cut test lies strictly below `bhksCutPrefixCount`, so its row
+  is retained. Proved through two `List.foldl` invariants over the strictly
+  increasing `finRange` index list (`List.pairwise_lt_finRange`).
+- `bhksWithinGramSchmidtCut_eq_true_of_le`: the cut Bool is `true` once the
+  leading Gram determinant is nonzero and the radius inequality on the
+  consecutive-determinant ratio holds.
+- `mem_prefixSubmodule_of_normSq_le` (**deliverable 1**): any reduced-BHKS
+  lattice vector `v` with `4·‖v‖² ≤ bhksCutRadiusSq4 L` lies in the integer
+  span of the retained prefix rows `b_0 … b_{t-1}`. Routes the top nonzero
+  index through the strengthened Gram-Schmidt lemma, the
+  `gramDetVec_eq_gramDet`/`basis_normSq` bridge into the executable cut
+  predicate (`StepWitness.ofGram` discharges the bridge hypothesis
+  unconditionally), the cut-fold prefix bound, and the #7633
+  `rowCombination_mem_prefixSubmodule_of_vector` helper. Pure forward argument;
+  no `CutRetention`, no `CutSeparation`.
+
+Verification: `lake build HexBerlekampZassenhausMathlib.Lattice` clean,
+`lake build HexBerlekampZassenhausMathlib` clean (pre-existing unrelated
+`sorry` in `FactorSoundness.lean:18` only), `python3 scripts/check_dag.py`
+clean, `git diff --check` clean, added-line forbidden-token scan clean.
+
+## Current frontier
+
+The keystone (the issue title's "prefix survivor span") is landed and reusable.
+The hypothesis is the **tight** `4·‖v‖² ≤ bhksCutRadiusSq4` matching the cut's
+`‖b*_i‖² ≤ bhksCutRadiusSq4/4` threshold, exactly as the prior skip comment's
+factor-of-4 diagnosis required.
+
+## Next step
+
+Two mechanical pieces (deliverables 2/3 and 5/6) plus one genuine analytic
+residual (deliverable 4):
+
+1. **Projection transport (deliverables 2,3)**: push
+   `mem_prefixSubmodule_of_normSq_le`'s conclusion through the
+   first-`factorCount`-coordinate projection into `projectedRowSpanInt`. The
+   retained rows of `bhksProjectedRows L hrows` are exactly
+   `bhksCutProjectReducedRows L reduced` (the foldl pushing
+   `bhksProjectIndicator factorCount coeffWidth (reduced.row i)` for `i < t`);
+   the transport is a linear-map/`Submodule.map` image argument plus an
+   `Array`-foldl membership lemma (each retained row's projection is a row of
+   `projectedRowsIntMatrix`). Watch the `Matrix.row` semantics on the Mathlib
+   `projectedRowsIntMatrix` and the `Array.getElem`/`mem`/`size` API.
+
+2. **CutProjectionHypotheses producer (deliverables 5,6)**: with the transport
+   and a tight per-true-factor norm certificate, produce
+   `indicatorVector S ∈ projectedRowSpanInt` directly, retiring
+   `cutProjectionHypotheses_of_retention`/`CutRetention` for this producer.
+   `trueFactorCLDVector L S` is in `memLattice L.basis` (via
+   `trueFactorCLDVector_memLattice`), transported to the reduced matrix by
+   `traceReducedMatrix_memLattice_iff`; its first block is `indicatorVector S`
+   via `TrueFactorCLDVectorData.project_eq`.
+
+3. **Tight CLD norm certificate (deliverable 4) — the analytic residual**:
+   the survivor-span lemma needs
+   `4·‖trueFactorCLDVector L S‖² ≤ bhksCutRadiusSq4 L`, i.e.
+   `‖·‖² ≤ factorCount + coeffWidth·factorCount²/4`, i.e. the per-column CLD
+   estimate `|Σ_{i∈S} cld[i][j]| ≤ factorCount/2`. This does **not** exist.
+   `HexBerlekampZassenhausMathlib/Lattice.lean`'s current
+   `normBound_of_colBound`/`cldTailSq_le_of_colBound` only handle the **loose**
+   per-column `≤ factorCount` → `‖·‖² ≤ bhksCutRadiusSq4` (4× too weak), and
+   even that loose column bound is still an unproven hypothesis (`hcol`), with
+   #7631's body explicitly flagging that the executable `psiCut` high bits may
+   not satisfy it. The tight `≤ factorCount/2` is the genuine BHKS Lemma 5.7
+   bound (the design radius is `r + n·(r/2)²`), so the premise is sound, but it
+   is a deep, separate `psiCut` high-bit magnitude analysis.
+
+## Blockers
+
+None for the landed deliverable 1. The full issue (final
+`indicatorVector S ∈ projectedRowSpanInt`) cannot close until the
+deliverable-4 tight CLD per-column estimate is proven; that is unproven
+analytic work, not a defect in deliverable 1's design. Routed to `replan` via
+`--partial` with this state recorded in a comment on #7620.


### PR DESCRIPTION
This PR proves the BHKS prefix survivor-span lemma (#7620 deliverable 1): any vector `v` of the reduced BHKS row lattice with `4·‖v‖² ≤ bhksCutRadiusSq4 L` lies in the integer span of the retained prefix rows `b_0 … b_{t-1}` selected by the executable Gram-Schmidt cut. The hypothesis is the tight `4·‖v‖²` form (equivalently `‖v‖² ≤ bhksCutRadiusSq4/4`) matching the cut's own `‖b*_i‖² ≤ bhksCutRadiusSq4/4` retention threshold, correcting the factor-of-4 calibration the prior worker's skip diagnosed. The argument is pure forward: it routes the highest nonzero coefficient index through a strengthened Gram-Schmidt norm lemma, the `gramDetVec`/`basis_normSq` bridge into the cut predicate, a `bhksCutPrefixCount` fold characterization, and the prefix-submodule helper from #7633 — with no `CutRetention` and no `CutSeparation` gap certificate.

Adds `exists_top_index_normSq_le_of_memLattice` in `HexGramSchmidt/Int.lean` (exposing the top index, its coefficients, the vanishing-above property, and the basis-row length bound) and `bhksWithinGramSchmidtCut_lt_prefixCount`, `bhksWithinGramSchmidtCut_eq_true_of_le`, and `mem_prefixSubmodule_of_normSq_le` in `HexBerlekampZassenhausMathlib/Lattice.lean`.

Partial against #7620: the projection transport into `projectedRowSpanInt` (deliverables 2,3) and the `CutProjectionHypotheses` producer that retires the `CutRetention` route (deliverables 5,6) are mechanical follow-ups on top of this lemma, and the tight per-column CLD estimate `|Σ_{i∈S} cld[i][j]| ≤ factorCount/2` (deliverable 4) is a genuine unproven analytic residual — the existing column-bound infrastructure only reaches the loose `≤ factorCount` bound, which is 4× too weak for the prefix cut. See the issue comment for the full remaining-work breakdown.

🤖 Prepared with Claude Code