### PR TITLE
feat: monic-lattice RecoveredLift family from fast-core indicator-candidate success

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -909,6 +909,34 @@ SupportShortVectorData L S` errors with "type of theorem `foo` is not a
 proposition". Match the existing producers (`cutProjectionHypotheses_of_shortVectors`
 is a `def`).
 
+Inside such a `def` you **cannot `obtain`/`rcases` an `Exists`** to extract a
+witness — the tactic fails with "recursor `Exists.casesOn` can only eliminate
+into `Prop`" because the goal is data-valued (`Type`). This bites two common
+shapes: the custom `∣` (`a ∣ b := ∃ r, b = a * r`, so `obtain ⟨cof, hcof⟩ :=
+hdvd` fails) and any `…_getD_candidate`-style `∃ quotient, …` success witness.
+Extract with `.choose` / `.choose_spec` instead (e.g. `have hcof :
+M = cl * hdvd.choose := hdvd.choose_spec`; pass `hdvd.choose` as the cofactor
+field). These layers run under `noncomputable section`, so `Classical.choice`
+is free. If you must rewrite the *type* a `.choose` was taken over (e.g.
+`rw [hindicators] at hSpec` where `hSpec := hex.choose_spec`), the motive breaks
+("motive is not type correct"); `rw` the equation into the `Exists` *before*
+taking `.choose_spec`.
+
+Reusing `Recovery.lean` helpers (`liftedFactorSubsetsOfSupports`,
+`selectedFactorArraysOfSupports_polyProduct`,
+`bhksIndicatorSelectedFactors_expectedIndicatorArrayOfSupports`,
+`supportPartitionByMinColumn_class_*`) from another file: they live in
+`BHKS.ForwardRecoveryInputs`, *not* `BHKS` — reference them from inside a
+`namespace ForwardRecoveryInputs` block (else autoImplicit silently turns the
+unresolved name into a `Sort u_1` binder and you get a misleading "Function
+expected"). Several recovery helpers are `private` (`selectedFactorsOfMembers_toList`,
+the Mathlib-`Basic` `polyProduct_monic_of_all_monic`, the executable
+`bhksIndicatorCandidate?_normalizeFactorSign`/`_leadingCoeff_nonneg`): prefer the
+public `liftedFactorProduct_monic` for product monicity, and derive a
+sign-normalization (`normalizeFactorSign c = c`) from positive leading
+coefficient (`leadingCoeff_primitivePart_dilate_pos`) rather than de-privatizing
+the executable layer (which forces a ~15-min `CrossCheck` rebuild).
+
 ### Projection equalities from a `*Lift` package: destructure, don't `rw [D.basis_eq]`
 
 To prove `L.p = D.p` / `L.precision = D.a` for `D : RecoveredLift L S` (or

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -19833,6 +19833,41 @@ theorem centeredLift_dvd_toMonic
       (hrecover.trans hg_recover.symm)
   rw [hcl_eq_g]; exact hg_dvd
 
+/-- For a monic `cl` and positive scalar `c`, the leading-coefficient dilation
+`dilate c cl` has positive leading coefficient `c ^ (cl.size - 1)`, and so does
+its primitive part (the content is positive). -/
+theorem leadingCoeff_primitivePart_dilate_pos {c : Int} (hc : 0 < c)
+    {cl : Hex.ZPoly} (hcl : Hex.DensePoly.Monic cl) :
+    0 < Hex.DensePoly.leadingCoeff
+      (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate c cl)) := by
+  set x := Hex.ZPoly.dilate c cl with hx
+  have hc_ne : c ≠ 0 := ne_of_gt hc
+  have hx_lead_pos : 0 < Hex.DensePoly.leadingCoeff x := by
+    rw [hx, leadingCoeff_dilate_of_monic hc_ne hcl]; exact pow_pos hc _
+  have hx0 : x ≠ 0 := by
+    intro hz
+    rw [hz, Hex.DensePoly.leadingCoeff_zero] at hx_lead_pos
+    exact lt_irrefl 0 hx_lead_pos
+  set K := Hex.ZPoly.content x with hK
+  have hK_ne : K ≠ 0 := HexPolyZMathlib.content_ne_zero _ hx0
+  have hK_nonneg : 0 ≤ K := by
+    rw [hK]; unfold Hex.ZPoly.content Hex.DensePoly.content; exact Int.natCast_nonneg _
+  have hK_pos : 0 < K := lt_of_le_of_ne hK_nonneg (Ne.symm hK_ne)
+  have hcmpp : Hex.DensePoly.scale K (Hex.ZPoly.primitivePart x) = x :=
+    Hex.ZPoly.content_mul_primitivePart x
+  have hlead_eq :
+      Hex.DensePoly.leadingCoeff x =
+        K * Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) := by
+    have := Hex.ZPoly.leadingCoeff_scale_of_nonzero K (Hex.ZPoly.primitivePart x) hK_ne
+    rw [hcmpp] at this; exact this
+  rcases lt_trichotomy (Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x)) 0 with
+    hneg | hzero | hpos
+  · exact absurd hx_lead_pos
+      (by rw [hlead_eq]; have := mul_neg_of_pos_of_neg hK_pos hneg; linarith)
+  · rw [hzero, Int.mul_zero] at hlead_eq
+    rw [hlead_eq] at hx_lead_pos; exact absurd hx_lead_pos (lt_irrefl 0)
+  · exact hpos
+
 /-- The recombination candidate emitted by `bhksIndicatorCandidate?` over a
 positive-leading-coefficient `core` is exactly the primitive part of the
 leading-coefficient dilation of the centred selected product: the
@@ -19852,38 +19887,10 @@ theorem primitivePart_dilate_centeredLift_eq_candidate
         (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core)
           (Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k))) = candidate := by
   set cl := Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k) with hcl
-  set lc := Hex.DensePoly.leadingCoeff core with hlc
-  set x := Hex.ZPoly.dilate lc cl with hx
-  have hlc_ne : lc ≠ 0 := ne_of_gt hcore_lc_pos
-  have hx_lead : Hex.DensePoly.leadingCoeff x = lc ^ (cl.size - 1) :=
-    leadingCoeff_dilate_of_monic hlc_ne hcl_monic
-  have hx_lead_pos : 0 < Hex.DensePoly.leadingCoeff x := by
-    rw [hx_lead]; exact pow_pos hcore_lc_pos _
-  have hx0 : x ≠ 0 := by
-    intro hz
-    rw [hz, Hex.DensePoly.leadingCoeff_zero] at hx_lead_pos
-    exact lt_irrefl 0 hx_lead_pos
-  set K := Hex.ZPoly.content x with hK
-  have hK_ne : K ≠ 0 := HexPolyZMathlib.content_ne_zero _ hx0
-  have hK_nonneg : 0 ≤ K := by
-    rw [hK]; unfold Hex.ZPoly.content Hex.DensePoly.content; exact Int.natCast_nonneg _
-  have hK_pos : 0 < K := lt_of_le_of_ne hK_nonneg (Ne.symm hK_ne)
-  have hcmpp : Hex.DensePoly.scale K (Hex.ZPoly.primitivePart x) = x :=
-    Hex.ZPoly.content_mul_primitivePart x
-  have hlead_eq :
-      Hex.DensePoly.leadingCoeff x =
-        K * Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) := by
-    have := Hex.ZPoly.leadingCoeff_scale_of_nonzero K (Hex.ZPoly.primitivePart x) hK_ne
-    rw [hcmpp] at this; exact this
+  set x := Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) cl with hx
   have hpp_lead_pos :
-      0 < Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) := by
-    rcases lt_trichotomy (Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x)) 0 with
-      hneg | hzero | hpos
-    · exact absurd hx_lead_pos
-        (by rw [hlead_eq]; have := mul_neg_of_pos_of_neg hK_pos hneg; linarith)
-    · rw [hzero, Int.mul_zero] at hlead_eq
-      rw [hlead_eq] at hx_lead_pos; exact absurd hx_lead_pos (lt_irrefl 0)
-    · exact hpos
+      0 < Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) :=
+    leadingCoeff_primitivePart_dilate_pos hcore_lc_pos hcl_monic
   have hchar := Hex.bhksIndicatorCandidate?_eq_normalized_dilatedCenteredLift h hselected
   have hcond : ¬ Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) < 0 :=
     not_lt.mpr (le_of_lt hpp_lead_pos)

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -19736,6 +19736,164 @@ theorem exists_monicCorrespondent_of_dvd
       exact ⟨h, hgh.symm⟩
   exact ⟨g, hg_monic, hdvdg, hprim⟩
 
+/-- **Recovery-map injectivity on monics.** The map `m ↦ primitivePart (dilate c m)`
+is injective on monic polynomials for a nonzero scalar `c`.  This is the
+uniqueness counterpart of `exists_monicCorrespondent_of_dvd`'s existence: it
+pins a centred-lift monic factor against the monic correspondent of a
+recombination candidate, both of which recover the same primitive integer
+factor under `primitivePart ∘ dilate (leadingCoeff core)`. -/
+theorem monic_eq_of_primitivePart_dilate_eq
+    {c : Int} (hc : c ≠ 0) {m₁ m₂ : Hex.ZPoly}
+    (hm₁ : Hex.DensePoly.Monic m₁) (hm₂ : Hex.DensePoly.Monic m₂)
+    (h : Hex.ZPoly.primitivePart (Hex.ZPoly.dilate c m₁) =
+         Hex.ZPoly.primitivePart (Hex.ZPoly.dilate c m₂)) :
+    m₁ = m₂ := by
+  -- The dilations of monic polynomials are nonzero (size preserved).
+  have hdil_ne : ∀ m : Hex.ZPoly, Hex.DensePoly.Monic m →
+      Hex.ZPoly.dilate c m ≠ 0 := by
+    intro m hm hz
+    have hsize : (Hex.ZPoly.dilate c m).size = m.size :=
+      size_dilate_eq_of_monic_of_ne_zero hc hm
+    rw [hz, Hex.DensePoly.size_zero] at hsize
+    have := zpoly_size_pos_of_monic hm
+    omega
+  set pp := Hex.ZPoly.primitivePart (Hex.ZPoly.dilate c m₁) with hpp
+  set K₁ := Hex.ZPoly.content (Hex.ZPoly.dilate c m₁) with hK₁
+  set K₂ := Hex.ZPoly.content (Hex.ZPoly.dilate c m₂) with hK₂
+  have hrec₁ : Hex.DensePoly.scale K₁ pp = Hex.ZPoly.dilate c m₁ :=
+    Hex.ZPoly.content_mul_primitivePart _
+  have hrec₂ : Hex.DensePoly.scale K₂ pp = Hex.ZPoly.dilate c m₂ := by
+    rw [h]; exact Hex.ZPoly.content_mul_primitivePart _
+  have hK₁_ne : K₁ ≠ 0 := HexPolyZMathlib.content_ne_zero _ (hdil_ne m₁ hm₁)
+  have hK₂_ne : K₂ ≠ 0 := HexPolyZMathlib.content_ne_zero _ (hdil_ne m₂ hm₂)
+  -- `pp` is nonzero with positive size, so its leading coefficient is nonzero.
+  have hpp_size : pp.size = m₁.size := by
+    have : (Hex.DensePoly.scale K₁ pp).size = m₁.size := by
+      rw [hrec₁]; exact size_dilate_eq_of_monic_of_ne_zero hc hm₁
+    rwa [Hex.ZPoly.scale_size_of_nonzero K₁ pp hK₁_ne] at this
+  have hpp_lead_ne : Hex.DensePoly.leadingCoeff pp ≠ 0 :=
+    Hex.DensePoly.leadingCoeff_ne_zero_of_pos_size pp
+      (by rw [hpp_size]; exact zpoly_size_pos_of_monic hm₁)
+  -- Sizes of `m₁`, `m₂` both equal `pp.size`, so the `c`-powers match.
+  have hpp_size₂ : pp.size = m₂.size := by
+    have : (Hex.DensePoly.scale K₂ pp).size = m₂.size := by
+      rw [hrec₂]; exact size_dilate_eq_of_monic_of_ne_zero hc hm₂
+    rwa [Hex.ZPoly.scale_size_of_nonzero K₂ pp hK₂_ne] at this
+  have hsize_eq : m₁.size = m₂.size := hpp_size ▸ hpp_size₂
+  -- Match leading coefficients to deduce `K₁ = K₂`.
+  have hlc₁ : c ^ (m₁.size - 1) = K₁ * Hex.DensePoly.leadingCoeff pp := by
+    rw [← leadingCoeff_dilate_of_monic hc hm₁, ← hrec₁,
+      Hex.ZPoly.leadingCoeff_scale_of_nonzero K₁ pp hK₁_ne]
+  have hlc₂ : c ^ (m₂.size - 1) = K₂ * Hex.DensePoly.leadingCoeff pp := by
+    rw [← leadingCoeff_dilate_of_monic hc hm₂, ← hrec₂,
+      Hex.ZPoly.leadingCoeff_scale_of_nonzero K₂ pp hK₂_ne]
+  have hKeq : K₁ = K₂ := by
+    have hpow : c ^ (m₁.size - 1) = c ^ (m₂.size - 1) := by rw [hsize_eq]
+    rw [hlc₁, hlc₂] at hpow
+    exact mul_right_cancel₀ hpp_lead_ne hpow
+  -- Equal contents give equal dilations; injectivity of `dilate c` finishes.
+  have hdil_eq : Hex.ZPoly.dilate c m₁ = Hex.ZPoly.dilate c m₂ := by
+    rw [← hrec₁, ← hrec₂, hKeq]
+  exact dilate_injective hc hdil_eq
+
+/-- **Centred-lift divisibility from a recombination candidate.** If a monic
+`cl` dilates (by `leadingCoeff core`) to a polynomial whose primitive part is a
+primitive, sign-normalized integer factor `candidate` of `core` of positive
+degree, then `cl` divides the monic transform `(toMonic core).monic`.
+
+This is the soundness step behind the monic-lattice `RecoveredLift` family: the
+selected lifted product's centred lift is exactly the monic correspondent of the
+recombination candidate (`monic_eq_of_primitivePart_dilate_eq` pins it against
+`exists_monicCorrespondent_of_dvd`'s witness), so the executable exact-division
+witness `candidate ∣ core` transports to `cl ∣ (toMonic core).monic`. -/
+theorem centeredLift_dvd_toMonic
+    {core cl candidate : Hex.ZPoly}
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcl_monic : Hex.DensePoly.Monic cl)
+    (hcand_deg : 1 ≤ candidate.degree?.getD 0)
+    (hrecover :
+       Hex.ZPoly.primitivePart
+         (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) cl) = candidate)
+    (hcand_dvd : candidate ∣ core)
+    (hcand_prim : Hex.ZPoly.Primitive candidate)
+    (hcand_sign : Hex.normalizeFactorSign candidate = candidate) :
+    cl ∣ (Hex.ZPoly.toMonic core).monic := by
+  have hcore0 : core ≠ 0 := by
+    intro h
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hcore_lc_pos
+    exact lt_irrefl 0 hcore_lc_pos
+  have hdeg : 1 ≤ (Hex.ZPoly.toMonic core).degree := by
+    rw [Hex.ZPoly.toMonic_degree core]; omega
+  obtain ⟨g, hg_monic, hg_dvd, hg_recover⟩ :=
+    exists_monicCorrespondent_of_dvd core candidate hcore0 hcore_lc_pos hdeg
+      hcand_deg hcand_dvd hcand_prim hcand_sign
+  have hcl_eq_g : cl = g :=
+    monic_eq_of_primitivePart_dilate_eq (ne_of_gt hcore_lc_pos) hcl_monic hg_monic
+      (hrecover.trans hg_recover.symm)
+  rw [hcl_eq_g]; exact hg_dvd
+
+/-- The recombination candidate emitted by `bhksIndicatorCandidate?` over a
+positive-leading-coefficient `core` is exactly the primitive part of the
+leading-coefficient dilation of the centred selected product: the
+`normalizeCandidateFactor`/`normalizeFactorSign` wrappers collapse because that
+dilation already has positive leading coefficient. -/
+theorem primitivePart_dilate_centeredLift_eq_candidate
+    {core : Hex.ZPoly} {d : Hex.LiftData} {indicator : Array Int}
+    {candidate quotient : Hex.ZPoly} {selected : Array Hex.ZPoly}
+    (h : Hex.bhksIndicatorCandidate? core d indicator = some (candidate, quotient))
+    (hselected :
+       Hex.bhksIndicatorSelectedFactors d.liftedFactors indicator = some selected)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcl_monic :
+       Hex.DensePoly.Monic
+         (Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k))) :
+    Hex.ZPoly.primitivePart
+        (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core)
+          (Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k))) = candidate := by
+  set cl := Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k) with hcl
+  set lc := Hex.DensePoly.leadingCoeff core with hlc
+  set x := Hex.ZPoly.dilate lc cl with hx
+  have hlc_ne : lc ≠ 0 := ne_of_gt hcore_lc_pos
+  have hx_lead : Hex.DensePoly.leadingCoeff x = lc ^ (cl.size - 1) :=
+    leadingCoeff_dilate_of_monic hlc_ne hcl_monic
+  have hx_lead_pos : 0 < Hex.DensePoly.leadingCoeff x := by
+    rw [hx_lead]; exact pow_pos hcore_lc_pos _
+  have hx0 : x ≠ 0 := by
+    intro hz
+    rw [hz, Hex.DensePoly.leadingCoeff_zero] at hx_lead_pos
+    exact lt_irrefl 0 hx_lead_pos
+  set K := Hex.ZPoly.content x with hK
+  have hK_ne : K ≠ 0 := HexPolyZMathlib.content_ne_zero _ hx0
+  have hK_nonneg : 0 ≤ K := by
+    rw [hK]; unfold Hex.ZPoly.content Hex.DensePoly.content; exact Int.natCast_nonneg _
+  have hK_pos : 0 < K := lt_of_le_of_ne hK_nonneg (Ne.symm hK_ne)
+  have hcmpp : Hex.DensePoly.scale K (Hex.ZPoly.primitivePart x) = x :=
+    Hex.ZPoly.content_mul_primitivePart x
+  have hlead_eq :
+      Hex.DensePoly.leadingCoeff x =
+        K * Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) := by
+    have := Hex.ZPoly.leadingCoeff_scale_of_nonzero K (Hex.ZPoly.primitivePart x) hK_ne
+    rw [hcmpp] at this; exact this
+  have hpp_lead_pos :
+      0 < Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) := by
+    rcases lt_trichotomy (Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x)) 0 with
+      hneg | hzero | hpos
+    · exact absurd hx_lead_pos
+        (by rw [hlead_eq]; have := mul_neg_of_pos_of_neg hK_pos hneg; linarith)
+    · rw [hzero, Int.mul_zero] at hlead_eq
+      rw [hlead_eq] at hx_lead_pos; exact absurd hx_lead_pos (lt_irrefl 0)
+    · exact hpos
+  have hchar := Hex.bhksIndicatorCandidate?_eq_normalized_dilatedCenteredLift h hselected
+  have hcond : ¬ Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart x) < 0 :=
+    not_lt.mpr (le_of_lt hpp_lead_pos)
+  have hnc : Hex.normalizeCandidateFactor x = Hex.ZPoly.primitivePart x := by
+    unfold Hex.normalizeCandidateFactor; simp [hcond]
+  have hns :
+      Hex.normalizeFactorSign (Hex.ZPoly.primitivePart x) = Hex.ZPoly.primitivePart x := by
+    unfold Hex.normalizeFactorSign; simp [hcond]
+  rw [hchar, hnc, hns]
+
 /-- **Mod-`p` representation of the monic correspondent (#7381, prereq of #7364).**
 
 For prime data selected by `toMonicPrimeData? core` — that is, `choosePrimeData?`

--- a/HexBerlekampZassenhausMathlib/LiftBridge.lean
+++ b/HexBerlekampZassenhausMathlib/LiftBridge.lean
@@ -1,5 +1,6 @@
 import HexBerlekampZassenhausMathlib.Basic
 import HexBerlekampZassenhausMathlib.Lattice
+import HexBerlekampZassenhausMathlib.Recovery
 
 /-!
 Bridge from recovery-side lifted-factor subsets to BHKS true-factor packages.
@@ -318,6 +319,117 @@ def trueFactorLiftSemanticsOfToMonicSubset
     rw [Array.getElem?_eq_getElem i.isLt]
     simp [d]
     exact Hex.ZPoly.congr_symm _ _ _ hcongr'
+
+namespace ForwardRecoveryInputs
+
+/--
+**Monic-lattice `RecoveredLift` family from fast-core indicator-candidate
+success** (prerequisite (A) of #7894, capstone #6672).
+
+From a successful indicator-candidate fold over the *non-monic* fast-path core
+(`bhksIndicatorCandidates? core d … = some coreFactors`), build, for every
+emitted support, a `RecoveredLift` over the **monic** lattice
+`bhksLatticeBasis (toMonic core).monic …`.  The recovered factor of each support
+is the centred lift of the selected lifted product, which is exactly the monic
+correspondent of the emitted recombination candidate
+(`centeredLift_dvd_toMonic`): the executable exact-division witness
+`candidate ∣ core` transports to `cl ∣ (toMonic core).monic`, and the
+leading-coefficient dilation in `recovered_eq` collapses because the monic
+transform has leading coefficient `1`.
+
+This is the monic-core regime where `recoveredLiftOfSubset` applies; a
+non-monic-core `RecoveredLift` is provably impossible (its `recovered_eq` would
+need `content (dilate (lc core) monicFactor) = 1`, false for non-unit
+`leadingCoeff core`).  The family feeds the period-adjusted column bound
+`supportShortVectorData_of_recoveredLift` (`CLDColumnBound.lean`).
+
+This is a `def` because `RecoveredLift` is a data-carrying certificate, not a
+`Prop`. -/
+def recoveredLift_family_of_indicatorCandidates
+    {core : Hex.ZPoly} {d : Hex.LiftData} {coreFactors : Array Hex.ZPoly}
+    (rows_pos : HasPositiveDimension core d)
+    (trueSupports :
+       Set (Set (Fin (projectedRowsOfLiftData core d rows_pos).factorCount)))
+    (hindicators :
+       equivalenceClassIndicatorsOfLiftData core d rows_pos =
+         expectedIndicatorArrayOfSupports trueSupports)
+    (hcandidates :
+       Hex.bhksIndicatorCandidates? core d
+           (equivalenceClassIndicatorsOfLiftData core d rows_pos) = some coreFactors)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hliftedFactor_monic : ∀ i : LiftedFactorIndex d, Hex.DensePoly.Monic (liftedFactor d i))
+    (hp_two_le : 2 ≤ d.p ^ d.k) :
+    ∀ i, i < (expectedIndicatorArrayOfSupports trueSupports).size →
+      RecoveredLift
+        (Hex.bhksLatticeBasis (Hex.ZPoly.toMonic core).monic d.p d.k d.liftedFactors)
+        (supportOfSubset (Hex.ZPoly.toMonic core).monic d
+          ((liftedFactorSubsetsOfSupports d trueSupports).getD i ∅)) := by
+  classical
+  intro i hi
+  have hi_expected : i < (equivalenceClassIndicatorsOfLiftData core d rows_pos).size := by
+    rw [hindicators]; exact hi
+  -- the emitted candidate and its selected lifted-factor product (extract the
+  -- quotient witness via `choose`, as the goal is data-valued)
+  have hcand_ex := Hex.bhksIndicatorCandidates?_getD_candidate hcandidates i hi_expected
+  rw [hindicators] at hcand_ex
+  have hcandidate0 := hcand_ex.choose_spec
+  have hselected :=
+    bhksIndicatorSelectedFactors_expectedIndicatorArrayOfSupports d trueSupports
+      (supportPartitionByMinColumn_class_nonempty trueSupports)
+      (supportPartitionByMinColumn_class_lt trueSupports) i hi
+  set selected := (selectedFactorArraysOfSupports d.liftedFactors trueSupports).getD i #[]
+    with hsel_def
+  set candidate := coreFactors.getD i 0 with hcand_def
+  set T := (liftedFactorSubsetsOfSupports d trueSupports).getD i ∅ with hT_def
+  set cl := Hex.centeredLiftPoly (Array.polyProduct selected) (d.p ^ d.k) with hcl_def
+  -- the selected product equals the lifted-factor product over `T`, which is
+  -- monic (product of monic lifted factors), so its centred lift `cl` is monic
+  have hpp_eq : Array.polyProduct selected = liftedFactorProduct d T :=
+    selectedFactorArraysOfSupports_polyProduct d trueSupports i hi
+  have hprod_monic : Hex.DensePoly.Monic (Array.polyProduct selected) := by
+    rw [hpp_eq]; exact liftedFactorProduct_monic d T (fun j _ => hliftedFactor_monic j)
+  have hcl_monic : Hex.DensePoly.Monic cl :=
+    monic_centeredLiftPoly_of_monic hprod_monic hp_two_le
+  -- the candidate is the primitive part of the leading-coefficient dilation of `cl`
+  have hcand_recover :
+      Hex.ZPoly.primitivePart
+          (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) cl) = candidate :=
+    primitivePart_dilate_centeredLift_eq_candidate hcandidate0 hselected hcore_lc_pos hcl_monic
+  have hcand_dvd : candidate ∣ core := Hex.bhksIndicatorCandidate?_dvd hcandidate0
+  have hcand_prim : Hex.ZPoly.Primitive candidate := Hex.bhksIndicatorCandidate?_primitive hcandidate0
+  -- the candidate has positive leading coefficient, so it is sign-normalized
+  have hcand_sign : Hex.normalizeFactorSign candidate = candidate := by
+    have hpos : 0 < Hex.DensePoly.leadingCoeff candidate := by
+      rw [← hcand_recover]; exact leadingCoeff_primitivePart_dilate_pos hcore_lc_pos hcl_monic
+    unfold Hex.normalizeFactorSign
+    rw [if_neg (not_lt.mpr (le_of_lt hpos))]
+  have hcand_deg : 1 ≤ candidate.degree?.getD 0 := by
+    have hsize_eq : coreFactors.size = (equivalenceClassIndicatorsOfLiftData core d rows_pos).size :=
+      Hex.bhksIndicatorCandidates?_size_eq hcandidates
+    have hi_cf : i < coreFactors.size := by rw [hsize_eq]; exact hi_expected
+    have hmem : candidate ∈ coreFactors.toList := by
+      have h1 : coreFactors.getD i 0 = coreFactors[i] := by
+        simp [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hi_cf]
+      rw [hcand_def, h1]
+      exact Array.getElem_mem_toList hi_cf
+    exact Hex.bhksIndicatorCandidates?_positive_degree hcandidates candidate hmem
+  -- the centred lift divides the monic transform
+  have hcl_dvd : cl ∣ (Hex.ZPoly.toMonic core).monic :=
+    centeredLift_dvd_toMonic hcore_lc_pos hcore_pos hcl_monic hcand_deg hcand_recover
+      hcand_dvd hcand_prim hcand_sign
+  have hcof : (Hex.ZPoly.toMonic core).monic = cl * hcl_dvd.choose := hcl_dvd.choose_spec
+  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
+    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos hcore_pos
+  have hrecovered :
+      Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff (Hex.ZPoly.toMonic core).monic)
+          (Hex.centeredLiftPoly (liftedFactorProduct d T) (d.p ^ d.k)) = cl := by
+    rw [← hpp_eq, show Hex.DensePoly.leadingCoeff (Hex.ZPoly.toMonic core).monic = 1 from hM_monic,
+      Hex.ZPoly.dilate_one]
+  exact recoveredLiftOfSubset (Hex.ZPoly.toMonic core).monic d T cl hcl_dvd.choose
+    hcof.symm hrecovered
+
+end ForwardRecoveryInputs
 
 end BHKS
 

--- a/progress/20260618T113612Z_267f0b4e.md
+++ b/progress/20260618T113612Z_267f0b4e.md
@@ -1,0 +1,63 @@
+# Session 267f0b4e — monic-lattice RecoveredLift family (#7909)
+
+## Accomplished
+
+Closed prerequisite (A) of #7894 (capstone #6672): the monic-lattice
+`RecoveredLift` family from fast-core indicator-candidate success.
+
+New declarations (`HexBerlekampZassenhausMathlib/Basic.lean`):
+- `monic_eq_of_primitivePart_dilate_eq` — recovery-map injectivity on monics:
+  two monic polynomials with equal `primitivePart (dilate c ·)` coincide (via
+  content/leading-coeff matching + `dilate_injective`). The uniqueness
+  counterpart to `exists_monicCorrespondent_of_dvd`'s existence.
+- `centeredLift_dvd_toMonic` — a monic `cl` whose `lc·`-dilation has primitive
+  part a sign-normalized integer factor of `core` divides `(toMonic core).monic`
+  (pins `cl` against the monic correspondent of the candidate).
+- `leadingCoeff_primitivePart_dilate_pos` — positivity of the dilated centred
+  lift's primitive-part leading coefficient.
+- `primitivePart_dilate_centeredLift_eq_candidate` — the `bhksIndicatorCandidate?`
+  candidate equals `primitivePart (dilate (lc core) (centeredLift selected))`
+  (the `normalizeFactorSign`/`normalizeCandidateFactor` wrappers collapse).
+
+New declaration (`HexBerlekampZassenhausMathlib/LiftBridge.lean`, +`import Recovery`):
+- `BHKS.ForwardRecoveryInputs.recoveredLift_family_of_indicatorCandidates` — the
+  headline deliverable: `∀` emitted support, `RecoveredLift` over
+  `bhksLatticeBasis (toMonic core).monic …`. The recovered factor is the centred
+  lift of the selected lifted product (= the monic correspondent of the emitted
+  candidate); `recovered_eq` collapses since `leadingCoeff (toMonic core).monic = 1`.
+
+`lake build HexBerlekampZassenhausMathlib` completes (3790 jobs, zero errors).
+No `sorry`/`axiom`/`native_decide` in added lines.
+
+## Key decisions
+
+- The issue's premise that #7852 exposes a *non-monic-core*
+  `RepresentsIntegerFactorAtLift core d candidate S` witness was slightly off:
+  the #7852 producer (`representsIntegerFactorAtLift_of_indicatorCandidates`)
+  requires `Monic core`, which the fast-path core is not. So rather than bridge
+  a (nonexistent) non-monic witness, I produced the monic-lattice family
+  *directly* from `bhksIndicatorCandidate?` success: the candidate's exact
+  divisor `candidate ∣ core` transports to `cl ∣ (toMonic core).monic` through
+  the monic correspondent (`exists_monicCorrespondent_of_dvd`) pinned by the new
+  uniqueness lemma. The deliverable (monic `RecoveredLift` family, factor = monic
+  correspondent) is exactly as specified.
+- Used the more direct `recoveredLiftOfSubset` (factor := centred lift, the `lc=1`
+  dilation collapses `recovered_eq` to `rfl`) instead of routing through
+  `recoveredLiftOfRepresents`/`representsIntegerFactorAtLift_of_monicCorrespondent`.
+  Same deliverable, fewer moving parts; the only nontrivial obligation is `cl ∣ M`.
+- Avoided de-privatizing the executable layer: derived `normalizeFactorSign
+  candidate = candidate` from `leadingCoeff_primitivePart_dilate_pos`, and product
+  monicity from public `liftedFactorProduct_monic` (not the private
+  `selectedFactorsOfMembers_toList`/`polyProduct_monic_of_all_monic`). So only the
+  Mathlib layer changed; no `CrossCheck` rebuild needed.
+
+## Next step
+
+Feeds (B): `supportShortVectorData_of_recoveredLift` (`CLDColumnBound.lean:1849`)
+can now consume the family. The downstream cut-package producer (#7894 (B)/(C))
+remains: `trueSupports`/`CutProjectionHypotheses` short-vector producer and the
+fast-path `hpartition` coverage.
+
+## Blockers
+
+None for this deliverable.


### PR DESCRIPTION
This PR adds the monic-lattice `RecoveredLift` family from fast-core indicator-candidate success, closing prerequisite (A) of #7894 (capstone #6672). From a successful `bhksIndicatorCandidates?` fold over the non-monic fast-path core, `recoveredLift_family_of_indicatorCandidates` produces, for every emitted support, a `RecoveredLift` over the monic lattice `bhksLatticeBasis (toMonic core).monic …`; the recovered factor is the centred lift of the selected lifted product (the monic correspondent of the emitted candidate), and `recovered_eq` collapses because the monic transform has leading coefficient `1`. The soundness obligation `cl ∣ (toMonic core).monic` is discharged by the new `centeredLift_dvd_toMonic`, which pins the centred lift against `exists_monicCorrespondent_of_dvd`'s witness via the recovery-map injectivity lemma `monic_eq_of_primitivePart_dilate_eq`. Supporting helpers `leadingCoeff_primitivePart_dilate_pos` and `primitivePart_dilate_centeredLift_eq_candidate` are added, and `LiftBridge` now imports `Recovery`.

Produced directly from the executable candidate success rather than bridging a non-monic `RepresentsIntegerFactorAtLift` witness (which cannot exist: that producer requires `Monic core`). The family feeds (B) `supportShortVectorData_of_recoveredLift`.

Closes #7909

🤖 Prepared with Claude Code