### PR TITLE
doc: use Matrix.identity in README examples instead of (1 : Matrix ...)

### DIFF
--- a/HexBareiss/README.md
+++ b/HexBareiss/README.md
@@ -31,7 +31,7 @@ open Hex
 def M : Matrix Int 3 3 := Matrix.ofFn fun i j => (i + 2 * j : Int)
 
 #eval Matrix.bareiss M                       -- fraction-free determinant
-#eval Matrix.bareiss (1 : Matrix Int 4 4)    -- 1
+#eval Matrix.bareiss (Matrix.identity (R := Int) 4)    -- 1
 
 -- bareissData also records the row-swap count alongside the determinant.
 #eval (Matrix.bareissData M).det

--- a/HexDeterminant/README.md
+++ b/HexDeterminant/README.md
@@ -29,7 +29,7 @@ open Hex
 def M : Matrix Int 3 3 := Matrix.ofFn fun i j => if i = j then (2 : Int) else 1
 
 #eval Matrix.det M                       -- 4, via the Leibniz formula
-#eval Matrix.det (1 : Matrix Int 4 4)    -- 1
+#eval Matrix.det (Matrix.identity (R := Int) 4)    -- 1
 
 -- The determinant tracks elementary row operations.
 #eval Matrix.det (Matrix.rowSwap M 0 1)  -- -4, negated

--- a/HexMatrix/README.md
+++ b/HexMatrix/README.md
@@ -37,7 +37,7 @@ def B : Matrix Int 3 2 := Matrix.ofFn fun i j => (i * j : Int)
 -- Elementary row operations are pure data transforms.
 #eval Matrix.rowSwap A 0 1
 #eval Matrix.rowScale A 0 5
-#eval (1 : Matrix Int 3 3)         -- the 3×3 identity
+#eval Matrix.identity (R := Int) 3 -- the 3×3 identity
 ```
 
 # Functionality


### PR DESCRIPTION
This PR updates the `#eval` examples in the HexMatrix, HexDeterminant, and HexBareiss READMEs to construct the identity matrix via `Matrix.identity (R := Int) n` rather than `(1 : Matrix Int n n)`. The Mathlib-free `One (Matrix R n n)` instance was removed when `Hex.Matrix` became an opaque one-field structure in https://github.com/kim-em/hex-dev/pull/8442 ("refactor: encapsulate Hex.Matrix behind a one-field structure"), so `(1 : Matrix Int n n)` no longer elaborates in a Mathlib-free context; `Matrix.identity` is the spelling already used throughout HexManual.

🤖 Prepared with Claude Code