### PR TITLE
refactor: migrate the Hex test-kit library to the module system

### DIFF
--- a/Hex.lean
+++ b/Hex.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import Hex.Conformance.Emit
-import Hex.BenchOracle.Flint
+module
+
+public import Hex.Conformance.Emit
+public import Hex.BenchOracle.Flint
+
+public section
 
 /-! Top-level helpers shared by the per-library `Hex<X>` packages.
 

--- a/Hex/BenchOracle/Flint.lean
+++ b/Hex/BenchOracle/Flint.lean
@@ -4,8 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
-import Lean.Data.Json
-import Lean.Data.Json.FromToJson
+module
+
+public import Lean.Data.Json
+public import Lean.Data.Json.FromToJson
+
+public section
 
 /-!
 # Shared FLINT persistent-subprocess bench driver helper

--- a/Hex/Conformance/Emit.lean
+++ b/Hex/Conformance/Emit.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kim Morrison
 -/
 
+module
+
 /-!
 JSONL fixture/result emission helper for the Hex conformance suite.
 

--- a/progress/20260630T104233Z_module_migration_testkit.md
+++ b/progress/20260630T104233Z_module_migration_testkit.md
@@ -1,0 +1,13 @@
+# Module migration: Hex/ test kit (hex-test-kit)
+
+## Accomplished
+
+Migrated the shared test-kit library `Hex` (`Hex/Conformance/Emit.lean`,
+`Hex/BenchOracle/Flint.lean`, umbrella `Hex.lean`) to the module system.
+Mechanical `module`/`public import`/`public section` wrap was sufficient; no
+`@[expose]` needed. Full `lake build` and `HexConformance` green.
+
+Risk 3 (public API for `Conformance.Emit`/`BenchOracle.Flint` consumed by
+legacy conformance/bench drivers) did not materialize: the legacy
+`HexConformance` drivers continue to build against the now-module `Hex`
+re-exported API.


### PR DESCRIPTION
This PR migrates the shared `Hex` test-kit library (`Hex.Conformance.Emit`, `Hex.BenchOracle.Flint`, and the `Hex` umbrella) to the Lean 4 module system. The mechanical `module`/`public import`/`public section` wrapping was sufficient with no `@[expose]` needed, and the legacy `HexConformance` drivers continue to build against the re-exported API. The full `lake build` and `HexConformance` both build green.

🤖 Prepared with Claude Code