### PR TITLE
fix: migrate berlekamp gcd transport consumers

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -534,31 +534,6 @@ theorem rabinTest_true_of_mathlib_checks
 end Rabin
 
 /--
-**Unsound up-to-unit overstatement — use `toMathlibPolynomial_gcd_normalize`.**
-
-This exact equality is false in general: `Hex.DensePoly.gcd` is the last nonzero
-`xgcdAux` remainder with no monic rescale (`HexPoly/Euclid.lean:913`), while
-Mathlib's `gcd` is `normalize`-canonical. Counterexample over `F₅`:
-`gcd(X²−1, 2X−2) = 2X−2` (leadCoeff `2`) executable, but `X−1` in Mathlib. The
-two sides are only associated; see `toMathlibPolynomial_gcd_associated` and
-`toMathlibPolynomial_gcd_normalize` for the sound primitives.
-
-Retained as an unproved placeholder only because the CI-gated
-`HexBerlekampZassenhausMathlib` consumers (`gcd_monicModularImage_derivative_eq_one`,
-`toMathlibPolynomial_coprime_of_gcdIsUnit`, the `HotPathDiscriminant`
-non-coprimality lemma) still rewrite with it. Removing it requires
-re-specifying the `gcd f f' = 1` square-free precondition of
-`toMathlibPolynomial_squareFree_coprime` / `irreducible_of_berlekampFactor_factors_length_le_one`
-to a `gcdIsUnit`/`IsUnit` hypothesis, then migrating those consumers onto the
-sound transport. See the diagnosis on issue #7763.
--/
-theorem toMathlibPolynomial_gcd
-    [Fact (Nat.Prime p)] (f g : Hex.FpPoly p) :
-    toMathlibPolynomial (Hex.DensePoly.gcd f g) =
-      gcd (toMathlibPolynomial f) (toMathlibPolynomial g) := by
-  sorry
-
-/--
 Executable gcd is associated to Mathlib's gcd after coefficient transport.
 
 `toMathlibPolynomial = fpPolyEquiv` is a ring iso, so executable divisibility
@@ -628,9 +603,68 @@ formal derivative.
 -/
 theorem toMathlibPolynomial_squareFree_coprime
     [Fact (Nat.Prime p)] (f : Hex.FpPoly p)
-    (hsquareFree : Hex.DensePoly.gcd f (Hex.DensePoly.derivative f) = 1) :
+    (hsquareFree :
+      Hex.Berlekamp.isUnitPolynomial
+        (Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)) = true) :
     IsCoprime (toMathlibPolynomial f) (Polynomial.derivative (toMathlibPolynomial f)) := by
-  sorry
+  let g : Hex.FpPoly p := Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)
+  have hg_size : g.size = 1 := by
+    have hdeg : g.degree? = some 0 := by
+      unfold Hex.Berlekamp.isUnitPolynomial at hsquareFree
+      cases h : g.degree? with
+      | none =>
+          rw [h] at hsquareFree
+          simp at hsquareFree
+      | some n =>
+          rw [h] at hsquareFree
+          cases n with
+          | zero => simp
+          | succ n => simp at hsquareFree
+    have hpos : 0 < g.size := by
+      by_contra hnot
+      have hzero : g.size = 0 := by omega
+      have hnone : g.degree? = none :=
+        (Hex.DensePoly.degree?_eq_none_iff g).mpr hzero
+      rw [hdeg] at hnone
+      contradiction
+    have hdeg_size : g.degree? = some (g.size - 1) :=
+      Hex.DensePoly.degree?_eq_some_of_pos_size g hpos
+    rw [hdeg] at hdeg_size
+    injection hdeg_size with hsub
+    omega
+  have hg_pos : 0 < g.size := by omega
+  have hg_coeff_ne : g.coeff 0 ≠ 0 := by
+    have hlast := Hex.DensePoly.coeff_last_ne_zero_of_pos_size g hg_pos
+    simpa [hg_size] using hlast
+  have hg_coeff_zmod_ne :
+      HexModArithMathlib.ZMod64.toZMod (g.coeff 0) ≠ 0 := by
+    intro hzero
+    apply hg_coeff_ne
+    have hinj := (HexModArithMathlib.ZMod64.equiv (p := p)).injective
+    apply hinj
+    simpa using hzero.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
+  have hg_poly_unit : IsUnit (toMathlibPolynomial g) := by
+    have hg_poly_eq :
+        toMathlibPolynomial g =
+          Polynomial.C (HexModArithMathlib.ZMod64.toZMod (g.coeff 0)) := by
+      ext n
+      cases n with
+      | zero =>
+          simp [coeff_toMathlibPolynomial]
+      | succ n =>
+          rw [coeff_toMathlibPolynomial,
+            Hex.DensePoly.coeff_eq_zero_of_size_le g (by omega)]
+          rw [Polynomial.coeff_C]
+          exact HexModArithMathlib.ZMod64.toZMod_zero (p := p)
+    rw [hg_poly_eq]
+    exact Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr hg_coeff_zmod_ne)
+  have hmath_gcd_unit :
+      IsUnit (gcd (toMathlibPolynomial f)
+        (Polynomial.derivative (toMathlibPolynomial f))) := by
+    rw [← toMathlibPolynomial_derivative f]
+    exact (toMathlibPolynomial_gcd_associated f (Hex.DensePoly.derivative f)).isUnit
+      hg_poly_unit
+  exact (gcd_isUnit_iff_isRelPrime.mp hmath_gcd_unit).isCoprime
 
 /--
 Every factor emitted by executable Berlekamp factorization is irreducible after
@@ -704,9 +738,16 @@ irreducibility theorem applies directly.
 theorem irreducible_of_berlekampFactor_factors_length_le_one
     (f : Hex.FpPoly p) (hmonic : Hex.DensePoly.Monic f)
     [Lean.Grind.Field (Hex.ZMod64 p)] [Hex.ZMod64.PrimeModulus p]
-    (hsquareFree : Hex.DensePoly.gcd f (Hex.DensePoly.derivative f) = 1)
+    (hsquareFree :
+      Hex.Berlekamp.isUnitPolynomial
+        (Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)) = true)
     (hsmall : (Hex.Berlekamp.berlekampFactor f hmonic).factors.length ≤ 1) :
     Irreducible (toMathlibPolynomial f) := by
+  have hsquareFree_common :
+      ∀ d, d ∣ f → d ∣ Hex.DensePoly.derivative f →
+        Hex.Berlekamp.isUnitPolynomial d = true := by
+    intro d hdf hdd
+    exact Hex.Berlekamp.isUnitPolynomial_of_dvd_gcd_isUnit hdf hdd hsquareFree
   cases hfactors : (Hex.Berlekamp.berlekampFactor f hmonic).factors with
   | nil =>
       exact False.elim
@@ -720,8 +761,8 @@ theorem irreducible_of_berlekampFactor_factors_length_le_one
             exact hprod
           have hirr_g :
               Irreducible (toMathlibPolynomial g) :=
-            irreducible_of_mem_berlekampFactor_of_gcd_eq_one
-              f hmonic hsquareFree g (by simp [hfactors])
+            irreducible_of_mem_berlekampFactor
+              f hmonic hsquareFree_common g (by simp [hfactors])
           simpa [hg_eq] using hirr_g
       | cons h rest =>
           simp [hfactors] at hsmall

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7466,7 +7466,7 @@ squarefreeness from `isGoodPrime` through `monicModularImage`; apply the
 generalized `quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared`
 helper with `X := monicModularImage (modP p core)` to walk the list.  The
 no-squared invariant on the modular image is the local Mathlib-side form
-of `gcd_monicModularImage_derivative_eq_one`, instantiated through
+of `gcd_monicModularImage_derivative_isUnit_local`, instantiated through
 `Hex.Berlekamp.isUnitPolynomial_of_squareFree_of_squared_dvd`.
 
 This is the third in the chain of `factorsModP`-side dischargers
@@ -7636,7 +7636,7 @@ theorem factorsModP_monic_of_factorsModPBerlekampForm
   rw [← hg'_eq]
   exact Hex.monicModularImage_monic hprime g' (Hex.isZero_false_of_ne_zero hg'_ne)
 
-/-- Square-freeness of a nonzero `FpPoly` transfers to its monic representative.
+/- Square-freeness of a nonzero `FpPoly` transfers to its monic representative.
 
 Local copy of the IntReductionMod helper of the same name (the canonical
 version lives at `HexBerlekampZassenhausMathlib/IntReductionMod.lean:307`).
@@ -7644,12 +7644,66 @@ Duplicated here because `IntReductionMod` imports `Basic`; the proof routes
 through `IsCoprime` in `Polynomial (ZMod p)` using
 `toMathlibPolynomial_squareFree_coprime` and the `toMathlibPolynomial_scale`
 identification for the unit scalar `(leadingCoeff f)⁻¹`. -/
-private theorem gcd_monicModularImage_derivative_eq_one_local
+/-- A bridged executable polynomial that transports to a unit has executable
+size one, hence passes the `gcdIsUnit` size check when used as a gcd. -/
+private theorem size_eq_one_of_toMathlibPolynomial_isUnit_local
+    {p : Nat} [Hex.ZMod64.Bounds p] [Fact (Nat.Prime p)]
+    {g : Hex.FpPoly p}
+    (h : IsUnit (HexBerlekampMathlib.toMathlibPolynomial g)) :
+    g.size = 1 := by
+  rcases Nat.lt_or_ge g.size 1 with hlt | hge
+  · exfalso
+    have hsize_zero : g.size = 0 := by omega
+    have hzero : HexBerlekampMathlib.toMathlibPolynomial g = 0 := by
+      apply Polynomial.ext
+      intro n
+      rw [Polynomial.coeff_zero, HexBerlekampMathlib.coeff_toMathlibPolynomial,
+        Hex.DensePoly.coeff_eq_zero_of_size_le _ (show g.size ≤ n by omega)]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
+    exact not_isUnit_zero (hzero ▸ h)
+  · by_contra hne
+    have hpos : 0 < g.size := by omega
+    have hge2 : 2 ≤ g.size := by omega
+    have hcoeff_ne : g.coeff (g.size - 1) ≠ 0 :=
+      Hex.DensePoly.coeff_last_ne_zero_of_pos_size g hpos
+    have hcoeff_zmod_ne :
+        HexModArithMathlib.ZMod64.toZMod (g.coeff (g.size - 1)) ≠ 0 := by
+      intro hzero
+      apply hcoeff_ne
+      have hinj := (HexModArithMathlib.ZMod64.equiv (p := p)).injective
+      apply hinj
+      simpa using hzero.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
+    have hcoeff_poly_ne :
+        (HexBerlekampMathlib.toMathlibPolynomial g).coeff (g.size - 1) ≠ 0 := by
+      rw [HexBerlekampMathlib.coeff_toMathlibPolynomial]
+      exact hcoeff_zmod_ne
+    have hpos_natDeg :
+        0 < (HexBerlekampMathlib.toMathlibPolynomial g).natDegree := by
+      have hle := Polynomial.le_natDegree_of_ne_zero hcoeff_poly_ne
+      omega
+    exact Polynomial.not_isUnit_of_natDegree_pos _ hpos_natDeg h
+
+/-- The Zassenhaus `gcdIsUnit` size check implies Berlekamp's nonzero-constant
+unit-polynomial predicate. -/
+private theorem isUnitPolynomial_of_gcdIsUnit_local
+    {p : Nat} [Hex.ZMod64.Bounds p] {g : Hex.FpPoly p}
+    (h : Hex.gcdIsUnit g = true) :
+    Hex.Berlekamp.isUnitPolynomial g = true := by
+  unfold Hex.gcdIsUnit at h
+  change (g.size == 1) = true at h
+  have hsize : g.size = 1 := beq_iff_eq.mp h
+  unfold Hex.Berlekamp.isUnitPolynomial
+  have hpos : 0 < g.size := by omega
+  rw [Hex.DensePoly.degree?_eq_some_of_pos_size g hpos, hsize]
+
+private theorem gcd_monicModularImage_derivative_isUnit_local
     {p : Nat} [Hex.ZMod64.Bounds p] [Fact (Nat.Prime p)]
     (f : Hex.FpPoly p) (hzero : f.isZero = false)
-    (hsquareFree : Hex.DensePoly.gcd f (Hex.DensePoly.derivative f) = 1) :
-    Hex.DensePoly.gcd (Hex.monicModularImage f)
-        (Hex.DensePoly.derivative (Hex.monicModularImage f)) = 1 := by
+    (hsquareFree :
+      Hex.gcdIsUnit (Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)) = true) :
+    Hex.gcdIsUnit
+      (Hex.DensePoly.gcd (Hex.monicModularImage f)
+        (Hex.DensePoly.derivative (Hex.monicModularImage f))) = true := by
   let u : Hex.ZMod64 p := (Hex.DensePoly.leadingCoeff f)⁻¹
   have hmonic_eq : Hex.monicModularImage f = Hex.DensePoly.scale u f := by
     simpa [u] using
@@ -7663,7 +7717,8 @@ private theorem gcd_monicModularImage_derivative_eq_one_local
         IsCoprime
           (HexBerlekampMathlib.toMathlibPolynomial f)
           (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) :=
-      HexBerlekampMathlib.toMathlibPolynomial_squareFree_coprime f hsquareFree
+      HexBerlekampMathlib.toMathlibPolynomial_squareFree_coprime f
+        (isUnitPolynomial_of_gcdIsUnit_local hsquareFree)
     have hu_ne : HexModArithMathlib.ZMod64.toZMod u ≠ 0 := by
       have hp_hex : Hex.Nat.Prime p := by
         constructor
@@ -7694,47 +7749,29 @@ private theorem gcd_monicModularImage_derivative_eq_one_local
     exact (isCoprime_mul_unit_left hC_unit
       (HexBerlekampMathlib.toMathlibPolynomial f)
       (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f))).mpr hcop_f
-  have hmath_gcd :
-      gcd
-        (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-        (Polynomial.derivative
-          (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))) = 1 := by
-    have hunit :
-        IsUnit
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) :=
-      gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
-    have hnorm :
-        normalize
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) =
-        gcd
+  let g : Hex.FpPoly p :=
+    Hex.DensePoly.gcd (Hex.monicModularImage f)
+      (Hex.DensePoly.derivative (Hex.monicModularImage f))
+  have hunit_math :
+      IsUnit
+        (gcd
           (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
           (Polynomial.derivative
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))) :=
-      normalize_gcd _ _
-    have hone :
-        normalize
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) = 1 :=
-      normalize_eq_one.mpr hunit
-    simpa [hnorm] using hone
-  apply HexBerlekampMathlib.fpPolyEquiv.injective
-  change
-    HexBerlekampMathlib.toMathlibPolynomial
-        (Hex.DensePoly.gcd (Hex.monicModularImage f)
-          (Hex.DensePoly.derivative (Hex.monicModularImage f))) =
-      HexBerlekampMathlib.toMathlibPolynomial (1 : Hex.FpPoly p)
-  rw [HexBerlekampMathlib.toMathlibPolynomial_gcd,
-      HexBerlekampMathlib.toMathlibPolynomial_derivative,
-      toMathlibPolynomial_one]
-  exact hmath_gcd
+            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) :=
+    gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
+  have hunit_transport :
+      IsUnit (HexBerlekampMathlib.toMathlibPolynomial g) := by
+    rw [← HexBerlekampMathlib.toMathlibPolynomial_derivative] at hunit_math
+    exact
+      (HexBerlekampMathlib.toMathlibPolynomial_gcd_associated
+        (Hex.monicModularImage f)
+        (Hex.DensePoly.derivative (Hex.monicModularImage f))).symm.isUnit
+        hunit_math
+  have hg_size : g.size = 1 :=
+    size_eq_one_of_toMathlibPolynomial_isUnit_local hunit_transport
+  unfold Hex.gcdIsUnit
+  change (g.size == 1) = true
+  exact beq_iff_eq.mpr hg_size
 
 private theorem derivative_scale_local
     {p : Nat} [Hex.ZMod64.Bounds p]
@@ -7785,7 +7822,7 @@ some raw Berlekamp factor `g`.  `irreducible_of_mem_berlekampFactor` gives
 original, and `Associated.irreducible` transfers the irreducibility.
 
 The square-freeness premise of `irreducible_of_mem_berlekampFactor` is
-discharged via `gcd_monicModularImage_derivative_eq_one_local` applied to
+discharged via `gcd_monicModularImage_derivative_isUnit_local` applied to
 the modular square-freeness from `Hex.isGoodPrime_squareFreeModP`.
 
 This is the per-index irreducibility component consumed by the

--- a/HexBerlekampZassenhausMathlib/HotPathDiscriminant.lean
+++ b/HexBerlekampZassenhausMathlib/HotPathDiscriminant.lean
@@ -76,16 +76,17 @@ private theorem toMathlibPolynomial_not_coprime_of_gcdIsUnit_false
         (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) := by
   intro hcop
   let g : Hex.FpPoly p := Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)
-  have hmath_gcd :
-      gcd
-        (HexBerlekampMathlib.toMathlibPolynomial f)
-        (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) =
-          HexBerlekampMathlib.toMathlibPolynomial g := by
-    rw [← HexBerlekampMathlib.toMathlibPolynomial_derivative f]
-    rw [← HexBerlekampMathlib.toMathlibPolynomial_gcd f (Hex.DensePoly.derivative f)]
+  have hmath_gcd_unit :
+      IsUnit
+        (gcd
+          (HexBerlekampMathlib.toMathlibPolynomial f)
+          (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f))) :=
+    gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
   have hg_unit : IsUnit (HexBerlekampMathlib.toMathlibPolynomial g) := by
-    rw [← hmath_gcd]
-    exact gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
+    rw [← HexBerlekampMathlib.toMathlibPolynomial_derivative] at hmath_gcd_unit
+    exact
+      (HexBerlekampMathlib.toMathlibPolynomial_gcd_associated
+        f (Hex.DensePoly.derivative f)).symm.isUnit hmath_gcd_unit
   have hg_size : g.size = 1 :=
     size_eq_one_of_toMathlibPolynomial_isUnit hg_unit
   have hsqf' : Hex.gcdIsUnit g = true := by

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -321,6 +321,59 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton
     hfModP_eq hprim hlc_map_ne hirr_fModP
 
 set_option maxHeartbeats 4000000 in
+/-- A bridged executable polynomial that transports to a unit has executable
+size one, hence passes the `gcdIsUnit` size check when used as a gcd. -/
+private theorem size_eq_one_of_toMathlibPolynomial_isUnit
+    {p : Nat} [Hex.ZMod64.Bounds p] [Fact (Nat.Prime p)]
+    {g : Hex.FpPoly p}
+    (h : IsUnit (HexBerlekampMathlib.toMathlibPolynomial g)) :
+    g.size = 1 := by
+  rcases Nat.lt_or_ge g.size 1 with hlt | hge
+  · exfalso
+    have hsize_zero : g.size = 0 := by omega
+    have hzero : HexBerlekampMathlib.toMathlibPolynomial g = 0 := by
+      apply Polynomial.ext
+      intro n
+      rw [Polynomial.coeff_zero, HexBerlekampMathlib.coeff_toMathlibPolynomial,
+        Hex.DensePoly.coeff_eq_zero_of_size_le _ (show g.size ≤ n by omega)]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
+    exact not_isUnit_zero (hzero ▸ h)
+  · by_contra hne
+    have hpos : 0 < g.size := by omega
+    have hge2 : 2 ≤ g.size := by omega
+    have hcoeff_ne : g.coeff (g.size - 1) ≠ 0 :=
+      Hex.DensePoly.coeff_last_ne_zero_of_pos_size g hpos
+    have hcoeff_zmod_ne :
+        HexModArithMathlib.ZMod64.toZMod (g.coeff (g.size - 1)) ≠ 0 := by
+      intro hzero
+      apply hcoeff_ne
+      have hinj := (HexModArithMathlib.ZMod64.equiv (p := p)).injective
+      apply hinj
+      simpa using hzero.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
+    have hcoeff_poly_ne :
+        (HexBerlekampMathlib.toMathlibPolynomial g).coeff (g.size - 1) ≠ 0 := by
+      rw [HexBerlekampMathlib.coeff_toMathlibPolynomial]
+      exact hcoeff_zmod_ne
+    have hpos_natDeg :
+        0 < (HexBerlekampMathlib.toMathlibPolynomial g).natDegree := by
+      have hle := Polynomial.le_natDegree_of_ne_zero hcoeff_poly_ne
+      omega
+    exact Polynomial.not_isUnit_of_natDegree_pos _ hpos_natDeg h
+
+/-- The Zassenhaus `gcdIsUnit` size check implies Berlekamp's nonzero-constant
+unit-polynomial predicate. -/
+private theorem isUnitPolynomial_of_gcdIsUnit
+    {p : Nat} [Hex.ZMod64.Bounds p] {g : Hex.FpPoly p}
+    (h : Hex.gcdIsUnit g = true) :
+    Hex.Berlekamp.isUnitPolynomial g = true := by
+  unfold Hex.gcdIsUnit at h
+  change (g.size == 1) = true at h
+  have hsize : g.size = 1 := beq_iff_eq.mp h
+  unfold Hex.Berlekamp.isUnitPolynomial
+  have hpos : 0 < g.size := by omega
+  rw [Hex.DensePoly.degree?_eq_some_of_pos_size g hpos, hsize]
+
+set_option maxHeartbeats 4000000 in
 /--
 The executable square-free check records that the raw Euclidean gcd is a
 nonzero constant.  After transport to Mathlib this is enough to give
@@ -334,61 +387,22 @@ private theorem toMathlibPolynomial_coprime_of_gcdIsUnit
       Hex.gcdIsUnit (Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)) = true) :
     IsCoprime
       (HexBerlekampMathlib.toMathlibPolynomial f)
-      (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) := by
-  let g : Hex.FpPoly p := Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)
-  have hg_size : g.size = 1 := by
-    unfold Hex.gcdIsUnit at hsquareFree
-    change (g.size == 1) = true at hsquareFree
-    exact beq_iff_eq.mp hsquareFree
-  have hg_pos : 0 < g.size := by omega
-  have hg_coeff_ne : g.coeff 0 ≠ 0 := by
-    have hlast := Hex.DensePoly.coeff_last_ne_zero_of_pos_size g hg_pos
-    simpa [hg_size] using hlast
-  have hg_coeff_zmod_ne :
-      HexModArithMathlib.ZMod64.toZMod (g.coeff 0) ≠ 0 := by
-    intro hzero
-    apply hg_coeff_ne
-    have hinj := (HexModArithMathlib.ZMod64.equiv (p := p)).injective
-    apply hinj
-    simpa using hzero.trans HexModArithMathlib.ZMod64.toZMod_zero.symm
-  have hg_poly_unit :
-      IsUnit (HexBerlekampMathlib.toMathlibPolynomial g) := by
-    have hg_poly_eq :
-        HexBerlekampMathlib.toMathlibPolynomial g =
-          Polynomial.C (HexModArithMathlib.ZMod64.toZMod (g.coeff 0)) := by
-      ext n
-      cases n with
-      | zero =>
-          simp [HexBerlekampMathlib.coeff_toMathlibPolynomial]
-      | succ n =>
-          rw [HexBerlekampMathlib.coeff_toMathlibPolynomial,
-            Hex.DensePoly.coeff_eq_zero_of_size_le g (by omega)]
-          rw [Polynomial.coeff_C]
-          exact HexModArithMathlib.ZMod64.toZMod_zero (p := p)
-    rw [hg_poly_eq]
-    exact Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr hg_coeff_zmod_ne)
-  have hmath_gcd :
-      gcd
-        (HexBerlekampMathlib.toMathlibPolynomial f)
-        (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) =
-          HexBerlekampMathlib.toMathlibPolynomial g := by
-    rw [← HexBerlekampMathlib.toMathlibPolynomial_derivative f]
-    rw [← HexBerlekampMathlib.toMathlibPolynomial_gcd f (Hex.DensePoly.derivative f)]
-  exact (gcd_isUnit_iff_isRelPrime.mp (by
-    rw [hmath_gcd]
-    exact hg_poly_unit)).isCoprime
+      (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f)) :=
+  HexBerlekampMathlib.toMathlibPolynomial_squareFree_coprime f
+    (isUnitPolynomial_of_gcdIsUnit hsquareFree)
 
 /--
 Scaling a nonzero modular image to its monic representative preserves the
 executable square-free gcd check used by Berlekamp.
 -/
-private theorem gcd_monicModularImage_derivative_eq_one
+private theorem gcd_monicModularImage_derivative_isUnit
     {p : Nat} [Hex.ZMod64.Bounds p] [Fact (Nat.Prime p)]
     (f : Hex.FpPoly p) (hzero : f.isZero = false)
     (hsquareFree :
       Hex.gcdIsUnit (Hex.DensePoly.gcd f (Hex.DensePoly.derivative f)) = true) :
-    Hex.DensePoly.gcd (Hex.monicModularImage f)
-        (Hex.DensePoly.derivative (Hex.monicModularImage f)) = 1 := by
+    Hex.gcdIsUnit
+      (Hex.DensePoly.gcd (Hex.monicModularImage f)
+        (Hex.DensePoly.derivative (Hex.monicModularImage f))) = true := by
   let u : Hex.ZMod64 p := (Hex.DensePoly.leadingCoeff f)⁻¹
   have hmonic_eq : Hex.monicModularImage f = Hex.DensePoly.scale u f := by
     unfold Hex.monicModularImage
@@ -433,47 +447,29 @@ private theorem gcd_monicModularImage_derivative_eq_one
     exact (isCoprime_mul_unit_left hC_unit
       (HexBerlekampMathlib.toMathlibPolynomial f)
       (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f))).mpr hcop_f
-  have hmath_gcd :
-      gcd
-        (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-        (Polynomial.derivative
-          (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))) = 1 := by
-    have hunit :
-        IsUnit
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) :=
-      gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
-    have hnorm :
-        normalize
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) =
-        gcd
+  let g : Hex.FpPoly p :=
+    Hex.DensePoly.gcd (Hex.monicModularImage f)
+      (Hex.DensePoly.derivative (Hex.monicModularImage f))
+  have hunit_math :
+      IsUnit
+        (gcd
           (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
           (Polynomial.derivative
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))) :=
-      normalize_gcd _ _
-    have hone :
-        normalize
-          (gcd
-            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f))
-            (Polynomial.derivative
-              (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) = 1 :=
-      normalize_eq_one.mpr hunit
-    simpa [hnorm] using hone
-  apply HexBerlekampMathlib.fpPolyEquiv.injective
-  change
-    HexBerlekampMathlib.toMathlibPolynomial
-        (Hex.DensePoly.gcd (Hex.monicModularImage f)
-          (Hex.DensePoly.derivative (Hex.monicModularImage f))) =
-      HexBerlekampMathlib.toMathlibPolynomial (1 : Hex.FpPoly p)
-  rw [HexBerlekampMathlib.toMathlibPolynomial_gcd,
-      HexBerlekampMathlib.toMathlibPolynomial_derivative,
-      toMathlibPolynomial_one]
-  exact hmath_gcd
+            (HexBerlekampMathlib.toMathlibPolynomial (Hex.monicModularImage f)))) :=
+    gcd_isUnit_iff_isRelPrime.mpr hcop.isRelPrime
+  have hunit_transport :
+      IsUnit (HexBerlekampMathlib.toMathlibPolynomial g) := by
+    rw [← HexBerlekampMathlib.toMathlibPolynomial_derivative] at hunit_math
+    exact
+      (HexBerlekampMathlib.toMathlibPolynomial_gcd_associated
+        (Hex.monicModularImage f)
+        (Hex.DensePoly.derivative (Hex.monicModularImage f))).symm.isUnit
+        hunit_math
+  have hg_size : g.size = 1 :=
+    size_eq_one_of_toMathlibPolynomial_isUnit hunit_transport
+  unfold Hex.gcdIsUnit
+  change (g.size == 1) = true
+  exact beq_iff_eq.mpr hg_size
 
 set_option maxHeartbeats 4000000
 
@@ -505,12 +501,13 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
       (Int.castRingHom (ZMod primeData.p))
         (HexPolyZMathlib.toPolynomial core).leadingCoeff ≠ 0)
     (hsquareFree_monic :
-      Hex.DensePoly.gcd
+      Hex.gcdIsUnit
+        (Hex.DensePoly.gcd
         (@Hex.monicModularImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds core))
         (Hex.DensePoly.derivative
           (@Hex.monicModularImage primeData.p primeData.bounds
-            (@Hex.ZPoly.modP primeData.p primeData.bounds core))) = 1) :
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core)))) = true) :
     Hex.ZPoly.Irreducible core := by
   letI := primeData.bounds
   have hprime_hex : Hex.Nat.Prime primeData.p :=
@@ -551,7 +548,7 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
     HexBerlekampMathlib.irreducible_of_berlekampFactor_factors_length_le_one
       (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
       (Hex.monicModularImage_monic hprime_hex (Hex.ZPoly.modP primeData.p core) hzero)
-      hsquareFree_monic hfactors_len_le
+      (isUnitPolynomial_of_gcdIsUnit hsquareFree_monic) hfactors_len_le
   -- Express monicModularImage fModP as scale (leadingCoeff fModP)⁻¹ fModP.
   have hmonicImg_eq :
       Hex.monicModularImage (Hex.ZPoly.modP primeData.p core) =
@@ -665,13 +662,14 @@ theorem squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squ
     · exact absurd h (Nat.ne_of_lt hmlt)
   haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
-      Hex.DensePoly.gcd
+      Hex.gcdIsUnit
+        (Hex.DensePoly.gcd
         (@Hex.monicModularImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds core))
         (Hex.DensePoly.derivative
           (@Hex.monicModularImage primeData.p primeData.bounds
-            (@Hex.ZPoly.modP primeData.p primeData.bounds core))) = 1 :=
-    gcd_monicModularImage_derivative_eq_one
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core)))) = true :=
+    gcd_monicModularImage_derivative_isUnit
       (p := primeData.p) (Hex.ZPoly.modP primeData.p core) hzero hsquareFree_modP
   exact squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData
     core primeData hselected hsmall hprim hlc_map_ne hsquareFree_monic
@@ -681,7 +679,7 @@ successful `choosePrimeData?` run is squarefree.
 
 The executable `isGoodPrime` check certifies `squareFreeModP core p`
 (`gcdIsUnit (gcd (modP core) (modP core)') = true`);
-`gcd_monicModularImage_derivative_eq_one` lifts this to the monic image's
+`gcd_monicModularImage_derivative_isUnit` lifts this to the monic image's
 coprimality with its derivative, which is exactly `Polynomial.Separable` over the
 field `ZMod p`, hence `Squarefree`.  This is the modular squarefreeness datum the
 mod-`p` disjointness lemma `modPFactorSubset_disjoint_of_not_associated` needs but
@@ -716,13 +714,14 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData
     · exact absurd h (Nat.ne_of_lt hmlt)
   haveI : Fact (_root_.Nat.Prime primeData.p) := ⟨hprime⟩
   have hsquareFree_monic :
-      Hex.DensePoly.gcd
+      Hex.gcdIsUnit
+        (Hex.DensePoly.gcd
         (@Hex.monicModularImage primeData.p primeData.bounds
           (@Hex.ZPoly.modP primeData.p primeData.bounds core))
         (Hex.DensePoly.derivative
           (@Hex.monicModularImage primeData.p primeData.bounds
-            (@Hex.ZPoly.modP primeData.p primeData.bounds core))) = 1 :=
-    gcd_monicModularImage_derivative_eq_one
+            (@Hex.ZPoly.modP primeData.p primeData.bounds core)))) = true :=
+    gcd_monicModularImage_derivative_isUnit
       (p := primeData.p) (Hex.ZPoly.modP primeData.p core) hzero hsquareFree_modP
   have hsep :
       IsCoprime
@@ -732,7 +731,8 @@ theorem squarefree_toMathlibPolynomial_monicModPImage_of_choosePrimeData
           (HexBerlekampMathlib.toMathlibPolynomial
             (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)))) :=
     HexBerlekampMathlib.toMathlibPolynomial_squareFree_coprime
-      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) hsquareFree_monic
+      (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core))
+      (isUnitPolynomial_of_gcdIsUnit hsquareFree_monic)
   have hsf :
       Squarefree
         (HexBerlekampMathlib.toMathlibPolynomial

--- a/progress/20260617_153744_2bd826fc.md
+++ b/progress/20260617_153744_2bd826fc.md
@@ -1,0 +1,44 @@
+# Progress - 2026-06-17 (session 2bd826fc, work #7771)
+
+## Accomplished
+
+Claimed #7771 and migrated the Berlekamp gcd transport consumers off the
+unsound exact `toMathlibPolynomial_gcd` placeholder.
+
+- Deleted `HexBerlekampMathlib.toMathlibPolynomial_gcd` and its `sorry`.
+- Proved `toMathlibPolynomial_squareFree_coprime` from the sound
+  `Hex.Berlekamp.isUnitPolynomial (gcd f f') = true` precondition.
+- Re-specified `irreducible_of_berlekampFactor_factors_length_le_one` to use
+  the same unit-gcd predicate and route through the existing common-divisor
+  square-free proof.
+- Updated the Zassenhaus consumers in `IntReductionMod`, `Basic`, and
+  `HotPathDiscriminant` to use associated gcd transport / unit-gcd adapters
+  rather than exact executable gcd equality.
+
+Verification:
+- `grep -c sorry HexBerlekampMathlib/Basic.lean`: 5 before, 3 after.
+- `lake build HexBerlekampMathlib.Basic`
+- `lake build HexBerlekampZassenhausMathlib.Basic`
+- `lake build HexBerlekampZassenhausMathlib.IntReductionMod`
+- `lake build HexBerlekampZassenhausMathlib`
+- `lake build HexBerlekampZassenhaus`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- Added-line forbidden-token scan over touched Lean files: no matches.
+
+## Current frontier
+
+The exact-gcd placeholder is gone. Downstream Zassenhaus code now consumes
+unit-gcd / associatedness-shaped facts, so the Berlekamp transport surface no
+longer states the false representative equality.
+
+## Next step
+
+The remaining `sorry`s in `HexBerlekampMathlib/Basic.lean` are unrelated Rabin
+and Berlekamp irreducibility placeholders. Future work can continue proving
+those headline bridge facts without relying on exact executable gcd equality.
+
+## Blockers
+
+None for this session. The worktree still contains a pre-existing unrelated
+`.claude/CLAUDE.md` modification, which was not touched or staged.


### PR DESCRIPTION
Closes #7771

Session: `2bd826fc-f585-455a-b4a4-48351d43d87a`

96101f5a fix: migrate berlekamp gcd transport consumers

🤖 Prepared with Claude Code