### PR TITLE
feat: Phase 6 grind coverage for HexMatrixMathlib Basic.lean and Determinant/Core.lean

### DIFF
--- a/HexMatrixMathlib/Basic.lean
+++ b/HexMatrixMathlib/Basic.lean
@@ -29,17 +29,17 @@ def matrixEquiv : Hex.Matrix R n m ≃ Matrix (Fin n) (Fin m) R where
     ext i j
     simp [Hex.Matrix.ofFn]
 
-@[simp]
+@[simp, grind =]
 theorem matrixEquiv_apply (M : Hex.Matrix R n m) (i : Fin n) (j : Fin m) :
     matrixEquiv M i j = M[i][j] :=
   rfl
 
-@[simp]
+@[simp, grind =]
 theorem matrixEquiv_symm_apply (M : Matrix (Fin n) (Fin m) R) (i : Fin n) (j : Fin m) :
     (matrixEquiv.symm M)[i][j] = M i j :=
   by simp [matrixEquiv, Hex.Matrix.ofFn]
 
-@[simp]
+@[simp, grind =]
 theorem matrixEquiv_ofFn (f : Fin n → Fin m → R) :
     matrixEquiv (Hex.Matrix.ofFn f) = f := by
   ext i j

--- a/HexMatrixMathlib/Determinant/Core.lean
+++ b/HexMatrixMathlib/Determinant/Core.lean
@@ -42,7 +42,7 @@ noncomputable def toPerm (perm : Vector (Fin n) n)
     ⟨get_injective_of_nodup hnodup,
       Finite.surjective_of_injective (get_injective_of_nodup hnodup)⟩
 
-@[simp]
+@[simp, grind =]
 theorem toPerm_apply (perm : Vector (Fin n) n)
     (hnodup : perm.toList.Nodup) (i : Fin n) :
     toPerm perm hnodup i = perm[i] := by
@@ -156,14 +156,14 @@ theorem detSign_eq_permSign [CommRing R]
 
 end PermutationVector
 
-@[simp]
+@[simp, grind =]
 theorem detProduct_eq_matrixEquiv
     [Lean.Grind.Ring R] (M : Hex.Matrix R n n) (perm : Vector (Fin n) n) :
     Hex.Matrix.detProduct M perm =
       (List.finRange n).foldl (fun acc i => acc * matrixEquiv M i (perm[i])) 1 := by
   rfl
 
-@[simp]
+@[simp, grind =]
 theorem detTerm_eq_matrixEquiv
     [Lean.Grind.Ring R] (M : Hex.Matrix R n n) (perm : Vector (Fin n) n) :
     Hex.Matrix.detTerm M perm =
@@ -2356,12 +2356,12 @@ def bareissDesnanotIndex (k : Nat) : Fin (k + 2) ≃ Fin (k + 2) where
       · have hlast : r.val = k + 1 := by omega
         simp [hlast]
 
-@[simp]
+@[simp, grind =]
 theorem bareissDesnanotIndex_zero (k : Nat) :
     bareissDesnanotIndex k 0 = (⟨k, by omega⟩ : Fin (k + 2)) := by
   rfl
 
-@[simp]
+@[simp, grind =]
 theorem bareissDesnanotIndex_last (k : Nat) :
     bareissDesnanotIndex k (Fin.last (k + 1)) = Fin.last (k + 1) := by
   simp [bareissDesnanotIndex]

--- a/progress/20260619T205502Z_72d5dba1.md
+++ b/progress/20260619T205502Z_72d5dba1.md
@@ -1,0 +1,40 @@
+# Phase 6 grind coverage: HexMatrixMathlib Basic.lean + Determinant/Core.lean (#8099)
+
+## Accomplished
+
+Promoted the 8 equation-shaped public `@[simp]` lemmas across two
+`HexMatrixMathlib` files to `@[simp, grind =]`:
+
+- `Basic.lean`: `matrixEquiv_apply`, `matrixEquiv_symm_apply`,
+  `matrixEquiv_ofFn`.
+- `Determinant/Core.lean`: `toPerm_apply`, `detProduct_eq_matrixEquiv`,
+  `detTerm_eq_matrixEquiv`, `bareissDesnanotIndex_zero`,
+  `bareissDesnanotIndex_last`.
+
+All 8 confirmed literal `lhs = rhs` on re-reading. The `private`
+`bareissCyclicShift_apply_zero` left `@[simp]`-only per the sweep's
+public-API scope.
+
+`matrixEquiv_symm_apply`'s LHS is `getElem`-headed
+(`(matrixEquiv.symm M)[i][j] = M i j`), the one carrying any risk of the
+`Array.getD`→`dite` invalid-pattern rejection flagged in the boundary
+skill. `grind =` accepted it cleanly — `Hex.Matrix`/`Hex.Vector` `getElem`
+is a regular projection, not the `Array.getD` dite-headed offender.
+
+## Current frontier
+
+`lake build HexMatrixMathlib HexBerlekampZassenhausMathlib` green
+(modules: Basic 5.6s, Determinant.Core 13s — no grind-loop slowdown; full
+CI-gated BZ Mathlib library built, 3792 jobs). `scripts/check_dag.py` exit
+0. Annotation-only; no proof bodies, signatures, or imports changed, no
+banned terms added.
+
+## Next step
+
+None for this issue. Sibling unclaimed Phase 6 sweeps in the same library:
+#8104 (`HexMatrixMathlib/RankSpanNullspace.lean`) and #8102
+(`HexBerlekampMathlib/Basic.lean`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8099

Session: `72d5dba1-34ba-42e5-90ba-482635a35698`

4f247855 chore: progress note for #8099 grind sweep
3f372fc0 feat: Phase 6 grind coverage for HexMatrixMathlib Basic.lean and Determinant/Core.lean (#8099)

🤖 Prepared with Claude Code