### PR TITLE
feat: prove divisor-generalized Berlekamp completeness (irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -62,6 +62,27 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   `DensePoly` lemma applied to an `FpPoly` goal. `exact` (defeq-tolerant) needs
   no such wrapper, so per-term closers like `exact toZMod_diagonalMulCoeffTerm …`
   match through the instance gap directly.
+- **`FpPoly` *products* need `FpPoly.*` rw lemmas, NOT `DensePoly.*_poly`.**
+  Same instance-path divergence: a product `a * z` you write for `FpPoly` terms
+  carries the canonical `Mul (ZMod64 p)`, but the general `DensePoly`
+  product lemmas (`mul_comm_poly`, `mul_assoc_poly`, `mul_add_right_poly`,
+  `mul_add_left_poly`, `neg_mul_right_poly`, `mul_sub_zero_comm`,
+  `sub_eq_add_neg_poly` *inside a product*) carry the `Lean.Grind.CommRing`-
+  derived `Mul`, so `rw [DensePoly.mul_comm_poly …]` reports "did not find
+  pattern" on a goal that visibly contains `a * z`. Use `FpPoly.mul_comm`,
+  `FpPoly.mul_assoc`, `FpPoly.left_distrib`, `FpPoly.right_distrib`,
+  `FpPoly.sub_eq_add_neg`, `FpPoly.add_assoc`, `FpPoly.add_left_neg`,
+  `FpPoly.add_right_neg`, `FpPoly.add_zero`, `FpPoly.mul_zero` for `rw`. There
+  is no `FpPoly.mul_sub`/`sub_mul`/`neg_mul`; derive them once from
+  `right_distrib`/`left_distrib` + additive cancellation (`a - b + b = a` via
+  `sub_eq_add_neg`+`add_assoc`+`add_left_neg`+`add_zero`). A `DensePoly` product
+  lemma still applies to an `FpPoly` goal via **`exact`/`:=`/`.trans`** (defeq-
+  tolerant) or by binding a `have` whose stated type uses the `FpPoly` ops
+  (then `rw [thatHave]`). `+`/`-`/coeff/`∣`/`Congr` lemmas (`DensePoly.coeff_add`
+  — needs an explicit `(0+0=0)` arg —, `coeff_sub_ring`, `dvd_add_poly`,
+  `dvd_mul_left_poly`, `congr_mod`, `mod_eq_mod_of_congr`) DO match `FpPoly`
+  under their `DensePoly` names. `grind` does *not* prove `FpPoly` product/ring
+  identities (only the `ZMod64` coefficient ring), so do not reach for it there.
 - **No `map_neg` / `map_one` / `map_zero` / `map_dvd` on `ZMod64`/`FpPoly`.**
   These need `ZeroHomClass`/`AddMonoidHomClass`/`Monoid` that the executable
   types don't have. To compute e.g. `toZMod (-1) = -1`: prove `(-1)+1 = 0` in
@@ -120,13 +141,19 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
 ## Proving *inside* the Mathlib-free files
 
 Lemmas that live in the executable files themselves (`HexPoly/*`,
-`HexPolyZ/*`, `HexBerlekampZassenhaus/Basic.lean`) cannot use Mathlib tactics
+`HexPolyZ/*`, `HexBerlekamp/*` including `RabinSoundness.lean`,
+`HexBerlekampZassenhaus/Basic.lean`) cannot use Mathlib tactics
 or `Monoid`/`CommRing` lemmas — those modules don't import Mathlib.
 
-- **`by_contra`, `ring`, `omega`-via-Mathlib are out.** `by_contra` reports
-  "unknown tactic"; replace with `rcases Nat.eq_zero_or_pos n` or
-  `rcases Nat.lt_trichotomy a b`. `omega`/`simp`/`rcases`/`conv` are core and
-  available.
+- **`by_contra`, `ring`, `omega`-via-Mathlib, `set`, `conv_lhs`/`conv_rhs`,
+  `push_neg` are out.** They report "unknown tactic". Replacements: `by_contra`
+  → `rcases Nat.eq_zero_or_pos n` / `rcases Nat.lt_trichotomy a b` /
+  `by_cases` + `Classical.byContradiction`; `set x := e` → `let x := e` (but a
+  `let` of a *huge* term blows the `whnf` heartbeat budget — `generalize e = x`
+  to an opaque var instead, after extracting the facts you need about `e`);
+  `push_neg` → `Classical.not_forall.mp` / `Classical.not_exists.mp`; `conv_lhs
+  => rw [h]` → `rw [h] at <aux-have>` then `exact`. `omega`/`simp`/`rcases` are
+  core and available.
 - **Integer `^` has no `pow_add`/`pow_succ`/`pow_one`/`one_pow` (Mathlib).**
   Use `Lean.Grind.Semiring.pow_succ` (`a^(n+1) = a^n * a`) and
   `Lean.Grind.Semiring.pow_zero`; `Int.one_pow`, `Int.mul_assoc`,

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -3451,6 +3451,163 @@ private theorem foldl_congr_const {α : Type _} (g : FpPoly p)
       have hsum := congr_add_of_congr ha0 hb0
       rwa [C_add_C] at hsum
 
+omit [ZMod64.PrimeModulus p] in
+/-- `d ∣ a → d ∣ a * z`, the right companion of `DensePoly.dvd_mul_left_poly`. -/
+private theorem dvd_mul_right_poly {d a : FpPoly p} (z : FpPoly p) (h : d ∣ a) :
+    d ∣ a * z := by
+  rcases h with ⟨e, he⟩
+  exact ⟨e * z, by rw [he, FpPoly.mul_assoc]⟩
+
+omit [ZMod64.PrimeModulus p] in
+/-- Two `(· + ·)`-`folds` with pointwise-equal step functions are equal. -/
+private theorem foldl_add_congr_terms {α : Type _} (F G : α → ZMod64 p) :
+    ∀ (xs : List α), (∀ k ∈ xs, F k = G k) →
+      ∀ init, xs.foldl (fun acc k => acc + F k) init =
+        xs.foldl (fun acc k => acc + G k) init := by
+  intro xs
+  induction xs with
+  | nil => intro _ init; rfl
+  | cons x xs ih =>
+      intro h init
+      simp only [List.foldl_cons]
+      rw [h x (by simp)]
+      exact ih (fun k hk => h k (List.mem_cons_of_mem _ hk)) (init + G x)
+
+/-- Each fixed-space kernel basis polynomial is reduced modulo `f`. -/
+private theorem fixedSpaceKernel_get_size_le
+    (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    (k : Fin (basisSize f - Matrix.rref_rank (fixedSpaceMatrix f hmonic))) :
+    ((fixedSpaceKernel f hmonic).get k).size ≤ basisSize f := by
+  have hker_eq :
+      (fixedSpaceKernel f hmonic).get k =
+        vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
+    unfold fixedSpaceKernel
+    rw [Vector.get_ofFn]
+  rw [hker_eq]
+  unfold vectorToPoly
+  have hle :
+      (FpPoly.ofCoeffs ((fixedSpaceKernelVectors f hmonic).get k).toArray).size ≤
+        ((fixedSpaceKernelVectors f hmonic).get k).toArray.size :=
+    DensePoly.size_ofCoeffs_le _
+  have hsz :
+      ((fixedSpaceKernelVectors f hmonic).get k).toArray.size = basisSize f :=
+    ((fixedSpaceKernelVectors f hmonic).get k).size_toArray
+  omega
+
+omit [ZMod64.PrimeModulus p] in
+/-- Square-freeness (as the `∀ d` divisor predicate) descends to a factor: if
+`g * cof = f` is square-free then so is `g`. -/
+private theorem squareFree_predicate_of_mul
+    (f g cof : FpPoly p) (hf_eq : g * cof = f)
+    (hsquareFree : ∀ d, d ∣ f → d ∣ DensePoly.derivative f →
+      isUnitPolynomial d = true) :
+    ∀ d, d ∣ g → d ∣ DensePoly.derivative g → isUnitPolynomial d = true := by
+  intro d hdg hdg'
+  apply hsquareFree d
+  · rcases hdg with ⟨e, he⟩
+    exact ⟨e * cof, by rw [← hf_eq, he, FpPoly.mul_assoc]⟩
+  · have hderiv : DensePoly.derivative f =
+        DensePoly.derivative g * cof + g * DensePoly.derivative cof := by
+      rw [← hf_eq]; exact DensePoly.derivative_mul g cof
+    rw [hderiv]
+    exact DensePoly.dvd_add_poly (dvd_mul_right_poly cof hdg')
+      (dvd_mul_right_poly (DensePoly.derivative cof) hdg)
+
+set_option maxHeartbeats 800000 in
+/--
+**CRT lift of a kernel witness.** Given `g * cof = f` with `f` square-free and
+`g` of positive degree, a `g`-kernel polynomial `hh` nonconstant modulo `g`
+lifts to an `f`-kernel polynomial `H` (reduced modulo `f`, hence
+`size ≤ basisSize f`) that is still nonconstant modulo `g`. The lift is the CRT
+combination `H ≡ hh (mod g)`, `H ≡ 0 (mod cof)`; coprimality of `g` and `cof`
+comes from square-freeness.
+-/
+private theorem exists_fKernel_witness_nonconst_mod_g
+    (f g cof : FpPoly p) (hf_eq : g * cof = f) (hf_ne : f ≠ 0)
+    (hg_pos : 0 < g.degree?.getD 0)
+    (hsquareFree : ∀ d, d ∣ f → d ∣ DensePoly.derivative f →
+      isUnitPolynomial d = true)
+    (hh : FpPoly p)
+    (hh_dvd : g ∣ (FpPoly.linearPow hh p - hh))
+    (hh_nonconst : ∀ c : ZMod64 p, ¬ DensePoly.Congr hh (DensePoly.C c) g) :
+    ∃ H : FpPoly p,
+      f ∣ (FpPoly.linearPow H p - H) ∧
+      H.size ≤ basisSize f ∧
+      ∀ c : ZMod64 p, ¬ DensePoly.Congr H (DensePoly.C c) g := by
+  haveI : DensePoly.DivModLaws (ZMod64 p) := ZMod64.instDivModLawsZMod64Fp p
+  have hg_ne : g ≠ 0 := ne_zero_of_pos_degree hg_pos
+  have hcof_ne : cof ≠ 0 := by
+    intro h; rw [h, FpPoly.mul_zero] at hf_eq; exact hf_ne hf_eq.symm
+  have hf_pos : 0 < f.degree?.getD 0 := by
+    rw [← hf_eq, FpPoly.degree?_mul_eq_add_degree? g cof hg_ne hcof_ne]; omega
+  -- Bezout from square-freeness: `gcd g cof ∣ 1`.
+  have hgcd_dvd_one : DensePoly.gcd g cof ∣ (1 : FpPoly p) :=
+    common_dvd_one_of_squareFree_mul
+      (fun e he hde => hsquareFree e (hf_eq ▸ he) (hf_eq ▸ hde))
+      (DensePoly.gcd_dvd_left g cof) (DensePoly.gcd_dvd_right g cof)
+  obtain ⟨s, t, hbez⟩ := exists_bezout_eq_one_of_gcd_dvd_one g cof hgcd_dvd_one
+  -- CRT combination `H0 ≡ hh (mod g)`, `H0 ≡ 0 (mod cof)`. Generalize the large
+  -- `polyCRT` term to an opaque `H0` to avoid `whnf` heartbeat blowups.
+  have hH0_g : DensePoly.Congr (DensePoly.polyCRT g cof hh 0 s t) hh g :=
+    DensePoly.polyCRT_congr_fst g cof hh 0 s t hbez
+  have hH0_cof : DensePoly.Congr (DensePoly.polyCRT g cof hh 0 s t) 0 cof :=
+    DensePoly.polyCRT_congr_snd g cof hh 0 s t hbez
+  generalize DensePoly.polyCRT g cof hh 0 s t = H0 at hH0_g hH0_cof
+  have hmg : H0 % g = hh % g :=
+    @DensePoly.mod_eq_mod_of_congr (ZMod64 p) inferInstance inferInstance inferInstance
+      (ZMod64.instDivModLawsZMod64Fp p) _ _ _ hH0_g
+  -- `g ∣ linearPow H0 p - H0`.
+  have hg_dvd_H0 : g ∣ (FpPoly.linearPow H0 p - H0) := by
+    have c1 : DensePoly.Congr (FpPoly.linearPow H0 p) (FpPoly.linearPow hh p) g :=
+      linearPow_congr_of_congr g H0 hh p hH0_g
+    have m1 : (FpPoly.linearPow H0 p) % g = (FpPoly.linearPow hh p) % g :=
+      @DensePoly.mod_eq_mod_of_congr (ZMod64 p) inferInstance inferInstance inferInstance
+        (ZMod64.instDivModLawsZMod64Fp p) _ _ _ c1
+    have m2 : (FpPoly.linearPow hh p) % g = hh % g :=
+      @DensePoly.mod_eq_mod_of_congr (ZMod64 p) inferInstance inferInstance inferInstance
+        (ZMod64.instDivModLawsZMod64Fp p) _ _ _ hh_dvd
+    have hmod : (FpPoly.linearPow H0 p) % g = H0 % g := by rw [m1, m2, ← hmg]
+    exact @DensePoly.congr_of_mod_eq_mod (ZMod64 p) inferInstance inferInstance inferInstance
+      (ZMod64.instDivModLawsZMod64Fp p) _ _ _ hmod
+  -- `cof ∣ linearPow H0 p - H0`.
+  have hcof_dvd_H0 : cof ∣ (FpPoly.linearPow H0 p - H0) :=
+    dvd_linearPow_sub_self_of_congr_zero cof H0 hH0_cof
+  -- `f ∣ linearPow H0 p - H0`.
+  have hf_dvd_H0 : f ∣ (FpPoly.linearPow H0 p - H0) := by
+    rw [← hf_eq]
+    exact mul_dvd_of_dvd_dvd_common hg_dvd_H0 hcof_dvd_H0
+      (fun d hdg hdc => common_dvd_one_of_bezout hbez d hdg hdc)
+  refine ⟨H0 % f, ?_, ?_, ?_⟩
+  · -- `f ∣ linearPow (H0 % f) p - (H0 % f)`.
+    have := (dvd_linearPow_sub_self_mod_iff f H0 1).mp (by simpa using hf_dvd_H0)
+    simpa using this
+  · -- `(H0 % f).size ≤ basisSize f`.
+    rw [basisSize]
+    have hlt := DensePoly.mod_degree_lt_of_pos_degree H0 f hf_pos
+    by_cases hsize : (H0 % f).size = 0
+    · omega
+    · have hpos : 0 < (H0 % f).size := Nat.pos_of_ne_zero hsize
+      have hdeg_eq : (H0 % f).degree?.getD 0 = (H0 % f).size - 1 := by
+        unfold DensePoly.degree?; simp [Nat.ne_of_gt hpos]
+      omega
+  · -- `H0 % f` is nonconstant modulo `g`.
+    intro c hc
+    apply hh_nonconst c
+    apply @DensePoly.congr_of_mod_eq_mod (ZMod64 p) inferInstance inferInstance inferInstance
+      (ZMod64.instDivModLawsZMod64Fp p) _ _ _
+    have e_hc : (H0 % f) % g = (DensePoly.C c) % g :=
+      @DensePoly.mod_eq_mod_of_congr (ZMod64 p) inferInstance inferInstance inferInstance
+        (ZMod64.instDivModLawsZMod64Fp p) _ _ _ hc
+    have e_modf : DensePoly.Congr (H0 % f) H0 g := by
+      have hcongr_f : DensePoly.Congr (H0 % f) H0 f :=
+        @DensePoly.congr_mod (ZMod64 p) inferInstance inferInstance inferInstance
+          (ZMod64.instDivModLawsZMod64Fp p) H0 f
+      exact fp_dvd_trans (⟨cof, hf_eq.symm⟩ : g ∣ f) hcongr_f
+    have e_modf' : (H0 % f) % g = H0 % g :=
+      @DensePoly.mod_eq_mod_of_congr (ZMod64 p) inferInstance inferInstance inferInstance
+        (ZMod64.instDivModLawsZMod64Fp p) _ _ _ e_modf
+    exact hmg.symm.trans (e_modf'.symm.trans e_hc)
+
 /--
 For a monic square-free `f` whose executable Berlekamp factorization returns
 at most one factor, `f` is irreducible. Composes the structural loop lemma

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -3699,6 +3699,163 @@ private theorem exists_basis_nonconst_mod_g
     obtain ⟨k, hk⟩ := Classical.not_forall.mp hall
     exact ⟨k, fun c hc => hk ⟨c, hc⟩⟩
 
+set_option maxHeartbeats 800000 in
+/--
+**Divisor-generalized Berlekamp completeness.** For a monic square-free `f` and
+a monic divisor `g ∣ f`, if no fixed-space kernel witness of `f` admits a
+Berlekamp split of `g`, then `g` is irreducible. This is the per-factor
+soundness obligation of `berlekampFactor`, which splits every returned factor
+with `f`'s single shared kernel. The case `f = g` recovers
+`irreducible_of_no_kernelWitnessSplit_squareFree`.
+
+The proof assumes a nontrivial factorization `g = a₀ * b₀`, extracts a monic
+irreducible factor `g₁ ∣ a₀` with monic cofactor `c₀ = g / g₁`, builds a
+`g`-kernel CRT witness `hh` nonconstant mod `g`, lifts it to an `f`-kernel
+witness `H` nonconstant mod `g` (`exists_fKernel_witness_nonconst_mod_g`), moves
+the nonconstancy to an `f`-basis polynomial `w` (`exists_basis_nonconst_mod_g`),
+and feeds `w` to the executable split surface to contradict `hno_split`.
+-/
+theorem irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd
+    (f g : FpPoly p) (hmonic : DensePoly.Monic f) (hg_monic : DensePoly.Monic g)
+    (hg_dvd_f : g ∣ f)
+    (hsquareFree : ∀ d, d ∣ f → d ∣ DensePoly.derivative f →
+      isUnitPolynomial d = true)
+    (hno_split : ∀ w ∈ (fixedSpaceKernel f hmonic).toList,
+      kernelWitnessSplit? g w = none) :
+    FpPoly.Irreducible g := by
+  haveI : DensePoly.DivModLaws (ZMod64 p) := ZMod64.instDivModLawsZMod64Fp p
+  have hf_ne_zero : f ≠ 0 := by
+    intro hzero
+    have hlead : f.leadingCoeff = 1 := hmonic
+    rw [hzero] at hlead
+    have hlead_zero : (0 : FpPoly p).leadingCoeff = 0 := by
+      change (0 : FpPoly p).coeffs.back?.getD 0 = 0
+      have hcoeffs : (0 : FpPoly p).coeffs = #[] := rfl
+      rw [hcoeffs]; rfl
+    rw [hlead_zero] at hlead
+    exact zmod64_one_ne_zero_local hlead.symm
+  have hg_ne_zero : g ≠ 0 := by
+    intro hzero
+    have hlead : g.leadingCoeff = 1 := hg_monic
+    rw [hzero] at hlead
+    have hlead_zero : (0 : FpPoly p).leadingCoeff = 0 := by
+      change (0 : FpPoly p).coeffs.back?.getD 0 = 0
+      have hcoeffs : (0 : FpPoly p).coeffs = #[] := rfl
+      rw [hcoeffs]; rfl
+    rw [hlead_zero] at hlead
+    exact zmod64_one_ne_zero_local hlead.symm
+  refine ⟨hg_ne_zero, ?_⟩
+  intro a₀ b₀ hab
+  by_cases ha₀_unit : a₀.degree? = some 0
+  · exact Or.inl ha₀_unit
+  refine Or.inr ?_
+  by_cases hb₀_unit : b₀.degree? = some 0
+  · exact hb₀_unit
+  exfalso
+  -- Both factors of `g` are nonconstant.
+  have ha₀_ne_zero : a₀ ≠ 0 := factor_ne_zero_of_ne_zero hab hg_ne_zero
+  have hb₀_ne_zero : b₀ ≠ 0 := by
+    have hba : b₀ * a₀ = g := by rw [FpPoly.mul_comm]; exact hab
+    exact factor_ne_zero_of_ne_zero hba hg_ne_zero
+  have ha₀_pos : 0 < a₀.degree?.getD 0 :=
+    pos_degree_of_ne_zero_of_not_isUnit ha₀_ne_zero ha₀_unit
+  have hb₀_pos : 0 < b₀.degree?.getD 0 :=
+    pos_degree_of_ne_zero_of_not_isUnit hb₀_ne_zero hb₀_unit
+  have ha₀_lt_g : a₀.degree?.getD 0 < basisSize g :=
+    factor_degree_lt_basisSize hab ha₀_ne_zero hb₀_pos
+  -- `g` is square-free (descent from `f`).
+  obtain ⟨cofg, hcofg⟩ := hg_dvd_f
+  have hsf_g : ∀ d, d ∣ g → d ∣ DensePoly.derivative g → isUnitPolynomial d = true :=
+    squareFree_predicate_of_mul f g cofg hcofg.symm hsquareFree
+  -- `g` has positive degree.
+  have hg_pos : 0 < g.degree?.getD 0 := by
+    have hdeg := FpPoly.degree?_mul_eq_add_degree? a₀ b₀ ha₀_ne_zero hb₀_ne_zero
+    rw [hab] at hdeg
+    omega
+  -- Extract a monic irreducible factor `g₁` of `a₀`, with cofactor `c₀ = g / g₁`.
+  obtain ⟨g₁, _hg₁_irr, hg₁_monic, hg₁_dvd_a₀, hg₁_deg_pos, hg₁_deg_le_a₀⟩ :=
+    exists_monic_irreducible_factor_of_factor hg_monic hab ha₀_pos
+  have hg₁_dvd_g : g₁ ∣ g := by
+    rcases hg₁_dvd_a₀ with ⟨r, hr⟩
+    refine ⟨r * b₀, ?_⟩
+    calc g = a₀ * b₀ := hab.symm
+      _ = (g₁ * r) * b₀ := by rw [hr]
+      _ = g₁ * (r * b₀) := FpPoly.mul_assoc g₁ r b₀
+  have hg₁_ne_zero : g₁ ≠ 0 := ne_zero_of_pos_degree hg₁_deg_pos
+  let c₀ : FpPoly p := g / g₁
+  have hc_eq : g₁ * c₀ = g := (fp_eq_mul_div_of_dvd hg₁_dvd_g).symm
+  have hc₀_ne_zero : c₀ ≠ 0 := by
+    intro hzero
+    rw [hzero, FpPoly.mul_zero] at hc_eq
+    exact hg_ne_zero hc_eq.symm
+  have hc₀_monic : DensePoly.Monic c₀ := by
+    have hlead : DensePoly.leadingCoeff g =
+        DensePoly.leadingCoeff g₁ * DensePoly.leadingCoeff c₀ := by
+      rw [← hc_eq]
+      exact FpPoly.leadingCoeff_mul g₁ c₀ hg₁_ne_zero hc₀_ne_zero
+    have hg_one : DensePoly.leadingCoeff g = 1 := hg_monic
+    have hg₁_one : DensePoly.leadingCoeff g₁ = 1 := hg₁_monic
+    unfold DensePoly.Monic
+    rw [hg₁_one, hg_one] at hlead
+    have hone_mul : (1 : ZMod64 p) * DensePoly.leadingCoeff c₀ =
+        DensePoly.leadingCoeff c₀ := by grind
+    rw [hone_mul] at hlead
+    exact hlead.symm
+  have hg₁_lt_g : g₁.degree?.getD 0 < basisSize g :=
+    Nat.lt_of_le_of_lt hg₁_deg_le_a₀ ha₀_lt_g
+  have hc₀_pos : 0 < c₀.degree?.getD 0 := by
+    have hdeg_eq : (g₁ * c₀).degree?.getD 0 =
+        g₁.degree?.getD 0 + c₀.degree?.getD 0 :=
+      FpPoly.degree?_mul_eq_add_degree? g₁ c₀ hg₁_ne_zero hc₀_ne_zero
+    rw [hc_eq] at hdeg_eq
+    unfold basisSize at hg₁_lt_g
+    omega
+  -- `g`-kernel CRT witness `hh`, nonconstant mod `g`.
+  obtain ⟨hh, hh_dvd, hh_nonconst, hh_size⟩ :=
+    exists_reduced_crtZeroOne_kernelWitness_of_squareFree_monic_split
+      g₁ c₀ hg₁_monic hc₀_monic hg₁_deg_pos hc₀_pos
+      (fun d hd hd' => hsf_g d (hc_eq ▸ hd) (hc_eq ▸ hd'))
+  rw [hc_eq] at hh_dvd hh_nonconst
+  -- Lift `hh` to an `f`-kernel witness `H`, still nonconstant mod `g`.
+  obtain ⟨H, hH_fdvd, hH_size, hH_nonconst⟩ :=
+    exists_fKernel_witness_nonconst_mod_g f g cofg hcofg.symm hf_ne_zero
+      hg_pos hsquareFree hh hh_dvd hh_nonconst
+  have hH_kernel : IsFixedSpaceKernelPolynomial f hmonic H := by
+    rw [isFixedSpaceKernelPolynomial_iff_dvd_linearPow_sub_self f hmonic H hH_size]
+    exact hH_fdvd
+  -- Move nonconstancy to an `f`-basis polynomial `w`.
+  obtain ⟨k, hk_nonconst⟩ :=
+    exists_basis_nonconst_mod_g f hmonic g H hH_kernel hH_size hH_nonconst
+  let w : FpPoly p := (fixedSpaceKernel f hmonic).get k
+  have hw_mem : w ∈ (fixedSpaceKernel f hmonic).toList := by
+    have hk_lt : k.val < (fixedSpaceKernel f hmonic).toList.length := by
+      rw [Vector.length_toList]; exact k.isLt
+    have hget : (fixedSpaceKernel f hmonic).toList[k.val]'hk_lt = w := by
+      rw [Vector.getElem_toList]; rfl
+    rw [← hget]; exact List.getElem_mem hk_lt
+  have hw_kernel : IsFixedSpaceKernelPolynomial f hmonic w :=
+    fixedSpaceKernel_sound f hmonic k
+  have hw_size_le : w.size ≤ basisSize f := fixedSpaceKernel_get_size_le f hmonic k
+  have hw_fdvd : f ∣ (FpPoly.linearPow w p - w) := by
+    rw [isFixedSpaceKernelPolynomial_iff_dvd_linearPow_sub_self f hmonic w hw_size_le]
+      at hw_kernel
+    exact hw_kernel
+  -- `g ∣ Π_c (w - C c)` (via `g ∣ f`) and `w` nonconstant mod `g`.
+  have hw_gdvd : g ∣ (FpPoly.linearPow w p - w) :=
+    fp_dvd_trans (⟨cofg, hcofg⟩ : g ∣ f) hw_fdvd
+  have hw_prod : g ∣ (ZMod64.values p).foldl
+      (fun acc c => acc * (w - FpPoly.C c)) 1 :=
+    dvd_primeFieldProduct_witness_of_dvd_linearPow_sub_self hw_gdvd
+  have hw_nonconst : ∀ c : ZMod64 p, ¬ (g ∣ (w - FpPoly.C c)) :=
+    fun c hc => hk_nonconst c hc
+  -- The executable split surface produces a split of `g`, contradicting `hno_split`.
+  obtain ⟨r, hsplit⟩ :=
+    exists_kernelWitnessSplit?_some_of_witnessProduct_dvd_of_pos_degree
+      hg_pos hw_prod hw_nonconst
+  have hno_w : kernelWitnessSplit? g w = none := hno_split w hw_mem
+  rw [hno_w] at hsplit
+  nomatch hsplit
+
 /--
 For a monic square-free `f` whose executable Berlekamp factorization returns
 at most one factor, `f` is irreducible. Composes the structural loop lemma

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -3313,6 +3313,144 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree
     rw [hno_w] at hsplit
     nomatch hsplit
 
+/-! ### Divisor-generalized Berlekamp completeness
+
+The single-polynomial theorem above ranges `hno_split` over `f`'s own kernel.
+The executable `berlekampFactor` (`HexBerlekamp/Factor.lean`) computes the
+witness set once as `f`'s kernel and splits *every* returned factor `g` with it,
+so the per-factor soundness obligation is the divisor-generalized form: `g ∣ f`,
+square-free `f`, no `f`-kernel witness splits `g`, conclude `g` irreducible. The
+new content is a CRT lift of a `g`-kernel witness to an `f`-kernel witness that
+stays nonconstant mod `g`, plus a span-mod-`g` argument moving the nonconstancy
+to an `f`-basis element. -/
+
+omit [ZMod64.PrimeModulus p] in
+/-- `C a * C b = C (a * b)` for `FpPoly`. -/
+private theorem C_mul_C (a b : ZMod64 p) :
+    (DensePoly.C a : FpPoly p) * DensePoly.C b = DensePoly.C (a * b) := by
+  rw [FpPoly.C_mul_eq_scale]
+  rw [show (DensePoly.C b : FpPoly p) = DensePoly.scale b (1 : FpPoly p) from
+        (FpPoly.scale_one_poly b).symm]
+  rw [FpPoly.scale_scale, FpPoly.scale_one_poly]
+
+omit [ZMod64.PrimeModulus p] in
+/-- `C a + C b = C (a + b)` for `FpPoly`. -/
+private theorem C_add_C (a b : ZMod64 p) :
+    (DensePoly.C a : FpPoly p) + DensePoly.C b = DensePoly.C (a + b) := by
+  apply DensePoly.ext_coeff
+  intro i
+  have h0 : (0 : ZMod64 p) + (0 : ZMod64 p) = 0 := by grind
+  rw [DensePoly.coeff_add (DensePoly.C a) (DensePoly.C b) i h0,
+      DensePoly.coeff_C, DensePoly.coeff_C, DensePoly.coeff_C]
+  by_cases hi : i = 0
+  · rw [if_pos hi, if_pos hi, if_pos hi]
+  · rw [if_neg hi, if_neg hi, if_neg hi]; exact h0
+
+omit [ZMod64.PrimeModulus p] in
+/-- The `i`-th coefficient of `q * C c` is `q.coeff i * c`. -/
+private theorem coeff_mul_C (q : FpPoly p) (c : ZMod64 p) (i : Nat) :
+    (q * DensePoly.C c).coeff i = q.coeff i * c := by
+  rw [FpPoly.mul_comm, FpPoly.C_mul_eq_scale]
+  have h_zero : c * (0 : ZMod64 p) = 0 := by grind
+  rw [DensePoly.coeff_scale _ _ _ h_zero]
+  grind
+
+omit [ZMod64.PrimeModulus p] in
+/-- `(a - b) + b = a` for `FpPoly`. -/
+private theorem sub_add_cancel_poly (a b : FpPoly p) : a - b + b = a := by
+  rw [FpPoly.sub_eq_add_neg, FpPoly.add_assoc, FpPoly.add_left_neg, FpPoly.add_zero]
+
+omit [ZMod64.PrimeModulus p] in
+/-- `(x + y) - y = x` for `FpPoly`. -/
+private theorem add_sub_cancel_poly (x y : FpPoly p) : x + y - y = x := by
+  rw [FpPoly.sub_eq_add_neg, FpPoly.add_assoc, FpPoly.add_right_neg, FpPoly.add_zero]
+
+omit [ZMod64.PrimeModulus p] in
+/-- Left distributivity over subtraction for `FpPoly`. -/
+private theorem mul_sub_poly (z a b : FpPoly p) :
+    z * (a - b) = z * a - z * b := by
+  have key : z * a = z * (a - b) + z * b := by
+    have h := FpPoly.left_distrib z (a - b) b
+    rw [sub_add_cancel_poly a b] at h
+    exact h
+  rw [key, add_sub_cancel_poly]
+
+omit [ZMod64.PrimeModulus p] in
+/-- Right distributivity over subtraction for `FpPoly`. -/
+private theorem sub_mul_poly (a b z : FpPoly p) :
+    (a - b) * z = a * z - b * z := by
+  rw [FpPoly.mul_comm (a - b) z, mul_sub_poly z a b, FpPoly.mul_comm z a,
+      FpPoly.mul_comm z b]
+
+omit [ZMod64.PrimeModulus p] in
+/-- Polynomial congruence modulo `m` is preserved by addition. -/
+private theorem congr_add_of_congr {m a b c d : FpPoly p}
+    (hab : DensePoly.Congr a b m) (hcd : DensePoly.Congr c d m) :
+    DensePoly.Congr (a + c) (b + d) m := by
+  have h0 : (0 : ZMod64 p) + (0 : ZMod64 p) = 0 := by grind
+  have heq : (a + c) - (b + d) = (a - b) + (c - d) := by
+    apply DensePoly.ext_coeff
+    intro i
+    rw [DensePoly.coeff_sub_ring,
+        DensePoly.coeff_add a c i h0, DensePoly.coeff_add b d i h0,
+        DensePoly.coeff_add (a - b) (c - d) i h0,
+        DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
+    grind
+  rw [DensePoly.Congr, heq]
+  exact DensePoly.dvd_add_poly hab hcd
+
+omit [ZMod64.PrimeModulus p] in
+/-- Polynomial congruence modulo `m` is preserved by right multiplication. -/
+private theorem congr_mul_right_of_congr {m a b : FpPoly p} (z : FpPoly p)
+    (hab : DensePoly.Congr a b m) :
+    DensePoly.Congr (a * z) (b * z) m := by
+  rcases hab with ⟨r, hr⟩
+  refine ⟨r * z, ?_⟩
+  rw [← sub_mul_poly a b z]
+  rw [show a - b = m * r from hr, FpPoly.mul_assoc]
+
+omit [ZMod64.PrimeModulus p] in
+/-- The `i`-th coefficient commutes with a `(· + ·)`-`foldl` of polynomials. -/
+private theorem coeff_foldl_add {α : Type _} (xs : List α)
+    (term : α → FpPoly p) (i : Nat) :
+    (xs.foldl (fun acc k => acc + term k) 0).coeff i =
+      xs.foldl (fun acc k => acc + (term k).coeff i) 0 := by
+  have h0 : (0 : ZMod64 p) + (0 : ZMod64 p) = 0 := by grind
+  suffices h : ∀ init : FpPoly p,
+      (xs.foldl (fun acc k => acc + term k) init).coeff i =
+        xs.foldl (fun acc k => acc + (term k).coeff i) (init.coeff i) by
+    have hh := h 0
+    rwa [DensePoly.coeff_zero] at hh
+  intro init
+  induction xs generalizing init with
+  | nil => rfl
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      rw [ih (init + term x), DensePoly.coeff_add init (term x) i h0]
+
+omit [ZMod64.PrimeModulus p] in
+/-- If every term of a `(· + ·)`-`foldl` is constant modulo `g` (and the
+accumulator starts constant), the whole fold is constant modulo `g`. -/
+private theorem foldl_congr_const {α : Type _} (g : FpPoly p)
+    (term : α → FpPoly p) :
+    ∀ (xs : List α),
+      (∀ k ∈ xs, ∃ a : ZMod64 p, DensePoly.Congr (term k) (DensePoly.C a) g) →
+      ∀ init : FpPoly p, (∃ a, DensePoly.Congr init (DensePoly.C a) g) →
+        ∃ a, DensePoly.Congr (xs.foldl (fun acc k => acc + term k) init)
+          (DensePoly.C a) g := by
+  intro xs
+  induction xs with
+  | nil => intro _ init hinit; exact hinit
+  | cons x xs ih =>
+      intro hterms init hinit
+      obtain ⟨a0, ha0⟩ := hinit
+      simp only [List.foldl_cons]
+      apply ih (fun k hk => hterms k (List.mem_cons_of_mem _ hk)) (init + term x)
+      obtain ⟨b0, hb0⟩ := hterms x (by simp)
+      refine ⟨a0 + b0, ?_⟩
+      have hsum := congr_add_of_congr ha0 hb0
+      rwa [C_add_C] at hsum
+
 /--
 For a monic square-free `f` whose executable Berlekamp factorization returns
 at most one factor, `f` is irreducible. Composes the structural loop lemma

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -3608,6 +3608,97 @@ private theorem exists_fKernel_witness_nonconst_mod_g
         (ZMod64.instDivModLawsZMod64Fp p) _ _ _ e_modf
     exact hmg.symm.trans (e_modf'.symm.trans e_hc)
 
+set_option maxHeartbeats 800000 in
+/--
+**Span-mod-`g`.** If an `f`-kernel polynomial `H` (reduced mod `f`) is
+nonconstant modulo `g`, then some `f`-kernel basis polynomial is nonconstant
+modulo `g`. Contrapositive: were every basis polynomial constant mod `g`, then
+`H`, being their `F_p`-linear combination
+(`fixedSpaceKernelPolynomial_coeffVector_complete`), would be constant mod `g`.
+-/
+private theorem exists_basis_nonconst_mod_g
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) (g : FpPoly p)
+    (H : FpPoly p) (hH_kernel : IsFixedSpaceKernelPolynomial f hmonic H)
+    (hH_size : H.size ≤ basisSize f)
+    (hH_nonconst : ∀ c : ZMod64 p, ¬ DensePoly.Congr H (DensePoly.C c) g) :
+    ∃ k : Fin (basisSize f - Matrix.rref_rank (fixedSpaceMatrix f hmonic)),
+      ∀ c : ZMod64 p,
+        ¬ DensePoly.Congr ((fixedSpaceKernel f hmonic).get k) (DensePoly.C c) g := by
+  by_cases hall : ∀ k : Fin (basisSize f - Matrix.rref_rank (fixedSpaceMatrix f hmonic)),
+      ∃ c : ZMod64 p,
+        DensePoly.Congr ((fixedSpaceKernel f hmonic).get k) (DensePoly.C c) g
+  · -- Every basis polynomial is constant mod `g`; derive that `H` is too.
+    exfalso
+    obtain ⟨c_coeff, hc_eq⟩ :=
+      fixedSpaceKernelPolynomial_coeffVector_complete f hmonic H hH_kernel
+    let ndim := basisSize f - Matrix.rref_rank (fixedSpaceMatrix f hmonic)
+    let term : Fin ndim → FpPoly p := fun k =>
+      (fixedSpaceKernel f hmonic).get k * DensePoly.C (c_coeff[k.val]'k.isLt)
+    -- The span polynomial `P = Σ_k basis_k · c_coeff[k]` is constant mod `g`.
+    have hP_const : ∃ a, DensePoly.Congr
+        ((List.finRange ndim).foldl (fun acc k => acc + term k) 0)
+        (DensePoly.C a) g := by
+      refine foldl_congr_const g term (List.finRange ndim) ?_ 0 ?_
+      · intro k _hk
+        obtain ⟨a, ha⟩ := hall k
+        refine ⟨a * (c_coeff[k.val]'k.isLt), ?_⟩
+        have h1 := congr_mul_right_of_congr (DensePoly.C (c_coeff[k.val]'k.isLt)) ha
+        rwa [C_mul_C] at h1
+      · refine ⟨0, 0, ?_⟩
+        have hC0 : (DensePoly.C (0 : ZMod64 p) : FpPoly p) = 0 := by
+          apply DensePoly.ext_coeff; intro i
+          rw [DensePoly.coeff_C, DensePoly.coeff_zero]; split <;> rfl
+        rw [hC0, FpPoly.mul_zero]
+        exact FpPoly.sub_self 0
+    -- And `H` equals that span polynomial.
+    have hHP : H = (List.finRange ndim).foldl (fun acc k => acc + term k) 0 := by
+      apply DensePoly.ext_coeff
+      intro i
+      rw [coeff_foldl_add (List.finRange ndim) term i]
+      by_cases hi : i < basisSize f
+      · have hget :
+            (Matrix.mulVec (Matrix.nullspaceBasisMatrix (fixedSpaceMatrix f hmonic))
+                c_coeff)[i]'hi = (coeffVector f H)[i]'hi :=
+          congrArg (fun v : Vector (ZMod64 p) (basisSize f) => v[i]'hi) hc_eq
+        have hrhs : (coeffVector f H)[i]'hi = H.coeff i := by
+          unfold coeffVector; rw [Vector.getElem_ofFn]
+        have hlhs :
+            (Matrix.mulVec (Matrix.nullspaceBasisMatrix (fixedSpaceMatrix f hmonic))
+                c_coeff)[i]'hi =
+              (List.finRange ndim).foldl
+                (fun acc k => acc +
+                  ((Matrix.nullspaceBasisMatrix (fixedSpaceMatrix f hmonic))[i]'hi)[k.val]'k.isLt *
+                    c_coeff[k.val]'k.isLt) 0 := by
+          unfold Matrix.mulVec Matrix.dot Hex.Vector.dotProduct Matrix.row
+          rw [Vector.getElem_ofFn hi]; rfl
+        rw [hlhs, hrhs] at hget
+        rw [← hget]
+        apply foldl_add_congr_terms
+        intro k _hk
+        rw [nullspaceBasisMatrix_entry_eq_basis_coeff f hmonic k i hi]
+        show ((fixedSpaceKernel f hmonic).get k).coeff i * (c_coeff[k.val]'k.isLt)
+          = ((fixedSpaceKernel f hmonic).get k *
+              DensePoly.C (c_coeff[k.val]'k.isLt)).coeff i
+        rw [coeff_mul_C]
+      · have hi' : basisSize f ≤ i := Nat.le_of_not_lt hi
+        rw [DensePoly.coeff_eq_zero_of_size_le H (Nat.le_trans hH_size hi')]
+        symm
+        apply foldl_add_eq_zero_of_terms_zero
+        intro k _hk
+        have hbz : ((fixedSpaceKernel f hmonic).get k).coeff i = 0 :=
+          DensePoly.coeff_eq_zero_of_size_le _
+            (Nat.le_trans (fixedSpaceKernel_get_size_le f hmonic k) hi')
+        show ((fixedSpaceKernel f hmonic).get k *
+            DensePoly.C (c_coeff[k.val]'k.isLt)).coeff i = 0
+        rw [coeff_mul_C, hbz]
+        simp
+    rw [hHP] at hH_nonconst
+    obtain ⟨a, ha⟩ := hP_const
+    exact hH_nonconst a ha
+  · -- Some basis polynomial is nonconstant mod `g`.
+    obtain ⟨k, hk⟩ := Classical.not_forall.mp hall
+    exact ⟨k, fun c hc => hk ⟨c, hc⟩⟩
+
 /--
 For a monic square-free `f` whose executable Berlekamp factorization returns
 at most one factor, `f` is irreducible. Composes the structural loop lemma

--- a/progress/20260617_174000_00e03396.md
+++ b/progress/20260617_174000_00e03396.md
@@ -1,0 +1,49 @@
+# Progress - 2026-06-17 (session 00e03396, feature #7788)
+
+## Accomplished
+
+Claimed and completed #7788: divisor-generalized Berlekamp completeness
+(`irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd`) in
+`HexBerlekamp/RabinSoundness.lean` (+543 lines, no sorry/axiom).
+
+The new theorem: for monic square-free `f` and monic `g ∣ f`, if no `f`-kernel
+witness splits `g`, then `g` is irreducible. This closes the witness-set
+mismatch diagnosed on #7783 (`berlekampFactor` splits every factor with `f`'s
+single shared kernel, so the per-factor obligation is `f`'s kernel applied to a
+divisor `g`, not `g`'s own kernel).
+
+Proof pieces added:
+- Small FpPoly algebra: `C_mul_C`, `C_add_C`, `coeff_mul_C`, `sub_add_cancel_poly`,
+  `add_sub_cancel_poly`, `mul_sub_poly`, `sub_mul_poly`, `congr_add_of_congr`,
+  `congr_mul_right_of_congr`, `coeff_foldl_add`, `foldl_congr_const`,
+  `foldl_add_congr_terms`, `dvd_mul_right_poly`, `fixedSpaceKernel_get_size_le`.
+- `squareFree_predicate_of_mul`: square-freeness descends to a factor (Leibniz
+  `derivative_mul`).
+- `exists_fKernel_witness_nonconst_mod_g`: CRT lift of a `g`-kernel witness to
+  an `f`-kernel witness nonconstant mod `g`, via `polyCRT` (H ≡ hh mod g, ≡ 0
+  mod cof) + `linearPow_congr_of_congr` + coprimality from square-freeness.
+- `exists_basis_nonconst_mod_g`: span-mod-`g` — if `H` (f-kernel) is nonconstant
+  mod `g`, some `f`-basis poly is too (else `H = Σ basis_k·c_k` is constant mod g).
+
+Verification: `lake build HexBerlekamp` clean; `grep -c sorry` = 0;
+added-line forbidden-token scan clean. The file is Mathlib-free (executable
+side), so no Mathlib-layer CI concern.
+
+## Current frontier
+
+The theorem is the load-bearing half of #7783. Its thin per-factor capstone
+`berlekampFactor_factors_irreducible` (#7789, currently `blocked on #7788`)
+becomes claimable once this merges.
+
+## Next step
+
+#7789: compose `irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd` with the
+structural loop lemma giving `∀ w ∈ f's kernel, kernelWitnessSplit? g w = none`
+for each returned factor `g`, plus `g ∣ f` / `g` monic at loop termination.
+
+## Blockers
+
+None. Updated `hex-lean-mathlib-boundary` skill with the FpPoly-product
+instance-path gotcha (use `FpPoly.*` rw lemmas, not `DensePoly.*_poly`) and the
+Mathlib-free tactic restrictions (`set`/`conv_lhs`/`push_neg` unavailable in the
+executable Berlekamp files) — both cost several build cycles this session.


### PR DESCRIPTION
Closes #7788

This PR proves divisor-generalized Berlekamp completeness in `HexBerlekamp/RabinSoundness.lean`: for a monic square-free `f` and a monic divisor `g ∣ f`, if no fixed-space kernel witness of `f` admits a Berlekamp split of `g`, then `g` is irreducible (`irreducible_of_no_kernelWitnessSplit_squareFree_of_dvd`). This closes the witness-set mismatch diagnosed on #7783: `berlekampFactor` computes the kernel once from `f` and splits every returned factor with it, so the per-factor soundness obligation ranges `f`'s kernel over a divisor `g`, not `g`'s own kernel, which the existing single-polynomial theorem does not cover. The new content is a CRT lift of a `g`-kernel witness to an `f`-kernel witness that stays nonconstant modulo `g` (via `polyCRT` and `linearPow_congr_of_congr`, with coprimality from square-freeness), plus a span-mod-`g` argument moving the nonconstancy to an `f`-basis polynomial fed to the executable split surface. The case `f = g` recovers the existing `irreducible_of_no_kernelWitnessSplit_squareFree`.

The change is entirely on the Mathlib-free executable side (no new `sorry`/`axiom`); it also records the FpPoly-product instance-path gotcha and the Mathlib-free tactic restrictions in the `hex-lean-mathlib-boundary` skill.

🤖 Prepared with Claude Code