### PR TITLE
feat: decouple scheduled fast-core loop start from recovery precision

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -127,6 +127,44 @@ theorem hex_choose_eq (n k : Nat) : Hex.Nat.choose n k = Nat.choose n k := by
 then `simp_rw [hex_choose_eq]` before reaching for any Mathlib `Nat.choose`
 lemma (`Nat.sum_range_choose`, etc.). Same pattern for `Hex.Nat.Prime`.
 
+## Fast-BHKS raw irreducibility ≠ slow-path raw irreducibility (scheduled-loop determinism)
+
+The slow-path raw irreducibility (`slowModularRaw_irreducible_of_fast_none`,
+#7665) is *unconditional* because the slow path runs a single fixed-precision
+`exhaustiveCoreFactorsWithBound` at `exhaustiveLiftBound` — one deterministic
+array, so `hraw : … = some rawFactors` pins it directly and the irreducibility
+producer applies at that one precision. **Do not assume the fast path is the same
+shape.** `factorFastCoreWithBound` is a *schedule loop* (`Basic.lean:6935`): it
+starts at `Hex.initialHenselPrecision a`, walks `henselPrecisionSchedule`, and
+returns the array of the **first** precision where `bhksRecoverClassified`
+returns `.success`. A `ForwardRecoveryInputs` package sits at the cap `target`
+(the *last* schedule element), so the loop's actual output need not equal the
+package's `expectedFactors` — an earlier schedule precision could exit `.success`
+with a different array.
+
+Consequences for any fast-BHKS irreducibility / `h_raw` work:
+
+- The existing `factorFastCore*_of_forwardInputs` wrappers force loop-start =
+  package precision = cut precision (the same `k`). They **cannot** apply to the
+  executable run, where `start = initialHenselPrecision a ≠ target = cap`. Use
+  the decoupled `…_of_forwardInputs_on_schedule` wrappers
+  (`PartitionRefinement.lean`, #7666): the count argument routes through
+  `factorFastCoreWithBound_some_factor_count_eq_of_cut`, whose loop-result params
+  (`k`,`fuel`) and cut-precision param (`L`) are already independent.
+- Those decoupled wrappers still take `h : factorFastCoreWithBound core B
+  primeData start fuel = some hinputs.expectedFactors` as a hypothesis. Producing
+  that `h` for the real `start = initialHenselPrecision a` is the **scheduled-loop
+  determinism obligation** (loop's first success returns the cap recovery). It is
+  *not* derivable from the cap package: `factorFastCoreWithBound_isSome_of_
+  recovery_on_schedule` (`Basic.lean:7105`) proves existence, not factor
+  identity, and `bhksRecoverClassified_success_*` (`Basic.lean:11238-11322`) give
+  product/dvd/sign for any success but neither irreducibility nor equality to the
+  cap recovery. Closing it needs "recovery fails below the Mignotte precision" (a
+  BHKS precision-soundness theorem) or a universal "recovery success ⟹ irreducible
+  at arbitrary precision" — neither is in the tree. Before claiming a fast-BHKS
+  "expose the loop array" / unconditional `h_raw` issue, confirm a determinism
+  producer exists, else land the decoupled bridges + diagnose (#7664).
+
 ## `Matrix` / `Vector` resolve to Mathlib's inside the Mathlib layer
 
 The mirror of the shadow above. In a Mathlib-layer file (namespace

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -684,4 +684,109 @@ theorem factorFastCoreDefault_factor_zpolyIrreducible_of_forwardInputs
     factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs
       hcore_ne hinputs h hcut hpartition
 
+/-- Scheduled-loop form of
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs`.
+
+The executable fast dispatcher does not start the core loop at the recovery
+precision: it starts at `Hex.initialHenselPrecision a` and walks the Hensel
+schedule, so the loop's `start` argument differs from the precision `target` at
+which the caller carries the `BHKS.ForwardRecoveryInputs` package.  This wrapper
+decouples the two: the loop-success hypothesis `h` is stated at an arbitrary
+`start`/`fuel`, while the forward package, cut certificate, and partition count
+all sit at the scheduled `target`.
+
+The decoupling is sound because the count argument routes through
+`factorFastCoreWithBound_some_factor_count_eq_of_cut`, whose loop-result
+parameters (`k`, `fuel`) and cut-precision parameters (`L`) are already
+independent — they meet only at the size identity `hsize`, which is derived
+purely from the package fields (`candidates_eq` / `indicators_match`) at
+`target`.  The hypothesis `h` pins the loop output to the package's
+`expectedFactors`; supplying that equality for the actual executable start
+`Hex.initialHenselPrecision a` is the scheduled-loop determinism obligation left
+to the caller (it is *not* implied by the package at `target` alone, since the
+loop returns the first schedule success and an earlier precision could exit with
+a different array). -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {start fuel target : Nat}
+    (hcore_ne : core ≠ 0)
+    (hinputs :
+      BHKS.ForwardRecoveryInputs core
+        (Hex.ZPoly.toMonicLiftData core target primeData))
+    (h :
+      Hex.factorFastCoreWithBound core B primeData start fuel =
+        some hinputs.expectedFactors)
+    (hcut :
+      BHKS.CutProjectionHypotheses
+        (BHKS.projectedRowsOfLiftData core
+          (Hex.ZPoly.toMonicLiftData core target primeData) hinputs.rows_pos)
+        hinputs.trueSupports)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn hinputs.trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ hinputs.expectedFactors.toList,
+      Hex.ZPoly.Irreducible factor := by
+  have hsize :
+      hinputs.expectedFactors.size =
+        (Hex.bhksEquivalenceClassIndicators
+          (BHKS.projectedRowsOfLiftData core
+            (Hex.ZPoly.toMonicLiftData core target primeData)
+            hinputs.rows_pos)).size := by
+    rw [Hex.bhksIndicatorCandidates?_size_eq hinputs.candidates_eq]
+    exact congrArg Array.size hinputs.indicators_match.symm
+  exact
+    factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut
+      hinputs.trueSupports hcore_ne h hcut hsize hpartition
+
+set_option maxHeartbeats 800000 in
+/--
+Default-bound scheduled-loop fast-BHKS direct-core specialization.
+
+Same as `factorFastCoreDefault_factor_zpolyIrreducible_of_forwardInputs`, but
+with the loop-success hypothesis `h` decoupled from the recovery precision
+`target` so that it matches the executable schedule walk (which starts the core
+loop at `Hex.initialHenselPrecision a`, not at `target`).  The forward package,
+cut certificate, and partition count are all carried at the scheduled `target`;
+`h` is the loop-output equality at the actual `start`/`fuel`, supplied by the
+scheduled-loop determinism obligation.
+-/
+theorem factorFastCoreDefault_factor_zpolyIrreducible_of_forwardInputs_on_schedule
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
+    (primeData : Hex.PrimeChoiceData) {start fuel target : Nat}
+    (hinputs :
+      BHKS.ForwardRecoveryInputs
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData
+          (Hex.normalizeForFactor f).squareFreeCore target primeData))
+    (h :
+      Hex.factorFastCoreWithBound
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.defaultFactorCoeffBound f) primeData start fuel =
+        some hinputs.expectedFactors)
+    (hcut :
+      BHKS.CutProjectionHypotheses
+        (BHKS.projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore target primeData)
+          hinputs.rows_pos)
+        hinputs.trueSupports)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn hinputs.trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (Hex.normalizeForFactor f).squareFreeCore)).card) :
+    ∀ factor ∈ hinputs.expectedFactors.toList,
+      Hex.ZPoly.Irreducible factor := by
+  have hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore :=
+    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
+  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 :=
+    zpoly_ne_zero_of_pos_lc hcore_lc_pos
+  exact
+    factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule
+      hcore_ne hinputs h hcut hpartition
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260617T025114Z_87549f60.md
+++ b/progress/20260617T025114Z_87549f60.md
@@ -1,0 +1,110 @@
+# Progress - 2026-06-17 (session 87549f60, one-shot #7664)
+
+## Accomplished
+
+Claimed #7664 (feat: bridge scheduled fast-core loop to raw fast disjunct) via
+`pod once`. Landed the **scheduled-precision-decoupled fast-core irreducibility
+bridges** — the sound core of deliverables 1-3 — and diagnosed the determinism
+obligation that blocks the unconditional capstone wiring (deliverable 4 / the
+`h_raw` consumer in #6672).
+
+### Landed (`HexBerlekampZassenhausMathlib/PartitionRefinement.lean`)
+
+Two wrappers that decouple the core loop's *start* precision from the
+`ForwardRecoveryInputs` *recovery* precision `target`:
+
+- `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule`
+- `factorFastCoreDefault_factor_zpolyIrreducible_of_forwardInputs_on_schedule`
+
+The existing `..._of_forwardInputs` (PR #7662) forces the loop start `k`, the
+package precision, and the cut precision to be the *same* `k`. But the executable
+dispatcher starts the loop at `Hex.initialHenselPrecision a` and walks the Hensel
+schedule, so for the real run `start = initialHenselPrecision a ≠ target = cap`.
+The landed theorem in #7662 therefore cannot be applied to the executable run at
+all.
+
+The decoupling is sound and one-line at the proof level: the count argument
+routes through `factorFastCoreWithBound_some_factor_count_eq_of_cut`, whose
+loop-result parameters (`k`, `fuel`) and cut-precision parameter (`L`) are
+already independent. They meet only at the size identity `hsize`, which is
+derived purely from the package fields (`candidates_eq` / `indicators_match`) at
+`target`. So a forward package + cut + partition at `target`, plus a loop-output
+equality `h : factorFastCoreWithBound core B primeData start fuel = some
+hinputs.expectedFactors` at the *actual* `start`, yields irreducibility of every
+emitted factor.
+
+Verification:
+- `lake build HexBerlekampZassenhausMathlib` — clean (full target, 3766 jobs,
+  Mathlib layer currently green on main; my additions compile).
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement` — clean.
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- Added-line forbidden-token scan: no sorry/axiom/native_decide/TODO/FIXME.
+- No executable files touched, so `HexBerlekampZassenhaus` is unaffected (its
+  conformance target built green in the same run).
+
+## Current frontier
+
+The decoupled bridge takes the loop-output equality `h` as a hypothesis. To
+make the fast `h_raw` disjunct **unconditional** (the shape `factor_headline_
+contract_core_with_primitive` / #6672 consume: `factorFastFactorsWithBound f B =
+some rawFactors → ∀ raw, Irreducible raw`, mirroring the slow path's
+`slowModularRaw_irreducible_of_fast_none`), a caller must supply
+
+  `factorFastCoreWithBound core (defaultFactorCoeffBound f) primeData
+     (Hex.initialHenselPrecision a) fuel = some hinputs.expectedFactors`
+
+i.e. that the **scheduled loop's first success returns the cap recovery's
+expected factors**. This is the determinism obligation below.
+
+## Next step (determinism + reassembly follow-up)
+
+**Determinism obligation (the genuine blocker).** `factorFastCoreWithBound`
+returns the array of the *first* schedule precision where
+`bhksRecoverClassified` returns `.success` (Basic.lean:6941). The package sits at
+the cap `target`, the last schedule element. Existing infrastructure proves only
+`factorFastCoreWithBound_isSome_of_recovery_on_schedule` / `..._ne_none_...`
+(Basic.lean:7105/7196) — existence, *not* factor identity. The
+`bhksRecoverClassified_success_*` lemmas (Basic.lean:11238-11322) give
+product/divisibility/sign/record for *any* successful recovery at *any*
+precision, but **not** irreducibility and **not** that the array equals the cap
+recovery. So an unconditional fast disjunct needs one of:
+
+- a determinism lemma `factorFastCoreWithBound core B primeData
+  (initialHenselPrecision a) fuel = bhksRecover? core (toMonicLiftData core cap
+  primeData)` (loop output = cap recovery), which in turn needs *recovery fails
+  below the Mignotte precision* (a BHKS precision-soundness theorem); or
+- a universal `bhksRecoverClassified core d = .success cands → ∀ q ∈ cands,
+  Irreducible q` at arbitrary `d`, which needs the cut/separation at the actual
+  success precision, not just the cap.
+
+Neither is derivable from a cap package alone, and neither is in the tree.
+This is *not* a defect that makes the bridge unsound — the bridge is sound and
+landed — it is a missing substrate, sized like the slow path's
+`slowPathHenselSubstrate_of_toMonicPrimeData` but harder (the slow path has no
+schedule loop; it runs a single fixed-precision `exhaustiveCoreFactorsWithBound`,
+so its raw irreducibility was unconditional with no determinism step).
+
+**Reassembly lift (deliverable 4), once determinism lands.** Compose the new
+default-cap bridge with
+`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`
+(IntReductionMod.lean:2295) and
+`reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`
+(Basic.lean:9781), mirroring `reassemblyComplete_of_slowSubstrate_bound` /
+`slowModularRaw_irreducible_of_fast_none` (#7665). Needs fast-core analogs of the
+generic facts: product (`factorFastCoreWithBound_product`, present), sign
+(`factorFastCoreWithBound_some_normalizeFactorSign`, present), and degree-pos /
+pos-lc / fuel (the slow path used `exhaustiveCoreFactorsWithBound_degree_pos_*`;
+fast-core equivalents need writing or deriving).
+
+**Deliverable 5 (factorFast_terminates).** Already proven —
+`factorFast_terminates` (Recovery.lean:7833) concludes `≠ none` and does not need
+determinism. Nothing to do.
+
+## Blockers
+
+Unconditional fast `h_raw` disjunct is blocked on the scheduled-loop determinism
+substrate described above. Routed to replan via `--partial`; the landed bridges
+are the consumable substrate for whoever produces the determinism lemma.
+Note: the worktree carries pre-existing unrelated `.claude/*` modifications from
+before this session; not touched or staged.


### PR DESCRIPTION
This PR adds two scheduled-precision-decoupled fast-core irreducibility wrappers, `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule` and its default-cap specialization, decoupling the BHKS core loop's start precision from the `ForwardRecoveryInputs` recovery precision `target`. The landed `..._of_forwardInputs` wrapper from https://github.com/kim-em/hex/pull/7662 (feat: specialize fast core forward irreducibility) forces the loop start, the package precision, and the cut precision to be the same `k`; but the executable dispatcher starts the loop at `Hex.initialHenselPrecision a` and walks the Hensel schedule, so for the real run `start = initialHenselPrecision a` differs from `target = cap` and that wrapper cannot apply. The decoupling is sound because the count argument routes through `factorFastCoreWithBound_some_factor_count_eq_of_cut`, whose loop-result parameters (`k`, `fuel`) and cut-precision parameter (`L`) are already independent and meet only at the size identity derived from the package fields at `target`.

Partial against https://github.com/kim-em/hex/issues/7664 (feat: bridge scheduled fast-core loop to raw fast disjunct): this lands the sound core of deliverables 1-3. The wrappers take the loop-output equality at the actual `start` as a hypothesis. Making the fast `h_raw` disjunct unconditional (deliverable 4) needs a scheduled-loop determinism substrate (the loop's first schedule success returns the cap recovery), which is not derivable from a cap package alone; see the diagnosis comment on the issue. Deliverable 5 (`factorFast_terminates`) is already proven. No executable changes.

🤖 Prepared with Claude Code