### PR TITLE
fix: clear bridge-layer warnings exposed by default *Mathlib targets

### DIFF
--- a/HexBareissMathlib/Bareiss.lean
+++ b/HexBareissMathlib/Bareiss.lean
@@ -511,11 +511,11 @@ private theorem borderedMinor_rowSwap_source_row {R : Type u}
       exact getElem_rowSwap_of_ne M kFin pivot ⟨r, hr_lt⟩ _ h_r_ne_kFin h_r_ne_pivot
   · by_cases hck : c < k
     · have hc_lt : c < n := Nat.lt_trans hck hk
-      simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.rows_ofRows, Vector.getElem_ofFn, Fin.getElem_fin,
+      simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.rows_ofRows, Vector.getElem_ofFn,
         hrk, hck, dif_pos, dif_neg, not_false_iff]
       show (Hex.Matrix.rowSwap M kFin pivot)[i][(⟨c, hc_lt⟩ : Fin n)] = _
       exact getElem_rowSwap_swap_eq M kFin pivot i _
-    · simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.rows_ofRows, Vector.getElem_ofFn, Fin.getElem_fin,
+    · simp only [Hex.Matrix.borderedMinor, Hex.Matrix.ofFn, Hex.Matrix.rows_ofRows, Vector.getElem_ofFn,
         hrk, hck, dif_neg, not_false_iff]
       show (Hex.Matrix.rowSwap M kFin pivot)[i][j] = _
       exact getElem_rowSwap_swap_eq M kFin pivot i j
@@ -1599,7 +1599,6 @@ theorem bareissData_eq_mathlib_det (M : Hex.Matrix Int n n) :
           simp [Hex.Matrix.bareissData_eq_finish_pivotLoop, Hex.Matrix.finish,
             Hex.Matrix.BareissData.sign, bareissStateSign]
         have hlogical_det : Hex.Matrix.det logicalSource = 1 := by
-          change Hex.Matrix.det logicalSource = 1
           exact (det_eq logicalSource).trans (by rw [Matrix.det_isEmpty])
         have hsource_det : Hex.Matrix.det M = (Hex.Matrix.bareissData M).sign := by
           rw [hdet, hlogical_det, mul_one]

--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -50,7 +50,7 @@ the standalone form of `coeff_toMathlibPolynomial` available before the ring
 equivalence is assembled. -/
 theorem coeff_fpPolyToPolynomial (f : Hex.FpPoly p) (n : Nat) :
     (fpPolyToPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) := by
-  rw [fpPolyToPolynomial, Polynomial.finset_sum_coeff]
+  rw [fpPolyToPolynomial, Polynomial.finsetSum_coeff]
   simp only [Polynomial.coeff_monomial]
   rw [Finset.sum_ite_eq' (Finset.range f.size) n
     (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]
@@ -226,7 +226,7 @@ theorem fpPolyEquiv_symm_apply (f : Polynomial (ZMod p)) :
 theorem coeff_toMathlibPolynomial (f : Hex.FpPoly p) (n : Nat) :
     (toMathlibPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n) := by
   show (fpPolyToPolynomial f).coeff n = HexModArithMathlib.ZMod64.toZMod (f.coeff n)
-  rw [fpPolyToPolynomial, Polynomial.finset_sum_coeff]
+  rw [fpPolyToPolynomial, Polynomial.finsetSum_coeff]
   simp only [Polynomial.coeff_monomial]
   rw [Finset.sum_ite_eq' (Finset.range f.size) n
     (fun i => HexModArithMathlib.ZMod64.toZMod (f.coeff i))]

--- a/HexBerlekampZassenhausMathlib/UFDPartition.lean
+++ b/HexBerlekampZassenhausMathlib/UFDPartition.lean
@@ -154,7 +154,7 @@ partition case. It is kept as the exact equality form because the exported
 lower-bound theorem below is the shape used by branch-level callers.
 -/
 theorem normalizedFactors_card_eq_length_of_irreducible_partition
-    {α : Type*} [CommMonoidWithZero α] [IsCancelMulZero α]
+    {α : Type*} [CommMonoidWithZero α]
     [NormalizationMonoid α] [UniqueFactorizationMonoid α]
     {f : α} (gs : List α)
     (hirr : ∀ g ∈ gs, Irreducible g)
@@ -185,7 +185,7 @@ associated to `f`, `f` cannot have more normalized irreducible factors than
 the emitted list.
 -/
 theorem normalizedFactors_card_le_length_of_irreducible_partition
-    {α : Type*} [CommMonoidWithZero α] [IsCancelMulZero α]
+    {α : Type*} [CommMonoidWithZero α]
     [NormalizationMonoid α] [UniqueFactorizationMonoid α]
     {f : α} (gs : List α)
     (hirr : ∀ g ∈ gs, Irreducible g)
@@ -206,7 +206,7 @@ Distinct normalized factors of a square-free `f` cannot share an emitted
 witness (associated normalized elements are equal), so the witness map is
 injective and the image cardinality bounds the list length. -/
 theorem normalizedFactors_card_le_length_of_coverage
-    {α : Type*} [CommMonoidWithZero α] [IsCancelMulZero α]
+    {α : Type*} [CommMonoidWithZero α]
     [NormalizationMonoid α] [UniqueFactorizationMonoid α]
     {f : α} (hf : f ≠ 0) (hsf : Squarefree f)
     (gs : List α)
@@ -271,7 +271,7 @@ abstract UFD factor multiset of a certified product by the concrete flattened
 list of factors.
 -/
 theorem normalizedFactors_list_prod_eq_of_irreducible
-    {α : Type*} [CommMonoidWithZero α] [IsCancelMulZero α]
+    {α : Type*} [CommMonoidWithZero α]
     [NormalizationMonoid α] [UniqueFactorizationMonoid α]
     (gs : List α) (hirr : ∀ g ∈ gs, Irreducible g) :
     normalizedFactors gs.prod = ((gs : Multiset α).map normalize) := by

--- a/HexGramSchmidtMathlib/Basic.lean
+++ b/HexGramSchmidtMathlib/Basic.lean
@@ -100,7 +100,7 @@ theorem rowToEuclidean_inner (a b : Vector Rat m) :
     inner ℝ (rowToEuclidean a) (rowToEuclidean b) =
       ((Vector.dotProduct (u := a) (v := b) : Rat) : ℝ) := by
   rw [PiLp.inner_apply]
-  simp [rowToEuclidean, PiLp.toLp_apply, real_inner_eq_re_inner,
+  simp [rowToEuclidean, PiLp.toLp_apply,
     RCLike.inner_apply, mul_comm]
   rw [Vector.dotProduct, cast_foldl_dotProduct_rat]
   simp only [Rat.cast_zero, zero_add]

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -55,7 +55,7 @@ private theorem rowAdd_row_at {R : Type u} [Mul R] [Add R] {n' m' : Nat}
     (M : Matrix R n' m') (src dst : Fin n') (c : R) :
     (Matrix.rowAdd M src dst c)[dst] =
       Vector.ofFn fun k => M[dst][k] + c * M[src][k] := by
-  simp [Matrix.rowAdd_eq_set, Hex.Matrix.getRow, Hex.Matrix.rows_setRow, Fin.getElem_fin, Hex.Matrix.getElem_pair_eq_nested]
+  simp [Matrix.rowAdd_eq_set, Hex.Matrix.getRow, Hex.Matrix.rows_setRow, Fin.getElem_fin]
 
 /-- Inductive helper for `dot_rowAdd_row_at_left`: distribution along a foldl. -/
 private theorem foldl_dot_rowAdd_at {n' m' : Nat}
@@ -236,8 +236,7 @@ theorem leadingGramMatrixInt_rowAdd_outside
       b[GramSchmidt.liftFinLE ⟨q, hq⟩ ht] :=
     rowAdd_row_eq_of_ne b j k (GramSchmidt.liftFinLE ⟨q, hq⟩ ht) c hq_ne
   simp only [GramSchmidt.leadingGramMatrixInt, Matrix.ofFn, Matrix.row,
-    Hex.Matrix.rows_ofRows, Hex.Matrix.getElem_eq_getRow, Vector.getElem_ofFn,
-    Fin.getElem_fin]
+    Hex.Matrix.rows_ofRows, Vector.getElem_ofFn]
   congr 1
 
 /-- Entry-level structural identity for the leading Gram matrix of

--- a/HexMatrixMathlib/Algebra.lean
+++ b/HexMatrixMathlib/Algebra.lean
@@ -195,8 +195,8 @@ def matrixRingEquiv [Semiring R] : Hex.Matrix R n n ≃+* Matrix (Fin n) (Fin n)
 
 instance instAlgebra [CommSemiring R] : Algebra R (Hex.Matrix R n n) :=
   Algebra.ofModule
-    (fun r A B => matrixEquiv.injective (by simp [smul_mul_assoc]))
-    (fun r A B => matrixEquiv.injective (by simp [mul_smul_comm]))
+    (fun r A B => matrixEquiv.injective (by simp))
+    (fun r A B => matrixEquiv.injective (by simp))
 
 /-- `matrixEquiv` as an `R`-algebra equivalence on square matrices. -/
 @[expose]

--- a/HexMatrixMathlib/Submatrix.lean
+++ b/HexMatrixMathlib/Submatrix.lean
@@ -31,7 +31,7 @@ variable {R : Type u} {n m : Nat}
       (matrixEquiv M).submatrix (Fin.castLE hk) (Fin.castLE hk) := by
   ext i j
   simp only [matrixEquiv_apply, Hex.Matrix.getElem_principalSubmatrix, Matrix.submatrix_apply,
-    Fin.castLE, Fin.castLT]
+    Fin.castLE]
 
 /-- The first-`k`-rows slice is the submatrix reindexing rows by `Fin.castLE`. -/
 @[simp, grind =] theorem matrixEquiv_takeRows (M : Hex.Matrix R n m) (k : Nat)
@@ -40,6 +40,6 @@ variable {R : Type u} {n m : Nat}
       (matrixEquiv M).submatrix (Fin.castLE hk) id := by
   ext i j
   simp only [matrixEquiv_apply, Hex.Matrix.getElem_takeRows, Matrix.submatrix_apply,
-    Fin.castLE, Fin.castLT, id_eq]
+    Fin.castLE, id_eq]
 
 end HexMatrixMathlib

--- a/HexPolyZMathlib/RobinsonForm.lean
+++ b/HexPolyZMathlib/RobinsonForm.lean
@@ -682,7 +682,7 @@ theorem mahlerMeasure_derivative_eq_natDegree_mul_of_roots_le_one
   have hsub : p.natDegree - 1 + 1 = p.natDegree :=
     Nat.sub_add_cancel hnatpos
   have hdeg_deriv : p.derivative.natDegree = p.natDegree - 1 :=
-    natDegree_eq_of_degree_eq_some (degree_derivative_eq p hnatpos)
+    natDegree_eq_of_degree_eq_some (degree_derivative hnatpos.ne')
   have hcast : ((p.natDegree - 1 : ℕ) : ℂ) + 1 = (p.natDegree : ℂ) := by
     rw [Nat.cast_sub hnatpos, Nat.cast_one]; ring
   have hlead_deriv : p.derivative.leadingCoeff =
@@ -821,7 +821,7 @@ theorem prod_max_one_norm_roots_derivative_le_of_mahlerMeasure_derivative_le
   have hsub : p.natDegree - 1 + 1 = p.natDegree :=
     Nat.sub_add_cancel hnatpos
   have hdeg_deriv : p.derivative.natDegree = p.natDegree - 1 :=
-    natDegree_eq_of_degree_eq_some (degree_derivative_eq p hnatpos)
+    natDegree_eq_of_degree_eq_some (degree_derivative hnatpos.ne')
   have hcast : ((p.natDegree - 1 : ℕ) : ℂ) + 1 = (p.natDegree : ℂ) := by
     rw [Nat.cast_sub hnatpos, Nat.cast_one]
     ring

--- a/progress/20260630T134817Z_bridge-layer-warnings.md
+++ b/progress/20260630T134817Z_bridge-layer-warnings.md
@@ -1,0 +1,43 @@
+# Clear bridge-layer warnings newly exposed by default *Mathlib targets
+
+## Accomplished
+
+#8475 made the `*Mathlib` bridge libraries default build targets, so a plain
+`lake build` now surfaces a batch of pre-existing linter warnings in those
+layers. Cleared every such warning in the sorry-free bridge files; full
+`lake build` (4081 jobs, incl. the merge-gating `HexBerlekampZassenhausMathlib`)
+is green.
+
+- Deprecations: `Polynomial.degree_derivative_eq` → `degree_derivative` (the
+  new lemma takes `p` implicitly and `p.natDegree ≠ 0`, so `hnatpos.ne'`) in
+  `HexPolyZMathlib/RobinsonForm.lean`; `Polynomial.finset_sum_coeff` →
+  `finsetSum_coeff` in `HexBerlekampMathlib/Basic.lean`.
+- Unused simp arguments: `Fin.castLT` (`HexMatrixMathlib/Submatrix.lean`),
+  the sole `smul_mul_assoc`/`mul_smul_comm` (`HexMatrixMathlib/Algebra.lean`,
+  now bare `simp`), `real_inner_eq_re_inner`
+  (`HexGramSchmidtMathlib/Basic.lean`), `Fin.getElem_fin`
+  (`HexBareissMathlib/Bareiss.lean`), and three in
+  `HexGramSchmidtMathlib/Int/RowAdd.lean`.
+- Removed a no-op `change Hex.Matrix.det logicalSource = 1` in
+  `HexBareissMathlib/Bareiss.lean`.
+- `linter.overlappingInstances`: dropped the redundant `[IsCancelMulZero α]`
+  from four `normalizedFactors_*` theorems in
+  `HexBerlekampZassenhausMathlib/UFDPartition.lean` (synthesized from
+  `[UniqueFactorizationMonoid α]`).
+
+## Current frontier
+
+All sorry-free bridge-layer warnings cleared. Deliberately untouched: the two
+sorry-bearing files (`HexBerlekampZassenhausMathlib/{Basic,FactorSoundness}.lean`,
+18 warnings) and the `@[expose]` module-system warning in
+`HexBerlekampZassenhaus/CrossCheck.lean`.
+
+## Next step
+
+The remaining build warnings are all module-system (`privateInPublic`, the
+`@[expose]` and `primeModulusOfPrime defProp` cases) or live in sorry-bearing
+files.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR clears the linter warnings surfaced in the sorry-free `*Mathlib` bridge libraries now that https://github.com/kim-em/hex-dev/pull/8475 made them default build targets. It migrates two deprecated `Polynomial` lemmas (`degree_derivative_eq` to `degree_derivative`, whose new signature takes the polynomial implicitly and a `natDegree ≠ 0` hypothesis; and `finset_sum_coeff` to `finsetSum_coeff`), drops unused simp arguments and a no-op `change` across the matrix, Bareiss, and Gram-Schmidt bridges, and removes the redundant `[IsCancelMulZero α]` instance binder from four `normalizedFactors_*` theorems in `UFDPartition.lean` (it is synthesized from `[UniqueFactorizationMonoid α]`).

The full `lake build` is green (4081 jobs, including the merge-gating `HexBerlekampZassenhausMathlib`). Deliberately untouched: the two sorry-bearing files (`HexBerlekampZassenhausMathlib/{Basic,FactorSoundness}.lean`) and the `@[expose]` module-system warning in `HexBerlekampZassenhaus/CrossCheck.lean`. The only remaining build warnings are module-system (`privateInPublic`) or inside those sorry-bearing files.

🤖 Prepared with Claude Code