### PR TITLE
style: combine consecutive rw calls into single rw

### DIFF
--- a/HexArith/Barrett/Context.lean
+++ b/HexArith/Barrett/Context.lean
@@ -96,16 +96,15 @@ theorem toNat_mulMod (ctx : BarrettCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     (ctx.mulMod a b).toNat = (a.toNat * b.toNat) % p.toNat := by
   unfold mulMod
-  rw [toNat_barrettReduce_eq_mod ctx (a * b) (product_toNat_lt_p2 ctx a b ha hb)]
-  rw [product_toNat_eq ctx a b ha hb]
+  rw [toNat_barrettReduce_eq_mod ctx (a * b) (product_toNat_lt_p2 ctx a b ha hb),
+    product_toNat_eq ctx a b ha hb]
 
 /-- Barrett modular multiplication returns a residue strictly below the modulus. -/
 @[grind =>]
 theorem mulMod_lt (ctx : BarrettCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     ctx.mulMod a b < p := by
-  rw [UInt64.lt_iff_toNat_lt]
-  rw [toNat_mulMod ctx a b ha hb]
+  rw [UInt64.lt_iff_toNat_lt, toNat_mulMod ctx a b ha hb]
   exact Nat.mod_lt _ (Nat.lt_trans (by decide : 0 < 1) ctx.p_gt)
 
 /--
@@ -117,8 +116,8 @@ theorem mulMod_eq (ctx : BarrettCtx p) (a b : UInt64)
     (ha : a < p) (hb : b < p) :
     ctx.mulMod a b = .ofNat ((a.toNat * b.toNat) % p.toNat) := by
   unfold mulMod
-  rw [barrettReduce_eq ctx (a * b) (product_toNat_lt_p2 ctx a b ha hb)]
-  rw [product_toNat_eq ctx a b ha hb]
+  rw [barrettReduce_eq ctx (a * b) (product_toNat_lt_p2 ctx a b ha hb),
+    product_toNat_eq ctx a b ha hb]
 
 /--
 Barrett modular multiplication fixes products that are already canonical

--- a/HexArith/ExtGcd.lean
+++ b/HexArith/ExtGcd.lean
@@ -479,8 +479,7 @@ theorem extGcd_zero_left_s_ofNat (p : Nat) (hp : 0 < p) :
       omega
   | succ p =>
       simp [extGcd, Hex.pureIntExtGcd]
-      rw [show (↑p + 1 : Int) = Int.ofNat (p + 1) by simp]
-      rw [Hex.pureIntExtGcd.go.eq_def]
+      rw [show (↑p + 1 : Int) = Int.ofNat (p + 1) by simp, Hex.pureIntExtGcd.go.eq_def]
       simp
       rw [Hex.pureIntExtGcd.go.eq_def]
       simp [show ¬ (↑p + 1 : Int) < 0 by omega]

--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -87,8 +87,7 @@ private theorem toNat_doubleMod (p acc : UInt64) (hacc : acc.toNat < p.toNat) :
         simpa [UInt64.word, UInt64.size] using UInt64.toNat_lt_size p
       omega
     have hadd : (acc + acc).toNat = 2 * acc.toNat := by
-      rw [UInt64.toNat_add]
-      rw [Nat.mod_eq_of_lt]
+      rw [UInt64.toNat_add, Nat.mod_eq_of_lt]
       · omega
       · simpa [UInt64.word, Nat.two_mul] using htwo_lt_word
     have hmod : (2 * acc.toNat) % p.toNat = 2 * acc.toNat :=
@@ -1083,8 +1082,8 @@ and reduce. -/
 @[grind =>]
 theorem powMod_succ (a n p : Nat) (hp : p > 0) :
     powMod a (n + 1) p = (a * powMod a n p) % p := by
-  rw [powMod_eq a (n + 1) p hp, powMod_eq a n p hp, Nat.pow_succ]
-  rw [Nat.mul_comm (a ^ n) a, Nat.mul_mod_mod]
+  rw [powMod_eq a (n + 1) p hp, powMod_eq a n p hp, Nat.pow_succ,
+    Nat.mul_comm (a ^ n) a, Nat.mul_mod_mod]
 
 /-- Reducing the base before modular exponentiation does not change `powMod`. -/
 @[simp, grind =]

--- a/HexArith/Montgomery/InvNat.lean
+++ b/HexArith/Montgomery/InvNat.lean
@@ -225,8 +225,7 @@ private theorem nat_mod_eq_pred_of_int_dvd_add_one {T n : Nat} (hT : 1 < T)
   obtain ⟨r, hr⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : q.toNat ≠ 0)
   rw [hr] at hn_eq
   have hn_split : n = T * r + (T - 1) := by grind
-  rw [hn_split]
-  rw [Nat.add_mod]
+  rw [hn_split, Nat.add_mod]
   simp [Nat.mod_eq_of_lt (by omega : T - 1 < T)]
 
 /-- The 3-bit Newton seed fact: the square of any odd number is `1 mod 8`. -/

--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -66,8 +66,7 @@ private theorem redc_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
           have hword : UInt64.word - 1 + 1 = UInt64.word :=
             Nat.sub_add_cancel hword_pos
           have hmul : a + a * (UInt64.word - 1) = a * UInt64.word := by
-            rw [Nat.add_comm]
-            rw [← Nat.mul_succ]
+            rw [Nat.add_comm, ← Nat.mul_succ]
             have hs : (UInt64.word - 1).succ = UInt64.word := by
               simpa [Nat.succ_eq_add_one] using hword
             rw [hs]
@@ -91,8 +90,7 @@ private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
           = (Tlo.toNat * ctx.p'.toNat * p.toNat) % UInt64.word := by
             rw [Nat.mul_mod ((Tlo.toNat * ctx.p'.toNat) % UInt64.word) p.toNat
               UInt64.word]
-            rw [Nat.mod_mod]
-            rw [← Nat.mul_mod (Tlo.toNat * ctx.p'.toNat) p.toNat UInt64.word]
+            rw [Nat.mod_mod, ← Nat.mul_mod (Tlo.toNat * ctx.p'.toNat) p.toNat UInt64.word]
       _ = (Tlo.toNat * (ctx.p'.toNat * p.toNat)) % UInt64.word := by
             rw [Nat.mul_assoc]
   calc
@@ -107,8 +105,7 @@ private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
           rw [hmul_mod]
     _ = (Tlo.toNat + (Tlo.toNat * ((ctx.p'.toNat * p.toNat) %
             UInt64.word)) % UInt64.word) % UInt64.word := by
-          rw [Nat.mul_mod]
-          rw [Nat.mod_eq_of_lt hTlo]
+          rw [Nat.mul_mod, Nat.mod_eq_of_lt hTlo]
     _ = 0 := by
           rw [hpp']
           exact redc_cancel_pred_word Tlo.toNat hTlo
@@ -197,10 +194,8 @@ theorem redc_u_spec (ctx : MontCtx p) (Thi Tlo : UInt64) :
                 UInt64.word * (Thi.toNat + (UInt64.mulHi m p).toNat + c1.toNat) := by
             have hlow_exact := hlow.2
             have hmul_exact := hmul
-            rw [Nat.mul_add, Nat.mul_add]
-            rw [Nat.mul_comm UInt64.word Thi.toNat]
-            rw [Nat.mul_comm UInt64.word (UInt64.mulHi m p).toNat]
-            rw [Nat.mul_comm UInt64.word c1.toNat]
+            rw [Nat.mul_add, Nat.mul_add, Nat.mul_comm UInt64.word Thi.toNat,
+              Nat.mul_comm UInt64.word (UInt64.mulHi m p).toNat, Nat.mul_comm UInt64.word c1.toNat]
             omega
           have hresult :
               addHi.toNat + c2.toNat * UInt64.word =

--- a/HexArith/Montgomery/RedcNat.lean
+++ b/HexArith/Montgomery/RedcNat.lean
@@ -29,9 +29,7 @@ def redcNat (p p' T : Nat) : Nat :=
 /-- Reducing `T` before multiplying by `p'` does not change the correction word. -/
 private theorem redcNat_correction_eq (p' T : Nat) :
     T * p' % UInt64.word = (T % UInt64.word) * p' % UInt64.word := by
-  rw [Nat.mul_mod T p' UInt64.word]
-  rw [Nat.mul_mod (T % UInt64.word) p' UInt64.word]
-  rw [Nat.mod_mod]
+  rw [Nat.mul_mod T p' UInt64.word, Nat.mul_mod (T % UInt64.word) p' UInt64.word, Nat.mod_mod]
 
 /-- A word-sized value plus its `R - 1` multiple vanishes modulo `R`. -/
 private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
@@ -50,8 +48,7 @@ private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
           have hword : UInt64.word - 1 + 1 = UInt64.word :=
             Nat.sub_add_cancel hword_pos
           have hmul : a + a * (UInt64.word - 1) = a * UInt64.word := by
-            rw [Nat.add_comm]
-            rw [← Nat.mul_succ]
+            rw [Nat.add_comm, ← Nat.mul_succ]
             have hs : (UInt64.word - 1).succ = UInt64.word := by
               simpa [Nat.succ_eq_add_one] using hword
             rw [hs]
@@ -72,8 +69,7 @@ private theorem redcNat_exact_dvd (p p' T : Nat)
           = ((T % UInt64.word) * p' * p) % UInt64.word := by
             rw [Nat.mul_mod ((T % UInt64.word) * p' % UInt64.word) p
               UInt64.word]
-            rw [Nat.mod_mod]
-            rw [← Nat.mul_mod ((T % UInt64.word) * p') p UInt64.word]
+            rw [Nat.mod_mod, ← Nat.mul_mod ((T % UInt64.word) * p') p UInt64.word]
       _ = (T % UInt64.word * (p' * p)) % UInt64.word := by
             rw [Nat.mul_assoc]
   calc
@@ -91,8 +87,7 @@ private theorem redcNat_exact_dvd (p p' T : Nat)
     _ = (T % UInt64.word +
             (T % UInt64.word * ((p * p') % UInt64.word)) %
               UInt64.word) % UInt64.word := by
-          rw [Nat.mul_mod]
-          rw [Nat.mod_mod]
+          rw [Nat.mul_mod, Nat.mod_mod]
     _ = 0 := by
           rw [hpp']
           exact redcNat_cancel_pred_word (T % UInt64.word)
@@ -114,9 +109,7 @@ private theorem redcNat_u_lt_two_p_core (hp_pos : 0 < p)
         p * UInt64.word + UInt64.word * p :=
     Nat.add_lt_add hT hmulp_lt
   have htarget : UInt64.word * (2 * p) = p * UInt64.word + UInt64.word * p := by
-    rw [Nat.mul_comm UInt64.word (2 * p)]
-    rw [Nat.mul_assoc]
-    rw [Nat.two_mul]
+    rw [Nat.mul_comm UInt64.word (2 * p), Nat.mul_assoc, Nat.two_mul]
     simp [Nat.mul_comm]
   have hn_lt :
       T + ((T % UInt64.word) * p' % UInt64.word) * p <
@@ -152,8 +145,7 @@ theorem redcNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
     exact hu_mod
   · have hpu : p ≤ u := Nat.le_of_not_lt h
     have hsub : (u - p) * UInt64.word + p * UInt64.word = u * UInt64.word := by
-      rw [← Nat.add_mul]
-      rw [Nat.sub_add_cancel hpu]
+      rw [← Nat.add_mul, Nat.sub_add_cancel hpu]
     simp [redcNat, h, u]
     calc
       (u - p) * UInt64.word % p

--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -850,8 +850,7 @@ theorem getEntry_stepArray_matches
       simp [getEntry, hi, hj]
       change exactDiv (pivot * getEntry rows i.val j.val - getEntry rows i.val k *
           getEntry rows k j.val) prevPivot = (stepMatrix M k pivot prevPivot)[i][j]
-      rw [stepMatrix_update_eq M k pivot prevPivot i j hi hj]
-      rw [hij, hcol₁, hrow₁]
+      rw [stepMatrix_update_eq M k pivot prevPivot i j hi hj, hij, hcol₁, hrow₁]
     · by_cases hjeq : j.val = k
       · have hjFin : j = (⟨k, Nat.lt_trans hi i.isLt⟩ : Fin n) := Fin.ext hjeq
         subst j
@@ -1390,8 +1389,8 @@ theorem pivotLoop_eq_noPivotLoop_of_no_singular {n : Nat}
               prevPivot := state.matrix[state.step][state.step]
               rowSwaps := state.rowSwaps
               singularStep := none }
-          rw [noPivotLoop_regular_branch f state hDone hp]
-          rw [pivotLoop_regular_branch_no_swap f state hDone hp]
+          rw [noPivotLoop_regular_branch f state hDone hp,
+            pivotLoop_regular_branch_no_swap f state hDone hp]
           show pivotLoop f next = noPivotLoop f next
           apply ih
           show (noPivotLoop f next).singularStep = none

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -450,8 +450,7 @@ private theorem rowSwap_getElem_of_ne {R : Type u}
     (M : Hex.Matrix R n n) (kFin pivot r : Fin n) (c : Fin n)
     (hr_ne_kFin : r ≠ kFin) (hr_ne_pivot : r ≠ pivot) :
     (Hex.Matrix.rowSwap M kFin pivot)[r][c] = M[r][c] := by
-  rw [Hex.Matrix.rowSwap_getElem]
-  rw [if_neg hr_ne_pivot, if_neg hr_ne_kFin]
+  rw [Hex.Matrix.rowSwap_getElem, if_neg hr_ne_pivot, if_neg hr_ne_kFin]
 
 /-- Reading row `r` of `rowSwap M kFin pivot` returns row `swap_idx r` of `M`,
 where `swap_idx kFin pivot r = if r = pivot then kFin else if r = kFin then pivot else r`. -/
@@ -1202,8 +1201,7 @@ private theorem submatrix_borderedMinor_succAbove_last_eq_topBlock
       omega
     rw [dif_neg hctlt]
     have h_succAbove_eq : c'.succAbove t = Fin.last k := Fin.ext hct_eq
-    rw [h_succAbove_eq]
-    rw [failedBareissTopBlock_apply_last source k hk s]
+    rw [h_succAbove_eq, failedBareissTopBlock_apply_last source k hk s]
     rfl
 
 /-- For any source row `r`, the dot product of `failedBareissColumn` with row
@@ -1600,11 +1598,9 @@ theorem bareissData_eq_mathlib_det (M : Hex.Matrix Int n n) :
           change Hex.Matrix.det logicalSource = 1
           exact (det_eq logicalSource).trans (by rw [Matrix.det_isEmpty])
         have hsource_det : Hex.Matrix.det M = (Hex.Matrix.bareissData M).sign := by
-          rw [hdet]
-          rw [hlogical_det, mul_one]
+          rw [hdet, hlogical_det, mul_one]
           exact hdata_sign.symm
-        rw [Hex.Matrix.BareissData.det_zero_eq _ hregular]
-        rw [← hsource_det]
+        rw [Hex.Matrix.BareissData.det_zero_eq _ hregular, ← hsource_det]
         exact det_eq M
     | k + 1, M, logicalSource, hdet, hnopiv, hregular =>
         have hloop_regular :
@@ -1635,9 +1631,7 @@ theorem bareissData_eq_mathlib_det (M : Hex.Matrix Int n n) :
                   (⟨k, Nat.lt_succ_self k⟩ : Fin (k + 1))] =
               Hex.Matrix.det logicalSource := by
           simpa [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish] using hentry
-        rw [Hex.Matrix.BareissData.det_succ_eq _ hregular]
-        rw [hdata_entry, hsign]
-        rw [← hdet]
+        rw [Hex.Matrix.BareissData.det_succ_eq _ hregular, hdata_entry, hsign, ← hdet]
         exact det_eq M
   · have hdata_zero : (Hex.Matrix.bareissData M).det = 0 := by
       unfold Hex.Matrix.BareissData.det

--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -112,10 +112,7 @@ private theorem berlekampColumnPolys_toList_eq_powModMonicLinear
             FpPoly.powModMonicLinear frobX f hmonic (offset + 1)
         rw [show offset + 1 = Nat.succ offset by omega]
         rfl
-      rw [hstep]
-      rw [ih (offset + 1)]
-      rw [Array.toList_push]
-      rw [List.range_succ_eq_map]
+      rw [hstep, ih (offset + 1), Array.toList_push, List.range_succ_eq_map]
       simp only [List.map_cons, List.map_map, List.append_assoc, List.append_cancel_left_eq]
       apply List.cons_eq_cons.mpr
       constructor
@@ -301,9 +298,8 @@ private theorem coeffVector_matrixActionPolySum_eq_mulVec
     (berlekampMatrix f hmonic)[ii][j] * (coeffVector f w)[j.val]
   rw [FpPoly.C_mul_eq_scale]
   have h_zero : w.coeff j.val * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ h_zero]
-  rw [berlekampMatrix_entry_eq_powModMonic_coeff f hmonic ii j]
-  rw [show (coeffVector f w)[j.val] = w.coeff j.val from by simp [coeffVector]]
+  rw [DensePoly.coeff_scale _ _ _ h_zero, berlekampMatrix_entry_eq_powModMonic_coeff f hmonic ii j,
+    show (coeffVector f w)[j.val] = w.coeff j.val from by simp [coeffVector]]
   show w.coeff j.val *
       (FpPoly.powModMonic (FpPoly.frobeniusXMod f hmonic) f hmonic j.val).coeff i =
     (FpPoly.powModMonic (FpPoly.frobeniusXMod f hmonic) f hmonic j.val).coeff i *
@@ -389,9 +385,7 @@ private theorem composeCoeffPowerSumUpTo_succ_right
         (DensePoly.C (coeff base) * FpPoly.linearPow q base +
           FpPoly.composeCoeffPowerSumUpTo coeff n (base + 1) q) +
         DensePoly.C (coeff (base + (n + 1))) * FpPoly.linearPow q (base + (n + 1))
-      rw [ih (base + 1)]
-      rw [show base + 1 + n = base + (n + 1) from by omega]
-      rw [FpPoly.add_assoc]
+      rw [ih (base + 1), show base + 1 + n = base + (n + 1) from by omega, FpPoly.add_assoc]
 
 /-- `composeCoeffPowerSumUpTo … n 0 q` viewed as the `List.finRange n`-foldl
 sum `Σ_{j < n} C(coeff j) · linearPow q j`. -/
@@ -406,11 +400,8 @@ private theorem composeCoeffPowerSumUpTo_eq_foldl_finRange
   | zero =>
       simp [FpPoly.composeCoeffPowerSumUpTo]
   | succ n ih =>
-      rw [composeCoeffPowerSumUpTo_succ_right coeff q n 0]
-      rw [Nat.zero_add]
-      rw [ih]
-      rw [List.finRange_succ_last]
-      rw [List.foldl_append]
+      rw [composeCoeffPowerSumUpTo_succ_right coeff q n 0, Nat.zero_add, ih,
+        List.finRange_succ_last, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
       -- foldl over (finRange n).map Fin.castSucc = foldl over finRange n
       have hmap :
@@ -589,8 +580,7 @@ private theorem matrixActionPolySum_eq_linearPow_mod
         apply DensePoly.ext_coeff
         intro n
         show (matrixActionPolySum f hmonic w).coeff n = (0 : FpPoly p).coeff n
-        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ n)]
-        rw [DensePoly.coeff_zero]
+        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ n), DensePoly.coeff_zero]
         rfl
       rw [h_zero]
       exact DensePoly.zero_mod_eq_zero_core (S := ZMod64 p) f
@@ -632,8 +622,8 @@ theorem berlekampMatrix_mulVec_coeffVector_eq
     (hw : w.size ≤ basisSize f) :
     Matrix.mulVec (berlekampMatrix f hmonic) (coeffVector f w) =
       coeffVector f (FpPoly.linearPow w p % f) := by
-  rw [← coeffVector_matrixActionPolySum_eq_mulVec f hmonic w]
-  rw [matrixActionPolySum_eq_linearPow_mod f hmonic w hw]
+  rw [← coeffVector_matrixActionPolySum_eq_mulVec f hmonic w,
+    matrixActionPolySum_eq_linearPow_mod f hmonic w hw]
 
 /-- The fixed-space matrix `Q_f - I` used in Berlekamp's kernel computation. -/
 def fixedSpaceMatrix (f : FpPoly p) (hmonic : DensePoly.Monic f) :
@@ -857,8 +847,8 @@ theorem isFixedSpaceKernelPolynomial_iff_dvd_linearPow_sub_self
   · have hbasis_pos : 0 < basisSize f := Nat.pos_of_ne_zero hbasis_zero
     have hw_mod : w % f = w := mod_eq_self_of_size_le_basis f w hw hbasis_pos
     unfold IsFixedSpaceKernelPolynomial
-    rw [isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq]
-    rw [berlekampMatrix_mulVec_coeffVector_eq f hmonic w hw]
+    rw [isFixedSpaceKernelVector_iff_berlekampMatrix_mulVec_eq,
+      berlekampMatrix_mulVec_coeffVector_eq f hmonic w hw]
     rw [coeffVector_eq_iff_eq_of_size_le f _ _
         (linearPow_mod_size_le_of_basis_pos f w hbasis_pos) hw]
     refine ⟨?_, ?_⟩

--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -314,8 +314,7 @@ private theorem degreeBucketProduct_appendBucket?_some
     (buckets : List (DegreeBucket p)) (bucket : DegreeBucket p) :
     degreeBucketProduct (appendBucket? buckets (some bucket)) =
       degreeBucketProduct buckets * bucket.factor := by
-  rw [appendBucket?]
-  rw [degreeBucketProduct_append, degreeBucketProduct_singleton]
+  rw [appendBucket?, degreeBucketProduct_append, degreeBucketProduct_singleton]
 
 /-- The factor contributed by an optional bucket: `1` for `none`, the recorded
 factor for `some bucket`. -/

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -239,8 +239,7 @@ private theorem isNontrivialSplitFactor_ne_one
       change DensePoly.C (1 : ZMod64 p) = 0
       apply DensePoly.ext_coeff
       intro n
-      rw [DensePoly.coeff_C]
-      rw [hone]
+      rw [DensePoly.coeff_C, hone]
       by_cases hn : n = 0 <;> simp [hn] <;> rfl
     rw [honePoly] at hnotZero
     have hzeroIsZero : (0 : FpPoly p).isZero = true := rfl
@@ -1027,8 +1026,7 @@ private theorem splitWithWitnesses?_cofactor_pos_degree
     exact hprod.symm
   have hsize_sum : r.factor.size + r.cofactor.size = f.size + 1 := by
     have hf_size_eq : f.size = (r.factor * r.cofactor).size := by rw [hprod]
-    rw [hf_size_eq]
-    rw [FpPoly.size_mul_eq_add_sub_one r.factor r.cofactor hfac_ne hcof_ne]
+    rw [hf_size_eq, FpPoly.size_mul_eq_add_sub_one r.factor r.cofactor hfac_ne hcof_ne]
     have hf_size_pos : 0 < f.size := FpPoly.size_pos_of_ne_zero hf_ne
     have hfac_size_pos : 0 < r.factor.size := FpPoly.size_pos_of_ne_zero hfac_ne
     have hcof_size_pos : 0 < r.cofactor.size := FpPoly.size_pos_of_ne_zero hcof_ne

--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -1051,10 +1051,8 @@ private theorem powModMonicLinear_two_eq_of_quotientWitness
   have hquotMod : (quot * f) % f = 0 :=
     DensePoly.mod_eq_zero_of_dvd (quot * f) f ⟨quot, (FpPoly.mul_comm f quot).symm⟩
   have hsquareMod : (prev * prev) % f = curr := by
-    rw [hmul]
-    rw [DensePoly.DivModLaws.mod_add_mod curr (quot * f) f]
-    rw [hcurrMod, hquotMod]
-    rw [FpPoly.add_zero]
+    rw [hmul, DensePoly.DivModLaws.mod_add_mod curr (quot * f) f, hcurrMod, hquotMod,
+      FpPoly.add_zero]
     exact hcurrMod
   unfold FpPoly.powModMonicLinear
   change FpPoly.modByMonic f (FpPoly.modByMonic f (1 * prev) hmonic * prev) hmonic =

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -268,8 +268,7 @@ private theorem zmod64_one_ne_zero_of_prime [ZMod64.PrimeModulus p] :
 theorem primeFieldLinearFactor_coeff_one (c : ZMod64 p) :
     (primeFieldLinearFactor c).coeff 1 = (1 : ZMod64 p) := by
   unfold primeFieldLinearFactor FpPoly.X FpPoly.C
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_C]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_monomial, DensePoly.coeff_C]
   simp
   show (1 : ZMod64 p) - 0 = 1
   grind
@@ -806,9 +805,8 @@ theorem dvd_xPowSubX_iff_frobeniusDiffMod_isZero
           ∀ i, f.size - 1 ≤ i → (frobeniusDiffMod f hmonic k).coeff i = 0 := by
         intro i hi
         unfold frobeniusDiffMod
-        rw [DensePoly.coeff_sub_ring]
-        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i)]
-        rw [DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i)]
+        rw [DensePoly.coeff_sub_ring, DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i),
+          DensePoly.coeff_eq_zero_of_size_le _ (by omega : _ ≤ i)]
         grind
       -- Conclude: (frobeniusDiffMod).size ≤ f.size - 1.
       have hdiff_size : (frobeniusDiffMod f hmonic k).size ≤ f.size - 1 := by
@@ -966,8 +964,7 @@ private theorem factor_degree_lt
     (hy_pos : 0 < y.degree?.getD 0) :
     x.degree?.getD 0 < a.degree?.getD 0 := by
   have hy_ne_zero : y ≠ 0 := ne_zero_of_pos_degree hy_pos
-  rw [← hxy]
-  rw [FpPoly.degree?_mul_eq_add_degree? x y hx_ne_zero hy_ne_zero]
+  rw [← hxy, FpPoly.degree?_mul_eq_add_degree? x y hx_ne_zero hy_ne_zero]
   omega
 
 private theorem exists_monic_irreducible_factor_of_pos_degree_aux :
@@ -1222,10 +1219,8 @@ private theorem xPowSubX_factor (k : Nat) :
     exact DensePoly.coeff_C (1 : ZMod64 p) i
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_sub_ring]
-  rw [FpPoly.coeff_monomial_mul]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_monomial, hcoeff_one]
+  rw [DensePoly.coeff_sub_ring, FpPoly.coeff_monomial_mul, DensePoly.coeff_sub_ring,
+    DensePoly.coeff_monomial, DensePoly.coeff_monomial, hcoeff_one]
   by_cases hn0 : n = 0
   · subst hn0
     have h0pow_ne : ¬ 0 = p ^ k := by omega
@@ -1579,8 +1574,7 @@ theorem factor_degree_lt_basisSize
     a.degree?.getD 0 < basisSize f := by
   have hb_ne_zero : b ≠ 0 := ne_zero_of_pos_degree hb_pos
   unfold basisSize
-  rw [← hab]
-  rw [FpPoly.degree?_mul_eq_add_degree? a b ha_ne_zero hb_ne_zero]
+  rw [← hab, FpPoly.degree?_mul_eq_add_degree? a b ha_ne_zero hb_ne_zero]
   omega
 
 omit [ZMod64.PrimeModulus p] in
@@ -1610,8 +1604,8 @@ little theorem packaged through the executable `FpPoly` evaluation. -/
 theorem xPowSubX_one_eval_eq_zero (c : ZMod64 p) :
     DensePoly.eval (xPowSubX (p := p) 1) c = 0 := by
   unfold xPowSubX
-  rw [FpPoly.eval_sub, FpPoly.eval_monomial, FpPoly.eval_X]
-  rw [Nat.pow_one, ZMod64.pow_prime_of_prime_modulus]
+  rw [FpPoly.eval_sub, FpPoly.eval_monomial, FpPoly.eval_X,
+    Nat.pow_one, ZMod64.pow_prime_of_prime_modulus]
   grind
 
 /-- Each prime-field linear factor `X - C c` divides `xPowSubX 1`. -/
@@ -1629,9 +1623,7 @@ private theorem primeFieldLinearFactor_sub_eq (c d : ZMod64 p) :
   apply DensePoly.ext_coeff
   intro n
   unfold primeFieldLinearFactor FpPoly.X FpPoly.C
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
   rw [DensePoly.coeff_monomial, DensePoly.coeff_C, DensePoly.coeff_C,
       DensePoly.coeff_C]
   have h0 : (Zero.zero : ZMod64 p) = 0 := rfl
@@ -1762,8 +1754,7 @@ omit [ZMod64.PrimeModulus p] in
 private theorem primeFieldLinearFactor_coeff_high (c : ZMod64 p) {n : Nat}
     (hn : 2 ≤ n) : (primeFieldLinearFactor c).coeff n = 0 := by
   unfold primeFieldLinearFactor FpPoly.X FpPoly.C
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_C]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_monomial, DensePoly.coeff_C]
   have hn1 : ¬ n = 1 := by omega
   have hn0 : ¬ n = 0 := by omega
   simp [hn1, hn0]
@@ -1821,8 +1812,7 @@ private theorem monic_mul_monic (a b : FpPoly p)
     hprod
   change DensePoly.leadingCoeff (a * b) =
     DensePoly.leadingCoeff a * DensePoly.leadingCoeff b at hlead
-  rw [hlead]
-  rw [ha, hb]
+  rw [hlead, ha, hb]
   grind
 
 /-- Foldl induction: size grows by one for each linear factor multiplied in. -/
@@ -1922,9 +1912,7 @@ theorem primeFieldLinearProduct_monic :
 private theorem xPowSubX_one_coeff_p :
     (xPowSubX (p := p) 1).coeff p = (1 : ZMod64 p) := by
   unfold xPowSubX FpPoly.X
-  rw [Nat.pow_one]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_monomial]
+  rw [Nat.pow_one, DensePoly.coeff_sub_ring, DensePoly.coeff_monomial, DensePoly.coeff_monomial]
   have hp_pos : 2 ≤ p :=
     Hex.Nat.Prime.two_le (ZMod64.PrimeModulus.prime (p := p))
   have hp1 : ¬ p = 1 := by omega
@@ -1937,9 +1925,7 @@ private theorem xPowSubX_one_coeff_p :
 private theorem xPowSubX_one_coeff_high {n : Nat} (hn : p < n) :
     (xPowSubX (p := p) 1).coeff n = 0 := by
   unfold xPowSubX FpPoly.X
-  rw [Nat.pow_one]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_monomial]
+  rw [Nat.pow_one, DensePoly.coeff_sub_ring, DensePoly.coeff_monomial, DensePoly.coeff_monomial]
   have hp_pos : 2 ≤ p :=
     Hex.Nat.Prime.two_le (ZMod64.PrimeModulus.prime (p := p))
   have hn_ne_p : ¬ n = p := by omega
@@ -2028,8 +2014,7 @@ private theorem eq_of_dvd_of_size_eq_of_monic
     grind
   rw [hq, hq_eq_C, hq_coeff0]
   show a = a * (DensePoly.C (1 : ZMod64 p))
-  rw [show (DensePoly.C (1 : ZMod64 p) : FpPoly p) = 1 from rfl]
-  rw [FpPoly.mul_one]
+  rw [show (DensePoly.C (1 : ZMod64 p) : FpPoly p) = 1 from rfl, FpPoly.mul_one]
 
 /-- The variable prime-field product identity: the canonical product over field
 constants equals `xPowSubX 1`. This is the headline deliverable for #4085. -/
@@ -2065,8 +2050,8 @@ theorem compose_xPowSubX_one (w : FpPoly p) :
     show DensePoly.monomial (p ^ 1) (1 : ZMod64 p) - FpPoly.X =
       FpPoly.linearPow FpPoly.X p - FpPoly.X
     congr 1
-    rw [show (FpPoly.X : FpPoly p) = DensePoly.monomial 1 (1 : ZMod64 p) from rfl]
-    rw [FpPoly.linearPow_monomial_one]
+    rw [show (FpPoly.X : FpPoly p) = DensePoly.monomial 1 (1 : ZMod64 p) from rfl,
+      FpPoly.linearPow_monomial_one]
     congr 1
     exact Nat.pow_one p
   rw [hxPow]
@@ -2077,8 +2062,7 @@ theorem primeFieldProduct_witness_eq (w : FpPoly p) :
     (ZMod64.values p).foldl
       (fun acc c => acc * (w - FpPoly.C c)) 1 =
         FpPoly.linearPow w p - w := by
-  rw [← FpPoly.compose_primeFieldLinearProduct w]
-  rw [primeFieldProduct_X_eq_xPowSubX]
+  rw [← FpPoly.compose_primeFieldLinearProduct w, primeFieldProduct_X_eq_xPowSubX]
   exact compose_xPowSubX_one w
 
 /-- Divisibility by `w^p - w` transports to the canonical witness product. -/
@@ -2605,9 +2589,7 @@ private theorem witnessLinearFactor_sub_eq
       = (DensePoly.C (d - c) : FpPoly p) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
   show w.coeff n - (FpPoly.C c).coeff n - (w.coeff n - (FpPoly.C d).coeff n)
     = (DensePoly.C (d - c) : FpPoly p).coeff n
   rw [show (FpPoly.C c).coeff n = (DensePoly.C c : FpPoly p).coeff n from rfl,
@@ -3478,8 +3460,7 @@ private theorem congr_mul_right_of_congr {m a b : FpPoly p} (z : FpPoly p)
     DensePoly.Congr (a * z) (b * z) m := by
   rcases hab with ⟨r, hr⟩
   refine ⟨r * z, ?_⟩
-  rw [← sub_mul_poly a b z]
-  rw [show a - b = m * r from hr, FpPoly.mul_assoc]
+  rw [← sub_mul_poly a b z, show a - b = m * r from hr, FpPoly.mul_assoc]
 
 omit [ZMod64.PrimeModulus p] in
 /-- The `i`-th coefficient commutes with a `(· + ·)`-`foldl` of polynomials. -/

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -888,8 +888,7 @@ private theorem fpPoly_one_monic
       FpPoly.size_pos_of_ne_zero (fpPoly_one_ne_zero hp)
     omega
   unfold DensePoly.Monic
-  rw [DensePoly.leadingCoeff_eq_coeff_last (1 : FpPoly p) (by omega)]
-  rw [hsize]
+  rw [DensePoly.leadingCoeff_eq_coeff_last (1 : FpPoly p) (by omega), hsize]
   change (DensePoly.C (1 : ZMod64 p)).coeff (1 - 1) = 1
   rw [DensePoly.coeff_C]
   simp
@@ -934,9 +933,8 @@ theorem factorProduct_map_monicModularImage_eq_monicModularImage_factorProduct
         factorProduct_ne_zero_of_forall_ne_zero hp tail htail_ne
       have ih_eq := ih htail_ne
       simp only [List.map_cons]
-      rw [Hex.Berlekamp.factorProduct_cons, Hex.Berlekamp.factorProduct_cons]
-      rw [ih_eq]
-      rw [monicModularImage_mul_of_nonzero hp hhead_ne htail_prod_ne]
+      rw [Hex.Berlekamp.factorProduct_cons, Hex.Berlekamp.factorProduct_cons, ih_eq,
+        monicModularImage_mul_of_nonzero hp hhead_ne htail_prod_ne]
 
 private def berlekampFactorsModP (f : ZPoly) (c : SmallPrimeCandidate) :
     Array (@FpPoly c.p c.bounds) :=
@@ -1234,8 +1232,7 @@ theorem isGoodPrime_modP_isZero_false
       rfl
     · exact hfsize
   have hcoeff_ne : (ZPoly.modP p f).coeff (f.size - 1) ≠ 0 := by
-    rw [ZPoly.coeff_modP]
-    rw [← DensePoly.leadingCoeff_eq_coeff_last f hfsize]
+    rw [ZPoly.coeff_modP, ← DensePoly.leadingCoeff_eq_coeff_last f hfsize]
     exact hadm
   cases hzero : (ZPoly.modP p f).isZero with
   | false => rfl
@@ -1277,8 +1274,7 @@ private theorem coeff_modP_top_eq_leadingCoeffModP
     (f : ZPoly) (p : Nat) [ZMod64.Bounds p]
     (hfsize : 0 < f.size) :
     (ZPoly.modP p f).coeff (f.size - 1) = ZPoly.leadingCoeffModP f p := by
-  rw [ZPoly.coeff_modP]
-  rw [← DensePoly.leadingCoeff_eq_coeff_last f hfsize]
+  rw [ZPoly.coeff_modP, ← DensePoly.leadingCoeff_eq_coeff_last f hfsize]
   rfl
 
 /-- Under `leadingCoeffAdmissible`, the modular image is nonzero. Companion of
@@ -1346,8 +1342,7 @@ theorem leadingCoeff_modP_eq_leadingCoeffModP_of_admissible
   have hfsize := leadingCoeffAdmissible_size_pos f p hadm
   have hsize := size_modP_eq_of_leadingCoeffAdmissible f p hadm
   have hmod_size_pos : 0 < (ZPoly.modP p f).size := by omega
-  rw [DensePoly.leadingCoeff_eq_coeff_last _ hmod_size_pos]
-  rw [hsize]
+  rw [DensePoly.leadingCoeff_eq_coeff_last _ hmod_size_pos, hsize]
   exact coeff_modP_top_eq_leadingCoeffModP f p hfsize
 
 /-- `ZPoly.modP p` never increases the executable dense size: the
@@ -3048,15 +3043,13 @@ private theorem shift_shift_one (power : Nat) (f : ZPoly) :
     DensePoly.shift 1 (DensePoly.shift power f) = DensePoly.shift (power + 1) f := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_shift (power + 1) f n]
-  rw [DensePoly.coeff_shift 1 (DensePoly.shift power f) n]
+  rw [DensePoly.coeff_shift (power + 1) f n, DensePoly.coeff_shift 1 (DensePoly.shift power f) n]
   cases n with
   | zero =>
       simp
   | succ n =>
       have hsub_one : n + 1 - 1 = n := by omega
-      rw [hsub_one]
-      rw [DensePoly.coeff_shift power f n]
+      rw [hsub_one, DensePoly.coeff_shift power f n]
       by_cases hn : n < power
       · have hsucc : n + 1 < power + 1 := by omega
         simp [hn, hsucc]
@@ -3073,12 +3066,9 @@ private theorem polyProduct_xPowerFactorArray_mul (power : Nat) (f : ZPoly) :
     Array.polyProduct (xPowerFactorArray power) * f = DensePoly.shift power f := by
   induction power with
   | zero =>
-      rw [polyProduct_xPowerFactorArray_zero]
-      rw [ZPoly.one_mul_zpoly, shift_zero]
+      rw [polyProduct_xPowerFactorArray_zero, ZPoly.one_mul_zpoly, shift_zero]
   | succ power ih =>
-      rw [polyProduct_xPowerFactorArray_succ]
-      rw [DensePoly.mul_assoc_poly (S := Int)]
-      rw [ih]
+      rw [polyProduct_xPowerFactorArray_succ, DensePoly.mul_assoc_poly (S := Int), ih]
       exact X_mul_shift power f
 
 private theorem splitInitialZeros_reassembles (coeffs : List Int) :
@@ -3103,8 +3093,8 @@ private theorem splitInitialZeros_reassembles (coeffs : List Int) :
             intro n
             cases n with
             | zero =>
-                rw [DensePoly.coeff_shift (power + 1) (DensePoly.ofCoeffs core.toArray) 0]
-                rw [DensePoly.coeff_ofCoeffs_list (0 :: coeffs) 0]
+                rw [DensePoly.coeff_shift (power + 1) (DensePoly.ofCoeffs core.toArray) 0,
+                  DensePoly.coeff_ofCoeffs_list (0 :: coeffs) 0]
                 simp
                 rfl
             | succ n =>
@@ -3113,8 +3103,8 @@ private theorem splitInitialZeros_reassembles (coeffs : List Int) :
                   (DensePoly.ofCoeffs coeffs.toArray).coeff n at hcoeff_n
                 rw [DensePoly.coeff_shift power (DensePoly.ofCoeffs core.toArray) n] at hcoeff_n
                 rw [DensePoly.coeff_ofCoeffs_list coeffs n] at hcoeff_n
-                rw [DensePoly.coeff_shift (power + 1) (DensePoly.ofCoeffs core.toArray) (n + 1)]
-                rw [DensePoly.coeff_ofCoeffs_list (0 :: coeffs) (n + 1)]
+                rw [DensePoly.coeff_shift (power + 1) (DensePoly.ofCoeffs core.toArray) (n + 1),
+                  DensePoly.coeff_ofCoeffs_list (0 :: coeffs) (n + 1)]
                 by_cases hn : n < power
                 · have hsucc : n + 1 < power + 1 := by omega
                   simpa [hsucc, hn] using hcoeff_n
@@ -3134,8 +3124,7 @@ private theorem extractXPower_product (f : ZPoly) :
   cases split with
   | mk power core =>
       simp only
-      rw [ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
-      rw [polyProduct_xPowerFactorArray_mul]
+      rw [ZPoly.polyProduct_append, ZPoly.polyProduct_singleton, polyProduct_xPowerFactorArray_mul]
       have hreassemble := splitInitialZeros_reassembles f.toArray.toList
       rw [hsplit] at hreassemble
       rw [← ofCoeffs_toArray f]
@@ -3160,11 +3149,8 @@ private theorem polyProduct_replicate_toArray (q : ZPoly) (m : Nat) :
   induction m with
   | zero => rfl
   | succ m ih =>
-      rw [List.replicate_succ]
-      rw [ZPoly.polyProduct_cons_toArray]
-      rw [ih]
-      rw [polyPow_succ_lemma]
-      rw [DensePoly.mul_comm_poly (S := Int)]
+      rw [List.replicate_succ, ZPoly.polyProduct_cons_toArray, ih, polyPow_succ_lemma,
+        DensePoly.mul_comm_poly (S := Int)]
 
 private theorem consumeExactPower_invariant
     (target candidate : ZPoly) (fuel : Nat) :
@@ -3184,12 +3170,10 @@ private theorem consumeExactPower_invariant
           have hquot : quot * candidate = target := exactQuotient?_product hex
           have hih := ih quot
           simp only
-          rw [polyPow_succ_lemma]
-          rw [DensePoly.mul_assoc_poly (S := Int)]
+          rw [polyPow_succ_lemma, DensePoly.mul_assoc_poly (S := Int)]
           rw [DensePoly.mul_comm_poly (S := Int) candidate
             (consumeExactPower quot candidate fuel).1]
-          rw [← DensePoly.mul_assoc_poly (S := Int)]
-          rw [hih]
+          rw [← DensePoly.mul_assoc_poly (S := Int), hih]
           exact hquot
 
 private theorem expandRepeatedPartFactorsAux_invariant
@@ -3205,10 +3189,8 @@ private theorem expandRepeatedPartFactorsAux_invariant
       have hcep := consumeExactPower_invariant rp q fuel
       have hih := ih (consumeExactPower rp q fuel).1
       simp only
-      rw [ZPoly.polyProduct_append]
-      rw [polyProduct_replicate_toArray]
-      rw [DensePoly.mul_assoc_poly (S := Int)]
-      rw [hih]
+      rw [ZPoly.polyProduct_append, polyProduct_replicate_toArray,
+        DensePoly.mul_assoc_poly (S := Int), hih]
       exact hcep
 
 private theorem expandRepeatedPartFactorArray_invariant
@@ -3347,13 +3329,11 @@ private theorem polyProduct_reassemblePolynomialFactors
       · rw [if_pos hres]
         rw [hres] at hinv
         rw [DensePoly.mul_one_right_poly (S := Int)] at hinv
-        rw [ZPoly.polyProduct_append, ZPoly.polyProduct_append]
-        rw [polyProduct_xPowerFactorArray_mul]
-        rw [hinv]
+        rw [ZPoly.polyProduct_append, ZPoly.polyProduct_append, polyProduct_xPowerFactorArray_mul,
+          hinv]
       · rw [if_neg hres]
-        rw [ZPoly.polyProduct_append, polyProduct_polynomialNormalizationPrefixFactors]
-        rw [polyProduct_xPowerFactorArray_mul]
-        rw [polyProduct_repeatedPartFactorArray_eq]
+        rw [ZPoly.polyProduct_append, polyProduct_polynomialNormalizationPrefixFactors,
+          polyProduct_xPowerFactorArray_mul, polyProduct_repeatedPartFactorArray_eq]
 
 private theorem polyProduct_normalizationPrefixFactors (d : FactorNormalizationData) :
     Array.polyProduct (normalizationPrefixFactors d) =
@@ -3361,8 +3341,7 @@ private theorem polyProduct_normalizationPrefixFactors (d : FactorNormalizationD
         (Array.polyProduct (xPowerFactorArray d.xPower) *
           Array.polyProduct (repeatedPartFactorArray d.repeatedPart)) := by
   unfold normalizationPrefixFactors
-  rw [ZPoly.polyProduct_append, ZPoly.polyProduct_append]
-  rw [DensePoly.mul_assoc_poly (S := Int)]
+  rw [ZPoly.polyProduct_append, ZPoly.polyProduct_append, DensePoly.mul_assoc_poly (S := Int)]
 
 private theorem polyPow_zero (g : ZPoly) :
     Factorization.polyPow g 0 = (1 : ZPoly) := rfl
@@ -3411,28 +3390,24 @@ private theorem multListProduct_cons (m : ZPoly × Nat) (ms : List (ZPoly × Nat
 
 private theorem multListProduct_singleton (m : ZPoly × Nat) :
     multListProduct [m] = Factorization.polyPow m.1 m.2 := by
-  rw [multListProduct_cons, multListProduct_nil]
-  rw [DensePoly.mul_one_right_poly]
+  rw [multListProduct_cons, multListProduct_nil, DensePoly.mul_one_right_poly]
 
 private theorem multListProduct_append (xs ys : List (ZPoly × Nat)) :
     multListProduct (xs ++ ys) = multListProduct xs * multListProduct ys := by
   induction xs with
   | nil =>
-      rw [List.nil_append, multListProduct_nil]
-      rw [ZPoly.one_mul_zpoly]
+      rw [List.nil_append, multListProduct_nil, ZPoly.one_mul_zpoly]
   | cons m ms ih =>
-      rw [List.cons_append]
-      rw [multListProduct_cons, multListProduct_cons, ih]
-      rw [DensePoly.mul_assoc_poly (S := Int)]
+      rw [List.cons_append, multListProduct_cons, multListProduct_cons, ih,
+        DensePoly.mul_assoc_poly (S := Int)]
 
 private theorem multListProduct_reverse (mults : List (ZPoly × Nat)) :
     multListProduct mults.reverse = multListProduct mults := by
   induction mults with
   | nil => rfl
   | cons m ms ih =>
-      rw [List.reverse_cons]
-      rw [multListProduct_append, multListProduct_singleton]
-      rw [ih, multListProduct_cons]
+      rw [List.reverse_cons, multListProduct_append, multListProduct_singleton,
+        ih, multListProduct_cons]
       exact DensePoly.mul_comm_poly (S := Int) _ _
 
 private theorem multListProduct_bumpFactorMultiplicity
@@ -3440,9 +3415,8 @@ private theorem multListProduct_bumpFactorMultiplicity
     multListProduct (bumpFactorMultiplicity g mults) = g * multListProduct mults := by
   induction mults with
   | nil =>
-      rw [bumpFactorMultiplicity, multListProduct_singleton, multListProduct_nil]
-      rw [polyPow_one]
-      rw [DensePoly.mul_one_right_poly]
+      rw [bumpFactorMultiplicity, multListProduct_singleton, multListProduct_nil, polyPow_one,
+        DensePoly.mul_one_right_poly]
   | cons entry entries ih =>
       unfold bumpFactorMultiplicity
       by_cases heq : entry.1 = g
@@ -3455,8 +3429,7 @@ private theorem multListProduct_bumpFactorMultiplicity
               (Factorization.polyPow g entry.2) g]
         rw [DensePoly.mul_assoc_poly (S := Int)]
       · simp only [heq, if_false]
-        rw [multListProduct_cons, multListProduct_cons, ih]
-        rw [← DensePoly.mul_assoc_poly (S := Int)]
+        rw [multListProduct_cons, multListProduct_cons, ih, ← DensePoly.mul_assoc_poly (S := Int)]
         rw [DensePoly.mul_comm_poly (S := Int)
               (Factorization.polyPow entry.1 entry.2) g]
         rw [DensePoly.mul_assoc_poly (S := Int)]
@@ -3621,9 +3594,8 @@ private theorem multListProduct_collectAux
               bumpFactorMultiplicity (normalizeFactorSign f) acc from by
               unfold collectFactorStep
               simp [hrec]]
-        rw [ih (bumpFactorMultiplicity (normalizeFactorSign f) acc)]
-        rw [multListProduct_bumpFactorMultiplicity]
-        rw [ZPoly.polyProduct_cons_toArray]
+        rw [ih (bumpFactorMultiplicity (normalizeFactorSign f) acc),
+          multListProduct_bumpFactorMultiplicity, ZPoly.polyProduct_cons_toArray]
         rw [DensePoly.mul_comm_poly (S := Int) (normalizeFactorSign f)
               (multListProduct acc)]
         rw [DensePoly.mul_assoc_poly (S := Int)]
@@ -3944,8 +3916,7 @@ private theorem factorizationOfFactors_product
         (fun acc m => acc * Factorization.polyPow m.1 m.2)
         (DensePoly.C (signedContentScalar f)) =
       _
-  rw [← Array.foldl_toList]
-  rw [multListFoldl_eq_mul_foldl_one]
+  rw [← Array.foldl_toList, multListFoldl_eq_mul_foldl_one]
   show
     DensePoly.C (signedContentScalar f) *
         multListProduct (collectFactorMultiplicities factors).toList =
@@ -3983,8 +3954,7 @@ private theorem signedContentScalar_zero :
 
 private theorem factorizationOfFactors_product_of_zero (factors : Array ZPoly) :
     Factorization.product (factorizationOfFactors 0 factors) = 0 := by
-  rw [factorizationOfFactors_product]
-  rw [signedContentScalar_zero]
+  rw [factorizationOfFactors_product, signedContentScalar_zero]
   change DensePoly.C (0 : Int) *
       Array.polyProduct (filteredNormalizedFactors factors.toList).toArray = 0
   rw [show (DensePoly.C (0 : Int) : ZPoly) = (0 : ZPoly) from rfl]
@@ -4173,19 +4143,17 @@ private theorem rat_scale_scale (u v : Rat) (p : DensePoly Rat) :
     DensePoly.scale u (DensePoly.scale v p) = DensePoly.scale (u * v) p := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Rat) u (DensePoly.scale v p) n (Rat.mul_zero u)]
-  rw [DensePoly.coeff_scale (R := Rat) v p n (Rat.mul_zero v)]
-  rw [DensePoly.coeff_scale (R := Rat) (u * v) p n (Rat.mul_zero (u * v))]
-  rw [Rat.mul_assoc]
+  rw [DensePoly.coeff_scale (R := Rat) u (DensePoly.scale v p) n (Rat.mul_zero u),
+    DensePoly.coeff_scale (R := Rat) v p n (Rat.mul_zero v),
+    DensePoly.coeff_scale (R := Rat) (u * v) p n (Rat.mul_zero (u * v)), Rat.mul_assoc]
 
 private theorem int_scale_scale (u v : Int) (p : ZPoly) :
     DensePoly.scale u (DensePoly.scale v p) = DensePoly.scale (u * v) p := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Int) u (DensePoly.scale v p) n (Int.mul_zero u)]
-  rw [DensePoly.coeff_scale (R := Int) v p n (Int.mul_zero v)]
-  rw [DensePoly.coeff_scale (R := Int) (u * v) p n (Int.mul_zero (u * v))]
-  rw [Int.mul_assoc]
+  rw [DensePoly.coeff_scale (R := Int) u (DensePoly.scale v p) n (Int.mul_zero u),
+    DensePoly.coeff_scale (R := Int) v p n (Int.mul_zero v),
+    DensePoly.coeff_scale (R := Int) (u * v) p n (Int.mul_zero (u * v)), Int.mul_assoc]
 
 private theorem shift_scale_int (k : Nat) (c : Int) (p : ZPoly) :
     DensePoly.shift k (DensePoly.scale c p) =
@@ -4201,8 +4169,7 @@ private theorem shift_scale_int (k : Nat) (c : Int) (p : ZPoly) :
     change (0 : Int) = c * 0
     rw [Int.mul_zero]
   · rw [if_neg hn]
-    rw [if_neg hn]
-    rw [DensePoly.coeff_scale (R := Int) c p (n - k) (Int.mul_zero c)]
+    rw [if_neg hn, DensePoly.coeff_scale (R := Int) c p (n - k) (Int.mul_zero c)]
 
 private theorem toRatPoly_mul_product (f g : ZPoly) :
     ZPoly.toRatPoly (f * g) = ZPoly.toRatPoly f * ZPoly.toRatPoly g := by
@@ -4227,10 +4194,8 @@ private theorem primitiveSquareFreeDecomposition_reassembles_xfree_over_rat
       ZPoly.toRatPoly xFree =
         DensePoly.scale (ZPoly.content xFree : Rat)
           (ZPoly.toRatPoly (ZPoly.primitivePart xFree)) := by
-    rw [← ZPoly.toRatPoly_scale_int]
-    rw [ZPoly.content_mul_primitivePart]
-  rw [hcontent, hunit, rat_scale_scale]
-  rw [toRatPoly_mul_product]
+    rw [← ZPoly.toRatPoly_scale_int, ZPoly.content_mul_primitivePart]
+  rw [hcontent, hunit, rat_scale_scale, toRatPoly_mul_product]
 
 /-- Converse to `exactQuotient?_product`: if `candidate` is monic with positive
 degree and `quotient * candidate = target`, then `exactQuotient? target candidate`
@@ -4278,8 +4243,7 @@ theorem exactQuotient?_eq_some_of_mul_eq_monic_of_pos_degree
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one]
-  rw [hdivMod_eq]
+  rw [if_neg hcandidate_ne_one, hdivMod_eq]
   simp [hmul]
 
 /--
@@ -4329,8 +4293,7 @@ theorem exactQuotient?_eq_some_of_divMod_eq_of_shouldRecord
   unfold exactQuotient?
   rw [hisZero_false]
   simp only [Bool.false_or, decide_eq_true_eq]
-  rw [if_neg hcandidate_ne_one]
-  rw [hdivMod]
+  rw [if_neg hcandidate_ne_one, hdivMod]
   simp [hmul]
 
 /-- Non-monic converse to `exactQuotient?_product` for divisors with positive
@@ -8359,8 +8322,7 @@ private theorem henselPrecisionSchedule_mem_cap
         rw [if_neg (by omega : ¬ k ≥ B)]
         unfold nextHenselPrecision
         have hpow : k * 2 ^ (fuel + 1) = 2 * k * 2 ^ fuel := by
-          rw [Nat.pow_succ']
-          rw [← Nat.mul_assoc, Nat.mul_comm k 2]
+          rw [Nat.pow_succ', ← Nat.mul_assoc, Nat.mul_comm k 2]
         by_cases h2 : 2 * k < B
         · rw [if_pos h2]
           refine ih (2 * k) (by omega) (by omega) ?_
@@ -11998,8 +11960,8 @@ private theorem normalizeForFactor_reassembles_signedContentScalar
 
 private theorem shift_mul_left_zpoly (k : Nat) (a b : ZPoly) :
     DensePoly.shift k (a * b) = DensePoly.shift k a * b := by
-  rw [← DensePoly.monomial_one_mul_poly_eq_shift k (a * b)]
-  rw [← DensePoly.monomial_one_mul_poly_eq_shift k a]
+  rw [← DensePoly.monomial_one_mul_poly_eq_shift k (a * b),
+    ← DensePoly.monomial_one_mul_poly_eq_shift k a]
   exact (DensePoly.mul_assoc_poly (S := Int) _ _ _).symm
 
 /--
@@ -14659,10 +14621,8 @@ private theorem dvd_polyProduct_toArray_of_mem {q : ZPoly} :
         exact ⟨Array.polyProduct tail.toArray, rfl⟩
       · rcases dvd_polyProduct_toArray_of_mem tail htail with ⟨k, hk⟩
         refine ⟨head * k, ?_⟩
-        rw [hk]
-        rw [← DensePoly.mul_assoc_poly (S := Int) head q k]
-        rw [DensePoly.mul_comm_poly (S := Int) head q]
-        rw [DensePoly.mul_assoc_poly (S := Int) q head k]
+        rw [hk, ← DensePoly.mul_assoc_poly (S := Int) head q k,
+          DensePoly.mul_comm_poly (S := Int) head q, DensePoly.mul_assoc_poly (S := Int) q head k]
 
 /-- A candidate that was tried by `trialDivisionPeelAux` but not emitted does
 not exactly divide the final residual.  This is the executable "no missed
@@ -15940,10 +15900,9 @@ private theorem trialDivisionPeel_factor_irreducible
             have hfactor_dvd_mid : factor ∣ mid := by
               rcases hfactor_dvd_prod_suf with ⟨k, hk⟩
               refine ⟨finalRes * k, ?_⟩
-              rw [← hsuf_prod, hk]
-              rw [← DensePoly.mul_assoc_poly (S := Int)]
-              rw [DensePoly.mul_comm_poly (S := Int) finalRes factor]
-              rw [DensePoly.mul_assoc_poly (S := Int)]
+              rw [← hsuf_prod, hk, ← DensePoly.mul_assoc_poly (S := Int),
+                DensePoly.mul_comm_poly (S := Int) finalRes factor,
+                DensePoly.mul_assoc_poly (S := Int)]
             have hq_dvd_mid : q ∣ mid := ZPoly_dvd_trans hq_dvd_factor hfactor_dvd_mid
             -- q ∈ pre (degree q = d_split, pre has degree ≤ d_split — but pre may exclude q
             -- since List.append may split at any boundary; however, the construction
@@ -16019,8 +15978,7 @@ private theorem trialDivisionPeel_factor_irreducible
             rcases hq_dvd_factor with ⟨wf, hwf⟩
             have hqq_dvd_qfactor : q * q ∣ q * factor := by
               refine ⟨wf, ?_⟩
-              rw [hwf]
-              rw [DensePoly.mul_assoc_poly (S := Int)]
+              rw [hwf, DensePoly.mul_assoc_poly (S := Int)]
             have hqq_dvd_core : q * q ∣ core :=
               ZPoly_dvd_trans hqq_dvd_qfactor hsquare_dvd_core
             exact square_not_dvd_of_squareFreeRat hcore_ne hcore_sq
@@ -16892,8 +16850,7 @@ theorem quadraticIntegerRootFactors?_product
         by_cases hres_deg : split.2.degree?.getD 0 ≤ 1
         · rw [if_pos hres_deg] at hquad
           cases hquad
-          rw [polyProduct_push]
-          rw [DensePoly.mul_comm_poly (S := Int)]
+          rw [polyProduct_push, DensePoly.mul_comm_poly (S := Int)]
           exact hsplit_prod
         · rw [if_neg hres_deg] at hquad
           contradiction
@@ -17726,8 +17683,7 @@ theorem repeatedPart_ne_zero_of_ne_zero (f : ZPoly) (hf : f ≠ 0) :
             (ZPoly.extractXPower (ZPoly.primitivePart f)).core).repeatedPart ≠ 0 :=
     ZPoly.ne_zero_of_primitive _ hprod_primitive
   apply hprod_ne
-  rw [hzero]
-  rw [DensePoly.mul_comm_poly (S := Int)]
+  rw [hzero, DensePoly.mul_comm_poly (S := Int)]
   exact DensePoly.zero_mul _
 
 private theorem repeatedPart_leadingCoeff_pos_of_ne_zero
@@ -17934,10 +17890,10 @@ private theorem consumeExactPower_pow_mul_of_not_dvd
           have htarget_eq :
               (Factorization.polyPow q m * r) * q =
                 Factorization.polyPow q (m + 1) * r := by
-            rw [polyPow_succ_lemma]
-            rw [DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) r q]
-            rw [DensePoly.mul_comm_poly (S := Int) r q]
-            rw [← DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) q r]
+            rw [polyPow_succ_lemma,
+              DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) r q,
+              DensePoly.mul_comm_poly (S := Int) r q,
+              ← DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) q r]
           have hquot :
               exactQuotient? (Factorization.polyPow q (m + 1) * r) q =
                 some (Factorization.polyPow q m * r) :=
@@ -17979,10 +17935,10 @@ private theorem consumeExactPower_pow_mul_of_not_dvd_of_pos_lc
           have htarget_eq :
               (Factorization.polyPow q m * r) * q =
                 Factorization.polyPow q (m + 1) * r := by
-            rw [polyPow_succ_lemma]
-            rw [DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) r q]
-            rw [DensePoly.mul_comm_poly (S := Int) r q]
-            rw [← DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) q r]
+            rw [polyPow_succ_lemma,
+              DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) r q,
+              DensePoly.mul_comm_poly (S := Int) r q,
+              ← DensePoly.mul_assoc_poly (S := Int) (Factorization.polyPow q m) q r]
           have hquot :
               exactQuotient? (Factorization.polyPow q (m + 1) * r) q =
                 some (Factorization.polyPow q m * r) :=
@@ -18617,9 +18573,8 @@ private theorem mulCoeffSum_const (p q : ZPoly) :
         rw [List.mem_map] at hi
         obtain ⟨k, _, rfl⟩ := hi
         exact Nat.succ_pos k
-      rw [List.range_succ_eq_map, List.foldl_cons]
-      rw [foldl_outer_const_pos p q _ hpos]
-      rw [foldl_step_const_inner p q q.size]
+      rw [List.range_succ_eq_map, List.foldl_cons, foldl_outer_const_pos p q _ hpos,
+        foldl_step_const_inner p q q.size]
       by_cases hq : 0 < q.size
       · rw [if_pos hq]
         show (0 : Int) + p.coeff 0 * q.coeff 0 = p.coeff 0 * q.coeff 0
@@ -18900,8 +18855,7 @@ private theorem filteredNormalizedFactors_append_one_of_all_recorded_normalized
     filteredNormalizedFactors (factors ++ [1]) = factors := by
   induction factors with
   | nil =>
-      rw [List.nil_append]
-      rw [filteredNormalizedFactors_cons_drop]
+      rw [List.nil_append, filteredNormalizedFactors_cons_drop]
       · rfl
       · rw [normalizeFactorSign_one]
         exact shouldRecordPolynomialFactor_one
@@ -18916,8 +18870,7 @@ private theorem filteredNormalizedFactors_append_one_of_all_recorded_normalized
           shouldRecordPolynomialFactor (normalizeFactorSign factor) = true := by
         rw [hfactor_normalized]
         exact hfactor_recorded
-      rw [List.cons_append]
-      rw [filteredNormalizedFactors_cons_keep _ hkeep, hfactor_normalized]
+      rw [List.cons_append, filteredNormalizedFactors_cons_keep _ hkeep, hfactor_normalized]
       rw [ih
         (fun factor hmem => hnormalized factor (by simp [hmem]))
         (fun factor hmem => hrecorded factor (by simp [hmem]))]
@@ -18953,8 +18906,8 @@ private theorem factorSlowModular_product_of_constant_branch
       rw [ZPoly.polyProduct_singleton]
       exact hcore_one.symm)
   · rw [reassemblePolynomialFactors_singleton_one_eq]
-    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized]
-    rw [ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
+    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized,
+      ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
     exact (DensePoly.mul_one_right_poly (S := Int) _).symm
     · intro factor hmem
       exact polynomialNormalizationPrefixFactors_normalizeFactorSign_of_ne_zero
@@ -19097,8 +19050,8 @@ private theorem factorFastWithBound_product_of_constant_branch
       rw [ZPoly.polyProduct_singleton]
       exact hcore_one.symm)
   · rw [reassemblePolynomialFactors_singleton_one_eq]
-    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized]
-    rw [ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
+    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized,
+      ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
     exact (DensePoly.mul_one_right_poly (S := Int) _).symm
     · intro factor hmem
       exact polynomialNormalizationPrefixFactors_normalizeFactorSign_of_ne_zero
@@ -19189,8 +19142,7 @@ private theorem factorFastWithBound_product_of_quadratic_branch
       factorFastFactorsWithBound f B =
         some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) := by
     unfold factorFastFactorsWithBound
-    rw [if_neg hdeg, if_neg (by omega : B ≠ 0), if_neg (by omega : B ≠ 1)]
-    rw [hquad]
+    rw [if_neg hdeg, if_neg (by omega : B ≠ 0), if_neg (by omega : B ≠ 1), hquad]
   have hphi :
       factorizationOfFactors f
           (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) = φ := by
@@ -19507,8 +19459,8 @@ private theorem factorSlowTrialWithBound_product_of_constant_branch
       rw [ZPoly.polyProduct_singleton]
       exact hcore_one.symm)
   · rw [reassemblePolynomialFactors_singleton_one_eq]
-    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized]
-    rw [ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
+    rw [polyProduct_filteredNormalizedFactors_append_one_of_all_recorded_normalized,
+      ZPoly.polyProduct_append, ZPoly.polyProduct_singleton]
     exact (DensePoly.mul_one_right_poly (S := Int) _).symm
     · intro factor hmem
       exact polynomialNormalizationPrefixFactors_normalizeFactorSign_of_ne_zero
@@ -19527,8 +19479,7 @@ private theorem factorSlowTrialWithBound_product_of_quadratic_branch
     Factorization.product (factorSlowTrialWithBound f B) = f := by
   apply factorSlowTrialWithBound_product_of_all_recorded_normalized
   · unfold factorSlowTrialFactorsWithBound
-    rw [if_neg hdeg]
-    rw [hquad]
+    rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
       coreFactors ?_ factor hmem
@@ -19536,8 +19487,7 @@ private theorem factorSlowTrialWithBound_product_of_quadratic_branch
     exact quadraticIntegerRootFactors?_normalizeFactorSign
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) hquad c hc
   · unfold factorSlowTrialFactorsWithBound
-    rw [if_neg hdeg]
-    rw [hquad]
+    rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
       coreFactors ?_ factor hmem
@@ -19553,8 +19503,7 @@ private theorem factorSlowTrialWithBound_product_of_trial_branch
     Factorization.product (factorSlowTrialWithBound f B) = f := by
   apply factorSlowTrialWithBound_product_of_all_recorded_normalized
   · unfold factorSlowTrialFactorsWithBound
-    rw [if_neg hdeg]
-    rw [hquad]
+    rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
       (exhaustiveIntegerTrialCoreFactorsWithBound
@@ -19565,8 +19514,7 @@ private theorem factorSlowTrialWithBound_product_of_trial_branch
       (normalizeForFactor f).squareFreeCore B
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) c hc
   · unfold factorSlowTrialFactorsWithBound
-    rw [if_neg hdeg]
-    rw [hquad]
+    rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
       (exhaustiveIntegerTrialCoreFactorsWithBound

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -552,8 +552,8 @@ private theorem factorizationProduct_toPolynomial_foldl
   | nil =>
       simp [flattenedFactorEntries]
   | cons entry entries ih =>
-      rw [List.foldl_cons, ih (init * Hex.Factorization.factorPower entry.1 entry.2)]
-      rw [HexPolyZMathlib.toPolynomial_mul, factorPower_toPolynomial]
+      rw [List.foldl_cons, ih (init * Hex.Factorization.factorPower entry.1 entry.2),
+        HexPolyZMathlib.toPolynomial_mul, factorPower_toPolynomial]
       simp [flattenedFactorEntries]
       ring
 
@@ -568,9 +568,9 @@ theorem factorizationProduct_toPolynomial (φ : Hex.Factorization) :
       (φ.factors.foldl
         (fun acc factor => acc * Hex.Factorization.factorPower factor.1 factor.2)
         (Hex.DensePoly.C φ.scalar)) = _
-  rw [← Array.foldl_toList]
-  rw [factorizationProduct_toPolynomial_foldl φ.factors.toList (Hex.DensePoly.C φ.scalar)]
-  rw [HexPolyZMathlib.toPolynomial_C]
+  rw [← Array.foldl_toList,
+    factorizationProduct_toPolynomial_foldl φ.factors.toList (Hex.DensePoly.C φ.scalar),
+    HexPolyZMathlib.toPolynomial_C]
   rfl
 
 /--
@@ -1370,8 +1370,7 @@ theorem checkIrreducibleCert_sound
           rw [Array.getElem_toList]
           have := natDegree_toMathlibPolynomial_factorPolys_eq primeData hfacts_align i
             hi_polys hi_deg hi_cert
-          rw [this]
-          rw [Array.getElem_toList]
+          rw [this, Array.getElem_toList]
       have hS_le' : S ≤ (primeData.factorDegrees.toList : Multiset Nat) := by
         have hmapcoe :
             Multiset.map Polynomial.natDegree
@@ -1653,12 +1652,8 @@ private theorem fpPoly_mul_dvd_mul
   obtain ⟨q, hq⟩ := hab
   obtain ⟨v, hv⟩ := hcd
   refine ⟨q * v, ?_⟩
-  rw [hq, hv]
-  rw [Hex.FpPoly.mul_assoc a q (c * v)]
-  rw [← Hex.FpPoly.mul_assoc q c v]
-  rw [Hex.FpPoly.mul_comm q c]
-  rw [Hex.FpPoly.mul_assoc c q v]
-  rw [← Hex.FpPoly.mul_assoc a c (q * v)]
+  rw [hq, hv, Hex.FpPoly.mul_assoc a q (c * v), ← Hex.FpPoly.mul_assoc q c v,
+    Hex.FpPoly.mul_comm q c, Hex.FpPoly.mul_assoc c q v, ← Hex.FpPoly.mul_assoc a c (q * v)]
 
 theorem monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
     {core factor : Hex.ZPoly}
@@ -3062,8 +3057,7 @@ private theorem centeredLiftPoly_reduceModPow_eq
   rw [Hex.coeff_centeredLiftPoly, Hex.coeff_centeredLiftPoly,
     Hex.ZPoly.coeff_reduceModPow_eq_emod_of_pos _ _ _ _ hpkpos]
   unfold Hex.centeredModNat
-  rw [if_neg hpkne, if_neg hpkne]
-  rw [Int.emod_emod_of_dvd _ (dvd_refl _)]
+  rw [if_neg hpkne, if_neg hpkne, Int.emod_emod_of_dvd _ (dvd_refl _)]
 
 /-- Precision-gated exact recovery for `liftedRecoveryCandidate` in the
 dilation-coordinate model. -/
@@ -4478,8 +4472,7 @@ theorem LiftedFactorListMatches.length_eq_card
     {d : Hex.LiftData} {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly}
     (h : LiftedFactorListMatches d J localFactors) :
     localFactors.length = J.card := by
-  rw [h, List.length_map]
-  rw [(finRange_filter_mem_perm_toList J).length_eq, Finset.length_toList]
+  rw [h, List.length_map, (finRange_filter_mem_perm_toList J).length_eq, Finset.length_toList]
 
 /-- A matched `localFactors` is `Nodup` whenever `liftedFactor d` is injective
 on the index set `J`.
@@ -4942,8 +4935,7 @@ theorem liftedSubsetSelectedList_eq_mask_partition_of_matches
     rw [show (J.min' hne :: ys).filter (fun i => decide (i ∈ T)) =
             J.min' hne :: ys.filter (fun i => decide (i ∈ T)) from
       List.filter_cons_of_pos (by simp [hmin_in_T])]
-    rw [List.map_cons]
-    rw [hhead_eq, htail_eq]
+    rw [List.map_cons, hhead_eq, htail_eq]
     congr 1
     -- (ys.filter (· ∈ T)).map (liftedFactor d) =
     --   ((ys.map (liftedFactor d)).zip mask).filterMap selected
@@ -8361,8 +8353,7 @@ private theorem gcd_monicModularImage_derivative_isUnit_local
     have hC_unit :
         IsUnit (Polynomial.C (HexModArithMathlib.ZMod64.toZMod u)) :=
       Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr hu_ne)
-    rw [hmonic_eq, toMathlibPolynomial_scale]
-    rw [Polynomial.derivative_C_mul]
+    rw [hmonic_eq, toMathlibPolynomial_scale, Polynomial.derivative_C_mul]
     exact (isCoprime_mul_unit_left hC_unit
       (HexBerlekampMathlib.toMathlibPolynomial f)
       (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f))).mpr hcop_f
@@ -19075,8 +19066,7 @@ private lemma toMathlibPolynomial_factorsModP_product_eq_monicModularImage
       (primeData.factorsModP.toList.map HexBerlekampMathlib.toMathlibPolynomial).prod =
         HexBerlekampMathlib.toMathlibPolynomial
           (Hex.monicModularImage (Hex.ZPoly.modP primeData.p core)) := by
-    rw [hlist]
-    rw [← toMathlibPolynomial_listFoldlMul_one (raw.map Hex.monicModularImage)]
+    rw [hlist, ← toMathlibPolynomial_listFoldlMul_one (raw.map Hex.monicModularImage)]
     show HexBerlekampMathlib.toMathlibPolynomial
         (Hex.Berlekamp.factorProduct (raw.map Hex.monicModularImage)) = _
     rw [hprod_mapped]
@@ -19188,8 +19178,8 @@ theorem exists_factor_of_modPIndex
         HexBerlekampMathlib.toMathlibPolynomial
           (Hex.monicModularImage
             (@Hex.ZPoly.modP primeData.p primeData.bounds core)) := by
-    rw [← toMathlibPolynomial_factorsModP_product_eq_monicModularImage hsome]
-    rw [← univ_val_map_modPFactor_eq_factorsModP_map primeData]
+    rw [← toMathlibPolynomial_factorsModP_product_eq_monicModularImage hsome,
+      ← univ_val_map_modPFactor_eq_factorsModP_map primeData]
     exact Multiset.dvd_prod (by
       rw [Multiset.mem_map]
       exact ⟨i, by simp, rfl⟩)
@@ -19446,9 +19436,8 @@ theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     monicModPImage_dvd_monicModularImage_of_dvd_of_choosePrimeData?_some
       hdvd hcore_ne hsome
   have hmathD_dvd : mathD ∣ factorsM.prod := by
-    rw [hfactorsM_def]
-    rw [toMathlibPolynomial_factorsModP_product_eq_monicModularImage hsome]
-    rw [hmathD_def]
+    rw [hfactorsM_def, toMathlibPolynomial_factorsModP_product_eq_monicModularImage hsome,
+      hmathD_def]
     rcases hbridge_dvd with ⟨c, hc⟩
     refine ⟨HexBerlekampMathlib.toMathlibPolynomial c, ?_⟩
     rw [hc, toMathlibPolynomial_mul]

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -448,8 +448,7 @@ private theorem gcd_monicModularImage_derivative_isUnit
     have hC_unit :
         IsUnit (Polynomial.C (HexModArithMathlib.ZMod64.toZMod u)) :=
       Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr hu_ne)
-    rw [hmonic_eq, toMathlibPolynomial_scale]
-    rw [Polynomial.derivative_C_mul]
+    rw [hmonic_eq, toMathlibPolynomial_scale, Polynomial.derivative_C_mul]
     exact (isCoprime_mul_unit_left hC_unit
       (HexBerlekampMathlib.toMathlibPolynomial f)
       (Polynomial.derivative (HexBerlekampMathlib.toMathlibPolynomial f))).mpr hcop_f
@@ -2088,8 +2087,7 @@ theorem normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible
                 (UniqueFactorizationMonoid.normalizedFactors R)))
         from zip_map_self _ _]
     simp [List.map_map, Function.comp_def]
-  rw [hRHS_eq]
-  rw [← List.prod_toFinset _ hPq_list_nodup]
+  rw [hRHS_eq, ← List.prod_toFinset _ hPq_list_nodup]
   -- Goal: R = ∏ p ∈ (coreFactors.toList.map toPoly).toFinset, p ^ count p (normalizedFactors R)
   have hR_prod_norm :
       (UniqueFactorizationMonoid.normalizedFactors R).prod = R := by

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -217,9 +217,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     apply foldl_acc_congr
     intro acc k _hmem
     rw [Lean.Grind.CommSemiring.mul_comm]
-  rw [hentry]
-  rw [mul_adjugate_apply M.transpose j i]
-  rw [det_transpose M]
+  rw [hentry, mul_adjugate_apply M.transpose j i, det_transpose M]
   by_cases hij : i = j
   · subst hij
     rfl
@@ -370,8 +368,7 @@ theorem det_mul
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M N : Matrix R n n) :
     det (M * N) = det M * det N := by
-  rw [mul_eq_columnSumMatrix_transpose M N]
-  rw [det_columnSumMatrix_eq_sum_columnTuples M N.transpose]
+  rw [mul_eq_columnSumMatrix_transpose M N, det_columnSumMatrix_eq_sum_columnTuples M N.transpose]
   have hbody_eq :
       (columnTupleVectors n n).foldl
           (fun acc cols => acc +
@@ -627,8 +624,7 @@ private theorem det_mul_cofactor_setRow_eq
           rw [if_pos rfl, if_pos rfl, Lean.Grind.AddCommMonoid.zero_add]
         · rw [if_neg his, if_neg his, Lean.Grind.Semiring.mul_zero,
             Lean.Grind.AddCommMonoid.add_zero]
-    rw [hbody]
-    rw [foldl_det_sum_add_zero]
+    rw [hbody, foldl_det_sum_add_zero]
     have hr_extract :=
       foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) r
         (fun i => (adjugate (setRow M r u))[c][i] * cofactorRowPairing M s u)

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -133,8 +133,7 @@ theorem columnTupleVectors_mem_ofFn {n m : Nat} (cols : Fin n → Fin m) :
   | zero =>
       simp [columnTupleVectors]
   | succ n ih =>
-      rw [columnTupleVectors_ofFn_succ cols]
-      rw [columnTupleVectors, List.mem_flatMap]
+      rw [columnTupleVectors_ofFn_succ cols, columnTupleVectors, List.mem_flatMap]
       refine ⟨Vector.ofFn fun i : Fin n => cols i.castSucc, ih (fun i => cols i.castSucc), ?_⟩
       rw [List.mem_map]
       exact ⟨cols (Fin.last n), List.mem_finRange (cols (Fin.last n)), rfl⟩
@@ -294,8 +293,8 @@ private theorem columnSumMatrixWithSuffix_nil
   ext r hr c hc
   change (columnSumMatrixWithSuffix source coeff [])[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix source coeff)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnSumMatrixWithSuffix_entry, columnSumMatrix_entry]
-  rw [dif_neg (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
+  rw [columnSumMatrixWithSuffix_entry, columnSumMatrix_entry,
+    dif_neg (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
 
 private theorem columnSumMatrixWithSuffix_eq
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
@@ -330,8 +329,7 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
   by_cases hkd : (⟨k, hk2⟩ : Fin n) = (⟨n - chosen.length - 1, by omega⟩ : Fin n)
   · have hkeq : k = n - chosen.length - 1 := by
       have := congrArg Fin.val hkd; simpa using this
-    rw [if_pos hkd]
-    rw [dif_pos (show n - (c :: chosen).length ≤ k by rw [hccons_len]; omega)]
+    rw [if_pos hkd, dif_pos (show n - (c :: chosen).length ≤ k by rw [hccons_len]; omega)]
     have hsub0 : k - (n - (c :: chosen).length) = 0 := by rw [hccons_len]; omega
     have hgetval : (c :: chosen)[k - (n - (c :: chosen).length)]'(by
         have : k < n := hk2; rw [hccons_len]; omega) = c := by
@@ -513,8 +511,7 @@ private theorem partialColumnTupleCoeff_insertAt_last_fold
             have hi : i.val < rem := i.isLt
             omega⟩ : Fin n)][pref[i]]) 1 *
         coeff[(⟨rem, hrem⟩ : Fin n)][c] := by
-  rw [List.finRange_succ_last]
-  rw [List.foldl_append, List.foldl_cons, List.foldl_nil]
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_cons, List.foldl_nil]
   congr 1
   · simp only [List.foldl_map]
     apply foldl_det_product_congr
@@ -625,8 +622,7 @@ private theorem columnTupleVectors_suffix_rhs_step
                         omega))))) 0) 0
   rw [foldl_det_sum_flatMap]
   simp only [List.foldl_map]
-  rw [foldl_det_sum_nested_zero]
-  rw [foldl_det_sum_swap]
+  rw [foldl_det_sum_nested_zero, foldl_det_sum_swap]
   apply foldl_det_sum_congr
   intro c _hc
   have hfactor :
@@ -795,8 +791,8 @@ private theorem det_columnSumMatrixWithSuffix_eq_sum
       grind
   ·
       have hklt : chosen.length < n := by omega
-      rw [det_columnSumMatrixWithSuffix_expand source coeff chosen hklt]
-      rw [columnTupleVectors_suffix_rhs_step_natural source coeff chosen hklt]
+      rw [det_columnSumMatrixWithSuffix_expand source coeff chosen hklt,
+        columnTupleVectors_suffix_rhs_step_natural source coeff chosen hklt]
       apply foldl_det_sum_congr
       intro c _hc
       congr 2
@@ -820,8 +816,8 @@ theorem det_columnSumMatrix_eq_sum_columnTuples
         (fun acc cols => acc +
           columnTupleCoeff coeff cols *
             det (columnTupleMatrix source (columnTupleVectorFn cols))) 0 := by
-  rw [← columnSumMatrixWithSuffix_nil source coeff]
-  rw [det_columnSumMatrixWithSuffix_eq_sum source coeff [] (by simp)]
+  rw [← columnSumMatrixWithSuffix_nil source coeff,
+    det_columnSumMatrixWithSuffix_eq_sum source coeff [] (by simp)]
   apply foldl_det_sum_congr
   intro cols _hcols
   have hcoeff : partialColumnTupleCoeff coeff [] cols = columnTupleCoeff coeff cols :=

--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -436,8 +436,7 @@ theorem det_setCol_existing_col_eq_zero
     det (setCol M dst (fun r => M[r][src])) = 0 := by
   apply det_eq_zero_of_col_eq (setCol M dst (fun r => M[r][src])) src dst hsrcdst
   intro r
-  rw [setCol_getElem, setCol_getElem]
-  rw [if_neg hsrcdst, if_pos rfl]
+  rw [setCol_getElem, setCol_getElem, if_neg hsrcdst, if_pos rfl]
 
 /-- Adding a finite linear combination of other columns of `M` to column `dst`
 preserves the determinant. The sources are given as a list and each source is
@@ -546,8 +545,8 @@ private theorem foldl_det_sum_nested_start {R : Type u} [Lean.Grind.CommRing R]
       grind
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [foldl_det_sum_start ys (fun y => f x y) z]
-      rw [ih (z + ys.foldl (fun acc' y => acc' + f x y) 0)]
+      rw [foldl_det_sum_start ys (fun y => f x y) z,
+        ih (z + ys.foldl (fun acc' y => acc' + f x y) 0)]
       rw [foldl_det_sum_start xs
         (fun x => ys.foldl (fun acc' y => acc' + f x y) 0)
         (0 + ys.foldl (fun acc' y => acc' + f x y) 0)]

--- a/HexDeterminant/Enumeration.lean
+++ b/HexDeterminant/Enumeration.lean
@@ -177,8 +177,8 @@ private theorem inversionCount_adjacent_swap_parity {n : Nat}
     cases Nat.lt_or_gt_of_ne hval with
     | inl hab => exact Or.inl hab
     | inr hba => exact Or.inr hba
-  rw [show pre ++ a :: b :: post = pre ++ ([a, b] ++ post) by simp]
-  rw [show pre ++ b :: a :: post = pre ++ ([b, a] ++ post) by simp]
+  rw [show pre ++ a :: b :: post = pre ++ ([a, b] ++ post) by simp,
+    show pre ++ b :: a :: post = pre ++ ([b, a] ++ post) by simp]
   have hcross :
       crossInversionCount pre ([a, b] ++ post) =
         crossInversionCount pre ([b, a] ++ post) := by
@@ -188,14 +188,9 @@ private theorem inversionCount_adjacent_swap_parity {n : Nat}
       crossInversionCount [a, b] post =
         crossInversionCount [b, a] post := by
     exact crossInversionCount_pair_swap_left post a b
-  rw [inversionCount_append pre ([a, b] ++ post)]
-  rw [inversionCount_append pre ([b, a] ++ post)]
-  rw [hcross]
-  rw [inversionCount_append [a, b] post]
-  rw [inversionCount_append [b, a] post]
-  rw [htail]
-  rw [inversionCount_pair a b]
-  rw [inversionCount_pair b a]
+  rw [inversionCount_append pre ([a, b] ++ post), inversionCount_append pre ([b, a] ++ post),
+    hcross, inversionCount_append [a, b] post, inversionCount_append [b, a] post, htail,
+    inversionCount_pair a b, inversionCount_pair b a]
   cases horder with
   | inl hab =>
       have hba : ¬ b < a := by omega

--- a/HexDeterminant/Index.lean
+++ b/HexDeterminant/Index.lean
@@ -150,8 +150,7 @@ private theorem inversionFold_map_raiseFinAbove_self {n : Nat} (i : Fin (n + 1))
             simp [raiseFinAbove, hxi]
             omega
           simp [hle, hlt]
-      rw [hhead]
-      rw [ih (acc + if i.val ≤ x.val then 1 else 0)]
+      rw [hhead, ih (acc + if i.val ≤ x.val then 1 else 0)]
       rw [foldCount_start xs (fun y : Fin n => i.val ≤ y.val)
         (0 + if i.val ≤ x.val then 1 else 0)]
       omega
@@ -163,13 +162,10 @@ private theorem inversionCount_map_raiseFinAbove_append_self {n : Nat}
     inversionCount ((xs.map (raiseFinAbove i)) ++ [i]) =
       inversionCount xs +
         xs.foldl (fun acc y => acc + if i.val ≤ y.val then 1 else 0) 0 := by
-  rw [inversionCount_append]
-  rw [inversionCount_map_raiseFinAbove]
+  rw [inversionCount_append, inversionCount_map_raiseFinAbove]
   have hsingle : inversionCount ([i] : List (Fin (n + 1))) = 0 := by
     simp [inversionCount]
-  rw [hsingle]
-  rw [crossInversionCount_singleton_right]
-  rw [inversionFold_map_raiseFinAbove_self i xs 0]
+  rw [hsingle, crossInversionCount_singleton_right, inversionFold_map_raiseFinAbove_self i xs 0]
   omega
 
 /-- The `i ≤ y` count fold is unchanged when the list is mapped through
@@ -226,10 +222,8 @@ private theorem foldCount_finRange_ge {n : Nat} (i : Fin (n + 1)) :
           _ = n + 1 - i.val := by omega
       · have hiLt : i.val < n + 1 := by omega
         let i' : Fin (n + 1) := ⟨i.val, hiLt⟩
-        rw [List.finRange_succ_last]
-        rw [List.foldl_append, List.foldl_cons, List.foldl_nil]
-        rw [foldCount_map_castSucc_ge i' (List.finRange n) 0]
-        rw [ih i']
+        rw [List.finRange_succ_last, List.foldl_append, List.foldl_cons, List.foldl_nil,
+          foldCount_map_castSucc_ge i' (List.finRange n) 0, ih i']
         have hleLast : i.val ≤ n := by omega
         simp [i', hleLast]
         omega
@@ -256,8 +250,8 @@ private theorem foldCount_perm {α : Type u} (p : α → Prop) [DecidablePred p]
               exact (foldCount_start l₂ p a).symm
   | swap x y xs =>
       simp only [List.foldl_cons]
-      rw [foldCount_start xs p ((0 + if p y then 1 else 0) + if p x then 1 else 0)]
-      rw [foldCount_start xs p ((0 + if p x then 1 else 0) + if p y then 1 else 0)]
+      rw [foldCount_start xs p ((0 + if p y then 1 else 0) + if p x then 1 else 0),
+        foldCount_start xs p ((0 + if p x then 1 else 0) + if p y then 1 else 0)]
       omega
   | trans _ _ ih₁ ih₂ =>
       exact ih₁.trans ih₂
@@ -434,8 +428,7 @@ private theorem insertAt_peelLastVector {n : Nat}
   change (insertAt (Fin.last n)
         ((peelLastVector perm k hk hidx hnodup).map Fin.castSucc) ⟨k, hk⟩).toList =
       perm.toList
-  rw [insertAt_toList]
-  rw [peelLastVector_castSucc_toList perm k hk hidx hnodup]
+  rw [insertAt_toList, peelLastVector_castSucc_toList perm k hk hidx hnodup]
   have hklist : k < perm.toList.length := by
     simpa [Vector.length_toList] using hk
   have hget : perm.toList[k]'hklist = Fin.last n := by
@@ -529,8 +522,7 @@ private theorem insertAt_last_castSucc_injective {n : Nat}
     i = j ∧ v = w := by
   have hidx :
       i.val = j.val := by
-    rw [← insertAt_last_castSucc_idxOf v i hv]
-    rw [h]
+    rw [← insertAt_last_castSucc_idxOf v i hv, h]
     exact insertAt_last_castSucc_idxOf w j hw
   have hij : i = j := Fin.ext hidx
   subst j
@@ -641,8 +633,7 @@ private theorem detSignParity_add {R : Type u} [Lean.Grind.Ring R] (a m : Nat) :
       simp [Nat.add_zero]
       grind
   | succ m ih =>
-      rw [Nat.add_succ]
-      rw [Lean.Grind.Semiring.pow_succ]
+      rw [Nat.add_succ, Lean.Grind.Semiring.pow_succ]
       rw [show (-1 : R) ^ m * -1 * (if a % 2 = 0 then (1 : R) else -1) =
           -1 * ((-1 : R) ^ m * if a % 2 = 0 then (1 : R) else -1) by
         grind]
@@ -712,8 +703,7 @@ theorem detProduct_insertAt_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
     detProduct M (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
       detProduct (principalSubmatrix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n] := by
   unfold detProduct
-  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl]
-  rw [Fin.foldl_succ_last]
+  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hfold :
       Fin.foldl n
           (fun acc i =>
@@ -842,9 +832,8 @@ private theorem foldl_finRange_succ_factor_skipIndex {R : Type u} [Lean.Grind.Co
   rw [foldl_det_product_perm f (list_finRange_succ_perm_skipIndex i) 1]
   show (i :: (List.finRange n).map (skipIndex i)).foldl (fun acc r => acc * f r) 1 = _
   simp only [List.foldl_cons]
-  rw [show (1 : R) * f i = f i * 1 from by grind]
-  rw [foldl_det_product_mul_left ((List.finRange n).map (skipIndex i)) (f i) f 1]
-  rw [List.foldl_map]
+  rw [show (1 : R) * f i = f i * 1 from by grind,
+    foldl_det_product_mul_left ((List.finRange n).map (skipIndex i)) (f i) f 1, List.foldl_map]
 
 /-- Permutation-product equation generalizing `detProduct_insertAt_last` to any
 insertion position: factor the Leibniz product into the `(i, last)` entry times
@@ -879,8 +868,7 @@ private theorem detTerm_insertAt_general {R : Type u} [Lean.Grind.CommRing R] {n
       cofactorSign (R := R) i (Fin.last n) *
         (M[i][Fin.last n] * detTerm (deleteRowCol M i (Fin.last n)) v) := by
   unfold detTerm
-  rw [detSign_insertAt_general, detProduct_insertAt_general]
-  rw [cofactorSign_last_eq_pow]
+  rw [detSign_insertAt_general, detProduct_insertAt_general, cofactorSign_last_eq_pow]
   grind
 
 private theorem detProduct_insertAt_not_last_zero
@@ -924,8 +912,7 @@ private theorem foldl_detTerm_last_row_insertions
           acc + detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
       z + detSign (R := R) v *
         (detProduct (principalSubmatrix M n (Nat.le_succ n)) v * M[Fin.last n][Fin.last n]) := by
-  rw [← Fin.foldl_eq_finRange_foldl]
-  rw [Fin.foldl_succ_last]
+  rw [← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hprefix :
       Fin.foldl n
           (fun acc i =>
@@ -949,8 +936,7 @@ private theorem foldl_detTerm_last_row_insertions
             hrow]
       _ = z := by
           exact foldl_det_sum_zero (List.finRange n) z
-  rw [hprefix]
-  rw [detTerm_insertAt_last]
+  rw [hprefix, detTerm_insertAt_last]
 
 /-- If the last row is zero before the diagonal entry, the determinant
 factors as the leading principal determinant times the bottom-right entry.
@@ -1112,8 +1098,7 @@ theorem det_upperTriangular_eq_foldl_diag
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
     (hzero : ∀ i j : Fin n, j.val < i.val → M[i][j] = 0) :
     det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
-  rw [det_upperTriangular_eq_finFoldl_diag M hzero]
-  rw [Fin.foldl_eq_finRange_foldl]
+  rw [det_upperTriangular_eq_finFoldl_diag M hzero, Fin.foldl_eq_finRange_foldl]
 
 private theorem detTerm_identity_insertAt_last {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) :
@@ -1130,8 +1115,7 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
           acc + detTerm (1 : Matrix R (n + 1) (n + 1))
             (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
       z + detTerm (1 : Matrix R n n) v := by
-  rw [← Fin.foldl_eq_finRange_foldl]
-  rw [Fin.foldl_succ_last]
+  rw [← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hprefix :
       Fin.foldl n
           (fun acc i =>
@@ -1155,8 +1139,7 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
           grind
       _ = z := by
           exact foldl_det_sum_zero (List.finRange n) z
-  rw [hprefix]
-  rw [detTerm_identity_insertAt_last]
+  rw [hprefix, detTerm_identity_insertAt_last]
 
 private theorem rowScale_get {R : Type u} [Mul R] {n m : Nat}
     (M : Matrix R n m) (i r : Fin n) (c : R) (k : Fin m) :

--- a/HexDeterminant/Laplace.lean
+++ b/HexDeterminant/Laplace.lean
@@ -143,9 +143,7 @@ pairwise distinct, the no-repeat condition needed to certify it as a genuine
 permutation of the columns. -/
 private theorem moveColumnToLastValues_nodup {n : Nat} (col : Fin (n + 1)) :
     (moveColumnToLastValues col).toList.Nodup := by
-  rw [moveColumnToLastValues, insertAt_last_toList]
-  rw [vector_toList_eq]
-  rw [List.nodup_append]
+  rw [moveColumnToLastValues, insertAt_last_toList, vector_toList_eq, List.nodup_append]
   refine ⟨?_, ?_, ?_⟩
   · apply list_nodup_map_of_injective
     · intro i j h
@@ -180,8 +178,7 @@ shape consumed by the inversion-count sign lemma. -/
 private theorem moveColumnToLastValues_toList {n : Nat} (col : Fin (n + 1)) :
     (moveColumnToLastValues col).toList =
       ((List.finRange n).map (raiseFinAbove col)) ++ [col] := by
-  rw [moveColumnToLastValues, insertAt_last_toList]
-  rw [vector_toList_eq]
+  rw [moveColumnToLastValues, insertAt_last_toList, vector_toList_eq]
   apply congrArg (fun xs => xs ++ [col])
   apply List.map_congr_left
   intro i _hi
@@ -203,9 +200,8 @@ private theorem detSign_moveColumnToLastValues
         (-1 : R) ^ (n - col.val) *
           detSign (R := R) (Vector.ofFn fun i : Fin n => i) := by
       apply detSign_of_inversionCount_add
-      rw [moveColumnToLastValues_toList, hidList]
-      rw [inversionCount_map_raiseFinAbove_append_self]
-      rw [foldCount_finRange_ge]
+      rw [moveColumnToLastValues_toList, hidList, inversionCount_map_raiseFinAbove_append_self,
+        foldCount_finRange_ge]
     _ = (-1 : R) ^ (n - col.val) := by
       rw [detSign_identity]
       grind
@@ -312,8 +308,7 @@ theorem det_eq_foldl_laplace_col
             simp [C, ofFn]]
           exact congrArg (fun c => M[skipIndex row ii][c])
             (moveColumnToLastValues_castSucc col jj)
-        rw [hClast, hminor]
-        rw [cofactorSign_col_eq (R := R) row col]
+        rw [hClast, hminor, cofactorSign_col_eq (R := R) row col]
         grind
 
 /-- Laplace expansion of the determinant along an arbitrary fixed row. -/
@@ -334,8 +329,7 @@ theorem det_eq_foldl_laplace_row
         (fun acc col => acc + M[row][col] * cofactor M row col) 0 := by
         apply foldl_acc_congr
         intro acc col _hmem
-        rw [cofactor_transpose]
-        rw [transpose_getElem]
+        rw [cofactor_transpose, transpose_getElem]
 
 end Matrix
 end Hex

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -598,8 +598,7 @@ private theorem detProduct_identity_insertAt_last {R : Type u}
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
     detProduct (1 : Matrix R n n) v := by
   unfold detProduct
-  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl]
-  rw [Fin.foldl_succ_last]
+  rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hfold :
       Fin.foldl n
           (fun acc i =>
@@ -666,9 +665,7 @@ private theorem inversionCount_insert_last_castSucc {n : Nat} (xs : List (Fin n)
   | nil => rfl
   | cons x xs ih =>
       simp only [List.map_cons, List.cons_append, inversionCount]
-      rw [ih]
-      rw [List.foldl_append, List.foldl_cons, List.foldl_nil]
-      rw [inversionFold_map_castSucc]
+      rw [ih, List.foldl_append, List.foldl_cons, List.foldl_nil, inversionFold_map_castSucc]
       simp [Fin.lt_def]
 
 /-- Inserting `Fin.last n` at any position into the `castSucc`-embedded list leaves
@@ -734,8 +731,7 @@ private theorem inversionCount_insertIdx_castSucc_last_eq {n : Nat}
           simp only [inversionCount, List.foldl_cons]
           rw [foldl_all_lt_last_castSucc xs
             (0 + if x.castSucc < Fin.last n then 1 else 0)]
-          rw [inversionFold_map_castSucc]
-          rw [inversionCount_map_castSucc]
+          rw [inversionFold_map_castSucc, inversionCount_map_castSucc]
           simp [Fin.lt_def]
           omega
       | succ p =>
@@ -751,10 +747,8 @@ private theorem inversionCount_insertIdx_castSucc_last_eq {n : Nat}
                 inversionCount ((xs.map Fin.castSucc).insertIdx p (Fin.last n)) =
               xs.foldl (fun acc y => acc + if y < x then 1 else 0) 0 +
                 inversionCount xs + ((x :: xs).length - (p + 1))
-          rw [foldl_insertIdx_last_castSucc_not_lt xs x p]
-          rw [inversionFold_map_castSucc]
-          rw [ih p hp']
-          rw [hlen]
+          rw [foldl_insertIdx_last_castSucc_not_lt xs x p, inversionFold_map_castSucc, ih p hp',
+            hlen]
           grind
 
 /-- Mapping a `Nodup` list through the injective `Fin.castSucc` keeps it `Nodup`. -/

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -165,8 +165,7 @@ private theorem vector_toList_eq {α : Type u} {n : Nat}
 private theorem transposePermutationValues_toList_perm {n : Nat}
     (perm : Vector (Fin n) n) (i j : Fin n) :
     (transposePermutationValues perm i j).toList.Perm perm.toList := by
-  rw [vector_toList_eq (transposePermutationValues perm i j)]
-  rw [vector_toList_eq perm]
+  rw [vector_toList_eq (transposePermutationValues perm i j), vector_toList_eq perm]
   have hleft :
       (List.finRange n).map (fun r => (transposePermutationValues perm i j)[r]) =
         (List.finRange n).map ((fun r => perm[r]) ∘ finTranspose i j) := by
@@ -334,10 +333,10 @@ private theorem transposePermutationValues_toList_of_lt {n : Nat}
       perm.toList.take i.val ++ perm[j] ::
         (perm.toList.drop (i.val + 1)).take (j.val - i.val - 1) ++
           perm[i] :: perm.toList.drop (j.val + 1) := by
-  rw [vector_toList_split_two (transposePermutationValues perm i j) hij]
-  rw [transposePermutationValues_take_of_lt perm hij]
-  rw [transposePermutationValues_middle_of_lt perm hij]
-  rw [transposePermutationValues_drop_of_lt perm hij]
+  rw [vector_toList_split_two (transposePermutationValues perm i j) hij,
+    transposePermutationValues_take_of_lt perm hij,
+    transposePermutationValues_middle_of_lt perm hij,
+    transposePermutationValues_drop_of_lt perm hij]
   have hi : (transposePermutationValues perm i j)[i] = perm[j] := by
     rw [transposePermutationValues_get]
     exact vector_get_fin_congr perm (finTranspose_left i j)
@@ -621,11 +620,8 @@ private theorem inversionCount_inversePermutationValues_insertAt_last_castSucc {
           (insertAt (Fin.last n) (v.map Fin.castSucc) i)
           (insertAt_last_castSucc_nodup v i hnodup)).toList =
       inversionCount (inversePermutationValues v hnodup).toList + (n - i.val) := by
-  rw [inversePermutationValues_insertAt_last_castSucc v i hnodup]
-  rw [insertAt_last_toList]
-  rw [vector_toList_map]
-  rw [inversionCount_map_raiseFinAbove_append_self]
-  rw [foldCount_full_nodup_ge i]
+  rw [inversePermutationValues_insertAt_last_castSucc v i hnodup, insertAt_last_toList,
+    vector_toList_map, inversionCount_map_raiseFinAbove_append_self, foldCount_full_nodup_ge i]
   · simp [Vector.length_toList]
   · exact inversePermutationValues_nodup v hnodup
 
@@ -677,8 +673,7 @@ private theorem inversionCount_inversePermutationValues_mod_two {n : Nat}
       have hperm_count :
           inversionCount perm.toList =
             inversionCount peeled.toList + (n - pos.val) := by
-        rw [← hinsert]
-        rw [insertAt_toList, vector_toList_map]
+        rw [← hinsert, insertAt_toList, vector_toList_map]
         simpa [peeled, pos, Vector.length_toList] using
           inversionCount_insertIdx_castSucc_last_eq peeled.toList pos.val (by
             simp [Vector.length_toList, pos]
@@ -1215,8 +1210,8 @@ private theorem inversionCount_adjacent_swap_descent {n : Nat}
     (pre post : List (Fin n)) (a b : Fin n) (hba : b < a) :
     inversionCount (pre ++ a :: b :: post) =
       inversionCount (pre ++ b :: a :: post) + 1 := by
-  rw [show pre ++ a :: b :: post = pre ++ ([a, b] ++ post) by simp]
-  rw [show pre ++ b :: a :: post = pre ++ ([b, a] ++ post) by simp]
+  rw [show pre ++ a :: b :: post = pre ++ ([a, b] ++ post) by simp,
+    show pre ++ b :: a :: post = pre ++ ([b, a] ++ post) by simp]
   have hcross :
       crossInversionCount pre ([a, b] ++ post) =
         crossInversionCount pre ([b, a] ++ post) := by
@@ -1226,14 +1221,9 @@ private theorem inversionCount_adjacent_swap_descent {n : Nat}
       crossInversionCount [a, b] post =
         crossInversionCount [b, a] post :=
     crossInversionCount_pair_swap_left post a b
-  rw [inversionCount_append pre ([a, b] ++ post)]
-  rw [inversionCount_append pre ([b, a] ++ post)]
-  rw [hcross]
-  rw [inversionCount_append [a, b] post]
-  rw [inversionCount_append [b, a] post]
-  rw [htail]
-  rw [inversionCount_pair a b]
-  rw [inversionCount_pair b a]
+  rw [inversionCount_append pre ([a, b] ++ post), inversionCount_append pre ([b, a] ++ post),
+    hcross, inversionCount_append [a, b] post, inversionCount_append [b, a] post, htail,
+    inversionCount_pair a b, inversionCount_pair b a]
   have hab' : ¬ a < b := by omega
   simp [hba, hab']
   omega
@@ -1310,8 +1300,7 @@ private theorem exists_adjacent_descent {n : Nat}
       have hcount :
           inversionCount perm.toList =
             inversionCount peeled.toList + (n - pos.val) := by
-        rw [← hinsert]
-        rw [insertAt_toList, vector_toList_map]
+        rw [← hinsert, insertAt_toList, vector_toList_map]
         simpa [peeled, pos, Vector.length_toList] using
           inversionCount_insertIdx_castSucc_last_eq peeled.toList pos.val (by
             simp [Vector.length_toList, pos]
@@ -1469,8 +1458,7 @@ private theorem perm_eq_identity {n : Nat}
       have hcount :
           inversionCount perm.toList =
             inversionCount peeled.toList + (n - pos.val) := by
-        rw [← hinsert]
-        rw [insertAt_toList, vector_toList_map]
+        rw [← hinsert, insertAt_toList, vector_toList_map]
         simpa [peeled, pos, Vector.length_toList] using
           inversionCount_insertIdx_castSucc_last_eq peeled.toList pos.val (by
             simp [Vector.length_toList, pos]
@@ -1717,8 +1705,8 @@ private theorem detTerm_colDuplicate_swapValues {R : Type u}
     (perm : Vector (Fin n) n) (hnodup : perm.toList.Nodup) :
     detTerm M perm = -detTerm M (swapPermutationValues perm src dst) := by
   unfold detTerm
-  rw [detProduct_colDuplicate_swapValues M src dst hcol perm]
-  rw [detSign_swapPermutationValues (R := R) perm src dst hnodup h]
+  rw [detProduct_colDuplicate_swapValues M src dst hcol perm,
+    detSign_swapPermutationValues (R := R) perm src dst hnodup h]
   grind
 
 /-- `M` with column `dst` overwritten by a copy of column `src`. -/
@@ -1829,8 +1817,8 @@ private theorem detTerm_rowSwap_transposeValues {R : Type u}
     detTerm (rowSwap M i j) perm =
       -detTerm M (transposePermutationValues perm i j) := by
   unfold detTerm
-  rw [detProduct_rowSwap_transposeValues M i j h perm]
-  rw [detSign_transposeValues (R := R) perm i j hnodup h]
+  rw [detProduct_rowSwap_transposeValues M i j h perm,
+    detSign_transposeValues (R := R) perm i j hnodup h]
   grind
 
 private theorem permutationVectors_transposeValues_neg_sum {R : Type u}
@@ -1969,8 +1957,7 @@ private theorem detProduct_rowAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         intro r _hmem
         by_cases h : r = dst
         · subst r
-          rw [rowAdd_get M src dst dst c perm[dst]]
-          rw [rowAddDuplicate_get M src dst dst perm[dst]]
+          rw [rowAdd_get M src dst dst c perm[dst], rowAddDuplicate_get M src dst dst perm[dst]]
           simp
         · rw [rowAdd_get, rowAddDuplicate_get]
           simp [h]
@@ -2088,8 +2075,8 @@ private theorem detTerm_rowAddDuplicate_transposeValues {R : Type u}
       -detTerm (rowAddDuplicate M src dst)
         (transposePermutationValues perm src dst) := by
   unfold detTerm
-  rw [detProduct_rowAddDuplicate_transposeValues M src dst h perm]
-  rw [detSign_transposeValues (R := R) perm src dst hnodup h]
+  rw [detProduct_rowAddDuplicate_transposeValues M src dst h perm,
+    detSign_transposeValues (R := R) perm src dst hnodup h]
   grind
 
 private theorem permutationVectors_duplicateRow_sum {R : Type u} [Lean.Grind.CommRing R]
@@ -2269,8 +2256,8 @@ private theorem permutationVectors_duplicateCol_sum {R : Type u} [Lean.Grind.Com
         · exact swapPermutationValues_mem_permutationVectors src dst hpreMem
         · have hpreNodup := permutationVectors_nodup hpreMem
           simp [p] at hpreP ⊢
-          rw [swapPermutationValues_idxOf_left pre src dst hpreNodup]
-          rw [swapPermutationValues_idxOf_right pre src dst hpreNodup]
+          rw [swapPermutationValues_idxOf_left pre src dst hpreNodup,
+            swapPermutationValues_idxOf_right pre src dst hpreNodup]
           omega
       · intro hmem
         simp only [List.mem_filter] at hmem
@@ -2280,8 +2267,8 @@ private theorem permutationVectors_duplicateCol_sum {R : Type u} [Lean.Grind.Com
           ⟨swapPermutationValues_mem_permutationVectors src dst hpermMem, ?_⟩, ?_⟩
         · have hpermNodup := permutationVectors_nodup hpermMem
           simp [p] at hpfalse ⊢
-          rw [swapPermutationValues_idxOf_left perm src dst hpermNodup]
-          rw [swapPermutationValues_idxOf_right perm src dst hpermNodup]
+          rw [swapPermutationValues_idxOf_left perm src dst hpermNodup,
+            swapPermutationValues_idxOf_right perm src dst hpermNodup]
           have hneIdx := permutation_idxOf_ne perm src dst hpermNodup h
           omega
         · exact swapPermutationValues_involutive perm src dst
@@ -2469,8 +2456,8 @@ theorem det_transpose {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         have hnodup := permutationVectors_nodup hmem
         rw [inversePermutationVector_eq perm hnodup]
         unfold detTerm
-        rw [detProduct_transpose_inversePermutationValues M perm hnodup]
-        rw [← detSign_inversePermutationValues (R := R) perm hnodup]
+        rw [detProduct_transpose_inversePermutationValues M perm hnodup,
+          ← detSign_inversePermutationValues (R := R) perm hnodup]
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 := by
         exact permutationVectors_inverseVector_sum (R := R) (n := n) (fun perm => detTerm M perm)
@@ -2486,9 +2473,7 @@ theorem cofactor_transpose {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     unfold cofactorSign
     have hsum : row.val + col.val = col.val + row.val := Nat.add_comm _ _
     rw [hsum]
-  rw [hsign]
-  rw [deleteRowCol_transpose]
-  rw [det_transpose]
+  rw [hsign, deleteRowCol_transpose, det_transpose]
 
 /-- Diagonal-product formula for the determinant of a lower-triangular matrix
 (entries above the diagonal are zero). Derived from the upper-triangular form
@@ -2521,8 +2506,7 @@ theorem det_lowerTriangular_eq_foldl_diag
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat} (M : Matrix R n n)
     (hzero : ∀ i j : Fin n, i.val < j.val → M[i][j] = 0) :
     det M = (List.finRange n).foldl (fun acc i => acc * M[i][i]) 1 := by
-  rw [det_lowerTriangular_eq_finFoldl_diag M hzero]
-  rw [Fin.foldl_eq_finRange_foldl]
+  rw [det_lowerTriangular_eq_finFoldl_diag M hzero, Fin.foldl_eq_finRange_foldl]
 
 /-- Permuting columns multiplies the determinant by the sign of the column permutation. -/
 theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
@@ -2569,9 +2553,9 @@ theorem det_colSwap {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     let rr : Fin n := ⟨r, hr⟩
     let cc : Fin n := ⟨c, hc⟩
     change C.transpose[rr][cc] = (rowSwap M.transpose i j)[rr][cc]
-    rw [rowSwap_get_finTranspose M.transpose i j rr h cc]
-    rw [show C.transpose[rr][cc] = C[cc][rr] by simp [Matrix.transpose, Matrix.col]]
-    rw [show C[cc][rr] = M[cc][finTranspose i j rr] by simp [C, ofFn]]
+    rw [rowSwap_get_finTranspose M.transpose i j rr h cc,
+      show C.transpose[rr][cc] = C[cc][rr] by simp [Matrix.transpose, Matrix.col],
+      show C[cc][rr] = M[cc][finTranspose i j rr] by simp [C, ofFn]]
     simp [Matrix.transpose, Matrix.col]
   calc
     det C = det C.transpose := (det_transpose C).symm

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -194,9 +194,7 @@ private theorem det_rowMoveUp {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         have hv : (⟨src + k, by omega⟩ : Fin n).val =
             (⟨src + k + 1, h⟩ : Fin n).val := congrArg Fin.val heq
         simp at hv
-      rw [ih]
-      rw [det_rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩ hne]
-      rw [Lean.Grind.Semiring.pow_succ]
+      rw [ih, det_rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩ hne, Lean.Grind.Semiring.pow_succ]
       grind
 
 /-- Rows of `M` strictly below the move interval are unchanged by
@@ -208,8 +206,7 @@ private theorem rowMoveUp_row_of_lt {R : Type u} {n m : Nat}
   induction k generalizing M with
   | zero => rfl
   | succ k ih =>
-      rw [rowMoveUp_succ]
-      rw [ih (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩) (by omega)]
+      rw [rowMoveUp_succ, ih (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩) (by omega)]
       ext j hj
       let jj : Fin m := ⟨j, hj⟩
       show (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩)[i][jj] = M[i][jj]
@@ -253,8 +250,7 @@ private theorem rowMoveUp_row_eq_src {R : Type u} {n m : Nat}
       have hii : i = (⟨src + 0, h⟩ : Fin n) := Fin.ext (by simp [hi])
       rw [hii]; rfl
   | succ k ih =>
-      rw [rowMoveUp_succ]
-      rw [ih (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩) (by omega)]
+      rw [rowMoveUp_succ, ih (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩) (by omega)]
       ext j hj
       let jj : Fin m := ⟨j, hj⟩
       show (rowSwap M ⟨src + k, by omega⟩ ⟨src + k + 1, h⟩)[
@@ -919,8 +915,7 @@ theorem twoColMatrix_entry_penultimate {R : Type u} {n : Nat}
     simp
   have hneq : (⟨n, by omega⟩ : Fin (n + 2)).val = n := by
     simp
-  rw [dif_neg hnlt]
-  rw [dif_pos hneq]
+  rw [dif_neg hnlt, dif_pos hneq]
 
 /-- The last column of `twoColMatrix B u v` is `v`. -/
 theorem twoColMatrix_entry_last {R : Type u} {n : Nat}
@@ -933,8 +928,7 @@ theorem twoColMatrix_entry_last {R : Type u} {n : Nat}
     simp [Fin.last]
   have hlast_ne : ¬ (Fin.last (n + 1) : Fin (n + 2)).val = n := by
     simp [Fin.last]
-  rw [dif_neg hlast_lt]
-  rw [dif_neg hlast_ne]
+  rw [dif_neg hlast_lt, dif_neg hlast_ne]
 
 /-- The determinant of `[B | u | v]`. -/
 @[expose]
@@ -1028,9 +1022,8 @@ theorem mMatrix_eq_setCol_last {R : Type u} {n : Nat}
       have hval := congrArg Fin.val h
       simp [Fin.last] at hval
       omega
-    rw [if_neg hjne]
-    rw [mMatrix_entry_lt B v p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt]
-    rw [mMatrix_entry_lt B w p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt]
+    rw [if_neg hjne, mMatrix_entry_lt B v p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt,
+      mMatrix_entry_lt B w p (⟨i, hi⟩ : Fin (n + 1)) (⟨j, hj⟩ : Fin (n + 1)) hjlt]
   · have hjeq : j = n := by omega
     have hjlast : (⟨j, hj⟩ : Fin (n + 1)) = Fin.last n := by
       apply Fin.ext
@@ -1053,9 +1046,7 @@ theorem mDet_add_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       fun i : Fin (n + 1) => v[skipIndex p i] + w[skipIndex p i] by
         funext i
         simp [Vector.getElem_add]]
-  rw [det_setCol_add]
-  rw [← mMatrix_eq_setCol_last B v v p]
-  rw [← mMatrix_eq_setCol_last B w v p]
+  rw [det_setCol_add, ← mMatrix_eq_setCol_last B v v p, ← mMatrix_eq_setCol_last B w v p]
 
 /-- `mDet` is homogeneous in the augmented vector column. -/
 theorem mDet_smul_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
@@ -1069,8 +1060,7 @@ theorem mDet_smul_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         simp [Vector.getElem_smul]
         change c * v[skipIndex p i] = c * v[skipIndex p i]
         rfl]
-  rw [det_setCol_smul]
-  rw [← mMatrix_eq_setCol_last B v v p]
+  rw [det_setCol_smul, ← mMatrix_eq_setCol_last B v v p]
 
 /-- Numeric entry form for the standard basis vector. -/
 private theorem unit_getElem_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
@@ -1176,8 +1166,7 @@ private theorem foldl_unit_weighted_single
     by_cases hp : p = q
     · rw [if_pos hp]
     · rw [if_neg hp]
-      rw [unit_getElem_num]
-      rw [if_neg hp]
+      rw [unit_getElem_num, if_neg hp]
       grind
   calc
     (List.finRange (n + 2)).foldl
@@ -1187,8 +1176,7 @@ private theorem foldl_unit_weighted_single
           acc + if p = q then (Hex.Vector.unit (R := R) q)[p] * f p else 0) 0 := hcongr
     _ = 0 + (Hex.Vector.unit (R := R) q)[q] * f q := hfold
     _ = f q := by
-      rw [unit_getElem_num]
-      rw [if_pos rfl]
+      rw [unit_getElem_num, if_pos rfl]
       grind
 
 /-- Expands the augmented vector column of `mDet` in the standard basis. -/
@@ -1223,8 +1211,7 @@ theorem mDet_eq_sum_unit
       by_cases hq : q = skipIndex p i
       · rw [if_pos hq]
       · rw [if_neg hq]
-        rw [unit_getElem_num]
-        rw [if_neg (fun h => hq h.symm)]
+        rw [unit_getElem_num, if_neg (fun h => hq h.symm)]
         grind
     symm
     calc
@@ -1236,11 +1223,9 @@ theorem mDet_eq_sum_unit
               v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := hcongr
       _ = 0 + v[skipIndex p i] * (Hex.Vector.unit (R := R) (skipIndex p i))[skipIndex p i] := hfold
       _ = v[skipIndex p i] := by
-        rw [unit_getElem_num]
-        rw [if_pos rfl]
+        rw [unit_getElem_num, if_pos rfl]
         grind
-  rw [hcol]
-  rw [det_setCol_sum_finRange]
+  rw [hcol, det_setCol_sum_finRange]
   apply foldl_acc_congr
   intro acc q _hmem
   rw [← mMatrix_eq_setCol_last B (Hex.Vector.unit (R := R) q) v p]
@@ -1298,8 +1283,7 @@ theorem deleteRowCol_mMatrix_at_q_minus_one_eq_nMatrix_of_lt
   change (deleteRowCol (mMatrix B v p)
         (⟨q.val - 1, by have := q.isLt; omega⟩ : Fin (n + 1)) (Fin.last n))[ii][jj] =
     (nMatrix B p q hpq)[ii][jj]
-  rw [deleteRowCol_entry]
-  rw [nMatrix_entry]
+  rw [deleteRowCol_entry, nMatrix_entry]
   -- The column index: skipIndex (Fin.last n) jj = jj.castSucc; its val = jj.val < n.
   have hjj_castSucc : (skipIndex (Fin.last n) jj).val = jj.val := by
     show (skipIndex (Fin.last n) jj).val = jj.val
@@ -1391,8 +1375,7 @@ theorem deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt
   change (deleteRowCol (mMatrix B v p)
         (⟨q.val, by have := p.isLt; omega⟩ : Fin (n + 1)) (Fin.last n))[ii][jj] =
     (nMatrix B q p hqp)[ii][jj]
-  rw [deleteRowCol_entry]
-  rw [nMatrix_entry]
+  rw [deleteRowCol_entry, nMatrix_entry]
   have hjj_castSucc : (skipIndex (Fin.last n) jj).val = jj.val := by
     show (skipIndex (Fin.last n) jj).val = jj.val
     rw [skipIndex_last]
@@ -1430,8 +1413,7 @@ theorem mDet_unit_eq_signed_nDet_of_gt
       (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
-    rw [mMatrix_entry_last]
-    rw [unit_getElem_num]
+    rw [mMatrix_entry_last, unit_getElem_num]
     by_cases hreq : r = r_q
     · subst hreq
       rw [if_pos rfl]
@@ -1475,8 +1457,7 @@ theorem mDet_unit_eq_signed_nDet_of_lt
       (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
-    rw [mMatrix_entry_last]
-    rw [unit_getElem_num]
+    rw [mMatrix_entry_last, unit_getElem_num]
     by_cases hreq : r = r_q
     · subst hreq
       rw [if_pos rfl]
@@ -1642,9 +1623,8 @@ private theorem det_plucker_three_term_unit_of_eq_p1
       mDet B (Hex.Vector.unit (R := R) p1) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B (Hex.Vector.unit (R := R) p1) p3 * nDet B p1 p2 h12 = 0 := by
-  rw [mDet_unit_eq_zero_of_eq B p1]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
+  rw [mDet_unit_eq_zero_of_eq B p1, mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
+    mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
   grind
 
 private theorem det_plucker_three_term_unit_of_eq_p2
@@ -1656,9 +1636,8 @@ private theorem det_plucker_three_term_unit_of_eq_p2
       mDet B (Hex.Vector.unit (R := R) p2) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B (Hex.Vector.unit (R := R) p2) p3 * nDet B p1 p2 h12 = 0 := by
-  rw [mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12]
-  rw [mDet_unit_eq_zero_of_eq B p2]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
+  rw [mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12, mDet_unit_eq_zero_of_eq B p2,
+    mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
   have hp2pos : 0 < p2.val := by omega
   have hrow :
       (⟨p2.val, by have := p3.isLt; omega⟩ : Fin (n + 1)) =
@@ -1680,9 +1659,8 @@ private theorem det_plucker_three_term_unit_of_eq_p3
       mDet B (Hex.Vector.unit (R := R) p3) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B (Hex.Vector.unit (R := R) p3) p3 * nDet B p1 p2 h12 = 0 := by
-  rw [mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23)]
-  rw [mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23]
-  rw [mDet_unit_eq_zero_of_eq B p3]
+  rw [mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
+    mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, mDet_unit_eq_zero_of_eq B p3]
   grind
 
 private theorem det_plucker_three_term_of_unit
@@ -1698,9 +1676,7 @@ private theorem det_plucker_three_term_of_unit
     mDet B v p1 * nDet B p2 p3 h23 -
       mDet B v p2 * nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B v p3 * nDet B p1 p2 h12 = 0 := by
-  rw [mDet_eq_sum_unit B v p1]
-  rw [mDet_eq_sum_unit B v p2]
-  rw [mDet_eq_sum_unit B v p3]
+  rw [mDet_eq_sum_unit B v p1, mDet_eq_sum_unit B v p2, mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
       (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p1)
       (nDet B p2 p3 h23)]
@@ -1858,8 +1834,8 @@ private theorem det_plucker_three_term_unit_of_lt_p1_of_nDet
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B (Hex.Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0 := by
   have hraw := det_plucker_three_term_nDet_of_lt_p1 B q p1 p2 p3 hq1 h12 h23
-  rw [mDet_unit_eq_signed_nDet_of_gt B p1 q hq1]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p2 q (Nat.lt_trans hq1 h12)]
+  rw [mDet_unit_eq_signed_nDet_of_gt B p1 q hq1,
+    mDet_unit_eq_signed_nDet_of_gt B p2 q (Nat.lt_trans hq1 h12)]
   rw [mDet_unit_eq_signed_nDet_of_gt B p3 q
       (Nat.lt_trans hq1 (Nat.lt_trans h12 h23))]
   grind
@@ -1880,9 +1856,8 @@ private theorem det_plucker_three_term_unit_of_between_p1_p2_of_nDet
         nDet B p1 p2 (Nat.lt_trans h1q hq2) = 0 := by
   have hraw :=
     det_plucker_three_term_nDet_of_between_p1_p2 B p1 q p2 p3 h1q hq2 h23
-  rw [mDet_unit_eq_signed_nDet_of_lt B p1 q h1q]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p2 q hq2]
-  rw [mDet_unit_eq_signed_nDet_of_gt B p3 q (Nat.lt_trans hq2 h23)]
+  rw [mDet_unit_eq_signed_nDet_of_lt B p1 q h1q, mDet_unit_eq_signed_nDet_of_gt B p2 q hq2,
+    mDet_unit_eq_signed_nDet_of_gt B p3 q (Nat.lt_trans hq2 h23)]
   have hrow :
       (⟨q.val, by have := p3.isLt; omega⟩ : Fin (n + 1)) =
         (⟨q.val - 1 + 1, by have := p3.isLt; omega⟩ : Fin (n + 1)) := by

--- a/HexDeterminant/Selection.lean
+++ b/HexDeterminant/Selection.lean
@@ -457,8 +457,8 @@ than to its repackaged Nat-value form. -/
 private theorem vector_ofFn_getElem_fin {α : Type u} {n : Nat}
     (f : Fin n → α) (k : Fin n) :
     (Vector.ofFn f)[k] = f k := by
-  rw [show ((Vector.ofFn f)[k] : α) = (Vector.ofFn f)[k.val]'(by simp [k.isLt]) from rfl]
-  rw [Vector.getElem_ofFn]
+  rw [show ((Vector.ofFn f)[k] : α) = (Vector.ofFn f)[k.val]'(by simp [k.isLt]) from rfl,
+    Vector.getElem_ofFn]
 
 /-- Every length-`n` tuple of column indices appears in
 `columnTupleVectors n m`. -/
@@ -733,9 +733,8 @@ private theorem permutationVectors_count_val_lt {n : Nat}
     rfl
   have htoList : perm.toList = (List.finRange n).map (fun j : Fin n => perm[j]) :=
     vector_toList_eq perm
-  rw [hmap, ← htoList]
-  rw [List.Perm.countP_eq _ (permutationVectors_toList_perm_finRange hmem)]
-  rw [countP_finRange_val_lt]
+  rw [hmap, ← htoList, List.Perm.countP_eq _ (permutationVectors_toList_perm_finRange hmem),
+    countP_finRange_val_lt]
   exact Nat.min_eq_right (Nat.le_of_lt k.isLt)
 
 /-- For a strictly-increasing `sel` and a permutation `perm`, the column
@@ -1007,9 +1006,8 @@ private theorem columnTupleExpansionTerm_reconstructInjTuple
       detTerm (columnTupleMatrix A (columnTupleVectorFn sel)) perm *
         det (columnTupleMatrix A (columnTupleVectorFn sel)) := by
   unfold columnTupleExpansionTerm detTerm
-  rw [columnTupleCoeff_reconstructInjTuple]
-  rw [columnTupleMatrix_reconstructInjTuple_eq A sel perm]
-  rw [det_columnTupleMatrix_compose_perm A sel perm hperm]
+  rw [columnTupleCoeff_reconstructInjTuple, columnTupleMatrix_reconstructInjTuple_eq A sel perm,
+    det_columnTupleMatrix_compose_perm A sel perm hperm]
   grind
 
 private theorem columnTupleExpansion_reconstruct_orbit_sum
@@ -1048,8 +1046,7 @@ private theorem columnTupleExpansion_selectedPerm_collapse
   intro acc sel _hsel
   rw [foldl_det_sum_start]
   congr 1
-  rw [foldl_det_sum_map]
-  rw [columnTupleExpansion_reconstruct_orbit_sum A sel]
+  rw [foldl_det_sum_map, columnTupleExpansion_reconstruct_orbit_sum A sel]
 
 /-- Cauchy-Binet for the row Gram matrix: the Gram determinant is the finite
 sum of squares of the selected column minors. -/

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -80,10 +80,10 @@ theorem ordered_four_det_mul_det_setRow_setRow_eq_det_setRow_mul_sub
         Hex.Matrix.det (Hex.Matrix.setRow M r3 B[p1]) *
           Hex.Matrix.det (Hex.Matrix.setRow M r2 B[q]) := by
   intro M r2 r3
-  rw [← ordered_four_cofactorRowPairing_p2_p1_eq_det_setRow B p1 p2 p3 q h12 h23 h3q]
-  rw [← ordered_four_cofactorRowPairing_p3_q_eq_det_setRow B p1 p2 p3 q h12 h23 h3q]
-  rw [← ordered_four_cofactorRowPairing_p3_p1_eq_det_setRow B p1 p2 p3 q h12 h23 h3q]
-  rw [← ordered_four_cofactorRowPairing_p2_q_eq_det_setRow B p1 p2 p3 q h12 h23 h3q]
+  rw [← ordered_four_cofactorRowPairing_p2_p1_eq_det_setRow B p1 p2 p3 q h12 h23 h3q,
+    ← ordered_four_cofactorRowPairing_p3_q_eq_det_setRow B p1 p2 p3 q h12 h23 h3q,
+    ← ordered_four_cofactorRowPairing_p3_p1_eq_det_setRow B p1 p2 p3 q h12 h23 h3q,
+    ← ordered_four_cofactorRowPairing_p2_q_eq_det_setRow B p1 p2 p3 q h12 h23 h3q]
   exact ordered_four_det_mul_det_setRow_setRow_eq_cofactorRowPairing_mul_sub
     B p1 p2 p3 q h12 h23 h3q
 
@@ -304,8 +304,7 @@ private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
                     (OrderedFourShift.cycleBehind (n := n) (p3.val - 1) m2 hm2 i).val := by
                 rw [h_cb_val, hm1_val]; omega
               have hσ_val : (σ i).val = i.val - 1 := by
-                rw [hσ_apply _]
-                rw [OrderedFourShift.cycleAhead_val_above p1.val m1 hm1 _ h_above_a1]
+                rw [hσ_apply _, OrderedFourShift.cycleAhead_val_above p1.val m1 hm1 _ h_above_a1]
                 exact h_cb_val
               apply B_entry_congr; apply Fin.ext
               have h_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -686,9 +685,9 @@ private theorem det_plucker_three_term_basisVec_of_eq_p1
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
       Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p1) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
-  rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p1]
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12]
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
+  rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p1,
+    Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
+    Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
   ring
 
 private theorem det_plucker_three_term_basisVec_of_eq_p2
@@ -702,9 +701,8 @@ private theorem det_plucker_three_term_basisVec_of_eq_p2
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
       Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p2) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12]
-  rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p2]
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
+  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12,
+    Hex.Matrix.mDet_unit_eq_zero_of_eq B p2, Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
   have hrow :
       (⟨p2.val, by have := p3.isLt; omega⟩ : Fin (n + 2)) =
         (⟨p2.val - 1 + 1, by have := p3.isLt; omega⟩ : Fin (n + 2)) := by
@@ -727,9 +725,8 @@ private theorem det_plucker_three_term_basisVec_of_eq_p3
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
       Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p3) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23)]
-  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23]
-  rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p3]
+  rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
+    Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, Hex.Matrix.mDet_unit_eq_zero_of_eq B p3]
   ring
 
 private theorem foldl_det_sum_congr {R : Type u} [Add R] {β : Type v}
@@ -812,9 +809,8 @@ private theorem det_plucker_three_term_of_basisVec
     Hex.Matrix.mDet B v p1 * Hex.Matrix.nDet B p2 p3 h23 -
       Hex.Matrix.mDet B v p2 * Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
       Hex.Matrix.mDet B v p3 * Hex.Matrix.nDet B p1 p2 h12 = 0 := by
-  rw [Hex.Matrix.mDet_eq_sum_unit B v p1]
-  rw [Hex.Matrix.mDet_eq_sum_unit B v p2]
-  rw [Hex.Matrix.mDet_eq_sum_unit B v p3]
+  rw [Hex.Matrix.mDet_eq_sum_unit B v p1, Hex.Matrix.mDet_eq_sum_unit B v p2,
+    Hex.Matrix.mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
       (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1)
       (Hex.Matrix.nDet B p2 p3 h23)]

--- a/HexDeterminantMathlib/CoreTransport.lean
+++ b/HexDeterminantMathlib/CoreTransport.lean
@@ -148,9 +148,7 @@ theorem detSign_vectorOfPerm_eq_permSign [CommRing R] (σ : Equiv.Perm (Fin n)) 
             -Hex.Matrix.detSign (R := R) (Vector.ofFn fun r : Fin n => σ r) := by
         rw [hflip]
         simp
-      rw [hswapped]
-      rw [Equiv.Perm.sign_mul, Equiv.Perm.sign_swap hne]
-      rw [ih]
+      rw [hswapped, Equiv.Perm.sign_mul, Equiv.Perm.sign_swap hne, ih]
       norm_num
 
 /-- Hex's inversion-count determinant sign agrees with Mathlib's permutation sign. -/
@@ -217,8 +215,7 @@ private theorem foldl_prod_finRange {S : Type u} [CommMonoid S] {n : Nat}
     (List.finRange n).foldl (fun acc i => acc * f i) 1 = ∏ i, f i := by
   rw [foldl_prod_map_start]
   simp only [one_mul]
-  rw [← List.prod_toFinset f (List.nodup_finRange n)]
-  rw [List.toFinset_finRange]
+  rw [← List.prod_toFinset f (List.nodup_finRange n), List.toFinset_finRange]
 
 private theorem prod_perm_inv [CommRing R] (A : Matrix (Fin n) (Fin n) R)
     (σ : Equiv.Perm (Fin n)) :
@@ -281,16 +278,14 @@ theorem det_eq [CommRing R] (M : Hex.Matrix R n n) :
             rw [foldl_prod_finRange]
             simp [PermutationVector.toPerm_apply]
       _ = ((PermutationVector.equivs n).map term).sum := by
-            rw [PermutationVector.equivs]
-            rw [List.map_map]
+            rw [PermutationVector.equivs, List.map_map]
             apply congrArg List.sum
             apply List.map_congr_left
             intro p hp
             rfl
       _ = (PermutationVector.equivs n).toFinset.sum term := by
             exact (List.sum_toFinset term (PermutationVector.equivs_nodup n)).symm
-  rw [hhex, det_apply_row]
-  rw [equivs_toFinset]
+  rw [hhex, det_apply_row, equivs_toFinset]
 
 /-- `matrixEquiv` sends Hex leading prefixes to Mathlib submatrices. -/
 theorem matrixEquiv_principalSubmatrix
@@ -388,8 +383,7 @@ private theorem matrixEquiv_deleteRowCol_zero_zero_last_last
       (matrixEquiv M).submatrix
         (Fin.succAbove 0 ∘ (Fin.last n).succAbove)
         (Fin.succAbove 0 ∘ (Fin.last n).succAbove) := by
-  rw [matrixEquiv_deleteRowCol]
-  rw [matrixEquiv_deleteRowCol_zero_zero]
+  rw [matrixEquiv_deleteRowCol, matrixEquiv_deleteRowCol_zero_zero]
   ext i j
   rfl
 
@@ -528,8 +522,7 @@ private theorem mathlib_det_mul_adjugate_updateRow_of_ne
     simp [adjN, adjA, N, Matrix.adjugate_apply]
   have hNr :
       (N * adjA) r s = (A.updateRow s rowv).det := by
-    rw [Matrix.mul_apply]
-    rw [Matrix.det_eq_sum_mul_adjugate_row (A.updateRow s rowv) s]
+    rw [Matrix.mul_apply, Matrix.det_eq_sum_mul_adjugate_row (A.updateRow s rowv) s]
     apply Finset.sum_congr rfl
     intro k _hk
     simp [N, adjA, Matrix.adjugate_apply]
@@ -1329,8 +1322,8 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
       have hv : (σ i).val = r.val := congrArg Fin.val he
       rw [hr_val, hσ_val] at hv
       omega
-    rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r]
-    rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+    rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
+      Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
     apply B_entry_congr
     apply Fin.ext
     by_cases hi1 : i.val < p1.val
@@ -1352,8 +1345,8 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
         have hv : (σ i).val = r.val := congrArg Fin.val he
         rw [hr_val, hσ_val] at hv
         omega
-      rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r]
-      rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+      rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
+        Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
       apply B_entry_congr
       apply Fin.ext
       have hi_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -1373,8 +1366,7 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
           rw [hσ_val, hr_val, ha_val]
         have hrow : (Hex.Matrix.setRow M r B[q])[σ i] = B[q] := by
           simpa [hσ_eq_r] using Hex.Matrix.setRow_get_self M r B[q]
-        rw [hrow]
-        rw [Hex.Matrix.nMatrix_entry]
+        rw [hrow, Hex.Matrix.nMatrix_entry]
         apply B_entry_congr
         apply Fin.ext
         have hi_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -1389,8 +1381,8 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
           have hv : (σ i).val = r.val := congrArg Fin.val he
           rw [hr_val, hσ_val] at hv
           omega
-        rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r]
-        rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+        rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
+          Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
         apply B_entry_congr
         apply Fin.ext
         have hi_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -1441,8 +1433,7 @@ private theorem det_setRow_q
     rw [h_cast]
   have hsign_sq : (-1 : R) ^ m * ((-1 : R) ^ m * Hex.Matrix.det (Hex.Matrix.setRow M r B[q])) =
       Hex.Matrix.det (Hex.Matrix.setRow M r B[q]) := by
-    rw [← mul_assoc]
-    rw [← pow_add]
+    rw [← mul_assoc, ← pow_add]
     have h_even : m + m = 2 * m := by omega
     rw [h_even, pow_mul]
     simp

--- a/HexDeterminantMathlib/DesnanotJacobi.lean
+++ b/HexDeterminantMathlib/DesnanotJacobi.lean
@@ -145,8 +145,8 @@ private lemma det_aux_adjugate_m_eq (M : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
   have h_M'_expand : (auxAdjugateM M).det =
       auxAdjugateM M 0 0 * M'11.det + (-1 : R) ^ (n + 1) *
       auxAdjugateM M 0 (Fin.last (n + 1)) * M'1n.det := by
-    rw [Matrix.det_succ_row (auxAdjugateM M) 0, Fin.sum_univ_succ]
-    rw [Finset.sum_eq_single (Fin.last n)]
+    rw [Matrix.det_succ_row (auxAdjugateM M) 0, Fin.sum_univ_succ,
+      Finset.sum_eq_single (Fin.last n)]
     · simp [M'11, M'1n, f0, fn]
     · intro b _ hb
       have h1 : (b.succ : Fin (n + 2)) ≠ 0 := Fin.succ_ne_zero b
@@ -189,8 +189,8 @@ private lemma det_aux_adjugate_m_eq (M : Matrix (Fin (n + 2)) (Fin (n + 2)) R) :
         simp [submatrix_apply, M'1n, auxAdjugateM,
             f0, fn, Fin.succAbove_zero, Fin.succAbove_last, Fin.succ_last, hr]
     · simp
-  rw [h_M'00, h_M'11_det, h_M'0n, h_M'1n]
-  rw [mul_neg, ← mul_assoc, ← mul_pow, neg_mul_neg, one_mul, one_pow]
+  rw [h_M'00, h_M'11_det, h_M'0n, h_M'1n,
+    mul_neg, ← mul_assoc, ← mul_pow, neg_mul_neg, one_mul, one_pow]
   ring
 
 private theorem det_desnanot_jacobi_mul

--- a/HexGF2/Basic.lean
+++ b/HexGF2/Basic.lean
@@ -285,8 +285,7 @@ bit agrees with `Nat.testBit`. This is the bridge used by the word-bit
 inspection lemmas that compare packed `UInt64` bits with natural-bit facts. -/
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by
-  rw [Nat.testBit_eq_decide_div_mod_eq]
-  rw [Nat.shiftRight_eq_div_pow]
+  rw [Nat.testBit_eq_decide_div_mod_eq, Nat.shiftRight_eq_div_pow]
   apply decide_eq_decide.mpr
   exact Iff.rfl
 
@@ -339,13 +338,10 @@ private theorem UInt64.bit_xor_bne (a b : UInt64) (i : Nat) :
     ((((a ^^^ b) >>> i.toUInt64) &&& 1) != 0) =
       ((((a >>> i.toUInt64) &&& 1) != 0) !=
         (((b >>> i.toUInt64) &&& 1) != 0)) := by
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero, UInt64.bne_zero_eq_toNat_bne_zero,
+    UInt64.bne_zero_eq_toNat_bne_zero]
   simp [UInt64.toNat_xor, UInt64.toNat_shiftRight, UInt64.toNat_and]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit, bit_eq_one_eq_testBit, bit_eq_one_eq_testBit]
   simp [Nat.testBit_xor]
 
 /-- In the high-bit branch of a shifted word with carry, where `old + shift <
@@ -358,13 +354,11 @@ private theorem UInt64.shiftLeft_or_carry_high_bit
     (((((w <<< shift.toUInt64) ||| (prev >>> (64 - shift).toUInt64)) >>>
           (old + shift).toUInt64) &&& 1) != 0) =
       ((((w >>> old.toUInt64) &&& 1) != 0)) := by
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero, UInt64.bne_zero_eq_toNat_bne_zero]
   simp [UInt64.toNat_or, UInt64.toNat_shiftLeft, UInt64.toNat_shiftRight,
     UInt64.toNat_and, Nat.mod_eq_of_lt hshift, Nat.mod_eq_of_lt hold,
     Nat.mod_eq_of_lt htarget]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit, bit_eq_one_eq_testBit]
   simp [Nat.testBit_or, Nat.testBit_shiftRight]
   have hprev :
       (prev.toNat >>> (64 - shift)).testBit (old + shift) = false := by
@@ -402,13 +396,11 @@ private theorem UInt64.shiftLeft_or_carry_low_bit
       ((((prev >>> old.toUInt64) &&& 1) != 0)) := by
   have htargetLt : old + shift - 64 < 64 := by omega
   have htargetShift : old + shift - 64 < shift := by omega
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero, UInt64.bne_zero_eq_toNat_bne_zero]
   simp [UInt64.toNat_or, UInt64.toNat_shiftLeft, UInt64.toNat_shiftRight,
     UInt64.toNat_and, Nat.mod_eq_of_lt hshift, Nat.mod_eq_of_lt hold,
     Nat.mod_eq_of_lt htargetLt]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit, bit_eq_one_eq_testBit]
   simp [Nat.testBit_or, Nat.testBit_shiftRight]
   have hleft :
       (((w.toNat <<< shift) % 18446744073709551616).testBit (old + shift - 64)) =
@@ -752,8 +744,7 @@ theorem coeff_eq_true_of_degree?_eq_some {p : GF2Poly} {d : Nat}
   obtain ⟨last, bit, hback, hbit, hwordBit, hd⟩ := degree?_eq_some_high_bit h
   have hbitLt : bit < 64 := highestSetBit?_lt hbit
   have hwordIdx : d / 64 = p.words.size - 1 := by
-    rw [hd, Nat.mul_add_div (by decide : 64 > 0)]
-    rw [Nat.div_eq_of_lt hbitLt, Nat.add_zero]
+    rw [hd, Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hbitLt, Nat.add_zero]
   have hbitIdx : d % 64 = bit := by
     rw [hd, Nat.mul_add_mod]
     exact Nat.mod_eq_of_lt hbitLt
@@ -841,8 +832,7 @@ theorem wordCount_eq_of_coeff_eq {p q : GF2Poly}
     obtain ⟨_last, bit, _hback, hbit, hdEq⟩ := degree?_eq_some_highestSetBit hd
     have hbitLt : bit < 64 := highestSetBit?_lt hbit
     have hdword : d / 64 = q.words.size - 1 := by
-      rw [hdEq, Nat.mul_add_div (by decide : 64 > 0)]
-      rw [Nat.div_eq_of_lt hbitLt, Nat.add_zero]
+      rw [hdEq, Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hbitLt, Nat.add_zero]
     have hpClear : p.coeff d = false := by
       apply coeff_eq_false_of_wordCount_le
       have hpSize : p.words.size < q.words.size := by
@@ -863,8 +853,7 @@ theorem wordCount_eq_of_coeff_eq {p q : GF2Poly}
     obtain ⟨_last, bit, _hback, hbit, hdEq⟩ := degree?_eq_some_highestSetBit hd
     have hbitLt : bit < 64 := highestSetBit?_lt hbit
     have hdword : d / 64 = p.words.size - 1 := by
-      rw [hdEq, Nat.mul_add_div (by decide : 64 > 0)]
-      rw [Nat.div_eq_of_lt hbitLt, Nat.add_zero]
+      rw [hdEq, Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hbitLt, Nat.add_zero]
     have hqClear : q.coeff d = false := by
       apply coeff_eq_false_of_wordCount_le
       have hqSize : q.words.size < p.words.size := by
@@ -891,8 +880,7 @@ agree and every packed coefficient agrees. -/
     intro j
     by_cases hj : j < 64
     · have hdiv : (64 * i + j) / 64 = i := by
-        rw [Nat.mul_add_div (by decide : 64 > 0)]
-        rw [Nat.div_eq_of_lt hj, Nat.add_zero]
+        rw [Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hj, Nat.add_zero]
       have hmod : (64 * i + j) % 64 = j := by
         rw [Nat.mul_add_mod]
         exact Nat.mod_eq_of_lt hj
@@ -1475,8 +1463,7 @@ private theorem UInt64.shiftRight_high_bit_false
   apply hne
   apply UInt64.toNat_inj.mp
   simp [UInt64.toNat_shiftRight, UInt64.toNat_and, Nat.mod_eq_of_lt hbit]
-  rw [← Nat.shiftRight_add]
-  rw [Nat.shiftRight_eq_div_pow]
+  rw [← Nat.shiftRight_add, Nat.shiftRight_eq_div_pow]
   have hzero :
       w.toNat / 2 ^ ((64 - shift) % 64 + bit) = 0 := by
     apply Nat.div_eq_of_lt
@@ -1914,9 +1901,7 @@ step used by long division. -/
 theorem coeff_division_step_cancel {rem q : GF2Poly} {rd qd : Nat}
     (hrem : rem.degree? = some rd) (hq : q.degree? = some qd) (hrd : ¬ rd < qd) :
     (rem + q.mulXk (rd - qd)).coeff rd = false := by
-  rw [coeff_add_bne]
-  rw [coeff_eq_true_of_degree?_eq_some hrem]
-  rw [coeff_mulXk_division_step hq hrd]
+  rw [coeff_add_bne, coeff_eq_true_of_degree?_eq_some hrem, coeff_mulXk_division_step hq hrd]
   rfl
 
 /-- A non-terminal long-division subtraction step strictly lowers the

--- a/HexGF2/Clmul.lean
+++ b/HexGF2/Clmul.lean
@@ -200,8 +200,7 @@ private theorem oneHot_shiftRight_of_sum_ge {hot bitIdx : Nat}
   simp [UInt64.toNat_shiftLeft, UInt64.toNat_shiftRight,
     Nat.mod_eq_of_lt hhot, Nat.mod_eq_of_lt hshift, Nat.mod_eq_of_lt htarget,
     Nat.mod_eq_of_lt hpowHot, Nat.mod_eq_of_lt hpowTarget, Nat.shiftLeft_eq]
-  rw [hexp, Nat.pow_add]
-  rw [Nat.shiftRight_eq_div_pow]
+  rw [hexp, Nat.pow_add, Nat.shiftRight_eq_div_pow]
   have hrhs : 64 - bitIdx + (hot + bitIdx - 64) + bitIdx - 64 =
       hot + bitIdx - 64 := by
     omega
@@ -316,8 +315,8 @@ private theorem foldl_oneHot_list (a : UInt64) {hot : Nat} (hhot : hot < 64) :
       · subst bitIdx
         have hnotTail : hot ∉ xs := by
           exact (List.nodup_cons.mp hnodup).1
-        rw [List.foldl_cons, clmulOneHotStep_self a hhot]
-        rw [foldl_oneHot_absent a hhot _ xs hnotTail hltTail]
+        rw [List.foldl_cons, clmulOneHotStep_self a hhot,
+          foldl_oneHot_absent a hhot _ xs hnotTail hltTail]
         simp
       · have hstep :
             clmulOneHotStep a hot (0, 0) bitIdx = (0, 0) :=
@@ -726,8 +725,7 @@ private theorem foldl_clmulLeftBitFoldStep_eq_right (bits : List Nat) (w y : UIn
       have htail : ∀ bit ∈ bits, bit < 64 := by
         intro bit hmem
         exact hlt bit (by simp [hmem])
-      rw [List.foldl_cons, List.foldl_cons]
-      rw [clmulLeftBitFoldStep_eq_right w y hbit acc]
+      rw [List.foldl_cons, List.foldl_cons, clmulLeftBitFoldStep_eq_right w y hbit acc]
       exact ih htail _
 
 /-- The left one-hot fold pulls its starting accumulator out as a leading XOR:
@@ -744,9 +742,9 @@ private theorem foldl_clmulLeftBitFoldStep_acc (bits : List Nat) (w y : UInt64)
       simp only [List.foldl_cons]
       by_cases hbit : (((w >>> bit.toUInt64) &&& 1) != 0)
       · simp [clmulLeftBitFoldStep, hbit]
-        rw [ih (xorPair acc (clmul ((1 : UInt64) <<< bit.toUInt64) y))]
-        rw [ih (xorPair (0, 0) (clmul ((1 : UInt64) <<< bit.toUInt64) y))]
-        rw [xorPair_zero_left, xorPair_assoc]
+        rw [ih (xorPair acc (clmul ((1 : UInt64) <<< bit.toUInt64) y)),
+          ih (xorPair (0, 0) (clmul ((1 : UInt64) <<< bit.toUInt64) y)),
+          xorPair_zero_left, xorPair_assoc]
       · simp [clmulLeftBitFoldStep, hbit]
         exact ih acc
 
@@ -772,8 +770,7 @@ private theorem clmul_wordBitFold_left_eq_bits_acc (bits : List Nat) (w y seed :
         rw [ih (seed ^^^ ((1 : UInt64) <<< bit.toUInt64)) htail]
         rw [foldl_clmulLeftBitFoldStep_acc bits w y
           (xorPair (0, 0) (clmul ((1 : UInt64) <<< bit.toUInt64) y))]
-        rw [clmul_xor_left]
-        rw [xorPair_zero_left]
+        rw [clmul_xor_left, xorPair_zero_left]
         simpa [xorPair] using
           xorPair_assoc (clmul seed y) (clmul ((1 : UInt64) <<< bit.toUInt64) y)
             (bits.foldl (clmulLeftBitFoldStep w y) (0, 0))
@@ -889,7 +886,6 @@ theorem pureClmul_xor_right (x y z : UInt64) :
     pureClmul x (y ^^^ z) =
       ((pureClmul x y).1 ^^^ (pureClmul x z).1,
         (pureClmul x y).2 ^^^ (pureClmul x z).2) := by
-  rw [← clmul_eq_pureClmul, clmul_xor_right]
-  rw [clmul_eq_pureClmul, clmul_eq_pureClmul]
+  rw [← clmul_eq_pureClmul, clmul_xor_right, clmul_eq_pureClmul, clmul_eq_pureClmul]
 
 end Hex

--- a/HexGF2/Euclid.lean
+++ b/HexGF2/Euclid.lean
@@ -619,8 +619,7 @@ private theorem nonzero_degree_zero_eq_one {p : GF2Poly}
   | zero =>
       rw [coeff_eq_true_of_degree?_eq_some hd, coeff_monomial_self]
   | succ n =>
-      rw [coeff_eq_false_of_degree?_lt hd (by omega)]
-      rw [coeff_monomial_ne (by omega)]
+      rw [coeff_eq_false_of_degree?_lt hd (by omega), coeff_monomial_ne (by omega)]
 
 /-- A nonzero divisor of a nonzero packed polynomial has degree no larger than
 the dividend. -/
@@ -685,8 +684,7 @@ private theorem lowerMask_toNat_of_lt_64 {n : Nat} (hn64 : n < 64) :
   have hle : (1 : UInt64) ≤ ((1 : UInt64) <<< n.toUInt64) := by
     rw [UInt64.le_iff_toNat_le, hshift]
     exact Nat.one_le_two_pow
-  rw [if_pos hn64]
-  rw [UInt64.toNat_sub_of_le _ _ hle, hshift]
+  rw [if_pos hn64, UInt64.toNat_sub_of_le _ _ hle, hshift]
   simp
 
 /-- Masking a word whose value is already `< 2 ^ n` with `lowerMask n` returns
@@ -1089,8 +1087,7 @@ theorem xgcd_left_mul_mod_eq_one_of_irreducible_of_nonzero_reduced {a f : GF2Pol
         exact False.elim (ha (eq_zero_of_isZero hzero))
     | inr hlt =>
         omega
-  rw [xgcd_left_mul_mod_eq_gcd_mod]
-  rw [gcd_eq_one_of_irreducible_of_nonzero_reduced hf ha hred]
+  rw [xgcd_left_mul_mod_eq_gcd_mod, gcd_eq_one_of_irreducible_of_nonzero_reduced hf ha hred]
   exact one_mod_eq_one_of_degree_pos hfdegree
 
 /-- Reducing the xgcd left coefficient before multiplying preserves the

--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -1130,8 +1130,7 @@ theorem reducePoly_add_eq (p q : GF2Poly) :
       reducePoly (f := f) (hirr := hirr)
         ((reducePoly (f := f) (hirr := hirr) p).val +
           (reducePoly (f := f) (hirr := hirr) q).val) := by
-  rw [reducePoly_eq_iff_mod_eq]
-  rw [reducePoly_val_eq_mod, reducePoly_val_eq_mod]
+  rw [reducePoly_eq_iff_mod_eq, reducePoly_val_eq_mod, reducePoly_val_eq_mod]
   exact (mod_add_mod_eq_mod_add p q f).symm
 
 /-- Negation is the identity in characteristic two. -/
@@ -1170,8 +1169,7 @@ theorem reducePoly_mul_eq (p q : GF2Poly) :
       reducePoly (f := f) (hirr := hirr)
         ((reducePoly (f := f) (hirr := hirr) p).val *
           (reducePoly (f := f) (hirr := hirr) q).val) := by
-  rw [reducePoly_eq_iff_mod_eq]
-  rw [reducePoly_val_eq_mod, reducePoly_val_eq_mod]
+  rw [reducePoly_eq_iff_mod_eq, reducePoly_val_eq_mod, reducePoly_val_eq_mod]
   exact (mod_mul_mod_eq_mod_mul p q f).symm
 
 /-- Natural power in the packed quotient field by repeated squaring. -/
@@ -1413,11 +1411,8 @@ theorem add_assoc (a b c : GF2nPoly f hirr) :
 private theorem add_pair_swap_quot
     (a b c d : GF2nPoly f hirr) :
     (a + b) + (c + d) = (a + c) + (b + d) := by
-  rw [add_assoc a b (c + d)]
-  rw [← add_assoc b c d]
-  rw [add_comm b c]
-  rw [add_assoc c b d]
-  rw [← add_assoc a c (b + d)]
+  rw [add_assoc a b (c + d), ← add_assoc b c d, add_comm b c, add_assoc c b d,
+    ← add_assoc a c (b + d)]
 
 /-- The additive identity is a left identity. -/
 @[simp, grind =] theorem zero_add (a : GF2nPoly f hirr) :
@@ -1502,8 +1497,7 @@ theorem add_sq (a b : GF2nPoly f hirr) :
     _ = (a * a + a * b) + (b * a + b * b) := by
       rw [left_distrib, left_distrib]
     _ = (a * a + b * b) + (a * b + b * a) := by
-      rw [add_comm (b * a) (b * b)]
-      rw [add_pair_swap_quot]
+      rw [add_comm (b * a) (b * b), add_pair_swap_quot]
     _ = (a * a + b * b) + (a * b + a * b) := by
       rw [mul_comm b a]
     _ = a * a + b * b := by
@@ -1776,8 +1770,7 @@ theorem frobeniusIter_reducePoly_monomial_eq_self_of_X_fixed {k : Nat}
           reducePoly (f := f) (hirr := hirr) (GF2Poly.monomial (n + 1))
               = reducePoly (f := f) (hirr := hirr)
                   (GF2Poly.monomial 1 * GF2Poly.monomial n) := by
-                    rw [GF2Poly.monomial_mul_monomial]
-                    rw [Nat.add_comm]
+                    rw [GF2Poly.monomial_mul_monomial, Nat.add_comm]
           _ = reducePoly (f := f) (hirr := hirr)
                 ((reducePoly (f := f) (hirr := hirr) (GF2Poly.monomial 1)).val *
                   (reducePoly (f := f) (hirr := hirr) (GF2Poly.monomial n)).val) := by
@@ -2300,8 +2293,7 @@ theorem frobeniusIter_eq_linearPow_two_pow (a : GF2nPoly f hirr) (k : Nat) :
         _ = linearPow a (2 ^ k + 2 ^ k) := by
               rw [linearPow_add]
         _ = linearPow a (2 ^ (k + 1)) := by
-              rw [Nat.pow_succ]
-              rw [show 2 ^ k + 2 ^ k = 2 ^ k * 2 by omega]
+              rw [Nat.pow_succ, show 2 ^ k + 2 ^ k = 2 ^ k * 2 by omega]
 
 end Internal
 

--- a/HexGF2/Irreducibility.lean
+++ b/HexGF2/Irreducibility.lean
@@ -454,8 +454,7 @@ theorem checkIrreducibilityCertificate_rabinTest
     have hxpow_eq : xpow2kMod f cert.n = monomial 1 % f := by
       have hsome := hdividesWitness
       exact Option.some.inj hsome
-    rw [← hn]
-    rw [hxpow_eq]
+    rw [← hn, hxpow_eq]
     -- Goal: (monomial 1 % f + monomial 1 % f).isZero = true
     have hself : monomial 1 % f + monomial 1 % f = 0 := by simp
     rw [hself]
@@ -524,8 +523,7 @@ theorem checkIrreducibilityCertificateLinear_rabinTest
     have hxpow_eq : xpow2kMod f cert.n = monomial 1 % f := by
       have hsome := hdividesWitness
       exact Option.some.inj hsome
-    rw [← hn]
-    rw [hxpow_eq]
+    rw [← hn, hxpow_eq]
     have hself : monomial 1 % f + monomial 1 % f = 0 := by simp
     rw [hself]
     exact (isZero_of_eq_zero rfl)

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -61,8 +61,7 @@ private theorem foldl_mulWords_size (is : List Nat) (acc : Array UInt64)
 /-- `bit_eq_one_eq_testBit` identifies the shifted low-bit test with `Nat.testBit`. -/
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by
-  rw [Nat.testBit_eq_decide_div_mod_eq]
-  rw [Nat.shiftRight_eq_div_pow]
+  rw [Nat.testBit_eq_decide_div_mod_eq, Nat.shiftRight_eq_div_pow]
   apply decide_eq_decide.mpr
   exact Iff.rfl
 
@@ -71,13 +70,10 @@ private theorem UInt64.bit_xor_bne (a b : UInt64) (i : Nat) :
     ((((a ^^^ b) >>> i.toUInt64) &&& 1) != 0) =
       ((((a >>> i.toUInt64) &&& 1) != 0) !=
         (((b >>> i.toUInt64) &&& 1) != 0)) := by
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
-  rw [UInt64.bne_zero_eq_toNat_bne_zero]
+  rw [UInt64.bne_zero_eq_toNat_bne_zero, UInt64.bne_zero_eq_toNat_bne_zero,
+    UInt64.bne_zero_eq_toNat_bne_zero]
   simp [UInt64.toNat_xor, UInt64.toNat_shiftRight, UInt64.toNat_and]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
-  rw [bit_eq_one_eq_testBit]
+  rw [bit_eq_one_eq_testBit, bit_eq_one_eq_testBit, bit_eq_one_eq_testBit]
   simp [Nat.testBit_xor]
 
 /-- `clmul_xor_left_snd_bit` gives bitwise linearity in the left input for the low word of `clmul`. -/
@@ -101,9 +97,7 @@ private theorem clmul_xor_right_snd_bit (x y z : UInt64) (i : Nat) :
     ((((clmul x (y ^^^ z)).2 >>> i.toUInt64) &&& 1) != 0) =
       (((((clmul x y).2 >>> i.toUInt64) &&& 1) != 0) !=
         ((((clmul x z).2 >>> i.toUInt64) &&& 1) != 0)) := by
-  rw [clmul_comm x (y ^^^ z)]
-  rw [clmul_xor_left]
-  rw [clmul_comm y x, clmul_comm z x]
+  rw [clmul_comm x (y ^^^ z), clmul_xor_left, clmul_comm y x, clmul_comm z x]
   exact UInt64.bit_xor_bne (clmul x y).2 (clmul x z).2 i
 
 /-- `clmul_xor_right_fst_bit` gives bitwise linearity in the right input for the high word of `clmul`. -/
@@ -111,9 +105,7 @@ private theorem clmul_xor_right_fst_bit (x y z : UInt64) (i : Nat) :
     ((((clmul x (y ^^^ z)).1 >>> i.toUInt64) &&& 1) != 0) =
       (((((clmul x y).1 >>> i.toUInt64) &&& 1) != 0) !=
         ((((clmul x z).1 >>> i.toUInt64) &&& 1) != 0)) := by
-  rw [clmul_comm x (y ^^^ z)]
-  rw [clmul_xor_left]
-  rw [clmul_comm y x, clmul_comm z x]
+  rw [clmul_comm x (y ^^^ z), clmul_xor_left, clmul_comm y x, clmul_comm z x]
   exact UInt64.bit_xor_bne (clmul x y).1 (clmul x z).1 i
 
 /-- `coeffWords_xorClmulAt_low` describes the low-word contribution of one `xorClmulAt` update. -/
@@ -147,9 +139,8 @@ private theorem coeffWords_xorClmulAt_low_xor_left (acc : Array UInt64) {idx n :
     coeffWords (xorClmulAt acc idx (x ^^^ y) z) n =
       (coeffWords (xorClmulAt acc idx x z) n !=
         ((((clmul y z).2 >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [coeffWords_xorClmulAt_low acc (x ^^^ y) z hidx hn]
-  rw [coeffWords_xorClmulAt_low acc x z hidx hn]
-  rw [clmul_xor_left_snd_bit]
+  rw [coeffWords_xorClmulAt_low acc (x ^^^ y) z hidx hn, coeffWords_xorClmulAt_low acc x z hidx hn,
+    clmul_xor_left_snd_bit]
   cases coeffWords acc n <;>
     cases ((((clmul x z).2 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
     cases ((((clmul y z).2 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
@@ -162,9 +153,8 @@ private theorem coeffWords_xorClmulAt_high_xor_left (acc : Array UInt64) {idx n 
     coeffWords (xorClmulAt acc idx (x ^^^ y) z) n =
       (coeffWords (xorClmulAt acc idx x z) n !=
         ((((clmul y z).1 >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [coeffWords_xorClmulAt_high acc (x ^^^ y) z hidx hidxNext hn]
-  rw [coeffWords_xorClmulAt_high acc x z hidx hidxNext hn]
-  rw [clmul_xor_left_fst_bit]
+  rw [coeffWords_xorClmulAt_high acc (x ^^^ y) z hidx hidxNext hn,
+    coeffWords_xorClmulAt_high acc x z hidx hidxNext hn, clmul_xor_left_fst_bit]
   cases coeffWords acc n <;>
     cases ((((clmul x z).1 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
     cases ((((clmul y z).1 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
@@ -311,8 +301,7 @@ private theorem coeffWords_xorClmulAt_oneHot_low_same_word
     omega
   rw [coeffWords_xorClmulAt_low acc x ((1 : UInt64) <<< shift.toUInt64) hidx
     htargetDiv]
-  rw [htargetMod]
-  rw [clmul_oneHot_low_bit_same_word x hshiftPos hshift hold hbit]
+  rw [htargetMod, clmul_oneHot_low_bit_same_word x hshiftPos hshift hold hbit]
 
 /-- `coeffWords_xorClmulAt_oneHot_low_before_shift` says coefficients below the one-hot shift are left unchanged. -/
 private theorem coeffWords_xorClmulAt_oneHot_low_before_shift
@@ -321,8 +310,8 @@ private theorem coeffWords_xorClmulAt_oneHot_low_before_shift
     (hn : target / 64 = idx) (hbit : target % 64 < shift) :
     coeffWords (xorClmulAt acc idx x ((1 : UInt64) <<< shift.toUInt64)) target =
       coeffWords acc target := by
-  rw [coeffWords_xorClmulAt_low acc x ((1 : UInt64) <<< shift.toUInt64) hidx hn]
-  rw [clmul_oneHot_low_bit_before_shift_false x hshiftPos hshift hbit]
+  rw [coeffWords_xorClmulAt_low acc x ((1 : UInt64) <<< shift.toUInt64) hidx hn,
+    clmul_oneHot_low_bit_before_shift_false x hshiftPos hshift hbit]
   simp
 
 /-- `coeffWords_xorClmulAt_oneHot_high_carry_word` says a one-hot right factor XORs the shifted source bit into the target coefficient when the shift carries it into the high word. -/
@@ -343,8 +332,7 @@ private theorem coeffWords_xorClmulAt_oneHot_high_carry_word
     omega
   rw [coeffWords_xorClmulAt_high acc x ((1 : UInt64) <<< shift.toUInt64) hidx
     hidxNext htargetDiv]
-  rw [htargetMod]
-  rw [clmul_oneHot_high_bit_carry_word x hshiftPos hshift hold hbit]
+  rw [htargetMod, clmul_oneHot_high_bit_carry_word x hshiftPos hshift hold hbit]
 
 /-- `coeffWords_xorClmulAt_oneHot_high_after_carry` says high-word coefficients at or beyond the shift window are left unchanged. -/
 private theorem coeffWords_xorClmulAt_oneHot_high_after_carry
@@ -453,8 +441,7 @@ private theorem coeffWords_xorClmulAt_oneHot_left_low_same_word
     omega
   rw [coeffWords_xorClmulAt_low acc ((1 : UInt64) <<< shift.toUInt64) x hidx
     htargetDiv]
-  rw [htargetMod]
-  rw [clmul_oneHot_left_low_bit_same_word x hshiftPos hshift hold hbit]
+  rw [htargetMod, clmul_oneHot_left_low_bit_same_word x hshiftPos hshift hold hbit]
 
 /-- `coeffWords_xorClmulAt_oneHot_left_low_before_shift` says coefficients below the one-hot shift are left unchanged for a left one-hot factor. -/
 private theorem coeffWords_xorClmulAt_oneHot_left_low_before_shift
@@ -463,8 +450,8 @@ private theorem coeffWords_xorClmulAt_oneHot_left_low_before_shift
     (hn : target / 64 = idx) (hbit : target % 64 < shift) :
     coeffWords (xorClmulAt acc idx ((1 : UInt64) <<< shift.toUInt64) x) target =
       coeffWords acc target := by
-  rw [coeffWords_xorClmulAt_low acc ((1 : UInt64) <<< shift.toUInt64) x hidx hn]
-  rw [clmul_oneHot_left_low_bit_before_shift_false x hshiftPos hshift hbit]
+  rw [coeffWords_xorClmulAt_low acc ((1 : UInt64) <<< shift.toUInt64) x hidx hn,
+    clmul_oneHot_left_low_bit_before_shift_false x hshiftPos hshift hbit]
   simp
 
 /-- `coeffWords_xorClmulAt_oneHot_left_high_carry_word` says a one-hot left factor XORs the shifted source bit into the target coefficient when the shift carries it into the high word. -/
@@ -485,8 +472,7 @@ private theorem coeffWords_xorClmulAt_oneHot_left_high_carry_word
     omega
   rw [coeffWords_xorClmulAt_high acc ((1 : UInt64) <<< shift.toUInt64) x hidx
     hidxNext htargetDiv]
-  rw [htargetMod]
-  rw [clmul_oneHot_left_high_bit_carry_word x hshiftPos hshift hold hbit]
+  rw [htargetMod, clmul_oneHot_left_high_bit_carry_word x hshiftPos hshift hold hbit]
 
 /-- `coeffWords_xorClmulAt_oneHot_left_high_after_carry` says high-word coefficients at or beyond the shift window are left unchanged for a left one-hot factor. -/
 private theorem coeffWords_xorClmulAt_oneHot_left_high_after_carry
@@ -506,8 +492,7 @@ private theorem coeffWords_xorClmulAt_oneHot_left_high_after_carry
 private theorem words_monomial_getElem!_active (k : Nat) :
     (monomial k).words[k / 64]! =
       ((1 : UInt64) <<< (k % 64).toUInt64) := by
-  rw [words_monomial]
-  rw [Array.getElem!_eq_getD]
+  rw [words_monomial, Array.getElem!_eq_getD]
   unfold Array.getD
   rw [dif_pos (by simp)]
   change ((Array.replicate (k / 64) (0 : UInt64)).push
@@ -519,8 +504,7 @@ private theorem words_monomial_getElem!_active (k : Nat) :
 /-- `words_monomial_getElem!_zero_lt` says every word of `monomial k` below the active index `k / 64` is zero. -/
 private theorem words_monomial_getElem!_zero_lt {j k : Nat} (hj : j < k / 64) :
     (monomial k).words[j]! = 0 := by
-  rw [words_monomial]
-  rw [Array.getElem!_eq_getD]
+  rw [words_monomial, Array.getElem!_eq_getD]
   unfold Array.getD
   rw [dif_pos]
   · simp [Array.getElem_push, hj]
@@ -698,8 +682,7 @@ private theorem foldl_xorClmulAt_monomial_active_low
         (n + k) =
       (coeffWords acc (n + k) !=
         (((x >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_monomial_active_low
     (hidx := by simpa [foldl_xorClmulAt_size] using hidx)
@@ -718,8 +701,7 @@ private theorem foldl_xorClmulAt_monomial_active_zero
         (n + k) =
       (coeffWords acc (n + k) !=
         (((x >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_monomial_active_zero
     (hidx := by simpa [foldl_xorClmulAt_size] using hidx)
@@ -737,8 +719,7 @@ private theorem foldl_xorClmulAt_monomial_active_low_before_shift
           acc)
         target =
       coeffWords acc target := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_monomial_active_low_before_shift
     (hidx := by simpa [foldl_xorClmulAt_size] using hidx)
@@ -757,8 +738,7 @@ private theorem foldl_xorClmulAt_monomial_active_high
         (n + k) =
       (coeffWords acc (n + k) !=
         (((x >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_monomial_active_high
     (hidx := by simpa [foldl_xorClmulAt_size] using hidx)
@@ -777,8 +757,7 @@ private theorem foldl_xorClmulAt_monomial_active_high_after_carry
           acc)
         target =
       coeffWords acc target := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_monomial_active_high_after_carry
     (hidx := by simpa [foldl_xorClmulAt_size] using hidx)
@@ -797,8 +776,7 @@ private theorem foldl_xorClmulAt_monomial_ne
           acc)
         target =
       coeffWords acc target := by
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show k / 64 + 1 = (k / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [coeffWords_xorClmulAt_ne
     (hnLow := hLow) (hnHigh := hHigh)]
@@ -826,9 +804,8 @@ private theorem coeffWords_xorClmulAt_xor_left
         coeffWords (xorClmulAt accY idx y z) n) := by
   by_cases hLow : n / 64 = idx
   · rw [coeffWords_xorClmulAt_low accXY (x ^^^ y) z hidx hLow]
-    rw [coeffWords_xorClmulAt_low accX x z (by simpa [hsizeX]) hLow]
-    rw [coeffWords_xorClmulAt_low accY y z (by simpa [hsizeY]) hLow]
-    rw [clmul_xor_left_snd_bit, hacc]
+    rw [coeffWords_xorClmulAt_low accX x z (by simpa [hsizeX]) hLow,
+      coeffWords_xorClmulAt_low accY y z (by simpa [hsizeY]) hLow, clmul_xor_left_snd_bit, hacc]
     cases coeffWords accX n <;>
       cases coeffWords accY n <;>
       cases ((((clmul x z).2 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
@@ -847,8 +824,8 @@ private theorem coeffWords_xorClmulAt_xor_left
         cases ((((clmul y z).1 >>> (n % 64).toUInt64) &&& 1) != 0) <;>
         rfl
     · rw [coeffWords_xorClmulAt_ne accXY (x ^^^ y) z hLow hHigh]
-      rw [coeffWords_xorClmulAt_ne accX x z hLow hHigh]
-      rw [coeffWords_xorClmulAt_ne accY y z hLow hHigh]
+      rw [coeffWords_xorClmulAt_ne accX x z hLow hHigh,
+        coeffWords_xorClmulAt_ne accY y z hLow hHigh]
       exact hacc
 
 /-- `foldl_xorClmulAt_xor_left_coeff` lifts left-factor xor-distributivity across the inner `xorClmulAt` fold over a list of word indices. -/
@@ -972,12 +949,10 @@ private theorem coeffWords_xorClmulAt_congr
       coeffWords (xorClmulAt accB idx x y) n := by
   by_cases hLow : n / 64 = idx
   · rw [coeffWords_xorClmulAt_low accA x y (by omega) hLow]
-    rw [coeffWords_xorClmulAt_low accB x y (by omega) hLow]
-    rw [hacc]
+    rw [coeffWords_xorClmulAt_low accB x y (by omega) hLow, hacc]
   · by_cases hHigh : n / 64 = idx + 1
     · rw [coeffWords_xorClmulAt_high accA x y (by omega) hidxA hHigh]
-      rw [coeffWords_xorClmulAt_high accB x y (by omega) hidxB hHigh]
-      rw [hacc]
+      rw [coeffWords_xorClmulAt_high accB x y (by omega) hidxB hHigh, hacc]
     · rw [coeffWords_xorClmulAt_ne accA x y hLow hHigh]
       rw [coeffWords_xorClmulAt_ne accB x y hLow hHigh]
       exact hacc
@@ -1115,8 +1090,7 @@ private theorem foldl_xorClmulAt_zero_left_coeff (js : List Nat) (acc : Array UI
 private theorem getElem!_eq_zero_of_size_le (xs : Array UInt64) {i : Nat}
     (hi : xs.size ≤ i) :
     xs[i]! = 0 := by
-  rw [getElem!_def]
-  rw [Array.getElem?_eq_none]
+  rw [getElem!_def, Array.getElem?_eq_none]
   · rfl
   · exact hi
 
@@ -1145,11 +1119,9 @@ private theorem foldl_mulWords_range_add_zero_left_coeff
   | zero =>
       simp
   | succ k ih =>
-      rw [show xs.size + Nat.succ k = xs.size + k + 1 by omega]
-      rw [List.range_succ, List.foldl_append]
+      rw [show xs.size + Nat.succ k = xs.size + k + 1 by omega, List.range_succ, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [getElem!_eq_zero_of_size_le xs (by omega)]
-      rw [foldl_xorClmulAt_zero_left_coeff]
+      rw [getElem!_eq_zero_of_size_le xs (by omega), foldl_xorClmulAt_zero_left_coeff]
       exact ih
 
 /-- `foldl_mulWords_range_extend_left_coeff` says running the outer `mulWords` fold over any range bound `m ≥ xs.size` gives the same coefficients as the exact `xs.size` range. -/
@@ -1535,8 +1507,7 @@ private theorem foldl_xorClmulAt_monomial_left_prefix_before_source
   | succ m ih =>
       have hm_le : m ≤ source / 64 := by omega
       have hm_lt : m < source / 64 := by omega
-      rw [show m + 1 = m.succ by omega]
-      rw [List.range_succ, List.foldl_append]
+      rw [show m + 1 = m.succ by omega, List.range_succ, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
       rw [words_monomial_size]
       by_cases hLow : (source + k) / 64 = k / 64 + m
@@ -1632,8 +1603,7 @@ private theorem foldl_xorClmulAt_monomial_left_prefix_after_source
   | succ m ih =>
       by_cases hm_active : m = source / 64
       · subst hm_active
-        rw [show source / 64 + 1 = (source / 64).succ by omega]
-        rw [List.range_succ, List.foldl_append]
+        rw [show source / 64 + 1 = (source / 64).succ by omega, List.range_succ, List.foldl_append]
         simp only [List.foldl_cons, List.foldl_nil]
         rw [words_monomial_size]
         have hprefix := foldl_xorClmulAt_monomial_left_prefix_before_source xs
@@ -1722,8 +1692,7 @@ private theorem foldl_xorClmulAt_monomial_left_prefix_after_source
             simp [coeffWords, hget]
       · have hm_tail : source / 64 + 1 ≤ m := by omega
         have hm_gt : source / 64 < m := by omega
-        rw [show m + 1 = m.succ by omega]
-        rw [List.range_succ, List.foldl_append]
+        rw [show m + 1 = m.succ by omega, List.range_succ, List.foldl_append]
         simp only [List.foldl_cons, List.foldl_nil]
         rw [words_monomial_size]
         by_cases hLow : (source + k) / 64 = k / 64 + m
@@ -1828,8 +1797,7 @@ private theorem foldl_mulWords_monomial_active_zero
             acc)
           (n + k) !=
         (((xs[n / 64]! >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show n / 64 + 1 = (n / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show n / 64 + 1 = (n / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_active_zero
@@ -1874,8 +1842,7 @@ private theorem foldl_mulWords_monomial_active_low
             acc)
           (n + k) !=
         (((xs[n / 64]! >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show n / 64 + 1 = (n / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show n / 64 + 1 = (n / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_active_low
@@ -1921,8 +1888,7 @@ private theorem foldl_mulWords_monomial_active_high
             acc)
           (n + k) !=
         (((xs[n / 64]! >>> (n % 64).toUInt64) &&& 1) != 0)) := by
-  rw [show n / 64 + 1 = (n / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show n / 64 + 1 = (n / 64).succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_active_high
@@ -1969,8 +1935,7 @@ private theorem foldl_mulWords_monomial_active_low_before_shift
               acc)
           acc)
         target := by
-  rw [show i + 1 = i.succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show i + 1 = i.succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_active_low_before_shift
@@ -2013,8 +1978,7 @@ private theorem foldl_mulWords_monomial_active_high_after_carry
               acc)
           acc)
         target := by
-  rw [show i + 1 = i.succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show i + 1 = i.succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_active_high_after_carry
@@ -2061,8 +2025,7 @@ private theorem foldl_mulWords_monomial_ne
               acc)
           acc)
         target := by
-  rw [show i + 1 = i.succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [show i + 1 = i.succ by omega, List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [words_monomial_size]
   exact foldl_xorClmulAt_monomial_ne
@@ -2385,8 +2348,7 @@ private theorem coeffWords_mulWords_monomial_lt
         · rw [Array.getElem?_eq_none]
           · rfl
           · exact Nat.le_of_not_gt h
-      rw [hword]
-      rw [UInt64.bne_zero_eq_toNat_bne_zero]
+      rw [hword, UInt64.bne_zero_eq_toNat_bne_zero]
       simp
     · intro i hi
       exact List.mem_range.mp hi
@@ -2415,8 +2377,7 @@ private theorem coeffWords_mulWords_monomial_source_oob
         · rw [Array.getElem?_eq_none]
           · rfl
           · exact Nat.le_of_not_gt h
-      rw [hword]
-      rw [UInt64.bne_zero_eq_toNat_bne_zero]
+      rw [hword, UInt64.bne_zero_eq_toNat_bne_zero]
       simp
     · intro i hi
       exact List.mem_range.mp hi
@@ -2455,8 +2416,7 @@ private theorem foldl_mulWords_monomial_prefix_before_source
   | succ m ih =>
       have hm_le : m ≤ source / 64 := by omega
       have hm_lt : m < source / 64 := by omega
-      rw [show m + 1 = m.succ by omega]
-      rw [List.range_succ, List.foldl_append]
+      rw [show m + 1 = m.succ by omega, List.range_succ, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
       rw [words_monomial_size]
       by_cases hLow : (source + k) / 64 = m + k / 64
@@ -2604,8 +2564,7 @@ private theorem foldl_mulWords_monomial_prefix_after_source
             simp [coeffWords, hget]
       · have hm_tail : source / 64 + 1 ≤ m := by omega
         have hm_gt : source / 64 < m := by omega
-        rw [show m + 1 = m.succ by omega]
-        rw [List.range_succ, List.foldl_append]
+        rw [show m + 1 = m.succ by omega, List.range_succ, List.foldl_append]
         simp only [List.foldl_cons, List.foldl_nil]
         rw [words_monomial_size]
         by_cases hLow : (source + k) / 64 = m + k / 64
@@ -2724,12 +2683,10 @@ private theorem coeffWords_monomial_mulWords_lt
   by_cases hxs : xs.isEmpty
   · simp [hmon, hxs, coeffWords]
   · simp [hmon, hxs]
-    rw [words_monomial_size]
-    rw [show k / 64 + 1 = (k / 64).succ by omega]
-    rw [List.range_succ, List.foldl_append]
+    rw [words_monomial_size, show k / 64 + 1 = (k / 64).succ by omega,
+      List.range_succ, List.foldl_append]
     simp only [List.foldl_cons, List.foldl_nil]
-    rw [foldl_mulWords_left_monomial_zero_prefix]
-    rw [foldl_xorClmulAt_monomial_left_target_lt]
+    rw [foldl_mulWords_left_monomial_zero_prefix, foldl_xorClmulAt_monomial_left_target_lt]
     · rw [coeffWords]
       have hword :
           ((Array.replicate (k / 64 + 1 + xs.size) (0 : UInt64))[target / 64]?).getD
@@ -2759,12 +2716,10 @@ private theorem coeffWords_monomial_mulWords_source_oob
   by_cases hxs : xs.isEmpty
   · simp [hmon, hxs, coeffWords]
   · simp [hmon, hxs]
-    rw [words_monomial_size]
-    rw [show k / 64 + 1 = (k / 64).succ by omega]
-    rw [List.range_succ, List.foldl_append]
+    rw [words_monomial_size, show k / 64 + 1 = (k / 64).succ by omega,
+      List.range_succ, List.foldl_append]
     simp only [List.foldl_cons, List.foldl_nil]
-    rw [foldl_mulWords_left_monomial_zero_prefix]
-    rw [foldl_xorClmulAt_monomial_left_source_oob]
+    rw [foldl_mulWords_left_monomial_zero_prefix, foldl_xorClmulAt_monomial_left_source_oob]
     · rw [coeffWords]
       have hword :
           ((Array.replicate (k / 64 + 1 + xs.size) (0 : UInt64))[(source + k) / 64]?).getD
@@ -2798,9 +2753,8 @@ private theorem coeffWords_monomial_mulWords_source
       simpa [Array.isEmpty] using hempty
     omega
   simp [hmon, hxs]
-  rw [words_monomial_size]
-  rw [show k / 64 + 1 = (k / 64).succ by omega]
-  rw [List.range_succ, List.foldl_append]
+  rw [words_monomial_size, show k / 64 + 1 = (k / 64).succ by omega,
+    List.range_succ, List.foldl_append]
   simp only [List.foldl_cons, List.foldl_nil]
   rw [foldl_mulWords_left_monomial_zero_prefix]
   simpa [words_monomial_size] using
@@ -2884,8 +2838,7 @@ private theorem List.flatMap_congr_left {α β : Type} {xs : List α} {f g : α 
       rfl
   | cons x xs ih =>
       simp only [List.flatMap_cons]
-      rw [h x (by simp)]
-      rw [ih]
+      rw [h x (by simp), ih]
       intro y hy
       exact h y (by simp [hy])
 
@@ -2900,8 +2853,7 @@ private theorem xorBoolList_flatMap_append {α : Type}
       simp [xorBoolList]
   | cons x xs ih =>
       simp only [List.flatMap_cons]
-      rw [xorBoolList_append, xorBoolList_append, xorBoolList_append, ih]
-      rw [xorBoolList_append]
+      rw [xorBoolList_append, xorBoolList_append, xorBoolList_append, ih, xorBoolList_append]
       generalize xorBoolList (left x) = a
       generalize xorBoolList (List.flatMap left xs) = b
       generalize xorBoolList (right x) = c
@@ -2928,8 +2880,7 @@ private theorem xorBoolList_wordPairs_swap
   | succ m ih =>
       rw [List.range_succ, List.flatMap_append]
       simp only [List.flatMap_cons]
-      rw [xorBoolList_append, ih]
-      rw [List.flatMap_empty_input]
+      rw [xorBoolList_append, ih, List.flatMap_empty_input]
       simp only [List.append_nil]
       have hcols :
           xorBoolList
@@ -2942,8 +2893,7 @@ private theorem xorBoolList_wordPairs_swap
                   (List.range n)) !=
               xorBoolList ((List.range n).map (fun j => term m j))) := by
         simp only [List.map_append, List.map_cons, List.map_nil]
-        rw [xorBoolList_flatMap_append]
-        rw [List.flatMap_singleton]
+        rw [xorBoolList_flatMap_append, List.flatMap_singleton]
       rw [hcols]
 
 /-- Congruence for `flatMap` under `xorBoolList`: if `left x` and `right x`
@@ -2958,8 +2908,7 @@ private theorem xorBoolList_flatMap_congr_xor {α : Type}
       rfl
   | cons x xs ih =>
       simp only [List.flatMap_cons]
-      rw [xorBoolList_append, xorBoolList_append]
-      rw [h x (by simp), ih]
+      rw [xorBoolList_append, xorBoolList_append, h x (by simp), ih]
       intro y hy
       exact h y (by simp [hy])
 
@@ -2990,8 +2939,7 @@ private theorem xorBoolList_map_bne_congr {α : Type}
       rfl
   | cons x xs ih =>
       simp only [List.map_cons]
-      rw [xorBoolList_cons, xorBoolList_cons, xorBoolList_cons]
-      rw [Bool.bne_medial, h x (by simp), ih]
+      rw [xorBoolList_cons, xorBoolList_cons, xorBoolList_cons, Bool.bne_medial, h x (by simp), ih]
       intro y hy
       exact h y (by simp [hy])
 
@@ -3009,8 +2957,8 @@ private theorem xorBoolList_flatMap_bne_congr {α : Type}
       rfl
   | cons x xs ih =>
       simp only [List.flatMap_cons]
-      rw [xorBoolList_append, xorBoolList_append, xorBoolList_append]
-      rw [Bool.bne_medial, h x (by simp), ih]
+      rw [xorBoolList_append, xorBoolList_append, xorBoolList_append,
+        Bool.bne_medial, h x (by simp), ih]
       intro y hy
       exact h y (by simp [hy])
 
@@ -3260,8 +3208,7 @@ private theorem foldl_mulWords_getElem!_contrib
         (by
           intro j hj
           exact hbound i (by simp) j hj)
-      rw [hinner]
-      rw [xorWordList_append, UInt64.xor_assoc]
+      rw [hinner, xorWordList_append, UInt64.xor_assoc]
 
 /-- Bit `n` of the carry-less word-pair product vanishes when the left
 factor word is zero; the left base case of the bilinearity ladder. -/
@@ -3423,8 +3370,7 @@ private theorem foldl_mulWords_coeff_contrib
           (by
             intro j hj
             exact hbound i (by simp) j hj)
-        rw [hinner]
-        rw [xorBoolList_append, Bool.bne_assoc]
+        rw [hinner, xorBoolList_append, Bool.bne_assoc]
       · intro i' hi' j hj
         have h := hbound i' (by simp [hi']) j hj
         simpa [foldl_xorClmulAt_size] using h
@@ -3593,8 +3539,7 @@ private theorem wordBitAt_getElem!_eq_coeff
     (p : GF2Poly) {i bit : Nat} (hbit : bit < 64) :
     wordBitAt p.words[i]! bit = p.coeff (64 * i + bit) := by
   have hdiv : (64 * i + bit) / 64 = i := by
-    rw [Nat.mul_add_div (by decide : 64 > 0)]
-    rw [Nat.div_eq_of_lt hbit, Nat.add_zero]
+    rw [Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hbit, Nat.add_zero]
   have hmod : (64 * i + bit) % 64 = bit := by
     rw [Nat.mul_add_mod]
     exact Nat.mod_eq_of_lt hbit
@@ -5456,8 +5401,7 @@ private theorem clmulAssoc_left_middle_sourceTriple
     (wordBitAt (clmul (clmul x y).2 z).1 bit !=
         wordBitAt (clmul (clmul x y).1 z).2 bit) =
       clmulSourceTripleCoeff x y z (bit + 64) := by
-  rw [clmulSourcePairCoeff_high (clmul x y).2 z hbit]
-  rw [clmulSourcePairCoeff_low (clmul x y).1 z hbit]
+  rw [clmulSourcePairCoeff_high (clmul x y).2 z hbit, clmulSourcePairCoeff_low (clmul x y).1 z hbit]
   unfold clmulSourcePairCoeff
   exact xorBoolList_left_middle_sourceTriple_collapse x y z hbit
 
@@ -6363,9 +6307,8 @@ private theorem coeffWords_mulWords_normalize_right
     (xs ys : Array UInt64) (n : Nat) :
     coeffWords (mulWords xs (normalizeWords ys)) n =
       coeffWords (mulWords xs ys) n := by
-  rw [coeffWords_mulWords_comm xs (normalizeWords ys)]
-  rw [coeffWords_mulWords_normalize_left ys xs]
-  rw [coeffWords_mulWords_comm ys xs]
+  rw [coeffWords_mulWords_comm xs (normalizeWords ys), coeffWords_mulWords_normalize_left ys xs,
+    coeffWords_mulWords_comm ys xs]
 
 private theorem coeffWords_mulWords_ofWords_left
     (xs ys zs : Array UInt64) (n : Nat) :

--- a/HexGF2/RabinSoundness.lean
+++ b/HexGF2/RabinSoundness.lean
@@ -82,8 +82,8 @@ private theorem mul_dvd_mul_left' (c : GF2Poly) {a b : GF2Poly} (h : a ∣ b) :
 /-- Char-2 freshman's dream: `(a + b) * (a + b) = a * a + b * b`. -/
 private theorem freshman_dream (a b : GF2Poly) :
     (a + b) * (a + b) = a * a + b * b := by
-  rw [right_distrib, left_distrib, left_distrib, mul_comm b a]
-  rw [add_assoc, ← add_assoc (a * b) (a * b) (b * b), add_self, zero_add]
+  rw [right_distrib, left_distrib, left_distrib, mul_comm b a,
+    add_assoc, ← add_assoc (a * b) (a * b) (b * b), add_self, zero_add]
 
 /-- The remainder added to its dividend is divisible by the divisor in
 characteristic two. -/
@@ -345,9 +345,8 @@ private theorem monomial_add_one_dvd_geom (k : Nat) :
       have heq :
           monomial (k * (n + 1)) + 1 =
             monomial k * (monomial (k * n) + 1) + (monomial k + 1) := by
-        rw [right_distrib, mul_one', monomial_mul_monomial]
-        rw [show k + k * n = k * (n + 1) from by rw [Nat.mul_succ]; omega]
-        rw [add_assoc]
+        rw [right_distrib, mul_one', monomial_mul_monomial,
+          show k + k * n = k * (n + 1) from by rw [Nat.mul_succ]; omega, add_assoc]
         congr 1
         rw [← add_assoc, add_self, zero_add]
       rw [heq]
@@ -606,9 +605,7 @@ theorem dvd_xPowSubX_iff_quotient_X_frobeniusIter_eq_X
         GF2nPoly.reducePoly (f := g) (hirr := hg_irr) (frobeniusDiffMod g k) =
           0 := by
       unfold frobeniusDiffMod
-      rw [GF2nPoly.reducePoly_add_eq]
-      rw [GF2nPoly.reducePoly_mod_eq]
-      rw [hquot']
+      rw [GF2nPoly.reducePoly_add_eq, GF2nPoly.reducePoly_mod_eq, hquot']
       change
         GF2nPoly.reducePoly (f := g) (hirr := hg_irr)
             ((GF2nPoly.reducePoly (f := g) (hirr := hg_irr) (monomial 1)).val +

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -93,8 +93,7 @@ instance : Hex.ZMod64.Bounds 2 := ⟨by decide, by decide⟩
 
 private theorem bit_eq_one_eq_testBit (x i : Nat) :
     (x >>> i % 2 == 1) = x.testBit i := by
-  rw [Nat.testBit_eq_decide_div_mod_eq]
-  rw [Nat.shiftRight_eq_div_pow]
+  rw [Nat.testBit_eq_decide_div_mod_eq, Nat.shiftRight_eq_div_pow]
   apply decide_eq_decide.mpr
   exact Iff.rfl
 
@@ -610,10 +609,9 @@ private theorem testBit_add_of_dvd_high {x y j : Nat}
 
 private theorem add_shift_testBit (x k s t : Nat) (hx : x < 2 ^ s) :
     (x + k * 2 ^ s).testBit (s + t) = k.testBit t := by
-  rw [Nat.testBit_eq_decide_div_mod_eq, Nat.testBit_eq_decide_div_mod_eq]
-  rw [Nat.pow_add, ← Nat.div_div_eq_div_mul]
-  rw [Nat.mul_comm k (2 ^ s)]
-  rw [Nat.add_mul_div_left _ _ (Nat.two_pow_pos s), Nat.div_eq_of_lt hx, Nat.zero_add]
+  rw [Nat.testBit_eq_decide_div_mod_eq, Nat.testBit_eq_decide_div_mod_eq,
+    Nat.pow_add, ← Nat.div_div_eq_div_mul, Nat.mul_comm k (2 ^ s),
+    Nat.add_mul_div_left _ _ (Nat.two_pow_pos s), Nat.div_eq_of_lt hx, Nat.zero_add]
 
 private theorem shift_testBit (k s t : Nat) :
     (k * 2 ^ s).testBit (s + t) = k.testBit t := by
@@ -623,8 +621,7 @@ private theorem testBit_add_of_lt_low {x y s t : Nat}
     (hx : x < 2 ^ s) (hy : 2 ^ s ∣ y) :
     (x + y).testBit (s + t) = y.testBit (s + t) := by
   rcases hy with ⟨k, hk⟩
-  rw [hk, Nat.mul_comm]
-  rw [add_shift_testBit x k s t hx, shift_testBit k s t]
+  rw [hk, Nat.mul_comm, add_shift_testBit x k s t hx, shift_testBit k s t]
 
 private theorem wordsToNatAux_dvd_shift :
     ∀ (ws : List UInt64) (i : Nat), 2 ^ (64 * i) ∣ wordsToNatAux ws i
@@ -685,8 +682,7 @@ private theorem wordsToNatAux_testBit_getD :
       have htargetLow :
           64 * (i + (wordIdx + 1)) + bitIdx =
             64 * (i + 1) + (64 * wordIdx + bitIdx) := by omega
-      rw [htargetLow]
-      rw [testBit_add_of_lt_low (s := 64 * (i + 1)) (t := 64 * wordIdx + bitIdx)]
+      rw [htargetLow, testBit_add_of_lt_low (s := 64 * (i + 1)) (t := 64 * wordIdx + bitIdx)]
       · rw [← htargetLow, htarget]
         exact wordsToNatAux_testBit_getD ws (i + 1) wordIdx bitIdx hbit
       · exact Nat.lt_of_lt_of_le (word_shift_lt_next w i) (le_rfl)
@@ -699,8 +695,7 @@ theorem toNat_testBit_eq_coeff (p : Hex.GF2Poly) (j : Nat) :
   have hbit : j % 64 < 64 := Nat.mod_lt j (by decide : 0 < 64)
   have hdecomp : 64 * (0 + j / 64) + j % 64 = j := by
     simpa using Nat.div_add_mod j 64
-  rw [← hdecomp]
-  rw [wordsToNatAux_testBit_getD p.toWords.toList 0 (j / 64) (j % 64) hbit]
+  rw [← hdecomp, wordsToNatAux_testBit_getD p.toWords.toList 0 (j / 64) (j % 64) hbit]
   have hdiv : (64 * (j / 64) + j % 64) / 64 = j / 64 := by
     rw [Nat.mul_add_div (by decide : 64 > 0), Nat.div_eq_of_lt hbit, Nat.add_zero]
   simp [Hex.GF2Poly.coeffWords, Hex.GF2Poly.UInt64.bne_zero_eq_toNat_bne_zero,

--- a/HexGFq/CrossCheck.lean
+++ b/HexGFq/CrossCheck.lean
@@ -1909,8 +1909,7 @@ reduced modulo `genericMod`. -/
 private theorem genericN32_finalEntry :
     genericN32SamePrimeCert.powChain[genericN32SamePrimeCert.n]? =
       some (FpPoly.modByMonic genericMod FpPoly.X genericMod_monic) := by
-  rw [genericMod_modByMonic_X]
-  rw [← polyP2_zero_one_eq_X]
+  rw [genericMod_modByMonic_X, ← polyP2_zero_one_eq_X]
   rfl
 
 /-- `genericN32Cert` passes the linear-incremental irreducibility-certificate check

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -282,8 +282,7 @@ private theorem scale_C (c d : ZMod64 p) :
   apply DensePoly.ext_coeff
   intro n
   have hzero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [DensePoly.coeff_C, DensePoly.coeff_C]
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => rfl
   | succ n => exact hzero
@@ -366,8 +365,7 @@ private theorem dvd_left_of_mul_const_right_eq
   have hc : c ≠ 0 := coeff_zero_ne_zero_of_degree_eq_zero r hrdeg
   refine ⟨DensePoly.C c⁻¹, ?_⟩
   have hfgC : g * DensePoly.C c = f := by
-    rw [← hfg]
-    rw [hrC]
+    rw [← hfg, hrC]
   calc
     g = g * (1 : FpPoly p) := by rw [FpPoly.mul_one]
     _ = g * (DensePoly.C c * DensePoly.C c⁻¹) := by
@@ -455,8 +453,7 @@ private theorem reduceMod_repr_mul_invPoly_eq_one
   have hnormalized :
       GFqRing.reduceMod f (DensePoly.scale c⁻¹ r.gcd) =
         GFqRing.reduceMod f 1 := by
-    rw [hgcd_C]
-    rw [scale_inv_C_eq_one_of_ne_zero hp hc]
+    rw [hgcd_C, scale_inv_C_eq_one_of_ne_zero hp hc]
   exact hscaled.trans (by simpa [r, c] using hnormalized)
 
 end InverseInternals
@@ -799,8 +796,7 @@ theorem mul_inv_cancel
         hmulReduce
     _ = GFqRing.reduceMod f 1 := hreduced
     _ = GFqRing.repr ((1 : FiniteField f hf hp hirr).toQuotient) := by
-        rw [toQuotient_one]
-        rw [honeQuotient]
+        rw [toQuotient_one, honeQuotient]
         rfl
 
 /-- A nonzero field element cancels against its inverse on the left. -/

--- a/HexGFqMathlib/GF2q.lean
+++ b/HexGFqMathlib/GF2q.lean
@@ -77,8 +77,8 @@ private theorem bit_and_one_eq_zero_iff (w : UInt64) {i : Nat} (hi : i < 64) :
       exact Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le hi (by norm_num))
     rw [hi64]; exact Nat.mod_eq_of_lt hi
   simp only [UInt64.toNat_and, UInt64.toNat_shiftRight, hshift]
-  rw [show ((1 : UInt64).toNat) = 1 from rfl, show ((0 : UInt64).toNat) = 0 from rfl]
-  rw [Nat.testBit, Nat.and_comm (w.toNat >>> i) 1]
+  rw [show ((1 : UInt64).toNat) = 1 from rfl, show ((0 : UInt64).toNat) = 0 from rfl,
+    Nat.testBit, Nat.and_comm (w.toNat >>> i) 1]
   generalize 1 &&& (w.toNat >>> i) = b
   constructor
   · intro hb; simp [hb]

--- a/HexGramSchmidt/Basic/Kernel.lean
+++ b/HexGramSchmidt/Basic/Kernel.lean
@@ -149,9 +149,8 @@ theorem dot_zero_of_dot_self_zero (row v : Vector Rat m)
       simp
   | cons i xs ih =>
       simp only [List.foldl_cons]
-      rw [dot_self_eq_zero_get v hzero i]
-      rw [show row[i] * (0 : Rat) = 0 by grind]
-      rw [show (0 : Rat) + 0 = 0 by grind]
+      rw [dot_self_eq_zero_get v hzero i, show row[i] * (0 : Rat) = 0 by grind,
+        show (0 : Rat) + 0 = 0 by grind]
       change xs.foldl (fun acc i => acc + row[i] * v[i]) 0 = 0
       exact ih
 
@@ -628,8 +627,8 @@ private theorem foldl_vec_acc_split_pointwise
       grind
   | cons x rest ih =>
       simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x), ih (acc := 0 + f x)]
-      rw [Vector.getElem_add, Vector.getElem_add, Vector.getElem_zero]
+      rw [ih (acc := acc + f x), ih (acc := 0 + f x),
+        Vector.getElem_add, Vector.getElem_add, Vector.getElem_zero]
       grind
 
 /-- `projectionCombination` extracts the accumulator from the fold. -/
@@ -724,8 +723,7 @@ private theorem subtractProjection_zero_left (basisRow : Vector Rat m) :
       have hentry : (0 : Vector Rat m)[i] = 0 := by
         change (0 : Vector Rat m)[i.val] = 0
         rw [Vector.getElem_zero]
-      rw [hentry]
-      rw [show (0 : Rat) + 0 * basisRow[i] = 0 by grind]
+      rw [hentry, show (0 : Rat) + 0 * basisRow[i] = 0 by grind]
       exact ih
   apply Vector.ext
   intro idx hidx

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -263,8 +263,7 @@ private theorem reduceAgainstBasis_basisRows_take_get!_eq_zero
       rw [hcomm]; exact hidx_lt_basis
     have hbget' :
         b = (basisRows rows)[ℓ + 1 + i]'hidx_lt_basis' := by
-      rw [← hbget]
-      rw [List.getElem_drop, List.getElem_take]
+      rw [← hbget, List.getElem_drop, List.getElem_take]
     have hbget!_eq :
         b = (basisRows rows)[ℓ + 1 + i]! := by
       rw [hbget']
@@ -314,11 +313,9 @@ private theorem reduceAgainstBasis_basisRows_take_source_eq_zero
   -- Reconstruction theorem for the source row.
   have hrec :=
     basisRows_get!_eq_reduceAgainstBasis_forward (rows := rows) (k := j) hjlen
-  rw [hrec]
-  rw [reduceAgainstBasis_add_left]
+  rw [hrec, reduceAgainstBasis_add_left]
   -- Basis-row component vanishes by Aux1 with ℓ = j.
-  rw [reduceAgainstBasis_basisRows_take_get!_eq_zero rows j k hjk hk]
-  rw [zero_add_vec]
+  rw [reduceAgainstBasis_basisRows_take_get!_eq_zero rows j k hjk hk, zero_add_vec]
   -- ProjectionCombination component vanishes: each contributing basis row is
   -- at index < j < k, so reducing it gives 0.
   apply reduceAgainstBasis_projectionCombination_eq_zero
@@ -417,8 +414,7 @@ private theorem reduceAgainstBasis_basisRows_take_source_adjacent
   have htake :
       (basisRows rows).take k =
         (basisRows rows).take km1 ++ [(basisRows rows)[km1]!] := by
-    rw [← hkm1]
-    rw [List.take_succ_eq_append_getElem hbasis_km1_len]
+    rw [← hkm1, List.take_succ_eq_append_getElem hbasis_km1_len]
     congr 1
     simp [List.getElem!_eq_getElem?_getD, List.getElem?_eq_getElem hbasis_km1_len]
   have hbasis_k :
@@ -816,8 +812,8 @@ private theorem basisMatrix_rowSwap_adjacent_curr
       (basisRows (Matrix.rowSwap b km1 k).toList).take k.val =
         (basisRows (Matrix.rowSwap b km1 k).toList).take km1.val ++
           [(basisRows (Matrix.rowSwap b km1 k).toList)[km1.val]!] := by
-    rw [show k.val = km1.val + 1 from hkm1.symm]
-    rw [List.take_succ_eq_append_getElem hkm1_lt_swap_basis]
+    rw [show k.val = km1.val + 1 from hkm1.symm,
+      List.take_succ_eq_append_getElem hkm1_lt_swap_basis]
     congr 1
     simp [List.getElem!_eq_getElem?_getD,
       List.getElem?_eq_getElem hkm1_lt_swap_basis]
@@ -1004,8 +1000,7 @@ private theorem rowCombination_prefixRows_extendStrictPrefixCoeff
           0 by
         unfold Matrix.mulVec Matrix.transpose Matrix.col Matrix.row Vector.dotProduct strictPrefixRows
         simp [Matrix.row]]
-  rw [List.finRange_succ_last]
-  rw [List.foldl_append, List.foldl_map]
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
   simp only [List.foldl_cons, List.foldl_nil]
   have hlast_not_lt : ¬i < i := Nat.lt_irrefl i
   simp [extendStrictPrefixCoeff, hlast_not_lt]
@@ -1155,8 +1150,7 @@ private theorem dot_zero_right (a : Vector Rat m) :
         change a[i] * (0 : Vector Rat m)[i.val] = 0
         rw [Vector.getElem_zero]
         grind
-      rw [hterm]
-      rw [show (0 : Rat) + 0 = 0 by grind]
+      rw [hterm, show (0 : Rat) + 0 = 0 by grind]
       exact ih
 
 private def unitCoeff (j : Fin n) : Vector Rat n :=
@@ -1278,8 +1272,7 @@ private theorem rowCombination_eq_foldl_rows
         apply ih
         change accL + M[j.val][idxFin.val] * c[j] =
           (accR + c[j] • M.row j)[idxFin.val]
-        rw [Vector.getElem_add, Vector.getElem_smul]
-        rw [hacc]
+        rw [Vector.getElem_add, Vector.getElem_smul, hacc]
         change accR[idx] + M[j.val][idx] * c[j] =
           accR[idx] + c[j] * M[j.val][idx]
         grind
@@ -1329,13 +1322,8 @@ private theorem normSq_add_smul
       Vector.normSq acc + c * c * Vector.normSq row := by
   change Vector.dotProduct (acc + c • row) (acc + c • row) =
     Vector.dotProduct acc acc + c * c * Vector.dotProduct row row
-  rw [dot_add_left]
-  rw [dot_add_right acc acc (c • row)]
-  rw [dot_smul_right]
-  rw [dot_smul_left]
-  rw [dot_add_right row acc (c • row)]
-  rw [dot_smul_right]
-  rw [horth]
+  rw [dot_add_left, dot_add_right acc acc (c • row), dot_smul_right, dot_smul_left,
+    dot_add_right row acc (c • row), dot_smul_right, horth]
   have horth' : Vector.dotProduct row acc = 0 := by
     rw [dot_comm_rat]
     exact horth
@@ -1401,8 +1389,8 @@ private theorem foldl_orthogonal_expansion_normSq
         Vector.dotProduct (rows.row a) (rows.row b) = 0 := by
       intro a ha b hb hab
       exact horth a (by simp [ha]) b (by simp [hb]) hab
-    rw [ih (acc := acc') hnodup_tail hacc' horth']
-    rw [normSq_add_smul acc (rows.row i) coeffs[i] (hacc i (by simp))]
+    rw [ih (acc := acc') hnodup_tail hacc' horth',
+      normSq_add_smul acc (rows.row i) coeffs[i] (hacc i (by simp))]
     rw [foldl_rat_sum_start rest
       (fun j => coeffs[j] * coeffs[j] * Vector.normSq (rows.row j))
       (0 + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i))]
@@ -1543,8 +1531,7 @@ theorem rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one
       Vector.dotProduct (rows.row i) (rows.row j) = 0)
     (hcoeff : 1 ≤ coeffs[k] * coeffs[k]) :
     Vector.normSq (rows.row k) ≤ Vector.normSq (Matrix.rowCombination rows coeffs) := by
-  rw [rowCombination_eq_foldl_rows]
-  rw [foldl_orthogonal_expansion_normSq_zero rows coeffs horth]
+  rw [rowCombination_eq_foldl_rows, foldl_orthogonal_expansion_normSq_zero rows coeffs horth]
   exact foldl_orthogonal_weighted_normSq_ge (xs := List.finRange n)
     (rows := rows) (coeffs := coeffs) k (by simp) hcoeff
 
@@ -1633,8 +1620,7 @@ private theorem residual_eq_of_same_prefixSpan
   have horth : ∀ j : Fin (i + 1),
       Vector.dotProduct (r - s) ((prefixRows M i hi).row j) = 0 := by
     intro j
-    rw [dot_comm_rat (r - s) ((prefixRows M i hi).row j)]
-    rw [dot_sub_right]
+    rw [dot_comm_rat (r - s) ((prefixRows M i hi).row j), dot_sub_right]
     rw [dot_comm_rat ((prefixRows M i hi).row j) r,
       dot_comm_rat ((prefixRows M i hi).row j) s, hrorth j, hsorth j]
     grind
@@ -1723,8 +1709,8 @@ private theorem prefixSpan_mono_succ
     prefixSpan M (i + 1) hi v := by
   rcases hv with ⟨c, hc⟩
   refine ⟨extendStrictPrefixCoeff c, ?_⟩
-  rw [rowCombination_prefixRows_extendStrictPrefixCoeff]
-  rw [strictPrefixRows_succ_eq_prefixRows (hi := hi)]
+  rw [rowCombination_prefixRows_extendStrictPrefixCoeff,
+    strictPrefixRows_succ_eq_prefixRows (hi := hi)]
   exact hc
 
 /-- `prefixSpan_mono_le` lifts prefix-span membership along any ordered pair of prefix indices. -/
@@ -2004,8 +1990,7 @@ private theorem prefixSumByRow_succ
         projectionCoeff row (basis.row ⟨k, Nat.lt_of_succ_le hk⟩) •
           basis.row ⟨k, Nat.lt_of_succ_le hk⟩ := by
   unfold prefixSumByRow
-  rw [List.finRange_succ_last]
-  rw [List.foldl_append, List.foldl_map]
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
   simp only [List.foldl_cons, List.foldl_nil]
   rfl
 
@@ -2043,8 +2028,7 @@ private theorem prefixSumByRow_eq_projectionCombination
   | succ k ih =>
       have hk_lt : k < n := Nat.lt_of_succ_le hi
       have hkrows : k < (basisRows b.toList).length := by rw [hlen]; exact hk_lt
-      rw [prefixSumByRow_succ]
-      rw [ih (Nat.le_of_succ_le hi)]
+      rw [prefixSumByRow_succ, ih (Nat.le_of_succ_le hi)]
       have htake : (basisRows b.toList).take (k + 1) =
           (basisRows b.toList).take k ++ [(basisRows b.toList)[k]!] := by
         rw [List.take_succ_eq_append_getElem hkrows]

--- a/HexGramSchmidt/Basic/Rat.lean
+++ b/HexGramSchmidt/Basic/Rat.lean
@@ -211,8 +211,7 @@ private theorem projectionCoeff_row_later_basis_eq_zero
             have hentry : (0 : Vector Rat m)[idx] = 0 := by
               change (0 : Vector Rat m)[idx.val] = 0
               rw [Vector.getElem_zero]
-            rw [hentry]
-            rw [show (0 : Rat) + 0 * ((basis b).row col)[idx] = 0 by grind]
+            rw [hentry, show (0 : Rat) + 0 * ((basis b).row col)[idx] = 0 by grind]
             exact ih
       have hzero_div : (0 : Rat) / Vector.dotProduct ((basis b).row col) ((basis b).row col) = 0 := by
         grind
@@ -438,9 +437,8 @@ theorem coeffs_rowSwap_adjacent_lower_prev (b : Matrix Rat n m) (km1 k j : Fin n
   have hbasis :
       (basis (Matrix.rowSwap b km1 k)).row j = (basis b).row j := by
     exact basis_rowSwap_of_before (b := b) (km1 := km1) (k := k) (i := j) hkm1k hj
-  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := km1) (j := j) hj]
-  rw [coeffs_lower_projection (b := b) (i := k) (j := j) (Nat.lt_trans hj hkm1k)]
-  rw [hrow, hbasis]
+  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := km1) (j := j) hj,
+    coeffs_lower_projection (b := b) (i := k) (j := j) (Nat.lt_trans hj hkm1k), hrow, hbasis]
 
 /-- Dual of `coeffs_rowSwap_adjacent_lower_prev`: after an adjacent swap, the
 coefficient at row `k` against an earlier column `j` equals the old coefficient
@@ -458,8 +456,7 @@ theorem coeffs_rowSwap_adjacent_lower_curr (b : Matrix Rat n m) (km1 k j : Fin n
     exact basis_rowSwap_of_before (b := b) (km1 := km1) (k := k) (i := j) hkm1k hj
   rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := k) (j := j)
     (by omega)]
-  rw [coeffs_lower_projection (b := b) (i := km1) (j := j) hj]
-  rw [hrow, hbasis]
+  rw [coeffs_lower_projection (b := b) (i := km1) (j := j) hj, hrow, hbasis]
 
 /-- The explicit value of the new pivot coefficient (row `k`, column `km1`)
 after an adjacent swap, in terms of the old projection coefficient and basis-row
@@ -547,8 +544,7 @@ theorem coeffs_rowAdd_lower (b : Matrix Rat n m) (col src dst : Fin n)
     intro idx hidx
     simp [Vector.getElem_add, Vector.getElem_smul]
     rfl
-  rw [hvec]
-  rw [GramSchmidt.projectionCoeff_add_left, GramSchmidt.projectionCoeff_smul_left]
+  rw [hvec, GramSchmidt.projectionCoeff_add_left, GramSchmidt.projectionCoeff_smul_left]
 
 /-- Under `rowAdd b src dst c` with `src < dst`, the pivot coefficient in the
 destination row increases by `c` when the source basis row has nonzero norm. -/
@@ -957,9 +953,8 @@ theorem coeffs_rowSwap_adjacent_before (b : Matrix Rat n m) (km1 k i j : Fin n)
       (basis (Matrix.rowSwap b km1 k)).row j = (basis b).row j := by
     exact basis_rowSwap_of_before (b := b) (km1 := km1) (k := k) (i := j) hkm1k
       (Nat.lt_trans hji hi)
-  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji]
-  rw [coeffs_lower_projection (b := b) (i := i) (j := j) hji]
-  rw [hrow, hbasis]
+  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji,
+    coeffs_lower_projection (b := b) (i := i) (j := j) hji, hrow, hbasis]
 
 /-- Coefficient entries for a row after the swapped pair against a column before
 it are unaffected by an adjacent swap. -/
@@ -981,9 +976,8 @@ theorem coeffs_rowSwap_adjacent_after_low (b : Matrix Rat n m) (km1 k i j : Fin 
   have hbasis :
       (basis (Matrix.rowSwap b km1 k)).row j = (basis b).row j := by
     exact basis_rowSwap_of_before (b := b) (km1 := km1) (k := k) (i := j) hkm1k hj
-  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji]
-  rw [coeffs_lower_projection (b := b) (i := i) (j := j) hji]
-  rw [hrow, hbasis]
+  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji,
+    coeffs_lower_projection (b := b) (i := i) (j := j) hji, hrow, hbasis]
 
 /-- Coefficient entries for a row and column both lying after the swapped pair
 are unaffected by an adjacent swap. -/
@@ -1004,9 +998,8 @@ theorem coeffs_rowSwap_adjacent_after_high (b : Matrix Rat n m) (km1 k i j : Fin
   have hbasis :
       (basis (Matrix.rowSwap b km1 k)).row j = (basis b).row j := by
     exact basis_rowSwap_of_after (b := b) (km1 := km1) (k := k) (i := j) hkm1 hj
-  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji]
-  rw [coeffs_lower_projection (b := b) (i := i) (j := j) hji]
-  rw [hrow, hbasis]
+  rw [coeffs_lower_projection (b := Matrix.rowSwap b km1 k) (i := i) (j := j) hji,
+    coeffs_lower_projection (b := b) (i := i) (j := j) hji, hrow, hbasis]
 
 end GramSchmidt.Rat
 end Hex

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -481,8 +481,7 @@ private theorem dot_rowCombination_mul_right_int
     intro a ha
     simp only [Vector.getElem_ofFn]
     grind
-  rw [h_eq_input]
-  rw [rowCombination_bareiss_coeff_update b s 0 (Vector.ofFn f) (Vector.ofFn f)]
+  rw [h_eq_input, rowCombination_bareiss_coeff_update b s 0 (Vector.ofFn f) (Vector.ofFn f)]
   rw [dot_bareiss_row_update_left s 0
     (Matrix.rowCombination b (Vector.ofFn f))
     (Matrix.rowCombination b (Vector.ofFn f)) w]
@@ -689,8 +688,7 @@ theorem bareissGramRowInvariant_regular_step_coeff_canonical
           bareissGramRowInvariantStepCoeff hinv hnext i hi := by
       show (if hi : _ then _ else _) = _
       rw [dif_pos hi]
-    rw [hLHS]
-    rw [bareissGramCanonicalCoeff_succ_regular b elapsed i hnext hp hi]
+    rw [hLHS, bareissGramCanonicalCoeff_succ_regular b elapsed i hnext hp hi]
     show Vector.ofFn (fun a : Fin n =>
         Matrix.exactDiv
           (_ * (hinv.coeff i)[a] - _ * (hinv.coeff _)[a])

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -95,9 +95,7 @@ private theorem cast_rowCombination_eq
       = (Matrix.rowCombination
           (GramSchmidt.prefixRows (castIntMatrix b) k.val k.isLt)
           (prefixCoeffsCast c k))[cf]
-  rw [hLHS]
-  rw [rowCombination_int_getElem b c cf]
-  rw [rowCombination_prefix_castIntMatrix_getElem b c k cf]
+  rw [hLHS, rowCombination_int_getElem b c cf, rowCombination_prefix_castIntMatrix_getElem b c k cf]
   -- LHS: cast of an integer foldl; RHS: a rational foldl over `finRange (k+1)`.
   -- First, push the cast through the integer foldl, getting a rational foldl
   -- over `finRange n` whose later terms vanish; then truncate to `k + 1`.
@@ -192,8 +190,7 @@ Gram-Schmidt basis rows: `coeffs b * basis b` collapses to the cast input
   have htrunc := foldl_finRange_eq_prefix_of_zero_above ii f hzero
   change (List.finRange n).foldl (fun acc k => acc + f k) 0 =
     (castIntMatrix b)[ii][jj]
-  rw [htrunc]
-  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
+  rw [htrunc, List.finRange_succ_last, List.foldl_append, List.foldl_map]
   simp only [List.foldl_cons, List.foldl_nil]
   have hprefix :
       (List.finRange i).foldl
@@ -297,15 +294,13 @@ theorem rowCombination_basis_coeffs_reconstruction
     rw [Matrix.mulVec_getElem]
     simp [Vector.dotProduct, Matrix.row, Matrix.transpose,
       Matrix.col, castIntMatrix]
-  rw [hleft]
-  rw [← hcoeff]
+  rw [hleft, ← hcoeff]
   change ((Matrix.transpose (coeffs b * basis b)) *
       Vector.map (fun x : Int => (x : Rat)) c)[jj] =
     (Matrix.transpose (basis b) *
       (Matrix.transpose (coeffs b) *
         Vector.map (fun x : Int => (x : Rat)) c))[jj]
-  rw [Matrix.transpose_mul_of_mul_comm]
-  rw [Matrix.mul_assoc_vec]
+  rw [Matrix.transpose_mul_of_mul_comm, Matrix.mul_assoc_vec]
 
 private theorem exists_highest_nonzero_coeff_in_list
     (c : Vector Int n) (xs : List (Fin n))
@@ -2103,9 +2098,8 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
       dsimp [GramSchmidt.scaledCoeffMatrix, Matrix.transpose, Matrix.col,
         Matrix.row, Matrix.ofFn]
       repeat rw [Vector.getElem_ofFn]
-      rw [if_pos hq_val]
-      rw [if_pos (by simpa [last] using congrArg Fin.val hp_last)]
-      rw [rowSwap_getRow_right_val_int]
+      rw [if_pos hq_val, if_pos (by simpa [last] using congrArg Fin.val hp_last),
+        rowSwap_getRow_right_val_int]
       rw [show (GramSchmidt.liftFinLE (⟨p.val, hr⟩ : Fin t) _) = km1 by
         apply Fin.ext
         dsimp [GramSchmidt.liftFinLE]
@@ -2128,10 +2122,8 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
       dsimp [GramSchmidt.scaledCoeffMatrix, Matrix.transpose, Matrix.col,
         Matrix.row, Matrix.ofFn]
       repeat rw [Vector.getElem_ofFn]
-      rw [if_pos hq_val]
-      rw [if_neg hp_val_ne]
-      rw [rowSwap_getRow_right_val_int]
-      rw [rowSwap_getRow_eq_of_ne_val_int]
+      rw [if_pos hq_val, if_neg hp_val_ne, rowSwap_getRow_right_val_int,
+        rowSwap_getRow_eq_of_ne_val_int]
       · rw [show (GramSchmidt.liftFinLE q _) = km1 by
           apply Fin.ext
           dsimp [GramSchmidt.liftFinLE]
@@ -2156,14 +2148,12 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
       dsimp [GramSchmidt.scaledCoeffMatrix, Matrix.transpose, Matrix.col,
         Matrix.row, Matrix.ofFn]
       repeat rw [Vector.getElem_ofFn]
-      rw [if_neg hq_ne_val]
-      rw [if_pos hp_val]
+      rw [if_neg hq_ne_val, if_pos hp_val]
       rw [show (GramSchmidt.liftFinLE (⟨p.val, hr⟩ : Fin t) _) = km1 by
         apply Fin.ext
         dsimp [GramSchmidt.liftFinLE]
         omega]
-      rw [rowSwap_getRow_left_val_int]
-      rw [rowSwap_getRow_eq_of_ne_val_int]
+      rw [rowSwap_getRow_left_val_int, rowSwap_getRow_eq_of_ne_val_int]
       · exact dot_comm_int _ _
       · dsimp [GramSchmidt.liftFinLE]
         omega
@@ -2181,9 +2171,7 @@ theorem scaledCoeffMatrix_rowSwap_adjacent_pivot_transpose
       dsimp [GramSchmidt.scaledCoeffMatrix, Matrix.transpose, Matrix.col,
         Matrix.row, Matrix.ofFn]
       repeat rw [Vector.getElem_ofFn]
-      rw [if_neg hq_ne_val]
-      rw [if_neg hp_ne_val]
-      rw [rowSwap_getRow_eq_of_ne_val_int]
+      rw [if_neg hq_ne_val, if_neg hp_ne_val, rowSwap_getRow_eq_of_ne_val_int]
       · rw [rowSwap_getRow_eq_of_ne_val_int]
         · exact dot_comm_int _ _
         · dsimp [GramSchmidt.liftFinLE]

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -323,8 +323,8 @@ private theorem getArrayEntry_foldl_setArrayEntry_row_ne
         intro y hy
         exact hxs y (by simp [hy])
       simp only [List.foldl_cons]
-      rw [ih (setArrayEntry coeffs x k (getArrayEntry rows x k)) hxs']
-      rw [getArrayEntry_setArrayEntry_of_row_ne]
+      rw [ih (setArrayEntry coeffs x k (getArrayEntry rows x k)) hxs',
+        getArrayEntry_setArrayEntry_of_row_ne]
       omega
 
 /-- A column-targeted `foldl` preserves rows whose index is absent from the
@@ -343,8 +343,8 @@ private theorem getArrayEntry_foldl_setArrayEntry_row_notMem
       have hrx : r ≠ x := fun h => hr (h ▸ List.mem_cons_self)
       have hrxs : r ∉ xs := fun h => hr (List.mem_cons_of_mem _ h)
       simp only [List.foldl_cons]
-      rw [ih (setArrayEntry coeffs x k (getArrayEntry rows x k)) hrxs]
-      rw [getArrayEntry_setArrayEntry_of_row_ne]
+      rw [ih (setArrayEntry coeffs x k (getArrayEntry rows x k)) hrxs,
+        getArrayEntry_setArrayEntry_of_row_ne]
       exact hrx
 
 /-- A column-targeted `foldl` of `setArrayEntry`s at column `k` leaves entries
@@ -538,8 +538,7 @@ private theorem getElem!_foldl_modify_of_mem_nodup
         have hbound' : r < (arr.modify x (f x)).size := by
           rw [modify_size]
           exact hbound
-        rw [ih _ hr_in hnodup' hbound']
-        rw [getElem!_modify_ne arr x r (f x) hr_ne_x]
+        rw [ih _ hr_in hnodup' hbound', getElem!_modify_ne arr x r (f x) hr_ne_x]
 
 /-- A `foldl` that modifies indices via `Array.modify` preserves the outer
 array size. -/
@@ -1198,8 +1197,7 @@ private theorem getArrayEntry_schurRowLoop_upper
       simp
   | cons row rowList ih =>
       simp only [List.foldl_cons]
-      rw [ih _]
-      rw [getArrayEntry_schurColumnLoop_upper]
+      rw [ih _, getArrayEntry_schurColumnLoop_upper]
       · exact hij
       · intro c hc
         rw [List.mem_range'] at hc
@@ -1335,8 +1333,8 @@ private theorem getArrayEntry_schurColumnLoop_col_zero
           · exact h.symm
           · exact (h_zero_in_tail h).elim
         subst h_col_eq
-        rw [getArrayEntry_schurColumnLoop_col_zero_preserve _ _ _ _ h_zero_in_tail]
-        rw [getArrayEntry_setArrayEntry_self _ _ _ _ hrow hcol]
+        rw [getArrayEntry_schurColumnLoop_col_zero_preserve _ _ _ _ h_zero_in_tail,
+          getArrayEntry_setArrayEntry_self _ _ _ _ hrow hcol]
         simp [schurScaledCoeffEntry]
 
 /-- Size preservation: the Schur column loop keeps the outer-array length. -/

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -131,9 +131,8 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
         rw [getArrayEntry_scaledCoeffArrayLoop_current_col_written n fuel' state_array
           i.val j.val h_array_step hji i.isLt h_coeffs_size h_coeffs_rows_size]
         have hdist : j.val - state_matrix.step = 0 := by omega
-        rw [hdist, Matrix.noPivotLoop_zero_fuel]
-        rw [getArrayEntry_eq_rowsToMatrix state_array.matrix i j]
-        rw [h_matrix_eq]
+        rw [hdist, Matrix.noPivotLoop_zero_fuel,
+          getArrayEntry_eq_rowsToMatrix state_array.matrix i j, h_matrix_eq]
       · have h_step_lt_j : state_matrix.step < j.val :=
           Nat.lt_of_le_of_ne h_step_le_j h_at_target
         have hDone : state_matrix.step + 1 < n := by
@@ -222,8 +221,7 @@ private theorem scaledCoeffArrayLoop_lower_matches_target_column
           have hdist :
               j.val - state_matrix.step = (j.val - (state_matrix.step + 1)) + 1 := by
             omega
-          rw [h_capture]
-          rw [hdist, Matrix.noPivotLoop_regular_branch _ state_matrix hDone hp]
+          rw [h_capture, hdist, Matrix.noPivotLoop_regular_branch _ state_matrix hDone hp]
           rfl
 
 /-- Early-singular zero tail after the singular column: if the lower entries
@@ -252,8 +250,8 @@ private theorem scaledCoeffArrayLoop_lower_singular_after_step
     have := getArrayEntry_eq_rowsToMatrix (n := n) state_array.matrix kFin kFin
     rw [this, h_matrix_eq]
     exact hp
-  rw [scaledCoeffArrayLoop_singular_branch fuel state_array hArrayStep hArrayNext hp_array]
-  rw [getArrayEntry_writeScaledColumn]
+  rw [scaledCoeffArrayLoop_singular_branch fuel state_array hArrayStep hArrayNext hp_array,
+    getArrayEntry_writeScaledColumn]
   · exact h_coeffs_unwritten i j hsj hji
   · rw [h_step_eq]
     omega
@@ -461,8 +459,8 @@ private theorem scaledCoeffArrayLoop_diag_matches
         · -- A1: singular branch.
           have hp_array : getArrayEntry state_array.matrix state_array.step state_array.step = 0 := by
             rw [h_pivot_array_eq_matrix]; exact hp
-          rw [scaledCoeffArrayLoop_singular_branch fuel' state_array hArrayStep hArrayNext hp_array]
-          rw [Matrix.noPivotLoop_singular_branch fuel' state_matrix hDone hp]
+          rw [scaledCoeffArrayLoop_singular_branch fuel' state_array hArrayStep hArrayNext hp_array,
+            Matrix.noPivotLoop_singular_branch fuel' state_matrix hDone hp]
           right
           refine ⟨state_matrix.step, rfl, ?_⟩
           by_cases h_ilt : i.val < state_matrix.step
@@ -505,8 +503,8 @@ private theorem scaledCoeffArrayLoop_diag_matches
         · -- A2: regular branch.
           have hp_array : getArrayEntry state_array.matrix state_array.step state_array.step ≠ 0 := by
             rw [h_pivot_array_eq_matrix]; exact hp
-          rw [scaledCoeffArrayLoop_regular_branch fuel' state_array hArrayStep hArrayNext hp_array]
-          rw [Matrix.noPivotLoop_regular_branch fuel' state_matrix hDone hp]
+          rw [scaledCoeffArrayLoop_regular_branch fuel' state_array hArrayStep hArrayNext hp_array,
+            Matrix.noPivotLoop_regular_branch fuel' state_matrix hDone hp]
           -- Build new compatible states.
           let new_array : ScaledCoeffArrayState :=
             { step := state_array.step + 1
@@ -576,8 +574,7 @@ private theorem scaledCoeffArrayLoop_diag_matches
                 rw [h_coeffs_rows_size j hjn]; exact hjn
               rw [getArrayEntry_writeScaledColumn_diag _ _ _ _ hrow hcol]
               -- Goal: getArrayEntry state_array.matrix j j = state_matrix.matrix[jFin][jFin]
-              rw [getArrayEntry_eq_rowsToMatrix state_array.matrix jFin jFin]
-              rw [h_matrix_eq]
+              rw [getArrayEntry_eq_rowsToMatrix state_array.matrix jFin jFin, h_matrix_eq]
             · have hj_lt : j < state_matrix.step := Nat.lt_of_le_of_ne hj_le hj_eq
               rw [getArrayEntry_writeScaledColumn _ _ _ _ _ _
                 (show j ≠ state_array.step by rw [h_step_eq]; omega)]
@@ -621,9 +618,8 @@ private theorem scaledCoeffArrayLoop_diag_matches
               rw [h_coeffs_size]; exact i.isLt
             have hcol : i.val < state_array.coeffs[i.val]!.size := by
               rw [h_coeffs_rows_size i.val i.isLt]; exact i.isLt
-            rw [getArrayEntry_writeScaledColumn_diag _ _ _ _ hrow hcol]
-            rw [getArrayEntry_eq_rowsToMatrix state_array.matrix i i]
-            rw [h_matrix_eq]
+            rw [getArrayEntry_writeScaledColumn_diag _ _ _ _ hrow hcol,
+              getArrayEntry_eq_rowsToMatrix state_array.matrix i i, h_matrix_eq]
           · by_cases h_ilt : i.val < state_matrix.step
             · change getArrayEntry (writeScaledColumn _ _ _ _) i.val i.val = _
               rw [getArrayEntry_writeScaledColumn _ _ _ _ _ _
@@ -825,8 +821,8 @@ private theorem scaledCoeffRows_diag_toNat_eq_gramDet
     (b : Matrix Int n m) (hquot : StepWitness b) (i : Nat) (hi : i < n) :
     (getArrayEntry (scaledCoeffRows b) i i).toNat =
       gramDet b (i + 1) (Nat.succ_le_of_lt hi) := by
-  rw [scaledCoeffRows_diag_toNat_eq_gramDetVecEntry (b := b) i hi]
-  rw [gramDetVecEntry_eq_gramDet (b := b) hquot (i + 1) (Nat.succ_le_of_lt hi)]
+  rw [scaledCoeffRows_diag_toNat_eq_gramDetVecEntry (b := b) i hi,
+    gramDetVecEntry_eq_gramDet (b := b) hquot (i + 1) (Nat.succ_le_of_lt hi)]
 
 /-- Signed leading-prefix diagonal information from the executable
 scaled-coefficient loop: the diagonal slot is either the zero tail after an

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -200,8 +200,7 @@ private theorem noPivotLoop_initial_gram_bareiss_step_dvd
     intro a ha
     rw [Vector.getElem_ofFn, Vector.getElem_ofFn]
     exact hq.coeff_num_eq_mul ⟨a, ha⟩
-  rw [h_q_eq_num]
-  rw [dot_rowCombination_mul_right_int b hq.q state.prevPivot (b.row j)]
+  rw [h_q_eq_num, dot_rowCombination_mul_right_int b hq.q state.prevPivot (b.row j)]
   exact Int.mul_comm _ _
 
 /-- Row-vector consumer for an initial no-pivot Gram pass.  A single supported

--- a/HexGramSchmidt/Int/Scaled.lean
+++ b/HexGramSchmidt/Int/Scaled.lean
@@ -242,8 +242,8 @@ private theorem getArrayEntry_scaledCoeffRowsSchur_eq_schurScaledCoeffEntry
         schurScaledCoeffEntry rowsBeforeC gram a c := by
     simp [scaledCoeffRowsSchur, gram, h_rows_split, h_cols_split, rowsBeforeA,
       rowsBeforeC]
-    rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ h_a_not_suffix]
-    rw [getArrayEntry_schurColumnLoop_col_not_mem _ _ _ _ _ h_c_not_colSuffix]
+    rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ h_a_not_suffix,
+      getArrayEntry_schurColumnLoop_col_not_mem _ _ _ _ _ h_c_not_colSuffix]
     exact getArrayEntry_setArrayEntry_self rowsBeforeC a c
       (schurScaledCoeffEntry rowsBeforeC gram a c) hrow_beforeC hcol_beforeC
   rw [h_write]
@@ -281,8 +281,8 @@ private theorem getArrayEntry_scaledCoeffRowsSchur_eq_schurScaledCoeffEntry
                     next) (zeroRows n)) k k := by
             rw [h_rows_split]
             simp [rowsBeforeA, gram]
-            rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ hk_not_suffix]
-            rw [getArrayEntry_schurColumnLoop_row_ne _ _ _ _ _ _ hk_not_a]
+            rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ hk_not_suffix,
+              getArrayEntry_schurColumnLoop_row_ne _ _ _ _ _ _ hk_not_a]
           _ = getArrayEntry (scaledCoeffRowsSchur b) k k := by
             simp [scaledCoeffRowsSchur]
       have h_row_a_cells :
@@ -361,8 +361,8 @@ private theorem getArrayEntry_scaledCoeffRowsSchur_eq_schurScaledCoeffEntry
                       next) (zeroRows n)) c p := by
               rw [h_rows_split]
               simp [rowsBeforeA, gram]
-              rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ hc_not_suffix]
-              rw [getArrayEntry_schurColumnLoop_row_ne _ _ _ _ _ _ hca_ne]
+              rw [getArrayEntry_schurRowLoop_row_not_mem _ _ _ _ _ hc_not_suffix,
+                getArrayEntry_schurColumnLoop_row_ne _ _ _ _ _ _ hca_ne]
             _ = getArrayEntry (scaledCoeffRowsSchur b) c p := by
               simp [scaledCoeffRowsSchur]
       have h_diag_prev :
@@ -728,15 +728,15 @@ private theorem noPivotLoop_sync_borderedMinor_aux
       · -- Singular branch on both sides.
         have hp_bm : state_bm.matrix[k_bm][k_bm] = 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full]
-        rw [Matrix.noPivotLoop_singular_branch f state_bm h_bm_done hp_bm]
+        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_singular_branch f state_bm h_bm_done hp_bm]
         refine ⟨h_step, h_prev, h_rows, ?_, h_mat⟩
         simp [h_step]
       · -- Regular branch on both sides; apply IH to the updated states.
         have hp_bm : state_bm.matrix[k_bm][k_bm] ≠ 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full]
-        rw [Matrix.noPivotLoop_regular_branch f state_bm h_bm_done hp_bm]
+        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_regular_branch f state_bm h_bm_done hp_bm]
         have h_new_mat :
             Matrix.borderedMinor
               (Matrix.stepMatrix state_full.matrix state_full.step
@@ -1013,15 +1013,15 @@ private theorem noPivotLoop_sync_principalSubmatrix_aux
       · -- Singular branch on both sides.
         have hp_pref : state_pref.matrix[k_pref][k_pref] = 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full]
-        rw [Matrix.noPivotLoop_singular_branch f state_pref h_pref_done hp_pref]
+        rw [Matrix.noPivotLoop_singular_branch f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_singular_branch f state_pref h_pref_done hp_pref]
         refine ⟨h_step, h_prev, h_rows, ?_, h_mat⟩
         simp [h_step]
       · -- Regular branch on both sides; apply IH to the updated states.
         have hp_pref : state_pref.matrix[k_pref][k_pref] ≠ 0 := by
           rw [← h_pivot_eq]; exact hp_full
-        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full]
-        rw [Matrix.noPivotLoop_regular_branch f state_pref h_pref_done hp_pref]
+        rw [Matrix.noPivotLoop_regular_branch f state_full h_full_done hp_full,
+          Matrix.noPivotLoop_regular_branch f state_pref h_pref_done hp_pref]
         -- After one step, the new states are still linked.
         have h_new_mat :
             Matrix.principalSubmatrix
@@ -1135,8 +1135,8 @@ theorem noPivotLoop_add
           rw [h_lhs, h_rhs_inner]
           exact ih _
       · -- Boundary: both sides return `state` unchanged.
-        rw [noPivotLoop_id_at_done (a' + 1 + b) state hDone]
-        rw [noPivotLoop_id_at_done (a' + 1) state hDone]
+        rw [noPivotLoop_id_at_done (a' + 1 + b) state hDone,
+          noPivotLoop_id_at_done (a' + 1) state hDone]
         exact (noPivotLoop_id_at_done b state hDone).symm
 
 /-- After running `noPivotLoop` from a state without a recorded singular
@@ -1346,8 +1346,7 @@ private theorem noPivotLoop_singularStep
         (Matrix.noPivotLoop a state).singularStep =
           some (Matrix.noPivotLoop a state).step := by
       rw [h_sing, h_step]
-    rw [noPivotLoop_id_at_singular_fixedpoint b _ hDone hp hsing_state]
-    rw [hs]
+    rw [noPivotLoop_id_at_singular_fixedpoint b _ hDone hp hsing_state, hs]
     exact h_sing
 
 /-- If a full no-pivot run has no singular step, every initial prefix run also

--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -112,8 +112,7 @@ theorem coeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n) (hjk : j.val 
     (hnorm : Vector.dotProduct ((basis b).row j) ((basis b).row j) ≠ 0) :
     GramSchmidt.entry (coeffs (sizeReduce b j k r)) k j =
       GramSchmidt.entry (coeffs b) k j - (r : Rat) := by
-  rw [sizeReduce]
-  rw [coeffs_rowAdd_pivot (b := b) (src := j) (dst := k) hjk (c := -r) hnorm]
+  rw [sizeReduce, coeffs_rowAdd_pivot (b := b) (src := j) (dst := k) hjk (c := -r) hnorm]
   grind
 
 /-- How size reduction propagates to coefficients below the pivot: for a column
@@ -126,8 +125,7 @@ theorem coeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
     GramSchmidt.entry (coeffs (sizeReduce b j k r)) k l =
       GramSchmidt.entry (coeffs b) k l -
         (r : Rat) * GramSchmidt.entry (coeffs b) j l := by
-  rw [sizeReduce]
-  rw [coeffs_rowAdd_lower (b := b) (col := l) (src := j) (dst := k) hlj hjk (c := -r)]
+  rw [sizeReduce, coeffs_rowAdd_lower (b := b) (col := l) (src := j) (dst := k) hlj hjk (c := -r)]
   grind
 
 /-- Size reduction is local to the row being reduced: every coefficient row

--- a/HexGramSchmidtMathlib/Basic.lean
+++ b/HexGramSchmidtMathlib/Basic.lean
@@ -121,8 +121,7 @@ theorem rat_coeffs_lower_projection_real (b : Matrix Rat n m) {i j : Fin n}
           ((Hex.GramSchmidt.Rat.basis b).row j) = 0
   · have hnorm_real :
         (‖rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j)‖ : ℝ) ^ 2 = 0 := by
-      rw [← real_inner_self_eq_norm_sq]
-      rw [rowToEuclidean_inner]
+      rw [← real_inner_self_eq_norm_sq, rowToEuclidean_inner]
       exact_mod_cast hnorm
     simp [hnorm, hnorm_real]
   ·
@@ -130,8 +129,7 @@ theorem rat_coeffs_lower_projection_real (b : Matrix Rat n m) {i j : Fin n}
         (‖rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j)‖ : ℝ) ^ 2 =
           ((Vector.dotProduct ((Hex.GramSchmidt.Rat.basis b).row j)
             ((Hex.GramSchmidt.Rat.basis b).row j) : Rat) : ℝ) := by
-      rw [← real_inner_self_eq_norm_sq]
-      rw [rowToEuclidean_inner]
+      rw [← real_inner_self_eq_norm_sq, rowToEuclidean_inner]
     simp [hnorm, rowToEuclidean_inner, hnorm_real]
 
 private theorem rowToEuclidean_foldl_linear

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -264,8 +264,7 @@ private theorem foldl_sum_start_rat {α : Type v}
   | nil => simp
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      rw [ih (acc := (0 : Rat) + f x)]
+      rw [ih (acc := acc + f x), ih (acc := (0 : Rat) + f x)]
       grind
 
 /-- Rational dot product is commutative. -/
@@ -326,16 +325,14 @@ private theorem dot_prefixCombination_right_rat
     | cons x xs ih =>
         intro acc
         simp only [List.foldl_cons]
-        rw [ih]
-        rw [dot_add_right_rat, dot_smul_right_rat]
+        rw [ih, dot_add_right_rat, dot_smul_right_rat]
         rw [foldl_sum_start_rat xs _
           ((0 : Rat) + (GramSchmidt.entry coeffs ⟨i, hi⟩
               ⟨x.val, Nat.lt_trans x.isLt hi⟩ *
             Vector.dotProduct u
               (basisM.row ⟨x.val, Nat.lt_trans x.isLt hi⟩)))]
         grind
-  rw [hgen (List.finRange i) 0]
-  rw [dot_zero_right_rat]
+  rw [hgen (List.finRange i) 0, dot_zero_right_rat]
   grind
 
 /-- Dot product against a `prefixCombination` is zero when the right vector is
@@ -447,8 +444,7 @@ private theorem rowCombination_eq_foldl_rows_rat
         apply ih
         change accL + M[j.val][idxFin.val] * c[j] =
           (accR + c[j] • M.row j)[idxFin.val]
-        rw [Vector.getElem_add, Vector.getElem_smul]
-        rw [hacc]
+        rw [Vector.getElem_add, Vector.getElem_smul, hacc]
         change accR[idx] + M[j.val][idx] * c[j] =
           accR[idx] + c[j] * M[j.val][idx]
         grind
@@ -474,13 +470,11 @@ private theorem dot_rowCombination_right_rat
     | cons x xs ih =>
         intro acc
         simp only [List.foldl_cons]
-        rw [ih]
-        rw [dot_add_right_rat, dot_smul_right_rat]
+        rw [ih, dot_add_right_rat, dot_smul_right_rat]
         rw [foldl_sum_start_rat xs _
           ((0 : Rat) + c[x] * Vector.dotProduct u (M.row x))]
         grind
-  rw [hgen (List.finRange n) 0]
-  rw [dot_zero_right_rat]
+  rw [hgen (List.finRange n) 0, dot_zero_right_rat]
   grind
 
 /-- Dotting the projection with an original prefix row is the corresponding
@@ -500,8 +494,7 @@ private theorem originalProjectionCoords_dot_eq
                 ⟨p.val, Nat.lt_of_lt_of_le p.isLt (Nat.succ_le_of_lt hj)⟩)
               (castIntRow b
                 ⟨q.val, Nat.lt_of_lt_of_le q.isLt (Nat.succ_le_of_lt hj)⟩)) 0 := by
-  rw [← originalProjectionCoords_spec b i j hi hj]
-  rw [dot_rowCombination_right_rat]
+  rw [← originalProjectionCoords_spec b i j hi hj, dot_rowCombination_right_rat]
   apply foldl_sum_congr_simple
   intro q _hq
   simp [GramSchmidt.prefixRows, Matrix.row, castIntMatrixRat, castIntRow]
@@ -539,13 +532,11 @@ private theorem auxMatrix_zero_above (b : Matrix Int n m) (k : Nat) (hk : k ≤ 
   have hj' : j.val < n := Nat.lt_of_lt_of_le j.isLt hk
   have hij' : i.val ≠ j.val := Nat.ne_of_lt hij
   -- liftFinLE i hk = ⟨i.val, hi'⟩ definitionally.
-  rw [show GramSchmidt.liftFinLE i hk = ⟨i.val, hi'⟩ from rfl]
-  rw [show GramSchmidt.liftFinLE j hk = ⟨j.val, hj'⟩ from rfl]
-  rw [castIntRow_decomposition b i.val hi']
-  rw [dot_comm_rat]
-  rw [dot_add_right_rat]
-  rw [dot_comm_rat ((basis b).row ⟨j.val, hj'⟩) ((basis b).row ⟨i.val, hi'⟩)]
-  rw [basis_orthogonal b i.val j.val hi' hj' hij']
+  rw [show GramSchmidt.liftFinLE i hk = ⟨i.val, hi'⟩ from rfl,
+    show GramSchmidt.liftFinLE j hk = ⟨j.val, hj'⟩ from rfl, castIntRow_decomposition b i.val hi',
+    dot_comm_rat, dot_add_right_rat,
+    dot_comm_rat ((basis b).row ⟨j.val, hj'⟩) ((basis b).row ⟨i.val, hi'⟩),
+    basis_orthogonal b i.val j.val hi' hj' hij']
   -- Second term: prefixCombination orthogonal to ((basis b).row j).
   have hprefix :
       Vector.dotProduct ((basis b).row ⟨j.val, hj'⟩)
@@ -568,10 +559,8 @@ private theorem auxMatrix_diag (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
       Vector.normSq ((basis b).row (GramSchmidt.liftFinLE i hk)) := by
   rw [auxMatrix_get]
   have hi' : i.val < n := Nat.lt_of_lt_of_le i.isLt hk
-  rw [show GramSchmidt.liftFinLE i hk = ⟨i.val, hi'⟩ from rfl]
-  rw [castIntRow_decomposition b i.val hi']
-  rw [dot_comm_rat]
-  rw [dot_add_right_rat]
+  rw [show GramSchmidt.liftFinLE i hk = ⟨i.val, hi'⟩ from rfl, castIntRow_decomposition b i.val hi',
+    dot_comm_rat, dot_add_right_rat]
   -- First term: dot ((basis b).row i) ((basis b).row i) = normSq ((basis b).row i)
   -- Second term: dot ((basis b).row i) prefixCombination = 0.
   have hprefix :
@@ -648,8 +637,7 @@ private theorem progressMatrix_full_eq_auxMatrix (b : Matrix Int n m)
   let jj : Fin k := ⟨j, hj⟩
   have hjlt : jj.val < k := hj
   change (progressMatrix b k hk k)[ii][jj] = (auxMatrix b k hk)[ii][jj]
-  rw [progressMatrix_get_lt b k hk k ii jj hjlt]
-  rw [auxMatrix_get]
+  rw [progressMatrix_get_lt b k hk k ii jj hjlt, auxMatrix_get]
 
 /-- The col-op coefficient list for the `s`-th transition step: indices
 `p : Fin s` lifted into `Fin k`. -/
@@ -729,8 +717,7 @@ private theorem progressMatrix_succ_eq_colReplace
     have hslift : GramSchmidt.liftFinLE (⟨s, hs⟩ : Fin k) hk = ⟨s, hsn⟩ := rfl
     rw [hslift]
     -- decomposition castIntRow b ⟨s, hsn⟩ = (basis b).row ⟨s, hsn⟩ + prefixComb
-    rw [castIntRow_decomposition b s hsn]
-    rw [dot_add_right_rat]
+    rw [castIntRow_decomposition b s hsn, dot_add_right_rat]
     -- LHS = dot (castIntRow ii) ((basis b).row ⟨s, _⟩)
     -- RHS_first = dot (castIntRow ii) ((basis b).row ⟨s, _⟩) + dot (castIntRow ii) prefixComb
     -- So we need: dot (castIntRow ii) ((basis b).row ⟨s,_⟩) = (above) + foldl
@@ -822,16 +809,16 @@ private theorem progressMatrix_succ_eq_colReplace
       have hjlt' : j < s + 1 := Nat.lt_succ_of_lt hjlt
       have hj_idx_lt_succ : (⟨j, hj⟩ : Fin k).val < s + 1 := hjlt'
       have hj_idx_lt : (⟨j, hj⟩ : Fin k).val < s := hjlt
-      rw [progressMatrix_get_lt b k hk (s + 1) ii (⟨j, hj⟩ : Fin k) hj_idx_lt_succ]
-      rw [progressMatrix_get_lt b k hk s ii (⟨j, hj⟩ : Fin k) hj_idx_lt]
+      rw [progressMatrix_get_lt b k hk (s + 1) ii (⟨j, hj⟩ : Fin k) hj_idx_lt_succ,
+        progressMatrix_get_lt b k hk s ii (⟨j, hj⟩ : Fin k) hj_idx_lt]
     · -- j ≥ s. Since j ≠ s, we have j > s.
       have hjge : j ≥ s := Nat.le_of_not_lt hjlt
       have hjgt : j > s := Nat.lt_of_le_of_ne hjge fun h => hjs_ne h.symm
       have hj_idx_nlt_succ : ¬ (⟨j, hj⟩ : Fin k).val < s + 1 := by
         change ¬ j < s + 1; omega
       have hj_idx_nlt : ¬ (⟨j, hj⟩ : Fin k).val < s := hjlt
-      rw [progressMatrix_get_ge b k hk (s + 1) ii (⟨j, hj⟩ : Fin k) hj_idx_nlt_succ]
-      rw [progressMatrix_get_ge b k hk s ii (⟨j, hj⟩ : Fin k) hj_idx_nlt]
+      rw [progressMatrix_get_ge b k hk (s + 1) ii (⟨j, hj⟩ : Fin k) hj_idx_nlt_succ,
+        progressMatrix_get_ge b k hk s ii (⟨j, hj⟩ : Fin k) hj_idx_nlt]
 
 /-- The col-op step preserves the determinant. -/
 private theorem progressMatrix_succ_det
@@ -873,8 +860,7 @@ private theorem dot_castIntRow_eq_cast_dot
   have hj_entry : (Vector.map (fun x : Int => (x : Rat)) (b.row j))[k] = ((b.row j)[k] : Rat) := by
     change (Vector.map (fun x : Int => (x : Rat)) (b.row j))[k.val] = ((b.row j)[k.val] : Rat)
     rw [Vector.getElem_map]
-  rw [hi_entry, hj_entry]
-  rw [Rat.intCast_mul]
+  rw [hi_entry, hj_entry, Rat.intCast_mul]
 
 /-- The original-row coordinates chosen for the Gram-Schmidt prefix projection
 solve the leading Gram linear system whose right-hand side is obtained by
@@ -969,8 +955,7 @@ private theorem progressMatrix_zero_eq_castIntDetMatrix (b : Matrix Int n m)
   change (progressMatrix b k hk 0)[ii][jj] =
     (castIntDetMatrix (GramSchmidt.leadingGramMatrixInt b k hk))[ii][jj]
   have hjnlt : ¬ jj.val < 0 := Nat.not_lt_zero _
-  rw [progressMatrix_get_ge b k hk 0 ii jj hjnlt]
-  rw [castIntDetMatrix_get]
+  rw [progressMatrix_get_ge b k hk 0 ii jj hjnlt, castIntDetMatrix_get]
   -- LHS: Vector.dotProduct (castIntRow b (lift ii)) (castIntRow b (lift jj))
   -- RHS: ((leadingGramMatrixInt b k hk)[ii][jj] : Int : Rat)
   --   = (Vector.dotProduct (b.row (lift ii)) (b.row (lift jj)) : Int : Rat)
@@ -1008,8 +993,7 @@ private theorem gramDet_rat_eq_progressMatrix_zero_det (b : Matrix Int n m)
   have hcast_chain : ((gramDet b k hk : Nat) : Rat) =
       ((gramDet b k hk : Int) : Rat) := by
     push_cast; rfl
-  rw [hcast_chain]
-  rw [hstep1, hstep2, hstep3]
+  rw [hcast_chain, hstep1, hstep2, hstep3]
 
 /-- Core proof of the Gram-determinant / squared-norm product identity.
 
@@ -1021,9 +1005,8 @@ theorem and downstream callers. -/
 private theorem gramDet_eq_prod_normSq_core (b : Matrix Int n m)
     (_hli : independent b) (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
-  rw [gramDet_rat_eq_progressMatrix_zero_det b k hk]
-  rw [← progressMatrix_det_invariant b k hk k (Nat.le_refl k)]
-  rw [progressMatrix_full_eq_auxMatrix]
+  rw [gramDet_rat_eq_progressMatrix_zero_det b k hk,
+    ← progressMatrix_det_invariant b k hk k (Nat.le_refl k), progressMatrix_full_eq_auxMatrix]
   exact auxMatrix_det_eq_prod_normSq b k hk
 
 /-- The `k`-leading Gram determinant equals, as a rational, the product of the
@@ -1053,8 +1036,7 @@ theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
       gramSchmidtNormProduct b k (Nat.le_of_succ_le hk) *
         Vector.normSq ((basis b).row ⟨k, Nat.lt_of_succ_le hk⟩) := by
   unfold gramSchmidtNormProduct
-  rw [List.finRange_succ_last]
-  rw [List.foldl_append, List.foldl_map]
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
   simp only [List.foldl_cons, List.foldl_nil]
   rfl
 
@@ -1072,10 +1054,9 @@ private theorem basis_normSq_core (b : Matrix Int n m)
   have hprod_ne : gramSchmidtNormProduct b k hk_le ≠ 0 := by
     rw [← gramDet_eq_prod_normSq b hli k hk_le]
     exact Rat.ne_of_gt hden_pos
-  rw [gramDet_eq_prod_normSq b hli (k + 1) (Nat.succ_le_of_lt hk)]
-  rw [gramDet_eq_prod_normSq b hli k hk_le]
-  rw [gramSchmidtNormProduct_succ b k (Nat.succ_le_of_lt hk)]
-  rw [Rat.mul_comm]
+  rw [gramDet_eq_prod_normSq b hli (k + 1) (Nat.succ_le_of_lt hk),
+    gramDet_eq_prod_normSq b hli k hk_le, gramSchmidtNormProduct_succ b k (Nat.succ_le_of_lt hk),
+    Rat.mul_comm]
   exact (Rat.mul_div_cancel hprod_ne).symm
 
 /-- The squared norm of the `k`-th Gram-Schmidt basis vector is the ratio of
@@ -1094,9 +1075,7 @@ index. For `p < r`, `castIntRow b p` lies in the basis-vector span of indices
 private theorem dot_castIntRow_basis_eq_zero_of_lt
     (b : Matrix Int n m) (p r : Nat) (hp : p < n) (hr : r < n) (hpr : p < r) :
     Vector.dotProduct (castIntRow b ⟨p, hp⟩) ((basis b).row ⟨r, hr⟩) = 0 := by
-  rw [dot_comm_rat]
-  rw [castIntRow_decomposition b p hp]
-  rw [dot_add_right_rat]
+  rw [dot_comm_rat, castIntRow_decomposition b p hp, dot_add_right_rat]
   have hbasis : Vector.dotProduct ((basis b).row ⟨r, hr⟩) ((basis b).row ⟨p, hp⟩) = 0 :=
     basis_orthogonal b r p hr hp (Nat.ne_of_gt hpr)
   have hprefix : Vector.dotProduct ((basis b).row ⟨r, hr⟩)
@@ -1163,8 +1142,7 @@ private theorem dot_castIntRow_castIntRow_eq
   obtain ⟨d, rfl⟩ : ∃ d, i = (j + 1) + d := ⟨i - (j + 1), by omega⟩
   have hkdn : (j + 1) + d ≤ n := Nat.le_of_lt hi
   -- LHS via basis_decomposition for `castIntRow b i`.
-  rw [castIntRow_decomposition b ((j + 1) + d) hi]
-  rw [dot_add_right_rat]
+  rw [castIntRow_decomposition b ((j + 1) + d) hi, dot_add_right_rat]
   rw [dot_castIntRow_basis_eq_zero_of_lt b p ((j + 1) + d) hp hi
     (Nat.lt_of_le_of_lt hp_le_j hj)]
   rw [Rat.zero_add]
@@ -1314,8 +1292,7 @@ private theorem dot_basis_basisPrefixProjection_eq_coeff_mul_normSq
         (GramSchmidt.prefixRows (basis b) j hjlt).row q =
           (basis b).row ⟨q.val, hq_lt_n⟩ := by
       simp [GramSchmidt.prefixRows, Matrix.row, Vector.getElem_ofFn]
-    rw [hrow]
-    rw [basis_orthogonal b j q.val hjlt hq_lt_n (Nat.ne_of_gt hqval)]
+    rw [hrow, basis_orthogonal b j q.val hjlt hq_lt_n (Nat.ne_of_gt hqval)]
     grind
 
 /-- Dotting `basisPrefixProjection b i j` with `(basis b).row ⟨j, _⟩` also
@@ -1327,9 +1304,8 @@ private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
       (originalProjectionCoords b i j hi (Nat.lt_trans hj hi))[Fin.last j] *
         Vector.normSq ((basis b).row ⟨j, Nat.lt_trans hj hi⟩) := by
   have hjlt : j < n := Nat.lt_trans hj hi
-  rw [← originalProjectionCoords_spec b i j hi hjlt]
-  rw [dot_rowCombination_right_rat]
-  rw [foldl_finRange_succ_isolate_last j _ ?_]
+  rw [← originalProjectionCoords_spec b i j hi hjlt, dot_rowCombination_right_rat,
+    foldl_finRange_succ_isolate_last j _ ?_]
   · -- Last term: origProjCoords[⟨j, _⟩] * dot basis[j] (cast b row j).
     -- castIntMatrixRat b row at ⟨j, _⟩ = castIntRow b ⟨j, _⟩.
     have hrow :
@@ -1339,8 +1315,7 @@ private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
         castIntMatrixRat, castIntRow, Fin.last]
     rw [hrow]
     -- dot basis[j] castIntRow b j = dot basis[j] (basis[j] + prefixComb) = normSq + 0.
-    rw [castIntRow_decomposition b j hjlt]
-    rw [dot_add_right_rat]
+    rw [castIntRow_decomposition b j hjlt, dot_add_right_rat]
     have hbasis_self :
         Vector.dotProduct ((basis b).row ⟨j, hjlt⟩) ((basis b).row ⟨j, hjlt⟩) =
           Vector.normSq ((basis b).row ⟨j, hjlt⟩) := rfl
@@ -1365,9 +1340,7 @@ private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
           castIntRow b ⟨q.val, hq_lt_n⟩ := by
       simp [GramSchmidt.prefixRows, Matrix.row, Vector.getElem_ofFn,
         castIntMatrixRat, castIntRow]
-    rw [hrow]
-    rw [dot_comm_rat]
-    rw [dot_castIntRow_basis_eq_zero_of_lt b q.val j hq_lt_n hjlt hqval]
+    rw [hrow, dot_comm_rat, dot_castIntRow_basis_eq_zero_of_lt b q.val j hq_lt_n hjlt hqval]
     grind
 
 /-- The Gram-determinant succession: `(gramDet (j+1) : Rat)` factors as
@@ -1379,9 +1352,9 @@ theorem gramDet_succ_rat
         Vector.normSq ((basis b).row ⟨j, Nat.lt_of_succ_le hjsuc⟩) := by
   have hgd_eq_gsnp :
       (gramDet b (j + 1) hjsuc : Rat) = gramSchmidtNormProduct b (j + 1) hjsuc := by
-    rw [gramDet_rat_eq_progressMatrix_zero_det]
-    rw [← progressMatrix_det_invariant b (j + 1) hjsuc (j + 1) (Nat.le_refl _)]
-    rw [progressMatrix_full_eq_auxMatrix]
+    rw [gramDet_rat_eq_progressMatrix_zero_det,
+      ← progressMatrix_det_invariant b (j + 1) hjsuc (j + 1) (Nat.le_refl _),
+      progressMatrix_full_eq_auxMatrix]
     exact auxMatrix_det_eq_prod_normSq b (j + 1) hjsuc
   rw [hgd_eq_gsnp]
   exact gramSchmidtNormProduct_succ b j hjsuc

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -220,8 +220,7 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
           simpa [last] using hval)
       simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Matrix.setCol, Matrix.ofFn,
         Vector.getElem_ofFn]
-      rw [if_pos hq_last]
-      rw [hq_lift]
+      rw [if_pos hq_last, hq_lift]
     · simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Matrix.setCol, Matrix.ofFn,
         Vector.getElem_ofFn]
       rw [if_neg hq_last]
@@ -341,8 +340,7 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
           (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE q ht] =
             (Matrix.rowAdd b j k c)[k] :=
         congrArg (Matrix.rowAdd b j k c).get hqn_k
-      rw [hrowAdd_p, hrowAdd_q]
-      rw [dot_rowAdd_row_at_left b j k c ((Matrix.rowAdd b j k c)[k])]
+      rw [hrowAdd_p, hrowAdd_q, dot_rowAdd_row_at_left b j k c ((Matrix.rowAdd b j k c)[k])]
       have hrec_k :
           Vector.dotProduct b[k] ((Matrix.rowAdd b j k c)[k]) =
             Vector.dotProduct b[k] b[k] + c * Vector.dotProduct b[k] b[j] :=
@@ -370,18 +368,16 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
         congrArg (Matrix.rowAdd b j k c).get hqn_k
       have hb_q : b[GramSchmidt.liftFinLE q ht] = b[k] :=
         congrArg b.get hqn_k
-      rw [hrowAdd_q]
-      rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne]
-      rw [dot_rowAdd_row_at_right b j k c (b[GramSchmidt.liftFinLE p ht])]
+      rw [hrowAdd_q, rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE p ht) c hpn_ne,
+        dot_rowAdd_row_at_right b j k c (b[GramSchmidt.liftFinLE p ht])]
       simp only [if_neg hpk]
-      rw [hM_entry p q, hM_entry p jt]
-      rw [hbjt_lift, hb_q]
+      rw [hM_entry p q, hM_entry p jt, hbjt_lift, hb_q]
   · -- q ≠ kt branch
     rw [if_neg hqk]
     have hqn_ne : (GramSchmidt.liftFinLE q ht).val ≠ k.val :=
       fun h => hqk (Fin.ext h)
-    rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q]
-    rw [rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE q ht) c hqn_ne]
+    rw [rowAdd_get_rect (GramSchmidt.leadingGramMatrixInt b t ht) jt kt p c q,
+      rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE q ht) c hqn_ne]
     have hbjt_lift : b[GramSchmidt.liftFinLE jt ht] = b[j] :=
       congrArg b.get hjt_lift
     have hbkt_lift : b[GramSchmidt.liftFinLE kt ht] = b[k] :=
@@ -394,11 +390,9 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
           (Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht] =
             (Matrix.rowAdd b j k c)[k] :=
         congrArg (Matrix.rowAdd b j k c).get hpn_k
-      rw [hrowAdd_p]
-      rw [dot_rowAdd_row_at_left b j k c (b[GramSchmidt.liftFinLE q ht])]
+      rw [hrowAdd_p, dot_rowAdd_row_at_left b j k c (b[GramSchmidt.liftFinLE q ht])]
       simp only [if_pos hpk]
-      rw [hM_entry kt q, hM_entry jt q]
-      rw [hbjt_lift, hbkt_lift]
+      rw [hM_entry kt q, hM_entry jt q, hbjt_lift, hbkt_lift]
     · -- p ≠ kt, q ≠ kt
       have hpn_ne : (GramSchmidt.liftFinLE p ht).val ≠ k.val :=
         fun h => hpk (Fin.ext h)
@@ -484,8 +478,7 @@ theorem gramDet_rowAdd_earlier
           (⟨k.val, hkt⟩ : Fin t).val :=
         congrArg Fin.val h
       exact Nat.ne_of_lt hjk hval
-    rw [Matrix.det_colAdd _ _ _ _ hjt_ne_kt]
-    rw [Matrix.det_rowAdd _ _ _ _ hjt_ne_kt]
+    rw [Matrix.det_colAdd _ _ _ _ hjt_ne_kt, Matrix.det_rowAdd _ _ _ _ hjt_ne_kt]
   · -- Outside case: leading prefix unchanged.
     have hkt' : t ≤ k.val := Nat.le_of_not_lt hkt
     rw [leadingGramMatrixInt_rowAdd_outside b j k c t ht hkt']
@@ -609,8 +602,7 @@ theorem scaledCoeffs_rowAdd_other_row (b : Matrix Int n m) (j k : Fin n)
       _ = ((GramSchmidt.entry (scaledCoeffs b) i l : Int) : Rat) := hold.symm
   · by_cases hil : i = l
     · subst l
-      rw [← hil]
-      rw [scaledCoeffs_diag, scaledCoeffs_diag]
+      rw [← hil, scaledCoeffs_diag, scaledCoeffs_diag]
       exact congrArg Int.ofNat
         (gramDet_rowAdd_earlier b j k c (i.val + 1)
           (Nat.succ_le_of_lt i.isLt) hjk)

--- a/HexGramSchmidtMathlib/Int/Swap.lean
+++ b/HexGramSchmidtMathlib/Int/Swap.lean
@@ -38,17 +38,15 @@ private theorem intCast_rat_injective_int_eq {a b : Int} (h : (a : Rat) = (b : R
 /-- The rational dot product is additive in its left argument. -/
 theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
     Vector.dotProduct (u + v) w = Vector.dotProduct u w + Vector.dotProduct v w := by
-  rw [dot_comm_rat (u := u + v) (v := w)]
-  rw [dot_add_right_rat (u := w) (v := u) (w := v)]
-  rw [dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
+  rw [dot_comm_rat (u := u + v) (v := w), dot_add_right_rat (u := w) (v := u) (w := v),
+    dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
 
 /-- The rational dot product is homogeneous in its left argument: a scalar
 factors out. -/
 theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
     Vector.dotProduct (s • u) v = s * Vector.dotProduct u v := by
-  rw [dot_comm_rat (u := s • u) (v := v)]
-  rw [dot_smul_right_rat (s := s) (u := v) (v := u)]
-  rw [dot_comm_rat (u := v) (v := u)]
+  rw [dot_comm_rat (u := s • u) (v := v), dot_smul_right_rat (s := s) (u := v) (v := u),
+    dot_comm_rat (u := v) (v := u)]
 
 /-- Pythagoras: if `curr ⊥ prev`, then the squared norm of `curr + μ • prev`
 splits as `‖curr‖² + μ² · ‖prev‖²`. -/
@@ -59,13 +57,13 @@ theorem normSq_add_smul_orthogonal_rat {m' : Nat}
       Vector.normSq curr + μ ^ 2 * Vector.normSq prev := by
   show Vector.dotProduct (curr + μ • prev) (curr + μ • prev) =
     Vector.dotProduct curr curr + μ ^ 2 * Vector.dotProduct prev prev
-  rw [dot_add_left_rat (u := curr) (v := μ • prev) (w := curr + μ • prev)]
-  rw [dot_add_right_rat (u := curr) (v := curr) (w := μ • prev)]
-  rw [dot_add_right_rat (u := μ • prev) (v := curr) (w := μ • prev)]
-  rw [dot_smul_right_rat (s := μ) (u := curr) (v := prev)]
-  rw [dot_smul_left_rat (s := μ) (u := prev) (v := curr)]
-  rw [dot_smul_left_rat (s := μ) (u := prev) (v := μ • prev)]
-  rw [dot_smul_right_rat (s := μ) (u := prev) (v := prev)]
+  rw [dot_add_left_rat (u := curr) (v := μ • prev) (w := curr + μ • prev),
+    dot_add_right_rat (u := curr) (v := curr) (w := μ • prev),
+    dot_add_right_rat (u := μ • prev) (v := curr) (w := μ • prev),
+    dot_smul_right_rat (s := μ) (u := curr) (v := prev),
+    dot_smul_left_rat (s := μ) (u := prev) (v := curr),
+    dot_smul_left_rat (s := μ) (u := prev) (v := μ • prev),
+    dot_smul_right_rat (s := μ) (u := prev) (v := prev)]
   have horth_swap : Vector.dotProduct prev curr = 0 := by
     rw [dot_comm_rat]; exact horth
   rw [horth, horth_swap]
@@ -94,9 +92,8 @@ not actually used by the proof. -/
 theorem gramDet_eq_prod_normSq_uncond (b : Matrix Int n m)
     (k : Nat) (hk : k ≤ n) :
     (gramDet b k hk : Rat) = gramSchmidtNormProduct b k hk := by
-  rw [gramDet_rat_eq_progressMatrix_zero_det b k hk]
-  rw [← progressMatrix_det_invariant b k hk k (Nat.le_refl k)]
-  rw [progressMatrix_full_eq_auxMatrix]
+  rw [gramDet_rat_eq_progressMatrix_zero_det b k hk,
+    ← progressMatrix_det_invariant b k hk k (Nat.le_refl k), progressMatrix_full_eq_auxMatrix]
   exact auxMatrix_det_eq_prod_normSq b k hk
 
 /-- `gramDet` is independent of the propositional `≤ n` proof, and depends only
@@ -285,11 +282,9 @@ theorem dot_basis_castRow_eq_coeffs_mul_normSq
   -- Expand `castIntRow b i` via `basis_decomposition`.
   have hrow := castIntRow_decomposition b i hi
   show Vector.dotProduct ((basis b).row ⟨j, hjlt⟩) (castIntRow b ⟨i, hi⟩) = _
-  rw [hrow]
-  rw [dot_add_right_rat]
+  rw [hrow, dot_add_right_rat]
   -- First term: `dot basis[j] basis[i] = 0` by orthogonality (j ≠ i).
-  rw [basis_orthogonal b j i hjlt hi (Nat.ne_of_lt hj)]
-  rw [Rat.zero_add]
+  rw [basis_orthogonal b j i hjlt hi (Nat.ne_of_lt hj), Rat.zero_add]
   -- Second term: linearise the prefixCombination, then isolate the j-th index.
   rw [dot_prefixCombination_right_rat (coeffs := coeffs b) (basisM := basis b)
       (i := i) (hi := hi) (u := (basis b).row ⟨j, hjlt⟩)]
@@ -613,8 +608,7 @@ theorem dot_basis_rowSwap_curr_castRow_eq
           ((basis b).row ⟨k.val, _⟩) = _
     have hi_eq : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
     have hk_eq : (⟨k.val, Nat.lt_trans hki i.isLt⟩ : Fin n) = k := Fin.ext rfl
-    rw [hi_eq, hk_eq]
-    rw [hdot_curr]
+    rw [hi_eq, hk_eq, hdot_curr]
   rw [hf_km1, hf_k]
   ring
 

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -59,9 +59,8 @@ theorem scaledCoeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n)
     GramSchmidt.entry (scaledCoeffs (sizeReduce b j k r)) k j =
       GramSchmidt.entry (scaledCoeffs b) k j -
         r * Int.ofNat (gramDet b (j.val + 1) (Nat.succ_le_of_lt j.isLt)) := by
-  rw [sizeReduce]
-  rw [scaledCoeffs_rowAdd_pivot (b := b) (j := j) (k := k) hjk (-r)]
-  rw [Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
+  rw [sizeReduce, scaledCoeffs_rowAdd_pivot (b := b) (j := j) (k := k) hjk (-r),
+    Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
 
 /-- Size-reduce update at a column `l` below the pivot (`l < j < k`): the
 scaled coefficient at `(k, l)` decreases by `r` times the `(j, l)`
@@ -72,9 +71,8 @@ theorem scaledCoeffs_sizeReduce_lower (b : Matrix Int n m) (l j k : Fin n)
     GramSchmidt.entry (scaledCoeffs (sizeReduce b j k r)) k l =
       GramSchmidt.entry (scaledCoeffs b) k l -
         r * GramSchmidt.entry (scaledCoeffs b) j l := by
-  rw [sizeReduce]
-  rw [scaledCoeffs_rowAdd_lower (b := b) (l := l) (j := j) (k := k) hlj hjk (-r)]
-  rw [Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
+  rw [sizeReduce, scaledCoeffs_rowAdd_lower (b := b) (l := l) (j := j) (k := k) hlj hjk (-r),
+    Int.neg_mul, Lean.Grind.Ring.sub_eq_add_neg]
 
 /-- Size-reduce touches only row `k`: every other row `i ≠ k` of the
 scaled-coefficient matrix is left unchanged. -/
@@ -230,8 +228,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
     have hT : (Matrix.rowSwap M km1' k').transpose[idx][pp] =
         (Matrix.rowSwap M km1' k')[pp][idx] := by
       simp [Matrix.transpose, Matrix.col]
-    rw [hT]
-    rw [Matrix.rowSwap_getElem (M := M) (i := km1') (j := k') (r := pp) (k := idx)]
+    rw [hT, Matrix.rowSwap_getElem (M := M) (i := km1') (j := k') (r := pp) (k := idx)]
     by_cases hpk : pp = k'
     · simp [hpk]
     · by_cases hpkm1 : pp = km1'
@@ -895,8 +892,7 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     rw [hcastRow_b'i, hbasis_swap]
     -- dot (curr + μ • prev) (cast b.row i)
     --   = dot curr (cast b.row i) + μ * dot prev (cast b.row i)
-    rw [dot_add_left_rat, dot_smul_left_rat]
-    rw [hdotk, hdotkm1]
+    rw [dot_add_left_rat, dot_smul_left_rat, hdotk, hdotkm1]
   -- Key Rat identity: nu'[i][km1] = G * <basis(b')[km1], cast(b'.row i)>.
   -- The proof uses scaledCoeffs_eq for b', plus dot_basis_castRow on b', plus
   -- the fact that d_k(b') = G * |basis(b')[km1]|^2 so the cancellation is clean.
@@ -940,8 +936,7 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
           (Nk + μ ^ 2 * Nkm1) =
         GramSchmidt.entry (coeffs b) i k * Nk +
           μ * (GramSchmidt.entry (coeffs b) i km1 * Nkm1) := by
-      rw [← hN'_eq]
-      rw [hcoeff_normSq]
+      rw [← hN'_eq, hcoeff_normSq]
       exact hdot_b'_km1
     linear_combination G * hcoeff_inner
   -- Combine all rational identities and discharge by ring.

--- a/HexHensel/Basic.lean
+++ b/HexHensel/Basic.lean
@@ -77,8 +77,7 @@ is the `ZMod64` image of the canonical representative of the original coefficien
 @[simp, grind =] theorem coeff_modP (p : Nat) [ZMod64.Bounds p] (f : ZPoly) (i : Nat) :
     (modP p f).coeff i = ZMod64.ofNat p (intModNat (f.coeff i) p) := by
   unfold modP FpPoly.ofCoeffs
-  rw [DensePoly.coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [DensePoly.coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hi : i < f.size
   · simp [hi]
   · have hcoeff : f.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
@@ -103,8 +102,7 @@ by its canonical nonnegative representative in `[0, p^k)`. -/
 @[simp, grind =] theorem coeff_reduceModPow (f : ZPoly) (p k i : Nat) :
     (reduceModPow f p k).coeff i = Int.ofNat (intModNat (f.coeff i) (p ^ k)) := by
   unfold reduceModPow
-  rw [DensePoly.coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [DensePoly.coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hi : i < f.size
   · simp [hi]
   · have hcoeff : f.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
@@ -272,8 +270,7 @@ nonnegative `Nat` representative of the corresponding `ZMod64` element. -/
 @[simp, grind =] theorem coeff_liftToZ (f : FpPoly p) (i : Nat) :
     (liftToZ f).coeff i = Int.ofNat (f.coeff i).toNat := by
   unfold liftToZ
-  rw [DensePoly.coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [DensePoly.coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hi : i < f.size
   · simp [hi]
   · have hcoeff : f.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
@@ -323,16 +320,14 @@ theorem modP_liftToZ_coeff (f : FpPoly p) (i : Nat) :
 `1 % p` form that blocks rewriting in monicity proofs of `liftToZ`. -/
 private theorem zmod64_toNat_one_of_one_lt (hp : 1 < p) :
     ZMod64.toNat (1 : ZMod64 p) = 1 := by
-  rw [show (1 : ZMod64 p) = ZMod64.one from rfl]
-  rw [ZMod64.toNat_one, Nat.mod_eq_of_lt hp]
+  rw [show (1 : ZMod64 p) = ZMod64.one from rfl, ZMod64.toNat_one, Nat.mod_eq_of_lt hp]
 
 /-- Specialised `toNat` reduction for `(0 : ZMod64 p)`, dual to
 `zmod64_toNat_one_of_one_lt`; lets monicity proofs derive `1 ≠ 0` from the lifted
 representatives. -/
 private theorem zmod64_toNat_zero :
     ZMod64.toNat (0 : ZMod64 p) = 0 := by
-  rw [show (0 : ZMod64 p) = ZMod64.zero from rfl]
-  rw [ZMod64.toNat_zero]
+  rw [show (0 : ZMod64 p) = ZMod64.zero from rfl, ZMod64.toNat_zero]
 
 /-- Size-positivity step for the monicity-preservation proof: a monic `FpPoly p`
 with `1 < p` lifts to a `ZPoly` of positive size. Factored out to keep the
@@ -387,8 +382,7 @@ theorem monic_liftToZ_of_monic
     DensePoly.Monic (liftToZ f) := by
   have hpos : 0 < (liftToZ f).size :=
     liftToZ_size_pos_of_monic f hp hf
-  rw [DensePoly.Monic, DensePoly.leadingCoeff_eq_coeff_last (liftToZ f) hpos]
-  rw [coeff_liftToZ]
+  rw [DensePoly.Monic, DensePoly.leadingCoeff_eq_coeff_last (liftToZ f) hpos, coeff_liftToZ]
   have hf_pos : 0 < f.size := by
     by_cases hf_pos : 0 < f.size
     · exact hf_pos
@@ -442,8 +436,7 @@ theorem monic_liftToZ_of_monic
 theorem congr_liftToZ_modP (f : ZPoly) :
     ZPoly.congr (liftToZ (ZPoly.modP p f)) f p := by
   intro i
-  rw [coeff_liftToZ, ZPoly.coeff_modP]
-  rw [ZMod64.toNat_ofNat]
+  rw [coeff_liftToZ, ZPoly.coeff_modP, ZMod64.toNat_ofNat]
   have hp : 0 < p := ZMod64.Bounds.pPos (p := p)
   have hmod : ZPoly.intModNat (f.coeff i) p % p = ZPoly.intModNat (f.coeff i) p := by
     rw [Nat.mod_eq_of_lt]

--- a/HexHensel/Linear.lean
+++ b/HexHensel/Linear.lean
@@ -38,8 +38,7 @@ coefficient, with no dependence on the polynomial's size. -/
 @[simp, grind =] theorem coeff_coeffwiseDiv (f : ZPoly) (m i : Nat) :
     (coeffwiseDiv f m).coeff i = f.coeff i / Int.ofNat m := by
   unfold coeffwiseDiv
-  rw [DensePoly.coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [DensePoly.coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hi : i < f.size
   · simp [hi]
   · have hcoeff : f.coeff i = 0 := DensePoly.coeff_eq_zero_of_size_le f (Nat.le_of_not_gt hi)
@@ -108,8 +107,7 @@ theorem congr_liftScaledIncrement_zero
     (p k : Nat) [ZMod64.Bounds p] (r : FpPoly p) :
     ZPoly.congr (liftScaledIncrement p k r) 0 (p ^ k) := by
   intro i
-  rw [coeff_liftScaledIncrement]
-  rw [DensePoly.coeff_zero]
+  rw [coeff_liftScaledIncrement, DensePoly.coeff_zero]
   simp
 
 end LinearLiftResult
@@ -311,10 +309,9 @@ theorem liftToZ_add_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f + g)) (FpPoly.liftToZ f + FpPoly.liftToZ g) p := by
   intro i
-  rw [FpPoly.coeff_liftToZ]
-  rw [DensePoly.coeff_add f g i (zmod_add_zero_zero p)]
-  rw [DensePoly.coeff_add (FpPoly.liftToZ f) (FpPoly.liftToZ g) i (by rfl)]
-  rw [FpPoly.coeff_liftToZ, FpPoly.coeff_liftToZ]
+  rw [FpPoly.coeff_liftToZ, DensePoly.coeff_add f g i (zmod_add_zero_zero p),
+    DensePoly.coeff_add (FpPoly.liftToZ f) (FpPoly.liftToZ g) i (by rfl),
+    FpPoly.coeff_liftToZ, FpPoly.coeff_liftToZ]
   exact zmod_add_lift_congr p (f.coeff i) (g.coeff i)
 
 /-- The integer lift of a `ZMod64 p` product agrees modulo `p` with the product
@@ -600,8 +597,7 @@ theorem liftToZ_mul_congr
     (p : Nat) [ZMod64.Bounds p] (f g : FpPoly p) :
     ZPoly.congr (FpPoly.liftToZ (f * g)) (FpPoly.liftToZ f * FpPoly.liftToZ g) p := by
   intro n
-  rw [FpPoly.coeff_liftToZ, FpPoly.coeff_mul, DensePoly.coeff_mul]
-  rw [mulCoeffSum_eq_diagonal_int]
+  rw [FpPoly.coeff_liftToZ, FpPoly.coeff_mul, DensePoly.coeff_mul, mulCoeffSum_eq_diagonal_int]
   rw [diagonalSum_eq_bound_int (FpPoly.liftToZ f) (FpPoly.liftToZ g) n f.size
     (liftToZ_size_le p f)]
   exact fold_liftToZ_mulCoeffTerm_congr p f g n (List.range f.size) 0 0 (by
@@ -751,8 +747,7 @@ private theorem scale_congr_of_congr_mod_base
   rcases hbase with ⟨w, hw⟩
   apply Int.emod_eq_zero_of_dvd
   refine ⟨w, ?_⟩
-  rw [← Int.mul_sub, hw]
-  rw [← Int.mul_assoc]
+  rw [← Int.mul_sub, hw, ← Int.mul_assoc]
   have hpow : p ^ (k + 1) = p ^ k * p := by
     rw [Nat.pow_succ]
   rw [hpow]
@@ -774,8 +769,7 @@ private theorem liftScaledCoeff_product_dvd_next
   have hpow_exp : (1 + k0) + (1 + k0) = (1 + k0 + 1) + k0 := by
     omega
   have hpow : p ^ (1 + k0) * p ^ (1 + k0) = p ^ (1 + k0 + 1) * p ^ k0 := by
-    rw [← Nat.pow_add, ← Nat.pow_add]
-    rw [hpow_exp]
+    rw [← Nat.pow_add, ← Nat.pow_add, hpow_exp]
   calc
     Int.ofNat (p ^ (1 + k0)) * Int.ofNat (r.coeff i).toNat *
         (Int.ofNat (p ^ (1 + k0)) * Int.ofNat (hCorrection.coeff j).toNat)
@@ -1006,9 +1000,8 @@ private theorem dense_scale_mul_left_int
 private theorem dense_scale_mul_right_int
     (c : Int) (hc : c ≠ 0) (f g : ZPoly) :
     f * DensePoly.scale c g = DensePoly.scale c (f * g) := by
-  rw [DensePoly.mul_comm_poly f (DensePoly.scale c g)]
-  rw [dense_scale_mul_left_int c hc]
-  rw [DensePoly.mul_comm_poly g f]
+  rw [DensePoly.mul_comm_poly f (DensePoly.scale c g), dense_scale_mul_left_int c hc,
+    DensePoly.mul_comm_poly g f]
 
 /-- Scaling by `c` distributes over addition:
 `scale c (f + g) = scale c f + scale c g`. -/
@@ -1017,11 +1010,9 @@ private theorem dense_scale_add_int
     DensePoly.scale c (f + g) = DensePoly.scale c f + DensePoly.scale c g := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
-  rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
+  rw [DensePoly.coeff_scale _ _ _ (Int.mul_zero c), DensePoly.coeff_add_semiring,
+    DensePoly.coeff_add_semiring, DensePoly.coeff_scale _ _ _ (Int.mul_zero c),
+    DensePoly.coeff_scale _ _ _ (Int.mul_zero c)]
   grind
 
 /-- When the cross term is zero modulo `m`, the regrouping
@@ -1031,11 +1022,8 @@ private theorem add_cross_congr
     (hcross : ZPoly.congr cross 0 m) :
     ZPoly.congr (base + a + (b + cross)) (base + (a + b)) m := by
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring,
+    DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring]
   have hx := hcross i
   rw [DensePoly.coeff_zero] at hx
   have hdiff :
@@ -1452,8 +1440,7 @@ private theorem coeff_last_eq_leadingCoeff (f : ZPoly) (hpos : 0 < f.size) :
       have hcoeffs : 0 < coeffs.size := by simpa [DensePoly.size] using hpos
       have hidx : coeffs.size - 1 < coeffs.size := Nat.sub_one_lt (Nat.ne_of_gt hcoeffs)
       change coeffs.getD (coeffs.size - 1) 0 = coeffs.back?.getD 0
-      rw [Array.back?_eq_getElem?]
-      rw [Array.getElem?_eq_getElem hidx]
+      rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx]
       exact (Array.getElem_eq_getD 0).symm
 
 /-- A monic polynomial is nonempty: its `size` is positive. A zero-size `f` would

--- a/HexHensel/Quadratic.lean
+++ b/HexHensel/Quadratic.lean
@@ -428,8 +428,7 @@ private theorem coeff_last_eq_leadingCoeff (f : ZPoly) (hpos : 0 < f.size) :
       have hcoeffs : 0 < coeffs.size := by simpa [DensePoly.size] using hpos
       have hidx : coeffs.size - 1 < coeffs.size := Nat.sub_one_lt (Nat.ne_of_gt hcoeffs)
       change coeffs.getD (coeffs.size - 1) 0 = coeffs.back?.getD 0
-      rw [Array.back?_eq_getElem?]
-      rw [Array.getElem?_eq_getElem hidx]
+      rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx]
       exact (Array.getElem_eq_getD 0).symm
 
 /-- `monic_of_coeff_eq_one_and_high_coeff_zero` builds monicity from a coefficient equal to one with all higher coefficients zero. -/
@@ -851,8 +850,7 @@ private theorem coeff_monomial_mul
     (k : Nat) (c : Int) (q : ZPoly) (n : Nat) :
     ((DensePoly.monomial k c : ZPoly) * q).coeff n =
       if n < k then 0 else c * q.coeff (n - k) := by
-  rw [DensePoly.coeff_mul, mulCoeffSum_eq_diagonal_int]
-  rw [fold_diagonal_monomial_left]
+  rw [DensePoly.coeff_mul, mulCoeffSum_eq_diagonal_int, fold_diagonal_monomial_left]
   by_cases hk : k < (DensePoly.monomial k c : ZPoly).size
   · simp [hk, diagonalCoeffTerm, DensePoly.coeff_monomial]
   · have hcoeff : (DensePoly.monomial k c : ZPoly).coeff k = 0 :=
@@ -883,8 +881,7 @@ private theorem coeff_mulModSquare_monomial_leading
     (mulModSquare (DensePoly.monomial k c) q m).coeff (k + qd) =
       c % Int.ofNat (m ^ 2) := by
   unfold mulModSquare QuadraticLiftResult.reduceModSquare
-  rw [ZPoly.coeff_reduceModPow_eq_emod_of_pos]
-  rw [coeff_monomial_mul]
+  rw [ZPoly.coeff_reduceModPow_eq_emod_of_pos, coeff_monomial_mul]
   have hnot : ¬ k + qd < k := by omega
   have hsub : k + qd - k = qd := by omega
   have hqpos : 0 < q.size := by omega
@@ -1130,22 +1127,17 @@ private theorem quadraticHenselStep_bezout_correction_exact
   calc
     ((s - s * b - q * h) * g + (t - r) * h)
         = ((s - s * b) * g + (0 - q * h) * g) + (t - r) * h := by
-          rw [DensePoly.sub_eq_add_neg_poly (s - s * b) (q * h)]
-          rw [DensePoly.mul_add_left_poly]
+          rw [DensePoly.sub_eq_add_neg_poly (s - s * b) (q * h), DensePoly.mul_add_left_poly]
     _ = ((s * g + (0 - s * b) * g) + (0 - q * h) * g) + (t - r) * h := by
-          rw [DensePoly.sub_eq_add_neg_poly s (s * b)]
-          rw [DensePoly.mul_add_left_poly]
+          rw [DensePoly.sub_eq_add_neg_poly s (s * b), DensePoly.mul_add_left_poly]
     _ = ((s * g + (0 - s * b * g)) + (0 - (q * h) * g)) + (t - r) * h := by
-          rw [DensePoly.neg_mul_right_poly (s * b) g]
-          rw [DensePoly.neg_mul_right_poly (q * h) g]
+          rw [DensePoly.neg_mul_right_poly (s * b) g, DensePoly.neg_mul_right_poly (q * h) g]
     _ = ((s * g + (0 - s * b * g)) + (0 - (q * g) * h)) + (t - r) * h := by
-          rw [DensePoly.mul_assoc_poly q h g]
-          rw [DensePoly.mul_comm_poly h g]
-          rw [← DensePoly.mul_assoc_poly q g h]
+          rw [DensePoly.mul_assoc_poly q h g, DensePoly.mul_comm_poly h g,
+            ← DensePoly.mul_assoc_poly q g h]
     _ = ((s * g + (0 - s * b * g)) + (0 - (q * g) * h)) +
           (t * h + (0 - r) * h) := by
-          rw [DensePoly.sub_eq_add_neg_poly t r]
-          rw [DensePoly.mul_add_left_poly]
+          rw [DensePoly.sub_eq_add_neg_poly t r, DensePoly.mul_add_left_poly]
     _ = ((s * g + (0 - s * b * g)) + (0 - (q * g) * h)) +
           (t * h + (0 - r * h)) := by
           rw [DensePoly.neg_mul_right_poly r h]
@@ -1820,10 +1812,8 @@ private theorem quadraticHenselStep_factor_first_order_exact
         = (g * (s * e) + g * (q * h)) + r * h := by
           rw [DensePoly.mul_add_right_poly]
     _ = ((s * g) * e + (q * g) * h) + r * h := by
-          rw [← DensePoly.mul_assoc_poly g s e]
-          rw [DensePoly.mul_comm_poly g s]
-          rw [← DensePoly.mul_assoc_poly g q h]
-          rw [DensePoly.mul_comm_poly g q]
+          rw [← DensePoly.mul_assoc_poly g s e, DensePoly.mul_comm_poly g s,
+            ← DensePoly.mul_assoc_poly g q h, DensePoly.mul_comm_poly g q]
     _ = (s * g) * e + ((q * g) * h + r * h) := by
           apply DensePoly.ext_coeff
           intro n
@@ -1839,9 +1829,8 @@ private theorem quadraticHenselStep_factor_first_order_bezout_exact
   calc
     (s * g) * e + (t * e) * h
         = (s * g) * e + (t * h) * e := by
-          rw [DensePoly.mul_assoc_poly t e h]
-          rw [DensePoly.mul_comm_poly e h]
-          rw [← DensePoly.mul_assoc_poly t h e]
+          rw [DensePoly.mul_assoc_poly t e h, DensePoly.mul_comm_poly e h,
+            ← DensePoly.mul_assoc_poly t h e]
     _ = (s * g + t * h) * e := by
           rw [DensePoly.mul_add_left_poly]
 

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -779,8 +779,7 @@ theorem monic_of_congr_mul_monic_monic
         (g * h).coeff (gTop + hTop) = h.coeff hTop := by
       have htop := Hex.ZPoly.coeff_mul_top g h hg_pos hh_pos
       unfold gTop hTop
-      rw [htop]
-      rw [hg_top]
+      rw [htop, hg_top]
       omega
     have hmod : h.coeff hTop % (m : Int) = 0 := by
       have hc := hcongr (gTop + hTop)
@@ -823,8 +822,7 @@ theorem monic_of_congr_mul_monic_monic
     exact int_eq_of_congr_of_bounds hc
       (hh_bound_nonneg hTop) (hh_bound_lt hTop)
       (by decide) (by exact_mod_cast hm)
-  rw [Hex.DensePoly.Monic]
-  rw [Hex.DensePoly.leadingCoeff_eq_coeff_last h hh_pos]
+  rw [Hex.DensePoly.Monic, Hex.DensePoly.leadingCoeff_eq_coeff_last h hh_pos]
   unfold hTop at hlead_one
   exact hlead_one
 

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -513,9 +513,8 @@ private theorem divStep_arith (d N Np : Rat) (hd : 0 < d)
   have hinv_nonneg : 0 ≤ (1 / d : Rat) := by grind
   have hmul := Rat.mul_le_mul_of_nonneg_left h hinv_nonneg
   have hleft : (1 / d : Rat) * (d * N) = N := by
-    rw [Rat.div_def]
-    rw [show (1 : Rat) * d⁻¹ = d⁻¹ by grind]
-    rw [← Rat.mul_assoc, Rat.inv_mul_cancel d hdne]
+    rw [Rat.div_def, show (1 : Rat) * d⁻¹ = d⁻¹ by grind,
+      ← Rat.mul_assoc, Rat.inv_mul_cancel d hdne]
     grind
   simpa [hleft] using hmul
 
@@ -700,8 +699,7 @@ theorem short_vector_bound_of_size_bound (b : Matrix Int n m) {δ η : Rat}
     have h_le : δ - η * η ≤ 1 := by grind
     have hne : δ - η * η ≠ 0 := by grind
     have hα_eq : (1 / (δ - η * η)) * (δ - η * η) = 1 := by
-      rw [Rat.div_def]
-      rw [show (1 : Rat) * (δ - η * η)⁻¹ = (δ - η * η)⁻¹ from by grind]
+      rw [Rat.div_def, show (1 : Rat) * (δ - η * η)⁻¹ = (δ - η * η)⁻¹ from by grind]
       exact Rat.inv_mul_cancel _ hne
     have hstep : (1 / (δ - η * η)) * (δ - η * η) ≤ (1 / (δ - η * η)) * 1 :=
       Rat.mul_le_mul_of_nonneg_left h_le hα_nn
@@ -2098,8 +2096,7 @@ membership of `v` is unchanged. -/
   | cons k ks ih =>
     intro t
     simp only [List.foldl_cons]
-    rw [ih]
-    rw [sizeReduce_memLattice_iff, refreshRow_b]
+    rw [ih, sizeReduce_memLattice_iff, refreshRow_b]
 
 end SteeredState
 

--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -223,8 +223,7 @@ theorem lovasz_check_iff_isLLLReduced_pair
           ((gd_k1 : Rat) * (gd_km1 : Rat) +
             (gd_k : Rat) ^ 2 * μ ^ 2) ≥
         (δ.num : Rat) * (gd_k : Rat) ^ 2) := by
-    rw [ge_iff_le, ge_iff_le, ← @Int.cast_le ℚ]
-    rw [hdk_eq, hdkPrev_eq, hdkNext_eq]
+    rw [ge_iff_le, ge_iff_le, ← @Int.cast_le ℚ, hdk_eq, hdkPrev_eq, hdkNext_eq]
     push_cast
     rw [hB_sq]
     simp only [Int.ofNat_eq_natCast, Int.cast_natCast]
@@ -557,8 +556,7 @@ private theorem sizeSq_of_intCheck
     have hμ_val : μ = (νij : Rat) / (dj1 : Rat) := by
       rw [eq_div_iff hdj1_ne, mul_comm]
       exact hbridge.symm
-    rw [hμ_val]
-    rw [abs_div]
+    rw [hμ_val, abs_div]
     have habs_dj1 : |(dj1 : Rat)| = (dj1 : Rat) := abs_of_pos hdj1_pos
     rw [habs_dj1]
     have habs_νij : |(νij : Rat)| = (νij.natAbs : Rat) := by

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -91,9 +91,8 @@ theorem sizeReduce_independent (s : LLLState n m) (k : Nat)
       GramSchmidt.Int.gramDet (s.sizeReduce k).b (i.val + 1)
           (Nat.succ_le_of_lt i.isLt) =
         GramSchmidt.Int.gramDet s.b (i.val + 1) (Nat.succ_le_of_lt i.isLt) := by
-    rw [← hvalid'.d_eq (i.val + 1) (Nat.succ_lt_succ i.isLt)]
-    rw [hd_vec]
-    rw [hvalid.d_eq (i.val + 1) (Nat.succ_lt_succ i.isLt)]
+    rw [← hvalid'.d_eq (i.val + 1) (Nat.succ_lt_succ i.isLt), hd_vec,
+      hvalid.d_eq (i.val + 1) (Nat.succ_lt_succ i.isLt)]
   rw [hgram]
   exact hind i
 
@@ -257,8 +256,7 @@ private theorem foldl_modify_rows_get
 private theorem swapStep_b_eq (s : LLLState n m) (k : Nat) (hk : k < n) (hk0 : 0 < k) :
     (s.swapStep k).b = GramSchmidt.Int.adjacentSwap s.b ⟨k, hk⟩ hk0 := by
   unfold swapStep
-  rw [dif_pos hk]
-  rw [dif_pos hk0]
+  rw [dif_pos hk, dif_pos hk0]
 
 theorem swapStep_valid (s : LLLState n m) (k : Nat)
     (hind : s.b.independent) (hvalid : s.Valid) :
@@ -381,18 +379,15 @@ theorem swapStep_valid (s : LLLState n m) (k : Nat)
             ∀ (l : Fin n), l.val ≠ km1.val → l.val ≠ kFin.val →
               νRowsSwapped.get l = s.ν.get l := by
           intro l hl_km1 hl_kFin
-          rw [hνRows_def]
-          rw [vector_modify_get_ne _ kFin.val _ l (fun h => hl_kFin h.symm)]
-          rw [vector_modify_get_ne _ km1.val _ l (fun h => hl_km1 h.symm)]
+          rw [hνRows_def, vector_modify_get_ne _ kFin.val _ l (fun h => hl_kFin h.symm),
+            vector_modify_get_ne _ km1.val _ l (fun h => hl_km1 h.symm)]
         have hνRows_get_km1 : νRowsSwapped.get km1 = setPrefix (s.ν.get kFin) (s.ν.get km1) km1 := by
-          rw [hνRows_def]
-          rw [vector_modify_get_ne _ kFin.val _ km1 (fun h => hkm1_val_ne_kFin h.symm)]
+          rw [hνRows_def, vector_modify_get_ne _ kFin.val _ km1 (fun h => hkm1_val_ne_kFin h.symm)]
           exact vector_modify_get_self _ km1 _
         have hνRows_get_kFin :
             νRowsSwapped.get kFin = setPrefix (s.ν.get km1) (s.ν.get kFin) km1 := by
-          rw [hνRows_def]
-          rw [vector_modify_get_self _ kFin _]
-          rw [vector_modify_get_ne _ km1.val _ kFin hkm1_val_ne_kFin]
+          rw [hνRows_def, vector_modify_get_self _ kFin _,
+            vector_modify_get_ne _ km1.val _ kFin hkm1_val_ne_kFin]
         -- Evaluate νPivot.get.
         have hνPivot_get_ne :
             ∀ (l : Fin n), l.val ≠ kFin.val → νPivot.get l = νRowsSwapped.get l := by
@@ -415,8 +410,7 @@ theorem swapStep_valid (s : LLLState n m) (k : Nat)
           have hi_ne_kFin : iFin.val ≠ kFin.val := by
             have : iFin.val > kFin.val := hki
             omega
-          rw [hνPivot_get_ne iFin hi_ne_kFin]
-          rw [hνRows_get_ne iFin hi_ne_km1 hi_ne_kFin]
+          rw [hνPivot_get_ne iFin hi_ne_kFin, hνRows_get_ne iFin hi_ne_km1 hi_ne_kFin]
           -- Now LHS = (upd iFin (s.ν.get iFin)).get jFin. Unfold `upd` to expose
           -- the `pairs.get iFin` reference, then substitute it with its explicit
           -- value (valid since `k < iFin.val` in this branch).
@@ -594,8 +588,7 @@ theorem swapStep_valid (s : LLLState n m) (k : Nat)
               have hi_ne_km1 : iFin.val ≠ km1.val := Nat.ne_of_lt hi_lt_km1
               have hi_ne_kFin : iFin.val ≠ kFin.val := by
                 rw [hkFinVal]; omega
-              rw [hνPivot_get_ne iFin hi_ne_kFin]
-              rw [hνRows_get_ne iFin hi_ne_km1 hi_ne_kFin]
+              rw [hνPivot_get_ne iFin hi_ne_kFin, hνRows_get_ne iFin hi_ne_km1 hi_ne_kFin]
               -- LHS = (s.ν.get iFin).get jFin. Bridge through Valid then
               -- scaledCoeffs_adjacentSwap_before.
               have hν := hν_eq iFin.val jFin.val iFin.isLt jFin.isLt hjiFin
@@ -1124,8 +1117,7 @@ theorem sizeReduceColumn_valid (s : LLLState n m) (j k : Fin n)
               (Nat.le_of_lt j.isLt) (s.ν.get iFin) (s.ν.get iFin) (s.ν.get j) r jFin]
           by_cases hjlt : jFin.val < j.val
           · -- Below pivot.
-            rw [if_pos hjlt]
-            rw [hν_at iFin jFin hji', hν_at j jFin hjlt]
+            rw [if_pos hjlt, hν_at iFin jFin hji', hν_at j jFin hjlt]
             have hsc :=
               GramSchmidt.Int.scaledCoeffs_sizeReduce_lower s.b jFin j iFin hjlt hjk r
             have hsc' : ((GramSchmidt.Int.scaledCoeffs b').get iFin).get jFin =
@@ -1150,8 +1142,7 @@ theorem sizeReduceColumn_valid (s : LLLState n m) (j k : Fin n)
             rw [hsc']
             rfl
       · -- Case iFin ≠ k.
-        rw [sizeReduceColumn_ν_get_ne s j k hjk hreduce iFin hi_k]
-        rw [hν_at iFin jFin hji']
+        rw [sizeReduceColumn_ν_get_ne s j k hjk hreduce iFin hi_k, hν_at iFin jFin hji']
         have hsc :=
           GramSchmidt.Int.scaledCoeffs_sizeReduce_other_row s.b j k hjk r iFin hi_k
         -- hsc : (scaledCoeffs b').row iFin = (scaledCoeffs s.b).row iFin
@@ -1164,8 +1155,7 @@ theorem sizeReduceColumn_valid (s : LLLState n m) (j k : Fin n)
         rfl
     · -- d_eq
       intro i hi
-      rw [hd_state_eq]
-      rw [hd_at i hi, hb_eq]
+      rw [hd_state_eq, hd_at i hi, hb_eq]
       exact (GramSchmidt.Int.gramDet_sizeReduce s.b j k hjk r i (Nat.le_of_lt_succ hi)).symm
   · -- The non-reducing branch: state unchanged.
     have h_eq : s.sizeReduceColumn j k hjk = s := by
@@ -1415,12 +1405,11 @@ private theorem sizeReduce_foldl_size_reduced {n m : Nat}
 /-- `(List.finRange k).reverse` is Pairwise strictly decreasing. -/
 private theorem pairwise_finRange_reverse_lt (k : Nat) :
     ((List.finRange k).reverse).Pairwise (fun a b : Fin k => b.val < a.val) := by
-  rw [List.pairwise_reverse]
-  rw [List.pairwise_iff_getElem]
+  rw [List.pairwise_reverse, List.pairwise_iff_getElem]
   intro i j hi hj hij
   rw [List.length_finRange] at hi hj
-  rw [List.getElem_finRange (by rw [List.length_finRange]; exact hi)]
-  rw [List.getElem_finRange (by rw [List.length_finRange]; exact hj)]
+  rw [List.getElem_finRange (by rw [List.length_finRange]; exact hi),
+    List.getElem_finRange (by rw [List.length_finRange]; exact hj)]
   exact hij
 
 /-- Integer formulation: after `s.sizeReduce k`, every column `j < k` of
@@ -1636,8 +1625,8 @@ private theorem foldl_mul_strict_lt {α : Type*} {xs : List α} (hnd : xs.Nodup)
         hpos i (List.mem_cons.mpr (Or.inr hi))
       have hP_pos : 0 < rest.foldl (fun acc i => acc * f i) 1 :=
         foldl_mul_pos rest f 1 Nat.one_pos hpos_rest
-      rw [foldl_mul_pull rest g (a * g x), foldl_mul_pull rest f (a * f x)]
-      rw [← foldl_mul_congr_pointwise rest f g 1 heq_rest]
+      rw [foldl_mul_pull rest g (a * g x), foldl_mul_pull rest f (a * f x),
+        ← foldl_mul_congr_pointwise rest f g 1 heq_rest]
       have h_factor : a * g x < a * f x := (Nat.mul_lt_mul_left ha).mpr hlt
       exact (Nat.mul_lt_mul_right hP_pos).mpr h_factor
     · have hk_rest : k ∈ rest := by

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -411,8 +411,7 @@ private theorem gsDot_eq_mu_mul_nrm (b : Hex.Matrix Int n m) {i j : Fin n}
     rw [dot_comm]
     exact GramSchmidt.Int.basis_orthogonal b i.val j.val i.isLt j.isLt
       (Nat.ne_of_gt hji)
-  rw [horth, zero_add]
-  rw [Finset.sum_eq_single (⟨j.val, hji⟩ : Fin i.val)]
+  rw [horth, zero_add, Finset.sum_eq_single (⟨j.val, hji⟩ : Fin i.val)]
   · rw [dot_comm, nrm_eq_dot]
   · intro k _ hk
     have hkj : k.val ≠ j.val := fun h => hk (Fin.ext h)

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -123,8 +123,7 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
       · have hjl : j ≠ l := fun heq => hij (hil.trans heq.symm)
         rw [if_pos hil, if_neg hjl]; grind
       · rw [if_neg hil]; grind
-    rw [foldl_add_eq_acc (List.finRange n) _ _ hzero]
-    rw [if_neg hij]
+    rw [foldl_add_eq_acc (List.finRange n) _ _ hzero, if_neg hij]
 
 end Vector
 
@@ -150,18 +149,16 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
     ext a ha
     show ((1 : Matrix R n n).row ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)] =
       (Hex.Vector.unit (R := R) ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
-    rw [Matrix.row]
-    rw [Hex.Matrix.getElem_one (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
-    rw [Hex.Vector.unit_getElem (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+    rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
+      Hex.Vector.unit_getElem (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   have hrow_j : (1 : Matrix R n n).row ⟨j, hj⟩ =
       Hex.Vector.unit (R := R) ⟨j, hj⟩ := by
     ext a ha
     show ((1 : Matrix R n n).row ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)] =
       (Hex.Vector.unit (R := R) ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
-    rw [Matrix.row]
-    rw [Hex.Matrix.getElem_one (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
-    rw [Hex.Vector.unit_getElem (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+    rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
+      Hex.Vector.unit_getElem (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   show (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
     (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -51,8 +51,7 @@ private theorem foldl_sum_start {R : Type u} [Lean.Grind.Ring R]
       grind
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      rw [ih (acc := (0 : R) + f x)]
+      rw [ih (acc := acc + f x), ih (acc := (0 : R) + f x)]
       grind
 
 /-- Two fold-sums over `xs` agree when their summand functions `f` and `g` agree
@@ -126,8 +125,7 @@ private theorem foldl_sum_comm {R : Type u} [Lean.Grind.Ring R]
         intro y _hy
         rw [foldl_sum_start xs (fun x' => g x' y) (0 + g x y)]
         grind
-      rw [hinner]
-      rw [foldl_sum_add]
+      rw [hinner, foldl_sum_add]
       grind
 
 /-- Right multiplication by `c` distributes through a fold-sum, scaling each summand `f x`
@@ -215,8 +213,7 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
           rw [if_neg hxy]
           grind
-        rw [if_pos rfl]
-        rw [foldl_add_eq_acc_ring xs _ _ hxs_zero]
+        rw [if_pos rfl, foldl_add_eq_acc_ring xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -61,9 +61,8 @@ def takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
   ext i hi j hj
   show (principalSubmatrix (1 : Matrix R n n) k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)] =
     (1 : Matrix R k k)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
-  rw [getElem_principalSubmatrix]
-  rw [getElem_one (i := (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n))]
-  rw [getElem_one (i := (⟨i, hi⟩ : Fin k))]
+  rw [getElem_principalSubmatrix, getElem_one (i := (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n)),
+    getElem_one (i := (⟨i, hi⟩ : Fin k))]
   by_cases hij : (⟨i, hi⟩ : Fin k) = ⟨j, hj⟩
   · have hval : i = j := Fin.val_eq_of_eq hij
     have hijn :

--- a/HexMatrixMathlib/Basic.lean
+++ b/HexMatrixMathlib/Basic.lean
@@ -134,8 +134,7 @@ theorem matrixEquiv_rowAdd (M : Hex.Matrix R n m) (src dst : Fin n) (c : R) :
       have hone :
           ((1 : Matrix (Fin n) (Fin n) R) * matrixEquiv M) dst k =
             M[dst][k] := by
-        rw [← Matrix.diagonal_one, Matrix.diagonal_mul]
-        rw [one_mul]
+        rw [← Matrix.diagonal_one, Matrix.diagonal_mul, one_mul]
         rfl
       have hsingle :
           (Matrix.single dst src c * matrixEquiv M) dst k =
@@ -164,8 +163,7 @@ theorem matrixEquiv_rowAdd (M : Hex.Matrix R n m) (src dst : Fin n) (c : R) :
       have hone :
           ((1 : Matrix (Fin n) (Fin n) R) * matrixEquiv M) r k =
             M[r][k] := by
-        rw [← Matrix.diagonal_one, Matrix.diagonal_mul]
-        rw [one_mul]
+        rw [← Matrix.diagonal_one, Matrix.diagonal_mul, one_mul]
         rfl
       have hsingle :
           (Matrix.single dst src c * matrixEquiv M) r k = 0 := by

--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -822,8 +822,7 @@ private theorem nat_mod_mul_pow_square_odd (acc base k p : Nat) (hodd : k % 2 �
   calc
     ((acc * base) % p * ((base * base) % p) ^ (k / 2)) % p =
         (acc * base * (base * base) ^ (k / 2)) % p := by
-      rw [Nat.mul_mod]
-      rw [Nat.mod_mod]
+      rw [Nat.mul_mod, Nat.mod_mod]
       rw [show ((base * base) % p) ^ (k / 2) % p = (base * base) ^ (k / 2) % p by
         exact (Nat.pow_mod (base * base) (k / 2) p).symm]
       rw [← Nat.mul_mod]
@@ -856,24 +855,19 @@ private theorem pow_go_toNat (base acc : ZMod64 p) (k : Nat) :
             have hrec := ih ((m + 1) / 2) hlt (mul base base) acc
             change (pow.go (mul base base) acc ((m + 1) / 2)).toNat =
               acc.toNat * base.toNat ^ (m + 1) % p
-            rw [hrec]
-            rw [toNat_mul]
+            rw [hrec, toNat_mul]
             exact nat_mod_mul_pow_square_even acc.toNat base.toNat (m + 1) p heven
           · rw [if_neg heven]
             have hrec := ih ((m + 1) / 2) hlt (mul base base) (mul acc base)
             change (pow.go (mul base base) (mul acc base) ((m + 1) / 2)).toNat =
               acc.toNat * base.toNat ^ (m + 1) % p
-            rw [hrec]
-            rw [toNat_mul, toNat_mul]
+            rw [hrec, toNat_mul, toNat_mul]
             exact nat_mod_mul_pow_square_odd acc.toNat base.toNat (m + 1) p heven
 
 /-- Exponentiation agrees with natural-power reduction of the canonical representative. -/
 @[simp, grind =] theorem toNat_pow (a : ZMod64 p) (n : Nat) :
     (pow a n).toNat = a.toNat ^ n % p := by
-  rw [pow]
-  rw [pow_go_toNat]
-  rw [toNat_one]
-  rw [← Nat.mod_mul_mod]
+  rw [pow, pow_go_toNat, toNat_one, ← Nat.mod_mul_mod]
   simp
 
 /-- Exponentiation is the residue built from the representative's natural power. -/

--- a/HexModArith/HotLoop.lean
+++ b/HexModArith/HotLoop.lean
@@ -192,8 +192,7 @@ representatives.
         _root_.BarrettCtx.mulMod ctx.toUInt64Ctx a.toUInt64 b.toUInt64 < ctx.modulus :=
       _root_.BarrettCtx.mulMod_lt ctx.toUInt64Ctx a.toUInt64 b.toUInt64 ha hb
     simpa [ctx.modulus_eq] using UInt64.lt_iff_toNat_lt.mp hlt64
-  rw [mulMod, ZMod64.toNat_ofNat]
-  rw [Nat.mod_eq_of_lt hlt]
+  rw [mulMod, ZMod64.toNat_ofNat, Nat.mod_eq_of_lt hlt]
   simpa [ctx.modulus_eq] using
     (_root_.BarrettCtx.toNat_mulMod ctx.toUInt64Ctx a.toUInt64 b.toUInt64 ha hb)
 

--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -307,8 +307,7 @@ theorem nat_left_distrib_mod (x y z m : Nat) :
       rw [← Nat.add_mod y z m, ← Nat.mul_mod x (y + z) m]
     _ = (x * y + x * z) % m := by rw [Nat.left_distrib]
     _ = ((x % m * (y % m)) % m + (x % m * (z % m)) % m) % m := by
-      rw [Nat.add_mod]
-      rw [Nat.mul_mod x y m, Nat.mul_mod x z m]
+      rw [Nat.add_mod, Nat.mul_mod x y m, Nat.mul_mod x z m]
 
 /-- Right distributivity of `Nat` multiplication over addition under an
 outer `% m`, with each operand pre-reduced `% m`. This is the
@@ -322,8 +321,7 @@ theorem nat_right_distrib_mod (x y z m : Nat) :
       rw [← Nat.add_mod x y m, ← Nat.mul_mod (x + y) z m]
     _ = (x * z + y * z) % m := by rw [Nat.right_distrib]
     _ = ((x % m * (z % m)) % m + (y % m * (z % m)) % m) % m := by
-      rw [Nat.add_mod]
-      rw [Nat.mul_mod x z m, Nat.mul_mod y z m]
+      rw [Nat.add_mod, Nat.mul_mod x z m, Nat.mul_mod y z m]
 
 /-- Additive cancellation of the modular negation representative: for
 `x < m`, the reduced complement `(m - x) % m` added back to `x` is `0`
@@ -441,18 +439,17 @@ instance : Lean.Grind.Semiring (ZMod64 p) := by
     apply ext_toNat
     change (OfNat.ofNat (n + 1) : ZMod64 p).toNat =
       (ZMod64.add (OfNat.ofNat n) ZMod64.one).toNat
-    rw [show (OfNat.ofNat (n + 1) : ZMod64 p) = ZMod64.natCast p (n + 1) from rfl]
-    rw [show (OfNat.ofNat n : ZMod64 p) = ZMod64.natCast p n from rfl]
-    rw [toNat_natCast, toNat_add, toNat_natCast, toNat_one]
+    rw [show (OfNat.ofNat (n + 1) : ZMod64 p) = ZMod64.natCast p (n + 1) from rfl,
+      show (OfNat.ofNat n : ZMod64 p) = ZMod64.natCast p n from rfl,
+      toNat_natCast, toNat_add, toNat_natCast, toNat_one]
     simp [Nat.add_mod]
   · intro n
     rfl
   · intro n a
     apply ext_toNat
     change (ZMod64.nsmul n a).toNat = (ZMod64.mul (↑n : ZMod64 p) a).toNat
-    rw [toNat_nsmul, toNat_mul]
-    rw [show (↑n : ZMod64 p).toNat = (ZMod64.natCast p n).toNat from rfl]
-    rw [toNat_natCast]
+    rw [toNat_nsmul, toNat_mul, show (↑n : ZMod64 p).toNat = (ZMod64.natCast p n).toNat from rfl,
+      toNat_natCast]
     simp [Nat.mul_mod]
 
 /-- Adding zero on the right leaves a residue unchanged. -/
@@ -535,8 +532,7 @@ instance : Lean.Grind.Semiring (ZMod64 p) := by
 @[simp, grind =] theorem one_pow (n : Nat) : (1 : ZMod64 p) ^ n = 1 := by
   apply ext_toNat
   change (ZMod64.pow ZMod64.one n).toNat = (ZMod64.one : ZMod64 p).toNat
-  rw [toNat_pow, toNat_one]
-  rw [← Nat.pow_mod (1 : Nat) n p]
+  rw [toNat_pow, toNat_one, ← Nat.pow_mod (1 : Nat) n p]
   simp
 
 instance : Lean.Grind.Ring (ZMod64 p) where

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -344,8 +344,7 @@ elsewhere, even when `c = 0` (in which case the polynomial is zero and every coe
       · have hrep : i < (Array.replicate n (Zero.zero : R)).size := by
           simpa using hlt
         have hpush : i < n + 1 := by omega
-        rw [dif_pos hpush]
-        rw [Array.getElem_push_lt hrep]
+        rw [dif_pos hpush, Array.getElem_push_lt hrep]
         simp [hi]
       · have hnle : n < i := by omega
         have hpush_not : ¬ i < n + 1 := by omega

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -864,10 +864,8 @@ theorem divModArray_remainder_degree_lt_of_pos_degree [Sub R] [Mul R]
         q.coeffs.back?.getD (Zero.zero : R)
       have hidx : q.coeffs.size - 1 < q.coeffs.size := by
         simpa [size] using Nat.sub_one_lt_of_lt hqpos
-      rw [Array.getD_eq_getD_getElem?]
-      rw [Array.getElem?_eq_getElem hidx]
-      rw [Array.back?_eq_getElem?]
-      rw [Array.getElem?_eq_getElem hidx]
+      rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx, Array.back?_eq_getElem?,
+        Array.getElem?_eq_getElem hidx]
     have hzero_start :
         ∀ i, qDegree + p.size ≤ i → p.toArray.getD i (Zero.zero : R) = (Zero.zero : R) := by
       intro i hi
@@ -1007,8 +1005,7 @@ theorem divMod_remainder_eq_zero_of_degree_zero_core [One R] [Add R] [Sub R] [Mu
     change q.coeffs.getD 0 (Zero.zero : R) = q.coeffs.back?.getD (Zero.zero : R)
     rw [Array.getD_eq_getD_getElem?]
     have hidx : 0 < q.coeffs.size := by omega
-    rw [Array.getElem?_eq_getElem hidx]
-    rw [Array.back?_eq_getElem?]
+    rw [Array.getElem?_eq_getElem hidx, Array.back?_eq_getElem?]
     have hlast : q.coeffs.size - 1 = 0 := by omega
     rw [hlast, Array.getElem?_eq_getElem hidx]
   have hzero_start :
@@ -1330,9 +1327,8 @@ private theorem ofCoeffs_set!_eq_add_monomial {S : Type _}
     intro x
     change x + (0 : S) = x
     grind
-  rw [coeff_ofCoeffs]
-  rw [coeff_add (ofCoeffs coeffs) (monomial shift coeff) n hzero_add]
-  rw [coeff_ofCoeffs, coeff_monomial]
+  rw [coeff_ofCoeffs, coeff_add (ofCoeffs coeffs) (monomial shift coeff) n hzero_add,
+    coeff_ofCoeffs, coeff_monomial]
   by_cases hn : n = shift
   · subst n
     rw [array_getD_set!_same]
@@ -1693,8 +1689,7 @@ private theorem fold_add_reverse_commring {S : Type _} [Lean.Grind.CommRing S]
   | cons x xs ih =>
       rw [List.reverse_cons, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [ih]
-      rw [fold_add_right_commring xs a x]
+      rw [ih, fold_add_right_commring xs a x]
 
 /-- `(List.range (n + 1)).reverse = (List.range (n + 1)).map (fun i => n - i)`; the
 index reflection `i ↦ n - i` underlying the convolution commutativity reindexing. -/
@@ -1755,9 +1750,7 @@ private theorem fold_diagonal_comm {S : Type _}
     simpa [List.foldl_map, ← List.map_reverse] using
       fold_add_reverse_commring (S := S)
         ((List.range (n + 1)).map (fun i => diagonalMulCoeffTerm p q n i)) 0
-  rw [← hrev]
-  rw [range_succ_reverse_eq_map_sub]
-  rw [List.foldl_map]
+  rw [← hrev, range_succ_reverse_eq_map_sub, List.foldl_map]
   exact fold_diagonal_comm_reindex_list p q n (List.range (n + 1)) (by
     intro i hi
     exact List.mem_range.mp hi) 0
@@ -1791,8 +1784,7 @@ private theorem diagonalSum_neg_right_aux {S : Type _}
       grind
   | cons i xs ih =>
       simp only [List.foldl_cons]
-      rw [diagonalMulCoeffTerm_neg_right]
-      rw [ih]
+      rw [diagonalMulCoeffTerm_neg_right, ih]
       have htail :=
         fold_add_right_commring (S := S)
           (xs.map (fun i => diagonalMulCoeffTerm p q n i)) 0 (diagonalMulCoeffTerm p q n i)
@@ -1823,11 +1815,10 @@ theorem mul_sub_zero_comm {S : Type _}
   apply ext_coeff
   intro n
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_mul, coeff_sub 0 (q * p) n hzero_sub, coeff_zero, coeff_mul]
-  rw [mulCoeffSum_eq_diagonal p (0 - q) n, mulCoeffSum_eq_diagonal q p n]
-  rw [diagonalSum_eq_degree_bound p (0 - q) n, diagonalSum_eq_degree_bound q p n]
-  rw [diagonalSum_neg_right p q n]
-  rw [fold_diagonal_comm p q n]
+  rw [coeff_mul, coeff_sub 0 (q * p) n hzero_sub, coeff_zero, coeff_mul,
+    mulCoeffSum_eq_diagonal p (0 - q) n, mulCoeffSum_eq_diagonal q p n,
+    diagonalSum_eq_degree_bound p (0 - q) n, diagonalSum_eq_degree_bound q p n,
+    diagonalSum_neg_right p q n, fold_diagonal_comm p q n]
 
 /-- Commutativity of `DensePoly` multiplication. Hand-proved because `DensePoly`
 carries only `Lean.Grind.CommRing`, not Mathlib's `CommRing`, so `mul_comm`
@@ -1838,10 +1829,8 @@ theorem mul_comm_poly {S : Type _}
     p * q = q * p := by
   apply ext_coeff
   intro n
-  rw [coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_diagonal p q n, mulCoeffSum_eq_diagonal q p n]
-  rw [diagonalSum_eq_degree_bound p q n, diagonalSum_eq_degree_bound q p n]
-  rw [fold_diagonal_comm p q n]
+  rw [coeff_mul, coeff_mul, mulCoeffSum_eq_diagonal p q n, mulCoeffSum_eq_diagonal q p n,
+    diagonalSum_eq_degree_bound p q n, diagonalSum_eq_degree_bound q p n, fold_diagonal_comm p q n]
 
 /-- Cancellation rearrangement `(x + y) - (z + x) = y + (0 - z)`, used to
 simplify mixed add/sub combinations arising in the Euclidean update steps. -/
@@ -1853,10 +1842,8 @@ theorem add_sub_add_swap {S : Type _}
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_sub (x + y) (z + x) n hzero_sub]
-  rw [coeff_add x y n hzero_add, coeff_add z x n hzero_add]
-  rw [coeff_add y (0 - z) n hzero_add]
-  rw [coeff_sub 0 z n hzero_sub, coeff_zero]
+  rw [coeff_sub (x + y) (z + x) n hzero_sub, coeff_add x y n hzero_add, coeff_add z x n hzero_add,
+    coeff_add y (0 - z) n hzero_add, coeff_sub 0 z n hzero_sub, coeff_zero]
   grind
 
 /-- Cancellation rearrangement `(x + y) - (x + z) = y + (0 - z)`. -/
@@ -1868,10 +1855,8 @@ theorem add_sub_add_left {S : Type _}
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_sub (x + y) (x + z) n hzero_sub]
-  rw [coeff_add x y n hzero_add, coeff_add x z n hzero_add]
-  rw [coeff_add y (0 - z) n hzero_add]
-  rw [coeff_sub 0 z n hzero_sub, coeff_zero]
+  rw [coeff_sub (x + y) (x + z) n hzero_sub, coeff_add x y n hzero_add, coeff_add x z n hzero_add,
+    coeff_add y (0 - z) n hzero_add, coeff_sub 0 z n hzero_sub, coeff_zero]
   grind
 
 /-- Commutativity of `DensePoly` addition (the Mathlib-free `add_comm`). -/
@@ -1893,10 +1878,8 @@ theorem add_assoc_poly {S : Type _}
   apply ext_coeff
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
-  rw [coeff_add (p + q) r n hzero_add]
-  rw [coeff_add p q n hzero_add]
-  rw [coeff_add p (q + r) n hzero_add]
-  rw [coeff_add q r n hzero_add]
+  rw [coeff_add (p + q) r n hzero_add, coeff_add p q n hzero_add, coeff_add p (q + r) n hzero_add,
+    coeff_add q r n hzero_add]
   grind
 
 /-- Right identity for polynomial addition over a commutative ring: `p + 0 = p`.
@@ -1921,9 +1904,8 @@ theorem sub_eq_add_neg_poly {S : Type _}
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_sub p q n hzero_sub]
-  rw [coeff_add p (0 - q) n hzero_add]
-  rw [coeff_sub 0 q n hzero_sub, coeff_zero]
+  rw [coeff_sub p q n hzero_sub, coeff_add p (0 - q) n hzero_add,
+    coeff_sub 0 q n hzero_sub, coeff_zero]
   grind
 
 private theorem diagonalMulCoeffTerm_one_right {S : Type _}
@@ -2036,8 +2018,7 @@ private theorem fold_add_acc_commring {S : Type _} [Lean.Grind.CommRing S]
   have h :=
     fold_add_right_commring (S := S) (xs.map f) 0 acc
   simp [List.foldl_map] at h
-  rw [← show (0 : S) + acc = acc by grind]
-  rw [h]
+  rw [← show (0 : S) + acc = acc by grind, h]
   grind
 
 /-- Flatten a nested additive fold over a mapped list of rows. -/
@@ -2189,11 +2170,8 @@ private theorem triangular_fold_reindex_commring {S : Type _} [Lean.Grind.CommRi
   | zero =>
       simp
   | succ n ih =>
-      rw [triangular_total_succ_commring F n]
-      rw [triangular_first_succ_commring F n]
-      rw [ih]
-      rw [triangular_prefix_succ_commring F n]
-      rw [triangular_boundary_succ_commring F n]
+      rw [triangular_total_succ_commring F n, triangular_first_succ_commring F n, ih,
+        triangular_prefix_succ_commring F n, triangular_boundary_succ_commring F n]
       grind
 
 private theorem fold_diagonal_add_right {S : Type _}
@@ -2262,10 +2240,8 @@ private theorem fold_add_mul_right_commring {S : Type _} [Lean.Grind.CommRing S]
       simp only [List.foldl_cons]
       have hzero_f : (0 : S) + f i = f i := by grind
       have hzero_fc : (0 : S) + f i * c = f i * c := by grind
-      rw [hzero_f, hzero_fc]
-      rw [fold_add_acc_commring xs f (f i)]
-      rw [fold_add_acc_commring xs (fun i => f i * c) (f i * c)]
-      rw [← ih]
+      rw [hzero_f, hzero_fc, fold_add_acc_commring xs f (f i),
+        fold_add_acc_commring xs (fun i => f i * c) (f i * c), ← ih]
       grind
 
 /-- Distribute left multiplication by a constant through an additive fold. -/
@@ -2280,10 +2256,8 @@ private theorem fold_add_mul_left_commring {S : Type _} [Lean.Grind.CommRing S]
       simp only [List.foldl_cons]
       have hzero_f : (0 : S) + f i = f i := by grind
       have hzero_cf : (0 : S) + c * f i = c * f i := by grind
-      rw [hzero_f, hzero_cf]
-      rw [fold_add_acc_commring xs f (f i)]
-      rw [fold_add_acc_commring xs (fun i => c * f i) (c * f i)]
-      rw [← ih]
+      rw [hzero_f, hzero_cf, fold_add_acc_commring xs f (f i),
+        fold_add_acc_commring xs (fun i => c * f i) (c * f i), ← ih]
       grind
 
 private theorem rat_fold_add_range_succ (A : Nat → Rat) (m : Nat) :
@@ -2387,12 +2361,9 @@ theorem rat_mulCoeffSum_derivative_product_rule
     (p q : DensePoly Rat) (n : Nat) :
     ((n + 1 : Nat) : Rat) * mulCoeffSum p q (n + 1) =
       mulCoeffSum (derivative p) q n + mulCoeffSum p (derivative q) n := by
-  rw [mulCoeffSum_eq_diagonal p q (n + 1)]
-  rw [diagonalSum_eq_degree_bound p q (n + 1)]
-  rw [mulCoeffSum_eq_diagonal (derivative p) q n]
-  rw [diagonalSum_eq_degree_bound (derivative p) q n]
-  rw [mulCoeffSum_eq_diagonal p (derivative q) n]
-  rw [diagonalSum_eq_degree_bound p (derivative q) n]
+  rw [mulCoeffSum_eq_diagonal p q (n + 1), diagonalSum_eq_degree_bound p q (n + 1),
+    mulCoeffSum_eq_diagonal (derivative p) q n, diagonalSum_eq_degree_bound (derivative p) q n,
+    mulCoeffSum_eq_diagonal p (derivative q) n, diagonalSum_eq_degree_bound p (derivative q) n]
   have hleft :
       (List.range (n + 2)).foldl
           (fun acc i => acc + diagonalMulCoeffTerm p q (n + 1) i) 0 =
@@ -2403,8 +2374,7 @@ theorem rat_mulCoeffSum_derivative_product_rule
     have hi' : i < n + 2 := List.mem_range.mp hi
     have hnot : ¬ n + 1 < i := by omega
     simp [diagonalMulCoeffTerm, hnot]
-  rw [hleft]
-  rw [rat_weighted_diagonal_fold (fun i => p.coeff i * q.coeff (n + 1 - i)) n]
+  rw [hleft, rat_weighted_diagonal_fold (fun i => p.coeff i * q.coeff (n + 1 - i)) n]
   congr 1
   · apply fold_add_congr
     intro i hi
@@ -2518,12 +2488,9 @@ theorem mulCoeffSum_derivative_product_rule [DecidableEq S]
     (p q : DensePoly S) (n : Nat) :
     ((n + 1 : Nat) : S) * mulCoeffSum p q (n + 1) =
       mulCoeffSum (derivative p) q n + mulCoeffSum p (derivative q) n := by
-  rw [mulCoeffSum_eq_diagonal p q (n + 1)]
-  rw [diagonalSum_eq_degree_bound p q (n + 1)]
-  rw [mulCoeffSum_eq_diagonal (derivative p) q n]
-  rw [diagonalSum_eq_degree_bound (derivative p) q n]
-  rw [mulCoeffSum_eq_diagonal p (derivative q) n]
-  rw [diagonalSum_eq_degree_bound p (derivative q) n]
+  rw [mulCoeffSum_eq_diagonal p q (n + 1), diagonalSum_eq_degree_bound p q (n + 1),
+    mulCoeffSum_eq_diagonal (derivative p) q n, diagonalSum_eq_degree_bound (derivative p) q n,
+    mulCoeffSum_eq_diagonal p (derivative q) n, diagonalSum_eq_degree_bound p (derivative q) n]
   have hleft :
       (List.range (n + 2)).foldl
           (fun acc i => acc + diagonalMulCoeffTerm p q (n + 1) i) 0 =
@@ -2534,8 +2501,7 @@ theorem mulCoeffSum_derivative_product_rule [DecidableEq S]
     have hi' : i < n + 2 := List.mem_range.mp hi
     have hnot : ¬ n + 1 < i := by omega
     simp [diagonalMulCoeffTerm, hnot]
-  rw [hleft]
-  rw [weighted_diagonal_fold_commring (fun i => p.coeff i * q.coeff (n + 1 - i)) n]
+  rw [hleft, weighted_diagonal_fold_commring (fun i => p.coeff i * q.coeff (n + 1 - i)) n]
   congr 1
   · apply fold_add_congr
     intro i hi
@@ -2564,12 +2530,10 @@ theorem derivative_mul [DecidableEq S]
       derivative p * q + p * derivative q := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_derivative_semiring]
-  rw [coeff_mul p q (n + 1)]
+  rw [coeff_derivative_semiring, coeff_mul p q (n + 1)]
   rw [coeff_add (derivative p * q) (p * derivative q) n
     (Lean.Grind.Semiring.add_zero (0 : S))]
-  rw [coeff_mul (derivative p) q n]
-  rw [coeff_mul p (derivative q) n]
+  rw [coeff_mul (derivative p) q n, coeff_mul p (derivative q) n]
   exact mulCoeffSum_derivative_product_rule p q n
 
 end CommRingDerivative
@@ -2634,8 +2598,7 @@ private theorem fold_diagonal_mul_assoc {S : Type _}
         (fun acc i => acc + diagonalMulCoeffTerm (p * q) r n i) 0 =
       (List.range p.size).foldl
         (fun acc i => acc + diagonalMulCoeffTerm p (q * r) n i) 0 := by
-  rw [diagonalSum_eq_degree_bound (p * q) r n]
-  rw [diagonalSum_eq_degree_bound p (q * r) n]
+  rw [diagonalSum_eq_degree_bound (p * q) r n, diagonalSum_eq_degree_bound p (q * r) n]
   let F : Nat → Nat → S := fun j k => p.coeff j * q.coeff k * r.coeff (n - (j + k))
   have hleft :
       (List.range (n + 1)).foldl
@@ -2682,9 +2645,8 @@ theorem mul_assoc_poly {S : Type _}
     (p * q) * r = p * (q * r) := by
   apply ext_coeff
   intro n
-  rw [coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_diagonal (p * q) r n]
-  rw [mulCoeffSum_eq_diagonal p (q * r) n]
+  rw [coeff_mul, coeff_mul, mulCoeffSum_eq_diagonal (p * q) r n,
+    mulCoeffSum_eq_diagonal p (q * r) n]
   exact fold_diagonal_mul_assoc p q r n
 
 /-- Left distributivity for `DensePoly`: `p * (q + r) = p * q + p * r`. -/
@@ -2695,9 +2657,9 @@ theorem mul_add_right_poly {S : Type _}
   apply ext_coeff
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
-  rw [coeff_mul, coeff_add (p * q) (p * r) n hzero_add, coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_diagonal p (q + r) n]
-  rw [mulCoeffSum_eq_diagonal p q n, mulCoeffSum_eq_diagonal p r n]
+  rw [coeff_mul, coeff_add (p * q) (p * r) n hzero_add, coeff_mul, coeff_mul,
+    mulCoeffSum_eq_diagonal p (q + r) n,
+    mulCoeffSum_eq_diagonal p q n, mulCoeffSum_eq_diagonal p r n]
   exact fold_diagonal_add_right p q r n
 
 /-- Right distributivity for `DensePoly`: `(p + q) * r = p * r + q * r`. -/
@@ -2727,8 +2689,7 @@ theorem monomial_mul_monomial {S : Type _}
     (monomial m c) * (monomial k d) = monomial (m + k) (c * d) := by
   apply ext_coeff
   intro n
-  rw [coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound]
-  rw [coeff_monomial]
+  rw [coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound, coeff_monomial]
   have hterm : ∀ i,
       diagonalMulCoeffTerm (monomial m c) (monomial k d) n i =
         if i = m ∧ n = m + k then c * d else 0 := by
@@ -2791,8 +2752,7 @@ theorem monomial_mul_monomial {S : Type _}
           simp only [List.foldl_cons]
           rw [hsimp i]
           exact ih _
-    rw [hfold2 (List.range (n + 1)) 0]
-    rw [fold_single_index]
+    rw [hfold2 (List.range (n + 1)) 0, fold_single_index]
     have hm_lt : m < n + 1 := by omega
     rw [if_pos hm_lt, if_pos hnmk]
   · have hzero_fold : ∀ (xs : List Nat) (acc : S),
@@ -2804,11 +2764,9 @@ theorem monomial_mul_monomial {S : Type _}
           intro acc
           simp only [List.foldl_cons]
           have hcond : ¬ (i = m ∧ n = m + k) := fun ⟨_, h⟩ => hnmk h
-          rw [if_neg hcond]
-          rw [show acc + (0 : S) = acc by grind]
+          rw [if_neg hcond, show acc + (0 : S) = acc by grind]
           exact ih _
-    rw [hzero_fold]
-    rw [if_neg hnmk]
+    rw [hzero_fold, if_neg hnmk]
     rfl
 
 /-- Multiplication by a unit-coefficient monomial shifts coefficients upward. -/
@@ -2818,8 +2776,7 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
     monomial shift 1 * q = DensePoly.shift shift q := by
   apply ext_coeff
   intro n
-  rw [coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound]
-  rw [coeff_shift]
+  rw [coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound, coeff_shift]
   have hterm : ∀ i,
       diagonalMulCoeffTerm (monomial shift 1) q n i =
         if i = shift ∧ shift ≤ n then q.coeff (n - shift) else 0 := by
@@ -2876,9 +2833,7 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
           simp only [List.foldl_cons]
           rw [hsimp i]
           exact ih _
-    rw [hfold2 (List.range (n + 1)) 0]
-    rw [fold_single_index]
-    rw [if_pos (by omega : shift < n + 1)]
+    rw [hfold2 (List.range (n + 1)) 0, fold_single_index, if_pos (by omega : shift < n + 1)]
   · rw [if_pos (by omega : n < shift)]
     have hzero_fold : ∀ (xs : List Nat) (acc : S),
         xs.foldl (fun acc i =>
@@ -2894,8 +2849,7 @@ theorem monomial_one_mul_poly_eq_shift {S : Type _}
           have hzero :
               (if i = shift ∧ shift ≤ n then q.coeff (n - shift) else 0) = 0 := by
             simp [hshift]
-          rw [hzero]
-          rw [show acc + (0 : S) = acc by grind]
+          rw [hzero, show acc + (0 : S) = acc by grind]
           exact ih _
     rw [hzero_fold]
     rfl
@@ -2920,10 +2874,8 @@ theorem add_mul_sub_cancel_right {S : Type _}
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_add (p * q + t * q) (r - t * q) n hzero_add]
-  rw [coeff_add (p * q) (t * q) n hzero_add]
-  rw [coeff_sub r (t * q) n hzero_sub]
-  rw [coeff_add (p * q) r n hzero_add]
+  rw [coeff_add (p * q + t * q) (r - t * q) n hzero_add, coeff_add (p * q) (t * q) n hzero_add,
+    coeff_sub r (t * q) n hzero_sub, coeff_add (p * q) r n hzero_add]
   grind
 
 /-- One long-division reconstruction step preserves the accumulated identity
@@ -2947,13 +2899,9 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
   apply ext_coeff
   intro n
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
-  rw [coeff_ofCoeffs]
-  rw [coeff_sub (ofCoeffs rem) (monomial shift coeff * ofCoeffs q) n hzero_sub]
-  rw [coeff_ofCoeffs]
-  rw [coeff_mul]
-  rw [mulCoeffSum_eq_diagonal]
-  rw [diagonalSum_eq_degree_bound]
-  rw [subtractScaledShift_getD rem q shift coeff n hbound]
+  rw [coeff_ofCoeffs, coeff_sub (ofCoeffs rem) (monomial shift coeff * ofCoeffs q) n hzero_sub,
+    coeff_ofCoeffs, coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound,
+    subtractScaledShift_getD rem q shift coeff n hbound]
   -- Compute each diagonal term using the monomial's coefficient law.
   have hterm : ∀ i,
       diagonalMulCoeffTerm (monomial shift coeff) (ofCoeffs q) n i =
@@ -3020,8 +2968,7 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
           simp only [List.foldl_cons]
           rw [hsimp i]
           exact ih _
-    rw [hfold2 (List.range (n + 1)) 0]
-    rw [fold_single_index]
+    rw [hfold2 (List.range (n + 1)) 0, fold_single_index]
     have hshift_lt : shift < n + 1 := by omega
     rw [if_pos hshift_lt]
     by_cases hsize : n - shift < q.size
@@ -3050,8 +2997,7 @@ private theorem ofCoeffs_subtractScaledShift_eq_sub_monomial_mul {S : Type _}
               then coeff * q.getD (n - shift) (Zero.zero : S)
               else (0 : S)) = 0 := by
             simp [hshift]
-          rw [h0]
-          rw [show acc + (0 : S) = acc by grind]
+          rw [h0, show acc + (0 : S) = acc by grind]
           exact ih _
     rw [hzero_fold (List.range (n + 1)) 0]
     have hand : ¬ (shift ≤ n ∧ n - shift < q.size) := fun ⟨h, _⟩ => hshift h
@@ -3172,24 +3118,21 @@ private theorem xgcd_bezout_step {S : Type _}
     (a s₀ t₀ s₁ t₁ p q : DensePoly S) :
     (s₀ - a * s₁) * p + (t₀ - a * t₁) * q =
       (s₀ * p + t₀ * q) - a * (s₁ * p + t₁ * q) := by
-  rw [sub_eq_add_neg_poly s₀ (a * s₁), sub_eq_add_neg_poly t₀ (a * t₁)]
-  rw [mul_add_left_poly, mul_add_left_poly]
-  rw [neg_mul_right_poly, neg_mul_right_poly]
-  rw [mul_assoc_poly a s₁ p, mul_assoc_poly a t₁ q]
-  rw [mul_add_right_poly]
+  rw [sub_eq_add_neg_poly s₀ (a * s₁), sub_eq_add_neg_poly t₀ (a * t₁),
+    mul_add_left_poly, mul_add_left_poly, neg_mul_right_poly, neg_mul_right_poly,
+    mul_assoc_poly a s₁ p, mul_assoc_poly a t₁ q, mul_add_right_poly]
   apply ext_coeff
   intro n
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
   rw [coeff_add (s₀ * p + (0 - a * (s₁ * p))) (t₀ * q + (0 - a * (t₁ * q))) n
     hzero_add]
-  rw [coeff_add (s₀ * p) (0 - a * (s₁ * p)) n hzero_add]
-  rw [coeff_sub 0 (a * (s₁ * p)) n hzero_sub, coeff_zero]
-  rw [coeff_add (t₀ * q) (0 - a * (t₁ * q)) n hzero_add]
-  rw [coeff_sub 0 (a * (t₁ * q)) n hzero_sub, coeff_zero]
-  rw [coeff_sub (s₀ * p + t₀ * q) (a * (s₁ * p) + a * (t₁ * q)) n hzero_sub]
-  rw [coeff_add (s₀ * p) (t₀ * q) n hzero_add]
-  rw [coeff_add (a * (s₁ * p)) (a * (t₁ * q)) n hzero_add]
+  rw [coeff_add (s₀ * p) (0 - a * (s₁ * p)) n hzero_add,
+    coeff_sub 0 (a * (s₁ * p)) n hzero_sub, coeff_zero,
+    coeff_add (t₀ * q) (0 - a * (t₁ * q)) n hzero_add,
+    coeff_sub 0 (a * (t₁ * q)) n hzero_sub, coeff_zero,
+    coeff_sub (s₀ * p + t₀ * q) (a * (s₁ * p) + a * (t₁ * q)) n hzero_sub,
+    coeff_add (s₀ * p) (t₀ * q) n hzero_add, coeff_add (a * (s₁ * p)) (a * (t₁ * q)) n hzero_add]
   grind
 
 /-- `xgcdAux` satisfies the Bezout identity: the returned `left * p + right * q`
@@ -3535,8 +3478,8 @@ theorem divModArray_reconstruction {S : Type _}
       have hcoeffpos : 0 < q.coeffs.size := by simpa [size] using hqpos
       have hidx : q.coeffs.size - 1 < q.coeffs.size :=
         Nat.sub_one_lt_of_lt hcoeffpos
-      rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx]
-      rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx]
+      rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx,
+        Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx]
     have hcancel_array :
         ∀ a, a - scaleLead a * q.toArray.getD (q.size - 1) (Zero.zero : S) =
           (Zero.zero : S) := by
@@ -3645,8 +3588,7 @@ private theorem coeff_mul_top_general {S : Type _}
     (hp : 0 < p.size) (hq : 0 < q.size) :
     (p * q).coeff (p.size - 1 + (q.size - 1)) =
       p.coeff (p.size - 1) * q.coeff (q.size - 1) := by
-  rw [coeff_mul, mulCoeffSum_eq_diagonal]
-  rw [foldl_add_general_eq_at_predecessor _ p.size hp]
+  rw [coeff_mul, mulCoeffSum_eq_diagonal, foldl_add_general_eq_at_predecessor _ p.size hp]
   · unfold diagonalMulCoeffTerm
     have hno : ¬ p.size - 1 + (q.size - 1) < p.size - 1 := by omega
     rw [if_neg hno]
@@ -3997,8 +3939,7 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
               intro i hi
               have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
               show (m - monomial shift coeff).coeff i = 0
-              rw [coeff_sub m (monomial shift coeff) i hzero_sub]
-              rw [coeff_monomial]
+              rw [coeff_sub m (monomial shift coeff) i hzero_sub, coeff_monomial]
               by_cases hi_eq : i = shift
               · subst i
                 rw [if_pos rfl, hcoeff_eq, hshift_eq_size]
@@ -4015,8 +3956,8 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
                 (ofCoeffs rem' : DensePoly S) = m_new * ofCoeffs q := by
               show (ofCoeffs (subtractScaledShift rem q shift coeff) : DensePoly S) =
                 (m - monomial shift coeff) * ofCoeffs q
-              rw [ofCoeffs_subtractScaledShift_eq_sub_monomial_mul rem q shift coeff hbound_rem]
-              rw [h_inv]
+              rw [ofCoeffs_subtractScaledShift_eq_sub_monomial_mul rem q shift coeff hbound_rem,
+                h_inv]
               apply ext_coeff
               intro n
               have hzero_add : (0 : S) + (0 : S) = 0 := by grind
@@ -4027,8 +3968,8 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
                   (m - monomial shift coeff) + monomial shift coeff = m := by
                 apply ext_coeff
                 intro k
-                rw [coeff_add (m - monomial shift coeff) (monomial shift coeff) k hzero_add]
-                rw [coeff_sub m (monomial shift coeff) k hzero_sub]
+                rw [coeff_add (m - monomial shift coeff) (monomial shift coeff) k hzero_add,
+                  coeff_sub m (monomial shift coeff) k hzero_sub]
                 grind
               have hrhs := congrArg (fun p : DensePoly S => p.coeff n)
                 (add_mul_sub_cancel_right (m - monomial shift coeff)
@@ -4121,9 +4062,9 @@ private theorem divModArrayAux_eq_of_polynomial_mul {S : Type _}
               have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
               rw [coeff_add (ofCoeffs quot + monomial shift coeff)
                 (m - monomial shift coeff) n hzero_add]
-              rw [coeff_add (ofCoeffs quot) (monomial shift coeff) n hzero_add]
-              rw [coeff_sub m (monomial shift coeff) n hzero_sub]
-              rw [coeff_add (ofCoeffs quot) m n hzero_add]
+              rw [coeff_add (ofCoeffs quot) (monomial shift coeff) n hzero_add,
+                coeff_sub m (monomial shift coeff) n hzero_sub,
+                coeff_add (ofCoeffs quot) m n hzero_add]
               grind
             · simp [hrd_lt_q]
               simp only [← Array.set!_eq_setIfInBounds, ← Array.getD_eq_getD_getElem?]
@@ -4465,8 +4406,7 @@ private theorem nat_gcd_bezout (a b : Nat) :
         rw [Int.natCast_mul] at h
         rw [Int.mul_comm ((a : Int)) ((b / a : Nat) : Int)] at h
         omega
-      rw [Nat.gcd_rec]
-      rw [← hxy]
+      rw [Nat.gcd_rec, ← hxy]
       calc
         (y - x * (b / a : Nat)) * (a : Int) + x * (b : Int) =
             x * ((b : Int) - (b / a : Nat) * (a : Int)) + y * (a : Int) := by
@@ -4527,10 +4467,8 @@ private theorem foldl_add_int_sub_terms
       simp
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [list_foldl_add_term_int xs f (0 + f x)]
-      rw [list_foldl_add_term_int xs g (0 + g x)]
-      rw [list_foldl_add_term_int xs (fun x => f x - g x) (0 + (f x - g x))]
-      rw [← ih]
+      rw [list_foldl_add_term_int xs f (0 + f x), list_foldl_add_term_int xs g (0 + g x),
+        list_foldl_add_term_int xs (fun x => f x - g x) (0 + (f x - g x)), ← ih]
       grind
 
 /-- If `d` divides the additive fold of `f` and divides each `f x - g x`, then it divides the additive fold of `g`, transporting divisibility across a term-wise congruence. -/
@@ -4736,9 +4674,7 @@ private theorem dvd_diagonalMulCoeffTerm_of_dvd_mul_coeff_of_dvd_other_diagonal_
   · have hsum :
         (d : Int) ∣ (List.range (n + 1)).foldl
           (fun s r => s + diagonalMulCoeffTerm p q n r) 0 := by
-      rw [← diagonalSum_eq_degree_bound p q n]
-      rw [← mulCoeffSum_eq_diagonal p q n]
-      rw [← coeff_mul p q n]
+      rw [← diagonalSum_eq_degree_bound p q n, ← mulCoeffSum_eq_diagonal p q n, ← coeff_mul p q n]
       exact hprod
     exact dvd_term_of_dvd_foldl_add_of_dvd_others (d : Int) (List.range (n + 1))
       (fun r => diagonalMulCoeffTerm p q n r) i
@@ -4852,9 +4788,7 @@ private theorem list_natAbs_gcd_bezout_aux (xs : List Int) (acc : Nat) :
       refine ⟨a * u, (a * v * sgn) :: weights, ?_, ?_⟩
       · simp [hlen]
       · simp only [List.zipWith_cons_cons, List.foldl_cons, List.foldl_cons]
-        rw [← hsum]
-        rw [← huv]
-        rw [list_foldl_add_int]
+        rw [← hsum, ← huv, list_foldl_add_int]
         have hterm : a * v * sgn * x = a * v * Int.ofNat x.natAbs := by
           rw [← hsgn]
           grind
@@ -4893,8 +4827,7 @@ divides the polynomial content. -/
 theorem dvd_content_of_nat_dvd_coeff (p : DensePoly Int) (d : Nat)
     (h : ∀ n, (d : Int) ∣ p.coeff n) :
     (d : Int) ∣ content p := by
-  rw [content]
-  rw [Int.ofNat_dvd_left]
+  rw [content, Int.ofNat_dvd_left]
   exact dvd_contentNat_of_dvd_coeff p d h
 
 /-- If a natural number divides every coefficient, then it divides the content. -/
@@ -5081,9 +5014,7 @@ theorem content_mul_primitivePart (p : DensePoly Int) :
       · have hpart :
             (primitivePart p).coeff n = p.coeff n / content p := by
           unfold primitivePart content
-          rw [if_neg hc]
-          rw [coeff_ofCoeffs_list]
-          rw [list_getD_map_ediv_zero]
+          rw [if_neg hc, coeff_ofCoeffs_list, list_getD_map_ediv_zero]
           unfold coeff toArray Array.getD
           by_cases hn : n < p.coeffs.size
           · simp [hn]
@@ -5211,9 +5142,7 @@ theorem content_scale_int (c : Int) (p : DensePoly Int) :
         trimTrailingZerosList (p.toArray.toList.map (fun x => c * x)) := by
     unfold scale ofCoeffs toArray trimTrailingZeros
     simp
-  rw [hscale_coeffs]
-  rw [foldl_gcd_natAbs_trim_eq]
-  rw [List.foldl_map]
+  rw [hscale_coeffs, foldl_gcd_natAbs_trim_eq, List.foldl_map]
   have h := foldl_gcd_natAbs_mul_const_int c p.toArray.toList 0
   rw [Nat.mul_zero] at h
   exact h
@@ -5337,9 +5266,8 @@ private theorem mod_sub_self_eq_mul_neg_div {S : Type _}
   have hzero_add : (0 : S) + (0 : S) = 0 := by grind
   change (((p / m) * m + (p % m)).coeff n = p.coeff n) at hcoeff
   rw [coeff_add ((p / m) * m) (p % m) n hzero_add] at hcoeff
-  rw [coeff_sub (p % m) p n hzero_sub]
-  rw [mul_sub_zero_comm m (p / m), coeff_sub 0 ((p / m) * m) n hzero_sub]
-  rw [coeff_zero]
+  rw [coeff_sub (p % m) p n hzero_sub,
+    mul_sub_zero_comm m (p / m), coeff_sub 0 ((p / m) * m) n hzero_sub, coeff_zero]
   grind
 
 /-- Packages `mod_sub_self_eq_mul_neg_div` as the divisibility `m ∣ (p % m - p)`, the core
@@ -5465,10 +5393,8 @@ theorem dvd_of_mod_eq_mod {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] [
       rw [coeff_sub 0 ((q / m) * m) n hzero_sub, coeff_zero]
       grind
     · -- m * (a - b) = a * m + (0 - b * m), via sub_eq_add_neg + mul_sub_zero_comm + mul_comm.
-      rw [sub_eq_add_neg_poly]
-      rw [mul_add_right_poly]
-      rw [mul_sub_zero_comm m (q / m)]
-      rw [mul_comm_poly m (p / m)]
+      rw [sub_eq_add_neg_poly, mul_add_right_poly, mul_sub_zero_comm m (q / m),
+        mul_comm_poly m (p / m)]
   rw [hgoal]
   grind
 
@@ -5507,10 +5433,7 @@ private theorem mod_mul_self_left {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S] [Div S] [DivModLaws S]
     (m r : DensePoly S) :
     (m * r) % m = 0 := by
-  rw [mod_mul_mod]
-  rw [mod_self_eq_zero]
-  rw [zero_mul_left]
-  rw [zero_mod_eq_zero]
+  rw [mod_mul_mod, mod_self_eq_zero, zero_mul_left, zero_mod_eq_zero]
 
 /-- Adding a multiple of `m` leaves the canonical remainder unchanged,
 `(q + m * r) % m = q % m`. -/
@@ -5524,9 +5447,7 @@ private theorem mod_add_mul_self {S : Type _}
     intro n
     have hzero_sub : (0 : S) - (0 : S) = 0 := by grind
     have hzero_add : (0 : S) + (0 : S) = 0 := by grind
-    rw [coeff_sub (q + m * r) q n hzero_sub]
-    rw [coeff_add q (m * r) n hzero_add]
-    rw [coeff_mul]
+    rw [coeff_sub (q + m * r) q n hzero_sub, coeff_add q (m * r) n hzero_add, coeff_mul]
     grind⟩
 
 /-- Under the Bezout hypothesis `s * a + t * b = 1`, exhibits `polyCRT a b u v s t - u` as
@@ -5612,8 +5533,7 @@ theorem polyCRT_modByMonic_fst :
     (a b u v s t : DensePoly S) -> (ha : Monic a) -> s * a + t * b = 1 ->
     modByMonic (polyCRT a b u v s t) a ha = modByMonic u a ha := by
   intro S _ _ _ _ a b u v s t ha hbez
-  rw [modByMonic_eq_mod]
-  rw [modByMonic_eq_mod]
+  rw [modByMonic_eq_mod, modByMonic_eq_mod]
   exact mod_eq_mod_of_congr (polyCRT_congr_fst a b u v s t hbez)
 
 /-- The CRT witness reduces to the prescribed first residue modulo `a`. -/
@@ -5632,8 +5552,7 @@ theorem polyCRT_modByMonic_snd :
     (a b u v s t : DensePoly S) -> (hb : Monic b) -> s * a + t * b = 1 ->
     modByMonic (polyCRT a b u v s t) b hb = modByMonic v b hb := by
   intro S _ _ _ _ a b u v s t hb hbez
-  rw [modByMonic_eq_mod]
-  rw [modByMonic_eq_mod]
+  rw [modByMonic_eq_mod, modByMonic_eq_mod]
   exact mod_eq_mod_of_congr (polyCRT_congr_snd a b u v s t hbez)
 
 /-- The CRT witness reduces to the prescribed second residue modulo `b`. -/
@@ -5804,8 +5723,7 @@ theorem coeff_mul_top_int (p q : DensePoly Int)
     (hp : 0 < p.size) (hq : 0 < q.size) :
     (p * q).coeff (p.size - 1 + (q.size - 1)) =
       p.coeff (p.size - 1) * q.coeff (q.size - 1) := by
-  rw [coeff_mul, mulCoeffSum_eq_diagonal]
-  rw [foldl_add_int_eq_at_predecessor _ p.size hp]
+  rw [coeff_mul, mulCoeffSum_eq_diagonal, foldl_add_int_eq_at_predecessor _ p.size hp]
   · unfold diagonalMulCoeffTerm
     have hno : ¬ (p.size - 1 + (q.size - 1)) < p.size - 1 := by omega
     rw [if_neg hno]
@@ -5892,8 +5810,7 @@ private theorem foldl_add_int_diagonal_scaled
         by_cases hn : n < m'
         · simp [hn]
         · rw [if_neg hn]
-          rw [coeff_scale a r m' (Int.mul_zero a)]
-          rw [coeff_scale b s (n - m') (Int.mul_zero b)]
+          rw [coeff_scale a r m' (Int.mul_zero a), coeff_scale b s (n - m') (Int.mul_zero b)]
           grind
       rw [hterm]
       grind
@@ -5901,8 +5818,7 @@ private theorem foldl_add_int_diagonal_scaled
 /-- Coefficient identity: scaling both factors of a product. -/
 private theorem coeff_scale_mul_scale (a b : Int) (r s : DensePoly Int) (n : Nat) :
     ((scale a r) * (scale b s)).coeff n = a * b * (r * s).coeff n := by
-  rw [coeff_mul (scale a r) (scale b s) n]
-  rw [coeff_mul r s n]
+  rw [coeff_mul (scale a r) (scale b s) n, coeff_mul r s n]
   rw [mulCoeffSum_eq_diagonal (scale a r) (scale b s) n,
       mulCoeffSum_eq_diagonal r s n]
   rw [diagonalSum_eq_degree_bound (scale a r) (scale b s) n,

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -690,8 +690,7 @@ theorem toArray_toList_eq_coeff_range (p : DensePoly R) :
   · intro i hi
     have hi_size : i < p.size := by
       simpa [toArray, size] using hi
-    rw [toArray_toList_getD_eq_coeff]
-    rw [list_getD_map_range]
+    rw [toArray_toList_getD_eq_coeff, list_getD_map_range]
     simp [hi_size]
 
 /-- Formal derivative. The coefficient of `x^i` becomes `(i + 1) * a_(i+1)`. -/
@@ -707,8 +706,7 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
     (p + q).coeff n = (p.coeff n + q.coeff n) := by
   change (add p q).coeff n = (p.coeff n + q.coeff n)
   unfold add
-  rw [coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hn : n < max p.size q.size
   · simp [hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn
@@ -731,8 +729,7 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
     (p - q).coeff n = (p.coeff n - q.coeff n) := by
   change (sub p q).coeff n = (p.coeff n - q.coeff n)
   unfold sub
-  rw [coeff_ofCoeffs_list]
-  rw [list_getD_map_range]
+  rw [coeff_ofCoeffs_list, list_getD_map_range]
   by_cases hn : n < max p.size q.size
   · simp [hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -107,9 +107,7 @@ private theorem divMod_spec_core [PrimeModulus p] (f g : DensePoly (ZMod64 p)) :
       unfold DensePoly.leadingCoeff DensePoly.coeff
       change g.coeffs.back?.getD (0 : ZMod64 p) =
         g.coeffs.getD (g.coeffs.size - 1) (Zero.zero : ZMod64 p)
-      rw [Array.back?_eq_getElem?]
-      rw [Array.getD_eq_getD_getElem?]
-      rw [Array.getElem?_eq_getElem hidx]
+      rw [Array.back?_eq_getElem?, Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx]
       rfl
     have hlead_ne : g.leadingCoeff ≠ (Zero.zero : ZMod64 p) := by
       rw [hlead_eq]
@@ -149,9 +147,7 @@ private theorem mod_sub_self_eq_mul_neg_div [PrimeModulus p] (f m : DensePoly (Z
       have hcoeff := congrArg (fun x : DensePoly (ZMod64 p) => x.coeff n) hdiv
       change (((f / m) * m + (f % m)).coeff n = f.coeff n) at hcoeff
       rw [DensePoly.coeff_add_semiring] at hcoeff
-      rw [DensePoly.coeff_sub_ring]
-      rw [DensePoly.coeff_sub_ring]
-      rw [DensePoly.coeff_zero]
+      rw [DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
       grind
     _ = m * (0 - (f / m)) := by
       exact (DensePoly.mul_sub_zero_comm m (f / m)).symm
@@ -178,10 +174,8 @@ private theorem add_sub_add_right (a b c d : DensePoly (ZMod64 p)) :
     (a + b) - (c + d) = (a - c) + (b - d) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring,
+    DensePoly.coeff_add_semiring, DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring]
   grind
 
 /-- `(DensePoly.divMod f m).2` has degree strictly below `m` when `m` has positive degree. -/
@@ -204,9 +198,7 @@ private theorem divMod_remainder_degree_lt_core
       simpa [DensePoly.size] using Nat.sub_one_lt_of_lt hpos_size
     change m.coeffs.back?.getD (0 : ZMod64 p) =
       m.coeffs.getD (m.coeffs.size - 1) (Zero.zero : ZMod64 p)
-    rw [Array.back?_eq_getElem?]
-    rw [Array.getD_eq_getD_getElem?]
-    rw [Array.getElem?_eq_getElem hidx]
+    rw [Array.back?_eq_getElem?, Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx]
     rfl
   have hlead_ne : lead ≠ (Zero.zero : ZMod64 p) := by
     rw [hlead_eq]
@@ -593,9 +585,7 @@ private theorem mod_eq_mod_of_congr_not_pos_degree
         unfold DensePoly.leadingCoeff DensePoly.coeff
         change m.coeffs.back?.getD (0 : ZMod64 p) =
           m.coeffs.getD (m.coeffs.size - 1) (Zero.zero : ZMod64 p)
-        rw [Array.back?_eq_getElem?]
-        rw [Array.getD_eq_getD_getElem?]
-        rw [Array.getElem?_eq_getElem hidx]
+        rw [Array.back?_eq_getElem?, Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx]
         rfl
       have hcoeff_ne := DensePoly.coeff_last_ne_zero_of_pos_size m hpos
       rw [hlead_eq]
@@ -645,8 +635,7 @@ private theorem sub_self_right_add (a b : DensePoly (ZMod64 p)) :
     (a + b) - a = b := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_add_semiring]
   grind
 
 private theorem mul_left_remainder_delta (f g m rf rg : DensePoly (ZMod64 p))
@@ -989,11 +978,8 @@ private theorem foldl_eval_replicate_zero (x : ZMod64 p) :
   | succ n ih =>
       intro acc
       simp only [List.replicate_succ, List.foldl_cons]
-      rw [zmod_add_zero]
-      rw [ih (acc * x)]
-      rw [Lean.Grind.Semiring.pow_succ x n]
-      rw [Lean.Grind.Semiring.mul_assoc acc x (x ^ n)]
-      rw [Lean.Grind.CommSemiring.mul_comm x (x ^ n)]
+      rw [zmod_add_zero, ih (acc * x), Lean.Grind.Semiring.pow_succ x n,
+        Lean.Grind.Semiring.mul_assoc acc x (x ^ n), Lean.Grind.CommSemiring.mul_comm x (x ^ n)]
 
 /-- Evaluating a monomial gives the coefficient times the corresponding power. -/
 @[simp, grind =]
@@ -1066,15 +1052,12 @@ private theorem mul_evalCoeffPowerSumFrom_eq_succ
       simp [evalCoeffPowerSumFrom, Lean.Grind.Semiring.mul_zero]
   | coeff :: coeffs, base => by
       simp only [evalCoeffPowerSumFrom]
-      rw [Lean.Grind.Semiring.left_distrib]
-      rw [mul_evalCoeffPowerSumFrom_eq_succ x coeffs (base + 1)]
-      rw [← Lean.Grind.Semiring.mul_assoc x coeff (x ^ base)]
-      rw [Lean.Grind.CommSemiring.mul_comm x coeff]
-      rw [Lean.Grind.Semiring.mul_assoc coeff x (x ^ base)]
-      rw [Lean.Grind.CommSemiring.mul_comm x (x ^ base)]
-      rw [← Lean.Grind.Semiring.mul_assoc coeff (x ^ base) x]
-      rw [Lean.Grind.Semiring.pow_succ x base]
-      rw [Lean.Grind.Semiring.mul_assoc coeff (x ^ base) x]
+      rw [Lean.Grind.Semiring.left_distrib, mul_evalCoeffPowerSumFrom_eq_succ x coeffs (base + 1),
+        ← Lean.Grind.Semiring.mul_assoc x coeff (x ^ base),
+        Lean.Grind.CommSemiring.mul_comm x coeff, Lean.Grind.Semiring.mul_assoc coeff x (x ^ base),
+        Lean.Grind.CommSemiring.mul_comm x (x ^ base),
+        ← Lean.Grind.Semiring.mul_assoc coeff (x ^ base) x, Lean.Grind.Semiring.pow_succ x base,
+        Lean.Grind.Semiring.mul_assoc coeff (x ^ base) x]
 
 /-- The Horner evaluation of a coefficient list equals its power sum based at
 exponent zero. -/
@@ -1086,8 +1069,8 @@ private theorem evalScalarCoeffList_eq_powerSumFrom_zero
       simp [evalScalarCoeffList, evalCoeffPowerSumFrom]
   | coeff :: coeffs => by
       simp only [evalScalarCoeffList, evalCoeffPowerSumFrom]
-      rw [evalScalarCoeffList_eq_powerSumFrom_zero x coeffs]
-      rw [mul_evalCoeffPowerSumFrom_eq_succ x coeffs 0]
+      rw [evalScalarCoeffList_eq_powerSumFrom_zero x coeffs,
+        mul_evalCoeffPowerSumFrom_eq_succ x coeffs 0]
       grind
 
 /-- The Horner-step left fold over the reversed coefficient list equals
@@ -1102,9 +1085,8 @@ private theorem foldl_eval_reverse_eq_evalScalarCoeffList
   | coeff :: coeffs => by
       rw [List.reverse_cons, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [foldl_eval_reverse_eq_evalScalarCoeffList x coeffs]
-      rw [Lean.Grind.CommSemiring.mul_comm]
-      rw [Lean.Grind.Semiring.add_comm]
+      rw [foldl_eval_reverse_eq_evalScalarCoeffList x coeffs, Lean.Grind.CommSemiring.mul_comm,
+        Lean.Grind.Semiring.add_comm]
       rfl
 
 /-- `DensePoly.eval f x` equals the power sum of `f`'s coefficient list based at
@@ -1170,8 +1152,7 @@ private theorem toArray_toList_eq_coeff_range (f : FpPoly p) :
   · intro i hi
     have hi_size : i < f.size := by
       simpa [DensePoly.toArray, DensePoly.size] using hi
-    rw [eval_coeff_list_getD_eq_coeff]
-    rw [list_getD_map_range_zmod]
+    rw [eval_coeff_list_getD_eq_coeff, list_getD_map_range_zmod]
     simp [hi_size]
 
 /-- `evalCoeffPowerSumUpTo coeff n base x` is the power sum
@@ -1206,8 +1187,7 @@ coefficients up to `f.size`. -/
 private theorem eval_eq_coeff_power_sum_upTo_size (f : FpPoly p)
     (x : ZMod64 p) :
     DensePoly.eval f x = evalCoeffPowerSumUpTo (fun i => f.coeff i) f.size 0 x := by
-  rw [eval_eq_coeff_power_sum]
-  rw [toArray_toList_eq_coeff_range]
+  rw [eval_eq_coeff_power_sum, toArray_toList_eq_coeff_range]
   simpa using evalCoeffPowerSumFrom_range_eq_upTo (fun i => f.coeff i) x f.size 0
 
 /-- Extending the power sum by one more term leaves it unchanged when the next
@@ -1220,9 +1200,8 @@ private theorem evalCoeffPowerSumUpTo_succ_of_next_zero
           evalCoeffPowerSumUpTo coeff (n + 1) base x
   | 0, base, hzero => by
       have hz : coeff base = 0 := by simpa using hzero
-      rw [evalCoeffPowerSumUpTo, evalCoeffPowerSumUpTo, hz]
-      rw [evalCoeffPowerSumUpTo]
-      rw [Lean.Grind.Semiring.add_zero]
+      rw [evalCoeffPowerSumUpTo, evalCoeffPowerSumUpTo, hz, evalCoeffPowerSumUpTo,
+        Lean.Grind.Semiring.add_zero]
       exact (Lean.Grind.Semiring.zero_mul (x ^ base)).symm
   | n + 1, base, hzero => by
       simp only [evalCoeffPowerSumUpTo]
@@ -1241,8 +1220,7 @@ private theorem evalCoeffPowerSumUpTo_le_extend_base
   | 0 => by
       simp
   | extra + 1 => by
-      rw [evalCoeffPowerSumUpTo_le_extend_base coeff x hzero extra]
-      rw [Nat.add_succ]
+      rw [evalCoeffPowerSumUpTo_le_extend_base coeff x hzero extra, Nat.add_succ]
       exact evalCoeffPowerSumUpTo_succ_of_next_zero
         coeff x (bound + extra) base (hzero (base + (bound + extra)) (by omega))
 
@@ -1325,18 +1303,17 @@ private theorem evalCoeffPowerSumUpTo_rebase_mul
       simp [evalCoeffPowerSumUpTo]
   | n + 1, base => by
       simp only [evalCoeffPowerSumUpTo]
-      rw [Lean.Grind.Semiring.left_distrib]
-      rw [evalCoeffPowerSumUpTo_rebase_mul coeff x shift n (base + 1)]
+      rw [Lean.Grind.Semiring.left_distrib,
+        evalCoeffPowerSumUpTo_rebase_mul coeff x shift n (base + 1)]
       have hpow :
           x ^ shift * x ^ base = x ^ (shift + base) := by
         exact (Lean.Grind.Semiring.pow_add x shift base).symm
       have hterm :
           x ^ shift * (coeff (shift + base) * x ^ base) =
             coeff (shift + base) * x ^ (shift + base) := by
-        rw [← Lean.Grind.Semiring.mul_assoc]
-        rw [Lean.Grind.CommSemiring.mul_comm (x ^ shift) (coeff (shift + base))]
-        rw [Lean.Grind.Semiring.mul_assoc]
-        rw [hpow]
+        rw [← Lean.Grind.Semiring.mul_assoc,
+          Lean.Grind.CommSemiring.mul_comm (x ^ shift) (coeff (shift + base)),
+          Lean.Grind.Semiring.mul_assoc, hpow]
       rw [hterm]
       grind
 
@@ -1350,8 +1327,7 @@ private theorem evalCoeffPowerSumUpTo_zero_prefix_shift
         x ^ shift * evalCoeffPowerSumUpTo coeff n 0 x
   | 0, n => by
       simp only [Nat.zero_add]
-      rw [Lean.Grind.Semiring.pow_zero]
-      rw [Lean.Grind.Semiring.one_mul]
+      rw [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.one_mul]
       rfl
   | shift + 1, n => by
       rw [Nat.succ_add]
@@ -1373,8 +1349,7 @@ private theorem evalCoeffPowerSumUpTo_zero_prefix_shift
           (fun k => if k < shift + 1 then 0 else coeff (k - (shift + 1)))
           x 1 (shift + n) 0]
         have hx_one : x ^ 1 = x := by
-          rw [Lean.Grind.Semiring.pow_succ x 0]
-          rw [Lean.Grind.Semiring.pow_zero]
+          rw [Lean.Grind.Semiring.pow_succ x 0, Lean.Grind.Semiring.pow_zero]
           grind
         rw [hx_one]
         have hfun :
@@ -1388,9 +1363,8 @@ private theorem evalCoeffPowerSumUpTo_zero_prefix_shift
             have hsub : 1 + k - (shift + 1) = k - shift := by omega
             simp [hk, hk', hsub]
         rw [hfun]
-      rw [htail]
-      rw [evalCoeffPowerSumUpTo_zero_prefix_shift coeff x shift n]
-      rw [Lean.Grind.Semiring.pow_succ x shift]
+      rw [htail, evalCoeffPowerSumUpTo_zero_prefix_shift coeff x shift n,
+        Lean.Grind.Semiring.pow_succ x shift]
       grind
 
 /-- A polynomial's size is at most `bound` when all coefficients from `bound`
@@ -1509,8 +1483,7 @@ structure on `FpPoly p`. -/
     f + 0 = f := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_zero]
   grind
 
 /-- `0` is a left identity for addition. Part of the commutative-ring
@@ -1519,8 +1492,7 @@ structure on `FpPoly p`. -/
     0 + f = f := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_zero]
   grind
 
 /-- Polynomial addition is commutative. Part of the commutative-ring
@@ -1529,8 +1501,7 @@ theorem add_comm (f g : FpPoly p) :
     f + g = g + f := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring]
   grind
 
 /-- Polynomial addition is associative, letting callers regroup sums freely.
@@ -1539,10 +1510,8 @@ theorem add_assoc (f g h : FpPoly p) :
     f + g + h = f + (g + h) := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring,
+    DensePoly.coeff_add_semiring]
   grind
 
 /-- Negating `0` gives `0`. -/
@@ -1550,8 +1519,7 @@ theorem add_assoc (f g h : FpPoly p) :
     -(0 : FpPoly p) = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_neg_ring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_neg_ring, DensePoly.coeff_zero]
   grind
 
 /-- The negation is a left additive inverse: `-f + f = 0`. -/
@@ -1559,9 +1527,7 @@ theorem add_assoc (f g h : FpPoly p) :
     -f + f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_neg_ring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_neg_ring, DensePoly.coeff_zero]
   grind
 
 /-- The negation is a right additive inverse: `f + -f = 0`. -/
@@ -1569,9 +1535,7 @@ theorem add_assoc (f g h : FpPoly p) :
     f + -f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_neg_ring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_neg_ring, DensePoly.coeff_zero]
   grind
 
 /-- Subtracting `0` leaves a polynomial unchanged. -/
@@ -1579,8 +1543,7 @@ theorem add_assoc (f g h : FpPoly p) :
     f - 0 = f := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
   grind
 
 /-- Subtracting a polynomial from `0` yields its negation. -/
@@ -1593,8 +1556,7 @@ theorem add_assoc (f g h : FpPoly p) :
     f - f = 0 := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_sub_ring, DensePoly.coeff_zero]
   grind
 
 /-- Subtraction unfolds to adding the negation. Rewrites subtraction in terms
@@ -1603,9 +1565,7 @@ theorem sub_eq_add_neg (f g : FpPoly p) :
     f - g = f + -g := by
   apply DensePoly.ext_coeff
   intro i
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_neg_ring]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_sub_ring, DensePoly.coeff_neg_ring]
   grind
 
 example (f : FpPoly p) :
@@ -1636,8 +1596,7 @@ private theorem coeff_mul_one_fold (f : FpPoly p) (n k : Nat) :
   | succ n ih =>
       rw [List.range_succ, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [DensePoly.coeff_add_semiring, ih]
-      rw [DensePoly.coeff_shift_scale]
+      rw [DensePoly.coeff_add_semiring, ih, DensePoly.coeff_shift_scale]
       · rw [coeff_one]
         by_cases hk : k < n
         · have hks : k < n + 1 := Nat.lt_trans hk (Nat.lt_succ_self n)
@@ -1906,8 +1865,7 @@ private theorem fold_add_reverse
   | cons x xs ih =>
       rw [List.reverse_cons, List.foldl_append]
       simp only [List.foldl_cons, List.foldl_nil]
-      rw [ih]
-      rw [fold_add_right xs a x]
+      rw [ih, fold_add_right xs a x]
 
 /-- `(List.range (n + 1)).reverse` equals `List.range (n + 1)` mapped by
 `fun i => n - i`, recasting the reversed summation order as the index
@@ -1966,9 +1924,7 @@ private theorem fold_mulCoeff_comm
     simpa [List.foldl_map, ← List.map_reverse] using
       fold_add_reverse (p := p)
         ((List.range (n + 1)).map (fun i => mulCoeffTerm f g n i)) 0
-  rw [← hrev]
-  rw [range_succ_reverse_eq_map_sub]
-  rw [List.foldl_map]
+  rw [← hrev, range_succ_reverse_eq_map_sub, List.foldl_map]
   exact fold_mulCoeff_comm_reindex_list f g n (List.range (n + 1)) (by
     intro i hi
     exact List.mem_range.mp hi) 0
@@ -1980,9 +1936,7 @@ theorem mul_comm (f g : FpPoly p) :
     f * g = g * f := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_degree_bound f g n]
-  rw [mulCoeffSum_eq_degree_bound g f n]
+  rw [coeff_mul, coeff_mul, mulCoeffSum_eq_degree_bound f g n, mulCoeffSum_eq_degree_bound g f n]
   exact fold_mulCoeff_comm f g n
 
 private theorem mulCoeffTerm_left_distrib (f g h : FpPoly p) (n i : Nat) :
@@ -2295,9 +2249,8 @@ private theorem fold_flatMap_map_add
   | nil =>
       rfl
   | cons x xs ih =>
-      rw [List.flatMap_cons, List.foldl_append]
-      rw [fold_add_acc (p := p) ((row x).map (term x)) acc]
-      rw [ih]
+      rw [List.flatMap_cons, List.foldl_append, fold_add_acc (p := p) ((row x).map (term x)) acc,
+        ih]
       simp [List.foldl_map]
 
 /-- `fold_triangular_assoc_reindex` reindexes the triangular coefficient double-fold
@@ -2353,8 +2306,7 @@ private theorem fold_add_zero_terms_acc
       rfl
   | cons i xs ih =>
       simp only [List.foldl_cons]
-      rw [hterm i (by simp)]
-      rw [zmod_add_zero]
+      rw [hterm i (by simp), zmod_add_zero]
       exact ih (by
         intro j hj
         exact hterm j (by simp [hj])) acc
@@ -2386,8 +2338,7 @@ private theorem fold_add_single_range
           have hi' : i < n + 1 := List.mem_range.mp hi
           have hne : i ≠ n + 1 := by omega
           rw [if_neg hne]
-        rw [hzero]
-        rw [if_pos rfl]
+        rw [hzero, if_pos rfl]
         exact zmod_zero_add a
       · have ht' : t < n + 1 := by omega
         rw [ih ht']
@@ -2469,8 +2420,7 @@ theorem coeff_mul_shift_scale_one
         have hlt : n - j < i := by omega
         simp [hlt]
         exact zmod_mul_zero (f.coeff j)
-    rw [hzero]
-    rw [if_neg hin]
+    rw [hzero, if_neg hin]
 
 /-- Expands the degree-`n` coefficient of `(f * g) * h` into a left-associated
 triple fold: the outer sum over `i` pairs the `i`-th coefficient of `f * g`
@@ -2642,10 +2592,9 @@ theorem right_distrib (f g h : FpPoly p) :
   apply DensePoly.ext_coeff
   intro n
   let m := max (max (f + g).size f.size) g.size
-  rw [DensePoly.coeff_add_semiring]
-  rw [coeff_mul_of_size_le (f + g) h n m (by dsimp [m]; omega)]
-  rw [coeff_mul_of_size_le f h n m (by dsimp [m]; omega)]
-  rw [coeff_mul_of_size_le g h n m (by dsimp [m]; omega)]
+  rw [DensePoly.coeff_add_semiring, coeff_mul_of_size_le (f + g) h n m (by dsimp [m]; omega),
+    coeff_mul_of_size_le f h n m (by dsimp [m]; omega),
+    coeff_mul_of_size_le g h n m (by dsimp [m]; omega)]
   exact fold_right_distrib (List.range m) f g h n
 
 /-- Polynomial multiplication is associative, letting callers regroup products
@@ -2654,9 +2603,8 @@ theorem mul_assoc (f g h : FpPoly p) :
     (f * g) * h = f * (g * h) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_degree_bound (f * g) h n]
-  rw [mulCoeffSum_eq_degree_bound f (g * h) n]
+  rw [coeff_mul, coeff_mul, mulCoeffSum_eq_degree_bound (f * g) h n,
+    mulCoeffSum_eq_degree_bound f (g * h) n]
   calc
     (List.range (n + 1)).foldl
         (fun acc i => acc + mulCoeffTerm (f * g) h n i) 0
@@ -2684,11 +2632,8 @@ theorem scale_add (c : ZMod64 p) (f g : FpPoly p) :
   apply DensePoly.ext_coeff
   intro n
   have hzero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [DensePoly.coeff_scale _ _ _ hzero]
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring,
+    DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_scale _ _ _ hzero]
   grind
 
 /-- Scaling a product equals scaling its left factor. With `mul_comm` this lets
@@ -2699,11 +2644,9 @@ theorem scale_mul_left (c : ZMod64 p) (f g : FpPoly p) :
   apply DensePoly.ext_coeff
   intro n
   have hzero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [coeff_mul, coeff_mul]
-  rw [mulCoeffSum_eq_degree_bound (DensePoly.scale c f) g n]
-  rw [mulCoeffSum_eq_degree_bound f g n]
-  rw [fold_mul_left]
+  rw [DensePoly.coeff_scale _ _ _ hzero, coeff_mul, coeff_mul,
+    mulCoeffSum_eq_degree_bound (DensePoly.scale c f) g n, mulCoeffSum_eq_degree_bound f g n,
+    fold_mul_left]
   apply fold_add_congr
   intro i _hi
   unfold mulCoeffTerm
@@ -2741,8 +2684,7 @@ The constant-multiplication special case of `eval_mul`. -/
 @[grind =]
 theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (DensePoly.C c * f) x = c * DensePoly.eval f x := by
-  rw [C_mul_eq_scale]
-  rw [eval_eq_coeff_power_sum_upTo_bound (DensePoly.scale c f) x (bound := f.size)]
+  rw [C_mul_eq_scale, eval_eq_coeff_power_sum_upTo_bound (DensePoly.scale c f) x (bound := f.size)]
   · rw [eval_eq_coeff_power_sum_upTo_size f x]
     have hcoeff :
         (fun i => (DensePoly.scale c f).coeff i) =
@@ -2755,8 +2697,7 @@ theorem eval_C_mul (c : ZMod64 p) (f : FpPoly p) (x : ZMod64 p) :
   · apply size_le_of_coeff_eq_zero_from
     intro i hi
     have hzero : c * (0 : ZMod64 p) = 0 := by grind
-    rw [DensePoly.coeff_scale _ _ _ hzero]
-    rw [DensePoly.coeff_eq_zero_of_size_le f hi]
+    rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_eq_zero_of_size_le f hi]
     exact hzero
 
 /-- Evaluating the constant polynomial `1` at any point gives `1`. -/
@@ -2779,9 +2720,8 @@ private theorem fold_eval_shift_scale_rows
       rfl
   | cons i xs ih =>
       simp only [List.foldl_cons]
-      rw [ih (acc + DensePoly.shift i (DensePoly.scale (f.coeff i) h))]
-      rw [eval_add]
-      rw [eval_shift_scale_row]
+      rw [ih (acc + DensePoly.shift i (DensePoly.scale (f.coeff i) h)), eval_add,
+        eval_shift_scale_row]
 
 private theorem fold_shift_scale_one_eq_self (f : FpPoly p) :
     (List.range f.size).foldl
@@ -2803,8 +2743,7 @@ private theorem mul_eq_fold_shift_scale_rows (f h : FpPoly p) :
         (0 : FpPoly p) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_mul]
-  rw [coeff_mul_fold]
+  rw [coeff_mul, coeff_mul_fold]
   unfold mulCoeffSum
   rw [DensePoly.coeff_zero]
   rfl
@@ -2815,9 +2754,7 @@ evaluation, used wherever a root or factorization is checked pointwise. -/
 @[simp, grind =]
 theorem eval_mul (f h : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval (f * h) x = DensePoly.eval f x * DensePoly.eval h x := by
-  rw [mul_eq_fold_shift_scale_rows]
-  rw [fold_eval_shift_scale_rows]
-  rw [DensePoly.eval_zero]
+  rw [mul_eq_fold_shift_scale_rows, fold_eval_shift_scale_rows, DensePoly.eval_zero]
   have hf :
       DensePoly.eval f x =
         (List.range f.size).foldl
@@ -2826,8 +2763,7 @@ theorem eval_mul (f h : FpPoly p) (x : ZMod64 p) :
     rw [← fold_eval_shift_scale_rows
       (List.range f.size) (0 : FpPoly p) f (1 : FpPoly p) x]
     rw [fold_shift_scale_one_eq_self]
-  rw [hf]
-  rw [DensePoly.eval_zero, eval_one]
+  rw [hf, DensePoly.eval_zero, eval_one]
   have hone :
       (List.range f.size).foldl
           (fun acc i => acc + (f.coeff i * x ^ i) * (1 : ZMod64 p)) 0 =
@@ -2859,9 +2795,8 @@ theorem scale_scale (c d : ZMod64 p) (f : FpPoly p) :
   have hzero_c : c * (0 : ZMod64 p) = 0 := by grind
   have hzero_d : d * (0 : ZMod64 p) = 0 := by grind
   have hzero_cd : (c * d) * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero_c]
-  rw [DensePoly.coeff_scale _ _ _ hzero_d]
-  rw [DensePoly.coeff_scale _ _ _ hzero_cd]
+  rw [DensePoly.coeff_scale _ _ _ hzero_c, DensePoly.coeff_scale _ _ _ hzero_d,
+    DensePoly.coeff_scale _ _ _ hzero_cd]
   grind
 
 /-- Scaling by `1` leaves the polynomial unchanged. The identity law of the
@@ -3000,10 +2935,9 @@ theorem leadingCoeff_scale_of_ne_zero_of_pos_degree [ZMod64.PrimeModulus p]
     scale_size_eq_of_ne_zero (p := p) hc f
   have hscale_pos : 0 < (DensePoly.scale c f).size := by omega
   have hscale_zero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [leadingCoeff_eq_coeff_pred (DensePoly.scale c f) hscale_pos]
-  rw [leadingCoeff_eq_coeff_pred f hfpos]
-  rw [show (DensePoly.scale c f).size - 1 = f.size - 1 by omega]
-  rw [DensePoly.coeff_scale _ _ _ hscale_zero]
+  rw [leadingCoeff_eq_coeff_pred (DensePoly.scale c f) hscale_pos,
+    leadingCoeff_eq_coeff_pred f hfpos, show (DensePoly.scale c f).size - 1 = f.size - 1 by omega,
+    DensePoly.coeff_scale _ _ _ hscale_zero]
 
 /-- The same leading-coefficient scaling law as
 `leadingCoeff_scale_of_ne_zero_of_pos_degree`, stated from the weaker nonempty
@@ -3019,10 +2953,9 @@ theorem leadingCoeff_scale_of_ne_zero_of_nonzero [ZMod64.PrimeModulus p]
     scale_size_eq_of_ne_zero (p := p) hc f
   have hscale_pos : 0 < (DensePoly.scale c f).size := by omega
   have hscale_zero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [leadingCoeff_eq_coeff_pred (DensePoly.scale c f) hscale_pos]
-  rw [leadingCoeff_eq_coeff_pred f hfpos]
-  rw [show (DensePoly.scale c f).size - 1 = f.size - 1 by omega]
-  rw [DensePoly.coeff_scale _ _ _ hscale_zero]
+  rw [leadingCoeff_eq_coeff_pred (DensePoly.scale c f) hscale_pos,
+    leadingCoeff_eq_coeff_pred f hfpos, show (DensePoly.scale c f).size - 1 = f.size - 1 by omega,
+    DensePoly.coeff_scale _ _ _ hscale_zero]
 
 /-- Scaling a positive-degree polynomial by the inverse of its leading
 coefficient produces a monic polynomial. This is the monic-normalization step
@@ -3075,8 +3008,7 @@ theorem irreducible_scale_iff_of_ne_zero [ZMod64.PrimeModulus p]
       apply DensePoly.ext_coeff
       intro n
       have hzero : c * (0 : ZMod64 p) = 0 := by grind
-      rw [DensePoly.coeff_scale _ _ _ hzero]
-      rw [DensePoly.coeff_zero]
+      rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_zero]
       exact hzero
     · intro a b hab
       have hab' : DensePoly.scale c (a * b) = DensePoly.scale c f := by
@@ -3102,8 +3034,7 @@ theorem irreducible_scale_iff_of_ne_zero [ZMod64.PrimeModulus p]
         apply DensePoly.ext_coeff
         intro n
         have hz : c⁻¹ * (0 : ZMod64 p) = 0 := by grind
-        rw [DensePoly.coeff_scale _ _ _ hz]
-        rw [DensePoly.coeff_zero]
+        rw [DensePoly.coeff_scale _ _ _ hz, DensePoly.coeff_zero]
         exact hz
       rw [hzero] at hback
       exact hback.symm
@@ -3367,10 +3298,8 @@ theorem leadingCoeff_mul
   have hab_pos : 0 < (a * b).size := size_pos_of_ne_zero hab_ne
   have hsize := size_mul_eq_add_sub_one a b ha hb
   have hindex : (a * b).size - 1 = a.size - 1 + (b.size - 1) := by omega
-  rw [DensePoly.leadingCoeff_eq_coeff_last (a * b) hab_pos]
-  rw [hindex]
-  rw [DensePoly.leadingCoeff_eq_coeff_last a ha_pos]
-  rw [DensePoly.leadingCoeff_eq_coeff_last b hb_pos]
+  rw [DensePoly.leadingCoeff_eq_coeff_last (a * b) hab_pos, hindex,
+    DensePoly.leadingCoeff_eq_coeff_last a ha_pos, DensePoly.leadingCoeff_eq_coeff_last b hb_pos]
   exact ZMod64.coeff_mul_at_top a b ha_pos hb_pos
 
 /-- Right cancellation for multiplication by a nonzero `FpPoly p` polynomial. -/
@@ -3649,13 +3578,11 @@ private theorem fold_mulCoeffTerm_monomial_eq
       simp
   | succ m ih =>
       intro acc
-      rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil]
-      rw [ih]
+      rw [List.range_succ, List.foldl_append, List.foldl_cons, List.foldl_nil, ih]
       by_cases hkm : k < m
       · -- k < m, so the new index m is not k.
         have hm_ne : m ≠ k := by omega
-        rw [mulCoeffTerm_monomial_eq_zero_of_ne k c g n m hm_ne]
-        rw [zmod_add_zero]
+        rw [mulCoeffTerm_monomial_eq_zero_of_ne k c g n m hm_ne, zmod_add_zero]
         have hkm' : k < m + 1 := by omega
         by_cases hkn : ¬ n < k
         · simp [hkm, hkn, hkm']
@@ -3672,8 +3599,7 @@ private theorem fold_mulCoeffTerm_monomial_eq
         · -- ¬ k < m and k ≠ m. So k > m, in particular k ≥ m + 1.
           have hkm' : ¬ k < m + 1 := by omega
           have hm_ne : m ≠ k := fun h => hkm_eq h.symm
-          rw [mulCoeffTerm_monomial_eq_zero_of_ne k c g n m hm_ne]
-          rw [zmod_add_zero]
+          rw [mulCoeffTerm_monomial_eq_zero_of_ne k c g n m hm_ne, zmod_add_zero]
           simp [hkm, hkm']
 
 /-- Coefficient of `monomial k c * g` at degree `n`: zero below `k`, `c · g[n-k]`
@@ -3681,9 +3607,8 @@ above. -/
 theorem coeff_monomial_mul (k : Nat) (c : ZMod64 p) (g : FpPoly p) (n : Nat) :
     ((DensePoly.monomial k c : FpPoly p) * g).coeff n =
       if n < k then 0 else c * g.coeff (n - k) := by
-  rw [coeff_mul, mulCoeffSum_eq_degree_bound]
-  rw [fold_mulCoeffTerm_monomial_eq k c g n (n + 1) 0]
-  rw [zmod_zero_add]
+  rw [coeff_mul, mulCoeffSum_eq_degree_bound, fold_mulCoeffTerm_monomial_eq k c g n (n + 1) 0,
+    zmod_zero_add]
   by_cases hnk : n < k
   · simp [hnk]
   · have hkn : k < n + 1 := by omega
@@ -3788,27 +3713,22 @@ private theorem scalar_linear_factor_mul_dividedDifference_coeff
   have hneg_mul : (-(FpPoly.C α) : FpPoly p) * q = -(FpPoly.C α * q) := by
     show (0 - FpPoly.C α) * q = 0 - FpPoly.C α * q
     exact DensePoly.neg_mul_right_poly (FpPoly.C α) q
-  rw [sub_eq_add_neg, right_distrib]
-  rw [DensePoly.coeff_add_semiring]
-  rw [hneg_mul]
-  rw [DensePoly.coeff_neg_ring]
+  rw [sub_eq_add_neg, right_distrib, DensePoly.coeff_add_semiring, hneg_mul,
+    DensePoly.coeff_neg_ring]
   have hCmul : FpPoly.C α * q = DensePoly.scale α q := C_mul_eq_scale α q
-  rw [hCmul]
-  rw [DensePoly.coeff_scale _ _ _ hzero_mul]
-  rw [show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl]
-  rw [coeff_monomial_mul]
-  rw [DensePoly.coeff_ofCoeffs_list, DensePoly.coeff_ofCoeffs_list]
-  rw [zmod_Zero_zero_eq_zero]
+  rw [hCmul, DensePoly.coeff_scale _ _ _ hzero_mul,
+    show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl, coeff_monomial_mul,
+    DensePoly.coeff_ofCoeffs_list, DensePoly.coeff_ofCoeffs_list, zmod_Zero_zero_eq_zero]
   cases n with
   | zero =>
       simp
-      rw [scalarDividedDifferenceCoeffs_getElem?_getD cs α 0]
-      rw [show cs.drop 1 = cs.tail by cases cs <;> rfl]
+      rw [scalarDividedDifferenceCoeffs_getElem?_getD cs α 0,
+        show cs.drop 1 = cs.tail by cases cs <;> rfl]
       grind
   | succ n =>
       simp
-      rw [scalarDividedDifferenceCoeffs_getElem?_getD cs α n]
-      rw [scalarDividedDifferenceCoeffs_getElem?_getD cs α (n + 1)]
+      rw [scalarDividedDifferenceCoeffs_getElem?_getD cs α n,
+        scalarDividedDifferenceCoeffs_getElem?_getD cs α (n + 1)]
       grind
 
 /-- Capstone factorization (Ruffini / Horner remainder identity): the polynomial
@@ -3824,15 +3744,12 @@ private theorem ofCoeffs_eq_C_eval_add_linear_mul_dividedDifference
           (DensePoly.ofCoeffs (scalarDividedDifferenceCoeffs cs α).toArray : FpPoly p) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_ofCoeffs_list]
-  rw [zmod_Zero_zero_eq_zero]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_ofCoeffs_list, zmod_Zero_zero_eq_zero]
   rw [show (FpPoly.C (evalScalarCoeffList cs α)).coeff n =
       if n = 0 then evalScalarCoeffList cs α else (Zero.zero : ZMod64 p) by
     unfold FpPoly.C
     rw [DensePoly.coeff_C]]
-  rw [zmod_Zero_zero_eq_zero]
-  rw [scalar_linear_factor_mul_dividedDifference_coeff cs α n]
+  rw [zmod_Zero_zero_eq_zero, scalar_linear_factor_mul_dividedDifference_coeff cs α n]
   cases n with
   | zero =>
       have hdrop := evalScalarCoeffList_drop_eq_getD_add cs α 0
@@ -3857,10 +3774,7 @@ theorem X_sub_C_dvd_of_eval_eq_zero
   rw [eval_eq_coeff_power_sum] at hroot
   have hroot_scalar : evalScalarCoeffList f.toArray.toList c = 0 := by
     rw [evalScalarCoeffList_eq_powerSumFrom_zero, hroot]
-  rw [← ofCoeffs_toArray_fp f]
-  rw [hcoeffs]
-  rw [hroot_scalar]
-  rw [C_zero_fp]
+  rw [← ofCoeffs_toArray_fp f, hcoeffs, hroot_scalar, C_zero_fp]
   change (0 : FpPoly p) +
       (FpPoly.X - FpPoly.C c) * q = (FpPoly.X - FpPoly.C c) * q
   exact zero_add ((FpPoly.X - FpPoly.C c) * q)
@@ -3872,8 +3786,7 @@ theorem monomial_mul_monomial (m n : Nat) :
       DensePoly.monomial (m + n) (1 : ZMod64 p) := by
   apply DensePoly.ext_coeff
   intro i
-  rw [coeff_monomial_mul]
-  rw [DensePoly.coeff_monomial, DensePoly.coeff_monomial]
+  rw [coeff_monomial_mul, DensePoly.coeff_monomial, DensePoly.coeff_monomial]
   by_cases him : i < m
   · simp [him]
     have hne : i ≠ m + n := by omega
@@ -4022,16 +3935,14 @@ theorem linearPow_C (c : ZMod64 p) (n : Nat) :
 /-- The polynomial-level subtraction-multiplication identity: `(P - 1) * Y = P * Y - Y`. -/
 private theorem sub_one_mul_eq (P Y : FpPoly p) :
     (P - 1) * Y = P * Y - Y := by
-  rw [sub_eq_add_neg]
-  rw [right_distrib]
+  rw [sub_eq_add_neg, right_distrib]
   have hneg : (-(1 : FpPoly p)) * Y = -Y := by
     show (0 - (1 : FpPoly p)) * Y = 0 - Y
     have h := DensePoly.neg_mul_right_poly (1 : FpPoly p) Y
     have h1 : (1 : FpPoly p) * Y = Y := one_mul Y
     calc (0 - (1 : FpPoly p)) * Y = 0 - 1 * Y := h
       _ = 0 - Y := by rw [h1]
-  rw [hneg]
-  rw [← sub_eq_add_neg]
+  rw [hneg, ← sub_eq_add_neg]
 
 /-- Geometric-series divisibility: `Y - 1 ∣ Y^j - 1`. -/
 theorem sub_one_dvd_linearPow_sub_one (Y : FpPoly p) (j : Nat) :
@@ -4044,19 +3955,15 @@ theorem sub_one_dvd_linearPow_sub_one (Y : FpPoly p) (j : Nat) :
       obtain ⟨q, hq⟩ := ih
       refine ⟨q * Y + 1, ?_⟩
       -- Need: linearPow Y (j + 1) - 1 = (Y - 1) * (q * Y + 1)
-      rw [linearPow_succ]
-      rw [left_distrib, mul_one]
-      rw [show (Y - 1) * (q * Y) = ((Y - 1) * q) * Y from (mul_assoc _ _ _).symm]
-      rw [← hq]
-      rw [sub_one_mul_eq]
+      rw [linearPow_succ, left_distrib, mul_one,
+        show (Y - 1) * (q * Y) = ((Y - 1) * q) * Y from (mul_assoc _ _ _).symm, ← hq,
+        sub_one_mul_eq]
       -- goal: linearPow Y j * Y - 1 = linearPow Y j * Y - Y + (Y - 1)
       -- A - 1 = A - Y + Y - 1, regroup at coefficient level.
       apply DensePoly.ext_coeff
       intro n
-      rw [DensePoly.coeff_sub_ring]
-      rw [DensePoly.coeff_add_semiring]
-      rw [DensePoly.coeff_sub_ring]
-      rw [DensePoly.coeff_sub_ring]
+      rw [DensePoly.coeff_sub_ring, DensePoly.coeff_add_semiring, DensePoly.coeff_sub_ring,
+        DensePoly.coeff_sub_ring]
       grind
 
 /-- Geometric-series divisibility for monomials: when `k ∣ l`,

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -104,11 +104,9 @@ composition. -/
   have hstep1 : ((0 : FpPoly p) * q + DensePoly.C (1 : ZMod64 p)) = (1 : FpPoly p) := by
     rw [FpPoly.zero_mul, FpPoly.zero_add]
     rfl
-  rw [hstep1]
-  rw [FpPoly.one_mul]
+  rw [hstep1, FpPoly.one_mul]
   show q + DensePoly.C (Zero.zero : ZMod64 p) = q
-  rw [show (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero]
-  rw [FpPoly.add_zero]
+  rw [show (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero, FpPoly.add_zero]
 
 /-- Composing the constant polynomial `1` with any `q` yields `1`: the
 multiplicative identity of `FpPoly` is fixed by substitution. This is the
@@ -143,13 +141,10 @@ private theorem mul_composeCoeffPowerSumFrom_eq_succ (q : FpPoly p) :
       simp [composeCoeffPowerSumFrom, FpPoly.mul_zero]
   | c :: cs, base => by
       simp only [composeCoeffPowerSumFrom]
-      rw [FpPoly.left_distrib]
-      rw [mul_composeCoeffPowerSumFrom_eq_succ q cs (base + 1)]
+      rw [FpPoly.left_distrib, mul_composeCoeffPowerSumFrom_eq_succ q cs (base + 1)]
       congr 1
       -- q * (C c * linearPow q base) = C c * linearPow q (base + 1)
-      rw [← FpPoly.mul_assoc]
-      rw [FpPoly.mul_comm q (DensePoly.C c)]
-      rw [FpPoly.mul_assoc]
+      rw [← FpPoly.mul_assoc, FpPoly.mul_comm q (DensePoly.C c), FpPoly.mul_assoc]
       congr 1
       change q * linearPow q base = linearPow q (base + 1)
       rw [linearPow_succ_left]
@@ -161,8 +156,8 @@ private theorem composeScalarCoeffList_eq_powerSumFrom_zero (q : FpPoly p) :
       simp [DensePoly.composeScalarCoeffList, composeCoeffPowerSumFrom]
   | c :: cs => by
       simp only [DensePoly.composeScalarCoeffList, composeCoeffPowerSumFrom]
-      rw [composeScalarCoeffList_eq_powerSumFrom_zero q cs]
-      rw [mul_composeCoeffPowerSumFrom_eq_succ q cs 0]
+      rw [composeScalarCoeffList_eq_powerSumFrom_zero q cs,
+        mul_composeCoeffPowerSumFrom_eq_succ q cs 0]
       congr 1
       -- C c = C c * linearPow q 0
       change DensePoly.C c = DensePoly.C c * 1
@@ -224,8 +219,7 @@ theorem C_mul_C_eq (a b : ZMod64 p) :
   apply DensePoly.ext_coeff
   intro n
   have hzero : a * (0 : ZMod64 p) = 0 := Lean.Grind.Semiring.mul_zero a
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [DensePoly.coeff_C, DensePoly.coeff_C]
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_C, DensePoly.coeff_C]
   cases n with
   | zero => simp
   | succ n =>
@@ -259,8 +253,8 @@ private theorem composeCoeffPowerSumFrom_replicate_zero_append_one
             (List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)]) (base + 1) w =
           linearPow w (base + (k + 1))
       have hCz : (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 := C_zero_eq_zero
-      rw [hCz, FpPoly.zero_mul, FpPoly.zero_add]
-      rw [composeCoeffPowerSumFrom_replicate_zero_append_one w k (base + 1)]
+      rw [hCz, FpPoly.zero_mul, FpPoly.zero_add,
+        composeCoeffPowerSumFrom_replicate_zero_append_one w k (base + 1)]
       congr 1
       omega
 
@@ -324,8 +318,7 @@ private theorem composePower_eq_linearPow (w : FpPoly p) :
   | 0 => rfl
   | k + 1 => by
       simp only [DensePoly.composePower]
-      rw [composePower_eq_linearPow w k]
-      rw [linearPow_succ_left]
+      rw [composePower_eq_linearPow w k, linearPow_succ_left]
 
 /-- The local `FpPoly` power-sum accumulator built from `linearPow` agrees
 with the shared `DensePoly.composeCoeffPowerSumUpTo`. Callers use this to
@@ -339,8 +332,7 @@ theorem composeCoeffPowerSumUpTo_eq_core
   | 0, _, _ => rfl
   | n + 1, base, w => by
       simp only [composeCoeffPowerSumUpTo, DensePoly.composeCoeffPowerSumUpTo]
-      rw [composePower_eq_linearPow]
-      rw [composeCoeffPowerSumUpTo_eq_core coeff n (base + 1) w]
+      rw [composePower_eq_linearPow, composeCoeffPowerSumUpTo_eq_core coeff n (base + 1) w]
 
 /-- The list-fed accumulator `composeCoeffPowerSumFrom` over the coefficient
 slice `[coeff base, …, coeff (base + n - 1)]` agrees with the index-fed
@@ -369,8 +361,7 @@ extend-past-the-bound variant `compose_eq_coeff_power_sum_upTo_bound` follows. -
 private theorem compose_eq_coeff_power_sum_upTo_size (f w : FpPoly p) :
     DensePoly.compose f w =
       composeCoeffPowerSumUpTo (fun i => f.coeff i) f.size 0 w := by
-  rw [compose_eq_powerSum]
-  rw [DensePoly.toArray_toList_eq_coeff_range]
+  rw [compose_eq_powerSum, DensePoly.toArray_toList_eq_coeff_range]
   simpa using composeCoeffPowerSumFrom_range_eq_upTo (fun i => f.coeff i) w f.size 0
 
 /-- Single-step extension invariance: when the next coefficient
@@ -388,9 +379,7 @@ private theorem composeCoeffPowerSumUpTo_succ_of_next_zero
       show (0 : FpPoly p) =
         DensePoly.C (coeff base) * linearPow w base +
           composeCoeffPowerSumUpTo coeff 0 (base + 1) w
-      rw [hz]
-      rw [show (DensePoly.C (0 : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero]
-      rw [FpPoly.zero_mul]
+      rw [hz, show (DensePoly.C (0 : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero, FpPoly.zero_mul]
       show (0 : FpPoly p) = 0 + composeCoeffPowerSumUpTo coeff 0 (base + 1) w
       rw [FpPoly.zero_add]
       rfl
@@ -413,8 +402,7 @@ private theorem composeCoeffPowerSumUpTo_le_extend_base
   | 0 => by
       simp
   | extra + 1 => by
-      rw [composeCoeffPowerSumUpTo_le_extend_base coeff w hzero extra]
-      rw [Nat.add_succ]
+      rw [composeCoeffPowerSumUpTo_le_extend_base coeff w hzero extra, Nat.add_succ]
       exact composeCoeffPowerSumUpTo_succ_of_next_zero
         coeff w (bound + extra) base (hzero (base + (bound + extra)) (by omega))
 
@@ -458,9 +446,7 @@ identity through `DensePoly.ext_coeff`. -/
 private theorem fp_sub_mul_right
     (a b c : FpPoly p) :
     (a - b) * c = a * c - b * c := by
-  rw [FpPoly.sub_eq_add_neg a b]
-  rw [FpPoly.right_distrib]
-  rw [FpPoly.sub_eq_add_neg (a * c) (b * c)]
+  rw [FpPoly.sub_eq_add_neg a b, FpPoly.right_distrib, FpPoly.sub_eq_add_neg (a * c) (b * c)]
   congr 1
   show ((0 - b : FpPoly p) * c) = 0 - b * c
   exact DensePoly.neg_mul_right_poly b c
@@ -470,12 +456,8 @@ private theorem fp_add_sub_add_sub
     (x - y) + (u - v) = (x + u) - (y + v) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_sub_ring]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_add_semiring]
+  rw [DensePoly.coeff_add_semiring, DensePoly.coeff_sub_ring, DensePoly.coeff_sub_ring,
+    DensePoly.coeff_sub_ring, DensePoly.coeff_add_semiring, DensePoly.coeff_add_semiring]
   grind
 
 /-- The accumulator is additive under coefficient subtraction: running
@@ -492,8 +474,7 @@ private theorem composeCoeffPowerSumUpTo_sub
       simp [composeCoeffPowerSumUpTo]
   | n + 1, base => by
       simp only [composeCoeffPowerSumUpTo]
-      rw [composeCoeffPowerSumUpTo_sub f h w n (base + 1)]
-      rw [C_sub_eq]
+      rw [composeCoeffPowerSumUpTo_sub f h w n (base + 1), C_sub_eq]
       rw [fp_sub_mul_right (DensePoly.C (f.coeff base))
         (DensePoly.C (h.coeff base)) (linearPow w base)]
       exact fp_add_sub_add_sub
@@ -547,8 +528,7 @@ theorem compose_sub [ZMod64.PrimeModulus p] (f h w : FpPoly p) :
 substituting `w` for `X` in `a - X` yields `compose a w - w`. -/
 theorem compose_sub_X [ZMod64.PrimeModulus p] (a w : FpPoly p) :
     DensePoly.compose (a - FpPoly.X) w = DensePoly.compose a w - w := by
-  rw [compose_sub]
-  rw [compose_X]
+  rw [compose_sub, compose_X]
 
 /-- The headline `linearPow X k - X` substitution: substituting `w`
 for `X` in `linearPow X k - X` yields `linearPow w k - w`. -/
@@ -556,8 +536,7 @@ theorem compose_linearPow_X_sub_X
     [ZMod64.PrimeModulus p] (w : FpPoly p) (k : Nat) :
     DensePoly.compose (FpPoly.linearPow FpPoly.X k - FpPoly.X) w =
       FpPoly.linearPow w k - w := by
-  rw [compose_sub]
-  rw [compose_linearPow_X, compose_X]
+  rw [compose_sub, compose_linearPow_X, compose_X]
 
 /-! ### Substitution into `a * (X - C c)`
 
@@ -644,14 +623,10 @@ private theorem fp_add_acm_rearrange
   -- RHS = D + B + C + A.
   -- Strategy: rewrite RHS via add_assoc to D + (B + C + A), then show A + B + C + D = D + (B + C + A)
   -- by adding D and then commuting.
-  rw [FpPoly.add_assoc D B C]
-  rw [FpPoly.add_assoc D (B + C) A]
+  rw [FpPoly.add_assoc D B C, FpPoly.add_assoc D (B + C) A]
   -- Now goal: A + B + C + D = D + (B + C + A)
   -- LHS = A + B + C + D, swap A and D via comm of the full sum.
-  rw [FpPoly.add_comm A B]
-  rw [FpPoly.add_assoc B A C]
-  rw [FpPoly.add_comm A C]
-  rw [← FpPoly.add_assoc B C A]
+  rw [FpPoly.add_comm A B, FpPoly.add_assoc B A C, FpPoly.add_comm A C, ← FpPoly.add_assoc B C A]
   -- Now goal: B + C + A + D = D + (B + C + A)
   rw [FpPoly.add_comm (B + C + A) D]
 
@@ -661,28 +636,22 @@ private theorem alg_compose_step
     (cprev ccx cx w s : FpPoly p) :
     cprev - ccx * cx + w * (s * (w - ccx) + cx) =
       (cx + w * s) * (w - ccx) + cprev := by
-  rw [FpPoly.left_distrib w (s * (w - ccx)) cx]
-  rw [← FpPoly.mul_assoc w s (w - ccx)]
-  rw [FpPoly.right_distrib cx (w * s) (w - ccx)]
+  rw [FpPoly.left_distrib w (s * (w - ccx)) cx, ← FpPoly.mul_assoc w s (w - ccx),
+    FpPoly.right_distrib cx (w * s) (w - ccx)]
   have hcx_sub :
       cx * (w - ccx) = cx * w - cx * ccx := by
     -- Use mul_comm to commute the multiplications, then existing neg_mul_right_poly.
-    rw [FpPoly.mul_comm cx (w - ccx)]
-    rw [FpPoly.mul_comm cx w]
-    rw [FpPoly.mul_comm cx ccx]
+    rw [FpPoly.mul_comm cx (w - ccx), FpPoly.mul_comm cx w, FpPoly.mul_comm cx ccx]
     -- Goal: (w - ccx) * cx = w * cx - ccx * cx
     rw [sub_eq_add_neg, sub_eq_add_neg, FpPoly.right_distrib]
     congr 1
     -- Goal: (-ccx) * cx = -(ccx * cx)
-    rw [show (-ccx : FpPoly p) = 0 - ccx from (zero_sub _).symm]
-    rw [show (-(ccx * cx) : FpPoly p) = 0 - ccx * cx from (zero_sub _).symm]
+    rw [show (-ccx : FpPoly p) = 0 - ccx from (zero_sub _).symm,
+      show (-(ccx * cx) : FpPoly p) = 0 - ccx * cx from (zero_sub _).symm]
     -- Goal: (0 - ccx) * cx = 0 - ccx * cx
     exact DensePoly.neg_mul_right_poly ccx cx
-  rw [hcx_sub]
-  rw [FpPoly.mul_comm cx w]
-  rw [FpPoly.mul_comm cx ccx]
-  rw [sub_eq_add_neg cprev (ccx * cx)]
-  rw [sub_eq_add_neg (w * cx) (ccx * cx)]
+  rw [hcx_sub, FpPoly.mul_comm cx w, FpPoly.mul_comm cx ccx, sub_eq_add_neg cprev (ccx * cx),
+    sub_eq_add_neg (w * cx) (ccx * cx)]
   -- Goal:
   --   cprev + -(ccx * cx) + (w * s * (w - ccx) + w * cx) =
   --   (w * cx + -(ccx * cx) + w * s * (w - ccx)) + cprev
@@ -699,13 +668,11 @@ private theorem composeScalarCoeffList_mulXSubCListAux
   | prev, [] => by
       simp only [mulXSubCListAux, DensePoly.composeScalarCoeffList]
       -- Goal: DensePoly.C prev + w * 0 = 0 * (w - C c) + C prev
-      rw [FpPoly.mul_zero, FpPoly.zero_mul]
-      rw [FpPoly.add_zero, FpPoly.zero_add]
+      rw [FpPoly.mul_zero, FpPoly.zero_mul, FpPoly.add_zero, FpPoly.zero_add]
       rfl
   | prev, x :: xs => by
       simp only [mulXSubCListAux, DensePoly.composeScalarCoeffList]
-      rw [composeScalarCoeffList_mulXSubCListAux c w x xs]
-      rw [C_sub_eq, C_mul_C_eq]
+      rw [composeScalarCoeffList_mulXSubCListAux c w x xs, C_sub_eq, C_mul_C_eq]
       -- Goal:
       --   DensePoly.C prev - DensePoly.C c * DensePoly.C x +
       --     w * (S * (w - C c) + C x) =
@@ -720,8 +687,7 @@ private theorem composeScalarCoeffList_mulXSubCList
     DensePoly.composeScalarCoeffList (mulXSubCList c cs) w =
       DensePoly.composeScalarCoeffList cs w * (w - FpPoly.C c) := by
   unfold mulXSubCList
-  rw [composeScalarCoeffList_mulXSubCListAux c w 0 cs]
-  rw [fp_C_zero, FpPoly.add_zero]
+  rw [composeScalarCoeffList_mulXSubCListAux c w 0 cs, fp_C_zero, FpPoly.add_zero]
 
 private theorem toArray_toList_getD_eq_coeff
     (f : FpPoly p) (n : Nat) :
@@ -800,15 +766,11 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
     have hneg_mul : (-(FpPoly.C c) : FpPoly p) * a = -(FpPoly.C c * a) := by
       show (0 - FpPoly.C c) * a = 0 - FpPoly.C c * a
       exact DensePoly.neg_mul_right_poly (FpPoly.C c) a
-    rw [sub_eq_add_neg, right_distrib]
-    rw [DensePoly.coeff_add_semiring]
-    rw [hneg_mul]
-    rw [DensePoly.coeff_neg_ring]
-    rw [show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl]
-    rw [coeff_monomial_mul]
+    rw [sub_eq_add_neg, right_distrib, DensePoly.coeff_add_semiring, hneg_mul,
+      DensePoly.coeff_neg_ring,
+      show FpPoly.X = (DensePoly.monomial 1 (1 : ZMod64 p) : FpPoly p) from rfl, coeff_monomial_mul]
     have hCmul : FpPoly.C c * a = DensePoly.scale c a := FpPoly.C_mul_eq_scale c a
-    rw [hCmul]
-    rw [DensePoly.coeff_scale _ _ _ hzero_mul_c]
+    rw [hCmul, DensePoly.coeff_scale _ _ _ hzero_mul_c]
     cases n with
     | zero =>
         simp; grind
@@ -816,10 +778,8 @@ private theorem mul_X_sub_C_eq_ofCoeffs_mulXSubCList
         simp; grind
   rw [hLHS]
   -- RHS computation
-  rw [DensePoly.coeff_ofCoeffs]
-  rw [array_getD_eq_list_getD]
-  rw [mulXSubCList_getD]
-  rw [toArray_toList_getD_eq_coeff a n]
+  rw [DensePoly.coeff_ofCoeffs, array_getD_eq_list_getD, mulXSubCList_getD,
+    toArray_toList_getD_eq_coeff a n]
   -- Replace cs.getD (n-1) 0 with a.coeff (n-1)
   cases n with
   | zero => simp
@@ -835,10 +795,8 @@ theorem compose_mul_X_sub_C [ZMod64.PrimeModulus p]
     (a : FpPoly p) (c : ZMod64 p) (w : FpPoly p) :
     DensePoly.compose (a * (FpPoly.X - FpPoly.C c)) w =
       DensePoly.compose a w * (w - FpPoly.C c) := by
-  rw [mul_X_sub_C_eq_ofCoeffs_mulXSubCList]
-  rw [compose_ofCoeffs_eq_composeScalarCoeffList]
-  rw [composeScalarCoeffList_mulXSubCList]
-  rw [compose_eq_composeScalarCoeffList]
+  rw [mul_X_sub_C_eq_ofCoeffs_mulXSubCList, compose_ofCoeffs_eq_composeScalarCoeffList,
+    composeScalarCoeffList_mulXSubCList, compose_eq_composeScalarCoeffList]
 
 /-! ### foldl transport for the prime-field linear product
 
@@ -859,8 +817,7 @@ theorem compose_foldl_X_sub_C [ZMod64.PrimeModulus p]
   | nil => simp
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [ih (init * (FpPoly.X - FpPoly.C x))]
-      rw [compose_mul_X_sub_C init x w]
+      rw [ih (init * (FpPoly.X - FpPoly.C x)), compose_mul_X_sub_C init x w]
 
 /-- Specialisation to the canonical prime-field linear product starting from
 `init = 1`: substituting `w` into the variable form gives the witness form. -/
@@ -871,8 +828,7 @@ theorem compose_primeFieldLinearProduct [ZMod64.PrimeModulus p]
         (fun acc c => acc * (FpPoly.X - FpPoly.C c)) 1) w =
       (ZMod64.values p).foldl
         (fun acc c => acc * (w - FpPoly.C c)) 1 := by
-  rw [compose_foldl_X_sub_C]
-  rw [compose_one]
+  rw [compose_foldl_X_sub_C, compose_one]
 
 /-! ### Compose-form Frobenius
 
@@ -919,13 +875,10 @@ private theorem composeCoeffPowerSumUpTo_subst_linearPow_X
       exact (linearPow_zero_of_pos p hp_pos).symm
   | n + 1, base => by
       simp only [composeCoeffPowerSumUpTo]
-      rw [composeCoeffPowerSumUpTo_subst_linearPow_X coeff n (base + 1)]
-      rw [FpPoly.linearPow_add_prime (ZMod64.PrimeModulus.prime (p := p))]
-      rw [FpPoly.linearPow_mul_base]
-      rw [Quotient.linearPow_C_pow_prime]
-      rw [linearPow_linearPow_mul FpPoly.X base p]
-      rw [linearPow_linearPow_mul FpPoly.X p base]
-      rw [Nat.mul_comm base p]
+      rw [composeCoeffPowerSumUpTo_subst_linearPow_X coeff n (base + 1),
+        FpPoly.linearPow_add_prime (ZMod64.PrimeModulus.prime (p := p)), FpPoly.linearPow_mul_base,
+        Quotient.linearPow_C_pow_prime, linearPow_linearPow_mul FpPoly.X base p,
+        linearPow_linearPow_mul FpPoly.X p base, Nat.mul_comm base p]
 
 private theorem composeCoeffPowerSumUpTo_X_coeff
     [ZMod64.PrimeModulus p] (coeff : Nat → ZMod64 p) :
@@ -940,8 +893,7 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
       rfl
   | n + 1, base, k => by
       simp only [composeCoeffPowerSumUpTo]
-      rw [DensePoly.coeff_add_semiring]
-      rw [composeCoeffPowerSumUpTo_X_coeff coeff n (base + 1) k]
+      rw [DensePoly.coeff_add_semiring, composeCoeffPowerSumUpTo_X_coeff coeff n (base + 1) k]
       rw [show FpPoly.linearPow (FpPoly.X : FpPoly p) base
               = DensePoly.monomial base (1 : ZMod64 p) from
               FpPoly.linearPow_monomial_one base]
@@ -954,8 +906,7 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
       have hzz : (Zero.zero : ZMod64 p) = (0 : ZMod64 p) := rfl
       have hmul_zero : coeff base * (Zero.zero : ZMod64 p) = Zero.zero := by
         rw [hzz]; grind
-      rw [DensePoly.coeff_scale _ _ _ hmul_zero]
-      rw [DensePoly.coeff_monomial]
+      rw [DensePoly.coeff_scale _ _ _ hmul_zero, DensePoly.coeff_monomial]
       have hzz_add : (Zero.zero : ZMod64 p) + Zero.zero = Zero.zero := by
         grind
       by_cases hk_base : k = base
@@ -983,8 +934,7 @@ private theorem composeCoeffPowerSumUpTo_X_coeff
             rw [if_neg (fun ⟨_, h⟩ => hcond h)]
             exact hzz_add
         · have hk1 : ¬ (base + 1 ≤ k) := by omega
-          rw [if_neg (fun ⟨h, _⟩ => hk1 h)]
-          rw [if_neg (fun ⟨h, _⟩ => hkb h)]
+          rw [if_neg (fun ⟨h, _⟩ => hk1 h), if_neg (fun ⟨h, _⟩ => hkb h)]
           exact hzz_add
 
 private theorem composeCoeffPowerSumUpTo_self_X_eq_self
@@ -1006,9 +956,9 @@ through the polynomial composition surface: viewed as
 theorem compose_w_linearPow_X [ZMod64.PrimeModulus p] (w : FpPoly p) :
     DensePoly.compose w (FpPoly.linearPow FpPoly.X p) =
       FpPoly.linearPow w p := by
-  rw [compose_eq_coeff_power_sum_upTo_size w (FpPoly.linearPow FpPoly.X p)]
-  rw [composeCoeffPowerSumUpTo_subst_linearPow_X (fun i => w.coeff i) w.size 0]
-  rw [composeCoeffPowerSumUpTo_self_X_eq_self w]
+  rw [compose_eq_coeff_power_sum_upTo_size w (FpPoly.linearPow FpPoly.X p),
+    composeCoeffPowerSumUpTo_subst_linearPow_X (fun i => w.coeff i) w.size 0,
+    composeCoeffPowerSumUpTo_self_X_eq_self w]
 
 end FpPoly
 end Hex

--- a/HexPolyFp/Frobenius.lean
+++ b/HexPolyFp/Frobenius.lean
@@ -209,9 +209,8 @@ private theorem mod_powLinear_mod_eq
   | succ n ih =>
       show (powLinear (base % f) n * (base % f)) % f =
         (powLinear base n * base) % f
-      rw [DensePoly.DivModLaws.mod_mul_mod (powLinear (base % f) n) (base % f) f]
-      rw [ih, DensePoly.mod_mod base f]
-      rw [← DensePoly.DivModLaws.mod_mul_mod (powLinear base n) base f]
+      rw [DensePoly.DivModLaws.mod_mul_mod (powLinear (base % f) n) (base % f) f,
+        ih, DensePoly.mod_mod base f, ← DensePoly.DivModLaws.mod_mul_mod (powLinear base n) base f]
 
 private theorem linearPow_eq_powLinear (f : FpPoly p) (n : Nat) :
     FpPoly.linearPow f n = powLinear f n := by
@@ -257,10 +256,9 @@ private theorem powModMonicLinear_mod_eq
       rw [show modByMonic f (powModMonicLinear base f hmonic n * base) hmonic =
             (powModMonicLinear base f hmonic n * base) % f from
           DensePoly.modByMonic_eq_mod _ _ hmonic]
-      rw [DensePoly.mod_mod]
-      rw [DensePoly.DivModLaws.mod_mul_mod (powModMonicLinear base f hmonic n) base f]
-      rw [ih]
-      rw [← DensePoly.DivModLaws.mod_mul_mod (powLinear base n) base f]
+      rw [DensePoly.mod_mod,
+        DensePoly.DivModLaws.mod_mul_mod (powModMonicLinear base f hmonic n) base f, ih,
+        ← DensePoly.DivModLaws.mod_mul_mod (powLinear base n) base f]
 
 /-- Positive structural powers are already reduced modulo the monic modulus. -/
 private theorem powModMonicLinear_pos_self_mod
@@ -296,8 +294,7 @@ private theorem powModMonicAux_mod_eq
     | succ m =>
         have hlt : (m + 1) / 2 < m + 1 :=
           Nat.div_lt_self (Nat.succ_pos m) (by decide)
-        rw [powModMonicAux_succ_eq]
-        rw [ih ((m + 1) / 2) hlt]
+        rw [powModMonicAux_succ_eq, ih ((m + 1) / 2) hlt]
         rw [show modByMonic f (base * base) hmonic = (base * base) % f from
               DensePoly.modByMonic_eq_mod _ _ hmonic]
         rcases Nat.mod_two_eq_zero_or_one (m + 1) with hmod | hmod

--- a/HexPolyFp/ModCompose.lean
+++ b/HexPolyFp/ModCompose.lean
@@ -27,11 +27,10 @@ private theorem mod_horner_step_eq
     [ZMod64.PrimeModulus p]
     (acc g modulus : FpPoly p) (c : ZMod64 p) :
     ((acc % modulus) * g + C c) % modulus = (acc * g + C c) % modulus := by
-  rw [DensePoly.DivModLaws.mod_add_mod ((acc % modulus) * g) (C c) modulus]
-  rw [DensePoly.DivModLaws.mod_add_mod (acc * g) (C c) modulus]
-  rw [DensePoly.DivModLaws.mod_mul_mod (acc % modulus) g modulus]
-  rw [DensePoly.DivModLaws.mod_mul_mod acc g modulus]
-  rw [DensePoly.mod_mod]
+  rw [DensePoly.DivModLaws.mod_add_mod ((acc % modulus) * g) (C c) modulus,
+    DensePoly.DivModLaws.mod_add_mod (acc * g) (C c) modulus,
+    DensePoly.DivModLaws.mod_mul_mod (acc % modulus) g modulus,
+    DensePoly.DivModLaws.mod_mul_mod acc g modulus, DensePoly.mod_mod]
 
 private theorem modByMonic_horner_step_eq
     [ZMod64.PrimeModulus p]

--- a/HexPolyFp/PrimeField.lean
+++ b/HexPolyFp/PrimeField.lean
@@ -86,9 +86,7 @@ theorem inv_inv_of_prime
       rw [Lean.Grind.CommSemiring.mul_comm]
       exact ZMod64.inv_mul_eq_one_of_prime hp ha
     have hprod : (((a⁻¹)⁻¹ - a) * a⁻¹) = (0 : ZMod64 p) := by
-      rw [Lean.Grind.Ring.sub_eq_add_neg]
-      rw [Lean.Grind.Semiring.right_distrib]
-      rw [hleft]
+      rw [Lean.Grind.Ring.sub_eq_add_neg, Lean.Grind.Semiring.right_distrib, hleft]
       grind
     rcases ZMod64.eq_zero_or_eq_zero_of_mul_eq_zero hp hprod with hdiff | hzero
     · grind

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -719,11 +719,8 @@ theorem add_comm (a b : Quotient g hmonic hg_pos) :
 
 private theorem add_pair_swap_quot (a b c d : Quotient g hmonic hg_pos) :
     (a + b) + (c + d) = (a + c) + (b + d) := by
-  rw [add_assoc a b (c + d)]
-  rw [← add_assoc b c d]
-  rw [add_comm b c]
-  rw [add_assoc c b d]
-  rw [← add_assoc a c (b + d)]
+  rw [add_assoc a b (c + d), ← add_assoc b c d, add_comm b c, add_assoc c b d,
+    ← add_assoc a c (b + d)]
 
 /-- Adding a quotient element to its left additive inverse gives zero. -/
 @[simp, grind =] theorem add_left_neg (a : Quotient g hmonic hg_pos) :
@@ -1496,8 +1493,7 @@ private theorem foldl_eval_replicate_zero (β : Quotient g hmonic hg_pos) :
       simp
   | n + 1, acc => by
       simp only [List.replicate_succ, List.foldl_cons]
-      rw [reduce_C_zero, add_zero]
-      rw [foldl_eval_replicate_zero β n (acc * β)]
+      rw [reduce_C_zero, add_zero, foldl_eval_replicate_zero β n (acc * β)]
       calc
         (acc * β) * β ^ n = acc * (β * β ^ n) := by rw [mul_assoc]
         _ = acc * (β ^ n * β) := by rw [mul_comm β (β ^ n)]
@@ -1535,8 +1531,7 @@ private theorem mul_evalCoeffPowerSumFrom_eq_succ
       simp [evalCoeffPowerSumFrom]
   | coeff :: coeffs, base => by
       simp only [evalCoeffPowerSumFrom]
-      rw [left_distrib]
-      rw [mul_evalCoeffPowerSumFrom_eq_succ β coeffs (base + 1)]
+      rw [left_distrib, mul_evalCoeffPowerSumFrom_eq_succ β coeffs (base + 1)]
       congr 1
       calc
         β *
@@ -1782,8 +1777,7 @@ private theorem toArray_toList_eq_coeff_range (f : FpPoly p) :
   · intro i hi
     have hi_size : i < f.size := by
       simpa [DensePoly.toArray, DensePoly.size] using hi
-    rw [eval_coeff_list_getD_eq_coeff]
-    rw [list_getD_map_range_zmod]
+    rw [eval_coeff_list_getD_eq_coeff, list_getD_map_range_zmod]
     simp [hi_size]
 
 /-- Power-sum evaluation of a coefficient function over a finite interval. -/
@@ -1822,8 +1816,7 @@ private theorem eval_eq_coeff_power_sum_upTo_size (f : FpPoly p)
       evalCoeffPowerSumUpTo
         (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (fun i => f.coeff i) f.size 0 β := by
-  rw [eval_eq_coeff_power_sum]
-  rw [toArray_toList_eq_coeff_range]
+  rw [eval_eq_coeff_power_sum, toArray_toList_eq_coeff_range]
   simpa using evalCoeffPowerSumFrom_range_eq_upTo
     (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
     (fun i => f.coeff i) β f.size 0
@@ -1840,9 +1833,8 @@ private theorem evalCoeffPowerSumUpTo_extend_zero
       simp [evalCoeffPowerSumUpTo]
   | extra + 1, base, hbase => by
       simp only [evalCoeffPowerSumUpTo]
-      rw [hzero base hbase, reduce_C_zero, zero_mul]
-      rw [evalCoeffPowerSumUpTo_extend_zero coeff β hzero extra (base + 1) (by omega)]
-      rw [zero_add]
+      rw [hzero base hbase, reduce_C_zero, zero_mul,
+        evalCoeffPowerSumUpTo_extend_zero coeff β hzero extra (base + 1) (by omega), zero_add]
 
 private theorem evalCoeffPowerSumUpTo_succ_of_next_zero
     (coeff : Nat → ZMod64 p) (β : Quotient g hmonic hg_pos) :
@@ -1879,8 +1871,7 @@ private theorem evalCoeffPowerSumUpTo_le_extend_base
   | 0 => by
       simp
   | extra + 1 => by
-      rw [evalCoeffPowerSumUpTo_le_extend_base coeff β hzero extra]
-      rw [Nat.add_succ]
+      rw [evalCoeffPowerSumUpTo_le_extend_base coeff β hzero extra, Nat.add_succ]
       exact evalCoeffPowerSumUpTo_succ_of_next_zero
         coeff β (bound + extra) base (hzero (base + (bound + extra)) (by omega))
 
@@ -2026,23 +2017,19 @@ private theorem evalCoeffPowerSumUpTo_add
       simp [evalCoeffPowerSumUpTo]
   | n + 1, base => by
       simp only [evalCoeffPowerSumUpTo]
-      rw [reduce_C_add]
-      rw [evalCoeffPowerSumUpTo_add f h β n (base + 1)]
-      rw [right_distrib]
+      rw [reduce_C_add, evalCoeffPowerSumUpTo_add f h β n (base + 1), right_distrib]
       exact add_pair_swap_quot _ _ _ _
 
 private theorem neg_add_quot (a b : Quotient g hmonic hg_pos) :
     -(a + b) = -a + -b := by
   have hzero : (a + b) + (-a + -b) = 0 := by
-    rw [add_pair_swap_quot a b (-a) (-b)]
-    rw [add_right_neg, add_right_neg, zero_add]
+    rw [add_pair_swap_quot a b (-a) (-b), add_right_neg, add_right_neg, zero_add]
   exact (eq_neg_of_add_eq_zero_right hzero).symm
 
 private theorem add_sub_pair_swap
     (a b c d : Quotient g hmonic hg_pos) :
     (a - b) + (c - d) = (a + c) - (b + d) := by
-  rw [sub_eq_add_neg a b, sub_eq_add_neg c d, sub_eq_add_neg (a + c) (b + d)]
-  rw [neg_add_quot]
+  rw [sub_eq_add_neg a b, sub_eq_add_neg c d, sub_eq_add_neg (a + c) (b + d), neg_add_quot]
   exact add_pair_swap_quot a (-b) c (-d)
 
 private theorem evalCoeffPowerSumUpTo_sub
@@ -2061,9 +2048,7 @@ private theorem evalCoeffPowerSumUpTo_sub
       simp [evalCoeffPowerSumUpTo, sub_self]
   | n + 1, base => by
       simp only [evalCoeffPowerSumUpTo]
-      rw [reduce_C_sub]
-      rw [evalCoeffPowerSumUpTo_sub f h β n (base + 1)]
-      rw [sub_mul]
+      rw [reduce_C_sub, evalCoeffPowerSumUpTo_sub f h β n (base + 1), sub_mul]
       exact add_sub_pair_swap _ _ _ _
 
 private theorem evalCoeffPowerSumUpTo_const_mul
@@ -2081,9 +2066,7 @@ private theorem evalCoeffPowerSumUpTo_const_mul
       simp [evalCoeffPowerSumUpTo, mul_zero]
   | n + 1, base => by
       simp only [evalCoeffPowerSumUpTo]
-      rw [reduce_C_mul]
-      rw [evalCoeffPowerSumUpTo_const_mul c f β n (base + 1)]
-      rw [left_distrib]
+      rw [reduce_C_mul, evalCoeffPowerSumUpTo_const_mul c f β n (base + 1), left_distrib]
       congr 1
       rw [mul_assoc]
 
@@ -2252,9 +2235,7 @@ private theorem eval_monomial_core (n : Nat) (c : ZMod64 p)
           (DensePoly.C (0 : ZMod64 p)) *
         β ^ n
     unfold DensePoly.monomial
-    rw [dif_pos (show (0 : ZMod64 p) = Zero.zero from rfl)]
-    rw [eval_zero, reduce_C_zero]
-    rw [zero_mul]
+    rw [dif_pos (show (0 : ZMod64 p) = Zero.zero from rfl), eval_zero, reduce_C_zero, zero_mul]
   · unfold eval DensePoly.toArray DensePoly.monomial
     have hc0 : ¬ c = (Zero.zero : ZMod64 p) := hc
     rw [dif_neg hc0]
@@ -2655,8 +2636,7 @@ private theorem evalQuotientCoeffs_topNonzero_of_ne_zero
     reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C topCoeff)
   refine ⟨topQuot, ?_, ?_⟩
   · unfold evalQuotientCoeffs topQuot topCoeff DensePoly.toArray DensePoly.coeff
-    rw [List.getLast?_map, List.getLast?_eq_getElem?]
-    rw [Array.getElem?_toList]
+    rw [List.getLast?_map, List.getLast?_eq_getElem?, Array.getElem?_toList]
     rw [Array.getElem?_eq_getElem
       (by simpa [DensePoly.size] using Nat.sub_one_lt_of_lt hsize_pos)]
     rw [Array.getElem_eq_getD (Zero.zero : ZMod64 p)]

--- a/HexPolyFp/QuotientFrobenius.lean
+++ b/HexPolyFp/QuotientFrobenius.lean
@@ -87,9 +87,8 @@ theorem add_pow_prime (a b : Quotient g hmonic hg_pos) :
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (FpPoly.linearPow (a.val + b.val) p) from
     (reduce_linearPow_eq_pow (a.val + b.val) p).symm]
-  rw [FpPoly.linearPow_add_prime hp]
-  rw [reduce_add]
-  rw [pow_eq_reduce_linearPow a, pow_eq_reduce_linearPow b]
+  rw [FpPoly.linearPow_add_prime hp, reduce_add,
+    pow_eq_reduce_linearPow a, pow_eq_reduce_linearPow b]
 
 omit [ZMod64.PrimeModulus p] in
 private theorem zmod64_pow_succ (c : ZMod64 p) (n : Nat) :
@@ -99,9 +98,8 @@ private theorem zmod64_pow_succ (c : ZMod64 p) (n : Nat) :
   show (c ^ (n + 1)).toNat = (c ^ n * c).toNat
   rw [show ((c ^ n * c) : ZMod64 p) = ZMod64.mul (c ^ n) c from rfl,
     ZMod64.toNat_mul]
-  rw [show (c ^ (n + 1) : ZMod64 p) = ZMod64.pow c (n + 1) from rfl]
-  rw [show (c ^ n : ZMod64 p) = ZMod64.pow c n from rfl]
-  rw [ZMod64.toNat_pow, ZMod64.toNat_pow]
+  rw [show (c ^ (n + 1) : ZMod64 p) = ZMod64.pow c (n + 1) from rfl,
+    show (c ^ n : ZMod64 p) = ZMod64.pow c n from rfl, ZMod64.toNat_pow, ZMod64.toNat_pow]
   have hc_lt : c.toNat < p := c.toNat_lt
   have hcm : c.toNat % p = c.toNat := Nat.mod_eq_of_lt hc_lt
   rw [Nat.pow_succ, Nat.mul_mod, hcm]
@@ -144,9 +142,8 @@ private theorem zmod64_pow_zero (c : ZMod64 p) :
   apply ZMod64.ext
   apply UInt64.toNat_inj.mp
   show (c ^ (0 : Nat) : ZMod64 p).toNat = (1 : ZMod64 p).toNat
-  rw [show ((c ^ (0 : Nat)) : ZMod64 p) = ZMod64.pow c 0 from rfl]
-  rw [ZMod64.toNat_pow]
-  rw [show ((1 : ZMod64 p) : ZMod64 p) = ZMod64.one from rfl, ZMod64.toNat_one]
+  rw [show ((c ^ (0 : Nat)) : ZMod64 p) = ZMod64.pow c 0 from rfl, ZMod64.toNat_pow,
+    show ((1 : ZMod64 p) : ZMod64 p) = ZMod64.one from rfl, ZMod64.toNat_one]
   simp
 
 omit [ZMod64.PrimeModulus p] in
@@ -171,8 +168,7 @@ theorem linearPow_C_pow_prime (c : ZMod64 p) :
 theorem reduce_C_pow_prime_eq (c : ZMod64 p) :
     (reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c)) ^ p =
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C c) := by
-  rw [← reduce_linearPow_eq_pow]
-  rw [linearPow_C_pow_prime]
+  rw [← reduce_linearPow_eq_pow, linearPow_C_pow_prime]
 
 /-- Constants are fixed by every iterate of the Frobenius on the quotient. -/
 theorem reduce_C_pow_pPow_eq (c : ZMod64 p) (k : Nat) :
@@ -263,8 +259,7 @@ theorem reduce_monomial_eq (m : Nat) (c : ZMod64 p) :
   rw [show (DensePoly.C c * DensePoly.monomial m (1 : ZMod64 p)
     : FpPoly p) = DensePoly.scale c (DensePoly.monomial m (1 : ZMod64 p))
     from FpPoly.C_mul_eq_scale c _]
-  rw [DensePoly.coeff_scale c _ k hzero]
-  rw [DensePoly.coeff_monomial m (1 : ZMod64 p) k]
+  rw [DensePoly.coeff_scale c _ k hzero, DensePoly.coeff_monomial m (1 : ZMod64 p) k]
   by_cases hk : k = m
   · simp only [hk, if_true]
     show c = c * (1 : ZMod64 p)
@@ -298,9 +293,7 @@ private theorem coeff_fpPolyMonoSum (f : FpPoly p) (m k : Nat) :
   | succ m ih =>
       show (fpPolyMonoSum f m + DensePoly.monomial m (f.coeff m)).coeff k =
         if k < m + 1 then f.coeff k else 0
-      rw [DensePoly.coeff_add_semiring]
-      rw [ih]
-      rw [DensePoly.coeff_monomial m (f.coeff m) k]
+      rw [DensePoly.coeff_add_semiring, ih, DensePoly.coeff_monomial m (f.coeff m) k]
       by_cases hk_lt_m : k < m
       · have hk_lt_succ : k < m + 1 := Nat.lt_succ_of_lt hk_lt_m
         have hk_ne_m : k ≠ m := Nat.ne_of_lt hk_lt_m
@@ -375,13 +368,9 @@ private theorem quotMonoSum_pow_pPow_eq_self
         quotMonoSum f g hmonic hg_pos m +
           reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
             (DensePoly.monomial m (f.coeff m))
-      rw [add_pow_pPow]
-      rw [ih]
+      rw [add_pow_pPow, ih]
       congr 1
-      rw [reduce_monomial_eq]
-      rw [mul_pow]
-      rw [reduce_C_pow_pPow_eq]
-      rw [X_pow_pPowN hp_pos hX m]
+      rw [reduce_monomial_eq, mul_pow, reduce_C_pow_pPow_eq, X_pow_pPowN hp_pos hX m]
 
 /-- **Capstone:** if the Frobenius iterate `β ↦ β ^ (p ^ n)` fixes
 `Quotient.X`, it fixes every quotient element.
@@ -398,8 +387,7 @@ theorem pow_pPowN_eq_self_of_pow_pPowN_X_eq_X
   -- Reduce β to its canonical representative.
   have hβ : β = reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β.val :=
     (reduce_val_self β).symm
-  rw [hβ]
-  rw [reduce_eq_quotMonoSum]
+  rw [hβ, reduce_eq_quotMonoSum]
   exact quotMonoSum_pow_pPow_eq_self hX β.val β.val.size
 
 end Quotient

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -270,10 +270,8 @@ private theorem scale_add_scalar (c d : ZMod64 p) (f : FpPoly p) :
   have hzero_cd : (c + d) * (0 : ZMod64 p) = 0 := by grind
   have hzero_c : c * (0 : ZMod64 p) = 0 := by grind
   have hzero_d : d * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero_cd]
-  rw [DensePoly.coeff_add_semiring]
-  rw [DensePoly.coeff_scale _ _ _ hzero_c]
-  rw [DensePoly.coeff_scale _ _ _ hzero_d]
+  rw [DensePoly.coeff_scale _ _ _ hzero_cd, DensePoly.coeff_add_semiring,
+    DensePoly.coeff_scale _ _ _ hzero_c, DensePoly.coeff_scale _ _ _ hzero_d]
   grind
 
 /-- Scalar scaling commutes through the right factor of a product. -/
@@ -308,8 +306,7 @@ private theorem powLinearBinom_scalar_zero (h : FpPoly p) :
   apply DensePoly.ext_coeff
   intro n
   have hzero : (0 : ZMod64 p) * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_zero]
   grind
 
 /-- Scaling by `1` is the identity. -/
@@ -369,8 +366,7 @@ private theorem powLinearBinomTerm_succ_zero (f g : FpPoly p) (n : Nat) :
   simp [Hex.Nat.choose]
   change DensePoly.scale (1 : ZMod64 p) (powLinear f (n + 1) * powLinear g 0) =
     f * DensePoly.scale (1 : ZMod64 p) (powLinear f n * powLinear g 0)
-  rw [powLinearBinom_scalar_one]
-  rw [powLinearBinom_scalar_one]
+  rw [powLinearBinom_scalar_one, powLinearBinom_scalar_one]
   have hg0 : powLinear g 0 = 1 := rfl
   rw [hg0]
   calc
@@ -388,8 +384,7 @@ private theorem powLinearBinomTerm_succ_succ_of_lt
       f * powLinearBinomTerm f g n (k + 1) +
         g * powLinearBinomTerm f g n k := by
   unfold powLinearBinomTerm
-  rw [Hex.Nat.choose_succ_succ]
-  rw [powLinearBinom_scalar_add]
+  rw [Hex.Nat.choose_succ_succ, powLinearBinom_scalar_add]
   have hsub : n + 1 - (k + 1) = n - k := by omega
   rw [hsub]
   have hf :
@@ -405,9 +400,7 @@ private theorem powLinearBinomTerm_succ_succ_of_lt
         powLinear f (n - k) * powLinear g (k + 1) := by
     exact congrArg (fun x => powLinear f (n - k) * x)
       (powLinear_succ_left g k).symm
-  rw [mul_powLinearBinom_scaled_left]
-  rw [mul_powLinearBinom_scaled_right]
-  rw [hf, hg]
+  rw [mul_powLinearBinom_scaled_left, mul_powLinearBinom_scaled_right, hf, hg]
   exact DensePoly.add_comm_poly _ _
 
 /-- The diagonal (`k = n`) case of Pascal's rule for binomial terms. -/
@@ -420,8 +413,7 @@ private theorem powLinearBinomTerm_succ_succ_top
   rw [Hex.Nat.choose_succ_succ]
   have hzero_choose : Hex.Nat.choose n (n + 1) = 0 :=
     Hex.Nat.choose_eq_zero_of_lt (by omega)
-  rw [hzero_choose]
-  rw [Hex.Nat.choose_self]
+  rw [hzero_choose, Hex.Nat.choose_self]
   have hcast : (((1 + 0 : Nat) : ZMod64 p)) = (1 : ZMod64 p) := by grind
   rw [hcast]
   have hsub_left : n + 1 - (n + 1) = 0 := by omega
@@ -431,15 +423,12 @@ private theorem powLinearBinomTerm_succ_succ_top
   change DensePoly.scale (1 : ZMod64 p) (powLinear f 0 * powLinear g (n + 1)) =
     f * DensePoly.scale (0 : ZMod64 p) (powLinear f 0 * powLinear g (n + 1)) +
       g * DensePoly.scale (1 : ZMod64 p) (powLinear f 0 * powLinear g n)
-  rw [powLinearBinom_scalar_one]
-  rw [powLinearBinom_scalar_zero]
-  rw [powLinearBinom_mul_zero]
+  rw [powLinearBinom_scalar_one, powLinearBinom_scalar_zero, powLinearBinom_mul_zero]
   have hzadd : (0 : FpPoly p) +
       g * DensePoly.scale (1 : ZMod64 p) (powLinear f 0 * powLinear g n) =
         g * DensePoly.scale (1 : ZMod64 p) (powLinear f 0 * powLinear g n) :=
     DensePoly.zero_add _
-  rw [hzadd]
-  rw [powLinearBinom_scalar_one]
+  rw [hzadd, powLinearBinom_scalar_one]
   have hf0 : powLinear f 0 = 1 := rfl
   rw [hf0]
   calc
@@ -471,10 +460,8 @@ private theorem powLinearBinomSum_succ_row
   | zero =>
       simp [powLinearBinomSum, powLinearBinomTerm_succ_zero]
   | succ m ih =>
-      rw [powLinearBinomSum, ih (by omega)]
-      rw [powLinearBinomSum]
-      rw [powLinearBinomSum]
-      rw [powLinearBinomTerm_succ_succ f g (by omega : m ≤ n)]
+      rw [powLinearBinomSum, ih (by omega), powLinearBinomSum, powLinearBinomSum,
+        powLinearBinomTerm_succ_succ f g (by omega : m ≤ n)]
       have hdistL :
           f * (powLinearBinomSum f g n m + powLinearBinomTerm f g n m) =
             f * powLinearBinomSum f g n m + f * powLinearBinomTerm f g n m :=
@@ -496,8 +483,7 @@ private theorem powLinearBinomSum_succ_row
       have hsum :
           powLinearBinomSum f g n (m + 1) =
             powLinearBinomSum f g n m + powLinearBinomTerm f g n m := rfl
-      rw [hsum]
-      rw [← hdistL]
+      rw [hsum, ← hdistL]
       apply DensePoly.ext_coeff
       intro i
       repeat rw [DensePoly.coeff_add_semiring]
@@ -516,8 +502,7 @@ private theorem powLinearBinomSum_top_succ
     (f g : FpPoly p) (n : Nat) :
     powLinearBinomSum f g n (n + 1 + 1) =
       powLinearBinomSum f g n (n + 1) := by
-  rw [powLinearBinomSum]
-  rw [powLinearBinomTerm_above f g (by omega : n < n + 1)]
+  rw [powLinearBinomSum, powLinearBinomTerm_above f g (by omega : n < n + 1)]
   exact DensePoly.add_zero_poly _
 
 /-- The binomial theorem: `(f + g)^n` equals its full binomial sum over the first `n + 1` terms. -/
@@ -529,9 +514,8 @@ private theorem powLinear_add_binom_sum
       simp [powLinear, powLinearBinomSum, powLinearBinomTerm, Hex.Nat.choose]
       exact (powLinearBinom_scalar_one (1 : FpPoly p)).symm
   | succ n ih =>
-      rw [powLinear_succ_left, ih]
-      rw [powLinearBinomSum_succ_row f g n (n + 1) (by omega)]
-      rw [powLinearBinomSum_top_succ f g n]
+      rw [powLinear_succ_left, ih, powLinearBinomSum_succ_row f g n (n + 1) (by omega),
+        powLinearBinomSum_top_succ f g n]
       exact DensePoly.mul_add_left_poly f g (powLinearBinomSum f g n (n + 1))
 
 /-- The zeroth term of the degree-`p` binomial expansion is `f^p`. -/
@@ -573,8 +557,8 @@ private theorem powLinearBinomSum_prime_middle
       rw [powLinearBinomSum, powLinearBinomTerm_prime_zero]
       exact DensePoly.zero_add _
   | succ m ih =>
-      rw [powLinearBinomSum, ih (by omega)]
-      rw [powLinearBinomTerm_prime_middle hp f g (by omega : 0 < m + 1) (by omega)]
+      rw [powLinearBinomSum, ih (by omega),
+        powLinearBinomTerm_prime_middle hp f g (by omega : 0 < m + 1) (by omega)]
       exact DensePoly.add_zero_poly _
 
 /-- The freshman's-dream identity `(f + g)^p = f^p + g^p` for prime `p`. -/
@@ -583,8 +567,7 @@ private theorem powLinear_add_prime
     powLinear (f + g) p = powLinear f p + powLinear g p := by
   have hp_two : 2 ≤ p := Hex.Nat.Prime.two_le hp
   have hp_pos : 0 < p := by omega
-  rw [powLinear_add_binom_sum]
-  rw [powLinearBinomSum]
+  rw [powLinear_add_binom_sum, powLinearBinomSum]
   have hmid : powLinearBinomSum f g p p = powLinear f p := by
     have hmid0 :
         powLinearBinomSum f g p ((p - 1) + 1) = powLinear f p :=
@@ -614,8 +597,8 @@ private theorem weightedProduct_foldl_eq_mul
   | cons sf factors ih =>
       unfold weightedProduct
       simp only [List.foldl_cons]
-      rw [ih (acc * pow sf.factor sf.multiplicity)]
-      rw [ih ((1 : FpPoly p) * pow sf.factor sf.multiplicity)]
+      rw [ih (acc * pow sf.factor sf.multiplicity),
+        ih ((1 : FpPoly p) * pow sf.factor sf.multiplicity)]
       have hone :
           (1 : FpPoly p) * pow sf.factor sf.multiplicity =
             pow sf.factor sf.multiplicity := by
@@ -805,19 +788,14 @@ private theorem coeffFold_coeff (g : FpPoly p) (m n : Nat) :
       by_cases hlt : n < m
       · rw [if_pos hlt]
         have hne : n ≠ m := by omega
-        rw [if_neg hne]
-        rw [if_pos (by omega : n < m + 1)]
+        rw [if_neg hne, if_pos (by omega : n < m + 1)]
         exact zmod64_add_zero_coeff (g.coeff n)
       · by_cases heq : n = m
         · rw [if_neg hlt]
-          rw [if_pos heq]
-          rw [if_pos (by omega : n < m + 1)]
-          rw [heq]
+          rw [if_pos heq, if_pos (by omega : n < m + 1), heq]
           exact zmod64_zero_add_coeff (g.coeff m)
         · have hsucc : ¬n < m + 1 := by omega
-          rw [if_neg hlt]
-          rw [if_neg heq]
-          rw [if_neg hsucc]
+          rw [if_neg hlt, if_neg heq, if_neg hsucc]
           exact zmod64_add_zero_zero_coeff
 
 /-- Any coefficient fold whose bound reaches `g.size` reconstructs `g`. -/
@@ -973,8 +951,7 @@ private theorem coeffFoldPowerCoeff_prime_coeff
           · have hnm : n = p * m := by rw [hn_eq, heq]
             rw [if_pos hnm]
             have hltsucc : n / p < m + 1 := by omega
-            rw [if_pos hltsucc]
-            rw [heq]
+            rw [if_pos hltsucc, heq]
             exact zmod64_zero_add_coeff (g.coeff m ^ p)
           · have hne : n ≠ p * m := by
               intro habs
@@ -1035,8 +1012,7 @@ private theorem powLinear_prime_coeff
             · rw [if_neg hsize]
               have hcoeff : g.coeff (n / p) = 0 :=
                 DensePoly.coeff_eq_zero_of_size_le g (by omega)
-              rw [hcoeff]
-              rw [if_pos hn]
+              rw [hcoeff, if_pos hn]
               exact (ZMod64.pow_prime hp (0 : ZMod64 p)).symm
           · rw [if_neg hn]
             rw [if_neg hn]
@@ -1209,8 +1185,7 @@ private theorem eq_zero_of_isZero_true
 private theorem normalizeMonic_zero_reconstruct
     (f : FpPoly p) (hzero : f.isZero = true) :
     DensePoly.C (normalizeMonic f).1 * (normalizeMonic f).2 = f := by
-  rw [normalizeMonic_zero f hzero]
-  rw [eq_zero_of_isZero_true f hzero]
+  rw [normalizeMonic_zero f hzero, eq_zero_of_isZero_true f hzero]
   exact mul_zero (DensePoly.C (0 : ZMod64 p))
 
 /-- On a nonzero `f`, `normalizeMonic f` is the pair of its leading coefficient and
@@ -1226,8 +1201,7 @@ over a prime modulus. -/
 private theorem normalizeMonic_nonzero_reconstruct
     (hp : Hex.Nat.Prime p) (f : FpPoly p) (hzero : f.isZero = false) :
     DensePoly.C (normalizeMonic f).1 * (normalizeMonic f).2 = f := by
-  rw [normalizeMonic_nonzero f hzero]
-  rw [C_mul_eq_scale, scale_scale]
+  rw [normalizeMonic_nonzero f hzero, C_mul_eq_scale, scale_scale]
   have hlead_ne := fpPoly_leadingCoeff_ne_zero_of_isZero_false f hzero
   rw [zmod64_mul_inv_eq_one_of_prime_ne_zero hp hlead_ne]
   exact scale_one_left f
@@ -2318,8 +2292,7 @@ private theorem squareFreeAuxRevContribution_one
         simp [hsize, DensePoly.isZero, DensePoly.ofCoeffs, DensePoly.trimTrailingZeros]
         rfl
       simp [hone_ne]
-      rw [hdf_one]
-      rw [pthRoot_one hp]
+      rw [hdf_one, pthRoot_one hp]
       exact ih (multiplicity * p)
 
 /-- A polynomial of `size` one is constant, so its derivative is zero. -/
@@ -3054,8 +3027,7 @@ private theorem quotient_common_dvd_mul_derivative_base
     have hfirst_eq :
         DensePoly.derivative c - d * DensePoly.derivative q =
           DensePoly.derivative d * q := by
-      rw [hderiv]
-      rw [sub_eq_add_neg]
+      rw [hderiv, sub_eq_add_neg]
       calc
         (DensePoly.derivative d * q + d * DensePoly.derivative q) +
             -(d * DensePoly.derivative q)
@@ -3226,8 +3198,7 @@ private theorem derivativeSplit_quotient_pow_succ_dvd_gcd
       rcases hpow with ⟨q, hq⟩
       have hg_eq : g = pow d (k + 1) * q := by simpa [g] using hq
       have hsucc_dvd_f : pow d (k + 2) ∣ f := by
-        rw [← hprod]
-        rw [ha, hg_eq]
+        rw [← hprod, ha, hg_eq]
         refine ⟨a * q, ?_⟩
         calc
           (d * a) * (pow d (k + 1) * q)
@@ -4356,8 +4327,8 @@ private theorem derivativeSplit_quotient_size_one_eq_one
           DensePoly.derivative c * g + c * DensePoly.derivative g := by
             exact DensePoly.derivative_mul c g
       _ = 0 * g + c * 0 := by
-            rw [eq_zero_of_isZero_true (DensePoly.derivative c) hc_der]
-            rw [eq_zero_of_isZero_true (DensePoly.derivative g) hg_der]
+            rw [eq_zero_of_isZero_true (DensePoly.derivative c) hc_der,
+              eq_zero_of_isZero_true (DensePoly.derivative g) hg_der]
       _ = 0 := by simp
   exfalso
   apply hdf
@@ -5262,8 +5233,8 @@ private theorem constant_nonzero_dvd
         rw [hg_coeff_zero]
         exact (DensePoly.coeff_C unit (n + 1)).symm
   refine ⟨DensePoly.scale unit⁻¹ f, ?_⟩
-  rw [hg_eq_C, C_mul_eq_scale, scale_scale]
-  rw [zmod64_mul_inv_eq_one_of_prime_ne_zero (ZMod64.PrimeModulus.prime (p := p)) hunit_ne]
+  rw [hg_eq_C, C_mul_eq_scale, scale_scale,
+    zmod64_mul_inv_eq_one_of_prime_ne_zero (ZMod64.PrimeModulus.prime (p := p)) hunit_ne]
   exact (scale_one_left f).symm
 
 private theorem yunStep_gcd_nonzero_of_left_nonzero

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -55,8 +55,7 @@ of `ofPolynomial p` agrees with the `n`th coefficient of `p`. -/
 theorem coeff_ofPolynomial [Semiring R] [DecidableEq R] (p : Polynomial R) (n : Nat) :
     (ofPolynomial p).coeff n = p.coeff n := by
   unfold ofPolynomial
-  rw [Hex.DensePoly.coeff_ofCoeffs_list]
-  rw [list_getD_map_range_zero]
+  rw [Hex.DensePoly.coeff_ofCoeffs_list, list_getD_map_range_zero]
   by_cases hn : n < p.natDegree + 1
   · simp [hn]
   · have hlt : p.natDegree < n := by omega
@@ -404,8 +403,8 @@ theorem toPolynomial_mul [Semiring R] [DecidableEq R] (p q : Hex.DensePoly R) :
   ext n
   rw [coeff_toPolynomial, Polynomial.coeff_mul]
   simp_rw [coeff_toPolynomial]
-  rw [Hex.DensePoly.coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound]
-  rw [range_foldl_add_eq_finset_sum]
+  rw [Hex.DensePoly.coeff_mul, mulCoeffSum_eq_diagonal, diagonalSum_eq_degree_bound,
+    range_foldl_add_eq_finset_sum]
   rw [show
       (∑ x ∈ Finset.antidiagonal n, p.coeff x.1 * q.coeff x.2) =
         ∑ i ∈ Finset.range (n + 1), p.coeff i * q.coeff (n - i) from
@@ -525,8 +524,8 @@ theorem leadingCoeff_toPolynomial [Semiring R] [DecidableEq R]
     have hidx : p.coeffs.size - 1 < p.coeffs.size := by
       have hs : p.size = p.coeffs.size := rfl
       omega
-    rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx, Option.getD_some]
-    rw [show p.size = p.coeffs.size from rfl]
+    rw [Array.back?_eq_getElem?, Array.getElem?_eq_getElem hidx, Option.getD_some,
+      show p.size = p.coeffs.size from rfl]
     exact (Array.getElem_eq_getD (Zero.zero : R)).symm
 
 /-- `toPolynomial` preserves divisibility: a divisibility in the executable

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -186,8 +186,7 @@ constant case. -/
     toRatPoly (DensePoly.C c) = DensePoly.C (c : Rat) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_toRatPoly]
-  rw [DensePoly.coeff_C, DensePoly.coeff_C]
+  rw [coeff_toRatPoly, DensePoly.coeff_C, DensePoly.coeff_C]
   by_cases hn : n = 0
   · simp [hn]
   · simp [hn]
@@ -208,8 +207,7 @@ theorem toRatPoly_scale_int (c : Int) (f : ZPoly) :
     toRatPoly (DensePoly.scale c f) = DensePoly.scale (c : Rat) (toRatPoly f) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [coeff_toRatPoly]
-  rw [DensePoly.coeff_scale (R := Int) c f n (Int.mul_zero c)]
+  rw [coeff_toRatPoly, DensePoly.coeff_scale (R := Int) c f n (Int.mul_zero c)]
   rw [DensePoly.coeff_scale (R := Rat) (c : Rat) (toRatPoly f) n (by
     exact Rat.mul_zero (c : Rat))]
   rw [coeff_toRatPoly]
@@ -309,8 +307,7 @@ private theorem toRatPoly_mulCoeffOuter_fold (f g : ZPoly) (n : Nat)
       rfl
   | cons i xs ih =>
       simp only [List.foldl_cons]
-      rw [size_toRatPoly g]
-      rw [toRatPoly_mulCoeffStep_fold]
+      rw [size_toRatPoly g, toRatPoly_mulCoeffStep_fold]
       simpa [size_toRatPoly g] using
         ih ((List.range g.size).foldl (DensePoly.mulCoeffStep (R := Int) f g n i) a)
 
@@ -515,8 +512,7 @@ private theorem rat_scale_toRatPoly_neg_int (u : Rat) (p : ZPoly) :
       DensePoly.scale (-u) (toRatPoly (DensePoly.scale (-1 : Int) p)) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Rat) u (toRatPoly p) n (Rat.mul_zero u)]
-  rw [toRatPoly_scale_int]
+  rw [DensePoly.coeff_scale (R := Rat) u (toRatPoly p) n (Rat.mul_zero u), toRatPoly_scale_int]
   change u * (toRatPoly p).coeff n =
     (DensePoly.scale (-u) (DensePoly.scale (-1 : Rat) (toRatPoly p))).coeff n
   rw [DensePoly.coeff_scale (R := Rat) (-u)
@@ -1031,9 +1027,8 @@ theorem leadingCoeff_mul_of_nonzero (p q : ZPoly)
   have hq_pos : 0 < q.size := size_pos_of_ne_zero q hq
   have hpq_size := mul_size_eq_top_succ_of_nonzero p q hp_pos hq_pos
   have hpq_pos : 0 < (p * q).size := by omega
-  rw [DensePoly.leadingCoeff_eq_coeff_last (p * q) hpq_pos]
-  rw [DensePoly.leadingCoeff_eq_coeff_last p hp_pos]
-  rw [DensePoly.leadingCoeff_eq_coeff_last q hq_pos]
+  rw [DensePoly.leadingCoeff_eq_coeff_last (p * q) hpq_pos,
+    DensePoly.leadingCoeff_eq_coeff_last p hp_pos, DensePoly.leadingCoeff_eq_coeff_last q hq_pos]
   have hlast : (p * q).size - 1 = p.size - 1 + (q.size - 1) := by omega
   rw [hlast]
   exact coeff_mul_top p q hp_pos hq_pos
@@ -1159,8 +1154,8 @@ theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
   by_cases hp : 0 < p.size
   · rw [DensePoly.leadingCoeff_eq_coeff_last (DensePoly.scale c p)]
     · rw [scale_size_of_nonzero c p hc]
-      rw [DensePoly.coeff_scale (R := Int) c p (p.size - 1) (Int.mul_zero c)]
-      rw [DensePoly.leadingCoeff_eq_coeff_last p hp]
+      rw [DensePoly.coeff_scale (R := Int) c p (p.size - 1) (Int.mul_zero c),
+        DensePoly.leadingCoeff_eq_coeff_last p hp]
     · rw [scale_size_of_nonzero c p hc]
       exact hp
   · have hpsize : p.size = 0 := by omega
@@ -1236,8 +1231,7 @@ theorem leadingCoeff_shift_of_nonzero (k : Nat) (p : ZPoly) (hp : p ≠ 0) :
     rw [DensePoly.coeff_shift]
     have hnot : ¬ k + p.size - 1 < k := by omega
     have hidx : k + p.size - 1 - k = p.size - 1 := by omega
-    rw [if_neg hnot, hidx]
-    rw [DensePoly.leadingCoeff_eq_coeff_last p hpos]
+    rw [if_neg hnot, hidx, DensePoly.leadingCoeff_eq_coeff_last p hpos]
   · rw [shift_size_of_nonzero_core k hp]
     omega
 
@@ -1271,8 +1265,8 @@ theorem mul_right_cancel_of_ne_zero {p q r : ZPoly}
   intro n
   have hzero_add : (0 : Int) + 0 = 0 := by omega
   have hzero_sub : (0 : Int) - 0 = 0 := by omega
-  rw [DensePoly.coeff_add (q * r) (0 - q * r) n hzero_add]
-  rw [DensePoly.coeff_sub 0 (q * r) n hzero_sub, DensePoly.coeff_zero]
+  rw [DensePoly.coeff_add (q * r) (0 - q * r) n hzero_add,
+    DensePoly.coeff_sub 0 (q * r) n hzero_sub, DensePoly.coeff_zero]
   omega
 
 /-- A nonzero divisor of a nonzero integer polynomial has no larger dense size. -/
@@ -1284,8 +1278,7 @@ theorem size_le_of_dvd_nonzero {d r : ZPoly}
   by_cases hk_zero : k = 0
   · apply False.elim
     apply hr
-    rw [hk, hk_zero]
-    rw [DensePoly.mul_comm_poly d (0 : ZPoly), DensePoly.zero_mul]
+    rw [hk, hk_zero, DensePoly.mul_comm_poly d (0 : ZPoly), DensePoly.zero_mul]
   · have hd_pos : 0 < d.size := by
       rcases Nat.lt_or_ge 0 d.size with h | h
       · exact h
@@ -1384,9 +1377,9 @@ theorem divMod_remainder_eq_zero_of_monic_mul_eq
       rw [DensePoly.coeff_mul] at hcoeff
       rw [DensePoly.sub_eq_add_neg_poly, DensePoly.mul_add_left_poly,
         DensePoly.neg_mul_right_poly]
-      rw [DensePoly.coeff_add (quotient * candidate) (0 - qr.1 * candidate) n hzero_add]
-      rw [DensePoly.coeff_sub 0 (qr.1 * candidate) n hzero_sub, DensePoly.coeff_zero]
-      rw [DensePoly.coeff_mul, DensePoly.coeff_mul]
+      rw [DensePoly.coeff_add (quotient * candidate) (0 - qr.1 * candidate) n hzero_add,
+        DensePoly.coeff_sub 0 (qr.1 * candidate) n hzero_sub, DensePoly.coeff_zero,
+        DensePoly.coeff_mul, DensePoly.coeff_mul]
       omega
     have hsize_le : candidate.size ≤ qr.2.size :=
       size_le_of_dvd_nonzero hcandidate_ne hrem_zero hrem_dvd
@@ -1709,8 +1702,7 @@ private theorem rat_scale_zero (p : DensePoly Rat) :
     DensePoly.scale 0 p = 0 := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Rat) 0 p n (Rat.mul_zero 0)]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_scale (R := Rat) 0 p n (Rat.mul_zero 0), DensePoly.coeff_zero]
   exact Rat.zero_mul (p.coeff n)
 
 /-- Scaling the zero rational dense polynomial by any unit `u` yields the zero polynomial. -/
@@ -1718,8 +1710,8 @@ private theorem rat_scale_zero_right (u : Rat) :
     DensePoly.scale u (0 : DensePoly Rat) = 0 := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Rat) u (0 : DensePoly Rat) n (Rat.mul_zero u)]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_scale (R := Rat) u (0 : DensePoly Rat) n (Rat.mul_zero u),
+    DensePoly.coeff_zero]
   exact Rat.mul_zero u
 
 /-- Scaling a rational dense polynomial by `1` leaves it unchanged. -/
@@ -1761,10 +1753,9 @@ private theorem rat_derivative_scale (u : Rat) (p : DensePoly Rat) :
       DensePoly.scale u (DensePoly.derivative p) := by
   apply DensePoly.ext_coeff
   intro n
-  rw [rat_coeff_derivative]
-  rw [DensePoly.coeff_scale (R := Rat) u (DensePoly.derivative p) n (Rat.mul_zero u)]
-  rw [rat_coeff_derivative]
-  rw [DensePoly.coeff_scale (R := Rat) u p (n + 1) (Rat.mul_zero u)]
+  rw [rat_coeff_derivative,
+    DensePoly.coeff_scale (R := Rat) u (DensePoly.derivative p) n (Rat.mul_zero u),
+    rat_coeff_derivative, DensePoly.coeff_scale (R := Rat) u p (n + 1) (Rat.mul_zero u)]
   grind [Rat.mul_assoc, Rat.mul_comm]
 
 /-- The Leibniz product rule `derivative (p * q) = derivative p * q + p * derivative q` for rational dense polynomials. -/
@@ -1773,12 +1764,11 @@ private theorem rat_derivative_mul (p q : DensePoly Rat) :
       DensePoly.derivative p * q + p * DensePoly.derivative q := by
   apply DensePoly.ext_coeff
   intro n
-  rw [rat_coeff_derivative]
-  rw [DensePoly.coeff_mul p q (n + 1)]
+  rw [rat_coeff_derivative, DensePoly.coeff_mul p q (n + 1)]
   rw [DensePoly.coeff_add (DensePoly.derivative p * q) (p * DensePoly.derivative q) n
     (by exact Rat.zero_add (0 : Rat))]
-  rw [DensePoly.coeff_mul (DensePoly.derivative p) q n]
-  rw [DensePoly.coeff_mul p (DensePoly.derivative q) n]
+  rw [DensePoly.coeff_mul (DensePoly.derivative p) q n,
+    DensePoly.coeff_mul p (DensePoly.derivative q) n]
   exact DensePoly.rat_mulCoeffSum_derivative_product_rule p q n
 
 /-- If `d` divides `p`, then `d` divides the left multiple `q * p`. -/
@@ -1882,8 +1872,8 @@ private theorem rat_scale_mulCoeffStep (u v : Rat) (p q : DensePoly Rat)
   unfold DensePoly.mulCoeffStep
   by_cases hij : i + j = n
   · rw [if_pos hij, if_pos hij]
-    rw [DensePoly.coeff_scale (R := Rat) u p i (Rat.mul_zero u)]
-    rw [DensePoly.coeff_scale (R := Rat) v q j (Rat.mul_zero v)]
+    rw [DensePoly.coeff_scale (R := Rat) u p i (Rat.mul_zero u),
+      DensePoly.coeff_scale (R := Rat) v q j (Rat.mul_zero v)]
     grind
   · rw [if_neg hij, if_neg hij]
 
@@ -1932,8 +1922,7 @@ private theorem rat_scale_mulCoeffSum_of_ne_zero {u v : Rat} (hu : u ≠ 0) (hv 
     DensePoly.mulCoeffSum (DensePoly.scale u p) (DensePoly.scale v q) n =
       (u * v) * DensePoly.mulCoeffSum p q n := by
   unfold DensePoly.mulCoeffSum
-  rw [rat_scale_size_of_ne_zero hu p]
-  rw [rat_scale_size_of_ne_zero hv q]
+  rw [rat_scale_size_of_ne_zero hu p, rat_scale_size_of_ne_zero hv q]
   simpa using rat_scale_mulCoeffOuter_fold u v p q n (List.range p.size) 0
 
 /-- `rat_scale_mul_scale`: scaling distributes over the product, so
@@ -1955,10 +1944,9 @@ private theorem rat_scale_mul_scale (u v : Rat) (p q : DensePoly Rat) :
       simpa using rat_list_foldl_ignore (List.range (DensePoly.scale u p).size) (0 : Rat)
     · apply DensePoly.ext_coeff
       intro n
-      rw [DensePoly.coeff_mul]
-      rw [rat_scale_mulCoeffSum_of_ne_zero hu hv]
-      rw [DensePoly.coeff_scale (R := Rat) (u * v) (p * q) n (Rat.mul_zero (u * v))]
-      rw [DensePoly.coeff_mul]
+      rw [DensePoly.coeff_mul, rat_scale_mulCoeffSum_of_ne_zero hu hv,
+        DensePoly.coeff_scale (R := Rat) (u * v) (p * q) n (Rat.mul_zero (u * v)),
+        DensePoly.coeff_mul]
 
 /-- `rat_dvd_scale_of_dvd`: a divisor of `p` also divides any scalar multiple
 `scale u p`, since the witness scales along with the dividend. -/
@@ -1982,9 +1970,7 @@ private theorem rat_leadingCoeff_ne_zero_of_pos_size (p : DensePoly Rat) (hpos :
     unfold DensePoly.leadingCoeff DensePoly.coeff
     change p.coeffs.back?.getD (0 : Rat) =
       p.coeffs.getD (p.coeffs.size - 1) (Zero.zero : Rat)
-    rw [Array.back?_eq_getElem?]
-    rw [Array.getD_eq_getD_getElem?]
-    rw [Array.getElem?_eq_getElem hidx]
+    rw [Array.back?_eq_getElem?, Array.getD_eq_getD_getElem?, Array.getElem?_eq_getElem hidx]
     rfl
   rw [hlead_eq]
   exact DensePoly.coeff_last_ne_zero_of_pos_size p hpos
@@ -2021,8 +2007,7 @@ private theorem rat_divMod_spec_core (p q : DensePoly Rat) :
     have hqzero : q = 0 := by
       apply DensePoly.ext_coeff
       intro n
-      rw [DensePoly.coeff_eq_zero_of_size_le q (by omega)]
-      rw [DensePoly.coeff_zero]
+      rw [DensePoly.coeff_eq_zero_of_size_le q (by omega), DensePoly.coeff_zero]
       rfl
     change (DensePoly.divMod p q).1 * q + (DensePoly.divMod p q).2 = p
     rw [hrem, hqzero]
@@ -2097,9 +2082,8 @@ private theorem rat_mod_sub_self_eq_mul_neg_div_of_not_isZero (p m : DensePoly R
       have hzero_add : (0 : Rat) + (0 : Rat) = 0 := by grind
       change (((p / m) * m + (p % m)).coeff n = p.coeff n) at hcoeff
       rw [DensePoly.coeff_add ((p / m) * m) (p % m) n hzero_add] at hcoeff
-      rw [DensePoly.coeff_sub (p % m) p n hzero_sub]
-      rw [DensePoly.coeff_sub 0 ((p / m) * m) n hzero_sub]
-      rw [DensePoly.coeff_zero]
+      rw [DensePoly.coeff_sub (p % m) p n hzero_sub,
+        DensePoly.coeff_sub 0 ((p / m) * m) n hzero_sub, DensePoly.coeff_zero]
       grind
     _ = m * (0 - (p / m)) := by
       exact (DensePoly.mul_sub_zero_comm m (p / m)).symm
@@ -2122,8 +2106,7 @@ private theorem rat_congr_mod_core (p m : DensePoly Rat) :
     apply DensePoly.ext_coeff
     intro i
     have hzero_sub : (0 : Rat) - (0 : Rat) = 0 := by grind
-    rw [DensePoly.coeff_sub p p i hzero_sub]
-    rw [DensePoly.zero_mul, DensePoly.coeff_zero]
+    rw [DensePoly.coeff_sub p p i hzero_sub, DensePoly.zero_mul, DensePoly.coeff_zero]
     grind
   · exact ⟨0 - (p / m), rat_mod_sub_self_eq_mul_neg_div_of_not_isZero p m hmzero⟩
 
@@ -2152,12 +2135,9 @@ private theorem rat_add_sub_add_right (a b c d : DensePoly Rat) :
   intro n
   have hzero_sub : (0 : Rat) - (0 : Rat) = 0 := by grind
   have hzero_add : (0 : Rat) + (0 : Rat) = 0 := by grind
-  rw [DensePoly.coeff_sub (a + b) (c + d) n hzero_sub]
-  rw [DensePoly.coeff_add a b n hzero_add]
-  rw [DensePoly.coeff_add c d n hzero_add]
-  rw [DensePoly.coeff_add (a - c) (b - d) n hzero_add]
-  rw [DensePoly.coeff_sub a c n hzero_sub]
-  rw [DensePoly.coeff_sub b d n hzero_sub]
+  rw [DensePoly.coeff_sub (a + b) (c + d) n hzero_sub, DensePoly.coeff_add a b n hzero_add,
+    DensePoly.coeff_add c d n hzero_add, DensePoly.coeff_add (a - c) (b - d) n hzero_add,
+    DensePoly.coeff_sub a c n hzero_sub, DensePoly.coeff_sub b d n hzero_sub]
   grind
 
 /-- `rat_sub_zero_right`: subtracting the zero polynomial leaves `p` unchanged,
@@ -2185,8 +2165,7 @@ private theorem rat_sub_self_right_add (a b : DensePoly Rat) :
   intro n
   have hzero_sub : (0 : Rat) - (0 : Rat) = 0 := by grind
   have hzero_add : (0 : Rat) + (0 : Rat) = 0 := by grind
-  rw [DensePoly.coeff_sub (a + b) a n hzero_sub]
-  rw [DensePoly.coeff_add a b n hzero_add]
+  rw [DensePoly.coeff_sub (a + b) a n hzero_sub, DensePoly.coeff_add a b n hzero_add]
   grind
 
 /-- `rat_mul_left_remainder_delta`: expresses the difference between the product of
@@ -2835,8 +2814,7 @@ private theorem rat_dvd_cofactor_derivative
         DensePoly.derivative d * a := by
     apply DensePoly.ext_coeff
     intro n
-    rw [DensePoly.coeff_sub_ring]
-    rw [DensePoly.coeff_add_semiring]
+    rw [DensePoly.coeff_sub_ring, DensePoly.coeff_add_semiring]
     grind
   rw [heq] at hsub
   rw [DensePoly.mul_comm_poly]
@@ -2888,23 +2866,16 @@ private theorem ratPolyPow_succ_dvd_a_mul_derivative
   | succ k ih =>
     show d * ratPolyPow d (k + 1) ∣
       a * DensePoly.derivative (d * ratPolyPow d (k + 1))
-    rw [rat_derivative_mul]
-    rw [DensePoly.mul_add_right_poly]
+    rw [rat_derivative_mul, DensePoly.mul_add_right_poly]
     apply rat_dvd_add
     · rcases h with ⟨c, hc⟩
       refine ⟨c, ?_⟩
-      rw [← DensePoly.mul_assoc_poly]
-      rw [hc]
-      rw [DensePoly.mul_assoc_poly d c (ratPolyPow d (k + 1))]
-      rw [DensePoly.mul_comm_poly c (ratPolyPow d (k + 1))]
-      rw [← DensePoly.mul_assoc_poly]
+      rw [← DensePoly.mul_assoc_poly, hc, DensePoly.mul_assoc_poly d c (ratPolyPow d (k + 1)),
+        DensePoly.mul_comm_poly c (ratPolyPow d (k + 1)), ← DensePoly.mul_assoc_poly]
     · rcases ih with ⟨c, hc⟩
       refine ⟨c, ?_⟩
-      rw [← DensePoly.mul_assoc_poly]
-      rw [DensePoly.mul_comm_poly a d]
-      rw [DensePoly.mul_assoc_poly]
-      rw [hc]
-      rw [← DensePoly.mul_assoc_poly]
+      rw [← DensePoly.mul_assoc_poly, DensePoly.mul_comm_poly a d, DensePoly.mul_assoc_poly, hc,
+        ← DensePoly.mul_assoc_poly]
 
 /-- Iterated power-divisibility: if `d` divides both the square-free quotient
 and its derivative, then every power `d^(n+1)` divides the repeated factor. -/
@@ -2939,12 +2910,11 @@ private theorem rat_pow_dvd_repeated_of_quotient_common_divisor
     apply DensePoly.dvd_gcd
     · refine ⟨a * Q, ?_⟩
       have h1 : ratPrimitive = quotientRat * repeatedRat := hrec.symm
-      rw [h1, ha, hQ]
-      rw [DensePoly.mul_assoc_poly d a (ratPolyPow d (k + 1) * Q)]
-      rw [← DensePoly.mul_assoc_poly a (ratPolyPow d (k + 1)) Q]
-      rw [DensePoly.mul_comm_poly a (ratPolyPow d (k + 1))]
-      rw [DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) a Q]
-      rw [← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (a * Q)]
+      rw [h1, ha, hQ, DensePoly.mul_assoc_poly d a (ratPolyPow d (k + 1) * Q),
+        ← DensePoly.mul_assoc_poly a (ratPolyPow d (k + 1)) Q,
+        DensePoly.mul_comm_poly a (ratPolyPow d (k + 1)),
+        DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) a Q,
+        ← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (a * Q)]
     · have hd_eq : derivative =
           DensePoly.derivative quotientRat * repeatedRat +
             quotientRat * DensePoly.derivative repeatedRat := by
@@ -2957,15 +2927,13 @@ private theorem rat_pow_dvd_repeated_of_quotient_common_divisor
       apply rat_dvd_add
       · rcases hdq' with ⟨a', ha'⟩
         refine ⟨a' * Q, ?_⟩
-        rw [ha', hQ]
-        rw [DensePoly.mul_assoc_poly d a' (ratPolyPow d (k + 1) * Q)]
-        rw [← DensePoly.mul_assoc_poly a' (ratPolyPow d (k + 1)) Q]
-        rw [DensePoly.mul_comm_poly a' (ratPolyPow d (k + 1))]
-        rw [DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) a' Q]
-        rw [← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (a' * Q)]
+        rw [ha', hQ, DensePoly.mul_assoc_poly d a' (ratPolyPow d (k + 1) * Q),
+          ← DensePoly.mul_assoc_poly a' (ratPolyPow d (k + 1)) Q,
+          DensePoly.mul_comm_poly a' (ratPolyPow d (k + 1)),
+          DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) a' Q,
+          ← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (a' * Q)]
       · rw [ha, hQ]
-        rw [rat_derivative_mul]
-        rw [DensePoly.mul_add_right_poly]
+        rw [rat_derivative_mul, DensePoly.mul_add_right_poly]
         apply rat_dvd_add
         · have haux := ratPolyPow_succ_dvd_a_mul_derivative hcofactor k
           rcases haux with ⟨c, hc⟩
@@ -2974,9 +2942,8 @@ private theorem rat_pow_dvd_repeated_of_quotient_common_divisor
             (DensePoly.derivative (ratPolyPow d (k + 1)) * Q)]
           rw [← DensePoly.mul_assoc_poly a
             (DensePoly.derivative (ratPolyPow d (k + 1))) Q]
-          rw [hc]
-          rw [DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) c Q]
-          rw [← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (c * Q)]
+          rw [hc, DensePoly.mul_assoc_poly (ratPolyPow d (k + 1)) c Q,
+            ← DensePoly.mul_assoc_poly d (ratPolyPow d (k + 1)) (c * Q)]
         · refine ⟨a * DensePoly.derivative Q, ?_⟩
           rw [DensePoly.mul_assoc_poly d a
             (ratPolyPow d (k + 1) * DensePoly.derivative Q)]
@@ -3044,8 +3011,7 @@ private theorem densePoly_eq_zero_of_isZero_true {R : Type _} [Zero R] [Decidabl
   intro n
   have hsize : p.size = 0 := by
     simpa [DensePoly.isZero, DensePoly.size, Array.isEmpty_iff_size_eq_zero] using h
-  rw [DensePoly.coeff_eq_zero_of_size_le p (by omega)]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_eq_zero_of_size_le p (by omega), DensePoly.coeff_zero]
   rfl
 
 private theorem rat_coeff_succ_eq_zero_of_derivative_zero {p : DensePoly Rat}
@@ -3134,8 +3100,7 @@ private theorem int_scale_zero (p : ZPoly) :
     DensePoly.scale (0 : Int) p = 0 := by
   apply DensePoly.ext_coeff
   intro n
-  rw [DensePoly.coeff_scale (R := Int) (0 : Int) p n (Int.zero_mul 0)]
-  rw [DensePoly.coeff_zero]
+  rw [DensePoly.coeff_scale (R := Int) (0 : Int) p n (Int.zero_mul 0), DensePoly.coeff_zero]
   exact Int.zero_mul (p.coeff n)
 
 private theorem content_ne_zero_of_ne_zero (p : ZPoly) (hp : p ≠ 0) :
@@ -3182,8 +3147,7 @@ private theorem ratPolyPrimitivePart_ne_zero_of_ne_zero (p : DensePoly Rat)
   rcases ratPolyPrimitivePart_rational_associate p with ⟨unit, hunit⟩
   intro hprimitive_zero
   apply hp
-  rw [hunit, hprimitive_zero]
-  rw [toRatPoly_zero]
+  rw [hunit, hprimitive_zero, toRatPoly_zero]
   exact rat_scale_zero_right unit
 
 private theorem int_eq_one_or_neg_one_of_natAbs_eq_one {c : Int}
@@ -3273,8 +3237,7 @@ theorem primitiveSquareFreeDecomposition_reassembly_over_rat (f : ZPoly) :
     rw [if_pos hzero]
     have hprimitive_zero : primitivePart f = 0 :=
       densePoly_eq_zero_of_isZero_true (primitivePart f) hzero
-    rw [hprimitive_zero, toRatPoly_zero]
-    rw [rat_scale_zero]
+    rw [hprimitive_zero, toRatPoly_zero, rat_scale_zero]
   · rw [if_neg hzero]
     let ratPrimitive := toRatPoly (primitivePart f)
     let derivative := DensePoly.derivative ratPrimitive
@@ -3282,8 +3245,7 @@ theorem primitiveSquareFreeDecomposition_reassembly_over_rat (f : ZPoly) :
     · rcases toRatPoly_normalizePrimitiveSign_rational_associate (primitivePart f) with
         ⟨unit, hunit⟩
       refine ⟨unit, ?_⟩
-      rw [if_pos hderivative]
-      rw [toRatPoly_one, DensePoly.mul_one_right_poly]
+      rw [if_pos hderivative, toRatPoly_one, DensePoly.mul_one_right_poly]
       simpa [ratPrimitive] using hunit
     · rw [if_neg hderivative]
       let repeatedRat := DensePoly.gcd ratPrimitive derivative
@@ -3793,8 +3755,7 @@ theorem primitiveSquareFreeDecomposition_reassembly_signed
       toRatPoly (primitivePart f)
     have htarget := hunit_product
     rw [hunit_one, rat_scale_one] at htarget
-    rw [rat_scale_one]
-    rw [← hdprimitive]
+    rw [rat_scale_one, ← hdprimitive]
     exact htarget.symm
   · refine ⟨-1, Or.inr rfl, ?_⟩
     apply toRatPoly_injective

--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -154,12 +154,10 @@ theorem reflectedLinearFactor_eq_C_mul_X_sub_C_schurReflectedRoot {α : ℂ} (h�
   rw [schurReflectedRoot, mul_sub, ← C_mul]
   have hmul : -(conj α) * (conj α)⁻¹ = -1 := by
     rw [neg_mul, mul_inv_cancel₀ hconj]
-  rw [hmul]
-  rw [mul_comm]
+  rw [hmul, mul_comm]
   have hxneg : X * C (-(conj α)) = -(X * C (conj α)) := by
     rw [← mul_neg, ← C_neg]
-  rw [mul_comm (C (-(conj α))) X]
-  rw [hxneg]
+  rw [mul_comm (C (-(conj α))) X, hxneg]
   norm_num
   ring
 
@@ -447,8 +445,7 @@ theorem mahlerMeasure_robinsonFactor (α : ℂ) :
         congr 1
         rw [map_neg]
         simp only [map_one]
-        rw [sub_eq_add_neg, add_comm]
-        rw [neg_mul]
+        rw [sub_eq_add_neg, add_comm, neg_mul]
       _ = max ‖-(conj α)‖ ‖(1 : ℂ)‖ := by
         simpa using mahlerMeasure_C_mul_X_add_C (a := -(conj α)) (b := 1) (by simpa using hconj_ne)
       _ = max 1 ‖α‖ := by
@@ -510,8 +507,7 @@ theorem norm_root_robinsonFactor_le (α : ℂ) {β : ℂ}
     rw [hβ]
     have : ‖-((-(conj α))⁻¹ * 1)‖ = ‖α‖⁻¹ := by
       rw [mul_one, norm_neg, norm_inv, norm_neg, Complex.norm_conj]
-    rw [this]
-    rw [inv_le_one_iff₀]
+    rw [this, inv_le_one_iff₀]
     right
     exact hα'.le
 

--- a/HexRowReduce/RREF/Echelon.lean
+++ b/HexRowReduce/RREF/Echelon.lean
@@ -217,8 +217,7 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
           rw [if_neg hxy]
           grind
-        rw [if_pos rfl]
-        rw [foldl_add_eq_acc_ring xs _ _ hxs_zero]
+        rw [if_pos rfl, foldl_add_eq_acc_ring xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq
@@ -228,8 +227,7 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
         have hzero : (0 : R) * f x = 0 := by grind
         rw [hzero]
         have hacc : acc + (0 : R) = acc := by grind
-        rw [hacc]
-        rw [ih hitail (List.nodup_cons.mp hnodup).2 acc]
+        rw [hacc, ih hitail (List.nodup_cons.mp hnodup).2 acc]
 
 /-- A row-combination vector with a single coefficient `1` at row `i`
 and zero elsewhere selects exactly row `i` of the matrix. This packages
@@ -635,8 +633,7 @@ private theorem foldl_sum_start {R : Type u} [Lean.Grind.Ring R]
       grind
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      rw [ih (acc := (0 : R) + f x)]
+      rw [ih (acc := acc + f x), ih (acc := (0 : R) + f x)]
       grind
 
 omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
@@ -661,8 +658,7 @@ private theorem foldl_one_nonzero {R : Type u} [Lean.Grind.Ring R]
             exact (List.nodup_cons.mp hnodup).1 hy
           exact hz y (List.mem_cons_of_mem _ hy) hya
         have h0x : (0 : R) + x = x := by grind
-        rw [h0x]
-        rw [foldl_add_eq_acc_ring_echelon zs f x hzero]
+        rw [h0x, foldl_add_eq_acc_ring_echelon zs f x hzero]
       · have hz0 : f z = 0 := hz z (by simp) hza
         rw [hz0]
         have haTail : a ∈ zs := by
@@ -705,9 +701,7 @@ private theorem foldl_two_nonzero {R : Type u} [Lean.Grind.Ring R]
             exact (List.nodup_cons.mp hnodup).1 ht
           exact hz t (List.mem_cons_of_mem _ ht) hta htb
         have h0x : (0 : R) + x = x := by grind
-        rw [h0x]
-        rw [foldl_sum_start zs f x]
-        rw [foldl_one_nonzero zs b f y hbTail hnodupTail hb hbOnly]
+        rw [h0x, foldl_sum_start zs f x, foldl_one_nonzero zs b f y hbTail hnodupTail hb hbOnly]
       · by_cases hzb : z = b
         · subst z
           rw [hb]
@@ -724,9 +718,7 @@ private theorem foldl_two_nonzero {R : Type u} [Lean.Grind.Ring R]
               exact (List.nodup_cons.mp hnodup).1 ht
             exact hz t (List.mem_cons_of_mem _ ht) hta htb
           have h0y : (0 : R) + y = y := by grind
-          rw [h0y]
-          rw [foldl_sum_start zs f y]
-          rw [foldl_one_nonzero zs a f x haTail hnodupTail ha haOnly]
+          rw [h0y, foldl_sum_start zs f y, foldl_one_nonzero zs a f x haTail hnodupTail ha haOnly]
           grind
         · have hz0 : f z = 0 := hz z (by simp) hza hzb
           rw [hz0]
@@ -765,8 +757,7 @@ private theorem nullspace_echelon_sound {R : Type u} [Lean.Grind.Ring R] {n m : 
       exact E.toIsEchelonForm.pivotCols_disjoint_freeCols ri k
     change (Matrix.mulVec D.echelon (E.nullspace.get k))[r] = (0 : Vector R n)[r]
     unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct
-    rw [Vector.getElem_ofFn hr]
-    rw [Vector.getElem_zero r hr]
+    rw [Vector.getElem_ofFn hr, Vector.getElem_zero r hr]
     change (List.finRange m).foldl
         (fun acc j => acc + D.echelon[row][j] * (E.nullspace.get k)[j]) 0 = 0
     have hpivotTerm :
@@ -834,8 +825,7 @@ private theorem nullspace_echelon_sound {R : Type u} [Lean.Grind.Ring R] {n m : 
       exact Nat.le_of_not_gt hrow)
     change (Matrix.mulVec D.echelon (E.nullspace.get k))[r] = (0 : Vector R n)[r]
     unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct
-    rw [Vector.getElem_ofFn hr]
-    rw [Vector.getElem_zero r hr]
+    rw [Vector.getElem_ofFn hr, Vector.getElem_zero r hr]
     change (List.finRange m).foldl
         (fun acc j => acc + D.echelon[row][j] * (E.nullspace.get k)[j]) 0 = 0
     have hzero :
@@ -919,8 +909,7 @@ private theorem pivotCols_toList_nodup
     {M : Matrix R n m} {D : RowEchelonData R n m}
     (E : IsEchelonForm M D) :
     D.pivotCols.toList.Nodup := by
-  rw [List.nodup_iff_pairwise_ne]
-  rw [List.pairwise_iff_getElem]
+  rw [List.nodup_iff_pairwise_ne, List.pairwise_iff_getElem]
   intro i j hi hj hij
   have hi' : i < D.rank := by simpa [Vector.length_toList] using hi
   have hj' : j < D.rank := by simpa [Vector.length_toList] using hj
@@ -985,9 +974,7 @@ private theorem pivot_column_entry_pivotRow {R : Type u} [Lean.Grind.Field R]
   have h := pivot_column_entry E i' (E.toIsEchelonForm.pivotRow i)
   by_cases hii : i' = i
   · subst i'
-    rw [if_pos rfl]
-    rw [h]
-    rw [if_pos rfl]
+    rw [if_pos rfl, h, if_pos rfl]
   · rw [if_neg hii]
     rw [h]
     have hrow_ne : E.toIsEchelonForm.pivotRow i' ≠ E.toIsEchelonForm.pivotRow i := by

--- a/HexRowReduce/RREF/Pivot.lean
+++ b/HexRowReduce/RREF/Pivot.lean
@@ -301,8 +301,7 @@ private theorem eliminateColumn_step_zero_at_x
     exact this
   · rw [if_neg hcoeff]
     show (rowAdd s.1 pivotRow x (-s.1[x][col]))[x][col] = 0
-    rw [rowAdd_get_dst s.1 pivotRow x (-s.1[x][col]) col]
-    rw [hpivot]
+    rw [rowAdd_get_dst s.1 pivotRow x (-s.1[x][col]) col, hpivot]
     grind
 
 /-- The pivot-row entries at column `col` are preserved through any fold of

--- a/HexRowReduce/RowEchelon.lean
+++ b/HexRowReduce/RowEchelon.lean
@@ -197,8 +197,7 @@ theorem rowSwap_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowSwap A i j) * B)[rr][ll] = (rowSwap (A * B) i j)[rr][ll]
-  rw [mul_getElem (rowSwap A i j) B rr ll]
-  rw [rowSwap_getElem (A * B) i j rr ll]
+  rw [mul_getElem (rowSwap A i j) B rr ll, rowSwap_getElem (A * B) i j rr ll]
   by_cases hrj : rr = j
   · rw [if_pos hrj]
     rw [mul_getElem A B i ll]
@@ -235,8 +234,7 @@ theorem rowScale_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowScale A i s) * B)[rr][ll] = (rowScale (A * B) i s)[rr][ll]
-  rw [mul_getElem (rowScale A i s) B rr ll]
-  rw [rowScale_getElem (A * B) i rr s ll]
+  rw [mul_getElem (rowScale A i s) B rr ll, rowScale_getElem (A * B) i rr s ll]
   by_cases hri : rr = i
   · rw [if_pos hri]
     rw [mul_getElem A B i ll]
@@ -258,12 +256,10 @@ theorem rowAdd_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowAdd A src dst s) * B)[rr][ll] = (rowAdd (A * B) src dst s)[rr][ll]
-  rw [mul_getElem (rowAdd A src dst s) B rr ll]
-  rw [rowAdd_getElem (A * B) src dst rr s ll]
+  rw [mul_getElem (rowAdd A src dst s) B rr ll, rowAdd_getElem (A * B) src dst rr s ll]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [mul_getElem A B dst ll]
-    rw [mul_getElem A B src ll]
+    rw [mul_getElem A B dst ll, mul_getElem A B src ll]
     rw [show row (rowAdd A src dst s) rr =
         Vector.ofFn (fun k' => A[dst][k'] + s * A[src][k']) by
       rw [hrd]
@@ -376,8 +372,7 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
       rw [rowSwap_getElem]
       simp [hri]
     · rw [if_neg hri]
-      rw [rowSwap_getElem]
-      rw [if_neg hrj, if_neg hri]
+      rw [rowSwap_getElem, if_neg hrj, if_neg hri]
 
 /-- Swapping a row with itself leaves the matrix unchanged. -/
 @[simp, grind =] theorem rowSwap_self (M : Matrix R n m) (i : Fin n) :
@@ -431,12 +426,10 @@ theorem rowScale_rowScale_inv_left [Lean.Grind.Field R]
   rw [rowScale_getElem]
   by_cases hri : rr = i
   · rw [if_pos hri]
-    rw [rowScale_getElem]
-    rw [if_pos rfl]
+    rw [rowScale_getElem, if_pos rfl]
     grind
   · rw [if_neg hri]
-    rw [rowScale_getElem]
-    rw [if_neg hri]
+    rw [rowScale_getElem, if_neg hri]
 
 /-- Scaling a row by `s⁻¹` and then by `s` restores the original matrix when
 `s` is nonzero. -/
@@ -450,12 +443,10 @@ theorem rowScale_rowScale_inv_right [Lean.Grind.Field R]
   rw [rowScale_getElem]
   by_cases hri : rr = i
   · rw [if_pos hri]
-    rw [rowScale_getElem]
-    rw [if_pos rfl]
+    rw [rowScale_getElem, if_pos rfl]
     grind
   · rw [if_neg hri]
-    rw [rowScale_getElem]
-    rw [if_neg hri]
+    rw [rowScale_getElem, if_neg hri]
 
 /-- Adding `s` times a distinct source row to a destination row and then
 adding `-s` times that source row restores the original matrix. -/
@@ -469,15 +460,12 @@ theorem rowAdd_rowAdd_neg [Lean.Grind.Ring R]
   rw [rowAdd_getElem]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [rowAdd_getElem]
-    rw [if_pos rfl]
+    rw [rowAdd_getElem, if_pos rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [rowAdd_getElem]
-    rw [if_neg hsrc_ne_dst]
+    rw [rowAdd_getElem, if_neg hsrc_ne_dst]
     grind
   · rw [if_neg hrd]
-    rw [rowAdd_getElem]
-    rw [if_neg hrd]
+    rw [rowAdd_getElem, if_neg hrd]
 
 /-- Adding `-s` times a distinct source row to a destination row and then
 adding `s` times that source row restores the original matrix. -/
@@ -491,15 +479,12 @@ theorem rowAdd_rowAdd_neg_left [Lean.Grind.Ring R]
   rw [rowAdd_getElem]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [rowAdd_getElem]
-    rw [if_pos rfl]
+    rw [rowAdd_getElem, if_pos rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [rowAdd_getElem]
-    rw [if_neg hsrc_ne_dst]
+    rw [rowAdd_getElem, if_neg hsrc_ne_dst]
     grind
   · rw [if_neg hrd]
-    rw [rowAdd_getElem]
-    rw [if_neg hrd]
+    rw [rowAdd_getElem, if_neg hrd]
 
 private theorem leftMul_left_inverse_preserve [Lean.Grind.Ring R]
     {S Sinv T : Matrix R n n} (hSinvS : Sinv * S = 1)
@@ -625,13 +610,10 @@ theorem mul_colAdd [Lean.Grind.CommRing R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show (A * colAdd B src dst s)[rr][ll] = (colAdd (A * B) src dst s)[rr][ll]
-  rw [mul_getElem A (colAdd B src dst s) rr ll]
-  rw [colAdd_getElem (A * B) src dst s rr ll]
+  rw [mul_getElem A (colAdd B src dst s) rr ll, colAdd_getElem (A * B) src dst s rr ll]
   by_cases hld : ll = dst
   · rw [if_pos hld]
-    rw [hld]
-    rw [mul_getElem A B rr dst]
-    rw [mul_getElem A B rr src]
+    rw [hld, mul_getElem A B rr dst, mul_getElem A B rr src]
     rw [show col (colAdd B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + s * B[i][src]) by
       exact col_colAdd_dst B src dst s]
@@ -654,13 +636,10 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   let ll : Fin k := ⟨l, hl⟩
   show (A * colAddRight B src dst s)[rr][ll] =
     (colAddRight (A * B) src dst s)[rr][ll]
-  rw [mul_getElem A (colAddRight B src dst s) rr ll]
-  rw [colAddRight_getElem (A * B) src dst s rr ll]
+  rw [mul_getElem A (colAddRight B src dst s) rr ll, colAddRight_getElem (A * B) src dst s rr ll]
   by_cases hld : ll = dst
   · rw [if_pos hld]
-    rw [hld]
-    rw [mul_getElem A B rr dst]
-    rw [mul_getElem A B rr src]
+    rw [hld, mul_getElem A B rr dst, mul_getElem A B rr src]
     rw [show col (colAddRight B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + B[i][src] * s) by
       exact col_colAddRight_dst B src dst s]

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -65,10 +65,8 @@ lemmas pass between the two row representations. -/
 
 private theorem foldl_finRange_eq_sum [AddCommMonoid R] {n : Nat} (f : Fin n → R) :
     (List.finRange n).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
-  rw [← List.foldl_map]
-  rw [← List.sum_eq_foldl]
-  rw [← List.sum_toFinset f (List.nodup_finRange n)]
-  rw [List.toFinset_finRange]
+  rw [← List.foldl_map, ← List.sum_eq_foldl, ← List.sum_toFinset f (List.nodup_finRange n),
+    List.toFinset_finRange]
 
 /-- Bridge invariant: the executable matrix-vector product transports to
 Mathlib's `Matrix.mulVec` under `matrixEquiv`/`vectorEquiv`. This is the key
@@ -79,8 +77,7 @@ private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector 
   simp only [vectorEquiv_apply]
   change (Hex.Matrix.mulVec M v)[i.val] = (matrixEquiv M).mulVec (vectorEquiv v) i
   unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
-  rw [Vector.getElem_ofFn i.isLt]
-  rw [foldl_finRange_eq_sum]
+  rw [Vector.getElem_ofFn i.isLt, foldl_finRange_eq_sum]
   unfold _root_.Matrix.mulVec dotProduct
   apply Finset.sum_congr rfl
   intro k _
@@ -100,10 +97,8 @@ theorem vectorEquiv_rowCombination [CommRing R] (M : Hex.Matrix R n m) (c : Vect
     (Fintype.linearCombination R (_root_.Matrix.row (matrixEquiv M)) (vectorEquiv c)) j
   unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct Hex.Matrix.transpose
     Hex.Matrix.col
-  rw [Vector.getElem_ofFn j.isLt]
-  rw [foldl_finRange_eq_sum]
-  rw [Fintype.linearCombination_apply]
-  rw [Finset.sum_apply]
+  rw [Vector.getElem_ofFn j.isLt, foldl_finRange_eq_sum, Fintype.linearCombination_apply,
+    Finset.sum_apply]
   apply Finset.sum_congr rfl
   intro i _
   simp only [vectorEquiv_apply, matrixEquiv_apply, _root_.Matrix.row_apply, Pi.smul_apply,
@@ -126,8 +121,7 @@ private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
   change (Hex.Matrix.mulVec E.nullspaceMatrix c)[j.val] =
     ∑ k : Fin (m - D.rank), c[k] * (E.nullspace.get k)[j]
   unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
-  rw [Vector.getElem_ofFn j.isLt]
-  rw [foldl_finRange_eq_sum]
+  rw [Vector.getElem_ofFn j.isLt, foldl_finRange_eq_sum]
   apply Finset.sum_congr rfl
   intro k _
   unfold Hex.Matrix.IsRREF.nullspace Hex.Matrix.col


### PR DESCRIPTION
This PR combines runs of adjacent single-line `rw [...]` goal rewrites into one `rw [..., ...]` across the library, covering 806 such runs in 88 files. The transformation is mechanical and behaviour-preserving: `rw [a]; rw [b]` differs from `rw [a, b]` only by an intermediate `rfl` attempt, which cannot have been firing in already-compiling code. Only same-indentation adjacent goal rewrites are merged; `rw ... at h` lines and blank-separated runs are left untouched.

🤖 Prepared with Claude Code