### PR TITLE
feat: prove fpPolyEquiv ring-equivalence round-trip and ring-hom structure

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -32,6 +32,36 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   (`mul_one`, `neg_add_cancel`, `ring`) need Mathlib instances these types lack.
   `grind` uses the `Lean.Grind.CommRing` instance; prime-inverse facts
   (`ZMod64.inv_mul_eq_one_of_prime`, `mul_inv_eq_one_of_prime`) are `@[grind]`.
+- **Transporting `FpPoly` multiplication to `Polynomial (ZMod p)`
+  (`map_mul'`-shaped goals): push `toZMod` through the executable List-fold,
+  *then* convert to a Finset sum on the `ZMod p` side — you cannot meet in the
+  middle.** `ZMod64 p` has no Mathlib `AddCommMonoid`, so a `Finset.antidiagonal`
+  sum (and `HexPolyMathlib.toPolynomial`, which needs Mathlib `Semiring`) does
+  **not** typecheck over `ZMod64`; the furthest multiplication form expressible
+  over `ZMod64` is the diagonal *List.foldl* of `Hex.DensePoly.mulCoeffSum_eq_diagonal`
+  (`HexPoly/Euclid.lean`, over `Lean.Grind.CommRing`). Recipe for
+  `toZMod (mulCoeffSum f g n) = ∑ x ∈ Finset.antidiagonal n, …`: (1) rewrite to
+  the diagonal fold; (2) a small induction `toZMod ((range m).foldl (·+·) 0) =
+  ∑ i ∈ range m, toZMod (term i)` via `toZMod_add` + `Finset.sum_range_succ`
+  (state it abstractly over `term : Nat → ZMod64 p`, see next bullet); (3)
+  `toZMod` the per-term `if`-guard via `toZMod_zero`/`toZMod_mul`; (4) match the
+  `f.size` range against `range (n+1)` through a `max`-bridge `Finset.sum_subset`
+  (terms vanish by support / degree guard) and finish with
+  `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`, mirroring
+  `HexPolyMathlib.toPolynomial_mul`. (Landed: `HexBerlekampMathlib.fpPolyEquiv`,
+  #7729.)
+- **The `coeff_*_semiring` instance-path mismatch also bites `mulCoeffSum` and
+  `mulCoeffSum_eq_diagonal`.** A `mulCoeffSum f g n` you write in an
+  `FpPoly`-context goal carries ZMod64-direct `Add`/`Mul`; the
+  `[Lean.Grind.CommRing]` lemma `mulCoeffSum_eq_diagonal` carries the
+  CommRing-derived ones, so `rw [mulCoeffSum_eq_diagonal …]` reports "did not
+  find pattern" on a goal that visibly contains the term. Fix: bind the equation
+  through a `have hdiag : <state with the goal's instances> :=
+  mulCoeffSum_eq_diagonal f g n` (the proof unifies the instances by defeq during
+  elaboration), then `rw [hdiag]`. Same trick for any `[Grind.CommRing]`-stated
+  `DensePoly` lemma applied to an `FpPoly` goal. `exact` (defeq-tolerant) needs
+  no such wrapper, so per-term closers like `exact toZMod_diagonalMulCoeffTerm …`
+  match through the instance gap directly.
 - **No `map_neg` / `map_one` / `map_zero` / `map_dvd` on `ZMod64`/`FpPoly`.**
   These need `ZeroHomClass`/`AddMonoidHomClass`/`Monoid` that the executable
   types don't have. To compute e.g. `toZMod (-1) = -1`: prove `(-1)+1 = 0` in

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -35,6 +35,112 @@ def polynomialToFpPoly (f : Polynomial (ZMod p)) : Hex.FpPoly p :=
     ((List.range (f.natDegree + 1)).map fun i =>
       HexModArithMathlib.ZMod64.equiv.symm (f.coeff i)).toArray
 
+/-- Coefficient view of the direct finite-field transport `fpPolyToPolynomial`,
+the standalone form of `coeff_toMathlibPolynomial` available before the ring
+equivalence is assembled. -/
+theorem coeff_fpPolyToPolynomial (f : Hex.FpPoly p) (n : Nat) :
+    (fpPolyToPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) := by
+  rw [fpPolyToPolynomial, Polynomial.finset_sum_coeff]
+  simp only [Polynomial.coeff_monomial]
+  rw [Finset.sum_ite_eq' (Finset.range f.size) n
+    (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]
+  by_cases hn : n ∈ Finset.range f.size
+  · rw [if_pos hn]
+  · rw [if_neg hn, Hex.DensePoly.coeff_eq_zero_of_size_le f
+      (Nat.le_of_not_lt (Finset.mem_range.not.mp hn))]
+    exact HexModArithMathlib.ZMod64.toZMod_zero.symm
+
+/-- The finite-field transport `toZMod` distributes over an additive
+`List.range` fold from `0`, converting it to the `ZMod p` range sum. -/
+private theorem toZMod_foldl_add_eq_sum (term : Nat → Hex.ZMod64 p) (m : Nat) :
+    HexModArithMathlib.ZMod64.toZMod
+        ((List.range m).foldl (fun acc i => acc + term i) 0) =
+      ∑ i ∈ Finset.range m, HexModArithMathlib.ZMod64.toZMod (term i) := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+      rw [List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rw [HexModArithMathlib.ZMod64.toZMod_add, ih, Finset.sum_range_succ]
+
+/-- The transported diagonal term is the `ZMod p` convolution contribution. -/
+private theorem toZMod_diagonalMulCoeffTerm (f g : Hex.FpPoly p) (n i : Nat) :
+    HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.diagonalMulCoeffTerm f g n i) =
+      if n < i then (0 : ZMod p)
+      else HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+        HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i)) := by
+  unfold Hex.DensePoly.diagonalMulCoeffTerm
+  by_cases hni : n < i
+  · simp only [if_pos hni]
+    exact HexModArithMathlib.ZMod64.toZMod_zero
+  · simp only [if_neg hni, HexModArithMathlib.ZMod64.toZMod_mul]
+
+/-- The executable schoolbook multiplication coefficient, transported to
+`ZMod p`, is the truncated convolution sum over the support of `f`. -/
+private theorem toZMod_mulCoeffSum_eq_sum (f g : Hex.FpPoly p) (n : Nat) :
+    HexModArithMathlib.ZMod64.toZMod (Hex.DensePoly.mulCoeffSum f g n) =
+      ∑ i ∈ Finset.range f.size,
+        (if n < i then (0 : ZMod p)
+         else HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+          HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i))) := by
+  have hdiag : Hex.DensePoly.mulCoeffSum f g n =
+      (List.range f.size).foldl
+        (fun acc i => acc + Hex.DensePoly.diagonalMulCoeffTerm f g n i) 0 :=
+    Hex.DensePoly.mulCoeffSum_eq_diagonal f g n
+  rw [hdiag, toZMod_foldl_add_eq_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  exact toZMod_diagonalMulCoeffTerm f g n i
+
+/-- The truncated convolution sum over the support of `f` agrees with the
+degree-`n` antidiagonal sum, the `ZMod p` side of the multiplication transport. -/
+private theorem sum_ite_diagonal_eq_range_succ (f g : Hex.FpPoly p) (n : Nat) :
+    (∑ i ∈ Finset.range f.size,
+      (if n < i then (0 : ZMod p)
+       else HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+        HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i)))) =
+      ∑ i ∈ Finset.range (n + 1),
+        HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+          HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i)) := by
+  set term : Nat → ZMod p := fun i =>
+    HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+      HexModArithMathlib.ZMod64.toZMod (g.coeff (n - i)) with hterm
+  set F : Nat → ZMod p := fun i => if n < i then 0 else term i with hF
+  have hF_size : ∀ i, f.size ≤ i → F i = 0 := by
+    intro i hi
+    simp only [hF]
+    by_cases hni : n < i
+    · simp [hni]
+    · simp only [hni, if_false, hterm]
+      rw [Hex.DensePoly.coeff_eq_zero_of_size_le f hi]
+      rw [show HexModArithMathlib.ZMod64.toZMod (Zero.zero : Hex.ZMod64 p) = 0 from
+        HexModArithMathlib.ZMod64.toZMod_zero, zero_mul]
+  have hF_deg : ∀ i, n < i → F i = 0 := by
+    intro i hi; simp [hF, hi]
+  have hFterm : ∀ i ∈ Finset.range (n + 1), F i = term i := by
+    intro i hi
+    have hle : ¬ n < i := by have := Finset.mem_range.mp hi; omega
+    simp [hF, hle]
+  have e1 : (∑ i ∈ Finset.range f.size, F i) =
+      ∑ i ∈ Finset.range (max f.size (n + 1)), F i := by
+    apply Finset.sum_subset
+    · intro a ha
+      exact Finset.mem_range.mpr
+        (lt_of_lt_of_le (Finset.mem_range.mp ha) (le_max_left _ _))
+    · intro i _ hi
+      exact hF_size i (Nat.le_of_not_lt (Finset.mem_range.not.mp hi))
+  have e2 : (∑ i ∈ Finset.range (n + 1), F i) =
+      ∑ i ∈ Finset.range (max f.size (n + 1)), F i := by
+    apply Finset.sum_subset
+    · intro a ha
+      exact Finset.mem_range.mpr
+        (lt_of_lt_of_le (Finset.mem_range.mp ha) (le_max_right _ _))
+    · intro i _ hi
+      exact hF_deg i (by have := Finset.mem_range.not.mp hi; omega)
+  calc (∑ i ∈ Finset.range f.size, F i)
+      = ∑ i ∈ Finset.range (n + 1), F i := by rw [e1, ← e2]
+    _ = ∑ i ∈ Finset.range (n + 1), term i := Finset.sum_congr rfl hFterm
+
 /--
 The executable finite-field polynomial representation is ring-equivalent to
 Mathlib polynomials over `ZMod p`.
@@ -43,13 +149,54 @@ def fpPolyEquiv : Hex.FpPoly p ≃+* Polynomial (ZMod p) where
   toFun := fpPolyToPolynomial
   invFun := polynomialToFpPoly
   left_inv := by
-    sorry
+    intro f
+    apply Hex.DensePoly.ext_coeff
+    intro n
+    rw [polynomialToFpPoly, Hex.DensePoly.coeff_ofCoeffs_list,
+      HexPolyMathlib.list_getD_map_range_zero]
+    by_cases hn : n < (fpPolyToPolynomial f).natDegree + 1
+    · simp only [if_pos hn, coeff_fpPolyToPolynomial,
+        HexModArithMathlib.ZMod64.equiv_symm_apply, HexModArithMathlib.ZMod64.ofZMod_toZMod]
+    · rw [if_neg hn]
+      have hcoeff : (fpPolyToPolynomial f).coeff n = 0 :=
+        Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)
+      rw [coeff_fpPolyToPolynomial f n] at hcoeff
+      have hzero : f.coeff n = 0 := by
+        have := congrArg HexModArithMathlib.ZMod64.ofZMod hcoeff
+        rwa [HexModArithMathlib.ZMod64.ofZMod_toZMod,
+          HexModArithMathlib.ZMod64.ofZMod_zero] at this
+      exact hzero.symm
   right_inv := by
-    sorry
+    intro P
+    apply Polynomial.ext
+    intro n
+    rw [coeff_fpPolyToPolynomial, polynomialToFpPoly, Hex.DensePoly.coeff_ofCoeffs_list,
+      HexPolyMathlib.list_getD_map_range_zero]
+    by_cases hn : n < P.natDegree + 1
+    · simp only [if_pos hn, HexModArithMathlib.ZMod64.equiv_symm_apply,
+        HexModArithMathlib.ZMod64.toZMod_ofZMod]
+    · rw [if_neg hn, Polynomial.coeff_eq_zero_of_natDegree_lt (by omega)]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
   map_mul' := by
-    sorry
+    intro f g
+    apply Polynomial.ext
+    intro n
+    rw [coeff_fpPolyToPolynomial (f * g) n, Hex.DensePoly.coeff_mul f g n,
+      toZMod_mulCoeffSum_eq_sum f g n, Polynomial.coeff_mul]
+    simp only [coeff_fpPolyToPolynomial]
+    rw [Finset.Nat.sum_antidiagonal_eq_sum_range_succ
+      (fun i j => HexModArithMathlib.ZMod64.toZMod (f.coeff i) *
+        HexModArithMathlib.ZMod64.toZMod (g.coeff j)) n]
+    exact sum_ite_diagonal_eq_range_succ f g n
   map_add' := by
-    sorry
+    intro f g
+    apply Polynomial.ext
+    intro n
+    rw [coeff_fpPolyToPolynomial (f + g) n, Polynomial.coeff_add,
+      coeff_fpPolyToPolynomial f n, coeff_fpPolyToPolynomial g n,
+      Hex.DensePoly.coeff_add f g n
+        (inferInstance : Hex.DensePoly.AddZeroLaw (Hex.ZMod64 p)).add_zero_zero]
+    exact HexModArithMathlib.ZMod64.toZMod_add _ _
 
 /-- Interpret an executable `FpPoly p` as a Mathlib polynomial over `ZMod p`. -/
 def toMathlibPolynomial (f : Hex.FpPoly p) : Polynomial (ZMod p) :=

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -1254,7 +1254,7 @@ namespace DensePoly
 /-- The `i`-th summand of the degree-`n` convolution diagonal of `p * q`,
 `p.coeff i * q.coeff (n - i)`, zeroed once the degree guard `n < i` fires;
 the single-index term that `mulCoeffSum` is reorganised into. -/
-private def diagonalMulCoeffTerm {S : Type _} [Zero S] [DecidableEq S] [Mul S]
+def diagonalMulCoeffTerm {S : Type _} [Zero S] [DecidableEq S] [Mul S]
     (p q : DensePoly S) (n i : Nat) : S :=
   if n < i then 0 else p.coeff i * q.coeff (n - i)
 
@@ -1334,7 +1334,7 @@ private theorem fold_mulCoeff_outer_eq_diagonal {S : Type _}
 /-- The schoolbook coefficient `mulCoeffSum p q n` equals the diagonal sum
 `Σ_{i < p.size} diagonalMulCoeffTerm p q n i`; the bridge from the executable
 loop order to the convolution form used in the ring-law proofs. -/
-private theorem mulCoeffSum_eq_diagonal {S : Type _}
+theorem mulCoeffSum_eq_diagonal {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]
     (p q : DensePoly S) (n : Nat) :
     mulCoeffSum p q n =

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -28,7 +28,7 @@ noncomputable section
 /-- Reading a mapped `List.range` with default zero returns the mapped index inside
 the range and zero outside it. This is the coefficient-array lookup fact used by
 `coeff_ofPolynomial` when rebuilding dense polynomials from Mathlib coefficients. -/
-private theorem list_getD_map_range_zero [Zero R] (size n : Nat) (f : Nat → R) :
+theorem list_getD_map_range_zero [Zero R] (size n : Nat) (f : Nat → R) :
     (List.map f (List.range size)).getD n (Zero.zero : R) =
       if n < size then f n else (Zero.zero : R) := by
   by_cases hn : n < size

--- a/progress/20260617_120000_4cad6b4f.md
+++ b/progress/20260617_120000_4cad6b4f.md
@@ -1,0 +1,67 @@
+# Progress - 2026-06-17 (session 4cad6b4f, feature #7729)
+
+## Accomplished
+
+Closed #7729: proved all four `fpPolyEquiv` structure fields in
+`HexBerlekampMathlib/Basic.lean`, the foundational `Hex.FpPoly p ≃+*
+Polynomial (ZMod p)` ring equivalence under the HO-1 finite-field
+transport chain. The four `sorry`s (`left_inv`, `right_inv`, `map_mul'`,
+`map_add'`) are gone; `lake build HexBerlekampMathlib` is clean (only the
+pre-existing sibling sorries remain: Rabin lemmas, gcd, monic, natDegree).
+
+Key structural fact: `Hex.ZMod64 p` carries only `Lean.Grind` ring
+instances, **not** Mathlib's `Semiring`/`AddCommMonoid`. So
+`Polynomial (ZMod64 p)` does not form and `Finset` sums over `ZMod64`
+do not typecheck — the map-factorization through
+`HexPolyMathlib.toPolynomial` over `ZMod64` is impossible. The
+multiplication transport (`map_mul'`) therefore pushes `toZMod` through
+the executable diagonal *List-fold* form of `mulCoeffSum` (the furthest
+form expressible over `ZMod64`), lands in `ZMod p`, and only then
+converts to a `Finset` antidiagonal sum matching `Polynomial.coeff_mul`.
+
+New helper lemmas (all in `HexBerlekampMathlib`):
+- `coeff_fpPolyToPolynomial` — pre-equiv coefficient view of the raw
+  transport (standalone form of `coeff_toMathlibPolynomial`).
+- `toZMod_foldl_add_eq_sum` — `toZMod` distributes over a `List.range`
+  additive fold; stated abstractly over `term : Nat → ZMod64 p` to dodge
+  the `Grind.CommRing`-vs-direct instance-path mismatch under `rw`.
+- `toZMod_diagonalMulCoeffTerm`, `toZMod_mulCoeffSum_eq_sum`,
+  `sum_ite_diagonal_eq_range_succ` — the convolution transport chain.
+
+De-privatized (visibility-only, in executable/bridge files):
+- `Hex.DensePoly.diagonalMulCoeffTerm` and
+  `Hex.DensePoly.mulCoeffSum_eq_diagonal` (`HexPoly/Euclid.lean`, over
+  `Lean.Grind.CommRing`, applicable to `ZMod64`).
+- `HexPolyMathlib.list_getD_map_range_zero` (round-trip getD-over-map).
+
+## Decisions / patterns
+
+- Instance-path mismatch (skill's `coeff_*_semiring` gotcha) bites
+  `mulCoeffSum_eq_diagonal`: bind the equation via a `have` with the
+  goal's ZMod64-direct instances so the proof unifies by defeq, then
+  `rw` the local hypothesis.
+- `Zero.zero` vs `0` reps closed with `exact toZMod_zero` (defeq
+  tolerant), not `rw`/`rfl`.
+- Antidiagonal matching mirrors `HexPolyMathlib.toPolynomial_mul`:
+  `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` + a `max`-bridge
+  `Finset.sum_subset` (the truncated `f.size` sum and the `n+1` range
+  sum both extend to `range (max f.size (n+1))`, terms vanishing by
+  support / degree guards).
+
+## Verification
+
+- `lake build HexBerlekampMathlib` (full target) — clean.
+- `lake build HexPolyMathlib`, `lake build HexPoly.Euclid` — clean.
+- `python3 scripts/check_dag.py` — pass. `git diff --check` — clean.
+- Added-line forbidden-token scan — none.
+
+## Next step
+
+`fpPolyEquiv` now grounds every downstream transport lemma; the next
+sibling sorries in this file (`toMathlibPolynomial_monic`,
+`natDegree_toMathlibPolynomial_eq_basisSize`, the Rabin/gcd lemmas) are
+the natural follow-ups for the HO-1 transport surface.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7729

Session: `4cad6b4f-7330-4ddb-9d58-fb34752a9038`

36250a48 doc: record FpPoly multiplication-transport recipe in boundary skill
003ec700 feat: prove fpPolyEquiv ring-equivalence round-trip and ring-hom structure

🤖 Prepared with Claude Code