### PR TITLE
feat: recovery-glue + hbridge math for the core-coordinate cut (#8290 pieces 1-3)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -3416,6 +3416,54 @@ theorem RecoveredAtLiftM1.candidate_eq
   rw [hscale_eq]
   exact hrec.recovered_eq
 
+/-- A centred lift is coefficientwise congruent to its argument modulo `m`: each
+coefficient is the centred representative `centeredModNat`, which differs from the
+original by a multiple of `m`. -/
+theorem centeredLiftPoly_congr_self (g : Hex.ZPoly) (m : Nat) :
+    Hex.ZPoly.congr (Hex.centeredLiftPoly g m) g m := by
+  intro i
+  rw [Hex.coeff_centeredLiftPoly]
+  apply Int.emod_eq_zero_of_dvd
+  simpa [neg_sub] using (dvd_neg (α := Int)).mpr (Hex.self_sub_centeredModNat_dvd (g.coeff i) m)
+
+/-- **Recovery proportionality (the `#8290` recovery glue).**
+
+From an `M1` recovery witness `RecoveredAtLiftM1 core d factor S`, the `ℓf`-scaled
+selected lifted product is congruent to a constant multiple of the recovered integer
+factor modulo `p^k`: `ℓf · (∏ S) ≡ c · factor (mod p^k)`, where `c` is the content
+of the centred lift.  This is the proportionality hypothesis consumed by the
+logarithmic-derivative bridge `congr_logDeriv_bridge_of_scale_congr`.
+
+The witness recovers `factor` as the primitive part of the centred lift `L` of the
+`ℓf`-scaled product, so `L = scale (content L) factor` by `content_mul_primitivePart`;
+`L` is itself congruent to the `ℓf`-scaled product (`centeredLiftPoly_congr_self`
+composed with `congr_reduceModPow`). -/
+theorem exists_scale_congr_factor_of_recoveredM1
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hrec : RecoveredAtLiftM1 core d factor S) (hpk : 0 < d.p ^ d.k) :
+    ∃ c : Int, Hex.ZPoly.congr
+      (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) (liftedFactorProduct d S))
+      (Hex.DensePoly.scale c factor)
+      (d.p ^ d.k) := by
+  classical
+  set L := Hex.centeredLiftPoly
+      (Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k)
+      (d.p ^ d.k) with hL
+  refine ⟨Hex.ZPoly.content L, ?_⟩
+  -- `L = scale (content L) factor` from the recovery `primitivePart L = factor`.
+  have hLeq : Hex.DensePoly.scale (Hex.ZPoly.content L) factor = L := by
+    have hpp : Hex.ZPoly.primitivePart L = factor := hrec.candidate_eq hpk
+    have hcm := Hex.ZPoly.content_mul_primitivePart L
+    rw [hpp] at hcm
+    exact hcm
+  -- `L ≡ scaledLiftedFactorProduct core d S (mod p^k)`.
+  have hcong : Hex.ZPoly.congr L (scaledLiftedFactorProduct core d S) (d.p ^ d.k) :=
+    Hex.ZPoly.congr_trans _ _ _ _
+      (centeredLiftPoly_congr_self _ _)
+      (Hex.ZPoly.congr_reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k hpk)
+  rw [hLeq]
+  exact Hex.ZPoly.congr_symm _ _ _ hcong
+
 /-! ### M1 Hensel lift invariant: `monicTarget` mod-`p` structure transfers from `core`
 
 The fast-core lift `coreLiftData` lifts `core`'s Berlekamp factors against the

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2446,6 +2446,31 @@ theorem congr_logDeriv_bridge_of_scale_congr
     Hex.ZPoly.congr_trans _ _ _ _ hD (Hex.ZPoly.congr_symm _ _ _ hC)
   exact congr_scale_cancel ℓf _ _ m hgcd hcancel
 
+/-- **`hbridge` producer from an `M1` recovery witness.**
+
+Chains the recovery proportionality `exists_scale_congr_factor_of_recoveredM1` into
+the logarithmic-derivative bridge `congr_logDeriv_bridge_of_scale_congr`, delivering
+the exact `hbridge` hypothesis consumed by `aggregateResidueData_of_factorBridge`,
+over the executable's concrete support product `supportProduct L S`.
+
+The only call-site obligation beyond the recovery witness and the good-prime gcd is
+the identification `liftedFactorProduct d Ssub = supportProduct L S` of the abstract
+lifted product with the concrete BHKS support product. -/
+theorem congr_logDeriv_bridge_of_recoveredM1
+    {core factor : Hex.ZPoly} {d : Hex.LiftData}
+    {L : Hex.BhksLatticeBasis} {Ssub : LiftedFactorSubset d}
+    {S : LiftedFactorSupport L}
+    (hrec : RecoveredAtLiftM1 core d factor Ssub)
+    (hpk : 0 < d.p ^ d.k)
+    (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (d.p ^ d.k)) = 1)
+    (hsupp : liftedFactorProduct d Ssub = supportProduct L S) :
+    Hex.ZPoly.congr
+      (factor * Hex.DensePoly.derivative (supportProduct L S))
+      (supportProduct L S * Hex.DensePoly.derivative factor) (d.p ^ d.k) := by
+  obtain ⟨c, hpropr⟩ := exists_scale_congr_factor_of_recoveredM1 hrec hpk
+  rw [hsupp] at hpropr
+  exact congr_logDeriv_bridge_of_scale_congr hgcd hpropr
+
 /-- **Core aggregate-residue producer (the non-monic `#8290` deliverable).**
 
 Discharges `AggregateResidueData` for one true support `S` of the executable's

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2353,6 +2353,99 @@ def cutProjectionHypotheses_of_aggregateResidue
     (fun S => supportShortVectorData_of_aggregateResidue f p a liftedFactors
       S.1 hp hthr (hagg S))
 
+/-- Pulling a constant scalar out of a product on the left:
+`scale c p * q = scale c (p * q)`. -/
+theorem scale_mul_left (c : Int) (p q : Hex.ZPoly) :
+    Hex.DensePoly.scale c p * q = Hex.DensePoly.scale c (p * q) := by
+  rw [← Hex.ZPoly.C_mul_eq_scale, ← Hex.ZPoly.C_mul_eq_scale,
+    Hex.DensePoly.mul_assoc_poly]
+
+/-- Pulling a constant scalar out of a product on the right:
+`p * scale c q = scale c (p * q)`. -/
+theorem scale_mul_right (c : Int) (p q : Hex.ZPoly) :
+    p * Hex.DensePoly.scale c q = Hex.DensePoly.scale c (p * q) := by
+  rw [← Hex.ZPoly.C_mul_eq_scale, ← Hex.ZPoly.C_mul_eq_scale,
+    ← Hex.DensePoly.mul_assoc_poly,
+    Hex.DensePoly.mul_comm_poly p (Hex.DensePoly.C c),
+    Hex.DensePoly.mul_assoc_poly]
+
+/-- The formal derivative commutes with constant scaling:
+`derivative (scale c p) = scale c (derivative p)`. -/
+theorem derivative_scale (c : Int) (p : Hex.ZPoly) :
+    Hex.DensePoly.derivative (Hex.DensePoly.scale c p) =
+      Hex.DensePoly.scale c (Hex.DensePoly.derivative p) := by
+  apply Hex.DensePoly.ext_coeff
+  intro n
+  rw [Hex.DensePoly.coeff_derivative _ n (mul_zero _),
+    Hex.DensePoly.coeff_scale c p (n + 1) (mul_zero c),
+    Hex.DensePoly.coeff_scale c (Hex.DensePoly.derivative p) n (mul_zero c),
+    Hex.DensePoly.coeff_derivative p n (mul_zero _)]
+  ring
+
+/-- Cancelling a constant scalar coprime to the modulus from a congruence: if `c`
+is coprime to `m` and `scale c x ≡ scale c y (mod m)`, then `x ≡ y (mod m)`. -/
+theorem congr_scale_cancel (c : Int) (x y : Hex.ZPoly) (m : Nat)
+    (hgcd : Int.gcd c (Int.ofNat m) = 1)
+    (h : Hex.ZPoly.congr (Hex.DensePoly.scale c x) (Hex.DensePoly.scale c y) m) :
+    Hex.ZPoly.congr x y m := by
+  intro i
+  have hi := h i
+  rw [Hex.DensePoly.coeff_scale c x i (mul_zero c),
+    Hex.DensePoly.coeff_scale c y i (mul_zero c)] at hi
+  have hdvd : (m : Int) ∣ c * (x.coeff i - y.coeff i) := by
+    have hd := Int.dvd_of_emod_eq_zero hi
+    have he : c * x.coeff i - c * y.coeff i = c * (x.coeff i - y.coeff i) := by ring
+    rwa [he] at hd
+  have hcop : IsCoprime (m : Int) c := by
+    rw [Int.isCoprime_iff_gcd_eq_one, Int.gcd_comm]
+    simpa [Int.ofNat_eq_natCast] using hgcd
+  exact Int.emod_eq_zero_of_dvd (hcop.dvd_of_dvd_mul_left hdvd)
+
+/-- **Logarithmic-derivative bridge from recovery proportionality.**
+
+Given the recovery proportionality `ℓf · G ≡ c · factor (mod m)` (the centred-lift
+/ primitive-part relation between the monic support product `G` scaled by `core`'s
+leading coefficient and the recovered integer factor) with `ℓf` coprime to `m`, the
+logarithmic-derivative numerators are proportional:
+`factor · G' ≡ G · factor' (mod m)`.
+
+This is exactly the `hbridge` hypothesis consumed by
+`aggregateResidueData_of_factorBridge`: differentiate the proportionality, cross-
+multiply by the respective other factor, and cancel the unit scalar `ℓf`. -/
+theorem congr_logDeriv_bridge_of_scale_congr
+    {ℓf c : Int} {factor G : Hex.ZPoly} {m : Nat}
+    (hgcd : Int.gcd ℓf (Int.ofNat m) = 1)
+    (hpropr : Hex.ZPoly.congr (Hex.DensePoly.scale ℓf G)
+        (Hex.DensePoly.scale c factor) m) :
+    Hex.ZPoly.congr
+      (factor * Hex.DensePoly.derivative G)
+      (G * Hex.DensePoly.derivative factor) m := by
+  -- Differentiate the proportionality and commute the scalar through.
+  have hder : Hex.ZPoly.congr
+      (Hex.DensePoly.scale ℓf (Hex.DensePoly.derivative G))
+      (Hex.DensePoly.scale c (Hex.DensePoly.derivative factor)) m := by
+    have h := congr_derivative _ _ _ hpropr
+    rwa [derivative_scale, derivative_scale] at h
+  -- Multiply the proportionality by `factor'` and the derivative congruence by `factor`.
+  have hC : Hex.ZPoly.congr
+      (Hex.DensePoly.scale ℓf (G * Hex.DensePoly.derivative factor))
+      (Hex.DensePoly.scale c (factor * Hex.DensePoly.derivative factor)) m := by
+    have h := Hex.ZPoly.congr_mul _ _ _ _ _ hpropr
+      (Hex.ZPoly.congr_refl (Hex.DensePoly.derivative factor) m)
+    rwa [scale_mul_left, scale_mul_left] at h
+  have hD : Hex.ZPoly.congr
+      (Hex.DensePoly.scale ℓf (factor * Hex.DensePoly.derivative G))
+      (Hex.DensePoly.scale c (factor * Hex.DensePoly.derivative factor)) m := by
+    have h := Hex.ZPoly.congr_mul _ _ _ _ _
+      (Hex.ZPoly.congr_refl factor m) hder
+    rwa [scale_mul_right, scale_mul_right] at h
+  -- Both sides equal `scale c (factor · factor')`; cancel `ℓf`.
+  have hcancel : Hex.ZPoly.congr
+      (Hex.DensePoly.scale ℓf (factor * Hex.DensePoly.derivative G))
+      (Hex.DensePoly.scale ℓf (G * Hex.DensePoly.derivative factor)) m :=
+    Hex.ZPoly.congr_trans _ _ _ _ hD (Hex.ZPoly.congr_symm _ _ _ hC)
+  exact congr_scale_cancel ℓf _ _ m hgcd hcancel
+
 /-- **Core aggregate-residue producer (the non-monic `#8290` deliverable).**
 
 Discharges `AggregateResidueData` for one true support `S` of the executable's

--- a/progress/20260623T071438Z_73313195.md
+++ b/progress/20260623T071438Z_73313195.md
@@ -1,0 +1,76 @@
+# Core-coordinate cut: recovery glue + hbridge math — #8290 (one-shot `/once`)
+
+Session type: feature (one-shot). UTC 2026-06-23T07:14.
+
+## Accomplished
+
+Landed the entire **recovery-glue + logarithmic-derivative bridge** residual that
+#8310's progress note flagged as the remaining new math for the core-coordinate
+forward cut. All additive, all green, no `sorry`/`axiom`/`native_decide`.
+
+In `HexBerlekampZassenhausMathlib/CLDColumnBound.lean`:
+
+- `scale_mul_left` / `scale_mul_right` — pull a constant scalar out of a product.
+- `derivative_scale` — the formal derivative commutes with constant scaling.
+- `congr_scale_cancel` — cancel a unit scalar (coprime to the modulus) from a
+  congruence (the "small scalar-unit congruence-cancellation helper" the note
+  flagged as missing).
+- `congr_logDeriv_bridge_of_scale_congr` — **the `hbridge` producer**: from the
+  proportionality `ℓf·G ≡ c·factor (mod m)` (ℓf coprime to m), derives
+  `factor·G' ≡ G·factor' (mod m)` by differentiating, cross-multiplying, and
+  cancelling ℓf. This is exactly the `hbridge` hypothesis consumed by
+  `aggregateResidueData_of_factorBridge` (#8310).
+- `congr_logDeriv_bridge_of_recoveredM1` — composition glue: chains the recovery
+  proportionality into the bridge, producing `hbridge` over the concrete
+  `supportProduct L S` directly from a `RecoveredAtLiftM1` witness; the only
+  remaining input is the identification `liftedFactorProduct d Ssub = supportProduct L S`.
+
+In `HexBerlekampZassenhausMathlib/Basic.lean`:
+
+- `centeredLiftPoly_congr_self` — a centred lift is congruent to its argument mod m.
+- `exists_scale_congr_factor_of_recoveredM1` — **the recovery proportionality
+  producer (piece 1)**: from `RecoveredAtLiftM1 core d factor S`, derives
+  `∃ c, ℓf·(∏ S) ≡ c·factor (mod p^k)` (c = content of the centred lift), via the
+  witness's `candidate_eq` + `content_mul_primitivePart` + the centred-lift
+  congruence.
+
+Verification: `lake build HexBerlekampZassenhausMathlib` — green (3784 jobs). The
+two pre-existing `sorry` warnings (`Basic.lean:233`, `FactorSoundness.lean:18`) are
+scaffolding, not from this work.
+
+## Current frontier
+
+The cut is now constructible end-to-end **given the call-site inputs**. The chain is:
+
+  RecoveredAtLiftM1 witness  ──exists_scale_congr_factor_of_recoveredM1──▶  hpropr
+  hpropr  ──congr_logDeriv_bridge_of_scale_congr──▶  hbridge
+  (hbridge + hfac + hfactor)  ──aggregateResidueData_of_factorBridge──▶  AggregateResidueData
+  AggregateResidueData per support  ──cutProjectionHypotheses_of_aggregateResidue (#8309)──▶  the core forward cut
+
+Every link except the first/last is landed and green.
+
+## Next step (the remaining residual — call-site assembly)
+
+The only remaining work is **executable call-site wiring**, which needs new
+infrastructure that does not exist yet:
+
+1. **A `RecoveredAtLiftM1` witness producer at the fast-core path.** `RecoveredAtLiftM1`
+   is currently only *consumed* — nothing produces one. The non-monic sibling of
+   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`
+   (`PartitionRefinement.lean:808`) must build it from the fast-core recovery witness.
+2. **The identification `liftedFactorProduct d Ssub = supportProduct (bhksLatticeBasis core p a liftedFactors) S`** — the abstract lifted product equals the concrete BHKS support product (a definitional/structural equality at the call site).
+3. **`hfactor : toPolynomial core = toPolynomial factor * toPolynomial cof`** — the integer factorisation, from the recovery's divisibility.
+4. **`hfac`** from #8307/#8308's `coreLiftData_liftedFactor_hensel_semantics`, and
+   the good-prime `gcd(ℓf, p^a) = 1`.
+5. Feed `aggregateResidueData_of_factorBridge` per true support into
+   `cutProjectionHypotheses_of_aggregateResidue` (#8309).
+
+This is the #8304-sequenced call-site swap territory; it is a distinct, substantial
+piece (it needs a brand-new `RecoveredAtLiftM1` producer), so it is left for a
+successor.
+
+## Blockers
+
+None technical for the landed math. Marked partial because the call-site assembly
+(item 1-5 above) remains and depends on a `RecoveredAtLiftM1` producer that does not
+exist yet.


### PR DESCRIPTION
This PR lands the recovery-glue and logarithmic-derivative bridge math for the core-coordinate forward cut, the remaining new math flagged by #8310. From an `M1` recovery witness it derives the proportionality `ℓf·(∏ S) ≡ c·factor (mod p^k)` (`exists_scale_congr_factor_of_recoveredM1`), turns that into the cross-multiplied bridge `factor·G' ≡ G·factor' (mod m)` (`congr_logDeriv_bridge_of_scale_congr`) by differentiating and cancelling the unit scalar `ℓf` (`congr_scale_cancel`), and composes the two into a direct `hbridge` producer over the concrete support product (`congr_logDeriv_bridge_of_recoveredM1`). The supporting scale and derivative algebra (`scale_mul_left`/`scale_mul_right`/`derivative_scale`) and the centred-lift congruence (`centeredLiftPoly_congr_self`) are added alongside. Together with the landed `aggregateResidueData_of_factorBridge` (#8310), `cutProjectionHypotheses_of_aggregateResidue` (#8309), and the `coreLiftData` Hensel `hfac` (#8307/#8308), every link of the cut chain except the executable call-site assembly is now green.

Partial: the remaining residual is call-site wiring, which needs a `RecoveredAtLiftM1` witness producer at the fast-core path (none exists yet — the type is currently only consumed), the identification `liftedFactorProduct d Ssub = supportProduct (bhksLatticeBasis core p a liftedFactors) S`, the integer factorisation `hfactor`, and the per-support feed into `cutProjectionHypotheses_of_aggregateResidue`. See the progress entry for the full chain and successor scope.

Additive only; no `sorry`/`axiom`/`native_decide`. `lake build HexBerlekampZassenhausMathlib` is green.

🤖 Prepared with Claude Code