### PR TITLE
feat: expose fast-BHKS raw disjunct from first-success state

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7666,8 +7666,12 @@ input is not zero-degree (`hdeg`), the recombination budget is at least one
 The `hnotsingleton` premise is the post-#4605 form: the small-mod singleton
 branch fires when `(choosePrimeData? sf).isSome ∧ size ≤ 1` is true; its
 negation routes the dispatcher to the BHKS core call, which is what this
-lemma's `hcore` invariant uses. -/
-private theorem factorFastFactorsWithBound_eq_some_of_core_success
+lemma's `hcore` invariant uses.
+
+Exposed publicly so the Mathlib-side fast `h_raw` disjunct producer can
+identify the raw fast-factor array as the normalization reassembly of the
+successful core output. -/
+theorem factorFastFactorsWithBound_eq_some_of_core_success
     (f : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     (coreFactors : Array ZPoly)
     (hB_pos : 1 ≤ B)

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -980,4 +980,100 @@ theorem factorWithBound_fastCore_entry_irreducible_of_forwardInputs
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hraw_irr
 
+/--
+Fast `h_raw` disjunct producer for the BHKS fast-core success arm.
+
+This is the fast half of the `h_raw` hypothesis consumed by
+`HexBerlekampZassenhausMathlib.factorWithBound_entries_irreducible` /
+`factor_entries_irreducible` (#3987 / #4170) and by the #6672 capstone:
+whenever the public fast factor function `Hex.factorFastFactorsWithBound f B`
+returns `some rawFactors`, every raw factor in that array is
+`Hex.ZPoly.Irreducible`.  Instantiating `B` at `Hex.ZPoly.defaultFactorCoeffBound f`
+yields exactly the first disjunct of `factor_entries_irreducible`'s `h_raw`.
+
+Unlike the #7738 entry-level theorem `factorWithBound_fastCore_entry_irreducible_of_forwardInputs`,
+which proves the *recorded* `factorWithBound` entries irreducible, this exposes
+the *raw* fast-factor array directly: it identifies that array as the
+normalization reassembly of the successful core output `hinputs.expectedFactors`
+(`Hex.factorFastFactorsWithBound_eq_some_of_core_success`), proves each core
+factor irreducible through the scheduled-loop forward-input wrapper
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule`,
+and lifts that across the reassembly via
+`Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`.
+
+The first-success certificates are threaded as hypotheses at the precision the
+caller carries them: `hcore` pins the *actual* executable loop output (started
+at `Hex.initialHenselPrecision a`, not at a cap precision) to
+`hinputs.expectedFactors`.  This does not force equality with any cap recovery
+array, and the cut certificate `hcut` runs through the true-factor lift/cut
+stack rather than the refuted no-early-success or cap-determinism shortcuts. -/
+theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hB_pos : 1 ≤ B)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+        some primeData)
+    (hdeg :
+      (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    (hmulti : 1 < primeData.factorsModP.size)
+    (hquadratic :
+      B = 1 ∨
+        Hex.quadraticIntegerRootFactors?
+          (Hex.normalizeForFactor f).squareFreeCore = none)
+    (hinputs :
+      BHKS.ForwardRecoveryInputs
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.precisionForCoeffBound B primeData.p) primeData))
+    (hcore :
+      let a := Hex.precisionForCoeffBound B primeData.p
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
+        primeData (Hex.initialHenselPrecision a)
+        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+          some hinputs.expectedFactors)
+    (hcut :
+      BHKS.CutProjectionHypotheses
+        (BHKS.projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.precisionForCoeffBound B primeData.p) primeData)
+          hinputs.rows_pos)
+        hinputs.trueSupports)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn hinputs.trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (Hex.normalizeForFactor f).squareFreeCore)).card)
+    (hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+        hinputs.expectedFactors)
+    {rawFactors : Array Hex.ZPoly}
+    (hfast : Hex.factorFastFactorsWithBound f B = some rawFactors) :
+    ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw := by
+  have hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore :=
+    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
+  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 :=
+    zpoly_ne_zero_of_pos_lc hcore_lc_pos
+  have hcore_irr :
+      ∀ factor ∈ hinputs.expectedFactors.toList,
+        Hex.ZPoly.Irreducible factor :=
+    factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule
+      hcore_ne hinputs hcore hcut hpartition
+  have hfast_eq :=
+    Hex.factorFastFactorsWithBound_eq_some_of_core_success f B primeData
+      hinputs.expectedFactors hB_pos hchoose hdeg (by omega) hquadratic hcore
+  rw [hfast] at hfast_eq
+  have hraw_eq := (Option.some.inj hfast_eq)
+  intro raw hraw_mem
+  rw [hraw_eq] at hraw_mem
+  exact
+    Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+      (Hex.normalizeForFactor f) hinputs.expectedFactors hcomplete hcore_irr
+      hraw_mem
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260617_115723_41016b56.md
+++ b/progress/20260617_115723_41016b56.md
@@ -1,0 +1,72 @@
+# Progress - 2026-06-17 (session 41016b56, one-shot #7739)
+
+## Accomplished
+
+Claimed and completed #7739 (feat: expose fast-BHKS raw disjunct from
+first-success state) via `pod once`. Landed the fast `h_raw` disjunct
+producer for the BHKS fast-core success arm.
+
+### Mathlib layer (`PartitionRefinement.lean`)
+
+Added `factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs`:
+whenever the public fast factor function `Hex.factorFastFactorsWithBound f B`
+returns `some rawFactors`, every raw factor is `Hex.ZPoly.Irreducible`, under
+the same first-success certificate set as #7738 (`ForwardRecoveryInputs` at
+`precisionForCoeffBound B primeData.p`, forward cut certificate, partition-count
+equality, reassembly-completeness, and the loop-output hypothesis `hcore`).
+
+This is the *raw*-array counterpart to #7738's *recorded-entry* theorem
+`factorWithBound_fastCore_entry_irreducible_of_forwardInputs`. The proof:
+- proves each core factor irreducible via the scheduled-loop wrapper
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_forwardInputs_on_schedule`
+  (#7666 decoupled wrapper — loop `start = initialHenselPrecision a`, cut
+  precision `target` independent);
+- identifies the raw array as `reassemblePolynomialFactors normalized
+  expectedFactors` via `factorFastFactorsWithBound_eq_some_of_core_success`;
+- lifts core irreducibility across the reassembly with
+  `reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`.
+
+Instantiating `B := defaultFactorCoeffBound f` gives exactly the first disjunct
+of `factor_entries_irreducible`'s `h_raw`.
+
+### Executable layer (`HexBerlekampZassenhaus/Basic.lean`)
+
+De-privatized `factorFastFactorsWithBound_eq_some_of_core_success`
+(visibility-only) so the Mathlib-side producer can name it. No behavior change.
+
+### Why this is the sound path (not the determinism trap)
+
+The hex-lean-mathlib-boundary skill warns that the fast path is a schedule loop
+whose first-success array need not equal a cap recovery package, so an
+*unconditional* `h_raw` is not derivable. This deliverable does not force that:
+`hcore` threads the *actual* executable loop output (started at
+`initialHenselPrecision a`) as a hypothesis, exactly as #7738 does, and `hcut`
+runs through the true-factor lift/cut stack. The scheduled-loop determinism
+obligation stays with the caller; deliverable 2's "no equality with a cap
+recovery array" is respected.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement` — green
+- `lake build HexBerlekampZassenhausMathlib` — green (3790 jobs; FactorSoundness
+  included)
+- `lake build HexBerlekampZassenhaus` — green
+- `python3 scripts/check_dag.py` — exit 0
+- `git diff --check` — clean
+- Added-line forbidden-token scan: no sorry/axiom/native_decide/TODO/FIXME
+
+## Current frontier
+
+Fast `h_raw` disjunct now exists as a proof-facing producer. The remaining
+wiring into the #6672 capstone is the caller-side composition that supplies the
+three disjuncts (fast / slow-modular / slow-trial) plus the scheduled-loop
+determinism `hcore` for the default bound.
+
+## Next step
+
+Compose the fast disjunct with the slow-path disjuncts into the full `h_raw`
+for `factor_entries_irreducible`, then feed #6672.
+
+## Blockers
+
+None for the landed change.


### PR DESCRIPTION
Closes #7739

Session: `41016b56-1a39-4d89-9e4a-eaaa1ee5da6f`

8f0c9f0c feat: expose fast-BHKS raw disjunct from first-success state

🤖 Prepared with Claude Code