### PR TITLE
doc: guard replan triage against concurrent-disposition races

### DIFF
--- a/.claude/commands/replan.md
+++ b/.claude/commands/replan.md
@@ -64,6 +64,17 @@ the following:
 - **Still valid, body stale**: update the issue body with current
   state, then remove the `replan` label.
 
+**Concurrency: check for a concurrent disposition before reverting.**
+Many sessions share one token, so a candidate can be triaged out from
+under you mid-session. Before reopening or reverting any candidate whose
+state changed unexpectedly (especially a close you did not make), run
+`gh issue list --search "<N> in:body,comments" --state all` to find a
+replacement issue that references it. If a concurrent planner already
+closed it forward to a successor, **adopt that disposition** (re-close
+forward, rewire dependents like `depends-on: #<N>` to the successor) —
+do not reopen and create a competing issue. Reopening a
+forward-closed issue causes a worker to claim and immediately skip it.
+
 Process **every** candidate from `list-replan` before exiting.
 
 ## Step 4: Exit


### PR DESCRIPTION
This PR adds a concurrency guard to the replan triage command. In the pod environment many agent sessions share one token, so an issue under triage can be disposed of by a concurrent planner mid-session. The new Step 3 note tells the replan agent to search for a successor issue referencing the candidate before reopening or reverting an unexpected state change, and to adopt that disposition (re-close forward, rewire `depends-on` dependents) rather than reopen a forward-closed issue — which otherwise makes a worker claim and immediately skip it.

The gap surfaced while triaging https://github.com/kim-em/hex/issues/7671 (feat: prove BHKS recovery precision soundness below Mignotte): a concurrent session had already closed it forward to https://github.com/kim-em/hex/issues/7675 (feat: prove fast BHKS irreducibility via instance-level cut soundness), and reopening it caused exactly that churn.

🤖 Prepared with Claude Code