### PR TITLE
doc: record the matrix encapsulation boundary in the SPECs

### DIFF
--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -14,6 +14,13 @@ Dense matrices over a coefficient type `R`.
 - Submatrix / leading-submatrix slicing and the Gram matrix
 - Generic over the coefficient type `R`
 
+**Entry vs row access.** `M[(i, j)]` is the O(1) entry accessor and the normal
+form for single entries. Row access `M[i]` is deliberately `noncomputable`: it
+exists only so proofs may speak of whole rows, while compiled code reads rows
+through the computable `getRow` and entries through `M[(i, j)]`. Any compiled
+definition that reaches for `M[i]` fails to compile, so a future flat backing
+representation never silently pays a per-entry row-materialization cost.
+
 This is the dense base of the matrix family. The row-reduction stack
 (`hex-row-reduce`), the Leibniz determinant theory (`hex-determinant`), and the
 executable Bareiss algorithm (`hex-bareiss`) build on it.

--- a/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
+++ b/HexMatrixMathlib/SPEC/hex-matrix-mathlib.md
@@ -14,6 +14,9 @@ correspondences build on this base in `HexRowReduceMathlib`,
 ```lean
 def matrixEquiv : Hex.Matrix R n m ≃ Matrix (Fin n) (Fin m) R
 ```
+Its forward map is `fun M i j => M[(i, j)]` — built on the public entry API, not
+on the (now-opaque) backing representation, so the equivalence is unaffected by a
+representation change.
 
 **Row operations correspond to Mathlib transvections / elementary matrices:**
 Our `rowAdd M i j c` is left-multiplication by `Matrix.transvection i j c`; our


### PR DESCRIPTION
This PR records the encapsulation boundary in the matrix SPECs: `hex-matrix` now notes that `M[(i, j)]` is the O(1) entry accessor and that row access `M[i]` is deliberately noncomputable (available to proofs, while compiled code uses `getRow`) so a future flat representation pays no per-entry cost, and `hex-matrix-mathlib` notes that `matrixEquiv`'s forward map is built on the entry API rather than the opaque representation.

🤖 Prepared with Claude Code