### PR TITLE
doc: review.md — check module consumption by declared names, not keyword greps

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -51,6 +51,18 @@ Rotate through these areas across sessions:
   `done_through` unbumped rather than bashing the deletion through a
   review session; removal needs an iterative delete→rescan→rebuild
   fixpoint.
+- Module-consumption gotcha: to decide whether an *imported module* is
+  actually used, enumerate that module's **declared symbol names** and
+  grep each downstream — never theory/module keywords. A keyword grep
+  (`grep "RobinsonForm\|graceWalsh\|schmeisser"`) misses consumed symbols
+  whose names don't contain the keyword, wrongly flagging a load-bearing
+  import as stale: `CLDColumnBound` consumes `RobinsonForm`'s
+  `rootDeletionDerivativeSummand` family, so the keyword grep declared the
+  import dead in two successive audits (#8233 and the #8245 premise built
+  on it) when dropping it would break the build. Loop over
+  `grep -oE '^(def|theorem|lemma|abbrev) +\w+' Mod.lean` and check each
+  name; module is dead only if **every** declared name has zero external
+  hits.
 
 **Idioms and best practices**:
 - Are newer APIs or language features being used where appropriate?

--- a/progress/20260620_104500_c36c47c6.md
+++ b/progress/20260620_104500_c36c47c6.md
@@ -1,0 +1,51 @@
+# HexPolyZMathlib SchurSzego / RobinsonForm dead-code triage (#8245)
+
+Session type: review (via /work). UTC 2026-06-20T10:45.
+
+## Accomplished
+
+Triaged the Schur–Szegő / Robinson theory in `HexPolyZMathlib` per #8245
+and posted an evidence-backed verdict comment. Found the issue's central
+premise factually wrong and routed it back for re-planning.
+
+- **`RobinsonForm.lean` is live, not stale.** `CLDColumnBound.lean`
+  consumes `rootDeletionDerivativeSummand` (22 refs),
+  `derivative_eq_sum_rootDeletionDerivativeSummand` (`:107`), and
+  `mahlerMeasure_rootDeletionDerivativeSummand_le` (`:126`) in the
+  private theorems discharging `abs_phi_coeff_le`'s `hphi_mahler`
+  obligation. The issue's path-(b) "drop the stale import" would break
+  the build. The #8233 audit missed this because its grep keys
+  (`RobinsonForm|robinsonForm|graceWalsh|schmeisser`) don't match the
+  `rootDeletionDerivativeSummand`-family consumed surface.
+- **`SchurSzego.lean` is genuinely orphaned** (87 public symbols, zero
+  external refs, not even consumed by `RobinsonForm`, whose
+  `import SchurSzego` is itself dead). It leans path (b) — the
+  Schmeisser/Grace–Walsh–Szegő route was superseded by the
+  Robinson-reflection route (#6185, 2026-06-02) that actually discharged
+  the CLD Phi Mahler bound. But `SPEC/Libraries/hex-poly-z-mathlib.md`
+  still explicitly *owns and stages* that surface (clarified #5652,
+  2026-05-20, pre-pivot), so excision is a design-of-record decision
+  (requires a SPEC amendment) plus a grind/simp-tag-sensitive build,
+  not a blind delete.
+
+No code changed. `python3 scripts/check_dag.py` exit 0.
+`done_through` unchanged (5). No axiom/sorry/native_decide.
+
+## Current frontier
+
+#8245 skipped → `replan`. The durable artifact is the verdict comment
+on the issue.
+
+## Next step
+
+Planner re-scopes #8245 to SchurSzego-only with corrected facts:
+delete `SchurSzego.lean` + its dead imports (root and `RobinsonForm`),
+keep `RobinsonForm` + its `CLDColumnBound` import, amend the SPEC
+Schmeisser-surface section, verify both `lake build`s green. OR record
+SchurSzego as a deliberate SPEC-staged dead-code exception if the
+Schmeisser analytic route is to be retained for directive #2564.
+
+## Blockers
+
+The SchurSzego excise-vs-retain call is a SPEC/design-of-record
+decision beyond a triage's safe remit; deferred to planner/owner.


### PR DESCRIPTION
This PR adds a module-consumption gotcha to the dead-code guidance in `.claude/commands/review.md`, capturing the failure mode diagnosed while triaging https://github.com/kim-em/hex/issues/8245 (review: triage dead Schur–Szegő / Robinson theory in HexPolyZMathlib): assessing whether an imported module is consumed by grepping theory/module keywords misses consumed symbols whose names don't contain the keyword. The `HexPolyZMathlib/RobinsonForm.lean` import into `HexBerlekampZassenhausMathlib/CLDColumnBound.lean` was flagged as a stale/unconsumed import in two successive audits because the keyword grep (`RobinsonForm|graceWalsh|schmeisser`) never matched the actually-consumed `rootDeletionDerivativeSummand` family — dropping that import would in fact break the build. The new guidance is to enumerate the module's declared symbol names and grep each downstream, treating the module as dead only when every declared name has zero external hits.

Triage verdict and full evidence are posted as a comment on #8245, which is routed back to `replan` with corrected scope (the dead-code question is genuine only for `SchurSzego.lean`, and its excision is a SPEC-staged design decision rather than a blind delete).

🤖 Prepared with Claude Code