### PR TITLE
feat: core-coordinate recovery-success producers from cap-separation (assembly tier for #8317)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -2830,6 +2830,55 @@ theorem bhksRecover_eq_some_of_capSeparation
       expectedFactors hsize hcandidate product_eq)
 
 /--
+Core (van Hoeij `M1`) cap-level specialisation: compose
+`ForwardRecoveryInputsCore.ofCapSeparation` with
+`coreRecover?_eq_some_of_forwardInputsCore` at a fixed `LiftData`.  Under
+cap-level BHKS separation and the residual B7 / `M1` A2 obligations,
+`Hex.coreRecover? f d` returns `some expectedFactors`.
+
+This is the core-coordinate analogue of `bhksRecover_eq_some_of_capSeparation`
+and the termination-side recovery producer the `#8304` swap consumes: once the
+executable `factorFast` routes through `Hex.coreRecover?`, the ~36 termination
+theorems re-point to this producer (their cap-separation `hcap` is supplied by
+`capSeparationOfBridgeDataAtFactorFastCoreCapLift`).
+-/
+theorem coreRecover?_eq_some_of_capSeparation
+    (f : Hex.ZPoly) (d : Hex.LiftData)
+    (rows_pos : HasPositiveDimension f d)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData f d rows_pos).factorCount)))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (hcap_le : Hex.factorFastPrecisionCap f ≤ d.k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcap :
+      ExecutableCapSeparationHypotheses
+        (badVectorWitnessOfLiftData f d rows_pos localFactorIndex
+          localFactorDegree H)
+        trueSupports)
+    (mignotte_precision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound f < d.p ^ d.k)
+    (expectedIndicators : Array (Array Int))
+    (indicators_match :
+      equivalenceClassIndicatorsOfLiftData f d rows_pos = expectedIndicators)
+    (nondegenerate :
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData f d rows_pos) expectedIndicators = false)
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hcandidate :
+      ∀ i, i < expectedIndicators.size →
+        ∃ quotient,
+          Hex.bhksIndicatorCandidateCore? f d (expectedIndicators.getD i #[]) =
+            some (expectedFactors.getD i 0, quotient))
+    (product_eq : Array.polyProduct expectedFactors = f) :
+    Hex.coreRecover? f d = some expectedFactors :=
+  coreRecover?_eq_some_of_forwardInputsCore f d
+    (ForwardRecoveryInputsCore.ofCapSeparation rows_pos trueSupports
+      localFactorIndex localFactorDegree H hcap_le C hC_nonneg hC hcap
+      mignotte_precision expectedIndicators indicators_match nondegenerate
+      expectedFactors hsize hcandidate product_eq)
+
+/--
 Compose the Mathlib-side forward-recovery inputs with the executable scheduled
 fast-path lemma: if a scheduled lift for the normalized square-free core
 satisfies the forward-verification inputs, then the public `Hex.factorFast`
@@ -10983,6 +11032,96 @@ theorem projectedRowSpan_eq_trueFactorIndicatorLattice_of_factorFastCoreCapLift_
     (capSeparationOfBridgeDataAtFactorFastCoreCapLift
       f primeData rows_pos localFactorIndex localFactorDegree H
       trueSupports hcut bridge hp hcomparison)
+
+/--
+Core (van Hoeij `M1`) recovery success for the actual `factorFast` cap lift:
+thread the landed cap-separation producer
+`capSeparationOfBridgeDataAtFactorFastCoreCapLift` (bridge package + analytic
+comparison) into `coreRecover?_eq_some_of_capSeparation`, discharging the
+`hcap` obligation from the bridge data and leaving only the B7 / `M1` A2 fields.
+
+This is the cap-lift-keyed recovery producer the `#8304` swap consumes: once the
+executable `factorFast` routes through `Hex.coreRecover?`, the termination
+theorems obtain `Hex.coreRecover? core (factorFastCoreCapLiftData f primeData) =
+some expectedFactors` from the same bridge/cut/comparison hypotheses that feed
+`projectedRowSpan_eq_trueFactorIndicatorLattice_of_factorFastCoreCapLift_bridge`.
+-/
+theorem coreRecover?_eq_some_of_factorFastCoreCapLift_bridge
+    (f : Hex.ZPoly) (primeData : Hex.PrimeChoiceData)
+    (rows_pos :
+      HasPositiveDimension
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCoreCapLiftData f primeData))
+    (localFactorIndex localFactorDegree : Nat) (H : Hex.ZPoly)
+    (trueSupports :
+      Set (Set (Fin (projectedRowsOfLiftData
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCoreCapLiftData f primeData)
+        rows_pos).factorCount)))
+    (hcap_le :
+      Hex.factorFastPrecisionCap (Hex.normalizeForFactor f).squareFreeCore ≤
+        (factorFastCoreCapLiftData f primeData).k)
+    (C : ℝ) (hC_nonneg : 0 ≤ C) (hC : C ≤ 2)
+    (hcut :
+      CutProjectionHypotheses
+        (projectedRowsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCoreCapLiftData f primeData)
+          rows_pos)
+        trueSupports)
+    (bridge :
+      ExecutableBadVectorWitness.BadVectorBridgeData
+        (badVectorWitnessOfFactorFastCoreCapLiftData
+          f primeData rows_pos localFactorIndex localFactorDegree H)
+        trueSupports)
+    (hp : 0 < (factorFastCoreCapLiftData f primeData).p)
+    (hcomparison :
+      FactorFastCoreCapLiftAnalyticComparison
+        f primeData rows_pos localFactorIndex localFactorDegree H)
+    (mignotte_precision :
+      2 * Hex.ZPoly.defaultFactorCoeffBound
+            (Hex.normalizeForFactor f).squareFreeCore <
+        (factorFastCoreCapLiftData f primeData).p ^
+          (factorFastCoreCapLiftData f primeData).k)
+    (expectedIndicators : Array (Array Int))
+    (indicators_match :
+      equivalenceClassIndicatorsOfLiftData
+          (Hex.normalizeForFactor f).squareFreeCore
+          (factorFastCoreCapLiftData f primeData) rows_pos =
+        expectedIndicators)
+    (nondegenerate :
+      Hex.bhksDegenerateIndicatorPartition
+          (projectedRowsOfLiftData
+            (Hex.normalizeForFactor f).squareFreeCore
+            (factorFastCoreCapLiftData f primeData) rows_pos)
+          expectedIndicators = false)
+    (expectedFactors : Array Hex.ZPoly)
+    (hsize : expectedFactors.size = expectedIndicators.size)
+    (hcandidate :
+      ∀ i, i < expectedIndicators.size →
+        ∃ quotient,
+          Hex.bhksIndicatorCandidateCore?
+              (Hex.normalizeForFactor f).squareFreeCore
+              (factorFastCoreCapLiftData f primeData)
+              (expectedIndicators.getD i #[]) =
+            some (expectedFactors.getD i 0, quotient))
+    (product_eq :
+      Array.polyProduct expectedFactors =
+        (Hex.normalizeForFactor f).squareFreeCore) :
+    Hex.coreRecover?
+        (Hex.normalizeForFactor f).squareFreeCore
+        (factorFastCoreCapLiftData f primeData) =
+      some expectedFactors :=
+  coreRecover?_eq_some_of_capSeparation
+    (Hex.normalizeForFactor f).squareFreeCore
+    (factorFastCoreCapLiftData f primeData)
+    rows_pos trueSupports localFactorIndex localFactorDegree H hcap_le
+    C hC_nonneg hC
+    (capSeparationOfBridgeDataAtFactorFastCoreCapLift
+      f primeData rows_pos localFactorIndex localFactorDegree H
+      trueSupports hcut bridge hp hcomparison)
+    mignotte_precision expectedIndicators indicators_match nondegenerate
+    expectedFactors hsize hcandidate product_eq
 
 end BHKS
 

--- a/progress/20260623T113823Z_5de1cefa.md
+++ b/progress/20260623T113823Z_5de1cefa.md
@@ -1,0 +1,65 @@
+# #8317 core-coordinate recovery-success producers — assembly tier landed (one-shot `/once`)
+
+Session type: feature (one-shot, `pod once 8317`). UTC 2026-06-23T11:38.
+
+## Accomplished
+
+Landed the **assembly tier** of #8317: two additive, green,
+`sorry`/`axiom`/`native_decide`-free core-coordinate (M1) recovery-success
+producers in `Recovery.lean`, completing the "feed
+`ForwardRecoveryInputsCore.ofCapSeparation`" deliverable. The cap-separation
+*hypotheses* over `coreLiftData` were already produced by #8318
+(`capSeparationOfBridgeDataAtFactorFastCoreCapLift`); this session composes them
+into a `Hex.coreRecover? = some` recovery success.
+
+New declarations (both `HexBerlekampZassenhausMathlib.BHKS`, clean cone
+`[propext, Classical.choice, Quot.sound]`):
+
+- **`coreRecover?_eq_some_of_capSeparation`** (generic, at fixed `LiftData d`) —
+  the direct core analogue of the existing M2 `bhksRecover_eq_some_of_capSeparation`.
+  Composes `ForwardRecoveryInputsCore.ofCapSeparation` (#8314) with
+  `coreRecover?_eq_some_of_forwardInputsCore` (#8314): from cap-level BHKS
+  separation (`ExecutableCapSeparationHypotheses (badVectorWitnessOfLiftData …)`)
+  plus the residual B7 / M1 A2 obligations, concludes
+  `Hex.coreRecover? f d = some expectedFactors`.
+- **`coreRecover?_eq_some_of_factorFastCoreCapLift_bridge`** (cap-lift-keyed) —
+  threads the landed cap producer `capSeparationOfBridgeDataAtFactorFastCoreCapLift`
+  (bridge package + analytic comparison) into the generic producer, discharging
+  the `hcap` obligation from bridge data and leaving only the B7/A2 fields. Its
+  hypothesis surface mirrors
+  `projectedRowSpan_eq_trueFactorIndicatorLattice_of_factorFastCoreCapLift_bridge`
+  exactly (same `rows_pos`/`hcap_le`/`C`/`hcut`/`bridge`/`hp`/`hcomparison`),
+  plus the B7/A2 fields over `core = (normalizeForFactor f).squareFreeCore`. The
+  `def badVectorWitnessOfFactorFastCoreCapLiftData` unfolds to
+  `badVectorWitnessOfLiftData core (factorFastCoreCapLiftData …) …`, so the cap
+  producer's output unifies with the generic producer's `hcap` field by defeq
+  (same unification the projectedRowSpan theorem already relies on).
+
+Verification: `lake build HexBerlekampZassenhausMathlib` green (3784 jobs, 0
+errors). Only `sorry` is the pre-existing `factor_irreducible_of_nonUnit`
+(`FactorSoundness.lean:18`). `#print axioms` on both new declarations =
+`[propext, Classical.choice, Quot.sound]`. Mathlib-layer only;
+executable/conformance/bench untouched.
+
+## Current frontier
+
+The full M1 recovery substrate now exists end-to-end: irreducibility side
+(#8312), recovery-success side (#8314 + this), cap-separation tower over
+`coreLiftData` (#8318), and the recovery-level `coreRecover? = some` producers
+keyed both generically and at the actual `factorFast` cap lift.
+
+## Next step
+
+#8304 (the M1 swap): re-point `factorFastCoreWithBound` to `coreLiftData`, add
+the executable `factorFast_ne_none_of_coreRecover_on_schedule` bridge (the
+core analogue of `factorFast_ne_none_of_core_recovery_on_schedule`, which
+currently consumes `bhksRecover?`), and re-point the ~36 M2 termination
+theorems to `coreRecover?_eq_some_of_factorFastCoreCapLift_bridge`. That bridge
+is the only piece that cannot land additively before the swap, since the
+current executable `factorFast` runs the M2 (`bhksRecover?`) path.
+
+## Blockers
+
+None. The `factorFast ≠ none` core capstone is intentionally *not* in this PR:
+it requires the swapped executable (the `coreRecover? → factorFast` bridge holds
+only once `factorFast` routes through `coreRecover?`), so it belongs to #8304.


### PR DESCRIPTION
Closes #8317

This PR lands the assembly tier of #8317, completing the "feed `ForwardRecoveryInputsCore.ofCapSeparation`" deliverable: two additive core-coordinate (van Hoeij M1) recovery-success producers that compose the `coreLiftData` cap-separation tower (landed by https://github.com/kim-em/hex/pull/8318) into a `Hex.coreRecover? = some` success. `coreRecover?_eq_some_of_capSeparation` is the direct core analogue of the existing M2 `bhksRecover_eq_some_of_capSeparation`, composing `ForwardRecoveryInputsCore.ofCapSeparation` with `coreRecover?_eq_some_of_forwardInputsCore` to turn cap-level BHKS separation plus the residual B7 / M1 A2 obligations into `Hex.coreRecover? f d = some expectedFactors`. `coreRecover?_eq_some_of_factorFastCoreCapLift_bridge` threads the landed cap producer `capSeparationOfBridgeDataAtFactorFastCoreCapLift` (bridge package + analytic comparison) into the generic producer, discharging the `hcap` obligation from bridge data and leaving only the B7/A2 fields over `core = (normalizeForFactor f).squareFreeCore`; its hypothesis surface mirrors `projectedRowSpan_eq_trueFactorIndicatorLattice_of_factorFastCoreCapLift_bridge` exactly.

The `factorFast ≠ none` core capstone is intentionally not included: it requires the executable to route through `Hex.coreRecover?`, which is the #8304 swap, so it cannot land additively here. After the swap, the ~36 M2 termination theorems re-point to `coreRecover?_eq_some_of_factorFastCoreCapLift_bridge` mechanically.

The additions are Mathlib-layer only and additive: `lake build HexBerlekampZassenhausMathlib` is green (3784 jobs, 0 errors; the only `sorry` is the pre-existing `factor_irreducible_of_nonUnit`), and `#print axioms` on both new declarations reports the clean cone `[propext, Classical.choice, Quot.sound]`.

🤖 Prepared with Claude Code
