### PR TITLE
doc: fix /once claim step for replan/plan worker types

### DIFF
--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -25,10 +25,21 @@ immediately with `ABORT: no issue number provided`.
    `coordination claim <N> --label <type>`. Do **NOT** use
    `coordination list-unclaimed` — you are not picking from the
    queue.
+   - **Exception — `replan` and `plan` worker types do not use
+     `coordination claim`.** That helper is for `feature`/`repair`
+     workers and **deliberately refuses** any `replan`-labelled issue
+     (it prints `CLAIM FAILED: Issue #<N> needs replan`). Replan triage
+     edits the issue directly (see the `replan` skill) and the planner
+     lock is held by `pod`, not claimed per-issue. For these types,
+     skip steps 3-4 and go straight to executing the skill's flow on
+     `<N>` (confirm `<N>` is in `coordination list-replan` first; that
+     is the only allowed list call — it is not queue-picking).
 4. **If the claim fails** (issue already claimed by another agent,
    issue closed, issue not labelled with the worker type, etc.),
    exit immediately. Print `ABORT: claim failed for #<N>` and do
-   nothing else. No worktree commits, no branches, no PR.
+   nothing else. No worktree commits, no branches, no PR. (Does not
+   apply to the `replan`/`plan` exception above, where a `claim`
+   refusal is expected, not a failure.)
 5. Once the claim succeeds, **execute the issue end-to-end**
    following the standard worker flow for the matched type
    (implementation, build, tests, commit, push, open PR).

--- a/.claude/commands/replan.md
+++ b/.claude/commands/replan.md
@@ -47,6 +47,10 @@ the following:
   close with a forward link.
 - **Plan stale / approach changed**: create a corrected replacement
   issue via `coordination plan`, close the original linking forward.
+  Invocation is `coordination plan [--label L] "<title>"` with the
+  **body piped on stdin** — there is no `--help`; any argument you pass
+  becomes an issue title, so probing usage creates a junk issue. Use
+  `--label feature` when the replacement is directly claimable work.
 - **Partial progress**: create an issue for the remaining deliverables,
   close the original linking forward.
 - **Worker-decomposed**: the worker created sub-issues before releasing

--- a/progress/20260623T010710Z_deaae543.md
+++ b/progress/20260623T010710Z_deaae543.md
@@ -1,0 +1,43 @@
+# Replan triage of #8297 (atomic M1 recovery swap)
+
+Session type: replan (one-shot `/once`). UTC 2026-06-23T01:07.
+
+## Accomplished
+
+Triaged the single one-shot target #8297 ("route fast-core recovery through
+`coreLiftData` + `cldCoeffFloor` ripple — atomic M1 swap, parts 2+3 of #8293").
+
+Disposition: **Plan stale / approach changed.** The issue demands the
+recovery-direction swap (`toMonicLiftData`/M2 → `coreLiftData`/M1) plus the
+`cldCoeffFloor` ripple in one atomic PR with no green CI intermediate. A prior
+feature session confirmed the premise is **sound** and the substrate is landed
+(#8294, #8292, #8298 all merged), but measured that the atomic remodel re-keys the
+whole merge-gating `HexBerlekampZassenhausMathlib` build with no green subset —
+unlandable green by an autonomous session. The owner's replan steer replaces it
+with a green-landable additive (parallel-change) dependency chain.
+
+- Created replacement #8300 (`agent-plan,feature`, unblocked — only dependency
+  #8298 is merged): step 1 of the chain — **introduce** a core-coordinate fast
+  recovery (`coreRecover?`/`bhksRecoverClassifiedCore` on `coreLiftData` + the M1
+  candidate `primitivePart (centeredLiftPoly ((ℓf·∏ selected) % p^k) modulus)`)
+  **alongside** the existing M2 path, nothing rerouted, with its own `#guard`s.
+  Purely additive, build stays green. Body records the deferred steps 2-4
+  (correctness proof → call-site swap + cldCoeffFloor ripple → dead-path removal)
+  so a planner files them as the chain extends.
+- Closed #8297 with a forward link to #8300.
+- Cleaned up #8299, an empty issue accidentally created by `coordination plan
+  --help` (the command treats its argument as a title).
+
+## Current frontier
+
+#8300 is claimable now; it is the first green checkpoint of the recovery-direction
+remodel the parent #8295/#8293/directive #2564 chain wants.
+
+## Next step
+
+A feature worker claims #8300 (additive introduction). Once it lands, a planner
+files steps 2-4 from the chain recorded in #8300's body.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR fixes a real failure mode in the `/once` one-shot dispatch command, found while triaging issue https://github.com/kim-em/hex/issues/8297 as a replan worker. The `/once` template instructs every worker type to claim via `coordination claim <N> --label <type>` and ABORT if the claim fails — but `coordination claim` deliberately refuses any `replan`-labelled issue (`CLAIM FAILED: Issue #N needs replan`), so a literal `/once` replan (or `plan`) session would wrongly abort and do nothing. Add a carve-out: `replan`/`plan` worker types skip the claim step and edit issues directly per their skill, treating a `claim` refusal as expected rather than fatal.

Also note in the `/replan` command that `coordination plan` takes a positional title with the body piped on stdin and has no `--help` flag, so probing its usage creates a junk issue (it did — a stray `#8299`, since closed).

Scope is limited to the two command docs plus this session's progress file; the pre-existing working-tree edits to `review.md` and `agent-worker-flow/SKILL.md` are left untouched.

🤖 Prepared with Claude Code