### PR TITLE
feat: (★) defaultFactorCoeffBound_toMonic_le_cldCoeffFloor floor gate for fast-BHKS core

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -1990,6 +1990,106 @@ theorem two_mul_bhksCoeffBound_le_cldCoeffFloor (core : Hex.ZPoly) (j : Nat) :
   simp only [Hex.cldCoeffFloor]
   omega
 
+/-- One Pascal step bounds a central binomial of row `m + 1` by twice the central
+binomial of row `m`: `C(m+1, ⌊(m+1)/2⌋) ≤ 2 · C(m, ⌊m/2⌋)`.  The two Pascal
+summands of the row-`m+1` central entry are each at most the row-`m` middle
+binomial. -/
+private theorem choose_central_succ_le (m : Nat) :
+    Nat.choose (m + 1) ((m + 1) / 2) ≤ 2 * Nat.choose m (m / 2) := by
+  rcases Nat.eq_zero_or_pos ((m + 1) / 2) with hr | hr
+  · rw [hr, Nat.choose_zero_right]
+    have hpos : 0 < Nat.choose m (m / 2) := Nat.choose_pos (Nat.div_le_self m 2)
+    omega
+  · obtain ⟨s, hs⟩ := Nat.exists_eq_succ_of_ne_zero hr.ne'
+    rw [hs, Nat.choose_succ_succ' m s]
+    have h1 : Nat.choose m s ≤ Nat.choose m (m / 2) := Nat.choose_le_middle s m
+    have h2 : Nat.choose m (s + 1) ≤ Nat.choose m (m / 2) := Nat.choose_le_middle (s + 1) m
+    omega
+
+/-- Central-binomial descent across the `n`/`n-1` row boundary: for `n ≥ 1`,
+`C(n, ⌊n/2⌋) ≤ 2 · C(n-1, ⌊(n-1)/2⌋)`.  This is `choose_central_succ_le` after
+`n = (n-1) + 1`. -/
+private theorem choose_central_pred (n : Nat) (hn : 1 ≤ n) :
+    Nat.choose n (n / 2) ≤ 2 * Nat.choose (n - 1) ((n - 1) / 2) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := Nat.exists_eq_succ_of_ne_zero (by omega)
+  simpa using choose_central_succ_le m
+
+/-- Every binomial coefficient `C(k, j)` with `k ≤ n` is bounded by
+`2 · C(n-1, ⌊(n-1)/2⌋) · n` (for `n ≥ 1`).  Chain: monotonicity in the upper
+index (`k ≤ n`), the row-`n` middle bound, the central-binomial descent across
+the row boundary, then the slack factor `n`.  (No `j ≤ k` premise is needed: the
+row-middle bound caps every column.) -/
+private theorem choose_le_two_mul_central_pred_mul (n k j : Nat)
+    (hn : 1 ≤ n) (hk : k ≤ n) :
+    Nat.choose k j ≤ 2 * Nat.choose (n - 1) ((n - 1) / 2) * n :=
+  calc Nat.choose k j
+        ≤ Nat.choose n j := Nat.choose_le_choose j hk
+    _ ≤ Nat.choose n (n / 2) := Nat.choose_le_middle j n
+    _ ≤ 2 * Nat.choose (n - 1) ((n - 1) / 2) := choose_central_pred n hn
+    _ ≤ 2 * Nat.choose (n - 1) ((n - 1) / 2) * n := Nat.le_mul_of_pos_right _ hn
+
+/-- Abstract per-term core of `mignotteCoeffBound_toMonic_le_cldCoeffFloor`: any
+polynomial `M` of positive degree whose per-coordinate doubled BHKS bounds are
+dominated by `cldCoeffFloor core` also dominates each in-range executable Mignotte
+coefficient bound.  Bounding `binom k j` by `2 · C(n-1, ⌊(n-1)/2⌋) · n` and
+recognising the right side as `2 · bhksCoeffBound` at the central index closes the
+gap. -/
+private theorem mignotteCoeffBound_le_floor_aux (M core : Hex.ZPoly)
+    (hMfloor : ∀ j, 2 * Hex.bhksCoeffBound M j ≤ Hex.cldCoeffFloor core)
+    (hn : 1 ≤ M.degree?.getD 0) {k j : Nat}
+    (hk : k ≤ M.degree?.getD 0) :
+    Hex.ZPoly.mignotteCoeffBound M k j ≤ Hex.cldCoeffFloor core := by
+  rw [Hex.ZPoly.mignotteCoeffBound_eq]
+  have hbinom : Hex.ZPoly.binom k j ≤
+      2 * Nat.choose (M.degree?.getD 0 - 1) ((M.degree?.getD 0 - 1) / 2) *
+        M.degree?.getD 0 := by
+    rw [HexPolyZMathlib.binom_eq_choose]
+    exact choose_le_two_mul_central_pred_mul (M.degree?.getD 0) k j hn hk
+  have hbhks : Hex.bhksCoeffBound M ((M.degree?.getD 0 - 1) / 2)
+      = Nat.choose (M.degree?.getD 0 - 1) ((M.degree?.getD 0 - 1) / 2) *
+          M.degree?.getD 0 * Hex.ZPoly.coeffL2NormBound M := by
+    simp only [Hex.bhksCoeffBound, hex_choose_eq]
+  calc Hex.ZPoly.binom k j * Hex.ZPoly.coeffL2NormBound M
+        ≤ (2 * Nat.choose (M.degree?.getD 0 - 1) ((M.degree?.getD 0 - 1) / 2) *
+            M.degree?.getD 0) * Hex.ZPoly.coeffL2NormBound M :=
+          Nat.mul_le_mul_right _ hbinom
+    _ = 2 * (Nat.choose (M.degree?.getD 0 - 1) ((M.degree?.getD 0 - 1) / 2) *
+            M.degree?.getD 0 * Hex.ZPoly.coeffL2NormBound M) := by ring
+    _ = 2 * Hex.bhksCoeffBound M ((M.degree?.getD 0 - 1) / 2) := by rw [hbhks]
+    _ ≤ Hex.cldCoeffFloor core := hMfloor _
+
+/-- Each in-range executable Mignotte coefficient bound of the monic transform
+`(toMonic core).monic` is dominated by the CLD column-adequacy floor. -/
+theorem mignotteCoeffBound_toMonic_le_cldCoeffFloor (core : Hex.ZPoly) {k j : Nat}
+    (hn : 1 ≤ (Hex.ZPoly.toMonic core).monic.degree?.getD 0)
+    (hk : k ≤ (Hex.ZPoly.toMonic core).monic.degree?.getD 0) :
+    Hex.ZPoly.mignotteCoeffBound (Hex.ZPoly.toMonic core).monic k j ≤
+      Hex.cldCoeffFloor core :=
+  mignotteCoeffBound_le_floor_aux (Hex.ZPoly.toMonic core).monic core
+    (two_mul_bhksCoeffBound_le_cldCoeffFloor core) hn hk
+
+/-- **(★) The Mignotte recovery bound is certified by the CLD column-adequacy
+floor.**  For any `core` of positive degree,
+`defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor core`.
+
+This is the gating lemma that lets the fast-core multi-factor producer instantiate
+the keystone's Mignotte precision hypothesis at the loop's *success* precision
+`k'` from the floor gate `cldCoeffFloor core ≤ k'` alone: the floor certifies not
+only CLD column adequacy (`hsep`/`hthr`) but the full Mignotte recovery precision.
+
+The positive-degree premise is essential.  At degree `0` the monic transform is a
+nonzero constant with `cldCoeffFloor core = 0` (the `bhksCoeffBound` degree factor
+`n` vanishes) while `defaultFactorCoeffBound` is the positive coefficient norm, so
+the inequality fails; the multi-factor core arm always supplies positive degree. -/
+theorem defaultFactorCoeffBound_toMonic_le_cldCoeffFloor (core : Hex.ZPoly)
+    (hpos : 0 < core.degree?.getD 0) :
+    Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic ≤
+      Hex.cldCoeffFloor core := by
+  have hn : 1 ≤ (Hex.ZPoly.toMonic core).monic.degree?.getD 0 := by
+    rw [Hex.ZPoly.toMonic_monic_degree_getD]; omega
+  exact Hex.ZPoly.defaultFactorCoeffBound_le _
+    (fun k hk _j _hj => mignotteCoeffBound_toMonic_le_cldCoeffFloor core hn hk)
+
 /-- The BHKS separation `hsep` follows from the CLD-adequacy gate
 `cldCoeffFloor core ≤ k`: at the lift precision `precisionForCoeffBound k p`
 the modulus `p ^ a` clears `2 · bhksCoeffBound (toMonic core).monic j` for every

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -710,6 +710,49 @@ theorem coeffL2NormBound_le_defaultFactorCoeffBound (f : ZPoly) :
     (mignotteCoeffBound_le_defaultFactorCoeffBound f
       (k := 0) (j := 0) (Nat.zero_le _) (Nat.zero_le _))
 
+/-- A maximizing natural-number `foldl` is bounded above by any value `B` that
+dominates the seed and every `g x` at a member index. -/
+private theorem foldl_max_le_of_forall {α : Type} (g : α → Nat) (B : Nat) :
+    ∀ (xs : List α) (init : Nat), init ≤ B → (∀ x ∈ xs, g x ≤ B) →
+      xs.foldl (fun acc x => max acc (g x)) init ≤ B := by
+  intro xs
+  induction xs with
+  | nil => intro init hinit _; exact hinit
+  | cons x xs ih =>
+      intro init hinit hall
+      simp only [List.foldl_cons]
+      exact ih (max init (g x))
+        (Nat.max_le.mpr ⟨hinit, hall x (List.mem_cons.mpr (Or.inl rfl))⟩)
+        (fun y hy => hall y (List.mem_cons.mpr (Or.inr hy)))
+
+/-- Upper-bound companion of `mignotteCoeffBound_le_defaultFactorCoeffBound`: if
+every executable Mignotte coefficient bound within the ambient degree range is at
+most `B`, then so is the default uniform factor coefficient bound. -/
+theorem defaultFactorCoeffBound_le (f : ZPoly) {B : Nat}
+    (h : ∀ k, k ≤ f.degree?.getD 0 → ∀ j, j ≤ k → mignotteCoeffBound f k j ≤ B) :
+    defaultFactorCoeffBound f ≤ B := by
+  unfold defaultFactorCoeffBound
+  have outer : ∀ (ks : List Nat) (init : Nat), init ≤ B →
+      (∀ k ∈ ks, ∀ j, j ≤ k → mignotteCoeffBound f k j ≤ B) →
+      ks.foldl
+        (fun acc k =>
+          (List.range (k + 1)).foldl
+            (fun acc j => max acc (mignotteCoeffBound f k j)) acc)
+        init ≤ B := by
+    intro ks
+    induction ks with
+    | nil => intro init hinit _; exact hinit
+    | cons k ks ih =>
+        intro init hinit hall
+        simp only [List.foldl_cons]
+        refine ih _ ?_ (fun k' hk' j hj => hall k' (List.mem_cons.mpr (Or.inr hk')) j hj)
+        exact foldl_max_le_of_forall (fun j => mignotteCoeffBound f k j) B
+          (List.range (k + 1)) init hinit
+          (fun j hj => hall k (List.mem_cons.mpr (Or.inl rfl)) j
+            (Nat.lt_succ_iff.mp (List.mem_range.mp hj)))
+  exact outer (List.range (f.degree?.getD 0 + 1)) 0 (Nat.zero_le _)
+    (fun k hk j hj => h k (Nat.lt_succ_iff.mp (List.mem_range.mp hk)) j hj)
+
 /-- An additive natural-number `foldl` only increases (or preserves) its
 accumulator. -/
 private theorem le_foldl_add_self {α : Type} (xs : List α) (g : α → Nat)

--- a/progress/20260621T093230Z_3132bd01.md
+++ b/progress/20260621T093230Z_3132bd01.md
@@ -1,0 +1,61 @@
+# (★) floor gate landed; multi-factor producer + dispatch decomposed (#8280 → #8282)
+
+Session type: one-shot `/once` on #8280 (work). UTC 2026-06-21.
+
+## Accomplished
+
+**Step 1 of #8280 — the gating lemma (★), proved and committed.**
+`HexBerlekampZassenhausMathlib.BHKS.defaultFactorCoeffBound_toMonic_le_cldCoeffFloor`
+(`HexBerlekampZassenhausMathlib/CLDColumnBound.lean`): for any `core` of positive
+degree, `defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor core`. This
+is the leaf that lets the fast-core multi-factor producer instantiate the
+keystone's Mignotte precision hypothesis at the loop **success** precision `k'`
+from the floor gate `cldCoeffFloor core ≤ k'` alone.
+
+Supporting lemmas:
+- `Hex.ZPoly.defaultFactorCoeffBound_le` (`HexPolyZ/Mignotte.lean`, Mathlib-free):
+  upper-bound companion of `mignotteCoeffBound_le_defaultFactorCoeffBound` — if
+  every in-range `mignotteCoeffBound` term is ≤ B then so is the nested
+  max-fold. Pure Nat fold induction (`foldl_max_le_of_forall`).
+- `choose_central_succ_le` / `choose_central_pred` (CLDColumnBound.lean,
+  private): the central-binomial descent `C(n,⌊n/2⌋) ≤ 2·C(n-1,⌊(n-1)/2⌋)` via
+  one Pascal step + `Nat.choose_le_middle`.
+- `mignotteCoeffBound_toMonic_le_cldCoeffFloor`: each in-range Mignotte term is
+  dominated by the floor. Reduction `binom k j ≤ choose n (n/2) ≤
+  2·C(n-1,⌊(n-1)/2⌋)`, recognised as `2·bhksCoeffBound` at the central index,
+  closed by the existing `two_mul_bhksCoeffBound_le_cldCoeffFloor`.
+
+`lake build HexBerlekampZassenhausMathlib.CLDColumnBound` green (3771 jobs); no
+new warnings on the added code.
+
+**Premise correction (recorded on #8280 and #8282).** The issue stated (★)
+unconditionally. It is **false at degree 0**: the monic transform of a constant
+core is a nonzero constant with `cldCoeffFloor core = 0` (the `bhksCoeffBound`
+degree factor `n` vanishes) while `defaultFactorCoeffBound` is the positive
+coefficient norm. (★) is proved with the `0 < core.degree?.getD 0` premise,
+which the multi-factor core arm always supplies (`recoveredLiftOfLiftedTrueSupport`,
+`factorFastCore_irreducible_of_monicRecoveredLift` both carry `hcore_pos`).
+
+## Current frontier
+
+Steps 2 (self-contained multi-factor producer at `k'`) and 3 (`h_raw` dispatch +
+close the headline `sorry`) are a large assembly: the producer must discharge
+~10 obligations (`hf_lc`/`hfactor_monic`/`hp`/`hk`/`hsep`/`hthr`/`hfac`/`hsize`/
+`hpartition`/`hbound`) with precise index-type alignment, and the dispatch
+case-splits four fast sub-branches plus two slow branches. Since each commit must
+compile, attempting this in the remainder of one session risks a broken
+intermediate state. Decomposed into **#8282** (`depends-on: #8280`), which carries
+the full step-by-step skeleton with every producer's file/line.
+
+## Next step
+
+Land this partial PR for #8280 (step 1). Planner closes #8280 with a forward
+link to #8282; #8282 unblocks on closure. Then execute #8282 starting from the
+floor-exposing extractor `factorFastCoreWithBound_some_indicatorCandidates` and
+the keystone `recoveredLiftOfLiftedTrueSupport` at `k'`, with `hbound` now
+derivable via (★).
+
+## Blockers
+
+None. (★) is the only genuinely new number theory; it is done. The rest is
+assembly against existing producers, captured in #8282.


### PR DESCRIPTION
This PR proves (★) `defaultFactorCoeffBound_toMonic_le_cldCoeffFloor`: for any `core` of positive degree, `defaultFactorCoeffBound (toMonic core).monic ≤ cldCoeffFloor core`. This is the gating lemma for the fast-BHKS multi-factor core arm of `factor_irreducible_of_nonUnit` (#8280): the CLD column-adequacy floor certifies not only column adequacy (`hsep`/`hthr`) but the full Mignotte recovery precision, so the loop's success precision `k'` gated by `cldCoeffFloor core ≤ k'` also clears the keystone's Mignotte hypothesis.

The reduction bounds each in-range `mignotteCoeffBound` term `binom k j * L` via the central-binomial chain `choose k j ≤ choose n (n/2) ≤ 2·choose(n-1, ⌊(n-1)/2⌋)` (one Pascal step plus `Nat.choose_le_middle`), recognises the right side as `2·bhksCoeffBound` at the central index, and closes the gap with the existing `two_mul_bhksCoeffBound_le_cldCoeffFloor`. The Mathlib-free upper-bound companion `Hex.ZPoly.defaultFactorCoeffBound_le` is added to `HexPolyZ/Mignotte.lean`; the central-binomial descent and (★) itself live in `CLDColumnBound.lean`.

The issue stated (★) unconditionally, but it is false at degree 0 (the monic transform of a constant core is a nonzero constant with `cldCoeffFloor core = 0` while `defaultFactorCoeffBound` is the positive coefficient norm); it is proved with the `0 < core.degree?.getD 0` premise the multi-factor arm always supplies. This is step 1 of #8280; the remaining assembly (the self-contained multi-factor producer at `k'` and the `h_raw` dispatch that closes the headline `sorry`) is captured as #8282.

🤖 Prepared with Claude Code