### PR TITLE
style: remove no-op @[expose] attributes that trigger build warnings

### DIFF
--- a/HexGFqRing/Basic.lean
+++ b/HexGFqRing/Basic.lean
@@ -72,7 +72,6 @@ def IsReduced (f : FpPoly p) (g : FpPoly p) : Prop :=
   ∃ h : FpPoly p, g = reduceMod f h
 
 /-- Executable quotient elements represented by canonical reduced polynomials. -/
-@[expose]
 abbrev PolyQuotient (f : FpPoly p) (_hf : 0 < FpPoly.degree f) :=
   { g : FpPoly p // IsReduced f g }
 

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -900,7 +900,6 @@ satisfying `entry_eq_dot` — from supplying integer quotients. The kernel-shift
 counterexample (SPEC #6505: rows `(1,1), (1,0), (-1,-1)` at row 2 step 1)
 shows the restriction is necessary: distinct non-canonical witnesses produce
 numerators differing by `1`, which is not divisible by `prevPivot = 2`. -/
-@[expose]
 abbrev StepWitness.Cell
     (b : Matrix Int n m) (fuel : Nat)
     (hinv : BareissGramRowInvariant b
@@ -926,7 +925,6 @@ the canonical coefficient vectors.
 Concrete providers are constructed in `HexGramSchmidtMathlib`, where the
 Bareiss-Desnanot proof infrastructure on PSD Gram minors is available; the
 Mathlib-free layer only consumes this abstraction. -/
-@[expose]
 abbrev StepWitness (b : Matrix Int n m) : Type :=
   ∀ (fuel : Nat)
     (hinv : BareissGramRowInvariant b

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -24,7 +24,6 @@ namespace Hex
 universe u
 
 /-- Dense `n × m` matrices over `R`, represented as vectors of rows. -/
-@[expose]
 abbrev Matrix (R : Type u) (n m : Nat) := Vector (Vector R m) n
 
 end Hex

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -862,7 +862,6 @@ instance instGcdLawsZMod64Fp [PrimeModulus p] : DensePoly.GcdLaws (ZMod64 p) whe
 end ZMod64
 
 /-- Executable dense polynomials over the prime-field candidate `ZMod64 p`. -/
-@[expose]
 abbrev FpPoly (p : Nat) [ZMod64.Bounds p] := DensePoly (ZMod64 p)
 
 namespace FpPoly

--- a/bench/HexPoly/Bench.lean
+++ b/bench/HexPoly/Bench.lean
@@ -75,7 +75,6 @@ structure F7 where
 
 namespace F7
 
-@[expose]
 def ofNat (n : Nat) : F7 :=
   { val := ⟨n % 7, Nat.mod_lt n (by decide)⟩ }
 

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -80,7 +80,6 @@ private def linear (r : Int) : ZPoly :=
 private def fromRoots (roots : List Int) : ZPoly :=
   Array.polyProduct (roots.map linear).toArray
 
-@[expose]
 private def coeffs (f : ZPoly) : List Int :=
   f.toArray.toList
 


### PR DESCRIPTION
This PR removes `@[expose]` attributes that the compiler reports as having no effect, so every build is warning-free on this front. Two situations are covered. In `conformance/HexBerlekampZassenhaus/Conformance.lean` and `bench/HexPoly/Bench.lean` the attribute sat in a non-`module` file, where it does nothing; these files cannot become module files because they import the non-module `HexBerlekampZassenhaus` and `HexPoly` libraries (a module file cannot import a non-module one), and it sat on a private local helper anyway, so dropping it matches every other conformance/bench file, all of which are non-module. In `HexMatrix.Matrix`, `HexPolyFp.FpPoly`, `HexGramSchmidt`'s `StepWitness`/`StepWitness.Cell`, and `HexGFqRing.PolyQuotient` the attribute decorated `abbrev`s that are already exposed by default, so it was redundant. There is no semantic change — the abbrevs stay exposed by default — and the full build is green.

🤖 Prepared with Claude Code