### PR TITLE
feat: Phase 6 grind coverage for HexPolyMathlib/Euclid.lean

### DIFF
--- a/HexPolyMathlib/Euclid.lean
+++ b/HexPolyMathlib/Euclid.lean
@@ -83,7 +83,7 @@ Bezout combination to the named raw gcd; the matching pattern only fires when
 the goal mentions `Hex.DensePoly.xgcd p q` literally with both coefficient
 projections, so the rule is narrow.
 -/
-@[simp]
+@[simp, grind =]
 theorem toPolynomial_xgcd_bezout_raw [Field R] [DecidableEq R] [Hex.DensePoly.GcdLaws R]
     (p q : Hex.DensePoly R) :
     toPolynomial (Hex.DensePoly.xgcd p q).left * toPolynomial p +

--- a/progress/20260619_220248_7b0673c7.md
+++ b/progress/20260619_220248_7b0673c7.md
@@ -1,0 +1,34 @@
+# Phase 6 grind coverage for HexPolyMathlib/Euclid.lean (#8108)
+
+## Accomplished
+
+Promoted the single equation-shaped public `@[simp]` lemma in
+`HexPolyMathlib/Euclid.lean`, `toPolynomial_xgcd_bezout_raw`, to
+`@[simp, grind =]`. Re-read at the point of promotion: its conclusion is a
+literal `lhs = rhs` (`toPolynomial (xgcd p q).left * toPolynomial p +
+toPolynomial (xgcd p q).right * toPolynomial q = toPolynomial (xgcd p q).gcd`),
+LHS head is `+` (a valid E-matching pattern, not `dite`/`getD`/`let`). The
+other public theorems in the file are `Associated`-shaped
+(`toPolynomial_xgcd_bezout_associated`, `equiv_gcd_associated`,
+`equiv_xgcd_bezout_raw`, `toPolynomial_gcd_associated`,
+`toPolynomial_xgcd_gcd_associated`, `equiv_xgcd_bezout_associated`) or carry no
+`@[simp]`, so they stay out of scope. This completes the `HexPolyMathlib`
+library sweep (Basic.lean was done by #8070).
+
+## Current frontier
+
+`lake build HexPolyMathlib.Euclid` green (Euclid 2.1s, no grind-loop slowdown,
+no `Try this`/`invalid pattern` rejection). Full CI-gated
+`lake build HexBerlekampZassenhausMathlib` (3790 jobs) completes successfully,
+zero `error:`; the sole warning (`Recovery.lean:1874` unused variable) is
+pre-existing and in an unrelated file. Annotation-only; no proof bodies
+changed, no imports touched.
+
+## Next step
+
+None for this issue. Remaining unclaimed Phase 6 sweeps at session start:
+#8104 (HexMatrixMathlib/RankSpanNullspace.lean), #8112 (HexGFqMathlib/GF2q.lean).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8108

Session: `7b0673c7-0648-4cc5-8650-7e00608e368d`

129dc22e feat: Phase 6 grind coverage for HexPolyMathlib/Euclid.lean (#8108)

🤖 Prepared with Claude Code