### PR TITLE
feat: add matrix-level adjugate identity mul_adjugate

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -169,6 +169,24 @@ theorem mul_adjugate_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
   · rw [hentry, if_neg hij]
     exact foldl_alien_cofactor_eq_zero M i j hij
 
+/-- The adjugate identity `M * adjugate M = det M • identity`. -/
+theorem mul_adjugate {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R (n + 1) (n + 1)) :
+    M * adjugate M = det M • Matrix.identity (n + 1) := by
+  ext i hi j hj
+  have hid : ((Matrix.identity (n + 1))[i]'hi)[j]'hj
+      = if (⟨i, hi⟩ : Fin (n + 1)) = ⟨j, hj⟩ then (1 : R) else 0 := by
+    simp [Matrix.identity, ofFn]
+  show (M * adjugate M)[(⟨i, hi⟩ : Fin (n + 1))][(⟨j, hj⟩ : Fin (n + 1))] =
+    (det M • Matrix.identity (n + 1))[(⟨i, hi⟩ : Fin (n + 1))][(⟨j, hj⟩ : Fin (n + 1))]
+  rw [mul_adjugate_apply]
+  simp only [Vector.getElem_smul, Fin.getElem_fin]
+  rw [hid]
+  clear hid
+  by_cases h : (⟨i, hi⟩ : Fin (n + 1)) = ⟨j, hj⟩
+  · rw [if_pos h, if_pos h]; show det M = det M * 1; grind
+  · rw [if_neg h, if_neg h]; show (0 : R) = det M * 0; grind
+
 /-- Entrywise version of `adjugate M * M = det M • 1`.
 
 This is the transpose-side companion to `mul_adjugate_apply`; it is useful

--- a/HexDeterminant/README.md
+++ b/HexDeterminant/README.md
@@ -76,9 +76,8 @@ theorem det_eq_foldl_laplace_row (M : Matrix R (n + 1) (n + 1)) (row : Fin (n + 
 
 We prove the Cauchy-Binet column-tuple product formula (Gram form) as
 `det_gramMatrix_eq_sum_columnTuples`, the adjugate identity
-`(M * adjugate M)[i][j] = if i = j then det M else 0` as `mul_adjugate_apply`,
-and the three-term Plücker / Desnanot-Jacobi identity as
-`det_plucker_three_term_consecutive_top`.
+`M * adjugate M = det M • identity` as `mul_adjugate`, and the three-term
+Plücker / Desnanot-Jacobi identity as `det_plucker_three_term_consecutive_top`.
 
 The identification of this determinant with Mathlib's `Matrix.det`, and the
 correspondence with the executable Bareiss determinant


### PR DESCRIPTION
This PR adds the matrix-level adjugate identity `mul_adjugate : M * adjugate M = det M • Matrix.identity (n + 1)` to `HexDeterminant/Adjugate.lean` and cites it from the hex-determinant README. It states `Matrix.identity` rather than the `1` literal because the matrix `One` / `OfNat` instance and the `getElem_one` theorem do not cross `HexMatrix.Basic`'s transitive public-import boundary into the determinant library under the module system, while `@[expose]` defs like `Matrix.identity` do; the entry computation goes through `simp [Matrix.identity, ofFn]` to avoid `getElem_one`.

🤖 Prepared with Claude Code