### PR TITLE
feat: HexModArithMathlib Phase 7 closeout — reconcile and bump done_through to 7

### DIFF
--- a/libraries.yml
+++ b/libraries.yml
@@ -357,7 +357,7 @@ libraries:
   HexModArithMathlib:
     deps: [HexModArith]
     mathlib: true
-    done_through: 6
+    done_through: 7
     status: active
   HexGramSchmidtMathlib:
     deps: [HexGramSchmidt, HexMatrixMathlib]

--- a/progress/20260620_030000_e4b96d64.md
+++ b/progress/20260620_030000_e4b96d64.md
@@ -1,0 +1,45 @@
+# HexModArithMathlib Phase 7 closeout — done_through 6→7 (#8164)
+
+## Accomplished
+
+Reconciled and completed the Phase 7 closeout bookkeeping for
+`HexModArithMathlib`.
+
+**Reconciliation (the issue's main caveat).** The issue body claimed
+`libraries.yml` showed `done_through: 4`, raising the possibility this
+was a Phase 6 gap rather than a Phase 7 closeout. That value was
+**stale**: the live file already showed `done_through: 6`, bumped by
+#7899 ("HexModArithMathlib Phase 6: docstrings + automation audit").
+`scripts/status.py` computes `phase = done_through + 1`, so at 6 it
+reported "HexModArithMathlib -> Phase 7 (Ready)" — fully consistent,
+no metadata conflict. Phase 6 is genuinely complete, so the only
+remaining step was the closeout bump 6→7.
+
+**Bump.** `libraries.yml[HexModArithMathlib].done_through: 6 → 7`
+(one-line diff).
+
+## Verification
+
+- `lake build HexManual` green (2545 jobs); chapter
+  `HexManual.Chapters.HexModArithMathlib` built (job 2479/2545). The
+  181-line reference chapter's `{name}`/`{ref}` directives all resolve
+  (Verso errors on unresolved directives; build is green).
+- `python3 scripts/check_dag.py` exit 0.
+- `python3 scripts/status.py` now lists `HexModArithMathlib` under
+  "Fully done", no longer "Ready".
+- No `axiom`/`sorry`/`native_decide` introduced; no computational
+  `*Mathlib` library gained a Mathlib dependency.
+
+## Current frontier
+
+Closeout complete. The build warnings seen during `lake build HexManual`
+are pre-existing `linter.unusedSimpArgs` hints in `HexGF2Mathlib/Basic.lean`
+(lines 369, 379), unrelated to this issue.
+
+## Next step
+
+None for this issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8164

Session: `e4b96d64-1b1d-48e8-a7f7-75872a05ce8a`

c5335b15 feat: HexModArithMathlib Phase 7 closeout — bump done_through to 7 (#8164)

🤖 Prepared with Claude Code