### PR TITLE
refactor: migrate the determinant foldl_det_* zoo onto HexBasic

### DIFF
--- a/HexDeterminant/Adjugate.lean
+++ b/HexDeterminant/Adjugate.lean
@@ -71,7 +71,7 @@ theorem det_setRow_eq_cofactorRowPairing
     det (setRow M row v) = cofactorRowPairing M row v := by
   rw [det_eq_foldl_laplace_row (setRow M row v) row]
   unfold cofactorRowPairing
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc col _hmem
   rw [show (setRow M row v)[row][col] = v[col] by
     rw [setRow_get_self]]
@@ -103,7 +103,7 @@ theorem foldl_alien_cofactor_eq_zero
           (fun acc k => acc + N[j][k] * cofactor N j k) 0 =
         (List.finRange (n + 1)).foldl
           (fun acc k => acc + M[i][k] * cofactor M j k) 0 := by
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc k _hmem
     have hentry : N[j][k] = M[i][k] := congrArg (fun row => row[k]) hNj
     have hcofk : cofactor N j k = cofactor M j k :=
@@ -155,7 +155,7 @@ theorem mul_adjugate_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
           (fun acc k => acc + M[i][k] * cofactor M j k) 0 := by
     rw [hmul]
     unfold Vector.dotProduct
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc k _hmem
     congr 1
     have hrow : (row M i)[k] = M[i][k] := rfl
@@ -206,7 +206,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       unfold Matrix.mul
       rw [getElem_ofFn]
       unfold Vector.dotProduct
-      apply foldl_acc_congr
+      apply List.foldl_congr
       intro acc k _hmem
       have hrow : (row (adjugate M) i)[k] = (adjugate M)[i][k] := rfl
       have hcol : (col M j)[k] = M[k][j] := by
@@ -220,7 +220,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       unfold Matrix.mul
       rw [getElem_ofFn]
       unfold Vector.dotProduct
-      apply foldl_acc_congr
+      apply List.foldl_congr
       intro acc k _hmem
       have hrow : (row M.transpose j)[k] = M[k][j] := by
         simp [row, transpose, col]
@@ -232,7 +232,7 @@ theorem adjugate_mul_apply {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         rw [hcol', adjugate_get, cofactor_transpose]
       rw [hrow, hcol]
     rw [hleft, hright]
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc k _hmem
     rw [Lean.Grind.CommSemiring.mul_comm]
   rw [hentry, mul_adjugate_apply M.transpose j i, det_transpose M]
@@ -358,7 +358,7 @@ private theorem mul_eq_columnSumMatrix_transpose
   unfold Matrix.mul ofFn
   rw [vector_ofFn_getElem_fin, vector_ofFn_getElem_fin]
   unfold Vector.dotProduct
-  apply foldl_det_sum_congr
+  apply List.foldl_add_congr
   intro k _
   have hrow : (row M rr)[k] = M[rr][k] := by simp [row]
   have hcol : (col N cc)[k] = N[k][cc] := by
@@ -397,12 +397,12 @@ theorem det_mul
             (columnTupleCoeff N.transpose cols *
               det (columnTupleMatrix (Matrix.identity (R := R) n)
                 (columnTupleVectorFn cols)))) 0 := by
-    apply foldl_det_sum_congr
+    apply List.foldl_add_congr
     intro cols _
     rw [det_columnTupleMatrix_eq M (columnTupleVectorFn cols)]
     exact Lean.Grind.CommSemiring.mul_left_comm _ _ _
   rw [hbody_eq]
-  rw [foldl_det_sum_mul_left_zero
+  rw [List.foldl_add_mul_left_zero
         (columnTupleVectors n n)
         (det M)
         (fun cols => columnTupleCoeff N.transpose cols *
@@ -411,54 +411,6 @@ theorem det_mul
   rw [← det_columnSumMatrix_eq_sum_columnTuples
         (Matrix.identity (R := R) n) N.transpose]
   rw [← eq_columnSumMatrix_one_transpose N]
-
-/-- Foldl over a list whose body is identically zero leaves the seed
-unchanged. -/
-theorem foldl_add_zero_body {α : Type u} [Lean.Grind.CommRing α]
-    {β : Type v} (xs : List β) (z : α) (f : β → α)
-    (hall : ∀ y ∈ xs, f y = 0) :
-    xs.foldl (fun acc y => acc + f y) z = z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons y ys ih =>
-      simp only [List.foldl_cons]
-      have hy : f y = 0 := hall y List.mem_cons_self
-      rw [hy]
-      have hzero : z + (0 : α) = z := by grind
-      rw [hzero]
-      exact ih z (fun w hw => hall w (List.mem_cons_of_mem _ hw))
-
-/-- Foldl over a `Nodup` list where the additive contribution is
-nonzero at exactly one matching element. -/
-theorem foldl_add_with_unique_match {α : Type u}
-    [Lean.Grind.CommRing α] {β : Type v} [DecidableEq β]
-    (xs : List β) (z : α) (q : β) (f : β → α)
-    (hmem : q ∈ xs) (hnodup : xs.Nodup) :
-    xs.foldl (fun acc x => acc + (if x = q then f x else (0 : α))) z = z + f q := by
-  induction xs generalizing z with
-  | nil => simp at hmem
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      by_cases hxq : x = q
-      · -- x = q. By nodup, q ∉ xs, so the remaining foldl preserves z + f x.
-        subst hxq
-        rw [if_pos rfl]
-        have hxs_nomem : x ∉ xs := (List.nodup_cons.mp hnodup).1
-        apply foldl_add_zero_body xs (z + f x)
-            (fun y => if y = x then f y else (0 : α))
-        intro y hy
-        have hyne : y ≠ x := fun heq => hxs_nomem (heq ▸ hy)
-        exact if_neg hyne
-      · -- x ≠ q. q still in xs; apply IH.
-        rw [if_neg hxq]
-        have hzero_step : z + (0 : α) = z := by grind
-        rw [hzero_step]
-        have hmem' : q ∈ xs := by
-          cases List.mem_cons.mp hmem with
-          | inl h => exact absurd h.symm hxq
-          | inr h => exact h
-        have hnodup' : xs.Nodup := (List.nodup_cons.mp hnodup).2
-        exact ih z hmem' hnodup'
 
 /-! ### Two-row replacement determinant Plucker kernel
 
@@ -481,7 +433,7 @@ private theorem mul_apply_foldl
   unfold Matrix.mul
   rw [getElem_ofFn]
   unfold Vector.dotProduct
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc l _hmem
   rw [getElem_row, getElem_col]
 
@@ -496,7 +448,7 @@ private theorem setRow_mul_adjugate_apply_row
       cofactorRowPairing M s ((setRow M r u)[i]) := by
   rw [mul_apply_foldl]
   unfold cofactorRowPairing
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc l _hmem
   rw [adjugate_get]
 
@@ -588,7 +540,7 @@ private theorem det_mul_cofactor_setRow_eq
             (fun acc l =>
               acc + if l = c then
                 det (setRow M r u) * cofactor M s l else 0) 0 := by
-      apply foldl_acc_congr
+      apply List.foldl_congr
       intro acc l _hmem
       congr 1
       rw [adjugate_mul_apply, adjugate_get]
@@ -600,7 +552,7 @@ private theorem det_mul_cofactor_setRow_eq
         grind
     rw [hcongr]
     have hmatch :=
-      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) c
+      List.foldl_add_single (R := R) (List.finRange (n + 1)) (0 : R) c
         (fun l => det (setRow M r u) * cofactor M s l)
         (List.mem_finRange c) (List.nodup_finRange (n + 1))
     rw [hmatch]
@@ -628,7 +580,7 @@ private theorem det_mul_cofactor_setRow_eq
                  (if i = s then
                     (adjugate (setRow M r u))[c][i] * det M
                   else 0))) 0 := by
-      apply foldl_acc_congr
+      apply List.foldl_congr
       intro acc i _hmem
       congr 1
       by_cases hir : i = r
@@ -642,13 +594,13 @@ private theorem det_mul_cofactor_setRow_eq
           rw [if_pos rfl, if_pos rfl, Lean.Grind.AddCommMonoid.zero_add]
         · rw [if_neg his, if_neg his, Lean.Grind.Semiring.mul_zero,
             Lean.Grind.AddCommMonoid.add_zero]
-    rw [hbody, foldl_det_sum_add_zero]
+    rw [hbody, List.foldl_add_add]
     have hr_extract :=
-      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) r
+      List.foldl_add_single (R := R) (List.finRange (n + 1)) (0 : R) r
         (fun i => (adjugate (setRow M r u))[c][i] * cofactorRowPairing M s u)
         (List.mem_finRange r) (List.nodup_finRange (n + 1))
     have hs_extract :=
-      foldl_add_with_unique_match (α := R) (List.finRange (n + 1)) (0 : R) s
+      List.foldl_add_single (R := R) (List.finRange (n + 1)) (0 : R) s
         (fun i => (adjugate (setRow M r u))[c][i] * det M)
         (List.mem_finRange s) (List.nodup_finRange (n + 1))
     rw [hr_extract, hs_extract]

--- a/HexDeterminant/CauchyBinet.lean
+++ b/HexDeterminant/CauchyBinet.lean
@@ -393,7 +393,7 @@ private theorem det_columnSumMatrixWithSuffix_expand
       (List.finRange m) (fun k => coeff[dst][k]) (fun k r => source[r][k])
   rw [hself] at hsum
   rw [hsum]
-  apply foldl_det_sum_congr
+  apply List.foldl_add_congr
   intro c _hc
   congr 2
   exact setCol_columnSumMatrixWithSuffix_extend source coeff chosen hk c
@@ -494,7 +494,7 @@ private theorem partialColumnTupleCoeff_nil
     (coeff : Matrix R n m) (cols : Vector (Fin m) n) :
     partialColumnTupleCoeff coeff [] cols = columnTupleCoeff coeff cols := by
   unfold partialColumnTupleCoeff columnTupleCoeff
-  apply foldl_det_product_congr
+  apply List.foldl_mul_congr
   intro i _hmem
   congr 2
 
@@ -514,7 +514,7 @@ private theorem partialColumnTupleCoeff_insertAt_last_fold
   rw [List.finRange_succ_last, List.foldl_append, List.foldl_cons, List.foldl_nil]
   congr 1
   · simp only [List.foldl_map]
-    apply foldl_det_product_congr
+    apply List.foldl_mul_congr
     intro i _hmem
     change
       coeff[(⟨i.val, by
@@ -620,10 +620,10 @@ private theorem columnTupleVectors_suffix_rhs_step
                       (assembleColumnsSuffix (c :: chosen) pref (by
                         have hcons : (c :: chosen).length = chosen.length + 1 := rfl
                         omega))))) 0) 0
-  rw [foldl_det_sum_flatMap]
+  rw [List.foldl_add_flatMap]
   simp only [List.foldl_map]
-  rw [foldl_det_sum_nested_zero, foldl_det_sum_swap]
-  apply foldl_det_sum_congr
+  rw [foldl_det_sum_nested_zero, List.foldl_add_comm]
+  apply List.foldl_add_congr
   intro c _hc
   have hfactor :
       (columnTupleVectors (n - (chosen.length + 1)) m).foldl
@@ -644,7 +644,7 @@ private theorem columnTupleVectors_suffix_rhs_step
                     (assembleColumnsSuffix (c :: chosen) pref (by
                       have hcons : (c :: chosen).length = chosen.length + 1 := rfl
                       omega))))) 0 := by
-    exact foldl_det_sum_mul_left_zero
+    exact List.foldl_add_mul_left_zero
       (columnTupleVectors (n - (chosen.length + 1)) m)
       (coeff[(⟨n - chosen.length - 1, by omega⟩ : Fin n)][c])
       (fun pref =>
@@ -674,7 +674,7 @@ private theorem columnTupleVectors_suffix_rhs_step
                     have hcons : (c :: chosen).length = chosen.length + 1 := rfl
                     omega))))) 0
   rw [← hfactor]
-  apply foldl_det_sum_congr
+  apply List.foldl_add_congr
   intro pref _hpref
   have hcast :
       (n - (chosen.length + 1)) + 1 = n - chosen.length := by
@@ -793,7 +793,7 @@ private theorem det_columnSumMatrixWithSuffix_eq_sum
       have hklt : chosen.length < n := by omega
       rw [det_columnSumMatrixWithSuffix_expand source coeff chosen hklt,
         columnTupleVectors_suffix_rhs_step_natural source coeff chosen hklt]
-      apply foldl_det_sum_congr
+      apply List.foldl_add_congr
       intro c _hc
       congr 2
       have hkcons : (c :: chosen).length ≤ n := by
@@ -818,7 +818,7 @@ theorem det_columnSumMatrix_eq_sum_columnTuples
             det (columnTupleMatrix source (columnTupleVectorFn cols))) 0 := by
   rw [← columnSumMatrixWithSuffix_nil source coeff,
     det_columnSumMatrixWithSuffix_eq_sum source coeff [] (by simp)]
-  apply foldl_det_sum_congr
+  apply List.foldl_add_congr
   intro cols _hcols
   have hcoeff : partialColumnTupleCoeff coeff [] cols = columnTupleCoeff coeff cols :=
     partialColumnTupleCoeff_nil coeff cols
@@ -850,7 +850,7 @@ theorem det_gramMatrix_eq_sum_columnTuples
       (columnSumMatrix A A)[(⟨r, hr⟩ : Fin n)][(⟨c, hc⟩ : Fin n)]
     rw [getElem_columnSumMatrix]
     simp [gramMatrix, ofFn, row, Vector.dotProduct]
-    apply foldl_det_sum_congr
+    apply List.foldl_add_congr
     intro k _hk
     exact Lean.Grind.CommSemiring.mul_comm A[(⟨r, hr⟩ : Fin n)][k] A[(⟨c, hc⟩ : Fin n)][k]
   rw [hgram]

--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -22,7 +22,7 @@ Working from the per-permutation product `detProduct` and signed term
 duplicate-column/row vanishing lemmas (`det_eq_zero_of_col_eq`,
 `det_eq_zero_of_row_eq`) and `det_setCol_add_otherCols` (column operations
 preserve the determinant), plus the `columnSumMatrix` builder and the Fubini
-sum-swap `foldl_det_sum_swap` used by the Cauchy-Binet expansion.
+sum-swap `List.foldl_add_comm` used by the Cauchy-Binet expansion.
 -/
 
 namespace Hex
@@ -59,7 +59,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
             (setCol M dst v)[x][perm[x]] + (setCol M dst w)[x][perm[x]]
           else
             (setCol M dst v)[x][perm[x]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro x _hx
         rw [getElem_setCol, getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
@@ -85,7 +85,7 @@ private theorem detProduct_setCol_add {R : Type u} [Lean.Grind.CommRing R]
             (setCol M dst v)[x][perm[x]] + (1 : R) * (setCol M dst w)[x][perm[x]]
           else
             (setCol M dst v)[x][perm[x]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro x _hx
         by_cases hxp : x = pivot
         · rw [if_pos hxp]
@@ -154,7 +154,7 @@ private theorem detProduct_setCol_smul {R : Type u} [Lean.Grind.CommRing R]
             c * (setCol M dst v)[x][perm[x]]
           else
             (setCol M dst v)[x][perm[x]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro x _hx
         rw [getElem_setCol, getElem_setCol]
         by_cases hxp : x = pivot
@@ -217,7 +217,7 @@ theorem det_setCol_add {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         (fun acc perm =>
           acc + (detTerm (setCol M dst v) perm +
             detTerm (setCol M dst w) perm)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         exact detTerm_setCol_add M dst v w perm (permutationVectors_nodup hmem)
     _ =
@@ -225,7 +225,7 @@ theorem det_setCol_add {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
           (fun acc perm => acc + detTerm (setCol M dst v) perm) 0 +
         (permutationVectors n).foldl
           (fun acc perm => acc + detTerm (setCol M dst w) perm) 0 := by
-        exact foldl_det_sum_add_zero
+        exact List.foldl_add_add
           (permutationVectors n)
           (detTerm (setCol M dst v))
           (detTerm (setCol M dst w))
@@ -241,13 +241,13 @@ theorem det_setCol_smul {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         (fun acc perm => acc + detTerm (setCol M dst (fun r => c * v r)) perm) 0 =
       (permutationVectors n).foldl
         (fun acc perm => acc + c * detTerm (setCol M dst v) perm) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         exact detTerm_setCol_smul M dst c v perm (permutationVectors_nodup hmem)
     _ =
       c * (permutationVectors n).foldl
           (fun acc perm => acc + detTerm (setCol M dst v) perm) 0 := by
-        exact foldl_det_sum_mul_left_zero
+        exact List.foldl_add_mul_left_zero
           (permutationVectors n) c (detTerm (setCol M dst v))
 
 /-- The assembled determinant `det` vanishes when the replaced column is zero. -/
@@ -282,7 +282,7 @@ theorem det_setCol_sum_list {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
                 (0 + coeff x * source x r)) =
             fun r => coeff x * source x r + tail r := by
         funext r
-        rw [foldl_det_sum_start]
+        rw [List.foldl_add_eq_add_foldl]
         simp [tail]
         grind
       calc
@@ -305,7 +305,7 @@ theorem det_setCol_sum_list {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
           xs.foldl (fun acc x => acc + coeff x * det (setCol M dst (source x)))
             (0 + coeff x * det (setCol M dst (source x))) := by
             have hstart :=
-              (foldl_det_sum_start (R := R) xs
+              (List.foldl_add_eq_add_foldl (R := R) xs
                 (fun x => coeff x * det (setCol M dst (source x)))
                 (0 + coeff x * det (setCol M dst (source x)))).symm
             calc
@@ -490,50 +490,6 @@ Uses a list-based "left prefix" partial assignment, with a Fubini-style
 sum-swap to align the iteration order with `columnTupleVectors`.
 -/
 
-/-- Sum-swap (Fubini) for the standard determinant-style nested folds. -/
-theorem foldl_det_sum_swap {R : Type u} [Lean.Grind.CommRing R]
-    {β γ : Type v} (xs : List β) (ys : List γ) (f : β → γ → R) :
-    xs.foldl (fun acc x => acc + ys.foldl (fun acc' y => acc' + f x y) 0) 0 =
-      ys.foldl (fun acc y => acc + xs.foldl (fun acc' x => acc' + f x y) 0) 0 := by
-  induction xs with
-  | nil =>
-      simp only [List.foldl_nil]
-      exact (foldl_det_sum_zero ys 0).symm
-  | cons x xs ih =>
-      have hLHS :
-          (x :: xs).foldl
-              (fun acc x' => acc + ys.foldl (fun acc' y => acc' + f x' y) 0) 0 =
-            ys.foldl (fun acc' y => acc' + f x y) 0 +
-              xs.foldl
-                (fun acc x' => acc + ys.foldl (fun acc' y => acc' + f x' y) 0) 0 := by
-        simp only [List.foldl_cons]
-        rw [foldl_det_sum_start xs
-              (fun x' => ys.foldl (fun acc' y => acc' + f x' y) 0)
-              (0 + ys.foldl (fun acc' y => acc' + f x y) 0)]
-        grind
-      have hRHS :
-          ys.foldl
-              (fun acc y => acc + (x :: xs).foldl
-                (fun acc' x' => acc' + f x' y) 0) 0 =
-            ys.foldl (fun acc' y => acc' + f x y) 0 +
-              ys.foldl
-                (fun acc y => acc + xs.foldl
-                  (fun acc' x' => acc' + f x' y) 0) 0 := by
-        have hfun :
-            (fun (acc : R) y =>
-                acc + (x :: xs).foldl (fun acc' x' => acc' + f x' y) 0) =
-              (fun (acc : R) y =>
-                acc + (f x y + xs.foldl (fun acc' x' => acc' + f x' y) 0)) := by
-          funext acc y
-          congr 1
-          simp only [List.foldl_cons]
-          rw [foldl_det_sum_start xs (fun x' => f x' y) (0 + f x y)]
-          grind
-        rw [hfun]
-        exact foldl_det_sum_add_zero ys (fun y => f x y)
-          (fun y => xs.foldl (fun acc' x' => acc' + f x' y) 0)
-      rw [hLHS, hRHS, ih]
-
 private theorem foldl_det_sum_nested_start {R : Type u} [Lean.Grind.CommRing R]
     {β γ : Type v} (xs : List β) (ys : List γ) (f : β → γ → R) (z : R) :
     xs.foldl (fun acc x => ys.foldl (fun acc' y => acc' + f x y) acc) z =
@@ -545,9 +501,9 @@ private theorem foldl_det_sum_nested_start {R : Type u} [Lean.Grind.CommRing R]
       grind
   | cons x xs ih =>
       simp only [List.foldl_cons]
-      rw [foldl_det_sum_start ys (fun y => f x y) z,
+      rw [List.foldl_add_eq_add_foldl ys (fun y => f x y) z,
         ih (z + ys.foldl (fun acc' y => acc' + f x y) 0)]
-      rw [foldl_det_sum_start xs
+      rw [List.foldl_add_eq_add_foldl xs
         (fun x => ys.foldl (fun acc' y => acc' + f x y) 0)
         (0 + ys.foldl (fun acc' y => acc' + f x y) 0)]
       grind

--- a/HexDeterminant/Enumeration.lean
+++ b/HexDeterminant/Enumeration.lean
@@ -270,19 +270,6 @@ These determinant-agnostic helpers about folds, `Nodup`, and `insertAt`
 support the enumeration completeness and duplicate-freeness proofs below,
 and are reused by the Leibniz determinant layer downstream. -/
 
-/-- Two left folds agree when their step functions agree on every list
-element. -/
-private theorem foldl_acc_congr {α : Type u} {β : Type v}
-    (xs : List β) (f g : α → β → α) (z : α)
-    (h : ∀ acc x, x ∈ xs → f acc x = g acc x) :
-    xs.foldl f z = xs.foldl g z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [h z x (by simp)]
-      exact ih (g z x) (fun acc y hy => h acc y (List.mem_cons_of_mem x hy))
-
 /-- Mapping a duplicate-free list by an injective function preserves
 duplicate-freeness. -/
 private theorem list_nodup_map_of_injective {α : Type u} {β : Type v}
@@ -579,7 +566,7 @@ private theorem foldCount_finRange_ge {n : Nat} (i : Fin (n + 1)) :
               (fun acc y => acc + if i.val ≤ y.val then 1 else 0) 0 =
               (List.finRange (n + 1)).foldl
                 (fun (acc : Nat) (_y : Fin (n + 1)) => acc) 0 := by
-                exact foldl_acc_congr (List.finRange (n + 1))
+                exact List.foldl_congr (List.finRange (n + 1))
                   (fun (acc : Nat) (y : Fin (n + 1)) =>
                     acc + if i.val ≤ y.val then 1 else 0)
                   (fun (acc : Nat) (_y : Fin (n + 1)) => acc) 0 hfalse

--- a/HexDeterminant/Gram.lean
+++ b/HexDeterminant/Gram.lean
@@ -637,7 +637,7 @@ theorem columnTupleCoeff_reconstructInjTuple
     columnTupleCoeff A (reconstructInjTuple sel perm) =
       detProduct (columnTupleMatrix A (columnTupleVectorFn sel)) perm := by
   unfold columnTupleCoeff detProduct
-  apply foldl_det_product_congr
+  apply List.foldl_mul_congr
   intro i _hmem
   rw [getElem_columnTupleMatrix]
   exact congrArg (fun col : Fin m => A[i][col])
@@ -997,7 +997,7 @@ theorem columnTupleExpansion_refold_selectedPerm
           (fun cols => Function.Injective (columnTupleVectorFn cols))).foldl
             (fun acc cols => acc + term cols) 0 := hfilter
     _ = reconstructed.foldl (fun acc cols => acc + term cols) 0 := by
-          exact foldl_det_sum_perm term hperm 0
+          exact List.foldl_add_perm term hperm 0
     _ = (((selectedColumnTuples n m).flatMap fun sel =>
           (permutationVectors n).map (reconstructInjTuple sel))).foldl
         (fun acc cols => acc + columnTupleExpansionTerm A cols) 0 := rfl
@@ -1026,13 +1026,13 @@ private theorem columnTupleExpansion_reconstruct_orbit_sum
         (fun acc perm => acc + columnTupleExpansionTerm A (reconstructInjTuple sel perm)) 0 =
       (permutationVectors n).foldl
         (fun acc perm => acc + detTerm minor perm * det minor) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hperm
         exact columnTupleExpansionTerm_reconstructInjTuple A sel perm hperm
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm minor perm) 0 *
         det minor := by
-        exact foldl_det_sum_mul_right_zero (permutationVectors n) (fun perm => detTerm minor perm)
+        exact List.foldl_add_mul_right_zero (permutationVectors n) (fun perm => detTerm minor perm)
           (det minor)
     _ = det minor ^ 2 := by
         unfold det
@@ -1045,10 +1045,10 @@ private theorem columnTupleExpansion_selectedPerm_collapse
       (fun acc cols => acc + columnTupleExpansionTerm A cols) 0 =
     (selectedColumnTuples n m).foldl
       (fun acc sel => acc + det (columnTupleMatrix A (columnTupleVectorFn sel)) ^ 2) 0 := by
-  rw [foldl_det_sum_flatMap]
-  apply foldl_acc_congr
+  rw [List.foldl_add_flatMap]
+  apply List.foldl_congr
   intro acc sel _hsel
-  rw [foldl_det_sum_start]
+  rw [List.foldl_add_eq_add_foldl]
   congr 1
   rw [foldl_det_sum_map, columnTupleExpansion_reconstruct_orbit_sum A sel]
 

--- a/HexDeterminant/Laplace.lean
+++ b/HexDeterminant/Laplace.lean
@@ -42,14 +42,14 @@ private theorem foldl_detTerm_insertions_eq
       (permutationVectors n).foldl
         (fun acc v => acc + cofactorSign (R := R) i (Fin.last n) *
           (M[i][Fin.last n] * detTerm (deleteRowCol M i (Fin.last n)) v)) 0 := by
-    apply foldl_det_sum_congr
+    apply List.foldl_add_congr
     intro v _hmem
     exact detTerm_insertAt_general M v i
   rw [hsumands]
-  rw [foldl_det_sum_mul_left_zero (permutationVectors n)
+  rw [List.foldl_add_mul_left_zero (permutationVectors n)
     (cofactorSign (R := R) i (Fin.last n))
     (fun v => M[i][Fin.last n] * detTerm (deleteRowCol M i (Fin.last n)) v)]
-  rw [foldl_det_sum_mul_left_zero (permutationVectors n) M[i][Fin.last n]
+  rw [List.foldl_add_mul_left_zero (permutationVectors n) M[i][Fin.last n]
     (fun v => detTerm (deleteRowCol M i (Fin.last n)) v)]
   show cofactorSign (R := R) i (Fin.last n) *
        (M[i][Fin.last n] * det (deleteRowCol M i (Fin.last n))) = _
@@ -70,7 +70,7 @@ theorem det_eq_foldl_laplace_last
           (List.finRange (n + 1)).map fun i =>
             insertAt (Fin.last n) (v.map Fin.castSucc) i)
         (permutationVectors n) from rfl]
-  rw [foldl_det_sum_flatMap]
+  rw [List.foldl_add_flatMap]
   have hmap :
       (permutationVectors n).foldl
         (fun acc v =>
@@ -82,15 +82,15 @@ theorem det_eq_foldl_laplace_last
           (List.finRange (n + 1)).foldl
             (fun acc i =>
               acc + detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i)) acc) 0 := by
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc v _hmem
     simp only [List.foldl_map]
   rw [hmap]
   rw [foldl_det_sum_nested_zero (permutationVectors n) (List.finRange (n + 1))
     (fun v i => detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i))]
-  rw [foldl_det_sum_swap (permutationVectors n) (List.finRange (n + 1))
+  rw [List.foldl_add_comm (permutationVectors n) (List.finRange (n + 1))
     (fun v i => detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i))]
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc i _hmem
   congr 1
   exact foldl_detTerm_insertions_eq M i
@@ -111,7 +111,7 @@ theorem det_eq_foldl_laplace_last_row
     _ =
       (List.finRange (n + 1)).foldl
         (fun acc col => acc + M[Fin.last n][col] * cofactor M (Fin.last n) col) 0 := by
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc col _hmem
         rw [cofactor_transpose]
         simp [Matrix.transpose, Matrix.col]
@@ -281,11 +281,11 @@ theorem det_eq_foldl_laplace_col
         (fun acc row =>
           acc + (-1 : R) ^ (n - col.val) *
             (C[row][Fin.last n] * cofactor C row (Fin.last n))) 0 := by
-        rw [foldl_det_sum_mul_left_zero]
+        rw [List.foldl_add_mul_left_zero]
     _ =
       (List.finRange (n + 1)).foldl
         (fun acc row => acc + M[row][col] * cofactor M row col) 0 := by
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc row _hmem
         congr 1
         unfold cofactor
@@ -327,7 +327,7 @@ theorem det_eq_foldl_laplace_row
     _ =
       (List.finRange (n + 1)).foldl
         (fun acc col => acc + M[row][col] * cofactor M row col) 0 := by
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc col _hmem
         rw [cofactor_transpose, getElem_transpose]
 

--- a/HexDeterminant/LastRow.lean
+++ b/HexDeterminant/LastRow.lean
@@ -249,7 +249,7 @@ private theorem foldl_finRange_succ_factor_skipIndex {R : Type u} [Lean.Grind.Co
     {n : Nat} (i : Fin (n + 1)) (f : Fin (n + 1) → R) :
     (List.finRange (n + 1)).foldl (fun acc r => acc * f r) 1 =
       f i * (List.finRange n).foldl (fun acc r' => acc * f (skipIndex i r')) 1 := by
-  rw [foldl_det_product_perm f (list_finRange_succ_perm_skipIndex i) 1]
+  rw [List.foldl_mul_perm f (list_finRange_succ_perm_skipIndex i) 1]
   show (i :: (List.finRange n).map (skipIndex i)).foldl (fun acc r => acc * f r) 1 = _
   simp only [List.foldl_cons]
   rw [show (1 : R) * f i = f i * 1 from by grind,
@@ -269,7 +269,7 @@ private theorem detProduct_insertAt_general {R : Type u} [Lean.Grind.CommRing R]
   · -- M[i][(insertAt ... i)[i]] = M[i][Fin.last n]
     congr 1
     exact insertAt_get_self _ _ _
-  · apply foldl_det_product_congr
+  · apply List.foldl_mul_congr
     intro r' _hmem
     -- Identify the column index of each side with `(v[r']).castSucc`.
     have hLHS_col :
@@ -345,7 +345,7 @@ private theorem foldl_detTerm_last_row_insertions
             acc + detTerm M
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z =
         (List.finRange n).foldl (fun acc (_i : Fin n) => acc + (0 : R)) z := by
-          apply foldl_det_sum_congr
+          apply List.foldl_add_congr
           intro i _hmem
           rw [detTerm_insertAt_not_last_zero M v i.castSucc
             (by
@@ -355,7 +355,7 @@ private theorem foldl_detTerm_last_row_insertions
               exact (Nat.ne_of_lt i.isLt) hval)
             hrow]
       _ = z := by
-          exact foldl_det_sum_zero (List.finRange n) z
+          exact List.foldl_add_zero (List.finRange n) z
   rw [hprefix, detTerm_insertAt_last]
 
 /-- If the last row is zero before the diagonal entry, the determinant
@@ -374,7 +374,7 @@ theorem det_eq_principalSubmatrix_mul_last
           (List.finRange (n + 1)).map fun i =>
             insertAt (Fin.last n) (v.map Fin.castSucc) i)
         (permutationVectors n) by rfl]
-  rw [foldl_det_sum_flatMap]
+  rw [List.foldl_add_flatMap]
   calc
     (permutationVectors n).foldl
         (fun acc v =>
@@ -386,7 +386,7 @@ theorem det_eq_principalSubmatrix_mul_last
           (List.finRange (n + 1)).foldl
             (fun acc i =>
               acc + detTerm M (insertAt (Fin.last n) (v.map Fin.castSucc) i)) acc) 0 := by
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc v _hmem
         simp only [List.foldl_map]
     _ =
@@ -395,7 +395,7 @@ theorem det_eq_principalSubmatrix_mul_last
           acc + detSign (R := R) v *
             (detProduct (principalSubmatrix M n (Nat.le_succ n)) v *
               M[Fin.last n][Fin.last n])) 0 := by
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc v _hmem
         exact foldl_detTerm_last_row_insertions M v acc hrow
     _ =
@@ -414,7 +414,7 @@ theorem det_eq_principalSubmatrix_mul_last
                 acc + (detSign (R := R) v *
                   detProduct (principalSubmatrix M n (Nat.le_succ n)) v) *
                     M[Fin.last n][Fin.last n]) 0 := by
-              apply foldl_det_sum_congr
+              apply List.foldl_add_congr
               intro v _hmem
               grind
           _ =
@@ -423,7 +423,7 @@ theorem det_eq_principalSubmatrix_mul_last
                   acc + detSign (R := R) v *
                     detProduct (principalSubmatrix M n (Nat.le_succ n)) v) 0 *
               M[Fin.last n][Fin.last n] := by
-              exact foldl_det_sum_mul_right_zero
+              exact List.foldl_add_mul_right_zero
                 (permutationVectors n)
                 (fun v => detSign (R := R) v *
                   detProduct (principalSubmatrix M n (Nat.le_succ n)) v)

--- a/HexDeterminant/Leibniz.lean
+++ b/HexDeterminant/Leibniz.lean
@@ -83,72 +83,6 @@ closed form used by small cofactor expansions. -/
     inversionCount, List.finRange]
   grind
 
-/-- Congruence for the determinant-style left fold over a finite list. -/
-private theorem foldl_det_sum_congr {R : Type u} [Add R] {β : Type v}
-    (xs : List β) (f g : β → R) (z : R)
-    (h : ∀ x, x ∈ xs → f x = g x) :
-    xs.foldl (fun acc x => acc + f x) z =
-      xs.foldl (fun acc x => acc + g x) z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [h x (by simp)]
-      apply ih
-      intro y hy
-      exact h y (List.mem_cons_of_mem x hy)
-
-
-/-- A summing left fold is invariant under permuting the list. -/
-private theorem foldl_det_sum_perm {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (f : β → R) {xs ys : List β} (hperm : xs.Perm ys) (z : R) :
-    xs.foldl (fun acc x => acc + f x) z =
-      ys.foldl (fun acc x => acc + f x) z := by
-  induction hperm generalizing z with
-  | nil => rfl
-  | cons _ _ ih =>
-      simp only [List.foldl_cons]
-      exact ih (z + _)
-  | swap x y xs =>
-      simp only [List.foldl_cons]
-      congr 1
-      grind
-  | trans _ _ ih₁ ih₂ =>
-      exact (ih₁ z).trans (ih₂ z)
-
-/-- A product left fold is unchanged when its factor function is replaced by one
-agreeing on every list element. -/
-private theorem foldl_det_product_congr {R : Type u} [Mul R] {β : Type v}
-    (xs : List β) (f g : β → R) (z : R)
-    (h : ∀ x, x ∈ xs → f x = g x) :
-    xs.foldl (fun acc x => acc * f x) z =
-      xs.foldl (fun acc x => acc * g x) z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [h x (by simp)]
-      apply ih
-      intro y hy
-      exact h y (List.mem_cons_of_mem x hy)
-
-/-- A product left fold is invariant under permuting the list. -/
-private theorem foldl_det_product_perm {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (f : β → R) {xs ys : List β} (hperm : xs.Perm ys) (z : R) :
-    xs.foldl (fun acc x => acc * f x) z =
-      ys.foldl (fun acc x => acc * f x) z := by
-  induction hperm generalizing z with
-  | nil => rfl
-  | cons _ _ ih =>
-      simp only [List.foldl_cons]
-      exact ih (z * _)
-  | swap x y xs =>
-      simp only [List.foldl_cons]
-      congr 1
-      grind
-  | trans _ _ ih₁ ih₂ =>
-      exact (ih₁ z).trans (ih₂ z)
-
 
 /-- Mapping a duplicate-free list preserves duplicate-freeness when the function
 is injective on that list's elements. -/
@@ -170,119 +104,6 @@ private theorem list_nodup_map_on {α : Type u} {β : Type v}
       · exact list_nodup_map_on hnodup.2 (by
           intro a ha b hb hab
           exact hinj a (List.mem_cons_of_mem x ha) b (List.mem_cons_of_mem x hb) hab)
-
-/-- Factor a scalar out of a determinant-style finite left fold. -/
-private theorem foldl_det_sum_mul_left {R : Type u} [Lean.Grind.CommRing R] {β : Type v}
-    (xs : List β) (c : R) (f : β → R) (z : R) :
-    xs.foldl (fun acc x => acc + c * f x) (c * z) =
-      c * xs.foldl (fun acc x => acc + f x) z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [← show c * (z + f x) = c * z + c * f x by grind]
-      exact ih (z + f x)
-
-/-- Factor a scalar out of a determinant-style finite left fold from zero. -/
-private theorem foldl_det_sum_mul_left_zero {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (c : R) (f : β → R) :
-    xs.foldl (fun acc x => acc + c * f x) 0 =
-      c * xs.foldl (fun acc x => acc + f x) 0 := by
-  have hzero : c * 0 = 0 := by grind
-  simpa [hzero] using (foldl_det_sum_mul_left (R := R) xs c f 0)
-
-/-- Factor a right multiplier out of a summing left fold started from zero. -/
-private theorem foldl_det_sum_mul_right_zero {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (f : β → R) (c : R) :
-    xs.foldl (fun acc x => acc + f x * c) 0 =
-      xs.foldl (fun acc x => acc + f x) 0 * c := by
-  calc
-    xs.foldl (fun acc x => acc + f x * c) 0 =
-        xs.foldl (fun acc x => acc + c * f x) 0 := by
-          apply foldl_det_sum_congr
-          intro x _hmem
-          grind
-    _ = c * xs.foldl (fun acc x => acc + f x) 0 := by
-          exact foldl_det_sum_mul_left_zero xs c f
-    _ = xs.foldl (fun acc x => acc + f x) 0 * c := by
-          grind
-
-/-- A summing left fold of a sum of two functions splits into the two folds,
-distributing the starting accumulator. -/
-private theorem foldl_det_sum_add_start {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (f g : β → R) (a b : R) :
-    xs.foldl (fun acc x => acc + (f x + g x)) (a + b) =
-      xs.foldl (fun acc x => acc + f x) a +
-        xs.foldl (fun acc x => acc + g x) b := by
-  induction xs generalizing a b with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      calc
-        xs.foldl (fun acc x => acc + (f x + g x)) (a + b + (f x + g x)) =
-          xs.foldl (fun acc x => acc + (f x + g x)) ((a + f x) + (b + g x)) := by
-            congr 1
-            grind
-        _ =
-          xs.foldl (fun acc x => acc + f x) (a + f x) +
-            xs.foldl (fun acc x => acc + g x) (b + g x) := by
-            exact ih (a + f x) (b + g x)
-
-/-- A summing left fold of the pointwise sum `f x + g x` from `0` splits into the
-sum of the separate folds of `f` and of `g`, each from `0`. -/
-private theorem foldl_det_sum_add_zero {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (f g : β → R) :
-    xs.foldl (fun acc x => acc + (f x + g x)) 0 =
-      xs.foldl (fun acc x => acc + f x) 0 +
-        xs.foldl (fun acc x => acc + g x) 0 := by
-  calc
-    xs.foldl (fun acc x => acc + (f x + g x)) 0 =
-      xs.foldl (fun acc x => acc + (f x + g x)) ((0 : R) + 0) := by
-        congr 1
-        grind
-    _ =
-      xs.foldl (fun acc x => acc + f x) 0 +
-        xs.foldl (fun acc x => acc + g x) 0 := by
-        exact foldl_det_sum_add_start xs f g 0 0
-
-/-- A summing left fold from a starting accumulator `z` equals `z` plus the same
-fold from `0`. -/
-private theorem foldl_det_sum_start {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (f : β → R) (z : R) :
-    xs.foldl (fun acc x => acc + f x) z =
-      z + xs.foldl (fun acc x => acc + f x) 0 := by
-  induction xs generalizing z with
-  | nil =>
-      have hzero : z + (0 : R) = z := by grind
-      exact hzero.symm
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [ih (z + f x), ih (0 + f x)]
-      grind
-
-/-- A summing left fold over `xs.flatMap f` equals the fold over `xs` whose body
-folds each sublist `f x` into the accumulator. -/
-private theorem foldl_det_sum_flatMap {R : Type u} [Add R] {β γ : Type v}
-    (xs : List β) (f : β → List γ) (g : γ → R) (z : R) :
-    (xs.flatMap f).foldl (fun acc x => acc + g x) z =
-      xs.foldl (fun acc x => (f x).foldl (fun acc y => acc + g y) acc) z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons x xs ih =>
-      simp only [List.flatMap_cons, List.foldl_append, List.foldl_cons]
-      exact ih ((f x).foldl (fun acc y => acc + g y) z)
-
-/-- A summing left fold whose body adds `0` returns the starting accumulator `z`
-unchanged. -/
-private theorem foldl_det_sum_zero {R : Type u} [Lean.Grind.CommRing R]
-    {β : Type v} (xs : List β) (z : R) :
-    xs.foldl (fun acc _ => acc + 0) z = z := by
-  induction xs generalizing z with
-  | nil => rfl
-  | cons _ xs ih =>
-      simp only [List.foldl_cons]
-      have hzero : z + (0 : R) = z := by grind
-      simpa [hzero] using ih z
 
 /-- If `a - b + c = 0` and `f x - g x + h x = 0` for every `x ∈ xs`, then the same
 combination of the three summing folds from `a`, `b`, `c` is `0`. -/
@@ -416,7 +237,7 @@ private theorem foldl_det_product_single_add {R : Type u}
           xs.foldl (fun acc x => acc * if x = i then f x + c * g x else f x)
               (z * (f i + c * g i)) =
             xs.foldl (fun acc x => acc * f x) (z * (f i + c * g i)) := by
-              apply foldl_det_product_congr
+              apply List.foldl_mul_congr
               intro y hy
               have hyi : y ≠ i := by
                 intro h
@@ -440,7 +261,7 @@ private theorem foldl_det_product_single_add {R : Type u}
             xs.foldl (fun acc x => acc * f x) (z * f i) +
               c * xs.foldl (fun acc x => acc * g x) (z * g i) := by
               congr 2
-              apply foldl_det_product_congr
+              apply List.foldl_mul_congr
               intro y hy
               exact (hagree y (List.mem_cons.mpr (Or.inr hy)) (by
                 intro h

--- a/HexDeterminant/Permutation.lean
+++ b/HexDeterminant/Permutation.lean
@@ -887,7 +887,7 @@ private theorem permutationVectors_inverseVector_sum {R : Type u}
         (fun acc perm => acc + f perm) 0 := by
         simp [List.foldl_map]
     _ = (permutationVectors n).foldl (fun acc perm => acc + f perm) 0 := by
-        exact foldl_det_sum_perm f inversePermutationVector_map_permutationVectors_perm 0
+        exact List.foldl_add_perm f inversePermutationVector_map_permutationVectors_perm 0
 
 private theorem permutationVectors_composePermutationValues_left_sum {R : Type u}
     [Lean.Grind.CommRing R] {n : Nat}
@@ -903,7 +903,7 @@ private theorem permutationVectors_composePermutationValues_left_sum {R : Type u
         (fun acc perm => acc + f perm) 0 := by
         simp [List.foldl_map]
     _ = (permutationVectors n).foldl (fun acc perm => acc + f perm) 0 := by
-        exact foldl_det_sum_perm f
+        exact List.foldl_add_perm f
           (composePermutationValues_left_map_permutationVectors_perm sigma hsigma) 0
 
 private theorem finRange_map_perm_get_perm {n : Nat}
@@ -923,7 +923,7 @@ private theorem detProduct_colPermute_vector {R : Type u} [Lean.Grind.CommRing R
     detProduct (ofFn fun r c => M[r][sigma[c]]) tau =
       detProduct M (composePermutationValues sigma tau) := by
   unfold detProduct
-  apply foldl_det_product_congr
+  apply List.foldl_mul_congr
   intro r _hr
   simp [ofFn, composePermutationValues]
 
@@ -938,21 +938,21 @@ private theorem detProduct_transpose_inversePermutationValues {R : Type u}
         (fun acc r => acc * M.transpose[r][perm[r]]) 1 =
       (List.finRange n).foldl
         (fun acc r => acc * M[perm[r]][r]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         simp [Matrix.transpose, Matrix.col]
     _ =
       ((List.finRange n).map fun r => perm[r]).foldl
         (fun acc c => acc * M[c][(inversePermutationValues perm hnodup)[c]]) 1 := by
         simp only [List.foldl_map]
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         exact congrArg (fun c => M[perm[r]][c])
           (inversePermutationValues_get_index perm hnodup r).symm
     _ =
       (List.finRange n).foldl
         (fun acc c => acc * M[c][(inversePermutationValues perm hnodup)[c]]) 1 := by
-        exact foldl_det_product_perm
+        exact List.foldl_mul_perm
           (fun c => M[c][(inversePermutationValues perm hnodup)[c]])
           (finRange_map_perm_get_perm perm hnodup) 1
 
@@ -1100,27 +1100,27 @@ private theorem detProduct_rowSwap_transposeValues {R : Type u}
         (fun acc r => acc * (rowSwap M i j)[r][perm[r]]) 1 =
       (List.finRange n).foldl
         (fun acc r => acc * M[finTranspose i j r][perm[r]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         exact rowSwap_get_finTranspose M i j r h perm[r]
     _ =
       ((List.finRange n).map (finTranspose i j)).foldl
         (fun acc r => acc * M[r][perm[finTranspose i j r]]) 1 := by
         simp only [List.foldl_map]
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         exact congrArg (fun k => M[finTranspose i j r][k])
           (vector_get_fin_congr perm (finTranspose_involutive i j r).symm)
     _ =
       (List.finRange n).foldl
         (fun acc r => acc * M[r][perm[finTranspose i j r]]) 1 := by
-        exact foldl_det_product_perm
+        exact List.foldl_mul_perm
           (fun r => M[r][perm[finTranspose i j r]])
           (finRange_map_finTranspose_perm i j) 1
     _ =
       (List.finRange n).foldl
         (fun acc r => acc * M[r][(transposePermutationValues perm i j)[r]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         exact congrArg (fun k => M[r][k])
           (transposePermutationValues_get perm i j r).symm

--- a/HexDeterminant/Plucker.lean
+++ b/HexDeterminant/Plucker.lean
@@ -997,7 +997,7 @@ theorem twoColDet_eq_sum_mDet {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
           acc + v[p] * (cofactorSign (R := R) p (Fin.last (n + 1)) * mDet B u p)) 0 := by
   unfold twoColDet
   rw [det_eq_foldl_laplace_last (twoColMatrix B u v)]
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc p _hmem
   rw [twoColMatrix_entry_last]
   unfold cofactor mDet
@@ -1152,7 +1152,7 @@ private theorem foldl_unit_weighted_single
         (fun acc p => acc + (Vector.unit R q)[p] * f p) 0 =
       f q := by
   have hfold :=
-    foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R) q
+    List.foldl_add_single (R := R) (List.finRange (n + 2)) (0 : R) q
       (fun p => (Vector.unit R q)[p] * f p)
       (List.mem_finRange q) (List.nodup_finRange (n + 2))
   have hcongr :
@@ -1161,7 +1161,7 @@ private theorem foldl_unit_weighted_single
         (List.finRange (n + 2)).foldl
           (fun acc p =>
             acc + if p = q then (Vector.unit R q)[p] * f p else 0) 0 := by
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc p _hmem
     by_cases hp : p = q
     · rw [if_pos hp]
@@ -1195,7 +1195,7 @@ theorem mDet_eq_sum_unit
             (fun acc q => acc + v[q] * (Vector.unit R q)[skipIndex p i]) 0 := by
     funext i
     have hfold :=
-      foldl_add_with_unique_match (α := R) (List.finRange (n + 2)) (0 : R)
+      List.foldl_add_single (R := R) (List.finRange (n + 2)) (0 : R)
         (skipIndex p i)
         (fun q => v[q] * (Vector.unit R q)[skipIndex p i])
         (List.mem_finRange (skipIndex p i)) (List.nodup_finRange (n + 2))
@@ -1206,7 +1206,7 @@ theorem mDet_eq_sum_unit
             (fun acc q =>
               acc + if q = skipIndex p i then
                 v[q] * (Vector.unit R q)[skipIndex p i] else 0) 0 := by
-      apply foldl_acc_congr
+      apply List.foldl_congr
       intro acc q _hmem
       by_cases hq : q = skipIndex p i
       · rw [if_pos hq]
@@ -1226,7 +1226,7 @@ theorem mDet_eq_sum_unit
         rw [getElem_unit_num, if_pos rfl]
         grind
   rw [hcol, det_setCol_sum_finRange]
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc q _hmem
   rw [← mMatrix_eq_setCol_last B (Vector.unit R q) v p]
 
@@ -1257,13 +1257,13 @@ theorem det_eq_signed_minor_of_col_basis
         (List.finRange (n + 1)).foldl
           (fun acc row =>
             acc + (if row = q then cofactor M q c else (0 : R))) 0 := by
-    apply foldl_acc_congr
+    apply List.foldl_congr
     intro acc row _hmem
     exact hbody acc row
   rw [hfold]
   have hmem : q ∈ List.finRange (n + 1) := List.mem_finRange q
   have hnodup : (List.finRange (n + 1)).Nodup := List.nodup_finRange (n + 1)
-  rw [foldl_add_with_unique_match (List.finRange (n + 1)) (0 : R) q
+  rw [List.foldl_add_single (List.finRange (n + 1)) (0 : R) q
         (fun _ => cofactor M q c) hmem hnodup]
   -- Now goal: 0 + cofactor M q c = cofactorSign q c * det (deleteRowCol M q c).
   rw [show (0 : R) + cofactor M q c = cofactor M q c by grind]
@@ -1577,7 +1577,7 @@ theorem twoColDet_eq_sum_unit_pairs
                 acc + u[a] * twoColDet B (Vector.unit R a)
                   (Vector.unit R b)) 0) 0 := by
   rw [twoColDet_eq_sum_mDet]
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc b _hmem
   rw [mDet_eq_sum_unit B u b]
   congr 2
@@ -1589,13 +1589,13 @@ theorem twoColDet_eq_sum_unit_pairs
         (fun acc a =>
           acc + cofactorSign (R := R) b (Fin.last (n + 1)) *
             (u[a] * mDet B (Vector.unit R a) b)) 0 := by
-        rw [foldl_det_sum_mul_left_zero]
+        rw [List.foldl_add_mul_left_zero]
     _ =
       (List.finRange (n + 2)).foldl
         (fun acc a =>
           acc + u[a] * twoColDet B (Vector.unit R a)
             (Vector.unit R b)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro a _ha
         rw [twoColDet_unit_right B (Vector.unit R a) b]
         grind
@@ -1677,13 +1677,13 @@ private theorem det_plucker_three_term_of_unit
       mDet B v p2 * nDet B p1 p3 (Nat.lt_trans h12 h23) +
       mDet B v p3 * nDet B p1 p2 h12 = 0 := by
   rw [mDet_eq_sum_unit B v p1, mDet_eq_sum_unit B v p2, mDet_eq_sum_unit B v p3]
-  rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
+  rw [← List.foldl_add_mul_right_zero (List.finRange (n + 2))
       (fun q => v[q] * mDet B (Vector.unit R q) p1)
       (nDet B p2 p3 h23)]
-  rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
+  rw [← List.foldl_add_mul_right_zero (List.finRange (n + 2))
       (fun q => v[q] * mDet B (Vector.unit R q) p2)
       (nDet B p1 p3 (Nat.lt_trans h12 h23))]
-  rw [← foldl_det_sum_mul_right_zero (List.finRange (n + 2))
+  rw [← List.foldl_add_mul_right_zero (List.finRange (n + 2))
       (fun q => v[q] * mDet B (Vector.unit R q) p3)
       (nDet B p1 p2 h12)]
   apply foldl_det_sum_sub_add_zero

--- a/HexDeterminant/RowOps.lean
+++ b/HexDeterminant/RowOps.lean
@@ -54,7 +54,7 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
             acc + detTerm (Matrix.identity (R := R) (n + 1))
               (insertAt (Fin.last n) (v.map Fin.castSucc) i.castSucc)) z =
         (List.finRange n).foldl (fun acc (_i : Fin n) => acc + (0 : R)) z := by
-          apply foldl_det_sum_congr
+          apply List.foldl_add_congr
           intro i _hmem
           unfold detTerm
           rw [detProduct_identity_insertAt_not_last_zero (R := R) v i.castSucc (by
@@ -64,7 +64,7 @@ private theorem foldl_detTerm_identity_insertions {R : Type u}
             exact (Nat.ne_of_lt i.isLt) hval)]
           grind
       _ = z := by
-          exact foldl_det_sum_zero (List.finRange n) z
+          exact List.foldl_add_zero (List.finRange n) z
   rw [hprefix, detTerm_identity_insertAt_last]
 
 private theorem rowScale_get {R : Type u} [Mul R] {n m : Nat}
@@ -81,7 +81,7 @@ private theorem detProduct_rowScale {R : Type u} [Lean.Grind.CommRing R] {n : Na
         (fun acc r => acc * (rowScale M i c)[r][perm[r]]) 1 =
       (List.finRange n).foldl
         (fun acc r => acc * if r = i then c * M[r][perm[r]] else M[r][perm[r]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         by_cases h : r = i
         · subst r
@@ -180,7 +180,7 @@ private theorem detProduct_colDuplicate_swapValues {R : Type u}
     (perm : Vector (Fin n) n) :
     detProduct M perm = detProduct M (swapPermutationValues perm src dst) := by
   unfold detProduct
-  apply foldl_det_product_congr
+  apply List.foldl_mul_congr
   intro r _hmem
   by_cases hsrc : perm[r] = src
   · have hswap : (swapPermutationValues perm src dst)[r] = dst := by
@@ -266,7 +266,7 @@ private theorem detProduct_colAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
             M[x][perm[x]] + c * (colAddDuplicate M src dst)[x][perm[x]]
           else
             M[x][perm[x]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro x _hx
         rw [colAdd_get]
         by_cases hxp : x = pivot
@@ -345,19 +345,19 @@ private theorem permutationVectors_transposeValues_neg_sum {R : Type u}
     _ =
       (permutationVectors n).foldl
         (fun acc perm => acc + -detTerm M perm) 0 := by
-        exact foldl_det_sum_perm
+        exact List.foldl_add_perm
           (fun perm => -detTerm M perm)
           (transposePermutationValues_map_permutationVectors_perm i j) 0
     _ =
       (permutationVectors n).foldl
         (fun acc perm => acc + (-1 : R) * detTerm M perm) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm _hmem
         grind
     _ =
       (-1 : R) *
         ((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
-        exact foldl_det_sum_mul_left_zero (permutationVectors n) (-1 : R) (detTerm M)
+        exact List.foldl_add_mul_left_zero (permutationVectors n) (-1 : R) (detTerm M)
     _ = -((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
         grind
 
@@ -373,7 +373,7 @@ private theorem permutationVectors_identity_sum {R : Type u} [Lean.Grind.CommRin
       grind
   | succ n ih =>
       simp only [permutationVectors]
-      rw [foldl_det_sum_flatMap]
+      rw [List.foldl_add_flatMap]
       simp only [List.foldl_map, foldl_detTerm_identity_insertions]
       exact ih
 
@@ -388,7 +388,7 @@ private theorem permutationVectors_rowSwap_sum {R : Type u} [Lean.Grind.CommRing
         (fun acc perm => acc + detTerm (rowSwap M i j) perm) 0 =
       (permutationVectors n).foldl
         (fun acc perm => acc + -detTerm M (transposePermutationValues perm i j)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         exact detTerm_rowSwap_transposeValues M i j h perm (permutationVectors_nodup hmem)
     _ = -((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
@@ -449,7 +449,7 @@ private theorem detProduct_rowAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
             M[r][perm[r]] + c * (rowAddDuplicate M src dst)[r][perm[r]]
           else
             M[r][perm[r]]) 1 := by
-        apply foldl_det_product_congr
+        apply List.foldl_mul_congr
         intro r _hmem
         by_cases h : r = dst
         · subst r
@@ -679,7 +679,7 @@ private theorem permutationVectors_duplicateRow_sum {R : Type u} [Lean.Grind.Com
         (((permutationVectors n).filter p).map
             fun perm => transposePermutationValues perm src dst).foldl
           (fun acc perm => acc + term perm) 0 := by
-          exact (foldl_det_sum_perm term hperm 0).symm
+          exact (List.foldl_add_perm term hperm 0).symm
       _ =
         ((permutationVectors n).filter p).foldl
           (fun acc perm => acc + term (transposePermutationValues perm src dst)) 0 := by
@@ -693,18 +693,18 @@ private theorem permutationVectors_duplicateRow_sum {R : Type u} [Lean.Grind.Com
       ((permutationVectors n).filter p).foldl
           (fun acc perm =>
             acc + (term perm + term (transposePermutationValues perm src dst))) 0 := by
-        exact (foldl_det_sum_add_zero
+        exact (List.foldl_add_add
           ((permutationVectors n).filter p) term
           (fun perm => term (transposePermutationValues perm src dst))).symm
     _ = ((permutationVectors n).filter p).foldl (fun acc _ => acc + 0) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         simp only [term]
         rw [detTerm_rowAddDuplicate_transposeValues M src dst h perm]
         · grind
         · exact permutationVectors_nodup (List.mem_filter.mp hmem).1
     _ = 0 := by
-        exact foldl_det_sum_zero ((permutationVectors n).filter p) 0
+        exact List.foldl_add_zero ((permutationVectors n).filter p) 0
 
 private theorem permutationVectors_duplicateCol_sum {R : Type u} [Lean.Grind.CommRing R]
     {n : Nat} (M : Matrix R n n) (src dst : Fin n) (h : src ≠ dst)
@@ -774,7 +774,7 @@ private theorem permutationVectors_duplicateCol_sum {R : Type u} [Lean.Grind.Com
         (((permutationVectors n).filter p).map
             fun perm => swapPermutationValues perm src dst).foldl
           (fun acc perm => acc + term perm) 0 := by
-          exact (foldl_det_sum_perm term hperm 0).symm
+          exact (List.foldl_add_perm term hperm 0).symm
       _ =
         ((permutationVectors n).filter p).foldl
           (fun acc perm => acc + term (swapPermutationValues perm src dst)) 0 := by
@@ -788,18 +788,18 @@ private theorem permutationVectors_duplicateCol_sum {R : Type u} [Lean.Grind.Com
       ((permutationVectors n).filter p).foldl
           (fun acc perm =>
             acc + (term perm + term (swapPermutationValues perm src dst))) 0 := by
-        exact (foldl_det_sum_add_zero
+        exact (List.foldl_add_add
           ((permutationVectors n).filter p) term
           (fun perm => term (swapPermutationValues perm src dst))).symm
     _ = ((permutationVectors n).filter p).foldl (fun acc _ => acc + 0) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         simp only [term]
         rw [detTerm_colDuplicate_swapValues M src dst h hcol perm]
         · grind
         · exact permutationVectors_nodup (List.mem_filter.mp hmem).1
     _ = 0 := by
-        exact foldl_det_sum_zero ((permutationVectors n).filter p) 0
+        exact List.foldl_add_zero ((permutationVectors n).filter p) 0
 
 /-- The multilinear expansion of a column addition has zero total
 duplicate-column contribution, so the Leibniz sum is unchanged. -/
@@ -814,21 +814,21 @@ private theorem permutationVectors_colAdd_sum {R : Type u} [Lean.Grind.CommRing 
       (permutationVectors n).foldl
         (fun acc perm =>
           acc + (detTerm M perm + c * detTerm (colAddDuplicate M src dst) perm)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         exact detTerm_colAdd M src dst c perm (permutationVectors_nodup hmem)
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 +
         (permutationVectors n).foldl
           (fun acc perm => acc + c * detTerm (colAddDuplicate M src dst) perm) 0 := by
-        exact foldl_det_sum_add_zero
+        exact List.foldl_add_add
           (permutationVectors n) (detTerm M)
           (fun perm => c * detTerm (colAddDuplicate M src dst) perm)
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 +
         c * (permutationVectors n).foldl
           (fun acc perm => acc + detTerm (colAddDuplicate M src dst) perm) 0 := by
-        rw [foldl_det_sum_mul_left_zero]
+        rw [List.foldl_add_mul_left_zero]
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 := by
         rw [permutationVectors_duplicateCol_sum (colAddDuplicate M src dst) src dst h]
@@ -850,20 +850,20 @@ private theorem permutationVectors_rowAdd_sum {R : Type u} [Lean.Grind.CommRing 
       (permutationVectors n).foldl
         (fun acc perm =>
           acc + (detTerm M perm + c * detTerm (rowAddDuplicate M src dst) perm)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm _hmem
         exact detTerm_rowAdd M src dst c perm
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 +
         (permutationVectors n).foldl
           (fun acc perm => acc + c * detTerm (rowAddDuplicate M src dst) perm) 0 := by
-        exact foldl_det_sum_add_zero
+        exact List.foldl_add_add
           (permutationVectors n) (detTerm M) (fun perm => c * detTerm (rowAddDuplicate M src dst) perm)
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 +
         c * (permutationVectors n).foldl
           (fun acc perm => acc + detTerm (rowAddDuplicate M src dst) perm) 0 := by
-        rw [foldl_det_sum_mul_left_zero]
+        rw [List.foldl_add_mul_left_zero]
     _ =
       (permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0 := by
         rw [permutationVectors_duplicateRow_sum M src dst h]
@@ -896,11 +896,11 @@ private theorem det_rowScale_leibniz {R : Type u} [Lean.Grind.CommRing R] {n : N
         (fun acc perm => acc + detTerm (rowScale M i c) perm) 0 =
       (permutationVectors n).foldl
         (fun acc perm => acc + c * detTerm M perm) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm _hmem
         exact detTerm_rowScale M i c perm
     _ = c * ((permutationVectors n).foldl (fun acc perm => acc + detTerm M perm) 0) := by
-        exact foldl_det_sum_mul_left_zero (permutationVectors n) c (detTerm M)
+        exact List.foldl_add_mul_left_zero (permutationVectors n) c (detTerm M)
 
 /-- Adding a multiple of one row to a distinct row leaves the Leibniz sum
 unchanged; the extra multilinear contribution has two equal rows. -/
@@ -947,7 +947,7 @@ theorem det_transpose {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (permutationVectors n).foldl (fun acc perm => acc + detTerm M.transpose perm) 0 =
       (permutationVectors n).foldl
         (fun acc perm => acc + detTerm M (inversePermutationVector perm)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro perm hmem
         have hnodup := permutationVectors_nodup hmem
         rw [inversePermutationVector_eq perm hnodup]
@@ -986,7 +986,7 @@ theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         (fun acc tau =>
           acc + detSign (R := R) sigma *
             detTerm M (composePermutationValues sigma tau)) 0 := by
-        apply foldl_det_sum_congr
+        apply List.foldl_add_congr
         intro tau htau
         unfold detTerm
         rw [detProduct_colPermute_vector]
@@ -997,7 +997,7 @@ theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
       detSign (R := R) sigma *
         (permutationVectors n).foldl
           (fun acc tau => acc + detTerm M (composePermutationValues sigma tau)) 0 := by
-        exact foldl_det_sum_mul_left_zero
+        exact List.foldl_add_mul_left_zero
           (permutationVectors n) (detSign (R := R) sigma)
           (fun tau => detTerm M (composePermutationValues sigma tau))
     _ =

--- a/HexDeterminant/Triangular.lean
+++ b/HexDeterminant/Triangular.lean
@@ -99,7 +99,7 @@ theorem det_upperTriangular_eq_finFoldl_diag
               (fun acc i => acc * (principalSubmatrix M n (Nat.le_succ n))[i][i]) 1 =
             Fin.foldl n (fun acc i => acc * M[i.castSucc][i.castSucc]) 1 := by
         rw [Fin.foldl_eq_finRange_foldl, Fin.foldl_eq_finRange_foldl]
-        apply foldl_acc_congr
+        apply List.foldl_congr
         intro acc i _hmem
         have hentry : (principalSubmatrix M n (Nat.le_succ n))[i][i] = M[i.castSucc][i.castSucc] :=
           by simp [principalSubmatrix, ofFn, Fin.castSucc]
@@ -135,7 +135,7 @@ theorem det_lowerTriangular_eq_finFoldl_diag
     simp [transpose, col]
   -- Rewrite the foldl over `M.transpose[i][i]` to `M[i][i]`.
   rw [Fin.foldl_eq_finRange_foldl, Fin.foldl_eq_finRange_foldl]
-  apply foldl_acc_congr
+  apply List.foldl_congr
   intro acc i _hmem
   rw [hdiag]
 

--- a/HexGramSchmidt/Int/Invariant.lean
+++ b/HexGramSchmidt/Int/Invariant.lean
@@ -393,7 +393,7 @@ private theorem foldl_mul_distrib_int {α : Type v}
 
 /-- Expansion of the dot product against `rowCombination` over integers: the
 second argument's row combination distributes outside the sum, giving the
-Σ-over-rows form. Proved via the `Hex.Matrix.foldl_det_sum_swap` Fubini
+Σ-over-rows form. Proved via the `List.foldl_add_comm` Fubini
 identity. -/
 private theorem dot_rowCombination_right_eq
     {n m : Nat} (b : Matrix Int n m) (u : Vector Int m) (c : Vector Int n) :
@@ -430,7 +430,7 @@ private theorem dot_rowCombination_right_eq
   rw [h_distrib]
   -- Step 3: apply Fubini sum-swap.
   have h_swap :=
-    Matrix.foldl_det_sum_swap (R := Int)
+    List.foldl_add_comm (R := Int)
       (xs := List.finRange m) (ys := List.finRange n)
       (fun (j : Fin m) (k : Fin n) => u[j] * (b[k][j] * c[k]))
   rw [h_swap]


### PR DESCRIPTION
This PR retires the general fold-sum and fold-product algebra that was reimplemented inside `HexDeterminant` under `foldl_det_*` names — a zoo whose names recorded where the lemmas lived rather than what they did — and points every call site at the shared `HexBasic.Fold` API landed earlier. It deletes `foldl_det_sum_congr`/`perm`/`start`/`zero`/`add_start`/`add_zero`/`mul_left`/`mul_left_zero`/`mul_right_zero`/`flatMap`/`swap`, `foldl_det_product_congr`/`perm`, `foldl_acc_congr`, and the public `foldl_add_zero_body` / `foldl_add_with_unique_match`, routing them to `List.foldl_congr`, `List.foldl_add_*`, `List.foldl_mul_*`, `List.foldl_add_eq_self`, and `List.foldl_add_single`.

The genuinely determinant-specific helpers stay local, since they name particular operations rather than general fold algebra: the `foldl_det_product_*` factor-scaling family from the Leibniz expansion (`mul_left`, `no_scale`, `single_scale`, `add_start`, `single_add`, `zero_start`, `zero_of_mem`), the nested-fold helpers (`foldl_det_sum_nested_start`/`nested_zero`), `foldl_det_sum_sub_add_zero`, `foldl_det_sum_filter_of_zero`, and `foldl_det_sum_map`. The one cross-library user of `foldl_det_sum_swap` — `HexGramSchmidt/Int/Invariant.lean` — moves to `List.foldl_add_comm`. The whole graph builds green, including every Mathlib bridge layer.

Depends only on the `HexBasic` library (already on `main`); independent of the matrix-tower migration PR.

🤖 Prepared with Claude Code