### PR TITLE
HexGFqMathlib Phase 5: discharge the packed↔generic Conway field RingEquiv (GF2q.lean)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -271,6 +271,36 @@ the dimension argument, `L.factorCount + L.coeffWidth` "has type ℕ … of sort
 outParam Type but is expected to have type Type", because Mathlib's `Matrix`
 wants its first two arguments to be index types, not `Nat`.
 
+## `HexGF2Mathlib` defines a project-local `RingEquiv`/`TypeEquiv` shadowing Mathlib's
+
+`HexGF2Mathlib/Basic.lean` declares its own minimal `structure RingEquiv`
+(fields `toFun`/`invFun`/`left_inv`/`right_inv`/`map_mul'`/`map_add'`, a CoeFun
+to `toFun`, and `symm`) **with the same `≃+*` notation** (`infixl:25 " ≃+* "`)
+and a `TypeEquiv` shadowing `Equiv`. So `HexGF2Mathlib.GF2n.equiv :
+GF2n … ≃+* GenericFiniteField` is **`HexGF2Mathlib.RingEquiv`, not Mathlib's**.
+
+Symptom when you forget: composing it with a Mathlib `RingEquiv` (e.g. a `cast`-
+based equiv on the generic Conway field) fails with `RingEquiv.trans`/`.trans`
+resolving to `HexGF2Mathlib.RingEquiv.trans` (which doesn't exist), or an
+"Application type mismatch" / "type mismatch" between two `≃+*` types that
+**print identically** (one is the custom struct, one is Mathlib's). `e.symm`,
+`e.map_mul'`, `e.symm_apply_apply` dot-notation resolves into the custom
+namespace too. Confirm early with `set_option pp.all true in #check e` — Mathlib's
+prints `@RingEquiv.{…}`, the custom one prints `@HexGF2Mathlib.RingEquiv.{…}`.
+
+Recipe to compose a custom `e : A ≃+*[Hex] B` with a Mathlib `g : B ≃+* C` into
+a Mathlib `A ≃+* C`: build the Mathlib structure literal directly,
+`{ toFun := fun x => g (e x), invFun := fun x => e.invFun (g.symm x), … }`, and
+discharge its fields from **`e`'s struct projections** (`e.left_inv`,
+`e.right_inv`, `e.map_mul'`, `e.map_add'` — `e` is a bare structure, no
+`MulHomClass`) and **`g`'s Mathlib lemmas** (`RingEquiv.symm_apply_apply`,
+`apply_symm_apply`, `map_mul`, `map_add`). Do **not** `RingEquiv.trans` across
+the boundary — the two `RingEquiv`s are different types. Inline `e`/`g`
+(no `let`): a `let`-bound equiv whose type mentions the heavy
+`GFqField.FiniteField`/`GenericFiniteField` carrier blows the `whnf` heartbeat
+budget (same trap as the `set d := toMonicLiftData` warning above); name a thin
+`private def` for the repackaged `e` if you must, but reference it inline.
+
 ## The Mathlib layer *models* executable definitions
 
 The bridge does not just prove lemmas about the executable types; it carries

--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -760,6 +760,21 @@ private theorem coeff_ofUInt64_and_lowerMask (w : UInt64) {n i : Nat} (hn64 : n 
     (ofUInt64Monic lower n).degree = n := by
   exact degree_eq_of_degree?_eq_some (degree?_ofUInt64Monic_of_lt_64 lower hn64)
 
+/-- The coefficients of the packed single-word monic modulus: the implicit
+leading `x^n` term sets degree `n`, and the lower degrees read the bits of
+`lower`. -/
+theorem coeff_ofUInt64Monic (lower : UInt64) {n : Nat} (hn64 : n < 64) (i : Nat) :
+    (ofUInt64Monic lower n).coeff i =
+      (decide (i = n) != (if i < n then (ofUInt64 lower).coeff i else false)) := by
+  unfold ofUInt64Monic
+  rw [coeff_add_eq_bne, coeff_ofUInt64_and_lowerMask lower hn64]
+  by_cases hi : i = n
+  · subst hi
+    rw [coeff_monomial_self]
+    simp [Nat.lt_irrefl]
+  · rw [coeff_monomial_ne hi]
+    simp [hi]
+
 /-- A nonzero `UInt64` word unpacks to a nonzero packed polynomial. -/
 private theorem ofUInt64_ne_zero_of_ne_zero {w : UInt64} (hw : w ≠ 0) :
     ofUInt64 w ≠ 0 := by

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -116,6 +116,44 @@ def ofFpPoly (p : Hex.FpPoly 2) : Hex.GF2Poly :=
   let words := Array.ofFn fun i : Fin wordCount => packWord p i.1
   Hex.GF2Poly.ofWords words
 
+/-- The `i`-th coefficient of `toFpPoly p` is the `ZMod64 2` lift of the packed
+bit `p.coeff i`. -/
+theorem coeff_toFpPoly (p : Hex.GF2Poly) (i : Nat) :
+    (toFpPoly p).coeff i = if p.coeff i then (1 : Hex.ZMod64 2) else 0 := by
+  have hcoeffToFp : ∀ b : Bool, coeffToFp b = if b then (1 : Hex.ZMod64 2) else 0 := by
+    intro b; cases b <;> rfl
+  by_cases hz : p.isZero = true
+  · have hbody : toFpPoly p = Hex.FpPoly.ofCoeffs (#[] : Array (Hex.ZMod64 2)) := by
+      unfold toFpPoly; rw [if_pos hz]
+    rw [hbody, Hex.FpPoly.ofCoeffs, Hex.DensePoly.coeff_ofCoeffs,
+      Hex.GF2Poly.eq_zero_of_isZero hz, Hex.GF2Poly.coeff_zero]
+    rfl
+  · have hbody : toFpPoly p =
+        Hex.FpPoly.ofCoeffs
+          ((List.range (p.degree + 1)).map (fun j => coeffToFp (p.coeff j))).toArray := by
+      unfold toFpPoly; rw [if_neg hz]
+    rw [hbody, Hex.FpPoly.ofCoeffs, Hex.DensePoly.coeff_ofCoeffs_list]
+    have hrange :
+        ((List.range (p.degree + 1)).map (fun j => coeffToFp (p.coeff j))).getD i
+          (Zero.zero : Hex.ZMod64 2) =
+          if i < p.degree + 1 then coeffToFp (p.coeff i)
+          else (Zero.zero : Hex.ZMod64 2) := by
+      by_cases hi : i < p.degree + 1 <;> simp [hi, List.getD]
+    rw [hrange]
+    by_cases hi : i < p.degree + 1
+    · rw [if_pos hi, hcoeffToFp]
+    · rw [if_neg hi]
+      have hzf : p.isZero = false := by
+        cases hb : p.isZero with
+        | false => rfl
+        | true => exact absurd hb hz
+      obtain ⟨d, hd⟩ := Hex.GF2Poly.degree?_isSome_of_isZero_false hzf
+      have hdd : p.degree = d := Hex.GF2Poly.degree_eq_of_degree?_eq_some hd
+      have hcoeff : p.coeff i = false :=
+        Hex.GF2Poly.coeff_eq_false_of_degree?_lt hd (by omega)
+      rw [hcoeff]
+      rfl
+
 @[simp]
 theorem toFpPoly_zero :
     toFpPoly (0 : Hex.GF2Poly) = 0 := by

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -25,20 +25,113 @@ private theorem cast_cast_symm {α β : Type u} (h : α = β) (x : β) :
   cases h
   rfl
 
-private theorem cast_mul {α β : Type u} [Mul α] [Mul β] (h : α = β) (x y : α) :
-    cast h (x * y) = cast h x * cast h y := by
-  sorry
+/-- Transport of multiplication along an equality of executable finite-field
+types induced by an equality of moduli. Sound because the field structure is
+defined uniformly in the modulus, so after `subst` the two multiplications
+coincide by proof irrelevance on the degree/prime/irreducibility witnesses. -/
+private theorem finiteField_cast_mul
+    {f₁ f₂ : FpPoly 2}
+    {pos₁ : 0 < FpPoly.degree f₁} {prime₁ : Hex.Nat.Prime 2}
+    {irr₁ : FpPoly.Irreducible f₁}
+    {pos₂ : 0 < FpPoly.degree f₂} {prime₂ : Hex.Nat.Prime 2}
+    {irr₂ : FpPoly.Irreducible f₂}
+    (hf : f₁ = f₂)
+    (hty : GFqField.FiniteField f₁ pos₁ prime₁ irr₁ =
+      GFqField.FiniteField f₂ pos₂ prime₂ irr₂)
+    (x y : GFqField.FiniteField f₁ pos₁ prime₁ irr₁) :
+    cast hty (x * y) = cast hty x * cast hty y := by
+  subst hf
+  rfl
 
-private theorem cast_add {α β : Type u} [Add α] [Add β] (h : α = β) (x y : α) :
-    cast h (x + y) = cast h x + cast h y := by
-  sorry
+/-- Transport of addition along an equality of executable finite-field types
+induced by an equality of moduli (companion to `finiteField_cast_mul`). -/
+private theorem finiteField_cast_add
+    {f₁ f₂ : FpPoly 2}
+    {pos₁ : 0 < FpPoly.degree f₁} {prime₁ : Hex.Nat.Prime 2}
+    {irr₁ : FpPoly.Irreducible f₁}
+    {pos₂ : 0 < FpPoly.degree f₂} {prime₂ : Hex.Nat.Prime 2}
+    {irr₂ : FpPoly.Irreducible f₂}
+    (hf : f₁ = f₂)
+    (hty : GFqField.FiniteField f₁ pos₁ prime₁ irr₁ =
+      GFqField.FiniteField f₂ pos₂ prime₂ irr₂)
+    (x y : GFqField.FiniteField f₁ pos₁ prime₁ irr₁) :
+    cast hty (x + y) = cast hty x + cast hty y := by
+  subst hf
+  rfl
+
+/-- The packed bit test `(w >>> i &&& 1) = 0` agrees with the cleared `ofUInt64`
+coefficient at position `i` (for `i < 64`). -/
+private theorem bit_and_one_eq_zero_iff (w : UInt64) {i : Nat} (hi : i < 64) :
+    (w >>> i.toUInt64 &&& 1) = 0 ↔ (Hex.GF2Poly.ofUInt64 w).coeff i = false := by
+  rw [Hex.GF2Poly.coeff_ofUInt64_eq_testBit w hi, ← UInt64.toNat_inj]
+  have hshift : (i.toUInt64).toNat % 64 = i := by
+    have hi64 : (i.toUInt64).toNat = i := by
+      simp only [Nat.toUInt64]
+      rw [UInt64.toNat_ofNat']
+      exact Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hi (by norm_num))
+    rw [hi64]; exact Nat.mod_eq_of_lt hi
+  simp only [UInt64.toNat_and, UInt64.toNat_shiftRight, hshift]
+  rw [show ((1 : UInt64).toNat) = 1 from rfl, show ((0 : UInt64).toNat) = 0 from rfl]
+  rw [Nat.testBit, Nat.and_comm (w.toNat >>> i) 1]
+  generalize 1 &&& (w.toNat >>> i) = b
+  constructor
+  · intro hb; simp [hb]
+  · intro hb
+    by_contra hne
+    rw [bne_iff_ne.mpr hne] at hb
+    exact absurd hb (by simp)
+
+/-- Coefficients of the packed binary modulus polynomial: the implicit leading
+`x^n` term, with lower degrees reading the bits of `lower`. -/
+private theorem coeff_packedGF2FpPoly (lower : UInt64) (n i : Nat) :
+    (Conway.packedGF2FpPoly lower n).coeff i =
+      if i = n then (1 : Hex.ZMod64 2)
+      else if i < n then (if (lower >>> i.toUInt64 &&& 1) = 0 then 0 else 1)
+      else 0 := by
+  unfold Conway.packedGF2FpPoly
+  rw [Hex.FpPoly.ofCoeffs, Hex.DensePoly.coeff_ofCoeffs, Array.getD_eq_getD_getElem?,
+    Array.getElem?_push]
+  have hsz : (((List.range n).map fun j =>
+      if (lower >>> j.toUInt64 &&& 1) = 0 then (0 : Hex.ZMod64 2) else 1).toArray).size = n := by
+    simp
+  rw [hsz]
+  by_cases hin : i = n
+  · simp [hin]
+  · rw [if_neg hin, List.getElem?_toArray, List.getElem?_map, if_neg hin]
+    by_cases hlt : i < n
+    · rw [List.getElem?_range hlt, if_pos hlt]
+      simp
+    · rw [List.getElem?_eq_none (by simp; omega), if_neg hlt]
+      rfl
 
 /-- The packed `GF2n` modulus, transported to `FpPoly 2`, is the Conway
 polynomial selected for the same committed packed entry. -/
 theorem modulusFpPoly_eq_conway :
     HexGF2Mathlib.GF2n.modulusFpPoly (n := n) (irr := h.lower) =
       GFq.modulus h.entry := by
-  sorry
+  rw [gfq_modulus_eq_packedFpPoly, lower_eq]
+  apply Hex.DensePoly.ext_coeff
+  intro i
+  show (HexGF2Mathlib.GF2Poly.toFpPoly (Hex.GF2Poly.ofUInt64Monic h.lower n)).coeff i =
+      (Conway.packedGF2FpPoly h.lower n).coeff i
+  have hn64 : n < 64 := h.degree_lt_word
+  rw [HexGF2Mathlib.GF2Poly.coeff_toFpPoly,
+    Hex.GF2Poly.coeff_ofUInt64Monic h.lower h.degree_lt_word,
+    coeff_packedGF2FpPoly]
+  by_cases hin : i = n
+  · subst hin; simp
+  · rw [if_neg hin]
+    by_cases hlt : i < n
+    · simp only [hin, decide_false, Bool.false_bne, if_pos hlt]
+      by_cases hb : (h.lower >>> i.toUInt64 &&& 1) = 0
+      · rw [if_pos hb, (bit_and_one_eq_zero_iff h.lower (by omega)).mp hb]
+        simp
+      · rw [if_neg hb]
+        have hc : (Hex.GF2Poly.ofUInt64 h.lower).coeff i = true := by
+          by_contra hcf
+          exact hb ((bit_and_one_eq_zero_iff h.lower (by omega)).mpr (by simpa using hcf))
+        rw [hc]; simp
+    · simp [hin, hlt]
 
 /-- The generic finite-field target of the packed correspondence is
 definitionally the same field type as `GFq 2 n` after identifying the
@@ -47,7 +140,13 @@ private theorem genericField_eq_conway :
     HexGF2Mathlib.GF2n.GenericFiniteField
       (n := n) (irr := h.lower) =
       GFq 2 n h.entry := by
-  sorry
+  have hmod : HexGF2Mathlib.GF2n.modulusFpPoly (n := n) (irr := h.lower) =
+      Conway.conwayPoly 2 n h.entry := modulusFpPoly_eq_conway
+  show GFqField.FiniteField (HexGF2Mathlib.GF2n.modulusFpPoly (n := n) (irr := h.lower)) _ _ _ =
+      GFqField.FiniteField (Conway.conwayPoly 2 n h.entry) _ _ _
+  congr 1 <;> first
+    | exact hmod
+    | exact proof_irrel_heq _ _
 
 /-- Reindex the generic finite-field target of the packed `GF2n` correspondence
 to the canonical Conway-field target used by `GFq 2 n`. -/
@@ -66,44 +165,53 @@ private def genericEquivGFq :
     exact cast_cast_symm (genericField_eq_conway (n := n)) x
   map_mul' := by
     intro x y
-    exact cast_mul (genericField_eq_conway (n := n)) x y
+    exact finiteField_cast_mul modulusFpPoly_eq_conway (genericField_eq_conway (n := n)) x y
   map_add' := by
     intro x y
-    exact cast_add (genericField_eq_conway (n := n)) x y
+    exact finiteField_cast_add modulusFpPoly_eq_conway (genericField_eq_conway (n := n)) x y
 
 set_option maxHeartbeats 800000
 
+/-- The packed-side equivalence `HexGF2Mathlib.GF2n.equiv`, repackaged with its
+domain stated as `GF2q n`. This is the project-local `HexGF2Mathlib.RingEquiv`;
+naming it avoids re-elaborating its `whnf`-heavy type inline. -/
+private def packedRingEquiv :
+    HexGF2Mathlib.RingEquiv
+      (GF2n n h.lower h.degree_pos h.degree_lt_word h.packed_irreducible)
+      (HexGF2Mathlib.GF2n.GenericFiniteField (n := n) (irr := h.lower)) :=
+  HexGF2Mathlib.GF2n.equiv
+    (n := n) (irr := h.lower)
+    (hn := h.degree_pos) (hn64 := h.degree_lt_word)
+    (hirr := h.packed_irreducible)
+
 /-- The optimized packed binary Conway field is ring-equivalent to the generic
-canonical Conway field over `p = 2`. -/
-def equivGFq : RingEquiv (GF2q n) (GFq 2 n h.entry) := by
-  let lower := h.lower
-  let hn := h.degree_pos
-  let hn64 := h.degree_lt_word
-  let hirr := h.packed_irreducible
-  change RingEquiv
-    (GF2n n lower hn hn64 hirr)
-    (GFq 2 n h.entry)
-  let e :=
-    HexGF2Mathlib.GF2n.equiv
-      (n := n) (irr := lower)
-      (hn := hn) (hn64 := hn64)
-      (hirr := hirr)
-  let g := genericEquivGFq (n := n)
-  exact
-    { toFun := fun x => g (e x)
-      invFun := fun x => e.symm (g.symm x)
-      left_inv := by
-        intro x
-        sorry
-      right_inv := by
-        intro x
-        sorry
-      map_mul' := by
-        intro x y
-        sorry
-      map_add' := by
-        intro x y
-        sorry }
+canonical Conway field over `p = 2`. The packed-side equivalence is the
+project-local `HexGF2Mathlib.RingEquiv`, which this composition repackages with
+the canonical Conway field on the generic side through `genericEquivGFq`. -/
+def equivGFq : RingEquiv (GF2q n) (GFq 2 n h.entry) where
+  toFun x := genericEquivGFq (n := n) (packedRingEquiv (n := n) x)
+  invFun x := (packedRingEquiv (n := n)).invFun ((genericEquivGFq (n := n)).symm x)
+  left_inv x := by
+    show (packedRingEquiv (n := n)).invFun
+        ((genericEquivGFq (n := n)).symm
+          (genericEquivGFq (n := n) (packedRingEquiv (n := n) x))) = x
+    rw [RingEquiv.symm_apply_apply]
+    exact (packedRingEquiv (n := n)).left_inv x
+  right_inv x := by
+    show genericEquivGFq (n := n)
+        (packedRingEquiv (n := n)
+          ((packedRingEquiv (n := n)).invFun ((genericEquivGFq (n := n)).symm x))) = x
+    rw [(packedRingEquiv (n := n)).right_inv, RingEquiv.apply_symm_apply]
+  map_mul' x y := by
+    show genericEquivGFq (n := n) (packedRingEquiv (n := n) (x * y)) =
+      genericEquivGFq (n := n) (packedRingEquiv (n := n) x) *
+        genericEquivGFq (n := n) (packedRingEquiv (n := n) y)
+    rw [(packedRingEquiv (n := n)).map_mul' x y, map_mul (genericEquivGFq (n := n))]
+  map_add' x y := by
+    show genericEquivGFq (n := n) (packedRingEquiv (n := n) (x + y)) =
+      genericEquivGFq (n := n) (packedRingEquiv (n := n) x) +
+        genericEquivGFq (n := n) (packedRingEquiv (n := n) y)
+    rw [(packedRingEquiv (n := n)).map_add' x y, map_add (genericEquivGFq (n := n))]
 
 end GF2q
 

--- a/progress/20260617_224134_1860fd89.md
+++ b/progress/20260617_224134_1860fd89.md
@@ -1,0 +1,83 @@
+# Progress — 2026-06-17 (session 1860fd89, /work → /feature #7841)
+
+## Accomplished
+
+Discharged all 8 `sorry`s in `HexGFqMathlib/GF2q.lean` (HexGFqMathlib Phase 5),
+the packed↔generic Conway field ring equivalence
+`equivGFq : GF2q n ≃+* GFq 2 n h.entry`.
+
+### `modulusFpPoly_eq_conway` (deliverable 1)
+
+Proved coefficient-wise via `DensePoly.ext_coeff`: the transported packed
+modulus `toFpPoly (ofUInt64Monic h.lower n)` equals the Conway polynomial
+`GFq.modulus h.entry` (through `gfq_modulus_eq_packedFpPoly`). Needed two new
+coefficient characterizations:
+
+- `HexGF2Mathlib.GF2Poly.coeff_toFpPoly` (added to `HexGF2Mathlib/Basic.lean`):
+  `(toFpPoly p).coeff i = if p.coeff i then 1 else 0`.
+- `Hex.GF2Poly.coeff_ofUInt64Monic` (added to `HexGF2/Euclid.lean`, public):
+  coefficients of the packed monic modulus, mirroring the existing degree lemma.
+- A local `bit_and_one_eq_zero_iff` reconciling the packed bit test
+  `(w >>> i &&& 1) = 0` with `(ofUInt64 w).coeff i = false`, and
+  `coeff_packedGF2FpPoly` evaluating `packedGF2FpPoly`'s pushed-array coeff.
+
+### `genericField_eq_conway` (deliverable 1)
+
+Follows from `modulusFpPoly_eq_conway` by `congr 1` on the modulus argument of
+`GFqField.FiniteField`, discharging the proof-argument `HEq` goals via
+`proof_irrel_heq`.
+
+### `genericEquivGFq` as a genuine RingEquiv (deliverable 2)
+
+Replaced the false generic `cast_mul`/`cast_add` (unsound for two independent
+`Mul` instances on one carrier, per the issue's premise check) with
+`finiteField_cast_mul`/`finiteField_cast_add`: transport along an equality of
+`FiniteField` *types induced by an equality of moduli*. After `subst` of the
+modulus equality, the two field structures' multiplications coincide by proof
+irrelevance on the degree/prime/irreducibility witnesses, so `rfl` closes it.
+
+### `equivGFq` composition (deliverable 3)
+
+The packed-side `HexGF2Mathlib.GF2n.equiv` is the project-local
+**`HexGF2Mathlib.RingEquiv`** (a bare structure), not Mathlib's `RingEquiv`;
+`genericEquivGFq` is Mathlib's. `equivGFq` builds the Mathlib `RingEquiv`
+directly, composing `e` (custom) and `g` (Mathlib) and discharging the four
+fields from `e`'s structure fields (`left_inv`/`right_inv`/`map_mul'`/`map_add'`)
+and `g`'s Mathlib lemmas (`symm_apply_apply`/`apply_symm_apply`/`map_mul`/
+`map_add`). All references are inlined (no `let`) to avoid `whnf` heartbeat
+blowups on the heavy `GenericFiniteField` type.
+
+## Verification
+
+- `lake build HexGFqMathlib HexBerlekampZassenhausMathlib` →
+  `Build completed successfully (3848 jobs)`, zero `error:` (the CI-gated
+  Mathlib layer stays green).
+- `grep -c sorry HexGFqMathlib/GF2q.lean` → 0.
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+
+## Current frontier
+
+`HexGFqMathlib/GF2q.lean` is fully `sorry`-free. Other Phase 5 clusters remain
+(`HexGFqMathlib/Basic.lean`, `HexGF2Mathlib/Basic.lean`, `HexGF2Mathlib/Field.lean`)
+— separate issues, out of scope here.
+
+## Next step
+
+The remaining `HexGFqMathlib`/`HexGF2Mathlib` sorry clusters (round-trip and
+field-law lemmas) for Phase 5 completion.
+
+## Blockers
+
+None.
+
+## Scope note
+
+The issue marked the executable `HexGF2`/`HexGFq` layers out of scope. The
+proof needed the packed monic modulus' coefficients, but the existing helper
+(`coeff_ofUInt64_and_lowerMask`) is `private`. Rather than duplicate that
+private bit-manipulation into the Mathlib layer, I added one pure public
+theorem `coeff_ofUInt64Monic` to `HexGF2/Euclid.lean` (no definition or
+behavior change; natural reusable home next to `degree_ofUInt64Monic_of_lt_64`).
+Flagged here and in the PR for reviewer awareness.


### PR DESCRIPTION
This PR discharges all eight `sorry`s in `HexGFqMathlib/GF2q.lean`, completing the packed↔generic Conway field ring equivalence `equivGFq : GF2q n ≃+* GFq 2 n h.entry` for HexGFqMathlib Phase 5.

`modulusFpPoly_eq_conway` proves coefficient-wise that the transported packed monic modulus `toFpPoly (ofUInt64Monic h.lower n)` equals the Conway polynomial `GFq.modulus h.entry`, supported by two new coefficient characterizations: `HexGF2Mathlib.GF2Poly.coeff_toFpPoly` and `Hex.GF2Poly.coeff_ofUInt64Monic`. `genericField_eq_conway` follows by congruence on the modulus argument of `GFqField.FiniteField`, discharging the proof-argument `HEq` goals with `proof_irrel_heq`. Per the issue's premise check, the false generic `cast_mul`/`cast_add` are replaced by `finiteField_cast_mul`/`finiteField_cast_add`, which transport multiplication and addition along an equality of `FiniteField` types induced by an equality of moduli — sound because after `subst` the two field structures' operations coincide by proof irrelevance on the degree/prime/irreducibility witnesses. `equivGFq` then composes the packed-side `HexGF2Mathlib.GF2n.equiv` (the project-local `HexGF2Mathlib.RingEquiv`) with `genericEquivGFq` (Mathlib's `RingEquiv`) by building the Mathlib structure directly from each side's lemmas.

Scope note: the issue listed the executable `HexGF2`/`HexGFq` layers as out of scope, but the coefficient comparison needs the packed monic modulus' coefficients and the existing helper (`coeff_ofUInt64_and_lowerMask`) is `private`. Rather than duplicate that private bit reasoning into the Mathlib layer, this adds one pure public theorem `coeff_ofUInt64Monic` to `HexGF2/Euclid.lean` (no definition or behavior change; it sits next to the existing `degree_ofUInt64Monic_of_lt_64`).

Verified with `lake build HexGFqMathlib HexBerlekampZassenhausMathlib` (3848 jobs, zero errors, CI-gated layer green), `grep -c sorry HexGFqMathlib/GF2q.lean` → 0, and `python3 scripts/check_dag.py` → exit 0.

Closes #7841

Session: `1860fd89-7097-43e4-a80e-f68f10200c6d`

🤖 Prepared with Claude Code
