### PR TITLE
review: Phase 6 exit-criteria audit for HexGFq (linter, docstrings, dead decls, irreducibility evidence)

### DIFF
--- a/HexGFq/Basic.lean
+++ b/HexGFq/Basic.lean
@@ -188,6 +188,9 @@ class PackedGF2Entry (n : Nat) where
   degree_lt_word : n < 64
   packed_irreducible : GF2Poly.Irreducible (GF2Poly.ofUInt64Monic lower n)
 
+/-- A degree-one `GF2Poly` is either the monomial `X` or `X + 1` — the only two
+monic degree-one polynomials over `𝔽₂`. Used to enumerate the possible factors
+when proving a degree-two packed modulus irreducible. -/
 private theorem gf2poly_degree_one_eq_monomial_or_x_plus_one {p : GF2Poly}
     (hp : p.degree = 1) :
     p = GF2Poly.monomial 1 ∨ p = GF2Poly.ofUInt64Monic 1 1 := by
@@ -241,6 +244,7 @@ private theorem gf2poly_degree_one_eq_monomial_or_x_plus_one {p : GF2Poly}
             rw [GF2Poly.coeff_monomial_ne
               (n := 1) (m := Nat.succ (Nat.succ n)) (by omega)]
 
+/-- The packed polynomial `X + 1` (`ofUInt64Monic 1 1`) is nonzero. -/
 private theorem gf2poly_x_plus_one_ne_zero :
     GF2Poly.ofUInt64Monic 1 1 ≠ 0 := by
   intro hzero
@@ -328,6 +332,11 @@ instance packedGF2Entry_2_1 : PackedGF2Entry 1 where
   degree_lt_word := by decide
   packed_irreducible := packedGF2Entry_2_1_irreducible
 
+/-- Build the Rabin-style irreducibility certificate for the packed degree-`n`
+modulus `ofUInt64Monic lower n`: the `X^(2^k)`-mod power chain for `k ≤ n`, and,
+for each maximal proper divisor `d` of `n`, the Bézout coefficients of the xgcd
+of the modulus with `X^(2^d) - X` (witnessing coprimality, hence no proper
+subfield root). Consumed by `checkIrreducibilityCertificate_imp_irreducible`. -/
 private def packedGF2IrreducibilityCertificate (lower : UInt64) (n : Nat) :
     GF2Poly.IrreducibilityCertificate :=
   let f := GF2Poly.ofUInt64Monic lower n
@@ -340,6 +349,8 @@ private def packedGF2IrreducibilityCertificate (lower : UInt64) (n : Nat) :
         { left := xg.left, right := xg.right }).toArray }
 
 set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 2)` (`0x3`) is irreducible,
+checked from its certificate. -/
 private theorem packedGF2Entry_2_2_irreducible :
     GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x3 2) :=
   GF2Poly.checkIrreducibilityCertificate_imp_irreducible
@@ -348,6 +359,8 @@ private theorem packedGF2Entry_2_2_irreducible :
     (by decide)
 
 set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 3)` (`0x3`) is irreducible,
+checked from its certificate. -/
 private theorem packedGF2Entry_2_3_irreducible :
     GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x3 3) :=
   GF2Poly.checkIrreducibilityCertificate_imp_irreducible
@@ -356,6 +369,8 @@ private theorem packedGF2Entry_2_3_irreducible :
     (by decide)
 
 set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 5)` (`0x5`) is irreducible,
+checked from its certificate. -/
 private theorem packedGF2Entry_2_5_irreducible :
     GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x5 5) :=
   GF2Poly.checkIrreducibilityCertificate_imp_irreducible
@@ -364,6 +379,8 @@ private theorem packedGF2Entry_2_5_irreducible :
     (by decide)
 
 set_option maxRecDepth 4096 in
+/-- The packed Conway modulus for `C(2, 6)` (`0x1B`) is irreducible,
+checked from its certificate. -/
 private theorem packedGF2Entry_2_6_irreducible :
     GF2Poly.Irreducible (GF2Poly.ofUInt64Monic 0x1B 6) :=
   GF2Poly.checkIrreducibilityCertificate_imp_irreducible

--- a/libraries.yml
+++ b/libraries.yml
@@ -295,7 +295,7 @@ libraries:
   HexGFq:
     deps: [HexGFqField, HexConway, HexGF2]
     mathlib: false
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       input_families:

--- a/progress/20260620_083821_f44c5c6d.md
+++ b/progress/20260620_083821_f44c5c6d.md
@@ -1,0 +1,51 @@
+# HexGFq Phase 6 exit-criteria audit (#8220)
+
+Session type: review. UTC 2026-06-20T08:38.
+
+## Accomplished
+
+Audited HexGFq against the four Phase 6 exit criteria and bumped
+`done_through` 5 → 6.
+
+- **Linter clean**: forced a fresh recompile (deleted all `HexGFq/*`
+  build artifacts to dodge the cache-hit false-clean), rebuilt 524/524
+  targets with zero warnings/errors/sorry. `mathlib: false`, so the gate
+  is Lean's built-in linters via a clean build.
+- **Docstrings**: public API already covered. Filled the only real gaps —
+  7 non-obvious private irreducibility helpers in `Basic.lean`
+  (`gf2poly_degree_one_eq_monomial_or_x_plus_one`,
+  `gf2poly_x_plus_one_ne_zero`, `packedGF2IrreducibilityCertificate`,
+  `packedGF2Entry_2_{2,3,5,6}_irreducible`). `Conformance.lean` private
+  test plumbing is exempt and out of scope per the issue.
+- **Dead code**: reachability scan with simp/grind/instance treated as
+  roots — no dead private helpers. The four `GFqC` `*_eq_gfq` delegation
+  lemmas are internally unreferenced but are deliberate documented
+  characterizing API for a user-facing leaf library (mirrors
+  `HexGFqRing` dt 7); left in place.
+- **Native + irreducibility evidence**: no `native_decide`, no runtime
+  oracle; irreducibility backed by certificate + `by decide`.
+
+Verdict (a): all four pass after inline fixes → bumped. `check_dag.py`
+exit 0; `status.py` moves HexGFq to "Phase 7".
+
+## Current frontier
+
+HexGFq is now Phase 7 eligible. Its reference chapter
+(`HexManual/Chapters/HexGFq.lean`) is the natural next work item (a
+separate future issue, explicitly not authored here).
+
+## Next step
+
+A planner/feature session can pick up the HexGFq Phase 7 chapter,
+modelled on the computational-layer chapters.
+
+## Blockers
+
+None.
+
+## Notes
+
+The reused worktree carried pre-existing uncommitted deletions in
+`.claude/commands/review.md` and `.claude/skills/agent-worker-flow/SKILL.md`
+(stripping prior audit/linter guidance). Unrelated to this audit and not
+mine — left untouched and excluded from my commits.


### PR DESCRIPTION
Closes #8220

Session: `f44c5c6d-5d97-43d3-83b6-0f5ec38f75be`

b8bd8e0c chore: progress entry for HexGFq Phase 6 audit (#8220)
196dc633 feat: bump HexGFq done_through 5 to 6 (Phase 6 closeout)
ac9f0dbf doc: docstring 7 private irreducibility helpers in HexGFq.Basic

🤖 Prepared with Claude Code