### PR TITLE
review: HexPolyFp Phase 6 linter cleanup + exit-criteria audit

### DIFF
--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -71,36 +71,6 @@ instance : DensePoly.ZeroSubNegLaw (ZMod64 p) where
     rw [toNat_sub, toNat_neg, toNat_zero]
     simp [Nat.zero_add]
 
-private theorem coeff_add_semiring_rw_smoke (a b : ZMod64 p) (n : Nat) :
-    (DensePoly.C a + DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
-      (DensePoly.C a).coeff n + (DensePoly.C b).coeff n := by
-  rw [DensePoly.coeff_add_semiring]
-
-private theorem coeff_add_semiring_simp_smoke (a b : ZMod64 p) (n : Nat) :
-    (DensePoly.C a + DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
-      (DensePoly.C a).coeff n + (DensePoly.C b).coeff n := by
-  simp
-
-private theorem coeff_sub_ring_rw_smoke (a b : ZMod64 p) (n : Nat) :
-    (DensePoly.C a - DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
-      (DensePoly.C a).coeff n - (DensePoly.C b).coeff n := by
-  rw [DensePoly.coeff_sub_ring]
-
-private theorem coeff_sub_ring_simp_smoke (a b : ZMod64 p) (n : Nat) :
-    (DensePoly.C a - DensePoly.C b : DensePoly (ZMod64 p)).coeff n =
-      (DensePoly.C a).coeff n - (DensePoly.C b).coeff n := by
-  simp
-
-private theorem coeff_neg_ring_rw_smoke (a : ZMod64 p) (n : Nat) :
-    (-DensePoly.C a : DensePoly (ZMod64 p)).coeff n =
-      -((DensePoly.C a).coeff n) := by
-  rw [DensePoly.coeff_neg_ring]
-
-private theorem coeff_neg_ring_simp_smoke (a : ZMod64 p) (n : Nat) :
-    (-DensePoly.C a : DensePoly (ZMod64 p)).coeff n =
-      -((DensePoly.C a).coeff n) := by
-  simp
-
 /-- `DensePoly.divMod f g` returns a quotient-remainder pair `(q, r)` with `q * g + r = f`. -/
 private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
     let qr := DensePoly.divMod f g
@@ -957,7 +927,7 @@ private theorem coeff_one (n : Nat) :
   exact DensePoly.coeff_C (1 : ZMod64 p) n
 
 /-- The zero polynomial evaluates to zero at every point. -/
-@[simp, grind =] theorem eval_zero (x : ZMod64 p) :
+@[grind =] theorem eval_zero (x : ZMod64 p) :
     DensePoly.eval (0 : FpPoly p) x = 0 := by
   exact DensePoly.eval_zero x
 
@@ -1037,13 +1007,13 @@ theorem eval_monomial (n : Nat) (c x : ZMod64 p) :
   exact DensePoly.coeff_C c n
 
 /-- The degree-zero coefficient of the indeterminate wrapper is zero. -/
-@[simp, grind =] theorem coeff_X_zero :
+@[grind =] theorem coeff_X_zero :
     ((FpPoly.X : FpPoly p)).coeff 0 = 0 := by
   unfold FpPoly.X
   exact DensePoly.coeff_monomial 1 (1 : ZMod64 p) 0
 
 /-- The degree-one coefficient of the indeterminate wrapper is one. -/
-@[simp, grind =] theorem coeff_X_one :
+@[grind =] theorem coeff_X_one :
     ((FpPoly.X : FpPoly p)).coeff 1 = 1 := by
   unfold FpPoly.X
   exact DensePoly.coeff_monomial 1 (1 : ZMod64 p) 1
@@ -2746,7 +2716,7 @@ theorem C_mul_eq_scale (c : ZMod64 p) (f : FpPoly p) :
 
 /-- Evaluating `C c * f` at `x` multiplies the value of `f` by the scalar `c`.
 The constant-multiplication special case of `eval_mul`. -/
-@[simp, grind =]
+@[grind =]
 theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (DensePoly.C c * f) x = c * DensePoly.eval f x := by
   rw [C_mul_eq_scale]
@@ -3933,7 +3903,7 @@ theorem linearPow_succ_left (f : FpPoly p) (n : Nat) :
         _ = f * linearPow f (n + 1) := rfl
 
 /-- The first `linearPow` of a polynomial is the polynomial itself. -/
-@[simp, grind =] theorem linearPow_one (f : FpPoly p) :
+@[grind =] theorem linearPow_one (f : FpPoly p) :
     linearPow f 1 = f := by
   grind
 

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -37,7 +37,7 @@ private theorem C_zero_eq_zero :
   rw [DensePoly.coeff_C, DensePoly.coeff_zero]
   cases n <;> rfl
 
-@[simp, grind =] theorem compose_zero (q : FpPoly p) :
+@[grind =] theorem compose_zero (q : FpPoly p) :
     DensePoly.compose (0 : FpPoly p) q = 0 := by
   rfl
 

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -21,7 +21,9 @@ local instance : DensePoly.DivModLaws (ZMod64 p) :=
 a monic positive-degree modulus. -/
 structure Quotient (g : FpPoly p) (hmonic : DensePoly.Monic g)
     (hg_pos : 0 < g.degree?.getD 0) where
+  /-- The chosen representative polynomial, of degree below `g`. -/
   val : FpPoly p
+  /-- The representative's degree is strictly below that of the modulus `g`. -/
   reduced : val.degree?.getD 0 < g.degree?.getD 0
 
 namespace Quotient

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -19,12 +19,16 @@ variable {p : Nat} [ZMod64.Bounds p]
 
 /-- One square-free factor together with its multiplicity. -/
 structure SquareFreeFactor (p : Nat) [ZMod64.Bounds p] where
+  /-- The square-free factor polynomial. -/
   factor : FpPoly p
+  /-- The exponent with which `factor` divides the original polynomial. -/
   multiplicity : Nat
 
 /-- A square-free decomposition records the scalar unit and the nonconstant factors. -/
 structure SquareFreeDecomposition (p : Nat) [ZMod64.Bounds p] where
+  /-- The leading-coefficient scalar unit pulled out of the polynomial. -/
   unit : ZMod64 p
+  /-- The square-free factors together with their multiplicities. -/
   factors : List (SquareFreeFactor p)
 
 /-- Detect the unit polynomial `1`. -/

--- a/progress/20260620_044500_4cbda784.md
+++ b/progress/20260620_044500_4cbda784.md
@@ -1,0 +1,84 @@
+# HexPolyFp Phase 6 exit-criteria audit (#8178)
+
+## Accomplished
+
+Audited the four Phase 6 exit criteria for `HexPolyFp` and landed the
+low-risk mechanical fixes inline. Verdict: **do not bump** `done_through`
+(stays at 5); two criteria have residual gaps too large for a review PR.
+
+### Criterion results
+
+1. **Mathlib linter** — WAS failing, NOW clean. `lake exe runLinter`
+   surfaced 11 unique errors (the default `#lint` suite, which build-time
+   linters miss):
+   - 6 `simpNF` errors: redundant/non-normal-form `@[simp]` lemmas
+     `eval_zero`, `coeff_X_zero`, `coeff_X_one`, `eval_C_mul`,
+     `linearPow_one` (Basic.lean) and `compose_zero` (Compose.lean).
+     Fixed by dropping `@[simp]` and keeping `@[grind =]` — simp can
+     still close those goals via other lemmas, so no proof breaks.
+   - 5 `docBlame` errors: undocumented structure fields `Quotient.val`,
+     `SquareFreeFactor.{factor,multiplicity}`,
+     `SquareFreeDecomposition.{unit,factors}`. Fixed with field docstrings.
+   `runLinter` now reports "Linting passed" for Basic, Compose, Quotient,
+   SquareFree. **PASS** after fixes.
+
+2. **Docstring coverage** — RESIDUAL GAP, not bump-blocking-trivial.
+   Public `def`/`structure`/`class`/`inductive` coverage is otherwise
+   complete (the only `def`/field gaps were the 5 docBlame ones, now
+   fixed; anonymous `instance`s are exempt). The project's stricter rule
+   ("every importable theorem carries a docstring") is unmet for ~27
+   public theorems across Basic/Quotient/Compose/ModCompose/Enumeration.
+   Most are standard ring-axiom restatements (`add_zero`, `zero_add`,
+   `mul_one`, …) that are arguably self-documenting, but several are not
+   (`linearPow_zero`, `elements_length`, `compose_foldl_X_sub_C`,
+   `coeffLists_succ`). The Mathlib `docBlame` linter does not flag these
+   (it checks defs, not theorems), so the gap is project-rule-only.
+
+3. **Dead code** — RESIDUAL GAP. Removed 6 obviously-dead private probe
+   lemmas in Basic.lean (`coeff_*_{rw,simp}_smoke`) — unreferenced, and
+   "smoke" is banned vocabulary. A larger cluster remains: ~49
+   unreferenced, untagged (no `@[simp]`/`@[grind]`) private lemmas in
+   SquareFree.lean whose names never appear outside their definition
+   (spot-checked: `monicGcd_mul_div_reconstruct`, `derivative_pow_succ`,
+   `yunFactorsContribution_reconstruct` are genuinely dead). Removing 49
+   lemmas from the 11k-line file is out of scope for a review PR and
+   risks proof breakage; punch-listed below.
+
+4. **Native path** — PASS. `grep` confirms no `native_decide` and no
+   runtime oracle anywhere in the library.
+
+### Punch-list for a follow-up planner
+
+- **Theorem docstrings**: add docstrings to the ~27 undocumented public
+  theorems (prioritize the non-obvious ones listed above; the standard
+  ring-axiom lemmas are low value). Bounded, one issue.
+- **SquareFree dead code**: adjudicate and remove the ~49 unreferenced
+  private lemmas in SquareFree.lean (verify each is not used by `grind`
+  set membership before deletion). The AI-slop long names
+  (`yunFactorsContributionWithLevel_scaled_normalized_tail_product_sync`,
+  7 qualifiers) suggest orphaned intermediate lemmas from superseded
+  proof paths. Likely 2-3 bounded issues by region of the file.
+
+After both punch-list items land, the bump 5→6 should be clean.
+
+## Verification
+
+- `lake build HexPolyFp` green (98 jobs).
+- Reverse deps green: `HexGFqRing`, `HexBerlekamp`, `HexHensel` (498 jobs)
+  and CI-gated `HexGF2Mathlib` (1131 jobs) — confirms the `@[simp]`
+  removals break no downstream simp call.
+- `lake exe runLinter` passes on Basic, Compose, Quotient, SquareFree.
+- No `axiom`/`sorry`/`native_decide` introduced; no Mathlib dep added.
+
+## Current frontier
+
+Audit complete; inline fixes landed; verdict is no-bump with the
+punch-list above.
+
+## Next step
+
+A planner turns the two punch-list items into bounded feature issues.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8178

This PR audits the four Phase 6 exit criteria for `HexPolyFp`, lands the low-risk mechanical fixes inline, and records a verdict of **no `done_through` bump** (stays at 5): two criteria carry residual gaps too large for a review PR.

Criterion results:

1. **Mathlib linter** — WAS failing, NOW clean. `lake exe runLinter` surfaced 11 errors the build-time linters miss: 6 `simpNF` (redundant/non-normal-form `@[simp]` on `eval_zero`, `coeff_X_zero`, `coeff_X_one`, `eval_C_mul`, `linearPow_one`, `compose_zero` — fixed by dropping `@[simp]`, keeping `@[grind =]`) and 5 `docBlame` (undocumented fields `Quotient.val`, `SquareFreeFactor.{factor,multiplicity}`, `SquareFreeDecomposition.{unit,factors}` — fixed with field docstrings). `runLinter` now passes on Basic, Compose, Quotient, SquareFree.
2. **Docstring coverage** — residual gap. Public def/structure/class/inductive coverage is complete after the docBlame fixes; the project's stricter "every importable theorem" rule is unmet for ~27 public theorems (most are standard ring-axiom restatements; a few non-obvious: `linearPow_zero`, `elements_length`, `compose_foldl_X_sub_C`, `coeffLists_succ`).
3. **Dead code** — residual gap. Removed 6 dead private `*_smoke` probe lemmas (unreferenced; "smoke" is banned vocabulary). ~49 unreferenced untagged private lemmas remain in the 11k-line SquareFree.lean — out of scope for a review PR.
4. **Native path** — pass. No `native_decide`, no runtime oracle.

Punch-list for a follow-up planner: (a) docstring the ~27 public theorems; (b) adjudicate and remove the ~49 unreferenced private SquareFree.lean lemmas (verify each is not a `grind`-set member first). After both land, the 5→6 bump should be clean.

Verification: `lake build HexPolyFp` green; reverse deps `HexGFqRing`/`HexBerlekamp`/`HexHensel` and CI-gated `HexGF2Mathlib` green (the `@[simp]` removals break no downstream simp call); `lake exe runLinter` passes on all touched modules; no `axiom`/`sorry`/`native_decide` introduced.

🤖 Prepared with Claude Code