### PR TITLE
refactor: rename matrix entry lemmas to the getElem_ convention

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -39,7 +39,7 @@ theorem deleteRowCol_setRow_self {R : Type u} {n : Nat}
   let jj : Fin n := ⟨j, hj⟩
   change (deleteRowCol (setRow M dst v) dst col)[ii][jj] =
     (deleteRowCol M dst col)[ii][jj]
-  rw [deleteRowCol_entry, deleteRowCol_entry]
+  rw [getElem_deleteRowCol, getElem_deleteRowCol]
   have hne : skipIndex dst ii ≠ dst := skipIndex_ne dst ii
   have hrow := setRow_row_ne M dst (skipIndex dst ii) v hne
   exact congrArg (fun row => row[skipIndex col jj]) hrow
@@ -296,7 +296,7 @@ private theorem columnTupleMatrix_eq_ofFn_ofFn
   show (columnTupleMatrix M cols)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
     (ofFn (fun r c => M[r][(Vector.ofFn cols)[c]]) : Matrix R n n)[
       (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix]
   unfold ofFn
   rw [vector_ofFn_getElem_fin, vector_ofFn_getElem_fin]
   exact congrArg (fun col : Fin n => M[(⟨r, hr⟩ : Fin n)][col])
@@ -335,7 +335,7 @@ private theorem mul_eq_columnSumMatrix_transpose
   let rr : Fin n := ⟨r, hr⟩
   let cc : Fin n := ⟨c, hc⟩
   show (M * N)[rr][cc] = (columnSumMatrix M N.transpose)[rr][cc]
-  rw [columnSumMatrix_entry]
+  rw [getElem_columnSumMatrix]
   change (Matrix.mul M N)[rr][cc] = _
   unfold Matrix.mul ofFn
   rw [vector_ofFn_getElem_fin, vector_ofFn_getElem_fin]

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -40,7 +40,7 @@ def columnTupleMatrix {R : Type u} {n m : Nat}
 
 /-- Entry `(r, c)` of the column-selected minor is the source entry
 `A[r][cols c]`. -/
-@[grind =] theorem columnTupleMatrix_entry {R : Type u} {n m : Nat}
+@[grind =] theorem getElem_columnTupleMatrix {R : Type u} {n m : Nat}
     (A : Matrix R n m) (cols : Fin n → Fin m) (r c : Fin n) :
     (columnTupleMatrix A cols)[r][c] = A[r][cols c] := by
   simp [columnTupleMatrix, ofFn]
@@ -63,13 +63,13 @@ Unattributed: the LHS `[r][c]` is not in simp-normal form (`Fin.getElem_fin`
 rewrites the `Fin` indices to `↑r`/`↑c`), and `grind =` rejects the pattern
 because the columns `s sigma` appear only under the `fun i => s[sigma[i]]`
 binder, so the LHS cannot instantiate them. Invoked explicitly via `rw`. -/
-theorem columnTupleMatrix_compose_perm_entry
+theorem getElem_columnTupleMatrix_compose_perm
     {R : Type u} {n m : Nat} (A : Matrix R n m)
     (s : Vector (Fin m) n) (sigma : Vector (Fin n) n)
     (r c : Fin n) :
     (columnTupleMatrix A (fun i => s[sigma[i]]))[r][c] =
       (columnTupleMatrix A (columnTupleVectorFn s))[r][sigma[c]] := by
-  rw [columnTupleMatrix_entry, columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact (congrArg (fun col : Fin m => A[r][col])
     (columnTupleVectorFn_apply s (sigma[c]))).symm
 
@@ -86,7 +86,7 @@ theorem columnTupleMatrix_compose_perm_eq_colPermute
       (ofFn fun r c =>
         (columnTupleMatrix A (columnTupleVectorFn s))[r][sigma[c]])[
           (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnTupleMatrix_compose_perm_entry]
+  rw [getElem_columnTupleMatrix_compose_perm]
   simp [Matrix.ofFn]
 
 /-- Specialization of the generic column-permutation determinant sign theorem
@@ -212,7 +212,7 @@ theorem det_columnTupleMatrix_eq_zero_of_col_eq
     det (columnTupleMatrix A cols) = 0 := by
   apply det_eq_zero_of_col_eq (columnTupleMatrix A cols) src dst h
   intro r
-  rw [columnTupleMatrix_entry, columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact congrArg (fun c : Fin m => A[r][c]) hcols
 
 /-- An ordered column-tuple minor with a non-injective selected-column map has
@@ -243,7 +243,7 @@ private def columnSumMatrixWithPrefix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[grind =] private theorem columnSumMatrixWithPrefix_entry
+@[grind =] private theorem getElem_columnSumMatrixWithPrefix
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithPrefix source coeff chosen)[r][j] =
@@ -274,7 +274,7 @@ private def columnSumMatrixWithSuffix
     else
       (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[grind =] private theorem columnSumMatrixWithSuffix_entry
+@[grind =] private theorem getElem_columnSumMatrixWithSuffix
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (chosen : List (Fin m)) (r j : Fin n) :
     (columnSumMatrixWithSuffix source coeff chosen)[r][j] =
@@ -293,7 +293,7 @@ private theorem columnSumMatrixWithSuffix_nil
   ext r hr c hc
   change (columnSumMatrixWithSuffix source coeff [])[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix source coeff)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnSumMatrixWithSuffix_entry, columnSumMatrix_entry,
+  rw [getElem_columnSumMatrixWithSuffix, getElem_columnSumMatrix,
     dif_neg (show ¬ n - ([] : List (Fin m)).length ≤ c by simp; omega)]
 
 private theorem columnSumMatrixWithSuffix_eq
@@ -305,7 +305,7 @@ private theorem columnSumMatrixWithSuffix_eq
   ext r hr c hc
   change (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnTupleMatrix source (fun j => chosen[j.val]'(by omega)))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnSumMatrixWithSuffix_entry, dif_pos (by omega : n - chosen.length ≤ c)]
+  rw [getElem_columnSumMatrixWithSuffix, dif_pos (by omega : n - chosen.length ≤ c)]
   simp [columnTupleMatrix, ofFn, hfull]
 
 /-- Replacing the rightmost sum column of the suffix-partial matrix with a fixed
@@ -324,7 +324,7 @@ private theorem setCol_columnSumMatrixWithSuffix_extend
     (columnSumMatrixWithSuffix source coeff (c :: chosen))[
       (⟨r, hr⟩ : Fin n)][(⟨k, hk2⟩ : Fin n)]
   rw [setCol_getElem]
-  simp only [columnSumMatrixWithSuffix_entry]
+  simp only [getElem_columnSumMatrixWithSuffix]
   have hccons_len : (c :: chosen).length = chosen.length + 1 := rfl
   by_cases hkd : (⟨k, hk2⟩ : Fin n) = (⟨n - chosen.length - 1, by omega⟩ : Fin n)
   · have hkeq : k = n - chosen.length - 1 := by
@@ -383,7 +383,7 @@ private theorem det_columnSumMatrixWithSuffix_expand
     change (setCol (columnSumMatrixWithSuffix source coeff chosen) dst _)[
         (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrixWithSuffix source coeff chosen)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-    rw [setCol_getElem, columnSumMatrixWithSuffix_entry]
+    rw [setCol_getElem, getElem_columnSumMatrixWithSuffix]
     by_cases hcd : (⟨c, hc⟩ : Fin n) = dst
     · rw [if_pos hcd, hcd]
       rw [dif_neg (show ¬ n - chosen.length ≤ dst.val by simp [dst]; omega)]
@@ -848,7 +848,7 @@ theorem det_gramMatrix_eq_sum_columnTuples
     ext r hr c hc
     change (gramMatrix A)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnSumMatrix A A)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-    rw [columnSumMatrix_entry]
+    rw [getElem_columnSumMatrix]
     simp [gramMatrix, ofFn, row, Hex.Vector.dotProduct]
     apply foldl_det_sum_congr
     intro k _hk

--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -340,7 +340,7 @@ def columnSumMatrix {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
   ofFn fun r j =>
     (List.finRange m).foldl (fun acc k => acc + coeff[j][k] * source[r][k]) 0
 
-@[grind =] private theorem columnSumMatrix_entry
+@[grind =] private theorem getElem_columnSumMatrix
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (r j : Fin n) :
     (columnSumMatrix source coeff)[r][j] =
@@ -365,7 +365,7 @@ private theorem setCol_columnSumMatrix_self
   by_cases hcol : (⟨c, hc⟩ : Fin n) = dst
   · subst dst
     rw [if_pos rfl]
-    exact (columnSumMatrix_entry source coeff (⟨r, hr⟩ : Fin n) (⟨c, hc⟩ : Fin n)).symm
+    exact (getElem_columnSumMatrix source coeff (⟨r, hr⟩ : Fin n) (⟨c, hc⟩ : Fin n)).symm
   · simp [hcol]
 
 private theorem det_columnSumMatrix_expand_column
@@ -394,7 +394,7 @@ private def columnChoiceMatrix {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     | some k => source[r][k]
     | none => (List.finRange m).foldl (fun acc k => acc + coeff[c][k] * source[r][k]) 0
 
-@[grind =] private theorem columnChoiceMatrix_entry
+@[grind =] private theorem getElem_columnChoiceMatrix
     {R : Type u} [Lean.Grind.CommRing R] {n m : Nat}
     (source coeff : Matrix R n m) (choices : Fin n → Option (Fin m)) (r c : Fin n) :
     (columnChoiceMatrix source coeff choices)[r][c] =

--- a/HexDeterminant/Index.lean
+++ b/HexDeterminant/Index.lean
@@ -859,7 +859,7 @@ private theorem detProduct_insertAt_general {R : Type u} [Lean.Grind.CommRing R]
       simp [Vector.getElem_map]
     have hRHS_col :
         skipIndex (Fin.last n) v[r'] = (v[r']).castSucc := skipIndex_last v[r']
-    simp only [deleteRowCol_entry, hLHS_col, hRHS_col]
+    simp only [getElem_deleteRowCol, hLHS_col, hRHS_col]
 
 /-- Leibniz-term equation for an arbitrary insertion position. -/
 private theorem detTerm_insertAt_general {R : Type u} [Lean.Grind.CommRing R] {n : Nat}

--- a/HexDeterminant/Laplace.lean
+++ b/HexDeterminant/Laplace.lean
@@ -299,7 +299,7 @@ theorem det_eq_foldl_laplace_col
           let jj : Fin n := ⟨j, hj⟩
           change (deleteRowCol C row (Fin.last n))[ii][jj] =
             (deleteRowCol M row col)[ii][jj]
-          rw [deleteRowCol_entry, deleteRowCol_entry]
+          rw [getElem_deleteRowCol, getElem_deleteRowCol]
           rw [show C[skipIndex row ii][skipIndex (Fin.last n) jj] =
               C[skipIndex row ii][jj.castSucc] by
             exact congrArg (fun c => C[skipIndex row ii][c]) (skipIndex_last jj)]

--- a/HexDeterminant/Minor.lean
+++ b/HexDeterminant/Minor.lean
@@ -97,7 +97,7 @@ def deleteRowCol {R : Type u} {n : Nat} (M : Matrix R (n + 1) (n + 1))
 
 /-- Entries of a deleted-row/deleted-column minor are the corresponding source
 entries at the skipped row and column indices. -/
-@[grind =] theorem deleteRowCol_entry {R : Type u} {n : Nat}
+@[grind =] theorem getElem_deleteRowCol {R : Type u} {n : Nat}
     (M : Matrix R (n + 1) (n + 1)) (row col : Fin (n + 1)) (i j : Fin n) :
     (deleteRowCol M row col)[i][j] = M[skipIndex row i][skipIndex col j] := by
   simp [deleteRowCol, ofFn]
@@ -113,7 +113,7 @@ This is the minor normalization used by bottom-right cofactor expansion. -/
   let jj : Fin n := ⟨j, hj⟩
   change (deleteRowCol M (Fin.last n) (Fin.last n))[ii][jj] =
     (principalSubmatrix M n (Nat.le_succ n))[ii][jj]
-  rw [deleteRowCol_entry]
+  rw [getElem_deleteRowCol]
   simp [principalSubmatrix, ofFn]
 
 /-- Deleting row `row` and column `col` after transposing is the transpose of

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -137,7 +137,7 @@ def nMatrix {R : Type u} {n : Nat}
 
 /-- Entry `(i, j)` of the two-row-deleted minor `nMatrix B p q hpq` is the source
 entry `B[skipIndex2 p q hpq i][j]`. -/
-@[grind =] theorem nMatrix_entry {R : Type u} {n : Nat}
+@[grind =] theorem getElem_nMatrix {R : Type u} {n : Nat}
     (B : Matrix R (n + 2) n) (p q : Fin (n + 2)) (hpq : p.val < q.val)
     (i : Fin n) (j : Fin n) :
     (nMatrix B p q hpq)[i][j] = B[skipIndex2 p q hpq i][j] := by
@@ -157,7 +157,7 @@ ordered `nMatrix` row sequence with one row displaced downward. Each
 "row-move" is realised as a chain of adjacent `rowSwap`s; the determinant
 picks up `(-1) ^ k` for a `k`-step move. The four row-content lemmas
 identify the rows of the moved matrix so consumers can pair them with
-`nMatrix_entry` / `skipIndex2` value lemmas. -/
+`getElem_nMatrix` / `skipIndex2` value lemmas. -/
 
 /-- Move the row at position `src + k` of `M` to position `src` by `k`
 adjacent row swaps. The rows previously at positions `src, …, src + k - 1`
@@ -359,7 +359,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_first
         setRow_row_ne (nMatrix B a b hab) s ii B[a] hii_ne_s]
     let jj : Fin n := ⟨j, hj⟩
     show (nMatrix B a b hab)[ii][jj] = (nMatrix B b t hbt)[ii][jj]
-    rw [nMatrix_entry, nMatrix_entry]
+    rw [getElem_nMatrix, getElem_nMatrix]
     have hii_lt_b : ii.val < b.val := Nat.lt_trans h_below hab
     have hidx : skipIndex2 a b hab ii = skipIndex2 b t hbt ii := by
       apply Fin.ext
@@ -388,7 +388,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_first
       rw [h_row_eq]
       let jj : Fin n := ⟨j, hj⟩
       show B[a][jj] = (nMatrix B b t hbt)[ii][jj]
-      rw [nMatrix_entry]
+      rw [getElem_nMatrix]
       have hii_lt_b : ii.val < b.val := by rw [h_eq]; exact hab
       have hidx : skipIndex2 b t hbt ii = a := by
         apply Fin.ext
@@ -409,7 +409,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_first
         rw [setRow_row_ne (nMatrix B a b hab) s ii B[a] hii_ne_s]
         let jj : Fin n := ⟨j, hj⟩
         show (nMatrix B a b hab)[ii][jj] = (nMatrix B b t hbt)[ii][jj]
-        rw [nMatrix_entry, nMatrix_entry]
+        rw [getElem_nMatrix, getElem_nMatrix]
         have h_not_lt_a : ¬ ii.val < a.val := h_below
         have h_not_between_lhs : ¬ ii.val + 1 < b.val := by omega
         have h_not_lt_b_rhs : ¬ ii.val < b.val := by omega
@@ -439,7 +439,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_first
         rw [setRow_row_ne (nMatrix B a b hab) s j_minus B[a] hj_ne_s]
         let jj : Fin n := ⟨j, hj⟩
         show (nMatrix B a b hab)[j_minus][jj] = (nMatrix B b t hbt)[ii][jj]
-        rw [nMatrix_entry, nMatrix_entry]
+        rw [getElem_nMatrix, getElem_nMatrix]
         have h_not_lt_a : ¬ j_minus.val < a.val := by
           show ¬ ii.val - 1 < a.val; omega
         by_cases h_below_b : ii.val < b.val
@@ -497,7 +497,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_second
         setRow_row_ne (nMatrix B a b hab) s ii B[b] hii_ne_s]
     let jj : Fin n := ⟨j, hj⟩
     show (nMatrix B a b hab)[ii][jj] = (nMatrix B a t hat)[ii][jj]
-    rw [nMatrix_entry, nMatrix_entry]
+    rw [getElem_nMatrix, getElem_nMatrix]
     by_cases h_lt_a : ii.val < a.val
     · have hidx : skipIndex2 a b hab ii = skipIndex2 a t hat ii := by
         apply Fin.ext
@@ -533,7 +533,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_second
       rw [h_row_eq]
       let jj : Fin n := ⟨j, hj⟩
       show B[b][jj] = (nMatrix B a t hat)[ii][jj]
-      rw [nMatrix_entry]
+      rw [getElem_nMatrix]
       have h_not_lt_a : ¬ ii.val < a.val := by
         have : a.val ≤ b.val - 1 := by omega
         rw [h_eq]; omega
@@ -558,7 +558,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_second
         rw [setRow_row_ne (nMatrix B a b hab) s ii B[b] hii_ne_s]
         let jj : Fin n := ⟨j, hj⟩
         show (nMatrix B a b hab)[ii][jj] = (nMatrix B a t hat)[ii][jj]
-        rw [nMatrix_entry, nMatrix_entry]
+        rw [getElem_nMatrix, getElem_nMatrix]
         have h_not_lt_a : ¬ ii.val < a.val := by omega
         have h_not_between_lhs : ¬ ii.val + 1 < b.val := by omega
         have h_not_between_rhs : ¬ ii.val + 1 < t.val := by omega
@@ -587,7 +587,7 @@ private theorem rowMoveUp_setRow_nMatrix_replace_second
         rw [setRow_row_ne (nMatrix B a b hab) s j_minus B[b] hj_ne_s]
         let jj : Fin n := ⟨j, hj⟩
         show (nMatrix B a b hab)[j_minus][jj] = (nMatrix B a t hat)[ii][jj]
-        rw [nMatrix_entry, nMatrix_entry]
+        rw [getElem_nMatrix, getElem_nMatrix]
         have h_not_lt_a_lhs : ¬ j_minus.val < a.val := by
           show ¬ ii.val - 1 < a.val
           have : a.val ≤ b.val - 1 := by omega
@@ -947,7 +947,7 @@ theorem deleteRowCol_twoColMatrix_last_eq_mMatrix {R : Type u} {n : Nat}
   let jj : Fin (n + 1) := ⟨j, hj⟩
   change (deleteRowCol (twoColMatrix B u v) p (Fin.last (n + 1)))[ii][jj] =
     (mMatrix B u p)[ii][jj]
-  rw [deleteRowCol_entry]
+  rw [getElem_deleteRowCol]
   have hcol :
       (skipIndex (Fin.last (n + 1)) jj).val = jj.val := by
     rw [skipIndex_last]
@@ -1283,7 +1283,7 @@ theorem deleteRowCol_mMatrix_at_q_minus_one_eq_nMatrix_of_lt
   change (deleteRowCol (mMatrix B v p)
         (⟨q.val - 1, by have := q.isLt; omega⟩ : Fin (n + 1)) (Fin.last n))[ii][jj] =
     (nMatrix B p q hpq)[ii][jj]
-  rw [deleteRowCol_entry, nMatrix_entry]
+  rw [getElem_deleteRowCol, getElem_nMatrix]
   -- The column index: skipIndex (Fin.last n) jj = jj.castSucc; its val = jj.val < n.
   have hjj_castSucc : (skipIndex (Fin.last n) jj).val = jj.val := by
     show (skipIndex (Fin.last n) jj).val = jj.val
@@ -1375,7 +1375,7 @@ theorem deleteRowCol_mMatrix_at_q_eq_nMatrix_of_gt
   change (deleteRowCol (mMatrix B v p)
         (⟨q.val, by have := p.isLt; omega⟩ : Fin (n + 1)) (Fin.last n))[ii][jj] =
     (nMatrix B q p hqp)[ii][jj]
-  rw [deleteRowCol_entry, nMatrix_entry]
+  rw [getElem_deleteRowCol, getElem_nMatrix]
   have hjj_castSucc : (skipIndex (Fin.last n) jj).val = jj.val := by
     show (skipIndex (Fin.last n) jj).val = jj.val
     rw [skipIndex_last]

--- a/HexDeterminant/Selection.lean
+++ b/HexDeterminant/Selection.lean
@@ -601,13 +601,13 @@ sorted choice `sel` through the permutation `perm`. -/
 /-- Selecting columns via the reconstructed tuple equals selecting via `sel`
 with the column index permuted by `perm`: entry `(r, c)` agrees with entry
 `(r, perm[c])` of the `sel`-selected minor. -/
-@[grind =] theorem columnTupleMatrix_reconstructInjTuple_entry
+@[grind =] theorem getElem_columnTupleMatrix_reconstructInjTuple
     {R : Type u} {n m : Nat} (A : Matrix R n m)
     (sel : Vector (Fin m) n) (perm : Vector (Fin n) n)
     (r c : Fin n) :
     (columnTupleMatrix A (columnTupleVectorFn (reconstructInjTuple sel perm)))[r][c] =
       (columnTupleMatrix A (columnTupleVectorFn sel))[r][perm[c]] := by
-  rw [columnTupleMatrix_entry, columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[r][col])
     (reconstructInjTuple_getElem sel perm c)
 
@@ -621,7 +621,7 @@ private theorem columnTupleMatrix_reconstructInjTuple_eq
     (columnTupleMatrix A (columnTupleVectorFn (reconstructInjTuple sel perm)))[
         (⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)] =
       (columnTupleMatrix A (fun i => sel[perm[i]]))[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
-  rw [columnTupleMatrix_entry, columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix, getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[(⟨r, hr⟩ : Fin n)][col])
     (reconstructInjTuple_getElem sel perm (⟨c, hc⟩ : Fin n))
 
@@ -635,7 +635,7 @@ theorem columnTupleCoeff_reconstructInjTuple
   unfold columnTupleCoeff detProduct
   apply foldl_det_product_congr
   intro i _hmem
-  rw [columnTupleMatrix_entry]
+  rw [getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[i][col])
     (reconstructInjTuple_getElem sel perm i)
 
@@ -1138,7 +1138,7 @@ def firstColumns (k n : Nat) (hk : k ≤ n) : Vector (Fin n) k :=
 
 /-- The `i`-th entry of the first-`k`-columns selection is the index `i` itself,
 embedded into `Fin n`. -/
-@[grind =] theorem firstColumns_entry (k n : Nat) (hk : k ≤ n) (i : Fin k) :
+@[grind =] theorem getElem_firstColumns (k n : Nat) (hk : k ≤ n) (i : Fin k) :
     (firstColumns k n hk)[i] = (⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩ : Fin n) := by
   simp [firstColumns]
 

--- a/HexDeterminantMathlib/CorePlucker.lean
+++ b/HexDeterminantMathlib/CorePlucker.lean
@@ -162,7 +162,7 @@ private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
         Hex.Matrix.setRow_row_ne _ r2 i B[p1] hir2]
     show (Hex.Matrix.nMatrix B p1 q h1q)[i][j] =
       (Hex.Matrix.nMatrix B p2 p3 h23)[σ i][j]
-    rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+    rw [Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
     apply B_entry_congr; apply Fin.ext
     rw [Hex.Matrix.skipIndex2_val_of_lt_p p1 q h1q i h_below_p1,
         Hex.Matrix.skipIndex2_val_of_lt_p p2 p3 h23 (σ i)
@@ -189,7 +189,7 @@ private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
         rw [hσ_apply _, h_cb_eq]
         exact OrderedFourShift.cycleAhead_val_top p1.val m1 hm1 r2 h_r2_top
       show B[p1][j] = (Hex.Matrix.nMatrix B p2 p3 h23)[σ r2][j]
-      rw [Hex.Matrix.nMatrix_entry]
+      rw [Hex.Matrix.getElem_nMatrix]
       apply B_entry_congr; apply Fin.ext
       show p1.val = (Hex.Matrix.skipIndex2 p2 p3 h23 (σ r2)).val
       have h_σ_lt : (σ r2).val < p2.val := by rw [hσ_val]; exact h12
@@ -216,7 +216,7 @@ private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
           rw [hσ_apply _, OrderedFourShift.cycleAhead_val_above p1.val m1 hm1 _ h_above]
           exact h_cb_q2
         show B[q][j] = (Hex.Matrix.nMatrix B p2 p3 h23)[σ r3][j]
-        rw [Hex.Matrix.nMatrix_entry]
+        rw [Hex.Matrix.getElem_nMatrix]
         apply B_entry_congr; apply Fin.ext
         show q.val = (Hex.Matrix.skipIndex2 p2 p3 h23 (σ r3)).val
         have h_not_lt : ¬ (σ r3).val < p2.val := by rw [hσ_val]; omega
@@ -236,7 +236,7 @@ private theorem matrixEquiv_double_setRow_eq_submatrix_nMatrix
             Hex.Matrix.setRow_row_ne _ r2 i B[p1] hir2]
         show (Hex.Matrix.nMatrix B p1 q h1q)[i][j] =
           (Hex.Matrix.nMatrix B p2 p3 h23)[σ i][j]
-        rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+        rw [Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
         -- Split on where i.val sits relative to the cycle ranges.
         by_cases h_below_p2 : i.val < p2.val
         · -- Case D: p1 ≤ i.val < p2 - 1. cycleA "in", cycleB fixes. σ(i).val = i.val + 1.

--- a/HexDeterminantMathlib/CoreTransport.lean
+++ b/HexDeterminantMathlib/CoreTransport.lean
@@ -340,7 +340,7 @@ theorem matrixEquiv_deleteRowCol
   ext i j
   change (Hex.Matrix.deleteRowCol M row col)[i][j] =
     M[Hex.Matrix.skipIndex row i][Hex.Matrix.skipIndex col j]
-  rw [Hex.Matrix.deleteRowCol_entry]
+  rw [Hex.Matrix.getElem_deleteRowCol]
 
 private theorem matrixEquiv_deleteRowCol_zero_zero
     (M : Hex.Matrix R (n + 2) (n + 2)) :
@@ -714,7 +714,7 @@ theorem nMatrix_ordered_four_row_p2 {R : Type u} {n : Nat}
   change (Hex.Matrix.nMatrix B p1 q
       (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)))[
         (⟨p2.val - 1, by have := q.isLt; omega⟩ : Fin n)][jj] = B[p2][jj]
-  rw [Hex.Matrix.nMatrix_entry]
+  rw [Hex.Matrix.getElem_nMatrix]
   have hrow := skipIndex2_ordered_four_row_p2 p1 p2 p3 q h12 h23 h3q
   simp [hrow]
 
@@ -730,7 +730,7 @@ theorem nMatrix_ordered_four_row_p3 {R : Type u} {n : Nat}
   change (Hex.Matrix.nMatrix B p1 q
       (Nat.lt_trans h12 (Nat.lt_trans h23 h3q)))[
         (⟨p3.val - 1, by have := q.isLt; omega⟩ : Fin n)][jj] = B[p3][jj]
-  rw [Hex.Matrix.nMatrix_entry]
+  rw [Hex.Matrix.getElem_nMatrix]
   have hrow := skipIndex2_ordered_four_row_p3 p1 p2 p3 q h12 h23 h3q
   simp [hrow]
 
@@ -773,7 +773,7 @@ theorem nMatrix_ordered_four_p1_p2_row_q {R : Type u} {n : Nat}
   let jj : Fin (n + 1) := ⟨j, hj⟩
   change (Hex.Matrix.nMatrix B p1 p2 h12)[
         (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))][jj] = B[q][jj]
-  rw [Hex.Matrix.nMatrix_entry]
+  rw [Hex.Matrix.getElem_nMatrix]
   have hrow := skipIndex2_ordered_four_p1_p2_row_q p1 p2 p3 q h12 h23 h3q
   simp [hrow]
 
@@ -788,7 +788,7 @@ theorem nMatrix_ordered_four_p1_p3_row_q {R : Type u} {n : Nat}
   let jj : Fin (n + 1) := ⟨j, hj⟩
   change (Hex.Matrix.nMatrix B p1 p3 (Nat.lt_trans h12 h23))[
         (⟨q.val - 2, by have := q.isLt; omega⟩ : Fin (n + 1))][jj] = B[q][jj]
-  rw [Hex.Matrix.nMatrix_entry]
+  rw [Hex.Matrix.getElem_nMatrix]
   have hrow := skipIndex2_ordered_four_p1_p3_row_q p1 p2 p3 q h12 h23 h3q
   simp [hrow]
 
@@ -1120,7 +1120,7 @@ private theorem matrixEquiv_setRow_p1_eq_submatrix_nMatrix
     rw [Hex.Matrix.setRow_row_ne M r i B[p1] hir]
     show (Hex.Matrix.nMatrix B p1 q h1q)[i][j] =
       (Hex.Matrix.nMatrix B p_t q htq)[σ i][j]
-    rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+    rw [Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
     apply B_entry_congr
     apply Fin.ext
     rw [Hex.Matrix.skipIndex2_val_of_lt_p p1 q h1q i h_below,
@@ -1143,7 +1143,7 @@ private theorem matrixEquiv_setRow_p1_eq_submatrix_nMatrix
       rw [Hex.Matrix.setRow_row_ne M r i B[p1] hir]
       show (Hex.Matrix.nMatrix B p1 q h1q)[i][j] =
         (Hex.Matrix.nMatrix B p_t q htq)[σ i][j]
-      rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+      rw [Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
       apply B_entry_congr
       apply Fin.ext
       have h_not_lt_pt_for_σi : ¬ (σ i).val < p_t.val := by
@@ -1179,7 +1179,7 @@ private theorem matrixEquiv_setRow_p1_eq_submatrix_nMatrix
           omega
         have hσ_val : (σ r).val = p1.val :=
           OrderedFourShift.cycleAhead_val_top p1.val m hm_bound r h_r_at_top
-        rw [Hex.Matrix.nMatrix_entry]
+        rw [Hex.Matrix.getElem_nMatrix]
         apply B_entry_congr
         apply Fin.ext
         show p1.val = (Hex.Matrix.skipIndex2 p_t q htq (σ r)).val
@@ -1201,7 +1201,7 @@ private theorem matrixEquiv_setRow_p1_eq_submatrix_nMatrix
         rw [Hex.Matrix.setRow_row_ne M r i B[p1] hir]
         show (Hex.Matrix.nMatrix B p1 q h1q)[i][j] =
           (Hex.Matrix.nMatrix B p_t q htq)[σ i][j]
-        rw [Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+        rw [Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
         apply B_entry_congr
         apply Fin.ext
         have h_not_lt_p1 : ¬ i.val < p1.val := by
@@ -1323,7 +1323,7 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
       rw [hr_val, hσ_val] at hv
       omega
     rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
-      Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+      Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
     apply B_entry_congr
     apply Fin.ext
     by_cases hi1 : i.val < p1.val
@@ -1346,7 +1346,7 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
         rw [hr_val, hσ_val] at hv
         omega
       rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
-        Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+        Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
       apply B_entry_congr
       apply Fin.ext
       have hi_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -1366,7 +1366,7 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
           rw [hσ_val, hr_val, ha_val]
         have hrow : (Hex.Matrix.setRow M r B[q])[σ i] = B[q] := by
           simpa [hσ_eq_r] using Hex.Matrix.setRow_get_self M r B[q]
-        rw [hrow, Hex.Matrix.nMatrix_entry]
+        rw [hrow, Hex.Matrix.getElem_nMatrix]
         apply B_entry_congr
         apply Fin.ext
         have hi_not_lt_p1 : ¬ i.val < p1.val := by omega
@@ -1382,7 +1382,7 @@ private theorem matrixEquiv_nMatrix_p1_pt_eq_submatrix_setRow_q
           rw [hr_val, hσ_val] at hv
           omega
         rw [Hex.Matrix.setRow_row_ne M r (σ i) B[q] hσ_ne_r,
-          Hex.Matrix.nMatrix_entry, Hex.Matrix.nMatrix_entry]
+          Hex.Matrix.getElem_nMatrix, Hex.Matrix.getElem_nMatrix]
         apply B_entry_congr
         apply Fin.ext
         have hi_not_lt_p1 : ¬ i.val < p1.val := by omega

--- a/HexRowReduce/RREF/Loop.lean
+++ b/HexRowReduce/RREF/Loop.lean
@@ -80,7 +80,7 @@ private theorem rrefCanonicalInvariant_pivot_step
   have hpivotVal_ne : pivotVal ≠ 0 := by
     have hentry : pivotVal = state.echelon[pivot][colFin] := by
       simpa [pivotVal, swappedEchelon] using
-        rowSwap_target_pivot_entry state.echelon target pivot colFin
+        getElem_rowSwap_target_pivot state.echelon target pivot colFin
     rw [hentry]
     exact findPivot?_some_nonzero state.echelon colFin hpivot
   -- Step A: for each OLD pivot index `i`, canonical column is preserved by
@@ -451,7 +451,7 @@ private theorem eliminateColumn_foldl_other_column
               if coeff = 0 then s
               else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff)).1[pivotRow][k]
             = 0 := by
-        rw [eliminateColumn_step_pivotRow_entry s pivotRow x col k]
+        rw [eliminateColumn_step_pivotRow_unchanged s pivotRow x col k]
         exact hs
       rw [ih _ r hstep_pivot]
       by_cases hxp : x = pivotRow
@@ -670,7 +670,7 @@ private theorem rrefLoop_left_inverse_preserve (col fuel : Nat)
                 have hpivotNonzero := findPivot?_some_nonzero state.echelon colFin hpivot
                 have hentry : pivotVal = state.echelon[pivot][colFin] := by
                   simpa [pivotVal, swappedEchelon] using
-                    (rowSwap_target_pivot_entry state.echelon target pivot colFin)
+                    (getElem_rowSwap_target_pivot state.echelon target pivot colFin)
                 simpa [hentry] using hpivotNonzero
               have hscale :
                   ∃ Tinv : Matrix R n n, Tinv * scaledTransform = 1 :=
@@ -722,7 +722,7 @@ private theorem rrefLoop_right_inverse_preserve (col fuel : Nat)
                 have hpivotNonzero := findPivot?_some_nonzero state.echelon colFin hpivot
                 have hentry : pivotVal = state.echelon[pivot][colFin] := by
                   simpa [pivotVal, swappedEchelon] using
-                    (rowSwap_target_pivot_entry state.echelon target pivot colFin)
+                    (getElem_rowSwap_target_pivot state.echelon target pivot colFin)
                 simpa [hentry] using hpivotNonzero
               have hscale :
                   ∃ Tinv : Matrix R n n, scaledTransform * Tinv = 1 :=

--- a/HexRowReduce/RREF/Pivot.lean
+++ b/HexRowReduce/RREF/Pivot.lean
@@ -244,7 +244,7 @@ private theorem rowAdd_get_other (M : Matrix R n m) (src dst : Fin n) (c : R)
   simpa [rowAdd] using congrArg (fun row => row[k]) hrow
 
 /-- One step of `eliminateColumn`'s fold preserves the entry at the pivot row. -/
-private theorem eliminateColumn_step_pivotRow_entry
+private theorem eliminateColumn_step_pivotRow_unchanged
     (s : Matrix R n m × Matrix R n n) (pivotRow x : Fin n)
     (col : Fin m) (k : Fin m) :
     (if _h : x = pivotRow then s
@@ -263,7 +263,7 @@ private theorem eliminateColumn_step_pivotRow_entry
 
 /-- One step of `eliminateColumn`'s fold preserves the entry at any row other
 than `x` (the row currently being processed) at column `col`. -/
-private theorem eliminateColumn_step_other_entry
+private theorem eliminateColumn_step_other_unchanged
     (s : Matrix R n m × Matrix R n n) (pivotRow x : Fin n)
     (col : Fin m) {r : Fin n} (hrx : r ≠ x) :
     (if _h : x = pivotRow then s
@@ -324,7 +324,7 @@ private theorem eliminateColumn_foldl_pivotRow
       intro s
       simp only [List.foldl_cons]
       rw [ih]
-      exact eliminateColumn_step_pivotRow_entry s pivotRow x col k
+      exact eliminateColumn_step_pivotRow_unchanged s pivotRow x col k
 
 /-- Rows outside the fold's processed list are unchanged at column `col`. -/
 private theorem eliminateColumn_foldl_outside
@@ -348,7 +348,7 @@ private theorem eliminateColumn_foldl_outside
       have hrtail : r ∉ xs := fun h => hnotin (List.mem_cons.mpr (Or.inr h))
       simp only [List.foldl_cons]
       rw [ih _ r hrtail]
-      exact eliminateColumn_step_other_entry s pivotRow x col hrx
+      exact eliminateColumn_step_other_unchanged s pivotRow x col hrx
 
 /-- The whole pivot row is unchanged by `eliminateColumn` at column `k`. -/
 private theorem eliminateColumn_pivotRow (M : Matrix R n m) (T : Matrix R n n)
@@ -397,7 +397,7 @@ private theorem eliminateColumn_zero (M : Matrix R n m) (T : Matrix R n n)
                 if coeff = 0 then s
                 else (rowAdd s.1 pivotRow x coeff, rowAdd s.2 pivotRow x coeff))).1[pivotRow][col]
               = (1 : R) := by
-          rw [eliminateColumn_step_pivotRow_entry s pivotRow x col col]
+          rw [eliminateColumn_step_pivotRow_unchanged s pivotRow x col col]
           exact hs
         exact ih _ hpivot_step hrtail (List.nodup_cons.mp hnodup).2
 
@@ -582,7 +582,7 @@ private theorem eliminateColumn_right_inverse_preserve
 omit [Lean.Grind.Field R] [DecidableEq R] in
 /-- Swapping the current row with the discovered pivot moves the nonzero pivot
 entry into the target row. -/
-private theorem rowSwap_target_pivot_entry
+private theorem getElem_rowSwap_target_pivot
     (E : Matrix R n m) (target pivot : Fin n) (col : Fin m) :
     (rowSwap E target pivot)[target][col] = E[pivot][col] := by
   rw [rowSwap_getElem]


### PR DESCRIPTION
This PR renames the `(op …)[i] = …` accessor lemmas from the `op_entry` form to Lean's `getElem_op` convention (matching `getElem_map`, `getElem_set`), for the lemmas that are genuine getElem accessors of a named operation: `columnTupleMatrix_entry`, `columnSumMatrix_entry`, `columnChoiceMatrix_entry`, `columnSumMatrixWithPrefix_entry`, `columnSumMatrixWithSuffix_entry`, `columnTupleMatrix_compose_perm_entry`, `columnTupleMatrix_reconstructInjTuple_entry`, `nMatrix_entry`, `deleteRowCol_entry`, `firstColumns_entry`, and `rowSwap_target_pivot_entry` become their `getElem_…` forms.

The two `eliminateColumn`-fold-step lemmas index an inline `dite`, not a named constructor, and sit beside `eliminateColumn_step_zero_at_x`; they are renamed into that descriptive family instead, as `eliminateColumn_step_pivotRow_unchanged` and `eliminateColumn_step_other_unchanged`. Three further `_entry` lemmas are left untouched because they are characterization/bridge lemmas rather than getElem accessors: `bareissGramCanonicalCoeff_eq_augmentedGram_entry`, `pivot_column_entry`, and `nullspace_get_free_entry`.

Follow-up to https://github.com/kim-em/hex-dev/pull/8427 ("refactor: rename matrix slicers and drop the leadingSubmatrix wrapper").

🤖 Prepared with Claude Code