### PR TITLE
doc: add the six split matrix repos to the released-set list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,12 @@ The split repos published from `hex-dev`, in dependency order, are:
 
 - `hex-test-kit` (shared conformance/bench helpers; source: `Hex/`)
 - `hex-matrix`
-- `hex-matrix-mathlib`, `hex-gram-schmidt`
+- `hex-row-reduce`, `hex-determinant`
+- `hex-bareiss`
+- `hex-matrix-mathlib`
+- `hex-row-reduce-mathlib`, `hex-determinant-mathlib`
+- `hex-bareiss-mathlib`
+- `hex-gram-schmidt`
 - `hex-gram-schmidt-mathlib`, `hex-lll`
 - `hex-lll-mathlib`
 


### PR DESCRIPTION
This PR adds the six repositories split from HexMatrix / HexMatrixMathlib to the released-set list in AGENTS.md (surfaced as .claude/CLAUDE.md): hex-row-reduce, hex-determinant, hex-bareiss and their -mathlib bridges, in dependency order. All six repos are created and published.

🤖 Prepared with Claude Code