### PR TITLE
style: clear non-module-system build warnings

### DIFF
--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -1027,7 +1027,7 @@ theorem checkPowChainLinearIncrementalQuotientWitnesses_of_steps
   intro k hk
   exact hsteps k (List.mem_range.mp hk)
 
-private def primeTwo : Hex.Nat.Prime 2 := by
+private theorem primeTwo : Hex.Nat.Prime 2 := by
   refine ⟨by decide, ?_⟩
   intro m hm
   have hmle : m ≤ 2 := Nat.le_of_dvd (by decide : 0 < 2) hm

--- a/HexGF2Mathlib/Basic.lean
+++ b/HexGF2Mathlib/Basic.lean
@@ -212,7 +212,7 @@ theorem toFpPoly_one :
 /-- A packed coefficient bit `coeffOfFp a` holds at most one set bit. -/
 private theorem coeffOfFp_toNat_lt (a : Hex.ZMod64 2) : (coeffOfFp a).toNat < 2 := by
   unfold coeffOfFp
-  by_cases h : a = Hex.ZMod64.zero <;> simp [h] <;> decide
+  by_cases h : a = Hex.ZMod64.zero <;> simp [h]
 
 /-- The low bit of a packed coefficient records whether the source coefficient
 is nonzero. -/
@@ -278,7 +278,7 @@ private theorem packWord_foldl_testBit (p : Hex.FpPoly 2) (wordIdx : Nat) :
       simp [hbn, Nat.lt_succ_of_lt hbn, h1]
     · subst hbn
       rw [Nat.sub_self, coeffOfFp_testBit_zero]
-      simp [Nat.lt_succ_self]
+      simp
     · have h1 : ¬ (b < n) := by omega
       have h2 : ¬ (b < n + 1) := by omega
       have h4 : (coeffOfFp (p.coeff (64 * wordIdx + n))).toNat.testBit (b - n) = false := by
@@ -357,7 +357,8 @@ theorem toFpPoly_add (p q : Hex.GF2Poly) :
   intro i
   rw [Hex.DensePoly.coeff_add_semiring (toFpPoly p) (toFpPoly q) i,
     coeff_toFpPoly, coeff_toFpPoly, coeff_toFpPoly, Hex.GF2Poly.coeff_add_eq_bne]
-  cases p.coeff i <;> cases q.coeff i <;> (try simp) <;> grind
+  cases p.coeff i <;> cases q.coeff i <;> (try simp)
+  grind
 
 /-- The `ZMod64 2` indicator of a bit, as a canonical residue. -/
 private theorem chi_eq_ofNat (b : Bool) :
@@ -371,7 +372,7 @@ private theorem chi_mul (b c : Bool) :
       (if b then (1 : Hex.ZMod64 2) else 0) * (if c then 1 else 0) := by
   rw [chi_eq_ofNat b, chi_eq_ofNat c, chi_eq_ofNat (b && c)]
   apply Hex.ZMod64.ext_toNat
-  simp only [Hex.ZMod64.toNat_mul, Hex.ZMod64.toNat_ofNat]
+  simp only [Hex.ZMod64.toNat_ofNat]
   cases b <;> cases c <;> decide
 
 /-- Indicators add by the `XOR` of the bits (`ZMod64 2` addition is `XOR` on
@@ -381,7 +382,7 @@ private theorem chi_xor (b c : Bool) :
       (if b then (1 : Hex.ZMod64 2) else 0) + (if c then 1 else 0) := by
   rw [chi_eq_ofNat b, chi_eq_ofNat c, chi_eq_ofNat (b != c)]
   apply Hex.ZMod64.ext_toNat
-  simp only [Hex.ZMod64.toNat_add, Hex.ZMod64.toNat_ofNat]
+  simp only [Hex.ZMod64.toNat_ofNat]
   cases b <;> cases c <;> decide
 
 /-- `ZMod64 2` is an additive monoid with `0` on the right. -/

--- a/HexGFq/CrossCheck.lean
+++ b/HexGFq/CrossCheck.lean
@@ -116,7 +116,7 @@ private def poly2ToWord (f : FpPoly 2) (n : Nat) : UInt64 :=
 
 /-- `primeTwo` is the primality witness for 2, used to build the prime-modulus
 instance for the binary base field. -/
-private def primeTwo : Hex.Nat.Prime 2 := by
+private theorem primeTwo : Hex.Nat.Prime 2 := by
   refine ⟨by decide, ?_⟩
   intro m hm
   have hmle : m ≤ 2 := Nat.le_of_dvd (by decide : 0 < 2) hm

--- a/HexModArith/Prime.lean
+++ b/HexModArith/Prime.lean
@@ -29,10 +29,10 @@ facts over `ZMod64 p`. -/
 class PrimeModulus (p : Nat) : Prop where
   prime : Hex.Nat.Prime p
 
+omit [Bounds p] in
 /-- Build the prime-modulus typeclass witness from an explicit project-local
 primality proof. -/
-@[expose, reducible]
-def primeModulusOfPrime (hp : Hex.Nat.Prime p) : PrimeModulus p :=
+theorem primeModulusOfPrime (hp : Hex.Nat.Prime p) : PrimeModulus p :=
   ⟨hp⟩
 
 private theorem eq_zero_of_dvd_modulus {a : ZMod64 p} (h : p ∣ a.toNat) : a = 0 := by

--- a/HexPolyMathlib/Basic.lean
+++ b/HexPolyMathlib/Basic.lean
@@ -254,7 +254,7 @@ of `toPolynomial p` agrees with the `n`th coefficient of the dense polynomial `p
 theorem coeff_toPolynomial [Semiring R] [DecidableEq R] (p : Hex.DensePoly R) (n : Nat) :
     (toPolynomial p).coeff n = p.coeff n := by
   unfold toPolynomial
-  rw [Polynomial.finset_sum_coeff]
+  rw [Polynomial.finsetSum_coeff]
   by_cases hn : n < p.size
   · simp [Polynomial.coeff_monomial, hn]
   · have hcoeff := Hex.DensePoly.coeff_eq_zero_of_size_le p (Nat.le_of_not_gt hn)

--- a/progress/20260630T113931Z_build-warning-cleanup.md
+++ b/progress/20260630T113931Z_build-warning-cleanup.md
@@ -1,0 +1,38 @@
+# Build warning cleanup (non-module-system)
+
+## Accomplished
+
+Cleared every non-sorry build warning that is not tied to the in-progress
+module-system migration. Full `lake build` is green; the only remaining
+warnings are the `backward.privateInPublic` set (deliberately left for the
+module-system work) and warnings inside the `verso`/`subverso` dependencies.
+
+- `linter.defProp` (`def` of a `Prop` → `theorem`): converted `primeTwo` in
+  `HexBerlekamp/Irreducibility.lean` and `HexGFq/CrossCheck.lean`, and
+  `HexModArith.primeModulusOfPrime`. The latter carried `@[expose, reducible]`
+  (which only apply to `def`); dropping both is sound because `PrimeModulus`
+  is a `Prop`, so proof irrelevance makes reducibility/exposure of the witness
+  irrelevant at use sites. Added `omit [Bounds p] in` to silence the now-unused
+  auto-included section instance.
+- Deprecation: `Polynomial.finset_sum_coeff` → `Polynomial.finsetSum_coeff`
+  in `HexPolyMathlib/Basic.lean`.
+- `HexGF2Mathlib/Basic.lean` tactic-linter warnings: dropped a dead
+  `<;> decide`, dropped an unused `Nat.lt_succ_self` simp arg, dropped unused
+  `ZMod64.toNat_mul` / `ZMod64.toNat_add` simp-only args, and split a
+  `... <;> grind` (`unnecessarySeqFocus`) into a sequenced `grind`.
+
+## Current frontier
+
+Tree builds green. Remaining warnings are all the module-system
+`privateInPublic` set or warnings inside third-party deps (`verso`,
+`subverso`).
+
+## Next step
+
+The `privateInPublic` warnings want the module-system migration finished
+(make the referenced helper decls public, drop
+`set_option backward.privateInPublic true`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR clears every non-sorry build warning that is not part of the in-progress module-system migration. It converts three `Prop`-valued `def`s to `theorem` (the two `primeTwo` witnesses and `primeModulusOfPrime`, the latter dropping its `@[expose, reducible]` since `PrimeModulus` is a `Prop` and proof irrelevance makes reducibility/exposure of the witness irrelevant at use sites), renames the deprecated `Polynomial.finset_sum_coeff` to `Polynomial.finsetSum_coeff`, and removes five tactic-linter warnings in `HexGF2Mathlib/Basic.lean` (a dead `decide`, three unused simp arguments, and an unnecessary `<;>`).

The full `lake build` is green. The only remaining warnings are the `backward.privateInPublic` set, which belongs to the separate module-system migration, and warnings inside the `verso`/`subverso` dependencies.

🤖 Prepared with Claude Code