### PR TITLE
refactor: migrate executable-core non-BZ libraries to the module system

### DIFF
--- a/HexArith.lean
+++ b/HexArith.lean
@@ -4,19 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexArith.Nat.ModArith
-import HexArith.Nat.Pow
-import HexArith.Nat.Prime
-import HexArith.Barrett.ReduceNat
-import HexArith.Barrett.Reduce
-import HexArith.Barrett.Context
-import HexArith.CrossCheck
-import HexArith.ExtGcd
-import HexArith.Montgomery.Context
-import HexArith.Montgomery.InvNat
-import HexArith.Montgomery.Redc
-import HexArith.Montgomery.RedcNat
-import HexArith.UInt64.Wide
+module
+
+public import HexArith.Nat.ModArith
+public import HexArith.Nat.Pow
+public import HexArith.Nat.Prime
+public import HexArith.Barrett.ReduceNat
+public import HexArith.Barrett.Reduce
+public import HexArith.Barrett.Context
+public import HexArith.CrossCheck
+public import HexArith.ExtGcd
+public import HexArith.Montgomery.Context
+public import HexArith.Montgomery.InvNat
+public import HexArith.Montgomery.Redc
+public import HexArith.Montgomery.RedcNat
+public import HexArith.UInt64.Wide
+
+public section
 
 /-!
 `HexArith` collects the low-level arithmetic foundations for the project:

--- a/HexArith/CrossCheck.lean
+++ b/HexArith/CrossCheck.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexArith.Barrett.Context
-import HexArith.Montgomery.Context
-import HexArith.ExtGcd
+module
+
+public import HexArith.Barrett.Context
+public import HexArith.Montgomery.Context
+public import HexArith.ExtGcd
+
+public section
 
 /-!
 Tier-G fast-vs-fast cross-checks for `HexArith` modular multiplication.

--- a/HexGFqRing.lean
+++ b/HexGFqRing.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexGFqRing.Basic
-import HexGFqRing.Operations
+module
+
+public import HexGFqRing.Basic
+public import HexGFqRing.Operations
+
+public section
 
 /-!
 Canonical quotient-ring API for executable `F_p[x] / (f)`.

--- a/HexModArith.lean
+++ b/HexModArith.lean
@@ -4,11 +4,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexModArith.Basic
-import HexModArith.HotLoop
-import HexModArith.Prime
-import HexModArith.Ring
-import HexModArith.Smoke
+module
+
+public import HexModArith.Basic
+public import HexModArith.HotLoop
+public import HexModArith.Prime
+public import HexModArith.Ring
+public import HexModArith.Smoke
+
+public section
 
 /-!
 The `HexModArith` library provides `UInt64`-backed modular arithmetic,

--- a/HexModArith/Smoke.lean
+++ b/HexModArith/Smoke.lean
@@ -4,7 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexModArith.Basic
+module
+
+public meta import HexModArith.Basic
+public import HexModArith.Basic
+
+public section
 
 /-!
 Executable `#guard` / `#eval` checks for the default `ZMod64` multiplication path.

--- a/HexModArithMathlib.lean
+++ b/HexModArithMathlib.lean
@@ -4,7 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexModArithMathlib.Basic
+module
+
+public import HexModArithMathlib.Basic
+
+public section
 
 /-!
 The `HexModArithMathlib` library identifies executable `Hex.ZMod64` residues

--- a/HexModArithMathlib/Basic.lean
+++ b/HexModArithMathlib/Basic.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import Mathlib.Data.ZMod.Basic
-import HexModArith
+module
+
+public import Mathlib.Data.ZMod.Basic
+public import HexModArith
+
+public section
 
 /-!
 Correspondence definitions between `Hex.ZMod64` and Mathlib's `ZMod`.
@@ -27,10 +31,12 @@ variable {p : Nat} [Hex.ZMod64.Bounds p]
 instance : NeZero p := ⟨Nat.ne_of_gt (Hex.ZMod64.Bounds.pPos (p := p))⟩
 
 /-- Interpret an executable `ZMod64` residue as a Mathlib `ZMod` class. -/
+@[expose]
 def toZMod (a : Hex.ZMod64 p) : ZMod p :=
   (a.toNat : ZMod p)
 
 /-- Rebuild an executable `ZMod64` residue from a Mathlib `ZMod` class. -/
+@[expose]
 def ofZMod (a : ZMod p) : Hex.ZMod64 p :=
   Hex.ZMod64.ofNat p a.val
 
@@ -204,6 +210,7 @@ theorem toZMod_pow (a : Hex.ZMod64 p) (n : Nat) :
       rw [Nat.cast_pow]
 
 /-- The executable `ZMod64` representation is ring-equivalent to Mathlib's `ZMod`. -/
+@[expose]
 def equiv : Hex.ZMod64 p ≃+* ZMod p where
   toFun := toZMod
   invFun := ofZMod

--- a/HexPoly.lean
+++ b/HexPoly.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPoly.Dense
-import HexPoly.Euclid
-import HexPoly.Operations
+module
+
+public import HexPoly.Dense
+public import HexPoly.Euclid
+public import HexPoly.Operations
+
+public section
 
 /-! Dense polynomial support for the Hex project. The library exposes the normalized
 array-backed representation together with basic constructors, structural queries, arithmetic,

--- a/HexPolyFp.lean
+++ b/HexPolyFp.lean
@@ -4,16 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPolyFp.Basic
-import HexPolyFp.Packed
-import HexPolyFp.PrimeField
-import HexPolyFp.Compose
-import HexPolyFp.Enumeration
-import HexPolyFp.Frobenius
-import HexPolyFp.SquareFree
-import HexPolyFp.ModCompose
-import HexPolyFp.Quotient
-import HexPolyFp.QuotientFrobenius
+module
+
+public import HexPolyFp.Basic
+public import HexPolyFp.Packed
+public import HexPolyFp.PrimeField
+public import HexPolyFp.Compose
+public import HexPolyFp.Enumeration
+public import HexPolyFp.Frobenius
+public import HexPolyFp.SquareFree
+public import HexPolyFp.ModCompose
+public import HexPolyFp.Quotient
+public import HexPolyFp.QuotientFrobenius
+
+public section
 
 /-!
 `HexPolyFp` specializes the executable dense-polynomial API to

--- a/progress/20260630T062105Z_module_migration_non_bz.md
+++ b/progress/20260630T062105Z_module_migration_non_bz.md
@@ -1,0 +1,91 @@
+# Module-system migration of non-BZ libraries (checkpoint)
+
+## Accomplished
+
+Migrating non-Berlekamp-Zassenhaus libraries to the Lean 4 module system in a
+fresh /tmp clone on branch `module-migration-non-bz`. Excluded per the plan:
+`HexBerlekampZassenhaus`, `HexBerlekampZassenhausMathlib` (only libs downstream
+of BZ), and `HexManual` (by choice; verified it does NOT import BZ).
+
+**Verified green** (`lake build` and `lake build HexConformance` both exit 0,
+real exit code checked in-log):
+
+- `HexArith` — `CrossCheck` + umbrella.
+- `HexPoly` — umbrella.
+- `HexPolyFp` — umbrella.
+- `HexModArith` — `Smoke` + umbrella (Smoke needed `public meta import`, below).
+- `HexModArithMathlib` — `Basic` (`@[expose]` on `toZMod`/`ofZMod`/`equiv`) +
+  umbrella.
+- `HexGFqRing` — umbrella.
+
+## The migration recipe (learned the hard way — read before continuing)
+
+Per file: `module` after the copyright header, blank line, then imports as
+`public import`, then `public section`. Umbrellas migrate last (after all their
+submodules are modules). A `module` file CANNOT import a legacy file, so strict
+bottom-up is mandatory.
+
+Two non-obvious requirements dominate the work:
+
+1. **`#eval` / `#guard_msgs` / `#guard` of imported executable defs need
+   `public meta import` of the providing module** (in addition to the regular
+   `public import` if also used in normal code). These commands run code at
+   elaboration time. Exception: defs marked `@[expose]` are meta-accessible, so
+   a file calling only exposed upstream defs (e.g. `HexArith/CrossCheck`, which
+   uses the exposed Barrett/Montgomery API) needs no meta import. Template:
+   `HexPolyFp/SquareFree.lean` (`public meta import` + `public import`).
+
+2. **Exported (in `public section`) theorems proved by `rfl` / `unfold` /
+   `change` / `decide` require EVERY definition they unfold to be `@[expose]`** —
+   including same-module defs and the backing defs of wrapping instances. The
+   compiler error is "Not a definitional equality ... This theorem is exported
+   ... all definitions that need to be unfolded ... must be exposed." This is
+   the main cost in the delegating-wrapper libraries (GFqField, Hensel, GFq).
+   Template: `HexGFqRing/Operations.lean` exposes its operation defs (`zero`,
+   `one`, `add`, `mul`, ...) but not the `instance`s.
+
+Gotchas found:
+- `@[expose]` is **rejected on a `structure`** ("can only be added when declaring
+  a `def`"). The `FiniteField` projection-`rfl` lemmas in `HexGFqField` still need
+  a solution for cross-module reduction of the structure projection — UNSOLVED.
+- Exposing a `def` whose body calls a `private` def fails with "unknown
+  identifier"; the referenced private def must be made public + `@[expose]`
+  (e.g. `HexGFqField.invPoly`).
+- A `private theorem` referenced later in the same file can report "unknown
+  identifier" under `module` + `public section` (seen at
+  `HexGFqField/Operations.lean` `pow_zero_eq_one`/`inv_inv_def`) — scoping
+  interaction to investigate.
+
+## Process note
+
+`lake build` here is wrapped so the shell ends in `tail`; the background-task
+"exit code 0" reflects `tail`, NOT `lake`. ALWAYS read the real status from a
+`LAKE_EXIT=$?` line written to the log, in the foreground. (An earlier commit
+bundled unverified-broken Tier-1 files because of this; it was reset.)
+
+## Current frontier / next step
+
+Remaining in scope (each needs the `@[expose]`-on-exported-rfl pass above):
+
+- `HexPolyMathlib` (`Basic` line ~524 rfl), `HexPolyZ` (`Basic`: `unfold IsUnit`,
+  `change`, and a private `normalizePrimitiveSign` reference), `HexGF2`
+  (`Basic` line ~646 rfl + likely more across its 11 files) — all reverted to
+  legacy in this checkpoint; redo with the exposure pass.
+- `HexGFqField/Operations` got to 5 residual errors (inv/invPoly expose,
+  `change` in `inv_zero`, the two private-theorem "unknown identifier"s);
+  reverted to legacy for now.
+- Then `HexGF2Mathlib`, `HexHensel`(+Mathlib), `HexPolyZMathlib`,
+  `HexBerlekamp`(+Mathlib — Risk 1: `ZMod64.Bounds` Prop-instance synthesis),
+  `HexConway`, `HexGFq`(+Mathlib), `Hex/` test kit (Risk 3 public API for
+  `Conformance.Emit`/`BenchOracle.Flint`).
+
+Build per file/library; read the real `LAKE_EXIT`; rebuild `HexConformance` after
+umbrellas (legacy conformance drivers must stay green — they do at this
+checkpoint).
+
+## Blockers
+
+`HexGF2` Risk-2 codegen blocker did NOT recur (mechanical `public section`
+without `@[expose]` builds the executable kernels fine); its remaining errors are
+the ordinary exported-rfl exposure pass. Risk 1 (HexBerlekamp `ZMod64.Bounds`)
+not yet reached.


### PR DESCRIPTION
This PR migrates six Mathlib-free executable-core libraries to the Lean 4 module system as a self-contained, bottom-up first step: `HexArith`, `HexPoly`, `HexPolyFp`, `HexModArith`, `HexModArithMathlib`, and `HexGFqRing`. Each migrated file gains a `module` header, `public import`s, and a `public section`; `HexModArith/Smoke.lean` additionally uses `public meta import` because its `#eval` checks run imported executable definitions at elaboration time; and `HexModArithMathlib/Basic.lean` marks the `toZMod`/`ofZMod`/`equiv` conversions `@[expose]` for downstream Mathlib-bridge use. Every other library stays on legacy imports: a `module` file cannot import a legacy file, but legacy files can import modules, so this mixed state is valid and the migration proceeds bottom-up. The full `lake build`, `HexConformance`, and the bench and emit-fixtures executables that depend on these libraries all build green. The remaining in-scope libraries each need an `@[expose]` pass over their exported definitional proofs and are left for follow-up PRs; `HexBerlekampZassenhaus`, its Mathlib bridge, and `HexManual` are out of scope.

🤖 Prepared with Claude Code