### PR TITLE
feat: forward fast-raw irreducibility wrapper without ForwardRecoveryInputs (factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut)

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -1076,4 +1076,113 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs
       (Hex.normalizeForFactor f) hinputs.expectedFactors hcomplete hcore_irr
       hraw_mem
 
+/--
+Forward `factorFastFactorsWithBound`-level raw irreducibility that takes the
+forward cut certificates **directly**, with no `BHKS.ForwardRecoveryInputs`
+parameter.
+
+Sibling of `factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs`,
+but routed through `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut`
+rather than reconstructing a `ForwardRecoveryInputs` value.  This deliberately
+avoids the structure's `lattice_eq_indicators` field — the dead reverse
+`L' = W` separation (route-blocked behind #6779 / #2564) that nothing
+downstream reads — so a forward-only producer never has to inhabit it.  The
+`expectedFactors`, `trueSupports`, dimension positivity (`rows_pos`),
+indicator-size, and partition-count certificates are supplied directly; the
+forward cut hypothesis `hcut` (over `projectedRowsOfLiftData`) is the only
+lattice obligation, and the first-success loop pin `hcore` is threaded at the
+actual executable `start = initialHenselPrecision a` (not at a cap precision),
+exactly as in the `_of_forwardInputs` sibling.
+
+This closes deliverable 1 of #7786.  Deliverable 2 — a producer that discharges
+the per-support `BHKS.TrueFactorLift` / `TrueFactorLiftSemantics` /
+Lemma-5.7 separation family (and hence `hcut`) for the actual first-success
+recovery — remains open on a missing coverage substrate (see the issue
+comment). -/
+theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hB_pos : 1 ≤ B)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+        some primeData)
+    (hdeg :
+      (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    (hmulti : 1 < primeData.factorsModP.size)
+    (hquadratic :
+      B = 1 ∨
+        Hex.quadraticIntegerRootFactors?
+          (Hex.normalizeForFactor f).squareFreeCore = none)
+    (rows_pos :
+      BHKS.HasPositiveDimension (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.precisionForCoeffBound B primeData.p) primeData))
+    (trueSupports :
+      Set (Set (Fin
+        (BHKS.projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.precisionForCoeffBound B primeData.p) primeData)
+          rows_pos).factorCount)))
+    {expectedFactors : Array Hex.ZPoly}
+    (hcore :
+      let a := Hex.precisionForCoeffBound B primeData.p
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
+        primeData (Hex.initialHenselPrecision a)
+        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+          some expectedFactors)
+    (hcut :
+      BHKS.CutProjectionHypotheses
+        (BHKS.projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.precisionForCoeffBound B primeData.p) primeData)
+          rows_pos)
+        trueSupports)
+    (hsize :
+      expectedFactors.size =
+        (Hex.bhksEquivalenceClassIndicators
+          (BHKS.projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData
+              (Hex.normalizeForFactor f).squareFreeCore
+              (Hex.precisionForCoeffBound B primeData.p) primeData)
+            rows_pos)).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (Hex.normalizeForFactor f).squareFreeCore)).card)
+    (hcomplete :
+      Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
+        expectedFactors)
+    {rawFactors : Array Hex.ZPoly}
+    (hfast : Hex.factorFastFactorsWithBound f B = some rawFactors) :
+    ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw := by
+  have hcore_lc_pos :
+      0 < Hex.DensePoly.leadingCoeff
+        (Hex.normalizeForFactor f).squareFreeCore :=
+    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
+  have hcore_ne : (Hex.normalizeForFactor f).squareFreeCore ≠ 0 :=
+    zpoly_ne_zero_of_pos_lc hcore_lc_pos
+  have hcore_irr :
+      ∀ factor ∈ expectedFactors.toList,
+        Hex.ZPoly.Irreducible factor :=
+    factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut
+      trueSupports hcore_ne hcore hcut hsize hpartition
+  have hfast_eq :=
+    Hex.factorFastFactorsWithBound_eq_some_of_core_success f B primeData
+      expectedFactors hB_pos hchoose hdeg (by omega) hquadratic hcore
+  rw [hfast] at hfast_eq
+  have hraw_eq := (Option.some.inj hfast_eq)
+  intro raw hraw_mem
+  rw [hraw_eq] at hraw_mem
+  exact
+    Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+      (Hex.normalizeForFactor f) expectedFactors hcomplete hcore_irr
+      hraw_mem
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260618_656d42c5.md
+++ b/progress/20260618_656d42c5.md
@@ -1,0 +1,70 @@
+# Progress — 2026-06-18 (session 656d42c5, /work)
+
+## Accomplished
+
+Picked up via `/work`; exercised judgment across the unclaimed feature queue.
+
+### #7783 (executable per-member Berlekamp irreducibility) — diagnosed & skipped
+
+Premise-checked the issue's proof route and found it **impossible as stated**.
+`berlekampFactor` (`Factor.lean:114-118`) fixes the witness set to `f`'s kernel
+`(fixedSpaceKernel f hmonic).toList` and applies it to *every* factor; loop
+termination gives, per factor `g`, `∀ w ∈ f-kernel, kernelWitnessSplit? g w =
+none`. But the only completeness producer
+`irreducible_of_no_kernelWitnessSplit_squareFree` (`RabinSoundness.lean:2994`)
+requires the factor's **own** kernel `(fixedSpaceKernel g _).toList`. No bridge
+between `f`'s kernel and a divisor's kernel exists in `HexBerlekamp/`. The
+theorem is *true* (Berlekamp completeness) but needs a new generalized
+completeness theorem (CRT-lift of a g-kernel splitter into f's kernel +
+span-mod-g linearity), not the thin per-factor composition. Posted evidence-rich
+comment, `coordination skip 7783` (→ replan).
+
+### #7786 (BHKS fast-core forward-recovery via _of_lift) — deliverable 1 landed
+
+- **Deliverable 1 (landed):** added
+  `factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut`
+  (`PartitionRefinement.lean`), the forward `factorFastFactorsWithBound`-level
+  raw-irreducibility wrapper with **no** `ForwardRecoveryInputs` param, routed
+  through `..._of_cut` (`:530`). Avoids the dead reverse `lattice_eq_indicators`
+  field (route-blocked behind #6779/#2564). Thin re-parameterization of the
+  `_of_forwardInputs` sibling (`:1010`).
+- **Deliverable 2 (blocked):** the producer feeding `_of_lift` needs the
+  per-support `∀ S, TrueFactorLift` family at first-success precision. Only the
+  single-subset constructors `trueFactorLiftOfSubset` /
+  `trueFactorLiftSemanticsOfToMonicSubset` (`LiftBridge.lean:78,104`) exist, and
+  they demand an exact `liftedFactorProduct d T = factor` witness per support —
+  the unproduced recovery/coverage direction. Every `∀ S, TrueFactorLift` is a
+  hypothesis, never a conclusion. Diagnosed on the issue with the missing-lemma
+  shape; partial PR.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement` → built the full
+  CI-gated library (3777 jobs), `Build completed successfully`, 0 `error:`.
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME` on
+  added lines.
+
+## Current frontier
+
+Deliverable 1's `_of_cut` wrapper is the furthest-forward fast-route piece; it
+composes the instant a deliverable-2 coverage producer exists.
+
+## Next step
+
+Replan deliverable 2 as its own issue gated on a coverage substrate: a producer
+concluding `∀ S : trueSupports, BHKS.TrueFactorLift L S` (+ semantics +
+separation) from the first-success recovery (the per-support exact
+`liftedFactorProduct d T = factor`). An *unconditional* form (for #6672) also
+needs the scheduled-loop determinism `hcore` (BHKS precision-soundness, not in
+tree). For #7783: replan as a generalized completeness theorem
+`irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd` + thin loop assembly.
+
+## Blockers
+
+- #7783: missing generalized completeness theorem (witness-set bridge).
+- #7786 deliverable 2: missing per-support coverage producer; unconditional form
+  additionally blocked on scheduled-loop determinism.
+
+Note: worktree carries pre-existing unrelated `.claude/*` modifications from
+before this session; not touched or staged.


### PR DESCRIPTION
This PR adds `factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut`, a forward `factorFastFactorsWithBound`-level raw-irreducibility wrapper that takes the forward cut certificates directly and routes through `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut`, with no `BHKS.ForwardRecoveryInputs` parameter. It deliberately avoids the structure's dead reverse `lattice_eq_indicators` separation (route-blocked behind #6779 / #2564) that nothing downstream reads, so a forward-only producer never has to inhabit it.

This is deliverable 1 of #7786 (partial). Deliverable 2 — a producer discharging the per-support `BHKS.TrueFactorLift` / semantics / Lemma-5.7 separation family (hence `hcut`) for the actual first-success recovery — remains blocked on a missing coverage substrate: only the single-subset constructors `trueFactorLiftOfSubset` / `trueFactorLiftSemanticsOfToMonicSubset` exist, and they demand an exact `liftedFactorProduct d T = factor` witness per support. See https://github.com/kim-em/hex/issues/7786#issuecomment-4733147484 for the missing-lemma shape.

🤖 Prepared with Claude Code