### PR TITLE
feat: add CLD-adequacy acceptance gate to fast-core

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -317,7 +317,49 @@ correction (drop the double `precisionForCoeffBound`), which is soundness-
 sensitive and touches the CI-gated determinism cluster — not a cheap gate.
 Before claiming any "discharge hsep/hthr" / "CLD precision floor" fast-path
 issue, `#eval` `liftData.k` at the scheduled precisions and confirm it actually
-clears the CLD floor; as of #7928 it does not.
+clears the CLD floor; as of #7928 it did not.
+
+### Resolved by #7938 (schedule) + #7951 (gate); the gate cascade is large
+
+#7938 dropped the double `precisionForCoeffBound` so the schedule now iterates
+*coefficient bounds* `k` up to the cap `factorFastPrecisionCap f` (single
+conversion inside `toMonicLiftData`). #7951 then added the acceptance gate:
+`factorFastCoreWithBound`'s `.success` branch accepts only when
+`k ≥ cldCoeffFloor core = 2·max_j bhksCoeffBound (toMonic core).monic j`, else
+continues the schedule. Post-#7951, `success → k ≥ cldCoeffFloor core` (hence
+`hsep` via `precisionForCoeffBound_spec`) *is* derivable — that is the premise
+#7945's hsep/hthr proofs consume. Verify the floor numerically with a
+pure-integer `#eval` (`cldCoeffFloor`, `factorFastPrecisionCap`, the schedule)
+under `lake env lean` — for `cldGuardF` floor`=32`, cap`=50803201`, first gated
+success at `k=32`/`liftData.k=3` (`2·bhksCoeffBound=32 < 5^3=125`).
+
+Two traps when touching the gate:
+
+- **Adding an acceptance condition to `factorFastCoreWithBound` cascades through
+  the entire CI-gated capstone chain, not just the obvious determinism lemmas.**
+  Every wrapper whose conclusion asserts `factorFast … ≠ none` / `= some …`
+  needs the new side condition threaded as an *open hypothesis* (like `hno`):
+  the `*_of_recovery_on_schedule` / `*_of_forwardInputs_*` lemmas in
+  `Basic.lean` + `PartitionRefinement.lean`, **and** the whole festooned
+  `Recovery.lean` chain — the `_internalCapPositive*` variants and all ~18
+  `factorFast_terminates*` capstones (which route through `factorFast_terminates`
+  → `…_internalCapPositiveAndPrimeLowerBound`). Size it up front by grepping the
+  `hB_pos`/`one_le_factorFastPrecisionCap f`/`hchoose` arg chain (~30 lemmas);
+  do **not** regex-replace on `f primeData` (it appears pervasively in
+  hypothesis *types* like `CanonicalRecoveryTailInputs f primeData …`, so a blind
+  sed corrupts signatures — target exact call lines). The success→*property*
+  lemmas (`_product`, `_dvd`, `_some_all_of_recovery`, `_some_classifiedSuccess`)
+  stay signature-stable; they only need a `by_cases hfloor` in the `.success`
+  case. Discharging the floor side condition needs
+  `cldCoeffFloor core ≤ factorFastPrecisionCap f` (a `toMonic` coefficient-norm
+  vs `bhksBound`-slack analysis with no existing infra) — thread it, don't try
+  to prove it inline.
+- **Reducing the gate `ite` on a `k ≥ cldCoeffFloor core` condition in a
+  *goal*.** `rw [if_pos hge]` fails ("did not find pattern" — the `GE.ge`
+  Decidable instance the `rw` infers differs from the goal's) and `split` may
+  silently not fire. Use `simp only [ge_iff_le, hfloor, if_true]` (or
+  `simp [hclass, hfloor] at hfast` when reducing it inside a *hypothesis*, which
+  is robust to the instance gap).
 
 ## `Matrix` / `Vector` resolve to Mathlib's inside the Mathlib layer
 

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7005,18 +7005,49 @@ def toMonicLiftData
 
 end ZPoly
 
+/--
+CLD column-adequacy floor for the fast-core acceptance gate.
+
+A successful BHKS recovery at schedule coefficient bound `k` only certifies
+column adequacy (the BHKS Lemma 5.7 separation `hsep`) once the lift precision
+`precisionForCoeffBound k primeData.p` clears the per-coordinate CLD threshold.
+Equivalently, the schedule bound `k` must reach twice the largest per-coordinate
+BHKS coefficient bound of the monic transform `(toMonic core).monic`: then
+`p ^ (precisionForCoeffBound k p) > 2·k ≥ 2·cldCoeffFloor core`, so
+`2·bhksCoeffBound (toMonic core).monic j < p ^ (precisionForCoeffBound k p)`
+holds for every coordinate `j`.  The floor is independent of the prime.
+-/
+def cldCoeffFloor (core : ZPoly) : Nat :=
+  let monicCore := (ZPoly.toMonic core).monic
+  let n := monicCore.degree?.getD 0
+  2 * (List.range (n + 1)).foldl (fun acc j => max acc (bhksCoeffBound monicCore j)) 0
+
 /-- BHKS fast-core recombination loop, exposed publicly so that Mathlib-side
 lemmas can quantify over its success state.  Internally driven by the
 classified BHKS recovery `bhksRecoverClassified`; `none` indicates the
 loop exhausted its precision bound without producing a verified factor
-list. -/
+list.
+
+The successful classified recovery is only *accepted* once the schedule
+coefficient bound `k` reaches `cldCoeffFloor core` — the CLD column-adequacy
+floor that makes the lift precision satisfy the BHKS separation `hsep`.  A
+success below the floor is treated like the non-success classes: the loop
+continues to the next scheduled precision (and reports `none` only if the cap
+`B` is reached first).  The schedule reaches the cap `B`, and the cap clears
+the floor, so acceptance is only deferred, never lost. -/
 def factorFastCoreWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : Nat → Nat → Option (Array ZPoly)
   | _k, 0 => none
   | k, fuel + 1 =>
       let liftData := ZPoly.toMonicLiftData core k primeData
       match bhksRecoverClassified core liftData with
-      | .success factors => some factors
+      | .success factors =>
+        if k ≥ cldCoeffFloor core then
+          some factors
+        else if k ≥ B then
+          none
+        else
+          factorFastCoreWithBound core B primeData (nextHenselPrecision k B) fuel
       | .candidateFailure =>
         if k ≥ B then
           none
@@ -7183,6 +7214,7 @@ theorem cap_mem_henselPrecisionSchedule (B : Nat) :
 private theorem factorFastCoreWithBound_isSome_of_recovery_on_schedule
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
+    (hfloor : cldCoeffFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hrecover :
       bhksRecover? core (ZPoly.toMonicLiftData core target primeData) = some factors) :
@@ -7194,7 +7226,26 @@ private theorem factorFastCoreWithBound_isSome_of_recovery_on_schedule
       rw [factorFastCoreWithBound]
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core start primeData) with
       | success xs =>
-          simp
+          by_cases hstart : start ≥ cldCoeffFloor core
+          · simp [hstart]
+          · by_cases hk : start ≥ B
+            · exfalso
+              have htarget : target = start := by
+                simpa [henselPrecisionSchedule, hk] using hmem
+              omega
+            · simp [hstart, hk]
+              have hmem' :
+                  target ∈
+                    henselPrecisionSchedule B (nextHenselPrecision start B) fuel := by
+                have hmem_tail :
+                    target = start ∨
+                      target ∈
+                        henselPrecisionSchedule B (nextHenselPrecision start B) fuel := by
+                  simpa [henselPrecisionSchedule, hk] using hmem
+                cases hmem_tail with
+                | inl htarget => omega
+                | inr htail => exact htail
+              exact ih hmem'
       | degenerate =>
           by_cases hk : start ≥ B
           · simp [hk]
@@ -7283,6 +7334,7 @@ Mignotte/cap precision.
 theorem factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_recovery
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
+    (hfloor : cldCoeffFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hno :
       ∀ k, k ∈ henselPrecisionSchedule B start fuel → k ≠ target →
@@ -7301,6 +7353,7 @@ theorem factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_reco
           · subst target
             rw [bhksRecover?] at hrecover
             simp [hclass, BhksRecoveryResult.toOption] at hrecover
+            simp only [ge_iff_le, hfloor, if_true]
             exact congrArg some hrecover
           · have hstart_mem :
                 start ∈ henselPrecisionSchedule B start (fuel + 1) := by
@@ -7402,6 +7455,7 @@ theorem factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_reco
 private theorem factorFastCoreWithBound_ne_none_of_recovery_on_schedule
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
+    (hfloor : cldCoeffFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hrecover :
       bhksRecover? core (ZPoly.toMonicLiftData core target primeData) = some factors) :
@@ -7409,7 +7463,7 @@ private theorem factorFastCoreWithBound_ne_none_of_recovery_on_schedule
   intro hnone
   have hsome :=
     factorFastCoreWithBound_isSome_of_recovery_on_schedule
-      core B primeData hmem hrecover
+      core B primeData hfloor hmem hrecover
   rw [hnone] at hsome
   simp at hsome
 
@@ -7425,8 +7479,19 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
     (initialHenselPrecision 1) (ZPoly.quadraticDoublingSteps 1 + 2) =
   none
 
+-- With the CLD-adequacy acceptance gate, a coefficient bound below
+-- `cldCoeffFloor cldGuardF = 32` cannot be accepted: the schedule reaches the
+-- cap `B` while every success is still below the floor, so the loop reports
+-- `none`.
 #guard factorFastCoreWithBound cldGuardF 4 factorFastCoreGuardPrimeData
     (initialHenselPrecision 4) (ZPoly.quadraticDoublingSteps 4 + 2) =
+  none
+
+-- At a bound that reaches the floor the first gated success is accepted: for
+-- `cldGuardF` this is schedule index `k = 32` (lift precision `liftData.k = 3`,
+-- modulus `5 ^ 3 = 125`), recovering the same factors.
+#guard factorFastCoreWithBound cldGuardF 32 factorFastCoreGuardPrimeData
+    (initialHenselPrecision 32) (ZPoly.quadraticDoublingSteps 32 + 2) =
   some bhksGuardFactors
 
 namespace ZPoly
@@ -8065,6 +8130,7 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
     (f : ZPoly) (primeData : PrimeChoiceData)
     {target : Nat} {coreFactors : Array ZPoly}
     (hB_pos : 1 ≤ factorFastPrecisionCap f)
+    (hfloor : cldCoeffFloor (normalizeForFactor f).squareFreeCore ≤ target)
     (hchoose :
       choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hmem :
@@ -8086,7 +8152,7 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
     exact
       factorFastCoreWithBound_ne_none_of_recovery_on_schedule
         (normalizeForFactor f).squareFreeCore B primeData
-        (by simpa [B] using hmem) hrecover
+        hfloor (by simpa [B] using hmem) hrecover
   have hfactors_ne :
       factorFastFactorsWithBound f B ≠ none := by
     unfold factorFastFactorsWithBound
@@ -9031,10 +9097,15 @@ private def nonMonicCubicRegression : ZPoly :=
 
 -- The fast BHKS path lifts the monic transform and dilates recovered
 -- candidates back to the original non-monic coordinate, so it recombines this
--- cubic directly instead of deferring to the slow path.
+-- cubic directly instead of deferring to the slow path.  The CLD-adequacy
+-- acceptance gate only certifies a recovery once the coefficient bound reaches
+-- `cldCoeffFloor nonMonicCubicRegression = 312`; the public path runs at the
+-- cap `factorFastPrecisionCap`, which clears the floor, so the cubic is still
+-- recombined directly (the default Mignotte bound `42` is below the floor and
+-- would now defer to the slow path).
 #guard
   (match factorFastFactorsWithBound nonMonicCubicRegression
-      (ZPoly.defaultFactorCoeffBound nonMonicCubicRegression) with
+      (factorFastPrecisionCap nonMonicCubicRegression) with
     | some fs => fs.size = 3
     | none => false)
 
@@ -11582,9 +11653,14 @@ theorem factorFastCoreWithBound_product
       rw [factorFastCoreWithBound] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          simp [hclass] at hfast
-          cases hfast
-          exact bhksRecoverClassified_success_product hclass
+          by_cases hfloor : k ≥ cldCoeffFloor core
+          · simp [hclass, hfloor] at hfast
+            cases hfast
+            exact bhksRecoverClassified_success_product hclass
+          · by_cases hk : k ≥ B
+            · simp [hclass, hfloor, hk] at hfast
+            · simp [hclass, hfloor, hk] at hfast
+              exact ih _ coreFactors hfast
       | degenerate =>
           by_cases hk : k ≥ B
           · simp [hclass, hk] at hfast
@@ -11673,9 +11749,14 @@ private theorem factorFastCoreWithBound_some_classifiedSuccess
       rw [factorFastCoreWithBound] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          simp [hclass] at hfast
-          cases hfast
-          exact ⟨k, hclass⟩
+          by_cases hfloor : k ≥ cldCoeffFloor core
+          · simp [hclass, hfloor] at hfast
+            cases hfast
+            exact ⟨k, hclass⟩
+          · by_cases hk : k ≥ B
+            · simp [hclass, hfloor, hk] at hfast
+            · simp [hclass, hfloor, hk] at hfast
+              exact ih _ coreFactors hfast
       | degenerate =>
           by_cases hk : k ≥ B
           · simp [hclass, hk] at hfast
@@ -11766,9 +11847,14 @@ private theorem factorFastCoreWithBound_some_all_of_recovery
       rw [factorFastCoreWithBound] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          simp [hclass] at hfast
-          cases hfast
-          exact hrecover hclass
+          by_cases hfloor : k ≥ cldCoeffFloor core
+          · simp [hclass, hfloor] at hfast
+            cases hfast
+            exact hrecover hclass
+          · by_cases hk : k ≥ B
+            · simp [hclass, hfloor, hk] at hfast
+            · simp [hclass, hfloor, hk] at hfast
+              exact ih _ coreFactors hfast
       | degenerate =>
           by_cases hk : k ≥ B
           · simp [hclass, hk] at hfast
@@ -11837,9 +11923,14 @@ theorem factorFastCoreWithBound_some_dvd
       rw [factorFastCoreWithBound] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          simp [hclass] at hfast
-          cases hfast
-          exact bhksRecoverClassified_success_dvd hclass
+          by_cases hfloor : k ≥ cldCoeffFloor core
+          · simp [hclass, hfloor] at hfast
+            cases hfast
+            exact bhksRecoverClassified_success_dvd hclass
+          · by_cases hk : k ≥ B
+            · simp [hclass, hfloor, hk] at hfast
+            · simp [hclass, hfloor, hk] at hfast
+              exact ih _ coreFactors hfast
       | degenerate =>
           by_cases hk : k ≥ B
           · simp [hclass, hk] at hfast

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -424,6 +424,7 @@ first-success loop returns exactly the package's expected factors.
 theorem factorFastCoreWithBound_eq_expected_of_forwardInputs_on_schedule_of_no_prior_recovery
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {start fuel target : Nat}
+    (hfloor : Hex.cldCoeffFloor core ≤ target)
     (hinputs :
       BHKS.ForwardRecoveryInputs core
         (Hex.ZPoly.toMonicLiftData core target primeData))
@@ -434,7 +435,7 @@ theorem factorFastCoreWithBound_eq_expected_of_forwardInputs_on_schedule_of_no_p
     Hex.factorFastCoreWithBound core B primeData start fuel =
       some hinputs.expectedFactors :=
   Hex.factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_recovery
-    core B primeData hmem hno
+    core B primeData hfloor hmem hno
     (BHKS.bhksRecover_eq_some_of_forwardInputs core
       (Hex.ZPoly.toMonicLiftData core target primeData) hinputs)
 
@@ -449,6 +450,7 @@ Mignotte/cap precision.
 -/
 theorem factorFastCoreWithBound_eq_expected_of_forwardInputs_at_cap_of_no_prior_recovery
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    (hfloor : Hex.cldCoeffFloor core ≤ B)
     (hinputs :
       BHKS.ForwardRecoveryInputs core
         (Hex.ZPoly.toMonicLiftData core B primeData))
@@ -463,7 +465,7 @@ theorem factorFastCoreWithBound_eq_expected_of_forwardInputs_at_cap_of_no_prior_
         (Hex.ZPoly.quadraticDoublingSteps B + 2) =
       some hinputs.expectedFactors :=
   factorFastCoreWithBound_eq_expected_of_forwardInputs_on_schedule_of_no_prior_recovery
-    hinputs (Hex.cap_mem_henselPrecisionSchedule B) hno
+    hfloor hinputs (Hex.cap_mem_henselPrecisionSchedule B) hno
 
 /-- Lower cardinality bound for a successful BHKS fast-core branch whose
 emitted candidates have been certified through the B8 partition-refinement

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2432,6 +2432,8 @@ theorem factorFast_ne_none_of_forwardInputs_on_schedule
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     {target : Nat}
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤ target)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hinputs :
@@ -2457,7 +2459,7 @@ theorem factorFast_ne_none_of_forwardInputs_on_schedule
       hinputs
   exact
     Hex.factorFast_ne_none_of_core_recovery_on_schedule
-      f primeData hB_pos hchoose hmem hrecover
+      f primeData hB_pos hfloor hchoose hmem hrecover
 
 /--
 Canonical scheduled-precision specialisation of
@@ -2473,6 +2475,9 @@ semantic hypotheses.
 theorem factorFast_ne_none_of_forwardInputs_at_cap
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hinputs :
@@ -2483,7 +2488,7 @@ theorem factorFast_ne_none_of_forwardInputs_at_cap
           (Hex.factorFastPrecisionCap f) primeData)) :
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_forwardInputs_on_schedule
-    f primeData hB_pos hchoose hinputs
+    f primeData hB_pos hfloor hchoose hinputs
     (Hex.cap_mem_henselPrecisionSchedule _)
 
 /-- The monic-core lift data produced by the public `factorFast` pipeline for
@@ -3386,6 +3391,9 @@ theorem factorFast_ne_none_of_capSeparationCanonicalIndicatorsAtPrecisionForCoef
           rows_pos localFactorIndex localFactorDegree H)
         trueSupports)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -3417,7 +3425,7 @@ theorem factorFast_ne_none_of_capSeparationCanonicalIndicatorsAtPrecisionForCoef
       Array.polyProduct expectedFactors =
         (Hex.normalizeForFactor f).squareFreeCore) :
     Hex.factorFast f ≠ none :=
-  factorFast_ne_none_of_forwardInputs_at_cap f primeData hB_pos hchoose
+  factorFast_ne_none_of_forwardInputs_at_cap f primeData hB_pos hfloor hchoose
     (ForwardRecoveryInputs.ofCapSeparationCanonicalIndicatorsAtPrecisionForCoeffBound
       rows_pos trueSupports localFactorIndex localFactorDegree H
       hcap_le C hC_nonneg hC hcap hp hk nondegenerate
@@ -3485,6 +3493,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
       ((factorFastCapLiftData f primeData).p ^
         ((factorFastCapLiftData f primeData).k * localFactorDegree) : ℝ))
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -3521,7 +3532,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
     hcap_le C hC_nonneg hC
     (capSeparationOfBridgeData rows_pos localFactorIndex localFactorDegree H
       trueSupports hcut bridge (by omega) hlt)
-    hB_pos hchoose hp hk nondegenerate expectedFactors hsize hcandidate
+    hB_pos hfloor hchoose hp hk nondegenerate expectedFactors hsize hcandidate
     product_eq
 
 /--
@@ -3564,6 +3575,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
     (hcomparison :
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -3600,6 +3614,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
     hcap_le C hC_nonneg hC hcut bridge
     hcomparison.hadamard_l2norm_lt_divisor
     (one_le_factorFastPrecisionCap f)
+    hfloor
     hchoose hp hk nondegenerate expectedFactors hsize hcandidate product_eq
 
 /--
@@ -3653,6 +3668,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -3686,7 +3704,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecisionForCoeffBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
     hcap_le C hC_nonneg hC hcut bridge
-    hcomparison.hadamard_l2norm_lt_divisor hB_pos hchoose
+    hcomparison.hadamard_l2norm_lt_divisor hB_pos hfloor hchoose
     (Hex.choosePrimeData?_prime _ _ hchoose).two_le
     hk nondegenerate expectedFactors hsize hcandidate product_eq
 
@@ -3735,6 +3753,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
     (hcomparison :
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -3768,7 +3789,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecis
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecisionForCoeffBound_internalPrimeLowerBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
     hcap_le C hC_nonneg hC hcut bridge hcomparison
-    (one_le_factorFastPrecisionCap f) hchoose hk nondegenerate expectedFactors
+    (one_le_factorFastPrecisionCap f) hfloor hchoose hk nondegenerate expectedFactors
     hsize hcandidate product_eq
 
 /--
@@ -3814,6 +3835,9 @@ theorem factorFast_ne_none_of_factorFastCapLiftBridgeDataCanonicalIndicatorsAtPr
     (hcomparison :
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -3846,7 +3870,7 @@ theorem factorFast_ne_none_of_factorFastCapLiftBridgeDataCanonicalIndicatorsAtPr
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalIndicatorsAtPrecisionForCoeffBound_internalCapPositiveAndPrimeLowerBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
-    hcap_le C hC_nonneg hC hcut bridge hcomparison hchoose hk
+    hcap_le C hC_nonneg hC hcut bridge hcomparison hfloor hchoose hk
     nondegenerate expectedFactors hsize hcandidate product_eq
 
 /--
@@ -3888,6 +3912,9 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalIndicatorsExpectedFactor
             rows_pos) =
         BHKS.trueFactorIndicatorLattice trueSupports)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -3928,7 +3955,7 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalIndicatorsExpectedFactor
                 (factorFastCapLiftData f primeData).k)) =
           expectedFactors.getD i 0) :
     Hex.factorFast f ≠ none :=
-  factorFast_ne_none_of_forwardInputs_at_cap f primeData hB_pos hchoose
+  factorFast_ne_none_of_forwardInputs_at_cap f primeData hB_pos hfloor hchoose
     (ForwardRecoveryInputs.ofMignottePrecisionCanonicalIndicatorsExpectedFactorsAtPrecisionForCoeffBound
       rows_pos trueSupports lattice_eq_indicators hp hk nondegenerate
       selectedFactors expectedFactors hf_ne_zero htrue hselected hdilated)
@@ -3963,6 +3990,9 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsA
             rows_pos) =
         BHKS.trueFactorIndicatorLattice trueSupports)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -4007,7 +4037,7 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsA
           expectedFactors.getD i 0) :
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_mignottePrecisionCanonicalIndicatorsExpectedFactorsAtPrecisionForCoeffBound
-    f primeData rows_pos trueSupports lattice_eq_indicators hB_pos hchoose
+    f primeData rows_pos trueSupports lattice_eq_indicators hB_pos hfloor hchoose
     hp hk
     (ForwardRecoveryInputs.canonicalSupportIndicators_nondegenerate
       (projectedRowsOfLiftData
@@ -7315,6 +7345,9 @@ input plumbing behind a single bundle. -/
 theorem factorFast_ne_none_of_canonicalRecoveryInputs
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -7328,7 +7361,7 @@ theorem factorFast_ne_none_of_canonicalRecoveryInputs
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsAtPrecisionForCoeffBound
     f primeData inputs.rows_pos inputs.trueSupports inputs.lattice_eq_indicators
-    hB_pos hchoose hp hk inputs.projected_nonempty inputs.classes_two
+    hB_pos hfloor hchoose hp hk inputs.projected_nonempty inputs.classes_two
     inputs.class_nonempty inputs.class_bounds inputs.expectedFactors
     inputs.hf_ne_zero inputs.expected_true_factors inputs.product_congr
 
@@ -7342,6 +7375,9 @@ equation, the executable precision equation, and the mathematical
 -/
 theorem factorFast_ne_none_of_canonicalRecoveryInputs_internalCapPositiveAndPrimeLowerBound
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -7355,6 +7391,7 @@ theorem factorFast_ne_none_of_canonicalRecoveryInputs_internalCapPositiveAndPrim
   factorFast_ne_none_of_canonicalRecoveryInputs
     f primeData
     (one_le_factorFastPrecisionCap f)
+    hfloor
     hchoose
     (Hex.choosePrimeData?_prime _ _ hchoose).two_le
     hk inputs
@@ -7385,6 +7422,9 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsA
             (factorFastCapLiftData f primeData)
             rows_pos) =
         BHKS.trueFactorIndicatorLattice trueSupports)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -7431,6 +7471,7 @@ theorem factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsA
   factorFast_ne_none_of_mignottePrecisionCanonicalSupportsExpectedFactorsAtPrecisionForCoeffBound
     f primeData rows_pos trueSupports lattice_eq_indicators
     (one_le_factorFastPrecisionCap f)
+    hfloor
     hchoose hp hk hprojected_nonempty hclasses_two
     hclass_nonempty hclass_bounds expectedFactors hf_ne_zero htrue hproduct
 
@@ -7486,6 +7527,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hp : 2 ≤ (factorFastCapLiftData f primeData).p)
@@ -7534,7 +7578,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
     (projectedRowSpan_eq_trueFactorIndicatorLattice_of_factorFastCapLift_bridge
       f primeData rows_pos localFactorIndex localFactorDegree H trueSupports
       hcap_le C hC_nonneg hC hcut bridge (by omega) hcomparison)
-    hB_pos hchoose hp hk hprojected_nonempty hclasses_two hclass_nonempty
+    hB_pos hfloor hchoose hp hk hprojected_nonempty hclasses_two hclass_nonempty
     hclass_bounds expectedFactors hf_ne_zero htrue hproduct
 
 /--
@@ -7585,6 +7629,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
     (hB_pos : 1 ≤ Hex.factorFastPrecisionCap f)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -7629,7 +7676,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFactorsAtPrecisionForCoeffBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
-    hcap_le C hC_nonneg hC hcut bridge hcomparison hB_pos hchoose
+    hcap_le C hC_nonneg hC hcut bridge hcomparison hB_pos hfloor hchoose
     (Hex.choosePrimeData?_prime _ _ hchoose).two_le
     hk hprojected_nonempty hclasses_two hclass_nonempty hclass_bounds
     expectedFactors hf_ne_zero htrue hproduct
@@ -7677,6 +7724,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
     (hcomparison :
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -7722,7 +7772,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFa
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFactorsAtPrecisionForCoeffBound_internalPrimeLowerBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
     hcap_le C hC_nonneg hC hcut bridge hcomparison
-    (one_le_factorFastPrecisionCap f) hchoose hk hprojected_nonempty
+    (one_le_factorFastPrecisionCap f) hfloor hchoose hk hprojected_nonempty
     hclasses_two hclass_nonempty hclass_bounds expectedFactors hf_ne_zero
     htrue hproduct
 
@@ -7767,6 +7817,9 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalRecoveryTailInputs
     (hcomparison :
       FactorFastCapLiftAnalyticComparison
         f primeData rows_pos localFactorIndex localFactorDegree H)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore = some primeData)
     (hk :
@@ -7780,7 +7833,7 @@ theorem factorFast_ne_none_of_capSeparationBridgeDataCanonicalRecoveryTailInputs
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_capSeparationBridgeDataCanonicalSupportsExpectedFactorsAtPrecisionForCoeffBound_internalCapPositiveAndPrimeLowerBound
     f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
-    hcap_le C hC_nonneg hC hcut bridge hcomparison hchoose hk
+    hcap_le C hC_nonneg hC hcut bridge hcomparison hfloor hchoose hk
     inputs.projected_nonempty inputs.classes_two inputs.class_nonempty
     inputs.class_bounds inputs.expectedFactors inputs.hf_ne_zero
     inputs.expected_true_factors inputs.product_congr
@@ -7796,6 +7849,9 @@ public success theorem under the packaged `choosePrimeData?` witness.
 -/
 theorem factorFast_ne_none_of_factorFastCapSeparationInputsCanonicalRecoveryTailInputs
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -7814,7 +7870,7 @@ theorem factorFast_ne_none_of_factorFastCapSeparationInputsCanonicalRecoveryTail
     f primeData rows_pos trueSupports capInputs.localFactorIndex
     capInputs.localFactorDegree capInputs.H capInputs.cap_le capInputs.C
     capInputs.C_nonneg capInputs.C_le_two capInputs.cut capInputs.bridge
-    capInputs.comparison capInputs.choose_eq capInputs.precision_eq
+    capInputs.comparison hfloor capInputs.choose_eq capInputs.precision_eq
     recoveryInputs
 
 /--
@@ -7836,6 +7892,9 @@ have the same conclusion and consume the same two packaged input records.
 -/
 theorem factorFast_ne_none_of_factorFastCapSeparationInputsAndCanonicalRecoveryInputs_internalCapPositiveAndPrimeLowerBound
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -7851,7 +7910,7 @@ theorem factorFast_ne_none_of_factorFastCapSeparationInputsAndCanonicalRecoveryI
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_canonicalRecoveryInputs_internalCapPositiveAndPrimeLowerBound
-    f primeData capInputs.choose_eq capInputs.precision_eq
+    f primeData hfloor capInputs.choose_eq capInputs.precision_eq
     (CanonicalRecoveryInputs.ofFactorFastCapSeparationInputsAndCanonicalRecoveryTailInputs
       capInputs recoveryInputs)
 
@@ -7885,6 +7944,9 @@ extracted from the closed packages.
 -/
 theorem factorFast_terminates
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -7900,7 +7962,7 @@ theorem factorFast_terminates
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_ne_none_of_factorFastCapSeparationInputsAndCanonicalRecoveryInputs_internalCapPositiveAndPrimeLowerBound
-    f primeData rows_pos trueSupports capInputs recoveryInputs
+    f primeData hfloor rows_pos trueSupports capInputs recoveryInputs
 
 /--
 SPEC D1 named wrapper: once the executable prime search succeeds, select its
@@ -7914,6 +7976,9 @@ prime. They are exactly the mathematical packages consumed by
 -/
 theorem factorFast_terminates_of_choosePrimeData
     (f : Hex.ZPoly)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (hchoose :
       Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore ≠ none)
     (rows_pos :
@@ -7955,7 +8020,7 @@ theorem factorFast_terminates_of_choosePrimeData
       exact False.elim (hchoose hselected)
   | some primeData =>
       exact
-        factorFast_terminates f primeData
+        factorFast_terminates f primeData hfloor
           (rows_pos primeData hselected)
           (trueSupports primeData hselected)
           (capInputs primeData hselected)
@@ -7977,6 +8042,9 @@ precision/prime-choice equations, and the canonical-recovery tail package.
 -/
 theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8078,7 +8146,7 @@ theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndPaperThresh
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBoundsAndPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld
@@ -8114,6 +8182,9 @@ sibling wrapper.
 -/
 theorem factorFast_terminates_ofForwardRecoveryInputsBridgeDataPointwiseAuxiliaryBoundsAndPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (h :
       ForwardRecoveryInputs
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8232,7 +8303,7 @@ theorem factorFast_terminates_ofForwardRecoveryInputsBridgeDataPointwiseAuxiliar
           (factorFastCapLiftData f primeData).p) :
     Hex.factorFast f ≠ none :=
   factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndPaperThreshold
-    f primeData h.rows_pos trueSupports
+    f primeData hfloor h.rows_pos trueSupports
     localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
     C hC_nonneg hC hcut bridge v hin hnot hcld
     vectorSquareBound hvectorSquareBound correctionWeightedBound
@@ -8263,6 +8334,9 @@ the combined product inequality.
 -/
 theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8368,7 +8442,7 @@ theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPap
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld
@@ -8387,6 +8461,9 @@ unprimed variant.
 -/
 theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold'
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8491,7 +8568,7 @@ theorem factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPap
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_terminates_ofBridgeDataPointwiseAuxiliaryBoundsAndFactoredPaperThreshold
-    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    f primeData hfloor rows_pos trueSupports localFactorIndex localFactorDegree H
     hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
     vectorSquareBound hvectorSquareBound correctionWeightedBound
     hcorrectionWeightedBound hauxiliaryBound_nonneg hauxiliaryBound_sq
@@ -8518,6 +8595,9 @@ collapsing to a direct `‖aux‖ ≤ auxiliaryBound` bound.
 -/
 theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8610,7 +8690,7 @@ theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndPaperThre
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataCorrectedAuxiliaryL2normSqAndPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld
@@ -8635,6 +8715,9 @@ than the combined product inequality.
 -/
 theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8731,7 +8814,7 @@ theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredP
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld
@@ -8749,6 +8832,9 @@ obligations.
 -/
 theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndJointPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8842,7 +8928,7 @@ theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndJointPape
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataCorrectedAuxiliaryL2normSqAndJointPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld
@@ -8859,6 +8945,9 @@ unprimed variant.
 -/
 theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold'
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -8954,7 +9043,7 @@ theorem factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredP
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_terminates_ofBridgeDataCorrectedAuxiliaryL2normSqAndFactoredPaperThreshold
-    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    f primeData hfloor rows_pos trueSupports localFactorIndex localFactorDegree H
     hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
     hauxiliaryBound_nonneg hauxiliary_sq_bound
     h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
@@ -8978,6 +9067,9 @@ hypotheses required by the pointwise wrapper.
 -/
 theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9031,7 +9123,7 @@ theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndPaperThreshold
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataAuxiliaryL2normAndPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge hauxiliary hpaper hchoose hprecision)
@@ -9046,6 +9138,9 @@ the way to `Hex.factorFast f ≠ none`.
 -/
 theorem factorFast_terminates_ofBridgeDataC2Auxiliary
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9106,7 +9201,7 @@ theorem factorFast_terminates_ofBridgeDataC2Auxiliary
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataC2Auxiliary
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le hcut
       bridge v hshort haux_eq hdeg hcoreNorm hchoose hprecision)
@@ -9132,6 +9227,9 @@ the combined product inequality.
 -/
 theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9189,7 +9287,7 @@ theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThresho
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge hauxiliary h_coeff h_aux hchoose hprecision)
@@ -9205,6 +9303,9 @@ unprimed variant.
 -/
 theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold'
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9261,7 +9362,7 @@ theorem factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThresho
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_terminates_ofBridgeDataAuxiliaryL2normAndFactoredPaperThreshold
-    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    f primeData hfloor rows_pos trueSupports localFactorIndex localFactorDegree H
     hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge hauxiliary
     h_coeff (by simpa [bhksPaperAuxiliaryFactorReal] using h_aux)
     hchoose hprecision recoveryInputs
@@ -9281,6 +9382,9 @@ auxiliary-l2 upper bound: both are derived internally from the bridge.
 -/
 theorem factorFast_terminates_ofBridgeDataAndPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9369,7 +9473,7 @@ theorem factorFast_terminates_ofBridgeDataAndPaperThreshold
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataAndPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld hpaper hchoose hprecision)
@@ -9392,6 +9496,9 @@ inequality.
 -/
 theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9484,7 +9591,7 @@ theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold
     (recoveryInputs :
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
-  factorFast_terminates f primeData rows_pos trueSupports
+  factorFast_terminates f primeData hfloor rows_pos trueSupports
     (FactorFastCapSeparationInputs.ofBridgeDataAndFactoredPaperThreshold
       localFactorIndex localFactorDegree H hlocalFactorDegree_pos hcap_le
       C hC_nonneg hC hcut bridge v hin hnot hcld h_coeff h_aux hchoose hprecision)
@@ -9500,6 +9607,9 @@ unprimed variant.
 -/
 theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold'
     (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (hfloor :
+      Hex.cldCoeffFloor (Hex.normalizeForFactor f).squareFreeCore ≤
+        Hex.factorFastPrecisionCap f)
     (rows_pos :
       HasPositiveDimension
         (Hex.normalizeForFactor f).squareFreeCore
@@ -9591,7 +9701,7 @@ theorem factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold'
       CanonicalRecoveryTailInputs f primeData rows_pos trueSupports) :
     Hex.factorFast f ≠ none :=
   factorFast_terminates_ofBridgeDataAndFactoredPaperThreshold
-    f primeData rows_pos trueSupports localFactorIndex localFactorDegree H
+    f primeData hfloor rows_pos trueSupports localFactorIndex localFactorDegree H
     hlocalFactorDegree_pos hcap_le C hC_nonneg hC hcut bridge v hin hnot hcld
     h_coeff
     (bhksPaperAuxiliaryFactorReal_eq_product

--- a/progress/20260618T170155Z_b5ac7104.md
+++ b/progress/20260618T170155Z_b5ac7104.md
@@ -1,0 +1,76 @@
+# Progress — 2026-06-18 (session b5ac7104, /once #7951)
+
+## Accomplished
+
+Added the CLD-adequacy acceptance gate to the fast-core loop (#7951) and kept
+the CI-gated `HexBerlekampZassenhausMathlib` layer green.
+
+### Executable gate (`HexBerlekampZassenhaus/Basic.lean`)
+
+- New `cldCoeffFloor core = 2 · max_{j≤n} bhksCoeffBound (toMonic core).monic j`
+  (the CLD column-adequacy floor, prime-independent).
+- `factorFastCoreWithBound`'s `.success factors` branch now accepts only when
+  the schedule coefficient bound `k ≥ cldCoeffFloor core`; below the floor it
+  continues the schedule exactly like the non-success branches (`none` only if
+  the cap `B` is hit first). Termination is unchanged (fuel-structural).
+- Verified the premise numerically (pure-integer `#eval`): for `cldGuardF`,
+  floor `= 32`, cap `= 50803201`, first gated success at `k = 32`
+  (`liftData.k = 3`, modulus `125`), and `2·bhksCoeffBound = 32 < 125`, so
+  `hsep` holds — exactly the issue's predicted shift from `k=4`/`liftData.k=2`.
+- Threaded a `hfloor : cldCoeffFloor core ≤ target` hypothesis through the
+  determinism lemmas whose conclusion asserts acceptance
+  (`factorFastCoreWithBound_isSome_of_recovery_on_schedule`,
+  `_eq_some_of_recovery_on_schedule_of_no_prior_recovery`,
+  `_ne_none_of_recovery_on_schedule`,
+  `factorFast_ne_none_of_core_recovery_on_schedule`). The
+  success→property lemmas (`_product`, `_dvd`, `_some_all_of_recovery`,
+  `_some_classifiedSuccess`) only needed a `by_cases hfloor` in the `.success`
+  case (they stay true and signature-stable).
+- `#guard`s updated: `factorFastCoreWithBound cldGuardF 4` was a unit test at a
+  sub-floor bound, now uses `32`; the `nonMonicCubicRegression` fast-path guard
+  now runs at `factorFastPrecisionCap` (the public bound, which clears the
+  floor — `factor`/`factorFast` outputs are unchanged). The quadratic-shortcut
+  guard (`factorFastFactorsWithBound cldGuardF 4`) is unaffected (degree-2 root
+  path runs before BHKS).
+
+### CI-gated Mathlib repair (`Recovery.lean`, `PartitionRefinement.lean`)
+
+The gate breaks every forward-recovery wrapper whose conclusion asserts the
+loop returns `some _`. Threaded the same `hfloor` open side-condition
+(`cldCoeffFloor (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f`)
+through the whole festooned capstone chain — the `_of_forwardInputs_*`
+wrappers, the `_internalCapPositive*` variants, and all 18
+`factorFast_terminates*` capstones — matching the existing `hno`/`hcap_le`
+open-hypothesis style.
+
+## Decisions
+
+- `hfloor` is carried as an **open side-condition**, not discharged.
+  Discharging it needs `cldCoeffFloor core ≤ factorFastPrecisionCap f`, which
+  relates the monic-transform coefficient bounds of the core to `bhksBound`'s
+  slack — a genuine `toMonic` coefficient-norm analysis with no existing
+  infrastructure, i.e. a separate precision-soundness lemma (same flavor as the
+  still-open `hno`). Threaded rather than proved.
+- The hsep/hthr soundness proofs and the `#7917` assembly named in the issue
+  body are the deliverables of **#7945** (which `depends-on: #7951`). This PR
+  delivers the gate + CI-green, unblocking #7945.
+
+## Current frontier
+
+Gate landed and CI-gated layer green. The gate makes
+`success → k ≥ cldCoeffFloor core` derivable, which is the missing premise for
+#7945's `success → hsep ∧ hthr`.
+
+## Next step
+
+#7945: prove `factorFastCoreWithBound … = some coreFactors → hsep ∧ hthr` at the
+gated success precision (via the new gate + `precisionForCoeffBound_spec`), then
+the #7917 assembly. Separately, a precision-soundness lemma
+`cldCoeffFloor core ≤ factorFastPrecisionCap f` would let the
+`_internalCapPositive*` variants discharge `hfloor` internally and drop it from
+the `factorFast_terminates*` surface.
+
+## Blockers
+
+None for the gate. The `cldCoeffFloor ≤ cap` discharge is deferred (open
+hypothesis), consistent with `hno`.


### PR DESCRIPTION
This PR adds a CLD column-adequacy acceptance gate to the BHKS fast-core loop. A new `cldCoeffFloor core = 2 · max_j bhksCoeffBound (toMonic core).monic j` is the prime-independent coefficient-bound floor at which the lift precision `precisionForCoeffBound k p` clears the BHKS Lemma 5.7 separation `hsep`. `factorFastCoreWithBound`'s `.success` branch now accepts a verified recovery only when the schedule coefficient bound `k ≥ cldCoeffFloor core`; below the floor it continues the schedule exactly like the non-success branches, reporting `none` only if the cap `B` is reached first. The schedule reaches the cap and the cap clears the floor, so acceptance is only deferred, never lost.

Outputs are unchanged. The public `factorFast`/`factor` path runs at `factorFastPrecisionCap`, which clears the floor (for `cldGuardF`: floor `32`, cap `50803201`, first gated success at `k = 32`/`liftData.k = 3`, where `2·bhksCoeffBound = 32 < 5^3 = 125`). Only the schedule index at which a fixture is accepted shifts; the `#guard` fixtures are updated accordingly. The whole `HexBerlekampZassenhausMathlib` layer stays green: the gate adds an acceptance side condition to every forward-recovery determinism wrapper, so a `hfloor : cldCoeffFloor core ≤ target` open hypothesis is threaded through the determinism lemmas and the `factorFast_terminates*` capstone chain, matching the existing `hno`/`hcap_le` open-hypothesis style.

This is the executable keystone post-#7938: it makes `success → k ≥ cldCoeffFloor core` (hence `hsep`) derivable, unblocking https://github.com/kim-em/hex/issues/7945 (`feat: prove fast-core CLD precision-soundness (hsep/hthr) and assemble factorFastCore_irreducible_of_success_given_partition`), which `depends-on` this issue and carries the hsep/hthr soundness proofs and the #7917 assembly. Discharging `hfloor` (proving `cldCoeffFloor core ≤ factorFastPrecisionCap f`) is a `toMonic` coefficient-norm analysis left to that precision-soundness work, like the still-open `hno`.

Closes #7951.

🤖 Prepared with Claude Code