### PR TITLE
refactor: migrate the matrix-tower foldl_sum_* family onto HexBasic

### DIFF
--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -236,6 +236,15 @@ theorem foldl_add_add_start (xs : List α) (f g : α → R) (a b : R) :
       _ = xs.foldl (fun acc x => acc + f x) (a + f x)
             + xs.foldl (fun acc x => acc + g x) (b + g x) := ih (a + f x) (b + g x)
 
+/-- An additive fold-sum of a pointwise sum splits into two folds, given a
+splitting of the starting accumulator. -/
+theorem foldl_add_add_of_acc (xs : List α) (f g : α → R) (acc accF accG : R)
+    (h : acc = accF + accG) :
+    xs.foldl (fun acc x => acc + (f x + g x)) acc =
+      xs.foldl (fun acc x => acc + f x) accF + xs.foldl (fun acc x => acc + g x) accG := by
+  subst h
+  exact foldl_add_add_start xs f g accF accG
+
 /-- An additive fold-sum of a pointwise sum from `0` splits into the sum of the
 two separate folds from `0`. -/
 theorem foldl_add_add (xs : List α) (f g : α → R) :

--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -259,6 +259,14 @@ theorem foldl_add_sub (xs : List α) (f g : α → R) (a b : R) :
         rw [foldl_add_add_start xs f (fun x => -g x) a (-b), foldl_add_neg xs g b]
         grind
 
+/-- An additive fold-sum of a pointwise difference from `0` splits into the
+difference of the two fold-sums from `0`. -/
+theorem foldl_add_sub_zero (xs : List α) (f g : α → R) :
+    xs.foldl (fun acc x => acc + (f x - g x)) 0 =
+      xs.foldl (fun acc x => acc + f x) 0 - xs.foldl (fun acc x => acc + g x) 0 := by
+  have h := foldl_add_sub xs f g 0 0
+  rwa [show (0 : R) - 0 = 0 by grind] at h
+
 /-! ### Fubini -/
 
 /-- Sum-swap (Fubini) for nested additive fold-sums. -/

--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -195,6 +195,30 @@ theorem foldl_add_mul_left_zero (xs : List α) (c : R) (f : α → R) :
   have hzero : c * 0 = 0 := by grind
   simpa [hzero] using foldl_add_mul_left xs c f 0
 
+/-- Factor a right scalar out of an additive fold-sum (right distributivity,
+no commutativity needed). -/
+theorem foldl_add_mul_right (xs : List α) (f : α → R) (c z : R) :
+    xs.foldl (fun acc x => acc + f x) z * c =
+      xs.foldl (fun acc x => acc + f x * c) (z * c) := by
+  induction xs generalizing z with
+  | nil => rfl
+  | cons x xs ih =>
+    simp only [List.foldl_cons]
+    rw [ih (z := z + f x), show (z + f x) * c = z * c + f x * c by grind]
+
+/-! ### Negation and subtraction -/
+
+/-- Negation distributes through an additive fold-sum. -/
+theorem foldl_add_neg (xs : List α) (f : α → R) (z : R) :
+    xs.foldl (fun acc x => acc + -f x) (-z) =
+      -xs.foldl (fun acc x => acc + f x) z := by
+  induction xs generalizing z with
+  | nil => rfl
+  | cons x xs ih =>
+    simp only [List.foldl_cons]
+    rw [show -z + -f x = -(z + f x) by grind]
+    exact ih (z + f x)
+
 /-! ### Additivity -/
 
 /-- An additive fold-sum of a pointwise sum splits into two folds, distributing
@@ -221,6 +245,19 @@ theorem foldl_add_add (xs : List α) (f g : α → R) :
       = xs.foldl (fun acc x => acc + (f x + g x)) ((0 : R) + 0) := by congr 1; grind
     _ = xs.foldl (fun acc x => acc + f x) 0 + xs.foldl (fun acc x => acc + g x) 0 :=
         foldl_add_add_start xs f g 0 0
+
+/-- An additive fold-sum of a pointwise difference splits into the difference
+of the two fold-sums, distributing the starting accumulator. -/
+theorem foldl_add_sub (xs : List α) (f g : α → R) (a b : R) :
+    xs.foldl (fun acc x => acc + (f x - g x)) (a - b) =
+      xs.foldl (fun acc x => acc + f x) a - xs.foldl (fun acc x => acc + g x) b := by
+  rw [show a - b = a + -b by grind]
+  calc xs.foldl (fun acc x => acc + (f x - g x)) (a + -b)
+      = xs.foldl (fun acc x => acc + (f x + -g x)) (a + -b) := by
+        apply foldl_add_congr; intro x _; grind
+    _ = xs.foldl (fun acc x => acc + f x) a - xs.foldl (fun acc x => acc + g x) b := by
+        rw [foldl_add_add_start xs f (fun x => -g x) a (-b), foldl_add_neg xs g b]
+        grind
 
 /-! ### Fubini -/
 

--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -18,71 +18,6 @@ universe u v
 
 namespace Vector
 
-/-- Two fold-sums agree when their summand functions agree pointwise on the index list. -/
-private theorem foldl_sum_congr_aux {R : Type u} [Add R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc : R)
-    (h : ∀ x ∈ xs, f x = g x) :
-    xs.foldl (fun acc x => acc + f x) acc =
-      xs.foldl (fun acc x => acc + g x) acc := by
-  induction xs generalizing acc with
-  | nil =>
-      rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = g x := h x (by simp)
-      have hxs : ∀ y ∈ xs, f y = g y := fun y hy => h y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      exact ih (acc + g x) hxs
-
-/-- Left multiplication by `c` distributes through a fold-sum. -/
-private theorem foldl_sum_mul_left_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    c * xs.foldl (fun acc x => acc + f x) acc =
-    xs.foldl (fun acc x => acc + c * f x) (c * acc) := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      have hdist : c * (acc + f x) = c * acc + c * f x := by
-        grind
-      rw [hdist]
-
-/-- The fold-sum of a pointwise sum splits into the sum of fold-sums. -/
-private theorem foldl_sum_add_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
-    (h : acc = accF + accG) :
-    xs.foldl (fun acc x => acc + (f x + g x)) acc =
-    xs.foldl (fun acc x => acc + f x) accF +
-    xs.foldl (fun acc x => acc + g x) accG := by
-  induction xs generalizing acc accF accG with
-  | nil =>
-      simp only [List.foldl_nil]
-      exact h
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      apply ih (acc := acc + (f x + g x)) (accF := accF + f x) (accG := accG + g x)
-      rw [h]
-      grind
-
-/-- The fold-sum of a pointwise difference splits into the difference of fold-sums. -/
-private theorem foldl_sum_sub_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
-    (h : acc = accF - accG) :
-    xs.foldl (fun acc x => acc + (f x - g x)) acc =
-    xs.foldl (fun acc x => acc + f x) accF -
-    xs.foldl (fun acc x => acc + g x) accG := by
-  induction xs generalizing acc accF accG with
-  | nil =>
-      simp only [List.foldl_nil]
-      exact h
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      apply ih (acc := acc + (f x - g x)) (accF := accF + f x) (accG := accG + g x)
-      rw [h]
-      grind
-
 /-- Dot product is additive in its left argument. -/
 theorem dotProduct_add_left {R : Type u} [Lean.Grind.Ring R]
     (u v w : Vector R n) :
@@ -92,11 +27,10 @@ theorem dotProduct_add_left {R : Type u} [Lean.Grind.Ring R]
         (fun acc i => acc + (u + v)[i] * w[i]) 0 =
       (List.finRange n).foldl
         (fun acc i => acc + (u[i] * w[i] + v[i] * w[i])) 0 from ?_]
-  · rw [foldl_sum_add_aux (xs := List.finRange n)
+  · rw [List.foldl_add_add (xs := List.finRange n)
         (f := fun i => u[i] * w[i])
-        (g := fun i => v[i] * w[i])
-        (acc := 0) (accF := 0) (accG := 0) (h := by grind)]
-  · apply foldl_sum_congr_aux
+        (g := fun i => v[i] * w[i])]
+  · apply List.foldl_add_congr
     intro i _
     have hentry : (u + v)[i] = u[i] + v[i] := by
       change (u + v)[i.val] = u[i.val] + v[i.val]
@@ -109,12 +43,12 @@ theorem dotProduct_smul_left {R : Type u} [Lean.Grind.Ring R]
     (c : R) (u w : Vector R n) :
     dotProduct (c • u) w = c * dotProduct u w := by
   unfold dotProduct
-  rw [foldl_sum_mul_left_aux (xs := List.finRange n)
-        (f := fun i => u[i] * w[i]) (c := c) (acc := 0)]
+  rw [← List.foldl_add_mul_left (xs := List.finRange n)
+        (f := fun i => u[i] * w[i]) (c := c)]
   have hzero : c * (0 : R) = 0 := by
     grind
   rw [hzero]
-  apply foldl_sum_congr_aux
+  apply List.foldl_add_congr
   intro i _
   -- `getElem_smul` rewrites the entry to `c • u[i]`, which is defeq to `c * u[i]`
   -- for the scalar action on the coefficient ring.
@@ -128,7 +62,7 @@ theorem dotProduct_comm {R : Type u} [Lean.Grind.CommRing R]
     (u v : Vector R n) :
     dotProduct u v = dotProduct v u := by
   unfold dotProduct
-  apply foldl_sum_congr_aux
+  apply List.foldl_add_congr
   intro i _
   grind
 
@@ -141,11 +75,10 @@ theorem dotProduct_add_right {R : Type u} [Lean.Grind.Ring R]
         (fun acc i => acc + u[i] * (v + w)[i]) 0 =
       (List.finRange n).foldl
         (fun acc i => acc + (u[i] * v[i] + u[i] * w[i])) 0 from ?_]
-  · rw [foldl_sum_add_aux (xs := List.finRange n)
+  · rw [List.foldl_add_add (xs := List.finRange n)
         (f := fun i => u[i] * v[i])
-        (g := fun i => u[i] * w[i])
-        (acc := 0) (accF := 0) (accG := 0) (h := by grind)]
-  · apply foldl_sum_congr_aux
+        (g := fun i => u[i] * w[i])]
+  · apply List.foldl_add_congr
     intro i _
     have hentry : (v + w)[i] = v[i] + w[i] := by
       change (v + w)[i.val] = v[i.val] + w[i.val]
@@ -185,11 +118,10 @@ theorem dotProduct_sub_right {R : Type u} [Lean.Grind.Ring R]
         (fun acc i => acc + u[i] * (v - w)[i]) 0 =
       (List.finRange n).foldl
         (fun acc i => acc + (u[i] * v[i] - u[i] * w[i])) 0 from ?_]
-  · rw [foldl_sum_sub_aux (xs := List.finRange n)
+  · rw [List.foldl_add_sub_zero (xs := List.finRange n)
         (f := fun i => u[i] * v[i])
-        (g := fun i => u[i] * w[i])
-        (acc := 0) (accF := 0) (accG := 0) (h := by grind)]
-  · apply foldl_sum_congr_aux
+        (g := fun i => u[i] * w[i])]
+  · apply List.foldl_add_congr
     intro i _
     have hentry : (v - w)[i] = v[i] - w[i] := by
       change (v - w)[i.val] = v[i.val] - w[i.val]

--- a/HexMatrix/MatrixAlgebra.lean
+++ b/HexMatrix/MatrixAlgebra.lean
@@ -20,178 +20,6 @@ universe u v w
 
 namespace Matrix
 
-/-- A left fold `xs.foldl (· + f ·) acc` leaves the accumulator unchanged when `f`
-vanishes on every element of `xs`; the base case for collapsing zero summands in the
-fold-sum algebra. -/
-private theorem foldl_add_eq_acc_ring {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R)
-    (hf : ∀ x ∈ xs, f x = 0) :
-    xs.foldl (fun acc x => acc + f x) acc = acc := by
-  induction xs generalizing acc with
-  | nil =>
-      simp only [List.foldl_nil]
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = 0 := hf x (by simp)
-      have hxs : ∀ y ∈ xs, f y = 0 := fun y hy => hf y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      have hac : acc + (0 : R) = acc := by grind
-      rw [hac]
-      exact ih acc hxs
-
-/-- `xs.foldl (· + f ·) acc` splits as `acc + xs.foldl (· + f ·) 0`, pulling the running
-accumulator out so a fold-sum can always be taken from a `0` start. -/
-private theorem foldl_sum_start {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R) :
-    xs.foldl (fun acc x => acc + f x) acc =
-      acc + xs.foldl (fun acc x => acc + f x) 0 := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-      grind
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x), ih (acc := (0 : R) + f x)]
-      grind
-
-/-- Two fold-sums over `xs` agree when their summand functions `f` and `g` agree
-pointwise on `xs`; congruence for the fold-sum under the integrand. -/
-private theorem foldl_sum_congr {R : Type u} [Add R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc : R)
-    (h : ∀ x ∈ xs, f x = g x) :
-    xs.foldl (fun acc x => acc + f x) acc =
-      xs.foldl (fun acc x => acc + g x) acc := by
-  induction xs generalizing acc with
-  | nil =>
-      rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = g x := h x (by simp)
-      have hxs : ∀ y ∈ xs, f y = g y := fun y hy => h y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      exact ih (acc + g x) hxs
-
-/-- The fold-sum of a pointwise sum splits into two fold-sums, provided the initial
-accumulator already splits the same way. -/
-private theorem foldl_sum_add_of_acc {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
-    (hacc : acc = accF + accG) :
-    xs.foldl (fun acc x => acc + (f x + g x)) acc =
-      xs.foldl (fun acc x => acc + f x) accF +
-        xs.foldl (fun acc x => acc + g x) accG := by
-  induction xs generalizing acc accF accG with
-  | nil =>
-      simpa only [List.foldl_nil] using hacc
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      apply ih
-      rw [hacc]
-      grind
-
-/-- The fold-sum of a pointwise sum `f x + g x` equals the sum of the two separate
-fold-sums; additivity of the fold-sum over its summand. -/
-private theorem foldl_sum_add {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) :
-    xs.foldl (fun acc x => acc + (f x + g x)) 0 =
-      xs.foldl (fun acc x => acc + f x) 0 +
-        xs.foldl (fun acc x => acc + g x) 0 := by
-  exact foldl_sum_add_of_acc xs f g 0 0 0 (by grind)
-
-/-- A double fold-sum may exchange the order of its outer and inner index lists `xs` and
-`ys`; the Fubini swap for fold-sums used to transpose iterated matrix sums. -/
-private theorem foldl_sum_comm {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} {β : Type w} (xs : List α) (ys : List β) (g : α → β → R) :
-    xs.foldl (fun acc x => acc + ys.foldl (fun acc y => acc + g x y) 0) 0 =
-      ys.foldl (fun acc y => acc + xs.foldl (fun acc x => acc + g x y) 0) 0 := by
-  induction xs with
-  | nil =>
-      symm
-      apply foldl_add_eq_acc_ring
-      intro y _hy
-      rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [foldl_sum_start xs (fun x => ys.foldl (fun acc y => acc + g x y) 0)
-        (0 + ys.foldl (fun acc y => acc + g x y) 0)]
-      rw [ih]
-      have hinner :
-          ys.foldl
-              (fun acc y =>
-                acc + xs.foldl (fun acc x' => acc + g x' y) (0 + g x y)) 0 =
-            ys.foldl
-              (fun acc y =>
-                acc + (g x y + xs.foldl (fun acc x' => acc + g x' y) 0)) 0 := by
-        apply foldl_sum_congr
-        intro y _hy
-        rw [foldl_sum_start xs (fun x' => g x' y) (0 + g x y)]
-        grind
-      rw [hinner, foldl_sum_add]
-      grind
-
-/-- Right multiplication by `c` distributes through a fold-sum, scaling each summand `f x`
-to `f x * c`. -/
-private theorem foldl_sum_mul_right {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    xs.foldl (fun acc x => acc + f x) acc * c =
-      xs.foldl (fun acc x => acc + f x * c) (acc * c) := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      have hdist : (acc + f x) * c = acc * c + f x * c := by grind
-      rw [hdist]
-
-/-- Left multiplication by `c` distributes through a fold-sum, scaling each summand `f x`
-to `c * f x`. -/
-private theorem foldl_sum_mul_left {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    c * xs.foldl (fun acc x => acc + f x) acc =
-      xs.foldl (fun acc x => acc + c * f x) (c * acc) := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      have hdist : c * (acc + f x) = c * acc + c * f x := by grind
-      rw [hdist]
-
-/-- Negation distributes through a fold-sum. -/
-private theorem foldl_sum_neg {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R) :
-    xs.foldl (fun acc x => acc + -f x) (-acc) =
-      -xs.foldl (fun acc x => acc + f x) acc := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [show -acc + -f x = -(acc + f x) by grind]
-      exact ih (acc + f x)
-
-/-- The fold-sum of a pointwise difference `f x - g x` equals the difference of the two
-separate fold-sums. -/
-private theorem foldl_sum_sub {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) (accF accG : R) :
-    xs.foldl (fun acc x => acc + (f x - g x)) (accF - accG) =
-      xs.foldl (fun acc x => acc + f x) accF -
-        xs.foldl (fun acc x => acc + g x) accG := by
-  rw [show accF - accG = accF + -accG by grind]
-  calc
-    xs.foldl (fun acc x => acc + (f x - g x)) (accF + -accG) =
-        xs.foldl (fun acc x => acc + (f x + -g x)) (accF + -accG) := by
-      apply foldl_sum_congr
-      intro x _hx
-      grind
-    _ = xs.foldl (fun acc x => acc + f x) accF -
-          xs.foldl (fun acc x => acc + g x) accG := by
-      rw [foldl_sum_add_of_acc xs f (fun x => -g x) (accF + -accG) accF (-accG)
-        (by grind)]
-      rw [foldl_sum_neg]
-      grind
-
 /-- Folding the indicator-weighted terms `(if i = l then 1 else 0) * f l` over a
 duplicate-free list containing `i` picks out exactly `f i`, adding it to the accumulator;
 the selection step behind reading a single matrix entry out of a sum. -/
@@ -213,7 +41,7 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
           rw [if_neg hxy]
           grind
-        rw [if_pos rfl, foldl_add_eq_acc_ring xs _ _ hxs_zero]
+        rw [if_pos rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq
@@ -251,21 +79,21 @@ theorem mul_assoc_vec [Lean.Grind.Ring R]
           (fun acc l =>
             acc + (List.finRange m).foldl
               (fun acc j => acc + A[ii][j] * B[j][l] * v[l]) 0) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro l _hl
-          rw [foldl_sum_mul_right]
+          rw [List.foldl_add_mul_right]
           grind
     _ = (List.finRange m).foldl
         (fun acc j =>
           acc + A[ii][j] *
             (List.finRange k).foldl (fun acc l => acc + B[j][l] * v[l]) 0) 0 := by
-          rw [foldl_sum_comm]
-          apply foldl_sum_congr
+          rw [List.foldl_add_comm]
+          apply List.foldl_add_congr
           intro j _hj
-          rw [foldl_sum_mul_left]
+          rw [← List.foldl_add_mul_left]
           have hzero : A[ii][j] * (0 : R) = 0 := by grind
           rw [hzero]
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro l _hl
           grind
 
@@ -283,7 +111,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
   change
     (List.finRange m).foldl (fun acc l => acc + A[jj][l] * B[l][ii]) 0 =
       (List.finRange m).foldl (fun acc l => acc + B[l][ii] * A[jj][l]) 0
-  apply foldl_sum_congr
+  apply List.foldl_add_congr
   intro l _hl
   rw [Lean.Grind.CommSemiring.mul_comm]
 
@@ -301,7 +129,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
         (fun acc j => acc + (Matrix.identity (R := R) n)[ii][j] * v[j]) 0 =
         (List.finRange n).foldl
           (fun acc j => acc + (if ii = j then (1 : R) else 0) * v[j]) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro j _hj
           rw [getElem_identity]
     _ = v[ii] := by
@@ -327,7 +155,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
         (fun acc l => acc + (Matrix.identity (R := R) n)[ii][l] * M[l][jj]) 0 =
         (List.finRange n).foldl
           (fun acc l => acc + (if ii = l then (1 : R) else 0) * M[l][jj]) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro l _hl
           rw [getElem_identity]
     _ = M[ii][jj] := by
@@ -353,7 +181,7 @@ theorem transpose_mul_of_mul_comm [Lean.Grind.CommRing R]
         (fun acc l => acc + M[ii][l] * (Matrix.identity (R := R) m)[l][jj]) 0 =
         (List.finRange m).foldl
           (fun acc l => acc + (if jj = l then (1 : R) else 0) * M[ii][l]) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro l _hl
           rw [getElem_identity]
           split <;> grind
@@ -380,7 +208,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
   let ii : Fin n := ⟨i, hi⟩
   simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange m).foldl (fun acc j => acc + A[ii][j] * (0 : R)) 0 = 0
-  apply foldl_add_eq_acc_ring
+  apply List.foldl_add_eq_self
   intro j _hj
   grind
 
@@ -391,7 +219,7 @@ theorem mul_assoc [Lean.Grind.Ring R]
   let ii : Fin n := ⟨i, hi⟩
   simp [HMul.hMul, mulVec, row, Vector.dotProduct]
   change (List.finRange m).foldl (fun acc j => acc + (0 : Matrix R n m)[ii][j] * v[j]) 0 = 0
-  apply foldl_add_eq_acc_ring
+  apply List.foldl_add_eq_self
   intro j _hj
   change (Matrix.zero n m : Matrix R n m)[ii][j] * v[j] = 0
   simpa [Matrix.zero, ofFn] using Lean.Grind.Semiring.zero_mul v[j]
@@ -416,13 +244,13 @@ theorem sub_identity_mulVec [Lean.Grind.Ring R] (Q : Matrix R n n) (v : Vector R
           ((0 : R) - 0) := by
           have hzero : (0 : R) - 0 = 0 := by grind
           rw [hzero]
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro j _hj
           grind
     _ = (List.finRange n).foldl (fun acc j => acc + Q[ii][j] * v[j]) 0 -
           (List.finRange n).foldl
             (fun acc j => acc + (if ii = j then 1 else 0) * v[j]) 0 := by
-          rw [foldl_sum_sub]
+          rw [List.foldl_add_sub]
     _ = (List.finRange n).foldl (fun acc j => acc + Q[ii][j] * v[j]) 0 - v[ii] := by
           rw [foldl_indicator_mul_unique (List.finRange n) ii (fun j => v[j])
             (List.mem_finRange _) (List.nodup_finRange n) 0]

--- a/HexRowReduce/Nullspace.lean
+++ b/HexRowReduce/Nullspace.lean
@@ -193,35 +193,7 @@ the matching pivot row and free column. -/
   simpa [Matrix.col] using nullspaceMatrix_pivot E i k
 
 omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
-private theorem foldl_add_eq_acc_ring_echelon {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R)
-    (hf : ∀ x ∈ xs, f x = 0) :
-    xs.foldl (fun acc x => acc + f x) acc = acc := by
-  induction xs generalizing acc with
-  | nil =>
-      simp only [List.foldl_nil]
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = 0 := hf x (by simp)
-      have hxs : ∀ y ∈ xs, f y = 0 := fun y hy => hf y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      have hac : acc + (0 : R) = acc := by grind
-      rw [hac]
-      exact ih acc hxs
 
-omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
-private theorem foldl_sum_start {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R) :
-    xs.foldl (fun acc x => acc + f x) acc =
-      acc + xs.foldl (fun acc x => acc + f x) 0 := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-      grind
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x), ih (acc := (0 : R) + f x)]
-      grind
 
 omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
 private theorem foldl_one_nonzero {R : Type u} [Lean.Grind.Ring R]
@@ -245,7 +217,7 @@ private theorem foldl_one_nonzero {R : Type u} [Lean.Grind.Ring R]
             exact (List.nodup_cons.mp hnodup).1 hy
           exact hz y (List.mem_cons_of_mem _ hy) hya
         have h0x : (0 : R) + x = x := by grind
-        rw [h0x, foldl_add_eq_acc_ring_echelon zs f x hzero]
+        rw [h0x, List.foldl_add_eq_self zs f x hzero]
       · have hz0 : f z = 0 := hz z (by simp) hza
         rw [hz0]
         have haTail : a ∈ zs := by
@@ -288,7 +260,7 @@ private theorem foldl_two_nonzero {R : Type u} [Lean.Grind.Ring R]
             exact (List.nodup_cons.mp hnodup).1 ht
           exact hz t (List.mem_cons_of_mem _ ht) hta htb
         have h0x : (0 : R) + x = x := by grind
-        rw [h0x, foldl_sum_start zs f x, foldl_one_nonzero zs b f y hbTail hnodupTail hb hbOnly]
+        rw [h0x, List.foldl_add_eq_add_foldl zs f x, foldl_one_nonzero zs b f y hbTail hnodupTail hb hbOnly]
       · by_cases hzb : z = b
         · subst z
           rw [hb]
@@ -305,7 +277,7 @@ private theorem foldl_two_nonzero {R : Type u} [Lean.Grind.Ring R]
               exact (List.nodup_cons.mp hnodup).1 ht
             exact hz t (List.mem_cons_of_mem _ ht) hta htb
           have h0y : (0 : R) + y = y := by grind
-          rw [h0y, foldl_sum_start zs f y, foldl_one_nonzero zs a f x haTail hnodupTail ha haOnly]
+          rw [h0y, List.foldl_add_eq_add_foldl zs f y, foldl_one_nonzero zs a f x haTail hnodupTail ha haOnly]
           grind
         · have hz0 : f z = 0 := hz z (by simp) hza hzb
           rw [hz0]
@@ -423,7 +395,7 @@ private theorem nullspace_echelon_sound {R : Type u} [Lean.Grind.Ring R] {n m : 
         simpa using hrowGet
       rw [hentry]
       grind
-    simpa only using foldl_add_eq_acc_ring_echelon (List.finRange m)
+    simpa only using List.foldl_add_eq_self (List.finRange m)
       (fun j => D.echelon[row][j] * (E.nullspace.get k)[j]) 0 hzero
 
 /-- Every basis vector returned by `nullspace` lies in the nullspace of `M`. -/
@@ -461,34 +433,7 @@ private theorem vector_toList_eq_finRange_map_get {α : Type u} {n : Nat}
   · intro k _ _
     simp
 
-private theorem foldl_sum_mul_left_local {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    c * xs.foldl (fun acc x => acc + f x) acc =
-      xs.foldl (fun acc x => acc + c * f x) (c * acc) := by
-  induction xs generalizing acc with
-  | nil =>
-      simp
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (acc := acc + f x)]
-      have hdist : c * (acc + f x) = c * acc + c * f x := by grind
-      rw [hdist]
 
-private theorem foldl_sum_perm_local {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (f : β → R) {xs ys : List β} (hperm : xs.Perm ys) (z : R) :
-    xs.foldl (fun acc x => acc + f x) z =
-      ys.foldl (fun acc x => acc + f x) z := by
-  induction hperm generalizing z with
-  | nil => rfl
-  | cons _ _ ih =>
-      simp only [List.foldl_cons]
-      exact ih (z + _)
-  | swap x y xs =>
-      simp only [List.foldl_cons]
-      congr 1
-      grind
-  | trans _ _ ih₁ ih₂ =>
-      exact (ih₁ z).trans (ih₂ z)
 
 omit [Mul R] [Add R] [OfNat R 0] [OfNat R 1] in
 private theorem pivotCols_toList_nodup
@@ -612,13 +557,13 @@ private theorem freeSum_eq_neg_pivot {R : Type u} [Lean.Grind.Field R] {n m : Na
             (fun acc l => acc + D.echelon[E.toIsEchelonForm.pivotRow i][l] * v[l]) 0 +
         E.toIsEchelonForm.freeColsList.foldl
             (fun acc l => acc + D.echelon[E.toIsEchelonForm.pivotRow i][l] * v[l]) 0 := by
-    rw [foldl_sum_perm_local
+    rw [List.foldl_add_perm
       (f := fun l => D.echelon[E.toIsEchelonForm.pivotRow i][l] * v[l]) hperm]
     rw [List.foldl_append]
-    rw [foldl_sum_start (R := R)
+    rw [List.foldl_add_eq_add_foldl (R := R)
       (xs := E.toIsEchelonForm.freeColsList)
       (f := fun l => D.echelon[E.toIsEchelonForm.pivotRow i][l] * v[l])
-      (acc := D.pivotCols.toList.foldl
+      (z := D.pivotCols.toList.foldl
         (fun acc l => acc + D.echelon[E.toIsEchelonForm.pivotRow i][l] * v[l]) 0)]
   -- Pivot half: convert to fold over Fin D.rank, use indicator structure.
   have hPivotPart :
@@ -753,12 +698,12 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
                     D.echelon[E.toIsEchelonForm.pivotRow i][
                       E.toIsEchelonForm.freeCols.get k] *
                       v[E.toIsEchelonForm.freeCols.get k]) 0) := by
-        have hmul := foldl_sum_mul_left_local
+        have hmul := (List.foldl_add_mul_left
           (xs := List.finRange (m - D.rank))
           (f := fun k =>
             D.echelon[E.toIsEchelonForm.pivotRow i][E.toIsEchelonForm.freeCols.get k] *
               v[E.toIsEchelonForm.freeCols.get k])
-          (c := (-1 : R)) (acc := 0)
+          (c := (-1 : R)) (z := 0)).symm
         have hzero : ((-1 : R)) * 0 = 0 := by grind
         rw [hzero] at hmul
         have h1 :

--- a/HexRowReduce/Nullspace.lean
+++ b/HexRowReduce/Nullspace.lean
@@ -638,7 +638,7 @@ private theorem freeSum_eq_neg_pivot {R : Type u} [Lean.Grind.Field R] {n m : Na
           (List.finRange D.rank).foldl
             (fun acc i' =>
               acc + (if i = i' then (1 : R) else 0) * v[D.pivotCols.get i']) 0 := by
-      apply foldl_sum_congr
+      apply List.foldl_add_congr
       intro i' _hi'
       have h := pivot_column_entry_pivotRow E i i'
       rw [h]
@@ -734,7 +734,7 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
                   -(D.echelon[E.toIsEchelonForm.pivotRow i][
                       E.toIsEchelonForm.freeCols.get k] *
                     v[E.toIsEchelonForm.freeCols.get k])) 0 := by
-        apply foldl_sum_congr
+        apply List.foldl_add_congr
         intro k _hk
         rw [nullspaceMatrix_pivot E i k, hcEntry k]
         grind
@@ -775,7 +775,7 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
                       (D.echelon[E.toIsEchelonForm.pivotRow i][
                           E.toIsEchelonForm.freeCols.get k] *
                         v[E.toIsEchelonForm.freeCols.get k]))) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro k _hk
           grind
         rw [h1, ← hmul]
@@ -805,7 +805,7 @@ theorem nullspace_complete {R : Type u} [Lean.Grind.Field R] {n m : Nat}
               (fun acc k =>
                 acc + (if l = k then (1 : R) else 0) *
                   v[E.toIsEchelonForm.freeCols.get k]) 0 := by
-        apply foldl_sum_congr
+        apply List.foldl_add_congr
         intro k _hk
         rw [hcEntry k]
         by_cases hkl : k = l

--- a/HexRowReduce/RowEchelon/Elementary.lean
+++ b/HexRowReduce/RowEchelon/Elementary.lean
@@ -29,71 +29,6 @@ universe u
 namespace Matrix
 
 
-/-- Two fold-sums over `xs` agree when their summand functions `f` and `g` agree
-pointwise on `xs`; congruence for the fold-sum under the integrand, used to rewrite
-the summand in the row-echelon sum manipulations. -/
-private theorem foldl_sum_congr_aux {R : Type u} [Add R] {α : Type v}
-    (xs : List α) (f g : α → R) (acc : R)
-    (h : ∀ x ∈ xs, f x = g x) :
-    xs.foldl (fun acc x => acc + f x) acc =
-    xs.foldl (fun acc x => acc + g x) acc := by
-  induction xs generalizing acc with
-  | nil => rfl
-  | cons x xs ih =>
-    simp only [List.foldl_cons]
-    have hx : f x = g x := h x (by simp)
-    have hxs : ∀ y ∈ xs, f y = g y := fun y hy => h y (List.mem_cons_of_mem _ hy)
-    rw [hx]
-    exact ih (acc + g x) hxs
-
-/-- Left multiplication by `c` distributes through a fold-sum, scaling each summand
-`f x` to `c * f x` and the initial accumulator to `c * acc`; pulls a left scalar
-factor through the accumulating sum in the row-echelon rewrites. -/
-private theorem foldl_sum_mul_left_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    c * xs.foldl (fun acc x => acc + f x) acc =
-    xs.foldl (fun acc x => acc + c * f x) (c * acc) := by
-  induction xs generalizing acc with
-  | nil => simp
-  | cons x xs ih =>
-    simp only [List.foldl_cons]
-    rw [ih (acc := acc + f x)]
-    have hdist : c * (acc + f x) = c * acc + c * f x := by grind
-    rw [hdist]
-
-/-- Right multiplication by `c` distributes through a fold-sum, scaling each summand
-`f x` to `f x * c` and the initial accumulator to `acc * c`; pulls a right scalar
-factor through the accumulating sum in the row-echelon rewrites. -/
-private theorem foldl_sum_mul_right_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (c acc : R) :
-    xs.foldl (fun acc x => acc + f x) acc * c =
-    xs.foldl (fun acc x => acc + f x * c) (acc * c) := by
-  induction xs generalizing acc with
-  | nil => simp
-  | cons x xs ih =>
-    simp only [List.foldl_cons]
-    rw [ih (acc := acc + f x)]
-    have hdist : (acc + f x) * c = acc * c + f x * c := by grind
-    rw [hdist]
-
-/-- The fold-sum of a pointwise sum `f x + g x` splits into the two separate
-fold-sums, provided the starting accumulator splits as `acc = accF + accG`;
-additivity of the fold-sum over its summand in the row-echelon rewrites. -/
-private theorem foldl_sum_add_aux {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc accF accG : R)
-    (h : acc = accF + accG) :
-    xs.foldl (fun acc x => acc + (f x + g x)) acc =
-    xs.foldl (fun acc x => acc + f x) accF +
-    xs.foldl (fun acc x => acc + g x) accG := by
-  induction xs generalizing acc accF accG with
-  | nil =>
-    simp only [List.foldl_nil]
-    exact h
-  | cons x xs ih =>
-    simp only [List.foldl_cons]
-    apply ih (acc := acc + (f x + g x)) (accF := accF + f x) (accG := accG + g x)
-    rw [h]; grind
-
 /-- Pull a scalar multiple out of the left argument of a dot product when the
 left vector is given by `Vector.ofFn (fun k => s * v[k])`. -/
 private theorem dotProduct_smul_ofFn_left [Lean.Grind.Ring R]
@@ -101,11 +36,11 @@ private theorem dotProduct_smul_ofFn_left [Lean.Grind.Ring R]
     (Vector.ofFn fun k => s * v[k]).dotProduct w =
     s * v.dotProduct w := by
   unfold Vector.dotProduct
-  rw [foldl_sum_mul_left_aux (xs := List.finRange m)
-        (f := fun i => v[i] * w[i]) (c := s) (acc := 0)]
+  rw [← List.foldl_add_mul_left (xs := List.finRange m)
+        (f := fun i => v[i] * w[i]) (c := s) (z := 0)]
   have hzero : s * (0 : R) = 0 := by grind
   rw [hzero]
-  apply foldl_sum_congr_aux
+  apply List.foldl_add_congr
   intro i _
   have hofFn : (Vector.ofFn (fun k : Fin m => s * v[k]))[i] = s * v[i] := by
     simp
@@ -126,14 +61,14 @@ private theorem dotProduct_add_smul_ofFn_left [Lean.Grind.Ring R]
         (fun acc i => acc + (u[i] * w[i] + s * (v[i] * w[i]))) 0 from ?_]
   · -- Now split the sum
     have hzero : (0 : R) = 0 + s * 0 := by grind
-    rw [foldl_sum_add_aux (xs := List.finRange m)
+    rw [List.foldl_add_add_of_acc (xs := List.finRange m)
           (f := fun i => u[i] * w[i])
           (g := fun i => s * (v[i] * w[i]))
           (acc := 0) (accF := 0) (accG := s * 0) (h := by grind)]
     -- Pull s out of the second sum
-    rw [← foldl_sum_mul_left_aux (xs := List.finRange m)
-          (f := fun i => v[i] * w[i]) (c := s) (acc := 0)]
-  · apply foldl_sum_congr_aux
+    rw [List.foldl_add_mul_left (xs := List.finRange m)
+          (f := fun i => v[i] * w[i]) (c := s) (z := 0)]
+  · apply List.foldl_add_congr
     intro i _
     have hofFn : (Vector.ofFn (fun k : Fin m => u[k] + s * v[k]))[i] =
         u[i] + s * v[i] := by
@@ -152,13 +87,13 @@ private theorem dotProduct_add_smul_ofFn_right [Lean.Grind.CommRing R]
         (fun acc i => acc + u[i] * (Vector.ofFn fun k => v[k] + s * w[k])[i]) 0 =
       (List.finRange m).foldl
         (fun acc i => acc + (u[i] * v[i] + s * (u[i] * w[i]))) 0 from ?_]
-  · rw [foldl_sum_add_aux (xs := List.finRange m)
+  · rw [List.foldl_add_add_of_acc (xs := List.finRange m)
         (f := fun i => u[i] * v[i])
         (g := fun i => s * (u[i] * w[i]))
         (acc := 0) (accF := 0) (accG := s * 0) (h := by grind)]
-    rw [← foldl_sum_mul_left_aux (xs := List.finRange m)
-        (f := fun i => u[i] * w[i]) (c := s) (acc := 0)]
-  · apply foldl_sum_congr_aux
+    rw [List.foldl_add_mul_left (xs := List.finRange m)
+        (f := fun i => u[i] * w[i]) (c := s) (z := 0)]
+  · apply List.foldl_add_congr
     intro i _
     have hofFn : (Vector.ofFn (fun k : Fin m => v[k] + s * w[k]))[i] =
         v[i] + s * w[i] := by
@@ -177,13 +112,13 @@ private theorem dotProduct_add_smulRight_ofFn_right [Lean.Grind.Ring R]
         (fun acc i => acc + u[i] * (Vector.ofFn fun k => v[k] + w[k] * s)[i]) 0 =
       (List.finRange m).foldl
         (fun acc i => acc + (u[i] * v[i] + (u[i] * w[i]) * s)) 0 from ?_]
-  · rw [foldl_sum_add_aux (xs := List.finRange m)
+  · rw [List.foldl_add_add_of_acc (xs := List.finRange m)
           (f := fun i => u[i] * v[i])
           (g := fun i => (u[i] * w[i]) * s)
           (acc := 0) (accF := 0) (accG := 0 * s) (h := by grind)]
-    rw [← foldl_sum_mul_right_aux (xs := List.finRange m)
-          (f := fun i => u[i] * w[i]) (c := s) (acc := 0)]
-  · apply foldl_sum_congr_aux
+    rw [← List.foldl_add_mul_right (xs := List.finRange m)
+          (f := fun i => u[i] * w[i]) (c := s) (z := 0)]
+  · apply List.foldl_add_congr
     intro i _
     have hofFn : (Vector.ofFn (fun k : Fin m => v[k] + w[k] * s))[i] =
         v[i] + w[i] * s := by

--- a/HexRowReduce/Span.lean
+++ b/HexRowReduce/Span.lean
@@ -167,37 +167,6 @@ theorem hasNonzeroPivots [Lean.Grind.Field R]
 
 variable {M : Matrix R n m} {D : RowEchelonData R n m}
 
-private theorem foldl_add_eq_acc_ring {R : Type u} [Lean.Grind.Ring R]
-    {α : Type v} (xs : List α) (f : α → R) (acc : R)
-    (hf : ∀ x ∈ xs, f x = 0) :
-    xs.foldl (fun acc x => acc + f x) acc = acc := by
-  induction xs generalizing acc with
-  | nil =>
-      simp only [List.foldl_nil]
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = 0 := hf x (by simp)
-      have hxs : ∀ y ∈ xs, f y = 0 := fun y hy => hf y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      have hac : acc + (0 : R) = acc := by grind
-      rw [hac]
-      exact ih acc hxs
-
-private theorem foldl_sum_congr {R : Type u} [Add R]
-    {α : Type v} (xs : List α) (f g : α → R) (acc : R)
-    (h : ∀ x ∈ xs, f x = g x) :
-    xs.foldl (fun acc x => acc + f x) acc =
-      xs.foldl (fun acc x => acc + g x) acc := by
-  induction xs generalizing acc with
-  | nil =>
-      rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      have hx : f x = g x := h x (by simp)
-      have hxs : ∀ y ∈ xs, f y = g y := fun y hy => h y (List.mem_cons_of_mem _ hy)
-      rw [hx]
-      exact ih (acc + g x) hxs
-
 private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
     {n : Nat} (xs : List (Fin n)) (i : Fin n) (f : Fin n → R)
     (hi : i ∈ xs) (hnodup : xs.Nodup) (acc : R) :
@@ -216,7 +185,7 @@ private theorem foldl_indicator_mul_unique {R : Type u} [Lean.Grind.Ring R]
           have hxy : x ≠ y := fun heq => (List.nodup_cons.mp hnodup).1 (heq ▸ hy)
           rw [if_neg hxy]
           grind
-        rw [if_pos rfl, foldl_add_eq_acc_ring xs _ _ hxs_zero]
+        rw [if_pos rfl, List.foldl_add_eq_self xs _ _ hxs_zero]
         grind
       · have hxi : i ≠ x := by
           intro heq
@@ -265,7 +234,7 @@ theorem rowCombination_single {R : Type u} [Lean.Grind.CommRing R]
             (Vector.ofFn fun l : Fin n => if i = l then (1 : R) else 0)[l]) 0 =
         (List.finRange n).foldl
           (fun acc l => acc + (if i = l then (1 : R) else 0) * M[l][jf]) 0 := by
-    apply foldl_sum_congr
+    apply List.foldl_add_congr
     intro l _hl
     by_cases hil : i = l
     · simp [hil, Lean.Grind.CommSemiring.mul_comm]
@@ -337,7 +306,7 @@ private theorem rowCombination_pivotCoeff [Lean.Grind.Field R] (E : IsRowReduced
         (List.finRange n).foldl
           (fun acc i =>
             acc + (if E.toIsEchelonForm.pivotRow p = i then (1 : R) else 0) * c[i]) 0 := by
-          apply foldl_sum_congr
+          apply List.foldl_add_congr
           intro i _hi
           rw [pivot_column_entry E p i]
     _ = c[E.toIsEchelonForm.pivotRow p] := by
@@ -366,7 +335,7 @@ private theorem rowCombination_eq_of_coeffs_eq_on_rank [Lean.Grind.Field R]
       (fun acc i => acc + D.echelon[i][jj] * c[i]) 0 =
     (List.finRange n).foldl
       (fun acc i => acc + D.echelon[i][jj] * d[i]) 0
-  apply foldl_sum_congr
+  apply List.foldl_add_congr
   intro i _hi
   by_cases hirank : i.val < D.rank
   · let r : Fin D.rank := ⟨i.val, hirank⟩


### PR DESCRIPTION
This PR migrates the matrix-tower's duplicated fold-sum algebra onto the shared `HexBasic.Fold` API introduced in the HexBasic library, removing roughly thirty private helper lemmas that were copied — often byte-for-byte — across five files. It first extends HexBasic with the `Lean.Grind.Ring`-level additive lemmas the matrix tower needs but that were not yet present: `List.foldl_add_mul_right` (right scalar factoring via right distributivity, no commutativity), `List.foldl_add_neg`, `List.foldl_add_sub` and `List.foldl_add_sub_zero`, and `List.foldl_add_add_of_acc` (the accumulator-split form). It then deletes the per-file `foldl_sum_*` / `foldl_add_eq_acc_ring` copies in `HexMatrix/MatrixAlgebra.lean`, `HexMatrix/DotProduct.lean`, `HexRowReduce/Span.lean`, `HexRowReduce/RowEchelon/Elementary.lean`, and `HexRowReduce/Nullspace.lean`, pointing every call site at `List.foldl_add_*`.

The `_aux`-suffixed copies in `DotProduct` and `Elementary` were exact duplicates of the `MatrixAlgebra` helpers, so they collapse to the same lemmas. The genuinely domain-specific helpers — `foldl_indicator_mul_unique`, `foldl_one_nonzero`, `foldl_two_nonzero` (indicator pickout of one or two matrix entries from a fold-sum) — stay local, since they name a specific operation rather than general fold algebra. The whole graph builds green, including every Mathlib bridge layer.

This is the first of the follow-ups flagged when HexBasic landed. Still to come: renaming the determinant `foldl_det_*` zoo onto the same API, per-type `Std.Associative (· * ·)` instances so the Berlekamp/Hensel product folds can join, and the Mathlib-side `foldl_finRange_eq_sum` dedup.

🤖 Prepared with Claude Code