### PR TITLE
review: Phase 6 exit-criteria audit for HexArith (linter, docstrings, dead decls, extern oracle)

### DIFF
--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -249,6 +249,11 @@ def mulMont (ctx : MontCtx p) (a b : UInt64) : UInt64 :=
   let (hi, lo) := UInt64.mulFull a b
   redc ctx hi lo
 
+/--
+For reduced inputs `a, b < p`, the two-word product `a * b` (encoded as
+`lo + hi * word`) stays below `p * word`. This is the range precondition
+`redc` needs to behave as Montgomery reduction on the `mulMont` product.
+-/
 private theorem twoWordProduct_lt_p_word (ctx : MontCtx p) (a b : UInt64)
     (ha : a.toNat < p.toNat) (hb : b.toNat < p.toNat) :
     (UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word <
@@ -263,6 +268,12 @@ private theorem twoWordProduct_lt_p_word (ctx : MontCtx p) (a b : UInt64)
     _ < p.toNat * p.toNat := hprod_lt_p2
     _ < p.toNat * UInt64.word := hp2_lt_pword
 
+/--
+Reducing the two-word product through `redc` produces the Montgomery
+representative: multiplying the result back by `word` recovers `a * b` modulo
+`p`. The `p * p' ≡ -1 (mod word)` hypothesis is the Montgomery inverse
+condition that makes the reduction exact.
+-/
 private theorem redc_mulFull_repr_word (ctx : MontCtx p) (a b : UInt64)
     (hT :
       (UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word <
@@ -281,6 +292,11 @@ private theorem redc_mulFull_repr_word (ctx : MontCtx p) (a b : UInt64)
             UInt64.word) % p.toNat := hredc
     _ = (a.toNat * b.toNat) % p.toNat := by grind
 
+/--
+Reducing the two-word product through `redc` lands strictly below the modulus,
+so `mulMont` returns an already-reduced residue with no extra conditional
+subtraction.
+-/
 private theorem redc_mulFull_lt (ctx : MontCtx p) (a b : UInt64)
     (hT :
       (UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word <
@@ -290,6 +306,12 @@ private theorem redc_mulFull_lt (ctx : MontCtx p) (a b : UInt64)
   rw [toNat_redc ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2 hT]
   exact redcNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
 
+/--
+Multiplication by `word` is injective on residues modulo `p`: since `p` is odd
+it is coprime to `word = 2 ^ 64`, so two reduced values `x, y < p` with
+`x * word ≡ y * word (mod p)` are equal. This is what lets the
+representative-mod-word characterisation pin down a unique `mulMont` value.
+-/
 private theorem cancel_word_mod_of_lt (ctx : MontCtx p) {x y : Nat}
     (hx : x < p.toNat) (hy : y < p.toNat)
     (h : x * UInt64.word % p.toNat = y * UInt64.word % p.toNat) :
@@ -414,6 +436,12 @@ theorem toNat_toMont (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
             _ = ((a.toNat * UInt64.word) % p.toNat * UInt64.word) % p.toNat := by
                   rw [Nat.mul_mod_mod]
 
+/--
+The Montgomery product `mulMont a b` represents `a * b` scaled by `word`:
+its representative multiplied back by `word` equals `a * b` modulo `p`. This
+is the core algebraic identity from which the user-facing `mulMont`
+correctness lemmas are derived.
+-/
 private theorem mulMont_repr_word (ctx : MontCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     (ctx.mulMont a b).toNat * UInt64.word % p.toNat =

--- a/libraries.yml
+++ b/libraries.yml
@@ -60,7 +60,7 @@ libraries:
   HexArith:
     deps: []
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       input_families:

--- a/progress/20260620T044252Z_473f329b.md
+++ b/progress/20260620T044252Z_473f329b.md
@@ -1,0 +1,53 @@
+# HexArith Phase 6 exit-criteria audit (#8189)
+
+Session type: review. Audited all four Phase 6 exit criteria for
+`HexArith` and bumped `libraries.yml` `HexArith.done_through: 5 → 6`.
+
+## Accomplished
+
+All four criteria pass:
+
+- **Mathlib linter clean.** `lake build HexArith` green (61 jobs), zero
+  warnings/errors, no `set_option linter`/`nolint` suppressions anywhere
+  in the library. `mathlib: false`, so env-linters are N/A.
+- **Docstrings.** The public/importable surface has zero gaps — every
+  public `def`/`structure`/`theorem` in the 12 core files is
+  docstringed. The 13 undocstringed declarations are all `private`; of
+  those, the routine plumbing (`choose_one_right`, `chooseSum_zero`,
+  `not_dvd_of_pos_lt`, `bitLength`/`testBit_*` numeric helpers, the
+  `isPrimeTrial` extraction lemmas) is convention-exempt. Added
+  docstrings to the five genuinely non-obvious private
+  Montgomery-multiplication invariant helpers
+  (`twoWordProduct_lt_p_word`, `redc_mulFull_repr_word`,
+  `redc_mulFull_lt`, `cancel_word_mod_of_lt`, `mulMont_repr_word`).
+- **No dead code.** Every public `def` is referenced. The unreferenced
+  public theorems (Barrett/Montgomery reduction range guarantees
+  `barrettReduce_lt`/`redc_lt`/etc., carry/borrow `_fst` projection
+  characterisations, `word_pos`/`toNat_lt_word`) are all docstringed
+  characterising/bound API lemmas — deliberate encapsulation surface per
+  Phase 6, not orphans. 42 more unreferenced lemmas are `@[simp]`/
+  `@[grind =]` tagged (used by automation).
+- **Native path + Lean-checked evidence.** No `native_decide`/`sorry`/
+  `axiom` (the one `native_decide` grep hit is a comment). All five
+  `@[extern]` bindings annotate a pure Lean reference `def` with proven
+  characterising theorems: `extGcd` → `Hex.pureIntExtGcd` with
+  `extGcd_spec`; `mulHi`/`mulFull`/`addCarry`/`subBorrow` with
+  `toNat_mulHi`/`toNat_mulFull`/`toNat_addCarry`/`toNat_subBorrow`. No
+  unproven oracle. HexArith exposes no irreducibility/field claim.
+
+`python3 scripts/check_dag.py` exit 0; `scripts/status.py` now shows
+HexArith at Phase 7 ready.
+
+## Current frontier
+
+HexArith Phase 6 complete. Next per-library step is Phase 7 (user-facing
+HexManual chapter), analogous to the open #8190 for HexPolyZ.
+
+## Next step
+
+None for this issue. A follow-up planner can file a Phase 7
+documentation issue for HexArith.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8189

Session: `473f329b-901d-40cc-a262-d5c90790b801`

94cfe7e2 review: HexArith Phase 6 exit-criteria audit — bump done_through to 6

🤖 Prepared with Claude Code