### PR TITLE
ci: drop LLL-only fpLLL/fpylll/Isabelle build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
       - run: python3 scripts/check_phase4.py
       - name: Lint benches are Mathlib-free (SPEC/benchmarking.md §Mathlib-free benches)
         run: python3 scripts/ci/check_benches_mathlib_free.py
-      - run: sudo apt-get install -y libgmp-dev libfplll-dev fplll-tools libntl-dev libmpfr-dev libc++-dev libc++abi-dev autoconf automake libtool pkg-config
+      - run: sudo apt-get install -y libgmp-dev libntl-dev pkg-config
       - name: Install Python bench comparator dependencies
-        run: python3 -m pip install --user cysignals fpylll python-flint
+        run: python3 -m pip install --user python-flint
       - name: Set up Lean toolchain (no build)
         uses: leanprover/lean-action@v1
         with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgmp-dev libpari-dev pari-gp libfplll-dev
+          sudo apt-get install -y libgmp-dev libpari-dev pari-gp
       - name: Install Python oracle dependencies
         run: |
           python3 -m pip install --user \
-            python-flint cypari2 conway-polynomials fpylll
+            python-flint cypari2 conway-polynomials
       - name: Set up Lean toolchain (no build)
         uses: leanprover/lean-action@v1
         with:


### PR DESCRIPTION
This PR trims the CI dependency lists that became dead weight after the matrix / gram-schmidt / LLL libraries were extracted: no library remaining in the monorepo uses fpLLL, fpylll, or the LLL Isabelle setup. It drops `libfplll-dev`, `fplll-tools`, `libmpfr-dev`, `libc++-dev`, `libc++abi-dev`, `autoconf`, `automake`, `libtool` (apt) and `cysignals`, `fpylll` (pip) from `ci.yml`, and `libfplll-dev` (apt) + `fpylll` (pip) from `conformance.yml`. It keeps `libgmp-dev`, `libntl-dev`, and `pkg-config`, which the staying HexGF2 NTL bench comparator (`gf2_ntl_bench_driver.cc`, which `#include`s `NTL/GF2X.h` and is discovered via pkg-config) hard-requires, along with the `python-flint` / `cypari2` / `conway-polynomials` oracle stack used by the staying FLINT/PARI/Conway conformance oracles. The BZ Isabelle comparator is not wired into CI and degrades gracefully when absent, so no Isabelle dependency is needed. CI is the final arbiter for the `libmpfr-dev`/`libc++` drops.

🤖 Prepared with Claude Code