### PR TITLE
refactor: drop the Batteries dependency from the Mathlib-free libraries

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5026,7 +5026,6 @@ def bhksRowsArrayToMatrix {m : Nat} (n : Nat) (rows : Array (Vector Int m)) :
   Matrix.ofFn fun i j => (rows.getD i.val (Vector.ofFn fun _ => 0))[j]
 
 set_option linter.unnecessarySimpa false in
-set_option linter.unreachableTactic false in
 theorem bhksRowsArrayToMatrix_row {m n : Nat} (rows : Array (Vector Int m))
     (i : Fin n) :
     Matrix.row (bhksRowsArrayToMatrix n rows) i =
@@ -5039,7 +5038,6 @@ theorem bhksRowsArrayToMatrix_row {m n : Nat} (rows : Array (Vector Int m))
       rfl)
 
 set_option linter.unnecessarySimpa false in
-set_option linter.unreachableTactic false in
 theorem bhksRowsArrayToMatrix_toArray {m n : Nat} (B : Matrix Int n m) :
     bhksRowsArrayToMatrix n B.toArray = B := by
   apply Vector.ext

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -755,7 +755,8 @@ private theorem partialColumnTupleCoeff_full
     partialColumnTupleCoeff coeff chosen pref = 1 := by
   subst n
   unfold partialColumnTupleCoeff
-  have hlist : List.finRange (chosen.length - chosen.length) = [] := by simp
+  have hlist : List.finRange (chosen.length - chosen.length) = [] := by
+    rw [Nat.sub_self]; rfl
   rw [hlist]
   rfl
 

--- a/HexDeterminant/Enumeration.lean
+++ b/HexDeterminant/Enumeration.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import Init.Grind.Ring.Field
-public import Batteries.Data.List.Lemmas
 public import HexMatrix.Vector.Insert
 
 public section

--- a/HexDeterminant/Index.lean
+++ b/HexDeterminant/Index.lean
@@ -269,14 +269,13 @@ private theorem fin_mem_of_full_nodup_for_count {n : Nat} {xs : List (Fin n)}
   by_cases hmem : x ∈ xs
   · exact hmem
   · exfalso
-    have hsub : List.Subperm xs ((List.finRange n).erase x) := by
-      apply List.subperm_of_subset hnodup
+    have hsubset : xs ⊆ (List.finRange n).erase x := by
       intro y hy
-      exact (List.mem_erase_of_ne (by
-        intro hyx
-        exact hmem (hyx ▸ hy))).2 (List.mem_finRange y)
+      refine (List.mem_erase_of_ne ?_).2 (List.mem_finRange y)
+      rintro rfl
+      exact hmem hy
     have hle : xs.length ≤ ((List.finRange n).erase x).length :=
-      List.Subperm.length_le hsub
+      List.nodup_subset_length_le hnodup hsubset
     have herase : ((List.finRange n).erase x).length = n - 1 := by
       rw [List.length_erase]
       simp [List.mem_finRange, List.length_finRange]
@@ -713,7 +712,7 @@ theorem detProduct_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     detProduct M (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
       detProduct (leadingPrefix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n] := by
   unfold detProduct
-  rw [← Fin.foldl_eq_foldl_finRange, ← Fin.foldl_eq_foldl_finRange]
+  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
   have hfold :
       Fin.foldl n
@@ -925,14 +924,14 @@ private theorem foldl_detTerm_last_row_insertions
           acc + detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
       z + detSign (R := R) v *
         (detProduct (leadingPrefix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
-  rw [← Fin.foldl_eq_foldl_finRange]
+  rw [← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
   have hprefix :
       Fin.foldl n
           (fun acc i =>
             acc + detTerm M
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z = z := by
-    rw [Fin.foldl_eq_foldl_finRange]
+    rw [Fin.foldl_eq_finRange_foldl]
     calc
       (List.finRange n).foldl
           (fun acc i =>
@@ -1099,7 +1098,7 @@ theorem det_upperTriangular_eq_finFoldl_diag
           Fin.foldl n
               (fun acc i => acc * (leadingPrefix M n (Nat.le_succ n))[i][i]) 1 =
             Fin.foldl n (fun acc i => acc * M[i.castSucc][i.castSucc]) 1 := by
-        rw [Fin.foldl_eq_foldl_finRange, Fin.foldl_eq_foldl_finRange]
+        rw [Fin.foldl_eq_finRange_foldl, Fin.foldl_eq_finRange_foldl]
         apply foldl_acc_congr
         intro acc i _hmem
         have hentry : (leadingPrefix M n (Nat.le_succ n))[i][i] = M[i.castSucc][i.castSucc] :=
@@ -1114,7 +1113,7 @@ theorem det_upperTriangular_eq_foldl_diag
     (hzero : ∀ i j : Fin n, j.val < i.val → M[i][j] = 0) :
     det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
   rw [det_upperTriangular_eq_finFoldl_diag M hzero]
-  rw [Fin.foldl_eq_foldl_finRange]
+  rw [Fin.foldl_eq_finRange_foldl]
 
 private theorem detTerm_identity_insertAt_last {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) :
@@ -1131,14 +1130,14 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
           acc + detTerm (1 : Matrix R (n + 1) (n + 1))
             (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
       z + detTerm (1 : Matrix R n n) v := by
-  rw [← Fin.foldl_eq_foldl_finRange]
+  rw [← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
   have hprefix :
       Fin.foldl n
           (fun acc i =>
             acc + detTerm (1 : Matrix R (n + 1) (n + 1))
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z = z := by
-    rw [Fin.foldl_eq_foldl_finRange]
+    rw [Fin.foldl_eq_finRange_foldl]
     calc
       (List.finRange n).foldl
           (fun acc i =>

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -8,11 +8,6 @@ module
 
 public import Std
 public import Init.Grind.Ring.Field
-public import Batteries.Data.Fin.Fold
-public import Batteries.Data.List.Lemmas
-public import Batteries.Data.List.Pairwise
-public import Batteries.Data.List.Perm
-public import Batteries.Data.Vector.Lemmas
 public import HexDeterminant.Enumeration
 public import HexMatrix.Elementary
 public import HexMatrix.DotProduct
@@ -603,7 +598,7 @@ private theorem detProduct_identity_insertAt_last {R : Type u}
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
     detProduct (1 : Matrix R n n) v := by
   unfold detProduct
-  rw [← Fin.foldl_eq_foldl_finRange, ← Fin.foldl_eq_foldl_finRange]
+  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
   have hfold :
       Fin.foldl n
@@ -821,14 +816,13 @@ private theorem finLast_mem {n : Nat} {xs : List (Fin (n + 1))}
   by_cases hmem : Fin.last n ∈ xs
   · exact hmem
   · exfalso
-    have hsub : List.Subperm xs ((List.finRange (n + 1)).erase (Fin.last n)) := by
-      apply List.subperm_of_subset hnodup
+    have hsubset : xs ⊆ (List.finRange (n + 1)).erase (Fin.last n) := by
       intro x hx
-      exact (List.mem_erase_of_ne (by
-        intro hxlast
-        exact hmem (hxlast ▸ hx))).2 (List.mem_finRange x)
+      refine (List.mem_erase_of_ne ?_).2 (List.mem_finRange x)
+      rintro rfl
+      exact hmem hx
     have hle : xs.length ≤ ((List.finRange (n + 1)).erase (Fin.last n)).length :=
-      List.Subperm.length_le hsub
+      List.nodup_subset_length_le hnodup hsubset
     have herase :
         ((List.finRange (n + 1)).erase (Fin.last n)).length = n := by
       rw [List.length_erase]

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -465,14 +465,13 @@ private theorem fin_mem_of_full_nodup {n : Nat} {xs : List (Fin n)}
   by_cases hmem : x ∈ xs
   · exact hmem
   · exfalso
-    have hsub : List.Subperm xs ((List.finRange n).erase x) := by
-      apply List.subperm_of_subset hnodup
+    have hsubset : xs ⊆ (List.finRange n).erase x := by
       intro y hy
-      exact (List.mem_erase_of_ne (by
-        intro hyx
-        exact hmem (hyx ▸ hy))).2 (List.mem_finRange y)
+      refine (List.mem_erase_of_ne ?_).2 (List.mem_finRange y)
+      rintro rfl
+      exact hmem hy
     have hle : xs.length ≤ ((List.finRange n).erase x).length :=
-      List.Subperm.length_le hsub
+      List.nodup_subset_length_le hnodup hsubset
     have herase : ((List.finRange n).erase x).length = n - 1 := by
       rw [List.length_erase]
       simp [List.mem_finRange, List.length_finRange]
@@ -2511,7 +2510,7 @@ theorem det_lowerTriangular_eq_finFoldl_diag
     intro i
     simp [transpose, col]
   -- Rewrite the foldl over `M.transpose[i][i]` to `M[i][i]`.
-  rw [Fin.foldl_eq_foldl_finRange, Fin.foldl_eq_foldl_finRange]
+  rw [Fin.foldl_eq_finRange_foldl, Fin.foldl_eq_finRange_foldl]
   apply foldl_acc_congr
   intro acc i _hmem
   rw [hdiag]
@@ -2523,7 +2522,7 @@ theorem det_lowerTriangular_eq_foldl_diag
     (hzero : ∀ i j : Fin n, i.val < j.val → M[i][j] = 0) :
     det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
   rw [det_lowerTriangular_eq_finFoldl_diag M hzero]
-  rw [Fin.foldl_eq_foldl_finRange]
+  rw [Fin.foldl_eq_finRange_foldl]
 
 /-- Permuting columns multiplies the determinant by the sign of the column permutation. -/
 theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import Batteries.Data.List.Lemmas
+public import HexMatrix.ListShim
 
 public section
 

--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexMatrix.Basic
-public import Batteries.Data.List.Lemmas
 
 public section
 

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexMatrix.Basic
-public import Batteries.Data.List.Lemmas
 
 public section
 

--- a/HexMatrix/ListShim.lean
+++ b/HexMatrix/ListShim.lean
@@ -1,0 +1,105 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Std
+
+public section
+
+/-!
+Lemmas reproduced from Batteries.
+
+These are the `Batteries` lemmas the Mathlib-free `hex` libraries (`HexMatrix`,
+`HexRowReduce`, `HexDeterminant`, `HexGramSchmidt`, `HexBerlekamp`) relied on but
+which are not (yet) in the Lean core library. They are reproduced here, with
+names and signatures identical to the Batteries originals, so the Mathlib-free
+libraries no longer need to depend on Batteries. Remove each one if it is
+migrated up to lean4.
+
+Keeping the signatures identical to Batteries is deliberate: the `*Mathlib`
+bridge libraries pull Batteries in via Mathlib, so both copies coexist there.
+Lean accepts duplicate declarations from different modules when their signatures
+match (the proofs may differ), so there is no clash. If you change a signature
+here it will collide with Batteries in the bridge libraries.
+-/
+
+namespace List
+
+/-- Reproduced from `Batteries.Data.List.Lemmas`; remove if migrated up to lean4. -/
+theorem pairwise_lt_finRange (n : Nat) : Pairwise (· < ·) (finRange n) := by
+  rw [pairwise_iff_getElem]
+  intro i j hi hj hlt
+  simp only [getElem_finRange]
+  exact hlt
+
+/-- Reproduced from `Batteries.Data.List.Lemmas`; remove if migrated up to lean4. -/
+theorem nodup_finRange (n : Nat) : (finRange n).Nodup :=
+  (pairwise_lt_finRange n).imp Fin.ne_of_lt
+
+/-- Reproduced from `Batteries.Data.List.Pairwise`; remove if migrated up to lean4. -/
+theorem pairwise_iff_get {α} {R : α → α → Prop} {l : List α} :
+    Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
+  rw [pairwise_iff_getElem]
+  constructor <;> intro h
+  · intros i j h'
+    exact h _ _ _ _ h'
+  · intros i j hi hj h'
+    exact h ⟨i, hi⟩ ⟨j, hj⟩ h'
+
+/-- Reproduced from `Batteries.Data.List.Perm`; remove if migrated up to lean4.
+The Batteries original has no `[DecidableEq α]`; we match that signature and use
+`classical` in the proof, since core lacks the `Subperm` API Batteries uses. -/
+theorem perm_ext_iff_of_nodup {α} {l₁ l₂ : List α}
+    (d₁ : l₁.Nodup) (d₂ : l₂.Nodup) : l₁ ~ l₂ ↔ ∀ a, a ∈ l₁ ↔ a ∈ l₂ := by
+  classical
+  rw [perm_iff_count]
+  refine ⟨fun h a => by rw [← count_pos_iff, ← count_pos_iff, h], fun h a => ?_⟩
+  rw [d₁.count, d₂.count]
+  simp only [h a]
+
+/-- Reproduced from `Batteries.Data.List.Lemmas`; remove if migrated up to lean4. -/
+@[simp, grind =]
+theorem getElem_idxOf [BEq α] [LawfulBEq α] {x : α} {xs : List α}
+    (h : idxOf x xs < xs.length) : xs[xs.idxOf x] = x := by
+  induction xs <;> grind
+
+/-- Reproduced from `Batteries.Data.List.Lemmas`; remove if migrated up to lean4. -/
+@[simp, grind =]
+theorem Nodup.idxOf_getElem [BEq α] [LawfulBEq α] {xs : List α} (H : Nodup xs)
+    (i : Nat) (h : i < xs.length) : idxOf xs[i] xs = i := by
+  induction xs generalizing i <;> grind
+
+/-- A `Nodup` list contained in another list is no longer than it. Replaces uses
+of `Batteries`' `Subperm` API (`subperm_of_subset`/`Subperm.length_le`), which
+core lacks; this name is not from Batteries. Remove in favour of a core lemma if
+one is migrated up to lean4. -/
+theorem nodup_subset_length_le {α} [DecidableEq α] {l₁ l₂ : List α}
+    (h₁ : l₁.Nodup) (hsub : l₁ ⊆ l₂) : l₁.length ≤ l₂.length := by
+  induction l₁ generalizing l₂ with
+  | nil => simp
+  | cons a t ih =>
+    rw [nodup_cons] at h₁
+    have ha : a ∈ l₂ := hsub (mem_cons_self ..)
+    have htsub : t ⊆ l₂.erase a := by
+      intro x hx
+      have hxa : x ≠ a := fun h => h₁.1 (h ▸ hx)
+      exact (mem_erase_of_ne hxa).2 (hsub (mem_cons_of_mem _ hx))
+    have hih := ih h₁.2 htsub
+    have hlen : (l₂.erase a).length = l₂.length - 1 := by rw [length_erase]; simp [ha]
+    have hpos : 1 ≤ l₂.length := length_pos_of_mem ha
+    simp only [length_cons]; omega
+
+end List
+
+namespace Vector
+
+/-- Reproduced from `Batteries.Data.Vector.Lemmas`; remove if migrated up to lean4.
+Core has `Vector.getElem_ofFn`, but not this `.get`-phrased form. -/
+@[simp] theorem get_ofFn (f : Fin n → α) (i : Fin n) : (ofFn f).get i = f i :=
+  getElem_ofFn _
+
+end Vector

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexMatrix.Basic
-public import Batteries.Data.List.Lemmas
 
 public section
 

--- a/HexMatrix/Vector/Insert.lean
+++ b/HexMatrix/Vector/Insert.lean
@@ -6,7 +6,6 @@ Authors: Kim Morrison
 
 module
 
-public import Batteries.Data.Vector.Lemmas
 public import HexMatrix.Basic
 
 public section

--- a/HexRowReduce/RREF/Pivot.lean
+++ b/HexRowReduce/RREF/Pivot.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import Std
-public import Batteries.Data.Vector.Lemmas
 public import HexRowReduce.RowEchelon
 
 public section

--- a/HexRowReduce/RowEchelon.lean
+++ b/HexRowReduce/RowEchelon.lean
@@ -9,9 +9,6 @@ module
 public import HexMatrix.Elementary
 public import HexMatrix.DotProduct
 public import HexMatrix.MatrixAlgebra
-public import Batteries.Data.List.Lemmas
-public import Batteries.Data.List.Pairwise
-public import Batteries.Data.List.Perm
 
 public section
 

--- a/bench/HexGF2/Bench.lean
+++ b/bench/HexGF2/Bench.lean
@@ -5,7 +5,6 @@ Authors: Kim Morrison
 -/
 
 import HexGF2
-import Batteries.Lean.IO.Process
 import LeanBench
 
 /-!

--- a/bench/HexLLLBench/Inputs.lean
+++ b/bench/HexLLLBench/Inputs.lean
@@ -7,7 +7,6 @@ Authors: Kim Morrison
 module
 
 public import HexLLL
-public import Batteries.Lean.IO.Process
 public import LeanBench
 
 public section


### PR DESCRIPTION
This PR removes the direct dependency on Batteries from the Mathlib-free libraries (HexMatrix, HexGramSchmidt, HexBerlekamp) by reproducing the handful of Batteries lemmas they relied on in a single new file, HexMatrix/ListShim.lean. The reproduced lemmas (`nodup_finRange`, `pairwise_lt_finRange`, `pairwise_iff_get`, `perm_ext_iff_of_nodup`, `getElem_idxOf`, `Nodup.idxOf_getElem`, `Vector.get_ofFn`) keep names and signatures identical to the Batteries originals, so they coexist as harmless duplicate declarations with Batteries — still pulled in via Mathlib — in the `*Mathlib` bridge libraries; Lean accepts same-signature declarations from different modules even when the proofs differ. The Batteries `Subperm` API (which core lacks) is replaced by a small `nodup_subset_length_le` helper, and `Fin.foldl_eq_foldl_finRange` is switched to the identical core lemma `Fin.foldl_eq_finRange_foldl`. Two dead `Batteries.Lean.IO.Process` bench imports and two now-unnecessary `set_option linter.unreachableTactic` lines are removed. Each reproduced lemma carries a comment marking it for removal if it is migrated up to lean4. The full graph builds green, including every `*Mathlib` bridge, conformance, and bench target.

🤖 Prepared with Claude Code