### PR TITLE
feat: discharge quadraticHenselStep_monic over Mathlib bridge

### DIFF
--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -174,14 +174,19 @@ theorem quadraticHenselStep_bezout_correct
     intro n
     exact Subsingleton.elim _ _
 
-/-- The quadratic step preserves monicity on the lifted `g` factor in Mathlib form. -/
+/-- The quadratic step preserves monicity on the lifted `g` factor in Mathlib form.
+
+The executable substrate (`Hex.ZPoly.quadraticHenselStep_monic`) requires `1 < m`:
+at `m = 1` every `*ModSquare` operation reduces modulo `1`, collapsing the lifted
+factor to the zero polynomial, which is not monic. So the hypothesis is `1 < m`. -/
 theorem quadraticHenselStep_monic
     (m : Nat) (f g h s t : Hex.ZPoly)
-    (hm : 0 < m)
+    (hm : 1 < m)
     (hmonic : Hex.DensePoly.Monic g) :
     let r := Hex.ZPoly.quadraticHenselStep m f g h s t
-    (HexPolyMathlib.toPolynomial r.g).Monic := by
-  sorry
+    (HexPolyMathlib.toPolynomial r.g).Monic :=
+  toPolynomial_monic_of_dense_monic _
+    (Hex.ZPoly.quadraticHenselStep_monic m f g h s t hm hmonic)
 
 /--
 Quadratic lifting is compatible with the Mathlib uniqueness theorem at the

--- a/progress/20260617_055942_1d72b69a.md
+++ b/progress/20260617_055942_1d72b69a.md
@@ -1,0 +1,42 @@
+# Session 20260617_055942 (feature, #7685)
+
+## Accomplished
+
+Discharged the `sorry` in `quadraticHenselStep_monic`
+(`HexHenselMathlib/Correctness.lean:177`). The Mathlib-facing monicity of the
+quadratic lift's `r.g` follows from the proven executable
+`Hex.ZPoly.quadraticHenselStep_monic` via the existing
+`toPolynomial_monic_of_dense_monic` bridge (which rewrites `Polynomial.Monic`
+through `leadingCoeff_toPolynomial` to the executable `DensePoly.Monic`).
+
+Per the project doctrine on premise checks, the signature's `hm : 0 < m` was a
+genuine over-statement: at `m = 1` the `*ModSquare` ops reduce modulo `1`,
+collapsing the lifted factor to the zero polynomial (leadingCoeff `0 ≠ 1`, not
+monic). Strengthened `hm` to `1 < m` to match the executable substrate, and
+documented the reason in the docstring. The theorem has no Lean consumers
+outside its own file, so strengthening the hypothesis is safe.
+
+## Current frontier
+
+`HexHenselMathlib/Correctness.lean` now carries 5 sorries (down from 6):
+`hensel_correct` (21), `hensel_extends` (39), `hensel_degree` (58),
+`quadraticHenselStep_unique_mod_pow_two_mul` (195),
+`multifactorLift_eq_multifactorLiftQuadratic` (434). All out of scope for #7685.
+
+## Next step
+
+The remaining `Correctness.lean` sorries depend on substrate not yet exposed
+(e.g. `hensel_degree` needs `henselLift_h_monic` / `LinearLiftLoopInvariant`
+per `HexHensel/Multifactor.lean:139`). Separate planned work.
+
+## Blockers
+
+None.
+
+## Verification
+
+- `lake build HexHenselMathlib.Correctness` — ok (target sorry gone)
+- `lake build HexHenselMathlib` — ok
+- `python3 scripts/check_dag.py` — exit 0
+- `git diff --check` — clean
+- Added-line forbidden-token scan — clean


### PR DESCRIPTION
This PR discharges the `quadraticHenselStep_monic` sorry in `HexHenselMathlib/Correctness.lean`, proving that the Mathlib polynomial image of the quadratic Hensel lift's lifted factor `r.g` is monic. The proof composes the proven executable `Hex.ZPoly.quadraticHenselStep_monic` with the existing `toPolynomial_monic_of_dense_monic` bridge, which rewrites `Polynomial.Monic` through `leadingCoeff_toPolynomial` to the executable `DensePoly.Monic` form. It strengthens the hypothesis from `0 < m` to `1 < m` to match the executable substrate: at `m = 1` every `*ModSquare` operation reduces modulo `1`, collapsing the lifted factor to the zero polynomial (leadingCoeff `0 ≠ 1`, not monic), so `0 < m` was an over-statement. The theorem has no Lean consumers outside its own file, so the strengthened hypothesis is safe.

Closes #7685

🤖 Prepared with Claude Code