### PR TITLE
doc: HexMatrixMathlib docstrings + linter + stale bareiss docstring (Phase 6 partial)

### DIFF
--- a/HexMatrixMathlib/Basic.lean
+++ b/HexMatrixMathlib/Basic.lean
@@ -29,16 +29,23 @@ def matrixEquiv : Hex.Matrix R n m ≃ Matrix (Fin n) (Fin m) R where
     ext i j
     simp [Hex.Matrix.ofFn]
 
+/-- The Mathlib matrix produced by `matrixEquiv` reads off the executable
+matrix entrywise, so a caller can rewrite `matrixEquiv M i j` to the underlying
+`M[i][j]` without unfolding the equivalence. -/
 @[simp, grind =]
 theorem matrixEquiv_apply (M : Hex.Matrix R n m) (i : Fin n) (j : Fin m) :
     matrixEquiv M i j = M[i][j] :=
   rfl
 
+/-- The inverse direction of `matrixEquiv` materialises a Mathlib matrix as an
+executable one entrywise: `(matrixEquiv.symm M)[i][j]` is just `M i j`. -/
 @[simp, grind =]
 theorem matrixEquiv_symm_apply (M : Matrix (Fin n) (Fin m) R) (i : Fin n) (j : Fin m) :
-    (matrixEquiv.symm M)[i][j] = M i j :=
+    (matrixEquiv.symm M)[(i : Nat)][(j : Nat)] = M i j :=
   by simp [matrixEquiv, Hex.Matrix.ofFn]
 
+/-- `matrixEquiv` is a left inverse of `Hex.Matrix.ofFn`: building an executable
+matrix from `f` and transporting it to Mathlib recovers `f` itself. -/
 @[simp, grind =]
 theorem matrixEquiv_ofFn (f : Fin n → Fin m → R) :
     matrixEquiv (Hex.Matrix.ofFn f) = f := by
@@ -49,6 +56,9 @@ section RowOps
 
 variable [Semiring R]
 
+/-- The executable elementary row swap corresponds to left multiplication by
+Mathlib's permutation matrix `Matrix.swap`, so downstream determinant and rank
+lemmas can reason about `rowSwap` through Mathlib's swap algebra. -/
 theorem matrixEquiv_rowSwap (M : Hex.Matrix R n m) (i j : Fin n) :
     matrixEquiv (Hex.Matrix.rowSwap M i j) = Matrix.swap R i j * matrixEquiv M := by
   ext r k
@@ -62,6 +72,9 @@ theorem matrixEquiv_rowSwap (M : Hex.Matrix R n m) (i j : Fin n) :
       simp [hrj]
     · simp [hrj, hri, Matrix.swap_mul_of_ne]
 
+/-- The executable elementary row scaling corresponds to left multiplication by
+the diagonal matrix that carries `c` in row `i` and `1` elsewhere, exposing
+`rowScale` to Mathlib's diagonal-matrix algebra. -/
 theorem matrixEquiv_rowScale (M : Hex.Matrix R n m) (i : Fin n) (c : R) :
     matrixEquiv (Hex.Matrix.rowScale M i c) =
       Matrix.diagonal (Function.update (fun _ : Fin n => (1 : R)) i c) * matrixEquiv M := by
@@ -88,6 +101,9 @@ section RowAdd
 
 variable [CommRing R]
 
+/-- The executable elementary row addition (add `c` times row `src` to row
+`dst`) corresponds to left multiplication by Mathlib's transvection matrix,
+completing the row-operation dictionary used by the determinant correspondence. -/
 theorem matrixEquiv_rowAdd (M : Hex.Matrix R n m) (src dst : Fin n) (c : R) :
     matrixEquiv (Hex.Matrix.rowAdd M src dst c) =
       Matrix.transvection dst src c * matrixEquiv M := by

--- a/HexMatrixMathlib/Determinant.lean
+++ b/HexMatrixMathlib/Determinant.lean
@@ -20,12 +20,10 @@ theorem bareissDet_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Matrix.det (matrixEquiv M) :=
   bareiss_eq_mathlib_det M
 
-/-- Mathlib-side companion to the Mathlib-free orphan
-`Hex.Matrix.bareiss_eq_det` (sorry-bound in `HexMatrix/Bareiss.lean`): the
-row-pivoted Bareiss determinant equals the executable Leibniz determinant
-on integer square matrices. Proven by composing `bareiss_eq_mathlib_det`
-with `det_eq`, so it carries no dependency on the Mathlib-free orphan and
-is the preferred surface for downstream Mathlib-side callers. -/
+/-- The row-pivoted Bareiss determinant equals the executable Leibniz
+determinant on integer square matrices. Proven Mathlib-side by composing
+`bareiss_eq_mathlib_det` with `det_eq`, so it holds outright (no sorry-bound
+hypothesis) and is the preferred surface for downstream Mathlib-side callers. -/
 theorem bareiss_eq_det (M : Hex.Matrix Int n n) :
     Hex.Matrix.bareiss M = Hex.Matrix.det M :=
   (bareiss_eq_mathlib_det M).trans (det_eq M).symm

--- a/HexMatrixMathlib/Determinant/Bareiss.lean
+++ b/HexMatrixMathlib/Determinant/Bareiss.lean
@@ -1562,9 +1562,9 @@ private theorem pivotLoop_initial_regular_step_eq_pred
   omega
 
 /-- Mathlib-side correctness theorem for the packaged row-pivoted Bareiss
-data. This theorem avoids using the Mathlib-free `Hex.Matrix.bareiss_eq_det`
-hole; it combines the row-pivot invariant with the singular-branch
-determinant-zero theorem above. -/
+data: its `.det` field equals Mathlib's determinant of the corresponding
+matrix. Proven directly here by combining the row-pivot invariant with the
+singular-branch determinant-zero theorem above. -/
 theorem bareissData_eq_mathlib_det (M : Hex.Matrix Int n n) :
     (Hex.Matrix.bareissData M).det = Matrix.det (matrixEquiv M) := by
   by_cases hregular : (Hex.Matrix.bareissData M).singularStep = none

--- a/HexMatrixMathlib/RankSpanNullspace.lean
+++ b/HexMatrixMathlib/RankSpanNullspace.lean
@@ -32,14 +32,21 @@ def vectorEquiv : Vector R n ≃ (Fin n → R) where
     funext i
     simp
 
+/-- `vectorEquiv` reads off the executable vector entrywise, so a caller can
+rewrite `vectorEquiv v i` to the underlying `v[i]` without unfolding it. -/
 @[simp, grind =] theorem vectorEquiv_apply (v : Vector R n) (i : Fin n) :
     vectorEquiv v i = v[i] :=
   rfl
 
+/-- The inverse direction of `vectorEquiv` materialises a function as an
+executable vector entrywise: `(vectorEquiv.symm f)[i]` is just `f i`. -/
 @[simp, grind =] theorem vectorEquiv_symm_apply (f : Fin n → R) (i : Fin n) :
-    (vectorEquiv.symm f)[i] = f i := by
+    (vectorEquiv.symm f)[(i : Nat)] = f i := by
   simp [vectorEquiv]
 
+/-- Row `i` of the Mathlib matrix `matrixEquiv M` is the image under
+`vectorEquiv` of the executable row `Hex.Matrix.row M i`, letting span/rank
+lemmas pass between the two row representations. -/
 @[simp, grind =] theorem matrixEquiv_row (M : Hex.Matrix R n m) (i : Fin n) :
     _root_.Matrix.row (matrixEquiv M) i = vectorEquiv (Hex.Matrix.row M i) := by
   funext j
@@ -52,6 +59,9 @@ private theorem foldl_finRange_eq_sum [AddCommMonoid R] {n : Nat} (f : Fin n →
   rw [← List.sum_toFinset f (List.nodup_finRange n)]
   rw [List.toFinset_finRange]
 
+/-- Bridge invariant: the executable matrix-vector product transports to
+Mathlib's `Matrix.mulVec` under `matrixEquiv`/`vectorEquiv`. This is the key
+step letting nullspace membership be phrased against `mulVecLin`. -/
 private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector R m) :
     vectorEquiv (M * v) = (matrixEquiv M).mulVec (vectorEquiv v) := by
   funext i
@@ -65,6 +75,10 @@ private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector 
   intro k _
   rfl
 
+/-- The executable row combination `Hex.Matrix.rowCombination M c` (the linear
+combination of the rows of `M` with coefficients `c`) transports under
+`vectorEquiv` to Mathlib's `Fintype.linearCombination` over the rows of
+`matrixEquiv M`. This identifies the computed row span with Mathlib's span. -/
 theorem vectorEquiv_rowCombination [CommRing R] (M : Hex.Matrix R n m) (c : Vector R n) :
     vectorEquiv (Hex.Matrix.rowCombination M c) =
       Fintype.linearCombination R (_root_.Matrix.row (matrixEquiv M)) (vectorEquiv c) := by
@@ -87,6 +101,10 @@ theorem vectorEquiv_rowCombination [CommRing R] (M : Hex.Matrix R n m) (c : Vect
   congr 1
   simp [Vector.getElem_ofFn]
 
+/-- Bridge invariant: applying the executable nullspace matrix to a coefficient
+vector `c` expands, under `vectorEquiv`, as the `c`-weighted sum of the computed
+nullspace basis vectors. Used to express an arbitrary kernel element as a span
+of the basis. -/
 private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) (c : Vector R (m - D.rank)) :
@@ -104,6 +122,10 @@ private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
   unfold Hex.Matrix.IsRREF.nullspace Hex.Matrix.col
   simp [mul_comm]
 
+/-- Soundness of the executable `spanCoeffs`: when echelon-form data certifies
+`v` as a row combination with coefficients `c`, the Mathlib image of `v` is the
+corresponding `linearCombination` of the rows of `M`. Witnesses span membership
+with explicit coefficients. -/
 theorem spanCoeffs_eq_linearCombination [Field R] [DecidableEq R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsEchelonForm M D) (v : Vector R m) (c : Vector R n) :
@@ -120,6 +142,9 @@ theorem spanCoeffs_eq_linearCombination [Field R] [DecidableEq R]
     exact (congrArg vectorEquiv hrow.symm).trans (vectorEquiv_rowCombination M _)
   · contradiction
 
+/-- The executable span-membership test `spanContains` is correct: it returns
+`true` exactly when the Mathlib image of `v` lies in the `R`-span of the rows of
+`M`. The decision procedure agrees with Mathlib's `Submodule.span`. -/
 theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) (v : Vector R m) :
@@ -138,6 +163,9 @@ theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
     rw [vectorEquiv_rowCombination M (vectorEquiv.symm c)]
     simpa using hc
 
+/-- Every row of the computed echelon form lies in the row span of the original
+matrix `M`: row reduction does not enlarge the span. One inclusion of the
+"echelon rows span the same subspace as `M`" equivalence. -/
 theorem rref_echelon_row_mem_span [Field R] [DecidableEq R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) (i : Fin n) :
@@ -152,6 +180,9 @@ theorem rref_echelon_row_mem_span [Field R] [DecidableEq R]
     simpa [e] using Hex.Matrix.IsRREF.rowCombination_single (M := D.echelon) i
   rw [htransport, hsingle]
 
+/-- Converse direction: any vector in the row span of `M` is realised as an
+executable row combination of the echelon rows. Together with
+`rref_echelon_row_mem_span` this shows row reduction preserves the row span. -/
 theorem rref_mem_span_echelon_of_mem_span [Field R] [DecidableEq R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) {v : Fin m → R} :
@@ -165,6 +196,9 @@ theorem rref_mem_span_echelon_of_mem_span [Field R] [DecidableEq R]
   exact E.toIsEchelonForm.exists_rowCombination_echelon_of_M
     ((E.spanContains_iff (vectorEquiv.symm v)).mp hcontains)
 
+/-- Each computed nullspace basis vector lies in the kernel of `M` (viewed as
+Mathlib's linear map `mulVecLin`): the executable nullspace really annihilates
+`M`. -/
 theorem nullspace_mem_ker [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) (k : Fin (m - D.rank)) :
@@ -180,6 +214,9 @@ theorem nullspace_mem_ker [Field R]
   rw [hzero] at hbridge
   exact hbridge.symm
 
+/-- The computed nullspace basis spans exactly the kernel of `M`: the span of
+the executable basis vectors equals Mathlib's `LinearMap.ker (mulVecLin M)`.
+This is the completeness counterpart to `nullspace_mem_ker`. -/
 theorem nullspace_span_eq_ker [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) :
@@ -215,6 +252,9 @@ theorem nullspace_span_eq_ker [Field R]
     exact Submodule.sum_mem _ fun k _ =>
       Submodule.smul_mem _ c[k] (Submodule.subset_span ⟨k, rfl⟩)
 
+/-- Invariant pinning the free-column entries of the nullspace basis: basis
+vector `k` reads `1` at its own free column and `0` at the others. This Kronecker
+pattern is what makes the basis linearly independent. -/
 private theorem nullspace_get_free_entry [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) (k l : Fin (m - D.rank)) :
@@ -225,6 +265,9 @@ private theorem nullspace_get_free_entry [Field R]
     simpa using Hex.Matrix.IsRREF.nullspace_get_free E l
   · simpa [hkl] using Hex.Matrix.IsRREF.nullspace_get_free_ne E hkl
 
+/-- The computed nullspace basis is linearly independent, read off from the
+Kronecker pattern of `nullspace_get_free_entry`. Supplies the dimension count in
+`rank_eq`. -/
 private theorem nullspace_linearIndependent [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) :
@@ -249,6 +292,9 @@ private theorem nullspace_linearIndependent [Field R]
   · intro hmem
     exact (hmem (Finset.mem_univ l)).elim
 
+/-- The rank computed by row reduction agrees with Mathlib's `Matrix.rank`.
+Proven by rank-nullity: the `m - D.rank` independent nullspace basis vectors pin
+the kernel dimension, and the complement is the matrix rank. -/
 theorem rank_eq [Field R]
     {M : Hex.Matrix R n m} {D : Hex.Matrix.RowEchelonData R n m}
     (E : Hex.Matrix.IsRREF M D) :

--- a/progress/20260620_123346_d444723a.md
+++ b/progress/20260620_123346_d444723a.md
@@ -1,0 +1,81 @@
+# HexMatrixMathlib Phase 6 closeout — partial (#8262)
+
+Session type: feature (via `/work`). UTC 2026-06-20T12:33.
+
+## Accomplished
+
+Started on `/work`, picked #8248 (packed UInt64 divMod/gcd kernel) as
+highest-value, but found its premise unmet and released it; then claimed
+and partially executed #8262 (HexMatrixMathlib Phase 6 closeout).
+
+### #8248 — released to replan (unmet dependency + superseded premise)
+
+The body claimed it "depends on the packed long-division kernel landed by
+#8247." #8247 landed nothing: it was decomposed into #8251 (packed monic
+kernel + correspondence proof, OPEN/claimed) and #8252 (csimp wiring,
+OPEN/blocked). No packed UInt64 division kernel exists on `main` — only the
+generic `divModArrayAux` over boxed `Array (ZMod64 p)`. The body also
+carries the raw-word arithmetic premise that #8247's decomposition
+corrected as unsound for `Bounds p` with `p > 2^32`. Posted concrete
+evidence and `coordination skip`-ped with replan guidance (re-link
+`depends-on: #8251`/`#8252`, keep the sound seam-based decomposition).
+
+### #8262 — landed docstrings + linter + stale docstring (no bump)
+
+Commit `0cdf8a95`:
+- **Docstrings.** `Basic.lean` matrixEquiv API (6 decls) and
+  `RankSpanNullspace.lean` span/nullspace/rank surface plus the non-obvious
+  private bridge helpers (`vectorEquiv_mulVec`,
+  `vectorEquiv_nullspaceMatrix_mulVec`, `nullspace_linearIndependent`,
+  `nullspace_get_free_entry`). Routine plumbing (`foldl_finRange_eq_sum`)
+  left undocumented per the "don't pad" rule.
+- **Linter (deliverable 3).** Two pre-existing `simpNF` errors:
+  `matrixEquiv_symm_apply` and `vectorEquiv_symm_apply` had Fin-indexed
+  `@[simp]` LHS that `Fin.getElem_fin` normalises to `↑i`. Restated their
+  LHS with Nat-indexed (simp-normal) form. `runLinter HexMatrixMathlib`
+  now passes.
+- **Stale `bareiss_eq_det` docstrings (part of deliverable 2).** The
+  Mathlib-free orphan `Hex.Matrix.bareiss_eq_det` they referenced as
+  "sorry-bound in `HexMatrix/Bareiss.lean`" no longer exists anywhere in
+  the tree. Rewrote both docstrings (`Determinant.lean`,
+  `Determinant/Bareiss.lean`) to describe the live Mathlib-side proofs.
+
+## Key decision: deferred the bump, filed #8265
+
+The dead-code half of deliverable 2 ("confirm no dead/unreferenced decls
+remain") could **not** be confirmed clean. A tree-wide word-boundary name
+grep found **23 unreferenced, untagged `theorem`s** in the library (mostly
+the determinant subtree, `Determinant/Core.lean` 2894 lines +
+`Determinant/Bareiss.lean` 1697 lines). Excluded the live simp/grind-tagged
+lemmas. The cluster mixes plausibly-intended exposed bridge API
+(`matrixEquiv_rowSwap/Scale/Add`, `spanCoeffs_eq_linearCombination`,
+`bareissDet_eq_det`) with slop-named proof scaffolding
+(`nMatrix_ordered_four_p1_p2_row_q`, …). Triaging API-vs-scaffolding and
+handling reference cascades across ~4600 lines is its own audit, beyond
+#8262's docstring-focused scope (which assumed the subtree was clean). Full
+evidence list (23 decls with file:line) is in #8265, which also carries the
+`done_through 5 → 6` bump once the audit lands.
+
+## Verification
+
+- `lake build HexMatrixMathlib` green (2663 jobs), all edited modules
+  recompiled fresh (not cache replay).
+- `lake exe runLinter HexMatrixMathlib`: "Linting passed."
+- No `axiom`/`sorry`/`native_decide` introduced (the one `sorry` in the
+  diff is the word in a docstring).
+- `done_through` stays at 5 (intentional — see above).
+
+## Current frontier
+
+`HexMatrixMathlib` Phase 6: docstrings + linter + stale-docstring done;
+dead-code audit + bump pending in #8265.
+
+## Next step
+
+Execute #8265: triage the 23 unreferenced theorems, excise dead
+scaffolding (iterating for cascades), keep justified API, bump
+`done_through` 5 → 6.
+
+## Blockers
+
+None for #8265. #8248 stays blocked on #8251 (packed monic kernel).


### PR DESCRIPTION
Partial progress on #8262

Session: `d444723a-2343-4241-8721-735259a61ec9`

5afc130f chore: progress entry for #8262 partial closeout
0cdf8a95 doc: HexMatrixMathlib Basic/RankSpanNullspace docstrings + simpNF + stale bareiss docstring (#8262)

🤖 Prepared with Claude Code