### PR TITLE
doc: render the kernel-basis recipe output in #m[...] form

### DIFF
--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -169,8 +169,9 @@ namespace HexRowReduceKernelRecipe
 -- M has rank 1 (second row twice the first), 3 columns.
 def M : Matrix Rat 2 3 := #m[1, 2, 3; 2, 4, 6]
 
--- The kernel basis, one vector per free column.
-#eval Matrix.nullspace M
+-- The kernel basis, one vector per free column. Collected as the rows of a
+-- matrix (`ofRows`) so it prints in copy-pasteable `#m[...]` form.
+#eval Matrix.ofRows (Matrix.nullspace M)
 
 -- The nullity is m - rank = 3 - 1 = 2.
 #guard (Matrix.nullspace M).toArray.size = 2


### PR DESCRIPTION
This PR wraps the `kernelBasis` how-to recipe's `#eval` in `Matrix.ofRows` so the kernel basis prints as a copy-pasteable `#m[...]` matrix. `Matrix.nullspace` returns a bare `Vector (Vector R m) k`, which has no `#m[...]` `Repr`, so the recipe's expected `leanOutput` had drifted from the raw structure dump the `#eval` actually produced and `lake build HexManual` failed to elaborate it. Collecting the basis vectors as the rows of a matrix restores the intended rendering, and the expected output block is unchanged.

🤖 Prepared with Claude Code