### PR TITLE
refactor: make matrix identity/zero/unit args explicit, drop matrix One instance

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -317,14 +317,14 @@ private theorem det_columnTupleMatrix_eq
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (cols : Fin n → Fin n) :
     det (columnTupleMatrix M cols) =
-      det M * det (columnTupleMatrix (1 : Matrix R n n) cols) := by
+      det M * det (columnTupleMatrix (Matrix.identity (R := R) n) cols) := by
   by_cases hinj : Function.Injective cols
   · rw [det_columnTupleMatrix_of_injective M cols hinj,
-        det_columnTupleMatrix_of_injective (1 : Matrix R n n) cols hinj]
-    rw [det_one]
+        det_columnTupleMatrix_of_injective (Matrix.identity (R := R) n) cols hinj]
+    rw [det_identity]
     grind
   · rw [det_columnTupleMatrix_eq_zero_of_not_injective M cols hinj,
-        det_columnTupleMatrix_eq_zero_of_not_injective (1 : Matrix R n n) cols hinj]
+        det_columnTupleMatrix_eq_zero_of_not_injective (Matrix.identity (R := R) n) cols hinj]
     grind
 
 private theorem mul_eq_columnSumMatrix_transpose
@@ -356,9 +356,9 @@ private theorem mul_eq_columnSumMatrix_transpose
 private theorem eq_columnSumMatrix_one_transpose
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (N : Matrix R n n) :
-    N = columnSumMatrix (1 : Matrix R n n) N.transpose := by
-  rw [← mul_eq_columnSumMatrix_transpose (1 : Matrix R n n) N]
-  exact (one_mul N).symm
+    N = columnSumMatrix (Matrix.identity (R := R) n) N.transpose := by
+  rw [← mul_eq_columnSumMatrix_transpose (Matrix.identity (R := R) n) N]
+  exact (identity_mul N).symm
 
 /-- Determinant of a product of square matrices.
 
@@ -377,7 +377,7 @@ theorem det_mul
         (columnTupleVectors n n).foldl
           (fun acc cols => acc + det M *
             (columnTupleCoeff N.transpose cols *
-              det (columnTupleMatrix (1 : Matrix R n n)
+              det (columnTupleMatrix (Matrix.identity (R := R) n)
                 (columnTupleVectorFn cols)))) 0 := by
     apply foldl_det_sum_congr
     intro cols _
@@ -388,10 +388,10 @@ theorem det_mul
         (columnTupleVectors n n)
         (det M)
         (fun cols => columnTupleCoeff N.transpose cols *
-            det (columnTupleMatrix (1 : Matrix R n n)
+            det (columnTupleMatrix (Matrix.identity (R := R) n)
               (columnTupleVectorFn cols)))]
   rw [← det_columnSumMatrix_eq_sum_columnTuples
-        (1 : Matrix R n n) N.transpose]
+        (Matrix.identity (R := R) n) N.transpose]
   rw [← eq_columnSumMatrix_one_transpose N]
 
 /-- Foldl over a list whose body is identically zero leaves the seed

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -498,12 +498,12 @@ private theorem foldl_det_product_zero_of_mem {R : Type u}
           | inr htail => exact htail
         exact ih (z * f x) htail
 
-/-- Entry `(i, j)` of the identity matrix `(1 : Matrix R n n)` is `1` when `i = j`
+/-- Entry `(i, j)` of the identity matrix `(Matrix.identity (R := R) n)` is `1` when `i = j`
 and `0` otherwise. -/
 private theorem identity_get {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}
     (i j : Fin n) :
-    (1 : Matrix R n n)[i][j] = if i = j then 1 else 0 := by
-  change Matrix.identity[i][j] = if i = j then 1 else 0
+    (Matrix.identity (R := R) n)[i][j] = if i = j then 1 else 0 := by
+  change (Matrix.identity n)[i][j] = if i = j then 1 else 0
   simp [Matrix.identity, Matrix.ofFn]
 
 /-- `detProduct` of the identity matrix along `perm` is `0` whenever `perm` moves
@@ -511,15 +511,15 @@ some index, that is `perm[i] ≠ i`. -/
 private theorem detProduct_identity_zero {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (perm : Vector (Fin n) n)
     (i : Fin n) (h : perm[i] ≠ i) :
-    detProduct (1 : Matrix R n n) perm = 0 := by
+    detProduct (Matrix.identity (R := R) n) perm = 0 := by
   unfold detProduct
   have hsymm : i ≠ perm[i] := by
     intro hi
     exact h hi.symm
   exact foldl_det_product_zero_of_mem
-    (List.finRange n) i (fun r => (1 : Matrix R n n)[r][perm[r]]) 1
+    (List.finRange n) i (fun r => (Matrix.identity (R := R) n)[r][perm[r]]) 1
     (List.mem_finRange i) (by
-      change (1 : Matrix R n n)[i][perm[i]] = 0
+      change (Matrix.identity (R := R) n)[i][perm[i]] = 0
       rw [identity_get]
       rw [if_neg hsymm])
 
@@ -530,7 +530,7 @@ moved. -/
 private theorem detProduct_identity_insertAt_not_last_zero {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n)
     (i : Fin (n + 1)) (h : i ≠ Fin.last n) :
-    detProduct (1 : Matrix R (n + 1) (n + 1))
+    detProduct (Matrix.identity (R := R) (n + 1))
       (insertAt (Fin.last n) (v.map Fin.castSucc) i) = 0 := by
   apply detProduct_identity_zero
   exact by
@@ -542,18 +542,18 @@ private theorem detProduct_identity_insertAt_not_last_zero {R : Type u}
 `n`-identity along `v`. -/
 private theorem detProduct_identity_insertAt_last {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) :
-    detProduct (1 : Matrix R (n + 1) (n + 1))
+    detProduct (Matrix.identity (R := R) (n + 1))
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
-    detProduct (1 : Matrix R n n) v := by
+    detProduct (Matrix.identity (R := R) n) v := by
   unfold detProduct
   rw [← Fin.foldl_eq_finRange_foldl, ← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hfold :
       Fin.foldl n
           (fun acc i =>
             acc *
-              (1 : Matrix R (n + 1) (n + 1))[i.castSucc][
+              (Matrix.identity (R := R) (n + 1))[i.castSucc][
                 (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n))[i.castSucc]]) 1 =
-      Fin.foldl n (fun acc i => acc * (1 : Matrix R n n)[i][v[i]]) 1 := by
+      Fin.foldl n (fun acc i => acc * (Matrix.identity (R := R) n)[i][v[i]]) 1 := by
     congr
     funext acc i
     rw [identity_get, identity_get]
@@ -564,7 +564,7 @@ private theorem detProduct_identity_insertAt_last {R : Type u}
     rw [hget]
     simp [Fin.ext_iff]
   have hlast :
-      (1 : Matrix R (n + 1) (n + 1))[Fin.last n][
+      (Matrix.identity (R := R) (n + 1))[Fin.last n][
         (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n))[Fin.last n]] = 1 := by
     rw [identity_get]
     have hself :

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -1065,7 +1065,7 @@ theorem mDet_smul_v {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
 /-- Numeric entry form for the standard basis vector. -/
 private theorem getElem_unit_num {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (q : Fin (n + 2)) (i : Fin (n + 2)) :
-    (Vector.unit (R := R) q)[i] = if i = q then (1 : R) else (0 : R) := by
+    (Vector.unit R q)[i] = if i = q then (1 : R) else (0 : R) := by
   rw [Vector.getElem_unit]
   by_cases h : i = q
   · rw [if_pos h.symm, if_pos h]
@@ -1149,18 +1149,18 @@ private theorem foldl_unit_weighted_single
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (q : Fin (n + 2)) (f : Fin (n + 2) → R) :
     (List.finRange (n + 2)).foldl
-        (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
+        (fun acc p => acc + (Vector.unit R q)[p] * f p) 0 =
       f q := by
   have hfold :=
     foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R) q
-      (fun p => (Vector.unit (R := R) q)[p] * f p)
+      (fun p => (Vector.unit R q)[p] * f p)
       (List.mem_finRange q) (List.nodup_finRange (n + 2))
   have hcongr :
       (List.finRange (n + 2)).foldl
-          (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
+          (fun acc p => acc + (Vector.unit R q)[p] * f p) 0 =
         (List.finRange (n + 2)).foldl
           (fun acc p =>
-            acc + if p = q then (Vector.unit (R := R) q)[p] * f p else 0) 0 := by
+            acc + if p = q then (Vector.unit R q)[p] * f p else 0) 0 := by
     apply foldl_acc_congr
     intro acc p _hmem
     by_cases hp : p = q
@@ -1170,11 +1170,11 @@ private theorem foldl_unit_weighted_single
       grind
   calc
     (List.finRange (n + 2)).foldl
-        (fun acc p => acc + (Vector.unit (R := R) q)[p] * f p) 0 =
+        (fun acc p => acc + (Vector.unit R q)[p] * f p) 0 =
       (List.finRange (n + 2)).foldl
         (fun acc p =>
-          acc + if p = q then (Vector.unit (R := R) q)[p] * f p else 0) 0 := hcongr
-    _ = 0 + (Vector.unit (R := R) q)[q] * f q := hfold
+          acc + if p = q then (Vector.unit R q)[p] * f p else 0) 0 := hcongr
+    _ = 0 + (Vector.unit R q)[q] * f q := hfold
     _ = f q := by
       rw [getElem_unit_num, if_pos rfl]
       grind
@@ -1185,27 +1185,27 @@ theorem mDet_eq_sum_unit
     (B : Matrix R (n + 2) n) (v : Vector R (n + 2)) (p : Fin (n + 2)) :
     mDet B v p =
       (List.finRange (n + 2)).foldl
-        (fun acc q => acc + v[q] * mDet B (Vector.unit (R := R) q) p) 0 := by
+        (fun acc q => acc + v[q] * mDet B (Vector.unit R q) p) 0 := by
   unfold mDet
   rw [mMatrix_eq_setCol_last B v v p]
   have hcol :
       (fun i : Fin (n + 1) => v[skipIndex p i]) =
         fun i : Fin (n + 1) =>
           (List.finRange (n + 2)).foldl
-            (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 := by
+            (fun acc q => acc + v[q] * (Vector.unit R q)[skipIndex p i]) 0 := by
     funext i
     have hfold :=
       foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R)
         (skipIndex p i)
-        (fun q => v[q] * (Vector.unit (R := R) q)[skipIndex p i])
+        (fun q => v[q] * (Vector.unit R q)[skipIndex p i])
         (List.mem_finRange (skipIndex p i)) (List.nodup_finRange (n + 2))
     have hcongr :
         (List.finRange (n + 2)).foldl
-            (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 =
+            (fun acc q => acc + v[q] * (Vector.unit R q)[skipIndex p i]) 0 =
           (List.finRange (n + 2)).foldl
             (fun acc q =>
               acc + if q = skipIndex p i then
-                v[q] * (Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := by
+                v[q] * (Vector.unit R q)[skipIndex p i] else 0) 0 := by
       apply foldl_acc_congr
       intro acc q _hmem
       by_cases hq : q = skipIndex p i
@@ -1216,19 +1216,19 @@ theorem mDet_eq_sum_unit
     symm
     calc
       (List.finRange (n + 2)).foldl
-          (fun acc q => acc + v[q] * (Vector.unit (R := R) q)[skipIndex p i]) 0 =
+          (fun acc q => acc + v[q] * (Vector.unit R q)[skipIndex p i]) 0 =
         (List.finRange (n + 2)).foldl
           (fun acc q =>
             acc + if q = skipIndex p i then
-              v[q] * (Vector.unit (R := R) q)[skipIndex p i] else 0) 0 := hcongr
-      _ = 0 + v[skipIndex p i] * (Vector.unit (R := R) (skipIndex p i))[skipIndex p i] := hfold
+              v[q] * (Vector.unit R q)[skipIndex p i] else 0) 0 := hcongr
+      _ = 0 + v[skipIndex p i] * (Vector.unit R (skipIndex p i))[skipIndex p i] := hfold
       _ = v[skipIndex p i] := by
         rw [getElem_unit_num, if_pos rfl]
         grind
   rw [hcol, det_setCol_sum_finRange]
   apply foldl_acc_congr
   intro acc q _hmem
-  rw [← mMatrix_eq_setCol_last B (Vector.unit (R := R) q) v p]
+  rw [← mMatrix_eq_setCol_last B (Vector.unit R q) v p]
 
 /-- Laplace expansion specialized to a column equal to a standard basis
 vector: if column `c` of `M` holds `1` at row `q` and `0` elsewhere, then
@@ -1401,16 +1401,16 @@ recovers a signed `n × n` minor of `B`. -/
 theorem mDet_unit_eq_signed_nDet_of_gt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hqp : q.val < p.val) :
-    mDet B (Vector.unit (R := R) q) p =
+    mDet B (Vector.unit R q) p =
       cofactorSign (R := R)
         (⟨q.val, by have := p.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
       nDet B q p hqp := by
   unfold mDet
   let r_q : Fin (n + 1) := ⟨q.val, by have := p.isLt; omega⟩
-  show (mMatrix B (Vector.unit (R := R) q) p).det =
+  show (mMatrix B (Vector.unit R q) p).det =
       cofactorSign (R := R) r_q (Fin.last n) * nDet B q p hqp
   have hcol : ∀ r : Fin (n + 1),
-      (mMatrix B (Vector.unit (R := R) q) p)[r][Fin.last n] =
+      (mMatrix B (Vector.unit R q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
     rw [mMatrix_entry_last, getElem_unit_num]
@@ -1429,13 +1429,13 @@ theorem mDet_unit_eq_signed_nDet_of_gt
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
       exact if_neg hne
-  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit (R := R) q) p) r_q
+  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit R q) p) r_q
         (Fin.last n) hcol]
   congr 1
   unfold nDet
   exact congrArg det
     (deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt B
-      (Vector.unit (R := R) q) p q hqp)
+      (Vector.unit R q) p q hqp)
 
 /-- Basis-vector evaluation of `mDet` when `q > p`: the basis vector
 `e_q` becomes the standard basis vector `e_{q.val - 1}` in the last
@@ -1444,17 +1444,17 @@ recovers a signed `n × n` minor of `B`. -/
 theorem mDet_unit_eq_signed_nDet_of_lt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hpq : p.val < q.val) :
-    mDet B (Vector.unit (R := R) q) p =
+    mDet B (Vector.unit R q) p =
       cofactorSign (R := R)
         (⟨q.val - 1, by have := q.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
       nDet B p q hpq := by
   unfold mDet
   -- Last column of `mMatrix B (Vector.unit q) p` is e_{r_q} where r_q = q.val - 1.
   let r_q : Fin (n + 1) := ⟨q.val - 1, by have := q.isLt; omega⟩
-  show (mMatrix B (Vector.unit (R := R) q) p).det =
+  show (mMatrix B (Vector.unit R q) p).det =
       cofactorSign (R := R) r_q (Fin.last n) * nDet B p q hpq
   have hcol : ∀ r : Fin (n + 1),
-      (mMatrix B (Vector.unit (R := R) q) p)[r][Fin.last n] =
+      (mMatrix B (Vector.unit R q) p)[r][Fin.last n] =
         if r = r_q then (1 : R) else (0 : R) := by
     intro r
     rw [mMatrix_entry_last, getElem_unit_num]
@@ -1475,30 +1475,30 @@ theorem mDet_unit_eq_signed_nDet_of_lt
         have : skipIndex p r = skipIndex p r_q := heq.trans hq_eq.symm
         exact hreq (skipIndex_injective p this)
       exact if_neg hne
-  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit (R := R) q) p) r_q
+  rw [det_eq_signed_minor_of_col_basis (mMatrix B (Vector.unit R q) p) r_q
         (Fin.last n) hcol]
   congr 1
   unfold nDet
   exact congrArg det
     (deleteRowCol_mMatrix_at_q_minus_one_eq_nMatrix_of_lt B
-      (Vector.unit (R := R) q) p q hpq)
+      (Vector.unit R q) p q hpq)
 
 /-- `mDet B (Vector.unit p) p = 0`: the basis vector `e_p` becomes the zero
 column inside `mMatrix B (Vector.unit p) p` after row `p` is deleted, so
 the determinant vanishes. -/
 theorem mDet_unit_eq_zero_of_eq {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (B : Matrix R (n + 2) n) (p : Fin (n + 2)) :
-    mDet B (Vector.unit (R := R) p) p = 0 := by
+    mDet B (Vector.unit R p) p = 0 := by
   unfold mDet
   -- The last column of `mMatrix B (Vector.unit p) p` is identically zero.
   have hcol : (fun r : Fin (n + 1) =>
-      (Vector.unit (R := R) p)[skipIndex p r]) = (fun _ => (0 : R)) := by
+      (Vector.unit R p)[skipIndex p r]) = (fun _ => (0 : R)) := by
     funext r
     rw [getElem_unit_num]
     exact if_neg (skipIndex_ne p r)
   -- Express mMatrix as setCol with that zero function on the last column.
-  rw [mMatrix_eq_setCol_last B (Vector.unit (R := R) p)
-        (Vector.unit (R := R) p) p]
+  rw [mMatrix_eq_setCol_last B (Vector.unit R p)
+        (Vector.unit R p) p]
   rw [hcol]
   exact det_setCol_zero _ _
 
@@ -1507,7 +1507,7 @@ surviving ordered pair is the deleted-row pair `(a, b)`. -/
 theorem twoColDet_unit_unit_of_lt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a b : Fin (n + 2)) (hab : a.val < b.val) :
-    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) b) =
+    twoColDet B (Vector.unit R a) (Vector.unit R b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) *
         (cofactorSign (R := R)
           (⟨a.val, by have := b.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
@@ -1515,7 +1515,7 @@ theorem twoColDet_unit_unit_of_lt
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit R a) p)]
   rw [mDet_unit_eq_signed_nDet_of_gt B b a hab]
 
 /-- Reverse ordered basis-pair evaluation for `twoColDet`: if `b < a`,
@@ -1524,7 +1524,7 @@ coefficient order. -/
 theorem twoColDet_unit_unit_of_gt
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a b : Fin (n + 2)) (hba : b.val < a.val) :
-    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) b) =
+    twoColDet B (Vector.unit R a) (Vector.unit R b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) *
         (cofactorSign (R := R)
           (⟨a.val - 1, by have := a.isLt; omega⟩ : Fin (n + 1)) (Fin.last n) *
@@ -1532,7 +1532,7 @@ theorem twoColDet_unit_unit_of_gt
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit R a) p)]
   rw [mDet_unit_eq_signed_nDet_of_lt B b a hba]
 
 /-- A repeated basis vector in the two appended columns makes
@@ -1540,11 +1540,11 @@ theorem twoColDet_unit_unit_of_gt
 theorem twoColDet_unit_unit_of_eq
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (a : Fin (n + 2)) :
-    twoColDet B (Vector.unit (R := R) a) (Vector.unit (R := R) a) = 0 := by
+    twoColDet B (Vector.unit R a) (Vector.unit R a) = 0 := by
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) a
       (fun p => cofactorSign (R := R) p (Fin.last (n + 1)) *
-        mDet B (Vector.unit (R := R) a) p)]
+        mDet B (Vector.unit R a) p)]
   rw [mDet_unit_eq_zero_of_eq B a]
   grind
 
@@ -1554,7 +1554,7 @@ vector. This is the one-column Laplace expansion with the remaining
 theorem twoColDet_unit_right
     {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (B : Matrix R (n + 2) n) (u : Vector R (n + 2)) (b : Fin (n + 2)) :
-    twoColDet B u (Vector.unit (R := R) b) =
+    twoColDet B u (Vector.unit R b) =
       cofactorSign (R := R) b (Fin.last (n + 1)) * mDet B u b := by
   rw [twoColDet_eq_sum_mDet]
   rw [foldl_unit_weighted_single (R := R) b
@@ -1574,8 +1574,8 @@ theorem twoColDet_eq_sum_unit_pairs
           acc + v[b] *
             (List.finRange (n + 2)).foldl
               (fun acc a =>
-                acc + u[a] * twoColDet B (Vector.unit (R := R) a)
-                  (Vector.unit (R := R) b)) 0) 0 := by
+                acc + u[a] * twoColDet B (Vector.unit R a)
+                  (Vector.unit R b)) 0) 0 := by
   rw [twoColDet_eq_sum_mDet]
   apply foldl_acc_congr
   intro acc b _hmem
@@ -1584,20 +1584,20 @@ theorem twoColDet_eq_sum_unit_pairs
   calc
     cofactorSign (R := R) b (Fin.last (n + 1)) *
         (List.finRange (n + 2)).foldl
-          (fun acc a => acc + u[a] * mDet B (Vector.unit (R := R) a) b) 0 =
+          (fun acc a => acc + u[a] * mDet B (Vector.unit R a) b) 0 =
       (List.finRange (n + 2)).foldl
         (fun acc a =>
           acc + cofactorSign (R := R) b (Fin.last (n + 1)) *
-            (u[a] * mDet B (Vector.unit (R := R) a) b)) 0 := by
+            (u[a] * mDet B (Vector.unit R a) b)) 0 := by
         rw [foldl_det_sum_mul_left_zero]
     _ =
       (List.finRange (n + 2)).foldl
         (fun acc a =>
-          acc + u[a] * twoColDet B (Vector.unit (R := R) a)
-            (Vector.unit (R := R) b)) 0 := by
+          acc + u[a] * twoColDet B (Vector.unit R a)
+            (Vector.unit R b)) 0 := by
         apply foldl_det_sum_congr
         intro a _ha
-        rw [twoColDet_unit_right B (Vector.unit (R := R) a) b]
+        rw [twoColDet_unit_right B (Vector.unit R a) b]
         grind
 
 private theorem cofactorSign_consecutive_last_neg
@@ -1619,10 +1619,10 @@ private theorem det_plucker_three_term_unit_of_eq_p1
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Vector.unit (R := R) p1) p1 * nDet B p2 p3 h23 -
-      mDet B (Vector.unit (R := R) p1) p2 *
+    mDet B (Vector.unit R p1) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit R p1) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Vector.unit (R := R) p1) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit R p1) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_zero_of_eq B p1, mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
     mDet_unit_eq_signed_nDet_of_gt B p3 p1 (Nat.lt_trans h12 h23)]
   grind
@@ -1632,10 +1632,10 @@ private theorem det_plucker_three_term_unit_of_eq_p2
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Vector.unit (R := R) p2) p1 * nDet B p2 p3 h23 -
-      mDet B (Vector.unit (R := R) p2) p2 *
+    mDet B (Vector.unit R p2) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit R p2) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Vector.unit (R := R) p2) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit R p2) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12, mDet_unit_eq_zero_of_eq B p2,
     mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
   have hp2pos : 0 < p2.val := by omega
@@ -1655,10 +1655,10 @@ private theorem det_plucker_three_term_unit_of_eq_p3
     (B : Matrix R (n + 2) n)
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Vector.unit (R := R) p3) p1 * nDet B p2 p3 h23 -
-      mDet B (Vector.unit (R := R) p3) p2 *
+    mDet B (Vector.unit R p3) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit R p3) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Vector.unit (R := R) p3) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit R p3) p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
     mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, mDet_unit_eq_zero_of_eq B p3]
   grind
@@ -1669,30 +1669,30 @@ private theorem det_plucker_three_term_of_unit
     (p1 p2 p3 : Fin (n + 2))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hbasis : ∀ q : Fin (n + 2),
-      mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-        mDet B (Vector.unit (R := R) q) p2 *
+      mDet B (Vector.unit R q) p1 * nDet B p2 p3 h23 -
+        mDet B (Vector.unit R q) p2 *
           nDet B p1 p3 (Nat.lt_trans h12 h23) +
-        mDet B (Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0) :
+        mDet B (Vector.unit R q) p3 * nDet B p1 p2 h12 = 0) :
     mDet B v p1 * nDet B p2 p3 h23 -
       mDet B v p2 * nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B v p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_eq_sum_unit B v p1, mDet_eq_sum_unit B v p2, mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p1)
+      (fun q => v[q] * mDet B (Vector.unit R q) p1)
       (nDet B p2 p3 h23)]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p2)
+      (fun q => v[q] * mDet B (Vector.unit R q) p2)
       (nDet B p1 p3 (Nat.lt_trans h12 h23))]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p3)
+      (fun q => v[q] * mDet B (Vector.unit R q) p3)
       (nDet B p1 p2 h12)]
   apply foldl_det_sum_sub_add_zero
       (List.finRange (n + 2))
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p1 *
+      (fun q => v[q] * mDet B (Vector.unit R q) p1 *
         nDet B p2 p3 h23)
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p2 *
+      (fun q => v[q] * mDet B (Vector.unit R q) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23))
-      (fun q => v[q] * mDet B (Vector.unit (R := R) q) p3 *
+      (fun q => v[q] * mDet B (Vector.unit R q) p3 *
         nDet B p1 p2 h12)
   · grind
   · intro q _hq
@@ -1829,10 +1829,10 @@ private theorem det_plucker_three_term_unit_of_lt_p1_of_nDet
     (B : Matrix R (n + 2) n)
     (q p1 p2 p3 : Fin (n + 2))
     (hq1 : q.val < p1.val) (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-      mDet B (Vector.unit (R := R) q) p2 *
+    mDet B (Vector.unit R q) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit R q) p2 *
         nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      mDet B (Vector.unit (R := R) q) p3 * nDet B p1 p2 h12 = 0 := by
+      mDet B (Vector.unit R q) p3 * nDet B p1 p2 h12 = 0 := by
   have hraw := det_plucker_three_term_nDet_of_lt_p1 B q p1 p2 p3 hq1 h12 h23
   rw [mDet_unit_eq_signed_nDet_of_gt B p1 q hq1,
     mDet_unit_eq_signed_nDet_of_gt B p2 q (Nat.lt_trans hq1 h12)]
@@ -1849,10 +1849,10 @@ private theorem det_plucker_three_term_unit_of_between_p1_p2_of_nDet
     (B : Matrix R (n + 2) n)
     (p1 q p2 p3 : Fin (n + 2))
     (h1q : p1.val < q.val) (hq2 : q.val < p2.val) (h23 : p2.val < p3.val) :
-    mDet B (Vector.unit (R := R) q) p1 * nDet B p2 p3 h23 -
-      mDet B (Vector.unit (R := R) q) p2 *
+    mDet B (Vector.unit R q) p1 * nDet B p2 p3 h23 -
+      mDet B (Vector.unit R q) p2 *
         nDet B p1 p3 (Nat.lt_trans (Nat.lt_trans h1q hq2) h23) +
-      mDet B (Vector.unit (R := R) q) p3 *
+      mDet B (Vector.unit R q) p3 *
         nDet B p1 p2 (Nat.lt_trans h1q hq2) = 0 := by
   have hraw :=
     det_plucker_three_term_nDet_of_between_p1_p2 B p1 q p2 p3 h1q hq2 h23

--- a/HexDeterminant/RowOps.lean
+++ b/HexDeterminant/RowOps.lean
@@ -16,7 +16,7 @@ Determinant of elementary row and column operations.
 
 Building on the permutation-vector structure in `HexDeterminant.Permutation`,
 this module reindexes the Leibniz sum to read off the determinant's reaction to
-the elementary operations: `det_one`, `det_rowSwap`, `det_rowScale`,
+the elementary operations: `det_identity`, `det_rowSwap`, `det_rowScale`,
 `det_rowAdd`, `det_transpose`, `cofactor_transpose`, and the column analogues
 `det_colPermute_vector`, `det_colSwap`, `det_colAdd`.
 -/
@@ -28,9 +28,9 @@ variable {α : Type u}
 
 private theorem detTerm_identity_insertAt_last {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) :
-    detTerm (1 : Matrix R (n + 1) (n + 1))
+    detTerm (Matrix.identity (R := R) (n + 1))
       (insertAt (Fin.last n) (v.map Fin.castSucc) (Fin.last n)) =
-    detTerm (1 : Matrix R n n) v := by
+    detTerm (Matrix.identity (R := R) n) v := by
   unfold detTerm
   rw [detSign_insertAt_last, detProduct_identity_insertAt_last]
 
@@ -38,20 +38,20 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat} (v : Vector (Fin n) n) (z : R) :
     (List.finRange (n + 1)).foldl
         (fun acc i =>
-          acc + detTerm (1 : Matrix R (n + 1) (n + 1))
+          acc + detTerm (Matrix.identity (R := R) (n + 1))
             (insertAt (Fin.last n) (v.map Fin.castSucc) i)) z =
-      z + detTerm (1 : Matrix R n n) v := by
+      z + detTerm (Matrix.identity (R := R) n) v := by
   rw [← Fin.foldl_eq_finRange_foldl, Fin.foldl_succ_last]
   have hprefix :
       Fin.foldl n
           (fun acc i =>
-            acc + detTerm (1 : Matrix R (n + 1) (n + 1))
+            acc + detTerm (Matrix.identity (R := R) (n + 1))
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z = z := by
     rw [Fin.foldl_eq_finRange_foldl]
     calc
       (List.finRange n).foldl
           (fun acc i =>
-            acc + detTerm (1 : Matrix R (n + 1) (n + 1))
+            acc + detTerm (Matrix.identity (R := R) (n + 1))
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z =
         (List.finRange n).foldl (fun acc (_i : Fin n) => acc + (0 : R)) z := by
           apply foldl_det_sum_congr
@@ -366,7 +366,7 @@ matrix: all non-identity terms vanish and the identity vector appears once. -/
 private theorem permutationVectors_identity_sum {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} :
     (permutationVectors n).foldl
-        (fun acc perm => acc + detTerm (1 : Matrix R n n) perm) 0 = 1 := by
+        (fun acc perm => acc + detTerm (Matrix.identity (R := R) n) perm) 0 = 1 := by
   induction n with
   | zero =>
       simp [permutationVectors, detTerm, detSign, detProduct, inversionCount]
@@ -873,7 +873,7 @@ private theorem permutationVectors_rowAdd_sum {R : Type u} [Lean.Grind.CommRing 
 permutation as its nonzero contribution. -/
 private theorem det_identity_leibniz {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
     (permutationVectors n).foldl
-        (fun acc perm => acc + detTerm (1 : Matrix R n n) perm) 0 = 1 := by
+        (fun acc perm => acc + detTerm (Matrix.identity (R := R) n) perm) 0 = 1 := by
   exact permutationVectors_identity_sum
 
 /-- Swapping two rows pairs each Leibniz summand with the corresponding
@@ -913,8 +913,8 @@ private theorem det_rowAdd_leibniz {R : Type u} [Lean.Grind.CommRing R] {n : Nat
 
 /-- The determinant of the identity matrix is one. -/
 @[grind =]
-theorem det_one {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
-    det (1 : Matrix R n n) = 1 := by
+theorem det_identity {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
+    det (Matrix.identity (R := R) n) = 1 := by
   simpa [det] using (det_identity_leibniz (R := R) (n := n))
 
 /-- Swapping two distinct rows negates the determinant. -/

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -541,11 +541,11 @@ private theorem det_plucker_three_term_basisVec_of_lt_p1
     {R : Type u} [CommRing R] {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (hq1 : q.val < p1.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have hq2 : q.val < p2.val := Nat.lt_trans hq1 h12
   have hq3 : q.val < p3.val := Nat.lt_trans hq2 h23
@@ -564,11 +564,11 @@ private theorem det_plucker_three_term_basisVec_of_between_p1_p2
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (h1q : p1.val < q.val) (hq2 : q.val < p2.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have hq3 : q.val < p3.val := Nat.lt_trans hq2 h23
   have hraw :=
@@ -595,11 +595,11 @@ private theorem det_plucker_three_term_basisVec_of_between_p2_p3
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (h2q : p2.val < q.val) (hq3 : q.val < p3.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have h1q : p1.val < q.val := Nat.lt_trans h12 h2q
   have hraw :=
@@ -625,11 +625,11 @@ private theorem det_plucker_three_term_basisVec_of_gt_p3
     {R : Type u} [CommRing R] {n : Nat}
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) (h3q : p3.val < q.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   have h1q : p1.val < q.val := Nat.lt_trans h12 (Nat.lt_trans h23 h3q)
   have h2q : p2.val < q.val := Nat.lt_trans h23 h3q
@@ -652,11 +652,11 @@ theorem det_plucker_three_term_basisVec_of_ne
     (B : Hex.Matrix R (n + 3) (n + 1)) (p1 p2 p3 q : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hq1 : q ≠ p1) (hq2 : q ≠ p2) (hq3 : q ≠ p3) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+    Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   by_cases hlt1 : q.val < p1.val
   · exact det_plucker_three_term_basisVec_of_lt_p1 B p1 p2 p3 q h12 h23 hlt1
@@ -688,11 +688,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p1
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) p1) p1 *
+    Hex.Matrix.mDet B (Vector.unit R p1) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) p1) p2 *
+      Hex.Matrix.mDet B (Vector.unit R p1) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) p1) p3 *
+      Hex.Matrix.mDet B (Vector.unit R p1) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_zero_of_eq B p1,
     Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p2 p1 h12,
@@ -704,11 +704,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p2
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) p2) p1 *
+    Hex.Matrix.mDet B (Vector.unit R p2) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) p2) p2 *
+      Hex.Matrix.mDet B (Vector.unit R p2) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) p2) p3 *
+      Hex.Matrix.mDet B (Vector.unit R p2) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p2 h12,
     Hex.Matrix.mDet_unit_eq_zero_of_eq B p2, Hex.Matrix.mDet_unit_eq_signed_nDet_of_gt B p3 p2 h23]
@@ -728,11 +728,11 @@ private theorem det_plucker_three_term_basisVec_of_eq_p3
     (B : Hex.Matrix R (n + 3) (n + 1))
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val) :
-    Hex.Matrix.mDet B (Vector.unit (R := R) p3) p1 *
+    Hex.Matrix.mDet B (Vector.unit R p3) p1 *
         Hex.Matrix.nDet B p2 p3 h23 -
-      Hex.Matrix.mDet B (Vector.unit (R := R) p3) p2 *
+      Hex.Matrix.mDet B (Vector.unit R p3) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-      Hex.Matrix.mDet B (Vector.unit (R := R) p3) p3 *
+      Hex.Matrix.mDet B (Vector.unit R p3) p3 *
         Hex.Matrix.nDet B p1 p2 h12 = 0 := by
   rw [Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p1 p3 (Nat.lt_trans h12 h23),
     Hex.Matrix.mDet_unit_eq_signed_nDet_of_lt B p2 p3 h23, Hex.Matrix.mDet_unit_eq_zero_of_eq B p3]
@@ -809,11 +809,11 @@ private theorem det_plucker_three_term_of_basisVec
     (p1 p2 p3 : Fin (n + 3))
     (h12 : p1.val < p2.val) (h23 : p2.val < p3.val)
     (hbasis : ∀ q : Fin (n + 3),
-      Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+      Hex.Matrix.mDet B (Vector.unit R q) p1 *
           Hex.Matrix.nDet B p2 p3 h23 -
-        Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+        Hex.Matrix.mDet B (Vector.unit R q) p2 *
           Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
-        Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+        Hex.Matrix.mDet B (Vector.unit R q) p3 *
           Hex.Matrix.nDet B p1 p2 h12 = 0) :
     Hex.Matrix.mDet B v p1 * Hex.Matrix.nDet B p2 p3 h23 -
       Hex.Matrix.mDet B v p2 * Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23) +
@@ -821,21 +821,21 @@ private theorem det_plucker_three_term_of_basisVec
   rw [Hex.Matrix.mDet_eq_sum_unit B v p1, Hex.Matrix.mDet_eq_sum_unit B v p2,
     Hex.Matrix.mDet_eq_sum_unit B v p3]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p1)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p1)
       (Hex.Matrix.nDet B p2 p3 h23)]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p2)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p2)
       (Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23))]
   rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p3)
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p3)
       (Hex.Matrix.nDet B p1 p2 h12)]
   apply foldl_det_sum_sub_add_zero_of_body_zero
       (List.finRange (n + 3))
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p1 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p1 *
         Hex.Matrix.nDet B p2 p3 h23)
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p2 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p2 *
         Hex.Matrix.nDet B p1 p3 (Nat.lt_trans h12 h23))
-      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit (R := R) q) p3 *
+      (fun q => v[q] * Hex.Matrix.mDet B (Vector.unit R q) p3 *
         Hex.Matrix.nDet B p1 p2 h12)
       0 0 0
   · ring

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -683,10 +683,10 @@ theorem independent_of_det_positive (b : Matrix Int n m)
 
 /-- The identity matrix is independent: its Gram matrix is the identity, so
 every leading principal minor has determinant `1 > 0`. -/
-theorem independent_one {n : Nat} : independent (1 : Matrix Int n n) := by
-  exact independent_of_det_positive (1 : Matrix Int n n) (by
+theorem independent_identity {n : Nat} : independent (Matrix.identity (R := Int) n) := by
+  exact independent_of_det_positive (Matrix.identity (R := Int) n) (by
     intro k hk _
-    rw [Matrix.gramMatrix_one, Matrix.principalSubmatrix_one, Matrix.det_one]
+    rw [Matrix.gramMatrix_identity, Matrix.principalSubmatrix_identity, Matrix.det_identity]
     decide)
 
 

--- a/HexLLL/Basic.lean
+++ b/HexLLL/Basic.lean
@@ -1439,9 +1439,9 @@ private theorem memLattice_of_rowSwap_memLattice
     Matrix.memLattice (Matrix.rowSwap b i j) v → Matrix.memLattice b v := by
   intro hv
   rcases hv with ⟨c, hc⟩
-  let S : Matrix Int n n := Matrix.rowSwap (1 : Matrix Int n n) i j
+  let S : Matrix Int n n := Matrix.rowSwap (Matrix.identity (R := Int) n) i j
   have hrow : S * b = Matrix.rowSwap b i j := by
-    rw [Matrix.rowSwap_mul, Matrix.one_mul]
+    rw [Matrix.rowSwap_mul, Matrix.identity_mul]
   refine ⟨Matrix.transpose S * c, ?_⟩
   calc
     Matrix.rowCombination b (Matrix.transpose S * c)
@@ -1474,9 +1474,9 @@ private theorem memLattice_of_rowAdd_memLattice
     Matrix.memLattice (Matrix.rowAdd b src dst c) v → Matrix.memLattice b v := by
   intro hv
   rcases hv with ⟨w, hw⟩
-  let S : Matrix Int n n := Matrix.rowAdd (1 : Matrix Int n n) src dst c
+  let S : Matrix Int n n := Matrix.rowAdd (Matrix.identity (R := Int) n) src dst c
   have hrow : S * b = Matrix.rowAdd b src dst c := by
-    simp [S, Matrix.rowAdd_mul, Matrix.one_mul]
+    simp [S, Matrix.rowAdd_mul, Matrix.identity_mul]
   refine ⟨Matrix.transpose S * w, ?_⟩
   calc
     Matrix.rowCombination b (Matrix.transpose S * w)

--- a/HexLLLMathlib/Independent.lean
+++ b/HexLLLMathlib/Independent.lean
@@ -37,8 +37,8 @@ namespace Matrix
 determinant is positive. Used by Phase 4 benchmarks of
 `lll.firstShortVector`, where the identity basis is the degenerate BZ-style
 recombination input with all-zero lift coefficients. -/
-theorem identity_independent {n : Nat} : (1 : Matrix Int n n).independent := by
-  exact GramSchmidt.Int.independent_one
+theorem identity_independent {n : Nat} : (Matrix.identity (R := Int) n).independent := by
+  exact GramSchmidt.Int.independent_identity
 
 theorem gramMatrix_takeRows_eq_principalSubmatrix {n : Nat} (M : Matrix Int n n) (k : Nat)
     (hk : k ≤ n) :

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -98,7 +98,7 @@ Multiplication by the identity is the identity, and matrix
 multiplication is associative — the algebraic facts the determinant and
 echelon proofs lean on.
 
-{docstring Hex.Matrix.one_mulVec}
+{docstring Hex.Matrix.identity_mulVec}
 
 {docstring Hex.Matrix.mul_assoc}
 
@@ -129,7 +129,7 @@ definition. Swapping two rows negates the determinant; scaling a row
 scales it; adding a multiple of one row to another leaves it unchanged;
 and the determinant is invariant under transpose.
 
-{docstring Hex.Matrix.det_one}
+{docstring Hex.Matrix.det_identity}
 
 {docstring Hex.Matrix.det_rowSwap}
 
@@ -282,8 +282,8 @@ private def A : Matrix Int 3 3 :=
 #guard Matrix.det (Matrix.transpose A) = 3
 
 -- The identity has determinant one, both routes.
-#guard Matrix.det (1 : Matrix Int 3 3) = 1
-#guard Matrix.bareiss (1 : Matrix Int 3 3) = 1
+#guard Matrix.det (Matrix.identity (R := Int) 3) = 1
+#guard Matrix.bareiss (Matrix.identity (R := Int) 3) = 1
 
 -- S = [[1, 2], [2, 4]] has a dependent row pair,
 -- so its determinant is zero.

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -43,12 +43,12 @@ def normSq [Mul R] [Add R] [OfNat R 0] (v : Vector R n) : R :=
 
 /-- The standard basis vector with value `1` at index `i` and `0` elsewhere. -/
 @[expose]
-def unit [Zero R] [One R] (i : Fin n) : Vector R n :=
+def unit (R : Type u) [Zero R] [One R] (i : Fin n) : Vector R n :=
   Vector.ofFn fun j => if i = j then One.one else Zero.zero
 
 /-- Entry formula for a standard basis vector. -/
 @[grind =] theorem getElem_unit [Zero R] [One R] (i j : Fin n) :
-    (unit (R := R) i)[j] = if i = j then One.one else Zero.zero := by
+    (unit R i)[j] = if i = j then One.one else Zero.zero := by
   simp [unit]
 
 end Vector
@@ -148,19 +148,16 @@ def transpose (M : Matrix R n m) : Matrix R m n :=
 
 /-- The all-zero matrix. -/
 @[expose]
-protected def zero [OfNat R 0] : Matrix R n m :=
+protected def zero (n m : Nat) [OfNat R 0] : Matrix R n m :=
   ofFn fun _ _ => 0
 
 instance [OfNat R 0] : Zero (Matrix R n m) where
-  zero := Matrix.zero
+  zero := Matrix.zero n m
 
 /-- The identity matrix. -/
 @[expose]
-protected def identity [OfNat R 0] [OfNat R 1] : Matrix R n n :=
+protected def identity (n : Nat) [OfNat R 0] [OfNat R 1] : Matrix R n n :=
   ofFn fun i j => if i = j then 1 else 0
-
-instance [OfNat R 0] [OfNat R 1] : One (Matrix R n n) where
-  one := Matrix.identity
 
 /-- Multiply a matrix by a column vector. -/
 @[expose]
@@ -200,18 +197,18 @@ instance [Mul R] [Add R] [OfNat R 0] : Mul (Matrix R n n) where
   show (mul M N)[i][j] = (row M i).dotProduct (col N j)
   rw [mul, getElem_ofFn]
 
-/-- The identity matrix entry function: `1[i][j] = 1` if `i = j`, else `0`. -/
-@[grind =] theorem getElem_one [OfNat R 0] [OfNat R 1] {n : Nat} (i j : Fin n) :
-    (1 : Matrix R n n)[i][j] = if i = j then (1 : R) else 0 := by
-  simp [show (1 : Matrix R n n) = Matrix.identity from rfl, Matrix.identity, ofFn]
+/-- The identity matrix entry function: `(identity n)[i][j] = 1` if `i = j`, else `0`. -/
+@[grind =] theorem getElem_identity [OfNat R 0] [OfNat R 1] {n : Nat} (i j : Fin n) :
+    (Matrix.identity (R := R) n)[i][j] = if i = j then (1 : R) else 0 := by
+  simp [Matrix.identity, ofFn]
 
 /-- The identity matrix is its own transpose. -/
-@[simp, grind =] theorem transpose_one [OfNat R 0] [OfNat R 1] {n : Nat} :
-    Matrix.transpose (1 : Matrix R n n) = (1 : Matrix R n n) := by
+@[simp, grind =] theorem transpose_identity [OfNat R 0] [OfNat R 1] {n : Nat} :
+    Matrix.transpose (Matrix.identity (R := R) n) = Matrix.identity n := by
   ext i hi j hj
-  show (Matrix.transpose (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
-    (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
-  rw [getElem_transpose, getElem_one, getElem_one]
+  show (Matrix.transpose (Matrix.identity (R := R) n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
+    (Matrix.identity (R := R) n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
+  rw [getElem_transpose, getElem_identity, getElem_identity]
   by_cases hij : (⟨i, hi⟩ : Fin n) = ⟨j, hj⟩
   · have hji : (⟨j, hj⟩ : Fin n) = ⟨i, hi⟩ := hij.symm
     rw [if_pos hij, if_pos hji]

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -91,7 +91,7 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (xs : List (Fin n)) (i j : Fin n) (acc : R) :
     xs.foldl
         (fun acc l =>
-          acc + (unit (R := R) i)[l] * (unit (R := R) j)[l]) acc =
+          acc + (unit R i)[l] * (unit R j)[l]) acc =
       xs.foldl
         (fun acc l =>
           acc + (if i = l then (1 : R) else 0) * (if j = l then (1 : R) else 0)) acc := by
@@ -105,7 +105,7 @@ private theorem foldl_dotProduct_unit_body {R : Type u} [Lean.Grind.CommRing R]
 /-- Dot product of standard basis vectors. -/
 @[simp] theorem dotProduct_unit_unit {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (i j : Fin n) :
-    dotProduct (unit (R := R) i) (unit (R := R) j) = if i = j then 1 else 0 := by
+    dotProduct (unit R i) (unit R j) = if i = j then 1 else 0 := by
   unfold dotProduct
   rw [foldl_dotProduct_unit_body]
   by_cases hij : i = j
@@ -141,34 +141,34 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
   rw [gramMatrix, getElem_ofFn]
 
 /-- The Gram matrix of the identity is the identity. -/
-@[simp, grind =] theorem gramMatrix_one {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
-    gramMatrix (1 : Matrix R n n) = (1 : Matrix R n n) := by
+@[simp, grind =] theorem gramMatrix_identity {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
+    gramMatrix (Matrix.identity (R := R) n) = (Matrix.identity (R := R) n) := by
   ext i hi j hj
-  have hrow_i : (1 : Matrix R n n).row ⟨i, hi⟩ =
-      Vector.unit (R := R) ⟨i, hi⟩ := by
+  have hrow_i : (Matrix.identity (R := R) n).row ⟨i, hi⟩ =
+      Vector.unit R ⟨i, hi⟩ := by
     ext a ha
-    show ((1 : Matrix R n n).row ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)] =
-      (Vector.unit (R := R) ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
-    rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
+    show ((Matrix.identity (R := R) n).row ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)] =
+      (Vector.unit R ⟨i, hi⟩)[(⟨a, ha⟩ : Fin n)]
+    rw [Matrix.row, Hex.Matrix.getElem_identity (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
       Vector.getElem_unit (i := (⟨i, hi⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
-  have hrow_j : (1 : Matrix R n n).row ⟨j, hj⟩ =
-      Vector.unit (R := R) ⟨j, hj⟩ := by
+  have hrow_j : (Matrix.identity (R := R) n).row ⟨j, hj⟩ =
+      Vector.unit R ⟨j, hj⟩ := by
     ext a ha
-    show ((1 : Matrix R n n).row ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)] =
-      (Vector.unit (R := R) ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
-    rw [Matrix.row, Hex.Matrix.getElem_one (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
+    show ((Matrix.identity (R := R) n).row ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)] =
+      (Vector.unit R ⟨j, hj⟩)[(⟨a, ha⟩ : Fin n)]
+    rw [Matrix.row, Hex.Matrix.getElem_identity (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n)),
       Vector.getElem_unit (i := (⟨j, hj⟩ : Fin n)) (j := (⟨a, ha⟩ : Fin n))]
     rfl
-  show (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
-    (1 : Matrix R n n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
+  show (gramMatrix (Matrix.identity (R := R) n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
+    (Matrix.identity (R := R) n)[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)]
   have hgram :
-      (gramMatrix (1 : Matrix R n n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
-        ((1 : Matrix R n n).row ⟨i, hi⟩).dotProduct
-          ((1 : Matrix R n n).row ⟨j, hj⟩) := by
+      (gramMatrix (Matrix.identity (R := R) n))[(⟨i, hi⟩ : Fin n)][(⟨j, hj⟩ : Fin n)] =
+        ((Matrix.identity (R := R) n).row ⟨i, hi⟩).dotProduct
+          ((Matrix.identity (R := R) n).row ⟨j, hj⟩) := by
     unfold gramMatrix ofFn
     simp
-  rw [hgram, hrow_i, hrow_j, Vector.dotProduct_unit_unit, getElem_one]
+  rw [hgram, hrow_i, hrow_j, Vector.dotProduct_unit_unit, getElem_identity]
 
 end Matrix
 

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -288,74 +288,74 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   rw [Lean.Grind.CommSemiring.mul_comm]
 
 /-- Left-multiplication by the identity matrix leaves a vector unchanged. -/
-@[simp, grind =] theorem one_mulVec [Lean.Grind.Ring R] (v : Vector R n) :
-    (1 : Matrix R n n) * v = v := by
+@[simp, grind =] theorem identity_mulVec [Lean.Grind.Ring R] (v : Vector R n) :
+    (Matrix.identity (R := R) n) * v = v := by
   ext i hi
   let ii : Fin n := ⟨i, hi⟩
   simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange n).foldl
-      (fun acc j => acc + (1 : Matrix R n n)[ii][j] * v[j]) 0 =
+      (fun acc j => acc + (Matrix.identity (R := R) n)[ii][j] * v[j]) 0 =
     v[ii]
   calc
     (List.finRange n).foldl
-        (fun acc j => acc + (1 : Matrix R n n)[ii][j] * v[j]) 0 =
+        (fun acc j => acc + (Matrix.identity (R := R) n)[ii][j] * v[j]) 0 =
         (List.finRange n).foldl
           (fun acc j => acc + (if ii = j then (1 : R) else 0) * v[j]) 0 := by
           apply foldl_sum_congr
           intro j _hj
-          rw [getElem_one]
+          rw [getElem_identity]
     _ = v[ii] := by
           rw [foldl_indicator_mul_unique (List.finRange n) ii (fun j => v[j])
             (List.mem_finRange _) (List.nodup_finRange n) 0]
           grind
 
 /-- Left-multiplication by the identity matrix leaves a matrix unchanged. -/
-@[simp, grind =] theorem one_mul [Lean.Grind.Ring R] (M : Matrix R n m) :
-    (1 : Matrix R n n) * M = M := by
+@[simp, grind =] theorem identity_mul [Lean.Grind.Ring R] (M : Matrix R n m) :
+    (Matrix.identity (R := R) n) * M = M := by
   ext i hi j hj
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
-  change ((1 : Matrix R n n) * M)[ii][jj] = M[ii][jj]
+  change ((Matrix.identity (R := R) n) * M)[ii][jj] = M[ii][jj]
   simp [HMul.hMul, mul, row, col, Vector.dotProduct]
   simp [ofFn]
   change
     (List.finRange n).foldl
-        (fun acc l => acc + (1 : Matrix R n n)[ii][l] * M[l][jj]) 0 =
+        (fun acc l => acc + (Matrix.identity (R := R) n)[ii][l] * M[l][jj]) 0 =
       M[ii][jj]
   calc
     (List.finRange n).foldl
-        (fun acc l => acc + (1 : Matrix R n n)[ii][l] * M[l][jj]) 0 =
+        (fun acc l => acc + (Matrix.identity (R := R) n)[ii][l] * M[l][jj]) 0 =
         (List.finRange n).foldl
           (fun acc l => acc + (if ii = l then (1 : R) else 0) * M[l][jj]) 0 := by
           apply foldl_sum_congr
           intro l _hl
-          rw [getElem_one]
+          rw [getElem_identity]
     _ = M[ii][jj] := by
           rw [foldl_indicator_mul_unique (List.finRange n) ii (fun l => M[l][jj])
             (List.mem_finRange _) (List.nodup_finRange n) 0]
           grind
 
 /-- Right-multiplication by the identity matrix leaves a matrix unchanged. -/
-@[simp, grind =] theorem mul_one [Lean.Grind.Ring R] (M : Matrix R n m) :
-    M * (1 : Matrix R m m) = M := by
+@[simp, grind =] theorem mul_identity [Lean.Grind.Ring R] (M : Matrix R n m) :
+    M * (Matrix.identity (R := R) m) = M := by
   ext i hi j hj
   let ii : Fin n := ⟨i, hi⟩
   let jj : Fin m := ⟨j, hj⟩
-  change (M * (1 : Matrix R m m))[ii][jj] = M[ii][jj]
+  change (M * (Matrix.identity (R := R) m))[ii][jj] = M[ii][jj]
   simp [HMul.hMul, mul, row, col, Vector.dotProduct]
   simp [ofFn]
   change
     (List.finRange m).foldl
-        (fun acc l => acc + M[ii][l] * (1 : Matrix R m m)[l][jj]) 0 =
+        (fun acc l => acc + M[ii][l] * (Matrix.identity (R := R) m)[l][jj]) 0 =
       M[ii][jj]
   calc
     (List.finRange m).foldl
-        (fun acc l => acc + M[ii][l] * (1 : Matrix R m m)[l][jj]) 0 =
+        (fun acc l => acc + M[ii][l] * (Matrix.identity (R := R) m)[l][jj]) 0 =
         (List.finRange m).foldl
           (fun acc l => acc + (if jj = l then (1 : R) else 0) * M[ii][l]) 0 := by
           apply foldl_sum_congr
           intro l _hl
-          rw [getElem_one]
+          rw [getElem_identity]
           split <;> grind
     _ = M[ii][jj] := by
           rw [foldl_indicator_mul_unique (List.finRange m) jj (fun l => M[ii][l])
@@ -393,7 +393,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
   change (List.finRange m).foldl (fun acc j => acc + (0 : Matrix R n m)[ii][j] * v[j]) 0 = 0
   apply foldl_add_eq_acc_ring
   intro j _hj
-  change (Matrix.zero : Matrix R n m)[ii][j] * v[j] = 0
+  change (Matrix.zero n m : Matrix R n m)[ii][j] * v[j] = 0
   simpa [Matrix.zero, ofFn] using Lean.Grind.Semiring.zero_mul v[j]
 
 /-- Multiplication by `Q - I`, expressed entrywise, is `Q * v - v`. -/

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -55,14 +55,14 @@ def takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
   simp [takeRows, ofFn]
 
 /-- The leading principal `k × k` submatrix of the identity is the identity. -/
-@[simp, grind =] theorem principalSubmatrix_one {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}
+@[simp, grind =] theorem principalSubmatrix_identity {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}
     (k : Nat) (hk : k ≤ n) :
-    principalSubmatrix (1 : Matrix R n n) k hk = (1 : Matrix R k k) := by
+    principalSubmatrix (Matrix.identity (R := R) n) k hk = (Matrix.identity (R := R) k) := by
   ext i hi j hj
-  show (principalSubmatrix (1 : Matrix R n n) k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)] =
-    (1 : Matrix R k k)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
-  rw [getElem_principalSubmatrix, getElem_one (i := (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n)),
-    getElem_one (i := (⟨i, hi⟩ : Fin k))]
+  show (principalSubmatrix (Matrix.identity (R := R) n) k hk)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)] =
+    (Matrix.identity (R := R) k)[(⟨i, hi⟩ : Fin k)][(⟨j, hj⟩ : Fin k)]
+  rw [getElem_principalSubmatrix, getElem_identity (i := (⟨i, Nat.lt_of_lt_of_le hi hk⟩ : Fin n)),
+    getElem_identity (i := (⟨i, hi⟩ : Fin k))]
   by_cases hij : (⟨i, hi⟩ : Fin k) = ⟨j, hj⟩
   · have hval : i = j := Fin.val_eq_of_eq hij
     have hijn :

--- a/HexMatrixMathlib/Algebra.lean
+++ b/HexMatrixMathlib/Algebra.lean
@@ -34,7 +34,7 @@ variable {R : Type u} {n m : Nat}
     matrixEquiv (0 : Hex.Matrix R n m) = 0 := by
   ext i j
   rw [matrixEquiv_apply, Matrix.zero_apply]
-  show (Hex.Matrix.zero : Hex.Matrix R n m)[i][j] = 0
+  show (Hex.Matrix.zero n m : Hex.Matrix R n m)[i][j] = 0
   rw [Hex.Matrix.zero, Hex.Matrix.getElem_ofFn]
 
 @[simp, grind =] theorem matrixEquiv_add [Add R] (A B : Hex.Matrix R n m) :
@@ -61,10 +61,15 @@ variable {R : Type u} {n m : Nat}
 is the executable `ofFn`-based `Hex.Matrix.zero`, not the core `Vector`
 `replicate` zero. The additive tower, `Semiring`, and `matrixEquiv_zero` all
 share this zero; this `rfl` fails loudly if instance resolution ever drifts. -/
-example [Zero R] : (0 : Hex.Matrix R n m) = Hex.Matrix.zero := rfl
+example [Zero R] : (0 : Hex.Matrix R n m) = Hex.Matrix.zero n m := rfl
 
-/-- Regression guard: the canonical square-matrix one is the executable identity. -/
-example [Zero R] [One R] : (1 : Hex.Matrix R n n) = Hex.Matrix.identity := rfl
+/-- `1` on a square matrix is the identity matrix. The instance is here rather than
+in `HexMatrix` because the `Semiring`/`Ring` structures transported below need it,
+while `HexMatrix` states its own lemmas with `Matrix.identity`. -/
+instance instOne [OfNat R 0] [OfNat R 1] : One (Hex.Matrix R n n) := ⟨Hex.Matrix.identity n⟩
+
+/-- Regression guard: `1` on a square matrix is `Matrix.identity`. -/
+example [Zero R] [One R] : (1 : Hex.Matrix R n n) = Hex.Matrix.identity n := rfl
 
 /-! ### Additive instances and the additive equivalence -/
 
@@ -107,7 +112,9 @@ def matrixLinearEquiv [Semiring R] : Hex.Matrix R n m ≃ₗ[R] Matrix (Fin n) (
 @[simp, grind =] theorem matrixEquiv_one [Zero R] [One R] :
     matrixEquiv (1 : Hex.Matrix R n n) = 1 := by
   ext i j
-  rw [matrixEquiv_apply, Hex.Matrix.getElem_one, Matrix.one_apply]
+  rw [matrixEquiv_apply]
+  show (Hex.Matrix.identity n)[i][j] = _
+  rw [Hex.Matrix.getElem_identity, Matrix.one_apply]
 
 @[simp, grind =] theorem matrixEquiv_mul [Semiring R] (A B : Hex.Matrix R n n) :
     matrixEquiv (A * B) = matrixEquiv A * matrixEquiv B := by

--- a/HexRowReduce/Loop.lean
+++ b/HexRowReduce/Loop.lean
@@ -39,7 +39,7 @@ omit [DecidableEq R] in
 invariant. -/
 private theorem rowReduceLoop_initial_canonical (M : Matrix R n m) :
     RowReduceCanonicalInvariant (R := R) (n := n) (m := m)
-      { row := 0, echelon := M, transform := 1, pivots := [] } where
+      { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] } where
   pivot_entry_one := by intro i hi _; exact absurd hi (by simp)
   other_entry_zero := by intro i hi _ _; exact absurd hi (by simp)
 
@@ -291,7 +291,7 @@ private theorem rowReduceLoop_initial_shape (M : Matrix R n m) :
     RowReduceShapeInvariant (R := R) (n := n) (m := m) 0
       { row := 0
         echelon := M
-        transform := 1
+        transform := Matrix.identity n
         pivots := [] } where
   row_eq_length := rfl
   row_le_n := Nat.zero_le n
@@ -310,12 +310,12 @@ private theorem rowReduce_final_shape (M : Matrix R n m) :
       (rowReduceLoop 0 m
         { row := 0
           echelon := M
-          transform := 1
+          transform := Matrix.identity n
           pivots := [] }) := by
   simpa using rowReduceLoop_shape (R := R) (n := n) (m := m) m 0
     { row := 0
       echelon := M
-      transform := 1
+      transform := Matrix.identity n
       pivots := [] } (rowReduceLoop_initial_shape M)
 
 /-- The canonical-column invariant is preserved through `rowReduceLoop`. -/
@@ -384,10 +384,10 @@ private theorem rowReduce_final_canonical (M : Matrix R n m) :
       (rowReduceLoop 0 m
         { row := 0
           echelon := M
-          transform := 1
+          transform := Matrix.identity n
           pivots := [] }) := by
   exact rowReduceLoop_canonical (R := R) (n := n) (m := m) m 0
-    { row := 0, echelon := M, transform := 1, pivots := [] }
+    { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] }
     (rowReduceLoop_initial_shape M) (rowReduceLoop_initial_canonical M)
 
 omit [DecidableEq R] in
@@ -491,7 +491,7 @@ private theorem rowReduceNoPivotZero_initial (M : Matrix R n m) :
     RowReduceNoPivotZero (R := R) (n := n) (m := m) 0
       { row := 0
         echelon := M
-        transform := 1
+        transform := Matrix.identity n
         pivots := [] } where
   zero_unrecorded := by
     intro c hc _ _ _
@@ -625,20 +625,20 @@ private theorem rowReduce_final_no_pivot_zero (M : Matrix R n m) :
       (rowReduceLoop 0 m
         { row := 0
           echelon := M
-          transform := 1
+          transform := Matrix.identity n
           pivots := [] }) := by
   simpa using rowReduceLoop_no_pivot_zero (R := R) (n := n) (m := m) m 0
     { row := 0
       echelon := M
-      transform := 1
+      transform := Matrix.identity n
       pivots := [] } (rowReduceNoPivotZero_initial M)
 
 /-- `rowReduceLoop` preserves existence of a left inverse for the transform. -/
 private theorem rowReduceLoop_left_inverse_preserve (col fuel : Nat)
     (state : RowReduceState R n m)
-    (h : ∃ Tinv : Matrix R n n, Tinv * state.transform = 1) :
+    (h : ∃ Tinv : Matrix R n n, Tinv * state.transform = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
-      Tinv' * (rowReduceLoop col fuel state).transform = 1 := by
+      Tinv' * (rowReduceLoop col fuel state).transform = (Matrix.identity (R := R) n) := by
   induction fuel generalizing col state with
   | zero =>
       simpa [rowReduceLoop] using h
@@ -664,7 +664,7 @@ private theorem rowReduceLoop_left_inverse_preserve (col fuel : Nat)
                   transform := eliminated.2
                   pivots := state.pivots.concat colFin }
               have hswap :
-                  ∃ Tinv : Matrix R n n, Tinv * swappedTransform = 1 :=
+                  ∃ Tinv : Matrix R n n, Tinv * swappedTransform = (Matrix.identity (R := R) n) :=
                 rowSwap_left_inverse_preserve state.transform target pivot h
               have hpivotVal : pivotVal ≠ 0 := by
                 have hpivotNonzero := findPivot?_some_nonzero state.echelon colFin hpivot
@@ -673,11 +673,11 @@ private theorem rowReduceLoop_left_inverse_preserve (col fuel : Nat)
                     (getElem_rowSwap_target_pivot state.echelon target pivot colFin)
                 simpa [hentry] using hpivotNonzero
               have hscale :
-                  ∃ Tinv : Matrix R n n, Tinv * scaledTransform = 1 :=
+                  ∃ Tinv : Matrix R n n, Tinv * scaledTransform = (Matrix.identity (R := R) n) :=
                 rowScale_left_inverse_preserve swappedTransform target
                   (show pivotVal⁻¹ ≠ 0 by grind) hswap
               have helim :
-                  ∃ Tinv : Matrix R n n, Tinv * eliminated.2 = 1 :=
+                  ∃ Tinv : Matrix R n n, Tinv * eliminated.2 = (Matrix.identity (R := R) n) :=
                 eliminateColumn_left_inverse_preserve scaledTransform scaledEchelon target colFin hscale
               simpa [rowReduceLoop, hRow, hCol, colFin, hpivot, target, swappedEchelon,
                 swappedTransform, pivotVal, scaledEchelon, scaledTransform, eliminated,
@@ -688,9 +688,9 @@ private theorem rowReduceLoop_left_inverse_preserve (col fuel : Nat)
 /-- `rowReduceLoop` preserves existence of a right inverse for the transform. -/
 private theorem rowReduceLoop_right_inverse_preserve (col fuel : Nat)
     (state : RowReduceState R n m)
-    (h : ∃ Tinv : Matrix R n n, state.transform * Tinv = 1) :
+    (h : ∃ Tinv : Matrix R n n, state.transform * Tinv = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
-      (rowReduceLoop col fuel state).transform * Tinv' = 1 := by
+      (rowReduceLoop col fuel state).transform * Tinv' = (Matrix.identity (R := R) n) := by
   induction fuel generalizing col state with
   | zero =>
       simpa [rowReduceLoop] using h
@@ -716,7 +716,7 @@ private theorem rowReduceLoop_right_inverse_preserve (col fuel : Nat)
                   transform := eliminated.2
                   pivots := state.pivots.concat colFin }
               have hswap :
-                  ∃ Tinv : Matrix R n n, swappedTransform * Tinv = 1 :=
+                  ∃ Tinv : Matrix R n n, swappedTransform * Tinv = (Matrix.identity (R := R) n) :=
                 rowSwap_right_inverse_preserve state.transform target pivot h
               have hpivotVal : pivotVal ≠ 0 := by
                 have hpivotNonzero := findPivot?_some_nonzero state.echelon colFin hpivot
@@ -725,11 +725,11 @@ private theorem rowReduceLoop_right_inverse_preserve (col fuel : Nat)
                     (getElem_rowSwap_target_pivot state.echelon target pivot colFin)
                 simpa [hentry] using hpivotNonzero
               have hscale :
-                  ∃ Tinv : Matrix R n n, scaledTransform * Tinv = 1 :=
+                  ∃ Tinv : Matrix R n n, scaledTransform * Tinv = (Matrix.identity (R := R) n) :=
                 rowScale_right_inverse_preserve swappedTransform target
                   (show pivotVal⁻¹ ≠ 0 by grind) hswap
               have helim :
-                  ∃ Tinv : Matrix R n n, eliminated.2 * Tinv = 1 :=
+                  ∃ Tinv : Matrix R n n, eliminated.2 * Tinv = (Matrix.identity (R := R) n) :=
                 eliminateColumn_right_inverse_preserve scaledTransform scaledEchelon target colFin hscale
               simpa [rowReduceLoop, hRow, hCol, colFin, hpivot, target, swappedEchelon,
                 swappedTransform, pivotVal, scaledEchelon, scaledTransform, eliminated,
@@ -796,7 +796,7 @@ def rowReduce (M : Matrix R n m) : RowEchelonData R n m :=
   let final := rowReduceLoop 0 m
     { row := 0
       echelon := M
-      transform := 1
+      transform := Matrix.identity n
       pivots := [] }
   { rank := final.pivots.length
     echelon := final.echelon
@@ -806,7 +806,7 @@ def rowReduce (M : Matrix R n m) : RowEchelonData R n m :=
 /-- Wrapper-level projection of the rank row bound from `rowReduce_isRowReduced M`. -/
 theorem rowReduce_rank_le_n (M : Matrix R n m) : (rowReduce M).rank ≤ n := by
   unfold rowReduce
-  change (rowReduceLoop 0 m { row := 0, echelon := M, transform := 1, pivots := [] }).pivots.length ≤ n
+  change (rowReduceLoop 0 m { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] }).pivots.length ≤ n
   rw [← (rowReduce_final_shape M).row_eq_length]
   exact (rowReduce_final_shape M).row_le_n
 
@@ -823,7 +823,7 @@ theorem rowReduce_pivotCols_sorted (M : Matrix R n m) :
   let final := rowReduceLoop 0 m
     { row := 0
       echelon := M
-      transform := 1
+      transform := Matrix.identity n
       pivots := [] }
   have hshape : RowReduceShapeInvariant (R := R) (n := n) (m := m) m final := by
     simpa [final] using rowReduce_final_shape M
@@ -834,19 +834,19 @@ theorem rowReduce_pivotCols_sorted (M : Matrix R n m) :
 
 /-- Final `rowReduce` row transform has a left inverse. -/
 private theorem rowReduce_transform_left_inverse (M : Matrix R n m) :
-    ∃ Tinv : Matrix R n n, Tinv * (rowReduce M).transform = 1 := by
+    ∃ Tinv : Matrix R n n, Tinv * (rowReduce M).transform = (Matrix.identity (R := R) n) := by
   unfold rowReduce
   exact rowReduceLoop_left_inverse_preserve 0 m
-    { row := 0, echelon := M, transform := 1, pivots := [] }
-    ⟨1, by rw [one_mul]⟩
+    { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] }
+    ⟨Matrix.identity n, by rw [identity_mul]⟩
 
 /-- Final `rowReduce` row transform has a right inverse. -/
 private theorem rowReduce_transform_right_inverse (M : Matrix R n m) :
-    ∃ Tinv : Matrix R n n, (rowReduce M).transform * Tinv = 1 := by
+    ∃ Tinv : Matrix R n n, (rowReduce M).transform * Tinv = (Matrix.identity (R := R) n) := by
   unfold rowReduce
   exact rowReduceLoop_right_inverse_preserve 0 m
-    { row := 0, echelon := M, transform := 1, pivots := [] }
-    ⟨1, by rw [one_mul]⟩
+    { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] }
+    ⟨Matrix.identity n, by rw [identity_mul]⟩
 
 /-- Wrapper-level projection of the transform equation from `rowReduce_isRowReduced M`. -/
 theorem rowReduce_transform_mul (M : Matrix R n m) :
@@ -855,14 +855,14 @@ theorem rowReduce_transform_mul (M : Matrix R n m) :
   exact rowReduceLoop_transform_preserve M 0 m
     { row := 0
       echelon := M
-      transform := 1
+      transform := Matrix.identity n
       pivots := [] }
-    (by rw [Matrix.one_mul])
+    (by rw [Matrix.identity_mul])
 
 /-- The computed `rowReduce` data satisfies the `IsRowReduced` contract. -/
 theorem rowReduce_isRowReduced (M : Matrix R n m) : IsRowReduced M (rowReduce M) := by
   let final := rowReduceLoop 0 m
-    { row := 0, echelon := M, transform := 1, pivots := [] }
+    { row := 0, echelon := M, transform := Matrix.identity n, pivots := [] }
   have hcanon : RowReduceCanonicalInvariant (R := R) (n := n) (m := m) final := by
     simpa [final] using rowReduce_final_canonical M
   have hshape : RowReduceShapeInvariant (R := R) (n := n) (m := m) m final := by

--- a/HexRowReduce/Nullspace.lean
+++ b/HexRowReduce/Nullspace.lean
@@ -442,8 +442,8 @@ theorem nullspace_sound {R : Type u} [Lean.Grind.Ring R] {n m : Nat}
       _ = 0 := hbEchelon
   rcases E.toIsEchelonForm.transform_inv with ⟨Tinv, hTinv⟩
   calc
-    M * b = (1 : Matrix R n n) * (M * b) := by
-      rw [Matrix.one_mulVec]
+    M * b = (Matrix.identity (R := R) n) * (M * b) := by
+      rw [Matrix.identity_mulVec]
     _ = (Tinv * D.transform) * (M * b) := by
       rw [hTinv]
     _ = Tinv * (D.transform * (M * b)) := by

--- a/HexRowReduce/Pivot.lean
+++ b/HexRowReduce/Pivot.lean
@@ -457,14 +457,14 @@ private theorem eliminateColumn_transform_preserve
 for the transform side. -/
 private theorem eliminateColumn_step_left_inverse_preserve
     (s : Matrix R n m × Matrix R n n) (pivotRow : Fin n) (col : Fin m)
-    (x : Fin n) (h : ∃ Tinv : Matrix R n n, Tinv * s.2 = 1) :
+    (x : Fin n) (h : ∃ Tinv : Matrix R n n, Tinv * s.2 = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
       Tinv' *
         (if _h : x = pivotRow then s
          else
            let coeff := -s.1[x][col]
            if coeff = 0 then s
-           else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).2 = 1 := by
+           else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).2 = (Matrix.identity (R := R) n) := by
   by_cases hx : x = pivotRow
   · rw [dif_pos hx]
     exact h
@@ -480,14 +480,14 @@ private theorem eliminateColumn_step_left_inverse_preserve
 for the transform side. -/
 private theorem eliminateColumn_step_right_inverse_preserve
     (s : Matrix R n m × Matrix R n n) (pivotRow : Fin n) (col : Fin m)
-    (x : Fin n) (h : ∃ Tinv : Matrix R n n, s.2 * Tinv = 1) :
+    (x : Fin n) (h : ∃ Tinv : Matrix R n n, s.2 * Tinv = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
       (if _h : x = pivotRow then s
        else
          let coeff := -s.1[x][col]
          if coeff = 0 then s
          else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).2 *
-        Tinv' = 1 := by
+        Tinv' = (Matrix.identity (R := R) n) := by
   by_cases hx : x = pivotRow
   · rw [dif_pos hx]
     exact h
@@ -504,7 +504,7 @@ transform side. -/
 private theorem eliminateColumn_foldl_left_inverse_preserve
     (pivotRow : Fin n) (col : Fin m) :
     ∀ (xs : List (Fin n)) (s : Matrix R n m × Matrix R n n),
-      (∃ Tinv : Matrix R n n, Tinv * s.2 = 1) →
+      (∃ Tinv : Matrix R n n, Tinv * s.2 = (Matrix.identity (R := R) n)) →
       ∃ Tinv' : Matrix R n n,
         Tinv' *
           (xs.foldl (fun (state : Matrix R n m × Matrix R n n) j =>
@@ -513,7 +513,7 @@ private theorem eliminateColumn_foldl_left_inverse_preserve
               let coeff := -state.1[j][col]
               if coeff = 0 then state
               else (rowAdd state.1 pivotRow j coeff, rowAdd state.2 pivotRow j coeff))
-            s).2 = 1 := by
+            s).2 = (Matrix.identity (R := R) n) := by
   intro xs
   induction xs with
   | nil =>
@@ -529,7 +529,7 @@ transform side. -/
 private theorem eliminateColumn_foldl_right_inverse_preserve
     (pivotRow : Fin n) (col : Fin m) :
     ∀ (xs : List (Fin n)) (s : Matrix R n m × Matrix R n n),
-      (∃ Tinv : Matrix R n n, s.2 * Tinv = 1) →
+      (∃ Tinv : Matrix R n n, s.2 * Tinv = (Matrix.identity (R := R) n)) →
       ∃ Tinv' : Matrix R n n,
         (xs.foldl (fun (state : Matrix R n m × Matrix R n n) j =>
           if _h : j = pivotRow then state
@@ -538,7 +538,7 @@ private theorem eliminateColumn_foldl_right_inverse_preserve
             if coeff = 0 then state
             else (rowAdd state.1 pivotRow j coeff, rowAdd state.2 pivotRow j coeff))
           s).2 *
-          Tinv' = 1 := by
+          Tinv' = (Matrix.identity (R := R) n) := by
   intro xs
   induction xs with
   | nil =>
@@ -553,9 +553,9 @@ private theorem eliminateColumn_foldl_right_inverse_preserve
 side. -/
 private theorem eliminateColumn_left_inverse_preserve
     (T : Matrix R n n) (E : Matrix R n m) (pivotRow : Fin n) (col : Fin m)
-    (h : ∃ Tinv : Matrix R n n, Tinv * T = 1) :
+    (h : ∃ Tinv : Matrix R n n, Tinv * T = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
-      Tinv' * (eliminateColumn E T pivotRow col).2 = 1 := by
+      Tinv' * (eliminateColumn E T pivotRow col).2 = (Matrix.identity (R := R) n) := by
   unfold eliminateColumn
   exact eliminateColumn_foldl_left_inverse_preserve pivotRow col (List.finRange n) (E, T) h
 
@@ -563,9 +563,9 @@ private theorem eliminateColumn_left_inverse_preserve
 side. -/
 private theorem eliminateColumn_right_inverse_preserve
     (T : Matrix R n n) (E : Matrix R n m) (pivotRow : Fin n) (col : Fin m)
-    (h : ∃ Tinv : Matrix R n n, T * Tinv = 1) :
+    (h : ∃ Tinv : Matrix R n n, T * Tinv = (Matrix.identity (R := R) n)) :
     ∃ Tinv' : Matrix R n n,
-      (eliminateColumn E T pivotRow col).2 * Tinv' = 1 := by
+      (eliminateColumn E T pivotRow col).2 * Tinv' = (Matrix.identity (R := R) n) := by
   unfold eliminateColumn
   exact eliminateColumn_foldl_right_inverse_preserve pivotRow col (List.finRange n) (E, T) h
 

--- a/HexRowReduce/RowEchelon/Contracts.lean
+++ b/HexRowReduce/RowEchelon/Contracts.lean
@@ -43,8 +43,8 @@ structure RowEchelonData (R : Type u) (n m : Nat) where
 structure IsEchelonForm [Mul R] [Add R] [OfNat R 0] [OfNat R 1]
     (M : Matrix R n m) (D : RowEchelonData R n m) : Prop where
   transform_mul : D.transform * M = D.echelon
-  transform_inv : ∃ Tinv : Matrix R n n, Tinv * D.transform = 1
-  transform_right_inv : ∃ Tinv : Matrix R n n, D.transform * Tinv = 1
+  transform_inv : ∃ Tinv : Matrix R n n, Tinv * D.transform = (Matrix.identity (R := R) n)
+  transform_right_inv : ∃ Tinv : Matrix R n n, D.transform * Tinv = (Matrix.identity (R := R) n)
   rank_le_n : D.rank ≤ n
   rank_le_m : D.rank ≤ m
   pivotCols_sorted : ∀ i j, i < j → D.pivotCols.get i < D.pivotCols.get j
@@ -79,7 +79,7 @@ def HasNonzeroPivots (E : IsEchelonForm M D) : Prop :=
 
 /-- The square row-transform has a right inverse. -/
 theorem transform_mul_inv (E : IsEchelonForm M D) :
-    ∃ Tinv : Matrix R n n, D.transform * Tinv = 1 := by
+    ∃ Tinv : Matrix R n n, D.transform * Tinv = (Matrix.identity (R := R) n) := by
   exact E.transform_right_inv
 
 private theorem pivotCols_pairwise (E : IsEchelonForm M D) :

--- a/HexRowReduce/RowEchelon/Elementary.lean
+++ b/HexRowReduce/RowEchelon/Elementary.lean
@@ -489,9 +489,9 @@ theorem rowAdd_rowAdd_neg_left [Lean.Grind.Ring R]
     rw [getElem_rowAdd, if_neg hrd]
 
 private theorem leftMul_left_inverse_preserve [Lean.Grind.Ring R]
-    {S Sinv T : Matrix R n n} (hSinvS : Sinv * S = 1)
-    (hT : ∃ Tinv : Matrix R n n, Tinv * T = 1) :
-    ∃ Tinv' : Matrix R n n, Tinv' * (S * T) = 1 := by
+    {S Sinv T : Matrix R n n} (hSinvS : Sinv * S = (Matrix.identity (R := R) n))
+    (hT : ∃ Tinv : Matrix R n n, Tinv * T = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, Tinv' * (S * T) = (Matrix.identity (R := R) n) := by
   rcases hT with ⟨Tinv, hTinv⟩
   refine ⟨Tinv * Sinv, ?_⟩
   calc
@@ -499,16 +499,16 @@ private theorem leftMul_left_inverse_preserve [Lean.Grind.Ring R]
       exact (mul_assoc (Tinv * Sinv) S T).symm
     _ = (Tinv * (Sinv * S)) * T := by
       rw [mul_assoc Tinv Sinv S]
-    _ = (Tinv * 1) * T := by
+    _ = (Tinv * (Matrix.identity (R := R) n)) * T := by
       rw [hSinvS]
     _ = Tinv * T := by
-      rw [mul_one]
-    _ = 1 := hTinv
+      rw [mul_identity]
+    _ = (Matrix.identity (R := R) n) := hTinv
 
 private theorem leftMul_right_inverse_preserve [Lean.Grind.Ring R]
-    {S Sinv T : Matrix R n n} (hSSinv : S * Sinv = 1)
-    (hT : ∃ Tinv : Matrix R n n, T * Tinv = 1) :
-    ∃ Tinv' : Matrix R n n, (S * T) * Tinv' = 1 := by
+    {S Sinv T : Matrix R n n} (hSSinv : S * Sinv = (Matrix.identity (R := R) n))
+    (hT : ∃ Tinv : Matrix R n n, T * Tinv = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, (S * T) * Tinv' = (Matrix.identity (R := R) n) := by
   rcases hT with ⟨Tinv, hTinv⟩
   refine ⟨Tinv * Sinv, ?_⟩
   calc
@@ -516,91 +516,91 @@ private theorem leftMul_right_inverse_preserve [Lean.Grind.Ring R]
       exact mul_assoc S T (Tinv * Sinv)
     _ = S * ((T * Tinv) * Sinv) := by
       rw [mul_assoc]
-    _ = S * (1 * Sinv) := by
+    _ = S * ((Matrix.identity (R := R) n) * Sinv) := by
       rw [hTinv]
     _ = S * Sinv := by
-      rw [one_mul]
-    _ = 1 := hSSinv
+      rw [identity_mul]
+    _ = (Matrix.identity (R := R) n) := hSSinv
 
 /-- A row swap preserves existence of a left inverse for a row transform. -/
 theorem rowSwap_left_inverse_preserve [Lean.Grind.Ring R]
     (T : Matrix R n n) (i j : Fin n)
-    (hT : ∃ Tinv : Matrix R n n, Tinv * T = 1) :
-    ∃ Tinv' : Matrix R n n, Tinv' * rowSwap T i j = 1 := by
-  let S : Matrix R n n := rowSwap (1 : Matrix R n n) i j
+    (hT : ∃ Tinv : Matrix R n n, Tinv * T = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, Tinv' * rowSwap T i j = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowSwap (Matrix.identity (R := R) n) i j
   have hS : S * T = rowSwap T i j := by
-    simp [S, rowSwap_mul, one_mul]
-  have hSS : S * S = 1 := by
-    simp [S, rowSwap_mul, one_mul, rowSwap_rowSwap]
+    simp [S, rowSwap_mul, identity_mul]
+  have hSS : S * S = (Matrix.identity (R := R) n) := by
+    simp [S, rowSwap_mul, identity_mul, rowSwap_rowSwap]
   simpa [hS] using leftMul_left_inverse_preserve (S := S) (Sinv := S) (T := T) hSS hT
 
 /-- A row swap preserves existence of a right inverse for a row transform. -/
 theorem rowSwap_right_inverse_preserve [Lean.Grind.Ring R]
     (T : Matrix R n n) (i j : Fin n)
-    (hT : ∃ Tinv : Matrix R n n, T * Tinv = 1) :
-    ∃ Tinv' : Matrix R n n, rowSwap T i j * Tinv' = 1 := by
-  let S : Matrix R n n := rowSwap (1 : Matrix R n n) i j
+    (hT : ∃ Tinv : Matrix R n n, T * Tinv = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, rowSwap T i j * Tinv' = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowSwap (Matrix.identity (R := R) n) i j
   have hS : S * T = rowSwap T i j := by
-    simp [S, rowSwap_mul, one_mul]
-  have hSS : S * S = 1 := by
-    simp [S, rowSwap_mul, one_mul, rowSwap_rowSwap]
+    simp [S, rowSwap_mul, identity_mul]
+  have hSS : S * S = (Matrix.identity (R := R) n) := by
+    simp [S, rowSwap_mul, identity_mul, rowSwap_rowSwap]
   simpa [hS] using leftMul_right_inverse_preserve (S := S) (Sinv := S) (T := T) hSS hT
 
 /-- Scaling a row by a nonzero scalar preserves existence of a left inverse for
 a row transform. -/
 theorem rowScale_left_inverse_preserve [Lean.Grind.Field R]
     (T : Matrix R n n) (i : Fin n) {s : R} (hs : s ≠ 0)
-    (hT : ∃ Tinv : Matrix R n n, Tinv * T = 1) :
-    ∃ Tinv' : Matrix R n n, Tinv' * rowScale T i s = 1 := by
-  let S : Matrix R n n := rowScale (1 : Matrix R n n) i s
-  let Sinv : Matrix R n n := rowScale (1 : Matrix R n n) i s⁻¹
+    (hT : ∃ Tinv : Matrix R n n, Tinv * T = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, Tinv' * rowScale T i s = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowScale (Matrix.identity (R := R) n) i s
+  let Sinv : Matrix R n n := rowScale (Matrix.identity (R := R) n) i s⁻¹
   have hS : S * T = rowScale T i s := by
-    simp [S, rowScale_mul, one_mul]
-  have hSinvS : Sinv * S = 1 := by
-    simp [Sinv, S, rowScale_mul, one_mul, rowScale_rowScale_inv_left _ _ hs]
+    simp [S, rowScale_mul, identity_mul]
+  have hSinvS : Sinv * S = (Matrix.identity (R := R) n) := by
+    simp [Sinv, S, rowScale_mul, identity_mul, rowScale_rowScale_inv_left _ _ hs]
   simpa [hS] using leftMul_left_inverse_preserve (S := S) (Sinv := Sinv) (T := T) hSinvS hT
 
 /-- Scaling a row by a nonzero scalar preserves existence of a right inverse for
 a row transform. -/
 theorem rowScale_right_inverse_preserve [Lean.Grind.Field R]
     (T : Matrix R n n) (i : Fin n) {s : R} (hs : s ≠ 0)
-    (hT : ∃ Tinv : Matrix R n n, T * Tinv = 1) :
-    ∃ Tinv' : Matrix R n n, rowScale T i s * Tinv' = 1 := by
-  let S : Matrix R n n := rowScale (1 : Matrix R n n) i s
-  let Sinv : Matrix R n n := rowScale (1 : Matrix R n n) i s⁻¹
+    (hT : ∃ Tinv : Matrix R n n, T * Tinv = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, rowScale T i s * Tinv' = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowScale (Matrix.identity (R := R) n) i s
+  let Sinv : Matrix R n n := rowScale (Matrix.identity (R := R) n) i s⁻¹
   have hS : S * T = rowScale T i s := by
-    simp [S, rowScale_mul, one_mul]
-  have hSSinv : S * Sinv = 1 := by
-    simp [S, Sinv, rowScale_mul, one_mul, rowScale_rowScale_inv_right _ _ hs]
+    simp [S, rowScale_mul, identity_mul]
+  have hSSinv : S * Sinv = (Matrix.identity (R := R) n) := by
+    simp [S, Sinv, rowScale_mul, identity_mul, rowScale_rowScale_inv_right _ _ hs]
   simpa [hS] using leftMul_right_inverse_preserve (S := S) (Sinv := Sinv) (T := T) hSSinv hT
 
 /-- Adding a multiple of a distinct source row preserves existence of a left
 inverse for a row transform. -/
 theorem rowAdd_left_inverse_preserve [Lean.Grind.Ring R]
     (T : Matrix R n n) {src dst : Fin n} (s : R) (hsrcdst : src ≠ dst)
-    (hT : ∃ Tinv : Matrix R n n, Tinv * T = 1) :
-    ∃ Tinv' : Matrix R n n, Tinv' * rowAdd T src dst s = 1 := by
-  let S : Matrix R n n := rowAdd (1 : Matrix R n n) src dst s
-  let Sinv : Matrix R n n := rowAdd (1 : Matrix R n n) src dst (-s)
+    (hT : ∃ Tinv : Matrix R n n, Tinv * T = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, Tinv' * rowAdd T src dst s = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowAdd (Matrix.identity (R := R) n) src dst s
+  let Sinv : Matrix R n n := rowAdd (Matrix.identity (R := R) n) src dst (-s)
   have hS : S * T = rowAdd T src dst s := by
-    simp [S, rowAdd_mul, one_mul]
-  have hSinvS : Sinv * S = 1 := by
-    simp [Sinv, S, rowAdd_mul, one_mul, rowAdd_rowAdd_neg _ _ hsrcdst]
+    simp [S, rowAdd_mul, identity_mul]
+  have hSinvS : Sinv * S = (Matrix.identity (R := R) n) := by
+    simp [Sinv, S, rowAdd_mul, identity_mul, rowAdd_rowAdd_neg _ _ hsrcdst]
   simpa [hS] using leftMul_left_inverse_preserve (S := S) (Sinv := Sinv) (T := T) hSinvS hT
 
 /-- Adding a multiple of a distinct source row preserves existence of a right
 inverse for a row transform. -/
 theorem rowAdd_right_inverse_preserve [Lean.Grind.Ring R]
     (T : Matrix R n n) {src dst : Fin n} (s : R) (hsrcdst : src ≠ dst)
-    (hT : ∃ Tinv : Matrix R n n, T * Tinv = 1) :
-    ∃ Tinv' : Matrix R n n, rowAdd T src dst s * Tinv' = 1 := by
-  let S : Matrix R n n := rowAdd (1 : Matrix R n n) src dst s
-  let Sinv : Matrix R n n := rowAdd (1 : Matrix R n n) src dst (-s)
+    (hT : ∃ Tinv : Matrix R n n, T * Tinv = (Matrix.identity (R := R) n)) :
+    ∃ Tinv' : Matrix R n n, rowAdd T src dst s * Tinv' = (Matrix.identity (R := R) n) := by
+  let S : Matrix R n n := rowAdd (Matrix.identity (R := R) n) src dst s
+  let Sinv : Matrix R n n := rowAdd (Matrix.identity (R := R) n) src dst (-s)
   have hS : S * T = rowAdd T src dst s := by
-    simp [S, rowAdd_mul, one_mul]
-  have hSSinv : S * Sinv = 1 := by
-    simp [S, Sinv, rowAdd_mul, one_mul]
-    exact rowAdd_rowAdd_neg_left (1 : Matrix R n n) s hsrcdst
+    simp [S, rowAdd_mul, identity_mul]
+  have hSSinv : S * Sinv = (Matrix.identity (R := R) n) := by
+    simp [S, Sinv, rowAdd_mul, identity_mul]
+    exact rowAdd_rowAdd_neg_left (Matrix.identity (R := R) n) s hsrcdst
   simpa [hS] using leftMul_right_inverse_preserve (S := S) (Sinv := Sinv) (T := T) hSSinv hT
 
 /-- Multiplication by `A` commutes with the column-add operation on the right

--- a/HexRowReduce/Span.lean
+++ b/HexRowReduce/Span.lean
@@ -55,7 +55,7 @@ forward transport at the candidate witness. -/
 theorem rowCombination_transformInv_transpose [Lean.Grind.CommRing R]
     {M : Matrix R n m} {D : RowEchelonData R n m}
     (E : IsEchelonForm M D) {Tinv : Matrix R n n}
-    (hTinv : Tinv * D.transform = 1) (c : Vector R n) :
+    (hTinv : Tinv * D.transform = (Matrix.identity (R := R) n)) (c : Vector R n) :
     rowCombination D.echelon (Matrix.transpose Tinv * c) = rowCombination M c := by
   have hcompose :
       Matrix.transpose D.transform * (Matrix.transpose Tinv * c) = c := by
@@ -66,11 +66,11 @@ theorem rowCombination_transformInv_transpose [Lean.Grind.CommRing R]
               (B := Matrix.transpose Tinv) (v := c)).symm
       _ = Matrix.transpose (Tinv * D.transform) * c := by
             rw [← Matrix.transpose_mul_of_mul_comm]
-      _ = Matrix.transpose (1 : Matrix R n n) * c := by
+      _ = Matrix.transpose (Matrix.identity (R := R) n) * c := by
             rw [hTinv]
-      _ = (1 : Matrix R n n) * c := by
-            rw [Matrix.transpose_one]
-      _ = c := Matrix.one_mulVec c
+      _ = (Matrix.identity (R := R) n) * c := by
+            rw [Matrix.transpose_identity]
+      _ = c := Matrix.identity_mulVec c
   have hforward := E.rowCombination_transform_transpose (e := Matrix.transpose Tinv * c)
   rw [hcompose] at hforward
   exact hforward.symm

--- a/conformance/HexDeterminant/Conformance.lean
+++ b/conformance/HexDeterminant/Conformance.lean
@@ -52,7 +52,7 @@ private def pivotInt : Matrix Int 3 3 :=
     | 2, 1 => 6
     | _, _ => 0
 
-#guard Matrix.det (1 : Matrix Int 2 2) = 1
+#guard Matrix.det (Matrix.identity (R := Int) 2) = 1
 #guard Matrix.det zeroInt = 0
 #guard Matrix.det singularInt = 0
 #guard Matrix.det (Matrix.rowSwap pivotInt ⟨0, by decide⟩ ⟨1, by decide⟩) = -Matrix.det pivotInt
@@ -61,8 +61,8 @@ private def pivotInt : Matrix Int 3 3 :=
 
 /- Determinant row-operation proof-mode automation examples. -/
 
-example : Matrix.det (1 : Matrix Int 2 2) = 1 := by
-  grind
+example : Matrix.det (Matrix.identity (R := Int) 2) = 1 := by
+  exact Matrix.det_identity
 
 example (M : Matrix Int 3 3) (i j : Fin 3) (h : i ≠ j) :
     Matrix.det (Matrix.rowSwap M i j) = -Matrix.det M := by

--- a/conformance/HexLLL/Conformance.lean
+++ b/conformance/HexLLL/Conformance.lean
@@ -62,7 +62,7 @@ Covered edge cases:
 namespace Hex
 namespace LLLConformance
 
-private def identity8 : Matrix Int 8 8 := 1
+private def identity8 : Matrix Int 8 8 := Matrix.identity 8
 
 private def zero8 : Matrix Int 8 8 := 0
 
@@ -339,7 +339,7 @@ private def independentCheck (b : Matrix Int n m) : Bool :=
 #guard match LLLProvider.certifyFlat certInput2 (3/4 : Rat) malformedFlat2 with
   | some _ => false
   | none => true
-#guard !certCheck etaBoundary2 etaBoundary2 1 1 (3/4 : Rat) (11/20 : Rat)
+#guard !certCheck etaBoundary2 etaBoundary2 (Matrix.identity (R := Int) 2) (Matrix.identity (R := Int) 2) (3/4 : Rat) (11/20 : Rat)
 
 private def stateOf (b : Matrix Int n m) : LLLState n m :=
   let gs := GramSchmidt.Int.data b

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -87,8 +87,8 @@ private def spanVec : Vector Rat 3 :=
 #guard vecInt.normSq = 61
 #guard spanVec.normSq = 14
 #guard Matrix.gramMatrix baseInt = baseGramInt
-#guard (1 : Matrix Int 2 2) * baseInt = baseInt
-#guard baseInt * (1 : Matrix Int 2 2) = baseInt
+#guard (Matrix.identity (R := Int) 2) * baseInt = baseInt
+#guard baseInt * (Matrix.identity (R := Int) 2) = baseInt
 #guard Matrix.transpose (Matrix.transpose baseInt) = baseInt
 
 /-- info: { toArray := #[{ toArray := #[1, 3], size_toArray := _ }, { toArray := #[2, 4], size_toArray := _ }],
@@ -129,6 +129,6 @@ private def bigInt : Matrix Int 6 6 :=
   Matrix.ofFn fun i j => (min i.val j.val + 1 : Int)
 
 #guard Matrix.transpose (Matrix.transpose bigInt) = bigInt
-#guard (1 : Matrix Int 6 6) * bigInt = bigInt
+#guard (Matrix.identity (R := Int) 6) * bigInt = bigInt
 
 end Matrix

--- a/conformance/HexRowReduce/Conformance.lean
+++ b/conformance/HexRowReduce/Conformance.lean
@@ -110,7 +110,7 @@ private def emptyNullspace : Vector (Vector Rat 2) 0 :=
 #guard let D := Matrix.rowReduce zeroRat23; D.rank = 0
 #guard let D := Matrix.rowReduce zeroRat23; D.pivotCols = Vector.ofFn (fun i => nomatch i)
 #guard let D := Matrix.rowReduce fullRat22; D.rank = 2
-#guard let D := Matrix.rowReduce fullRat22; D.echelon = (1 : Matrix Rat 2 2)
+#guard let D := Matrix.rowReduce fullRat22; D.echelon = (Matrix.identity (R := Rat) 2)
 
 #guard Matrix.spanCoeffs dependentRat spanVec = some spanCoeffsWitness
 #guard Matrix.rowCombination dependentRat spanCoeffsWitness = spanVec


### PR DESCRIPTION
This PR makes the dimension arguments of `Hex.Matrix.identity` (`n`) and `Hex.Matrix.zero` (`n m`) explicit, and the value-type argument `R` of `Hex.Vector.unit` explicit, replacing the `(R := R)` workarounds at call sites with positional arguments. It removes the `One (Matrix R n n)` instance from `HexMatrix` and states the results that used the matrix literal `1` with `Matrix.identity` instead, renaming the lemmas to match: `getElem_one` to `getElem_identity`, `transpose_one` to `transpose_identity`, `one_mul` to `identity_mul`, `mul_one` to `mul_identity`, `one_mulVec` to `identity_mulVec`, `det_one` to `det_identity`, `gramMatrix_one` to `gramMatrix_identity`, `principalSubmatrix_one` to `principalSubmatrix_identity`, and `independent_one` to `independent_identity`.

The `One` instance moves to the `HexMatrixMathlib` bridge, where the Mathlib `Semiring`/`Ring`/`Algebra` structures transported onto `Hex.Matrix` need it. One conformance example (`det (Matrix.identity 2) = 1`) is proved with `exact Matrix.det_identity` rather than `grind`, which cannot bridge the `OfNat`-instance diamond between the ring-derived and native `Int` numerals at `reducible_and_instances` transparency.

The full library, the conformance `#guard` drivers, and the matrix bench drivers all build.

🤖 Prepared with Claude Code