### PR TITLE
feat: derive BHKS hsep/hthr from the CLD-adequacy gate (#7969 D2)

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -1946,6 +1946,97 @@ def supportShortVectorData_of_recoveredLift
   rw [hcoord_eq j]
   exact le_trans (ht j) hcard
 
+/-- The accumulator of a `max`-fold never decreases below its seed. -/
+private theorem foldl_max_ge_init (l : List Nat) (f : Nat → Nat) :
+    ∀ init : Nat, init ≤ l.foldl (fun acc x => max acc (f x)) init := by
+  induction l with
+  | nil => intro init; simp
+  | cons x xs ih =>
+    intro init
+    simp only [List.foldl_cons]
+    exact le_trans (le_max_left init (f x)) (ih (max init (f x)))
+
+/-- Every member of a list is bounded by the running `max`-fold of `f`. -/
+private theorem foldl_max_ge_mem (l : List Nat) (f : Nat → Nat) :
+    ∀ (init j : Nat), j ∈ l → f j ≤ l.foldl (fun acc x => max acc (f x)) init := by
+  induction l with
+  | nil => intro init j hj; simp at hj
+  | cons x xs ih =>
+    intro init j hj
+    simp only [List.foldl_cons]
+    rcases List.mem_cons.mp hj with heq | hj'
+    · rw [heq]
+      exact le_trans (le_max_right init (f x)) (foldl_max_ge_init xs f (max init (f x)))
+    · exact ih (max init (f x)) j hj'
+
+/-- Each per-coordinate BHKS coefficient bound of the monic transform is
+dominated by the CLD column-adequacy floor.  For coordinates past the degree the
+bound is zero (the binomial factor vanishes); for coordinates in range it is one
+of the terms of the `max`-fold that defines `cldCoeffFloor`. -/
+theorem two_mul_bhksCoeffBound_le_cldCoeffFloor (core : Hex.ZPoly) (j : Nat) :
+    2 * Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j ≤ Hex.cldCoeffFloor core := by
+  have key :
+      Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j ≤
+        (List.range ((Hex.ZPoly.toMonic core).monic.degree?.getD 0 + 1)).foldl
+          (fun acc j => max acc (Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j)) 0 := by
+    by_cases hj : j ≤ (Hex.ZPoly.toMonic core).monic.degree?.getD 0
+    · exact foldl_max_ge_mem _
+        (fun j => Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j) 0 j
+        (List.mem_range.mpr (by omega))
+    · have hlt : (Hex.ZPoly.toMonic core).monic.degree?.getD 0 - 1 < j := by omega
+      have hz : Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j = 0 := by
+        simp only [Hex.bhksCoeffBound, Hex.Nat.choose_eq_zero_of_lt hlt, Nat.zero_mul]
+      rw [hz]; exact Nat.zero_le _
+  simp only [Hex.cldCoeffFloor]
+  omega
+
+/-- The BHKS separation `hsep` follows from the CLD-adequacy gate
+`cldCoeffFloor core ≤ k`: at the lift precision `precisionForCoeffBound k p`
+the modulus `p ^ a` clears `2 · bhksCoeffBound (toMonic core).monic j` for every
+coordinate `j`.  This is the input the `_of_toMonicRepresents` recovery lemma
+previously had to assume; post-gate it is derivable. -/
+theorem two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le
+    (core : Hex.ZPoly) (k : Nat) (primeData : Hex.PrimeChoiceData)
+    (hp : 2 ≤ primeData.p) (hfloor : Hex.cldCoeffFloor core ≤ k) :
+    ∀ j, 2 * Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j <
+        (Hex.ZPoly.toMonicLiftData core k primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core k primeData).k := by
+  intro j
+  have hpk : (Hex.ZPoly.toMonicLiftData core k primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hkk : (Hex.ZPoly.toMonicLiftData core k primeData).k
+      = Hex.precisionForCoeffBound k primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  rw [hpk, hkk]
+  have hspec : 2 * k < primeData.p ^ Hex.precisionForCoeffBound k primeData.p :=
+    Hex.precisionForCoeffBound_spec hp k
+  have hfold := two_mul_bhksCoeffBound_le_cldCoeffFloor core j
+  omega
+
+/-- The BHKS cut threshold `hthr` follows from the CLD-adequacy gate
+`cldCoeffFloor core ≤ k`: every per-coordinate Hensel cut threshold stays below
+the lift precision `precisionForCoeffBound k p`.  Companion of
+`two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le`. -/
+theorem bhksCoeffCutThreshold_le_of_cldCoeffFloor_le
+    (core : Hex.ZPoly) (k : Nat) (primeData : Hex.PrimeChoiceData)
+    (hp : 2 ≤ primeData.p) (hfloor : Hex.cldCoeffFloor core ≤ k) :
+    ∀ j, Hex.bhksCoeffCutThreshold (Hex.ZPoly.toMonicLiftData core k primeData).p
+          (Hex.ZPoly.toMonic core).monic j ≤
+        (Hex.ZPoly.toMonicLiftData core k primeData).k := by
+  intro j
+  have hpk : (Hex.ZPoly.toMonicLiftData core k primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hkk : (Hex.ZPoly.toMonicLiftData core k primeData).k
+      = Hex.precisionForCoeffBound k primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  rw [hpk, hkk]
+  unfold Hex.bhksCoeffCutThreshold
+  apply Hex.ceilLogP_le_of_le_pow hp
+  have hspec : 2 * k < primeData.p ^ Hex.precisionForCoeffBound k primeData.p :=
+    Hex.precisionForCoeffBound_spec hp k
+  have hfold := two_mul_bhksCoeffBound_le_cldCoeffFloor core j
+  omega
+
 /--
 Package the non-monic fast path's monic-coordinate recovery witness as BHKS
 short-vector data for the corresponding support.

--- a/progress/20260618_193135_238788e0.md
+++ b/progress/20260618_193135_238788e0.md
@@ -1,0 +1,59 @@
+# Session 238788e0 — feature (#7969, partial)
+
+## Accomplished
+
+Landed **deliverable 2** of #7969 ("success → hsep ∧ hthr"): the BHKS
+separation and cut-threshold hypotheses are now *derived* from the
+CLD-adequacy gate `cldCoeffFloor core ≤ k`, no longer assumed.
+
+New lemmas in `HexBerlekampZassenhausMathlib/CLDColumnBound.lean`
+(namespace `HexBerlekampZassenhausMathlib.BHKS`):
+
+- `two_mul_bhksCoeffBound_le_cldCoeffFloor core j` — every per-coordinate
+  `2 · bhksCoeffBound (toMonic core).monic j ≤ cldCoeffFloor core`. For
+  `j ≤ deg` it is a term of the defining `max`-fold (helpers
+  `foldl_max_ge_init` / `foldl_max_ge_mem`); for `j > deg` the binomial
+  factor `Hex.Nat.choose (n-1) j` vanishes
+  (`Hex.Nat.choose_eq_zero_of_lt`).
+- `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le` — `hsep` in the
+  canonical `toMonicLiftData` form, via `precisionForCoeffBound_spec`
+  (`2k < p ^ precisionForCoeffBound k p`). Chain:
+  `2·bhksCoeffBound ≤ cldCoeffFloor ≤ k ≤ 2k < p^a`.
+- `bhksCoeffCutThreshold_le_of_cldCoeffFloor_le` — `hthr`, via
+  `ceilLogP_le_of_le_pow` with `2·bhksCoeffBound+1 ≤ 2k+1 ≤ p^a`.
+
+These plug directly into `supportShortVectorData_of_toMonicRepresents`
+(CLDColumnBound.lean:1957), whose `hsep`/`hthr` parameters match the two
+new lemmas' conclusions verbatim.
+
+`lake build HexBerlekampZassenhausMathlib` completes (3790 jobs, zero
+errors). Additions are `sorry`/`axiom`/`native_decide`-free.
+
+## Current frontier
+
+Two deliverables of #7969 remain, decomposed into sub-issues:
+
+- **D1 (`hfloor` discharge):** prove
+  `cldCoeffFloor (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f`.
+  This is the `toMonic` coefficient-norm vs `bhksBound`-slack analysis the
+  boundary skill flags as having *no existing infra* — relating the monic
+  transform of a factor of `f` back to `bhksBound f`. Independent of D2/D3
+  (it threads through the `factorFast ≠ none` determinism chain, not the
+  irreducibility endpoint). Multi-session.
+- **D3 (#7917 assembly):** instantiate
+  `factorFastCore_irreducible_of_monicRecoveredLift`
+  (PartitionRefinement.lean:764) / the line-716 endpoint, supplying the new
+  `hsep`/`hthr` and discharging the many structural side conditions
+  (`hindicators`, `hcandidates`, the `recoveredLift_subtypeFamily` lift,
+  `hf_lc`, `hfactor_monic`, `hfac`, `hsize`) from `success`, leaving only
+  `hpartition`. Intricate; depends on D2 (now landed).
+
+## Next step
+
+A successor claims the D1 sub-issue (foundational, no infra) or the D3
+sub-issue (assembly, now unblocked by D2's hsep/hthr lemmas).
+
+## Blockers
+
+None for D2 (landed). D1 needs new coefficient-norm infrastructure; D3 is
+a large mechanical assembly over the deep BHKS side conditions.


### PR DESCRIPTION
This PR derives the BHKS separation (`hsep`) and cut-threshold (`hthr`) hypotheses from the CLD-adequacy gate `cldCoeffFloor core ≤ k` rather than assuming them, landing deliverable 2 of #7969. `two_mul_bhksCoeffBound_le_cldCoeffFloor` bounds each per-coordinate `2·bhksCoeffBound (toMonic core).monic j` by `cldCoeffFloor core` — a term of the defining `max`-fold for `j ≤ deg`, and zero for `j > deg` via the vanishing binomial. `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le` and `bhksCoeffCutThreshold_le_of_cldCoeffFloor_le` then conclude `hsep`/`hthr` in the canonical `toMonicLiftData` form through `precisionForCoeffBound_spec` and `ceilLogP_le_of_le_pow`, matching the `hsep`/`hthr` parameters of `supportShortVectorData_of_toMonicRepresents` verbatim.

This is a partial completion of the three-deliverable #7969. The remaining two are decomposed into #7978 (discharge `hfloor`, the no-infra `toMonic` coefficient-norm analysis) and #7979 (the #7917 irreducibility assembly, now unblocked by these `hsep`/`hthr` lemmas).

🤖 Prepared with Claude Code