### PR TITLE
feat: transport FpPoly irreducibility to Mathlib (irreducible_toMathlibPolynomial_of_fpPolyIrreducible)

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -437,6 +437,35 @@ theorem isUnit_toMathlibPolynomial_of_isUnitPolynomial
   rw [hC_eq]
   exact Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr htoZ_ne)
 
+/-- Transport executable `FpPoly.Irreducible` to Mathlib `Irreducible` over
+`ZMod p`.
+
+The positive Mathlib-degree hypothesis is essential: `FpPoly.Irreducible` holds
+vacuously for any nonzero constant (every factorization has a degree-0 factor),
+whereas such a constant transports to a Mathlib *unit*, not an irreducible.  At
+the Berlekamp use site the emitted factors are nonconstant, so the hypothesis is
+available. -/
+theorem irreducible_toMathlibPolynomial_of_fpPolyIrreducible
+    [Fact (Nat.Prime p)] {f : Hex.FpPoly p}
+    (hpos : 0 < (toMathlibPolynomial f).natDegree)
+    (hirr : Hex.FpPoly.Irreducible f) :
+    Irreducible (toMathlibPolynomial f) := by
+  refine ⟨fun h => Polynomial.not_isUnit_of_natDegree_pos _ hpos h, ?_⟩
+  intro a b hab
+  -- Pull `a`, `b` back through `fpPolyEquiv.symm` to executable factors of `f`.
+  have ha : toMathlibPolynomial (fpPolyEquiv.symm a) = a := by
+    rw [← fpPolyEquiv_apply, fpPolyEquiv.apply_symm_apply]
+  have hb : toMathlibPolynomial (fpPolyEquiv.symm b) = b := by
+    rw [← fpPolyEquiv_apply, fpPolyEquiv.apply_symm_apply]
+  have hprod : fpPolyEquiv.symm a * fpPolyEquiv.symm b = f := by
+    rw [← map_mul, ← hab, ← fpPolyEquiv_apply, fpPolyEquiv.symm_apply_apply]
+  -- `FpPoly.Irreducible` forces one pulled-back factor to be a nonzero constant.
+  rcases hirr.2 _ _ hprod with hdeg | hdeg
+  · exact Or.inl (ha ▸ isUnit_toMathlibPolynomial_of_isUnitPolynomial
+      (by unfold Hex.Berlekamp.isUnitPolynomial; rw [hdeg]))
+  · exact Or.inr (hb ▸ isUnit_toMathlibPolynomial_of_isUnitPolynomial
+      (by unfold Hex.Berlekamp.isUnitPolynomial; rw [hdeg]))
+
 /-- The Mathlib primality fact yields the executable prime-modulus witness, so
 executable field-dependent lemmas (gcd/Bezout, modular division) become
 available in the Mathlib transport layer. -/
@@ -848,6 +877,11 @@ theorem irreducible_of_mem_berlekampFactor
       Hex.Berlekamp.isUnitPolynomial d = true) :
     ∀ g ∈ (Hex.Berlekamp.berlekampFactor f hmonic).factors,
       Irreducible (toMathlibPolynomial g) := by
+  -- The Mathlib leg is `irreducible_toMathlibPolynomial_of_fpPolyIrreducible`
+  -- (above): each nonconstant factor with `FpPoly.Irreducible g` transports.
+  -- The remaining gap is purely executable: there is no theorem yet that every
+  -- `g ∈ (berlekampFactor f hmonic).factors` is `FpPoly.Irreducible` (only the
+  -- singleton case `berlekampFactor_singleton_irreducible` exists).
   sorry
 
 /--

--- a/progress/20260617_162408_8df0d1a6.md
+++ b/progress/20260617_162408_8df0d1a6.md
@@ -1,0 +1,57 @@
+# Progress - session 8df0d1a6 (/work → /feature)
+
+## Accomplished
+
+### #7782 — FpPoly→Mathlib irreducibility transport (landed)
+
+Added `irreducible_toMathlibPolynomial_of_fpPolyIrreducible`
+(`HexBerlekampMathlib/Basic.lean`, after
+`isUnit_toMathlibPolynomial_of_isUnitPolynomial`):
+
+```lean
+theorem irreducible_toMathlibPolynomial_of_fpPolyIrreducible
+    [Fact (Nat.Prime p)] {f : Hex.FpPoly p}
+    (hpos : 0 < (toMathlibPolynomial f).natDegree)
+    (hirr : Hex.FpPoly.Irreducible f) :
+    Irreducible (toMathlibPolynomial f)
+```
+
+Chose the natDegree positive-degree form (the issue's permitted "natDegree
+form") since it makes the non-unit leg a one-liner
+(`Polynomial.not_isUnit_of_natDegree_pos`) and needs no monicity. The premise
+check holds: the hypothesis excludes the constant-unit case where
+`FpPoly.Irreducible` is vacuously true. Factorization leg pulls `a, b` back
+through `fpPolyEquiv.symm`, applies `hirr.2` to get a degree-0 factor, and
+transports it to a Mathlib unit via
+`isUnit_toMathlibPolynomial_of_isUnitPolynomial`.
+
+Left a pointer comment at the in-scope-excluded `irreducible_of_mem_berlekampFactor`
+sorry naming the new primitive and the remaining executable gap (no per-member
+`FpPoly.Irreducible` theorem; only `berlekampFactor_singleton_irreducible`).
+
+Verification: `lake build HexBerlekampMathlib` clean. Sorry count in the file
+unchanged (2 → 2, both pre-existing). No forbidden tokens in added lines.
+
+### #7772 — premise-rejected (separate, earlier in this session)
+
+Diagnosed and `skip`ped #7772 (BHKS fast-core forward-recovery producer): it
+requires inhabiting `ForwardRecoveryInputs.lattice_eq_indicators` (full `L'=W`),
+whose reverse inclusion routes through the dead `resultant_divisible_by_p_pow`
+clause (#6779/#2564) — yet that field is unused downstream (`_of_forwardInputs`
+proves irreducibility via the forward `_of_cut`). Recommended re-targeting at the
+forward `_of_lift` route. Full evidence on the issue comment.
+
+## Current frontier
+
+`irreducible_of_mem_berlekampFactor` sorry now has a clean Mathlib leg; the
+remaining gap is the executable per-member irreducibility theorem.
+
+## Next step
+
+A successor can prove "every `g ∈ (berlekampFactor f hmonic).factors` is
+`FpPoly.Irreducible`" (executable side), then compose with the new primitive to
+discharge the `irreducible_of_mem_berlekampFactor` sorry.
+
+## Blockers
+
+None for #7782 (landed). #7772 blocked on #6779/#2564 (van Hoeij CLD rollback).


### PR DESCRIPTION
This PR adds `irreducible_toMathlibPolynomial_of_fpPolyIrreducible` to `HexBerlekampMathlib/Basic.lean`, transporting executable `Hex.FpPoly.Irreducible` of positive Mathlib degree to Mathlib `Irreducible` over `ZMod p`. The positive-degree hypothesis is essential: `FpPoly.Irreducible` holds vacuously for any nonzero constant, which transports to a Mathlib unit rather than an irreducible, so the constant case must be excluded. The non-unit leg uses `Polynomial.not_isUnit_of_natDegree_pos`; the factorization leg pulls candidate factors back through `fpPolyEquiv.symm`, applies the executable irreducibility predicate to obtain a degree-0 factor, and transports it to a unit via `isUnit_toMathlibPolynomial_of_isUnitPolynomial`. This is the in-scope Mathlib leg of the load-bearing `irreducible_of_mem_berlekampFactor` sorry; that sorry stays in place with a pointer comment, since the remaining gap is the out-of-scope executable per-member irreducibility theorem.

Closes #7782

Session: `8df0d1a6-5340-4fec-b4e7-a6bdaedf20c3`

🤖 Prepared with Claude Code
