### PR TITLE
fix: correct fast-core precision schedule

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7696,12 +7696,11 @@ def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPoly) :=
       match choosePrimeData? normalized.squareFreeCore with
       | none => none
       | some primeData =>
-          let a := precisionForCoeffBound B primeData.p
           if primeData.factorsModP.size ≤ 1 then
             some (reassemblePolynomialFactors normalized #[normalized.squareFreeCore])
           else
-            match factorFastCoreWithBound normalized.squareFreeCore a primeData
-                (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) with
+            match factorFastCoreWithBound normalized.squareFreeCore B primeData
+                (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
             | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
             | none => none
     else
@@ -7711,12 +7710,11 @@ def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPoly) :=
         match choosePrimeData? normalized.squareFreeCore with
         | none => none
         | some primeData =>
-            let a := precisionForCoeffBound B primeData.p
             if primeData.factorsModP.size ≤ 1 then
               some (reassemblePolynomialFactors normalized #[normalized.squareFreeCore])
             else
-              match factorFastCoreWithBound normalized.squareFreeCore a primeData
-                  (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) with
+              match factorFastCoreWithBound normalized.squareFreeCore B primeData
+                  (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
               | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
               | none => none
 
@@ -7760,10 +7758,9 @@ theorem factorFastFactorsWithBound_eq_some_of_core_success
     (hquadratic : B = 1 ∨
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
     (hcore :
-      let a := precisionForCoeffBound B primeData.p
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-        primeData (initialHenselPrecision a)
-        (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors) :
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+        primeData (initialHenselPrecision B)
+        (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors) :
     factorFastFactorsWithBound f B =
       some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) := by
   unfold factorFastFactorsWithBound
@@ -7857,19 +7854,17 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
       (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧
       B = 1 ∧
       ¬ primeData.factorsModP.size ≤ 1 ∧
-      (let a := precisionForCoeffBound B primeData.p
-       factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-         primeData (initialHenselPrecision a)
-         (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors)) ∨
+      (factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+         primeData (initialHenselPrecision B)
+         (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors)) ∨
     -- (e) B = 1, fast-core none
     (factorFastFactorsWithBound f B = none ∧
       (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧
       B = 1 ∧
       ¬ primeData.factorsModP.size ≤ 1 ∧
-      (let a := precisionForCoeffBound B primeData.p
-       factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-         primeData (initialHenselPrecision a)
-         (ZPoly.quadraticDoublingSteps a + 2) = none)) ∨
+      (factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+         primeData (initialHenselPrecision B)
+         (ZPoly.quadraticDoublingSteps B + 2) = none)) ∨
     -- (f) B > 1, quadratic
     (∃ coreFactors, factorFastFactorsWithBound f B =
         some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) ∧
@@ -7892,20 +7887,18 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
       1 < B ∧
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none ∧
       ¬ primeData.factorsModP.size ≤ 1 ∧
-      (let a := precisionForCoeffBound B primeData.p
-       factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-         primeData (initialHenselPrecision a)
-         (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors)) ∨
+      (factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+         primeData (initialHenselPrecision B)
+         (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors)) ∨
     -- (i) B > 1, fast-core none
     (factorFastFactorsWithBound f B = none ∧
       (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧
       1 < B ∧
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none ∧
       ¬ primeData.factorsModP.size ≤ 1 ∧
-      (let a := precisionForCoeffBound B primeData.p
-       factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-         primeData (initialHenselPrecision a)
-         (ZPoly.quadraticDoublingSteps a + 2) = none)) := by
+      (factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+         primeData (initialHenselPrecision B)
+         (ZPoly.quadraticDoublingSteps B + 2) = none)) := by
   unfold factorFastFactorsWithBound
   by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
   · left
@@ -7923,16 +7916,16 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
           simp [hchoose, hsmall]
         · cases hcore :
             factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-              (precisionForCoeffBound B primeData.p) primeData
-              (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-              (ZPoly.quadraticDoublingSteps (precisionForCoeffBound B primeData.p) + 2) with
+              B primeData
+              (initialHenselPrecision B)
+              (ZPoly.quadraticDoublingSteps B + 2) with
           | some coreFactors =>
               right; right; right; left
-              refine ⟨coreFactors, ?_, hdeg, hB1, hsmall, hcore⟩
+              refine ⟨coreFactors, ?_, hdeg, hB1, hsmall, rfl⟩
               simp [hchoose, hsmall, hcore]
           | none =>
               right; right; right; right; left
-              refine ⟨?_, hdeg, hB1, hsmall, hcore⟩
+              refine ⟨?_, hdeg, hB1, hsmall, rfl⟩
               simp [hchoose, hsmall, hcore]
       · rw [if_neg hB1]
         have hBgt : 1 < B := by omega
@@ -7948,17 +7941,16 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
               simp [hchoose, hsmall]
             · cases hcore :
                 factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                  (precisionForCoeffBound B primeData.p) primeData
-                  (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-                  (ZPoly.quadraticDoublingSteps
-                    (precisionForCoeffBound B primeData.p) + 2) with
+                        B primeData
+                        (initialHenselPrecision B)
+                        (ZPoly.quadraticDoublingSteps B + 2) with
               | some coreFactors =>
                   right; right; right; right; right; right; right; left
-                  refine ⟨coreFactors, ?_, hdeg, hBgt, rfl, hsmall, hcore⟩
+                  refine ⟨coreFactors, ?_, hdeg, hBgt, rfl, hsmall, rfl⟩
                   simp [hchoose, hsmall, hcore]
               | none =>
                   right; right; right; right; right; right; right; right
-                  refine ⟨?_, hdeg, hBgt, rfl, hsmall, hcore⟩
+                  refine ⟨?_, hdeg, hBgt, rfl, hsmall, rfl⟩
                   simp [hchoose, hsmall, hcore]
 
 /--
@@ -8076,27 +8068,25 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
     (hchoose :
       choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hmem :
-      let a := precisionForCoeffBound (factorFastPrecisionCap f) primeData.p
       target ∈
-        henselPrecisionSchedule a
-          (initialHenselPrecision a)
-          (ZPoly.quadraticDoublingSteps a + 2))
+        henselPrecisionSchedule (factorFastPrecisionCap f)
+          (initialHenselPrecision (factorFastPrecisionCap f))
+          (ZPoly.quadraticDoublingSteps (factorFastPrecisionCap f) + 2))
     (hrecover :
       bhksRecover? (normalizeForFactor f).squareFreeCore
         (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore target primeData) =
           some coreFactors) :
     factorFast f ≠ none := by
   let B := factorFastPrecisionCap f
-  let a := precisionForCoeffBound B primeData.p
   have hB_pos' : 1 ≤ B := by
     simpa [B] using hB_pos
   have hcore_ne :
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a primeData
-          (initialHenselPrecision a) (ZPoly.quadraticDoublingSteps a + 2) ≠ none := by
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B primeData
+          (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) ≠ none := by
     exact
       factorFastCoreWithBound_ne_none_of_recovery_on_schedule
-        (normalizeForFactor f).squareFreeCore a primeData
-        (by simpa [a, B] using hmem) hrecover
+        (normalizeForFactor f).squareFreeCore B primeData
+        (by simpa [B] using hmem) hrecover
   have hfactors_ne :
       factorFastFactorsWithBound f B ≠ none := by
     unfold factorFastFactorsWithBound
@@ -8113,9 +8103,9 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
         · simp [hpred]
           cases hcore :
               factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                (precisionForCoeffBound B primeData.p) primeData
-                (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-                (ZPoly.quadraticDoublingSteps (precisionForCoeffBound B primeData.p) + 2) with
+                B primeData
+                (initialHenselPrecision B)
+                (ZPoly.quadraticDoublingSteps B + 2) with
           | none => exact absurd hcore hcore_ne
           | some factors =>
               simp
@@ -8131,10 +8121,9 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
             · simp [hpred]
               cases hcore :
                   factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                    (precisionForCoeffBound B primeData.p) primeData
-                    (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-                    (ZPoly.quadraticDoublingSteps
-                      (precisionForCoeffBound B primeData.p) + 2) with
+                    B primeData
+                    (initialHenselPrecision B)
+                    (ZPoly.quadraticDoublingSteps B + 2) with
               | none => exact absurd hcore hcore_ne
               | some factors =>
                   simp
@@ -8946,10 +8935,9 @@ theorem factorWithBound_entry_mem_fast_core_success_raw
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
     {coreFactors : Array ZPoly}
     (hcore :
-      let a := precisionForCoeffBound B primeData.p
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-        primeData (initialHenselPrecision a)
-        (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors)
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+        primeData (initialHenselPrecision B)
+        (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors)
     (hmem : entry ∈ (factorWithBound f B).factors.toList) :
     ∃ raw ∈ (reassemblePolynomialFactors (normalizeForFactor f) coreFactors).toList,
       entry.1 = normalizeFactorSign raw := by
@@ -15802,10 +15790,9 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
             · simp [hchoose, hsmall] at hfast
               cases hcore :
                   factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                    (precisionForCoeffBound 1 primeData.p) primeData
-                    (initialHenselPrecision (precisionForCoeffBound 1 primeData.p))
-                    (ZPoly.quadraticDoublingSteps
-                      (precisionForCoeffBound 1 primeData.p) + 2) with
+                    1 primeData
+                    (initialHenselPrecision 1)
+                    2 with
               | none =>
                   rw [hcore] at hfast
                   contradiction
@@ -15816,10 +15803,9 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
                   exact reassemblePolynomialFactors_product_eq_input f coreFactors
                     (factorFastCoreWithBound_product
                       (normalizeForFactor f).squareFreeCore
-                      (precisionForCoeffBound 1 primeData.p) primeData
-                      (initialHenselPrecision (precisionForCoeffBound 1 primeData.p))
-                      (ZPoly.quadraticDoublingSteps
-                        (precisionForCoeffBound 1 primeData.p) + 2)
+                      1 primeData
+                      (initialHenselPrecision 1)
+                      2
                       coreFactors hcore)
       · simp only [hB1, if_false] at hfast
         cases hquad : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
@@ -15844,10 +15830,9 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
                 · simp [hchoose, hsmall] at hfast
                   cases hcore :
                       factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                        (precisionForCoeffBound B primeData.p) primeData
-                        (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-                        (ZPoly.quadraticDoublingSteps
-                          (precisionForCoeffBound B primeData.p) + 2) with
+                        B primeData
+                        (initialHenselPrecision B)
+                        (ZPoly.quadraticDoublingSteps B + 2) with
                   | none =>
                       rw [hcore] at hfast
                       contradiction
@@ -15858,10 +15843,9 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
                       exact reassemblePolynomialFactors_product_eq_input f coreFactors
                         (factorFastCoreWithBound_product
                           (normalizeForFactor f).squareFreeCore
-                          (precisionForCoeffBound B primeData.p) primeData
-                          (initialHenselPrecision (precisionForCoeffBound B primeData.p))
-                          (ZPoly.quadraticDoublingSteps
-                            (precisionForCoeffBound B primeData.p) + 2)
+                          B primeData
+                          (initialHenselPrecision B)
+                          (ZPoly.quadraticDoublingSteps B + 2)
                           coreFactors hcore)
 
 private theorem factorSlowModular_product_of_all_recorded_normalized
@@ -17347,10 +17331,9 @@ private theorem factorFastWithBound_product_of_factorFastFactorsWithBound_some_c
       factorFastFactorsWithBound f B =
         some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors))
     (hcore :
-      let a := precisionForCoeffBound B primeData.p
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-        primeData (initialHenselPrecision a)
-        (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors)
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+        primeData (initialHenselPrecision B)
+        (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors)
     (h : factorFastWithBound f B = some φ) :
     Factorization.product φ = f := by
   have hphi :
@@ -17367,11 +17350,10 @@ private theorem factorFastWithBound_product_of_factorFastFactorsWithBound_some_c
     exact
       factorFastCoreWithBound_some_normalizeFactorSign
         (core := (normalizeForFactor f).squareFreeCore)
-        (B := precisionForCoeffBound B primeData.p)
+        (B := B)
         (primeData := primeData)
-        (k := initialHenselPrecision (precisionForCoeffBound B primeData.p))
-        (fuel := ZPoly.quadraticDoublingSteps
-          (precisionForCoeffBound B primeData.p) + 2)
+        (k := initialHenselPrecision B)
+        (fuel := ZPoly.quadraticDoublingSteps B + 2)
         (coreFactors := coreFactors)
         hcore c hc
   · intro factor hmem
@@ -17381,11 +17363,10 @@ private theorem factorFastWithBound_product_of_factorFastFactorsWithBound_some_c
     exact
       factorFastCoreWithBound_some_shouldRecord
         (core := (normalizeForFactor f).squareFreeCore)
-        (B := precisionForCoeffBound B primeData.p)
+        (B := B)
         (primeData := primeData)
-        (k := initialHenselPrecision (precisionForCoeffBound B primeData.p))
-        (fuel := ZPoly.quadraticDoublingSteps
-          (precisionForCoeffBound B primeData.p) + 2)
+        (k := initialHenselPrecision B)
+        (fuel := ZPoly.quadraticDoublingSteps B + 2)
         (coreFactors := coreFactors)
         hcore c hc
 
@@ -17403,10 +17384,9 @@ private theorem factorFastWithBound_product_of_core_success_branch
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
     (coreFactors : Array ZPoly)
     (hcore :
-      let a := precisionForCoeffBound B primeData.p
-      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore a
-        primeData (initialHenselPrecision a)
-        (ZPoly.quadraticDoublingSteps a + 2) = some coreFactors)
+      factorFastCoreWithBound (normalizeForFactor f).squareFreeCore B
+        primeData (initialHenselPrecision B)
+        (ZPoly.quadraticDoublingSteps B + 2) = some coreFactors)
     (h : factorFastWithBound f B = some φ) :
     Factorization.product φ = f := by
   have hfast :
@@ -17451,12 +17431,10 @@ private theorem factorFastWithBound_product_of_some
                   f 1 primeData hf hdeg hB_pos hc hsmall (Or.inl rfl) h
               · cases hcore :
                     factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                      (precisionForCoeffBound 1 primeData.p)
+                      1
                       primeData
-                      (initialHenselPrecision
-                        (precisionForCoeffBound 1 primeData.p))
-                      (ZPoly.quadraticDoublingSteps
-                        (precisionForCoeffBound 1 primeData.p) + 2) with
+                      (initialHenselPrecision 1)
+                      2 with
                 | none =>
                     exfalso
                     have hfast_none : factorFastFactorsWithBound f 1 = none := by
@@ -17498,12 +17476,10 @@ private theorem factorFastWithBound_product_of_some
                   f B primeData hf hdeg hB_pos hc hsmall (Or.inr hquadNone) h
               · cases hcore :
                     factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
-                      (precisionForCoeffBound B primeData.p)
+                      B
                       primeData
-                      (initialHenselPrecision
-                        (precisionForCoeffBound B primeData.p))
-                      (ZPoly.quadraticDoublingSteps
-                        (precisionForCoeffBound B primeData.p) + 2) with
+                      (initialHenselPrecision B)
+                      (ZPoly.quadraticDoublingSteps B + 2) with
                 | none =>
                     exfalso
                     have hfast_none : factorFastFactorsWithBound f B = none := by

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -1047,12 +1047,11 @@ theorem factorWithBound_fastCore_entry_irreducible_of_forwardInputs
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some hinputs.expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1060,7 +1059,7 @@ theorem factorWithBound_fastCore_entry_irreducible_of_forwardInputs
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           hinputs.rows_pos)
         hinputs.trueSupports)
     (hpartition :
@@ -1170,12 +1169,11 @@ theorem fastCoreComplete_of_forwardInputs
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some hinputs.expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1183,7 +1181,7 @@ theorem fastCoreComplete_of_forwardInputs
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           hinputs.rows_pos)
         hinputs.trueSupports)
     (hpartition :
@@ -1193,7 +1191,6 @@ theorem fastCoreComplete_of_forwardInputs
             (Hex.normalizeForFactor f).squareFreeCore)).card) :
     Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
       hinputs.expectedFactors := by
-  let a := Hex.precisionForCoeffBound B primeData.p
   have hcore_lc_pos :
       0 < Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore :=
@@ -1206,10 +1203,10 @@ theorem fastCoreComplete_of_forwardInputs
   have hprod :
       Array.polyProduct hinputs.expectedFactors =
         (Hex.normalizeForFactor f).squareFreeCore := by
-    simpa [a] using
+    simpa using
       Hex.factorFastCoreWithBound_product
-        (Hex.normalizeForFactor f).squareFreeCore a primeData
-        (Hex.initialHenselPrecision a) (Hex.ZPoly.quadraticDoublingSteps a + 2)
+        (Hex.normalizeForFactor f).squareFreeCore B primeData
+        (Hex.initialHenselPrecision B) (Hex.ZPoly.quadraticDoublingSteps B + 2)
         hinputs.expectedFactors hcore
   have hnorm :
       ∀ q ∈ hinputs.expectedFactors.toList, Hex.normalizeFactorSign q = q := by
@@ -1325,12 +1322,11 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some hinputs.expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1338,7 +1334,7 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_forwardInputs
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           hinputs.rows_pos)
         hinputs.trueSupports)
     (hpartition :
@@ -1404,12 +1400,11 @@ theorem rawIrreducible_of_forwardInputs
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some hinputs.expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1417,7 +1412,7 @@ theorem rawIrreducible_of_forwardInputs
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           hinputs.rows_pos)
         hinputs.trueSupports)
     (hpartition :
@@ -1448,21 +1443,20 @@ theorem fastCoreComplete_of_cut
       BHKS.HasPositiveDimension (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (trueSupports :
       Set (Set (Fin
         (BHKS.projectedRowsOfLiftData
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos).factorCount)))
     {expectedFactors : Array Hex.ZPoly}
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1470,7 +1464,7 @@ theorem fastCoreComplete_of_cut
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos)
         trueSupports)
     (hsize :
@@ -1480,7 +1474,7 @@ theorem fastCoreComplete_of_cut
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.toMonicLiftData
               (Hex.normalizeForFactor f).squareFreeCore
-              (Hex.precisionForCoeffBound B primeData.p) primeData)
+              B primeData)
             rows_pos)).size)
     (hpartition :
       (BHKS.supportPartitionByMinColumn trueSupports).length =
@@ -1489,7 +1483,6 @@ theorem fastCoreComplete_of_cut
             (Hex.normalizeForFactor f).squareFreeCore)).card) :
     Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
       expectedFactors := by
-  let a := Hex.precisionForCoeffBound B primeData.p
   have hcore_lc_pos :
       0 < Hex.DensePoly.leadingCoeff
         (Hex.normalizeForFactor f).squareFreeCore :=
@@ -1502,10 +1495,10 @@ theorem fastCoreComplete_of_cut
   have hprod :
       Array.polyProduct expectedFactors =
         (Hex.normalizeForFactor f).squareFreeCore := by
-    simpa [a] using
+    simpa using
       Hex.factorFastCoreWithBound_product
-        (Hex.normalizeForFactor f).squareFreeCore a primeData
-        (Hex.initialHenselPrecision a) (Hex.ZPoly.quadraticDoublingSteps a + 2)
+        (Hex.normalizeForFactor f).squareFreeCore B primeData
+        (Hex.initialHenselPrecision B) (Hex.ZPoly.quadraticDoublingSteps B + 2)
         expectedFactors hcore
   have hnorm :
       ∀ q ∈ expectedFactors.toList, Hex.normalizeFactorSign q = q := by
@@ -1615,21 +1608,20 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut
       BHKS.HasPositiveDimension (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (trueSupports :
       Set (Set (Fin
         (BHKS.projectedRowsOfLiftData
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos).factorCount)))
     {expectedFactors : Array Hex.ZPoly}
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1637,7 +1629,7 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos)
         trueSupports)
     (hsize :
@@ -1647,7 +1639,7 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_cut
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.toMonicLiftData
               (Hex.normalizeForFactor f).squareFreeCore
-              (Hex.precisionForCoeffBound B primeData.p) primeData)
+              B primeData)
             rows_pos)).size)
     (hpartition :
       (BHKS.supportPartitionByMinColumn trueSupports).length =
@@ -1706,21 +1698,20 @@ theorem rawIrreducible_of_cut
       BHKS.HasPositiveDimension (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound B primeData.p) primeData))
+          B primeData))
     (trueSupports :
       Set (Set (Fin
         (BHKS.projectedRowsOfLiftData
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos).factorCount)))
     {expectedFactors : Array Hex.ZPoly}
     (hcore :
-      let a := Hex.precisionForCoeffBound B primeData.p
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore a
-        primeData (Hex.initialHenselPrecision a)
-        (Hex.ZPoly.quadraticDoublingSteps a + 2) =
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some expectedFactors)
     (hcut :
       BHKS.CutProjectionHypotheses
@@ -1728,7 +1719,7 @@ theorem rawIrreducible_of_cut
           (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData
             (Hex.normalizeForFactor f).squareFreeCore
-            (Hex.precisionForCoeffBound B primeData.p) primeData)
+            B primeData)
           rows_pos)
         trueSupports)
     (hsize :
@@ -1738,7 +1729,7 @@ theorem rawIrreducible_of_cut
             (Hex.normalizeForFactor f).squareFreeCore
             (Hex.ZPoly.toMonicLiftData
               (Hex.normalizeForFactor f).squareFreeCore
-              (Hex.precisionForCoeffBound B primeData.p) primeData)
+              B primeData)
             rows_pos)).size)
     (hpartition :
       (BHKS.supportPartitionByMinColumn trueSupports).length =

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2440,11 +2440,10 @@ theorem factorFast_ne_none_of_forwardInputs_on_schedule
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore target primeData))
     (hmem :
-      let a := Hex.precisionForCoeffBound (Hex.factorFastPrecisionCap f) primeData.p
       target ∈
-        Hex.henselPrecisionSchedule a
-          (Hex.initialHenselPrecision a)
-          (Hex.ZPoly.quadraticDoublingSteps a + 2)) :
+        Hex.henselPrecisionSchedule (Hex.factorFastPrecisionCap f)
+          (Hex.initialHenselPrecision (Hex.factorFastPrecisionCap f))
+          (Hex.ZPoly.quadraticDoublingSteps (Hex.factorFastPrecisionCap f) + 2)) :
     Hex.factorFast f ≠ none := by
   have hrecover :
       Hex.bhksRecover? (Hex.normalizeForFactor f).squareFreeCore
@@ -2463,8 +2462,8 @@ theorem factorFast_ne_none_of_forwardInputs_on_schedule
 /--
 Canonical scheduled-precision specialisation of
 `factorFast_ne_none_of_forwardInputs_on_schedule`: if the SPEC Group D
-forward-recovery inputs hold at the executable terminal precision
-`a = precisionForCoeffBound (factorFastPrecisionCap f) primeData.p`, the
+forward-recovery inputs hold at the executable terminal coefficient bound
+`factorFastPrecisionCap f`, the
 public `Hex.factorFast` entry point succeeds.  The doubling-schedule
 membership obligation is discharged here using
 `Hex.cap_mem_henselPrecisionSchedule`, so later HO-4 work only needs to
@@ -2481,9 +2480,7 @@ theorem factorFast_ne_none_of_forwardInputs_at_cap
         (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData
           (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.precisionForCoeffBound
-            (Hex.factorFastPrecisionCap f) primeData.p)
-          primeData)) :
+          (Hex.factorFastPrecisionCap f) primeData)) :
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_forwardInputs_on_schedule
     f primeData hB_pos hchoose hinputs
@@ -2500,13 +2497,12 @@ private abbrev factorFastCapLiftData
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData) : Hex.LiftData :=
   Hex.ZPoly.toMonicLiftData
     (Hex.normalizeForFactor f).squareFreeCore
-    (Hex.precisionForCoeffBound (Hex.factorFastPrecisionCap f) primeData.p)
-    primeData
+    (Hex.factorFastPrecisionCap f) primeData
 
 /--
 The bad-vector witness attached to the actual Hensel lift used by
-`Hex.factorFast`: the normalized square-free core lifted to
-`precisionForCoeffBound (factorFastPrecisionCap f) primeData.p`.
+`Hex.factorFast`: the normalized square-free core lifted from coefficient bound
+`factorFastPrecisionCap f`.
 
 This is a named cap-lift specialization of `badVectorWitnessOfLiftData`, so
 callers no longer have to rebuild the nested executable lift expression before

--- a/progress/20260618T141447Z_afc3ec33.md
+++ b/progress/20260618T141447Z_afc3ec33.md
@@ -1,0 +1,43 @@
+# Progress — 2026-06-18 (session afc3ec33, /work → /feature #7933)
+
+## Accomplished
+
+Fixed the public BHKS fast-core schedule so `factorFastFactorsWithBound` passes
+the coefficient-bound cap `B` into `factorFastCoreWithBound`, starts at
+`initialHenselPrecision B`, and uses `quadraticDoublingSteps B + 2`. The single
+conversion to the actual Hensel exponent remains inside
+`ZPoly.toMonicLiftData`.
+
+Updated executable branch-shape/product lemmas in
+`HexBerlekampZassenhaus/Basic.lean` to match the corrected schedule. Updated the
+Mathlib-facing schedule/cap-lift surface in `Recovery.lean` and
+`PartitionRefinement.lean` so cap-level forward-recovery and cut/refinement
+theorems target `toMonicLiftData ... B`, whose stored exponent is still
+`precisionForCoeffBound B p`.
+
+## Current frontier
+
+The CLD precision obligations now line up with the actual lift used by the fast
+core: callers at `factorFastPrecisionCap` get the cap lift rather than a
+double-converted weaker lift. The remaining partition/cut package work is still
+the existing semantic BHKS producer gap, not a schedule mismatch.
+
+## Next step
+
+Continue the #6672/#7894 chain by producing the missing BHKS true-support/cut
+package for successful indicator candidates once its prerequisite producers are
+available.
+
+## Blockers
+
+None for #7933.
+
+Verification:
+- `lake build HexBerlekampZassenhaus`
+- `lake build HexBerlekampZassenhausMathlib`
+- `python3 scripts/check_dag.py`
+- `git diff --check`
+- added-line scan for `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+
+Note: pre-existing unrelated `.claude/CLAUDE.md` worktree modification remains
+untouched and unstaged.


### PR DESCRIPTION
Closes #7933

Session: `afc3ec33-4381-4d50-8679-0d45707dee15`

afbda042 fix fast-core precision schedule

🤖 Prepared with Claude Code