### PR TITLE
review: HexGramSchmidtMathlib Phase 6 audit (linter, dead decl, partial docstrings; keep done_through 5)

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -86,6 +86,22 @@ rebuild the direct downstream consumer too (`HexFooMathlib`) after any
 dead-code removal — the cross-repo grep can miss nothing, but the
 compiler is the only proof the removals were safe.
 
+The *docstring coverage* criterion has its own trap: a Lean docstring is
+`/-- … -/`, but `/-! … -/` is a **section/module comment** that does NOT
+attach to the following declaration. A coverage script that just checks
+"is the line above a decl a `-/`?" counts section headers as docstrings
+and **undercounts** the gap — a whole `/-! ### Foo updates -/`-headed
+block of theorems reads as documented when none of them are. Match the
+comment *opener* (`/--` vs `/-!`), not just the closer. Note the doc rule
+(`SPEC/design-principles.md` § Docstrings) covers **every importable
+theorem**, not only `def`/`structure`, so thin public wrappers over a
+documented private `_core` still each need their own `/--`. When a
+library has *dozens* of undocumented public theorems, that is the issue's
+explicit signal to leave `done_through` unbumped and punch-list the
+docstrings (verdict (b)) rather than cram them — but still land the
+genuinely-trivial inline fixes (linter, dead decls, the obvious one-line
+docstrings) in the same PR.
+
 ## Updating Skills
 
 When you discover a recurring pattern or encounter a situation not covered by

--- a/HexGramSchmidtMathlib/Basic.lean
+++ b/HexGramSchmidtMathlib/Basic.lean
@@ -18,38 +18,42 @@ space on `Fin m`. -/
 def rowToEuclidean (row : Vector Rat m) : EuclideanSpace ℝ (Fin m) :=
   WithLp.toLp 2 (fun j : Fin m => (row[j] : ℝ))
 
+/-- Coordinate access commutes with `rowToEuclidean`: the `j`-th component of the
+converted vector is the real cast of the `j`-th rational entry. -/
 @[simp, grind =]
 theorem rowToEuclidean_apply (row : Vector Rat m) (j : Fin m) :
     rowToEuclidean row j = (row[j] : ℝ) := by
   rfl
 
+/-- `rowToEuclidean` sends the zero row to the zero vector. -/
 @[simp, grind =]
 theorem rowToEuclidean_zero :
     rowToEuclidean (0 : Vector Rat m) = 0 := by
   ext j
   simp [rowToEuclidean]
 
+/-- `rowToEuclidean` is additive: it sends a rowwise sum to the sum of converted
+vectors. -/
 @[simp, grind =]
 theorem rowToEuclidean_add (a b : Vector Rat m) :
     rowToEuclidean (a + b) = rowToEuclidean a + rowToEuclidean b := by
   ext j
   simp [rowToEuclidean]
 
+/-- `rowToEuclidean` commutes with subtraction. -/
 @[simp, grind =]
 theorem rowToEuclidean_sub (a b : Vector Rat m) :
     rowToEuclidean (a - b) = rowToEuclidean a - rowToEuclidean b := by
   ext j
   simp [rowToEuclidean]
 
+/-- `rowToEuclidean` is rational-linear: it sends a rational scalar multiple to the
+corresponding real scalar multiple of the converted vector. -/
 @[simp, grind =]
 theorem rowToEuclidean_smul (c : Rat) (row : Vector Rat m) :
     rowToEuclidean (c • row) = (c : ℝ) • rowToEuclidean row := by
   ext j
   simp [rowToEuclidean]
-
-/-- Cast a rational dense matrix into the real matrix space used by the correspondence. -/
-def castRatMatrix (b : Matrix Rat n m) : Matrix ℝ n m :=
-  Vector.map (fun row => Vector.map (fun x : Rat => (x : ℝ)) row) b
 
 /-- Cast an integer dense matrix into the rational matrix space of `HexGramSchmidt`. -/
 def castIntMatrix (b : Matrix Int n m) : Matrix Rat n m :=

--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -2839,7 +2839,7 @@ theorem dot_basis_castRow_eq_coeffs_mul_normSq
 /-- Foldl isolation for two indices: when every term except those at `j₁` and `j₂`
 vanishes, the foldl over `List.finRange i` collapses to `f ⟨j₁, hj₁⟩ + f ⟨j₂, hj₂⟩`. -/
 private theorem foldl_finRange_isolate_two_rat :
-    ∀ (i : Nat) (j₁ j₂ : Nat) (hj₁ : j₁ < i) (hj₂ : j₂ < i) (hne : j₁ ≠ j₂)
+    ∀ (i : Nat) (j₁ j₂ : Nat) (hj₁ : j₁ < i) (hj₂ : j₂ < i) (_hne : j₁ ≠ j₂)
       (f : Fin i → Rat),
       (∀ q : Fin i, q.val ≠ j₁ → q.val ≠ j₂ → f q = 0) →
       (List.finRange i).foldl (fun acc q => acc + f q) 0 =

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -664,7 +664,7 @@ theorem gramDet_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
 
 theorem adjacentSwap_gramDetNumerator_dvd (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    (_hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
     adjacentSwapDenom b k ∣ adjacentSwapGramDetNumerator b k hk := by
   let km1 := GramSchmidt.prevRow k hk
   have hkm1 : km1.val + 1 = k.val := by
@@ -699,7 +699,7 @@ the basis identity `basis (rowSwap b km1 k) [km1] = basis b [k] + μ * basis b [
 theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hki : k.val < i.val)
-    (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
+    (_hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
     let km1 := GramSchmidt.prevRow k hk
     let hkm1i : km1.val < i.val := by
       dsimp [km1, GramSchmidt.prevRow]; omega

--- a/progress/20260620_091739_9b708af5.md
+++ b/progress/20260620_091739_9b708af5.md
@@ -1,0 +1,101 @@
+# HexGramSchmidtMathlib Phase 6 exit-criteria audit (#8229)
+
+Session type: review. UTC 2026-06-20T09:17.
+
+## Accomplished
+
+Audited `HexGramSchmidtMathlib` (a `mathlib: true` bridge library,
+`done_through: 5`, deps `[HexGramSchmidt, HexMatrixMathlib]`) against the
+four Phase 6 exit criteria. Verdict: **(b) — keep `done_through` at 5**;
+the docstring-coverage criterion fails by a wide margin (31 public
+theorems with no `/-- -/` docstring), which the issue itself names as the
+don't-bump threshold ("dozens of missing docstrings").
+
+Landed the low-risk inline fixes that clear three of the four criteria:
+
+- **Linter (criterion 1) → clean after fix.** A fresh full compile
+  surfaced three `unusedVariables` warnings. Fixed by underscoring the
+  unused binders (signature-preserving, all three theorems have callers
+  that pass the argument positionally, so removal would churn
+  `HexLLLMathlib` and in-file call sites):
+  - `Int.lean:2842` `_hne` in `foldl_finRange_isolate_two_rat`;
+  - `Update.lean:667` `_hdet` in `adjacentSwap_gramDetNumerator_dvd`
+    (called by `HexLLLMathlib/Independent.lean:691`);
+  - `Update.lean:702` `_hdet` in
+    `bareiss_scaledCoeffMatrix_rowSwap_above_prev` (called in-file at
+    `Update.lean:1128/1154`).
+  No mathlib `runLinter` binary is built and the project has no linter
+  script, so — as with the sibling `HexGFq`/`HexGF2` audits — the
+  criterion is Lean's built-in linters via a clean compile. The
+  `info: Try these` lines in the build log are all from the `HexMatrix`
+  dependency (`HexMatrix/Bareiss.lean`), not this library.
+- **Dead code (criterion 3) → clean after fix.** Reachability scan over
+  every private declaration: none unreferenced. One **public** def was
+  genuinely dead — `castRatMatrix` (`Basic.lean:51`, `Rat`-matrix → ℝ
+  cast) with zero references anywhere in the repo (the code casts
+  Int → Rat via `castIntMatrix` directly). Removed it.
+- **Native / oracle + irreducibility (criterion 4) → pass.** No
+  `native_decide`, `sorry`, or `axiom` anywhere (grep + transitive
+  `#print axioms` on the headline correspondence theorems
+  `int_basis_row_eq_gramSchmidt`, `rat_basis_row_eq_gramSchmidt`,
+  `scaledCoeffs_adjacentSwap_above_curr`: all
+  `[propext, Classical.choice, Quot.sound]`). Irreducibility N/A — this is
+  a `noncomputable` linear-algebra bridge, not a decision procedure.
+- **Also done inline:** the 5 trivial Basic.lean docstrings (the
+  `rowToEuclidean_*` `@[simp, grind =]` coercion/linearity lemmas), which
+  fully document that file's public surface.
+
+`lake build HexGramSchmidtMathlib` green, zero warnings, after the fixes.
+
+## Current frontier
+
+Docstring coverage (criterion 2) remains failing: **26** public theorems
+still lack `/-- -/` docstrings (the 5 Basic.lean ones are now done). Per
+the issue, this is the substantial work that blocks the `5 → 6` bump.
+Enumerated as a punch-list (below) for a follow-up planner.
+
+## Punch-list (criterion 2 — public-theorem docstrings)
+
+Two bounded follow-up feature issues, both docstring-only (zero proof
+changes, zero compile risk; each public theorem has a clear name and, for
+the `Update.lean` groups, a `/-! ### -/` section header already
+explaining the family):
+
+**A. `Update.lean` size-reduce / adjacent-swap update laws (20):**
+`gramDet_sizeReduce` (33), `scaledCoeffs_sizeReduce_pivot` (39),
+`_lower` (48), `_other_row` (57), `_above_pivot` (63),
+`gramDet_adjacentSwap_of_ne` (402),
+`scaledCoeffs_adjacentSwap_lower_prev` (441), `_lower_curr` (474),
+`_pivot` (507), `_before` (532), `_above_low` (567), `_above_high` (603),
+`gramDet_adjacentSwap_pivot` (635), `adjacentSwap_gramDetNumerator_dvd`
+(665), `bareiss_scaledCoeffMatrix_rowSwap_above_prev` (699),
+`_above_curr` (922), `adjacentSwap_scaledCoeffAbovePrevNumerator_dvd`
+(1124), `_AboveCurrNumerator_dvd` (1134),
+`scaledCoeffs_adjacentSwap_above_prev` (1144), `_above_curr` (1165).
+
+**B. `Int.lean` public theorems (6):** `gramDet_eq_prod_normSq` (1025),
+`gramDet_pos` (1030), `basis_normSq` (1070) — all thin wrappers whose
+private `_core` siblings already carry docstrings to adapt;
+`dot_add_left_rat` (2571), `dot_smul_left_rat` (2577) — rational
+dot-product linearity; `independent_one` (3979).
+
+Borderline (optional, private "non-obvious" helpers, currently
+undocumented but arguably routine `_aux` plumbing): `Basic.lean`
+`sum_fin_eq_sum_Iio` (132), `rowToEuclidean_prefixCombination_eq_Iio_sum`
+(152). Not blocking.
+
+Also noted for a future cleanup (not blocking): the two `_hdet`
+hypotheses are mathematically redundant (the divisibility / Cramer
+identity holds unconditionally). Removing them would strengthen the API
+but requires updating the `HexLLLMathlib` and in-file callers, so it is
+out of scope for this low-risk audit.
+
+## Next step
+
+A planner turns punch-list A and B into two bounded `feature` issues.
+Once both land, a follow-up review re-runs the four criteria and performs
+the `done_through 5 → 6` bump.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8229

Session: `9b708af5-380d-41cc-b466-07277e650e46`

56017e95 review: HexGramSchmidtMathlib Phase 6 audit — linter fixes, dead-decl removal, partial docstrings

🤖 Prepared with Claude Code