### PR TITLE
feat: prove BHKS Lemma 5.7 carry core for tight psiCut column bound

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -628,3 +628,30 @@ is `f`, so you can take `core := f` and avoid the modular `normalizeForFactor`
 path entirely; (2) if you genuinely need the ZMod64 path, put the `#eval`/`#guard`
 in a module the package builds (`precompileModules := true` is set, so build-time
 `#eval` resolves the native symbols) rather than running a standalone file.
+
+## The BHKS tight CLD column bound is an *aggregation* phenomenon, not per-factor
+
+The tight `2·|col j| ≤ factorCount` estimate (BHKS Lemma 5.7, packaged as
+`TightColumnBound` in `Lattice.lean`, consumed by `tightNormBound_of_lift`) is
+**not** provable per-factor through `Hex.abs_cldCoeffs_le_bhksCoeffBound`. That
+lemma is the *loose* bound `|cldCoeffs f p a gᵢ .getD j| ≤ bhksCoeffBound f j`;
+the individual high-bit cuts `psiCut p a b ((cldQuotientMod f gᵢ p a).coeff j)`
+are genuinely large (verified: `±7` for `f=(x-1)(x²+1)`, `p=5`, `a=4` with
+`factorCount=3`, so `2·7=14 > 3`) and only become small after **cancellation
+over the support sum**. Do not try to bound the column term-by-term.
+
+Why the cancellation is exact: `TrueFactorLift.support_product_eq :
+supportProduct L S = factor` uses the **raw** `Array.polyProduct` (no mod-`p^a`
+reduction), so it forces `∏_{i∈S} gᵢ = factor` **exactly over ℤ**. The selected
+lifted factors are therefore exact monic integer *divisors* of `f` (cofactor
+`f/gᵢ` is a genuine integer polynomial), so the log-derivative identity
+`Σ_{i∈S} phi(f, gᵢ) = phi(f, factor)` holds exactly (`phi f g = f·g'/g`), and the
+per-factor coefficient bound routes through the **unconditional**
+`BHKS.abs_phi_coeff_le_of_monic_factor` (`CLDColumnBound.lean`) — it discharges
+its own Mahler hypothesis, unlike the conditional `abs_phi_coeff_le`. The carry
+cancellation itself is `BHKS.two_mul_natAbs_sum_psiCut_le` (the BHKS 5.7 high-bit
+estimate, landed by #7651's carry-core PR): feed it per-element exact ambient
+residues (`centeredResiduePow p a (z i) = w i`) whose support sum is a small
+integer (`|y| ≤ B`, `2B < p^b`). Sanity-check any "tight CLD column" directive
+that points at `abs_cldCoeffs`: that is the loose route and will not close the
+`factorCount` shape.

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -753,6 +753,98 @@ theorem TrueFactorLiftSemantics.supportProduct_cld_aggregation
   rw [D.liftedFactors_eq]
   exact TrueFactorLiftSemantics.selected_cldQuotientMod_congr_mul_derivative D H hk i hiS
 
+/-- A centred residue modulo `m` has magnitude at most `m / 2`: `2·|x mod^± m| ≤ m`. -/
+theorem two_mul_natAbs_centeredModNat_le (z : Int) (m : Nat) (hm : 0 < m) :
+    2 * (Hex.centeredModNat z m).natAbs ≤ m := by
+  unfold Hex.centeredModNat
+  rw [if_neg hm.ne']
+  have h1 : 0 ≤ z % (m : Int) := Int.emod_nonneg z (by exact_mod_cast hm.ne')
+  have h2 : z % (m : Int) < (m : Int) := Int.emod_lt_of_pos z (by exact_mod_cast hm)
+  simp only [Int.ofNat_eq_natCast]
+  by_cases hc : 2 * (z % (m : Int)).natAbs ≤ m
+  · rw [if_pos hc]; exact hc
+  · rw [if_neg hc, if_neg (by omega : ¬ z % (m : Int) < 0)]
+    omega
+
+/-- The high-bit cut residue `Psi^a_b` lands in the centred range modulo `p^b`. -/
+theorem two_mul_natAbs_centeredResiduePow_le (p b : Nat) (z : Int) (hpb : 0 < p ^ b) :
+    2 * (Hex.centeredResiduePow p b z).natAbs ≤ p ^ b := by
+  unfold Hex.centeredResiduePow
+  exact two_mul_natAbs_centeredModNat_le z (p ^ b) hpb
+
+/--
+**BHKS Lemma 5.7 high-bit estimate (carry core).**  The sum over a finite index
+set of the high-bit cuts `Psi^a_b(z i)` is bounded in magnitude by half the
+cardinality: `2·|Σ Psi^a_b(z i)| ≤ |T|`.
+
+The hypotheses pin the per-element ambient centred residue to an exact integer
+`w i` (`hw`), whose support sum is a small integer `y` with `|y| ≤ B` and
+`2·B < p^b` (`hsum`/`hy`/`hsep`).  This is exactly the cancellation that makes
+the *aggregated* column small even though individual high-bit cuts `Psi^a_b(z i)`
+need not be: the per-element loose bound `|Psi^a_b(z i)| ≤ B` is *not* used and
+would not give the tight `|T|/2` shape.
+-/
+theorem two_mul_natAbs_sum_psiCut_le
+    {ι : Type*} (T : Finset ι) (p a b : Nat) (hpb : 0 < p ^ b)
+    (z w : ι → Int) (y : Int) (B : Nat)
+    (hw : ∀ i ∈ T, Hex.centeredResiduePow p a (z i) = w i)
+    (hsum : ∑ i ∈ T, w i = y)
+    (hy : y.natAbs ≤ B)
+    (hsep : 2 * B < p ^ b) :
+    2 * (∑ i ∈ T, Hex.psiCut p a b (z i)).natAbs ≤ T.card := by
+  classical
+  have hm0 : (p ^ b : Nat) ≠ 0 := hpb.ne'
+  set col : Int := ∑ i ∈ T, Hex.psiCut p a b (z i) with hcol
+  set lo : ι → Int := fun i => Hex.centeredResiduePow p b (w i) with hlodef
+  -- Per element: `p^b · Psi(z i) = w i - lo i`.
+  have hkey : ∀ i ∈ T, ((p ^ b : Nat) : Int) * Hex.psiCut p a b (z i) = w i - lo i := by
+    intro i hi
+    have hdec := Hex.centeredResiduePow_add_pow_mul_psiCut p a b (z i) hm0
+    rw [hw i hi] at hdec
+    simp only [hlodef]
+    linarith [hdec]
+  -- Aggregate: `p^b · col = y - Σ lo`.
+  have hagg : ((p ^ b : Nat) : Int) * col = y - ∑ i ∈ T, lo i := by
+    rw [hcol, Finset.mul_sum, Finset.sum_congr rfl hkey, Finset.sum_sub_distrib, hsum]
+  -- Bound on the lower-residue sum: `2 · |Σ lo| ≤ |T| · p^b`.
+  have hlo_le : 2 * |∑ i ∈ T, lo i| ≤ (T.card : Int) * (p ^ b : Nat) := by
+    have htri : |∑ i ∈ T, lo i| ≤ ∑ i ∈ T, |lo i| := Finset.abs_sum_le_sum_abs _ _
+    have hpt : ∑ i ∈ T, (2 * |lo i|) ≤ ∑ i ∈ T, ((p ^ b : Nat) : Int) := by
+      refine Finset.sum_le_sum (fun i _ => ?_)
+      have := two_mul_natAbs_centeredResiduePow_le p b (w i) hpb
+      have hcast : 2 * |lo i| = ((2 * (Hex.centeredResiduePow p b (w i)).natAbs : Nat) : Int) := by
+        simp only [hlodef, Nat.cast_mul, Nat.cast_ofNat, Int.abs_eq_natAbs]
+      rw [hcast]; exact_mod_cast this
+    calc 2 * |∑ i ∈ T, lo i| ≤ 2 * ∑ i ∈ T, |lo i| := by linarith
+      _ = ∑ i ∈ T, (2 * |lo i|) := by rw [Finset.mul_sum]
+      _ ≤ ∑ i ∈ T, ((p ^ b : Nat) : Int) := hpt
+      _ = (T.card : Int) * (p ^ b : Nat) := by rw [Finset.sum_const, nsmul_eq_mul]
+  -- Combine into `2 · p^b · |col| < (|T| + 1) · p^b`, then cancel `p^b`.
+  have hyZ : 2 * |y| ≤ 2 * (B : Int) := by
+    have : |y| ≤ (B : Int) := by rw [Int.abs_eq_natAbs]; exact_mod_cast hy
+    linarith
+  have habs : ((p ^ b : Nat) : Int) * |col| = |y - ∑ i ∈ T, lo i| := by
+    rw [← hagg, abs_mul]; congr 1
+    rw [Int.abs_eq_natAbs]; simp
+  have hstep : 2 * (((p ^ b : Nat) : Int) * |col|) ≤ 2 * (B : Int) + (T.card : Int) * (p ^ b : Nat) := by
+    rw [habs]
+    calc 2 * |y - ∑ i ∈ T, lo i| ≤ 2 * (|y| + |∑ i ∈ T, lo i|) := by
+            linarith [abs_sub y (∑ i ∈ T, lo i)]
+      _ = 2 * |y| + 2 * |∑ i ∈ T, lo i| := by ring
+      _ ≤ 2 * (B : Int) + (T.card : Int) * (p ^ b : Nat) := by linarith
+  -- `2·B < p^b` upgrades the bound to a strict one and cancels the factor `p^b`.
+  have hsepZ : 2 * (B : Int) < ((p ^ b : Nat) : Int) := by exact_mod_cast hsep
+  have hpbZ : (0 : Int) < ((p ^ b : Nat) : Int) := by exact_mod_cast hpb
+  have hcolNat : 2 * |col| ≤ (T.card : Int) := by
+    have hlt2 : ((p ^ b : Nat) : Int) * (2 * |col|) <
+        ((p ^ b : Nat) : Int) * ((T.card : Int) + 1) := by
+      nlinarith [hstep, hsepZ, hpbZ]
+    have h2N : 2 * |col| < (T.card : Int) + 1 := lt_of_mul_lt_mul_left hlt2 (le_of_lt hpbZ)
+    omega
+  have : (2 * col.natAbs : Int) ≤ (T.card : Int) := by
+    rw [Int.abs_eq_natAbs] at hcolNat; push_cast at hcolNat ⊢; linarith
+  exact_mod_cast this
+
 end BHKS
 
 end

--- a/progress/20260617_082249_80b8ce38.md
+++ b/progress/20260617_082249_80b8ce38.md
@@ -1,0 +1,67 @@
+# Progress - 2026-06-17 (session 80b8ce38, one-shot #7651)
+
+## Accomplished
+
+Claimed #7651 (feat: prove tight psiCut aggregation bound) via `pod once`.
+**Confirmed the premise is sound** (the tight `2·|col j| ≤ factorCount` bound
+does hold for genuine integer-factor supports) and **landed the genuine
+mathematical core** of BHKS Lemma 5.7 — the carry-cancellation estimate — as
+proven, compiling Lean. Left the remaining executable↔Mathlib bridge + exact
+log-derivative sum + assembly for a follow-up, with a precise plan on the issue.
+
+### Soundness verification (numerical)
+
+The issue says the tight bound "routes through
+`Hex.abs_cldCoeffs_le_bhksCoeffBound`". That lemma is a **per-factor** bound
+`|cldCoeffs f p a g_i .getD j| ≤ bhksCoeffBound f j`, which is the *loose*
+estimate — it does **not** compose to `2·|col j| ≤ factorCount`. Numerically the
+per-factor high-bit cuts are genuinely large (e.g. `cldCoeffs` entries `±7` for
+`f=(x-1)(x²+1)`, `p=5`, `a=4`, while `factorCount=3`, so `2·7=14 > 3`
+per-factor); they only become small after **aggregation over the support**,
+where they cancel. Verified `2·|col j| ≤ factorCount` holds for *every* genuine
+integer-factor support across `f=(x²+1)(x²+2)`, `(x²+1)(x²+4)`,
+`(x-1)(x-2)(x²+1)`, `(x²+1)(x²+2)(x²+4)` at primes `5,13,17` and precisions
+`a=3..8` (recombination sizes `r=4,6`). Non-genuine supports (whose product is
+not an integer factor) violate the bound but cannot instantiate `TrueFactorLift`
+(its `support_product_eq : supportProduct L S = factor` forces `∏_{i∈S} g_i =
+factor` **exactly over ℤ**, so the selected lifted factors are exact integer
+divisors).
+
+### Landed (HexBerlekampZassenhausMathlib/CLDColumnBound.lean)
+
+- `two_mul_natAbs_centeredModNat_le` / `two_mul_natAbs_centeredResiduePow_le`:
+  a centred residue mod `m` has `2·|·| ≤ m`.
+- `two_mul_natAbs_sum_psiCut_le` (**the carry core**): given per-element exact
+  ambient residues `centeredResiduePow p a (z i) = w i`, with support sum a small
+  integer (`Σ w i = y`, `|y| ≤ B`, `2B < p^b`), then
+  `2·|Σ psiCut p a b (z i)| ≤ |T|`. This is exactly the BHKS Lemma 5.7 high-bit
+  estimate: the aggregated column is bounded by `|T|/2` even though the
+  individual `psiCut` terms are not.
+
+`lake build HexBerlekampZassenhausMathlib.CLDColumnBound` green;
+`scripts/check_dag.py` green; no new sorry/axiom/native_decide.
+
+## Current frontier
+
+The carry core is the substrate; the remaining work is mechanical bridging,
+spelled out in the issue comment:
+- **Per-factor bridge**: `centeredResiduePow p a ((cldQuotientMod f g_i p a).coeff
+  j) = (phi (toPoly f) (toPoly g_i)).coeff j`, with `|·| ≤ bhksCoeffBound f j`.
+  Uses `cldQuotientMod_congr_mul_derivative` (have) + monic-cancellation mod `p^a`
+  + `abs_phi_coeff_le_of_monic_factor` (have, unconditional) + `coeffL2NormBound ≥
+  l2norm` and `degree? ↔ natDegree` bridges + `centeredResiduePow_eq_of_natAbs_le`.
+- **Exact log-derivative sum**: `Σ_{i∈S} phi (toPoly f) (toPoly g_i) = phi (toPoly
+  f) (toPoly factor)` over `Polynomial ℤ` (product rule; `∏ g_i = factor` exact).
+- **Assembly** `tightColumnBound_of_lift`: rewrite the column via
+  `coeff_eq_cldCoeffs`, instantiate `two_mul_natAbs_sum_psiCut_le` at `T = S`,
+  `B = bhksCoeffBound f j`, `b = bhksCoeffCutThreshold p f j`; `|S| ≤ factorCount`.
+
+## Next step
+
+Land the three bridge lemmas above. The hardest is the monic-cancellation step
+`C(p^a) ∣ G·(X−Y)` with `G` monic ⟹ `C(p^a) ∣ (X−Y)` (monic polys are regular
+mod `p^a`).
+
+## Blockers
+
+None. Premise confirmed sound; partial PR lands the carry core.


### PR DESCRIPTION
This PR proves the carry-cancellation core of the BHKS Lemma 5.7 high-bit estimate, the genuine analytic substrate of the tight per-column `psiCut` bound in #7651. The new `two_mul_natAbs_sum_psiCut_le` shows that the aggregated high-bit column `2·|Σ psiCut(z i)| ≤ |T|` follows once the per-element ambient centred residues are pinned to exact integers whose support sum is a small integer (`|y| ≤ B`, `2B < p^b`) — the cancellation that the loose per-factor `abs_cldCoeffs` route cannot capture, since the individual high-bit cuts are large and only cancel after aggregation over a genuine integer-factor support. Supporting lemmas `two_mul_natAbs_centeredModNat_le` / `two_mul_natAbs_centeredResiduePow_le` give the centred-residue magnitude bound.

This is partial: it lands the carry core and a verified soundness check (the bound holds for every genuine support across many primes/precisions), and corrects the issue's stated route. The remaining `tightColumnBound_of_lift` assembly — the per-factor `cldQuotientMod ≡ phi` congruence bridge, the exact log-derivative sum, and the instantiation — is spelled out on #7651 for a follow-up.

🤖 Prepared with Claude Code