### PR TITLE
feat: derive RecoveredLift from fast-core recovery witnesses

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6119,6 +6119,79 @@ theorem monic_primitive_sign_normalized_of_monic
     zpoly_normalize_factor_sign_of_monic hfactor_monic⟩
 
 /--
+In the monic-core regime the centered/dilated recovered product equals the
+represented integer factor with no primitive-part correction.
+
+The carrier's `dilate_eq` field only exposes
+`primitivePart (dilate (lc core) monicFactor) = factor`, but when `core` is
+monic the dilation collapses (`leadingCoeff core = 1`) and `monicFactor` is a
+divisor of the monic core, hence primitive, so the `primitivePart` is the
+identity.  The congruence field plus the Mignotte bound then identify the
+centered selected product with `monicFactor`.  This is exactly the
+recovered-equality input consumed by `BHKS.recoveredLiftOfSubset`, and unlike
+`RecoveredAtLift.candidate_eq_of_monic_dvd` it is stated without the
+`primitivePart`/`normalizeFactorSign` corrections that the `RecoveredLift`
+package omits.
+-/
+theorem dilate_centeredLift_eq_factor_of_represents_monic
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        d.p ^ d.k) :
+    Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core)
+        (Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k)) =
+      factor := by
+  classical
+  obtain ⟨R⟩ := hrep
+  have hlc : Hex.DensePoly.leadingCoeff core = (1 : Int) := hcore_monic
+  have htoMonic : (Hex.ZPoly.toMonic core).monic = core :=
+    Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one core hlc
+  have hcore_prim : Hex.ZPoly.Primitive core := zpoly_primitive_of_monic hcore_monic
+  have hcore_ne : core ≠ 0 := by
+    intro h
+    have hc : Hex.ZPoly.content core = 1 := hcore_prim
+    rw [h] at hc
+    simp [Hex.ZPoly.content] at hc
+  -- `monicFactor` divides the monic core, hence is primitive.
+  have hdvd : R.monicFactor ∣ core := by
+    have h := R.monic_dvd
+    rw [htoMonic] at h
+    exact h
+  have hcore_poly_prim : (HexPolyZMathlib.toPolynomial core).IsPrimitive :=
+    HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive core hcore_prim
+  have hmf_dvd_poly :
+      HexPolyZMathlib.toPolynomial R.monicFactor ∣
+        HexPolyZMathlib.toPolynomial core :=
+    HexPolyMathlib.toPolynomial_dvd hdvd
+  have hmf_prim_poly : (HexPolyZMathlib.toPolynomial R.monicFactor).IsPrimitive :=
+    isPrimitive_of_dvd hcore_poly_prim hmf_dvd_poly
+  have hmf_prim : Hex.ZPoly.Primitive R.monicFactor := by
+    have := Polynomial.isPrimitive_iff_content_eq_one.mp hmf_prim_poly
+    rwa [HexPolyZMathlib.toPolynomial_content] at this
+  have hprim_self : Hex.ZPoly.primitivePart R.monicFactor = R.monicFactor :=
+    Hex.ZPoly.primitivePart_eq_self_of_primitive R.monicFactor hmf_prim
+  -- `dilate_eq` collapses to `monicFactor = factor`.
+  have hmf_eq : R.monicFactor = factor := by
+    have h := R.dilate_eq
+    rw [hlc, Hex.ZPoly.dilate_one, hprim_self] at h
+    exact h
+  -- The Mignotte bound and the congruence field recover `monicFactor`.
+  have hmonic_ne : (Hex.ZPoly.toMonic core).monic ≠ 0 := by rw [htoMonic]; exact hcore_ne
+  have hbound : ∀ i, (R.monicFactor.coeff i).natAbs ≤
+      Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic := fun i =>
+    defaultFactorCoeffBound_valid (Hex.ZPoly.toMonic core).monic hmonic_ne
+      R.monicFactor R.monic_dvd i
+  have hcl :
+      Hex.centeredLiftPoly (liftedFactorProduct d S) (d.p ^ d.k) = R.monicFactor := by
+    rw [← centeredLiftPoly_reduceModPow_eq (liftedFactorProduct d S) d.p d.k d.p_pos,
+      R.congr]
+    exact Hex.centeredLiftPoly_reduceModPow_eq_of_coeff_natAbs_le
+      R.monicFactor d.p d.k _ hbound hprecision
+  rw [hlc, Hex.ZPoly.dilate_one, hcl, hmf_eq]
+
+/--
 Size of the lifted-factor array equals the size of the modular-factor array.
 
 This is the `factor_count_eq` field that `HenselSubsetLiftHypotheses` (line

--- a/HexBerlekampZassenhausMathlib/LiftBridge.lean
+++ b/HexBerlekampZassenhausMathlib/LiftBridge.lean
@@ -123,6 +123,32 @@ def recoveredLiftOfSubset
     rw [supportProduct_supportOfSubset, hrecovered]
 
 /--
+Build a recovered BHKS true-factor package directly from a monic-core
+`RepresentsIntegerFactorAtLift` witness emitted by the fast-core extractor.
+
+This is the producer half of the recovery contract: the centered/dilated
+recovery equality that `recoveredLiftOfSubset` consumes is discharged from the
+witness by `dilate_centeredLift_eq_factor_of_represents_monic`, so the caller
+only supplies the cofactor identity and the Mignotte precision bound.  The monic
+hypothesis is the regime the fast-core extractor operates in (`Monic core`),
+where the leading-coefficient dilation collapses and the represented
+monic-coordinate witness is itself primitive.
+-/
+def recoveredLiftOfRepresents
+    (core : Hex.ZPoly) (d : Hex.LiftData) (S : LiftedFactorSubset d)
+    (factor cofactor : Hex.ZPoly)
+    (hcore_monic : Hex.DensePoly.Monic core)
+    (hfactor : factor * cofactor = core)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        d.p ^ d.k)
+    (hrep : RepresentsIntegerFactorAtLift core d factor S) :
+    RecoveredLift (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors)
+      (supportOfSubset core d S) :=
+  recoveredLiftOfSubset core d S factor cofactor hfactor
+    (dilate_centeredLift_eq_factor_of_represents_monic hcore_monic hrep hprecision)
+
+/--
 Every raw true-factor lift also gives a recovered-lift certificate when the
 caller supplies the corresponding centered/dilated recovery equality.  This is a
 thin adapter for proof paths that already carry `TrueFactorLift` data but need

--- a/progress/20260618T010548Z_762682a3.md
+++ b/progress/20260618T010548Z_762682a3.md
@@ -1,0 +1,72 @@
+# Progress — 2026-06-18 (session 762682a3, /once #7854)
+
+## Accomplished
+
+Closed the re-scoped #7854: a producer that turns a monic-core
+`RepresentsIntegerFactorAtLift` witness (from the merged #7852 fast-core
+extractor) into a `BHKS.RecoveredLift`. Dependency #7852 is now merged, so the
+extractor symbols exist on `main`.
+
+### Recovered-equality bridge (`HexBerlekampZassenhausMathlib/Basic.lean`)
+
+`dilate_centeredLift_eq_factor_of_represents_monic`: from `Monic core`, a
+`RepresentsIntegerFactorAtLift core d factor S` witness, and Mignotte precision,
+derive the un-primitivised recovered equality
+`dilate (leadingCoeff core) (centeredLiftPoly (liftedFactorProduct d S) (p^k)) =
+factor` — exactly the shape `RecoveredLift.recovered_eq` /
+`recoveredLiftOfSubset` consume.
+
+This bridges the normalisation mismatch the issue flagged: the carrier's
+`dilate_eq` field only gives `primitivePart (dilate (lc core) monicFactor) =
+factor`, but `RecoveredLift.recovered_eq` drops the `primitivePart`. In the
+monic regime `lc core = 1` collapses the dilation, and `monicFactor` (a divisor
+of the monic core) is primitive — proved by transporting `monicFactor ∣ core`
+through `HexPolyMathlib.toPolynomial_dvd` and Mathlib's `isPrimitive_of_dvd`
+applied to `(toPolynomial core).IsPrimitive`, then back via `toPolynomial_content`
+— so `primitivePart monicFactor = monicFactor` and the wrapper vanishes. The
+congruence field plus `defaultFactorCoeffBound_valid` / the `centeredLiftPoly ∘
+reduceModPow` machinery then identify the centered selected product with
+`monicFactor`.
+
+Restricting to monic core is the correct scope, not a weakening: the boundary
+skill records that the un-primitivised `dilate (lc) (centeredLiftPoly …)` shape
+is unsatisfiable for non-unit `leadingCoeff core` (a dilated factor has content
+`> 1`). The #7852 extractor `representsIntegerFactorAtLift_of_indicatorCandidates`
+carries `Monic core`, so the producer fits its call site.
+
+### Producer (`HexBerlekampZassenhausMathlib/LiftBridge.lean`)
+
+`recoveredLiftOfRepresents`: thin `def` feeding the bridge into the existing
+`recoveredLiftOfSubset` constructor. Caller supplies only the cofactor identity
+and the precision bound.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` / `.LiftBridge` /
+  `.Recovery` / `.PartitionRefinement` / `HexBerlekampZassenhausMathlib` →
+  `Build completed successfully`, zero `error:`.
+- `lake build HexBerlekampZassenhaus` → 497 jobs, success.
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+
+## Current frontier
+
+`recoveredLiftOfRepresents` is the recovered-side producer. It does not yet have
+an in-tree consumer reindexed through `supportPartitionByMinColumn` /
+`liftedFactorSubsetsOfSupports` to a `RecoveredLift` family; that family-level
+reindex is the natural follow-up (deliverable 3's optional reindex), kept out of
+this PR.
+
+## Next step
+
+A `RecoveredLift` family over the #7852 per-candidate witnesses (one per emitted
+core factor), feeding the recovery constructors. The raw `TrueFactorLift` /
+capstone direction remains out of scope (separate exact-product migration).
+
+## Blockers
+
+None for this issue.
+
+Note: worktree carries a pre-existing unrelated `.claude/*` modification from
+before this session; not touched or staged.


### PR DESCRIPTION
This PR adds a producer that turns a monic-core `RepresentsIntegerFactorAtLift` witness from the merged #7852 fast-core extractor into a `BHKS.RecoveredLift`. The supporting bridge `dilate_centeredLift_eq_factor_of_represents_monic` derives the un-primitivised recovered equality `dilate (leadingCoeff core) (centeredLiftPoly (liftedFactorProduct d S) (p^k)) = factor` that `recoveredLiftOfSubset` consumes: it bridges the normalization mismatch where the carrier's `dilate_eq` field only exposes `primitivePart (dilate (lc core) monicFactor) = factor`. In the monic regime `leadingCoeff core = 1` collapses the dilation, and `monicFactor` (a divisor of the monic core, hence primitive via `isPrimitive_of_dvd`) makes the `primitivePart` the identity, so the wrapper vanishes; the congruence field plus the Mignotte bound then identify the centered selected product with `monicFactor`. The thin `def recoveredLiftOfRepresents` feeds this into the existing constructor, leaving the caller only the cofactor identity and the precision bound.

Restricting to monic core is the correct scope rather than a weakening: the un-primitivised `dilate (lc) (centeredLiftPoly …)` shape is unsatisfiable for non-unit `leadingCoeff core` (a dilated factor has content > 1), and the #7852 extractor operates under `Monic core`. The raw `TrueFactorLift` / capstone direction stays out of scope, per the issue's re-scope.

Closes #7854

🤖 Prepared with Claude Code