### PR TITLE
feat: add BZ slow-backstop subset bucket conformance guard

### DIFF
--- a/HexBerlekampZassenhaus/Conformance.lean
+++ b/HexBerlekampZassenhaus/Conformance.lean
@@ -12,7 +12,8 @@ Covered operations:
 - `normalizeForFactor`, `normalizationPrefixFactors`, and
   `reassembleNormalizedFactors`
 - `henselLiftData`
-- `bhksRecover?`, `recombinationSearch`, `factorSlowTrial`, and `factorFast`
+- `bhksRecover?`, `recombinationSearch`, `factorSlowTrial`,
+  `factorSlowModular`, and `factorFast`
 - `factorWithBound` and `factor`
 - `PrimeFactorData.degreeSum`, `PrimeFactorData.factorProduct`,
   `PrimeFactorData.containsDegree`, `PrimeFactorData.hasSubsetDegree`,
@@ -522,6 +523,17 @@ recovered true factor.
     sameFactorCoeffSet (factorizationCoeffSummary φ)
       (factorCoeffSummary quadSqrt2Sqrt3ExpectedFactors |>.map fun coeffs =>
         (coeffs, 1))
+-- The exhaustive *modular* recombination backstop (subset-product search, as
+-- opposed to `factorSlowTrial`'s integer trial division) recovers the same
+-- quadratic buckets `X^2 - 2`, `X^2 - 3` on the adversarial subset-product case.
+#guard
+  match factorSlowModular quadSqrt2Sqrt3 with
+  | some φ =>
+      Factorization.product φ = quadSqrt2Sqrt3 &&
+        sameFactorCoeffSet (factorizationCoeffSummary φ)
+          (factorCoeffSummary quadSqrt2Sqrt3ExpectedFactors |>.map fun coeffs =>
+            (coeffs, 1))
+  | none => false
 #guard
   match factorFast (linear 3) with
   | some φ => Factorization.product φ = linear 3
@@ -565,6 +577,14 @@ recovered true factor.
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[zpoly #[-3, 0, 1], zpoly #[-2, 0, 1]] |>.map fun coeffs =>
         (coeffs, 1))
+-- `X^4 + 1` splits into two quadratics mod every admissible prime yet is
+-- irreducible over `ℤ`, so the fast recombination "misses" and the public
+-- `factor` falls back to returning the single irreducible input.
+#guard
+  let factors := factor x4Plus1
+  factorPreservesProduct x4Plus1 &&
+    sameFactorCoeffSet (factorizationCoeffSummary factors)
+      (factorCoeffSummary #[x4Plus1] |>.map fun coeffs => (coeffs, 1))
 
 #guard PrimeFactorData.degreeSum primeDataValidQuad = 2
 #guard coeffNats (PrimeFactorData.factorProduct primeDataValidQuad) = [2, 0, 1]

--- a/progress/20260617_161002_fd0be64f.md
+++ b/progress/20260617_161002_fd0be64f.md
@@ -1,0 +1,65 @@
+# Progress - 2026-06-17 (session fd0be64f, /work → /feature #7779)
+
+## Accomplished
+
+Claimed and completed #7779 (feat: add BZ slow-backstop subset bucket
+conformance guard). All deliverables landed in
+`HexBerlekampZassenhaus/Conformance.lean`.
+
+### Premise check
+
+The issue's current-state text says only `factorSlowTrial`'s *product* is
+guarded. By the time I claimed it, #7775 ("test: guard slow-trial subset
+buckets") had already landed the `factorSlowTrial` *bucket* guard
+(lines 519-524), ~17 min before #7779 was filed. So the genuine remaining
+gap is the *other* slow tier: the **exhaustive modular recombination
+backstop** `factorSlowModular` (`Basic.lean:7560`, via
+`exhaustiveCoreFactorsWithBound` → `scaledRecombinationSearchMod`), which is
+the one doing true subset-product recombination — as opposed to
+`factorSlowTrial`'s integer trial division. That matches the issue's
+"exhaustive slow backstop ... subset-product bucket factors" wording.
+Verified by `#eval`: `factorSlowModular quadSqrt2Sqrt3` returns
+`some (scalar 1, [X^2-3, X^2-2])`.
+
+### Guards added
+
+1. **Modular backstop bucket guard** (deliverables 1+2): `#guard` that
+   `factorSlowModular quadSqrt2Sqrt3 = some φ` with `φ` recovering exactly the
+   expected quadratic buckets `X^2 - 2`, `X^2 - 3`, compared order-insensitively
+   via the existing `sameFactorCoeffSet` / `factorizationCoeffSummary` /
+   `quadSqrt2Sqrt3ExpectedFactors` helpers. Placed adjacent to the existing
+   `factorSlowTrial` guard.
+2. **Public-fallback guard** (deliverable 3): `#guard` that `factor x4Plus1`
+   returns `X^4 + 1` as a single irreducible factor — the fast recombination
+   "misses" (splits into two quadratics mod every admissible prime, irreducible
+   over ℤ) and the public `factor` falls back to the input. Placed adjacent to
+   the existing `factor quadSqrt2Sqrt3` adversarial guard. Reuses
+   `factorPreservesProduct`.
+3. Added `factorSlowModular` to the file's covered-operations docstring.
+
+No `factorSlowTrial`, `bhksRecover?`, `factor`, or recombination algorithm was
+changed — conformance-only patch. No SPEC/PLAN/AGENTS edits.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus.Conformance` — clean, both new guards pass.
+- `lake build HexBerlekampZassenhaus` — clean (497 jobs; CrossCheck untouched).
+- `git diff --check` — clean.
+- Added-line forbidden-token scan — none (no sorry/axiom/native_decide/TODO/FIXME).
+
+## Current frontier
+
+#7779 complete. The remaining high-value queue items (#6672 capstone, #7772
+fast-core forward-recovery substrate) are both blocked on the BHKS/van Hoeij
+proof chain (#2564 / #6779), not claimable by a worker.
+
+## Next step
+
+For a successor: the `factorSlowModular` exhaustive-modular bucket recovery is
+now pinned for the four-way subset-product adversarial case. A parallel guard
+for `swinnerton_dyer_sd3` (the heavy-split fixture) through `factorSlowModular`
+could harden coverage further if a planner wants it.
+
+## Blockers
+
+None for this change.


### PR DESCRIPTION
Closes #7779

Session: `fd0be64f-01f7-49af-964d-eb29b08a15bf`

101b8634 test: guard modular slow-backstop subset buckets (#7779)

🤖 Prepared with Claude Code