### PR TITLE
feat: Phase 6 grind coverage for HexMatrix Determinant/Basic column-construction cluster

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -57,7 +57,19 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   refuses it with `invalid E-matching equality theorem, conclusion must be an
   equality` even though it "looks like a literal equation." Leave such lemmas
   `@[simp]`-only; it is a permanent property of the statement shape, not a
-  fixable regression, so no follow-up issue is warranted.
+  fixable regression, so no follow-up issue is warranted. A third rejection,
+  independent of the head/conclusion shape: a literal `lhs = rhs` whose
+  **parameters appear only under a binder in the LHS** is rejected with
+  `invalid pattern(s) for <lemma> … the following theorem parameters cannot
+  be instantiated`. `grind =` keys on the LHS head term, so a param that
+  surfaces only inside a `fun`/`ofFn` lambda (e.g. `dotProduct_basis_basis`'s
+  `i j` inside `ofFn (fun b => if i = b then …)`, or
+  `columnTupleMatrix_compose_perm_entry`'s `s sigma` inside
+  `fun i => s[sigma[i]]`, both `HexMatrix`) cannot be solved for. Same hard
+  build error, same disposition: leave `@[simp]`-only, note why in the
+  docstring/PR body. Indices that appear as a projection of a direct param
+  (`i.val` inside a `Fin.mk` index) DO instantiate fine — only fully
+  binder-bound params fail.
 - **`grind =` ACCEPTS `↔` (Iff) — it is NOT an ineligible shape.** `grind =`
   registers `a ↔ b` as a rewrite rule exactly like `a = b`, so a public
   characterising `↔` lemma (`p.isZero = true ↔ p = 0`,

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -887,7 +887,11 @@ private theorem foldl_dotProduct_basis_body {R : Type u} [Lean.Grind.CommRing R]
       rw [hxi, hxj]
       exact ih (acc + (if i = x then 1 else 0) * (if j = x then 1 else 0))
 
-/-- Dot product of the `i`-th and `j`-th identity rows. -/
+/-- Dot product of the `i`-th and `j`-th identity rows.
+
+Left `@[simp]`-only (not promoted to `grind =`): the indices `i j` appear only
+under the `ofFn` binders, so the LHS pattern `dotProduct (ofFn _) (ofFn _)`
+cannot instantiate them and `grind =` rejects it. -/
 @[simp] theorem dotProduct_basis_basis {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (i j : Fin n) :
     Hex.Vector.dotProduct

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -5652,7 +5652,7 @@ private def setColumnChoice {n m : Nat} (choices : Fin n → Option (Fin m))
     (dst : Fin n) (k : Fin m) : Fin n → Option (Fin m) :=
   fun c => if c = dst then some k else choices c
 
-@[simp] private theorem columnChoiceMatrix_entry
+@[simp, grind =] private theorem columnChoiceMatrix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (r c : Fin n) :
     (columnChoiceMatrix source coeff choices)[r][c] =
@@ -5875,7 +5875,11 @@ def columnTupleVectorFn {n m : Nat} (cols : Vector (Fin m) n) : Fin n → Fin m 
     columnTupleVectorFn cols i = cols[i] := rfl
 
 /-- Reindexing the selected columns by a permutation is entrywise the generic
-column permutation of the selected minor. -/
+column permutation of the selected minor.
+
+Left `@[simp]`-only (not promoted to `grind =`): the columns `s sigma` appear
+only under the `fun i => s[sigma[i]]` binder, so the LHS pattern cannot
+instantiate them and `grind =` rejects it. -/
 @[simp] theorem columnTupleMatrix_compose_perm_entry
     {R : Type u} {n m : Nat} (A : Matrix R n m)
     (s : Vector (Fin m) n) (sigma : Vector (Fin n) n)
@@ -6446,7 +6450,7 @@ private def columnSumMatrixWithPrefix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[simp] private theorem columnSumMatrixWithPrefix_entry
+@[simp, grind =] private theorem columnSumMatrixWithPrefix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithPrefix source coeff chosen)[r][j] =
@@ -6584,7 +6588,7 @@ private def columnSumMatrixWithSuffix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[simp] private theorem columnSumMatrixWithSuffix_entry
+@[simp, grind =] private theorem columnSumMatrixWithSuffix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithSuffix source coeff chosen)[r][j] =
@@ -6727,7 +6731,7 @@ private def assembleColumnsSuffix {n m : Nat} (chosen : List (Fin m))
   ⟨(pref.toList ++ chosen).toArray, by
     simp [hk]⟩
 
-@[simp] private theorem assembleColumnsSuffix_left
+@[simp, grind =] private theorem assembleColumnsSuffix_left
     {n m : Nat} (chosen : List (Fin m))
     (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
     (i : Fin (n - chosen.length)) :
@@ -6737,7 +6741,7 @@ private def assembleColumnsSuffix {n m : Nat} (chosen : List (Fin m))
           omega⟩ : Fin n)] = pref[i] := by
   simp [assembleColumnsSuffix]
 
-@[simp] private theorem assembleColumnsSuffix_right
+@[simp, grind =] private theorem assembleColumnsSuffix_right
     {n m : Nat} (chosen : List (Fin m))
     (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
     (i : Fin chosen.length) :
@@ -8908,7 +8912,7 @@ private def rowMoveUp {R : Type u} {n m : Nat} (M : Matrix R n m) (src : Nat) :
     rowMoveUp
       (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩) src k (by omega)
 
-@[simp] private theorem rowMoveUp_zero {R : Type u} {n m : Nat}
+@[simp, grind =] private theorem rowMoveUp_zero {R : Type u} {n m : Nat}
     (M : Matrix R n m) (src : Nat) (h : src + 0 < n) :
     rowMoveUp M src 0 h = M := rfl
 

--- a/progress/20260620_011122_6448a255.md
+++ b/progress/20260620_011122_6448a255.md
@@ -1,0 +1,53 @@
+# Phase 6 grind coverage for HexMatrix Determinant/Basic column-construction cluster (#8138)
+
+## Accomplished
+
+Promoted 6 `@[simp]`-only equation lemmas in the column-construction cluster
+of `HexMatrix/Determinant.lean` to `@[simp, grind =]`:
+
+- `columnChoiceMatrix_entry` (`:5655`, `match` RHS)
+- `columnSumMatrixWithPrefix_entry` (`:6449`, `dite` RHS)
+- `columnSumMatrixWithSuffix_entry` (`:6587`, `dite` RHS)
+- `assembleColumnsSuffix_left` (`:6730`)
+- `assembleColumnsSuffix_right` (`:6740`)
+- `rowMoveUp_zero` (`:8911`, `:= rfl`)
+
+All six are private; `grind =` registers private lemmas fine. The two
+`assembleColumnsSuffix` lemmas index by `⟨i.val, proof⟩`; the embedded `by`
+proof did not block pattern extraction (`i` instantiates via `i.val`).
+
+## Exclusions
+
+The two **public** candidate lemmas were rejected by `grind =` elaboration
+(a hard build error) and left `@[simp]`-only, each with a one-line docstring
+note recording why:
+
+- `dotProduct_basis_basis` (`HexMatrix/Basic.lean:891`): indices `i j` appear
+  only under the `ofFn` binders (`fun b => if i = b then 1 else 0`), so the
+  LHS pattern `dotProduct (ofFn _) (ofFn _)` cannot instantiate them
+  (`invalid pattern(s) … i j cannot be instantiated`).
+- `columnTupleMatrix_compose_perm_entry` (`HexMatrix/Determinant.lean:5879`):
+  columns `s sigma` appear only under the `fun i => s[sigma[i]]` binder, same
+  under-binder non-instantiability.
+
+Both are genuine literal equations (the issue anticipated some candidates
+might be ineligible), but their parameters live under binders in the LHS,
+which `grind =` cannot key on — a permanent property of the statement shape,
+not a fixable regression.
+
+## Current frontier
+
+- `lake build HexMatrix.Basic HexMatrix.Determinant` green.
+- `lake build HexMatrix HexMatrixMathlib` green (2664 jobs, zero errors, zero
+  warnings — no grind heartbeat/timeout, no `Try this` marker noise).
+- `python3 scripts/check_dag.py` exit 0.
+- Annotation/docstring-only: no proof bodies, signatures, imports, or
+  `*Mathlib` files touched. No `axiom`/`sorry`/`native_decide` on added lines.
+
+## Next step
+
+None for this issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8138

Session: `6448a255-1181-478b-a981-9959780960af`

3e843b24 chore: document grind = under-binder parameter rejection in boundary skill
17dac632 feat: Phase 6 grind coverage for HexMatrix column-construction cluster (#8138)

🤖 Prepared with Claude Code