### PR TITLE
refactor: migrate HexGFqField to the module system

### DIFF
--- a/HexGFqField.lean
+++ b/HexGFqField.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import HexGFqField.Basic
-import HexGFqField.Operations
+module
+
+public import HexGFqField.Basic
+public import HexGFqField.Operations
+
+public section
 
 /-!
 Thin finite-field wrapper for executable `F_p[x] / (f)`.

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -4,9 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import Init.Grind.Ring.Field
-import HexGFqField.Basic
-import HexGFqRing.Operations
+module
+
+public import Init.Grind.Ring.Field
+public import HexGFqField.Basic
+public import HexGFqRing.Operations
+
+public section
 
 /-!
 Executable finite-field operations for `F_p[x] / (f)`.
@@ -25,59 +29,70 @@ variable {p : Nat} [ZMod64.Bounds p] {hp : Hex.Nat.Prime p}
 
 /-- Natural-number literals reuse the quotient-ring cast and then rewrap the
 resulting reduced residue. -/
+@[expose]
 def natCast (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
     (hirr : FpPoly.Irreducible f) (n : Nat) : FiniteField f hf hp hirr :=
   ofQuotient (n : GFqRing.PolyQuotient f hf)
 
 /-- The additive identity in the finite-field wrapper. -/
+@[expose]
 def zero (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
     (hirr : FpPoly.Irreducible f) :
     FiniteField f hf hp hirr :=
   ofQuotient 0
 
 /-- The multiplicative identity in the finite-field wrapper. -/
+@[expose]
 def one (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
     (hirr : FpPoly.Irreducible f) :
     FiniteField f hf hp hirr :=
   ofQuotient 1
 
 /-- Field addition reuses the quotient-ring sum. -/
+@[expose]
 def add {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x y : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (x.toQuotient + y.toQuotient)
 
 /-- Field multiplication reuses the quotient-ring product. -/
+@[expose]
 def mul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x y : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (x.toQuotient * y.toQuotient)
 
 /-- Field negation reuses the quotient-ring additive inverse. -/
+@[expose]
 def neg {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (-x.toQuotient)
 
 /-- Field subtraction reuses the quotient-ring difference. -/
+@[expose]
 def sub {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x y : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (x.toQuotient - y.toQuotient)
 
 /-- Exponentiation reuses the quotient-ring repeated-multiplication path. -/
+@[expose]
 def pow {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) (n : Nat) : FiniteField f hf hp hirr :=
   ofQuotient (x.toQuotient ^ n)
 
 /-- Natural scalar multiplication reuses the quotient-ring scalar action. -/
+@[expose]
 def nsmul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (n : Nat) (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (n • x.toQuotient)
 
 /-- Integer literals reuse the quotient-ring cast and then rewrap the reduced
 residue. -/
+@[expose]
 def intCast (f : FpPoly p) (hf : 0 < FpPoly.degree f) (hp : Hex.Nat.Prime p)
     (hirr : FpPoly.Irreducible f) (i : Int) : FiniteField f hf hp hirr :=
   ofQuotient (i : GFqRing.PolyQuotient f hf)
 
 /-- Integer scalar multiplication reuses the quotient-ring scalar action. -/
+@[expose]
 def zsmul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (i : Int) (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   ofQuotient (i • x.toQuotient)
@@ -91,7 +106,8 @@ variable [ZMod64.PrimeModulus p]
 This normalizes the extended-GCD left coefficient by the gcd's constant-unit
 factor, producing a polynomial whose residue is the multiplicative inverse
 whenever the quotient element is nonzero. -/
-private def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+@[expose]
+def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : GFqRing.PolyQuotient f hf) : FpPoly p :=
   let r := DensePoly.xgcd (GFqRing.repr x) f
   let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹
@@ -466,6 +482,7 @@ end InverseInternals
 polynomial extended-GCD witness, normalized by the gcd's constant unit factor.
 The `0` case follows the usual junk-value convention required by
 `Lean.Grind.Field`. -/
+@[expose]
 def inv {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   letI : ZMod64.PrimeModulus p := ZMod64.primeModulusOfPrime hp
@@ -484,12 +501,14 @@ private theorem toQuotient_inv_of_ne_zero
   simp [GFqField.inv, hx]
 
 /-- Division is multiplication by the inverse candidate. -/
+@[expose]
 def div {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x y : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   mul x (inv y)
 
 /-- Integer exponentiation uses the existing natural-power path together with
 the inverse candidate for negative exponents. -/
+@[expose]
 def zpow {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) : Int → FiniteField f hf hp hirr
   | .ofNat n => pow x n
@@ -497,6 +516,7 @@ def zpow {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
 
 /-- The Frobenius map is the `p`-th power map on the existing quotient
 representation. -/
+@[expose]
 def frob {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) : FiniteField f hf hp hirr :=
   pow x p
@@ -1022,14 +1042,14 @@ private theorem eq_inv_of_mul_eq_one
 
 /-- The inverse of `1` is `1`, since `1 * 1 = 1`; a normalization step in the
 field-structure proofs. -/
-private theorem inv_one
+theorem inv_one
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f} :
     (1 : FiniteField f hf hp hirr)⁻¹ = 1 :=
   (eq_inv_of_mul_eq_one (Lean.Grind.Semiring.mul_one (1 : FiniteField f hf hp hirr))).symm
 
 /-- Double inverse is the identity: `x⁻¹⁻¹ = x`; obtained from inverse uniqueness
 via the cancellation `x⁻¹ * x = 1`, with the zero case handled separately. -/
-private theorem inv_inv
+theorem inv_inv
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) :
     x⁻¹⁻¹ = x := by
@@ -1043,7 +1063,7 @@ private theorem inv_inv
 /-- Double inverse stated through the `inv`-named function: `(inv x)⁻¹ = x`; the
 form consumed where the explicit `inv` definition appears rather than the `⁻¹`
 notation. -/
-private theorem inv_inv_def
+theorem inv_inv_def
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) :
     (inv x)⁻¹ = x :=
@@ -1051,7 +1071,7 @@ private theorem inv_inv_def
 
 /-- The empty product `pow x 0 = 1`; the base case anchoring the exponentiation
 recursion in the `FiniteField` power API. -/
-private theorem pow_zero_eq_one
+theorem pow_zero_eq_one
     {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
     (x : FiniteField f hf hp hirr) :
     pow x 0 = 1 := by

--- a/progress/20260630T080256Z_module_migration_gfqfield.md
+++ b/progress/20260630T080256Z_module_migration_gfqfield.md
@@ -1,0 +1,26 @@
+# Module migration: HexGFqField
+
+## Accomplished
+
+Migrated `HexGFqField` (Operations + umbrella; Basic was already a module) to
+the module system. Full `lake build` and `HexConformance` green.
+
+Exposure/fixes:
+- `@[expose]` on the 15 delegating operation defs in `Operations` (natCast,
+  zero, one, add, mul, neg, sub, pow, nsmul, intCast, zsmul, inv, div, zpow,
+  frob) so the exported `toQuotient_*`/`repr_*` `rfl` simp lemmas reduce
+  through them (the `FiniteField` structure projection reduces by iota once
+  the constructor-producing ops are exposed; the structure itself cannot take
+  `@[expose]`).
+- `invPoly`: `private` -> public + `@[expose]` (the exposed `inv` references
+  it, and `inv_zero`'s `change` unfolds it).
+- `inv_one`, `inv_inv`, `inv_inv_def`, `pow_zero_eq_one`: `private` -> public.
+  The module system does not resolve `private` sibling theorems from inside a
+  `public` declaration's proof (the `Grind.Field`/`HPow` instances), so helper
+  theorems used by public instances must themselves be public.
+
+## Next
+
+Remaining Group B: `HexHensel`(+Mathlib), `HexConway`, `HexGFq`(+Mathlib),
+`HexPolyZMathlib` (the last depends on Group A's `HexPolyZ`/`HexPolyMathlib`).
+Then `HexBerlekamp`(+Mathlib) (Risk 1).


### PR DESCRIPTION
This PR migrates `HexGFqField` to the Lean 4 module system. It exposes the fifteen delegating finite-field operation definitions in `HexGFqField.Operations` (`zero`, `one`, `add`, `mul`, `inv`, `div`, `zpow`, and the rest) so the exported `toQuotient_*`/`repr_*` `rfl` simp lemmas reduce through them, promotes `invPoly` from `private` to public and `@[expose]` because the exposed `inv` and `inv_zero` reference it, and promotes the inverse/power helper theorems `inv_one`, `inv_inv`, `inv_inv_def`, and `pow_zero_eq_one` to public since the module system does not resolve private sibling theorems from inside a public instance proof. The full `lake build` and `HexConformance` both build green.

🤖 Prepared with Claude Code