### PR TITLE
feat(release): publish-out sync for the released split repos

### DIFF
--- a/.github/workflows/sync-released.yml
+++ b/.github/workflows/sync-released.yml
@@ -1,0 +1,44 @@
+name: Sync released repos
+
+# Publish-out sync: regenerate the released split repos from this monorepo
+# (scripts/release/released.yml + scripts/release/sync_released.py).
+#
+# Manual-only for now, defaulting to a dry run. A real sync OVERWRITES the
+# managed paths in each released repo and rewrites their cross-repo Lake pins,
+# so it must only be run once the monorepo content is known to be at or ahead of
+# every released repo's `main` (otherwise it would delete released-only work).
+# Flip `dry_run` to false — and, once trusted, add an `on: push` trigger — after
+# that invariant holds and the `RELEASED_SYNC_PAT` secret is configured.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (print planned changes; do not push)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: sync-released
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python3 -m pip install --user pyyaml
+      - name: Sync released repos
+        env:
+          RELEASED_SYNC_PAT: ${{ secrets.RELEASED_SYNC_PAT }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "false" ]; then
+            python3 scripts/release/sync_released.py
+          else
+            python3 scripts/release/sync_released.py --dry-run
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,13 @@ near-mechanical copy):
   drivers (shared `conformance/` sub-project).
 - `conformance-fixtures/HexX/*.jsonl`, `scripts/oracle/<lib>_*.py`.
 
+The publish mechanism is `scripts/release/released.yml` (the per-repo
+managed-path + pin manifest), `scripts/release/sync_released.py` (the
+driver; supports `--dry-run`), and `.github/workflows/sync-released.yml`
+(manual dispatch). A real sync overwrites each released repo's managed
+paths and rewrites its Lake pins, so it must only run once this monorepo
+is at or ahead of every released repo's `main`. Run `--dry-run` first.
+
 # hex — agent-specific conventions
 
 Conventions specifically for LLM agents working on this project.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -1,0 +1,103 @@
+# Publish-out sync manifest.
+#
+# `hex-dev` is the source of truth. The sync (scripts/release/sync_released.py,
+# driven by .github/workflows/sync-released.yml) regenerates each released repo
+# from this monorepo: it overwrites the repo's *managed* paths from here, leaves
+# everything else (root + sidecar lakefiles, CI, toolchains, LICENSE, README,
+# manifests) untouched, rewrites the root lakefile's cross-repo Hex pins to the
+# commits just synced, and commits to the released repo's `main`.
+#
+# Order is topological (upstream first) so each repo's freshly-pushed SHA is
+# known before its downstream consumers are processed.
+#
+# Per-repo managed path conventions (resolved by the driver):
+#   <Lib>/            (minus <Lib>/SPEC/)   -> <Lib>/
+#   <Lib>.lean        (if umbrella: true)   -> <Lib>.lean
+#   <Lib>/SPEC/<spec>.md                    -> SPEC/<spec>.md
+#   bench/<Lib>/       (if bench: true)      -> bench/<Lib>/
+#   conformance/<Lib>/ (if conformance)      -> conformance/<Lib>/
+#   conformance-fixtures/<f>/                -> conformance-fixtures/<f>/
+#   scripts/oracle/<o>                       -> scripts/oracle/<o>
+# `pins` lists the upstream repos whose git rev is rewritten in this repo's root
+# lakefile (matched by their github URL); `lakefile` is that file's format.
+
+repos:
+  - repo: kim-em/hex-test-kit
+    lib: Hex
+    umbrella: false        # released HexTestKit.lean umbrella is fixed
+    paths:                 # explicit: only the shared helper source
+      - { src: "Hex", dest: "Hex" }
+    spec: null
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: []
+    lakefile: toml
+
+  - repo: kim-em/hex-matrix
+    lib: HexMatrix
+    umbrella: true
+    spec: hex-matrix
+    bench: true
+    conformance: true
+    fixtures: [HexMatrix]
+    oracles: [matrix_flint.py, common.py, flint_bench_driver.py]
+    pins: []
+    lakefile: toml
+
+  - repo: kim-em/hex-matrix-mathlib
+    lib: HexMatrixMathlib
+    umbrella: true
+    spec: hex-matrix-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-gram-schmidt
+    lib: HexGramSchmidt
+    umbrella: true
+    spec: hex-gram-schmidt
+    bench: true
+    conformance: true
+    fixtures: [HexGramSchmidt]
+    oracles: [gs_flint.py, common.py]
+    pins: [hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-gram-schmidt-mathlib
+    lib: HexGramSchmidtMathlib
+    umbrella: true
+    spec: hex-gram-schmidt-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-gram-schmidt, hex-matrix-mathlib, hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-lll
+    lib: HexLLL
+    umbrella: true
+    spec: hex-lll
+    bench: true
+    bench_dir: HexLLLBench   # multi-file bench lives under bench/HexLLLBench/
+    conformance: true
+    fixtures: [HexLLL]
+    oracles: [lll_fpylll.py, lll_fpylll_bench_driver.py, common.py, __init__.py, setup_fplll_ffi.sh, setup_lll_isabelle.sh, patches]
+    pins: [hex-matrix, hex-gram-schmidt]
+    lakefile: lean
+
+  - repo: kim-em/hex-lll-mathlib
+    lib: HexLLLMathlib
+    umbrella: true
+    spec: hex-lll-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-lll, hex-gram-schmidt-mathlib, hex-matrix-mathlib, hex-gram-schmidt, hex-matrix]
+    lakefile: toml

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Publish the released split repos from this monorepo.
+
+For each repo in scripts/release/released.yml (topological order), this:
+  1. clones the repo's `main`,
+  2. overwrites its *managed* paths from this monorepo (leaving lakefiles, CI,
+     toolchains, LICENSE, README, manifests untouched),
+  3. rewrites the root lakefile's cross-repo Hex pins to the commits synced
+     this run,
+  4. commits `chore: sync from hex-dev@<sha>` and pushes to `main`
+     (unless --dry-run, which prints the planned changes and pin rewrites).
+
+Auth (non-dry-run): a token from --token or $RELEASED_SYNC_PAT is used as an
+`x-access-token` basic-auth credential for clone and push. Dry-run clones over
+public https and never pushes.
+
+Usage:
+  python3 scripts/release/sync_released.py --dry-run
+  RELEASED_SYNC_PAT=... python3 scripts/release/sync_released.py
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "scripts" / "release" / "released.yml"
+
+
+def run(cmd: list[str], cwd: Path | None = None, capture: bool = False) -> str:
+    result = subprocess.run(
+        cmd, cwd=cwd, check=True, text=True,
+        stdout=subprocess.PIPE if capture else None,
+    )
+    return (result.stdout or "").strip()
+
+
+def clone_url(repo: str, token: str | None) -> str:
+    if token:
+        return f"https://x-access-token:{token}@github.com/{repo}.git"
+    return f"https://github.com/{repo}.git"
+
+
+def rsync_dir(src: Path, dest: Path, excludes: list[str] | None = None) -> None:
+    """Mirror src/ onto dest/ (creating dest), deleting stale files under dest."""
+    dest.mkdir(parents=True, exist_ok=True)
+    cmd = ["rsync", "-a", "--delete"]
+    for e in excludes or []:
+        cmd += ["--exclude", e]
+    cmd += [f"{src}/", f"{dest}/"]
+    run(cmd)
+
+
+def copy_file(src: Path, dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+
+
+def managed_paths(entry: dict) -> list[tuple[Path, Path, bool]]:
+    """Yield (src, dest_rel, is_dir) managed mappings for one repo entry.
+
+    Sources are absolute monorepo paths; dest_rel is relative to the repo root.
+    """
+    lib = entry["lib"]
+    out: list[tuple[Path, Path, bool]] = []
+    # explicit path list (e.g. hex-test-kit ships only `Hex/`)
+    for p in entry.get("paths") or []:
+        src = REPO_ROOT / p["src"]
+        out.append((src, Path(p["dest"]), src.is_dir()))
+    # conventional library source dir (minus its co-located SPEC/)
+    if not entry.get("paths"):
+        out.append((REPO_ROOT / lib, Path(lib), True))
+    if entry.get("umbrella"):
+        out.append((REPO_ROOT / f"{lib}.lean", Path(f"{lib}.lean"), False))
+    if entry.get("spec"):
+        slug = entry["spec"]
+        out.append((REPO_ROOT / lib / "SPEC" / f"{slug}.md", Path("SPEC") / f"{slug}.md", False))
+    if entry.get("bench"):
+        bdir = entry.get("bench_dir", lib)
+        out.append((REPO_ROOT / "bench" / bdir, Path("bench") / bdir, True))
+        umb = REPO_ROOT / "bench" / f"{bdir}.lean"
+        if umb.exists():
+            out.append((umb, Path("bench") / f"{bdir}.lean", False))
+    if entry.get("conformance"):
+        out.append((REPO_ROOT / "conformance" / lib, Path("conformance") / lib, True))
+    for f in entry.get("fixtures") or []:
+        out.append((REPO_ROOT / "conformance-fixtures" / f, Path("conformance-fixtures") / f, True))
+    for o in entry.get("oracles") or []:
+        src = REPO_ROOT / "scripts" / "oracle" / o
+        out.append((src, Path("scripts") / "oracle" / o, src.is_dir()))
+    return out
+
+
+def apply_paths(entry: dict, clone: Path) -> list[str]:
+    notes: list[str] = []
+    lib = entry["lib"]
+    for src, dest_rel, is_dir in managed_paths(entry):
+        dest = clone / dest_rel
+        if not src.exists():
+            notes.append(f"  WARN missing source {src.relative_to(REPO_ROOT)} -> {dest_rel} (skipped)")
+            continue
+        if is_dir:
+            # the library source dir excludes its co-located SPEC/ subtree
+            excludes = ["SPEC/"] if dest_rel == Path(lib) else None
+            rsync_dir(src, dest, excludes)
+        else:
+            copy_file(src, dest)
+        notes.append(f"  {src.relative_to(REPO_ROOT)} -> {dest_rel}")
+    return notes
+
+
+def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str]) -> list[str]:
+    """Rewrite the root lakefile's cross-repo Hex pins to synced SHAs."""
+    notes: list[str] = []
+    pins = entry.get("pins") or []
+    if not pins:
+        return notes
+    fmt = entry["lakefile"]
+    lf = clone / ("lakefile.toml" if fmt == "toml" else "lakefile.lean")
+    text = lf.read_text(encoding="utf-8")
+    for dep in pins:
+        sha = synced.get(dep)
+        if sha is None:
+            notes.append(f"  WARN no synced SHA for pin {dep} (left unchanged)")
+            continue
+        url = re.escape(f"github.com/kim-em/{dep}.git")
+        if fmt == "toml":
+            # `git = ".../<dep>.git"` then the next `rev = "..."`
+            pat = re.compile(r'(git\s*=\s*"https://' + url + r'"\s*\n\s*rev\s*=\s*")[0-9a-f]{7,40}(")')
+        else:
+            # `".../<dep>.git" @ "<sha>"`
+            pat = re.compile(r'("https://' + url + r'"\s*@\s*")[0-9a-f]{7,40}(")')
+        text, n = pat.subn(lambda m: m.group(1) + sha + m.group(2), text)
+        if n:
+            notes.append(f"  pin {dep} -> {sha[:12]} ({n} site)")
+        else:
+            notes.append(f"  WARN pin {dep} not found in {lf.name}")
+    lf.write_text(text, encoding="utf-8")
+    return notes
+
+
+def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
+              synced: dict[str, str]) -> None:
+    repo = entry["repo"]
+    short = repo.split("/")[-1]
+    print(f"\n=== {repo} ===")
+    with tempfile.TemporaryDirectory() as td:
+        clone = Path(td) / short
+        run(["git", "clone", "--depth", "1", clone_url(repo, token), str(clone)], capture=True)
+        for line in apply_paths(entry, clone):
+            print(line)
+        for line in rewrite_pins(entry, clone, synced):
+            print(line)
+        status = run(["git", "status", "--porcelain"], cwd=clone, capture=True)
+        if not status:
+            print("  (no changes)")
+            synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+            return
+        print("  changed files:")
+        for l in status.splitlines():
+            print(f"    {l}")
+        if dry_run:
+            # stand-in SHA so downstream pin rewrites can be previewed
+            synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+            print("  DRY-RUN: not committing or pushing")
+            return
+        run(["git", "add", "-A"], cwd=clone)
+        run(["git", "-c", "user.name=hex-dev sync",
+             "-c", "user.email=noreply@anthropic.com",
+             "commit", "-q", "-m", f"chore: sync from hex-dev@{source_sha[:12]}"], cwd=clone)
+        run(["git", "push", "origin", "HEAD:main"], cwd=clone)
+        synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+        print(f"  pushed {synced[short][:12]} to {repo}@main")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Publish released split repos from the monorepo.")
+    ap.add_argument("--dry-run", action="store_true", help="print planned changes; do not push")
+    ap.add_argument("--token", default=os.environ.get("RELEASED_SYNC_PAT"),
+                    help="GitHub token with contents:write on the released repos")
+    ap.add_argument("--only", help="sync only this repo short-name (e.g. hex-matrix)")
+    args = ap.parse_args()
+
+    if not args.dry_run and not args.token:
+        ap.error("a token (--token or $RELEASED_SYNC_PAT) is required unless --dry-run")
+
+    manifest = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    source_sha = run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, capture=True)
+    synced: dict[str, str] = {}
+    for entry in manifest["repos"]:
+        if args.only and entry["repo"].split("/")[-1] != args.only:
+            continue
+        sync_repo(entry, source_sha, args.token, args.dry_run, synced)
+    print(f"\nsynced {len(synced)} repo(s) from hex-dev@{source_sha[:12]}"
+          + (" (dry-run)" if args.dry_run else ""))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR adds the publish-out sync that regenerates the seven released split repos (hex-test-kit plus the six libraries) from this monorepo, completing the inversion of the split: develop here, publish outward. It introduces `scripts/release/released.yml` (a per-repo manifest of managed paths, oracle sets, and cross-repo pin dependencies in topological order), `scripts/release/sync_released.py` (which clones each released repo, overwrites only its managed paths from this tree, rewrites the root lakefile's Hex pins to the freshly-synced commits, and commits to `main`, with a `--dry-run` that prints the planned changes and pin rewrites), and a manual-dispatch workflow `sync-released.yml` that defaults to a dry run.

The dry run against the live released repos validates the path mappings and the pin rewriting in both the TOML `rev =` and Lean `@ "sha"` lakefile forms. It also surfaced that several released repos' `main` branches have advanced past the revs internalized so far, so a real sync would delete that newer released-only work. The monorepo therefore needs to be brought up to each released repo's `main` before the first live sync; until then the workflow stays manual and dry-by-default, and a real run additionally needs a fine-grained `RELEASED_SYNC_PAT` secret with `contents: write` on the seven repos.

🤖 Prepared with Claude Code