### PR TITLE
feat: add Mathlib algebra instances and equiv upgrades to HexMatrixMathlib

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -176,6 +176,12 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Vector R m) (Vector 
 instance [Mul R] [Add R] [OfNat R 0] : HMul (Matrix R n m) (Matrix R m k) (Matrix R n k) where
   hMul := mul
 
+/-- Homogeneous multiplication on square matrices, agreeing with the
+heterogeneous `HMul`. This is the `Mul` instance Mathlib's `Semiring`/`Ring`
+structures build on; see `HexMatrixMathlib`. -/
+instance [Mul R] [Add R] [OfNat R 0] : Mul (Matrix R n n) where
+  mul := mul
+
 /-- Entry characterization for matrix-vector multiplication. -/
 @[grind =] theorem mulVec_getElem [Mul R] [Add R] [OfNat R 0]
     (M : Matrix R n m) (v : Vector R m) (i : Fin n) :

--- a/HexMatrixMathlib.lean
+++ b/HexMatrixMathlib.lean
@@ -7,6 +7,11 @@ Authors: Kim Morrison
 module
 
 public import HexMatrixMathlib.Basic
+public import HexMatrixMathlib.Vector
+public import HexMatrixMathlib.Algebra
+public import HexMatrixMathlib.Lemmas
+public import HexMatrixMathlib.Gram
+public import HexMatrixMathlib.Submatrix
 
 public section
 
@@ -16,6 +21,16 @@ It exposes the concrete equivalence `matrixEquiv` between the executable
 `HexMatrix` dense representation and Mathlib's function-based `Matrix`, together
 with the row-operation correspondence lemmas relating our executable `rowSwap`,
 `rowScale`, and `rowAdd` helpers to Mathlib's elementary matrix operations.
+
+On top of this, `HexMatrixMathlib` equips `Hex.Matrix` with the Mathlib
+algebraic tower whose operations are the executable ones — `AddCommMonoid`,
+`AddCommGroup`, `Module`, `Semiring`, `Ring`, and `Algebra` — and upgrades
+`matrixEquiv` to additive (`matrixAddEquiv`), linear (`matrixLinearEquiv`), ring
+(`matrixRingEquiv`), and algebra (`matrixAlgEquiv`) equivalences. The companion
+modules carry the vector equivalence and matrix-vector product (`Vector`), the
+container API such as transpose and row/column updates (`Lemmas`), the Gram
+matrix (`Gram`), and the leading-submatrix family (`Submatrix`) across the
+equivalence.
 
 The determinant correspondence lives in `HexDeterminantMathlib`, the row-pivoted
 Bareiss correctness theorems in `HexBareissMathlib`, and the rank/span/nullspace

--- a/HexMatrixMathlib/Algebra.lean
+++ b/HexMatrixMathlib/Algebra.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Vector
+
+public section
+
+/-!
+Mathlib algebraic structure on `Hex.Matrix`, transported along `matrixEquiv`.
+
+`matrixEquiv` carries the executable dense-matrix operations to Mathlib's
+function-based `Matrix`, so we equip `Hex.Matrix` with the Mathlib algebraic
+tower (`AddCommMonoid`, `AddCommGroup`, `Module`, `Semiring`, `Ring`, `Algebra`)
+whose operations are the executable ones, and upgrade `matrixEquiv` to the
+corresponding additive, linear, ring, and algebra equivalences.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+universe u
+
+variable {R : Type u} {n m : Nat}
+
+/-! ### Preservation of the additive operations -/
+
+@[simp, grind =] theorem matrixEquiv_zero [Zero R] :
+    matrixEquiv (0 : Hex.Matrix R n m) = 0 := by
+  ext i j
+  rw [matrixEquiv_apply, Matrix.zero_apply]
+  show (Hex.Matrix.zero : Hex.Matrix R n m)[i][j] = 0
+  rw [Hex.Matrix.zero, Hex.Matrix.getElem_ofFn]
+
+@[simp, grind =] theorem matrixEquiv_add [Add R] (A B : Hex.Matrix R n m) :
+    matrixEquiv (A + B) = matrixEquiv A + matrixEquiv B := by
+  ext i j
+  simp
+
+@[simp, grind =] theorem matrixEquiv_neg [Neg R] (A : Hex.Matrix R n m) :
+    matrixEquiv (-A) = -matrixEquiv A := by
+  ext i j
+  simp
+
+@[simp, grind =] theorem matrixEquiv_sub [Sub R] (A B : Hex.Matrix R n m) :
+    matrixEquiv (A - B) = matrixEquiv A - matrixEquiv B := by
+  ext i j
+  simp
+
+@[simp, grind =] theorem matrixEquiv_smul {S : Type*} [SMul S R] (c : S) (A : Hex.Matrix R n m) :
+    matrixEquiv (c • A) = c • matrixEquiv A := by
+  ext i j
+  simp
+
+/-- Regression guard: under a Mathlib scalar instance the canonical matrix zero
+is the executable `ofFn`-based `Hex.Matrix.zero`, not the core `Vector`
+`replicate` zero. The additive tower, `Semiring`, and `matrixEquiv_zero` all
+share this zero; this `rfl` fails loudly if instance resolution ever drifts. -/
+example [Zero R] : (0 : Hex.Matrix R n m) = Hex.Matrix.zero := rfl
+
+/-- Regression guard: the canonical square-matrix one is the executable identity. -/
+example [Zero R] [One R] : (1 : Hex.Matrix R n n) = Hex.Matrix.identity := rfl
+
+/-! ### Additive instances and the additive equivalence -/
+
+instance instAddCommMonoid [AddCommMonoid R] : AddCommMonoid (Hex.Matrix R n m) :=
+  matrixEquiv.injective.addCommMonoid _ matrixEquiv_zero matrixEquiv_add
+    (fun _ _ => matrixEquiv_smul _ _)
+
+instance instAddCommGroup [AddCommGroup R] : AddCommGroup (Hex.Matrix R n m) :=
+  matrixEquiv.injective.addCommGroup _ matrixEquiv_zero matrixEquiv_add matrixEquiv_neg
+    matrixEquiv_sub (fun _ _ => matrixEquiv_smul _ _) (fun _ _ => matrixEquiv_smul _ _)
+
+/-- `matrixEquiv` as an additive equivalence. -/
+@[expose]
+def matrixAddEquiv [AddCommMonoid R] : Hex.Matrix R n m ≃+ Matrix (Fin n) (Fin m) R :=
+  { matrixEquiv with map_add' := matrixEquiv_add }
+
+@[simp] theorem matrixAddEquiv_apply [AddCommMonoid R] (M : Hex.Matrix R n m) :
+    matrixAddEquiv M = matrixEquiv M := rfl
+
+/-! ### Module structure and the linear equivalence -/
+
+instance instModule [Semiring R] : Module R (Hex.Matrix R n m) :=
+  Function.Injective.module R (M := Matrix (Fin n) (Fin m) R)
+    (matrixAddEquiv (R := R) (n := n) (m := m)).toAddMonoidHom
+    (fun _ _ h => matrixAddEquiv.injective h)
+    (fun c x => matrixEquiv_smul c x)
+
+/-- `matrixEquiv` as an `R`-linear equivalence. -/
+@[expose]
+def matrixLinearEquiv [Semiring R] : Hex.Matrix R n m ≃ₗ[R] Matrix (Fin n) (Fin m) R :=
+  { matrixEquiv with
+    map_add' := matrixEquiv_add
+    map_smul' := fun c A => matrixEquiv_smul c A }
+
+@[simp] theorem matrixLinearEquiv_apply [Semiring R] (M : Hex.Matrix R n m) :
+    matrixLinearEquiv M = matrixEquiv M := rfl
+
+/-! ### Multiplicative preservation -/
+
+@[simp, grind =] theorem matrixEquiv_one [Zero R] [One R] :
+    matrixEquiv (1 : Hex.Matrix R n n) = 1 := by
+  ext i j
+  rw [matrixEquiv_apply, Hex.Matrix.getElem_one, Matrix.one_apply]
+
+@[simp, grind =] theorem matrixEquiv_mul [Semiring R] (A B : Hex.Matrix R n n) :
+    matrixEquiv (A * B) = matrixEquiv A * matrixEquiv B := by
+  ext i j
+  rw [matrixEquiv_apply, Matrix.mul_apply]
+  show (Hex.Matrix.mul A B)[i][j] = ∑ k, matrixEquiv A i k * matrixEquiv B k j
+  rw [Hex.Matrix.mul, Hex.Matrix.getElem_ofFn, dotProduct_eq]
+  unfold dotProduct
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  grind
+
+/-! ### Auxiliary operations, pulled back through `matrixEquiv`
+
+These `NatCast`, `IntCast`, and `Pow` instances exist only to populate the
+corresponding fields of the `Semiring`/`Ring` structures. They are *proof-facing*:
+defined by transport through `matrixEquiv`, not in executable form. Executable
+code never goes through them — it uses the `HexMatrix` operations directly (the
+square-matrix `*`, the `ofFn` identity). Their transport lemmas below reduce them
+to the Mathlib side for `simp`/`grind`. -/
+
+instance instNatCast [Semiring R] : NatCast (Hex.Matrix R n n) :=
+  ⟨fun k => matrixEquiv.symm (k : Matrix (Fin n) (Fin n) R)⟩
+
+instance instIntCast [Ring R] : IntCast (Hex.Matrix R n n) :=
+  ⟨fun k => matrixEquiv.symm (k : Matrix (Fin n) (Fin n) R)⟩
+
+instance instPow [Semiring R] : Pow (Hex.Matrix R n n) ℕ :=
+  ⟨fun M k => matrixEquiv.symm (matrixEquiv M ^ k)⟩
+
+@[simp, grind =] theorem matrixEquiv_natCast [Semiring R] (k : ℕ) :
+    matrixEquiv (k : Hex.Matrix R n n) = k :=
+  matrixEquiv.apply_symm_apply (k : Matrix (Fin n) (Fin n) R)
+
+@[simp, grind =] theorem matrixEquiv_intCast [Ring R] (k : ℤ) :
+    matrixEquiv (k : Hex.Matrix R n n) = k :=
+  matrixEquiv.apply_symm_apply (k : Matrix (Fin n) (Fin n) R)
+
+@[simp, grind =] theorem matrixEquiv_pow [Semiring R] (M : Hex.Matrix R n n) (k : ℕ) :
+    matrixEquiv (M ^ k) = matrixEquiv M ^ k :=
+  matrixEquiv.apply_symm_apply (matrixEquiv M ^ k)
+
+/-! ### Ring structure and the ring equivalence -/
+
+instance instSemiring [Semiring R] : Semiring (Hex.Matrix R n n) :=
+  matrixEquiv.injective.semiring _ matrixEquiv_zero matrixEquiv_one matrixEquiv_add
+    matrixEquiv_mul (fun _ _ => matrixEquiv_smul _ _) (fun _ _ => matrixEquiv_pow _ _)
+    matrixEquiv_natCast
+
+instance instRing [Ring R] : Ring (Hex.Matrix R n n) :=
+  matrixEquiv.injective.ring _ matrixEquiv_zero matrixEquiv_one matrixEquiv_add
+    matrixEquiv_mul matrixEquiv_neg matrixEquiv_sub (fun _ _ => matrixEquiv_smul _ _)
+    (fun _ _ => matrixEquiv_smul _ _) (fun _ _ => matrixEquiv_pow _ _)
+    matrixEquiv_natCast matrixEquiv_intCast
+
+/-- `matrixEquiv` as a ring equivalence on square matrices. -/
+@[expose]
+def matrixRingEquiv [Semiring R] : Hex.Matrix R n n ≃+* Matrix (Fin n) (Fin n) R :=
+  { matrixEquiv with map_add' := matrixEquiv_add, map_mul' := matrixEquiv_mul }
+
+@[simp] theorem matrixRingEquiv_apply [Semiring R] (M : Hex.Matrix R n n) :
+    matrixRingEquiv M = matrixEquiv M := rfl
+
+/-! ### Algebra structure and the algebra equivalence -/
+
+instance instAlgebra [CommSemiring R] : Algebra R (Hex.Matrix R n n) :=
+  Algebra.ofModule
+    (fun r A B => matrixEquiv.injective (by simp [smul_mul_assoc]))
+    (fun r A B => matrixEquiv.injective (by simp [mul_smul_comm]))
+
+/-- `matrixEquiv` as an `R`-algebra equivalence on square matrices. -/
+@[expose]
+def matrixAlgEquiv [CommSemiring R] : Hex.Matrix R n n ≃ₐ[R] Matrix (Fin n) (Fin n) R :=
+  { matrixRingEquiv with
+    commutes' := fun r => by
+      simp [Algebra.algebraMap_eq_smul_one] }
+
+@[simp] theorem matrixAlgEquiv_apply [CommSemiring R] (M : Hex.Matrix R n n) :
+    matrixAlgEquiv M = matrixEquiv M := rfl
+
+end HexMatrixMathlib

--- a/HexMatrixMathlib/Gram.lean
+++ b/HexMatrixMathlib/Gram.lean
@@ -1,0 +1,36 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Algebra
+public import HexMatrix.Gram
+
+public section
+
+/-!
+The executable Gram matrix corresponds to `M * Mᵀ` under `matrixEquiv`.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+universe u
+
+variable {R : Type u} {n m : Nat}
+
+/-- The Gram matrix of the rows of `M` is `matrixEquiv M * (matrixEquiv M)ᵀ`. -/
+@[simp, grind =] theorem matrixEquiv_gramMatrix [Semiring R] (M : Hex.Matrix R n m) :
+    matrixEquiv (Hex.Matrix.gramMatrix M) = matrixEquiv M * (matrixEquiv M)ᵀ := by
+  ext i j
+  rw [matrixEquiv_apply, Hex.Matrix.gramMatrix_getElem, Matrix.mul_apply, dotProduct_eq]
+  unfold dotProduct
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [Matrix.transpose_apply]
+  grind
+
+end HexMatrixMathlib

--- a/HexMatrixMathlib/Lemmas.lean
+++ b/HexMatrixMathlib/Lemmas.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Vector
+
+public section
+
+/-!
+Correspondence lemmas carrying the executable container API of `Hex.Matrix`
+(transpose, row/column updates) across `matrixEquiv` to the matching Mathlib
+`Matrix` operations.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+universe u
+
+variable {R : Type u} {n m : Nat}
+
+/-- Transpose commutes with `matrixEquiv`: the executable transpose becomes
+Mathlib's `ᵀ`. -/
+@[simp, grind =] theorem matrixEquiv_transpose (M : Hex.Matrix R n m) :
+    matrixEquiv (Hex.Matrix.transpose M) = (matrixEquiv M)ᵀ := by
+  ext i j
+  rw [matrixEquiv_apply, Hex.Matrix.transpose_getElem, Matrix.transpose_apply,
+    matrixEquiv_apply]
+
+/-- Replacing a row carries `matrixEquiv` to Mathlib's `updateRow`. -/
+@[simp, grind =] theorem matrixEquiv_setRow (M : Hex.Matrix R n m) (dst : Fin n)
+    (v : Vector R m) :
+    matrixEquiv (Hex.Matrix.setRow M dst v) =
+      (matrixEquiv M).updateRow dst (vectorEquiv v) := by
+  ext i j
+  rw [matrixEquiv_apply, Matrix.updateRow_apply]
+  by_cases h : i = dst
+  · subst h
+    rw [if_pos rfl, vectorEquiv_apply]
+    exact congrArg (·[j.val]) (Hex.Matrix.setRow_get_self M i v)
+  · rw [if_neg h]
+    rw [matrixEquiv_apply]
+    exact congrArg (·[j.val]) (Hex.Matrix.setRow_row_ne M dst i v h)
+
+/-- Replacing a column carries `matrixEquiv` to Mathlib's `updateCol`. -/
+@[simp, grind =] theorem matrixEquiv_setCol (M : Hex.Matrix R n m) (dst : Fin m)
+    (v : Fin n → R) :
+    matrixEquiv (Hex.Matrix.setCol M dst v) = (matrixEquiv M).updateCol dst v := by
+  ext i j
+  rw [matrixEquiv_apply, Hex.Matrix.setCol_getElem, Matrix.updateCol_apply,
+    matrixEquiv_apply]
+
+end HexMatrixMathlib

--- a/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
+++ b/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
@@ -28,3 +28,45 @@ theorem matrixEquiv_rowAdd   (M : Hex.Matrix R n m) (src dst : Fin n) (c : R) : 
 These give the base dictionary through which the determinant and rank bridges
 transfer Mathlib theorems (Cramer's rule, Cayley-Hamilton, rank-nullity,
 `diagonal_transvection_induction`) to our matrices.
+
+**Algebraic instances and equivalence upgrades:**
+`Hex.Matrix` carries the Mathlib algebraic tower whose operations are the
+executable ones (entrywise `+`/`-`/`•` from the `Vector` representation, the
+`ofFn` zero/identity, and the executable matrix product). The instances are
+transported along `matrixEquiv` (so the laws come from Mathlib's `Matrix`):
+
+```lean
+instance [AddCommMonoid R] : AddCommMonoid (Hex.Matrix R n m)
+instance [AddCommGroup R]  : AddCommGroup (Hex.Matrix R n m)
+instance [Semiring R]      : Module R (Hex.Matrix R n m)
+instance [Semiring R]      : Semiring (Hex.Matrix R n n)
+instance [Ring R]          : Ring (Hex.Matrix R n n)
+instance [CommSemiring R]  : Algebra R (Hex.Matrix R n n)
+```
+
+`matrixEquiv` upgrades to the matching bundled equivalences:
+
+```lean
+def matrixAddEquiv    [AddCommMonoid R] : Hex.Matrix R n m ≃+ Matrix (Fin n) (Fin m) R
+def matrixLinearEquiv [Semiring R]      : Hex.Matrix R n m ≃ₗ[R] Matrix (Fin n) (Fin m) R
+def matrixRingEquiv   [Semiring R]      : Hex.Matrix R n n ≃+* Matrix (Fin n) (Fin n) R
+def matrixAlgEquiv    [CommSemiring R]  : Hex.Matrix R n n ≃ₐ[R] Matrix (Fin n) (Fin n) R
+```
+
+with `@[simp]` transport lemmas (`matrixEquiv_add`, `matrixEquiv_mul`,
+`matrixEquiv_smul`, `matrixEquiv_one`, …) feeding `simp`/`grind`.
+
+**Operation correspondence across the equivalence:**
+The vector equivalence and the basic container API also cross `matrixEquiv`:
+
+```lean
+def vectorEquiv : Vector R n ≃ (Fin n → R)
+theorem vectorEquiv_mulVec    : vectorEquiv (M * v) = (matrixEquiv M).mulVec (vectorEquiv v)
+theorem matrixEquiv_transpose : matrixEquiv Mᵀ = (matrixEquiv M)ᵀ
+theorem matrixEquiv_setRow    : matrixEquiv (setRow M i v) = (matrixEquiv M).updateRow i (vectorEquiv v)
+theorem matrixEquiv_setCol    : matrixEquiv (setCol M j v) = (matrixEquiv M).updateCol j v
+theorem matrixEquiv_gramMatrix         : matrixEquiv (gramMatrix M) = matrixEquiv M * (matrixEquiv M)ᵀ
+theorem matrixEquiv_principalSubmatrix : matrixEquiv (principalSubmatrix M k hk) = (matrixEquiv M).submatrix (Fin.castLE hk) (Fin.castLE hk)
+```
+
+(plus `matrixEquiv_takeRows`).

--- a/HexMatrixMathlib/Submatrix.lean
+++ b/HexMatrixMathlib/Submatrix.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Vector
+public import HexMatrix.Submatrix
+
+public section
+
+/-!
+The executable principal-submatrix and row-prefix operations correspond to
+Mathlib's `Matrix.submatrix` reindexed along `Fin.castLE`.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+universe u
+
+variable {R : Type u} {n m : Nat}
+
+/-- The `k × k` principal submatrix is the `Fin.castLE`-reindexed submatrix. -/
+@[simp, grind =] theorem matrixEquiv_principalSubmatrix (M : Hex.Matrix R n n) (k : Nat)
+    (hk : k ≤ n) :
+    matrixEquiv (Hex.Matrix.principalSubmatrix M k hk) =
+      (matrixEquiv M).submatrix (Fin.castLE hk) (Fin.castLE hk) := by
+  ext i j
+  simp only [matrixEquiv_apply, Hex.Matrix.getElem_principalSubmatrix, Matrix.submatrix_apply,
+    Fin.castLE, Fin.castLT]
+
+/-- The first-`k`-rows slice is the submatrix reindexing rows by `Fin.castLE`. -/
+@[simp, grind =] theorem matrixEquiv_takeRows (M : Hex.Matrix R n m) (k : Nat)
+    (hk : k ≤ n) :
+    matrixEquiv (Hex.Matrix.takeRows M k hk) =
+      (matrixEquiv M).submatrix (Fin.castLE hk) id := by
+  ext i j
+  simp only [matrixEquiv_apply, Hex.Matrix.getElem_takeRows, Matrix.submatrix_apply,
+    Fin.castLE, Fin.castLT, id_eq]
+
+end HexMatrixMathlib

--- a/HexMatrixMathlib/Vector.lean
+++ b/HexMatrixMathlib/Vector.lean
@@ -1,0 +1,103 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrixMathlib.Basic
+
+public section
+
+/-!
+The executable-`Vector` ↔ Mathlib-`Fin n → R` equivalence, the fold-to-`Finset.sum`
+bridge for dot products, and the matrix-vector-product correspondence.
+
+These are the base facts through which the row-span, rank, and nullspace bridges
+(in `HexRowReduceMathlib`) and the lattice bridges (in `HexLLLMathlib`) move
+between the two vector representations.
+-/
+
+open Matrix
+
+namespace HexMatrixMathlib
+
+universe u
+
+variable {R : Type u} {n m : Nat}
+
+/-- Convert an executable `Vector` into Mathlib's function representation. -/
+@[expose]
+def vectorEquiv : Vector R n ≃ (Fin n → R) where
+  toFun := fun v i => v[i]
+  invFun := Vector.ofFn
+  left_inv := by
+    intro v
+    ext i
+    simp
+  right_inv := by
+    intro f
+    funext i
+    simp
+
+/-- `vectorEquiv` reads off the executable vector entrywise, so a caller can
+rewrite `vectorEquiv v i` to the underlying `v[i]` without unfolding it. -/
+@[simp, grind =] theorem vectorEquiv_apply (v : Vector R n) (i : Fin n) :
+    vectorEquiv v i = v[i] :=
+  rfl
+
+/-- The inverse direction of `vectorEquiv` materialises a function as an
+executable vector entrywise: `(vectorEquiv.symm f)[i]` is just `f i`. -/
+@[simp, grind =] theorem vectorEquiv_symm_apply (f : Fin n → R) (i : Fin n) :
+    (vectorEquiv.symm f)[(i : Nat)] = f i := by
+  simp [vectorEquiv]
+
+/-- A left fold of `(· + f ·)` over `List.finRange n` from `0` is the finite sum
+`∑ i, f i`; the bridge from the executable fold-sum to Mathlib's `Finset.sum`. -/
+theorem foldl_finRange_eq_sum [AddCommMonoid R] (f : Fin n → R) :
+    (List.finRange n).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
+  rw [← List.foldl_map]
+  rw [← List.sum_eq_foldl]
+  rw [← List.sum_toFinset f (List.nodup_finRange n)]
+  rw [List.toFinset_finRange]
+
+/-- The executable dot product equals Mathlib's `dotProduct` of the two vectors
+read through `vectorEquiv`. -/
+theorem dotProduct_eq [NonUnitalNonAssocSemiring R] (u v : Vector R n) :
+    Hex.Vector.dotProduct u v = dotProduct (vectorEquiv u) (vectorEquiv v) := by
+  unfold Hex.Vector.dotProduct dotProduct
+  rw [foldl_finRange_eq_sum]
+  rfl
+
+/-- Row `i` of the Mathlib matrix `matrixEquiv M` is the image under `vectorEquiv`
+of the executable row `Hex.Matrix.row M i`, letting span/rank lemmas pass between
+the two row representations. -/
+@[simp, grind =] theorem matrixEquiv_row (M : Hex.Matrix R n m) (i : Fin n) :
+    _root_.Matrix.row (matrixEquiv M) i = vectorEquiv (Hex.Matrix.row M i) := by
+  funext j
+  simp [Hex.Matrix.row]
+
+/-- Column `j` of the Mathlib matrix `matrixEquiv M` is the image under
+`vectorEquiv` of the executable column `Hex.Matrix.col M j`. -/
+@[simp, grind =] theorem matrixEquiv_col (M : Hex.Matrix R n m) (j : Fin m) :
+    _root_.Matrix.col (matrixEquiv M) j = vectorEquiv (Hex.Matrix.col M j) := by
+  funext i
+  simp [Hex.Matrix.col]
+
+/-- The executable matrix-vector product transports to Mathlib's `Matrix.mulVec`
+under `matrixEquiv`/`vectorEquiv`. -/
+theorem vectorEquiv_mulVec [Semiring R] (M : Hex.Matrix R n m) (v : Vector R m) :
+    vectorEquiv (M * v) = (matrixEquiv M).mulVec (vectorEquiv v) := by
+  funext i
+  simp only [vectorEquiv_apply]
+  change (Hex.Matrix.mulVec M v)[i.val] = (matrixEquiv M).mulVec (vectorEquiv v) i
+  unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
+  rw [Vector.getElem_ofFn i.isLt]
+  rw [foldl_finRange_eq_sum]
+  unfold _root_.Matrix.mulVec dotProduct
+  apply Finset.sum_congr rfl
+  intro k _
+  rfl
+
+end HexMatrixMathlib

--- a/HexRowReduceMathlib/RankSpanNullspace.lean
+++ b/HexRowReduceMathlib/RankSpanNullspace.lean
@@ -6,7 +6,7 @@ Authors: Kim Morrison
 
 module
 
-public import HexMatrixMathlib.Basic
+public import HexMatrixMathlib.Vector
 public import HexRowReduce.RREF
 public import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 public import Mathlib.LinearAlgebra.Dimension.Constructions
@@ -28,60 +28,6 @@ namespace HexMatrixMathlib
 universe u
 
 variable {R : Type u} {n m : Nat}
-
-/-- Convert an executable `Vector` into Mathlib's function representation. -/
-@[expose]
-def vectorEquiv : Vector R n ≃ (Fin n → R) where
-  toFun := fun v i => v[i]
-  invFun := Vector.ofFn
-  left_inv := by
-    intro v
-    ext i
-    simp
-  right_inv := by
-    intro f
-    funext i
-    simp
-
-/-- `vectorEquiv` reads off the executable vector entrywise, so a caller can
-rewrite `vectorEquiv v i` to the underlying `v[i]` without unfolding it. -/
-@[simp, grind =] theorem vectorEquiv_apply (v : Vector R n) (i : Fin n) :
-    vectorEquiv v i = v[i] :=
-  rfl
-
-/-- The inverse direction of `vectorEquiv` materialises a function as an
-executable vector entrywise: `(vectorEquiv.symm f)[i]` is just `f i`. -/
-@[simp, grind =] theorem vectorEquiv_symm_apply (f : Fin n → R) (i : Fin n) :
-    (vectorEquiv.symm f)[(i : Nat)] = f i := by
-  simp [vectorEquiv]
-
-/-- Row `i` of the Mathlib matrix `matrixEquiv M` is the image under
-`vectorEquiv` of the executable row `Hex.Matrix.row M i`, letting span/rank
-lemmas pass between the two row representations. -/
-@[simp, grind =] theorem matrixEquiv_row (M : Hex.Matrix R n m) (i : Fin n) :
-    _root_.Matrix.row (matrixEquiv M) i = vectorEquiv (Hex.Matrix.row M i) := by
-  funext j
-  simp [Hex.Matrix.row]
-
-private theorem foldl_finRange_eq_sum [AddCommMonoid R] {n : Nat} (f : Fin n → R) :
-    (List.finRange n).foldl (fun acc i => acc + f i) 0 = ∑ i, f i := by
-  rw [← List.foldl_map, ← List.sum_eq_foldl, ← List.sum_toFinset f (List.nodup_finRange n),
-    List.toFinset_finRange]
-
-/-- Bridge invariant: the executable matrix-vector product transports to
-Mathlib's `Matrix.mulVec` under `matrixEquiv`/`vectorEquiv`. This is the key
-step letting nullspace membership be phrased against `mulVecLin`. -/
-private theorem vectorEquiv_mulVec [Field R] (M : Hex.Matrix R n m) (v : Vector R m) :
-    vectorEquiv (M * v) = (matrixEquiv M).mulVec (vectorEquiv v) := by
-  funext i
-  simp only [vectorEquiv_apply]
-  change (Hex.Matrix.mulVec M v)[i.val] = (matrixEquiv M).mulVec (vectorEquiv v) i
-  unfold Hex.Matrix.mulVec Hex.Matrix.row Hex.Vector.dotProduct
-  rw [Vector.getElem_ofFn i.isLt, foldl_finRange_eq_sum]
-  unfold _root_.Matrix.mulVec dotProduct
-  apply Finset.sum_congr rfl
-  intro k _
-  rfl
 
 /-- The executable row combination `Hex.Matrix.rowCombination M c` (the linear
 combination of the rows of `M` with coefficients `c`) transports under

--- a/progress/20260629T070000Z_hexmatrixmathlib-algebra.md
+++ b/progress/20260629T070000Z_hexmatrixmathlib-algebra.md
@@ -1,0 +1,54 @@
+# Mathlib algebra instances + equiv upgrades for HexMatrixMathlib
+
+## Accomplished
+
+Built out `HexMatrixMathlib`, which previously held only `matrixEquiv` and the
+three row-operation lemmas:
+
+- **`HexMatrixMathlib/Vector.lean`** (new): relocated `vectorEquiv`,
+  `vectorEquiv_apply/_symm_apply`, `matrixEquiv_row`, and the
+  `foldl_finRange_eq_sum` fold-to-`Finset.sum` bridge down from
+  `HexRowReduceMathlib/RankSpanNullspace.lean` (they lived in the
+  `HexMatrixMathlib` namespace there, a latent name clash). Added `dotProduct_eq`,
+  `matrixEquiv_col`, and a generalized public `vectorEquiv_mulVec`.
+- **`HexMatrix/Basic.lean`**: added the homogeneous `Mul (Matrix R n n)` instance
+  (defeq to `Hex.Matrix.mul`), required by Mathlib's `Semiring`/`Ring`.
+- **`HexMatrixMathlib/Algebra.lean`** (new): the Mathlib algebraic tower on
+  `Hex.Matrix`, transported along `matrixEquiv` via `Function.Injective.*`
+  (`AddCommMonoid`, `AddCommGroup`, `Module`, `Semiring`, `Ring`, `Algebra`),
+  with per-operation `@[simp, grind =]` transport lemmas and the four bundled
+  equivalences `matrixAddEquiv` (`≃+`), `matrixLinearEquiv` (`≃ₗ`),
+  `matrixRingEquiv` (`≃+*`), `matrixAlgEquiv` (`≃ₐ`). Includes regression-guard
+  `example`s pinning the canonical zero/one to the executable `ofFn` versions.
+- **`HexMatrixMathlib/Lemmas.lean`** (new): `matrixEquiv_transpose/_setRow/_setCol`.
+- **`HexMatrixMathlib/Gram.lean`** (new): `matrixEquiv_gramMatrix = M * Mᵀ`.
+- **`HexMatrixMathlib/Submatrix.lean`** (new): `principalSubmatrix`/`takeRows`
+  correspond to `Matrix.submatrix` reindexed by `Fin.castLE`.
+- Refactored `RankSpanNullspace.lean` to drop the relocated declarations and
+  import `HexMatrixMathlib.Vector`; updated the umbrella and SPEC.
+
+Whole-monorepo `lake build` is green; no `sorry`/`axiom`. Codex second opinion
+found no soundness/correctness issues (validated the injective transport and the
+`Zero`-diamond resolution); its suggestions (regression guards, documenting the
+proof-facing cast/pow plumbing) are applied.
+
+## Notes / context
+
+- `Hex.Matrix R n m = Vector (Vector R m) n` carries TWO non-defeq `Zero`
+  instances under Mathlib `[Semiring R]` (core `Vector.replicate` zero vs Hex's
+  `ofFn` `Matrix.zero`). Resolution deterministically selects Hex's `ofFn` zero;
+  the whole tower and `matrixEquiv_zero` share it. Guard `example`s lock this in.
+- `HexMatrix/MatrixAlgebra.lean:~422` has a **flaky `grind`** (fails then passes
+  on retry) independent of this work — worth a separate hardening pass.
+- This work overlaps live fleet branches (`refactor/vector-namespace`,
+  `refactor/dotproduct-smul-consolidate`, executable `Matrix.add/neg/sub`); built
+  off `main`, so expect to reconcile when those land.
+
+## Next step
+
+Land the PR; reconcile with the fleet's executable-algebra branches if they merge
+first.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR equips `Hex.Matrix` with the Mathlib algebraic tower whose operations are the executable ones — `AddCommMonoid`, `AddCommGroup`, `Module`, `Semiring`, `Ring`, and `Algebra` — transported along `matrixEquiv` via `Function.Injective.*`, and upgrades `matrixEquiv` to the bundled `matrixAddEquiv` (`≃+`), `matrixLinearEquiv` (`≃ₗ`), `matrixRingEquiv` (`≃+*`), and `matrixAlgEquiv` (`≃ₐ`). It adds the homogeneous `Mul (Matrix R n n)` instance these structures build on to the Mathlib-free `HexMatrix`, carries the basic container API across the equivalence (vector equivalence and matrix-vector product in `Vector`, transpose and row/column updates in `Lemmas`, the Gram matrix as `M * Mᵀ` in `Gram`, the leading-submatrix family as `Matrix.submatrix` reindexings in `Submatrix`), and relocates `vectorEquiv`, `matrixEquiv_row`, and the fold-to-`Finset.sum` bridge down from `HexRowReduceMathlib` into `HexMatrixMathlib` where they belong.

The instances are built so the structure operations are the executable ones: `+`/`-`/`•` from the `Vector` representation, the `ofFn` zero/identity, and the executable matrix product; only the proof-facing `NatCast`/`IntCast`/`Pow` fields route through the equivalence. Regression-guard `example`s pin the canonical zero/one to the executable `ofFn` versions, since `Hex.Matrix` carries two non-defeq `Zero` instances under a Mathlib scalar.

The whole monorepo plus the bench and conformance sub-projects build green; no `sorry` or `axiom`. A Codex second opinion found no soundness or correctness issues.

🤖 Prepared with Claude Code