### PR TITLE
chore(release): advance sync baseline post-publish; upload baseline as artifact

### DIFF
--- a/.github/workflows/sync-released.yml
+++ b/.github/workflows/sync-released.yml
@@ -23,7 +23,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write   # to commit the advanced scripts/release/synced.json baseline
+  contents: read
 
 jobs:
   sync:
@@ -45,13 +45,20 @@ jobs:
           else
             python3 scripts/release/sync_released.py --dry-run
           fi
-      - name: Commit advanced baseline
+      # `main` is a protected branch, so the advanced baseline cannot be pushed
+      # from CI. After a real sync it is uploaded as an artifact; download it and
+      # commit `scripts/release/synced.json` via a normal PR to keep the guard
+      # accurate for the next run.
+      - name: Upload advanced baseline
         if: ${{ inputs.dry_run == false }}
         run: |
           if ! git diff --quiet -- scripts/release/synced.json; then
-            git config user.name "hex-dev sync"
-            git config user.email "noreply@anthropic.com"
-            git add scripts/release/synced.json
-            git commit -m "chore(release): advance sync baseline"
-            git push origin HEAD:main
+            echo "::notice::Baseline advanced — commit scripts/release/synced.json via a PR."
+            git --no-pager diff -- scripts/release/synced.json
           fi
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.dry_run == false }}
+        with:
+          name: advanced-sync-baseline
+          path: scripts/release/synced.json
+          if-no-files-found: ignore

--- a/scripts/release/synced.json
+++ b/scripts/release/synced.json
@@ -1,10 +1,10 @@
 {
-  "_comment": "Per-repo `main` HEAD that this monorepo's content corresponds to. The publish sync (sync_released.py) refuses to overwrite a released repo whose main has moved off this baseline (an uncoordinated commit), and updates the baseline after each push. Edit only via a re-seed or the sync itself.",
+  "_comment": "Per-repo `main` HEAD that this monorepo's content corresponds to. The publish sync (sync_released.py) refuses to overwrite a released repo whose main has moved off this baseline (an uncoordinated commit). After a real sync the workflow uploads the advanced baseline as an artifact; commit it via a normal PR (main is a protected branch).",
   "hex-test-kit": "597e6a3b68807ef0fdf23ba3f6ae31549124ce23",
-  "hex-matrix": "aa6f75c83e6464bbe58e01ce53d99eefb5d994bd",
-  "hex-matrix-mathlib": "9cc6d8689d12c2775f8e1016b946a3debe6a8c9f",
-  "hex-gram-schmidt": "3ce6d453934ca1bb5eb84ebd5e09b43e3d8ae4ce",
-  "hex-gram-schmidt-mathlib": "9e04dc003acbb73973b0aa728a437174534f0066",
-  "hex-lll": "79eb689115559c45edf7eb35ae809379243290a5",
-  "hex-lll-mathlib": "11b204b2c21c84ae93eb0b714bb81b085b6129ee"
+  "hex-matrix": "64db1edd0e35f9b22831f628942525a112812996",
+  "hex-matrix-mathlib": "3febf6e7b12e90a014c05da9d3a26482c28c9c7c",
+  "hex-gram-schmidt": "8f3b5b8cdb0ae24b777de59347c1fbdb82e4ef19",
+  "hex-gram-schmidt-mathlib": "d26c5a7baff35dca5f5b5774eeb2374ed66cb80b",
+  "hex-lll": "1c8956cf22ed2b854bd5b4dd42981080af995f4f",
+  "hex-lll-mathlib": "d85b942b96f0e80364cb8ad2a9b8a0235485bd12"
 }


### PR DESCRIPTION
The first live publish sync pushed the migrated content to all six released repos successfully (hex-test-kit was already current). The only failure was the workflow's final step committing the advanced baseline back to hex-dev, because `main` is a protected branch and CI cannot push to it.

This advances `scripts/release/synced.json` to the just-published released HEADs so the uncoordinated-commit guard stays accurate, and changes the sync workflow to upload the advanced baseline as an artifact (with a notice and diff) instead of pushing to protected `main`. After a real sync, download that artifact and commit the baseline via a normal PR.

🤖 Prepared with Claude Code