### PR TITLE
[codex] fix BZ fast precision cap for squarefree core

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9837,15 +9837,17 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
 /--
 Precision cap used by the public fast path.
 
-The cap is the larger of the BHKS separation threshold bound and the
-Mignotte coefficient bound, so later termination proofs can use the same
-precision for both lattice separation and exact integer reconstruction.
+The cap is the larger of the square-free core's BHKS separation threshold
+bound and the original input's Mignotte coefficient bound.  The lattice and
+fast tiers run the van Hoeij/BHKS certificate on
+`(normalizeForFactor f).squareFreeCore`, so the BHKS side of the cap must be
+computed from that core rather than from the original input.
 -/
 def factorFastPrecisionCap (f : ZPoly) : Nat :=
-  max (bhksBound f) (ZPoly.defaultFactorCoeffBound f)
+  max (bhksBound (normalizeForFactor f).squareFreeCore) (ZPoly.defaultFactorCoeffBound f)
 
 theorem bhksBound_le_factorFastPrecisionCap (f : ZPoly) :
-    bhksBound f ≤ factorFastPrecisionCap f := by
+    bhksBound (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f := by
   unfold factorFastPrecisionCap
   exact Nat.le_max_left _ _
 
@@ -9853,6 +9855,26 @@ theorem defaultFactorCoeffBound_le_factorFastPrecisionCap (f : ZPoly) :
     ZPoly.defaultFactorCoeffBound f ≤ factorFastPrecisionCap f := by
   unfold factorFastPrecisionCap
   exact Nat.le_max_right _ _
+
+theorem coreBhksPrecision_lt_factorFastPrecisionCap
+    (f : ZPoly) (primeData : PrimeChoiceData) (hp : 2 ≤ primeData.p) :
+    2 * bhksBound (normalizeForFactor f).squareFreeCore <
+      primeData.p ^
+        (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
+          (factorFastPrecisionCap f) primeData).k := by
+  have hspec :
+      2 * factorFastPrecisionCap f <
+        primeData.p ^ precisionForCoeffBound (factorFastPrecisionCap f) primeData.p :=
+    precisionForCoeffBound_spec hp (factorFastPrecisionCap f)
+  have hle :
+      2 * bhksBound (normalizeForFactor f).squareFreeCore ≤
+        2 * factorFastPrecisionCap f :=
+    Nat.mul_le_mul_left 2 (bhksBound_le_factorFastPrecisionCap f)
+  have hlt :
+      2 * bhksBound (normalizeForFactor f).squareFreeCore <
+        primeData.p ^ precisionForCoeffBound (factorFastPrecisionCap f) primeData.p :=
+    by omega
+  simpa [ZPoly.toMonicLiftData] using hlt
 
 def factorFastWithBound (f : ZPoly) (B : Nat) : Option Factorization :=
   (factorFastFactorsWithBound f B).map (factorizationOfFactors f)

--- a/progress/20260702T011245Z_issue-8521-core-precision-cap.md
+++ b/progress/20260702T011245Z_issue-8521-core-precision-cap.md
@@ -1,0 +1,39 @@
+# Issue #8521 — core-aware BHKS precision cap
+
+## Accomplished
+
+Fixed the executable precision reconciliation for the fast/lattice BZ tiers.
+`factorFastPrecisionCap f` now computes the BHKS separation side from
+`(normalizeForFactor f).squareFreeCore` while preserving the original input's
+`defaultFactorCoeffBound f` for coefficient reconstruction.  Updated
+`bhksBound_le_factorFastPrecisionCap` to expose the core bound, and added
+`coreBhksPrecision_lt_factorFastPrecisionCap`, proving the exact
+`toMonicLiftData` precision inequality needed by the #8521 reduction.
+
+Verification:
+
+- `lake build HexBerlekampZassenhaus` green.
+- `lake build HexBerlekampZassenhausMathlib` green, with the pre-existing
+  lattice theorem `sorry` still reported in `IntReductionMod.lean`.
+- `lake build HexConformance` green.
+- `python3 scripts/oracle/bz_flint.py --check` reports 100 cases, 0 failures.
+
+## Current frontier
+
+The executable soundness gap identified by #8521 is fixed.  This checkout does
+not contain the partial `factorLatticeFactorsWithBound_factor_irreducible` proof
+body described by the issue; the theorem is still a top-level `sorry`, so the
+new precision lemma is available but not yet wired into a full lattice
+irreducibility proof.
+
+## Next step
+
+Open the PR with the core-aware cap and precision lemma.  A follow-up proof pass
+can use `coreBhksPrecision_lt_factorFastPrecisionCap` at the former `hprec`
+site once the lattice theorem proof body is present.
+
+## Blockers
+
+No implementation blocker for the executable fix.  Full discharge of the
+lattice irreducibility theorem remains blocked on the broader #8417 proof body
+in this worktree.


### PR DESCRIPTION
## Summary

Fixes the executable precision-cap mismatch from #8521 by computing the BHKS side of `factorFastPrecisionCap f` from `(normalizeForFactor f).squareFreeCore`, while keeping `defaultFactorCoeffBound f` as the coefficient reconstruction side of the cap.

Also adds `coreBhksPrecision_lt_factorFastPrecisionCap`, proving the exact `toMonicLiftData` inequality for the square-free core at the public cap.

## Notes

This worktree has `factorLatticeFactorsWithBound_factor_irreducible` as a single top-level `sorry`, not the partial proof body with a local `hprec` hole described in #8521. The new lemma is the intended discharge for that precision obligation once the broader #8417 lattice proof body is present.

## Validation

- `lake build HexBerlekampZassenhaus`
- `lake build HexBerlekampZassenhausMathlib` (green; existing lattice `sorry` warning remains)
- `lake build HexConformance`
- `python3 scripts/oracle/bz_flint.py --check` (`100 case(s), 0 failure(s)`)

Addresses #8521.
