### PR TITLE
refactor: move vector operations to the root Vector namespace

### DIFF
--- a/HexBerlekamp/Basic.lean
+++ b/HexBerlekamp/Basic.lean
@@ -290,7 +290,7 @@ private theorem coeffVector_matrixActionPolySum_eq_mulVec
         FpPoly.powModMonic (FpPoly.frobeniusXMod f hmonic) f hmonic j.val)
       0 i]
   rw [DensePoly.coeff_zero]
-  simp [HMul.hMul, Matrix.mulVec, Vector.dotProduct, Matrix.row, Hex.Vector.dotProduct]
+  simp [HMul.hMul, Matrix.mulVec, Vector.dotProduct, Matrix.row, Vector.dotProduct]
   apply foldl_add_congr
   intro j _hj
   show (DensePoly.C (w.coeff j.val) *

--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -142,11 +142,11 @@ theorem mul_adjugate_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       if i = j then det M else 0 := by
   have hmul :
       (M * adjugate M)[i][j] =
-        Hex.Vector.dotProduct (row M i) (col (adjugate M) j) := by
+        (row M i).dotProduct (col (adjugate M) j) := by
     change (Matrix.mul M (adjugate M))[i][j] = _
     unfold Matrix.mul
     show
-      (ofFn fun i j => Hex.Vector.dotProduct (row M i) (col (adjugate M) j))[i][j] =
+      (ofFn fun i j => (row M i).dotProduct (col (adjugate M) j))[i][j] =
         _
     simp [ofFn]
   have hentry :
@@ -154,7 +154,7 @@ theorem mul_adjugate_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         (List.finRange (n + 1)).foldl
           (fun acc k => acc + M[i][k] * cofactor M j k) 0 := by
     rw [hmul]
-    unfold Hex.Vector.dotProduct
+    unfold Vector.dotProduct
     apply foldl_acc_congr
     intro acc k _hmem
     congr 1
@@ -187,7 +187,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       change (Matrix.mul (adjugate M) M)[i][j] = _
       unfold Matrix.mul
       rw [getElem_ofFn]
-      unfold Hex.Vector.dotProduct
+      unfold Vector.dotProduct
       apply foldl_acc_congr
       intro acc k _hmem
       have hrow : (row (adjugate M) i)[k] = (adjugate M)[i][k] := rfl
@@ -201,7 +201,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       change (Matrix.mul M.transpose (adjugate M.transpose))[j][i] = _
       unfold Matrix.mul
       rw [getElem_ofFn]
-      unfold Hex.Vector.dotProduct
+      unfold Vector.dotProduct
       apply foldl_acc_congr
       intro acc k _hmem
       have hrow : (row M.transpose j)[k] = M[k][j] := by
@@ -339,7 +339,7 @@ private theorem mul_eq_columnSumMatrix_transpose
   change (Matrix.mul M N)[rr][cc] = _
   unfold Matrix.mul ofFn
   rw [vector_ofFn_getElem_fin, vector_ofFn_getElem_fin]
-  unfold Hex.Vector.dotProduct
+  unfold Vector.dotProduct
   apply foldl_det_sum_congr
   intro k _
   have hrow : (row M rr)[k] = M[rr][k] := by simp [row]
@@ -462,7 +462,7 @@ private theorem mul_apply_foldl
   change (Matrix.mul A B)[i][j] = _
   unfold Matrix.mul
   rw [getElem_ofFn]
-  unfold Hex.Vector.dotProduct
+  unfold Vector.dotProduct
   apply foldl_acc_congr
   intro acc l _hmem
   rw [getElem_row, getElem_col]

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -849,7 +849,7 @@ theorem det_gramMatrix_eq_sum_columnTuples
     change (gramMatrix A)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix A A)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
     rw [getElem_columnSumMatrix]
-    simp [gramMatrix, ofFn, row, Hex.Vector.dotProduct]
+    simp [gramMatrix, ofFn, row, Vector.dotProduct]
     apply foldl_det_sum_congr
     intro k _hk
     exact Lean.Grind.CommSemiring.mul_comm A[(⟨r, hr⟩ : Fin n)][k] A[(⟨c, hc⟩ : Fin n)][k]

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -1065,8 +1065,8 @@ theorem mDet_smul_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
 /-- Numeric entry form for the standard basis vector. -/
 private theorem getElem_unit_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (q : Fin (n + 2)) (i : Fin (n + 2)) :
-    (Hex.Vector.unit (R := R) q)[i] = if i = q then (1 : R) else (0 : R) := by
-  rw [Hex.Vector.getElem_unit]
+    (Vector.unit (R := R) q)[i] = if i = q then (1 : R) else (0 : R) := by
+  rw [Vector.getElem_unit]
   by_cases h : i = q
   · rw [if_pos h.symm, if_pos h]
     rfl
@@ -1091,7 +1091,7 @@ theorem skipIndex_at_q_minus_one_eq_q_of_lt {n : Nat}
 /-- For `p < q`, the chained skip `skipIndex p ∘ skipIndex r_q`
 (where `r_q = q.val - 1`) equals `skipIndex2 p q hpq`. This is the
 row-reindexing identity used to recover the `n × n` minor of `B` from
-the deleted-row-and-last-column minor of `mMatrix B (Hex.Vector.unit q) p`. -/
+the deleted-row-and-last-column minor of `mMatrix B (Vector.unit q) p`. -/
 theorem skipIndex_skipIndex_eq_skipIndex2_of_lt {n : Nat}
     (p q : Fin (n + 2)) (hpq : p.val < q.val) (i : Fin n) :
     skipIndex p
@@ -1149,18 +1149,18 @@ private theorem foldl_unit_weighted_single
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (q : Fin (n + 2)) (f : Fin (n + 2) → R) :
     (List.finRange (n + 2)).foldl
-        (fun acc p => acc + (Hex.Vector.unit (R := R) q)[p] * f p) 0 =
+        (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
       f q := by
   have hfold :=
     foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R) q
-      (fun p => (Hex.Vector.unit (R := R) q)[p] * f p)
+      (fun p => (Vector.unit (R := R) q)[p] * f p)
       (List.mem_finRange q) (List.nodup_finRange (n + 2))
   have hcongr :
       (List.finRange (n + 2)).foldl
-          (fun acc p => acc + (Hex.Vector.unit (R := R) q)[p] * f p) 0 =
+          (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
         (List.finRange (n + 2)).foldl
           (fun acc p =>
-            acc + if p = q then (Hex.Vector.unit (R := R) q)[p] * f p else 0) 0 := by
+            acc + if p = q then (Vector.unit (R := R) q)[p] * f p else 0) 0 := by
     apply foldl_acc_congr
     intro acc p _hmem
     by_cases hp : p = q
@@ -1170,11 +1170,11 @@ private theorem foldl_unit_weighted_single
       grind
   calc
     (List.finRange (n + 2)).foldl
-        (fun acc p => acc + (Hex.Vector.unit (R := R) q)[p] * f p) 0 =
+        (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
       (List.finRange (n + 2)).foldl
         (fun acc p =>
-          acc + if p = q then (Hex.Vector.unit (R := R) q)[p] * f p else 0) 0 := hcongr
-    _ = 0 + (Hex.Vector.unit (R := R) q)[q] * f q := hfold
+          acc + if p = q then (Vector.unit (R := R) q)[p] * f p else 0) 0 := hcongr
+    _ = 0 + (Vector.unit (R := R) q)[q] * f q := hfold
     _ = f q := by
       rw [getElem_unit_num, if_pos rfl]
       grind
@@ -1185,27 +1185,27 @@ theorem mDet_eq_sum_unit
     (B : Matrix R (n + 2) n) (v : Vector R (n + 2)) (p : Fin (n + 2)) :
     mDet B v p =
       (List.finRange (n + 2)).foldl
-        (fun acc q => acc + v[q] * mDet B (Hex.Vector.unit (R := R) q) p) 0 := by
+        (fun acc q => acc + v[q] * mDet B (Vector.unit (R := R) q) p) 0 := by
   unfold mDet
   rw [mMatrix_eq_setCol_last B v v p]
   have hcol :
       (fun i : Fin (n + 1) => v[skipIndex p i]) =
         fun i : Fin (n + 1) =>
           (List.finRange (n + 2)).foldl
-            (fun acc q => acc + v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i]) 0 := by
+            (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 := by
     funext i
     have hfold :=
       foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R)
         (skipIndex p i)
-        (fun q => v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i])
+        (fun q => v[q] * (Vector.unit (R := R) q)[skipIndex p i])
         (List.mem_finRange (skipIndex p i)) (List.nodup_finRange (n + 2))
     have hcongr :
         (List.finRange (n + 2)).foldl
-            (fun acc q => acc + v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i]) 0 =
+            (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 =
           (List.finRange (n + 2)).foldl
             (fun acc q =>
               acc + if q = skipIndex p i then
-                v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := by
+                v[q] * (Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := by
       apply foldl_acc_congr
       intro acc q _hmem
       by_cases hq : q = skipIndex p i
@@ -1216,19 +1216,19 @@ theorem mDet_eq_sum_unit
     symm
     calc
       (List.finRange (n + 2)).foldl
-          (fun acc q => acc + v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i]) 0 =
+          (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 =
         (List.finRange (n + 2)).foldl
           (fun acc q =>
             acc + if q = skipIndex p i then
-              v[q] * (Hex.Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := hcongr
-      _ = 0 + v[skipIndex p i] * (Hex.Vector.unit (R := R) (skipIndex p i))[skipIndex p i] := hfold
+              v[q] * (Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := hcongr
+      _ = 0 + v[skipIndex p i] * (Vector.unit (R := R) (skipIndex p i))[skipIndex p i] := hfold
       _ = v[skipIndex p i] := by
         rw [getElem_unit_num, if_pos rfl]
         grind
   rw [hcol, det_setCol_sum_finRange]
   apply foldl_acc_congr
   intro acc q _hmem
-  rw [← mMatrix_eq_setCol_last B (Hex.Vector.unit (R := R) q) v p]
+  rw [← mMatrix_eq_setCol_last B (Vector.unit (R := R) q) v p]
 
 /-- Laplace expansion specialized to a column equal to a standard basis
 vector: if column `c` of `M` holds `1` at row `q` and `0` elsewhere, then
@@ -1396,21 +1396,21 @@ theorem deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt
 
 /-- Basis-vector evaluation of `mDet` when `q < p`: the basis vector
 `e_q` becomes the standard basis vector `e_{q.val}` in the last
-column of `mMatrix B (Hex.Vector.unit q) p`, so Laplace along that column
+column of `mMatrix B (Vector.unit q) p`, so Laplace along that column
 recovers a signed `n × n` minor of `B`. -/
 theorem mDet_unit_eq_signed_nDet_of_gt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hqp : q.val < p.val) :
-    mDet B (Hex.Vector.unit (R := R) q) p =
+    mDet B (Vector.unit (R := R) q) p =
       cofactorSign (R := R)
         (⟨q.val, by have := p.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
       nDet B q p hqp := by
   unfold mDet
   let r_q : Fin (n + 1) := ⟨q.val, by have := p.isLt; omega⟩
-  show (mMatrix B (Hex.Vector.unit (R := R) q) p).det =
+  show (mMatrix B (Vector.unit (R := R) q) p).det =
       cofactorSign (R := R) r_q (Fin.last n) * nDet B q p hqp
   have hcol : ∀ r : Fin (n + 1),
-      (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
+      (mMatrix B (Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
     rw [mMatrix_entry_last, getElem_unit_num]
@@ -1429,32 +1429,32 @@ theorem mDet_unit_eq_signed_nDet_of_gt
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
       exact if_neg hne
-  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Hex.Vector.unit (R := R) q) p) r_q
+  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit (R := R) q) p) r_q
         (Fin.last n) hcol]
   congr 1
   unfold nDet
   exact congrArg det
     (deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt B
-      (Hex.Vector.unit (R := R) q) p q hqp)
+      (Vector.unit (R := R) q) p q hqp)
 
 /-- Basis-vector evaluation of `mDet` when `q > p`: the basis vector
 `e_q` becomes the standard basis vector `e_{q.val - 1}` in the last
-column of `mMatrix B (Hex.Vector.unit q) p`, so Laplace along that column
+column of `mMatrix B (Vector.unit q) p`, so Laplace along that column
 recovers a signed `n × n` minor of `B`. -/
 theorem mDet_unit_eq_signed_nDet_of_lt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hpq : p.val < q.val) :
-    mDet B (Hex.Vector.unit (R := R) q) p =
+    mDet B (Vector.unit (R := R) q) p =
       cofactorSign (R := R)
         (⟨q.val - 1, by have := q.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
       nDet B p q hpq := by
   unfold mDet
-  -- Last column of `mMatrix B (Hex.Vector.unit q) p` is e_{r_q} where r_q = q.val - 1.
+  -- Last column of `mMatrix B (Vector.unit q) p` is e_{r_q} where r_q = q.val - 1.
   let r_q : Fin (n + 1) := ⟨q.val - 1, by have := q.isLt; omega⟩
-  show (mMatrix B (Hex.Vector.unit (R := R) q) p).det =
+  show (mMatrix B (Vector.unit (R := R) q) p).det =
       cofactorSign (R := R) r_q (Fin.last n) * nDet B p q hpq
   have hcol : ∀ r : Fin (n + 1),
-      (mMatrix B (Hex.Vector.unit (R := R) q) p)[r][Fin.last n] =
+      (mMatrix B (Vector.unit (R := R) q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
     rw [mMatrix_entry_last, getElem_unit_num]
@@ -1475,30 +1475,30 @@ theorem mDet_unit_eq_signed_nDet_of_lt
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
       exact if_neg hne
-  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Hex.Vector.unit (R := R) q) p) r_q
+  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit (R := R) q) p) r_q
         (Fin.last n) hcol]
   congr 1
   unfold nDet
   exact congrArg det
     (deleteRowCol_mMatrix_at_q_minus_one_eq_nMatrix_of_lt B
-      (Hex.Vector.unit (R := R) q) p q hpq)
+      (Vector.unit (R := R) q) p q hpq)
 
-/-- `mDet B (Hex.Vector.unit p) p = 0`: the basis vector `e_p` becomes the zero
-column inside `mMatrix B (Hex.Vector.unit p) p` after row `p` is deleted, so
+/-- `mDet B (Vector.unit p) p = 0`: the basis vector `e_p` becomes the zero
+column inside `mMatrix B (Vector.unit p) p` after row `p` is deleted, so
 the determinant vanishes. -/
 theorem mDet_unit_eq_zero_of_eq {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (B : Matrix R (n + 2) n) (p : Fin (n + 2)) :
-    mDet B (Hex.Vector.unit (R := R) p) p = 0 := by
+    mDet B (Vector.unit (R := R) p) p = 0 := by
   unfold mDet
-  -- The last column of `mMatrix B (Hex.Vector.unit p) p` is identically zero.
+  -- The last column of `mMatrix B (Vector.unit p) p` is identically zero.
   have hcol : (fun r : Fin (n + 1) =>
-      (Hex.Vector.unit (R := R) p)[skipIndex p r]) = (fun _ => (0 : R)) := by
+      (Vector.unit (R := R) p)[skipIndex p r]) = (fun _ => (0 : R)) := by
     funext r
     rw [getElem_unit_num]
     exact if_neg (skipIndex_ne p r)
   -- Express mMatrix as setCol with that zero function on the last column.
-  rw [mMatrix_eq_setCol_last B (Hex.Vector.unit (R := R) p)
-        (Hex.Vector.unit (R := R) p) p]
+  rw [mMatrix_eq_setCol_last B (Vector.unit (R := R) p)
+        (Vector.unit (R := R) p) p]
   rw [hcol]
   exact det_setCol_zero _ _
 
@@ -1507,7 +1507,7 @@ surviving ordered pair is the deleted-row pair `(a, b)`. -/
 theorem twoColDet_unit_unit_of_lt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a b : Fin (n + 2)) (hab : a.val < b.val) :
-    twoColDet B (Hex.Vector.unit (R := R) a) (Hex.Vector.unit (R := R) b) =
+    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) *
         (cofactorSign (R := R)
           (⟨a.val, by have := b.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
@@ -1515,7 +1515,7 @@ theorem twoColDet_unit_unit_of_lt
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Hex.Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit (R := R) a) p)]
   rw [mDet_unit_eq_signed_nDet_of_gt B b a hab]
 
 /-- Reverse ordered basis-pair evaluation for `twoColDet`: if `b < a`,
@@ -1524,7 +1524,7 @@ coefficient order. -/
 theorem twoColDet_unit_unit_of_gt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a b : Fin (n + 2)) (hba : b.val < a.val) :
-    twoColDet B (Hex.Vector.unit (R := R) a) (Hex.Vector.unit (R := R) b) =
+    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) *
         (cofactorSign (R := R)
           (⟨a.val - 1, by have := a.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
@@ -1532,7 +1532,7 @@ theorem twoColDet_unit_unit_of_gt
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Hex.Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit (R := R) a) p)]
   rw [mDet_unit_eq_signed_nDet_of_lt B b a hba]
 
 /-- A repeated basis vector in the two appended columns makes
@@ -1540,11 +1540,11 @@ theorem twoColDet_unit_unit_of_gt
 theorem twoColDet_unit_unit_of_eq
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a : Fin (n + 2)) :
-    twoColDet B (Hex.Vector.unit (R := R) a) (Hex.Vector.unit (R := R) a) = 0 := by
+    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) a) = 0 := by
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) a
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Hex.Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit (R := R) a) p)]
   rw [mDet_unit_eq_zero_of_eq B a]
   grind
 
@@ -1554,7 +1554,7 @@ vector. This is the one-column Laplace expansion with the remaining
 theorem twoColDet_unit_right
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (u : Vector R (n + 2)) (b : Fin (n + 2)) :
-    twoColDet B u (Hex.Vector.unit (R := R) b) =
+    twoColDet B u (Vector.unit (R := R) b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) * mDet B u b := by
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
@@ -1574,8 +1574,8 @@ theorem twoColDet_eq_sum_unit_pairs
           acc + v[b] *
             (List.finRange (n + 2)).foldl
               (fun acc a =>
-                acc + u[a] * twoColDet B (Hex.Vector.unit (R := R) a)
-                  (Hex.Vector.unit (R := R) b)) 0) 0 := by
+                acc + u[a] * twoColDet B (Vector.unit (R := R) a)
+                  (Vector.unit (R := R) b)) 0) 0 := by
   rw [twoColDet_eq_sum_mDet]
   apply foldl_acc_congr
   intro acc b _hmem
@@ -1584,20 +1584,20 @@ theorem twoColDet_eq_sum_unit_pairs
   calc
     cofactorSign (R := R) b (Fin.last (n + 1)) *
         (List.finRange (n + 2)).foldl
-          (fun acc a => acc + u[a] * mDet B (Hex.Vector.unit (R := R) a) b) 0 =
+          (fun acc a => acc + u[a] * mDet B (Vector.unit (R := R) a) b) 0 =
       (List.finRange (n + 2)).foldl
         (fun acc a =>
           acc + cofactorSign (R := R) b (Fin.last (n + 1)) *
-            (u[a] * mDet B (Hex.Vector.unit (R := R) a) b)) 0 := by
+            (u[a] * mDet B (Vector.unit (R := R) a) b)) 0 := by
         rw [foldl_det_sum_mul_left_zero]
     _ =
       (List.finRange (n + 2)).foldl
         (fun acc a =>
-          acc + u[a] * twoColDet B (Hex.Vector.unit (R := R) a)
-            (Hex.Vector.unit (R := R) b)) 0 := by
+          acc + u[a] * twoColDet B (Vector.unit (R := R) a)
+            (Vector.unit (R := R) b)) 0 := by
         apply foldl_det_sum_congr
         intro a _ha
-        rw [twoColDet_unit_right B (Hex.Vector.unit (R := R) a) b]
+        rw [twoColDet_unit_right B (Vector.unit (R := R) a) b]
         grind
 
 private theorem cofactorSign_consecutive_last_neg
@@ -1619,10 +1619,10 @@ private theorem det_plucker_three_term_unit_of_eq_p1
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Hex.Vector.unit (R := R) p1) p1 * nDet B p2 p3 h23 -
-      mDet B (Hex.Vector.unit (R := R) p1) p2 *
+    mDet B (Vector.unit (R := R) p1) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit (R := R) p1) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Hex.Vector.unit (R := R) p1) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit (R := R) p1) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_zero_of_eq B p1, mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
     mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
   grind
@@ -1632,10 +1632,10 @@ private theorem det_plucker_three_term_unit_of_eq_p2
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Hex.Vector.unit (R := R) p2) p1 * nDet B p2 p3 h23 -
-      mDet B (Hex.Vector.unit (R := R) p2) p2 *
+    mDet B (Vector.unit (R := R) p2) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit (R := R) p2) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Hex.Vector.unit (R := R) p2) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit (R := R) p2) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12, mDet_unit_eq_zero_of_eq B p2,
     mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
   have hp2pos : 0 < p2.val := by omega
@@ -1655,10 +1655,10 @@ private theorem det_plucker_three_term_unit_of_eq_p3
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Hex.Vector.unit (R := R) p3) p1 * nDet B p2 p3 h23 -
-      mDet B (Hex.Vector.unit (R := R) p3) p2 *
+    mDet B (Vector.unit (R := R) p3) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit (R := R) p3) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Hex.Vector.unit (R := R) p3) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit (R := R) p3) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
     mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, mDet_unit_eq_zero_of_eq B p3]
   grind
@@ -1669,30 +1669,30 @@ private theorem det_plucker_three_term_of_unit
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hbasis : ∀ q : Fin (n + 2),
-      mDet B (Hex.Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-        mDet B (Hex.Vector.unit (R := R) q) p2 *
+      mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
+        mDet B (Vector.unit (R := R) q) p2 *
           nDet B p1 p3 (Nat.lt_trans h12 h23) +
-        mDet B (Hex.Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0) :
+        mDet B (Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0) :
     mDet B v p1 * nDet B p2 p3 h23 -
       mDet B v p2 * nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B v p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_eq_sum_unit B v p1, mDet_eq_sum_unit B v p2, mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p1)
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p1)
       (nDet B p2 p3 h23)]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p2)
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p2)
       (nDet B p1 p3 (Nat.lt_trans h12 h23))]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p3)
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p3)
       (nDet B p1 p2 h12)]
   apply foldl_det_sum_sub_add_zero
       (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p1 *
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p1 *
         nDet B p2 p3 h23)
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p2 *
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23))
-      (fun q => v[q] * mDet B (Hex.Vector.unit (R := R) q) p3 *
+      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p3 *
         nDet B p1 p2 h12)
   · grind
   · intro q _hq
@@ -1822,17 +1822,17 @@ private theorem det_plucker_three_term_nDet_of_lt_p1
   nDet_plucker_four_row_canonical B q p1 p2 p3 hq1 h12 h23
 
 /-- Basis-vector case `q < p1` of the three-term Plucker identity:
-expanding `mDet B (Hex.Vector.unit q) p_i` via `mDet_unit_eq_signed_nDet_of_gt`
+expanding `mDet B (Vector.unit q) p_i` via `mDet_unit_eq_signed_nDet_of_gt`
 (each `q < p_i`) reduces the goal to the raw q-before `nDet` kernel. -/
 private theorem det_plucker_three_term_unit_of_lt_p1_of_nDet
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n)
     (q p1 p2 p3 : Fin (n + 2))
     (hq1 : q.val < p1.val) (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Hex.Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-      mDet B (Hex.Vector.unit (R := R) q) p2 *
+    mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit (R := R) q) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Hex.Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0 := by
   have hraw := det_plucker_three_term_nDet_of_lt_p1 B q p1 p2 p3 hq1 h12 h23
   rw [mDet_unit_eq_signed_nDet_of_gt B p1 q hq1,
     mDet_unit_eq_signed_nDet_of_gt B p2 q (Nat.lt_trans hq1 h12)]
@@ -1849,10 +1849,10 @@ private theorem det_plucker_three_term_unit_of_between_p1_p2_of_nDet
     (B : Matrix R (n + 2) n)
     (p1 q p2 p3 : Fin (n + 2))
     (h1q : p1.val < q.val) (hq2 : q.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Hex.Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-      mDet B (Hex.Vector.unit (R := R) q) p2 *
+    mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit (R := R) q) p2 *
         nDet B p1 p3 (Nat.lt_trans (Nat.lt_trans h1q hq2) h23) +
-      mDet B (Hex.Vector.unit (R := R) q) p3 *
+      mDet B (Vector.unit (R := R) q) p3 *
         nDet B p1 p2 (Nat.lt_trans h1q hq2) = 0 := by
   have hraw :=
     det_plucker_three_term_nDet_of_between_p1_p2 B p1 q p2 p3 h1q hq2 h23

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -532,11 +532,11 @@ private theorem det_plucker_three_term_basisVec_of_lt_p1
     {R : Type u} [CommRing R] {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (hq1 : q.val < p1.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have hq2 : q.val < p2.val := Nat.lt_trans hq1 h12
   have hq3 : q.val < p3.val := Nat.lt_trans hq2 h23
@@ -555,11 +555,11 @@ private theorem det_plucker_three_term_basisVec_of_between_p1_p2
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (h1q : p1.val < q.val) (hq2 : q.val < p2.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have hq3 : q.val < p3.val := Nat.lt_trans hq2 h23
   have hraw :=
@@ -586,11 +586,11 @@ private theorem det_plucker_three_term_basisVec_of_between_p2_p3
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (h2q : p2.val < q.val) (hq3 : q.val < p3.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have h1q : p1.val < q.val := Nat.lt_trans h12 h2q
   have hraw :=
@@ -616,11 +616,11 @@ private theorem det_plucker_three_term_basisVec_of_gt_p3
     {R : Type u} [CommRing R] {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (h3q : p3.val < q.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have h1q : p1.val < q.val := Nat.lt_trans h12 (Nat.lt_trans h23 h3q)
   have h2q : p2.val < q.val := Nat.lt_trans h23 h3q
@@ -643,11 +643,11 @@ theorem det_plucker_three_term_basisVec_of_ne
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hq1 : q ≠ p1) (hq2 : q ≠ p2) (hq3 : q ≠ p3) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   by_cases hlt1 : q.val < p1.val
   · exact det_plucker_three_term_basisVec_of_lt_p1 B p1 p2 p3 q h12 h23 hlt1
@@ -679,11 +679,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p1
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p1) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) p1) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p1) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p1) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p1) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p1) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p1,
     Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
@@ -695,11 +695,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p2
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p2) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) p2) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p2) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p2) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p2) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p2) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12,
     Hex.Matrix.mDet_unit_eq_zero_of_eq B p2, Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
@@ -719,11 +719,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p3
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p3) p1 *
+    Hex.Matrix.mDet B (Vector.unit (R := R) p3) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p3) p2 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p3) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) p3) p3 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) p3) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
     Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, Hex.Matrix.mDet_unit_eq_zero_of_eq B p3]
@@ -800,11 +800,11 @@ private theorem det_plucker_three_term_of_basisVec
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hbasis : ∀ q : Fin (n + 3),
-      Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+      Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
           Hex.Matrix.nDet B p2 p3 h23 -
-        Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+        Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
           Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-        Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+        Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
           Hex.Matrix.nDet B p1 p2 h12 = 0) :
     Hex.Matrix.mDet B v p1 * Hex.Matrix.nDet B p2 p3 h23 -
       Hex.Matrix.mDet B v p2 * Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
@@ -812,21 +812,21 @@ private theorem det_plucker_three_term_of_basisVec
   rw [Hex.Matrix.mDet_eq_sum_unit B v p1, Hex.Matrix.mDet_eq_sum_unit B v p2,
     Hex.Matrix.mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p1)
       (Hex.Matrix.nDet B p2 p3 h23)]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p2)
       (Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23))]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p3)
       (Hex.Matrix.nDet B p1 p2 h12)]
   apply foldl_det_sum_sub_add_zero_of_body_zero
       (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p1 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
         Hex.Matrix.nDet B p2 p3 h23)
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p2 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23))
-      (fun q => v[q] * Hex.Matrix.mDet B (Hex.Vector.unit (R := R) q) p3 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
         Hex.Matrix.nDet B p1 p2 h12)
       0 0 0
   · ring

--- a/HexGramSchmidt/Basic/IntCast.lean
+++ b/HexGramSchmidt/Basic/IntCast.lean
@@ -51,7 +51,7 @@ mutually orthogonal. -/
 @[grind =]
 theorem basis_orthogonal (b : Matrix Int n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i ≠ j) :
-    Vector.dotProduct ((basis b).row ⟨i, hi⟩) ((basis b).row ⟨j, hj⟩) = 0 := by
+    ((basis b).row ⟨i, hi⟩).dotProduct ((basis b).row ⟨j, hj⟩) = 0 := by
   simpa [basis, GramSchmidt.Rat.basis] using
     GramSchmidt.Rat.basis_orthogonal (b := GramSchmidt.castIntMatrix b) i j hi hj hij
 
@@ -184,8 +184,8 @@ theorem basis_rowSwap_adjacent_curr (b : Matrix Int n m) (km1 k : Fin n)
     let mu := GramSchmidt.entry (coeffs b) k km1
     let swappedPrev := curr + mu • prev
     (basis (Matrix.rowSwap b km1 k)).row k =
-      (Vector.dotProduct curr curr / Vector.dotProduct swappedPrev swappedPrev) • prev -
-        (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) • curr := by
+      (curr.dotProduct curr / swappedPrev.dotProduct swappedPrev) • prev -
+        (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) • curr := by
   have hnormRat :
       Vector.dotProduct
         ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row k +
@@ -239,7 +239,7 @@ theorem coeffs_rowSwap_adjacent_pivot (b : Matrix Int n m) (km1 k : Fin n)
     let curr := (basis b).row k
     let swappedPrev := curr + mu • prev
     GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) k km1 =
-      mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev := by
+      mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev := by
   have hnormRat :
       Vector.dotProduct
         ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row k +
@@ -313,11 +313,11 @@ destination row increases by the added integer multiple. -/
 @[grind =]
 theorem coeffs_rowAdd_pivot (b : Matrix Int n m) (src dst : Fin n)
     (hsrcdst : src.val < dst.val) (c : Int)
-    (hnorm : Vector.dotProduct ((basis b).row src) ((basis b).row src) ≠ 0) :
+    (hnorm : ((basis b).row src).dotProduct ((basis b).row src) ≠ 0) :
     GramSchmidt.entry (coeffs (Matrix.rowAdd b src dst c)) dst src =
       GramSchmidt.entry (coeffs b) dst src + (c : Rat) := by
   have hnormRat :
-      Vector.dotProduct ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row src)
+      ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row src).dotProduct
           ((GramSchmidt.Rat.basis (GramSchmidt.castIntMatrix b)).row src) ≠ 0 := by
     simpa [basis, GramSchmidt.Rat.basis] using hnorm
   simpa [coeffs, basis, GramSchmidt.Rat.coeffs, GramSchmidt.Rat.basis,

--- a/HexGramSchmidt/Basic/Kernel.lean
+++ b/HexGramSchmidt/Basic/Kernel.lean
@@ -32,8 +32,8 @@ When the basis row has zero norm we use `0`, which matches the degenerate
 case of Gram-Schmidt where the corresponding projection term vanishes. -/
 @[expose]
 def projectionCoeff (row basisRow : Vector Rat m) : Rat :=
-  let denom := Vector.dotProduct basisRow basisRow
-  if denom = 0 then 0 else Vector.dotProduct row basisRow / denom
+  let denom := basisRow.dotProduct basisRow
+  if denom = 0 then 0 else row.dotProduct basisRow / denom
 
 /-- Subtract the projection of `row` onto `basisRow`. -/
 @[expose]
@@ -43,8 +43,8 @@ def subtractProjection (row basisRow : Vector Rat m) : Vector Rat m :=
 /-- `dot (subtractProjection row basisRow) target` expands as `dot row target`
 minus the projection coefficient times `dot basisRow target`. -/
 private theorem dot_subtractProjection (row basisRow target : Vector Rat m) :
-    Vector.dotProduct (subtractProjection row basisRow) target =
-      Vector.dotProduct row target - projectionCoeff row basisRow * Vector.dotProduct basisRow target := by
+    (subtractProjection row basisRow).dotProduct target =
+      row.dotProduct target - projectionCoeff row basisRow * basisRow.dotProduct target := by
   simp [subtractProjection, Vector.dotProduct_sub_smul_left]
 
 /-- Reconstruction identity: `row` is the sum of its residual
@@ -61,8 +61,8 @@ private theorem subtractProjection_add_projection (row basisRow : Vector Rat m) 
 /-- The residual `subtractProjection row basisRow` is orthogonal to `basisRow`
 whenever `basisRow` has nonzero norm. -/
 private theorem dot_subtractProjection_self_zero (row basisRow : Vector Rat m)
-    (hnorm : Vector.dotProduct basisRow basisRow ≠ 0) :
-    Vector.dotProduct (subtractProjection row basisRow) basisRow = 0 := by
+    (hnorm : basisRow.dotProduct basisRow ≠ 0) :
+    (subtractProjection row basisRow).dotProduct basisRow = 0 := by
   rw [dot_subtractProjection]
   simp [projectionCoeff, hnorm]
   grind
@@ -130,7 +130,7 @@ private theorem foldl_dot_self_eq_zero_of_mem (xs : List (Fin m)) (v : Vector Ra
 
 /-- A vector with zero self-dot-product has every coordinate equal to zero. -/
 private theorem dot_self_eq_zero_get (v : Vector Rat m)
-    (hzero : Vector.dotProduct v v = 0) (i : Fin m) :
+    (hzero : v.dotProduct v = 0) (i : Fin m) :
     v[i] = 0 := by
   have hmem : i ∈ List.finRange m := by
     simp
@@ -141,8 +141,8 @@ private theorem dot_self_eq_zero_get (v : Vector Rat m)
 its dot product with any other row also vanishes. Used to discharge the
 degenerate zero-norm basis row case when reasoning about orthogonality. -/
 theorem dot_zero_of_dot_self_zero (row v : Vector Rat m)
-    (hzero : Vector.dotProduct v v = 0) :
-    Vector.dotProduct row v = 0 := by
+    (hzero : v.dotProduct v = 0) :
+    row.dotProduct v = 0 := by
   unfold Vector.dotProduct
   induction List.finRange m with
   | nil =>
@@ -158,8 +158,8 @@ theorem dot_zero_of_dot_self_zero (row v : Vector Rat m)
 orthogonal to `basisRow`. -/
 private theorem dot_subtractProjection_self_zero_of_dot_self_zero
     (row basisRow : Vector Rat m)
-    (hnorm : Vector.dotProduct basisRow basisRow = 0) :
-    Vector.dotProduct (subtractProjection row basisRow) basisRow = 0 := by
+    (hnorm : basisRow.dotProduct basisRow = 0) :
+    (subtractProjection row basisRow).dotProduct basisRow = 0 := by
   exact dot_zero_of_dot_self_zero (row := subtractProjection row basisRow)
     (v := basisRow) hnorm
 
@@ -179,7 +179,7 @@ private theorem foldl_dot_comm_rat (xs : List (Fin m)) (u v : Vector Rat m)
 
 /-- The rational dot product is commutative. -/
 private theorem dot_comm_rat (u v : Vector Rat m) :
-    Vector.dotProduct u v = Vector.dotProduct v u := by
+    u.dotProduct v = v.dotProduct u := by
   simpa [Vector.dotProduct] using
     foldl_dot_comm_rat (xs := List.finRange m) (u := u) (v := v)
       (accU := 0) (accV := 0) rfl
@@ -188,10 +188,10 @@ private theorem dot_comm_rat (u v : Vector Rat m) :
 leaves the projection coefficient onto `basisRow` unchanged. -/
 private theorem projectionCoeff_subtractProjection_eq
     (row otherBasisRow basisRow : Vector Rat m)
-    (horth : Vector.dotProduct otherBasisRow basisRow = 0) :
+    (horth : otherBasisRow.dotProduct basisRow = 0) :
     projectionCoeff (subtractProjection row otherBasisRow) basisRow =
       projectionCoeff row basisRow := by
-  by_cases hnorm : Vector.dotProduct basisRow basisRow = 0
+  by_cases hnorm : basisRow.dotProduct basisRow = 0
   · simp [projectionCoeff, hnorm]
   · simp [projectionCoeff, dot_subtractProjection, horth, hnorm]
     grind
@@ -206,16 +206,16 @@ def reduceAgainstBasis (basisRev : List (Vector Rat m)) (row : Vector Rat m) :
 does, whenever `target` is orthogonal to every row in `basisRev`. -/
 private theorem dot_reduceAgainstBasis_zero_of_forall_dot_zero
     (basisRev : List (Vector Rat m)) (row target : Vector Rat m)
-    (horth : ∀ basisRow ∈ basisRev, Vector.dotProduct basisRow target = 0) :
-    Vector.dotProduct (reduceAgainstBasis basisRev row) target = Vector.dotProduct row target := by
+    (horth : ∀ basisRow ∈ basisRev, basisRow.dotProduct target = 0) :
+    (reduceAgainstBasis basisRev row).dotProduct target = row.dotProduct target := by
   induction basisRev generalizing row with
   | nil =>
       simp [reduceAgainstBasis]
   | cons basisRow rest ih =>
       rw [reduceAgainstBasis]
       simp only [List.foldl_cons]
-      change Vector.dotProduct (reduceAgainstBasis rest (subtractProjection row basisRow)) target =
-        Vector.dotProduct row target
+      change (reduceAgainstBasis rest (subtractProjection row basisRow)).dotProduct target =
+        row.dotProduct target
       rw [ih]
       · rw [dot_subtractProjection, horth basisRow (by simp)]
         grind
@@ -226,9 +226,9 @@ private theorem dot_reduceAgainstBasis_zero_of_forall_dot_zero
 `row` and every row in `basisRev` are orthogonal to `target`. -/
 private theorem dot_reduceAgainstBasis_zero_of_dot_zero
     (basisRev : List (Vector Rat m)) (row target : Vector Rat m)
-    (hrow : Vector.dotProduct row target = 0)
-    (horth : ∀ basisRow ∈ basisRev, Vector.dotProduct basisRow target = 0) :
-    Vector.dotProduct (reduceAgainstBasis basisRev row) target = 0 := by
+    (hrow : row.dotProduct target = 0)
+    (horth : ∀ basisRow ∈ basisRev, basisRow.dotProduct target = 0) :
+    (reduceAgainstBasis basisRev row).dotProduct target = 0 := by
   rw [dot_reduceAgainstBasis_zero_of_forall_dot_zero basisRev row target horth, hrow]
 
 /-- `reduceAgainstBasis basisRev row` is orthogonal to every member of a pairwise-orthogonal
@@ -236,8 +236,8 @@ private theorem dot_reduceAgainstBasis_zero_of_dot_zero
 private theorem dot_reduceAgainstBasis_of_mem
     (basisRev : List (Vector Rat m)) (row basisRow : Vector Rat m)
     (hmem : basisRow ∈ basisRev)
-    (horth : basisRev.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0)) :
-    Vector.dotProduct (reduceAgainstBasis basisRev row) basisRow = 0 := by
+    (horth : basisRev.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0)) :
+    (reduceAgainstBasis basisRev row).dotProduct basisRow = 0 := by
   induction basisRev generalizing row with
   | nil =>
       simp at hmem
@@ -247,7 +247,7 @@ private theorem dot_reduceAgainstBasis_of_mem
       by_cases hhead : head = basisRow
       · subst basisRow
         apply dot_reduceAgainstBasis_zero_of_dot_zero
-        · by_cases hnorm : Vector.dotProduct head head = 0
+        · by_cases hnorm : head.dotProduct head = 0
           · exact dot_subtractProjection_self_zero_of_dot_self_zero row head hnorm
           · exact dot_subtractProjection_self_zero row head hnorm
         · intro later hlater
@@ -266,7 +266,7 @@ private theorem dot_reduceAgainstBasis_of_mem
 as `row`, when every row in `basisRev` is orthogonal to `basisRow`. -/
 private theorem projectionCoeff_reduceAgainstBasis_eq
     (basisRev : List (Vector Rat m)) (row basisRow : Vector Rat m)
-    (horth : ∀ otherBasisRow ∈ basisRev, Vector.dotProduct otherBasisRow basisRow = 0) :
+    (horth : ∀ otherBasisRow ∈ basisRev, otherBasisRow.dotProduct basisRow = 0) :
     projectionCoeff (reduceAgainstBasis basisRev row) basisRow =
       projectionCoeff row basisRow := by
   induction basisRev generalizing row with
@@ -328,7 +328,7 @@ private theorem subtractProjection_add_projection_with_acc
 combination reconstructs `row + acc`. -/
 private theorem reduceAgainstBasis_reconstruction_acc
     (basisRev : List (Vector Rat m)) (row acc : Vector Rat m)
-    (horth : basisRev.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0)) :
+    (horth : basisRev.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0)) :
     reduceAgainstBasis basisRev row + projectionCombination row basisRev acc =
       row + acc := by
   induction basisRev generalizing row acc with
@@ -359,7 +359,7 @@ private theorem reduceAgainstBasis_reconstruction_acc
 projections onto the basis rows. -/
 private theorem reduceAgainstBasis_reconstruction
     (basisRev : List (Vector Rat m)) (row : Vector Rat m)
-    (horth : basisRev.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0)) :
+    (horth : basisRev.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0)) :
     row =
       reduceAgainstBasis basisRev row +
         projectionCombination row basisRev 0 := by
@@ -429,8 +429,8 @@ private theorem basisRows_length (rows : List (Vector Rat m)) :
 
 /-- `rows.reverse` is pairwise orthogonal whenever `rows` is. -/
 private theorem orthPairwise_reverse (rows : List (Vector Rat m))
-    (horth : rows.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0)) :
-    rows.reverse.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) := by
+    (horth : rows.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0)) :
+    rows.reverse.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) := by
   rw [List.pairwise_iff_getElem] at horth ⊢
   intro i j hirev hjrev hij
   simp [List.length_reverse] at hirev hjrev
@@ -445,9 +445,9 @@ private theorem orthPairwise_reverse (rows : List (Vector Rat m))
 `basisRev` is. -/
 private theorem basisRowsAux_pairwise
     (basisRev pending : List (Vector Rat m))
-    (horth : basisRev.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0)) :
+    (horth : basisRev.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0)) :
     (basisRowsAux basisRev pending).Pairwise
-      (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) := by
+      (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) := by
   induction pending generalizing basisRev with
   | nil =>
       simpa [basisRowsAux] using orthPairwise_reverse basisRev horth
@@ -463,7 +463,7 @@ private theorem basisRowsAux_pairwise
 
 /-- `basisRows rows` is a pairwise-orthogonal list of rows. -/
 private theorem basisRows_pairwise (rows : List (Vector Rat m)) :
-    (basisRows rows).Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) := by
+    (basisRows rows).Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) := by
   simpa [basisRows] using
     basisRowsAux_pairwise ([] : List (Vector Rat m)) rows (by simp)
 
@@ -476,13 +476,13 @@ private theorem basisMatrix_row_eq_basisRows_get!
 /-- Distinct rows of `basisRows b.toList` have dot product zero. -/
 private theorem basisRows_get!_dot_eq_zero
     (b : Matrix Rat n m) (i j : Nat) (hi : i < n) (hj : j < n) (hij : i ≠ j) :
-    Vector.dotProduct (basisRows b.toList)[i]! (basisRows b.toList)[j]! = 0 := by
+    (basisRows b.toList)[i]!.dotProduct (basisRows b.toList)[j]! = 0 := by
   let rows := basisRows b.toList
   have hlen : rows.length = n := by
     simp [rows, basisRows_length]
   have hirows : i < rows.length := by simpa [hlen] using hi
   have hjrows : j < rows.length := by simpa [hlen] using hj
-  have hpair : rows.Pairwise (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) := by
+  have hpair : rows.Pairwise (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) := by
     simpa [rows] using basisRows_pairwise (rows := b.toList)
   have hget_i : rows[i]! = rows[i] := by simp [hirows]
   have hget_j : rows[j]! = rows[j] := by simp [hjrows]
@@ -612,7 +612,7 @@ private theorem basisRows_get!_eq_reduceAgainstBasis_take
 orthogonal — they form a Pairwise sublist. -/
 private theorem basisRows_take_pairwise (rows : List (Vector Rat m)) (k : Nat) :
     ((basisRows rows).take k).Pairwise
-      (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) :=
+      (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) :=
   ((basisRows_pairwise rows).sublist (List.take_sublist k _))
 
 /-- Pointwise foldl-with-accumulator-split for vector folds. -/
@@ -713,7 +713,7 @@ Base case for the vanishing facts the later `prefixSpan`/`projectionCoeff`
 proofs invoke when a reduced row has already collapsed to zero. -/
 private theorem subtractProjection_zero_left (basisRow : Vector Rat m) :
     subtractProjection 0 basisRow = 0 := by
-  have hdot : Vector.dotProduct (0 : Vector Rat m) basisRow = 0 := by
+  have hdot : (0 : Vector Rat m).dotProduct basisRow = 0 := by
     unfold Vector.dotProduct
     induction List.finRange m with
     | nil =>
@@ -727,7 +727,7 @@ private theorem subtractProjection_zero_left (basisRow : Vector Rat m) :
       exact ih
   apply Vector.ext
   intro idx hidx
-  by_cases hnorm : Vector.dotProduct basisRow basisRow = 0
+  by_cases hnorm : basisRow.dotProduct basisRow = 0
   · have hcoeff : projectionCoeff 0 basisRow = 0 := by
       simp [projectionCoeff, hnorm]
     rw [subtractProjection, Vector.getElem_sub, Vector.getElem_zero, Vector.getElem_smul,
@@ -735,7 +735,7 @@ private theorem subtractProjection_zero_left (basisRow : Vector Rat m) :
     change (0 : Rat) - 0 * basisRow[idx] = 0
     grind
   · have hcoeff : projectionCoeff 0 basisRow = 0 := by
-      have hzero_div : (0 : Rat) / Vector.dotProduct basisRow basisRow = 0 := by
+      have hzero_div : (0 : Rat) / basisRow.dotProduct basisRow = 0 := by
         grind
       simp [projectionCoeff, hnorm, hdot, hzero_div]
     rw [subtractProjection, Vector.getElem_sub, Vector.getElem_zero, Vector.getElem_smul,
@@ -760,22 +760,22 @@ private theorem reduceAgainstBasis_zero_left (basisRev : List (Vector Rat m)) :
       exact ih
 
 /-- A row already orthogonal to a basis row is unchanged by projecting that
-basis row out: when `Vector.dotProduct row basisRow = 0` the projection coefficient
+basis row out: when `row.dotProduct basisRow = 0` the projection coefficient
 is `0`, so `subtractProjection row basisRow = row`. The single-step
 orthogonality-invariance fact underpinning the list version below. -/
 private theorem subtractProjection_eq_self
-    (row basisRow : Vector Rat m) (h : Vector.dotProduct row basisRow = 0) :
+    (row basisRow : Vector Rat m) (h : row.dotProduct basisRow = 0) :
     subtractProjection row basisRow = row := by
   apply Vector.ext
   intro idx hidx
-  by_cases hnorm : Vector.dotProduct basisRow basisRow = 0
+  by_cases hnorm : basisRow.dotProduct basisRow = 0
   · have hcoeff : projectionCoeff row basisRow = 0 := by
       simp [projectionCoeff, hnorm]
     rw [subtractProjection, Vector.getElem_sub, Vector.getElem_smul, hcoeff]
     change row[idx] - 0 * basisRow[idx] = row[idx]
     grind
   · have hcoeff : projectionCoeff row basisRow = 0 := by
-      have hzero_div : (0 : Rat) / Vector.dotProduct basisRow basisRow = 0 := by
+      have hzero_div : (0 : Rat) / basisRow.dotProduct basisRow = 0 := by
         grind
       simp [projectionCoeff, h, hnorm, hzero_div]
     rw [subtractProjection, Vector.getElem_sub, Vector.getElem_smul, hcoeff]
@@ -788,7 +788,7 @@ gives `reduceAgainstBasis basisRev row = row`. Lets later proofs conclude a
 row lies outside the prefix span without recomputing the fold. -/
 private theorem reduceAgainstBasis_eq_self
     (basisRev : List (Vector Rat m)) (row : Vector Rat m)
-    (h : ∀ basisRow ∈ basisRev, Vector.dotProduct row basisRow = 0) :
+    (h : ∀ basisRow ∈ basisRev, row.dotProduct basisRow = 0) :
     reduceAgainstBasis basisRev row = row := by
   induction basisRev generalizing row with
   | nil =>
@@ -809,7 +809,7 @@ coefficient is `1` (or the row is already zero), so
 makes a basis row vanish once it appears in its own reduction prefix. -/
 private theorem subtractProjection_self_eq_zero (basisRow : Vector Rat m) :
     subtractProjection basisRow basisRow = 0 := by
-  by_cases hnorm : Vector.dotProduct basisRow basisRow = 0
+  by_cases hnorm : basisRow.dotProduct basisRow = 0
   · apply Vector.ext
     intro idx hidx
     have hzero : basisRow[idx] = 0 :=
@@ -822,7 +822,7 @@ private theorem subtractProjection_self_eq_zero (basisRow : Vector Rat m) :
     grind
   · apply Vector.ext
     intro idx hidx
-    have hdiv : Vector.dotProduct basisRow basisRow / Vector.dotProduct basisRow basisRow = 1 := by
+    have hdiv : basisRow.dotProduct basisRow / basisRow.dotProduct basisRow = 1 := by
       grind
     have hcoeff : projectionCoeff basisRow basisRow = 1 := by
       simp [projectionCoeff, hnorm, hdiv]

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -39,7 +39,7 @@ private theorem foldl_dot_add_left
 
 /-- `dot_add_left` states left-additivity of the dot product. -/
 private theorem dot_add_left (a b c : Vector Rat m) :
-    Vector.dotProduct (a + b) c = Vector.dotProduct a c + Vector.dotProduct b c := by
+    (a + b).dotProduct c = a.dotProduct c + b.dotProduct c := by
   unfold Vector.dotProduct
   have hzero : (0 : Rat) + 0 = 0 := by grind
   simpa [hzero] using
@@ -67,7 +67,7 @@ private theorem foldl_dot_smul_left
 
 /-- `dot_smul_left` states left-homogeneity of the dot product. -/
 private theorem dot_smul_left (s : Rat) (a c : Vector Rat m) :
-    Vector.dotProduct (s • a) c = s * Vector.dotProduct a c := by
+    (s • a).dotProduct c = s * a.dotProduct c := by
   unfold Vector.dotProduct
   have hzero : s * (0 : Rat) = 0 := by grind
   simpa [hzero] using
@@ -77,7 +77,7 @@ private theorem dot_smul_left (s : Rat) (a c : Vector Rat m) :
 private theorem projectionCoeff_add_left (a b c : Vector Rat m) :
     projectionCoeff (a + b) c = projectionCoeff a c + projectionCoeff b c := by
   unfold projectionCoeff
-  by_cases hnorm : Vector.dotProduct c c = 0
+  by_cases hnorm : c.dotProduct c = 0
   · simp [hnorm]
     grind
   · simp [hnorm]
@@ -88,7 +88,7 @@ private theorem projectionCoeff_add_left (a b c : Vector Rat m) :
 private theorem projectionCoeff_smul_left (s : Rat) (a c : Vector Rat m) :
     projectionCoeff (s • a) c = s * projectionCoeff a c := by
   unfold projectionCoeff
-  by_cases hnorm : Vector.dotProduct c c = 0
+  by_cases hnorm : c.dotProduct c = 0
   · simp [hnorm]
   · simp [hnorm]
     rw [dot_smul_left]
@@ -179,11 +179,11 @@ private theorem reduceAgainstBasis_append
 private theorem basisRows_get!_dot_eq_zero_of_list
     (rows : List (Vector Rat m)) (i j : Nat)
     (hi : i < rows.length) (hj : j < rows.length) (hij : i ≠ j) :
-    Vector.dotProduct (basisRows rows)[i]! (basisRows rows)[j]! = 0 := by
+    (basisRows rows)[i]!.dotProduct (basisRows rows)[j]! = 0 := by
   have hilen : i < (basisRows rows).length := by simpa [basisRows_length]
   have hjlen : j < (basisRows rows).length := by simpa [basisRows_length]
   have hpair : (basisRows rows).Pairwise
-      (fun x y => Vector.dotProduct x y = 0 ∧ Vector.dotProduct y x = 0) :=
+      (fun x y => x.dotProduct y = 0 ∧ y.dotProduct x = 0) :=
     basisRows_pairwise rows
   have hget_i : (basisRows rows)[i]! = (basisRows rows)[i] := by simp [hilen]
   have hget_j : (basisRows rows)[j]! = (basisRows rows)[j] := by simp [hjlen]
@@ -901,22 +901,22 @@ private theorem basisMatrix_rowSwap_adjacent_curr
     -- dot swappedPrev (basisRows[idx]) = dot curr (basisRows[idx]) + mu * dot prev (basisRows[idx])
     -- Both inner products vanish by pairwise orthogonality.
     have hcurr_orth :
-        Vector.dotProduct curr (basisRows b.toList)[idx]! = 0 := by
-      change Vector.dotProduct ((basisMatrix b).row k) _ = 0
+        curr.dotProduct (basisRows b.toList)[idx]! = 0 := by
+      change ((basisMatrix b).row k).dotProduct _ = 0
       rw [basisMatrix_row_eq_basisRows_get!]
       exact basisRows_get!_dot_eq_zero_of_list b.toList k.val idx
         (by simp [k.isLt])
         (by simp only [Vector.length_toList]; omega)
         (by omega)
     have hprev_orth :
-        Vector.dotProduct prev (basisRows b.toList)[idx]! = 0 := by
-      change Vector.dotProduct ((basisMatrix b).row km1) _ = 0
+        prev.dotProduct (basisRows b.toList)[idx]! = 0 := by
+      change ((basisMatrix b).row km1).dotProduct _ = 0
       rw [basisMatrix_row_eq_basisRows_get!]
       exact basisRows_get!_dot_eq_zero_of_list b.toList km1.val idx
         (by simp [km1.isLt])
         (by simp only [Vector.length_toList]; omega)
         (by omega)
-    show Vector.dotProduct (curr + mu • prev) _ = 0
+    show (curr + mu • prev).dotProduct _ = 0
     rw [dot_add_left, dot_smul_left, hcurr_orth, hprev_orth]
     grind
   rw [hreduce_row, hreduce_sP]
@@ -1115,17 +1115,17 @@ private theorem prefixSpan_sub
 
 /-- `dot_add_right` gives additivity of the rational dot product in its right argument. -/
 private theorem dot_add_right (a b c : Vector Rat m) :
-    Vector.dotProduct a (b + c) = Vector.dotProduct a b + Vector.dotProduct a c := by
+    a.dotProduct (b + c) = a.dotProduct b + a.dotProduct c := by
   rw [dot_comm_rat, dot_add_left, dot_comm_rat b a, dot_comm_rat c a]
 
 /-- `dot_smul_right` pulls a rational scalar out of the right argument of the dot product. -/
 private theorem dot_smul_right (s : Rat) (a b : Vector Rat m) :
-    Vector.dotProduct a (s • b) = s * Vector.dotProduct a b := by
+    a.dotProduct (s • b) = s * a.dotProduct b := by
   rw [dot_comm_rat, dot_smul_left, dot_comm_rat b a]
 
 /-- `dot_sub_right` gives subtractivity of the rational dot product in its right argument. -/
 private theorem dot_sub_right (a b c : Vector Rat m) :
-    Vector.dotProduct a (b - c) = Vector.dotProduct a b - Vector.dotProduct a c := by
+    a.dotProduct (b - c) = a.dotProduct b - a.dotProduct c := by
   have hsub : b - c = b + (-1 : Rat) • c := by
     apply Vector.ext
     intro idx hidx
@@ -1137,7 +1137,7 @@ private theorem dot_sub_right (a b c : Vector Rat m) :
 
 /-- `dot_zero_right` says the rational dot product with a zero right argument is zero. -/
 private theorem dot_zero_right (a : Vector Rat m) :
-    Vector.dotProduct a 0 = 0 := by
+    a.dotProduct 0 = 0 := by
   unfold Vector.dotProduct
   change (List.finRange m).foldl
       (fun acc i => acc + a[i] * (0 : Vector Rat m)[i]) 0 = 0
@@ -1282,14 +1282,14 @@ private theorem dot_eq_zero_of_prefixSpan
     (M : Matrix Rat n m) (i : Nat) (hi : i < n)
     (u v : Vector Rat m)
     (hspan : prefixSpan M i hi v)
-    (horth : ∀ j : Fin (i + 1), Vector.dotProduct u ((prefixRows M i hi).row j) = 0) :
-    Vector.dotProduct u v = 0 := by
+    (horth : ∀ j : Fin (i + 1), u.dotProduct ((prefixRows M i hi).row j) = 0) :
+    u.dotProduct v = 0 := by
   rcases hspan with ⟨c, hc⟩
   rw [← hc, rowCombination_eq_foldl_rows]
   have hfold :
       ∀ xs : List (Fin (i + 1)), ∀ acc : Vector Rat m,
-        Vector.dotProduct u acc = 0 →
-          Vector.dotProduct u
+        u.dotProduct acc = 0 →
+          u.dotProduct
             (xs.foldl
               (fun acc j => acc + c[j] • (prefixRows M i hi).row j) acc) = 0 := by
     intro xs
@@ -1305,26 +1305,26 @@ private theorem dot_eq_zero_of_prefixSpan
         grind
   exact hfold (List.finRange (i + 1)) 0 (dot_zero_right u)
 
-/-- `Vector.normSq v` is nonnegative for a rational vector, since it is the
+/-- `v`.normSq is nonnegative for a rational vector, since it is the
 self-dot-product, a sum of squares (via `foldl_dot_self_start_le`). -/
 private theorem rat_normSq_nonneg (v : Vector Rat m) :
-    0 ≤ Vector.normSq v := by
+    0 ≤ v.normSq := by
   simpa [Vector.normSq, Vector.dotProduct] using
     foldl_dot_self_start_le (xs := List.finRange m) (v := v)
       (acc := 0) (by decide)
 
 /-- Pythagorean split: when `acc` is orthogonal to `row`, the squared norm of
-`acc + c • row` expands to `Vector.normSq acc + c * c * Vector.normSq row`. -/
+`acc + c • row` expands to `acc.normSq + c * c * row`..normSq -/
 private theorem normSq_add_smul
     (acc row : Vector Rat m) (c : Rat)
-    (horth : Vector.dotProduct acc row = 0) :
-    Vector.normSq (acc + c • row) =
-      Vector.normSq acc + c * c * Vector.normSq row := by
-  change Vector.dotProduct (acc + c • row) (acc + c • row) =
-    Vector.dotProduct acc acc + c * c * Vector.dotProduct row row
+    (horth : acc.dotProduct row = 0) :
+    (acc + c • row).normSq =
+      acc.normSq + c * c * row.normSq := by
+  change (acc + c • row).dotProduct (acc + c • row) =
+    acc.dotProduct acc + c * c * row.dotProduct row
   rw [dot_add_left, dot_add_right acc acc (c • row), dot_smul_right, dot_smul_left,
     dot_add_right row acc (c • row), dot_smul_right, horth]
-  have horth' : Vector.dotProduct row acc = 0 := by
+  have horth' : row.dotProduct acc = 0 := by
     rw [dot_comm_rat]
     exact horth
   rw [horth']
@@ -1351,20 +1351,20 @@ private theorem foldl_rat_sum_start {α : Type v}
 
 /-- Orthogonal-expansion of a folded row combination: when the listed rows are
 pairwise orthogonal and `acc` is orthogonal to each, the squared norm of the
-fold splits as `Vector.normSq acc` plus the fold of weighted squared norms
-`coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)`. -/
+fold splits as `acc`.normSq plus the fold of weighted squared norms
+`coeffs[i] * coeffs[i] * (rows.row i)`..normSq -/
 private theorem foldl_orthogonal_expansion_normSq
     (xs : List (Fin n)) (rows : Matrix Rat n m) (coeffs : Vector Rat n)
     (acc : Vector Rat m)
     (hnodup : xs.Nodup)
-    (hacc : ∀ i ∈ xs, Vector.dotProduct acc (rows.row i) = 0)
+    (hacc : ∀ i ∈ xs, acc.dotProduct (rows.row i) = 0)
     (horth : ∀ i ∈ xs, ∀ j ∈ xs, i ≠ j →
-      Vector.dotProduct (rows.row i) (rows.row j) = 0) :
+      (rows.row i).dotProduct (rows.row j) = 0) :
     Vector.normSq
         (xs.foldl (fun acc i => acc + coeffs[i] • rows.row i) acc) =
-      Vector.normSq acc +
+      acc.normSq +
         xs.foldl
-          (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 := by
+          (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 := by
   induction xs generalizing acc with
   | nil =>
       simp
@@ -1374,52 +1374,52 @@ private theorem foldl_orthogonal_expansion_normSq
     have hnodup_tail : rest.Nodup := (List.nodup_cons.mp hnodup).2
     have hi_not_mem : i ∉ rest := (List.nodup_cons.mp hnodup).1
     let acc' := acc + coeffs[i] • rows.row i
-    have hacc' : ∀ j ∈ rest, Vector.dotProduct acc' (rows.row j) = 0 := by
+    have hacc' : ∀ j ∈ rest, acc'.dotProduct (rows.row j) = 0 := by
       intro j hj
       have hij : i ≠ j := by
         intro h
         subst h
         exact hi_not_mem hj
-      have hrow : Vector.dotProduct (rows.row i) (rows.row j) = 0 :=
+      have hrow : (rows.row i).dotProduct (rows.row j) = 0 :=
         horth i (by simp) j (by simp [hj]) hij
       simp only [acc']
       rw [dot_add_left, dot_smul_left, hacc j (by simp [hj]), hrow]
       grind
     have horth' : ∀ a ∈ rest, ∀ b ∈ rest, a ≠ b →
-        Vector.dotProduct (rows.row a) (rows.row b) = 0 := by
+        (rows.row a).dotProduct (rows.row b) = 0 := by
       intro a ha b hb hab
       exact horth a (by simp [ha]) b (by simp [hb]) hab
     rw [ih (acc := acc') hnodup_tail hacc' horth',
       normSq_add_smul acc (rows.row i) coeffs[i] (hacc i (by simp))]
     rw [foldl_rat_sum_start rest
-      (fun j => coeffs[j] * coeffs[j] * Vector.normSq (rows.row j))
-      (0 + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i))]
+      (fun j => coeffs[j] * coeffs[j] * (rows.row j).normSq)
+      (0 + coeffs[i] * coeffs[i] * (rows.row i).normSq)]
     grind
 
 /-- The `acc = 0` case of `foldl_orthogonal_expansion_normSq`: for pairwise
 orthogonal rows the squared norm of the full row combination equals the fold of
-`coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)` over `List.finRange n`. -/
+`coeffs[i] * coeffs[i] * (rows.row i)`.normSq over `List.finRange n`. -/
 private theorem foldl_orthogonal_expansion_normSq_zero
     (rows : Matrix Rat n m) (coeffs : Vector Rat n)
     (horth : ∀ i j : Fin n, i ≠ j →
-      Vector.dotProduct (rows.row i) (rows.row j) = 0) :
+      (rows.row i).dotProduct (rows.row j) = 0) :
     Vector.normSq
         ((List.finRange n).foldl (fun acc i => acc + coeffs[i] • rows.row i) 0) =
       (List.finRange n).foldl
-        (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 := by
-  have hacc : ∀ i ∈ List.finRange n, Vector.dotProduct (0 : Vector Rat m) (rows.row i) = 0 := by
+        (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 := by
+  have hacc : ∀ i ∈ List.finRange n, (0 : Vector Rat m).dotProduct (rows.row i) = 0 := by
     intro i _hi
     rw [dot_comm_rat]
     exact dot_zero_right (rows.row i)
   have horth' : ∀ i ∈ List.finRange n, ∀ j ∈ List.finRange n, i ≠ j →
-      Vector.dotProduct (rows.row i) (rows.row j) = 0 := by
+      (rows.row i).dotProduct (rows.row j) = 0 := by
     intro i _hi j _hj hij
     exact horth i j hij
   have h :=
     foldl_orthogonal_expansion_normSq (xs := List.finRange n)
       (rows := rows) (coeffs := coeffs) (acc := (0 : Vector Rat m))
       (List.nodup_finRange n) hacc horth'
-  have hzero : Vector.normSq (0 : Vector Rat m) = 0 := by
+  have hzero : (0 : Vector Rat m).normSq = 0 := by
     have hfold :
         ∀ xs : List (Fin m), ∀ acc : Rat,
           xs.foldl (fun acc _ => acc + 0) acc = acc := by
@@ -1434,48 +1434,48 @@ private theorem foldl_orthogonal_expansion_normSq_zero
           have hacc : acc + 0 = acc := by grind
           rw [hacc]
           exact ih acc
-    simpa [Vector.normSq, Hex.Vector.dotProduct] using
+    simpa [Vector.normSq, Vector.dotProduct] using
       hfold (List.finRange m) 0
   rw [hzero] at h
   have hzero_add :
       (0 : Rat) +
           (List.finRange n).foldl
-            (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 =
+            (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 =
         (List.finRange n).foldl
-            (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 := by
+            (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 := by
     grind
   rw [hzero_add] at h
   exact h
 
 /-- The weighted-squared-norm fold `xs.foldl (· + coeffs[i] * coeffs[i] *
-Vector.normSq (rows.row i)) 0` is nonnegative, being a sum of nonnegative
+(rows.row i).normSq) 0` is nonnegative, being a sum of nonnegative
 terms. -/
 private theorem foldl_orthogonal_weighted_nonneg
     (xs : List (Fin n)) (rows : Matrix Rat n m) (coeffs : Vector Rat n) :
     0 ≤ xs.foldl
-      (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 := by
+      (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 := by
   induction xs with
   | nil =>
       simp
   | cons i rest ih =>
       simp only [List.foldl_cons]
       rw [foldl_rat_sum_start rest
-        (fun j => coeffs[j] * coeffs[j] * Vector.normSq (rows.row j))
-        (0 + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i))]
-      have hterm : 0 ≤ coeffs[i] * coeffs[i] * Vector.normSq (rows.row i) :=
+        (fun j => coeffs[j] * coeffs[j] * (rows.row j).normSq)
+        (0 + coeffs[i] * coeffs[i] * (rows.row i).normSq)]
+      have hterm : 0 ≤ coeffs[i] * coeffs[i] * (rows.row i).normSq :=
         Rat.mul_nonneg (rat_mul_self_nonneg coeffs[i]) (rat_normSq_nonneg (rows.row i))
       exact Rat.add_nonneg (by grind) ih
 
 /-- If `k ∈ xs` and its coefficient square is at least `1`, the
-weighted-squared-norm fold over `xs` is at least `Vector.normSq (rows.row k)`,
+weighted-squared-norm fold over `xs` is at least `(rows.row k)`.normSq,
 the single term contributed by `k`. -/
 private theorem foldl_orthogonal_weighted_normSq_ge
     (xs : List (Fin n)) (rows : Matrix Rat n m) (coeffs : Vector Rat n)
     (k : Fin n) (hk : k ∈ xs)
     (hcoeff : 1 ≤ coeffs[k] * coeffs[k]) :
-    Vector.normSq (rows.row k) ≤
+    (rows.row k).normSq ≤
       xs.foldl
-        (fun total i => total + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i)) 0 := by
+        (fun total i => total + coeffs[i] * coeffs[i] * (rows.row i).normSq) 0 := by
   induction xs with
   | nil =>
       cases hk
@@ -1483,43 +1483,43 @@ private theorem foldl_orthogonal_weighted_normSq_ge
       simp only [List.foldl_cons]
       simp only [List.mem_cons] at hk
       have hterm_nonneg :
-          0 ≤ coeffs[i] * coeffs[i] * Vector.normSq (rows.row i) := by
+          0 ≤ coeffs[i] * coeffs[i] * (rows.row i).normSq := by
         exact Rat.mul_nonneg (rat_mul_self_nonneg coeffs[i]) (rat_normSq_nonneg (rows.row i))
       cases hk with
       | inl hik =>
           subst hik
           rw [foldl_rat_sum_start rest
-            (fun j => coeffs[j] * coeffs[j] * Vector.normSq (rows.row j))
-            (0 + coeffs[k] * coeffs[k] * Vector.normSq (rows.row k))]
-          have hrow_nonneg : 0 ≤ Vector.normSq (rows.row k) :=
+            (fun j => coeffs[j] * coeffs[j] * (rows.row j).normSq)
+            (0 + coeffs[k] * coeffs[k] * (rows.row k).normSq)]
+          have hrow_nonneg : 0 ≤ (rows.row k).normSq :=
             rat_normSq_nonneg (rows.row k)
           have hfirst :
-              Vector.normSq (rows.row k) ≤
-                coeffs[k] * coeffs[k] * Vector.normSq (rows.row k) := by
+              (rows.row k).normSq ≤
+                coeffs[k] * coeffs[k] * (rows.row k).normSq := by
             have hdelta_nonneg : 0 ≤ (coeffs[k] * coeffs[k] - 1) *
-                Vector.normSq (rows.row k) :=
+                (rows.row k).normSq :=
               Rat.mul_nonneg (by grind) hrow_nonneg
             have hsplit :
-                coeffs[k] * coeffs[k] * Vector.normSq (rows.row k) =
-                  Vector.normSq (rows.row k) +
-                    (coeffs[k] * coeffs[k] - 1) * Vector.normSq (rows.row k) := by
+                coeffs[k] * coeffs[k] * (rows.row k).normSq =
+                  (rows.row k).normSq +
+                    (coeffs[k] * coeffs[k] - 1) * (rows.row k).normSq := by
               grind
             calc
-              Vector.normSq (rows.row k) ≤
-                  Vector.normSq (rows.row k) +
-                    (coeffs[k] * coeffs[k] - 1) * Vector.normSq (rows.row k) := by
+              (rows.row k).normSq ≤
+                  (rows.row k).normSq +
+                    (coeffs[k] * coeffs[k] - 1) * (rows.row k).normSq := by
                     grind
-              _ = coeffs[k] * coeffs[k] * Vector.normSq (rows.row k) := hsplit.symm
+              _ = coeffs[k] * coeffs[k] * (rows.row k).normSq := hsplit.symm
           have htail_nonneg :
               0 ≤ rest.foldl
-                (fun total j => total + coeffs[j] * coeffs[j] * Vector.normSq (rows.row j)) 0 := by
+                (fun total j => total + coeffs[j] * coeffs[j] * (rows.row j).normSq) 0 := by
             exact foldl_orthogonal_weighted_nonneg rest rows coeffs
           exact Rat.le_trans hfirst (by grind)
       | inr htail =>
           have htail_le := ih htail
           rw [foldl_rat_sum_start rest
-            (fun j => coeffs[j] * coeffs[j] * Vector.normSq (rows.row j))
-            (0 + coeffs[i] * coeffs[i] * Vector.normSq (rows.row i))]
+            (fun j => coeffs[j] * coeffs[j] * (rows.row j).normSq)
+            (0 + coeffs[i] * coeffs[i] * (rows.row i).normSq)]
           exact Rat.le_trans htail_le (by grind)
 
 /-- Orthogonal row-combination lower bound. If the rows of `rows` are pairwise
@@ -1528,9 +1528,9 @@ norm of the whole row combination is at least the squared norm of row `k`. -/
 theorem rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one
     (rows : Matrix Rat n m) (coeffs : Vector Rat n) (k : Fin n)
     (horth : ∀ i j : Fin n, i ≠ j →
-      Vector.dotProduct (rows.row i) (rows.row j) = 0)
+      (rows.row i).dotProduct (rows.row j) = 0)
     (hcoeff : 1 ≤ coeffs[k] * coeffs[k]) :
-    Vector.normSq (rows.row k) ≤ Vector.normSq (Matrix.rowCombination rows coeffs) := by
+    (rows.row k).normSq ≤ (Matrix.rowCombination rows coeffs).normSq := by
   rw [rowCombination_eq_foldl_rows, foldl_orthogonal_expansion_normSq_zero rows coeffs horth]
   exact foldl_orthogonal_weighted_normSq_ge (xs := List.finRange n)
     (rows := rows) (coeffs := coeffs) k (by simp) hcoeff
@@ -1586,9 +1586,9 @@ theorem one_le_intCast_mul_self_of_ne_zero (z : Int) (hz : z ≠ 0) :
 private theorem eq_zero_of_prefixSpan
     (M : Matrix Rat n m) (i : Nat) (hi : i < n) (v : Vector Rat m)
     (hspan : prefixSpan M i hi v)
-    (horth : ∀ j : Fin (i + 1), Vector.dotProduct v ((prefixRows M i hi).row j) = 0) :
+    (horth : ∀ j : Fin (i + 1), v.dotProduct ((prefixRows M i hi).row j) = 0) :
     v = 0 := by
-  have hself : Vector.dotProduct v v = 0 :=
+  have hself : v.dotProduct v = 0 :=
     dot_eq_zero_of_prefixSpan M i hi v v hspan horth
   apply Vector.ext
   intro idx hidx
@@ -1604,8 +1604,8 @@ private theorem residual_eq_of_same_prefixSpan
     (row r s : Vector Rat m)
     (hrspan : prefixSpan M i hi (row - r))
     (hsspan : prefixSpan M i hi (row - s))
-    (hrorth : ∀ j : Fin (i + 1), Vector.dotProduct r ((prefixRows M i hi).row j) = 0)
-    (hsorth : ∀ j : Fin (i + 1), Vector.dotProduct s ((prefixRows M i hi).row j) = 0) :
+    (hrorth : ∀ j : Fin (i + 1), r.dotProduct ((prefixRows M i hi).row j) = 0)
+    (hsorth : ∀ j : Fin (i + 1), s.dotProduct ((prefixRows M i hi).row j) = 0) :
     r = s := by
   have hspanDiff :
       prefixSpan M i hi ((row - s) - (row - r)) :=
@@ -1618,7 +1618,7 @@ private theorem residual_eq_of_same_prefixSpan
   have hspan : prefixSpan M i hi (r - s) := by
     simpa [hdiff_eq] using hspanDiff
   have horth : ∀ j : Fin (i + 1),
-      Vector.dotProduct (r - s) ((prefixRows M i hi).row j) = 0 := by
+      (r - s).dotProduct ((prefixRows M i hi).row j) = 0 := by
     intro j
     rw [dot_comm_rat (r - s) ((prefixRows M i hi).row j), dot_sub_right]
     rw [dot_comm_rat ((prefixRows M i hi).row j) r,
@@ -1644,8 +1644,8 @@ private theorem residual_eq_of_equiv_prefixSpan
     (hB_to_A : ∀ v : Vector Rat m, prefixSpan B i hi v → prefixSpan A i hi v)
     (hA_rows_to_B :
       ∀ j : Fin (i + 1), prefixSpan B i hi ((prefixRows A i hi).row j))
-    (hrorth : ∀ j : Fin (i + 1), Vector.dotProduct r ((prefixRows A i hi).row j) = 0)
-    (hsorth : ∀ j : Fin (i + 1), Vector.dotProduct s ((prefixRows B i hi).row j) = 0) :
+    (hrorth : ∀ j : Fin (i + 1), r.dotProduct ((prefixRows A i hi).row j) = 0)
+    (hsorth : ∀ j : Fin (i + 1), s.dotProduct ((prefixRows B i hi).row j) = 0) :
     r = s := by
   apply residual_eq_of_same_prefixSpan A i hi row r s hrspan (hB_to_A _ hsspan) hrorth
   intro j

--- a/HexGramSchmidt/Basic/Rat.lean
+++ b/HexGramSchmidt/Basic/Rat.lean
@@ -52,7 +52,7 @@ basis rows are mutually orthogonal (their dot product is zero). -/
 @[grind =]
 theorem basis_orthogonal (b : Matrix Rat n m)
     (i j : Nat) (hi : i < n) (hj : j < n) (hij : i ≠ j) :
-    Vector.dotProduct ((basis b).row ⟨i, hi⟩) ((basis b).row ⟨j, hj⟩) = 0 := by
+    ((basis b).row ⟨i, hi⟩).dotProduct ((basis b).row ⟨j, hj⟩) = 0 := by
   rw [basis, GramSchmidt.basisMatrix_row_eq_basisRows_get!,
     GramSchmidt.basisMatrix_row_eq_basisRows_get!]
   exact GramSchmidt.basisRows_get!_dot_eq_zero b i j hi hj hij
@@ -91,10 +91,10 @@ coefficient of the input row onto the earlier generated basis row. -/
 theorem coeffs_lower_projection (b : Matrix Rat n m) {i j : Fin n}
     (hji : j.val < i.val) :
     GramSchmidt.entry (coeffs b) i j =
-      (if Vector.dotProduct ((basis b).row j) ((basis b).row j) = 0 then 0
+      (if ((basis b).row j).dotProduct ((basis b).row j) = 0 then 0
        else
-        Vector.dotProduct (b.row i) ((basis b).row j) /
-          Vector.dotProduct ((basis b).row j) ((basis b).row j)) := by
+        (b.row i).dotProduct ((basis b).row j) /
+          ((basis b).row j).dotProduct ((basis b).row j)) := by
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn,
     GramSchmidt.projectionCoeff, Matrix.row, hji]
 
@@ -103,12 +103,12 @@ Mathlib's projection coefficient numerator. -/
 theorem coeffs_lower_projection_comm (b : Matrix Rat n m) {i j : Fin n}
     (hji : j.val < i.val) :
     GramSchmidt.entry (coeffs b) i j =
-      (if Vector.dotProduct ((basis b).row j) ((basis b).row j) = 0 then 0
+      (if ((basis b).row j).dotProduct ((basis b).row j) = 0 then 0
        else
-        Vector.dotProduct ((basis b).row j) (b.row i) /
-          Vector.dotProduct ((basis b).row j) ((basis b).row j)) := by
+        ((basis b).row j).dotProduct (b.row i) /
+          ((basis b).row j).dotProduct ((basis b).row j)) := by
   rw [coeffs_lower_projection (b := b) hji]
-  by_cases hnorm : Vector.dotProduct ((basis b).row j) ((basis b).row j) = 0
+  by_cases hnorm : ((basis b).row j).dotProduct ((basis b).row j) = 0
   · simp [hnorm]
   · simp [hnorm, GramSchmidt.dot_comm_rat]
 
@@ -200,9 +200,9 @@ private theorem projectionCoeff_row_later_basis_eq_zero
           (Nat.ne_of_lt hidx_col))
   rw [hreduce] at hproj
   have hzero : GramSchmidt.projectionCoeff (0 : Vector Rat m) ((basis b).row col) = 0 := by
-    by_cases hnorm : Vector.dotProduct ((basis b).row col) ((basis b).row col) = 0
+    by_cases hnorm : ((basis b).row col).dotProduct ((basis b).row col) = 0
     · simp [GramSchmidt.projectionCoeff, hnorm]
-    · have hdot : Vector.dotProduct (0 : Vector Rat m) ((basis b).row col) = 0 := by
+    · have hdot : (0 : Vector Rat m).dotProduct ((basis b).row col) = 0 := by
         unfold Vector.dotProduct
         induction List.finRange m with
         | nil => rfl
@@ -213,14 +213,14 @@ private theorem projectionCoeff_row_later_basis_eq_zero
               rw [Vector.getElem_zero]
             rw [hentry, show (0 : Rat) + 0 * ((basis b).row col)[idx] = 0 by grind]
             exact ih
-      have hzero_div : (0 : Rat) / Vector.dotProduct ((basis b).row col) ((basis b).row col) = 0 := by
+      have hzero_div : (0 : Rat) / ((basis b).row col).dotProduct ((basis b).row col) = 0 := by
         grind
       simp [GramSchmidt.projectionCoeff, hnorm, hdot, hzero_div]
   simpa [hzero] using hproj.symm
 
 private theorem projectionCoeff_row_basis_self_eq_one
     (b : Matrix Rat n m) (src : Fin n)
-    (hnorm : Vector.dotProduct ((basis b).row src) ((basis b).row src) ≠ 0) :
+    (hnorm : ((basis b).row src).dotProduct ((basis b).row src) ≠ 0) :
     GramSchmidt.projectionCoeff (b.row src) ((basis b).row src) = 1 := by
   have hsrc_toList : b.toList[src.val]! = b.row src := by simp [Matrix.row]
   have hbasis_src :
@@ -270,8 +270,8 @@ private theorem projectionCoeff_row_basis_self_eq_one
   have hself :
       GramSchmidt.projectionCoeff ((basis b).row src) ((basis b).row src) = 1 := by
     have hdiv :
-        Vector.dotProduct ((basis b).row src) ((basis b).row src) /
-            Vector.dotProduct ((basis b).row src) ((basis b).row src) = 1 := by
+        ((basis b).row src).dotProduct ((basis b).row src) /
+            ((basis b).row src).dotProduct ((basis b).row src) = 1 := by
       grind
     simp [GramSchmidt.projectionCoeff, hnorm, hdiv]
   simpa [hself] using hproj.symm
@@ -291,8 +291,8 @@ theorem basis_rowSwap_adjacent_curr (b : Matrix Rat n m) (km1 k : Fin n)
     let mu := GramSchmidt.entry (coeffs b) k km1
     let swappedPrev := curr + mu • prev
     (basis (Matrix.rowSwap b km1 k)).row k =
-      (Vector.dotProduct curr curr / Vector.dotProduct swappedPrev swappedPrev) • prev -
-        (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) • curr := by
+      (curr.dotProduct curr / swappedPrev.dotProduct swappedPrev) • prev -
+        (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) • curr := by
   let prev := (basis b).row km1
   let curr := (basis b).row k
   let mu := GramSchmidt.entry (coeffs b) k km1
@@ -311,69 +311,69 @@ theorem basis_rowSwap_adjacent_curr (b : Matrix Rat n m) (km1 k : Fin n)
       (basis (Matrix.rowSwap b km1 k)).row k =
         prev - GramSchmidt.projectionCoeff (b.row km1) swappedPrev • swappedPrev := by
     simpa [basis, prev, curr, mu, swappedPrev, hmu_raw] using hraw
-  have horth_curr_prev : Vector.dotProduct curr prev = 0 := by
+  have horth_curr_prev : curr.dotProduct prev = 0 := by
     simpa [curr, prev] using
       basis_orthogonal (b := b) k.val km1.val k.isLt km1.isLt (by omega)
-  have horth_prev_curr : Vector.dotProduct prev curr = 0 := by
+  have horth_prev_curr : prev.dotProduct curr = 0 := by
     simpa [prev, curr, GramSchmidt.dot_comm_rat] using horth_curr_prev
-  have hrow_curr : Vector.dotProduct (b.row km1) curr = 0 := by
+  have hrow_curr : (b.row km1).dotProduct curr = 0 := by
     have hpc :=
       projectionCoeff_row_later_basis_eq_zero (b := b) (src := km1) (col := k) hlt
-    by_cases hcurr : Vector.dotProduct curr curr = 0
+    by_cases hcurr : curr.dotProduct curr = 0
     · exact GramSchmidt.dot_zero_of_dot_self_zero (row := b.row km1) (v := curr) hcurr
     · have hdiv :
-        Vector.dotProduct (b.row km1) curr / Vector.dotProduct curr curr = 0 := by
+        (b.row km1).dotProduct curr / curr.dotProduct curr = 0 := by
           simpa [curr, GramSchmidt.projectionCoeff, hcurr] using hpc
       grind
-  have hrow_prev : Vector.dotProduct (b.row km1) prev = Vector.dotProduct prev prev := by
-    by_cases hprev : Vector.dotProduct prev prev = 0
+  have hrow_prev : (b.row km1).dotProduct prev = prev.dotProduct prev := by
+    by_cases hprev : prev.dotProduct prev = 0
     · have hzero := GramSchmidt.dot_zero_of_dot_self_zero (row := b.row km1) (v := prev) hprev
       simp [hzero, hprev]
     · have hpc := projectionCoeff_row_basis_self_eq_one (b := b) (src := km1) (by
         simpa [prev] using hprev)
       have hdiv :
-        Vector.dotProduct (b.row km1) prev / Vector.dotProduct prev prev = 1 := by
+        (b.row km1).dotProduct prev / prev.dotProduct prev = 1 := by
           simpa [prev, GramSchmidt.projectionCoeff, hprev] using hpc
       grind
   have hrow_swapped :
-      Vector.dotProduct (b.row km1) swappedPrev = mu * Vector.dotProduct prev prev := by
+      (b.row km1).dotProduct swappedPrev = mu * prev.dotProduct prev := by
     rw [GramSchmidt.dot_comm_rat]
-    change Vector.dotProduct (curr + mu • prev) (b.row km1) = mu * Vector.dotProduct prev prev
+    change (curr + mu • prev).dotProduct (b.row km1) = mu * prev.dotProduct prev
     rw [GramSchmidt.dot_add_left, GramSchmidt.dot_smul_left]
-    have hcurr_row : Vector.dotProduct curr (b.row km1) = 0 := by
+    have hcurr_row : curr.dotProduct (b.row km1) = 0 := by
       simpa [GramSchmidt.dot_comm_rat] using hrow_curr
-    have hprev_row : Vector.dotProduct prev (b.row km1) = Vector.dotProduct prev prev := by
+    have hprev_row : prev.dotProduct (b.row km1) = prev.dotProduct prev := by
       simpa [GramSchmidt.dot_comm_rat] using hrow_prev
     rw [hcurr_row, hprev_row]
     grind
   have hproj :
       GramSchmidt.projectionCoeff (b.row km1) swappedPrev =
-        mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev := by
-    have hnorm' : Vector.dotProduct swappedPrev swappedPrev ≠ 0 := by
+        mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev := by
+    have hnorm' : swappedPrev.dotProduct swappedPrev ≠ 0 := by
       simpa [prev, curr, mu, swappedPrev] using hnorm
     simp [GramSchmidt.projectionCoeff, hnorm', hrow_swapped]
-  have hcurr_swapped : Vector.dotProduct curr swappedPrev = Vector.dotProduct curr curr := by
+  have hcurr_swapped : curr.dotProduct swappedPrev = curr.dotProduct curr := by
     rw [GramSchmidt.dot_comm_rat]
-    change Vector.dotProduct (curr + mu • prev) curr = Vector.dotProduct curr curr
+    change (curr + mu • prev).dotProduct curr = curr.dotProduct curr
     rw [GramSchmidt.dot_add_left, GramSchmidt.dot_smul_left, horth_prev_curr]
     grind
-  have hprev_swapped : Vector.dotProduct prev swappedPrev = mu * Vector.dotProduct prev prev := by
+  have hprev_swapped : prev.dotProduct swappedPrev = mu * prev.dotProduct prev := by
     rw [GramSchmidt.dot_comm_rat]
-    change Vector.dotProduct (curr + mu • prev) prev = mu * Vector.dotProduct prev prev
+    change (curr + mu • prev).dotProduct prev = mu * prev.dotProduct prev
     rw [GramSchmidt.dot_add_left, GramSchmidt.dot_smul_left, horth_curr_prev]
     grind
   have hdenom :
-      Vector.dotProduct swappedPrev swappedPrev =
-        Vector.dotProduct curr curr + mu * mu * Vector.dotProduct prev prev := by
-    change Vector.dotProduct (curr + mu • prev) swappedPrev =
-      Vector.dotProduct curr curr + mu * mu * Vector.dotProduct prev prev
+      swappedPrev.dotProduct swappedPrev =
+        curr.dotProduct curr + mu * mu * prev.dotProduct prev := by
+    change (curr + mu • prev).dotProduct swappedPrev =
+      curr.dotProduct curr + mu * mu * prev.dotProduct prev
     rw [GramSchmidt.dot_add_left, GramSchmidt.dot_smul_left, hcurr_swapped, hprev_swapped]
     grind
   rw [hraw', hproj]
   change
-    prev - (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) • swappedPrev =
-      (Vector.dotProduct curr curr / Vector.dotProduct swappedPrev swappedPrev) • prev -
-        (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) • curr
+    prev - (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) • swappedPrev =
+      (curr.dotProduct curr / swappedPrev.dotProduct swappedPrev) • prev -
+        (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) • curr
   apply Vector.ext
   intro idx hidx
   simp only [Vector.getElem_sub, Vector.getElem_smul]
@@ -384,11 +384,11 @@ theorem basis_rowSwap_adjacent_curr (b : Matrix Rat n m) (km1 k : Fin n)
   rw [hswapped_idx]
   change
     prev[idx] -
-        (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) *
+        (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) *
           (curr[idx] + mu * prev[idx]) =
-      (Vector.dotProduct curr curr / Vector.dotProduct swappedPrev swappedPrev) * prev[idx] -
-        (mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) * curr[idx]
-  have hdenom_ne : Vector.dotProduct swappedPrev swappedPrev ≠ 0 := by
+      (curr.dotProduct curr / swappedPrev.dotProduct swappedPrev) * prev[idx] -
+        (mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) * curr[idx]
+  have hdenom_ne : swappedPrev.dotProduct swappedPrev ≠ 0 := by
     simpa [prev, curr, mu, swappedPrev] using hnorm
   rw [hdenom]
   grind
@@ -472,7 +472,7 @@ theorem coeffs_rowSwap_adjacent_pivot (b : Matrix Rat n m) (km1 k : Fin n)
     let curr := (basis b).row k
     let swappedPrev := curr + mu • prev
     GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) k km1 =
-      mu * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev := by
+      mu * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev := by
   let mu := GramSchmidt.entry (coeffs b) k km1
   let prev := (basis b).row km1
   let curr := (basis b).row k
@@ -486,40 +486,40 @@ theorem coeffs_rowSwap_adjacent_pivot (b : Matrix Rat n m) (km1 k : Fin n)
     simpa [swappedPrev, curr, prev, mu] using
       basis_rowSwap_adjacent_prev (b := b) (km1 := km1) (k := k) hkm1
   rw [hrow, hbasis]
-  have horth_curr_prev : Vector.dotProduct curr prev = 0 := by
+  have horth_curr_prev : curr.dotProduct prev = 0 := by
     simpa [curr, prev] using
       basis_orthogonal (b := b) k.val km1.val k.isLt km1.isLt (by omega)
-  have hrow_curr : Vector.dotProduct (b.row km1) curr = 0 := by
+  have hrow_curr : (b.row km1).dotProduct curr = 0 := by
     have hpc :=
       projectionCoeff_row_later_basis_eq_zero (b := b) (src := km1) (col := k) hkm1k
-    by_cases hcurr : Vector.dotProduct curr curr = 0
+    by_cases hcurr : curr.dotProduct curr = 0
     · exact GramSchmidt.dot_zero_of_dot_self_zero (row := b.row km1) (v := curr) hcurr
     · have hdiv :
-        Vector.dotProduct (b.row km1) curr / Vector.dotProduct curr curr = 0 := by
+        (b.row km1).dotProduct curr / curr.dotProduct curr = 0 := by
           simpa [curr, GramSchmidt.projectionCoeff, hcurr] using hpc
       grind
-  have hrow_prev : Vector.dotProduct (b.row km1) prev = Vector.dotProduct prev prev := by
-    by_cases hprev : Vector.dotProduct prev prev = 0
+  have hrow_prev : (b.row km1).dotProduct prev = prev.dotProduct prev := by
+    by_cases hprev : prev.dotProduct prev = 0
     · have hzero := GramSchmidt.dot_zero_of_dot_self_zero (row := b.row km1) (v := prev) hprev
       simp [hzero, hprev]
     · have hpc := projectionCoeff_row_basis_self_eq_one (b := b) (src := km1) (by
         simpa [prev] using hprev)
       have hdiv :
-        Vector.dotProduct (b.row km1) prev / Vector.dotProduct prev prev = 1 := by
+        (b.row km1).dotProduct prev / prev.dotProduct prev = 1 := by
           simpa [prev, GramSchmidt.projectionCoeff, hprev] using hpc
       grind
   have hrow_swapped :
-      Vector.dotProduct (b.row km1) swappedPrev = mu * Vector.dotProduct prev prev := by
+      (b.row km1).dotProduct swappedPrev = mu * prev.dotProduct prev := by
     rw [GramSchmidt.dot_comm_rat]
-    change Vector.dotProduct (curr + mu • prev) (b.row km1) = mu * Vector.dotProduct prev prev
+    change (curr + mu • prev).dotProduct (b.row km1) = mu * prev.dotProduct prev
     rw [GramSchmidt.dot_add_left, GramSchmidt.dot_smul_left]
-    have hcurr_row : Vector.dotProduct curr (b.row km1) = 0 := by
+    have hcurr_row : curr.dotProduct (b.row km1) = 0 := by
       simpa [GramSchmidt.dot_comm_rat] using hrow_curr
-    have hprev_row : Vector.dotProduct prev (b.row km1) = Vector.dotProduct prev prev := by
+    have hprev_row : prev.dotProduct (b.row km1) = prev.dotProduct prev := by
       simpa [GramSchmidt.dot_comm_rat] using hrow_prev
     rw [hcurr_row, hprev_row]
     grind
-  have hnorm' : Vector.dotProduct swappedPrev swappedPrev ≠ 0 := by
+  have hnorm' : swappedPrev.dotProduct swappedPrev ≠ 0 := by
     simpa [swappedPrev, curr, prev, mu] using hnorm
   simp [hnorm', hrow_swapped, swappedPrev, curr, prev, mu]
 
@@ -551,7 +551,7 @@ destination row increases by `c` when the source basis row has nonzero norm. -/
 @[grind =]
 theorem coeffs_rowAdd_pivot (b : Matrix Rat n m) (src dst : Fin n)
     (hsrcdst : src.val < dst.val) (c : Rat)
-    (hnorm : Vector.dotProduct ((basis b).row src) ((basis b).row src) ≠ 0) :
+    (hnorm : ((basis b).row src).dotProduct ((basis b).row src) ≠ 0) :
     GramSchmidt.entry (coeffs (Matrix.rowAdd b src dst c)) dst src =
       GramSchmidt.entry (coeffs b) dst src + c := by
   have hbasis := basis_rowAdd (b := b) (src := src) (dst := dst) (c := c) hsrcdst
@@ -827,7 +827,7 @@ private theorem basis_row_orthogonal_prefix_pred
     (b : Matrix Rat n m) (i p : Nat) (hi : i < n) (hp : p < n)
     (hsucc : p + 1 = i) :
     ∀ j : Fin (p + 1),
-      Vector.dotProduct ((basis b).row ⟨i, hi⟩)
+      ((basis b).row ⟨i, hi⟩).dotProduct
         ((GramSchmidt.prefixRows (basis b) p hp).row j) = 0 := by
   subst i
   intro j

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -28,7 +28,7 @@ structure BareissGramRowInvariant (b : Matrix Int n m)
     (coeff i)[k] = 0
   entry_eq_dot : ∀ i j : Fin n, state.step ≤ i.val →
     state.matrix[i][j] =
-      Vector.dotProduct (Matrix.rowCombination b (coeff i)) (b.row j)
+      (Matrix.rowCombination b (coeff i)).dotProduct (b.row j)
 
 /-- The initial no-pivot Gram state satisfies the row-coefficient invariant
 with each row represented by the standard basis vector `eᵢ`. -/
@@ -78,8 +78,8 @@ private theorem foldl_sum_bareiss_row_update
 /-- `dot_bareiss_row_update_left` expands the dot product of a Bareiss-updated left vector as the corresponding linear combination of dots. -/
 private theorem dot_bareiss_row_update_left
     (x y : Int) (u v w : Vector Int m) :
-    Vector.dotProduct (Vector.ofFn fun a : Fin m => x * u[a] - y * v[a]) w =
-      x * Vector.dotProduct u w - y * Vector.dotProduct v w := by
+    (Vector.ofFn fun a : Fin m => x * u[a] - y * v[a]).dotProduct w =
+      x * u.dotProduct w - y * v.dotProduct w := by
   unfold Vector.dotProduct
   simpa using
     foldl_sum_bareiss_row_update
@@ -113,8 +113,8 @@ private theorem foldl_sum_bareiss_row_update_right
 /-- `dot_bareiss_row_update_right` expands the dot product with a Bareiss-updated right vector as the corresponding linear combination of dots. -/
 private theorem dot_bareiss_row_update_right
     (x y : Int) (w u v : Vector Int m) :
-    Vector.dotProduct w (Vector.ofFn fun a : Fin m => x * u[a] - y * v[a]) =
-      x * Vector.dotProduct w u - y * Vector.dotProduct w v := by
+    w.dotProduct (Vector.ofFn fun a : Fin m => x * u[a] - y * v[a]) =
+      x * w.dotProduct u - y * w.dotProduct v := by
   unfold Vector.dotProduct
   simpa using
     foldl_sum_bareiss_row_update_right
@@ -186,7 +186,7 @@ private theorem dot_rowCombination_exactDiv_eq_of_eq_mul_right
         (Matrix.rowCombination M
           (Vector.ofFn fun a : Fin n => Matrix.exactDiv (num a) denom))
         w =
-      Vector.dotProduct (Matrix.rowCombination M (Vector.ofFn q)) w := by
+      (Matrix.rowCombination M (Vector.ofFn q)).dotProduct w := by
   rw [rowCombination_exactDiv_eq_of_eq_mul_right M hdenom num q hnum]
 
 /-- Project the explicit coefficient witness for the row at index `i`. -/
@@ -472,7 +472,7 @@ private theorem dot_rowCombination_mul_right_int
     (b : Matrix Int n m) (f : Fin n → Int) (s : Int) (w : Vector Int m) :
     Vector.dotProduct
         (Matrix.rowCombination b (Vector.ofFn fun a : Fin n => f a * s)) w =
-      Vector.dotProduct (Matrix.rowCombination b (Vector.ofFn f)) w * s := by
+      (Matrix.rowCombination b (Vector.ofFn f)).dotProduct w * s := by
   have h_eq_input :
       (Vector.ofFn fun a : Fin n => f a * s) =
         Vector.ofFn fun a : Fin n =>

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -51,7 +51,7 @@ private theorem rowCombination_int_getElem
         (fun (acc : Int) (i : Fin n) => acc + b[i][col] * c[i]) 0 := by
   show (Matrix.transpose b * c)[col] = _
   rw [Matrix.getElem_mulVec]
-  show Vector.dotProduct ((Matrix.transpose b).row col) c = _
+  show ((Matrix.transpose b).row col).dotProduct c = _
   simp [Vector.dotProduct, Matrix.row, Matrix.transpose, Matrix.col]
 
 /-- Entry expansion of the cast prefix row combination. The `(j + 1)`-row prefix
@@ -69,7 +69,7 @@ private theorem rowCombination_prefix_castIntMatrix_getElem
           acc + (b[jn][col] : Rat) * (c[jn] : Rat)) 0 := by
   show (Matrix.transpose _ * _)[col] = _
   rw [Matrix.getElem_mulVec]
-  show Vector.dotProduct ((Matrix.transpose _).row col) _ = _
+  show ((Matrix.transpose _).row col).dotProduct _ = _
   simp [Vector.dotProduct, GramSchmidt.prefixRows,
     castIntMatrix, prefixCoeffsCast, Matrix.row, Matrix.transpose, Matrix.col]
 
@@ -368,9 +368,9 @@ transfers norm facts proved over `ℤ` into the rational Gram-Schmidt setting. A
 a `simp` rule it pushes the cast outward, putting the rational squared norm in
 the normal form `((normSq v : Int) : Rat)`. -/
 @[simp, grind =] theorem normSq_map_intCast (v : Vector Int m) :
-    Vector.normSq (Vector.map (fun x : Int => (x : Rat)) v) =
-      ((Vector.normSq v : Int) : Rat) := by
-  simpa [Vector.normSq, Hex.Vector.normSq, Vector.dotProduct]
+    (Vector.map (fun x : Int => (x : Rat)) v).normSq =
+      ((v.normSq : Int) : Rat) := by
+  simpa [Vector.normSq, Vector.dotProduct]
     using (foldl_int_dot_cast (List.finRange m)
       (fun i : Fin m => v[i]) (fun i : Fin m => v[i]) 0).symm
 
@@ -382,7 +382,7 @@ theorem normSq_latticeVec_ge_min_basis_normSq
     (b : Matrix Int n m) (_hli : independent b)
     (v : Vector Int m) (hv : memLattice b v) (hv' : v ≠ 0) :
     ∃ i : Fin n,
-      Vector.normSq ((basis b).row i) ≤ ((Vector.normSq v : Int) : Rat) := by
+      ((basis b).row i).normSq ≤ ((v.normSq : Int) : Rat) := by
   rcases hv with ⟨c, hcv⟩
   have hc_nonzero : ∃ i : Fin n, c[i] ≠ 0 := by
     by_cases h : ∃ i : Fin n, c[i] ≠ 0
@@ -410,14 +410,14 @@ theorem normSq_latticeVec_ge_min_basis_normSq
     exact GramSchmidt.one_le_intCast_mul_self_of_ne_zero c[k] hck
   refine ⟨k, ?_⟩
   have horth : ∀ i j : Fin n, i ≠ j →
-      Vector.dotProduct ((basis b).row i) ((basis b).row j) = 0 := by
+      ((basis b).row i).dotProduct ((basis b).row j) = 0 := by
     intro i j hij
     exact basis_orthogonal b i.val j.val i.isLt j.isLt (by
       intro hval
       exact hij (Fin.ext hval))
   have hle :
-      Vector.normSq ((basis b).row k) ≤
-        Vector.normSq (Matrix.rowCombination (basis b) d) :=
+      ((basis b).row k).normSq ≤
+        (Matrix.rowCombination (basis b) d).normSq :=
     GramSchmidt.rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one
       (rows := basis b) (coeffs := d) (k := k) horth hcoeff_sq
   have hrec :
@@ -427,8 +427,8 @@ theorem normSq_latticeVec_ge_min_basis_normSq
     dsimp [d]
     exact rowCombination_basis_coeffs_reconstruction b c
   have hnorm :
-      Vector.normSq (Matrix.rowCombination (basis b) d) =
-        ((Vector.normSq v : Int) : Rat) := by
+      (Matrix.rowCombination (basis b) d).normSq =
+        ((v.normSq : Int) : Rat) := by
     rw [← hrec, normSq_map_intCast]
   rw [← hnorm]
   exact hle
@@ -448,7 +448,7 @@ theorem exists_top_index_normSq_le_of_memLattice
       Matrix.rowCombination b c = v ∧
       c[k] ≠ 0 ∧
       (∀ j : Fin n, k.val < j.val → c[j] = 0) ∧
-      Vector.normSq ((basis b).row k) ≤ ((Vector.normSq v : Int) : Rat) := by
+      ((basis b).row k).normSq ≤ ((v.normSq : Int) : Rat) := by
   rcases hv with ⟨c, hcv⟩
   have hc_nonzero : ∃ i : Fin n, c[i] ≠ 0 := by
     by_cases h : ∃ i : Fin n, c[i] ≠ 0
@@ -475,14 +475,14 @@ theorem exists_top_index_normSq_le_of_memLattice
     rw [htop]
     exact GramSchmidt.one_le_intCast_mul_self_of_ne_zero c[k] hck
   have horth : ∀ i j : Fin n, i ≠ j →
-      Vector.dotProduct ((basis b).row i) ((basis b).row j) = 0 := by
+      ((basis b).row i).dotProduct ((basis b).row j) = 0 := by
     intro i j hij
     exact basis_orthogonal b i.val j.val i.isLt j.isLt (by
       intro hval
       exact hij (Fin.ext hval))
   have hle :
-      Vector.normSq ((basis b).row k) ≤
-        Vector.normSq (Matrix.rowCombination (basis b) d) :=
+      ((basis b).row k).normSq ≤
+        (Matrix.rowCombination (basis b) d).normSq :=
     GramSchmidt.rowCombination_normSq_ge_of_orthogonal_coeff_sq_ge_one
       (rows := basis b) (coeffs := d) (k := k) horth hcoeff_sq
   have hrec :
@@ -492,8 +492,8 @@ theorem exists_top_index_normSq_le_of_memLattice
     dsimp [d]
     exact rowCombination_basis_coeffs_reconstruction b c
   have hnorm :
-      Vector.normSq (Matrix.rowCombination (basis b) d) =
-        ((Vector.normSq v : Int) : Rat) := by
+      (Matrix.rowCombination (basis b) d).normSq =
+        ((v.normSq : Int) : Rat) := by
     rw [← hrec, normSq_map_intCast]
   rw [← hnorm]
   exact hle
@@ -514,7 +514,7 @@ private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))
 
 /-- The dot product of integer vectors is commutative. -/
 private theorem dot_comm_int {n' : Nat} (u v : Vector Int n') :
-    Vector.dotProduct u v = Vector.dotProduct v u := by
+    u.dotProduct v = v.dotProduct u := by
   simpa [Vector.dotProduct] using
     foldl_dot_comm_int (xs := List.finRange n') (u := u) (v := v)
       (accU := 0) (accV := 0) rfl
@@ -524,9 +524,9 @@ swapped index. Consumed by the no-pivot Bareiss symmetry/transpose argument for
 bordered minors of `gramMatrix b`. -/
 private theorem gramMatrix_symm (b : Matrix Int n m) (a c : Fin n) :
     (Matrix.gramMatrix b)[a][c] = (Matrix.gramMatrix b)[c][a] := by
-  show (Matrix.ofFn fun i j => Hex.Vector.dotProduct
+  show (Matrix.ofFn fun i j => Vector.dotProduct
         (Matrix.row b i) (Matrix.row b j))[a][c]
-    = (Matrix.ofFn fun i j => Hex.Vector.dotProduct
+    = (Matrix.ofFn fun i j => Vector.dotProduct
         (Matrix.row b i) (Matrix.row b j))[c][a]
   simp [Matrix.ofFn, Vector.getElem_ofFn]
   exact dot_comm_int _ _

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -42,7 +42,7 @@ def liftFinLE (i : Fin k) (hk : k ≤ n) : Fin n :=
 @[expose]
 def leadingGramMatrixInt (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Matrix Int k k :=
   Matrix.ofFn fun i j =>
-    Vector.dotProduct (b.row (liftFinLE i hk)) (b.row (liftFinLE j hk))
+    (b.row (liftFinLE i hk)).dotProduct (b.row (liftFinLE j hk))
 
 /-- The Gram-Schmidt leading Gram matrix is the leading prefix of the full
 Gram matrix. This is the shape equation between the public `gramDet` API and
@@ -62,7 +62,7 @@ theorem leadingGramMatrixInt_eq_principalSubmatrix_gram
 @[expose]
 def leadingGramMatrixRat (b : Matrix Rat n m) (k : Nat) (hk : k ≤ n) : Matrix Rat k k :=
   Matrix.ofFn fun i j =>
-    Vector.dotProduct (b.row (liftFinLE i hk)) (b.row (liftFinLE j hk))
+    (b.row (liftFinLE i hk)).dotProduct (b.row (liftFinLE j hk))
 
 /-- Determinant matrix used by the integral `scaledCoeffs` entry formula:
 take the leading `j + 1` Gram matrix and replace its last column by the inner
@@ -74,10 +74,10 @@ def scaledCoeffMatrix (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val) :
   Matrix.ofFn fun p q =>
     let p' := liftFinLE p hk
     if q.val = j.val then
-      Vector.dotProduct (b.row p') (b.row i)
+      (b.row p').dotProduct (b.row i)
     else
       let q' := liftFinLE q hk
-      Vector.dotProduct (b.row p') (b.row q')
+      (b.row p').dotProduct (b.row q')
 
 end GramSchmidt
 
@@ -110,7 +110,7 @@ noncomputable def gramSchmidtNormProduct (b : Matrix Int n m) (k : Nat) (hk : k 
   (List.finRange k).foldl
     (fun acc j =>
       let jn : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
-      acc * Vector.normSq ((basis b).row jn))
+      acc * ((basis b).row jn).normSq)
     1
 
 /-- Read a diagonal entry from a Bareiss elimination matrix as a natural
@@ -179,7 +179,7 @@ def zeroRows (n : Nat) : Array (Array Int) :=
 def gramRows (b : Matrix Int n m) : Array (Array Int) :=
   Array.ofFn fun i : Fin n =>
     Array.ofFn fun j : Fin n =>
-      Vector.dotProduct (b.row i) (b.row j)
+      (b.row i).dotProduct (b.row j)
 
 /-- Reading entry `(i, j)` of `gramRows b` recovers the Gram matrix entry
 `(gramMatrix b)[i][j]`. -/

--- a/HexGramSchmidt/Int/Correspondence.lean
+++ b/HexGramSchmidt/Int/Correspondence.lean
@@ -1078,7 +1078,7 @@ theorem rowCombination_coeffs_apply_eq_of_zero_above
             (fun acc i => acc + (coeffs b)[i][k] * castc[i]) 0 := by
     show ((coeffs b).transpose * castc)[k] = _
     rw [Matrix.getElem_mulVec]
-    show Vector.dotProduct (((coeffs b).transpose).row k) castc = _
+    show (((coeffs b).transpose).row k).dotProduct castc = _
     show (List.finRange n).foldl
         (fun acc i =>
           acc + (((coeffs b).transpose).row k)[i] * castc[i]) 0 = _

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -183,7 +183,7 @@ private theorem noPivotLoop_initial_gram_bareiss_step_dvd
   have hq := hquot fuel hinv h_canon h_prefix_none hnext hp i hi
   have h_step_le_i : state.step ≤ i.val := Nat.le_trans (Nat.le_succ _) hi
   have h_step_le_k : state.step ≤ k.val := Nat.le_refl _
-  refine ⟨Vector.dotProduct (Matrix.rowCombination b (Vector.ofFn hq.q)) (b.row j), ?_⟩
+  refine ⟨(Matrix.rowCombination b (Vector.ofFn hq.q)).dotProduct (b.row j), ?_⟩
   rw [hinv.entry_eq_dot i j h_step_le_i, hinv.entry_eq_dot k j h_step_le_k]
   rw [← dot_bareiss_row_update_left state.matrix[k][k] state.matrix[i][k]
         (Matrix.rowCombination b (hinv.coeff i))
@@ -222,7 +222,7 @@ private theorem noPivotLoop_initial_gram_exists_rowVec
         ∀ j : Fin n,
           (Matrix.noPivotLoop fuel
             (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[i][j] =
-            Vector.dotProduct v (b.row j) := by
+            v.dotProduct (b.row j) := by
   let hinv :=
     bareissGramRowInvariant_noPivotLoop_initial b fuel hquot
   refine ⟨Matrix.rowCombination b (hinv.coeff i), ?_, ?_⟩
@@ -294,11 +294,11 @@ private theorem foldl_int_dot_self_eq_zero_of_mem (xs : List (Fin m))
       | inr h =>
           exact ih (acc := acc + v[head] * v[head]) hnext_nonneg hzero i h
 
-/-- `int_dot_self_eq_zero_get`: from a vanishing self-dot `Vector.dotProduct v v = 0`
+/-- `int_dot_self_eq_zero_get`: from a vanishing self-dot `v.dotProduct v = 0`
 each component `v[i]` is zero, specialising the fold lemma to the full index
-list and the running form of `Vector.dotProduct`. -/
+list and the running form of ``..dotProduct -/
 private theorem int_dot_self_eq_zero_get (v : Vector Int m)
-    (hzero : Vector.dotProduct v v = 0) (i : Fin m) :
+    (hzero : v.dotProduct v = 0) (i : Fin m) :
     v[i] = 0 := by
   have hmem : i ∈ List.finRange m := by simp
   exact foldl_int_dot_self_eq_zero_of_mem (xs := List.finRange m) (v := v)
@@ -308,8 +308,8 @@ private theorem int_dot_self_eq_zero_get (v : Vector Int m)
 /-- If `v : Vector Int m` has zero self-dot product, then any other integer
 vector dots it to zero from the left as well. -/
 private theorem int_dot_eq_zero_of_dot_self_zero_left (u v : Vector Int m)
-    (hzero : Vector.dotProduct v v = 0) :
-    Vector.dotProduct v u = 0 := by
+    (hzero : v.dotProduct v = 0) :
+    v.dotProduct u = 0 := by
   unfold Vector.dotProduct
   induction List.finRange m with
   | nil =>
@@ -341,7 +341,7 @@ private theorem foldl_dot_comm_int_local {n' : Nat} (xs : List (Fin n'))
 /-- The dot product of integer vectors is commutative. (Local form for use
 inside this file before the existing `dot_comm_int` declaration.) -/
 private theorem int_dot_comm_local {n' : Nat} (u v : Vector Int n') :
-    Vector.dotProduct u v = Vector.dotProduct v u := by
+    u.dotProduct v = v.dotProduct u := by
   simpa [Vector.dotProduct] using
     foldl_dot_comm_int_local (xs := List.finRange n') (u := u) (v := v)
       (accU := 0) (accV := 0) rfl
@@ -395,12 +395,12 @@ second argument's row combination distributes outside the sum, giving the
 identity. -/
 private theorem dot_rowCombination_right_eq
     {n m : Nat} (b : Matrix Int n m) (u : Vector Int m) (c : Vector Int n) :
-    Vector.dotProduct u (Matrix.rowCombination b c) =
+    u.dotProduct (Matrix.rowCombination b c) =
       (List.finRange n).foldl
-        (fun acc k => acc + c[k] * Vector.dotProduct u (b.row k)) 0 := by
+        (fun acc k => acc + c[k] * u.dotProduct (b.row k)) 0 := by
   -- Step 1: rewrite each (rowComb b c)[j] entry using getElem_rowCombination_int.
   have h_lhs :
-      Vector.dotProduct u (Matrix.rowCombination b c) =
+      u.dotProduct (Matrix.rowCombination b c) =
         (List.finRange m).foldl
           (fun accj j => accj + u[j] *
             (List.finRange n).foldl (fun acck k => acck + b[k][j] * c[k]) 0) 0 := by
@@ -437,7 +437,7 @@ private theorem dot_rowCombination_right_eq
   intro k _hk
   -- We want:
   --   (List.finRange m).foldl (fun accj j => accj + u[j] * (b[k][j] * c[k])) 0
-  --     = c[k] * Vector.dotProduct u (b.row k)
+  --     = c[k] * u.dotProduct (b.row k)
   -- Rearrange body so c[k] is the multiplier: u[j] * (b[k][j] * c[k])
   --     = c[k] * (u[j] * b[k][j]).
   have h_body :
@@ -457,10 +457,10 @@ private theorem dot_rowCombination_right_eq
   rw [h_zero] at h_pull
   rw [← h_pull]
   -- Goal: c[k] * (List.finRange m).foldl (fun accj j => accj + u[j] * b[k][j]) 0
-  --      = c[k] * Vector.dotProduct u (b.row k)
-  -- Rewrite Vector.dotProduct definitionally to the foldl form using row entry equality.
+  --      = c[k] * u.dotProduct (b.row k)
+  -- Rewrite definitionally.dotProduct to the foldl form using row entry equality.
   have h_dot_eq :
-      Vector.dotProduct u (b.row k) =
+      u.dotProduct (b.row k) =
         (List.finRange m).foldl (fun accj j => accj + u[j] * b[k][j]) 0 := by
     unfold Vector.dotProduct
     apply foldl_add_pointwise_eq_int
@@ -504,10 +504,10 @@ The argument: by the closed row-vector consumer, the represented pivot row has
 integer support on indices `≤ s` and inner product zero against `b.row k` for
 every `k.val ≤ s` (those matrix entries are either the zero pivot itself or
 zeros left by earlier regular elimination steps). Linearity of dot against
-`rowCombination` over the supported indices then gives `Vector.dotProduct v v = 0`,
+`rowCombination` over the supported indices then gives `v.dotProduct v = 0`,
 and integer positive definiteness forces every dot against `v` to be zero.
 Trailing-block symmetry transports
-`state.matrix[sFin][i] = Vector.dotProduct v (b.row i) = 0` across the diagonal to
+`state.matrix[sFin][i] = v.dotProduct (b.row i) = 0` across the diagonal to
 `state.matrix[i][sFin] = 0`. -/
 private theorem principalSubmatrix_gram_zero_pivot_column_zero
     {n m : Nat} (b : Matrix Int n m) (s : Nat) (hs : s + 1 < n)
@@ -536,14 +536,14 @@ private theorem principalSubmatrix_gram_zero_pivot_column_zero
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step ≤ sFin.val := by
     rw [h_step]; show s ≤ s; exact Nat.le_refl _
   -- The row-vector consumer aligns `matrix[sFin][j]` with
-  -- `Vector.dotProduct v (b.row j)` for all columns `j`.
+  -- `v.dotProduct (b.row j)` for all columns `j`.
   obtain ⟨v, ⟨c, h_coeff_supp_above, hv_def⟩, h_dot_eq_matrix⟩ :=
     noPivotLoop_initial_gram_exists_rowVec b s hquot sFin h_state_step_le_sFin
   -- The represented row is orthogonal to `b.row k` for every `k.val ≤ s`:
   -- on `k.val = s`, the hypothesis `h_zero` gives a zero pivot dot, and on
   -- `k.val < s` the column was cleared by an earlier regular Bareiss step.
   have h_dot_zero_le : ∀ k : Fin n, k.val ≤ s →
-      Vector.dotProduct v (b.row k) = 0 := by
+      v.dotProduct (b.row k) = 0 := by
     intro k hks
     rw [← h_dot_eq_matrix k]
     by_cases hk_eq : k.val = s
@@ -565,12 +565,12 @@ private theorem principalSubmatrix_gram_zero_pivot_column_zero
       exact noPivotLoop_matrix_processed_col_eq_zero s
         (Matrix.noPivotInitialState (Matrix.gramMatrix b)) h_prefix_none
         k.val h_init_step_le h_k_lt_result k rfl sFin h_k_lt_sFin
-  -- `Vector.dotProduct v v = 0`: every term in the rowCombination expansion is zero.
-  have h_dot_self_zero : Vector.dotProduct v v = 0 := by
+  -- `v.dotProduct v = 0`: every term in the rowCombination expansion is zero.
+  have h_dot_self_zero : v.dotProduct v = 0 := by
     have h_expand_aux :
-        Vector.dotProduct v (Matrix.rowCombination b c) =
+        v.dotProduct (Matrix.rowCombination b c) =
           (List.finRange n).foldl
-            (fun acc k => acc + c[k] * Vector.dotProduct v (b.row k))
+            (fun acc k => acc + c[k] * v.dotProduct (b.row k))
             0 :=
       dot_rowCombination_right_eq b v c
     rw [← hv_def] at h_expand_aux

--- a/HexGramSchmidt/Update.lean
+++ b/HexGramSchmidt/Update.lean
@@ -109,7 +109,7 @@ nondegeneracy hypothesis `hnorm` records that row `j` of the basis is nonzero,
 so its coefficient is well defined. -/
 theorem coeffs_sizeReduce_pivot (b : Matrix Int n m) (j k : Fin n) (hjk : j.val < k.val)
     (r : Int)
-    (hnorm : Vector.dotProduct ((basis b).row j) ((basis b).row j) ≠ 0) :
+    (hnorm : ((basis b).row j).dotProduct ((basis b).row j) ≠ 0) :
     GramSchmidt.entry (coeffs (sizeReduce b j k r)) k j =
       GramSchmidt.entry (coeffs b) k j - (r : Rat) := by
   rw [sizeReduce, coeffs_rowAdd_pivot (b := b) (src := j) (dst := k) hjk (c := -r) hnorm]
@@ -218,15 +218,15 @@ theorem basis_adjacentSwap_curr (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.val
       let km1 := GramSchmidt.prevRow k hk
       let swappedPrev :=
         (basis b).row k + GramSchmidt.entry (coeffs b) k km1 • (basis b).row km1
-      Vector.dotProduct swappedPrev swappedPrev ≠ 0) :
+      swappedPrev.dotProduct swappedPrev ≠ 0) :
     let km1 := GramSchmidt.prevRow k hk
     let μ := GramSchmidt.entry (coeffs b) k km1
     let prev := (basis b).row km1
     let curr := (basis b).row k
     let swappedPrev := curr + μ • prev
     (basis (adjacentSwap b k hk)).row k =
-      (Vector.dotProduct curr curr / Vector.dotProduct swappedPrev swappedPrev) • prev -
-        (μ * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev) • curr := by
+      (curr.dotProduct curr / swappedPrev.dotProduct swappedPrev) • prev -
+        (μ * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev) • curr := by
   let km1 := GramSchmidt.prevRow k hk
   have hkm1 : km1.val + 1 = k.val := by
     dsimp [km1, GramSchmidt.prevRow]
@@ -289,14 +289,14 @@ theorem coeffs_adjacentSwap_pivot (b : Matrix Int n m) (k : Fin n) (hk : 0 < k.v
       let km1 := GramSchmidt.prevRow k hk
       let swappedPrev :=
         (basis b).row k + GramSchmidt.entry (coeffs b) k km1 • (basis b).row km1
-      Vector.dotProduct swappedPrev swappedPrev ≠ 0) :
+      swappedPrev.dotProduct swappedPrev ≠ 0) :
     let km1 := GramSchmidt.prevRow k hk
     let μ := GramSchmidt.entry (coeffs b) k km1
     let prev := (basis b).row km1
     let curr := (basis b).row k
     let swappedPrev := curr + μ • prev
     GramSchmidt.entry (coeffs (adjacentSwap b k hk)) k km1 =
-      μ * Vector.dotProduct prev prev / Vector.dotProduct swappedPrev swappedPrev := by
+      μ * prev.dotProduct prev / swappedPrev.dotProduct swappedPrev := by
   let km1 := GramSchmidt.prevRow k hk
   have hkm1 : km1.val + 1 = k.val := by
     dsimp [km1, GramSchmidt.prevRow]

--- a/HexGramSchmidtMathlib/Basic.lean
+++ b/HexGramSchmidtMathlib/Basic.lean
@@ -102,7 +102,7 @@ theorem rowToEuclidean_inner (a b : Vector Rat m) :
   rw [PiLp.inner_apply]
   simp [rowToEuclidean, PiLp.toLp_apply, real_inner_eq_re_inner,
     RCLike.inner_apply, mul_comm]
-  rw [Hex.Vector.dotProduct, cast_foldl_dotProduct_rat]
+  rw [Vector.dotProduct, cast_foldl_dotProduct_rat]
   simp only [Rat.cast_zero, zero_add]
   rw [← List.sum_toFinset _ (List.nodup_finRange m)]
   simp [List.toFinset_finRange]
@@ -117,7 +117,7 @@ theorem rat_coeffs_lower_projection_real (b : Matrix Rat n m) {i j : Fin n}
         (‖rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j)‖ : ℝ) ^ 2 := by
   rw [Hex.GramSchmidt.Rat.coeffs_lower_projection_comm (b := b) hji]
   by_cases hnorm :
-      Vector.dotProduct ((Hex.GramSchmidt.Rat.basis b).row j)
+      ((Hex.GramSchmidt.Rat.basis b).row j).dotProduct
           ((Hex.GramSchmidt.Rat.basis b).row j) = 0
   · have hnorm_real :
         (‖rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j)‖ : ℝ) ^ 2 = 0 := by
@@ -127,7 +127,7 @@ theorem rat_coeffs_lower_projection_real (b : Matrix Rat n m) {i j : Fin n}
   ·
     have hnorm_real :
         (‖rowToEuclidean ((Hex.GramSchmidt.Rat.basis b).row j)‖ : ℝ) ^ 2 =
-          ((Vector.dotProduct ((Hex.GramSchmidt.Rat.basis b).row j)
+          ((((Hex.GramSchmidt.Rat.basis b).row j).dotProduct
             ((Hex.GramSchmidt.Rat.basis b).row j) : Rat) : ℝ) := by
       rw [← real_inner_self_eq_norm_sq, rowToEuclidean_inner]
     simp [hnorm, rowToEuclidean_inner, hnorm_real]

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -171,9 +171,9 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
     rw [hdetG]
     -- Cancellation: origProjCoords[Fin.last j] * gramDet = gramDet * coeffs[i][j].
     have hcancel_normSq :
-        Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+        ((basis b).row ⟨j, hjlt⟩).normSq *
             (originalProjectionCoords b i j hi hjlt)[Fin.last j] =
-          Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+          ((basis b).row ⟨j, hjlt⟩).normSq *
             GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩ := by
       have hH2 := dot_basis_basisPrefixProjection_eq_coeff_mul_normSq b i j hi hj
       have hH3 := dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq b i j hi hj
@@ -185,25 +185,25 @@ private theorem scaledCoeffMatrix_det_eq_gramDet_mul_coeffs
     rw [hgd_succ]
     have hgnp_ne_or_zero :
         gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              ((basis b).row ⟨j, hjlt⟩).normSq *
             (originalProjectionCoords b i j hi hjlt)[Fin.last j] =
           gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              ((basis b).row ⟨j, hjlt⟩).normSq *
             GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩ := by
       have h1 :
           gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              ((basis b).row ⟨j, hjlt⟩).normSq *
             (originalProjectionCoords b i j hi hjlt)[Fin.last j] =
             gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              (Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              (((basis b).row ⟨j, hjlt⟩).normSq *
                 (originalProjectionCoords b i j hi hjlt)[Fin.last j]) := by
         grind
       have h2 :
           gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              ((basis b).row ⟨j, hjlt⟩).normSq *
             GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩ =
             gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-              (Vector.normSq ((basis b).row ⟨j, hjlt⟩) *
+              (((basis b).row ⟨j, hjlt⟩).normSq *
                 GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩) := by
         grind
       rw [h1, h2, hcancel_normSq]

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -180,7 +180,7 @@ private theorem det_intCast {k : Nat} (M : Matrix Int k k) :
 
 /-- Right-side dot product distributes over vector addition. -/
 theorem dot_add_right_rat {m' : Nat} (u v w : Vector Rat m') :
-    Vector.dotProduct u (v + w) = Vector.dotProduct u v + Vector.dotProduct u w := by
+    u.dotProduct (v + w) = u.dotProduct v + u.dotProduct w := by
   unfold Vector.dotProduct
   have h :
       ∀ (xs : List (Fin m')) (accV accW : Rat),
@@ -208,7 +208,7 @@ theorem dot_add_right_rat {m' : Nat} (u v w : Vector Rat m') :
 
 /-- Right-side dot product distributes over scalar multiplication. -/
 theorem dot_smul_right_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
-    Vector.dotProduct u (s • v) = s * Vector.dotProduct u v := by
+    u.dotProduct (s • v) = s * u.dotProduct v := by
   unfold Vector.dotProduct
   have h :
       ∀ (xs : List (Fin m')) (acc : Rat),
@@ -235,7 +235,7 @@ theorem dot_smul_right_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
 
 /-- Dot product of a vector against the zero vector is zero. -/
 private theorem dot_zero_right_rat {m' : Nat} (u : Vector Rat m') :
-    Vector.dotProduct u (0 : Vector Rat m') = 0 := by
+    u.dotProduct (0 : Vector Rat m') = 0 := by
   unfold Vector.dotProduct
   have h : ∀ (xs : List (Fin m')) (acc : Rat),
       xs.foldl (fun acc i => acc + u[i] * (0 : Vector Rat m')[i]) acc = acc := by
@@ -269,7 +269,7 @@ private theorem foldl_sum_start_rat {α : Type v}
 
 /-- Rational dot product is commutative. -/
 private theorem dot_comm_rat {m' : Nat} (u v : Vector Rat m') :
-    Vector.dotProduct u v = Vector.dotProduct v u := by
+    u.dotProduct v = v.dotProduct u := by
   unfold Vector.dotProduct
   have h : ∀ (xs : List (Fin m')) (accU accV : Rat),
       accU = accV →
@@ -290,18 +290,18 @@ private theorem dot_comm_rat {m' : Nat} (u v : Vector Rat m') :
 private theorem dot_prefixCombination_right_rat
     (coeffs : Matrix Rat n n) (basisM : Matrix Rat n m)
     (i : Nat) (hi : i < n) (u : Vector Rat m) :
-    Vector.dotProduct u (GramSchmidt.prefixCombination coeffs basisM i hi) =
+    u.dotProduct (GramSchmidt.prefixCombination coeffs basisM i hi) =
       (List.finRange i).foldl
         (fun (acc : Rat) (j : Fin i) =>
           acc +
             GramSchmidt.entry coeffs ⟨i, hi⟩
                 ⟨j.val, Nat.lt_trans j.isLt hi⟩ *
-              Vector.dotProduct u
+              u.dotProduct
                 (basisM.row ⟨j.val, Nat.lt_trans j.isLt hi⟩)) 0 := by
   unfold GramSchmidt.prefixCombination
   have hgen :
       ∀ (xs : List (Fin i)) (acc : Vector Rat m),
-        Vector.dotProduct u
+        u.dotProduct
             (xs.foldl
               (fun acc (j : Fin i) =>
                 acc +
@@ -309,13 +309,13 @@ private theorem dot_prefixCombination_right_rat
                       ⟨j.val, Nat.lt_trans j.isLt hi⟩ •
                     basisM.row ⟨j.val, Nat.lt_trans j.isLt hi⟩)
               acc) =
-          Vector.dotProduct u acc +
+          u.dotProduct acc +
             xs.foldl
               (fun (acc' : Rat) (j : Fin i) =>
                 acc' +
                   GramSchmidt.entry coeffs ⟨i, hi⟩
                       ⟨j.val, Nat.lt_trans j.isLt hi⟩ *
-                    Vector.dotProduct u
+                    u.dotProduct
                       (basisM.row ⟨j.val, Nat.lt_trans j.isLt hi⟩)) 0 := by
     intro xs
     induction xs with
@@ -329,7 +329,7 @@ private theorem dot_prefixCombination_right_rat
         rw [foldl_sum_start_rat xs _
           ((0 : Rat) + (GramSchmidt.entry coeffs ⟨i, hi⟩
               ⟨x.val, Nat.lt_trans x.isLt hi⟩ *
-            Vector.dotProduct u
+            u.dotProduct
               (basisM.row ⟨x.val, Nat.lt_trans x.isLt hi⟩)))]
         grind
   rw [hgen (List.finRange i) 0, dot_zero_right_rat]
@@ -341,9 +341,9 @@ private theorem dot_prefixCombination_right_eq_zero
     (coeffs : Matrix Rat n n) (basisM : Matrix Rat n m)
     (i : Nat) (hi : i < n) (u : Vector Rat m)
     (h : ∀ (j : Fin i),
-      Vector.dotProduct u
+      u.dotProduct
           (basisM.row ⟨j.val, Nat.lt_trans j.isLt hi⟩) = 0) :
-    Vector.dotProduct u (GramSchmidt.prefixCombination coeffs basisM i hi) = 0 := by
+    u.dotProduct (GramSchmidt.prefixCombination coeffs basisM i hi) = 0 := by
   rw [dot_prefixCombination_right_rat]
   -- All terms are zero: the foldl with each entry = 0 reduces to 0.
   induction (List.finRange i) with
@@ -452,15 +452,15 @@ private theorem rowCombination_eq_foldl_rows_rat
 
 private theorem dot_rowCombination_right_rat
     (u : Vector Rat m) (M : Matrix Rat n m) (c : Vector Rat n) :
-    Vector.dotProduct u (Matrix.rowCombination M c) =
+    u.dotProduct (Matrix.rowCombination M c) =
       (List.finRange n).foldl
-        (fun acc j => acc + c[j] * Vector.dotProduct u (M.row j)) 0 := by
+        (fun acc j => acc + c[j] * u.dotProduct (M.row j)) 0 := by
   rw [rowCombination_eq_foldl_rows_rat]
   have hgen :
       ∀ xs : List (Fin n), ∀ acc : Vector Rat m,
-        Vector.dotProduct u (xs.foldl (fun acc j => acc + c[j] • M.row j) acc) =
-          Vector.dotProduct u acc +
-            xs.foldl (fun acc' j => acc' + c[j] * Vector.dotProduct u (M.row j)) 0 := by
+        u.dotProduct (xs.foldl (fun acc j => acc + c[j] • M.row j) acc) =
+          u.dotProduct acc +
+            xs.foldl (fun acc' j => acc' + c[j] * u.dotProduct (M.row j)) 0 := by
     intro xs
     induction xs with
     | nil =>
@@ -472,7 +472,7 @@ private theorem dot_rowCombination_right_rat
         simp only [List.foldl_cons]
         rw [ih, dot_add_right_rat, dot_smul_right_rat]
         rw [foldl_sum_start_rat xs _
-          ((0 : Rat) + c[x] * Vector.dotProduct u (M.row x))]
+          ((0 : Rat) + c[x] * u.dotProduct (M.row x))]
         grind
   rw [hgen (List.finRange n) 0, dot_zero_right_rat]
   grind
@@ -505,13 +505,13 @@ Gram-Schmidt orthogonal basis row `b*_j`. -/
 private noncomputable def auxMatrix (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :
     Matrix Rat k k :=
   Matrix.ofFn fun i j =>
-    Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+    (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
       ((basis b).row (GramSchmidt.liftFinLE j hk))
 
 private theorem auxMatrix_get (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
     (i j : Fin k) :
     (auxMatrix b k hk)[i][j] =
-      Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+      (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
         ((basis b).row (GramSchmidt.liftFinLE j hk)) := by
   simp [auxMatrix, Matrix.ofFn]
 
@@ -539,7 +539,7 @@ private theorem auxMatrix_zero_above (b : Matrix Int n m) (k : Nat) (hk : k ≤ 
     basis_orthogonal b i.val j.val hi' hj' hij']
   -- Second term: prefixCombination orthogonal to ((basis b).row j).
   have hprefix :
-      Vector.dotProduct ((basis b).row ⟨j.val, hj'⟩)
+      ((basis b).row ⟨j.val, hj'⟩).dotProduct
           (GramSchmidt.prefixCombination (coeffs b) (basis b) i.val hi') = 0 := by
     apply dot_prefixCombination_right_eq_zero
       (coeffs := coeffs b) (basisM := basis b) (i := i.val) (hi := hi')
@@ -556,7 +556,7 @@ private theorem auxMatrix_zero_above (b : Matrix Int n m) (k : Nat) (hk : k ≤ 
 private theorem auxMatrix_diag (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) :
     (auxMatrix b k hk)[i][i] =
-      Vector.normSq ((basis b).row (GramSchmidt.liftFinLE i hk)) := by
+      ((basis b).row (GramSchmidt.liftFinLE i hk)).normSq := by
   rw [auxMatrix_get]
   have hi' : i.val < n := Nat.lt_of_lt_of_le i.isLt hk
   rw [show GramSchmidt.liftFinLE i hk = ⟨i.val, hi'⟩ from rfl, castIntRow_decomposition b i.val hi',
@@ -564,7 +564,7 @@ private theorem auxMatrix_diag (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
   -- First term: dot ((basis b).row i) ((basis b).row i) = normSq ((basis b).row i)
   -- Second term: dot ((basis b).row i) prefixCombination = 0.
   have hprefix :
-      Vector.dotProduct ((basis b).row ⟨i.val, hi'⟩)
+      ((basis b).row ⟨i.val, hi'⟩).dotProduct
           (GramSchmidt.prefixCombination (coeffs b) (basis b) i.val hi') = 0 := by
     apply dot_prefixCombination_right_eq_zero
       (coeffs := coeffs b) (basisM := basis b) (i := i.val) (hi := hi')
@@ -577,8 +577,8 @@ private theorem auxMatrix_diag (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
   rw [hprefix]
   -- Remaining: dot ((basis b).row i) ((basis b).row i) + 0 = normSq ((basis b).row i)
   have hns :
-      Vector.normSq ((basis b).row ⟨i.val, hi'⟩) =
-        Vector.dotProduct ((basis b).row ⟨i.val, hi'⟩) ((basis b).row ⟨i.val, hi'⟩) := by
+      ((basis b).row ⟨i.val, hi'⟩).normSq =
+        ((basis b).row ⟨i.val, hi'⟩).dotProduct ((basis b).row ⟨i.val, hi'⟩) := by
     rfl
   rw [hns]
   grind
@@ -591,7 +591,7 @@ private theorem auxMatrix_det_eq_prod_normSq (b : Matrix Int n m)
     (fun i j hij => auxMatrix_zero_above b k hk i j hij)]
   unfold gramSchmidtNormProduct
   -- Both foldls are over `List.finRange k`. The diagonal of auxMatrix at i
-  -- equals Vector.normSq of (basis b) row at the lifted index.
+  -- equals of.normSq (basis b) row at the lifted index.
   apply foldl_mul_congr_simple
   intro i _hi
   rw [auxMatrix_diag b k hk i]
@@ -605,23 +605,23 @@ private noncomputable def progressMatrix (b : Matrix Int n m) (k : Nat)
     (hk : k ≤ n) (s : Nat) : Matrix Rat k k :=
   Matrix.ofFn fun i j =>
     if j.val < s then
-      Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+      (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
         ((basis b).row (GramSchmidt.liftFinLE j hk))
     else
-      Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+      (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
         (castIntRow b (GramSchmidt.liftFinLE j hk))
 
 private theorem progressMatrix_get_lt (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
     (s : Nat) (i j : Fin k) (hj : j.val < s) :
     (progressMatrix b k hk s)[i][j] =
-      Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+      (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
         ((basis b).row (GramSchmidt.liftFinLE j hk)) := by
   simp [progressMatrix, Matrix.ofFn, hj]
 
 private theorem progressMatrix_get_ge (b : Matrix Int n m) (k : Nat) (hk : k ≤ n)
     (s : Nat) (i j : Fin k) (hj : ¬ j.val < s) :
     (progressMatrix b k hk s)[i][j] =
-      Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE i hk))
+      (castIntRow b (GramSchmidt.liftFinLE i hk)).dotProduct
         (castIntRow b (GramSchmidt.liftFinLE j hk)) := by
   simp [progressMatrix, Matrix.ofFn, hj]
 
@@ -710,8 +710,8 @@ private theorem progressMatrix_succ_eq_colReplace
     rw [progressMatrix_get_lt b k hk (s + 1) ii (⟨s, hs⟩ : Fin k) hjlt]
     have hjnlt : ¬ (⟨s, hs⟩ : Fin k).val < s := Nat.lt_irrefl s
     rw [progressMatrix_get_ge b k hk s ii (⟨s, hs⟩ : Fin k) hjnlt]
-    -- LHS = Vector.dotProduct (castIntRow b (lift ii)) ((basis b).row (lift ⟨s, hs⟩))
-    -- RHS' first piece = Vector.dotProduct (castIntRow b (lift ii)) (castIntRow b (lift ⟨s, hs⟩))
+    -- LHS = (castIntRow b (lift ii)).dotProduct ((basis b).row (lift ⟨s, hs⟩))
+    -- RHS' first piece = (castIntRow b (lift ii)).dotProduct (castIntRow b (lift ⟨s, hs⟩))
     -- We need: LHS = RHS' first + foldl (coeff * (basis row p))
     have hsn : s < n := Nat.lt_of_lt_of_le hs hk
     have hslift : GramSchmidt.liftFinLE (⟨s, hs⟩ : Fin k) hk = ⟨s, hsn⟩ := rfl
@@ -739,7 +739,7 @@ private theorem progressMatrix_succ_eq_colReplace
             acc +
               GramSchmidt.entry (coeffs b) ⟨s, hsn⟩
                   ⟨jp.val, Nat.lt_trans jp.isLt hsn⟩ *
-                Vector.dotProduct (castIntRow b (GramSchmidt.liftFinLE ii hk))
+                (castIntRow b (GramSchmidt.liftFinLE ii hk)).dotProduct
                   ((basis b).row ⟨jp.val, Nat.lt_trans jp.isLt hsn⟩)) 0 =
         - ((progressMatrixSources k s hs).foldl
           (fun acc src =>
@@ -845,8 +845,8 @@ private theorem progressMatrix_det_invariant
 dot product. -/
 private theorem dot_castIntRow_eq_cast_dot
     (b : Matrix Int n m) (i j : Fin n) :
-    Vector.dotProduct (castIntRow b i) (castIntRow b j) =
-      ((Vector.dotProduct (b.row i) (b.row j) : Int) : Rat) := by
+    (castIntRow b i).dotProduct (castIntRow b j) =
+      (((b.row i).dotProduct (b.row j) : Int) : Rat) := by
   unfold Vector.dotProduct
   rw [foldl_intCast_add_aux (xs := List.finRange m)
     (f := fun k : Fin m => (b.row i)[k] * (b.row j)[k]) (acc := 0)]
@@ -956,9 +956,9 @@ private theorem progressMatrix_zero_eq_castIntDetMatrix (b : Matrix Int n m)
     (castIntDetMatrix (GramSchmidt.leadingGramMatrixInt b k hk))[ii][jj]
   have hjnlt : ¬ jj.val < 0 := Nat.not_lt_zero _
   rw [progressMatrix_get_ge b k hk 0 ii jj hjnlt, castIntDetMatrix_get]
-  -- LHS: Vector.dotProduct (castIntRow b (lift ii)) (castIntRow b (lift jj))
+  -- LHS: (castIntRow b (lift ii)).dotProduct (castIntRow b (lift jj))
   -- RHS: ((leadingGramMatrixInt b k hk)[ii][jj] : Int : Rat)
-  --   = (Vector.dotProduct (b.row (lift ii)) (b.row (lift jj)) : Int : Rat)
+  --   = ((b.row (lift ii)).dotProduct (b.row (lift jj)) : Int : Rat)
   rw [dot_castIntRow_eq_cast_dot]
   -- Match up the leadingGramMatrixInt entry definition.
   simp [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn]
@@ -1027,14 +1027,14 @@ theorem gramDet_pos (b : Matrix Int n m)
   exact gramDet_pos_core b hli k hk hk'
 
 /-- One-step extension of `gramSchmidtNormProduct`: appending the `k`-th
-factor multiplies the `k`-fold product by `Vector.normSq ((basis b).row ⟨k, _⟩)`.
+factor multiplies the `k`-fold product by `((basis b).row ⟨k, _⟩)`..normSq
 This is a `List.finRange` cancellation lemma; positivity of the leading Gram
 determinant is handled separately by `gramDet_pos`. -/
 theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
     (k : Nat) (hk : k + 1 ≤ n) :
     gramSchmidtNormProduct b (k + 1) hk =
       gramSchmidtNormProduct b k (Nat.le_of_succ_le hk) *
-        Vector.normSq ((basis b).row ⟨k, Nat.lt_of_succ_le hk⟩) := by
+        ((basis b).row ⟨k, Nat.lt_of_succ_le hk⟩).normSq := by
   unfold gramSchmidtNormProduct
   rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
   simp only [List.foldl_cons, List.foldl_nil]
@@ -1042,7 +1042,7 @@ theorem gramSchmidtNormProduct_succ (b : Matrix Int n m)
 
 private theorem basis_normSq_core (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k < n) :
-    Vector.normSq ((basis b).row ⟨k, hk⟩) =
+    ((basis b).row ⟨k, hk⟩).normSq =
       (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
         (gramDet b k (Nat.le_of_lt hk) : Rat) := by
   have hk_le : k ≤ n := Nat.le_of_lt hk
@@ -1064,7 +1064,7 @@ consecutive leading Gram determinants `d_{k+1} / d_k`, the standard telescoping
 identity. Public wrapper over `basis_normSq_core`. -/
 theorem basis_normSq (b : Matrix Int n m)
     (hli : independent b) (k : Nat) (hk : k < n) :
-    Vector.normSq ((basis b).row ⟨k, hk⟩) =
+    ((basis b).row ⟨k, hk⟩).normSq =
       (gramDet b (k + 1) (Nat.succ_le_of_lt hk) : Rat) /
         (gramDet b k (Nat.le_of_lt hk) : Rat) := by
   exact basis_normSq_core b hli k hk
@@ -1074,11 +1074,11 @@ index. For `p < r`, `castIntRow b p` lies in the basis-vector span of indices
 `≤ p`, which is orthogonal to `(basis b).row r`. -/
 private theorem dot_castIntRow_basis_eq_zero_of_lt
     (b : Matrix Int n m) (p r : Nat) (hp : p < n) (hr : r < n) (hpr : p < r) :
-    Vector.dotProduct (castIntRow b ⟨p, hp⟩) ((basis b).row ⟨r, hr⟩) = 0 := by
+    (castIntRow b ⟨p, hp⟩).dotProduct ((basis b).row ⟨r, hr⟩) = 0 := by
   rw [dot_comm_rat, castIntRow_decomposition b p hp, dot_add_right_rat]
-  have hbasis : Vector.dotProduct ((basis b).row ⟨r, hr⟩) ((basis b).row ⟨p, hp⟩) = 0 :=
+  have hbasis : ((basis b).row ⟨r, hr⟩).dotProduct ((basis b).row ⟨p, hp⟩) = 0 :=
     basis_orthogonal b r p hr hp (Nat.ne_of_gt hpr)
-  have hprefix : Vector.dotProduct ((basis b).row ⟨r, hr⟩)
+  have hprefix : ((basis b).row ⟨r, hr⟩).dotProduct
       (GramSchmidt.prefixCombination (coeffs b) (basis b) p hp) = 0 := by
     apply dot_prefixCombination_right_eq_zero
       (coeffs := coeffs b) (basisM := basis b) (i := p) (hi := hp)
@@ -1135,8 +1135,8 @@ of indices `> j`, hence orthogonal to `castIntRow b p`. -/
 private theorem dot_castIntRow_castIntRow_eq
     (b : Matrix Int n m) (i j p : Nat) (hi : i < n) (hj : j < i)
     (hp_le_j : p ≤ j) (hp : p < n) :
-    Vector.dotProduct (castIntRow b ⟨p, hp⟩) (castIntRow b ⟨i, hi⟩) =
-      Vector.dotProduct (castIntRow b ⟨p, hp⟩)
+    (castIntRow b ⟨p, hp⟩).dotProduct (castIntRow b ⟨i, hi⟩) =
+      (castIntRow b ⟨p, hp⟩).dotProduct
         (basisPrefixProjection b i j hi (Nat.lt_trans hj hi)) := by
   -- Substitute `i = (j + 1) + d` so the foldl bounds align with the helper.
   obtain ⟨d, rfl⟩ : ∃ d, i = (j + 1) + d := ⟨i - (j + 1), by omega⟩
@@ -1154,7 +1154,7 @@ private theorem dot_castIntRow_castIntRow_eq
   -- Define a Nat-indexed body shared by both sides.
   let body : ∀ (k : Nat), k < n → Rat := fun k hk =>
     GramSchmidt.entry (coeffs b) ⟨(j + 1) + d, hi⟩ ⟨k, hk⟩ *
-      Vector.dotProduct (castIntRow b ⟨p, hp⟩) ((basis b).row ⟨k, hk⟩)
+      (castIntRow b ⟨p, hp⟩).dotProduct ((basis b).row ⟨k, hk⟩)
   -- Normalize the RHS foldl body to use `body`. The literal proof inside the
   -- unfolded `basisPrefixProjection` is `Nat.lt_trans hj hi`.
   have hRHS :
@@ -1163,7 +1163,7 @@ private theorem dot_castIntRow_castIntRow_eq
             acc' +
               (projectionCoeffPrefix b ((j + 1) + d) j hi
                 (Nat.lt_trans hj hi))[q] *
-              Vector.dotProduct (castIntRow b ⟨p, hp⟩)
+              (castIntRow b ⟨p, hp⟩).dotProduct
                 ((GramSchmidt.prefixRows (basis b) j (Nat.lt_trans hj hi)).row q)) 0 =
         (List.finRange (j + 1)).foldl
           (fun (acc' : Rat) (q : Fin (j + 1)) =>
@@ -1188,7 +1188,7 @@ private theorem dot_castIntRow_castIntRow_eq
     (by
       intro r hjr hrn
       show GramSchmidt.entry (coeffs b) ⟨(j + 1) + d, hi⟩ ⟨r, hrn⟩ *
-          Vector.dotProduct (castIntRow b ⟨p, hp⟩) ((basis b).row ⟨r, hrn⟩) = 0
+          (castIntRow b ⟨p, hp⟩).dotProduct ((basis b).row ⟨r, hrn⟩) = 0
       have hpr : p < r := Nat.lt_of_le_of_lt hp_le_j (Nat.lt_of_succ_le hjr)
       rw [dot_castIntRow_basis_eq_zero_of_lt b p r hp hrn hpr]
       grind)
@@ -1264,10 +1264,10 @@ private theorem foldl_finRange_succ_isolate_last
 weighted by `(basis b).row j`'s squared norm. -/
 private theorem dot_basis_basisPrefixProjection_eq_coeff_mul_normSq
     (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
-    Vector.dotProduct ((basis b).row ⟨j, Nat.lt_trans hj hi⟩)
+    ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).dotProduct
         (basisPrefixProjection b i j hi (Nat.lt_trans hj hi)) =
       GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ *
-        Vector.normSq ((basis b).row ⟨j, Nat.lt_trans hj hi⟩) := by
+        ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).normSq := by
   have hjlt : j < n := Nat.lt_trans hj hi
   unfold basisPrefixProjection
   rw [dot_rowCombination_right_rat]
@@ -1299,10 +1299,10 @@ private theorem dot_basis_basisPrefixProjection_eq_coeff_mul_normSq
 extracts the original-row coordinate, weighted by the squared norm. -/
 private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
     (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
-    Vector.dotProduct ((basis b).row ⟨j, Nat.lt_trans hj hi⟩)
+    ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).dotProduct
         (basisPrefixProjection b i j hi (Nat.lt_trans hj hi)) =
       (originalProjectionCoords b i j hi (Nat.lt_trans hj hi))[Fin.last j] *
-        Vector.normSq ((basis b).row ⟨j, Nat.lt_trans hj hi⟩) := by
+        ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).normSq := by
   have hjlt : j < n := Nat.lt_trans hj hi
   rw [← originalProjectionCoords_spec b i j hi hjlt, dot_rowCombination_right_rat,
     foldl_finRange_succ_isolate_last j _ ?_]
@@ -1317,11 +1317,11 @@ private theorem dot_basis_basisPrefixProjection_eq_origProjCoords_mul_normSq
     -- dot basis[j] castIntRow b j = dot basis[j] (basis[j] + prefixComb) = normSq + 0.
     rw [castIntRow_decomposition b j hjlt, dot_add_right_rat]
     have hbasis_self :
-        Vector.dotProduct ((basis b).row ⟨j, hjlt⟩) ((basis b).row ⟨j, hjlt⟩) =
-          Vector.normSq ((basis b).row ⟨j, hjlt⟩) := rfl
+        ((basis b).row ⟨j, hjlt⟩).dotProduct ((basis b).row ⟨j, hjlt⟩) =
+          ((basis b).row ⟨j, hjlt⟩).normSq := rfl
     rw [hbasis_self]
     have hprefix :
-        Vector.dotProduct ((basis b).row ⟨j, hjlt⟩)
+        ((basis b).row ⟨j, hjlt⟩).dotProduct
             (GramSchmidt.prefixCombination (coeffs b) (basis b) j hjlt) = 0 := by
       apply dot_prefixCombination_right_eq_zero
         (coeffs := coeffs b) (basisM := basis b) (i := j) (hi := hjlt)
@@ -1349,7 +1349,7 @@ theorem gramDet_succ_rat
     (b : Matrix Int n m) (j : Nat) (hjsuc : j + 1 ≤ n) :
     (gramDet b (j + 1) hjsuc : Rat) =
       gramSchmidtNormProduct b j (Nat.le_of_succ_le hjsuc) *
-        Vector.normSq ((basis b).row ⟨j, Nat.lt_of_succ_le hjsuc⟩) := by
+        ((basis b).row ⟨j, Nat.lt_of_succ_le hjsuc⟩).normSq := by
   have hgd_eq_gsnp :
       (gramDet b (j + 1) hjsuc : Rat) = gramSchmidtNormProduct b (j + 1) hjsuc := by
     rw [gramDet_rat_eq_progressMatrix_zero_det,

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -37,8 +37,8 @@ private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))
 
 /-- The dot product of integer vectors is commutative. -/
 private theorem dot_comm_int {n' : Nat} (u v : Vector Int n') :
-    Vector.dotProduct u v = Vector.dotProduct v u := by
-  simpa [Hex.Vector.dotProduct] using
+    u.dotProduct v = v.dotProduct u := by
+  simpa [Vector.dotProduct] using
     foldl_dot_comm_int (xs := List.finRange n') (u := u) (v := v)
       (accU := 0) (accV := 0) rfl
 
@@ -83,17 +83,17 @@ private theorem foldl_dot_rowAdd_at {n' m' : Nat}
 so dot with `w` distributes over the sum. -/
 private theorem dot_rowAdd_row_at_left {n' m' : Nat}
     (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m') :
-    Vector.dotProduct ((Matrix.rowAdd M src dst c)[dst]) w =
-      Vector.dotProduct M[dst] w + c * Vector.dotProduct M[src] w := by
-  simp only [Hex.Vector.dotProduct]
+    ((Matrix.rowAdd M src dst c)[dst]).dotProduct w =
+      M[dst].dotProduct w + c * M[src].dotProduct w := by
+  simp only [Vector.dotProduct]
   exact foldl_dot_rowAdd_at M src dst c w (List.finRange m')
     0 0 0 (by show (0 : Int) = 0 + c * 0; grind)
 
 /-- Symmetric form: dot product on the right with the modified row. -/
 private theorem dot_rowAdd_row_at_right {n' m' : Nat}
     (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m') :
-    Vector.dotProduct w ((Matrix.rowAdd M src dst c)[dst]) =
-      Vector.dotProduct w M[dst] + c * Vector.dotProduct w M[src] := by
+    w.dotProduct ((Matrix.rowAdd M src dst c)[dst]) =
+      w.dotProduct M[dst] + c * w.dotProduct M[src] := by
   rw [dot_comm_int w, dot_rowAdd_row_at_left, dot_comm_int w M[dst], dot_comm_int w M[src]]
 
 /-- Determinant-level pivot identity for scaled Gram-Schmidt coefficients under
@@ -113,9 +113,9 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
   let last : Fin t := ⟨j.val, Nat.lt_succ_self j.val⟩
   let M := GramSchmidt.leadingGramMatrixInt b t ht
   let oldCol : Fin t → Int := fun p =>
-    Vector.dotProduct (b.row (GramSchmidt.liftFinLE p ht)) (b.row k)
+    (b.row (GramSchmidt.liftFinLE p ht)).dotProduct (b.row k)
   let gramCol : Fin t → Int := fun p =>
-    Vector.dotProduct (b.row (GramSchmidt.liftFinLE p ht)) (b.row j)
+    (b.row (GramSchmidt.liftFinLE p ht)).dotProduct (b.row j)
   have hnew :
       GramSchmidt.scaledCoeffMatrix (Matrix.rowAdd b j k c) k j hjk =
         Matrix.setCol M last (fun p => oldCol p + c * gramCol p) := by
@@ -139,11 +139,11 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
         Vector.getElem_ofFn, hqNat, if_true]
       rw [if_pos (rfl : (⟨j.val, Nat.lt_succ_self j.val⟩ : Fin t) = last)]
       simp only [Matrix.row]
-      change Vector.dotProduct ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht])
+      change ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht]).dotProduct
           ((Matrix.rowAdd b j k c)[k]) =
         oldCol p + c * gramCol p
       rw [hp_row]
-      change Vector.dotProduct (b.row (GramSchmidt.liftFinLE p ht))
+      change (b.row (GramSchmidt.liftFinLE p ht)).dotProduct
           ((Matrix.rowAdd b j k c)[k]) =
         oldCol p + c * gramCol p
       exact dot_rowAdd_row_at_right b j k c (b.row (GramSchmidt.liftFinLE p ht))
@@ -279,14 +279,14 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
   -- The Gram matrix entry as a dot product of integer rows.
   have hM_entry : ∀ (a b' : Fin t),
       (GramSchmidt.leadingGramMatrixInt b t ht)[a][b'] =
-        Vector.dotProduct (b[GramSchmidt.liftFinLE a ht]) (b[GramSchmidt.liftFinLE b' ht]) := by
+        (b[GramSchmidt.liftFinLE a ht]).dotProduct (b[GramSchmidt.liftFinLE b' ht]) := by
     intro a b'
     simp [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
       Vector.getElem_ofFn]
   -- LHS is a dot product over `Matrix.rowAdd b j k c` rows.
   have hLHS :
       (GramSchmidt.leadingGramMatrixInt (Matrix.rowAdd b j k c) t ht)[p][q] =
-        Vector.dotProduct ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht])
+        ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE p ht]).dotProduct
           ((Matrix.rowAdd b j k c)[GramSchmidt.liftFinLE q ht]) := by
     simp [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
       Vector.getElem_ofFn]
@@ -331,12 +331,12 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
         congrArg (Matrix.rowAdd b j k c).get hqn_k
       rw [hrowAdd_p, hrowAdd_q, dot_rowAdd_row_at_left b j k c ((Matrix.rowAdd b j k c)[k])]
       have hrec_k :
-          Vector.dotProduct b[k] ((Matrix.rowAdd b j k c)[k]) =
-            Vector.dotProduct b[k] b[k] + c * Vector.dotProduct b[k] b[j] :=
+          b[k].dotProduct ((Matrix.rowAdd b j k c)[k]) =
+            b[k].dotProduct b[k] + c * b[k].dotProduct b[j] :=
         dot_rowAdd_row_at_right b j k c b[k]
       have hrec_j :
-          Vector.dotProduct b[j] ((Matrix.rowAdd b j k c)[k]) =
-            Vector.dotProduct b[j] b[k] + c * Vector.dotProduct b[j] b[j] :=
+          b[j].dotProduct ((Matrix.rowAdd b j k c)[k]) =
+            b[j].dotProduct b[k] + c * b[j].dotProduct b[j] :=
         dot_rowAdd_row_at_right b j k c b[j]
       rw [hrec_k, hrec_j]
       simp only [if_pos hpk]
@@ -344,7 +344,7 @@ private theorem leadingGramMatrixInt_rowAdd_entry_inside
       have hb_q : b[GramSchmidt.liftFinLE q ht] = b[k] :=
         congrArg b.get hqn_k
       rw [hbjt_lift, hbkt_lift, hb_q]
-      have hsym : Vector.dotProduct b[j] b[k] = Vector.dotProduct b[k] b[j] := dot_comm_int _ _
+      have hsym : b[j].dotProduct b[k] = b[k].dotProduct b[j] := dot_comm_int _ _
       rw [hsym]
     · -- p ≠ kt, q = kt
       have hpn_ne : (GramSchmidt.liftFinLE p ht).val ≠ k.val :=

--- a/HexGramSchmidtMathlib/Int/Swap.lean
+++ b/HexGramSchmidtMathlib/Int/Swap.lean
@@ -37,14 +37,14 @@ private theorem intCast_rat_injective_int_eq {a b : Int} (h : (a : Rat) = (b : R
 
 /-- The rational dot product is additive in its left argument. -/
 theorem dot_add_left_rat {m' : Nat} (u v w : Vector Rat m') :
-    Vector.dotProduct (u + v) w = Vector.dotProduct u w + Vector.dotProduct v w := by
+    (u + v).dotProduct w = u.dotProduct w + v.dotProduct w := by
   rw [dot_comm_rat (u := u + v) (v := w), dot_add_right_rat (u := w) (v := u) (w := v),
     dot_comm_rat (u := w) (v := u), dot_comm_rat (u := w) (v := v)]
 
 /-- The rational dot product is homogeneous in its left argument: a scalar
 factors out. -/
 theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
-    Vector.dotProduct (s • u) v = s * Vector.dotProduct u v := by
+    (s • u).dotProduct v = s * u.dotProduct v := by
   rw [dot_comm_rat (u := s • u) (v := v), dot_smul_right_rat (s := s) (u := v) (v := u),
     dot_comm_rat (u := v) (v := u)]
 
@@ -52,11 +52,11 @@ theorem dot_smul_left_rat {m' : Nat} (s : Rat) (u v : Vector Rat m') :
 splits as `‖curr‖² + μ² · ‖prev‖²`. -/
 theorem normSq_add_smul_orthogonal_rat {m' : Nat}
     (curr prev : Vector Rat m') (μ : Rat)
-    (horth : Vector.dotProduct curr prev = 0) :
-    Vector.normSq (curr + μ • prev) =
-      Vector.normSq curr + μ ^ 2 * Vector.normSq prev := by
-  show Vector.dotProduct (curr + μ • prev) (curr + μ • prev) =
-    Vector.dotProduct curr curr + μ ^ 2 * Vector.dotProduct prev prev
+    (horth : curr.dotProduct prev = 0) :
+    (curr + μ • prev).normSq =
+      curr.normSq + μ ^ 2 * prev.normSq := by
+  show (curr + μ • prev).dotProduct (curr + μ • prev) =
+    curr.dotProduct curr + μ ^ 2 * prev.dotProduct prev
   rw [dot_add_left_rat (u := curr) (v := μ • prev) (w := curr + μ • prev),
     dot_add_right_rat (u := curr) (v := curr) (w := μ • prev),
     dot_add_right_rat (u := μ • prev) (v := curr) (w := μ • prev),
@@ -64,7 +64,7 @@ theorem normSq_add_smul_orthogonal_rat {m' : Nat}
     dot_smul_left_rat (s := μ) (u := prev) (v := curr),
     dot_smul_left_rat (s := μ) (u := prev) (v := μ • prev),
     dot_smul_right_rat (s := μ) (u := prev) (v := prev)]
-  have horth_swap : Vector.dotProduct prev curr = 0 := by
+  have horth_swap : prev.dotProduct curr = 0 := by
     rw [dot_comm_rat]; exact horth
   rw [horth, horth_swap]
   grind
@@ -140,8 +140,8 @@ theorem gramDet_rowSwap_adjacent_pivot_product
   let prev : Vector Rat m := (basis b).row km1
   let curr : Vector Rat m := (basis b).row k
   let G : Rat := gramSchmidtNormProduct b km1.val hkm1_le_n
-  let Nkm1 : Rat := Vector.normSq prev
-  let Nk : Rat := Vector.normSq curr
+  let Nkm1 : Rat := prev.normSq
+  let Nk : Rat := curr.normSq
   -- Rational expressions for each Gram determinant we touch.
   have hdkm1_rat : (gramDet b km1.val hkm1_le_n : Rat) = G :=
     gramDet_eq_prod_normSq_uncond b km1.val hkm1_le_n
@@ -162,7 +162,7 @@ theorem gramDet_rowSwap_adjacent_pivot_product
     rw [h_succ, hgnp_k_eq,
         gramSchmidtNormProduct_succ b km1.val hkm1_succ_le]
   -- Basis orthogonality between curr and prev.
-  have horth : Vector.dotProduct curr prev = 0 :=
+  have horth : curr.dotProduct prev = 0 :=
     basis_orthogonal b k.val km1.val k.isLt km1.isLt (by omega)
   -- New basis row at km1 of the swapped matrix is `curr + μ • prev`.
   have hbasis_swap :
@@ -180,8 +180,8 @@ theorem gramDet_rowSwap_adjacent_pivot_product
       gramDet_subst_val (Matrix.rowSwap b km1 k) _ _ _ _ hkm1
     rw [← hgd_eq, h_succ,
         gramSchmidtNormProduct_rowSwap_below b km1 k hkm1k]
-    show G * Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
-        ⟨km1.val, km1.isLt⟩) = G * (Nk + μ ^ 2 * Nkm1)
+    show G * ((basis (Matrix.rowSwap b km1 k)).row
+        ⟨km1.val, km1.isLt⟩).normSq = G * (Nk + μ ^ 2 * Nkm1)
     have hbasis_row :
         (basis (Matrix.rowSwap b km1 k)).row ⟨km1.val, km1.isLt⟩ =
           curr + μ • prev := hbasis_swap
@@ -274,14 +274,14 @@ zero, both sides vanish (orthogonality + the `if`-branch in
 `coeffs_lower_projection`). -/
 theorem dot_basis_castRow_eq_coeffs_mul_normSq
     (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
-    Vector.dotProduct ((basis b).row ⟨j, Nat.lt_trans hj hi⟩)
+    ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row ⟨i, hi⟩)) =
       GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ *
-        Vector.normSq ((basis b).row ⟨j, Nat.lt_trans hj hi⟩) := by
+        ((basis b).row ⟨j, Nat.lt_trans hj hi⟩).normSq := by
   have hjlt : j < n := Nat.lt_trans hj hi
   -- Expand `castIntRow b i` via `basis_decomposition`.
   have hrow := castIntRow_decomposition b i hi
-  show Vector.dotProduct ((basis b).row ⟨j, hjlt⟩) (castIntRow b ⟨i, hi⟩) = _
+  show ((basis b).row ⟨j, hjlt⟩).dotProduct (castIntRow b ⟨i, hi⟩) = _
   rw [hrow, dot_add_right_rat]
   -- First term: `dot basis[j] basis[i] = 0` by orthogonality (j ≠ i).
   rw [basis_orthogonal b j i hjlt hi (Nat.ne_of_lt hj), Rat.zero_add]
@@ -291,7 +291,7 @@ theorem dot_basis_castRow_eq_coeffs_mul_normSq
   have h_zero_term : ∀ q : Fin i, q.val ≠ j →
       GramSchmidt.entry (coeffs b) ⟨i, hi⟩
             ⟨q.val, Nat.lt_trans q.isLt hi⟩ *
-          Vector.dotProduct ((basis b).row ⟨j, hjlt⟩)
+          ((basis b).row ⟨j, hjlt⟩).dotProduct
             ((basis b).row ⟨q.val, Nat.lt_trans q.isLt hi⟩) = 0 := by
     intro q hqj
     have hq_lt_n : q.val < n := Nat.lt_trans q.isLt hi
@@ -405,8 +405,8 @@ with `q < k`, and the relevant `(basis b).row q` agrees with `(basis b').row q`
 for `q < km1`. -/
 theorem dot_basis_rowSwap_curr_prev_eq_normSq
     (b : Matrix Int n m) (km1 k : Fin n) (hkm1 : km1.val + 1 = k.val) :
-    Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) =
-      Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row k) := by
+    ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) =
+      ((basis (Matrix.rowSwap b km1 k)).row k).normSq := by
   have hkm1k : km1.val < k.val := by omega
   -- Row equality: (rowSwap b km1 k).row k = b.row km1.
   have hrow_eq : (Matrix.rowSwap b km1 k).row k = b.row km1 := by
@@ -418,7 +418,7 @@ theorem dot_basis_rowSwap_curr_prev_eq_normSq
     simp
   -- prefixCombination of b at km1 vanishes against u_k.
   have hpfx_b_zero :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           (GramSchmidt.prefixCombination (coeffs b) (basis b) km1.val km1.isLt) = 0 := by
     apply dot_prefixCombination_right_eq_zero
     intro q
@@ -433,7 +433,7 @@ theorem dot_basis_rowSwap_curr_prev_eq_normSq
       (Nat.ne_of_gt hq_lt_k)
   -- prefixCombination of b' at k vanishes against u_k.
   have hpfx_b'_zero :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           (GramSchmidt.prefixCombination (coeffs (Matrix.rowSwap b km1 k))
             (basis (Matrix.rowSwap b km1 k)) k.val k.isLt) = 0 := by
     apply dot_prefixCombination_right_eq_zero
@@ -444,20 +444,20 @@ theorem dot_basis_rowSwap_curr_prev_eq_normSq
       (Nat.ne_of_gt hq_lt_k)
   -- dot u_k (cast b.row km1) = dot u_k (basis b.row km1)
   have hdot_cast_b_km1 :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           (Vector.map (fun x : Int => (x : Rat)) (b.row km1)) =
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) := by
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) := by
     have hdec := basis_decomposition b km1.val km1.isLt
-    show Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+    show ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row ⟨km1.val, km1.isLt⟩)) = _
     rw [hdec, dot_add_right_rat, hpfx_b_zero, Rat.add_zero]
   -- dot u_k (cast b'.row k) = ||u_k||²
   have hdot_cast_b'_k :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           (Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k).row k)) =
-      Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row k) := by
+      ((basis (Matrix.rowSwap b km1 k)).row k).normSq := by
     have hdec := basis_decomposition (Matrix.rowSwap b km1 k) k.val k.isLt
-    show Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+    show ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         (Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k).row ⟨k.val, k.isLt⟩)) = _
     rw [hdec, dot_add_right_rat, hpfx_b'_zero, Rat.add_zero]
     rfl
@@ -484,9 +484,9 @@ b'-side Cramer formula `c'[i][k] * ||u_k||² = dot u_k (cast b.row i)`. -/
 theorem dot_basis_rowSwap_curr_castRow_eq
     (b : Matrix Int n m) (km1 k : Fin n) (hkm1 : km1.val + 1 = k.val)
     (i : Fin n) (hki : k.val < i.val) :
-    Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+    ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) *
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) *
         (GramSchmidt.entry (coeffs b) i ⟨km1.val, Nat.lt_trans (Nat.lt_of_succ_le
           (le_of_eq hkm1)) k.isLt⟩ -
          GramSchmidt.entry (coeffs b) k ⟨km1.val, Nat.lt_trans (Nat.lt_of_succ_le
@@ -496,15 +496,15 @@ theorem dot_basis_rowSwap_curr_castRow_eq
   have hkm1_lt_i : km1.val < i.val := by omega
   have hkm1_lt_n : km1.val < n := Nat.lt_trans hkm1k k.isLt
   -- The dot product `D = dot u_k prev`.
-  set D : Rat := Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) with hD_def
+  set D : Rat := ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) with hD_def
   -- Step A: dot u_k cast b.row i = dot u_k basis b.row i + dot u_k prefixCombination(b, i)
   have hdec_b_i := basis_decomposition b i.val i.isLt
-  show Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+  show ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
       (Vector.map (fun x : Int => (x : Rat)) (b.row ⟨i.val, i.isLt⟩)) = _
   rw [hdec_b_i, dot_add_right_rat]
   -- dot u_k basis b.row i = 0 (basis b.row i = basis b'.row i and orthogonality).
   have hdot_basis_i :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row ⟨i.val, i.isLt⟩) = 0 := by
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row ⟨i.val, i.isLt⟩) = 0 := by
     have hbasis_eq : (basis b).row ⟨i.val, i.isLt⟩ =
         (basis (Matrix.rowSwap b km1 k)).row ⟨i.val, i.isLt⟩ :=
       (basis_rowSwap_of_after b km1 k ⟨i.val, i.isLt⟩ hkm1 hki).symm
@@ -520,7 +520,7 @@ theorem dot_basis_rowSwap_curr_castRow_eq
   set f : Fin i.val → Rat := fun q =>
     GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩
         ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩ *
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         ((basis b).row ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩) with hf_def
   -- For q ≠ km1, k: f q = 0.
   have h_zero : ∀ q : Fin i.val, q.val ≠ km1.val → q.val ≠ k.val → f q = 0 := by
@@ -536,7 +536,7 @@ theorem dot_basis_rowSwap_curr_castRow_eq
         have h_gt_k : k.val < q.val := by omega
         exact (basis_rowSwap_of_after b km1 k ⟨q.val, hq_lt_n⟩ hkm1 h_gt_k).symm
     show GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩ _ *
-        Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+        ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           ((basis b).row ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩) = 0
     rw [hbasis_eq_q]
     rw [basis_orthogonal (Matrix.rowSwap b km1 k) k.val q.val k.isLt hq_lt_n
@@ -551,12 +551,12 @@ theorem dot_basis_rowSwap_curr_castRow_eq
       (fun (acc : Rat) (q : Fin i.val) =>
         acc + GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩
               ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩ *
-            Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+            ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
               ((basis b).row ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩)) 0 = _
   rw [show (fun (acc : Rat) (q : Fin i.val) =>
         acc + GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩
               ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩ *
-            Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+            ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
               ((basis b).row ⟨q.val, Nat.lt_trans q.isLt i.isLt⟩)) =
        (fun (acc : Rat) (q : Fin i.val) => acc + f q) from rfl]
   rw [hfoldl_eq]
@@ -570,20 +570,20 @@ theorem dot_basis_rowSwap_curr_castRow_eq
       (basis (Matrix.rowSwap b km1 k)).row km1 = (basis b).row k + μ • (basis b).row km1 :=
     basis_rowSwap_adjacent_prev b km1 k hkm1
   have hdot_swap_zero :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         ((basis (Matrix.rowSwap b km1 k)).row km1) = 0 :=
     basis_orthogonal (Matrix.rowSwap b km1 k) k.val km1.val k.isLt km1.isLt
       (fun h => Nat.lt_irrefl km1.val (h ▸ hkm1k))
   -- Expand the orthogonality via the basis swap.
   have hdot_curr :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row k) = -μ * D := by
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row k) = -μ * D := by
     have h := hdot_swap_zero
     rw [hbasis_swap] at h
     rw [dot_add_right_rat, dot_smul_right_rat] at h
     -- h : dot u_k curr + μ * (dot u_k prev) = 0
     -- i.e., dot u_k curr + μ * D = 0
     -- ⟹ dot u_k curr = -μ * D
-    have hD_eq : Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+    have hD_eq : ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         ((basis b).row km1) = D := rfl
     rw [hD_eq] at h
     linarith
@@ -592,10 +592,10 @@ theorem dot_basis_rowSwap_curr_castRow_eq
   have hf_km1 : f ⟨km1.val, hkm1_lt_i⟩ =
       GramSchmidt.entry (coeffs b) i ⟨km1.val, hkm1_lt_n⟩ * D := by
     show GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩ ⟨km1.val, _⟩ *
-        Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+        ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           ((basis b).row ⟨km1.val, _⟩) = _
     show GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩ ⟨km1.val, hkm1_lt_n⟩ *
-        Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+        ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           ((basis b).row ⟨km1.val, hkm1_lt_n⟩) =
         GramSchmidt.entry (coeffs b) i ⟨km1.val, hkm1_lt_n⟩ * D
     have hi_eq : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
@@ -604,7 +604,7 @@ theorem dot_basis_rowSwap_curr_castRow_eq
   have hf_k : f ⟨k.val, hki⟩ =
       GramSchmidt.entry (coeffs b) i k * (-μ * D) := by
     show GramSchmidt.entry (coeffs b) ⟨i.val, i.isLt⟩ ⟨k.val, _⟩ *
-        Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+        ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           ((basis b).row ⟨k.val, _⟩) = _
     have hi_eq : (⟨i.val, i.isLt⟩ : Fin n) = i := Fin.ext rfl
     have hk_eq : (⟨k.val, Nat.lt_trans hki i.isLt⟩ : Fin n) = k := Fin.ext rfl
@@ -734,9 +734,9 @@ theorem gramDet_pos_of_upperTriangular_pos_diag
           intro c hc
           simp [Matrix.row, Matrix.takeRows, Matrix.ofFn, jFin, jj]
         have hdot :
-            Vector.dotProduct (Matrix.row (Matrix.takeRows M (r + 1) hk) iFin)
+            (Matrix.row (Matrix.takeRows M (r + 1) hk) iFin).dotProduct
                 (Matrix.row (Matrix.takeRows M (r + 1) hk) jFin) =
-              Vector.dotProduct (Matrix.row M ii) (Matrix.row M jj) := by
+              (Matrix.row M ii).dotProduct (Matrix.row M jj) := by
           rw [hrow_i, hrow_j]
         simpa [Matrix.gramMatrix, Matrix.principalSubmatrix, Matrix.ofFn, iFin, jFin, ii, jj]
           using hdot

--- a/HexGramSchmidtMathlib/Update.lean
+++ b/HexGramSchmidtMathlib/Update.lean
@@ -157,11 +157,11 @@ private theorem leadingGramMatrixInt_rowSwap_outside
        (Matrix.gramMatrix b)[pn][qn]
   have hentry_swap :
       (Matrix.gramMatrix (Matrix.rowSwap b km1 k))[pn][qn] =
-        Hex.Vector.dotProduct ((Matrix.rowSwap b km1 k)[pn]) ((Matrix.rowSwap b km1 k)[qn]) := by
+        ((Matrix.rowSwap b km1 k)[pn]).dotProduct ((Matrix.rowSwap b km1 k)[qn]) := by
     simp [Matrix.gramMatrix, Matrix.row, Matrix.ofFn]
   have hentry_b :
       (Matrix.gramMatrix b)[pn][qn] =
-        Hex.Vector.dotProduct (b[pn]) (b[qn]) := by
+        (b[pn]).dotProduct (b[qn]) := by
     simp [Matrix.gramMatrix, Matrix.row, Matrix.ofFn]
   rw [hentry_swap, hentry_b, hp_eq, hq_eq]
 
@@ -199,12 +199,12 @@ private theorem leadingGramMatrixInt_rowSwap_inside
          ((Matrix.rowSwap ((Matrix.rowSwap M km1' k').transpose) km1' k').transpose)[pp][qq]
   have hLHS :
       (Matrix.principalSubmatrix (Matrix.gramMatrix (Matrix.rowSwap b km1 k)) t ht)[pp][qq] =
-        Hex.Vector.dotProduct ((Matrix.rowSwap b km1 k)[pn]) ((Matrix.rowSwap b km1 k)[qn]) := by
+        ((Matrix.rowSwap b km1 k)[pn]).dotProduct ((Matrix.rowSwap b km1 k)[qn]) := by
     simp [Matrix.principalSubmatrix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn,
       pp, qq, pn, qn]
   have hM_entry : ∀ (a b' : Fin t),
       M[a][b'] =
-        Hex.Vector.dotProduct (b[(⟨a.val, Nat.lt_of_lt_of_le a.isLt ht⟩ : Fin n)])
+        (b[(⟨a.val, Nat.lt_of_lt_of_le a.isLt ht⟩ : Fin n)]).dotProduct
           (b[(⟨b'.val, Nat.lt_of_lt_of_le b'.isLt ht⟩ : Fin n)]) := by
     intro a b'
     simp [M, Matrix.principalSubmatrix, Matrix.gramMatrix, Matrix.row, Matrix.ofFn]
@@ -775,8 +775,8 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
   set prev : Vector Rat m := (basis b).row km1 with hprev_def
   set curr : Vector Rat m := (basis b).row k with hcurr_def
   set G : Rat := gramSchmidtNormProduct b km1.val hkm1_le_n with hG_def
-  set Nkm1 : Rat := Vector.normSq prev with hNkm1_def
-  set Nk : Rat := Vector.normSq curr with hNk_def
+  set Nkm1 : Rat := prev.normSq with hNkm1_def
+  set Nk : Rat := curr.normSq with hNk_def
   -- Rational expressions for the Gram determinants.
   have hdkm1_rat : (gramDet b km1.val hkm1_le_n : Rat) = G :=
     gramDet_eq_prod_normSq_uncond b km1.val hkm1_le_n
@@ -795,14 +795,14 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     rw [h_succ, hgnp_k_eq,
         gramSchmidtNormProduct_succ b km1.val hkm1_succ_le]
   -- Basis orthogonality between curr and prev.
-  have horth : Vector.dotProduct curr prev = 0 :=
+  have horth : curr.dotProduct prev = 0 :=
     basis_orthogonal b k.val km1.val k.isLt km1.isLt (by omega)
   -- New basis row at km1 of the swapped matrix.
   have hbasis_swap :
       (basis (Matrix.rowSwap b km1 k)).row km1 = curr + μ • prev :=
     basis_rowSwap_adjacent_prev b km1 k hkm1
   -- normSq of the new basis row at km1.
-  have hN'_eq : Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row km1) =
+  have hN'_eq : ((basis (Matrix.rowSwap b km1 k)).row km1).normSq =
       Nk + μ ^ 2 * Nkm1 := by
     rw [hbasis_swap]
     exact normSq_add_smul_orthogonal_rat curr prev μ horth
@@ -818,8 +818,8 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
       gramDet_subst_val (Matrix.rowSwap b km1 k) _ _ _ _ hkm1
     rw [← hgd_eq, h_succ,
         gramSchmidtNormProduct_rowSwap_below b km1 k hkm1k]
-    show G * Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
-        ⟨km1.val, km1.isLt⟩) = G * (Nk + μ ^ 2 * Nkm1)
+    show G * ((basis (Matrix.rowSwap b km1 k)).row
+        ⟨km1.val, km1.isLt⟩).normSq = G * (Nk + μ ^ 2 * Nkm1)
     rw [hN'_eq]
   -- B = d_k * μ.
   have hB_rat :
@@ -871,21 +871,21 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     rw [hrow_b'_i]
     rfl
   -- Inner products of basis(b)[k] and basis(b)[km1] with cast(b.row i).
-  have hdotk : Vector.dotProduct curr
+  have hdotk : curr.dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
       GramSchmidt.entry (coeffs b) i k * Nk := by
     have h := dot_basis_castRow_eq_coeffs_mul_normSq b i.val k.val i.isLt hki
-    show Vector.dotProduct ((basis b).row ⟨k.val, k.isLt⟩) _ = _
+    show ((basis b).row ⟨k.val, k.isLt⟩).dotProduct _ = _
     rw [h]
-  have hdotkm1 : Vector.dotProduct prev
+  have hdotkm1 : prev.dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
       GramSchmidt.entry (coeffs b) i km1 * Nkm1 := by
     have h := dot_basis_castRow_eq_coeffs_mul_normSq b i.val km1.val i.isLt hkm1_lt_i
-    show Vector.dotProduct ((basis b).row ⟨km1.val, km1.isLt⟩) _ = _
+    show ((basis b).row ⟨km1.val, km1.isLt⟩).dotProduct _ = _
     rw [h]
   -- Inner product of basis(b')[km1] with cast(b'.row i) = c[i][k] * Nk + μ * c[i][km1] * Nkm1.
   have hdot_b'_km1 :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row km1)
+      ((basis (Matrix.rowSwap b km1 k)).row km1).dotProduct
           (Vector.map (fun x : Int => (x : Rat)) ((Matrix.rowSwap b km1 k).row i)) =
         GramSchmidt.entry (coeffs b) i k * Nk +
           μ * (GramSchmidt.entry (coeffs b) i km1 * Nkm1) := by
@@ -904,16 +904,16 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_prev
     -- And c'[i][km1] * |basis(b')[km1]|^2 = dot basis(b')[km1] (cast b'.row i)
     have hcoeff_normSq :
         GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) i km1 *
-          Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row km1) =
-        Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row km1)
+          ((basis (Matrix.rowSwap b km1 k)).row km1).normSq =
+        ((basis (Matrix.rowSwap b km1 k)).row km1).dotProduct
           (Vector.map (fun x : Int => (x : Rat))
             ((Matrix.rowSwap b km1 k).row i)) := by
       have h := dot_basis_castRow_eq_coeffs_mul_normSq
         (Matrix.rowSwap b km1 k) i.val km1.val i.isLt hkm1_lt_i
       show GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) ⟨i.val, i.isLt⟩
             ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ *
-          Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
-            ⟨km1.val, km1.isLt⟩) = _
+          ((basis (Matrix.rowSwap b km1 k)).row
+            ⟨km1.val, km1.isLt⟩).normSq = _
       exact h.symm
     -- Apply scaledCoeffs_eq for b'.
     have heq := scaledCoeffs_eq (Matrix.rowSwap b km1 k) i.val km1.val i.isLt hkm1_lt_i
@@ -996,8 +996,8 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
   set prev : Vector Rat m := (basis b).row km1 with hprev_def
   set curr : Vector Rat m := (basis b).row k with hcurr_def
   set G : Rat := gramSchmidtNormProduct b km1.val hkm1_le_n with hG_def
-  set Nkm1 : Rat := Vector.normSq prev with hNkm1_def
-  set Nk : Rat := Vector.normSq curr with hNk_def
+  set Nkm1 : Rat := prev.normSq with hNkm1_def
+  set Nk : Rat := curr.normSq with hNk_def
   -- Standard rationalisations.
   have hdkm1_rat : (gramDet b km1.val hkm1_le_n : Rat) = G :=
     gramDet_eq_prod_normSq_uncond b km1.val hkm1_le_n
@@ -1061,8 +1061,8 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
         ⟨km1.val, Nat.lt_trans hkm1_lt_i i.isLt⟩ : Int) : Rat) = _
     rw [heq, hgd_eq, hdk_rat]
   -- Squared norms of swapped basis rows.
-  set Nk' : Rat := Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row k) with hNk'_def
-  set Nkm1' : Rat := Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row km1) with hNkm1'_def
+  set Nk' : Rat := ((basis (Matrix.rowSwap b km1 k)).row k).normSq with hNk'_def
+  set Nkm1' : Rat := ((basis (Matrix.rowSwap b km1 k)).row km1).normSq with hNkm1'_def
   -- d_{k+1}(b') as Rat = G * Nkm1' * Nk' via normProduct rewrite.
   have hdkp1_swap_rat_factored :
       (gramDet (Matrix.rowSwap b km1 k) (k.val + 1) hk1_le_n : Rat) =
@@ -1081,15 +1081,15 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
   -- Cramer dot product for b' at col k.
   have hcoeff_normSq :
       GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) i k * Nk' =
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         (Vector.map (fun x : Int => (x : Rat))
           ((Matrix.rowSwap b km1 k).row i)) := by
     have h := dot_basis_castRow_eq_coeffs_mul_normSq
       (Matrix.rowSwap b km1 k) i.val k.val i.isLt hki
     show GramSchmidt.entry (coeffs (Matrix.rowSwap b km1 k)) ⟨i.val, i.isLt⟩
           ⟨k.val, Nat.lt_trans hki i.isLt⟩ *
-        Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row
-          ⟨k.val, k.isLt⟩) = _
+        ((basis (Matrix.rowSwap b km1 k)).row
+          ⟨k.val, k.isLt⟩).normSq = _
     exact h.symm
   -- For i > k, (rowSwap b km1 k).row i = b.row i.
   have hrow_b'_i : (Matrix.rowSwap b km1 k)[i] = b[i] := by
@@ -1107,24 +1107,24 @@ theorem bareiss_scaledCoeffMatrix_rowSwap_above_curr
     rw [hrow_b'_i]
     rfl
   -- D = dot u_k prev, and dot u_k (cast b.row i) = D * (c[i][km1] - μ * c[i][k]).
-  set D : Rat := Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1)
+  set D : Rat := ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1)
     with hD_def
   have hdot_castb_i :
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
           (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
         D * (GramSchmidt.entry (coeffs b) i km1 -
           μ * GramSchmidt.entry (coeffs b) i k) := by
     have h := dot_basis_rowSwap_curr_castRow_eq b km1 k hkm1 i hki
     -- The conclusion of dot_basis_rowSwap_curr_castRow_eq matches (modulo Fin equality).
-    show Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k)
+    show ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct
         (Vector.map (fun x : Int => (x : Rat)) (b.row i)) =
-      Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) *
+      ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) *
         (GramSchmidt.entry (coeffs b) i km1 -
          μ * GramSchmidt.entry (coeffs b) i k)
     convert h using 2
   have hD_eq_normSq : D = Nk' := by
-    show Vector.dotProduct ((basis (Matrix.rowSwap b km1 k)).row k) ((basis b).row km1) =
-      Vector.normSq ((basis (Matrix.rowSwap b km1 k)).row k)
+    show ((basis (Matrix.rowSwap b km1 k)).row k).dotProduct ((basis b).row km1) =
+      ((basis (Matrix.rowSwap b km1 k)).row k).normSq
     exact dot_basis_rowSwap_curr_prev_eq_normSq b km1 k hkm1
   -- Combine into a Cramer-style identity: c'[i][k] * Nk' = Nk' * (c[i][km1] - μ * c[i][k])
   have hcoeff_eq_Nk' :

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -103,7 +103,7 @@ def mulEqCert (M : Matrix Int n n) (A C : Matrix Int n m) : Bool :=
   let K := packWidth M A C
   let packs : Vector Int n := Vector.ofFn fun l => packRow K (row A l)
   (List.finRange n).all fun i =>
-    Vector.dotProduct (row M i) packs == packRow K (row C i)
+    (row M i).dotProduct packs == packRow K (row C i)
 
 /-- `foldl_max_le_init` shows that the initial accumulator is bounded by the
 running `Nat.max` scan used to compute entrywise absolute-value bounds. -/
@@ -228,10 +228,10 @@ private theorem foldl_zipWith_getElem (c : Vector Int n) (A : Matrix Int n m)
 the (unformed) product `M * A`. -/
 theorem dotProduct_packRow (K : Nat) (M : Matrix Int n n) (A : Matrix Int n m)
     (i : Fin n) :
-    Vector.dotProduct (row M i) (Vector.ofFn fun l => packRow K (row A l)) =
+    (row M i).dotProduct (Vector.ofFn fun l => packRow K (row A l)) =
       packRow K (row (M * A) i) := by
   have hstart :
-      Vector.dotProduct (row M i) (Vector.ofFn fun l => packRow K (row A l)) =
+      (row M i).dotProduct (Vector.ofFn fun l => packRow K (row A l)) =
         (List.finRange n).foldl
           (fun acc l => acc + (row M i)[l] * packRow K (row A l))
           (packRow K (Vector.replicate m (0 : Int))) := by
@@ -333,7 +333,7 @@ private theorem foldl_dot_natAbs_le (u v : Vector Int k) (Bu Bv : Nat)
 /-- Entrywise bound on an integer dot product. -/
 theorem natAbs_dotProduct_le (u v : Vector Int k) (Bu Bv : Nat)
     (hu : ∀ l : Fin k, u[l].natAbs ≤ Bu) (hv : ∀ l : Fin k, v[l].natAbs ≤ Bv) :
-    (Vector.dotProduct u v).natAbs ≤ k * (Bu * Bv) := by
+    (u.dotProduct v).natAbs ≤ k * (Bu * Bv) := by
   have h := foldl_dot_natAbs_le u v Bu Bv hu hv (List.finRange k) 0
   simpa [Vector.dotProduct] using h
 
@@ -431,7 +431,7 @@ namespace LLLCore
 /-- Recover the squared norm of a Gram-Schmidt basis vector. -/
 @[expose]
 def basisNormSq (basis : Matrix Rat n m) (i : Fin n) : Rat :=
-  Vector.normSq (basis.row i)
+  (basis.row i).normSq
 
 end LLLCore
 
@@ -478,7 +478,7 @@ private theorem foldlNonneg {α : Type} (xs : List α) (f : α → Rat)
 its rational entries. -/
 theorem basisNormSq_nonneg (basis : Matrix Rat n m) (i : Fin n) :
     0 ≤ basisNormSq basis i := by
-  simp only [basisNormSq, Vector.normSq, Hex.Vector.dotProduct]
+  simp only [basisNormSq, Vector.normSq, Vector.dotProduct]
   exact foldlNonneg (List.finRange m) (fun j => (basis.row i)[j] * (basis.row i)[j]) 0
     (by grind) (fun j => ratMulSelfNonneg ((basis.row i)[j]))
 
@@ -624,7 +624,7 @@ theorem teleBound (b : Matrix Int n m) {δ η : Rat}
 coincides with the 0-th input row, so their squared norms agree. -/
 theorem basisNormSq_zero (b : Matrix Int n m) (hn : 0 < n) :
     basisNormSq (GramSchmidt.Int.basis b) ⟨0, hn⟩ =
-      ((Vector.normSq (b.row ⟨0, hn⟩) : Int) : Rat) := by
+      (((b.row ⟨0, hn⟩).normSq : Int) : Rat) := by
   unfold basisNormSq
   rw [GramSchmidt.Int.basis_zero b hn]
   exact GramSchmidt.Int.normSq_map_intCast (b.row ⟨0, hn⟩)
@@ -668,9 +668,9 @@ theorem short_vector_bound_of_size_bound (b : Matrix Int n m) {δ η : Rat}
     (hli : Matrix.independent b) (hred : isLLLReduced b δ η)
     (hη : (1 / 2 : Rat) ≤ η) (hδη : η * η < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
-    ((Vector.normSq (b.row ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
+    (((b.row ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩).normSq : Int) : Rat) ≤
       (1 / (δ - η * η)) ^ (n - 1) *
-        ((Vector.normSq v : Int) : Rat) := by
+        ((v.normSq : Int) : Rat) := by
   have h0n : 0 < n := Nat.lt_of_lt_of_le Nat.zero_lt_one hn
   obtain ⟨i, hi_norm⟩ :=
     GramSchmidt.Int.normSq_latticeVec_ge_min_basis_normSq b hli v hv hv'
@@ -713,13 +713,13 @@ theorem short_vector_bound_of_size_bound (b : Matrix Int n m) {δ η : Rat}
   have hαpow_nn : 0 ≤ (1 / (δ - η * η)) ^ (n - 1) :=
     LLLCore.ratPow_nonneg _ hα_nn (n - 1)
   calc
-    ((Vector.normSq (b.row ⟨0, h0n⟩) : Int) : Rat)
+    (((b.row ⟨0, h0n⟩).normSq : Int) : Rat)
         ≤ (1 / (δ - η * η)) ^ i.val *
             LLLCore.basisNormSq (GramSchmidt.Int.basis b) i := htele
     _ ≤ (1 / (δ - η * η)) ^ (n - 1) *
             LLLCore.basisNormSq (GramSchmidt.Int.basis b) i :=
         Rat.mul_le_mul_of_nonneg_right hpow_mono hbasis_nn
-    _ ≤ (1 / (δ - η * η)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) :=
+    _ ≤ (1 / (δ - η * η)) ^ (n - 1) * ((v.normSq : Int) : Rat) :=
         Rat.mul_le_mul_of_nonneg_left hi_norm hαpow_nn
 
 /-- Monotonicity of the size-reduction bound: a `(δ, η₁)`-LLL-reduced basis
@@ -1083,7 +1083,7 @@ dispatches that read it keep per-input timing deterministic. -/
 @[expose]
 def maxDiagBits (b : Matrix Int n m) : Nat :=
   (List.finRange n).foldl
-    (fun acc i => max acc (Vector.normSq (b.row i)).natAbs.log2)
+    (fun acc i => max acc ((b.row i).normSq).natAbs.log2)
     0
 
 /-- Size predictor for the reducedness dispatch: `true` when the
@@ -1779,7 +1779,7 @@ def init (b : Matrix Int n m) : SteeredState n m :=
       let mut c : Array Float := Array.replicate (i + 1) 0.0
       let mut mui : Array Float := Array.replicate i 0.0
       for j in [0:i+1] do
-        let mut s := Float.ofInt (Vector.dotProduct rows[i]! rows[j]!)
+        let mut s := Float.ofInt (rows[i]!.dotProduct rows[j]!)
         let murow := if j == i then mui else mu[j]!
         for l in [0:j] do
           s := s - murow[l]! * c[l]!
@@ -1807,7 +1807,7 @@ def refreshRow (s : SteeredState n m) (k : Nat) : SteeredState n m :=
     let mut c : Array Float := Array.replicate (k + 1) 0.0
     let mut muk : Array Float := Array.replicate k 0.0
     for j in [0:k+1] do
-      let mut sm := Float.ofInt (Vector.dotProduct rows[k]! rows[j]!)
+      let mut sm := Float.ofInt (rows[k]!.dotProduct rows[j]!)
       let murow := if j == k then muk else s.mu[j]!
       for l in [0:j] do
         sm := sm - murow[l]! * c[l]!
@@ -1943,7 +1943,7 @@ def fuel (b : Matrix Int n m) : Nat :=
   Id.run do
     let mut s := 0
     for i in [0:n] do
-      s := s + (Vector.dotProduct rows[i]! rows[i]!).natAbs.log2 + 1
+      s := s + (rows[i]!.dotProduct rows[i]!).natAbs.log2 + 1
     return (3 * s + 1) * (n + 1)
 
 end SteeredState

--- a/HexLLLMathlib/Basic.lean
+++ b/HexLLLMathlib/Basic.lean
@@ -179,7 +179,7 @@ theorem lovasz_check_iff_isLLLReduced_pair
   have hNk_mul : (gd_k : Rat) * Nk = (gd_k1 : Rat) := by
     have hbn := Hex.GramSchmidt.Int.basis_normSq s.b hind k hk
     have hNk_val : Nk = (gd_k1 : Rat) / (gd_k : Rat) := by
-      show Hex.Vector.normSq ((Hex.GramSchmidt.Int.basis s.b).row ⟨k, hk⟩) = _
+      show ((Hex.GramSchmidt.Int.basis s.b).row ⟨k, hk⟩).normSq = _
       exact hbn
     rw [hNk_val, mul_div_cancel₀ _ hgd_k_ne]
   have hNkm1_mul : (gd_km1 : Rat) * Nkm1 = (gd_k : Rat) := by
@@ -187,7 +187,7 @@ theorem lovasz_check_iff_isLLLReduced_pair
     have hNkm1_val :
         Nkm1 = (Hex.GramSchmidt.Int.gramDet s.b (k - 1 + 1)
             (Nat.succ_le_of_lt hkm1lt) : Rat) / (gd_km1 : Rat) := by
-      show Hex.Vector.normSq ((Hex.GramSchmidt.Int.basis s.b).row ⟨k - 1, hkm1lt⟩) = _
+      show ((Hex.GramSchmidt.Int.basis s.b).row ⟨k - 1, hkm1lt⟩).normSq = _
       exact hbn
     have hgd_eq :
         Hex.GramSchmidt.Int.gramDet s.b (k - 1 + 1)
@@ -369,10 +369,10 @@ private theorem foldl_finRange_eq_sum {R : Type*} [AddCommMonoid R] {n : Nat}
 `EuclideanSpace ℝ (Fin m)` equals the real cast of the executable integer
 squared norm. -/
 theorem norm_sq_intRowToEuclidean (row : Vector Int m) :
-    ‖intRowToEuclidean row‖ ^ 2 = ((Hex.Vector.normSq row : Int) : ℝ) := by
+    ‖intRowToEuclidean row‖ ^ 2 = ((row.normSq : Int) : ℝ) := by
   rw [EuclideanSpace.real_norm_sq_eq]
   simp only [intRowToEuclidean, PiLp.toLp_apply]
-  unfold Hex.Vector.normSq Hex.Vector.dotProduct
+  unfold Vector.normSq Vector.dotProduct
   rw [foldl_finRange_eq_sum]
   push_cast
   refine Finset.sum_congr rfl ?_
@@ -384,7 +384,7 @@ theorem norm_sq_intRowToEuclidean (row : Vector Int m) :
 squared norm of its `Vector` preimage. -/
 theorem norm_sq_intVectorToEuclidean (x : Fin m → ℤ) :
     ‖intVectorToEuclidean x‖ ^ 2 =
-      ((Hex.Vector.normSq (HexMatrixMathlib.vectorEquiv.symm x) : Int) : ℝ) := by
+      (((HexMatrixMathlib.vectorEquiv.symm x).normSq : Int) : ℝ) := by
   have heq :
       intVectorToEuclidean x =
         intRowToEuclidean (HexMatrixMathlib.vectorEquiv.symm x) := by
@@ -681,13 +681,13 @@ private theorem lovasz_of_intCheck
   have hNi_mul : (gd_i : Rat) * Ni = (gd_i1 : Rat) := by
     have hbn := Hex.GramSchmidt.Int.basis_normSq b hindep i hi_lt
     have hNi_val : Ni = (gd_i1 : Rat) / (gd_i : Rat) := by
-      show Hex.Vector.normSq ((Hex.GramSchmidt.Int.basis b).row ⟨i, hi_lt⟩) = _
+      show ((Hex.GramSchmidt.Int.basis b).row ⟨i, hi_lt⟩).normSq = _
       exact hbn
     rw [hNi_val, mul_div_cancel₀ _ hgd_i_ne]
   have hNi1_mul : (gd_i1 : Rat) * Ni1 = (gd_i2 : Rat) := by
     have hbn := Hex.GramSchmidt.Int.basis_normSq b hindep (i + 1) hi1_lt
     have hNi1_val : Ni1 = (gd_i2 : Rat) / (gd_i1 : Rat) := by
-      show Hex.Vector.normSq ((Hex.GramSchmidt.Int.basis b).row ⟨i + 1, hi1_lt⟩) = _
+      show ((Hex.GramSchmidt.Int.basis b).row ⟨i + 1, hi1_lt⟩).normSq = _
       exact hbn
     rw [hNi1_val, mul_div_cancel₀ _ hgd_i1_ne]
   -- ν[i+1][i] = gd_i1 · μ via scaledCoeffs_eq.

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -54,8 +54,8 @@ theorem gramMatrix_takeRows_eq_principalSubmatrix {n : Nat} (M : Matrix Int n n)
     intro c hc
     simp [row, takeRows, ofFn, jFin, jj]
   have hdot :
-      Hex.Vector.dotProduct (row (takeRows M k hk) iFin) (row (takeRows M k hk) jFin) =
-        Hex.Vector.dotProduct (row M ii) (row M jj) := by
+      (row (takeRows M k hk) iFin).dotProduct (row (takeRows M k hk) jFin) =
+        (row M ii).dotProduct (row M jj) := by
     rw [hrow_i, hrow_j]
   simpa [gramMatrix, principalSubmatrix, ofFn, iFin, jFin, ii, jj] using
     hdot
@@ -2367,9 +2367,9 @@ theorem lllNative_short_vector
     (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent)
     {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
-    ((Vector.normSq ((lllNative b δ hδ hδ' hn).row
-        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
-      (1 / (δ - 1 / 4)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) := by
+    ((((lllNative b δ hδ hδ' hn).row
+        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩).normSq : Int) : Rat) ≤
+      (1 / (δ - 1 / 4)) ^ (n - 1) * ((v.normSq : Int) : Rat) := by
   have hred : isLLLReduced (lllNative b δ hδ hδ' hn) δ (1 / 2) :=
     lllNative_isLLLReduced b δ hδ hδ' hn hind
   have hind' : (lllNative b δ hδ hδ' hn).independent :=
@@ -2491,9 +2491,9 @@ theorem lll_short_vector
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)
     {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
-    ((Vector.normSq ((lll b δ hδ hδ' hn hind).row
-        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩) : Int) : Rat) ≤
-      (1 / (δ - 121 / 400)) ^ (n - 1) * ((Vector.normSq v : Int) : Rat) := by
+    ((((lll b δ hδ hδ' hn hind).row
+        ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩).normSq : Int) : Rat) ≤
+      (1 / (δ - 121 / 400)) ^ (n - 1) * ((v.normSq : Int) : Rat) := by
   have hred : isLLLReduced (lll b δ hδ hδ' hn hind) δ (11 / 20) :=
     lll_isLLLReduced b δ hδ hδ' hn hind
   have hind' : (lll b δ hδ hδ' hn hind).independent :=

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -263,8 +263,8 @@ private theorem foldl_finRange_eq_sum {R : Type*} [AddCommMonoid R] {k : Nat}
     ← List.sum_toFinset f (List.nodup_finRange k), List.toFinset_finRange]
 
 private theorem dot_eq_sum {m' : Nat} (u v : Vector Rat m') :
-    Hex.Vector.dotProduct u v = ∑ k : Fin m', u[k] * v[k] := by
-  unfold Hex.Vector.dotProduct
+    u.dotProduct v = ∑ k : Fin m', u[k] * v[k] := by
+  unfold Vector.dotProduct
   exact foldl_finRange_eq_sum _
 
 /-- The rational cast of a basis row of the integer input. -/
@@ -278,24 +278,24 @@ private noncomputable def muExact (b : Hex.Matrix Int n m) (i j : Fin n) : Rat :
 /-- Exact dot product `⟨b_i, b*_j⟩` of an input row against a
 Gram-Schmidt basis row. -/
 private noncomputable def gsDot (b : Hex.Matrix Int n m) (i j : Fin n) : Rat :=
-  Hex.Vector.dotProduct (castRow b i) ((GramSchmidt.Int.basis b).row j)
+  (castRow b i).dotProduct ((GramSchmidt.Int.basis b).row j)
 
 /-- Exact squared Gram-Schmidt norm `‖b*_j‖²`. -/
 private noncomputable def nrm (b : Hex.Matrix Int n m) (j : Fin n) : Rat :=
   Hex.LLLCore.basisNormSq (GramSchmidt.Int.basis b) j
 
 private theorem nrm_eq_dot (b : Hex.Matrix Int n m) (j : Fin n) :
-    nrm b j = Hex.Vector.dotProduct ((GramSchmidt.Int.basis b).row j)
+    nrm b j = ((GramSchmidt.Int.basis b).row j).dotProduct
       ((GramSchmidt.Int.basis b).row j) := by
   unfold nrm Hex.LLLCore.basisNormSq
   rfl
 
 /-- Cast of an integer Gram entry as a rational dot product of cast rows. -/
 private theorem gram_cast (b : Hex.Matrix Int n m) (i j : Fin n) :
-    ((Hex.Vector.dotProduct (b.row i) (b.row j) : Int) : Rat) =
-      Hex.Vector.dotProduct (castRow b i) (castRow b j) := by
+    (((b.row i).dotProduct (b.row j) : Int) : Rat) =
+      (castRow b i).dotProduct (castRow b j) := by
   rw [dot_eq_sum]
-  rw [show Hex.Vector.dotProduct (b.row i) (b.row j) =
+  rw [show (b.row i).dotProduct (b.row j) =
       ∑ k : Fin m, (b.row i)[k] * (b.row j)[k] from foldl_finRange_eq_sum _]
   push_cast
   refine Finset.sum_congr rfl fun k _ => ?_
@@ -337,23 +337,23 @@ private theorem getElem_prefixCombination
   rw [← List.foldl_map, ← List.sum_eq_foldl]
 
 private theorem dot_add_right {m' : Nat} (u v w : Vector Rat m') :
-    Hex.Vector.dotProduct u (v + w) = Hex.Vector.dotProduct u v + Hex.Vector.dotProduct u w := by
+    u.dotProduct (v + w) = u.dotProduct v + u.dotProduct w := by
   rw [dot_eq_sum, dot_eq_sum, dot_eq_sum, ← Finset.sum_add_distrib]
   refine Finset.sum_congr rfl fun k _ => ?_
   simp only [Fin.getElem_fin, Vector.getElem_add]
   ring
 
 private theorem dot_comm {m' : Nat} (u v : Vector Rat m') :
-    Hex.Vector.dotProduct u v = Hex.Vector.dotProduct v u := by
+    u.dotProduct v = v.dotProduct u := by
   rw [dot_eq_sum, dot_eq_sum]
   exact Finset.sum_congr rfl fun k _ => mul_comm _ _
 
 private theorem dot_prefixCombination (u : Vector Rat m)
     (C : Hex.Matrix Rat n n) (B : Hex.Matrix Rat n m) (i : Nat) (hi : i < n) :
-    Hex.Vector.dotProduct u (GramSchmidt.prefixCombination C B i hi) =
+    u.dotProduct (GramSchmidt.prefixCombination C B i hi) =
       ∑ k : Fin i,
         GramSchmidt.entry C ⟨i, hi⟩ ⟨k.val, Nat.lt_trans k.isLt hi⟩ *
-          Hex.Vector.dotProduct u (B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩) := by
+          u.dotProduct (B.row ⟨k.val, Nat.lt_trans k.isLt hi⟩) := by
   rw [dot_eq_sum]
   have : ∀ l : Fin m,
       u[l] * (GramSchmidt.prefixCombination C B i hi)[l] =
@@ -375,11 +375,11 @@ private theorem dot_prefixCombination (u : Vector Rat m)
 Gram-Schmidt basis: `⟨u, b_j⟩ = ⟨u, b*_j⟩ + Σ_{k<j} μ[j][k]·⟨u, b*_k⟩`. -/
 private theorem dot_castRow_decompose (b : Hex.Matrix Int n m)
     (u : Vector Rat m) (j : Fin n) :
-    Hex.Vector.dotProduct u (castRow b j) =
-      Hex.Vector.dotProduct u ((GramSchmidt.Int.basis b).row j) +
+    u.dotProduct (castRow b j) =
+      u.dotProduct ((GramSchmidt.Int.basis b).row j) +
         ∑ k : Fin j.val,
           muExact b j ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩ *
-            Hex.Vector.dotProduct u
+            u.dotProduct
               ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩) := by
   have hdecomp := GramSchmidt.Int.basis_decomposition b j.val j.isLt
   have hrow : castRow b j = Vector.map (fun x : Int => (x : Rat)) (b.row ⟨j.val, j.isLt⟩) := by
@@ -392,7 +392,7 @@ private theorem dot_castRow_decompose (b : Hex.Matrix Int n m)
 the `⟨b_i, b*_j⟩` dot product plus the `μ[j][·]`-weighted prefix of the
 `⟨b_i, b*_·⟩` dot products. -/
 private theorem gram_recurrence (b : Hex.Matrix Int n m) (i j : Fin n) :
-    ((Hex.Vector.dotProduct (b.row i) (b.row j) : Int) : Rat) =
+    (((b.row i).dotProduct (b.row j) : Int) : Rat) =
       gsDot b i j +
         ∑ k : Fin j.val,
           muExact b j ⟨k.val, Nat.lt_trans k.isLt j.isLt⟩ *
@@ -406,7 +406,7 @@ private theorem gsDot_eq_mu_mul_nrm (b : Hex.Matrix Int n m) {i j : Fin n}
     gsDot b i j = muExact b i j * nrm b j := by
   unfold gsDot
   rw [dot_comm, dot_castRow_decompose]
-  have horth : Hex.Vector.dotProduct ((GramSchmidt.Int.basis b).row j)
+  have horth : ((GramSchmidt.Int.basis b).row j).dotProduct
       ((GramSchmidt.Int.basis b).row i) = 0 := by
     rw [dot_comm]
     exact GramSchmidt.Int.basis_orthogonal b i.val j.val i.isLt j.isLt
@@ -415,7 +415,7 @@ private theorem gsDot_eq_mu_mul_nrm (b : Hex.Matrix Int n m) {i j : Fin n}
   · rw [dot_comm, nrm_eq_dot]
   · intro k _ hk
     have hkj : k.val ≠ j.val := fun h => hk (Fin.ext h)
-    have horth' : Hex.Vector.dotProduct ((GramSchmidt.Int.basis b).row j)
+    have horth' : ((GramSchmidt.Int.basis b).row j).dotProduct
         ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩) = 0 := by
       rw [dot_comm]
       exact GramSchmidt.Int.basis_orthogonal b k.val j.val
@@ -431,10 +431,10 @@ private theorem gsDot_self (b : Hex.Matrix Int n m) (i : Fin n) :
   rw [dot_comm, dot_castRow_decompose]
   have hsum : (∑ k : Fin i.val,
       muExact b i ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩ *
-        Hex.Vector.dotProduct ((GramSchmidt.Int.basis b).row i)
+        ((GramSchmidt.Int.basis b).row i).dotProduct
           ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩)) = 0 := by
     refine Finset.sum_eq_zero fun k _ => ?_
-    have horth : Hex.Vector.dotProduct ((GramSchmidt.Int.basis b).row i)
+    have horth : ((GramSchmidt.Int.basis b).row i).dotProduct
         ((GramSchmidt.Int.basis b).row ⟨k.val, Nat.lt_trans k.isLt i.isLt⟩) = 0 :=
       GramSchmidt.Int.basis_orthogonal b i.val k.val i.isLt
         (Nat.lt_trans k.isLt i.isLt) (Nat.ne_of_gt k.isLt)
@@ -670,7 +670,7 @@ private theorem rowFold_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
     (gRow : Array Int) (mus : Array (Array Ival)) (bstars : Array Ival)
     (i : Fin n) (hinv : Inv b S i.val (Nat.le_of_lt i.isLt) mus bstars)
     (hgRow : ∀ j (hj : j ≤ i.val),
-      gRow[j]! = Hex.Vector.dotProduct (b.row i)
+      gRow[j]! = (b.row i).dotProduct
         (b.row ⟨j, Nat.lt_of_le_of_lt hj i.isLt⟩))
     (t : Nat) (ht : t ≤ i.val) :
     ((List.range t).foldl (IntervalGS.rowStep S gRow mus bstars) (#[], #[])).1.size = t ∧
@@ -749,7 +749,7 @@ private theorem row_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
     (gRow : Array Int) (mus : Array (Array Ival)) (bstars : Array Ival)
     (i : Fin n) (hinv : Inv b S i.val (Nat.le_of_lt i.isLt) mus bstars)
     (hgRow : ∀ j (hj : j ≤ i.val),
-      gRow[j]! = Hex.Vector.dotProduct (b.row i)
+      gRow[j]! = (b.row i).dotProduct
         (b.row ⟨j, Nat.lt_of_le_of_lt hj i.isLt⟩)) :
     (IntervalGS.row S gRow mus bstars i.val).1.size = i.val ∧
       (∀ j (hj : j < i.val),
@@ -787,7 +787,7 @@ private theorem row_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
 private theorem pass_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
     (g : Array (Array Int))
     (hg : ∀ i (hi : i < n) j (hj : j ≤ i),
-      (g[i]!)[j]! = Hex.Vector.dotProduct (b.row ⟨i, hi⟩)
+      (g[i]!)[j]! = (b.row ⟨i, hi⟩).dotProduct
         (b.row ⟨j, Nat.lt_of_le_of_lt hj hi⟩)) :
     ∀ t (ht : t ≤ n) (res : Array (Array Ival) × Array Ival),
       (List.range t).foldlM (IntervalGS.passStep S g) (#[], #[]) = some res →
@@ -813,7 +813,7 @@ private theorem pass_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
       have htn : t < n := Nat.lt_of_succ_le ht
       let iF : Fin n := ⟨t, htn⟩
       have hgRow : ∀ j (hj : j ≤ iF.val),
-          (g[t]!)[j]! = Hex.Vector.dotProduct (b.row iF)
+          (g[t]!)[j]! = (b.row iF).dotProduct
             (b.row ⟨j, Nat.lt_of_le_of_lt hj iF.isLt⟩) := fun j hj => hg t htn j hj
       obtain ⟨hrsz, hrmu, hrb⟩ := row_spec b hS g[t]! s.1 s.2 iF hinv_t hgRow
       -- unfold the step and the positivity test
@@ -846,7 +846,7 @@ private theorem pass_spec (b : Hex.Matrix Int n m) {S : Int} (hS : 0 < S)
 private theorem g_entries (b : Hex.Matrix Int n m) (i : Nat) (hi : i < n)
     (j : Nat) (hj : j < n) :
     ((((Matrix.gramMatrix b).toArray.map Vector.toArray))[i]!)[j]! =
-      Hex.Vector.dotProduct (b.row ⟨i, hi⟩) (b.row ⟨j, hj⟩) := by
+      (b.row ⟨i, hi⟩).dotProduct (b.row ⟨j, hj⟩) := by
   have hi1 : i < ((Matrix.gramMatrix b).toArray.map Vector.toArray).size := by
     rw [Array.size_map, Vector.size_toArray]
     exact hi
@@ -912,7 +912,7 @@ theorem lllReducedInterval_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
   rw [Bool.and_eq_true] at h
   obtain ⟨hsizeOK, hlovOK⟩ := h
   have hg : ∀ i (hi : i < n) j (hj : j ≤ i),
-      (g[i]!)[j]! = Hex.Vector.dotProduct (b.row ⟨i, hi⟩)
+      (g[i]!)[j]! = (b.row ⟨i, hi⟩).dotProduct
         (b.row ⟨j, Nat.lt_of_le_of_lt hj hi⟩) :=
     fun i hi j hj => g_entries b i hi j (Nat.lt_of_le_of_lt hj hi)
   have hinv : Inv b S n (Nat.le_refl n) mus bstars :=

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -88,7 +88,7 @@ Multiplication is the usual row-by-column dot product, available both
 matrix-by-vector and matrix-by-matrix, with `*` notation for each. The
 dot product itself is exposed directly.
 
-{docstring Hex.Vector.dotProduct}
+{docstring Vector.dotProduct}
 
 {docstring Hex.Matrix.mulVec}
 

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -27,6 +27,8 @@ universe u
 @[expose]
 abbrev Matrix (R : Type u) (n m : Nat) := Vector (Vector R m) n
 
+end Hex
+
 namespace Vector
 
 /-- Dot product of two vectors. -/
@@ -50,6 +52,8 @@ def unit [Zero R] [One R] (i : Fin n) : Vector R n :=
   simp [unit]
 
 end Vector
+
+namespace Hex
 
 namespace Matrix
 
@@ -162,13 +166,13 @@ instance [OfNat R 0] [OfNat R 1] : One (Matrix R n n) where
 @[expose]
 def mulVec [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (v : Vector R m) :
     Vector R n :=
-  Vector.ofFn fun i => Hex.Vector.dotProduct (row M i) v
+  Vector.ofFn fun i => (row M i).dotProduct v
 
 /-- Multiply two matrices. -/
 @[expose]
 def mul [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (N : Matrix R m k) :
     Matrix R n k :=
-  ofFn fun i j => Hex.Vector.dotProduct (row M i) (col N j)
+  ofFn fun i j => (row M i).dotProduct (col N j)
 
 instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Vector R m) (Vector R n) where
   hMul := mulVec
@@ -185,15 +189,15 @@ instance [Mul R] [Add R] [OfNat R 0] : Mul (Matrix R n n) where
 /-- Entry characterization for matrix-vector multiplication. -/
 @[grind =] theorem getElem_mulVec [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (v : Vector R m) (i : Fin n) :
-    (M * v)[i] = Hex.Vector.dotProduct (row M i) v := by
-  show (mulVec M v)[i] = Hex.Vector.dotProduct (row M i) v
+    (M * v)[i] = (row M i).dotProduct v := by
+  show (mulVec M v)[i] = (row M i).dotProduct v
   simp [mulVec]
 
 /-- Entry characterization for matrix multiplication. -/
 @[grind =] theorem getElem_mul [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (N : Matrix R m k) (i : Fin n) (j : Fin k) :
-    (M * N)[i][j] = Hex.Vector.dotProduct (row M i) (col N j) := by
-  show (mul M N)[i][j] = Hex.Vector.dotProduct (row M i) (col N j)
+    (M * N)[i][j] = (row M i).dotProduct (col N j) := by
+  show (mul M N)[i][j] = (row M i).dotProduct (col N j)
   rw [mul, getElem_ofFn]
 
 /-- The identity matrix entry function: `1[i][j] = 1` if `i = j`, else `0`. -/

--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -14,8 +14,6 @@ public section
 Algebraic properties of dense vector dot products.
 -/
 
-namespace Hex
-
 universe u v
 
 namespace Vector
@@ -212,5 +210,3 @@ theorem dotProduct_sub_smul_right {R : Type u} [Lean.Grind.CommRing R]
   rw [dotProduct_sub_right, dotProduct_smul_right]
 
 end Vector
-
-end Hex

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -14,8 +14,6 @@ public section
 Gram matrices and standard-basis dot products.
 -/
 
-namespace Hex
-
 universe u v
 
 namespace Vector
@@ -127,17 +125,19 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
 
 end Vector
 
+namespace Hex
+
 namespace Matrix
 
 /-- Gram matrix of the rows of a dense matrix. -/
 @[expose]
 def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
-  ofFn fun i j => Hex.Vector.dotProduct (row M i) (row M j)
+  ofFn fun i j => (row M i).dotProduct (row M j)
 
 /-- Entry characterization for the Gram matrix of the rows of a dense matrix. -/
 @[grind =] theorem getElem_gramMatrix [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (i j : Fin n) :
-    (gramMatrix M)[i][j] = Hex.Vector.dotProduct (row M i) (row M j) := by
+    (gramMatrix M)[i][j] = (row M i).dotProduct (row M j) := by
   rw [gramMatrix, getElem_ofFn]
 
 /-- The Gram matrix of the identity is the identity. -/
@@ -145,30 +145,30 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
     gramMatrix (1 : Matrix R n n) = (1 : Matrix R n n) := by
   ext i hi j hj
   have hrow_i : (1 : Matrix R n n).row ⟨i, hi⟩ =
-      Hex.Vector.unit (R := R) ⟨i, hi⟩ := by
+      Vector.unit (R := R) ⟨i, hi⟩ := by
     ext a ha
     show ((1 : Matrix R n n).row ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)] =
-      (Hex.Vector.unit (R := R) ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
+      (Vector.unit (R := R) ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
     rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
-      Hex.Vector.getElem_unit (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+      Vector.getElem_unit (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   have hrow_j : (1 : Matrix R n n).row ⟨j, hj⟩ =
-      Hex.Vector.unit (R := R) ⟨j, hj⟩ := by
+      Vector.unit (R := R) ⟨j, hj⟩ := by
     ext a ha
     show ((1 : Matrix R n n).row ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)] =
-      (Hex.Vector.unit (R := R) ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
+      (Vector.unit (R := R) ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
     rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
-      Hex.Vector.getElem_unit (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
+      Vector.getElem_unit (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
   show (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
     (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
   have hgram :
       (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
-        Hex.Vector.dotProduct ((1 : Matrix R n n).row ⟨i, hi⟩)
+        ((1 : Matrix R n n).row ⟨i, hi⟩).dotProduct
           ((1 : Matrix R n n).row ⟨j, hj⟩) := by
     unfold gramMatrix ofFn
     simp
-  rw [hgram, hrow_i, hrow_j, Hex.Vector.dotProduct_unit_unit, getElem_one]
+  rw [hgram, hrow_i, hrow_j, Vector.dotProduct_unit_unit, getElem_one]
 
 end Matrix
 

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -232,7 +232,7 @@ theorem mul_assoc_vec [Lean.Grind.Ring R]
     (A * B) * v = A * (B * v) := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [HMul.hMul, mulVec, mul, row, col, Hex.Vector.dotProduct, ofFn]
+  simp [HMul.hMul, mulVec, mul, row, col, Vector.dotProduct, ofFn]
   change
     (List.finRange k).foldl
         (fun acc l =>
@@ -279,7 +279,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   change (Matrix.transpose (A * B))[ii][jj] = (Matrix.transpose B * Matrix.transpose A)[ii][jj]
   rw [getElem_transpose]
   change (A * B)[jj][ii] = (Matrix.transpose B * Matrix.transpose A)[ii][jj]
-  simp [HMul.hMul, mul, row, col, transpose, Hex.Vector.dotProduct, ofFn]
+  simp [HMul.hMul, mul, row, col, transpose, Vector.dotProduct, ofFn]
   change
     (List.finRange m).foldl (fun acc l => acc + A[jj][l] * B[l][ii]) 0 =
       (List.finRange m).foldl (fun acc l => acc + B[l][ii] * A[jj][l]) 0
@@ -292,7 +292,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
     (1 : Matrix R n n) * v = v := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [HMul.hMul, mulVec, row, Hex.Vector.dotProduct]
+  simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange n).foldl
       (fun acc j => acc + (1 : Matrix R n n)[ii][j] * v[j]) 0 =
     v[ii]
@@ -316,7 +316,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
   change ((1 : Matrix R n n) * M)[ii][jj] = M[ii][jj]
-  simp [HMul.hMul, mul, row, col, Hex.Vector.dotProduct]
+  simp [HMul.hMul, mul, row, col, Vector.dotProduct]
   simp [ofFn]
   change
     (List.finRange n).foldl
@@ -342,7 +342,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
   change (M * (1 : Matrix R m m))[ii][jj] = M[ii][jj]
-  simp [HMul.hMul, mul, row, col, Hex.Vector.dotProduct]
+  simp [HMul.hMul, mul, row, col, Vector.dotProduct]
   simp [ofFn]
   change
     (List.finRange m).foldl
@@ -370,7 +370,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin l := ⟨j, hj⟩
   change ((A * B) * C)[ii][jj] = (A * (B * C))[ii][jj]
-  simpa [HMul.hMul, mulVec, mul, row, col, Hex.Vector.dotProduct, ofFn] using
+  simpa [HMul.hMul, mulVec, mul, row, col, Vector.dotProduct, ofFn] using
     congrArg (fun v => v[ii]) (mul_assoc_vec A B (col C jj))
 
 /-- Matrix-vector multiplication sends the zero vector to the zero vector. -/
@@ -378,7 +378,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
     A * (0 : Vector R m) = 0 := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [HMul.hMul, mulVec, row, Hex.Vector.dotProduct]
+  simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange m).foldl (fun acc j => acc + A[ii][j] * (0 : R)) 0 = 0
   apply foldl_add_eq_acc_ring
   intro j _hj
@@ -389,7 +389,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
     (0 : Matrix R n m) * v = 0 := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [HMul.hMul, mulVec, row, Hex.Vector.dotProduct]
+  simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange m).foldl (fun acc j => acc + (0 : Matrix R n m)[ii][j] * v[j]) 0 = 0
   apply foldl_add_eq_acc_ring
   intro j _hj
@@ -403,7 +403,7 @@ theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R
       mulVec (R := R) (n := n) (m := n) Q v - v := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
-  simp [mulVec, row, Hex.Vector.dotProduct, ofFn]
+  simp [mulVec, row, Vector.dotProduct, ofFn]
   change
     (List.finRange n).foldl
         (fun acc j => acc + (Q[ii][j] - if ii = j then 1 else 0) * v[j]) 0 =

--- a/HexMatrixMathlib/Vector.lean
+++ b/HexMatrixMathlib/Vector.lean
@@ -65,8 +65,8 @@ theorem foldl_finRange_eq_sum [AddCommMonoid R] (f : Fin n → R) :
 /-- The executable dot product equals Mathlib's `dotProduct` of the two vectors
 read through `vectorEquiv`. -/
 theorem dotProduct_eq [NonUnitalNonAssocSemiring R] (u v : Vector R n) :
-    Hex.Vector.dotProduct u v = dotProduct (vectorEquiv u) (vectorEquiv v) := by
-  unfold Hex.Vector.dotProduct dotProduct
+    u.dotProduct v = dotProduct (vectorEquiv u) (vectorEquiv v) := by
+  unfold Vector.dotProduct dotProduct
   rw [foldl_finRange_eq_sum]
   rfl
 
@@ -92,7 +92,7 @@ theorem vectorEquiv_mulVec [Semiring R] (M : Hex.Matrix R n m) (v : Vector R m) 
   funext i
   simp only [vectorEquiv_apply]
   change (Hex.Matrix.mulVec M v)[i.val] = (matrixEquiv M).mulVec (vectorEquiv v) i
-  unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
+  unfold Hex.Matrix.mulVec Hex.Matrix.row Vector.dotProduct
   rw [Vector.getElem_ofFn i.isLt]
   rw [foldl_finRange_eq_sum]
   unfold _root_.Matrix.mulVec dotProduct

--- a/HexRowReduce/RREF/Echelon.lean
+++ b/HexRowReduce/RREF/Echelon.lean
@@ -245,7 +245,7 @@ theorem rowCombination_single {R : Type u} [Lean.Grind.CommRing R]
   change (Matrix.mulVec (Matrix.transpose M)
       (Vector.ofFn fun l : Fin n => if i = l then (1 : R) else 0))[jf] =
     (row M i)[jf]
-  unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct Matrix.transpose
+  unfold Matrix.mulVec Matrix.row Vector.dotProduct Matrix.transpose
     Matrix.col
   change (Vector.ofFn fun j : Fin m =>
       (List.finRange n).foldl
@@ -327,7 +327,7 @@ private theorem rowCombination_pivotCoeff [Lean.Grind.Field R] (E : IsRREF M D)
     (rowCombination D.echelon c)[D.pivotCols.get p] =
       c[E.toIsEchelonForm.pivotRow p] := by
   unfold rowCombination
-  simp [HMul.hMul, Matrix.mulVec, Matrix.row, Hex.Vector.dotProduct,
+  simp [HMul.hMul, Matrix.mulVec, Matrix.row, Vector.dotProduct,
     Matrix.transpose, Matrix.col]
   change (List.finRange n).foldl
       (fun acc i => acc + D.echelon[i][D.pivotCols.get p] * c[i]) 0 =
@@ -361,7 +361,7 @@ private theorem rowCombination_eq_of_coeffs_eq_on_rank [Lean.Grind.Field R]
   ext j hj
   let jj : Fin m := ⟨j, hj⟩
   unfold rowCombination
-  simp [HMul.hMul, Matrix.mulVec, Matrix.row, Hex.Vector.dotProduct,
+  simp [HMul.hMul, Matrix.mulVec, Matrix.row, Vector.dotProduct,
     Matrix.transpose, Matrix.col]
   change (List.finRange n).foldl
       (fun acc i => acc + D.echelon[i][jj] * c[i]) 0 =
@@ -756,7 +756,7 @@ private theorem nullspace_echelon_sound {R : Type u} [Lean.Grind.Ring R] {n m : 
     have hpivotFree : pivot ≠ free := by
       exact E.toIsEchelonForm.pivotCols_disjoint_freeCols ri k
     change (Matrix.mulVec D.echelon (E.nullspace.get k))[r] = (0 : Vector R n)[r]
-    unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct
+    unfold Matrix.mulVec Matrix.row Vector.dotProduct
     rw [Vector.getElem_ofFn hr, Vector.getElem_zero r hr]
     change (List.finRange m).foldl
         (fun acc j => acc + D.echelon[row][j] * (E.nullspace.get k)[j]) 0 = 0
@@ -824,7 +824,7 @@ private theorem nullspace_echelon_sound {R : Type u} [Lean.Grind.Ring R] {n m : 
   · have hzeroRow := E.toIsEchelonForm.zero_row row (by
       exact Nat.le_of_not_gt hrow)
     change (Matrix.mulVec D.echelon (E.nullspace.get k))[r] = (0 : Vector R n)[r]
-    unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct
+    unfold Matrix.mulVec Matrix.row Vector.dotProduct
     rw [Vector.getElem_ofFn hr, Vector.getElem_zero r hr]
     change (List.finRange m).foldl
         (fun acc j => acc + D.echelon[row][j] * (E.nullspace.get k)[j]) 0 = 0
@@ -1011,7 +1011,7 @@ private theorem freeSum_eq_neg_pivot {R : Type u} [Lean.Grind.Field R] {n m : Na
         (E.toIsEchelonForm.pivotRow i).isLt =
       (0 : Vector R n)[(E.toIsEchelonForm.pivotRow i).val]'
         (E.toIsEchelonForm.pivotRow i).isLt at hentry
-    unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct at hentry
+    unfold Matrix.mulVec Matrix.row Vector.dotProduct at hentry
     rw [Vector.getElem_ofFn (E.toIsEchelonForm.pivotRow i).isLt] at hentry
     rw [Vector.getElem_zero (E.toIsEchelonForm.pivotRow i).val
       (E.toIsEchelonForm.pivotRow i).isLt] at hentry
@@ -1123,7 +1123,7 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
       (Matrix.mulVec E.nullspaceMatrix
         (Vector.ofFn (fun k => v[E.toIsEchelonForm.freeCols.get k]) :
           Vector R (m - D.rank)))[jj.val]'jj.isLt = v[jj.val]'jj.isLt
-    unfold Matrix.mulVec Matrix.row Hex.Vector.dotProduct
+    unfold Matrix.mulVec Matrix.row Vector.dotProduct
     rw [Vector.getElem_ofFn jj.isLt]
     change
       (List.finRange (m - D.rank)).foldl

--- a/HexRowReduce/RowEchelon.lean
+++ b/HexRowReduce/RowEchelon.lean
@@ -96,9 +96,9 @@ private theorem foldl_sum_add_aux {R : Type u} [Lean.Grind.Ring R]
 left vector is given by `Vector.ofFn (fun k => s * v[k])`. -/
 private theorem dotProduct_smul_ofFn_left [Lean.Grind.Ring R]
     (s : R) (v w : Vector R m) :
-    Hex.Vector.dotProduct (Vector.ofFn fun k => s * v[k]) w =
-    s * Hex.Vector.dotProduct v w := by
-  unfold Hex.Vector.dotProduct
+    (Vector.ofFn fun k => s * v[k]).dotProduct w =
+    s * v.dotProduct w := by
+  unfold Vector.dotProduct
   rw [foldl_sum_mul_left_aux (xs := List.finRange m)
         (f := fun i => v[i] * w[i]) (c := s) (acc := 0)]
   have hzero : s * (0 : R) = 0 := by grind
@@ -114,9 +114,9 @@ private theorem dotProduct_smul_ofFn_left [Lean.Grind.Ring R]
 `Vector.ofFn (fun k => v[k] + s * w[k])`. -/
 private theorem dotProduct_add_smul_ofFn_left [Lean.Grind.Ring R]
     (u v w : Vector R m) (s : R) :
-    Hex.Vector.dotProduct (Vector.ofFn fun k => u[k] + s * v[k]) w =
-    Hex.Vector.dotProduct u w + s * Hex.Vector.dotProduct v w := by
-  unfold Hex.Vector.dotProduct
+    (Vector.ofFn fun k => u[k] + s * v[k]).dotProduct w =
+    u.dotProduct w + s * v.dotProduct w := by
+  unfold Vector.dotProduct
   -- LHS body: (u[k] + s * v[k]) * w[k] = u[k] * w[k] + s * (v[k] * w[k])
   rw [show (List.finRange m).foldl
         (fun acc i => acc + (Vector.ofFn fun k => u[k] + s * v[k])[i] * w[i]) 0 =
@@ -143,9 +143,9 @@ private theorem dotProduct_add_smul_ofFn_left [Lean.Grind.Ring R]
 `Vector.ofFn (fun k => v[k] + s * w[k])`. -/
 private theorem dotProduct_add_smul_ofFn_right [Lean.Grind.CommRing R]
     (u v w : Vector R m) (s : R) :
-    Hex.Vector.dotProduct u (Vector.ofFn fun k => v[k] + s * w[k]) =
-    Hex.Vector.dotProduct u v + s * Hex.Vector.dotProduct u w := by
-  unfold Hex.Vector.dotProduct
+    u.dotProduct (Vector.ofFn fun k => v[k] + s * w[k]) =
+    u.dotProduct v + s * u.dotProduct w := by
+  unfold Vector.dotProduct
   rw [show (List.finRange m).foldl
         (fun acc i => acc + u[i] * (Vector.ofFn fun k => v[k] + s * w[k])[i]) 0 =
       (List.finRange m).foldl
@@ -168,9 +168,9 @@ private theorem dotProduct_add_smul_ofFn_right [Lean.Grind.CommRing R]
 `Vector.ofFn (fun k => v[k] + w[k] * s)`. -/
 private theorem dotProduct_add_smulRight_ofFn_right [Lean.Grind.Ring R]
     (u v w : Vector R m) (s : R) :
-    Hex.Vector.dotProduct u (Vector.ofFn fun k => v[k] + w[k] * s) =
-    Hex.Vector.dotProduct u v + Hex.Vector.dotProduct u w * s := by
-  unfold Hex.Vector.dotProduct
+    u.dotProduct (Vector.ofFn fun k => v[k] + w[k] * s) =
+    u.dotProduct v + u.dotProduct w * s := by
+  unfold Vector.dotProduct
   rw [show (List.finRange m).foldl
         (fun acc i => acc + u[i] * (Vector.ofFn fun k => v[k] + w[k] * s)[i]) 0 =
       (List.finRange m).foldl

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -41,7 +41,7 @@ theorem vectorEquiv_rowCombination [CommRing R] (M : Hex.Matrix R n m) (c : Vect
   unfold Hex.Matrix.rowCombination
   change (Hex.Matrix.mulVec (Hex.Matrix.transpose M) c)[j.val] =
     (Fintype.linearCombination R (_root_.Matrix.row (matrixEquiv M)) (vectorEquiv c)) j
-  unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct Hex.Matrix.transpose
+  unfold Hex.Matrix.mulVec Hex.Matrix.row Vector.dotProduct Hex.Matrix.transpose
     Hex.Matrix.col
   rw [Vector.getElem_ofFn j.isLt, foldl_finRange_eq_sum, Fintype.linearCombination_apply,
     Finset.sum_apply]
@@ -66,7 +66,7 @@ private theorem vectorEquiv_nullspaceMatrix_mulVec [Field R]
   simp only [vectorEquiv_apply, Pi.smul_apply, Finset.sum_apply]
   change (Hex.Matrix.mulVec E.nullspaceMatrix c)[j.val] =
     ∑ k : Fin (m - D.rank), c[k] * (E.nullspace.get k)[j]
-  unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
+  unfold Hex.Matrix.mulVec Hex.Matrix.row Vector.dotProduct
   rw [Vector.getElem_ofFn j.isLt, foldl_finRange_eq_sum]
   apply Finset.sum_congr rfl
   intro k _

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -15,7 +15,7 @@ Oracle: none
 Mode: always
 Covered operations:
 - dense matrix constructors and accessors (`ofFn`, `row`, `col`, `transpose`, `principalSubmatrix`)
-- vector and matrix arithmetic (`dotProduct`, `Hex.Vector.normSq`, `mulVec`, `mul`, `gramMatrix`)
+- vector and matrix arithmetic (`dotProduct`, ``.normSq, `mulVec`, `mul`, `gramMatrix`)
 - elementary row operations (`rowSwap`, `rowScale`, `rowAdd`)
 Covered properties:
 - transpose is involutive on committed fixtures
@@ -84,8 +84,8 @@ private def spanVec : Vector Rat 3 :=
 #guard Matrix.col baseInt ⟨0, by decide⟩ = colZeroInt
 #guard Matrix.principalSubmatrix baseInt 1 (by decide) = unitSubmatrix
 #guard Matrix.principalSubmatrix baseInt 2 (by decide) = baseInt
-#guard Hex.Vector.normSq vecInt = 61
-#guard Hex.Vector.normSq spanVec = 14
+#guard vecInt.normSq = 61
+#guard spanVec.normSq = 14
 #guard Matrix.gramMatrix baseInt = baseGramInt
 #guard (1 : Matrix Int 2 2) * baseInt = baseInt
 #guard baseInt * (1 : Matrix Int 2 2) = baseInt


### PR DESCRIPTION
This PR relocates `dotProduct`, `normSq`, `unit`, and their lemmas from the `Hex.Vector` namespace to the root `Vector` namespace, attaching them to Lean core's `Vector` type and joining `Vector.modify` and `Vector.get_ofFn`, which already lived there, so every vector operation shares one home. It rewrites the call sites across the monorepo and, where the receiver is a vector, switches to dot notation (`u.dotProduct v`, `v.normSq`); `unit` keeps its `Vector.unit` spelling since it takes a `Fin n` rather than a vector. The full `lake build` (2400 jobs) plus the `bench` and `conformance` sub-projects build green.

🤖 Prepared with Claude Code