### PR TITLE
feat: Phase 6 grind coverage for HexModArith/Basic.lean values-enumeration cluster

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -148,7 +148,7 @@ def values (p : Nat) [Bounds p] : List (ZMod64 p) :=
   (List.range p).map fun n => ofNat p n
 
 /-- The canonical list of residues modulo `p` has one entry for each representative. -/
-@[simp] theorem values_length : (values p).length = p := by
+@[simp, grind =] theorem values_length : (values p).length = p := by
   simp [values]
 
 /-- Every residue appears in `values`. -/
@@ -162,7 +162,7 @@ theorem mem_values (a : ZMod64 p) : a ∈ values p := by
   exact (Nat.mod_eq_of_lt a.toNat_lt).trans (by rfl)
 
 /-- Membership in the canonical residue list is automatic for every residue. -/
-@[simp] theorem mem_values_iff (a : ZMod64 p) : a ∈ values p ↔ True :=
+@[simp, grind =] theorem mem_values_iff (a : ZMod64 p) : a ∈ values p ↔ True :=
   iff_true_intro (mem_values a)
 
 /-- Reduced representatives below `p` construct the same residue exactly when

--- a/progress/2026-06-20_872853d6.md
+++ b/progress/2026-06-20_872853d6.md
@@ -1,0 +1,30 @@
+# 2026-06-20 — feature session 872853d6
+
+Session type: feature (`/work` → #8141)
+
+## Accomplished
+
+Completed #8141: Phase 6 grind coverage for `HexModArith/Basic.lean`
+`values`-enumeration cluster. Promoted the two missed public
+`@[simp]`-only equation/iff lemmas to `@[simp, grind =]`:
+
+- `values_length` — `(values p).length = p` (literal `=`).
+- `mem_values_iff` — `a ∈ values p ↔ True` (`↔`, accepted by `grind =`).
+
+Excluded `toNat_lt` (`a.toNat < p`, `<`-headed) as specified.
+Annotation-only; no proof bodies, signatures, or imports touched.
+
+## Current frontier
+
+`lake build HexModArith` green (82 jobs, no new warnings),
+`python3 scripts/check_dag.py` exit 0. Diff is exactly the two
+attribute additions.
+
+## Next step
+
+Open PR closing #8141. Remaining unclaimed Phase 6 grind issues:
+#8144 (HexGFq inv_zero), #8151 (HexPolyZ ratPolyPow).
+
+## Blockers
+
+None. Directive #2564 remains blocked on its dependency chain.


### PR DESCRIPTION
Closes #8141

Session: `872853d6-c6fa-4200-a5ed-336c6b15b9c6`

3a7d2cbe chore: progress entry for #8141 (session 872853d6)
69d6dd78 feat: Phase 6 grind coverage for HexModArith/Basic.lean values cluster (#8141)

🤖 Prepared with Claude Code