### PR TITLE
doc: skeptical plain-language pass over every manual chapter

### DIFF
--- a/HexManual/Chapters/HexArith.lean
+++ b/HexManual/Chapters/HexArith.lean
@@ -39,10 +39,12 @@ Euclidean algorithm in three flavours (`Nat`, GMP-backed `Int`, and
 primality test that produces a primality witness without `native_decide`
 or a hardcoded prime list.
 
-Everything here is executable. Some wide-word operations carry an
-`@[extern]` C implementation for speed, but each is defined by a Lean
-model the C code is proved to match, so the library has a meaning
-independent of the native binding; see
+Everything here is executable. Some wide-word operations also carry an
+`@[extern]` C implementation for speed. The Lean definition is the
+meaning, and proofs and the kernel reduce it directly. `@[extern]` only
+redirects compiled code and the interpreter to the C version, which is
+*trusted* to match the Lean definition, never proved to. The `Nat`-level
+laws below are stated about the Lean definitions. See
 {ref "hex-arith-cross-references"}[Cross-references].
 
 # Wide-word `UInt64` operations
@@ -88,9 +90,8 @@ single-word range.
 {docstring UInt64.subBorrow_snd}
 
 These four operations are `@[extern]`-backed for speed, so they run
-through a C implementation in compiled code; their Lean models are what
-the manual's evaluated examples below avoid and what the laws above are
-stated against.
+through a C implementation in compiled code. The laws above are stated
+about their Lean definitions.
 
 # Extended GCD
 %%%
@@ -112,6 +113,21 @@ that destructure the returned triple.
 
 {docstring HexArith.extGcd_spec}
 
+The `Int` variant runs the same recurrence over `Int`, with the GMP
+`mpz_gcdext` extern as its trusted runtime replacement.
+
+{docstring HexArith.Int.extGcd}
+
+{docstring HexArith.Int.extGcd_spec}
+
+The `UInt64` variant interprets its word inputs by their natural values,
+returning the gcd as a word and the Bezout coefficients as signed
+integers.
+
+{docstring HexArith.UInt64.extGcd}
+
+{docstring HexArith.UInt64.extGcd_spec}
+
 # Barrett reduction
 %%%
 tag := "hex-arith-barrett"
@@ -121,14 +137,14 @@ Barrett reduction computes `T mod p` for a small modulus `p` using a
 single precomputed reciprocal, replacing the hardware division with one
 multiply-and-shift and at most one corrective subtraction. The
 `Nat`-level routine states the arithmetic abstractly over the radix
-{name}`barrettRadix`; the reciprocal is `pinv = floor(R / p)`.
+{name}`barrettRadix`. The reciprocal is `pinv = floor(R / p)`.
 
 {docstring barrettRadix}
 
 {docstring barrettReduceNat}
 
 The reciprocal approximates the true quotient from below, never
-overshooting by more than one; these two bounds make the single
+overshooting by more than one. These two bounds make the single
 corrective subtraction sufficient.
 
 {docstring barrettQuotient_le_div}
@@ -183,7 +199,7 @@ modulus below the radix.
 {docstring redcNat_lt}
 
 The executable side carries the machine-word Montgomery parameters in
-a {name}`MontCtx`; {name}`redc` consumes a two-word product `(Thi, Tlo)`
+a {name}`MontCtx`. {name}`redc` consumes a two-word product `(Thi, Tlo)`
 and returns one reduced residue, proved to match the `Nat` model and to
 stay canonical.
 
@@ -218,13 +234,12 @@ precomputed list.
 tag := "hex-arith-worked"
 %%%
 
-The block below exercises the pure (non-`@[extern]`) computational
-surface: the `Nat` extended GCD, the trial-division test, and the
-`Nat`-level Barrett reducer. Each `#guard` is checked when the chapter
-is built, so the expected outputs are guaranteed to match what the
-executable implementation produces. The wide-word operations are
-omitted here because their `@[extern]` C binding is not available to the
-manual's evaluator; they are documented by signature and law above.
+The block below runs the pure (non-`@[extern]`) operations: the `Nat`
+extended GCD, the trial-division test, and the `Nat`-level Barrett
+reducer. The wide-word operations are `@[extern]`: the interpreter runs
+their native C symbol rather than the Lean definition, and that symbol is
+not linked into the manual's evaluator, so `#eval` and `#guard` cannot
+run them. They are documented by signature and law above.
 
 ```lean
 open HexArith Hex.Nat
@@ -263,7 +278,7 @@ tag := "hex-arith-cross-references"
 * The wide-word multiply and carry primitives are `@[extern]`-backed by
   the C sources in `HexArith/ffi/` (`wide_arith.c`, `mpz_gcdext.c`), and
   the {ref "hex-arith-wide"}[`Nat`-level laws] above are the
-  specification those bindings are proved against; the library's meaning
+  specification those bindings are proved against. The library's meaning
   does not depend on the native code being linked.
 * The arithmetic here has no Mathlib correspondence library of its own.
   The Mathlib correspondences live in the consuming libraries' `*Mathlib`

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -54,8 +54,8 @@ the first step at which a zero pivot with no replacement row was found
 {docstring Hex.Matrix.BareissData}
 
 The sign contributed by the row swaps and the encoded determinant are
-read off that record. A recorded singular step encodes determinant zero;
-otherwise the determinant is the last diagonal entry of the terminal
+read off that record. A recorded singular step encodes determinant zero.
+Otherwise the determinant is the last diagonal entry of the terminal
 matrix with the swap sign applied.
 
 {docstring Hex.Matrix.BareissData.sign}
@@ -68,7 +68,7 @@ tag := "hex-bareiss-entry"
 %%%
 
 The public entry points run the row-pivoting elimination.
-{name}`Hex.Matrix.bareissData` returns the full record;
+{name}`Hex.Matrix.bareissData` returns the full record.
 {name}`Hex.Matrix.bareiss` returns just the integer determinant. The
 no-pivot variants skip the pivot search, for inputs whose leading pivots
 are already nonzero.
@@ -83,8 +83,8 @@ are already nonzero.
 
 The division at each step is `Int.divExact` (a GMP-backed
 `mpz_divexact`), which is always exact and carries its divisibility
-proof; the bordered minors track the elimination invariant the
-correctness development relies on.
+proof. The bordered minors are the intermediate determinants the
+correctness proof uses as its elimination invariant.
 
 {docstring Hex.Matrix.borderedMinor}
 
@@ -94,15 +94,14 @@ tag := "hex-bareiss-theorems"
 %%%
 
 `HexBareiss` proves the structural facts about the elimination: that the
-packaged record is exactly the structured pivot
-loop finished into determinant data, and that the public
-{name}`Hex.Matrix.bareiss` value agrees with the determinant encoded by
-{name}`Hex.Matrix.bareissData`. It does not prove that the Bareiss
-determinant equals the Leibniz {name}`Hex.Matrix.det`; that
+packaged record is the pivot loop's final state packaged as determinant
+data, and that the public {name}`Hex.Matrix.bareiss` value agrees with
+the determinant encoded by {name}`Hex.Matrix.bareissData`. It does not prove that the Bareiss
+determinant equals the Leibniz {name}`Hex.Matrix.det`. That
 identification is in `HexBareissMathlib`. Within `HexBareiss` itself the
-agreement is pinned as value-level conformance fixtures: a fixed bank of
-matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M` is checked at
-build time.
+agreement is checked at build time by value-level conformance fixtures: a
+fixed bank of matrices on which `Hex.Matrix.bareiss M = Hex.Matrix.det M`
+is verified.
 
 {docstring Hex.Matrix.bareissData_eq_finish_pivotLoop}
 
@@ -117,7 +116,7 @@ The block below builds the integer matrix with rows `(2, 0, 1)`,
 `(1, 3, 2)`, and `(0, 1, 1)`, whose determinant is `3`. The Bareiss
 route agrees with the Leibniz {ref "hex-determinant"}[determinant] on it,
 the identity has determinant one, and a matrix with a dependent row pair
-is singular. Every `#guard` is checked when the chapter is built.
+is singular.
 
 ```lean
 open Hex Hex.Matrix

--- a/HexManual/Chapters/HexConway.lean
+++ b/HexManual/Chapters/HexConway.lean
@@ -25,7 +25,7 @@ tag := "hex-conway-intro"
 
 A *Conway polynomial* `C(p, n)` is the canonical irreducible degree-`n`
 polynomial over the prime field `𝔽_p` used to give a standard,
-compatible presentation of the finite field `𝔽_{pⁿ}`. The full story
+compatible presentation of the finite field `𝔽_{pⁿ}`. The full treatment
 of Conway polynomials has three tiers: a Tier 1 lookup of committed
 table entries, Tier 2 proofs that those entries satisfy the Conway
 compatibility conditions across the subfield lattice, and Tier 3
@@ -35,12 +35,12 @@ executable Tier 1 library: it exposes the imported
 Conway table as a lookup, keeping the baseline lookup separate from the
 later compatibility and search work.
 
-`HexConway` is Mathlib-free; it depends only on `HexBerlekamp` (for the
+`HexConway` is Mathlib-free. It depends only on `HexBerlekamp` (for the
 Rabin irreducibility checker that certifies each committed entry) and
 the prime-field polynomial library it reaches through it. Each supported
 `(p, n)` pair commits a named polynomial literal, a machine-checked
 irreducibility proof, and a {name}`Hex.Conway.SupportedEntry` witness
-packaging the lookup together with its proof; see
+packaging the lookup together with its proof. See
 {ref "hex-conway-cross-references"}[Cross-references].
 
 # The lookup
@@ -50,7 +50,7 @@ tag := "hex-conway-lookup"
 
 The committed data is a raw coefficient table, stored ascending by
 degree and keyed on the pair `(p, n)`. It returns `none` on any pair
-outside the committed slice.
+outside the committed table.
 
 {docstring Hex.Conway.luebeckConwayCoeffs?}
 
@@ -62,7 +62,7 @@ through the normalizing constructor.
 
 The main entry point composes the two: it looks up the coefficient
 list and, on a hit, builds the polynomial. The supported coverage is
-`p ∈ {2, 3, 5, 7, 11, 13}` and `n ∈ {1, …, 6}`; every other pair
+`p ∈ {2, 3, 5, 7, 11, 13}` and `n ∈ {1, …, 6}`. Every other pair
 returns `none` rather than triggering Tier 2 compatibility checks or
 Tier 3 search.
 
@@ -91,9 +91,9 @@ named `supportedEntry_p_n` (for example {name}`Hex.Conway.supportedEntry_2_3`).
 tag := "hex-conway-worked"
 %%%
 
-The block below exercises the lookup on the supported pair `(2, 3)` (the
+The block below runs the lookup on the supported pair `(2, 3)` (the
 Conway polynomial `C(2, 3) = 1 + x + x³` over `𝔽₂`) and on two
-unsupported pairs. Each `#guard` is checked when the chapter builds.
+unsupported pairs.
 
 ```lean
 open Hex Hex.Conway
@@ -153,16 +153,16 @@ tag := "hex-conway-cross-references"
 
 `HexConway` is near the top of the finite-field portion of the DAG:
 
-* `HexBerlekamp` is the direct dependency: its Rabin irreducibility
-  test, and the soundness theorem `rabinTest_imp_irreducible` lifting a
-  passing certificate to {name}`Hex.FpPoly.Irreducible`, is what
-  certifies every committed entry in the
+* `HexBerlekamp` is the direct dependency. Its Rabin irreducibility
+  test and the soundness theorem `rabinTest_imp_irreducible` (lifting a
+  passing certificate to {name}`Hex.FpPoly.Irreducible`) certify every
+  committed entry in the
   {ref "hex-conway-correctness"}[correctness section]. The prime-field
   polynomial type {name}`Hex.FpPoly` and its arithmetic are reached
   transitively through it.
 * The Tier 2 compatibility proofs (Conway conditions across the
   subfield lattice) and Tier 3 search live in separate libraries above
-  this one; this chapter documents only the Tier 1 committed lookup.
-* `HexConway` is Mathlib-free and never depends on Mathlib; the Mathlib
-  correspondence for the finite-field theory it draws on flows through
-  the higher layers' `*Mathlib` counterparts, not through this library.
+  this one. This chapter documents only the Tier 1 committed lookup.
+* `HexConway` is Mathlib-free and never depends on Mathlib. The Mathlib
+  correspondence proofs for the finite-field theory it draws on live in
+  the higher layers' `*Mathlib` counterparts, not in this library.

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -30,7 +30,7 @@ with the Mathlib correspondence in
 `HexDeterminant` is the determinant of a dense square matrix via the
 Leibniz formula, with the cofactor and adjugate theory built on it. It
 depends only on {ref "hex-matrix"}[HexMatrix] and is generic over the
-coefficient ring; the row-operation, Laplace, Cauchy-Binet, and Plücker
+coefficient ring. The row-operation, Laplace, Cauchy-Binet, and Plücker
 results hold over a commutative ring.
 
 The Leibniz determinant is the definition: correct by construction but
@@ -49,7 +49,7 @@ tag := "hex-determinant-leibniz"
 %%%
 
 The reference determinant is the Leibniz formula: a signed sum over all
-permutation vectors of the product of the selected entries.
+permutations of the product of the selected entries.
 
 {docstring Hex.Matrix.det}
 
@@ -71,7 +71,7 @@ transpose.
 
 {docstring Hex.Matrix.det_colSwap}
 
-The determinant is linear in each column separately; the additive law in
+The determinant is linear in each column separately. The additive law in
 one column is the building block for Laplace expansion.
 
 {docstring Hex.Matrix.det_setCol_add}
@@ -81,7 +81,7 @@ one column is the building block for Laplace expansion.
 tag := "hex-determinant-cofactor"
 %%%
 
-Deleting one row and one column gives a minor; the signed minor is a
+Deleting one row and one column gives a minor. The signed minor is a
 cofactor, and the determinant is the alternating sum of entries against
 their cofactors along any fixed row or column.
 
@@ -99,9 +99,9 @@ tag := "hex-determinant-adjugate"
 %%%
 
 The adjugate is the transpose of the cofactor matrix. Its defining
-identity, `M * adjugate M = det M • identity`, is the executable
-Cramer's-rule kernel: over a commutative ring it holds without any
-invertibility hypothesis.
+identity, `M * adjugate M = det M • identity`, is what Cramer's rule
+rests on. Over a commutative ring it holds without any invertibility
+hypothesis.
 
 {docstring Hex.Matrix.adjugate}
 
@@ -115,8 +115,8 @@ tag := "hex-determinant-identities"
 The determinant of a Gram matrix expands as a sum over column tuples
 (the Cauchy-Binet formula), and the three-term Plücker /
 Desnanot-Jacobi identity relates the determinants of a matrix and its
-bordered minors. The triangular-determinant law reads the determinant
-of an upper- or lower-triangular matrix off its diagonal.
+bordered minors. The triangular-determinant law gives the determinant of an upper- or
+lower-triangular matrix as the product of its diagonal entries.
 
 {docstring Hex.Matrix.det_gramMatrix_eq_sum_columnTuples}
 
@@ -133,7 +133,6 @@ The block below builds the integer matrix with rows `(2, 0, 1)`,
 `(1, 3, 2)`, and `(0, 1, 1)`, whose determinant is `3`. The identity has
 determinant one, the determinant is invariant under transpose, swapping
 two rows negates it, and a matrix with a dependent row pair is singular.
-Every `#guard` is checked when the chapter is built.
 
 ```lean
 open Hex Hex.Matrix

--- a/HexManual/Chapters/HexGF2.lean
+++ b/HexManual/Chapters/HexGF2.lean
@@ -43,8 +43,8 @@ irreducibility test.
 
 `HexGF2` is Mathlib-free and depends only on
 {ref "hex-poly"}[`HexPoly`], the generic dense-polynomial library, which
-supply the shared polynomial vocabulary the packed representation is
-checked against; see {ref "hex-gf2-cross-references"}[Cross-references].
+supplies the shared polynomial vocabulary the packed representation is
+checked against. See {ref "hex-gf2-cross-references"}[Cross-references].
 
 # The packed word representation
 %%%
@@ -104,7 +104,7 @@ and the compiled path merely runs faster.
 Lifting the word-level product to packed polynomials gives
 {name}`Hex.GF2Poly.mul` (the `*` of the `Mul GF2Poly` instance). Its
 correctness is stated as the carry-less convolution coefficient law,
-the reference specification `HexGF2Mathlib` is checked against.
+which `HexGF2Mathlib` is checked against.
 
 {docstring Hex.GF2Poly.coeff_mul_diagonal}
 
@@ -153,9 +153,8 @@ square-and-multiply exponentiation {name}`Hex.GF2n.pow`.
 tag := "hex-gf2-worked"
 %%%
 
-The first block exercises the packed operations: the bit accessors,
-XOR addition, the shift, and a gcd. Each `#guard` is checked when the
-chapter is built.
+The first block runs the packed operations: the bit accessors, XOR
+addition, the shift, and a gcd.
 
 ```lean
 open Hex Hex.GF2Poly
@@ -192,7 +191,7 @@ The second block works inside the AES field `GF(2⁸)`, presented by the
 Rijndael modulus `x⁸ + x⁴ + x³ + x + 1` (the word `0x1B` above the
 leading `x⁸`). The irreducibility of that modulus is the committed
 theorem {name}`Hex.GF2Poly.aes_modulus_irreducible`, so the field type
-typechecks; the byte `0x53` and its inverse `0xCA` are the standard AES
+typechecks. The byte `0x53` and its inverse `0xCA` are the standard AES
 worked pair.
 
 ```lean
@@ -261,6 +260,6 @@ Where `HexGF2` fits in the executable DAG:
   it (the packed characteristic-two entries of the `GFq` constructors),
   which reuse its `GF2n`/`GF2nPoly` wrappers and committed
   irreducibility certificates.
-* `HexGF2` is Mathlib-free; the Mathlib correspondence for the `GF(2ⁿ)`
-  field theory flows through the `*Mathlib` counterparts of the
-  libraries that build on it, not through this library.
+* `HexGF2` is Mathlib-free. The Mathlib correspondence for the `GF(2ⁿ)`
+  field theory is provided by the `*Mathlib` counterparts of the
+  libraries that build on it, not by this library.

--- a/HexManual/Chapters/HexGFq.lean
+++ b/HexManual/Chapters/HexGFq.lean
@@ -38,7 +38,7 @@ The *packed* characteristic-two family, for committed binary entries,
 instead routes through the single-word `HexGF2` representation, trading
 the generic quotient for machine-word arithmetic while certifying, at
 elaboration time, that the packed modulus is the same Conway polynomial.
-`HexGFq` is Mathlib-free; everything below typechecks against the
+`HexGFq` is Mathlib-free. Everything below typechecks against the
 executable libraries only.
 
 # The committed-entry mechanism
@@ -57,7 +57,7 @@ committed {name}`Hex.Conway.SupportedEntry` for the pair `(p, n)`. The
 library commits one instance per committed table cell, named
 `committedEntry_p_n` (for example `committedEntry_2_3`), covering
 `p ∈ {2, 3, 5, 7, 11, 13}` and `n ∈ {1, …, 6}`. With the instance in
-scope, the short field spelling resolves the witness automatically; where
+scope, the short field spelling resolves the witness automatically. Where
 a proof needs to name the witness, the explicit form still takes it as an
 argument.
 
@@ -74,9 +74,10 @@ sibling {name}`Hex.GFqC` is the same field with the entry resolved by
 {name}`Hex.Conway.CommittedEntry` synthesis, so `GFqC 2 3` denotes
 `GF(8)` with no further arguments.
 
-Elements are built by reducing a raw `FpPoly` into the field and read
-back through the canonical representative projection. The generic
-constructor:
+Each field element is a polynomial over `F_p` of degree below `n`: the
+remainder of an `FpPoly` modulo the field's Conway polynomial. `repr`
+returns that remainder. The generic constructor reduces an arbitrary
+`FpPoly` to it:
 
 {docstring Hex.GFq.ofPoly}
 
@@ -125,12 +126,11 @@ instances are named `packedGF2Entry_2_n`.
 
 The optimized field itself is {name}`Hex.GF2q`: for a committed
 `PackedGF2Entry n`, the single-word `HexGF2` field `GF2n` with that
-modulus. Words enter and leave through:
+modulus. A `UInt64` word becomes a packed element through:
 
 {docstring Hex.GF2q.ofWord}
 
-and the translation into the generic model (packing's correctness made
-executable) is:
+and the map from a packed element to its generic `GFq` counterpart is:
 
 {docstring Hex.GF2q.toGFq}
 
@@ -140,11 +140,10 @@ tag := "hex-gfq-worked"
 %%%
 
 The committed pair `(2, 3)` gives `GF(8) = 𝔽₂[x] / (x³ + x + 1)`, the
-Conway field `C(2, 3)`. The block below picks up its field type two
-ways (the generic `GFqC 2 3` and the packed `GF2q 3`), then exercises the
-packed constructors, where elements are machine words whose bits are the
-polynomial coefficients (bit `i` is the coefficient of `xⁱ`). Each
-`#guard` is checked when the chapter builds.
+Conway field `C(2, 3)`. The block below spells `GF(8)` two ways (the
+generic `GFqC 2 3` and the packed `GF2q 3`), then computes with the packed
+representation, where elements are machine words whose bits are the
+polynomial coefficients (bit `i` is the coefficient of `xⁱ`).
 
 ```lean
 open Hex
@@ -232,6 +231,6 @@ tag := "hex-gfq-cross-references"
   {name}`Hex.GF2q`, together with the `GF2Poly.Irreducible` predicate the
   packed certificates discharge.
 
-`HexGFq` is Mathlib-free; its Mathlib correspondence
+`HexGFq` is Mathlib-free. Its Mathlib correspondence
 ({ref "hex-gfq-mathlib"}[above], via `HexGFqMathlib`) identifies the
 executable field with Mathlib's `GaloisField`.

--- a/HexManual/Chapters/HexGFqField.lean
+++ b/HexManual/Chapters/HexGFqField.lean
@@ -57,7 +57,7 @@ structure is only available where it is justified.
 Callers build elements through two smart constructors and read them back
 through one projection. {name}`Hex.GFqField.ofQuotient` wraps an existing
 quotient residue, {name}`Hex.GFqField.ofPoly` reduces a raw polynomial
-into the field, and {name}`Hex.GFqField.repr` recovers the canonical
+modulo the modulus, and {name}`Hex.GFqField.repr` recovers the canonical
 representative, always of degree strictly below the modulus.
 
 {docstring Hex.GFqField.ofQuotient}
@@ -77,9 +77,9 @@ quotient residues.
 tag := "hex-gfq-field-operations"
 %%%
 
-The ring operations re-use the quotient-ring path directly: each wraps
-the corresponding {name}`Hex.GFqRing.PolyQuotient` operation and rewraps
-the reduced result.
+The ring operations delegate to the quotient ring: each wraps the
+corresponding {name}`Hex.GFqRing.PolyQuotient` operation and rewraps the
+reduced result.
 
 {docstring Hex.GFqField.add}
 
@@ -102,7 +102,7 @@ elements directly.
 The operations that need irreducibility come next. Inversion runs the
 polynomial extended GCD on the representative and the modulus, then
 normalizes the Bézout coefficient by the constant unit factor of the
-gcd; irreducibility is exactly what forces that gcd to be a nonzero
+gcd. Irreducibility is exactly what forces that gcd to be a nonzero
 constant for any nonzero element. Division is multiplication by the
 inverse, and Frobenius is the `p`-th power map.
 
@@ -125,15 +125,14 @@ tag := "hex-gfq-field-worked-example"
 
 The example below builds the same modulus `x⁴ + 2` used in the
 {ref "hex-gfq-ring-worked-example"}[`HexGFqRing` worked example], whose
-reduction rule is `x⁴ ≡ -2 ≡ 3 (mod 5)`, but now exercises the field
+reduction rule is `x⁴ ≡ -2 ≡ 3 (mod 5)`, but now runs the field
 operations: inverses, division, and Frobenius alongside the ring
 operations. Irreducibility of the modulus is discharged by a Rabin
 {name}`Hex.Berlekamp.IrreducibilityCertificate`, whose pow chain and
 Bézout witness are checked by the kernel-reducible
 {name}`Hex.Berlekamp.checkIrreducibilityCertificateLinear` and routed to
 {name}`Hex.FpPoly.Irreducible` through
-{name}`Hex.Berlekamp.rabinTest_imp_irreducible`. Each `#guard` is checked
-when the chapter builds.
+{name}`Hex.Berlekamp.rabinTest_imp_irreducible`.
 
 ```lean
 open Hex Hex.GFqField
@@ -300,7 +299,7 @@ positive-degree modulus) is used.
 {docstring Hex.GFqField.zero_ne_one}
 
 The Frobenius endomorphism is definitionally the `p`-th power map, the
-form the rest of the finite-field theory consumes.
+form downstream code uses.
 
 {docstring Hex.GFqField.frob_eq_pow}
 
@@ -345,7 +344,7 @@ Like {ref "hex-gfq-ring-no-mathlib-correspondence"}[`HexGFqRing`],
 `*Mathlib` correspondence: there is no `HexGFqFieldMathlib`, and
 this chapter therefore carries no "computational vs. Mathlib
 correspondence" cross-reference. The canonical mathematical home of
-GF(pⁿ) is Mathlib's `GaloisField` / `AdjoinRoot` construction; a
+GF(pⁿ) is Mathlib's `GaloisField` / `AdjoinRoot` construction. A
 correspondence between {name}`Hex.GFqField.FiniteField` and those
 structures is deferred to a downstream library if and when a
 Mathlib-valued caller needs it.

--- a/HexManual/Chapters/HexGFqRing.lean
+++ b/HexManual/Chapters/HexGFqRing.lean
@@ -34,8 +34,8 @@ representatives.
 The modulus `f` is not required to be irreducible: when `f` is reducible
 the quotient is still a ring, used downstream wherever a fixed-modulus
 polynomial ring is needed. When `f` is irreducible, the same underlying
-representation supports a field structure, supplied by `HexGFqField`;
-see {ref "hex-gfq-ring-cross-references"}[Cross-references] below.
+representation supports a field structure, supplied by `HexGFqField`.
+See {ref "hex-gfq-ring-cross-references"}[Cross-references] below.
 
 # Quotient types
 %%%
@@ -88,7 +88,7 @@ corresponding operations on representatives and re-reduce the result.
 
 Exponentiation uses square-and-multiply on the exponent bits, costing
 `O(log n)` quotient-ring multiplications. The natural and integer
-scalar maps below use the same binary-decomposition shape; the
+scalar maps below use the same binary-decomposition shape. The
 textbook `n + 1 ↦ pred + 1` recursion is forbidden in this library
 because its cost would be linear in the scalar.
 
@@ -113,9 +113,8 @@ tag := "hex-gfq-ring-worked-example"
 
 The reduction rule for this quotient is `x⁴ ≡ -2 ≡ 3 (mod 5)`. The
 example below builds the modulus, three reduced representatives `a`,
-`b`, and `x`, then exercises addition, multiplication, negation,
-subtraction, and exponentiation. Each `#guard` is checked when the
-chapter is built.
+`b`, and `x`, then runs addition, multiplication, negation,
+subtraction, and exponentiation.
 
 ```lean
 open Hex Hex.GFqRing
@@ -232,8 +231,7 @@ addition and multiplication to the quotient.
 The full ring axioms over canonical representatives are bundled into
 the `Lean.Grind.CommRing` instance on
 {name}`Hex.GFqRing.PolyQuotient`, which is the entry point for
-downstream proof automation. Its existence is the prerequisite that promotes
-`HexGFqRing` to a Phase 6 grind-clean state.
+downstream proof automation.
 
 # Cross-references
 %%%
@@ -247,8 +245,8 @@ finite-field library depends on it:
   {name}`Hex.GFqRing.reduceMod` operates on, together with the
   `Hex.DensePoly.divMod` and `Hex.DensePoly.mod` operations from which
   `reduceMod` is built. The univariate polynomial division laws
-  packaged there are what make the canonical-representative invariant
-  meaningful.
+  packaged there are what justify the canonical-representative
+  invariant.
 * `HexGFqField` specializes the same quotient to an irreducible
   modulus and adds the field structure. The `FiniteField` type in
   `HexGFqField` is a thin wrapper carrying a
@@ -272,7 +270,7 @@ correspondence" cross-reference that future chapters will include for
 libraries that have one.
 
 For `HexGFqRing` the canonical mathematical home of the quotient is
-Mathlib's `AdjoinRoot` or `Polynomial.quotient` construction; a
+Mathlib's `AdjoinRoot` or `Polynomial.quotient` construction. A
 correspondence between {name}`Hex.GFqRing.PolyQuotient` and those
 constructions is deferred to a downstream library if and when a
 Mathlib-valued caller needs it.

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -43,23 +43,22 @@ to `Rat` first, and adds computable integer data (the leading Gram
 determinants and the integer scaled coefficient matrix) that lattice
 code uses to stay in exact arithmetic. The orthogonal basis and rational
 coefficients involve division, so {name}`Hex.GramSchmidt.Rat.basis` and
-{name}`Hex.GramSchmidt.Rat.coeffs` are `noncomputable`; the determinant
+{name}`Hex.GramSchmidt.Rat.coeffs` are `noncomputable`. The determinant
 operations ({name}`Hex.GramSchmidt.Int.gramDet`,
 {name}`Hex.GramSchmidt.Int.scaledCoeffs`) are computable and drive the
 worked examples below.
 
 `HexGramSchmidt` is Mathlib-free and depends only on `HexMatrix`. `HexLLL`
-uses it for orthogonalization and the exact-update formulas, but it is
-logically independent of LLL; see
+uses it for orthogonalization and the exact-update formulas. See
 {ref "hex-gram-schmidt-cross-references"}[Cross-references].
 
-# Core operations
+# Fundamental operations
 %%%
 tag := "hex-gram-schmidt-core"
 %%%
 
 The two fundamental constructions are the orthogonal basis and the
-coefficient matrix. The basis rows are mutually orthogonal; the
+coefficient matrix. The basis rows are mutually orthogonal. The
 coefficient matrix is lower-unitriangular and reconstructs the input as
 `coeffs · basis`. Both come in a rational and an integer flavour, the
 integer one casting its input into `Rat` first.
@@ -72,12 +71,12 @@ integer one casting its input into `Rat` first.
 
 {docstring Hex.GramSchmidt.Int.coeffs}
 
-Because the basis and coefficient matrices divide, they are
-`noncomputable` and are documented here by signature. The integer
+The basis and coefficient matrices are `noncomputable` (their entries
+involve division), so they are documented here by signature. The integer
 namespace adds two *computable* operations that stay in exact arithmetic.
 The leading Gram determinants are the determinants of the leading
 principal Gram minors `B Bᵀ` (the squared volumes of the prefix
-sublattices); the scaled coefficient matrix clears the denominators of
+sublattices). The scaled coefficient matrix clears the denominators of
 the rational coefficients against them.
 
 {docstring Hex.GramSchmidt.Int.gramDet}
@@ -85,7 +84,7 @@ the rational coefficients against them.
 {docstring Hex.GramSchmidt.Int.scaledCoeffs}
 
 The scaled coefficients are packaged together with the Gram-determinant
-vector inside {name}`Hex.GramSchmidt.Int.Data`; `scaledCoeffs` projects
+vector inside {name}`Hex.GramSchmidt.Int.Data`. `scaledCoeffs` projects
 out its coefficient matrix.
 
 ## Worked example: Gram determinants and scaled coefficients
@@ -95,9 +94,7 @@ tag := "hex-gram-schmidt-worked"
 
 The block below works over the integer matrix with rows `(1,1,0)`,
 `(1,0,1)`, `(0,1,1)`. It reads off the leading Gram determinants and the
-scaled coefficient matrix, then exercises a size-reduction row
-operation. Each `#guard` is checked when the chapter is built, so the
-expected values are guaranteed to match the executable implementation.
+scaled coefficient matrix, then applies a size-reduction row operation.
 
 ```lean
 open Hex Hex.GramSchmidt Hex.GramSchmidt.Int
@@ -192,7 +189,7 @@ Lattice reduction modifies the input by elementary row operations and
 needs to know how the Gram-Schmidt data changes. `HexGramSchmidt`
 packages the two operations LLL uses (size reduction and adjacent swap)
 and states the resulting update formulas. The row operations themselves
-live in `HexMatrix`; `HexGramSchmidt` supplies the API for reasoning
+live in `HexMatrix`. `HexGramSchmidt` supplies the API for reasoning
 about their effect on the Gram-Schmidt data.
 
 {docstring Hex.GramSchmidt.Int.sizeReduce}
@@ -200,10 +197,9 @@ about their effect on the Gram-Schmidt data.
 {docstring Hex.GramSchmidt.Int.adjacentSwap}
 
 Size reduction subtracts an integer multiple of an earlier row from a
-later one. This unimodular operation preserves the orthogonal profile,
-so it leaves the entire Gram-Schmidt basis unchanged: LLL can
-size-reduce freely without disturbing the orthogonalized vectors or the
-Gram determinants the swap step depends on.
+later one. This unimodular operation leaves the entire Gram-Schmidt basis
+unchanged, so LLL can size-reduce freely without changing the
+orthogonalized vectors or the Gram determinants the swap step depends on.
 
 {docstring Hex.GramSchmidt.Int.basis_sizeReduce}
 
@@ -234,6 +230,4 @@ tag := "hex-gram-schmidt-cross-references"
 * `HexLLL` consumes the {ref "hex-gram-schmidt-core"}[integer data]
   (the Gram determinants and scaled coefficients) and the
   {ref "hex-gram-schmidt-updates"}[exact update formulas] to drive
-  lattice reduction in integer arithmetic. `HexGramSchmidt` is logically
-  independent of LLL: it states the orthogonalization and its updates
-  without reference to the reduction algorithm that uses them.
+  lattice reduction in integer arithmetic.

--- a/HexManual/Chapters/HexHensel.lean
+++ b/HexManual/Chapters/HexHensel.lean
@@ -41,7 +41,7 @@ polynomials (`HexPolyFp`, `Hex.FpPoly p`). It provides coefficientwise
 reduction modulo powers of `p`, the linear and quadratic single-step
 corrections, the iterative {name}`Hex.ZPoly.henselLift` wrapper, and the
 ordered multifactor lift API the factorization pipeline consumes. It is
-Mathlib-free and depends only on `HexPolyFp` and `HexPolyZ`; see
+Mathlib-free and depends only on `HexPolyFp` and `HexPolyZ`. See
 {ref "hex-hensel-cross-references"}[Cross-references].
 
 # Coefficientwise reduction
@@ -73,7 +73,6 @@ tag := "hex-hensel-worked-reduction"
 The block below reduces the coefficients of `100 - 3x + 50x²`. Modulo
 `7² = 49` the coefficients become `2, 46, 1`; modulo `5² = 25` they
 become `0, 22, 0`, and the trailing zero is trimmed by normalization.
-Each `#guard` is checked when the chapter is built.
 
 ```lean
 open Hex Hex.DensePoly Hex.QuadraticLiftResult
@@ -111,7 +110,7 @@ The linear step returns the corrected pair of factors.
 {docstring Hex.ZPoly.linearHenselStep}
 
 The quadratic step doubles the modulus and so must carry the Bezout
-witnesses forward alongside the factors; its result bundles all four.
+witnesses forward alongside the factors. Its result bundles all four.
 
 {name}`Hex.QuadraticLiftResult` packages the updated leading factor `g`
 (monic), the complementary factor `h`, and the updated Bezout witnesses
@@ -133,8 +132,8 @@ Factorization pipelines need to lift an *ordered list* of mod-`p`
 factors simultaneously, not just a single split. The multifactor API
 does this by a sequential binary split tree: at each node it lifts the
 first factor against the product of the rest, then recurses. There are
-linear and quadratic-doubling versions; the quadratic one is the
-production path, because of its `O(log k)` precision growth.
+linear and quadratic-doubling versions. The factorization pipeline uses
+the quadratic one, because of its `O(log k)` precision growth.
 
 {docstring Hex.ZPoly.multifactorLift}
 
@@ -151,9 +150,8 @@ iterative single-split wrapper:
 
 {docstring Hex.ZPoly.henselLift_spec}
 
-The multifactor lifters carry the same product-congruence guarantee,
-threaded through the recursive split tree by a per-node invariant
-package.
+The multifactor lifters carry the same product-congruence guarantee. The
+proof maintains it at each node of the recursive split.
 
 {docstring Hex.ZPoly.multifactorLift_spec}
 
@@ -162,15 +160,15 @@ package.
 The quadratic doubling loop is verified against an explicit loop
 invariant: the three facts a caller must maintain across one doubling
 (product congruence, Bezout congruence, and monicity of the leading
-factor) are exactly the preconditions the doubling step consumes.
+factor) are exactly the preconditions the doubling step requires.
 
 {docstring Hex.ZPoly.QuadraticLiftLoopInvariant}
 
 {docstring Hex.ZPoly.quadraticLiftLoopInvariant_step}
 
 Monicity of the leading factor is preserved by the whole quadratic
-multifactor lift, so a monic input yields monic lifted factors, the
-shape the factorization pipeline relies on.
+multifactor lift, so a monic input yields monic lifted factors, which
+the factorization pipeline requires.
 
 {docstring Hex.ZPoly.multifactorLiftQuadratic_each_monic}
 

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -35,22 +35,22 @@ Its first row is a provably short lattice vector, which is what the
 the BHKS van Hoeij recombination step in `hex-berlekamp-zassenhaus`
 reconstructs true factors from short vectors of a knapsack lattice.
 
-On adversarial worst-case input the payoff of the design is stark. These are the
+On adversarial worst-case input the reducers diverge sharply in cost. These are the
 five benchmarked reducers on fplll's Ajtai-style `gen_trg` bases, whose steeply
 decreasing profile forces a `Θ(d² log B)` swap count:
 
 ![HexLLL reducers on Ajtai-style worst-case bases](https://kim-em.github.io/hex-dev/figures/hex-lll-comparator-ajtai.svg)
 
 The exact integer reducers (Lean's `lllNative` and the verified Isabelle
-extraction) blow up `~d⁷`, while the certified path — an `fpLLL` candidate
-checked by a verified Lean checker — stays cheap, near raw floating-point speed.
-The {ref "hex-lll-performance"}[performance comparison] below walks through every
+extraction) blow up `~d⁷`. The certified path (an `fpLLL` candidate
+checked by a verified Lean checker) stays cheap, near raw floating-point speed.
+The {ref "hex-lll-performance"}[performance comparison] below describes every
 curve and all six input families.
 
 The library splits computation from proof. The public reducer can
-accelerate through an optional external `fpLLL` provider — fast, untrusted
-numerics — but no proof depends on those numerics being correct. Every
-external candidate is fed through a verified integer checker; only a basis
+accelerate through an optional external `fpLLL` provider (fast, untrusted
+numerics), but no proof depends on those numerics being correct. Every
+external candidate is fed through a verified integer checker. Only a basis
 the checker accepts is returned, and the checker's soundness theorem
 (proved on the Mathlib side) turns that acceptance into the mathematical
 guarantee. When no external candidate certifies, the exact all-integer
@@ -68,7 +68,7 @@ tag := "hex-lll-predicates"
 %%%
 
 A lattice is the set of integer combinations of the basis rows. Membership
-and independence are the two structural predicates; both are propositions
+and independence are the two structural predicates. Both are propositions
 about the exact integer data, never about the numerics.
 
 {docstring Hex.Matrix.memLattice}
@@ -89,7 +89,7 @@ size bound `η` grows.
 
 {docstring Hex.Internal.isLLLReduced.mono_η}
 
-The payoff theorem is the short-vector bound: in a reduced basis the first
+The key theorem is the short-vector bound: in a reduced basis the first
 row is within an explicit `δ`/`η`-dependent factor of the shortest nonzero
 lattice vector. This is the property downstream callers actually rely on.
 
@@ -100,7 +100,7 @@ lattice vector. This is the property downstream callers actually rely on.
 tag := "hex-lll-checkers"
 %%%
 
-The predicates above mention rational Gram-Schmidt data; deciding them
+The predicates above mention rational Gram-Schmidt data. Deciding them
 directly would require rational (or interval) arithmetic. The checkers
 instead work over the scaled integer Gram-Schmidt representation (the
 leading Gram determinants `d` and the integer scaled coefficients `ν`),
@@ -110,7 +110,7 @@ clears denominators in both the size-reduced and Lovász clauses.
 {docstring Hex.lllReducedInt}
 
 For larger inputs an unverified fixed-precision interval pass is usually
-faster; the dispatching checker uses a size predictor to choose it, but
+faster. The dispatching checker uses a size predictor to choose it, but
 always keeps the exact integer checker as a mandatory fallback when the
 interval pass is indecisive, so completeness stays structural rather than
 numerical.
@@ -119,7 +119,7 @@ numerical.
 
 The same-lattice side of an external candidate is certified separately. A
 pair of integer transforms `U`, `V` witnessing `U·B = B'` and `V·B' = B`
-proves the two bases generate the same lattice; the certificate is a
+proves the two bases generate the same lattice. The certificate is a
 denominator-free `Bool` check with an overflow-safe packed-row comparison.
 
 {docstring Hex.Matrix.sameLatticeCert}
@@ -147,24 +147,24 @@ letting the Mathlib side reason about them.
 {docstring Hex.Internal.LLLState.Valid}
 
 The exact all-integer reducer {name}`Hex.lllNative` drives the standard LLL
-outer loop — integer size-reduction and adjacent Lovász swaps — from that exact
+outer loop (integer size-reduction and adjacent Lovász swaps) from that exact
 `d`/`ν` data alone. Its size-reduction step produces exact `|μ| ≤ 1/2`, so it
-carries the classical `η = 1/2` contract and is the direct `1/4 < δ` entry
+satisfies the classical `η = 1/2` bound and is the direct `1/4 < δ` entry
 point.
 
 {docstring Hex.lllNative}
 
 The public entry point hides all of this behind one signature. Given a
 basis with independent rows and `δ` in the classical range, it returns a
-reduced basis generating the same lattice; the short-vector and same-lattice
+reduced basis generating the same lattice. The short-vector and same-lattice
 post-conditions are identical on every internal path, so callers and proofs
 never see the dispatch.
 
 {docstring Hex.lll}
 
-The canonical consumer surface reads short vectors off the reduced basis.
-{name}`Hex.lll.firstShortVector` is the single short vector wanted by
-recombination; {name}`Hex.lll.shortVectors` exposes the whole reduced
+Two functions return the short vectors of the reduced basis.
+{name}`Hex.lll.firstShortVector` is the single short vector used by
+recombination. {name}`Hex.lll.shortVectors` returns the whole reduced
 basis as an ordered candidate list. Each has a proof-free `Unchecked`
 variant that drops the independence hypothesis for quick experimentation.
 
@@ -207,16 +207,17 @@ bit-length grows with the dimension:
 
 Each plot is log-scale wall-time per reduction against the family dimension:
 
-* `fpLLL` — the raw floating-point reducer, unverified; the speed baseline.
-* `Lean native` — `Hex.lllNative`, the exact all-integer `d`/`ν` reducer.
+* `fpLLL`: the raw floating-point reducer, unverified; the speed baseline.
+* `Lean native`: `Hex.lllNative`, the exact all-integer `d`/`ν` reducer.
   Correct by construction, but its exact arithmetic pays for wide operands and
   high swap counts.
-* `Lean certified` — an `fpLLL` candidate *checked* by the verified Lean checker
+* `Lean certified`: an `fpLLL` candidate *checked* by the verified Lean checker
   `Hex.certCheck`. It inherits floating-point speed and adds only a cheap
-  integer check, so it hugs the `fpLLL` curve while remaining fully verified.
-* `verified Isabelle native` — the Isabelle extraction's own reducer; the
+  integer check, so it stays close to the `fpLLL` curve while remaining fully
+  verified.
+* `verified Isabelle native`: the Isabelle extraction's own reducer; the
   independent verified point of comparison.
-* `verified Isabelle certified` — the *same* `fpLLL` candidate checked by the
+* `verified Isabelle certified`: the *same* `fpLLL` candidate checked by the
   Isabelle checker instead of the Lean one; the apples-to-apples yardstick for
   the Lean certified path.
 
@@ -225,19 +226,19 @@ Each plot is log-scale wall-time per reduction against the family dimension:
 Each family is a faithful port of an fplll generator, and stresses a different
 part of the algorithm:
 
-* `random-bounded` — near-orthogonal random bases; the easy baseline, few swaps.
-* `harsh-cubic` — entries of bit-length about `3.3·n`; exact-integer
+* `random-bounded`: near-orthogonal random bases; the easy baseline, few swaps.
+* `harsh-cubic`: entries of bit-length about `3.3·n`; exact-integer
   operand-width growth (shown above).
-* `ajtai` — fplll `gen_trg` worst-case triangular bases; the swap / iteration
+* `ajtai`: fplll `gen_trg` worst-case triangular bases; the swap / iteration
   count `Θ(d² log B)` (shown in the {ref "hex-lll-intro"}[introduction]).
-* `q-ary` — LWE/SIS bases `[[I, H], [0, qI]]`; the cryptographic Z-shape.
-* `ntru` — bases `[[I, Rot h], [0, qI]]`; a planted dense sublattice plus a
+* `q-ary`: LWE/SIS bases `[[I, H], [0, qI]]`; the cryptographic Z-shape.
+* `ntru`: bases `[[I, Rot h], [0, qI]]`; a planted dense sublattice plus a
   q-block.
-* `knapsack` — the rectangular `d × (d+1)` integer-relation form; the only
-  family with more columns than rows, exercising the `m > n` construction.
+* `knapsack`: the rectangular `d × (d+1)` integer-relation form; the only
+  family with more columns than rows, using the `m > n` construction.
 
 Across every family the exact reducers are correct but climb steeply on the hard
-bases, while `Lean certified` stays within about 1.2 to 2.5 times raw `fpLLL` —
+bases, while `Lean certified` stays within about 1.2 to 2.5 times raw `fpLLL`:
 verified output at close to floating-point cost.
 
 ## Selecting the certified versus native path
@@ -247,21 +248,21 @@ shim, and the *same* `Hex.lll` call picks its path by whether an external
 provider symbol is resolvable in the process:
 
 * set the environment variable `HEX_FPLLL_FFI_LIB` to a built fpLLL-ffi shared
-  library and `lll` takes the certified path — the shim `dlopen`s it,
+  library and `lll` takes the certified path: the shim `dlopen`s it,
   `providerAvailable` returns true, and the candidate is certified by
   `Hex.certCheck`;
 * leave it unset (or if certification ever fails) and `lll` runs the exact
   `Hex.lllNative` directly.
 
-Either way the returned basis satisfies the same `(δ, 11/20)`-reduced contract.
+Either way the returned basis is `(δ, 11/20)`-reduced.
 
 ## The size-reduction bound and its constants
 
 The public `Hex.lll` certifies its output `(δ, 11/20)`-reduced: every
 Gram-Schmidt coefficient satisfies `|μ| ≤ 11/20`. Two numbers in its signature
 follow from `η = 11/20`. The precondition is `121/400 < δ`, because
-`121/400 = (11/20)² = η²` and the bound is well-defined only when `η² < δ`; and
-the short-vector constant is `1/(δ − 121/400)`. So the `121/400` stands exactly
+`121/400 = (11/20)² = η²` and the bound is well-defined only when `η² < δ`. The
+short-vector constant is `1/(δ − 121/400)`. So the `121/400` stands exactly
 where the classical bound would put `1/4 = (1/2)²`.
 
 Why `11/20` rather than the classical `1/2`? Solely the external provider. The
@@ -292,10 +293,9 @@ tag := "hex-lll-worked"
 %%%
 
 The block reduces the rank-2 lattice with basis rows `(1, 12)` and
-`(0, 1)`. The skewed first row is far from orthogonal; reduction returns
+`(0, 1)`. The skewed first row is far from orthogonal. Reduction returns
 `(0, 1)`, `(1, 0)` (the two unit vectors), which generate the same
-lattice and are as short as possible. Each `#guard` is checked when the
-chapter builds.
+lattice and are as short as possible.
 
 ```lean
 open Hex Hex.Matrix Hex.Internal
@@ -375,8 +375,8 @@ proofs in `HexLLLMathlib`:
   the leading Gram determinants) on which both the
   {ref "hex-lll-predicates"}[reducedness predicates] and the
   {ref "hex-lll-checkers"}[integer checkers] are defined. Through it,
-  `HexLLL` rests transitively on the fraction-free integer determinant stack
-  (`HexBareiss`, `HexDeterminant`, `HexRowReduce`).
+  `HexLLL` rests transitively on the fraction-free integer determinant
+  libraries `HexBareiss`, `HexDeterminant`, and `HexRowReduce`.
 * `HexLLLMathlib` carries the soundness theorems. `lllReducedInt_sound`
   and `lllReducedCheck_sound` relate the integer checkers to
   {name}`Hex.isLLLReduced`, and `certCheck_sound` combines those with

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -47,7 +47,8 @@ tag := "hex-matrix-core"
 %%%
 
 {name}`Hex.Matrix.ofFn` builds a matrix from an entry function
-`Fin n → Fin m → R`; `row`, `col`, and `transpose` read it back.
+`Fin n → Fin m → R`. `row` and `col` return its rows and columns, and
+`transpose` swaps them.
 
 {docstring Hex.Matrix.ofFn}
 
@@ -65,8 +66,8 @@ The zero and identity matrices:
 
 {docstring Hex.Matrix.identity}
 
-Multiplication is the row-by-column dot product, matrix-vector and
-matrix-matrix, both written `*`.
+Matrix-vector and matrix-matrix multiplication are both written `*`.
+Each product entry is a row-by-column dot product.
 
 {docstring Vector.dotProduct}
 
@@ -110,11 +111,10 @@ over a field.
 tag := "hex-matrix-worked"
 %%%
 
-The block builds an integer matrix with the `#m[...]` literal and reads
-three quantities off it: the squared norm of the first row
+The block builds an integer matrix with the `#m[...]` literal and checks
+three things about it: the squared norm of the first row
 (`2² + 0² + 1² = 5`), the dot product of the first two rows (`4`), and
-that the identity fixes a vector. Each `#guard` is checked when the
-chapter builds.
+that the identity fixes a vector.
 
 ```lean
 open Hex

--- a/HexManual/Chapters/HexModArith.lean
+++ b/HexManual/Chapters/HexModArith.lean
@@ -27,18 +27,17 @@ tag := "hex-mod-arith-intro"
 coefficients. A residue is a single machine word holding the standard
 representative in `[0, p)`, bundled with a proof that the word is
 reduced. There is one residue type, {name}`Hex.ZMod64`, parametrised by
-the modulus `p`; the Barrett and Montgomery hot-loop routines are opt-in
+the modulus `p`. The Barrett and Montgomery hot-loop routines are opt-in
 *operations* on that type, not parallel residue types.
 
 The modulus carries a side condition: it must be positive and fit in a
 machine word. That condition is packaged as the typeclass
 {name}`Hex.ZMod64.Bounds`, which every `ZMod64 p` value and operation
-takes as an instance argument. `HexModArith` is Mathlib-free; it depends
+takes as an instance argument. `HexModArith` is Mathlib-free. It depends
 only on `HexArith`, from which it borrows the Barrett and Montgomery
 machine-word kernels. The finite-field and prime-field polynomial
-libraries (`HexGFqRing`, `HexPolyFp`, and beyond) read their coefficient
-arithmetic off this representation; see
-{ref "hex-mod-arith-cross-references"}[Cross-references].
+libraries (`HexGFqRing`, `HexPolyFp`) use `ZMod64 p` as their coefficient
+type. See {ref "hex-mod-arith-cross-references"}[Cross-references].
 
 # The residue type
 %%%
@@ -106,7 +105,7 @@ representative. The standard `Add`, `Sub`, `Neg`, and `Mul` instances on
 {docstring Hex.ZMod64.mul}
 
 Exponentiation uses repeated squaring, and inversion runs the
-extended-GCD helper from `HexArith`; for an element coprime to the
+extended-GCD helper from `HexArith`. For an element coprime to the
 modulus the result is the modular inverse.
 
 {docstring Hex.ZMod64.pow}
@@ -119,8 +118,7 @@ tag := "hex-mod-arith-worked-ring"
 %%%
 
 The block below works in `ZMod64 7`. After supplying the `Bounds 7`
-instance it builds two residues and exercises the constructors and the
-ring operations. Each `#guard` is checked when the chapter builds.
+instance it builds two residues and runs the ring operations on them.
 
 ```lean
 open Hex Hex.ZMod64
@@ -282,8 +280,8 @@ tag := "hex-mod-arith-mathlib"
 
 Everything above is executable and Mathlib-free. `HexModArithMathlib`
 connects it to Mathlib: every {name}`Hex.ZMod64` value corresponds to an
-element of Mathlib's `ZMod p`. The two transfer maps read a residue as a
-`ZMod p` class and back.
+element of Mathlib's `ZMod p`. The two transfer maps convert a residue to a
+`ZMod p` element and back.
 
 {docstring HexModArithMathlib.ZMod64.toZMod}
 

--- a/HexManual/Chapters/HexPoly.lean
+++ b/HexManual/Chapters/HexPoly.lean
@@ -32,12 +32,12 @@ equality coincide with semantic equality, so two `HexPoly` polynomials
 are equal as Lean values exactly when they are equal as polynomials.
 
 {name}`Hex.DensePoly` is generic over any coefficient type `R` with a
-`Zero` and a `DecidableEq`; the arithmetic, evaluation, and Euclidean
-parts add the further operations (`Add`, `Mul`, `Sub`, `Div`) they each
-need. `HexPoly` is Mathlib-free and depends on no other `hex` library.
+`Zero` and a `DecidableEq`. The arithmetic, evaluation, and Euclidean
+operations require the further structure (`Add`, `Mul`, `Sub`, `Div`)
+that each one needs. `HexPoly` is Mathlib-free and depends on no other `hex` library.
 The integer library `HexPolyZ`, the prime-field library `HexPolyFp`,
 and through them the factorization and finite-field libraries all
-consume this representation; see
+consume this representation. See
 {ref "hex-poly-cross-references"}[Cross-references].
 
 # Dense polynomial type
@@ -55,7 +55,7 @@ predicate.
 
 Because the invariant pins down a unique array for each polynomial
 value, `HexPoly` derives a `DecidableEq` on {name}`Hex.DensePoly` and
-proves the preferred extensionality principle: two normalized
+proves the extensionality principle: two normalized
 polynomials are equal as soon as their coefficient functions agree.
 
 {docstring Hex.DensePoly.ext_coeff}
@@ -66,7 +66,7 @@ tag := "hex-poly-constructors"
 %%%
 
 Every constructor routes through normalization so the no-trailing-zeros
-invariant holds by construction; callers never trim by hand. The
+invariant holds by construction. Callers never trim by hand. The
 primitive normalizer drops trailing zeros from a raw array, and
 {name}`Hex.DensePoly.ofCoeffs` wraps it to build a polynomial.
 
@@ -153,7 +153,7 @@ operations. Evaluation and composition both use Horner's method.
 {docstring Hex.DensePoly.derivative}
 
 Each operation comes with a characterising coefficient law. These are
-the lemmas downstream proofs rewrite with; the zero-absorption side
+the lemmas downstream proofs rewrite with. The zero-absorption side
 conditions (`hzero`) are discharged automatically over any semiring,
 via the `*_semiring`/`*_ring` specializations.
 
@@ -171,9 +171,8 @@ tag := "hex-poly-worked-arithmetic"
 %%%
 
 The block below works over `DensePoly Int`. It builds a quadratic and a
-monomial, then exercises the constructors, addition, multiplication,
-evaluation, and the derivative. Each `#guard` is checked when the
-chapter builds.
+monomial, then computes their sum and product, an evaluation, and a
+derivative.
 
 ```lean
 open Hex Hex.DensePoly
@@ -227,7 +226,7 @@ leading coefficient and the monic predicate.
 {docstring Hex.DensePoly.monic_iff_leadingCoeff_eq_one}
 
 Division has two flavours. {name}`Hex.DensePoly.divModMonic` divides by
-a monic divisor over any commutative ring; no division of coefficients
+a monic divisor over any commutative ring. No division of coefficients
 is needed because the leading coefficient is `1`.
 {name}`Hex.DensePoly.divMod` is the field version: it scales by the
 inverse of the divisor's leading coefficient and so requires a `Div` on
@@ -258,8 +257,7 @@ tag := "hex-poly-worked-euclid"
 
 This block works over `DensePoly Rat`. It divides `x² - 1` by `x - 1`,
 reads off the quotient and remainder, checks the Euclidean
-reconstruction, and computes a gcd. As before, every `#guard` is
-verified at build time.
+reconstruction, and computes a gcd.
 
 ```lean
 open Hex Hex.DensePoly
@@ -350,7 +348,7 @@ They are mutually inverse:
 
 {docstring HexPolyMathlib.ofPolynomial_toPolynomial}
 
-`toPolynomial` is a degree-preserving ring homomorphism; addition,
+`toPolynomial` is a degree-preserving ring homomorphism. Addition,
 multiplication, and the degree transfer:
 
 {docstring HexPolyMathlib.toPolynomial_add}
@@ -378,6 +376,6 @@ tag := "hex-poly-cross-references"
   specializes to the prime fields `ZMod64 p`, supplying the concrete
   `DivModLaws` and `GcdLaws` instances that turn the
   {ref "hex-poly-key-correctness"}[Euclidean laws] above into usable
-  facts. The finite-field and factorization libraries
-  (`HexGFqRing`, `HexBerlekamp`, and beyond) reach this representation
-  transitively through `HexPolyFp`.
+  facts. The finite-field and factorization libraries, including `HexGFqRing`
+  and `HexBerlekamp`, reach this representation transitively through
+  `HexPolyFp`.

--- a/HexManual/Chapters/HexPolyFp.lean
+++ b/HexManual/Chapters/HexPolyFp.lean
@@ -23,8 +23,8 @@ tag := "hex-poly-fp"
 tag := "hex-poly-fp-intro"
 %%%
 
-`HexPolyFp` specializes the executable dense polynomials to the
-prime-field candidate `Hex.ZMod64 p`. Where {ref "hex-poly"}[`HexPoly`]
+`HexPolyFp` specializes the executable dense polynomials to
+coefficients in `Hex.ZMod64 p`. Where {ref "hex-poly"}[`HexPoly`]
 is generic over any coefficient type with a `Zero` and a `DecidableEq`,
 `HexPolyFp` fixes the coefficients to machine-word residues modulo a
 prime `p` and adds the operations that only make sense over `` `Fₚ` ``:
@@ -36,8 +36,8 @@ modulus is irreducible.
 {name}`Hex.FpPoly` is a thin `abbrev` over
 {name}`Hex.DensePoly`, so the entire constructor, arithmetic, and
 Euclidean API documented in the {ref "hex-poly"}[`HexPoly` chapter] is
-available unchanged; this chapter covers only what the prime-field
-specialization adds on top. `HexPolyFp` is Mathlib-free; it depends on
+available unchanged. This chapter covers only what the prime-field
+specialization adds on top. `HexPolyFp` is Mathlib-free. It depends on
 {ref "hex-poly"}[`HexPoly`] for the representation and on
 {ref "hex-mod-arith"}[`HexModArith`] for the `ZMod64 p` coefficient
 arithmetic. See {ref "hex-poly-fp-cross-references"}[Cross-references].
@@ -58,8 +58,8 @@ Because {name}`Hex.FpPoly` unfolds to {name}`Hex.DensePoly`, the
 needs for the specialized type. {name}`Hex.FpPoly.ofCoeffs` builds a
 polynomial from a coefficient array, {name}`Hex.FpPoly.X` is the
 indeterminate, and {name}`Hex.FpPoly.modByMonic` reduces modulo a monic
-divisor. The irreducibility predicate that gates the field operations is
-also stated here.
+divisor. The irreducibility predicate the field operations require as a
+hypothesis is also stated here.
 
 {docstring Hex.FpPoly.Irreducible}
 
@@ -80,8 +80,8 @@ results never grow past the modulus degree.
 {docstring Hex.FpPoly.composeModMonic}
 
 The finite-field irreducibility and factorization tests are built on the
-Frobenius-power maps. {name}`Hex.FpPoly.frobeniusXMod` computes the
-basic generator `X^p mod f`, and {name}`Hex.FpPoly.frobeniusXPowMod`
+Frobenius-power maps. {name}`Hex.FpPoly.frobeniusXMod` computes
+`X^p mod f`, and {name}`Hex.FpPoly.frobeniusXPowMod`
 iterates it to `X^(pᵏ) mod f` for arbitrary `k`.
 
 {docstring Hex.FpPoly.frobeniusXMod}
@@ -90,7 +90,7 @@ iterates it to `X^(pᵏ) mod f` for arbitrary `k`.
 
 Square-free decomposition runs Yun's algorithm over `` `Fₚ` ``. The
 result bundles a scalar unit with a list of square-free factors and
-their multiplicities; the two record types name those pieces.
+their multiplicities. The two record types name those pieces.
 
 {docstring Hex.FpPoly.SquareFreeFactor}
 
@@ -99,9 +99,8 @@ their multiplicities; the two record types name those pieces.
 {docstring Hex.FpPoly.squareFreeDecomposition}
 
 The inverse operation reassembles a polynomial from a decomposition by
-raising each factor to its multiplicity and multiplying. It documents
-the record's meaning and is the reconstruction side of the correctness
-laws below.
+raising each factor to its multiplicity and multiplying. It is the
+reconstruction side of the correctness laws below.
 
 {docstring Hex.FpPoly.weightedProduct}
 
@@ -119,7 +118,7 @@ degree below the modulus, together with a proof of that bound.
 The quotient is unconditionally a commutative ring. It becomes a
 *field* only when `g` is irreducible, and `HexPolyFp` parametrizes
 over that fact rather than deciding it. There is no unconditional
-`Field` instance; instead the field-promoting laws are theorems that
+`Field` instance. Instead the field-promoting laws are theorems that
 take `FpPoly.Irreducible g` as an explicit hypothesis. A downstream
 caller supplies an irreducibility witness (in practice a checkable
 Rabin certificate from `HexBerlekamp`), and only then are inverses
@@ -133,11 +132,10 @@ tag := "hex-poly-fp-worked-example"
 
 The block below works over `FpPoly 5`. It fixes the monic quadratic
 modulus `x² + 2` (whose reduction rule is `x² ≡ -2 ≡ 3 (mod 5)`) and a
-linear modulus `x + 3`, then exercises modular exponentiation,
-Frobenius, composition, weighted products, and square-free
-decomposition. The helper `coeffNats` reads a polynomial back as a list
-of natural-number coefficients. Each `#guard` is checked when the
-chapter is built. These values are the same ones pinned by the
+linear modulus `x + 3`, then runs modular exponentiation, Frobenius,
+composition, weighted products, and square-free decomposition. The
+helper `coeffNats` converts a polynomial to a list of natural-number
+coefficients. The expected values are the same ones pinned by the
 library's conformance suite.
 
 ```lean
@@ -283,8 +281,8 @@ tag := "hex-poly-fp-key-correctness"
 
 The executable operations are pinned to their mathematical meaning.
 Modular composition agrees with the spelled-out "compose then take the
-remainder" definition, and the Frobenius iterate reduces to the
-absolute monomial it represents. That last identity is the one Rabin's
+remainder" definition, and the Frobenius iterate reduces to
+`X^(pᵏ) mod f`. That last identity is the one Rabin's
 irreducibility test relies on.
 
 {docstring Hex.FpPoly.composeModMonic_eq_mod}
@@ -323,7 +321,7 @@ the prime-field specialization the finite-field libraries use:
 * {ref "hex-poly"}[`HexPoly`] is the generic dense-polynomial library.
   {name}`Hex.FpPoly` is an `abbrev` over {name}`Hex.DensePoly`, so every
   constructor, arithmetic, evaluation, and Euclidean operation
-  documented in that chapter is inherited at the specialized type; the
+  documented in that chapter is inherited at the specialized type. The
   concrete `DivModLaws`/`GcdLaws` the generic Euclidean laws are stated
   under are discharged here for `ZMod64 p`.
 * {ref "hex-mod-arith"}[`HexModArith`] supplies the `ZMod64 p`
@@ -335,6 +333,6 @@ the prime-field specialization the finite-field libraries use:
 Downstream, the finite-field libraries consume `HexPolyFp` directly:
 `HexGFqRing` builds the quotient ring `` `Fₚ[x] / (g)` `` and
 {ref "hex-gfq-field"}[`HexGFqField`] promotes it to a field using the
-irreducibility-gated inverse laws documented above, with the
-{name}`Hex.FpPoly.Irreducible` witness produced by a checkable Rabin
-certificate from `HexBerlekamp`.
+inverse laws documented above, each conditioned on irreducibility of the
+modulus, with the {name}`Hex.FpPoly.Irreducible` witness produced by a
+checkable Rabin certificate from `HexBerlekamp`.

--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -33,11 +33,11 @@ congruence* predicate used by Hensel lifting, and a conservative
 executable *Mignotte coefficient bound* on the coefficients of any
 integer factor.
 
-The library is Mathlib-free and depends only on `HexPoly`; `HexHensel`
+The library is Mathlib-free and depends only on `HexPoly`. `HexHensel`
 and the integer-factorization libraries consume it in turn. The
 mathematical justification of the Mignotte bound, that these executable
 quantities really do bound the coefficients of a factor, is proved in
-`HexPolyZMathlib`; see
+`HexPolyZMathlib`. See
 {ref "hex-poly-z-cross-references"}[Cross-references].
 
 # Integer polynomial type
@@ -90,8 +90,7 @@ tag := "hex-poly-z-worked-content"
 %%%
 
 The block below builds `f = 2 + 4x + 6x²`, reads off its content and
-primitive part, and checks the reconstruction law and a dilation. Each
-`#guard` is checked when the chapter builds.
+primitive part, and checks the reconstruction law and a dilation.
 
 ```lean
 open Hex Hex.DensePoly
@@ -181,8 +180,8 @@ norm is replaced by a conservative integer ceiling-square-root
 overestimate, so every bound here is an upper bound on the true
 quantity.
 
-The pieces are an executable binomial coefficient and the integer
-square-root bracket.
+The pieces are an executable binomial coefficient and an integer
+ceiling square root.
 
 {docstring Hex.ZPoly.binom}
 
@@ -209,8 +208,7 @@ tag := "hex-poly-z-worked-mignotte"
 
 The block below works over `g = 1 + x + x² + x³ + x⁴`, computes its
 coefficient-norm bound, some binomial coefficients, a single Mignotte
-bound, and the uniform default bound. Every `#guard` is checked when
-the chapter is built.
+bound, and the uniform default bound.
 
 ```lean
 open Hex Hex.DensePoly
@@ -246,9 +244,8 @@ tag := "hex-poly-z-key-correctness"
 %%%
 
 Two facts pin down the bound for downstream callers. First, the
-conservative norm bound overestimates by at most a factor of two in
-square: a genuine but not wasteful overapproximation of the exact
-Euclidean norm.
+conservative norm bound's square is at most twice the exact squared norm:
+a bounded overestimate of the Euclidean norm.
 
 {docstring Hex.ZPoly.coeffL2NormBound_sq_le_two_mul_coeffNormSq}
 
@@ -262,8 +259,8 @@ factors.
 {docstring Hex.ZPoly.coeffL2NormBound_le_defaultFactorCoeffBound}
 
 Finally, the uniform bound is strictly positive on any nonzero
-polynomial: the fact the factorization driver needs to know its
-precision modulus is nontrivial.
+polynomial, which the factorization driver needs to set a valid
+precision modulus.
 
 {docstring Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero}
 
@@ -279,13 +276,13 @@ integer-factorization libraries:
   this one specializes. The constructors, arithmetic, and Euclidean
   operations used throughout this chapter (`ofCoeffs`, `scale`, the
   rational division underlying `primitiveSquareFreeDecomposition`) are
-  documented there; `HexPolyZ` only fixes the coefficient type to
+  documented there. `HexPolyZ` only fixes the coefficient type to
   `Int` and adds the content, congruence, and Mignotte operations.
 * `HexPolyZMathlib` is the correspondence library: it identifies
   {name}`Hex.ZPoly` with Mathlib's `Polynomial ℤ` and proves the
   Mignotte bound as a theorem about the Mahler measure of the
   corresponding `Polynomial ℤ`. The executable quantities in this
-  chapter are the computational shadow of that theorem; the Mathlib
+  chapter compute the bound that theorem proves valid. The Mathlib
   dependency lives entirely there, never inside `HexPolyZ` itself.
 * `HexHensel` consumes the congruence predicate and the
   `defaultFactorCoeffBound` to drive the Hensel-lifting and

--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -48,8 +48,8 @@ tag := "hex-row-reduce-echelon"
 
 The elementary row operations ({name}`Hex.Matrix.rowSwap`,
 {name}`Hex.Matrix.rowScale`, {name}`Hex.Matrix.rowAdd`) are documented in
-{ref "hex-matrix"}[HexMatrix]. The reductions here compose them over a
-field.
+{ref "hex-matrix"}[HexMatrix]. The Gauss-Jordan reduction in this chapter
+applies these operations to a matrix over a field.
 
 An echelon computation returns a certificate of how it reduced: the
 rank, the reduced matrix, an invertible transform `T` with
@@ -69,10 +69,10 @@ conditions: each pivot is one, and every entry above a pivot is zero.
 tag := "hex-row-reduce-driver"
 %%%
 
-The driver is Gauss-Jordan elimination, returning a
-{name}`Hex.Matrix.RowEchelonData` whose record satisfies the
-reduced-form contract, with the transform equation and the rank read off
-the result.
+The driver is Gauss-Jordan elimination. It returns a
+{name}`Hex.Matrix.RowEchelonData` satisfying
+{name}`Hex.Matrix.IsRowReduced`, with the transform equation and the rank
+read off the result.
 
 {docstring Hex.Matrix.rowReduce}
 
@@ -87,10 +87,10 @@ the result.
 tag := "hex-row-reduce-span"
 %%%
 
-From the reduced form we compute what a caller wants: the linear
-combination of the rows, row-span membership with an explicit witness,
-the Boolean span test, and a nullspace basis. Each has a soundness
-theorem. The nullspace basis also has a completeness theorem.
+From the reduced form we compute the linear combination of the rows,
+row-span membership with an explicit witness, the Boolean span test, and
+a nullspace basis. Each has a soundness theorem. The nullspace basis also
+has a completeness theorem.
 
 {docstring Hex.Matrix.vecMul}
 
@@ -117,10 +117,10 @@ theorem. The nullspace basis also has a completeness theorem.
 tag := "hex-row-reduce-recipes"
 %%%
 
-Task-oriented how-tos for the things callers reach for most. Each
-executable recipe shows the idiomatic call and its result; where a
-Mathlib correspondence theorem exists, a companion recipe then shows how
-to *prove* the matching Mathlib fact by running the executable.
+These are how-to recipes for common tasks. Each executable recipe shows
+the idiomatic call and its result. Where a Mathlib correspondence theorem
+exists, a companion recipe shows how to *prove* the matching Mathlib fact
+by running the executable.
 
 ## How to find a basis for the kernel of a matrix
 %%%
@@ -129,7 +129,7 @@ tag := "hex-row-reduce-recipe-kernel"
 
 You have a matrix over a field and want a basis for its kernel: the
 vectors `x` with `M * x = 0`. Build the matrix with the `#m[...]`
-literal; {name}`Hex.Matrix.nullspaceBasisMatrix` returns the basis as
+literal. {name}`Hex.Matrix.nullspaceBasisMatrix` returns the basis as
 the columns of a matrix, one column per free (non-pivot) column of `M`.
 
 ```lean (name := kernelBasis)
@@ -197,10 +197,10 @@ theorem rank_eq_one : A.rank = 1 := by
 end HexRowReduceKernelProof
 ```
 
-`decide +kernel` runs the row reduction in the kernel and checks the
-result. It is kernel-honest: the proof depends only on `propext`,
-`Classical.choice`, and `Quot.sound`, never the compiler-trusting
-`native_decide` (banned project-wide). For the kernel as a subspace, the
+`decide +kernel` runs the row reduction in Lean's kernel and checks the
+result. The proof depends only on `propext`, `Classical.choice`, and
+`Quot.sound`, never the compiler-trusting `native_decide` (banned
+project-wide). For the kernel as a subspace, the
 same pattern uses {name}`HexMatrixMathlib.nullspace_span_eq_ker`, whose
 right-hand side is exactly the Mathlib `LinearMap.ker` of `M`'s
 `mulVecLin`.
@@ -212,7 +212,7 @@ tag := "hex-row-reduce-recipe-span"
 
 You have a matrix and a vector and want to know whether the vector is a
 linear combination of the rows. {name}`Hex.Matrix.spanContains` is the
-decidable test; {name}`Hex.Matrix.spanCoeffs` returns the witnessing
+decidable test. {name}`Hex.Matrix.spanCoeffs` returns the witnessing
 coefficients when the answer is yes.
 
 ```lean (name := spanTest)
@@ -242,8 +242,8 @@ tag := "hex-row-reduce-recipe-span-proof"
 The Mathlib-side companion, like the kernel proof above, crosses into
 Mathlib. {name}`HexMatrixMathlib.spanContains_iff_mem_span` turns the
 executable {name}`Hex.Matrix.spanContains` test into membership in
-Mathlib's `Submodule.span` of the rows, so a `Submodule.span` goal falls
-to the same run-and-rewrite move.
+Mathlib's `Submodule.span` of the rows, so a `Submodule.span` goal is
+proved the same way: rewrite through this theorem, then `decide +kernel`.
 
 ```lean
 open Hex Hex.Matrix HexMatrixMathlib
@@ -274,8 +274,8 @@ tag := "hex-row-reduce-cross-references"
 matrix type, arithmetic, and elementary operations.
 
 * {ref "hex-determinant"}[HexDeterminant] and
-  {ref "hex-bareiss"}[HexBareiss] handle the determinant; row reduction
+  {ref "hex-bareiss"}[HexBareiss] handle the determinant. Row reduction
   is the separate field-valued route for rank, span, and nullspace.
 * `HexRowReduceMathlib` identifies the executable rank, span, and
-  nullspace with Mathlib's linear algebra. `HexRowReduce` is
-  Mathlib-free.
+  nullspace with their Mathlib analogues `Matrix.rank`, `Submodule.span`,
+  and `LinearMap.ker`. `HexRowReduce` is Mathlib-free.

--- a/HexManual/README.md
+++ b/HexManual/README.md
@@ -1,16 +1,11 @@
 # HexManual
 
 The Verso reference manual for the `hex` project. Each per-library
-reference chapter lives in `Chapters/`; `HexManual.lean` is the aggregator
-that includes them.
+reference chapter lives in `Chapters/`. `HexManual.lean` serves as the table of contents
 
-Prose in the chapters follows [SPEC/writing-style.md](../SPEC/writing-style.md):
-plain, literal, mathematician-facing language, with a list of banned
-jargon words. Read it before editing a chapter.
-
-`lake build HexManual` *typechecks* the manual: every `{docstring}`,
-`{ref}`, `#eval`/`leanOutput`, and `#guard` in the chapters is checked as
-they elaborate. It does not produce a website.
+`lake build HexManual` *typechecks* the manual: it checks every
+`{docstring}`, `{ref}`, `#eval`/`leanOutput`, and `#guard` in the
+chapters as they elaborate. It does not produce a website.
 
 To view the manual, render it to static HTML with the `hexmanual`
 executable:
@@ -20,4 +15,4 @@ executable:
 
 CI publishes the rendered manual to GitHub Pages on every push to `main`
 (`.github/workflows/pages.yml`). See [PLAN/Releases.md](../PLAN/Releases.md)
-for the full render-and-publish story.
+for the full render-and-publish process.


### PR DESCRIPTION
This PR reads every sentence of the manual against a strict meaning test (is it true, does each noun denote a real thing, is the grammar plain) and rewrites the prose that only looked right. It removes abstractions that named nothing ("the canonical consumer surface", "the computational shadow of that theorem", "reduce an FpPoly into the field"), verbs applied to the wrong object (matrices that "divide", minors that "track", a correspondence that "flows"), fancy filler ("the payoff of the design is stark"), and internal roadmap jargon ("Phase 6 grind-clean state"). It corrects the HexArith claim that the `@[extern]` C code is "proved to match" its Lean model, which Lean cannot express: the C is trusted, not proved. It also documents the `Int` and `UInt64` extGcd variants that the chapter previously omitted. Net shorter, and `lake build HexManual` stays green.

🤖 Prepared with Claude Code
