### PR TITLE
feat: end-to-end core-coordinate forward cut from M1 recovery witnesses

### DIFF
--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2639,6 +2639,118 @@ theorem aggregateResidueData_of_factorBridge
   exact listSum_emod_eq _ _ _ _
     (fun i _ => centeredResiduePow_emod_self p a _)
 
+/-- **Forward cut over the core basis from per-support factor-bridge data
+(the non-monic `#8290` assembly).**
+
+Builds the core-coordinate `CutProjectionHypotheses` — the forward `W ⊆ L'` over
+the executable's actual non-monic basis `bhksLatticeBasis core p a liftedFactors`
+— by discharging `AggregateResidueData` for each true support via
+`aggregateResidueData_of_factorBridge` and routing the family through
+`cutProjectionHypotheses_of_aggregateResidue`.
+
+This is the non-monic analogue of `cutProjectionHypotheses_of_recoveredLift`: per
+support it consumes the genuine integer factorisation `core = factorₛ · cofₛ`
+(`hfactor`), the per-selected-factor Hensel congruence (`hfac`), and the
+logarithmic-derivative bridge `factorₛ · G' ≡ G · factorₛ' (mod pᵃ)` (`hbridge`,
+where `G = supportProduct …`). -/
+theorem cutProjectionHypotheses_of_factorBridge
+    (core : Hex.ZPoly) (p a : Nat) (liftedFactors : Array Hex.ZPoly)
+    (hrows :
+      1 ≤ (Hex.bhksLatticeBasis core p a liftedFactors).factorCount +
+        (Hex.bhksLatticeBasis core p a liftedFactors).coeffWidth)
+    (hbasis : (Hex.bhksLatticeBasis core p a liftedFactors).basis.independent)
+    (trueSupports :
+      Set (Set (Fin
+        (Hex.bhksProjectedRows
+          (Hex.bhksLatticeBasis core p a liftedFactors) hrows).factorCount)))
+    (hp : 2 ≤ p)
+    (hk : 1 < p ^ a)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound core j < p ^ a)
+    (hthr : ∀ j, Hex.bhksCoeffCutThreshold p core j ≤ a)
+    (factor cof : trueSupports → Hex.ZPoly)
+    (hfac : ∀ S : trueSupports,
+      ∀ i : Fin (Hex.bhksLatticeBasis core p a liftedFactors).factorCount, i ∈ S.1 →
+        ∃ h : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((Hex.bhksLatticeBasis core p a liftedFactors).liftedFactors.getD i.val 1) ∧
+          0 < ((Hex.bhksLatticeBasis core p a liftedFactors).liftedFactors.getD
+            i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr core
+            (((Hex.bhksLatticeBasis core p a liftedFactors).liftedFactors.getD i.val 1) * h)
+            (p ^ a))
+    (hfactor : ∀ S : trueSupports,
+      HexPolyMathlib.toPolynomial core
+        = HexPolyMathlib.toPolynomial (factor S) * HexPolyMathlib.toPolynomial (cof S))
+    (hbridge : ∀ S : trueSupports,
+      Hex.ZPoly.congr
+        ((factor S) *
+          Hex.DensePoly.derivative
+            (supportProduct (Hex.bhksLatticeBasis core p a liftedFactors) S.1))
+        (supportProduct (Hex.bhksLatticeBasis core p a liftedFactors) S.1 *
+          Hex.DensePoly.derivative (factor S)) (p ^ a)) :
+    CutProjectionHypotheses
+      (Hex.bhksProjectedRows (Hex.bhksLatticeBasis core p a liftedFactors) hrows)
+      trueSupports :=
+  cutProjectionHypotheses_of_aggregateResidue core p a liftedFactors hrows hbasis
+    trueSupports hp hthr
+    (fun S => aggregateResidueData_of_factorBridge core (factor S) (cof S) p a
+      liftedFactors S.1 hk hsep (hfac S) (hfactor S) (hbridge S))
+
+/-- **Forward cut over the core basis from a family of `M1` recovery witnesses.**
+
+The non-monic analogue of `cutProjectionHypotheses_of_recoveredLift`: where the
+monic route consumes a `RecoveredLift` per support, this consumes the
+`RecoveredAtLiftM1` witness that the executable fast-core recovery actually
+exposes (#8290), plus the abstract/concrete support-product identification
+`hsupp : liftedFactorProduct d (subset S) = supportProduct L S`.  Each witness
+yields the logarithmic-derivative bridge via
+`congr_logDeriv_bridge_of_recoveredM1`, which then drives
+`cutProjectionHypotheses_of_factorBridge`.
+
+Everything is stated over the lift data `d`'s own modulus `d.p ^ d.k`; the basis
+is `bhksLatticeBasis core d.p d.k d.liftedFactors`. -/
+theorem cutProjectionHypotheses_of_recoveredM1
+    (core : Hex.ZPoly) (d : Hex.LiftData)
+    (hrows :
+      1 ≤ (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount +
+        (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).coeffWidth)
+    (hbasis : (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).basis.independent)
+    (trueSupports :
+      Set (Set (Fin
+        (Hex.bhksProjectedRows
+          (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows).factorCount)))
+    (hp : 2 ≤ d.p)
+    (hk : 1 < d.p ^ d.k)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound core j < d.p ^ d.k)
+    (hthr : ∀ j, Hex.bhksCoeffCutThreshold d.p core j ≤ d.k)
+    (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (d.p ^ d.k)) = 1)
+    (factor cof : trueSupports → Hex.ZPoly)
+    (subset : trueSupports → LiftedFactorSubset d)
+    (hrec : ∀ S : trueSupports, RecoveredAtLiftM1 core d (factor S) (subset S))
+    (hsupp : ∀ S : trueSupports,
+      liftedFactorProduct d (subset S)
+        = supportProduct (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) S.1)
+    (hfac : ∀ S : trueSupports,
+      ∀ i : Fin (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount, i ∈ S.1 →
+        ∃ h : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) ∧
+          0 < ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD
+            i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr core
+            (((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) * h)
+            (d.p ^ d.k))
+    (hfactor : ∀ S : trueSupports,
+      HexPolyMathlib.toPolynomial core
+        = HexPolyMathlib.toPolynomial (factor S) * HexPolyMathlib.toPolynomial (cof S)) :
+    CutProjectionHypotheses
+      (Hex.bhksProjectedRows (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows)
+      trueSupports :=
+  cutProjectionHypotheses_of_factorBridge core d.p d.k d.liftedFactors hrows hbasis
+    trueSupports hp hk hsep hthr factor cof hfac hfactor
+    (fun S => congr_logDeriv_bridge_of_recoveredM1 (hrec S)
+      (lt_trans Nat.zero_lt_one hk) hgcd (hsupp S))
+
 /-- The accumulator of a `max`-fold never decreases below its seed. -/
 private theorem foldl_max_ge_init (l : List Nat) (f : Nat → Nat) :
     ∀ init : Nat, init ≤ l.foldl (fun acc x => max acc (f x)) init := by

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -844,6 +844,76 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift
     hcore_ne h hcut hsize hpartition
 
 /--
+Non-monic sibling of
+`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`: the
+fast-core irreducibility endpoint discharged over the executable's **core**
+(non-monic) basis `bhksLatticeBasis core d.p d.k d.liftedFactors`, issue #8290.
+
+Where the monic version consumes a `RecoveredLift` per true support, this consumes
+the `RecoveredAtLiftM1` recovery witness the fast-core path actually exposes,
+together with the abstract/concrete support-product identification
+`hsupp : liftedFactorProduct d (subset S) = supportProduct L S`.  The forward cut
+is built by `BHKS.cutProjectionHypotheses_of_recoveredM1` (recovery proportionality
+→ logarithmic-derivative bridge → non-monic aggregate residue), bypassing the
+type-impossible monic `RecoveredLift` (#8288).  `hgcd` is the good-prime condition
+`p ∤ leadingCoeff core`; `hp`/`hk`/`hsep`/`hthr` are the BHKS Lemma 5.7 separation
+inputs at the recovery precision; `hfac` is the per-selected-factor Hensel datum
+`gᵢ ∣ core (mod pᵃ)`; `hfactor` is the genuine integer factorisation
+`core = factorₛ · cofₛ`. -/
+theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredM1
+    {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
+    {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
+    {d : Hex.LiftData}
+    {hrows :
+      1 ≤ (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount +
+        (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).coeffWidth}
+    (trueSupports :
+      Set (Set (Fin
+        (Hex.bhksProjectedRows
+          (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows).factorCount)))
+    (hcore_ne : core ≠ 0)
+    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (hbasis : (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).basis.independent)
+    (hp : 2 ≤ d.p)
+    (hk : 1 < d.p ^ d.k)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound core j < d.p ^ d.k)
+    (hthr : ∀ j, Hex.bhksCoeffCutThreshold d.p core j ≤ d.k)
+    (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (d.p ^ d.k)) = 1)
+    (factor cof : trueSupports → Hex.ZPoly)
+    (subset : trueSupports → LiftedFactorSubset d)
+    (hrec : ∀ S : trueSupports, RecoveredAtLiftM1 core d (factor S) (subset S))
+    (hsupp : ∀ S : trueSupports,
+      liftedFactorProduct d (subset S)
+        = BHKS.supportProduct (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) S.1)
+    (hfac : ∀ S : trueSupports,
+      ∀ i : Fin (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount, i ∈ S.1 →
+        ∃ g : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) ∧
+          0 < ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD
+            i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr core
+            (((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) * g)
+            (d.p ^ d.k))
+    (hfactor : ∀ S : trueSupports,
+      HexPolyMathlib.toPolynomial core
+        = HexPolyMathlib.toPolynomial (factor S) * HexPolyMathlib.toPolynomial (cof S))
+    (hsize :
+      coreFactors.size =
+        (Hex.bhksEquivalenceClassIndicators
+          (Hex.bhksProjectedRows
+            (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows)).size)
+    (hpartition :
+      (BHKS.supportPartitionByMinColumn trueSupports).length =
+        (UniqueFactorizationMonoid.normalizedFactors
+          (HexPolyZMathlib.toPolynomial core)).card) :
+    ∀ factor ∈ coreFactors.toList, Hex.ZPoly.Irreducible factor := by
+  have hcut := BHKS.cutProjectionHypotheses_of_recoveredM1 core d hrows hbasis
+    trueSupports hp hk hsep hthr hgcd factor cof subset hrec hsupp hfac hfactor
+  exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut trueSupports
+    hcore_ne h hcut hsize hpartition
+
+/--
 Fast-core irreducibility wrapper from a monic recovered-lift family produced by
 `recoveredLift_subtypeFamily_of_indicatorCandidates`.
 

--- a/progress/20260623T075227Z_8b56f761.md
+++ b/progress/20260623T075227Z_8b56f761.md
@@ -1,0 +1,73 @@
+# Core-coordinate cut: end-to-end forward-cut assembly — #8290 (one-shot `/once`)
+
+Session type: feature (one-shot). UTC 2026-06-23T07:52.
+
+## Accomplished
+
+Closed the assembly gap the previous session (`73313195`) flagged: the
+landed recovery-glue + `hbridge` math is now wired all the way to the
+fast-core irreducibility endpoint over the **core** (non-monic) basis.
+All additive, all green, no `sorry`/`axiom`/`native_decide`.
+
+In `HexBerlekampZassenhausMathlib/CLDColumnBound.lean` (namespace `BHKS`):
+
+- `cutProjectionHypotheses_of_factorBridge` — the non-monic analogue of
+  `cutProjectionHypotheses_of_recoveredLift`. Builds the core-coordinate
+  `CutProjectionHypotheses` (the forward `W ⊆ L'`, the #8290 deliverable)
+  by discharging `AggregateResidueData` per true support via
+  `aggregateResidueData_of_factorBridge` (#8310) and routing the family
+  through `cutProjectionHypotheses_of_aggregateResidue` (#8309). Per support
+  it consumes the integer factorisation `core = factorₛ·cofₛ`, the
+  per-factor Hensel datum, and the log-derivative bridge.
+- `cutProjectionHypotheses_of_recoveredM1` — consumes the
+  `RecoveredAtLiftM1` witness the fast-core path actually exposes plus the
+  support-product identification `hsupp`, derives the bridge per support via
+  `congr_logDeriv_bridge_of_recoveredM1` (#8311), then calls the bridge
+  producer. Stated over `d`'s own modulus `d.p ^ d.k`.
+
+In `HexBerlekampZassenhausMathlib/PartitionRefinement.lean`:
+
+- `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredM1` —
+  the non-monic sibling of
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`
+  (`:808`). Takes the `RecoveredAtLiftM1` family + separation/Hensel/gcd
+  inputs, builds the cut via `BHKS.cutProjectionHypotheses_of_recoveredM1`,
+  and finishes through `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_cut`.
+
+The chain the previous note drew (`RecoveredAtLiftM1 → hpropr → hbridge →
+AggregateResidueData → cut`) is now a single typed call path from the
+recovery witness family to `∀ factor ∈ coreFactors, Irreducible factor`.
+
+Verification: `lake build HexBerlekampZassenhausMathlib` — green (3784 jobs).
+Pre-existing `sorry` warnings (`Basic.lean:233`, `FactorSoundness.lean:18`)
+are scaffolding, not from this work.
+
+## Current frontier
+
+The forward cut over the core basis is reachable end-to-end **given** a
+per-support `RecoveredAtLiftM1` witness family and the `hsupp`
+identification — exactly the way the monic `:808` wrapper is reachable
+given a `RecoveredLift` family. #8290's "produce the core-coordinate cut"
+deliverable is met at the theorem level.
+
+## Next step (the #8304-sequenced call-site swap)
+
+What remains is the executable call-site instantiation, which is #8304
+territory, not #8290:
+
+1. A `RecoveredAtLiftM1` witness **producer** at the fast-core success
+   path (currently `RecoveredAtLiftM1` is only consumed). The executable
+   `bhksIndicatorCandidateCore?` (`HexBerlekampZassenhaus/Basic.lean:6867`)
+   is the M1 image; a producer must package it into the structure.
+2. The identification `liftedFactorProduct d (subset S) =
+   supportProduct (bhksLatticeBasis core d.p d.k d.liftedFactors) S` at the
+   call site (`subset := coreLiftData …`).
+3. `hfac` from `coreLiftData_liftedFactor_hensel_semantics` (#8308),
+   `hgcd` from the good-prime condition, `hfactor` from the recovery's
+   integer divisibility.
+4. Feed into `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredM1`.
+
+## Blockers
+
+None technical for the landed math. The remaining call-site swap (#8304)
+needs a brand-new `RecoveredAtLiftM1` producer and is a distinct piece.


### PR DESCRIPTION
Closes #8290

This PR wires the landed non-monic aggregate-residue and logarithmic-derivative-bridge math to the fast-core irreducibility endpoint over the executable's actual **core** (non-monic) basis `bhksLatticeBasis core d.p d.k d.liftedFactors`, producing the forward cut `W ⊆ L'` that issue #8290 names — without the type-impossible monic `RecoveredLift` (#8288). It adds, all additive and green:

- `BHKS.cutProjectionHypotheses_of_factorBridge` — the non-monic analogue of `cutProjectionHypotheses_of_recoveredLift`: the core-coordinate `CutProjectionHypotheses` from per-support integer factorisation `core = factorₛ · cofₛ`, the per-factor Hensel datum, and the log-derivative bridge, by discharging `AggregateResidueData` (#8310) and routing through `cutProjectionHypotheses_of_aggregateResidue` (#8309).
- `BHKS.cutProjectionHypotheses_of_recoveredM1` — the same, consuming the `RecoveredAtLiftM1` recovery witness the fast-core path exposes plus the support-product identification `hsupp`, deriving the bridge per support via `congr_logDeriv_bridge_of_recoveredM1` (#8311).
- `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredM1` — the non-monic sibling of the monic `:808` wrapper, carrying the `RecoveredAtLiftM1` family to `∀ factor ∈ coreFactors, Irreducible factor`.

This completes #8290's stated deliverable (piece 3: feed the core aggregate residue into the cut producer); pieces 1 and 2 landed in #8310/#8311. As with the monic `:808` sibling, the cut is reachable given a per-support recovery-witness family; the executable `RecoveredAtLiftM1` producer and call-site instantiation are the separate #8304 swap.

`lake build HexBerlekampZassenhausMathlib` is green (3784 jobs); no `sorry`/`axiom`/`native_decide` introduced.

🤖 Prepared with Claude Code
