### PR TITLE
review: HexPolyZMathlib Phase 6 audit (docstrings, dead decl; keep done_through 5)

### DIFF
--- a/HexPolyZMathlib/Basic.lean
+++ b/HexPolyZMathlib/Basic.lean
@@ -28,56 +28,70 @@ abbrev toPolynomial (p : Hex.ZPoly) : Polynomial ℤ :=
 abbrev ofPolynomial (p : Polynomial ℤ) : Hex.ZPoly :=
   HexPolyMathlib.ofPolynomial p
 
+/-- Coefficients of the embedded Mathlib polynomial agree with the executable
+coefficients. -/
 @[simp, grind =]
 theorem coeff_toPolynomial (p : Hex.ZPoly) (n : Nat) :
     (toPolynomial p).coeff n = p.coeff n :=
   HexPolyMathlib.coeff_toPolynomial p n
 
+/-- `ofPolynomial` sends the zero polynomial to the zero `ZPoly`. -/
 @[simp, grind =]
 theorem ofPolynomial_zero :
     ofPolynomial (0 : Polynomial ℤ) = 0 :=
   HexPolyMathlib.ofPolynomial_zero
 
+/-- `toPolynomial` sends the zero `ZPoly` to the zero polynomial. -/
 @[simp, grind =]
 theorem toPolynomial_zero :
     toPolynomial (0 : Hex.ZPoly) = 0 :=
   HexPolyMathlib.toPolynomial_zero
 
+/-- `toPolynomial` sends the executable constant `C c` to Mathlib's `Polynomial.C c`. -/
 @[simp, grind =]
 theorem toPolynomial_C (c : ℤ) :
     toPolynomial (Hex.DensePoly.C c) = Polynomial.C c :=
   HexPolyMathlib.toPolynomial_C c
 
+/-- `toPolynomial` is additive. -/
 @[simp, grind =]
 theorem toPolynomial_add (p q : Hex.ZPoly) :
     toPolynomial (p + q) = toPolynomial p + toPolynomial q :=
   HexPolyMathlib.toPolynomial_add p q
 
+/-- `toPolynomial` is multiplicative. -/
 @[simp, grind =]
 theorem toPolynomial_mul (p q : Hex.ZPoly) :
     toPolynomial (p * q) = toPolynomial p * toPolynomial q :=
   HexPolyMathlib.toPolynomial_mul p q
 
+/-- `toPolynomial` sends the executable `1` to Mathlib's `1`. -/
 @[simp, grind =]
 theorem toPolynomial_one :
     toPolynomial (1 : Hex.ZPoly) = 1 :=
   HexPolyMathlib.toPolynomial_one
 
+/-- `toPolynomial` commutes with negation. -/
 @[simp, grind =]
 theorem toPolynomial_neg (p : Hex.ZPoly) :
     toPolynomial (-p) = -toPolynomial p :=
   HexPolyMathlib.toPolynomial_neg p
 
+/-- `toPolynomial` commutes with subtraction. -/
 @[simp, grind =]
 theorem toPolynomial_sub (p q : Hex.ZPoly) :
     toPolynomial (p - q) = toPolynomial p - toPolynomial q :=
   HexPolyMathlib.toPolynomial_sub p q
 
+/-- `toPolynomial` is a left inverse of `ofPolynomial`: embedding a rebuilt
+polynomial recovers it. -/
 @[simp, grind =]
 theorem toPolynomial_ofPolynomial (p : Polynomial ℤ) :
     toPolynomial (ofPolynomial p) = p :=
   HexPolyMathlib.toPolynomial_ofPolynomial p
 
+/-- `ofPolynomial` is a left inverse of `toPolynomial`: rebuilding an embedded
+`ZPoly` recovers it. -/
 @[simp, grind =]
 theorem ofPolynomial_toPolynomial (p : Hex.ZPoly) :
     ofPolynomial (toPolynomial p) = p :=
@@ -88,11 +102,13 @@ polynomials over `ℤ`. -/
 abbrev equiv : Hex.ZPoly ≃+* Polynomial ℤ :=
   HexPolyMathlib.equiv
 
+/-- The ring equivalence acts as `toPolynomial` in the forward direction. -/
 @[simp, grind =]
 theorem equiv_apply (p : Hex.ZPoly) :
     equiv p = toPolynomial p := by
   rfl
 
+/-- The inverse ring equivalence acts as `ofPolynomial`. -/
 @[simp, grind =]
 theorem equiv_symm_apply (p : Polynomial ℤ) :
     equiv.symm p = ofPolynomial p := by
@@ -164,18 +180,6 @@ theorem eq_map_intCast_of_coeff_eq_toZMod_modP
   ext n
   rw [hq, coeff_toZMod_modP_eq_coeff_map_intCast]
 
-/--
-Divisibility of executable integer polynomials reduces modulo `p` after
-transporting both sides to Mathlib polynomials over `ZMod p`.
--/
-theorem map_intCast_zmod_dvd_of_zpoly_dvd
-    (p : Nat) {g f : Hex.ZPoly} (hgf : g ∣ f) :
-    (toPolynomial g).map (Int.castRingHom (ZMod p)) ∣
-      (toPolynomial f).map (Int.castRingHom (ZMod p)) := by
-  rcases hgf with ⟨q, rfl⟩
-  refine ⟨(toPolynomial q).map (Int.castRingHom (ZMod p)), ?_⟩
-  rw [toPolynomial_mul, Polynomial.map_mul]
-
 /-- Reduction modulo `p` preserves natural degree when the leading coefficient
 survives the map to `ZMod p`. -/
 theorem natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero
@@ -188,15 +192,16 @@ theorem natDegree_map_intCast_zmod_eq_of_leadingCoeff_ne_zero
     (Int.castRingHom (ZMod p)) hlc
 
 /--
-Issue-spec rename of `map_intCast_zmod_dvd_of_zpoly_dvd`: divisibility of
-executable integer polynomials transports to divisibility of their Mathlib
-reductions modulo `p`.
+Divisibility of executable integer polynomials transports to divisibility of
+their Mathlib reductions modulo `p`.
 -/
 theorem dvd_modP_of_dvd
     (p : Nat) {g f : Hex.ZPoly} (hgf : g ∣ f) :
     (toPolynomial g).map (Int.castRingHom (ZMod p)) ∣
-      (toPolynomial f).map (Int.castRingHom (ZMod p)) :=
-  map_intCast_zmod_dvd_of_zpoly_dvd p hgf
+      (toPolynomial f).map (Int.castRingHom (ZMod p)) := by
+  rcases hgf with ⟨q, rfl⟩
+  refine ⟨(toPolynomial q).map (Int.castRingHom (ZMod p)), ?_⟩
+  rw [toPolynomial_mul, Polynomial.map_mul]
 
 /--
 Core integer-to-`ZMod p` identity underlying `modP`: pushing an

--- a/HexPolyZMathlib/Mignotte.lean
+++ b/HexPolyZMathlib/Mignotte.lean
@@ -17,6 +17,9 @@ namespace HexPolyZMathlib
 
 noncomputable section
 
+/-- A left fold of additions over `List.range m` equals the corresponding
+`Finset.range` sum. Bridges the executable `coeffNormSq` accumulation fold to a
+Mathlib `Finset` sum. -/
 private theorem range_foldl_add_eq_finset_sum_nat (g : Nat → Nat) (m : Nat) :
     (List.range m).foldl (fun acc i => acc + g i) 0 = ∑ i ∈ Finset.range m, g i := by
   induction m with
@@ -31,11 +34,14 @@ private theorem range_foldl_add_eq_finset_sum_nat (g : Nat → Nat) (m : Nat) :
 def l2norm (f : Polynomial ℤ) : ℝ :=
   Real.sqrt (∑ i ∈ f.support, (f.coeff i : ℝ) ^ 2)
 
+/-- Coefficients of the complex cast of an integer polynomial are the complex
+casts of its integer coefficients. -/
 @[simp, grind =]
 theorem coeff_map_intCast (f : Polynomial ℤ) (n : Nat) :
     (f.map (Int.castRingHom ℂ)).coeff n = (f.coeff n : ℂ) := by
   simp
 
+/-- Casting an integer polynomial into `ℂ[X]` preserves its natural degree. -/
 @[simp, grind =]
 theorem natDegree_map_intCast (f : Polynomial ℤ) :
     (f.map (Int.castRingHom ℂ)).natDegree = f.natDegree := by
@@ -43,6 +49,7 @@ theorem natDegree_map_intCast (f : Polynomial ℤ) :
     (Polynomial.natDegree_map_eq_of_injective (f := Int.castRingHom ℂ)
       (hf := RingHom.injective_int (Int.castRingHom ℂ)) f)
 
+/-- Casting an integer polynomial into `ℂ[X]` preserves its support. -/
 @[simp, grind =]
 theorem support_map_intCast (f : Polynomial ℤ) :
     (f.map (Int.castRingHom ℂ)).support = f.support := by
@@ -50,11 +57,15 @@ theorem support_map_intCast (f : Polynomial ℤ) :
     (Polynomial.support_map_of_injective (f := Int.castRingHom ℂ) f
       (RingHom.injective_int (Int.castRingHom ℂ)))
 
+/-- The complex norm of a cast coefficient is the absolute value of the integer
+coefficient. -/
 @[simp, grind =]
 theorem norm_coeff_map_intCast (f : Polynomial ℤ) (n : Nat) :
     ‖(f.map (Int.castRingHom ℂ)).coeff n‖ = (Int.natAbs (f.coeff n) : ℝ) := by
   simp [Complex.norm_intCast]
 
+/-- The squared complex norm of a cast coefficient is the squared integer
+coefficient, the term appearing under the `l2norm` square root. -/
 theorem sq_norm_coeff_map_intCast (f : Polynomial ℤ) (n : Nat) :
     ‖(f.map (Int.castRingHom ℂ)).coeff n‖ ^ 2 = (f.coeff n : ℝ) ^ 2 := by
   simp [Complex.norm_intCast, pow_two]
@@ -170,6 +181,8 @@ theorem l2norm_toPolynomial_sq_eq_coeffNormSq (f : Hex.ZPoly) :
     _ = ∑ i ∈ Finset.range f.size, (p.coeff i : ℝ) ^ 2 := hsupport_sum
     _ = (Hex.ZPoly.coeffNormSq f : ℝ) := hnorm_sum.symm
 
+/-- The executable multiplicative binomial-coefficient fold over `List.range m`
+equals `Nat.choose n m`, the recurrence the `binom_eq_choose` bridge consumes. -/
 private theorem foldl_binom_iter_eq_choose (n m : Nat) :
     (List.range m).foldl (fun acc i => acc * (n - i) / (i + 1)) 1 = Nat.choose n m := by
   induction m with

--- a/progress/20260620_094350_d8835e3a.md
+++ b/progress/20260620_094350_d8835e3a.md
@@ -1,0 +1,173 @@
+# HexPolyZMathlib Phase 6 exit-criteria audit (#8233)
+
+Session type: review. UTC 2026-06-20T09:43.
+
+## Accomplished
+
+Audited `HexPolyZMathlib` against the four Phase 6 exit criteria.
+**Verdict (b): keep `done_through` at 5** — docstring coverage and the
+dead-code criterion both fail with substantial remaining work; enumerated
+below as a punch-list. Two of four files brought fully to standard inline.
+
+### Criterion results
+
+1. **Mathlib linter — PASS.** The project has no `runLinter` exe; the
+   gate is Lean's built-in linters run during compilation. `lake build
+   HexPolyZMathlib` is green with **zero** warnings/errors/sorry (3408
+   jobs). The CI-gated downstream `HexBerlekampZassenhausMathlib` also
+   builds green (0 errors, 3790 jobs) after my edits.
+
+2. **Docstring coverage — FAIL** (`SPEC/design-principles.md` §Docstrings:
+   all public `def`/`structure`/`class`/`inductive`; non-obvious private
+   helpers; every importable theorem). After inline fixes, `Basic.lean`
+   and `Mignotte.lean` are fully covered. Remaining gaps (92 undocumented
+   public importable decls), all in the two large files:
+   - `RobinsonForm.lean`: 31 (see punch-list).
+   - `SchurSzego.lean`: 61 (see punch-list).
+
+3. **Dead / unreferenced declarations — FAIL.** Structural finding:
+   - `SchurSzego.lean` (1366 lines, ~70 public theorems) is imported
+     **only** by the library root `HexPolyZMathlib.lean`; **no** downstream
+     consumer references any of its symbols. The entire module is
+     unconsumed.
+   - `RobinsonForm.lean` is `import`ed by
+     `HexBerlekampZassenhausMathlib/CLDColumnBound.lean` but **none** of
+     its public symbols are referenced there (stale import + unconsumed
+     module).
+   - 41 zero-reference public decls in `SchurSzego.lean`, 12 in
+     `RobinsonForm.lean` (lists below). NB many are legitimate
+     characterising lemmas (`_zero`/`_one`/`_eq_filter_card`) that
+     design-principles *encourages* even when not yet consumed — these are
+     candidates requiring per-decl judgement, not blind deletion. The
+     load-bearing signal is the module-level unconsumption, which a planner
+     should triage (wire the theory into a capstone, or excise it).
+   - Removed one clear-cut dead duplicate inline (see below).
+
+4. **native_decide / runtime oracle — PASS; irreducibility N/A.** No
+   `native_decide`, `@[extern]`, or `ofReduceBool` anywhere in the
+   library. It is a `noncomputable` Mathlib bridge, so the Lean-checked
+   irreducibility sub-criterion does not apply. Transitive `#print axioms`
+   on representative theorems across all four modules
+   (`mignotte_bound`, `dilate_recovery`,
+   `l2norm_toPolynomial_sq_eq_coeffNormSq`,
+   `Polynomial.mahlerMeasure_robinsonForm`,
+   `Polynomial.schmeisserComposition_zero`,
+   `Polynomial.rootsRadiusProduct_le_of_graceWalshSzegoZeroControlAtDegree`)
+   reports exactly `[propext, Classical.choice, Quot.sound]` — clean cone,
+   no `sorryAx`/`ofReduceBool`.
+
+### Inline fixes landed (commit 58b1804a)
+
+- **Docstrings, `Basic.lean`:** documented the 13 transport simp lemmas
+  (`coeff_toPolynomial`, `toPolynomial_{zero,C,add,mul,one,neg,sub}`,
+  `ofPolynomial_zero`, the two round-trips, `equiv_apply`,
+  `equiv_symm_apply`). File now fully covered.
+- **Docstrings, `Mignotte.lean`:** documented the 5 public complex-cast
+  lemmas (`coeff_map_intCast`, `natDegree_map_intCast`,
+  `support_map_intCast`, `norm_coeff_map_intCast`,
+  `sq_norm_coeff_map_intCast`) and the two private fold helpers
+  (`range_foldl_add_eq_finset_sum_nat`, `foldl_binom_iter_eq_choose`).
+  File now fully covered.
+- **Dead code, `Basic.lean`:** removed the unreferenced public duplicate
+  `map_intCast_zmod_dvd_of_zpoly_dvd` (an AI-slop long name), inlining its
+  proof into the short, convention-following `dvd_modP_of_dvd` and
+  dropping the "Issue-spec rename of …" process-word docstring. Both were
+  externally zero-ref; `dvd_modP_of_dvd` is kept as the canonical name.
+
+## Current frontier
+
+`HexPolyZMathlib` stays at `done_through: 5`. The remaining work is
+concentrated entirely in the two large math-theory files
+(`RobinsonForm.lean`, `SchurSzego.lean`), which the issue explicitly
+scoped *out* of inline refactoring for this review.
+
+## Punch-list for a follow-up planner
+
+A planner can turn these into bounded `feature` issues. The dead-code and
+docstring questions are coupled: if a module is excised, its docstring gap
+disappears with it, so **triage dead code first**.
+
+### (P1) Dead-code triage — `SchurSzego.lean` and `RobinsonForm.lean`
+
+Decide, per module, whether the Schur–Szegő / Grace–Walsh–Szego / Robinson
+theory is (a) staged toward a future `BHKSBound`/`CLDColumnBound` capstone
+and should be wired in, or (b) abandoned and should be excised. Evidence
+it is currently inert: `SchurSzego.lean` has no consumer outside the
+library root; `RobinsonForm.lean` is imported by `CLDColumnBound.lean` but
+unused there. Resolution likely shrinks (P2) substantially.
+
+Zero-reference public decls (candidates; filter out intentional
+characterising API):
+- `RobinsonForm.lean` (12): `mahlerMeasure_derivative_le_schurReflectedAtRootForm_derivative_of_monotoneOn`,
+  `norm_eval_robinsonForm_eq_norm_eval`, `mahlerMeasure_le_circleAverage_norm`,
+  `mahlerMeasure_derivative_map_intCast_le_of_roots_le_one`,
+  `prod_max_one_norm_roots_derivative_le_of_sum_log_le`,
+  `prod_max_one_norm_roots_derivative_le_of_schmeisser_radius_one`,
+  `roots_filter_norm_product_derivative_le_of_X_mul_derivative`,
+  `prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le`,
+  `prod_max_one_norm_roots_derivative_le_of_roots_le_one`,
+  `prod_max_one_norm_roots_robinsonForm_derivative_le`,
+  `mahlerMeasure_derivative_le_derivative_of_boundary_norm_eq_of_roots_le_one_of_derivative_le`,
+  `mahlerMeasure_robinsonRootDeletionDerivativeSum_le`.
+- `SchurSzego.lean` (41): `support_schmeisserComposition_subset`,
+  `complex_nat_choose_ne_zero`, `real_nat_choose_pos`,
+  `schmeisserComposition_{zero_left,zero_right,C_C,two_eq}`,
+  `roots_quadratic_eq_pair_of_vieta_complex`,
+  `exists_roots_eq_pair_and_vieta_of_natDegree_eq_two`,
+  `schmeisserDerivativeKernel_{zero,one}`,
+  `schmeisserComposition_derivativeKernel_eq_X_mul_derivative`,
+  `roots_derivative_kernel_norm_le_one`,
+  `schur_boundary_denominator_ne_zero`,
+  `schur_two_interior_roots_norm_le`,
+  `rootsRadiusProduct_{zero,one,mul_pow_card,nonneg,eq_one_of_forall_lt}`,
+  `filtered_norm_div_one`,
+  `rootsOutsideRadiusCount_{zero,eq_filter_card}`,
+  `rootsStrictlyOutsideRadiusCount_{zero,eq_filter_card}`,
+  `graceWalshSzegoOpenZeroControlAtDegree_{zero,one}`,
+  `openExteriorRootCountDominatedFrom_of_schmeisserCompositionOpenZeroControl`,
+  `rootsOutsideRadiusCount_le_of_schmeisserCompositionZeroControl`,
+  `rootsStrictlyOutsideRadiusCount_le_of_schmeisserCompositionOpenZeroControl`,
+  `roots_count_radius_le_of_schmeisserComposition`,
+  `roots_strictly_count_radius_le_of_schmeisserComposition{,_exact_source}`,
+  `schmeisserCompositionOpenZeroControl_of_graceWalshSzegoOpenZeroControlAtDegree`,
+  `schmeisserCompositionOpenZeroControl_of_graceWalshSzegoOpenZeroControlAtExactDegree`,
+  `schmeisserCompositionZeroControl_of_graceWalshSzegoZeroControlAtExactDegree`,
+  `graceWalshSzegoZeroControlAtDegree_of_open`,
+  `graceWalshSzegoZeroControlAtExactDegree_of_open`,
+  `rootsRadiusProduct_le_of_schmeisserCompositionZeroControl_of_coeff`,
+  `rootsRadiusProduct_le_of_graceWalshSzegoZeroControlAtDegree_of_coeff`,
+  `roots_filter_norm_product_le_of_schmeisserComposition_radius_one_of_source`.
+
+### (P2) Docstrings — the 92 surviving undocumented public importable decls
+(scope after P1; counts may drop). `RobinsonForm.lean` L61, L79, L105,
+L109, L112, L131, L143, L158, L174, L223, L228, L233, L236, L266, L289,
+L299, L358, L382, L392, L411, L436, L454, L469, L486, L531, L566, L594,
+L609, L620, L685, L793. `SchurSzego.lean`: 61 (every public theorem;
+their `def`s are documented, the theorems are not).
+
+### (P3) Namespace pollution (Phase 6 quality, not an exit criterion)
+`RobinsonForm.lean` and `SchurSzego.lean` declare all ~100 of their
+defs/theorems into Mathlib's `Polynomial` namespace (`namespace
+Polynomial`), e.g. `Polynomial.schur_two_interior_roots_norm_le`. Project
+defs probably belong under `HexPolyZMathlib` (or a dedicated
+`Polynomial.Schmeisser`-style sub-namespace if upstream-shaped), per
+design-principles "no namespace pollution". Worth a planner decision while
+the theory is being triaged in P1.
+
+## Next step
+
+A planner picks up (P1) — the dead-code/module-fate triage — first, since
+it likely subsumes much of (P2). Do **not** bump `done_through` to 6 until
+docstrings and dead code both pass.
+
+## Blockers
+
+None.
+
+## Notes
+
+The reused worktree carried pre-existing uncommitted deletions in
+`.claude/commands/review.md` and `.claude/skills/agent-worker-flow/SKILL.md`
+(95 lines stripping prior audit/linter guidance). Not mine and unrelated
+to this audit — left untouched and excluded from my commit (same note as
+the prior HexGFq audit progress file).


### PR DESCRIPTION
Closes #8233

This PR audits `HexPolyZMathlib` against the four Phase 6 exit criteria and lands the verdict-(b) inline fixes. Linter (clean zero-warning build) and the native_decide/oracle criterion (none; irreducibility N/A; transitive `#print axioms` clean) pass. Docstring coverage and dead code fail, so `done_through` stays at 5. Inline: document `Basic.lean` (13 transport lemmas + 2 equiv accessors) and `Mignotte.lean` (5 cast lemmas + 2 private fold helpers) to full coverage, and remove the unreferenced public duplicate `map_intCast_zmod_dvd_of_zpoly_dvd`, keeping the short `dvd_modP_of_dvd`. `lake build HexPolyZMathlib` and the CI-gated `HexBerlekampZassenhausMathlib` both green.

Remaining gaps are a planner punch-list in `progress/20260620_094350_d8835e3a.md`: dead-code/module-fate triage (`SchurSzego.lean` is entirely unconsumed downstream; `RobinsonForm.lean` exports nothing used downstream), 92 undocumented public theorems in the two large files, and `Polynomial`-namespace pollution. Triage dead code first — it likely subsumes much of the docstring work.

🤖 Prepared with Claude Code