### PR TITLE
feat: add aggregate-tail CLD lattice path for RecoveredLift

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -807,8 +807,46 @@ residue `centeredResiduePow p a (∑ zᵢ) = c` — which controls `aggregateCld
 `∑ psiCut = 8`, `2·8 = 16 ≫ |T| = 2`. The **monic coordinate** only fixes the
 `dilate (lc f)` transport in `recovered_eq` (`dilate` collapses at `lc=1`); it is
 orthogonal to this period, so it does not rescue a per-factor-column producer.
-Any "bound the tight column from `RecoveredLift` in the monic coordinate"
-directive is unsound for this reason — the genuine fix is migrating
-`bhksLatticeBasis`/`cldRows`/`trueFactorCLDVector` to emit the `aggregateCldTail`
-aggregate column (a lattice-basis redesign, not a binder-preserving consumer
-swap); diagnose and skip rather than reaching for the per-factor route.
+Any "bound the **zero-period** tight column (`trueFactorCLDVector`) from
+`RecoveredLift`" directive is unsound for this reason — do not reach for the
+per-factor `tightColumnBound_of_lift` route from a `RecoveredLift`.
+
+**The sound fix landed (#7876) and is NOT a basis redesign.** The executable
+`bhksLatticeBasis` already carries the diagonal *period rows* `diag(p^(a−ℓⱼ))`, so
+the *period-adjusted* tail `∑ psiCut(zᵢ) − tⱼ·p^(a−ℓⱼ)` is a genuine lattice
+vector (`periodAdjustedVector`, `CLDColumnBound.lean`) — packaged as a
+`SupportShortVectorData` (the period-adjusted certificate carrying its own
+`vector`), **not** the zero-period `trueFactorCLDVector`.
+`supportShortVectorData_of_recoveredLift` bounds each period-adjusted column by
+`factorCount/2` from the aggregate residue (`recoveredLift_aggregate_residue`,
+#7872) plus `two_mul_natAbs_sum_psiCut_period_le` (#7869), and
+`cutProjectionHypotheses_of_shortVectors` (the existing `SupportShortVectorData`
+consumer) carries it to the fast-disjunct endpoint
+(`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`). Two
+load-bearing facts the earlier "skip" advice missed: (a) the period lemma's
+*proof* gives `2|d| < T.card+1`, i.e. `≤ T.card` over ℤ — the tight column bound,
+fitting the exact radius `4r+n·r²` (its stated `≤ T.card+1` was weaker than
+proved; #7876 strengthened it in place); (b) the period reduction lives in the
+lattice's *period rows*, applied to the ordinary per-factor cut sum — no
+executable basis change (and no `aggregateCldTail` emission) is needed.
+
+### Producers of data-carrying certificate structures must be `def`, not `theorem`
+
+This layer has many certificate *structures* that carry data, not Props:
+`SupportShortVectorData` (a `vector` field), `TrueFactorCLDVectorData`,
+`CutProjectionHypotheses`, `RecoveredLift`. A producer concluding
+`: <SuchStruct>` is a `def`, not a `theorem` — `theorem foo :
+SupportShortVectorData L S` errors with "type of theorem `foo` is not a
+proposition". Match the existing producers (`cutProjectionHypotheses_of_shortVectors`
+is a `def`).
+
+### Projection equalities from a `*Lift` package: destructure, don't `rw [D.basis_eq]`
+
+To prove `L.p = D.p` / `L.precision = D.a` for `D : RecoveredLift L S` (or
+`TrueFactorLift`), do **not** `rw [D.basis_eq]` in the goal: `D`'s own type
+mentions `L`, so abstracting `L` gives "motive is not type correct". Add a helper
+lemma proved by the destructure pattern the namespace already uses
+(`rcases D with ⟨…, basis_eq, …⟩; cases basis_eq; rfl`) — e.g.
+`RecoveredLift.p_eq`/`precision_eq`/`cutThresholds_eq` — then consume it with
+`:=` or `simp only [hLp]` (simp rewrites the *projection term* fine; only the
+`rw [D.basis_eq]` whole-`L` abstraction fails).

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -980,7 +980,7 @@ theorem two_mul_natAbs_sum_psiCut_period_le
     (hy : y.natAbs ≤ B) (hsep : 2 * B < p ^ b) :
     ∃ t : Int,
       2 * (((∑ i ∈ T, Hex.psiCut p a b (z i)) - t * (p ^ (a - b) : Int))).natAbs
-        ≤ T.card + 1 := by
+        ≤ T.card := by
   classical
   have hp0 : 0 < p := lt_trans zero_lt_one hp
   have hpb : 0 < p ^ b := pow_pos hp0 b
@@ -1042,13 +1042,13 @@ theorem two_mul_natAbs_sum_psiCut_period_le
       _ ≤ 2 * (B : Int) + (T.card : Int) * (p ^ b : Nat) := by linarith [hlo_le, hyZ]
   have hsepZ : 2 * (B : Int) < ((p ^ b : Nat) : Int) := by exact_mod_cast hsep
   have hpbZ : (0 : Int) < ((p ^ b : Nat) : Int) := by exact_mod_cast hpb
-  have hdNat : 2 * |d| ≤ (T.card : Int) + 1 := by
+  have hdNat : 2 * |d| ≤ (T.card : Int) := by
     have hlt2 : ((p ^ b : Nat) : Int) * (2 * |d|) <
         ((p ^ b : Nat) : Int) * ((T.card : Int) + 1) := by
       nlinarith [hstep, hsepZ, hpbZ]
     have h2N : 2 * |d| < (T.card : Int) + 1 := lt_of_mul_lt_mul_left hlt2 (le_of_lt hpbZ)
     omega
-  have hfin : (2 * d.natAbs : Int) ≤ (T.card : Int) + 1 := by
+  have hfin : (2 * d.natAbs : Int) ≤ (T.card : Int) := by
     rw [Int.abs_eq_natAbs] at hdNat; push_cast at hdNat ⊢; linarith
   exact_mod_cast hfin
 
@@ -1562,6 +1562,280 @@ theorem recoveredLift_aggregate_residue
   rw [hA, hB]
   exact listSum_emod_eq _ _ _ _
     (fun i _ => centeredResiduePow_emod_self D.p D.a _)
+
+/-! ### Period-adjusted true-factor short vector from a `RecoveredLift` (issue #7876)
+
+The per-factor tight column (`tightColumnBound_of_lift`) bounds the *zero-period*
+tail `∑_{i∈S} psiCut(zᵢ)` and routes through per-factor integer divisibility,
+which a `RecoveredLift` cannot supply (the period trap of #7866/#7867).  The
+sound route uses the BHKS lattice's own period rows `diag(p^(a−ℓⱼ))`: the
+*period-adjusted* tail `∑_{i∈S} psiCut(zᵢ) − tⱼ·p^(a−ℓⱼ)` is still bounded by
+`factorCount/2` (`two_mul_natAbs_sum_psiCut_period_le`) from only the aggregate
+residue (`recoveredLift_aggregate_residue`), and the adjusted vector is still a
+genuine BHKS lattice vector (the period rows are basis rows), projecting to the
+same support indicator.  This produces a `SupportShortVectorData`, fed to the
+fast-disjunct consumer through `cutProjectionHypotheses_of_shortVectors`. -/
+
+/-- The executable cut-threshold array reads back the per-coordinate threshold. -/
+theorem bhksCutThresholds_getD_of_lt (f : Hex.ZPoly) (p j : Nat)
+    (h : j < f.degree?.getD 0) :
+    (Hex.bhksCutThresholds f p).getD j 0 = Hex.bhksCoeffCutThreshold p f j := by
+  unfold Hex.bhksCutThresholds
+  rw [Array.getD_eq_getD_getElem?]
+  have hsize :
+      (((List.range (f.degree?.getD 0)).map
+        (fun j => Hex.bhksCoeffCutThreshold p f j)).toArray).size = f.degree?.getD 0 := by
+    simp
+  rw [Array.getElem?_eq_getElem (by simpa [hsize] using h)]
+  simp [List.getElem_toArray, List.getElem_map, List.getElem_range]
+
+/-- Selection coefficients for the period-adjusted true-factor short vector: the
+support indicator on the first block, and `−t j` on the diagonal-period rows. -/
+def periodAdjustedRowCoeffs (L : Hex.BhksLatticeBasis) (S : LiftedFactorSupport L)
+    (t : Fin L.coeffWidth → ℤ) : Vector ℤ (L.factorCount + L.coeffWidth) :=
+  Vector.ofFn fun x =>
+    if hx : x.val < L.factorCount then indicatorVector S ⟨x.val, hx⟩
+    else - t ⟨x.val - L.factorCount, by omega⟩
+
+theorem periodAdjustedRowCoeffs_castAdd (L : Hex.BhksLatticeBasis)
+    (S : LiftedFactorSupport L) (t : Fin L.coeffWidth → ℤ) (i : Fin L.factorCount) :
+    (periodAdjustedRowCoeffs L S t)[Fin.castAdd L.coeffWidth i] = indicatorVector S i := by
+  show (periodAdjustedRowCoeffs L S t).get _ = _
+  unfold periodAdjustedRowCoeffs
+  rw [Vector.get_ofFn,
+    dif_pos (show (Fin.castAdd L.coeffWidth i).val < L.factorCount from i.isLt)]
+  congr 1
+
+theorem periodAdjustedRowCoeffs_natAdd (L : Hex.BhksLatticeBasis)
+    (S : LiftedFactorSupport L) (t : Fin L.coeffWidth → ℤ) (j : Fin L.coeffWidth) :
+    (periodAdjustedRowCoeffs L S t)[Fin.natAdd L.factorCount j] = - t j := by
+  show (periodAdjustedRowCoeffs L S t).get _ = _
+  unfold periodAdjustedRowCoeffs
+  rw [Vector.get_ofFn,
+    dif_neg (by simp only [Fin.val_natAdd]; omega)]
+  congr 2
+  apply Fin.ext
+  simp only [Fin.val_natAdd]
+  omega
+
+/-- The period-adjusted true-factor short vector: the support indicator on the
+first block, with the CLD tail reduced by the diagonal-period rows. -/
+def periodAdjustedVector (L : Hex.BhksLatticeBasis) (S : LiftedFactorSupport L)
+    (t : Fin L.coeffWidth → ℤ) : Vector ℤ (L.factorCount + L.coeffWidth) :=
+  Hex.Matrix.rowCombination L.basis (periodAdjustedRowCoeffs L S t)
+
+theorem periodAdjustedVector_memLattice (L : Hex.BhksLatticeBasis)
+    (S : LiftedFactorSupport L) (t : Fin L.coeffWidth → ℤ) :
+    Hex.Matrix.memLattice L.basis (periodAdjustedVector L S t) :=
+  ⟨periodAdjustedRowCoeffs L S t, rfl⟩
+
+/-- Under block form, the first `factorCount` coordinates of the period-adjusted
+vector are exactly the support indicator (the period rows do not touch the first
+block). -/
+theorem periodAdjustedVector_project_of_blockForm
+    {L : Hex.BhksLatticeBasis} (S : LiftedFactorSupport L)
+    (hL : BhksBlockForm L) (t : Fin L.coeffWidth → ℤ) (i : Fin L.factorCount) :
+    (periodAdjustedVector L S t)[
+        (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth))] =
+      indicatorVector S i := by
+  unfold periodAdjustedVector
+  rw [rowCombination_getElem_eq_sum, Fin.sum_univ_add]
+  have hentry : ∀ x : Fin (L.factorCount + L.coeffWidth),
+      L.basis[x][(⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth))]
+        = Hex.bhksLatticeEntry L.factorCount L.coeffWidth L.p L.precision
+            L.cutThresholds L.cldRows x
+            ⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ := by
+    intro x
+    rw [hL, Hex.Matrix.getElem_ofFn]
+  have hsnd : (∑ j : Fin L.coeffWidth,
+      L.basis[Fin.natAdd L.factorCount j][(⟨i.val,
+          Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth))] *
+        (periodAdjustedRowCoeffs L S t)[Fin.natAdd L.factorCount j]) = 0 := by
+    apply Finset.sum_eq_zero
+    intro j _
+    rw [hentry]
+    unfold Hex.bhksLatticeEntry
+    rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
+      dif_pos (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth)).val < L.factorCount from i.isLt),
+      zero_mul]
+  rw [hsnd, add_zero]
+  have hfst : ∀ i' : Fin L.factorCount,
+      L.basis[Fin.castAdd L.coeffWidth i'][(⟨i.val,
+          Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth))] *
+        (periodAdjustedRowCoeffs L S t)[Fin.castAdd L.coeffWidth i']
+        = (if i' = i then (1 : ℤ) else 0) * indicatorVector S i' := by
+    intro i'
+    rw [hentry, periodAdjustedRowCoeffs_castAdd]
+    unfold Hex.bhksLatticeEntry
+    rw [dif_pos (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
+      dif_pos (show (⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+          Fin (L.factorCount + L.coeffWidth)).val < L.factorCount from i.isLt)]
+    by_cases h : i' = i
+    · subst h; simp
+    · rw [if_neg h,
+        if_neg (by simp only [Fin.val_castAdd]; exact fun hv => h (Fin.ext hv))]
+  rw [Finset.sum_congr rfl (fun i' _ => hfst i'), Finset.sum_eq_single i]
+  · rw [if_pos rfl, one_mul]
+  · intro i' _ hne
+    rw [if_neg hne, zero_mul]
+  · intro h
+    exact absurd (Finset.mem_univ i) h
+
+/-- Under block form, the trailing `coeffWidth` coordinates of the period-adjusted
+vector are the support CLD-column sum reduced by the diagonal-period correction. -/
+theorem periodAdjustedVector_coeff_of_blockForm
+    {L : Hex.BhksLatticeBasis} (S : LiftedFactorSupport L)
+    (hL : BhksBlockForm L) (t : Fin L.coeffWidth → ℤ) (j : Fin L.coeffWidth) :
+    (periodAdjustedVector L S t)[
+        (⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+          Fin (L.factorCount + L.coeffWidth))] =
+      (∑ i : Fin L.factorCount,
+        indicatorVector S i * (L.cldRows.getD i.val #[]).getD j.val 0)
+      - (Int.ofNat (L.p ^ (L.precision - L.cutThresholds.getD j.val 0))) * t j := by
+  unfold periodAdjustedVector
+  rw [rowCombination_getElem_eq_sum, Fin.sum_univ_add]
+  have hentry : ∀ x : Fin (L.factorCount + L.coeffWidth),
+      L.basis[x][(⟨L.factorCount + j.val,
+          Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+          Fin (L.factorCount + L.coeffWidth))]
+        = Hex.bhksLatticeEntry L.factorCount L.coeffWidth L.p L.precision
+            L.cutThresholds L.cldRows x
+            ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩ := by
+    intro x
+    rw [hL, Hex.Matrix.getElem_ofFn]
+  -- First block: the indicator-weighted CLD column sum.
+  have hfst : (∑ i' : Fin L.factorCount,
+      L.basis[Fin.castAdd L.coeffWidth i'][(⟨L.factorCount + j.val,
+          Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+          Fin (L.factorCount + L.coeffWidth))] *
+        (periodAdjustedRowCoeffs L S t)[Fin.castAdd L.coeffWidth i'])
+      = ∑ i : Fin L.factorCount,
+        indicatorVector S i * (L.cldRows.getD i.val #[]).getD j.val 0 := by
+    refine Finset.sum_congr rfl ?_
+    intro i' _
+    rw [hentry, periodAdjustedRowCoeffs_castAdd]
+    have hcld : Hex.bhksLatticeEntry L.factorCount L.coeffWidth L.p L.precision
+        L.cutThresholds L.cldRows (Fin.castAdd L.coeffWidth i')
+        ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩
+        = (L.cldRows.getD i'.val #[]).getD j.val 0 := by
+      unfold Hex.bhksLatticeEntry
+      rw [dif_pos (show (Fin.castAdd L.coeffWidth i').val < L.factorCount from i'.isLt),
+        dif_neg (by
+          show ¬ (⟨L.factorCount + j.val,
+            Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+            Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
+          simp only []; omega)]
+      simp [Fin.val_castAdd]
+    rw [hcld, mul_comm]
+  -- Tail block: only the diagonal row `j` survives, contributing the period term.
+  have hsnd : (∑ j' : Fin L.coeffWidth,
+      L.basis[Fin.natAdd L.factorCount j'][(⟨L.factorCount + j.val,
+          Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+          Fin (L.factorCount + L.coeffWidth))] *
+        (periodAdjustedRowCoeffs L S t)[Fin.natAdd L.factorCount j'])
+      = - (Int.ofNat (L.p ^ (L.precision - L.cutThresholds.getD j.val 0)) * t j) := by
+    rw [Finset.sum_eq_single j]
+    · rw [hentry, periodAdjustedRowCoeffs_natAdd]
+      have hdiag : Hex.bhksLatticeEntry L.factorCount L.coeffWidth L.p L.precision
+          L.cutThresholds L.cldRows (Fin.natAdd L.factorCount j)
+          ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩
+          = Int.ofNat (L.p ^ (L.precision - L.cutThresholds.getD j.val 0)) := by
+        unfold Hex.bhksLatticeEntry
+        rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
+          dif_neg (by
+            show ¬ (⟨L.factorCount + j.val,
+              Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+              Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
+            simp only []; omega)]
+        simp only [Fin.val_natAdd, Nat.add_sub_cancel_left, ↓reduceIte]
+      rw [hdiag]; ring
+    · intro j' _ hne
+      rw [hentry]
+      have hoff : Hex.bhksLatticeEntry L.factorCount L.coeffWidth L.p L.precision
+          L.cutThresholds L.cldRows (Fin.natAdd L.factorCount j')
+          ⟨L.factorCount + j.val, Nat.add_lt_add_left j.isLt L.factorCount⟩ = 0 := by
+        unfold Hex.bhksLatticeEntry
+        rw [dif_neg (by simp only [Fin.val_natAdd]; omega),
+          dif_neg (by
+            show ¬ (⟨L.factorCount + j.val,
+              Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+              Fin (L.factorCount + L.coeffWidth)).val < L.factorCount
+            simp only []; omega)]
+        simp only [Fin.val_natAdd, Nat.add_sub_cancel_left]
+        rw [if_neg (by
+          intro hcontra
+          exact hne (Fin.ext hcontra.symm))]
+      rw [hoff, zero_mul]
+    · intro h
+      exact absurd (Finset.mem_univ j) h
+  rw [hfst, hsnd]
+  ring
+
+private theorem intSq_le_of_natAbs_le' (z : ℤ) (B : Nat) (h : z.natAbs ≤ B) :
+    ((z : ℝ) ^ 2) ≤ (B : ℝ) ^ 2 := by
+  have hR : (z.natAbs : ℝ) ≤ (B : ℝ) := by exact_mod_cast h
+  have hsq : ((z.natAbs : ℝ) ^ 2) ≤ (B : ℝ) ^ 2 := by
+    have hdiff : 0 ≤ (B : ℝ) - (z.natAbs : ℝ) := sub_nonneg.mpr hR
+    have hsum : 0 ≤ (B : ℝ) + (z.natAbs : ℝ) := by positivity
+    nlinarith [mul_nonneg hdiff hsum]
+  rcases Int.natAbs_eq z with hz | hz
+  · rw [hz]; exact hsq
+  · rw [hz]; simpa using hsq
+
+/-- Generic tight cut-radius norm bound for any support vector whose first block
+is the indicator and whose tail columns satisfy `2·|colⱼ| ≤ factorCount`. -/
+theorem four_mul_sq_norm_le_of_colBound
+    {L : Hex.BhksLatticeBasis} (S : LiftedFactorSupport L)
+    (v : Vector ℤ (L.factorCount + L.coeffWidth))
+    (hfirst : ∀ i : Fin L.factorCount,
+      (v[(⟨i.val, Nat.lt_add_right L.coeffWidth i.isLt⟩ :
+        Fin (L.factorCount + L.coeffWidth))] : ℤ) = indicatorVector S i)
+    (hcol : ∀ j : Fin L.coeffWidth,
+      2 * (v[Fin.natAdd L.factorCount j] : ℤ).natAbs ≤ L.factorCount) :
+    4 * (∑ i : Fin (L.factorCount + L.coeffWidth), (((v[i] : ℤ) : ℝ) ^ 2))
+      ≤ (Hex.bhksCutRadiusSq4 L : ℝ) := by
+  rw [Fin.sum_univ_add, mul_add]
+  have hcast : ∀ i : Fin L.factorCount,
+      (v[Fin.castAdd L.coeffWidth i] : ℤ) = indicatorVector S i := fun i => hfirst i
+  have hfirst' : (∑ i : Fin L.factorCount,
+      (((v[Fin.castAdd L.coeffWidth i] : ℤ) : ℝ) ^ 2)) ≤ (L.factorCount : ℝ) := by
+    have heq : (∑ i : Fin L.factorCount,
+        (((v[Fin.castAdd L.coeffWidth i] : ℤ) : ℝ) ^ 2))
+        = ∑ i : Fin L.factorCount, (((indicatorVector S i : ℤ) : ℝ) ^ 2) :=
+      Finset.sum_congr rfl (fun i _ => by rw [hcast i])
+    rw [heq]
+    exact indicatorVector_sq_sum_le_factorCount S
+  have hfirst4 : 4 * (∑ i : Fin L.factorCount,
+      (((v[Fin.castAdd L.coeffWidth i] : ℤ) : ℝ) ^ 2))
+      ≤ 4 * (L.factorCount : ℝ) := by linarith
+  have htail : 4 * (∑ j : Fin L.coeffWidth,
+        (((v[Fin.natAdd L.factorCount j] : ℤ) : ℝ) ^ 2))
+      ≤ (L.coeffWidth * L.factorCount * L.factorCount : ℝ) := by
+    rw [Finset.mul_sum]
+    calc
+      (∑ j : Fin L.coeffWidth,
+          4 * (((v[Fin.natAdd L.factorCount j] : ℤ) : ℝ) ^ 2))
+          ≤ ∑ _j : Fin L.coeffWidth, ((L.factorCount : ℝ) ^ 2) := by
+            refine Finset.sum_le_sum (fun j _ => ?_)
+            set z : ℤ := (v[Fin.natAdd L.factorCount j] : ℤ) with hz
+            have hnat : (2 * z).natAbs ≤ L.factorCount := by
+              rw [Int.natAbs_mul]; simpa using hcol j
+            have hsq := intSq_le_of_natAbs_le' (2 * z) L.factorCount hnat
+            have hexpand : (((2 * z : ℤ)) : ℝ) ^ 2 = 4 * ((z : ℤ) : ℝ) ^ 2 := by
+              push_cast; ring
+            rw [hexpand] at hsq
+            exact hsq
+      _ = (L.coeffWidth * L.factorCount * L.factorCount : ℝ) := by
+            simp [pow_two, mul_assoc]
+  refine (add_le_add hfirst4 htail).trans (le_of_eq ?_)
+  unfold Hex.bhksCutRadiusSq4
+  push_cast
+  ring
 
 end BHKS
 

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -1837,6 +1837,114 @@ theorem four_mul_sq_norm_le_of_colBound
   push_cast
   ring
 
+/-- **Period-adjusted true-factor short vector from a `RecoveredLift` (issue
+#7876).**  In the monic regime, the aggregate residue bridge
+(`recoveredLift_aggregate_residue`) and the period-aware carry lemma
+(`two_mul_natAbs_sum_psiCut_period_le`) bound each tail column of the
+period-adjusted vector by `factorCount/2`.  Together with the structural project
+and lattice-membership facts, this yields a `SupportShortVectorData` for the
+recovered support — the genuine aggregate-tail lattice path the period trap
+(#7866/#7867) forces, feeding the fast-disjunct consumer through
+`cutProjectionHypotheses_of_shortVectors`. -/
+def supportShortVectorData_of_recoveredLift
+    {L : Hex.BhksLatticeBasis} {S : LiftedFactorSupport L}
+    (D : RecoveredLift L S)
+    (hf_lc : Hex.DensePoly.leadingCoeff D.f = 1)
+    (hfactor_monic : (HexPolyMathlib.toPolynomial D.factor).Monic)
+    (hp : 2 ≤ D.p)
+    (hk : 1 < D.p ^ D.a)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound D.f j < D.p ^ D.a)
+    (hthr : ∀ j, Hex.bhksCoeffCutThreshold D.p D.f j ≤ D.a)
+    (hfac : ∀ i : Fin L.factorCount, i ∈ S →
+        ∃ h : Hex.ZPoly,
+          Hex.DensePoly.Monic (L.liftedFactors.getD i.val 1) ∧
+          0 < (L.liftedFactors.getD i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr D.f ((L.liftedFactors.getD i.val 1) * h) (D.p ^ D.a)) :
+    SupportShortVectorData L S := by
+  classical
+  -- Per-column cut-modulus separation `2·B < p^ℓⱼ`.
+  have hsep_b : ∀ j : Fin L.coeffWidth,
+      2 * Hex.bhksCoeffBound D.f j.val < D.p ^ Hex.bhksCoeffCutThreshold D.p D.f j.val := by
+    intro j
+    have hcut := Hex.le_pow_ceilLogP hp (2 * Hex.bhksCoeffBound D.f j.val + 1)
+    have hcut2 : 2 * Hex.bhksCoeffBound D.f j.val + 1
+        ≤ D.p ^ Hex.bhksCoeffCutThreshold D.p D.f j.val := hcut
+    omega
+  -- Per-column period existential from the aggregate residue and carry lemma.
+  have hperiod : ∀ j : Fin L.coeffWidth, ∃ tj : ℤ,
+      2 * (((∑ i ∈ Finset.univ.filter (fun i => i ∈ S),
+          Hex.psiCut D.p D.a (Hex.bhksCoeffCutThreshold D.p D.f j.val)
+            ((Hex.cldQuotientMod D.f (L.liftedFactors.getD i.val 1) D.p D.a).coeff j.val))
+        - tj * (D.p ^ (D.a - Hex.bhksCoeffCutThreshold D.p D.f j.val) : Int))).natAbs
+        ≤ (Finset.univ.filter (fun i => i ∈ S)).card := by
+    intro j
+    obtain ⟨hres, hbnd⟩ :=
+      recoveredLift_aggregate_residue D hf_lc hfactor_monic hk hsep hfac j.val
+    exact two_mul_natAbs_sum_psiCut_period_le
+      (Finset.univ.filter (fun i => i ∈ S)) D.p D.a
+      (Hex.bhksCoeffCutThreshold D.p D.f j.val) (hthr j.val) (by omega)
+      (fun i => (Hex.cldQuotientMod D.f (L.liftedFactors.getD i.val 1) D.p D.a).coeff j.val)
+      ((phi (HexPolyMathlib.toPolynomial D.f)
+        (HexPolyMathlib.toPolynomial D.factor)).coeff j.val)
+      (Hex.bhksCoeffBound D.f j.val) hres hbnd (hsep_b j)
+  set t : Fin L.coeffWidth → ℤ := fun j => Classical.choose (hperiod j) with ht_def
+  have ht : ∀ j : Fin L.coeffWidth,
+      2 * (((∑ i ∈ Finset.univ.filter (fun i => i ∈ S),
+          Hex.psiCut D.p D.a (Hex.bhksCoeffCutThreshold D.p D.f j.val)
+            ((Hex.cldQuotientMod D.f (L.liftedFactors.getD i.val 1) D.p D.a).coeff j.val))
+        - t j * (D.p ^ (D.a - Hex.bhksCoeffCutThreshold D.p D.f j.val) : Int))).natAbs
+        ≤ (Finset.univ.filter (fun i => i ∈ S)).card :=
+    fun j => Classical.choose_spec (hperiod j)
+  have hcard : (Finset.univ.filter (fun i => i ∈ S)).card ≤ L.factorCount := by
+    calc (Finset.univ.filter (fun i => i ∈ S)).card
+          ≤ (Finset.univ : Finset (Fin L.factorCount)).card := Finset.card_filter_le _ _
+      _ = L.factorCount := by simp
+  -- Each tail coordinate of the period-adjusted vector is the period-reduced cut.
+  have hcoord_eq : ∀ j : Fin L.coeffWidth,
+      ((periodAdjustedVector L S t)[Fin.natAdd L.factorCount j] : ℤ)
+        = (∑ i ∈ Finset.univ.filter (fun i => i ∈ S),
+            Hex.psiCut D.p D.a (Hex.bhksCoeffCutThreshold D.p D.f j.val)
+              ((Hex.cldQuotientMod D.f (L.liftedFactors.getD i.val 1) D.p D.a).coeff j.val))
+          - t j * (D.p ^ (D.a - Hex.bhksCoeffCutThreshold D.p D.f j.val) : Int) := by
+    intro j
+    have hjlt : j.val < D.f.degree?.getD 0 := j.isLt.trans_eq D.coeffWidth_eq
+    have hcoord := periodAdjustedVector_coeff_of_blockForm S D.blockForm t j
+    rw [show ((periodAdjustedVector L S t)[Fin.natAdd L.factorCount j] : ℤ)
+        = (periodAdjustedVector L S t)[(⟨L.factorCount + j.val,
+            Nat.add_lt_add_left j.isLt L.factorCount⟩ :
+            Fin (L.factorCount + L.coeffWidth))] from rfl, hcoord]
+    have hLp : L.p = D.p := D.p_eq
+    have hLprec : L.precision = D.a := D.precision_eq
+    have hLthr : L.cutThresholds.getD j.val 0 = Hex.bhksCoeffCutThreshold D.p D.f j.val := by
+      rw [D.cutThresholds_eq, bhksCutThresholds_getD_of_lt D.f D.p j.val hjlt]
+    simp only [hLp, hLprec, hLthr]
+    congr 1
+    · rw [Finset.sum_filter]
+      refine Finset.sum_congr rfl (fun i _ => ?_)
+      by_cases hi : i ∈ S
+      · rw [indicatorVector_apply_mem S hi, one_mul, if_pos hi]
+        have hLcld : (L.cldRows.getD i.val #[]).getD j.val 0
+            = (Hex.cldCoeffs D.f D.p D.a (L.liftedFactors.getD i.val 1)).getD j.val 0 := by
+          congr 1
+          rw [D.cldRows_eq, D.liftedFactors_eq]
+          have hsz : i.val < D.liftedFactors.size := i.isLt.trans_eq D.factorCount_eq
+          simp [Array.getD, hsz]
+        rw [hLcld,
+          Hex.cldCoeffs_getD_of_lt D.f D.p D.a (L.liftedFactors.getD i.val 1) j.val hjlt]
+      · rw [indicatorVector_apply_not_mem S hi, zero_mul, if_neg hi]
+    · rw [Int.ofNat_eq_natCast, Nat.cast_pow]
+      ring
+  refine
+    { vector := periodAdjustedVector L S t
+      memLattice := periodAdjustedVector_memLattice L S t
+      project_eq := fun i => periodAdjustedVector_project_of_blockForm S D.blockForm t i
+      four_mul_sq_norm_le := ?_ }
+  refine four_mul_sq_norm_le_of_colBound S (periodAdjustedVector L S t)
+    (fun i => periodAdjustedVector_project_of_blockForm S D.blockForm t i)
+    (fun j => ?_)
+  rw [hcoord_eq j]
+  exact le_trans (ht j) hcard
+
 end BHKS
 
 end

--- a/HexBerlekampZassenhausMathlib/Lattice.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice.lean
@@ -587,6 +587,26 @@ theorem coeffWidth_eq
   cases basis_eq
   rfl
 
+/-- The packaged basis carries exactly the input prime. -/
+theorem p_eq
+    {L : Hex.BhksLatticeBasis} {S : LiftedFactorSupport L}
+    (D : RecoveredLift L S) :
+    L.p = D.p := by
+  rcases D with ⟨f, p, a, liftedFactors, basis_eq, factor, cofactor, factor_mul,
+    recovered_eq⟩
+  cases basis_eq
+  rfl
+
+/-- The packaged basis carries exactly the Hensel precision exponent. -/
+theorem precision_eq
+    {L : Hex.BhksLatticeBasis} {S : LiftedFactorSupport L}
+    (D : RecoveredLift L S) :
+    L.precision = D.a := by
+  rcases D with ⟨f, p, a, liftedFactors, basis_eq, factor, cofactor, factor_mul,
+    recovered_eq⟩
+  cases basis_eq
+  rfl
+
 end RecoveredLift
 
 /--

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -636,6 +636,62 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift
   exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_trueFactors
     trueSupports hcore_ne h hbasis data tight hsize hpartition
 
+/--
+Capstone composition for the fast `h_raw` disjunct via the **aggregate-tail CLD
+lattice path** (issue #7876).  Where
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift` needs a
+`TrueFactorLift` (raw per-factor integer divisibility), this consumes the weaker
+`RecoveredLift` that the executable fast-core recovery actually exposes: each
+support's `RecoveredLift` produces a period-adjusted `SupportShortVectorData`
+(`BHKS.supportShortVectorData_of_recoveredLift`, in the monic coordinate), which
+`BHKS.cutProjectionHypotheses_of_shortVectors` turns into the forward cut
+certificate.  This is the route that survives the CLD period trap
+(#7866/#7867): the per-factor column bound is unavailable, but the
+period-reduced aggregate column is bounded by the aggregate residue alone.
+
+The monic-coordinate hypothesis `hf_lc` (`leadingCoeff f = 1`) and the
+precision/threshold separations `hk`/`hsep`/`hthr` are the BHKS Lemma 5.7 inputs
+at the first-success lift precision, threaded here verbatim; `hfac` is the
+Hensel-factorisation datum `∏ gᵢ ≡ f (mod pᵃ)` per selected factor. -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {L : Hex.BhksLatticeBasis} {hrows : 1 ≤ L.factorCount + L.coeffWidth}
+    (trueSupports :
+      Set (Set (Fin (Hex.bhksProjectedRows L hrows).factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hbasis : L.basis.independent)
+    (lift : ∀ S : trueSupports, BHKS.RecoveredLift L S.1)
+    (hf_lc : ∀ S : trueSupports, Hex.DensePoly.leadingCoeff (lift S).f = 1)
+    (hfactor_monic : ∀ S : trueSupports,
+      (HexPolyMathlib.toPolynomial (lift S).factor).Monic)
+    (hp : ∀ S : trueSupports, 2 ≤ (lift S).p)
+    (hk : ∀ S : trueSupports, 1 < (lift S).p ^ (lift S).a)
+    (hsep : ∀ S : trueSupports,
+      ∀ j, 2 * Hex.bhksCoeffBound (lift S).f j < (lift S).p ^ (lift S).a)
+    (hthr : ∀ S : trueSupports,
+      ∀ j, Hex.bhksCoeffCutThreshold (lift S).p (lift S).f j ≤ (lift S).a)
+    (hfac : ∀ S : trueSupports, ∀ i : Fin L.factorCount, i ∈ S.1 →
+        ∃ g : Hex.ZPoly,
+          Hex.DensePoly.Monic (L.liftedFactors.getD i.val 1) ∧
+          0 < (L.liftedFactors.getD i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr (lift S).f ((L.liftedFactors.getD i.val 1) * g)
+            ((lift S).p ^ (lift S).a))
+    (hsize :
+      coreFactors.size =
+        (Hex.bhksEquivalenceClassIndicators (Hex.bhksProjectedRows L hrows)).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ coreFactors.toList, Hex.ZPoly.Irreducible factor := by
+  have hcut := BHKS.cutProjectionHypotheses_of_shortVectors L hrows hbasis trueSupports
+    (fun S => BHKS.supportShortVectorData_of_recoveredLift (lift S) (hf_lc S)
+      (hfactor_monic S) (hp S) (hk S) (hsep S) (hthr S) (hfac S))
+  exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut trueSupports
+    hcore_ne h hcut hsize hpartition
+
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`
 with `factorFastCoreWithBound_some_factor_count_ge`, exposing the count

--- a/progress/20260618T065527Z_8a34c047.md
+++ b/progress/20260618T065527Z_8a34c047.md
@@ -1,0 +1,66 @@
+# Progress — 2026-06-18 (session 8a34c047, /work → /feature #7876)
+
+## Accomplished
+
+Implemented the aggregate-tail CLD lattice path for `RecoveredLift` (#7876),
+the genuine sound fix for the CLD period trap that blocked #7866/#7867. All
+in `HexBerlekampZassenhausMathlib` (CI-gated Mathlib layer).
+
+### Premise check (sound)
+
+The period trap is real for the *zero-period* per-factor column
+`∑ psiCut(zᵢ)`, but the BHKS lattice's own period rows `diag(p^(a−ℓⱼ))` make the
+*period-adjusted* tail `∑ psiCut(zᵢ) − tⱼ·p^(a−ℓⱼ)` a genuine lattice vector, and
+that column IS bounded by `factorCount/2` from only the aggregate residue. Key
+discovery: `two_mul_natAbs_sum_psiCut_period_le` (#7869) *proves*
+`2|d| < T.card+1` hence `≤ T.card` over ℤ — its stated `≤ T.card+1` was weaker
+than proved, so the period column fits the *exact* tight cut radius `4r+n·r²`.
+
+### Changes
+
+- `CLDColumnBound.lean`:
+  - Strengthened `two_mul_natAbs_sum_psiCut_period_le` conclusion to `≤ T.card`.
+  - `bhksCutThresholds_getD_of_lt`; `periodAdjustedRowCoeffs` / `periodAdjustedVector`
+    (indicator on first block, `−tⱼ` on the diagonal-period rows) with
+    `memLattice`, block-form `project` and CLD-tail `coeff` coordinate identities.
+  - `four_mul_sq_norm_le_of_colBound`: generic tight cut-radius norm bound from
+    `2|colⱼ| ≤ factorCount`.
+  - `supportShortVectorData_of_recoveredLift`: from a `RecoveredLift` (monic
+    coordinate), aggregate residue (#7872) + period carry lemma bound each tail
+    column, assembling a `SupportShortVectorData` on the period-adjusted vector.
+- `Lattice.lean`: `RecoveredLift.p_eq` / `precision_eq` helpers.
+- `PartitionRefinement.lean`:
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift` —
+  RecoveredLift analog of the `_of_lift` consumer, threading the period-adjusted
+  short-vector certificates through `cutProjectionHypotheses_of_shortVectors`.
+
+Deliverable 4 honored: no false binder-preserving theorem reintroduced; no
+per-factor integer divisibility assumed (only the aggregate residue + the period
+reduction); the bound is on the period-adjusted column, never on `∑ psiCut(zᵢ)`.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib` → Build completed successfully (3790 jobs).
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff origin/main --check` → exit 0.
+- Added-line forbidden-token scan (sorry/axiom/native_decide/TODO/FIXME) → none.
+
+## Current frontier
+
+`..._of_recoveredLift` is the producer endpoint. No in-tree consumer yet: the
+per-support `RecoveredLift` family for the first-success recovery is the same
+residual the `_of_lift` consumer already carries (PartitionRefinement.lean
+~597-601), to be supplied by the #2564 / fast-disjunct (#6672) wiring.
+
+## Next step
+
+Supply the per-support `RecoveredLift`/separation family for the first
+successful fast-core recovery, instantiating `..._of_recoveredLift` toward the
+fast `h_raw` disjunct of #6672.
+
+## Blockers
+
+None for this issue.
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+modification from before this session; not touched or staged.


### PR DESCRIPTION
Closes #7876

This PR adds the aggregate-tail CLD lattice path that lets a `RecoveredLift` discharge the BHKS fast-disjunct irreducibility endpoint, the sound route around the CLD period trap that blocked #7866/#7867. The executable `bhksLatticeBasis` already carries the diagonal period rows `diag(p^(a−ℓⱼ))`, so the period-adjusted true-factor tail `∑ psiCut(zᵢ) − tⱼ·p^(a−ℓⱼ)` is a genuine lattice vector whose every column is bounded by `factorCount/2` from only the aggregate residue — no per-factor integer divisibility, no basis redesign. `supportShortVectorData_of_recoveredLift` (monic coordinate) packages this as a `SupportShortVectorData`, and `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift` threads it through `cutProjectionHypotheses_of_shortVectors` to the irreducibility endpoint, mirroring the existing `TrueFactorLift` `_of_lift` consumer.

The analytic input is the landed aggregate residue bridge (#7872) and the period-aware carry lemma (#7869); the latter is strengthened in place to its tight `2|d| ≤ T.card` conclusion (its proof already established `< T.card+1`), which fits the exact cut radius `4r+n·r²`. The deliverable-4 constraints are honored: no false binder-preserving theorem, no per-factor integer divisibility for recovered factors, and the bound is on the period-reduced column rather than on `∑ psiCut(zᵢ)`.

🤖 Prepared with Claude Code