### PR TITLE
doc: writing-style guide and a plain-language pass over the manual

### DIFF
--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -256,7 +256,7 @@ Uniqueness specialised against the default executable factorization, so callers
 only provide the competing product, irreducibility, sign-normalization, and
 nonconstant-factor facts, plus that the input is nonzero. The default
 factorization's own well-formedness is supplied by
-`factor_irreducible_of_nonUnit` and forthcoming sibling lemmas.
+`factor_irreducible_of_nonUnit` and its sibling lemmas.
 -/
 theorem factor_unique_of_product
     (f : Hex.ZPoly) (φ : Hex.Factorization) (hf_ne : f ≠ 0)

--- a/HexManual/Chapters/HexArith.lean
+++ b/HexManual/Chapters/HexArith.lean
@@ -265,7 +265,7 @@ tag := "hex-arith-cross-references"
   the {ref "hex-arith-wide"}[`Nat`-level laws] above are the
   specification those bindings are proved against; the library's meaning
   does not depend on the native code being linked.
-* The arithmetic here has no single Mathlib bridge of its own; the
-  Mathlib correspondences live in the consuming libraries' `*Mathlib`
+* The arithmetic here has no Mathlib correspondence library of its own.
+  The Mathlib correspondences live in the consuming libraries' `*Mathlib`
   counterparts. `HexArith` itself imports only `Std` and never depends
   on Mathlib.

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -23,6 +23,10 @@ tag := "hex-bareiss"
 tag := "hex-bareiss-intro"
 %%%
 
+Released as [hex-bareiss](https://github.com/kim-em/hex-bareiss), with
+the Mathlib correspondence in
+[hex-bareiss-mathlib](https://github.com/kim-em/hex-bareiss-mathlib).
+
 `HexBareiss` is the executable fraction-free Bareiss determinant of a
 dense integer matrix: a Gaussian elimination in which every intermediate
 entry stays an exact integer because each update divides *exactly* by
@@ -35,7 +39,7 @@ specification it is checked against).
 
 `HexBareiss` is Mathlib-free. The theorem identifying the Bareiss
 determinant with the Leibniz determinant, via the Desnanot-Jacobi
-invariant, lives in the forthcoming `HexBareissMathlib` bridge.
+invariant, lives in `HexBareissMathlib`.
 
 # The elimination record
 %%%

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -23,6 +23,10 @@ tag := "hex-determinant"
 tag := "hex-determinant-intro"
 %%%
 
+Released as [hex-determinant](https://github.com/kim-em/hex-determinant),
+with the Mathlib correspondence in
+[hex-determinant-mathlib](https://github.com/kim-em/hex-determinant-mathlib).
+
 `HexDeterminant` is the determinant of a dense square matrix via the
 Leibniz formula, with the cofactor and adjugate theory built on it. It
 depends only on {ref "hex-matrix"}[HexMatrix] and is generic over the
@@ -36,8 +40,8 @@ a caller runs on a large matrix.
 
 `HexDeterminant` is Mathlib-free. The identification of this determinant
 with Mathlib's `Matrix.det`, and with the executable Bareiss
-determinant, lives in the forthcoming `HexDeterminantMathlib` and
-`HexBareissMathlib` bridges.
+determinant, lives in `HexDeterminantMathlib` and
+`HexBareissMathlib`.
 
 # The Leibniz determinant
 %%%

--- a/HexManual/Chapters/HexGFq.lean
+++ b/HexManual/Chapters/HexGFq.lean
@@ -230,8 +230,7 @@ tag := "hex-gfq-cross-references"
   delegates to it.
 * `HexGF2` provides the single-word packed field `GF2n` backing
   {name}`Hex.GF2q`, together with the `GF2Poly.Irreducible` predicate the
-  packed certificates discharge. (Its reference chapter is forthcoming;
-  until it lands this dependency is named in prose.)
+  packed certificates discharge.
 
 `HexGFq` is Mathlib-free; its Mathlib correspondence
 ({ref "hex-gfq-mathlib"}[above], via `HexGFqMathlib`) identifies the

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -23,6 +23,11 @@ tag := "hex-gram-schmidt"
 tag := "hex-gram-schmidt-intro"
 %%%
 
+Released as
+[hex-gram-schmidt](https://github.com/kim-em/hex-gram-schmidt), with the
+Mathlib correspondence in
+[hex-gram-schmidt-mathlib](https://github.com/kim-em/hex-gram-schmidt-mathlib).
+
 `HexGramSchmidt` orthogonalizes the rows of a matrix by Gram-Schmidt:
 from each row it subtracts the projection onto the earlier rows, and
 returns the orthogonal basis together with the lower-unitriangular matrix

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -23,6 +23,10 @@ tag := "hex-lll"
 tag := "hex-lll-intro"
 %%%
 
+Released as [hex-lll](https://github.com/kim-em/hex-lll), with the
+Mathlib correspondence in
+[hex-lll-mathlib](https://github.com/kim-em/hex-lll-mathlib).
+
 `HexLLL` reduces an integer lattice basis. Given the rows of a
 {name}`Hex.Matrix` over `Int`, it produces a new basis for the same
 lattice made of short, nearly orthogonal vectors (the LLL guarantee).
@@ -119,8 +123,8 @@ tag := "hex-lll-reduction"
 
 The reducer carries two pieces of state. The proof-facing
 {name}`Hex.Internal.LLLState` holds the exact integer basis together with the scaled
-Gram-Schmidt data, and a separate {name}`Hex.Internal.LLLState.Valid` predicate ties
-that data back to the `GramSchmidt.Int` representation, keeping the state
+Gram-Schmidt data, and a separate {name}`Hex.Internal.LLLState.Valid` predicate relates
+that data to the `GramSchmidt.Int` representation, keeping the state
 updates computational while letting the Mathlib side reason about them.
 
 {docstring Hex.Internal.LLLState}

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -23,6 +23,10 @@ tag := "hex-matrix"
 tag := "hex-matrix-intro"
 %%%
 
+Released as [hex-matrix](https://github.com/kim-em/hex-matrix), with the
+Mathlib correspondence in
+[hex-matrix-mathlib](https://github.com/kim-em/hex-matrix-mathlib).
+
 `Hex.Matrix R n m` is an `n × m` matrix over `R`.
 
 This library has the type, its arithmetic (the dot product, matrix-vector
@@ -72,12 +76,14 @@ matrix-matrix, both written `*`.
 
 The identity is a left and right unit, and multiplication is associative.
 
-{docstring Hex.Matrix.identity_mulVec}
+{docstring Hex.Matrix.identity_mul}
+
+{docstring Hex.Matrix.mul_identity}
 
 {docstring Hex.Matrix.mul_assoc}
 
-The squared norm of a vector, the Gram matrix of the rows, and the
-leading principal submatrices the Bareiss recurrence uses:
+The Gram matrix of the rows and the leading principal submatrices used by
+the Bareiss recurrence:
 
 {docstring Hex.Matrix.gramMatrix}
 
@@ -89,7 +95,7 @@ tag := "hex-matrix-elementary"
 %%%
 
 The elementary row operations work over any ring. Each has a determinant
-law, proved in {ref "hex-determinant"}[HexDeterminant];
+law, proved in {ref "hex-determinant"}[HexDeterminant].
 {ref "hex-row-reduce"}[HexRowReduce] uses them for Gauss-Jordan reduction
 over a field.
 

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -79,8 +79,8 @@ results never grow past the modulus degree.
 
 {docstring Hex.FpPoly.composeModMonic}
 
-The Frobenius-power maps are the engine of finite-field irreducibility
-and factorization tests. {name}`Hex.FpPoly.frobeniusXMod` computes the
+The finite-field irreducibility and factorization tests are built on the
+Frobenius-power maps. {name}`Hex.FpPoly.frobeniusXMod` computes the
 basic generator `X^p mod f`, and {name}`Hex.FpPoly.frobeniusXPowMod`
 iterates it to `X^(pᵏ) mod f` for arbitrary `k`.
 

--- a/HexManual/README.md
+++ b/HexManual/README.md
@@ -4,6 +4,10 @@ The Verso reference manual for the `hex` project. Each per-library
 reference chapter lives in `Chapters/`; `HexManual.lean` is the aggregator
 that includes them.
 
+Prose in the chapters follows [SPEC/writing-style.md](../SPEC/writing-style.md):
+plain, literal, mathematician-facing language, with a list of banned
+jargon words. Read it before editing a chapter.
+
 `lake build HexManual` *typechecks* the manual: every `{docstring}`,
 `{ref}`, `#eval`/`leanOutput`, and `#guard` in the chapters is checked as
 they elaborate. It does not produce a website.

--- a/HexRowReduce.lean
+++ b/HexRowReduce.lean
@@ -16,8 +16,8 @@ public import HexRowReduce.Api
 public section
 
 /-!
-The `HexRowReduce` library: the executable row-reduction stack over the
-`HexMatrix` dense core. It re-exports the elementary-operation algebra and
+The `HexRowReduce` library: executable row reduction for the dense
+matrices of `HexMatrix`. It re-exports the elementary-operation algebra and
 echelon contracts (`RowEchelon`), the pivot search and column elimination
 (`Pivot`), the `rowReduce` loop and its correctness (`Loop`), and the row-span
 and nullspace APIs (`Span`, `Nullspace`, `Api`).

--- a/SPEC/writing-style.md
+++ b/SPEC/writing-style.md
@@ -1,0 +1,135 @@
+# Writing style
+
+Rules for all prose in this repository: docstrings, SPEC files, and the
+manual (`HexManual/`). The audience is a working mathematician who reads
+Lean. Write for them: plain, literal, and accurate. When a sentence is
+awkward, the fix is almost always to say the ordinary thing directly, not
+to reach for a fancier word.
+
+The test for every sentence: read each verb with its object. If the pair
+is not something an ordinary English speaker would say about that kind of
+thing, rewrite it.
+
+## Banned words
+
+Do not use these as nouns or verbs for a thing in the repository:
+
+- **stack** ("the row-reduction stack") — name the library or the
+  operation.
+- **core** ("the matrix core", "documented with the matrix core") — name
+  the library (`HexMatrix`) or the type (`Hex.Matrix`).
+- **bridge** ("the Mathlib bridge") — name the library
+  (`HexMatrixMathlib`) and say what it does (relates the executable
+  types to Mathlib's).
+- **reader** for an accessor or query function ("the linear-algebra
+  readers a caller wants") — name the functions, or call them the span
+  and nullspace *operations* / *queries*.
+- **smoke** ("smoke test") — say "fast check" or name the check.
+- **gate** ("gates the merge") — say "required check".
+
+This list grows. When a review rejects a word as jargon, add it here.
+
+## No em-dashes
+
+Do not use em-dashes (`—`). Rewrite as two sentences, a colon, or
+parentheses.
+
+## No run-on sentences joined by a semicolon
+
+A semicolon does not license welding two only-loosely-related statements
+into one sentence. If the two halves are independent thoughts, write two
+sentences.
+
+- Bad: "Each has a determinant law, proved in HexDeterminant;
+  HexRowReduce uses them for Gauss-Jordan reduction over a field."
+- Good: "Each has a determinant law, proved in HexDeterminant.
+  HexRowReduce uses them for Gauss-Jordan reduction over a field."
+
+A semicolon is fine inside a genuine list whose items themselves contain
+commas.
+
+## Every verb-object pair must be literal
+
+No metaphorical or anthropomorphic verb applied to an abstract object.
+The reader should never have to decode a figure of speech.
+
+- Bad: "This chapter walks the echelon certificate." You cannot walk a
+  certificate.
+- Bad: "tying the executable answer back to the matrix." You do not tie
+  an answer to a matrix.
+- Bad: "the linear-algebra readers sit on top of the reduced form."
+- Good: name the real action. "This chapter describes the echelon
+  certificate." "a soundness theorem proving the computed coefficients
+  reconstruct the vector." "From the reduced form we compute the span and
+  nullspace."
+
+## Do not invent noun phrases
+
+If a phrase would make a reader stop and ask "what is that?", it is
+wrong. "Linear-algebra reader" is not a thing anyone says. Name the
+actual function, type, or library.
+
+## Match categories
+
+Identify or relate a concrete object with its concrete counterpart, not
+with a field of study or a body of theory.
+
+- Bad: "identifies the executable rank, span, and nullspace with
+  Mathlib's linear algebra." Rank is not identified with a subject.
+- Good: "identifies the executable rank, span, and nullspace with their
+  Mathlib analogues `Matrix.rank`, `Submodule.span`, and `LinearMap.ker`"
+  (or "with Mathlib's noncomputable versions").
+
+## Punctuation-separated noun phrases are not a list
+
+Comma-separated noun phrases followed by a trailing verb read as one
+clause with a subject and objects, not as a list. Written that way, the
+sentence can assert a relationship you did not mean.
+
+- Bad: "The squared norm of a vector, the Gram matrix of the rows, and
+  the leading principal submatrices the Bareiss recurrence uses:" reads
+  as a claim that the squared norm uses the Gram matrix.
+- Good, when you mean a heading for what follows: a noun phrase with no
+  trailing verb, introduced by a colon, like "The zero and identity
+  matrices:".
+
+## Keep build and verification notes out of the reading flow
+
+A reader in the middle of the mathematics should not be told how the
+manual is checked. Do not mix "checked when the chapter builds" or
+"closes with a worked example verified at build time" into exposition.
+If the fact matters, put it in its own note.
+
+## Be accurate about what exists and what is cited
+
+- Do not call an existing library "forthcoming". Tense and
+  cross-references must match reality.
+- A docstring or lemma cited for a claim must actually be about that
+  claim. "The identity is a left and right unit" is `identity_mul` and
+  `mul_identity`, not `identity_mulVec` (which is the left unit on
+  vectors).
+
+## Manual examples that cross into Mathlib
+
+A recipe that shows how to prove a *Mathlib* fact by running the
+executable is written for someone who already has a Mathlib goal. The
+definitions and the theorem statement must therefore be stated in Mathlib
+types alone. The translation into `Hex.Matrix` belongs entirely in the
+proof body (through `matrixEquiv` and the correspondence theorems).
+
+Antipattern: defining the example matrix as a `Hex.Matrix` and stating
+the theorem about `matrixEquiv M`. That presumes the reader started on
+the Hex side, which is exactly backwards for a "prove a Mathlib fact"
+recipe, and it hides the boundary crossing the recipe is meant to teach.
+
+- Bad: `def M : Hex.Matrix Rat 2 3 := ...` then
+  `theorem _ : Matrix.rank (matrixEquiv M) = 1`.
+- Good: `def A : Matrix (Fin 2) (Fin 3) Rat := ...` then
+  `theorem _ : A.rank = 1`, with the proof introducing the Hex matrix and
+  rewriting through the correspondence theorem.
+
+## Naming (cross-reference)
+
+Short verb-noun names, qualifiers in namespaces. See the naming section
+of `.claude/CLAUDE.md`. A name whose qualifier list reads like a sentence
+belongs in the docstring, not the name.


### PR DESCRIPTION
This PR adds `SPEC/writing-style.md`, a prose guide for the manual and docstrings (banned jargon such as stack/core/bridge/smoke/gate and "reader", no em-dashes, literal verb-object pairs, category-matched comparisons, list-versus-clause grammar, and the Mathlib-boundary-example antipattern), linked from the manual README. It then applies that guide across the reference chapters: replacing non-literal phrasings and jargon, removing stale "forthcoming" claims for libraries that already exist, and adding at the top of each release-library chapter it touches a direct link to that library's two published repositories (the computational one and its Mathlib layer). It also fixes two source docstrings in the same spirit, in `HexRowReduce` and `HexBerlekampZassenhausMathlib.FactorSoundness`.

🤖 Prepared with Claude Code