### PR TITLE
feat: M1 recovery-witness constructor + recovery-data forward cut (assembly tier for #8319)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6017,6 +6017,64 @@ theorem centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
     (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
     hscaled hprecision
 
+/-- **M1 recovery-witness constructor.**
+
+Build a `RecoveredAtLiftM1 core d factor S` from genuine core-coordinate recovery
+data: a monic-coordinate witness `monicFactor` congruent to the selected lifted
+product modulo `p^k` and dividing the `monicTarget core p k`, together with the M1
+recovery congruence `ℓf·∏S ≡ factor (mod p^k)`
+(`scaledLiftedFactorProduct core d S ≡ factor`), the factor's primitivity, and the
+Mignotte precision bound.
+
+This is the core-coordinate (`scale`/`monicTarget`) analogue of
+`recoveredLiftOfRepresents`, which builds the M2 `RecoveredLift` from a
+dilation-coordinate witness.  `recovered_eq` is discharged from the recovery
+congruence by the landed per-factor recovery
+`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery` (after pushing
+the `ℓf`-scaling through `congr` exactly as `RecoveredAtLiftM1.candidate_eq` does in
+the reverse direction); `congr` and `monic_dvd` are recorded verbatim.  No `dilate`
+and no `(toMonic core).monic` divisibility: the `monicTarget` coordinate already is
+`core`'s own coordinate. -/
+def recoveredAtLiftM1_of_recovery
+    {core factor monicFactor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (hcongr :
+      Hex.ZPoly.reduceModPow (liftedFactorProduct d S) d.p d.k =
+        Hex.ZPoly.reduceModPow monicFactor d.p d.k)
+    (hmonic_dvd : monicFactor ∣ Hex.ZPoly.monicTarget core d.p d.k)
+    (hcore_ne : core ≠ 0)
+    (hdvd : factor ∣ core)
+    (hscaled :
+      Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k =
+        Hex.ZPoly.reduceModPow factor d.p d.k)
+    (hfactor_prim : Hex.ZPoly.primitivePart factor = factor)
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
+    RecoveredAtLiftM1 core d factor S where
+  monicFactor := monicFactor
+  congr := hcongr
+  monic_dvd := hmonic_dvd
+  recovered_eq := by
+    have hp_pos : 0 < d.p := d.p_pos
+    have hpk : 0 < d.p ^ d.k := Nat.pow_pos hp_pos
+    -- `∏S ≡ monicFactor (mod p^k)`, from the reduced-form congruence.
+    have hcongr_poly :
+        Hex.ZPoly.congr (liftedFactorProduct d S) monicFactor (d.p ^ d.k) := by
+      have hf := Hex.ZPoly.congr_reduceModPow (liftedFactorProduct d S) d.p d.k hpk
+      have hg := Hex.ZPoly.congr_reduceModPow monicFactor d.p d.k hpk
+      rw [hcongr] at hf
+      exact Hex.ZPoly.congr_trans _ _ _ _ (Hex.ZPoly.congr_symm _ _ _ hf) hg
+    -- `ℓf·monicFactor ≡ ℓf·∏S = scaledLiftedFactorProduct (mod p^k)`.
+    have hscale_eq :
+        Hex.ZPoly.reduceModPow
+            (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) monicFactor) d.p d.k
+          = Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k := by
+      unfold scaledLiftedFactorProduct
+      exact Hex.ZPoly.reduceModPow_eq_of_congr _ _ d.p d.k
+        (scale_congr_of_congr (Hex.DensePoly.leadingCoeff core) _ _ _
+          (Hex.ZPoly.congr_symm _ _ _ hcongr_poly))
+    rw [hscale_eq, centeredLiftPoly_reduceModPow_eq _ _ _ hp_pos,
+      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
+        hcore_ne hdvd hscaled hprecision, hfactor_prim]
+
 /-- Abstract-bound recovered-coordinate equality: if the variable-dilated
 centred lifted-factor product is congruent to `factor` modulo the Hensel
 modulus, then Mignotte precision recovers `factor` exactly. -/

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2751,6 +2751,74 @@ theorem cutProjectionHypotheses_of_recoveredM1
     (fun S => congr_logDeriv_bridge_of_recoveredM1 (hrec S)
       (lt_trans Nat.zero_lt_one hk) hgcd (hsupp S))
 
+/-- **Forward cut from per-support M1 recovery data.**
+
+The assembly-tier wrapper over `cutProjectionHypotheses_of_recoveredM1`: rather than
+demanding a pre-built `RecoveredAtLiftM1` family, it accepts the genuine
+core-coordinate recovery data per true support and builds the witness family in line
+via `recoveredAtLiftM1_of_recovery`.  Each support `S` supplies a monic-coordinate
+witness `monicFactor S` congruent to the selected lifted product and dividing
+`monicTarget core p k`, together with the M1 recovery congruence
+`scaledLiftedFactorProduct core d (subset S) ≡ factor S (mod p^k)`, the factor's
+primitivity, and divisibility into `core`.  The Mignotte precision bound is supplied
+once as `hprecision` (the `defaultFactorCoeffBound` form); `hsep`, `hthr`, `hfac`,
+`hfactor`, `hsupp` are threaded unchanged to the underlying consumer. -/
+theorem cutProjectionHypotheses_of_recoveryData
+    (core : Hex.ZPoly) (d : Hex.LiftData)
+    (hrows :
+      1 ≤ (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount +
+        (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).coeffWidth)
+    (hbasis : (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).basis.independent)
+    (trueSupports :
+      Set (Set (Fin
+        (Hex.bhksProjectedRows
+          (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows).factorCount)))
+    (hp : 2 ≤ d.p)
+    (hk : 1 < d.p ^ d.k)
+    (hsep : ∀ j, 2 * Hex.bhksCoeffBound core j < d.p ^ d.k)
+    (hthr : ∀ j, Hex.bhksCoeffCutThreshold d.p core j ≤ d.k)
+    (hgcd : Int.gcd (Hex.DensePoly.leadingCoeff core) (Int.ofNat (d.p ^ d.k)) = 1)
+    (factor cof : trueSupports → Hex.ZPoly)
+    (subset : trueSupports → LiftedFactorSubset d)
+    (monicFactor : trueSupports → Hex.ZPoly)
+    (hcore_ne : core ≠ 0)
+    (hcongr : ∀ S : trueSupports,
+      Hex.ZPoly.reduceModPow (liftedFactorProduct d (subset S)) d.p d.k =
+        Hex.ZPoly.reduceModPow (monicFactor S) d.p d.k)
+    (hmonic_dvd : ∀ S : trueSupports,
+      monicFactor S ∣ Hex.ZPoly.monicTarget core d.p d.k)
+    (hfactor_dvd : ∀ S : trueSupports, factor S ∣ core)
+    (hscaled : ∀ S : trueSupports,
+      Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d (subset S)) d.p d.k =
+        Hex.ZPoly.reduceModPow (factor S) d.p d.k)
+    (hfactor_prim : ∀ S : trueSupports,
+      Hex.ZPoly.primitivePart (factor S) = factor S)
+    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (hsupp : ∀ S : trueSupports,
+      liftedFactorProduct d (subset S)
+        = supportProduct (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) S.1)
+    (hfac : ∀ S : trueSupports,
+      ∀ i : Fin (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).factorCount, i ∈ S.1 →
+        ∃ h : Hex.ZPoly,
+          Hex.DensePoly.Monic
+            ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) ∧
+          0 < ((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD
+            i.val 1).degree?.getD 0 ∧
+          Hex.ZPoly.congr core
+            (((Hex.bhksLatticeBasis core d.p d.k d.liftedFactors).liftedFactors.getD i.val 1) * h)
+            (d.p ^ d.k))
+    (hfactor : ∀ S : trueSupports,
+      HexPolyMathlib.toPolynomial core
+        = HexPolyMathlib.toPolynomial (factor S) * HexPolyMathlib.toPolynomial (cof S)) :
+    CutProjectionHypotheses
+      (Hex.bhksProjectedRows (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) hrows)
+      trueSupports :=
+  cutProjectionHypotheses_of_recoveredM1 core d hrows hbasis trueSupports hp hk hsep
+    hthr hgcd factor cof subset
+    (fun S => recoveredAtLiftM1_of_recovery (hcongr S) (hmonic_dvd S) hcore_ne
+      (hfactor_dvd S) (hscaled S) (hfactor_prim S) hprecision)
+    hsupp hfac hfactor
+
 /-- The accumulator of a `max`-fold never decreases below its seed. -/
 private theorem foldl_max_ge_init (l : List Nat) (f : Nat → Nat) :
     ∀ init : Nat, init ≤ l.foldl (fun acc x => max acc (f x)) init := by

--- a/progress/20260623T122202Z_14ddcdfc.md
+++ b/progress/20260623T122202Z_14ddcdfc.md
@@ -1,0 +1,81 @@
+# #8319 RecoveredAtLiftM1 producer — assembly tier landed; recovery-data producer rescoped (one-shot `/once`)
+
+Session type: feature (one-shot, `pod once 8319`). UTC 2026-06-23T12:22.
+
+## Accomplished
+
+Landed the **assembly tier** of the M1 recovery keystone (#8319): two
+additive, green, `sorry`/`axiom`/`native_decide`-free declarations
+(axiom cone `[propext, Classical.choice, Quot.sound]`).
+
+- **`recoveredAtLiftM1_of_recovery`** (`Basic.lean`, after
+  `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery`) — the
+  core-coordinate (`scale`/`monicTarget`) analogue of
+  `recoveredLiftOfRepresents`. Builds `RecoveredAtLiftM1 core d factor S`
+  from genuine M1 recovery data: a monic-coordinate witness `monicFactor`
+  with `∏S ≡ monicFactor (mod p^k)` and `monicFactor ∣ monicTarget core p k`,
+  the M1 recovery congruence `scaledLiftedFactorProduct core d S ≡ factor`,
+  `primitivePart factor = factor`, and the Mignotte bound. `recovered_eq`
+  is discharged by the landed per-factor recovery
+  `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery`,
+  pushing the `ℓf`-scaling through `congr` (mirroring
+  `RecoveredAtLiftM1.candidate_eq` in reverse).
+- **`BHKS.cutProjectionHypotheses_of_recoveryData`** (`CLDColumnBound.lean`,
+  after `cutProjectionHypotheses_of_recoveredM1`) — threads per-true-support
+  recovery-data families through the constructor and feeds
+  `cutProjectionHypotheses_of_recoveredM1` to produce the `hcut`
+  (`CutProjectionHypotheses`) object directly from recovery data.
+
+`lake build HexBerlekampZassenhausMathlib` green (3784 jobs). Only `sorry`
+remains the pre-existing `factor_irreducible_of_nonUnit`.
+
+## Current frontier — directive premise correction
+
+The issue proposed producing the per-support recovery data over
+`coreLiftData` via `representsIntegerFactorAtLift_of_indicatorCandidates`
+(M2) + `representsIntegerFactorAtLift_of_monicCorrespondent`. That route is
+**unsound for the M1 coordinate**, with concrete evidence:
+
+1. `representsIntegerFactorAtLift_of_indicatorCandidates` (`Recovery.lean:1733`)
+   **requires `hf_monic : Hex.DensePoly.Monic core`** — false in the
+   non-monic fast-core (M1) regime that #8319 targets.
+2. `RepresentsIntegerFactorAtLift` unfolds to `Nonempty (RecoveredAtLift …)`,
+   whose `monic_dvd` pins `monicFactor ∣ (Hex.ZPoly.toMonic core).monic`
+   (the `x ↦ x/ℓf` *dilation* coordinate) and whose recovery is
+   `primitivePart (dilate ℓf monicFactor) = factor`. `RecoveredAtLiftM1`
+   needs `monicFactor ∣ monicTarget core p k` (the `ℓf⁻¹·core` *scaling*
+   coordinate) and `scale`-based recovery. `monicTarget` and
+   `(toMonic core).monic` are different polynomials, so an M2 witness's
+   `monicFactor` is the wrong object for M1: it satisfies neither M1
+   `monic_dvd` nor M1 `recovered_eq`. The two recoveries (`dilate` vs
+   `scale`) genuinely diverge; there is no syntactic conversion.
+
+So the M2 represents witness does **not** supply M1 recovery data. The
+deliverable's *goal* (a `RecoveredAtLiftM1` family producer) is sound — the
+constructor above realizes it — but its *proposed input source* is wrong.
+
+## Next step
+
+A **scale-coordinate recovery producer** for the true supports of
+`coreLiftData`: for each true support `S`, produce
+- `monicFactor` with `∏S ≡ monicFactor (mod p^k)` and
+  `monicFactor ∣ monicTarget core p k`, and
+- the recovery congruence
+  `reduceModPow (scaledLiftedFactorProduct core d S) p k = reduceModPow factor p k`.
+
+This is the M1 (`monicTarget`) analogue of the M2
+`bhksIndicatorCandidates?_canonicalRepresentations` tower, not a port of
+`recoveredLiftOfRepresents`. The existing whole-product mod-bridges
+(`scaledLiftedFactorProduct_congr_core_of_product_congr_monicTarget`,
+`centeredLift_scaledLiftedFactorProduct_eq_core_of_product_congr_monicTarget`,
+`leadingCoeff_scale_monicTarget_congr_core`) are the right substrate; the gap
+is the per-true-support (subset) version against the lattice/partition
+framework. Once it lands, `cutProjectionHypotheses_of_recoveryData` consumes
+it directly to close the `hcut` obligation, then the #8315 reduction + #8312
+close the capstone.
+
+## Blockers
+
+None for the landed pieces. The recovery-data producer is a distinct,
+larger piece (recovery correctness in the `monicTarget` coordinate) that the
+directive folded into "port the template"; rescoped above for a successor.


### PR DESCRIPTION
This PR adds the core-coordinate (M1) recovery-witness constructor `recoveredAtLiftM1_of_recovery` and the assembly wrapper `BHKS.cutProjectionHypotheses_of_recoveryData`, the assembly tier of the M1 recovery keystone (#8319). Both are additive and green, with axiom cone `[propext, Classical.choice, Quot.sound]` (no sorry/axiom/native_decide).

`recoveredAtLiftM1_of_recovery` is the `scale`/`monicTarget` analogue of `recoveredLiftOfRepresents`: it builds `RecoveredAtLiftM1 core d factor S` from genuine core-coordinate recovery data (a monic-coordinate witness congruent to the selected lifted product and dividing `monicTarget core p k`, the M1 recovery congruence `scaledLiftedFactorProduct core d S ≡ factor`, factor primitivity, and the Mignotte bound), discharging `recovered_eq` via the landed per-factor recovery `centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery`. `cutProjectionHypotheses_of_recoveryData` threads per-true-support recovery data through that constructor and feeds `cutProjectionHypotheses_of_recoveredM1` to obtain the `hcut` object directly.

Partial against #8319: the proposed route for *producing* the recovery data over `coreLiftData` (M2 `representsIntegerFactorAtLift_of_indicatorCandidates`) is unsound — its producer requires `Monic core` (false in the non-monic M1 regime) and its witness divides `(toMonic core).monic` rather than `monicTarget core p k`. The remaining obligation is a scale-coordinate recovery-congruence producer for the true supports; see the issue comment and progress note for the corrected scope.

🤖 Prepared with Claude Code