### PR TITLE
refactor: migrate List/Vector .get to getElem, dropping two shim lemmas

### DIFF
--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -730,8 +730,12 @@ theorem fixedSpaceKernel_sound (f : FpPoly p) (hmonic : DensePoly.Monic f)
     (k : Fin (basisSize f -
       Matrix.rref_rank (fixedSpaceMatrix f hmonic))) :
     IsFixedSpaceKernelPolynomial f hmonic ((fixedSpaceKernel f hmonic).get k) := by
-  unfold IsFixedSpaceKernelPolynomial fixedSpaceKernel
-  rw [Vector.get_ofFn, coeffVector_vectorToPoly]
+  have hk : (fixedSpaceKernel f hmonic).get k =
+      vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
+    unfold fixedSpaceKernel
+    exact Vector.getElem_ofFn _
+  unfold IsFixedSpaceKernelPolynomial
+  rw [hk, coeffVector_vectorToPoly]
   exact fixedSpaceKernelVectors_sound f hmonic k
 
 /-- Every vector satisfying the executable fixed-space kernel condition is a

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -3025,11 +3025,14 @@ private theorem nullspaceBasisMatrix_entry_eq_basis_coeff
     unfold coeffVector
     rw [Vector.getElem_ofFn]
   -- coeffVector f (basis k) = (fixedSpaceKernelVectors f hmonic).get k
+  have hker_get : (fixedSpaceKernel f hmonic).get k =
+      vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
+    unfold fixedSpaceKernel
+    exact Vector.getElem_ofFn _
   have hker_eq :
       coeffVector f ((fixedSpaceKernel f hmonic).get k) =
         (fixedSpaceKernelVectors f hmonic).get k := by
-    unfold fixedSpaceKernel
-    rw [Vector.get_ofFn, coeffVector_vectorToPoly]
+    rw [hker_get, coeffVector_vectorToPoly]
   rw [hker_coeff, hker_eq]
   -- Goal: M'[i][k.val] = ((fixedSpaceKernelVectors f hmonic).get k)[i]
   unfold fixedSpaceKernelVectors
@@ -3172,7 +3175,7 @@ theorem irreducible_of_no_kernelWitnessSplit_squareFree
         (fixedSpaceKernel f hmonic).get k =
           vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
       unfold fixedSpaceKernel
-      rw [Vector.get_ofFn]
+      exact Vector.getElem_ofFn _
     rw [hker_eq]
     unfold vectorToPoly
     have hle :
@@ -3551,7 +3554,7 @@ private theorem fixedSpaceKernel_get_size_le
       (fixedSpaceKernel f hmonic).get k =
         vectorToPoly ((fixedSpaceKernelVectors f hmonic).get k) := by
     unfold fixedSpaceKernel
-    rw [Vector.get_ofFn]
+    exact Vector.getElem_ofFn _
   rw [hker_eq]
   unfold vectorToPoly
   have hle :

--- a/HexGramSchmidt/Basic/Kernel.lean
+++ b/HexGramSchmidt/Basic/Kernel.lean
@@ -485,20 +485,18 @@ private theorem basisRows_get!_dot_eq_zero
   have hjrows : j < rows.length := by simpa [hlen] using hj
   have hpair : rows.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) := by
     simpa [rows] using basisRows_pairwise (rows := b.toList)
-  have hget_i : rows.get ⟨i, hirows⟩ = rows[i]! := by
-    simp [hirows]
-  have hget_j : rows.get ⟨j, hjrows⟩ = rows[j]! := by
-    simp [hjrows]
+  have hget_i : rows[i]! = rows[i] := by simp [hirows]
+  have hget_j : rows[j]! = rows[j] := by simp [hjrows]
   by_cases hlt : i < j
   · have hrel :=
-      (List.pairwise_iff_get.1 hpair) ⟨i, hirows⟩ ⟨j, hjrows⟩ (by simpa using hlt)
-    rw [← hget_i, ← hget_j]
+      (List.pairwise_iff_getElem.1 hpair) i j hirows hjrows hlt
+    rw [hget_i, hget_j]
     exact hrel.1
   · have hji : j < i := by
       exact Nat.lt_of_le_of_ne (Nat.le_of_not_gt hlt) (fun h => hij h.symm)
     have hrel :=
-      (List.pairwise_iff_get.1 hpair) ⟨j, hjrows⟩ ⟨i, hirows⟩ (by simpa using hji)
-    rw [← hget_i, ← hget_j]
+      (List.pairwise_iff_getElem.1 hpair) j i hjrows hirows hji
+    rw [hget_i, hget_j]
     exact hrel.2
 
 private theorem basisRows_head (b : Matrix Rat n m) (hn : 0 < n) :

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -185,20 +185,18 @@ private theorem basisRows_get!_dot_eq_zero_of_list
   have hpair : (basisRows rows).Pairwise
       (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) :=
     basisRows_pairwise rows
-  have hget_i : (basisRows rows).get ⟨i, hilen⟩ = (basisRows rows)[i]! := by
-    simp [hilen]
-  have hget_j : (basisRows rows).get ⟨j, hjlen⟩ = (basisRows rows)[j]! := by
-    simp [hjlen]
+  have hget_i : (basisRows rows)[i]! = (basisRows rows)[i] := by simp [hilen]
+  have hget_j : (basisRows rows)[j]! = (basisRows rows)[j] := by simp [hjlen]
   by_cases hlt : i < j
   · have hrel :=
-      (List.pairwise_iff_get.1 hpair) ⟨i, hilen⟩ ⟨j, hjlen⟩ (by simpa using hlt)
-    rw [← hget_i, ← hget_j]
+      (List.pairwise_iff_getElem.1 hpair) i j hilen hjlen hlt
+    rw [hget_i, hget_j]
     exact hrel.1
   · have hji : j < i :=
       Nat.lt_of_le_of_ne (Nat.le_of_not_gt hlt) (fun h => hij h.symm)
     have hrel :=
-      (List.pairwise_iff_get.1 hpair) ⟨j, hjlen⟩ ⟨i, hilen⟩ (by simpa using hji)
-    rw [← hget_i, ← hget_j]
+      (List.pairwise_iff_getElem.1 hpair) j i hjlen hilen hji
+    rw [hget_i, hget_j]
     exact hrel.2
 
 private theorem zero_add_vec (v : Vector Rat m) : (0 : Vector Rat m) + v = v := by

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -141,10 +141,7 @@ private theorem rowCombination_bareiss_coeff_update
   have h_rhs :
       (Vector.ofFn fun j : Fin m => x * (M.transpose * c)[j] - y * (M.transpose * d)[j])[jf] =
         x * (M.transpose * c)[jf] - y * (M.transpose * d)[jf] := by
-    change (Vector.ofFn fun j : Fin m =>
-      x * (M.transpose * c)[j] - y * (M.transpose * d)[j]).get jf =
-        x * (M.transpose * c)[jf] - y * (M.transpose * d)[jf]
-    rw [Vector.get_ofFn]
+    simp
   rw [h_rhs]
   repeat rw [Matrix.mulVec_getElem]
   exact dot_bareiss_row_update_right x y ((Matrix.transpose M).row jf) c d

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -1866,7 +1866,7 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (hquot : StepWitness b)
   rcases k with _ | r
   · show (gramDetVec b).get ⟨0, _⟩ = gramDet b 0 hk
     have h_one : (gramDetVec b).get ⟨0, Nat.zero_lt_succ n⟩ = 1 := by
-      simp [gramDetVec, data, gramDetVecFromScaledCoeffRows]
+      simp [gramDetVec, data, gramDetVecFromScaledCoeffRows, Vector.get, Vector.toArray_ofFn]
     rw [show (gramDetVec b).get ⟨0, Nat.lt_succ_of_le hk⟩
           = (gramDetVec b).get ⟨0, Nat.zero_lt_succ n⟩ from rfl, h_one]
     exact (gramDet_zero b).symm
@@ -1875,7 +1875,7 @@ theorem gramDetVec_eq_gramDet (b : Matrix Int n m) (hquot : StepWitness b)
     have hget :
         (gramDetVec b).get ⟨r + 1, Nat.succ_lt_succ hr⟩ =
           (getArrayEntry (scaledCoeffRowsSchur b) r r).toNat := by
-      simp [gramDetVec, data, gramDetVecFromScaledCoeffRows]
+      simp [gramDetVec, data, gramDetVecFromScaledCoeffRows, Vector.get, Vector.toArray_ofFn]
     rw [hget, getArrayEntry_scaledCoeffRowsSchur_eq b hquot]
     exact scaledCoeffRows_diag_toNat_eq_gramDet (b := b) hquot r hr
 
@@ -1891,7 +1891,7 @@ theorem scaledCoeffs_diag_toNat (b : Matrix Int n m) (hquot : StepWitness b)
   have hpack :
       (gramDetVec b).get ⟨i + 1, Nat.succ_lt_succ hi⟩ =
         (getArrayEntry (scaledCoeffRowsSchur b) i i).toNat := by
-    simp [gramDetVec, data, gramDetVecFromScaledCoeffRows]
+    simp [gramDetVec, data, gramDetVecFromScaledCoeffRows, Vector.get, Vector.toArray_ofFn]
   rw [← hpack]
   exact gramDetVec_eq_gramDet (b := b) hquot (i + 1) (Nat.succ_le_of_lt hi)
 

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -331,8 +331,8 @@ theorem swapStep_valid (s : LLLState n m) (k : Nat)
       have hpairs_at : ∀ (i : Fin n), k < i.val →
           pairs.get i = ((s.ν.get i).get kFin, (s.ν.get i).get km1) := by
         intro i hi
-        show (Vector.ofFn _).get i = _
-        rw [Vector.get_ofFn]
+        show (Vector.ofFn _)[i.1] = _
+        rw [Vector.getElem_ofFn]
         exact dif_pos hi
       have hkm1_ne_kFin : km1 ≠ kFin := by
         intro h; rw [h] at hkm1_lt_k; omega

--- a/HexMatrix/ListShim.lean
+++ b/HexMatrix/ListShim.lean
@@ -40,16 +40,6 @@ theorem pairwise_lt_finRange (n : Nat) : Pairwise (· < ·) (finRange n) := by
 theorem nodup_finRange (n : Nat) : (finRange n).Nodup :=
   (pairwise_lt_finRange n).imp Fin.ne_of_lt
 
-/-- Reproduced from `Batteries.Data.List.Pairwise`; remove if migrated up to lean4. -/
-theorem pairwise_iff_get {α} {R : α → α → Prop} {l : List α} :
-    Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
-  rw [pairwise_iff_getElem]
-  constructor <;> intro h
-  · intros i j h'
-    exact h _ _ _ _ h'
-  · intros i j hi hj h'
-    exact h ⟨i, hi⟩ ⟨j, hj⟩ h'
-
 /-- Reproduced from `Batteries.Data.List.Perm`; remove if migrated up to lean4.
 The Batteries original has no `[DecidableEq α]`; we match that signature and use
 `classical` in the proof, since core lacks the `Subperm` API Batteries uses. -/
@@ -94,12 +84,3 @@ theorem nodup_subset_length_le {α} [DecidableEq α] {l₁ l₂ : List α}
     simp only [length_cons]; omega
 
 end List
-
-namespace Vector
-
-/-- Reproduced from `Batteries.Data.Vector.Lemmas`; remove if migrated up to lean4.
-Core has `Vector.getElem_ofFn`, but not this `.get`-phrased form. -/
-@[simp] theorem get_ofFn (f : Fin n → α) (i : Fin n) : (ofFn f).get i = f i :=
-  getElem_ofFn _
-
-end Vector

--- a/HexRowReduce/RREF/Echelon.lean
+++ b/HexRowReduce/RREF/Echelon.lean
@@ -252,9 +252,9 @@ theorem rowCombination_single {R : Type u} [Lean.Grind.CommRing R]
   change (Vector.ofFn fun j : Fin m =>
       (List.finRange n).foldl
         (fun acc l => acc + (Vector.ofFn fun j : Fin m => Vector.ofFn fun i : Fin n => M[i][j])[j][l] *
-          (Vector.ofFn fun l : Fin n => if i = l then (1 : R) else 0)[l]) 0).get jf =
+          (Vector.ofFn fun l : Fin n => if i = l then (1 : R) else 0)[l]) 0)[jf.1] =
     M[i][jf]
-  rw [Vector.get_ofFn]
+  rw [Vector.getElem_ofFn]
   change
     (List.finRange n).foldl
         (fun acc l => acc +
@@ -582,7 +582,7 @@ private theorem nullspace_get [Lean.Grind.Ring R] (E : IsRREF M D)
     (k : Fin (m - D.rank)) :
     E.nullspace.get k = Matrix.col E.nullspaceMatrix k := by
   unfold nullspace
-  rw [Vector.get_ofFn]
+  exact Vector.getElem_ofFn _
 
 /-- On its own free column, a nullspace basis vector has entry `1`. -/
 @[grind =] theorem nullspace_get_free [Lean.Grind.Ring R] (E : IsRREF M D)

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -131,7 +131,7 @@ private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
   apply Finset.sum_congr rfl
   intro k _
   unfold Hex.Matrix.IsRREF.nullspace Hex.Matrix.col
-  simp [mul_comm]
+  simp [mul_comm, Vector.get, Vector.toArray_ofFn]
 
 /-- Soundness of the executable `spanCoeffs`: when echelon-form data certifies
 `v` as a row combination with coefficients `c`, the Mathlib image of `v` is the


### PR DESCRIPTION
This PR removes the two `.get`-phrased reproductions from `HexMatrix/ListShim.lean` — `Vector.get_ofFn` and `List.pairwise_iff_get` — by migrating their call sites to the Lean core `getElem` lemmas they mirror, `Vector.getElem_ofFn` and `List.pairwise_iff_getElem`. The Lean core library deliberately ships no `.get` companions for `Vector`/`List` (that family lives only in Batteries), so these two were never upstreaming candidates; moving the Mathlib-free libraries to `getElem` removes the need for them outright and leaves `ListShim` holding only `getElem`-phrased lemmas that are clean candidates to upstream. Removing the `@[simp]` `Vector.get_ofFn` rippled to a handful of `simp` proofs that implicitly relied on it to reduce `(Vector.ofFn g).get i`; those are reduced instead with `simp [Vector.get, Vector.toArray_ofFn]`, and the explicit `rw [Vector.get_ofFn]` sites become `exact Vector.getElem_ofFn _` or the corresponding `getElem` rewrite. The full graph builds green, including every `*Mathlib` bridge, conformance, and bench target.

🤖 Prepared with Claude Code