### PR TITLE
feat: honestCongr_of_correspondence — algebraic core of M1 honest congruence (partial, deliverable (b) of #8319)

### DIFF
--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -20006,6 +20006,45 @@ theorem scale_mul_scale (a b : Int) (p q : Hex.ZPoly) :
     HexPolyZMathlib.toPolynomial_C, Polynomial.C_mul]
   ring
 
+/-- **Honest scale-coordinate congruence from a `monicTarget` subset correspondence**
+(the algebraic core of deliverable (b) of #8319).
+
+Given the per-support `monicTarget`-coordinate correspondence
+`scale (leadingCoeff factor) (∏ S) ≡ factor (mod p^k)` — the selected lifted
+product, rescaled to `factor`'s leading coefficient, lands on `factor` itself —
+together with the leading-coefficient factorisation
+`leadingCoeff core = leadingCoeff factor * cofactorLc`, the honest proportional
+congruence `scale (leadingCoeff core) (∏ S) ≡ scale cofactorLc factor (mod p^k)`
+follows by scaling the correspondence by `cofactorLc` and composing the two
+scalings (`scale_scale`).  This is exactly the `hhonest` field that
+`recoveredAtLiftM1_of_recovery` / `cutProjectionHypotheses_of_recoveryData`
+consume per support.
+
+The spurious constant `cofactorLc` is the cofactor's leading coefficient; it is
+the `c` of the M1 recovery, stripped by `primitivePart` in `recovered_eq`.  This
+lemma is the `dilate`-free, soundness-clean reduction: it leaves a *single*
+remaining obligation — the correspondence hypothesis `hcorr`, i.e. the
+Hensel-uniqueness subset recovery in the `monicTarget` coordinate, which the
+`dilate`-coordinate `RecoveredAtLift` witness backing each true support does not
+itself supply (the two coordinates diverge). -/
+theorem honestCongr_of_correspondence
+    {core factor : Hex.ZPoly} {d : Hex.LiftData} {S : LiftedFactorSubset d}
+    (cofactorLc : Int)
+    (hlc : Hex.DensePoly.leadingCoeff core
+        = Hex.DensePoly.leadingCoeff factor * cofactorLc)
+    (hcorr :
+      Hex.ZPoly.congr
+        (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff factor) (liftedFactorProduct d S))
+        factor (d.p ^ d.k)) :
+    Hex.ZPoly.congr
+      (Hex.DensePoly.scale (Hex.DensePoly.leadingCoeff core) (liftedFactorProduct d S))
+      (Hex.DensePoly.scale cofactorLc factor)
+      (d.p ^ d.k) := by
+  have hscaled := scale_congr_of_congr cofactorLc _ _ _ hcorr
+  rw [scale_scale] at hscaled
+  rwa [show cofactorLc * Hex.DensePoly.leadingCoeff factor
+        = Hex.DensePoly.leadingCoeff core by rw [hlc]; ring] at hscaled
+
 /-- The monic dilation transform of `base` by `c`: coefficient `n` is
 `c ^ (deg - n) * base.coeff n / leadingCoeff base` below the degree `deg`, and `1`
 at `deg`.  When `leadingCoeff base ∣ c`, dilating this by `c` recovers a scalar

--- a/progress/20260623T140452Z_dbd84ef1.md
+++ b/progress/20260623T140452Z_dbd84ef1.md
@@ -1,0 +1,57 @@
+# #8323 M1 honest-congruence algebraic core landed; Hensel-uniqueness remodel split to #8325
+
+Session type: one-shot feature (`pod once 8323`). UTC 2026-06-23T14:04.
+Branch `agent/dbd84ef1`.
+
+## Accomplished
+
+Landed the **algebraic core** of deliverable (b) of #8319: a sound, additive
+reduction of the M1 per-support honest congruence to a single remaining
+obligation.
+
+- **`honestCongr_of_correspondence`** (`Basic.lean`, after `scale_mul_scale`) —
+  takes the `monicTarget`-coordinate subset correspondence
+  `scale (lc factor) (∏ S) ≡ factor (mod p^k)` plus the leading-coefficient
+  factorisation `lc core = lc factor * cofactorLc`, and produces the honest
+  proportional congruence
+  `scale (lc core) (∏ S) ≡ scale cofactorLc factor (mod p^k)` — exactly the
+  `hhonest` field `recoveredAtLiftM1_of_recovery` /
+  `cutProjectionHypotheses_of_recoveryData` consume. Proof: scale the
+  correspondence by `cofactorLc` (`scale_congr_of_congr`), compose scalings
+  (`scale_scale`), rewrite `cofactorLc * lc factor = lc core`.
+
+`lake build HexBerlekampZassenhausMathlib` green (3784 jobs). Axiom cone
+`[propext, Classical.choice, Quot.sound]`. Only the pre-existing
+`factor_irreducible_of_nonUnit` sorry (FactorSoundness.lean:18) remains.
+
+## Current frontier
+
+The honest congruence now reduces to a *single* clean obligation. The remaining
+math — the `monicTarget`-coordinate subset correspondence — is split to **#8325**.
+
+## Why (b) was not fully landed here
+
+The supports `liftedTrueSupports` ranges over are defined via the **dilate**
+coordinate (`RepresentsIntegerFactorAtLift` = `Nonempty (RecoveredAtLift …)`).
+A `RecoveredAtLift` witness gives `∏ S ≡ monicFactor (mod p^k)` and
+`primitivePart (dilate ℓf monicFactor) = factor`, but **not** the scale-coordinate
+correspondence `scale (lc factor) (∏ S) ≡ factor (mod p^k)`: `dilate` (coeff
+`cⁿ·qₙ`) and `scale` (coeff `c·qₙ`) genuinely diverge, and
+`primitivePart (dilate ℓf m)` is a different integer polynomial from `scale (lc
+factor) m`. The correspondence must be built from the Hensel lift structure
+directly — `∏_{i∈S} gᵢ ≡ (lc factor)⁻¹ · factor (mod p^k)`, the subset Hensel-
+uniqueness lift of the mod-p subset correspondence
+(`henselLiftData_liftedSubset_product_congr_mod_base`, mod p) up to mod p^k. This
+is the #7479/#7866-class period-trap, soundness-sensitive remodel — too large to
+land soundly in one one-shot session, consistent with the prior session
+(ff0b6f61) which split (b) out as the substantive multi-session piece.
+
+## Next step
+
+Execute **#8325**: produce `scale (lc factor) (∏ S) ≡ factor (mod p^k)` per true
+support, then chain `honestCongr_of_correspondence` → `hhonest` →
+`cutProjectionHypotheses_of_recoveryData` → `hcut` → capstone.
+
+## Blockers
+
+None for the landed core. #8325 is the substantive remodel.


### PR DESCRIPTION
This PR adds `honestCongr_of_correspondence` (`HexBerlekampZassenhausMathlib/Basic.lean`), the sound, additive algebraic core of deliverable (b) of #8319: given the `monicTarget`-coordinate subset correspondence `scale (lc factor) (∏ S) ≡ factor (mod p^k)` and the leading-coefficient factorisation `lc core = lc factor * cofactorLc`, it produces the honest proportional congruence `scale (lc core) (∏ S) ≡ scale cofactorLc factor (mod p^k)` — exactly the `hhonest` field that `recoveredAtLiftM1_of_recovery` and `cutProjectionHypotheses_of_recoveryData` consume. The proof scales the correspondence by `cofactorLc` and composes the two scalings via `scale_scale`.

This reduces the M1 per-support honest congruence to a single remaining obligation — the correspondence hypothesis itself, the `monicTarget`-coordinate subset Hensel-uniqueness recovery — which the dilate-coordinate `RecoveredAtLift` witness backing each true support does not supply (the coordinates diverge). That remodel is split to #8325. Partial against #8323.

`lake build HexBerlekampZassenhausMathlib` green; axiom cone `[propext, Classical.choice, Quot.sound]`; no `sorry`/`axiom`/`native_decide` introduced.

🤖 Prepared with Claude Code