### PR TITLE
feat: assemble factor_irreducible_of_nonUnit over the hybrid's three branches

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -10118,6 +10118,36 @@ theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
       | none =>
           simp only [Option.map_none]; exact htrial
 
+/-- Every raw factor of the cost-based hybrid comes from one of its three
+dispatch branches: the classical tier's certified output, the CLD lattice
+tier's certified output, or the `factorSlowTrial` totality backstop. This is
+the hybrid analogue of `factorWithBound_entry_mem_raw_source`; it exposes the
+branch source without leaking the private `factorizationOfFactors` guard, so
+the Mathlib-side irreducibility assembly can case-split over the branches. -/
+theorem factorHybridFactors_mem_source (f : ZPoly) {raw : ZPoly}
+    (hmem : raw ∈ (factorHybridFactors f).toList) :
+    (∃ cf, factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
+        some cf ∧ raw ∈ cf.toList) ∨
+      (∃ cf, factorLatticeFactorsWithBound f (factorFastPrecisionCap f) =
+        some cf ∧ raw ∈ cf.toList) ∨
+      raw ∈ (factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).toList := by
+  unfold factorHybridFactors at hmem
+  rcases Option.eq_none_or_eq_some
+      (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) with hcf | ⟨cf, hcf⟩
+  · simp only [hcf] at hmem
+    rcases Option.eq_none_or_eq_some
+        (factorLatticeFactorsWithBound f (factorFastPrecisionCap f)) with hl | ⟨cf, hl⟩
+    · simp only [hl] at hmem
+      exact Or.inr (Or.inr hmem)
+    · simp only [hl] at hmem
+      rcases Classical.em (Factorization.product (factorizationOfFactors f cf) = f) with hp | hp
+      · rw [if_pos hp] at hmem; exact Or.inr (Or.inl ⟨cf, hl, hmem⟩)
+      · rw [if_neg hp] at hmem; exact Or.inr (Or.inr hmem)
+  · simp only [hcf] at hmem
+    rcases Classical.em (Factorization.product (factorizationOfFactors f cf) = f) with hp | hp
+    · rw [if_pos hp] at hmem; exact Or.inl ⟨cf, hcf, hmem⟩
+    · rw [if_neg hp] at hmem; exact Or.inr (Or.inr hmem)
+
 /-- Smoke-test driver for the core-coordinate fast recovery: select the good
 prime exactly as the fast path does, then run `coreRecover?` against the
 `coreLiftData` (`monicTarget`) lift at the public precision cap.  Used by the
@@ -10581,6 +10611,14 @@ theorem factor_scalar (f : ZPoly) :
     (factor 0).scalar = 0 := by
   rw [factor_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar_zero (factorHybridFactors 0)
+
+/-- The default factorization of `0` records no polynomial factors: the
+square-free core of `0` is the unit `1`, so every reassembled raw factor is
+dropped by the `shouldRecordPolynomialFactor` filter.  This lets the capstone
+`factor_irreducible_of_nonUnit` discharge the degenerate `f = 0` case
+vacuously, without a nonzero hypothesis. -/
+theorem factor_zero_factors : (factor (0 : ZPoly)).factors = #[] := by
+  decide
 
 theorem factor_scalar_of_leadingCoeff_neg
     {f : ZPoly} (hf : f ≠ 0) (hneg : DensePoly.leadingCoeff f < 0) :

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -23,7 +23,17 @@ irreducible in the executable `Hex.ZPoly` sense.
 -/
 theorem factor_irreducible_of_nonUnit (f : Hex.ZPoly) :
     ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
-  sorry
+  intro entry hentry
+  by_cases hf : f = 0
+  · subst hf
+    rw [Hex.factor_zero_factors] at hentry
+    simp at hentry
+  · have hmem : entry ∈ (Hex.factor f).factors.toList := Array.mem_toList_iff.mpr hentry
+    obtain ⟨raw, hraw_mem, hentry_eq⟩ := Hex.factor_entry_mem_raw_source f entry hmem
+    have hrec := Hex.factor_entry_shouldRecord f entry hmem
+    rw [hentry_eq] at hrec ⊢
+    exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
+      (factorHybridFactors_factor_irreducible f hf hraw_mem hrec)
 
 /--
 Every polynomial factor emitted by the default executable factorization is

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -7302,4 +7302,175 @@ theorem reassemblyExpansionComplete_classicalCore_of_ne_zero
     Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne_zero hrp_ne_zero hfp_dvd_rp
   omega
 
+/-- **Trial-branch raw-factor irreducibility (hybrid guard form).**
+
+Restatement of `factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`
+for the cost-based hybrid, where the trial arm fires as the totality backstop
+rather than off `factorFast … = none`.  Because the deg-0 (constant-core)
+short-circuit is now reachable, the raw output can contain the unit `1`, so the
+statement carries the `shouldRecordPolynomialFactor` guard that excludes it.  The
+two positive-degree arms reuse the quadratic and exhaustive integer-trial
+completeness/irreducibility content. -/
+theorem factorSlowTrialFactorsWithBound_factor_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    {raw : Hex.ZPoly}
+    (hmem : raw ∈ (Hex.factorSlowTrialFactorsWithBound f
+      (Hex.ZPoly.defaultFactorCoeffBound f)).toList)
+    (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
+    Hex.ZPoly.Irreducible raw := by
+  have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
+  have hcore_prim :=
+    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf
+  simp only [Hex.factorSlowTrialFactorsWithBound] at hmem
+  by_cases hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
+  · rw [if_pos hdeg] at hmem
+    have hcomplete := Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg
+    rcases Hex.reassemblePolynomialFactors_mem_xPower_or_core_of_expansionComplete
+        _ _ raw hcomplete hmem with hx | hcore
+    · exact Hex.xPowerFactorArray_irreducible _ raw hx
+    · exfalso
+      have hraw_one : raw = 1 := by
+        have hraw_core : raw = (Hex.normalizeForFactor f).squareFreeCore := by
+          simpa using hcore
+        rw [hraw_core, Hex.squareFreeCore_eq_one_of_constant_of_ne_zero f hf hdeg]
+      rw [hraw_one, Hex.normalizeFactorSign_one, Hex.shouldRecordPolynomialFactor_one] at hrec
+      exact absurd hrec (by decide)
+  · rw [if_neg hdeg] at hmem
+    cases hquad :
+        Hex.quadraticIntegerRootFactors? (Hex.normalizeForFactor f).squareFreeCore with
+    | some coreFactors =>
+        simp only [hquad] at hmem
+        refine Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+          _ _ ?_ ?_ hmem
+        · exact IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
+            f hf hquad
+        · intro factor hfmem
+          exact Hex.quadraticIntegerRootFactors?_factor_irreducible_of_primitive
+            hcore_pos hcore_prim hquad hfmem
+    | none =>
+        simp only [hquad] at hmem
+        refine Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+          _ _ ?_ ?_ hmem
+        · exact reassemblyExpansionComplete_exhaustiveIntegerTrial_of_ne_zero f hf
+        · exact
+            exhaustiveIntegerTrialCoreFactorsWithBound_normalizeForFactor_factor_irreducible_at_default
+              f hf
+
+/-- **Classical-branch raw-factor irreducibility.**
+
+Every raw factor of the classical tier's output `factorClassicalFactorsWithBound
+f (defaultFactorCoeffBound f)` that passes the recorded-factor filter is
+irreducible.  Case-split over the branch: deg-0 constant short-circuit, quadratic
+integer-root short-circuit, and the size-ordered recombination residual.
+
+The residual arm composes the bound-parameterized classical core irreducibility
+`classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` (#8510) with
+the reassembly-completeness discharger
+`reassemblyExpansionComplete_classicalCore_of_ne_zero` (#8511) through the lift
+`reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`.
+The bound is handled at `defaultFactorCoeffBound f` directly (validity from
+`core ∣ f`, precision from `exhaustiveLiftBound_precision`), so no
+`defaultFactorCoeffBound core ≤ defaultFactorCoeffBound f` monotonicity is needed. -/
+theorem factorClassicalFactorsWithBound_factor_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    {cf : Array Hex.ZPoly}
+    (hcf : Hex.factorClassicalFactorsWithBound f
+      (Hex.ZPoly.defaultFactorCoeffBound f) = some cf)
+    {raw : Hex.ZPoly}
+    (hmem : raw ∈ cf.toList)
+    (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
+    Hex.ZPoly.Irreducible raw := by
+  have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
+  have hcore_prim :=
+    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf
+  simp only [Hex.factorClassicalFactorsWithBound] at hcf
+  by_cases hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
+  · rw [if_pos hdeg] at hcf
+    obtain rfl := Option.some.inj hcf
+    have hcomplete := Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg
+    rcases Hex.reassemblePolynomialFactors_mem_xPower_or_core_of_expansionComplete
+        _ _ raw hcomplete hmem with hx | hcore
+    · exact Hex.xPowerFactorArray_irreducible _ raw hx
+    · exfalso
+      have hraw_one : raw = 1 := by
+        have hraw_core : raw = (Hex.normalizeForFactor f).squareFreeCore := by
+          simpa using hcore
+        rw [hraw_core, Hex.squareFreeCore_eq_one_of_constant_of_ne_zero f hf hdeg]
+      rw [hraw_one, Hex.normalizeFactorSign_one, Hex.shouldRecordPolynomialFactor_one] at hrec
+      exact absurd hrec (by decide)
+  · rw [if_neg hdeg] at hcf
+    cases hquad :
+        Hex.quadraticIntegerRootFactors? (Hex.normalizeForFactor f).squareFreeCore with
+    | some coreFactors =>
+        simp only [hquad] at hcf
+        obtain rfl := Option.some.inj hcf
+        refine Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+          _ _ ?_ ?_ hmem
+        · exact IntReductionMod.reassemblyExpansionComplete_quadraticIntegerRootFactors_of_ne_zero
+            f hf hquad
+        · intro factor hfmem
+          exact Hex.quadraticIntegerRootFactors?_factor_irreducible_of_primitive
+            hcore_pos hcore_prim hquad hfmem
+    | none =>
+        simp only [hquad] at hcf
+        cases hsel :
+            Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore with
+        | none => simp [hsel] at hcf
+        | some primeData =>
+            simp only [hsel, Option.bind_some] at hcf
+            cases hcore :
+                Hex.classicalCoreFactorsWithBound (Hex.normalizeForFactor f).squareFreeCore
+                  (Hex.ZPoly.defaultFactorCoeffBound f) primeData with
+            | none => simp [hcore] at hcf
+            | some coreFactors =>
+                simp only [hcore, Option.map_some] at hcf
+                obtain rfl := Option.some.inj hcf
+                -- Residual arm: the size-ordered classical recombination core.
+                -- Per-factor irreducibility from #8510, reassembly completeness
+                -- from #8511.
+                exact
+                  Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
+                    _ _
+                    (reassemblyExpansionComplete_classicalCore_of_ne_zero
+                      f hf primeData hsel hdeg hcore)
+                    (classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
+                      f hf primeData hsel hdeg hcore)
+                    hmem
+
+/-- **Lattice-branch raw-factor irreducibility (pending #8417).**
+
+The remaining expected blocker for `factor_irreducible_of_nonUnit`: every raw
+factor of the CLD lattice tier's output `factorLatticeFactorsWithBound f
+(factorFastPrecisionCap f)` that passes the recorded-factor filter is
+irreducible.  This holds once the van Hoeij/CLD method is verified to land on
+minimal (irreducible) subsets; see #8417. -/
+theorem factorLatticeFactorsWithBound_factor_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    {cf : Array Hex.ZPoly}
+    (hcf : Hex.factorLatticeFactorsWithBound f
+      (Hex.factorFastPrecisionCap f) = some cf)
+    {raw : Hex.ZPoly}
+    (hmem : raw ∈ cf.toList)
+    (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
+    Hex.ZPoly.Irreducible raw := by
+  sorry
+
+/-- **Hybrid raw-factor irreducibility assembly.**
+
+Every raw factor of `factorHybridFactors f` that passes the recorded-factor
+filter is irreducible, dispatched over the three tiers via
+`factorHybridFactors_mem_source`: classical, lattice (pending #8417), and the
+`factorSlowTrial` totality backstop. -/
+theorem factorHybridFactors_factor_irreducible
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    {raw : Hex.ZPoly}
+    (hmem : raw ∈ (Hex.factorHybridFactors f).toList)
+    (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
+    Hex.ZPoly.Irreducible raw := by
+  rcases Hex.factorHybridFactors_mem_source f hmem with
+    ⟨cf, hcf, hraw⟩ | ⟨cf, hcf, hraw⟩ | htrial
+  · exact factorClassicalFactorsWithBound_factor_irreducible f hf hcf hraw hrec
+  · exact factorLatticeFactorsWithBound_factor_irreducible f hf hcf hraw hrec
+  · exact factorSlowTrialFactorsWithBound_factor_irreducible f hf htrial hrec
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260701T200000Z_issue-8414-assembly.md
+++ b/progress/20260701T200000Z_issue-8414-assembly.md
@@ -1,0 +1,84 @@
+# Issue #8414 — assemble `factor_irreducible_of_nonUnit` over the hybrid's three branches
+
+## Accomplished
+
+Built the full irreducibility assembly for the cost-based hybrid factorisation
+(`Hex.factor = factorHybrid`) and closed `factor_irreducible_of_nonUnit`
+against it, modulo two clearly-scoped branch `sorry`s.
+
+- **Basic.lean (Mathlib-free):**
+  - `factorHybridFactors_mem_source` — every raw factor of `factorHybridFactors f`
+    comes from the classical / lattice / trial branch, stated without leaking the
+    private `factorizationOfFactors` guard (uses `Option.eq_none_or_eq_some` +
+    `simp only` to dodge a `whnf` blowup on `factorFastPrecisionCap`).
+  - `factor_zero_factors : (factor 0).factors = #[]` (by `decide`) for the
+    degenerate `f = 0` capstone case.
+- **IntReductionMod.lean (Mathlib layer):**
+  - `factorSlowTrialFactorsWithBound_factor_irreducible` — trial branch **fully
+    proven**: the hybrid-guard restatement of the surviving `…_of_fast_none`,
+    carrying the `shouldRecordPolynomialFactor` guard so the now-reachable deg-0
+    constant arm (which emits the unit `1`) is discharged by the guard.
+  - `factorClassicalFactorsWithBound_factor_irreducible` — classical branch: deg-0
+    and quadratic arms **proven**; the size-ordered recombination residual arm is
+    a scoped `sorry`.
+  - `factorLatticeFactorsWithBound_factor_irreducible` — scoped `sorry` (#8417).
+  - `factorHybridFactors_factor_irreducible` — assembly over the three tiers.
+- **FactorSoundness.lean:** `factor_irreducible_of_nonUnit` closed against the
+  assembly (f = 0 via `factor_zero_factors`; nonzero via the branch source +
+  `factor_entry_shouldRecord` + `zpolyIrreducible_normalizeFactorSign_…`).
+
+`lake build HexBerlekampZassenhausMathlib` is green (only the two new scoped
+`sorry`s plus the pre-existing unrelated `Hex.ZPoly.isIrreducible_iff` sorry).
+
+## Update (after #8510 / #8511 landed)
+
+The classical residual arm is now **closed**. Rebased onto `main` (which carries
+#8510 `classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` and
+#8511 `reassemblyExpansionComplete_classicalCore_of_ne_zero`) and wired the residual
+to a two-lemma composition through
+`reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible`.
+The predicted "monotonicity gap" was a red herring: #8510 discharges the bound at
+`defaultFactorCoeffBound f` directly (validity from `core ∣ f`, precision from
+`exhaustiveLiftBound_precision`). The lone remaining blocker on
+`factor_irreducible_of_nonUnit` is now the **lattice** arm (#8417), exactly as
+#8414 anticipated. `lake build HexBerlekampZassenhausMathlib` green.
+
+## Original frontier (historical)
+
+Two branch obligations remained at first, both isolated as one-line-goal `sorry`s:
+
+1. **Classical residual** (`IntReductionMod.lean`, in
+   `factorClassicalFactorsWithBound_factor_irreducible`, `none`/`none`/`some`
+   arm) — now closed via #8510/#8511. Originally: composing the landed #8413
+   `classicalCoreFactorsWithBound_factor_irreducible`
+   with the reassembly lift needs infrastructure that does **not** exist yet:
+   - classical-core structural lemmas (cover product = core, per-factor
+     sign-normalisation, per-factor positive degree) to discharge
+     `reassemblyExpansionComplete` via
+     `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`.
+     Only `scaledRecombinationSmartAux_product` / `_shouldRecord` exist; there is
+     no `_normalizeFactorSign` / `_degree` for the smart core.
+   - a Mignotte bound relation `defaultFactorCoeffBound core ≤
+     defaultFactorCoeffBound f` (core = `squareFreeCore`). The branch runs the
+     core search at bound `defaultFactorCoeffBound f`, but the #8413 natural-bound
+     lemma requires `defaultFactorCoeffBound core ≤ B`. The exhaustive/trial path
+     sidesteps this (works with `defaultFactorCoeffBound f` as the coefficient
+     bound plus a validity hypothesis), but the smart-recombination correctness
+     lemma `RecoveredSmartSearch.covers` is stated with `defaultFactorCoeffBound
+     core`. A `defaultFactorCoeffBound core ≤ defaultFactorCoeffBound (toMonic
+     core).monic` route also needs an unproven Mignotte-scaling lemma.
+
+2. **Lattice** — `factorLatticeFactorsWithBound_factor_irreducible`, blocked on
+   #8417 (verify van Hoeij/CLD lands on minimal subsets). Expected by the issue.
+
+## Next step
+
+Either land the classical-core structural lemmas + bound relation (a real
+sub-project, not the "just compose" the directive assumed), or refine #8414 to
+carve the classical residual into its own successor issue. The assembly, trial
+branch, and classical deg-0/quadratic arms are done and green.
+
+## Blockers
+
+- Classical residual needs new Mignotte / smart-core infrastructure (above).
+- Lattice arm needs #8417.


### PR DESCRIPTION
This PR builds the full irreducibility assembly for the cost-based hybrid factorisation (`Hex.factor = factorHybrid`) and closes `factor_irreducible_of_nonUnit` down to the single lattice-tier blocker (#8417), exactly as #8414 asks. With #8510 and #8511 now landed, the classical branch is fully proven; the only remaining `sorry` in the chain is `factorLatticeFactorsWithBound_factor_irreducible`, pending #8417.

The Mathlib-free layer gains `factorHybridFactors_mem_source`, which exposes that every raw factor of `factorHybridFactors f` comes from the classical, lattice, or `factorSlowTrial` branch without leaking the private `factorizationOfFactors` product guard, plus `factor_zero_factors` for the degenerate `f = 0` capstone case. The Mathlib layer proves `factorSlowTrialFactorsWithBound_factor_irreducible` in full — the hybrid-guard restatement of the surviving `…_of_fast_none`, carrying the `shouldRecordPolynomialFactor` guard so the now-reachable degree-0 constant arm (which emits the unit `1`) is discharged rather than falsely required irreducible — proves the classical branch across all three arms (deg-0 constant, quadratic short-circuit, and the size-ordered recombination residual composed from `classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` of #8510 and `reassemblyExpansionComplete_classicalCore_of_ne_zero` of #8511), assembles `factorHybridFactors_factor_irreducible` over the three tiers, and closes `factor_irreducible_of_nonUnit` against it.

The classical residual runs the core search at `defaultFactorCoeffBound f`; the precision is discharged directly there (divisor-validity from `core ∣ f`, precision from `exhaustiveLiftBound_precision`), so no `defaultFactorCoeffBound core ≤ defaultFactorCoeffBound f` monotonicity is needed. Per #8414 the top-level sorry is deliberately not closed while a branch is unproven: the lattice arm remains the lone blocker until #8417 lands, at which point `factor_irreducible_of_nonUnit` closes with no further changes here.

`lake build HexBerlekampZassenhausMathlib` is green; the only new warning is the single lattice `sorry`.

🤖 Prepared with Claude Code