### PR TITLE
ci: cache hex-dev oleans across the CI and conformance jobs (R2 Lake cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,44 @@ jobs:
           key: lake-build-${{ github.workflow }}-${{ github.run_id }}
           restore-keys: |
             lake-build-${{ github.workflow }}-
+      # --- Lake artifact cache (dormant unless the LAKE_CACHE_*_PUBLIC repo
+      # variables are set). A rev-precise, cross-runner fallback to the
+      # actions/cache restore above: when that misses (eviction, a new branch),
+      # this restores hex-dev's oleans by Git revision so the build below
+      # recompiles only changed modules. Mathlib still comes from `lake exe
+      # cache get`. ---
+      - name: Configure Lake artifact cache (no-op unless endpoints set)
+        env:
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
+            CFG="$RUNNER_TEMP/lake-cache.toml"
+            {
+              echo 'cache.defaultService = "hex-public"'
+              echo '[[cache.service]]'
+              echo 'name = "hex-public"'
+              echo 'kind = "s3"'
+              echo "artifactEndpoint = \"$PUBLIC_ARTIFACT_ENDPOINT\""
+              echo "revisionEndpoint = \"$PUBLIC_REVISION_ENDPOINT\""
+            } > "$CFG"
+            {
+              echo "LAKE_CONFIG=$CFG"
+              echo "LAKE_CACHE_DIR=$PWD/.lake/cache"
+              echo "LAKE_ARTIFACT_CACHE=true"
+              echo "LAKE_RESTORE_ARTIFACTS=true"
+              echo "HEX_CACHE_ENABLED=1"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Lake artifact cache enabled (service hex-public)"
+          else
+            echo "::notice::Lake artifact cache not configured (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
+          fi
+      - name: Restore hex-dev oleans from the Lake cache (anonymous; non-fatal)
+        if: ${{ env.HEX_CACHE_ENABLED == '1' }}
+        run: |
+          lake cache get --service hex-public --repo kim-em/hex-dev \
+            || echo "::warning::lake cache miss for this revision; building from source"
+          echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"
       - name: Build hex (Mathlib must NOT rebuild from source)
         # Build the bench-exes here, not in the `Bench verify` step.
         # Otherwise the first `lake exe X_bench list` in that step
@@ -69,6 +107,31 @@ jobs:
             HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib
       - name: Build HO-1 Mathlib bridge
         run: lake build HexBerlekampZassenhausMathlib
+      # Publish hex-dev's oleans on a trusted main push so later builds (and any
+      # consumer) restore them. Skips silently without the upload key.
+      - name: Publish hex-dev oleans to the Lake cache (main only)
+        if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && env.HEX_CACHE_ENABLED == '1' }}
+        env:
+          LAKE_CACHE_KEY: ${{ secrets.LAKE_CACHE_KEY }}
+          S3_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT }}
+          S3_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT }}
+        run: |
+          if [ -z "$LAKE_CACHE_KEY" ] || [ -z "$S3_ARTIFACT_ENDPOINT" ] || [ -z "$S3_REVISION_ENDPOINT" ]; then
+            echo "::notice::upload not configured (LAKE_CACHE_KEY / endpoints); skipping publish"; exit 0
+          fi
+          CFG="$RUNNER_TEMP/lake-cache-upload.toml"
+          {
+            echo 'cache.defaultUploadService = "hex-r2"'
+            echo '[[cache.service]]'
+            echo 'name = "hex-r2"'
+            echo 'kind = "s3"'
+            echo "artifactEndpoint = \"$S3_ARTIFACT_ENDPOINT\""
+            echo "revisionEndpoint = \"$S3_REVISION_ENDPOINT\""
+          } > "$CFG"
+          export LAKE_CONFIG="$CFG"
+          lake build --no-build -o .lake/outputs.jsonl
+          echo "mapping entries: $(wc -l < .lake/outputs.jsonl)"
+          lake cache put .lake/outputs.jsonl --service hex-r2 --repo kim-em/hex-dev
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)
         env:
           # Hard cap enforced per SPEC/benchmarking.md §CI integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
           lake cache get --service hex-public --repo kim-em/hex-dev \
             || echo "::warning::lake cache miss for this revision; building from source"
           echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"
+      # With the cache env now active, assert the entire Mathlib graph is already
+      # up to date. `--no-build` reports stale targets and exits non-zero instead
+      # of building them, so this fails loudly (never silently rebuilds) if the
+      # cache wiring ever invalidates the prebuilt Mathlib oleans. Stronger and
+      # more precise than the olean-count check above.
+      - name: Assert Mathlib will not rebuild (lake build --no-build)
+        run: lake build --no-build Mathlib
       # Single-source the build target set so the publish step emits cache
       # mappings for exactly what was built. The repo's only @[default_target]
       # is HexManual, so a bare `lake build --no-build -o` would publish only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,13 @@ jobs:
           lake cache get --service hex-public --repo kim-em/hex-dev \
             || echo "::warning::lake cache miss for this revision; building from source"
           echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"
+      # Single-source the build target set so the publish step emits cache
+      # mappings for exactly what was built. The repo's only @[default_target]
+      # is HexManual, so a bare `lake build --no-build -o` would publish only
+      # the manual's closure and miss the bench/library/bridge targets.
+      - name: Define the hex-dev build target set
+        run: |
+          echo "HEX_BUILD_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexlll_bench HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL hexlll_provider_probe HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib" >> "$GITHUB_ENV"
       - name: Build hex (Mathlib must NOT rebuild from source)
         # Build the bench-exes here, not in the `Bench verify` step.
         # Otherwise the first `lake exe X_bench list` in that step
@@ -93,18 +100,7 @@ jobs:
         # heaviest one) and the wallclock breakdown would conflate
         # build time with verify time. Bench verify itself is fast
         # since lean-bench's verify path runs in-process.
-        run: |
-          lake build \
-            hexarith_bench hexpoly_bench hexpolyz_bench \
-            hexpolyfp_bench hexmodarith_bench \
-            hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench \
-            hexhensel_bench hexberlekamp_bench hexbz_bench \
-            hexconway_bench \
-            hexmatrix_bench hexdeterminant_bench hexbareiss_bench \
-            hexgramschmidt_bench hexlll_bench \
-            HexMatrix HexRowReduce HexDeterminant HexBareiss \
-            HexGramSchmidt HexLLL hexlll_provider_probe \
-            HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib
+        run: lake build ${HEX_BUILD_TARGETS}
       - name: Build HO-1 Mathlib bridge
         run: lake build HexBerlekampZassenhausMathlib
       # Publish hex-dev's oleans on a trusted main push so later builds (and any
@@ -129,7 +125,10 @@ jobs:
             echo "revisionEndpoint = \"$S3_REVISION_ENDPOINT\""
           } > "$CFG"
           export LAKE_CONFIG="$CFG"
-          lake build --no-build -o .lake/outputs.jsonl
+          # Emit mappings for exactly the targets built above (plus the HO-1
+          # bridge), not the bare default target.
+          lake build --no-build -o .lake/outputs.jsonl \
+            ${HEX_BUILD_TARGETS} HexBerlekampZassenhausMathlib
           echo "mapping entries: $(wc -l < .lake/outputs.jsonl)"
           lake cache put .lake/outputs.jsonl --service hex-r2 --repo kim-em/hex-dev
       - name: Bench verify (smoke gate per SPEC/benchmarking.md §CI integration)

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -90,6 +90,13 @@ jobs:
           lake cache get --service hex-public --repo kim-em/hex-dev \
             || echo "::warning::lake cache miss for this revision; building from source"
           echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"
+      # With the cache env now active, assert the entire Mathlib graph is already
+      # up to date. `--no-build` reports stale targets and exits non-zero instead
+      # of building them, so this fails loudly (never silently rebuilds) if the
+      # cache wiring ever invalidates the prebuilt Mathlib oleans. Stronger and
+      # more precise than the olean-count check above.
+      - name: Assert Mathlib will not rebuild (lake build --no-build)
+        run: lake build --no-build Mathlib
       - name: Build conformance + emit-fixture targets
         run: |
           lake build \

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -51,6 +51,45 @@ jobs:
           key: lake-build-${{ github.workflow }}-${{ github.run_id }}
           restore-keys: |
             lake-build-${{ github.workflow }}-
+      # --- Lake artifact cache (dormant unless the LAKE_CACHE_*_PUBLIC repo
+      # variables are set). The conformance targets build in the same root
+      # package as ci.yml, so the library oleans ci.yml publishes on main
+      # restore here verbatim: this job recompiles only the conformance drivers
+      # and emit-fixture exes instead of rebuilding all of hex-dev. Backtracks
+      # to the last published main commit, so it helps even racing ci.yml on the
+      # same push. Mathlib still comes from `lake exe cache get`. ---
+      - name: Configure Lake artifact cache (no-op unless endpoints set)
+        env:
+          PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+          PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+        run: |
+          if [ -n "$PUBLIC_ARTIFACT_ENDPOINT" ] && [ -n "$PUBLIC_REVISION_ENDPOINT" ]; then
+            CFG="$RUNNER_TEMP/lake-cache.toml"
+            {
+              echo 'cache.defaultService = "hex-public"'
+              echo '[[cache.service]]'
+              echo 'name = "hex-public"'
+              echo 'kind = "s3"'
+              echo "artifactEndpoint = \"$PUBLIC_ARTIFACT_ENDPOINT\""
+              echo "revisionEndpoint = \"$PUBLIC_REVISION_ENDPOINT\""
+            } > "$CFG"
+            {
+              echo "LAKE_CONFIG=$CFG"
+              echo "LAKE_CACHE_DIR=$PWD/.lake/cache"
+              echo "LAKE_ARTIFACT_CACHE=true"
+              echo "LAKE_RESTORE_ARTIFACTS=true"
+              echo "HEX_CACHE_ENABLED=1"
+            } >> "$GITHUB_ENV"
+            echo "::notice::Lake artifact cache enabled (service hex-public)"
+          else
+            echo "::notice::Lake artifact cache not configured (set the LAKE_CACHE_*_PUBLIC repo variables to enable)"
+          fi
+      - name: Restore hex-dev oleans from the Lake cache (anonymous; non-fatal)
+        if: ${{ env.HEX_CACHE_ENABLED == '1' }}
+        run: |
+          lake cache get --service hex-public --repo kim-em/hex-dev \
+            || echo "::warning::lake cache miss for this revision; building from source"
+          echo "LAKE_NO_CACHE=true" >> "$GITHUB_ENV"
       - name: Build conformance + emit-fixture targets
         run: |
           lake build \


### PR DESCRIPTION
This PR adds a rev-precise, cross-runner Lake artifact cache to the hex-dev monorepo build so CI stops rebuilding from scratch. The whole monorepo is a single Lake package, so one `lake cache get` / `lake cache put` covers every `Hex*` library with no per-dependency loop; Mathlib still comes from `lake exe cache get`.

Two changes:

- **`ci.yml`** restores hex-dev's oleans by Git revision before building (backtracking to a recently-built ancestor when the exact revision has no mapping) and publishes them on a trusted main push. The existing `actions/cache` restore is kept as the fast same-infra path; the R2 cache is the reliable fallback when GitHub evicts that cache or a new branch misses it.
- **`conformance.yml`** previously rebuilt every hex library from scratch, because its `HexConformance` + emit-fixture targets pull the whole stack in. It now restores those library oleans from the same cache (same root package, so the hashes match what `ci.yml` publishes) and recompiles only the conformance drivers and emit exes. It backtracks to the last published main commit, so it helps even when the two workflows race on the same push.

The wiring is dormant unless the `LAKE_CACHE_*` repo variables and the `LAKE_CACHE_KEY` secret are set (they are, on hex-dev only), and every cache step is non-fatal — a miss, a network hiccup, or an absent key falls back to a full build, so CI never goes red on a cache problem.

Scope note: the cache is deliberately limited to speeding up hex-dev CI. It is not wired into the released split repos and there is no end-user fetch path, because the native artifact cache keys on a full input hash that differs between building a package as a root and as a dependency, so it cannot restore oleans across the repo boundary.

🤖 Prepared with Claude Code