### PR TITLE
refactor: make Hex.Matrix render representation-agnostic

### DIFF
--- a/HexMatrix/Notation.lean
+++ b/HexMatrix/Notation.lean
@@ -65,7 +65,7 @@ the columns line up. The output is copy-pasteable as input. For example,
 This is what the `Repr` instance shows under `#eval`. -/
 def render [Repr R] (M : Matrix R n m) : Std.Format :=
   let cells : List (List String) :=
-    M.toList.map fun row => row.toList.map fun x => (repr x).pretty
+    (List.finRange n).map fun i => (M.row i).toList.map fun x => (repr x).pretty
   let widths : List Nat :=
     (List.range m).map fun j => cells.foldl (fun w r => max w (r.getD j "").length) 0
   let pad : String → Nat → String := fun s w => String.ofList (List.replicate (w - s.length) ' ') ++ s


### PR DESCRIPTION
This PR makes the `Hex.Matrix` `#m[...]` renderer iterate rows via `Matrix.row` instead of `M.toList`. `Matrix.row` is a public accessor that is present and computable on both the current `Vector`-of-rows `abbrev` and the upcoming one-field-structure representation, whereas `M.toList` is specific to the `abbrev`. With this change the renderer compiles unchanged across the encapsulation in https://github.com/kim-em/hex-dev/pull/8442 (refactor: encapsulate Hex.Matrix behind a one-field structure), so that PR can rebase and land without touching the notation module and `main` stays green through the transition. Output is unchanged: matrices still render as copy-pasteable, column-aligned `#m[...]` literals.

🤖 Prepared with Claude Code