### PR TITLE
perf: linear-time csimp Nat.choose removes van Hoeij high-degree blowup

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -157,6 +157,63 @@ private theorem choose_succ_mul_eq (n k : Nat) :
       | succ k =>
           grind [choose]
 
+/-- Within-row multiplicative recurrence `(k+1) · choose n (k+1) = (n - k) · choose n k`.
+Reading it left to right computes one Pascal row in a single linear pass, which is
+what `chooseFast` exploits. -/
+theorem succ_mul_choose_succ (n k : Nat) :
+    (k + 1) * choose n (k + 1) = (n - k) * choose n k := by
+  have hcross := choose_succ_mul_eq n k
+  have hpascal : choose (n + 1) (k + 1) = choose n k + choose n (k + 1) := rfl
+  rw [hpascal, Nat.mul_add] at hcross
+  rcases Nat.lt_or_ge n k with hlt | hge
+  · rw [choose_eq_zero_of_lt hlt, choose_eq_zero_of_lt (Nat.lt_succ_of_lt hlt),
+      Nat.mul_zero, Nat.mul_zero]
+  · have hsplit : (n + 1) * choose n k
+        = (n - k) * choose n k + (k + 1) * choose n k := by
+      rw [← Nat.add_mul]
+      congr 1
+      omega
+    rw [hsplit] at hcross
+    omega
+
+/--
+Linear-time binomial coefficient.
+
+`chooseFast n k` walks a single Pascal row from `choose n 0 = 1` using the
+multiplicative recurrence `succ_mul_choose_succ`, so it costs `O(k)` natural-number
+operations.  The proof-facing `choose` is the exponential Pascal double recursion
+(`choose n k` spawns `Θ(choose n k)` calls); `chooseFast` is proven equal to it and
+registered `@[csimp]`, so every compiled caller of `choose` runs this instead.
+-/
+def chooseFast (n k : Nat) : Nat :=
+  if n < k then 0
+  else (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1
+
+private theorem chooseFast_foldl (n : Nat) :
+    ∀ k, k ≤ n →
+      (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1 = choose n k := by
+  intro k
+  induction k with
+  | zero => intro _; simp
+  | succ k ih =>
+      intro hk
+      rw [List.range_succ, List.foldl_append, ih (Nat.le_of_succ_le hk)]
+      simp only [List.foldl_cons, List.foldl_nil]
+      have hid : choose n k * (n - k) = (k + 1) * choose n (k + 1) := by
+        rw [Nat.mul_comm, succ_mul_choose_succ]
+      rw [hid, Nat.mul_div_cancel_left _ (Nat.succ_pos k)]
+
+/-- `chooseFast` agrees with the proof-facing Pascal `choose`. -/
+theorem chooseFast_eq (n k : Nat) : chooseFast n k = choose n k := by
+  unfold chooseFast
+  by_cases h : n < k
+  · rw [if_pos h]; exact (choose_eq_zero_of_lt h).symm
+  · rw [if_neg h]; exact chooseFast_foldl n k (Nat.le_of_not_lt h)
+
+@[csimp] theorem choose_eq_chooseFast : @choose = @chooseFast := by
+  funext n k
+  exact (chooseFast_eq n k).symm
+
 /-- Euclid-step bridge turning the multiplicative Pascal identity into `p ∣ choose p k`. -/
 private theorem choose_prime_dvd_from_mul_identity {p k : Nat} (hp : Prime p)
     (hk : 0 < k) (hk' : k < p) : p ∣ choose p k := by

--- a/progress/20260621_051448_71036103.md
+++ b/progress/20260621_051448_71036103.md
@@ -1,0 +1,63 @@
+# van Hoeij recombination high-degree scaling (#8064)
+
+Session type: feature (one-shot). UTC 2026-06-21T05:14.
+
+## Accomplished
+
+Profiled `factorFast` on the split family `(x-1)…(x-n)` at degree 16/20/24
+and attributed the high-degree cost, then removed the dominant term.
+
+**Attribution (degree 24, sampled with macOS `sample`):**
+- ~81% of wallclock was in `Hex.Nat.choose`, the naive Pascal double
+  recursion (`choose n k` spawns `Θ(choose n k)` calls). It is reached
+  through `bhksCoeffBound` → `bhksCoeffCutThreshold` → `cldCoeffs` during
+  the CLD lattice build — the exact "lattice core" stage the issue names.
+  `bhksCoeffBound f j = Nat.choose (n-1) j * …`, and `cldCoeffs` recomputes
+  it for every one of the `r` lifted factors, so the cost was
+  `r · Σⱼ C(n-1,j) = r · 2^(n-1)` additions (~2×10⁸ at degree 24).
+- The remaining stages of the recombination core proper (Hensel lift, the
+  `bhksLatticeBasis` matrix assembly, `hex-lll`, candidate reconstruction)
+  were each sub-millisecond at the recovery precision.
+
+**Fix:** added a proof-backed `@[csimp]` linear-time `chooseFast` in
+`HexArith/Nat/Prime.lean`. It walks one Pascal row left-to-right via the
+multiplicative recurrence `(k+1)·C(n,k+1) = (n-k)·C(n,k)` (new lemma
+`succ_mul_choose_succ`, derived from the existing cross-row
+`choose_succ_mul_eq`), costing `O(k)` ops. `chooseFast_eq` proves it equal
+to the Pascal `choose`, and the `@[csimp]` swap redirects every compiled
+caller while leaving the proof-facing `choose` (and all its `rfl`-backed
+lemmas) untouched. No `sorry`, no `axiom`, no trusted `implemented_by`.
+
+**Result (official `hexbz_bench` cold profile, `runFactorFastChecksum`):**
+
+| degree | issue | post-#8251 | this PR |
+|--------|-------|-----------|---------|
+| 16 | 411 ms | 382 ms | 347 ms |
+| 20 | 2.38 s | 1.55 s | 1.09 s |
+| 24 | 30.5 s | 12.8 s | 2.75 s |
+
+Degree 24 is 4.6× faster than the post-#8251 baseline (11× vs the original
+issue). The 20→24 step fell from ~8× to ~2.5×.
+
+## Current frontier / Next step
+
+After this fix the dominant remaining cost at degree 24 (the full ~2.75 s)
+is in **prime selection** — `choosePrimeData?` → `primeChoiceDataScore` →
+`berlekampFactorsModP` (the mod-`p` Berlekamp factorization at the first
+good prime, `p = 29` for degree 24), not in the recombination core. This
+revises the issue's premise: the lattice core is no longer the bottleneck;
+the mod-`p` factorization is. That is a separate subsystem
+(`HexBerlekamp/Factor.lean`, `splitFirstFactor?`/`gcdAux`) and a good
+candidate for a follow-up issue if its high-degree scaling matters.
+
+## Verification
+
+- `lake build HexArith HexBerlekampZassenhaus HexBerlekampZassenhausMathlib`
+  green (3786 jobs; the CI-gated Mathlib layer included).
+- `hexbz_bench verify`: all 18 benchmarks pass (factorizations unchanged).
+- Pre-existing `Fin.coe_*` deprecation warnings in
+  `HexBerlekampZassenhausMathlib/Resultant.lean` are unrelated to this change.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR removes the steep high-degree scaling of the van Hoeij fast factoring path by replacing the executable binomial coefficient with a linear-time, proof-backed implementation. Sampling `factorFast` on the split family `(x-1)…(x-n)` at degree 24 attributes ~81% of wallclock to `Hex.Nat.choose`, the naive Pascal double recursion (`choose n k` spawns `Θ(choose n k)` calls). It is reached through `bhksCoeffBound` → `bhksCoeffCutThreshold` → `cldCoeffs` during the CLD lattice build, and `cldCoeffs` recomputes it for every lifted factor, so the cost is `r · Σⱼ C(n-1,j) = r · 2^(n-1)` additions. Add `chooseFast`, which walks a single Pascal row left to right via the multiplicative recurrence `(k+1)·C(n,k+1) = (n-k)·C(n,k)` (new lemma `succ_mul_choose_succ`, derived from the existing cross-row `choose_succ_mul_eq`) at `O(k)` cost. `chooseFast_eq` proves it equal to the Pascal `choose`, and the `@[csimp]` swap redirects every compiled caller while leaving the proof-facing `choose` and its `rfl`-backed lemmas untouched — no `axiom`, no `sorry`, no trusted `implemented_by`.

Degree-24 `factorFast` drops from 12.8 s to 2.75 s (4.6×; 11× against the original issue baseline of 30.5 s), and the 20→24 step falls from ~8× to ~2.5×:

| degree | issue | post-#8251 | this PR |
|--------|-------|-----------|---------|
| 16 | 411 ms | 382 ms | 347 ms |
| 20 | 2.38 s | 1.55 s | 1.09 s |
| 24 | 30.5 s | 12.8 s | 2.75 s |

One note on the issue's premise: after this fix the dominant remaining cost at degree 24 is no longer the lattice core but prime selection — `choosePrimeData?` → `primeChoiceDataScore` → `berlekampFactorsModP`, the mod-`p` Berlekamp factorization at the first good prime. That is a separate subsystem and a candidate for a follow-up if its high-degree scaling matters.

Verification: `lake build HexArith HexBerlekampZassenhaus HexBerlekampZassenhausMathlib` is green (3786 jobs, CI-gated Mathlib layer included) and `hexbz_bench verify` passes all 18 benchmarks (factorizations unchanged).

🤖 Prepared with Claude Code