### PR TITLE
fix: complete the getElem rename in the HexMatrixMathlib bridge

### DIFF
--- a/HexMatrixMathlib/Gram.lean
+++ b/HexMatrixMathlib/Gram.lean
@@ -27,7 +27,7 @@ variable {R : Type u} {n m : Nat}
 @[simp, grind =] theorem matrixEquiv_gramMatrix [Semiring R] (M : Hex.Matrix R n m) :
     matrixEquiv (Hex.Matrix.gramMatrix M) = matrixEquiv M * (matrixEquiv M)ᵀ := by
   ext i j
-  rw [matrixEquiv_apply, Hex.Matrix.gramMatrix_getElem, Matrix.mul_apply, dotProduct_eq]
+  rw [matrixEquiv_apply, Hex.Matrix.getElem_gramMatrix, Matrix.mul_apply, dotProduct_eq]
   unfold dotProduct
   refine Finset.sum_congr rfl (fun k _ => ?_)
   rw [Matrix.transpose_apply]

--- a/HexMatrixMathlib/Lemmas.lean
+++ b/HexMatrixMathlib/Lemmas.lean
@@ -29,7 +29,7 @@ Mathlib's `ᵀ`. -/
 @[simp, grind =] theorem matrixEquiv_transpose (M : Hex.Matrix R n m) :
     matrixEquiv (Hex.Matrix.transpose M) = (matrixEquiv M)ᵀ := by
   ext i j
-  rw [matrixEquiv_apply, Hex.Matrix.transpose_getElem, Matrix.transpose_apply,
+  rw [matrixEquiv_apply, Hex.Matrix.getElem_transpose, Matrix.transpose_apply,
     matrixEquiv_apply]
 
 /-- Replacing a row carries `matrixEquiv` to Mathlib's `updateRow`. -/
@@ -52,7 +52,7 @@ Mathlib's `ᵀ`. -/
     (v : Fin n → R) :
     matrixEquiv (Hex.Matrix.setCol M dst v) = (matrixEquiv M).updateCol dst v := by
   ext i j
-  rw [matrixEquiv_apply, Hex.Matrix.setCol_getElem, Matrix.updateCol_apply,
+  rw [matrixEquiv_apply, Hex.Matrix.getElem_setCol, Matrix.updateCol_apply,
     matrixEquiv_apply]
 
 end HexMatrixMathlib


### PR DESCRIPTION
This PR points three `HexMatrixMathlib` references at the renamed entry lemmas. The `getElem_<op>` rename in https://github.com/kim-em/hex-dev/pull/8431 (refactor: name getElem lemmas getElem_<op> per the lean4 convention) and https://github.com/kim-em/hex-dev/pull/8438 left `HexMatrixMathlib.Lemmas` and `HexMatrixMathlib.Gram` calling `transpose_getElem`, `setCol_getElem`, and `gramMatrix_getElem`, which no longer exist, so `main` does not build. They now call `getElem_transpose`, `getElem_setCol`, and `getElem_gramMatrix`.

🤖 Prepared with Claude Code
