### PR TITLE
chore: record the RecoveredLift CLD period trap in the boundary skill

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -790,3 +790,25 @@ residues (`centeredResiduePow p a (z i) = w i`) whose support sum is a small
 integer (`|y| ≤ B`, `2B < p^b`). Sanity-check any "tight CLD column" directive
 that points at `abs_cldCoeffs`: that is the loose route and will not close the
 `factorCount` shape.
+
+**`RecoveredLift` cannot feed this column — the period trap (#7866, #7867).**
+The lattice column `(trueFactorCLDVector L S)[natAdd factorCount j]` is
+`∑_{i∈S} psiCut(zᵢ)` (sum of **per-factor** cuts; `cldRows = map (cldCoeffs …)`),
+and `two_mul_natAbs_sum_psiCut_le` needs the **strong** input
+`∑ᵢ centeredResiduePow p a (zᵢ) = y`, `|y| ≤ B` — the *integer* sum of per-factor
+centered residues is small, forcing the wraparound `k = 0`. Only per-factor
+`gᵢ ∣ f over ℤ` (raw `support_product_eq`, via
+`residue_cldQuotientMod_eq_phi_coeff`) gives that. `RecoveredLift` carries only
+`factor ∣ f` (`factor_mul`), so the best it yields is the **weak** aggregate
+residue `centeredResiduePow p a (∑ zᵢ) = c` — which controls `aggregateCldTail`
+(`Basic.lean:4665`, `psiCut` applied *once after summing*), **not**
+`∑ psiCut(zᵢ)`. They differ by an unbounded period `p^{a-b}·k`. Concrete:
+`p=2,a=4,b=1,z₁=z₂=8` gives `centeredResiduePow 2 4 16 = 0` (weak holds) yet
+`∑ psiCut = 8`, `2·8 = 16 ≫ |T| = 2`. The **monic coordinate** only fixes the
+`dilate (lc f)` transport in `recovered_eq` (`dilate` collapses at `lc=1`); it is
+orthogonal to this period, so it does not rescue a per-factor-column producer.
+Any "bound the tight column from `RecoveredLift` in the monic coordinate"
+directive is unsound for this reason — the genuine fix is migrating
+`bhksLatticeBasis`/`cldRows`/`trueFactorCLDVector` to emit the `aggregateCldTail`
+aggregate column (a lattice-basis redesign, not a binder-preserving consumer
+swap); diagnose and skip rather than reaching for the per-factor route.

--- a/progress/20260618T022626Z_ec5ee989.md
+++ b/progress/20260618T022626Z_ec5ee989.md
@@ -1,0 +1,58 @@
+# Progress — 2026-06-18 (session ec5ee989, /once #7867)
+
+## Accomplished
+
+Premise-checked #7867 ("aggregate mod-p^a CLD column bound from RecoveredLift,
+monic coordinate") and found its load-bearing step 2 provably false. Posted a
+counterexample-backed diagnosis and `coordination skip`ped for replan. No code
+changed.
+
+### The obstruction
+
+`tightColumnBound_of_recoveredLift` must produce `TightColumnBound L S D`
+(`Lattice.lean:952`), whose bound is on
+`(trueFactorCLDVector L S)[natAdd factorCount j]` = `∑ i∈T psiCut(zᵢ)` (the
+**sum of per-factor cuts**, `CLDColumnBound.lean:1114-1116`), with
+`zᵢ = (cldQuotientMod f gᵢ p a).coeff j`. `RecoveredLift` carries the same
+per-factor `cldCoeffs` lattice (`RecoveredLift.cldRows_eq`).
+
+Step 2 asks to bound `∑ psiCut(zᵢ)` from the aggregate residue
+`centeredResiduePow p a (∑ zᵢ) = c`, `|c| ≤ B`, `2B < p^b`. False:
+`p=2, a=4, b=1, z₁=z₂=8, B=0` gives aggregate residue `= 0` (hypothesis holds)
+yet `2·|∑ psiCut| = 16 ≤ |T| = 2` fails. Verified `#eval` against standalone
+replicas of `centeredModNat`/`centeredResiduePow`/`psiCut` (`Basic.lean:4537-4627`).
+
+Root cause: the sound `two_mul_natAbs_sum_psiCut_le` (`CLDColumnBound.lean:901`)
+needs `∑ᵢ centeredResiduePow p a (zᵢ) = y` small (integer sum of per-factor
+centered residues — forces period `k=0`). RecoveredLift gives only the aggregate
+residue (the modular sum), which differs by `p^a·k`; that period propagates into
+the column as `p^{a-b}·k`, unbounded. `k=0` requires per-factor `gᵢ ∣ f over ℤ`
+(via `residue_cldQuotientMod_eq_phi_coeff`), which RecoveredLift deliberately
+lacks. The monic coordinate fixes the dilate/centered transport but is
+orthogonal to this period obstruction. This is the same fundamental issue that
+got #7866 skipped.
+
+## Current frontier
+
+The aggregate residue *does* control `aggregateCldTail` (`Basic.lean:4665`,
+single cut after summing; bridges at `Lattice.lean:190/202`). The sound route is
+to migrate the lattice column from per-factor `cldCoeffs` rows to
+`aggregateCldTail` columns across `bhksLatticeBasis`/`cldRows`/`trueFactorCLDVector`
+— a lattice-basis redesign (affects independence, dimension, projection/knapsack
+wiring #7593/#7675), upstream of and out of scope for a binder-preserving
+consumer migration.
+
+## Next step
+
+A planner should re-scope #7867 (or #6672's fast-disjunct line) around an
+aggregate-column lattice redesign issue landed *first*; once the lattice column
+is the aggregate residue, the RecoveredLift consumer migration becomes the thin
+composition the issue originally envisioned.
+
+## Blockers
+
+The aggregate-column lattice redesign is the prerequisite; it is not a
+binder-preserving change and was explicitly the #7866 worker's recommendation.
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+modification from before this session; not touched or staged.


### PR DESCRIPTION
This PR records the period obstruction that has now blocked two issues (#7866, #7867) in the `hex-lean-mathlib-boundary` skill, so the next agent does not re-derive it from scratch.

The BHKS tight-CLD-column lattice entry is `∑_{i∈S} psiCut(zᵢ)` (sum of per-factor cuts). The carry lemma `two_mul_natAbs_sum_psiCut_le` needs the integer sum of per-factor centered residues to be small, which forces wraparound `k = 0` and is only available from per-factor `gᵢ ∣ f over ℤ` (raw `support_product_eq`). `RecoveredLift` gives only the aggregate residue, which controls `aggregateCldTail` (a single cut on the summed quotient), not `∑ psiCut(zᵢ)`; they differ by an unbounded period `p^{a-b}·k`. The monic coordinate fixes the `dilate` transport but is orthogonal to the period. The full diagnosis, with a counterexample verified against the executable definitions, is on #7867.

No Lean sources change.

🤖 Prepared with Claude Code