### PR TITLE
refactor: name getElem lemmas getElem_<op> per the lean4 convention

### DIFF
--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -581,7 +581,7 @@ swapped rows read from the opposite source, every other row is unchanged. -/
 private theorem rowSwap_get (M : Matrix Int n n) (rowA rowB i j : Fin n) :
     (rowSwap M rowA rowB)[i][j] =
       if i = rowB then M[rowA][j] else if i = rowA then M[rowB][j] else M[i][j] :=
-  rowSwap_getElem M rowA rowB i j
+  getElem_rowSwap M rowA rowB i j
 
 /-- `swapRowsArray` applied to `matrixToRows M` matches the abstract
 `rowSwap M rowA rowB` entry by entry. -/

--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -442,23 +442,23 @@ private theorem principalSubmatrix_rowSwap_eq_of_le {R : Type u}
       (⟨c, hc⟩ : Fin k)] =
     (M.principalSubmatrix k hk)[(⟨r, hr⟩ : Fin k)][(⟨c, hc⟩ : Fin k)]
   rw [Hex.Matrix.getElem_principalSubmatrix, Hex.Matrix.getElem_principalSubmatrix]
-  simp only [Hex.Matrix.rowSwap_getElem, if_neg h_r_ne_pivot, if_neg h_r_ne_kFin]
+  simp only [Hex.Matrix.getElem_rowSwap, if_neg h_r_ne_pivot, if_neg h_r_ne_kFin]
 
 /-- Auxiliary: a row of `rowSwap M kFin pivot` with index `r` not equal to
 either swap target equals the corresponding row of `M`. -/
-private theorem rowSwap_getElem_of_ne {R : Type u}
+private theorem getElem_rowSwap_of_ne {R : Type u}
     (M : Hex.Matrix R n n) (kFin pivot r : Fin n) (c : Fin n)
     (hr_ne_kFin : r ≠ kFin) (hr_ne_pivot : r ≠ pivot) :
     (Hex.Matrix.rowSwap M kFin pivot)[r][c] = M[r][c] := by
-  rw [Hex.Matrix.rowSwap_getElem, if_neg hr_ne_pivot, if_neg hr_ne_kFin]
+  rw [Hex.Matrix.getElem_rowSwap, if_neg hr_ne_pivot, if_neg hr_ne_kFin]
 
 /-- Reading row `r` of `rowSwap M kFin pivot` returns row `swap_idx r` of `M`,
 where `swap_idx kFin pivot r = if r = pivot then kFin else if r = kFin then pivot else r`. -/
-private theorem rowSwap_getElem_swap_eq {R : Type u}
+private theorem getElem_rowSwap_swap_eq {R : Type u}
     (M : Hex.Matrix R n n) (kFin pivot r : Fin n) (c : Fin n) :
     (Hex.Matrix.rowSwap M kFin pivot)[r][c] =
       M[if r = pivot then kFin else if r = kFin then pivot else r][c] := by
-  rw [Hex.Matrix.rowSwap_getElem]
+  rw [Hex.Matrix.getElem_rowSwap]
   by_cases hrp : r = pivot
   · simp only [if_pos hrp]
   · by_cases hrk : r = kFin
@@ -481,7 +481,7 @@ private theorem borderedMinor_rowSwap_source_row {R : Type u}
   -- then reads `M[rr][cc]`. For r < k, rr = ⟨r, _⟩ on both sides, so the
   -- equation reduces to a row equality on M (modulo the source row swap).
   -- For r = k, rr = i on LHS and rr = swap_idx i on RHS; the row equality
-  -- is exactly `rowSwap_getElem`.
+  -- is exactly `getElem_rowSwap`.
   apply Vector.ext
   intro r _hr
   apply Vector.ext
@@ -501,21 +501,21 @@ private theorem borderedMinor_rowSwap_source_row {R : Type u}
       simp [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, hrk, hck]
       show (Hex.Matrix.rowSwap M kFin pivot)[(⟨r, hr_lt⟩ : Fin n)][(⟨c, hc_lt⟩ : Fin n)] =
           M[(⟨r, hr_lt⟩ : Fin n)][(⟨c, hc_lt⟩ : Fin n)]
-      exact rowSwap_getElem_of_ne M kFin pivot ⟨r, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
+      exact getElem_rowSwap_of_ne M kFin pivot ⟨r, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
     · simp [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, hrk, hck]
       show (Hex.Matrix.rowSwap M kFin pivot)[(⟨r, hr_lt⟩ : Fin n)][j] =
           M[(⟨r, hr_lt⟩ : Fin n)][j]
-      exact rowSwap_getElem_of_ne M kFin pivot ⟨r, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
+      exact getElem_rowSwap_of_ne M kFin pivot ⟨r, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
   · by_cases hck : c < k
     · have hc_lt : c < n := Nat.lt_trans hck hk
       simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Vector.getElem_ofFn,
         hrk, hck, dif_pos, dif_neg, not_false_iff]
       show (Hex.Matrix.rowSwap M kFin pivot)[i][(⟨c, hc_lt⟩ : Fin n)] = _
-      exact rowSwap_getElem_swap_eq M kFin pivot i _
+      exact getElem_rowSwap_swap_eq M kFin pivot i _
     · simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Vector.getElem_ofFn,
         hrk, hck, dif_neg, not_false_iff]
       show (Hex.Matrix.rowSwap M kFin pivot)[i][j] = _
-      exact rowSwap_getElem_swap_eq M kFin pivot i j
+      exact getElem_rowSwap_swap_eq M kFin pivot i j
 
 /-- Public regular swap-only step surface for the row-pivoted Bareiss proof.
 When the current diagonal pivot is zero and `findPivot?` returns a later row,
@@ -565,7 +565,7 @@ theorem bareissPivotInvariant_regular_swap
     exact hinv.prevPivot_eq
   · intro hnext i j hi hj
     -- The working matrix entry at (i, j) under rowSwap rewrites by cases on i.
-    rw [Hex.Matrix.rowSwap_getElem]
+    rw [Hex.Matrix.getElem_rowSwap]
     -- The bordered minor at (i, j) of the row-swapped source equals the
     -- bordered minor of the original source with the border row swapped.
     rw [borderedMinor_rowSwap_source_row source state.step hk kFin pivot hkF_val
@@ -684,7 +684,7 @@ private theorem pivotLoop_swap_pivot_ne_zero
   have hentry :
       (Hex.Matrix.rowSwap state.matrix kFin pivot)[kFin][kFin] =
         state.matrix[pivot][kFin] := by
-    rw [Hex.Matrix.rowSwap_getElem]
+    rw [Hex.Matrix.getElem_rowSwap]
     simp [hpivot_ne.symm]
   simpa [kFin] using hentry ▸ hpivot
 

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -465,7 +465,7 @@ private theorem mul_apply_foldl
   unfold Hex.Vector.dotProduct
   apply foldl_acc_congr
   intro acc l _hmem
-  rw [row_getElem, col_getElem]
+  rw [getElem_row, getElem_col]
 
 /-- Row decomposition of `setRow M r u * adjugate M`: the `(i, s)` entry is
 the `cofactor-row pairing` of `M`'s row `s` against the (possibly replaced)

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -323,7 +323,7 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
       (⟨r, hr⟩ : Fin n)][(⟨k, hk2⟩ : Fin n)] =
     (columnSumMatrixWithSuffix source coeff (c :: chosen))[
       (⟨r, hr⟩ : Fin n)][(⟨k, hk2⟩ : Fin n)]
-  rw [setCol_getElem]
+  rw [getElem_setCol]
   simp only [getElem_columnSumMatrixWithSuffix]
   have hccons_len : (c :: chosen).length = chosen.length + 1 := rfl
   by_cases hkd : (⟨k, hk2⟩ : Fin n) = (⟨n - chosen.length - 1, by omega⟩ : Fin n)
@@ -383,7 +383,7 @@ private theorem det_columnSumMatrixWithSuffix_expand
     change (setCol (columnSumMatrixWithSuffix source coeff chosen) dst _)[
         (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-    rw [setCol_getElem, getElem_columnSumMatrixWithSuffix]
+    rw [getElem_setCol, getElem_columnSumMatrixWithSuffix]
     by_cases hcd : (⟨c, hc⟩ : Fin n) = dst
     · rw [if_pos hcd, hcd]
       rw [dif_neg (show ¬ n - chosen.length ≤ dst.val by simp [dst]; omega)]

--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -61,7 +61,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
             (setCol M dst v)[x][perm[x]]) 1 := by
         apply foldl_det_product_congr
         intro x _hx
-        rw [setCol_getElem, setCol_getElem, setCol_getElem]
+        rw [getElem_setCol, getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
         · subst x
           rw [if_pos hpivot, if_pos hpivot, if_pos hpivot, if_pos rfl]
@@ -115,7 +115,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
                 exact hxp (Fin.ext hval)
               change (setCol M dst w)[x][perm[x]] =
                 (setCol M dst v)[x][perm[x]]
-              rw [setCol_getElem, setCol_getElem]
+              rw [getElem_setCol, getElem_setCol]
               change (if perm[x] = dst then w x else M[x][perm[x]]) =
                 (if perm[x] = dst then v x else M[x][perm[x]])
               rw [if_neg hperm_ne, if_neg hperm_ne])
@@ -156,7 +156,7 @@ private theorem detProduct_setCol_smul {R : Type u} [Lean.Grind.CommRing R]
             (setCol M dst v)[x][perm[x]]) 1 := by
         apply foldl_det_product_congr
         intro x _hx
-        rw [setCol_getElem, setCol_getElem]
+        rw [getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
         · subst x
           rw [if_pos hpivot, if_pos hpivot, if_pos rfl]
@@ -361,7 +361,7 @@ private theorem setCol_columnSumMatrix_self
           (fun acc k => acc + coeff[dst][k] * source[r][k]) 0))[
           (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix source coeff)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [setCol_getElem]
+  rw [getElem_setCol]
   by_cases hcol : (⟨c, hc⟩ : Fin n) = dst
   · subst dst
     rw [if_pos rfl]
@@ -436,7 +436,7 @@ theorem det_setCol_existing_col_eq_zero
     det (setCol M dst (fun r => M[r][src])) = 0 := by
   apply det_eq_zero_of_col_eq (setCol M dst (fun r => M[r][src])) src dst hsrcdst
   intro r
-  rw [setCol_getElem, setCol_getElem, if_neg hsrcdst, if_pos rfl]
+  rw [getElem_setCol, getElem_setCol, if_neg hsrcdst, if_pos rfl]
 
 /-- Adding a finite linear combination of other columns of `M` to column `dst`
 preserves the determinant. The sources are given as a list and each source is

--- a/HexDeterminant/Laplace.lean
+++ b/HexDeterminant/Laplace.lean
@@ -329,7 +329,7 @@ theorem det_eq_foldl_laplace_row
         (fun acc col => acc + M[row][col] * cofactor M row col) 0 := by
         apply foldl_acc_congr
         intro acc col _hmem
-        rw [cofactor_transpose, transpose_getElem]
+        rw [cofactor_transpose, getElem_transpose]
 
 end Matrix
 end Hex

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -104,7 +104,7 @@ private theorem rowSwap_get {R : Type u} {n m : Nat}
     (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
     (rowSwap M i j)[r][k] =
       if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] :=
-  rowSwap_getElem M i j r k
+  getElem_rowSwap M i j r k
 
 /-- For distinct `i, j`, reading row `r` of `rowSwap M i j` is the same as
 reading row `finTranspose i j r` of `M`, identifying the swap with the
@@ -1704,7 +1704,7 @@ private theorem colAdd_get {R : Type u} [Mul R] [Add R] {n : Nat}
     (M : Matrix R n n) (src dst r cidx : Fin n) (c : R) :
     (colAdd M src dst c)[r][cidx] =
       if cidx = dst then M[r][cidx] + c * M[r][src] else M[r][cidx] := by
-  exact colAdd_getElem M src dst c r cidx
+  exact getElem_colAdd M src dst c r cidx
 
 /-- For a nodup permutation, the product term of `colAdd M src dst c` splits as
 `detProduct M perm + c · detProduct (colAddDuplicate M src dst) perm`. -/

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -1015,7 +1015,7 @@ theorem mMatrix_eq_setCol_last {R : Type u} {n : Nat}
   change (mMatrix B v p)[(⟨i, hi⟩ : Fin (n + 1))][(⟨j, hj⟩ : Fin (n + 1))] =
     (setCol (mMatrix B w p) (Fin.last n)
         (fun i : Fin (n + 1) => v[skipIndex p i]))[(⟨i, hi⟩ : Fin (n + 1))][(⟨j, hj⟩ : Fin (n + 1))]
-  rw [setCol_getElem]
+  rw [getElem_setCol]
   by_cases hjlt : j < n
   · have hjne : (⟨j, hj⟩ : Fin (n + 1)) ≠ Fin.last n := by
       intro h
@@ -1063,10 +1063,10 @@ theorem mDet_smul_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
   rw [det_setCol_smul, ← mMatrix_eq_setCol_last B v v p]
 
 /-- Numeric entry form for the standard basis vector. -/
-private theorem unit_getElem_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+private theorem getElem_unit_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (q : Fin (n + 2)) (i : Fin (n + 2)) :
     (Hex.Vector.unit (R := R) q)[i] = if i = q then (1 : R) else (0 : R) := by
-  rw [Hex.Vector.unit_getElem]
+  rw [Hex.Vector.getElem_unit]
   by_cases h : i = q
   · rw [if_pos h.symm, if_pos h]
     rfl
@@ -1166,7 +1166,7 @@ private theorem foldl_unit_weighted_single
     by_cases hp : p = q
     · rw [if_pos hp]
     · rw [if_neg hp]
-      rw [unit_getElem_num, if_neg hp]
+      rw [getElem_unit_num, if_neg hp]
       grind
   calc
     (List.finRange (n + 2)).foldl
@@ -1176,7 +1176,7 @@ private theorem foldl_unit_weighted_single
           acc + if p = q then (Hex.Vector.unit (R := R) q)[p] * f p else 0) 0 := hcongr
     _ = 0 + (Hex.Vector.unit (R := R) q)[q] * f q := hfold
     _ = f q := by
-      rw [unit_getElem_num, if_pos rfl]
+      rw [getElem_unit_num, if_pos rfl]
       grind
 
 /-- Expands the augmented vector column of `mDet` in the standard basis. -/
@@ -1211,7 +1211,7 @@ theorem mDet_eq_sum_unit
       by_cases hq : q = skipIndex p i
       · rw [if_pos hq]
       · rw [if_neg hq]
-        rw [unit_getElem_num, if_neg (fun h => hq h.symm)]
+        rw [getElem_unit_num, if_neg (fun h => hq h.symm)]
         grind
     symm
     calc
@@ -1223,7 +1223,7 @@ theorem mDet_eq_sum_unit
               v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := hcongr
       _ = 0 + v[skipIndex p i] * (Hex.Vector.unit (R := R) (skipIndex p i))[skipIndex p i] := hfold
       _ = v[skipIndex p i] := by
-        rw [unit_getElem_num, if_pos rfl]
+        rw [getElem_unit_num, if_pos rfl]
         grind
   rw [hcol, det_setCol_sum_finRange]
   apply foldl_acc_congr
@@ -1413,7 +1413,7 @@ theorem mDet_unit_eq_signed_nDet_of_gt
       (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
-    rw [mMatrix_entry_last, unit_getElem_num]
+    rw [mMatrix_entry_last, getElem_unit_num]
     by_cases hreq : r = r_q
     · subst hreq
       rw [if_pos rfl]
@@ -1457,7 +1457,7 @@ theorem mDet_unit_eq_signed_nDet_of_lt
       (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
-    rw [mMatrix_entry_last, unit_getElem_num]
+    rw [mMatrix_entry_last, getElem_unit_num]
     by_cases hreq : r = r_q
     · subst hreq
       rw [if_pos rfl]
@@ -1494,7 +1494,7 @@ theorem mDet_unit_eq_zero_of_eq {R : Type u} [Lean.Grind.CommRing R]
   have hcol : (fun r : Fin (n + 1) =>
       (Hex.Vector.unit (R := R) p)[skipIndex p r]) = (fun _ => (0 : R)) := by
     funext r
-    rw [unit_getElem_num]
+    rw [getElem_unit_num]
     exact if_neg (skipIndex_ne p r)
   -- Express mMatrix as setCol with that zero function on the last column.
   rw [mMatrix_eq_setCol_last B (Hex.Vector.unit (R := R) p)

--- a/HexDeterminant/Selection.lean
+++ b/HexDeterminant/Selection.lean
@@ -593,7 +593,7 @@ def reconstructInjTuple {m n : Nat}
 
 /-- The `i`-th entry of the reconstructed tuple is `sel[perm[i]]`: read the
 sorted choice `sel` through the permutation `perm`. -/
-@[grind =] theorem reconstructInjTuple_getElem {m n : Nat}
+@[grind =] theorem getElem_reconstructInjTuple {m n : Nat}
     (sel : Vector (Fin m) n) (perm : Vector (Fin n) n) (i : Fin n) :
     (reconstructInjTuple sel perm)[i] = sel[perm[i]] := by
   rw [reconstructInjTuple, vector_ofFn_getElem_fin]
@@ -609,7 +609,7 @@ with the column index permuted by `perm`: entry `(r, c)` agrees with entry
       (columnTupleMatrix A (columnTupleVectorFn sel))[r][perm[c]] := by
   rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[r][col])
-    (reconstructInjTuple_getElem sel perm c)
+    (getElem_reconstructInjTuple sel perm c)
 
 private theorem columnTupleMatrix_reconstructInjTuple_eq
     {R : Type u} {n m : Nat} (A : Matrix R n m)
@@ -623,7 +623,7 @@ private theorem columnTupleMatrix_reconstructInjTuple_eq
       (columnTupleMatrix A (fun i => sel[perm[i]]))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
   rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[(⟨r, hr⟩ : Fin n)][col])
-    (reconstructInjTuple_getElem sel perm (⟨c, hc⟩ : Fin n))
+    (getElem_reconstructInjTuple sel perm (⟨c, hc⟩ : Fin n))
 
 /-- Reconstructing an injective tuple from a selected tuple and a permutation
 turns the coefficient product into the corresponding determinant product. -/
@@ -637,7 +637,7 @@ theorem columnTupleCoeff_reconstructInjTuple
   intro i _hmem
   rw [getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[i][col])
-    (reconstructInjTuple_getElem sel perm i)
+    (getElem_reconstructInjTuple sel perm i)
 
 /-- Counting how many entries of `List.finRange n` have value `< k`. -/
 private theorem countP_finRange_val_lt :
@@ -688,8 +688,8 @@ theorem reconstructInjTuple_injective {m n : Nat}
   have hperm_inj := permutationVectors_getElem_injective hperm
   -- `hij` is equality of reconstructed entries; extract `sel[perm[i]] = sel[perm[j]]`.
   have hval : sel[perm[i]] = sel[perm[j]] := by
-    have hi := reconstructInjTuple_getElem sel perm i
-    have hj := reconstructInjTuple_getElem sel perm j
+    have hi := getElem_reconstructInjTuple sel perm i
+    have hj := getElem_reconstructInjTuple sel perm j
     have hij' :
         (reconstructInjTuple sel perm)[i] = (reconstructInjTuple sel perm)[j] := hij
     exact hi.symm.trans (hij'.trans hj)
@@ -753,7 +753,7 @@ private theorem columnRankNat_reconstructInjTuple {m n : Nat}
                                    < (reconstructInjTuple sel perm)[i].val)) =
         (fun j : Fin n => decide ((perm[j]).val < (perm[i]).val)) := by
     funext j
-    rw [reconstructInjTuple_getElem, reconstructInjTuple_getElem]
+    rw [getElem_reconstructInjTuple, getElem_reconstructInjTuple]
     exact decide_eq_decide.mpr (isStrictlyIncreasingColumnTuple_val_lt_iff hsel _ _)
   rw [hpred]
   exact permutationVectors_count_val_lt hperm (perm[i])
@@ -809,7 +809,7 @@ theorem sortInjTuple_reconstructInjTuple {m n : Nat}
       hinv_eq
   rw [hstep]
   -- Now: reconstruction at (inv perm)[r] = sel[perm[(inv perm)[r]]] = sel[r].
-  rw [reconstructInjTuple_getElem]
+  rw [getElem_reconstructInjTuple]
   -- Use that perm ∘ inv perm = id (i.e., perm[(inv perm)[r]] = r).
   have hnodup := permutationVectors_nodup hperm
   have hinv_perm : inversePermutationVector perm
@@ -837,7 +837,7 @@ theorem reconstructInjTuple_sortInj {m n : Nat}
   apply Fin.val_eq_of_eq
   let i : Fin n := ⟨k, hk⟩
   show (reconstructInjTuple (sortInjTuple cols) (sortInjPerm cols))[i] = cols[i]
-  rw [reconstructInjTuple_getElem]
+  rw [getElem_reconstructInjTuple]
   exact (cols_getElem_eq_sortInjTuple_sortInjPerm cols hinj i).symm
 
 /-- For each fixed `sel`, the inner `map (reconstructInjTuple sel)` list

--- a/HexGramSchmidt/Basic/IntCast.lean
+++ b/HexGramSchmidt/Basic/IntCast.lean
@@ -114,8 +114,8 @@ private theorem castIntMatrix_rowSwap (b : Matrix Int n m) (i j : Fin n) :
         = ((Matrix.rowSwap b i j)[r][c] : Rat) := by
           simp [GramSchmidt.castIntMatrix]
     _ = (Matrix.rowSwap (GramSchmidt.castIntMatrix b) i j)[r][c] := by
-          rw [Matrix.rowSwap_getElem (M := b) (i := i) (j := j) (r := r) (k := c)]
-          rw [Matrix.rowSwap_getElem (M := GramSchmidt.castIntMatrix b)
+          rw [Matrix.getElem_rowSwap (M := b) (i := i) (j := j) (r := r) (k := c)]
+          rw [Matrix.getElem_rowSwap (M := GramSchmidt.castIntMatrix b)
             (i := i) (j := j) (r := r) (k := c)]
           by_cases hrj : r = j
           · simp [hrj, GramSchmidt.castIntMatrix]

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -646,7 +646,7 @@ private theorem rowSwap_toList_get!_of_lt
   intro idx hidx
   let cc : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b km1 k)[r][cc] = b[r][cc]
-  rw [Matrix.rowSwap_getElem]
+  rw [Matrix.getElem_rowSwap]
   simp [hrk, hrkm1]
 
 /-- `rowSwap_toList_get!_left`: at the lower swapped index `km1`, the swapped matrix
@@ -668,7 +668,7 @@ private theorem rowSwap_toList_get!_left
   intro idx hidx
   let cc : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b km1 k)[km1][cc] = b[k][cc]
-  rw [Matrix.rowSwap_getElem]
+  rw [Matrix.getElem_rowSwap]
   simp [hne]
 
 /-- `rowSwap_toList_get!_right`: at the upper swapped index `k`, the swapped matrix
@@ -687,7 +687,7 @@ private theorem rowSwap_toList_get!_right
   intro idx hidx
   let cc : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b km1 k)[k][cc] = b[km1][cc]
-  rw [Matrix.rowSwap_getElem]
+  rw [Matrix.getElem_rowSwap]
   simp
 
 /-- `rowSwap_toList_get!_of_gt`: reading `toList`/`get!` at an index `t` strictly
@@ -723,7 +723,7 @@ private theorem rowSwap_toList_get!_of_gt
   intro idx hidx
   let cc : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b km1 k)[r][cc] = b[r][cc]
-  rw [Matrix.rowSwap_getElem]
+  rw [Matrix.getElem_rowSwap]
   simp [hrk, hrkm1]
 
 /-- `basisMatrix_rowSwap`: swapping rows `km1` and `k` leaves the
@@ -1747,7 +1747,7 @@ private theorem prefixRows_rowSwap_row_mem_prefixSpan
       let c : Fin m := ⟨col, hcol⟩
       simp [prefixRows, Matrix.row]
       change (Matrix.rowSwap b km1 k)[r][c] = b[k][c]
-      rw [Matrix.rowSwap_getElem]
+      rw [Matrix.getElem_rowSwap]
       simp [hjkm1, hkm1_ne_k]
     rw [hrow]
     exact prefixSpan_mono_le b k.isLt hi hki (prefixSpan_matrix_row b k)
@@ -1761,7 +1761,7 @@ private theorem prefixRows_rowSwap_row_mem_prefixSpan
         let c : Fin m := ⟨col, hcol⟩
         simp [prefixRows, Matrix.row]
         change (Matrix.rowSwap b km1 k)[r][c] = b[km1][c]
-        rw [Matrix.rowSwap_getElem]
+        rw [Matrix.getElem_rowSwap]
         simp [hjk]
       rw [hrow]
       exact prefixSpan_mono_le b km1.isLt hi hkm1_le_i (prefixSpan_matrix_row b km1)
@@ -1773,7 +1773,7 @@ private theorem prefixRows_rowSwap_row_mem_prefixSpan
         let c : Fin m := ⟨col, hcol⟩
         simp [prefixRows, Matrix.row, r]
         change (Matrix.rowSwap b km1 k)[r][c] = b[r][c]
-        rw [Matrix.rowSwap_getElem]
+        rw [Matrix.getElem_rowSwap]
         simp [hjk, hjkm1]
       rw [hrow]
       exact prefixSpan_mono_le b r.isLt hi hrle (prefixSpan_matrix_row b r)

--- a/HexGramSchmidt/Basic/Rat.lean
+++ b/HexGramSchmidt/Basic/Rat.lean
@@ -399,7 +399,7 @@ private theorem rowSwap_row_left (b : Matrix Rat n m) (i j : Fin n) :
   intro idx hidx
   let c : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b i j)[i][c] = b[j][c]
-  rw [Matrix.rowSwap_getElem (M := b) (i := i) (j := j) (r := i) (k := c)]
+  rw [Matrix.getElem_rowSwap (M := b) (i := i) (j := j) (r := i) (k := c)]
   by_cases hij : i = j
   · simp [hij]
   · simp [hij]
@@ -410,7 +410,7 @@ private theorem rowSwap_row_right (b : Matrix Rat n m) (i j : Fin n) :
   intro idx hidx
   let c : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b i j)[j][c] = b[i][c]
-  rw [Matrix.rowSwap_getElem (M := b) (i := i) (j := j) (r := j) (k := c)]
+  rw [Matrix.getElem_rowSwap (M := b) (i := i) (j := j) (r := j) (k := c)]
   simp
 
 private theorem rowSwap_row_eq (b : Matrix Rat n m) (i j r : Fin n)
@@ -420,7 +420,7 @@ private theorem rowSwap_row_eq (b : Matrix Rat n m) (i j r : Fin n)
   intro idx hidx
   let c : Fin m := ⟨idx, hidx⟩
   change (Matrix.rowSwap b i j)[r][c] = b[r][c]
-  rw [Matrix.rowSwap_getElem (M := b) (i := i) (j := j) (r := r) (k := c)]
+  rw [Matrix.getElem_rowSwap (M := b) (i := i) (j := j) (r := r) (k := c)]
   simp [hri, hrj]
 
 /-- After an adjacent swap, the coefficient at the lower row `km1` against an
@@ -860,7 +860,7 @@ private theorem basis_rowSwap_of_after_private (b : Matrix Rat n m) (km1 k i : F
     intro col hcol
     let c : Fin m := ⟨col, hcol⟩
     change (Matrix.rowSwap b km1 k)[i][c] = b[i][c]
-    rw [Matrix.rowSwap_getElem]
+    rw [Matrix.getElem_rowSwap]
     have hik : i ≠ k := by
       intro h
       exact Nat.ne_of_gt hi (congrArg Fin.val h)

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -143,7 +143,7 @@ private theorem rowCombination_bareiss_coeff_update
         x * (M.transpose * c)[jf] - y * (M.transpose * d)[jf] := by
     simp
   rw [h_rhs]
-  repeat rw [Matrix.mulVec_getElem]
+  repeat rw [Matrix.getElem_mulVec]
   exact dot_bareiss_row_update_right x y ((Matrix.transpose M).row jf) c d
 
 /-- `exactDiv_eq_of_eq_mul_right` recovers the right quotient when the exact-division numerator is a quotient times the nonzero denominator. -/

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -50,7 +50,7 @@ private theorem rowCombination_int_getElem
       (List.finRange n).foldl
         (fun (acc : Int) (i : Fin n) => acc + b[i][col] * c[i]) 0 := by
   show (Matrix.transpose b * c)[col] = _
-  rw [Matrix.mulVec_getElem]
+  rw [Matrix.getElem_mulVec]
   show Vector.dotProduct ((Matrix.transpose b).row col) c = _
   simp [Vector.dotProduct, Matrix.row, Matrix.transpose, Matrix.col]
 
@@ -68,7 +68,7 @@ private theorem rowCombination_prefix_castIntMatrix_getElem
             ⟨j.val, Nat.lt_of_lt_of_le j.isLt (Nat.succ_le_of_lt k.isLt)⟩
           acc + (b[jn][col] : Rat) * (c[jn] : Rat)) 0 := by
   show (Matrix.transpose _ * _)[col] = _
-  rw [Matrix.mulVec_getElem]
+  rw [Matrix.getElem_mulVec]
   show Vector.dotProduct ((Matrix.transpose _).row col) _ = _
   simp [Vector.dotProduct, GramSchmidt.prefixRows,
     castIntMatrix, prefixCoeffsCast, Matrix.row, Matrix.transpose, Matrix.col]
@@ -176,7 +176,7 @@ Gram-Schmidt basis rows: `coeffs b * basis b` collapses to the cast input
     have hdecj := congrArg (fun v : Vector Rat m => v[jj]) hdec
     simpa [castIntMatrix, Matrix.row, Vector.getElem_add] using hdecj.symm
   show (coeffs b * basis b)[ii][jj] = (castIntMatrix b)[ii][jj]
-  rw [Matrix.mul_getElem]
+  rw [Matrix.getElem_mul]
   unfold Vector.dotProduct
   let f : Fin n → Rat := fun k => ((coeffs b).row ii)[k] * ((basis b).col jj)[k]
   have hzero : ∀ k : Fin n, i < k.val → f k = 0 := by
@@ -291,7 +291,7 @@ theorem rowCombination_basis_coeffs_reconstruction
     rw [show ((0 : Int) : Rat) = 0 by norm_cast]
     show _ = (Matrix.transpose (castIntMatrix b) *
         Vector.map (fun x : Int => (x : Rat)) c)[jj]
-    rw [Matrix.mulVec_getElem]
+    rw [Matrix.getElem_mulVec]
     simp [Vector.dotProduct, Matrix.row, Matrix.transpose,
       Matrix.col, castIntMatrix]
   rw [hleft, ← hcoeff]
@@ -596,7 +596,7 @@ theorem scaledCoeffMatrix_eq_borderedMinor
             (⟨cc.val, Nat.lt_trans hcj (Nat.lt_trans hji i.isLt)⟩ : Fin n)] := by
         have hpr_not : ¬ pp.val < j.val := Nat.not_lt.mpr (Nat.le_of_eq hpr.symm)
         simp [Matrix.borderedMinor, Matrix.ofFn, Vector.getElem_ofFn, hpr_not, hcj]
-      rw [h_sc, h_bm, Matrix.gramMatrix_getElem]
+      rw [h_sc, h_bm, Matrix.getElem_gramMatrix]
       have hrow : (⟨pp.val, Nat.lt_of_lt_of_le pp.isLt
           (Nat.succ_le_of_lt (Nat.lt_trans hji i.isLt))⟩ : Fin n)
           = ⟨j.val, Nat.lt_trans hji i.isLt⟩ := Fin.ext hpr
@@ -634,7 +634,7 @@ theorem scaledCoeffMatrix_eq_borderedMinor
           (Matrix.gramMatrix b)[(⟨j.val, Nat.lt_trans hji i.isLt⟩ : Fin n)][i] := by
         have hpr_not : ¬ pp.val < j.val := hrj
         simp [Matrix.borderedMinor, Matrix.ofFn, Vector.getElem_ofFn, hpr_not, hcj]
-      rw [h_sc, h_bm, Matrix.gramMatrix_getElem]
+      rw [h_sc, h_bm, Matrix.getElem_gramMatrix]
       have hrow : (⟨pp.val, Nat.lt_of_lt_of_le pp.isLt
           (Nat.succ_le_of_lt (Nat.lt_trans hji i.isLt))⟩ : Fin n)
           = ⟨j.val, Nat.lt_trans hji i.isLt⟩ := Fin.ext hpr_eq
@@ -1970,7 +1970,7 @@ private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
   intro c hc
   have hr_ne_j : r ≠ j := fun h => hrj (congrArg Fin.val h)
   have hr_ne_i : r ≠ i := fun h => hri (congrArg Fin.val h)
-  have hget := Matrix.rowSwap_getElem M i j r ⟨c, hc⟩
+  have hget := Matrix.getElem_rowSwap M i j r ⟨c, hc⟩
   rw [if_neg hr_ne_j, if_neg hr_ne_i] at hget
   simpa [Matrix.row] using hget
 
@@ -1984,10 +1984,10 @@ theorem rowSwap_row_left_int {n' m' : Nat}
   intro c hc
   by_cases hij : i = j
   · subst j
-    have hget := Matrix.rowSwap_getElem M i i i ⟨c, hc⟩
+    have hget := Matrix.getElem_rowSwap M i i i ⟨c, hc⟩
     rw [if_pos rfl] at hget
     exact hget
-  · have hget := Matrix.rowSwap_getElem M i j i ⟨c, hc⟩
+  · have hget := Matrix.getElem_rowSwap M i j i ⟨c, hc⟩
     rw [if_neg hij, if_pos rfl] at hget
     simpa [Matrix.row] using hget
 
@@ -1999,7 +1999,7 @@ theorem rowSwap_row_right_int {n' m' : Nat}
     (Matrix.rowSwap M i j)[j] = M[i] := by
   apply Vector.ext
   intro c hc
-  have hget := Matrix.rowSwap_getElem M i j j ⟨c, hc⟩
+  have hget := Matrix.getElem_rowSwap M i j j ⟨c, hc⟩
   rw [if_pos rfl] at hget
   simpa [Matrix.row] using hget
 
@@ -2024,7 +2024,7 @@ private theorem rowSwap_getRow_left_val_int {n' m' : Nat}
   intro c hc
   let ii : Fin n' := ⟨i.val, hr⟩
   change (Matrix.rowSwap M i j)[ii][c] = M[j][c]
-  have hget := Matrix.rowSwap_getElem M i j ii ⟨c, hc⟩
+  have hget := Matrix.getElem_rowSwap M i j ii ⟨c, hc⟩
   by_cases hij : ii = j
   · have hij' : i = j := by
       apply Fin.ext
@@ -2046,7 +2046,7 @@ private theorem rowSwap_getRow_right_val_int {n' m' : Nat}
   let jj : Fin n' := ⟨j.val, hr⟩
   change (Matrix.rowSwap M i j)[jj][c] = M[i][c]
   have hjj : jj = j := Fin.ext rfl
-  have hget := Matrix.rowSwap_getElem M i j jj ⟨c, hc⟩
+  have hget := Matrix.getElem_rowSwap M i j jj ⟨c, hc⟩
   rw [if_pos hjj] at hget
   simpa [Matrix.row] using hget
 

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -1077,12 +1077,12 @@ theorem rowCombination_coeffs_apply_eq_of_zero_above
         = (List.finRange n).foldl
             (fun acc i => acc + (coeffs b)[i][k] * castc[i]) 0 := by
     show ((coeffs b).transpose * castc)[k] = _
-    rw [Matrix.mulVec_getElem]
+    rw [Matrix.getElem_mulVec]
     show Vector.dotProduct (((coeffs b).transpose).row k) castc = _
     show (List.finRange n).foldl
         (fun acc i =>
           acc + (((coeffs b).transpose).row k)[i] * castc[i]) 0 = _
-    simp only [Matrix.row_getElem, Matrix.transpose_getElem]
+    simp only [Matrix.getElem_row, Matrix.getElem_transpose]
   rw [hcol]
   -- Step 2: drop the tail above `k` via the zero-above truncation helper.
   let f : Fin n → Rat := fun i => (coeffs b)[i][k] * castc[i]

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -365,12 +365,12 @@ private theorem foldl_add_pointwise_eq_int {α : Type v}
 
 /-- Entry-level formula for `rowCombination` over integers: the `j`th entry is
 the sum over `k` of `b[k][j] * c[k]`. -/
-private theorem rowCombination_getElem_int
+private theorem getElem_rowCombination_int
     {n m : Nat} (b : Matrix Int n m) (c : Vector Int n) (j : Fin m) :
     (Matrix.rowCombination b c)[j] =
       (List.finRange n).foldl (fun acc k => acc + b[k][j] * c[k]) 0 := by
   show (Matrix.transpose b * c)[j] = _
-  rw [Matrix.mulVec_getElem]
+  rw [Matrix.getElem_mulVec]
   unfold Vector.dotProduct
   apply foldl_add_pointwise_eq_int
   intro k _hk
@@ -398,7 +398,7 @@ private theorem dot_rowCombination_right_eq
     Vector.dotProduct u (Matrix.rowCombination b c) =
       (List.finRange n).foldl
         (fun acc k => acc + c[k] * Vector.dotProduct u (b.row k)) 0 := by
-  -- Step 1: rewrite each (rowComb b c)[j] entry using rowCombination_getElem_int.
+  -- Step 1: rewrite each (rowComb b c)[j] entry using getElem_rowCombination_int.
   have h_lhs :
       Vector.dotProduct u (Matrix.rowCombination b c) =
         (List.finRange m).foldl
@@ -407,7 +407,7 @@ private theorem dot_rowCombination_right_eq
     unfold Vector.dotProduct
     apply foldl_add_pointwise_eq_int
     intro j _hj
-    rw [rowCombination_getElem_int (b := b) (c := c) j]
+    rw [getElem_rowCombination_int (b := b) (c := c) j]
   rw [h_lhs]
   -- Step 2: distribute u[j] over the inner sum so the body has shape (acc + f j k).
   have h_distrib :
@@ -594,7 +594,7 @@ private theorem principalSubmatrix_gram_zero_pivot_column_zero
           (Matrix.noPivotInitialState (Matrix.gramMatrix b)).matrix[c][a] := by
     intros a c _ha _hc
     show (Matrix.gramMatrix b)[a][c] = (Matrix.gramMatrix b)[c][a]
-    rw [Matrix.gramMatrix_getElem, Matrix.gramMatrix_getElem]
+    rw [Matrix.getElem_gramMatrix, Matrix.getElem_gramMatrix]
     exact int_dot_comm_local (Matrix.row b a) (Matrix.row b c)
   have h_symm :
       (Matrix.noPivotLoop s

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -66,7 +66,7 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
       (castIntDetMatrix
           (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, hjlt⟩ hj))[pp][cc] =
         (Matrix.setCol _ _ _)[pp][cc]
-    rw [Matrix.setCol_getElem, castIntDetMatrix_get]
+    rw [Matrix.getElem_setCol, castIntDetMatrix_get]
     by_cases hc_eq : cc = (⟨j, Nat.lt_succ_self j⟩ : Fin (j + 1))
     · rw [if_pos hc_eq]
       have hc_val : cc.val = j := congrArg Fin.val hc_eq

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -691,7 +691,7 @@ private theorem progressMatrix_succ_eq_colReplace
           (fun acc src =>
             acc + progressMatrixCoeff b k hk s hs src *
               (progressMatrix b k hk s)[i'][src]) 0))[ii][(⟨j, hj⟩ : Fin k)]
-  rw [Matrix.setCol_getElem]
+  rw [Matrix.getElem_setCol]
   -- Case split on Fin k equality.
   by_cases hjs : (⟨j, hj⟩ : Fin k) = (⟨s, hs⟩ : Fin k)
   · -- Column s case.

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -310,7 +310,7 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
           (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] +
             c * (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][jt]
         else (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c)[p][q] := by
-    exact Matrix.colAdd_getElem
+    exact Matrix.getElem_colAdd
       (Matrix.rowAdd (GramSchmidt.leadingGramMatrixInt b t ht) jt kt c) jt kt c p q
   rw [hLHS, hRHS]
   -- Case split on `q = kt` and `p = kt`.

--- a/HexGramSchmidtMathlib/Int/Swap.lean
+++ b/HexGramSchmidtMathlib/Int/Swap.lean
@@ -414,7 +414,7 @@ theorem dot_basis_rowSwap_curr_prev_eq_normSq
     intro idx hidx
     let c : Fin m := ⟨idx, hidx⟩
     change (Matrix.rowSwap b km1 k)[k][c] = b[km1][c]
-    rw [Matrix.rowSwap_getElem]
+    rw [Matrix.getElem_rowSwap]
     simp
   -- prefixCombination of b at km1 vanishes against u_k.
   have hpfx_b_zero :

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -103,7 +103,7 @@ private theorem rowSwap_row_eq_of_ne_int {n' m' : Nat}
   intro idx hidx
   let c : Fin m' := ⟨idx, hidx⟩
   change (Matrix.rowSwap b i j)[r][c] = b[r][c]
-  rw [Matrix.rowSwap_getElem]
+  rw [Matrix.getElem_rowSwap]
   by_cases hrj' : r = j
   · exact absurd hrj' hrj
   · by_cases hri' : r = i
@@ -213,7 +213,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
         (Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k')[qq][pp] := by
     simp [Matrix.transpose, Matrix.col]
   rw [hLHS, hRHS_T]
-  rw [Matrix.rowSwap_getElem (M := (Matrix.rowSwap M km1' k').transpose)
+  rw [Matrix.getElem_rowSwap (M := (Matrix.rowSwap M km1' k').transpose)
     (i := km1') (j := k') (r := qq) (k := pp)]
   have hkm1'_ne_k' : (km1' : Fin t) ≠ k' := by
     intro h
@@ -228,7 +228,7 @@ private theorem leadingGramMatrixInt_rowSwap_inside
     have hT : (Matrix.rowSwap M km1' k').transpose[idx][pp] =
         (Matrix.rowSwap M km1' k')[pp][idx] := by
       simp [Matrix.transpose, Matrix.col]
-    rw [hT, Matrix.rowSwap_getElem (M := M) (i := km1') (j := k') (r := pp) (k := idx)]
+    rw [hT, Matrix.getElem_rowSwap (M := M) (i := km1') (j := k') (r := pp) (k := idx)]
     by_cases hpk : pp = k'
     · simp [hpk]
     · by_cases hpkm1 : pp = km1'

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -248,9 +248,9 @@ theorem dotProduct_packRow (K : Nat) (M : Matrix Int n n) (A : Matrix Int n m)
       (List.finRange n).foldl
         (fun acc l => acc + (row M i)[l] * A[l][(⟨j, hj⟩ : Fin m)])
         ((Vector.replicate m (0 : Int))[(⟨j, hj⟩ : Fin m)]) := by
-    simp only [row_getElem, mul_getElem]
+    simp only [getElem_row, getElem_mul]
     unfold Vector.dotProduct
-    simp only [col_getElem, row_getElem]
+    simp only [getElem_col, getElem_row]
     simp only [Fin.getElem_fin, Vector.getElem_replicate]
   exact hentry.trans htarget.symm
 
@@ -350,10 +350,10 @@ private theorem two_mul_lt_width {x B : Nat} (hx : x ≤ B) :
 theorem natAbs_mul_entry_le (M : Matrix Int n n) (A : Matrix Int n m)
     (i : Fin n) (j : Fin m) :
     (M * A)[i][j].natAbs ≤ n * (maxAbs M * maxAbs A) := by
-  rw [mul_getElem]
+  rw [getElem_mul]
   exact natAbs_dotProduct_le _ _ _ _
     (fun l => natAbs_le_maxAbs M i l)
-    (fun l => by rw [col_getElem]; exact natAbs_le_maxAbs A l j)
+    (fun l => by rw [getElem_col]; exact natAbs_le_maxAbs A l j)
 
 /-- The packed certificate decides product equality: sound (`= true` implies
 `M * A = C`, by balanced-digit uniqueness at width `packWidth M A C`) and

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -318,7 +318,7 @@ private theorem getElem_foldl_add_smul {m' : Nat} (xs : List (Fin m'))
       rw [this]
       ring
 
-private theorem prefixCombination_getElem
+private theorem getElem_prefixCombination
     (C : Hex.Matrix Rat n n) (B : Hex.Matrix Rat n m) (i : Nat) (hi : i < n)
     (l : Fin m) :
     (GramSchmidt.prefixCombination C B i hi)[l] =
@@ -361,7 +361,7 @@ private theorem dot_prefixCombination (u : Vector Rat m)
           GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
             ((B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩)[l] * u[l]) := by
     intro l
-    rw [prefixCombination_getElem, Finset.mul_sum]
+    rw [getElem_prefixCombination, Finset.mul_sum]
     refine Finset.sum_congr rfl fun k _ => ?_
     ring
   simp_rw [this]
@@ -860,7 +860,7 @@ private theorem g_entries (b : Hex.Matrix Int n m) (i : Nat) (hi : i < n)
     exact hj
   rw [getElem!_pos (((Matrix.gramMatrix b).toArray[i]'hi2).toArray) j hj1]
   simp only [Vector.getElem_toArray]
-  simpa using Hex.Matrix.gramMatrix_getElem b ⟨i, hi⟩ ⟨j, hj⟩
+  simpa using Hex.Matrix.getElem_gramMatrix b ⟨i, hi⟩ ⟨j, hj⟩
 
 /-! ### Positivity of the Gram-determinant product -/
 

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -45,7 +45,7 @@ def unit [Zero R] [One R] (i : Fin n) : Vector R n :=
   Vector.ofFn fun j => if i = j then One.one else Zero.zero
 
 /-- Entry formula for a standard basis vector. -/
-@[grind =] theorem unit_getElem [Zero R] [One R] (i j : Fin n) :
+@[grind =] theorem getElem_unit [Zero R] [One R] (i j : Fin n) :
     (unit (R := R) i)[j] = if i = j then One.one else Zero.zero := by
   simp [unit]
 
@@ -69,7 +69,7 @@ def row (M : Matrix R n m) (i : Fin n) : Vector R m :=
   M[i]
 
 /-- Entry access for a selected matrix row. -/
-@[grind =] theorem row_getElem (M : Matrix R n m) (i : Fin n) (j : Fin m) :
+@[grind =] theorem getElem_row (M : Matrix R n m) (i : Fin n) (j : Fin m) :
     (row M i)[j] = M[i][j] := by
   rfl
 
@@ -79,7 +79,7 @@ def col (M : Matrix R n m) (j : Fin m) : Vector R n :=
   Vector.ofFn fun i => M[i][j]
 
 /-- Entry access for a selected matrix column. -/
-@[grind =] theorem col_getElem (M : Matrix R n m) (j : Fin m) (i : Fin n) :
+@[grind =] theorem getElem_col (M : Matrix R n m) (j : Fin m) (i : Fin n) :
     (col M j)[i] = M[i][j] := by
   simp [col]
 
@@ -107,7 +107,7 @@ def setCol (M : Matrix R n m) (dst : Fin m) (v : Fin n → R) : Matrix R n m :=
 
 /-- Entrywise characterization of `setCol`: the destination column is read from
 the replacement function and every other column is read from `M`. -/
-@[grind =] theorem setCol_getElem (M : Matrix R n m) (dst : Fin m) (v : Fin n → R)
+@[grind =] theorem getElem_setCol (M : Matrix R n m) (dst : Fin m) (v : Fin n → R)
     (r : Fin n) (c : Fin m) :
     (setCol M dst v)[r][c] = if c = dst then v r else M[r][c] := by
   simp [setCol, ofFn]
@@ -118,7 +118,7 @@ the replacement function and every other column is read from `M`. -/
   ext r hr c hc
   change (setCol M dst (fun r => M[r][dst]))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin m)] =
     M[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin m)]
-  rw [setCol_getElem]
+  rw [getElem_setCol]
   by_cases hc' : (⟨c, hc⟩ : Fin m) = dst
   · rw [if_pos hc']
     exact congrArg (fun c' : Fin m => M[(⟨r, hr⟩ : Fin n)][c']) hc'.symm
@@ -130,7 +130,7 @@ def transpose (M : Matrix R n m) : Matrix R m n :=
   Vector.ofFn fun j => col M j
 
 /-- Entry access for the transpose of a dense matrix. -/
-@[grind =] theorem transpose_getElem (M : Matrix R n m) (i : Fin m) (j : Fin n) :
+@[grind =] theorem getElem_transpose (M : Matrix R n m) (i : Fin m) (j : Fin n) :
     (transpose M)[i][j] = M[j][i] := by
   simp [transpose, col]
 
@@ -140,7 +140,7 @@ def transpose (M : Matrix R n m) : Matrix R m n :=
   ext i hi j hj
   show (transpose (transpose M))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin m)] =
     M[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin m)]
-  rw [transpose_getElem, transpose_getElem]
+  rw [getElem_transpose, getElem_transpose]
 
 /-- The all-zero matrix. -/
 @[expose]
@@ -177,14 +177,14 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Matrix R m k) (Matri
   hMul := mul
 
 /-- Entry characterization for matrix-vector multiplication. -/
-@[grind =] theorem mulVec_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem getElem_mulVec [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (v : Vector R m) (i : Fin n) :
     (M * v)[i] = Hex.Vector.dotProduct (row M i) v := by
   show (mulVec M v)[i] = Hex.Vector.dotProduct (row M i) v
   simp [mulVec]
 
 /-- Entry characterization for matrix multiplication. -/
-@[grind =] theorem mul_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem getElem_mul [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (N : Matrix R m k) (i : Fin n) (j : Fin k) :
     (M * N)[i][j] = Hex.Vector.dotProduct (row M i) (col N j) := by
   show (mul M N)[i][j] = Hex.Vector.dotProduct (row M i) (col N j)
@@ -201,7 +201,7 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Matrix R m k) (Matri
   ext i hi j hj
   show (Matrix.transpose (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
     (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
-  rw [transpose_getElem, getElem_one, getElem_one]
+  rw [getElem_transpose, getElem_one, getElem_one]
   by_cases hij : (⟨i, hi⟩ : Fin n) = ⟨j, hj⟩
   · have hji : (⟨j, hj⟩ : Fin n) = ⟨i, hi⟩ := hij.symm
     rw [if_pos hij, if_pos hji]

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -36,7 +36,7 @@ def rowSwap (M : Matrix R n m) (i j : Fin n) : Matrix R n m :=
 /-- Read an entry of `rowSwap M i j` by cases on the row index: row `j`
 returns the original row `i`, row `i` returns the original row `j`, and any
 other row is unchanged. -/
-theorem rowSwap_getElem (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
+theorem getElem_rowSwap (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
     (rowSwap M i j)[r][k] =
       if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] := by
   rw [rowSwap]
@@ -49,7 +49,7 @@ theorem rowSwap_getElem (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowSwap M i j) i)[kk] = (row M j)[kk]
-  rw [row_getElem, row_getElem, rowSwap_getElem]
+  rw [getElem_row, getElem_row, getElem_rowSwap]
   by_cases hij : i = j
   · simp [hij]
   · simp [hij]
@@ -60,7 +60,7 @@ theorem rowSwap_getElem (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowSwap M i j) j)[kk] = (row M i)[kk]
-  rw [row_getElem, row_getElem, rowSwap_getElem]
+  rw [getElem_row, getElem_row, getElem_rowSwap]
   simp
 
 /-- Any row other than `i` and `j` is unchanged by `rowSwap M i j`. -/
@@ -70,16 +70,16 @@ theorem row_rowSwap_of_ne (M : Matrix R n m) {i j r : Fin n}
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowSwap M i j) r)[kk] = (row M r)[kk]
-  rw [row_getElem, row_getElem, rowSwap_getElem]
+  rw [getElem_row, getElem_row, getElem_rowSwap]
   simp [hri, hrj]
 
-/-- Diagonal-entry corollary of `rowSwap_getElem` for square matrices: when
+/-- Diagonal-entry corollary of `getElem_rowSwap` for square matrices: when
 `pivot ≠ k`, the `(k, k)` entry of `rowSwap M k pivot` is the original
 `(pivot, k)` entry. -/
 theorem rowSwap_diag_of_ne (M : Matrix R n n) {k pivot : Fin n}
     (h : pivot ≠ k) :
     (rowSwap M k pivot)[k][k] = M[pivot][k] := by
-  rw [rowSwap_getElem]
+  rw [getElem_rowSwap]
   by_cases hkp : k = pivot
   · exact (h hkp.symm).elim
   · simp [hkp]
@@ -96,7 +96,7 @@ def rowScale [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) : Matrix R n m :=
 
 /-- Read an entry of `rowScale M i c` by cases on the row index: row `i`
 returns `c * M[i][k]`, any other row is unchanged. -/
-theorem rowScale_getElem [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : Fin m) :
+theorem getElem_rowScale [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : Fin m) :
     (rowScale M i c)[r][k] =
       if r = i then c * M[i][k] else M[r][k] := by
   by_cases h : r = i
@@ -119,7 +119,7 @@ theorem rowScale_getElem [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : F
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowScale M i c) i)[kk] = (Vector.ofFn (fun k => c * M[i][k]))[kk]
-  rw [row_getElem, rowScale_getElem]
+  rw [getElem_row, getElem_rowScale]
   simp
 
 /-- Any row other than `i` is unchanged by `rowScale M i c`. -/
@@ -129,7 +129,7 @@ theorem row_rowScale_of_ne [Mul R] (M : Matrix R n m) {i r : Fin n} (c : R)
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowScale M i c) r)[kk] = (row M r)[kk]
-  rw [row_getElem, row_getElem, rowScale_getElem]
+  rw [getElem_row, getElem_row, getElem_rowScale]
   simp [hri]
 
 /-- Replace row `dst` by `row dst + c * row src`.
@@ -145,7 +145,7 @@ def rowAdd [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : R) : Matrix
 
 /-- Read an entry of `rowAdd M src dst c` by cases on the row index: row `dst`
 returns `M[dst][k] + c * M[src][k]`, any other row is unchanged. -/
-theorem rowAdd_getElem [Mul R] [Add R]
+theorem getElem_rowAdd [Mul R] [Add R]
     (M : Matrix R n m) (src dst r : Fin n) (c : R) (k : Fin m) :
     (rowAdd M src dst c)[r][k] =
       if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
@@ -165,10 +165,10 @@ theorem rowAdd_getElem [Mul R] [Add R]
     simpa [rowAdd] using congrArg (fun row => row[k]) hrow
 
 /-- Source-row entries are unchanged by `rowAdd M src dst c` when `src ≠ dst`. -/
-theorem rowAdd_getElem_src_of_ne [Mul R] [Add R]
+theorem getElem_rowAdd_src_of_ne [Mul R] [Add R]
     (M : Matrix R n m) {src dst : Fin n} (c : R) (hsrcdst : src ≠ dst) (k : Fin m) :
     (rowAdd M src dst c)[src][k] = M[src][k] := by
-  rw [rowAdd_getElem]
+  rw [getElem_rowAdd]
   simp [hsrcdst]
 
 /-- Row `dst` of `rowAdd M src dst c` is the pointwise row combination. -/
@@ -180,7 +180,7 @@ theorem rowAdd_getElem_src_of_ne [Mul R] [Add R]
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowAdd M src dst c) dst)[kk] =
     (Vector.ofFn (fun k => M[dst][k] + c * M[src][k]))[kk]
-  rw [row_getElem, rowAdd_getElem]
+  rw [getElem_row, getElem_rowAdd]
   simp
 
 /-- Any row other than `dst` is unchanged by `rowAdd M src dst c`. -/
@@ -191,7 +191,7 @@ theorem row_rowAdd_of_ne [Mul R] [Add R]
   ext k hk
   let kk : Fin m := ⟨k, hk⟩
   show (row (rowAdd M src dst c) r)[kk] = (row M r)[kk]
-  rw [row_getElem, row_getElem, rowAdd_getElem]
+  rw [getElem_row, getElem_row, getElem_rowAdd]
   simp [hrdst]
 
 /-- The source row is unchanged by `rowAdd M src dst c` when `src ≠ dst`. -/
@@ -223,7 +223,7 @@ def colAddRight [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin m) (c : R) :
 /-- Read an entry of `colAdd M src dst c` by cases on the column index:
 column `dst` returns `M[i][dst] + c * M[i][src]`, any other column is
 unchanged. -/
-theorem colAdd_getElem [Mul R] [Add R]
+theorem getElem_colAdd [Mul R] [Add R]
     (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) (j : Fin m) :
     (colAdd M src dst c)[i][j] =
       if j = dst then M[i][j] + c * M[i][src] else M[i][j] := by
@@ -234,7 +234,7 @@ theorem colAdd_getElem [Mul R] [Add R]
 /-- Read an entry of `colAddRight M src dst c` by cases on the column index:
 column `dst` returns `M[i][dst] + M[i][src] * c`, any other column is
 unchanged. -/
-theorem colAddRight_getElem [Mul R] [Add R]
+theorem getElem_colAddRight [Mul R] [Add R]
     (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) (j : Fin m) :
     (colAddRight M src dst c)[i][j] =
       if j = dst then M[i][j] + M[i][src] * c else M[i][j] := by
@@ -251,7 +251,7 @@ theorem colAddRight_getElem [Mul R] [Add R]
   let ii : Fin n := ⟨i, hi⟩
   show (col (colAdd M src dst c) dst)[ii] =
     (Vector.ofFn (fun i => M[i][dst] + c * M[i][src]))[ii]
-  rw [col_getElem, colAdd_getElem]
+  rw [getElem_col, getElem_colAdd]
   simp
 
 /-- Column `dst` of `colAddRight M src dst c` is the pointwise column
@@ -264,7 +264,7 @@ combination with right scalar multiplication. -/
   let ii : Fin n := ⟨i, hi⟩
   show (col (colAddRight M src dst c) dst)[ii] =
     (Vector.ofFn (fun i => M[i][dst] + M[i][src] * c))[ii]
-  rw [col_getElem, colAddRight_getElem]
+  rw [getElem_col, getElem_colAddRight]
   simp
 
 /-- Any column other than `dst` is unchanged by `colAdd M src dst c`. -/
@@ -275,7 +275,7 @@ theorem col_colAdd_of_ne [Mul R] [Add R]
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
   show (col (colAdd M src dst c) j)[ii] = (col M j)[ii]
-  rw [col_getElem, col_getElem, colAdd_getElem]
+  rw [getElem_col, getElem_col, getElem_colAdd]
   simp [hjdst]
 
 /-- Any column other than `dst` is unchanged by `colAddRight M src dst c`. -/
@@ -286,22 +286,22 @@ theorem col_colAddRight_of_ne [Mul R] [Add R]
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
   show (col (colAddRight M src dst c) j)[ii] = (col M j)[ii]
-  rw [col_getElem, col_getElem, colAddRight_getElem]
+  rw [getElem_col, getElem_col, getElem_colAddRight]
   simp [hjdst]
 
 /-- Source-column entries are unchanged by `colAdd M src dst c` when `src ≠ dst`. -/
-theorem colAdd_getElem_src_of_ne [Mul R] [Add R]
+theorem getElem_colAdd_src_of_ne [Mul R] [Add R]
     (M : Matrix R n m) {src dst : Fin m} (c : R) (hsrcdst : src ≠ dst) (i : Fin n) :
     (colAdd M src dst c)[i][src] = M[i][src] := by
-  rw [colAdd_getElem]
+  rw [getElem_colAdd]
   simp [hsrcdst]
 
 /-- Source-column entries are unchanged by `colAddRight M src dst c` when
 `src ≠ dst`. -/
-theorem colAddRight_getElem_src_of_ne [Mul R] [Add R]
+theorem getElem_colAddRight_src_of_ne [Mul R] [Add R]
     (M : Matrix R n m) {src dst : Fin m} (c : R) (hsrcdst : src ≠ dst) (i : Fin n) :
     (colAddRight M src dst c)[i][src] = M[i][src] := by
-  rw [colAddRight_getElem]
+  rw [getElem_colAddRight]
   simp [hsrcdst]
 
 /-- The source column is unchanged by `colAdd M src dst c` when `src ≠ dst`. -/

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -101,7 +101,7 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
   | nil => rfl
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [unit_getElem, unit_getElem]
+      rw [getElem_unit, getElem_unit]
       exact ih (acc + (if i = x then 1 else 0) * (if j = x then 1 else 0))
 
 /-- Dot product of standard basis vectors. -/
@@ -135,7 +135,7 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
   ofFn fun i j => Hex.Vector.dotProduct (row M i) (row M j)
 
 /-- Entry characterization for the Gram matrix of the rows of a dense matrix. -/
-@[grind =] theorem gramMatrix_getElem [Mul R] [Add R] [OfNat R 0]
+@[grind =] theorem getElem_gramMatrix [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (i j : Fin n) :
     (gramMatrix M)[i][j] = Hex.Vector.dotProduct (row M i) (row M j) := by
   rw [gramMatrix, getElem_ofFn]
@@ -150,7 +150,7 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
     show ((1 : Matrix R n n).row ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)] =
       (Hex.Vector.unit (R := R) ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
     rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
-      Hex.Vector.unit_getElem (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+      Hex.Vector.getElem_unit (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   have hrow_j : (1 : Matrix R n n).row ⟨j, hj⟩ =
       Hex.Vector.unit (R := R) ⟨j, hj⟩ := by
@@ -158,7 +158,7 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
     show ((1 : Matrix R n n).row ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)] =
       (Hex.Vector.unit (R := R) ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
     rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
-      Hex.Vector.unit_getElem (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+      Hex.Vector.getElem_unit (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   show (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
     (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -277,7 +277,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   let ii : Fin k := ⟨i, hi⟩
   let jj : Fin n := ⟨j, hj⟩
   change (Matrix.transpose (A * B))[ii][jj] = (Matrix.transpose B * Matrix.transpose A)[ii][jj]
-  rw [transpose_getElem]
+  rw [getElem_transpose]
   change (A * B)[jj][ii] = (Matrix.transpose B * Matrix.transpose A)[ii][jj]
   simp [HMul.hMul, mul, row, col, transpose, Hex.Vector.dotProduct, ofFn]
   change

--- a/HexMatrixMathlib/Basic.lean
+++ b/HexMatrixMathlib/Basic.lean
@@ -74,7 +74,7 @@ theorem matrixEquiv_rowSwap (M : Hex.Matrix R n m) (i j : Fin n) :
     matrixEquiv (Hex.Matrix.rowSwap M i j) = Matrix.swap R i j * matrixEquiv M := by
   ext r k
   change (Hex.Matrix.rowSwap M i j)[r][k] = (Matrix.swap R i j * matrixEquiv M) r k
-  rw [Hex.Matrix.rowSwap_getElem]
+  rw [Hex.Matrix.getElem_rowSwap]
   by_cases hrj : r = j
   · subst r
     simp

--- a/HexRowReduce/RREF/Loop.lean
+++ b/HexRowReduce/RREF/Loop.lean
@@ -163,7 +163,7 @@ private theorem rrefCanonicalInvariant_pivot_step
     have hScaled_pivot : scaledEchelon[target][colFin] = 1 := by
       have hEntry : scaledEchelon[target][colFin] = pivotVal⁻¹ * pivotVal := by
         simpa [scaledEchelon, pivotVal] using
-          rowScale_getElem swappedEchelon target target pivotVal⁻¹ colFin
+          getElem_rowScale swappedEchelon target target pivotVal⁻¹ colFin
       rw [hEntry]
       exact Lean.Grind.Field.inv_mul_cancel hpivotVal_ne
     -- eliminateColumn_pivotRow: target's row is unchanged at colFin.
@@ -400,7 +400,7 @@ private theorem rowSwap_zero_column_preserve {M : Matrix R n m}
     (h : ∀ r : Fin n, start ≤ r.val → M[r][k] = 0) :
     ∀ r : Fin n, start ≤ r.val → (rowSwap M i j)[r][k] = 0 := by
   intro r hr
-  rw [rowSwap_getElem]
+  rw [getElem_rowSwap]
   by_cases hrj : r = j
   · subst r; rw [if_pos rfl]; exact h i hi
   · rw [if_neg hrj]
@@ -417,7 +417,7 @@ private theorem rowScale_zero_column_preserve {M : Matrix R n m}
     (h : ∀ r : Fin n, start ≤ r.val → M[r][k] = 0) :
     ∀ r : Fin n, start ≤ r.val → (rowScale M i c)[r][k] = 0 := by
   intro r hr
-  rw [rowScale_getElem]
+  rw [getElem_rowScale]
   by_cases hri : r = i
   · subst r
     rw [if_pos rfl, h i hr]

--- a/HexRowReduce/RREF/Pivot.lean
+++ b/HexRowReduce/RREF/Pivot.lean
@@ -585,7 +585,7 @@ entry into the target row. -/
 private theorem getElem_rowSwap_target_pivot
     (E : Matrix R n m) (target pivot : Fin n) (col : Fin m) :
     (rowSwap E target pivot)[target][col] = E[pivot][col] := by
-  rw [rowSwap_getElem]
+  rw [getElem_rowSwap]
   by_cases h : target = pivot
   · simp [h]
   · simp [h]
@@ -602,10 +602,10 @@ private theorem rowSwap_preserve_canonical_column
     (rowSwap E target pivot)[pivotRow][oldCol] = 1 ∧
       ∀ r : Fin n, r ≠ pivotRow → (rowSwap E target pivot)[r][oldCol] = 0 := by
   constructor
-  · rw [rowSwap_getElem]
+  · rw [getElem_rowSwap]
     simpa [hrowPivot, hrowTarget] using hpivotRow
   · intro r hr
-    rw [rowSwap_getElem]
+    rw [getElem_rowSwap]
     by_cases hrPivot : r = pivot
     · simpa [hrPivot] using hTarget
     · by_cases hrTarget : r = target
@@ -625,10 +625,10 @@ private theorem rowScale_preserve_canonical_column
     (rowScale E target c)[pivotRow][oldCol] = 1 ∧
       ∀ r : Fin n, r ≠ pivotRow → (rowScale E target c)[r][oldCol] = 0 := by
   constructor
-  · rw [rowScale_getElem]
+  · rw [getElem_rowScale]
     simpa [hrowTarget] using hpivotRow
   · intro r hr
-    rw [rowScale_getElem]
+    rw [getElem_rowScale]
     by_cases hrTarget : r = target
     · subst r
       rw [if_pos rfl, hTarget]
@@ -646,14 +646,14 @@ private theorem rowAdd_preserve_canonical_column
     (rowAdd E src dst c)[pivotRow][oldCol] = 1 ∧
       ∀ r : Fin n, r ≠ pivotRow → (rowAdd E src dst c)[r][oldCol] = 0 := by
   constructor
-  · rw [rowAdd_getElem]
+  · rw [getElem_rowAdd]
     by_cases hrowDst : pivotRow = dst
     · subst dst
       rw [if_pos rfl, hpivotRow, hSrc]
       grind
     · simpa [hrowDst] using hpivotRow
   · intro r hr
-    rw [rowAdd_getElem]
+    rw [getElem_rowAdd]
     by_cases hrDst : r = dst
     · subst dst
       rw [if_pos rfl, hzero r hr, hSrc]

--- a/HexRowReduce/RowEchelon.lean
+++ b/HexRowReduce/RowEchelon.lean
@@ -197,33 +197,33 @@ theorem rowSwap_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowSwap A i j) * B)[rr][ll] = (rowSwap (A * B) i j)[rr][ll]
-  rw [mul_getElem (rowSwap A i j) B rr ll, rowSwap_getElem (A * B) i j rr ll]
+  rw [getElem_mul (rowSwap A i j) B rr ll, getElem_rowSwap (A * B) i j rr ll]
   by_cases hrj : rr = j
   · rw [if_pos hrj]
-    rw [mul_getElem A B i ll]
+    rw [getElem_mul A B i ll]
     have hrow : (rowSwap A i j)[rr] = A[i] := by
       ext k' hk
       let kk : Fin m := ⟨k', hk⟩
       show (rowSwap A i j)[rr][kk] = A[i][kk]
-      rw [rowSwap_getElem]; rw [if_pos hrj]
+      rw [getElem_rowSwap]; rw [if_pos hrj]
     rw [show row (rowSwap A i j) rr = row A i by simpa [row] using hrow]
   · rw [if_neg hrj]
     by_cases hri : rr = i
     · rw [if_pos hri]
-      rw [mul_getElem A B j ll]
+      rw [getElem_mul A B j ll]
       have hrow : (rowSwap A i j)[rr] = A[j] := by
         ext k' hk
         let kk : Fin m := ⟨k', hk⟩
         show (rowSwap A i j)[rr][kk] = A[j][kk]
-        rw [rowSwap_getElem]; rw [if_neg hrj, if_pos hri]
+        rw [getElem_rowSwap]; rw [if_neg hrj, if_pos hri]
       rw [show row (rowSwap A i j) rr = row A j by simpa [row] using hrow]
     · rw [if_neg hri]
-      rw [mul_getElem A B rr ll]
+      rw [getElem_mul A B rr ll]
       have hrow : (rowSwap A i j)[rr] = A[rr] := by
         ext k' hk
         let kk : Fin m := ⟨k', hk⟩
         show (rowSwap A i j)[rr][kk] = A[rr][kk]
-        rw [rowSwap_getElem]; rw [if_neg hrj, if_neg hri]
+        rw [getElem_rowSwap]; rw [if_neg hrj, if_neg hri]
       rw [show row (rowSwap A i j) rr = row A rr by simpa [row] using hrow]
 
 /-- Multiplication by `B` commutes with row scaling on the left factor. -/
@@ -234,16 +234,16 @@ theorem rowScale_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowScale A i s) * B)[rr][ll] = (rowScale (A * B) i s)[rr][ll]
-  rw [mul_getElem (rowScale A i s) B rr ll, rowScale_getElem (A * B) i rr s ll]
+  rw [getElem_mul (rowScale A i s) B rr ll, getElem_rowScale (A * B) i rr s ll]
   by_cases hri : rr = i
   · rw [if_pos hri]
-    rw [mul_getElem A B i ll]
+    rw [getElem_mul A B i ll]
     rw [show row (rowScale A i s) rr = Vector.ofFn (fun k' => s * A[i][k']) by
       rw [hri]
       exact row_rowScale_self A i s]
     exact dotProduct_smul_ofFn_left s A[i] (col B ll)
   · rw [if_neg hri]
-    rw [mul_getElem A B rr ll]
+    rw [getElem_mul A B rr ll]
     rw [show row (rowScale A i s) rr = row A rr by
       exact row_rowScale_of_ne A s hri]
 
@@ -256,17 +256,17 @@ theorem rowAdd_mul [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show ((rowAdd A src dst s) * B)[rr][ll] = (rowAdd (A * B) src dst s)[rr][ll]
-  rw [mul_getElem (rowAdd A src dst s) B rr ll, rowAdd_getElem (A * B) src dst rr s ll]
+  rw [getElem_mul (rowAdd A src dst s) B rr ll, getElem_rowAdd (A * B) src dst rr s ll]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [mul_getElem A B dst ll, mul_getElem A B src ll]
+    rw [getElem_mul A B dst ll, getElem_mul A B src ll]
     rw [show row (rowAdd A src dst s) rr =
         Vector.ofFn (fun k' => A[dst][k'] + s * A[src][k']) by
       rw [hrd]
       exact row_rowAdd_dst A src dst s]
     exact dotProduct_add_smul_ofFn_left A[dst] A[src] (col B ll) s
   · rw [if_neg hrd]
-    rw [mul_getElem A B rr ll]
+    rw [getElem_mul A B rr ll]
     rw [show row (rowAdd A src dst s) rr = row A rr by
       exact row_rowAdd_of_ne A src s hrd]
 
@@ -275,19 +275,19 @@ theorem rowSwap_mulVec_getElem [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (v : Vector R m) (i j r : Fin n) :
     (rowSwap M i j * v)[r] =
       if r = j then (M * v)[i] else if r = i then (M * v)[j] else (M * v)[r] := by
-  rw [mulVec_getElem (rowSwap M i j) v r]
+  rw [getElem_mulVec (rowSwap M i j) v r]
   by_cases hrj : r = j
-  · rw [if_pos hrj, mulVec_getElem M v i]
+  · rw [if_pos hrj, getElem_mulVec M v i]
     rw [show row (rowSwap M i j) r = row M i by
       rw [hrj]
       exact row_rowSwap_right M i j]
   · rw [if_neg hrj]
     by_cases hri : r = i
-    · rw [if_pos hri, mulVec_getElem M v j]
+    · rw [if_pos hri, getElem_mulVec M v j]
       rw [show row (rowSwap M i j) r = row M j by
         rw [hri]
         exact row_rowSwap_left M i j]
-    · rw [if_neg hri, mulVec_getElem M v r]
+    · rw [if_neg hri, getElem_mulVec M v r]
       rw [show row (rowSwap M i j) r = row M r by
         exact row_rowSwap_of_ne M hri hrj]
 
@@ -296,14 +296,14 @@ theorem rowScale_mulVec_getElem [Lean.Grind.Ring R]
     (M : Matrix R n m) (v : Vector R m) (i r : Fin n) (s : R) :
     (rowScale M i s * v)[r] =
       if r = i then s * (M * v)[i] else (M * v)[r] := by
-  rw [mulVec_getElem (rowScale M i s) v r]
+  rw [getElem_mulVec (rowScale M i s) v r]
   by_cases hri : r = i
   · subst r
-    rw [if_pos rfl, mulVec_getElem M v i]
+    rw [if_pos rfl, getElem_mulVec M v i]
     rw [show row (rowScale M i s) i = Vector.ofFn (fun k => s * M[i][k]) by
       exact row_rowScale_self M i s]
     exact dotProduct_smul_ofFn_left s M[i] v
-  · rw [if_neg hri, mulVec_getElem M v r]
+  · rw [if_neg hri, getElem_mulVec M v r]
     rw [show row (rowScale M i s) r = row M r by
       exact row_rowScale_of_ne M s hri]
 
@@ -312,15 +312,15 @@ theorem rowAdd_mulVec_getElem [Lean.Grind.Ring R]
     (M : Matrix R n m) (v : Vector R m) (src dst r : Fin n) (s : R) :
     (rowAdd M src dst s * v)[r] =
       if r = dst then (M * v)[dst] + s * (M * v)[src] else (M * v)[r] := by
-  rw [mulVec_getElem (rowAdd M src dst s) v r]
+  rw [getElem_mulVec (rowAdd M src dst s) v r]
   by_cases hrd : r = dst
   · subst r
-    rw [if_pos rfl, mulVec_getElem M v dst, mulVec_getElem M v src]
+    rw [if_pos rfl, getElem_mulVec M v dst, getElem_mulVec M v src]
     rw [show row (rowAdd M src dst s) dst =
         Vector.ofFn (fun k => M[dst][k] + s * M[src][k]) by
       exact row_rowAdd_dst M src dst s]
     exact dotProduct_add_smul_ofFn_left M[dst] M[src] v s
-  · rw [if_neg hrd, mulVec_getElem M v r]
+  · rw [if_neg hrd, getElem_mulVec M v r]
     rw [show row (rowAdd M src dst s) r = row M r by
       exact row_rowAdd_of_ne M src s hrd]
 
@@ -359,20 +359,20 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowSwap (rowSwap M i j) i j)[rr][kk] = M[rr][kk]
-  rw [rowSwap_getElem]
+  rw [getElem_rowSwap]
   by_cases hrj : rr = j
   · rw [if_pos hrj]
-    rw [rowSwap_getElem]
+    rw [getElem_rowSwap]
     by_cases hji : i = j
     · simp [hrj, hji]
     · simp [hrj, hji]
   · rw [if_neg hrj]
     by_cases hri : rr = i
     · rw [if_pos hri]
-      rw [rowSwap_getElem]
+      rw [getElem_rowSwap]
       simp [hri]
     · rw [if_neg hri]
-      rw [rowSwap_getElem, if_neg hrj, if_neg hri]
+      rw [getElem_rowSwap, if_neg hrj, if_neg hri]
 
 /-- Swapping a row with itself leaves the matrix unchanged. -/
 @[simp, grind =] theorem rowSwap_self (M : Matrix R n m) (i : Fin n) :
@@ -381,7 +381,7 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowSwap M i i)[rr][kk] = M[rr][kk]
-  rw [rowSwap_getElem]
+  rw [getElem_rowSwap]
   by_cases hri : rr = i
   · simp [hri]
   · simp [hri]
@@ -394,7 +394,7 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowScale M i 1)[rr][kk] = M[rr][kk]
-  rw [rowScale_getElem]
+  rw [getElem_rowScale]
   by_cases hri : rr = i
   · rw [if_pos hri]
     grind
@@ -408,7 +408,7 @@ theorem rowSwap_rowSwap (M : Matrix R n m) (i j : Fin n) :
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowAdd M src dst 0)[rr][kk] = M[rr][kk]
-  rw [rowAdd_getElem]
+  rw [getElem_rowAdd]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
     grind
@@ -423,13 +423,13 @@ theorem rowScale_rowScale_inv_left [Lean.Grind.Field R]
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowScale (rowScale M i s) i s⁻¹)[rr][kk] = M[rr][kk]
-  rw [rowScale_getElem]
+  rw [getElem_rowScale]
   by_cases hri : rr = i
   · rw [if_pos hri]
-    rw [rowScale_getElem, if_pos rfl]
+    rw [getElem_rowScale, if_pos rfl]
     grind
   · rw [if_neg hri]
-    rw [rowScale_getElem, if_neg hri]
+    rw [getElem_rowScale, if_neg hri]
 
 /-- Scaling a row by `s⁻¹` and then by `s` restores the original matrix when
 `s` is nonzero. -/
@@ -440,13 +440,13 @@ theorem rowScale_rowScale_inv_right [Lean.Grind.Field R]
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowScale (rowScale M i s⁻¹) i s)[rr][kk] = M[rr][kk]
-  rw [rowScale_getElem]
+  rw [getElem_rowScale]
   by_cases hri : rr = i
   · rw [if_pos hri]
-    rw [rowScale_getElem, if_pos rfl]
+    rw [getElem_rowScale, if_pos rfl]
     grind
   · rw [if_neg hri]
-    rw [rowScale_getElem, if_neg hri]
+    rw [getElem_rowScale, if_neg hri]
 
 /-- Adding `s` times a distinct source row to a destination row and then
 adding `-s` times that source row restores the original matrix. -/
@@ -457,15 +457,15 @@ theorem rowAdd_rowAdd_neg [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowAdd (rowAdd M src dst s) src dst (-s))[rr][kk] = M[rr][kk]
-  rw [rowAdd_getElem]
+  rw [getElem_rowAdd]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [rowAdd_getElem, if_pos rfl]
+    rw [getElem_rowAdd, if_pos rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [rowAdd_getElem, if_neg hsrc_ne_dst]
+    rw [getElem_rowAdd, if_neg hsrc_ne_dst]
     grind
   · rw [if_neg hrd]
-    rw [rowAdd_getElem, if_neg hrd]
+    rw [getElem_rowAdd, if_neg hrd]
 
 /-- Adding `-s` times a distinct source row to a destination row and then
 adding `s` times that source row restores the original matrix. -/
@@ -476,15 +476,15 @@ theorem rowAdd_rowAdd_neg_left [Lean.Grind.Ring R]
   let rr : Fin n := ⟨r, hr⟩
   let kk : Fin m := ⟨k, hk⟩
   show (rowAdd (rowAdd M src dst (-s)) src dst s)[rr][kk] = M[rr][kk]
-  rw [rowAdd_getElem]
+  rw [getElem_rowAdd]
   by_cases hrd : rr = dst
   · rw [if_pos hrd]
-    rw [rowAdd_getElem, if_pos rfl]
+    rw [getElem_rowAdd, if_pos rfl]
     have hsrc_ne_dst : src ≠ dst := hsrcdst
-    rw [rowAdd_getElem, if_neg hsrc_ne_dst]
+    rw [getElem_rowAdd, if_neg hsrc_ne_dst]
     grind
   · rw [if_neg hrd]
-    rw [rowAdd_getElem, if_neg hrd]
+    rw [getElem_rowAdd, if_neg hrd]
 
 private theorem leftMul_left_inverse_preserve [Lean.Grind.Ring R]
     {S Sinv T : Matrix R n n} (hSinvS : Sinv * S = 1)
@@ -610,10 +610,10 @@ theorem mul_colAdd [Lean.Grind.CommRing R]
   let rr : Fin n := ⟨r, hr⟩
   let ll : Fin k := ⟨l, hl⟩
   show (A * colAdd B src dst s)[rr][ll] = (colAdd (A * B) src dst s)[rr][ll]
-  rw [mul_getElem A (colAdd B src dst s) rr ll, colAdd_getElem (A * B) src dst s rr ll]
+  rw [getElem_mul A (colAdd B src dst s) rr ll, getElem_colAdd (A * B) src dst s rr ll]
   by_cases hld : ll = dst
   · rw [if_pos hld]
-    rw [hld, mul_getElem A B rr dst, mul_getElem A B rr src]
+    rw [hld, getElem_mul A B rr dst, getElem_mul A B rr src]
     rw [show col (colAdd B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + s * B[i][src]) by
       exact col_colAdd_dst B src dst s]
@@ -621,7 +621,7 @@ theorem mul_colAdd [Lean.Grind.CommRing R]
       dotProduct_add_smul_ofFn_right (row A rr)
         (Vector.ofFn fun i => B[i][dst]) (Vector.ofFn fun i => B[i][src]) s
   · rw [if_neg hld]
-    rw [mul_getElem A B rr ll]
+    rw [getElem_mul A B rr ll]
     rw [show col (colAdd B src dst s) ll = col B ll by
       exact col_colAdd_of_ne B src s hld]
 
@@ -636,17 +636,17 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   let ll : Fin k := ⟨l, hl⟩
   show (A * colAddRight B src dst s)[rr][ll] =
     (colAddRight (A * B) src dst s)[rr][ll]
-  rw [mul_getElem A (colAddRight B src dst s) rr ll, colAddRight_getElem (A * B) src dst s rr ll]
+  rw [getElem_mul A (colAddRight B src dst s) rr ll, getElem_colAddRight (A * B) src dst s rr ll]
   by_cases hld : ll = dst
   · rw [if_pos hld]
-    rw [hld, mul_getElem A B rr dst, mul_getElem A B rr src]
+    rw [hld, getElem_mul A B rr dst, getElem_mul A B rr src]
     rw [show col (colAddRight B src dst s) dst =
         Vector.ofFn (fun i => B[i][dst] + B[i][src] * s) by
       exact col_colAddRight_dst B src dst s]
     simpa [col] using
       dotProduct_add_smulRight_ofFn_right (row A rr) (col B dst) (col B src) s
   · rw [if_neg hld]
-    rw [mul_getElem A B rr ll]
+    rw [getElem_mul A B rr ll]
     rw [show col (colAddRight B src dst s) ll = col B ll by
       exact col_colAddRight_of_ne B src s hld]
 
@@ -658,7 +658,7 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
   show (colAdd M src dst 0)[ii][jj] = M[ii][jj]
-  rw [colAdd_getElem]
+  rw [getElem_colAdd]
   by_cases hjd : jj = dst
   · rw [if_pos hjd]
     grind
@@ -672,7 +672,7 @@ theorem mul_colAddRight [Lean.Grind.Ring R]
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
   show (colAddRight M src dst 0)[ii][jj] = M[ii][jj]
-  rw [colAddRight_getElem]
+  rw [getElem_colAddRight]
   by_cases hjd : jj = dst
   · rw [if_pos hjd]
     grind


### PR DESCRIPTION
This PR renames the matrix and word-array element-access lemmas from the `<op>_getElem` suffix form to the `getElem_<op>` prefix form, matching the lean4 `Vector`/`Array`/`List` convention of naming a lemma by the head symbol of its left-hand side. For a lemma whose left-hand side is `(rowScale M i c)[r][k] = …`, the head symbol is `getElem`, so the canonical name is `getElem_rowScale`, not `rowScale_getElem`. lean4 reserves the `_getElem` suffix for lemmas where `getElem` is *not* the head (`ext_getElem`, `getD_getElem`, `idxOf_getElem`); those, along with the no-op `setIfInBounds_getElem`, are left untouched here.

The renamed declarations span the matrix elementary operations (`getElem_row`, `getElem_col`, `getElem_mul`, `getElem_mulVec`, `getElem_transpose`, `getElem_setCol`, `getElem_gramMatrix`, `getElem_unit`, `getElem_rowSwap`, `getElem_rowScale`, `getElem_rowAdd`, `getElem_colAdd`, `getElem_colAddRight`), the GF(2) word-array helpers (`getElem_wordBitAt`, `getElem_xorWords`, `getElem_mulWords`, `getElem_normalizeWords`, `getElem_xorClmulAt`), and a handful of determinant/Gram-Schmidt helpers (`getElem_reconstructInjTuple`, `getElem_scalarDividedDifferenceCoeffs`, `getElem_prefixCombination`, `getElem_rowCombination`). Trailing qualifiers ride along unchanged, e.g. `rowSwap_getElem_of_ne` becomes `getElem_rowSwap_of_ne`. The change is a pure mechanical rename across the whole monorepo; no statements or proofs are altered.

🤖 Prepared with Claude Code
