### PR TITLE
refactor: generalize dotProduct right-argument lemmas to Ring

### DIFF
--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -68,6 +68,23 @@ private theorem foldl_sum_add_aux {R : Type u} [Lean.Grind.Ring R]
       rw [h]
       grind
 
+/-- The fold-sum of a pointwise difference splits into the difference of fold-sums. -/
+private theorem foldl_sum_sub_aux {R : Type u} [Lean.Grind.Ring R]
+    {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
+    (h : acc = accF - accG) :
+    xs.foldl (fun acc x => acc + (f x - g x)) acc =
+    xs.foldl (fun acc x => acc + f x) accF -
+    xs.foldl (fun acc x => acc + g x) accG := by
+  induction xs generalizing acc accF accG with
+  | nil =>
+      simp only [List.foldl_nil]
+      exact h
+  | cons x xs ih =>
+      simp only [List.foldl_cons]
+      apply ih (acc := acc + (f x - g x)) (accF := accF + f x) (accG := accG + g x)
+      rw [h]
+      grind
+
 /-- Dot product is additive in its left argument. -/
 theorem dotProduct_add_left {R : Type u} [Lean.Grind.Ring R]
     (u v w : Vector R n) :
@@ -116,20 +133,32 @@ theorem dotProduct_comm {R : Type u} [Lean.Grind.CommRing R]
   grind
 
 /-- Dot product is additive in its right argument. -/
-theorem dotProduct_add_right {R : Type u} [Lean.Grind.CommRing R]
+theorem dotProduct_add_right {R : Type u} [Lean.Grind.Ring R]
     (u v w : Vector R n) :
     dotProduct u (v + w) = dotProduct u v + dotProduct u w := by
-  rw [dotProduct_comm u (v + w)]
-  rw [dotProduct_add_left]
-  rw [dotProduct_comm v u, dotProduct_comm w u]
+  unfold dotProduct
+  rw [show (List.finRange n).foldl
+        (fun acc i => acc + u[i] * (v + w)[i]) 0 =
+      (List.finRange n).foldl
+        (fun acc i => acc + (u[i] * v[i] + u[i] * w[i])) 0 from ?_]
+  · rw [foldl_sum_add_aux (xs := List.finRange n)
+        (f := fun i => u[i] * v[i])
+        (g := fun i => u[i] * w[i])
+        (acc := 0) (accF := 0) (accG := 0) (h := by grind)]
+  · apply foldl_sum_congr_aux
+    intro i _
+    have hentry : (v + w)[i] = v[i] + w[i] := by
+      change (v + w)[i.val] = v[i.val] + w[i.val]
+      rw [Vector.getElem_add]
+    rw [hentry]
+    grind
 
 /-- Dot product is homogeneous in a pointwise right scalar multiple. -/
 theorem dotProduct_mul_right {R : Type u} [Lean.Grind.CommRing R]
     (c : R) (u v : Vector R n) :
     dotProduct u (Vector.ofFn fun i => c * v[i]) = c * dotProduct u v := by
-  rw [dotProduct_comm u (Vector.ofFn fun i => c * v[i])]
-  rw [dotProduct_mul_left]
-  rw [dotProduct_comm v u]
+  rw [dotProduct_comm u (Vector.ofFn fun i => c * v[i]), dotProduct_mul_left,
+    dotProduct_comm v u]
 
 /-- Dot product is homogeneous in its left argument. -/
 theorem dotProduct_smul_left {R : Type u} [Lean.Grind.Ring R]
@@ -149,9 +178,7 @@ theorem dotProduct_smul_left {R : Type u} [Lean.Grind.Ring R]
 theorem dotProduct_smul_right {R : Type u} [Lean.Grind.CommRing R]
     (c : R) (u v : Vector R n) :
     dotProduct u (c • v) = c * dotProduct u v := by
-  rw [dotProduct_comm u (c • v)]
-  rw [dotProduct_smul_left]
-  rw [dotProduct_comm v u]
+  rw [dotProduct_comm u (c • v), dotProduct_smul_left, dotProduct_comm v u]
 
 /-- Dot product is additive over subtraction in its left argument. -/
 theorem dotProduct_sub_left {R : Type u} [Lean.Grind.Ring R]
@@ -171,12 +198,25 @@ theorem dotProduct_sub_left {R : Type u} [Lean.Grind.Ring R]
   grind
 
 /-- Dot product is additive over subtraction in its right argument. -/
-theorem dotProduct_sub_right {R : Type u} [Lean.Grind.CommRing R]
+theorem dotProduct_sub_right {R : Type u} [Lean.Grind.Ring R]
     (u v w : Vector R n) :
     dotProduct u (v - w) = dotProduct u v - dotProduct u w := by
-  rw [dotProduct_comm u (v - w)]
-  rw [dotProduct_sub_left]
-  rw [dotProduct_comm v u, dotProduct_comm w u]
+  unfold dotProduct
+  rw [show (List.finRange n).foldl
+        (fun acc i => acc + u[i] * (v - w)[i]) 0 =
+      (List.finRange n).foldl
+        (fun acc i => acc + (u[i] * v[i] - u[i] * w[i])) 0 from ?_]
+  · rw [foldl_sum_sub_aux (xs := List.finRange n)
+        (f := fun i => u[i] * v[i])
+        (g := fun i => u[i] * w[i])
+        (acc := 0) (accF := 0) (accG := 0) (h := by grind)]
+  · apply foldl_sum_congr_aux
+    intro i _
+    have hentry : (v - w)[i] = v[i] - w[i] := by
+      change (v - w)[i.val] = v[i.val] - w[i.val]
+      rw [Vector.getElem_sub]
+    rw [hentry]
+    grind
 
 /-- Dot product distributes over subtracting a scalar multiple in the left argument. -/
 theorem dotProduct_sub_smul_left {R : Type u} [Lean.Grind.Ring R]


### PR DESCRIPTION
This PR generalizes `dotProduct_add_right` and `dotProduct_sub_right` to `Lean.Grind.Ring`, proving them directly rather than routing through `dotProduct_comm` (which forced a needless `CommRing` constraint), and adds a `foldl_sum_sub_aux` helper for the subtraction case. The multiplicative right-argument lemmas `dotProduct_mul_right` and `dotProduct_smul_right` genuinely require `CommRing` (they are false over a noncommutative ring, where `u[i] * c ≠ c * u[i]`), so they keep it; their rewrite chains are combined into single `rw` calls.

🤖 Prepared with Claude Code