### PR TITLE
feat: non-monic Core recovery-success producer (ForwardRecoveryInputsCore + coreRecover?_eq_some) — termination-side prereq for the M1 swap

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7415,6 +7415,136 @@ theorem bhksIndicatorCandidatesCore?_size_eq
     bhksIndicatorCandidatesCoreStep_fold_size_eq f d indicators.toList #[] candidates h
   simpa [Array.length_toList] using hfold
 
+private theorem bhksIndicatorCandidatesCoreStep_fold_eq_some_append
+    (f : ZPoly) (d : LiftData) :
+    ∀ (indicators : List (Array Int)) (candidates : List ZPoly) (acc : Array ZPoly),
+      (hlength : candidates.length = indicators.length) →
+      (∀ i (hi : i < indicators.length),
+        ∃ quotient,
+          bhksIndicatorCandidateCore? f d indicators[i] =
+            some (candidates[i]'(by rw [hlength]; exact hi), quotient)) →
+      List.foldl (bhksIndicatorCandidatesCoreStep f d) (some acc) indicators =
+        some (acc ++ candidates.toArray)
+  | [], candidates, acc, hlength, _ => by
+      have hcandidates : candidates = [] := List.eq_nil_of_length_eq_zero hlength
+      subst hcandidates
+      apply congrArg some
+      rw [← Array.toList_inj]
+      simp
+  | indicator :: indicators, candidates, acc, hlength, hcandidate => by
+      cases candidates with
+      | nil => simp at hlength
+      | cons candidate candidates =>
+          have hhead :
+              ∃ quotient,
+                bhksIndicatorCandidateCore? f d indicator =
+                  some (candidate, quotient) := by
+            simpa using hcandidate 0 (Nat.succ_pos _)
+          rcases hhead with ⟨quotient, hhead⟩
+          have hlength_tail : candidates.length = indicators.length := by
+            simpa using Nat.succ.inj hlength
+          have htail :
+              ∀ i (hi : i < indicators.length),
+                ∃ quotient,
+                  bhksIndicatorCandidateCore? f d indicators[i] =
+                    some (candidates[i]'(by rw [hlength_tail]; exact hi), quotient) := by
+            intro i hi
+            simpa using hcandidate (i + 1) (Nat.succ_lt_succ hi)
+          calc
+            List.foldl (bhksIndicatorCandidatesCoreStep f d) (some acc)
+                (indicator :: indicators)
+                =
+              List.foldl (bhksIndicatorCandidatesCoreStep f d)
+                (some (acc.push candidate)) indicators := by
+                  simp [bhksIndicatorCandidatesCoreStep, hhead]
+            _ = some (acc.push candidate ++ candidates.toArray) := by
+                  exact bhksIndicatorCandidatesCoreStep_fold_eq_some_append
+                    f d indicators candidates (acc.push candidate) hlength_tail htail
+            _ = some (acc ++ (candidate :: candidates).toArray) := by
+                  apply congrArg some
+                  rw [← Array.toList_inj]
+                  simp [Array.toList_append]
+
+/--
+Assemble the Core indicator-candidate fold from per-indicator reconstruction
+facts.  The Core-coordinate (van Hoeij `M1`) analogue of
+`bhksIndicatorCandidates?_eq_some_of_getD`: with a size agreement and one
+quotient witness for each indicator row, the executable Core fold returns the
+requested candidate array.
+-/
+theorem bhksIndicatorCandidatesCore?_eq_some_of_getD
+    (f : ZPoly) (d : LiftData)
+    (indicators : Array (Array Int)) (candidates : Array ZPoly)
+    (hsize : candidates.size = indicators.size)
+    (hcandidate :
+      ∀ i, i < indicators.size →
+        ∃ quotient,
+          bhksIndicatorCandidateCore? f d (indicators.getD i #[]) =
+            some (candidates.getD i 0, quotient)) :
+    bhksIndicatorCandidatesCore? f d indicators = some candidates := by
+  unfold bhksIndicatorCandidatesCore?
+  rw [← Array.foldl_toList]
+  have hlength : candidates.toList.length = indicators.toList.length := by
+    simpa [Array.length_toList] using hsize
+  have hcandidate_list :
+      ∀ i (hi : i < indicators.toList.length),
+        ∃ quotient,
+          bhksIndicatorCandidateCore? f d indicators.toList[i] =
+            some (candidates.toList[i]'(by rw [hlength]; exact hi), quotient) := by
+    intro i hi
+    have hi_array : i < indicators.size := by
+      simpa [Array.length_toList] using hi
+    have hi_candidates : i < candidates.size := by
+      simpa [hsize] using hi_array
+    rcases hcandidate i hi_array with ⟨quotient, hquotient⟩
+    refine ⟨quotient, ?_⟩
+    have hind :
+        indicators.toList[i] = indicators.getD i #[] := by
+      simp [Array.getD, Array.getElem_toList, hi_array]
+    have hcand :
+        candidates.toList[i] = candidates.getD i 0 := by
+      simp [Array.getD, Array.getElem_toList, hi_candidates]
+    rw [hind, hcand]
+    exact hquotient
+  have hfold :=
+    bhksIndicatorCandidatesCoreStep_fold_eq_some_append f d
+      indicators.toList candidates.toList #[] hlength hcandidate_list
+  rw [hfold]
+  apply congrArg some
+  rw [← Array.toList_inj]
+  simp
+
+/--
+If the executable Core BHKS recovery guards all pass, `coreRecover?` returns the
+verified candidate array.  Core-coordinate (van Hoeij `M1`) analogue of
+`bhksRecover?_eq_some_of_checks`: the public proof-facing surface for callers
+that should not unfold the private failure classifier.
+-/
+theorem coreRecover?_eq_some_of_checks
+    (f : ZPoly) (d : LiftData) {candidates : Array ZPoly}
+    (hrows : 1 ≤ (bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
+      (bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth)
+    (hnondeg :
+      bhksDegenerateIndicatorPartition
+          (bhksProjectedRows (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
+          (bhksEquivalenceClassIndicators
+            (bhksProjectedRows
+              (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) = false)
+    (hcand :
+      bhksIndicatorCandidatesCore? f d
+          (bhksEquivalenceClassIndicators
+            (bhksProjectedRows
+              (bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) =
+        some candidates)
+    (hprod : Array.polyProduct candidates = f) :
+    coreRecover? f d = some candidates := by
+  unfold coreRecover?
+  rw [bhksRecoverClassifiedCore]
+  have hproductCheck : (Array.polyProduct candidates == f) = true := by
+    simpa [beq_iff_eq] using hprod
+  simp only [dif_pos hrows, hnondeg, Bool.false_eq_true, if_false, hcand,
+    hproductCheck, if_true, BhksRecoveryResult.toOption]
+
 private def recombinationSearchAux
     (target : ZPoly) (localFactors : List ZPoly) : Nat → Option (List ZPoly)
   | 0 => none

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -7545,6 +7545,91 @@ theorem coreRecover?_eq_some_of_checks
   simp only [dif_pos hrows, hnondeg, Bool.false_eq_true, if_false, hcand,
     hproductCheck, if_true, BhksRecoveryResult.toOption]
 
+/--
+`M1` A2 reconstruction surface for a single Core indicator, stated at the
+Mathlib-free executable layer.  Core-coordinate analogue of
+`bhksIndicatorCandidate?_eq_some_of_dilatedCenteredLift`: if the indicator
+selects `selected`, the primitive part of the scaled selected-product centred
+lift (`ℓf · ∏ selected mod p^k`, the van Hoeij `M1` formula) is the expected
+factor, and that factor divides `f` as a positive-leading-coefficient
+positive-degree sign-normalised factor, then `bhksIndicatorCandidateCore?`
+returns that expected factor with some quotient.
+-/
+theorem bhksIndicatorCandidateCore?_eq_some_of_scaledCenteredLift
+    (f : ZPoly) (d : LiftData) (indicator : Array Int)
+    (selected : Array ZPoly) (expectedFactor : ZPoly)
+    (hselected :
+      bhksIndicatorSelectedFactors d.liftedFactors indicator = some selected)
+    (hdvd : expectedFactor ∣ f)
+    (hexpected_sign : 0 ≤ DensePoly.leadingCoeff expectedFactor)
+    (hexpected_pos_lc : 0 < DensePoly.leadingCoeff expectedFactor)
+    (hexpected_degree : 0 < expectedFactor.degree?.getD 0)
+    (hscaled :
+      ZPoly.primitivePart
+          (centeredLiftPoly
+            (ZPoly.reduceModPow
+              (DensePoly.scale (DensePoly.leadingCoeff f) (Array.polyProduct selected))
+              d.p d.k)
+            (d.p ^ d.k)) =
+        expectedFactor) :
+    ∃ quotient,
+      bhksIndicatorCandidateCore? f d indicator = some (expectedFactor, quotient) := by
+  have hnormalize :
+      normalizeFactorSign
+          (ZPoly.primitivePart
+            (centeredLiftPoly
+              (ZPoly.reduceModPow
+                (DensePoly.scale (DensePoly.leadingCoeff f)
+                  (Array.polyProduct selected))
+                d.p d.k)
+              (d.p ^ d.k))) =
+        expectedFactor := by
+    rw [hscaled]
+    exact normalizeFactorSign_eq_self_of_leadingCoeff_nonneg expectedFactor hexpected_sign
+  have hrecord :
+      shouldRecordPolynomialFactor expectedFactor = true := by
+    apply shouldRecordPolynomialFactor_eq_true_of_ne
+    · intro hzero
+      rw [hzero] at hexpected_degree
+      simp [DensePoly.degree?] at hexpected_degree
+    · intro hone
+      rw [hone] at hexpected_degree
+      have hdeg0 : (DensePoly.degree? (1 : ZPoly)).getD 0 = 0 := by rfl
+      rw [hdeg0] at hexpected_degree
+      omega
+    · intro hneg
+      rw [hneg] at hexpected_degree
+      have hdeg0 : (DensePoly.degree? (DensePoly.C (-1 : Int))).getD 0 = 0 := by simp
+      rw [hdeg0] at hexpected_degree
+      omega
+  rcases hdvd with ⟨quotient, hquotient_mul⟩
+  have hmul : quotient * expectedFactor = f := by
+    rw [DensePoly.mul_comm_poly (S := Int)]
+    exact hquotient_mul.symm
+  have hquotient :
+      exactQuotient? f expectedFactor = some quotient :=
+    exactQuotient?_eq_some_of_pos_lc_pos_degree_mul_eq
+      hexpected_pos_lc hexpected_degree hmul
+  refine ⟨quotient, ?_⟩
+  unfold bhksIndicatorCandidateCore?
+  rw [hselected]
+  change
+    (let modulus := liftModulus d
+     let candidate :=
+       normalizeFactorSign <| ZPoly.primitivePart <|
+         centeredLiftPoly
+           (ZPoly.reduceModPow
+             (DensePoly.scale (DensePoly.leadingCoeff f) (Array.polyProduct selected))
+             d.p d.k)
+           modulus
+     if shouldRecordPolynomialFactor candidate then
+       match exactQuotient? f candidate with
+       | some quotient => some (candidate, quotient)
+       | none => none
+     else
+       none) = some (expectedFactor, quotient)
+  simp [liftModulus, hnormalize, hrecord, hquotient]
+
 private def recombinationSearchAux
     (target : ZPoly) (localFactors : List ZPoly) : Nat → Option (List ZPoly)
   | 0 => none

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2642,6 +2642,128 @@ def ofCapSeparation
     expectedIndicators indicators_match nondegenerate
     expectedFactors hsize hcandidate product_eq
 
+/--
+Fold the single-indicator `M1` reconstruction theorem over an expected indicator
+array.  Core analogue of `ForwardRecoveryInputs.candidatesOfDilatedCenteredLift`:
+callers supply the selected lifted-factor products, true-factor facts, and the
+`M1` scaled-centred-lift equalities (`primitivePart (ℓf · ∏ selected mod p^k)`)
+for each indicator, and the executable Core candidate fold returns the expected
+factor array.
+-/
+theorem candidatesOfScaledCenteredLift
+    {f : Hex.ZPoly} {d : Hex.LiftData}
+    (expectedIndicators : Array (Array Int))
+    (selectedFactors : Array (Array Hex.ZPoly))
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hselected :
+      ∀ i, i < expectedIndicators.size →
+        Hex.bhksIndicatorSelectedFactors d.liftedFactors
+            (expectedIndicators.getD i #[]) =
+          some (selectedFactors.getD i #[]))
+    (hdivides :
+      ∀ i, i < expectedIndicators.size →
+        expectedFactors.getD i 0 ∣ f)
+    (hsign :
+      ∀ i, i < expectedIndicators.size →
+        0 ≤ Hex.DensePoly.leadingCoeff (expectedFactors.getD i 0))
+    (hpos_lc :
+      ∀ i, i < expectedIndicators.size →
+        0 < Hex.DensePoly.leadingCoeff (expectedFactors.getD i 0))
+    (hdegree :
+      ∀ i, i < expectedIndicators.size →
+        0 < (expectedFactors.getD i 0).degree?.getD 0)
+    (hscaled :
+      ∀ i, i < expectedIndicators.size →
+        Hex.ZPoly.primitivePart
+            (Hex.centeredLiftPoly
+              (Hex.ZPoly.reduceModPow
+                (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff f)
+                  (Array.polyProduct (selectedFactors.getD i #[])))
+                d.p d.k)
+              (d.p ^ d.k)) =
+          expectedFactors.getD i 0) :
+    Hex.bhksIndicatorCandidatesCore? f d expectedIndicators =
+      some expectedFactors :=
+  bhksIndicatorCandidatesCore?_eq_some_of_forwardCandidates
+    f d expectedIndicators expectedFactors hsize
+    (fun i hi =>
+      Hex.bhksIndicatorCandidateCore?_eq_some_of_scaledCenteredLift
+        f d (expectedIndicators.getD i #[])
+        (selectedFactors.getD i #[]) (expectedFactors.getD i 0)
+        (hselected i hi) (hdivides i hi)
+        (hsign i hi) (hpos_lc i hi) (hdegree i hi)
+        (hscaled i hi))
+
+/--
+Build `ForwardRecoveryInputsCore` from per-indicator `M1` reconstruction facts.
+Core analogue of `ForwardRecoveryInputs.ofMignottePrecisionCandidateProducts`:
+callers supply the selected-factor array for each indicator and the `M1`
+scaled-centred-lift equality the recovery formula establishes, and this
+constructor packages them through the Core candidate fold.
+-/
+def ofMignottePrecisionCandidateProducts
+    {f : Hex.ZPoly} {d : Hex.LiftData}
+    (rows_pos : HasPositiveDimension f d)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData f d rows_pos).factorCount)))
+    (lattice_eq_indicators :
+      BHKS.projectedRowSpanInt (projectedRowsOfLiftData f d rows_pos) =
+        BHKS.trueFactorIndicatorLattice trueSupports)
+    (mignotte_precision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound f < d.p ^ d.k)
+    (expectedIndicators : Array (Array Int))
+    (indicators_match :
+      equivalenceClassIndicatorsOfLiftData f d rows_pos = expectedIndicators)
+    (nondegenerate :
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData f d rows_pos) expectedIndicators = false)
+    (selectedFactors : Array (Array Hex.ZPoly))
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hselected :
+      ∀ i, i < expectedIndicators.size →
+        Hex.bhksIndicatorSelectedFactors d.liftedFactors
+            (expectedIndicators.getD i #[]) =
+          some (selectedFactors.getD i #[]))
+    (hdivides :
+      ∀ i, i < expectedIndicators.size →
+        expectedFactors.getD i 0 ∣ f)
+    (hsign :
+      ∀ i, i < expectedIndicators.size →
+        0 ≤ Hex.DensePoly.leadingCoeff (expectedFactors.getD i 0))
+    (hpos_lc :
+      ∀ i, i < expectedIndicators.size →
+        0 < Hex.DensePoly.leadingCoeff (expectedFactors.getD i 0))
+    (hdegree :
+      ∀ i, i < expectedIndicators.size →
+        0 < (expectedFactors.getD i 0).degree?.getD 0)
+    (hscaled :
+      ∀ i, i < expectedIndicators.size →
+        Hex.ZPoly.primitivePart
+            (Hex.centeredLiftPoly
+              (Hex.ZPoly.reduceModPow
+                (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff f)
+                  (Array.polyProduct (selectedFactors.getD i #[])))
+                d.p d.k)
+              (d.p ^ d.k)) =
+          expectedFactors.getD i 0)
+    (product_eq : Array.polyProduct expectedFactors = f) :
+    ForwardRecoveryInputsCore f d :=
+  { rows_pos := rows_pos
+    trueSupports := trueSupports
+    lattice_eq_indicators := lattice_eq_indicators
+    mignotte_precision := mignotte_precision
+    expectedIndicators := expectedIndicators
+    indicators_match := indicators_match
+    nondegenerate := nondegenerate
+    expectedFactors := expectedFactors
+    candidates_eq :=
+      candidatesOfScaledCenteredLift
+        expectedIndicators selectedFactors expectedFactors hsize
+        hselected hdivides hsign hpos_lc hdegree hscaled
+    product_eq := product_eq }
+
 end ForwardRecoveryInputsCore
 
 /--

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2380,6 +2380,291 @@ theorem bhksRecover_isSome_of_forwardInputs
     (Hex.bhksRecover? f d).isSome :=
   bhksRecover_isSome_of_recovery f d h.toRecoveryHypotheses
 
+/-! ### Core-coordinate (van Hoeij `M1`) recovery-success producers
+
+The structures and producers below mirror the monic-transform (`M2`)
+`RecoveryHypotheses` / `ForwardRecoveryInputs` family, but target the
+core-coordinate recovery `Hex.coreRecover?` and the core candidate fold
+`Hex.bhksIndicatorCandidatesCore?` instead of `Hex.bhksRecover?` /
+`Hex.bhksIndicatorCandidates?`.  The lattice machinery
+(`projectedRowsOfLiftData`, `equivalenceClassIndicatorsOfLiftData`, the B7
+indicator partition) is shared verbatim — only the per-indicator candidate
+reconstruction differs (no `dilate`; the `M1` formula scales the selected
+lifted product by `lc f` and takes the primitive part), so these producers
+carry the candidate equality over the core fold while reusing every lattice
+field from the monic-side layer.
+
+This is the termination-side substrate for the `#8304` M1 fast-path swap: the
+irreducibility side landed via `…_zpolyIrreducible_of_recoveredM1` (`#8312`);
+the termination side (`factorFast ≠ none`) needs a `coreRecover? = some`
+producer, which is `coreRecover?_eq_some_of_forwardInputsCore` below. -/
+
+/--
+Proof-facing hypotheses for forward Core (van Hoeij `M1`) BHKS recovery at fixed
+precision.  Core-coordinate analogue of `RecoveryHypotheses`: the only field
+that differs is `candidates_eq`, which is over the core candidate fold
+`Hex.bhksIndicatorCandidatesCore?`.
+-/
+structure RecoveryHypothesesCore (f : Hex.ZPoly) (d : Hex.LiftData) where
+  /-- Positive lattice dimension so the recovery enters the recovery branch. -/
+  rows_pos : HasPositiveDimension f d
+  /-- The equivalence-class partition is non-degenerate, so the executable
+      function does not bail out via `bhksDegenerateIndicatorPartition`. -/
+  nondegenerate :
+    Hex.bhksDegenerateIndicatorPartition
+        (projectedRowsOfLiftData f d rows_pos)
+        (equivalenceClassIndicatorsOfLiftData f d rows_pos) = false
+  /-- The verified factor list returned by the executable Core recovery. -/
+  expectedFactors : Array Hex.ZPoly
+  /-- Per-indicator `M1` centred-residue reconstruction succeeds and divides
+      `f`. -/
+  candidates_eq :
+    Hex.bhksIndicatorCandidatesCore? f d
+        (equivalenceClassIndicatorsOfLiftData f d rows_pos) =
+      some expectedFactors
+  /-- The reconstructed factors multiply back to `f`, so the final product
+      check inside `Hex.coreRecover?` succeeds. -/
+  product_eq : Array.polyProduct expectedFactors = f
+
+/--
+Core-coordinate forward-verification theorem: under the executable Core recovery
+hypotheses, `Hex.coreRecover? f d` returns `some <expected factors>`.  Mirrors
+`bhksRecover_eq_some_of_recovery`, routing through the executable
+`Hex.coreRecover?_eq_some_of_checks`.
+-/
+theorem coreRecover_eq_some_of_recovery
+    (f : Hex.ZPoly) (d : Hex.LiftData) (h : RecoveryHypothesesCore f d) :
+    Hex.coreRecover? f d = some h.expectedFactors := by
+  have hrows : 1 ≤ (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors).factorCount +
+      (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors).coeffWidth := h.rows_pos
+  have hnondeg :
+      Hex.bhksDegenerateIndicatorPartition
+          (Hex.bhksProjectedRows (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)
+          (Hex.bhksEquivalenceClassIndicators
+            (Hex.bhksProjectedRows
+              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) = false :=
+    h.nondegenerate
+  have hcand :
+      Hex.bhksIndicatorCandidatesCore? f d
+          (Hex.bhksEquivalenceClassIndicators
+            (Hex.bhksProjectedRows
+              (Hex.bhksLatticeBasis f d.p d.k d.liftedFactors) hrows)) =
+        some h.expectedFactors :=
+    h.candidates_eq
+  have hprod := h.product_eq
+  exact Hex.coreRecover?_eq_some_of_checks f d hrows hnondeg hcand hprod
+
+/-- Corollary form of `coreRecover_eq_some_of_recovery` that drops the
+expected-factors witness from the conclusion. -/
+theorem coreRecover_isSome_of_recovery
+    (f : Hex.ZPoly) (d : Hex.LiftData) (h : RecoveryHypothesesCore f d) :
+    (Hex.coreRecover? f d).isSome := by
+  rw [coreRecover_eq_some_of_recovery f d h]
+  rfl
+
+/--
+Core-coordinate analogue of `bhksIndicatorCandidates?_eq_some_of_forwardCandidates`:
+assemble the core candidate fold equality from per-indicator `M1` reconstruction
+facts.  Mathlib-side wrapper around the executable
+`Hex.bhksIndicatorCandidatesCore?_eq_some_of_getD`.
+-/
+theorem bhksIndicatorCandidatesCore?_eq_some_of_forwardCandidates
+    (f : Hex.ZPoly) (d : Hex.LiftData)
+    (expectedIndicators : Array (Array Int)) (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hcandidate :
+      ∀ i, i < expectedIndicators.size →
+        ∃ quotient,
+          Hex.bhksIndicatorCandidateCore? f d (expectedIndicators.getD i #[]) =
+            some (expectedFactors.getD i 0, quotient)) :
+    Hex.bhksIndicatorCandidatesCore? f d expectedIndicators =
+      some expectedFactors :=
+  Hex.bhksIndicatorCandidatesCore?_eq_some_of_getD
+    f d expectedIndicators expectedFactors hsize hcandidate
+
+/--
+Core-coordinate (van Hoeij `M1`) analogue of `ForwardRecoveryInputs`.
+
+Every field except `candidates_eq` is identical to the monic-side
+`ForwardRecoveryInputs` (the lattice / B7 indicator machinery is shared);
+`candidates_eq` is over the core candidate fold `Hex.bhksIndicatorCandidatesCore?`,
+reconstructing each indicator through the `M1` formula instead of the
+`dilate`-based `M2` one.
+-/
+structure ForwardRecoveryInputsCore (f : Hex.ZPoly) (d : Hex.LiftData) where
+  /-- Positive lattice dimension so the projected rows / recovery branch make
+      sense. -/
+  rows_pos : HasPositiveDimension f d
+  /-- True-factor supports backing the indicator lattice `W`. -/
+  trueSupports :
+    Set (Set (Fin (projectedRowsOfLiftData f d rows_pos).factorCount))
+  /-- BHKS `L' = W` at this lift data, the recovery-level core lattice
+      equality (the completeness sibling of the `#8290`/`#8312` cut). -/
+  lattice_eq_indicators :
+    BHKS.projectedRowSpanInt (projectedRowsOfLiftData f d rows_pos) =
+      BHKS.trueFactorIndicatorLattice trueSupports
+  /-- Mignotte-precision side condition: the modular precision exceeds twice
+      the executable Mignotte coefficient bound. -/
+  mignotte_precision :
+    2 * Hex.ZPoly.defaultFactorCoeffBound f < d.p ^ d.k
+  /-- BHKS Lemma 3.3 / B7 conclusion: the executable equivalence-class
+      indicators agree with a target indicator list `expectedIndicators`. -/
+  expectedIndicators : Array (Array Int)
+  indicators_match :
+    equivalenceClassIndicatorsOfLiftData f d rows_pos = expectedIndicators
+  /-- The chosen indicator partition is non-degenerate. -/
+  nondegenerate :
+    Hex.bhksDegenerateIndicatorPartition
+        (projectedRowsOfLiftData f d rows_pos) expectedIndicators = false
+  /-- `M1` A2 + exact division: each indicator reconstructs into a verified
+      integer factor via the core fold. -/
+  expectedFactors : Array Hex.ZPoly
+  candidates_eq :
+    Hex.bhksIndicatorCandidatesCore? f d expectedIndicators = some expectedFactors
+  /-- Final product check: the verified factors multiply back to `f`. -/
+  product_eq : Array.polyProduct expectedFactors = f
+
+namespace ForwardRecoveryInputsCore
+
+/-- Promote a core SPEC-input bundle to the immediate recovery hypotheses
+consumed by `coreRecover_eq_some_of_recovery`.  Mirrors
+`ForwardRecoveryInputs.toRecoveryHypotheses`. -/
+def toRecoveryHypothesesCore {f : Hex.ZPoly} {d : Hex.LiftData}
+    (h : ForwardRecoveryInputsCore f d) : RecoveryHypothesesCore f d where
+  rows_pos := h.rows_pos
+  nondegenerate := by
+    have hindicators := h.indicators_match
+    show
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData f d h.rows_pos)
+          (equivalenceClassIndicatorsOfLiftData f d h.rows_pos) = false
+    rw [hindicators]
+    exact h.nondegenerate
+  expectedFactors := h.expectedFactors
+  candidates_eq := by
+    have hindicators := h.indicators_match
+    show
+      Hex.bhksIndicatorCandidatesCore? f d
+        (equivalenceClassIndicatorsOfLiftData f d h.rows_pos) =
+        some h.expectedFactors
+    rw [hindicators]
+    exact h.candidates_eq
+  product_eq := h.product_eq
+
+/--
+Build `ForwardRecoveryInputsCore` when the `M1` A2/exact-division obligation is
+available as per-indicator core reconstruction witnesses rather than as the
+folded candidate equality.  Core analogue of
+`ForwardRecoveryInputs.ofIndicatorCandidateFacts`.
+-/
+def ofIndicatorCandidateFacts
+    {f : Hex.ZPoly} {d : Hex.LiftData}
+    (rows_pos : HasPositiveDimension f d)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData f d rows_pos).factorCount)))
+    (lattice_eq_indicators :
+      BHKS.projectedRowSpanInt (projectedRowsOfLiftData f d rows_pos) =
+        BHKS.trueFactorIndicatorLattice trueSupports)
+    (mignotte_precision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound f < d.p ^ d.k)
+    (expectedIndicators : Array (Array Int))
+    (indicators_match :
+      equivalenceClassIndicatorsOfLiftData f d rows_pos = expectedIndicators)
+    (nondegenerate :
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData f d rows_pos) expectedIndicators = false)
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hcandidate :
+      ∀ i, i < expectedIndicators.size →
+        ∃ quotient,
+          Hex.bhksIndicatorCandidateCore? f d (expectedIndicators.getD i #[]) =
+            some (expectedFactors.getD i 0, quotient))
+    (product_eq : Array.polyProduct expectedFactors = f) :
+    ForwardRecoveryInputsCore f d where
+  rows_pos := rows_pos
+  trueSupports := trueSupports
+  lattice_eq_indicators := lattice_eq_indicators
+  mignotte_precision := mignotte_precision
+  expectedIndicators := expectedIndicators
+  indicators_match := indicators_match
+  nondegenerate := nondegenerate
+  expectedFactors := expectedFactors
+  candidates_eq :=
+    bhksIndicatorCandidatesCore?_eq_some_of_forwardCandidates
+      f d expectedIndicators expectedFactors hsize hcandidate
+  product_eq := product_eq
+
+/--
+Build `ForwardRecoveryInputsCore f d` from cap-level BHKS separation plus the
+abstract B7 / `M1` A2 obligations.  Core analogue of
+`ForwardRecoveryInputs.ofCapSeparation`: `lattice_eq_indicators` is supplied
+internally by `projectedRowsOfLiftData_eq_trueFactorIndicatorLattice_of_cap`
+(shared with the monic side, since the lattice basis is the same), and the
+remaining fields pass through to `ofIndicatorCandidateFacts`.
+-/
+def ofCapSeparation
+    {f : Hex.ZPoly} {d : Hex.LiftData}
+    (rows_pos : HasPositiveDimension f d)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData f d rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hcap_le : Hex.factorFastPrecisionCap f ≤ d.k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcap :
+      ExecutableCapSeparationHypotheses
+        (badVectorWitnessOfLiftData f d rows_pos localFactorIndex
+          localFactorDegree H)
+        trueSupports)
+    (mignotte_precision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound f < d.p ^ d.k)
+    (expectedIndicators : Array (Array Int))
+    (indicators_match :
+      equivalenceClassIndicatorsOfLiftData f d rows_pos = expectedIndicators)
+    (nondegenerate :
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData f d rows_pos) expectedIndicators = false)
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hcandidate :
+      ∀ i, i < expectedIndicators.size →
+        ∃ quotient,
+          Hex.bhksIndicatorCandidateCore? f d (expectedIndicators.getD i #[]) =
+            some (expectedFactors.getD i 0, quotient))
+    (product_eq : Array.polyProduct expectedFactors = f) :
+    ForwardRecoveryInputsCore f d :=
+  ofIndicatorCandidateFacts
+    rows_pos trueSupports
+    (projectedRowsOfLiftData_eq_trueFactorIndicatorLattice_of_cap
+      f d rows_pos localFactorIndex localFactorDegree H trueSupports
+      hcap_le C hC_nonneg hC hcap)
+    mignotte_precision
+    expectedIndicators indicators_match nondegenerate
+    expectedFactors hsize hcandidate product_eq
+
+end ForwardRecoveryInputsCore
+
+/--
+Core-coordinate (van Hoeij `M1`) forward-verification statement at one
+precision/recovery call: under `L' = W`, Mignotte precision, and the residual
+B7 / `M1` A2 obligations, the executable `Hex.coreRecover? f d` returns
+`some <expected factors>`.
+
+This is the termination-side headline producer the `#8304` swap consumes (the
+irreducibility side is `#8312`'s `…_zpolyIrreducible_of_recoveredM1`).
+-/
+theorem coreRecover?_eq_some_of_forwardInputsCore
+    (f : Hex.ZPoly) (d : Hex.LiftData) (h : ForwardRecoveryInputsCore f d) :
+    Hex.coreRecover? f d = some h.expectedFactors :=
+  coreRecover_eq_some_of_recovery f d h.toRecoveryHypothesesCore
+
+/-- Corollary form: under the core forward-verification inputs,
+`Hex.coreRecover? f d` is `some _`. -/
+theorem coreRecover?_isSome_of_forwardInputsCore
+    (f : Hex.ZPoly) (d : Hex.LiftData) (h : ForwardRecoveryInputsCore f d) :
+    (Hex.coreRecover? f d).isSome :=
+  coreRecover_isSome_of_recovery f d h.toRecoveryHypothesesCore
+
 /--
 Cap-level specialisation: compose `ForwardRecoveryInputs.ofCapSeparation`
 with `bhksRecover_eq_some_of_forwardInputs` at a fixed `LiftData`.  Under

--- a/progress/20260623T084519Z_9b4773e0.md
+++ b/progress/20260623T084519Z_9b4773e0.md
@@ -1,0 +1,77 @@
+# Non-monic Core recovery-success producer — #8313 (one-shot `/once`)
+
+Session type: feature (one-shot). UTC 2026-06-23T08:45.
+
+## Accomplished
+
+Landed the Core-coordinate (van Hoeij `M1`) analogue of the monic-transform
+(`M2`) recovery-success producer family — the termination-side prerequisite
+for the `#8304` fast-path swap. All additive, all green, no
+`sorry`/`axiom`/`native_decide`.
+
+In `HexBerlekampZassenhaus/Basic.lean` (executable layer, additive):
+
+- `bhksIndicatorCandidatesCore?_eq_some_of_getD` (+ its fold-append helper
+  `bhksIndicatorCandidatesCoreStep_fold_eq_some_append`) — the Core reverse
+  fold, mirror of `bhksIndicatorCandidates?_eq_some_of_getD`.
+- `coreRecover?_eq_some_of_checks` — the public checks→success surface, mirror
+  of `bhksRecover?_eq_some_of_checks` (routes through the private
+  `bhksRecoverClassifiedCore`).
+- `bhksIndicatorCandidateCore?_eq_some_of_scaledCenteredLift` — the `M1`
+  per-indicator reconstruction primitive (no `dilate`: scale by `lc f`,
+  `reduceModPow`, centre-lift, `primitivePart`), mirror of
+  `bhksIndicatorCandidate?_eq_some_of_dilatedCenteredLift`.
+
+In `HexBerlekampZassenhausMathlib/Recovery.lean` (`namespace BHKS`):
+
+- `RecoveryHypothesesCore` + `coreRecover_eq_some_of_recovery`
+  (+ `coreRecover_isSome_of_recovery`).
+- `ForwardRecoveryInputsCore` — the deliverable structure: `candidates_eq`
+  over `bhksIndicatorCandidatesCore?`, `lattice_eq_indicators` over the shared
+  projected-row span (the recovery-level core lattice equality).
+- `coreRecover?_eq_some_of_forwardInputsCore` — the headline producer:
+  `coreRecover? f d = some h.expectedFactors`
+  (+ `coreRecover?_isSome_of_forwardInputsCore`).
+- Core constructor family in `namespace ForwardRecoveryInputsCore`:
+  `toRecoveryHypothesesCore`, `ofIndicatorCandidateFacts`, `ofCapSeparation`,
+  `candidatesOfScaledCenteredLift`, `ofMignottePrecisionCandidateProducts`,
+  plus the wrapper `bhksIndicatorCandidatesCore?_eq_some_of_forwardCandidates`.
+
+The lattice machinery (`projectedRowsOfLiftData`,
+`equivalenceClassIndicatorsOfLiftData`, the B7 indicator partition,
+`projectedRowsOfLiftData_eq_trueFactorIndicatorLattice_of_cap`) is shared
+verbatim with the monic side — only the per-indicator `M1` reconstruction
+differs, so `ofCapSeparation` reuses the monic cap-separation lattice equality
+directly. The structures/producers are generic in `d : Hex.LiftData`,
+instantiated to `coreLiftData …` at the `#8304` call site exactly as the `M2`
+family is instantiated to `toMonicLiftData …`.
+
+Verification: `lake build HexBerlekampZassenhausMathlib` — green (3784 jobs).
+Pre-existing `sorry` warnings (`Basic.lean:233`, `FactorSoundness.lean:18`) and
+the pre-existing M2 unused-variable warning (`Recovery.lean:1874`,
+`hf_ne_zero`) are not from this work.
+
+## Current frontier
+
+The three `#8313` deliverables are met at the theorem level and consumable by
+`#8304`: a caller with per-indicator `M1` recovery witnesses
+(`#8298 RecoveredAtLiftM1`, `#8308 coreLiftData_liftedFactor_hensel_semantics`,
+`#8306` Core extractors) builds a `ForwardRecoveryInputsCore` via
+`ofMignottePrecisionCandidateProducts` (supplying the scaled-centred-lift
+equality the recovery formula gives) and obtains `coreRecover? = some …` from
+`coreRecover?_eq_some_of_forwardInputsCore`.
+
+## Next step (the #8304 call-site swap)
+
+`#8304` instantiates `d := coreLiftData core target primeData`, derives the
+per-support `hscaled` reconstruction equalities from the `RecoveredAtLiftM1`
+witness family (the analogue of `M2`'s `RecoveredAtLift.candidate_eq_of_monic_dvd`
+→ `hdilated` route), and feeds `coreRecover?_eq_some_of_forwardInputsCore` into
+`factorFast_ne_none_of_core_recovery_on_schedule` for the termination side —
+pairing with `#8312`'s `…_zpolyIrreducible_of_recoveredM1` irreducibility side.
+
+## Blockers
+
+None. The recovery→reconstruction chain (deriving each `hscaled` from
+`RecoveredAtLiftM1`) is `#8304` territory, exactly as the `M2` reconstruction
+witnesses are supplied at the call site rather than inside the producer family.


### PR DESCRIPTION
Closes #8313

Session: `9b4773e0-c8e9-41c8-855f-4038e2b3d6e1`

8781ec48 docs: progress note for #8313 Core recovery-success producer
1154d55b feat: M1 per-indicator reconstruction primitive completing the Core constructor family (#8313)
8f65e39d feat: non-monic Core recovery-success producer (ForwardRecoveryInputsCore + coreRecover?_eq_some) — termination-side prereq for the M1 swap (#8313)
d23155c4 feat: executable Core recovery-success substrate (coreRecover?_eq_some_of_checks) for #8313

🤖 Prepared with Claude Code