### PR TITLE
fix: clear Mathlib-free warnings from the Matrix encapsulation

### DIFF
--- a/HexBareiss/Bareiss.lean
+++ b/HexBareiss/Bareiss.lean
@@ -207,7 +207,7 @@ theorem findPivotAux_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
             · exact hzero
             · have hzeroNat : ¬ M[start][col.val] = 0 := by
                 simpa using hzero
-              simp only [findPivotAux, hlt, dif_pos, getRow, Fin.getElem_fin] at hfind
+              simp only [findPivotAux, hlt, dif_pos] at hfind
               rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
               simp at hfind
           have hiFin : i = (⟨start, hlt⟩ : Fin n) := Fin.ext hi
@@ -218,13 +218,13 @@ theorem findPivotAux_eq_zero_of_none (M : Matrix Int n n) (col : Fin n)
             · exact hzero
             · have hzeroNat : ¬ M[start][col.val] = 0 := by
                 simpa using hzero
-              simp only [findPivotAux, hlt, dif_pos, getRow, Fin.getElem_fin] at hfind
+              simp only [findPivotAux, hlt, dif_pos] at hfind
               rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
               simp at hfind
           have hnext : findPivotAux M col (start + 1) fuel = none := by
             have hentryNat : M[start][col.val] = 0 := by
               simpa using hentry
-            simp only [findPivotAux, hlt, dif_pos, getRow, Fin.getElem_fin] at hfind
+            simp only [findPivotAux, hlt, dif_pos] at hfind
             rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hentry)] at hfind
             exact hfind
           have hstart' : start + 1 ≤ i.val := by omega
@@ -259,7 +259,7 @@ theorem findPivotAux_eq_none_of_zero (M : Matrix Int n n) (col : Fin n)
           hzero ⟨start, hstart⟩ (Nat.le_refl _)
             (show (⟨start, hstart⟩ : Fin n).val < start + (fuel + 1) by
               simp)
-        simp only [findPivotAux, hstart, dif_pos, getRow, Fin.getElem_fin]
+        simp only [findPivotAux, hstart, dif_pos]
         rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hentry)]
         apply ih
         intro i hle hlt
@@ -296,10 +296,10 @@ theorem findPivotAux_some_ne_zero (M : Matrix Int n n) (col : Fin n)
   | succ fuel ih =>
       by_cases hlt : start < n
       · by_cases hzero : M[(⟨start, hlt⟩ : Fin n)][col] = 0
-        · simp only [findPivotAux, hlt, dif_pos, getRow, Fin.getElem_fin] at hfind
+        · simp only [findPivotAux, hlt, dif_pos] at hfind
           rw [if_pos (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
           exact ih (start + 1) hfind
-        · simp only [findPivotAux, hlt, dif_pos, getRow, Fin.getElem_fin] at hfind
+        · simp only [findPivotAux, hlt, dif_pos] at hfind
           rw [if_neg (by simpa [getRow, Fin.getElem_fin] using hzero)] at hfind
           simp only [Option.some.injEq] at hfind
           subst hfind
@@ -719,7 +719,7 @@ private theorem findPivotArrayAux_matrixToRows (M : Matrix Int n n)
             getEntry_matrixToRows M (⟨start, hstart⟩ : Fin n) col
         rw [hentry]
         by_cases hpivot : M[(⟨start, hstart⟩ : Fin n)][col] = 0 <;>
-          simp_all [getRow, Fin.getElem_fin, ih]
+          simp_all [getRow, Fin.getElem_fin]
       · simp [hstart]
 
 /-- `findPivotArray?_matrixToRows` identifies full array pivot search on
@@ -752,7 +752,7 @@ private theorem findPivotArrayAux_matches (rows : Array (Array Int))
           hentry ⟨start, hstart⟩
         rw [hentry_start]
         by_cases hpivot : M[(⟨start, hstart⟩ : Fin n)][col] = 0 <;>
-          simp_all [getRow, Fin.getElem_fin, ih]
+          simp_all [getRow, Fin.getElem_fin]
       · simp [hstart]
 
 /-- `findPivotArray?_matches` shows full array pivot search agrees with
@@ -958,7 +958,7 @@ theorem pivotLoop_regular_branch_no_swap (fuel : Nat) (state : BareissState n)
           prevPivot := state.matrix[state.step][state.step]
           rowSwaps := state.rowSwaps
           singularStep := none } := by
-  simp_all [pivotLoop, hDone, getRow, Fin.getElem_fin]
+  simp_all [pivotLoop, getRow, Fin.getElem_fin]
 
 /-- If the current pivot is zero and pivot search finds no replacement row,
 the row-pivoted Bareiss loop records a singular step. -/
@@ -972,7 +972,7 @@ theorem pivotLoop_singular_branch_no_pivot (fuel : Nat) (state : BareissState n)
         (state.step + 1) = none) :
     pivotLoop (fuel + 1) state =
       { state with singularStep := some state.step } := by
-  simp_all [pivotLoop, hDone]
+  simp_all [pivotLoop]
 
 /-- If the current pivot is zero, pivot search finds a replacement row, and
 the swapped pivot is nonzero, one loop iteration swaps rows, applies
@@ -1007,7 +1007,7 @@ theorem pivotLoop_regular_branch_swap (fuel : Nat) (state : BareissState n)
               pivot)[state.step][state.step]
           rowSwaps := state.rowSwaps + 1
           singularStep := none } := by
-  simp_all [pivotLoop, hDone]
+  simp_all [pivotLoop]
 
 /-- `bareissArrayState` runs the matrix-level Bareiss elimination via `pivotLoop`
 and repackages the reduced result as a `BareissArrayState`, storing the matrix
@@ -1103,7 +1103,7 @@ theorem noPivotLoop_singular_branch (fuel : Nat) (state : BareissState n)
     (hDone : state.step + 1 < n)
     (hp : state.matrix[state.step][state.step] = 0) :
     noPivotLoop (fuel + 1) state = { state with singularStep := some state.step } := by
-  simp_all [noPivotLoop, hDone]
+  simp_all [noPivotLoop]
 
 /-- If the current no-pivot Bareiss pivot is nonzero, one loop iteration applies
 `stepMatrix`, advances the step, and recurses on the remaining fuel. -/
@@ -1119,7 +1119,7 @@ theorem noPivotLoop_regular_branch (fuel : Nat) (state : BareissState n)
           prevPivot := state.matrix[state.step][state.step]
           rowSwaps := state.rowSwaps
           singularStep := none } := by
-  simp_all [noPivotLoop, hDone]
+  simp_all [noPivotLoop]
 
 /-- Entries in rows already processed, or in columns strictly before the current
 step, are unchanged by subsequent no-pivot loop iterations. -/

--- a/HexGramSchmidt/Basic/Kernel.lean
+++ b/HexGramSchmidt/Basic/Kernel.lean
@@ -517,7 +517,7 @@ private theorem basisRows_head (b : Matrix Rat n m) (hn : 0 < n) :
 @[expose]
 def coeffMatrix (rows basis : Matrix Rat n m) : Matrix Rat n n :=
   Matrix.ofFn fun i j =>
-    if hlt : j.val < i.val then
+    if _hlt : j.val < i.val then
       projectionCoeff (rows.getRow i) (basis.getRow j)
     else if i = j then
       1

--- a/HexGramSchmidt/Int/Canonical.lean
+++ b/HexGramSchmidt/Int/Canonical.lean
@@ -386,7 +386,7 @@ coefficient at `fuel + 1` collapses to the one at `fuel`. -/
     (hnext :
       (Matrix.noPivotLoop fuel
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 < n)
-    (hp :
+    (_hp :
       (Matrix.noPivotLoop fuel
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).matrix[
           (Matrix.noPivotLoop fuel
@@ -397,7 +397,7 @@ coefficient at `fuel + 1` collapses to the one at `fuel`. -/
         (Matrix.noPivotInitialState (Matrix.gramMatrix b))).step + 1 ≤ i.val) :
     bareissGramCanonicalCoeff b (fuel + 1) i =
       bareissGramCanonicalCoeff b fuel i := by
-  simp [bareissGramCanonicalCoeff, dif_pos hnext, if_neg hp, if_neg hi]
+  simp [bareissGramCanonicalCoeff, dif_pos hnext, if_neg hi]
 
 /-- Recursion equation: singular branch (zero diagonal). A zero pivot skips the
 update, so the canonical coefficient at `fuel + 1` collapses to the one at

--- a/HexGramSchmidt/Int/Combination.lean
+++ b/HexGramSchmidt/Int/Combination.lean
@@ -398,7 +398,7 @@ theorem normSq_latticeVec_ge_min_basis_normSq
         · exact False.elim (h ⟨ii, hci⟩)
       have hv_zero : v = 0 := by
         rw [← hcv, hc_zero]
-        simp [Matrix.rowCombination, Hex.Matrix.getRow, Fin.getElem_fin]
+        simp [Matrix.rowCombination]
       exact False.elim (hv' hv_zero)
   rcases exists_highest_nonzero_coeff c hc_nonzero with ⟨k, hck, hzero_above⟩
   let d : Vector Rat n :=
@@ -464,7 +464,7 @@ theorem exists_top_index_normSq_le_of_memLattice
         · exact False.elim (h ⟨ii, hci⟩)
       have hv_zero : v = 0 := by
         rw [← hcv, hc_zero]
-        simp [Matrix.rowCombination, Hex.Matrix.getRow, Fin.getElem_fin]
+        simp [Matrix.rowCombination]
       exact False.elim (hv' hv_zero)
   rcases exists_highest_nonzero_coeff c hc_nonzero with ⟨k, hck, hzero_above⟩
   refine ⟨k, c, hcv, hck, hzero_above, ?_⟩

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -42,7 +42,7 @@ theorem getElem_rowSwap (M : Matrix R n m) (i j r : Fin n) (k : Fin m) :
       if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] := by
   rw [rowSwap]
   by_cases hri : r = i <;> by_cases hrj : r = j <;>
-    simp_all [getRow, rows_swap, Vector.getElem_swap, Fin.getElem_fin, Fin.ext_iff]
+    simp_all [getRow, rows_swap, Fin.getElem_fin, Fin.ext_iff]
 
 /-- Row `i` of `rowSwap M i j` is the original row `j`. -/
 @[simp, grind =] theorem row_rowSwap_left (M : Matrix R n m) (i j : Fin n) :
@@ -101,7 +101,7 @@ theorem getElem_rowScale [Mul R] (M : Matrix R n m) (i r : Fin n) (c : R) (k : F
       if r = i then c * M[i][k] else M[r][k] := by
   rw [rowScale]
   simp only [getElem_eq_getRow, getRow, rows_modify, Vector.getElem_modify,
-    Vector.getElem_map, Fin.getElem_fin, Fin.ext_iff]
+    Fin.getElem_fin, Fin.ext_iff]
   grind
 
 /-- Row `i` of `rowScale M i c` is the pointwise scalar multiple of row `i`. -/
@@ -142,7 +142,7 @@ theorem getElem_rowAdd [Mul R] [Add R]
       if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
   rw [rowAdd]
   simp only [getElem_eq_getRow, getRow, rows_modify, Vector.getElem_modify,
-    Vector.getElem_ofFn, Fin.getElem_fin, Fin.ext_iff]
+    Fin.getElem_fin, Fin.ext_iff]
   grind
 
 /-- Source-row entries are unchanged by `rowAdd M src dst c` when `src ≠ dst`. -/

--- a/progress/20260630T125531Z_matrix-encapsulation-warnings.md
+++ b/progress/20260630T125531Z_matrix-encapsulation-warnings.md
@@ -1,0 +1,41 @@
+# Clear Mathlib-free warnings from the Matrix-encapsulation refactor
+
+## Accomplished
+
+After the `Hex.Matrix` encapsulation (it was previously a type alias for
+`Vector (Vector R m) n`, now a one-field structure), a batch of linter
+warnings appeared in matrix-consuming Mathlib-free code. All resolved; the
+files below build with no warnings.
+
+- Dead simp arguments after the normal-form shift: dropped
+  `getRow`/`Fin.getElem_fin` from six `simp only` calls and `ih`/`hDone` from
+  the `simp_all` calls in `HexBareiss/Bareiss.lean`; `Vector.getElem_*` from
+  three `simp_all`/`simp only` calls in `HexMatrix/Elementary.lean`;
+  `Hex.Matrix.getRow`/`Fin.getElem_fin` from two `simp` calls in
+  `HexGramSchmidt/Int/Combination.lean`; and `if_neg hp` in
+  `HexGramSchmidt/Int/Canonical.lean`.
+- Unreferenced binders: renamed the now-unused hypothesis `hp` to `_hp` in
+  `Canonical.lean` (its only use was the removed `if_neg hp`), and the unused
+  `if`-witness `hlt` to `_hlt` in `HexGramSchmidt/Basic/Kernel.lean`
+  (`coeffMatrix` is `@[expose]`, so `_hlt` keeps the `dite` term shape rather
+  than switching to `ite`).
+
+The kernel-basis manual recipe that the encapsulation also broke was fixed
+independently on `main` (#8479, switched to `nullspaceBasisMatrix`), so no
+manual change is carried here.
+
+## Current frontier
+
+The Mathlib-free matrix-consumer warnings are cleared. Note that #8475 made
+the `*Mathlib` bridge libraries default build targets, which newly surfaces a
+separate batch of pre-existing warnings in those bridge layers (deprecations,
+`defProp`, unused simp args, unreferenced binders); those are out of scope
+for this unit.
+
+## Next step
+
+Decide whether to clear the bridge-layer warning set newly exposed by #8475.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR clears the linter warnings that surfaced in Mathlib-free matrix-consumer code after the refactor encapsulating `Hex.Matrix` behind a one-field structure (it was previously a type alias for `Vector (Vector R m) n`). It drops dead `simp`/`simp_all`/`simp only` arguments across `HexBareiss/Bareiss.lean`, `HexMatrix/Elementary.lean`, and `HexGramSchmidt/Int/{Canonical,Combination}.lean`, and renames two now-unused binders (`hp` to `_hp`, `hlt` to `_hlt`) to satisfy the unused-variable linter while preserving the underlying term shapes (`_hlt` keeps the `dite` form for the `@[expose] coeffMatrix`).

The kernel-basis manual recipe that the same refactor broke was fixed independently on `main` (https://github.com/kim-em/hex-dev/pull/8479), so no manual change is carried here. The full `lake build` is green; the only remaining warnings are the module-system `privateInPublic` set, the bridge-layer warnings newly exposed by https://github.com/kim-em/hex-dev/pull/8475 (separate scope), and warnings inside the `verso`/`subverso` dependencies.

🤖 Prepared with Claude Code