### PR TITLE
refactor: weaken independent_of_det_positive to positive prefixes

### DIFF
--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -661,7 +661,7 @@ already have a determinant lemma for a special matrix family can produce the
 public `independent` predicate stated over Mathlib-free computed data. -/
 
 private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ (k : Nat) (hk : k ≤ n),
+    (hdet : ∀ (k : Nat) (hk : k ≤ n), 0 < k →
       0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) k hk))
     (k : Nat) (hk : k ≤ n) (hk' : 0 < k) :
     0 < gramDet b k hk := by
@@ -671,7 +671,7 @@ private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
   | succ r =>
       have hsub :
           0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hk) :=
-        hdet (r + 1) hk
+        hdet (r + 1) hk (Nat.succ_pos r)
       have hsub_eq :
           Matrix.principalSubmatrix (Matrix.gramMatrix b) (r + 1) hk =
             GramSchmidt.leadingGramMatrixInt b (r + 1) hk :=
@@ -692,7 +692,7 @@ private theorem gramDet_pos_of_det_positive (b : Matrix Int n m)
 have determinant lemmas for special matrix families, while keeping the public
 predicate stated over Mathlib-free computed data. -/
 theorem independent_of_det_positive (b : Matrix Int n m)
-    (hdet : ∀ (k : Nat) (hk : k ≤ n),
+    (hdet : ∀ (k : Nat) (hk : k ≤ n), 0 < k →
       0 < Matrix.det (Matrix.principalSubmatrix (Matrix.gramMatrix b) k hk)) :
     independent b := by
   intro k
@@ -703,7 +703,7 @@ theorem independent_of_det_positive (b : Matrix Int n m)
 every leading principal minor has determinant `1 > 0`. -/
 theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
   exact independent_of_det_positive (1 : Matrix Int n n) (by
-    intro k hk
+    intro k hk _
     rw [Matrix.gramMatrix_one, Matrix.principalSubmatrix_one, Matrix.det_one]
     decide)
 

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -65,7 +65,7 @@ theorem independent_of_upperTriangular_pos_diag {n : Nat}
     (hzero : ∀ i j : Fin n, j.val < i.val -> M[i][j] = 0)
     (hdiag : ∀ i : Fin n, 0 < M[i][i]) : M.independent := by
   exact GramSchmidt.Int.independent_of_det_positive M (by
-    intro k hk
+    intro k hk _
     have hpos :=
       det_gramMatrix_takeRows_pos_of_upperTriangular_pos_diag M hzero hdiag k hk
     rwa [gramMatrix_takeRows_eq_principalSubmatrix M k hk] at hpos)


### PR DESCRIPTION
This PR adds a `0 < k` antecedent to the determinant-positivity hypothesis of `GramSchmidt.Int.independent_of_det_positive` (and the private `gramDet_pos_of_det_positive` it delegates to), so callers only have to supply positivity for the nonempty leading principal submatrices that the proof actually consumes, rather than also the vacuous `0 × 0` case. The two existing callers discharge the new antecedent by ignoring it.

Follow-up to https://github.com/kim-em/hex-dev/pull/8427 ("refactor: rename matrix slicers and drop the leadingSubmatrix wrapper").

🤖 Prepared with Claude Code