### PR TITLE
chore: add hex-basic to the release publish manifest

### DIFF
--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -23,6 +23,18 @@
 # lakefile (matched by their github URL); `lakefile` is that file's format.
 
 repos:
+  - repo: kim-em/hex-basic
+    lib: HexBasic
+    umbrella: true
+    readme: false        # README is authored in the released repo, not managed
+    spec: null
+    bench: false
+    conformance: false
+    fixtures: []
+    oracles: []
+    pins: []
+    lakefile: toml
+
   - repo: kim-em/hex-test-kit
     lib: Hex
     umbrella: false        # released HexTestKit.lean umbrella is fixed


### PR DESCRIPTION
This PR registers the new `HexBasic` library with the publish-out sync so the released split repos stay buildable. Since the HexBasic library landed, `hex-matrix` (and transitively the whole matrix tower) imports it, so the released `hex-matrix` repo now needs a `hex-basic` dependency. This adds `kim-em/hex-basic` as the first (lowest, dependency-free) entry in `scripts/release/released.yml` — umbrella `HexBasic.lean`, managed source `HexBasic/`, no spec/bench/conformance, README authored in the released repo rather than managed.

The `kim-em/hex-basic` repo has been bootstrapped (Std-only skeleton plus the current HexBasic content; builds standalone), and a `hex-basic` pin is added to the consumer repos' lakefiles/manifests so the sync rewrites it to the published revision. A `--dry-run` of the sync for `hex-basic` reports the managed paths map cleanly with no content drift.

🤖 Prepared with Claude Code