### PR TITLE
doc: link each library README to its reference-manual chapter

### DIFF
--- a/HexBareiss/README.md
+++ b/HexBareiss/README.md
@@ -84,6 +84,11 @@ The correspondence of the Bareiss determinant with the Leibniz
 invariant, is proven in
 [`hex-bareiss-mathlib`](https://github.com/kim-em/hex-bareiss-mathlib), not here.
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-bareiss>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexBareissMathlib/README.md
+++ b/HexBareissMathlib/README.md
@@ -81,6 +81,11 @@ The executable algorithm itself lives in
 [`hex-bareiss`](https://github.com/kim-em/hex-bareiss); these theorems are on
 that Mathlib-free library's forbidden list and live here by design.
 
+# Reference manual
+
+The hex reference manual covers this library and its computational base at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-bareiss>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexDeterminant/README.md
+++ b/HexDeterminant/README.md
@@ -84,6 +84,11 @@ correspondence with the executable Bareiss determinant
 ([`hex-bareiss`](https://github.com/kim-em/hex-bareiss)), live in the Mathlib
 bridge layers.
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-determinant>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexDeterminantMathlib/README.md
+++ b/HexDeterminantMathlib/README.md
@@ -95,6 +95,11 @@ live in [`hex-determinant`](https://github.com/kim-em/hex-determinant); the
 `bareiss = det` headline theorems live in
 [`hex-bareiss-mathlib`](https://github.com/kim-em/hex-bareiss-mathlib).
 
+# Reference manual
+
+The hex reference manual covers this library and its computational base at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-determinant>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexGramSchmidt/README.md
+++ b/HexGramSchmidt/README.md
@@ -98,6 +98,11 @@ matrix go through Bareiss-Desnanot integrality, so they live in
 along with the correspondence between `GramSchmidt.Int.basis` and Mathlib's
 `gramSchmidt`.
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-gram-schmidt>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexGramSchmidtMathlib/README.md
+++ b/HexGramSchmidtMathlib/README.md
@@ -97,6 +97,11 @@ theorem gramDet_eq_prod_normSq (b : Matrix Int n m)
 The executable Gram-Schmidt algorithm and its own algebraic API live in
 [`hex-gram-schmidt`](https://github.com/kim-em/hex-gram-schmidt).
 
+# Reference manual
+
+The hex reference manual covers this library and its computational base at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-gram-schmidt>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -188,6 +188,11 @@ theorems reduce to the ordinary Lean axioms `propext`, `Classical.choice`, and
 The requested-parameter, precision, and dispatch-calibration constants are
 performance tuning only and are outside the trusted story; none affects soundness.
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-lll>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexLLLMathlib/README.md
+++ b/HexLLLMathlib/README.md
@@ -119,6 +119,11 @@ algebra:
 The executable algorithm, the rational short-vector bound, and the reducedness
 theory live in [`hex-lll`](https://github.com/kim-em/hex-lll).
 
+# Reference manual
+
+The hex reference manual covers this library and its computational base at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-lll>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexMatrix/README.md
+++ b/HexMatrix/README.md
@@ -69,6 +69,11 @@ The `Semiring` / `Ring` structure and the equivalence with Mathlib's
 `Matrix`, which let you transfer Mathlib's linear-algebra results, live in
 [`hex-matrix-mathlib`](https://github.com/kim-em/hex-matrix-mathlib).
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-matrix>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexMatrixMathlib/README.md
+++ b/HexMatrixMathlib/README.md
@@ -105,6 +105,11 @@ The executable matrices and their operations live in
 reduction, and Bareiss correspondences build on this base in their own bridge
 libraries.
 
+# Reference manual
+
+The Mathlib correspondence section of the hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-matrix-mathlib>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexRowReduce/README.md
+++ b/HexRowReduce/README.md
@@ -86,6 +86,11 @@ theorem nullspace_complete [Lean.Grind.Field R] [DecidableEq R] (M : Matrix R n 
 The identification with Mathlib's linear-algebra theory lives in
 [`hex-row-reduce-mathlib`](https://github.com/kim-em/hex-row-reduce-mathlib).
 
+# Reference manual
+
+The hex reference manual covers this library at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-row-reduce>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/HexRowReduceMathlib/README.md
+++ b/HexRowReduceMathlib/README.md
@@ -94,6 +94,11 @@ theorem spanContains_iff_mem_span [Field R] [DecidableEq R]
 The executable row reduction itself lives in
 [`hex-row-reduce`](https://github.com/kim-em/hex-row-reduce).
 
+# Reference manual
+
+The hex reference manual covers this library and its computational base at
+<https://kim-em.github.io/hex-dev/find/?domain=Verso.Genre.Manual.section&name=hex-row-reduce>.
+
 # Contributing
 
 Development happens in the [`hex-dev`](https://github.com/kim-em/hex-dev)

--- a/progress/20260701T000000Z_readme-manual-links.md
+++ b/progress/20260701T000000Z_readme-manual-links.md
@@ -1,0 +1,32 @@
+# README → reference-manual links
+
+## Accomplished
+
+- Added a low-key `# Reference manual` section, placed just before
+  `# Contributing`, to the 12 released-library READMEs (the six
+  Mathlib-free libraries and their six `*Mathlib` bridges).
+- Linked each via Verso's stable tag-based permalink
+  (`find/?domain=Verso.Genre.Manual.section&name=<tag>`), which redirects
+  by chapter tag and survives title/slug changes, rather than the
+  title-derived page slug.
+- Computational READMEs point at their own chapter tag; five bridge
+  READMEs point at the computational chapter ("covers this library and
+  its computational base"); `HexMatrixMathlib` points at the dedicated
+  `hex-matrix-mathlib` "Mathlib correspondence" section, the only bridge
+  with its own section tag.
+- Confirmed every target tag resolves (HTTP 200) and is present in the
+  published manual's `xref.json`.
+
+## Current frontier
+
+Codex second opinion incorporated: tightened bridge wording and the
+`HexMatrixMathlib` target. PR opened.
+
+## Next step
+
+Edits land through the normal `sync-released` publish to the split repos;
+no hand-editing of mirrors.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a low-key "# Reference manual" section, placed just before "# Contributing", to the 12 released-library READMEs (the six Mathlib-free libraries and their six `*Mathlib` bridges), linking each to its Verso reference-manual chapter. The link uses Verso's stable tag-based permalink (`find/?domain=Verso.Genre.Manual.section&name=<tag>`), which redirects by chapter tag and so survives chapter retitling, rather than the title-derived page slug. Computational READMEs point at their own chapter tag; five bridge READMEs point at the computational chapter, and `HexMatrixMathlib` points at the dedicated `hex-matrix-mathlib` correspondence section (the only bridge with its own section tag). Every target tag was confirmed to resolve and to be present in the published manual's `xref.json`. The edits land in the split repos through the normal `sync-released` publish, not by hand-editing the mirrors.

🤖 Prepared with Claude Code