### PR TITLE
feat: expose per-support tight CLD norm-bound family for fast-BHKS cut projection

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -1191,6 +1191,52 @@ theorem tightColumnBound_of_lift
   · -- hy: the factor's `Phi`-column is Mignotte-bounded.
     exact abs_phi_coeff_le_bhksCoeffBound D.f D.factor j.val hfac_monic hfac_dvd
 
+/--
+**Single-support tight CLD norm certificate.**  A genuine true-factor lift
+package directly yields `TrueFactorCLDTightNormBound` (the
+`4·‖v‖² ≤ bhksCutRadiusSq4` cut-radius bound the prefix cut consumes), by
+composing the tight per-column estimate `tightColumnBound_of_lift` with the
+column-to-norm reducer `tightNormBound_of_lift`.
+
+This lives in `CLDColumnBound` rather than `Lattice` because
+`tightColumnBound_of_lift` is downstream of `Lattice` in the import graph
+(`CLDColumnBound → BadVectorAuxiliary → BadVector → Lattice`); placing the
+composition in `Lattice` would be circular.
+-/
+theorem trueFactorCLDTightNormBound_of_lift
+    {L : Hex.BhksLatticeBasis} {S : LiftedFactorSupport L}
+    (D : TrueFactorLift L S) (H : TrueFactorLiftSemantics D)
+    (hp : 2 ≤ D.p) (hk : 1 < D.p ^ D.a)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound D.f j < D.p ^ D.a) :
+    TrueFactorCLDTightNormBound L S :=
+  tightNormBound_of_lift D (tightColumnBound_of_lift D H hp hk hsep)
+
+/--
+**Per-support tight CLD norm-bound family.**  Assemble the `∀ S` certificate
+family that `cutProjectionHypotheses_of_trueFactors` (`Lattice.lean`) consumes
+as its `tight` argument, from a per-support family of genuine lift packages plus
+the per-support separation facts.
+
+The binder shape mirrors `cutProjectionHypotheses_of_trueFactors` exactly (same
+`L`, same `trueSupports`), so the result drops straight into its `tight` slot
+with no reshaping.  The separation facts `hp`/`hk`/`hsep` are taken per-support,
+since they reference `(Dfam S).p`, `(Dfam S).a`, `(Dfam S).f`, which vary per
+package and are not fields of `TrueFactorLift`/`TrueFactorLiftSemantics`.
+-/
+theorem trueFactorCLDTightNormBoundFamily_of_lift
+    (L : Hex.BhksLatticeBasis) (hrows : 1 ≤ L.factorCount + L.coeffWidth)
+    (trueSupports :
+      Set (Set (Fin (Hex.bhksProjectedRows L hrows).factorCount)))
+    (Dfam : ∀ S : trueSupports, TrueFactorLift L S.1)
+    (Hfam : ∀ S : trueSupports, TrueFactorLiftSemantics (Dfam S))
+    (hp : ∀ S : trueSupports, 2 ≤ (Dfam S).p)
+    (hk : ∀ S : trueSupports, 1 < (Dfam S).p ^ (Dfam S).a)
+    (hsep : ∀ S : trueSupports,
+      ∀ j, 2 * Hex.bhksCoeffBound (Dfam S).f j < (Dfam S).p ^ (Dfam S).a) :
+    ∀ S : trueSupports, TrueFactorCLDTightNormBound L S.1 :=
+  fun S =>
+    trueFactorCLDTightNormBound_of_lift (Dfam S) (Hfam S) (hp S) (hk S) (hsep S)
+
 end BHKS
 
 end

--- a/progress/20260617_104002_fc7e4702.md
+++ b/progress/20260617_104002_fc7e4702.md
@@ -1,0 +1,57 @@
+# Progress - 2026-06-17 (session fc7e4702, feature #7730)
+
+## Accomplished
+
+Claimed #7730 (feat: produce per-support tight CLD norm-bound family for
+fast-BHKS cut projection) and landed both deliverables.
+
+### Single-support certificate + family producer
+
+`HexBerlekampZassenhausMathlib/CLDColumnBound.lean` (below
+`tightColumnBound_of_lift`, inside `namespace BHKS`):
+
+- `trueFactorCLDTightNormBound_of_lift`: the single-support certificate, the
+  composition `tightNormBound_of_lift D (tightColumnBound_of_lift D H hp hk hsep)`
+  yielding `TrueFactorCLDTightNormBound L S` from a genuine `TrueFactorLift`
+  package plus separation facts.
+- `trueFactorCLDTightNormBoundFamily_of_lift`: the `∀ S : trueSupports`
+  certificate family that `cutProjectionHypotheses_of_trueFactors`
+  (`Lattice.lean:1552`) consumes as its `tight` argument. Binder shape mirrors
+  the cut-projection producer exactly (same `L`, same
+  `trueSupports : Set (Set (Fin (Hex.bhksProjectedRows L hrows).factorCount))`),
+  so it drops into the `tight` slot with no reshaping. Separation facts
+  (`hp`/`hk`/`hsep`) taken **per-support** as the issue's premise check
+  recommended — they reference `(Dfam S).p/.a/.f`, which vary per package and
+  are not fields of `TrueFactorLift`/`TrueFactorLiftSemantics`.
+
+### File-placement correction (premise fix)
+
+The issue asked for deliverable 1 in `Lattice.lean`. That is a **circular
+import**: `tightColumnBound_of_lift` lives in `CLDColumnBound.lean`, which is
+downstream of `Lattice` (`CLDColumnBound → BadVectorAuxiliary → BadVector →
+Lattice`). Both new lemmas therefore live in `CLDColumnBound.lean`, the lowest
+file that sees both `tightColumnBound_of_lift` (local) and the Lattice-side
+`tightNormBound_of_lift` / `TrueFactorCLDTightNormBound`. The lemma *content*
+(the composition the issue specified) is unchanged; only the home file moved.
+Noted in the PR body.
+
+## Current frontier
+
+The per-support certificate is now exposed as named lemmas. Nothing yet imports
+`CLDColumnBound`, so the family producer is standalone; the consumers
+(`cutProjectionHypotheses_of_trueFactors`, `factorFastCoreWithBound_*_of_trueFactors`)
+still take `tight` as a hypothesis.
+
+## Next step
+
+Wire `trueFactorCLDTightNormBoundFamily_of_lift` into the executable fast-BHKS
+driver: a follow-up that imports `CLDColumnBound` and supplies the per-support
+`Dfam`/`Hfam` lift packages + separation facts from genuine factor construction
+evidence, then feeds the result into `cutProjectionHypotheses_of_trueFactors`.
+
+## Blockers
+
+None. Verification: `lake build HexBerlekampZassenhausMathlib.CLDColumnBound`
+and full `lake build HexBerlekampZassenhausMathlib` both green (3789 jobs);
+`python3 scripts/check_dag.py` clean; `git diff --check` clean; no
+sorry/axiom/native_decide/TODO/FIXME on added lines.


### PR DESCRIPTION
This PR exposes the per-support tight CLD norm-bound certificate that the fast-BHKS cut-projection chain consumes as a hypothesis. It adds `BHKS.trueFactorCLDTightNormBound_of_lift`, the single-support composition `tightNormBound_of_lift D (tightColumnBound_of_lift D H hp hk hsep)` producing `TrueFactorCLDTightNormBound L S` from a genuine `TrueFactorLift` package, and `BHKS.trueFactorCLDTightNormBoundFamily_of_lift`, the `∀ S : trueSupports` family whose binder shape mirrors `cutProjectionHypotheses_of_trueFactors` exactly so it drops straight into that producer's `tight` slot. The separation facts are taken per-support, since `(Dfam S).p`/`.a`/`.f` vary per package and are not fields of `TrueFactorLift`/`TrueFactorLiftSemantics`.

Both lemmas land in `CLDColumnBound.lean` rather than `Lattice.lean` as the issue suggested: `tightColumnBound_of_lift` is downstream of `Lattice` in the import graph (`CLDColumnBound → BadVectorAuxiliary → BadVector → Lattice`), so placing the composition in `Lattice` would be circular. The lemma content is exactly the composition the issue specified; only the home file moved.

Verified locally (the Mathlib layer is not built by CI): `lake build HexBerlekampZassenhausMathlib.CLDColumnBound` and full `lake build HexBerlekampZassenhausMathlib` both green, `scripts/check_dag.py` clean, no `sorry`/`axiom`/`native_decide` on added lines.

Closes #7730

🤖 Prepared with Claude Code