### PR TITLE
review: Phase 6 exit-criteria audit for HexGFqField (linter, docstrings, dead decls)

### DIFF
--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -91,17 +91,6 @@ private def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
   let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹
   DensePoly.scale unitInv r.left
 
-/-- The inverse candidate is the normalized left Bezout coefficient from the
-extended gcd between the representative and the modulus. -/
-private theorem invPoly_eq_scale_xgcd_left
-    {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : GFqRing.PolyQuotient f hf) :
-    invPoly x =
-      let r := DensePoly.xgcd (GFqRing.repr x) f
-      let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹
-      DensePoly.scale unitInv r.left := by
-  rfl
-
 /-- The extended-gcd output gives the unscaled Bezout identity for the reduced
 representative and the modulus. -/
 private theorem xgcd_repr_bezout

--- a/libraries.yml
+++ b/libraries.yml
@@ -224,7 +224,7 @@ libraries:
   HexGFqField:
     deps: [HexGFqRing, HexBerlekamp]
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       comparators:

--- a/progress/20260620_042811_316400c0.md
+++ b/progress/20260620_042811_316400c0.md
@@ -1,0 +1,61 @@
+# HexGFqField Phase 6 exit-criteria audit — bump done_through 5→6 (#8179)
+
+## Accomplished
+
+Audited all Phase 6 exit criteria for `HexGFqField` and bumped
+`libraries.yml` `HexGFqField.done_through` 5 → 6. All criteria pass:
+
+- **Mathlib linter clean.** `lake build HexGFqField` green (481 jobs),
+  zero warnings/errors on any HexGFqField file (the only `info` lines
+  in the log are `grind` pattern suggestions on the dependency
+  `HexMatrix/Bareiss.lean`, not our library). `mathlib: false`, so
+  env-linters are N/A. Two `set_option linter.X false` overrides exist
+  and both are legitimate, narrowly-scoped false-positive silencers:
+  `linter.unusedSectionVars false` (Operations.lean:16, file-scoped —
+  the `hp` section var is used by most but not all declarations) and
+  `linter.unnecessarySimpa false in` (Operations.lean:783, `in`-scoped
+  over one `have` whose `simpa [hxrepr] … .symm` genuinely needs
+  `hxrepr` to bridge `reduceMod f repr → repr`, since
+  `reduceMod_mul_reduceMod` reduces both factors).
+
+- **Docstrings.** Every public `def`/`structure`/`theorem` in the core
+  surface (`Operations.lean` + `Basic.lean`) carries a real `/--`
+  docstring — verified mechanically, zero public gaps. The undocumented
+  declarations are all in `Conformance.lean` and all `private`
+  test-harness plumbing (fixtures, the GF(5⁴) modulus, certificate
+  helpers) — convention-exempt.
+
+- **Dead code.** Removed one genuinely-dead private `rfl` unfolding
+  lemma, `invPoly_eq_scale_xgcd_left` (Operations.lean), referenced
+  nowhere (private → cannot be used externally). The only unreferenced
+  *public* declaration, `frob_eq_pow`, is the characterising lemma for
+  the public `frob` def (40 refs) — forward-looking spec API per the
+  Phase 6 encapsulation principle, not an orphan.
+
+- **Native path + Lean-checked evidence.** No
+  `native_decide`/`sorry`/`axiom`/oracle anywhere. The field-
+  construction criterion (hex-gfq-field-specific) is met: the
+  conformance modulus `x⁴ + 2` over F₅ has its irreducibility proven by
+  a Lean-checked Berlekamp/Rabin certificate
+  (`modulus_irreducible` ← `checkIrreducibilityCertificateLinear`,
+  discharged by `decide`/`simp`/`rfl`).
+
+## Verification
+
+- `lake build HexGFqField` green after the dead-code removal (481 jobs).
+- `python3 scripts/check_dag.py` exit 0.
+- `python3 scripts/status.py` now lists `HexGFqField -> Phase 7`, off the
+  Phase 6 ready list.
+- No `axiom`/`sorry`/`native_decide` introduced.
+
+## Current frontier
+
+Audit complete; the bump is landed in this PR.
+
+## Next step
+
+None for this issue. Sibling audit #8181 (HexHensel) remains unclaimed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8179

Session: `316400c0-6530-4b42-9be1-018623f62409`

6fb50a04 review: HexGFqField Phase 6 exit-criteria audit — bump done_through to 6

🤖 Prepared with Claude Code