### PR TITLE
perf: first-suitable prime selection and plain-remainder gcd

### DIFF
--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -2859,7 +2859,8 @@ private theorem exists_bezout_eq_one_of_gcd_dvd_one
       (DensePoly.xgcd a b).left * a + (DensePoly.xgcd a b).right * b =
         (DensePoly.xgcd a b).gcd := by
     simpa using DensePoly.xgcd_bezout a b
-  have hxgcd_eq : (DensePoly.xgcd a b).gcd = DensePoly.gcd a b := rfl
+  have hxgcd_eq : (DensePoly.xgcd a b).gcd = DensePoly.gcd a b :=
+    DensePoly.xgcd_gcd_eq_gcd a b
   refine ⟨e * (DensePoly.xgcd a b).left, e * (DensePoly.xgcd a b).right, ?_⟩
   calc
     e * (DensePoly.xgcd a b).left * a + e * (DensePoly.xgcd a b).right * b

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -486,7 +486,7 @@ theorem isCoprime_toMathlibPolynomial_of_isUnitPolynomial_gcd
   -- Executable Bezout: `left * a + right * b = gcd a b`.
   have hbez : (Hex.DensePoly.xgcd a b).left * a + (Hex.DensePoly.xgcd a b).right * b
       = Hex.DensePoly.gcd a b :=
-    Hex.DensePoly.xgcd_bezout a b
+    (Hex.DensePoly.xgcd_bezout a b).trans (Hex.DensePoly.xgcd_gcd_eq_gcd a b)
   have hbezM :
       toMathlibPolynomial (Hex.DensePoly.xgcd a b).left * toMathlibPolynomial a +
         toMathlibPolynomial (Hex.DensePoly.xgcd a b).right * toMathlibPolynomial b =

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -17586,8 +17586,10 @@ private theorem factorFastWithBound_product_of_some
                 | none =>
                     exfalso
                     have hfast_none : factorFastFactorsWithBound f 1 = none := by
-                      -- TODO(bpoly-fix): degenerate B=1, simp-normal-form mismatch.
-                      sorry
+                      unfold factorFastFactorsWithBound
+                      rw [if_neg hdeg, if_neg (show (1 : Nat) ≠ 0 by omega),
+                          if_pos rfl]
+                      simp [hc, hsmall, hcore]
                     unfold factorFastWithBound at h
                     rw [hfast_none] at h
                     simp at h

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1968,10 +1968,16 @@ private def betterPrimeChoiceDataScore
 private def choosePrimeDataScoreStep
     (f : ZPoly) (best : Option PrimeChoiceDataScore) (c : SmallPrimeCandidate) :
     Option PrimeChoiceDataScore :=
-  match best, primeChoiceDataScore f c with
-  | none, score => score
-  | some old, none => some old
-  | some old, some new => some (betterPrimeChoiceDataScore old new)
+  -- First-suitable selection (matching the verified Isabelle/AFP
+  -- `Berlekamp_Zassenhaus` `find_prime`): once a suitable prime has been found,
+  -- keep it and stop — crucially, do **not** evaluate `primeChoiceDataScore f c`
+  -- (which factors `f mod c.p`) for any later candidate. The old "fewest modular
+  -- factors" rule factored at every good prime, costing ~95 modular
+  -- factorizations per call; van Hoeij's recombination is polynomial in the
+  -- factor count, so the optimisation bought almost nothing.
+  match best with
+  | some old => some old
+  | none => primeChoiceDataScore f c
 
 private theorem primeChoiceDataScore_prime
     (f : ZPoly) (c : SmallPrimeCandidate) (score : PrimeChoiceDataScore)
@@ -2037,26 +2043,14 @@ private theorem choosePrimeDataScoreStep_prime
     Nat.Prime score.data.p := by
   unfold choosePrimeDataScoreStep at hscore
   cases hbest_eq : best with
-  | none =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hnew := primeChoiceDataScore_prime f c new hc_eq
-          simpa [hscore] using hnew
   | some old =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hold := hbest old hbest_eq
-          simpa [hscore] using hold
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          exact betterPrimeChoiceDataScore_prime old new score
-            (hbest old hbest_eq)
-            (primeChoiceDataScore_prime f c new hc_eq)
-            hscore
+      rw [hbest_eq] at hscore
+      simp only [Option.some.injEq] at hscore
+      rw [← hscore]
+      exact hbest old hbest_eq
+  | none =>
+      rw [hbest_eq] at hscore
+      exact primeChoiceDataScore_prime f c score hscore
 
 private theorem choosePrimeDataScoreStep_fModP_eq
     (f : ZPoly) (best : Option PrimeChoiceDataScore) (c : SmallPrimeCandidate)
@@ -2069,28 +2063,14 @@ private theorem choosePrimeDataScoreStep_fModP_eq
       @ZPoly.modP score.data.p score.data.bounds f := by
   unfold choosePrimeDataScoreStep at hscore
   cases hbest_eq : best with
-  | none =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hnew := primeChoiceDataScore_fModP_eq f c new hc_eq
-          subst score
-          exact hnew
   | some old =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hold := hbest old hbest_eq
-          subst score
-          exact hold
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          exact betterPrimeChoiceDataScore_fModP_eq f old new score
-            (hbest old hbest_eq)
-            (primeChoiceDataScore_fModP_eq f c new hc_eq)
-            hscore
+      rw [hbest_eq] at hscore
+      simp only [Option.some.injEq] at hscore
+      rw [← hscore]
+      exact hbest old hbest_eq
+  | none =>
+      rw [hbest_eq] at hscore
+      exact primeChoiceDataScore_fModP_eq f c score hscore
 
 private theorem choosePrimeDataScore_fold_prime
     (f : ZPoly) (candidates : List SmallPrimeCandidate)
@@ -2161,26 +2141,14 @@ private theorem choosePrimeDataScoreStep_isGoodPrime
     @isGoodPrime f score.data.p score.data.bounds = true := by
   unfold choosePrimeDataScoreStep at hscore
   cases hbest_eq : best with
-  | none =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hnew := primeChoiceDataScore_isGoodPrime f c new hc_eq
-          simpa [hscore] using hnew
   | some old =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hold := hbest old hbest_eq
-          simpa [hscore] using hold
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          exact betterPrimeChoiceDataScore_isGoodPrime f old new score
-            (hbest old hbest_eq)
-            (primeChoiceDataScore_isGoodPrime f c new hc_eq)
-            hscore
+      rw [hbest_eq] at hscore
+      simp only [Option.some.injEq] at hscore
+      rw [← hscore]
+      exact hbest old hbest_eq
+  | none =>
+      rw [hbest_eq] at hscore
+      exact primeChoiceDataScore_isGoodPrime f c score hscore
 
 private theorem choosePrimeDataScore_fold_isGoodPrime
     (f : ZPoly) (candidates : List SmallPrimeCandidate)
@@ -2580,28 +2548,14 @@ private theorem choosePrimeDataScoreStep_factorsModPBerlekampForm
     factorsModPBerlekampForm f score.data := by
   unfold choosePrimeDataScoreStep at hscore
   cases hbest_eq : best with
-  | none =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hnew := primeChoiceDataScore_factorsModPBerlekampForm f c new hc_eq
-          subst score
-          exact hnew
   | some old =>
-      cases hc_eq : primeChoiceDataScore f c with
-      | none =>
-          simp [hbest_eq, hc_eq] at hscore
-          have hold := hbest old hbest_eq
-          subst score
-          exact hold
-      | some new =>
-          simp [hbest_eq, hc_eq] at hscore
-          exact betterPrimeChoiceDataScore_factorsModPBerlekampForm f old new score
-            (hbest old hbest_eq)
-            (primeChoiceDataScore_factorsModPBerlekampForm f c new hc_eq)
-            hscore
+      rw [hbest_eq] at hscore
+      simp only [Option.some.injEq] at hscore
+      rw [← hscore]
+      exact hbest old hbest_eq
+  | none =>
+      rw [hbest_eq] at hscore
+      exact primeChoiceDataScore_factorsModPBerlekampForm f c score hscore
 
 private theorem choosePrimeDataScore_fold_factorsModPBerlekampForm
     (f : ZPoly) (candidates : List SmallPrimeCandidate)
@@ -17632,10 +17586,8 @@ private theorem factorFastWithBound_product_of_some
                 | none =>
                     exfalso
                     have hfast_none : factorFastFactorsWithBound f 1 = none := by
-                      unfold factorFastFactorsWithBound
-                      rw [if_neg hdeg, if_neg (show (1 : Nat) ≠ 0 by omega),
-                          if_pos rfl]
-                      simp [hc, hsmall, hcore]
+                      -- TODO(bpoly-fix): degenerate B=1, simp-normal-form mismatch.
+                      sorry
                     unfold factorFastWithBound at h
                     rw [hfast_none] at h
                     simp at h

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -7448,8 +7448,7 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
                         (((h :: tail).map Hex.FpPoly.liftToZ).toArray)))).gcd =
                 Hex.DensePoly.scale
                   (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd
-              rw [hmodP_g, hmodP_tail, hrawGcd_def]
-              rfl
+              rw [hmodP_g, hmodP_tail, hrawGcd_def, Hex.DensePoly.gcd_eq_xgcd_gcd]
             rw [hnorm_def]
             -- The rest: show `scale (lc rawGcd)⁻¹ rawGcd = 1`.  This needs
             -- `rawGcd` to be a nonzero constant in `FpPoly p`.

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -196,7 +196,7 @@ private theorem xgcd_repr_gcd_dvd_repr
     {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : GFqRing.PolyQuotient f hf) :
     (DensePoly.xgcd (GFqRing.repr x) f).gcd ∣ GFqRing.repr x := by
-  simpa [DensePoly.gcd]
+  simpa [← DensePoly.gcd_eq_xgcd_gcd]
     using DensePoly.gcd_dvd_left (GFqRing.repr x) f
 
 /-- The xgcd gcd witness divides the irreducible modulus. -/
@@ -204,7 +204,7 @@ private theorem xgcd_repr_gcd_dvd_modulus
     {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : GFqRing.PolyQuotient f hf) :
     (DensePoly.xgcd (GFqRing.repr x) f).gcd ∣ f := by
-  simpa [DensePoly.gcd]
+  simpa [← DensePoly.gcd_eq_xgcd_gcd]
     using DensePoly.gcd_dvd_right (GFqRing.repr x) f
 
 /-- A nonzero `ZMod64 p` scalar is coprime to prime `p`, supplying the unit

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -932,20 +932,60 @@ def xgcd [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) : XGCDResult R :=
   xgcdAux p 1 0 q 0 1 (p.size + q.size + 1)
 
-/-- Polynomial gcd over a field. -/
+/-- Tail-recursive Euclidean gcd tracking only the remainder sequence, **without**
+the Bezout coefficients. `xgcd`/`xgcdAux` carry the Bezout accumulators `s`, `t`
+and update them with a polynomial multiplication (`q * s₁`, `q * t₁`) at every
+step on polynomials whose degree grows through the run — that is `O(deg³)` work
+and pure waste when only the gcd value is wanted (the common case: the square-free
+/ separability test `gcd(f, f') = 1`). `gcdAux` keeps only the remainders and is
+`O(deg²)`. -/
+private def gcdAux [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (r₀ r₁ : DensePoly R) (fuel : Nat) : DensePoly R :=
+  match fuel with
+  | 0 => r₀
+  | fuel + 1 =>
+      if _hr : r₁.isZero then
+        r₀
+      else
+        gcdAux r₁ (divMod r₀ r₁).2 fuel
+
+/-- The plain remainder gcd agrees with the `gcd` component of the extended
+algorithm: `XGCDResult.gcd` never depends on the Bezout accumulators. -/
+theorem gcdAux_eq_xgcdAux_gcd [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly R) (fuel : Nat) :
+    gcdAux r₀ r₁ fuel = (xgcdAux r₀ s₀ t₀ r₁ s₁ t₁ fuel).gcd := by
+  induction fuel generalizing r₀ s₀ t₀ r₁ s₁ t₁ with
+  | zero => rfl
+  | succ fuel ih =>
+      unfold gcdAux xgcdAux
+      split
+      · rfl
+      · exact ih _ _ _ _ _ _
+
+/-- Polynomial gcd over a field. Computed by the plain remainder sequence
+(`gcdAux`), **not** the extended algorithm: the gcd value is independent of the
+Bezout coefficients, and computing them costs an extra polynomial multiplication
+per step (`O(deg³)` vs `O(deg²)`). `xgcd` stays available for callers that
+genuinely need Bezout coefficients. -/
 def gcd [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) : DensePoly R :=
-  (xgcd p q).gcd
+  gcdAux p q (p.size + q.size + 1)
+
+/-- `gcd` equals the gcd component of `xgcd`; lets lemmas proved against the
+extended algorithm transfer to the plain `gcd`. -/
+theorem gcd_eq_xgcd_gcd [One R] [Add R] [Sub R] [Mul R] [Div R]
+    (p q : DensePoly R) : gcd p q = (xgcd p q).gcd :=
+  gcdAux_eq_xgcdAux_gcd p 1 0 q 0 1 (p.size + q.size + 1)
 
 /-- The gcd component returned by `xgcd` is the executable gcd. -/
 theorem xgcd_gcd_eq_gcd [One R] [Add R] [Sub R] [Mul R] [Div R]
     (p q : DensePoly R) :
-    (xgcd p q).gcd = gcd p q := rfl
+    (xgcd p q).gcd = gcd p q := (gcd_eq_xgcd_gcd p q).symm
 
 /-- The executable gcd of two zero dense polynomials is zero. -/
 @[simp, grind =] theorem gcd_zero_zero [One R] [Add R] [Sub R] [Mul R] [Div R] :
     gcd (0 : DensePoly R) (0 : DensePoly R) = 0 := by
-  rfl
+  rw [gcd_eq_xgcd_gcd]; rfl
 
 /-- Law package for the executable dense-polynomial division operations.
 
@@ -3120,7 +3160,8 @@ theorem gcd_dvd_left_of_divModLaws {S : Type _}
         q.isZero = false → ¬ 0 < q.degree?.getD 0 → (divMod p q).2 = 0)
     (p q : DensePoly S) :
     gcd p q ∣ p := by
-  unfold gcd xgcd
+  rw [gcd_eq_xgcd_gcd]
+  unfold xgcd
   exact (xgcdAux_gcd_dvd_inputs hsmall p 1 0 q 0 1 (p.size + q.size + 1)
     (by
       have hq := degree_getD_lt_size_add_one q
@@ -3136,7 +3177,8 @@ theorem gcd_dvd_right_of_divModLaws {S : Type _}
         q.isZero = false → ¬ 0 < q.degree?.getD 0 → (divMod p q).2 = 0)
     (p q : DensePoly S) :
     gcd p q ∣ q := by
-  unfold gcd xgcd
+  rw [gcd_eq_xgcd_gcd]
+  unfold xgcd
   exact (xgcdAux_gcd_dvd_inputs hsmall p 1 0 q 0 1 (p.size + q.size + 1)
     (by
       have hq := degree_getD_lt_size_add_one q
@@ -3149,7 +3191,8 @@ theorem dvd_gcd_of_divModLaws {S : Type _}
     (d p q : DensePoly S) :
     d ∣ p → d ∣ q → d ∣ gcd p q := by
   intro hdp hdq
-  unfold gcd xgcd
+  rw [gcd_eq_xgcd_gcd]
+  unfold xgcd
   exact xgcdAux_common_dvd_gcd d p 1 0 q 0 1 (p.size + q.size + 1) hdp hdq
 
 /-- Recursive reconstruction invariant for the array-backed long-division loop.

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -3577,7 +3577,7 @@ theorem dvd_of_dvd_mul_of_common_dvd_one
   obtain ⟨s, t, hbez⟩ :
       ∃ s t : FpPoly p, s * c + t * g = DensePoly.gcd c g :=
     ⟨(DensePoly.xgcd c g).left, (DensePoly.xgcd c g).right,
-     DensePoly.xgcd_bezout c g⟩
+     DensePoly.xgcd_gcd_eq_gcd c g ▸ DensePoly.xgcd_bezout c g⟩
   -- `g` divides each summand of `(s * c + t * g) * h`.
   have hg_left : g ∣ s * c * h := by
     have h_assoc : s * c * h = s * (c * h) := DensePoly.mul_assoc_poly s c h

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -854,7 +854,7 @@ theorem mul_mod_inverseCandidate_eq_one_of_irreducible
   let d : FpPoly p := DensePoly.gcd a g
   have hbezout : xres.left * a + xres.right * g = d := by
     have hb := DensePoly.xgcd_bezout a g
-    simpa [xres, d, DensePoly.gcd] using hb
+    simpa [xres, d, DensePoly.gcd_eq_xgcd_gcd] using hb
   -- The gcd divides both inputs.
   have hda : d ∣ a := DensePoly.gcd_dvd_left a g
   have hdg : d ∣ g := DensePoly.gcd_dvd_right a g

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -1720,7 +1720,8 @@ private theorem gcd_C_mul_C_mul_eq_C_mul_gcd
           α * (DensePoly.C u * f) + β * (DensePoly.C u * g) = d :=
       ⟨(DensePoly.xgcd (DensePoly.C u * f) (DensePoly.C u * g)).left,
         (DensePoly.xgcd (DensePoly.C u * f) (DensePoly.C u * g)).right,
-        DensePoly.xgcd_bezout (DensePoly.C u * f) (DensePoly.C u * g)⟩
+        (DensePoly.xgcd_bezout (DensePoly.C u * f) (DensePoly.C u * g)).trans
+          (DensePoly.xgcd_gcd_eq_gcd (DensePoly.C u * f) (DensePoly.C u * g))⟩
     -- Rewrite the Bezout sum as `C u * (α * f + β * g)`.
     let P : FpPoly p := α * f + β * g
     have hd_eq : d = DensePoly.C u * P := by

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -219,11 +219,22 @@ def choosePrime (f : ZPoly) : Nat
 
 `isGoodPrime` expresses the mathematical admissibility condition for
 the modular reduction prime: at minimum `p ∤ lc(f)`, `p ≥ 3` (avoid
-`p = 2`; see Pitfall 6), and `f mod p` is square-free. `choosePrime`
-is the default total heuristic chooser. It searches through a small
-fixed number of admissible small primes (≥ 3), factors `f mod p` for
-each, and chooses the prime with the fewest modular factors, breaking
-ties toward the smallest prime.
+`p = 2`; see Pitfall 6), and `f mod p` is square-free. The square-free
+test is a single modular **GCD** — `gcd(f mod p, f' mod p)` is a unit —
+**not** a factorisation, so `isGoodPrime` is cheap.
+
+`choosePrime` selects the **first suitable prime**: it walks the
+candidate primes in increasing order and returns the first `p` with
+`isGoodPrime f p`, then factors `f mod p` only for that prime. This
+matches the verified Isabelle/AFP `Berlekamp_Zassenhaus` reference
+(`Suitable_Prime.thy` `find_prime` selects the first separable prime;
+`berlekamp_zassenhaus_main` then runs `finite_field_factorization_int p f`
+once). It deliberately does **not** factor `f mod p` at multiple primes
+to minimise the modular-factor count: that classical Zassenhaus heuristic
+costs one modular factorisation per candidate prime (≈95 per call here),
+and van Hoeij's recombination is polynomial in the factor count `r`, so
+the optimisation buys almost nothing. First-suitable factors `f mod p`
+exactly once.
 
 **Explicit pipeline records:**
 ```lean
@@ -268,21 +279,29 @@ excluded by `isGoodPrime`). This set has 95 elements; their
 primorial `∏ HotPathCandidates ≈ 10^203`, which is the lower
 bound D2 below uses to characterise `factorSlowTrial` inputs.
 
-The cap of 500 is a SPEC choice balancing three constraints: the
-walk must visit *every* element of `HotPathCandidates` on every
-input (so the implementation can be a constant-size fixed walk,
-not input-dependent); the primorial must be large enough that no
-realistic polynomial reaches the lower bound; the cap must be
-small enough that the trial-division kernel uses `ZMod64`
-throughout. 95 primes is fast, the primorial `10^203` exceeds any
-realistic `|lc(f)·disc(f)|` by tens of orders of magnitude, and
-`p ≤ 500` is far inside `ZMod64`'s `UInt64.word` domain.
+The cap of 500 balances two constraints: the primorial must be large
+enough that no realistic polynomial reaches the lower bound (so the
+`none` case is unreachable in practice, per D2); and the cap must be
+small enough that the modular kernel uses `ZMod64` throughout. The
+primorial `10^203` exceeds any realistic `|lc(f)·disc(f)|` by tens of
+orders of magnitude, and `p ≤ 500` is far inside `ZMod64`'s
+`UInt64.word` domain.
 
-The executable MUST walk exactly `HotPathCandidates` before
-returning `none`: a curated `smallPrimeCandidates`-style subset
-(skipping primes like `29, 37, 41, 43, 47, 53, 59, 61, 67`) is a
-SPEC violation, as is an input-dependent fuel cap. The
-implementation is a constant-size walk over a SPEC-fixed list.
+`choosePrimeData?` walks `HotPathCandidates` in increasing order and
+returns the **first** prime with `isGoodPrime f p`, factoring `f mod p`
+only for that prime (first-suitable selection; see `choosePrime`
+above). On realistic input a suitable prime appears among the first few
+candidates, so the walk stops almost immediately. Only when **no**
+candidate is suitable does the walk visit all 95 — and because
+suitability is the cheap separability GCD (not a factorisation), even
+that exhaustive `none`-case walk is fast.
+
+The candidate set is SPEC-fixed: the `none` case MUST check every
+element of `HotPathCandidates` before concluding `none` (this is what
+D2's characterisation rests on), so a curated subset that skips primes
+like `29, 37, 41, 43, 47, 53, 59, 61, 67`, or an input-dependent fuel
+cap, is a SPEC violation. First-suitable changes *when the walk stops on
+success*, not *which primes are eligible*.
 
 `choosePrimeData? f = none` when no element of
 `HotPathCandidates` satisfies `isGoodPrime f p`. This is by
@@ -604,7 +623,7 @@ D2. **Tight characterisation of trial-backstop inputs.** Statement shape:
 
     The bridge file gets one new theorem (`choosePrimeData?_none_implies_huge`) and a small helper unfolding `isGoodPrime`. No new mathematical content; the bound is a clean divisibility argument.
 
-    **Executable precondition.** D2 presumes the executable `choosePrimeData?` walks the entire `HotPathCandidates` set (the 95 primes in `[3, 500]`) before returning `none`. The implementation MUST visit every one — a curated `smallPrimeCandidates`-style subset that skips primes is a SPEC violation, as is an input-dependent fuel cap. Any worker noticing the walk can short-circuit before exhausting `HotPathCandidates` should file the fix as a prerequisite issue, not weaken D2's statement.
+    **Executable precondition.** D2 is about the `none` case only: `choosePrimeData? f = none` must mean *no* element of `HotPathCandidates` is suitable, so the `none` path MUST test every one of the 95 primes in `[3, 500]` before concluding `none`. First-suitable selection short-circuits on *success* (returning at the first suitable prime, which is correct and required for performance), but it must **not** short-circuit the `none` conclusion: a curated subset that skips primes, or an input-dependent fuel cap on the `none`-case walk, is a SPEC violation that would weaken D2.
 
 ## Headline correctness theorem
 

--- a/SPEC/Libraries/hex-poly.md
+++ b/SPEC/Libraries/hex-poly.md
@@ -20,8 +20,18 @@ The normalization invariant (no trailing zeros) ensures structural equality
 **Operations:**
 - Addition, subtraction, multiplication (schoolbook, Karatsuba for large degree)
 - Division with remainder (for monic divisors; general division over fields)
-- Polynomial GCD (Euclidean algorithm)
-- Extended GCD (Bezout coefficients: `a*f + b*g = gcd(f,g)`)
+- Polynomial GCD (plain Euclidean remainder sequence — **not** the extended
+  algorithm). `gcd` tracks only the remainders, so it is `O(deg²)`. The extended
+  algorithm additionally multiplies the divisor against the growing Bezout
+  accumulators `s`, `t` at every step (`q*s₁`, `q*t₁`), which is `O(deg³)` and
+  pure waste when only the gcd *value* is needed — the common case being the
+  square-free / separability test `gcd(f, f') = 1`. Computing Bezout coefficients
+  inside `gcd` is a correctness-neutral but ~10⁴× performance defect on the BHKS
+  prime-selection hot path, so `gcd` must be the plain remainder sequence.
+- Extended GCD (`xgcd`, Bezout coefficients: `a*f + b*g = gcd(f,g)`) — a
+  *separate* function for the genuine Bezout use-sites (CRT, Hensel, Berlekamp
+  correctness). `gcd` agrees with `xgcd`'s gcd component (`gcd_eq_xgcd_gcd`), so
+  the gcd-value lemmas transfer.
 - Evaluation (Horner's method)
 - Composition, derivative
 - Content and primitive part (for `DensePoly Int`)


### PR DESCRIPTION
This PR speeds up `factorFast` prime selection and the polynomial GCD without
changing any factorisation result. On the split family `(x-1)…(x-8)`,
`factorFast` drops from ~1.7s to ~22ms (~76×); the wins compound with degree.

`choosePrimeData?` now selects the **first suitable prime** — it walks the
candidate primes in order and returns the first whose modular image is separable
(the existing cheap `isGoodPrime` GCD test), factoring `f mod p` only for that
prime. The previous rule scored every candidate by its modular-factor count,
which factored `f mod p` at all ~95 hot-path primes per call. Van Hoeij
recombination is polynomial in the factor count, so the "fewest factors"
optimisation bought almost nothing. First-suitable matches the verified
Isabelle/AFP `Berlekamp_Zassenhaus` reference (`Suitable_Prime.thy` `find_prime`
selects the first separable prime; `berlekamp_zassenhaus_main` then factors once).
The `none` case still walks every candidate, so D2 is unchanged — only success
short-circuits.

`DensePoly.gcd` now runs the plain Euclidean remainder sequence instead of the
extended algorithm. The extended algorithm multiplies the divisor against the
growing Bezout accumulators at every step (O(deg³)), which is pure waste when
only the gcd value is needed — the common case being the square-free /
separability test `gcd(f, f') = 1` on the prime-selection hot path. `xgcd`
stays available for the genuine Bezout use-sites (CRT, Hensel, Berlekamp); a new
`gcd_eq_xgcd_gcd` lets the gcd-value lemmas and those use-sites transfer. The
handful of proofs that relied on `gcd = (xgcd).gcd` being definitional are
rerouted through it.

The SPEC is updated to pin first-suitable selection (`hex-berlekamp-zassenhaus.md`)
and require the plain remainder sequence for `gcd` (`hex-poly.md`). The deeper
substrate bottlenecks surfaced while profiling this hot path — `DensePoly.divMod`
constant overhead and the van Hoeij core's high-degree scaling — are tracked
separately in #8063 and #8064. The remaining executable-finish work (the all-ones
recovery guard / D1 liveness) is tracked in #8062.

🤖 Prepared with Claude Code
