### PR TITLE
doc: record floor-gate-vs-cap bad-vector-exclusion gap (#7985 diagnosis)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -373,6 +373,42 @@ Two traps when touching the gate:
   `simp [hclass, hfloor] at hfast` when reducing it inside a *hypothesis*, which
   is robust to the instance gap).
 
+### The floor gate discharges `cut` (hsep/hthr) but NOT the bad-vector exclusion — `L'=W` is still cap-only (#7985)
+
+A "success ⟹ recovery package / `EquivalenceClassRecoveryHypotheses` /
+`ForwardRecoveryInputs` producer" directive (the #7917 prerequisite) looks like
+a thin assembly after #7980 landed hsep/hthr, but is **not** constructible.
+`factorFastCoreWithBound_some_indicatorCandidates` (`Basic.lean:11785`) already
+gives `k'`, `hrows`, `hcandidates`, non-degeneracy, and product=core from loop
+success with no extra hypotheses — so `hcandidates`/`hsize` are free. The whole
+deliverable collapses to the single field `hindicators`
+(`equivalenceClassIndicatorsOfLiftData … = expectedIndicatorArrayOfSupports
+trueSupports`), whose only route
+(`equivalenceClassIndicatorsOfLiftData_eq_expectedIndicatorArrayOfSupports`,
+`Recovery.lean:572`) demands `lattice_eq_indicators` = the BHKS Lemma 3.3
+equality `L'=W`. That needs `SeparationHypotheses.no_projected_not_indicator`
+(bad-vector exclusion), whose **only** producer
+(`no_projected_not_indicator_of_factorFastPrecisionCap_le`,
+`TerminationBound.lean:508`) requires precision `≥ factorFastPrecisionCap` **and**
+the still-open `BadVectorBridgeData` (BHKS Lemma 3.2 resultant divisibility).
+Crucially: the #7951 gate forces only `k' ≥ cldCoeffFloor core`, which feeds
+**only** the CLD column adequacy (`cut`/hsep/hthr, in `CLDColumnBound.lean`) —
+`cldCoeffFloor` appears in **zero** lines of `BadVector.lean`/`Lattice.lean`/
+`TerminationBound.lean`, all of which key the exclusion on
+`factorFastPrecisionCap … ≤ a`. And floor ≪ cap by orders of magnitude
+(`cldGuardF`: floor=32, cap=50803201, both pure-integer `#eval`-checkable), so
+the cap producer cannot fire at the first-success precision. The `on_schedule`
+`hno` route is *worse than hard — it is false*: the gated loop returns at the
+first success `k'=floor ≪ cap`, so a non-cap scheduled precision recovers,
+contradicting `hno` (which fixes target=cap). There is also no function
+producing a genuine `trueSupports` from `core`/success; inverting the indicator
+array gives junk that the downstream #7917 `hpartition`/`hfac`/`lift` (all over
+the *same* `trueSupports`) cannot consume. So **diagnose and skip** any such
+producer issue: the genuine prerequisite is either a floor-keyed bad-vector
+exclusion (push the `TerminationBound.lean` cap argument down to the CLD floor)
+or a `BadVectorBridgeData` producer from core facts — soundness substrate, not a
+thin producer. (#7985 skipped on exactly this.)
+
 **#7938 fixed only the *cap*, not the success precision — the trap persists
 (#7945).** #7938 removed the *caller-side* double `precisionForCoeffBound` (the
 public path now passes the raw cap `B = factorFastPrecisionCap core`), so the

--- a/progress/20260618_220241_9d3772a4.md
+++ b/progress/20260618_220241_9d3772a4.md
@@ -1,0 +1,41 @@
+# Session 9d3772a4 — #7985 premise-check (BHKS precision-soundness producer)
+
+## Accomplished
+- Premise-checked #7985 ("success ⟹ recovery package producer") against the
+  tree. Confirmed blocker 1 (D2 hsep/hthr) resolved by #7980, but the producer
+  itself is **not constructible** and the missing lemma is provably out of
+  reach of the post-#7951 gate. Posted a full diagnosis and `coordination skip`
+  → replan.
+
+## Key finding (chain of obstruction)
+- `factorFastCoreWithBound_some_indicatorCandidates` (Basic.lean:11785) already
+  yields `k'`, `hrows`, `hcandidates`, non-degeneracy, product=core from loop
+  success. The producer reduces solely to `hindicators`
+  (`equivalenceClassIndicatorsOfLiftData … = expectedIndicatorArrayOfSupports
+  trueSupports`).
+- `hindicators` → `lattice_eq_indicators` (`L'=W`) → `SeparationHypotheses.
+  no_projected_not_indicator` (bad-vector exclusion) → only producer
+  `no_projected_not_indicator_of_factorFastPrecisionCap_le`
+  (TerminationBound.lean:508), which needs `factorFastPrecisionCap ≤ a` (cap)
+  AND the still-open `BadVectorBridgeData` (BHKS Lemma 3.2 resultant
+  divisibility).
+- Numbers (pure-integer #eval, cldGuardF): floor `cldCoeffFloor=32`,
+  cap `factorFastPrecisionCap=50803201`. Gate gives k'≥32 ≪ cap. `cldCoeffFloor`
+  appears in 0 lines of BadVector/Lattice/TerminationBound — it feeds only the
+  CLD column adequacy (`cut`), never the bad-vector exclusion.
+- Alternative 1 (`hno`) is false for the gated run: loop returns at first
+  success k'=32 ≪ cap, so a non-cap scheduled precision recovers, contradicting
+  `hno` when target=cap.
+
+## Current frontier
+- The real prerequisite is a floor-keyed bad-vector exclusion (push the cap
+  argument down to the CLD-adequacy floor) OR a `BadVectorBridgeData` producer
+  from core facts. Both are soundness-substrate work, not a thin producer.
+
+## Next step
+- Replan #7985 into one of the two soundness shapes above.
+
+## Blockers
+- BHKS `L'=W` soundness at sub-cap (first-success) precision is absent from the
+  tree; cannot be produced without sorrying/weakening (declined per project
+  rules).


### PR DESCRIPTION
This PR records, in the `hex-lean-mathlib-boundary` skill, the premise-check diagnosis of https://github.com/kim-em/hex/issues/7985 (feat: BHKS precision-soundness producer — loop success yields the recovery package): after #7980 landed the D2 hsep/hthr lemmas, a "success ⟹ recovery package" producer still cannot be constructed, because the #7951 floor gate discharges only the CLD column adequacy (the `cut`/hsep/hthr half of separation) while the bad-vector exclusion (`no_projected_not_indicator`, the other half of `L'=W`) is keyed entirely on `factorFastPrecisionCap` in `TerminationBound.lean`, and the gated first-success precision (`cldGuardF`: floor=32) sits far below the cap (50803201). The note pinpoints where the post-gate gap lives so the next agent claiming this shape diagnoses and skips rather than re-tracing the multi-file chain. The issue is marked `replan` with the full diagnosis.

No Lean source changes; documentation only.

🤖 Prepared with Claude Code
