### PR TITLE
refactor: migrate FpPoly/ZPoly product folds onto HexBasic

### DIFF
--- a/HexBasic/Fold.lean
+++ b/HexBasic/Fold.lean
@@ -93,6 +93,23 @@ theorem foldl_mul_congr [Mul R] (xs : List α) (f g : α → R) (z : R)
     xs.foldl (fun acc x => acc * f x) z = xs.foldl (fun acc x => acc * g x) z :=
   foldl_congr xs _ _ z fun acc x hx => by rw [h x hx]
 
+/-- Pull the running accumulator out of a multiplicative fold-product, taking
+the product from a `1` start. Stated for any associative multiplication with a
+two-sided unit, so it applies to monoids that are not `Grind` rings (e.g. the
+executable polynomial types). -/
+theorem foldl_mul_eq_mul_foldl {M : Type u} [Mul M] [One M]
+    [Std.Associative (· * · : M → M → M)] [Std.LawfulIdentity (· * · : M → M → M) 1]
+    (xs : List α) (f : α → M) (z : M) :
+    xs.foldl (fun acc x => acc * f x) z = z * xs.foldl (fun acc x => acc * f x) 1 :=
+  calc xs.foldl (fun acc x => acc * f x) z
+      = (xs.map f).foldl (· * ·) z :=
+        (List.foldl_map (l := xs) (f := f) (g := (· * ·)) (init := z)).symm
+    _ = (xs.map f).foldl (· * ·) (z * 1) := by
+        rw [show z * 1 = z from Std.LawfulRightIdentity.right_id z]
+    _ = z * (xs.map f).foldl (· * ·) 1 := List.foldl_assoc
+    _ = z * xs.foldl (fun acc x => acc * f x) 1 := by
+        rw [List.foldl_map (l := xs) (f := f) (g := (· * ·)) (init := 1)]
+
 /-! ### Constant step -/
 
 /-- Folding with a step that discards the element and returns the accumulator
@@ -144,19 +161,6 @@ theorem foldl_add_eq_add_foldl (xs : List α) (f : α → R) (z : R) :
     _ = z + (xs.map f).foldl (· + ·) 0 := List.foldl_assoc
     _ = z + xs.foldl (fun acc x => acc + f x) 0 := by
         rw [List.foldl_map (l := xs) (f := f) (g := (· + ·)) (init := 0)]
-
-/-- Pull the running accumulator out of a multiplicative fold-product, taking
-the product from a `1` start. -/
-theorem foldl_mul_eq_mul_foldl (xs : List α) (f : α → R) (z : R) :
-    xs.foldl (fun acc x => acc * f x) z
-      = z * xs.foldl (fun acc x => acc * f x) 1 :=
-  calc xs.foldl (fun acc x => acc * f x) z
-      = (xs.map f).foldl (· * ·) z :=
-        (List.foldl_map (l := xs) (f := f) (g := (· * ·)) (init := z)).symm
-    _ = (xs.map f).foldl (· * ·) (z * 1) := by rw [Lean.Grind.Semiring.mul_one]
-    _ = z * (xs.map f).foldl (· * ·) 1 := List.foldl_assoc
-    _ = z * xs.foldl (fun acc x => acc * f x) 1 := by
-        rw [List.foldl_map (l := xs) (f := f) (g := (· * ·)) (init := 1)]
 
 /-! ### All-zero collapse -/
 

--- a/HexBerlekamp/DistinctDegree.lean
+++ b/HexBerlekamp/DistinctDegree.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import HexBasic
 import HexBerlekamp.Factor
 import HexBerlekamp.Irreducibility
 import HexBerlekamp.RabinSoundness
@@ -221,39 +222,6 @@ private theorem one_mul_poly
     (1 : FpPoly p) * a = a :=
   (DensePoly.mul_comm_poly (1 : FpPoly p) a).trans (DensePoly.mul_one_right_poly a)
 
-/-- A left factor `z` pulls out of a left-folded product: folding from `z * a`
-equals `z` times folding from `a`. -/
-private theorem foldl_mul_left_factor
-    [ZMod64.PrimeModulus p]
-    (z a : FpPoly p) (xs : List (FpPoly p)) :
-    xs.foldl (fun acc factor => acc * factor) (z * a)
-      = z * xs.foldl (fun acc factor => acc * factor) a := by
-  induction xs generalizing a with
-  | nil => rfl
-  | cons b bs ih =>
-    have hcong : List.foldl (fun acc factor : FpPoly p => acc * factor) ((z * a) * b) bs
-        = List.foldl (fun acc factor => acc * factor) (z * (a * b)) bs := by
-      congr 1
-      exact DensePoly.mul_assoc_poly z a b
-    have hih : List.foldl (fun acc factor : FpPoly p => acc * factor) (z * (a * b)) bs
-        = z * List.foldl (fun acc factor => acc * factor) (a * b) bs := ih (a * b)
-    show List.foldl (fun acc factor => acc * factor) (z * a * b) bs
-        = z * List.foldl (fun acc factor => acc * factor) (a * b) bs
-    exact hcong.trans hih
-
-/-- A left-folded product from seed `z` factors as `z` times the same fold from
-seed `1`. -/
-private theorem foldl_mul_eq_mul_foldl
-    [ZMod64.PrimeModulus p]
-    (z : FpPoly p) (xs : List (FpPoly p)) :
-    xs.foldl (fun acc factor => acc * factor) z
-      = z * xs.foldl (fun acc factor => acc * factor) 1 := by
-  have h1 : xs.foldl (fun acc factor => acc * factor) z
-      = xs.foldl (fun acc factor => acc * factor) (z * 1) := by
-    congr 1
-    exact (DensePoly.mul_one_right_poly z).symm
-  exact h1.trans (foldl_mul_left_factor z 1 xs)
-
 /-- `factorProduct` of a cons is the head times the `factorProduct` of the
 tail. -/
 private theorem factorProduct_cons_eq
@@ -263,7 +231,7 @@ private theorem factorProduct_cons_eq
   show xs.foldl (fun acc factor => acc * factor) (1 * x)
     = x * xs.foldl (fun acc factor => acc * factor) 1
   rw [one_mul_poly x]
-  exact foldl_mul_eq_mul_foldl x xs
+  exact List.foldl_mul_eq_mul_foldl xs id x
 
 /-- `factorProduct` distributes over list append. -/
 private theorem factorProduct_append

--- a/HexBerlekamp/Factor.lean
+++ b/HexBerlekamp/Factor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import HexBasic
 import HexBerlekamp.Basic
 
 /-!
@@ -681,35 +682,6 @@ private theorem one_mul_poly
     (1 : FpPoly p) * a = a :=
   (DensePoly.mul_comm_poly (1 : FpPoly p) a).trans (DensePoly.mul_one_right_poly a)
 
-private theorem foldl_mul_left_factor
-    [ZMod64.PrimeModulus p]
-    (z a : FpPoly p) (xs : List (FpPoly p)) :
-    xs.foldl (fun acc factor => acc * factor) (z * a)
-      = z * xs.foldl (fun acc factor => acc * factor) a := by
-  induction xs generalizing a with
-  | nil => rfl
-  | cons b bs ih =>
-    have hcong : List.foldl (fun acc factor : FpPoly p => acc * factor) ((z * a) * b) bs
-        = List.foldl (fun acc factor => acc * factor) (z * (a * b)) bs := by
-      congr 1
-      exact DensePoly.mul_assoc_poly z a b
-    have hih : List.foldl (fun acc factor : FpPoly p => acc * factor) (z * (a * b)) bs
-        = z * List.foldl (fun acc factor => acc * factor) (a * b) bs := ih (a * b)
-    show List.foldl (fun acc factor => acc * factor) (z * a * b) bs
-        = z * List.foldl (fun acc factor => acc * factor) (a * b) bs
-    exact hcong.trans hih
-
-private theorem foldl_mul_eq_mul_foldl
-    [ZMod64.PrimeModulus p]
-    (z : FpPoly p) (xs : List (FpPoly p)) :
-    xs.foldl (fun acc factor => acc * factor) z
-      = z * xs.foldl (fun acc factor => acc * factor) 1 := by
-  have h1 : xs.foldl (fun acc factor => acc * factor) z
-      = xs.foldl (fun acc factor => acc * factor) (z * 1) := by
-    congr 1
-    exact (DensePoly.mul_one_right_poly z).symm
-  exact h1.trans (foldl_mul_left_factor z 1 xs)
-
 /--
 Cons-expansion for `factorProduct`: pulling the head factor out of the running
 product. Useful for downstream proofs that reason about `factorProduct` without
@@ -722,7 +694,7 @@ theorem factorProduct_cons
   show xs.foldl (fun acc factor => acc * factor) (1 * x)
     = x * xs.foldl (fun acc factor => acc * factor) 1
   rw [one_mul_poly x]
-  exact foldl_mul_eq_mul_foldl x xs
+  exact List.foldl_mul_eq_mul_foldl xs id x
 
 /-- `factorProduct` distributes over list append. -/
 private theorem factorProduct_append

--- a/HexHensel/Multifactor.lean
+++ b/HexHensel/Multifactor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+import HexBasic
 import HexHensel.Linear
 
 /-!
@@ -205,20 +206,8 @@ theorem polyProduct_singleton (g : ZPoly) :
 left fold. -/
 theorem list_foldl_mul_eq_mul_foldl_one (g : ZPoly) (xs : List ZPoly) :
     xs.foldl (fun acc factor => acc * factor) g =
-      g * xs.foldl (fun acc factor => acc * factor) 1 := by
-  induction xs generalizing g with
-  | nil =>
-      simpa using (DensePoly.mul_one_right_poly (S := Int) g).symm
-  | cons x xs ih =>
-      simp only [List.foldl_cons]
-      rw [one_mul_zpoly]
-      calc
-        xs.foldl (fun acc factor => acc * factor) (g * x) =
-            (g * x) * xs.foldl (fun acc factor => acc * factor) 1 := ih (g * x)
-        _ = g * (x * xs.foldl (fun acc factor => acc * factor) 1) := by
-            rw [DensePoly.mul_assoc_poly (S := Int)]
-        _ = g * xs.foldl (fun acc factor => acc * factor) x := by
-            rw [ih x]
+      g * xs.foldl (fun acc factor => acc * factor) 1 :=
+  List.foldl_mul_eq_mul_foldl xs id g
 
 /-- Splitting `Array.polyProduct` across a singleton prepend: the head
 factors out as a left multiplication. Used to relate the multifactor

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -2682,6 +2682,18 @@ cancel multiplications by the unit polynomial through it. -/
   rw [coeff_mul, mulCoeffSum_eq_diagonal]
   exact fold_diagonal_one_right p n
 
+/-- `DensePoly S` is a multiplicative monoid: these `Std` instances let the
+shared `List.foldl_mul_*` algebra (and core's `List.foldl_assoc`) apply to
+fold-products of polynomials such as `FpPoly`/`ZPoly`. -/
+instance instAssociativeMulDensePoly {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] :
+    Std.Associative (· * · : DensePoly S → DensePoly S → DensePoly S) :=
+  ⟨mul_assoc_poly⟩
+
+instance instLawfulIdentityMulDensePoly {S : Type _} [Lean.Grind.CommRing S] [DecidableEq S] :
+    Std.LawfulIdentity (· * · : DensePoly S → DensePoly S → DensePoly S) 1 where
+  left_id p := (mul_comm_poly 1 p).trans (mul_one_right_poly p)
+  right_id := mul_one_right_poly
+
 /-- Product of two monomials: `xⁱ * cⱼ * xʲ = cᵢcⱼ * xⁱ⁺ʲ`. -/
 theorem monomial_mul_monomial {S : Type _}
     [Lean.Grind.CommRing S] [DecidableEq S]

--- a/HexPolyFp/Basic.lean
+++ b/HexPolyFp/Basic.lean
@@ -2620,6 +2620,18 @@ theorem mul_assoc (f g h : FpPoly p) :
         (fun acc i => acc + mulCoeffTerm f (g * h) n i) 0 := by
             exact (fold_mulCoeff_assoc_right_expand f g h n).symm
 
+/-- `FpPoly p` is a multiplicative monoid for `Std`, so the shared
+`List.foldl_mul_*` algebra and core's `List.foldl_assoc` apply to fold-products
+of `FpPoly`. -/
+instance instAssociativeMul {p : Nat} [ZMod64.Bounds p] :
+    Std.Associative (· * · : FpPoly p → FpPoly p → FpPoly p) :=
+  ⟨mul_assoc⟩
+
+instance instLawfulIdentityMul {p : Nat} [ZMod64.Bounds p] :
+    Std.LawfulIdentity (· * · : FpPoly p → FpPoly p → FpPoly p) 1 where
+  left_id := one_mul
+  right_id := mul_one
+
 /-- Scalar scaling distributes over polynomial addition. Lets callers move a
 scalar across a sum, for example when normalizing a linear combination. -/
 theorem scale_add (c : ZMod64 p) (f g : FpPoly p) :

--- a/HexPolyZ/Basic.lean
+++ b/HexPolyZ/Basic.lean
@@ -20,6 +20,16 @@ namespace Hex
 from `HexPoly`. -/
 abbrev ZPoly := DensePoly Int
 
+/-- `ZPoly` is a multiplicative monoid for `Std`, so the shared
+`List.foldl_mul_*` algebra and core's `List.foldl_assoc` apply to fold-products
+of integer polynomials. -/
+instance : Std.Associative (· * · : ZPoly → ZPoly → ZPoly) :=
+  ⟨DensePoly.mul_assoc_poly⟩
+
+instance : Std.LawfulIdentity (· * · : ZPoly → ZPoly → ZPoly) 1 where
+  left_id p := (DensePoly.mul_comm_poly 1 p).trans (DensePoly.mul_one_right_poly p)
+  right_id := DensePoly.mul_one_right_poly
+
 instance : DensePoly.AddZeroLaw Int where
   add_zero_zero := rfl
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -267,7 +267,7 @@ libraries:
 
   # ---------- Factoring pipeline ----------
   HexBerlekamp:
-    deps: [HexPolyFp, HexMatrix, HexRowReduce, HexGFqRing]
+    deps: [HexPolyFp, HexMatrix, HexRowReduce, HexGFqRing, HexBasic]
     mathlib: false
     done_through: 3
     status: active
@@ -289,7 +289,7 @@ libraries:
         - name: distinct-degree-factorization
           description: Deterministic dense monic F_5 polynomials with mixed low-degree factor structure for distinct-degree factorization.
   HexHensel:
-    deps: [HexPolyFp, HexPolyZ]
+    deps: [HexPolyFp, HexPolyZ, HexBasic]
     mathlib: false
     done_through: 7
     status: active


### PR DESCRIPTION
This PR finishes the foldl consolidation by bringing the concrete polynomial product-folds onto the shared `HexBasic.Fold` API. It generalizes `List.foldl_mul_eq_mul_foldl` from `Lean.Grind.Ring` to a bare multiplicative monoid (`[Mul M] [One M] [Std.Associative (· * ·)] [Std.LawfulIdentity (· * ·) 1]`), proved through core's `List.foldl_assoc` / `List.foldl_map`, so it applies to monoids that are not Grind rings — in particular the executable polynomial types.

It then makes `FpPoly` and `ZPoly` multiplicative monoids for `Std`: explicit `Std.Associative`/`Std.LawfulIdentity` instances in `HexPolyFp` and `HexPolyZ` (plus the generic `DensePoly` pair in `HexPoly`), built from the existing `mul_assoc`/`mul_one`/`one_mul` lemmas. With those in place it deletes the duplicated `foldl_mul_left_factor` / `foldl_mul_eq_mul_foldl` reimplementations in `HexBerlekamp` (both `Factor` and `DistinctDegree` carried byte-identical copies) and points the call sites at `List.foldl_mul_eq_mul_foldl`. `HexHensel`'s public `list_foldl_mul_eq_mul_foldl_one` keeps its signature (it is used by `HexBerlekampZassenhaus`), but its proof now delegates to the shared lemma instead of re-inducting.

Each changed library builds green individually (HexBasic, HexPoly, HexPolyFp, HexPolyZ, HexBerlekamp, HexHensel); the only downstream recompile is the Mathlib bridge against the unchanged Hensel signature, which CI confirms.

🤖 Prepared with Claude Code