### PR TITLE
feat: (★★) un-monic CLD floor bridge unblocking fast-BHKS multi-factor producer

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2090,6 +2090,161 @@ theorem defaultFactorCoeffBound_toMonic_le_cldCoeffFloor (core : Hex.ZPoly)
   exact Hex.ZPoly.defaultFactorCoeffBound_le _
     (fun k hk _j _hj => mignotteCoeffBound_toMonic_le_cldCoeffFloor core hn hk)
 
+/-- `List.range`-`foldl` addition rewritten as a `Finset.range` sum (local copy of
+the private BHKSBound helper). -/
+private theorem range_foldl_add_eq_finset_sum (g : Nat → Nat) (m : Nat) :
+    (List.range m).foldl (fun acc i => acc + g i) 0 = ∑ i ∈ Finset.range m, g i := by
+  induction m with
+  | zero => simp
+  | succ k ih =>
+      rw [List.range_succ, List.foldl_append, ih, Finset.sum_range_succ]
+      simp
+
+/-- **(★★) norm leaf.**  For a core with nonzero constant term and degree `≥ 2`,
+the executable squared coefficient norm does not exceed that of its monic
+transform: the monic transform inflates each low coefficient by a power of the
+leading coefficient, and the nonzero constant term lets the inflated bottom
+coefficient absorb the leading-coefficient deficit at the top. -/
+private theorem coeffNormSq_le_toMonic_monic_of_const_degree (core : Hex.ZPoly)
+    (hconst : core.coeff 0 ≠ 0) (hn : 2 ≤ core.degree?.getD 0) :
+    Hex.ZPoly.coeffNormSq core ≤
+      Hex.ZPoly.coeffNormSq (Hex.ZPoly.toMonic core).monic := by
+  classical
+  by_cases hlc1 : Hex.DensePoly.leadingCoeff core = 1
+  · rw [Hex.ZPoly.toMonic_monic_eq_core_of_leadingCoeff_eq_one core hlc1]
+  · set n := core.degree?.getD 0 with hn_def
+    have hcore_ne : core ≠ 0 := fun h => hconst (by rw [h]; rfl)
+    have hsize_pos : 0 < core.size := Hex.ZPoly.size_pos_of_ne_zero core hcore_ne
+    have hn_size : n = core.size - 1 := by
+      simp [hn_def, Hex.DensePoly.degree?, Nat.ne_of_gt hsize_pos]
+    have hcoresize : core.size = n + 1 := by omega
+    have hmonsize : (Hex.ZPoly.toMonic core).monic.size = n + 1 :=
+      Hex.ZPoly.toMonic_monic_size_of_pos_degree core (by omega)
+    set L := Hex.DensePoly.leadingCoeff core with hL_def
+    have hL_ne : L ≠ 0 := Hex.ZPoly.leadingCoeff_ne_zero_of_ne_zero core hcore_ne
+    have hsizeidx : core.size - 1 = n := by omega
+    have hcore_top : core.coeff n = L := by
+      rw [hL_def, Hex.DensePoly.leadingCoeff_eq_coeff_last core hsize_pos, hsizeidx]
+    have hmon_coeff : ∀ i, (Hex.ZPoly.toMonic core).monic.coeff i =
+        if i < n then core.coeff i * L ^ (n - 1 - i) else if i = n then 1 else 0 := by
+      intro i
+      rw [Hex.ZPoly.toMonic_monic_coeff_of_leadingCoeff_ne_one core hlc1 i]
+    -- convert both norms to `Finset.range` sums
+    rw [Hex.ZPoly.coeffNormSq_eq_sum, Hex.ZPoly.coeffNormSq_eq_sum, hcoresize, hmonsize,
+      range_foldl_add_eq_finset_sum, range_foldl_add_eq_finset_sum]
+    -- peel the top index `n`
+    rw [Finset.sum_range_succ (fun i => (core.coeff i).natAbs ^ 2) n,
+      Finset.sum_range_succ
+        (fun i => ((Hex.ZPoly.toMonic core).monic.coeff i).natAbs ^ 2) n]
+    -- top terms: `core.coeff n = L`, `monic.coeff n = 1`
+    have hc_top : (core.coeff n).natAbs ^ 2 = L.natAbs ^ 2 := by rw [hcore_top]
+    have hm_top : ((Hex.ZPoly.toMonic core).monic.coeff n).natAbs ^ 2 = 1 := by
+      rw [hmon_coeff n]; simp
+    rw [hc_top, hm_top]
+    set l := L.natAbs with hl_def
+    have hlpos : 1 ≤ l := Int.natAbs_pos.mpr hL_ne
+    -- per-index domination on `(range n).erase 0`
+    have h0mem : (0 : Nat) ∈ Finset.range n := Finset.mem_range.mpr (by omega)
+    have hcmono : ∀ i ∈ (Finset.range n).erase 0,
+        (core.coeff i).natAbs ^ 2 ≤
+          ((Hex.ZPoly.toMonic core).monic.coeff i).natAbs ^ 2 := by
+      intro i hi
+      have hilt : i < n := Finset.mem_range.mp (Finset.mem_of_mem_erase hi)
+      rw [hmon_coeff i, if_pos hilt, Int.natAbs_mul, mul_pow, Int.natAbs_pow, ← pow_mul]
+      exact Nat.le_mul_of_pos_right _ (pow_pos (by omega : (0 : Nat) < l) _)
+    -- bottom boost: `monic.coeff 0 = core.coeff 0 * L ^ (n-1)`
+    have hm0 : ((Hex.ZPoly.toMonic core).monic.coeff 0).natAbs ^ 2 =
+        (core.coeff 0).natAbs ^ 2 * l ^ (2 * (n - 1)) := by
+      rw [hmon_coeff 0, if_pos (by omega : 0 < n), Int.natAbs_mul, mul_pow, Int.natAbs_pow,
+        ← pow_mul, hl_def]
+      congr 2; omega
+    have hnum : (core.coeff 0).natAbs ^ 2 + l ^ 2 ≤
+        ((Hex.ZPoly.toMonic core).monic.coeff 0).natAbs ^ 2 + 1 := by
+      rw [hm0]
+      set c0 := (core.coeff 0).natAbs with hc0_def
+      have hc0pos : 1 ≤ c0 := Int.natAbs_pos.mpr hconst
+      have hA : 1 ≤ c0 ^ 2 := Nat.one_le_pow _ _ (by omega)
+      have hB : 1 ≤ l ^ 2 := Nat.one_le_pow _ _ (by omega)
+      have hpow : l ^ 2 ≤ l ^ (2 * (n - 1)) := Nat.pow_le_pow_right (by omega) (by omega)
+      have step1 : c0 ^ 2 * l ^ 2 ≤ c0 ^ 2 * l ^ (2 * (n - 1)) :=
+        Nat.mul_le_mul_left _ hpow
+      have step2 : c0 ^ 2 + l ^ 2 ≤ c0 ^ 2 * l ^ 2 + 1 := by
+        obtain ⟨B', hB'⟩ : ∃ B', l ^ 2 = B' + 1 := ⟨l ^ 2 - 1, by omega⟩
+        have hexp : c0 ^ 2 * (B' + 1) = c0 ^ 2 * B' + c0 ^ 2 := by ring
+        have hle : B' ≤ c0 ^ 2 * B' := Nat.le_mul_of_pos_left B' (by omega)
+        rw [hB', hexp]; omega
+      exact le_trans step2 (Nat.add_le_add_right step1 1)
+    -- assemble: split off index `0` from both `range n` sums
+    rw [← Finset.add_sum_erase _ (fun i => (core.coeff i).natAbs ^ 2) h0mem,
+      ← Finset.add_sum_erase _
+        (fun i => ((Hex.ZPoly.toMonic core).monic.coeff i).natAbs ^ 2) h0mem]
+    have hsum_erase :
+        ∑ i ∈ (Finset.range n).erase 0, (core.coeff i).natAbs ^ 2 ≤
+          ∑ i ∈ (Finset.range n).erase 0,
+            ((Hex.ZPoly.toMonic core).monic.coeff i).natAbs ^ 2 :=
+      Finset.sum_le_sum hcmono
+    omega
+
+/-- **(★★) norm bound.**  The executable Euclidean-norm bound of a positive-degree
+core with nonzero constant term does not exceed that of its monic transform. -/
+theorem coeffL2NormBound_le_toMonic_monic_of_const_degree (core : Hex.ZPoly)
+    (hconst : core.coeff 0 ≠ 0) (hn : 2 ≤ core.degree?.getD 0) :
+    Hex.ZPoly.coeffL2NormBound core ≤
+      Hex.ZPoly.coeffL2NormBound (Hex.ZPoly.toMonic core).monic := by
+  rw [Hex.ZPoly.coeffL2NormBound_eq_ceilSqrt_coeffNormSq core]
+  apply ceilSqrt_le_of_le_sq
+  calc Hex.ZPoly.coeffNormSq core
+        ≤ Hex.ZPoly.coeffNormSq (Hex.ZPoly.toMonic core).monic :=
+          coeffNormSq_le_toMonic_monic_of_const_degree core hconst hn
+    _ ≤ (Hex.ZPoly.coeffL2NormBound (Hex.ZPoly.toMonic core).monic) ^ 2 := by
+          rw [Hex.ZPoly.coeffL2NormBound_eq_ceilSqrt_coeffNormSq]
+          exact Hex.ZPoly.le_ceilSqrt_sq _
+
+/-- **(★★) The un-monic Mignotte recovery bound is certified by the CLD
+column-adequacy floor.**  For a core with nonzero constant term and degree `≥ 2`
+(both supplied by the multi-factor branch: the normalized square-free core has a
+nonzero constant term and at least two local factors), the core's own default
+factor coefficient bound is dominated by the floor.  This is the un-monic sibling
+of `defaultFactorCoeffBound_toMonic_le_cldCoeffFloor`, supplying the
+`hcore_bound` precision that the partition-count leaf
+(`factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`) needs for the
+integer factor recovery, which the monic floor `(★)` alone does not. -/
+theorem defaultFactorCoeffBound_le_cldCoeffFloor (core : Hex.ZPoly)
+    (hconst : core.coeff 0 ≠ 0) (hn : 2 ≤ core.degree?.getD 0) :
+    Hex.ZPoly.defaultFactorCoeffBound core ≤ Hex.cldCoeffFloor core := by
+  have hMfloor : ∀ j, 2 * Hex.bhksCoeffBound core j ≤ Hex.cldCoeffFloor core := by
+    intro j
+    have hbhks_le :
+        Hex.bhksCoeffBound core j ≤
+          Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j := by
+      simp only [Hex.bhksCoeffBound, Hex.ZPoly.toMonic_monic_degree_getD]
+      gcongr
+      exact coeffL2NormBound_le_toMonic_monic_of_const_degree core hconst hn
+    calc 2 * Hex.bhksCoeffBound core j
+          ≤ 2 * Hex.bhksCoeffBound (Hex.ZPoly.toMonic core).monic j := by gcongr
+      _ ≤ Hex.cldCoeffFloor core := two_mul_bhksCoeffBound_le_cldCoeffFloor core j
+  exact Hex.ZPoly.defaultFactorCoeffBound_le core
+    (fun k hk _j _hj => mignotteCoeffBound_le_floor_aux core core hMfloor (by omega) hk)
+
+/-- The `hcore_bound` precision leaf follows from the CLD-adequacy gate
+`cldCoeffFloor core ≤ k`: at the lift precision `precisionForCoeffBound k p` the
+modulus `p ^ a` clears `2 · defaultFactorCoeffBound core`, so the core's own
+integer factors are recovered.  Un-monic companion of
+`two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le`, routed through the `(★★)`
+floor bridge; this is the leaf the partition-count theorem
+(`factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`) consumes. -/
+theorem two_mul_defaultFactorCoeffBound_core_lt_pow_of_cldCoeffFloor_le
+    (core : Hex.ZPoly) (k : Nat) (primeData : Hex.PrimeChoiceData)
+    (hp : 2 ≤ primeData.p) (hfloor : Hex.cldCoeffFloor core ≤ k)
+    (hconst : core.coeff 0 ≠ 0) (hn : 2 ≤ core.degree?.getD 0) :
+    2 * Hex.ZPoly.defaultFactorCoeffBound core <
+      primeData.p ^ Hex.precisionForCoeffBound k primeData.p := by
+  have hle : Hex.ZPoly.defaultFactorCoeffBound core ≤ k :=
+    le_trans (defaultFactorCoeffBound_le_cldCoeffFloor core hconst hn) hfloor
+  have hspec : 2 * k < primeData.p ^ Hex.precisionForCoeffBound k primeData.p :=
+    Hex.precisionForCoeffBound_spec hp k
+  omega
+
 /-- The BHKS separation `hsep` follows from the CLD-adequacy gate
 `cldCoeffFloor core ≤ k`: at the lift precision `precisionForCoeffBound k p`
 the modulus `p ^ a` clears `2 · bhksCoeffBound (toMonic core).monic j` for every

--- a/progress/20260621T102146Z_df3e6148.md
+++ b/progress/20260621T102146Z_df3e6148.md
@@ -1,0 +1,79 @@
+# Un-monic CLD floor bridge (★★) — the prerequisite step 1 missed (#8282)
+
+Session type: one-shot `/once` on #8282 (steps 2-3 of #8280). UTC 2026-06-21T10:21.
+
+## Accomplished
+
+Landed the **un-monic CLD floor bridge**, the genuine gating prerequisite for
+#8282's step 2 that step 1 (#8283) did not include. In
+`HexBerlekampZassenhausMathlib/CLDColumnBound.lean`, after `(★)`:
+
+- `coeffL2NormBound_le_toMonic_monic_of_const_degree` — for a core with nonzero
+  constant term and degree `≥ 2`, `coeffL2NormBound core ≤ coeffL2NormBound
+  (toMonic core).monic`. (Private leaf `coeffNormSq_le_toMonic_monic_of_const_degree`
+  does the squared-norm comparison: the monic transform inflates each low
+  coefficient by a power of the leading coefficient — coeff formula
+  `toMonic_monic_coeff_of_leadingCoeff_ne_one` — and the nonzero bottom
+  coefficient lets the inflated `x^0` term absorb the leading-coefficient deficit
+  at `x^n`.)
+- `defaultFactorCoeffBound_le_cldCoeffFloor` — **(★★)**: `defaultFactorCoeffBound
+  core ≤ cldCoeffFloor core` for valid cores. Mirrors `(★)`'s proof via
+  `mignotteCoeffBound_le_floor_aux core core`, with the norm bound feeding
+  `bhksCoeffBound core j ≤ bhksCoeffBound (toMonic core).monic j` (same degree).
+- `two_mul_defaultFactorCoeffBound_core_lt_pow_of_cldCoeffFloor_le` — the
+  `hcore_bound` precision leaf at success precision `k`, un-monic companion of
+  `two_mul_bhksCoeffBound_lt_pow_of_cldCoeffFloor_le`.
+
+`lake build HexBerlekampZassenhausMathlib.CLDColumnBound` green. No
+`sorry`/`axiom`/`native_decide`.
+
+## Why this was needed (premise gap in #8282 step 2)
+
+The step-2 skeleton discharges the keystone's `hpartition` leaf via
+`factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`
+(`PartitionRefinement.lean:480`). That lemma — and every route to the
+partition-length equality (`:204`, `:232`, the `liftedTrueSupports` nonemptiness)
+— additionally requires `hcore_bound : 2 * defaultFactorCoeffBound core <
+p ^ precisionForCoeffBound k' p`, the **un-monic** core recovery precision needed
+so each integer factor of `core` is actually recovered (the lifted true-support
+family is nonempty). The floor gate `cldCoeffFloor core ≤ k'` only bounds the
+**monic** `defaultFactorCoeffBound (toMonic core).monic` via `(★)`; it does not by
+itself bound the un-monic one. The naive sibling is false in general (e.g.
+`core = 10x²+x`: `defaultFactorCoeffBound = 22 > cldCoeffFloor = 8`), but holds for
+valid multi-factor cores because they have a nonzero constant term (the `x`-power
+is stripped by `extractXPower`; `squareFreeCore_coeff_zero_ne_zero`) and degree
+`≥ 2`. That is exactly `(★★)`.
+
+## Current frontier
+
+`(★★)` + the precision corollary now make the `hcore_bound` leaf trivially
+dischargeable. Step 2 (the self-contained multi-factor producer at success
+precision `k'` feeding `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`,
+`PartitionRefinement.lean:807`, via `recoveredLiftOfLiftedTrueSupport`) and step 3
+(the `h_raw` dispatch closing `factor_irreducible_of_nonUnit`,
+`FactorSoundness.lean:20`) remain.
+
+## Next step (steps 2-3, now unblocked)
+
+Build the step-2 producer. All leaves now have sources:
+`hbasis` ← `bhksLiftData_latticeBasis_independent`; `rows_pos`/`hsize` ← the
+`_some_indicatorCandidates` extractor (`Basic.lean:11939`, exposes `cldCoeffFloor
+core ≤ k'`) + `_some_size_eq_indicators`; `hpartition` ←
+`_some_partition_eq_normalizedFactors_card` with `hbound` from `(★)` and
+**`hcore_bound` from `(★★)`** (`two_mul_defaultFactorCoeffBound_core_lt_pow_of_cldCoeffFloor_le`);
+`hf_lc`/`hfactor_monic`/`hp`/`hk`/`hsep`/`hthr`/`hfac` ← the
+`recoveredLiftOfLiftedTrueSupport` projections + `two_mul_bhksCoeffBound_lt_pow…` /
+`bhksCoeffCutThreshold_le…` / `toMonicLiftData_liftedFactor_hensel_semantics`.
+The index alignment `liftedTrueSupports core d : Set (Set (LiftedFactorIndex d))`
+≡ `Fin (bhksProjectedRows L hrows).factorCount` is definitional
+(`LiftedFactorIndex d = Fin d.liftedFactors.size`, `factorCount = liftedFactors.size`).
+Then step 3 case-splits the four fast branches (constant / smallModSingleton /
+quadratic / multi-factor) + two slow disjuncts into their existing producers.
+The valid-core side conditions for `(★★)` (`core.coeff 0 ≠ 0`,
+`2 ≤ core.degree?.getD 0`) come from `squareFreeCore_coeff_zero_ne_zero` and the
+multi-factor reachability (`1 < primeData.factorsModP.size ⟹ degree ≥ 2`).
+
+## Blockers
+
+None. The hard prerequisite is landed. Steps 2-3 are a (large but) mechanical
+assembly on the now-complete leaf set; best scoped as a fresh successor issue.


### PR DESCRIPTION
This PR adds the un-monic CLD floor bridge `(★★)`, the prerequisite that unblocks
the fast-BHKS multi-factor producer (steps 2-3 of #8282). It proves
`defaultFactorCoeffBound core ≤ cldCoeffFloor core` for a core with nonzero
constant term and degree `≥ 2` (both supplied by the multi-factor branch), the
un-monic sibling of the landed `(★)`. This certifies the `hcore_bound` core-
recovery precision that the partition-count leaf
(`factorFastCoreWithBound_some_partition_eq_normalizedFactors_card`) requires for
integer factor recovery, which the monic floor `(★)` alone does not supply. The
bridge routes through a new `toMonic` squared-norm comparison
`coeffL2NormBound core ≤ coeffL2NormBound (toMonic core).monic` (the monic
transform inflates each low coefficient by a power of the leading coefficient, and
the nonzero constant term lets the inflated bottom coefficient absorb the
leading-coefficient deficit at the top) and the existing central-binomial floor
machinery, and exposes the success-precision corollary
`two_mul_defaultFactorCoeffBound_core_lt_pow_of_cldCoeffFloor_le`.

The step-2 skeleton in #8282 overlooked `hcore_bound`: the floor gate plus `(★)`
bound only the monic `defaultFactorCoeffBound (toMonic core).monic`, and the naive
un-monic sibling is false in general (`core = 10x²+x` gives `22 > 8`). With `(★★)`
in place the remaining step-2 producer and step-3 dispatch are a mechanical
assembly on a complete leaf set; #8282 is marked `replan` to re-scope them. See the
issue comment and `progress/20260621T102146Z_df3e6148.md` for the full leaf map.

`lake build HexBerlekampZassenhausMathlib` green (3784 jobs); no `sorry`/`axiom`/`native_decide`.

🤖 Prepared with Claude Code