### PR TITLE
refactor: use Vector.modify for the in-place row operations

### DIFF
--- a/HexDeterminant/Index.lean
+++ b/HexDeterminant/Index.lean
@@ -1143,20 +1143,8 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
 
 private theorem rowScale_get {R : Type u} [Mul R] {n m : Nat}
     (M : Matrix R n m) (i r : Fin n) (c : R) (k : Fin m) :
-    (rowScale M i c)[r][k] = if r = i then c * M[i][k] else M[r][k] := by
-  by_cases h : r = i
-  · subst r
-    simp [rowScale]
-  · simp [rowScale, h]
-    have hval : i.val ≠ r.val := by
-      intro hval
-      exact h (Fin.ext hval.symm)
-    have hrow :
-        (M.set i (Vector.ofFn fun k => c * M[i][k]))[r] = M[r] := by
-      exact
-        (Vector.getElem_set_ne (xs := M) (x := Vector.ofFn fun k => c * M[i][k])
-          i.isLt r.isLt hval)
-    simpa [rowScale] using congrArg (fun row => row[k]) hrow
+    (rowScale M i c)[r][k] = if r = i then c * M[i][k] else M[r][k] :=
+  getElem_rowScale M i r c k
 
 private theorem detProduct_rowScale {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (i : Fin n) (c : R) (perm : Vector (Fin n) n) :

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -1881,21 +1881,8 @@ private def rowAddDuplicate {R : Type u} {n : Nat}
 private theorem rowAdd_get {R : Type u} [Mul R] [Add R] {n : Nat}
     (M : Matrix R n n) (src dst r : Fin n) (c : R) (k : Fin n) :
     (rowAdd M src dst c)[r][k] =
-      if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
-  by_cases h : r = dst
-  · subst r
-    simp [rowAdd]
-  · simp [rowAdd, h]
-    have hval : dst.val ≠ r.val := by
-      intro hval
-      exact h (Fin.ext hval.symm)
-    have hrow :
-        (M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]))[r] = M[r] := by
-      exact
-        (Vector.getElem_set_ne
-          (xs := M) (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
-          dst.isLt r.isLt hval)
-    simpa [rowAdd] using congrArg (fun row => row[k]) hrow
+      if r = dst then M[dst][k] + c * M[src][k] else M[r][k] :=
+  getElem_rowAdd M src dst r c k
 
 /-- Entrywise value of `rowAddDuplicate M src dst`: row `dst` reads from row
 `src`, every other row is left unchanged. -/

--- a/HexGramSchmidt/Basic/IntCast.lean
+++ b/HexGramSchmidt/Basic/IntCast.lean
@@ -94,11 +94,11 @@ private theorem castIntMatrix_rowAdd (b : Matrix Int n m) (src dst : Fin n) (c :
   intro col hcol
   by_cases hdst : row = dst.val
   · subst row
-    simp [GramSchmidt.castIntMatrix, Matrix.rowAdd, Vector.getElem_set_self]
+    simp [GramSchmidt.castIntMatrix, Matrix.rowAdd_eq_set, Vector.getElem_set_self]
   · have hne : dst.val ≠ row := by
       intro h
       exact hdst h.symm
-    simp [GramSchmidt.castIntMatrix, Matrix.rowAdd, Vector.getElem_set_ne, hne]
+    simp [GramSchmidt.castIntMatrix, Matrix.rowAdd_eq_set, Vector.getElem_set_ne, hne]
 
 private theorem castIntMatrix_rowSwap (b : Matrix Int n m) (i j : Fin n) :
     GramSchmidt.castIntMatrix (Matrix.rowSwap b i j) =

--- a/HexGramSchmidt/Basic/Linearity.lean
+++ b/HexGramSchmidt/Basic/Linearity.lean
@@ -601,7 +601,7 @@ private theorem basisMatrix_rowAdd
       (Matrix.rowAdd b src dst c).toList =
         b.toList.set dst.val
           (b.toList[dst.val]! + c • b.toList[src.val]!) := by
-    show (b.set dst (Vector.ofFn fun k => b[dst][k] + c * b[src][k])).toList = _
+    rw [Matrix.rowAdd_eq_set]
     rw [Vector.toList_set]
     congr 1
     rw [hsrc_toList, hdst_toList]

--- a/HexGramSchmidt/Basic/Rat.lean
+++ b/HexGramSchmidt/Basic/Rat.lean
@@ -535,7 +535,7 @@ theorem coeffs_rowAdd_lower (b : Matrix Rat n m) (col src dst : Fin n)
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn,
     hcolsrc, Nat.lt_trans hcolsrc hsrcdst]
   rw [hbasis]
-  unfold Matrix.rowAdd
+  rw [Matrix.rowAdd_eq_set]
   simp [Vector.getElem_set_self]
   have hvec :
       (Vector.ofFn fun k : Fin m => b[dst.val][k.val] + c * b[src.val][k.val]) =
@@ -563,7 +563,7 @@ theorem coeffs_rowAdd_pivot (b : Matrix Rat n m) (src dst : Fin n)
     simpa [Matrix.row] using hself
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn, hsrcdst]
   rw [hbasis]
-  unfold Matrix.rowAdd
+  rw [Matrix.rowAdd_eq_set]
   simp [Vector.getElem_set_self]
   have hvec :
       (Vector.ofFn fun k : Fin m => b[dst.val][k.val] + c * b[src.val][k.val]) =
@@ -593,7 +593,7 @@ theorem coeffs_rowAdd_above_pivot (b : Matrix Rat n m) (src col dst : Fin n)
     simpa [Matrix.row] using hzero
   simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn, hcoldst]
   rw [hbasis]
-  unfold Matrix.rowAdd
+  rw [Matrix.rowAdd_eq_set]
   simp [Vector.getElem_set_self]
   have hvec :
       (Vector.ofFn fun k : Fin m => b[dst.val][k.val] + c * b[src.val][k.val]) =
@@ -621,7 +621,7 @@ theorem coeffs_rowAdd_other_row (b : Matrix Rat n m) (src dst : Fin n) (c : Rat)
   by_cases hlt : colFin.val < row.val
   · simp [coeffs, GramSchmidt.coeffMatrix, GramSchmidt.entry_ofFn, hlt]
     rw [hbasis]
-    unfold Matrix.rowAdd
+    rw [Matrix.rowAdd_eq_set]
     have hval : dst.val ≠ row.val := by
       intro h
       exact hrow (Fin.ext h.symm)

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -20,20 +20,8 @@ namespace Int
 private theorem rowAdd_get_rect {R : Type u} [Mul R] [Add R] {n' m' : Nat}
     (M : Matrix R n' m') (src dst r : Fin n') (c : R) (k : Fin m') :
     (Matrix.rowAdd M src dst c)[r][k] =
-      if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
-  by_cases h : r = dst
-  · subst r
-    simp [Matrix.rowAdd]
-  · simp [Matrix.rowAdd, h]
-    have hval : dst.val ≠ r.val := by
-      intro hval
-      exact h (Fin.ext hval.symm)
-    have hrow :
-        (M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]))[r] = M[r] :=
-      (Vector.getElem_set_ne (xs := M)
-        (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
-        dst.isLt r.isLt hval)
-    simpa [Matrix.rowAdd] using congrArg (fun row => row[k]) hrow
+      if r = dst then M[dst][k] + c * M[src][k] else M[r][k] :=
+  Matrix.getElem_rowAdd M src dst r c k
 
 private theorem foldl_dot_comm_int {n' : Nat} (xs : List (Fin n'))
     (u v : Vector Int n') (accU accV : Int) (hacc : accU = accV) :
@@ -57,8 +45,9 @@ private theorem dot_comm_int {n' : Nat} (u v : Vector Int n') :
 /-- A row of `Matrix.rowAdd M src dst c` away from `dst` is unchanged. -/
 private theorem rowAdd_row_eq_of_ne {R : Type u} [Mul R] [Add R] {n' m' : Nat}
     (M : Matrix R n' m') (src dst r : Fin n') (c : R) (hr : r.val ≠ dst.val) :
-    (Matrix.rowAdd M src dst c)[r] = M[r] :=
-  Vector.getElem_set_ne (xs := M)
+    (Matrix.rowAdd M src dst c)[r] = M[r] := by
+  rw [Matrix.rowAdd_eq_set]
+  exact Vector.getElem_set_ne (xs := M)
     (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
     dst.isLt r.isLt (fun heq => hr heq.symm)
 
@@ -68,8 +57,7 @@ private theorem rowAdd_row_at {R : Type u} [Mul R] [Add R] {n' m' : Nat}
     (M : Matrix R n' m') (src dst : Fin n') (c : R) :
     (Matrix.rowAdd M src dst c)[dst] =
       Vector.ofFn fun k => M[dst][k] + c * M[src][k] := by
-  unfold Matrix.rowAdd
-  simp
+  simp [Matrix.rowAdd_eq_set]
 
 /-- Inductive helper for `dot_rowAdd_row_at_left`: distribution along a foldl. -/
 private theorem foldl_dot_rowAdd_at {n' m' : Nat}

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexMatrix.Basic
+public import HexMatrix.Vector.Modify
 
 public section
 
@@ -86,32 +87,21 @@ theorem rowSwap_diag_of_ne (M : Matrix R n n) {k pivot : Fin n}
 
 /-- Scale row `i` by `c`.
 
-The row is read once into `row`, so the only remaining reference to `M` is the
-consuming `set`, which updates the backing store in place when `M` is uniquely
-referenced. -/
+`Vector.modify` frees the row slot before applying the update, so when `M` is
+uniquely referenced both the outer vector and the row itself are updated in
+place: `Vector.map` reuses the freed row's backing store. -/
 @[expose]
 def rowScale [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) : Matrix R n m :=
-  let row := M[i]
-  M.set i <| Vector.ofFn fun k => c * row[k]
+  M.modify i fun row => row.map fun x => c * x
 
 /-- Read an entry of `rowScale M i c` by cases on the row index: row `i`
 returns `c * M[i][k]`, any other row is unchanged. -/
 theorem getElem_rowScale [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : Fin m) :
     (rowScale M i c)[r][k] =
       if r = i then c * M[i][k] else M[r][k] := by
-  by_cases h : r = i
-  · subst r
-    simp [rowScale]
-  · simp [rowScale, h]
-    have hval : i.val ≠ r.val := by
-      intro hval
-      exact h (Fin.ext hval.symm)
-    have hrow :
-        (M.set i (Vector.ofFn fun k => c * M[i][k]))[r] = M[r] := by
-      exact
-        (Vector.getElem_set_ne (xs := M) (x := Vector.ofFn fun k => c * M[i][k])
-          i.isLt r.isLt hval)
-    simpa [rowScale] using congrArg (fun row => row[k]) hrow
+  rw [rowScale]
+  simp only [Fin.getElem_fin]
+  grind
 
 /-- Row `i` of `rowScale M i c` is the pointwise scalar multiple of row `i`. -/
 @[simp, grind =] theorem row_rowScale_self [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) :
@@ -134,14 +124,14 @@ theorem row_rowScale_of_ne [Mul R] (M : Matrix R n m) {i r : Fin n} (c : R)
 
 /-- Replace row `dst` by `row dst + c * row src`.
 
-Both rows are read once into `rdst`/`rsrc`, so the only remaining reference to
-`M` is the consuming `set`, which updates the backing store in place when `M` is
-uniquely referenced. -/
+The source row is read once into `rsrc`, so the only remaining reference to `M`
+is the consuming `Vector.modify`, which updates the outer vector in place when
+`M` is uniquely referenced (dropping the old row `dst`). The replacement row is
+built fresh, since every entry of it changes. -/
 @[expose]
 def rowAdd [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : R) : Matrix R n m :=
-  let rdst := M[dst]
   let rsrc := M[src]
-  M.set dst <| Vector.ofFn fun k => rdst[k] + c * rsrc[k]
+  M.modify dst fun rdst => Vector.ofFn fun k => rdst[k] + c * rsrc[k]
 
 /-- Read an entry of `rowAdd M src dst c` by cases on the row index: row `dst`
 returns `M[dst][k] + c * M[src][k]`, any other row is unchanged. -/
@@ -149,20 +139,9 @@ theorem getElem_rowAdd [Mul R] [Add R]
     (M : Matrix R n m) (src dst r : Fin n) (c : R) (k : Fin m) :
     (rowAdd M src dst c)[r][k] =
       if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
-  by_cases h : r = dst
-  · subst r
-    simp [rowAdd]
-  · simp [rowAdd, h]
-    have hval : dst.val ≠ r.val := by
-      intro hval
-      exact h (Fin.ext hval.symm)
-    have hrow :
-        (M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]))[r] = M[r] := by
-      exact
-        (Vector.getElem_set_ne (xs := M)
-          (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k])
-          dst.isLt r.isLt hval)
-    simpa [rowAdd] using congrArg (fun row => row[k]) hrow
+  rw [rowAdd]
+  simp only [Fin.getElem_fin]
+  grind
 
 /-- Source-row entries are unchanged by `rowAdd M src dst c` when `src ≠ dst`. -/
 theorem getElem_rowAdd_src_of_ne [Mul R] [Add R]
@@ -199,6 +178,42 @@ theorem row_rowAdd_of_ne [Mul R] [Add R]
     (M : Matrix R n m) {src dst : Fin n} (c : R) (hsrcdst : src ≠ dst) :
     row (rowAdd M src dst c) src = row M src := by
   exact row_rowAdd_of_ne M src c hsrcdst
+
+/-- `rowScale` as a single `set` of the scaled row. The executable definition
+goes through `Vector.modify` for in-place update; this is the value-level
+characterization for callers that reason about the result as a `set`. -/
+theorem rowScale_eq_set [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) :
+    rowScale M i c = M.set i (Vector.ofFn fun k => c * M[i][k]) := by
+  apply Vector.ext
+  intro r hr
+  rw [rowScale, Vector.getElem_modify, Vector.getElem_set]
+  by_cases hri : r = (i : Nat)
+  · subst hri
+    rw [if_pos rfl, if_pos rfl]
+    apply Vector.ext
+    intro k hk
+    simp [Fin.getElem_fin]
+  · have h' : ¬ ((i : Nat) = r) := fun h => hri h.symm
+    rw [if_neg h', if_neg h']
+
+/-- `rowAdd` as a single `set` of the combined row. The executable definition
+goes through `Vector.modify` for in-place update; this is the value-level
+characterization for callers that reason about the result as a `set`. -/
+theorem rowAdd_eq_set [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : R) :
+    rowAdd M src dst c =
+      M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]) := by
+  apply Vector.ext
+  intro r hr
+  simp only [rowAdd]
+  rw [Vector.getElem_modify, Vector.getElem_set]
+  by_cases hrd : r = (dst : Nat)
+  · subst hrd
+    rw [if_pos rfl, if_pos rfl]
+    apply Vector.ext
+    intro k hk
+    simp [Fin.getElem_fin]
+  · have h' : ¬ ((dst : Nat) = r) := fun h => hrd h.symm
+    rw [if_neg h', if_neg h']
 
 /-- Replace column `dst` by `col dst + c * col src`.
 

--- a/HexMatrix/Vector/Modify.lean
+++ b/HexMatrix/Vector/Modify.lean
@@ -26,4 +26,24 @@ that copy when `xs` is uniquely owned.
 @[expose, inline] def modify (xs : Vector α n) (i : Nat) (f : α → α) : Vector α n :=
   ⟨xs.toArray.modify i f, by simp⟩
 
+/-- Entrywise read of `modify`: the modified index gets `f` applied, every other
+index is unchanged. -/
+@[grind =] theorem getElem_modify {xs : Vector α n} {i : Nat} {f : α → α}
+    {j : Nat} (hj : j < n) :
+    (xs.modify i f)[j] = if i = j then f xs[j] else xs[j] := by
+  rcases xs with ⟨a, rfl⟩
+  simp only [modify, Vector.getElem_mk]
+  rw [Array.getElem_modify]
+
+/-- The modified index of `modify` reads back `f` applied to the old value. -/
+theorem getElem_modify_self {xs : Vector α n} {i : Nat} {f : α → α} (hi : i < n) :
+    (xs.modify i f)[i] = f xs[i] := by
+  rw [getElem_modify hi, if_pos rfl]
+
+/-- Any index other than the modified one is unchanged by `modify`. -/
+theorem getElem_modify_of_ne {xs : Vector α n} {i j : Nat} {f : α → α}
+    (hj : j < n) (h : i ≠ j) :
+    (xs.modify i f)[j] = xs[j] := by
+  rw [getElem_modify hj, if_neg h]
+
 end Vector

--- a/HexMatrixMathlib/Basic.lean
+++ b/HexMatrixMathlib/Basic.lean
@@ -92,19 +92,11 @@ theorem matrixEquiv_rowScale (M : Hex.Matrix R n m) (i : Fin n) (c : R) :
   ext r k
   change (Hex.Matrix.rowScale M i c)[r][k] =
     (Matrix.diagonal (Function.update (fun _ : Fin n => (1 : R)) i c) * matrixEquiv M) r k
+  rw [Hex.Matrix.getElem_rowScale]
   by_cases hri : r = i
   · subst r
-    simp [Hex.Matrix.rowScale]
-  · have hval : i.val ≠ r.val := by
-      intro h
-      exact hri (Fin.ext h).symm
-    have hentry :
-        ((Vector.set M i.val (Vector.ofFn fun k => c * M[i][k]) i.isLt)[r.val])[k.val] =
-          M[r][k] := by
-      exact congrArg (fun row => row[k])
-        (Vector.getElem_set_ne (xs := M) (x := Vector.ofFn fun k => c * M[i][k])
-          (hi := i.isLt) (hj := r.isLt) hval)
-    simpa [Hex.Matrix.rowScale, hri] using hentry
+    simp
+  · simp [hri]
 
 end RowOps
 
@@ -121,6 +113,7 @@ theorem matrixEquiv_rowAdd (M : Hex.Matrix R n m) (src dst : Fin n) (c : R) :
   ext r k
   change (Hex.Matrix.rowAdd M src dst c)[r][k] =
     (Matrix.transvection dst src c * matrixEquiv M) r k
+  rw [Hex.Matrix.rowAdd_eq_set]
   by_cases hrd : r = dst
   · subst r
     have hentry :

--- a/HexRowReduce/RREF/Pivot.lean
+++ b/HexRowReduce/RREF/Pivot.lean
@@ -227,21 +227,14 @@ omit [DecidableEq R] in
 private theorem rowAdd_get_dst (M : Matrix R n m) (src dst : Fin n) (c : R)
     (k : Fin m) :
     (rowAdd M src dst c)[dst][k] = M[dst][k] + c * M[src][k] := by
-  simp [rowAdd]
+  rw [getElem_rowAdd, if_pos rfl]
 
 omit [DecidableEq R] in
 /-- Entry of `rowAdd M src dst c` at any row other than `dst`. -/
 private theorem rowAdd_get_other (M : Matrix R n m) (src dst : Fin n) (c : R)
     {r : Fin n} (hne : r ≠ dst) (k : Fin m) :
     (rowAdd M src dst c)[r][k] = M[r][k] := by
-  have hval : dst.val ≠ r.val := by
-    intro hval
-    exact hne (Fin.ext hval.symm)
-  have hrow :
-      (M.set dst (Vector.ofFn fun k => M[dst][k] + c * M[src][k]))[r] = M[r] :=
-    Vector.getElem_set_ne (xs := M)
-      (x := Vector.ofFn fun k => M[dst][k] + c * M[src][k]) dst.isLt r.isLt hval
-  simpa [rowAdd] using congrArg (fun row => row[k]) hrow
+  rw [getElem_rowAdd, if_neg hne]
 
 /-- One step of `eliminateColumn`'s fold preserves the entry at the pivot row. -/
 private theorem eliminateColumn_step_pivotRow_unchanged

--- a/progress/20260629T082848Z_row-ops-modify.md
+++ b/progress/20260629T082848Z_row-ops-modify.md
@@ -1,0 +1,36 @@
+# Row ops via Vector.modify
+
+## Accomplished
+
+- Switched `Matrix.rowScale`/`rowAdd` to the shipped `Vector.modify`
+  (HexMatrix/Vector/Modify.lean), which frees the row slot before applying
+  `f` so the row is uniquely owned:
+  - `rowScale M i c = M.modify i (·.map (c * ·))` — `Array.map` is in-place on
+    a unique array, so outer vector AND row reuse their backing stores (no
+    fresh array allocation; the `c * x` products may still allocate for
+    non-scalar `R`).
+  - `rowAdd M src dst c = let rsrc := M[src]; M.modify dst (fun rdst =>
+    ofFn fun k => rdst[k] + c*rsrc[k])` — outer in place; replacement row is
+    built fresh (every entry changes).
+- Added `Vector.getElem_modify` (+ `_self`/`_of_ne`) to Modify.lean,
+  mirroring `Array.getElem_modify` (`@[grind =]`).
+- Entrywise `getElem` lemma statements unchanged; proofs now
+  `rw [..]; simp only [Fin.getElem_fin]; grind`.
+- Added `rowScale_eq_set`/`rowAdd_eq_set` value-level characterizations.
+  `rowAdd_eq_set` replaces the GramSchmidt Mathlib-layer proofs that relied
+  on `rowAdd` being definitionally `set`+`ofFn` (Rat, IntCast, Linearity).
+- Redirected downstream `_get` duplicates to the canonical entry lemmas.
+- Full `lake build` (2400 jobs) green; `HexConformance` `#guard`/`#eval`
+  runtime checks pass.
+
+## Current frontier
+
+Refactor complete; awaiting second opinion + CI before merge.
+
+## Next step
+
+Merge once CI is green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR routes the in-place row operations `Matrix.rowScale` and `rowAdd` through the project's `Vector.modify`, which frees the row slot before applying its function so the row is uniquely owned and can be updated in place. `rowScale` maps the freed row with `Vector.map`, which is itself in-place on a unique array, so both the outer vector and the row reuse their backing stores without a fresh array allocation (the `c * x` products may still allocate for non-scalar `R`). `rowAdd` reads the source row once into `rsrc` and rebuilds the destination row, leaving only the consuming `modify` to update the outer vector in place and drop the old row.

It adds `Vector.getElem_modify` (and the `_self`/`_of_ne` corollaries) to `HexMatrix/Vector/Modify.lean`, mirroring `Array.getElem_modify`. The entrywise `getElem` lemma statements for the row operations are unchanged. The value-level `rowScale_eq_set`/`rowAdd_eq_set` characterizations let the GramSchmidt Mathlib-layer proofs that previously relied on `rowAdd` being definitionally a `set` of an `ofFn` row keep reasoning about the result as a single `set`. Downstream duplicate entry lemmas now defer to the canonical ones.

The full `lake build` is green and the `HexConformance` `#guard`/`#eval` runtime checks confirm the refactored operations compute identical values.

🤖 Prepared with Claude Code
