### PR TITLE
chore: make the Mathlib bridge libraries default build targets

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -107,20 +107,28 @@ lean_lib HexGFq where
 
 lean_lib HexBerlekampZassenhaus where
 
+@[default_target]
 lean_lib HexPolyMathlib where
 
+@[default_target]
 lean_lib HexModArithMathlib where
 
+@[default_target]
 lean_lib HexPolyZMathlib where
 
+@[default_target]
 lean_lib HexBerlekampMathlib where
 
+@[default_target]
 lean_lib HexHenselMathlib where
 
+@[default_target]
 lean_lib HexGF2Mathlib where
 
+@[default_target]
 lean_lib HexGFqMathlib where
 
+@[default_target]
 lean_lib HexBerlekampZassenhausMathlib where
 
 lean_lib HexMatrix where
@@ -146,16 +154,22 @@ lean_lib HexLLL where
     else
       #["-ldl"]
 
+@[default_target]
 lean_lib HexMatrixMathlib where
 
+@[default_target]
 lean_lib HexRowReduceMathlib where
 
+@[default_target]
 lean_lib HexDeterminantMathlib where
 
+@[default_target]
 lean_lib HexBareissMathlib where
 
+@[default_target]
 lean_lib HexGramSchmidtMathlib where
 
+@[default_target]
 lean_lib HexLLLMathlib where
 
 lean_exe hexlll_provider_probe where


### PR DESCRIPTION
This PR marks every `Hex*Mathlib` bridge library `@[default_target]` so a bare `lake build` builds them, and transitively the computational libraries they depend on. Previously only `HexManual` was a default target, so `lake build` silently skipped the Mathlib bridges and their errors surfaced only in the explicit CI target list; this closes that gap so a local `lake build` matches what CI checks for the bridge layer.

🤖 Prepared with Claude Code