### PR TITLE
HexGramSchmidt Phase 6: simp/grind + docs for Basic.lean basis/coeffs API

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -187,6 +187,27 @@ or `Monoid`/`CommRing` lemmas — those modules don't import Mathlib.
   For `(xs.push a).getD`, `HexBerlekampZassenhaus/Basic.lean` already has
   `array_getD_push_lt`/`array_getD_push_size`/`array_toList_getD` — reuse them.
 
+### Phase 6 `@[simp]`/`@[grind]` annotation pitfalls
+
+Adding automation annotations to a characterising lemma is not free; two
+traps cost a build cycle each:
+
+- **Bare `@[grind]` on a conditional/equational lemma errors with "Try
+  these".** When grind cannot uniquely pick an E-matching pattern (typical
+  for `dot … = 0` / `entry … = 0` lemmas with `i ≠ j` / `i < j` side
+  conditions) it refuses and prints `[apply] [grind =] for pattern: …`. Use
+  the explicit marker it suggests — `@[grind =]` selects the conclusion
+  pattern and elaborates silently. Plain `@[grind]` is only safe on lemmas
+  with an obvious head.
+- **`@[simp]` on a "push through" transport equality can break a downstream
+  proof in the same file.** A lemma like `basis (rowAdd b …) = basis b`
+  looks like a clean normal form, but as `@[simp]` it fires inside dependent
+  terms (e.g. a `coeffMatrix` proof obligation) and triggers `rewrite …
+  motive is not type correct`. Transport/invariance equalities are exactly
+  the class the Phase 6 issues warn against blanket-annotating — leave them
+  un-annotated unless you confirm the whole library still builds. Stick to
+  genuine value normal forms (`coeffs_diag = 1`, `basis_zero`) for `@[simp]`.
+
 ## Signature gotcha
 
 A hypothesis whose type mentions `toMathlibPolynomial`/`monicModPImage`/`modP`

--- a/HexGramSchmidt/Basic.lean
+++ b/HexGramSchmidt/Basic.lean
@@ -2996,6 +2996,7 @@ noncomputable def coeffs (b : Matrix Rat n m) : Matrix Rat n n :=
 
 /-- Gram-Schmidt leaves the first row untouched: the leading basis row of a
 rational matrix is its leading input row. -/
+@[simp]
 theorem basis_zero (b : Matrix Rat n m) (hn : 0 < n) :
     (basis b).row ⟨0, hn⟩ = b.row ⟨0, hn⟩ := by
   simpa [basis, GramSchmidt.basisMatrix, Matrix.row] using
@@ -3003,6 +3004,7 @@ theorem basis_zero (b : Matrix Rat n m) (hn : 0 < n) :
 
 /-- The defining guarantee of the construction: distinct rational Gram-Schmidt
 basis rows are mutually orthogonal (their dot product is zero). -/
+@[grind =]
 theorem basis_orthogonal (b : Matrix Rat n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i ≠ j) :
     Matrix.dot ((basis b).row ⟨i, hi⟩) ((basis b).row ⟨j, hj⟩) = 0 := by
@@ -3022,12 +3024,14 @@ theorem basis_decomposition (b : Matrix Rat n m) (i : Nat) (hi : i < n) :
 
 /-- The rational coefficient matrix has unit diagonal: each input row enters its
 own decomposition with weight `1`. -/
+@[simp]
 theorem coeffs_diag (b : Matrix Rat n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 1 := by
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn]
 
 /-- The rational coefficient matrix is lower triangular: entries strictly above
 the diagonal vanish, since a row only combines basis rows with smaller index. -/
+@[grind =]
 theorem coeffs_upper (b : Matrix Rat n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hj⟩ = 0 := by
@@ -3983,6 +3987,7 @@ noncomputable def coeffs (b : Matrix Int n m) : Matrix Rat n n :=
 
 /-- Gram-Schmidt leaves the first row untouched: the leading basis row of an
 integer matrix is its leading input row cast into `Rat`. -/
+@[simp]
 theorem basis_zero (b : Matrix Int n m) (hn : 0 < n) :
     (basis b).row ⟨0, hn⟩ =
       Vector.map (fun x : Int => (x : Rat)) (b.row ⟨0, hn⟩) := by
@@ -3991,6 +3996,7 @@ theorem basis_zero (b : Matrix Int n m) (hn : 0 < n) :
 
 /-- Distinct Gram-Schmidt basis rows of an integer matrix (taken in `Rat`) are
 mutually orthogonal. -/
+@[grind =]
 theorem basis_orthogonal (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i ≠ j) :
     Matrix.dot ((basis b).row ⟨i, hi⟩) ((basis b).row ⟨j, hj⟩) = 0 := by
@@ -4010,12 +4016,14 @@ theorem basis_decomposition (b : Matrix Int n m) (i : Nat) (hi : i < n) :
 
 /-- The coefficient matrix of an integer input has unit diagonal: each row
 enters its own decomposition with weight `1`. -/
+@[simp]
 theorem coeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 1 := by
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn]
 
 /-- The coefficient matrix of an integer input is lower triangular: entries
 strictly above the diagonal vanish. -/
+@[grind =]
 theorem coeffs_upper (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
     GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hj⟩ = 0 := by

--- a/progress/20260618T082726Z_2b124b63.md
+++ b/progress/20260618T082726Z_2b124b63.md
@@ -1,0 +1,60 @@
+# Progress — 2026-06-18 (session 2b124b63, /work → /feature #7889)
+
+## Accomplished
+
+Phase 6 simp/grind annotations for the `GramSchmidt.Rat` / `GramSchmidt.Int`
+basis/coefficient API in `HexGramSchmidt/Basic.lean` (#7889). Annotation-and-
+docstring-only, no `def`/statement changes.
+
+- `@[simp]` on `basis_zero` (leading basis row = leading input row) and
+  `coeffs_diag` (unit diagonal `= 1`) in both namespaces — genuine
+  terminating normal forms with strictly simpler RHS.
+- `@[grind =]` on `basis_orthogonal` (off-diagonal basis dot `= 0`) and
+  `coeffs_upper` (above-diagonal coeff entry `= 0`) in both namespaces —
+  conditional zero facts better suited to grind's E-matching than simp
+  rewriting. Used the explicit `=` marker (per grind's own "Try these"
+  suggestion) so the conclusion pattern is selected and no info/warning is
+  emitted.
+
+### Rejected candidates (deliberately un-annotated)
+
+- `basis_rowAdd`: tried `@[simp]`, but it broke an existing in-file proof at
+  `Basic.lean:3540` (dependent-motive rewrite failure when simp collapsed
+  `basis (b.rowAdd …)` inside a `coeffMatrix` proof term). It is a transport
+  lemma, exactly the class the issue warned against; dropped.
+- rowSwap basis/coeff transport lemmas, `coeffs_lower_projection(_comm)`,
+  `basis_decomposition`, `basis_span`: not normal forms (case-split, expand
+  input rows, or are iff-over-all-`v`); left alone.
+
+Deliverable 2 (docstrings): all public decls in both namespaces already carry
+Mathlib-quality characterising docstrings (verified 0 missing). No doc changes
+needed; padding would be noise.
+
+## Verification
+
+- `lake build HexGramSchmidt` → 396 jobs, completed successfully, no
+  error/warning/info.
+- `lake build HexGramSchmidtMathlib HexLLL HexLLLMathlib` → 2682 jobs,
+  completed successfully. Only pre-existing warnings in those files (unused
+  vars, deprecated `push_neg`), none from this change.
+- `python3 scripts/check_dag.py` → exit 0.
+- `grep -cE "@\[simp|@\[grind" HexGramSchmidt/Basic.lean` → 8 (was 0).
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`.
+
+## Current frontier
+
+`Basic.lean` basis/coeffs API now carries normalization + grind annotations.
+Sibling #7890 (`Int.lean` canonical-coeff / lattice-norm API) is the parallel
+Phase 6 task, still open.
+
+## Next step
+
+#7890, or further Phase 6 declarations in `HexGramSchmidt`.
+
+## Blockers
+
+None.
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/
+agent-worker-flow/SKILL.md` modification from before this session; not touched
+or staged.


### PR DESCRIPTION
Closes #7889

Session: `2b124b63-c4cd-4a45-ad75-8b553ed826e2`

b46571e3 doc: note Phase 6 simp/grind annotation pitfalls in boundary skill
987b6e91 feat: add simp/grind annotations to GramSchmidt basis/coeffs API (#7889)

🤖 Prepared with Claude Code