### PR TITLE
feat: packed UInt64 monic-division kernel for FpPoly.modByMonic + value-correspondence proof

### DIFF
--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -84,7 +84,7 @@ theorem leadingCoeff_ne_zero_of_pos_size (p : DensePoly R) (hpos : 0 < p.size) :
 
 /-- `arrayDegreeAux coeffs fuel` scans indices below `fuel` downward and returns the
 greatest index whose coefficient is nonzero, or `none` if every coefficient below `fuel` is zero. -/
-private def arrayDegreeAux (coeffs : Array R) : Nat → Option Nat
+def arrayDegreeAux (coeffs : Array R) : Nat → Option Nat
   | 0 => none
   | fuel + 1 =>
       let i := fuel
@@ -95,7 +95,7 @@ private def arrayDegreeAux (coeffs : Array R) : Nat → Option Nat
 
 /-- `arrayDegree? coeffs` is the highest index of a nonzero coefficient of `coeffs`, or `none`
 when every coefficient is zero, computed by scanning from `coeffs.size` downward. -/
-private def arrayDegree? (coeffs : Array R) : Option Nat :=
+def arrayDegree? (coeffs : Array R) : Option Nat :=
   arrayDegreeAux coeffs coeffs.size
 
 /-- A degree `arrayDegreeAux` reports lies strictly below the scan ceiling `fuel`. -/
@@ -233,7 +233,7 @@ private theorem ofCoeffs_degree_getD_lt_of_forall_zero_ge {coeffs : Array R} {bo
 /-- One coefficient of a long-division elimination step: subtract `coeff * q[j]` from
 position `shift + j` of `next`, the inner action folded by `subtractScaledShift` to wipe
 out the leading term of the current remainder. -/
-private def subtractScaledShiftStep [Sub R] [Mul R]
+def subtractScaledShiftStep [Sub R] [Mul R]
     (q : Array R) (shift : Nat) (coeff : R) (next : Array R) (j : Nat) : Array R :=
   let idx := shift + j
   next.set! idx (next.getD idx (Zero.zero : R) - coeff * q.getD j (Zero.zero : R))
@@ -241,7 +241,7 @@ private def subtractScaledShiftStep [Sub R] [Mul R]
 /-- Subtract `coeff` times the divisor `q` shifted up by `shift` positions from the
 remainder `rem`, i.e. one full long-division step `rem - coeff * xˢʰⁱᶠᵗ * q`, realised by
 folding `subtractScaledShiftStep` over every index of `q`. -/
-private def subtractScaledShift [Sub R] [Mul R]
+def subtractScaledShift [Sub R] [Mul R]
     (rem q : Array R) (shift : Nat) (coeff : R) : Array R :=
   (List.range q.size).foldl (subtractScaledShiftStep q shift coeff) rem
 
@@ -546,7 +546,7 @@ it in `quot`, eliminate the leading term via `subtractScaledShift`, and recurse,
 the final `(quotient, remainder)` pair. The compiled runtime uses the value-equal
 `divModArrayAuxImpl` (proved by `divModArrayAux_eq_impl`, registered `@[csimp]`), which
 tracks the working degree instead of rescanning. -/
-private def divModArrayAux [Sub R] [Mul R]
+def divModArrayAux [Sub R] [Mul R]
     (q : Array R) (qDegree : Nat) (scaleLead : R → R)
     (fuel : Nat) (quot rem : Array R) : Array R × Array R :=
   match fuel with
@@ -775,7 +775,7 @@ private theorem divModArrayAux_remainder_zero_ge [Sub R] [Mul R]
 /-- Array-backed long division of dense polynomial `p` by `q`: returns `(0, p)` when `q`
 is zero, otherwise seeds a zero quotient and runs `divModArrayAux` with `p.size` fuel,
 packaging the resulting coefficient arrays back as `DensePoly` quotient and remainder. -/
-private def divModArray [Sub R] [Mul R]
+def divModArray [Sub R] [Mul R]
     (p q : DensePoly R) (scaleLead : R → R) : DensePoly R × DensePoly R :=
   if q.isZero then
     (0, p)

--- a/HexPolyFp.lean
+++ b/HexPolyFp.lean
@@ -1,4 +1,5 @@
 import HexPolyFp.Basic
+import HexPolyFp.Packed
 import HexPolyFp.PrimeField
 import HexPolyFp.Compose
 import HexPolyFp.Enumeration

--- a/HexPolyFp/Packed.lean
+++ b/HexPolyFp/Packed.lean
@@ -1,0 +1,280 @@
+import HexPolyFp.Basic
+
+/-!
+Packed `Array UInt64` monic-division kernel for `FpPoly` and its
+value-correspondence with the reference `FpPoly.modByMonic`.
+
+`FpPoly p = DensePoly (ZMod64 p)` stores coefficients as `Array (ZMod64 p)`,
+which boxes every element (`lean_ctor` per coefficient) and allocates per
+operation. The packed kernel below mirrors the reference array long-division
+loop (`HexPoly/Euclid.lean`) over a bare `Array UInt64`, eliminating the boxing
+on the monic-division / Frobenius hot path.
+
+The arithmetic stays overflow-safe: `ZMod64.Bounds p` only gives `p ≤ 2^64`, so
+`p` may exceed `2^32` and naive `UInt64` `(a*b) % p` would wrap mod `2^64`. The
+word helpers `ZMod64.mulWord` / `ZMod64.subWord` reconstruct residues and reuse
+the multi-branch `ZMod64.mul` / `ZMod64.sub` (the former extern-backed by a
+`__uint128_t` widening multiply), so the packed kernel equals the reference for
+*every* `Bounds p`.
+
+`modByMonicPacked_eq` is the value-correspondence theorem; a later `@[csimp]`
+swap of `FpPoly.modByMonic` for `modByMonicPacked` is therefore
+behaviour-preserving.
+-/
+
+namespace Hex
+
+namespace ZMod64
+
+variable {p : Nat} [Bounds p]
+
+/-- Overflow-safe modular product of two raw words, reconstructing residues and
+delegating to the (extern-backed) `ZMod64.mul`. Defined so that
+`mulWord p x.val y.val = (x * y).val`. -/
+def mulWord (p : Nat) [Bounds p] (a b : UInt64) : UInt64 :=
+  (mul (ofNat p a.toNat) (ofNat p b.toNat)).val
+
+/-- Overflow-safe modular difference of two raw words, reconstructing residues
+and delegating to `ZMod64.sub`. Defined so that
+`subWord p x.val y.val = (x - y).val`. -/
+def subWord (p : Nat) [Bounds p] (a b : UInt64) : UInt64 :=
+  (sub (ofNat p a.toNat) (ofNat p b.toNat)).val
+
+/-- The backing word of the zero residue is the zero word. -/
+@[simp] theorem val_zero : (Zero.zero : ZMod64 p).val = 0 := by
+  apply UInt64.toNat_inj.mp
+  show (ofNat p 0).val.toNat = (0 : UInt64).toNat
+  rw [val_toNat_ofNat]
+  simp
+
+/-- A residue's backing word is zero exactly when the residue is zero. -/
+theorem val_eq_zero_iff (x : ZMod64 p) : x.val = 0 ↔ x = (Zero.zero : ZMod64 p) := by
+  constructor
+  · intro h
+    apply ZMod64.ext
+    rw [h, val_zero]
+  · intro h
+    rw [h, val_zero]
+
+/-- The word multiply agrees with the residue product read off in words. -/
+theorem mulWord_val (x y : ZMod64 p) : mulWord p x.val y.val = (x * y).val := by
+  unfold mulWord
+  have hx : ofNat p x.val.toNat = x := by
+    rw [← ZMod64.toNat_eq_val]; exact ZMod64.ofNat_toNat x
+  have hy : ofNat p y.val.toNat = y := by
+    rw [← ZMod64.toNat_eq_val]; exact ZMod64.ofNat_toNat y
+  rw [hx, hy]
+  rfl
+
+/-- The word subtract agrees with the residue difference read off in words. -/
+theorem subWord_val (x y : ZMod64 p) : subWord p x.val y.val = (x - y).val := by
+  unfold subWord
+  have hx : ofNat p x.val.toNat = x := by
+    rw [← ZMod64.toNat_eq_val]; exact ZMod64.ofNat_toNat x
+  have hy : ofNat p y.val.toNat = y := by
+    rw [← ZMod64.toNat_eq_val]; exact ZMod64.ofNat_toNat y
+  rw [hx, hy]
+  rfl
+
+end ZMod64
+
+namespace FpPoly
+
+variable {p : Nat} [ZMod64.Bounds p]
+
+/-- Pack a residue coefficient array into its backing words. -/
+def toWords (a : Array (ZMod64 p)) : Array UInt64 :=
+  a.map (fun x => x.val)
+
+/-- Reconstruct a residue coefficient array from raw words. -/
+def ofWords (p : Nat) [ZMod64.Bounds p] (a : Array UInt64) : Array (ZMod64 p) :=
+  a.map (fun w => ZMod64.ofNat p w.toNat)
+
+@[simp] theorem toWords_size (a : Array (ZMod64 p)) : (toWords a).size = a.size := by
+  simp [toWords]
+
+/-- Reading a packed word with default `0` is the residue coefficient read with
+default `0`, packed. -/
+theorem toWords_getD (a : Array (ZMod64 p)) (i : Nat) :
+    (toWords a).getD i (0 : UInt64) = (a.getD i (Zero.zero : ZMod64 p)).val := by
+  unfold toWords
+  rw [Array.getD_eq_getD_getElem?, Array.getD_eq_getD_getElem?, Array.getElem?_map]
+  cases a[i]? with
+  | none => simp [ZMod64.val_zero]
+  | some v => simp
+
+/-- Writing a residue then packing equals packing then writing the word. -/
+theorem toWords_set! (a : Array (ZMod64 p)) (i : Nat) (v : ZMod64 p) :
+    (toWords a).set! i v.val = toWords (a.set! i v) := by
+  simp [toWords, Array.set!_eq_setIfInBounds, Array.map_setIfInBounds]
+
+/-- Packing a zero-filled array gives a zero-word-filled array. -/
+theorem toWords_replicate (n : Nat) :
+    toWords (Array.replicate n (Zero.zero : ZMod64 p)) = Array.replicate n (0 : UInt64) := by
+  simp [toWords, Array.map_replicate, ZMod64.val_zero]
+
+/-- Reconstructing the words of a residue array recovers the original array. -/
+theorem ofWords_toWords (a : Array (ZMod64 p)) : ofWords p (toWords a) = a := by
+  unfold ofWords toWords
+  rw [Array.map_map]
+  have hid : ((fun w => ZMod64.ofNat p w.toNat) ∘ (fun x : ZMod64 p => x.val)) = id := by
+    funext x
+    show ZMod64.ofNat p x.val.toNat = x
+    rw [← ZMod64.toNat_eq_val]
+    exact ZMod64.ofNat_toNat x
+  rw [hid, Array.map_id]
+
+/-- Packed downward degree scan: the highest index below `fuel` with a nonzero
+word, mirroring `DensePoly.arrayDegreeAux`. -/
+def arrayDegreeAuxPacked (coeffs : Array UInt64) : Nat → Option Nat
+  | 0 => none
+  | fuel + 1 =>
+      if coeffs.getD fuel 0 = 0 then
+        arrayDegreeAuxPacked coeffs fuel
+      else
+        some fuel
+
+/-- Packed degree: the highest index of a nonzero word, mirroring
+`DensePoly.arrayDegree?`. -/
+def arrayDegreePacked? (coeffs : Array UInt64) : Option Nat :=
+  arrayDegreeAuxPacked coeffs coeffs.size
+
+/-- One packed elimination coefficient write, mirroring
+`DensePoly.subtractScaledShiftStep` with overflow-safe word arithmetic. -/
+def subtractScaledShiftStepPacked (p : Nat) [ZMod64.Bounds p]
+    (q : Array UInt64) (shift : Nat) (coeff : UInt64) (next : Array UInt64) (j : Nat) :
+    Array UInt64 :=
+  next.set! (shift + j)
+    (ZMod64.subWord p (next.getD (shift + j) 0) (ZMod64.mulWord p coeff (q.getD j 0)))
+
+/-- One full packed elimination step `rem - coeff * xˢʰⁱᶠᵗ * q`, mirroring
+`DensePoly.subtractScaledShift`. -/
+def subtractScaledShiftPacked (p : Nat) [ZMod64.Bounds p]
+    (rem q : Array UInt64) (shift : Nat) (coeff : UInt64) : Array UInt64 :=
+  (List.range q.size).foldl (subtractScaledShiftStepPacked p q shift coeff) rem
+
+/-- The packed fuel-bounded long-division loop, mirroring
+`DensePoly.divModArrayAux`. -/
+def divModArrayAuxPacked (p : Nat) [ZMod64.Bounds p]
+    (q : Array UInt64) (qDegree : Nat) (scaleLead : UInt64 → UInt64)
+    (fuel : Nat) (quot rem : Array UInt64) : Array UInt64 × Array UInt64 :=
+  match fuel with
+  | 0 => (quot, rem)
+  | fuel + 1 =>
+      match arrayDegreePacked? rem with
+      | none => (quot, rem)
+      | some rd =>
+          if _hdeg : rd < qDegree then
+            (quot, rem)
+          else
+            let shift := rd - qDegree
+            let coeff := scaleLead (rem.getD rd 0)
+            let quot := quot.set! shift coeff
+            let rem := subtractScaledShiftPacked p rem q shift coeff
+            divModArrayAuxPacked p q qDegree scaleLead fuel quot rem
+
+/-- Packed monic division remainder, identical in signature to
+`FpPoly.modByMonic` (csimp requirement). Packs both operand arrays, runs the
+packed loop with `scaleLead = id` (the divisor is monic), and reconstructs the
+remainder. -/
+def modByMonicPacked (f g : FpPoly p) (_hmonic : DensePoly.Monic f) : FpPoly p :=
+  if f.isZero then
+    g
+  else
+    let qDegree := f.size - 1
+    let quotientSize := g.size - qDegree
+    let quot := Array.replicate quotientSize (0 : UInt64)
+    let qr := divModArrayAuxPacked p (toWords f.toArray) qDegree id g.size quot (toWords g.toArray)
+    DensePoly.ofCoeffs (ofWords p qr.2)
+
+/-- Packed degree scan agrees with the reference scan on packed input. -/
+theorem arrayDegreeAuxPacked_eq (a : Array (ZMod64 p)) (ceil : Nat) :
+    arrayDegreeAuxPacked (toWords a) ceil = DensePoly.arrayDegreeAux a ceil := by
+  induction ceil with
+  | zero => rfl
+  | succ ceil ih =>
+      simp only [arrayDegreeAuxPacked, DensePoly.arrayDegreeAux]
+      by_cases h : a.getD ceil (Zero.zero : ZMod64 p) = (Zero.zero : ZMod64 p)
+      · have hp : (toWords a).getD ceil (0 : UInt64) = 0 := by
+          rw [toWords_getD, h, ZMod64.val_zero]
+        rw [if_pos hp, if_pos h, ih]
+      · have hp : ¬ (toWords a).getD ceil (0 : UInt64) = 0 := by
+          rw [toWords_getD]
+          intro hc
+          exact h ((ZMod64.val_eq_zero_iff _).mp hc)
+        rw [if_neg hp, if_neg h]
+
+/-- Packed degree agrees with the reference degree on packed input. -/
+theorem arrayDegreePacked?_eq (a : Array (ZMod64 p)) :
+    arrayDegreePacked? (toWords a) = DensePoly.arrayDegree? a := by
+  unfold arrayDegreePacked? DensePoly.arrayDegree?
+  rw [toWords_size]
+  exact arrayDegreeAuxPacked_eq a a.size
+
+/-- One packed elimination coefficient write corresponds to the reference write. -/
+theorem subtractScaledShiftStepPacked_eq (q : Array (ZMod64 p)) (shift : Nat)
+    (coeff : ZMod64 p) (rem : Array (ZMod64 p)) (j : Nat) :
+    subtractScaledShiftStepPacked p (toWords q) shift coeff.val (toWords rem) j
+      = toWords (DensePoly.subtractScaledShiftStep q shift coeff rem j) := by
+  unfold subtractScaledShiftStepPacked DensePoly.subtractScaledShiftStep
+  rw [← toWords_set!, toWords_getD, toWords_getD, ZMod64.mulWord_val, ZMod64.subWord_val]
+
+/-- Folding the packed step over any index list corresponds to folding the
+reference step. -/
+theorem foldl_subtractScaledShiftStepPacked (q : Array (ZMod64 p)) (shift : Nat)
+    (coeff : ZMod64 p) (xs : List Nat) (rem : Array (ZMod64 p)) :
+    xs.foldl (subtractScaledShiftStepPacked p (toWords q) shift coeff.val) (toWords rem)
+      = toWords (xs.foldl (DensePoly.subtractScaledShiftStep q shift coeff) rem) := by
+  induction xs generalizing rem with
+  | nil => rfl
+  | cons j js ih =>
+      simp only [List.foldl_cons]
+      rw [subtractScaledShiftStepPacked_eq]
+      exact ih (DensePoly.subtractScaledShiftStep q shift coeff rem j)
+
+/-- A full packed elimination step corresponds to the reference step. -/
+theorem subtractScaledShiftPacked_eq (rem q : Array (ZMod64 p)) (shift : Nat)
+    (coeff : ZMod64 p) :
+    subtractScaledShiftPacked p (toWords rem) (toWords q) shift coeff.val
+      = toWords (DensePoly.subtractScaledShift rem q shift coeff) := by
+  unfold subtractScaledShiftPacked DensePoly.subtractScaledShift
+  rw [toWords_size]
+  exact foldl_subtractScaledShiftStepPacked q shift coeff (List.range q.size) rem
+
+/-- The packed long-division loop corresponds, coordinatewise, to the reference
+loop with `scaleLead = id`. -/
+theorem divModArrayAuxPacked_eq (q : Array (ZMod64 p)) (qDegree : Nat) (fuel : Nat)
+    (quot rem : Array (ZMod64 p)) :
+    divModArrayAuxPacked p (toWords q) qDegree id fuel (toWords quot) (toWords rem)
+      = (toWords (DensePoly.divModArrayAux q qDegree id fuel quot rem).1,
+         toWords (DensePoly.divModArrayAux q qDegree id fuel quot rem).2) := by
+  induction fuel generalizing quot rem with
+  | zero => rfl
+  | succ fuel ih =>
+      simp only [divModArrayAuxPacked, DensePoly.divModArrayAux, id_eq, arrayDegreePacked?_eq]
+      cases h : DensePoly.arrayDegree? rem with
+      | none => rfl
+      | some rd =>
+          by_cases hlt : rd < qDegree
+          · simp only [dif_pos hlt]
+          · simp only [dif_neg hlt, toWords_getD, toWords_set!, subtractScaledShiftPacked_eq]
+            exact ih (quot.set! (rd - qDegree) (rem.getD rd (Zero.zero : ZMod64 p)))
+              (DensePoly.subtractScaledShift rem q (rd - qDegree)
+                (rem.getD rd (Zero.zero : ZMod64 p)))
+
+/-- **Value correspondence.** The packed monic-division remainder equals the
+reference `FpPoly.modByMonic` for every modulus `p` (every `Bounds p`). -/
+theorem modByMonicPacked_eq (f g : FpPoly p) (hmonic : DensePoly.Monic f) :
+    FpPoly.modByMonic f g hmonic = modByMonicPacked f g hmonic := by
+  rw [FpPoly.modByMonic, DensePoly.modByMonic, DensePoly.divModMonic, DensePoly.divModArray]
+  unfold modByMonicPacked
+  by_cases hz : f.isZero
+  · simp [hz]
+  · rw [if_neg hz, if_neg hz]
+    dsimp only
+    rw [← toWords_replicate (p := p) (g.size - (f.size - 1))]
+    simp only [divModArrayAuxPacked_eq, ofWords_toWords]
+
+end FpPoly
+
+end Hex

--- a/progress/20260620T123113Z_cb32c7a0.md
+++ b/progress/20260620T123113Z_cb32c7a0.md
@@ -1,0 +1,62 @@
+# Packed UInt64 monic-division kernel for FpPoly (#8251)
+
+Session type: feature. UTC 2026-06-20T12:31.
+
+## Accomplished
+
+Landed the packed `Array UInt64` monic-division kernel for `FpPoly` plus
+its value-correspondence theorem (`HexPolyFp/Packed.lean`), discharging
+#8251.
+
+- **Word helpers** `ZMod64.mulWord` / `ZMod64.subWord`: overflow-safe
+  modular ops on raw words, reconstructing residues and delegating to the
+  multi-branch `ZMod64.mul` (extern, `__uint128_t` widening) / `ZMod64.sub`.
+  Correctness lemmas `mulWord_val` / `subWord_val` (`= (x * y).val` etc.)
+  via `ofNat_toNat`. This honours #8251's premise correction: naive
+  `(a*b) % p` on `UInt64` is unsound for `p > 2^32` (`Bounds p` only gives
+  `p ≤ 2^64`).
+- **Packed kernel** mirroring `HexPoly/Euclid.lean`'s reference loop:
+  `arrayDegreeAuxPacked`, `arrayDegreePacked?`,
+  `subtractScaledShiftStepPacked`, `subtractScaledShiftPacked`,
+  `divModArrayAuxPacked`, and `modByMonicPacked` (signature-identical to
+  `FpPoly.modByMonic`, csimp-ready).
+- **Correspondence** `modByMonicPacked_eq : FpPoly.modByMonic = modByMonicPacked`
+  for every `Bounds p`. No `@[csimp]` yet (that is the follow-up #8252).
+
+## Key decisions / patterns
+
+- **`toWords`/`ofWords` map-commute strategy.** Instead of re-proving the
+  ~15 `getD`/`set!` characterisation lemmas in packed form (the literal
+  reading of "mirror the reference loop"), I packed via
+  `toWords a = a.map (·.val)` and proved each layer *commutes* with that
+  map: `arrayDegree`, the elimination step/fold, and the fuel loop. The
+  whole correspondence is one fuel induction reusing the reference loop's
+  structure — far shorter (~330 lines incl. defs) than the projected
+  400-600, and it never touches division *correctness* (degree-drop etc.),
+  only value-equality. Reusable for #8248's non-monic `divMod`/`gcd`.
+- **Un-private the reference seams.** `arrayDegreeAux`, `arrayDegree?`,
+  `subtractScaledShiftStep`, `subtractScaledShift`, `divModArrayAux`,
+  `divModArray` were `private` in `HexPoly/Euclid.lean`; the cross-file
+  correspondence must reference and unfold them, so I removed `private`
+  (visibility-widening only; the generic Euclid file gains no new
+  dependency on `ZMod64`). The packed development lives in `HexPolyFp`,
+  which already imports both `HexPoly.Euclid` and `HexModArith`.
+- **Tactic gotchas.** (a) `rw` cannot abstract a subterm under a `let idx`
+  binder, so I inlined `shift + j` in `subtractScaledShiftStepPacked`.
+  (b) After `cases h : arrayDegree? rem`, the matcher on `some rd` does not
+  iota-reduce for `rw [dif_*]`; `simp only [dif_pos/dif_neg hlt, ...]`
+  reduces matcher + dite together.
+
+## Verification
+
+- `lake build HexPoly HexPolyFp` green (102 jobs), no warnings/sorries.
+- `#print axioms FpPoly.modByMonicPacked` and `..._eq`:
+  `[propext, Quot.sound]` only (no `Classical.choice`, no `native_decide`).
+
+## Next step
+
+- #8252: register `@[csimp] FpPoly.modByMonic = modByMonicPacked` and
+  add the Frobenius bench (it is unblocked by this PR).
+- #8248 can reuse `mulWord`/`subWord` + the `toWords` map-commute lemmas
+  for the non-monic `divMod`/`gcd` packed kernels (`scaleLead =` multiply
+  by inverse instead of `id`).


### PR DESCRIPTION
Closes #8251

Session: `cb32c7a0-fc8b-4e3b-ba22-7644c09260d8`

bc64371f feat: packed UInt64 monic-division kernel for FpPoly.modByMonic (#8251)

🤖 Prepared with Claude Code