### PR TITLE
doc: note recovery→TrueFactorLift centered/raw trap in boundary skill

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -790,3 +790,29 @@ residues (`centeredResiduePow p a (z i) = w i`) whose support sum is a small
 integer (`|y| ≤ B`, `2B < p^b`). Sanity-check any "tight CLD column" directive
 that points at `abs_cldCoeffs`: that is the loose route and will not close the
 `factorCount` shape.
+
+### "Package the recovery witnesses into `TrueFactorLift`" is the centered/raw trap
+
+A directive asking you to derive a `TrueFactorLift` family (the hypothesis of
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift`,
+`PartitionRefinement.lean`) from `RepresentsIntegerFactorAtLift` recovery
+witnesses is **not** a packaging step — it asks for a witness recovery cannot
+provide. `TrueFactorLift.support_product_eq` needs the **raw** integer product
+`supportProduct L S = factor` (`Lattice.lean`, `supportProduct` is
+`Array.polyProduct` with no mod reduction) plus `factor * cofactor = f` over ℤ.
+`RepresentsIntegerFactorAtLift` / `RecoveredAtLift` give only a mod-`p^k`
+congruence + the **centered** equality `centeredLiftPoly (liftedFactorProduct d
+S) (p^k) = monicFactor` (already discharged by
+`RecoveredAtLift.candidate_eq_of_monic_dvd`, `Basic.lean`) — i.e. the
+`RecoveredLift.recovered_eq` shape, **not** `TrueFactorLift`. For a support of
+size ≥ 2 over mod-`p^k` Hensel lifts the raw product overflows `p^k/2`, so the
+raw equality (and `factor_mul`) is false; the `RecoveredLift` docstring
+(`Lattice.lean`, "deliberately does not assert the raw integer equality") says
+this outright. So: recovery → `RecoveredLift` is landable; recovery →
+`TrueFactorLift` is the #7479-class exact-product / unscaled-support migration,
+a separate structural remodel. Diagnose and skip the latter rather than
+attempting it as a thin composition. (#7854 was skipped on exactly this, with
+the added wrinkle that its executable extractor lived in an unmerged PR — for
+any "residual after PR #N" issue, `grep` the named substrate symbols on `main`
+first; if absent, the residual depends on the unmerged PR and cannot build
+yet.)

--- a/progress/20260618T001424Z_a7ff6db1.md
+++ b/progress/20260618T001424Z_a7ff6db1.md
@@ -1,0 +1,47 @@
+# Session a7ff6db1 — /once #7854 (TrueFactorLift family from recovery witnesses)
+
+## Accomplished
+
+Diagnosed #7854 as blocked and skipped it (→ `replan`) with a concrete,
+code-cited comment rather than landing partial work against an unsound premise.
+
+Two blockers established with evidence:
+
+1. **Dependency.** Deliverables 3/4 are keyed on the executable extractor
+   `Hex.factorFastCoreWithBound_some_indicatorCandidates` and the Mathlib
+   `representsIntegerFactorAtLift_of_indicatorCandidates`, which exist only in
+   the still-open PR #7852 — absent from `main` (`e9fa34ff`). Cannot build on a
+   main-based branch until #7852 merges.
+
+2. **Structural exact-product gap.** The cited capstone
+   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift`
+   (`PartitionRefinement.lean:601`) consumes `∀ S, TrueFactorLift L S.1`, whose
+   `support_product_eq` needs the **raw** integer product `supportProduct L S =
+   factor` (`Lattice.lean:151-157,231`, no mod reduction). The
+   `RepresentsIntegerFactorAtLift` witnesses (`Basic.lean:2360-2385`) provide
+   only a mod-`p^k` congruence + centered/dilated equality, i.e. the
+   **centered** `RecoveredLift.recovered_eq` shape (already discharged by
+   `RecoveredAtLift.candidate_eq_of_monic_dvd`, `Basic.lean:3128`). For supports
+   of size ≥ 2 over mod-`p^k` Hensel lifts the raw product overflows `p^k/2`, so
+   `supportProduct L S = factor` is false. The `RecoveredLift` docstring
+   (`Lattice.lean:233-243`) documents this directly: recovery "deliberately does
+   not assert the raw integer equality". No in-tree producer derives the raw
+   exact product — the #7479-class gap that blocks the toMonic capstone.
+
+## Current frontier
+
+#7854 routed to `replan`. The `RecoveredLift` half of deliverable 2 is the only
+genuinely main-landable piece; the `TrueFactorLift` family + capstone wiring
+belong to the exact-product / unscaled-support migration (#7479-class), not to
+recovery-witness packaging.
+
+## Next step
+
+Planner re-scope: add `depends-on: #7852`; narrow #7854 to the `RecoveredLift`
+producer (`RepresentsIntegerFactorAtLift → recoveredLiftOfSubset`, monic
+regime); move the `TrueFactorLift`/capstone half under the exact-product
+migration.
+
+## Blockers
+
+As above. No code changes made; nothing to PR.


### PR DESCRIPTION
This PR records, in the `hex-lean-mathlib-boundary` skill, that deriving a `TrueFactorLift` family from `RepresentsIntegerFactorAtLift` recovery witnesses is the centered/raw exact-product trap, not a packaging step: recovery yields only the centered `RecoveredLift.recovered_eq` shape, while `TrueFactorLift.support_product_eq` needs the raw integer product (false for multi-element supports over mod-`p^k` Hensel lifts). It also adds the reflex of grepping a "residual after PR #N" issue's substrate symbols on `main` before working it.

Diagnosed while working #7854 (skipped → replan); see https://github.com/kim-em/hex/issues/7854#issuecomment-4736659735 for the full evidence. No Lean source changes; doc/skill and a session progress note only.

🤖 Prepared with Claude Code