### PR TITLE
feat: add product-side CLD aggregation lemma

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -628,6 +628,131 @@ theorem auxCutBridge
       (liftData.liftedFactors.getD i 0) h liftData.p liftData.k
       hk hg_monic hg_deg hdvd
 
+/-- A coefficientwise congruence `a ≡ b (mod m)` transports to a
+`Polynomial.C (m : ℤ)`-divisibility of the difference of the mapped Mathlib
+polynomials. -/
+private theorem C_dvd_toPolynomial_sub_of_congr
+    (a b : Hex.ZPoly) (m : Nat) (h : Hex.ZPoly.congr a b m) :
+    Polynomial.C (m : ℤ) ∣
+      (HexPolyMathlib.toPolynomial a - HexPolyMathlib.toPolynomial b) := by
+  rw [Polynomial.C_dvd_iff_dvd_coeff]
+  intro j
+  rw [Polynomial.coeff_sub, HexPolyMathlib.coeff_toPolynomial,
+    HexPolyMathlib.coeff_toPolynomial]
+  exact Int.dvd_of_emod_eq_zero (h j)
+
+/-- The converse of `C_dvd_toPolynomial_sub_of_congr`. -/
+private theorem congr_of_C_dvd_toPolynomial_sub
+    (a b : Hex.ZPoly) (m : Nat)
+    (h : Polynomial.C (m : ℤ) ∣
+      (HexPolyMathlib.toPolynomial a - HexPolyMathlib.toPolynomial b)) :
+    Hex.ZPoly.congr a b m := by
+  rw [Polynomial.C_dvd_iff_dvd_coeff] at h
+  intro j
+  have hj := h j
+  rw [Polynomial.coeff_sub, HexPolyMathlib.coeff_toPolynomial,
+    HexPolyMathlib.coeff_toPolynomial] at hj
+  exact Int.emod_eq_zero_of_dvd hj
+
+/-- **Product-side CLD aggregation.**  If every factor `q` in a list satisfies
+the per-factor logarithmic-derivative congruence `q * cld q ≡ f * q'  (mod m)` —
+the shape produced by `cldQuotientMod_congr_mul_derivative` with
+`cld q = cldQuotientMod f q p k` — then the ordered product `∏ qs` satisfies the
+aggregated congruence `(∏ qs) * Σ (cld qs) ≡ f * (∏ qs)'  (mod m)`.
+
+This is the polynomial-level core of the BHKS product CLD column identity: the
+logarithmic derivative of a product is the sum of the per-factor logarithmic
+derivatives.  The proof maps to `Polynomial ℤ`, where `Polynomial.C (m : ℤ) ∣ ·`
+is an ideal and `Polynomial.derivative_mul` supplies the Leibniz rule. -/
+theorem polyProduct_cld_aggregation
+    (f : Hex.ZPoly) (m : Nat) (cld : Hex.ZPoly → Hex.ZPoly) :
+    ∀ qs : List Hex.ZPoly,
+      (∀ q ∈ qs, Hex.ZPoly.congr (q * cld q)
+        (f * Hex.DensePoly.derivative q) m) →
+      Hex.ZPoly.congr
+        (Array.polyProduct qs.toArray * (qs.map cld).foldr (· + ·) 0)
+        (f * Hex.DensePoly.derivative (Array.polyProduct qs.toArray)) m := by
+  intro qs
+  induction qs with
+  | nil =>
+    intro _
+    apply congr_of_C_dvd_toPolynomial_sub
+    have hp : Array.polyProduct ([] : List Hex.ZPoly).toArray = 1 := rfl
+    rw [hp]
+    simp only [List.map_nil, List.foldr_nil, HexPolyMathlib.toPolynomial_mul,
+      HexPolyMathlib.toPolynomial_derivative, HexPolyMathlib.toPolynomial_one,
+      HexPolyMathlib.toPolynomial_zero, Polynomial.derivative_one, mul_zero,
+      sub_zero]
+    exact dvd_zero _
+  | cons q rest ih =>
+    intro hper
+    have hq : Hex.ZPoly.congr (q * cld q) (f * Hex.DensePoly.derivative q) m :=
+      hper q (by simp)
+    have hrest : ∀ q' ∈ rest, Hex.ZPoly.congr (q' * cld q')
+        (f * Hex.DensePoly.derivative q') m :=
+      fun q' hq' => hper q' (List.mem_cons_of_mem q hq')
+    have IHc := ih hrest
+    have Dq := C_dvd_toPolynomial_sub_of_congr _ _ m hq
+    have Dr := C_dvd_toPolynomial_sub_of_congr _ _ m IHc
+    rw [Hex.ZPoly.polyProduct_cons_toArray]
+    simp only [List.map_cons, List.foldr_cons]
+    apply congr_of_C_dvd_toPolynomial_sub
+    have key :
+        HexPolyMathlib.toPolynomial
+            (q * Array.polyProduct rest.toArray *
+              (cld q + (rest.map cld).foldr (· + ·) 0))
+          - HexPolyMathlib.toPolynomial
+              (f * Hex.DensePoly.derivative (q * Array.polyProduct rest.toArray))
+          = HexPolyMathlib.toPolynomial (Array.polyProduct rest.toArray) *
+              (HexPolyMathlib.toPolynomial (q * cld q)
+                - HexPolyMathlib.toPolynomial (f * Hex.DensePoly.derivative q))
+            + HexPolyMathlib.toPolynomial q *
+              (HexPolyMathlib.toPolynomial
+                  (Array.polyProduct rest.toArray * (rest.map cld).foldr (· + ·) 0)
+                - HexPolyMathlib.toPolynomial
+                    (f * Hex.DensePoly.derivative (Array.polyProduct rest.toArray))) := by
+      simp only [HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_add,
+        HexPolyMathlib.toPolynomial_derivative, Polynomial.derivative_mul]
+      ring
+    rw [key]
+    exact dvd_add (Dq.mul_left _) (Dr.mul_left _)
+
+open Classical in
+/-- Product-side CLD aggregation specialised to the selected support of a
+`TrueFactorLift`.  The selected support product satisfies the aggregated
+logarithmic-derivative congruence against the sum of the per-selected-factor CLD
+quotients, with all per-factor hypotheses discharged from the semantic package.
+
+This is the interface form consumed by the tight `psiCut` / `TightColumnBound`
+column estimate: it identifies the executable column sum
+`Σᵢ cldQuotientMod f gᵢ` (before centring) with `f · (∏ gᵢ)' / (∏ gᵢ)` modulo
+the Hensel precision. -/
+theorem TrueFactorLiftSemantics.supportProduct_cld_aggregation
+    {L : Hex.BhksLatticeBasis} {S : LiftedFactorSupport L}
+    (D : TrueFactorLift L S) (H : TrueFactorLiftSemantics D)
+    (hk : 1 < D.p ^ D.a) :
+    Hex.ZPoly.congr
+      (supportProduct L S *
+        ((((List.finRange L.factorCount).filter fun i => decide (i ∈ S)).map
+            fun i => L.liftedFactors.getD i.val 1).map
+          (fun q => Hex.cldQuotientMod D.f q D.p D.a)).foldr (· + ·) 0)
+      (D.f * Hex.DensePoly.derivative (supportProduct L S))
+      (D.p ^ D.a) := by
+  have hsp : supportProduct L S =
+      Array.polyProduct
+        (((List.finRange L.factorCount).filter fun i => decide (i ∈ S)).map
+          fun i => L.liftedFactors.getD i.val 1).toArray := rfl
+  rw [hsp]
+  apply polyProduct_cld_aggregation D.f (D.p ^ D.a)
+    (fun q => Hex.cldQuotientMod D.f q D.p D.a)
+  intro q hq
+  rw [List.mem_map] at hq
+  obtain ⟨i, hi_mem, rfl⟩ := hq
+  rw [List.mem_filter] at hi_mem
+  have hiS : i ∈ S := by simpa using hi_mem.2
+  rw [D.liftedFactors_eq]
+  exact TrueFactorLiftSemantics.selected_cldQuotientMod_congr_mul_derivative D H hk i hiS
+
 end BHKS
 
 end

--- a/progress/20260617T055037Z_8ccd9ed3.md
+++ b/progress/20260617T055037Z_8ccd9ed3.md
@@ -1,0 +1,67 @@
+# Progress - 2026-06-17 (session 8ccd9ed3, work #7674 partial)
+
+## Accomplished
+
+Claimed #7674 (semantic lift facts for TrueFactorLift CLD aggregation). The
+prior partial (#7678) landed deliverable 1 (the `TrueFactorLiftSemantics`
+package and a per-selected-factor CLD column congruence). This session landed
+**deliverable 3, the product-side CLD aggregation lemma**, in
+`HexBerlekampZassenhausMathlib/CLDColumnBound.lean`:
+
+- `BHKS.polyProduct_cld_aggregation` — the polynomial-level core. For any list
+  of factors `qs` each satisfying the per-factor congruence
+  `q * cld q ≡ f * q'  (mod m)`, the ordered product satisfies the aggregated
+  congruence `(∏ qs) * Σ (cld qs) ≡ f * (∏ qs)'  (mod m)`. This is the
+  logarithmic-derivative product rule: `(∏ gᵢ)'/(∏ gᵢ) = Σ gᵢ'/gᵢ`. Proved by
+  list induction, mapping to `Polynomial ℤ` where `Polynomial.C (m:ℤ) ∣ ·` is an
+  ideal and `Polynomial.derivative_mul` supplies the Leibniz rule. Two private
+  bridges `C_dvd_toPolynomial_sub_of_congr` / `congr_of_C_dvd_toPolynomial_sub`
+  translate `ZPoly.congr` to/from `C`-divisibility of mapped polynomials.
+- `BHKS.TrueFactorLiftSemantics.supportProduct_cld_aggregation` — the interface
+  specialisation. Instantiates the generic lemma at the selected support list of
+  a `TrueFactorLift`, discharging every per-factor hypothesis from the semantic
+  package via `selected_cldQuotientMod_congr_mul_derivative`. Identifies the
+  executable column sum `Σᵢ cldQuotientMod f gᵢ` (before centring) with
+  `f · (∏ gᵢ)' / (∏ gᵢ)` modulo the Hensel precision.
+
+Verification:
+- `lake build HexBerlekampZassenhausMathlib.CLDColumnBound` — clean (no errors,
+  no warnings).
+- `lake build HexBerlekampZassenhausMathlib.Lattice` — clean (built in the full
+  pass; Lattice untouched this session).
+- `python3 scripts/check_dag.py` — exit 0.
+- `git diff --check` — clean.
+- Added-line forbidden-token scan — no sorry/axiom/native_decide/TODO/FIXME.
+
+## Current frontier
+
+The polynomial-level product-side aggregation identity now exists and is
+consumable. #7651 (tight psiCut bound) can instantiate it.
+
+## Next step (residual for replan)
+
+Two deliverables of #7674 remain:
+
+1. **Deliverable 2 — derive `TrueFactorLiftSemantics` from Hensel/lift data.**
+   The package fields (per-factor monicity, positive degree, cofactor
+   congruence) are still asserted, not produced from actual
+   `RepresentsIntegerFactorAtLift` / Hensel recovery evidence. This is a
+   separate bridge from concrete lift data into the semantic carrier.
+
+2. **Column-wise psiCut step (feeds #7651).** The aggregation lands at the
+   `cldQuotientMod` polynomial level. Turning it into the tight per-column bound
+   `2 * |colⱼ| ≤ factorCount` needs (a) monic cancellation mod `p^a` to identify
+   `Σᵢ cldQuotientMod f gᵢ` with the genuine factor's `cldQuotientMod f factor`
+   (the support product is monic via `supportProduct_monic`), and (b) handling
+   the `psiCut` centring nonlinearity: the lattice column is
+   `Σᵢ indicatorᵢ · psiCut(cldᵢ.coeff j)`, a sum of *centred* per-factor values,
+   not `psiCut` of the sum — so the bound cannot be read off a single factor's
+   CLD column directly. This is the genuine analytic content #7651 owns; the
+   aggregation identity here is its prerequisite.
+
+## Blockers
+
+None for the landed lemmas. The residual deliverables 2 and the column-wise
+psiCut step are separate analytic pieces, routed to replan.
+
+Pre-existing unrelated `.claude/*` modifications remain unstaged and untouched.


### PR DESCRIPTION
This PR adds the product-side CLD aggregation lemma for the BHKS true-factor lift, the residual analytic core of #7674 left open after #7678 packaged the semantic facts. `BHKS.polyProduct_cld_aggregation` is the polynomial-level logarithmic-derivative product rule: for a list of factors each satisfying the per-factor congruence `q * cld q ≡ f * q' (mod m)`, the ordered product satisfies `(∏ qs) * Σ (cld qs) ≡ f * (∏ qs)' (mod m)`. It is proved by list induction through the `toPolynomial` bridge into `Polynomial ℤ`, where `Polynomial.C (m : ℤ) ∣ ·` is an ideal and `Polynomial.derivative_mul` supplies the Leibniz rule. `TrueFactorLiftSemantics.supportProduct_cld_aggregation` specialises it to a `TrueFactorLift` selected support, discharging every per-factor hypothesis from the semantic package.

This is a partial completion of #7674. Two deliverables remain and are routed to replan: deriving `TrueFactorLiftSemantics` from concrete Hensel/lift data rather than asserted fields, and the column-wise `psiCut` step that turns this aggregation identity into the tight per-column bound (monic cancellation mod `p^a` plus the `psiCut` centring nonlinearity), which #7651 consumes.

🤖 Prepared with Claude Code