### PR TITLE
feat: non-monic aggregate-residue producer for the core-coordinate cut

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -235,6 +235,21 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   type ascription first (`have hlc : (HexPolyZMathlib.toPolynomial g).leadingCoeff
   = … := HexPolyMathlib.leadingCoeff_toPolynomial g`), then `rw [← hlc, …]`.
 
+- **Don't `set`/`let` `bhksLatticeBasis …` when a hypothesis depends on it
+  through a dependent type.** In BHKS proofs `S : LiftedFactorSupport
+  (bhksLatticeBasis f p a liftedFactors)` (and `Fin L.factorCount`,
+  `AggregateResidueData`, etc.) mention the basis in their *type*. `set L :=
+  bhksLatticeBasis …` abstracts inside that type and produces an `S✝` /
+  `i ∈ S✝` mismatch against the goal's `S`, which then cascades into
+  `(deterministic) timeout at whnf` on later lemma applications. A `let L`
+  is defeq but its fvar won't match the goal's spelled-out basis under the
+  syntactic `rw` you need for the final `AggregateResidueData`/sum
+  assembly. Simplest fix in the Mathlib layer: **spell
+  `Hex.bhksLatticeBasis f p a liftedFactors` out in full** everywhere it must
+  match the goal; only `set` the plain `ZPoly` pieces (`G := supportProduct …`),
+  whose types carry no `S` dependency, and compute `supportProduct_cldSum_*`
+  *before* that `set` so it folds the product into `G`.
+
 ## Proving *inside* the Mathlib-free files
 
 Lemmas that live in the executable files themselves (`HexPoly/*`,

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2353,6 +2353,174 @@ def cutProjectionHypotheses_of_aggregateResidue
     (fun S => supportShortVectorData_of_aggregateResidue f p a liftedFactors
       S.1 hp hthr (hagg S))
 
+/-- **Core aggregate-residue producer (the non-monic `#8290` deliverable).**
+
+Discharges `AggregateResidueData` for one true support `S` of the executable's
+*core* basis `bhksLatticeBasis f p a liftedFactors`, where `f = core` is **not**
+monic, so the monic `RecoveredLift` / `phi` route (`recoveredLift_aggregate_residue`)
+is unavailable.
+
+The integer column extracted is the genuine non-monic CLD numerator
+`cof · factor'` (with `core = factor · cof` over `ℤ`), bounded by
+`abs_factorDeriv_coeff_le_bhksCoeffBound` (#8292) — **not** the monic `phi`,
+which vanishes for the non-monic factor.
+
+Two inputs drive the bridge:
+* `hfac` — the per-selected-factor Hensel congruence `gᵢ ∣ core (mod p^a)`
+  (monic `gᵢ`), supplied by `coreLiftData_liftedFactor_hensel_semantics` (#8307);
+  it powers the landed aggregate CLD congruence `G · Σ ≡ core · G' (mod p^a)`.
+* `hbridge` — the recovery proportionality `factor · G' ≡ G · factor' (mod p^a)`
+  of the monic support product `G = supportProduct L S` and the integer factor
+  `factor` (both have proportional logarithmic-derivative numerators mod `p^a`
+  because `G ≡ unit · factor (mod p^a)`).
+
+`G` is monic (a product of monic Hensel factors), so it is cancelled by
+`C_dvd_of_monic_mul` exactly as in the monic proof; no non-monic polynomial
+cancellation is needed. -/
+theorem aggregateResidueData_of_factorBridge
+    (f factor cof : Hex.ZPoly) (p a : Nat)
+    (liftedFactors : Array Hex.ZPoly)
+    (S : LiftedFactorSupport (Hex.bhksLatticeBasis f p a liftedFactors))
+    (hk : 1 < p ^ a)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound f j < p ^ a)
+    (hfac : ∀ i : Fin (Hex.bhksLatticeBasis f p a liftedFactors).factorCount, i ∈ S →
+        ∃ h : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1) ∧
+          0 < ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr f
+            (((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1) * h) (p ^ a))
+    (hfactor : HexPolyMathlib.toPolynomial f
+        = HexPolyMathlib.toPolynomial factor * HexPolyMathlib.toPolynomial cof)
+    (hbridge : Hex.ZPoly.congr
+        (factor *
+          Hex.DensePoly.derivative (supportProduct (Hex.bhksLatticeBasis f p a liftedFactors) S))
+        (supportProduct (Hex.bhksLatticeBasis f p a liftedFactors) S *
+          Hex.DensePoly.derivative factor) (p ^ a)) :
+    AggregateResidueData (Hex.bhksLatticeBasis f p a liftedFactors) S f p a := by
+  classical
+  -- Landed aggregate CLD congruence over the core basis (folded into `G` below).
+  have hagg := supportProduct_cldSum_congr_of_factors f p a hk hfac
+  set G := supportProduct (Hex.bhksLatticeBasis f p a liftedFactors) S with hG
+  -- Monicity of the support product `G` (product of monic Hensel factors).
+  have hGG_monic : (HexPolyMathlib.toPolynomial G).Monic := by
+    have heq : HexPolyZMathlib.toPolynomial G
+        = ∏ i ∈ Finset.univ.filter
+            (fun i : Fin (Hex.bhksLatticeBasis f p a liftedFactors).factorCount => i ∈ S),
+            HexPolyZMathlib.toPolynomial
+              ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1) := by
+      rw [hG]
+      unfold supportProduct
+      rw [polyProduct_toPolynomial, List.toList_toArray, List.map_map]
+      simp only [Function.comp_def]
+      rw [← List.prod_toFinset
+        (fun i => HexPolyZMathlib.toPolynomial
+          ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1))
+        ((List.nodup_finRange (Hex.bhksLatticeBasis f p a liftedFactors).factorCount).filter _)]
+      refine Finset.prod_congr ?_ (fun _ _ => rfl)
+      ext i
+      simp only [List.mem_toFinset, List.mem_filter, List.mem_finRange, true_and,
+        decide_eq_true_eq, Finset.mem_filter, Finset.mem_univ]
+    show (HexPolyZMathlib.toPolynomial G).Monic
+    rw [heq]
+    refine Polynomial.monic_prod_of_monic _ _ (fun i hi => ?_)
+    obtain ⟨h, hmono, _, _⟩ := hfac i (Finset.mem_filter.mp hi).2
+    exact HexHenselMathlib.toPolynomial_monic_of_dense_monic _ hmono
+  -- Transport `hagg` and `hbridge` to `C (p^a)`-divisibilities over `Polynomial ℤ`.
+  have hC_agg : Polynomial.C ((p ^ a : Nat) : ℤ)
+      ∣ (HexPolyMathlib.toPolynomial G
+            * HexPolyMathlib.toPolynomial
+                (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a)
+          - HexPolyMathlib.toPolynomial f * (HexPolyMathlib.toPolynomial G).derivative) := by
+    have h := C_dvd_toPolynomial_sub_of_congr
+      (G * supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a)
+      (f * Hex.DensePoly.derivative G) (p ^ a) hagg
+    rwa [HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_mul,
+      HexPolyMathlib.toPolynomial_derivative] at h
+  have hC_bridge : Polynomial.C ((p ^ a : Nat) : ℤ)
+      ∣ (HexPolyMathlib.toPolynomial factor * (HexPolyMathlib.toPolynomial G).derivative
+          - HexPolyMathlib.toPolynomial G * (HexPolyMathlib.toPolynomial factor).derivative) := by
+    have h := C_dvd_toPolynomial_sub_of_congr (factor * Hex.DensePoly.derivative G)
+      (G * Hex.DensePoly.derivative factor) (p ^ a) hbridge
+    rwa [HexPolyMathlib.toPolynomial_mul, HexPolyMathlib.toPolynomial_mul,
+      HexPolyMathlib.toPolynomial_derivative, HexPolyMathlib.toPolynomial_derivative] at h
+  -- Combine: `C (p^a) ∣ GG * (Σ − cof·factor')`.
+  have key : (HexPolyMathlib.toPolynomial G
+            * HexPolyMathlib.toPolynomial
+                (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a)
+          - HexPolyMathlib.toPolynomial f * (HexPolyMathlib.toPolynomial G).derivative)
+        + HexPolyMathlib.toPolynomial cof
+            * (HexPolyMathlib.toPolynomial factor * (HexPolyMathlib.toPolynomial G).derivative
+              - HexPolyMathlib.toPolynomial G * (HexPolyMathlib.toPolynomial factor).derivative)
+      = HexPolyMathlib.toPolynomial G
+          * (HexPolyMathlib.toPolynomial
+                (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a)
+              - HexPolyMathlib.toPolynomial cof * (HexPolyMathlib.toPolynomial factor).derivative) := by
+    rw [hfactor]; ring
+  have hC_final : Polynomial.C ((p ^ a : Nat) : ℤ)
+      ∣ HexPolyMathlib.toPolynomial G
+          * (HexPolyMathlib.toPolynomial
+                (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a)
+              - HexPolyMathlib.toPolynomial cof * (HexPolyMathlib.toPolynomial factor).derivative) := by
+    rw [← key]
+    exact dvd_add hC_agg (Dvd.dvd.mul_left hC_bridge (HexPolyMathlib.toPolynomial cof))
+  -- Cancel the monic support product.
+  have hZ := C_dvd_of_monic_mul hGG_monic hC_final
+  rw [Polynomial.C_dvd_iff_dvd_coeff] at hZ
+  -- The Mignotte bound on the genuine non-monic column (#8292).
+  have hbnd : ∀ j, ((HexPolyMathlib.toPolynomial cof
+        * (HexPolyMathlib.toPolynomial factor).derivative).coeff j).natAbs
+      ≤ Hex.bhksCoeffBound f j := fun j =>
+    abs_factorDeriv_coeff_le_bhksCoeffBound f factor (HexPolyMathlib.toPolynomial cof) j hfactor
+  -- The per-column residue identity: `residue (Σ.coeff j) = (cof·factor').coeff j`.
+  have hcol : ∀ j, Hex.centeredResiduePow p a
+        ((supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a).coeff j)
+      = (HexPolyMathlib.toPolynomial cof * (HexPolyMathlib.toPolynomial factor).derivative).coeff j := by
+    intro j
+    have hj := hZ j
+    rw [Polynomial.coeff_sub, HexPolyMathlib.coeff_toPolynomial] at hj
+    have hcongr_emod : (HexPolyMathlib.toPolynomial cof
+            * (HexPolyMathlib.toPolynomial factor).derivative).coeff j % ((p ^ a : Nat) : Int)
+        = (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a).coeff j
+            % ((p ^ a : Nat) : Int) :=
+      Int.modEq_iff_dvd.mpr hj
+    exact Hex.centeredResiduePow_eq_of_natAbs_le p a _ _ (Hex.bhksCoeffBound f j)
+      (hbnd j) (hsep j) hcongr_emod
+  -- Assemble `AggregateResidueData`.
+  unfold AggregateResidueData
+  intro j
+  refine ⟨_, ?_, hbnd j⟩
+  rw [← hcol j]
+  refine centeredResiduePow_emod_eq p a _ _ ?_
+  have hA : (∑ i ∈ Finset.univ.filter
+        (fun i : Fin (Hex.bhksLatticeBasis f p a liftedFactors).factorCount => i ∈ S),
+        Hex.centeredResiduePow p a
+          ((Hex.cldQuotientMod f
+            ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1) p a).coeff j))
+      = (((List.finRange (Hex.bhksLatticeBasis f p a liftedFactors).factorCount).filter
+            (fun i => decide (i ∈ S))).map
+          (fun i => Hex.centeredResiduePow p a
+            ((Hex.cldQuotientMod f
+              ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1)
+                p a).coeff j))).sum :=
+    sum_filter_univ_eq_listSum (fun i => i ∈ S) _
+  have hB : (supportCldSum (Hex.bhksLatticeBasis f p a liftedFactors) S f p a).coeff j
+      = (((List.finRange (Hex.bhksLatticeBasis f p a liftedFactors).factorCount).filter
+            (fun i => decide (i ∈ S))).map
+          (fun i => (Hex.cldQuotientMod f
+            ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1)
+              p a).coeff j)).sum := by
+    show (((List.finRange (Hex.bhksLatticeBasis f p a liftedFactors).factorCount).filter
+          (fun i => decide (i ∈ S))).map
+          (fun i => Hex.cldQuotientMod f
+            ((Hex.bhksLatticeBasis f p a liftedFactors).liftedFactors.getD i.val 1) p a)).sum.coeff j
+        = _
+    rw [coeff_listSum, List.map_map]
+    rfl
+  rw [hA, hB]
+  exact listSum_emod_eq _ _ _ _
+    (fun i _ => centeredResiduePow_emod_self p a _)
+
 /-- The accumulator of a `max`-fold never decreases below its seed. -/
 private theorem foldl_max_ge_init (l : List Nat) (f : Nat → Nat) :
     ∀ init : Nat, init ≤ l.foldl (fun acc x => max acc (f x)) init := by

--- a/progress/20260623T063317Z_bb914afc.md
+++ b/progress/20260623T063317Z_bb914afc.md
@@ -1,0 +1,68 @@
+# Core aggregate-residue identity — #8290 (one-shot `/once`)
+
+Session type: feature (one-shot). UTC 2026-06-23T06:33.
+
+## Accomplished
+
+Landed the substantial new math of #8290 — the **non-monic aggregate-residue
+producer** — in `HexBerlekampZassenhausMathlib/CLDColumnBound.lean`:
+
+- `BHKS.aggregateResidueData_of_factorBridge`: produces
+  `AggregateResidueData (bhksLatticeBasis f p a liftedFactors) S f p a` for a
+  true support `S`, with `f = core` **non-monic**, extracting the genuine
+  non-monic CLD numerator column `cof · factor'` (where `core = factor · cof`
+  over `ℤ`), bounded by `abs_factorDeriv_coeff_le_bhksCoeffBound` (#8292) —
+  not the monic `phi` (which vanishes for the non-monic factor).
+
+Key idea that made it tractable: the monic support product `G = supportProduct
+L S` is a product of monic Hensel factors, hence **monic**, so it is cancelled
+by the existing `C_dvd_of_monic_mul` exactly as in the monic
+`residue_eq_phi_coeff_of_congr`. No non-monic polynomial cancellation lemma is
+needed. The recovery enters only through one clean hypothesis
+`hbridge : factor · G' ≡ G · factor' (mod p^a)` (the logarithmic-derivative
+proportionality that holds because `G ≡ unit · factor (mod p^a)`), combined
+with the landed aggregate CLD congruence `supportProduct_cldSum_congr_of_factors`
+(driven by #8307's per-factor Hensel `hfac`).
+
+Verification:
+
+- `lake build HexBerlekampZassenhausMathlib.CLDColumnBound` — green.
+- `lake build HexBerlekampZassenhaus HexBerlekampZassenhausMathlib` — green
+  (0 errors; the two `sorry` warnings, `Basic.lean:233` and
+  `FactorSoundness.lean:18`, are pre-existing scaffolding, not from this work).
+
+No `sorry`, `axiom`, or `native_decide` added.
+
+## Current frontier
+
+With #8309's surface (`cutProjectionHypotheses_of_aggregateResidue`,
+`supportShortVectorData_of_aggregateResidue`) plus this producer, the
+core-coordinate forward cut is **constructible** given, per true support, the
+bridge `hbridge` and the integer factorisation `hfactor : core = factor · cof`.
+
+## Next step (the partial residual — successor work)
+
+Derive `hbridge` and `hfactor` from the M1 recovery witness
+`RecoveredAtLiftM1 core d factor S` at a real call site, then assemble the
+end-to-end core-basis `CutProjectionHypotheses`:
+
+1. Recovery proportionality `G ≡ unit · factor (mod p^a)`: from
+   `leadingCoeff_scale_monicTarget_congr_core` /
+   `scaledLiftedFactorProduct_congr_core_of_product_congr_monicTarget`
+   (`Basic.lean:3262/3313`) plus the centred-lift/primitive-part recovery
+   `ℓf · G ≡ content · factor (mod p^a)`.
+2. A small scalar-unit congruence-cancellation helper (`ℓf` coprime to `p`):
+   `ℓf · x ≡ ℓf · y (mod p^a) → x ≡ y (mod p^a)`. None exists yet.
+3. `hbridge` then follows: differentiate (1) and cancel the scalar via (2).
+4. Feed `aggregateResidueData_of_factorBridge` (this PR) per support into
+   `cutProjectionHypotheses_of_aggregateResidue` (#8309) at the executable's
+   true-support call site (no consumer exists yet; the eventual caller is the
+   non-monic sibling of
+   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`,
+   `PartitionRefinement.lean:808`).
+
+## Blockers
+
+None technical. Marked partial because the recovery→`hbridge` derivation
+(piece 1 of the issue) and the end-to-end cut call site remain; both are
+well-scoped and named above.


### PR DESCRIPTION
This PR adds `BHKS.aggregateResidueData_of_factorBridge`, the non-monic aggregate-residue producer that supplies `AggregateResidueData` for a true support over the executable's actual core basis `bhksLatticeBasis core p a liftedFactors`, where `core` is not monic so the monic `phi` / `RecoveredLift` route (`recoveredLift_aggregate_residue`) does not apply. The integer column extracted is the genuine non-monic CLD numerator `cof · factor'` (with `core = factor · cof` over ℤ), bounded by `abs_factorDeriv_coeff_le_bhksCoeffBound` (#8292) rather than the monic `phi`, which vanishes for the non-monic factor.

The proof stays tractable because the monic support product `G = supportProduct L S` is a product of monic Hensel factors, hence monic, and is cancelled by the existing `C_dvd_of_monic_mul` exactly as in `residue_eq_phi_coeff_of_congr` — no non-monic polynomial cancellation is needed. The recovery enters only through one clean hypothesis, the logarithmic-derivative proportionality `factor · G' ≡ G · factor' (mod p^a)` (which holds because `G ≡ unit · factor (mod p^a)`), combined with the landed aggregate CLD congruence `supportProduct_cldSum_congr_of_factors` driven by #8307's per-factor Hensel data.

Together with the cut surface landed in #8309 (`cutProjectionHypotheses_of_aggregateResidue`), this makes the core-coordinate forward cut constructible per true support. Partial: deriving the proportionality bridge and `core = factor · cof` from the M1 `RecoveredAtLiftM1` recovery witness (plus a small scalar-unit congruence cancellation) and wiring the end-to-end cut call site remain; both are scoped in the issue follow-up comment.

🤖 Prepared with Claude Code
