### PR TITLE
feat: HexGramSchmidtMathlib public-theorem docstrings (Phase 6 criterion 2)

### DIFF
--- a/HexGramSchmidtMathlib/Int.lean
+++ b/HexGramSchmidtMathlib/Int.lean
@@ -1022,11 +1022,18 @@ private theorem gramDet_eq_prod_normSq_core (b : Matrix Int n m)
   rw [progressMatrix_full_eq_auxMatrix]
   exact auxMatrix_det_eq_prod_normSq b k hk
 
+/-- The `k`-leading Gram determinant equals, as a rational, the product of the
+squared Gram-Schmidt norms of the first `k` basis vectors
+(`gramSchmidtNormProduct b k`). Public wrapper over
+`gramDet_eq_prod_normSq_core`. -/
 theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk :=
   gramDet_eq_prod_normSq_core b hli k hk
 
+/-- For an independent integer matrix `b`, every nonempty leading Gram
+determinant is strictly positive (`0 < k ≤ n`). Public wrapper over
+`gramDet_pos_core`. -/
 theorem gramDet_pos (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by
@@ -1067,6 +1074,9 @@ private theorem basis_normSq_core (b : Matrix Int n m)
   rw [Rat.mul_comm]
   exact (Rat.mul_div_cancel hprod_ne).symm
 
+/-- The squared norm of the `k`-th Gram-Schmidt basis vector is the ratio of
+consecutive leading Gram determinants `d_{k+1} / d_k`, the standard telescoping
+identity. Public wrapper over `basis_normSq_core`. -/
 theorem basis_normSq (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k < n) :
     Vector.normSq ((basis b).row ⟨k, hk⟩) =
@@ -2568,12 +2578,15 @@ private theorem intCast_rat_injective_int_eq {a b : Int} (h : (a : Rat) = (b : R
   have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
   omega
 
+/-- The rational dot product is additive in its left argument. -/
 theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
     Matrix.dot (u + v) w = Matrix.dot u w + Matrix.dot v w := by
   rw [dot_comm_rat (u := u + v) (v := w)]
   rw [dot_add_right_rat (u := w) (v := u) (w := v)]
   rw [dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
 
+/-- The rational dot product is homogeneous in its left argument: a scalar
+factors out. -/
 theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
     Matrix.dot (s • u) v = s * Matrix.dot u v := by
   rw [dot_comm_rat (u := s • u) (v := v)]
@@ -3976,6 +3989,8 @@ theorem independent_of_det_positive (b : Matrix Int n m)
   exact gramDet_pos_of_det_positive b hdet (k.val + 1) (Nat.succ_le_of_lt k.isLt)
     (Nat.succ_pos k.val)
 
+/-- The identity matrix is independent: its Gram matrix is the identity, so
+every leading principal minor has determinant `1 > 0`. -/
 theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
   exact independent_of_det_positive (1 : Matrix Int n n) (by
     intro k

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -30,12 +30,20 @@ in this Mathlib-side module because their proof path composes
 `HexMatrixMathlib.bareiss_eq_mathlib_det` with
 `HexMatrixMathlib.det_eq.symm`. -/
 
+/-- The size-reduce row operation leaves every leading Gram determinant
+unchanged: `sizeReduce b j k r` adds `-r` times the earlier row `j` to the
+later row `k` (`j < k`), a unimodular operation. Specialises
+`gramDet_rowAdd_earlier`. -/
 theorem gramDet_sizeReduce (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int) (t : Nat) (ht : t ≤ n) :
     gramDet (sizeReduce b j k r) t ht = gramDet b t ht := by
   unfold sizeReduce
   exact gramDet_rowAdd_earlier b j k (-r) t ht hjk
 
+/-- Size-reduce update at the pivot column `j`: the scaled coefficient at
+`(k, j)` decreases by `r * gramDet b (j+1)`, reflecting that subtracting
+`r` times row `j` cancels exactly that multiple of the `j`-leading Gram
+determinant from the `(k, j)` Cramer numerator. -/
 theorem scaledCoeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n)
     (hjk : j.val < k.val) (r : Int) :
     GramSchmidt.entry (scaledCoeffs (sizeReduce b j k r)) k j =
@@ -45,6 +53,10 @@ theorem scaledCoeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n)
   rw [scaledCoeffs_rowAdd_pivot (b := b) (j := j) (k := k) hjk (-r)]
   rw [Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
 
+/-- Size-reduce update at a column `l` below the pivot (`l < j < k`): the
+scaled coefficient at `(k, l)` decreases by `r` times the `(j, l)`
+coefficient, since row `k` inherits `-r` times row `j`'s contribution in
+that column. -/
 theorem scaledCoeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
     (hlj : l.val < j.val) (hjk : j.val < k.val) (r : Int) :
     GramSchmidt.entry (scaledCoeffs (sizeReduce b j k r)) k l =
@@ -54,12 +66,18 @@ theorem scaledCoeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
   rw [scaledCoeffs_rowAdd_lower (b := b) (l := l) (j := j) (k := k) hlj hjk (-r)]
   rw [Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
 
+/-- Size-reduce touches only row `k`: every other row `i ≠ k` of the
+scaled-coefficient matrix is left unchanged. -/
 theorem scaledCoeffs_sizeReduce_other_row (b : Matrix Int n m) (j k : Fin n)
     (hjk : j.val < k.val) (r : Int) (i : Fin n) (hik : i ≠ k) :
     (scaledCoeffs (sizeReduce b j k r)).row i = (scaledCoeffs b).row i := by
   rw [sizeReduce]
   exact scaledCoeffs_rowAdd_other_row (b := b) (j := j) (k := k) hjk (-r) i hik
 
+/-- Size-reduce leaves the scaled coefficient at `(k, l)` unchanged for any
+column `l` strictly between the pivot `j` and `k` (`j < l < k`): row `j`'s
+contribution there is already orthogonalised away, so adding a multiple of
+it has no effect. -/
 theorem scaledCoeffs_sizeReduce_above_pivot (b : Matrix Int n m) (j k : Fin n)
     (hjk : j.val < k.val) (r : Int) (l : Fin n)
     (hjl : j.val < l.val) (hlk : l.val < k.val) :
@@ -399,6 +417,11 @@ private theorem det_rowSwap_transpose_rowSwap_transpose
       Matrix.det_transpose, Matrix.det_rowSwap _ _ _ h]
   grind
 
+/-- Swapping the adjacent rows `k-1` and `k` leaves the `t`-leading Gram
+determinant unchanged for every `t ≠ k`. For `t > k` both swapped rows lie
+inside the leading block, so the Gram matrix is conjugated by a row-and-column
+swap (determinant invariant); for `t < k` neither row is involved. Only the
+`t = k` prefix, which separates the two swapped rows, can change. -/
 theorem gramDet_adjacentSwap_of_ne (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (t : Nat) (ht : t ≤ n) (htk : t ≠ k.val) :
     gramDet (adjacentSwap b k hk) t ht = gramDet b t ht := by
@@ -438,6 +461,10 @@ private theorem intCast_rat_injective_local {a b : Int} (h : (a : Rat) = (b : Ra
   have hsub : a - b = 0 := Rat.intCast_eq_zero_iff.mp hz
   omega
 
+/-- Adjacent-swap update for a column `j` strictly below the swapped block
+(`j + 1 < k`): the new scaled coefficient at row `k-1` equals the old one at
+row `k`, because the swap moves the original row `k` into position `k-1`
+while leaving the `j`-leading Gram determinant fixed. -/
 theorem scaledCoeffs_adjacentSwap_lower_prev (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (j : Fin n) (hj : j.val + 1 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -471,6 +498,10 @@ theorem scaledCoeffs_adjacentSwap_lower_prev (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) k j : Int) : Rat) := hRHS.symm
 
+/-- Adjacent-swap companion to `scaledCoeffs_adjacentSwap_lower_prev`: for a
+column `j` strictly below the swapped block (`j + 1 < k`), the new scaled
+coefficient at row `k` equals the old one at row `k-1`, since the swap moves
+the original row `k-1` into position `k`. -/
 theorem scaledCoeffs_adjacentSwap_lower_curr (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (j : Fin n) (hj : j.val + 1 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -504,6 +535,9 @@ theorem scaledCoeffs_adjacentSwap_lower_curr (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) km1 j : Int) : Rat) := hRHS.symm
 
+/-- The pivot scaled coefficient `(k, k-1)` is invariant under the adjacent
+swap of rows `k-1` and `k`: the swap transposes the Cramer minor
+`scaledCoeffMatrix`, and a transpose preserves its determinant. -/
 theorem scaledCoeffs_adjacentSwap_pivot (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) :
     let km1 := GramSchmidt.prevRow k hk
@@ -529,6 +563,9 @@ theorem scaledCoeffs_adjacentSwap_pivot (b : Matrix Int n m)
           rw [← scaledCoeffs_eq_scaledCoeffMatrix_det]
 
 
+/-- The adjacent swap of rows `k-1, k` leaves the scaled coefficient at
+`(i, j)` unchanged whenever the whole entry lies strictly below the swapped
+block (`i + 1 < k`, so both row `i` and its columns `j < i` are untouched). -/
 theorem scaledCoeffs_adjacentSwap_before (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i j : Fin n)
     (hi : i.val + 1 < k.val) (hji : j.val < i.val) :
@@ -564,6 +601,10 @@ theorem scaledCoeffs_adjacentSwap_before (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) i j : Int) : Rat) := hRHS.symm
 
+/-- For a row `i` above the swapped block (`i > k`) and a column `j` strictly
+below it (`j + 1 < k`), the adjacent swap of rows `k-1, k` leaves the scaled
+coefficient at `(i, j)` unchanged: the `j`-leading Gram determinant and the
+relevant Cramer numerator are both unaffected. -/
 theorem scaledCoeffs_adjacentSwap_above_low (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i j : Fin n)
     (hki : k.val < i.val) (hj : j.val + 1 < k.val) :
@@ -600,6 +641,9 @@ theorem scaledCoeffs_adjacentSwap_above_low (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) i j : Int) : Rat) := hRHS.symm
 
+/-- For a row `i` and column `j` both strictly above the swapped block
+(`k < j < i`), the adjacent swap of rows `k-1, k` leaves the scaled
+coefficient at `(i, j)` unchanged. -/
 theorem scaledCoeffs_adjacentSwap_above_high (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i j : Fin n)
     (hki : k.val < i.val) (hkj : k.val < j.val) (hji : j.val < i.val) :
@@ -632,6 +676,12 @@ theorem scaledCoeffs_adjacentSwap_above_high (b : Matrix Int n m)
           rw [hdet, hcoeff]
     _ = ((GramSchmidt.entry (scaledCoeffs b) i j : Int) : Rat) := hRHS.symm
 
+/-- The single `k`-leading Gram determinant that the adjacent swap of rows
+`k-1, k` can change, expressed as an exact integer quotient: writing
+`B = scaledCoeffs b k (k-1)`, the new value is
+`(d_{k+1} · d_{k-1} + B²) / d_k`, where `d_t = gramDet b t`. Exactness of the
+division is supplied by `adjacentSwap_gramDetNumerator_dvd`; the hypothesis
+`d_k ≠ 0` makes the quotient well-defined. -/
 theorem gramDet_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
     let km1 := GramSchmidt.prevRow k hk
@@ -662,6 +712,10 @@ theorem gramDet_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.
   rw [← hprod]
   exact (Int.mul_ediv_cancel _ hdk_pos).symm
 
+/-- Exactness witness for `gramDet_adjacentSwap_pivot`: the pre-swap pivot
+`adjacentSwapDenom b k = d_k` divides the numerator
+`adjacentSwapGramDetNumerator b k = d_{k+1} · d_{k-1} + B²`, because that
+numerator equals `d_k` times the post-swap `k`-leading Gram determinant. -/
 theorem adjacentSwap_gramDetNumerator_dvd (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val)
     (_hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
@@ -696,6 +750,11 @@ where `B = nu[k][km1]`. The proof linearises `nu'[i][km1]` (as a `Rat`) through
 the basis identity `basis (rowSwap b km1 k) [km1] = basis b [k] + μ * basis b [km1]`
 (via `basis_rowSwap_adjacent_prev`), identifies `bareiss = nu'` via
 `scaledCoeffs_eq_scaledCoeffMatrix_bareiss`, and discharges with `ring`. -/
+/-- Bordered-minor identity for the swapped `prev` (`km1`) column at a row
+`i > k`: the executable Bareiss determinant of the Cramer minor times the
+pre-swap pivot `d_k` equals the integer numerator
+`adjacentSwapScaledCoeffAbovePrevNumerator`. Feeds the exact division in
+`scaledCoeffs_adjacentSwap_above_prev`. -/
 theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hki : k.val < i.val)
@@ -919,6 +978,11 @@ expansion) and `dot_basis_rowSwap_curr_prev_eq_normSq` (`D = Nk'`), combined
 with `gramDet_adjacentSwap_of_ne` for `t = k + 1 ≠ k` (giving
 `d_{k+1}(b') = d_{k+1}(b)`), and the standard rationalisation lemmas for
 gramDet. -/
+/-- Bordered-minor identity for the swapped `curr` (`k`) column at a row
+`i > k`: the executable Bareiss determinant of the Cramer minor times the
+pre-swap pivot `d_k` equals the integer numerator
+`adjacentSwapScaledCoeffAboveCurrNumerator`. Feeds the exact division in
+`scaledCoeffs_adjacentSwap_above_curr`. -/
 theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
     (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val)
     (i : Fin n) (hki : k.val < i.val)
@@ -1121,6 +1185,10 @@ from the bordered-minor identities `bareiss_scaledCoeffMatrix_rowSwap_above_prev
 and `_above_curr` once we rewrite `bareiss → scaledCoeffs` via
 `scaledCoeffs_eq_scaledCoeffMatrix_bareiss`. -/
 
+/-- Exactness witness for `scaledCoeffs_adjacentSwap_above_prev`: the pre-swap
+pivot `adjacentSwapDenom b k = d_k` divides
+`adjacentSwapScaledCoeffAbovePrevNumerator`, immediate from the bordered-minor
+identity `bareiss_scaledCoeffMatrix_rowSwap_above_prev`. -/
 theorem adjacentSwap_scaledCoeffAbovePrevNumerator_dvd (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
@@ -1131,6 +1199,10 @@ theorem adjacentSwap_scaledCoeffAbovePrevNumerator_dvd (b : Matrix Int n m)
   rw [← h]
   exact ⟨_, Int.mul_comm _ _⟩
 
+/-- Exactness witness for `scaledCoeffs_adjacentSwap_above_curr`: the pre-swap
+pivot `adjacentSwapDenom b k = d_k` divides
+`adjacentSwapScaledCoeffAboveCurrNumerator`, immediate from the bordered-minor
+identity `bareiss_scaledCoeffMatrix_rowSwap_above_curr`. -/
 theorem adjacentSwap_scaledCoeffAboveCurrNumerator_dvd (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
@@ -1141,6 +1213,11 @@ theorem adjacentSwap_scaledCoeffAboveCurrNumerator_dvd (b : Matrix Int n m)
   rw [← h]
   exact ⟨_, Int.mul_comm _ _⟩
 
+/-- Adjacent-swap quotient formula at the `prev` (`km1`) column for a row
+`i > k`: the new scaled coefficient equals
+`adjacentSwapScaledCoeffAbovePrevNumerator / adjacentSwapDenom`, an exact
+integer division by the divisibility witness
+`adjacentSwap_scaledCoeffAbovePrevNumerator_dvd`. -/
 theorem scaledCoeffs_adjacentSwap_above_prev (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :
@@ -1162,6 +1239,11 @@ theorem scaledCoeffs_adjacentSwap_above_prev (b : Matrix Int n m)
   rw [hbridge, ← h]
   exact (Int.mul_ediv_cancel _ hdk_pos).symm
 
+/-- Adjacent-swap quotient formula at the `curr` (`k`) column for a row
+`i > k`: the new scaled coefficient equals
+`adjacentSwapScaledCoeffAboveCurrNumerator / adjacentSwapDenom`, an exact
+integer division by the divisibility witness
+`adjacentSwap_scaledCoeffAboveCurrNumerator_dvd`. -/
 theorem scaledCoeffs_adjacentSwap_above_curr (b : Matrix Int n m)
     (k : Fin n) (hk : 0 < k.val) (i : Fin n) (hki : k.val < i.val)
     (hdet : gramDet b k.val (Nat.le_of_lt k.isLt) ≠ 0) :

--- a/progress/20260620_100302_6185cc5c.md
+++ b/progress/20260620_100302_6185cc5c.md
@@ -1,0 +1,46 @@
+# HexGramSchmidtMathlib public-theorem docstrings (#8237)
+
+Session type: feature. UTC 2026-06-20T10:03.
+
+## Accomplished
+
+Executed the docstring punch-list from review #8229, closing the last
+Phase 6 exit-criterion gap (criterion 2, public-theorem docstring
+coverage) for `HexGramSchmidtMathlib`. Added `/-- … -/` docstrings to all
+26 flagged public theorems:
+
+- **`Update.lean` (20):** the size-reduce update laws
+  (`gramDet_sizeReduce`, `scaledCoeffs_sizeReduce_{pivot,lower,other_row,
+  above_pivot}`) and the adjacent-swap family
+  (`gramDet_adjacentSwap_of_ne`, the six `scaledCoeffs_adjacentSwap_*`
+  positional laws, `gramDet_adjacentSwap_pivot`, the two
+  `*GramDetNumerator_dvd` / `*Numerator_dvd` exactness witnesses, the two
+  `bareiss_scaledCoeffMatrix_rowSwap_above_*` bordered-minor identities,
+  and the two `scaledCoeffs_adjacentSwap_above_*` quotient formulas).
+  Each docstring names the row operation, the affected position, and
+  (for the `_dvd` / quotient pairs) the divisibility-witness relationship.
+- **`Int.lean` (6):** the three thin wrappers `gramDet_eq_prod_normSq`,
+  `gramDet_pos`, `basis_normSq` (adapting their `_core` siblings'
+  content); the rational dot-product linearity lemmas `dot_add_left_rat`,
+  `dot_smul_left_rat`; and `independent_one`.
+
+Docstring-only: zero proof, signature, or `libraries.yml` changes.
+`lake build HexGramSchmidtMathlib` green, no warnings in the library
+(the `info: Try these` lines in the log are all from the `HexMatrix`
+dependency's `Bareiss.lean`, not this library).
+
+## Current frontier
+
+`HexGramSchmidtMathlib` now passes all four Phase 6 exit criteria
+(linter/dead-code/native cleared by #8232, docstrings cleared here).
+`done_through` remains 5 — this issue is docstring-only and explicitly
+defers the bump.
+
+## Next step
+
+A follow-up `review` re-runs the four criteria and performs the
+`done_through 5 → 6` bump in `libraries.yml`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #8237

Session: `6185cc5c-bf87-43b3-8ac8-388ec839467f`

4670df78 chore: progress entry for #8237 docstrings
2c0acbff doc: HexGramSchmidtMathlib public-theorem docstrings (Phase 6 criterion 2)

🤖 Prepared with Claude Code