### PR TITLE
feat: primitivePart-aware M1 recovery constructor (deliverable (a) of #8319)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -6017,37 +6017,52 @@ theorem centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
     (defaultFactorCoeffBound_valid core hcore_ne factor hdvd)
     hscaled hprecision
 
-/-- **M1 recovery-witness constructor.**
+/-- **M1 recovery-witness constructor (primitivePart-aware).**
 
 Build a `RecoveredAtLiftM1 core d factor S` from genuine core-coordinate recovery
-data: a monic-coordinate witness `monicFactor` congruent to the selected lifted
-product modulo `p^k` and dividing the `monicTarget core p k`, together with the M1
-recovery congruence `ℓf·∏S ≡ factor (mod p^k)`
-(`scaledLiftedFactorProduct core d S ≡ factor`), the factor's primitivity, and the
-Mignotte precision bound.
+data, in the *honest* scale coordinate.  The recovery input is the proportional
+congruence
+
+  `ℓf · (∏ S) ≡ c · factor (mod p^k)`,   `ℓf = leadingCoeff core`,   `c > 0`,
+
+which is the true shape of the M1 recovery: the `ℓf`-scaled lifted product lands on
+a *constant multiple* of the primitive integer factor (the constant `c` is the
+leading coefficient of the cofactor), not on `factor` itself.  Together with a
+monic-coordinate witness `monicFactor` congruent to the selected lifted product and
+dividing `monicTarget core p k`, the factor's primitivity, and a Mignotte precision
+bound on `c · factor`, this recovers `factor` as the primitive part of the centred
+lift.
+
+This replaces the earlier `_of_recovery` constructor whose `hscaled` premise asked
+for the *strong* congruence `reduceModPow (scaledLiftedFactorProduct …) =
+reduceModPow factor`, which is provably **false** for proper factors with a non-unit
+cofactor leading coefficient (the scale carries the spurious constant `c`).  The
+`primitivePart` in `RecoveredAtLiftM1.recovered_eq` is exactly what strips that
+constant, so the honest proportional congruence above is the satisfiable premise.
 
 This is the core-coordinate (`scale`/`monicTarget`) analogue of
-`recoveredLiftOfRepresents`, which builds the M2 `RecoveredLift` from a
-dilation-coordinate witness.  `recovered_eq` is discharged from the recovery
-congruence by the landed per-factor recovery
-`centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery` (after pushing
-the `ℓf`-scaling through `congr` exactly as `RecoveredAtLiftM1.candidate_eq` does in
-the reverse direction); `congr` and `monic_dvd` are recorded verbatim.  No `dilate`
-and no `(toMonic core).monic` divisibility: the `monicTarget` coordinate already is
-`core`'s own coordinate. -/
+`recoveredLiftOfRepresents`.  `recovered_eq` is discharged by
+`centeredLiftPoly_eq_of_reduceModPow_eq` on the target `c · factor` (its centred
+lift is `scale c factor` exactly), followed by `primitivePart (scale c factor) =
+primitivePart factor = factor` (`c > 0`, `factor` primitive).  `congr` and
+`monic_dvd` are recorded verbatim.  No `dilate` and no `(toMonic core).monic`
+divisibility: the `monicTarget` coordinate already is `core`'s own coordinate. -/
 def recoveredAtLiftM1_of_recovery
     {core factor monicFactor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (c : Int) (hc_pos : 0 < c)
     (hcongr :
       Hex.ZPoly.reduceModPow (liftedFactorProduct d S) d.p d.k =
         Hex.ZPoly.reduceModPow monicFactor d.p d.k)
     (hmonic_dvd : monicFactor ∣ Hex.ZPoly.monicTarget core d.p d.k)
-    (hcore_ne : core ≠ 0)
-    (hdvd : factor ∣ core)
-    (hscaled :
-      Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k =
-        Hex.ZPoly.reduceModPow factor d.p d.k)
+    (hhonest :
+      Hex.ZPoly.congr
+        (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) (liftedFactorProduct d S))
+        (Hex.DensePoly.scale c factor)
+        (d.p ^ d.k))
     (hfactor_prim : Hex.ZPoly.primitivePart factor = factor)
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
+    (B' : Nat)
+    (hvalid : ∀ i, ((Hex.DensePoly.scale c factor).coeff i).natAbs ≤ B')
+    (hprecision : 2 * B' < d.p ^ d.k) :
     RecoveredAtLiftM1 core d factor S where
   monicFactor := monicFactor
   congr := hcongr
@@ -6062,18 +6077,28 @@ def recoveredAtLiftM1_of_recovery
       have hg := Hex.ZPoly.congr_reduceModPow monicFactor d.p d.k hpk
       rw [hcongr] at hf
       exact Hex.ZPoly.congr_trans _ _ _ _ (Hex.ZPoly.congr_symm _ _ _ hf) hg
-    -- `ℓf·monicFactor ≡ ℓf·∏S = scaledLiftedFactorProduct (mod p^k)`.
+    -- `ℓf·monicFactor ≡ ℓf·∏S ≡ c·factor (mod p^k)`.
     have hscale_eq :
         Hex.ZPoly.reduceModPow
             (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) monicFactor) d.p d.k
-          = Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d S) d.p d.k := by
-      unfold scaledLiftedFactorProduct
-      exact Hex.ZPoly.reduceModPow_eq_of_congr _ _ d.p d.k
-        (scale_congr_of_congr (Hex.DensePoly.leadingCoeff core) _ _ _
-          (Hex.ZPoly.congr_symm _ _ _ hcongr_poly))
-    rw [hscale_eq, centeredLiftPoly_reduceModPow_eq _ _ _ hp_pos,
-      centeredLiftPoly_scaledLiftedFactorProduct_eq_factor_of_recovery
-        hcore_ne hdvd hscaled hprecision, hfactor_prim]
+          = Hex.ZPoly.reduceModPow (Hex.DensePoly.scale c factor) d.p d.k :=
+      Hex.ZPoly.reduceModPow_eq_of_congr _ _ d.p d.k
+        (Hex.ZPoly.congr_trans _ _ _ _
+          (scale_congr_of_congr (Hex.DensePoly.leadingCoeff core) _ _ _
+            (Hex.ZPoly.congr_symm _ _ _ hcongr_poly))
+          hhonest)
+    -- Recover `c·factor` exactly, then strip the positive constant via primitivePart.
+    have hcl :
+        Hex.centeredLiftPoly
+            (Hex.ZPoly.reduceModPow
+              (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) monicFactor) d.p d.k)
+            (d.p ^ d.k) =
+          Hex.DensePoly.scale c factor :=
+      Hex.centeredLiftPoly_eq_of_reduceModPow_eq
+        (Hex.DensePoly.scale c factor)
+        (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) monicFactor)
+        d.p d.k B' hvalid hprecision hscale_eq
+    rw [hcl, primitivePart_scale_of_pos hc_pos factor, hfactor_prim]
 
 /-- Abstract-bound recovered-coordinate equality: if the variable-dilated
 centred lifted-factor product is congruent to `factor` modulo the Hensel

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -2758,11 +2758,19 @@ demanding a pre-built `RecoveredAtLiftM1` family, it accepts the genuine
 core-coordinate recovery data per true support and builds the witness family in line
 via `recoveredAtLiftM1_of_recovery`.  Each support `S` supplies a monic-coordinate
 witness `monicFactor S` congruent to the selected lifted product and dividing
-`monicTarget core p k`, together with the M1 recovery congruence
-`scaledLiftedFactorProduct core d (subset S) ≡ factor S (mod p^k)`, the factor's
-primitivity, and divisibility into `core`.  The Mignotte precision bound is supplied
-once as `hprecision` (the `defaultFactorCoeffBound` form); `hsep`, `hthr`, `hfac`,
-`hfactor`, `hsupp` are threaded unchanged to the underlying consumer. -/
+`monicTarget core p k`, together with the *honest* M1 recovery congruence
+`ℓf · (∏ subset S) ≡ cofactorLc S · factor S (mod p^k)` (the `ℓf`-scaled lifted
+product is a positive constant multiple of the primitive integer factor, where the
+constant `cofactorLc S > 0` is the cofactor's leading coefficient), the factor's
+primitivity, and a per-support Mignotte precision bound on `cofactorLc S · factor S`.
+`hsep`, `hthr`, `hfac`, `hfactor`, `hsupp` are threaded unchanged to the underlying
+consumer.
+
+The earlier signature carried the strong congruence
+`reduceModPow (scaledLiftedFactorProduct …) = reduceModPow factor`, which is false
+for proper factors with non-unit cofactor leading coefficient; the honest
+proportional congruence above is the satisfiable premise (see
+`recoveredAtLiftM1_of_recovery`). -/
 theorem cutProjectionHypotheses_of_recoveryData
     (core : Hex.ZPoly) (d : Hex.LiftData)
     (hrows :
@@ -2781,19 +2789,25 @@ theorem cutProjectionHypotheses_of_recoveryData
     (factor cof : trueSupports → Hex.ZPoly)
     (subset : trueSupports → LiftedFactorSubset d)
     (monicFactor : trueSupports → Hex.ZPoly)
-    (hcore_ne : core ≠ 0)
+    (cofactorLc : trueSupports → Int)
+    (hcofactorLc_pos : ∀ S : trueSupports, 0 < cofactorLc S)
     (hcongr : ∀ S : trueSupports,
       Hex.ZPoly.reduceModPow (liftedFactorProduct d (subset S)) d.p d.k =
         Hex.ZPoly.reduceModPow (monicFactor S) d.p d.k)
     (hmonic_dvd : ∀ S : trueSupports,
       monicFactor S ∣ Hex.ZPoly.monicTarget core d.p d.k)
-    (hfactor_dvd : ∀ S : trueSupports, factor S ∣ core)
-    (hscaled : ∀ S : trueSupports,
-      Hex.ZPoly.reduceModPow (scaledLiftedFactorProduct core d (subset S)) d.p d.k =
-        Hex.ZPoly.reduceModPow (factor S) d.p d.k)
+    (hhonest : ∀ S : trueSupports,
+      Hex.ZPoly.congr
+        (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core)
+          (liftedFactorProduct d (subset S)))
+        (Hex.DensePoly.scale (cofactorLc S) (factor S))
+        (d.p ^ d.k))
     (hfactor_prim : ∀ S : trueSupports,
       Hex.ZPoly.primitivePart (factor S) = factor S)
-    (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k)
+    (coeffBound : trueSupports → Nat)
+    (hvalid : ∀ S : trueSupports, ∀ i,
+      ((Hex.DensePoly.scale (cofactorLc S) (factor S)).coeff i).natAbs ≤ coeffBound S)
+    (hprecision : ∀ S : trueSupports, 2 * coeffBound S < d.p ^ d.k)
     (hsupp : ∀ S : trueSupports,
       liftedFactorProduct d (subset S)
         = supportProduct (Hex.bhksLatticeBasis core d.p d.k d.liftedFactors) S.1)
@@ -2815,8 +2829,9 @@ theorem cutProjectionHypotheses_of_recoveryData
       trueSupports :=
   cutProjectionHypotheses_of_recoveredM1 core d hrows hbasis trueSupports hp hk hsep
     hthr hgcd factor cof subset
-    (fun S => recoveredAtLiftM1_of_recovery (hcongr S) (hmonic_dvd S) hcore_ne
-      (hfactor_dvd S) (hscaled S) (hfactor_prim S) hprecision)
+    (fun S => recoveredAtLiftM1_of_recovery (cofactorLc S) (hcofactorLc_pos S)
+      (hcongr S) (hmonic_dvd S) (hhonest S) (hfactor_prim S)
+      (coeffBound S) (hvalid S) (hprecision S))
     hsupp hfac hfactor
 
 /-- The accumulator of a `max`-fold never decreases below its seed. -/

--- a/progress/20260623T131512Z_ff0b6f61.md
+++ b/progress/20260623T131512Z_ff0b6f61.md
@@ -1,0 +1,63 @@
+# #8319 M1 recovery keystone — deliverable (a) landed (honest constructor); (b) split out
+
+Session type: feature (one-shot, `pod once 8319`). UTC 2026-06-23T13:15.
+Branch `agent/ff0b6f61`.
+
+## Accomplished
+
+Landed **deliverable (a)** of the owner's re-scope: the *primitivePart-aware*
+M1 recovery-witness constructor, replacing the dead unsatisfiable-premise one.
+Additive, green, no `sorry`/`axiom`/`native_decide` (axiom cone
+`[propext, Classical.choice, Quot.sound]` for both touched decls).
+
+- **`recoveredAtLiftM1_of_recovery`** (`Basic.lean`) — rewritten. Its premise is
+  now the *honest* proportional congruence
+  `ℓf · (∏ S) ≡ c · factor (mod p^k)` with `c > 0` (the cofactor's leading
+  coefficient), plus `monicFactor` congruent to the product and dividing
+  `monicTarget`, `factor` primitive, and a Mignotte precision bound on
+  `c · factor`. `recovered_eq` is discharged by
+  `centeredLiftPoly_eq_of_reduceModPow_eq` on the target `c · factor` (its centred
+  lift is `scale c factor` exactly), then `primitivePart (scale c factor) =
+  primitivePart factor = factor` (`primitivePart_scale_of_pos` + `c > 0` +
+  primitivity). This is the satisfiable premise: the prior `hscaled`
+  (`reduceModPow (scaledLiftedFactorProduct …) = reduceModPow factor`) was proved
+  FALSE for proper factors with non-unit cofactor lc (session 8353ba49's
+  counterexample `core=(2x+1)(x+3)`), and the `primitivePart` in `recovered_eq` is
+  exactly what strips the spurious constant `c`.
+- **`BHKS.cutProjectionHypotheses_of_recoveryData`** (`CLDColumnBound.lean`) —
+  threaded to consume the honest premise: per-support `cofactorLc S > 0`,
+  `hhonest S` (the proportional congruence), and an abstract per-support coeff
+  bound (`coeffBound`/`hvalid`/`hprecision`). Dropped the now-unused `hcore_ne`
+  and `hfactor_dvd` (the abstract bound replaces the `defaultFactorCoeffBound`
+  derivation). Still feeds `cutProjectionHypotheses_of_recoveredM1` → `hcut`.
+
+`lake build HexBerlekampZassenhausMathlib` green (3784 jobs). Only the
+pre-existing `factor_irreducible_of_nonUnit` sorry remains.
+
+## Current frontier
+
+Deliverable (a) makes the `hcut` assembly tier *sound and usable* — it now
+consumes a satisfiable premise. The remaining gap is the producer of that
+premise: **deliverable (b)**, the scale-coordinate per-subset
+modular-factorization correspondence. Split to a successor issue (see below).
+
+## Next step (deliverable (b), the substantive piece)
+
+Per true support `S` of `coreLiftData`, produce the honest congruence
+`congr (scale ℓf (∏ subset S)) (scale (cofactorLc S) (factor S)) (p^k)` with
+`cofactorLc S > 0` and `factor S` primitive — i.e. the subset → primitive-integer-
+divisor correspondence with the cofactor-lc constant tracked. The correspondence
+currently exists ONLY in the dilate coordinate
+(`RepresentsIntegerFactorAtLift`/`RecoveredAtLift`, on which `liftedTrueSupports`
+is defined). `coreLiftData_liftedFactor_hensel_semantics` (`LiftBridge.lean:692`)
+supplies only the per-FACTOR `hfac` (`core ≡ gᵢ·h mod p^k`), not the per-SUBSET
+recovery. This is the #7479/#7866-class (period-trap), soundness-sensitive remodel
+— the genuine remaining math, and a separate (likely multi-session) piece.
+`cutProjectionHypotheses_of_recoveryData` consumes it directly → hcut → capstone.
+
+## Blockers
+
+None for (a). (b) is the substantive remodel, scoped to a successor; not
+attempted here because it is the #7479/#7866 period-trap-class math the owner
+flagged as the genuine prerequisite, too large to land soundly in one one-shot
+session alongside (a).


### PR DESCRIPTION
This PR replaces the dead M1 recovery-witness constructor with a primitivePart-aware one over an honest, satisfiable premise (deliverable (a) of #8319). The earlier `recoveredAtLiftM1_of_recovery` carried the strong congruence `reduceModPow (scaledLiftedFactorProduct core d S) = reduceModPow factor`, which is provably false for proper factors with non-unit cofactor leading coefficient (`scale` carries the spurious constant `lc(cofactor)`). The rewritten constructor takes instead the honest proportional congruence `ℓf · (∏ S) ≡ c · factor (mod p^k)` with `c > 0`, recovering `factor` as `primitivePart (scale c factor)` — exactly the constant-stripping that `RecoveredAtLiftM1.recovered_eq` encodes. `recovered_eq` is discharged via `centeredLiftPoly_eq_of_reduceModPow_eq` on `c · factor` followed by `primitivePart (scale c factor) = primitivePart factor = factor`. `BHKS.cutProjectionHypotheses_of_recoveryData` is threaded to consume the honest per-support premise (the cofactor-lc constant plus an abstract Mignotte bound), dropping the now-unused `hcore_ne`/`hfactor_dvd`; the `hcut` assembly tier now consumes a satisfiable premise.

The producer of that premise — the scale-coordinate per-subset modular-factorization correspondence (the #7479/#7866-class period-trap remodel) — is deliverable (b), split to #8323.

Additive and green: `lake build HexBerlekampZassenhausMathlib` completes (3784 jobs), no `sorry`/`axiom`/`native_decide` added, axiom cone `[propext, Classical.choice, Quot.sound]` for both touched declarations.

Partial completion of #8319 (deliverable (a) only; (b) tracked in #8323).

🤖 Prepared with Claude Code