### PR TITLE
refactor: make elementary row/column operations use the matrix linearly

### DIFF
--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -580,36 +580,8 @@ swapped rows read from the opposite source, every other row is unchanged. -/
 @[grind =]
 private theorem rowSwap_get (M : Matrix Int n n) (rowA rowB i j : Fin n) :
     (rowSwap M rowA rowB)[i][j] =
-      if i = rowB then M[rowA][j] else if i = rowA then M[rowB][j] else M[i][j] := by
-  by_cases hiB : i = rowB
-  · subst i
-    simp [rowSwap]
-  · by_cases hiA : i = rowA
-    · subst i
-      simp [rowSwap, hiB]
-      have hval : rowB.val ≠ rowA.val := by
-        intro hval
-        exact hiB (Fin.ext hval.symm)
-      have hrow : ((M.set rowA M[rowB]).set rowB M[rowA])[rowA] =
-          (M.set rowA M[rowB])[rowA] := by
-        exact Vector.getElem_set_ne (xs := M.set rowA M[rowB]) (x := M[rowA])
-          rowB.isLt rowA.isLt hval
-      simpa using congrArg (fun row => row[j]) hrow
-    · simp [rowSwap, hiB, hiA]
-      have hAi : rowA.val ≠ i.val := by
-        intro hval
-        exact hiA (Fin.ext hval.symm)
-      have hBi : rowB.val ≠ i.val := by
-        intro hval
-        exact hiB (Fin.ext hval.symm)
-      have hrow₁ : (M.set rowA M[rowB])[i] = M[i] := by
-        exact Vector.getElem_set_ne (xs := M) (x := M[rowB]) rowA.isLt i.isLt hAi
-      have hrow₂ : ((M.set rowA M[rowB]).set rowB M[rowA])[i] =
-          (M.set rowA M[rowB])[i] := by
-        exact Vector.getElem_set_ne (xs := M.set rowA M[rowB]) (x := M[rowA])
-          rowB.isLt i.isLt hBi
-      exact (congrArg (fun row => row[j]) hrow₂).trans
-        (congrArg (fun row => row[j]) hrow₁)
+      if i = rowB then M[rowA][j] else if i = rowA then M[rowB][j] else M[i][j] :=
+  rowSwap_getElem M rowA rowB i j
 
 /-- `swapRowsArray` applied to `matrixToRows M` matches the abstract
 `rowSwap M rowA rowB` entry by entry. -/
@@ -621,7 +593,9 @@ private theorem getEntry_swapRowsArray_matrixToRows (M : Matrix Int n n)
   by_cases hsame : rowA.val = rowB.val
   · have hrows : rowA = rowB := Fin.ext hsame
     subst rowB
-    simp [swapRowsArray, getEntry_matrixToRows, rowSwap]
+    rw [rowSwap_get]
+    by_cases hir : i = rowA <;>
+      simp [swapRowsArray, getEntry_matrixToRows, hir]
   · have hrows_size : (matrixToRows M).size = n := by
       simp [matrixToRows]
     have hrowA : rowA.val < (matrixToRows M).size := by

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -103,31 +103,8 @@ when `r = j`, from row `j` when `r = i`, and from row `r` otherwise. -/
 private theorem rowSwap_get {R : Type u} {n m : Nat}
     (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
     (rowSwap M i j)[r][k] =
-      if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] := by
-  by_cases hrj : r = j
-  · subst r
-    simp [rowSwap]
-  · by_cases hri : r = i
-    · subst r
-      simp [rowSwap, hrj]
-      have hval : j.val ≠ i.val := by
-        intro hval
-        exact hrj (Fin.ext hval.symm)
-      have hrow : ((M.set i M[j]).set j M[i])[i] = (M.set i M[j])[i] := by
-        exact Vector.getElem_set_ne (xs := M.set i M[j]) (x := M[i]) j.isLt i.isLt hval
-      simpa using congrArg (fun row => row[k]) hrow
-    · simp [rowSwap, hrj, hri]
-      have hir : i.val ≠ r.val := by
-        intro hval
-        exact hri (Fin.ext hval.symm)
-      have hjr : j.val ≠ r.val := by
-        intro hval
-        exact hrj (Fin.ext hval.symm)
-      have hrow₁ : (M.set i M[j])[r] = M[r] := by
-        exact Vector.getElem_set_ne (xs := M) (x := M[j]) i.isLt r.isLt hir
-      have hrow₂ : ((M.set i M[j]).set j M[i])[r] = (M.set i M[j])[r] := by
-        exact Vector.getElem_set_ne (xs := M.set i M[j]) (x := M[i]) j.isLt r.isLt hjr
-      exact (congrArg (fun row => row[k]) hrow₂).trans (congrArg (fun row => row[k]) hrow₁)
+      if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] :=
+  rowSwap_getElem M i j r k
 
 /-- For distinct `i, j`, reading row `r` of `rowSwap M i j` is the same as
 reading row `finTranspose i j r` of `M`, identifying the swap with the
@@ -1739,7 +1716,7 @@ private theorem colAdd_get {R : Type u} [Mul R] [Add R] {n : Nat}
     (M : Matrix R n n) (src dst r cidx : Fin n) (c : R) :
     (colAdd M src dst c)[r][cidx] =
       if cidx = dst then M[r][cidx] + c * M[r][src] else M[r][cidx] := by
-  simp [colAdd, Matrix.ofFn]
+  exact colAdd_getElem M src dst c r cidx
 
 /-- For a nodup permutation, the product term of `colAdd M src dst c` splits as
 `detProduct M perm + c · detProduct (colAddDuplicate M src dst) perm`. -/

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -311,7 +311,8 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
           (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] +
             c * (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][jt]
         else (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] := by
-    simp [Matrix.colAdd, Matrix.ofFn, Vector.getElem_ofFn]
+    exact Matrix.colAdd_getElem
+      (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c) jt kt c p q
   rw [hLHS, hRHS]
   -- Case split on `q = kt` and `p = kt`.
   by_cases hqk : q = kt

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -24,10 +24,14 @@ universe u
 
 namespace Matrix
 
-/-- Swap rows `i` and `j` in a dense matrix. -/
+/-- Swap rows `i` and `j` in a dense matrix.
+
+Implemented with `Vector.swap`, which updates the dense backing store in place
+when `M` is uniquely referenced, rather than reading both rows and writing them
+back through two `set`s (which forces a copy of the outer vector). -/
 @[expose]
 def rowSwap (M : Matrix R n m) (i j : Fin n) : Matrix R n m :=
-  (M.set i M[j]).set j M[i]
+  M.swap i j
 
 /-- Read an entry of `rowSwap M i j` by cases on the row index: row `j`
 returns the original row `i`, row `i` returns the original row `j`, and any
@@ -35,33 +39,9 @@ other row is unchanged. -/
 theorem rowSwap_getElem (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
     (rowSwap M i j)[r][k] =
       if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] := by
-  by_cases hrj : r = j
-  · subst r
-    simp [rowSwap]
-  · by_cases hri : r = i
-    · subst r
-      simp [rowSwap, hrj]
-      have hval : j.val ≠ i.val := by
-        intro hval
-        exact hrj (Fin.ext hval.symm)
-      have hrow : ((M.set i M[j]).set j M[i])[i] = (M.set i M[j])[i] := by
-        exact Vector.getElem_set_ne (xs := M.set i M[j]) (x := M[i])
-          j.isLt i.isLt hval
-      simpa using congrArg (fun row => row[k]) hrow
-    · simp [rowSwap, hrj, hri]
-      have hir : i.val ≠ r.val := by
-        intro hval
-        exact hri (Fin.ext hval.symm)
-      have hjr : j.val ≠ r.val := by
-        intro hval
-        exact hrj (Fin.ext hval.symm)
-      have hrow₁ : (M.set i M[j])[r] = M[r] := by
-        exact Vector.getElem_set_ne (xs := M) (x := M[j]) i.isLt r.isLt hir
-      have hrow₂ : ((M.set i M[j]).set j M[i])[r] = (M.set i M[j])[r] := by
-        exact Vector.getElem_set_ne (xs := M.set i M[j]) (x := M[i])
-          j.isLt r.isLt hjr
-      exact (congrArg (fun row => row[k]) hrow₂).trans
-        (congrArg (fun row => row[k]) hrow₁)
+  rw [rowSwap]
+  by_cases hri : r = i <;> by_cases hrj : r = j <;>
+    simp_all [Fin.getElem_fin, Fin.ext_iff]
 
 /-- Row `i` of `rowSwap M i j` is the original row `j`. -/
 @[simp, grind =] theorem row_rowSwap_left (M : Matrix R n m) (i j : Fin n) :
@@ -104,10 +84,15 @@ theorem rowSwap_diag_of_ne (M : Matrix R n n) {k pivot : Fin n}
   · exact (h hkp.symm).elim
   · simp [hkp]
 
-/-- Scale row `i` by `c`. -/
+/-- Scale row `i` by `c`.
+
+The row is read once into `row`, so the only remaining reference to `M` is the
+consuming `set`, which updates the backing store in place when `M` is uniquely
+referenced. -/
 @[expose]
 def rowScale [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) : Matrix R n m :=
-  M.set i <| Vector.ofFn fun k => c * M[i][k]
+  let row := M[i]
+  M.set i <| Vector.ofFn fun k => c * row[k]
 
 /-- Read an entry of `rowScale M i c` by cases on the row index: row `i`
 returns `c * M[i][k]`, any other row is unchanged. -/
@@ -147,10 +132,16 @@ theorem row_rowScale_of_ne [Mul R] (M : Matrix R n m) {i r : Fin n} (c : R)
   rw [row_getElem, row_getElem, rowScale_getElem]
   simp [hri]
 
-/-- Replace row `dst` by `row dst + c * row src`. -/
+/-- Replace row `dst` by `row dst + c * row src`.
+
+Both rows are read once into `rdst`/`rsrc`, so the only remaining reference to
+`M` is the consuming `set`, which updates the backing store in place when `M` is
+uniquely referenced. -/
 @[expose]
 def rowAdd [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : R) : Matrix R n m :=
-  M.set dst <| Vector.ofFn fun k => M[dst][k] + c * M[src][k]
+  let rdst := M[dst]
+  let rsrc := M[src]
+  M.set dst <| Vector.ofFn fun k => rdst[k] + c * rsrc[k]
 
 /-- Read an entry of `rowAdd M src dst c` by cases on the row index: row `dst`
 returns `M[dst][k] + c * M[src][k]`, any other row is unchanged. -/
@@ -209,10 +200,16 @@ theorem row_rowAdd_of_ne [Mul R] [Add R]
     row (rowAdd M src dst c) src = row M src := by
   exact row_rowAdd_of_ne M src c hsrcdst
 
-/-- Replace column `dst` by `col dst + c * col src`. -/
+/-- Replace column `dst` by `col dst + c * col src`.
+
+Rather than rebuilding the whole matrix with `ofFn`, each row is mapped to its
+update of the single `dst` entry. `Vector.map` frees each row slot before
+applying the function, so the outer vector is reused when `M` is uniquely
+referenced, and each row's single-entry update is itself in place when that row
+vector is uniquely referenced. -/
 @[expose]
 def colAdd [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin m) (c : R) : Matrix R n m :=
-  Matrix.ofFn fun i j => if j = dst then M[i][j] + c * M[i][src] else M[i][j]
+  M.map fun row => row.set dst (row[dst] + c * row[src])
 
 /-- Replace column `dst` by `col dst + col src * c`.
 
@@ -221,7 +218,7 @@ whose right-multiplication wrapper is valid over a noncommutative ring. -/
 @[expose]
 def colAddRight [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin m) (c : R) :
     Matrix R n m :=
-  Matrix.ofFn fun i j => if j = dst then M[i][j] + M[i][src] * c else M[i][j]
+  M.map fun row => row.set dst (row[dst] + row[src] * c)
 
 /-- Read an entry of `colAdd M src dst c` by cases on the column index:
 column `dst` returns `M[i][dst] + c * M[i][src]`, any other column is
@@ -230,7 +227,9 @@ theorem colAdd_getElem [Mul R] [Add R]
     (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) (j : Fin m) :
     (colAdd M src dst c)[i][j] =
       if j = dst then M[i][j] + c * M[i][src] else M[i][j] := by
-  rw [colAdd, getElem_ofFn]
+  rw [colAdd]
+  simp only [Fin.getElem_fin, Vector.getElem_map]
+  grind
 
 /-- Read an entry of `colAddRight M src dst c` by cases on the column index:
 column `dst` returns `M[i][dst] + M[i][src] * c`, any other column is
@@ -239,7 +238,9 @@ theorem colAddRight_getElem [Mul R] [Add R]
     (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) (j : Fin m) :
     (colAddRight M src dst c)[i][j] =
       if j = dst then M[i][j] + M[i][src] * c else M[i][j] := by
-  rw [colAddRight, getElem_ofFn]
+  rw [colAddRight]
+  simp only [Fin.getElem_fin, Vector.getElem_map]
+  grind
 
 /-- Column `dst` of `colAdd M src dst c` is the pointwise column combination. -/
 @[simp, grind =] theorem col_colAdd_dst [Mul R] [Add R]


### PR DESCRIPTION
This PR makes the dense elementary row and column operations in `HexMatrix/Elementary.lean` use the matrix linearly, so the compiler mutates the backing store in place instead of copying it. `rowSwap` previously read both rows and wrote them back through two `set`s while still mentioning `M` a third time, forcing a copy of the outer vector; it now calls `Vector.swap`, the extern in-place swap. `rowScale` and `rowAdd` read their rows into `let` bindings first, leaving the consuming `set` as the only remaining reference to `M`. `colAdd` and `colAddRight` rebuilt the entire `n × m` matrix with `ofFn`; they now map each row to its single-entry update, and because `Vector.map` frees each row slot before applying the function, a uniquely referenced `M` reuses the outer vector, with each row's single-entry update also in place when that row vector is uniquely referenced.

The entrywise `getElem` lemma statements are byte-identical, so only their proofs moved, and the duplicate restatements in `HexDeterminant` and `HexBareiss` now defer to the canonical lemmas. The full `lake build` is green and the `HexConformance` `#guard`/`#eval` runtime checks (including `rowSwap` involution and the determinant identities) confirm the refactored operations compute identical values.

🤖 Prepared with Claude Code
