### PR TITLE
doc: record post-#7938 persistence of the hsep/hthr success-precision trap

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -319,6 +319,25 @@ Before claiming any "discharge hsep/hthr" / "CLD precision floor" fast-path
 issue, `#eval` `liftData.k` at the scheduled precisions and confirm it actually
 clears the CLD floor; as of #7928 it does not.
 
+**#7938 fixed only the *cap*, not the success precision — the trap persists
+(#7945).** #7938 removed the *caller-side* double `precisionForCoeffBound` (the
+public path now passes the raw cap `B = factorFastPrecisionCap core`), so the
+*cap* schedule entry is now adequate (cldGuardF: `liftData.k = 12` at `k = cap =
+50803201`). But the per-iteration lift still applies `precisionForCoeffBound` to
+the **schedule variable** `k` (`toMonicLiftData core k primeData` ⟹ `liftData.k
+= precisionForCoeffBound k p`, `Basic.lean:7001-7017`), and the loop returns at
+the **first** `k` that recovers — not the cap. For cldGuardF the first schedule
+entry `k = 4` already recovers (the `polyProduct == f` product check passes on
+the tiny true coefficients), so `liftData.k = precisionForCoeffBound 4 5 = 2`,
+and hsep is `2·bhksCoeffBound … = 2·16 = 32 < 5² = 25` → **false** (floor needs
+`precisionForCoeffBound 16 5 = 3`). So "the schedule fix makes hsep/hthr
+provable" is still a false premise: success is certified by the empirical
+product check, not by column-adequacy, so `success ⟹ hsep at liftData.k` remains
+refutable. The genuine residual is an **executable** acceptance gate (reject a
+success whose `liftData.k < bhksCoeffCutThreshold`, forcing cldGuardF from
+`k=4 → liftData.k=2` to `k=16 → liftData.k=3`) plus its Mathlib determinism
+remodel — not a proofs-only deliverable. (#7945 skipped on exactly this.)
+
 ## `Matrix` / `Vector` resolve to Mathlib's inside the Mathlib layer
 
 The mirror of the shadow above. In a Mathlib-layer file (namespace

--- a/progress/20260618T152947Z_589d4526.md
+++ b/progress/20260618T152947Z_589d4526.md
@@ -1,0 +1,71 @@
+# Progress — 2026-06-18 (session 589d4526, /once → /work #7945)
+
+## Accomplished
+
+Premise-checked #7945 (prove fast-core CLD precision-soundness `hsep`/`hthr`)
+and **skipped it for replan** — the premise is unsound. The issue claims #7938's
+schedule fix makes the per-coordinate CLD conditions true at a successful
+fast-core precision; it does not.
+
+### Diagnosis (concrete, `#eval`-verified against main 5e59f311)
+
+`#7938` removed the *caller-side* double `precisionForCoeffBound`, but the
+per-iteration lift still applies `precisionForCoeffBound` to the **schedule
+variable** `k`:
+`liftData.k = (toMonicLiftData core k primeData).k = precisionForCoeffBound k p`
+(`Basic.lean:7001-7004,7017`; `henselLiftData_k`). The loop returns at the
+**first** `k` that recovers, not the cap.
+
+Counterexample `cldGuardF = x²−5x+6`, `p=5`:
+- `factorFastPrecisionCap = 50803201`; schedule `[4,8,16,…,50803201]`.
+- `liftData.k` per `k`: `[(4,2),(8,2),(16,3),…,(cap,12)]`.
+- `bhksCoeffBound (toMonic cldGuardF).monic j = 16` (both `j`); CLD floor
+  `precisionForCoeffBound 16 5 = 3`.
+- Loop succeeds at the first entry `k=4 → liftData.k=2` (matches the existing
+  `#guard … cldGuardF 4 = some bhksGuardFactors` and the issue's own note
+  "recovers at lift precision 2"). `B` does not enter the `k=4` recovery, so the
+  public `B=cap` path recovers at the same `liftData.k=2`.
+- **hsep at `liftData.k=2`: `2·16 = 32 < 5² = 25` → FALSE** (both `j`).
+
+So `hsep` is literally false at the success precision (the #7928 trap the
+`hex-lean-mathlib-boundary` skill documents), not merely underivable. The
+empirical `polyProduct == f` check certifies correctness at `liftData.k=2` but
+not column-adequacy. The cap *is* adequate now (`liftData.k=12`); the gap is the
+loop accepting the first product-verified precision below the CLD floor.
+
+Deliverable 1 (universal `success ⟹ hsep`) is refuted by cldGuardF; deliverable
+2 consumes `hsep`, so it is blocked too. The real residual is an **executable**
+acceptance-gate / precision-floor change in `factorFastCoreWithBound` (reject a
+success with `liftData.k < bhksCoeffCutThreshold`, pushing cldGuardF to
+`k=16 → liftData.k=3`), paired with its Mathlib determinism-cluster remodel —
+which the issue body explicitly scopes *out* ("proofs only; executable change
+already on main"). With the executable schedule unchanged, no hsep/hthr proof at
+the success precision exists.
+
+Posted the full evidence as an issue comment; `coordination skip 7945` for
+replan. No code changes, no PR, no sorry/axiom (per doctrine).
+
+## Current frontier
+
+#7945's deliverables are blocked on an executable acceptance-gate change, not a
+missing proof. A replan should re-scope it as an executable+Mathlib pair (the
+soundness-sensitive precision-floor correction in `factorFastCoreWithBound`), or
+narrow `hsep`/`hthr` to hold at the cap precision and add a separate gate forcing
+the loop to recover at/above the floor.
+
+## Next step
+
+Replan #7945 per the above. The `#7917` assembly
+(`factorFastCore_irreducible_of_success_given_partition`) remains blocked until a
+success-precision that clears the CLD floor is guaranteed.
+
+## Blockers
+
+#7945 premise is unsound as scoped (proofs-only). Documented; skipped.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus.Basic` → Build completed successfully (491 jobs).
+- `#eval` scratch (pure-integer; deleted before finishing) produced the table above.
+- No source changes; only the pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+  worktree modification remains (untouched, unstaged).


### PR DESCRIPTION
This PR records, in the \`hex-lean-mathlib-boundary\` skill, that #7938 fixed only the *cap* precision of the fast-core schedule and not the success precision, so the hsep/hthr "discharge from success" premise remains a false premise. The loop still applies \`precisionForCoeffBound\` to the schedule variable and returns at the first product-verified precision, which for cldGuardF is \`liftData.k = 2\` where \`2·16 = 32 < 5² = 25\` makes hsep literally false (floor needs \`precisionForCoeffBound 16 5 = 3\`). This was verified by a pure-integer \`#eval\` against \`main\` and is the basis for skipping #7945; the genuine residual is an executable acceptance-gate change plus its Mathlib determinism remodel, not a proofs-only deliverable.

Does not close #7945 — that issue is marked \`replan\` so a planner can re-scope it as an executable+Mathlib pair.

🤖 Prepared with Claude Code