### PR TITLE
review: HexMatrix Phase 6 exit-criteria audit — docBlame fixed, no bump (3/4 fail)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -251,6 +251,15 @@ or `Monoid`/`CommRing` lemmas — those modules don't import Mathlib.
   `push_neg` → `Classical.not_forall.mp` / `Classical.not_exists.mp`; `conv_lhs
   => rw [h]` → `rw [h] at <aux-have>` then `exact`. `omega`/`simp`/`rcases` are
   core and available.
+- **`@[nolint ...]` is unavailable** — the attribute lives in Mathlib's
+  linter framework, so writing `@[nolint unusedArguments]` (or any
+  `nolint`) in a Mathlib-free file is a build error (`unsupportedSyntax`),
+  even though `lake exe runLinter` itself resolves from the mathlib dep.
+  This bites Phase 6 linter audits: a Mathlib-free lib **cannot suppress**
+  a `unusedArguments` lint on a deliberate phantom argument (e.g. a proof
+  carried only to pin a precondition, or a witness carried only for
+  dot-notation). Restructure the signature or punch-list the lint as an
+  accepted exception — do not reach for `@[nolint]`.
 - **Integer `^` has no `pow_add`/`pow_succ`/`pow_one`/`one_pow` (Mathlib).**
   Use `Lean.Grind.Semiring.pow_succ` (`a^(n+1) = a^n * a`) and
   `Lean.Grind.Semiring.pow_zero`; `Int.one_pow`, `Int.mul_assoc`,

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -8783,7 +8783,10 @@ theorem det_mul
 Encoding for the universal 3-term Plucker identity substrate. -/
 
 /-- Embed `Fin n` into `Fin (n + 2)` while skipping two deleted indices
-`p < q`. This indexes minors with two removed rows. -/
+`p < q`. This indexes minors with two removed rows.
+
+The ordering proof `_hpq` is a phantom argument: it documents and pins the
+`p < q` precondition at call sites but is not consumed by the definition. -/
 def skipIndex2 {n : Nat} (p q : Fin (n + 2)) (_hpq : p.val < q.val)
     (i : Fin n) : Fin (n + 2) :=
   if hi1 : i.val < p.val then

--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -1052,9 +1052,13 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
 
 /-- Pure data produced by an echelon-form algorithm. -/
 structure RowEchelonData (R : Type u) (n m : Nat) where
+  /-- Number of pivots, i.e. the rank of the original matrix. -/
   rank : Nat
+  /-- The matrix reduced to row-echelon form. -/
   echelon : Matrix R n m
+  /-- The accumulated row-operation transform `T` with `T * original = echelon`. -/
   transform : Matrix R n n
+  /-- Column index of each pivot, in increasing order. -/
   pivotCols : Vector (Fin m) rank
 
 /-- Shared conditions for any echelon form. -/
@@ -1133,7 +1137,11 @@ theorem pivotCols_injective (E : IsEchelonForm M D) :
       rw [h'] at hp
       exact False.elim (by omega)
 
-/-- The non-pivot columns, enumerated in increasing order. -/
+/-- The non-pivot columns, enumerated in increasing order.
+
+The echelon-form witness `_E` is a phantom argument: it carries no runtime
+data but enables dot-notation (`E.freeColsList`) and fixes the implicit
+matrix/data parameters. -/
 def freeColsList (_E : IsEchelonForm M D) : List (Fin m) :=
   (List.finRange m).filter fun j => j ∉ D.pivotCols.toList
 

--- a/progress/20260620_050247_69a144d2.md
+++ b/progress/20260620_050247_69a144d2.md
@@ -1,0 +1,137 @@
+# HexMatrix Phase 6 exit-criteria audit (#8193)
+
+Session type: review. Audited the four Phase 6 exit criteria for
+`HexMatrix` (`done_through: 5`). **Verdict: do not bump.** Three of the
+four criteria fail with gaps too large for a review PR; the trivial
+`docBlame` slice was fixed inline.
+
+## Criterion results
+
+### 1. Mathlib linter — FAIL (46 → 42 errors after inline fix)
+
+`lake exe runLinter` across the five core modules surfaced **46 unique
+errors** (the runs re-lint the import closure, so raw counts repeat):
+
+- **`simpNF`: 40** — every `M[i][j]`-shaped `@[simp]` entry lemma. The
+  general lemma `Fin.getElem_fin` rewrites a `Fin` index `i` to `↑i`, so
+  the stated LHS `(foo …)[i][j]` is not in simp-normal form (simp would
+  match `(foo …)[↑i][↑j]`). Systematic across `Basic` (15),
+  `Determinant` (19), `RREF` (6). **Not fixed** — restating each LHS in
+  `↑i`/`Fin.val` form or dropping `@[simp]` (keeping `@[grind =]`) is
+  downstream-risky for these foundational getElem lemmas and needs a
+  dedicated pass. Punch-listed.
+- **`docBlame`: 4** — `RowEchelonData` fields `rank`/`echelon`/
+  `transform`/`pivotCols` (RowEchelon.lean:1055–1058). **FIXED inline**
+  (field docstrings added); re-lint confirms the category is now clear.
+- **`unusedArguments`: 2** — the deliberate phantom args
+  `skipIndex2 _hpq` (Determinant.lean:8785) and
+  `freeColsList _E` (RowEchelon.lean:1136). The Mathlib linter flags
+  these despite the `_`-prefix, and the usual `@[nolint unusedArguments]`
+  suppression is **unavailable** in this Mathlib-free library (it parses
+  to `unsupportedSyntax`). Documented the intent inline; resolving the
+  lint needs restructuring or a project decision. Punch-listed.
+
+### 2. Docstring coverage — FAIL (core library)
+
+Against `SPEC/design-principles.md` ("all public decls; every importable
+theorem; non-obvious private helpers"):
+
+- **13 public theorems** in `Determinant.lean` lack docstrings (all
+  importable): `columnTupleMatrix_entry` (5850), `columnTupleVectorFn_apply`
+  (5873), `sortInjPerm_getElem_val` (7498), `reconstructInjTuple_getElem`
+  (7761), `columnTupleMatrix_reconstructInjTuple_entry` (7766),
+  `firstColumns_entry` (8306), `setRow_get_self` (8397), `adjugate_get`
+  (8510), `skipIndex2_val_of_lt_p` (8796), `skipIndex2_val_of_between`
+  (8801), `skipIndex2_val_of_ge_q` (8807), `nMatrix_entry` (8883),
+  `basisVec_getElem` (9849). *(Line numbers pre-commit; +9 in
+  Determinant after the inline docstring commit.)*
+- **Private helpers**: `Determinant` ~125, `RREF` 19, `RowEchelon` 6,
+  `Bareiss` 2, `Basic` 1 private decls without docstrings. Many are
+  routine unfolding/`_aux` getters (exempt); the non-obvious ones
+  (invariant- or algorithm-encoding) need docs. Needs per-decl
+  adjudication.
+- **Test/bench surfaces** (lower priority per the issue): `Bench` 27
+  public `runBareissDet*`/`main` defs, `Conformance` 25 private,
+  `EmitFixtures` 8.
+
+### 3. Dead code — FAIL (21 provably-dead private theorems, ~457 lines)
+
+A library-wide reachability scan (name references across all of
+`HexMatrix/`, excluding `@[simp]`/`@[grind]`-tagged automation roots and
+instances) found **21 `private` theorems referenced nowhere outside
+their own definition** — provably safe to delete (a rebuild proves it):
+
+- `Bareiss.lean`: `getEntry_swapRowsArray_matches` (L692–761, 70 lines).
+- `RowEchelon.lean`: `dotProduct_smul_ofFn_right` (L293–309, 17 lines).
+- `Determinant.lean` (19 blocks, 370 lines): `crossInversionCount_append_left`,
+  `crossInversionCount_singleton_left`, `detTerm_congr_matrix`,
+  `insertAt_prefix_get_self`, `insertAt_prefix_get_before`,
+  `insertAt_prefix_get_last`, `finList_length_le_card`, `finTranspose_ne_iff`,
+  `transposePermutationValues_insertAt_last_boundary` (99 lines),
+  `swapPermutationValues_map_permutationVectors_perm`,
+  `detSign_transposePermutationValues_involutive`, `columnChoiceMatrix_none`,
+  `det_columnChoiceMatrix_expand_column`, `columnChoiceMatrix_some`,
+  `columnSumMatrixWithPrefix_nil`, `columnSumMatrixWithPrefix_eq_columnTupleMatrix`,
+  `det_columnSumMatrixWithPrefix_expand`,
+  `det_plucker_three_term_basisVec_of_gt_p3_of_nDet`,
+  `twoColDet_plucker_basisVec_of_lt_p1`.
+
+Exceeds the review PR's ~200-line / 2-file inline cap and spans 3 files,
+so punch-listed rather than removed inline. The detection script is at
+`/tmp/deadfix.py` (reproducible: flags `private` defs/theorems with ≤1
+library-wide name reference and no `simp`/`grind` attribute).
+
+### 4. Native path / no oracle — PASS
+
+No `native_decide` (grep-confirmed). No runtime oracle. The sole
+`@[extern]` is `Bareiss.exactDiv` → `lean_int_div_exact`, a GMP-backed
+exact-division performance binding whose Lean model is `num / denom`
+(the same `@[extern]` pattern core Lean uses for `Int.div`); it is not
+an external decision oracle and the def runs natively without it.
+
+### Residual bare `@[simp]` (issue's criterion-1 sub-check) — PASS
+
+The 2 bare `@[simp]` lemmas (`dotProduct_basis_basis` Basic.lean:895,
+`columnTupleMatrix_compose_perm_entry` Determinant.lean:5883) each carry
+a documented justification for being simp-only (indices appear only under
+`ofFn`/`fun` binders, so `grind =` cannot instantiate the LHS pattern).
+Documented exclusions, not missed promotions.
+
+## What landed inline
+
+`doc:` commit adding the 4 `RowEchelonData` field docstrings (clears the
+`docBlame` category) plus phantom-arg docstrings on `skipIndex2` /
+`freeColsList`. `lake build HexMatrix` green (389 jobs). No
+`axiom`/`sorry`/`native_decide`/Mathlib dep introduced. No `done_through`
+bump.
+
+## Punch-list for a follow-up planner
+
+1. **simpNF cleanup (40)** — restate the `getElem`/`_entry` simp lemmas
+   in `↑i`/`Fin.val` normal form (or demote `@[simp]`→`@[grind =]`),
+   auditing each against downstream simp calls. One issue (or split
+   Basic / Determinant / RREF).
+2. **Dead-code removal (21 private theorems, ~457 lines)** — delete the
+   listed blocks across Bareiss/Determinant/RowEchelon; rebuild to
+   confirm. One bounded issue (use `/tmp/deadfix.py` or the ranges above).
+3. **Public-theorem docstrings (13)** in Determinant; bounded, one issue.
+4. **Private-helper docstrings** — adjudicate the non-obvious subset
+   across Determinant/RREF/RowEchelon. Likely 1–2 issues by file.
+5. **unusedArguments (2)** — restructure the `skipIndex2`/`freeColsList`
+   phantom args, or decide they are accepted lints (no `@[nolint]` in
+   Mathlib-free libs). Small; can fold into the simpNF issue.
+
+After 1–3 (and the non-obvious slice of 4) land, the 5→6 bump is clean.
+
+## Current frontier
+
+Audit complete; `docBlame` fixed inline; verdict no-bump with the
+punch-list above.
+
+## Next step
+
+A planner turns punch-list items 1–3 into bounded feature issues.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8193

Session: `69a144d2-e3d7-445e-8010-b43ed7eb7231`

22e1b92c review: HexMatrix Phase 6 exit-criteria audit report (#8193)
f4386138 doc: document RowEchelonData fields, skipIndex2/freeColsList phantom args (HexMatrix Phase 6 audit)

🤖 Prepared with Claude Code