### PR TITLE
feat: HexPolyFp Phase 6 grind automation coverage for Basic.lean

### DIFF
--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -957,13 +957,13 @@ private theorem coeff_one (n : Nat) :
   exact DensePoly.coeff_C (1 : ZMod64 p) n
 
 /-- The zero polynomial evaluates to zero at every point. -/
-@[simp] theorem eval_zero (x : ZMod64 p) :
+@[simp, grind =] theorem eval_zero (x : ZMod64 p) :
     DensePoly.eval (0 : FpPoly p) x = 0 := by
   exact DensePoly.eval_zero x
 
 /-- A constant polynomial evaluates to its constant at every point. This is
 the base case from which the evaluation map's homomorphism laws are built. -/
-@[simp]
+@[simp, grind =]
 theorem eval_C (c x : ZMod64 p) :
     DensePoly.eval (FpPoly.C c) x = c := by
   unfold FpPoly.C
@@ -971,7 +971,7 @@ theorem eval_C (c x : ZMod64 p) :
 
 /-- The variable `X` evaluates to the evaluation point. The companion base
 case to `eval_C` for reasoning about the evaluation map. -/
-@[simp]
+@[simp, grind =]
 theorem eval_X [ZMod64.PrimeModulus p] (x : ZMod64 p) :
     DensePoly.eval (FpPoly.X : FpPoly p) x = x := by
   unfold FpPoly.X DensePoly.eval DensePoly.toArray DensePoly.monomial
@@ -1010,7 +1010,7 @@ private theorem foldl_eval_replicate_zero (x : ZMod64 p) :
       rw [Lean.Grind.CommSemiring.mul_comm x (x ^ n)]
 
 /-- Evaluating a monomial gives the coefficient times the corresponding power. -/
-@[simp]
+@[simp, grind =]
 theorem eval_monomial (n : Nat) (c x : ZMod64 p) :
     DensePoly.eval (DensePoly.monomial n c : FpPoly p) x = c * x ^ n := by
   by_cases hc : c = 0
@@ -1031,25 +1031,25 @@ theorem eval_monomial (n : Nat) (c x : ZMod64 p) :
     exact foldl_eval_replicate_zero x n c
 
 /-- Coefficients of the constant polynomial wrapper are constant at degree zero and zero elsewhere. -/
-@[simp] theorem coeff_C (c : ZMod64 p) (n : Nat) :
+@[simp, grind =] theorem coeff_C (c : ZMod64 p) (n : Nat) :
     (FpPoly.C c).coeff n = if n = 0 then c else 0 := by
   unfold FpPoly.C
   exact DensePoly.coeff_C c n
 
 /-- The degree-zero coefficient of the indeterminate wrapper is zero. -/
-@[simp] theorem coeff_X_zero :
+@[simp, grind =] theorem coeff_X_zero :
     ((FpPoly.X : FpPoly p)).coeff 0 = 0 := by
   unfold FpPoly.X
   exact DensePoly.coeff_monomial 1 (1 : ZMod64 p) 0
 
 /-- The degree-one coefficient of the indeterminate wrapper is one. -/
-@[simp] theorem coeff_X_one :
+@[simp, grind =] theorem coeff_X_one :
     ((FpPoly.X : FpPoly p)).coeff 1 = 1 := by
   unfold FpPoly.X
   exact DensePoly.coeff_monomial 1 (1 : ZMod64 p) 1
 
 /-- Coefficients of the indeterminate wrapper are one at degree one and zero elsewhere. -/
-@[simp] theorem coeff_X (n : Nat) :
+@[simp, grind =] theorem coeff_X (n : Nat) :
     ((FpPoly.X : FpPoly p)).coeff n = if n = 1 then 1 else 0 := by
   unfold FpPoly.X
   exact DensePoly.coeff_monomial 1 (1 : ZMod64 p) n
@@ -1454,7 +1454,7 @@ theorem eval_shift_scale_row (i : Nat) (c : ZMod64 p) (f : FpPoly p)
 
 /-- Evaluation is additive: the value of a sum is the sum of the values.
 One half of the statement that evaluation at a point is a ring homomorphism. -/
-@[simp]
+@[simp, grind =]
 theorem eval_add (f h : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (f + h) x = DensePoly.eval f x + DensePoly.eval h x := by
   let bound := max f.size h.size
@@ -1483,7 +1483,7 @@ theorem eval_add (f h : FpPoly p) (x : ZMod64 p) :
 /-- Evaluation respects subtraction. Lets callers push an evaluation through
 a difference of polynomials, for example when checking that two polynomials
 agree at a point. -/
-@[simp]
+@[simp, grind =]
 theorem eval_sub (f h : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (f - h) x = DensePoly.eval f x - DensePoly.eval h x := by
   let bound := max f.size h.size
@@ -1510,14 +1510,14 @@ theorem eval_sub (f h : FpPoly p) (x : ZMod64 p) :
     grind
 
 /-- Evaluation respects additive inverses. -/
-@[simp] theorem eval_neg (f : FpPoly p) (x : ZMod64 p) :
+@[simp, grind =] theorem eval_neg (f : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (-f) x = -(DensePoly.eval f x) := by
   change DensePoly.eval (DensePoly.neg f) x = -(DensePoly.eval f x)
   unfold DensePoly.neg
   rw [eval_sub, eval_zero]
   exact DensePoly.ZeroSubNegLaw.zero_sub_eq_neg (DensePoly.eval f x)
 
-@[simp] theorem add_zero (f : FpPoly p) :
+@[simp, grind =] theorem add_zero (f : FpPoly p) :
     f + 0 = f := by
   apply DensePoly.ext_coeff
   intro i
@@ -1525,7 +1525,7 @@ theorem eval_sub (f h : FpPoly p) (x : ZMod64 p) :
   rw [DensePoly.coeff_zero]
   grind
 
-@[simp] theorem zero_add (f : FpPoly p) :
+@[simp, grind =] theorem zero_add (f : FpPoly p) :
     0 + f = f := by
   apply DensePoly.ext_coeff
   intro i
@@ -1555,7 +1555,7 @@ theorem add_assoc (f g h : FpPoly p) :
   rw [DensePoly.coeff_add_semiring]
   grind
 
-@[simp] theorem neg_zero :
+@[simp, grind =] theorem neg_zero :
     -(0 : FpPoly p) = 0 := by
   apply DensePoly.ext_coeff
   intro i
@@ -1563,7 +1563,7 @@ theorem add_assoc (f g h : FpPoly p) :
   rw [DensePoly.coeff_zero]
   grind
 
-@[simp] theorem add_left_neg (f : FpPoly p) :
+@[simp, grind =] theorem add_left_neg (f : FpPoly p) :
     -f + f = 0 := by
   apply DensePoly.ext_coeff
   intro i
@@ -1572,7 +1572,7 @@ theorem add_assoc (f g h : FpPoly p) :
   rw [DensePoly.coeff_zero]
   grind
 
-@[simp] theorem add_right_neg (f : FpPoly p) :
+@[simp, grind =] theorem add_right_neg (f : FpPoly p) :
     f + -f = 0 := by
   apply DensePoly.ext_coeff
   intro i
@@ -1581,7 +1581,7 @@ theorem add_assoc (f g h : FpPoly p) :
   rw [DensePoly.coeff_zero]
   grind
 
-@[simp] theorem sub_zero (f : FpPoly p) :
+@[simp, grind =] theorem sub_zero (f : FpPoly p) :
     f - 0 = f := by
   apply DensePoly.ext_coeff
   intro i
@@ -1589,11 +1589,11 @@ theorem add_assoc (f g h : FpPoly p) :
   rw [DensePoly.coeff_zero]
   grind
 
-@[simp] theorem zero_sub (f : FpPoly p) :
+@[simp, grind =] theorem zero_sub (f : FpPoly p) :
     0 - f = -f := by
   rfl
 
-@[simp] theorem sub_self (f : FpPoly p) :
+@[simp, grind =] theorem sub_self (f : FpPoly p) :
     f - f = 0 := by
   apply DensePoly.ext_coeff
   intro i
@@ -1616,11 +1616,11 @@ example (f : FpPoly p) :
     (f + 0) - f = 0 := by
   simp
 
-@[simp] theorem zero_mul (f : FpPoly p) :
+@[simp, grind =] theorem zero_mul (f : FpPoly p) :
     0 * f = 0 := by
   rfl
 
-@[simp] theorem mul_zero (f : FpPoly p) :
+@[simp, grind =] theorem mul_zero (f : FpPoly p) :
     f * 0 = 0 := by
   exact (DensePoly.mul_comm_poly f 0).trans (DensePoly.zero_mul f)
 
@@ -1653,11 +1653,11 @@ private theorem coeff_mul_one_fold (f : FpPoly p) (n k : Nat) :
             simp [hk, hks, hsub]
       · exact zmod_mul_zero (f.coeff n)
 
-@[simp] theorem one_mul (f : FpPoly p) :
+@[simp, grind =] theorem one_mul (f : FpPoly p) :
     1 * f = f := by
   exact (DensePoly.mul_comm_poly (1 : FpPoly p) f).trans (DensePoly.mul_one_right_poly f)
 
-@[simp] theorem mul_one (f : FpPoly p) :
+@[simp, grind =] theorem mul_one (f : FpPoly p) :
     f * 1 = f := by
   exact DensePoly.mul_one_right_poly f
 
@@ -2746,7 +2746,7 @@ theorem C_mul_eq_scale (c : ZMod64 p) (f : FpPoly p) :
 
 /-- Evaluating `C c * f` at `x` multiplies the value of `f` by the scalar `c`.
 The constant-multiplication special case of `eval_mul`. -/
-@[simp]
+@[simp, grind =]
 theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (DensePoly.C c * f) x = c * DensePoly.eval f x := by
   rw [C_mul_eq_scale]
@@ -2767,7 +2767,7 @@ theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p) (x : ZMod64 p) :
     rw [DensePoly.coeff_eq_zero_of_size_le f hi]
     exact hzero
 
-@[simp] theorem eval_one (x : ZMod64 p) :
+@[simp, grind =] theorem eval_one (x : ZMod64 p) :
     DensePoly.eval (1 : FpPoly p) x = 1 := by
   change DensePoly.eval (FpPoly.C (1 : ZMod64 p)) x = 1
   exact eval_C 1 x
@@ -2819,7 +2819,7 @@ private theorem mul_eq_fold_shift_scale_rows (f h : FpPoly p) :
 /-- Evaluation is multiplicative: the value of a product is the product of the
 values. Together with `eval_add` this is the ring-homomorphism property of
 evaluation, used wherever a root or factorization is checked pointwise. -/
-@[simp]
+@[simp, grind =]
 theorem eval_mul (f h : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (f * h) x = DensePoly.eval f x * DensePoly.eval h x := by
   rw [mul_eq_fold_shift_scale_rows]
@@ -3912,10 +3912,10 @@ def linearPow (f : FpPoly p) : Nat → FpPoly p
   | 0 => 1
   | n + 1 => linearPow f n * f
 
-@[simp] theorem linearPow_zero (f : FpPoly p) : linearPow f 0 = 1 := rfl
+@[simp, grind =] theorem linearPow_zero (f : FpPoly p) : linearPow f 0 = 1 := rfl
 
 /-- Successor exponents append one right multiplication by the base. -/
-@[simp] theorem linearPow_succ (f : FpPoly p) (n : Nat) :
+@[simp, grind =] theorem linearPow_succ (f : FpPoly p) (n : Nat) :
     linearPow f (n + 1) = linearPow f n * f := rfl
 
 /-- Successor exponents may also be read as one left multiplication by the base. -/
@@ -3933,7 +3933,7 @@ theorem linearPow_succ_left (f : FpPoly p) (n : Nat) :
         _ = f * linearPow f (n + 1) := rfl
 
 /-- The first `linearPow` of a polynomial is the polynomial itself. -/
-@[simp] theorem linearPow_one (f : FpPoly p) :
+@[simp, grind =] theorem linearPow_one (f : FpPoly p) :
     linearPow f 1 = f := by
   rw [linearPow_succ, linearPow_zero, one_mul]
 

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -3935,7 +3935,7 @@ theorem linearPow_succ_left (f : FpPoly p) (n : Nat) :
 /-- The first `linearPow` of a polynomial is the polynomial itself. -/
 @[simp, grind =] theorem linearPow_one (f : FpPoly p) :
     linearPow f 1 = f := by
-  rw [linearPow_succ, linearPow_zero, one_mul]
+  grind
 
 /-- `linearPow` turns exponent addition into polynomial multiplication. -/
 theorem linearPow_add (f : FpPoly p) (m n : Nat) :

--- a/progress/20260618T170528Z_839e6600.md
+++ b/progress/20260618T170528Z_839e6600.md
@@ -1,0 +1,52 @@
+# Progress — session 839e6600 (/work → diagnose #6672, /feature #7955)
+
+## Accomplished
+
+### Diagnosed and skipped #6672 (HO-1 capstone, directive #2564 critical path)
+Claimed the unblocked capstone `factor_irreducible_of_nonUnit`
+(its only `depends-on: #7894` is closed). Premise-checked: the assembly
+route `factor_entries_irreducible f h_raw` (`Basic.lean:427`) still needs
+the **unconditional fast substrate** `factorFastRaw_irreducible_of_some`,
+which does not exist (`grep` empty). The two slow disjuncts have
+unconditional substrates (`slowModularRaw_irreducible_of_fast_none`
+`IntReductionMod.lean:6243`, `factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`
+`:6440`); the fast disjunct's routes (`PartitionRefinement.lean:589/660/613`)
+all still take `CutProjectionHypotheses`/`TrueFactorLift`/`hsep` as free
+binders. Root blocker is the hsep-at-success-precision trap (verified in
+commit 5d6e9fae / #7950): the fast-core loop accepts a product-verified
+precision below the CLD floor, where `hsep` is literally false. The
+concrete unblocker is the executable CLD-adequacy gate #7951 (in progress)
+plus a follow-on Mathlib soundness remodel. Posted full evidence as an
+issue comment and `coordination skip 6672` for replan. No code, no sorry.
+
+### Completed #7955 (HexPolyFp Phase 6 grind automation)
+Annotated all 29 equation-shaped `@[simp]` lemmas in
+`HexPolyFp/Basic.lean` (eval_*, coeff_*, ring laws, linearPow_*) as
+`@[simp, grind =]`, following the Mathlib-free sibling convention
+(HexMatrix/HexModArith). `FpPoly p` has no `Grind.CommRing` instance, so
+grind otherwise lacks these characterising rewrites. Demonstrated payoff:
+`linearPow_one` shortened from a three-rewrite chain to `by grind`.
+
+## Verification
+- `lake build HexPolyFp` → 98 jobs, success, no warnings/errors (downstream
+  files SquareFree/Conformance/QuotientFrobenius/Compose included — no
+  grind loop or regression).
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no `sorry`/`axiom`/`native_decide`/`TODO`/`FIXME`
+  on added lines. sorry/axiom count unchanged at 0.
+- Diff scoped to `HexPolyFp/Basic.lean` only (30/30).
+
+## Current frontier
+#7955 done. The directive #2564 capstone (#6672) is sequenced behind the
+executable acceptance gate #7951.
+
+## Next step
+After #7951 lands, file/sequence the Mathlib `factorFastRaw_irreducible_of_some`
+substrate, then re-open #6672 assembly. Sibling grind pass #7957 (HexLLL)
+remains unclaimed.
+
+## Blockers
+#6672 blocked on #7951 + post-gate Mathlib substrate (documented on the issue).
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+modification from before this session; left untouched and unstaged.


### PR DESCRIPTION
Closes #7955

Session: `839e6600-d32f-4a5d-8528-358bc4c1e4be`

911116d6 doc: progress for #7955 grind pass and #6672 diagnosis (#7955)
0a19005d refactor: close linearPow_one by grind in HexPolyFp (#7955)
464449d6 feat: add @[grind =] to HexPolyFp/Basic.lean characterising lemmas (#7955)

🤖 Prepared with Claude Code