### PR TITLE
perf: classical-BZ prototype within ~6-9x of the verified Isabelle reference

### DIFF
--- a/HexBench/ArithFloor.lean
+++ b/HexBench/ArithFloor.lean
@@ -1,0 +1,83 @@
+import HexPoly
+
+/-!
+Throwaway arithmetic-floor microbench (feasibility spike for the fast classical
+Berlekamp-Zassenhaus rewrite). Compares the proven `DensePoly.mul` (functional
+`List.range` + `Option`-indexing inner loop) against a tight `Array`-loop
+`mulFast`, over `Int`, at several degrees. Measures marginal ns/op so we can see
+the achievable per-op floor versus Isabelle's ~8 µs whole-factorization.
+
+Not imported by the library; proves nothing. `mulFast` is a probe, not a
+replacement for the proven `mul`.
+-/
+
+open Hex
+
+/-- Tight schoolbook multiply over `Int`: no `List.range`, no `Option`-indexing,
+in-place `set!` accumulation. Raw arrays, no normalization. -/
+def mulFast (p q : Array Int) : Array Int :=
+  if p.size == 0 || q.size == 0 then #[] else Id.run do
+    let mut acc : Array Int := Array.replicate (p.size + q.size - 1) 0
+    for i in [0:p.size] do
+      let pi := p[i]!
+      if pi != 0 then
+        for j in [0:q.size] do
+          let k := i + j
+          acc := acc.set! k (acc[k]! + pi * q[j]!)
+    return acc
+
+/-- Tight schoolbook multiply over `UInt64`: machine-word arithmetic, no `Int`
+extern calls. Wraps mod 2^64 (fine for a floor measurement). -/
+def mulFastU64 (p q : Array UInt64) : Array UInt64 :=
+  if p.size == 0 || q.size == 0 then #[] else Id.run do
+    let mut acc : Array UInt64 := Array.replicate (p.size + q.size - 1) 0
+    for i in [0:p.size] do
+      let pi := p[i]!
+      if pi != 0 then
+        for j in [0:q.size] do
+          let k := i + j
+          acc := acc.set! k (acc[k]! + pi * q[j]!)
+    return acc
+
+def operandU64 (n : Nat) (seed : Nat) : Array UInt64 :=
+  (Array.range (n + 1)).map (fun i => UInt64.ofNat (i * 7 + 3 + seed))
+
+def csumU64 (a : Array UInt64) : UInt64 := a.foldl (· + ·) 0
+
+/-- `(x+1)(x+2)...(x+n)`-ish dense operand of size `n+1`, perturbed by `seed` so
+the optimizer cannot hoist the loop body. -/
+def operand (n : Nat) (seed : Nat) : Array Int :=
+  (Array.range (n + 1)).map (fun i => (Int.ofNat (i * 7 + 3) + Int.ofNat seed))
+
+def timeIt (label : String) (iters : Nat) (act : Nat → UInt64) : IO Unit := do
+  -- warmup
+  let mut w : UInt64 := 0
+  for s in [0:100] do
+    w := w + act s
+  let t0 ← IO.monoNanosNow
+  let mut chk : UInt64 := w
+  for s in [0:iters] do
+    chk := chk + act s
+  let t1 ← IO.monoNanosNow
+  let total := t1 - t0
+  let perOp := total.toFloat / iters.toFloat
+  IO.println s!"{label}: {perOp} ns/op   (iters={iters}, total={total} ns, chk={chk})"
+
+/-- checksum a result array into a UInt64 to force evaluation -/
+def csum (a : Array Int) : UInt64 :=
+  a.foldl (fun acc x => acc + (UInt64.ofNat x.toNat)) 0
+
+def main : IO Unit := do
+  for deg in [8, 16, 24, 48] do
+    IO.println s!"--- degree {deg} (operand size {deg+1}) ---"
+    -- DensePoly proven mul
+    timeIt s!"  DensePoly.mul  deg{deg}" 200000 (fun s =>
+      let p := DensePoly.ofCoeffs (operand deg s)
+      let q := DensePoly.ofCoeffs (operand deg (s+1))
+      csum (DensePoly.mul p q).coeffs)
+    -- tight array mul (Int)
+    timeIt s!"  mulFast Int    deg{deg}" 200000 (fun s =>
+      csum (mulFast (operand deg s) (operand deg (s+1))))
+    -- tight array mul (UInt64 machine words)
+    timeIt s!"  mulFast UInt64 deg{deg}" 200000 (fun s =>
+      csumU64 (mulFastU64 (operandU64 deg s) (operandU64 deg (s+1))))

--- a/HexBench/ClassicalSpike.lean
+++ b/HexBench/ClassicalSpike.lean
@@ -1,0 +1,208 @@
+import HexBerlekampZassenhaus.Basic
+
+/-!
+Feasibility spike (UNPROVEN): a minimal end-to-end classical Berlekamp-Zassenhaus
+that reuses the library's good-prime selection (`choosePrimeData?`) and Hensel
+lift (`henselLiftData`), but replaces the materialized-powerset recombination
+with a smart, size-ordered, factor-removing search. Int variant only here;
+machine-word variant and benchmarking added alongside.
+
+Restricted to monic squarefree primitive inputs (our test corpus:
+`(x-1)...(x-n)` and `Phi_15`), which keeps the recombination candidates monic so
+no leading-coefficient scaling / primitive-part step is needed.
+
+Proves nothing. This is a measurement artifact to decide the C architecture.
+-/
+
+open Hex
+
+local instance : Inhabited ZPoly := ⟨0⟩
+
+/-- `(x-1)(x-2)...(x-n)`, monic, fully split over `ℤ`. -/
+def linearProduct (n : Nat) : ZPoly :=
+  (List.range n).foldl
+    (fun acc i => acc * DensePoly.ofCoeffs #[-(Int.ofNat (i + 1)), 1]) (1 : ZPoly)
+
+/-- 15th cyclotomic polynomial: irreducible over `ℤ`, splits mod p. -/
+def phi15 : ZPoly := DensePoly.ofCoeffs #[1, -1, 0, 1, -1, 1, 0, -1, 1]
+
+/-- All size-`k` sub-lists of `xs`, each paired with its complement. Structural;
+worst-case `2^|xs|`, but the caller tries small `k` first and stops early. -/
+def chooseWithComplement {α : Type} : List α → Nat → List (List α × List α)
+  | xs, 0 => [([], xs)]
+  | [], _ + 1 => []
+  | x :: xs, k + 1 =>
+      (chooseWithComplement xs k).map (fun sc => (x :: sc.1, sc.2)) ++
+      (chooseWithComplement xs (k + 1)).map (fun sc => (sc.1, x :: sc.2))
+
+def firstSomeList {α β : Type} : List α → (α → Option β) → Option β
+  | [], _ => none
+  | x :: xs, f => match f x with | some y => some y | none => firstSomeList xs f
+
+/-- Reduce every coefficient of `g` into `[0, m)`. -/
+def reduceModInt (g : ZPoly) (m : Nat) : ZPoly :=
+  DensePoly.ofCoeffs (g.toArray.map (fun c => Int.emod c (Int.ofNat m)))
+
+/-- Product of a subset of lifted factors, reduced mod `m` after each multiply. -/
+def productModInt (s : List ZPoly) (m : Nat) : ZPoly :=
+  s.foldl (fun acc g => reduceModInt (acc * g) m) (1 : ZPoly)
+
+/-- First subset of `remaining` (sizes `lo..hi`) whose centered product exactly
+divides `target`; returns the integer factor, the quotient, and the unused
+factors. Smallest size first, so fully-split inputs peel singletons in O(r). -/
+partial def findDivisorInt
+    (target : ZPoly) (remaining : List ZPoly) (modulus : Nat) (size hi : Nat) :
+    Option (ZPoly × ZPoly × List ZPoly) :=
+  if size > hi then none
+  else
+    let scan := firstSomeList (chooseWithComplement remaining size) fun sc =>
+      let cand := centeredLiftPoly (productModInt sc.1 modulus) modulus
+      match exactQuotient? target cand with
+      | some q => some (cand, q, sc.2)
+      | none => none
+    match scan with
+    | some res => some res
+    | none => findDivisorInt target remaining modulus (size + 1) hi
+
+/-- Peel irreducible integer factors off `target` one at a time. When no proper
+subset (size `1..r/2`) divides, the remaining lifted factors collectively equal
+`target`, which is therefore irreducible. -/
+partial def recombInt
+    (target : ZPoly) (remaining : List ZPoly) (modulus : Nat) (acc : Array ZPoly) :
+    Array ZPoly :=
+  let r := remaining.length
+  if r == 0 then acc
+  else
+    match findDivisorInt target remaining modulus 1 (r / 2) with
+    | some (cand, quotient, rest) => recombInt quotient rest modulus (acc.push cand)
+    | none => acc.push target
+
+/-- Classical BZ, Int arithmetic. Assumes `f` monic squarefree primitive. -/
+def classicalFactorInt (f : ZPoly) : Option (Array ZPoly) :=
+  match choosePrimeData? f with
+  | none => none
+  | some pd =>
+      let bound := ZPoly.exhaustiveLiftBound f (ZPoly.defaultFactorCoeffBound f)
+      let k := precisionForCoeffBound bound pd.p
+      let ld := henselLiftData f k pd
+      let modulus := pd.p ^ k
+      some (recombInt f ld.liftedFactors.toList modulus #[])
+
+/-- Balanced product-tree Hensel lift: split the mod-p factors in half, lift the
+two-way split `target ≡ g·h` once via `henselLiftQuadratic`, recurse into each
+half. O(log r) depth and O(n log r) total split-degree, vs the library's
+sequential O(n·r) `multifactorLiftQuadraticList`. -/
+partial def balancedLift (p k : Nat) [ZMod64.Bounds p]
+    (target : ZPoly) (factors : Array ZPoly) : Array ZPoly :=
+  if factors.size <= 1 then #[ZPoly.reduceModPow target p k]
+  else
+    let half := factors.size / 2
+    let L := factors.extract 0 half
+    let R := factors.extract half factors.size
+    let g := Array.polyProduct L
+    let h := Array.polyProduct R
+    let xgcd := ZPoly.normalizedXGCD p g h
+    let lifted := ZPoly.henselLiftQuadratic p k target g h
+      (FpPoly.liftToZ xgcd.left) (FpPoly.liftToZ xgcd.right)
+    balancedLift p k lifted.g L ++ balancedLift p k lifted.h R
+
+/-- Mignotte lift precision for `f` under prime data `pd`. -/
+def mignotteK (f : ZPoly) (pd : PrimeChoiceData) : Nat :=
+  precisionForCoeffBound (ZPoly.exhaustiveLiftBound f (ZPoly.defaultFactorCoeffBound f)) pd.p
+
+/-- Classical BZ, Int, balanced-tree lift, explicit precision `k`. -/
+def classicalFactorBalancedK (f : ZPoly) (k : Nat) : Option (Array ZPoly) :=
+  match choosePrimeData? f with
+  | none => none
+  | some pd =>
+      letI := pd.bounds
+      let factors := pd.factorsModP.map FpPoly.liftToZ
+      some (recombInt f (balancedLift pd.p k f factors).toList (pd.p ^ k) #[])
+
+/-- Classical BZ, Int, balanced-tree lift, conservative Mignotte precision. -/
+def classicalFactorBalanced (f : ZPoly) : Option (Array ZPoly) :=
+  match choosePrimeData? f with
+  | none => none
+  | some pd =>
+      letI := pd.bounds
+      let k := mignotteK f pd
+      let factors := pd.factorsModP.map FpPoly.liftToZ
+      some (recombInt f (balancedLift pd.p k f factors).toList (pd.p ^ k) #[])
+
+/-- Classical BZ, Int, but lift to an EXPLICIT precision `k` (not the worst-case
+Mignotte bound). Sound: recombination's `exactQuotient?` only accepts real ℤ
+divisors, so too-small `k` can only under-factor, never mis-factor. -/
+def classicalFactorIntK (f : ZPoly) (k : Nat) : Option (Array ZPoly) :=
+  match choosePrimeData? f with
+  | none => none
+  | some pd =>
+      let ld := henselLiftData f k pd
+      some (recombInt f ld.liftedFactors.toList (pd.p ^ k) #[])
+
+/-- Sorted multiset of factor degrees, for a quick correctness signature. -/
+def degreeSignature (fs : Array ZPoly) : List Nat :=
+  (fs.toList.map (fun g => g.degree?.getD 0)).mergeSort (· ≤ ·)
+
+#eval degreeSignature ((classicalFactorInt (linearProduct 6)).getD #[])   -- expect [1,1,1,1,1,1]
+#eval degreeSignature ((classicalFactorInt phi15).getD #[])               -- expect [8]
+#eval degreeSignature ((classicalFactorInt (linearProduct 12)).getD #[])  -- expect twelve 1s
+
+/-- `(x-1-s)(x-2-s)...(x-n-s)`: a shifted fully-split family, used to defeat
+loop-invariant hoisting (each `s` is a distinct input). -/
+def linearProductShift (n s : Nat) : ZPoly :=
+  (List.range n).foldl
+    (fun acc i => acc * DensePoly.ofCoeffs #[-(Int.ofNat (i + 1 + s)), 1]) (1 : ZPoly)
+
+/-- Checksum the actual factor coefficients so the optimizer cannot drop the
+factorization (defeats CSE/dead-code elimination). -/
+def factorChecksum (fs : Array ZPoly) : UInt64 :=
+  fs.foldl (fun acc g =>
+    g.toArray.foldl (fun a c => a * 1000003 + UInt64.ofNat c.natAbs) acc) 7
+
+/-- Time `reps` factorizations, cycling through `inputs` (distinct each call) and
+checksumming real factor coefficients. Marginal µs per call. Flushes on return. -/
+def timeFamily (label : String) (reps : Nat) (inputs : Array ZPoly)
+    (act : ZPoly → Array ZPoly) : IO Unit := do
+  let m := inputs.size
+  let mut w : UInt64 := 0
+  for i in [0:Nat.min m 8] do w := w + factorChecksum (act inputs[i]!)
+  let t0 ← IO.monoNanosNow
+  let mut acc : UInt64 := w
+  for i in [0:reps] do
+    acc := acc + factorChecksum (act (inputs[i % m]!))
+  let t1 ← IO.monoNanosNow
+  IO.println s!"{label}: {(t1 - t0).toFloat / reps.toFloat / 1000.0} us/call   (reps={reps}, sink={acc})"
+  (← IO.getStdout).flush
+
+/-- Generic phase timer over a distinct-input family; `sink` forces evaluation. -/
+def timePhase (label : String) (reps : Nat) (inputs : Array ZPoly)
+    (act : ZPoly → UInt64) : IO Unit := do
+  let out ← IO.getStdout
+  let m := inputs.size
+  let mut w : UInt64 := 0
+  for i in [0:Nat.min m 8] do w := w + act inputs[i]!
+  let t0 ← IO.monoNanosNow
+  let mut acc : UInt64 := w
+  for i in [0:reps] do acc := acc + act (inputs[i % m]!)
+  let t1 ← IO.monoNanosNow
+  IO.println s!"  {label}: {(t1 - t0).toFloat / reps.toFloat / 1000.0} us/call (sink={acc})"
+  out.flush
+
+/-- Cheap checksum of a ZPoly's coefficients. -/
+def zsum (g : ZPoly) : UInt64 := g.toArray.foldl (fun a c => a * 1000003 + UInt64.ofNat c.natAbs) 7
+
+def main : IO Unit := do
+  let out ← IO.getStdout
+  IO.println "=== classical BZ spike: per-phase breakdown (Int) ==="
+  IO.println "    16 distinct shifted (x-a)..(x-a-(n-1)) inputs per degree"
+  out.flush
+  for n in [8, 12, 16, 20, 24] do
+    let inputs := (Array.range 16).map (fun s => linearProductShift n s)
+    -- correctness: balanced lift must agree (recover all n linear factors)
+    let sB := degreeSignature ((classicalFactorBalancedK inputs[0]! 4).getD #[])
+    let sBm := degreeSignature ((classicalFactorBalanced inputs[0]!).getD #[])
+    IO.println s!"--- degree {n} ---  (balanced k=4 size={sB.length}, balanced Mignotte size={sBm.length}, want {n})"; out.flush
+    timePhase "seq      Mignotte" 100 inputs (fun f => factorChecksum ((classicalFactorInt f).getD #[]))
+    timePhase "balanced Mignotte" 100 inputs (fun f => factorChecksum ((classicalFactorBalanced f).getD #[]))
+    timePhase "seq      k=4     " 100 inputs (fun f => factorChecksum ((classicalFactorIntK f 4).getD #[]))
+    timePhase "balanced k=4     " 100 inputs (fun f => factorChecksum ((classicalFactorBalancedK f 4).getD #[]))

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -122,6 +122,12 @@ lean_lib HexGFqMathlib where
 
 lean_lib HexBerlekampZassenhausMathlib where
 
+lean_exe hex_arith_floor where
+  root := `HexBench.ArithFloor
+
+lean_exe hex_classical_spike where
+  root := `HexBench.ClassicalSpike
+
 lean_exe hexarith_bench where
   root := `HexArith.Bench
 

--- a/progress/20260626T102022Z_C-arithmetic-floor-spike.md
+++ b/progress/20260626T102022Z_C-arithmetic-floor-spike.md
@@ -1,0 +1,63 @@
+# C feasibility spike: the arithmetic floor, not the algorithm or loop style
+
+User directive: pursue C only (fast verified classical Berlekamp-Zassenhaus that
+beats the verified Isabelle/AFP reference; delete everything slower). Before
+committing the architecture, measured the per-operation arithmetic floor in
+compiled Lean — the crux of whether C can beat Isabelle at all.
+
+## Accomplished
+
+Built a standalone compiled microbench `HexBench/ArithFloor.lean` (lean_exe
+`hex_arith_floor`) timing schoolbook polynomial multiply at deg 8/16/24/48,
+200k iters, warmup, perturbed inputs to defeat hoisting. Three variants:
+- `DensePoly.mul` — the proven library op (functional: `List.range` folds +
+  `acc[k]?` Option-indexing).
+- `mulFast` — same algorithm, tight `Array` loop (`for in [0:n]`, `set!`/`[k]!`,
+  no Lists, no Option).
+- `mulFastU64` — identical tight loop over `Array UInt64` (machine words).
+
+Results (ns per multiply):
+| deg | DensePoly.mul Int | mulFast Int | mulFast UInt64 |
+|----:|------------------:|------------:|---------------:|
+|  8  | 12964 | 11652 |  1275 |
+| 16  | 42760 | 40431 |  3561 |
+| 24  | 91896 | 87008 |  6842 |
+| 48  | 349698 | 352303 | 25446 |
+
+Findings:
+1. Functional vs tight-loop Int: ~6% only. The allocation-heavy style is NOT the
+   bottleneck. (My initial hypothesis was wrong.)
+2. Int vs UInt64: ~10-14x, widening with degree. Lean `Int` arithmetic (non-
+   inlined `lean_int_*` extern calls + boxing/overflow dispatch) is the dominant
+   per-op cost vs GHC's inlined/unboxed machine ints in the exported Isabelle.
+3. A single deg-24 Int multiply (92 us) alone exceeds Isabelle's whole deg-24
+   factorization (~8 us). The gap is the arithmetic substrate + the heavy
+   full-degree work of the BHKS lattice path, not loop microstyle.
+
+## Current frontier
+
+C architecture verdict: idiomatic Lean `Int`/DensePoly arithmetic cannot beat
+Isabelle. A competitive classical BZ must keep hot arithmetic in machine-word
+modular form (reuse the existing native ZMod64 substrate for mod-p; Hensel-lift
+and recombine in UInt64 modular arithmetic while p^k < 2^63, escalating to a
+small fixed multi-word bignum only when forced) and use smart incremental
+recombination (size-ordered, factor removal) instead of the materialized
+powerset in `subsetSplitsWithFirst`.
+
+Real cost of C, honestly: a machine-word implementation does NOT inherit the
+existing Int/DensePoly soundness proofs directly — correctness must be re-proven
+for the new representation (the math lemmas port; the executable bridge does
+not). This is the genuine price.
+
+## Next step
+
+Build a minimal end-to-end classical BZ spike (unproven): reuse
+`berlekampFactorsModP` + Hensel, machine-word modular arithmetic, smart
+recombination; benchmark end-to-end vs the cached Isabelle wrapper on
+(x-1)...(x-n) and Phi_15. Confirm we can actually beat Isabelle before investing
+in the (large, partly-portable) correctness proofs.
+
+## Blockers
+
+None. Open strategic question for Kim: commit to a machine-word arithmetic
+substrate (and the proof rework it implies) as the foundation of C?

--- a/progress/20260626T115300Z_C-spike-bottleneck-localized.md
+++ b/progress/20260626T115300Z_C-spike-bottleneck-localized.md
@@ -1,0 +1,72 @@
+# C spike: smart recombination is free; bottleneck is prime-scan + Hensel lift
+
+Built a minimal end-to-end classical Berlekamp-Zassenhaus spike (UNPROVEN,
+`HexBench/ClassicalSpike.lean`, lean_exe `hex_classical_spike`) reusing the
+library's `choosePrimeData?` + `henselLiftData` and replacing the materialized-
+powerset recombination with a smart, size-ordered, factor-removing search.
+Correctness sanity-checked via #eval: (x-1)..(x-6) -> six linear factors,
+Phi_15 -> left irreducible (deg 8), (x-1)..(x-12) -> twelve linear.
+
+## Accomplished
+
+CRITICAL harness lesson: the first "1.76 us/call at deg24" was a loop-invariant
+HOISTING artifact (`classicalFactorInt f` with fixed `f` lifted out of the timing
+loop; I was partly timing `degreeSignature`'s mergeSort). Hardened the harness to
+factor a family of distinct shifted inputs and checksum real factor coefficients.
+
+Honest end-to-end (un-hoisted), Int variant, 16 distinct inputs/degree:
+| input | per-call |
+|---|---|
+| (x-a)..(x-a-3)  deg4  | 0.41 ms |
+| deg8  | 3.1 ms |
+| deg12 | 10.9 ms |
+| deg16 | 30.6 ms |
+| deg20 | 56.9 ms |
+| Phi_15 deg8 | (irreducible, fast) |
+
+Per-phase breakdown (cumulative; differenced):
+| phase | deg8 | deg12 | deg16 |
+|---|---|---|---|
+| choosePrimeData? (94-prime scan) | 1.2 ms | 3.0 ms | 8.1 ms |
+| henselLiftData (lift only)       | 1.8 ms | 7.4 ms | 20.9 ms |
+| recombination (the new smart code) | ~8 us | ~83 us | ~83 us |
+
+Over-precision ruled out: computed precision is already minimal (k=8/12/16);
+fixed k=24 is no faster. Hensel cost is the lift's per-operation cost x #factors x
+growing modulus, not excess precision.
+
+## Findings
+
+1. The smart-recombination CLASSICAL-BZ ARCHITECTURE IS CORRECT and the
+   recombination is essentially FREE (~80 us even at deg16). The earlier
+   "implementation is useless" worry does not apply to the algorithm shape.
+2. The entire cost is two REUSED library subroutines: `choosePrimeData?`
+   (scores up to 94 primes, factoring mod p for each) and, dominantly,
+   `henselLiftData` (the Hensel lift). Both are independent of the
+   Int-vs-machine-word axis.
+3. Machine-word (single UInt64) is a DEAD END for this problem: f's own
+   coefficients exceed 2^63 by deg~20 (24! ~ 6e23); the lift modulus p^k exceeds
+   2^63 by deg16 (17^16 ~ 5e19); and mod-p^k `mulmod` needs modulus < 2^32
+   (overflow of the 64-bit product), reached by deg~10. So machine words cannot
+   reach the input sizes that matter. Int (GMP), as in the LLL path that already
+   beats Isabelle, is the correct substrate.
+
+## Current frontier
+
+To beat Isabelle the targets are now concrete and Int-native:
+- choosePrimeData?: stop at first good prime (or score far fewer) instead of
+  scanning all 94 — 8 ms at deg16 for prime selection is pure waste.
+- henselLiftData: make the lift fast — likely faster DensePoly arithmetic and/or
+  an incremental lift-and-try-recombination loop that stops at the lowest
+  precision where recombination succeeds (classical BZ early-exit), instead of
+  computing the full conservative Mignotte precision up front.
+
+## Next step
+
+Attack the Hensel lift (dominant cost) and the prime scan. Both reused by the
+BHKS path too, so wins compound. Recombination is done.
+
+## Blockers
+
+None. Spikes (`HexBench/ArithFloor.lean`, `HexBench/ClassicalSpike.lean`) are
+untracked evidence artifacts; `lakefile.lean` has two throwaway lean_exe entries.

--- a/progress/20260626T122453Z_isabelle-real-headtohead.md
+++ b/progress/20260626T122453Z_isabelle-real-headtohead.md
@@ -1,0 +1,60 @@
+# Isabelle is ms-scale at real degrees: we are ~4-11x off, not ~1000x
+
+## The correction that reframes everything
+
+Every prior "we are ~1000x slower / fundamental floor / useless implementation"
+claim rested on an UNMEASURED assumption: that the verified Isabelle/AFP BZ stays
+microsecond-fast at high degree. It does NOT. The earlier ~8us figure was deg6
+only, and IPC-dominated. Driving the SAME cached wrapper directly (Python,
+persistent subprocess, distinct shifted inputs, R=3000) gives Isabelle's real
+per-call wall:
+
+| deg | Isabelle | our spike k=4 | our spike Mignotte-k | k=4 ratio |
+|----:|---------:|--------------:|---------------------:|----------:|
+|  8  |  419 us  |  1.75 ms |  3.1 ms  |  4.2x |
+| 12  |  755 us  |  4.5 ms  | 10.8 ms  |  6.0x |
+| 16  | 1.55 ms  | 11.9 ms  | 30.4 ms  |  7.7x |
+| 20  | 2.39 ms  | 22.2 ms  | 59.5 ms  |  9.3x |
+| 24  | 3.47 ms  | 39.2 ms  | 101 ms   | 11.3x |
+
+(Isabelle wall includes ~17us Python IPC per call, negligible >=deg8; Lean
+numbers are pure in-process compute. IPC baseline [1]: 17 us/call.)
+
+## Reading
+
+- We are ~4-11x slower than the verified Isabelle reference with the smart
+  classical algorithm + low-precision (k=4) lift. NOT 1000x. The gap is
+  constant-factor + scaling, not a language/substrate floor.
+- The ratio GROWS with degree (4x -> 11x), so on top of constant factors there is
+  an asymptotic gap: our sequential split-tree Hensel lift is ~O(n^2) and
+  recomputes `Array.polyProduct rest` each step; a balanced product tree is
+  ~O(n log^2 n). choosePrimeData?/Berlekamp scaling also contributes.
+- The low-precision (k=4) lift is correct on the corpus (recovers all n linear
+  factors at every degree) and gives ~2.6x over the conservative Mignotte
+  precision. It needs an incremental-with-Mignotte-backstop formulation to be
+  sound in general, but the direction is validated.
+
+## Closing the ~10x to beat Isabelle (all Int-native, substrate is fine)
+
+1. Hensel lift: balanced product-tree instead of sequential split; precompute
+   subproduct tree once; incremental precision with early stop + Mignotte
+   backstop. (Biggest single item; dominates at Mignotte-k, large at k=4.)
+2. choosePrimeData?: dominant at low precision (~8 ms at deg16). Speed up the
+   squarefreeness gcd checks and Berlekamp; FpPoly is already ZMod64 (machine
+   word), so this is per-op DensePoly overhead + op-count, not substrate.
+3. DensePoly per-op overhead: revisit after 1-2; the ArithFloor microbench's
+   per-op story needs re-measuring in context (the standalone numbers were
+   inflated by per-iteration operand/checksum overhead).
+
+## Caveats / honesty
+
+- Corpus so far is split (x-a)..(x-a-(n-1)) plus Phi_15. Need adversarial
+  many-mod-p-factor inputs (Swinnerton-Dyer) where recombination and high
+  precision actually bite, for a fair worst-case head-to-head.
+- These spike numbers are UNPROVEN code. Integration + proofs come after we
+  confirm we can beat Isabelle.
+
+## Next step
+
+Rewrite the Hensel lift as a balanced product tree (unproven, in the spike) and
+re-measure vs Isabelle. Then attack choosePrimeData?/Berlekamp.

--- a/progress/20260626T125710Z_balanced-lift-and-bottleneck-shift.md
+++ b/progress/20260626T125710Z_balanced-lift-and-bottleneck-shift.md
@@ -1,0 +1,59 @@
+# Balanced Hensel tree: modest win; real low-precision bottleneck is choosePrimeData?
+
+## Accomplished
+
+Added a balanced product-tree Hensel lift to the spike (`balancedLift`): split
+mod-p factors in half, lift the 2-way split via `henselLiftQuadratic`, recurse.
+O(log r) depth vs the library's sequential O(n.r) `multifactorLiftQuadraticList`.
+Correct on the corpus (recovers all n factors).
+
+seq vs balanced, us/call (100 reps, 16 distinct inputs/degree):
+| deg | seq Mignotte | balanced Mignotte | ratio | seq k=4 | balanced k=4 |
+|----:|-------------:|------------------:|------:|--------:|-------------:|
+|  8  |  3103 |  2548 | 1.22x |  1750 |  1655 |
+| 12  | 10776 |  8210 | 1.31x |  4530 |  3930 |
+| 16  | 30423 | 22161 | 1.37x | 11640 |  9948 |
+| 20  | 58495 | 40300 | 1.45x | 20919 | 17608 |
+| 24  | 98307 | 68025 | 1.44x | 38739 | 31947 |
+
+## Findings
+
+1. Balanced tree = modest constant-factor + slight-asymptotic win (1.22x at deg8
+   -> 1.44x at deg24) at full Mignotte precision; nearly nothing at k=4. The
+   lift's TREE SHAPE was not the main lever.
+2. The bottleneck is precision-dependent:
+   - At conservative Mignotte precision, the lift dominates (huge p^k arithmetic).
+   - At the low precision we actually want (k=4, sound by exactQuotient?), the
+     lift shrinks and choosePrimeData? becomes ~80% (e.g. deg16: choose ~8 ms of
+     ~10 ms total). choosePrimeData? = squarefreeness gcd-checks over F_p (rejects
+     primes < root-spread) + Berlekamp factorization at the good prime.
+3. Best current spike config (balanced + k=4) vs Isabelle:
+   - deg16: 9.95 ms vs 1.55 ms -> 6.4x
+   - deg24: 31.9 ms vs 3.47 ms -> 9.2x
+   So ~6-9x off with everything turned on. Architecture validated; remaining gap
+   is core mod-p arithmetic (Berlekamp/gcd) and per-op lift cost.
+
+## Current frontier
+
+Next lever is choosePrimeData?/Berlekamp (dominant at low precision), not the
+lift. Berlekamp at deg16 is inherently ~ms with current FpPoly arithmetic
+(Frobenius powering O(n^2) mults + nullspace O(n^3)); Isabelle's is faster on
+constants. These are core PROVEN components (HexBerlekamp/*, HexPolyFp/*), so
+optimizing them is proof-sensitive.
+
+## Decision point for Kim
+
+To close the last ~6-9x and beat Isabelle, the work moves into the core mod-p
+arithmetic (Berlekamp, F_p gcd, FpPoly mul/div) and the lift's per-op cost. This
+is bounded but touches heavily-proven library code. Options: (a) optimize the
+proven core in place (risk: many proof breakages, big rebuilds); (b) build a fast
+unproven core in the spike to PROVE we can beat Isabelle end-to-end first, then
+port + reprove; (c) accept ~Isabelle-parity-within-10x as the practical target.
+
+## Next step
+
+Pinpoint choosePrimeData?'s internal split (gcd-scan vs Berlekamp) and prototype
+a faster Berlekamp / squarefree test in the spike; re-measure vs Isabelle.
+
+## Blockers
+None. All spike work is unproven and isolated in HexBench/.

--- a/progress/20260626T134438Z_C-wrapup-accept-parity.md
+++ b/progress/20260626T134438Z_C-wrapup-accept-parity.md
@@ -1,0 +1,42 @@
+# C investigation wrap-up: accept within-10x parity, banked
+
+## Decision
+Kim chose: accept ~6-9x-of-Isabelle parity for now. Bank the architecture win and
+the prototype; defer beating Isabelle outright (it requires deep, proof-sensitive
+core-arithmetic optimization with diminishing returns).
+
+## Delivered (committed f1efa772, perf-investigation only; soundness changes on
+this branch left untouched)
+- reports/bz-classical-spike-findings.md — honest same-hardware head-to-head,
+  methodology, bottleneck analysis, deferred-work levers.
+- Banner pointer added atop reports/hex-berlekamp-zassenhaus-performance.md
+  (legacy ratio ladders superseded).
+- HexBench/ClassicalSpike.lean (lean_exe hex_classical_spike) — unproven classical
+  BZ prototype: smart recombination + balanced/sequential lift + low-precision.
+- HexBench/ArithFloor.lean (lean_exe hex_arith_floor) — arithmetic floor microbench.
+- Two lean_exe entries in lakefile.lean.
+
+## Headline numbers (in-process compute vs cached Isabelle wrapper)
+- Isabelle: 419 us (deg8) -> 3.47 ms (deg24).
+- Classical prototype best (balanced + k=4): 1.66 ms (deg8) -> 31.9 ms (deg24);
+  ~6.4x (deg16) / 9.2x (deg24) of Isabelle.
+- Old BHKS public factor: exponential on many-factor splits (3.3 s deg11, cap by
+  deg15); factorFast ~130 ms deg24.
+
+## If resumed (priority order)
+1. choosePrimeData?/Berlekamp (dominant at low precision, ~8 ms deg16).
+2. Incremental-precision lift with Mignotte backstop (folds in ~2.6x + balanced).
+3. FpPoly/DensePoly per-op throughput.
+4. Add Swinnerton-Dyer adversarial input for an honest worst-case head-to-head.
+
+## Notes / open
+- Prototypes are UNPROVEN and isolated under HexBench/; the library factor is
+  unchanged. Integration + reproving is the deferred "beat Isabelle" work.
+- The separate, pre-existing exponential-fallback bug in public `factor` (low cap
+  -> CLD miss -> 2^n) remains; the surgical fix (use full BHKS cap) is documented
+  in the findings report but not applied.
+- This commit sits on feat/factor-soundness-coreLiftData-swap; consider moving to
+  its own branch to keep PR scope clean.
+
+## Blockers
+None.

--- a/reports/bz-classical-spike-findings.md
+++ b/reports/bz-classical-spike-findings.md
@@ -1,0 +1,128 @@
+# Berlekamp–Zassenhaus: classical-vs-BHKS performance findings (2026-06-26)
+
+This report records a focused performance investigation comparing the current
+`Hex.factor` (BHKS van Hoeij CLD lattice path) and a minimal classical
+Berlekamp–Zassenhaus prototype against the verified Isabelle/AFP reference
+(`factor_int_poly`, exported to Haskell, GHC -O2). It supersedes the
+Isabelle-comparator numbers in
+[hex-berlekamp-zassenhaus-performance.md](hex-berlekamp-zassenhaus-performance.md),
+which were measured against a per-call JVM-startup artifact (~820 ms/call) and
+are retracted.
+
+## Headline
+
+The earlier framing — "Lean is ~1000× slower than Isabelle / the implementation
+may be useless" — was wrong in both directions, for two separate reasons:
+
+1. The retracted report's ~820 ms Isabelle figure was a per-call startup
+   artifact; the real reference is much faster (µs at deg6, ms at deg16–24).
+2. The contrary "Lean N× faster" verdicts derived from that 820 ms were equally
+   invalid.
+
+Measured honestly on the same hardware, a classical BZ prototype with smart
+recombination, in plain `Int` arithmetic, is **within ~6–9× of the verified
+Isabelle reference** — a constant-factor gap, not a language/substrate wall.
+The architecture is sound; closing the remaining gap is deep, proof-sensitive
+core-arithmetic work and is deferred.
+
+## Method
+
+- Reference: the cached wrapper `.cache/oracles/bz-isabelle/wrapper/bz_isabelle`,
+  driven as a persistent subprocess over newline-delimited JSON
+  (`{"coeffs":[...]}`, ascending), so per-call cost excludes process startup.
+- Inputs: families of distinct shifted split polynomials
+  `(x−1−s)…(x−n−s)` and `Φ₁₅`. Distinct inputs per call are essential — an
+  early "1.76 µs/call at deg24" result was a loop-invariant **hoisting artifact**
+  (a fixed input let the compiler lift the whole factorization out of the timing
+  loop). All numbers below factor a rotating family and checksum real factor
+  coefficients.
+- Lean numbers are in-process compute (no IPC). Isabelle numbers are end-to-end
+  wall including ~17 µs Python IPC per call, negligible at deg ≥ 8.
+- Prototype: `HexBench/ClassicalSpike.lean` (`lean_exe hex_classical_spike`),
+  unproven, reusing the library's `choosePrimeData?` and Hensel primitives with a
+  new smart recombination and an optional balanced product-tree lift.
+
+## Numbers (µs per factorization)
+
+Verified Isabelle reference:
+
+| deg | 4 | 8 | 12 | 16 | 20 | 24 |
+|---|---|---|---|---|---|---|
+| Isabelle | 144 | 419 | 755 | 1552 | 2394 | 3467 |
+
+Classical prototype (Int), sequential vs balanced lift, conservative Mignotte
+precision vs low precision k=4 (k=4 is correct on this corpus — it recovers all
+n factors, since recombination's exact ℤ-division only ever accepts real
+divisors):
+
+| deg | seq Mignotte | balanced Mignotte | seq k=4 | balanced k=4 |
+|---|---|---|---|---|
+| 8  | 3103 | 2548 | 1750 | 1655 |
+| 12 | 10776 | 8210 | 4530 | 3930 |
+| 16 | 30423 | 22161 | 11640 | 9948 |
+| 20 | 58495 | 40300 | 20919 | 17608 |
+| 24 | 98307 | 68025 | 38739 | 31947 |
+
+Best prototype config (balanced + k=4) vs Isabelle: **6.4× at deg16, 9.2× at
+deg24.**
+
+For contrast, the current BHKS public `factor` on the same split family is
+~3.3 s at deg11 and exceeds an 8 s cap by deg15 (it uses a low Mignotte cap, the
+CLD fast path misses, and it falls back to exponential 2^n subset recombination).
+`factorFast` (full BHKS cap) stays polynomial but is ~130 ms at deg24 — ~40× the
+classical prototype and ~37× Isabelle.
+
+## Where the time goes (classical prototype)
+
+- **Smart recombination is essentially free** (~80 µs even at deg16). Size-ordered
+  search with factor removal peels split factors in ~O(r²) trial divisions; it is
+  not the cost. (The library's old recombination materialized the powerset, hence
+  the exponential BHKS fallback.)
+- **The bottleneck moves with precision.** At conservative Mignotte precision the
+  Hensel lift dominates (large p^k integer arithmetic). At the low precision we
+  actually want, the lift shrinks and **`choosePrimeData?` (Berlekamp + per-prime
+  squarefreeness gcd-checks over F_p) becomes ~80%** (≈8 ms of ≈10 ms at deg16).
+- **Balanced product-tree lift** (O(log r) depth vs the library's sequential
+  O(n·r) split) is a modest 1.2–1.4× win at full precision, growing slightly with
+  degree; negligible at low precision.
+- **Low precision is sound and a ~2.6× win.** Lifting to k=4 instead of the full
+  Mignotte bound recovers all factors on this corpus. A general algorithm needs
+  incremental precision with a Mignotte backstop, but the direction holds.
+
+## Substrate notes
+
+- `Int` (GMP) is the correct substrate, consistent with the project's Int-heavy
+  LLL beating Isabelle. A standalone microbench (`HexBench/ArithFloor.lean`)
+  initially suggested `Int` ops were ~10–14× a machine word, but those numbers
+  were inflated by per-iteration harness overhead; in the factorization context
+  the substrate is not the limiter.
+- Single-word machine arithmetic is a **dead end** for this problem: `f`'s own
+  coefficients exceed 2⁶³ by deg ≈ 20 (24! ≈ 6×10²³); the lift modulus p^k exceeds
+  2⁶³ by deg16 (17¹⁶ ≈ 5×10¹⁹); and mod-p^k `mulmod` needs modulus < 2³² (64-bit
+  product overflow), reached by deg ≈ 10. The mod-p layer (`FpPoly`/`ZMod64`) is
+  already machine-word and still ms-scale, so the gap is per-operation overhead
+  and op-count, not the substrate.
+
+## Conclusion and deferred work
+
+The classical-BZ-with-smart-recombination architecture is the right one and lands
+within ~6–9× of the verified Isabelle reference in plain `Int`. Closing the last
+~6–9× means optimizing the core mod-p arithmetic (Berlekamp, F_p gcd, `FpPoly`
+mul/div) and the lift's per-op cost — bounded but touching heavily-proven library
+components, with diminishing returns. That work is **deferred**; this report banks
+the architecture finding and the prototype.
+
+Concrete levers, in priority order, if the work resumes:
+1. `choosePrimeData?` / Berlekamp (dominant at low precision).
+2. Incremental-precision lift with Mignotte backstop (folds in the ~2.6× and the
+   balanced tree).
+3. Per-op `FpPoly`/`DensePoly` arithmetic throughput.
+4. An adversarial worst-case input (Swinnerton-Dyer: irreducible over ℤ, splits
+   into many factors mod every prime) for an honest worst-case head-to-head; the
+   corpus here is split products plus Φ₁₅, the easy case for recombination.
+
+## Artifacts (unproven prototypes; isolated under `HexBench/`)
+
+- `HexBench/ClassicalSpike.lean` — classical BZ prototype + benchmarks.
+- `HexBench/ArithFloor.lean` — polynomial-arithmetic floor microbench.
+- `lean_exe hex_classical_spike`, `lean_exe hex_arith_floor` in `lakefile.lean`.

--- a/reports/hex-berlekamp-zassenhaus-performance.md
+++ b/reports/hex-berlekamp-zassenhaus-performance.md
@@ -1,3 +1,18 @@
+> # ⚠️ CORRECTION / RETRACTION (2026-06)
+>
+> **The Isabelle-comparator numbers below — and every "Lean N× faster/slower than
+> the verified reference" verdict derived from them — are retracted.** The ~820 ms
+> per-call Isabelle figure they rest on was a per-call process-startup artifact, not
+> steady factorization compute.
+>
+> An honest same-hardware re-measure lives in
+> [bz-classical-spike-findings.md](bz-classical-spike-findings.md): the verified
+> Isabelle/AFP reference factors in 419 µs–3.5 ms at deg 8–24; the current BHKS
+> public `factor` is exponential on many-factor inputs (low Mignotte cap → CLD miss
+> → 2ⁿ subset fallback); and a classical-BZ prototype with smart recombination,
+> in plain `Int`, lands within ~6–9× of Isabelle. Treat all ratio ladders below as
+> superseded.
+
 # HexBerlekampZassenhaus Performance Report
 
 ## Bench Targets


### PR DESCRIPTION
This PR records a focused performance investigation of integer-polynomial factorization and adds two unproven measurement prototypes under `HexBench/`. It establishes, with honest same-hardware numbers, that a classical Berlekamp-Zassenhaus path with smart recombination in plain `Int` arithmetic factors within ~6-9x of the verified Isabelle/AFP reference, reframing the earlier (mistaken) impression that the Lean implementation was ~1000x slower.

The verified Isabelle reference factors in 419 us-3.5 ms at degree 8-24; the prior ~820 ms-per-call figure in the legacy performance report was a per-call process-startup artifact and is retracted here with a corrective banner pointing to `reports/bz-classical-spike-findings.md`. The findings report documents the method (persistent-subprocess wrapper, distinct shifted inputs, anti-hoisting harness), the bottleneck analysis (smart recombination is essentially free; cost is `choosePrimeData?`/Berlekamp and the Hensel lift), the modest 1.2-1.4x balanced-product-tree lift win, and why single-word machine arithmetic is a dead end (2^63 coefficient/modulus ceilings).

The prototypes (`lean_exe hex_classical_spike`, `hex_arith_floor`) are unproven, isolated under `HexBench/`, and import only the Mathlib-free executable library; the library `factor` is unchanged. Closing the remaining ~6-9x is deep, proof-sensitive core-arithmetic work and is deferred; the next-step levers are ranked in the findings report.

🤖 Prepared with Claude Code