### PR TITLE
HexGramSchmidt Phase 6: simp/grind + docs for Int.lean canonical-coeff & lattice-norm API

### DIFF
--- a/HexGramSchmidt/Int.lean
+++ b/HexGramSchmidt/Int.lean
@@ -3496,8 +3496,10 @@ def bareissGramCanonicalCoeff (b : Matrix Int n m) :
     bareissGramCanonicalCoeff b 0 i =
       Vector.ofFn fun k : Fin n => if i = k then (1 : Int) else 0 := rfl
 
-/-- Recursion equation: regular-branch active-row case. -/
-theorem bareissGramCanonicalCoeff_succ_regular
+/-- Recursion equation: regular-branch active-row case. With the branch
+hypotheses in context, `simp [*]`/`simp_all` rewrites `bareissGramCanonicalCoeff`
+at `fuel + 1` to its explicit Bareiss exact-division update. -/
+@[simp] theorem bareissGramCanonicalCoeff_succ_regular
     (b : Matrix Int n m) (fuel : Nat) (i : Fin n)
     (hnext :
       (Matrix.noPivotLoop fuel
@@ -3524,8 +3526,10 @@ theorem bareissGramCanonicalCoeff_succ_regular
            state.prevPivot) := by
   simp only [bareissGramCanonicalCoeff, dif_pos hnext, if_neg hp, if_pos hi]
 
-/-- Recursion equation: regular-branch processed-row case. -/
-theorem bareissGramCanonicalCoeff_succ_processed
+/-- Recursion equation: regular-branch processed-row case. An already-processed
+row (`i ≤ step`) keeps its previous coefficient vector, so the canonical
+coefficient at `fuel + 1` collapses to the one at `fuel`. -/
+@[simp] theorem bareissGramCanonicalCoeff_succ_processed
     (b : Matrix Int n m) (fuel : Nat) (i : Fin n)
     (hnext :
       (Matrix.noPivotLoop fuel
@@ -3543,8 +3547,10 @@ theorem bareissGramCanonicalCoeff_succ_processed
       bareissGramCanonicalCoeff b fuel i := by
   simp only [bareissGramCanonicalCoeff, dif_pos hnext, if_neg hp, if_neg hi]
 
-/-- Recursion equation: singular branch (zero diagonal). -/
-theorem bareissGramCanonicalCoeff_succ_singular
+/-- Recursion equation: singular branch (zero diagonal). A zero pivot skips the
+update, so the canonical coefficient at `fuel + 1` collapses to the one at
+`fuel`. -/
+@[simp] theorem bareissGramCanonicalCoeff_succ_singular
     (b : Matrix Int n m) (fuel : Nat) (i : Fin n)
     (hnext :
       (Matrix.noPivotLoop fuel
@@ -3560,8 +3566,10 @@ theorem bareissGramCanonicalCoeff_succ_singular
       bareissGramCanonicalCoeff b fuel i := by
   simp only [bareissGramCanonicalCoeff, dif_pos hnext, if_pos hp]
 
-/-- Recursion equation: done branch (no further work possible). -/
-theorem bareissGramCanonicalCoeff_succ_done
+/-- Recursion equation: done branch (no further work possible). Once the loop can
+take no further step (`¬ step + 1 < n`), the canonical coefficient at `fuel + 1`
+collapses to the one at `fuel`. -/
+@[simp] theorem bareissGramCanonicalCoeff_succ_done
     (b : Matrix Int n m) (fuel : Nat) (i : Fin n)
     (hDone : ¬ (Matrix.noPivotLoop fuel
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n) :
@@ -6568,7 +6576,7 @@ private theorem scaledCoeffRows_diag_eq_gramDet_of_nonneg
 /-- The empty leading Gram determinant is `1`: the determinant of the `0 × 0`
 principal Gram minor. This is the base case anchoring the `gramDetVec` diagonal
 recurrence (`gramDetVec_eq_gramDet` at `k = 0`). -/
-theorem gramDet_zero (b : Matrix Int n m) :
+@[simp] theorem gramDet_zero (b : Matrix Int n m) :
     gramDet b 0 (Nat.zero_le n) = 1 := by
   rfl
 
@@ -6585,8 +6593,11 @@ private theorem getArrayEntry_scaledCoeffRows_above
 
 /-- The integral scaled Gram-Schmidt coefficient matrix is lower triangular:
 every strict-upper-triangle entry (`i < j`) is zero. Callers treating
-`scaledCoeffs` as a triangular factor use this to discard above-diagonal terms. -/
-theorem scaledCoeffs_upper (b : Matrix Int n m)
+`scaledCoeffs` as a triangular factor use this to discard above-diagonal terms.
+Tagged `@[grind =]` (keyed on the `entry (scaledCoeffs b) i j` term) so the
+strict-upper hypothesis `i < j` is discharged by `grind`'s arithmetic when the
+vanishing fact is needed. -/
+@[grind =] theorem scaledCoeffs_upper (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i < j) :
     GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨j, hj⟩ = 0 := by
   rw [scaledCoeffs_entry_eq_getArrayEntry]
@@ -6943,8 +6954,9 @@ theorem prefixSpan_basis_and_coeffs_apply_ne_zero_of_rowCombination
   exact_mod_cast hck
 
 /-- The coefficient matrix reconstructs the cast integer input rows from the
-Gram-Schmidt basis rows. -/
-theorem coeffs_mul_basis_eq_castIntMatrix (b : Matrix Int n m) :
+Gram-Schmidt basis rows: `coeffs b * basis b` collapses to the cast input
+`castIntMatrix b`. -/
+@[simp] theorem coeffs_mul_basis_eq_castIntMatrix (b : Matrix Int n m) :
     coeffs b * basis b = castIntMatrix b := by
   apply Vector.ext
   intro i hi
@@ -7151,8 +7163,10 @@ private theorem exists_highest_nonzero_coeff
 
 /-- Casting commutes with the squared norm: the rational squared norm of an
 integer vector mapped into `ℚ` equals its integer squared norm cast to `ℚ`. This
-transfers norm facts proved over `ℤ` into the rational Gram-Schmidt setting. -/
-theorem normSq_map_intCast (v : Vector Int m) :
+transfers norm facts proved over `ℤ` into the rational Gram-Schmidt setting. As
+a `simp` rule it pushes the cast outward, putting the rational squared norm in
+the normal form `((normSq v : Int) : Rat)`. -/
+@[simp] theorem normSq_map_intCast (v : Vector Int m) :
     Vector.normSq (Vector.map (fun x : Int => (x : Rat)) v) =
       ((Vector.normSq v : Int) : Rat) := by
   simpa [Vector.normSq, Hex.Vector.normSq, Matrix.dot, Hex.Vector.dotProduct]

--- a/progress/20260618T085856Z_90637e3e.md
+++ b/progress/20260618T085856Z_90637e3e.md
@@ -1,0 +1,61 @@
+# Progress — 2026-06-18T08:58Z (session 90637e3e, /work → /feature #7890)
+
+## Accomplished
+
+Completed #7890 (HexGramSchmidt Phase 6 simp/grind + docs for the
+`Int.lean` canonical-coefficient and lattice-norm public API). Commit
+`79fc67f0`. Annotation- and docstring-only; no `def` body, executable
+operation, or theorem statement changed.
+
+Annotations added to `HexGramSchmidt/Int.lean`:
+
+- `@[simp]` on the four `bareissGramCanonicalCoeff_succ_*` recursion
+  unfolders. Conditional on the branch hypotheses (`hnext`/`hp`/`hi`),
+  so they fire under `simp [*]`/`simp_all` from context; fuel-decreasing,
+  so no loop. The `_zero` base case was already `@[simp]`.
+- `@[simp]` on `gramDet_zero` (→ constant `1`), `normSq_map_intCast`
+  (cast push-out to `((normSq v : Int) : Rat)`), and
+  `coeffs_mul_basis_eq_castIntMatrix` (`coeffs b * basis b → castIntMatrix b`).
+- `@[grind =]` on `scaledCoeffs_upper`, keyed on the
+  `entry (scaledCoeffs b) i j` term so the `i < j` side condition is
+  discharged by grind. (Plain `@[grind]` emitted a pattern-selection
+  `info`; `@[grind =]` picks the intended rewrite pattern and silences it.)
+
+Left unannotated per the issue's caution against inequality/existence
+rules: `normSq_latticeVec_ge_min_basis_normSq`,
+`exists_top_index_normSq_le_of_memLattice`, `isCanonicalAt_initial`.
+
+Docstrings on the annotated lemmas were tightened to state the rewrite
+contract (the existing docstrings were already strong, so this was a
+light touch).
+
+## Verification
+
+- `lake build HexGramSchmidt` → 396 jobs, success, no error/warning/info/sorry.
+- Dependents `lake build HexGramSchmidtMathlib HexLLL HexLLLMathlib` →
+  2682 jobs, success. Pre-existing warnings (unused vars in
+  `HexGramSchmidtMathlib/{Int,Update}.lean`, `push_neg` deprecation in
+  `HexLLLMathlib/Independent.lean`) are in untouched files, unrelated.
+- `grep -cE "@\[simp|@\[grind" HexGramSchmidt/Int.lean` → 10 (was 1).
+- `grep -c sorry HexGramSchmidt/Int.lean` → 0 (unchanged).
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+  on added lines.
+
+## Current frontier
+
+`HexGramSchmidt/Int.lean` canonical-coeff and lattice-norm API now carries
+automation annotations. The parallel `Basic.lean` Phase 6 work is PR #7896
+(#7889).
+
+## Next step
+
+Other Phase 6 items remain unclaimed: #7895 (HexGFqMathlib finite-cardinality
+bridges), #7897 (HexModArithMathlib docstrings + automation audit).
+
+## Blockers
+
+None for this issue.
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/...SKILL.md`
+modification from before this session; not touched or staged.


### PR DESCRIPTION
Closes #7890

Session: `90637e3e-4a2b-40b3-8bc9-f9194b84cef4`

c5a2605b doc: progress entry for #7890 (session 90637e3e)
79fc67f0 feat: simp/grind + docs for Int.lean canonical-coeff & lattice-norm API (#7890)

🤖 Prepared with Claude Code