### PR TITLE
doc: record fast-path liftData.k double-log collapse in boundary skill

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -289,6 +289,36 @@ Consequences for any fast-BHKS irreducibility / `h_raw` work:
   "expose the loop array" / unconditional `h_raw` issue, confirm a determinism
   producer exists, else land the decoupled bridges + diagnose (#7664).
 
+### The fast-path lift exponent `liftData.k` is double-log small — hsep/hthr are *false*, not just underivable (#7928)
+
+`precisionForCoeffBound` is applied **twice** on the public fast path, so the
+CLD lattice runs at a precision far below the BHKS column-adequacy threshold.
+The public caller computes `a := precisionForCoeffBound B primeData.p`
+(`Basic.lean:7699/7714`, `B = factorFastPrecisionCap core`) and passes `a` as
+`factorFastCoreWithBound`'s coefficient-bound parameter; the loop then feeds the
+schedule variable `k` into `toMonicLiftData core k primeData`, which applies
+`precisionForCoeffBound` **again** (`:7001`, `(henselLiftData _ B _).k = B`).
+Net: the lattice's actual exponent is
+`liftData.k = precisionForCoeffBound k p = ceilLogP p (2k+1)`, collapsing
+double-logarithmically. Concretely for `cldGuardF = x²−5x+6`, `p=5`: every
+scheduled `k ∈ [4,8,12]` (cap included) gives `liftData.k = 2` (modulus 25), but
+the CLD floor `precisionForCoeffBound (bhksCoeffBound (toMonic core).monic 0 =
+16) 5 = 3` is not met. So **hsep** (`2·bhksCoeffBound (lift S).f j <
+(lift S).p ^ (lift S).a`, with `(lift S).a = d.k = liftData.k = 2`) is literally
+`32 < 25` — **false**, not merely "not derivable from success." The final
+product check (`Array.polyProduct candidates == f`) rescues *correctness*
+empirically (true factor coefficients are tiny) but certifies nothing about
+column-adequacy. **Consequence:** no acceptance gate against the current
+`liftData.k` (the #7928 plan) can supply hsep/hthr — it would only flip fixtures
+`some → none`. Verify with a pure-integer `#eval` scratch (`bhksCoeffBound`,
+`precisionForCoeffBound`, `henselPrecisionSchedule`, `factorFastPrecisionCap` all
+run under `lake env lean`, no extern). The real fix is a precision-*schedule*
+correction (drop the double `precisionForCoeffBound`), which is soundness-
+sensitive and touches the CI-gated determinism cluster — not a cheap gate.
+Before claiming any "discharge hsep/hthr" / "CLD precision floor" fast-path
+issue, `#eval` `liftData.k` at the scheduled precisions and confirm it actually
+clears the CLD floor; as of #7928 it does not.
+
 ## `Matrix` / `Vector` resolve to Mathlib's inside the Mathlib layer
 
 The mirror of the shadow above. In a Mathlib-layer file (namespace

--- a/progress/20260618T134500Z_5bb71a62.md
+++ b/progress/20260618T134500Z_5bb71a62.md
@@ -1,0 +1,68 @@
+# Progress — 2026-06-18 (session 5bb71a62, /once #7928)
+
+## Accomplished
+
+Diagnosed #7928 (CLD-adequacy precision floor for fast-core acceptance) as
+premise-unsound and skipped it for replan with concrete evidence. No Lean
+source changed.
+
+The proposed acceptance gate — accept `bhksRecoverClassified core liftData =
+.success factors` only when `∀ j, 2·bhksCoeffBound (toMonic core).monic j <
+primeData.p ^ liftData.k` — is **unsatisfiable on the public fast path**, so
+it trips this issue's own "if any fixture's output changes, STOP and report"
+clause.
+
+### Root cause: `precisionForCoeffBound` applied twice
+
+- Public caller computes `a := precisionForCoeffBound B primeData.p`
+  (`Basic.lean:7699/7714`, `B = factorFastPrecisionCap core`, `:7994`) and
+  passes `a` as the loop's coefficient-bound parameter.
+- The loop then feeds the schedule variable `k` into
+  `toMonicLiftData core k primeData`, which applies `precisionForCoeffBound`
+  **again** (`:7001`); `(henselLiftData f B d).k = B` (`:2751`).
+- Net: the actual CLD/Hensel lift exponent is
+  `liftData.k = precisionForCoeffBound k p = ceilLogP p (2k+1)`, collapsing
+  double-logarithmically. For `cldGuardF = x²−5x+6`, `p=5`, every scheduled
+  precision (`k ∈ [4,8,12]`, cap included) yields `liftData.k = 2`
+  (modulus 25), but the CLD floor needs exponent `3`
+  (`bhksCoeffBound (toMonic cldGuardF).monic 0 = 16`, `5²=25 < 33 ≤ 125`).
+- Verified by pure-integer `#eval` (no extern); Codex independently
+  reproduced the same wiring and arithmetic.
+
+### Why this also dooms #7917/#7925's hsep/hthr as stated
+
+`hsep : 2·bhksCoeffBound (lift S).f j < (lift S).p ^ (lift S).a` has
+`(lift S).a = d.k = liftData.k = 2`. For `cldGuardF` that is `32 < 25` —
+**false**, not merely underivable. The executable runs the CLD lattice at a
+precision below the BHKS column-adequacy threshold; the final product check
+(`Array.polyProduct candidates == f`) rescues correctness empirically but
+certifies only "multiplies to `f`", never irreducibility/column-adequacy.
+
+### Recommended re-scope
+
+Not a cheap acceptance gate but a **precision-schedule correction**: drop the
+double `precisionForCoeffBound` (pass the coefficient cap `B` /
+`factorFastPrecisionCap` into the loop and let `toMonicLiftData` do the single
+conversion, or walk coefficient-magnitude bounds up to the true cap). Then the
+terminal precision (or a gate) legitimately supplies hsep/hthr. This is
+soundness-sensitive and touches the CI-gated determinism cluster
+(`factorFastCoreWithBound_isSome_of_recovery_on_schedule`,
+`bhksRecover_eq_some_of_forwardInputs` in `Recovery.lean`, the
+`…_of_forwardInputs_on_schedule` wrappers in `PartitionRefinement.lean`).
+
+## Current frontier
+
+#7928 skipped (replan). #7923/#7924 (RecoveredLift indexing + Hensel
+semantics) remain open; #7925 (assembly) blocked on them and on hsep/hthr,
+which this diagnosis shows are false at the current executable precision.
+
+## Next step
+
+A planner re-authors #7928 as a fast-path precision-schedule fix (remove the
+double `precisionForCoeffBound`), after which hsep/hthr become provable and
+the #7925 assembly can consume them.
+
+## Blockers
+
+The whole #7894/#6672 fast-disjunct irreducibility chain is blocked on the
+executable lifting at CLD-adequate precision, which it currently does not.


### PR DESCRIPTION
This PR records in the `hex-lean-mathlib-boundary` skill that the fast-path CLD lattice exponent `liftData.k` collapses double-logarithmically, so the BHKS `hsep`/`hthr` column-adequacy conditions are *false* (not merely underivable) at the executable's actual lift precision.

`precisionForCoeffBound` is applied twice on the public fast path: the caller computes `a := precisionForCoeffBound B primeData.p` and passes `a` to `factorFastCoreWithBound`, whose `toMonicLiftData core k primeData` applies `precisionForCoeffBound` again, leaving `liftData.k = ceilLogP p (2k+1)` ≈ 2 (modulus 25) — below the CLD floor (3 for `cldGuardF = x²−5x+6`). This is the premise-unsoundness that closed issue https://github.com/kim-em/hex/issues/7928 ("feat: CLD-adequacy precision floor for fast-core acceptance") as replan: no acceptance gate against the current `liftData.k` can supply `hsep`/`hthr`; the real fix is a precision-schedule correction. The note tells the next agent to `#eval` `liftData.k` against the CLD floor before claiming such an issue.

Docs-only (skill file); no Lean source changes.

🤖 Prepared with Claude Code
