### PR TITLE
feat: add #m[...] matrix notation and grid pretty-printing for Hex.Matrix

### DIFF
--- a/HexMatrix.lean
+++ b/HexMatrix.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexMatrix.Basic
+public import HexMatrix.Notation
 public import HexMatrix.Vector.Insert
 public import HexMatrix.DotProduct
 public import HexMatrix.MatrixAlgebra

--- a/HexMatrix/Notation.lean
+++ b/HexMatrix/Notation.lean
@@ -44,7 +44,10 @@ macro_rules
   | `(#m[$[$[$rows],*];*]) => do
     let nRows := rows.size
     let nCols := if h : 0 < nRows then rows[0].size else 0
-    let rowVecs ← rows.mapM fun row => do
+    let rowVecs ← rows.zipIdx.mapM fun (row, i) => do
+      unless row.size = nCols do
+        Macro.throwErrorAt (mkNullNode (row.map (·.raw)))
+          s!"ragged matrix literal: row {i + 1} has {row.size} entries, but row 1 has {nCols}"
       let elems : Syntax.TSepArray `term "," := .ofElems row
       `(#v[$elems,*])
     let rowsSep : Syntax.TSepArray `term "," := .ofElems rowVecs

--- a/HexMatrix/Notation.lean
+++ b/HexMatrix/Notation.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrix.Basic
+
+public section
+
+/-!
+`#m[...]` literal notation and grid pretty-printing for `Hex.Matrix`.
+
+`#m[a, b; c, d]` builds the matrix with rows `[a, b]` and `[c, d]`: rows are
+separated by `;` and entries by `,`, mirroring Mathlib's `!![...]` but with a
+distinct opening token, so the two notations coexist in the Mathlib bridge
+libraries (Mathlib owns `![` and `!![`).
+
+```
+#m[1, 2;
+   3, 4]   -- : Hex.Matrix Int 2 2
+```
+
+A literal collects its rows into nested `#v[...]` vectors and feeds them to
+`Hex.Matrix.ofFn`, so the construction goes through the public matrix API. Row
+lengths are checked by the elaborator: a ragged literal fails to typecheck
+rather than silently building a malformed matrix.
+
+The `Repr` instance renders a matrix as a column-aligned grid under `#eval`.
+-/
+
+namespace Hex.Matrix
+
+open Lean
+
+/-- `#m[a, b; c, d]` is the `Hex.Matrix` with rows `[a, b]` and `[c, d]`.
+Rows are `;`-separated and entries `,`-separated. -/
+syntax (name := matrixLiteral)
+  "#m[" ppRealGroup(sepBy1(ppGroup(term,+,?), ";", "; ", allowTrailingSep)) "]" : term
+
+macro_rules
+  | `(#m[$[$[$rows],*];*]) => do
+    let nRows := rows.size
+    let nCols := if h : 0 < nRows then rows[0].size else 0
+    let rowVecs ← rows.mapM fun row => do
+      let elems : Syntax.TSepArray `term "," := .ofElems row
+      `(#v[$elems,*])
+    let rowsSep : Syntax.TSepArray `term "," := .ofElems rowVecs
+    `(let d := #v[$rowsSep,*];
+      Hex.Matrix.ofFn (n := $(quote nRows)) (m := $(quote nCols)) fun i j => d[i][j])
+
+/-- Render `M` as a column-aligned grid of its entries, right-justified within
+each column. For example,
+```
+⎡  0 2  1 ⎤
+⎢ -6 0 -8 ⎥
+⎣  5 6  0 ⎦
+```
+This is what the `Repr` instance shows under `#eval`. -/
+def render [Repr R] (M : Matrix R n m) : Std.Format :=
+  let cells : List (List String) :=
+    M.toList.map fun row => row.toList.map fun x => (repr x).pretty
+  let widths : List Nat :=
+    (List.range m).map fun j => cells.foldl (fun w r => max w (r.getD j "").length) 0
+  let pad : String → Nat → String := fun s w => String.ofList (List.replicate (w - s.length) ' ') ++ s
+  let rowText : List String → String := fun r =>
+    " ".intercalate (((List.range m).zip widths).map fun (j, w) => pad (r.getD j "") w)
+  let n := cells.length
+  let decorate : Nat → String → String := fun i s =>
+    let (l, r) :=
+      if n = 1 then ("[", "]")
+      else if i = 0 then ("⎡", "⎤")
+      else if i + 1 = n then ("⎣", "⎦")
+      else ("⎢", "⎥")
+    l ++ " " ++ s ++ " " ++ r
+  Std.Format.text (String.intercalate "\n" (cells.zipIdx.map fun (r, i) => decorate i (rowText r)))
+
+/-- Show matrices as column-aligned grids under `#eval`/`Repr`. Higher priority
+than the generic `Vector` instance so it wins for the nested-vector
+representation; plain (non-nested) vectors keep the default rendering. -/
+instance (priority := high) [Repr R] : Repr (Matrix R n m) where
+  reprPrec M _ := M.render
+
+/-- The grid rendering as a `String`. -/
+instance [Repr R] : ToString (Matrix R n m) where
+  toString M := M.render.pretty
+
+end Hex.Matrix

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -91,6 +91,10 @@ private def spanVec : Vector Rat 3 :=
 #guard baseInt * (Matrix.identity (R := Int) 2) = baseInt
 #guard Matrix.transpose (Matrix.transpose baseInt) = baseInt
 
+-- `#m[...]` literal notation agrees with the `ofFn` fixtures.
+#guard (#m[1, 2; 3, 4] : Matrix Int 2 2) = baseInt
+#guard (#m[0, 2, 1; 3, 0, 4; 5, 6, 0] : Matrix Int 3 3) = pivotInt
+
 /-- info: ⎡ 1 3 ⎤
 ⎣ 2 4 ⎦ -/
 #guard_msgs in #eval Matrix.transpose baseInt

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -91,29 +91,29 @@ private def spanVec : Vector Rat 3 :=
 #guard baseInt * (Matrix.identity (R := Int) 2) = baseInt
 #guard Matrix.transpose (Matrix.transpose baseInt) = baseInt
 
-/-- info: { toArray := #[{ toArray := #[1, 3], size_toArray := _ }, { toArray := #[2, 4], size_toArray := _ }],
-  size_toArray := _ } -/
+/-- info: ⎡ 1 3 ⎤
+⎣ 2 4 ⎦ -/
 #guard_msgs in #eval Matrix.transpose baseInt
 
 /-- info: { toArray := #[17, 39], size_toArray := _ } -/
 #guard_msgs in #eval Matrix.mulVec baseInt vecInt
 
-/-- info: { toArray := #[{ toArray := #[7, 10], size_toArray := _ }, { toArray := #[15, 22], size_toArray := _ }],
-  size_toArray := _ } -/
+/-- info: ⎡  7 10 ⎤
+⎣ 15 22 ⎦ -/
 #guard_msgs in #eval baseInt * baseInt
 
-/-- info: { toArray := #[{ toArray := #[3, 4], size_toArray := _ }, { toArray := #[1, 2], size_toArray := _ }],
-  size_toArray := _ } -/
+/-- info: ⎡ 3 4 ⎤
+⎣ 1 2 ⎦ -/
 #guard_msgs in #eval Matrix.rowSwap baseInt ⟨0, by decide⟩ ⟨1, by decide⟩
 
-/-- info: { toArray := #[{ toArray := #[0, 2, 1], size_toArray := _ }, { toArray := #[-6, 0, -8], size_toArray := _ },
-               { toArray := #[5, 6, 0], size_toArray := _ }],
-  size_toArray := _ } -/
+/-- info: ⎡  0 2  1 ⎤
+⎢ -6 0 -8 ⎥
+⎣  5 6  0 ⎦ -/
 #guard_msgs in #eval Matrix.rowScale pivotInt ⟨1, by decide⟩ (-2)
 
-/-- info: { toArray := #[{ toArray := #[0, 2, 1], size_toArray := _ }, { toArray := #[3, 0, 4], size_toArray := _ },
-               { toArray := #[5, 12, 3], size_toArray := _ }],
-  size_toArray := _ } -/
+/-- info: ⎡ 0  2 1 ⎤
+⎢ 3  0 4 ⎥
+⎣ 5 12 3 ⎦ -/
 #guard_msgs in #eval Matrix.rowAdd pivotInt ⟨0, by decide⟩ ⟨2, by decide⟩ 3
 
 #guard Matrix.rowSwap (Matrix.rowSwap baseInt ⟨0, by decide⟩ ⟨1, by decide⟩)


### PR DESCRIPTION
This PR adds `#m[...]` literal notation and grid pretty-printing for `Hex.Matrix`. A literal `#m[1, 2; 3, 4]` builds the matrix with `;`-separated rows and `,`-separated entries, mirroring Mathlib's `!![...]` but with a distinct opening token so the two coexist in the Mathlib bridge libraries (Mathlib owns `![` and `!![`). The literal collects its rows into nested `#v[...]` vectors and feeds them to `Hex.Matrix.ofFn`, so the construction goes through the public matrix API and is independent of the underlying representation; this makes the notation land cleanly before or after https://github.com/kim-em/hex-dev/pull/8442 (refactor: encapsulate Hex.Matrix behind a one-field structure). Row lengths are checked by the elaborator, so a ragged literal fails to typecheck rather than building a malformed matrix.

A `Repr` instance renders matrices as column-aligned grids under `#eval` (right-justified per column), with higher priority than the generic `Vector` instance so it wins for the nested-vector representation while plain vectors keep their default rendering. The `HexMatrix` conformance snapshots are updated to the grid output.

```
#eval #m[0, 2, 1; -6, 0, -8; 5, 6, 0]
-- ⎡  0 2  1 ⎤
-- ⎢ -6 0 -8 ⎥
-- ⎣  5 6  0 ⎦
```

🤖 Prepared with Claude Code