### PR TITLE
doc: split the HexManual matrix chapter into four per-library chapters

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -24,6 +24,9 @@ import HexManual.Chapters.HexConway
 import HexManual.Chapters.HexGFq
 import HexManual.Chapters.HexGF2
 import HexManual.Chapters.HexMatrix
+import HexManual.Chapters.HexDeterminant
+import HexManual.Chapters.HexRowReduce
+import HexManual.Chapters.HexBareiss
 
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
@@ -86,3 +89,9 @@ documentation phase of the development plan.
 {include 0 HexManual.Chapters.HexGF2}
 
 {include 0 HexManual.Chapters.HexMatrix}
+
+{include 0 HexManual.Chapters.HexDeterminant}
+
+{include 0 HexManual.Chapters.HexRowReduce}
+
+{include 0 HexManual.Chapters.HexBareiss}

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexBareiss
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexBareiss: the fraction-free integer determinant" =>
+%%%
+tag := "hex-bareiss"
+%%%
+
+# Introduction
+%%%
+tag := "hex-bareiss-intro"
+%%%
+
+`HexBareiss` is the executable fraction-free Bareiss determinant of a
+dense integer matrix: a Gaussian elimination in which every intermediate
+entry stays an exact integer because each update divides *exactly* by
+the previous pivot. It runs in cubic time and never leaves the integers,
+so it avoids both the factorial blow-up of the Leibniz
+{ref "hex-determinant"}[determinant] and the denominators of ordinary
+Gaussian elimination. It builds on the {ref "hex-matrix"}[HexMatrix]
+dense core and the {ref "hex-determinant"}[HexDeterminant] Leibniz
+determinant (the specification it is checked against).
+
+This chapter walks the elimination record, the public entry points, and
+the structural theorems the Mathlib-free layer proves, and closes with a
+worked example checked when the chapter is built.
+
+`HexBareiss` is Mathlib-free. The theorem identifying the Bareiss
+determinant with the Leibniz determinant, via the Desnanot-Jacobi
+invariant, lives in the forthcoming `HexBareissMathlib` bridge.
+
+# The elimination record
+%%%
+tag := "hex-bareiss-record"
+%%%
+
+An elimination pass returns a small record: the terminal matrix, the
+number of row swaps performed during pivoting, and an optional record of
+the first step at which a zero pivot with no replacement row was found
+(the signal that the matrix is singular).
+
+{docstring Hex.Matrix.BareissData}
+
+The sign contributed by the row swaps and the encoded determinant are
+read off that record. A recorded singular step encodes determinant zero;
+otherwise the determinant is the last diagonal entry of the terminal
+matrix with the swap sign applied.
+
+{docstring Hex.Matrix.BareissData.sign}
+
+{docstring Hex.Matrix.BareissData.det}
+
+# Entry points
+%%%
+tag := "hex-bareiss-entry"
+%%%
+
+The public entry points run the row-pivoting elimination.
+{name}`Hex.Matrix.bareissData` returns the full record;
+{name}`Hex.Matrix.bareiss` returns just the integer determinant. The
+no-pivot variants skip the pivot search, for inputs whose leading pivots
+are already nonzero.
+
+{docstring Hex.Matrix.bareissData}
+
+{docstring Hex.Matrix.bareiss}
+
+{docstring Hex.Matrix.bareissNoPivotData}
+
+{docstring Hex.Matrix.bareissNoPivot}
+
+The division at each step is `Int.divExact` (a GMP-backed
+`mpz_divexact`), which is always exact and carries its divisibility
+proof; the bordered minors track the elimination invariant the
+correctness development relies on.
+
+{docstring Hex.Matrix.borderedMinor}
+
+# Structural theorems
+%%%
+tag := "hex-bareiss-theorems"
+%%%
+
+This is where the computational/proof boundary falls. The Mathlib-free
+layer proves the internal structural facts about the elimination — that
+the packaged record is exactly the structured pivot loop finished into
+determinant data, and that the public {name}`Hex.Matrix.bareiss` value
+agrees with the determinant encoded by {name}`Hex.Matrix.bareissData` —
+but it does *not* prove that the Bareiss determinant equals the Leibniz
+{name}`Hex.Matrix.det`. That identification is a correspondence theorem
+living in the forthcoming `HexBareissMathlib` bridge. Within `HexBareiss`
+itself the agreement is pinned only as value-level conformance fixtures:
+a fixed bank of matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M`
+is checked at build time.
+
+{docstring Hex.Matrix.bareissData_eq_finish_pivotLoop}
+
+{docstring Hex.Matrix.bareiss_eq_bareissData_det}
+
+# Worked example
+%%%
+tag := "hex-bareiss-worked"
+%%%
+
+The block below builds the integer matrix with rows `(2, 0, 1)`,
+`(1, 3, 2)`, and `(0, 1, 1)`, whose determinant is `3`. The Bareiss
+route agrees with the Leibniz {ref "hex-determinant"}[determinant] on it,
+the identity has determinant one, and a matrix with a dependent row pair
+is singular. Every `#guard` is checked when the chapter is built.
+
+```lean
+open Hex Hex.Matrix
+
+namespace HexBareissChapterExample
+
+-- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]], det = 3.
+private def A : Matrix Int 3 3 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 2 | 0, 1 => 0 | 0, 2 => 1
+    | 1, 0 => 1 | 1, 1 => 3 | 1, 2 => 2
+    | 2, 0 => 0 | 2, 1 => 1 | 2, 2 => 1
+    | _, _ => 0
+
+-- The Bareiss determinant is 3, agreeing with Leibniz.
+#guard Matrix.bareiss A = 3
+#guard Matrix.bareiss A = Matrix.det A
+
+-- The packaged record reads off the same determinant.
+#guard (Matrix.bareissData A).det = 3
+
+-- The identity has determinant one.
+#guard Matrix.bareiss (Matrix.identity (R := Int) 3) = 1
+
+-- S = [[1, 2], [2, 4]]: dependent rows, so singular.
+private def S : Matrix Int 2 2 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 1 | 0, 1 => 2
+    | 1, 0 => 2 | 1, 1 => 4
+    | _, _ => 0
+
+#guard Matrix.bareiss S = 0
+
+end HexBareissChapterExample
+```
+
+# Cross-references
+%%%
+tag := "hex-bareiss-cross-references"
+%%%
+
+`HexBareiss` is the fast integer-determinant layer of the stack:
+
+* It depends on {ref "hex-matrix"}[HexMatrix] for the matrix type and on
+  {ref "hex-determinant"}[HexDeterminant] for the Leibniz `det` it uses
+  as its specification.
+* `HexBareissMathlib` is the correspondence library proving the Bareiss
+  determinant equals the Leibniz determinant (and hence Mathlib's
+  determinant), via the Desnanot-Jacobi invariant. The Mathlib
+  dependency lives entirely on that side of the boundary; `HexBareiss`
+  itself is Mathlib-free.

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -1,0 +1,193 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexDeterminant
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexDeterminant: the Leibniz determinant and cofactor theory" =>
+%%%
+tag := "hex-determinant"
+%%%
+
+# Introduction
+%%%
+tag := "hex-determinant-intro"
+%%%
+
+`HexDeterminant` is the determinant of a dense square matrix via the
+Leibniz formula, together with the cofactor and adjugate theory built on
+it. It depends only on the {ref "hex-matrix"}[HexMatrix] dense core and
+is generic over the coefficient ring; the row-operation, Laplace,
+Cauchy-Binet, and Plücker results hold over a commutative ring.
+
+The Leibniz determinant is the *definitional* semantics: correct by
+construction, but factorially slow, so it serves as the specification
+the faster {ref "hex-bareiss"}[HexBareiss] route is checked against
+rather than the routine a caller invokes on a large matrix. This chapter
+walks the definition, the elementary-operation laws, cofactor expansion,
+the adjugate identity, and the column-tuple and two-row identities, and
+closes with a worked example checked when the chapter is built.
+
+`HexDeterminant` is Mathlib-free. The identification of this determinant
+with Mathlib's `Matrix.det`, and with the executable Bareiss
+determinant, lives in the forthcoming `HexDeterminantMathlib` and
+`HexBareissMathlib` bridges.
+
+# The Leibniz determinant
+%%%
+tag := "hex-determinant-leibniz"
+%%%
+
+The reference determinant is the Leibniz formula: a signed sum over all
+permutation vectors of the product of the selected entries.
+
+{docstring Hex.Matrix.det}
+
+The classical row and column laws are all proved against this
+definition. The identity has determinant one; swapping two rows negates
+the determinant; scaling a row scales it; adding a multiple of one row
+to another leaves it unchanged; and the determinant is invariant under
+transpose.
+
+{docstring Hex.Matrix.det_identity}
+
+{docstring Hex.Matrix.det_rowSwap}
+
+{docstring Hex.Matrix.det_rowScale}
+
+{docstring Hex.Matrix.det_rowAdd}
+
+{docstring Hex.Matrix.det_transpose}
+
+{docstring Hex.Matrix.det_colSwap}
+
+The determinant is linear in each column separately; the additive law in
+one column is the building block for Laplace expansion.
+
+{docstring Hex.Matrix.det_setCol_add}
+
+# Cofactor expansion
+%%%
+tag := "hex-determinant-cofactor"
+%%%
+
+Deleting one row and one column gives a minor; the signed minor is a
+cofactor, and the determinant is the alternating sum of entries against
+their cofactors along any fixed row or column.
+
+{docstring Hex.Matrix.deleteRowCol}
+
+{docstring Hex.Matrix.cofactorSign}
+
+{docstring Hex.Matrix.cofactor}
+
+{docstring Hex.Matrix.det_eq_foldl_laplace_row}
+
+# The adjugate
+%%%
+tag := "hex-determinant-adjugate"
+%%%
+
+The adjugate is the transpose of the cofactor matrix. Its defining
+identity, `M * adjugate M = det M • identity`, is the executable
+Cramer's-rule kernel: over a commutative ring it holds without any
+invertibility hypothesis.
+
+{docstring Hex.Matrix.adjugate}
+
+{docstring Hex.Matrix.mul_adjugate}
+
+# Cauchy-Binet and Plücker identities
+%%%
+tag := "hex-determinant-identities"
+%%%
+
+The determinant of a Gram matrix expands as a sum over column tuples
+(the Cauchy-Binet formula), and the three-term Plücker /
+Desnanot-Jacobi identity relates the determinants of a matrix and its
+bordered minors. The triangular-determinant law reads the determinant
+of an upper- or lower-triangular matrix off its diagonal.
+
+{docstring Hex.Matrix.det_gramMatrix_eq_sum_columnTuples}
+
+{docstring Hex.Matrix.det_plucker_three_term_consecutive_top}
+
+{docstring Hex.Matrix.det_upperTriangular_eq_foldl_diag}
+
+# Worked example
+%%%
+tag := "hex-determinant-worked"
+%%%
+
+The block below builds the integer matrix with rows `(2, 0, 1)`,
+`(1, 3, 2)`, and `(0, 1, 1)`, whose determinant is `3`. The identity has
+determinant one, the determinant is invariant under transpose, swapping
+two rows negates it, and a matrix with a dependent row pair is singular.
+Every `#guard` is checked when the chapter is built.
+
+```lean
+open Hex Hex.Matrix
+
+namespace HexDeterminantChapterExample
+
+-- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]], det = 3.
+private def A : Matrix Int 3 3 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 2 | 0, 1 => 0 | 0, 2 => 1
+    | 1, 0 => 1 | 1, 1 => 3 | 1, 2 => 2
+    | 2, 0 => 0 | 2, 1 => 1 | 2, 2 => 1
+    | _, _ => 0
+
+-- The Leibniz determinant evaluates to 3.
+#guard Matrix.det A = 3
+
+-- The determinant is invariant under transpose.
+#guard Matrix.det (Matrix.transpose A) = 3
+
+-- Swapping two rows negates the determinant.
+#guard Matrix.det (Matrix.rowSwap A 0 1) = -3
+
+-- The identity has determinant one.
+#guard Matrix.det (Matrix.identity (R := Int) 3) = 1
+
+-- S = [[1, 2], [2, 4]] has a dependent row pair,
+-- so its determinant is zero.
+private def S : Matrix Int 2 2 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => 1 | 0, 1 => 2
+    | 1, 0 => 2 | 1, 1 => 4
+    | _, _ => 0
+
+#guard Matrix.det S = 0
+
+end HexDeterminantChapterExample
+```
+
+# Cross-references
+%%%
+tag := "hex-determinant-cross-references"
+%%%
+
+`HexDeterminant` is the determinant layer of the linear-algebra stack:
+
+* It depends only on {ref "hex-matrix"}[HexMatrix] — the matrix type,
+  its arithmetic, and the elementary operations whose determinant laws
+  are proved here.
+* {ref "hex-bareiss"}[HexBareiss] computes the same integer determinant
+  fraction-free in cubic time, using this Leibniz `det` as its
+  specification.
+* `HexDeterminantMathlib` is the correspondence library identifying this
+  executable determinant with Mathlib's `Matrix.det`. The Mathlib
+  dependency lives entirely on that side of the boundary;
+  `HexDeterminant` itself is Mathlib-free.

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -6,18 +6,14 @@ Authors: Kim Morrison
 
 import VersoManual
 
-import HexMatrix.Basic
-import HexDeterminant
-import HexRowReduce.RowEchelon
-import HexRowReduce
-import HexBareiss.Bareiss
+import HexMatrix
 
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
 
 set_option pp.rawOnError true
 
-#doc (Manual) "HexMatrix: dense linear algebra over Int" =>
+#doc (Manual) "HexMatrix: dense matrices and arithmetic" =>
 %%%
 tag := "hex-matrix"
 %%%
@@ -27,30 +23,32 @@ tag := "hex-matrix"
 tag := "hex-matrix-intro"
 %%%
 
-`HexMatrix` is the dense matrix core of the stack: the `Matrix` type and
-its arithmetic, a Leibniz determinant, the fraction-free Bareiss
-determinant algorithm over the integers, and the row-echelon and
-reduced-row-echelon transforms with their span and nullspace readers.
-Everything here is executable and exact — entries are honest `Int` (or,
-for the field-valued reductions, `Rat`) values, never floating point —
-so the algorithms double as both the computational engine the rest of
-the project calls and the reference semantics its correctness proofs are
-stated against.
+`HexMatrix` is the dense matrix core of the stack: the `Matrix` type,
+its constructors and readers, matrix and matrix-vector arithmetic, the
+elementary row and column operations, and the submatrix and Gram-matrix
+helpers. Everything here is executable and exact — entries are honest
+values of the coefficient type, never floating point — so the type
+doubles as both the computational engine the rest of the project calls
+and the reference representation its correctness proofs are stated
+against. The type is generic over the coefficient ring `R`; the
+integer- and rational-valued instances are the ones the rest of the
+stack uses.
 
 The library is deliberately small and self-contained: it has no library
-dependencies at all. Downstream, the integer Gram-Schmidt layer reads
-its matrices off this type, the lattice-reduction path manipulates
-bases as `Matrix Int` rows, and the factorization stack uses the Bareiss
-determinant where a fraction-free exact integer determinant is wanted.
-This chapter walks the type and its operations, then the two
-determinant routes (Leibniz and Bareiss), then the echelon transforms,
-and closes with a worked determinant example that is checked when the
+dependencies at all, building directly on Lean's `Vector`. The three
+algorithms that sit on top of it each live in their own sibling
+library: the Leibniz determinant in {ref "hex-determinant"}[HexDeterminant],
+the Gauss-Jordan row reduction in {ref "hex-row-reduce"}[HexRowReduce],
+and the fraction-free integer determinant in {ref "hex-bareiss"}[HexBareiss].
+This chapter walks the type, its arithmetic, and the elementary
+operations, and closes with a worked example that is checked when the
 chapter is built.
 
-`HexMatrix` is Mathlib-free. The theorems identifying its executable
-routines with the abstract Mathlib `Matrix` determinant live one
-boundary away in the forthcoming `HexMatrixMathlib` correspondence
-library; this chapter states where that boundary falls.
+`HexMatrix` is Mathlib-free. The `Semiring` / `Ring` structure on
+square matrices, the `One` instance, and the equivalence with Mathlib's
+abstract `Matrix` all live one boundary away in the forthcoming
+`HexMatrixMathlib` correspondence library; this chapter states where
+that boundary falls.
 
 # The dense matrix type
 %%%
@@ -77,8 +75,12 @@ row, column, and transpose readers are its inverses.
 
 {docstring Hex.Matrix.transpose_transpose}
 
-The all-zero and identity matrices are the additive and multiplicative
-units, exposed through the standard `Zero` and `One` instances.
+The all-zero matrix is the additive unit, exposed through the standard
+`Zero` instance; the identity is the function {name}`Hex.Matrix.identity`.
+There is deliberately no `One` instance here — that, with the rest of
+the multiplicative `Semiring` / `Ring` structure, lives in
+`HexMatrixMathlib`, so the Mathlib-free core stays free of the algebraic
+typeclasses.
 
 {docstring Hex.Matrix.zero}
 
@@ -111,94 +113,16 @@ the Bareiss recurrence.
 
 {docstring Hex.Matrix.principalSubmatrix}
 
-# The determinant
+# Elementary operations
 %%%
-tag := "hex-matrix-determinant"
-%%%
-
-The reference determinant is the Leibniz formula: a signed sum over all
-permutation vectors of the product of the selected entries. It is the
-definitional semantics — correct by construction, but factorially slow,
-so it serves as the specification the faster Bareiss route is checked
-against rather than the routine a caller invokes on a large matrix.
-
-{docstring Hex.Matrix.det}
-
-The classical row and column laws are all proved against this
-definition. Swapping two rows negates the determinant; scaling a row
-scales it; adding a multiple of one row to another leaves it unchanged;
-and the determinant is invariant under transpose.
-
-{docstring Hex.Matrix.det_identity}
-
-{docstring Hex.Matrix.det_rowSwap}
-
-{docstring Hex.Matrix.det_rowScale}
-
-{docstring Hex.Matrix.det_rowAdd}
-
-{docstring Hex.Matrix.det_transpose}
-
-{docstring Hex.Matrix.det_colSwap}
-
-# The Bareiss determinant
-%%%
-tag := "hex-matrix-bareiss"
-%%%
-
-For an actual integer determinant computation the library uses Bareiss
-elimination: a fraction-free Gaussian elimination in which every
-intermediate entry stays an exact integer because each update divides
-*exactly* by the previous pivot. It runs in cubic time and never leaves
-the integers, so it avoids both the factorial blow-up of the Leibniz
-sum and the denominators of ordinary Gaussian elimination.
-
-An elimination pass returns a small record: the terminal matrix, the
-number of row swaps performed during pivoting, and an optional record of
-the first step at which a zero pivot with no replacement row was found
-(the signal that the matrix is singular).
-
-{docstring Hex.Matrix.BareissData}
-
-The sign contributed by the row swaps and the encoded determinant are
-read off that record. A recorded singular step encodes determinant zero;
-otherwise the determinant is the last diagonal entry of the terminal
-matrix with the swap sign applied.
-
-{docstring Hex.Matrix.BareissData.sign}
-
-{docstring Hex.Matrix.BareissData.det}
-
-The public entry points run the row-pivoting elimination. {name}`Hex.Matrix.bareissData`
-returns the full record; {name}`Hex.Matrix.bareiss` returns just the
-integer determinant.
-
-{docstring Hex.Matrix.bareissData}
-
-{docstring Hex.Matrix.bareiss}
-
-This is where the computational/proof boundary falls. The Mathlib-free
-layer proves the internal structural facts about the elimination — for
-instance that the packaged record is exactly the structured pivot loop
-finished into determinant data — but it does *not* prove that the
-Bareiss determinant equals the Leibniz {name}`Hex.Matrix.det`. That
-identification is a correspondence theorem living in the forthcoming
-`HexMatrixMathlib` bridge. Within `HexMatrix` itself the agreement is
-pinned only as value-level conformance fixtures: a fixed bank of
-matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M` is checked
-at build time.
-
-{docstring Hex.Matrix.bareissData_eq_finish_pivotLoop}
-
-# Row echelon and reduced row echelon
-%%%
-tag := "hex-matrix-echelon"
+tag := "hex-matrix-elementary"
 %%%
 
 The elementary row operations are the building blocks of the echelon
-transforms, and each carries the determinant law quoted above. They
-operate on a matrix over any ring; the reductions that follow specialize
-to a field, where division by a pivot is available.
+transforms, and each carries a determinant law (stated and proved in
+{ref "hex-determinant"}[HexDeterminant]). They operate on a matrix over
+any ring; the {ref "hex-row-reduce"}[HexRowReduce] reductions that use
+them specialize to a field, where division by a pivot is available.
 
 {docstring Hex.Matrix.rowSwap}
 
@@ -206,64 +130,25 @@ to a field, where division by a pivot is available.
 
 {docstring Hex.Matrix.rowAdd}
 
-An echelon computation returns its result packaged with a certificate of
-how it got there: the rank, the reduced matrix, the accumulated
-invertible row-operation transform `T` with `T * original = echelon`,
-and the pivot column of each row.
-
-{docstring Hex.Matrix.RowEchelonData}
-
-Two predicates capture what it means for such a record to be a genuine
-echelon or reduced-echelon form. {name}`Hex.Matrix.IsEchelonForm` bundles
-the conditions shared by any echelon form — the transform equation, the
-transform's invertibility, the rank bounds, and the staircase pivot
-structure. {name}`Hex.Matrix.IsRowReduced` extends it with the two
-reduced-form conditions: each pivot is one, and every entry above a
-pivot is zero.
-
-{name}`Hex.Matrix.IsEchelonForm` and {name}`Hex.Matrix.IsRowReduced` are those
-two predicates.
-
-The driver is Gauss-Jordan elimination, returning a
-{name}`Hex.Matrix.RowEchelonData` whose record satisfies the
-reduced-form contract.
-
-{docstring Hex.Matrix.rowReduce}
-
-{docstring Hex.Matrix.rowReduce_transform_mul}
-
-{docstring Hex.Matrix.rowReduce_isRowReduced}
-
-On top of the reduced form sit the linear-algebra readers a caller
-actually wants: membership in the row span with an explicit witness, the
-boolean span test, and a basis for the nullspace — each with a soundness
-theorem tying the executable answer back to the matrix.
-
-{docstring Hex.Matrix.spanCoeffs}
-
-{docstring Hex.Matrix.spanContains}
-
-{docstring Hex.Matrix.nullspace}
-
 # Worked example
 %%%
 tag := "hex-matrix-worked"
 %%%
 
 The block below builds the integer matrix with rows `(2, 0, 1)`,
-`(1, 3, 2)`, and `(0, 1, 1)`, whose determinant is `3`. Both determinant
-routes agree on it, and both agree with each other; the identity has
-determinant one, the determinant is invariant under transpose, and a
-matrix with a repeated-up-to-scale row is singular. Every `#guard` is
-checked when the chapter is built, so the outputs are guaranteed to
-match the executable implementation.
+`(1, 3, 2)`, and `(0, 1, 1)`, and reads a few core quantities off it:
+the squared norm of the first row is `2² + 0² + 1² = 5`, the dot product
+of the first two rows is `2·1 + 0·3 + 1·2 = 4`, and multiplying a vector
+by the identity returns it unchanged. Every `#guard` is checked when the
+chapter is built, so the outputs are guaranteed to match the executable
+implementation.
 
 ```lean
 open Hex Hex.Matrix
 
 namespace HexMatrixChapterExample
 
--- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]], det = 3.
+-- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]].
 private def A : Matrix Int 3 3 :=
   Matrix.ofFn fun i j =>
     match i.val, j.val with
@@ -272,30 +157,17 @@ private def A : Matrix Int 3 3 :=
     | 2, 0 => 0 | 2, 1 => 1 | 2, 2 => 1
     | _, _ => 0
 
--- The Leibniz determinant evaluates to 3.
-#guard Matrix.det A = 3
+-- The squared norm of the first row is 5.
+#guard Vector.normSq (Matrix.row A 0) = 5
 
--- The Bareiss determinant agrees with Leibniz.
-#guard Matrix.bareiss A = Matrix.det A
+-- The dot product of the first two rows is 4.
+#guard (Matrix.row A 0).dotProduct (Matrix.row A 1) = 4
 
--- The determinant is invariant under transpose.
-#guard Matrix.det (Matrix.transpose A) = 3
+-- The identity fixes every vector under mulVec.
+private def v : Vector Int 3 :=
+  Vector.ofFn fun i => (i.val + 1 : Int)
 
--- The identity has determinant one, both routes.
-#guard Matrix.det (Matrix.identity (R := Int) 3) = 1
-#guard Matrix.bareiss (Matrix.identity (R := Int) 3) = 1
-
--- S = [[1, 2], [2, 4]] has a dependent row pair,
--- so its determinant is zero.
-private def S : Matrix Int 2 2 :=
-  Matrix.ofFn fun i j =>
-    match i.val, j.val with
-    | 0, 0 => 1 | 0, 1 => 2
-    | 1, 0 => 2 | 1, 1 => 4
-    | _, _ => 0
-
-#guard Matrix.det S = 0
-#guard Matrix.bareiss S = 0
+#guard Matrix.mulVec (Matrix.identity (R := Int) 3) v = v
 
 end HexMatrixChapterExample
 ```
@@ -307,16 +179,16 @@ tag := "hex-matrix-cross-references"
 
 `HexMatrix` sits at the base of the linear-algebra stack:
 
-* It has no library dependencies — the matrix type, its arithmetic, both
-  determinant routes, and the echelon transforms are all built directly
-  on Lean's `Vector`, with no other `hex-*` library underneath.
+* It has no library dependencies — the matrix type, its arithmetic, and
+  the elementary operations are all built directly on Lean's `Vector`,
+  with no other `hex-*` library underneath.
+* {ref "hex-determinant"}[HexDeterminant], {ref "hex-row-reduce"}[HexRowReduce],
+  and {ref "hex-bareiss"}[HexBareiss] each build on this core: the
+  Leibniz determinant and its cofactor theory, the Gauss-Jordan row
+  reduction with its span and nullspace readers, and the fraction-free
+  integer determinant, respectively.
 * `HexMatrixMathlib` is the correspondence library carrying the
-  soundness theorems that relate these executable routines to Mathlib's
-  abstract `Matrix` API — in particular the identification of the
-  {name}`Hex.Matrix.bareiss` determinant with the Leibniz
-  {name}`Hex.Matrix.det` and with Mathlib's determinant. That chapter is
-  forthcoming; until it lands, the agreement between the two determinant
-  routes is exercised here only through the conformance fixtures
-  described in the {ref "hex-matrix-bareiss"}[Bareiss section]. The
-  Mathlib dependency lives entirely on that side of the boundary;
-  `HexMatrix` itself is Mathlib-free.
+  `Semiring` / `Ring` structure, the `One` instance, and the soundness
+  theorems that relate this executable representation to Mathlib's
+  abstract `Matrix` API. The Mathlib dependency lives entirely on that
+  side of the boundary; `HexMatrix` itself is Mathlib-free.

--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -1,0 +1,160 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexRowReduce
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "HexRowReduce: Gauss-Jordan reduction, span, and nullspace" =>
+%%%
+tag := "hex-row-reduce"
+%%%
+
+# Introduction
+%%%
+tag := "hex-row-reduce-intro"
+%%%
+
+`HexRowReduce` is the executable row-reduction stack over the
+{ref "hex-matrix"}[HexMatrix] dense core: Gauss-Jordan reduction to
+reduced row echelon form over a field, together with the row-span and
+nullspace computations built on it. It depends only on `HexMatrix`.
+
+The reduction returns more than a reduced matrix: it returns a
+certificate — the rank, the reduced form, the accumulated invertible
+transform, and the pivot columns — and the linear-algebra readers a
+caller actually wants are derived from that certificate with soundness
+(and, for the nullspace, completeness) theorems tying the executable
+answer back to the matrix. This chapter walks the echelon certificate,
+the `rowReduce` driver, and the span and nullspace readers, and closes
+with a worked example checked when the chapter is built.
+
+`HexRowReduce` is Mathlib-free. The identification of its rank, span, and
+nullspace with Mathlib's linear-algebra theory lives in the forthcoming
+`HexRowReduceMathlib` bridge.
+
+# The echelon certificate
+%%%
+tag := "hex-row-reduce-echelon"
+%%%
+
+The elementary row operations ({name}`Hex.Matrix.rowSwap`,
+{name}`Hex.Matrix.rowScale`, {name}`Hex.Matrix.rowAdd`) are documented
+with the {ref "hex-matrix"}[matrix core]; the reductions here compose
+them over a field, where division by a pivot is available.
+
+An echelon computation returns its result packaged with a certificate of
+how it got there: the rank, the reduced matrix, the accumulated
+invertible row-operation transform `T` with `T * original = echelon`,
+and the pivot column of each row.
+
+{docstring Hex.Matrix.RowEchelonData}
+
+Two predicates capture what it means for such a record to be a genuine
+echelon or reduced-echelon form. {name}`Hex.Matrix.IsEchelonForm` bundles
+the conditions shared by any echelon form — the transform equation, the
+transform's invertibility, the rank bounds, and the staircase pivot
+structure. {name}`Hex.Matrix.IsRowReduced` extends it with the two
+reduced-form conditions: each pivot is one, and every entry above a
+pivot is zero.
+
+# Gauss-Jordan reduction
+%%%
+tag := "hex-row-reduce-driver"
+%%%
+
+The driver is Gauss-Jordan elimination, returning a
+{name}`Hex.Matrix.RowEchelonData` whose record satisfies the
+reduced-form contract, with the transform equation and the rank read off
+the result.
+
+{docstring Hex.Matrix.rowReduce}
+
+{docstring Hex.Matrix.rowReduce_transform_mul}
+
+{docstring Hex.Matrix.rowReduce_isRowReduced}
+
+{docstring Hex.Matrix.rowReduce_rank}
+
+# Span and nullspace
+%%%
+tag := "hex-row-reduce-span"
+%%%
+
+On top of the reduced form sit the linear-algebra readers a caller
+actually wants: the linear combination of the rows, membership in the
+row span with an explicit witness, the boolean span test, and a basis
+for the nullspace — each with a soundness theorem, and the nullspace
+basis additionally with a completeness theorem.
+
+{docstring Hex.Matrix.rowCombination}
+
+{docstring Hex.Matrix.spanCoeffs}
+
+{docstring Hex.Matrix.spanCoeffs_sound}
+
+{docstring Hex.Matrix.spanContains}
+
+{docstring Hex.Matrix.nullspace}
+
+{docstring Hex.Matrix.nullspaceBasisMatrix}
+
+{docstring Hex.Matrix.nullspace_sound}
+
+{docstring Hex.Matrix.nullspace_complete}
+
+# Worked example
+%%%
+tag := "hex-row-reduce-worked"
+%%%
+
+The block below builds the `2 × 3` rational matrix with rows `(1, 2, 3)`
+and `(2, 4, 6)`. The second row is twice the first, so the rank is `1`,
+and the vector `(1, 2, 3)` — the first row itself — lies in the row
+span. Every `#guard` is checked when the chapter is built.
+
+```lean
+open Hex Hex.Matrix
+
+namespace HexRowReduceChapterExample
+
+-- M = [[1,2,3],[2,4,6]], rank 1 (rows dependent).
+private def M : Matrix Rat 2 3 :=
+  Matrix.ofFn fun i j => (i + 1) * (j + 1)
+
+-- The reduction reports rank 1.
+#guard (Matrix.rowReduce M).rank = 1
+
+-- (1, 2, 3) is the first row, hence in the row span.
+private def v : Vector Rat 3 := Vector.ofFn fun j => j + 1
+
+#guard Matrix.spanContains M v = true
+
+end HexRowReduceChapterExample
+```
+
+# Cross-references
+%%%
+tag := "hex-row-reduce-cross-references"
+%%%
+
+`HexRowReduce` is the row-reduction layer of the linear-algebra stack:
+
+* It depends only on {ref "hex-matrix"}[HexMatrix] — the matrix type,
+  its arithmetic, and the elementary operations it composes.
+* The {ref "hex-determinant"}[HexDeterminant] and
+  {ref "hex-bareiss"}[HexBareiss] libraries handle the determinant; row
+  reduction is the separate field-valued route for rank, span, and
+  nullspace.
+* `HexRowReduceMathlib` is the correspondence library identifying the
+  executable rank, span, and nullspace with Mathlib's linear algebra.
+  The Mathlib dependency lives entirely on that side of the boundary;
+  `HexRowReduce` itself is Mathlib-free.

--- a/progress/20260630T055054Z_hexmanual-matrix-split.md
+++ b/progress/20260630T055054Z_hexmanual-matrix-split.md
@@ -1,0 +1,39 @@
+# HexManual matrix-chapter split (PR 1 of the manual refresh)
+
+## Accomplished
+
+- Split the single `HexManual/Chapters/HexMatrix.lean` chapter, which
+  conflated four now-separate libraries, into four per-library chapters:
+  - `HexMatrix.lean` trimmed to the dense-matrix core.
+  - new `HexDeterminant.lean`, widened toward its README (Laplace
+    `det_eq_foldl_laplace_row`, `det_setCol_add`, `adjugate`/
+    `mul_adjugate`, Cauchy-Binet, Plücker, triangular).
+  - new `HexRowReduce.lean` (Gauss-Jordan, span, nullspace).
+  - new `HexBareiss.lean` (fraction-free integer determinant).
+- Fixed stale prose: the core chapter claimed the identity is exposed
+  via a `One` instance, but that instance was dropped from the
+  Mathlib-free core and now lives only in `HexMatrixMathlib`.
+- Registered all four chapters in `HexManual.lean` (dependency order)
+  and cross-linked them with `{ref}` tags.
+- `lake build HexManual` green in a fresh clone: every `{docstring}`
+  resolves, every worked-example `#guard` passes, no over-length code
+  lines, no warnings on the four chapters.
+
+## Current frontier
+
+PR 1 is committed on `claude/manual-matrix-split`. PR 2 (per-chapter
+`# Recipes` how-to sections, mathlib-phrasebook style) starts with a
+single exemplar recipe for review before the rest are written.
+
+## Next step
+
+Land the exemplar recipe (kernel basis, HexRowReduce) for review, then
+the first-pass recipe set (matrix family + HexGF2/HexGFq/HexLLL). Then
+PR 3: `PLAN/Phase7.md` one-chapter-per-library rule + `SPEC/recipes.md`.
+
+## Blockers
+
+None. README quickstarts (HexMatrix/HexDeterminant) still use
+`(1 : Matrix ...)` for the identity, which no longer elaborates after
+the `One`-instance drop; that is released-README source, out of scope
+for the manual PRs but worth a separate fix.


### PR DESCRIPTION
This PR splits the single HexManual matrix chapter, which conflated four now-separate libraries, into one reference chapter per library: HexMatrix (the dense-matrix core), HexDeterminant (the Leibniz determinant and cofactor/adjugate theory, widened to cover Laplace expansion, the adjugate identity, Cauchy-Binet, the Plücker/Desnanot-Jacobi identity, and triangular determinants), HexRowReduce (Gauss-Jordan reduction with the span and nullspace readers), and HexBareiss (the fraction-free integer determinant). It registers the four chapters in the HexManual aggregator in dependency order, cross-links them, and corrects stale prose in the core chapter that described a One instance the Mathlib-free matrix library no longer carries.

🤖 Prepared with Claude Code