### PR TITLE
doc: record the release publishing model and matrix-refactor conventions

### DIFF
--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -1,9 +1,12 @@
 # hex-matrix (foundation, no dependencies)
 
-Dense matrices as `Vector (Vector R m) n`.
+Dense matrices over a coefficient type `R`.
 
 **Contents:**
-- `Matrix R n m` := `Vector (Vector R m) n` (uses stdlib `Vector`)
+- `Matrix R n m`, an encapsulated dense matrix type. Consumers go through
+  its API — `ofFn`, `ofRows`, `getRow`, `rows`, and entry access
+  `M[(i, j)]` (the normal form for entries) — so the backing representation
+  stays private and can change.
 - Matrix-vector multiplication, matrix-matrix multiplication
 - Dot product, norm squared (for `R = Int` and `R = Rat`)
 - Row operations (swap, scale, add multiple of one row to another) and the
@@ -20,7 +23,10 @@ column analogues `colAdd` / `colAddRight` are pure data transforms on the dense
 representation. Their algebraic identities (involutivity of `rowSwap`,
 multiplicative behaviour `rowSwap_mul` / `rowScale_mul` / `rowAdd_mul`, and the
 inverse-preservation lemmas) live here and are reused by row reduction and by
-the determinant row-operation laws.
+the determinant row-operation laws. They update the matrix in place when it is
+uniquely referenced: each uses its argument linearly and goes through
+`Vector.swap` / `Vector.modify` / `Vector.map`, which reuse the backing store
+rather than copying it.
 
 **Key properties:**
 - identity matrices act as left and right multiplicative identities

--- a/PLAN/Conventions.md
+++ b/PLAN/Conventions.md
@@ -157,7 +157,32 @@ So `hex-gf2` → `HexGF2`, `hex-lll` → `HexLLL`, `hex-lll-mathlib`
 lower-case; `fp` is "F_p" with `p` variable, lower-case.)
 
 Extend this table when adding libraries whose names involve further
-acronyms. Do not silently introduce a mixed-case spelling.
+acronyms. Do not silently introduce a mixed-case spelling. An acronym of
+four or more letters is not carried as a name segment at all: spell it
+out, following the lean4 naming guide (`RREF` → `RowReduce` /
+`IsRowReduced` / `rowReduce`, like `Json`). The acronyms above are all
+three letters or fewer.
+
+### Lemma and operation naming
+
+- **Entry-access lemmas use the `getElem_<op>` form.** Name a lemma for
+  the head symbol of its left-hand side. When the left-hand side is
+  `(op …)[…] = …` the head is `getElem`, so the lemma is `getElem_<op>`
+  (`getElem_row`, `getElem_transpose`, `getElem_rowSwap`, `getElem_modify`),
+  usually tagged `@[grind =]`; trailing qualifiers ride along
+  (`getElem_rowSwap_of_ne`). Reserve the `_getElem` *suffix* for lemmas
+  where `getElem` is not the head (`ext_getElem`, `getD_getElem`).
+
+- **Vector operations live in the root `Vector` namespace.** `dotProduct`,
+  `normSq`, `unit`, `modify`, and their lemmas attach to Lean core's
+  `Vector`, not a `Hex.Vector` or `Matrix.Vector` namespace — additions to
+  an existing type live in that type's namespace.
+
+- **State a lemma at its weakest typeclass.** Prove an algebraic lemma over
+  the weakest class that admits it (e.g. dot-product additivity over a
+  general ring), but keep a stronger class exactly where the statement is
+  false without it (the multiplicative right-argument lemmas genuinely need
+  commutativity).
 
 ### Process vocabulary stops at the issue boundary
 
@@ -210,6 +235,12 @@ to CI in [Phase0.md §6](Phase0.md).
 or imported (directly or transitively) by `Foo.lean`. Any PR that adds
 a new module under `Foo/` must also update `Foo.lean` (or chain the
 import through an existing intermediate module).
+
+### Module organization
+
+Give each module one subject and name it for its contents; do not keep
+re-export shell modules whose only job is to import others. Every file
+opens with a module docstring, placed immediately after `public section`.
 
 ---
 

--- a/PLAN/Releases.md
+++ b/PLAN/Releases.md
@@ -89,3 +89,74 @@ Per release:
   release entry point.
 - A short release notes entry listing the libraries, the user story,
   and the integration example.
+
+## Published libraries
+
+"Release" above means a milestone. Separately, several libraries are
+*published* as standalone repositories under `kim-em/`, so they can be
+used without the whole monorepo. `hex-dev` is the single source of
+truth: all development happens here, and a workflow regenerates each
+published repo from this tree. A published repo is a mirror — never
+hand-edit one; change it here and let the sync publish.
+
+### The published set
+
+In dependency order (`scripts/release/released.yml`):
+
+`hex-test-kit`, `hex-matrix`, `hex-row-reduce`, `hex-determinant`,
+`hex-bareiss`, `hex-matrix-mathlib`, `hex-row-reduce-mathlib`,
+`hex-determinant-mathlib`, `hex-bareiss-mathlib`, `hex-gram-schmidt`,
+`hex-gram-schmidt-mathlib`, `hex-lll`, `hex-lll-mathlib`.
+
+This is the current set, not a permanent one; more sublibraries may be
+published later. The computational repos are Mathlib-free; the
+`*-mathlib` repos are the bridge layers.
+
+### Uniform per-library layout
+
+Every library uses the same layout, so publishing is a near-mechanical
+copy:
+
+- `HexX/` — source plus the `HexX.lean` umbrella.
+- `HexX/SPEC/hex-x.md` — the library's SPEC.
+- `bench/HexX/Bench.lean` — bench driver.
+- `conformance/HexX/{Conformance,EmitFixtures}.lean` — conformance drivers.
+- `conformance-fixtures/HexX/*.jsonl`, `scripts/oracle/<lib>_*.py`.
+
+The bench and conformance drivers stay in the root Lake package (via
+`srcDir`), not in sub-packages: a sub-package would re-resolve and
+duplicate the whole Mathlib checkout.
+
+### The publish mechanism
+
+Four pieces, under `scripts/release/` and `.github/workflows/`:
+
+- `released.yml` — a per-repo manifest: which paths to copy, which
+  oracles to ship, and which upstream repos to pin, in dependency order.
+- `sync_released.py` — the driver. For each repo it clones `main`,
+  overwrites the managed paths from this tree, rewrites the cross-repo
+  Lake revisions, and commits to `main`. `--dry-run` prints the planned
+  changes without pushing; run it first.
+- `synced.json` — the baseline seed (see below).
+- `sync-released.yml` — a manual workflow (`workflow_dispatch`, dry by
+  default). One dispatch drives the whole publish.
+
+Rewriting the cross-repo revisions touches **every** lakefile and
+`lake-manifest.json` in a repo — the root and the `bench/` and
+`conformance/` sub-projects — updating both `rev` and `inputRev`. Lake
+trusts the manifest, so a stale lockfile would otherwise rebuild against
+the old revision.
+
+### Baseline and the uncoordinated-commit guard
+
+The sync records, per repo, the `main` commit this monorepo was last
+synced from. If a published repo's `main` has moved off that baseline,
+the sync refuses to overwrite it — it reports the divergence and skips
+(`--force` overrides) — so an out-of-band commit is never silently lost.
+
+Reconciling means re-seeding: bring that library's content here up to
+the published `main`, rebuild the whole graph green, then re-run the
+sync. The baseline lives on the unprotected `release-sync-baseline`
+branch, which the workflow reads and advances on every real run;
+`scripts/release/synced.json` is the seed used before that branch
+exists.

--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -2,7 +2,10 @@
 
 - **hex-arith** — extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
 - **hex-poly** — dense `Array`-backed polynomial representation
-- **hex-matrix** — dense matrices as `Vector (Vector R m) n`, RREF, Bareiss determinant, span, nullspace
+- **hex-matrix** — dense matrices, matrix/vector arithmetic, elementary row and column operations, submatrix slicing, the Gram matrix
+- **hex-row-reduce** — row reduction (RREF), rank, span, nullspace
+- **hex-determinant** — the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
+- **hex-bareiss** — the fraction-free Bareiss determinant algorithm
 - **hex-gram-schmidt** — Gram-Schmidt orthogonalization, GS coefficients, Gram determinants, update formulas under row operations
 - **hex-mod-arith** — `ZMod64 p`: `UInt64`-backed arithmetic in `Z/pZ`
 - **hex-poly-fp** — polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
@@ -25,7 +28,10 @@ proving correspondence with Mathlib's mathematical definitions):
 
 - **hex-mod-arith-mathlib** — `ZMod64 p ≃+* ZMod p`
 - **hex-poly-mathlib** — `DensePoly R ≃+* Polynomial R`
-- **hex-matrix-mathlib** — matrix equivalence, `det` agreement, rank = `Matrix.rank`, nullspace = `LinearMap.ker`, row ops = transvections
+- **hex-matrix-mathlib** — matrix equivalence, row ops = transvections, and the Mathlib algebra tower transported onto our matrix type
+- **hex-row-reduce-mathlib** — rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
+- **hex-determinant-mathlib** — `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
+- **hex-bareiss-mathlib** — Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
 - **hex-gram-schmidt-mathlib** — `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
 - **hex-poly-z-mathlib** — `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
 - **hex-roots-mathlib** — Pellet on circles (built from `circleIntegral`) + Mahler/Mignotte separation bound; correctness of refinement and `isolate`
@@ -45,9 +51,12 @@ Each library with its immediate dependencies:
 - **hex-arith** — (none)
 - **hex-poly** — (none)
 - **hex-matrix** — (none)
+- **hex-row-reduce** — hex-matrix
+- **hex-determinant** — hex-matrix
+- **hex-bareiss** — hex-determinant, hex-matrix
 - **hex-mod-arith** — hex-arith
-- **hex-gram-schmidt** — hex-matrix
-- **hex-lll** — hex-gram-schmidt
+- **hex-gram-schmidt** — hex-row-reduce, hex-determinant, hex-bareiss
+- **hex-lll** — hex-gram-schmidt, hex-matrix
 - **hex-poly-fp** — hex-poly, hex-mod-arith
 - **hex-poly-z** — hex-poly
 - **hex-roots** — hex-poly-z
@@ -71,8 +80,11 @@ Mathlib bridge libraries (each also depends on Mathlib):
 - **hex-resultant-mathlib** — hex-resultant, hex-poly-mathlib
 - **hex-number-field-mathlib** — hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
 - **hex-matrix-mathlib** — hex-matrix
-- **hex-gram-schmidt-mathlib** — hex-gram-schmidt
-- **hex-lll-mathlib** — hex-lll
+- **hex-row-reduce-mathlib** — hex-row-reduce, hex-matrix-mathlib
+- **hex-determinant-mathlib** — hex-determinant, hex-bareiss, hex-matrix-mathlib
+- **hex-bareiss-mathlib** — hex-determinant-mathlib
+- **hex-gram-schmidt-mathlib** — hex-gram-schmidt, hex-bareiss-mathlib
+- **hex-lll-mathlib** — hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib
 - **hex-berlekamp-mathlib** — hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib
 - **hex-hensel-mathlib** — hex-hensel, hex-poly-mathlib
 - **hex-gf2-mathlib** — hex-gf2, hex-poly-fp, hex-gfq-field
@@ -88,6 +100,13 @@ hex-berlekamp-zassenhaus` is part of the production graph, not an
 optional optimisation edge.
 
 ## Library DAG
+
+The matrix family splits internally: `hex-matrix` is the dense base;
+`hex-row-reduce`, `hex-determinant`, and `hex-bareiss` build on it
+(`hex-bareiss` also on `hex-determinant`); `hex-gram-schmidt` uses all
+three; and `hex-lll` builds on `hex-gram-schmidt`. Each has a matching
+`*-mathlib` bridge of the same shape. In the diagram below, `hex-matrix`
+stands for that whole family.
 
 Three independent roots: hex-poly, hex-arith, hex-matrix.
 
@@ -120,9 +139,18 @@ hex-gfq-field   hex-conway   hex-gf2
 
 ## Index
 
+Libraries marked **(released)** are published as standalone repositories;
+see [PLAN/Releases.md §Published libraries](../../PLAN/Releases.md#published-libraries).
+
 - [hex-arith.md](hex-arith.md) — extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
-- [hex-matrix](https://github.com/kim-em/hex-matrix/blob/main/SPEC/hex-matrix.md) (released) — dense matrices, RREF, Bareiss determinant, span, nullspace
-- [hex-matrix-mathlib](https://github.com/kim-em/hex-matrix-mathlib/blob/main/SPEC/hex-matrix-mathlib.md) (released) — matrix equivalence with Mathlib, determinant/rank/nullspace correspondence
+- [hex-matrix](https://github.com/kim-em/hex-matrix/blob/main/SPEC/hex-matrix.md) (released) — dense matrices, arithmetic, elementary row/column operations, submatrix slicing, the Gram matrix
+- [hex-row-reduce](https://github.com/kim-em/hex-row-reduce/blob/main/SPEC/hex-row-reduce.md) (released) — row reduction, rank, span, nullspace
+- [hex-determinant](https://github.com/kim-em/hex-determinant/blob/main/SPEC/hex-determinant.md) (released) — Leibniz determinant and cofactor/Cauchy-Binet/Plücker theory
+- [hex-bareiss](https://github.com/kim-em/hex-bareiss/blob/main/SPEC/hex-bareiss.md) (released) — fraction-free Bareiss determinant algorithm
+- [hex-matrix-mathlib](https://github.com/kim-em/hex-matrix-mathlib/blob/main/SPEC/hex-matrix-mathlib.md) (released) — matrix equivalence, row operations as transvections, transported algebra tower
+- [hex-row-reduce-mathlib](https://github.com/kim-em/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released) — rank/nullspace/span correspondence
+- [hex-determinant-mathlib](https://github.com/kim-em/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released) — `det` agreement with `Matrix.det`
+- [hex-bareiss-mathlib](https://github.com/kim-em/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released) — Bareiss determinant correctness
 - [hex-mod-arith.md](hex-mod-arith.md) — `ZMod64 p`: `UInt64`-backed arithmetic in `Z/pZ`
 - [hex-mod-arith-mathlib.md](hex-mod-arith-mathlib.md) — `ZMod64 p ≃+* ZMod p`
 - [hex-poly.md](hex-poly.md) — dense polynomial library, operations, GCD, CRT

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -1,7 +1,10 @@
 # Design principles
 
 1. **Many small libraries** in a single monorepo, each its own Lake
-   library target.
+   library target. Split a large library along its dependency seams into
+   one-subject units — the matrix stack is `hex-matrix` (dense base) with
+   `hex-row-reduce`, `hex-determinant`, and `hex-bareiss` on top — and
+   give each computational library a matching `*-mathlib` bridge.
 
 2. **No Mathlib in the computational core.** Every library that computes
    something is Mathlib-free. Where full correctness requires results
@@ -20,12 +23,29 @@
    Mathlib-free library, regardless of which file the issue happens
    to name.
 
+   A Mathlib-free library also depends only on Lean core and other
+   Mathlib-free Hex libraries — not on Batteries. Where it needs a
+   Batteries lemma, it reproduces that lemma in a small Mathlib-free
+   shim, keeping the upstream name and signature, marked for removal
+   once the lemma lands in Lean core.
+
+   Mathlib *typeclass instances* on an executable type — algebraic
+   structures like `Ring` or `Module` — also live in the `*-mathlib`
+   bridge, transported along the equivalence so the operations stay the
+   executable ones.
+
 3. **Performant by default.** Dense array-backed representations, `UInt64`
    coefficients for `F_p`, Barrett/Montgomery reduction for modular
    arithmetic. New GMP `@[extern]` primitives where Lean's runtime
    doesn't yet expose what we need (notably extended GCD for big
    integers). FLINT is used for conformance testing, not as a runtime
    dependency.
+
+   Hot data transforms use their container linearly, so the compiler
+   mutates the backing store in place: prefer `Vector.swap` /
+   `Vector.modify` / `Vector.map`, which reuse a uniquely-owned buffer,
+   over reading with `getElem` and writing back with `set`, which forces
+   a copy.
 
 4. **Lean algorithms from the start.** All algorithms are implemented and
    run in Lean natively, and the native algorithm is always the default and
@@ -150,6 +170,16 @@
    be *established* by the gates first and *certified* by the proofs
    last. This does not relax principle 7 (no data-level scaffolding) or
    the no-`axiom` rule; it orders the work, it does not lower the bar.
+
+10. **Encapsulate representations.** Expose a core datatype as an opaque
+    type with an API, not as a transparent alias, so its representation
+    can change without touching consumers. `Hex.Matrix` is a one-field
+    structure; consumers construct and read it through its API (`ofFn`,
+    `ofRows`, `getRow`, `rows`, and entry access `M[(i, j)]`) and never
+    its backing store, so a later switch (e.g. to a flat
+    `Vector R (n*m)`) stays invisible. Change such a type by
+    expand-contract: add the full API and its lemmas first, convert every
+    consumer, then swap the representation last.
 
 ## Lakefile
 

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -177,9 +177,7 @@
     structure; consumers construct and read it through its API (`ofFn`,
     `ofRows`, `getRow`, `rows`, and entry access `M[(i, j)]`) and never
     its backing store, so a later switch (e.g. to a flat
-    `Vector R (n*m)`) stays invisible. Change such a type by
-    expand-contract: add the full API and its lemmas first, convert every
-    consumer, then swap the representation last.
+    `Vector R (n*m)`) stays invisible.
 
 ## Lakefile
 

--- a/SPEC/testing.md
+++ b/SPEC/testing.md
@@ -321,10 +321,16 @@ subsection. Default oracle assignments:
   oracle.
 - `hex-poly`, `hex-poly-z`, `hex-poly-fp` — `python-flint` primary
   for univariate polynomial arithmetic.
-- `hex-matrix`, `hex-gram-schmidt` (released — oracle conformance runs in their own repos) — `python-flint` exact
-  (`fmpz_mat` / `fmpq_mat`); numpy/scipy float for well-conditioned
-  float-level cross-checks; `fpylll`'s `GSO.Mat` for Gram-Schmidt
-  size-reduction parity.
+- `hex-matrix` (released — conformance runs in its own repo) — no
+  external oracle; the dense base (arithmetic, row/column ops, transpose,
+  slicing) is checked by property `#guard`s (structural layer).
+- `hex-row-reduce`, `hex-determinant`, `hex-bareiss` (released — oracle
+  conformance runs in their own repos) — `python-flint` exact
+  (`fmpz_mat`: rank / RREF / nullspace, determinant, Bareiss determinant).
+- `hex-gram-schmidt` (released — oracle conformance runs in its own repo)
+  — `python-flint` exact (`fmpq_mat`); numpy/scipy float for
+  well-conditioned float-level cross-checks; `fpylll`'s `GSO.Mat` for
+  Gram-Schmidt size-reduction parity.
 - `hex-gf2`, `hex-gfq-ring`, `hex-gfq-field`, `hex-gfq` —
   `python-flint` (`nmod_poly`, `fq_nmod`, `fq_default`); `cypari2`
   as a secondary independent finite-field oracle when independence


### PR DESCRIPTION
This PR records, in PLAN/ and SPEC/, the design decisions from the last two days of release-readiness and HexMatrix-split work, so a clean-room build from the docs would reproduce them. It is documentation only — no Lean source changes.

It adds a "Published libraries" section to PLAN/Releases.md: the source-of-truth model (develop in hex-dev, publish outward to mirror repos), the thirteen published repos in dependency order, the uniform per-library layout that makes publishing a near-mechanical copy, the four-part publish mechanism (`released.yml`, `sync_released.py`, `synced.json`, the `sync-released.yml` workflow with its lakefile and `lake-manifest.json` rewriting), and the baseline / uncoordinated-commit guard with re-seeding as the recovery path.

It updates SPEC/Libraries/README.md for the HexMatrix split, replacing the single hex-matrix entry with hex-matrix, hex-row-reduce, hex-determinant, and hex-bareiss plus their four Mathlib bridges, refreshing the dependency lists and released-index links, and adding a short note on the matrix-family shape. It updates the matrix oracle assignments in SPEC/testing.md the same way: the dense base is oracle-free, and the FLINT matrix oracle now serves hex-row-reduce, hex-determinant, and hex-bareiss.

It adds five points to SPEC/design-principles.md: splitting a library by operation family with a bridge each; Mathlib-free implies Batteries-free (reproduce needed lemmas in a Mathlib-free shim); algebraic typeclass instances live in the bridge, transported so the operations stay the executable ones; in-place mutation through linear use of `Vector.swap`/`modify`/`map`; and encapsulating a datatype behind an opaque type with an API (`Hex.Matrix` as a one-field structure). It adds naming and organization conventions to PLAN/Conventions.md: the `getElem_<op>` lemma form, the root `Vector` namespace, stating a lemma at its weakest typeclass, spelling out four-plus-letter acronyms, and one-subject-per-file modules. It presents `Hex.Matrix` as an encapsulated type in HexMatrix/SPEC/hex-matrix.md and notes the in-place row operations.

The representation-encapsulation point describes the target of the in-flight Matrix-structure PR rather than today's `abbrev`. I deliberately left the "One-free core" direction out, since that one is not settled.

🤖 Prepared with Claude Code