### PR TITLE
feat: prove reverse Rabin transport (rabinTest_true_of_mathlib_checks)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,3 +120,37 @@ project, so the rule is "no parallelism in CI." Routine timing-
 sensitive runs live on a separate scheduled workflow on dedicated
 hardware (per [SPEC/benchmarking.md](../SPEC/benchmarking.md)),
 not on the merge-gating workflows.
+
+
+# Pod Agent Session
+
+You are running as an autonomous agent launched by `pod`. This is a
+non-interactive session via `claude -p` — there is no human to answer
+questions. Never ask for confirmation or approval. Just do the work.
+
+Each agent runs in its own git worktree on its own branch, coordinating
+via GitHub issues, labels, and PRs. The `coordination` script is already
+on your PATH — just run it directly (e.g. `coordination orient`,
+`coordination claim 42`). Do NOT search for it or try to locate it.
+
+Session UUID is available as `$POD_SESSION_ID`.
+
+## Agent Types
+
+- **Planners** (`/plan`): create work items as GitHub issues, then exit
+- **Workers** (`/feature`, `/review`, `/summarize`, `/meditate`): claim
+  and execute issues using the `agent-worker-flow` skill
+- **Repair** (`/repair`): salvage unhealthy PRs (merge conflicts, failed
+  CI, stuck CI) using the `pr-repair-flow` skill. Dispatched by pod ahead
+  of planners and workers whenever `coordination list-pr-repair` reports
+  candidates. Two outcomes only: salvaged or abandoned (→ `replan` on the
+  linked issue). No escalation to humans.
+
+See your `/command` file and the relevant skill (`agent-worker-flow` or
+`pr-repair-flow`) for the full workflow.
+
+## Off-limits Files
+
+Agents must not modify the project's top-level CLAUDE.md (`.claude/CLAUDE.md`)
+or roadmap file (`PLAN.md`). PRs touching these files are rejected by
+`coordination create-pr`. Update skills and commands instead.

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -20,19 +20,6 @@ cycle described in the project's CLAUDE.md.
 After each coherent chunk of changes, build, test, and commit following the
 project's conventions. Each commit must compile and pass tests.
 
-### Phase 6 doc-batch gotcha: docstrings on `omit ... in` lemmas
-
-A `/-- ... -/` docstring must sit *between* the `omit [...] in` modifier
-and the `private theorem`/`def`, not before `omit`. Placing it before the
-`omit` line is a parse error (`unexpected token 'omit'`). Put it directly
-on the declaration:
-
-```
-omit [DecidableEq R] in
-/-- ... -/
-private theorem foo ...
-```
-
 ## Reflect
 
 Run `/reflect` before finishing.

--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -25,20 +25,10 @@ immediately with `ABORT: no issue number provided`.
    `coordination claim <N> --label <type>`. Do **NOT** use
    `coordination list-unclaimed` — you are not picking from the
    queue.
-   **Exception — `replan` worker type.** `replan` issues are
-   deliberately *unclaimable*: `coordination claim <N> --label replan`
-   returns `CLAIM FAILED: Issue #<N> needs replan`. Do **not** treat
-   this as an abort. Replan triages issues directly (edit body/labels,
-   close with forward links) via the `replan` skill — there is no
-   claim and no PR. Skip the claim, read the `replan` skill, and triage
-   `#<N>` per its disposition rules. If `#<N>` no longer carries the
-   `replan` label (already triaged by a concurrent session), confirm
-   the disposition is correct and exit without further edits.
 4. **If the claim fails** (issue already claimed by another agent,
-   issue closed, issue not labelled with the worker type, etc.) — and
-   the worker type is **not** `replan` — exit immediately. Print
-   `ABORT: claim failed for #<N>` and do nothing else. No worktree
-   commits, no branches, no PR.
+   issue closed, issue not labelled with the worker type, etc.),
+   exit immediately. Print `ABORT: claim failed for #<N>` and do
+   nothing else. No worktree commits, no branches, no PR.
 5. Once the claim succeeds, **execute the issue end-to-end**
    following the standard worker flow for the matched type
    (implementation, build, tests, commit, push, open PR).

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -110,12 +110,6 @@ Each issue body MUST be **self-contained**:
 **Sizing**: max 3 deliverables, ~2 files, ~200 lines. Over 300 lines → split.
 When in doubt, split. Each issue must have a single logical concern.
 
-**Lean doc-batch issues**: for a declaration carrying an `omit … in`
-modifier, the `/-- … -/` docstring goes *between* the `omit … in` line
-and the `theorem`/`def` keyword, never above the `omit` line (a docstring
-above `omit` is a parse error). Do not instruct workers to place it above
-the `omit` line.
-
 **Stage granularity**: If the project roadmap has "stages" or "phases", **never
 create an issue that spans multiple stages**. Each issue belongs to exactly one
 stage.

--- a/.claude/commands/replan.md
+++ b/.claude/commands/replan.md
@@ -64,17 +64,6 @@ the following:
 - **Still valid, body stale**: update the issue body with current
   state, then remove the `replan` label.
 
-**Concurrency: check for a concurrent disposition before reverting.**
-Many sessions share one token, so a candidate can be triaged out from
-under you mid-session. Before reopening or reverting any candidate whose
-state changed unexpectedly (especially a close you did not make), run
-`gh issue list --search "<N> in:body,comments" --state all` to find a
-replacement issue that references it. If a concurrent planner already
-closed it forward to a successor, **adopt that disposition** (re-close
-forward, rewire dependents like `depends-on: #<N>` to the successor) —
-do not reopen and create a competing issue. Reopening a
-forward-closed issue causes a worker to claim and immediately skip it.
-
 Process **every** candidate from `list-replan` before exiting.
 
 ## Step 4: Exit

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -39,14 +39,6 @@ Rotate through these areas across sessions:
 **Security**:
 - Check for new issues in recent code, verify past fixes
 
-## Posting Your Review
-
-`gh pr review <N> --approve` fails on agent-authored PRs ("Can not approve
-your own pull request") — every agent commits under the same GitHub
-account, so all PRs are self-authored. Skip `gh pr review` entirely and
-post findings as a plain `gh pr comment <N> --body-file ...`. State your
-verdict (approve / changes-requested) in the comment text.
-
 ## Updating Skills
 
 When you discover a recurring pattern or encounter a situation not covered by

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -150,34 +150,11 @@ Check that the plan's assumptions still hold:
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
 
-**Closed dependency ≠ delivered dependency.** When the issue says to
-compose a bound/lemma/API "from #N", do not trust `#N` being closed. The
-replan-triage step closes a *skipped* issue as `COMPLETED` while forwarding
-its real scope to a successor (`#N` -> `#N'` -> `#N''`), so a chain of
-`CLOSED COMPLETED` issues can all be premise-skips with the deliverable
-still unbuilt. Before deep-reading consumer code, check the named
-dependency's closing comments (`gh issue view #N --json comments`) and grep
-the codebase for the actual artifact (a *proof* concluding the bound, not a
-hypothesis of the same shape). If the artifact is absent, the premise is
-stale: comment with evidence, `add-dep` on the live successor, and skip.
-
 If stale:
 ```
 coordination skip <issue-number> "reason: <what changed>"
 ```
 Go back to Step 1 and try the next issue.
-
-**Already-done duplicates (especially doc-coverage issues)**: planner-
-generated batches are sometimes already complete on `main`. Before
-writing anything, confirm the work is genuinely absent. For "add
-docstrings to X" issues, grep each named declaration for an actual
-`/-- ... -/` block *above* it — and note the docstring can sit one line
-above an `@[simp]`/`@[grind]` attribute, so a check of only the
-immediately-preceding line gives a false "undocumented" reading. If
-every deliverable already exists, do NOT open an empty PR: post a
-comment with `git blame` evidence (commit + that it is an ancestor of
-`origin/main`) and `coordination skip <N> "already complete via #M"` to
-route it to replan for closure.
 
 **PR fix plans**: If the plan asks you to fix a broken PR, use judgement. If the
 PR is low quality or not worth salvaging:

--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -74,6 +74,20 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   `obtain ⟨r, hr⟩ := h; ⟨toMathlibPolynomial r, by rw [hr, toMathlibPolynomial_mul]⟩`.
   (`HexBerlekampZassenhausMathlib/Basic.lean` exposes `toMathlibPolynomial_dvd`
   and `self_dvd_monicModPImage` for exactly this.)
+- **Through `fpPolyEquiv : FpPoly p ≃+* Polynomial (ZMod p)`, `map_mul` and
+  `map_add` work but `map_one`/`map_zero`/`map_sub` do NOT.** `toMathlibPolynomial
+  f` is defeq `fpPolyEquiv f`, and `map_mul`/`map_add` need only `MulHomClass`/
+  `AddHomClass` (i.e. `[Mul]`/`[Add]`, which `FpPoly` has), so
+  `map_mul fpPolyEquiv a b` / `map_add fpPolyEquiv a b` close
+  `toMathlibPolynomial (a * b) = …` / `(a + b) = …` directly. But `map_one`/
+  `map_zero`/`map_sub` resolve `OneHomClass`/`ZeroHomClass`/`AddGroup`-class
+  instances that need Mathlib `MulOneClass`/`AddGroup` on `FpPoly` — which it
+  lacks — so they fail with "failed to synthesize `OneHomClass (FpPoly p ≃+* …)`".
+  Prove `toMathlibPolynomial (1 : FpPoly p) = 1` inline by `Polynomial.ext` +
+  `coeff_toMathlibPolynomial` + `(1 : FpPoly p) = DensePoly.C 1` (rfl) +
+  `coeff_C`/`Polynomial.coeff_one` (mirror `toZMod_zero` for the `Zero.zero`
+  else-branch via `exact`, not `simp`); for subtraction use
+  `toMathlibPolynomial_sub` (the named coeffwise lemma), not `map_sub`.
 - **`ZPoly = DensePoly Int` ring identities: `grind` is unreliable; use the
   `equiv`/`toPolynomial` bridge.** `grind` is advertised for `ZMod64`/`FpPoly`
   arithmetic, but on `ZPoly` it *fails* on basics like `factor * 0 = 0` and

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -1394,6 +1394,68 @@ theorem dvd_frobeniusDiffMod_of_dvd_dvd
   exact DensePoly.dvd_sub_poly hg_dvd_pow hg_dvd_diff
 
 /--
+A `g` that divides both `f` and the modular Frobenius remainder
+`frobeniusDiffMod f hmonic k` also divides the absolute polynomial
+`xPowSubX k`.
+
+The converse companion to `dvd_frobeniusDiffMod_of_dvd_dvd`. Used by the
+Mathlib reverse Rabin transport to lift an executable common divisor of `f`
+and `frobeniusDiffMod` up to `X^(p^k) - X`, where it transports to a divisor
+of `frobeniusPolynomial p k`.
+-/
+theorem dvd_xPowSubX_of_dvd_frobeniusDiffMod
+    {f g : FpPoly p} (hmonic : DensePoly.Monic f)
+    (hg_dvd_f : g ∣ f) {k : Nat}
+    (hg_dvd_diff : g ∣ frobeniusDiffMod f hmonic k) :
+    g ∣ xPowSubX (p := p) k := by
+  have inst_dvd : DensePoly.DivModLaws (ZMod64 p) := inferInstance
+  -- Step 1: f ∣ ((xPowSubX k) - frobeniusDiffMod), reusing the algebra from the iff proof.
+  have hdvd_diff : f ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    have hp1 : f ∣ ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+                    FpPoly.frobeniusXPowMod f hmonic k) :=
+      @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _
+        (FpPoly.frobeniusXPowMod_mod_eq_monomial_mod f hmonic k).symm
+    have hp2 : f ∣ (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      rw [show FpPoly.modByMonic f FpPoly.X hmonic = FpPoly.X % f from
+            DensePoly.modByMonic_eq_mod _ _ hmonic]
+      have hmm : (FpPoly.X (p := p)) % f = (FpPoly.X (p := p) % f) % f :=
+        (DensePoly.mod_mod FpPoly.X f).symm
+      exact @DensePoly.dvd_of_mod_eq_mod (ZMod64 p) _ _ _ inst_dvd _ _ _ hmm
+    have heq :
+        xPowSubX (p := p) k - frobeniusDiffMod f hmonic k =
+          ((DensePoly.monomial (p^k) (1 : ZMod64 p)) -
+              FpPoly.frobeniusXPowMod f hmonic k) -
+            (FpPoly.X - FpPoly.modByMonic f FpPoly.X hmonic) := by
+      unfold xPowSubX frobeniusDiffMod
+      apply DensePoly.ext_coeff
+      intro n
+      rw [DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring,
+          DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring,
+          DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
+      grind
+    rw [heq]
+    exact DensePoly.dvd_sub_poly hp1 hp2
+  -- Step 2: g ∣ (xPowSubX k - frobeniusDiffMod) since g ∣ f and f ∣ ...
+  have hg_dvd_diff' : g ∣ (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    rcases hdvd_diff with ⟨c, hc⟩
+    rcases hg_dvd_f with ⟨e, he⟩
+    refine ⟨e * c, ?_⟩
+    rw [hc, he, FpPoly.mul_assoc]
+  -- Step 3: xPowSubX k = frobeniusDiffMod + (xPowSubX k - frobeniusDiffMod), so g divides it.
+  have hgoal :
+      xPowSubX (p := p) k =
+        frobeniusDiffMod f hmonic k +
+          (xPowSubX (p := p) k - frobeniusDiffMod f hmonic k) := by
+    apply DensePoly.ext_coeff
+    intro n
+    rw [DensePoly.coeff_add _ _ _
+          (inferInstance : DensePoly.AddZeroLaw (ZMod64 p)).add_zero_zero,
+        DensePoly.coeff_sub_ring]
+    grind
+  rw [hgoal]
+  exact DensePoly.dvd_add_poly hg_dvd_diff hg_dvd_diff'
+
+/--
 A divisor of a unit polynomial is itself a unit polynomial.
 
 Routine consequence of degree arithmetic: if `g ∣ h` and `h` has degree 0

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -515,6 +515,34 @@ theorem rabinTest_true_to_mathlib_checks
         IsCoprime (toMathlibPolynomial f) (frobeniusPolynomial p d) := by
   sorry
 
+/-- The executable absolute polynomial `xPowSubX d = X^(p^d) - X` transports to
+the Mathlib Frobenius polynomial `frobeniusPolynomial p d`. The reverse-leg
+counterpart of the remainder transport: it identifies the executable divisibility
+target with its `Polynomial (ZMod p)` form. -/
+theorem toMathlibPolynomial_xPowSubX (d : Nat) :
+    toMathlibPolynomial (Hex.Berlekamp.xPowSubX (p := p) d) = frobeniusPolynomial p d := by
+  apply Polynomial.ext
+  intro n
+  have hz : HexModArithMathlib.ZMod64.toZMod (Zero.zero : Hex.ZMod64 p) = 0 :=
+    HexModArithMathlib.ZMod64.toZMod_zero
+  rw [coeff_toMathlibPolynomial]
+  unfold Hex.Berlekamp.xPowSubX
+  rw [Hex.DensePoly.coeff_sub_ring,
+    show (Hex.FpPoly.X : Hex.FpPoly p) = Hex.DensePoly.monomial 1 (1 : Hex.ZMod64 p) from rfl,
+    Hex.DensePoly.coeff_monomial, Hex.DensePoly.coeff_monomial,
+    frobeniusPolynomial, Polynomial.coeff_sub, Polynomial.coeff_X_pow, Polynomial.coeff_X]
+  by_cases h1 : n = p ^ d
+  · by_cases h2 : n = 1
+    · simp only [if_pos h1, if_pos h2, if_pos h2.symm]
+      simp [HexModArithMathlib.ZMod64.toZMod_sub]
+    · simp only [if_pos h1, if_neg h2, if_neg (fun h : (1 : Nat) = n => h2 h.symm)]
+      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
+  · by_cases h2 : n = 1
+    · simp only [if_neg h1, if_pos h2, if_pos h2.symm]
+      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
+    · simp only [if_neg h1, if_neg h2, if_neg (fun h : (1 : Nat) = n => h2 h.symm)]
+      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
+
 /--
 The Mathlib Rabin checks imply the executable test surface once the transport
 lemmas connect executable remainders and gcds to `Polynomial (ZMod p)`.
@@ -529,7 +557,82 @@ theorem rabinTest_true_of_mathlib_checks
         ∀ d ∈ Hex.Berlekamp.maximalProperDivisors n,
           IsCoprime (toMathlibPolynomial f) (frobeniusPolynomial p d)) :
     Hex.Berlekamp.rabinTest f hmonic = true := by
-  sorry
+  -- Build the executable prime-modulus instance from `Fact (Nat.Prime p)`.
+  have hp_hex : Hex.Nat.Prime p := by
+    refine ⟨(Fact.out : Nat.Prime p).two_le, ?_⟩
+    intro m hmdvd
+    rcases (Fact.out : Nat.Prime p).eq_one_or_self_of_dvd m hmdvd with h | h
+    · exact Or.inl h
+    · exact Or.inr h
+  haveI : Hex.ZMod64.PrimeModulus p := Hex.ZMod64.primeModulusOfPrime hp_hex
+  obtain ⟨hn_pos, hdvd, hcoprime⟩ := hchecks
+  -- Transport executable divisibility along the ring iso, in both directions.
+  have transport : ∀ {a b : Hex.FpPoly p}, a ∣ b →
+      toMathlibPolynomial a ∣ toMathlibPolynomial b := by
+    rintro a b ⟨r, hr⟩
+    exact ⟨toMathlibPolynomial r, by rw [hr]; exact map_mul fpPolyEquiv a r⟩
+  have untransport : ∀ {a b : Hex.FpPoly p},
+      toMathlibPolynomial a ∣ toMathlibPolynomial b → a ∣ b := by
+    rintro a b ⟨R, hR⟩
+    refine ⟨fpPolyEquiv.symm R, ?_⟩
+    apply fpPolyEquiv.injective
+    rw [map_mul, fpPolyEquiv.apply_symm_apply]
+    exact hR
+  rw [Hex.Berlekamp.rabinTest_eq_true_iff]
+  refine ⟨by rw [hdegree]; exact hn_pos, ?_, ?_⟩
+  · -- Divisibility leg: untransport `M f ∣ frobeniusPolynomial p n` to `f ∣ xPowSubX n`.
+    apply untransport
+    rw [toMathlibPolynomial_xPowSubX, hdegree]
+    exact hdvd
+  · -- Coprimality leg: each maximal-proper-divisor witness is accepted.
+    rw [List.all_eq_true]
+    intro x hx
+    rw [Hex.Berlekamp.rabinWitnesses, List.mem_map] at hx
+    obtain ⟨d, hd_mem, rfl⟩ := hx
+    show Hex.Berlekamp.rabinCoprimeTest f hmonic d = true
+    rw [hdegree] at hd_mem
+    have hcop_d := hcoprime d hd_mem
+    unfold Hex.Berlekamp.rabinCoprimeTest
+    -- Let `g` be the executable gcd of `f` and `diff = frobeniusDiffMod f hmonic d`.
+    have hg_dvd_f : Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d) ∣ f :=
+      Hex.DensePoly.gcd_dvd_left _ _
+    have hg_dvd_diff :
+        Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d) ∣
+          Hex.Berlekamp.frobeniusDiffMod f hmonic d :=
+      Hex.DensePoly.gcd_dvd_right _ _
+    have hg_dvd_xpow :
+        Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d) ∣
+          Hex.Berlekamp.xPowSubX (p := p) d :=
+      Hex.Berlekamp.dvd_xPowSubX_of_dvd_frobeniusDiffMod hmonic hg_dvd_f hg_dvd_diff
+    -- Transport the two divisibilities and read off a Bezout combination of `1`.
+    have hMg_dvd_Mf := transport hg_dvd_f
+    have hMg_dvd_frob :
+        toMathlibPolynomial (Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d)) ∣
+          frobeniusPolynomial p d := by
+      have h := transport hg_dvd_xpow
+      rwa [toMathlibPolynomial_xPowSubX] at h
+    obtain ⟨u, v, huv⟩ := hcop_d
+    have hMg_dvd_one :
+        toMathlibPolynomial (Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d)) ∣
+          (1 : Polynomial (ZMod p)) := by
+      rw [← huv]
+      exact dvd_add (hMg_dvd_Mf.mul_left u) (hMg_dvd_frob.mul_left v)
+    have h_one : toMathlibPolynomial (1 : Hex.FpPoly p) = 1 := by
+      apply Polynomial.ext
+      intro m
+      rw [coeff_toMathlibPolynomial,
+        show (1 : Hex.FpPoly p) = Hex.DensePoly.C (1 : Hex.ZMod64 p) from rfl,
+        Hex.DensePoly.coeff_C, Polynomial.coeff_one]
+      by_cases hm : m = 0
+      · simp [hm, HexModArithMathlib.ZMod64.toZMod_one]
+      · rw [if_neg hm, if_neg hm]; exact HexModArithMathlib.ZMod64.toZMod_zero
+    have hg_dvd_one :
+        Hex.DensePoly.gcd f (Hex.Berlekamp.frobeniusDiffMod f hmonic d) ∣ (1 : Hex.FpPoly p) := by
+      apply untransport
+      rw [h_one]
+      exact hMg_dvd_one
+    exact Hex.Berlekamp.isUnitPolynomial_of_dvd_isUnitPolynomial hg_dvd_one
+      Hex.Berlekamp.isUnitPolynomial_one_FpPoly
 
 end Rabin
 

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -685,34 +685,6 @@ theorem rabinTest_true_to_mathlib_checks
     rw [hfrob_eq]
     exact hcopM.add_mul_left_right t
 
-/-- The executable absolute polynomial `xPowSubX d = X^(p^d) - X` transports to
-the Mathlib Frobenius polynomial `frobeniusPolynomial p d`. The reverse-leg
-counterpart of the remainder transport: it identifies the executable divisibility
-target with its `Polynomial (ZMod p)` form. -/
-theorem toMathlibPolynomial_xPowSubX (d : Nat) :
-    toMathlibPolynomial (Hex.Berlekamp.xPowSubX (p := p) d) = frobeniusPolynomial p d := by
-  apply Polynomial.ext
-  intro n
-  have hz : HexModArithMathlib.ZMod64.toZMod (Zero.zero : Hex.ZMod64 p) = 0 :=
-    HexModArithMathlib.ZMod64.toZMod_zero
-  rw [coeff_toMathlibPolynomial]
-  unfold Hex.Berlekamp.xPowSubX
-  rw [Hex.DensePoly.coeff_sub_ring,
-    show (Hex.FpPoly.X : Hex.FpPoly p) = Hex.DensePoly.monomial 1 (1 : Hex.ZMod64 p) from rfl,
-    Hex.DensePoly.coeff_monomial, Hex.DensePoly.coeff_monomial,
-    frobeniusPolynomial, Polynomial.coeff_sub, Polynomial.coeff_X_pow, Polynomial.coeff_X]
-  by_cases h1 : n = p ^ d
-  · by_cases h2 : n = 1
-    · simp only [if_pos h1, if_pos h2, if_pos h2.symm]
-      simp [HexModArithMathlib.ZMod64.toZMod_sub]
-    · simp only [if_pos h1, if_neg h2, if_neg (fun h : (1 : Nat) = n => h2 h.symm)]
-      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
-  · by_cases h2 : n = 1
-    · simp only [if_neg h1, if_pos h2, if_pos h2.symm]
-      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
-    · simp only [if_neg h1, if_neg h2, if_neg (fun h : (1 : Nat) = n => h2 h.symm)]
-      simp [HexModArithMathlib.ZMod64.toZMod_sub, hz]
-
 /--
 The Mathlib Rabin checks imply the executable test surface once the transport
 lemmas connect executable remainders and gcds to `Polynomial (ZMod p)`.

--- a/progress/20260617_160741_23d4d821.md
+++ b/progress/20260617_160741_23d4d821.md
@@ -1,0 +1,65 @@
+# Progress - 2026-06-17 (session 23d4d821, /work → #7777)
+
+## Accomplished
+
+Claimed #7777 (feat: prove reverse Rabin transport
+`rabinTest_true_of_mathlib_checks`) and discharged its `sorry`.
+
+The reverse leg ("Mathlib criterion facts ⟹ executable Rabin test passes")
+is the sibling of the forward leg `rabinTest_true_to_mathlib_checks` (still
+`sorry`, owned by #7774 / PR #7776, not yet merged). I built the reverse
+helpers locally rather than blocking on #7776, and deliberately routed
+ring-hom transport through `fpPolyEquiv`'s `map_mul`/`map_add` so my additions
+do **not** collide by declaration name with #7776's top-level
+`toMathlibPolynomial_mul/_sub/_X/_monomial_one/_dvd` helpers regardless of
+merge order.
+
+### Executable layer (`HexBerlekamp/RabinSoundness.lean`)
+
+Added the public converse companion to `dvd_frobeniusDiffMod_of_dvd_dvd`:
+`dvd_xPowSubX_of_dvd_frobeniusDiffMod` — from `g ∣ f` and
+`g ∣ frobeniusDiffMod f hmonic k`, concludes `g ∣ xPowSubX k`. Proof mirrors
+the existing forward lemma (reuses the `f ∣ (xPowSubX k − frobeniusDiffMod)`
+algebra), then `xPowSubX = frobeniusDiffMod + (xPowSubX − frobeniusDiffMod)`
+via `dvd_add_poly`.
+
+### Mathlib layer (`HexBerlekampMathlib/Basic.lean`)
+
+- `Rabin.toMathlibPolynomial_xPowSubX`: `toMathlibPolynomial (xPowSubX d) =
+  frobeniusPolynomial p d`, by coefficientwise `toZMod` matching of
+  `monomial(p^d)1 − monomial 1 1` against `X^(p^d) − X`.
+- `Rabin.rabinTest_true_of_mathlib_checks`: reduces the goal through
+  `rabinTest_eq_true_iff`. Divisibility leg = untransport
+  `M f ∣ frobeniusPolynomial p n` to `f ∣ xPowSubX n`. Coprimality leg: for
+  each maximal proper divisor `d`, `M g ∣ M f` and `M g ∣ frobeniusPolynomial p
+  d` (via `g ∣ xPowSubX d` + transport), then the `IsCoprime` Bezout pair gives
+  `M g ∣ 1`, untransport to `g ∣ 1`, and `isUnitPolynomial_of_dvd_isUnitPolynomial`
+  + `isUnitPolynomial_one_FpPoly` close `rabinCoprimeTest f hmonic d = true`.
+
+Key facts used: `IsCoprime a b := ∃ u v, u*a + v*b = 1` (no separate
+coprimality-invariance lemma needed); `map_one` is unavailable (FpPoly lacks
+Mathlib `MulOneClass`), so `M 1 = 1` is proved inline via `coeff_C`/`coeff_one`.
+
+## Verification
+
+- `lake build HexBerlekamp.RabinSoundness` — clean.
+- `lake build HexBerlekampMathlib.Basic` — clean; sorry count 5 → 4 (exactly
+  the reverse leg removed; forward leg 507 still `sorry` per #7774).
+- `lake build HexBerlekampZassenhausMathlib` (full CI-gated layer) — clean,
+  `Build completed successfully (3790 jobs)`, zero `error:`.
+- Added-line scan: no sorry/axiom/native_decide/TODO/FIXME. `git diff --check`
+  clean.
+
+## Current frontier
+
+Reverse Rabin transport landed. Forward + reverse now give the iff once #7776
+lands its forward leg.
+
+## Next step
+
+Nothing for #7777. Downstream: the iff feeds the executable irreducibility
+checker soundness chain (#4818 executable `isIrreducible_iff`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7777

This PR proves the reverse leg of the Rabin executable-to-Mathlib bridge, `rabinTest_true_of_mathlib_checks`: the Mathlib irreducibility-criterion facts (the transported polynomial divides the Frobenius polynomial `X^(p^n) - X`, and is coprime to `X^(p^d) - X` at every maximal proper divisor `d`) imply the executable `rabinTest` passes. Together with the forward leg it gives the iff characterisation the executable irreducibility checker soundness chain consumes for its modular checks, in support of directive #2564.

It adds the public executable converse `dvd_xPowSubX_of_dvd_frobeniusDiffMod` (companion to the existing `dvd_frobeniusDiffMod_of_dvd_dvd`) and the Mathlib transport `toMathlibPolynomial_xPowSubX`, then routes the proof through `rabinTest_eq_true_iff`: untransport divisibility for the divides leg, and read off `M g ∣ 1` from the `IsCoprime` Bezout pair for each coprime witness. Ring-hom transport goes through `fpPolyEquiv`'s `map_mul`/`map_add` so the additions do not collide by declaration name with the forward leg's helpers (#7774 / PR #7776, in review). It also records the `map_one`/`map_sub`-unavailable boundary gotcha in the `hex-lean-mathlib-boundary` skill.

`HexBerlekampMathlib/Basic.lean`'s sorry count drops by exactly one, and `lake build HexBerlekampZassenhausMathlib` (the CI-gated layer) stays green.

🤖 Prepared with Claude Code