### PR TITLE
doc: trim the LLL README size-reduction constant notes

### DIFF
--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -140,10 +140,9 @@ the per-vector length factor is about `5.7%` larger per dimension: modest in
 low dimension, real in high. Tightening `η` back toward `1/2` would require a
 stricter certified checker (higher working precision, tighter requested
 margins, or enforcing exact `|μ| ≤ 1/2`), trading run time and a higher
-fallback rate for a better constant. The requested-parameter and precision
-constants the dispatch uses (`requestedEta = 107/200`, `requestedDelta`,
-`intervalPrec = 128`, `dispatchFactor`, `steerDimThreshold`) are documented in
-full at their definitions; none of them affects soundness.
+fallback rate for a better constant. The dispatch's requested-parameter and
+precision constants are internal tuning, documented at their definitions; none
+of them affects soundness.
 
 The end-to-end guarantees of `lll` are proved in
 [`hex-lll-mathlib`](https://github.com/kim-em/hex-lll-mathlib): that its output

--- a/HexLLLMathlib/README.md
+++ b/HexLLLMathlib/README.md
@@ -45,7 +45,9 @@ open HexLLLMathlib
 Every result builds without `sorry`.
 
 **The short-vector guarantee.** For an independent basis `b`, any factor
-`δ` with `121/400 < δ ≤ 1`, and any nonzero lattice vector `x`, the first row
+`δ` with `121/400 < δ ≤ 1` (`121/400 = (11/20)²`, the public size-reduction
+bound; see [`hex-lll`](https://github.com/kim-em/hex-lll) for why `11/20`), and
+any nonzero lattice vector `x`, the first row
 of `Hex.lll b δ …` has squared Euclidean norm at most
 `(1 / (δ − 121/400))^(n−1)` times that of `x`:
 

--- a/progress/20260630T134500Z_lll-readme-trim.md
+++ b/progress/20260630T134500Z_lll-readme-trim.md
@@ -1,0 +1,28 @@
+# LLL README trim
+
+## Accomplished
+
+Two prose-only follow-ups to the merged #8450 README rewrite, on branch
+`lll-readme-trim`:
+
+- `HexLLL/README.md`: collapsed the five-constant dump (`requestedEta`,
+  `requestedDelta`, `intervalPrec`, `dispatchFactor`, `steerDimThreshold`)
+  in the size-reduction-constants section into one sentence. The names are
+  internal tuning the reader can neither act on nor needs; they live at
+  their definition sites.
+- `HexLLLMathlib/README.md`: glossed the first mention of `121/400` as
+  `(11/20)²` with a pointer to `hex-lll`, so a reader landing on the
+  headline-result repo first is not met by the constant cold.
+
+## Current frontier
+
+Edits made; no build needed (prose only, no code blocks touched). Opening
+a fresh PR because #8450 already merged.
+
+## Next step
+
+Push branch, open PR against `main`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR tightens two spots in the LLL READMEs left by the #8450 rewrite, both prose-only. In `HexLLL/README.md` it collapses the sentence that listed five internal dispatch constants (`requestedEta`, `requestedDelta`, `intervalPrec`, `dispatchFactor`, `steerDimThreshold`) into a single sentence: those names are internal tuning the reader can neither act on nor needs, and they are already documented at their definition sites, so spelling them out in the README only overburdens a reader who does not care. In `HexLLLMathlib/README.md` it glosses the first mention of `121/400` as `(11/20)²` with a pointer to `hex-lll`, so a reader who lands on the headline-result repo first is not met by the constant cold.

No code blocks change, so the quickstarts still type-check unchanged.

🤖 Prepared with Claude Code