### PR TITLE
refactor: rename Montgomery redc to montgomeryReduce

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -52,7 +52,7 @@ on these types. Do arithmetic with `grind`, and cross to the Mathlib
   `dite` over `Array.getInternal`. Leave such lemmas as plain `@[simp]`.
   Plain *def*-headed LHSs (`coeff`, `size`, `support`) and `Option.getD`
   LHSs are fine. A second, softer rejection: a lemma whose **conclusion is
-  wrapped in a `let`** (e.g. `redc_m_spec` in `HexArith/Montgomery/Redc.lean`:
+  wrapped in a `let`** (e.g. `montgomeryReduce_m_spec` in `HexArith/Montgomery/Redc.lean`:
   `let m := Tlo * ctx.p'; m.toNat = …`) is not a bare `Eq`, so `grind =`
   refuses it with `invalid E-matching equality theorem, conclusion must be an
   equality` even though it "looks like a literal equation." Leave such lemmas

--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -253,23 +253,23 @@ theorem mk_p_lt_R (p : UInt64) (hp : p % 2 = 1) :
 @[expose]
 def toMont (ctx : MontCtx p) (a : UInt64) : UInt64 :=
   let (hi, lo) := UInt64.mulFull a ctx.r2
-  redc ctx hi lo
+  montgomeryReduce ctx hi lo
 
 /-- Convert a Montgomery residue back to the standard representation. -/
 @[expose]
 def fromMont (ctx : MontCtx p) (a : UInt64) : UInt64 :=
-  redc ctx 0 a
+  montgomeryReduce ctx 0 a
 
 /-- Multiply two Montgomery residues, staying inside the Montgomery domain. -/
 @[expose]
 def mulMont (ctx : MontCtx p) (a b : UInt64) : UInt64 :=
   let (hi, lo) := UInt64.mulFull a b
-  redc ctx hi lo
+  montgomeryReduce ctx hi lo
 
 /--
 For reduced inputs `a, b < p`, the two-word product `a * b` (encoded as
 `lo + hi * word`) stays below `p * word`. This is the range precondition
-`redc` needs to behave as Montgomery reduction on the `mulMont` product.
+`montgomeryReduce` needs to behave as Montgomery reduction on the `mulMont` product.
 -/
 private theorem twoWordProduct_lt_p_word (ctx : MontCtx p) (a b : UInt64)
     (ha : a.toNat < p.toNat) (hb : b.toNat < p.toNat) :
@@ -286,42 +286,42 @@ private theorem twoWordProduct_lt_p_word (ctx : MontCtx p) (a b : UInt64)
     _ < p.toNat * UInt64.word := hp2_lt_pword
 
 /--
-Reducing the two-word product through `redc` produces the Montgomery
+Reducing the two-word product through `montgomeryReduce` produces the Montgomery
 representative: multiplying the result back by `word` recovers `a * b` modulo
 `p`. The `p * p' ≡ -1 (mod word)` hypothesis is the Montgomery inverse
 condition that makes the reduction exact.
 -/
-private theorem redc_mulFull_repr_word (ctx : MontCtx p) (a b : UInt64)
+private theorem montgomeryReduce_mulFull_repr_word (ctx : MontCtx p) (a b : UInt64)
     (hT :
       (UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word <
         p.toNat * UInt64.word)
     (hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1) :
-    (redc ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2).toNat *
+    (montgomeryReduce ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2).toNat *
         UInt64.word % p.toNat =
       (a.toNat * b.toNat) % p.toNat := by
-  rw [toNat_redc ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2 hT]
-  have hredc := redcNat_eq_mod ctx.p_pos ctx.p_lt_R hpp' hT
+  rw [toNat_montgomeryReduce ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2 hT]
+  have hmontgomeryReduce := montgomeryReduceNat_eq_mod ctx.p_pos ctx.p_lt_R hpp' hT
   calc
-    redcNat p.toNat ctx.p'.toNat
+    montgomeryReduceNat p.toNat ctx.p'.toNat
           ((UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word) *
         UInt64.word % p.toNat
         = ((UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat *
-            UInt64.word) % p.toNat := hredc
+            UInt64.word) % p.toNat := hmontgomeryReduce
     _ = (a.toNat * b.toNat) % p.toNat := by grind
 
 /--
-Reducing the two-word product through `redc` lands strictly below the modulus,
+Reducing the two-word product through `montgomeryReduce` lands strictly below the modulus,
 so `mulMont` returns an already-reduced residue with no extra conditional
 subtraction.
 -/
-private theorem redc_mulFull_lt (ctx : MontCtx p) (a b : UInt64)
+private theorem montgomeryReduce_mulFull_lt (ctx : MontCtx p) (a b : UInt64)
     (hT :
       (UInt64.mulFull a b).2.toNat + (UInt64.mulFull a b).1.toNat * UInt64.word <
         p.toNat * UInt64.word)
     (hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1) :
-    (redc ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2).toNat < p.toNat := by
-  rw [toNat_redc ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2 hT]
-  exact redcNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
+    (montgomeryReduce ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2).toNat < p.toNat := by
+  rw [toNat_montgomeryReduce ctx (UInt64.mulFull a b).1 (UInt64.mulFull a b).2 hT]
+  exact montgomeryReduceNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
 
 /--
 Multiplication by `word` is injective on residues modulo `p`: since `p` is odd
@@ -386,8 +386,8 @@ theorem fromMont_lt (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
   unfold fromMont
-  rw [toNat_redc ctx 0 a hT]
-  exact redcNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
+  rw [toNat_montgomeryReduce ctx 0 a hT]
+  exact montgomeryReduceNat_lt ctx.p_pos ctx.p_lt_R hpp' hT
 
 /--
 `fromMont` removes one Montgomery radix factor from a reduced Montgomery
@@ -407,9 +407,9 @@ theorem fromMont_repr (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
   unfold fromMont
-  rw [toNat_redc ctx 0 a hT]
-  have hredc := redcNat_eq_mod ctx.p_pos ctx.p_lt_R hpp' hT
-  simpa [Nat.mod_eq_of_lt haNat] using hredc
+  rw [toNat_montgomeryReduce ctx 0 a hT]
+  have hmontgomeryReduce := montgomeryReduceNat_eq_mod ctx.p_pos ctx.p_lt_R hpp' hT
+  simpa [Nat.mod_eq_of_lt haNat] using hmontgomeryReduce
 
 /-- The `Nat` value of `toMont` is multiplication by the Montgomery radix. -/
 @[simp, grind =]
@@ -426,9 +426,9 @@ theorem toNat_toMont (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   have hraw :
       (ctx.toMont a).toNat * UInt64.word % p.toNat =
         (a.toNat * ctx.r2.toNat) % p.toNat := by
-    simpa [toMont] using redc_mulFull_repr_word ctx a ctx.r2 hT hpp'
+    simpa [toMont] using montgomeryReduce_mulFull_repr_word ctx a ctx.r2 hT hpp'
   have hto_lt_nat : (ctx.toMont a).toNat < p.toNat := by
-    simpa [toMont] using redc_mulFull_lt ctx a ctx.r2 hT hpp'
+    simpa [toMont] using montgomeryReduce_mulFull_lt ctx a ctx.r2 hT hpp'
   apply cancel_word_mod_of_lt ctx
   · exact hto_lt_nat
   · exact Nat.mod_lt _ ctx.p_pos
@@ -470,7 +470,7 @@ private theorem mulMont_repr_word (ctx : MontCtx p) (a b : UInt64)
   have hT := twoWordProduct_lt_p_word ctx a b haNat hbNat
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
-  simpa [mulMont] using redc_mulFull_repr_word ctx a b hT hpp'
+  simpa [mulMont] using montgomeryReduce_mulFull_repr_word ctx a b hT hpp'
 
 /-- Montgomery conversion returns a canonical residue. -/
 @[grind =>]
@@ -485,7 +485,7 @@ theorem toMont_lt (ctx : MontCtx p) (a : UInt64) (ha : a < p) :
   have hT := twoWordProduct_lt_p_word ctx a ctx.r2 haNat hr2Nat
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
-  simpa [toMont] using redc_mulFull_lt ctx a ctx.r2 hT hpp'
+  simpa [toMont] using montgomeryReduce_mulFull_lt ctx a ctx.r2 hT hpp'
 
 /-- Montgomery multiplication returns a canonical residue. -/
 @[grind =>]
@@ -499,7 +499,7 @@ theorem mulMont_lt (ctx : MontCtx p) (a b : UInt64) (ha : a < p) (hb : b < p) :
   have hT := twoWordProduct_lt_p_word ctx a b haNat hbNat
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
-  simpa [mulMont] using redc_mulFull_lt ctx a b hT hpp'
+  simpa [mulMont] using montgomeryReduce_mulFull_lt ctx a b hT hpp'
 
 /-- Montgomery multiplication preserves the represented residue product. -/
 @[grind =]

--- a/HexArith/Montgomery/Redc.lean
+++ b/HexArith/Montgomery/Redc.lean
@@ -33,11 +33,11 @@ structure MontCtx (p : UInt64) where
   r2_eq : r2.toNat = (UInt64.word * UInt64.word) % p.toNat
 
 /--
-Executable Montgomery reduction from a two-word product `(Thi, Tlo)` encoded in
-base `2^64`.
+Executable Montgomery reduction (classically `REDC`) from a two-word product
+`(Thi, Tlo)` encoded in base `2^64`.
 -/
 @[expose]
-def redc (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
+def montgomeryReduce (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
   let m := Tlo * ctx.p'
   let (mhi, mlo) := UInt64.mulFull m p
   let (_, c1) := UInt64.addCarry Tlo mlo false
@@ -50,7 +50,7 @@ def redc (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
     addHi
 
 /-- A word-sized value plus its `R - 1` multiple vanishes modulo `R`. -/
-private theorem redc_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
+private theorem montgomeryReduce_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
     (a + (a * (UInt64.word - 1)) % UInt64.word) % UInt64.word = 0 := by
   have hword_pos : 0 < UInt64.word := by
     simp [UInt64.word]
@@ -73,7 +73,7 @@ private theorem redc_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
           rw [hmul, Nat.mul_mod_left]
 
 /-- The low-word Montgomery correction makes the adjusted low word zero modulo `R`. -/
-private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
+private theorem montgomeryReduce_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
     let m := Tlo * ctx.p'
     (Tlo.toNat + (m * p).toNat) % UInt64.word = 0 := by
   intro m
@@ -108,10 +108,10 @@ private theorem redc_low_correction_zero (ctx : MontCtx p) (Tlo : UInt64) :
           rw [Nat.mul_mod, Nat.mod_eq_of_lt hTlo]
     _ = 0 := by
           rw [hpp']
-          exact redc_cancel_pred_word Tlo.toNat hTlo
+          exact montgomeryReduce_cancel_pred_word Tlo.toNat hTlo
 
 /-- The first add-with-carry step computes an exact carry and a zero low word. -/
-private theorem redc_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
+private theorem montgomeryReduce_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
     let m := Tlo * ctx.p'
     let (lo, c1) := UInt64.addCarry Tlo (m * p) false
     lo.toNat = 0 ∧ Tlo.toNat + (m * p).toNat = c1.toNat * UInt64.word := by
@@ -121,7 +121,7 @@ private theorem redc_low_addCarry_exact (ctx : MontCtx p) (Tlo : UInt64) :
       have hcarry := UInt64.toNat_addCarry Tlo (m * p) false
       simp [hcarry_pair] at hcarry
       have hmod : (Tlo.toNat + (m * p).toNat) % UInt64.word = 0 := by
-        simpa [m] using redc_low_correction_zero ctx Tlo
+        simpa [m] using montgomeryReduce_low_correction_zero ctx Tlo
       have hmul_toNat : (m * p).toNat = m.toNat * p.toNat % UInt64.word := by
         simp [UInt64.toNat_mul, UInt64.word]
       have hlo : lo.toNat < UInt64.word := by
@@ -158,7 +158,7 @@ private theorem MontCtx.p_lt_word (_ctx : MontCtx p) : p.toNat < UInt64.word := 
 
 /-- The low-word multiply computes the Montgomery correction factor `m`. -/
 @[simp]
-theorem redc_m_spec (ctx : MontCtx p) (_Thi Tlo : UInt64) :
+theorem montgomeryReduce_m_spec (ctx : MontCtx p) (_Thi Tlo : UInt64) :
     let m := Tlo * ctx.p'
     m.toNat = (Tlo.toNat * ctx.p'.toNat) % UInt64.word := by
   simp [UInt64.toNat_mul, UInt64.word]
@@ -168,7 +168,7 @@ The carry pair `(c2, addHi)` represents the exact quotient `u`, stated over the
 `(mhi, mlo)` pair returned by `UInt64.mulFull m p` rather than the split
 `(UInt64.mulHi m p, m * p)` view.
 -/
-theorem redc_u_spec (ctx : MontCtx p) (Thi Tlo : UInt64) :
+theorem montgomeryReduce_u_spec (ctx : MontCtx p) (Thi Tlo : UInt64) :
     let m := Tlo * ctx.p'
     let (mhi, mlo) := UInt64.mulFull m p
     let (_, c1) := UInt64.addCarry Tlo mlo false
@@ -181,7 +181,7 @@ theorem redc_u_spec (ctx : MontCtx p) (Thi Tlo : UInt64) :
   | mk lo c1 =>
       have hlow : lo.toNat = 0 ∧
           Tlo.toNat + (m * p).toNat = c1.toNat * UInt64.word := by
-        simpa [m, hlow_pair] using redc_low_addCarry_exact ctx Tlo
+        simpa [m, hlow_pair] using montgomeryReduce_low_addCarry_exact ctx Tlo
       cases hhi_pair : UInt64.addCarry Thi (UInt64.mulHi m p) c1 with
       | mk addHi c2 =>
           have hhi := UInt64.toNat_addCarry Thi (UInt64.mulHi m p) c1
@@ -211,10 +211,10 @@ theorem redc_u_spec (ctx : MontCtx p) (Thi Tlo : UInt64) :
           simpa [hlow_pair, hhi_pair] using hresult
 
 /-- The final subtraction logic matches the Nat-level REDC normalization step. -/
-theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
+theorem montgomeryReduce_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
     (hT : Tlo.toNat + Thi.toNat * UInt64.word < p.toNat * UInt64.word) :
-    (redc ctx Thi Tlo).toNat =
-      redcNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word) := by
+    (montgomeryReduce ctx Thi Tlo).toNat =
+      montgomeryReduceNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word) := by
   let m := Tlo * ctx.p'
   have hTmod :
       (Tlo.toNat + Thi.toNat * UInt64.word) % UInt64.word = Tlo.toNat := by
@@ -227,8 +227,8 @@ theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
         ((Tlo.toNat + Thi.toNat * UInt64.word) % UInt64.word) * ctx.p'.toNat %
           UInt64.word := by
     rw [hTmod]
-    exact redc_m_spec ctx Thi Tlo
-  unfold redc
+    exact montgomeryReduce_m_spec ctx Thi Tlo
+  unfold montgomeryReduce
   change
     (match UInt64.mulFull m p with
       | (mhi, mlo) =>
@@ -237,14 +237,14 @@ theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
           match UInt64.addCarry Thi mhi c1 with
           | (addHi, c2) =>
             if c2 then addHi - p else if addHi ≥ p then addHi - p else addHi).toNat =
-      redcNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word)
+      montgomeryReduceNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word)
   cases hfull_pair : UInt64.mulFull m p with
   | mk mhi mlo =>
       cases hlow_pair : UInt64.addCarry Tlo mlo false with
       | mk lo c1 =>
           cases hhi_pair : UInt64.addCarry Thi mhi c1 with
           | mk addHi c2 =>
-              have hu := redc_u_spec ctx Thi Tlo
+              have hu := montgomeryReduce_u_spec ctx Thi Tlo
               simp [m, hfull_pair, hlow_pair, hhi_pair] at hu
               have hp_pos := ctx.p_pos
               have hp_lt := ctx.p_lt_word
@@ -253,8 +253,8 @@ theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
               have hu_lt :
                   addHi.toNat + c2.toNat * UInt64.word < 2 * p.toNat := by
                 rw [hu]
-                simpa [hTmod, UInt64.word] using redcNat_u_lt_two_p hp_pos hp_lt hpp' hT
-              simp [redcNat, hTmod]
+                simpa [hTmod, UInt64.word] using montgomeryReduceNat_u_lt_two_p hp_pos hp_lt hpp' hT
+              simp [montgomeryReduceNat, hTmod]
               simp only [UInt64.word] at hu ⊢
               rw [← hu]
               cases c2
@@ -294,32 +294,32 @@ theorem redc_sub_spec (ctx : MontCtx p) (Thi Tlo : UInt64)
                 exact (Nat.sub_add_comm (Nat.le_of_lt hp_lt_lit)).symm
 
 /-- The executable REDC routine agrees with the Nat-level specification. -/
-theorem toNat_redc (ctx : MontCtx p) (Thi Tlo : UInt64)
+theorem toNat_montgomeryReduce (ctx : MontCtx p) (Thi Tlo : UInt64)
     (hT : Tlo.toNat + Thi.toNat * UInt64.word < p.toNat * UInt64.word) :
-    (redc ctx Thi Tlo).toNat =
-      redcNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word) := by
-  exact redc_sub_spec ctx Thi Tlo hT
+    (montgomeryReduce ctx Thi Tlo).toNat =
+      montgomeryReduceNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * UInt64.word) := by
+  exact montgomeryReduce_sub_spec ctx Thi Tlo hT
 
 /-- Executable REDC returns a canonical residue below the modulus. -/
-theorem redc_lt (ctx : MontCtx p) (Thi Tlo : UInt64)
+theorem montgomeryReduce_lt (ctx : MontCtx p) (Thi Tlo : UInt64)
     (hT : Tlo.toNat + Thi.toNat * UInt64.word < p.toNat * UInt64.word) :
-    redc ctx Thi Tlo < p := by
-  rw [UInt64.lt_iff_toNat_lt, toNat_redc ctx Thi Tlo hT]
+    montgomeryReduce ctx Thi Tlo < p := by
+  rw [UInt64.lt_iff_toNat_lt, toNat_montgomeryReduce ctx Thi Tlo hT]
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
-  exact redcNat_lt ctx.p_pos ctx.p_lt_word hpp' hT
+  exact montgomeryReduceNat_lt ctx.p_pos ctx.p_lt_word hpp' hT
 
 /--
 Executable REDC represents division by the Montgomery radix modulo `p`.
 
-This is the direct executable form of `redcNat_eq_mod`, avoiding an explicit
+This is the direct executable form of `montgomeryReduceNat_eq_mod`, avoiding an explicit
 unfolding through the Nat-level REDC definition for downstream callers.
 -/
-theorem redc_mul_word_mod (ctx : MontCtx p) (Thi Tlo : UInt64)
+theorem montgomeryReduce_mul_word_mod (ctx : MontCtx p) (Thi Tlo : UInt64)
     (hT : Tlo.toNat + Thi.toNat * UInt64.word < p.toNat * UInt64.word) :
-    (redc ctx Thi Tlo).toNat * UInt64.word % p.toNat =
+    (montgomeryReduce ctx Thi Tlo).toNat * UInt64.word % p.toNat =
       (Tlo.toNat + Thi.toNat * UInt64.word) % p.toNat := by
-  rw [toNat_redc ctx Thi Tlo hT]
+  rw [toNat_montgomeryReduce ctx Thi Tlo hT]
   have hpp' : p.toNat * ctx.p'.toNat % UInt64.word = UInt64.word - 1 := by
     simpa [Nat.mul_comm] using ctx.p'_eq
-  exact redcNat_eq_mod ctx.p_pos ctx.p_lt_word hpp' hT
+  exact montgomeryReduceNat_eq_mod ctx.p_pos ctx.p_lt_word hpp' hT

--- a/HexArith/Montgomery/RedcNat.lean
+++ b/HexArith/Montgomery/RedcNat.lean
@@ -21,18 +21,18 @@ is proved against these definitions.
 
 /-- Nat-level Montgomery reduction with radix `R = 2^64`. -/
 @[expose]
-def redcNat (p p' T : Nat) : Nat :=
+def montgomeryReduceNat (p p' T : Nat) : Nat :=
   let m := (T % UInt64.word) * p' % UInt64.word
   let u := (T + m * p) / UInt64.word
   if u < p then u else u - p
 
 /-- Reducing `T` before multiplying by `p'` does not change the correction word. -/
-private theorem redcNat_correction_eq (p' T : Nat) :
+private theorem montgomeryReduceNat_correction_eq (p' T : Nat) :
     T * p' % UInt64.word = (T % UInt64.word) * p' % UInt64.word := by
   rw [Nat.mul_mod T p' UInt64.word, Nat.mul_mod (T % UInt64.word) p' UInt64.word, Nat.mod_mod]
 
 /-- A word-sized value plus its `R - 1` multiple vanishes modulo `R`. -/
-private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
+private theorem montgomeryReduceNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
     (a + (a * (UInt64.word - 1)) % UInt64.word) % UInt64.word = 0 := by
   have hword_pos : 0 < UInt64.word := by
     simp [UInt64.word]
@@ -55,7 +55,7 @@ private theorem redcNat_cancel_pred_word (a : Nat) (ha : a < UInt64.word) :
           rw [hmul, Nat.mul_mod_left]
 
 /-- The Montgomery correction makes the adjusted numerator exactly divisible by `R`. -/
-private theorem redcNat_exact_dvd (p p' T : Nat)
+private theorem montgomeryReduceNat_exact_dvd (p p' T : Nat)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) :
     UInt64.word ∣ T + ((T % UInt64.word) * p' % UInt64.word) * p := by
   rw [Nat.dvd_iff_mod_eq_zero]
@@ -90,11 +90,11 @@ private theorem redcNat_exact_dvd (p p' T : Nat)
           rw [Nat.mul_mod, Nat.mod_mod]
     _ = 0 := by
           rw [hpp']
-          exact redcNat_cancel_pred_word (T % UInt64.word)
+          exact montgomeryReduceNat_cancel_pred_word (T % UInt64.word)
             (Nat.mod_lt T hword_pos)
 
 /-- Core quotient bound before threading the inverse and modulus-size hypotheses. -/
-private theorem redcNat_u_lt_two_p_core (hp_pos : 0 < p)
+private theorem montgomeryReduceNat_u_lt_two_p_core (hp_pos : 0 < p)
     (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have hword_pos : 0 < UInt64.word := by
@@ -121,16 +121,16 @@ private theorem redcNat_u_lt_two_p_core (hp_pos : 0 < p)
 /--
 Montgomery reduction computes a residue congruent to `T * R⁻¹` modulo `p`.
 -/
-theorem redcNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
+theorem montgomeryReduceNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) (hT : T < p * UInt64.word) :
-    redcNat p p' T * UInt64.word % p = T % p := by
+    montgomeryReduceNat p p' T * UInt64.word % p = T % p := by
   have _hp_pos : 0 < p := hp_pos
   have _hp_lt : p < UInt64.word := hp_lt
   have _hT : T < p * UInt64.word := hT
-  have hc := redcNat_correction_eq p' T
+  have hc := montgomeryReduceNat_correction_eq p' T
   have hdvd : UInt64.word ∣ T + (T * p' % UInt64.word) * p := by
     rw [hc]
-    exact redcNat_exact_dvd p p' T hpp'
+    exact montgomeryReduceNat_exact_dvd p p' T hpp'
   let u := (T + (T * p' % UInt64.word) * p) / UInt64.word
   have hdiv : u * UInt64.word = T + (T * p' % UInt64.word) * p := by
     exact Nat.div_mul_cancel hdvd
@@ -141,12 +141,12 @@ theorem redcNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
       _ = T % p := by
         rw [Nat.add_mul_mod_self_right]
   by_cases h : u < p
-  · simp [redcNat, h, u]
+  · simp [montgomeryReduceNat, h, u]
     exact hu_mod
   · have hpu : p ≤ u := Nat.le_of_not_lt h
     have hsub : (u - p) * UInt64.word + p * UInt64.word = u * UInt64.word := by
       rw [← Nat.add_mul, Nat.sub_add_cancel hpu]
-    simp [redcNat, h, u]
+    simp [montgomeryReduceNat, h, u]
     calc
       (u - p) * UInt64.word % p
           = ((u - p) * UInt64.word + p * UInt64.word) % p := by
@@ -156,27 +156,27 @@ theorem redcNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
       _ = T % p := hu_mod
 
 /-- Montgomery reduction lands in the canonical residue interval `[0, p)`. -/
-theorem redcNat_lt (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
+theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) (hT : T < p * UInt64.word) :
-    redcNat p p' T < p := by
+    montgomeryReduceNat p p' T < p := by
   have _hp_lt : p < UInt64.word := hp_lt
   have _hpp' : p * p' % UInt64.word = UInt64.word - 1 := hpp'
-  have hc := redcNat_correction_eq p' T
+  have hc := montgomeryReduceNat_correction_eq p' T
   have hu : (T + (T * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
     rw [hc]
-    exact redcNat_u_lt_two_p_core hp_pos hT
+    exact montgomeryReduceNat_u_lt_two_p_core hp_pos hT
   by_cases h : (T + (T * p' % UInt64.word) * p) / UInt64.word < p
-  · simp [redcNat, h]
-  · simp [redcNat, h]
+  · simp [montgomeryReduceNat, h]
+  · simp [montgomeryReduceNat, h]
     omega
 
 /--
 The unreduced Montgomery quotient is always below `2p`, so one subtraction is
 enough to normalize the result.
 -/
-theorem redcNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
+theorem montgomeryReduceNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < UInt64.word)
     (hpp' : p * p' % UInt64.word = UInt64.word - 1) (hT : T < p * UInt64.word) :
     (T + ((T % UInt64.word) * p' % UInt64.word) * p) / UInt64.word < 2 * p := by
   have _hp_lt : p < UInt64.word := hp_lt
   have _hpp' : p * p' % UInt64.word = UInt64.word - 1 := hpp'
-  exact redcNat_u_lt_two_p_core hp_pos hT
+  exact montgomeryReduceNat_u_lt_two_p_core hp_pos hT

--- a/HexArith/SPEC/hex-arith.md
+++ b/HexArith/SPEC/hex-arith.md
@@ -280,20 +280,20 @@ Needed because `omega` won't solve nonlinear modular goals.
 stated and proved at `Nat` with `R = 2^64`. No `UInt64` appears:
 
 ```lean
-def redcNat (p p' T : Nat) : Nat :=
+def montgomeryReduceNat (p p' T : Nat) : Nat :=
   let m := (T % R) * p' % R
   let u := (T + m * p) / R
   if u < p then u else u - p
 
-theorem redcNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < R)
+theorem montgomeryReduceNat_eq_mod (hp_pos : 0 < p) (hp_lt : p < R)
     (hpp' : p * p' % R = R - 1) (hT : T < p * R) :
-    redcNat p p' T * R % p = T % p
+    montgomeryReduceNat p p' T * R % p = T % p
 
-theorem redcNat_lt (hp_pos : 0 < p) (hp_lt : p < R)
+theorem montgomeryReduceNat_lt (hp_pos : 0 < p) (hp_lt : p < R)
     (hpp' : p * p' % R = R - 1) (hT : T < p * R) :
-    redcNat p p' T < p
+    montgomeryReduceNat p p' T < p
 
-theorem redcNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < R)
+theorem montgomeryReduceNat_u_lt_two_p (hp_pos : 0 < p) (hp_lt : p < R)
     (hpp' : p * p' % R = R - 1) (hT : T < p * R) :
     (T + ((T % R) * p' % R) * p) / R < 2 * p
 ```
@@ -329,13 +329,13 @@ Note: `2 - p*x` is computed in wrapping UInt64 arithmetic (underflows
 in `Nat`). The Nat-level proof works mod `2^(2k)`.
 
 *Layer 5 — `HexArith/Montgomery/Redc.lean` (UInt64 bridge).* Executable
-REDC in `UInt64`, proven equivalent to `redcNat` via intermediate lemmas
+REDC in `UInt64`, proven equivalent to `montgomeryReduceNat` via intermediate lemmas
 (not definitional equality — executable code uses `mulHi`/carries while
-`redcNat` uses division). Key subtlety: `u < 2p` may exceed `UInt64.size`
+`montgomeryReduceNat` uses division). Key subtlety: `u < 2p` may exceed `UInt64.size`
 when `p` is near `2^64`, so `u` is a 65-bit value `(carry, lo) : Bool × UInt64`:
 
 ```lean
-def redc (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
+def montgomeryReduce (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
   let m := Tlo * ctx.p'
   let (_, c1) := UInt64.addCarry Tlo (m * p) false
   let (addHi, c2) := UInt64.addCarry Thi (mulHi m p) c1
@@ -343,18 +343,18 @@ def redc (ctx : MontCtx p) (Thi Tlo : UInt64) : UInt64 :=
   else if addHi ≥ p then addHi - p else addHi
 
 -- Intermediate bridge lemmas
-theorem redc_m_spec ...    -- m.toNat = (T % R) * p'.toNat % R
-theorem redc_u_spec ...    -- (c2, addHi) represents u = (T + m*p) / R
-theorem redc_sub_spec ...  -- conditional subtraction matches redcNat
+theorem montgomeryReduce_m_spec ...    -- m.toNat = (T % R) * p'.toNat % R
+theorem montgomeryReduce_u_spec ...    -- (c2, addHi) represents u = (T + m*p) / R
+theorem montgomeryReduce_sub_spec ...  -- conditional subtraction matches montgomeryReduceNat
 
-theorem toNat_redc (ctx : MontCtx p) (Thi Tlo : UInt64)
+theorem toNat_montgomeryReduce (ctx : MontCtx p) (Thi Tlo : UInt64)
     (hT : Tlo.toNat + Thi.toNat * 2^64 < p.toNat * 2^64) :
-    (redc ctx Thi Tlo).toNat =
-      redcNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * 2^64)
+    (montgomeryReduce ctx Thi Tlo).toNat =
+      montgomeryReduceNat p.toNat ctx.p'.toNat (Tlo.toNat + Thi.toNat * 2^64)
 ```
 
 *Layer 6 — `HexArith/Montgomery/Context.lean` (user-facing API).*
-Definitions of `toMont`, `fromMont`, `mulMont` in terms of `redc`,
+Definitions of `toMont`, `fromMont`, `mulMont` in terms of `montgomeryReduce`,
 plus derived Nat-level projections (`p_pos`, `p_lt_R`, `p_odd_nat`)
 proved once on `MontCtx`, bounds/closure lemmas (`toMont_lt`,
 `mulMont_lt`), a Montgomery domain invariant (`mulMont_repr`), and

--- a/HexManual/Chapters/HexArith.lean
+++ b/HexManual/Chapters/HexArith.lean
@@ -31,7 +31,7 @@ It has four pieces. The wide-word `UInt64` operations give a two-word
 view of machine arithmetic (full products and add/subtract-with-carry),
 so higher libraries can build multi-word modular reduction in
 native-word code. Two single-word modular reducers,
-{name}`barrettReduce` (Barrett) and {name}`redc` (Montgomery), each come
+{name}`barrettReduce` and {name}`montgomeryReduce`, each come
 with a `Nat`-level model stating the arithmetic before the machine-word
 encoding is pinned down. {name}`HexArith.extGcd` is the extended
 Euclidean algorithm in three flavours (`Nat`, GMP-backed `Int`, and
@@ -172,28 +172,28 @@ multiply-add-shift with no trial division at all. As with Barrett, a
 `Nat`-level model states the computation before the machine-word
 encoding.
 
-{docstring redcNat}
+{docstring montgomeryReduceNat}
 
 The model is proved to compute the reduced residue exactly and to land
 below the modulus, given the precomputed inverse word `p'` and an odd
 modulus below the radix.
 
-{docstring redcNat_eq_mod}
+{docstring montgomeryReduceNat_eq_mod}
 
-{docstring redcNat_lt}
+{docstring montgomeryReduceNat_lt}
 
 The executable side carries the machine-word Montgomery parameters in
-a {name}`MontCtx`; {name}`redc` consumes a two-word product `(Thi, Tlo)`
+a {name}`MontCtx`; {name}`montgomeryReduce` consumes a two-word product `(Thi, Tlo)`
 and returns one reduced residue, proved to match the `Nat` model and to
 stay canonical.
 
 {docstring MontCtx}
 
-{docstring redc}
+{docstring montgomeryReduce}
 
-{docstring toNat_redc}
+{docstring toNat_montgomeryReduce}
 
-{docstring redc_lt}
+{docstring montgomeryReduce_lt}
 
 # Trial-division primality
 %%%

--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -99,7 +99,7 @@ the C body, in order of simplicity:
    per modulus (lifted from `MontCtx` in `hex-arith`) when
    `p % 2 = 1`. ~10 cycles per multiply with values stored in
    Montgomery form internally; `ZMod64.mul` exposes standard form,
-   so this strategy adds two `redc`s per call to amortize.
+   so this strategy adds two `montgomeryReduce`s per call to amortize.
 
 The Phase-1 deliverable is the strategy-1 reference body plus the
 `@[extern]` wiring; later phases may swap the body for a


### PR DESCRIPTION
This PR renames the executable Montgomery reducer `redc` to `montgomeryReduce` and its Nat-level model `redcNat` to `montgomeryReduceNat`, along with their specification lemmas, so the two single-word reducers read as a matched pair alongside `barrettReduce`. REDC is the classical name (Montgomery, 1985) but is opaque to readers who do not know it; the `montgomeryReduce` docstring keeps REDC as the classical reference. This is a breaking rename of public `HexArith` API, but nothing else in the tree references it by name (only through `MontCtx`). No behaviour changes; HexArith, HexModArith, and the HexArith manual chapter build.

🤖 Prepared with Claude Code
