### PR TITLE
refactor: replace divMod/trim implemented_by with proven csimp

### DIFF
--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -110,29 +110,113 @@ theorem trimTrailingZerosList_normalized (coeffs : List R) :
             · apply has_last
               simpa [trimTrailingZerosList, htrim, htail] using hlast
 
-/-- Runtime helper for `trimTrailingZeros`: scan `coeffs` from index `ceil - 1`
-downward for the highest nonzero coefficient and keep that prefix. Structural on
-`ceil`, mirroring `trimTrailingZerosList` on `coeffs.toList` without the
-`Array → List → Array` round-trip. -/
-private def trimTrailingZerosImplAux (coeffs : Array R) : Nat → Array R
-  | 0 => #[]
-  | ceil + 1 =>
-      if coeffs.getD ceil (Zero.zero : R) = (Zero.zero : R) then
-        trimTrailingZerosImplAux coeffs ceil
-      else
-        coeffs.shrink (ceil + 1)
+/-- Appending a trailing zero does not change the trailing-zero-trimmed list. -/
+private theorem trimTrailingZerosList_append_zero (L : List R) :
+    trimTrailingZerosList (L ++ [(Zero.zero : R)]) = trimTrailingZerosList L := by
+  induction L with
+  | nil => simp [trimTrailingZerosList]
+  | cons a as ih =>
+      show trimTrailingZerosList (a :: (as ++ [Zero.zero])) = trimTrailingZerosList (a :: as)
+      unfold trimTrailingZerosList
+      rw [ih]
 
-/-- Runtime implementation of `trimTrailingZeros`. Returns the same array value as
-the reference definition (the input with its trailing zeros dropped) but works
-directly on the array, reusing the input storage in place when it is uniquely
-referenced instead of allocating an intermediate list. -/
-private def trimTrailingZerosImpl (coeffs : Array R) : Array R :=
-  trimTrailingZerosImplAux coeffs coeffs.size
+/-- A list whose last entry is nonzero is its own trailing-zero-trim. -/
+private theorem trimTrailingZerosList_append_ne_zero (L : List R) {v : R}
+    (hv : v ≠ (Zero.zero : R)) :
+    trimTrailingZerosList (L ++ [v]) = L ++ [v] := by
+  induction L with
+  | nil => simp [trimTrailingZerosList, hv]
+  | cons a as ih =>
+      show trimTrailingZerosList (a :: (as ++ [v])) = a :: (as ++ [v])
+      unfold trimTrailingZerosList
+      rw [ih]; simp
 
-/-- Normalize a coefficient array by discarding all trailing zeros. -/
-@[implemented_by trimTrailingZerosImpl]
+/-- Normalize a coefficient array by discarding all trailing zeros. The compiled runtime
+uses the value-equal `trimTrailingZerosImpl` (proved by `trimTrailingZeros_eq_impl`,
+registered `@[csimp]`), which pops trailing zeros off the array in place instead of
+round-tripping through `coeffs.toList`. -/
 def trimTrailingZeros (coeffs : Array R) : Array R :=
   (trimTrailingZerosList coeffs.toList).toArray
+
+omit [Zero R] [DecidableEq R] in
+/-- An array with last element `v` splits as `pop ++ [v]` on the list side. -/
+private theorem toList_eq_pop_append (coeffs : Array R) {v : R} (hb : coeffs.back? = some v) :
+    coeffs.toList = coeffs.pop.toList ++ [v] := by
+  have hgl : coeffs.toList.getLast? = some v := by
+    rw [List.getLast?_eq_getElem?, Array.length_toList, Array.getElem?_toList,
+      ← Array.back?_eq_getElem?, hb]
+  have hne : coeffs.toList ≠ [] := by intro h; rw [h] at hgl; simp at hgl
+  have hv : coeffs.toList.getLast hne = v := by
+    rw [List.getLast?_eq_some_getLast hne] at hgl
+    exact (Option.some.injEq _ _).mp hgl
+  rw [Array.toList_pop, ← hv]
+  exact (List.dropLast_concat_getLast hne).symm
+
+/-- An array whose last entry is nonzero (or which is empty) is already trailing-zero free,
+so trimming its coefficient list returns the list unchanged. -/
+private theorem trimTrailingZerosList_toList_self (coeffs : Array R)
+    (hb : coeffs.back? ≠ some (Zero.zero : R)) :
+    trimTrailingZerosList coeffs.toList = coeffs.toList := by
+  cases hbk : coeffs.back? with
+  | none => rw [Array.back?_eq_none_iff] at hbk; subst hbk; simp [trimTrailingZerosList]
+  | some v =>
+      have hv : v ≠ (Zero.zero : R) := fun h => hb (h ▸ hbk)
+      rw [toList_eq_pop_append coeffs hbk, trimTrailingZerosList_append_ne_zero _ hv]
+
+/-- Trimming an array with nonzero last entry (or empty) is the identity. -/
+private theorem trimTrailingZeros_self (coeffs : Array R)
+    (hb : coeffs.back? ≠ some (Zero.zero : R)) :
+    trimTrailingZeros coeffs = coeffs := by
+  unfold trimTrailingZeros
+  rw [trimTrailingZerosList_toList_self coeffs hb, Array.toArray_toList]
+
+/-- Popping a trailing zero does not change the trim. -/
+private theorem trimTrailingZeros_pop (coeffs : Array R)
+    (hb : coeffs.back? = some (Zero.zero : R)) :
+    trimTrailingZeros coeffs.pop = trimTrailingZeros coeffs := by
+  unfold trimTrailingZeros
+  rw [toList_eq_pop_append coeffs hb, trimTrailingZerosList_append_zero]
+
+/-- Runtime loop for `trimTrailingZeros`: pop trailing zeros off the array, up to `n` of
+them. With `n = coeffs.size` it pops the whole trailing-zero run, reusing the input
+storage in place when it is uniquely referenced rather than allocating a list. -/
+private def trimTrailingZerosGo (coeffs : Array R) : Nat → Array R
+  | 0 => coeffs
+  | n + 1 =>
+      if coeffs.back? = some (Zero.zero : R) then trimTrailingZerosGo coeffs.pop n else coeffs
+
+/-- Once the fuel `n` is at least the array size, `trimTrailingZerosGo` has popped the whole
+trailing-zero run and so agrees with `trimTrailingZeros`. -/
+private theorem trimTrailingZerosGo_eq (n : Nat) :
+    ∀ (coeffs : Array R), coeffs.size ≤ n →
+      trimTrailingZerosGo coeffs n = trimTrailingZeros coeffs := by
+  induction n with
+  | zero =>
+      intro coeffs hsize
+      have hbk : coeffs.back? = none := by
+        rw [Array.back?_eq_getElem?]; exact Array.getElem?_eq_none (by omega)
+      have hbne : coeffs.back? ≠ some (Zero.zero : R) := by rw [hbk]; simp
+      rw [trimTrailingZerosGo, trimTrailingZeros_self coeffs hbne]
+  | succ n ih =>
+      intro coeffs hsize
+      rw [trimTrailingZerosGo]
+      by_cases hb : coeffs.back? = some (Zero.zero : R)
+      · rw [if_pos hb, ih coeffs.pop (by rw [Array.size_pop]; omega), trimTrailingZeros_pop coeffs hb]
+      · rw [if_neg hb, trimTrailingZeros_self coeffs hb]
+
+/-- Runtime implementation of `trimTrailingZeros`. -/
+private def trimTrailingZerosImpl (coeffs : Array R) : Array R :=
+  trimTrailingZerosGo coeffs coeffs.size
+
+/-- Register the value-equal `trimTrailingZerosImpl` as the compiled implementation of
+`trimTrailingZeros`. Unlike `@[implemented_by]`, the `@[csimp]` swap is backed by the proof
+`trimTrailingZerosGo_eq`, so the runtime loop is verified equal to the specification. -/
+@[csimp]
+private theorem trimTrailingZeros_eq_impl : @trimTrailingZeros = @trimTrailingZerosImpl := by
+  funext R _ _ coeffs
+  show trimTrailingZeros coeffs = trimTrailingZerosImpl coeffs
+  unfold trimTrailingZerosImpl
+  exact (trimTrailingZerosGo_eq coeffs.size coeffs (Nat.le_refl _)).symm
 
 /-- Build a dense polynomial from a raw coefficient array by normalizing away trailing zeros. -/
 def ofCoeffs (coeffs : Array R) : DensePoly R :=

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -507,10 +507,13 @@ private def subtractScaledShiftImpl [Sub R] [Mul R]
 /-- Runtime loop for `divModArrayAux` that resumes the degree scan from the previous
 remainder degree instead of rescanning from the top each step. The reference loop calls
 `arrayDegree? rem` (a scan from `rem.size` downward) on every iteration, which is `O(n)`
-per step and `O(n²)` overall; here `ceil` is the scan ceiling, which only ever decreases,
-so the total scanning cost is `O(n)`. Every coefficient above the current degree `rd` is
-already zero, so `arrayDegreeAux rem ceil` with `ceil = rd + 1` returns the same index as
-the reference's `arrayDegree? rem`. -/
+per step and `O(n²)` overall; here `ceil` is the scan ceiling, which in the well-formed
+case (`q.size = qDegree + 1`) only ever decreases, so the total scanning cost is `O(n)`.
+After eliminating at degree `rd`, the only coefficients that can be nonzero are those at
+or below `max (rd + 1) (shift + q.size)` — the elimination window tops out at
+`shift + q.size - 1` and everything above `rd` was already zero — so seeding the next scan
+at that ceiling returns the same index as the reference's `arrayDegree? rem`.
+`divModArrayAux_eq_impl` proves the two loops agree on every input. -/
 private def divModArrayAuxImplGo [Sub R] [Mul R]
     (q : Array R) (qDegree : Nat) (scaleLead : R → R) :
     Nat → Nat → Array R → Array R → Array R × Array R
@@ -526,7 +529,8 @@ private def divModArrayAuxImplGo [Sub R] [Mul R]
             let coeff := scaleLead (rem.getD rd (Zero.zero : R))
             let quot := quot.set! shift coeff
             let rem := subtractScaledShiftImpl q shift coeff 0 q.size rem
-            divModArrayAuxImplGo q qDegree scaleLead fuel (rd + 1) quot rem
+            divModArrayAuxImplGo q qDegree scaleLead fuel
+              (Nat.max (rd + 1) (shift + q.size)) quot rem
 
 /-- Runtime implementation of `divModArrayAux`. Seeds the scan ceiling at `rem.size`, so
 the first iteration is identical to the reference's `arrayDegree? rem`; thereafter the
@@ -539,8 +543,9 @@ private def divModArrayAuxImpl [Sub R] [Mul R]
 /-- The fuel-bounded long-division loop: while the remainder's degree `rd` is at least
 the divisor degree `qDegree`, pick the quotient coefficient `scaleLead (rem[rd])`, record
 it in `quot`, eliminate the leading term via `subtractScaledShift`, and recurse, returning
-the final `(quotient, remainder)` pair. -/
-@[implemented_by divModArrayAuxImpl]
+the final `(quotient, remainder)` pair. The compiled runtime uses the value-equal
+`divModArrayAuxImpl` (proved by `divModArrayAux_eq_impl`, registered `@[csimp]`), which
+tracks the working degree instead of rescanning. -/
 private def divModArrayAux [Sub R] [Mul R]
     (q : Array R) (qDegree : Nat) (scaleLead : R → R)
     (fuel : Nat) (quot rem : Array R) : Array R × Array R :=
@@ -558,6 +563,120 @@ private def divModArrayAux [Sub R] [Mul R]
             let quot := quot.set! shift coeff
             let rem := subtractScaledShift rem q shift coeff
             divModArrayAux q qDegree scaleLead fuel quot rem
+
+/-- Dropping a run of indices on which `coeffs` is zero does not change what
+`arrayDegreeAux` reports: scanning down from `c + n` through `n` zeros reaches the same
+answer as scanning down from `c`. -/
+private theorem arrayDegreeAux_drop {coeffs : Array R} {c : Nat}
+    (h : ∀ i, c ≤ i → coeffs.getD i (Zero.zero : R) = (Zero.zero : R)) (n : Nat) :
+    arrayDegreeAux coeffs (c + n) = arrayDegreeAux coeffs c := by
+  induction n with
+  | zero => rfl
+  | succ n ih =>
+      have hzero : coeffs.getD (c + n) (Zero.zero : R) = (Zero.zero : R) := h _ (by omega)
+      show (if coeffs.getD (c + n) (Zero.zero : R) = (Zero.zero : R)
+              then arrayDegreeAux coeffs (c + n) else some (c + n)) = arrayDegreeAux coeffs c
+      rw [if_pos hzero]
+      exact ih
+
+/-- When every coefficient at or above the scan ceiling `ceil` is zero, the bounded scan
+`arrayDegreeAux coeffs ceil` reports the same degree as the full `arrayDegree? coeffs`. -/
+private theorem arrayDegreeAux_eq_arrayDegree? {coeffs : Array R} {ceil : Nat}
+    (h : ∀ i, ceil ≤ i → coeffs.getD i (Zero.zero : R) = (Zero.zero : R)) :
+    arrayDegreeAux coeffs ceil = arrayDegree? coeffs := by
+  have hsize : ∀ i, coeffs.size ≤ i → coeffs.getD i (Zero.zero : R) = (Zero.zero : R) := by
+    intro i hi
+    unfold Array.getD
+    exact dif_neg (by omega)
+  rw [arrayDegree?]
+  rcases Nat.le_total ceil coeffs.size with hle | hle
+  · have hdrop := arrayDegreeAux_drop h (coeffs.size - ceil)
+    rw [show ceil + (coeffs.size - ceil) = coeffs.size from by omega] at hdrop
+    exact hdrop.symm
+  · have hdrop := arrayDegreeAux_drop hsize (ceil - coeffs.size)
+    rw [show coeffs.size + (ceil - coeffs.size) = ceil from by omega] at hdrop
+    exact hdrop
+
+omit [DecidableEq R] in
+/-- The tail-recursive `subtractScaledShiftImpl` realises the same fold as
+`subtractScaledShiftStep` over `List.range' j cnt`. -/
+private theorem subtractScaledShiftImpl_eq_foldl [Sub R] [Mul R]
+    (q : Array R) (shift : Nat) (coeff : R) (cnt : Nat) :
+    ∀ (j : Nat) (rem : Array R),
+      subtractScaledShiftImpl q shift coeff j cnt rem =
+        (List.range' j cnt).foldl (subtractScaledShiftStep q shift coeff) rem := by
+  induction cnt with
+  | zero => intro j rem; rfl
+  | succ cnt ih =>
+      intro j rem
+      rw [subtractScaledShiftImpl, List.range'_succ]
+      simp only [List.foldl_cons]
+      exact ih (j + 1) (subtractScaledShiftStep q shift coeff rem j)
+
+omit [DecidableEq R] in
+/-- The runtime subtraction loop computes the same array as `subtractScaledShift`. -/
+private theorem subtractScaledShiftImpl_eq [Sub R] [Mul R]
+    (rem q : Array R) (shift : Nat) (coeff : R) :
+    subtractScaledShiftImpl q shift coeff 0 q.size rem =
+      subtractScaledShift rem q shift coeff := by
+  rw [subtractScaledShiftImpl_eq_foldl, subtractScaledShift, List.range_eq_range']
+
+/-- The ceiling-tracking loop `divModArrayAuxImplGo` agrees with the rescanning reference
+`divModArrayAux`, provided every coefficient at or above the seed ceiling is already zero. -/
+private theorem divModArrayAuxImplGo_eq [Sub R] [Mul R]
+    (q : Array R) (qDegree : Nat) (scaleLead : R → R) (fuel : Nat) :
+    ∀ (ceil : Nat) (quot rem : Array R),
+      (∀ i, ceil ≤ i → rem.getD i (Zero.zero : R) = (Zero.zero : R)) →
+      divModArrayAuxImplGo q qDegree scaleLead fuel ceil quot rem =
+        divModArrayAux q qDegree scaleLead fuel quot rem := by
+  induction fuel with
+  | zero => intro ceil quot rem _; rfl
+  | succ fuel ih =>
+      intro ceil quot rem hzero
+      have hdeg : arrayDegreeAux rem ceil = arrayDegree? rem :=
+        arrayDegreeAux_eq_arrayDegree? hzero
+      unfold divModArrayAuxImplGo divModArrayAux
+      rw [hdeg]
+      cases hd : arrayDegree? rem with
+      | none => rfl
+      | some rd =>
+          dsimp only
+          by_cases hlt : rd < qDegree
+          · rw [if_pos hlt, dif_pos hlt]
+          · rw [if_neg hlt, dif_neg hlt]
+            rw [subtractScaledShiftImpl_eq rem q (rd - qDegree)
+              (scaleLead (rem.getD rd (Zero.zero : R)))]
+            apply ih
+            intro i hi
+            have hb1 : rd + 1 ≤ Nat.max (rd + 1) (rd - qDegree + q.size) :=
+              Nat.le_max_left _ _
+            have hb2 : rd - qDegree + q.size ≤ Nat.max (rd + 1) (rd - qDegree + q.size) :=
+              Nat.le_max_right _ _
+            have hi1 : rd < i := by omega
+            have hi2 : rd - qDegree + q.size ≤ i := by omega
+            rw [subtractScaledShift_getD_of_forall_ne rem q (rd - qDegree)
+              (scaleLead (rem.getD rd (Zero.zero : R))) i (by intro j hj; omega)]
+            exact arrayDegree?_some_above_eq_zero hd hi1
+
+/-- The runtime long-division loop computes the same quotient/remainder as the reference. -/
+private theorem divModArrayAuxImpl_eq [Sub R] [Mul R]
+    (q : Array R) (qDegree : Nat) (scaleLead : R → R)
+    (fuel : Nat) (quot rem : Array R) :
+    divModArrayAuxImpl q qDegree scaleLead fuel quot rem =
+      divModArrayAux q qDegree scaleLead fuel quot rem := by
+  unfold divModArrayAuxImpl
+  apply divModArrayAuxImplGo_eq
+  intro i hi
+  unfold Array.getD
+  exact dif_neg (by omega)
+
+/-- Register the value-equal `divModArrayAuxImpl` as the compiled implementation of
+`divModArrayAux`. Unlike `@[implemented_by]`, the `@[csimp]` swap is backed by the proof
+`divModArrayAuxImpl_eq`, so the runtime loop is verified equal to the specification. -/
+@[csimp]
+private theorem divModArrayAux_eq_impl : @divModArrayAux = @divModArrayAuxImpl := by
+  funext R _ _ _ _ q qDegree scaleLead fuel quot rem
+  exact (divModArrayAuxImpl_eq q qDegree scaleLead fuel quot rem).symm
 
 /-- `divModArrayAux` depends only on the pointwise values of its `scaleLead` argument:
 two scaling functions agreeing on every input produce identical quotient/remainder, so

--- a/progress/20260619T110528Z_issue-8063.md
+++ b/progress/20260619T110528Z_issue-8063.md
@@ -3,22 +3,28 @@
 ## Accomplished
 
 Value-preserving runtime optimizations to the dense-polynomial long-division
-path, via `@[implemented_by]` (logical definitions and all proofs untouched):
+path, via `@[csimp]` (logical definitions are the unchanged specification; the
+fast runtime is *proved* equal to it, so all downstream proofs are untouched and
+value-preservation is a theorem rather than a trust gap). `@[implemented_by]` is
+forbidden in this project — it is a trusted, unproven swap — so the speedup is
+carried by proven `@[csimp]` equivalences instead (the `List.length`/`lengthTR`
+pattern).
 
-- `trimTrailingZeros` (`HexPoly/Dense.lean`): runtime helper scans the array
-  for the highest nonzero coefficient and `shrink`s in place, dropping the
-  `Array → List → Array` round-trip of the reference.
+- `trimTrailingZeros` (`HexPoly/Dense.lean`): runtime pops trailing zeros off the
+  array in place, dropping the `Array → List → Array` round-trip. Proved equal to
+  the reference via `trimTrailingZeros_eq_impl` (csimp).
 - `divModArrayAux` (`HexPoly/Euclid.lean`): runtime loop carries a scan ceiling
-  that only decreases, so total degree-scanning is amortized `O(n)` rather than
-  the reference's per-step `arrayDegree?` rescan (`O(n²)`). Leading-term
-  subtraction uses a tail-recursive index loop instead of folding over a freshly
-  allocated `List.range`.
+  (`max (rd+1) (shift + q.size)`, correct for *any* divisor) so total
+  degree-scanning is `O(n)` rather than the reference's per-step `arrayDegree?`
+  rescan (`O(n²)`); leading-term subtraction is a tail-recursive index loop, not a
+  `List.range` fold. Proved equal via `divModArrayAux_eq_impl` (csimp).
 - Added `divMod` and `gcd` bench targets over `F_65537` at degrees
   8/16/32/64/128/256 to `HexPolyFp/Bench.lean`.
 
-Value preservation verified by comparing bench `result_hash` between the
-reference build (attributes disabled) and the optimized build: all 12 rungs
-(both targets) identical.
+Value preservation is guaranteed by the csimp equivalence proofs (the build only
+succeeds if `@trimTrailingZeros = @trimTrailingZerosImpl` and
+`@divModArrayAux = @divModArrayAuxImpl` are proved). Earlier hash-cross-checks
+across all 12 bench rungs corroborated this empirically.
 
 ## Current frontier
 
@@ -57,3 +63,11 @@ remove `ZMod64` boxing; (b) profile `factorFast` to localize the seconds-scale
 ## Blockers
 
 None for the landed scope.
+
+## Recovery note
+
+PR #8065 auto-merged at the `@[implemented_by]` revision before the
+`@[csimp]` conversion was pushed (GitHub merged on green CI). Follow-up PR
+on branch `issue-8063-csimp` replaces both `@[implemented_by]` attributes on
+`main` with the proven `@[csimp]` equivalences. No `@[implemented_by]` remains
+after it lands.


### PR DESCRIPTION
This PR replaces the two `@[implemented_by]` runtime swaps that landed in https://github.com/kim-em/hex/pull/8065 with proven `@[csimp]` equivalences. `@[implemented_by]` is a trusted, unproven swap — nothing checks that the fast code computes the same value as the definition — which is forbidden in this project on the same basis as the `native_decide` ban. With `@[csimp]`, the list-based `trimTrailingZeros` and the `arrayDegree?`-rescan `divModArrayAux` stay as the specifications, the efficient runtime implementations are *proved equal* to them, and the compiler uses those proofs to compile the fast code. Value-preservation is therefore a theorem, and every existing proof (the `DivModLaws` / `GcdLaws` instances and the long-division invariants) is untouched.

- `trimTrailingZeros`: the runtime pops trailing zeros off the array in place instead of round-tripping through `coeffs.toList`. Proved equal by `trimTrailingZeros_eq_impl`.
- `divModArrayAux`: the runtime loop tracks the working degree with a scan ceiling (`max (rd + 1) (shift + q.size)`, correct for any divisor) so total degree-scanning is `O(n)` instead of the per-step rescan's `O(n^2)`, and subtracts the shifted divisor with a tail-recursive index loop instead of folding over a freshly allocated `List.range`. Proved equal by `divModArrayAux_eq_impl`.

No `@[implemented_by]` remains in the tree. The `divMod`/`gcd` bench numbers over `F_65537` are unchanged from #8065 (degree-256 `gcd` ~1.16ms, `divMod` ~13.5ms; the algorithmic/allocation fixes are ~5-8%, with `ZMod64` boxing the dominant remaining constant, tracked in https://github.com/kim-em/hex/issues/8171).

Verification: `lake build HexPoly HexPolyFp` green; `hexpolyfp_bench run` shows both divMod/gcd targets consistent with the declared `O(n^2)`.

🤖 Prepared with Claude Code
