### PR TITLE
chore: register the six split matrix libraries in the publish tooling

### DIFF
--- a/progress/20260629T022849Z.md
+++ b/progress/20260629T022849Z.md
@@ -1,0 +1,49 @@
+# Register the six split libraries in the release tooling (PR4)
+
+## Accomplished
+
+Register the six libraries split from HexMatrix/HexMatrixMathlib as part of the
+released set in `scripts/release/released.yml`:
+
+- Three computational repos: `hex-row-reduce`, `hex-determinant`, `hex-bareiss`.
+- Three Mathlib bridges: `hex-row-reduce-mathlib`, `hex-determinant-mathlib`,
+  `hex-bareiss-mathlib`.
+
+Each entry is placed in topological order (every `pins:` entry references a
+repo declared earlier) with its bench/conformance/fixtures/oracles flags set to
+match the PR2 partition: the determinant oracle `matrix_flint.py` (+`common.py`)
+goes to the three computational repos that own a conformance stream, the FLINT
+bench driver to `hex-bareiss`, and the now-oracle-free `hex-matrix` base drops
+its fixtures/oracles. Downstream `pins` (`hex-gram-schmidt(-mathlib)`,
+`hex-lll(-mathlib)`) are widened to their full transitive Hex closures so the
+sync keeps every cross-repo rev current.
+
+`synced.json` is intentionally **unchanged**: a repo absent from the baseline
+has no uncoordinated-commit guard, so the first real sync publishes the new
+repos and advances the baseline (Codex's recommendation — no placeholder SHAs).
+
+`scripts/release/BOOTSTRAP.md` documents creating and seeding the six repos
+before their first publish, and the dry-run-then-real `workflow_dispatch`.
+
+Validated: `released.yml` parses, is topologically ordered, and every `lib`
+cross-checks against a `lean_lib` in the lakefile.
+
+## Current frontier
+
+The monorepo is publish-ready for the full thirteen-repo matrix family. The
+remaining steps are operational (outward-facing) and intentionally left for a
+gated run, per BOOTSTRAP.md:
+
+## Next step
+
+1. Create the six GitHub repos and author their skeletons (modelled on
+   `hex-gram-schmidt` / `hex-matrix-mathlib`).
+2. Dispatch `sync-released.yml` dry-run, confirm, then real.
+3. Update the released-set list in the top-level `.claude/CLAUDE.md` (Kim's file;
+   off-limits to agents).
+
+## Blockers
+
+None. Branch `split-hexmatrix-release` (stacked on `split-hexmatrix-mathlib` /
+PR #8420) in the /tmp clone. Repo creation + sync deferred to a deliberate,
+dry-run-gated publish run.

--- a/scripts/release/BOOTSTRAP.md
+++ b/scripts/release/BOOTSTRAP.md
@@ -1,0 +1,72 @@
+# Bootstrapping new released repos
+
+`scripts/release/released.yml` lists every repo the publish sync
+(`sync_released.py`, driven by `.github/workflows/sync-released.yml`)
+regenerates from this monorepo. The sync **clones each repo's `main`**, overwrites
+its *managed* paths, rewrites its cross-repo Hex pins, and pushes. It does **not**
+create repos and does **not** author their non-managed skeleton (root lakefile,
+`lean-toolchain`, `lake-manifest.json`, LICENSE, README, CI). A new repo must be
+bootstrapped with that skeleton **before** its first sync.
+
+`synced.json` is deliberately **not** seeded for new repos: a repo absent from the
+baseline has no uncoordinated-commit guard, so the first real sync publishes it and
+advances the baseline (committed to the `release-sync-baseline` branch). Never seed
+a placeholder/zero SHA — any truthy baseline that differs from the cloned `main`
+HEAD makes the sync skip the repo.
+
+## The six repos added for the HexMatrix split
+
+Computational (Mathlib-free), then their Mathlib bridges:
+
+| repo | lib | direct upstream `require`s | lakefile |
+|---|---|---|---|
+| `hex-row-reduce` | `HexRowReduce` | `hex-matrix`, batteries | toml |
+| `hex-determinant` | `HexDeterminant` | `hex-matrix`, batteries | toml |
+| `hex-bareiss` | `HexBareiss` | `hex-determinant`, batteries | toml |
+| `hex-row-reduce-mathlib` | `HexRowReduceMathlib` | `hex-row-reduce`, `hex-matrix-mathlib`, mathlib | toml |
+| `hex-determinant-mathlib` | `HexDeterminantMathlib` | `hex-determinant`, `hex-bareiss`, `hex-matrix-mathlib`, mathlib | toml |
+| `hex-bareiss-mathlib` | `HexBareissMathlib` | `hex-determinant-mathlib`, mathlib | toml |
+
+`require`s list only **direct** dependencies; Lake pulls the rest transitively.
+The full transitive Hex closure that the sync keeps pinned is the `pins:` list for
+each repo in `released.yml`.
+
+## Procedure (per repo)
+
+Model the skeleton on the closest existing released repo: `hex-gram-schmidt` for a
+computational lib that pins an upstream Hex repo, `hex-matrix-mathlib` for a
+Mathlib bridge.
+
+1. `gh repo create kim-em/<repo> --public`
+2. Author the skeleton on `main`:
+   - `lean-toolchain` — copy from `hex-matrix` (`leanprover/lean4:v4.30.0-rc2`).
+   - `lakefile.toml` — `name`, `defaultTargets = ["<Lib>"]`, a `[[require]]` per
+     direct upstream (batteries and/or mathlib, plus each upstream Hex repo by its
+     `github.com/kim-em/<repo>.git` URL), and `[[lean_lib]] name = "<Lib>"`.
+   - `lake-manifest.json` — for a **computational** repo, copy `hex-gram-schmidt`'s
+     (two packages) and adjust the Hex entries. For a **Mathlib bridge**, copy
+     `hex-matrix-mathlib`'s manifest verbatim (the mathlib transitive closure is
+     identical at this toolchain) and add/adjust the Hex package entries. The Hex
+     revs are placeholders here — the sync rewrites them on first publish.
+   - LICENSE, README.md, AGENTS.md, `.gitignore`, `.github/` CI, `.claude/` — copy
+     from the closest existing released repo.
+   - The bench/conformance sub-project lakefiles, if `bench`/`conformance` is true
+     for the repo in `released.yml`, mirroring the matching sub-project skeleton.
+3. Commit and push `main` (the skeleton does not build standalone until its
+   upstream Hex repos have been published — that is expected).
+
+## First publish
+
+Once all six repos exist with `main`:
+
+1. Ensure this monorepo is at or ahead of every released repo's `main`.
+2. Dispatch `.github/workflows/sync-released.yml` with `dry_run=true`; confirm the
+   planned managed-path writes and pin rewrites for all thirteen repos, with no
+   uncoordinated-commit skips.
+3. Dispatch again with `dry_run=false`. The topological order in `released.yml`
+   guarantees each upstream is published (and its new SHA known) before its
+   downstream consumers are pinned. The run advances the baseline on the
+   `release-sync-baseline` branch.
+
+Finally, update the released-set list in the top-level `.claude/CLAUDE.md` to name
+the six new repos.

--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -39,11 +39,44 @@ repos:
     lib: HexMatrix
     umbrella: true
     spec: hex-matrix
-    bench: true
-    conformance: true
-    fixtures: [HexMatrix]
-    oracles: [matrix_flint.py, common.py, flint_bench_driver.py]
+    bench: true                # dense multiplication
+    conformance: true          # oracle-free base #guard module
+    fixtures: []
+    oracles: []
     pins: []
+    lakefile: toml
+
+  - repo: kim-em/hex-row-reduce
+    lib: HexRowReduce
+    umbrella: true
+    spec: hex-row-reduce
+    bench: false
+    conformance: true
+    fixtures: [HexRowReduce]
+    oracles: [matrix_flint.py, common.py]
+    pins: [hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-determinant
+    lib: HexDeterminant
+    umbrella: true
+    spec: hex-determinant
+    bench: true                # Leibniz determinant
+    conformance: true
+    fixtures: [HexDeterminant]
+    oracles: [matrix_flint.py, common.py]
+    pins: [hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-bareiss
+    lib: HexBareiss
+    umbrella: true
+    spec: hex-bareiss
+    bench: true                # Bareiss determinant + FLINT comparator
+    conformance: true
+    fixtures: [HexBareiss]
+    oracles: [matrix_flint.py, common.py, flint_bench_driver.py]
+    pins: [hex-determinant, hex-matrix]
     lakefile: toml
 
   - repo: kim-em/hex-matrix-mathlib
@@ -57,6 +90,39 @@ repos:
     pins: [hex-matrix]
     lakefile: toml
 
+  - repo: kim-em/hex-row-reduce-mathlib
+    lib: HexRowReduceMathlib
+    umbrella: true
+    spec: hex-row-reduce-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-row-reduce, hex-matrix-mathlib, hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-determinant-mathlib
+    lib: HexDeterminantMathlib
+    umbrella: true
+    spec: hex-determinant-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-matrix]
+    lakefile: toml
+
+  - repo: kim-em/hex-bareiss-mathlib
+    lib: HexBareissMathlib
+    umbrella: true
+    spec: hex-bareiss-mathlib
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: [hex-determinant-mathlib, hex-determinant, hex-bareiss, hex-matrix-mathlib, hex-matrix]
+    lakefile: toml
+
   - repo: kim-em/hex-gram-schmidt
     lib: HexGramSchmidt
     umbrella: true
@@ -65,7 +131,7 @@ repos:
     conformance: true
     fixtures: [HexGramSchmidt]
     oracles: [gs_flint.py, common.py]
-    pins: [hex-matrix]
+    pins: [hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: toml
 
   - repo: kim-em/hex-gram-schmidt-mathlib
@@ -76,7 +142,7 @@ repos:
     conformance: false
     fixtures: []
     oracles: []
-    pins: [hex-gram-schmidt, hex-matrix-mathlib, hex-matrix]
+    pins: [hex-gram-schmidt, hex-bareiss-mathlib, hex-determinant-mathlib, hex-matrix-mathlib, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: toml
 
   - repo: kim-em/hex-lll
@@ -88,7 +154,7 @@ repos:
     conformance: true
     fixtures: [HexLLL]
     oracles: [lll_fpylll.py, lll_fpylll_bench_driver.py, common.py, __init__.py, setup_fplll_ffi.sh, setup_lll_isabelle.sh, patches]
-    pins: [hex-matrix, hex-gram-schmidt]
+    pins: [hex-gram-schmidt, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: lean
 
   - repo: kim-em/hex-lll-mathlib
@@ -99,5 +165,5 @@ repos:
     conformance: false
     fixtures: []
     oracles: []
-    pins: [hex-lll, hex-gram-schmidt-mathlib, hex-matrix-mathlib, hex-gram-schmidt, hex-matrix]
+    pins: [hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-matrix-mathlib, hex-gram-schmidt, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
     lakefile: toml


### PR DESCRIPTION
This PR registers the six libraries split from `HexMatrix` / `HexMatrixMathlib` as part of the released set, so the monorepo can publish the full thirteen-repo matrix family. It stacks on https://github.com/kim-em/hex-dev/pull/8420 (base branch `split-hexmatrix-mathlib`).

It adds entries to `scripts/release/released.yml` for the computational repos `hex-row-reduce`, `hex-determinant`, `hex-bareiss` and the Mathlib bridges `hex-row-reduce-mathlib`, `hex-determinant-mathlib`, `hex-bareiss-mathlib`, each in topological order so every `pins:` entry references a repo declared earlier. The bench/conformance/fixtures/oracles flags follow the operation-family partition: the determinant oracle `matrix_flint.py` (with `common.py`) goes to the three computational conformance repos, the FLINT bench driver to `hex-bareiss`, and the now-oracle-free `hex-matrix` base drops its fixtures and oracles. The downstream `hex-gram-schmidt(-mathlib)` and `hex-lll(-mathlib)` pins are widened to their full transitive Hex closures so the sync keeps every cross-repo revision current.

`synced.json` is intentionally left unchanged: a repo absent from the baseline has no uncoordinated-commit guard, so the first real sync publishes the new repos and advances the baseline. This follows the review recommendation to avoid placeholder baseline SHAs (any truthy baseline that differs from the cloned `main` HEAD makes the sync skip the repo).

`scripts/release/BOOTSTRAP.md` documents creating and seeding the six repos before their first publish, and the dry-run-then-real `workflow_dispatch`.

Validated that `released.yml` parses, is topologically ordered, and every `lib` maps to a `lean_lib` in the lakefile. Creating the six GitHub repos and running the publish sync are deliberate, dry-run-gated operations left for a separate publish run per `BOOTSTRAP.md`; the released-set list in the top-level `.claude/CLAUDE.md` still needs updating by hand.

🤖 Prepared with Claude Code