### PR TITLE
feat: determinism floor exposure + keystone field projections for fast-BHKS core (#8276)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -11892,7 +11892,7 @@ private theorem factorFastCoreWithBound_some_classifiedSuccess
     ∀ k fuel coreFactors,
       factorFastCoreWithBound core B primeData k fuel = some coreFactors →
         ∃ k', bhksRecoverClassified core (ZPoly.toMonicLiftData core k' primeData) =
-          .success coreFactors := by
+          .success coreFactors ∧ cldCoeffFloor core ≤ k' := by
   intro k fuel
   induction fuel generalizing k with
   | zero =>
@@ -11906,7 +11906,7 @@ private theorem factorFastCoreWithBound_some_classifiedSuccess
           by_cases hfloor : k ≥ cldCoeffFloor core
           · simp [hclass, hfloor] at hfast
             cases hfast
-            exact ⟨k, hclass⟩
+            exact ⟨k, hclass, hfloor⟩
           · by_cases hk : k ≥ B
             · simp [hclass, hfloor, hk] at hfast
             · simp [hclass, hfloor, hk] at hfast
@@ -11974,12 +11974,12 @@ theorem factorFastCoreWithBound_some_indicatorCandidates
                 (ZPoly.toMonicLiftData core k' primeData).liftedFactors)
               hrows)) =
         false ∧
-      Array.polyProduct coreFactors = core := by
-  obtain ⟨k', hsuccess⟩ :=
+      Array.polyProduct coreFactors = core ∧ cldCoeffFloor core ≤ k' := by
+  obtain ⟨k', hsuccess, hfloor⟩ :=
     factorFastCoreWithBound_some_classifiedSuccess core B primeData k fuel coreFactors h
   obtain ⟨hrows, hcand, hdeg⟩ :=
     bhksRecoverClassified_success_indicatorCandidates hsuccess
-  exact ⟨k', hrows, hcand, hdeg, bhksRecoverClassified_success_product hsuccess⟩
+  exact ⟨k', hrows, hcand, hdeg, bhksRecoverClassified_success_product hsuccess, hfloor⟩
 
 private theorem factorFastCoreWithBound_some_all_of_recovery
     (P : ZPoly → Prop)

--- a/HexBerlekampZassenhausMathlib/LiftBridge.lean
+++ b/HexBerlekampZassenhausMathlib/LiftBridge.lean
@@ -192,6 +192,80 @@ def recoveredLiftOfToMonicRepresents
   exact recoveredLiftOfRepresents M d S factor cofactor hM_monic hfactor
     hprecisionM hrep
 
+@[simp] theorem recoveredLiftOfToMonicRepresents_f
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData))
+    (factor cofactor : Hex.ZPoly)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hfactor : factor * cofactor = (Hex.ZPoly.toMonic core).monic)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k)
+    (hrep :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) factor S) :
+    (recoveredLiftOfToMonicRepresents core B primeData S factor cofactor
+      hcore_lc_pos hcore_pos hfactor hprecision hrep).f = (Hex.ZPoly.toMonic core).monic := by
+  simp [recoveredLiftOfToMonicRepresents, recoveredLiftOfRepresents, recoveredLiftOfSubset]
+
+@[simp] theorem recoveredLiftOfToMonicRepresents_p
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData))
+    (factor cofactor : Hex.ZPoly)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hfactor : factor * cofactor = (Hex.ZPoly.toMonic core).monic)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k)
+    (hrep :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) factor S) :
+    (recoveredLiftOfToMonicRepresents core B primeData S factor cofactor
+      hcore_lc_pos hcore_pos hfactor hprecision hrep).p =
+        (Hex.ZPoly.toMonicLiftData core B primeData).p := by
+  simp [recoveredLiftOfToMonicRepresents, recoveredLiftOfRepresents, recoveredLiftOfSubset]
+
+@[simp] theorem recoveredLiftOfToMonicRepresents_a
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData))
+    (factor cofactor : Hex.ZPoly)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hfactor : factor * cofactor = (Hex.ZPoly.toMonic core).monic)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k)
+    (hrep :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) factor S) :
+    (recoveredLiftOfToMonicRepresents core B primeData S factor cofactor
+      hcore_lc_pos hcore_pos hfactor hprecision hrep).a =
+        (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+  simp [recoveredLiftOfToMonicRepresents, recoveredLiftOfRepresents, recoveredLiftOfSubset]
+
+@[simp] theorem recoveredLiftOfToMonicRepresents_factor
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (S : LiftedFactorSubset (Hex.ZPoly.toMonicLiftData core B primeData))
+    (factor cofactor : Hex.ZPoly)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hfactor : factor * cofactor = (Hex.ZPoly.toMonic core).monic)
+    (hprecision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        (Hex.ZPoly.toMonicLiftData core B primeData).p ^
+          (Hex.ZPoly.toMonicLiftData core B primeData).k)
+    (hrep :
+      RepresentsIntegerFactorAtLift (Hex.ZPoly.toMonic core).monic
+        (Hex.ZPoly.toMonicLiftData core B primeData) factor S) :
+    (recoveredLiftOfToMonicRepresents core B primeData S factor cofactor
+      hcore_lc_pos hcore_pos hfactor hprecision hrep).factor = factor := by
+  simp [recoveredLiftOfToMonicRepresents, recoveredLiftOfRepresents, recoveredLiftOfSubset]
+
 /--
 Transport a represented monic-coordinate factor through `toMonic` and recover
 the original non-monic factor as the primitive-part carrier.
@@ -764,15 +838,27 @@ def recoveredLift_subtypeFamily_of_indicatorCandidates
 
 /-- Transport along a support equality leaves the `RecoveredLift.p` field
 unchanged: the field does not depend on the support index. -/
-private theorem RecoveredLift.p_eqRec {L : Hex.BhksLatticeBasis}
+@[simp] theorem RecoveredLift.p_eqRec {L : Hex.BhksLatticeBasis}
     {a b : LiftedFactorSupport L} (h : a = b) (x : RecoveredLift L a) :
     (h ▸ x).p = x.p := by subst h; rfl
 
 /-- Transport along a support equality leaves the `RecoveredLift.a` field
 unchanged: the field does not depend on the support index. -/
-private theorem RecoveredLift.a_eqRec {L : Hex.BhksLatticeBasis}
+@[simp] theorem RecoveredLift.a_eqRec {L : Hex.BhksLatticeBasis}
     {a b : LiftedFactorSupport L} (h : a = b) (x : RecoveredLift L a) :
     (h ▸ x).a = x.a := by subst h; rfl
+
+/-- Transport along a support equality leaves the `RecoveredLift.f` field
+unchanged: the field does not depend on the support index. -/
+@[simp] theorem RecoveredLift.f_eqRec {L : Hex.BhksLatticeBasis}
+    {a b : LiftedFactorSupport L} (h : a = b) (x : RecoveredLift L a) :
+    (h ▸ x).f = x.f := by subst h; rfl
+
+/-- Transport along a support equality leaves the `RecoveredLift.factor` field
+unchanged: the field does not depend on the support index. -/
+@[simp] theorem RecoveredLift.factor_eqRec {L : Hex.BhksLatticeBasis}
+    {a b : LiftedFactorSupport L} (h : a = b) (x : RecoveredLift L a) :
+    (h ▸ x).factor = x.factor := by subst h; rfl
 
 /-- The lift modulus base `p` of every member of the subtype-indexed
 recovered-lift family is the underlying lift data's prime base `d.p`. -/

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -1072,6 +1072,123 @@ noncomputable def recoveredLiftOfLiftedTrueSupport
       hsize_d hdesc.choose_spec.choose)
     hdesc.choose hgf_dvd.choose hcore_lc_pos hcore_pos hgf_dvd.choose_spec.symm hprecision hliftM
 
+/-- The lift modulus base `p` of the separation-free keystone recovered lift is
+the underlying `toMonicLiftData`'s prime base. -/
+@[simp] theorem recoveredLiftOfLiftedTrueSupport_p
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+      hcore_prim hB_ne_zero hbound U hU).p =
+        (Hex.ZPoly.toMonicLiftData core B primeData).p := by
+  unfold recoveredLiftOfLiftedTrueSupport
+  simp only [BHKS.ForwardRecoveryInputs.RecoveredLift.p_eqRec, BHKS.recoveredLiftOfToMonicRepresents_p]
+
+/-- The lift precision `a` of the separation-free keystone recovered lift is the
+underlying `toMonicLiftData`'s precision. -/
+@[simp] theorem recoveredLiftOfLiftedTrueSupport_a
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+      hcore_prim hB_ne_zero hbound U hU).a =
+        (Hex.ZPoly.toMonicLiftData core B primeData).k := by
+  unfold recoveredLiftOfLiftedTrueSupport
+  simp only [BHKS.ForwardRecoveryInputs.RecoveredLift.a_eqRec, BHKS.recoveredLiftOfToMonicRepresents_a]
+
+/-- The lift target `f` of the separation-free keystone recovered lift is the
+monic transform `(toMonic core).monic`. -/
+@[simp] theorem recoveredLiftOfLiftedTrueSupport_f
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+      hcore_prim hB_ne_zero hbound U hU).f = (Hex.ZPoly.toMonic core).monic := by
+  unfold recoveredLiftOfLiftedTrueSupport
+  simp only [BHKS.ForwardRecoveryInputs.RecoveredLift.f_eqRec, BHKS.recoveredLiftOfToMonicRepresents_f]
+
+/-- The recovered integer factor of the separation-free keystone lift is the
+monic correspondent descended from the witnessing factor, hence monic. -/
+theorem recoveredLiftOfLiftedTrueSupport_factor_denseMonic
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    Hex.DensePoly.Monic
+      (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+        hcore_prim hB_ne_zero hbound U hU).factor := by
+  classical
+  have hf_irr : Irreducible (HexPolyZMathlib.toPolynomial hU.choose) :=
+    hU.choose_spec.choose_spec.1
+  have hf_dvd : hU.choose ∣ core := hU.choose_spec.choose_spec.2.1
+  have hrep :
+      RepresentsIntegerFactorAtLift core (Hex.ZPoly.toMonicLiftData core B primeData)
+        hU.choose hU.choose_spec.choose :=
+    hU.choose_spec.choose_spec.2.2.1
+  have hdesc :=
+    IntReductionMod.monicCorrespondentDescent_of_representsAtLift core B primeData hselected
+      hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound hf_irr hf_dvd hrep
+  have hval :
+      (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+        hcore_prim hB_ne_zero hbound U hU).factor = hdesc.choose := by
+    unfold recoveredLiftOfLiftedTrueSupport
+    simp only [BHKS.ForwardRecoveryInputs.RecoveredLift.factor_eqRec,
+      BHKS.recoveredLiftOfToMonicRepresents_factor]
+  rw [hval]
+  exact hdesc.choose_spec.choose_spec.1
+
+/-- Mathlib-monic form of `recoveredLiftOfLiftedTrueSupport_factor_denseMonic`,
+the `hfactor_monic` leaf of the separation-free fast-core endpoint. -/
+theorem recoveredLiftOfLiftedTrueSupport_factor_monic
+    (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hB_ne_zero : B ≠ 0)
+    (hbound :
+      2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
+        primeData.p ^ Hex.precisionForCoeffBound B primeData.p)
+    (U : Set (LiftedFactorIndex (Hex.ZPoly.toMonicLiftData core B primeData)))
+    (hU : U ∈ liftedTrueSupports core (Hex.ZPoly.toMonicLiftData core B primeData)) :
+    (HexPolyMathlib.toPolynomial
+      (recoveredLiftOfLiftedTrueSupport core B primeData hselected hcore_lc_pos hcore_pos
+        hcore_prim hB_ne_zero hbound U hU).factor).Monic :=
+  HexHenselMathlib.toPolynomial_monic_of_dense_monic _
+    (recoveredLiftOfLiftedTrueSupport_factor_denseMonic core B primeData hselected
+      hcore_lc_pos hcore_pos hcore_prim hB_ne_zero hbound U hU)
+
 /-- Cardinality equality for a successful BHKS fast-core branch under the B8
 partition-refinement package.  Pairs `factorFastCoreWithBound_some_factor_count_le`
 with `factorFastCoreWithBound_some_factor_count_ge`, exposing the count

--- a/progress/20260621_085746_178bf5ad.md
+++ b/progress/20260621_085746_178bf5ad.md
@@ -1,0 +1,123 @@
+# Fast-BHKS core arm assembly toward factor_irreducible_of_nonUnit (#8276)
+
+Session type: feature (one-shot `/once`). UTC 2026-06-21T08:57.
+
+## Accomplished
+
+Landed two of the four deliverables of #8276 (the residual fast-BHKS
+multi-factor core arm of `factor_irreducible_of_nonUnit`), and diagnosed +
+numerically de-risked the central remaining obstacle.
+
+**Deliverable 3 — determinism floor exposure (the issue's "genuine hard
+remainder").** Strengthened the determinism extractors in
+`HexBerlekampZassenhaus/Basic.lean`:
+- `factorFastCoreWithBound_some_classifiedSuccess` (private) and
+  `factorFastCoreWithBound_some_indicatorCandidates` (public) now also conclude
+  `cldCoeffFloor core ≤ k'` for the accepted first-success precision `k'`.
+- The floor gate `hfloor : k ≥ cldCoeffFloor core` is already in scope at the
+  success-acceptance point of the loop induction (the #7951 gate); the change
+  just carries it into the existential. Two-line additive change; the only
+  consumer of `_some_classifiedSuccess` is its own re-exporter, and
+  `_some_indicatorCandidates` has no code consumers (only docstring mentions).
+
+**Deliverable 1 — keystone field projections (complete).**
+- `HexBerlekampZassenhausMathlib/LiftBridge.lean`: dropped `private` from
+  `RecoveredLift.p_eqRec`/`a_eqRec`, added `f_eqRec`/`factor_eqRec`
+  transport-invariance analogs (all `@[simp]`), and `@[simp]` projections
+  `recoveredLiftOfToMonicRepresents_{f,p,a,factor}`.
+- `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+  `recoveredLiftOfLiftedTrueSupport_{p,a,f}` (via `unfold` + the eqRec/projection
+  simp set), plus `recoveredLiftOfLiftedTrueSupport_factor_denseMonic`
+  (reconstructs the `monicCorrespondentDescent` to read `.factor = gf`) and its
+  Mathlib-monic form `recoveredLiftOfLiftedTrueSupport_factor_monic`.
+
+These directly supply the `hf_lc`/`hp`/`hk`/`hfactor_monic` leaves of the
+period-trap-safe endpoint
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`
+(`PartitionRefinement.lean:807`), and the `.f = (toMonic core).monic` projection
+bridges `hsep`/`hthr` (whose floor producers are stated over `(toMonic
+core).monic`).
+
+`lake build HexBerlekampZassenhausMathlib` green (3784 jobs) after both changes.
+
+## Current frontier — the central residual is now concrete and de-risked
+
+The separation-free endpoint (`:807`) takes the loop success `h` directly and
+sidesteps the false `hno`/cap-identification (the period trap of #7985/#7945).
+The remaining assembly instantiates `:807` at the **success precision `k'`**
+(not the cap `B`), with `trueSupports := liftedTrueSupports core (toMonicLiftData
+core k' primeData)` and `lift := recoveredLiftOfLiftedTrueSupport core k'
+primeData …`.
+
+**The linchpin obstacle (resolved as TRUE, not false).** Instantiating the
+keystone at `k'` requires its Mignotte precision hypothesis
+`hbound : 2 * defaultFactorCoeffBound (toMonic core).monic < primeData.p ^
+precisionForCoeffBound k' primeData.p`. Via `precisionForCoeffBound_spec` this
+needs `defaultFactorCoeffBound (toMonic core).monic ≤ k'`, and the floor gate
+gives only `cldCoeffFloor core ≤ k'`. So the route needs:
+
+    defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor core    (★)
+
+Prior skill lore feared the floor gate certifies only CLD **column** adequacy
+(hsep/hthr), not Mignotte **recovery** precision. **(★) shows it certifies both.**
+Numerically verified true on every test core (`/tmp/FloorCheck.lean`, pure-integer
+`#eval`), margin growing with degree:
+
+| core | defaultFactorCoeffBound(M) | cldCoeffFloor | ratio |
+|------|---------------------------|---------------|-------|
+| (x-2)(x-3) | 16 | 32 | 2× |
+| (x-1)…(x-4) | 402 | 1608 | 4× |
+| (x-1)…(x-6) | 52320 | 313920 | 6× |
+| (x-1)…(x-8) | 12646550 | 101172400 | 8× |
+| 3(x-2)(x-3) | 114 | 228 | 2× |
+| (x-10)(x-11)(x+12) | 3984 | 15936 | 4× |
+
+**Structural reduction of (★).** With `L = coeffL2NormBound M`, `n = M.degree`:
+- `mignotteCoeffBound M k j = binom k j · L`, so
+  `defaultFactorCoeffBound M = L · max_{k≤n, j≤k} binom k j = L · binom n ⌊n/2⌋`.
+- `bhksCoeffBound M j = choose(n-1) j · n · L`, so
+  `cldCoeffFloor core = 2nL · max_{j≤n} choose(n-1,j)`.
+
+So (★) ⇔ `binom n ⌊n/2⌋ ≤ 2n · choose(n-1, ⌊(n-1)/2⌋)` — a central-binomial
+inequality, true with the `2n` factor providing large slack. Provable per-term:
+`mignotteCoeffBound M k j = choose k j · L ≤ choose n j · L` (`Nat.choose_le_choose`,
+plus the `Hex.Nat.choose`/`binom` shadow bridge), then `choose n j ≤ 2n·choose(n-1,j)`
+(from `choose n j · (n-j) = n · choose(n-1,j)`), bounded below by a floor term
+via `le_foldl_max_of_mem`. Foldl-max infra already exists in
+`HexPolyZ/Mignotte.lean:601-660` (`le_foldl_max_left`, `le_foldl_max_of_mem`,
+the nested-foldl restatement at `:528`).
+
+## Next step (the remaining ~3 pieces, in order)
+
+1. **Prove (★)** `defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor
+   core` (number-theoretic; the reduction above; ~100-150 lines with the
+   binom/choose shadow + foldl-max plumbing). This is the new "real work"; a
+   good standalone sub-issue.
+2. **Self-contained multi-factor producer** parallel to
+   `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift`
+   (`PartitionRefinement.lean:2226`) but discharging all open hypotheses from
+   core facts at precision `k'`: extract `k'`/`rows_pos`/`hcandidates`/floor from
+   the loop success (the now-floor-exposing extractor), build the `lift` family
+   from `recoveredLiftOfLiftedTrueSupport core k' …`, discharge leaves via the
+   step-1 projections + `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le` /
+   `bhksCoeffCutThreshold_le_of_cldCoeffFloor_le` (`CLDColumnBound:1998/2020`,
+   hsep/hthr), `toMonicLiftData_liftedFactor_hensel_semantics` (`LiftBridge:499`,
+   hfac), `factorFastCoreWithBound_some_size_eq_indicators` (`:449`, hsize),
+   `factorFastCoreWithBound_some_partition_eq_normalizedFactors_card` (`:480`,
+   hpartition), and `hbound`-at-`k'` via (★). Note the index alignment
+   `liftedTrueSupports core d : Set (Set (LiftedFactorIndex d))` ≡ projected-row
+   `factorCount` index is definitional (the `:480` producer relies on it).
+3. **Dispatch + close.** Produce `h_raw` of `factor_entries_irreducible`
+   (`HexBerlekampZassenhausMathlib/Basic.lean:443`) by case-splitting the fast
+   disjunct (constant `factorFastFactorsWithBound_raw_irreducible_of_constant`,
+   small-mod-singleton `…_of_smallModSingleton`, quadratic `…_of_quadratic`,
+   multi-factor = the new producer) and routing the two slow disjuncts to their
+   `…_of_fast_none` producers; then
+   `factor_irreducible_of_nonUnit f := fun e he => factor_entries_irreducible f
+   h_raw e he`, adding `import …PartitionRefinement` to `FactorSoundness`.
+
+## Blockers
+
+None hard. (★) is true (verified) but unproven; it is the gating lemma for the
+keystone's `hbound` at the success precision. No `sorry`/`axiom`/`native_decide`
+introduced; the route remains separation-free (no #6779/#2564).


### PR DESCRIPTION
This PR lands two of the four deliverables of #8276 — the residual fast-BHKS multi-factor core arm of `factor_irreducible_of_nonUnit` — and reduces the remaining work to one concrete, numerically-verified inequality plus mechanical assembly.

Deliverable 3 (the issue's "genuine hard remainder"): expose the CLD-adequacy floor from a fast-core loop success. `factorFastCoreWithBound_some_classifiedSuccess` and `factorFastCoreWithBound_some_indicatorCandidates` (`HexBerlekampZassenhaus/Basic.lean`) now additionally conclude `cldCoeffFloor core ≤ k'` for the accepted first-success precision `k'`. The #7951 floor gate already puts `hfloor : k ≥ cldCoeffFloor core` in scope at the success-acceptance point of the loop induction; this carries it into the existential. The only consumer of the private `_classifiedSuccess` is its own re-exporter, and `_indicatorCandidates` has no code consumers, so the change is additive.

Deliverable 1 (complete): the `.f`/`.p`/`.a`/`.factor` field projections of the separation-free keystone `recoveredLiftOfLiftedTrueSupport`. `HexBerlekampZassenhausMathlib/LiftBridge.lean` exposes `RecoveredLift.p_eqRec`/`a_eqRec` (drops `private`), adds `f_eqRec`/`factor_eqRec` transport-invariance analogs (all `@[simp]`), and `@[simp]` projections `recoveredLiftOfToMonicRepresents_{f,p,a,factor}`. `HexBerlekampZassenhausMathlib/PartitionRefinement.lean` adds `recoveredLiftOfLiftedTrueSupport_{p,a,f}` and the `.factor`-monic pair `recoveredLiftOfLiftedTrueSupport_factor_denseMonic`/`recoveredLiftOfLiftedTrueSupport_factor_monic` (which reconstructs the `monicCorrespondentDescent` to read `.factor = gf`). These directly supply the `hf_lc`/`hp`/`hk`/`hfactor_monic` leaves of the period-trap-safe endpoint `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`, and the `.f = (toMonic core).monic` projection bridges `hsep`/`hthr`.

`lake build HexBerlekampZassenhausMathlib` is green (3784 jobs). No `sorry`/`axiom`/`native_decide`; the route stays separation-free (no #6779/#2564).

What remains (steps 2 and 4), with the central obstacle now resolved as true rather than false: instantiating the keystone at the success precision `k'` needs its Mignotte hypothesis `2·defaultFactorCoeffBound (toMonic core).monic < primeData.p ^ precisionForCoeffBound k' primeData.p`, which via `precisionForCoeffBound_spec` reduces to `defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor core` (★). Prior lore feared the floor gate certifies only CLD column adequacy, not Mignotte recovery precision; (★) shows it certifies both. (★) is numerically verified on every test core (margin 2×→8×, growing with degree) and reduces structurally to a central-binomial inequality `binom n ⌊n/2⌋ ≤ 2n·choose(n-1,⌊(n-1)/2⌋)`, true with large slack — a clean standalone lemma to prove next. After (★): a self-contained multi-factor producer parallel to `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift` (`PartitionRefinement.lean:2226`) discharging all open hypotheses at `k'` (lift family from the keystone, leaves from the step-1 projections plus the named producers `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le`/`bhksCoeffCutThreshold_le_of_cldCoeffFloor_le`/`toMonicLiftData_liftedFactor_hensel_semantics`/`factorFastCoreWithBound_some_size_eq_indicators`/`factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`); then the fast-disjunct dispatch into `factor_entries_irreducible`'s `h_raw` and the final close of `FactorSoundness.lean:18`. The progress note `progress/20260621_085746_178bf5ad.md` records the full reduction.

🤖 Prepared with Claude Code
