### PR TITLE
feat: close GF2Poly ≃+* FpPoly 2 toFpPoly_mul via carryless-convolution coeff lemma

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -32,6 +32,16 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   (`mul_one`, `neg_add_cancel`, `ring`) need Mathlib instances these types lack.
   `grind` uses the `Lean.Grind.CommRing` instance; prime-inverse facts
   (`ZMod64.inv_mul_eq_one_of_prime`, `mul_inv_eq_one_of_prime`) are `@[grind]`.
+  **But `grind` only knows the ring *axioms*, not the *characteristic*:** it
+  proves `x + 0 = x` and `0 * x = 0`, yet **fails** on char-`p` facts like
+  `(1 : ZMod64 2) + 1 = 0`. For those, route through the canonical residue:
+  `(1 : ZMod64 2) = ZMod64.ofNat 2 1` and `(0 : ZMod64 2) = ZMod64.ofNat 2 0`
+  hold by `rfl`, so `apply ZMod64.ext_toNat; simp only [toNat_mul, toNat_add,
+  toNat_ofNat]; decide` discharges any concrete `ZMod64 p` arithmetic
+  (`toNat_mul`/`toNat_add`/`toNat_ofNat` are `@[simp, grind =]`, reducing the
+  goal to a `Nat`-mod identity `decide`/`omega` closes). This is how the
+  GF(2)-indicator facts `if b then 1 else 0` ↦ `*`=AND / `+`=XOR get proved
+  (`HexGF2Mathlib.toFpPoly_mul`).
 - **Transporting `FpPoly` multiplication to `Polynomial (ZMod p)`
   (`map_mul'`-shaped goals): push `toZMod` through the executable List-fold,
   *then* convert to a Finset sum on the `ZMod p` side — you cannot meet in the

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -6650,6 +6650,127 @@ private theorem clmulCoeffAt_diag (c : Nat) (x y : UInt64) (n : Nat) :
       rw [hguard, ← xorBoolList_map_xorBoolList]
       simp [xorBoolList_range_false]
 
+/-- Carryless-convolution coefficient law: bit `n` of a packed `GF(2)` product
+is the XOR-parity of the diagonal `p.coeff i && q.coeff (n - i)` for
+`i ∈ range (n + 1)`. This is the public coefficient-level convolution that the
+`HexGF2Mathlib` bridge uses to relate the carryless `clmul` product to the
+schoolbook `mulCoeffSum` over `ZMod64 2`. -/
+theorem coeff_mul_diagonal (p q : GF2Poly) (n : Nat) :
+    (p * q).coeff n =
+      xorBoolList ((List.range (n + 1)).map (fun s => p.coeff s && q.coeff (n - s))) := by
+  rw [coeff_mul, coeffWords_mulWords_contrib]
+  calc
+    xorBoolList ((List.range p.words.size).flatMap (fun i =>
+        (List.range q.words.size).map (fun j =>
+          clmulCoeffAt (i + j) p.words[i]! q.words[j]! n)))
+      = xorBoolList ((List.range p.words.size).flatMap (fun i =>
+          (List.range q.words.size).flatMap (fun j =>
+            (List.range 64).flatMap (fun a => (List.range 64).map (fun b =>
+              (wordBitAt p.words[i]! a && wordBitAt q.words[j]! b) &&
+                decide (64 * (i + j) + a + b = n)))))) := by
+        apply xorBoolList_flatMap_congr_xor
+        intro i _hi
+        have hmap : (List.range q.words.size).map (fun j =>
+              clmulCoeffAt (i + j) p.words[i]! q.words[j]! n)
+            = (List.range q.words.size).map (fun j =>
+              xorBoolList ((List.range 64).flatMap (fun a => (List.range 64).map (fun b =>
+                (wordBitAt p.words[i]! a && wordBitAt q.words[j]! b) &&
+                  decide (64 * (i + j) + a + b = n))))) := by
+          apply List.map_congr_left
+          intro j _hj
+          exact clmulCoeffAt_diag (i + j) p.words[i]! q.words[j]! n
+        rw [hmap, xorBoolList_map_xorBoolList]
+    _ = xorBoolList ((List.range p.words.size).flatMap (fun i =>
+          (List.range q.words.size).flatMap (fun j =>
+            (List.range 64).flatMap (fun a => (List.range 64).map (fun b =>
+              (p.coeff (64 * i + a) && q.coeff (64 * j + b)) &&
+                decide (64 * i + a + (64 * j + b) = n)))))) := by
+        apply congrArg xorBoolList
+        apply List.flatMap_congr_left; intro i _hi
+        apply List.flatMap_congr_left; intro j _hj
+        apply List.flatMap_congr_left; intro a ha
+        apply List.map_congr_left; intro b hb
+        have ha' : a < 64 := List.mem_range.mp ha
+        have hb' : b < 64 := List.mem_range.mp hb
+        rw [wordBitAt_getElem!_eq_coeff p ha', wordBitAt_getElem!_eq_coeff q hb',
+          show 64 * (i + j) + a + b = 64 * i + a + (64 * j + b) from by omega]
+    _ = xorBoolList ((List.range p.words.size).flatMap (fun i =>
+          (List.range 64).flatMap (fun a => (List.range q.words.size).flatMap (fun j =>
+            (List.range 64).map (fun b =>
+              (p.coeff (64 * i + a) && q.coeff (64 * j + b)) &&
+                decide (64 * i + a + (64 * j + b) = n)))))) := by
+        apply xorBoolList_flatMap_congr_xor
+        intro i _hi
+        exact xorBoolList_flatMap_ranges_swap_list q.words.size 64
+          (fun j a => (List.range 64).map (fun b =>
+            (p.coeff (64 * i + a) && q.coeff (64 * j + b)) &&
+              decide (64 * i + a + (64 * j + b) = n)))
+    _ = xorBoolList ((List.range (64 * p.words.size)).flatMap (fun s =>
+          (List.range q.words.size).flatMap (fun j => (List.range 64).map (fun b =>
+            (p.coeff s && q.coeff (64 * j + b)) && decide (s + (64 * j + b) = n))))) := by
+        apply congrArg xorBoolList
+        exact flatMap_range_flatMap_range 64 p.words.size (fun s =>
+          (List.range q.words.size).flatMap (fun j => (List.range 64).map (fun b =>
+            (p.coeff s && q.coeff (64 * j + b)) && decide (s + (64 * j + b) = n))))
+    _ = xorBoolList ((List.range (64 * p.words.size)).flatMap (fun s =>
+          (List.range (64 * q.words.size)).map (fun t =>
+            (p.coeff s && q.coeff t) && decide (s + t = n)))) := by
+        apply congrArg xorBoolList
+        apply List.flatMap_congr_left
+        intro s _hs
+        exact flatMap_range_map_range 64 q.words.size (fun t =>
+          (p.coeff s && q.coeff t) && decide (s + t = n))
+    _ = xorBoolList ((List.range (64 * p.words.size)).map (fun s =>
+          xorBoolList ((List.range (64 * q.words.size)).map (fun t =>
+            (p.coeff s && q.coeff t) && decide (s + t = n))))) := by
+        rw [← xorBoolList_map_xorBoolList]
+    _ = xorBoolList ((List.range (64 * p.words.size)).map (fun s =>
+          p.coeff s && (if s ≤ n then q.coeff (n - s) else false))) := by
+        apply congrArg xorBoolList
+        apply List.map_congr_left
+        intro s _hs
+        have hbody : (List.range (64 * q.words.size)).map (fun t =>
+              (p.coeff s && q.coeff t) && decide (s + t = n))
+            = (List.range (64 * q.words.size)).map (fun t =>
+              p.coeff s && (q.coeff t && decide (s + t = n))) := by
+          apply List.map_congr_left; intro t _ht; rw [Bool.and_assoc]
+        rw [hbody, xorBoolList_map_and_left' (p.coeff s) (List.range (64 * q.words.size))
+              (fun t => q.coeff t && decide (s + t = n)),
+          xorBoolList_map_decide_add (64 * q.words.size) s n (fun t => q.coeff t)]
+        congr 1
+        by_cases hsn : s ≤ n
+        · rw [if_pos hsn, if_pos hsn]
+          by_cases hlt : n - s < 64 * q.words.size
+          · rw [if_pos hlt]
+          · rw [if_neg hlt]
+            symm
+            apply coeff_eq_false_of_wordCount_le
+            simp only [wordCount]
+            omega
+        · rw [if_neg hsn, if_neg hsn]
+    _ = xorBoolList ((List.range (n + 1)).map (fun s => p.coeff s && q.coeff (n - s))) := by
+        have hzero : ∀ s, min (64 * p.words.size) (n + 1) ≤ s →
+            (p.coeff s && (if s ≤ n then q.coeff (n - s) else false)) = false := by
+          intro s hs
+          have hcase : 64 * p.words.size ≤ s ∨ n + 1 ≤ s := by omega
+          rcases hcase with h | h
+          · have hp : p.coeff s = false := by
+              apply coeff_eq_false_of_wordCount_le
+              simp only [wordCount]
+              omega
+            simp [hp]
+          · have hsn : ¬ (s ≤ n) := by omega
+            simp [hsn]
+        rw [xorBoolList_map_range_eq_of_ge
+              (fun s => p.coeff s && (if s ≤ n then q.coeff (n - s) else false))
+              (64 * p.words.size) (n + 1) (min (64 * p.words.size) (n + 1))
+              hzero (Nat.min_le_left _ _) (Nat.min_le_right _ _)]
+        apply congrArg xorBoolList
+        apply List.map_congr_left
+        intro s hs
+        have hsn : s ≤ n := by have := List.mem_range.mp hs; omega
+        simp [hsn]
+
 /-- The unit polynomial is the degree-zero monomial. -/
 theorem one_eq_monomial_zero : (1 : GF2Poly) = monomial 0 := by
   change one = monomial 0

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -6442,6 +6442,173 @@ example (p q : GF2Poly) (n : Nat) :
     (p * q).coeff n = coeffWords (mulWords p.words q.words) n := by
   simp
 
+/-! ### Public carryless-convolution coefficient lemma
+
+`coeff_mul_diagonal` (below) expresses bit `n` of a packed product as the
+XOR-parity of the diagonal `p.coeff i && q.coeff (n - i)` over `i ∈ range (n+1)`.
+This is the public coefficient-level convolution the Mathlib bridge
+`HexGF2Mathlib` needs to relate the carryless `clmul` product to the schoolbook
+`mulCoeffSum` over `ZMod64 2`. The proof reindexes the `(word, bit)` double
+decomposition `64 * I + A` / `64 * J + B` of the internal source-pair sum into
+the flat coefficient indices `s + t = n`. -/
+
+/-- Split `range (m + k)` into a low block and a shifted high block. -/
+private theorem range_eq_append_map_add (m k : Nat) :
+    List.range (m + k) = List.range m ++ (List.range k).map (· + m) := by
+  induction k with
+  | zero => simp
+  | succ k ih =>
+      rw [Nat.add_succ, List.range_succ, ih, List.range_succ, List.map_append,
+        List.map_cons, List.map_nil, List.append_assoc, Nat.add_comm m k]
+
+/-- Flattening a shifted index map commutes with `flatMap`. -/
+private theorem flatMap_map_add_shift (l : List Nat) (c : Nat) (G : Nat → List Bool) :
+    (l.map (· + c)).flatMap G = l.flatMap (fun a => G (a + c)) := by
+  induction l with
+  | nil => rfl
+  | cons x xs ih => simp [List.flatMap_cons, ih]
+
+/-- Range-product reindexing for `map`: iterating `i < W` then `a < d` over the
+combined index `d * i + a` enumerates `range (d * W)` exactly. -/
+private theorem flatMap_range_map_range (d W : Nat) (g : Nat → Bool) :
+    (List.range W).flatMap (fun i => (List.range d).map (fun a => g (d * i + a))) =
+      (List.range (d * W)).map g := by
+  induction W with
+  | zero => simp
+  | succ W ih =>
+      rw [List.range_succ, List.flatMap_append, List.flatMap_cons, List.flatMap_nil,
+        List.append_nil, ih, Nat.mul_succ, range_eq_append_map_add (d * W) d,
+        List.map_append, List.map_map]
+      congr 1
+      apply List.map_congr_left
+      intro a _ha
+      simp [Function.comp, Nat.add_comm (d * W) a]
+
+/-- Range-product reindexing for `flatMap`: iterating `i < W` then `a < d` over
+the combined index `d * i + a` enumerates `range (d * W)` exactly. -/
+private theorem flatMap_range_flatMap_range (d W : Nat) (G : Nat → List Bool) :
+    (List.range W).flatMap (fun i => (List.range d).flatMap (fun a => G (d * i + a))) =
+      (List.range (d * W)).flatMap G := by
+  induction W with
+  | zero => simp
+  | succ W ih =>
+      rw [List.range_succ, List.flatMap_append, List.flatMap_cons, List.flatMap_nil,
+        List.append_nil, ih, Nat.mul_succ, range_eq_append_map_add (d * W) d,
+        List.flatMap_append, flatMap_map_add_shift]
+      congr 1
+      apply List.flatMap_congr_left
+      intro a _ha
+      rw [Nat.add_comm (d * W) a]
+
+/-- Singleton parity. -/
+private theorem xorBoolList_singleton (x : Bool) : xorBoolList [x] = x := by
+  cases x <;> rfl
+
+/-- Selecting a single index by decidable equality collapses the parity to that
+entry, or `false` when the index is out of range. -/
+private theorem xorBoolList_map_decide_eq (M T : Nat) (g : Nat → Bool) :
+    xorBoolList ((List.range M).map (fun t => g t && decide (t = T))) =
+      if T < M then g T else false := by
+  by_cases hT : T < M
+  · rw [if_pos hT]
+    have hmap : (List.range M).map (fun t => g t && decide (t = T)) =
+        (List.range M).map (fun t => g T && decide (t = T)) := by
+      apply List.map_congr_left
+      intro t _ht
+      by_cases htT : t = T
+      · subst htT; rfl
+      · simp [htT]
+    rw [hmap, xorBoolList_range_single_decide (g T) hT]
+  · rw [if_neg hT]
+    have hmap : (List.range M).map (fun t => g t && decide (t = T)) =
+        (List.range M).map (fun _ => false) := by
+      apply List.map_congr_left
+      intro t ht
+      have htlt : t < M := List.mem_range.mp ht
+      have htne : t ≠ T := by omega
+      simp [htne]
+    rw [hmap, xorBoolList_range_false]
+
+/-- Extending the mapped range past a point where `f` is identically `false`
+does not change the parity. -/
+private theorem xorBoolList_map_range_reduce (f : Nat → Bool) (m : Nat)
+    (hzero : ∀ s, m ≤ s → f s = false) :
+    ∀ d, xorBoolList ((List.range (m + d)).map f) =
+      xorBoolList ((List.range m).map f)
+  | 0 => by simp
+  | d + 1 => by
+      rw [Nat.add_succ, List.range_succ, List.map_append, xorBoolList_append,
+        xorBoolList_map_range_reduce f m hzero d]
+      have hf : f (m + d) = false := hzero (m + d) (by omega)
+      simp only [List.map_cons, List.map_nil, hf, xorBoolList_singleton]
+      cases xorBoolList ((List.range m).map f) <;> rfl
+
+/-- Per-word-pair source decomposition with a unified guard: bit `n` of the
+carryless product of two words at combined slot `c` is the XOR-parity over all
+source bit pairs `(a, b)` whose product `64 * c + a + b` lands at `n`. -/
+private theorem clmulCoeffAt_diag (c : Nat) (x y : UInt64) (n : Nat) :
+    clmulCoeffAt c x y n =
+      xorBoolList ((List.range 64).flatMap (fun a =>
+        (List.range 64).map (fun b =>
+          (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n)))) := by
+  have hswap :
+      xorBoolList ((List.range 64).flatMap (fun a =>
+        (List.range 64).map (fun b =>
+          (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n)))) =
+      xorBoolList ((List.range 64).flatMap (fun b =>
+        (List.range 64).map (fun a =>
+          (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n)))) :=
+    xorBoolList_wordPairs_swap 64 64
+      (fun a b => (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n))
+  rw [hswap, clmulCoeffAt_sourcePairCoeff]
+  by_cases hlow : n / 64 = c
+  · rw [if_pos hlow]
+    unfold clmulSourcePairCoeff
+    apply congrArg xorBoolList
+    apply List.flatMap_congr_left
+    intro b hb
+    apply List.map_congr_left
+    intro a ha
+    have ha' : a < 64 := List.mem_range.mp ha
+    have hb' : b < 64 := List.mem_range.mp hb
+    by_cases h : 64 * c + a + b = n
+    · have h2 : a + b = n % 64 := by omega
+      simp [h, h2]
+    · have h2 : ¬ (a + b = n % 64) := by omega
+      simp [h, h2]
+  · by_cases hhigh : n / 64 = c + 1
+    · rw [if_neg hlow, if_pos hhigh]
+      unfold clmulSourcePairCoeff
+      apply congrArg xorBoolList
+      apply List.flatMap_congr_left
+      intro b hb
+      apply List.map_congr_left
+      intro a ha
+      have ha' : a < 64 := List.mem_range.mp ha
+      have hb' : b < 64 := List.mem_range.mp hb
+      by_cases h : 64 * c + a + b = n
+      · have h2 : a + b = n % 64 + 64 := by omega
+        simp [h, h2]
+      · have h2 : ¬ (a + b = n % 64 + 64) := by omega
+        simp [h, h2]
+    · rw [if_neg hlow, if_neg hhigh]
+      have hguard :
+          (List.range 64).flatMap (fun b =>
+            (List.range 64).map (fun a =>
+              (wordBitAt x a && wordBitAt y b) && decide (64 * c + a + b = n))) =
+          (List.range 64).flatMap (fun b =>
+            (List.range 64).map (fun _ : Nat => (false : Bool))) := by
+        apply List.flatMap_congr_left
+        intro b hb
+        apply List.map_congr_left
+        intro a ha
+        have ha' : a < 64 := List.mem_range.mp ha
+        have hb' : b < 64 := List.mem_range.mp hb
+        have hne : 64 * c + a + b ≠ n := by omega
+        simp [hne]
+      rw [hguard, ← xorBoolList_map_xorBoolList]
+      simp [xorBoolList_range_false]
+
 /-- The unit polynomial is the degree-zero monomial. -/
 theorem one_eq_monomial_zero : (1 : GF2Poly) = monomial 0 := by
   change one = monomial 0

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -6543,6 +6543,47 @@ private theorem xorBoolList_map_range_reduce (f : Nat → Bool) (m : Nat)
       simp only [List.map_cons, List.map_nil, hf, xorBoolList_singleton]
       cases xorBoolList ((List.range m).map f) <;> rfl
 
+/-- Two mapped ranges with the same `false`-from-`m` tail have equal parity. -/
+private theorem xorBoolList_map_range_eq_of_ge (f : Nat → Bool) (A B m : Nat)
+    (hzero : ∀ s, m ≤ s → f s = false) (hA : m ≤ A) (hB : m ≤ B) :
+    xorBoolList ((List.range A).map f) = xorBoolList ((List.range B).map f) := by
+  obtain ⟨a, rfl⟩ : ∃ a, A = m + a := ⟨A - m, by omega⟩
+  obtain ⟨b, rfl⟩ : ∃ b, B = m + b := ⟨B - m, by omega⟩
+  rw [xorBoolList_map_range_reduce f m hzero a, xorBoolList_map_range_reduce f m hzero b]
+
+/-- Factor a constant left `AND` out of a mapped parity. -/
+private theorem xorBoolList_map_and_left' (value : Bool) (l : List Nat) (X : Nat → Bool) :
+    xorBoolList (l.map (fun t => value && X t)) = (value && xorBoolList (l.map X)) := by
+  have h := xorBoolList_map_and_left value (l.map X)
+  rw [List.map_map] at h
+  exact h
+
+/-- Selecting the diagonal index `t = n - s` collapses the parity to that entry,
+or `false` outside the range. -/
+private theorem xorBoolList_map_decide_add (M s n : Nat) (g : Nat → Bool) :
+    xorBoolList ((List.range M).map (fun t => g t && decide (s + t = n))) =
+      if s ≤ n then (if n - s < M then g (n - s) else false) else false := by
+  by_cases hsn : s ≤ n
+  · rw [if_pos hsn]
+    have hmap : (List.range M).map (fun t => g t && decide (s + t = n)) =
+        (List.range M).map (fun t => g t && decide (t = n - s)) := by
+      apply List.map_congr_left
+      intro t _ht
+      by_cases h : t = n - s
+      · subst h
+        simp [show s + (n - s) = n from by omega]
+      · have hne : ¬ (s + t = n) := by omega
+        simp [h, hne]
+    rw [hmap, xorBoolList_map_decide_eq M (n - s) g]
+  · rw [if_neg hsn]
+    have hmap : (List.range M).map (fun t => g t && decide (s + t = n)) =
+        (List.range M).map (fun _ => false) := by
+      apply List.map_congr_left
+      intro t _ht
+      have hne : ¬ (s + t = n) := by omega
+      simp [hne]
+    rw [hmap, xorBoolList_range_false]
+
 /-- Per-word-pair source decomposition with a unified guard: bit `n` of the
 carryless product of two words at combined slot `c` is the XOR-parity over all
 source bit pairs `(a, b)` whose product `64 * c + a + b` lands at `n`. -/

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -189,10 +189,126 @@ theorem toFpPoly_add (p q : Hex.GF2Poly) :
     toFpPoly (p + q) = toFpPoly p + toFpPoly q := by
   sorry
 
+/-- The `ZMod64 2` indicator of a bit, as a canonical residue. -/
+private theorem chi_eq_ofNat (b : Bool) :
+    (if b then (1 : Hex.ZMod64 2) else 0) = Hex.ZMod64.ofNat 2 (if b then 1 else 0) := by
+  cases b <;> rfl
+
+/-- Indicators multiply by the `AND` of the bits (`ZMod64 2` multiplication is
+`AND` on `0/1` residues). -/
+private theorem chi_mul (b c : Bool) :
+    (if b && c then (1 : Hex.ZMod64 2) else 0) =
+      (if b then (1 : Hex.ZMod64 2) else 0) * (if c then 1 else 0) := by
+  rw [chi_eq_ofNat b, chi_eq_ofNat c, chi_eq_ofNat (b && c)]
+  apply Hex.ZMod64.ext_toNat
+  simp only [Hex.ZMod64.toNat_mul, Hex.ZMod64.toNat_ofNat]
+  cases b <;> cases c <;> decide
+
+/-- Indicators add by the `XOR` of the bits (`ZMod64 2` addition is `XOR` on
+`0/1` residues: `1 + 1 = 0`). -/
+private theorem chi_xor (b c : Bool) :
+    (if (b != c) then (1 : Hex.ZMod64 2) else 0) =
+      (if b then (1 : Hex.ZMod64 2) else 0) + (if c then 1 else 0) := by
+  rw [chi_eq_ofNat b, chi_eq_ofNat c, chi_eq_ofNat (b != c)]
+  apply Hex.ZMod64.ext_toNat
+  simp only [Hex.ZMod64.toNat_add, Hex.ZMod64.toNat_ofNat]
+  cases b <;> cases c <;> decide
+
+/-- `ZMod64 2` is an additive monoid with `0` on the right. -/
+private theorem zmod2_add_zero (x : Hex.ZMod64 2) : x + 0 = x := by grind
+
+/-- Left absorption in `ZMod64 2`. -/
+private theorem zmod2_zero_mul (x : Hex.ZMod64 2) : (0 : Hex.ZMod64 2) * x = 0 := by grind
+
+/-- The `ZMod64 2` indicator of an XOR-fold equals the running sum of the
+per-bit indicators: addition realizes the parity fold. -/
+private theorem chi_foldl_aux (l : List Bool) (init : Bool) :
+    (if (l.foldl (fun a b => a != b) init) then (1 : Hex.ZMod64 2) else 0) =
+      l.foldl (fun acc b => acc + (if b then (1 : Hex.ZMod64 2) else 0))
+        (if init then 1 else 0) := by
+  induction l generalizing init with
+  | nil => rfl
+  | cons b bs ih =>
+      show (if (bs.foldl (fun a b => a != b) (init != b)) then (1 : Hex.ZMod64 2) else 0) =
+        bs.foldl (fun acc b => acc + (if b then (1 : Hex.ZMod64 2) else 0))
+          ((if init then (1 : Hex.ZMod64 2) else 0) + (if b then 1 else 0))
+      rw [ih (init != b), chi_xor init b]
+
+private theorem chi_foldl (l : List Bool) :
+    (if (l.foldl (fun a b => a != b) false) then (1 : Hex.ZMod64 2) else 0) =
+      l.foldl (fun acc b => acc + (if b then (1 : Hex.ZMod64 2) else 0)) 0 := by
+  have h := chi_foldl_aux l false
+  simpa using h
+
+/-- Congruence for an additive fold: step functions that agree on the list
+elements produce equal folds. -/
+private theorem foldl_add_congr (l : List Nat) (f g : Nat → Hex.ZMod64 2)
+    (h : ∀ s ∈ l, f s = g s) (init : Hex.ZMod64 2) :
+    l.foldl (fun acc s => acc + f s) init = l.foldl (fun acc s => acc + g s) init := by
+  induction l generalizing init with
+  | nil => rfl
+  | cons s ss ih =>
+      simp only [List.foldl_cons]
+      rw [h s (by simp)]
+      exact ih (fun x hx => h x (by simp [hx])) _
+
+/-- Extending an additive fold past a point where every term vanishes leaves the
+sum unchanged. -/
+private theorem foldl_add_range_reduce (term : Nat → Hex.ZMod64 2) (m : Nat)
+    (hzero : ∀ i, m ≤ i → term i = 0) :
+    ∀ d, (List.range (m + d)).foldl (fun acc i => acc + term i) 0 =
+      (List.range m).foldl (fun acc i => acc + term i) 0
+  | 0 => by simp
+  | d + 1 => by
+      rw [Nat.add_succ, List.range_succ, List.foldl_append]
+      simp only [List.foldl_cons, List.foldl_nil]
+      rw [hzero (m + d) (by omega), zmod2_add_zero,
+        foldl_add_range_reduce term m hzero d]
+
+private theorem foldl_add_range_eq_of_ge (term : Nat → Hex.ZMod64 2) (A B m : Nat)
+    (hzero : ∀ i, m ≤ i → term i = 0) (hA : m ≤ A) (hB : m ≤ B) :
+    (List.range A).foldl (fun acc i => acc + term i) 0 =
+      (List.range B).foldl (fun acc i => acc + term i) 0 := by
+  obtain ⟨a, rfl⟩ : ∃ a, A = m + a := ⟨A - m, by omega⟩
+  obtain ⟨b, rfl⟩ : ∃ b, B = m + b := ⟨B - m, by omega⟩
+  rw [foldl_add_range_reduce term m hzero a, foldl_add_range_reduce term m hzero b]
+
 @[simp]
 theorem toFpPoly_mul (p q : Hex.GF2Poly) :
     toFpPoly (p * q) = toFpPoly p * toFpPoly q := by
-  sorry
+  apply Hex.DensePoly.ext_coeff
+  intro n
+  rw [coeff_toFpPoly, Hex.GF2Poly.coeff_mul_diagonal, Hex.FpPoly.coeff_mul, chi_foldl]
+  simp only [List.foldl_map]
+  have hterm : ∀ s ∈ List.range (n + 1),
+      (if (p.coeff s && q.coeff (n - s)) then (1 : Hex.ZMod64 2) else 0) =
+        Hex.FpPoly.mulCoeffTerm (toFpPoly p) (toFpPoly q) n s := by
+    intro s hs
+    have hsn : s ≤ n := by have := List.mem_range.mp hs; omega
+    rw [chi_mul, ← coeff_toFpPoly, ← coeff_toFpPoly]
+    unfold Hex.FpPoly.mulCoeffTerm
+    rw [if_neg (by omega : ¬ n < s)]
+  rw [foldl_add_congr (List.range (n + 1)) _ _ hterm 0]
+  have hzero : ∀ i, min ((toFpPoly p).size) (n + 1) ≤ i →
+      Hex.FpPoly.mulCoeffTerm (toFpPoly p) (toFpPoly q) n i = 0 := by
+    intro i hi
+    unfold Hex.FpPoly.mulCoeffTerm
+    by_cases hni : n < i
+    · rw [if_pos hni]
+    · rw [if_neg hni]
+      have hcase : (toFpPoly p).size ≤ i ∨ n + 1 ≤ i := by
+        rcases Nat.le_total ((toFpPoly p).size) (n + 1) with hle | hle
+        · left; rw [Nat.min_eq_left hle] at hi; exact hi
+        · right; rw [Nat.min_eq_right hle] at hi; exact hi
+      rcases hcase with h | h
+      · rw [Hex.DensePoly.coeff_eq_zero_of_size_le (toFpPoly p) h]
+        exact zmod2_zero_mul _
+      · exact absurd (by omega : n < i) hni
+  unfold Hex.FpPoly.mulCoeffSum
+  exact foldl_add_range_eq_of_ge
+    (fun i => Hex.FpPoly.mulCoeffTerm (toFpPoly p) (toFpPoly q) n i)
+    (n + 1) ((toFpPoly p).size) (min ((toFpPoly p).size) (n + 1))
+    hzero (Nat.min_le_right _ _) (Nat.min_le_left _ _)
 
 /-- The packed `GF2Poly` representation is ring-equivalent to the generic
 degree-normalized `FpPoly 2` representation. -/

--- a/progress/20260618_008b1156.md
+++ b/progress/20260618_008b1156.md
@@ -1,0 +1,73 @@
+# Progress — 2026-06-18 (session 008b1156, /work → /feature #7901)
+
+## Accomplished
+
+Closed all three deliverables of #7901 (HexGF2Mathlib: close `toFpPoly_mul`
+via a public carryless-convolution coeff bridge).
+
+### Deliverable 1 — public convolution coeff lemma (`HexGF2/Multiply.lean`)
+
+`Hex.GF2Poly.coeff_mul_diagonal (p q : GF2Poly) (n : Nat)`:
+`(p * q).coeff n = ((List.range (n+1)).map (fun s => p.coeff s && q.coeff (n-s)))`
+`.foldl (· != ·) false` — bit `n` of a packed `GF(2)` product is the XOR-parity
+of the diagonal. Stated in the public `List.foldl (· != ·)` form (the internal
+`xorBoolList` is private).
+
+The proof reindexes the internal `(word, bit)` source-pair sum to flat
+coefficient indices `s + t = n`. Key new private helpers:
+- `clmulCoeffAt_diag`: unified per-word-pair source decomposition with a single
+  guard `decide (64*c + a + b = n)` (folds the low/high carry cases of
+  `clmulCoeffAt_sourcePairCoeff` into one).
+- range-product reindexers `flatMap_range_map_range` / `flatMap_range_flatMap_range`
+  (turn `i<W, a<64` double loops over `64*i+a` into a flat `range (64*W)`),
+  `range_eq_append_map_add`, `flatMap_map_add_shift`.
+- parity helpers `xorBoolList_map_decide_eq` / `_decide_add` (diagonal
+  selection), `xorBoolList_map_range_reduce` / `_eq_of_ge` (false-tail
+  trimming), `xorBoolList_map_and_left'`, `xorBoolList_singleton`.
+
+The assembly is a `calc` chain: contrib → per-pair source expansion → wordBit→coeff
+→ swap loops → RP reindex (i,a)→s and (j,b)→t → diagonal selection → false-tail
+range reduction to `range (n+1)`. No `List.Perm` needed; uses the file's existing
+`xorBoolList_*` combinators plus the new ones.
+
+### Deliverables 2 & 3 — `toFpPoly_mul` (`HexGF2Mathlib/Basic.lean`)
+
+`toFpPoly (p * q) = toFpPoly p * toFpPoly q`, closed coefficientwise:
+`coeff_toFpPoly` + `coeff_mul_diagonal` reduce the LHS to the indicator of an
+XOR-parity; `FpPoly.coeff_mul` reduces the RHS to `mulCoeffSum`. The bridge:
+- `chi_mul` / `chi_xor`: the `ZMod64 2` indicator `if b then 1 else 0` turns AND
+  into `*` and XOR into `+` (`1+1=0`), via `eq_ofNat` + `toNat_*`.
+- `chi_foldl`: indicator of the XOR-fold = running `+`-sum of per-bit indicators.
+- `foldl_add_range_eq_of_ge`: trims the `mulCoeffTerm` fold between
+  `range (n+1)` and `range (toFpPoly p).size` (extra terms vanish:
+  `i>n` or `i≥size`).
+
+`def equiv`'s `map_mul'` is now sorry-free.
+
+## Verification
+
+- `lake build HexGF2.Multiply`, `lake build HexGF2 HexGF2Mathlib`,
+  `lake build HexGFqMathlib` → `Build completed successfully`, no `error`.
+- My added lines carry no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`.
+- HexBerlekampZassenhausMathlib (the only CI-gated *Mathlib bridge) imports no
+  HexGF2 code, so it is unaffected.
+
+## Current frontier
+
+`toFpPoly_mul` is the 5th and final ring-equivalence obligation for
+`GF2Poly ≃+* FpPoly 2`. The other four (`toFpPoly_one`, `toFpPoly_add`,
+`ofFpPoly_toFpPoly`, `toFpPoly_ofFpPoly`) are still `sorry` on `main` — they live
+in open PR #7902 (branch `agent/506bf0ec`). `def equiv` becomes fully sorry-free
+once both #7902 and this PR land. The `HexGF2Mathlib/Field.lean` sorry cluster is
+pre-existing and out of scope.
+
+## Next step
+
+Land this PR; then `def equiv` is sorry-free after #7902 merges. A follow-up could
+expose `coeff_mul_diagonal` consumers (e.g. for `GF2q`/`GFq` bridges).
+
+## Blockers
+
+None for this issue. Premise note: #7901's body claimed the other four sorries had
+already "landed in #7900", but on `main` they are still open (in PR #7902);
+`toFpPoly_mul` is independent of them and was closeable on `main` regardless.


### PR DESCRIPTION
Closes #7901

This PR closes `Hex.GF2Poly ≃+* Hex.FpPoly 2`'s remaining multiplication obligation `toFpPoly_mul` by adding a public carryless-convolution coefficient lemma to the `HexGF2` executable layer and using it as the bridge to the schoolbook `FpPoly 2` convolution.

The new `Hex.GF2Poly.coeff_mul_diagonal` (`HexGF2/Multiply.lean`) states that bit `n` of a packed `GF(2)` product is the XOR-parity of the diagonal `p.coeff i && q.coeff (n - i)` over `i ∈ range (n + 1)`. Its proof reindexes the internal `(word, bit)` source-pair sum — previously reachable only through the `private` `clmulCoeffAt`/`clmulSourcePairCoeff` machinery — into the flat coefficient indices `s + t = n`, via a unified per-word-pair source decomposition and range-product reindexers, using the file's existing `xorBoolList` parity combinators.

`toFpPoly_mul` (`HexGF2Mathlib/Basic.lean`) then follows coefficientwise: `coeff_toFpPoly` and `coeff_mul_diagonal` reduce the packed product to the indicator of an XOR-parity, `FpPoly.coeff_mul` reduces the generic product to `mulCoeffSum`, and a small `ZMod64 2` indicator bridge identifies the two (over `ZMod64 2`, `+` is XOR with `1 + 1 = 0` and `*` is AND on `0/1` residues), trimming the `mulCoeffTerm` fold from `range (toFpPoly p).size` to `range (n + 1)`. `def equiv`'s `map_mul'` is now sorry-free.

Note on the issue premise: #7901's body states the other four ring-equivalence sorries (`toFpPoly_one`, `toFpPoly_add`, `ofFpPoly_toFpPoly`, `toFpPoly_ofFpPoly`) had already landed in #7900, but on `main` they are still open in PR https://github.com/kim-em/hex/pull/7902. `toFpPoly_mul` is independent of those four and was closeable on `main` regardless; `def equiv` becomes fully sorry-free once both that PR and this one land. `lake build HexGF2`, `HexGF2Mathlib`, and `HexGFqMathlib` all finish green; `HexBerlekampZassenhausMathlib` (the only CI-gated `*Mathlib` bridge) imports no `HexGF2` code and is unaffected.

🤖 Prepared with Claude Code
