### PR TITLE
fix: skip doomed steered LLL on ill-conditioned bases via float-GSO conditioning gate

### DIFF
--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -295,6 +295,25 @@ its certification — directly to `lllNative`; like every other dispatch in this
 library it is a function of the input alone and both branches satisfy the same
 post-condition.
 
+Above that dimension floor the reducer additionally consults a **conditioning
+test** before committing to the steered loop. The `Float64` Gram-Schmidt is only
+accurate when the basis's Gram-Schmidt dynamic range fits the 53-bit mantissa;
+on bases whose range far exceeds it (the structured worst-case families —
+ajtai/q-ary/ntru/knapsack — with a `q·I` block or a steep diagonal-bit profile)
+the initial approximate squared norms suffer catastrophic cancellation and some
+come out **non-positive**, which is impossible for a genuine `‖b*_i‖² > 0`. A
+non-positive initial approximate norm is a cheap, `O(n)`, deterministic signature
+that the float steering is numerically unusable on this basis, so the reducer
+skips the steered attempt and runs `lllNative` directly rather than wasting the
+full steered loop before an all-but-certain certification failure. This is an
+empirically-calibrated routing heuristic, not a soundness property: a candidate
+that did slip through would still be certified, and any basis routed here still
+gets an exact reduction. The near-orthogonal (`random-bounded`) and width-bound
+(`harsh-cubic`) families produce no non-positive norm on any committed rung and
+continue to steer. Like every dispatch here it is a function of the input alone
+(the float pass is deterministic) and does not affect the output contract — it
+only avoids wasted work.
+
 Both pinned `η` values are unchanged: `lllNative` retains `η = 1/2` and the
 public `lll` retains `η = 11/20`. The public `lll` contract — same lattice,
 `isLLLReduced (lll …) δ (11/20)`, and the `lll_short_vector` bound — holds

--- a/HexLLL/Steered.lean
+++ b/HexLLL/Steered.lean
@@ -86,6 +86,32 @@ def init (b : Matrix Int n m) : SteeredState n m :=
 the float `mu`/`bb` approximation and copies `b` through unchanged. -/
 @[simp, grind =] theorem init_b (b : Matrix Int n m) : (init b).b = b := rfl
 
+/-- Conditioning test on the float Gram-Schmidt: `true` when every approximate
+squared norm `bb[i] ≈ ‖b*_i‖²` came out strictly positive.
+
+A genuine Gram-Schmidt squared norm is strictly positive (the rows are
+independent), so a non-positive `bb[i]` is a definitive signature that `Float64`
+catastrophic cancellation has corrupted the approximation on this basis: the
+initial `bb[i]` is formed by subtracting `Σ μ² · c` from `⟨b_i, b_i⟩`, and when
+the true `‖b*_i‖²` is many mantissa bits smaller than those terms the difference
+loses all significance and can even go negative. Steering from such a corrupted
+approximation makes wrong swap and size-reduction decisions, so the exact-integer
+candidate almost always misses `(δ, 11/20)`-certification and the whole steered
+attempt is wasted before falling back to the exact reducer.
+
+This is an empirically-calibrated routing heuristic, not a theorem: soundness
+never depends on it (a candidate that does slip through still certifies, and any
+basis routed here still gets an exact reduction). The four structured worst-case
+families (ajtai / q-ary / ntru / knapsack) have a Gram-Schmidt dynamic range far
+exceeding the 53-bit mantissa and produce many non-positive `bb[i]` (13+ of 32 on
+the smallest steered rungs), all of which fail certification; the near-orthogonal
+random-bounded and width-bound harsh-cubic families produce none across every
+committed rung and seed, and all certify. Reading the signs is `O(n)` on the
+`init` the steered path already builds. -/
+@[expose]
+def wellConditioned (s : SteeredState n m) : Bool :=
+  s.bb.all fun x => decide (0.0 < x)
+
 /-- Recompute `mu` row `k` and `bb[k]` from the exact Gram entries `⟨b_k, b_j⟩`
 and the stored approximation of rows `< k`. The basis is unchanged. This is the
 drift-control step: each working row's coefficients are recomputed from the exact
@@ -255,12 +281,19 @@ costs ~5% on random-bounded n=45). A stricter `δsteer` does not monotonically
 help robustness or cost, because it steers a different swap trajectory through
 different float-rounding boundaries. -/
 @[expose]
-def steeredReduce (b : Matrix Int n m) (δ : Rat) : Matrix Int n m :=
-  let s0 := SteeredState.init b
+def steeredReduceFrom (s0 : SteeredState n m) (δ : Rat) : Matrix Int n m :=
   let δf : Float := Float.ofInt δ.num / Float.ofNat δ.den
   let δsteer : Float := (δf + 2.0) / 3.0
-  let s := SteeredState.loop δsteer 16 s0 1 0 (SteeredState.fuel b)
+  let s := SteeredState.loop δsteer 16 s0 1 0 (SteeredState.fuel s0.b)
   (SteeredState.finalSweep s).b
+
+/-- Run the approximation-steered reducer by building the float GSO once with
+`init` and driving the loop and final sweep from it. `lllSteered` builds the same
+initial state, inspects its conditioning, and calls `steeredReduceFrom` directly
+to avoid a second `init`. -/
+@[expose]
+def steeredReduce (b : Matrix Int n m) (δ : Rat) : Matrix Int n m :=
+  steeredReduceFrom (SteeredState.init b) δ
 
 /-! ### Lattice preservation of the steered reducer
 
@@ -390,6 +423,14 @@ membership of `v` is unchanged. -/
 
 end SteeredState
 
+/-- Running the steered loop and final sweep from any initial state preserves the
+lattice: both `loop` and `finalSweep` are lattice-preserving, so the output spans
+the same integer lattice as `s0.b`, independent of the float approximation. -/
+@[grind =] theorem steeredReduceFrom_memLattice_iff
+    (s0 : SteeredState n m) (δ : Rat) (v : Vector Int m) :
+    Matrix.memLattice (steeredReduceFrom s0 δ) v ↔ Matrix.memLattice s0.b v := by
+  unfold steeredReduceFrom; grind
+
 /-- The complete steered reducer preserves the lattice: `init`, `loop`, and
 `finalSweep` are each lattice-preserving, so the steered output basis spans the
 same integer lattice as the input `b` and membership of `v` is unchanged. This is
@@ -402,18 +443,26 @@ approximation. -/
 
 
 /-- Outcome of one steered reduction: the steered candidate certified at
-`(δ, 11/20)`, or the run fell back to the exact `lllNative`. -/
+`(δ, 11/20)`; the run attempted steering but the candidate failed certification,
+so it fell back to the exact `lllNative`; or the conditioning test predicted the
+float GSO was degenerate and the run skipped straight to `lllNative` without
+attempting (and wasting) a steered reduction. -/
 inductive SteeredOutcome where
   | certified
   | fellBack
+  | skipped
 deriving Repr, BEq
 
 /-- Fallback-rate diagnostic for the steered reducer. `fellBack = 0` across a
-bench ladder confirms the steered path certified every rung, so the measured
-medians are honest (no exact-reducer time mixed in). -/
+bench ladder confirms the steered path certified every rung it attempted, so the
+measured medians are honest (no exact-reducer time mixed in). `skipped` counts the
+rungs the conditioning test routed straight to the exact reducer without a wasted
+steered attempt; on the ill-conditioned structured families these previously
+showed up as `fellBack`. -/
 structure SteeredTally where
   certified : Nat := 0
   fellBack : Nat := 0
+  skipped : Nat := 0
 deriving Repr, BEq, Inhabited
 
 initialize steeredTallyRef : IO.Ref SteeredTally ← IO.mkRef {}
@@ -433,6 +482,7 @@ def steeredTally : IO SteeredTally := steeredTallyRef.get
 private def bumpSteered (t : SteeredTally) : SteeredOutcome → SteeredTally
   | .certified => { t with certified := t.certified + 1 }
   | .fellBack => { t with fellBack := t.fellBack + 1 }
+  | .skipped => { t with skipped := t.skipped + 1 }
 
 /-- Side-effecting tally bump callable from pure code; definitionally the
 continuation `k`. Mirrors `withRecordCheckerOutcome`. -/
@@ -489,21 +539,30 @@ def steerWins (_b : Matrix Int n m) : Bool :=
 end Internal
 
 /-- Approximation-steered native reducer with certified output. When `steerWins`
-holds it runs the steered loop (exact integer row operations driven by an
-untrusted float Gram-Schmidt), certifies the candidate at the public `(δ, 11/20)`
-bound via `lllReducedCheck`, and falls back to the exact `lllNative` on
-certification failure; otherwise it runs `lllNative` directly. The output is
-therefore always a `(δ, 11/20)`-reduced basis of the same lattice as `b`; the
-exact `d`/`ν` state is materialized only on the small-input and fallback paths. -/
+holds it builds the float Gram-Schmidt with `init` and consults its conditioning:
+if the approximation is numerically usable (`wellConditioned`) it runs the steered
+loop from that state (exact integer row operations driven by the untrusted float
+Gram-Schmidt), certifies the candidate at the public `(δ, 11/20)` bound via
+`lllReducedCheck`, and falls back to the exact `lllNative` on certification
+failure. If the float GSO is degenerate (a non-positive approximate squared norm,
+the signature of the structured worst-case families) it skips the predicted-futile
+steered attempt and runs `lllNative` directly; below the dimension floor it also runs
+`lllNative` directly. The output is therefore always a `(δ, 11/20)`-reduced basis
+of the same lattice as `b`; the exact `d`/`ν` state is materialized only on the
+small-input, skip, and fallback paths. -/
 @[expose]
 def lllSteered (b : Matrix Int n m) (δ : Rat)
     (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) : Matrix Int n m :=
   if steerWins b then
-    let candidate := steeredReduce b δ
-    if lllReducedCheck candidate δ (11 / 20) then
-      withRecordSteeredOutcome .certified candidate
+    let s0 := SteeredState.init b
+    if s0.wellConditioned then
+      let candidate := steeredReduceFrom s0 δ
+      if lllReducedCheck candidate δ (11 / 20) then
+        withRecordSteeredOutcome .certified candidate
+      else
+        withRecordSteeredOutcome .fellBack (lllNative b δ hδ hδ' hn)
     else
-      withRecordSteeredOutcome .fellBack (lllNative b δ hδ hδ' hn)
+      withRecordSteeredOutcome .skipped (lllNative b δ hδ hδ' hn)
   else
     lllNative b δ hδ hδ' hn
 

--- a/HexLLLMathlib/Reducer.lean
+++ b/HexLLLMathlib/Reducer.lean
@@ -2439,8 +2439,8 @@ theorem dispatch_some_property {b : Matrix Int n m} {δ : Rat}
   exact HexLLLMathlib.certCheck_sound hcheck
 
 /-- The steered reducer preserves the generated lattice: the certified candidate
-preserves it by construction (`steeredReduce_memLattice_iff`), the fallback by
-`lllNative_memLattice_iff`. -/
+preserves it by construction (`steeredReduce_memLattice_iff`), the skip and
+fallback paths by `lllNative_memLattice_iff`. -/
 theorem lllSteered_memLattice_iff (b : Matrix Int n m) (δ : Rat)
     (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (v : Vector Int m) :
     Matrix.memLattice (Hex.lllSteered b δ hδ hδ' hn) v ↔ Matrix.memLattice b v := by
@@ -2448,7 +2448,9 @@ theorem lllSteered_memLattice_iff (b : Matrix Int n m) (δ : Rat)
   simp only [Hex.Internal.withRecordSteeredOutcome]
   split
   · split
-    · exact Hex.Internal.steeredReduce_memLattice_iff b δ v
+    · split
+      · exact Hex.Internal.steeredReduce_memLattice_iff b δ v
+      · exact lllNative_memLattice_iff b δ hδ hδ' hn v
     · exact lllNative_memLattice_iff b δ hδ hδ' hn v
   · exact lllNative_memLattice_iff b δ hδ hδ' hn v
 
@@ -2465,8 +2467,10 @@ theorem lllSteered_isLLLReduced (b : Matrix Int n m) (δ : Rat)
   simp only [Hex.Internal.withRecordSteeredOutcome]
   split
   · split
-    · rename_i h
-      exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).1
+    · split
+      · rename_i h
+        exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).1
+      · exact hnative
     · exact hnative
   · exact hnative
 
@@ -2478,8 +2482,10 @@ theorem lllSteered_independent (b : Matrix Int n m) (δ : Rat)
   simp only [Hex.Internal.withRecordSteeredOutcome]
   split
   · split
-    · rename_i h
-      exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).2
+    · split
+      · rename_i h
+        exact (HexLLLMathlib.lllReducedCheck_sound _ δ (11 / 20) h).2
+      · exact lllNative_independent b δ hδ hδ' hn hind
     · exact lllNative_independent b δ hδ hδ' hn hind
   · exact lllNative_independent b δ hδ hδ' hn hind
 

--- a/progress/20260701T120000Z_issue-8491-steered-conditioning-gate.md
+++ b/progress/20260701T120000Z_issue-8491-steered-conditioning-gate.md
@@ -1,0 +1,56 @@
+# Issue #8491: steered LLL never certifies on structured bench families
+
+## Accomplished
+
+Diagnosed and fixed the root cause of `Hex.lllSteered` wasting a full steered
+reduction + failed certification on the four structured Phase-4 bench families
+(ajtai / q-ary / ntru / knapsack) before falling back to exact.
+
+**Diagnosis (scratch probe, since the structured families live on the unmerged
+`feat/hexlll-perf-restore-extend` branch — copied their generators locally):**
+
+- Which condition fails: on every structured rung the steered candidate fails
+  BOTH size-reduction (`|μ| ≤ 11/20`) AND Lovász — it is genuinely not
+  `(δ, 11/20)`-reduced, `ind=true size=false lovasz=false`.
+- The discriminator is NOT entry magnitude (harsh-cubic has `2^264` entries yet
+  certifies) and NOT the positive-`bb` spread (random-bounded's is 45-61 bits,
+  overlapping the structured families' 51-57). It is the **count of
+  non-positive float `bb[i]`** from `SteeredState.init`: a genuine `‖b*_i‖² > 0`,
+  so a `Float64` value `≤ 0` is a definitive catastrophic-cancellation signature.
+  - structured: 13-36 non-positive of 32-40 rows (ajtai 18, q-ary 13-19,
+    ntru 13, knapsack 29-36).
+  - random-bounded (30..180, all seeds 1-12) and harsh-cubic (25..80): **0**
+    non-positive on every rung.
+
+**Fix (`HexLLL/Steered.lean`):** `SteeredState.wellConditioned` reads off the
+sign of every `init.bb[i]` in `O(n)`. `lllSteered` now builds `init` once,
+consults `wellConditioned`, and skips the doomed steered loop straight to
+`lllNative` when the float GSO is degenerate. Factored `steeredReduce` into
+`steeredReduceFrom` (loop + final sweep from a prebuilt state) so the gate reuses
+the same `init` — no second float pass on the well-conditioned path. Added a
+`skipped` outcome to `SteeredTally` distinguishing "conditioning-skipped" from
+"attempted then fell back".
+
+**Verified end-to-end** (routing via the same internal calls `lllSteered` makes):
+all four structured families → SKIPPED (native, no wasted steer); all
+well-conditioned families → CERTIFIED (unchanged).
+
+Proofs: `steeredReduceFrom_memLattice_iff` added; the three `lllSteered_*`
+soundness theorems in `HexLLLMathlib/Reducer.lean` gained one nested `split` for
+the new skip branch. `HexLLL`, `HexLLLMathlib`, `HexLLLBenchSupport` all build.
+
+## Current frontier
+
+Fix complete and verified locally. SPEC updated with the conditioning-gate
+paragraph.
+
+## Next step
+
+Second opinion, then PR.
+
+## Blockers
+
+None. Note: the structured bench families / comparator SVGs / perf-doc framing
+live on `feat/hexlll-perf-restore-extend`; when that branch merges the four
+families will route via the new SKIPPED path (their comparator "Lean steered"
+curve becomes an honest copy of `lllNative`, not a failed-attempt artifact).


### PR DESCRIPTION
This PR makes the approximation-steered reducer `Hex.lllSteered` skip its float-steered loop on bases whose Gram-Schmidt dynamic range exceeds `Float64` precision, instead of running the full loop, failing `(δ, 11/20)`-certification, and falling back to `lllNative` on every rung of the four structured worst-case bench families (ajtai / q-ary / ntru / knapsack). On those families the steered attempt was pure waste (a reported 17-81x slowdown over exact); this routes them straight to the exact reducer.

The discriminator is not entry magnitude — harsh-cubic has `2^264` entries yet certifies — and not the spread of the positive approximate norms, which overlaps between the well- and ill-conditioned families. It is the sign of the initial approximate squared norms `bb[i]` from `SteeredState.init`: a genuine `‖b*_i‖²` is strictly positive, so a non-positive `Float64` value is a definitive catastrophic-cancellation signature. A scratch probe (structured-family generators copied from the unmerged `feat/hexlll-perf-restore-extend` branch) confirms 13-36 of 32-40 norms come out non-positive on every structured rung, versus exactly zero on random-bounded (dims 30..180, seeds 1..12) and harsh-cubic (25..80).

Add `SteeredState.wellConditioned`, an `O(n)` sign check over the `init` `bb` profile, and gate the steered loop on it in `lllSteered`: when the float GSO is degenerate the reducer runs `lllNative` directly. Factor `steeredReduce` into `steeredReduceFrom` so the gate reuses the single `init` pass with no second float pass on the well-conditioned path. Add a `skipped` outcome to `SteeredTally` distinguishing a conditioning skip from an attempted-then-fell-back run (on the structured families this previously showed as `fellBack`). The gate is an empirically-calibrated routing heuristic, not a soundness property: the float approximation never enters a proof, and the three `lllSteered_*` soundness theorems hold verbatim (each gains one nested `split` for the skip branch).

Verified end-to-end (routing via the same internal calls `lllSteered` makes): all four structured families route to the skip path; every well-conditioned rung keeps a zero non-positive count and still certifies. `HexLLL`, `HexLLLMathlib`, and `HexLLLBenchSupport` build clean. A second opinion (OpenAI Codex) found no correctness or soundness blocker and confirmed the `steeredReduceFrom` refactor is behavior-preserving on the public paths; its prose-softening suggestion is folded in.

Closes #8491

🤖 Prepared with Claude Code