### PR TITLE
doc: plain-language pass on the released linear-algebra chapters

### DIFF
--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -29,13 +29,9 @@ entry stays an exact integer because each update divides *exactly* by
 the previous pivot. It runs in cubic time and never leaves the integers,
 so it avoids both the factorial blow-up of the Leibniz
 {ref "hex-determinant"}[determinant] and the denominators of ordinary
-Gaussian elimination. It builds on the {ref "hex-matrix"}[HexMatrix]
-dense core and the {ref "hex-determinant"}[HexDeterminant] Leibniz
-determinant (the specification it is checked against).
-
-This chapter walks the elimination record, the public entry points, and
-the structural theorems the Mathlib-free layer proves, and closes with a
-worked example checked when the chapter is built.
+Gaussian elimination. It builds on {ref "hex-matrix"}[HexMatrix] and the
+{ref "hex-determinant"}[HexDeterminant] Leibniz determinant (the
+specification it is checked against).
 
 `HexBareiss` is Mathlib-free. The theorem identifying the Bareiss
 determinant with the Leibniz determinant, via the Desnanot-Jacobi
@@ -93,17 +89,16 @@ correctness development relies on.
 tag := "hex-bareiss-theorems"
 %%%
 
-This is where the computational/proof boundary falls. The Mathlib-free
-layer proves the internal structural facts about the elimination — that
-the packaged record is exactly the structured pivot loop finished into
-determinant data, and that the public {name}`Hex.Matrix.bareiss` value
-agrees with the determinant encoded by {name}`Hex.Matrix.bareissData` —
-but it does *not* prove that the Bareiss determinant equals the Leibniz
-{name}`Hex.Matrix.det`. That identification is a correspondence theorem
-living in the forthcoming `HexBareissMathlib` bridge. Within `HexBareiss`
-itself the agreement is pinned only as value-level conformance fixtures:
-a fixed bank of matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M`
-is checked at build time.
+`HexBareiss` proves the structural facts about the elimination: that the
+packaged record is exactly the structured pivot
+loop finished into determinant data, and that the public
+{name}`Hex.Matrix.bareiss` value agrees with the determinant encoded by
+{name}`Hex.Matrix.bareissData`. It does not prove that the Bareiss
+determinant equals the Leibniz {name}`Hex.Matrix.det`; that
+identification is in `HexBareissMathlib`. Within `HexBareiss` itself the
+agreement is pinned as value-level conformance fixtures: a fixed bank of
+matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M` is checked at
+build time.
 
 {docstring Hex.Matrix.bareissData_eq_finish_pivotLoop}
 
@@ -162,13 +157,11 @@ end HexBareissChapterExample
 tag := "hex-bareiss-cross-references"
 %%%
 
-`HexBareiss` is the fast integer-determinant layer of the stack:
+`HexBareiss` is the fast route to an exact integer determinant.
 
 * It depends on {ref "hex-matrix"}[HexMatrix] for the matrix type and on
   {ref "hex-determinant"}[HexDeterminant] for the Leibniz `det` it uses
   as its specification.
-* `HexBareissMathlib` is the correspondence library proving the Bareiss
-  determinant equals the Leibniz determinant (and hence Mathlib's
-  determinant), via the Desnanot-Jacobi invariant. The Mathlib
-  dependency lives entirely on that side of the boundary; `HexBareiss`
-  itself is Mathlib-free.
+* `HexBareissMathlib` proves the Bareiss determinant equals the Leibniz
+  determinant (and hence Mathlib's), via the Desnanot-Jacobi invariant.
+  `HexBareiss` itself is Mathlib-free.

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -24,18 +24,15 @@ tag := "hex-determinant-intro"
 %%%
 
 `HexDeterminant` is the determinant of a dense square matrix via the
-Leibniz formula, together with the cofactor and adjugate theory built on
-it. It depends only on the {ref "hex-matrix"}[HexMatrix] dense core and
-is generic over the coefficient ring; the row-operation, Laplace,
-Cauchy-Binet, and Plücker results hold over a commutative ring.
+Leibniz formula, with the cofactor and adjugate theory built on it. It
+depends only on {ref "hex-matrix"}[HexMatrix] and is generic over the
+coefficient ring; the row-operation, Laplace, Cauchy-Binet, and Plücker
+results hold over a commutative ring.
 
-The Leibniz determinant is the *definitional* semantics: correct by
-construction, but factorially slow, so it serves as the specification
-the faster {ref "hex-bareiss"}[HexBareiss] route is checked against
-rather than the routine a caller invokes on a large matrix. This chapter
-walks the definition, the elementary-operation laws, cofactor expansion,
-the adjugate identity, and the column-tuple and two-row identities, and
-closes with a worked example checked when the chapter is built.
+The Leibniz determinant is the definition: correct by construction but
+factorially slow, so it is the specification the faster
+{ref "hex-bareiss"}[HexBareiss] route is checked against, not the routine
+a caller runs on a large matrix.
 
 `HexDeterminant` is Mathlib-free. The identification of this determinant
 with Mathlib's `Matrix.det`, and with the executable Bareiss
@@ -179,15 +176,12 @@ end HexDeterminantChapterExample
 tag := "hex-determinant-cross-references"
 %%%
 
-`HexDeterminant` is the determinant layer of the linear-algebra stack:
+`HexDeterminant` depends only on {ref "hex-matrix"}[HexMatrix], using its
+matrix type, arithmetic, and elementary operations (whose determinant
+laws are proved here).
 
-* It depends only on {ref "hex-matrix"}[HexMatrix] — the matrix type,
-  its arithmetic, and the elementary operations whose determinant laws
-  are proved here.
 * {ref "hex-bareiss"}[HexBareiss] computes the same integer determinant
   fraction-free in cubic time, using this Leibniz `det` as its
   specification.
-* `HexDeterminantMathlib` is the correspondence library identifying this
-  executable determinant with Mathlib's `Matrix.det`. The Mathlib
-  dependency lives entirely on that side of the boundary;
-  `HexDeterminant` itself is Mathlib-free.
+* `HexDeterminantMathlib` identifies this executable determinant with
+  Mathlib's `Matrix.det`. `HexDeterminant` itself is Mathlib-free.

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -23,34 +23,29 @@ tag := "hex-gram-schmidt"
 tag := "hex-gram-schmidt-intro"
 %%%
 
-`HexGramSchmidt` is the Gram-Schmidt orthogonalization layer of the
-stack. Given a matrix whose rows are the input vectors, it produces the
-orthogonal basis obtained by subtracting from each row its projection
-onto the earlier rows, together with the lower-unitriangular matrix of
-projection coefficients that reconstructs the input. The whole surface
-is phrased over the dense {name}`Hex.Matrix` representation: operations
-take and return *whole matrices* (`basis b : Matrix Rat n m`,
-`coeffs b : Matrix Rat n n`) rather than indexed single-entry
-functions, and rows are addressed by `Nat` indices with explicit bounds
-rather than `Fin`.
+`HexGramSchmidt` orthogonalizes the rows of a matrix by Gram-Schmidt:
+from each row it subtracts the projection onto the earlier rows, and
+returns the orthogonal basis together with the lower-unitriangular matrix
+of projection coefficients that reconstructs the input. Everything is
+phrased over {name}`Hex.Matrix`: operations take and return whole
+matrices (`basis b : Matrix Rat n m`, `coeffs b : Matrix Rat n n`), and
+rows are addressed by `Nat` indices with explicit bounds rather than
+`Fin`.
 
-The library carries two parallel surfaces. The `Hex.GramSchmidt.Rat`
-namespace orthogonalizes a rational matrix directly; the
-`Hex.GramSchmidt.Int` namespace casts an integer matrix into `Rat`
-before orthogonalizing, and adds the determinant-driven *integral*
-surface — the leading Gram determinants and the integer scaled
-coefficient matrix — that downstream lattice code uses to stay in exact
-arithmetic. The orthogonal basis and the rational coefficient matrix
-involve genuine division, so {name}`Hex.GramSchmidt.Rat.basis` and
-{name}`Hex.GramSchmidt.Rat.coeffs` are `noncomputable`; the
-determinant surface {name}`Hex.GramSchmidt.Int.gramDet` and
-{name}`Hex.GramSchmidt.Int.scaledCoeffs` is computable and drives the
+The library has two namespaces. `Hex.GramSchmidt.Rat` orthogonalizes a
+rational matrix directly. `Hex.GramSchmidt.Int` casts an integer matrix
+to `Rat` first, and adds computable integer data (the leading Gram
+determinants and the integer scaled coefficient matrix) that lattice
+code uses to stay in exact arithmetic. The orthogonal basis and rational
+coefficients involve division, so {name}`Hex.GramSchmidt.Rat.basis` and
+{name}`Hex.GramSchmidt.Rat.coeffs` are `noncomputable`; the determinant
+operations ({name}`Hex.GramSchmidt.Int.gramDet`,
+{name}`Hex.GramSchmidt.Int.scaledCoeffs`) are computable and drive the
 worked examples below.
 
-`HexGramSchmidt` is Mathlib-free and depends only on `HexMatrix`. It is
-a dependency of `HexLLL`, supplying the orthogonalization and the
-exact-update formulas that lattice reduction needs, but it is logically
-independent of LLL; see
+`HexGramSchmidt` is Mathlib-free and depends only on `HexMatrix`. `HexLLL`
+uses it for orthogonalization and the exact-update formulas, but it is
+logically independent of LLL; see
 {ref "hex-gram-schmidt-cross-references"}[Cross-references].
 
 # Core operations
@@ -74,11 +69,11 @@ integer one casting its input into `Rat` first.
 
 Because the basis and coefficient matrices divide, they are
 `noncomputable` and are documented here by signature. The integer
-surface adds two *computable* operations that stay in exact arithmetic.
+namespace adds two *computable* operations that stay in exact arithmetic.
 The leading Gram determinants are the determinants of the leading
-principal Gram minors `B Bᵀ` — these are the squared volumes of the
-prefix sublattices — and the scaled coefficient matrix clears the
-denominators of the rational coefficients against them.
+principal Gram minors `B Bᵀ` (the squared volumes of the prefix
+sublattices); the scaled coefficient matrix clears the denominators of
+the rational coefficients against them.
 
 {docstring Hex.GramSchmidt.Int.gramDet}
 
@@ -166,7 +161,7 @@ integer input (the latter taken in `Rat`).
 
 The basis and coefficient matrices together factor the input. Each
 input row equals its orthogonalized basis row plus the
-coefficient-weighted combination of the earlier basis rows — the
+coefficient-weighted combination of the earlier basis rows: the
 triangular factorization `b = coeffs · basis`, stated row by row.
 
 {docstring Hex.GramSchmidt.Rat.basis_decomposition}
@@ -190,20 +185,20 @@ tag := "hex-gram-schmidt-updates"
 
 Lattice reduction modifies the input by elementary row operations and
 needs to know how the Gram-Schmidt data changes. `HexGramSchmidt`
-packages the two operations LLL uses — size reduction and adjacent swap
-— and states the resulting update formulas. The executable row
-operations themselves live in `HexMatrix`; this layer supplies the
-`HexGramSchmidt`-level API for reasoning about them.
+packages the two operations LLL uses (size reduction and adjacent swap)
+and states the resulting update formulas. The row operations themselves
+live in `HexMatrix`; `HexGramSchmidt` supplies the API for reasoning
+about their effect on the Gram-Schmidt data.
 
 {docstring Hex.GramSchmidt.Int.sizeReduce}
 
 {docstring Hex.GramSchmidt.Int.adjacentSwap}
 
 Size reduction subtracts an integer multiple of an earlier row from a
-later one. This is a unimodular operation that preserves the orthogonal
-profile, so it leaves the entire Gram-Schmidt basis unchanged — LLL can
+later one. This unimodular operation preserves the orthogonal profile,
+so it leaves the entire Gram-Schmidt basis unchanged: LLL can
 size-reduce freely without disturbing the orthogonalized vectors or the
-Gram determinants that the swap step depends on.
+Gram determinants the swap step depends on.
 
 {docstring Hex.GramSchmidt.Int.basis_sizeReduce}
 
@@ -222,22 +217,17 @@ Gram-Schmidt.
 tag := "hex-gram-schmidt-cross-references"
 %%%
 
-`HexGramSchmidt` sits one level above `HexMatrix` and below the lattice
-layer:
+`HexGramSchmidt` depends only on `HexMatrix` and underpins `HexLLL`:
 
-* `HexMatrix` supplies the dense {name}`Hex.Matrix` representation and
-  the row operations (`rowAdd`, `rowSwap`) that the
+* `HexMatrix` supplies the {name}`Hex.Matrix` representation and the row
+  operations (`rowAdd`, `rowSwap`) that the
   {ref "hex-gram-schmidt-updates"}[update formulas] reason about. The
-  orthogonalization in this chapter is built entirely on that
-  representation.
-* `HexGramSchmidtMathlib` is the correspondence library: it re-exports
-  this executable theory as theorems about Mathlib's `LinearMap` and
-  `Matrix` Gram-Schmidt, so the computational results here transfer to
-  the abstract setting. The Mathlib dependency lives entirely on that
-  side of the boundary; `HexGramSchmidt` itself imports only `HexMatrix`
-  and `Std`.
-* `HexLLL` consumes the {ref "hex-gram-schmidt-core"}[integral surface]
-  — the Gram determinants and scaled coefficients — and the
+  orthogonalization here is built entirely on that representation.
+* `HexGramSchmidtMathlib` re-exports this executable theory as theorems
+  about Mathlib's `LinearMap` and `Matrix` Gram-Schmidt. `HexGramSchmidt`
+  itself imports only `HexMatrix` and `Std`.
+* `HexLLL` consumes the {ref "hex-gram-schmidt-core"}[integer data]
+  (the Gram determinants and scaled coefficients) and the
   {ref "hex-gram-schmidt-updates"}[exact update formulas] to drive
   lattice reduction in integer arithmetic. `HexGramSchmidt` is logically
   independent of LLL: it states the orthogonalization and its updates

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -23,30 +23,25 @@ tag := "hex-lll"
 tag := "hex-lll-intro"
 %%%
 
-`HexLLL` is the executable lattice-reduction layer of the stack. Given an
-integer basis — the rows of a {name}`Hex.Matrix` over `Int` — it produces a
-new basis generating the *same* integer lattice but made of short, nearly
-orthogonal vectors, the LLL guarantee. Its first row is a provably short
-lattice vector, which is the service the
+`HexLLL` reduces an integer lattice basis. Given the rows of a
+{name}`Hex.Matrix` over `Int`, it produces a new basis for the same
+lattice made of short, nearly orthogonal vectors (the LLL guarantee).
+Its first row is a provably short lattice vector, which is what the
 {ref "hex-lll-cross-references"}[downstream factorization path] consumes:
 the BHKS van Hoeij recombination step in `hex-berlekamp-zassenhaus`
 reconstructs true factors from short vectors of a knapsack lattice.
 
-The library is built around a strict computational/proof split. The
-reduction itself runs through fast, untrusted numerics (a floating-point
-steering pass, and optionally an external `fpLLL` provider), but no proof
-ever depends on those numerics being correct. Instead every reduced basis
-is fed through a *verified integer checker*; only a basis the checker
-accepts is returned, and the checker's soundness theorem — proved on the
-Mathlib side — turns that acceptance into the real mathematical guarantee.
-This chapter follows that arc: first the predicates that *define* a reduced
-basis, then the integer checkers that *decide* them, then the reduction
-{ref "hex-lll-reduction"}[entry points] that produce candidates, and
-finally the {ref "hex-lll-dispatch"}[certified dispatch] that ties the two
-together.
+The library splits computation from proof. The reduction runs through
+fast, untrusted numerics (a floating-point steering pass, and optionally
+an external `fpLLL` provider), but no proof depends on those numerics
+being correct. Every reduced basis is fed through a verified integer
+checker; only a basis the checker accepts is returned, and the checker's
+soundness theorem (proved on the Mathlib side) turns that acceptance into
+the mathematical guarantee.
 
-`HexLLL` is Mathlib-free and depends only on {ref "hex-lll-cross-references"}[`HexGramSchmidt`] for the
-Gram-Schmidt machinery underlying both the predicates and the checkers.
+`HexLLL` is Mathlib-free and depends only on
+{ref "hex-lll-cross-references"}[`HexGramSchmidt`] for the Gram-Schmidt
+machinery underlying both the predicates and the checkers.
 
 # Lattices and reducedness
 %%%
@@ -88,9 +83,9 @@ tag := "hex-lll-checkers"
 
 The predicates above mention rational Gram-Schmidt data; deciding them
 directly would require rational (or interval) arithmetic. The checkers
-instead work over the *scaled integer* Gram-Schmidt representation — the
-leading Gram determinants `d` and the integer scaled coefficients `ν` — so
-a `Bool` answer needs only exact integer comparisons. The base checker
+instead work over the scaled integer Gram-Schmidt representation (the
+leading Gram determinants `d` and the integer scaled coefficients `ν`),
+so a `Bool` answer needs only exact integer comparisons. The base checker
 clears denominators in both the size-reduced and Lovász clauses.
 
 {docstring Hex.lllReducedInt}
@@ -125,9 +120,8 @@ tag := "hex-lll-reduction"
 The reducer carries two pieces of state. The proof-facing
 {name}`Hex.Internal.LLLState` holds the exact integer basis together with the scaled
 Gram-Schmidt data, and a separate {name}`Hex.Internal.LLLState.Valid` predicate ties
-that data back to the `GramSchmidt.Int` representation — keeping the state
-updates purely computational while letting the Mathlib layer reason about
-them.
+that data back to the `GramSchmidt.Int` representation, keeping the state
+updates computational while letting the Mathlib side reason about them.
 
 {docstring Hex.Internal.LLLState}
 
@@ -144,7 +138,7 @@ steer the swap trajectory but never enter a proof.
 `steeredReduce` is a heuristic with no standalone guarantee, so it is never
 returned raw. {name}`Hex.lllSteered` runs it, checks the candidate with
 {name}`Hex.lllReducedCheck`, and falls back to the exact integer reducer if
-the check fails — so its output is always certified `(δ, 11/20)`-reduced.
+the check fails, so its output is always certified `(δ, 11/20)`-reduced.
 
 {docstring Hex.lllSteered}
 
@@ -174,8 +168,8 @@ tag := "hex-lll-dispatch"
 When an external `fpLLL` provider is linked in, {name}`Hex.Internal.LLLProvider.dispatch`
 asks it for a reduced basis and validates the answer with {name}`Hex.certCheck`
 before trusting it. A rejected or absent provider yields `none`, and the
-caller falls through to the native path — so the foreign reducer is a
-performance accelerator that can never compromise correctness.
+caller falls through to the native path, so the foreign reducer can speed
+things up but can never compromise correctness.
 
 {docstring Hex.Internal.LLLProvider.dispatch}
 
@@ -190,12 +184,11 @@ its certificate, the single fact the certified-dispatch path of
 tag := "hex-lll-worked"
 %%%
 
-The block below reduces the rank-2 lattice with basis rows `(1, 12)` and
+The block reduces the rank-2 lattice with basis rows `(1, 12)` and
 `(0, 1)`. The skewed first row is far from orthogonal; reduction returns
-the basis `(0, 1)`, `(1, 0)` — the two unit vectors, which generate the
-same lattice and are as short as possible. Every `#guard` is checked when
-the chapter is built, so the outputs are guaranteed to match the executable
-implementation.
+`(0, 1)`, `(1, 0)` (the two unit vectors), which generate the same
+lattice and are as short as possible. Each `#guard` is checked when the
+chapter builds.
 
 ```lean
 open Hex Hex.Matrix Hex.Internal
@@ -263,19 +256,18 @@ end HexLLLChapterExample
 tag := "hex-lll-cross-references"
 %%%
 
-`HexLLL` sits one layer above the Gram-Schmidt machinery and one boundary
-away from its correctness proofs:
+`HexLLL` depends only on `HexGramSchmidt`, with its correctness proofs in
+`HexLLLMathlib`:
 
-* `HexGramSchmidt` supplies the integer Gram-Schmidt representation —
-  {name}`Hex.GramSchmidt.Int.independent`, the scaled coefficients, and the
-  leading Gram determinants — on which both the {ref "hex-lll-predicates"}[reducedness
-  predicates] and the {ref "hex-lll-checkers"}[integer checkers] are
-  defined. `HexLLL` is its only direct dependency.
-* `HexLLLMathlib` is the correspondence library carrying the soundness
-  theorems. `lllReducedInt_sound` and `lllReducedCheck_sound` bridge the
-  integer checkers to {name}`Hex.isLLLReduced`, and `certCheck_sound`
-  combines those with {name}`Hex.Matrix.sameLatticeCert_sound` into the
-  property triple (same lattice, independence, reducedness) that the
-  certified-dispatch path of {name}`Hex.lll` relies on. The Mathlib
-  dependency lives entirely on that side of the boundary; `HexLLL` itself
-  is Mathlib-free.
+* `HexGramSchmidt` supplies the integer Gram-Schmidt representation
+  ({name}`Hex.GramSchmidt.Int.independent`, the scaled coefficients, and
+  the leading Gram determinants) on which both the
+  {ref "hex-lll-predicates"}[reducedness predicates] and the
+  {ref "hex-lll-checkers"}[integer checkers] are defined. It is `HexLLL`'s
+  only direct dependency.
+* `HexLLLMathlib` carries the soundness theorems. `lllReducedInt_sound`
+  and `lllReducedCheck_sound` relate the integer checkers to
+  {name}`Hex.isLLLReduced`, and `certCheck_sound` combines those with
+  {name}`Hex.Matrix.sameLatticeCert_sound` into the property triple (same
+  lattice, independence, reducedness) that the certified-dispatch path of
+  {name}`Hex.lll` relies on. `HexLLL` itself is Mathlib-free.

--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -23,23 +23,20 @@ tag := "hex-row-reduce"
 tag := "hex-row-reduce-intro"
 %%%
 
-`HexRowReduce` is the executable row-reduction stack over the
-{ref "hex-matrix"}[HexMatrix] dense core: Gauss-Jordan reduction to
-reduced row echelon form over a field, together with the row-span and
-nullspace computations built on it. It depends only on `HexMatrix`.
+`HexRowReduce` does Gauss-Jordan reduction of a matrix over a field to
+reduced row echelon form, and computes the row span and nullspace from
+it. It depends only on {ref "hex-matrix"}[HexMatrix].
 
-The reduction returns more than a reduced matrix: it returns a
-certificate — the rank, the reduced form, the accumulated invertible
-transform, and the pivot columns — and the linear-algebra readers a
-caller actually wants are derived from that certificate with soundness
-(and, for the nullspace, completeness) theorems tying the executable
-answer back to the matrix. This chapter walks the echelon certificate,
-the `rowReduce` driver, and the span and nullspace readers, and closes
-with a worked example checked when the chapter is built.
+The reduction returns a certificate, not just a reduced matrix: the rank,
+the reduced form, an invertible transform `T` with `T * original =
+echelon`, and the pivot columns. The span and nullspace readers are
+derived from it, each with a soundness theorem (and the nullspace basis
+with a completeness theorem) relating the executable answer to the
+matrix.
 
-`HexRowReduce` is Mathlib-free. The identification of its rank, span, and
-nullspace with Mathlib's linear-algebra theory lives in the forthcoming
-`HexRowReduceMathlib` bridge.
+`HexRowReduce` is Mathlib-free. `HexRowReduceMathlib` relates its rank,
+span, and nullspace to Mathlib's linear algebra; the proof recipes below
+use it.
 
 # The echelon certificate
 %%%
@@ -48,23 +45,21 @@ tag := "hex-row-reduce-echelon"
 
 The elementary row operations ({name}`Hex.Matrix.rowSwap`,
 {name}`Hex.Matrix.rowScale`, {name}`Hex.Matrix.rowAdd`) are documented
-with the {ref "hex-matrix"}[matrix core]; the reductions here compose
-them over a field, where division by a pivot is available.
+with {ref "hex-matrix"}[HexMatrix]; the reductions here compose them over
+a field.
 
-An echelon computation returns its result packaged with a certificate of
-how it got there: the rank, the reduced matrix, the accumulated
-invertible row-operation transform `T` with `T * original = echelon`,
-and the pivot column of each row.
+An echelon computation returns a certificate of how it reduced: the
+rank, the reduced matrix, an invertible transform `T` with
+`T * original = echelon`, and each row's pivot column.
 
 {docstring Hex.Matrix.RowEchelonData}
 
-Two predicates capture what it means for such a record to be a genuine
-echelon or reduced-echelon form. {name}`Hex.Matrix.IsEchelonForm` bundles
-the conditions shared by any echelon form — the transform equation, the
+Two predicates say when such a record is a genuine echelon or
+reduced-echelon form. {name}`Hex.Matrix.IsEchelonForm` bundles the
+conditions any echelon form shares: the transform equation, the
 transform's invertibility, the rank bounds, and the staircase pivot
-structure. {name}`Hex.Matrix.IsRowReduced` extends it with the two
-reduced-form conditions: each pivot is one, and every entry above a
-pivot is zero.
+structure. {name}`Hex.Matrix.IsRowReduced` adds the two reduced-form
+conditions: each pivot is one, and every entry above a pivot is zero.
 
 # Gauss-Jordan reduction
 %%%
@@ -89,11 +84,10 @@ the result.
 tag := "hex-row-reduce-span"
 %%%
 
-On top of the reduced form sit the linear-algebra readers a caller
-actually wants: the linear combination of the rows, membership in the
-row span with an explicit witness, the boolean span test, and a basis
-for the nullspace — each with a soundness theorem, and the nullspace
-basis additionally with a completeness theorem.
+The reduced form gives the readers a caller wants: the linear
+combination of the rows, row-span membership with an explicit witness,
+the boolean span test, and a nullspace basis. Each has a soundness
+theorem; the nullspace basis also has a completeness theorem.
 
 {docstring Hex.Matrix.rowCombination}
 
@@ -116,10 +110,10 @@ basis additionally with a completeness theorem.
 tag := "hex-row-reduce-worked"
 %%%
 
-The block below builds the `2 × 3` rational matrix with rows `(1, 2, 3)`
-and `(2, 4, 6)`. The second row is twice the first, so the rank is `1`,
-and the vector `(1, 2, 3)` — the first row itself — lies in the row
-span. Every `#guard` is checked when the chapter is built.
+The block builds the `2 × 3` rational matrix with rows `(1, 2, 3)` and
+`(2, 4, 6)`. The second row is twice the first, so the rank is `1`, and
+`(1, 2, 3)` (the first row) lies in the row span. Each `#guard` is
+checked when the chapter builds.
 
 ```lean
 open Hex Hex.Matrix
@@ -231,7 +225,7 @@ right-hand side is exactly the Mathlib `LinearMap.ker` of `M`'s
 `mulVecLin`.
 
 If a matrix is large enough that kernel reduction stalls, `decide_cbv`
-is a drop-in fallback — also kernel-honest, but roughly forty times
+is a drop-in fallback: also kernel-honest, but roughly forty times
 slower on the matrices measured here.
 
 ## How to test whether a vector is in the row span
@@ -297,15 +291,12 @@ end HexRowReduceSpanProof
 tag := "hex-row-reduce-cross-references"
 %%%
 
-`HexRowReduce` is the row-reduction layer of the linear-algebra stack:
+`HexRowReduce` depends only on {ref "hex-matrix"}[HexMatrix], using its
+matrix type, arithmetic, and elementary operations.
 
-* It depends only on {ref "hex-matrix"}[HexMatrix] — the matrix type,
-  its arithmetic, and the elementary operations it composes.
-* The {ref "hex-determinant"}[HexDeterminant] and
-  {ref "hex-bareiss"}[HexBareiss] libraries handle the determinant; row
-  reduction is the separate field-valued route for rank, span, and
-  nullspace.
-* `HexRowReduceMathlib` is the correspondence library identifying the
-  executable rank, span, and nullspace with Mathlib's linear algebra.
-  The Mathlib dependency lives entirely on that side of the boundary;
-  `HexRowReduce` itself is Mathlib-free.
+* {ref "hex-determinant"}[HexDeterminant] and
+  {ref "hex-bareiss"}[HexBareiss] handle the determinant; row reduction
+  is the separate field-valued route for rank, span, and nullspace.
+* `HexRowReduceMathlib` identifies the executable rank, span, and
+  nullspace with Mathlib's linear algebra. `HexRowReduce` is
+  Mathlib-free.


### PR DESCRIPTION
This PR removes the em-dashes and vague filler from the HexRowReduce, HexDeterminant, HexBareiss, HexGramSchmidt, and HexLLL manual chapters, the same pass HexMatrix already had: it drops "stack" / "layer" / "core" / "boundary" / "sits above-below" / "building blocks of" framing, chapter-tour boilerplate, and "guaranteed to match the executable implementation" filler, replacing em-dashes with colons or parentheses. It also corrects two stale "forthcoming bridge" references (the HexBareissMathlib and HexRowReduceMathlib bridges already exist).

The unreleased chapters (HexArith, HexPoly, the finite-field stack, etc.) get the same treatment in a follow-up.

🤖 Prepared with Claude Code