### PR TITLE
feat: produce fast lifted-support partition count from core facts

### DIFF
--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -237,6 +237,64 @@ theorem supportPartitionByMinColumn_length_eq_normalizedFactors_card
       hpartition hcore_ne hcore_primitive hcore_lc_pos hprecision,
     liftedTrueSupports.ncard_eq_normalizedFactors_card hpartition hcore_ne]
 
+/--
+Fast-path B8 partition-refinement count from core facts alone.
+
+Composes the carrier-free `toMonicPrimeData?` partition producer
+`liftedFactorSubsetPartition_of_toMonicPrimeData_complete` -- which derives the
+full `LiftedFactorSubsetPartition core (toMonicLiftData core B primeData)
+Finset.univ core` from the executable selection witness and the standard core
+side conditions, without routing through slow exhaustive enumeration -- with the
+generic count theorem
+`supportPartitionByMinColumn_length_eq_normalizedFactors_card`.
+
+The result discharges the exact `hpartition` length-equality shape threaded
+through the fast-BHKS irreducibility wrappers, for the lifted true-support family
+`liftedTrueSupports core (toMonicLiftData core B primeData)`, with no free
+partition hypothesis.  `hbound` is the monic-coordinate Mignotte precision the
+producer consumes; `hcore_bound` is the corresponding core-coordinate precision
+that the count theorem needs (the two refer to distinct default coefficient
+bounds, so both are supplied by the caller).
+-/
+theorem supportPartitionByMinColumn_length_eq_normalizedFactors_card_of_toMonicPrimeData
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (hcore_bound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound core <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p) :
+    (supportPartitionByMinColumn
+        (liftedTrueSupports core
+          (Hex.ZPoly.toMonicLiftData core B primeData))).length =
+      (UniqueFactorizationMonoid.normalizedFactors
+        (HexPolyZMathlib.toPolynomial core)).card := by
+  have hcore_ne : core ≠ 0 := by
+    intro h
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hcore_lc_pos
+    exact lt_irrefl 0 hcore_lc_pos
+  have hp_eq : (Hex.ZPoly.toMonicLiftData core B primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hk_eq : (Hex.ZPoly.toMonicLiftData core B primeData).k =
+      Hex.precisionForCoeffBound B primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  have hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound core <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hcore_bound
+  exact supportPartitionByMinColumn_length_eq_normalizedFactors_card
+    (liftedFactorSubsetPartition_of_toMonicPrimeData_complete
+      core B primeData hselected hcore_lc_pos hcore_pos hcore_prim hcore_sqfree
+      hB_ne_zero hbound)
+    hcore_ne hcore_prim hcore_lc_pos hprecision
+
 namespace ForwardRecoveryInputs
 
 /-- Under an `ExpectedTrueFactors` package whose indicators are the

--- a/progress/20260618_113940_06046464.md
+++ b/progress/20260618_113940_06046464.md
@@ -1,0 +1,80 @@
+# Progress — 2026-06-18 (session 06046464, /work → /feature #7910)
+
+## Accomplished
+
+Landed the fast lifted-support partition *count* producer (#7910 deliverable 2)
+and verified deliverable 1 was already satisfied by prior work.
+
+### Deliverable 2 (the genuine gap)
+
+`HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+`supportPartitionByMinColumn_length_eq_normalizedFactors_card_of_toMonicPrimeData`
+— a thin core-facts wrapper concluding the `hpartition` length-equality shape
+
+```
+(supportPartitionByMinColumn (liftedTrueSupports core
+    (Hex.ZPoly.toMonicLiftData core B primeData))).length
+  = (normalizedFactors (toPolynomial core)).card
+```
+
+with **no free partition hypothesis**. It composes the existing core-facts
+partition producer `liftedFactorSubsetPartition_of_toMonicPrimeData_complete`
+with the existing count theorem
+`supportPartitionByMinColumn_length_eq_normalizedFactors_card`. Takes the
+`toMonicPrimeData?` selection witness + standard core side conditions
+(lc>0, deg>0, primitive, squarefree, B≠0) + the monic-coordinate Mignotte
+precision (`hbound`) and the core-coordinate precision (`hcore_bound`); the two
+refer to distinct default coefficient bounds so both are caller-supplied. The
+`.p`/`.k` projection equalities of `toMonicLiftData` are discharged by `unfold`
++ `henselLiftData_p`/`_k` (per the boundary-skill recipe, not `rfl`/`simp`).
+
+### Deliverable 1 — already satisfied (premise overtaken)
+
+The directive asked for a fast-path `LiftedFactorSubsetPartition core d
+Finset.univ core` producer in `Basic.lean`. That producer already exists as
+`liftedFactorSubsetPartition_of_toMonicPrimeData_complete`
+(`IntReductionMod.lean`, landed #7589). It is **path-independent**: derived from
+the `toMonicPrimeData?` selection witness + core facts via the carrier-free
+`henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` and
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`, with no
+slow exhaustive enumeration. So the issue's premise ("available producers are
+keyed to the slow exhaustive path") was already false. The requested `Basic.lean`
+placement is also infeasible: the producer must call the initial-evidence
+constructor that lives downstream in `IntReductionMod.lean` (it needs the mod-`p`
+squarefreeness datum below `Basic.lean`). No duplicate was added.
+
+### Deliverable 3 (scope) — respected
+
+No `CutProjectionHypotheses`, no `SupportShortVectorData`, no #7894 cut package.
+The `liftedTrueSupports core d` ↔ fast-path `hinputs.trueSupports` identity (the
+remaining wiring into the fast-BHKS irreducibility lemmas) is the separate
+downstream concern the issue scopes out.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib.Basic` → completed, 0 errors.
+- `lake build HexBerlekampZassenhausMathlib.PartitionRefinement` → 0 errors.
+- `lake build HexBerlekampZassenhausMathlib` → 3790 jobs, completed, 0 errors
+  (CI-gated layer green).
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+  in added lines.
+- Skipped `lake build HexBerlekampZassenhaus` full target (pulls the ~11min
+  CrossCheck oracle); the change is a theorem-only Mathlib-layer addition that
+  cannot affect the executable library, which built green as a dependency.
+
+## Current frontier
+
+The count producer is available; wiring it into the fast irreducibility lemmas
+needs the `liftedTrueSupports core d = hinputs.trueSupports` identification.
+
+## Next step
+
+A `trueSupports`-identity bridge connecting `liftedTrueSupports core
+(toMonicLiftData …)` to the BHKS lattice `hinputs.trueSupports`, then the fast
+endpoint lemmas can drop their free `hpartition`.
+
+## Blockers
+
+None for this issue. The pre-existing worktree `.claude/*` modification was left
+untouched.


### PR DESCRIPTION
This PR adds `supportPartitionByMinColumn_length_eq_normalizedFactors_card_of_toMonicPrimeData`, a thin core-facts wrapper in `HexBerlekampZassenhausMathlib/PartitionRefinement.lean` that concludes the `hpartition` length-equality shape `(supportPartitionByMinColumn (liftedTrueSupports core (toMonicLiftData core B primeData))).length = (normalizedFactors (toPolynomial core)).card` with no free partition hypothesis, for the fast indicator-candidate path. It composes the existing path-independent partition producer `liftedFactorSubsetPartition_of_toMonicPrimeData_complete` with the existing count theorem `supportPartitionByMinColumn_length_eq_normalizedFactors_card`, deriving the partition entirely from the executable `toMonicPrimeData?` selection witness and the standard core side conditions without routing through slow exhaustive enumeration.

This is deliverable 2 of the issue. Deliverable 1 (the `LiftedFactorSubsetPartition core d Finset.univ core` producer) already exists as `liftedFactorSubsetPartition_of_toMonicPrimeData_complete` (`IntReductionMod.lean`, landed in https://github.com/kim-em/hex/pull/7589 — "feat: produce toMonicPrimeData Hensel substrate from core facts"), which is path-independent: it derives the full partition from the carrier-free `henselSubsetCorrespondenceHypotheses_of_toMonicPrimeData` and `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`. The issue's premise that "the available producers are currently keyed to the slow exhaustive Hensel-subset correspondence path" was already overtaken by that work. The requested `Basic.lean` placement for deliverable 1 is also infeasible: the producer must call the initial-evidence constructor, which lives downstream in `IntReductionMod.lean` because it needs the mod-`p` squarefreeness datum below `Basic.lean`. No duplicate producer was added.

Deliverable 3 scope is respected: no `CutProjectionHypotheses`, no `SupportShortVectorData`, no #7894 cut package. The `liftedTrueSupports core d` ↔ fast-path `hinputs.trueSupports` identification (the remaining wiring into the fast-BHKS irreducibility endpoint lemmas) is the separate downstream concern the issue scopes out.

Closes #7910.

🤖 Prepared with Claude Code
