### PR TITLE
feat: compose true-factor cut stack into fast BHKS irreducibility

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -1,5 +1,6 @@
 import HexBerlekampZassenhausMathlib.Recovery
 import HexBerlekampZassenhausMathlib.Basic
+import HexBerlekampZassenhausMathlib.CLDColumnBound
 
 /-!
 BHKS B8 partition-refinement step.
@@ -573,6 +574,66 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_trueFactors
     hcore_ne h
     (BHKS.cutProjectionHypotheses_of_trueFactors L hrows hbasis trueSupports data tight)
     hsize hpartition
+
+/--
+Capstone composition for the fast `h_raw` disjunct: per-candidate irreducibility
+of the first successful BHKS fast-core recovery, with the forward cut
+certificates discharged from genuine true-factor lift data rather than taken as
+opaque hypotheses.
+
+For each true support `S`, the per-support lift package `lift S`
+(`BHKS.TrueFactorLift`) and its semantic facts `sem S`
+(`BHKS.TrueFactorLiftSemantics`), together with the prime, Hensel-precision, and
+per-column CLD separation hypotheses, produce the tight per-column bound via
+`BHKS.tightColumnBound_of_lift`.  That feeds `BHKS.tightNormBound_of_lift` to the
+tight cut-radius certificate `TrueFactorCLDTightNormBound`; its loose companion
+(`toNormBound`) and the structural block-form coordinate identities assemble the
+`TrueFactorCLDVectorData` arm.  Both arms drive
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_trueFactors`.
+
+This is the first consumer to wire the analytic stack (#7650 product CLD
+identity, #7674 semantic lift facts, #7712 tight column bound producer) through
+to the irreducibility endpoint.  The remaining residual is supplying the
+per-support `TrueFactorLift`/semantics/separation family for the first
+successful recovery; the separation hypotheses `hp`, `hk`, `hsep` are the BHKS
+Lemma 5.7 inputs at the first-success lift precision, threaded here verbatim
+rather than re-derived from the global Mignotte recovery bound. -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksLatticeBasis} {hrows : 1 ≤ L.factorCount + L.coeffWidth}
+    (trueSupports :
+      Set (Set (Fin (Hex.bhksProjectedRows L hrows).factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hbasis : L.basis.independent)
+    (lift : ∀ S : trueSupports, BHKS.TrueFactorLift L S.1)
+    (sem : ∀ S : trueSupports, BHKS.TrueFactorLiftSemantics (lift S))
+    (hp : ∀ S : trueSupports, 2 ≤ (lift S).p)
+    (hk : ∀ S : trueSupports, 1 < (lift S).p ^ (lift S).a)
+    (hsep : ∀ S : trueSupports,
+      ∀ j, 2 * Hex.bhksCoeffBound (lift S).f j < (lift S).p ^ (lift S).a)
+    (hsize :
+      coreFactors.size =
+        (Hex.bhksEquivalenceClassIndicators (Hex.bhksProjectedRows L hrows)).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ coreFactors.toList, Hex.ZPoly.Irreducible factor := by
+  have tight : ∀ S : trueSupports, BHKS.TrueFactorCLDTightNormBound L S.1 :=
+    fun S =>
+      BHKS.tightNormBound_of_lift (lift S)
+        (BHKS.tightColumnBound_of_lift (lift S) (sem S) (hp S) (hk S) (hsep S))
+  have data : ∀ S : trueSupports, BHKS.TrueFactorCLDVectorData L S.1 :=
+    fun S =>
+      { project_eq := fun i =>
+          BHKS.trueFactorCLDVector_project_of_blockForm S.1 (lift S).blockForm i
+        coeff_eq := fun j =>
+          BHKS.trueFactorCLDVector_coeff_of_blockForm S.1 (lift S).blockForm j
+        norm_bound := (tight S).toNormBound }
+  exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_trueFactors
+    trueSupports hcore_ne h hbasis data tight hsize hpartition
 
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`

--- a/progress/2026-06-17T09-53-17Z_8510cd6c.md
+++ b/progress/2026-06-17T09-53-17Z_8510cd6c.md
@@ -1,0 +1,65 @@
+# Progress - 2026-06-17 (session 8510cd6c, one-shot #7675)
+
+## Accomplished
+
+Claimed and landed #7675 (feat: compose true-factor cut stack into fast BHKS
+irreducibility, critical-path). All three blocking analytic-stack issues
+(#7712 tight column bound producer, #7674 semantic lift facts, #7650 product
+CLD identity) are now closed, so the composition finally has sound inputs.
+
+Added `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift` to
+`HexBerlekampZassenhausMathlib/PartitionRefinement.lean`. This is the first
+consumer to wire `BHKS.tightColumnBound_of_lift` (#7712) through to
+per-candidate irreducibility of a successful fast-core recovery. For each true
+support `S` it composes:
+
+- `tightColumnBound_of_lift (lift S) (sem S) (hp S) (hk S) (hsep S)` →
+  `TightColumnBound`
+- `tightNormBound_of_lift` → `TrueFactorCLDTightNormBound` (the `tight` arm)
+- `(tight S).toNormBound` + the block-form coordinate identities
+  (`trueFactorCLDVector_project/coeff_of_blockForm` via `TrueFactorLift.blockForm`)
+  → `TrueFactorCLDVectorData` (the `data` arm)
+- both arms drive `..._zpolyIrreducible_of_trueFactors`.
+
+Needed `import HexBerlekampZassenhausMathlib.CLDColumnBound` in
+PartitionRefinement (no import cycle: nothing in CLDColumnBound's closure
+imports PartitionRefinement).
+
+The composition is sound and non-vacuous: `TrueFactorLift` carries a genuine
+`factor * cofactor = f` witness; the result is full `Irreducible factor` for
+every emitted candidate (no product-equality weakening); it holds for an
+arbitrary successful branch at any `k`/`fuel` (no "no early success"
+assumption) and does not force equality to the cap recovery. The BHKS
+Lemma 5.7 separation inputs (`hp`/`hk`/`hsep`) are threaded verbatim rather
+than extracted from recovery artifacts (the refuted route).
+
+Verification: `lake build HexBerlekampZassenhausMathlib.PartitionRefinement`,
+`lake build HexBerlekampZassenhausMathlib HexBerlekampZassenhaus`,
+`python3 scripts/check_dag.py` (exit 0), `git diff --check` clean,
+added-line forbidden-token scan clean. Only `PartitionRefinement.lean` changed.
+(Pre-existing `FactorSoundness.lean:18` sorry and unrelated `.claude/*` edits
+are untouched.)
+
+## Current frontier
+
+The capstone composition exists and is sorry/axiom-free. It is *conditional*
+on the per-support lift family (`lift`/`sem`/`hp`/`hk`/`hsep`) being supplied
+for the concrete first-success recovery.
+
+## Next step
+
+Turn the conditional composition into an unconditional first-success theorem by
+*producing* the `TrueFactorLift`/`TrueFactorLiftSemantics` family from
+`factorFastCoreWithBound ... = some coreFactors`. This needs a Hensel-correctness
+producer (each true integer factor of `core` is the support product of a subset
+of the lifted local factors mod `p^k`, with the cofactor/monicity witnesses) and
+a discharge of `hsep` (the per-column CLD separation `2·bhksCoeffBound f j < p^k`)
+at the first-success lift precision. The latter is the genuine analytic risk
+flagged in the #7675 soundness comment; if it cannot hold at first-success
+precision, the documented fallback is cap-precision re-verification, not a
+weakened soundness theorem. This is a distinct, larger obligation than the
+composition and should be its own issue.
+
+## Blockers
+
+None for the landed composition.


### PR DESCRIPTION
Closes #7675

This PR adds `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift`, the capstone composition that wires the true-factor cut stack into per-candidate irreducibility for the first successful BHKS fast-core recovery. It is the first consumer to thread the analytic stack (https://github.com/kim-em/hex/issues/7650 product CLD identity, https://github.com/kim-em/hex/issues/7674 semantic lift facts, https://github.com/kim-em/hex/issues/7712 tight column bound producer) through to irreducibility. For each true support it composes `tightColumnBound_of_lift` then `tightNormBound_of_lift` for the tight cut-radius arm, and the block-form coordinate identities plus `toNormBound` for the CLD-vector arm, driving `..._zpolyIrreducible_of_trueFactors`. The BHKS Lemma 5.7 separation inputs (`hp`, `hk`, `hsep`) are threaded verbatim rather than extracted from recovery artifacts (the refuted route).

The statement is sound and non-vacuous: `TrueFactorLift` carries a genuine `factor * cofactor = f` witness, the conclusion is full `Irreducible` for every emitted candidate with no product-equality weakening, and it holds for an arbitrary successful branch at any precision without assuming no early success or forcing cap equality. It stays conditional on the per-support lift family; producing that family (and discharging `hsep`) from recovery success at the first-success lift precision is the distinct, larger follow-up flagged in the issue's soundness analysis.

🤖 Prepared with Claude Code