### PR TITLE
refactor: migrate HexPolyMathlib and HexPolyZ to the module system

### DIFF
--- a/HexPolyMathlib.lean
+++ b/HexPolyMathlib.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPolyMathlib.Basic
-import HexPolyMathlib.Euclid
+module
+
+public import HexPolyMathlib.Basic
+public import HexPolyMathlib.Euclid
+
+public section
 
 /-!
 The `HexPolyMathlib` library identifies the executable `HexPoly` core with

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -4,14 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import Mathlib.Algebra.Polynomial.Basic
-import Mathlib.Algebra.Polynomial.Coeff
-import Mathlib.Algebra.Polynomial.Degree.Defs
-import Mathlib.Algebra.Polynomial.Degree.Lemmas
-import Mathlib.Algebra.Polynomial.Degree.Operations
-import Mathlib.Algebra.Polynomial.Derivative
-import Mathlib.Algebra.Polynomial.Monomial
-import HexPoly
+module
+
+public import Mathlib.Algebra.Polynomial.Basic
+public import Mathlib.Algebra.Polynomial.Coeff
+public import Mathlib.Algebra.Polynomial.Degree.Defs
+public import Mathlib.Algebra.Polynomial.Degree.Lemmas
+public import Mathlib.Algebra.Polynomial.Degree.Operations
+public import Mathlib.Algebra.Polynomial.Derivative
+public import Mathlib.Algebra.Polynomial.Monomial
+public import HexPoly
+
+public section
 
 /-!
 Identification definitions between the executable `Hex.DensePoly`
@@ -42,10 +46,12 @@ theorem list_getD_map_range_zero [Zero R] (size n : Nat) (f : Nat → R) :
   · simp [hn, List.getD]
 
 /-- Interpret a normalized dense coefficient array as a Mathlib polynomial. -/
+@[expose]
 def toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R) : Polynomial R :=
   Finset.sum (Finset.range p.size) fun i => Polynomial.monomial i (p.coeff i)
 
 /-- Rebuild a normalized dense polynomial from the coefficients of a Mathlib polynomial. -/
+@[expose]
 def ofPolynomial [Semiring R] [DecidableEq R] (p : Polynomial R) : Hex.DensePoly R :=
   Hex.DensePoly.ofCoeffs <| ((List.range (p.natDegree + 1)).map p.coeff).toArray
 
@@ -447,6 +453,7 @@ theorem ofPolynomial_toPolynomial [CommRing R] [DecidableEq R] (p : Hex.DensePol
   simp [coeff_ofPolynomial, coeff_toPolynomial]
 
 /-- The executable dense-polynomial representation is ring-equivalent to Mathlib polynomials. -/
+@[expose]
 def equiv [CommRing R] [DecidableEq R] : Hex.DensePoly R ≃+* Polynomial R where
   toFun := toPolynomial
   invFun := ofPolynomial
@@ -514,7 +521,7 @@ theorem leadingCoeff_toPolynomial [Semiring R] [DecidableEq R]
       rw [Hex.DensePoly.coeff_zero]
       exact Hex.DensePoly.coeff_eq_zero_of_size_le p (by omega)
     rw [hp_zero]
-    rfl
+    simp [Hex.DensePoly.coeff_zero]
   · have hpos : 0 < p.size := Nat.pos_of_ne_zero hsize
     have hdegree_some : p.degree? = some (p.size - 1) := by
       simp [Hex.DensePoly.degree?, hsize]

--- a/HexPolyMathlib/Euclid.lean
+++ b/HexPolyMathlib/Euclid.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPolyMathlib.Basic
-import Mathlib.Algebra.Polynomial.FieldDivision
+module
+
+public import HexPolyMathlib.Basic
+public import Mathlib.Algebra.Polynomial.FieldDivision
+
+public section
 
 /-!
 Euclidean-algorithm correspondence for `HexPolyMathlib`.

--- a/HexPolyZ.lean
+++ b/HexPolyZ.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPolyZ.Basic
-import HexPolyZ.Mignotte
+module
+
+public import HexPolyZ.Basic
+public import HexPolyZ.Mignotte
+
+public section
 
 /-!
 The `HexPolyZ` library specializes the generic dense polynomial library to

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -4,7 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexPoly
+module
+
+public import HexPoly
+
+public section
 
 /-!
 Core `ZPoly` definitions for `hex-poly-z`.
@@ -96,6 +100,7 @@ def Primitive (f : ZPoly) : Prop :=
   content f = 1
 
 /-- A `ZPoly` is a unit iff it is the constant polynomial `1` or `-1`. -/
+@[expose]
 def IsUnit (f : ZPoly) : Prop :=
   f = DensePoly.C 1 ∨ f = DensePoly.C (-1)
 
@@ -341,7 +346,8 @@ private def ratCoeffToIntWithDen (den : Nat) (coeff : Rat) : Int :=
 
 /-- Negate `f` when its leading coefficient is negative, normalizing a primitive part to
 have nonnegative leading sign. -/
-private def normalizePrimitiveSign (f : ZPoly) : ZPoly :=
+@[expose]
+def normalizePrimitiveSign (f : ZPoly) : ZPoly :=
   if DensePoly.leadingCoeff f < 0 then
     DensePoly.scale (-1 : Int) f
   else
@@ -1042,12 +1048,12 @@ theorem leadingCoeff_mul_pos_of_pos (p q : ZPoly)
   have hp_ne : p ≠ 0 := by
     intro hp_zero
     rw [hp_zero] at hp_pos
-    change 0 < (0 : Int) at hp_pos
+    rw [DensePoly.leadingCoeff_zero] at hp_pos
     omega
   have hq_ne : q ≠ 0 := by
     intro hq_zero
     rw [hq_zero] at hq_pos
-    change 0 < (0 : Int) at hq_pos
+    rw [DensePoly.leadingCoeff_zero] at hq_pos
     omega
   rw [leadingCoeff_mul_of_nonzero p q hp_ne hq_ne]
   exact Int.mul_pos hp_pos hq_pos
@@ -1167,10 +1173,7 @@ theorem leadingCoeff_scale_of_nonzero (c : Int) (p : ZPoly) (hc : c ≠ 0) :
       rw [DensePoly.coeff_zero]
       exact DensePoly.coeff_eq_zero_of_size_le p (by omega)
     rw [hpzero]
-    change (DensePoly.scale c (0 : ZPoly)).leadingCoeff = c * (0 : Int)
-    have hleft : (DensePoly.scale c (0 : ZPoly)).leadingCoeff = 0 := by
-      rfl
-    rw [hleft, Int.mul_zero]
+    simp
 
 private theorem shift_size_of_nonzero_core (k : Nat) {p : ZPoly} (hp : p ≠ 0) :
     (DensePoly.shift k p).size = k + p.size := by

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexBasic
-import HexPolyZ.Basic
+module
+
+public import HexBasic
+public import HexPolyZ.Basic
+
+public section
 
 /-!
 Executable Mignotte-bound helpers for `hex-poly-z`.
@@ -394,16 +398,19 @@ private theorem sqrtAux_full_fuel_sq_le
   simpa [hself] using hsq
 
 /-- The squared Euclidean norm of the coefficient vector of `f`. -/
+@[expose]
 def coeffNormSq (f : ZPoly) : Nat :=
   (List.range f.size).foldl (fun acc i => acc + (f.coeff i).natAbs ^ 2) 0
 
 /-- A conservative natural-number upper bound on the Euclidean norm of the
 coefficient vector of `f`. -/
+@[expose]
 def coeffL2NormBound (f : ZPoly) : Nat :=
   ceilSqrt (coeffNormSq f)
 
 /-- The executable Mignotte bound for the `j`-th coefficient of a degree-`k`
 factor of `f`, using the conservative `coeffL2NormBound`. -/
+@[expose]
 def mignotteCoeffBound (f : ZPoly) (k j : Nat) : Nat :=
   binom k j * coeffL2NormBound f
 
@@ -415,6 +422,7 @@ It takes the maximum of the executable Mignotte coefficient bounds over every
 candidate factor degree up to `f.degree?.getD 0` and every coefficient index up
 to that degree.
 -/
+@[expose]
 def defaultFactorCoeffBound (f : ZPoly) : Nat :=
   let degreeBound := f.degree?.getD 0
   (List.range (degreeBound + 1)).foldl

--- a/progress/20260630T075041Z_module_migration_groupA.md
+++ b/progress/20260630T075041Z_module_migration_groupA.md
@@ -1,0 +1,46 @@
+# Module migration Group A: HexPolyMathlib, HexPolyZ (HexGF2 deferred)
+
+## Accomplished
+
+Migrated `HexPolyMathlib` (Basic + Euclid + umbrella) and `HexPolyZ`
+(Basic + Mignotte + umbrella) to the module system. Full `lake build` and
+`HexConformance` both green (real exit 0).
+
+Exposure/fix details:
+- `HexPolyMathlib/Basic`: `@[expose]` on `toPolynomial`/`ofPolynomial`/`equiv`;
+  rewrote one `leadingCoeff_toPolynomial` zero-branch `rfl` to
+  `simp [DensePoly.coeff_zero]` (the `rfl` reduced through the `DensePoly`
+  structure/Zero instance, which a module cannot unfold cross-file).
+- `HexPolyZ/Basic`: `@[expose]` on `IsUnit`; made `normalizePrimitiveSign`
+  public + `@[expose]` (two public theorems name it in their statements and
+  `unfold` it — illegal for a `private` def under the module system); replaced
+  two `change 0 < (0 : Int) at h` with `rw [DensePoly.leadingCoeff_zero] at h`
+  and one scale-zero `change`+`rfl` block with `simp`.
+- `HexPolyZ/Mignotte`: `@[expose]` on `coeffNormSq`, `coeffL2NormBound`,
+  `mignotteCoeffBound`, `defaultFactorCoeffBound` (their exported `_def`
+  unfolding lemmas).
+
+## HexGF2 deferred (Risk 2 CONFIRMED)
+
+`HexGF2` cannot be migrated: its exported `@[simp]` lemmas (e.g.
+`degree?_zero`) are `rfl` proofs that must unfold `ofWords`/`degree?`/`zero`.
+Exposing those defs under `precompileModules := true` triggers codegen errors
+`"Failed to find LCNF signature for Hex.GF2Poly.ofWords"`,
+`"declaration has metavariables"`, and `"failed to compile definition,
+consider marking it 'noncomputable'"`. The only alternatives — making the
+`@[simp]` lemmas `private` — would break the downstream API that
+`HexGF2Mathlib` consumes. This is a genuine Lean toolchain limitation (the
+prior sweep also left `HexGF2` legacy); `HexGF2` and `HexGF2Mathlib` stay
+legacy.
+
+## Next step
+
+Group B: `HexGFqField`, `HexHensel`(+Mathlib), `HexConway`, `HexGFq`(+Mathlib),
+`HexPolyZMathlib`. Then `HexBerlekamp`(+Mathlib) (Risk 1). Each needs the
+exported-`rfl` `@[expose]` pass; expect more `private`→public promotions where
+public theorem statements name internal defs.
+
+## Blockers
+
+`HexGF2`/`HexGF2Mathlib`: confirmed `@[expose]`+`precompileModules` codegen
+blocker (above).


### PR DESCRIPTION
This PR migrates `HexPolyMathlib` and `HexPolyZ` to the Lean 4 module system, continuing the bottom-up migration after the executable cores. Beyond the mechanical `module`/`public import`/`public section` wrapping it exposes the conversion and bound definitions that downstream module consumers unfold (`toPolynomial`/`ofPolynomial`/`equiv` in `HexPolyMathlib.Basic`; `IsUnit`, `normalizePrimitiveSign`, and the Mignotte-bound defs in `HexPolyZ`), promotes `normalizePrimitiveSign` from `private` to public because two public theorems name it in their statements, and replaces a few `rfl`/`change` proofs that reduced through the `DensePoly` structure with the existing `@[simp]` lemmas. The full `lake build` and `HexConformance` both build green.

`HexGF2` (and its bridge `HexGF2Mathlib`) are deliberately left on legacy imports: their exported `@[simp]` lemmas are `rfl` proofs that must unfold executable definitions, and exposing those under `precompileModules := true` triggers `"Failed to find LCNF signature"` codegen errors, while making the lemmas `private` would break the downstream API. This is a Lean toolchain limitation, documented in the progress note for a future revisit.

🤖 Prepared with Claude Code