### PR TITLE
feat: separation-free RecoveredLift family for liftedTrueSupports (#8068)

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -836,7 +836,23 @@ find a `theorem … : <StructureName> …` whose body builds it (or a `{ field :
 literal), not just `(h : <StructureName>)` binders and `…_fields h` projections.
 If every occurrence is a hypothesis or destructor, the substrate is unproduced —
 diagnose on the issue (per the CLAUDE.md "Directives are hypotheses" rule) and
-`coordination skip` rather than attempting the integration. Substrate producers
+`coordination skip` rather than attempting the integration. **But before
+concluding a transport/producer is genuinely missing, grep producer proof
+*bodies*, not just signatures: a needed construction is frequently performed
+*inline inside a larger producer's proof* and can be lifted to a top-level
+lemma, even when no theorem states it.** #8068 was nearly skipped a 5th time on
+"no original→monic `RepresentsIntegerFactorAtLift` inversion exists"
+(`representsIntegerFactorAtLift_of_monicCorrespondent` only goes monic→original);
+that conclusion was *wrong* — the partition producer
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData` already
+reconstructs the monic correspondent from the *factor itself* (a local `descent`
+`have`, `IntReductionMod.lean`), via `exists_monicCorrespondent_of_dvd` +
+`representsModP_correspondent` + `toMonicLiftData_represents_lifted_monicCorrespondent`,
+never the represents predicate's hidden witness. Extracting that `have` as
+`monicCorrespondentDescent_of_representsAtLift` unblocked the whole separation-free
+route. A fan-out `Explore` agent that only checks the named-lemma path will
+report a confident, wrong "NO" here — read the construction sites yourself.
+Substrate producers
 still missing as of this writing: `HenselLiftDescentHypotheses` and the
 `toMonicLiftData` modP→lift transport. `InitialLiftedFactorSubsetPartitionEvidence`
 now *has* one — `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3113,6 +3113,128 @@ theorem initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData
     exact toMonicLiftData_liftedRecoveryCandidate_eq core B primeData hcore_lc_pos hcore_pos
       hselected hbound hfsign hrep
 
+/--
+**Monic-correspondent descent for a represented integer factor (#8068).**
+
+Top-level extraction of the `descent` step inside
+`initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`.  From an
+original-core represented factor `f` (irreducible, dividing `core`, represented
+at the `toMonicLiftData` lift by subset `S`) this reconstructs the *monic
+correspondent* `gf` of `f` from `f` alone: the monic irreducible factor of
+`(toMonic core).monic`, its mod-`p` representing subset `S₀`, the
+`primitivePart ∘ dilate` recovery `f = primitivePart (dilate (lc core) gf)`, and
+the identification `S = liftedSubsetOfModPSubset … S₀`.
+
+This is the keystone that lets the centered `RecoveredLift` family for
+`liftedTrueSupports core d` be built directly (via
+`recoveredLiftOfToMonicRepresents`), without the reverse `L' = W` separation: the
+witnessing `f` carried by a `liftedTrueSupports` membership is enough to recover
+the monic-coordinate representation that the recovered-lift producers consume.
+-/
+theorem monicCorrespondentDescent_of_representsAtLift
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    {f : Hex.ZPoly}
+    {S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData)}
+    (hf_irr : Irreducible (HexPolyZMathlib.toPolynomial f))
+    (hf_dvd : f ∣ core)
+    (hrep :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData) f S) :
+    ∃ (gf : Hex.ZPoly) (S₀ : ModPFactorSubset primeData),
+      Hex.DensePoly.Monic gf ∧
+      gf ∣ (Hex.ZPoly.toMonic core).monic ∧
+      Irreducible (HexPolyZMathlib.toPolynomial gf) ∧
+      RepresentsIntegerFactorModP primeData gf S₀ ∧
+      Hex.ZPoly.primitivePart
+        (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) gf) = f ∧
+      S = liftedSubsetOfModPSubset primeData
+        (Hex.ZPoly.toMonicLiftData core B primeData)
+        (Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B primeData) S₀ := by
+  classical
+  have hp_prime : Hex.Nat.Prime primeData.p :=
+    Hex.ZPoly.toMonicPrimeData?_prime core primeData hselected
+  have hp2 : 2 ≤ primeData.p := hp_prime.two_le
+  have hprec_spec : 2 * B < primeData.p ^ Hex.precisionForCoeffBound B primeData.p :=
+    Hex.precisionForCoeffBound_spec hp2 B
+  have hB1 : 1 ≤ B := Nat.one_le_iff_ne_zero.mpr hB_ne_zero
+  have hmodulus : 2 ≤ primeData.p ^ Hex.precisionForCoeffBound B primeData.p := by omega
+  have hprecision : 1 ≤ Hex.precisionForCoeffBound B primeData.p := by
+    by_contra hlt
+    have hzero : Hex.precisionForCoeffBound B primeData.p = 0 := by omega
+    rw [hzero, pow_zero] at hmodulus
+    omega
+  have hcore0 : core ≠ 0 := by
+    intro h
+    rw [h, Hex.DensePoly.leadingCoeff_zero] at hcore_lc_pos
+    exact lt_irrefl 0 hcore_lc_pos
+  have hdeg : 1 ≤ (Hex.ZPoly.toMonic core).degree := hcore_pos
+  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
+    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos hcore_pos
+  have hM_ne : (Hex.ZPoly.toMonic core).monic ≠ 0 := zpoly_ne_zero_of_monic hM_monic
+  have hsize : (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size =
+      primeData.factorsModP.size :=
+    Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B primeData
+  have hlf_monic :
+      ∀ i, Hex.DensePoly.Monic
+        (liftedFactor (Hex.ZPoly.toMonicLiftData core B primeData) i) :=
+    Hex.ZPoly.toMonicLiftData_liftedFactor_monic_of_monicPrimeData core B primeData
+      hcore_lc_pos hcore_pos hselected hprecision
+  have hp_eq : (Hex.ZPoly.toMonicLiftData core B primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hk_eq : (Hex.ZPoly.toMonicLiftData core B primeData).k =
+      Hex.precisionForCoeffBound B primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  have hmod2 : 2 ≤ (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+      (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hmodulus
+  have hprec_dk :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hbound
+  have hfsign : Hex.normalizeFactorSign f = f :=
+    normalizeFactorSign_eq_of_representsAtLift hrep hcore_lc_pos hM_ne hlf_monic hprec_dk
+  have hcand :
+      liftedRecoveryCandidate core (Hex.ZPoly.toMonicLiftData core B primeData) S = f :=
+    toMonicLiftData_liftedRecoveryCandidate_eq core B primeData hcore_lc_pos hcore_pos
+      hselected hbound hfsign hrep
+  have hf_prim : Hex.ZPoly.Primitive f := by
+    rw [← hcand]
+    exact zpoly_primitive_liftedRecoveryCandidate hcore_lc_pos hmod2 hlf_monic S
+  have hfdeg : 1 ≤ f.degree?.getD 0 :=
+    one_le_degree_getD_of_irreducible_dvd_primitive hcore_prim hf_irr hf_dvd
+  obtain ⟨gf, hgf_monic, hgf_dvd, hrecover⟩ :=
+    exists_monicCorrespondent_of_dvd core f hcore0 hcore_lc_pos hdeg hfdeg hf_dvd hf_prim hfsign
+  have hgf_irr : Irreducible (HexPolyZMathlib.toPolynomial gf) :=
+    irreducible_toPolynomial_monicCorrespondent (ne_of_gt hcore_lc_pos) hgf_monic hf_prim
+      hf_irr hrecover
+  obtain ⟨S₀, hS₀⟩ :=
+    representsModP_correspondent core primeData hcore_lc_pos hcore_pos hselected hgf_irr hgf_dvd
+  have hliftM :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) gf
+        (liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+          hsize S₀) :=
+    toMonicLiftData_represents_lifted_monicCorrespondent core B primeData hcore_lc_pos
+      hcore_pos hselected hB_ne_zero hgf_monic hgf_irr hgf_dvd hS₀
+  have hliftcore :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData) f
+        (liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+          hsize S₀) :=
+    representsIntegerFactorAtLift_of_monicCorrespondent rfl hM_monic hliftM hrecover
+  have hSeq : S = liftedSubsetOfModPSubset primeData
+      (Hex.ZPoly.toMonicLiftData core B primeData) hsize S₀ :=
+    toMonicLiftData_unique_subset core B primeData hcore_lc_pos hcore_pos hselected
+      hprecision hbound hf_irr hf_dvd hrep hliftcore
+  exact ⟨gf, S₀, hgf_monic, hgf_dvd, hgf_irr, hS₀, hrecover, hSeq⟩
+
 end IntReductionMod
 
 /-- **#7584 core-facts producer (lifted-subset partition).**

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -981,6 +981,97 @@ theorem factorFastCore_irreducible_of_monicRecoveredLift
         BHKS.ForwardRecoveryInputs.recoveredLift_subtypeFamily_of_indicatorCandidates_a]
     exact BHKS.toMonicLiftData_one_lt_modulus core k' primeData hvalid hprecision
 
+/--
+**Centered `RecoveredLift` for a genuine lifted true support (#8068 keystone).**
+
+For any support `U` in the genuine `liftedTrueSupports core (toMonicLiftData core
+B primeData)` family, the centered recovered lift over the monic basis exists.
+
+Unlike `recoveredLift_subtypeFamily_of_indicatorCandidates`, this consumes **no**
+`hindicators` (`L' = W`) hypothesis: the witnessing integer factor `f` carried by
+the `liftedTrueSupports` membership is descended to its monic correspondent `gf`
+(via `IntReductionMod.monicCorrespondentDescent_of_representsAtLift`), whose
+monic-coordinate representation feeds `recoveredLiftOfToMonicRepresents`.  The
+support is then transported back along the membership's coercion `↑S = U`.  This
+is the separation-free producer of the `lift` family consumed by
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`.
+-/
+noncomputable def recoveredLiftOfLiftedTrueSupport
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    BHKS.RecoveredLift
+      (Hex.bhksLatticeBasis (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData).p
+        (Hex.ZPoly.toMonicLiftData core B primeData).k
+        (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors) U := by
+  classical
+  have hsize_d :
+      (Hex.ZPoly.toMonicLiftData core B primeData).liftedFactors.size =
+        primeData.factorsModP.size :=
+    Hex.ZPoly.toMonicLiftData_liftedFactors_size_eq core B primeData
+  have hp_eq : (Hex.ZPoly.toMonicLiftData core B primeData).p = primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_p _ _ _
+  have hk_eq : (Hex.ZPoly.toMonicLiftData core B primeData).k =
+      Hex.precisionForCoeffBound B primeData.p := by
+    unfold Hex.ZPoly.toMonicLiftData; exact Hex.henselLiftData_k _ _ _
+  have hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+    rw [hp_eq, hk_eq]; exact hbound
+  -- Extract the witnessing integer factor and its representing subset (Prop → data: `choose`).
+  have hf_irr : Irreducible (HexPolyZMathlib.toPolynomial hU.choose) :=
+    hU.choose_spec.choose_spec.1
+  have hf_dvd : hU.choose ∣ core := hU.choose_spec.choose_spec.2.1
+  have hrep :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData)
+        hU.choose hU.choose_spec.choose :=
+    hU.choose_spec.choose_spec.2.2.1
+  have hcoe :
+      (↑hU.choose_spec.choose :
+          Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData))) = U :=
+    hU.choose_spec.choose_spec.2.2.2
+  -- Descend to the monic correspondent.
+  have hdesc :=
+    IntReductionMod.monicCorrespondentDescent_of_representsAtLift core B primeData hselected
+      hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound hf_irr hf_dvd hrep
+  have hgf_monic := hdesc.choose_spec.choose_spec.1
+  have hgf_dvd := hdesc.choose_spec.choose_spec.2.1
+  have hgf_irr := hdesc.choose_spec.choose_spec.2.2.1
+  have hmodP := hdesc.choose_spec.choose_spec.2.2.2.1
+  have hSeq := hdesc.choose_spec.choose_spec.2.2.2.2.2
+  -- Monic-coordinate lifted representation of the correspondent.
+  have hliftM :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) hdesc.choose
+        (liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+          hsize_d hdesc.choose_spec.choose) :=
+    toMonicLiftData_represents_lifted_monicCorrespondent core B primeData hcore_lc_pos
+      hcore_pos hselected hB_ne_zero hgf_monic hgf_irr hgf_dvd hmodP
+  -- Build the recovered lift over the monic basis, then transport the support to `U`.
+  have hsupp :
+      BHKS.supportOfSubset (Hex.ZPoly.toMonic core).monic
+          (Hex.ZPoly.toMonicLiftData core B primeData)
+          (liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+            hsize_d hdesc.choose_spec.choose) = U := by
+    show (↑(liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+        hsize_d hdesc.choose_spec.choose) :
+        Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData))) = U
+    rw [← hSeq]; exact hcoe
+  exact hsupp ▸ BHKS.recoveredLiftOfToMonicRepresents core B primeData
+    (liftedSubsetOfModPSubset primeData (Hex.ZPoly.toMonicLiftData core B primeData)
+      hsize_d hdesc.choose_spec.choose)
+    hdesc.choose hgf_dvd.choose hcore_lc_pos hcore_pos hgf_dvd.choose_spec.symm hprecision hliftM
+
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`
 with `factorFastCoreWithBound_some_factor_count_ge`, exposing the count

--- a/progress/20260621T045526Z_72ca9c63.md
+++ b/progress/20260621T045526Z_72ca9c63.md
@@ -1,0 +1,82 @@
+# Progress — #8068 fast-BHKS core irreducibility (separation-free RecoveredLift route)
+
+Session type: feature (one-shot `/once 8068`). UTC 2026-06-21.
+
+## Accomplished
+
+The centered `RecoveredLift` route IS viable and separation-free — the prior
+near-skip reasoning (no original→monic represents inversion) was wrong. The
+inversion already exists inside the partition producer, and I extracted it.
+
+1. **`IntReductionMod.monicCorrespondentDescent_of_representsAtLift`** (top-level
+   extraction of the `descent` step from
+   `initialLiftedFactorSubsetPartitionEvidence_of_toMonicChoosePrimeData`): from
+   an original-core represented factor `f` (`Irreducible (toPolynomial f)`,
+   `f ∣ core`, `RepresentsIntegerFactorAtLift core d f S`) it reconstructs the
+   monic correspondent `gf`, its mod-`p` subset `S₀`, the `primitivePart∘dilate`
+   recovery, and `S = liftedSubsetOfModPSubset … S₀` — all from `f` alone, no
+   `L' = W`.
+
+2. **`recoveredLiftOfLiftedTrueSupport`** (PartitionRefinement, the keystone):
+   for any support `U ∈ liftedTrueSupports core (toMonicLiftData core B primeData)`,
+   produces `RecoveredLift (bhksLatticeBasis (toMonic core).monic …) U`, **with no
+   `hindicators`/`L' = W` hypothesis**. It descends the membership's witnessing
+   `f` to `gf` (deliverable 1), lifts to the monic-coordinate represents
+   (`toMonicLiftData_represents_lifted_monicCorrespondent`), builds via
+   `recoveredLiftOfToMonicRepresents`, and transports the support back along
+   `↑S = U`.
+
+Both compile; full `HexBerlekampZassenhausMathlib` builds green (0 errors). Only
+the pre-existing `factor_irreducible_of_nonUnit` sorry remains.
+
+## Why this corrects the premise
+
+The 4 prior skips bottomed out at either the raw `TrueFactorLift` product
+equality or the `hindicators` (`L' = W`) needed to align the candidate array with
+the genuine supports. The keystone sidesteps both: `liftedTrueSupports` already
+carries the witnessing integer factor, and `monicCorrespondentDescent` rebuilds
+the monic-coordinate data from that factor (exactly what the partition producer
+does internally at `IntReductionMod.lean:2958-2981`, then discards). No #6779/#2564.
+
+## Current frontier
+
+`recoveredLiftOfLiftedTrueSupport` is the `lift` family argument of
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`
+(PartitionRefinement.lean:807). Instantiating that consumer with
+`trueSupports := (liftedTrueSupports core d : Set (Set (Fin …)))` and this `lift`
+closes the fast-core (c) arm — separation-free.
+
+## Next step (mechanical, but multi-session)
+
+1. **Field projections** for the keystone (to discharge 807's leaves):
+   `.f = (toMonic core).monic` (⇒ `hf_lc`), `.factor` monic (⇒ `hfactor_monic`),
+   `.p = primeData.p` (⇒ `hp`), `.a = (toMonicLiftData …).k` (⇒ `hk`). The
+   keystone ends in `hsupp ▸ recoveredLiftOfToMonicRepresents …`; the fields are
+   transport-invariant (cf. `RecoveredLift.p_eqRec`/`a_eqRec`, LiftBridge.lean:767/773),
+   so add `f_eqRec`/`factor_eqRec` analogs + unfold the `recoveredLiftOf*` chain.
+2. `hsep`/`hthr` from the floor producers
+   `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le` /
+   `bhksCoeffCutThreshold_le_of_cldCoeffFloor_le` (CLDColumnBound.lean:1998/2020)
+   given `cldCoeffFloor core ≤ k'`.
+3. `hfac` from `toMonicLiftData_liftedFactor_hensel_semantics` (LiftBridge.lean:499).
+4. `hsize` from `factorFastCoreWithBound_some_size_eq_indicators` (449) +
+   `factorFastCoreWithBound_some_indicatorCandidates` (executable, public);
+   `hpartition` from `factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`
+   (480).
+5. **Determinism (the genuine remaining hard piece, deliverable 2):** extract the
+   accepted first-success precision `k'`, `rows_pos`, `hcandidates`, AND
+   `cldCoeffFloor core ≤ k'` from `h : factorFastCoreWithBound core B primeData
+   start fuel = some coreFactors`. The skill flags this as a strengthening of the
+   **private** executable `factorFastCoreWithBound_some_classifiedSuccess`
+   (HexBerlekampZassenhaus/Basic.lean:11890) to also expose the floor bound — an
+   executable-layer change (CrossCheck rebuild + the determinism-cluster cascade).
+6. **Outer (c)-branch wiring** into `h_raw`'s first disjunct, parallel to
+   `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift`
+   (PartitionRefinement.lean:2135); then combine with the already-landed
+   constant/singleton/quadratic/slow producers and close FactorSoundness:18
+   (adding `import …PartitionRefinement` to FactorSoundness).
+
+## Blockers
+
+None hard. Step 5 (determinism) is the largest remaining piece and touches the
+executable layer; steps 1-4 and 6 are assembly against existing producers.


### PR DESCRIPTION
This PR lands the separation-free keystone of the HO-1 correctness capstone: `recoveredLiftOfLiftedTrueSupport` produces the per-support `RecoveredLift` family for `liftedTrueSupports` directly from the membership witness (which carries `RepresentsIntegerFactorAtLift`), via the `monicCorrespondentDescent` extraction and `recoveredLiftOfToMonicRepresents` — with no `L'=W` separation and no dead raw-product equality. This is the `lift` argument of the period-trap-safe endpoint `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`, instantiated at `liftedTrueSupports`, so the fast BHKS-core arm of `factor_irreducible_of_nonUnit` closes via the forward cut alone (no #6779/#2564). Sorry-free; full library builds green.

🤖 Prepared with Claude Code