### PR TITLE
doc: record soundness audit of Hensel Mathlib-bridge dischargers

### DIFF
--- a/progress/20260617_063307_ddcf0f6d.md
+++ b/progress/20260617_063307_ddcf0f6d.md
@@ -1,0 +1,89 @@
+# Progress — review #7692 (session ddcf0f6d)
+
+## Accomplished
+
+Claimed and executed #7692 (review: audit Hensel Mathlib-bridge dischargers
+`hensel_extends`, `quadraticHenselStep_monic` for soundness). **Verdict: PASS** —
+both landed lemmas are sound. Posted a per-deliverable evidence comment on the
+issue. No code change (the one finding — vacuous hypotheses in `hensel_extends` —
+is a defensible API-uniformity choice, not a soundness defect; see below).
+
+Build baseline: `lake build HexHenselMathlib.Correctness` green
+(`Built HexHenselMathlib.Correctness`, 1536 jobs). The compiler's own warnings
+corroborate the audit: `unused variable hprod/hbez/hmonic` at lines 60/61/65
+(Point 1), and **no** warning at line 188 `quadraticHenselStep_monic` (both
+`hm` and `hmonic` consumed). The `sorry`s at 38/81/201/440 are other issues'
+scope (#7690 `hensel_correct`/`hensel_degree`, #7689 the quadratic-uniqueness
+obligation), pre-existing and untouched.
+
+### Point 1 — `hensel_extends` signature (`Correctness.lean:56`)
+
+`hprod`, `hbez`, `hmonic` are **genuinely vacuous** (compiler-confirmed unused),
+and **not load-bearing for any contract**: `grep` finds zero consumers of
+`hensel_extends` anywhere in the repo. The conclusion is structurally true for
+arbitrary `g h s t` — `henselLift` only ever adds multiples of `p`, so the base
+lemmas `henselLift_{g,h}_congr_mod_base` (`HexHensel/Linear.lean:1941/1967`)
+require **only** `hk : 1 ≤ k`, which is all the proof passes.
+
+This is **not** a soundness defect: the hypotheses are satisfiable (genuine
+Hensel inputs meet them), so they cannot mask an unsatisfiable premise, and
+vacuous-but-satisfiable hypotheses can never make a true conclusion false. It is
+a minor premise smell. Recommendation: leave as-is. The two sibling surface
+lemmas in the same file — `hensel_correct` (line 38) and `hensel_degree`
+(line 81) — carry the identical signature and genuinely consume all four
+hypotheses, so the uniform signature is a deliberate lift-API-triple design: a
+consumer holding the standard Hensel precondition bundle (`hk ∧ hprod ∧ hbez ∧
+hmonic`) applies all three uniformly. Dropping the three hyps from
+`hensel_extends` alone would diverge its signature from its siblings for no
+caller benefit (there are no callers). If the siblings are ever proven and the
+bundle is repackaged, revisit then.
+
+### Point 2 — translation faithfulness (PASS)
+
+`zpoly_congr_toPolynomial_map_eq` (`Correctness.lean:24`) is a faithful transfer:
+- `Hex.ZPoly.congr f g m := ∀ i, (f.coeff i - g.coeff i) % m = 0`
+  (`HexPolyZ/Basic.lean:40`), so `hcongr n` + `Int.dvd_of_emod_eq_zero` gives
+  exactly `(m:ℤ) ∣ f.coeff n - g.coeff n`.
+- `coeff_map_intCastRingHom_eq_iff_dvd_sub` (`HexHenselMathlib/Basic.lean:35`)
+  consumes precisely that divisibility to conclude the mapped-coefficient
+  equality over `ZMod m`.
+- `coeff_toPolynomial` (`HexPolyMathlib/Basic.lean:243`) is index-faithful
+  (`(toPolynomial p).coeff n = p.coeff n`, no reindexing).
+
+Modulus: the base lemmas establish congruence at `p` (the base prime), and
+`hensel_extends` instantiates the transfer at `m := p`, so the map equality is
+over `ZMod p` — matching the `φ := Int.castRingHom (ZMod p)` headline, **not**
+`p^k`. Correct.
+
+### Point 3 — `quadraticHenselStep_monic` minimality (PASS)
+
+`1 < m` is correct and minimal. The executable
+`Hex.ZPoly.quadraticHenselStep_monic` (`HexHensel/Quadratic.lean:2285`) requires
+`hm : 1 < m` and `hmonic`, routing through `quadraticHenselStep_g_update_monic`
+→ `addModSquare_divModMonicModSquare_remainder_monic` (line 2208), both `1 < m`.
+The `m = 1` counterexample is **real**: `addModSquare g r m =
+reduceModSquare (g + r) m` reduces every coefficient mod `m²`, so at `m = 1`
+(m²=1) the result is the zero polynomial, whose `leadingCoeff` is `0 ≠ 1` —
+not monic. Hence `0 < m` is genuinely unsound at `m = 1`, and over `Nat` the
+only value satisfying `0 < m ∧ ¬(1 < m)` is `m = 1`, so `1 < m` is the exact
+minimal cutoff. `hmonic` is consumed (passed to the executable lemma).
+`toPolynomial_monic_of_dense_monic` (`Correctness.lean:115`) is a sound monicity
+transfer: `DensePoly.Monic p := p.leadingCoeff = 1` (`HexPoly/Euclid.lean:55`),
+and `leadingCoeff_toPolynomial` (`HexPolyMathlib/Basic.lean:501`) proves
+`(toPolynomial p).leadingCoeff = p.leadingCoeff`, so the transfer is exact.
+
+## Current frontier
+
+Both dischargers audited sound. The same file still carries the `sorry`s owned
+by #7690 (`hensel_correct`, `hensel_degree`) and #7689 (quadratic-step
+uniqueness) — out of scope for this review, untouched.
+
+## Next step
+
+#7690 / #7689 workers discharge the remaining `sorry`s on this now-audited
+bridge. No follow-up fix issue is warranted from this audit.
+
+## Blockers
+
+None. (The worktree carries pre-existing unrelated `.claude/*` modifications
+from before this session; not touched or staged.)


### PR DESCRIPTION
Closes #7692

Session: `ddcf0f6d-f29b-4ca1-a1a1-c939f00905d5`

adca8112 doc: record soundness audit of Hensel Mathlib-bridge dischargers (#7692)

🤖 Prepared with Claude Code