### PR TITLE
feat: core-coordinate BHKS target builder (monicTarget) with monicity proof

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -251,6 +251,14 @@ or `Monoid`/`CommRing` lemmas — those modules don't import Mathlib.
   `push_neg` → `Classical.not_forall.mp` / `Classical.not_exists.mp`; `conv_lhs
   => rw [h]` → `rw [h] at <aux-have>` then `exact`. `omega`/`simp`/`rcases` are
   core and available.
+- **The general order lemmas and transitivity dot-notation are out too.**
+  `le_trans`/`lt_of_le_of_lt`/`lt_of_lt_of_le` report "unknown identifier", and
+  `(h : a ≤ b).trans_eq`/`.trans` fail with "environment does not contain
+  `Nat.le.trans_eq`". Use the type-prefixed core lemmas — `Nat.le_trans`,
+  `Nat.lt_of_le_of_lt`, `Nat.le_of_lt`, `Nat.le_of_eq`, `Nat.le_antisymm` (and
+  `Int.*` analogues) — or just `omega` for any concrete `Nat`/`Int` inequality
+  chain. Transitivity is common in size/degree bookkeeping, so this bites most
+  arithmetic proofs in the executable layer.
 - **`@[nolint ...]` is unavailable** — the attribute lives in Mathlib's
   linter framework, so writing `@[nolint unusedArguments]` (or any
   `nolint`) in a Mathlib-free file is a build error (`unsupportedSyntax`),

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7007,6 +7007,43 @@ def toMonicLiftData
   henselLiftData (toMonic core).monic
     (precisionForCoeffBound B primeData.p) primeData
 
+/--
+Multiplicative inverse of `core`'s leading coefficient modulo `p ^ k`, read off
+the integer Bezout certificate `s · ℓf + t · p^k = gcd(ℓf, p^k)`.  When
+`gcd(leadingCoeff core, p ^ k) = 1` (the good-prime condition `p ∤ ℓf`) this is a
+genuine inverse: `leadingCoeffInverse core p k * leadingCoeff core ≡ 1 (mod p^k)`
+(`leadingCoeffInverse_mul_emod`).
+-/
+def leadingCoeffInverse (core : ZPoly) (p k : Nat) : Int :=
+  (HexArith.Int.extGcd (DensePoly.leadingCoeff core) (Int.ofNat (p ^ k))).2.1
+
+/--
+BHKS leading-coefficient-faithful monic target for `core`: rescale `core` by the
+modular inverse of its leading coefficient, then reduce modulo `p ^ k`.
+
+This is van Hoeij's `M1` normalisation (factor out `ℓf`, BHKS §2: `f = ℓf·f₁···fr`
+with the `fᵢ` monic in `Z_p`), distinct from the `toMonic` `x ↦ x/ℓf` substitution
+(`M2`).  Over `(ℤ/p^k)[x]` it equals `core · ℓf⁻¹`, so its monic local factors
+divide `core` directly with no dilation.  It is monic over ℤ when
+`gcd(leadingCoeff core, p ^ k) = 1` and `core` is nonconstant
+(`monicTarget_monic`).
+-/
+def monicTarget (core : ZPoly) (p k : Nat) : ZPoly :=
+  reduceModPow (DensePoly.scale (leadingCoeffInverse core p k) core) p k
+
+/--
+Fixed-precision Hensel lift data over `core`'s own coordinate (BHKS-faithful).
+
+Mirrors `toMonicLiftData`, but lifts `core`'s monic modular factors against the
+leading-coefficient-normalised `monicTarget` rather than the `x ↦ x/ℓf` dilation
+`(toMonic core).monic`.  The lifted factors therefore divide `core` in
+`(ℤ/p^a)[x]` directly, and the CLD lattice runs over `core`'s own coordinate.
+-/
+def coreLiftData
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : LiftData :=
+  henselLiftData (monicTarget core primeData.p (precisionForCoeffBound B primeData.p))
+    (precisionForCoeffBound B primeData.p) primeData
+
 end ZPoly
 
 /--

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7044,6 +7044,94 @@ def coreLiftData
   henselLiftData (monicTarget core primeData.p (precisionForCoeffBound B primeData.p))
     (precisionForCoeffBound B primeData.p) primeData
 
+/-- Abstract Bezout-to-residue step: if `A + t·P = 1` and `1 < P` then `A % P = 1`.
+Used to read the unit residue `leadingCoeffInverse · ℓf ≡ 1 (mod p^k)` off the
+integer extended-GCD certificate. -/
+private theorem emod_eq_one_of_bezout {A t P : Int} (hP : 1 < P) (h : A + t * P = 1) :
+    A % P = 1 := by
+  have h2 : A = 1 + (-t) * P := by
+    have hsub : A = 1 - t * P := by omega
+    rw [hsub, Int.sub_eq_add_neg, Int.neg_mul]
+  rw [h2, Int.add_mul_emod_self_right]
+  exact Int.emod_eq_of_lt (by decide) hP
+
+/-- The `leadingCoeffInverse` is a genuine inverse of `core`'s leading coefficient
+modulo `p ^ k` when the leading coefficient is coprime to `p ^ k` (the good-prime
+condition `p ∤ ℓf`).  This is the unit-residue fact the BHKS monic target rests on. -/
+theorem leadingCoeffInverse_mul_emod (core : ZPoly) (p k : Nat)
+    (hpk : 1 < p ^ k)
+    (hgcd : Int.gcd (DensePoly.leadingCoeff core) (Int.ofNat (p ^ k)) = 1) :
+    (leadingCoeffInverse core p k * DensePoly.leadingCoeff core)
+        % Int.ofNat (p ^ k) = 1 := by
+  unfold leadingCoeffInverse
+  have hbez := HexArith.Int.extGcd_bezout_proj
+    (DensePoly.leadingCoeff core) (Int.ofNat (p ^ k))
+  rw [HexArith.Int.extGcd_fst, hgcd] at hbez
+  have hP : (1 : Int) < Int.ofNat (p ^ k) := by
+    have h := Int.ofNat_lt.mpr hpk
+    simpa using h
+  exact emod_eq_one_of_bezout hP hbez
+
+/-- Size of `reduceModPow` is bounded by the source size (trimming only drops
+trailing zeros). -/
+theorem reduceModPow_size_le (f : ZPoly) (p k : Nat) :
+    (reduceModPow f p k).size ≤ f.size := by
+  unfold reduceModPow
+  refine Nat.le_trans (DensePoly.size_ofCoeffs_le _) ?_
+  simp
+
+/--
+The BHKS leading-coefficient-faithful monic target is genuinely monic over ℤ when
+`core`'s leading coefficient is coprime to `p ^ k` and `core` is nonconstant.
+
+This is the load-bearing soundness fact for routing the existing monic Hensel lift
+against `monicTarget` (van Hoeij `M1`) instead of the `toMonic` `x ↦ x/ℓf`
+dilation (`M2`): the lift's producer lemma
+`QuadraticMultifactorLiftInvariant_of_choosePrimeData` requires its target monic,
+and `monicTarget` supplies that while keeping `core`'s own coordinate.
+-/
+theorem monicTarget_monic (core : ZPoly) (p k : Nat)
+    (hpk : 1 < p ^ k)
+    (hgcd : Int.gcd (DensePoly.leadingCoeff core) (Int.ofNat (p ^ k)) = 1)
+    (hcore : 0 < core.size) :
+    DensePoly.Monic (monicTarget core p k) := by
+  have hpk_pos : 0 < p ^ k := Nat.lt_of_lt_of_le Nat.zero_lt_one (Nat.le_of_lt hpk)
+  have hemod := leadingCoeffInverse_mul_emod core p k hpk hgcd
+  have hs_ne : leadingCoeffInverse core p k ≠ 0 := by
+    intro h0
+    rw [h0, Int.zero_mul, Int.zero_emod] at hemod
+    exact absurd hemod (by decide)
+  have hscale_size :
+      (DensePoly.scale (leadingCoeffInverse core p k) core).size = core.size :=
+    scale_size_of_nonzero _ core hs_ne
+  have hscale_pos :
+      0 < (DensePoly.scale (leadingCoeffInverse core p k) core).size := by
+    rw [hscale_size]; exact hcore
+  have hg_top :
+      (DensePoly.scale (leadingCoeffInverse core p k) core).coeff (core.size - 1)
+        = leadingCoeffInverse core p k * DensePoly.leadingCoeff core := by
+    have h1 := leadingCoeff_scale_of_nonzero (leadingCoeffInverse core p k) core hs_ne
+    rw [DensePoly.leadingCoeff_eq_coeff_last _ hscale_pos, hscale_size] at h1
+    exact h1
+  have htop : (monicTarget core p k).coeff (core.size - 1) = 1 := by
+    unfold monicTarget
+    rw [coeff_reduceModPow_eq_emod_of_pos _ _ _ _ hpk_pos, hg_top]
+    exact hemod
+  have hmt_le : (monicTarget core p k).size ≤ core.size := by
+    unfold monicTarget
+    exact Nat.le_trans (reduceModPow_size_le _ p k) (Nat.le_of_eq hscale_size)
+  have hmt_ge : core.size ≤ (monicTarget core p k).size := by
+    rcases Nat.lt_or_ge (monicTarget core p k).size core.size with hlt | hge
+    · have hle : (monicTarget core p k).size ≤ core.size - 1 := by omega
+      have hz := DensePoly.coeff_eq_zero_of_size_le (monicTarget core p k) hle
+      rw [htop] at hz
+      exact absurd hz (by decide)
+    · exact hge
+  have hsize : (monicTarget core p k).size = core.size := Nat.le_antisymm hmt_le hmt_ge
+  unfold DensePoly.Monic
+  rw [DensePoly.leadingCoeff_eq_coeff_last _ (by rw [hsize]; exact hcore), hsize]
+  exact htop
+
 end ZPoly
 
 /--

--- a/progress/20260622T141002Z_77674c5a.md
+++ b/progress/20260622T141002Z_77674c5a.md
@@ -1,0 +1,86 @@
+# BHKS-faithful core-coordinate lift — target-builder infrastructure (#8293)
+
+Session type: feature (one-shot `/once`). UTC 2026-06-22T14:10.
+
+## Accomplished
+
+Landed deliverable #1 of the re-scoped #8293 (owner's `monicTarget = core·ℓf⁻¹
+mod p^k` reuse plan): the executable target-builder infrastructure for the
+BHKS leading-coefficient-faithful (van Hoeij `M1`) lift, in
+`HexBerlekampZassenhaus/Basic.lean` (all `sorry`/`axiom`/`native_decide`-free).
+
+New defs (in `namespace ZPoly`, after `toMonicLiftData`):
+- `leadingCoeffInverse core p k` — `ℓf⁻¹ mod p^k` read off the integer Bezout
+  certificate `HexArith.Int.extGcd ℓf (p^k)`.
+- `monicTarget core p k := reduceModPow (DensePoly.scale (leadingCoeffInverse …) core) p k`
+  — van Hoeij `M1`: `core` rescaled by `ℓf⁻¹` and reduced mod `p^k`. Over
+  `(ℤ/p^k)[x]` it equals `core·ℓf⁻¹`, so its monic local factors divide `core`
+  directly with **no** `x→x/ℓf` dilation.
+- `coreLiftData core B primeData` — mirrors `toMonicLiftData` but lifts against
+  `monicTarget` at the same `precisionForCoeffBound B primeData.p` precision.
+
+New lemmas (the load-bearing validation of the owner's re-scoped premise):
+- `monicTarget_monic` — when `gcd(ℓf, p^k)=1` (good prime `p∤ℓf`) and `core`
+  nonconstant, `monicTarget core p k` is `DensePoly.Monic` over ℤ. This is what
+  lets the existing monic lift producer
+  `QuadraticMultifactorLiftInvariant_of_choosePrimeData` (which requires a
+  **monic target**) apply at `monicTarget`, confirming "the existing lift
+  applies verbatim" — no parallel lift stack, no unit-lc division kernel.
+- `leadingCoeffInverse_mul_emod` — `leadingCoeffInverse·ℓf ≡ 1 (mod p^k)` (unit
+  residue off the Bezout certificate; `emod_eq_one_of_bezout` abstract helper).
+- `reduceModPow_size_le` — `(reduceModPow f p k).size ≤ f.size`.
+
+Size of `monicTarget` is pinned `= core.size` from the nonzero top coeff
+(`coeff_ofCoeffs` / `size_ofCoeffs_le` / `coeff_eq_zero_of_size_le`) — no
+`trimTrailingZeros` lemma needed. Mathlib-free constraints respected (no `set`,
+`ring`, `by_contra`, `le_trans`/`.trans_eq`; used `Nat.le_trans`,
+`Int.add_mul_emod_self_right`, `Int.emod_eq_of_lt`, `Int.ofNat_lt`, `omega`).
+
+`lake build HexBerlekampZassenhaus.Basic` green (492 jobs). Full CI-gated
+`HexBerlekampZassenhausMathlib` build confirmed green (additive change only).
+
+## Current frontier
+
+The core-coordinate target builder and its monicity soundness fact are landed.
+Nothing consumes them yet — `factorFastCoreWithBound` still routes through
+`toMonicLiftData`, and the recovery/floor are still `(toMonic core).monic`-keyed.
+
+## Next step (the remaining, indivisible remodel — #2 + #3)
+
+Per the boundary skill (`hex-lean-mathlib-boundary` §"The Mathlib layer models
+executable definitions"), the recovery-direction change and its Mathlib ripple
+**must land in one PR with no intermediate green state**. The owner's "three
+small parts" framing notwithstanding, only deliverable #1 (this PR) is
+separable; #2 and #3 are one large CI-gated remodel. Scope measured this
+session:
+
+1. **Mathlib producer instantiation** (validation completion): instantiate
+   `QuadraticMultifactorLiftInvariant_of_choosePrimeData` at `monicTarget`,
+   discharging `∏ factorsModP ≡ monicTarget (mod p)` (both equal `core`'s
+   monic associate mod p). Gives the lifted `fᵢ ∣ core` in `(ℤ/p^a)[x]`.
+2. **Wiring** (#2): route `factorFastCoreWithBound` / `bhksRecoverClassified`
+   through `coreLiftData` instead of `toMonicLiftData` — ~50 executable
+   references in `Basic.lean`.
+3. **Recovery swap** (#2): replace `bhksIndicatorCandidate?`'s
+   `ZPoly.dilate (lc f) (centeredLiftPoly (∏ selected) modulus)`
+   (`Basic.lean:5556`) with the van Hoeij lc-aware
+   `primitivePart (centeredLiftPoly ((ℓf · ∏ selected) mod p^k) modulus)`.
+   Breaks **every** Mathlib recovery-direction proof (`bhksIndicatorCandidate?_*`,
+   `RepresentsIntegerFactorAtLift`, `RecoveredAtLift`/`RecoveredLift` model,
+   coverage, partition) — a structural remodel needing new math, not a token
+   swap (skill: recovery direction does NOT survive a shape change).
+4. **Floor ripple** (#3): `cldCoeffFloor` (`Basic.lean:7024`) from
+   `2·maxⱼ bhksCoeffBound (toMonic core).monic j` to the core-coordinate
+   `2·maxⱼ bhksCoeffBound core j` (consuming the landed #8292
+   `abs_factorDeriv_coeff_le_bhksCoeffBound`), cascading through the ~30-lemma
+   CI-gated capstone chain in `Recovery.lean` / `BHKSBound.lean` /
+   `CLDColumnBound.lean` / `PartitionRefinement.lean` / `IntReductionMod.lean`
+   (hundreds of references measured).
+
+This is a multi-session effort with no green intermediate; it should be its own
+follow-up issue (or claimed against the parent after this PR).
+
+## Blockers
+
+None for deliverable #1. The remaining remodel is large but the foundation it
+needs (a monic core-coordinate target + its monicity) now exists and is proven.


### PR DESCRIPTION
Partial progress on #8293.

This PR adds the executable target-builder infrastructure for the BHKS leading-coefficient-faithful (van Hoeij `M1`) lift, landing the first separable deliverable of the re-scoped #8293 (the owner's `monicTarget = core·ℓf⁻¹ mod p^k` reuse plan). It introduces `ZPoly.leadingCoeffInverse`, `ZPoly.monicTarget` and `ZPoly.coreLiftData` in `HexBerlekampZassenhaus/Basic.lean`, and proves the load-bearing soundness fact `monicTarget_monic`: when `gcd(leadingCoeff core, p^k) = 1` (the good-prime condition `p ∤ ℓf`) and `core` is nonconstant, `monicTarget core p k = reduceModPow (scale ℓf⁻¹ core) p k` is monic over ℤ. Over `(ℤ/p^k)[x]` this target equals `core·ℓf⁻¹`, so its monic local factors divide `core` directly — keeping `core`'s own coordinate with no `x→x/ℓf` dilation. Monicity is exactly what lets the existing monic Hensel-lift producer `QuadraticMultifactorLiftInvariant_of_choosePrimeData` (which requires a monic target) apply at `monicTarget`, confirming the owner's premise that the existing lift applies verbatim — no parallel lc-tracking lift stack, invariant, or unit-lc division kernel is needed. Supporting lemmas `leadingCoeffInverse_mul_emod` (unit residue read off the integer Bezout certificate) and `reduceModPow_size_le` are added; the change is purely additive and `sorry`/`axiom`/`native_decide`-free.

The remaining work is the indivisible recovery remodel, left for a follow-up because per the project's Mathlib-boundary doctrine the executable recombination change and its CI-gated Mathlib ripple must land together with no intermediate green state: (1) instantiate the lift producer at `monicTarget` (discharging `∏ factorsModP ≡ monicTarget (mod p)`); (2) route `factorFastCoreWithBound` / `bhksRecoverClassified` through `coreLiftData` (≈50 executable sites) and swap `bhksIndicatorCandidate?`'s `dilate (lc f) …` recovery transform for the van Hoeij lc-aware `primitivePart (centeredLiftPoly ((ℓf · ∏ selected) mod p^k) …)`, which restructures the entire Mathlib recovery direction (`RepresentsIntegerFactorAtLift`, `RecoveredAtLift`/`RecoveredLift`, coverage, partition); (3) re-point `cldCoeffFloor` from `bhksCoeffBound (toMonic core).monic` to the core-coordinate `bhksCoeffBound core` (consuming the landed #8292 bound), cascading through the ~30-lemma capstone chain. The issue is marked `replan` so this remaining scope is picked up fresh.

Both `lake build HexBerlekampZassenhaus.Basic` and the full CI-gated `lake build HexBerlekampZassenhausMathlib` (3784 jobs) are green.

🤖 Prepared with Claude Code
