### PR TITLE
feat: close GF2nPoly.toGeneric RingEquiv obligations in HexGF2Mathlib/Field.lean

### DIFF
--- a/HexGF2Mathlib/Field.lean
+++ b/HexGF2Mathlib/Field.lean
@@ -290,31 +290,111 @@ def ofGeneric (x : GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)) :
     Hex.GF2nPoly f hirr :=
   Hex.GF2nPoly.reducePoly (f := f) (HexGF2Mathlib.GF2Poly.ofFpPoly (Hex.GFqField.repr x))
 
+/-- `FpPoly.degree` of a transported packed polynomial equals its packed degree. -/
+theorem degree_toFpPoly (q : Hex.GF2Poly) :
+    Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly q) = q.degree := by
+  unfold Hex.FpPoly.degree Hex.GF2Poly.degree
+  rw [HexGF2Mathlib.GF2Poly.degree?_toFpPoly]
+
+/-- **Reduction-compatibility bridge.** Packed remainder reduction modulo `f`
+transports across the `GF2Poly ≃+* FpPoly 2` conversion layer to the generic
+quotient-ring reduction `GFqRing.reduceMod`. This is the missing transport that
+lets the `GF2nPoly` quotient round-trip / add / mul obligations follow from the
+already-proved packed-level ring equivalence. -/
+theorem toFpPoly_reduceMod (p g : Hex.GF2Poly) (hgdeg : 0 < g.degree) :
+    HexGF2Mathlib.GF2Poly.toFpPoly (p % g) =
+      Hex.GFqRing.reduceMod (HexGF2Mathlib.GF2Poly.toFpPoly g)
+        (HexGF2Mathlib.GF2Poly.toFpPoly p) := by
+  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime GF2n.prime_two
+  have hgne : g ≠ 0 := by
+    intro h; rw [h] at hgdeg; simp [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] at hgdeg
+  have hgdeg' : 0 < Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
+    rw [degree_toFpPoly]; exact hgdeg
+  have hdeglt :
+      Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly (p % g)) <
+        Hex.FpPoly.degree (HexGF2Mathlib.GF2Poly.toFpPoly g) := by
+    rw [degree_toFpPoly, degree_toFpPoly]
+    rcases Hex.GF2Poly.mod_degree_lt p g hgne with hz | hlt
+    · rw [Hex.GF2Poly.eq_zero_of_isZero hz]
+      simpa [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] using hgdeg
+    · exact hlt
+  have heucl :
+      HexGF2Mathlib.GF2Poly.toFpPoly p =
+        HexGF2Mathlib.GF2Poly.toFpPoly (p % g) +
+          HexGF2Mathlib.GF2Poly.toFpPoly (p / g) * HexGF2Mathlib.GF2Poly.toFpPoly g := by
+    conv_lhs => rw [← Hex.GF2Poly.div_mul_add_mod p g]
+    rw [HexGF2Mathlib.GF2Poly.toFpPoly_add, HexGF2Mathlib.GF2Poly.toFpPoly_mul,
+      Hex.FpPoly.add_comm]
+  rw [heucl, Hex.GFqRing.reduceMod_add_mul_self_right _ hgdeg']
+  exact (Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _ hdeglt).symm
+
+/-- Equality of generic finite-field elements from equality of canonical
+representatives. -/
+theorem eq_of_repr_eq
+    {x y : GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)}
+    (h : Hex.GFqField.repr x = Hex.GFqField.repr y) : x = y := by
+  apply Hex.GFqField.ext
+  exact Subtype.ext h
+
+/-- The canonical representative of a packed element embedded into the generic
+model is simply its packed value, transported to `FpPoly 2`. -/
+theorem repr_toGeneric (x : Hex.GF2nPoly f hirr) :
+    Hex.GFqField.repr (toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x) =
+      HexGF2Mathlib.GF2Poly.toFpPoly x.val := by
+  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime GF2n.prime_two
+  unfold toGeneric
+  rw [Hex.GFqField.repr_ofPoly]
+  apply Hex.GFqRing.reduceMod_eq_self_of_degree_lt
+  rw [degree_toFpPoly]
+  show Hex.FpPoly.degree (modulusFpPoly (f := f)) > x.val.degree
+  rw [show modulusFpPoly (f := f) = HexGF2Mathlib.GF2Poly.toFpPoly f from rfl, degree_toFpPoly]
+  rcases x.val_reduced with hz | hlt
+  · rw [Hex.GF2Poly.eq_zero_of_isZero hz]
+    simpa [Hex.GF2Poly.degree, Hex.GF2Poly.degree?] using hdeg
+  · exact hlt
+
 @[simp]
 theorem ofGeneric_toGeneric (x : Hex.GF2nPoly f hirr) :
     ofGeneric (f := f) (hirr := hirr) (hdeg := hdeg)
       (toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x) = x := by
-  sorry
+  unfold ofGeneric
+  rw [repr_toGeneric, HexGF2Mathlib.GF2Poly.ofFpPoly_toFpPoly]
+  apply Hex.GF2nPoly.eq_of_val_eq
+  rw [Hex.GF2nPoly.reducePoly_val_eq_mod]
+  exact Hex.GF2Poly.mod_eq_self_of_reduced x.val f x.val_reduced
 
 @[simp]
 theorem toGeneric_ofGeneric (x : GenericFiniteField (f := f) (hirr := hirr) (hdeg := hdeg)) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg)
       (ofGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x) = x := by
-  sorry
+  letI : Hex.ZMod64.PrimeModulus 2 := Hex.ZMod64.primeModulusOfPrime GF2n.prime_two
+  apply eq_of_repr_eq
+  rw [repr_toGeneric]
+  unfold ofGeneric
+  rw [Hex.GF2nPoly.reducePoly_val_eq_mod,
+    toFpPoly_reduceMod _ _ hdeg, HexGF2Mathlib.GF2Poly.toFpPoly_ofFpPoly]
+  exact Hex.GFqRing.reduceMod_eq_self_of_degree_lt _ _
+    (Hex.GFqField.degree_repr_lt_degree x)
 
 @[simp]
 theorem toGeneric_add (x y : Hex.GF2nPoly f hirr) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) (x + y) =
       (toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x +
         toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) y) := by
-  sorry
+  apply eq_of_repr_eq
+  rw [Hex.GFqField.repr_add, repr_toGeneric, repr_toGeneric, repr_toGeneric,
+    Hex.GF2nPoly.add_val, toFpPoly_reduceMod _ _ hdeg, HexGF2Mathlib.GF2Poly.toFpPoly_add,
+    show modulusFpPoly (f := f) = HexGF2Mathlib.GF2Poly.toFpPoly f from rfl]
 
 @[simp]
 theorem toGeneric_mul (x y : Hex.GF2nPoly f hirr) :
     toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) (x * y) =
       (toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) x *
         toGeneric (f := f) (hirr := hirr) (hdeg := hdeg) y) := by
-  sorry
+  apply eq_of_repr_eq
+  rw [Hex.GFqField.repr_mul, repr_toGeneric, repr_toGeneric, repr_toGeneric,
+    Hex.GF2nPoly.mul_val, toFpPoly_reduceMod _ _ hdeg, HexGF2Mathlib.GF2Poly.toFpPoly_mul,
+    show modulusFpPoly (f := f) = HexGF2Mathlib.GF2Poly.toFpPoly f from rfl]
 
 include hdeg in
 /-- The packed arbitrary-degree field wrapper is ring-equivalent to the generic

--- a/progress/20260618T152135Z_72c4dbdb.md
+++ b/progress/20260618T152135Z_72c4dbdb.md
@@ -1,0 +1,74 @@
+# Progress — 2026-06-18 (session 72c4dbdb, /work)
+
+## Accomplished
+
+### Diagnosed and skipped #7925 (recovered-lift fast-core irreducibility wrapper)
+
+Premise-checked the issue's deliverable 1 (derive the monic-lattice
+projected-indicator `hsize`/`hindicators` from the non-monic
+`factorFastCoreWithBound` success, NOT as a free hypothesis) and found it
+blocked on the unproduced `L' = W` reverse separation
+(`ExecutableCapSeparationHypotheses` / bad-vector resultant, HO B-builder
+#6779), the same deep BHKS content directive #2564 tracks. The endpoint forces
+`L` = the monic lattice (#7923's family is monic-only; non-monic `RecoveredLift`
+is provably impossible), while the executable success only bounds the
+**non-monic** lattice's class count; equating the two reduces, via
+`bhksEquivalenceClassIndicators_size_eq` and
+`bhksEquivalenceClassIndicators_eq_expectedIndicatorArrayOfSupports`, to
+`projectedRowSpanInt = trueFactorIndicatorLattice`, whose reverse inclusion is
+unproduced. Posted the full chain as a diagnosis comment and `coordination
+skip`ped for re-scope (carry `hsize`/`hindicators` as residual hypotheses like
+`hsep`/`hthr`/`hpartition`, or gate on the bad-vector separation issue).
+
+### Completed #7937 (GF2nPoly arbitrary-degree ring equivalence)
+
+`HexGF2Mathlib/Field.lean`: discharged the four `GF2nPoly`-namespace `sorry`s
+behind `GF2nPoly.equiv : GF2nPoly f hirr ≃+* GenericFiniteField`, making the
+arbitrary-degree quotient-field ring equivalence sorry-free.
+
+New helpers (in the `HexGF2Mathlib.GF2nPoly` namespace, kept distinct from the
+parallel `GF2n` work):
+- `toFpPoly_reduceMod` — the reduction-compatibility bridge requested by the
+  issue: `toFpPoly (p % g) = GFqRing.reduceMod (toFpPoly g) (toFpPoly p)` for
+  `0 < g.degree`. Proof: lift the GF2Poly Euclidean identity
+  (`div_mul_add_mod`) across the already-proved ring hom (`toFpPoly_add`/`_mul`)
+  into the `q + r*g` shape, kill the multiple with
+  `GFqRing.reduceMod_add_mul_self_right`, and finish with
+  `reduceMod_eq_self_of_degree_lt` using the transported remainder degree bound
+  (`mod_degree_lt` + `degree_toFpPoly`).
+- `degree_toFpPoly` — `FpPoly.degree (toFpPoly q) = q.degree` (from
+  `degree?_toFpPoly`).
+- `eq_of_repr_eq` — generic-field elements are equal when their canonical
+  representatives are (via `Subtype.ext` + `GFqField.ext`).
+- `repr_toGeneric` — `repr (toGeneric x) = toFpPoly x.val` (the value is already
+  reduced).
+
+The four obligations then compose these with the packed-level equivalence
+(`ofFpPoly_toFpPoly`, `toFpPoly_ofFpPoly`, `toFpPoly_add`, `toFpPoly_mul`) and
+the GFqField `repr_add`/`repr_mul`/`repr_ofPoly` lemmas.
+
+## Verification
+
+- `lake build HexGF2Mathlib` and `lake build HexGFqMathlib` → `Build completed
+  successfully`, 0 `error:`. Only the 4 `GF2n`-namespace `sorry` warnings
+  (Field.lean:101/107/114/121) remain — parallel #7936/#7942 scope, untouched.
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+
+## Current frontier
+
+`GF2nPoly.equiv` is sorry-free; `finEquiv`/`fintype_card` downstream consume it.
+The single-word `GF2n.equiv` obligations (Field.lean:101-121) remain for the
+parallel #7936/#7942 PRs.
+
+## Next step
+
+The #7925 capstone path needs a planner re-scope (see the diagnosis comment).
+
+## Blockers
+
+None for #7937. #7925 blocked on the bad-vector `L' = W` separation (#6779).
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+modification from before this session; not touched or staged.


### PR DESCRIPTION
Closes #7937

Session: `72c4dbdb-11fb-4b17-bca8-ac4f90f8edb2`

33e1029d feat: close GF2nPoly.toGeneric ring equivalence via reduction bridge (#7937)

🤖 Prepared with Claude Code