### PR TITLE
test: guard heavy-split irreducible backstops (swinnerton_dyer_sd3, phi15) through factorSlowModular

### DIFF
--- a/HexBerlekampZassenhaus/Conformance.lean
+++ b/HexBerlekampZassenhaus/Conformance.lean
@@ -44,6 +44,9 @@ Covered edge cases:
 - exhaustive slow-backstop and BHKS recovery branch inputs
 - four-way modular split inputs whose integer factors are quadratic subset
   products
+- eight-way modular split inputs (`swinnertonDyerSD3`, `phi15`) that are
+  irreducible over `ℤ`, where every `2^8` subset product is rejected and the
+  modular backstop and public `factor` fall back to the single input
 - valid, wrong-prime, missing-obstruction, malformed-degree, and composite
   integer irreducibility certificates
 -/
@@ -585,6 +588,38 @@ recovered true factor.
   factorPreservesProduct x4Plus1 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[x4Plus1] |>.map fun coeffs => (coeffs, 1))
+
+-- Heavy (8-way split) adversarial backstop cases: `swinnertonDyerSD3` and
+-- `phi15` each split into eight linear factors over their small admissible
+-- prime yet are irreducible over `ℤ`.  The exhaustive *modular* recombination
+-- must reject every one of the `2^8` proper subset products and fall back to
+-- the single irreducible input. This is the genuine worst case for "no
+-- spurious recombination," dual to the `quadSqrt2Sqrt3` / `x4Plus1` guards
+-- above.
+#guard
+  match factorSlowModular swinnertonDyerSD3 with
+  | some φ =>
+      Factorization.product φ = swinnertonDyerSD3 &&
+        sameFactorCoeffSet (factorizationCoeffSummary φ)
+          (factorCoeffSummary #[swinnertonDyerSD3] |>.map fun coeffs => (coeffs, 1))
+  | none => false
+#guard
+  let factors := factor swinnertonDyerSD3
+  factorPreservesProduct swinnertonDyerSD3 &&
+    sameFactorCoeffSet (factorizationCoeffSummary factors)
+      (factorCoeffSummary #[swinnertonDyerSD3] |>.map fun coeffs => (coeffs, 1))
+#guard
+  match factorSlowModular phi15 with
+  | some φ =>
+      Factorization.product φ = phi15 &&
+        sameFactorCoeffSet (factorizationCoeffSummary φ)
+          (factorCoeffSummary #[phi15] |>.map fun coeffs => (coeffs, 1))
+  | none => false
+#guard
+  let factors := factor phi15
+  factorPreservesProduct phi15 &&
+    sameFactorCoeffSet (factorizationCoeffSummary factors)
+      (factorCoeffSummary #[phi15] |>.map fun coeffs => (coeffs, 1))
 
 #guard PrimeFactorData.degreeSum primeDataValidQuad = 2
 #guard coeffNats (PrimeFactorData.factorProduct primeDataValidQuad) = [2, 0, 1]

--- a/progress/20260617T180851Z_3177be69.md
+++ b/progress/20260617T180851Z_3177be69.md
@@ -1,0 +1,39 @@
+# Session 3177be69 — feature #7790
+
+## Accomplished
+
+Added heavy (8-way split) adversarial backstop guards to
+`HexBerlekampZassenhaus/Conformance.lean` for `swinnertonDyerSD3`
+(`x^8 - 40x^6 + 352x^4 - 960x^2 + 576`) and `phi15` (Φ₁₅). Both split into
+eight linear factors over their small admissible primes (71 and 31) yet are
+irreducible over ℤ, so the exhaustive modular recombination must reject all
+`2^8` proper subset products and fall back to the single irreducible input.
+
+Four new `#guard`s, dual to the existing `quadSqrt2Sqrt3` / `x4Plus1` guards:
+
+1. `factorSlowModular swinnertonDyerSD3` recovers the single irreducible
+   factor (`some φ` match, product preserved, coeff set = `#[swinnertonDyerSD3]`).
+2. `factor swinnertonDyerSD3` falls back to the single input.
+3. + 4. The same pair for `phi15`.
+
+Verified the actual runtime output with temporary `#eval`s before pinning
+(both confirmed single-factor-equal-to-input, product preserved); the temps
+were removed. Added the two fixtures to the docstring covered-edge-cases note.
+
+Reused existing helpers (`factorPreservesProduct`, `sameFactorCoeffSet`,
+`factorizationCoeffSummary`, `factorCoeffSummary`); no new helper, no
+algorithm change.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhaus.Conformance` and
+`lake build HexBerlekampZassenhaus` both clean. `git diff --check` clean;
+no `sorry` / `axiom` / `native_decide` / `TODO` / `FIXME` on added lines.
+
+## Next step
+
+PR closing #7790.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7790

This PR adds heavy eight-way-split adversarial backstop guards to `HexBerlekampZassenhaus/Conformance.lean` for `swinnertonDyerSD3` and `phi15`. Both polynomials split into eight linear factors over their small admissible primes (71 and 31) yet are irreducible over ℤ, so the exhaustive modular recombination must reject all `2^8` proper subset products and fall back to the single irreducible input. Four new `#guard`s pin `factorSlowModular` and the public `factor` fallback for each fixture, dual to the existing `quadSqrt2Sqrt3` / `x4Plus1` guards. The runtime output was confirmed with temporary `#eval`s before pinning. Reuses existing helpers with no algorithm change.

Session: `3177be69-12ae-435b-bae3-4a314fc25e83`

🤖 Prepared with Claude Code