### PR TITLE
refactor: add Matrix additive structure, restate sub_identity_mulVec

### DIFF
--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -635,8 +635,7 @@ theorem berlekampMatrix_mulVec_coeffVector_eq
 /-- The fixed-space matrix `Q_f - I` used in Berlekamp's kernel computation. -/
 def fixedSpaceMatrix (f : FpPoly p) (hmonic : DensePoly.Monic f) :
     Matrix (ZMod64 p) (basisSize f) (basisSize f) :=
-  let Q := berlekampMatrix f hmonic
-  Matrix.ofFn fun i j => Q[(i, j)] - if i = j then 1 else 0
+  berlekampMatrix f hmonic - Matrix.identity (basisSize f)
 
 /-- Convert a coefficient vector back to its polynomial representative. -/
 @[expose]
@@ -699,13 +698,10 @@ theorem isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq
       Matrix.mulVec (berlekampMatrix f hmonic) v = v := by
   unfold IsFixedSpaceKernelVector
   dsimp only [fixedSpaceMatrix]
-  have hsub :
-      Matrix.mulVec
-          (Matrix.ofFn fun i j => (berlekampMatrix f hmonic)[(i, j)] - if i = j then 1 else 0) v =
-        Matrix.mulVec (berlekampMatrix f hmonic) v - v :=
-    Matrix.sub_identity_mulVec (berlekampMatrix f hmonic) v
-  rw [hsub]
-  exact vector_sub_eq_zero_iff_eq (Matrix.mulVec (berlekampMatrix f hmonic) v) v
+  show (berlekampMatrix f hmonic - Matrix.identity (basisSize f)) * v = 0 ↔
+    berlekampMatrix f hmonic * v = v
+  rw [Matrix.sub_identity_mulVec]
+  exact vector_sub_eq_zero_iff_eq (berlekampMatrix f hmonic * v) v
 
 /-- Polynomial-level executable Berlekamp kernel condition, by reading the
 representative in the quotient basis used by `fixedSpaceMatrix`. -/

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -246,6 +246,45 @@ instance [OfNat R 0] : Zero (Matrix R n m) where
 protected def identity (n : Nat) [OfNat R 0] [OfNat R 1] : Matrix R n n :=
   ofFn fun i j => if i = j then 1 else 0
 
+/-- Entrywise matrix addition. -/
+@[expose]
+protected def add [Add R] (A B : Matrix R n m) : Matrix R n m :=
+  ofFn fun i j => A[(i, j)] + B[(i, j)]
+
+instance [Add R] : Add (Matrix R n m) where
+  add := Matrix.add
+
+/-- Entrywise matrix negation. -/
+@[expose]
+protected def neg [Neg R] (A : Matrix R n m) : Matrix R n m :=
+  ofFn fun i j => -A[(i, j)]
+
+instance [Neg R] : Neg (Matrix R n m) where
+  neg := Matrix.neg
+
+/-- Entrywise matrix subtraction. -/
+@[expose]
+protected def sub [Sub R] (A B : Matrix R n m) : Matrix R n m :=
+  ofFn fun i j => A[(i, j)] - B[(i, j)]
+
+instance [Sub R] : Sub (Matrix R n m) where
+  sub := Matrix.sub
+
+/-- Entry access for matrix addition. -/
+@[grind =] theorem getElem_add [Add R] (A B : Matrix R n m) (i : Fin n) (j : Fin m) :
+    (A + B)[i][j] = A[i][j] + B[i][j] := by
+  simp [show A + B = Matrix.add A B from rfl, Matrix.add, ofFn]
+
+/-- Entry access for matrix negation. -/
+@[grind =] theorem getElem_neg [Neg R] (A : Matrix R n m) (i : Fin n) (j : Fin m) :
+    (-A)[i][j] = -A[i][j] := by
+  simp [show -A = Matrix.neg A from rfl, Matrix.neg, ofFn]
+
+/-- Entry access for matrix subtraction. -/
+@[grind =] theorem getElem_sub [Sub R] (A B : Matrix R n m) (i : Fin n) (j : Fin m) :
+    (A - B)[i][j] = A[i][j] - B[i][j] := by
+  simp [show A - B = Matrix.sub A B from rfl, Matrix.sub, ofFn]
+
 /-- Multiply a matrix by a column vector. -/
 @[expose]
 def mulVec [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (v : Vector R m) :

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -224,37 +224,36 @@ theorem mul_assoc [Lean.Grind.Ring R]
   change (Matrix.zero n m : Matrix R n m)[ii][j] * v[j] = 0
   simpa [Matrix.zero, ofFn] using Lean.Grind.Semiring.zero_mul v[j]
 
-/-- Multiplication by `Q - I`, expressed entrywise, is `Q * v - v`. -/
-theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R n) :
-    mulVec (R := R) (n := n) (m := n)
-        (ofFn fun i j => Q[i][j] - if i = j then 1 else 0) v =
-      mulVec (R := R) (n := n) (m := n) Q v - v := by
+/-- Matrix-vector multiplication distributes over matrix subtraction. -/
+@[grind =] theorem sub_mulVec [Lean.Grind.Ring R] (A B : Matrix R n m) (v : Vector R m) :
+    (A - B) * v = A * v - B * v := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [mulVec, row, Vector.dotProduct, ofFn]
+  simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change
-    (List.finRange n).foldl
-        (fun acc j => acc + (Q[ii][j] - if ii = j then 1 else 0) * v[j]) 0 =
-      (List.finRange n).foldl (fun acc j => acc + Q[ii][j] * v[j]) 0 - v[ii]
+    (List.finRange m).foldl (fun acc j => acc + (A - B)[ii][j] * v[j]) 0 =
+      (List.finRange m).foldl (fun acc j => acc + A[ii][j] * v[j]) 0 -
+        (List.finRange m).foldl (fun acc j => acc + B[ii][j] * v[j]) 0
   calc
-    (List.finRange n).foldl
-        (fun acc j => acc + (Q[ii][j] - if ii = j then 1 else 0) * v[j]) 0 =
-        (List.finRange n).foldl
-          (fun acc j => acc + (Q[ii][j] * v[j] - (if ii = j then 1 else 0) * v[j]))
+    (List.finRange m).foldl (fun acc j => acc + (A - B)[ii][j] * v[j]) 0 =
+        (List.finRange m).foldl
+          (fun acc j => acc + (A[ii][j] * v[j] - B[ii][j] * v[j]))
           ((0 : R) - 0) := by
           have hzero : (0 : R) - 0 = 0 := by grind
           rw [hzero]
           apply List.foldl_add_congr
           intro j _hj
-          grind
-    _ = (List.finRange n).foldl (fun acc j => acc + Q[ii][j] * v[j]) 0 -
-          (List.finRange n).foldl
-            (fun acc j => acc + (if ii = j then 1 else 0) * v[j]) 0 := by
+          rw [getElem_sub]
+          have hdist : ∀ a b c : R, (a - b) * c = a * c - b * c := fun a b c => by grind
+          exact hdist _ _ _
+    _ = (List.finRange m).foldl (fun acc j => acc + A[ii][j] * v[j]) 0 -
+          (List.finRange m).foldl (fun acc j => acc + B[ii][j] * v[j]) 0 := by
           rw [List.foldl_add_sub]
-    _ = (List.finRange n).foldl (fun acc j => acc + Q[ii][j] * v[j]) 0 - v[ii] := by
-          rw [foldl_indicator_mul_unique (List.finRange n) ii (fun j => v[j])
-            (List.mem_finRange _) (List.nodup_finRange n) 0]
-          grind
+
+/-- Multiplication by `Q - I` is `Q * v - v`. -/
+theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R n) :
+    (Q - Matrix.identity n) * v = Q * v - v := by
+  rw [sub_mulVec, identity_mulVec]
 
 end Matrix
 

--- a/progress/20260630T120616Z_matrix-sub-instances-rebased.md
+++ b/progress/20260630T120616Z_matrix-sub-instances-rebased.md
@@ -1,0 +1,37 @@
+# Matrix additive structure and `sub_identity_mulVec` cleanup (rebased on opaque Matrix)
+
+## Accomplished
+
+- Rebased onto main after #8442 made `Hex.Matrix` an opaque one-field
+  structure. With `Matrix` no longer a transparent abbrev for nested
+  `Vector`, entrywise arithmetic instances no longer leak into `grind`'s
+  linarith on downstream `det` proofs, so the full set is safe.
+- Added entrywise `Add`/`Neg`/`Sub` instances on `Matrix R n m` in
+  `HexMatrix/Basic.lean`, with `@[grind =]` entry lemmas
+  `getElem_add`/`getElem_neg`/`getElem_sub`. The defs use the executable
+  pair accessor `A[(i, j)]` (the nested `A[i][j]` form is noncomputable
+  post-#8442).
+- Added `sub_mulVec : (A - B) * v = A * v - B * v` in
+  `HexMatrix/MatrixAlgebra.lean` and collapsed `sub_identity_mulVec` to
+  `(Q - Matrix.identity n) * v = Q * v - v`, proved by
+  `rw [sub_mulVec, identity_mulVec]`. The old thirty-line entrywise
+  `ofFn fun i j => Q[i][j] - if i = j then 1 else 0` statement is gone.
+- Restated `fixedSpaceMatrix` as
+  `berlekampMatrix f hmonic - Matrix.identity (basisSize f)` and updated
+  the one call site with a `show ... * ...` bridge from the `.mulVec`
+  spelling to `*`.
+
+## Current frontier
+
+- `HexMatrix`, `HexBerlekamp`, and the full linear-algebra conformance set
+  (`HexMatrix`/`HexRowReduce`/`HexDeterminant`/`HexBareiss`/`HexGramSchmidt`/
+  `HexLLL`/`HexBerlekamp` Conformance) all build green: 280 jobs.
+  `HexDeterminant.Conformance` (which the pre-opaque version broke) is green.
+
+## Next step
+
+- CI on the PR exercises the full graph and the `*Mathlib` bridge layers.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR gives `Matrix R n m` entrywise `Add`/`Neg`/`Sub` instances, each with a `@[grind =]` entry lemma (`getElem_add`/`getElem_neg`/`getElem_sub`). With matrix subtraction available, the Berlekamp fixed-space matrix is written as the honest `berlekampMatrix f hmonic - Matrix.identity (basisSize f)` rather than the previous `ofFn fun i j => Q[i][j] - if i = j then 1 else 0` spelling, and `sub_identity_mulVec` is restated as `(Q - Matrix.identity n) * v = Q * v - v` — a three-line consequence of the new general `sub_mulVec : (A - B) * v = A * v - B * v` together with the existing `identity_mulVec`, replacing the previous thirty-line entrywise fold manipulation.

The one consumer, `isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq`, gains a one-line `show` to bridge the `.mulVec`/`*` spelling before the rewrite. This builds on the opaque-`Matrix` encapsulation from https://github.com/kim-em/hex-dev/pull/8442 ("refactor: encapsulate Hex.Matrix behind a one-field structure"): because `Matrix` is no longer a transparent abbrev for nested `Vector`, these arithmetic instances no longer leak into `grind`'s linarith on downstream `det` proofs.

🤖 Prepared with Claude Code