### PR TITLE
feat: close GF2n.toGeneric RingEquiv obligations in HexGF2Mathlib/Field.lean

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -384,6 +384,59 @@ bridge *are* in-file (coeff-level: `coeff_toFpPoly` + `coeff_ofFpPoly` via the
 `packWord` bit-extraction helpers); only `mul` carries this gap. (#7900 landed
 4/5; the `mul` bridge is #7901.)
 
+### Bridging `GF2n`/`GF2nPoly` `≃+*` obligations to the `GFqField` quotient
+
+The four `≃+*` obligations for `GF2n.equiv` / `GF2nPoly.equiv` in
+`HexGF2Mathlib/Field.lean` (`ofGeneric_toGeneric`, `toGeneric_ofGeneric`,
+`toGeneric_add`, `toGeneric_mul`) compose the `GF2Poly ≃+* FpPoly 2` bridge with
+the `GFqField` quotient layer. The whole proof factors through **one** crux
+helper plus mechanical glue (#7936 landed the `GF2n` single-word side; `GF2nPoly`
+is #7937):
+
+- **The crux is `toFpPoly (p % q) = GFqRing.reduceMod (toFpPoly q) (toFpPoly p)`**
+  — `toFpPoly` commutes with the polynomial remainder. Prove it from
+  `Hex.GF2Poly.div_mul_add_mod p q` (`(p/q)*q + p%q = p`), push `toFpPoly`
+  through (`toFpPoly_add`/`toFpPoly_mul`), then `GFqRing.reduceMod_add_mul_self_right`
+  (kills the `(p/q)*q` term) and `GFqRing.reduceMod_eq_self_of_degree_lt` (the
+  remainder is already reduced). Degree transports via a one-liner
+  `FpPoly.degree (toFpPoly p) = p.degree` from `degree?_toFpPoly` (both `degree`s
+  are `degree?.getD 0`).
+- **`Hex.GFqRing.reduceMod` and its algebraic lemmas need a
+  `ZMod64.PrimeModulus 2` instance** (the FpPoly division law). Add
+  `instance : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two`
+  in the namespace once; without it you get a bare "failed to synthesize
+  `ZMod64.PrimeModulus 2`" deep inside a `reduceMod`-lemma application.
+- **Reach the executable `reduce`/`reduceWide` value without naming private
+  defs.** `(Hex.GF2n.reduce w).val` is **defeq** to the fully-public term
+  `Hex.GF2Poly.canonicalWordLT n hn64 (Hex.GF2Poly.packedReduceWord n irr
+  (Hex.GF2Poly.ofUInt64 w))` (it unfolds through the `private` `canonicalWord`,
+  `reducePoly`, `toPolyWord`), so a helper stated over that public term applies
+  by `exact`/defeq — no need to de-privatize `HexGF2/Field.lean` or
+  `HexGF2/Euclid.lean`. The masking is idempotent: `canonicalWordLT n hn64 v = v`
+  for `v.toNat < 2^n` (re-prove the private `canonicalWordLT_eq_self_of_lt`
+  inline via `UInt64.toNat_inj` + `Nat.mod_eq_of_lt`, fed
+  `packedReduceWord_toNat_lt`), then `ofUInt64_packedReduceWord_eq_of_degree_lt`
+  (public) + `mod_degree_lt` close it. The low-word round-trip
+  `ofUInt64 (p.toWords.getD 0 0) = p` for reduced `p` (#7936 replicated the
+  private `ofUInt64_lowWord_eq_of_degree_lt_64`; its proof uses only public
+  `coeff_ofWords`/`ext_coeff`/`coeff_eq_false_of_degree?_lt`). All of this lives
+  in the Mathlib layer — **no executable-layer edits**, matching the issue's
+  "add helpers privately / to Basic.lean" guidance.
+- **`rw [helper]` leaves trivial side goals (`0 < n`, `n < 64`) when the helper
+  carries `include`d section hypotheses not fixed by the rewrite pattern** (e.g.
+  a helper whose statement mentions `n`/`irr` but uses `hn`/`hn64` only in its
+  proof). The fix is named args in the `rw`: `rw [helper (hn := hn) (hn64 :=
+  hn64)]`. Also note `rw`'s closing `rfl` runs at *reducible* transparency, so a
+  residual goal that is true only by unfolding a plain `def` (e.g.
+  `modulusFpPoly = toFpPoly (ofUInt64Monic irr n)`) is **not** auto-closed —
+  append an explicit `rfl` (default transparency) or pre-unfold the def.
+
+With those, `toGeneric_add`/`_mul` are
+`apply GFqField.ext; apply GFqRing.ext; simp only [toGeneric, toQuotient_*,
+repr_*_ofPoly]; rw [ofUInt64_{add,mul}_val, toFpPoly_mod_modulus, toFpPoly_{add,mul},
+reduceMod_idem]`, and the round-trips chain the same helpers with
+`ofFpPoly_toFpPoly`/`toFpPoly_ofFpPoly` + the low-word round-trip.
+
 ## The Mathlib layer *models* executable definitions
 
 The bridge does not just prove lemmas about the executable types; it carries

--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -42,6 +42,8 @@ private theorem prime_two : Hex.Nat.Prime 2 := by
     · exact Or.inl rfl
     · exact Or.inr rfl
 
+instance : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime prime_two
+
 variable {n : Nat} {irr : UInt64}
 variable {hn : 0 < n} {hn64 : n < 64}
 variable {hirr : Hex.GF2Poly.Irreducible (Hex.GF2Poly.ofUInt64Monic irr n)}
@@ -97,32 +99,276 @@ def ofGeneric
     (n := n) (irr := irr)
     ((((HexGF2Mathlib.GF2Poly.ofFpPoly (Hex.GFqField.repr x)).toWords).getD 0 0))
 
+/-! Bridge helpers: the single-word reduction `Hex.GF2n.reduce` reads back the
+polynomial residue modulo the field modulus, `toFpPoly` commutes with the
+polynomial remainder, and the packed conversions round-trip on reduced
+representatives. These let the four `≃+*` obligations follow by composing the
+`GF2Poly ≃+* FpPoly 2` bridge with the `GFqField` quotient layer. -/
+
+/-- Degree is preserved across the `GF2Poly → FpPoly 2` bridge. -/
+private theorem degree_toFpPoly (p : Hex.GF2Poly) :
+    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly p) = p.degree := by
+  unfold Hex.FpPoly.degree Hex.GF2Poly.degree
+  rw [HexGF2Mathlib.GF2Poly.degree?_toFpPoly]
+
+/-- Degree is preserved across the `FpPoly 2 → GF2Poly` bridge. -/
+private theorem degree_ofFpPoly (P : Hex.FpPoly 2) :
+    (HexGF2Mathlib.GF2Poly.ofFpPoly P).degree = Hex.FpPoly.degree P := by
+  have hdeg? : (HexGF2Mathlib.GF2Poly.ofFpPoly P).degree? = P.degree? := by
+    have h := HexGF2Mathlib.GF2Poly.degree?_toFpPoly (HexGF2Mathlib.GF2Poly.ofFpPoly P)
+    rw [HexGF2Mathlib.GF2Poly.toFpPoly_ofFpPoly] at h
+    exact h.symm
+  unfold Hex.GF2Poly.degree Hex.FpPoly.degree
+  rw [hdeg?]
+
+include hn64 hirr in
+/-- The canonical single-word reduction of any packed polynomial reads back its
+residue modulo the field modulus. -/
+private theorem ofUInt64_canonicalWordLT_packedReduceWord (p : Hex.GF2Poly) :
+    Hex.GF2Poly.ofUInt64
+        (Hex.GF2Poly.canonicalWordLT n hn64 (Hex.GF2Poly.packedReduceWord n irr p))
+      = p % Hex.GF2Poly.ofUInt64Monic irr n := by
+  have hself :
+      Hex.GF2Poly.canonicalWordLT n hn64 (Hex.GF2Poly.packedReduceWord n irr p)
+        = Hex.GF2Poly.packedReduceWord n irr p := by
+    apply UInt64.toNat_inj.mp
+    simp [Hex.GF2Poly.canonicalWordLT,
+      Nat.mod_eq_of_lt (Hex.GF2Poly.packedReduceWord_toNat_lt hn64 p)]
+  rw [hself]
+  have hred := Hex.GF2Poly.mod_degree_lt p (Hex.GF2Poly.ofUInt64Monic irr n) hirr.1
+  rw [Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64] at hred
+  exact Hex.GF2Poly.ofUInt64_packedReduceWord_eq_of_degree_lt hn64 p hred
+
+include hn hn64 hirr in
+/-- Reading back the reduced single-word representative recovers the polynomial
+residue modulo the field modulus. -/
+private theorem ofUInt64_reduce_val (w : UInt64) :
+    Hex.GF2Poly.ofUInt64
+        (Hex.GF2n.reduce (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) w).val
+      = Hex.GF2Poly.ofUInt64 w % Hex.GF2Poly.ofUInt64Monic irr n :=
+  ofUInt64_canonicalWordLT_packedReduceWord (n := n) (irr := irr) (hn64 := hn64) (hirr := hirr)
+    (Hex.GF2Poly.ofUInt64 w)
+
+include hn hn64 hirr in
+/-- Reading back the reduced representative of a wide carry-less product. -/
+private theorem ofUInt64_reduceWide_val (hi lo : UInt64) :
+    Hex.GF2Poly.ofUInt64
+        (Hex.GF2n.reduceWide (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
+          hi lo).val
+      = Hex.GF2Poly.ofWords #[lo, hi] % Hex.GF2Poly.ofUInt64Monic irr n :=
+  ofUInt64_canonicalWordLT_packedReduceWord (n := n) (irr := irr) (hn64 := hn64) (hirr := hirr)
+    (Hex.GF2Poly.ofWords #[lo, hi])
+
+/-- `toFpPoly` commutes with the polynomial remainder: the bridge carries the
+`GF2Poly` modulus reduction to the `FpPoly` quotient reduction. -/
+private theorem toFpPoly_mod (p q : Hex.GF2Poly) (hq : 0 < q.degree) :
+    HexGF2Mathlib.GF2Poly.toFpPoly (p % q)
+      = Hex.GFqRing.reduceMod (HexGF2Mathlib.GF2Poly.toFpPoly q)
+          (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
+  have hqne : q ≠ 0 := by
+    intro h; rw [h] at hq; simp [Hex.GF2Poly.degree] at hq
+  have hfdeg : 0 < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) := by
+    rw [degree_toFpPoly]; exact hq
+  have hdecomp : (p / q) * q + p % q = p := Hex.GF2Poly.div_mul_add_mod p q
+  have e1 :
+      HexGF2Mathlib.GF2Poly.toFpPoly (p % q)
+          + HexGF2Mathlib.GF2Poly.toFpPoly (p / q) * HexGF2Mathlib.GF2Poly.toFpPoly q
+        = HexGF2Mathlib.GF2Poly.toFpPoly p := by
+    rw [← HexGF2Mathlib.GF2Poly.toFpPoly_mul, ← HexGF2Mathlib.GF2Poly.toFpPoly_add,
+      Hex.GF2Poly.add_comm, hdecomp]
+  have hdeg :
+      Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly (p % q))
+        < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) := by
+    rw [degree_toFpPoly, degree_toFpPoly]
+    rcases Hex.GF2Poly.mod_degree_lt p q hqne with h | h
+    · rw [Hex.GF2Poly.eq_zero_of_isZero h, Hex.GF2Poly.degree_zero]; exact hq
+    · exact h
+  rw [← e1, Hex.GFqRing.reduceMod_add_mul_self_right (HexGF2Mathlib.GF2Poly.toFpPoly q) hfdeg
+      (HexGF2Mathlib.GF2Poly.toFpPoly (p % q)) (HexGF2Mathlib.GF2Poly.toFpPoly (p / q)),
+    Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ hdeg]
+
+/-- Reading back the low word of a reduced packed polynomial round-trips. -/
+private theorem ofUInt64_toWords_getD_of_reduced (p : Hex.GF2Poly)
+    (hred : p.isZero = true ∨ p.degree < 64) :
+    Hex.GF2Poly.ofUInt64 (p.toWords.getD 0 0) = p := by
+  by_cases hzero : p.isZero = true
+  · rw [Hex.GF2Poly.eq_zero_of_isZero hzero]
+    change Hex.GF2Poly.ofWords #[(0 : UInt64)] = 0
+    apply Hex.GF2Poly.ext_words
+    simp
+  · have hzeroFalse : p.isZero = false := by
+      cases h : p.isZero <;> simp [h] at hzero ⊢
+    obtain ⟨d, hd⟩ := Hex.GF2Poly.degree?_isSome_of_isZero_false hzeroFalse
+    have hd64 : d < 64 := by
+      cases hred with
+      | inl h => rw [h] at hzeroFalse; contradiction
+      | inr hdegree => simpa [Hex.GF2Poly.degree, hd] using hdegree
+    apply Hex.GF2Poly.ext_coeff
+    intro i
+    unfold Hex.GF2Poly.ofUInt64
+    rw [Hex.GF2Poly.coeff_ofWords]
+    by_cases hi64 : i < 64
+    · have hiword : i / 64 = 0 := Nat.div_eq_of_lt hi64
+      simp [Hex.GF2Poly.toWords, Hex.GF2Poly.coeff, Hex.GF2Poly.coeffWords, hiword]
+    · have hpfalse : p.coeff i = false :=
+        Hex.GF2Poly.coeff_eq_false_of_degree?_lt hd (by omega)
+      rw [hpfalse]
+      cases hidx : i / 64 with
+      | zero => omega
+      | succ k => simp [Hex.GF2Poly.coeffWords, hidx]
+
+/-- A packed word below `2 ^ n` represents a polynomial reduced below the
+extension degree. -/
+private theorem isZero_or_degree_lt_ofUInt64 {w : UInt64} (hw : w.toNat < 2 ^ n) :
+    (Hex.GF2Poly.ofUInt64 w).isZero = true ∨ (Hex.GF2Poly.ofUInt64 w).degree < n := by
+  by_cases hz : (Hex.GF2Poly.ofUInt64 w).isZero = true
+  · exact Or.inl hz
+  · right
+    have hzf : (Hex.GF2Poly.ofUInt64 w).isZero = false := by
+      cases h : (Hex.GF2Poly.ofUInt64 w).isZero <;> simp_all
+    obtain ⟨d, hd⟩ := Hex.GF2Poly.degree?_isSome_of_isZero_false hzf
+    rw [Hex.GF2Poly.degree_eq_of_degree?_eq_some hd]
+    rcases Nat.lt_or_ge d n with hlt | hge
+    · exact hlt
+    · exfalso
+      have htrue := Hex.GF2Poly.coeff_eq_true_of_degree?_eq_some hd
+      have hfalse : (Hex.GF2Poly.ofUInt64 w).coeff d = false := by
+        by_cases h64 : d < 64
+        · rw [Hex.GF2Poly.coeff_ofUInt64_eq_testBit w h64]
+          apply Nat.testBit_eq_false_of_lt
+          exact Nat.lt_of_lt_of_le hw (Nat.pow_le_pow_right (by decide : 0 < 2) hge)
+        · exact Hex.GF2Poly.coeff_ofUInt64_eq_false_of_ge_64 w (Nat.le_of_not_lt h64)
+      rw [htrue] at hfalse
+      exact Bool.noConfusion hfalse
+
+/-- Single-word field elements are determined by their stored canonical word. -/
+private theorem eq_of_val_eq {a b : Hex.GF2n n irr hn hn64 hirr} (h : a.val = b.val) :
+    a = b := by
+  cases a; cases b; simp at h; subst h; rfl
+
+include hn hn64 hirr in
+/-- Single-word addition reads back as the polynomial sum modulo the modulus. -/
+private theorem ofUInt64_add_val (x y : Hex.GF2n n irr hn hn64 hirr) :
+    Hex.GF2Poly.ofUInt64 (x + y).val
+      = (Hex.GF2Poly.ofUInt64 x.val + Hex.GF2Poly.ofUInt64 y.val)
+          % Hex.GF2Poly.ofUInt64Monic irr n := by
+  rw [← Hex.GF2Poly.ofUInt64_xor]
+  exact ofUInt64_reduce_val (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
+    (x.val ^^^ y.val)
+
+include hn hn64 hirr in
+/-- Single-word multiplication reads back as the polynomial product modulo the
+modulus. -/
+private theorem ofUInt64_mul_val (x y : Hex.GF2n n irr hn hn64 hirr) :
+    Hex.GF2Poly.ofUInt64 (x * y).val
+      = (Hex.GF2Poly.ofUInt64 x.val * Hex.GF2Poly.ofUInt64 y.val)
+          % Hex.GF2Poly.ofUInt64Monic irr n := by
+  rw [Hex.GF2Poly.ofUInt64_mul_ofUInt64]
+  exact ofUInt64_reduceWide_val (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) _ _
+
+include hn64 in
+/-- The transported modulus has the extension degree. -/
+private theorem degree_modulusFpPoly :
+    Hex.FpPoly.degree (modulusFpPoly (n := n) (irr := irr)) = n := by
+  unfold modulusFpPoly
+  rw [degree_toFpPoly, Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]
+
+include hn hn64 in
+/-- `toFpPoly` carries the `GF2Poly` reduction by the field modulus to the
+`FpPoly` quotient reduction by the transported modulus. -/
+private theorem toFpPoly_mod_modulus (p : Hex.GF2Poly) :
+    HexGF2Mathlib.GF2Poly.toFpPoly (p % Hex.GF2Poly.ofUInt64Monic irr n)
+      = Hex.GFqRing.reduceMod (modulusFpPoly (n := n) (irr := irr))
+          (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
+  rw [toFpPoly_mod p (Hex.GF2Poly.ofUInt64Monic irr n)
+    (by rw [Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]; exact hn)]
+  rfl
+
+include hn hn64 in
+/-- Quotient reduction is the identity on `toFpPoly` of an already-reduced
+polynomial. -/
+private theorem reduceMod_modulusFpPoly_toFpPoly_of_reduced (p : Hex.GF2Poly)
+    (hred : p.isZero = true ∨ p.degree < n) :
+    Hex.GFqRing.reduceMod (modulusFpPoly (n := n) (irr := irr))
+        (HexGF2Mathlib.GF2Poly.toFpPoly p)
+      = HexGF2Mathlib.GF2Poly.toFpPoly p := by
+  apply Hex.GFqRing.reduceMod_eq_self_of_degree_lt
+  rw [degree_toFpPoly, degree_modulusFpPoly (hn64 := hn64)]
+  rcases hred with h | h
+  · rw [Hex.GF2Poly.eq_zero_of_isZero h, Hex.GF2Poly.degree_zero]; exact hn
+  · exact h
+
 @[simp]
 theorem ofGeneric_toGeneric (x : Hex.GF2n n irr hn hn64 hirr) :
     ofGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
         (toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x) = x := by
-  sorry
+  have hxred : (Hex.GF2Poly.ofUInt64 x.val).isZero = true
+      ∨ (Hex.GF2Poly.ofUInt64 x.val).degree < n :=
+    isZero_or_degree_lt_ofUInt64 x.val_lt
+  have hrepr :
+      Hex.GFqField.repr
+          (toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x)
+        = HexGF2Mathlib.GF2Poly.toFpPoly (Hex.GF2Poly.ofUInt64 x.val) := by
+    simp only [toGeneric, Hex.GF2n.toPolyWord, Hex.GFqField.repr_ofPoly]
+    exact reduceMod_modulusFpPoly_toFpPoly_of_reduced (n := n) (irr := irr) (hn := hn)
+      (hn64 := hn64) _ hxred
+  apply eq_of_val_eq
+  apply Hex.GF2Poly.ofUInt64_injective
+  simp only [ofGeneric]
+  rw [ofUInt64_reduce_val, hrepr, HexGF2Mathlib.GF2Poly.ofFpPoly_toFpPoly,
+    ofUInt64_toWords_getD_of_reduced _ (hxred.imp_right (fun h => Nat.lt_trans h hn64))]
+  exact Hex.GF2Poly.mod_eq_self_of_reduced _ _
+    (hxred.imp_right
+      (fun h => by rw [Hex.GF2Poly.degree_ofUInt64Monic_of_lt_64 irr hn64]; exact h))
 
 @[simp]
 theorem toGeneric_ofGeneric
     (x : GenericFiniteField (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)) :
     toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
         (ofGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x) = x := by
-  sorry
+  have hofred :
+      (HexGF2Mathlib.GF2Poly.ofFpPoly (Hex.GFqField.repr x)).isZero = true
+        ∨ (HexGF2Mathlib.GF2Poly.ofFpPoly (Hex.GFqField.repr x)).degree < 64 := by
+    right
+    rw [degree_ofFpPoly]
+    have hlt := Hex.GFqField.degree_repr_lt_degree x
+    rw [degree_modulusFpPoly (hn64 := hn64)] at hlt
+    exact Nat.lt_trans hlt hn64
+  apply GFqField.ext
+  apply GFqRing.ext
+  show Hex.GFqField.repr
+        (toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr)
+          (ofGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x))
+      = Hex.GFqField.repr x
+  simp only [toGeneric, ofGeneric, Hex.GF2n.toPolyWord, Hex.GFqField.repr_ofPoly]
+  rw [ofUInt64_reduce_val, toFpPoly_mod_modulus (hn := hn) (hn64 := hn64),
+    Hex.GFqRing.reduceMod_idem,
+    ofUInt64_toWords_getD_of_reduced _ hofred, HexGF2Mathlib.GF2Poly.toFpPoly_ofFpPoly,
+    Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ (Hex.GFqField.degree_repr_lt_degree x)]
 
 @[simp]
 theorem toGeneric_add (x y : Hex.GF2n n irr hn hn64 hirr) :
     toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) (x + y) =
       (toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x +
         toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) y) := by
-  sorry
+  apply GFqField.ext
+  apply GFqRing.ext
+  simp only [toGeneric, Hex.GF2n.toPolyWord, Hex.GFqField.toQuotient_add,
+    Hex.GFqField.toQuotient_ofPoly, Hex.GFqRing.repr_ofPoly, Hex.GFqRing.repr_add_ofPoly]
+  rw [ofUInt64_add_val, toFpPoly_mod_modulus (hn := hn) (hn64 := hn64),
+    HexGF2Mathlib.GF2Poly.toFpPoly_add, Hex.GFqRing.reduceMod_idem]
 
 @[simp]
 theorem toGeneric_mul (x y : Hex.GF2n n irr hn hn64 hirr) :
     toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) (x * y) =
       (toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) x *
         toGeneric (n := n) (irr := irr) (hn := hn) (hn64 := hn64) (hirr := hirr) y) := by
-  sorry
+  apply GFqField.ext
+  apply GFqRing.ext
+  simp only [toGeneric, Hex.GF2n.toPolyWord, Hex.GFqField.toQuotient_mul,
+    Hex.GFqField.toQuotient_ofPoly, Hex.GFqRing.repr_ofPoly, Hex.GFqRing.repr_mul_ofPoly]
+  rw [ofUInt64_mul_val, toFpPoly_mod_modulus (hn := hn) (hn64 := hn64),
+    HexGF2Mathlib.GF2Poly.toFpPoly_mul, Hex.GFqRing.reduceMod_idem]
 
 /-- The packed single-word field wrapper is ring-equivalent to the generic
 finite-field construction over the transported modulus. -/

--- a/progress/2026-06-18T14-43-18Z_15978c89.md
+++ b/progress/2026-06-18T14-43-18Z_15978c89.md
@@ -1,0 +1,39 @@
+# Session: close GF2n.toGeneric RingEquiv obligations (#7936)
+
+## Accomplished
+- Discharged the four `sorry`s in the `GF2n` namespace of
+  `HexGF2Mathlib/Field.lean` (`ofGeneric_toGeneric`, `toGeneric_ofGeneric`,
+  `toGeneric_add`, `toGeneric_mul`), so `GF2n.equiv : GF2n ≃+* GenericFiniteField`
+  is sorry-free.
+- Added private bridge helpers (all in the Mathlib layer, no executable-layer
+  edits):
+  - `degree_toFpPoly` / `degree_ofFpPoly`: degree preserved across the
+    `GF2Poly ↔ FpPoly 2` bridge.
+  - `ofUInt64_canonicalWordLT_packedReduceWord`: the single-word reduction reads
+    back the residue mod the modulus (re-derives the masking-identity privately,
+    so `Hex.GF2n.reduce` need not be unfolded by name — `(reduce w).val` is defeq
+    to the fully-public `canonicalWordLT … (packedReduceWord …)` term).
+  - `toFpPoly_mod` / `toFpPoly_mod_modulus`: `toFpPoly` commutes with the
+    polynomial remainder (`div_mul_add_mod` + `reduceMod_add_mul_self_right` +
+    degree bridge).
+  - `ofUInt64_reduce_val` / `ofUInt64_reduceWide_val` / `ofUInt64_add_val` /
+    `ofUInt64_mul_val`: word-level XOR/clmul ops read back as poly +/* mod the
+    modulus.
+  - `ofUInt64_toWords_getD_of_reduced` (low-word round-trip for reduced polys,
+    replica of the private `ofUInt64_lowWord_eq_of_degree_lt_64`),
+    `isZero_or_degree_lt_ofUInt64`, `eq_of_val_eq`, `reduceMod_modulusFpPoly_*`.
+  - Added a `ZMod64.PrimeModulus 2` instance in the `GF2n` namespace (needed by
+    the `GFqRing.reduceMod` algebraic lemmas).
+
+## Current frontier
+- `HexGF2Mathlib` builds green; `HexGFqMathlib` (downstream) builds green;
+  `scripts/check_dag.py` exit 0. No new sorry/axiom/native_decide on added lines.
+
+## Next step
+- The parallel `GF2nPoly` namespace in the same file still has its four `≃+*`
+  sorries (#7937) — out of scope here. The helpers added here are GF2n-specific;
+  GF2nPoly already has its own `reducePoly_val_eq_mod`/`mod` machinery in the
+  executable layer to mirror.
+
+## Blockers
+- None.


### PR DESCRIPTION
Closes #7936

Session: `15978c89-3165-4195-b04a-3ce34d2f0b3c`

98cbf7d3 feat: close GF2n.toGeneric RingEquiv obligations in HexGF2Mathlib/Field.lean (#7936)

🤖 Prepared with Claude Code