### PR TITLE
feat: discharge HexBerlekampMathlib coefficient-transport bridges (coeff + derivative)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -15,6 +15,19 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
 
 ## Concrete rules
 
+- **The `*_semiring`/`*_ring`-specialized `DensePoly` coeff `@[simp]` lemmas
+  do not match a goal term built with the canonical instances.**
+  `DensePoly.coeff_derivative_semiring` / `coeff_add_semiring` / `coeff_sub_ring`
+  restate `derivative`/`add`/`sub` through the `Lean.Grind.Semiring`-derived
+  `NatCast`/`Mul` (the `attribute [local instance 1100] Semiring.natCast`), a
+  *different instance path* than the canonical `NatCast (ZMod64 p)` /
+  `Mul (ZMod64 p)` that a `DensePoly.derivative f` term in a Mathlib-layer goal
+  carries. So `rw`/`simp only [coeff_derivative_semiring]` silently fails to fire
+  (reported "unused" / "did not find pattern") even though the statement looks
+  right. Use the **general** lemma with the explicit zero hypothesis instead —
+  `rw [Hex.DensePoly.coeff_derivative f n (Lean.Grind.Semiring.mul_zero _)]` — it
+  matches the goal's operation exactly, then `toZMod_mul`/`toZMod_natCast` +
+  `push_cast; ring` finish the transport against `Polynomial.coeff_derivative`.
 - **`grind`, not `ring`, for `ZMod64`/`FpPoly` arithmetic.** Ring lemmas
   (`mul_one`, `neg_add_cancel`, `ring`) need Mathlib instances these types lack.
   `grind` uses the `Lean.Grind.CommRing` instance; prime-inverse facts

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -67,12 +67,21 @@ theorem fpPolyEquiv_symm_apply (f : Polynomial (ZMod p)) :
 @[simp]
 theorem coeff_toMathlibPolynomial (f : Hex.FpPoly p) (n : Nat) :
     (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) := by
-  sorry
+  show (fpPolyToPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n)
+  rw [fpPolyToPolynomial, Polynomial.finset_sum_coeff]
+  simp only [Polynomial.coeff_monomial]
+  rw [Finset.sum_ite_eq' (Finset.range f.size) n
+    (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]
+  by_cases hn : n ∈ Finset.range f.size
+  · rw [if_pos hn]
+  · rw [if_neg hn, Hex.DensePoly.coeff_eq_zero_of_size_le f
+      (Nat.le_of_not_lt (Finset.mem_range.not.mp hn))]
+    exact HexModArithMathlib.ZMod64.toZMod_zero.symm
 
 @[simp]
 theorem coeff_toMathlibPolynomial_equiv (f : Hex.FpPoly p) (n : Nat) :
     (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.equiv (f.coeff n) := by
-  sorry
+  rw [coeff_toMathlibPolynomial, HexModArithMathlib.ZMod64.equiv_apply]
 
 /-- Coefficient view supplied by `HexPolyMathlib.toPolynomial`. -/
 theorem hexPolyMathlib_coeff_bridge
@@ -104,7 +113,13 @@ theorem natDegree_toMathlibPolynomial_eq_basisSize
 theorem toMathlibPolynomial_derivative (f : Hex.FpPoly p) :
     toMathlibPolynomial (Hex.DensePoly.derivative f) =
       Polynomial.derivative (toMathlibPolynomial f) := by
-  sorry
+  ext n
+  rw [coeff_toMathlibPolynomial,
+    Hex.DensePoly.coeff_derivative f n (Lean.Grind.Semiring.mul_zero _),
+    HexModArithMathlib.ZMod64.toZMod_mul, HexModArithMathlib.ZMod64.toZMod_natCast,
+    Polynomial.coeff_derivative, coeff_toMathlibPolynomial]
+  push_cast
+  ring
 
 namespace Rabin
 

--- a/progress/20260617_100227_1dd356a4.md
+++ b/progress/20260617_100227_1dd356a4.md
@@ -1,0 +1,54 @@
+# Progress - 2026-06-17 (session 1dd356a4, feature #7722)
+
+## Accomplished
+
+Claimed and completed #7722 (discharge HexBerlekampMathlib coefficient-transport
+bridges). Replaced all three target `sorry`s in `HexBerlekampMathlib/Basic.lean`
+with real proofs:
+
+- `coeff_toMathlibPolynomial` (`:68`): `(toMathlibPolynomial f).coeff n =
+  toZMod (f.coeff n)`. `toMathlibPolynomial f` reduces (via the equiv coe) to
+  `fpPolyToPolynomial f`, a `Finset.sum` of monomials; `finset_sum_coeff` +
+  `coeff_monomial` + `Finset.sum_ite_eq'` collapse it to `if n ∈ range f.size
+  then toZMod (f.coeff n) else 0`. The out-of-range branch closes via
+  `DensePoly.coeff_eq_zero_of_size_le` and `toZMod_zero`.
+- `coeff_toMathlibPolynomial_equiv` (`:72`): same statement with `equiv`; one-line
+  from deliverable 1 plus `ZMod64.equiv_apply` (`equiv a = toZMod a` by `rfl`).
+- `toMathlibPolynomial_derivative` (`:104`): coefficientwise via `Polynomial.ext`,
+  `DensePoly.coeff_derivative` (general form with explicit `mul_zero` hypothesis),
+  `toZMod_mul`, `toZMod_natCast`, `Polynomial.coeff_derivative`, then `push_cast;
+  ring`.
+
+## Key patterns / gotchas hit
+
+- `Finset.mem_range` cannot be `rw`-rewritten inside an `if` condition (Decidable
+  motive not type correct). Branch on `n ∈ Finset.range f.size` directly instead,
+  converting to a size bound only in the term you feed `coeff_eq_zero_of_size_le`.
+- `coeff_derivative_semiring` (`@[simp]`) does **not** match a `DensePoly.derivative`
+  term written with the canonical `NatCast`/`Mul (ZMod64 p)` instances — the
+  semiring-specialized lemma restates `derivative` through the Semiring-derived
+  `natCast` (the `attribute [local instance 1100]`), a different instance path.
+  Use the general `Hex.DensePoly.coeff_derivative f n (Lean.Grind.Semiring.mul_zero _)`
+  via `rw`; it matches the goal's derivative exactly.
+- The two-representations-of-zero gotcha: closed the out-of-range branch with
+  `exact toZMod_zero.symm` (defeq-tolerant), not `rw`.
+
+## Verification
+
+- `lake build HexBerlekampMathlib.Basic` — clean (remaining `sorry`s are the
+  unrelated `fpPolyEquiv` round-trip / `monic` / `natDegree` ones, untouched).
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod` — clean (downstream
+  consumers at `:64,375,474` typecheck against the now-proved lemmas).
+- `python3 scripts/check_dag.py` exit 0; `git diff --check` clean.
+- Added-line forbidden-token scan: no sorry/axiom/native_decide/TODO/FIXME.
+
+## Current frontier / Next step
+
+The three live transport bridges are closed. Remaining `sorry`s in the file
+(the harder `fpPolyEquiv` `left_inv`/`right_inv`/`map_mul'`/`map_add'`,
+`toMathlibPolynomial_monic`, `natDegree_toMathlibPolynomial_eq_basisSize`) are
+explicitly out of scope for this issue and remain for follow-up.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7722

Session: `1dd356a4-4e5c-48b3-b26f-0193e7731080`

6df88263 doc: note the *_semiring DensePoly coeff lemmas miss canonical-instance goals
394d138c feat: discharge HexBerlekampMathlib coefficient-transport bridges (#7722)

🤖 Prepared with Claude Code