### PR TITLE
ci: let main runs finish so the Lake cache actually publishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs, but let main runs finish: ci.yml's publish
+  # step only runs at the end, and main merges arrive faster than a cold
+  # build, so cancelling main would mean the Lake cache never publishes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   build:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs, but let main runs finish: ci.yml's publish
+  # step only runs at the end, and main merges arrive faster than a cold
+  # build, so cancelling main would mean the Lake cache never publishes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   conformance:


### PR DESCRIPTION
The cache wiring merged in #8472 never populated the bucket: with `cancel-in-progress: true`, each main run was cancelled by the next merge (hex-dev main lands commits ~10 min apart) well before `ci.yml`'s end-of-run publish step, which only runs after the full build. So the publish step was skipped on every run.

This scopes cancellation to non-main refs (`cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}`): PR pushes still cancel their own superseded runs, but main runs queue on the per-workflow concurrency group and run to completion, so the publish actually happens. Main runs serialize (no added parallelism), and once the first cold build publishes, subsequent main runs restore and finish fast, so the queue self-drains.

🤖 Prepared with Claude Code