### PR TITLE
feat: add sound normalize/associated gcd transport primitives

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -464,12 +464,93 @@ theorem rabinTest_true_of_mathlib_checks
 
 end Rabin
 
-/-- Executable gcd transfers to Mathlib's gcd after coefficient transport. -/
+/--
+**Unsound up-to-unit overstatement — use `toMathlibPolynomial_gcd_normalize`.**
+
+This exact equality is false in general: `Hex.DensePoly.gcd` is the last nonzero
+`xgcdAux` remainder with no monic rescale (`HexPoly/Euclid.lean:913`), while
+Mathlib's `gcd` is `normalize`-canonical. Counterexample over `F₅`:
+`gcd(X²−1, 2X−2) = 2X−2` (leadCoeff `2`) executable, but `X−1` in Mathlib. The
+two sides are only associated; see `toMathlibPolynomial_gcd_associated` and
+`toMathlibPolynomial_gcd_normalize` for the sound primitives.
+
+Retained as an unproved placeholder only because the CI-gated
+`HexBerlekampZassenhausMathlib` consumers (`gcd_monicModularImage_derivative_eq_one`,
+`toMathlibPolynomial_coprime_of_gcdIsUnit`, the `HotPathDiscriminant`
+non-coprimality lemma) still rewrite with it. Removing it requires
+re-specifying the `gcd f f' = 1` square-free precondition of
+`toMathlibPolynomial_squareFree_coprime` / `irreducible_of_berlekampFactor_factors_length_le_one`
+to a `gcdIsUnit`/`IsUnit` hypothesis, then migrating those consumers onto the
+sound transport. See the diagnosis on issue #7763.
+-/
 theorem toMathlibPolynomial_gcd
     [Fact (Nat.Prime p)] (f g : Hex.FpPoly p) :
     toMathlibPolynomial (Hex.DensePoly.gcd f g) =
       gcd (toMathlibPolynomial f) (toMathlibPolynomial g) := by
   sorry
+
+/--
+Executable gcd is associated to Mathlib's gcd after coefficient transport.
+
+`toMathlibPolynomial = fpPolyEquiv` is a ring iso, so executable divisibility
+transports both ways; feeding the executable `GcdLaws` through it shows the
+transported gcd satisfies Mathlib's gcd universal property. The two are only
+*associated*, not equal, because the executable gcd is the last nonzero xgcd
+remainder with no monic rescale while Mathlib's gcd is `normalize`-canonical.
+-/
+theorem toMathlibPolynomial_gcd_associated
+    [Fact (Nat.Prime p)] (f g : Hex.FpPoly p) :
+    Associated (toMathlibPolynomial (Hex.DensePoly.gcd f g))
+      (gcd (toMathlibPolynomial f) (toMathlibPolynomial g)) := by
+  have hp_hex : Hex.Nat.Prime p := by
+    refine ⟨(Fact.out : Nat.Prime p).two_le, ?_⟩
+    intro m hmdvd
+    rcases (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hmdvd with h | h
+    · exact Or.inl h
+    · exact Or.inr h
+  haveI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hp_hex
+  -- The executable `∣` is custom (`∃ r, b = a * r`), so transport it through the
+  -- iso by destructuring and re-multiplying rather than via `map_dvd`.
+  have transport : ∀ {a b : Hex.FpPoly p}, a ∣ b →
+      toMathlibPolynomial a ∣ toMathlibPolynomial b := by
+    rintro a b ⟨r, hr⟩
+    exact ⟨toMathlibPolynomial r, by rw [hr]; exact map_mul fpPolyEquiv a r⟩
+  have untransport : ∀ {a b : Hex.FpPoly p},
+      toMathlibPolynomial a ∣ toMathlibPolynomial b → a ∣ b := by
+    rintro a b ⟨R, hR⟩
+    refine ⟨fpPolyEquiv.symm R, ?_⟩
+    apply fpPolyEquiv.injective
+    rw [map_mul, fpPolyEquiv.apply_symm_apply]
+    exact hR
+  apply associated_of_dvd_dvd
+  · exact dvd_gcd (transport (Hex.DensePoly.gcd_dvd_left f g))
+      (transport (Hex.DensePoly.gcd_dvd_right f g))
+  · set d : Hex.FpPoly p :=
+      fpPolyEquiv.symm (gcd (toMathlibPolynomial f) (toMathlibPolynomial g)) with hd
+    have hsymm :
+        toMathlibPolynomial d = gcd (toMathlibPolynomial f) (toMathlibPolynomial g) := by
+      rw [hd]; exact fpPolyEquiv.apply_symm_apply _
+    have hdf : d ∣ f := by
+      apply untransport; rw [hsymm]; exact gcd_dvd_left _ _
+    have hdg : d ∣ g := by
+      apply untransport; rw [hsymm]; exact gcd_dvd_right _ _
+    rw [← hsymm]
+    exact transport (Hex.DensePoly.dvd_gcd d f g hdf hdg)
+
+/--
+Executable gcd transfers to Mathlib's gcd after coefficient transport, up to
+normalization. The executable `Hex.DensePoly.gcd` is the last nonzero xgcd
+remainder and is not monic, while Mathlib's `gcd` applies `normalize`; the two
+coincide only after normalizing the transport. Coprimality is a unit-gcd
+statement, so this up-to-unit shape is the correct primitive for downstream
+square-free reasoning.
+-/
+theorem toMathlibPolynomial_gcd_normalize
+    [Fact (Nat.Prime p)] (f g : Hex.FpPoly p) :
+    normalize (toMathlibPolynomial (Hex.DensePoly.gcd f g)) =
+      gcd (toMathlibPolynomial f) (toMathlibPolynomial g) := by
+  rw [normalize_eq_normalize_iff_associated.mpr (toMathlibPolynomial_gcd_associated f g),
+    normalize_gcd]
 
 /--
 The executable square-free hypothesis used by Berlekamp is the corresponding

--- a/progress/20260617_135934_8603efb1.md
+++ b/progress/20260617_135934_8603efb1.md
@@ -1,0 +1,73 @@
+# Progress — 2026-06-17 (session 8603efb1, feature #7763)
+
+## Accomplished
+
+Claimed #7763 (feat: transport executable gcd to Mathlib gcd up to
+normalization). Landed the **sound gcd transport primitives** in
+`HexBerlekampMathlib/Basic.lean`:
+
+- `toMathlibPolynomial_gcd_associated` — `Associated (toMathlibPolynomial
+  (Hex.DensePoly.gcd f g)) (gcd (toMathlibPolynomial f) (toMathlibPolynomial g))`.
+  Proof transports the executable custom `∣` through the `fpPolyEquiv` ring iso
+  both ways (forward by destructure-and-remultiply, backward via
+  `fpPolyEquiv.injective` + `apply_symm_apply`), feeds the executable `GcdLaws`
+  (`gcd_dvd_left`/`gcd_dvd_right`/`dvd_gcd`) into Mathlib's gcd universal
+  property, and closes with `associated_of_dvd_dvd`.
+- `toMathlibPolynomial_gcd_normalize` — the issue's target shape
+  `normalize (toMathlibPolynomial (gcd f g)) = gcd (toMathlibPolynomial f)
+  (toMathlibPolynomial g)`, one line from the associated lemma via
+  `normalize_eq_normalize_iff_associated` + `normalize_gcd`.
+
+Both compile cleanly (`lake build HexBerlekampMathlib.Basic` green, no new real
+sorries; added lines free of axiom/native_decide/TODO/FIXME).
+
+## Why this is a PARTIAL (sorry NOT dropped)
+
+The issue asked to **remove** the unsound exact `toMathlibPolynomial_gcd` sorry.
+I could not, within scope, while keeping CI green. Three machine-checked facts:
+
+1. **The exact equality is genuinely unsound** (issue's own counterexample;
+   `xgcdAux` at `HexPoly/Euclid.lean:913-919` returns the last nonzero remainder
+   with no monic rescale). Confirmed re-read of the source.
+2. **CI gates the full downstream layer.** `.github/workflows/ci.yml:67` runs
+   `lake build HexBerlekampZassenhausMathlib` ("Build HO-1 Mathlib bridge"). The
+   `hex-lean-mathlib-boundary` skill's claim that this layer is *not* CI-built is
+   **stale** — it is. So removing `toMathlibPolynomial_gcd` (4 consumers rewrite
+   with it) turns the CI gate red.
+3. **Two of the four consumers are themselves unsound** and bottom out at the
+   forbidden `:459`/`:470` lemmas. `gcd_monicModularImage_derivative_eq_one`
+   (`IntReductionMod.lean:473`) and its `_local` twin (`Basic.lean:7734`)
+   conclude executable `gcd(monic, monic') = 1` *exactly* — false (the gcd is a
+   nonzero constant, e.g. `2` over `F₅`), provable only via the unsound exact
+   transport. Their `= 1` output feeds `toMathlibPolynomial_squareFree_coprime`
+   (`:459`) and `irreducible_of_berlekampFactor_factors_length_le_one`, whose
+   `gcd f f' = 1` precondition is the real design flaw — and the issue explicitly
+   forbids touching `:459`/`:470`.
+
+So a green removal requires re-specifying the `gcd = 1` square-free API to a
+`gcdIsUnit`/`IsUnit` hypothesis (the sound `toMathlibPolynomial_coprime_of_gcdIsUnit`
+at `IntReductionMod.lean:330` already shows the route) and migrating the four
+consumers — out of this issue's scope. I retained `toMathlibPolynomial_gcd` as
+an unproved placeholder with an honest "unsound, superseded" docstring so the
+sound primitives land green now and the next worker has a precise map.
+
+## Current frontier
+
+Sound primitives are in `HexBerlekampMathlib/Basic.lean`; nothing consumes them
+yet. Real sorry count unchanged at 7 (status quo).
+
+## Next step (follow-up issue)
+
+Re-spec `toMathlibPolynomial_squareFree_coprime` (`:459`) and
+`irreducible_of_berlekampFactor_factors_length_le_one` to take
+`Hex.gcdIsUnit (gcd f f') = true` (or `IsUnit (toMathlibPolynomial (gcd f f'))`)
+instead of `gcd f f' = 1`; migrate the four `toMathlibPolynomial_gcd` consumers
+onto `toMathlibPolynomial_gcd_normalize` / the existing
+`toMathlibPolynomial_coprime_of_gcdIsUnit`; then delete the unsound exact
+`toMathlibPolynomial_gcd`.
+
+## Blockers
+
+Scope: the clean removal touches the explicitly out-of-scope `:459`/`:470`
+square-free/irreducible API. Routed to replan via partial PR + diagnostic
+comment on #7763.


### PR DESCRIPTION
This PR adds `toMathlibPolynomial_gcd_associated` and `toMathlibPolynomial_gcd_normalize` to `HexBerlekampMathlib/Basic.lean`, the sound up-to-unit gcd transport primitives the square-free coprimality chain needs. The proof transports the executable custom divisibility through the `fpPolyEquiv` ring iso in both directions and feeds the executable `GcdLaws` into Mathlib's gcd universal property, closing the `Associated` fact with `associated_of_dvd_dvd`; the `normalize` equality follows in one step via `normalize_eq_normalize_iff_associated` and `normalize_gcd`.

This is a partial completion of #7763. The issue asked to remove the pre-existing unsound exact `toMathlibPolynomial_gcd` placeholder, but that removal cannot be done in isolation while keeping CI green: `ci.yml` builds the full `HexBerlekampZassenhausMathlib` layer, four consumers there still rewrite with the exact lemma, and two of them (`gcd_monicModularImage_derivative_eq_one` and its `_local` twin) are themselves unsound — they conclude the executable `gcd(monic, monic') = 1` exactly, which is false, and feed the `gcd f f' = 1` precondition of `toMathlibPolynomial_squareFree_coprime` / `irreducible_of_berlekampFactor_factors_length_le_one` (the `:459`/`:470` lemmas the issue forbids touching). The placeholder is retained with an honest "unsound, superseded" docstring; the diagnostic comment on #7763 maps the sound follow-up. `lake build HexBerlekampMathlib.Basic` and `lake build HexBerlekampZassenhausMathlib` both stay green; the added lines carry no `axiom`/`native_decide`/`TODO`/`FIXME` and the real sorry count is unchanged.

🤖 Prepared with Claude Code