### PR TITLE
HexGFqMathlib Phase 5: prove the FpPoly base-p index encode/decode bijection (Basic.lean)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -666,7 +666,11 @@ restructure around the reported line first; it is usually a cheap `omega` or
   between the `/-- … -/` and the `structure`/`def`/`theorem` keyword** — a doc
   comment binds to the declaration it is adjacent to, so the wrong order gives a
   parse error (`unexpected token 'set_option'; expected 'lemma'`). Order is
-  `set_option … in` → `/-- doc -/` → `structure …`. Once the budget is large
+  `set_option … in` → `/-- doc -/` → `structure …`. The same applies to any
+  `… in` declaration modifier — e.g. `omit [Inst] in` to silence the
+  unused-section-variable linter on a pure-`Nat` helper in an instance-carrying
+  `variable` block — must come *before* the docstring (`omit … in` → `/-- doc -/`
+  → `theorem …`), else the same `unexpected token 'omit'` parse error. Once the budget is large
   enough, the *real* error often surfaces (e.g. an inline `by omega` whose
   target type wasn't yet determined because it sat under `lt_of_le_of_lt _ (by
   omega)` — fix by giving the bound an explicitly-typed `have h2 : … := by

--- a/HexGFqMathlib/Basic.lean
+++ b/HexGFqMathlib/Basic.lean
@@ -33,23 +33,158 @@ def ofIndexBelowDegree (degree index : Nat) : Hex.FpPoly p :=
     ((List.range degree).map fun i =>
       Hex.ZMod64.ofNat p (index / p ^ i)).toArray
 
+/-- Peeling the top position of the base-`p` encoding. -/
+theorem coeffIndex_succ (degree : Nat) (f : Hex.FpPoly p) :
+    coeffIndex (degree + 1) f
+      = coeffIndex degree f + (f.coeff degree).toNat * p ^ degree := by
+  unfold coeffIndex
+  rw [List.range_succ, List.foldl_append]
+  simp
+
+/-- `coeffIndex` is the base-`p` interpretation of the per-position residue
+digits, exposing Mathlib's `Nat.ofDigits` API. -/
+theorem coeffIndex_eq_ofDigits (degree : Nat) (f : Hex.FpPoly p) :
+    coeffIndex degree f
+      = Nat.ofDigits p ((List.range degree).map (fun i => (f.coeff i).toNat)) := by
+  induction degree with
+  | zero => simp [coeffIndex]
+  | succ d ih =>
+    rw [coeffIndex_succ, ih, List.range_succ, List.map_append, List.map_cons,
+      List.map_nil, Nat.ofDigits_append, Nat.ofDigits_singleton, List.length_map,
+      List.length_range]
+    ring
+
+/-- A base-`p` positional sum of `degree` residue digits stays below `p ^ degree`. -/
+theorem coeffIndex_lt (degree : Nat) (f : Hex.FpPoly p) :
+    coeffIndex degree f < p ^ degree := by
+  induction degree with
+  | zero => simp [coeffIndex]
+  | succ d ih =>
+    rw [coeffIndex_succ, pow_succ]
+    have hb : (f.coeff d).toNat < p := Hex.ZMod64.toNat_lt _
+    have hq : 0 < p ^ d := pow_pos Hex.ZMod64.Bounds.pPos d
+    calc coeffIndex d f + (f.coeff d).toNat * p ^ d
+        < p ^ d + (f.coeff d).toNat * p ^ d := by omega
+      _ = ((f.coeff d).toNat + 1) * p ^ d := by ring
+      _ ≤ p * p ^ d := by exact Nat.mul_le_mul_right _ (by omega)
+      _ = p ^ d * p := Nat.mul_comm _ _
+
+omit [Hex.ZMod64.Bounds p] in
+/-- Extracting digit `j` of a base-`p` number presented through `Nat.ofDigits`. -/
+theorem ofDigits_div_pow_mod (hp : 0 < p) (L : List Nat)
+    (hL : ∀ x ∈ L, x < p) (j : Nat) (hj : j < L.length) :
+    Nat.ofDigits p L / p ^ j % p = L.getD j 0 := by
+  rw [Nat.ofDigits_div_pow_eq_ofDigits_drop j hp L hL,
+    List.drop_eq_getElem_cons hj, Nat.ofDigits_cons, Nat.add_mul_mod_self_left,
+    Nat.mod_eq_of_lt (hL _ (List.getElem_mem hj)),
+    List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hj, Option.getD_some]
+
+omit [Hex.ZMod64.Bounds p] in
+/-- Reconstructing a number below `p ^ degree` from its fixed-width base-`p`
+digits. -/
+theorem ofDigits_range_map_div_pow_mod (hp : 0 < p) :
+    ∀ (degree n : Nat), n < p ^ degree →
+      Nat.ofDigits p ((List.range degree).map (fun i => n / p ^ i % p)) = n := by
+  intro degree
+  induction degree with
+  | zero =>
+    intro n hn
+    simp only [pow_zero, Nat.lt_one_iff] at hn
+    subst hn
+    simp
+  | succ d ih =>
+    intro n hn
+    rw [List.range_succ_eq_map, List.map_cons, List.map_map, Nat.ofDigits_cons]
+    have hfun : ((fun i => n / p ^ i % p) ∘ Nat.succ)
+        = (fun i => n / p / p ^ i % p) := by
+      funext i
+      have hpow : p ^ (i + 1) = p * p ^ i := by rw [pow_succ]; ring
+      simp only [Function.comp_apply, hpow, Nat.div_div_eq_div_mul]
+    rw [hfun]
+    have hdiv : n / p < p ^ d := by
+      rw [Nat.div_lt_iff_lt_mul hp]
+      calc n < p ^ (d + 1) := hn
+        _ = p ^ d * p := by rw [pow_succ]
+    rw [ih (n / p) hdiv]
+    simp only [pow_zero, Nat.div_one]
+    exact Nat.mod_add_div n p
+
+/-- Coefficients below the width read back the encoded base-`p` digit. -/
+theorem coeff_ofIndexBelowDegree_of_lt (degree index i : Nat) (hi : i < degree) :
+    (ofIndexBelowDegree (p := p) degree index).coeff i
+      = Hex.ZMod64.ofNat p (index / p ^ i) := by
+  unfold ofIndexBelowDegree Hex.FpPoly.ofCoeffs
+  rw [Hex.DensePoly.coeff_ofCoeffs]
+  simp [Array.getD_eq_getD_getElem?, List.getElem?_range hi]
+
+/-- Coefficients at or beyond the width vanish. -/
+theorem coeff_ofIndexBelowDegree_of_ge (degree index i : Nat) (hi : degree ≤ i) :
+    (ofIndexBelowDegree (p := p) degree index).coeff i = 0 := by
+  apply Hex.DensePoly.coeff_eq_zero_of_size_le
+  unfold ofIndexBelowDegree Hex.FpPoly.ofCoeffs
+  calc (Hex.DensePoly.ofCoeffs
+          ((List.range degree).map (fun i => Hex.ZMod64.ofNat p (index / p ^ i))).toArray).size
+      ≤ _ := Hex.DensePoly.size_ofCoeffs_le _
+    _ = degree := by simp
+    _ ≤ i := hi
+
+/-- The width-`degree` decoder produces a polynomial of size at most `degree`,
+hence degree below `degree` whenever the width is positive. -/
+theorem degree_lt_of_size_le (g : Hex.FpPoly p) (d : Nat)
+    (hsz : g.size ≤ d) (hd : 0 < d) : Hex.FpPoly.degree g < d := by
+  rcases Nat.eq_zero_or_pos g.size with h | h
+  · have hzero : Hex.FpPoly.degree g = 0 := by
+      unfold Hex.FpPoly.degree
+      rw [(Hex.DensePoly.degree?_eq_none_iff g).mpr h]; rfl
+    omega
+  · have hsome : Hex.FpPoly.degree g = g.size - 1 := by
+      unfold Hex.FpPoly.degree
+      rw [Hex.DensePoly.degree?_eq_some_of_pos_size g h]; rfl
+    omega
+
+/-- A polynomial's stored size is at most one more than its `FpPoly.degree`. -/
+theorem size_le_degree_succ (f : Hex.FpPoly p) :
+    f.size ≤ Hex.FpPoly.degree f + 1 := by
+  rcases Nat.eq_zero_or_pos f.size with h | h
+  · omega
+  · have hsome : Hex.FpPoly.degree f = f.size - 1 := by
+      unfold Hex.FpPoly.degree
+      rw [Hex.DensePoly.degree?_eq_some_of_pos_size f h]; rfl
+    omega
+
 /-- Bounded reduced polynomials encode to indices below `p ^ degree`. -/
 theorem coeffIndex_lt_of_degree_lt {degree : Nat} {f : Hex.FpPoly p}
     (_hdeg : Hex.FpPoly.degree f < degree) :
-    coeffIndex degree f < p ^ degree := by
-  sorry
+    coeffIndex degree f < p ^ degree :=
+  coeffIndex_lt degree f
 
 /-- Decoded indices are represented by polynomials with degree below the
-requested bound. -/
-theorem ofIndexBelowDegree_degree_lt (degree : Nat) (index : Fin (p ^ degree)) :
-    Hex.FpPoly.degree (ofIndexBelowDegree (p := p) degree index.1) < degree := by
-  sorry
+requested bound. The positivity hypothesis is necessary: at `degree = 0` the
+index type `Fin (p ^ 0) = Fin 1` is inhabited but the decoder returns the zero
+polynomial, whose `FpPoly.degree` is `0`. -/
+theorem ofIndexBelowDegree_degree_lt (degree index : Nat) (hd : 0 < degree) :
+    Hex.FpPoly.degree (ofIndexBelowDegree (p := p) degree index) < degree := by
+  apply degree_lt_of_size_le _ _ _ hd
+  unfold ofIndexBelowDegree Hex.FpPoly.ofCoeffs
+  calc (Hex.DensePoly.ofCoeffs
+          ((List.range degree).map (fun i => Hex.ZMod64.ofNat p (index / p ^ i))).toArray).size
+      ≤ _ := Hex.DensePoly.size_ofCoeffs_le _
+    _ = degree := by simp
 
 /-- Encoding after decoding recovers the bounded index. -/
 @[simp]
 theorem coeffIndex_ofIndexBelowDegree (degree : Nat) (index : Fin (p ^ degree)) :
     coeffIndex degree (ofIndexBelowDegree (p := p) degree index.1) = index.1 := by
-  sorry
+  rw [coeffIndex_eq_ofDigits]
+  have hmap : ((List.range degree).map
+        (fun i => ((ofIndexBelowDegree (p := p) degree index.1).coeff i).toNat))
+      = (List.range degree).map (fun i => index.1 / p ^ i % p) := by
+    apply List.map_congr_left
+    intro i hi
+    rw [coeff_ofIndexBelowDegree_of_lt degree index.1 i (List.mem_range.mp hi),
+      Hex.ZMod64.toNat_ofNat]
+  rw [hmap]
+  exact ofDigits_range_map_div_pow_mod Hex.ZMod64.Bounds.pPos degree index.1 index.2
 
 /-- Decoding after encoding recovers a polynomial already below the degree
 bound. -/
@@ -57,7 +192,24 @@ bound. -/
 theorem ofIndexBelowDegree_coeffIndex {degree : Nat} {f : Hex.FpPoly p}
     (hdeg : Hex.FpPoly.degree f < degree) :
     ofIndexBelowDegree (p := p) degree (coeffIndex degree f) = f := by
-  sorry
+  apply Hex.DensePoly.ext_coeff
+  intro j
+  rcases Nat.lt_or_ge j degree with hj | hj
+  · rw [coeff_ofIndexBelowDegree_of_lt degree (coeffIndex degree f) j hj,
+      Hex.ZMod64.ofNat_eq_iff_toNat_eq, coeffIndex_eq_ofDigits]
+    have hL : ∀ x ∈ (List.range degree).map (fun i => (f.coeff i).toNat), x < p := by
+      intro x hx
+      simp only [List.mem_map] at hx
+      obtain ⟨i, _, rfl⟩ := hx
+      exact Hex.ZMod64.toNat_lt _
+    have hlen : j < ((List.range degree).map (fun i => (f.coeff i).toNat)).length := by
+      simpa [List.length_map, List.length_range] using hj
+    rw [ofDigits_div_pow_mod Hex.ZMod64.Bounds.pPos _ hL j hlen,
+      List.getD_eq_getElem?_getD, List.getElem?_eq_getElem hlen, Option.getD_some]
+    simp [List.getElem_map, List.getElem_range]
+  · refine (coeff_ofIndexBelowDegree_of_ge degree (coeffIndex degree f) j hj).trans ?_
+    exact (Hex.DensePoly.coeff_eq_zero_of_size_le f
+      (by have := size_le_degree_succ f; omega)).symm
 
 end FpPoly
 
@@ -109,8 +261,11 @@ def reducedRepEquiv :
     intro x
     sorry
 
-/-- Reduced representatives are indexed by `Fin (p ^ degree f)`. -/
-def reducedRepFinEquiv (f : Hex.FpPoly p) :
+/-- Reduced representatives are indexed by `Fin (p ^ degree f)`. The
+positive-degree hypothesis is needed for the decoder's degree bound (see
+`FpPoly.ofIndexBelowDegree_degree_lt`); it is supplied at every call site by the
+nonconstant-modulus assumption. -/
+def reducedRepFinEquiv (f : Hex.FpPoly p) (hf : 0 < Hex.FpPoly.degree f) :
     HexGF2Mathlib.TypeEquiv
       (ReducedRep f)
       (Fin (p ^ Hex.FpPoly.degree f)) where
@@ -119,7 +274,7 @@ def reducedRepFinEquiv (f : Hex.FpPoly p) :
       FpPoly.coeffIndex_lt_of_degree_lt x.2⟩
   invFun index :=
     ⟨FpPoly.ofIndexBelowDegree (p := p) (Hex.FpPoly.degree f) index.1,
-      FpPoly.ofIndexBelowDegree_degree_lt (p := p) (Hex.FpPoly.degree f) index⟩
+      FpPoly.ofIndexBelowDegree_degree_lt (p := p) (Hex.FpPoly.degree f) index.1 hf⟩
   left_inv := by
     intro x
     exact Subtype.ext (FpPoly.ofIndexBelowDegree_coeffIndex x.2)
@@ -134,7 +289,7 @@ noncomputable def finEquiv :
     Hex.GFqField.FiniteField f hf hp hirr ≃
       Fin (p ^ Hex.FpPoly.degree f) :=
   HexGF2Mathlib.TypeEquiv.toEquiv <|
-    HexGF2Mathlib.TypeEquiv.trans reducedRepEquiv (reducedRepFinEquiv f)
+    HexGF2Mathlib.TypeEquiv.trans reducedRepEquiv (reducedRepFinEquiv f hf)
 
 /-- The generic executable finite-field wrapper is finite. -/
 noncomputable instance fintype :

--- a/progress/20260617_221043_61c55593.md
+++ b/progress/20260617_221043_61c55593.md
@@ -1,0 +1,71 @@
+# Progress — session 61c55593 (/work → /feature #7843)
+
+## Accomplished
+
+Cleared the `FpPoly` base-`p` index encode/decode bijection cluster in
+`HexGFqMathlib/Basic.lean` (the four sorries at the old lines 40/46/52/60),
+plus the necessary supporting helpers.
+
+### Helper layer (all `0 < p`, no `2 ≤ p` needed)
+
+- `coeffIndex_succ`: top-position peel of the foldl encoder.
+- `coeffIndex_eq_ofDigits`: `coeffIndex` is `Nat.ofDigits p` of the per-position
+  `toNat` digit list, opening Mathlib's `Nat.ofDigits` API.
+- `coeffIndex_lt`: direct induction bound `coeffIndex d f < p ^ d` (works at
+  `p = 1`, so no primality needed; this is the real content of
+  `coeffIndex_lt_of_degree_lt`, whose degree hypothesis is genuinely unused —
+  it was already named `_hdeg`).
+- `ofDigits_div_pow_mod`: digit extraction `ofDigits p L / p^j % p = L.getD j 0`
+  via `Nat.ofDigits_div_pow_eq_ofDigits_drop` (the key Mathlib lemma — needs only
+  `0 < p` and entries `< p`, no trailing-zero/`digits` requirement).
+- `ofDigits_range_map_div_pow_mod`: fixed-width reconstruction
+  `ofDigits p (range d |>.map (n / p^· % p)) = n` for `n < p^d`, by low-digit
+  induction.
+- `coeff_ofIndexBelowDegree_of_lt` / `_of_ge`: coefficient readback of the
+  decoder (digit below the width, zero at/above it).
+- `degree_lt_of_size_le`, `size_le_degree_succ`: bridge `FpPoly.degree`
+  (= `degree?.getD 0`) to the stored `size`.
+
+### The four target lemmas
+
+- `coeffIndex_lt_of_degree_lt` → `coeffIndex_lt`.
+- `coeffIndex_ofIndexBelowDegree` → reconstruction helper.
+- `ofIndexBelowDegree_coeffIndex` → `ext_coeff` + digit extraction (j < width) /
+  vanishing (j ≥ width).
+- `ofIndexBelowDegree_degree_lt` → `degree_lt_of_size_le`.
+
+### Premise correction (degree = 0)
+
+`ofIndexBelowDegree_degree_lt` as planned was **false at `degree = 0`**: there
+`index : Fin (p^0) = Fin 1` is inhabited, the decoder returns the zero
+polynomial, and `FpPoly.degree 0 = 0`, so `0 < 0` is unprovable. Added the
+necessary `0 < degree` hypothesis and threaded it through the one consumer,
+`FiniteField.reducedRepFinEquiv` (which gains a `0 < FpPoly.degree f` argument).
+That equivalence is itself only sound at positive degree (`ReducedRep f` is empty
+but `Fin (p^0)` is not), so the hypothesis is correct, not a weakening. The only
+call site, `finEquiv`, already has `hf : 0 < FpPoly.degree f` in scope. No other
+file consumes either declaration.
+
+## Verification
+
+- `lake build HexGFqMathlib` → `Build completed successfully (2380 jobs)`, zero
+  `error:`.
+- `grep -n sorry HexGFqMathlib/Basic.lean` → only 259, 262, 335 remain
+  (`reducedRepEquiv` left/right inv and `GFq.modulus_degree` — the two
+  out-of-scope clusters).
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+
+## Current frontier
+
+`FiniteField.reducedRepFinEquiv` is now sorry-free with a sound signature.
+
+## Next step
+
+The remaining two Phase 5 sorry clusters: `reducedRepEquiv` left/right inverses
+(lines 259/262) and `GFq.modulus_degree` (335).
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #7843

Session: `61c55593-03ab-44ee-8831-acdd04dc0218`

89e6ce48 chore: note `omit … in` placement in boundary skill (#7843)
70ddd85e feat: prove FpPoly base-p index encode/decode bijection (#7843)

🤖 Prepared with Claude Code