### PR TITLE
feat(release): uncoordinated-commit guard for the publish sync

### DIFF
--- a/.github/workflows/sync-released.yml
+++ b/.github/workflows/sync-released.yml
@@ -22,6 +22,9 @@ concurrency:
   group: sync-released
   cancel-in-progress: false
 
+permissions:
+  contents: write   # to commit the advanced scripts/release/synced.json baseline
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -41,4 +44,14 @@ jobs:
             python3 scripts/release/sync_released.py
           else
             python3 scripts/release/sync_released.py --dry-run
+          fi
+      - name: Commit advanced baseline
+        if: ${{ inputs.dry_run == false }}
+        run: |
+          if ! git diff --quiet -- scripts/release/synced.json; then
+            git config user.name "hex-dev sync"
+            git config user.email "noreply@anthropic.com"
+            git add scripts/release/synced.json
+            git commit -m "chore(release): advance sync baseline"
+            git push origin HEAD:main
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,22 @@ near-mechanical copy):
 
 The publish mechanism is `scripts/release/released.yml` (the per-repo
 managed-path + pin manifest), `scripts/release/sync_released.py` (the
-driver; supports `--dry-run`), and `.github/workflows/sync-released.yml`
-(manual dispatch). A real sync overwrites each released repo's managed
-paths and rewrites its Lake pins, so it must only run once this monorepo
-is at or ahead of every released repo's `main`. Run `--dry-run` first.
+driver; supports `--dry-run`), `scripts/release/synced.json` (the
+per-repo `main` baseline this monorepo corresponds to), and
+`.github/workflows/sync-released.yml` (manual dispatch, dry by default).
+A real sync overwrites each released repo's managed paths and rewrites
+its Lake pins, so it must only run once this monorepo is at or ahead of
+every released repo's `main`. Run `--dry-run` first.
+
+**Uncoordinated-commit guard.** The sync refuses to overwrite a released
+repo whose `main` HEAD has moved off its `synced.json` baseline, so an
+out-of-band commit on a released repo is never silently clobbered; it
+skips that repo and reports the divergence (override with `--force` only
+after reconciling). Reconciling means **re-seeding**: bring the affected
+library's content here up to the released `main`, rebuild the whole graph
+green (a released repo can advance with breaking API changes its
+downstream consumers have not adopted — the monorepo build surfaces
+that), then update the baseline.
 
 # hex — agent-specific conventions
 

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -21,6 +21,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import re
 import shutil
@@ -33,6 +34,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MANIFEST = REPO_ROOT / "scripts" / "release" / "released.yml"
+BASELINE = REPO_ROOT / "scripts" / "release" / "synced.json"
 
 
 def run(cmd: list[str], cwd: Path | None = None, capture: bool = False) -> str:
@@ -148,13 +150,26 @@ def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str]) -> list[str]:
 
 
 def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
-              synced: dict[str, str]) -> None:
+              synced: dict[str, str], baseline: dict[str, str], force: bool) -> bool:
+    """Sync one repo. Returns True if the baseline SHA changed (a push happened)."""
     repo = entry["repo"]
     short = repo.split("/")[-1]
     print(f"\n=== {repo} ===")
     with tempfile.TemporaryDirectory() as td:
         clone = Path(td) / short
         run(["git", "clone", "--depth", "1", clone_url(repo, token), str(clone)], capture=True)
+        head = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+        # Compare-and-swap guard: refuse to overwrite a repo whose main has moved
+        # off the baseline this monorepo was synced from (an uncoordinated commit).
+        expected = baseline.get(short)
+        if expected and head != expected:
+            msg = (f"  UNCOORDINATED: {repo} main is {head[:12]}, baseline expects "
+                   f"{expected[:12]}. Reconcile (re-seed from main) before syncing.")
+            if not force:
+                print(msg + " Skipping (use --force to override).")
+                synced[short] = expected
+                return False
+            print(msg + " Overriding (--force).")
         for line in apply_paths(entry, clone):
             print(line)
         for line in rewrite_pins(entry, clone, synced):
@@ -162,16 +177,15 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         status = run(["git", "status", "--porcelain"], cwd=clone, capture=True)
         if not status:
             print("  (no changes)")
-            synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
-            return
+            synced[short] = head
+            return False
         print("  changed files:")
         for l in status.splitlines():
             print(f"    {l}")
         if dry_run:
-            # stand-in SHA so downstream pin rewrites can be previewed
-            synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
+            synced[short] = head  # stand-in so downstream pin previews resolve
             print("  DRY-RUN: not committing or pushing")
-            return
+            return False
         run(["git", "add", "-A"], cwd=clone)
         run(["git", "-c", "user.name=hex-dev sync",
              "-c", "user.email=noreply@anthropic.com",
@@ -179,6 +193,7 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         run(["git", "push", "origin", "HEAD:main"], cwd=clone)
         synced[short] = run(["git", "rev-parse", "HEAD"], cwd=clone, capture=True)
         print(f"  pushed {synced[short][:12]} to {repo}@main")
+        return True
 
 
 def main() -> int:
@@ -187,18 +202,29 @@ def main() -> int:
     ap.add_argument("--token", default=os.environ.get("RELEASED_SYNC_PAT"),
                     help="GitHub token with contents:write on the released repos")
     ap.add_argument("--only", help="sync only this repo short-name (e.g. hex-matrix)")
+    ap.add_argument("--force", action="store_true",
+                    help="override the uncoordinated-commit guard and overwrite anyway")
     args = ap.parse_args()
 
     if not args.dry_run and not args.token:
         ap.error("a token (--token or $RELEASED_SYNC_PAT) is required unless --dry-run")
 
     manifest = yaml.safe_load(MANIFEST.read_text(encoding="utf-8"))
+    baseline_doc = json.loads(BASELINE.read_text(encoding="utf-8")) if BASELINE.exists() else {}
+    baseline = {k: v for k, v in baseline_doc.items() if not k.startswith("_")}
     source_sha = run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, capture=True)
     synced: dict[str, str] = {}
+    pushed_any = False
     for entry in manifest["repos"]:
         if args.only and entry["repo"].split("/")[-1] != args.only:
             continue
-        sync_repo(entry, source_sha, args.token, args.dry_run, synced)
+        pushed_any |= sync_repo(entry, source_sha, args.token, args.dry_run,
+                                synced, baseline, args.force)
+    # Persist the advanced baseline so the next run's guard is accurate.
+    if pushed_any and not args.dry_run:
+        baseline_doc.update({k: v for k, v in synced.items()})
+        BASELINE.write_text(json.dumps(baseline_doc, indent=2) + "\n", encoding="utf-8")
+        print(f"\nupdated {BASELINE.relative_to(REPO_ROOT)} (commit it back to hex-dev)")
     print(f"\nsynced {len(synced)} repo(s) from hex-dev@{source_sha[:12]}"
           + (" (dry-run)" if args.dry_run else ""))
     return 0

--- a/scripts/release/synced.json
+++ b/scripts/release/synced.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Per-repo `main` HEAD that this monorepo's content corresponds to. The publish sync (sync_released.py) refuses to overwrite a released repo whose main has moved off this baseline (an uncoordinated commit), and updates the baseline after each push. Edit only via a re-seed or the sync itself.",
+  "hex-test-kit": "597e6a3b68807ef0fdf23ba3f6ae31549124ce23",
+  "hex-matrix": "85c2bb9b2f93677fe1435d898c81a56b9e7b33e8",
+  "hex-matrix-mathlib": "9cc6d8689d12c2775f8e1016b946a3debe6a8c9f",
+  "hex-gram-schmidt": "3ce6d453934ca1bb5eb84ebd5e09b43e3d8ae4ce",
+  "hex-gram-schmidt-mathlib": "9e04dc003acbb73973b0aa728a437174534f0066",
+  "hex-lll": "79eb689115559c45edf7eb35ae809379243290a5",
+  "hex-lll-mathlib": "11b204b2c21c84ae93eb0b714bb81b085b6129ee"
+}


### PR DESCRIPTION
This PR adds a safety guard so the publish-out sync never silently clobbers an out-of-band commit on a released repo. It introduces `scripts/release/synced.json` — the per-repo `main` baseline this monorepo corresponds to — and makes `sync_released.py` refuse to overwrite a released repo whose `main` HEAD has moved off that baseline, skipping it with a clear report unless `--force`. After a real push the driver advances the baseline and the workflow commits it back to `hex-dev`.

The baseline starts at the revs the monorepo actually matches. For `hex-matrix` that is the coordinated `85c2bb9b`: its released `main` (`aa6f75c`) has advanced with breaking API changes (`Hex.Matrix.dot` moved to `Hex.Vector.dot`, plus a determinant restructuring) that `hex-gram-schmidt` and `hex-lll` have not adopted, so building the monorepo against the new `hex-matrix` fails. A dry run now correctly flags `hex-matrix` as uncoordinated and skips it rather than reverting that newer work. Reconciling it means re-seeding the monorepo up to the new `hex-matrix` and porting the downstream API across `hex-gram-schmidt`/`hex-lll` (and their mathlib proofs), which is a separate task tracked for follow-up.

🤖 Prepared with Claude Code