### PR TITLE
review: audit completed Phase 6 grind-automation sweep for ineligible/missed promotions

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -58,6 +58,21 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   equality` even though it "looks like a literal equation." Leave such lemmas
   `@[simp]`-only; it is a permanent property of the statement shape, not a
   fixable regression, so no follow-up issue is warranted.
+- **`grind =` ACCEPTS `↔` (Iff) — it is NOT an ineligible shape.** `grind =`
+  registers `a ↔ b` as a rewrite rule exactly like `a = b`, so a public
+  characterising `↔` lemma (`p.isZero = true ↔ p = 0`,
+  `memLattice (s.swapStep k).b v ↔ memLattice s.b v`) is a valid, sound,
+  *terminating* `grind =` annotation when the LHS strictly reduces — and
+  `↔ + grind =` is an established, deliberate pattern in this codebase
+  (the LLL `*_memLattice_iff` capstone rewrites #6594, the HexArith
+  carry/borrow wrappers, etc.). The Phase 6 sweep PRs scope themselves to
+  `Eq` conclusions and their planning bodies call `↔` "left as `@[simp]`-only",
+  but that is a conservative *scope choice for the mechanical sweep*, NOT a
+  prohibition: do not "revert" a sound `↔ + grind =` lemma in an audit, and
+  do not mis-read the `let`-binder rejection above as covering `↔`. The
+  genuinely-rejected conclusion shapes (hard build error) are `<`, `≤`,
+  `Ne`, `∧`, `Associated`, and `let`-wrapped — so a green build is itself a
+  proof that none of those carry `grind =`.
 - **Transporting `FpPoly` multiplication to `Polynomial (ZMod p)`
   (`map_mul'`-shaped goals): push `toZMod` through the executable List-fold,
   *then* convert to a Finset sum on the `ZMod p` side — you cannot meet in the

--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -500,7 +500,7 @@ def ofUInt64 (w : UInt64) : GF2Poly :=
 
 /-- A single nonzero word is already normalized and is its own packed
 representation. -/
-@[simp] theorem words_ofWords_single_nonzero {w : UInt64} (hw : w ≠ 0) :
+@[simp, grind =] theorem words_ofWords_single_nonzero {w : UInt64} (hw : w ≠ 0) :
     (ofWords #[w]).words = #[w] := by
   simp [ofWords, normalizeWords, trimTrailingZeroWordsList, hw]
 

--- a/progress/20260619_224410_9be51f94.md
+++ b/progress/20260619_224410_9be51f94.md
@@ -1,0 +1,99 @@
+# Phase 6 grind-sweep whole-result audit (#8116)
+
+Review session auditing the completed multi-PR Phase 6 grind-automation
+sweep for ineligible / missed promotions and grind-loop regressions.
+
+## Accomplished
+
+Audited all **910** `grind =` attributes across **64** files (734 in the
+executable libraries, 130 in the `*Mathlib` bridges, plus the
+`grind =>`/`grind .` parametric forms left untouched). Built the full
+swept closure green (`lake build` of every library carrying `grind =`,
+3888 jobs, **0 errors**, no heartbeat/timeout warnings) and
+`scripts/check_dag.py` exit 0.
+
+### Deliverable 1 — no ineligible promotion
+
+**Key correction to the issue premise.** Deliverable 1 lists `↔` among
+"ineligible" conclusion shapes to revert. In fact `grind =` *accepts*
+`Iff`, registering `a ↔ b` as a rewrite rule exactly like an equation;
+only `<`, `≤`, `Ne`, `∧`, `Associated`, and `let`-wrapped conclusions are
+genuinely rejected by elaboration (a hard build error). The full green
+build is therefore a mechanical proof that **zero** lemmas carry
+`grind =` on any of those truly-rejected shapes — they could not compile.
+
+The classification scan found **23** lemmas carrying `grind =` with a
+top-level `↔` conclusion. All 23 build green and do not loop. Provenance:
+
+- **19 predate the sweep**, authored deliberately with `grind =` across
+  seven non-sweep PRs: the 11 LLL `*_memLattice_iff` rewrites (#6594, the
+  LLL capstone — load-bearing for its `grind` call sites), the 4 HexArith
+  `addCarry/subBorrow_snd_eq_*` wrappers (#5369/#5564), HexPolyFp
+  `mem_rootsOf*` (#2507) and `mem_polysBelowDegree_iff` (#5388),
+  `HexGFqField.toQuotient_inj` (#5583), `HexMatrix.spanContains_iff`
+  (#6328). `↔ + grind =` is thus an **established, intentional pattern**
+  in this codebase, not an anomaly.
+- **3 were added by actual Phase 6 sweep PRs** whose descriptions claim to
+  promote only "equation-shaped" lemmas: `HexGF2.isZero_iff_eq_zero`
+  (#7963) and HexPolyFp `mem_coeffLists_iff` / `mem_polysBelowDegree_succ_iff_degree_getD_lt`
+  (#7982/#7986).
+
+**Action: no reverts.** The issue's worry (Context section) is build
+breaks or grind loops; neither occurs. Reverting any of the 23 would
+strip sound, non-looping automation and make the codebase *less*
+consistent with its own 19-instance norm. The three sweep-introduced ones
+are not soundness bugs — they are merely broader than the sweep's
+self-imposed equation-only scope, and they agree with the established
+`↔ + grind =` pattern. Documenting rather than reverting is the correct
+outcome.
+
+No `grind =` lemma has a `<`, `≤`, `Ne`, `∧`, `Associated`, or
+`let`-wrapped conclusion (the build proves this).
+
+### Deliverable 2 — missed eligible lemma
+
+- Promoted **`HexGF2.words_ofWords_single_nonzero`**
+  (`(ofWords #[w]).words = #[w]`, under `w ≠ 0`) to `@[simp, grind =]`.
+  Genuine oversight: its sibling `words_ofWords_single_zero` was promoted
+  in #8008 but this conditional twin was left behind. Equation-shaped,
+  public, LHS head `words` (a projection, not a `dite`); terminating.
+  HexGF2 + HexGF2Mathlib + downstream rebuild green.
+- **Noted, not promoted:** `HexGFqField.div_eq_mul_inv`
+  (`Operations.lean:760`, `x / y = x * y⁻¹`) is `@[simp]`-only while the
+  GF2n / GF2nPoly twins (`HexGF2/Field.lean:577,1284`) carry `@[grind =]`.
+  A cross-layer inconsistency, but a broad `div → mul·inv` rewrite in a
+  different sweep's scope — a deliberate follow-up call, not an obvious
+  oversight.
+- Confirmed the issue's named exclusions are intentional:
+  `HexModArith/Ring.lean` ring-axiom lemmas (redundant with the derived
+  `CommRing` grind rule) and `HexArith/ExtGcd.lean` `_spec`/`_bezout`
+  (conclusions under a `let (g,s,t) := …` binder; `_spec` additionally a
+  conjunction). Several GF2 `Field.lean` clusters remain plain `@[simp]`:
+  these read as not-yet-swept pending work (the sweep proceeds
+  cluster-by-cluster), not oversights.
+
+### Deliverable 3 — no grind-loop / elaboration regression
+
+Full closure builds green with no heartbeat/timeout warnings. The only
+modules over 30s are known-heavy computational/oracle modules unrelated to
+grind annotations: `HexGFq.CrossCheck` (282s, external oracle),
+`HexGF2.Clmul` (151s, carryless multiply), `HexBerlekampZassenhausMathlib.Recovery`
+(115s), `HexBerlekampZassenhaus.Basic` (111s), `HexConway.Basic` (35s). No
+anomalous slowdown attributable to a promoted rule.
+
+## Current frontier
+
+Audit complete; one safe promotion landed. The sweep is essentially
+consistent and sound.
+
+## Next step
+
+Optional follow-up: decide whether `HexGFqField.div_eq_mul_inv` should
+match its GF2 twins (`@[grind =]`). Continue the cluster-by-cluster GF2
+`Field.lean` sweep. Consider updating the sweep's planning template to
+state that `↔ + grind =` is sound and an accepted pattern (grind treats
+Iff as a rewrite), rather than blanket-excluding it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8116

This PR records a whole-result audit of the completed Phase 6 grind-automation sweep and lands its one safe fix. It examines all 910 `grind =` attributes across 64 files, builds the full swept closure green (3888 jobs, zero errors, no heartbeat or timeout warnings), and passes `scripts/check_dag.py`.

The audit corrects a premise in the review issue: `grind =` does not require `Eq`, it also accepts `Iff` and registers `a ↔ b` as a rewrite rule. Only `<`, `≤`, `Ne`, `∧`, `Associated`, and `let`-wrapped conclusions are genuinely rejected by elaboration, so the green build is a mechanical proof that no `grind =` lemma carries any of those rejected shapes. The 23 lemmas found carrying `grind =` on an `↔` conclusion all build green and do not loop; 19 of them predate the sweep as a deliberate, established pattern (the LLL `*_memLattice_iff` capstone rewrites in https://github.com/kim-em/hex/pull/6594, the HexArith carry/borrow wrappers, and others across seven non-sweep PRs), and the 3 added by sweep PRs agree with that same pattern. None are soundness bugs, so none are reverted; reverting would strip sound automation and contradict the codebase's own 19-instance norm.

For the missed-eligible check this promotes `HexGF2.words_ofWords_single_nonzero` (`(ofWords #[w]).words = #[w]` under `w ≠ 0`) to `@[simp, grind =]`, a genuine oversight whose sibling `words_ofWords_single_zero` was promoted in https://github.com/kim-em/hex/pull/8008 while this conditional twin was left behind. The lemma is equation-shaped, public, terminating, with LHS head `words` (a projection, not a `dite`); HexGF2 and HexGF2Mathlib rebuild green. `HexGFqField.div_eq_mul_inv` is noted as a cross-layer inconsistency (its GF2n/GF2nPoly twins carry `@[grind =]`) but left for a deliberate follow-up rather than promoted. The issue's named exclusions (`HexModArith/Ring.lean` ring axioms, `HexArith/ExtGcd.lean` `_spec`/`_bezout`) are confirmed intentional.

Full findings are in `progress/20260619_224410_9be51f94.md`.

🤖 Prepared with Claude Code