### PR TITLE
fix(release): rewrite Hex revs in lake-manifest.json, not just the lakefile pin

### DIFF
--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -149,6 +149,33 @@ def rewrite_pins(entry: dict, clone: Path, synced: dict[str, str]) -> list[str]:
     return notes
 
 
+def rewrite_manifest(entry: dict, clone: Path, synced: dict[str, str]) -> list[str]:
+    """Pin the synced SHAs in the committed lake-manifest.json too, so the
+    released repo's CI builds against the new revisions rather than the stale
+    lockfile (Lake trusts the manifest, not just the lakefile)."""
+    notes: list[str] = []
+    pins = entry.get("pins") or []
+    mf = clone / "lake-manifest.json"
+    if not pins or not mf.exists():
+        return notes
+    import json as _json
+    doc = _json.loads(mf.read_text(encoding="utf-8"))
+    by_url = {f"github.com/kim-em/{dep}.git": dep for dep in pins}
+    changed = 0
+    for pkg in doc.get("packages", []):
+        url = pkg.get("url", "")
+        for frag, dep in by_url.items():
+            if frag in url and synced.get(dep):
+                pkg["rev"] = synced[dep]
+                if "inputRev" in pkg and pkg["inputRev"] and len(pkg["inputRev"]) >= 7:
+                    pkg["inputRev"] = synced[dep]
+                changed += 1
+                notes.append(f"  manifest {dep} -> {synced[dep][:12]}")
+    if changed:
+        mf.write_text(_json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+    return notes
+
+
 def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
               synced: dict[str, str], baseline: dict[str, str], force: bool) -> bool:
     """Sync one repo. Returns True if the baseline SHA changed (a push happened)."""
@@ -173,6 +200,8 @@ def sync_repo(entry: dict, source_sha: str, token: str | None, dry_run: bool,
         for line in apply_paths(entry, clone):
             print(line)
         for line in rewrite_pins(entry, clone, synced):
+            print(line)
+        for line in rewrite_manifest(entry, clone, synced):
             print(line)
         status = run(["git", "status", "--porcelain"], cwd=clone, capture=True)
         if not status:


### PR DESCRIPTION
The first live publish sync left the downstream released repos failing their standalone CI: `hex-matrix` passed, but `hex-matrix-mathlib`, `hex-gram-schmidt`, `hex-lll`, and the rest built against the **old** hex-matrix and failed (`Unknown identifier Hex.Vector.unit`, the old `dotProduct`). The cause: the sync rewrote each repo's lakefile pin to the new revision but not its committed `lake-manifest.json` lockfile, and Lake trusts the manifest ("git revision of dependency 'HexMatrix' changed").

This pins the synced SHAs in `lake-manifest.json` (`rev` and `inputRev`) for every Hex dependency too, so re-running the sync makes each released repo build against the correct revisions. Verified by a dry run: every downstream repo's `lake-manifest.json` is updated to the freshly-synced Hex revs.

🤖 Prepared with Claude Code