### PR TITLE
feat: prove forward Rabin executable-to-Mathlib transport (rabinTest_true_to_mathlib_checks)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -72,6 +72,15 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   `map_dvd` does not apply and `dvd_trans` is replaced by `fpPoly_dvd_trans`.
   Transport divisibility to Mathlib by destructuring and re-multiplying:
   `obtain ⟨r, hr⟩ := h; ⟨toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩`.
+- **Executable gcd/Bezout/modular-division lemmas silently need
+  `[Hex.ZMod64.PrimeModulus p]`** (via `GcdLaws`/`DivModLaws`/field), but
+  Mathlib-layer transport theorems usually carry only `[Fact (Nat.Prime p)]`.
+  The mismatch surfaces as a confusing "failed to synthesize `PrimeModulus p`"
+  deep inside a transport proof (e.g. when calling
+  `DensePoly.xgcd_bezout` or `dvd_xPowSubX_iff_frobeniusDiffMod_isZero`).
+  Bridge it with `haveI : Hex.ZMod64.PrimeModulus p :=
+  HexBerlekampMathlib.primeModulus_of_fact p` (landed by #7774;
+  builds the witness from `Nat.Prime.two_le` + `eq_one_or_self_of_dvd`).
   (`HexBerlekampZassenhausMathlib/Basic.lean` exposes `toMathlibPolynomial_dvd`
   and `self_dvd_monicModPImage` for exactly this.)
 - **`ZPoly = DensePoly Int` ring identities: `grind` is unreliable; use the

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -673,6 +673,42 @@ theorem frobeniusDiffMod_mod_self_of_degree_zero
     rw [hfrob_zero, hX_zero, FpPoly.sub_self]
   rw [hdiff_zero, hmod_zero]
 
+/-- `f` divides the difference between the absolute polynomial `X^(p^k) - X`
+and its modular form `frobeniusDiffMod f hmonic k`. This is the reduction fact
+that makes the executable modular test equivalent to the absolute divisibility
+leg, and it is reused by the Mathlib transport of Rabin's criterion. -/
+theorem dvd_xPowSubX_sub_frobeniusDiffMod
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) (k : Nat) :
+    f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+  have inst_dvd : DensePoly.DivModLaws (ZMod64 p) := inferInstance
+  have hp1 : f ∣ ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+                  FpPoly.frobeniusXPowMod f hmonic k) :=
+    @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _
+      (FpPoly.frobeniusXPowMod_mod_eq_monomial_mod f hmonic k).symm
+  have hp2 : f ∣ (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+    rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+          DensePoly.modByMonic_eq_mod _ _ hmonic]
+    have hmm : (FpPoly.X (p := p)) % f = (FpPoly.X (p := p) % f) % f :=
+      (DensePoly.mod_mod FpPoly.X f).symm
+    exact @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _ hmm
+  have heq :
+      xPowSubX (p := p) k - frobeniusDiffMod f hmonic k =
+        ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+            FpPoly.frobeniusXPowMod f hmonic k) -
+          (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+    unfold xPowSubX frobeniusDiffMod
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring]
+    grind
+  rw [heq]
+  exact DensePoly.dvd_sub_poly hp1 hp2
+
 /--
 `f` divides `X^(p^k) - X` (in the absolute sense) exactly when the
 Berlekamp Frobenius remainder `frobeniusDiffMod f hmonic k` vanishes.
@@ -708,34 +744,8 @@ theorem dvd_xPowSubX_iff_frobeniusDiffMod_isZero
       subst h
       rfl
   -- Step 1: f ∣ ((xPowSubX k) - frobeniusDiffMod).
-  have hdvd_diff : f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
-    have hp1 : f ∣ ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
-                    FpPoly.frobeniusXPowMod f hmonic k) :=
-      @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _
-        (FpPoly.frobeniusXPowMod_mod_eq_monomial_mod f hmonic k).symm
-    have hp2 : f ∣ (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
-      rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
-            DensePoly.modByMonic_eq_mod _ _ hmonic]
-      have hmm : (FpPoly.X (p := p)) % f = (FpPoly.X (p := p) % f) % f :=
-        (DensePoly.mod_mod FpPoly.X f).symm
-      exact @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _ hmm
-    have heq :
-        xPowSubX (p := p) k - frobeniusDiffMod f hmonic k =
-          ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
-              FpPoly.frobeniusXPowMod f hmonic k) -
-            (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
-      unfold xPowSubX frobeniusDiffMod
-      apply DensePoly.ext_coeff
-      intro n
-      rw [DensePoly.coeff_sub_ring,
-          DensePoly.coeff_sub_ring,
-          DensePoly.coeff_sub_ring,
-          DensePoly.coeff_sub_ring,
-          DensePoly.coeff_sub_ring,
-          DensePoly.coeff_sub_ring]
-      grind
-    rw [heq]
-    exact DensePoly.dvd_sub_poly hp1 hp2
+  have hdvd_diff : f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) :=
+    dvd_xPowSubX_sub_frobeniusDiffMod f hmonic k
   -- Step 2: (xPowSubX k) % f = (frobeniusDiffMod) % f.
   have hmodeq : (xPowSubX (p := p) k) % f = (frobeniusDiffMod f hmonic k) % f :=
     @DensePoly.mod_eq_mod_of_congr (ZMod64 p) _ _ _ inst_dvd _ _ _ hdvd_diff

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -338,11 +338,148 @@ theorem toMathlibPolynomial_derivative (f : Hex.FpPoly p) :
   push_cast
   ring
 
+/-- Multiplication commutes with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_mul (f g : Hex.FpPoly p) :
+    toMathlibPolynomial (f * g) = toMathlibPolynomial f * toMathlibPolynomial g :=
+  map_mul fpPolyEquiv f g
+
+/-- Addition commutes with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_add (f g : Hex.FpPoly p) :
+    toMathlibPolynomial (f + g) = toMathlibPolynomial f + toMathlibPolynomial g :=
+  map_add fpPolyEquiv f g
+
+/-- Subtraction commutes with the finite-field polynomial transport. -/
+theorem toMathlibPolynomial_sub (f g : Hex.FpPoly p) :
+    toMathlibPolynomial (f - g) = toMathlibPolynomial f - toMathlibPolynomial g := by
+  apply Polynomial.ext
+  intro n
+  rw [Polynomial.coeff_sub, coeff_toMathlibPolynomial, coeff_toMathlibPolynomial,
+    coeff_toMathlibPolynomial, Hex.DensePoly.coeff_sub_ring,
+    HexModArithMathlib.ZMod64.toZMod_sub]
+
+/-- The constant executable polynomial transports to the Mathlib constant. -/
+theorem toMathlibPolynomial_C (c : Hex.ZMod64 p) :
+    toMathlibPolynomial (Hex.DensePoly.C c) =
+      Polynomial.C (HexModArithMathlib.ZMod64.toZMod c) := by
+  apply Polynomial.ext
+  intro n
+  rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_C, Polynomial.coeff_C]
+  by_cases hn : n = 0
+  · subst hn; rw [if_pos rfl, if_pos rfl]
+  · rw [if_neg hn, if_neg hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
+
+/-- The monic monomial `X^m` transports to `X^m` over `ZMod p`. -/
+theorem toMathlibPolynomial_monomial_one (m : Nat) :
+    toMathlibPolynomial (Hex.DensePoly.monomial m (1 : Hex.ZMod64 p)) =
+      (Polynomial.X : Polynomial (ZMod p)) ^ m := by
+  apply Polynomial.ext
+  intro n
+  rw [coeff_toMathlibPolynomial, Hex.DensePoly.coeff_monomial, Polynomial.coeff_X_pow]
+  by_cases hn : n = m
+  · rw [if_pos hn, if_pos hn]; exact HexModArithMathlib.ZMod64.toZMod_one
+  · rw [if_neg hn, if_neg hn]; exact HexModArithMathlib.ZMod64.toZMod_zero
+
+/-- The executable indeterminate transports to Mathlib's `X`. -/
+theorem toMathlibPolynomial_X :
+    toMathlibPolynomial (Hex.FpPoly.X (p := p)) = (Polynomial.X : Polynomial (ZMod p)) := by
+  apply Polynomial.ext
+  intro n
+  rw [coeff_toMathlibPolynomial, Hex.FpPoly.coeff_X, Polynomial.coeff_X]
+  by_cases hn : n = 1
+  · subst hn; rw [if_pos rfl, if_pos rfl, HexModArithMathlib.ZMod64.toZMod_one]
+  · rw [if_neg hn, if_neg (show ¬ (1 = n) by omega), HexModArithMathlib.ZMod64.toZMod_zero]
+
+/-- Divisibility transports along the finite-field polynomial map. -/
+theorem toMathlibPolynomial_dvd {f g : Hex.FpPoly p} (h : f ∣ g) :
+    toMathlibPolynomial f ∣ toMathlibPolynomial g := by
+  obtain ⟨r, hr⟩ := h
+  exact ⟨toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩
+
+/-- An executable unit polynomial (a nonzero constant) transports to a Mathlib
+unit. -/
+theorem isUnit_toMathlibPolynomial_of_isUnitPolynomial
+    [Fact (Nat.Prime p)] {g : Hex.FpPoly p}
+    (h : Hex.Berlekamp.isUnitPolynomial g = true) :
+    IsUnit (toMathlibPolynomial g) := by
+  -- `isUnitPolynomial g = true` means `g` has degree `0`, hence size `1`.
+  have hdeg : g.degree? = some 0 := by
+    unfold Hex.Berlekamp.isUnitPolynomial at h
+    split at h <;> first | assumption | simp_all
+  have hsize : g.size = 1 := by
+    rcases Nat.eq_zero_or_pos g.size with hz | hpos
+    · rw [(Hex.DensePoly.degree?_eq_none_iff g).mpr hz] at hdeg
+      exact absurd hdeg (by simp)
+    · rw [Hex.DensePoly.degree?_eq_some_of_pos_size g hpos] at hdeg
+      have hsub : g.size - 1 = 0 := Option.some.inj hdeg
+      omega
+  -- So `g = C (g.coeff 0)` with `g.coeff 0 ≠ 0`.
+  have hgC : g = Hex.DensePoly.C (g.coeff 0) := by
+    apply Hex.DensePoly.ext_coeff
+    intro i
+    rw [Hex.DensePoly.coeff_C]
+    by_cases hi : i = 0
+    · subst hi; rw [if_pos rfl]
+    · rw [if_neg hi,
+        Hex.DensePoly.coeff_eq_zero_of_size_le g (by omega : g.size ≤ i)]
+  have hne : g.coeff 0 ≠ 0 := by
+    have hlast := Hex.DensePoly.coeff_last_ne_zero_of_pos_size g (by omega : 0 < g.size)
+    simpa [hsize] using hlast
+  have htoZ_ne : HexModArithMathlib.ZMod64.toZMod (g.coeff 0) ≠ 0 := by
+    intro hzero
+    apply hne
+    apply HexModArithMathlib.ZMod64.equiv.injective
+    rw [HexModArithMathlib.ZMod64.equiv_apply, HexModArithMathlib.ZMod64.equiv_apply,
+      HexModArithMathlib.ZMod64.toZMod_zero, hzero]
+  have hC_eq : toMathlibPolynomial g =
+      Polynomial.C (HexModArithMathlib.ZMod64.toZMod (g.coeff 0)) := by
+    conv_lhs => rw [hgC]
+    exact toMathlibPolynomial_C (g.coeff 0)
+  rw [hC_eq]
+  exact Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr htoZ_ne)
+
+/-- The Mathlib primality fact yields the executable prime-modulus witness, so
+executable field-dependent lemmas (gcd/Bezout, modular division) become
+available in the Mathlib transport layer. -/
+theorem primeModulus_of_fact (p : Nat) [Fact (Nat.Prime p)] :
+    Hex.ZMod64.PrimeModulus p :=
+  Hex.ZMod64.primeModulusOfPrime
+    ⟨(Fact.out : Nat.Prime p).two_le,
+      fun m hm => (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hm⟩
+
+/-- A passing executable gcd-unit check transports to Mathlib coprimality of the
+transported polynomials, via the executable Bezout identity. -/
+theorem isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd
+    [Fact (Nat.Prime p)] {a b : Hex.FpPoly p}
+    (h : Hex.Berlekamp.isUnitPolynomial (Hex.DensePoly.gcd a b) = true) :
+    IsCoprime (toMathlibPolynomial a) (toMathlibPolynomial b) := by
+  haveI : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  obtain ⟨u, hu⟩ := isUnit_toMathlibPolynomial_of_isUnitPolynomial h
+  -- Executable Bezout: `left * a + right * b = gcd a b`.
+  have hbez : (Hex.DensePoly.xgcd a b).left * a + (Hex.DensePoly.xgcd a b).right * b
+      = Hex.DensePoly.gcd a b :=
+    Hex.DensePoly.xgcd_bezout a b
+  have hbezM :
+      toMathlibPolynomial (Hex.DensePoly.xgcd a b).left * toMathlibPolynomial a +
+        toMathlibPolynomial (Hex.DensePoly.xgcd a b).right * toMathlibPolynomial b =
+        toMathlibPolynomial (Hex.DensePoly.gcd a b) := by
+    rw [← toMathlibPolynomial_mul, ← toMathlibPolynomial_mul, ← toMathlibPolynomial_add, hbez]
+  refine ⟨↑u⁻¹ * toMathlibPolynomial (Hex.DensePoly.xgcd a b).left,
+    ↑u⁻¹ * toMathlibPolynomial (Hex.DensePoly.xgcd a b).right, ?_⟩
+  rw [mul_assoc, mul_assoc, ← mul_add, hbezM, ← hu]
+  exact u.inv_mul
+
 namespace Rabin
 
 /-- The Mathlib polynomial `X^(p^n) - X` used by Rabin's divisibility leg. -/
 abbrev frobeniusPolynomial (p n : Nat) : Polynomial (ZMod p) :=
   X ^ (p ^ n) - X
+
+/-- The executable absolute polynomial `X^(p^k) - X` transports to
+`frobeniusPolynomial p k`. -/
+theorem toMathlibPolynomial_xPowSubX (k : Nat) :
+    toMathlibPolynomial (Hex.Berlekamp.xPowSubX (p := p) k) = frobeniusPolynomial p k := by
+  unfold Hex.Berlekamp.xPowSubX frobeniusPolynomial
+  rw [toMathlibPolynomial_sub, toMathlibPolynomial_monomial_one, toMathlibPolynomial_X]
 
 /-
 Divisibility by the modulus is exactly vanishing in the corresponding
@@ -513,7 +650,40 @@ theorem rabinTest_true_to_mathlib_checks
       toMathlibPolynomial f ∣ frobeniusPolynomial p n ∧
       ∀ d ∈ Hex.Berlekamp.maximalProperDivisors n,
         IsCoprime (toMathlibPolynomial f) (frobeniusPolynomial p d) := by
-  sorry
+  haveI : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  subst hdegree
+  simp only [Hex.Berlekamp.rabinTest, Bool.and_eq_true] at htest
+  obtain ⟨⟨hpos, hdiv⟩, hwit⟩ := htest
+  refine ⟨of_decide_eq_true hpos, ?_, ?_⟩
+  · -- Divisibility leg: transport `f ∣ X^(p^n) - X` from the executable side.
+    have hisZero : (Hex.Berlekamp.frobeniusDiffMod f hmonic
+        (Hex.Berlekamp.basisSize f)).isZero = true := by
+      rw [← Hex.Berlekamp.rabinDividesTest_spec]; exact hdiv
+    have hdvd := (Hex.Berlekamp.dvd_xPowSubX_iff_frobeniusDiffMod_isZero f hmonic _).mpr hisZero
+    rw [← toMathlibPolynomial_xPowSubX]
+    exact toMathlibPolynomial_dvd hdvd
+  · -- Coprimality leg: transport the gcd-unit witnesses, then reduce
+    -- `frobeniusDiffMod` to the absolute `X^(p^d) - X`.
+    intro d hd
+    have hcop := Hex.Berlekamp.rabinCoprimeTest_of_mem_maximalProperDivisors f hmonic hwit hd
+    rw [Hex.Berlekamp.rabinCoprimeTest] at hcop
+    have hcopM :
+        IsCoprime (toMathlibPolynomial f)
+          (toMathlibPolynomial (Hex.Berlekamp.frobeniusDiffMod f hmonic d)) :=
+      isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd hcop
+    have hredM : toMathlibPolynomial f ∣
+        (frobeniusPolynomial p d -
+          toMathlibPolynomial (Hex.Berlekamp.frobeniusDiffMod f hmonic d)) := by
+      have hred := toMathlibPolynomial_dvd
+        (Hex.Berlekamp.dvd_xPowSubX_sub_frobeniusDiffMod f hmonic d)
+      rwa [toMathlibPolynomial_sub, toMathlibPolynomial_xPowSubX] at hred
+    obtain ⟨t, ht⟩ := hredM
+    have hfrob_eq : frobeniusPolynomial p d =
+        toMathlibPolynomial (Hex.Berlekamp.frobeniusDiffMod f hmonic d) +
+          toMathlibPolynomial f * t := by
+      rw [← ht]; ring
+    rw [hfrob_eq]
+    exact hcopM.add_mul_left_right t
 
 /--
 The Mathlib Rabin checks imply the executable test surface once the transport

--- a/progress/20260617_152412_ffe8ef41.md
+++ b/progress/20260617_152412_ffe8ef41.md
@@ -1,0 +1,82 @@
+# Progress - 2026-06-17 (session ffe8ef41, feature #7774)
+
+## Accomplished
+
+Claimed and completed #7774 (feat: prove forward Rabin executable-to-Mathlib
+transport `rabinTest_true_to_mathlib_checks`). Discharged the `sorry` at the
+forward leg of the Rabin executable-to-Mathlib bridge in
+`HexBerlekampMathlib/Basic.lean`.
+
+Key finding: the premise was **sound** and most of the math already existed on
+the executable side. `dvd_xPowSubX_iff_frobeniusDiffMod_isZero`
+(`RabinSoundness.lean`) already proves `f ∣ X^(p^n) - X ↔ frobeniusDiffMod
+vanishes` over `FpPoly`. The work was almost entirely *transport*, not
+re-proving the number theory.
+
+### Executable layer (`HexBerlekamp/RabinSoundness.lean`)
+
+Extracted `dvd_xPowSubX_sub_frobeniusDiffMod` (`f ∣ (xPowSubX k -
+frobeniusDiffMod f hmonic k)`) from the inline `hdvd_diff` block of
+`dvd_xPowSubX_iff_frobeniusDiffMod_isZero` into a standalone public theorem, and
+refactored the iff to consume it. This reduction fact is reused by the
+coprimality-leg transport. Pure refactor — identical proof, no behavior change.
+
+### Mathlib layer (`HexBerlekampMathlib/Basic.lean`)
+
+Added transport helpers and discharged the target:
+- `toMathlibPolynomial_mul` / `_add` (direct `map_mul`/`map_add` of the ring
+  equiv `fpPolyEquiv` — these work without Mathlib ring instances on `FpPoly`).
+- `toMathlibPolynomial_sub` / `_C` / `_X` / `_monomial_one` (coeff-ext, using
+  `toZMod_sub`/`_one`/`_zero`; `map_sub`/`map_one`/`map_zero` are unavailable on
+  `FpPoly` per the Mathlib-free boundary).
+- `toMathlibPolynomial_dvd` (FpPoly custom `∣` → Mathlib `∣` by destructuring
+  the witness and reapplying `toMathlibPolynomial_mul`).
+- `toMathlibPolynomial_xPowSubX : toMathlibPolynomial (xPowSubX k) =
+  frobeniusPolynomial p k`.
+- `primeModulus_of_fact`: bridges `Fact (Nat.Prime p)` → executable
+  `Hex.ZMod64.PrimeModulus p` (the executable gcd/Bezout and modular-division
+  lemmas need it; the target signature only carries `Fact`).
+- `isUnit_toMathlibPolynomial_of_isUnitPolynomial`: a degree-0 nonzero
+  executable constant transports to a Mathlib unit.
+- `isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd`: passing executable
+  gcd-unit check → Mathlib `IsCoprime`, via the executable Bezout identity
+  transported through the ring equiv and divided by the unit gcd.
+
+Main proof `rabinTest_true_to_mathlib_checks`:
+- divisibility leg: `rabinDividesTest → frobeniusDiffMod vanishes →
+  dvd_xPowSubX_iff → f ∣ xPowSubX n` (executable), transported via
+  `toMathlibPolynomial_dvd` + `toMathlibPolynomial_xPowSubX`.
+- coprimality leg: per maximal proper divisor `d`, the gcd-unit witness gives
+  `IsCoprime f diff`; the reduction `f ∣ (xPowSubX d - frobeniusDiffMod d)`
+  transports and `IsCoprime.add_mul_left_right` moves coprimality from the
+  reduced `frobeniusDiffMod` to the absolute `frobeniusPolynomial p d`.
+
+## Verification
+
+- `lake build HexBerlekamp.RabinSoundness` — clean.
+- `lake build HexBerlekampMathlib.Basic` — no errors; target theorem is
+  discharged (absent from the `sorry`-warning list). Remaining sorries are all
+  pre-existing/out-of-scope: `rabinTest_true_of_mathlib_checks` (reverse
+  direction), `toMathlibPolynomial_gcd`, `toMathlibPolynomial_squareFree_coprime`,
+  `irreducible_of_mem_berlekampFactor`.
+- Executable consumers of the refactored `RabinSoundness` build clean:
+  `HexBerlekamp.Conformance`, `HexBerlekampZassenhaus.SmallModSingleton`,
+  `HexConway.Basic`, `HexBerlekamp.DistinctDegree`.
+- Added-line forbidden-token scan: no sorry/axiom/native_decide/TODO/FIXME.
+
+## Current frontier
+
+The forward Rabin transport is now complete. `rabinTest_true_irreducible`
+(which consumes it) no longer depends on this sorry.
+
+## Next step
+
+The reverse direction `rabinTest_true_of_mathlib_checks` is still a sorry — it
+needs the inverse transports (Mathlib `IsCoprime`/divisibility back to the
+executable gcd-unit / `frobeniusDiffMod` vanishing). The new general transport
+helpers (`toMathlibPolynomial_mul/add/sub/C/X/dvd`, `primeModulus_of_fact`) are
+reusable for that and for the `toMathlibPolynomial_gcd` sorry.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7774

Session: `ffe8ef41-5d37-48db-b436-1ccc6734a1f0`

1d014d32 chore: note Fact-to-PrimeModulus bridge in mathlib-boundary skill (#7774)
41b70e1f feat: prove forward Rabin executable-to-Mathlib transport (#7774)

🤖 Prepared with Claude Code