### PR TITLE
feat: closed primitive headline for nonzero factor inputs

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -17669,6 +17669,101 @@ theorem factorSlowTrialFactorsWithBound_polyProduct
           (exhaustiveIntegerTrialCoreFactorsWithBound_polyProduct
             (normalizeForFactor f).squareFreeCore B)
 
+/-- Every member of a primitive ordered array product is itself primitive: each
+member divides the product (`dvd_polyProduct_toArray_of_mem`), and a left
+divisor of a primitive `ZPoly` is primitive (`ZPoly_primitive_left_of_mul`). -/
+private theorem polyProduct_mem_primitive_of_primitive
+    (factors : Array ZPoly)
+    (h : ZPoly.Primitive (Array.polyProduct factors)) :
+    ∀ g ∈ factors.toList, ZPoly.Primitive g := by
+  intro g hg
+  obtain ⟨c, hc⟩ := dvd_polyProduct_toArray_of_mem factors.toList hg
+  rw [show factors.toList.toArray = factors from by simp] at hc
+  rw [hc] at h
+  exact ZPoly_primitive_left_of_mul g c h
+
+/-- A product reconstructing a nonzero `f` from its signed content scalar is
+primitive. Content is multiplicative, so `content f = content f * content P`
+(the scalar constant has content `content f`); `content f ≠ 0` then forces
+`content P = 1`. -/
+private theorem primitive_of_signedContentScalar_mul_eq
+    (f P : ZPoly) (hf : f ≠ 0)
+    (h : DensePoly.C (signedContentScalar f) * P = f) :
+    ZPoly.Primitive P := by
+  have hnonneg : (0 : Int) ≤ ZPoly.content f := by
+    show 0 ≤ DensePoly.content f
+    rw [DensePoly.content]
+    exact Int.natCast_nonneg _
+  have hcontent_ne : ZPoly.content f ≠ 0 := by
+    intro hc
+    apply hf
+    have hr := ZPoly.content_mul_primitivePart f
+    rw [hc, DensePoly.scale_zero_left_semiring] at hr
+    exact hr.symm
+  have hCc : ZPoly.content (DensePoly.C (signedContentScalar f)) = ZPoly.content f := by
+    have h1 : ZPoly.content (DensePoly.C (signedContentScalar f))
+        = Int.ofNat (signedContentScalar f).natAbs := DensePoly.content_C _
+    rw [h1]
+    have hnat : (signedContentScalar f).natAbs = (ZPoly.content f).natAbs := by
+      unfold signedContentScalar
+      rw [if_neg hf]
+      by_cases hl : DensePoly.leadingCoeff f < 0
+      · rw [if_pos hl, Int.natAbs_neg]
+      · rw [if_neg hl]
+    rw [hnat]
+    exact Int.natAbs_of_nonneg hnonneg
+  have key : ZPoly.content f = ZPoly.content f * ZPoly.content P := by
+    have step : ZPoly.content (DensePoly.C (signedContentScalar f) * P)
+        = ZPoly.content f * ZPoly.content P := by
+      rw [ZPoly.content_mul, hCc]
+    rw [h] at step
+    exact step
+  have hzero : ZPoly.content f * (ZPoly.content P - 1) = 0 := by
+    rw [Int.mul_sub, Int.mul_one, ← key, Int.sub_self]
+  rcases Int.mul_eq_zero.mp hzero with hc | hc
+  · exact absurd hc hcontent_ne
+  · show ZPoly.content P = 1
+    omega
+
+/-- The default-precision raw factor array selected by the dispatch is primitive
+entrywise, for nonzero `f`. This is the closed discharge of the raw-source
+primitivity hypothesis threaded through `factor_entries_primitive`: the array
+product reconstructs `f` from its signed content scalar
+(`factor*FactorsWithBound_polyProduct*` per branch), so the product is primitive
+and hence so is every member. -/
+theorem factor_chosen_raw_primitive_of_ne_zero
+    (f : ZPoly) (hf : f ≠ 0) :
+    ∀ rawFactors : Array ZPoly,
+      (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
+          some rawFactors ∨
+        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
+          factorSlowModularFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
+            some rawFactors) ∨
+        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
+          factorSlowModularWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
+          rawFactors =
+            factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) →
+      ∀ raw ∈ rawFactors.toList, ZPoly.Primitive raw := by
+  intro rawFactors hsource
+  have hprod : DensePoly.C (signedContentScalar f) *
+      Array.polyProduct rawFactors = f := by
+    rcases hsource with hfast | ⟨_, hmod⟩ | ⟨_, _, htrial⟩
+    · exact factorFastFactorsWithBound_polyProduct_of_some hfast
+    · exact factorSlowModularFactorsWithBound_polyProduct_of_some hmod
+    · subst htrial
+      exact factorSlowTrialFactorsWithBound_polyProduct f _
+  have hprim : ZPoly.Primitive (Array.polyProduct rawFactors) :=
+    primitive_of_signedContentScalar_mul_eq f (Array.polyProduct rawFactors) hf hprod
+  exact polyProduct_mem_primitive_of_primitive rawFactors hprim
+
+/-- Every recorded entry of the default factorization of a nonzero `f` is
+primitive, with no raw-source hypothesis: it is discharged internally by
+`factor_chosen_raw_primitive_of_ne_zero`. -/
+theorem factor_entries_primitive_of_ne_zero
+    (f : ZPoly) (hf : f ≠ 0) :
+    ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 :=
+  factor_entries_primitive f (factor_chosen_raw_primitive_of_ne_zero f hf)
+
 private theorem factorSlowTrialWithBound_product_of_all_recorded_normalized
     (f : ZPoly) (B : Nat)
     (hnormalized :

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -149,6 +149,40 @@ theorem factor_headline_contract_core_with_primitive
     exact Hex.factor_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
+Closed primitive-strengthened headline for the default executable factorization
+of a nonzero input.
+
+This is the same bundle as `factor_headline_contract_core_with_primitive` but
+with the raw-source primitivity hypothesis `h_raw` discharged internally via
+`Hex.factor_chosen_raw_primitive_of_ne_zero`, so callers no longer supply it:
+product preservation, primitive plus Mathlib irreducibility per recorded factor,
+positive multiplicities, the syntactic distinct-key clause, and the
+signed-content scalar convention.
+
+The `f ≠ 0` side condition is essential rather than incidental. For `f = 0` the
+square-free core is `0` (content `0`, hence not primitive), so the raw-source
+primitivity statement quantified over the dispatch is literally false; the
+factorization of `0` is itself degenerate (`scalar = 0`, product `0`).
+-/
+theorem factor_headline_primitive (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.Factorization.product (Hex.factor f) = f ∧
+      (∀ entry ∈ (Hex.factor f).factors,
+        Hex.ZPoly.Primitive entry.1 ∧
+          Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
+      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
+        (Hex.factor f).factors.toList ∧
+      (Hex.factor f).scalar =
+        if f = 0 then
+          0
+        else if Hex.DensePoly.leadingCoeff f < 0 then
+          -Hex.ZPoly.content f
+        else
+          Hex.ZPoly.content f :=
+  factor_headline_contract_core_with_primitive f
+    (Hex.factor_chosen_raw_primitive_of_ne_zero f hf)
+
+/--
 The sign-normalization side condition for the default executable factorization:
 every recorded polynomial factor is fixed by `normalizeFactorSign`. This is the
 `hψ_norm` clause that uniqueness/checker callers would otherwise reconstruct from

--- a/progress/20260619T005536Z_44c3c47f.md
+++ b/progress/20260619T005536Z_44c3c47f.md
@@ -1,0 +1,85 @@
+# Progress — 2026-06-19 (session 44c3c47f, /work → /feature #6867)
+
+## Accomplished
+
+Closed the raw-factor **primitivity** package for the default executable
+factorization (#6867), discharging the `h_raw` raw-source hypothesis that had
+been threaded through `factor_entries_primitive` and
+`factor_headline_contract_core_with_primitive`.
+
+### Uniform argument (not per-branch)
+
+The directive framed this as a per-branch package. The Explore pass suggested
+that route was large (no primitivity lemmas exist for `quadraticIntegerRootFactors?`,
+`exhaustiveIntegerTrialCoreFactorsWithBound`, `factorFastCoreWithBound`, or the
+reassembly prefix arrays). A **uniform content/Gauss argument** collapses it:
+
+- Each branch already proves `C (signedContentScalar f) * polyProduct rawFactors = f`
+  (`factorFastFactorsWithBound_polyProduct_of_some`,
+  `factorSlowModularFactorsWithBound_polyProduct_of_some`,
+  `factorSlowTrialFactorsWithBound_polyProduct`).
+- So `polyProduct rawFactors` is `f` with its signed content divided out, hence
+  primitive: content is multiplicative (`ZPoly.content_mul`), the scalar constant
+  has content `content f`, and `content f ≠ 0` forces `content (polyProduct) = 1`.
+- A left divisor of a primitive `ZPoly` is primitive
+  (`ZPoly_primitive_left_of_mul`), and every array member divides the product
+  (`dvd_polyProduct_toArray_of_mem`), so every raw factor is primitive.
+
+### New declarations
+
+- `HexBerlekampZassenhaus/Basic.lean` (executable, Mathlib-free):
+  `polyProduct_mem_primitive_of_primitive`,
+  `primitive_of_signedContentScalar_mul_eq`,
+  `factor_chosen_raw_primitive_of_ne_zero` (the closed raw package),
+  `factor_entries_primitive_of_ne_zero`.
+- `HexBerlekampZassenhausMathlib/FactorSoundness.lean` (Mathlib bridge):
+  `factor_headline_primitive` — the primitive-strengthened headline bundle with
+  no `h_raw` parameter, packaging product preservation, primitive + Mathlib
+  irreducibility per entry, positive multiplicities, the syntactic distinct-key
+  clause, and the signed-content scalar convention.
+
+### `f ≠ 0` is necessary, not a shortcut
+
+The directive implicitly assumed `h_raw` is dischargeable unconditionally. It is
+**not**: for `f = 0` the square-free core is `0` (content `0`, not primitive), so
+the raw-source primitivity statement quantified over the dispatch is literally
+false. The factorization of `0` is itself degenerate (`scalar = 0`, product `0`).
+The new package and wrapper therefore carry an `f ≠ 0` hypothesis (matching the
+existing `factor_unique_of_product`, which already requires `hf_ne`). All
+existing theorem names are preserved; only new declarations were added.
+
+## Verification
+
+- `lake build HexBerlekampZassenhaus` → 491 jobs, success, no error/warning/sorry
+  in the added code.
+- `lake build HexBerlekampZassenhausMathlib` → 3790 jobs, `Build completed
+  successfully`.
+- `python3 scripts/check_dag.py` → exit 0.
+- `git diff --check` clean; no added-line `sorry`/`axiom`/`native_decide`/
+  `TODO`/`FIXME`.
+- The single remaining `sorry` in `FactorSoundness.lean` is the pre-existing
+  line-18 `factor_irreducible_of_nonUnit` (tracked by #6672), explicitly out of
+  scope for #6867.
+
+## Current frontier
+
+`factor_headline_primitive` is the closed primitive headline for nonzero inputs.
+Its irreducibility clause still routes through `factor_polynomialIrreducible_of_nonUnit`,
+whose `sorry` is the open #6672 capstone.
+
+## Next step
+
+#6672: assemble `factor_irreducible_of_nonUnit` (the remaining headline sorry).
+A truly unconditional (no `f ≠ 0`) primitive headline would additionally need
+`(factor 0).factors = #[]` (the recorded factors of `0` are empty after the
+`shouldRecordPolynomialFactor` filter); not pursued here since the `f = 0` case
+is degenerate and the standard API already gates on nonzero.
+
+## Blockers
+
+None for this issue. The directive's implicit `h_raw`-unconditional premise was
+unsound at `f = 0`; handled with the necessary `f ≠ 0` hypothesis rather than a
+workaround.
+
+Note: worktree carries a pre-existing unrelated `.claude/skills/agent-worker-flow/SKILL.md`
+modification from before this session; not touched or staged.


### PR DESCRIPTION
Closes #6867

This PR closes the raw-factor primitivity package for the default executable factorization, discharging the `h_raw` raw-source hypothesis that `factor_entries_primitive` and `factor_headline_contract_core_with_primitive` previously threaded through to their callers, and adds a public primitive headline wrapper that no longer takes `h_raw`.

The discharge is uniform across all three dispatch branches rather than per-branch. Each branch already proves `C (signedContentScalar f) * polyProduct rawFactors = f`, so the raw-factor product is `f` with its signed content divided out and is therefore primitive (content is multiplicative, the scalar constant has content `content f`, and `content f != 0` forces the product's content to `1`). A left divisor of a primitive `ZPoly` is primitive and every array member divides the product, so every raw factor is primitive. New executable helpers `polyProduct_mem_primitive_of_primitive` and `primitive_of_signedContentScalar_mul_eq` support `factor_chosen_raw_primitive_of_ne_zero` and `factor_entries_primitive_of_ne_zero`; the Mathlib-side `factor_headline_primitive` packages the full bundle (product preservation, primitive plus Mathlib irreducibility per entry, positive multiplicities, distinct-key clause, signed-content scalar clause).

The new package and wrapper carry an `f != 0` hypothesis, which is necessary rather than incidental: for `f = 0` the square-free core is `0` (content `0`, not primitive), so the raw-source primitivity statement quantified over the dispatch is literally false, and the factorization of `0` is degenerate (`scalar = 0`, product `0`). The directive's implicit assumption that `h_raw` is dischargeable unconditionally does not hold; the `f != 0` form matches the existing `factor_unique_of_product`, which already requires nonzero input. All existing theorem names are preserved and `factor_headline_contract_core` remains available; only new declarations were added. The irreducibility clause of the headline still routes through the pre-existing `factor_polynomialIrreducible_of_nonUnit` sorry, tracked separately by https://github.com/kim-em/hex/issues/6672 and out of scope here.

Supports HO-1 directive https://github.com/kim-em/hex/issues/2564 headline clause 2.

🤖 Prepared with Claude Code
