### PR TITLE
doc: reframe BZ comparator goal as parity; lattice is a correct fallback

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -105,7 +105,7 @@ reverse. We have thrashed too often bending the implementation to ease proofs.
 | `factorClassical` full-domain entry + FLINT invariant op | #8377 | #8386 | ✅ merged |
 | Adversarial corpus + metamorphic relations | #8378 | #8387 | ✅ merged |
 | Merge-blocking conformance + counter + wall-clock gate (+ budget soundness) | #8379 | #8390 | ✅ merged |
-| CLD lattice tier: certify irreducibility (Swinnerton-Dyer / high-`r`) | #8380 | — | ⬜ next (unblocked); root cause diagnosed |
+| CLD lattice tier: certify irreducibility (Swinnerton-Dyer / high-`r`) | #8380 | #8393 | ✅ merged (correctness); speed = #8395 stretch |
 | Cost-based `dispatchTier` | #8381 | — | ⬜ blocked on #8379, #8380 |
 | Optimize the easy regime (arithmetic constants) | #8382 | — | ⬜ blocked on #8379 |
 | Swap public `factor` to the hybrid | #8383 | — | ⬜ blocked on #8380, #8381, #8382 |
@@ -151,11 +151,19 @@ staged in `conformance-fixtures/HexBerlekampZassenhaus/bz-scheduled.jsonl`.
   rather than `degenerate` (keep declining at sub-cap precision); expose the
   lattice-dimension counter; validate via the FLINT oracle + counter gate on the
   SD/cyclotomic corpus (those inputs are irreducible, so `[f]` is correct).
-- **Open question (not a blocker):** *speed*. The localized fix makes the tier
-  **correct**; whether it is fast enough to strictly beat Isabelle's exponential
-  on the SD ladder needs a clean benchmark (the earlier ">90s" was a
-  wrong-precision probe artifact). If too slow, reassess (lattice/LLL optimization
-  vs accept parity-via-classical).
+- **Outcome (merged in #8393, correctness only):** `factorLattice` certifies SD2 /
+  Φ₁₅ etc. as `some #[f]`. **But it is slow** — it grinds the doubling loop to the
+  cap on irreducibles (SD2 14ms → Φ₁₅ 216ms → SD3 1.8s → SD4 deg16 **>120s**). The
+  classical tier already handles everything up to its budget (~`r ≤ 18`, including
+  SD2–SD5) fast, so the lattice is only the **correct fallback** for the extreme-`r`
+  tail (SD6+). On that tail it is slow (correct-but-slow), so the practical goal is
+  **parity** with Isabelle via the classical tier, not beating it on hard inputs.
+- **Speed is deferred to #8395 (stretch).** Making the lattice fast needs a
+  *certificate-backed* early-stop (a believed-sound `L'=W`/no-bad-vector check
+  before the cap), **not** a partition-stability heuristic (which could mis-declare
+  a reducible input irreducible — a wrong factorisation, not a deferred proof).
+  #8395 scopes a feasibility spike on exposing such a certificate from the kept
+  `BadVector`/`Recovery`/`TerminationBound` proofs; if infeasible, we bank parity.
 - The kept BHKS proofs (Recovery/Lattice/CLDColumnBound/BadVector/…) and the
   cap-suffices proof (BHKS Thm 5.2 / D1, deferred per principle 9) live here.
 
@@ -258,8 +266,14 @@ Never bend the implementation to a future proof. Never introduce an `axiom`.
 
 ## End state
 
-Public `factor` is the cost-based hybrid: it ties the verified Isabelle reference
-on easy inputs (after #8382), strictly beats it on hard (Swinnerton-Dyer) inputs
-via the verified LLL, the counter gate blocks performance regressions, and the
-headline correctness theorem is restored (after #8384). The BHKS work is
-preserved as the large-`r` tier, not deleted.
+Public `factor` is the cost-based hybrid: it reaches **parity** with the verified
+Isabelle reference on every input the classical tier covers (after #8382) — which
+is everything up to the classical subset budget, including the Swinnerton-Dyer
+ladder up to SD5; the verified-LLL lattice tier is a **correct fallback** for the
+extreme-`r` tail (SD6+) where exhaustive search would explode; the counter gate
+blocks performance regressions; and the headline correctness theorem is restored
+(after #8384). The BHKS work is preserved as the large-`r` tier, not deleted.
+
+*Stretch (#8395):* a certificate-backed early-stop would make the lattice tier
+fast enough to *strictly beat* the reference on the extreme-`r` tail too, not just
+match it. Not on the critical path.

--- a/SPEC/Libraries/hex-berlekamp-zassenhaus.md
+++ b/SPEC/Libraries/hex-berlekamp-zassenhaus.md
@@ -17,10 +17,12 @@ factors:
   number of lifted factors `r` is small; worst-case `O(2^r)`.
 - **`factorLattice`** (returns `Option`) — van Hoeij CLD lattice
   recombination via `hex-lll`. *Polynomial in `r`*; used when `r` is
-  large enough that classical recombination would explode (e.g.
-  Swinnerton-Dyer inputs, on which the classical reference *also*
-  explodes — this is where the lattice tier strictly beats the
-  reference).
+  large enough that classical recombination would exceed its subset
+  budget (e.g. Swinnerton-Dyer inputs, on which the classical reference
+  *also* explodes). The lattice tier is a **correct fallback** there;
+  whether it is *fast enough to strictly beat* the reference on that
+  extreme-`r` tail is a separate optimisation (it currently grinds to
+  the precision cap — see the early-termination follow-up).
 - **`factorTrial`** (total) — exhaustive integer trial division. No
   modular reduction; the unconditional totality backstop, reached only
   when no admissible prime exists.
@@ -473,9 +475,14 @@ No BHKS termination theorem is needed: the loop is finite by subset enumeration,
 lifted-factor count `r` is large enough that `factorClassical`'s
 size-ordered subset search would exceed its budget. It is **polynomial
 in `r`** (the classical reference, and `factorClassical`, are `O(2^r)`
-there), so it is where `factor` strictly beats the verified reference —
-e.g. Swinnerton-Dyer inputs, which split into many small factors mod
-every prime. It is built on the verified `hex-lll` short-vector
+there), so it is the asymptotically-correct path on the extreme-`r` tail
+— e.g. Swinnerton-Dyer inputs, which split into many small factors mod
+every prime. It certifies irreducibility (unlike a CLD recovery that
+declines on the single-class case), so it returns `some` where exhaustive
+search would explode. Beating the reference *in wall-clock* on that tail
+additionally requires terminating before the precision cap (a separate
+optimisation; today it grinds to the cap and is correct-but-slow). It is
+built on the verified `hex-lll` short-vector
 machinery.
 
 Recombination uses van Hoeij's algorithm with the **Combined Logarithmic Derivative (CLD)** invariant (BHKS Definition 3.1.1; HHN Definition 2). The all-coefficients-lattice variant of BHKS §5.2 is pinned: every coefficient index of the CLD is a column of the lattice. HHN's incremental-column / U-LLL / Progress-potential refinements are deliberately not used — they are a constant-factor performance optimisation, not required for correctness, and add proof complexity disproportionate to their gain.
@@ -806,8 +813,8 @@ Phase 4 declares one external comparator:
   **The reference is classical exhaustive recombination, not a lattice method**: `factor_int_poly` reconstructs via `zassenhaus_reconstruction` over `subseqs` of the lifted factors (`Reconstruction.thy`), with fast constants (GHC + Karatsuba). It is exponential in the modular-factor count `r` — the same class as `factorClassical`.
 
   **Gating goal, by regime:**
-  - small/medium `r` (reference is fast): **`hex/isabelle ≤ a small constant`** — a constant-factor race won by competitive arithmetic. Measured on the scheduled ratio workflow.
-  - large `r` (Swinnerton-Dyer class, reference's exhaustive search explodes): **hex strictly faster.** CI cannot wait out the reference's blow-up, so the merge gate only checks hex finishes the large-`r` corpus under cap *using `factorLattice`*; the "strictly beats the reference" claim is recorded offline against a checked-in baseline.
+  - small/medium `r` (reference is fast; the classical tier handles it, including the Swinnerton-Dyer ladder up to where its subset budget is exceeded): **`hex/isabelle ≤ a small constant`** — a constant-factor race won by competitive arithmetic. This is the achievable target: **parity** with the reference on every input the classical tier covers. Measured on the scheduled ratio workflow.
+  - extreme `r` (beyond the classical budget, reference's exhaustive search explodes): hex is **correct** via `factorLattice` (which exhaustive search cannot be — it would explode). *Strictly beating* the reference in wall-clock here additionally requires `factorLattice` terminating before the precision cap; until that optimisation lands it is correct-but-slow, so the merge gate only checks hex finishes under cap *using `factorLattice`* (not `factorTrial`), and the "strictly beats" claim is a goal, not a current guarantee.
 
 The fpLLL/python-flint comparators that adjacent libraries declare are *informational only* at the BZ level.
 


### PR DESCRIPTION
Following #8380/#8393 (the CLD lattice tier is now correct but slow — it grinds the doubling loop to the precision cap on irreducibles), reframe the comparator goal to the achievable target. The classical tier already matches Isabelle on everything up to its subset budget (including the Swinnerton-Dyer ladder up to SD5), so the lattice tier is the **correct fallback** for the extreme-`r` tail (SD6+), where it is correct-but-slow. The SPEC's "strictly beat on large r" is softened to **parity** via the classical tier; strictly beating on the extreme tail additionally requires the lattice terminating before the cap (a certificate-backed early-stop, tracked as stretch issue #8395). Updates the SPEC comparator/large-`r` sections and the DEV.md status table, #8380 section, and end-state. Documentation only.

🤖 Prepared with Claude Code