### PR TITLE
feat: classical-core completeness structural lemmas for reassembly

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -8186,6 +8186,227 @@ theorem scaledRecombinationSmartCandLoop_shouldRecord
 termination_by fuel
 end
 
+mutual
+/-- Every factor emitted by the size-ordered recombination search is fixed by
+`normalizeFactorSign`: each recorded candidate is `normalizeFactorSign …` by
+construction, so `normalizeFactorSign_idem` closes it. Shared conclusion across
+the three loops, proved by structural recursion on `fuel`. Sibling of
+`scaledRecombinationSmartAux_shouldRecord`; consumed by the classical-tier
+completeness wiring. -/
+theorem scaledRecombinationSmartAux_normalizeFactorSign
+    (coreLc : Int) (target : ZPoly) (modulus : Nat) (localFactors : List ZPoly)
+    (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartAux coreLc target modulus localFactors budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, normalizeFactorSign g = g := by
+  unfold scaledRecombinationSmartAux at h
+  split at h
+  · simp only [Prod.mk.injEq, Option.some.injEq] at h
+    obtain ⟨hf, _⟩ := h; subst hf; intro g hg; simp at hg
+  · split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · split at h
+        · simp at h
+        · exact scaledRecombinationSmartSizeLoop_normalizeFactorSign _ _ _ _ _ _ _ _ _ _ h
+termination_by fuel
+
+theorem scaledRecombinationSmartSizeLoop_normalizeFactorSign
+    (coreLc : Int) (target : ZPoly) (modulus : Nat) (head : ZPoly) (tail : List ZPoly)
+    (sizes : List Nat) (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartSizeLoop coreLc target modulus head tail sizes budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, normalizeFactorSign g = g := by
+  unfold scaledRecombinationSmartSizeLoop at h
+  split at h
+  · simp at h
+  · split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · simp only [] at h
+        split at h
+        · rename_i res bres hcand
+          simp only [Prod.mk.injEq, Option.some.injEq] at h
+          obtain ⟨hres, _⟩ := h; subst hres
+          exact scaledRecombinationSmartCandLoop_normalizeFactorSign _ _ _ _ _ _ _ _ hcand
+        · exact scaledRecombinationSmartSizeLoop_normalizeFactorSign _ _ _ _ _ _ _ _ _ _ h
+termination_by fuel
+
+theorem scaledRecombinationSmartCandLoop_normalizeFactorSign
+    (coreLc : Int) (target : ZPoly) (modulus : Nat)
+    (splits : List (List ZPoly × List ZPoly)) (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartCandLoop coreLc target modulus splits budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, normalizeFactorSign g = g := by
+  unfold scaledRecombinationSmartCandLoop at h
+  split at h
+  · simp at h
+  · rename_i split rest
+    split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · rename_i fuel'
+        simp only [] at h
+        split at h
+        · rename_i hrecord
+          cases hquot : exactQuotient? target
+              (normalizeFactorSign (ZPoly.primitivePart
+                (ZPoly.dilate coreLc (centeredLiftPoly (Array.polyProduct split.1.toArray) modulus)))) with
+          | none =>
+              simp only [hquot] at h
+              exact scaledRecombinationSmartCandLoop_normalizeFactorSign _ _ _ _ _ _ _ _ h
+          | some quotient =>
+              simp only [hquot] at h
+              cases haux : scaledRecombinationSmartAux coreLc quotient modulus split.2
+                  (budget - 1) fuel' with
+              | mk ores ob =>
+                  cases ores with
+                  | none =>
+                      simp only [haux] at h
+                      exact scaledRecombinationSmartCandLoop_normalizeFactorSign _ _ _ _ _ _ _ _ h
+                  | some sub =>
+                      simp only [haux] at h
+                      simp only [Prod.mk.injEq, Option.some.injEq] at h
+                      obtain ⟨hfac, _⟩ := h; subst hfac
+                      intro g hg
+                      rcases List.mem_cons.mp hg with hg_eq | hg_sub
+                      · subst hg_eq
+                        exact normalizeFactorSign_idem
+                          (ZPoly.primitivePart (ZPoly.dilate coreLc
+                            (centeredLiftPoly (Array.polyProduct split.1.toArray) modulus)))
+                      · exact scaledRecombinationSmartAux_normalizeFactorSign _ _ _ _ _ _ _ _ haux g hg_sub
+        · exact scaledRecombinationSmartCandLoop_normalizeFactorSign _ _ _ _ _ _ _ _ h
+termination_by fuel
+end
+
+mutual
+/-- Every factor emitted by the size-ordered recombination search is primitive:
+each recorded candidate is `normalizeFactorSign (primitivePart …)`, and the
+`shouldRecordPolynomialFactor` gate forces the candidate nonzero, hence the inner
+`primitivePart` argument has nonzero content, so the candidate is primitive.
+Shared conclusion across the three loops, proved by structural recursion on
+`fuel`. Consumed by the classical-tier completeness wiring (positive degree
+via `degree_pos_of_primitive_norm_record`). -/
+theorem scaledRecombinationSmartAux_primitive
+    (coreLc : Int) (target : ZPoly) (modulus : Nat) (localFactors : List ZPoly)
+    (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartAux coreLc target modulus localFactors budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, ZPoly.Primitive g := by
+  unfold scaledRecombinationSmartAux at h
+  split at h
+  · simp only [Prod.mk.injEq, Option.some.injEq] at h
+    obtain ⟨hf, _⟩ := h; subst hf; intro g hg; simp at hg
+  · split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · split at h
+        · simp at h
+        · exact scaledRecombinationSmartSizeLoop_primitive _ _ _ _ _ _ _ _ _ _ h
+termination_by fuel
+
+theorem scaledRecombinationSmartSizeLoop_primitive
+    (coreLc : Int) (target : ZPoly) (modulus : Nat) (head : ZPoly) (tail : List ZPoly)
+    (sizes : List Nat) (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartSizeLoop coreLc target modulus head tail sizes budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, ZPoly.Primitive g := by
+  unfold scaledRecombinationSmartSizeLoop at h
+  split at h
+  · simp at h
+  · split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · simp only [] at h
+        split at h
+        · rename_i res bres hcand
+          simp only [Prod.mk.injEq, Option.some.injEq] at h
+          obtain ⟨hres, _⟩ := h; subst hres
+          exact scaledRecombinationSmartCandLoop_primitive _ _ _ _ _ _ _ _ hcand
+        · exact scaledRecombinationSmartSizeLoop_primitive _ _ _ _ _ _ _ _ _ _ h
+termination_by fuel
+
+theorem scaledRecombinationSmartCandLoop_primitive
+    (coreLc : Int) (target : ZPoly) (modulus : Nat)
+    (splits : List (List ZPoly × List ZPoly)) (budget fuel : Nat) (factors : List ZPoly) (b : Nat)
+    (h : scaledRecombinationSmartCandLoop coreLc target modulus splits budget fuel
+        = (some factors, b)) :
+    ∀ g ∈ factors, ZPoly.Primitive g := by
+  unfold scaledRecombinationSmartCandLoop at h
+  split at h
+  · simp at h
+  · rename_i split rest
+    split at h
+    · simp at h
+    · split at h
+      · simp at h
+      · rename_i fuel'
+        simp only [] at h
+        split at h
+        · rename_i hrecord
+          cases hquot : exactQuotient? target
+              (normalizeFactorSign (ZPoly.primitivePart
+                (ZPoly.dilate coreLc (centeredLiftPoly (Array.polyProduct split.1.toArray) modulus)))) with
+          | none =>
+              simp only [hquot] at h
+              exact scaledRecombinationSmartCandLoop_primitive _ _ _ _ _ _ _ _ h
+          | some quotient =>
+              simp only [hquot] at h
+              cases haux : scaledRecombinationSmartAux coreLc quotient modulus split.2
+                  (budget - 1) fuel' with
+              | mk ores ob =>
+                  cases ores with
+                  | none =>
+                      simp only [haux] at h
+                      exact scaledRecombinationSmartCandLoop_primitive _ _ _ _ _ _ _ _ h
+                  | some sub =>
+                      simp only [haux] at h
+                      simp only [Prod.mk.injEq, Option.some.injEq] at h
+                      obtain ⟨hfac, _⟩ := h; subst hfac
+                      intro g hg
+                      rcases List.mem_cons.mp hg with hg_eq | hg_sub
+                      · subst hg_eq
+                        have hcand_ne :
+                            normalizeFactorSign (ZPoly.primitivePart
+                                (ZPoly.dilate coreLc
+                                  (centeredLiftPoly
+                                    (Array.polyProduct split.1.toArray) modulus))) ≠ 0 := by
+                          unfold shouldRecordPolynomialFactor at hrecord
+                          simp at hrecord
+                          exact hrecord.1.1
+                        have hpp_ne :
+                            ZPoly.primitivePart
+                                (ZPoly.dilate coreLc
+                                  (centeredLiftPoly
+                                    (Array.polyProduct split.1.toArray) modulus)) ≠ 0 := by
+                          intro hpp
+                          apply hcand_ne
+                          rw [hpp]
+                          unfold normalizeFactorSign
+                          rw [if_neg
+                            (by decide : ¬ DensePoly.leadingCoeff (0 : ZPoly) < 0)]
+                        have hcontent_ne :
+                            ZPoly.content
+                                (ZPoly.dilate coreLc
+                                  (centeredLiftPoly
+                                    (Array.polyProduct split.1.toArray) modulus)) ≠ 0 := by
+                          intro hcontent
+                          apply hpp_ne
+                          show DensePoly.primitivePart _ = 0
+                          exact DensePoly.primitivePart_eq_zero_of_content_eq_zero _
+                            (by simpa [ZPoly.content] using hcontent)
+                        exact normalizeFactorSign_primitive _
+                          (ZPoly.primitivePart_primitive _ hcontent_ne)
+                      · exact scaledRecombinationSmartAux_primitive _ _ _ _ _ _ _ _ haux g hg_sub
+        · exact scaledRecombinationSmartCandLoop_primitive _ _ _ _ _ _ _ _ h
+termination_by fuel
+end
+
 /-- Exhaustive recombination of the lifted local factors stored in `d`,
 using the *scaled* candidate shape parameterised by the integer leading
 coefficient `coreLc`.  Returns the recovered integer factors as an array
@@ -14193,6 +14414,124 @@ theorem degree_pos_of_primitive_norm_record
       rfl
     unfold shouldRecordPolynomialFactor at hq_record
     simp [hq_one] at hq_record
+
+/-- Structural case-split for the size-ordered classical recombination core.
+Every `some cf` result of `classicalCoreFactorsWithBound` is either the
+short-circuit singleton `#[core]` (the `B = 0`, budget-`none`, and empty-result
+arms all return `#[core]`) or the array of a nonempty recombination result, in
+which case the product reconstructs `core` and each factor is
+`normalizeFactorSign`-fixed, primitive, and recorded. The trio
+`classicalCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`
+below are thin consumers, mirroring the exhaustive-tier structural trio. -/
+private theorem classicalCoreFactorsWithBound_spec
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    {cf : Array ZPoly}
+    (h : classicalCoreFactorsWithBound core B primeData = some cf) :
+    cf = #[core] ∨
+      (Array.polyProduct cf = core ∧
+        (∀ g ∈ cf.toList, normalizeFactorSign g = g) ∧
+        (∀ g ∈ cf.toList, ZPoly.Primitive g) ∧
+        (∀ g ∈ cf.toList, shouldRecordPolynomialFactor g = true)) := by
+  by_cases hB : B = 0
+  · left
+    rw [classicalCoreFactorsWithBound, if_pos hB] at h
+    exact (Option.some.inj h).symm
+  · rw [classicalCoreFactorsWithBound, if_neg hB] at h
+    simp only [scaledRecombinationSmart] at h
+    generalize hld : ZPoly.toMonicLiftData core (ZPoly.exhaustiveLiftBound core B) primeData
+      = liftData at h
+    cases haux : scaledRecombinationSmartAux (DensePoly.leadingCoeff core) core
+        (liftModulus liftData) liftData.liftedFactors.toList
+        defaultSubsetBudget
+        (defaultSubsetBudget + (liftData.liftedFactors.toList.length + 1) *
+          (2 * liftData.liftedFactors.toList.length + 3)) with
+    | mk res remaining =>
+      rw [haux] at h
+      cases res with
+      | none =>
+        left
+        by_cases hrem : remaining = 0
+        · subst hrem; simp at h
+        · simp only [Option.isNone_none, Bool.true_and] at h
+          rw [if_neg (by simp [hrem])] at h
+          exact (Option.some.inj h).symm
+      | some factors =>
+        simp only [Option.isNone_some, Bool.false_and, Bool.false_eq_true, if_false] at h
+        by_cases hemp : factors.isEmpty = true
+        · left
+          rw [if_pos hemp] at h
+          exact (Option.some.inj h).symm
+        · right
+          rw [if_neg hemp] at h
+          obtain rfl := (Option.some.inj h).symm
+          refine ⟨scaledRecombinationSmartAux_product _ _ _ _ _ _ _ _ haux, ?_, ?_, ?_⟩
+          · intro g hg
+            rw [List.toList_toArray] at hg
+            exact scaledRecombinationSmartAux_normalizeFactorSign _ _ _ _ _ _ _ _ haux g hg
+          · intro g hg
+            rw [List.toList_toArray] at hg
+            exact scaledRecombinationSmartAux_primitive _ _ _ _ _ _ _ _ haux g hg
+          · intro g hg
+            rw [List.toList_toArray] at hg
+            exact scaledRecombinationSmartAux_shouldRecord _ _ _ _ _ _ _ _ haux g hg
+
+/-- PolyProduct identity for the size-ordered classical recombination core:
+every emitted factor array multiplies back to `core`. Mirror of
+`exhaustiveIntegerTrialCoreFactorsWithBound_polyProduct`; the `B = 0`,
+budget-`none`, and empty-result arms return the singleton `#[core]` (product
+`core`), and the nonempty recombination arm reuses
+`scaledRecombinationSmartAux_product`. -/
+theorem classicalCoreFactorsWithBound_polyProduct
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    {cf : Array ZPoly}
+    (h : classicalCoreFactorsWithBound core B primeData = some cf) :
+    Array.polyProduct cf = core := by
+  rcases classicalCoreFactorsWithBound_spec core B primeData h with hsing | ⟨hprod, _⟩
+  · rw [hsing]; exact ZPoly.polyProduct_singleton core
+  · exact hprod
+
+/-- Each factor emitted by the size-ordered classical recombination core is
+fixed by `normalizeFactorSign`, provided `core` has positive leading
+coefficient. Mirror of
+`exhaustiveIntegerTrialCoreFactorsWithBound_normalizeFactorSign`: the smart
+candidates are `normalizeFactorSign …` by construction (so fixed), and the
+singleton short-circuit is `core`, fixed by its positive leading coefficient. -/
+theorem classicalCoreFactorsWithBound_normalizeFactorSign
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_pos : 0 < DensePoly.leadingCoeff core)
+    {cf : Array ZPoly}
+    (h : classicalCoreFactorsWithBound core B primeData = some cf) :
+    ∀ factor ∈ cf.toList, normalizeFactorSign factor = factor := by
+  rcases classicalCoreFactorsWithBound_spec core B primeData h with hsing | ⟨_, hnorm, _⟩
+  · intro factor hmem
+    rw [hsing] at hmem
+    have hfactor : factor = core := by simpa using hmem
+    rw [hfactor]
+    exact normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core (by omega)
+  · exact hnorm
+
+/-- Each factor emitted by the size-ordered classical recombination core has
+positive `degree?`, provided `core` itself has positive degree. Classical analog
+of `exhaustiveIntegerTrialCoreFactorsWithBound_degree_pos`: the recombination
+factors are primitive and `normalizeFactorSign`-fixed with `shouldRecord = true`
+(all supplied by `classicalCoreFactorsWithBound_spec`), so
+`degree_pos_of_primitive_norm_record` applies; the singleton short-circuit is
+`core`, whose positive degree is the sole hypothesis. -/
+theorem classicalCoreFactorsWithBound_degree_pos
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_deg : 0 < core.degree?.getD 0)
+    {cf : Array ZPoly}
+    (h : classicalCoreFactorsWithBound core B primeData = some cf) :
+    ∀ factor ∈ cf.toList, 0 < factor.degree?.getD 0 := by
+  rcases classicalCoreFactorsWithBound_spec core B primeData h with
+    hsing | ⟨_, hnorm, hprim, hrecord⟩
+  · intro factor hmem
+    rw [hsing] at hmem
+    have hfactor : factor = core := by simpa using hmem
+    rw [hfactor]; exact hcore_deg
+  · intro factor hmem
+    exact degree_pos_of_primitive_norm_record factor
+      (hprim factor hmem) (hnorm factor hmem) (hrecord factor hmem)
 
 /-- Weakened-conclusion sibling of `exhaustiveCoreFactorsWithBound_degree_pos`:
 every emitted factor of the exhaustive recombination wrapper has positive

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -7156,4 +7156,150 @@ theorem classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
   intro g hg
   exact (Hex.ZPoly.Irreducible_iff_polynomialIrreducible g).mpr (hirr g hg)
 
+/-- **Classical residual-arm reassembly discharger (Mathlib-side).**
+
+When the classical small-`r` tier returns a recombination of the classical core
+factors of `(normalizeForFactor f).squareFreeCore` at the public bound
+`B := Hex.ZPoly.defaultFactorCoeffBound f`, the reassembly is
+expansion-complete.  The size-ordered classical analog of
+`reassemblyExpansionComplete_exhaustiveIntegerTrial_of_ne_zero`: it composes the
+public-bound classical-core irreducibility wrapper
+`classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` (#8510),
+the polyProduct / normalizeFactorSign / degree-positivity structural companions
+(#8511, `classicalCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`),
+and the non-monic expansion-complete surface
+`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`.
+Per-factor positive leading coefficient follows from the sign-normalisation
+identity and irreducibility; the fuel bound from the per-factor `factorPower`
+size lower bound and `size_le_of_dvd_nonzero`.  Consumed by the classical
+residual arm of `factorClassicalFactorsWithBound_factor_irreducible` (#8414). -/
+theorem reassemblyExpansionComplete_classicalCore_of_ne_zero
+    (f : Hex.ZPoly) (hf : f ≠ 0) (primeData : Hex.PrimeChoiceData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
+      = some primeData)
+    (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    {cf : Array Hex.ZPoly}
+    (hclassical : Hex.classicalCoreFactorsWithBound
+      (Hex.normalizeForFactor f).squareFreeCore
+      (Hex.ZPoly.defaultFactorCoeffBound f) primeData = some cf) :
+    Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) cf := by
+  classical
+  have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
+  have hcore_deg : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 :=
+    Nat.pos_of_ne_zero hdeg_ne
+  have hirr : ∀ q ∈ cf.toList, Hex.ZPoly.Irreducible q :=
+    classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
+      f hf primeData hselected hdeg_ne hclassical
+  have hprod :
+      Array.polyProduct cf = (Hex.normalizeForFactor f).squareFreeCore :=
+    Hex.classicalCoreFactorsWithBound_polyProduct _ _ _ hclassical
+  have hnorm : ∀ q ∈ cf.toList, Hex.normalizeFactorSign q = q :=
+    Hex.classicalCoreFactorsWithBound_normalizeFactorSign _ _ _ hcore_pos hclassical
+  have hdegree : ∀ q ∈ cf.toList, 0 < q.degree?.getD 0 :=
+    Hex.classicalCoreFactorsWithBound_degree_pos _ _ _ hcore_deg hclassical
+  -- Per-factor positive leading coefficient from `normalizeFactorSign q = q`
+  -- and irreducibility (hence `q ≠ 0`).
+  have hpos_lc : ∀ q ∈ cf.toList, 0 < Hex.DensePoly.leadingCoeff q := by
+    intro q hq
+    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
+    have hq_norm := hnorm q hq
+    have hq_nonneg : 0 ≤ Hex.DensePoly.leadingCoeff q := by
+      by_contra hlt
+      have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
+      unfold Hex.normalizeFactorSign at hq_norm
+      rw [if_pos hlt'] at hq_norm
+      apply hq_ne
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      have hcoeff :
+          (Hex.DensePoly.scale (-1 : Int) q).coeff n = q.coeff n := by
+        rw [hq_norm]
+      rw [Hex.DensePoly.coeff_scale (R := Int) (-1) q n
+        (by decide : (-1 : Int) * 0 = 0)] at hcoeff
+      rw [Hex.DensePoly.coeff_zero]
+      omega
+    have hq_lc_ne : Hex.DensePoly.leadingCoeff q ≠ 0 :=
+      Hex.ZPoly.leadingCoeff_ne_zero_of_ne_zero q hq_ne
+    omega
+  refine IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc
+    f hf cf hirr hprod hnorm hpos_lc hdegree ?_
+  -- Fuel bound.
+  intro exponents hlen hdecomp
+  have hsize_ge : ∀ q ∈ cf.toList, 2 ≤ q.size := by
+    intro q hq
+    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
+    have hq_size_pos : 0 < q.size := Hex.ZPoly.size_pos_of_ne_zero q hq_ne
+    have hq_deg := hdegree q hq
+    have hq_deg_eq : q.degree?.getD 0 = q.size - 1 := by
+      unfold Hex.DensePoly.degree?
+      simp [Nat.ne_of_gt hq_size_pos]
+    omega
+  have hrp_ne_zero : (Hex.normalizeForFactor f).repeatedPart ≠ 0 :=
+    Hex.repeatedPart_ne_zero_of_ne_zero f hf
+  have dvd_foldl_one_of_mem :
+      ∀ (x : Hex.ZPoly) (xs : List Hex.ZPoly),
+        x ∈ xs → x ∣ xs.foldl (· * ·) (1 : Hex.ZPoly) := by
+    intro x xs
+    induction xs with
+    | nil =>
+        intro hmem
+        exact absurd hmem List.not_mem_nil
+    | cons y ys ih =>
+        intro hmem
+        rcases List.mem_cons.mp hmem with rfl | hin
+        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
+              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one]
+          exact ⟨ys.foldl (· * ·) 1, rfl⟩
+        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
+              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one y ys]
+          obtain ⟨k, hk⟩ := ih hin
+          refine ⟨y * k, ?_⟩
+          rw [hk, ← Hex.DensePoly.mul_assoc_poly (S := Int),
+              Hex.DensePoly.mul_comm_poly (S := Int) y x,
+              Hex.DensePoly.mul_assoc_poly (S := Int)]
+  have factorPower_size_lb :
+      ∀ (q : Hex.ZPoly) (e : Nat),
+        2 ≤ q.size → e + 1 ≤ (Hex.Factorization.factorPower q e).size := by
+    intro q e hq_size
+    induction e with
+    | zero =>
+        show 1 ≤ (1 : Hex.ZPoly).size
+        rfl
+    | succ n ih =>
+        rw [Hex.Factorization.factorPower_succ]
+        have hprev_size_pos :
+            0 < (Hex.Factorization.factorPower q n).size := by omega
+        have hq_size_pos : 0 < q.size := by omega
+        have hmul_size :
+            (Hex.Factorization.factorPower q n * q).size =
+              (Hex.Factorization.factorPower q n).size + q.size - 1 :=
+          Hex.ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hprev_size_pos hq_size_pos
+        omega
+  intro qe hqe_mem
+  have hq_mem : qe.1 ∈ cf.toList := List.of_mem_zip hqe_mem |>.1
+  have hq_size := hsize_ge qe.1 hq_mem
+  have hfp_size_lb :
+      qe.2 + 1 ≤ (Hex.Factorization.factorPower qe.1 qe.2).size :=
+    factorPower_size_lb qe.1 qe.2 hq_size
+  have hfp_ne_zero : Hex.Factorization.factorPower qe.1 qe.2 ≠ 0 := by
+    intro hzero
+    rw [hzero] at hfp_size_lb
+    have h0 : (0 : Hex.ZPoly).size = 0 := rfl
+    omega
+  have hfp_mem :
+      Hex.Factorization.factorPower qe.1 qe.2 ∈
+        ((cf.toList.zip exponents).map
+          (fun qe' => Hex.Factorization.factorPower qe'.1 qe'.2)) :=
+    List.mem_map.mpr ⟨qe, hqe_mem, rfl⟩
+  have hfp_dvd_rp :
+      Hex.Factorization.factorPower qe.1 qe.2 ∣
+        (Hex.normalizeForFactor f).repeatedPart := by
+    rw [hdecomp]
+    exact dvd_foldl_one_of_mem _ _ hfp_mem
+  have hfp_size_le :
+      (Hex.Factorization.factorPower qe.1 qe.2).size ≤
+        (Hex.normalizeForFactor f).repeatedPart.size :=
+    Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne_zero hrp_ne_zero hfp_dvd_rp
+  omega
+
 end HexBerlekampZassenhausMathlib

--- a/progress/20260701T135634Z_issue-8511-classical-core-completeness.md
+++ b/progress/20260701T135634Z_issue-8511-classical-core-completeness.md
@@ -1,0 +1,59 @@
+# Issue #8511 classical-core completeness structural lemmas
+
+## Accomplished
+
+Delivered the classical-core completeness trio and the residual-arm
+reassembly discharger, mirroring the exhaustive-tier analogs.
+
+In `HexBerlekampZassenhaus/Basic.lean` (Mathlib-free layer):
+- Two new smart-core mutual-recursion families over the size-ordered
+  search (`Aux` / `SizeLoop` / `CandLoop`), siblings of the existing
+  `scaledRecombinationSmartAux_shouldRecord`:
+  - `scaledRecombinationSmartAux_normalizeFactorSign` — each emitted
+    factor is `normalizeFactorSign`-fixed (candidate is
+    `normalizeFactorSign …`, closed by `normalizeFactorSign_idem`).
+  - `scaledRecombinationSmartAux_primitive` — each emitted factor is
+    primitive (record gate forces the candidate nonzero, so the inner
+    `primitivePart` argument has nonzero content).
+- `classicalCoreFactorsWithBound_spec`, a private structural case-split:
+  every `some cf` result is either the short-circuit singleton `#[core]`
+  (`B = 0`, budget-`none`, empty-result all return `#[core]`) or a
+  nonempty recombination whose product reconstructs `core` with each
+  factor sign-fixed, primitive, and recorded. Destructures via
+  `generalize` (no Mathlib `set` in this layer).
+- The public trio consuming the spec:
+  `classicalCoreFactorsWithBound_polyProduct`,
+  `_normalizeFactorSign` (needs `0 < leadingCoeff core`),
+  `_degree_pos` (needs `0 < core.degree?.getD 0`; the singleton arm
+  emits `core`, so core-degree positivity is genuinely required —
+  unlike the exhaustive-trial analog).
+
+In `HexBerlekampZassenhausMathlib/IntReductionMod.lean`:
+- `reassemblyExpansionComplete_classicalCore_of_ne_zero`, the classical
+  analog of `reassemblyExpansionComplete_exhaustiveIntegerTrial_of_ne_zero`:
+  wires the trio + #8510's
+  `classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible`
+  into `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`
+  (per-factor positive leading coefficient and the fuel bound follow
+  generically, exactly as in the exhaustive analog).
+
+`lake build HexBerlekampZassenhausMathlib` green; no new `sorry`/`axiom`;
+no new warnings in the touched files. Second opinion (Codex) found no
+soundness issues; its one low-severity note (unused `hcore_prim` /
+`hcore_pos` on `_degree_pos`) was addressed by trimming the signature to
+the sole needed hypothesis `hcore_deg`.
+
+## Current frontier
+
+Both classical-residual ingredients now exist: #8510's per-factor
+irreducibility and this issue's completeness side condition.
+
+## Next step
+
+#8414 residual arm consumes
+`reassemblyExpansionComplete_classicalCore_of_ne_zero` (with #8510) to
+drop the `factor_irreducible_of_nonUnit` classical-branch `sorry`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds the classical-core completeness structural lemmas (product / sign / degree) and the residual-arm reassembly discharger that the classical arm of `factor_irreducible_of_nonUnit` needs, mirroring the exhaustive-tier trio and its discharger. Together with the per-factor irreducibility from #8510, this supplies the completeness side condition `reassemblyExpansionComplete (normalizeForFactor f) coreFactors` for `coreFactors = classicalCoreFactorsWithBound core (defaultFactorCoeffBound f) primeData`.

In the Mathlib-free `HexBerlekampZassenhaus/Basic.lean` it adds two smart-core mutual-recursion families over the size-ordered search (`Aux` / `SizeLoop` / `CandLoop`), siblings of the existing `scaledRecombinationSmartAux_shouldRecord`: `scaledRecombinationSmartAux_normalizeFactorSign` (each emitted factor is `normalizeFactorSign`-fixed, closed by `normalizeFactorSign_idem`) and `scaledRecombinationSmartAux_primitive` (the record gate forces the candidate nonzero, so the inner `primitivePart` argument has nonzero content). On top of these it adds the private structural case-split `classicalCoreFactorsWithBound_spec` — every `some cf` is either the short-circuit singleton `#[core]` (the `B = 0`, budget-`none`, and empty-result arms all return `#[core]`) or a nonempty recombination whose product reconstructs `core` with each factor sign-fixed, primitive, and recorded — and the public trio `classicalCoreFactorsWithBound_polyProduct`, `_normalizeFactorSign`, `_degree_pos` consuming it.

In `HexBerlekampZassenhausMathlib/IntReductionMod.lean` it adds `reassemblyExpansionComplete_classicalCore_of_ne_zero`, the classical analog of `reassemblyExpansionComplete_exhaustiveIntegerTrial_of_ne_zero`, wiring the trio and #8510's `classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` into the generic discharger `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc` (per-factor positive leading coefficient and the fuel bound follow generically).

`lake build HexBerlekampZassenhausMathlib` is green; no new `sorry`/`axiom`; no new warnings in the touched files.

Closes #8511.

🤖 Prepared with Claude Code