### PR TITLE
review: audit product-side CLD aggregation lemma soundness

### DIFF
--- a/progress/20260617_070206_4e8b985a.md
+++ b/progress/20260617_070206_4e8b985a.md
@@ -1,0 +1,61 @@
+# Progress — review #7694 (session 4e8b985a)
+
+## Accomplished
+
+Claimed and executed #7694 (review: audit product-side CLD aggregation lemma
+soundness). Posted **PASS** verdict with per-deliverable file:line evidence. No
+code change (no docstring fix warranted; the lemmas and their guard comments are
+accurate).
+
+Audited `HexBerlekampZassenhausMathlib/CLDColumnBound.lean` (landed by PR #7686,
+partial progress on #7674): `polyProduct_cld_aggregation` (`:667`),
+`TrueFactorLiftSemantics.supportProduct_cld_aggregation` (`:730`), and the two
+private transport helpers `C_dvd_toPolynomial_sub_of_congr` (`:634`) /
+`congr_of_C_dvd_toPolynomial_sub` (`:645`).
+
+Findings (all PASS):
+- **Transport faithful**: both helpers route through `coeff_toPolynomial`
+  (`HexPolyMathlib/Basic.lean:243`, exactly coeff-preserving `∀ n`) and
+  `Polynomial.C_dvd_iff_dvd_coeff`, with `Int.dvd_of_emod_eq_zero` /
+  `Int.emod_eq_zero_of_dvd` as the inverse pair. They quantify over all
+  coefficient indices, matching `congr`'s `∀ i` (`HexPolyZ/Basic.lean:41`). No
+  asymmetry, no loss of `mod m` content. Opposite of the `CutRetention` (#7575)
+  and arbitrary-vector (#7660) defects.
+- **Non-vacuous guard**: `polyProduct_cld_aggregation` is correctly stated for
+  arbitrary `m` (the `C m ∣ ·` ideal identity needs no guard); the real
+  constraint `hk : 1 < D.p ^ D.a` enters at `supportProduct_cld_aggregation`
+  (`:730`) and is threaded through to `cldQuotientMod_congr_mul_derivative`
+  (`:393`). Not the `m = 1` triviality.
+- **Hypotheses derived, not asserted**: per-factor congruences come from the
+  proven `cldQuotientMod_congr_mul_derivative` (`:393-489`, monic-division
+  uniqueness, no sorry) via `TrueFactorLiftSemantics` fields — the aggregated
+  congruence is itself *not* a structure field, so no circular smuggling.
+- **Consumer shape match**: the CLD sum uses the same filtered-`finRange`
+  ordering as `supportProduct` (`Lattice.lean:155`), and the cons-step `key`
+  (`:700-716`) is the genuine Leibniz product rule (`derivative_mul` + `ring`).
+  The uncentred `Σ cldQuotientMod` is the correct pre-centring shape; the
+  `psiCut`/`centeredResiduePow` centring into `trueFactorCLDVector` tail columns
+  (`TightColumnBound`, `Lattice.lean:803`) is the residual #7651 analytic step.
+
+Verification: `lake build HexBerlekampZassenhausMathlib.CLDColumnBound` clean on
+untouched `origin/main` (full 3771-job build, 0 errors — the Mathlib layer is
+not CI-built, so this was checked locally per the boundary skill);
+`python3 scripts/check_dag.py` exit 0; `git diff --check` clean.
+
+## Current frontier
+
+The product-side CLD aggregation lemma is audited sound and load-bearing for the
+tight `psiCut` / `TightColumnBound` column estimate. The aggregation B1 fact is
+in place; the residual is the centring bridge from the uncentred `Σ cldQuotientMod`
+congruence to the centred `trueFactorCLDVector` tail columns.
+
+## Next step
+
+#7651 (tight psiCut aggregation bound) consumes this lemma: build the centring
+bridge identifying `trueFactorCLDVector` tail entries with the centred high-bits
+of `Σ cldQuotientMod`, then derive the per-column `2·|col j| ≤ factorCount`
+estimate that `TightColumnBound` (`Lattice.lean:803`) packages.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7694

Session: `4e8b985a-fcfd-4ffc-8da1-7ca63eac3e23`

264448e3 doc: record review of product-side CLD aggregation lemma (#7694)

🤖 Prepared with Claude Code