### PR TITLE
feat(bz): swap public factor to the cost-based hybrid (re-point both layers)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9585,6 +9585,117 @@ def factorHybrid (f : ZPoly) : Factorization :=
 #guard (factorHybridTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.tier = "classical"
 #guard (factorHybridTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.declined = false
 
+/-- The classical traced tier's `Factorization` agrees with the raw classical
+factor array packed through `factorizationOfFactors f`. The traced variant only
+adds the diagnostic `FactorTrace` in the `.2` component; its `.1` is the same
+self-certifying-free classical answer as `factorClassicalFactorsWithBound`. -/
+theorem factorClassicalTracedWithBound_fst (f : ZPoly) (B : Nat) :
+    (factorClassicalTracedWithBound f B).1 =
+      (factorClassicalFactorsWithBound f B).map (factorizationOfFactors f) := by
+  unfold factorClassicalTracedWithBound factorClassicalFactorsWithBound
+    classicalCoreFactorsWithBound
+  by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
+  · simp only [hdeg, if_true, Option.map_some]
+  · simp only [hdeg, if_false]
+    cases quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
+    | some cf => simp only [Option.map_some]
+    | none =>
+        cases ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore with
+        | none => simp only [Option.map_none, Option.bind_none]
+        | some primeData =>
+            simp only [Option.bind_some]
+            by_cases hB : B = 0
+            · simp only [hB, if_true, Option.map_some]
+            · simp only [hB, if_false]
+              generalize
+                scaledRecombinationSmart
+                  (DensePoly.leadingCoeff (normalizeForFactor f).squareFreeCore)
+                  (normalizeForFactor f).squareFreeCore
+                  (liftModulus
+                    (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
+                      (ZPoly.exhaustiveLiftBound (normalizeForFactor f).squareFreeCore B)
+                      primeData))
+                  (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
+                      (ZPoly.exhaustiveLiftBound (normalizeForFactor f).squareFreeCore B)
+                      primeData).liftedFactors.toList = rs
+              obtain ⟨res, stats⟩ := rs
+              by_cases hbudget : stats.budgetExhausted = true
+              · rw [if_pos hbudget, if_pos hbudget]; rfl
+              · rw [if_neg hbudget, if_neg hbudget]
+                cases res with
+                | some factors => simp only [Option.map_some]
+                | none => simp only [Option.map_some]
+
+/-- The CLD lattice tier's `Factorization` is the raw lattice factor array packed
+through `factorizationOfFactors f`. -/
+theorem factorLattice_eq_map (f : ZPoly) :
+    factorLattice f =
+      (factorLatticeFactorsWithBound f (factorFastPrecisionCap f)).map
+        (factorizationOfFactors f) := rfl
+
+/-- Raw factor array assembled by the cost-based hybrid, the bridge counterpart
+of `factorHybridFactors`-consuming structural lemmas.
+
+Each non-backstop tier (`factorClassicalFactorsWithBound` / lattice) is accepted
+only when its `factorizationOfFactors`-packed answer reconstructs `f` (the
+self-certifying guard mirrored here), and every fallback is the proven
+`factorSlowTrial` backstop's raw array. The headline contract
+`factorHybrid f = factorizationOfFactors f (factorHybridFactors f)` is
+`factorHybrid_eq_factorizationOfFactors`. -/
+def factorHybridFactors (f : ZPoly) : Array ZPoly :=
+  match factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) with
+  | some cf =>
+      if Factorization.product (factorizationOfFactors f cf) = f then cf
+      else factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+  | none =>
+      match factorLatticeFactorsWithBound f (factorFastPrecisionCap f) with
+      | some cf =>
+          if Factorization.product (factorizationOfFactors f cf) = f then cf
+          else factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+      | none => factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+
+/-- The cost-based hybrid factorisation is the `factorizationOfFactors`-packed
+form of its raw factor array `factorHybridFactors`. Every tier (classical /
+lattice / trial) assembles via `factorizationOfFactors f`, so this bridge lets
+the structural `factorizationOfFactors_entry_*` lemmas re-point every
+`factor`-level entry contract onto the hybrid. -/
+theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
+    factorHybrid f = factorizationOfFactors f (factorHybridFactors f) := by
+  have htrial : factorSlowTrial f =
+      factorizationOfFactors f
+        (factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) := by
+    rw [factorSlowTrial, factorSlowTrialWithBound_eq_factorizationOfFactors]
+  unfold factorHybrid factorHybridTraced factorHybridFactors
+  have hclassical :
+      (factorClassicalTraced f).1 =
+        (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).map
+          (factorizationOfFactors f) := by
+    rw [factorClassicalTraced, factorClassicalTracedWithBound_fst]
+  rcases hcl : factorClassicalTraced f with ⟨cres, trace⟩
+  rw [hcl] at hclassical
+  cases hcf : factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) with
+  | some cf =>
+      rw [hcf] at hclassical
+      simp only [Option.map_some] at hclassical
+      subst hclassical
+      by_cases hp : Factorization.product (factorizationOfFactors f cf) = f
+      · simp only [hp, if_true]
+      · simp only [hp, if_false]; exact htrial
+  | none =>
+      rw [hcf] at hclassical
+      simp only [Option.map_none] at hclassical
+      subst hclassical
+      simp only
+      rw [factorLattice_eq_map]
+      cases hl : factorLatticeFactorsWithBound f (factorFastPrecisionCap f) with
+      | some cf =>
+          simp only [Option.map_some]
+          by_cases hp : Factorization.product (factorizationOfFactors f cf) = f
+          · simp only [hp, if_true]
+          · simp only [hp, if_false]; exact htrial
+      | none =>
+          simp only [Option.map_none]; exact htrial
+
 /-- Smoke-test driver for the core-coordinate fast recovery: select the good
 prime exactly as the fast path does, then run `coreRecover?` against the
 `coreLiftData` (`monicTarget`) lift at the public precision cap.  Used by the
@@ -9808,10 +9919,15 @@ path, and on no admissible prime continues to integer trial division so that
 the removed silent prime-data fallback is never consulted.
 -/
 def factor (f : ZPoly) : Factorization :=
-  factorWithBound f (ZPoly.defaultFactorCoeffBound f)
+  factorHybrid f
 
-@[simp, grind =] theorem factor_eq_factorWithBound_default (f : ZPoly) :
-    factor f = factorWithBound f (ZPoly.defaultFactorCoeffBound f) := rfl
+/-- The public factorisation is the `factorizationOfFactors`-packed form of the
+hybrid's raw factor array. This bridge re-points every `factor`-level entry
+contract onto the hybrid via the structural `factorizationOfFactors_entry_*`
+lemmas. -/
+theorem factor_eq_factorizationOfFactors (f : ZPoly) :
+    factor f = factorizationOfFactors f (factorHybridFactors f) :=
+  factorHybrid_eq_factorizationOfFactors f
 
 /--
 Option-returning bounded factoring entry point that propagates explicit failure
@@ -9838,14 +9954,17 @@ def factorWithBound? (f : ZPoly) (B : Nat) : Option Factorization :=
     none
 
 /--
-Option-returning factoring entry point at the default Mignotte bound; mirrors
-`factor` but propagates explicit failure on no-admissible-prime per #5816.
+Option-returning factoring entry point at the default Mignotte bound. The public
+path is now the total cost-based hybrid (`factor = factorHybrid`, whose trial
+backstop never declines), so there is no no-admissible-prime failure surface to
+propagate: this always succeeds with the hybrid factorisation. (The proof-facing
+`factorWithBound?` retains the cap-based three-tier `none` surface.)
 -/
 def factor? (f : ZPoly) : Option Factorization :=
-  factorWithBound? f (ZPoly.defaultFactorCoeffBound f)
+  some (factor f)
 
-@[simp, grind =] theorem factor?_eq_factorWithBound?_default (f : ZPoly) :
-    factor? f = factorWithBound? f (ZPoly.defaultFactorCoeffBound f) := rfl
+@[simp, grind =] theorem factor?_eq_some (f : ZPoly) :
+    factor? f = some (factor f) := rfl
 
 /-- When `factorWithBound?` succeeds, it agrees with the total `factorWithBound`.
 The total form's fallback only engages on the `none` branch this function
@@ -9870,18 +9989,6 @@ theorem factorWithBound?_eq_some_iff_safe_branch (f : ZPoly) (B : Nat) :
           (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
         · simp [hdeg, hquad, hprime, hmonicPrime]
         · simp [hdeg, hquad, hprime, hmonicPrime]
-
-/-- `factor?` and `factor` agree on the `some` branch (immediate from
-`factorWithBound?_eq_some_iff_safe_branch`). -/
-theorem factor?_eq_some_iff_safe_branch (f : ZPoly) :
-    factor? f =
-      (if (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0 ∨
-          (quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore).isSome ∨
-          (choosePrimeData? (normalizeForFactor f).squareFreeCore).isSome ∨
-          (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
-        then some (factor f) else none) := by
-  unfold factor? factor
-  exact factorWithBound?_eq_some_iff_safe_branch f _
 
 set_option maxHeartbeats 800000
 
@@ -10058,31 +10165,30 @@ theorem factor_scalar (f : ZPoly) :
         -ZPoly.content f
       else
         ZPoly.content f := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_scalar f (ZPoly.defaultFactorCoeffBound f)
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_scalar f (factorHybridFactors f)
 
 @[simp, grind =] theorem factor_scalar_zero :
     (factor 0).scalar = 0 := by
-  simp [factor_eq_factorWithBound_default]
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_scalar_zero (factorHybridFactors 0)
 
 theorem factor_scalar_of_leadingCoeff_neg
     {f : ZPoly} (hf : f ≠ 0) (hneg : DensePoly.leadingCoeff f < 0) :
     (factor f).scalar = -ZPoly.content f := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_scalar_of_leadingCoeff_neg
-      (f := f) (ZPoly.defaultFactorCoeffBound f) hf hneg
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_scalar_of_leadingCoeff_neg (factorHybridFactors f) hf hneg
 
 theorem factor_scalar_of_leadingCoeff_pos
     {f : ZPoly} (hf : f ≠ 0) (hpos : 0 < DensePoly.leadingCoeff f) :
     (factor f).scalar = ZPoly.content f := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_scalar_of_leadingCoeff_pos
-      (f := f) (ZPoly.defaultFactorCoeffBound f) hf hpos
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_scalar_of_leadingCoeff_pos (factorHybridFactors f) hf hpos
 
 theorem factor_scalar_eq_zero_iff (f : ZPoly) :
     (factor f).scalar = 0 ↔ f = 0 := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_scalar_eq_zero_iff f (ZPoly.defaultFactorCoeffBound f)
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_scalar_eq_zero_iff f (factorHybridFactors f)
 
 /-- Any recorded entry of `factorWithBound` comes from one of three raw factor
 arrays: the fast path's output, the modular slow path's
@@ -10209,9 +10315,8 @@ theorem factor_entry_multiplicity_pos
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
     0 < entry.2 := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_multiplicity_pos
-      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+  rw [factor_eq_factorizationOfFactors] at hmem
+  exact factorizationOfFactors_entry_multiplicity_pos f (factorHybridFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is fixed by
 `normalizeFactorSign`. -/
@@ -10219,9 +10324,8 @@ theorem factor_entry_normalizeFactorSign_id
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
     normalizeFactorSign entry.1 = entry.1 := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_normalizeFactorSign_id
-      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+  rw [factor_eq_factorizationOfFactors] at hmem
+  exact factorizationOfFactors_entry_normalizeFactorSign_id f (factorHybridFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization has positive
 leading coefficient. -/
@@ -10229,9 +10333,8 @@ theorem factor_entry_leadingCoeff_pos
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
     0 < DensePoly.leadingCoeff entry.1 := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_leadingCoeff_pos
-      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+  rw [factor_eq_factorizationOfFactors] at hmem
+  exact factorizationOfFactors_entry_leadingCoeff_pos f (factorHybridFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization passes the
 `shouldRecordPolynomialFactor` filter. -/
@@ -10239,77 +10342,36 @@ theorem factor_entry_shouldRecord
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
     shouldRecordPolynomialFactor entry.1 = true := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_shouldRecord
-      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+  rw [factor_eq_factorizationOfFactors] at hmem
+  have hmem' : entry ∈ (collectFactorMultiplicities (factorHybridFactors f)).toList := by
+    simpa only [factorizationOfFactors] using hmem
+  exact collectFactorMultiplicities_entry_shouldRecord (factorHybridFactors f) entry hmem'
 
-/-- Any recorded entry of the default public factorization comes from the raw
-factor array selected by one of the three tiers (fast, slow-modular,
-slow-trial), up to sign normalization. -/
+/-- Any recorded entry of the default public factorization comes from the
+hybrid's raw factor array `factorHybridFactors`, up to sign normalization. -/
 theorem factor_entry_mem_raw_source
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
-    ∃ rawFactors : Array ZPoly,
-      (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-          some rawFactors ∨
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            none ∧
-          factorSlowModularFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors) ∨
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            none ∧
-          factorSlowModularWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-          rawFactors =
-            factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) ∧
-      ∃ raw ∈ rawFactors.toList, entry.1 = normalizeFactorSign raw := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_mem_raw_source
-      f (ZPoly.defaultFactorCoeffBound f) entry hmem
+    ∃ raw ∈ (factorHybridFactors f).toList, entry.1 = normalizeFactorSign raw := by
+  rw [factor_eq_factorizationOfFactors] at hmem
+  exact factorizationOfFactors_entry_mem_normalized_raw f (factorHybridFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is primitive once
-every raw factor in the selected default-precision dispatch branch is
-primitive. -/
+every raw factor in the hybrid's raw factor array is primitive. -/
 theorem factor_entry_primitive_of_chosen_raw_primitive
     {f : ZPoly} {entry : ZPoly × Nat}
     (hmem : entry ∈ (factor f).factors.toList)
-    (h_raw :
-      ∀ rawFactors : Array ZPoly,
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            factorSlowModularFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              some rawFactors) ∨
-          (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            factorSlowModularWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-            rawFactors =
-              factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, ZPoly.Primitive raw) :
-    ZPoly.Primitive entry.1 :=
-  factorWithBound_entry_primitive_of_chosen_raw_primitive
-    (B := ZPoly.defaultFactorCoeffBound f)
-    (by simpa [factor_eq_factorWithBound_default] using hmem)
-    h_raw
+    (h_raw : ∀ raw ∈ (factorHybridFactors f).toList, ZPoly.Primitive raw) :
+    ZPoly.Primitive entry.1 := by
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factor_entry_mem_raw_source f entry hmem
+  rw [hentry_eq]
+  exact normalizeFactorSign_primitive _ (h_raw raw hraw_mem)
 
-/-- Default-precision specialisation of `factorWithBound_entries_primitive`
-for the public `factor` entry point. -/
+/-- Public-entry specialisation: every recorded entry is primitive once the
+hybrid's raw factor array is primitive entrywise. -/
 theorem factor_entries_primitive
     (f : ZPoly)
-    (h_raw :
-      ∀ rawFactors : Array ZPoly,
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            factorSlowModularFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              some rawFactors) ∨
-          (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            factorSlowModularWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-            rawFactors =
-              factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, ZPoly.Primitive raw) :
+    (h_raw : ∀ raw ∈ (factorHybridFactors f).toList, ZPoly.Primitive raw) :
     ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 := by
   intro entry hentry
   exact factor_entry_primitive_of_chosen_raw_primitive
@@ -10320,8 +10382,8 @@ theorem factor_pairwise_first
     (f : ZPoly) :
     List.Pairwise (fun a b : ZPoly × Nat => a.1 ≠ b.1)
       (factor f).factors.toList := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_pairwise_first f (ZPoly.defaultFactorCoeffBound f)
+  rw [factor_eq_factorizationOfFactors]
+  exact factorizationOfFactors_pairwise_first f (factorHybridFactors f)
 
 /-- In the slow exhaustive modular fallback branch, every recorded
 `factorWithBound` entry comes from the explicit raw exhaustive slow-factor
@@ -10422,36 +10484,6 @@ theorem factorWithBound_entry_mem_exhaustive_branch_xPower_or_core_of_reassembly
       (exhaustiveCoreFactorsWithBound (normalizeForFactor f).squareFreeCore B
         primeData)
       raw hcomplete hraw_mem
-
-/--
-Default-precision specialization of
-`factorWithBound_entry_mem_exhaustive_branch_xPower_or_core_of_reassemblyComplete`
-for the public `factor` entry point.
--/
-theorem factor_entry_mem_exhaustive_branch_xPower_or_core_of_reassemblyComplete
-    (f : ZPoly) (entry : ZPoly × Nat)
-    (primeData : PrimeChoiceData)
-    (hchoose :
-      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
-    (hbranch :
-      factorWithBoundUsesExhaustiveBranch f (ZPoly.defaultFactorCoeffBound f))
-    (hcomplete :
-      reassemblyExpansionComplete (normalizeForFactor f)
-        (exhaustiveCoreFactorsWithBound (normalizeForFactor f).squareFreeCore
-          (ZPoly.defaultFactorCoeffBound f)
-          primeData))
-    (hmem : entry ∈ (factor f).factors.toList) :
-    ∃ raw,
-      (raw ∈ (xPowerFactorArray (normalizeForFactor f).xPower).toList ∨
-        raw ∈
-          (exhaustiveCoreFactorsWithBound (normalizeForFactor f).squareFreeCore
-            (ZPoly.defaultFactorCoeffBound f)
-            primeData).toList) ∧
-        entry.1 = normalizeFactorSign raw := by
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound_entry_mem_exhaustive_branch_xPower_or_core_of_reassemblyComplete
-      f (ZPoly.defaultFactorCoeffBound f) entry primeData hchoose
-      hbranch hcomplete hmem
 
 /-- In the fast-path small-mod singleton branch, every recorded
 `factorWithBound` entry comes from the normalization reassembly whose core array
@@ -19455,45 +19487,6 @@ private theorem primitive_of_signedContentScalar_mul_eq
   · show ZPoly.content P = 1
     omega
 
-/-- The default-precision raw factor array selected by the dispatch is primitive
-entrywise, for nonzero `f`. This is the closed discharge of the raw-source
-primitivity hypothesis threaded through `factor_entries_primitive`: the array
-product reconstructs `f` from its signed content scalar
-(`factor*FactorsWithBound_polyProduct*` per branch), so the product is primitive
-and hence so is every member. -/
-theorem factor_chosen_raw_primitive_of_ne_zero
-    (f : ZPoly) (hf : f ≠ 0) :
-    ∀ rawFactors : Array ZPoly,
-      (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-          some rawFactors ∨
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-          factorSlowModularFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors) ∨
-        (factorFastFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-          factorSlowModularWithBound f (ZPoly.defaultFactorCoeffBound f) = none ∧
-          rawFactors =
-            factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f))) →
-      ∀ raw ∈ rawFactors.toList, ZPoly.Primitive raw := by
-  intro rawFactors hsource
-  have hprod : DensePoly.C (signedContentScalar f) *
-      Array.polyProduct rawFactors = f := by
-    rcases hsource with hfast | ⟨_, hmod⟩ | ⟨_, _, htrial⟩
-    · exact factorFastFactorsWithBound_polyProduct_of_some hfast
-    · exact factorSlowModularFactorsWithBound_polyProduct_of_some hmod
-    · subst htrial
-      exact factorSlowTrialFactorsWithBound_polyProduct f _
-  have hprim : ZPoly.Primitive (Array.polyProduct rawFactors) :=
-    primitive_of_signedContentScalar_mul_eq f (Array.polyProduct rawFactors) hf hprod
-  exact polyProduct_mem_primitive_of_primitive rawFactors hprim
-
-/-- Every recorded entry of the default factorization of a nonzero `f` is
-primitive, with no raw-source hypothesis: it is discharged internally by
-`factor_chosen_raw_primitive_of_ne_zero`. -/
-theorem factor_entries_primitive_of_ne_zero
-    (f : ZPoly) (hf : f ≠ 0) :
-    ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 :=
-  factor_entries_primitive f (factor_chosen_raw_primitive_of_ne_zero f hf)
-
 private theorem factorSlowTrialWithBound_product_of_all_recorded_normalized
     (f : ZPoly) (B : Nat)
     (hnormalized :
@@ -19639,18 +19632,13 @@ theorem factorFast_product_of_some
     Factorization.product φ = f := by
   exact factorFastWithBound_product_of_some h
 
-/-- Product contract for the public total factorization entry point. -/
-theorem factor_product (f : ZPoly) :
-    Factorization.product (factor f) = f := by
-  exact factorWithBound_product f (ZPoly.defaultFactorCoeffBound f)
-
 /-- Product preservation for the cost-based hybrid. Holds unconditionally: each
 non-backstop tier's result is accepted only when it reconstructs `f` (the
 self-certifying guard in `factorHybridTraced`), and every fallback is the proven
 `factorSlowTrial` backstop. This is the headline contract the public `factor`
-swap will inherit, established here without yet proving the classical
-recombination loop reconstructs (that, with per-factor irreducibility, is the
-re-proof capstone). -/
+swap inherits, established without proving the classical recombination loop
+reconstructs (that, with per-factor irreducibility, is the still-blocked re-proof
+capstone #8384). -/
 theorem factorHybrid_product (f : ZPoly) :
     Factorization.product (factorHybrid f) = f := by
   unfold factorHybrid factorHybridTraced
@@ -19667,6 +19655,53 @@ theorem factorHybrid_product (f : ZPoly) :
           · simp [hp]
           · simp only [hp, if_false]; exact factorSlowTrial_product f
       | none => exact factorSlowTrial_product f
+
+/-- Product contract for the public total factorization entry point: the
+self-certifying hybrid always reconstructs its input. -/
+theorem factor_product (f : ZPoly) :
+    Factorization.product (factor f) = f :=
+  factorHybrid_product f
+
+/-- Every recorded entry of the default factorization of a nonzero `f` is
+primitive, with no raw-source hypothesis. The hybrid's `factorizationOfFactors`
+packing certifies the *filtered* product reconstructs `f`
+(`factor_product` + `factorizationOfFactors_product`), so that product is
+primitive and hence so is every recorded (filtered) entry. -/
+theorem factor_entries_primitive_of_ne_zero
+    (f : ZPoly) (hf : f ≠ 0) :
+    ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 := by
+  intro entry hentry
+  have hmem : entry ∈ (factor f).factors.toList := Array.mem_toList_iff.mpr hentry
+  -- The filtered product reconstructs `f`, hence is primitive.
+  have hfiltered_prod :
+      DensePoly.C (signedContentScalar f) *
+        Array.polyProduct
+          (filteredNormalizedFactors (factorHybridFactors f).toList).toArray = f := by
+    have hp := factor_product f
+    rw [factor_eq_factorizationOfFactors, factorizationOfFactors_product] at hp
+    exact hp
+  have hprim :
+      ZPoly.Primitive
+        (Array.polyProduct
+          (filteredNormalizedFactors (factorHybridFactors f).toList).toArray) :=
+    primitive_of_signedContentScalar_mul_eq f _ hf hfiltered_prod
+  have hmem_filtered :
+      ∀ g ∈ (filteredNormalizedFactors (factorHybridFactors f).toList).toArray.toList,
+        ZPoly.Primitive g :=
+    polyProduct_mem_primitive_of_primitive _ hprim
+  -- The entry lies in the filtered list (it equals a sign-normalized raw factor
+  -- and passes the recording filter).
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factor_entry_mem_raw_source f entry hmem
+  have hrecord : shouldRecordPolynomialFactor (normalizeFactorSign raw) = true := by
+    have := factor_entry_shouldRecord f entry hmem
+    rwa [hentry_eq] at this
+  have hentry_in :
+      entry.1 ∈ (filteredNormalizedFactors (factorHybridFactors f).toList).toArray.toList := by
+    rw [List.toList_toArray, hentry_eq]
+    unfold filteredNormalizedFactors
+    rw [List.mem_filterMap]
+    exact ⟨raw, hraw_mem, by simp only [hrecord, if_true]⟩
+  exact hmem_filtered entry.1 hentry_in
 
 /-- Product preservation for the Option-returning bounded API on its successful
 branch. The `none` branch is the explicit no-admissible-prime surface; when a
@@ -19694,7 +19729,9 @@ theorem factor?_product_of_some
     {f : ZPoly} {φ : Factorization}
     (h : factor? f = some φ) :
     Factorization.product φ = f := by
-  exact factorWithBound?_product_of_some h
+  rw [factor?_eq_some] at h
+  cases h
+  exact factor_product f
 
 /-- A successful `factorWithBound?` result is exactly the total bounded
 factorization. The `none` branch is the explicit no-admissible-prime surface;
@@ -19719,9 +19756,8 @@ theorem factor?_eq_some_eq_factor
     {f : ZPoly} {φ : Factorization}
     (h : factor? f = some φ) :
     φ = factor f := by
-  unfold factor? at h
-  simpa [factor_eq_factorWithBound_default] using
-    factorWithBound?_eq_some_eq_factorWithBound h
+  rw [factor?_eq_some] at h
+  exact (Option.some.inj h).symm
 
 /-- Scalar contract for the Option-returning bounded API on its successful
 branch. -/

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9953,19 +9953,6 @@ def factorWithBound? (f : ZPoly) (B : Nat) : Option Factorization :=
   else
     none
 
-/--
-Option-returning factoring entry point at the default Mignotte bound. The public
-path is now the total cost-based hybrid (`factor = factorHybrid`, whose trial
-backstop never declines), so there is no no-admissible-prime failure surface to
-propagate: this always succeeds with the hybrid factorisation. (The proof-facing
-`factorWithBound?` retains the cap-based three-tier `none` surface.)
--/
-def factor? (f : ZPoly) : Option Factorization :=
-  some (factor f)
-
-@[simp, grind =] theorem factor?_eq_some (f : ZPoly) :
-    factor? f = some (factor f) := rfl
-
 /-- When `factorWithBound?` succeeds, it agrees with the total `factorWithBound`.
 The total form's fallback only engages on the `none` branch this function
 exposes. -/
@@ -19722,17 +19709,6 @@ theorem factorWithBound?_product_of_some
   · rw [if_neg hsafe] at h
     cases h
 
-/-- Product preservation for the Option-returning default API on its successful
-branch. This is the proof-facing contract for callers that choose to propagate
-no-admissible-prime failure instead of consuming the total fallback. -/
-theorem factor?_product_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ) :
-    Factorization.product φ = f := by
-  rw [factor?_eq_some] at h
-  cases h
-  exact factor_product f
-
 /-- A successful `factorWithBound?` result is exactly the total bounded
 factorization. The `none` branch is the explicit no-admissible-prime surface;
 on `some`, all total-API contracts can be transported to the returned record. -/
@@ -19751,14 +19727,6 @@ theorem factorWithBound?_eq_some_eq_factorWithBound
   · rw [if_neg hsafe] at h
     cases h
 
-/-- A successful `factor?` result is exactly the total default factorization. -/
-theorem factor?_eq_some_eq_factor
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ) :
-    φ = factor f := by
-  rw [factor?_eq_some] at h
-  exact (Option.some.inj h).symm
-
 /-- Scalar contract for the Option-returning bounded API on its successful
 branch. -/
 theorem factorWithBound?_scalar_of_some
@@ -19774,21 +19742,6 @@ theorem factorWithBound?_scalar_of_some
   rw [factorWithBound?_eq_some_eq_factorWithBound h]
   exact factorWithBound_scalar f B
 
-/-- Scalar contract for the Option-returning default API on its successful
-branch. -/
-theorem factor?_scalar_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ) :
-    φ.scalar =
-      if f = 0 then
-        0
-      else if DensePoly.leadingCoeff f < 0 then
-        -ZPoly.content f
-      else
-        ZPoly.content f := by
-  rw [factor?_eq_some_eq_factor h]
-  exact factor_scalar f
-
 /-- Every entry emitted by a successful `factorWithBound?` call has positive
 multiplicity. -/
 theorem factorWithBound?_entry_multiplicity_pos_of_some
@@ -19800,17 +19753,6 @@ theorem factorWithBound?_entry_multiplicity_pos_of_some
   rw [factorWithBound?_eq_some_eq_factorWithBound h] at hmem
   exact factorWithBound_entry_multiplicity_pos f B entry hmem
 
-/-- Every entry emitted by a successful `factor?` call has positive
-multiplicity. -/
-theorem factor?_entry_multiplicity_pos_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ)
-    (entry : ZPoly × Nat)
-    (hmem : entry ∈ φ.factors.toList) :
-    0 < entry.2 := by
-  rw [factor?_eq_some_eq_factor h] at hmem
-  exact factor_entry_multiplicity_pos f entry hmem
-
 /-- Entries emitted by a successful `factorWithBound?` call are sign-normalized. -/
 theorem factorWithBound?_entry_normalizeFactorSign_id_of_some
     {f : ZPoly} {B : Nat} {φ : Factorization}
@@ -19820,16 +19762,6 @@ theorem factorWithBound?_entry_normalizeFactorSign_id_of_some
     normalizeFactorSign entry.1 = entry.1 := by
   rw [factorWithBound?_eq_some_eq_factorWithBound h] at hmem
   exact factorWithBound_entry_normalizeFactorSign_id f B entry hmem
-
-/-- Entries emitted by a successful `factor?` call are sign-normalized. -/
-theorem factor?_entry_normalizeFactorSign_id_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ)
-    (entry : ZPoly × Nat)
-    (hmem : entry ∈ φ.factors.toList) :
-    normalizeFactorSign entry.1 = entry.1 := by
-  rw [factor?_eq_some_eq_factor h] at hmem
-  exact factor_entry_normalizeFactorSign_id f entry hmem
 
 /-- Entries emitted by a successful `factorWithBound?` call have positive
 leading coefficient. -/
@@ -19842,17 +19774,6 @@ theorem factorWithBound?_entry_leadingCoeff_pos_of_some
   rw [factorWithBound?_eq_some_eq_factorWithBound h] at hmem
   exact factorWithBound_entry_leadingCoeff_pos f B entry hmem
 
-/-- Entries emitted by a successful `factor?` call have positive leading
-coefficient. -/
-theorem factor?_entry_leadingCoeff_pos_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ)
-    (entry : ZPoly × Nat)
-    (hmem : entry ∈ φ.factors.toList) :
-    0 < DensePoly.leadingCoeff entry.1 := by
-  rw [factor?_eq_some_eq_factor h] at hmem
-  exact factor_entry_leadingCoeff_pos f entry hmem
-
 /-- Entries emitted by a successful `factorWithBound?` call pass the executable
 recording filter. -/
 theorem factorWithBound?_entry_shouldRecord_of_some
@@ -19864,17 +19785,6 @@ theorem factorWithBound?_entry_shouldRecord_of_some
   rw [factorWithBound?_eq_some_eq_factorWithBound h] at hmem
   exact factorWithBound_entry_shouldRecord f B entry hmem
 
-/-- Entries emitted by a successful `factor?` call pass the executable
-recording filter. -/
-theorem factor?_entry_shouldRecord_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ)
-    (entry : ZPoly × Nat)
-    (hmem : entry ∈ φ.factors.toList) :
-    shouldRecordPolynomialFactor entry.1 = true := by
-  rw [factor?_eq_some_eq_factor h] at hmem
-  exact factor_entry_shouldRecord f entry hmem
-
 /-- A successful `factorWithBound?` result has no duplicate polynomial keys. -/
 theorem factorWithBound?_pairwise_first_of_some
     {f : ZPoly} {B : Nat} {φ : Factorization}
@@ -19882,14 +19792,6 @@ theorem factorWithBound?_pairwise_first_of_some
     List.Pairwise (fun a b : ZPoly × Nat => a.1 ≠ b.1) φ.factors.toList := by
   rw [factorWithBound?_eq_some_eq_factorWithBound h]
   exact factorWithBound_pairwise_first f B
-
-/-- A successful `factor?` result has no duplicate polynomial keys. -/
-theorem factor?_pairwise_first_of_some
-    {f : ZPoly} {φ : Factorization}
-    (h : factor? f = some φ) :
-    List.Pairwise (fun a b : ZPoly × Nat => a.1 ≠ b.1) φ.factors.toList := by
-  rw [factor?_eq_some_eq_factor h]
-  exact factor_pairwise_first f
 
 /--
 A successful integer certificate exposes the per-prime polynomial check fact:

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -158,8 +158,8 @@ def irreducibleByFactorization (f : Polynomial ℤ) : Bool :=
 /-- The default executable factorization multiplies back to the input. -/
 @[simp, grind =]
 theorem factor_product (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.factor f) = f := by
-  exact Hex.factorWithBound_product f (Hex.ZPoly.defaultFactorCoeffBound f)
+    Hex.Factorization.product (Hex.factor f) = f :=
+  Hex.factor_product f
 
 /--
 The Mathlib-free executable irreducibility predicate agrees with Mathlib's
@@ -374,7 +374,8 @@ the public `Hex.factor` entry point.  This is the form consumed by the
 HO-1 capstone `factor_irreducible_of_nonUnit` (#4170). -/
 theorem factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     {f : Hex.ZPoly} {entry : Hex.ZPoly × Nat}
-    (hmem : entry ∈ (Hex.factor f).factors.toList)
+    (hmem : entry ∈
+      (Hex.factorWithBound f (Hex.ZPoly.defaultFactorCoeffBound f)).factors.toList)
     (h_raw :
       ∀ rawFactors : Array Hex.ZPoly,
         (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
@@ -395,9 +396,7 @@ theorem factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
             Hex.ZPoly.Irreducible raw) :
     Hex.ZPoly.Irreducible entry.1 :=
   factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
-    (B := Hex.ZPoly.defaultFactorCoeffBound f)
-    (by simpa [Hex.factor_eq_factorWithBound_default] using hmem)
-    h_raw
+    (B := Hex.ZPoly.defaultFactorCoeffBound f) hmem h_raw
 
 /-- **#3987 assembled output theorem.**
 
@@ -436,10 +435,11 @@ theorem factorWithBound_entries_irreducible
   exact factorWithBound_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (Array.mem_toList_iff.mpr hentry) h_raw
 
-/-- Default-precision specialisation of `factorWithBound_entries_irreducible`
-for the public `Hex.factor` entry point.  Matches the signature of
-`factor_irreducible_of_nonUnit` (#4170 capstone) modulo the `h_raw` hypothesis;
-unconditional discharge of `h_raw` is tracked by #4170. -/
+/-- Default-precision specialisation of `factorWithBound_entries_irreducible`,
+attached to the now-proof-facing `factorWithBound` combinator (the public
+`Hex.factor` is the cost-based hybrid since #8383; its headline irreducibility is
+the still-`sorry` `factor_irreducible_of_nonUnit`). Unconditional discharge of
+`h_raw` is tracked by #8384. -/
 theorem factor_entries_irreducible
     (f : Hex.ZPoly)
     (h_raw :
@@ -460,36 +460,22 @@ theorem factor_entries_irreducible
         ∀ raw ∈ rawFactors.toList,
           Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
             Hex.ZPoly.Irreducible raw) :
-    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
+    ∀ entry ∈ (Hex.factorWithBound f (Hex.ZPoly.defaultFactorCoeffBound f)).factors,
+      Hex.ZPoly.Irreducible entry.1 := by
   intro entry hentry
   exact factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible
     (Array.mem_toList_iff.mpr hentry) h_raw
 
 /--
-Every polynomial factor emitted by the default executable factorization is
-primitive once the selected raw fast branch, or the slow fallback branch when
-the fast path returns `none`, is primitive entrywise.
+Every polynomial factor emitted by the default executable factorization of a
+nonzero input is primitive. The public path is the self-certifying hybrid
+(#8383), so primitivity is discharged from `f ≠ 0` alone (the filtered product
+reconstructs `f`); no raw-source hypothesis is needed.
 -/
 theorem factor_entries_primitive_of_chosen_raw_primitive
-    (f : Hex.ZPoly)
-    (h_raw :
-      ∀ rawFactors : Array Hex.ZPoly,
-        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            rawFactors =
-              Hex.factorSlowTrialFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    (f : Hex.ZPoly) (hf : f ≠ 0) :
     ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Primitive entry.1 :=
-  Hex.factor_entries_primitive f h_raw
+  Hex.factor_entries_primitive_of_ne_zero f hf
 
 private theorem toPolynomial_foldl_mul (lst : List Hex.ZPoly) (init : Hex.ZPoly) :
     HexPolyZMathlib.toPolynomial (lst.foldl (· * ·) init) =
@@ -678,28 +664,12 @@ theorem zpoly_not_associated_of_ne_of_primitive_pos_leading
 set_option maxHeartbeats 3000000
 
 /--
-Recorded entries of the default executable factorization are pairwise
-non-associated after transport to `Polynomial ℤ`, assuming the selected raw
-factor branch is primitive entrywise.
+Recorded entries of the default executable factorization of a nonzero input are
+pairwise non-associated after transport to `Polynomial ℤ`. Primitivity is
+discharged from `f ≠ 0` (the self-certifying hybrid, #8383).
 -/
 theorem factor_entries_not_associated
-    (f : Hex.ZPoly)
-    (h_raw :
-      ∀ rawFactors : Array Hex.ZPoly,
-        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            rawFactors =
-              Hex.factorSlowTrialFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    (f : Hex.ZPoly) (hf : f ≠ 0) :
     List.Pairwise
       (fun a b : Hex.ZPoly × Nat =>
         ¬ Associated (HexPolyZMathlib.toPolynomial a.1)
@@ -708,8 +678,8 @@ theorem factor_entries_not_associated
   exact List.Pairwise.imp_of_mem
     (fun {a b} ha hb hab =>
       zpoly_not_associated_of_ne_of_primitive_pos_leading
-        (Hex.factor_entries_primitive f h_raw a (Array.mem_toList_iff.mp ha))
-        (Hex.factor_entries_primitive f h_raw b (Array.mem_toList_iff.mp hb))
+        (Hex.factor_entries_primitive_of_ne_zero f hf a (Array.mem_toList_iff.mp ha))
+        (Hex.factor_entries_primitive_of_ne_zero f hf b (Array.mem_toList_iff.mp hb))
         (Hex.factor_entry_leadingCoeff_pos f a ha)
         (Hex.factor_entry_leadingCoeff_pos f b hb)
         hab)

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -109,23 +109,7 @@ headline primitive-irreducibility clause as a single per-entry conjunction under
 the raw-branch primitive hypothesis supplied by the executable layer.
 -/
 theorem factor_headline_contract_core_with_primitive
-    (f : Hex.ZPoly)
-    (h_raw :
-      ∀ rawFactors : Array Hex.ZPoly,
-        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            rawFactors =
-              Hex.factorSlowTrialFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    (f : Hex.ZPoly) (hf : f ≠ 0) :
     Hex.Factorization.product (Hex.factor f) = f ∧
       (∀ entry ∈ (Hex.factor f).factors,
         Hex.ZPoly.Primitive entry.1 ∧
@@ -143,7 +127,7 @@ theorem factor_headline_contract_core_with_primitive
   refine ⟨factor_product f, ?_, ?_, Hex.factor_pairwise_first f, Hex.factor_scalar f⟩
   · intro entry hentry
     exact
-      ⟨factor_entries_primitive_of_chosen_raw_primitive f h_raw entry hentry,
+      ⟨factor_entries_primitive_of_chosen_raw_primitive f hf entry hentry,
         factor_polynomialIrreducible_of_nonUnit f entry hentry⟩
   · intro entry hentry
     exact Hex.factor_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
@@ -179,8 +163,7 @@ theorem factor_headline_primitive (f : Hex.ZPoly) (hf : f ≠ 0) :
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f :=
-  factor_headline_contract_core_with_primitive f
-    (Hex.factor_chosen_raw_primitive_of_ne_zero f hf)
+  factor_headline_contract_core_with_primitive f hf
 
 /--
 The HO-1 headline contract for the default executable factorization of a nonzero
@@ -224,8 +207,7 @@ theorem factor_headline (f : Hex.ZPoly) (hf : f ≠ 0) :
     ⟨hproduct, hentries, hmultiplicity, _, hscalar⟩
   exact
     ⟨hproduct, hentries, hmultiplicity,
-      factor_entries_not_associated f
-        (Hex.factor_chosen_raw_primitive_of_ne_zero f hf),
+      factor_entries_not_associated f hf,
       hscalar⟩
 
 /--
@@ -249,33 +231,17 @@ Positive degree is *not* derivable from `shouldRecordPolynomialFactor` alone —
 constant like `Hex.DensePoly.C 2` passes the recording filter, has positive
 leading coefficient, and is sign-normalized. The constant case is excluded by
 *primitivity* (content `1` forces a constant to be `±1`), so this carries the
-same raw-source primitivity hypothesis `h_raw` as `Hex.factor_entries_primitive`
-and `factor_headline_contract_core_with_primitive`. The constant-exclusion
-argument itself is `Hex.degree_pos_of_primitive_norm_record`.
+`f ≠ 0` side condition that `Hex.factor_entries_primitive_of_ne_zero` needs
+(the self-certifying hybrid, #8383). The constant-exclusion argument itself is
+`Hex.degree_pos_of_primitive_norm_record`.
 -/
 theorem factor_entries_degree_pos
-    (f : Hex.ZPoly)
-    (h_raw :
-      ∀ rawFactors : Array Hex.ZPoly,
-        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            rawFactors =
-              Hex.factorSlowTrialFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    (f : Hex.ZPoly) (hf : f ≠ 0) :
     ∀ entry ∈ (Hex.factor f).factors, 0 < entry.1.degree?.getD 0 := by
   intro entry hentry
   have hmem := Array.mem_toList_iff.mpr hentry
   exact Hex.degree_pos_of_primitive_norm_record entry.1
-    (Hex.factor_entries_primitive f h_raw entry hentry)
+    (Hex.factor_entries_primitive_of_ne_zero f hf entry hentry)
     (Hex.factor_entry_normalizeFactorSign_id f entry hmem)
     (Hex.factor_entry_shouldRecord f entry hmem)
 
@@ -309,39 +275,22 @@ theorem factor_unique_of_product
 Default-specialised sibling of `factor_unique_of_product` that discharges the
 default factorization's own sign-normalization and nonconstant side conditions
 internally, so callers no longer supply `hψ_norm` or `hψ_nonconst`. The
-nonconstant clause needs the raw-source primitivity hypothesis `h_raw` (the same
-hypothesis `factor_entries_degree_pos` and `Hex.factor_entries_primitive`
-require); `hψ_norm` is discharged unconditionally.
+nonconstant clause needs only `f ≠ 0` (the same `hf_ne` already supplied), via
+`factor_entries_degree_pos`; `hψ_norm` is discharged unconditionally.
 -/
 theorem factor_unique_of_product_default
     (f : Hex.ZPoly) (φ : Hex.Factorization) (hf_ne : f ≠ 0)
     (hproduct : Hex.Factorization.product φ = f)
     (hφ_norm : ∀ entry ∈ φ.factors, Hex.normalizeFactorSign entry.1 = entry.1)
     (hφ_nonconst : ∀ entry ∈ φ.factors, 0 < entry.1.degree?.getD 0)
-    (hirr : ∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1)
-    (h_raw :
-      ∀ rawFactors : Array Hex.ZPoly,
-        (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-            some rawFactors ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f) = some rawFactors) ∨
-          (Hex.factorFastFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            Hex.factorSlowModularWithBound f (Hex.ZPoly.defaultFactorCoeffBound f) =
-              none ∧
-            rawFactors =
-              Hex.factorSlowTrialFactorsWithBound f
-                (Hex.ZPoly.defaultFactorCoeffBound f))) →
-        ∀ raw ∈ rawFactors.toList, Hex.ZPoly.Primitive raw) :
+    (hirr : ∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1) :
     φ.scalar = (Hex.factor f).scalar ∧
       (φ.factors.toList.map (fun e => Multiset.replicate e.2 e.1)).sum =
         ((Hex.factor f).factors.toList.map
           (fun e => Multiset.replicate e.2 e.1)).sum :=
   factor_unique_of_product f φ hf_ne hproduct hφ_norm
     (factor_entries_normalizeFactorSign f) hφ_nonconst
-    (factor_entries_degree_pos f h_raw) hirr
+    (factor_entries_degree_pos f hf_ne) hirr
 
 /-!
 ### HO-1 capstone assembly: `factor_irreducible_of_nonUnit` reduced to the fast-core arm
@@ -450,7 +399,8 @@ theorem factor_irreducible_of_nonUnit_of_fastCore
               (Hex.ZPoly.defaultFactorCoeffBound f) + 2) =
           some coreFactors →
         ∀ factor ∈ coreFactors.toList, Hex.ZPoly.Irreducible factor) :
-    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
+    ∀ entry ∈ (Hex.factorWithBound f (Hex.ZPoly.defaultFactorCoeffBound f)).factors,
+      Hex.ZPoly.Irreducible entry.1 := by
   have hB_pos : 1 ≤ Hex.ZPoly.defaultFactorCoeffBound f :=
     Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hf
   apply factor_entries_irreducible f

--- a/progress/20260628T083522Z_8383-factor-hybrid-swap.md
+++ b/progress/20260628T083522Z_8383-factor-hybrid-swap.md
@@ -7,11 +7,12 @@ One green PR, both the Mathlib-free executable layer and the whole CI-gated
 `HexBerlekampZassenhausMathlib` library build green.
 
 ### Mathlib-free (`HexBerlekampZassenhaus/Basic.lean`)
-- `def factor := factorHybrid f`; `def factor? := some (factor f)` (the hybrid is
-  total — its trial backstop never declines — so the no-admissible-prime `none`
-  surface moved to the proof-facing `factorWithBound?`). Deleted the now-false
-  `factor_eq_factorWithBound_default`, `factor?_eq_factorWithBound?_default`,
-  `factor?_eq_some_iff_safe_branch`.
+- `def factor := factorHybrid f`. The hybrid is total (its trial backstop never
+  declines), so `factor?` would be the trivial `some (factor f)` — dropped it and
+  its whole `factor?_*_of_some` corollary cluster (zero consumers; the no-prime
+  `none` surface lives only on the proof-facing `factorWithBound?`, which stays).
+  Deleted the now-false `factor_eq_factorWithBound_default`,
+  `factor?_eq_factorWithBound?_default`, `factor?_eq_some_iff_safe_branch`.
 - Added `factorHybridFactors : ZPoly → Array ZPoly` (the hybrid's raw factor
   array) plus the bridge `factorHybrid_eq_factorizationOfFactors` /
   `factor_eq_factorizationOfFactors : factor f = factorizationOfFactors f

--- a/progress/20260628T083522Z_8383-factor-hybrid-swap.md
+++ b/progress/20260628T083522Z_8383-factor-hybrid-swap.md
@@ -1,0 +1,67 @@
+# #8383 — swap public `factor` to the cost-based hybrid (both layers)
+
+## Accomplished
+The headline migration: `Hex.factor` / `Hex.factor?` are now the cost-based
+hybrid `factorHybrid`, retiring the cap-based three-tier from the public path.
+One green PR, both the Mathlib-free executable layer and the whole CI-gated
+`HexBerlekampZassenhausMathlib` library build green.
+
+### Mathlib-free (`HexBerlekampZassenhaus/Basic.lean`)
+- `def factor := factorHybrid f`; `def factor? := some (factor f)` (the hybrid is
+  total — its trial backstop never declines — so the no-admissible-prime `none`
+  surface moved to the proof-facing `factorWithBound?`). Deleted the now-false
+  `factor_eq_factorWithBound_default`, `factor?_eq_factorWithBound?_default`,
+  `factor?_eq_some_iff_safe_branch`.
+- Added `factorHybridFactors : ZPoly → Array ZPoly` (the hybrid's raw factor
+  array) plus the bridge `factorHybrid_eq_factorizationOfFactors` /
+  `factor_eq_factorizationOfFactors : factor f = factorizationOfFactors f
+  (factorHybridFactors f)`. Supporting decomposition lemmas:
+  `factorClassicalTracedWithBound_fst`, `factorLattice_eq_map`.
+- Re-pointed the `factor`-level contracts through the bridge + the structural
+  `factorizationOfFactors_*` lemmas: `factor_product` (via `factorHybrid_product`,
+  #8398), `factor_scalar*`, `factor_entry_{multiplicity_pos,normalizeFactorSign_id,
+  leadingCoeff_pos,shouldRecord}`, `factor_pairwise_first`, `factor_entry_mem_raw_source`
+  (now over `factorHybridFactors f`), `factor_entry_primitive_of_chosen_raw_primitive`
+  / `factor_entries_primitive` (hybrid raw-source `h_raw`).
+- `factor_entries_primitive_of_ne_zero` is now proved from the **filtered**
+  product reconstruction (`factor_product` + `factorizationOfFactors_product`):
+  the self-certifying hybrid only guarantees the filtered product = f, which is
+  exactly what Gauss needs, so no "all raw factors primitive" intermediate is
+  required (that is *false* for the hybrid — a certified tier's raw array can
+  carry filtered-out units). Deleted the old 3-tier
+  `factor_chosen_raw_primitive_of_ne_zero` and the now-false
+  `factor_entry_mem_exhaustive_branch_xPower_or_core_of_reassemblyComplete`.
+
+### Mathlib layer (CI-gated)
+- `Basic.lean`: `factor_product` via `Hex.factor_product`; the irreducibility
+  specializations (`factor_entry_zpolyIrreducible_of_chosen_raw_zpolyIrreducible`,
+  `factor_entries_irreducible`) re-pointed to the now-proof-facing
+  `factorWithBound f default`; `factor_entries_primitive_of_chosen_raw_primitive`
+  and `factor_entries_not_associated` rewired to discharge primitivity from
+  `f ≠ 0` (`Hex.factor_entries_primitive_of_ne_zero`).
+- `FactorSoundness.lean`: `factor_headline_*` / `factor_unique_*` /
+  `factor_entries_degree_pos` rewired off the giant 3-tier `h_raw` onto `f ≠ 0`.
+  `factor_irreducible_of_nonUnit` stays a `sorry` (no regression — it was a
+  shipped sorry on main); `factor_irreducible_of_nonUnit_of_fastCore` re-pointed
+  to `factorWithBound f default`.
+- IntReductionMod's conditional `factor_*_branch_entry_irreducible_of_choosePrimeData`
+  cluster was already attached to `factorWithBound`; untouched.
+
+## Gates — before / after (both green, unchanged)
+- Conformance (FLINT): 100/0 → 100/0
+- FactorTrace counter gate: 50/0 → 50/0 (factorHybridTraced unchanged)
+- Wall-clock backstop: 5.857s → 5.424s (< 180s)
+- Bench verify: 18/18 → 18/18
+- Mathlib library: green → green (only pre-existing sorries:
+  `isIrreducible_iff`, `factor_irreducible_of_nonUnit`)
+- Easy-regime bench-run before/after (`runFactorChecksum`, warm cache):
+  the hybrid removes the exponential-on-easy-inputs blow-up and is faster
+  across the board — n=2 281µs→179µs, n=16 52.2ms→37.1ms, n=20 244.8ms→65.1ms,
+  **n=22 781.8ms→82.7ms** (~9.5×). No regression on any param.
+
+## Next step
+PR review. The capstone irreducibility re-proof over the hybrid (#8384) remains
+the still-blocked follow-up (#7479-class substrate); the headline stays a sorry.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR makes the public `Hex.factor` the cost-based hybrid `factorHybrid`, retiring the cap-based three-tier from the public path and removing the exponential-on-easy-inputs blow-up from the public API. Since the hybrid is total, the `Hex.factor?` Option wrapper would collapse to `some (factor f)`, so it (and its trivial `factor?_*_of_some` cluster) is dropped; the proof-facing `factorWithBound?` with its genuine no-prime `none` branch stays. It adds `factorHybridFactors` (the hybrid's raw factor array) and the bridge `factor f = factorizationOfFactors f (factorHybridFactors f)`, then re-points the ~34 Mathlib-free `factor`-level contracts (product via `factorHybrid_product`; entries / scalar / pairwise via the bridge and the structural `factorizationOfFactors_*` lemmas) and the CI-gated Mathlib-layer users (`factor_product`, `factor_headline_*`, `factor_unique_*`, `factor_entries_*`). Recorded-entry primitivity is discharged from `f ≠ 0` via the filtered product reconstruction the self-certifying hybrid guarantees, so the giant three-tier `h_raw` hypotheses drop out. The irreducibility specialisations re-point to the now-proof-facing `factorWithBound`; the headline `factor_irreducible_of_nonUnit` stays the shipped `sorry` (no regression — its unconditional discharge over the hybrid remains https://github.com/kim-em/hex-dev/issues/8384).

Closes https://github.com/kim-em/hex-dev/issues/8383.

Gates, before → after (all green, unchanged):

- Conformance (FLINT differential + invariants): 100/0 → 100/0
- FactorTrace counter gate: 50/0 → 50/0 (`factorHybridTraced` is unchanged)
- Wall-clock backstop (`hexbz_emit_fixtures`): 5.857s → 5.424s (< 180s)
- Bench verify: 18/18 → 18/18
- Whole `HexBerlekampZassenhausMathlib` library: green → green (only the pre-existing shipped sorries `isIrreducible_iff` and `factor_irreducible_of_nonUnit`)

Easy-regime `runFactorChecksum` timings (warm cache), before (cap-based three-tier) → after (hybrid): the hybrid is faster on every param and the easy-input blow-up is gone.

| n  | before    | after    |
|----|-----------|----------|
| 2  | 280.8 µs  | 178.6 µs |
| 4  | 888.6 µs  | 574.2 µs |
| 8  | 5.514 ms  | 4.019 ms |
| 12 | 15.71 ms  | 11.80 ms |
| 16 | 52.21 ms  | 37.14 ms |
| 18 | 99.10 ms  | 47.14 ms |
| 20 | 244.8 ms  | 65.08 ms |
| 22 | 781.8 ms  | 82.75 ms |

🤖 Prepared with Claude Code
