### PR TITLE
HexGFqMathlib Phase 5: prove reduced representative equivalence

### DIFF
--- a/HexConway/Basic.lean
+++ b/HexConway/Basic.lean
@@ -3758,6 +3758,41 @@ private theorem ofCoeffs_degree_pos_of_back_ne_zero
           simp at hzero
           exact absurd hzero (zmod64_one_ne_zero_of_one_lt (by decide))))
 
+/-- A polynomial with a nonzero coefficient at `n` and no storage beyond `n`
+has degree exactly `n`. -/
+private theorem degree_eq_of_coeff_ne_zero_of_size_le
+    {p n : Nat} [ZMod64.Bounds p] {f : FpPoly p}
+    (hcoeff : f.coeff n ≠ 0) (hsize : f.size ≤ n + 1) :
+    FpPoly.degree f = n := by
+  have hnlt : n < f.size := by
+    by_cases hlt : n < f.size
+    · exact hlt
+    · exact False.elim
+        (hcoeff (DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hlt)))
+  change f.degree?.getD 0 = n
+  rw [DensePoly.degree?_eq_some_of_pos_size f (by omega)]
+  simp only [Option.getD_some]
+  omega
+
+/-- Every committed Tier 1 Conway entry has the degree requested by its lookup key. -/
+@[simp] theorem luebeckConwayPolynomial?_degree_eq
+    {p n : Nat} [ZMod64.Bounds p] {f : FpPoly p}
+    (h : luebeckConwayPolynomial? p n = some f) :
+    FpPoly.degree f = n := by
+  unfold luebeckConwayPolynomial? at h
+  rw [Option.map_eq_some_iff] at h
+  obtain ⟨coeffs, hcoeffs, hf⟩ := h
+  subst hf
+  unfold luebeckConwayCoeffs? at hcoeffs
+  split at hcoeffs
+  all_goals
+    cases hcoeffs <;>
+      (apply degree_eq_of_coeff_ne_zero_of_size_le
+       · simp [luebeckConwayPolynomialOfCoeffs]
+         exact zmod64_one_ne_zero_of_one_lt (by decide)
+       · unfold luebeckConwayPolynomialOfCoeffs
+         simpa using (DensePoly.size_ofCoeffs_le _))
+
 /-- Supported Conway entries produce nonconstant moduli. -/
 @[simp, grind =>] theorem conwayPoly_nonconstant
     (p n : Nat) [ZMod64.Bounds p] (h : SupportedEntry p n) :

--- a/HexGFqMathlib/Basic.lean
+++ b/HexGFqMathlib/Basic.lean
@@ -256,10 +256,13 @@ def reducedRepEquiv :
   invFun x := Hex.GFqField.ofPoly f hf hp hirr x.1
   left_inv := by
     intro x
-    sorry
+    apply Hex.GFqField.ext
+    apply Hex.GFqRing.ext
+    simp [Hex.GFqField.ofPoly, Hex.GFqField.repr]
   right_inv := by
     intro x
-    sorry
+    apply Subtype.ext
+    exact Hex.GFqRing.reduceMod_eq_self_of_degree_lt f x.1 x.2
 
 /-- Reduced representatives are indexed by `Fin (p ^ degree f)`. The
 positive-degree hypothesis is needed for the decoder's degree bound (see
@@ -296,7 +299,6 @@ noncomputable instance fintype :
     Fintype (Hex.GFqField.FiniteField f hf hp hirr) :=
   Fintype.ofEquiv (Fin (p ^ Hex.FpPoly.degree f)) finEquiv.symm
 
-omit [Hex.ZMod64.PrimeModulus p] in
 /-- The generic executable finite-field wrapper has the expected cardinality. -/
 theorem fintype_card :
     Fintype.card (Hex.GFqField.FiniteField f hf hp hirr) =
@@ -316,7 +318,6 @@ noncomputable instance fintype (h : Hex.Conway.SupportedEntry p n) :
     Fintype (Hex.GFq p n h) :=
   FiniteField.fintype
 
-omit [Hex.ZMod64.PrimeModulus p] in
 /-- Cardinality of the canonical Conway-backed `GFq` in terms of its selected
 modulus degree. -/
 theorem fintype_card (h : Hex.Conway.SupportedEntry p n) :
@@ -329,10 +330,12 @@ theorem fintype_card (h : Hex.Conway.SupportedEntry p n) :
       (hp := Hex.GFq.modulus_prime h)
       (hirr := Hex.GFq.modulus_irreducible h))
 
+omit [Hex.ZMod64.PrimeModulus p] in
 /-- The committed Conway modulus has the requested extension degree. -/
 theorem modulus_degree (h : Hex.Conway.SupportedEntry p n) :
     Hex.FpPoly.degree (Hex.GFq.modulus h) = n := by
-  sorry
+  exact Hex.Conway.luebeckConwayPolynomial?_degree_eq
+    (f := Hex.GFq.modulus h) (Hex.Conway.luebeckConwayPolynomial?_conwayPoly h)
 
 /-- Cardinality of canonical `GFq p n` as `p ^ n`. -/
 theorem fintype_card_eq_pow (h : Hex.Conway.SupportedEntry p n) :

--- a/libraries.yml
+++ b/libraries.yml
@@ -392,7 +392,7 @@ libraries:
   HexGFqMathlib:
     deps: [HexGFq, HexGF2Mathlib]
     mathlib: true
-    done_through: 4
+    done_through: 5
     status: active
   HexBerlekampZassenhausMathlib:
     deps: [HexBerlekampZassenhaus, HexBerlekampMathlib, HexHenselMathlib, HexPolyZMathlib, HexMatrixMathlib, HexLLLMathlib]

--- a/progress/20260618T071518Z_43ef4713.md
+++ b/progress/20260618T071518Z_43ef4713.md
@@ -1,0 +1,30 @@
+# Progress — 2026-06-18 (session 43ef4713, /work → /feature #7886)
+
+## Accomplished
+
+Skipped #7861 as stale: its capstone proof needs the encoder-side packed
+`toNat` helper from #7881/#7885, which is still an open PR and not on `main`.
+
+Completed #7886:
+
+- Proved `FiniteField.reducedRepEquiv.left_inv` and
+  `FiniteField.reducedRepEquiv.right_inv` in `HexGFqMathlib/Basic.lean`.
+- Added `Hex.Conway.luebeckConwayPolynomial?_degree_eq`, plus a small private
+  degree helper, so supported Conway lookup hits expose exact degree.
+- Proved `GFq.modulus_degree` from the supported-entry lookup theorem.
+- Bumped `HexGFqMathlib.done_through` from 4 to 5 in `libraries.yml`.
+
+## Current frontier
+
+`HexGFqMathlib` now reports Phase 6 readiness. Remaining sorries in adjacent
+GF2 Mathlib files are outside this issue.
+
+## Next step
+
+Phase 6 proof-polishing work for `HexGFqMathlib`, as reported by
+`python3 scripts/status.py HexGFqMathlib`.
+
+## Blockers
+
+None for #7886. #7861 remains blocked/stale until #7881/#7885 lands or the
+capstone issue is relinked to that prerequisite.


### PR DESCRIPTION
Closes #7886

Session: `43ef4713-ac8a-4020-89ac-016fef2ca1c6`

f7ecfe89 feat: prove GFq reduced representative equivalence

🤖 Prepared with Claude Code