### PR TITLE
feat: correct fast raw irreducibility contract for recorded entries

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -294,6 +294,36 @@ lemma (`Nat.sum_range_choose`, etc.). Same pattern for `Hex.Nat.Prime`.
 
 ## Fast-BHKS raw irreducibility ≠ slow-path raw irreducibility (scheduled-loop determinism)
 
+### Raw-irreducibility contracts on the fast path must be guarded by `shouldRecordPolynomialFactor`
+
+The unguarded shape `factorFastFactorsWithBound f B = some rawFactors →
+∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw` is **false**, not just
+underivable: the constant early-return (`squareFreeCore.degree?.getD 0 = 0`)
+emits `reassemblePolynomialFactors normalized #[squareFreeCore]` with
+`squareFreeCore = 1` (for `f = 1`), and `Irreducible 1` is impossible (`1` is a
+unit). #8067 was skipped on exactly this; #8079 fixed it. The satisfiable
+contract guards each raw obligation with the recorded-factor filter:
+`Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+Hex.ZPoly.Irreducible raw`. The guard excludes the unit/constant raw outputs
+that never become recorded `(Hex.factor f).factors` entries; it is discharged
+for free at the consumer from `Hex.factorWithBound_entry_shouldRecord` (every
+recorded entry passes the filter), so the guarded form composes exactly where
+the unguarded one was needed. The fast producers of the guarded contract:
+`Hex.factorFastFactorsWithBound_raw_irreducible_of_constant` (degree-0
+early-return; reassembly is a power of `X`, the unit core fails the guard via
+`shouldRecordPolynomialFactor_one`) and
+`factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift` (BHKS
+core-success, routing through the #8058 capstone). Slow producers
+(`slowModularRaw_irreducible_of_fast_none`,
+`factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`) keep their
+*unguarded* statements — `fast = none` forces `degree ≠ 0`, so there is no unit
+core — and imply the guarded form by `fun raw hmem _ => producer raw hmem`. Note
+this guarded contract is the fast-path counterpart to the `normalizeFactorSign`
+sign-guard trap below: both are sound *narrowings* of an over-quantified raw
+obligation, not core-facts assembly. Still missing as of #8079: guarded
+producers for the fast small-mod-singleton (`factorsModP.size ≤ 1`) and
+quadratic short-circuit sub-branches.
+
 The slow-path raw irreducibility (`slowModularRaw_irreducible_of_fast_none`,
 #7665) is *unconditional* because the slow path runs a single fixed-precision
 `exhaustiveCoreFactorsWithBound` at `exhaustiveLiftBound` — one deterministic

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -17186,6 +17186,53 @@ theorem reassemblyExpansionComplete_constant_of_ne_zero
   rw [hcore_one, expandRepeatedPartFactorArray_singleton_one]
   exact hrep_one
 
+/-- Guarded constant-branch raw irreducibility for the fast path.
+
+When the square-free core has degree zero, `factorFastFactorsWithBound`
+short-circuits to `reassemblePolynomialFactors (normalizeForFactor f)
+#[(normalizeForFactor f).squareFreeCore]`, whose core collapses to the unit `1`
+(`squareFreeCore_eq_one_of_constant_of_ne_zero`).  The reassembly is then a pure
+power of `X`, so every raw factor that *passes the recorded-factor filter* is
+irreducible: the extracted `X`-powers are irreducible
+(`xPowerFactorArray_irreducible`), and the unit core fails the
+`shouldRecordPolynomialFactor` guard (`shouldRecordPolynomialFactor_one`) and so
+never incurs an `ZPoly.Irreducible 1` obligation.
+
+The `shouldRecordPolynomialFactor (normalizeFactorSign raw) = true` guard is what
+makes the contract satisfiable: the over-strong "every raw element is
+irreducible" form is false here precisely because the singleton core is the unit
+`1`.  This discharges the constant/unit early-return disjunct of the corrected
+fast-branch recorded-entry irreducibility contract. -/
+theorem factorFastFactorsWithBound_raw_irreducible_of_constant
+    (f : ZPoly) (hf : f ≠ 0) (B : Nat)
+    (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0)
+    {rawFactors : Array ZPoly}
+    (hfast : factorFastFactorsWithBound f B = some rawFactors) :
+    ∀ raw ∈ rawFactors.toList,
+      shouldRecordPolynomialFactor (normalizeFactorSign raw) = true →
+        ZPoly.Irreducible raw := by
+  have hval :
+      factorFastFactorsWithBound f B =
+        some (reassemblePolynomialFactors (normalizeForFactor f)
+          #[(normalizeForFactor f).squareFreeCore]) := by
+    unfold factorFastFactorsWithBound
+    rw [if_pos hdeg]
+  rw [hval] at hfast
+  have hraw_eq := Option.some.inj hfast
+  subst hraw_eq
+  intro raw hmem hrecord
+  have hcomplete := reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg
+  rcases reassemblePolynomialFactors_mem_xPower_or_core_of_expansionComplete
+      (normalizeForFactor f) #[(normalizeForFactor f).squareFreeCore] raw hcomplete hmem with
+    hx | hcore
+  · exact xPowerFactorArray_irreducible (normalizeForFactor f).xPower raw hx
+  · have hraw_one : raw = 1 := by
+      have hraw_core : raw = (normalizeForFactor f).squareFreeCore := by
+        simpa using hcore
+      rw [hraw_core, squareFreeCore_eq_one_of_constant_of_ne_zero f hf hdeg]
+    rw [hraw_one, normalizeFactorSign_one, shouldRecordPolynomialFactor_one] at hrecord
+    exact absurd hrecord (by decide)
+
 /-- The normalized square-free core has positive leading coefficient
 (`squareFreeCore_leadingCoeff_pos_of_ne_zero`), so its sign-normalisation
 is the identity. Exposed publicly for HO-1 support-lemma callers in the

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -320,10 +320,17 @@ hypothesis `h_raw` is dispatched by the public fast/slow case-split exposed
 through `Hex.factorWithBound_entry_mem_raw_source`: it asks the caller to
 prove that every raw factor produced by the chosen branch (the fast BHKS
 output when `factorFastFactorsWithBound = some _`, or the slow exhaustive
-output when `factorFastFactorsWithBound = none`) is `Hex.ZPoly.Irreducible`.
-The recorded entry's first component is the `Hex.normalizeFactorSign`-image
-of one such raw factor, so `zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible`
-discharges the sign-normalisation step.
+output when `factorFastFactorsWithBound = none`) is `Hex.ZPoly.Irreducible`,
+**guarded by** `Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw)
+= true`.  The guard excludes unit/constant raw outputs that never produce a
+recorded entry — without it the contract is unsatisfiable on the fast path,
+whose constant early-return emits the unit `1` (e.g. `f = 1`), and
+`Hex.ZPoly.Irreducible 1` is false.  The recorded entry's first component is the
+`Hex.normalizeFactorSign`-image of one such raw factor and passes the
+recorded-factor filter (`Hex.factorWithBound_entry_shouldRecord`), so the guard
+is discharged automatically and
+`zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible` then lifts the
+sign-normalisation step.
 
 Combined with the Mathlib-free reassembly lift
 `Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`,
@@ -348,13 +355,18 @@ theorem factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
           (Hex.factorFastFactorsWithBound f B = none ∧
             Hex.factorSlowModularWithBound f B = none ∧
             rawFactors = Hex.factorSlowTrialFactorsWithBound f B)) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+        ∀ raw ∈ rawFactors.toList,
+          Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+            Hex.ZPoly.Irreducible raw) :
     Hex.ZPoly.Irreducible entry.1 := by
   obtain ⟨rawFactors, hsource, raw, hraw_mem, hentry_eq⟩ :=
     Hex.factorWithBound_entry_mem_raw_source f B entry hmem
+  have hrecord : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true := by
+    have := Hex.factorWithBound_entry_shouldRecord f B entry hmem
+    rwa [hentry_eq] at this
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
-    (h_raw rawFactors hsource raw hraw_mem)
+    (h_raw rawFactors hsource raw hraw_mem hrecord)
 
 /-- Default-precision specialisation of
 `factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible` for
@@ -378,7 +390,9 @@ theorem factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
             rawFactors =
               Hex.factorSlowTrialFactorsWithBound f
                 (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+        ∀ raw ∈ rawFactors.toList,
+          Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+            Hex.ZPoly.Irreducible raw) :
     Hex.ZPoly.Irreducible entry.1 :=
   factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (B := Hex.ZPoly.defaultFactorCoeffBound f)
@@ -414,7 +428,9 @@ theorem factorWithBound_entries_irreducible
           (Hex.factorFastFactorsWithBound f B = none ∧
             Hex.factorSlowModularWithBound f B = none ∧
             rawFactors = Hex.factorSlowTrialFactorsWithBound f B)) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+        ∀ raw ∈ rawFactors.toList,
+          Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+            Hex.ZPoly.Irreducible raw) :
     ∀ entry ∈ (Hex.factorWithBound f B).factors, Hex.ZPoly.Irreducible entry.1 := by
   intro entry hentry
   exact factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
@@ -441,7 +457,9 @@ theorem factor_entries_irreducible
             rawFactors =
               Hex.factorSlowTrialFactorsWithBound f
                 (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Irreducible raw) :
+        ∀ raw ∈ rawFactors.toList,
+          Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+            Hex.ZPoly.Irreducible raw) :
     ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
   intro entry hentry
   exact factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -2119,4 +2119,123 @@ theorem factorFastFactorsWithBound_raw_zpolyIrreducible_of_recoveredLift
       rows_pos hbasis trueSupports lift hf_lc hfactor_monic hp hk hsep hthr hfac)
     hsize hpartition hfast
 
+/--
+Recorded-entry (guarded) form of
+`factorFastFactorsWithBound_raw_zpolyIrreducible_of_recoveredLift`.
+
+The corrected fast-branch irreducibility contract (#8079) guards each raw
+obligation with `Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw)
+= true`, excluding the unit/constant raw outputs the public factorization never
+records.  On the BHKS core-success disjunct every raw factor is unconditionally
+irreducible, so the guard is simply dropped and the obligation routes through the
+#8058 capstone `factorFastFactorsWithBound_raw_zpolyIrreducible_of_recoveredLift`
+— no cut, partition-count, or support-family proof is re-derived here.  The
+companion constant/unit early-return disjunct is
+`Hex.factorFastFactorsWithBound_raw_irreducible_of_constant`. -/
+theorem factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat)
+    (primeData : Hex.PrimeChoiceData)
+    (hB_pos : 1 ≤ B)
+    (hchoose :
+      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+        some primeData)
+    (hdeg :
+      (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    (hmulti : 1 < primeData.factorsModP.size)
+    (hquadratic :
+      B = 1 ∨
+        Hex.quadraticIntegerRootFactors?
+          (Hex.normalizeForFactor f).squareFreeCore = none)
+    (rows_pos :
+      BHKS.HasPositiveDimension (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          B primeData))
+    (trueSupports :
+      Set (Set (Fin
+        (BHKS.projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            B primeData)
+          rows_pos).factorCount)))
+    {expectedFactors : Array Hex.ZPoly}
+    (hcore :
+      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+        primeData (Hex.initialHenselPrecision B)
+        (Hex.ZPoly.quadraticDoublingSteps B + 2) =
+          some expectedFactors)
+    (hbasis :
+      (BHKS.latticeBasisOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (Hex.ZPoly.toMonicLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          B primeData)).basis.independent)
+    (lift : ∀ S : trueSupports,
+      BHKS.RecoveredLift
+        (BHKS.latticeBasisOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            B primeData)) S.1)
+    (hf_lc : ∀ S : trueSupports,
+      Hex.DensePoly.leadingCoeff (lift S).f = 1)
+    (hfactor_monic : ∀ S : trueSupports,
+      (HexPolyMathlib.toPolynomial (lift S).factor).Monic)
+    (hp : ∀ S : trueSupports, 2 ≤ (lift S).p)
+    (hk : ∀ S : trueSupports, 1 < (lift S).p ^ (lift S).a)
+    (hsep : ∀ S : trueSupports,
+      ∀ j, 2 * Hex.bhksCoeffBound (lift S).f j < (lift S).p ^ (lift S).a)
+    (hthr : ∀ S : trueSupports,
+      ∀ j, Hex.bhksCoeffCutThreshold (lift S).p (lift S).f j ≤ (lift S).a)
+    (hfac : ∀ S : trueSupports,
+      ∀ i : Fin (BHKS.latticeBasisOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (Hex.ZPoly.toMonicLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            B primeData)).factorCount, i ∈ S.1 →
+        ∃ g : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((BHKS.latticeBasisOfLiftData
+              (Hex.normalizeForFactor f).squareFreeCore
+              (Hex.ZPoly.toMonicLiftData
+                (Hex.normalizeForFactor f).squareFreeCore
+                B primeData)).liftedFactors.getD i.val 1) ∧
+          0 < ((BHKS.latticeBasisOfLiftData
+              (Hex.normalizeForFactor f).squareFreeCore
+              (Hex.ZPoly.toMonicLiftData
+                (Hex.normalizeForFactor f).squareFreeCore
+                B primeData)).liftedFactors.getD i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr (lift S).f
+            ((BHKS.latticeBasisOfLiftData
+              (Hex.normalizeForFactor f).squareFreeCore
+              (Hex.ZPoly.toMonicLiftData
+                (Hex.normalizeForFactor f).squareFreeCore
+                B primeData)).liftedFactors.getD i.val 1 * g)
+            ((lift S).p ^ (lift S).a))
+    (hsize :
+      expectedFactors.size =
+        (Hex.bhksEquivalenceClassIndicators
+          (BHKS.projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (Hex.ZPoly.toMonicLiftData
+              (Hex.normalizeForFactor f).squareFreeCore
+              B primeData)
+            rows_pos)).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial
+            (Hex.normalizeForFactor f).squareFreeCore)).card)
+    {rawFactors : Array Hex.ZPoly}
+    (hfast : Hex.factorFastFactorsWithBound f B = some rawFactors) :
+    ∀ raw ∈ rawFactors.toList,
+      Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+        Hex.ZPoly.Irreducible raw :=
+  fun raw hmem _hrecord =>
+    factorFastFactorsWithBound_raw_zpolyIrreducible_of_recoveredLift
+      f hf_ne B primeData hB_pos hchoose hdeg hmulti hquadratic
+      rows_pos trueSupports hcore hbasis lift hf_lc hfactor_monic hp hk hsep hthr hfac
+      hsize hpartition hfast raw hmem
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260619_182749_e73165b4.md
+++ b/progress/20260619_182749_e73165b4.md
@@ -1,0 +1,62 @@
+# Correct fast raw irreducibility contract for recorded entries (#8079)
+
+## Accomplished
+
+Corrected the over-strong fast-branch raw irreducibility contract that #8067
+proved unsatisfiable (the constant early-return emits the unit `1`, and
+`Hex.ZPoly.Irreducible 1` is false).
+
+**Deliverable 1 — guard the recorded-entry contract** (`HexBerlekampZassenhausMathlib/Basic.lean`):
+weakened the `h_raw` hypothesis of
+`factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`,
+`factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`,
+`factorWithBound_entries_irreducible`, and `factor_entries_irreducible` from
+`∀ raw ∈ rawFactors.toList, Irreducible raw` to the guarded form
+`∀ raw ∈ rawFactors.toList,
+  Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
+    Irreducible raw`.
+The guard excludes the unit/constant raw outputs that never produce a recorded
+entry. The base theorem discharges the guard automatically from
+`Hex.factorWithBound_entry_shouldRecord` (every recorded entry's first component
+passes the filter), so consumers see no extra obligation.
+
+**Deliverable 2 — fast-branch producers**:
+- constant/unit early-return (`HexBerlekampZassenhaus/Basic.lean`):
+  `factorFastFactorsWithBound_raw_irreducible_of_constant` proves the guarded
+  contract in the degree-0 branch. The reassembly collapses to a power of `X`
+  (core `= 1` via `squareFreeCore_eq_one_of_constant_of_ne_zero`,
+  `repeatedPart = 1`); `X` factors are irreducible and the unit core fails the
+  guard (`shouldRecordPolynomialFactor_one`), so no `Irreducible 1` is ever
+  claimed.
+- BHKS core-success (`HexBerlekampZassenhausMathlib/PartitionRefinement.lean`):
+  `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift` is the
+  guarded wrapper that drops the guard and routes through the #8058 capstone
+  `factorFastFactorsWithBound_raw_zpolyIrreducible_of_recoveredLift` — no cut,
+  partition-count, or support-family proof is re-derived.
+
+**Deliverable 3 — slow producers preserved**: `slowModularRaw_irreducible_of_fast_none`
+and `factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`
+(`IntReductionMod.lean`) prove the *unguarded* form, which trivially implies the
+new guarded contract (`fun raw hmem _ => producer raw hmem`), so their
+statements are unchanged.
+
+## Current frontier
+
+`lake build HexBerlekampZassenhausMathlib` green (3790 jobs, 0 errors),
+including the executable `HexBerlekampZassenhaus.Basic` and the CI-gated bridge.
+`scripts/check_dag.py` exit 0, `git diff --check` clean. No `sorry`/`axiom`/
+`native_decide` in added lines.
+
+## Next step
+
+#8068 (capstone, depends on #8079): assemble the fast disjunct from the two new
+producers, slow-modular via `slowModularRaw_irreducible_of_fast_none`, and
+slow-trial via `factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`,
+to close the `factor_irreducible_of_nonUnit` sorry. Residual not covered by
+#8079: the fast branch's small-mod singleton (`factorsModP.size ≤ 1`) and
+quadratic short-circuit sub-cases still need their own guarded producers for a
+complete fast-disjunct discharge.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8079

This PR corrects the fast-branch raw irreducibility contract that #8067 found unsatisfiable. The consumer theorems `factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`, `factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`, `factorWithBound_entries_irreducible`, and `factor_entries_irreducible` previously demanded `∀ raw ∈ rawFactors.toList, Irreducible raw`; this is false on the fast path, whose constant early-return emits the unit `1` (e.g. `f = 1`), for which `Hex.ZPoly.Irreducible 1` cannot hold. It guards each raw obligation with `Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true`, excluding the unit/constant raw outputs the public factorization never records; the guard is discharged automatically inside the base consumer from `Hex.factorWithBound_entry_shouldRecord`, so callers see no new obligation.

It adds the two matching fast-branch producers of the corrected contract: `Hex.factorFastFactorsWithBound_raw_irreducible_of_constant` discharges the constant/unit early-return (the reassembly collapses to a power of `X`, whose factors are irreducible, while the unit core fails the guard, so `Irreducible 1` is never claimed), and `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift` routes the BHKS core-success case through the #8058 capstone without re-deriving cut, partition-count, or support-family proofs. The slow-branch producers in `IntReductionMod.lean` are preserved unchanged: their unguarded conclusion trivially implies the new guarded contract.

🤖 Prepared with Claude Code