### PR TITLE
ci: let the Pages publish finish instead of cancelling it

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A render takes ~20 min. Let an in-flight publish finish and queue the
+  # next push behind it, rather than cancelling it: cancelling on every
+  # push left the published site several commits behind `main` on busy days.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
This PR sets `cancel-in-progress: false` on the Pages publish workflow. A manual render takes about 20 minutes, and with `cancel-in-progress: true` each push to `main` cancelled the previous render before it could deploy, so on a busy day the published site sat several commits behind `main` indefinitely. Letting an in-flight publish finish and queuing the next push behind it makes the site reliably catch up to the latest commit.

🤖 Prepared with Claude Code
