### PR TITLE
doc: add module doc-strings to undocumented Matrix/GramSchmidt/LLL files

### DIFF
--- a/HexGramSchmidt/Basic/IntCast.lean
+++ b/HexGramSchmidt/Basic/IntCast.lean
@@ -11,6 +11,18 @@ import all HexGramSchmidt.Basic.Rat
 
 public section
 
+/-!
+Integer-cast layer of the Gram-Schmidt surface for `hex-gram-schmidt`.
+
+This module defines the rational-valued `basis` and `coeffs` of an integer
+input matrix (via `GramSchmidt.castIntMatrix`) and lifts the rational results
+of `HexGramSchmidt/Basic/Rat.lean` to the integer setting: the leading-row,
+orthogonality, triangular-decomposition, and prefix-span facts (`basis_zero`,
+`basis_orthogonal`, `basis_decomposition`, `coeffs_diag`, `coeffs_upper`,
+`basis_span`), together with the behaviour of `basis`/`coeffs` under the
+integer row operations `Matrix.rowAdd` and adjacent `Matrix.rowSwap` used by
+the LLL size-reduction and swap steps.
+-/
 namespace Hex
 namespace GramSchmidt.Int
 

--- a/HexGramSchmidt/Basic/Kernel.lean
+++ b/HexGramSchmidt/Basic/Kernel.lean
@@ -10,6 +10,20 @@ public import HexMatrix.RREF
 
 public section
 
+/-!
+Executable Gram-Schmidt orthogonalization kernel for `hex-gram-schmidt`.
+
+This module is the rational core that the rest of the library builds on. It
+defines the projection primitives (`projectionCoeff`, `subtractProjection`),
+the per-row reduction `reduceAgainstBasis`, the left-to-right orthogonalization
+`basisRows`/`basisMatrix`, the coefficient matrix `coeffMatrix`, and the
+supporting entry/prefix helpers (`entry`, `castIntMatrix`, `prefixCombination`,
+`prefixRows`, `prefixSpan`). It also proves the foundational facts the
+correspondence proofs consume: pairwise orthogonality of `basisRows`, the
+residual/projection reconstruction identity, the leading-row equation, and the
+zero-norm degeneracy lemmas (a `Rat` vector with zero self-dot-product is the
+zero vector).
+-/
 namespace Hex
 namespace GramSchmidt
 

--- a/HexGramSchmidt/Basic/Rat.lean
+++ b/HexGramSchmidt/Basic/Rat.lean
@@ -11,6 +11,21 @@ import all HexGramSchmidt.Basic.Linearity
 
 public section
 
+/-!
+Rational Gram-Schmidt API for `hex-gram-schmidt`.
+
+This module wraps the executable kernel into the rational-valued `basis` and
+`coeffs` of a `Matrix Rat n m` and proves their defining properties: the
+leading row is untouched (`basis_zero`), distinct basis rows are orthogonal
+(`basis_orthogonal`), the triangular factorization `b = coeffs · basis`
+(`basis_decomposition`), and the unit-diagonal / lower-triangular shape of
+`coeffs` (`coeffs_diag`, `coeffs_upper`, `coeffs_lower_projection`). It also
+tracks how `basis` and `coeffs` transform under `Matrix.rowAdd` and adjacent
+`Matrix.rowSwap` (the explicit re-orthogonalization formulas
+`basis_rowSwap_adjacent_prev`/`_curr` and the coefficient updates), and proves
+that orthogonalization preserves every row-prefix span (`basis_span`). These
+are the rational facts the integer-cast layer lifts.
+-/
 namespace Hex
 namespace GramSchmidt.Rat
 

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -12,6 +12,23 @@ public import HexMatrix.Determinant
 
 public section
 
+/-!
+Executable array/loop machinery for the integer scaled Gram-Schmidt pass in
+`hex-gram-schmidt`.
+
+This module defines the integer-determinant surface (`gramDet` and
+`independent`, the leading Gram matrices (`leadingGramMatrixInt`/`Rat`),
+`scaledCoeffMatrix`, lattice membership `memLattice`, and the no-pivot Bareiss
+determinant reader `gramDetVecEntry`) together with the mutable row-major array
+kernel that computes the scaled coefficients fraction-free. The kernel includes the
+nested-array storage (`gramRows`, `zeroRows`, `getArrayEntry`/`setArrayEntry`,
+`rowsToMatrix`), the Bareiss-style elimination sweep `stepScaledRows` and
+column-writer `writeScaledColumn`, the driver `scaledCoeffArrayLoop`, the two
+formulations `scaledCoeffRows` (reference) and `scaledCoeffRowsSchur` (live
+per-row Schur recurrence, with `schurSigma`/`schurScaledCoeffEntry`), and a
+large body of frame/size bookkeeping lemmas plus the per-step correspondence
+`rowsToMatrix_stepScaledRows_eq` between the array update and `Matrix.stepMatrix`.
+-/
 namespace Hex
 
 namespace GramSchmidt

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -11,6 +11,21 @@ import all HexGramSchmidt.Int.Invariant
 
 public section
 
+/-!
+Correspondence between the executable `scaledCoeffRows` pass and the
+matrix-level Gram-determinant API for `hex-gram-schmidt`.
+
+This module proves that the array-storage scaled-coefficient loop tracks the
+matrix-level no-pivot Bareiss pass entry for entry: the diagonal slots record
+the leading Gram determinants (`gramDetVecEntry_eq_gramDet`,
+`scaledCoeffRows_diag_toNat_eq_gramDet`) including the zero tail after an early
+singular step, and the lower-triangle slots capture the corresponding Bareiss
+target-column values. It exposes the determinant base case `gramDet_zero`, the
+lower-triangularity of the public matrix (`scaledCoeffs_upper`), and the
+lattice-norm helper `rowCombination_coeffs_apply_eq_of_zero_above` giving the
+top Gram-Schmidt coordinate of a row combination when the later integer
+coefficients vanish.
+-/
 namespace Hex
 namespace GramSchmidt.Int
 /-- Bareiss-side counterpart of the Schur `j = 0` boundary: at column `0`,

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -11,6 +11,21 @@ import all HexGramSchmidt.Int.Canonical
 
 public section
 
+/-!
+Bareiss row-invariant proofs for the no-pivot Gram pass in `hex-gram-schmidt`.
+
+This module establishes that the no-pivot Bareiss elimination over a Gram
+matrix carries the `BareissGramRowInvariant` row-coefficient invariant and
+that its coefficients stay canonical (matching `bareissGramCanonicalCoeff`),
+threading the `StepWitness`/`IsCanonicalAt` quotient gate through the
+recursion. It proves the supporting fraction-free divisibility and
+singular-step facts (exact divisibility of each Bareiss step, propagation of
+the first singular step, and that a singular leading Gram prefix forces the
+later leading determinants to zero), the integer dot-product degeneracy
+lemmas, and the row-combination expansion of inner products. It also supplies
+the `scaledCoeffArrayLoop` branch/size lemmas (singular, regular, last-step,
+done, and current-column-written) that the correspondence proofs unfold.
+-/
 namespace Hex
 namespace GramSchmidt.Int
 /-- Initial no-pivot Gram specialization indexed by elapsed fuel.  The regular

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -11,6 +11,24 @@ import all HexGramSchmidt.Int.Core
 
 public section
 
+/-!
+Scaled-coefficient and Gram-determinant surface for `hex-gram-schmidt`.
+
+This module packages the executable scaled Gram-Schmidt output: the `Data`
+record bundling the leading Gram determinant vector `d` with the scaled
+coefficient matrix `ν`, produced by `data` from a single
+`scaledCoeffRowsSchur` pass, and exposed as the public `gramDetVec` and
+`scaledCoeffs`. It proves the per-row Schur kernel agrees with the reference
+`scaledCoeffRows` formulation (`schurSigma_congr` and the column/boundary
+frame lemmas), and develops the Bareiss commutation infrastructure the
+determinant correspondence rests on: a `Matrix.stepMatrix` step commutes with
+taking a `leadingPrefix` and with taking a trailing `borderedMinor`
+(`leadingPrefix_stepMatrix_eq`, `borderedMinor_stepMatrix_eq`), the no-pivot
+loop stays synchronized across a matrix and its bordered minor
+(`noPivotLoop_full_eq_borderedMinor_at_trailing`), it preserves trailing-block
+symmetry, and its `step`/`singularStep` bookkeeping is monotone and stable
+under prefixing.
+-/
 namespace Hex
 namespace GramSchmidt.Int
 /-- σ-chain dependency frame lemma. The value of `schurSigma rows i j`

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -11,6 +11,23 @@ import all HexGramSchmidtMathlib.Int.GramDet
 
 public section
 
+/-!
+Mathlib-side determinantal identification of the canonical Bareiss
+Gram-Schmidt coefficients for `hex-gram-schmidt`.
+
+This module finishes the Cramer identity
+`scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`, expressing the scaled
+coefficient determinant as `gramDet (j+1) * coeffs[i][j]`.  Its second half
+introduces the augmented `(n+1) × (n+1)` matrix `augmentedGram`, whose upper
+block is `gramMatrix b` and whose trailing column carries a standard basis
+vector, and proves `noPivotLoop_augmentedGram_invariant`: the no-pivot Bareiss
+pass on the augmented matrix mirrors the pass on `gramMatrix b` while its
+trailing column tracks `bareissGramCanonicalCoeff`.  This yields
+`bareissGramCanonicalCoeff_eq_augmentedGram_entry` and its bordered-minor
+form, identifying the canonical row coefficients with a Bareiss minor
+determinant.
+-/
+
 namespace Hex
 namespace GramSchmidt
 namespace Int

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -11,6 +11,21 @@ public import HexMatrixMathlib.Determinant
 
 public section
 
+/-!
+Mathlib-side determinantal theory for the integer Gram-Schmidt surface of
+`hex-gram-schmidt`.
+
+This module relates the executable leading integer Gram determinant `gramDet`
+to products of squared norms of the orthogonal Gram-Schmidt basis rows.  Its
+spine is a rational column-operation reduction from `leadingGramMatrixInt`
+(via the interpolating `progressMatrix`, the triangular `auxMatrix`, and the
+`Int → Rat` cast law `det_intCast`) to the diagonal norm-squared matrix,
+giving `gramDet_succ_rat` and `leadingGramMatrixInt_det_nonneg`.  Along the
+way it builds the Cramer machinery (`scaledCoeffMatrix` solved through the
+chosen `originalProjectionCoords`) that the sibling module uses to read off
+the Gram-Schmidt coefficients `coeffs`.
+-/
+
 namespace Hex
 namespace GramSchmidt
 namespace Int

--- a/HexLLL/ProviderProbe.lean
+++ b/HexLLL/ProviderProbe.lean
@@ -10,6 +10,17 @@ public import HexLLL.Basic
 
 public section
 
+/-!
+Executable probe entry point for the `hex-lll` external reduction provider.
+
+This module defines a small `main` driver that checks the optional native LLL
+provider against an expected `absent`/`present` state.  It compares
+`LLLProvider.providerAvailable` to the argument, and when the provider is
+expected to be absent it additionally confirms that `LLLProvider.providerReduce`
+reports `.error` rather than succeeding.  The driver returns process exit codes
+(`0` on agreement, `1`/`2` on mismatch or misuse) for use as a CI check.
+-/
+
 namespace Hex
 namespace LLLProviderProbe
 

--- a/HexMatrix/Determinant/CauchyBinet.lean
+++ b/HexMatrix/Determinant/CauchyBinet.lean
@@ -12,6 +12,21 @@ import all HexMatrix.Determinant.ColumnLinear
 
 public section
 
+/-!
+Ordered column-tuple expansion underlying Cauchy-Binet for `hex-matrix`.
+
+This module expands the determinant of a column-sum matrix as a finite sum
+over all ordered column tuples drawn from `Fin m`. It defines the
+column-selected minor `columnTupleMatrix`, its product coefficient
+`columnTupleCoeff`, the tuple enumerator `columnTupleVectors`, and proves the
+summands of repeated columns vanish. The headline results are
+`det_columnSumMatrix_eq_sum_columnTuples` (the Mathlib-free multilinearity
+form) and `det_gramMatrix_eq_sum_columnTuples`, which specializes it to a row
+Gram matrix. The bulk of the file is a suffix-based partial-assignment
+recursion (`columnSumMatrixWithSuffix`) aligning the iteration with
+`columnTupleVectors`.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/ColumnLinear.lean
+++ b/HexMatrix/Determinant/ColumnLinear.lean
@@ -11,6 +11,20 @@ import all HexMatrix.Determinant.Permutation
 
 public section
 
+/-!
+Determinant column linearity for `hex-matrix`.
+
+This module proves that `det` is multilinear in a single replaced column.
+Working from the per-permutation product `detProduct` and signed term
+`detTerm`, it establishes the additive `det_setCol_add`, the scalar
+`det_setCol_smul`, and the finite-list/`Fin m` aggregated forms
+`det_setCol_sum_list` and `det_setCol_sum_finRange`. It also collects the
+duplicate-column/row vanishing lemmas (`det_eq_zero_of_col_eq`,
+`det_eq_zero_of_row_eq`) and `det_setCol_add_otherCols` (column operations
+preserve the determinant), plus the `columnSumMatrix` builder and the Fubini
+sum-swap `foldl_det_sum_swap` used by the Cauchy-Binet expansion.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Enumeration.lean
+++ b/HexMatrix/Determinant/Enumeration.lean
@@ -12,6 +12,21 @@ public import HexMatrix.Vector.Insert
 
 public section
 
+/-!
+Permutation enumeration and inversion-parity arithmetic for the local
+Leibniz determinant.
+
+This module defines `permutationVectors`, the recursive enumeration of the
+permutations of `Fin n` as length-`n` vectors, together with `inversionCount`,
+which counts the inversions of a permutation written as a list. The bulk of the
+file establishes how inversion count behaves under list concatenation and under
+swaps: `inversionCount_append` splits a concatenation into the inversions of
+each part plus the cross-inversions (`crossInversionCount`), and
+`inversionCount_adjacent_swap_parity` / `inversionCount_swap_separated_parity`
+show that swapping two distinct entries flips inversion parity. These parity
+facts underpin the sign computations used by the determinant.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Index.lean
+++ b/HexMatrix/Determinant/Index.lean
@@ -13,6 +13,23 @@ import all HexMatrix.Determinant.Enumeration
 
 public section
 
+/-!
+Index-manipulation lemmas and triangular-determinant corollaries.
+
+This module supplies the index plumbing that lets the Leibniz determinant
+recurse on the final row and column. `raiseFinAbove`, `lowerFinLast`, and
+`peelLastVector` move between `Fin n` and `Fin (n + 1)` while inserting or
+removing `Fin.last n`, and the surrounding lemmas prove that
+`permutationVectors` is complete (`permutationVectors_complete`) and
+duplicate-free (`permutationVectors_nodup`, `permutationVectors_nodup_list`).
+Building on these, it derives the determinant's behaviour on the
+`insertAt`-extended permutation (`detTerm_insertAt_general`,
+`detSign_insertAt_general`), the last-row factorisation
+`det_eq_det_leadingPrefix_mul_last_of_last_row_zero`, and the triangular
+results `det_upperTriangular_eq_finFoldl_diag`,
+`det_upperTriangular_eq_foldl_diag`, and `det_upperTriangular_pos_diag`.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Laplace.lean
+++ b/HexMatrix/Determinant/Laplace.lean
@@ -11,6 +11,19 @@ import all HexMatrix.Determinant.ColumnLinear
 
 public section
 
+/-!
+Laplace (cofactor) expansion of the determinant.
+
+This module proves that `det` expands as a signed sum of `M[·][·] * cofactor`
+along any fixed row or column. `det_eq_foldl_laplace_last` and
+`det_eq_foldl_laplace_last_row` handle the final column and final row, and
+`det_eq_foldl_laplace_col` / `det_eq_foldl_laplace_row` generalize to an
+arbitrary column or row. The general case is reduced to the last-column case by
+the column-move permutation `moveColumnToLastValues`, whose sign
+`(-1) ^ (n - col.val)` is computed via the inversion-count machinery and
+cancelled against the cofactor sign through `cofactorSign_col_eq`.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Leibniz.lean
+++ b/HexMatrix/Determinant/Leibniz.lean
@@ -17,6 +17,20 @@ public import HexMatrix.Submatrix
 
 public section
 
+/-!
+Core Leibniz-formula definitions for the dense determinant.
+
+This module defines the determinant `det` of a dense square matrix as the
+`permutationVectors`-indexed sum of signed Leibniz terms, built from `detSign`
+(the inversion-parity sign of a permutation vector), `detProduct` (the unsigned
+diagonal product), and `detTerm` (their product). It records the small base
+cases `det_one_by_one`, `det_two_by_two`, and `det_leadingPrefix_zero`, and
+provides the reusable `foldl`-arithmetic toolkit (scalar factoring, additive
+splitting, permutation invariance, single-index scaling) plus the
+`Fin.castSucc`/`Fin.last` inversion-count lemmas used by the recursive
+determinant proofs in the sibling modules.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Minor.lean
+++ b/HexMatrix/Determinant/Minor.lean
@@ -10,6 +10,19 @@ public import HexMatrix.Determinant.Leibniz
 
 public section
 
+/-!
+Minors, deleted row/column submatrices, and signed cofactors.
+
+This module defines `skipIndex`, the embedding of `Fin n` into `Fin (n + 1)`
+that skips a deleted index, and uses it to build `deleteRowCol`, the
+`(n + 1) × (n + 1)` minor obtained by removing one row and one column. It then
+introduces the alternating `cofactorSign` and the signed `cofactor`, with the
+`simp`/`grind` characterizations of their values by parity. Key normalizations
+include `deleteRowCol_last_last` and `cofactor_last_last` (bottom-right minor is
+the leading prefix) and `deleteRowCol_transpose`, the transpose-compatibility
+used by row/column cofactor expansion.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/Determinant/Permutation.lean
+++ b/HexMatrix/Determinant/Permutation.lean
@@ -11,6 +11,22 @@ import all HexMatrix.Determinant.Index
 
 public section
 
+/-!
+Permutation-group structure on permutation vectors and the multiplicative
+determinant laws.
+
+This module develops the operations on permutation vectors needed to prove the
+determinant's reaction to elementary row and column operations: `finTranspose`
+and `transposePermutationValues`/`swapPermutationValues` (position and value
+swaps), `inversePermutationVector`, and `composePermutationValues`. It shows
+these preserve membership in `permutationVectors` and tracks their effect on
+inversion parity, culminating in `detSign_swapPermutationValues` and the
+multiplicativity law `detSign_composePermutationValues`. These feed the headline
+determinant theorems `det_one`, `det_rowSwap`, `det_rowScale`, `det_rowAdd`,
+`det_transpose`, `cofactor_transpose`, `det_colPermute_vector`, `det_colSwap`,
+`det_colAdd`, and the lower-triangular diagonal-product formulas.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/RREF/Echelon.lean
+++ b/HexMatrix/RREF/Echelon.lean
@@ -11,6 +11,20 @@ import all HexMatrix.RREF.Loop
 
 public section
 
+/-!
+Echelon/RREF span and nullspace APIs for `hex-matrix`.
+
+This module hangs the row-span and nullspace correctness theory off the
+`IsEchelonForm` and `IsRREF` contracts. The `IsEchelonForm` section transports
+row combinations across the echelon transform and builds the decidable
+row-span tests `spanCoeffs`/`spanContains` with their soundness lemmas. The
+`IsRREF` section proves these tests complete (`spanContains_iff`), constructs
+the nullspace basis (`nullspaceMatrix`, `nullspace`) from the free columns,
+and shows it is both sound (`nullspace_sound`) and complete
+(`nullspace_complete`). The file closes with the public `rref`-backed wrappers
+`spanCoeffs`, `spanContains`, `nullspaceBasisMatrix`, and `nullspace`.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/RREF/Loop.lean
+++ b/HexMatrix/RREF/Loop.lean
@@ -11,6 +11,21 @@ import all HexMatrix.RREF.Pivot
 
 public section
 
+/-!
+Correctness of the Gauss-Jordan `rrefLoop` for `hex-matrix`.
+
+This module runs `rrefLoop` to a finished `rref` and proves it meets the
+`IsRREF` contract. It tracks the loop's proof-only invariants through each
+pivot step: the shape invariant (`rrefLoop_shape`), the canonical-column
+invariant (`rrefLoop_canonical`), the no-pivot-zero invariant
+(`rrefLoop_no_pivot_zero`), the same-operation transform equation
+(`rrefLoop_transform_preserve`), and existence of left/right inverses for the
+transform, then specializes each to the full run. The headline `def rref`
+packages the result, with `rref_isRREF` assembling the
+`IsEchelonForm`/`IsRREF` fields and `rref_transform_mul`, `rref_rank_le_n`,
+`rref_pivotCols_sorted` exposing the wrapper-level projections.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrix/RREF/Pivot.lean
+++ b/HexMatrix/RREF/Pivot.lean
@@ -12,6 +12,21 @@ public import HexMatrix.RowEchelon
 
 public section
 
+/-!
+Pivot search and column elimination for the `hex-matrix` RREF loop.
+
+This module supplies the executable building blocks of Gauss-Jordan
+elimination and their entrywise lemmas. It defines `rowCombination`, the
+`RrefState` carrier, the pivot search `findPivot?` (with the `_some_ge`,
+`_some_nonzero`, `_some_above`, `_none` characterizations) and the
+column-clearing `eliminateColumn`, proving the latter zeros non-pivot rows,
+fixes the pivot row, leaves other columns untouched, and preserves both the
+transform equation and the transform's left/right inverses. It assembles the
+`rrefLoop` driver itself together with the proof-only `RrefShapeInvariant`,
+`RrefCanonicalInvariant` structures and their one-step `concat` extension
+lemmas, which `RREF/Loop` then carries through the recursion.
+-/
+
 namespace Hex
 universe u
 namespace Matrix

--- a/HexMatrixMathlib/Determinant/CorePlucker.lean
+++ b/HexMatrixMathlib/Determinant/CorePlucker.lean
@@ -11,6 +11,20 @@ import all HexMatrixMathlib.Determinant.CoreTransport
 
 public section
 
+/-!
+Mathlib-side Grassmann-Plucker identity for the executable `Hex.Matrix` minors.
+
+This module assembles the three-term Plucker relation among the ordered
+`nDet` minors of a tall matrix `B`.  Starting from the two-row replacement
+adjugate identity, it transports the double `setRow` matrix to the signed
+`nDet B p2 p3` minor via the disjoint-cycle permutation
+`cycleAhead * cycleBehind`, proving `det_double_setRow_eq_pow_mul_nDet` and the
+signed `ordered_four_signed_Plucker_p1_side`.  These combine into the raw
+kernel `det_plucker_three_term_nDet_of_ordered_four` and, after a case split on
+the position of a basis-vector row `q`, the arbitrary-row form
+`det_plucker_three_term_basisVec_of_ne` (with its diagonal `q = p_t` cases).
+-/
+
 namespace HexMatrixMathlib
 universe u v
 variable {R : Type u} {n : Nat}

--- a/HexMatrixMathlib/Determinant/CoreTransport.lean
+++ b/HexMatrixMathlib/Determinant/CoreTransport.lean
@@ -15,6 +15,21 @@ public import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 
 public section
 
+/-!
+Core determinant correspondence between executable `Hex.Matrix` and Mathlib.
+
+This module proves the central bridge lemma `det_eq`: the executable
+Leibniz determinant `Hex.Matrix.det` equals `Matrix.det` of the corresponding
+Mathlib matrix `matrixEquiv M`.  It first matches Hex permutation vectors to
+Mathlib `Equiv.Perm` (`PermutationVector.toPerm`, `equivs`) and the
+inversion-count sign to `Equiv.Perm.sign` (`detSign_eq_permSign`).  Building on
+`det_eq`, it translates `matrixEquiv` of leading prefixes, bordered minors,
+deleted rows/columns, and row updates, and ports the Desnanot-Jacobi and
+adjugate row-replacement identities (`desnanot_jacobi_deleteRowCol_endpoints`,
+`det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub`) into the Hex API,
+plus the ordered `nMatrix`/`skipIndex2` row-transport helpers used downstream.
+-/
+
 namespace HexMatrixMathlib
 universe u v
 variable {R : Type u} {n : Nat}


### PR DESCRIPTION
This PR adds a top-of-file module doc-string to the 23 Lean files across `HexMatrix`, `HexGramSchmidt`, `HexLLL` and their `*Mathlib` bridge layers that lacked one, so every file in these libraries now opens with a concise description of its contents. Each doc-string names the file's key definitions and theorems and its role in the library, and is placed immediately after `public section` to match the existing convention. The remaining files in these libraries already had module doc-strings and are untouched.

All six libraries build green.

🤖 Prepared with Claude Code