### PR TITLE
feat: HexMatrix Phase 6 simpNF + unusedArguments cleanup (final gap before 5→6 bump)

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -81,7 +81,7 @@ def ofFn (f : Fin n → Fin m → R) : Matrix R n m :=
   Vector.ofFn fun i => Vector.ofFn fun j => f i j
 
 /-- Entry access for a matrix built from an entry function. -/
-@[simp, grind =] theorem getElem_ofFn (f : Fin n → Fin m → R) (i : Fin n) (j : Fin m) :
+@[grind =] theorem getElem_ofFn (f : Fin n → Fin m → R) (i : Fin n) (j : Fin m) :
     (ofFn f)[i][j] = f i j := by
   simp [ofFn]
 
@@ -90,7 +90,7 @@ def row (M : Matrix R n m) (i : Fin n) : Vector R m :=
   M[i]
 
 /-- Entry access for a selected matrix row. -/
-@[simp, grind =] theorem row_getElem (M : Matrix R n m) (i : Fin n) (j : Fin m) :
+@[grind =] theorem row_getElem (M : Matrix R n m) (i : Fin n) (j : Fin m) :
     (row M i)[j] = M[i][j] := by
   rfl
 
@@ -99,7 +99,7 @@ def col (M : Matrix R n m) (j : Fin m) : Vector R n :=
   Vector.ofFn fun i => M[i][j]
 
 /-- Entry access for a selected matrix column. -/
-@[simp, grind =] theorem col_getElem (M : Matrix R n m) (j : Fin m) (i : Fin n) :
+@[grind =] theorem col_getElem (M : Matrix R n m) (j : Fin m) (i : Fin n) :
     (col M j)[i] = M[i][j] := by
   simp [col]
 
@@ -108,7 +108,7 @@ def transpose (M : Matrix R n m) : Matrix R m n :=
   Vector.ofFn fun j => col M j
 
 /-- Entry access for the transpose of a dense matrix. -/
-@[simp, grind =] theorem transpose_getElem (M : Matrix R n m) (i : Fin m) (j : Fin n) :
+@[grind =] theorem transpose_getElem (M : Matrix R n m) (i : Fin m) (j : Fin n) :
     (transpose M)[i][j] = M[j][i] := by
   simp [transpose, col]
 
@@ -171,14 +171,14 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Matrix R m k) (Matri
   hMul := mul
 
 /-- Entry characterization for matrix-vector multiplication. -/
-@[simp, grind =] theorem mulVec_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem mulVec_getElem [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (v : Vector R m) (i : Fin n) :
     (M * v)[i] = dot (row M i) v := by
   show (mulVec M v)[i] = dot (row M i) v
   simp [mulVec]
 
 /-- Entry characterization for matrix multiplication. -/
-@[simp, grind =] theorem mul_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem mul_getElem [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (N : Matrix R m k) (i : Fin n) (j : Fin k) :
     (M * N)[i][j] = dot (row M i) (col N j) := by
   show (mul M N)[i][j] = dot (row M i) (col N j)
@@ -608,7 +608,7 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
   ofFn fun i j => Hex.Vector.dotProduct (row M i) (row M j)
 
 /-- Entry characterization for the Gram matrix of the rows of a dense matrix. -/
-@[simp, grind =] theorem gramMatrix_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem gramMatrix_getElem [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (i j : Fin n) :
     (gramMatrix M)[i][j] = Hex.Vector.dotProduct (row M i) (row M j) := by
   rw [gramMatrix, getElem_ofFn]
@@ -638,7 +638,7 @@ def leadingRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
 the source entry `M[i][j]` at the same coordinates, reembedded into `Fin n`. This
 is the `simp` normalization that rewrites a prefix lookup back to a source lookup
 in determinant expansions. -/
-@[simp, grind =] theorem leadingPrefix_entry (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
+@[grind =] theorem leadingPrefix_entry (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
     (i j : Fin k) :
     (leadingPrefix M k hk)[i][j] =
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
@@ -650,7 +650,7 @@ in determinant expansions. -/
 source entry `M[i][j]` with the row index reembedded into `Fin n` and the column
 index `j` retained unchanged. This is the `simp` normalization a determinant
 expansion relies on to rewrite a row-slice lookup back to a source lookup. -/
-@[simp, grind =] theorem leadingRows_entry (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
+@[grind =] theorem leadingRows_entry (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) (j : Fin m) :
     (leadingRows M k hk)[i][j] =
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
@@ -661,7 +661,7 @@ expansion relies on to rewrite a row-slice lookup back to a source lookup. -/
 to the source entry `M[i][j]` at the same coordinates, reembedded into `Fin n` via
 `k.val + 1 ≤ n`. This is the `simp` normalization that rewrites a submatrix lookup
 back to a source lookup in determinant expansions. -/
-@[simp, grind =] theorem submatrix_entry (M : Matrix R n n) (k : Fin n)
+@[grind =] theorem submatrix_entry (M : Matrix R n n) (k : Fin n)
     (i j : Fin (k.val + 1)) :
     (submatrix M k)[i][j] =
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt (Nat.succ_le_of_lt k.isLt)⟩
@@ -702,7 +702,7 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
 and `c.val < k`, the `(r, c)` entry resolves to the source entry `M[r][c]` at the
 reembedded leading-block coordinates, independent of the border row `i` and column
 `j`. This is the `simp` normalization for the top-left `k × k` block. -/
-@[simp, grind =] theorem borderedMinor_entry_lt_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
+@[grind =] theorem borderedMinor_entry_lt_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (r c : Fin (k + 1)) (hr : r.val < k) (hc : c.val < k) :
     (borderedMinor M k hk i j)[r][c] =
       (let rr : Fin n := ⟨r.val, Nat.lt_trans hr hk⟩
@@ -714,7 +714,7 @@ reembedded leading-block coordinates, independent of the border row `i` and colu
 `Fin.last k` with `r.val < k`, the `(r, last)` entry resolves to the source entry
 `M[r][j]`, taking the border column `j` and the reembedded leading-block row. This
 is the `simp` normalization for the appended border column. -/
-@[simp, grind =] theorem borderedMinor_entry_lt_last (M : Matrix R n n) (k : Nat) (hk : k < n)
+@[grind =] theorem borderedMinor_entry_lt_last (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (r : Fin (k + 1)) (hr : r.val < k) :
     (borderedMinor M k hk i j)[r][Fin.last k] =
       (let rr : Fin n := ⟨r.val, Nat.lt_trans hr hk⟩
@@ -725,7 +725,7 @@ is the `simp` normalization for the appended border column. -/
 `Fin.last k` with `c.val < k`, the `(last, c)` entry resolves to the source entry
 `M[i][c]`, taking the border row `i` and the reembedded leading-block column. This
 is the `simp` normalization for the appended border row. -/
-@[simp, grind =] theorem borderedMinor_entry_last_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
+@[grind =] theorem borderedMinor_entry_last_lt (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) (c : Fin (k + 1)) (hc : c.val < k) :
     (borderedMinor M k hk i j)[Fin.last k][c] =
       (let cc : Fin n := ⟨c.val, Nat.lt_trans hc hk⟩
@@ -736,7 +736,7 @@ is the `simp` normalization for the appended border row. -/
 `(Fin.last k, Fin.last k)`, the entry resolves to the source entry `M[i][j]` formed
 from the border row `i` and border column `j`. This is the `simp` normalization for
 the corner that a determinant expansion isolates last. -/
-@[simp, grind =] theorem borderedMinor_entry_last_last (M : Matrix R n n) (k : Nat) (hk : k < n)
+@[grind =] theorem borderedMinor_entry_last_last (M : Matrix R n n) (k : Nat) (hk : k < n)
     (i j : Fin n) :
     (borderedMinor M k hk i j)[Fin.last k][Fin.last k] = M[i][j] := by
   simp [borderedMinor, ofFn]
@@ -776,7 +776,7 @@ theorem leadingPrefix_borderedMinor_succ_eq_borderedMinor (M : Matrix R n n)
     simp [leadingPrefix, borderedMinor, ofFn, hr_eq, hc_eq]
 
 /-- The identity matrix entry function: `1[i][j] = 1` if `i = j`, else `0`. -/
-@[simp, grind =] theorem getElem_one [OfNat R 0] [OfNat R 1] {n : Nat} (i j : Fin n) :
+@[grind =] theorem getElem_one [OfNat R 0] [OfNat R 1] {n : Nat} (i j : Fin n) :
     (1 : Matrix R n n)[i][j] = if i = j then (1 : R) else 0 := by
   simp [show (1 : Matrix R n n) = Matrix.identity from rfl, Matrix.identity, ofFn]
 

--- a/HexMatrix/Determinant.lean
+++ b/HexMatrix/Determinant.lean
@@ -345,7 +345,7 @@ def deleteRowCol {R : Type u} {n : Nat} (M : Matrix R (n + 1) (n + 1))
 
 /-- Entries of a deleted-row/deleted-column minor are the corresponding source
 entries at the skipped row and column indices. -/
-@[simp, grind =] theorem deleteRowCol_entry {R : Type u} {n : Nat}
+@[grind =] theorem deleteRowCol_entry {R : Type u} {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (row col : Fin (n + 1)) (i j : Fin n) :
     (deleteRowCol M row col)[i][j] = M[skipIndex row i][skipIndex col j] := by
   simp [deleteRowCol, ofFn]
@@ -5382,7 +5382,7 @@ private def columnSumMatrix {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
   ofFn fun r j =>
     (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[simp, grind =] private theorem columnSumMatrix_entry
+@[grind =] private theorem columnSumMatrix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (r j : Fin n) :
     (columnSumMatrix source coeff)[r][j] =
@@ -5443,7 +5443,7 @@ private def setColumnChoice {n m : Nat} (choices : Fin n → Option (Fin m))
     (dst : Fin n) (k : Fin m) : Fin n → Option (Fin m) :=
   fun c => if c = dst then some k else choices c
 
-@[simp, grind =] private theorem columnChoiceMatrix_entry
+@[grind =] private theorem columnChoiceMatrix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (r c : Fin n) :
     (columnChoiceMatrix source coeff choices)[r][c] =
@@ -5594,7 +5594,7 @@ def columnTupleMatrix {R : Type u} {n m : Nat}
     (A : Matrix R n m) (cols : Fin n → Fin m) : Matrix R n n :=
   ofFn fun r c => A[r][cols c]
 
-@[simp, grind =] theorem columnTupleMatrix_entry {R : Type u} {n m : Nat}
+@[grind =] theorem columnTupleMatrix_entry {R : Type u} {n m : Nat}
     (A : Matrix R n m) (cols : Fin n → Fin m) (r c : Fin n) :
     (columnTupleMatrix A cols)[r][c] = A[r][cols c] := by
   simp [columnTupleMatrix, ofFn]
@@ -5610,10 +5610,11 @@ def columnTupleVectorFn {n m : Nat} (cols : Vector (Fin m) n) : Fin n → Fin m 
 /-- Reindexing the selected columns by a permutation is entrywise the generic
 column permutation of the selected minor.
 
-Left `@[simp]`-only (not promoted to `grind =`): the columns `s sigma` appear
-only under the `fun i => s[sigma[i]]` binder, so the LHS pattern cannot
-instantiate them and `grind =` rejects it. -/
-@[simp] theorem columnTupleMatrix_compose_perm_entry
+Unattributed: the LHS `[r][c]` is not in simp-normal form (`Fin.getElem_fin`
+rewrites the `Fin` indices to `↑r`/`↑c`), and `grind =` rejects the pattern
+because the columns `s sigma` appear only under the `fun i => s[sigma[i]]`
+binder, so the LHS cannot instantiate them. Invoked explicitly via `rw`. -/
+theorem columnTupleMatrix_compose_perm_entry
     {R : Type u} {n m : Nat} (A : Matrix R n m)
     (s : Vector (Fin m) n) (sigma : Vector (Fin n) n)
     (r c : Fin n) :
@@ -6183,7 +6184,7 @@ private def columnSumMatrixWithPrefix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[simp, grind =] private theorem columnSumMatrixWithPrefix_entry
+@[grind =] private theorem columnSumMatrixWithPrefix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithPrefix source coeff chosen)[r][j] =
@@ -6255,7 +6256,7 @@ private def columnSumMatrixWithSuffix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[simp, grind =] private theorem columnSumMatrixWithSuffix_entry
+@[grind =] private theorem columnSumMatrixWithSuffix_entry
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithSuffix source coeff chosen)[r][j] =
@@ -6398,7 +6399,7 @@ private def assembleColumnsSuffix {n m : Nat} (chosen : List (Fin m))
   ⟨(pref.toList ++ chosen).toArray, by
     simp [hk]⟩
 
-@[simp, grind =] private theorem assembleColumnsSuffix_left
+@[grind =] private theorem assembleColumnsSuffix_left
     {n m : Nat} (chosen : List (Fin m))
     (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
     (i : Fin (n - chosen.length)) :
@@ -6408,7 +6409,7 @@ private def assembleColumnsSuffix {n m : Nat} (chosen : List (Fin m))
           omega⟩ : Fin n)] = pref[i] := by
   simp [assembleColumnsSuffix]
 
-@[simp, grind =] private theorem assembleColumnsSuffix_right
+@[grind =] private theorem assembleColumnsSuffix_right
     {n m : Nat} (chosen : List (Fin m))
     (pref : Vector (Fin m) (n - chosen.length)) (hk : chosen.length ≤ n)
     (i : Fin chosen.length) :
@@ -7162,7 +7163,7 @@ is still well-defined but may have repeated values. -/
 def sortInjPerm {m n : Nat} (cols : Vector (Fin m) n) : Vector (Fin n) n :=
   Vector.ofFn fun i => ⟨columnRankNat cols i, columnRankNat_lt cols i⟩
 
-@[simp, grind =] theorem sortInjPerm_getElem_val {m n : Nat}
+@[grind =] theorem sortInjPerm_getElem_val {m n : Nat}
     (cols : Vector (Fin m) n) (i : Fin n) :
     (sortInjPerm cols)[i].val = columnRankNat cols i := by
   simp [sortInjPerm]
@@ -7425,12 +7426,12 @@ def reconstructInjTuple {m n : Nat}
     (sel : Vector (Fin m) n) (perm : Vector (Fin n) n) : Vector (Fin m) n :=
   Vector.ofFn fun i => sel[perm[i]]
 
-@[simp, grind =] theorem reconstructInjTuple_getElem {m n : Nat}
+@[grind =] theorem reconstructInjTuple_getElem {m n : Nat}
     (sel : Vector (Fin m) n) (perm : Vector (Fin n) n) (i : Fin n) :
     (reconstructInjTuple sel perm)[i] = sel[perm[i]] := by
   rw [reconstructInjTuple, vector_ofFn_getElem_fin]
 
-@[simp, grind =] theorem columnTupleMatrix_reconstructInjTuple_entry
+@[grind =] theorem columnTupleMatrix_reconstructInjTuple_entry
     {R : Type u} {n m : Nat} (A : Matrix R n m)
     (sel : Vector (Fin m) n) (perm : Vector (Fin n) n)
     (r c : Fin n) :
@@ -7970,7 +7971,7 @@ theorem det_gramMatrix_nonneg {n m : Nat} (A : Matrix Int n m) :
 def firstColumns (k n : Nat) (hk : k ≤ n) : Vector (Fin n) k :=
   Vector.ofFn fun i => ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
 
-@[simp, grind =] theorem firstColumns_entry (k n : Nat) (hk : k ≤ n) (i : Fin k) :
+@[grind =] theorem firstColumns_entry (k n : Nat) (hk : k ≤ n) (i : Fin k) :
     (firstColumns k n hk)[i] = (⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩ : Fin n) := by
   simp [firstColumns]
 
@@ -8061,7 +8062,7 @@ def setRow {R : Type u} {n m : Nat}
     (M : Matrix R n m) (dst : Fin n) (v : Vector R m) : Matrix R n m :=
   M.set dst v
 
-@[simp, grind =] theorem setRow_get_self {R : Type u} {n m : Nat}
+@[grind =] theorem setRow_get_self {R : Type u} {n m : Nat}
     (M : Matrix R n m) (dst : Fin n) (v : Vector R m) :
     (setRow M dst v)[dst] = v := by
   simp [setRow]
@@ -8174,7 +8175,7 @@ def adjugate {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) : Matrix R (n + 1) (n + 1) :=
   ofFn fun i j => cofactor M j i
 
-@[simp, grind =] theorem adjugate_get {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+@[grind =] theorem adjugate_get {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (i j : Fin (n + 1)) :
     (adjugate M)[i][j] = cofactor M j i := by
   simp [adjugate, ofFn]
@@ -8293,7 +8294,7 @@ theorem adjugate_eq_cofactorSign_mul_deleteRowCol
 
 /-- The `(0, 0)` adjugate entry equals the determinant of the minor
 obtained by deleting row `0` and column `0`. -/
-@[simp, grind =] theorem adjugate_zero_zero
+@[grind =] theorem adjugate_zero_zero
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) :
     (adjugate M)[(0 : Fin (n + 1))][(0 : Fin (n + 1))] =
@@ -8303,7 +8304,7 @@ obtained by deleting row `0` and column `0`. -/
 
 /-- The `(Fin.last, Fin.last)` adjugate entry equals the determinant of
 the leading prefix minor obtained by deleting the last row and column. -/
-@[simp, grind =] theorem adjugate_last_last
+@[grind =] theorem adjugate_last_last
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) :
     (adjugate M)[Fin.last n][Fin.last n] =
@@ -8453,7 +8454,9 @@ Encoding for the universal 3-term Plucker identity substrate. -/
 `p < q`. This indexes minors with two removed rows.
 
 The ordering proof `_hpq` is a phantom argument: it documents and pins the
-`p < q` precondition at call sites but is not consumed by the definition. -/
+`p < q` precondition at call sites but is not consumed by the definition.
+This intentionally triggers the `unusedArguments` linter; the binder is kept
+deliberately (no `@[nolint]` exists in the Mathlib-free layer). -/
 def skipIndex2 {n : Nat} (p q : Fin (n + 2)) (_hpq : p.val < q.val)
     (i : Fin n) : Fin (n + 2) :=
   if hi1 : i.val < p.val then
@@ -8550,7 +8553,7 @@ def nMatrix {R : Type u} {n : Nat}
     Matrix R n n :=
   ofFn fun i j => B[skipIndex2 p q hpq i][j]
 
-@[simp, grind =] theorem nMatrix_entry {R : Type u} {n : Nat}
+@[grind =] theorem nMatrix_entry {R : Type u} {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hpq : p.val < q.val)
     (i : Fin n) (j : Fin n) :
     (nMatrix B p q hpq)[i][j] = B[skipIndex2 p q hpq i][j] := by
@@ -9516,7 +9519,7 @@ def basisVec {R : Type u} [Zero R] [One R] {n : Nat} (q : Fin (n + 2)) :
     Vector R (n + 2) :=
   Vector.ofFn fun i => if i = q then (1 : R) else (0 : R)
 
-@[simp, grind =] theorem basisVec_getElem {R : Type u} [Zero R] [One R] {n : Nat}
+@[grind =] theorem basisVec_getElem {R : Type u} [Zero R] [One R] {n : Nat}
     (q : Fin (n + 2)) (i : Fin (n + 2)) :
     (basisVec (R := R) q)[i] = if i = q then (1 : R) else (0 : R) := by
   simp [basisVec]

--- a/HexMatrix/RREF.lean
+++ b/HexMatrix/RREF.lean
@@ -2268,14 +2268,14 @@ def nullspaceMatrix [Lean.Grind.Ring R] (E : IsRREF M D) :
       | none => 0
 
 /-- In the `k`th nullspace-matrix column, the row for its own free column is `1`. -/
-@[simp, grind =] theorem nullspaceMatrix_free [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspaceMatrix_free [Lean.Grind.Ring R] (E : IsRREF M D)
     (k : Fin (m - D.rank)) :
     E.nullspaceMatrix[E.toIsEchelonForm.freeCols.get k][k] = 1 := by
   unfold nullspaceMatrix Matrix.ofFn
   simp
 
 /-- In the `k`th nullspace-matrix column, every other free-column row is `0`. -/
-@[simp, grind =] theorem nullspaceMatrix_free_ne [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspaceMatrix_free_ne [Lean.Grind.Ring R] (E : IsRREF M D)
     {k l : Fin (m - D.rank)} (hkl : k ≠ l) :
     E.nullspaceMatrix[E.toIsEchelonForm.freeCols.get l][k] = 0 := by
   unfold nullspaceMatrix Matrix.ofFn
@@ -2286,7 +2286,7 @@ def nullspaceMatrix [Lean.Grind.Ring R] (E : IsRREF M D) :
 
 /-- In a pivot-column row, a nullspace-matrix entry is the negative RREF entry in
 the matching pivot row and free column. -/
-@[simp, grind =] theorem nullspaceMatrix_pivot [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspaceMatrix_pivot [Lean.Grind.Ring R] (E : IsRREF M D)
     (i : Fin D.rank) (k : Fin (m - D.rank)) :
     E.nullspaceMatrix[D.pivotCols.get i][k] =
       -(D.echelon[(IsEchelonForm.pivotRow E.toIsEchelonForm i)][E.toIsEchelonForm.freeCols.get k]) := by
@@ -2306,14 +2306,14 @@ private theorem nullspace_get [Lean.Grind.Ring R] (E : IsRREF M D)
   rw [Vector.get_ofFn]
 
 /-- On its own free column, a nullspace basis vector has entry `1`. -/
-@[simp, grind =] theorem nullspace_get_free [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspace_get_free [Lean.Grind.Ring R] (E : IsRREF M D)
     (k : Fin (m - D.rank)) :
     (E.nullspace.get k)[E.toIsEchelonForm.freeCols.get k] = 1 := by
   rw [nullspace_get]
   simpa [Matrix.col] using nullspaceMatrix_free E k
 
 /-- On every other free column, a nullspace basis vector has entry `0`. -/
-@[simp, grind =] theorem nullspace_get_free_ne [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspace_get_free_ne [Lean.Grind.Ring R] (E : IsRREF M D)
     {k l : Fin (m - D.rank)} (hkl : k ≠ l) :
     (E.nullspace.get k)[E.toIsEchelonForm.freeCols.get l] = 0 := by
   rw [nullspace_get]
@@ -2321,7 +2321,7 @@ private theorem nullspace_get [Lean.Grind.Ring R] (E : IsRREF M D)
 
 /-- On a pivot column, a nullspace basis vector is the negative RREF entry in
 the matching pivot row and free column. -/
-@[simp, grind =] theorem nullspace_get_pivot [Lean.Grind.Ring R] (E : IsRREF M D)
+@[grind =] theorem nullspace_get_pivot [Lean.Grind.Ring R] (E : IsRREF M D)
     (i : Fin D.rank) (k : Fin (m - D.rank)) :
     (E.nullspace.get k)[D.pivotCols.get i] =
       -(D.echelon[(IsEchelonForm.pivotRow E.toIsEchelonForm i)][E.toIsEchelonForm.freeCols.get k]) := by

--- a/HexMatrix/RowEchelon.lean
+++ b/HexMatrix/RowEchelon.lean
@@ -1123,7 +1123,9 @@ theorem pivotCols_injective (E : IsEchelonForm M D) :
 
 The echelon-form witness `_E` is a phantom argument: it carries no runtime
 data but enables dot-notation (`E.freeColsList`) and fixes the implicit
-matrix/data parameters. -/
+matrix/data parameters. This intentionally triggers the `unusedArguments`
+linter; the binder is kept deliberately (no `@[nolint]` exists in the
+Mathlib-free layer). -/
 def freeColsList (_E : IsEchelonForm M D) : List (Fin m) :=
   (List.finRange m).filter fun j => j ∉ D.pivotCols.toList
 

--- a/progress/20260620T090757Z_66421aef.md
+++ b/progress/20260620T090757Z_66421aef.md
@@ -1,0 +1,53 @@
+# HexMatrix Phase 6 simpNF + unusedArguments cleanup (#8226)
+
+## Accomplished
+
+Cleared the last Phase 6 exit-criteria lint gap for `HexMatrix`.
+
+- **simpNF (40 lints).** Demoted every `@[simp, grind =]` getElem/entry
+  lemma whose stated LHS `(foo …)[i][j]` is not simp-normal (the general
+  `Fin.getElem_fin` rewrites each `Fin` index `i` to `↑i`) to `@[grind =]`,
+  across `Basic` (15), `Determinant` (19), `RREF` (6). These lemmas are
+  consumed almost exclusively through explicit `rw [...]` / `grind`
+  (e.g. `nMatrix_entry` has 26 `rw` callers, `adjugate_get` 9), not bare
+  `simp`, so dropping `@[simp]` while keeping the original Fin-indexed LHS
+  and `@[grind =]` clears all 40 lints with zero downstream proof churn.
+  `columnTupleMatrix_compose_perm_entry` was `@[simp]`-only and `grind`
+  rejects its binder-bound pattern, so it is left unattributed (invoked via
+  one explicit `rw`); its stale "left `@[simp]`-only" docstring was updated.
+- **unusedArguments (2 lints).** Adjudicated `skipIndex2 _hpq` and
+  `freeColsList _E` as documented intentional phantom args: both pin
+  call-site preconditions / enable dot-notation and are kept deliberately.
+  Named the `unusedArguments` lint explicitly in each docstring (no
+  `@[nolint]` exists in the Mathlib-free layer, so "accept" = document).
+
+## Decisions
+
+- Chose uniform **demotion** over LHS restatement. Restatement (rewrite LHS
+  to `↑i`/`.val` form, keep `@[simp]`) was tried first on `Basic` and broke
+  every explicit `rw [lemma]` caller (pattern mismatch on the Fin index) —
+  5 sites in `Basic` alone, 40+ across the library. Demotion preserves all
+  explicit callers; the non-normal LHS meant bare `simp` was never reliably
+  firing these anyway. One consistent decision across all three files, per
+  the issue's instruction.
+
+## Verification
+
+- `lake build HexMatrix` green; **full `lake build` green (2569 jobs)**,
+  including CI-gated `HexBerlekampZassenhausMathlib` and all HexMatrix
+  dependents (`HexMatrixMathlib`, `HexGramSchmidt`, `HexBerlekamp`).
+- `lake exe runLinter` on `Basic`/`Determinant`/`RREF`/`RowEchelon`:
+  simpNF category fully cleared; only the 2 documented-intentional
+  `unusedArguments` remain.
+- No `axiom`/`sorry`/`native_decide` introduced; no Mathlib dep added.
+
+## Current frontier / Next step
+
+- `libraries.yml[HexMatrix].done_through` left at **5**. The 5→6 bump is
+  deliberately deferred: PR #8224 (public-theorem docstrings, the last
+  remaining Phase 6 gap) is still open. Whichever issue closes that gap
+  owns the bump.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8226

Session: `66421aef-566f-4116-b14e-21ec8e5af244`

25625fa9 chore: progress entry for #8226 HexMatrix simpNF cleanup
baba2395 refactor: clear HexMatrix Phase 6 simpNF lints by demoting getElem entry lemmas to grind

🤖 Prepared with Claude Code