### PR TITLE
refactor: rename matrix slicers and drop the leadingSubmatrix wrapper

### DIFF
--- a/HexBareiss/BorderedMinor.lean
+++ b/HexBareiss/BorderedMinor.lean
@@ -73,30 +73,30 @@ def borderedMinor (M : Matrix R n n) (k : Nat) (hk : k < n) (i j : Fin n) :
 
 /-- The top-left `k × k` block of a bordered minor is the leading prefix of the
 source matrix. -/
-theorem leadingPrefix_borderedMinor_eq_leadingPrefix (M : Matrix R n n) (k : Nat)
+theorem principalSubmatrix_borderedMinor_eq_principalSubmatrix (M : Matrix R n n) (k : Nat)
     (hk : k < n) (i j : Fin n) :
-    leadingPrefix (borderedMinor M k hk i j) k (Nat.le_succ k) =
-      leadingPrefix M k (Nat.le_of_lt hk) := by
+    principalSubmatrix (borderedMinor M k hk i j) k (Nat.le_succ k) =
+      principalSubmatrix M k (Nat.le_of_lt hk) := by
   ext r _hr c _hc
-  simp [leadingPrefix, borderedMinor, ofFn]
+  simp [principalSubmatrix, borderedMinor, ofFn]
 
 /-- The top-left `(k + 1) × (k + 1)` block of the next bordered minor is the
 current bordered minor whose extra row/column are the `k`-th source row/column. -/
-theorem leadingPrefix_borderedMinor_succ_eq_borderedMinor (M : Matrix R n n)
+theorem principalSubmatrix_borderedMinor_succ_eq_borderedMinor (M : Matrix R n n)
     (k : Nat) (hk : k < n) (hnext : k + 1 < n) (i j : Fin n) :
-    leadingPrefix (borderedMinor M (k + 1) hnext i j) (k + 1)
+    principalSubmatrix (borderedMinor M (k + 1) hnext i j) (k + 1)
         (Nat.le_succ (k + 1)) =
       borderedMinor M k hk ⟨k, hk⟩ ⟨k, hk⟩ := by
   ext r _hr c _hc
   by_cases hrk : r < k <;> by_cases hck : c < k
-  · simp [leadingPrefix, borderedMinor, ofFn, hrk, hck]
+  · simp [principalSubmatrix, borderedMinor, ofFn, hrk, hck]
   · have hc_eq : c = k := by omega
-    simp [leadingPrefix, borderedMinor, ofFn, hrk, hc_eq]
+    simp [principalSubmatrix, borderedMinor, ofFn, hrk, hc_eq]
   · have hr_eq : r = k := by omega
-    simp [leadingPrefix, borderedMinor, ofFn, hck, hr_eq]
+    simp [principalSubmatrix, borderedMinor, ofFn, hck, hr_eq]
   · have hr_eq : r = k := by omega
     have hc_eq : c = k := by omega
-    simp [leadingPrefix, borderedMinor, ofFn, hr_eq, hc_eq]
+    simp [principalSubmatrix, borderedMinor, ofFn, hr_eq, hc_eq]
 
 end Matrix
 

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -38,27 +38,27 @@ variable {n : Nat}
 /-- The `k`-bordered minor of `M` at the corner row/column `⟨k, hk⟩` is exactly
 the `(k + 1)`-leading prefix of `M`. This identifies the trailing-corner entry
 under the no-pivot Bareiss invariant with a leading-prefix determinant. -/
-theorem borderedMinor_corner_eq_leadingPrefix {R : Type u}
+theorem borderedMinor_corner_eq_principalSubmatrix {R : Type u}
     [Lean.Grind.Ring R]
     (M : Hex.Matrix R n n) (k : Nat) (hk : k < n) :
     Hex.Matrix.borderedMinor M k hk ⟨k, hk⟩ ⟨k, hk⟩ =
-      Hex.Matrix.leadingPrefix M (k + 1) (Nat.succ_le_of_lt hk) := by
+      Hex.Matrix.principalSubmatrix M (k + 1) (Nat.succ_le_of_lt hk) := by
   apply Vector.ext
   intro r _hr
   apply Vector.ext
   intro c _hc
   by_cases hrk : r < k <;> by_cases hck : c < k
-  · simp [Hex.Matrix.borderedMinor, Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn,
+  · simp [Hex.Matrix.borderedMinor, Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn,
       hrk, hck]
   · have hc_eq : c = k := by omega
-    simp [Hex.Matrix.borderedMinor, Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn,
+    simp [Hex.Matrix.borderedMinor, Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn,
       hrk, hc_eq]
   · have hr_eq : r = k := by omega
-    simp [Hex.Matrix.borderedMinor, Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn,
+    simp [Hex.Matrix.borderedMinor, Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn,
       hck, hr_eq]
   · have hr_eq : r = k := by omega
     have hc_eq : c = k := by omega
-    simp [Hex.Matrix.borderedMinor, Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn,
+    simp [Hex.Matrix.borderedMinor, Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn,
       hr_eq, hc_eq]
 
 /-- Hypothesis used by the no-pivot Bareiss soundness proof: every leading
@@ -67,7 +67,7 @@ prefix determinant up to size `n` is nonzero. -/
 def NonzeroBareissPivots (M : Hex.Matrix Int n n) : Prop :=
   ∀ k : Fin n,
     Hex.Matrix.det
-      (Hex.Matrix.leadingPrefix M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) ≠ 0
+      (Hex.Matrix.principalSubmatrix M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) ≠ 0
 
 /-- Bordered-minor invariant of the no-pivot Bareiss recurrence:
 - `singularStep` is `none` (no pivot has been zero yet);
@@ -80,14 +80,14 @@ def NonzeroBareissPivots (M : Hex.Matrix Int n n) : Prop :=
 
 The implication on diagonal entries (`state.matrix[k][k]` agrees with the
 leading-prefix determinant of size `k + 1`) follows from `trailing_eq` taken
-at `i = j = ⟨k, _⟩` together with `borderedMinor_corner_eq_leadingPrefix`. -/
+at `i = j = ⟨k, _⟩` together with `borderedMinor_corner_eq_principalSubmatrix`. -/
 structure BareissNoPivotInvariant
     (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n) : Prop where
   singular_none : state.singularStep = none
   step_le : state.step ≤ n
   prevPivot_eq :
     state.prevPivot =
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source state.step step_le)
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source state.step step_le)
   prevPivot_ne : state.prevPivot ≠ 0
   trailing_eq :
     ∀ (h : state.step < n) (i j : Fin n)
@@ -97,13 +97,13 @@ structure BareissNoPivotInvariant
 
 /-- The initial Bareiss no-pivot state satisfies the bordered-minor invariant:
 the matrix is the source itself, and the previous-pivot convention is
-`det (leadingPrefix _ 0 _) = 1`. -/
+`det (principalSubmatrix _ 0 _) = 1`. -/
 theorem bareissNoPivotInvariant_initial (M : Hex.Matrix Int n n) :
     BareissNoPivotInvariant M (Hex.Matrix.noPivotInitialState M) where
   singular_none := rfl
   step_le := Nat.zero_le _
   prevPivot_eq := by
-    show (1 : Int) = Hex.Matrix.det (Hex.Matrix.leadingPrefix M 0 (Nat.zero_le n))
+    show (1 : Int) = Hex.Matrix.det (Hex.Matrix.principalSubmatrix M 0 (Nat.zero_le n))
     simp
   prevPivot_ne := by
     show (1 : Int) ≠ 0
@@ -140,8 +140,8 @@ private theorem bareissNoPivotInvariant_step
   singular_none := rfl
   step_le := Nat.le_of_lt hDone
   prevPivot_eq := by
-    -- Pivot at step k equals det (leadingPrefix source (k + 1) _), via
-    -- trailing_eq @ (i = j = ⟨k, _⟩) and borderedMinor_corner_eq_leadingPrefix.
+    -- Pivot at step k equals det (principalSubmatrix source (k + 1) _), via
+    -- trailing_eq @ (i = j = ⟨k, _⟩) and borderedMinor_corner_eq_principalSubmatrix.
     have hk : state.step < n := Nat.lt_of_succ_lt hDone
     have hkk :
         state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
@@ -151,7 +151,7 @@ private theorem bareissNoPivotInvariant_step
       hinv.trailing_eq hk ⟨state.step, hk⟩ ⟨state.step, hk⟩
         (Nat.le_refl _) (Nat.le_refl _)
     show state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] = _
-    rw [hkk, borderedMinor_corner_eq_leadingPrefix source state.step hk]
+    rw [hkk, borderedMinor_corner_eq_principalSubmatrix source state.step hk]
   prevPivot_ne := hp
   trailing_eq := by
     intro hnext i j hi hj
@@ -277,7 +277,7 @@ theorem bareissPivotNoPivot_column_eq_zero
 
 /-- In the pivot-search failure branch, the bordered-minor invariant identifies
 the zero current pivot with the next leading-prefix determinant. -/
-theorem bareissPivotNoPivot_leadingPrefix_det_eq_zero
+theorem bareissPivotNoPivot_principalSubmatrix_det_eq_zero
     (source : Hex.Matrix Int n n) (state : Hex.Matrix.BareissState n)
     (hinv : BareissNoPivotInvariant source state)
     (hDone : state.step + 1 < n)
@@ -287,7 +287,7 @@ theorem bareissPivotNoPivot_leadingPrefix_det_eq_zero
         (⟨state.step, Nat.lt_trans (Nat.lt_succ_self state.step) hDone⟩ : Fin n)
         (state.step + 1) = none) :
     Hex.Matrix.det
-      (Hex.Matrix.leadingPrefix source (state.step + 1)
+      (Hex.Matrix.principalSubmatrix source (state.step + 1)
         (Nat.succ_le_of_lt (Nat.lt_of_succ_lt hDone))) = 0 := by
   have hcol := bareissPivotNoPivot_column_eq_zero state hDone hp0 hfind
   have hk : state.step < n := Nat.lt_of_succ_lt hDone
@@ -301,7 +301,7 @@ theorem bareissPivotNoPivot_leadingPrefix_det_eq_zero
             (⟨state.step, hk⟩ : Fin n) (⟨state.step, hk⟩ : Fin n)) :=
     hinv.trailing_eq hk ⟨state.step, hk⟩ ⟨state.step, hk⟩
       (Nat.le_refl _) (Nat.le_refl _)
-  rw [hpivot_det, borderedMinor_corner_eq_leadingPrefix source state.step hk] at hpivot
+  rw [hpivot_det, borderedMinor_corner_eq_principalSubmatrix source state.step hk] at hpivot
   exact hpivot
 
 /-- One-step zero propagation for the singular row-pivoted Bareiss branch.
@@ -314,7 +314,7 @@ nonzero, so the next determinant must vanish. -/
 theorem borderedMinor_zero_column_succ_det_eq_zero_of_entries
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (hprev :
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) ≠ 0)
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val)
     (hcorner :
       Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
@@ -328,10 +328,10 @@ theorem borderedMinor_zero_column_succ_det_eq_zero_of_entries
     desnanot_jacobi_borderedMinor source k hk hnext i j hi hj
   have hmul_zero :
       Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) *
-          Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) = 0 := by
+          Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) = 0 := by
     calc
       Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) *
-          Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk))
+          Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk))
           =
         Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
             (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
@@ -365,7 +365,7 @@ transports that to this determinant column hypothesis. -/
 theorem borderedMinor_zero_column_succ_det_eq_zero
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (hprev :
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) ≠ 0)
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol : ∀ i : Fin n, k ≤ i.val →
       Hex.Matrix.det
         (Hex.Matrix.borderedMinor source k hk i (⟨k, hk⟩ : Fin n)) = 0)
@@ -420,11 +420,11 @@ theorem bareissPivotRegularSwap_det
 size-`k` leading prefix unchanged. Used in the row-pivoted Bareiss invariant
 to identify `prevPivot` with the leading-prefix determinant of the row-swapped
 source matrix. -/
-private theorem leadingPrefix_rowSwap_eq_of_le {R : Type u}
+private theorem principalSubmatrix_rowSwap_eq_of_le {R : Type u}
     (M : Hex.Matrix R n n) (k : Nat) (hk : k ≤ n)
     (kFin pivot : Fin n) (hkF : k ≤ kFin.val) (hp : k ≤ pivot.val) :
-    Hex.Matrix.leadingPrefix (Hex.Matrix.rowSwap M kFin pivot) k hk =
-      Hex.Matrix.leadingPrefix M k hk := by
+    Hex.Matrix.principalSubmatrix (Hex.Matrix.rowSwap M kFin pivot) k hk =
+      Hex.Matrix.principalSubmatrix M k hk := by
   apply Vector.ext
   intro r hr
   apply Vector.ext
@@ -438,10 +438,10 @@ private theorem leadingPrefix_rowSwap_eq_of_le {R : Type u}
     intro h
     have hval : r = pivot.val := by simpa using congrArg Fin.val h
     omega
-  show ((Hex.Matrix.rowSwap M kFin pivot).leadingPrefix k hk)[(⟨r, hr⟩ : Fin k)][
+  show ((Hex.Matrix.rowSwap M kFin pivot).principalSubmatrix k hk)[(⟨r, hr⟩ : Fin k)][
       (⟨c, hc⟩ : Fin k)] =
-    (M.leadingPrefix k hk)[(⟨r, hr⟩ : Fin k)][(⟨c, hc⟩ : Fin k)]
-  rw [Hex.Matrix.leadingPrefix_entry, Hex.Matrix.leadingPrefix_entry]
+    (M.principalSubmatrix k hk)[(⟨r, hr⟩ : Fin k)][(⟨c, hc⟩ : Fin k)]
+  rw [Hex.Matrix.getElem_principalSubmatrix, Hex.Matrix.getElem_principalSubmatrix]
   simp only [Hex.Matrix.rowSwap_getElem, if_neg h_r_ne_pivot, if_neg h_r_ne_kFin]
 
 /-- Auxiliary: a row of `rowSwap M kFin pivot` with index `r` not equal to
@@ -561,7 +561,7 @@ theorem bareissPivotInvariant_regular_swap
     -- have value ≥ state.step.
     have hkF_ge : state.step ≤ kFin.val := Nat.le_of_eq hkF_val.symm
     have hp_le : state.step ≤ pivot.val := Nat.le_of_succ_le hp_ge
-    rw [leadingPrefix_rowSwap_eq_of_le source state.step hinv.step_le kFin pivot
+    rw [principalSubmatrix_rowSwap_eq_of_le source state.step hinv.step_le kFin pivot
       hkF_ge hp_le]
     exact hinv.prevPivot_eq
   · intro hnext i j hi hj
@@ -778,7 +778,7 @@ theorem noPivotLoop_invariant
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
       Hex.Matrix.det
-        (Hex.Matrix.leadingPrefix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
+        (Hex.Matrix.principalSubmatrix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
           ≠ 0) :
     BareissNoPivotInvariant source (Hex.Matrix.noPivotLoop fuel state) := by
   induction fuel generalizing state with
@@ -793,11 +793,11 @@ theorem noPivotLoop_invariant
         have hpivot_idx :
             state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
               Hex.Matrix.det
-                (Hex.Matrix.leadingPrefix source (state.step + 1)
+                (Hex.Matrix.principalSubmatrix source (state.step + 1)
                   (Nat.succ_le_of_lt hk)) := by
           rw [hinv.trailing_eq hk ⟨state.step, hk⟩ ⟨state.step, hk⟩
             (Nat.le_refl _) (Nat.le_refl _)]
-          rw [borderedMinor_corner_eq_leadingPrefix source state.step hk]
+          rw [borderedMinor_corner_eq_principalSubmatrix source state.step hk]
         have hp_ne :
             state.matrix[(⟨state.step, hk⟩ : Fin n)][
               (⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
@@ -901,7 +901,7 @@ private theorem noPivotLoop_step_succ_ge
     (hinv : BareissNoPivotInvariant source state)
     (hpivots : ∀ (k : Fin n), state.step ≤ k.val →
       Hex.Matrix.det
-        (Hex.Matrix.leadingPrefix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
+        (Hex.Matrix.principalSubmatrix source (k.val + 1) (Nat.succ_le_of_lt k.isLt))
           ≠ 0)
     (hfuel : n ≤ state.step + fuel + 1) :
     n ≤ (Hex.Matrix.noPivotLoop fuel state).step + 1 := by
@@ -915,11 +915,11 @@ private theorem noPivotLoop_step_succ_ge
         have hpivot_idx :
             state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
               Hex.Matrix.det
-                (Hex.Matrix.leadingPrefix source (state.step + 1)
+                (Hex.Matrix.principalSubmatrix source (state.step + 1)
                   (Nat.succ_le_of_lt hk)) := by
           rw [hinv.trailing_eq hk ⟨state.step, hk⟩ ⟨state.step, hk⟩
             (Nat.le_refl _) (Nat.le_refl _)]
-          rw [borderedMinor_corner_eq_leadingPrefix source state.step hk]
+          rw [borderedMinor_corner_eq_principalSubmatrix source state.step hk]
         have hp_ne :
             state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] ≠ 0 := by
           rw [hpivot_idx]
@@ -937,14 +937,14 @@ private theorem noPivotLoop_step_succ_ge
         omega
 
 /-- The leading prefix of size `n` of an `n × n` matrix is the matrix itself. -/
-private theorem leadingPrefix_self {R : Type u} [Lean.Grind.Ring R]
+private theorem principalSubmatrix_self {R : Type u} [Lean.Grind.Ring R]
     (M : Hex.Matrix R n n) (h : n ≤ n) :
-    Hex.Matrix.leadingPrefix M n h = M := by
+    Hex.Matrix.principalSubmatrix M n h = M := by
   apply Vector.ext
   intro i hi
   apply Vector.ext
   intro j hj
-  simp [Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn]
+  simp [Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn]
 
 /-- Helper: under the bordered-minor invariant, when the recurrence step
 equals `k`, the `(k, k)` entry of the working matrix equals `Hex.Matrix.det M`.
@@ -971,8 +971,8 @@ private theorem trailing_corner_entry_eq_det
       (⟨step', hk'⟩ : Fin (step' + 1))] =
     Hex.Matrix.det
       (Hex.Matrix.borderedMinor M step' hk' ⟨step', hk'⟩ ⟨step', hk'⟩) at h_trail
-  rw [h_trail, borderedMinor_corner_eq_leadingPrefix M step' hk',
-    leadingPrefix_self M (Nat.succ_le_of_lt hk')]
+  rw [h_trail, borderedMinor_corner_eq_principalSubmatrix M step' hk',
+    principalSubmatrix_self M (Nat.succ_le_of_lt hk')]
 
 /-- Capstone: under `NonzeroBareissPivots`, the no-pivot Bareiss recurrence
 computes the Mathlib determinant of the source matrix. -/
@@ -1046,7 +1046,7 @@ preceding leading-prefix determinant is nonzero, then there is an explicit
 linear combination of the columns of `source` — with coefficients given by the
 signed `k × k` cofactors of the leading prefix augmented with column `k` —
 that vanishes at every row. The coefficient on column `k` is
-`Hex.Matrix.det (Hex.Matrix.leadingPrefix source k _)`, which is nonzero by
+`Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k _)`, which is nonzero by
 hypothesis. The follow-up issue closes the determinant via
 `Matrix.det_updateCol_sum` and the duplicate-column determinant identity. -/
 
@@ -1067,7 +1067,7 @@ def failedBareissTopBlock
 /-- Coefficient function for the failed-pivot column dependence. The value at
 `c` is `(-1)^(k + c.val) * det(failedBareissTopBlock with column c removed)` for
 `c.val ≤ k` and `0` otherwise. The coefficient on column `k` is
-`det (leadingPrefix source k _)`; see `failedBareissColumn_at_pivot`. -/
+`det (principalSubmatrix source k _)`; see `failedBareissColumn_at_pivot`. -/
 @[expose]
 noncomputable def failedBareissColumn
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
@@ -1108,21 +1108,21 @@ private theorem failedBareissTopBlock_apply_last
 private theorem failedBareissTopBlock_succAbove_last
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
     (failedBareissTopBlock source k hk).submatrix id (Fin.last k).succAbove =
-      matrixEquiv (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) := by
+      matrixEquiv (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) := by
   ext s t
   show failedBareissTopBlock source k hk s ((Fin.last k).succAbove t) = _
   rw [Fin.succAbove_last]
   have ht : (t.castSucc : Fin (k + 1)).val < k := by
     show t.val < k; exact t.isLt
   rw [failedBareissTopBlock_apply_lt source k hk s t.castSucc ht]
-  show matrixEquiv source _ _ = matrixEquiv (Hex.Matrix.leadingPrefix _ _ _) _ _
-  rw [matrixEquiv_apply, matrixEquiv_apply, Hex.Matrix.leadingPrefix_entry]
+  show matrixEquiv source _ _ = matrixEquiv (Hex.Matrix.principalSubmatrix _ _ _) _ _
+  rw [matrixEquiv_apply, matrixEquiv_apply, Hex.Matrix.getElem_principalSubmatrix]
   rfl
 
 theorem failedBareissColumn_at_pivot
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n) :
     failedBareissColumn source k hk ⟨k, hk⟩ =
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) := by
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) := by
   show (if hc : (⟨k, hk⟩ : Fin n).val ≤ k then
       (-1) ^ (k + (⟨k, hk⟩ : Fin n).val) *
         Matrix.det ((failedBareissTopBlock source k hk).submatrix id
@@ -1314,7 +1314,7 @@ function `failedBareissColumn`. -/
 theorem failed_bareiss_column_dependence
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
     (hprev :
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) ≠ 0)
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol :
       ∀ i : Fin n, k ≤ i.val →
         Hex.Matrix.det
@@ -1358,7 +1358,7 @@ determinant via `Matrix.exists_mulVec_eq_zero_iff`. -/
 theorem det_eq_zero_of_bareiss_failed_column
     (source : Hex.Matrix Int n n) (k : Nat) (hk : k < n)
     (hprev :
-      Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) ≠ 0)
+      Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) ≠ 0)
     (hcol : ∀ i : Fin n, k ≤ i.val →
       Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk i ⟨k, hk⟩) = 0) :
     Hex.Matrix.det source = 0 := by
@@ -1387,7 +1387,7 @@ theorem bareissPivotInvariant_singular_no_pivot_det_eq_zero
   have hk : state.step < n := Nat.lt_of_succ_lt hDone
   have hprev :
       Hex.Matrix.det
-          (Hex.Matrix.leadingPrefix logicalSource state.step (Nat.le_of_lt hk)) ≠ 0 := by
+          (Hex.Matrix.principalSubmatrix logicalSource state.step (Nat.le_of_lt hk)) ≠ 0 := by
     rw [← hnopiv.prevPivot_eq]
     exact hnopiv.prevPivot_ne
   have hzero_col := bareissPivotNoPivot_column_eq_zero state hDone hp0 hfind

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -265,7 +265,7 @@ the leading prefix minor obtained by deleting the last row and column. -/
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) :
     (adjugate M)[Fin.last n][Fin.last n] =
-      det (leadingPrefix M n (Nat.le_succ n)) := by
+      det (principalSubmatrix M n (Nat.le_succ n)) := by
   rw [adjugate_get]
   exact cofactor_last_last M
 

--- a/HexDeterminant/Index.lean
+++ b/HexDeterminant/Index.lean
@@ -25,7 +25,7 @@ duplicate-free (`permutationVectors_nodup`, `permutationVectors_nodup_list`).
 Building on these, it derives the determinant's behaviour on the
 `insertAt`-extended permutation (`detTerm_insertAt_general`,
 `detSign_insertAt_general`), the last-row factorisation
-`det_eq_det_leadingPrefix_mul_last_of_last_row_zero`, and the triangular
+`det_eq_det_principalSubmatrix_mul_last_of_last_row_zero`, and the triangular
 results `det_upperTriangular_eq_finFoldl_diag`,
 `det_upperTriangular_eq_foldl_diag`, and `det_upperTriangular_pos_diag`.
 -/
@@ -710,7 +710,7 @@ row/column entry. -/
 theorem detProduct_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (v : Vector (Fin n) n) :
     detProduct M (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
-      detProduct (leadingPrefix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n] := by
+      detProduct (principalSubmatrix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n] := by
   unfold detProduct
   rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
@@ -721,14 +721,14 @@ theorem detProduct_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
               M[i.castSucc][
                 (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n))[i.castSucc]]) 1 =
         Fin.foldl n
-          (fun acc i => acc * (leadingPrefix M n (Nat.le_succ n))[i][v[i]]) 1 := by
+          (fun acc i => acc * (principalSubmatrix M n (Nat.le_succ n))[i][v[i]]) 1 := by
     congr
     funext acc i
     have hget :
         (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n))[i.castSucc] =
           (v[i]).castSucc := by
       simpa using insertAt_last_get_castSucc (Fin.last n) (v.map Fin.castSucc) i
-    simp [leadingPrefix, ofFn, hget]
+    simp [principalSubmatrix, ofFn, hget]
   have hlast :
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n))[Fin.last n] =
         Fin.last n := by
@@ -742,7 +742,7 @@ theorem detTerm_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (v : Vector (Fin n) n) :
     detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
       detSign (R := R) v *
-        (detProduct (leadingPrefix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
+        (detProduct (principalSubmatrix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
   unfold detTerm
   rw [detSign_insertAt_last, detProduct_insertAt_last]
 
@@ -923,7 +923,7 @@ private theorem foldl_detTerm_last_row_insertions
         (fun acc i =>
           acc + detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
       z + detSign (R := R) v *
-        (detProduct (leadingPrefix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
+        (detProduct (principalSubmatrix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
   rw [← Fin.foldl_eq_finRange_foldl]
   rw [Fin.foldl_succ_last]
   have hprefix :
@@ -956,11 +956,11 @@ private theorem foldl_detTerm_last_row_insertions
 factors as the leading principal determinant times the bottom-right entry.
 This is the triangular-recursion step used by positivity and diagonal-product
 lemmas. -/
-theorem det_eq_det_leadingPrefix_mul_last_of_last_row_zero
+theorem det_eq_det_principalSubmatrix_mul_last_of_last_row_zero
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1))
     (hrow : ∀ j : Fin (n + 1), j.val < n → M[Fin.last n][j] = 0) :
-    det M = det (leadingPrefix M n (Nat.le_succ n)) * M[Fin.last n][Fin.last n] := by
+    det M = det (principalSubmatrix M n (Nat.le_succ n)) * M[Fin.last n][Fin.last n] := by
   unfold det
   rw [show permutationVectors (n + 1) =
       List.flatMap
@@ -987,26 +987,26 @@ theorem det_eq_det_leadingPrefix_mul_last_of_last_row_zero
       (permutationVectors n).foldl
         (fun acc v =>
           acc + detSign (R := R) v *
-            (detProduct (leadingPrefix M n (Nat.le_succ n)) v *
+            (detProduct (principalSubmatrix M n (Nat.le_succ n)) v *
               M[Fin.last n][Fin.last n])) 0 := by
         apply foldl_acc_congr
         intro acc v _hmem
         exact foldl_detTerm_last_row_insertions M v acc hrow
     _ =
       (permutationVectors n).foldl
-          (fun acc v => acc + detTerm (leadingPrefix M n (Nat.le_succ n)) v) 0 *
+          (fun acc v => acc + detTerm (principalSubmatrix M n (Nat.le_succ n)) v) 0 *
         M[Fin.last n][Fin.last n] := by
         unfold detTerm
         calc
           (permutationVectors n).foldl
               (fun acc v =>
                 acc + detSign (R := R) v *
-                  (detProduct (leadingPrefix M n (Nat.le_succ n)) v *
+                  (detProduct (principalSubmatrix M n (Nat.le_succ n)) v *
                     M[Fin.last n][Fin.last n])) 0 =
             (permutationVectors n).foldl
               (fun acc v =>
                 acc + (detSign (R := R) v *
-                  detProduct (leadingPrefix M n (Nat.le_succ n)) v) *
+                  detProduct (principalSubmatrix M n (Nat.le_succ n)) v) *
                     M[Fin.last n][Fin.last n]) 0 := by
               apply foldl_det_sum_congr
               intro v _hmem
@@ -1015,14 +1015,14 @@ theorem det_eq_det_leadingPrefix_mul_last_of_last_row_zero
             (permutationVectors n).foldl
                 (fun acc v =>
                   acc + detSign (R := R) v *
-                    detProduct (leadingPrefix M n (Nat.le_succ n)) v) 0 *
+                    detProduct (principalSubmatrix M n (Nat.le_succ n)) v) 0 *
               M[Fin.last n][Fin.last n] := by
               exact foldl_det_sum_mul_right_zero
                 (permutationVectors n)
                 (fun v => detSign (R := R) v *
-                  detProduct (leadingPrefix M n (Nat.le_succ n)) v)
+                  detProduct (principalSubmatrix M n (Nat.le_succ n)) v)
                 M[Fin.last n][Fin.last n]
-    _ = det (leadingPrefix M n (Nat.le_succ n)) * M[Fin.last n][Fin.last n] := by
+    _ = det (principalSubmatrix M n (Nat.le_succ n)) * M[Fin.last n][Fin.last n] := by
         rfl
 
 /-- An integer upper-triangular matrix with strictly positive diagonal has
@@ -1039,26 +1039,26 @@ theorem det_upperTriangular_pos_diag
       have hrow : ∀ j : Fin (n + 1), j.val < n → M[Fin.last n][j] = 0 := by
         intro j hj
         exact hzero (Fin.last n) j hj
-      rw [det_eq_det_leadingPrefix_mul_last_of_last_row_zero M hrow]
+      rw [det_eq_det_principalSubmatrix_mul_last_of_last_row_zero M hrow]
       have hprefixZero :
           ∀ i j : Fin n, j.val < i.val →
-            (leadingPrefix M n (Nat.le_succ n))[i][j] = 0 := by
+            (principalSubmatrix M n (Nat.le_succ n))[i][j] = 0 := by
         intro i j hij
         let ii : Fin (n + 1) := ⟨i.val, by omega⟩
         let jj : Fin (n + 1) := ⟨j.val, by omega⟩
-        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][j] = M[ii][jj] := by
-          simp [leadingPrefix, ofFn, ii, jj]
+        have hentry : (principalSubmatrix M n (Nat.le_succ n))[i][j] = M[ii][jj] := by
+          simp [principalSubmatrix, ofFn, ii, jj]
         rw [hentry]
         exact hzero ii jj hij
       have hprefixDiag :
-          ∀ i : Fin n, 0 < (leadingPrefix M n (Nat.le_succ n))[i][i] := by
+          ∀ i : Fin n, 0 < (principalSubmatrix M n (Nat.le_succ n))[i][i] := by
         intro i
         let ii : Fin (n + 1) := ⟨i.val, by omega⟩
-        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][i] = M[ii][ii] := by
-          simp [leadingPrefix, ofFn, ii]
+        have hentry : (principalSubmatrix M n (Nat.le_succ n))[i][i] = M[ii][ii] := by
+          simp [principalSubmatrix, ofFn, ii]
         rw [hentry]
         exact hdiag ii
-      exact Int.mul_pos (ih (leadingPrefix M n (Nat.le_succ n)) hprefixZero hprefixDiag)
+      exact Int.mul_pos (ih (principalSubmatrix M n (Nat.le_succ n)) hprefixZero hprefixDiag)
         (hdiag (Fin.last n))
 
 /-- The determinant of an upper-triangular square matrix (entries below the
@@ -1078,31 +1078,31 @@ theorem det_upperTriangular_eq_finFoldl_diag
       have hrow : ∀ j : Fin (n + 1), j.val < n → M[Fin.last n][j] = 0 := by
         intro j hj
         exact hzero (Fin.last n) j hj
-      rw [det_eq_det_leadingPrefix_mul_last_of_last_row_zero M hrow]
+      rw [det_eq_det_principalSubmatrix_mul_last_of_last_row_zero M hrow]
       have hprefixZero :
           ∀ i j : Fin n, j.val < i.val →
-            (leadingPrefix M n (Nat.le_succ n))[i][j] = 0 := by
+            (principalSubmatrix M n (Nat.le_succ n))[i][j] = 0 := by
         intro i j hij
         let ii : Fin (n + 1) := ⟨i.val, by omega⟩
         let jj : Fin (n + 1) := ⟨j.val, by omega⟩
-        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][j] = M[ii][jj] := by
-          simp [leadingPrefix, ofFn, ii, jj]
+        have hentry : (principalSubmatrix M n (Nat.le_succ n))[i][j] = M[ii][jj] := by
+          simp [principalSubmatrix, ofFn, ii, jj]
         rw [hentry]
         exact hzero ii jj hij
-      rw [ih (leadingPrefix M n (Nat.le_succ n)) hprefixZero]
+      rw [ih (principalSubmatrix M n (Nat.le_succ n)) hprefixZero]
       -- The (n+1)-length Fin.foldl over diagonals splits as the n-length foldl
       -- times the last diagonal entry.
       rw [Fin.foldl_succ_last]
       -- Rewrite the leading prefix diagonal entries as M[i.castSucc][i.castSucc].
       have hcongr :
           Fin.foldl n
-              (fun acc i => acc * (leadingPrefix M n (Nat.le_succ n))[i][i]) 1 =
+              (fun acc i => acc * (principalSubmatrix M n (Nat.le_succ n))[i][i]) 1 =
             Fin.foldl n (fun acc i => acc * M[i.castSucc][i.castSucc]) 1 := by
         rw [Fin.foldl_eq_finRange_foldl, Fin.foldl_eq_finRange_foldl]
         apply foldl_acc_congr
         intro acc i _hmem
-        have hentry : (leadingPrefix M n (Nat.le_succ n))[i][i] = M[i.castSucc][i.castSucc] :=
-          by simp [leadingPrefix, ofFn, Fin.castSucc]
+        have hentry : (principalSubmatrix M n (Nat.le_succ n))[i][i] = M[i.castSucc][i.castSucc] :=
+          by simp [principalSubmatrix, ofFn, Fin.castSucc]
         rw [hentry]
       rw [hcongr]
 

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -23,7 +23,7 @@ This module defines the determinant `det` of a dense square matrix as the
 `permutationVectors`-indexed sum of signed Leibniz terms, built from `detSign`
 (the inversion-parity sign of a permutation vector), `detProduct` (the unsigned
 diagonal product), and `detTerm` (their product). It records the small base
-cases `det_one_by_one`, `det_two_by_two`, and `det_leadingPrefix_zero`, and
+cases `det_one_by_one`, `det_two_by_two`, and `det_principalSubmatrix_zero`, and
 provides the reusable `foldl`-arithmetic toolkit (scalar factoring, additive
 splitting, permutation invariance, single-index scaling) plus the
 `Fin.castSucc`/`Fin.last` inversion-count lemmas used by the recursive
@@ -59,9 +59,9 @@ def det {R : Type u} [Lean.Grind.Ring R] {n : Nat} (M : Matrix R n n) : R :=
 
 /-- The determinant of the empty leading prefix is the Bareiss previous-pivot
 convention `1`. -/
-@[simp, grind =] theorem det_leadingPrefix_zero {R : Type u} [Lean.Grind.Ring R]
+@[simp, grind =] theorem det_principalSubmatrix_zero {R : Type u} [Lean.Grind.Ring R]
     (M : Matrix R n n) :
-    det (leadingPrefix M 0 (Nat.zero_le n)) = (1 : R) := by
+    det (principalSubmatrix M 0 (Nat.zero_le n)) = (1 : R) := by
   simp [det, detTerm, detSign, detProduct, permutationVectors, inversionCount]
   grind
 

--- a/HexDeterminant/Minor.lean
+++ b/HexDeterminant/Minor.lean
@@ -107,14 +107,14 @@ This is the minor normalization used by bottom-right cofactor expansion. -/
 @[simp, grind =] theorem deleteRowCol_last_last {R : Type u} {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) :
     deleteRowCol M (Fin.last n) (Fin.last n) =
-      leadingPrefix M n (Nat.le_succ n) := by
+      principalSubmatrix M n (Nat.le_succ n) := by
   ext i hi j hj
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin n := ⟨j, hj⟩
   change (deleteRowCol M (Fin.last n) (Fin.last n))[ii][jj] =
-    (leadingPrefix M n (Nat.le_succ n))[ii][jj]
+    (principalSubmatrix M n (Nat.le_succ n))[ii][jj]
   rw [deleteRowCol_entry]
-  simp [leadingPrefix, ofFn]
+  simp [principalSubmatrix, ofFn]
 
 /-- Deleting row `row` and column `col` after transposing is the transpose of
 the minor obtained by deleting row `col` and column `row` before transposing. -/
@@ -177,7 +177,7 @@ This combines the final-index minor with its even sign. -/
 @[simp, grind =] theorem cofactor_last_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) :
     cofactor M (Fin.last n) (Fin.last n) =
-      det (leadingPrefix M n (Nat.le_succ n)) := by
+      det (principalSubmatrix M n (Nat.le_succ n)) := by
   rw [cofactor_of_even]
   · simp
   · omega

--- a/HexDeterminant/Selection.lean
+++ b/HexDeterminant/Selection.lean
@@ -1155,62 +1155,62 @@ theorem firstColumns_mem_selectedColumnTuples (k n : Nat) (hk : k ≤ n) :
 
 /-- Selecting the first `k` columns from the leading `k` rows of a square
 matrix gives exactly its leading `k × k` prefix. -/
-theorem columnTupleMatrix_leadingRows_firstColumns_eq_leadingPrefix
+theorem columnTupleMatrix_takeRows_firstColumns_eq_principalSubmatrix
     {R : Type u} {n : Nat} (M : Matrix R n n) (k : Nat) (hk : k ≤ n) :
-    columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn (firstColumns k n hk)) =
-      leadingPrefix M k hk := by
+    columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn (firstColumns k n hk)) =
+      principalSubmatrix M k hk := by
   ext i hi j hj
   change
-    (columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn (firstColumns k n hk)))[
+    (columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn (firstColumns k n hk)))[
         (⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)] =
-      (leadingPrefix M k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
-  simp [columnTupleMatrix, leadingRows, leadingPrefix, columnTupleVectorFn, firstColumns, ofFn]
+      (principalSubmatrix M k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
+  simp [columnTupleMatrix, takeRows, principalSubmatrix, columnTupleVectorFn, firstColumns, ofFn]
 
 /-- The Gram determinant of the first `k` rows of a positive-diagonal integer
 upper-triangular matrix is strictly positive. The leading-principal minor
 provides a positive square term in the Cauchy-Binet expansion. -/
-theorem det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag
+theorem det_gramMatrix_takeRows_pos_of_upperTriangular_pos_diag
     {n : Nat} (M : Matrix Int n n)
     (hzero : ∀ i j : Fin n, j.val < i.val → M[i][j] = 0)
     (hdiag : ∀ i : Fin n, 0 < M[i][i])
     (k : Nat) (hk : k ≤ n) :
-    0 < det (gramMatrix (leadingRows M k hk)) := by
-  rw [det_gramMatrix_eq_sum_minors_sq (leadingRows M k hk)]
+    0 < det (gramMatrix (takeRows M k hk)) := by
+  rw [det_gramMatrix_eq_sum_minors_sq (takeRows M k hk)]
   let cols := firstColumns k n hk
   have hmem : cols ∈ selectedColumnTuples k n :=
     firstColumns_mem_selectedColumnTuples k n hk
   have hminor_eq :
-      det (columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn cols)) =
-        det (leadingPrefix M k hk) := by
+      det (columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn cols)) =
+        det (principalSubmatrix M k hk) := by
     dsimp [cols]
-    rw [columnTupleMatrix_leadingRows_firstColumns_eq_leadingPrefix M k hk]
+    rw [columnTupleMatrix_takeRows_firstColumns_eq_principalSubmatrix M k hk]
   have hprefixZero :
-      ∀ i j : Fin k, j.val < i.val → (leadingPrefix M k hk)[i][j] = 0 := by
+      ∀ i j : Fin k, j.val < i.val → (principalSubmatrix M k hk)[i][j] = 0 := by
     intro i j hij
     let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
     let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
-    have hentry : (leadingPrefix M k hk)[i][j] = M[ii][jj] := by
-      simp [leadingPrefix, ofFn, ii, jj]
+    have hentry : (principalSubmatrix M k hk)[i][j] = M[ii][jj] := by
+      simp [principalSubmatrix, ofFn, ii, jj]
     rw [hentry]
     exact hzero ii jj hij
   have hprefixDiag :
-      ∀ i : Fin k, 0 < (leadingPrefix M k hk)[i][i] := by
+      ∀ i : Fin k, 0 < (principalSubmatrix M k hk)[i][i] := by
     intro i
     let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
-    have hentry : (leadingPrefix M k hk)[i][i] = M[ii][ii] := by
-      simp [leadingPrefix, ofFn, ii]
+    have hentry : (principalSubmatrix M k hk)[i][i] = M[ii][ii] := by
+      simp [principalSubmatrix, ofFn, ii]
     rw [hentry]
     exact hdiag ii
   have hminor_pos :
-      0 < det (columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn cols)) := by
+      0 < det (columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn cols)) := by
     rw [hminor_eq]
-    exact det_upperTriangular_pos_diag (leadingPrefix M k hk) hprefixZero hprefixDiag
+    exact det_upperTriangular_pos_diag (principalSubmatrix M k hk) hprefixZero hprefixDiag
   have hminor_sq_pos :
-      0 < det (columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn cols)) ^ 2 := by
+      0 < det (columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn cols)) ^ 2 := by
     simpa [Lean.Grind.Semiring.pow_two] using Int.mul_pos hminor_pos hminor_pos
   exact foldl_int_sum_sq_pos_of_mem
     (xs := selectedColumnTuples k n)
-    (f := fun cols => det (columnTupleMatrix (leadingRows M k hk) (columnTupleVectorFn cols)))
+    (f := fun cols => det (columnTupleMatrix (takeRows M k hk) (columnTupleVectorFn cols)))
     (x := cols) hmem hminor_sq_pos
 
 

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -1341,22 +1341,22 @@ private theorem M_k1_eq_matrixEquiv_borderedMinor_submatrix [CommRing R]
 
 /-- The interior `(k × k)` submatrix of the reindexed Bareiss bordered minor:
 deleting both row 0 and the last row (and similarly columns) leaves exactly
-`matrixEquiv (leadingPrefix source k _)`. -/
-private theorem M_interior_eq_matrixEquiv_leadingPrefix [CommRing R]
+`matrixEquiv (principalSubmatrix source k _)`. -/
+private theorem M_interior_eq_matrixEquiv_principalSubmatrix [CommRing R]
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) :
     (((matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)).submatrix
         (bareissDesnanotIndex k) (bareissDesnanotIndex k)).submatrix
         (Fin.succAbove (0 : Fin (k + 2)) ∘ (Fin.last k).succAbove)
         (Fin.succAbove (0 : Fin (k + 2)) ∘ (Fin.last k).succAbove)) =
-      matrixEquiv (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) := by
+      matrixEquiv (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) := by
   ext r c
   show matrixEquiv (Hex.Matrix.borderedMinor source (k + 1) hnext i j)
         (bareissDesnanotIndex k (Fin.succAbove (0 : Fin (k + 2))
           ((Fin.last k).succAbove r)))
         (bareissDesnanotIndex k (Fin.succAbove (0 : Fin (k + 2))
           ((Fin.last k).succAbove c))) =
-      matrixEquiv (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) r c
+      matrixEquiv (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) r c
   -- (last k).succAbove r = r.castSucc, then succAbove 0 of r.castSucc = r.castSucc.succ
   simp only [Fin.succAbove_last, Fin.succAbove_zero]
   -- Now use bareissDesnanotIndex_succ_lt with r.castSucc, since (r.castSucc).val = r.val < k
@@ -1371,7 +1371,7 @@ private theorem M_interior_eq_matrixEquiv_leadingPrefix [CommRing R]
   show (Hex.Matrix.borderedMinor source (k + 1) hnext i j)[
       (⟨r.val, by omega⟩ : Fin (k + 2))][
       (⟨c.val, by omega⟩ : Fin (k + 2))] = _
-  simp [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.leadingPrefix,
+  simp [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.principalSubmatrix,
     show r.val ≤ k from r.isLt.le, show c.val ≤ k from c.isLt.le]
 
 /-- After reindexing the `(k+2)` bordered minor by `bareissDesnanotIndex k`,
@@ -1396,14 +1396,14 @@ private theorem M11_eq_matrixEquiv_borderedMinor [CommRing R]
 
 /-- Desnanot-Jacobi specialised to a Bareiss bordered minor: the Mathlib
 determinant identity from `desnanot_jacobi_borderedMinor_reindex` translated
-back into Hex `borderedMinor`/`leadingPrefix` determinants. This produces the
+back into Hex `borderedMinor`/`principalSubmatrix` determinants. This produces the
 `hdesnanot` premise expected by `bareissExactDiv_borderedMinor_of_mul_eq` with
-`prevPivot` instantiated as `det (leadingPrefix source k _)`. -/
+`prevPivot` instantiated as `det (principalSubmatrix source k _)`. -/
 theorem desnanot_jacobi_borderedMinor [CommRing R]
     (source : Hex.Matrix R n n) (k : Nat) (hk : k < n) (hnext : k + 1 < n)
     (i j : Fin n) (hi : k < i.val) (hj : k < j.val) :
     Hex.Matrix.det (Hex.Matrix.borderedMinor source (k + 1) hnext i j) *
-        Hex.Matrix.det (Hex.Matrix.leadingPrefix source k (Nat.le_of_lt hk)) =
+        Hex.Matrix.det (Hex.Matrix.principalSubmatrix source k (Nat.le_of_lt hk)) =
       Hex.Matrix.det (Hex.Matrix.borderedMinor source k hk
           (⟨k, Nat.lt_trans hj j.isLt⟩ : Fin n)
           (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n)) *
@@ -1418,7 +1418,7 @@ theorem desnanot_jacobi_borderedMinor [CommRing R]
   dsimp only at hdj
   -- Identify each Mathlib determinant with a Hex determinant.
   rw [det_borderedMinor_bareissDesnanotIndex source k hnext i j] at hdj
-  rw [M_interior_eq_matrixEquiv_leadingPrefix source k hk hnext i j,
+  rw [M_interior_eq_matrixEquiv_principalSubmatrix source k hk hnext i j,
       ← det_eq] at hdj
   rw [M11_eq_matrixEquiv_borderedMinor source k hk hnext i j, ← det_eq] at hdj
   rw [M_kk_eq_matrixEquiv_borderedMinor_submatrix source k hk hnext i j,

--- a/HexDeterminantMathlib/CoreTransport.lean
+++ b/HexDeterminantMathlib/CoreTransport.lean
@@ -293,14 +293,14 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
   rw [equivs_toFinset]
 
 /-- `matrixEquiv` sends Hex leading prefixes to Mathlib submatrices. -/
-theorem matrixEquiv_leadingPrefix
+theorem matrixEquiv_principalSubmatrix
     (M : Hex.Matrix R n n) (k : Nat) (hk : k ≤ n) :
-    matrixEquiv (Hex.Matrix.leadingPrefix M k hk) =
+    matrixEquiv (Hex.Matrix.principalSubmatrix M k hk) =
       (matrixEquiv M).submatrix
         (fun r : Fin k => ⟨r.val, Nat.lt_of_lt_of_le r.isLt hk⟩)
         (fun c : Fin k => ⟨c.val, Nat.lt_of_lt_of_le c.isLt hk⟩) := by
   ext r c
-  simp [Hex.Matrix.leadingPrefix, Hex.Matrix.ofFn]
+  simp [Hex.Matrix.principalSubmatrix, Hex.Matrix.ofFn]
 
 /-- `matrixEquiv` sends Hex bordered Bareiss minors to Mathlib submatrices. -/
 theorem matrixEquiv_borderedMinor
@@ -314,15 +314,15 @@ theorem matrixEquiv_borderedMinor
   ext r c
   simp [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn]
 
-/-- Determinant form of `matrixEquiv_leadingPrefix`. -/
-theorem det_leadingPrefix_eq_submatrix_det [CommRing R]
+/-- Determinant form of `matrixEquiv_principalSubmatrix`. -/
+theorem det_principalSubmatrix_eq_submatrix_det [CommRing R]
     (M : Hex.Matrix R n n) (k : Nat) (hk : k ≤ n) :
-    Hex.Matrix.det (Hex.Matrix.leadingPrefix M k hk) =
+    Hex.Matrix.det (Hex.Matrix.principalSubmatrix M k hk) =
       Matrix.det
         ((matrixEquiv M).submatrix
           (fun r : Fin k => ⟨r.val, Nat.lt_of_lt_of_le r.isLt hk⟩)
           (fun c : Fin k => ⟨c.val, Nat.lt_of_lt_of_le c.isLt hk⟩)) := by
-  rw [det_eq, matrixEquiv_leadingPrefix]
+  rw [det_eq, matrixEquiv_principalSubmatrix]
 
 /-- Determinant form of `matrixEquiv_borderedMinor`. -/
 theorem det_borderedMinor_eq_submatrix_det [CommRing R]

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -1619,7 +1619,7 @@ The row-`s` column is cleared by combining the non-singular Schur≡Bareiss
 correspondence at fuel `s`
 (`getArrayEntry_scaledCoeffRowsSchur_eq_noPivotLoop_of_nonsing`) with the
 column-zero structural lemma at the singular step
-(`leadingPrefix_gram_zero_pivot_column_zero`). Strong
+(`principalSubmatrix_gram_zero_pivot_column_zero`). Strong
 induction on `j' ∈ (s, j]` then propagates the zeros via the Schur recurrence
 `rows[i'][j'] = rows[j'-1][j'-1] · gram[i'][j'] - schurSigma i' j'`. The
 diagonal factor `rows[j'-1][j'-1]` is zero by the row-`s` lemma when
@@ -1655,7 +1655,7 @@ theorem getArrayEntry_scaledCoeffRowsSchur_eq_zero_of_singularStep_lt
     · have hc_gt : s < c := Nat.lt_of_le_of_ne hcs (Ne.symm hcs_eq)
       have hs_succ_lt_n : s + 1 < n := Nat.lt_of_le_of_lt hc_gt hcn
       rw [h_corr_at_s.2 c hc_gt hcn]
-      exact leadingPrefix_gram_zero_pivot_column_zero
+      exact principalSubmatrix_gram_zero_pivot_column_zero
         b s hs_succ_lt_n hquot h_s_prefix_none h_s_diag_zero ⟨c, hcn⟩ hc_gt
   -- Strong induction on `j'` ∈ (s, j].
   suffices h_cascade : ∀ (j' : Nat), j' ≤ j → s < j' →
@@ -1899,17 +1899,17 @@ theorem scaledCoeffs_diag_toNat (b : Matrix Int n m) (hquot : StepWitness b)
 The diagonal slot is either the zero tail recorded after an earlier singular
 no-pivot step, or the Bareiss determinant of the corresponding leading Gram
 prefix. -/
-theorem scaledCoeffs_diag_eq_zero_or_eq_leadingPrefix_bareiss
+theorem scaledCoeffs_diag_eq_zero_or_eq_principalSubmatrix_bareiss
     (b : Matrix Int n m) (hquot : StepWitness b)
     (i : Nat) (hi : i < n) :
     GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ = 0 ∨
       GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
         Matrix.bareiss
-          (Matrix.leadingPrefix (Matrix.gramMatrix b) (i + 1)
+          (Matrix.principalSubmatrix (Matrix.gramMatrix b) (i + 1)
             (Nat.succ_le_of_lt hi)) := by
   rw [scaledCoeffs_entry_eq_getArrayEntry,
     getArrayEntry_scaledCoeffRowsSchur_eq b hquot]
-  exact scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss (b := b) i hi
+  exact scaledCoeffRows_diag_eq_zero_or_eq_principalSubmatrix_bareiss (b := b) i hi
 
 /-- Int-valued diagonal identity for the scaled Gram-Schmidt coefficients: once
 the `(i, i)` slot is known nonnegative, it equals the Gram determinant

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -47,15 +47,15 @@ def leadingGramMatrixInt (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Matrix 
 /-- The Gram-Schmidt leading Gram matrix is the leading prefix of the full
 Gram matrix. This is the shape equation between the public `gramDet` API and
 the one-pass `gramDetVec` implementation. -/
-theorem leadingGramMatrixInt_eq_leadingPrefix_gram
+theorem leadingGramMatrixInt_eq_principalSubmatrix_gram
     (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
     leadingGramMatrixInt b k hk =
-      Matrix.leadingPrefix (Matrix.gramMatrix b) k hk := by
+      Matrix.principalSubmatrix (Matrix.gramMatrix b) k hk := by
   apply Vector.ext
   intro i hi
   apply Vector.ext
   intro j hj
-  simp [leadingGramMatrixInt, Matrix.leadingPrefix, Matrix.gramMatrix, Vector.dotProduct, Matrix.ofFn,
+  simp [leadingGramMatrixInt, Matrix.principalSubmatrix, Matrix.gramMatrix, Vector.dotProduct, Matrix.ofFn,
     liftFinLE]
 
 /-- Leading principal Gram matrix of the first `k` rows of a rational basis. -/

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -641,12 +641,12 @@ private theorem scaledCoeffArrayLoop_diag_matches
           exact h_coeffs_processed i.val h_ilt i.isLt
 /-- The no-pivot Bareiss pass over the full Gram matrix records the same
 leading-prefix determinant as the public `gramDet` API at every vector slot. -/
-private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
+private theorem gramDetVecEntry_eq_principalSubmatrix_bareiss
     (b : Matrix Int n m) (hquot : StepWitness b) (r : Nat) (hr : r < n) :
     gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
         ⟨r + 1, Nat.succ_lt_succ hr⟩ =
       (Matrix.bareiss
-        (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+        (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
           (Nat.succ_le_of_lt hr))).toNat := by
   let GM := Matrix.gramMatrix b
   let init := Matrix.noPivotInitialState GM
@@ -655,7 +655,7 @@ private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
   by_cases h_prefix :
       (Matrix.noPivotLoop r init).singularStep = none
   · have hdiag :=
-      bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+      bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingular
         (b := b) r hr (by simpa [GM, init] using h_prefix)
     have h_step_r : (Matrix.noPivotLoop r init).step = r := by
       have h_room : init.step + r + 1 ≤ n := by
@@ -706,7 +706,7 @@ private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
           (data.matrix[i][i]).toNat := by
             simpa [data, GM, i] using h_entry_diag
       _ = (Matrix.bareiss
-            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+            (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
               (Nat.succ_le_of_lt hr))).toNat := by
             exact congrArg Int.toNat (by simpa [data, GM, i] using hdiag)
   · rcases noPivotLoop_singular_inv (n := n) r init rfl with h_none | h_sing
@@ -730,9 +730,9 @@ private theorem gramDetVecEntry_eq_leadingPrefix_bareiss
         simp [gramDetVecEntry, data, hdata, hsr]
       have hright :
           (Matrix.bareiss
-            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+            (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
               (Nat.succ_le_of_lt hr))).toNat = 0 :=
-        leadingPrefix_gram_bareiss_toNat_eq_zero
+        principalSubmatrix_gram_bareiss_toNat_eq_zero
           (b := b) r hr hquot k.val (by simpa [GM, init] using h_sing_r)
       rw [hright]
       simpa [data, GM] using hleft
@@ -757,11 +757,11 @@ theorem gramDetVecEntry_eq_gramDet
             ⟨r + 1, Nat.succ_lt_succ hr⟩ := by
               rfl
         _ = (Matrix.bareiss
-              (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+              (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
                 (Nat.succ_le_of_lt hr))).toNat :=
-              gramDetVecEntry_eq_leadingPrefix_bareiss (b := b) hquot r hr
+              gramDetVecEntry_eq_principalSubmatrix_bareiss (b := b) hquot r hr
         _ = gramDet b (r + 1) hk := by
-              simp [gramDet, GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+              simp [gramDet, GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram]
 
 
 /-- The scaled-coefficient array loop writes the same diagonal determinant
@@ -832,12 +832,12 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDet
 scaled-coefficient loop: the diagonal slot is either the zero tail after an
 early singular no-pivot step, or the Bareiss determinant of the matching
 leading Gram prefix. -/
-private theorem scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss
+private theorem scaledCoeffRows_diag_eq_zero_or_eq_principalSubmatrix_bareiss
     (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     getArrayEntry (scaledCoeffRows b) i i = 0 ∨
       getArrayEntry (scaledCoeffRows b) i i =
         Matrix.bareiss
-          (Matrix.leadingPrefix (Matrix.gramMatrix b) (i + 1)
+          (Matrix.principalSubmatrix (Matrix.gramMatrix b) (i + 1)
             (Nat.succ_le_of_lt hi)) := by
   let iFin : Fin n := ⟨i, hi⟩
   have hdiag :=
@@ -873,7 +873,7 @@ private theorem scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss
           coeffs := zeroRows n
           prevPivot := 1 }).coeffs i i =
         Matrix.bareiss
-          (Matrix.leadingPrefix (Matrix.gramMatrix b) (i + 1)
+          (Matrix.principalSubmatrix (Matrix.gramMatrix b) (i + 1)
             (Nat.succ_le_of_lt hi))
   rcases hdiag with ⟨h_sing, h_eq⟩ | ⟨s, h_sing, h_cases⟩
   · right
@@ -888,7 +888,7 @@ private theorem scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss
       noPivotLoop_prefix_none_of_final_none i (n - i)
         (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl h_final
     have h_leading :=
-      bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+      bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingular
         (b := b) i hi h_prefix
     have h_eq_noPivot :
         getArrayEntry
@@ -920,7 +920,7 @@ private theorem scaledCoeffRows_diag_eq_zero_or_eq_leadingPrefix_bareiss
         noPivotLoop_prefix_none_of_final_singular_after i (n - i)
           (Matrix.noPivotInitialState (Matrix.gramMatrix b)) rfl h_final h_after
       have h_leading :=
-        bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+        bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingular
           (b := b) i hi h_prefix
       have h_eq_noPivot :
           getArrayEntry

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -510,7 +510,7 @@ and integer positive definiteness forces every dot against `v` to be zero.
 Trailing-block symmetry transports
 `state.matrix[sFin][i] = Vector.dotProduct v (b.row i) = 0` across the diagonal to
 `state.matrix[i][sFin] = 0`. -/
-private theorem leadingPrefix_gram_zero_pivot_column_zero
+private theorem principalSubmatrix_gram_zero_pivot_column_zero
     {n m : Nat} (b : Matrix Int n m) (s : Nat) (hs : s + 1 < n)
     (hquot : StepWitness b)
     (h_prefix_none :
@@ -831,19 +831,19 @@ the `(r + 1)` leading Gram prefix is `Nat.zero`. The proof translates the
 column-zero suffix from the closed row invariant on the full trajectory to the
 leading prefix via the no-pivot sync lemma, then derives `findPivot? = none` on
 the prefix, so the row-pivoted Bareiss loop records the same singular step. -/
-private theorem leadingPrefix_gram_bareiss_toNat_eq_zero
+private theorem principalSubmatrix_gram_bareiss_toNat_eq_zero
     {n m : Nat} (b : Matrix Int n m) (r : Nat) (hr : r < n)
     (hquot : StepWitness b)
     (s : Nat)
     (h_sing : (Matrix.noPivotLoop r
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
     (Matrix.bareiss
-      (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+      (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
         (Nat.succ_le_of_lt hr))).toNat = 0 := by
   let GM := Matrix.gramMatrix b
   let initGM := Matrix.noPivotInitialState GM
   let hK : r + 1 ≤ n := Nat.succ_le_of_lt hr
-  let LP := Matrix.leadingPrefix GM (r + 1) hK
+  let LP := Matrix.principalSubmatrix GM (r + 1) hK
   let initLP := Matrix.noPivotInitialState LP
   -- Step 1: s < r via noPivotLoop_singularStep_lt.
   have hsr : s < r := by
@@ -857,18 +857,18 @@ private theorem leadingPrefix_gram_bareiss_toNat_eq_zero
   have hsucc_n : s + 1 ≤ n := Nat.le_of_lt hs1n
   obtain ⟨h_full_none, h_full_step, h_full_zero⟩ :=
     noPivotLoop_prefix_state_at_singular GM r s hsucc_n h_sing
-  -- Step 3: column-zero on FULL via leadingPrefix_gram_zero_pivot_column_zero.
+  -- Step 3: column-zero on FULL via principalSubmatrix_gram_zero_pivot_column_zero.
   have h_full_col_zero :
       ∀ i : Fin n, s + 1 ≤ i.val →
         (Matrix.noPivotLoop s initGM).matrix[i][(⟨s, hsn⟩ : Fin n)] = 0 :=
-    leadingPrefix_gram_zero_pivot_column_zero
+    principalSubmatrix_gram_zero_pivot_column_zero
       (b := b) s hs1n hquot h_full_none h_full_zero
-  -- Step 4: sync — leadingPrefix (noPivotLoop s initGM).matrix (r+1) = (noPivotLoop s initLP).matrix.
+  -- Step 4: sync — principalSubmatrix (noPivotLoop s initGM).matrix (r+1) = (noPivotLoop s initLP).matrix.
   have h_sync :=
-    noPivotLoop_sync_leadingPrefix_aux (n := n) (K := r + 1) hK s
+    noPivotLoop_sync_principalSubmatrix_aux (n := n) (K := r + 1) hK s
       initGM initLP rfl rfl rfl rfl
       (by
-        show Matrix.leadingPrefix initGM.matrix (r + 1) hK = initLP.matrix
+        show Matrix.principalSubmatrix initGM.matrix (r + 1) hK = initLP.matrix
         rfl)
       (show s + initGM.step < r + 1 by
         change s + 0 < r + 1; omega)
@@ -885,11 +885,11 @@ private theorem leadingPrefix_gram_bareiss_toNat_eq_zero
     have h_LP_entry :
         (Matrix.noPivotLoop s initLP).matrix[i'][
           (⟨s, hs_lt_r1⟩ : Fin (r + 1))] =
-        (Matrix.leadingPrefix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK)[i'][
+        (Matrix.principalSubmatrix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK)[i'][
           (⟨s, hs_lt_r1⟩ : Fin (r + 1))] := by
       rw [← h_mat_sync]
     rw [h_LP_entry]
-    rw [Matrix.leadingPrefix_entry (Matrix.noPivotLoop s initGM).matrix (r + 1) hK i'
+    rw [Matrix.getElem_principalSubmatrix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK i'
       (⟨s, hs_lt_r1⟩ : Fin (r + 1))]
     have hi_iN : s + 1 ≤ iN.val := hi'
     have h_col_zero_iN := h_full_col_zero iN hi_iN
@@ -912,12 +912,12 @@ private theorem leadingPrefix_gram_bareiss_toNat_eq_zero
     have h_LP_entry :
         (Matrix.noPivotLoop s initLP).matrix[(⟨s, hs_lt_r1⟩ : Fin (r + 1))][
           (⟨s, hs_lt_r1⟩ : Fin (r + 1))] =
-        (Matrix.leadingPrefix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK)[
+        (Matrix.principalSubmatrix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK)[
           (⟨s, hs_lt_r1⟩ : Fin (r + 1))][
           (⟨s, hs_lt_r1⟩ : Fin (r + 1))] := by
       rw [← h_mat_sync]
     rw [h_LP_entry]
-    rw [Matrix.leadingPrefix_entry (Matrix.noPivotLoop s initGM).matrix (r + 1) hK
+    rw [Matrix.getElem_principalSubmatrix (Matrix.noPivotLoop s initGM).matrix (r + 1) hK
       (⟨s, hs_lt_r1⟩ : Fin (r + 1)) (⟨s, hs_lt_r1⟩ : Fin (r + 1))]
     have h_idx_eq :
         (⟨s, Nat.lt_of_lt_of_le hs_lt_r1 hK⟩ : Fin n) =

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -22,8 +22,8 @@ coefficient matrix `ν`, produced by `data` from a single
 `scaledCoeffRows` formulation (`schurSigma_congr` and the column/boundary
 frame lemmas), and develops the Bareiss commutation infrastructure the
 determinant correspondence rests on: a `Matrix.stepMatrix` step commutes with
-taking a `leadingPrefix` and with taking a trailing `borderedMinor`
-(`leadingPrefix_stepMatrix_eq`, `borderedMinor_stepMatrix_eq`), the no-pivot
+taking a `principalSubmatrix` and with taking a trailing `borderedMinor`
+(`principalSubmatrix_stepMatrix_eq`, `borderedMinor_stepMatrix_eq`), the no-pivot
 loop stays synchronized across a matrix and its bordered minor
 (`noPivotLoop_full_eq_borderedMinor_at_trailing`), it preserves trailing-block
 symmetry, and its `step`/`singularStep` bookkeeping is monotone and stable
@@ -428,11 +428,11 @@ theorem scaledCoeffs_entry_eq_getArrayEntry
 prefix: the leading prefix of the updated full matrix equals the result
 of running the same step on the leading prefix. The pivot/`prevPivot`
 scalars are passed through unchanged. -/
-private theorem leadingPrefix_stepMatrix_eq
+private theorem principalSubmatrix_stepMatrix_eq
     {n K : Nat} (M : Matrix Int n n) (hK : K ≤ n)
     (k : Nat) (pivot prevPivot : Int) :
-    Matrix.leadingPrefix (Matrix.stepMatrix M k pivot prevPivot) K hK =
-      Matrix.stepMatrix (Matrix.leadingPrefix M K hK) k pivot prevPivot := by
+    Matrix.principalSubmatrix (Matrix.stepMatrix M k pivot prevPivot) K hK =
+      Matrix.stepMatrix (Matrix.principalSubmatrix M K hK) k pivot prevPivot := by
   apply Vector.ext
   intro i hi
   apply Vector.ext
@@ -441,20 +441,20 @@ private theorem leadingPrefix_stepMatrix_eq
   let jK : Fin K := ⟨j, hj⟩
   let iN : Fin n := ⟨i, Nat.lt_of_lt_of_le hi hK⟩
   let jN : Fin n := ⟨j, Nat.lt_of_lt_of_le hj hK⟩
-  show (Matrix.leadingPrefix (Matrix.stepMatrix M k pivot prevPivot) K hK)[iK][jK] =
-      (Matrix.stepMatrix (Matrix.leadingPrefix M K hK) k pivot prevPivot)[iK][jK]
-  simp only [Matrix.leadingPrefix_entry]
+  show (Matrix.principalSubmatrix (Matrix.stepMatrix M k pivot prevPivot) K hK)[iK][jK] =
+      (Matrix.stepMatrix (Matrix.principalSubmatrix M K hK) k pivot prevPivot)[iK][jK]
+  simp only [Matrix.getElem_principalSubmatrix]
   show (Matrix.stepMatrix M k pivot prevPivot)[iN][jN] =
-      (Matrix.stepMatrix (Matrix.leadingPrefix M K hK) k pivot prevPivot)[iK][jK]
+      (Matrix.stepMatrix (Matrix.principalSubmatrix M K hK) k pivot prevPivot)[iK][jK]
   by_cases htrail : k < i ∧ k < j
   · have hki_n : k < iN.val := htrail.1
     have hkj_n : k < jN.val := htrail.2
     have hki_K : k < iK.val := htrail.1
     have hkj_K : k < jK.val := htrail.2
     rw [Matrix.stepMatrix_update_eq M k pivot prevPivot iN jN hki_n hkj_n]
-    rw [Matrix.stepMatrix_update_eq (Matrix.leadingPrefix M K hK) k pivot prevPivot
+    rw [Matrix.stepMatrix_update_eq (Matrix.principalSubmatrix M K hK) k pivot prevPivot
       iK jK hki_K hkj_K]
-    simp only [Matrix.leadingPrefix_entry]
+    simp only [Matrix.getElem_principalSubmatrix]
     rfl
   · by_cases hbelow : k < i ∧ j = k
     · have hki_n : k < iN.val := hbelow.1
@@ -462,16 +462,16 @@ private theorem leadingPrefix_stepMatrix_eq
       have hki_K : k < iK.val := hbelow.1
       have hjk_K : jK.val = k := hbelow.2
       rw [Matrix.stepMatrix_pivot_col_below M k pivot prevPivot iN jN hki_n hjk_n]
-      rw [Matrix.stepMatrix_pivot_col_below (Matrix.leadingPrefix M K hK) k
+      rw [Matrix.stepMatrix_pivot_col_below (Matrix.principalSubmatrix M K hK) k
         pivot prevPivot iK jK hki_K hjk_K]
     · have hnot_n : ¬ (k < iN.val ∧ k < jN.val) := htrail
       have hnot_n' : ¬ (k < iN.val ∧ jN.val = k) := hbelow
       have hnot_K : ¬ (k < iK.val ∧ k < jK.val) := htrail
       have hnot_K' : ¬ (k < iK.val ∧ jK.val = k) := hbelow
       rw [Matrix.stepMatrix_eq_of_not_update M k pivot prevPivot iN jN hnot_n hnot_n']
-      rw [Matrix.stepMatrix_eq_of_not_update (Matrix.leadingPrefix M K hK) k
+      rw [Matrix.stepMatrix_eq_of_not_update (Matrix.principalSubmatrix M K hK) k
         pivot prevPivot iK jK hnot_K hnot_K']
-      simp only [Matrix.leadingPrefix_entry]
+      simp only [Matrix.getElem_principalSubmatrix]
       rfl
 
 /-- A bordered-minor entry equals the source matrix at the lifted index.
@@ -951,14 +951,14 @@ prefix from two BareissStates that agree on the leading prefix. While
 both runs are still synchronized (fuel fits within `K - state.step`),
 their bookkeeping fields agree and the full state's matrix, restricted
 to the leading prefix, matches the prefix state's matrix. -/
-private theorem noPivotLoop_sync_leadingPrefix_aux
+private theorem noPivotLoop_sync_principalSubmatrix_aux
     {n K : Nat} (hK : K ≤ n) (fuel : Nat) :
     ∀ (state_full : Matrix.BareissState n) (state_pref : Matrix.BareissState K),
       state_full.step = state_pref.step →
       state_full.prevPivot = state_pref.prevPivot →
       state_full.rowSwaps = state_pref.rowSwaps →
       state_full.singularStep = state_pref.singularStep →
-      Matrix.leadingPrefix state_full.matrix K hK = state_pref.matrix →
+      Matrix.principalSubmatrix state_full.matrix K hK = state_pref.matrix →
       fuel + state_full.step < K →
       (Matrix.noPivotLoop fuel state_full).step =
           (Matrix.noPivotLoop fuel state_pref).step ∧
@@ -968,7 +968,7 @@ private theorem noPivotLoop_sync_leadingPrefix_aux
           (Matrix.noPivotLoop fuel state_pref).rowSwaps ∧
       (Matrix.noPivotLoop fuel state_full).singularStep =
           (Matrix.noPivotLoop fuel state_pref).singularStep ∧
-      Matrix.leadingPrefix (Matrix.noPivotLoop fuel state_full).matrix K hK =
+      Matrix.principalSubmatrix (Matrix.noPivotLoop fuel state_full).matrix K hK =
           (Matrix.noPivotLoop fuel state_pref).matrix := by
   induction fuel with
   | zero =>
@@ -995,7 +995,7 @@ private theorem noPivotLoop_sync_leadingPrefix_aux
       have h_pivot_eq : state_full.matrix[k_full][k_full] =
           state_pref.matrix[k_pref][k_pref] := by
         have hcongr := congrArg (fun (M : Matrix Int K K) => M[k_pref][k_pref]) h_mat
-        simp only [Matrix.leadingPrefix_entry] at hcongr
+        simp only [Matrix.getElem_principalSubmatrix] at hcongr
         -- hcongr : state_full.matrix[⟨k_pref.val, _⟩][⟨k_pref.val, _⟩] =
         --          state_pref.matrix[k_pref][k_pref]
         -- k_full.val = state_full.step = state_pref.step = k_pref.val (by h_step),
@@ -1024,12 +1024,12 @@ private theorem noPivotLoop_sync_leadingPrefix_aux
         rw [Matrix.noPivotLoop_regular_branch f state_pref h_pref_done hp_pref]
         -- After one step, the new states are still linked.
         have h_new_mat :
-            Matrix.leadingPrefix
+            Matrix.principalSubmatrix
               (Matrix.stepMatrix state_full.matrix state_full.step
                 state_full.matrix[k_full][k_full] state_full.prevPivot) K hK =
               Matrix.stepMatrix state_pref.matrix state_pref.step
                 state_pref.matrix[k_pref][k_pref] state_pref.prevPivot := by
-          rw [leadingPrefix_stepMatrix_eq, h_mat, h_step, h_prev, h_pivot_eq]
+          rw [principalSubmatrix_stepMatrix_eq, h_mat, h_step, h_prev, h_pivot_eq]
         apply ih
         · -- step
           simp [h_step]
@@ -1390,19 +1390,19 @@ matrix and on its `(r+1)`-leading prefix yields states whose `(r, r)`
 diagonal entry agrees (after the leading-prefix identification) and
 whose `singularStep` field agrees. This is the executable-loop
 projection needed by the parent assembly of
-`gramDetVecEntry_eq_leadingPrefix_bareiss`. -/
+`gramDetVecEntry_eq_principalSubmatrix_bareiss`. -/
 private theorem noPivotLoop_full_eq
     (b : Matrix Int n m) (r : Nat) (hr : r < n) :
     let GM := Matrix.gramMatrix b
     let hK : r + 1 ≤ n := Nat.succ_le_of_lt hr
-    let LP := Matrix.leadingPrefix GM (r + 1) hK
+    let LP := Matrix.principalSubmatrix GM (r + 1) hK
     let s_full := Matrix.noPivotLoop r (Matrix.noPivotInitialState GM)
     let s_pref := Matrix.noPivotLoop r (Matrix.noPivotInitialState LP)
     s_full.matrix[(⟨r, hr⟩ : Fin n)][(⟨r, hr⟩ : Fin n)] =
         s_pref.matrix[(⟨r, Nat.lt_succ_self r⟩ : Fin (r + 1))][(⟨r, Nat.lt_succ_self r⟩ : Fin (r + 1))]
       ∧ s_full.singularStep = s_pref.singularStep := by
   intro GM hK LP s_full s_pref
-  have h_sync := noPivotLoop_sync_leadingPrefix_aux hK r
+  have h_sync := noPivotLoop_sync_principalSubmatrix_aux hK r
     (Matrix.noPivotInitialState GM) (Matrix.noPivotInitialState LP)
     rfl rfl rfl rfl rfl
     (show r + (Matrix.noPivotInitialState GM).step < r + 1 by
@@ -1415,14 +1415,14 @@ private theorem noPivotLoop_full_eq
     (fun (M : Matrix Int (r + 1) (r + 1)) =>
       M[(⟨r, Nat.lt_succ_self r⟩ : Fin (r + 1))][(⟨r, Nat.lt_succ_self r⟩ : Fin (r + 1))])
     h_mat
-  simp only [Matrix.leadingPrefix_entry] at hcongr
+  simp only [Matrix.getElem_principalSubmatrix] at hcongr
   -- hcongr's LHS index in Fin n has val = r; same as the goal's LHS index.
   exact hcongr
 
 /-- Signed diagonal projection for a non-singular target prefix: the final
 no-pivot full-Gram diagonal at `r` is the public Bareiss determinant of the
 `(r + 1)` leading prefix. -/
-theorem bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+theorem bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingular
     (b : Matrix Int n m) (r : Nat) (hr : r < n)
     (h_nonsing :
       (Matrix.noPivotLoop r
@@ -1430,12 +1430,12 @@ theorem bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
     (Matrix.bareissNoPivotData (Matrix.gramMatrix b)).matrix[
         (⟨r, hr⟩ : Fin n)][(⟨r, hr⟩ : Fin n)] =
       Matrix.bareiss
-        (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+        (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
           (Nat.succ_le_of_lt hr)) := by
   let GM := Matrix.gramMatrix b
   let init := Matrix.noPivotInitialState GM
   let fullAtR := Matrix.noPivotLoop r init
-  let LP := Matrix.leadingPrefix GM (r + 1) (Nat.succ_le_of_lt hr)
+  let LP := Matrix.principalSubmatrix GM (r + 1) (Nat.succ_le_of_lt hr)
   have h_step_r : fullAtR.step = r := by
     have h_room : init.step + r + 1 ≤ n := by
       simp [init, Matrix.noPivotInitialState]

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -851,13 +851,13 @@ theorem noPivotLoop_initial_step_eq_and_fuel_succ_le
 
 /-- Companion to `trailing_eq_at_step_local`: rewrite
 `BareissNoPivotInvariant.prevPivot_eq` with the step value supplied externally
-so the dependent `leadingPrefix` type matches the desired `s = state.step`
+so the dependent `principalSubmatrix` type matches the desired `s = state.step`
 substitution cleanly. -/
 theorem prevPivot_eq_at_step_local
     {n' : Nat} {M : Hex.Matrix Int n' n'} {state : Matrix.BareissState n'}
     (hinv : HexMatrixMathlib.BareissNoPivotInvariant M state)
     (s : Nat) (hs : s ≤ n') (hstep : s = state.step) :
-    state.prevPivot = Hex.Matrix.det (Hex.Matrix.leadingPrefix M s hs) := by
+    state.prevPivot = Hex.Matrix.det (Hex.Matrix.principalSubmatrix M s hs) := by
   subst hstep
   exact hinv.prevPivot_eq
 
@@ -950,7 +950,7 @@ def StepWitness.ofGram (b : Matrix Int n m) :
       ((augmentedGram b a).borderedMinor fuel hfuel_lt_naug iA kA).det *
         ((augmentedGram b a).borderedMinor fuel hfuel_lt_naug kA L).det =
     (bareissGramCanonicalCoeff b (fuel + 1) i)[a] *
-      ((augmentedGram b a).leadingPrefix fuel hfuel_le_naug).det
+      ((augmentedGram b a).principalSubmatrix fuel hfuel_le_naug).det
   rw [bareissGramCanonicalCoeff_eq_borderedMinor_aug b (fuel + 1) i a
         h_fuel_succ_le_i h_prefix_none_succ]
   -- Desnanot-Jacobi on the augmented matrix at level `fuel`.

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -661,22 +661,21 @@ already have a determinant lemma for a special matrix family can produce the
 public `independent` predicate stated over Mathlib-free computed data. -/
 
 private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.leadingSubmatrix (Matrix.gramMatrix b) k))
+    (hdet : ∀ (k : Nat) (hk : k ≤ n),
+      0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) k hk))
     (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by
   cases k with
   | zero =>
       omega
   | succ r =>
-      have hrn : r < n := Nat.lt_of_succ_le hk
-      let last : Fin n := ⟨r, hrn⟩
-      have hsub : 0 < Matrix.det (Matrix.leadingSubmatrix (Matrix.gramMatrix b) last) :=
-        hdet last
+      have hsub :
+          0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hk) :=
+        hdet (r + 1) hk
       have hsub_eq :
-          Matrix.leadingSubmatrix (Matrix.gramMatrix b) last =
-            GramSchmidt.leadingGramMatrixInt b (r + 1) hk := by
-        rw [Matrix.leadingSubmatrix_eq_leadingPrefix]
-        rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+          Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hk =
+            GramSchmidt.leadingGramMatrixInt b (r + 1) hk :=
+        (GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram b (r + 1) hk).symm
       have hdet_pos :
           0 < Matrix.det (GramSchmidt.leadingGramMatrixInt b (r + 1) hk) := by
         simpa [hsub_eq] using hsub
@@ -693,7 +692,8 @@ private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
 have determinant lemmas for special matrix families, while keeping the public
 predicate stated over Mathlib-free computed data. -/
 theorem independent_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ k : Fin n, 0 < Matrix.det (Matrix.leadingSubmatrix (Matrix.gramMatrix b) k)) :
+    (hdet : ∀ (k : Nat) (hk : k ≤ n),
+      0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) k hk)) :
     independent b := by
   intro k
   exact gramDet_pos_of_det_positive b hdet (k.val + 1) (Nat.succ_le_of_lt k.isLt)
@@ -703,8 +703,8 @@ theorem independent_of_det_positive (b : Matrix Int n m)
 every leading principal minor has determinant `1 > 0`. -/
 theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
   exact independent_of_det_positive (1 : Matrix Int n n) (by
-    intro k
-    rw [Matrix.gramMatrix_one, Matrix.leadingSubmatrix_one, Matrix.det_one]
+    intro k hk
+    rw [Matrix.gramMatrix_one, Matrix.principalSubmatrix_one, Matrix.det_one]
     decide)
 
 
@@ -714,7 +714,7 @@ When the no-pivot Bareiss loop on a Gram matrix records a singular step at
 index `s`, the `(s+1)`-leading Gram prefix has zero determinant. By the
 multiplicative succession `gramSchmidtNormProduct_succ`, the same vanishing
 propagates to every larger prefix. This is the singular branch of the
-`gramDetVecEntry_eq_leadingPrefix_bareiss` placeholder. -/
+`gramDetVecEntry_eq_principalSubmatrix_bareiss` placeholder. -/
 
 
 /-- From a partial no-pivot Bareiss pass on `M` recording a singular step at
@@ -815,7 +815,7 @@ private theorem bareissNoPivotInvariant_diag_eq
     (hinv : HexMatrixMathlib.BareissNoPivotInvariant M state)
     (hsk : k = state.step) (hk : k < n) :
     state.matrix[(⟨k, hk⟩ : Fin n)][(⟨k, hk⟩ : Fin n)] =
-      Matrix.det (Matrix.leadingPrefix M (k + 1) (Nat.succ_le_of_lt hk)) := by
+      Matrix.det (Matrix.principalSubmatrix M (k + 1) (Nat.succ_le_of_lt hk)) := by
   subst hsk
   have h_trail :
       state.matrix[(⟨state.step, hk⟩ : Fin n)][(⟨state.step, hk⟩ : Fin n)] =
@@ -823,18 +823,18 @@ private theorem bareissNoPivotInvariant_diag_eq
           (⟨state.step, hk⟩ : Fin n) (⟨state.step, hk⟩ : Fin n)) :=
     hinv.trailing_eq hk (⟨state.step, hk⟩ : Fin n) (⟨state.step, hk⟩ : Fin n)
       (Nat.le_refl _) (Nat.le_refl _)
-  rw [HexMatrixMathlib.borderedMinor_corner_eq_leadingPrefix M state.step hk] at h_trail
+  rw [HexMatrixMathlib.borderedMinor_corner_eq_principalSubmatrix M state.step hk] at h_trail
   exact h_trail
 
 /-- Identification with the Mathlib leading-prefix determinant: from a partial
 no-pivot Bareiss pass that records a singular step at index `s`, the
 `(s+1)`-leading prefix of the source matrix has zero determinant (Hex's
 `Matrix.det`). -/
-private theorem leadingPrefix_det_eq_zero
+private theorem principalSubmatrix_det_eq_zero
     {n : Nat} (M : Matrix Int n n) (fuel s : Nat) (hs : s + 1 ≤ n)
     (h_sing : (Matrix.noPivotLoop fuel
         (Matrix.noPivotInitialState M)).singularStep = some s) :
-    Matrix.det (Matrix.leadingPrefix M (s + 1) hs) = 0 := by
+    Matrix.det (Matrix.principalSubmatrix M (s + 1) hs) = 0 := by
   obtain ⟨h_none, h_step, h_zero⟩ :=
     noPivotLoop_prefix_state_at_singular M fuel s hs h_sing
   -- Apply the noPivotLoop_invariant variant: S satisfies BareissNoPivotInvariant.
@@ -846,15 +846,15 @@ private theorem leadingPrefix_det_eq_zero
     HexMatrixMathlib.noPivotLoop_invariant_of_singularStep_eq_none M s
       (Matrix.noPivotInitialState M) hinv_init h_none
   -- Use Nat.lt_of_succ_le hs as the bound throughout to match the helper's output type.
-  -- Specialize the diagonal-corner helper: matrix[⟨s, _⟩][⟨s, _⟩] = det(leadingPrefix M (s+1) _).
+  -- Specialize the diagonal-corner helper: matrix[⟨s, _⟩][⟨s, _⟩] = det(principalSubmatrix M (s+1) _).
   have h_diag_eq_lp :
       (Matrix.noPivotLoop s (Matrix.noPivotInitialState M)).matrix[(⟨s, Nat.lt_of_succ_le hs⟩ : Fin n)][(⟨s, Nat.lt_of_succ_le hs⟩ : Fin n)] =
-        Matrix.det (Matrix.leadingPrefix M (s + 1) (Nat.succ_le_of_lt (Nat.lt_of_succ_le hs))) :=
+        Matrix.det (Matrix.principalSubmatrix M (s + 1) (Nat.succ_le_of_lt (Nat.lt_of_succ_le hs))) :=
     bareissNoPivotInvariant_diag_eq
       M (Matrix.noPivotLoop s (Matrix.noPivotInitialState M)) s hinv_S
       h_step.symm (Nat.lt_of_succ_le hs)
   rw [h_zero] at h_diag_eq_lp
-  -- h_diag_eq_lp : 0 = det(leadingPrefix M (s+1) (Nat.succ_le_of_lt ...)). The proof
+  -- h_diag_eq_lp : 0 = det(principalSubmatrix M (s+1) (Nat.succ_le_of_lt ...)). The proof
   -- argument is definitionally equal to `hs`, so the goal matches up to proof irrelevance.
   exact h_diag_eq_lp.symm
 
@@ -886,18 +886,18 @@ slot `r + 1`, the public row-pivoted Bareiss determinant of the `(r + 1)`
 leading Gram prefix is zero.
 
 This is the supporting lemma needed by the singular branch of the
-`gramDetVecEntry_eq_leadingPrefix_bareiss` placeholder: both sides vanish in
+`gramDetVecEntry_eq_principalSubmatrix_bareiss` placeholder: both sides vanish in
 this case, and this lemma supplies the right-hand side. The proof composes the
 new lemma `HexMatrixMathlib.noPivotLoop_invariant_of_singularStep_eq_none`
-(to identify `det(leadingPrefix _ (s+1)) = 0` at the moment of singularity) with
+(to identify `det(principalSubmatrix _ (s+1)) = 0` at the moment of singularity) with
 the unconditional `gramDet_eq_prod_normSq_uncond` and the multiplicative
 succession `gramSchmidtNormProduct_succ` to propagate zero from `s + 1` to
 `r + 1`. -/
-theorem leadingPrefix_gram_bareiss_eq_zero_of_singularStep_lt
+theorem principalSubmatrix_gram_bareiss_eq_zero_of_singularStep_lt
     (b : Matrix Int n m) (r : Nat) (hr : r < n) (s : Nat)
     (h_sing : (Matrix.noPivotLoop r
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = some s) :
-    Matrix.bareiss (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+    Matrix.bareiss (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
         (Nat.succ_le_of_lt hr)) = 0 := by
   -- Step A: derive `s < r` from the partial-pass singular bound.
   have hsr : s < r := by
@@ -906,16 +906,16 @@ theorem leadingPrefix_gram_bareiss_eq_zero_of_singularStep_lt
     change s < 0 + r at h
     omega
   have hs1 : s + 1 ≤ n := Nat.le_trans (Nat.succ_le_of_lt hsr) (Nat.le_of_lt hr)
-  -- Step B: derive det(leadingPrefix (gramMatrix b) (s+1)) = 0 via the new lemma.
+  -- Step B: derive det(principalSubmatrix (gramMatrix b) (s+1)) = 0 via the new lemma.
   have h_det_s1_zero :
-      Matrix.det (Matrix.leadingPrefix (Matrix.gramMatrix b) (s + 1) hs1) = 0 :=
-    leadingPrefix_det_eq_zero
+      Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) (s + 1) hs1) = 0 :=
+    principalSubmatrix_det_eq_zero
       (Matrix.gramMatrix b) r s hs1 h_sing
   -- Step C: convert to gramSchmidtNormProduct b (s+1) = 0.
   have h_lead_eq_s :
       GramSchmidt.leadingGramMatrixInt b (s + 1) hs1 =
-        Matrix.leadingPrefix (Matrix.gramMatrix b) (s + 1) hs1 :=
-    GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram b (s + 1) hs1
+        Matrix.principalSubmatrix (Matrix.gramMatrix b) (s + 1) hs1 :=
+    GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram b (s + 1) hs1
   have h_det_lead_s1_zero :
       Matrix.det (GramSchmidt.leadingGramMatrixInt b (s + 1) hs1) = 0 := by
     rw [h_lead_eq_s]; exact h_det_s1_zero
@@ -948,11 +948,11 @@ theorem leadingPrefix_gram_bareiss_eq_zero_of_singularStep_lt
     rw [h_gd_r1_zero] at hnat
     simpa using hnat
   have h_det_prefix_r1_zero :
-      Matrix.det (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1) hr1) = 0 := by
+      Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hr1) = 0 := by
     have h_lead_eq_r :
         GramSchmidt.leadingGramMatrixInt b (r + 1) hr1 =
-          Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1) hr1 :=
-      GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram b (r + 1) hr1
+          Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hr1 :=
+      GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram b (r + 1) hr1
     rw [← h_lead_eq_r]; exact h_det_lead_r1_zero
   rw [HexMatrixMathlib.bareiss_eq_det]
   exact h_det_prefix_r1_zero
@@ -966,12 +966,12 @@ This theorem lives in `HexGramSchmidtMathlib` because the proof path for the
 singular branch identifies the executable determinant with Mathlib's Leibniz
 determinant. Mathlib-free callers should use the executable `gramDet` API
 instead of depending on this Bareiss-facing statement. -/
-theorem gramDetVecEntry_eq_leadingPrefix_bareiss
+theorem gramDetVecEntry_eq_principalSubmatrix_bareiss
     (b : Matrix Int n m) (r : Nat) (hr : r < n) :
     gramDetVecEntry (Matrix.bareissNoPivotData (Matrix.gramMatrix b))
         ⟨r + 1, Nat.succ_lt_succ hr⟩ =
       (Matrix.bareiss
-        (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+        (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
           (Nat.succ_le_of_lt hr))).toNat := by
   let GM := Matrix.gramMatrix b
   let init := Matrix.noPivotInitialState GM
@@ -980,7 +980,7 @@ theorem gramDetVecEntry_eq_leadingPrefix_bareiss
   by_cases h_prefix :
       (Matrix.noPivotLoop r init).singularStep = none
   · have hdiag :=
-      bareissNoPivotData_diag_eq_leadingPrefix_bareiss_of_prefix_nonsingular
+      bareissNoPivotData_diag_eq_principalSubmatrix_bareiss_of_prefix_nonsingular
         (b := b) r hr (by simpa [GM, init] using h_prefix)
     have h_step_r : (Matrix.noPivotLoop r init).step = r := by
       have h_room : init.step + r + 1 ≤ n := by
@@ -1031,7 +1031,7 @@ theorem gramDetVecEntry_eq_leadingPrefix_bareiss
           (data.matrix[i][i]).toNat := by
             simpa [data, GM, i] using h_entry_diag
       _ = (Matrix.bareiss
-            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+            (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
               (Nat.succ_le_of_lt hr))).toNat := by
             exact congrArg Int.toNat (by simpa [data, GM, i] using hdiag)
   · rcases noPivotLoop_singular_inv (n := n) r init rfl with h_none | h_sing
@@ -1055,9 +1055,9 @@ theorem gramDetVecEntry_eq_leadingPrefix_bareiss
         simp [gramDetVecEntry, data, hdata, hsr]
       have hright :
           Matrix.bareiss
-            (Matrix.leadingPrefix (Matrix.gramMatrix b) (r + 1)
+            (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1)
               (Nat.succ_le_of_lt hr)) = 0 :=
-        leadingPrefix_gram_bareiss_eq_zero_of_singularStep_lt
+        principalSubmatrix_gram_bareiss_eq_zero_of_singularStep_lt
           (b := b) r hr k.val (by simpa [GM, init] using h_sing_r)
       rw [hright]
       simpa [data, GM] using hleft

--- a/HexGramSchmidtMathlib/Int/Swap.lean
+++ b/HexGramSchmidtMathlib/Int/Swap.lean
@@ -660,7 +660,7 @@ theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨i, hi⟩ =
       Int.ofNat (gramDet b (i + 1) (Nat.succ_le_of_lt hi)) := by
   let hk : i + 1 ≤ n := Nat.succ_le_of_lt hi
-  rcases scaledCoeffs_diag_eq_zero_or_eq_leadingPrefix_bareiss b (StepWitness.ofGram b)
+  rcases scaledCoeffs_diag_eq_zero_or_eq_principalSubmatrix_bareiss b (StepWitness.ofGram b)
       i hi with hzero | hbareiss
   · have hnat := scaledCoeffs_diag_toNat (b := b) (StepWitness.ofGram b) i hi
     rw [hzero] at hnat
@@ -671,9 +671,9 @@ theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     rw [hbareiss]
     have hbareiss_eq :
         Matrix.bareiss
-            (Matrix.leadingPrefix (Matrix.gramMatrix b) (i + 1) hk) =
+            (Matrix.principalSubmatrix (Matrix.gramMatrix b) (i + 1) hk) =
           Matrix.det (GramSchmidt.leadingGramMatrixInt b (i + 1) hk) := by
-      rw [← GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+      rw [← GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram]
       exact HexMatrixMathlib.bareiss_eq_det
         (GramSchmidt.leadingGramMatrixInt b (i + 1) hk)
     rw [hbareiss_eq]
@@ -717,8 +717,8 @@ theorem gramDet_pos_of_upperTriangular_pos_diag
   | succ r =>
       have hrn : r < n := Nat.lt_of_succ_le hk
       have hlead :
-          Matrix.gramMatrix (Matrix.leadingRows M (r + 1) hk) =
-            Matrix.leadingPrefix (Matrix.gramMatrix M) (r + 1) hk := by
+          Matrix.gramMatrix (Matrix.takeRows M (r + 1) hk) =
+            Matrix.principalSubmatrix (Matrix.gramMatrix M) (r + 1) hk := by
         apply Vector.ext
         intro i hi
         apply Vector.ext
@@ -728,30 +728,30 @@ theorem gramDet_pos_of_upperTriangular_pos_diag
         let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi hk⟩
         let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj hk⟩
         have hrow_i :
-            Matrix.row (Matrix.leadingRows M (r + 1) hk) iFin =
+            Matrix.row (Matrix.takeRows M (r + 1) hk) iFin =
               Matrix.row M ii := by
           apply Vector.ext
           intro c hc
-          simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, iFin, ii]
+          simp [Matrix.row, Matrix.takeRows, Matrix.ofFn, iFin, ii]
         have hrow_j :
-            Matrix.row (Matrix.leadingRows M (r + 1) hk) jFin =
+            Matrix.row (Matrix.takeRows M (r + 1) hk) jFin =
               Matrix.row M jj := by
           apply Vector.ext
           intro c hc
-          simp [Matrix.row, Matrix.leadingRows, Matrix.ofFn, jFin, jj]
+          simp [Matrix.row, Matrix.takeRows, Matrix.ofFn, jFin, jj]
         have hdot :
-            Vector.dotProduct (Matrix.row (Matrix.leadingRows M (r + 1) hk) iFin)
-                (Matrix.row (Matrix.leadingRows M (r + 1) hk) jFin) =
+            Vector.dotProduct (Matrix.row (Matrix.takeRows M (r + 1) hk) iFin)
+                (Matrix.row (Matrix.takeRows M (r + 1) hk) jFin) =
               Vector.dotProduct (Matrix.row M ii) (Matrix.row M jj) := by
           rw [hrow_i, hrow_j]
-        simpa [Matrix.gramMatrix, Matrix.leadingPrefix, Matrix.ofFn, iFin, jFin, ii, jj]
+        simpa [Matrix.gramMatrix, Matrix.principalSubmatrix, Matrix.ofFn, iFin, jFin, ii, jj]
           using hdot
       have hdet_pos :
           0 < Matrix.det (GramSchmidt.leadingGramMatrixInt M (r + 1) hk) := by
         have hpos :=
-          Matrix.det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
+          Matrix.det_gramMatrix_takeRows_pos_of_upperTriangular_pos_diag M hzero hdiag
             (r + 1) hk
-        rwa [hlead, ← GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram] at hpos
+        rwa [hlead, ← GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram] at hpos
       have hdet_nat :
           Matrix.det (GramSchmidt.leadingGramMatrixInt M (r + 1) hk) =
             Int.ofNat (gramDet M (r + 1) hk) :=

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -122,8 +122,8 @@ private theorem leadingGramMatrixInt_rowSwap_outside
     (t : Nat) (ht : t ≤ n) (htkm1 : t ≤ km1.val) :
     GramSchmidt.leadingGramMatrixInt (Matrix.rowSwap b km1 k) t ht =
       GramSchmidt.leadingGramMatrixInt b t ht := by
-  rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram,
-      GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram]
+  rw [GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram,
+      GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram]
   apply Vector.ext
   intro p hp
   apply Vector.ext
@@ -152,9 +152,9 @@ private theorem leadingGramMatrixInt_rowSwap_outside
     rowSwap_row_eq_of_ne_int b km1 k pn hp_ne_km1 hp_ne_k
   have hq_eq : (Matrix.rowSwap b km1 k)[qn] = b[qn] :=
     rowSwap_row_eq_of_ne_int b km1 k qn hq_ne_km1 hq_ne_k
-  show (Matrix.leadingPrefix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
-       (Matrix.leadingPrefix (Matrix.gramMatrix b) t ht)[pp][qq]
-  simp only [Matrix.leadingPrefix_entry]
+  show (Matrix.principalSubmatrix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
+       (Matrix.principalSubmatrix (Matrix.gramMatrix b) t ht)[pp][qq]
+  simp only [Matrix.getElem_principalSubmatrix]
   show (Matrix.gramMatrix (Matrix.rowSwap b km1 k))[pn][qn] =
        (Matrix.gramMatrix b)[pn][qn]
   have hentry_swap :
@@ -182,12 +182,12 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         ((Matrix.rowSwap (GramSchmidt.leadingGramMatrixInt b t ht) km1' k').transpose)
         km1' k').transpose := by
   intro km1' k'
-  rw [GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram
+  rw [GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram
         (b := Matrix.rowSwap b km1 k) (k := t) (hk := ht),
-      GramSchmidt.leadingGramMatrixInt_eq_leadingPrefix_gram
+      GramSchmidt.leadingGramMatrixInt_eq_principalSubmatrix_gram
         (b := b) (k := t) (hk := ht)]
-  let M : Matrix Int t t := Matrix.leadingPrefix (Matrix.gramMatrix b) t ht
-  show Matrix.leadingPrefix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht =
+  let M : Matrix Int t t := Matrix.principalSubmatrix (Matrix.gramMatrix b) t ht
+  show Matrix.principalSubmatrix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht =
        (Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k').transpose
   apply Vector.ext
   intro p hp
@@ -197,19 +197,19 @@ private theorem leadingGramMatrixInt_rowSwap_inside
   let qq : Fin t := ⟨q, hq⟩
   let pn : Fin n := ⟨p, Nat.lt_of_lt_of_le hp ht⟩
   let qn : Fin n := ⟨q, Nat.lt_of_lt_of_le hq ht⟩
-  change (Matrix.leadingPrefix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
+  change (Matrix.principalSubmatrix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
          ((Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k').transpose)[pp][qq]
   have hLHS :
-      (Matrix.leadingPrefix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
+      (Matrix.principalSubmatrix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
         Hex.Vector.dotProduct ((Matrix.rowSwap b km1 k)[pn]) ((Matrix.rowSwap b km1 k)[qn]) := by
-    simp [Matrix.leadingPrefix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn,
+    simp [Matrix.principalSubmatrix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn,
       pp, qq, pn, qn]
   have hM_entry : ∀ (a b' : Fin t),
       M[a][b'] =
         Hex.Vector.dotProduct (b[(⟨a.val, Nat.lt_of_lt_of_le a.isLt ht⟩ : Fin n)])
           (b[(⟨b'.val, Nat.lt_of_lt_of_le b'.isLt ht⟩ : Fin n)]) := by
     intro a b'
-    simp [M, Matrix.leadingPrefix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn]
+    simp [M, Matrix.principalSubmatrix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn]
   have hRHS_T :
       ((Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k').transpose)[pp][qq] =
         (Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k')[qq][pp] := by

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -34,34 +34,30 @@ recombination input with all-zero lift coefficients. -/
 theorem identity_independent {n : Nat} : (1 : Matrix Int n n).independent := by
   exact GramSchmidt.Int.independent_one
 
-theorem gramMatrix_leadingRows_eq_submatrix {n : Nat} (M : Matrix Int n n) (k : Fin n) :
-    gramMatrix (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) =
-      leadingSubmatrix (gramMatrix M) k := by
+theorem gramMatrix_takeRows_eq_principalSubmatrix {n : Nat} (M : Matrix Int n n) (k : Nat)
+    (hk : k ≤ n) :
+    gramMatrix (takeRows M k hk) = principalSubmatrix (gramMatrix M) k hk := by
   apply Vector.ext
   intro i hi
   apply Vector.ext
   intro j hj
-  let iFin : Fin (k.val + 1) := ⟨i, hi⟩
-  let jFin : Fin (k.val + 1) := ⟨j, hj⟩
-  let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩
-  let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt k.isLt)⟩
-  have hrow_i :
-      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin = row M ii := by
+  let iFin : Fin k := ⟨i, hi⟩
+  let jFin : Fin k := ⟨j, hj⟩
+  let ii : Fin n := ⟨i, Nat.lt_of_lt_of_le hi hk⟩
+  let jj : Fin n := ⟨j, Nat.lt_of_lt_of_le hj hk⟩
+  have hrow_i : row (takeRows M k hk) iFin = row M ii := by
     apply Vector.ext
     intro c hc
-    simp [row, leadingRows, ofFn, iFin, ii]
-  have hrow_j :
-      row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin = row M jj := by
+    simp [row, takeRows, ofFn, iFin, ii]
+  have hrow_j : row (takeRows M k hk) jFin = row M jj := by
     apply Vector.ext
     intro c hc
-    simp [row, leadingRows, ofFn, jFin, jj]
+    simp [row, takeRows, ofFn, jFin, jj]
   have hdot :
-      Hex.Vector.dotProduct
-          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) iFin)
-          (row (leadingRows M (k.val + 1) (Nat.succ_le_of_lt k.isLt)) jFin) =
+      Hex.Vector.dotProduct (row (takeRows M k hk) iFin) (row (takeRows M k hk) jFin) =
         Hex.Vector.dotProduct (row M ii) (row M jj) := by
     rw [hrow_i, hrow_j]
-  simpa [gramMatrix, leadingSubmatrix, ofFn, iFin, jFin, ii, jj] using
+  simpa [gramMatrix, principalSubmatrix, ofFn, iFin, jFin, ii, jj] using
     hdot
 
 theorem independent_of_upperTriangular_pos_diag {n : Nat}
@@ -69,11 +65,10 @@ theorem independent_of_upperTriangular_pos_diag {n : Nat}
     (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
     (hdiag : ∀ i : Fin n, 0 < M[i][i]) : M.independent := by
   exact GramSchmidt.Int.independent_of_det_positive M (by
-    intro k
+    intro k hk
     have hpos :=
-      det_gramMatrix_leadingRows_pos_of_upperTriangular_pos_diag M hzero hdiag
-        (k.val + 1) (Nat.succ_le_of_lt k.isLt)
-    rwa [gramMatrix_leadingRows_eq_submatrix M k] at hpos)
+      det_gramMatrix_takeRows_pos_of_upperTriangular_pos_diag M hzero hdiag k hk
+    rwa [gramMatrix_takeRows_eq_principalSubmatrix M k hk] at hpos)
 
 end Matrix
 

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -109,7 +109,7 @@ the Bareiss recurrence.
 
 {docstring Hex.Matrix.gramMatrix}
 
-{docstring Hex.Matrix.leadingPrefix}
+{docstring Hex.Matrix.principalSubmatrix}
 
 # The determinant
 %%%

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -11,7 +11,7 @@ public import HexMatrix.Basic
 public section
 
 /-!
-Leading submatrices and row prefixes.
+Principal submatrices and row prefixes.
 -/
 
 namespace Hex
@@ -20,18 +20,11 @@ universe u
 
 namespace Matrix
 
-/-- Leading principal `(k + 1) × (k + 1)` submatrix of a square matrix. -/
+/-- Leading principal `k × k` submatrix of a square matrix: the top-left block
+indexed by `{0, …, k-1}` along both axes. Includes the empty submatrix
+(`k = 0`) and is convenient for Bareiss pivot/minor statements. -/
 @[expose]
-def leadingSubmatrix (M : Matrix R n n) (k : Fin n) : Matrix R (k.val + 1) (k.val + 1) :=
-  ofFn fun i j =>
-    let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt (Nat.succ_le_of_lt k.isLt)⟩
-    let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
-    M[ii][jj]
-
-/-- Leading principal `k × k` prefix of a square matrix. This variant includes
-the empty prefix and is convenient for Bareiss pivot/minor statements. -/
-@[expose]
-def leadingPrefix (M : Matrix R n n) (k : Nat) (hk : k ≤ n) : Matrix R k k :=
+def principalSubmatrix (M : Matrix R n n) (k : Nat) (hk : k ≤ n) : Matrix R k k :=
   ofFn fun i j =>
     let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
     let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
@@ -39,68 +32,47 @@ def leadingPrefix (M : Matrix R n n) (k : Nat) (hk : k ≤ n) : Matrix R k k :=
 
 /-- The first `k` rows of a matrix, retaining all source columns. -/
 @[expose]
-def leadingRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
+def takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
   ofFn fun i j =>
     let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
     M[ii][j]
 
-/-- Entry formula for the `k × k` leading prefix. -/
-@[grind =] theorem leadingPrefix_entry (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
+/-- Entry formula for the `k × k` principal submatrix. -/
+@[grind =] theorem getElem_principalSubmatrix (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
     (i j : Fin k) :
-    (leadingPrefix M k hk)[i][j] =
+    (principalSubmatrix M k hk)[i][j] =
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
        let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
        M[ii][jj]) := by
-  simp [leadingPrefix, ofFn]
+  simp [principalSubmatrix, ofFn]
 
 /-- Entry formula for the first-`k`-rows slice. -/
-@[grind =] theorem leadingRows_entry (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
+@[grind =] theorem getElem_takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) (j : Fin m) :
-    (leadingRows M k hk)[i][j] =
+    (takeRows M k hk)[i][j] =
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
        M[ii][j]) := by
-  simp [leadingRows, ofFn]
+  simp [takeRows, ofFn]
 
-/-- Entry formula for the `(k + 1)` leading submatrix. -/
-@[grind =] theorem leadingSubmatrix_entry (M : Matrix R n n) (k : Fin n)
-    (i j : Fin (k.val + 1)) :
-    (leadingSubmatrix M k)[i][j] =
-      (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt (Nat.succ_le_of_lt k.isLt)⟩
-       let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
-       M[ii][jj]) := by
-  simp [leadingSubmatrix, ofFn]
-
-/-- The `leadingSubmatrix` API is the `(k + 1)` leading-prefix API at the
-same boundary. -/
-theorem leadingSubmatrix_eq_leadingPrefix (M : Matrix R n n) (k : Fin n) :
-    leadingSubmatrix M k = leadingPrefix M (k.val + 1) (Nat.succ_le_of_lt k.isLt) := by
+/-- The leading principal `k × k` submatrix of the identity is the identity. -/
+@[simp, grind =] theorem principalSubmatrix_one {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}
+    (k : Nat) (hk : k ≤ n) :
+    principalSubmatrix (1 : Matrix R n n) k hk = (1 : Matrix R k k) := by
   ext i hi j hj
-  simp [leadingSubmatrix, leadingPrefix, ofFn]
-
-/-- The leading principal `(k + 1) × (k + 1)` submatrix of the identity is the
-identity. -/
-@[simp, grind =] theorem leadingSubmatrix_one {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}
-    (k : Fin n) :
-    leadingSubmatrix (1 : Matrix R n n) k = (1 : Matrix R (k.val + 1) (k.val + 1)) := by
-  ext i hi j hj
-  show (leadingSubmatrix (1 : Matrix R n n) k)[(⟨i, hi⟩ : Fin (k.val + 1))][
-      (⟨j, hj⟩ : Fin (k.val + 1))] =
-    (1 : Matrix R (k.val + 1) (k.val + 1))[(⟨i, hi⟩ : Fin (k.val + 1))][
-      (⟨j, hj⟩ : Fin (k.val + 1))]
-  rw [leadingSubmatrix_entry]
-  rw [getElem_one (i := (⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩ : Fin n))]
-  rw [getElem_one (i := (⟨i, hi⟩ : Fin (k.val + 1)))]
-  by_cases hij : (⟨i, hi⟩ : Fin (k.val + 1)) = ⟨j, hj⟩
+  show (principalSubmatrix (1 : Matrix R n n) k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)] =
+    (1 : Matrix R k k)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
+  rw [getElem_principalSubmatrix]
+  rw [getElem_one (i := (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n))]
+  rw [getElem_one (i := (⟨i, hi⟩ : Fin k))]
+  by_cases hij : (⟨i, hi⟩ : Fin k) = ⟨j, hj⟩
   · have hval : i = j := Fin.val_eq_of_eq hij
     have hijn :
-        (⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩ : Fin n) =
-          ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt k.isLt)⟩ := by
+        (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n) = ⟨j, Nat.lt_of_lt_of_le hj hk⟩ := by
       apply Fin.eq_of_val_eq; exact hval
     simp [hij, hijn]
   · have hval : i ≠ j := fun heq => hij (by apply Fin.eq_of_val_eq; exact heq)
     have hijn :
-        (⟨i, Nat.lt_of_lt_of_le hi (Nat.succ_le_of_lt k.isLt)⟩ : Fin n) ≠
-          ⟨j, Nat.lt_of_lt_of_le hj (Nat.succ_le_of_lt k.isLt)⟩ := fun heq =>
+        (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n) ≠ ⟨j, Nat.lt_of_lt_of_le hj hk⟩ := fun heq =>
       hval (Fin.val_eq_of_eq heq)
     simp [hij, hijn]
 

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -14,7 +14,7 @@ Run this file through the conformance Lake target, not direct `lake env lean`.
 Oracle: none
 Mode: always
 Covered operations:
-- dense matrix constructors and accessors (`ofFn`, `row`, `col`, `transpose`, `leadingSubmatrix`)
+- dense matrix constructors and accessors (`ofFn`, `row`, `col`, `transpose`, `principalSubmatrix`)
 - vector and matrix arithmetic (`dotProduct`, `Hex.Vector.normSq`, `mulVec`, `mul`, `gramMatrix`)
 - elementary row operations (`rowSwap`, `rowScale`, `rowAdd`)
 Covered properties:
@@ -82,8 +82,8 @@ private def spanVec : Vector Rat 3 :=
 
 #guard Matrix.row baseInt ⟨1, by decide⟩ = rowOneInt
 #guard Matrix.col baseInt ⟨0, by decide⟩ = colZeroInt
-#guard Matrix.leadingSubmatrix baseInt ⟨0, by decide⟩ = unitSubmatrix
-#guard Matrix.leadingSubmatrix baseInt ⟨1, by decide⟩ = baseInt
+#guard Matrix.principalSubmatrix baseInt 1 (by decide) = unitSubmatrix
+#guard Matrix.principalSubmatrix baseInt 2 (by decide) = baseInt
 #guard Hex.Vector.normSq vecInt = 61
 #guard Hex.Vector.normSq spanVec = 14
 #guard Matrix.gramMatrix baseInt = baseGramInt


### PR DESCRIPTION
This PR renames the leading-submatrix family for clarity and collapses a redundant definition. `Matrix.leadingPrefix` becomes `Matrix.principalSubmatrix` ("principal" signals the square, equal-index-set block that "prefix" did not), `Matrix.leadingRows` becomes `Matrix.takeRows` (matching `List.take`), and the per-slice entry lemmas move to the `getElem_` convention (`getElem_principalSubmatrix`, `getElem_takeRows`). The `Matrix.leadingSubmatrix` wrapper, which was just the non-empty `(k+1)×(k+1)` special case of the prefix taken over `Fin n`, is removed; its only load-bearing users (the Gram determinant-positivity API in `independent_of_det_positive` and `gramMatrix_takeRows_eq_principalSubmatrix`) are restated over `∀ k (hk : k ≤ n)`, which drops the `k.val + 1` bookkeeping and simplifies the proofs. Compound lemma names embedding the old slicer names are renamed to match.

🤖 Prepared with Claude Code