### PR TITLE
perf: cut the matrix-encapsulation heartbeat bumps from 1000000 to 400000

### DIFF
--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -1089,7 +1089,7 @@ private theorem schurSigma_noPivotCorrection_succ
   exact exactDiv_bareissCorrection_succ_algebra
     denom pivot gram entry row col hdenom h_step_dvd
 
-set_option maxHeartbeats 1000000 in
+set_option maxHeartbeats 400000 in
 /-- The σ-chain Bareiss correction invariant.  At step `q < p_out` of the
 σ-update fold for position `(a, p_out)`, the cumulative fold value equals
 the algebraic closed form `matrix_q[q][q] * gram - matrix_(q+1)[a][p_out]`.
@@ -1343,17 +1343,16 @@ private theorem schurSigma_foldl_eq
       simp only [h_step_q'_succ]
       rfl
     -- Symmetry of matrix_(q'+1) at (q'+1, p_out).
-    have h_sym_pivot_row :
-        (Matrix.noPivotLoop (q' + 1) state₀).matrix[
-          (⟨q' + 1, hq'_succ_n⟩ : Fin n)][(⟨p_out, hp_out_n⟩ : Fin n)] =
-          (Matrix.noPivotLoop (q' + 1) state₀).matrix[
-            (⟨p_out, hp_out_n⟩ : Fin n)][(⟨q' + 1, hq'_succ_n⟩ : Fin n)] := by
-      apply noPivotLoop_matrix_symm_preserve (q' + 1) state₀
-      · intro x y _ _
-        simp [state₀, Matrix.noPivotInitialState]
-        exact gramMatrix_symm (b := b) x y
-      · rw [h_step_q'_succ]; exact Nat.le_refl _
-      · rw [h_step_q'_succ]; exact Nat.le_of_lt hq'_succ_lt
+    -- Built by application (not by re-elaborating the written-out nested-getElem
+    -- type, which whnf-reduces the `noPivotLoop` term and is very slow).
+    have h_sym_pivot_row :=
+      noPivotLoop_matrix_symm_preserve (q' + 1) state₀
+        (fun x y _ _ => by
+          simp only [state₀, Matrix.noPivotInitialState]
+          exact gramMatrix_symm (b := b) x y)
+        (⟨q' + 1, hq'_succ_n⟩ : Fin n) (⟨p_out, hp_out_n⟩ : Fin n)
+        (by rw [h_step_q'_succ]; exact Nat.le_refl _)
+        (by rw [h_step_q'_succ]; exact Nat.le_of_lt hq'_succ_lt)
     -- Matrix-level Bareiss divisibility at fuel q'+1: prevPivot ∣ numerator.
     have hpivot_q'_succ :
         (Matrix.noPivotLoop (q' + 1) state₀).matrix[

--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -345,7 +345,10 @@ private theorem noPivotLoop_singularStep_none_of_succ
     rw [hpersist, hsing] at h_no_sing
     nomatch h_no_sing
 
-set_option maxHeartbeats 1000000 in
+-- Encapsulation makes the nested entry reads and the canonical-coefficient
+-- rewrites over the recursive `noPivotLoop` term defeq-heavy here; a modest
+-- bump (down from the original 1000000) covers it.
+set_option maxHeartbeats 400000 in
 /-- Combined invariant relating the no-pivot Bareiss trajectory on the
 augmented matrix to the trajectory on `gramMatrix b`.  Under `fuel + 1 ≤ n`
 and a non-singular prefix on the Gram side, the augmented loop tracks the


### PR DESCRIPTION
This PR reduces the two `set_option maxHeartbeats 1000000` bumps introduced for the matrix encapsulation down to `400000`. It builds the worst-offending `have` in `schurSigma_foldl_eq` (the entry-symmetry fact) in term-mode so its nested `(noPivotLoop ..).matrix[i][j]` type is inferred from the lemma rather than re-elaborated from text — that text elaboration whnf-reduces the recursive `noPivotLoop` term and was the bulk of the cost. The remaining `noPivotLoop`-form `have`s keep a modest bump, since their types are dictated by the lemmas that consume them and so cannot be abstracted to an opaque local without restating those lemmas across files. These are elaboration-time settings only, with no runtime effect.

🤖 Prepared with Claude Code