### PR TITLE
feat: prove lattice-tier reassembly completeness, discharging the LatticeTier sorry

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -14629,6 +14629,79 @@ theorem classicalCoreFactorsWithBound_degree_pos
     exact degree_pos_of_primitive_norm_record factor
       (hprim factor hmem) (hnorm factor hmem) (hrecord factor hmem)
 
+/-- Structural case-split for the van Hoeij lattice-tier core. Every `some cf`
+result of `latticeCoreFactorsWithBound` is either the singleton `#[core]` (the
+small-mod and all-ones certification arms) or a `factorFastCoreWithBound`
+success (the CLD-split arm). The trio
+`latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`
+below are thin consumers, mirroring the classical structural trio. -/
+private theorem latticeCoreFactorsWithBound_spec
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    {cf : Array ZPoly}
+    (h : latticeCoreFactorsWithBound core B primeData = some cf) :
+    cf = #[core] ∨
+      factorFastCoreWithBound core B primeData (initialHenselPrecision B)
+        (ZPoly.quadraticDoublingSteps B + 2) = some cf := by
+  rw [latticeCoreFactorsWithBound] at h
+  split at h
+  · exact Or.inl (Option.some.inj h).symm
+  · split at h
+    · rename_i coreFactors hfast
+      exact Or.inr ((Option.some.inj h) ▸ hfast)
+    · split at h
+      · exact Or.inl (Option.some.inj h).symm
+      · exact absurd h.symm (Option.some_ne_none cf)
+
+/-- PolyProduct identity for the van Hoeij lattice-tier core: every emitted
+factor array multiplies back to `core`. Mirror of
+`classicalCoreFactorsWithBound_polyProduct`; the singleton arms are immediate
+and the CLD-split arm reuses `factorFastCoreWithBound_product`. -/
+theorem latticeCoreFactorsWithBound_polyProduct
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    {cf : Array ZPoly}
+    (h : latticeCoreFactorsWithBound core B primeData = some cf) :
+    Array.polyProduct cf = core := by
+  rcases latticeCoreFactorsWithBound_spec core B primeData h with hsing | hfast
+  · rw [hsing]; exact ZPoly.polyProduct_singleton core
+  · exact factorFastCoreWithBound_product core B primeData _ _ cf hfast
+
+/-- Each factor emitted by the van Hoeij lattice-tier core is fixed by
+`normalizeFactorSign`, provided `core` has positive leading coefficient. Mirror
+of `classicalCoreFactorsWithBound_normalizeFactorSign`: the CLD-split factors
+are sign-normalized by construction, and the singleton arms are `core`, fixed
+by its positive leading coefficient. -/
+theorem latticeCoreFactorsWithBound_normalizeFactorSign
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_pos : 0 < DensePoly.leadingCoeff core)
+    {cf : Array ZPoly}
+    (h : latticeCoreFactorsWithBound core B primeData = some cf) :
+    ∀ factor ∈ cf.toList, normalizeFactorSign factor = factor := by
+  rcases latticeCoreFactorsWithBound_spec core B primeData h with hsing | hfast
+  · intro factor hmem
+    rw [hsing] at hmem
+    have hfactor : factor = core := by simpa using hmem
+    rw [hfactor]
+    exact normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core (by omega)
+  · exact factorFastCoreWithBound_some_normalizeFactorSign hfast
+
+/-- Each factor emitted by the van Hoeij lattice-tier core has positive
+`degree?`, provided `core` itself has positive degree. Mirror of
+`classicalCoreFactorsWithBound_degree_pos`: the CLD-split factors have positive
+degree by construction, and the singleton arms are `core`, whose positive
+degree is the sole hypothesis. -/
+theorem latticeCoreFactorsWithBound_degree_pos
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
+    (hcore_deg : 0 < core.degree?.getD 0)
+    {cf : Array ZPoly}
+    (h : latticeCoreFactorsWithBound core B primeData = some cf) :
+    ∀ factor ∈ cf.toList, 0 < factor.degree?.getD 0 := by
+  rcases latticeCoreFactorsWithBound_spec core B primeData h with hsing | hfast
+  · intro factor hmem
+    rw [hsing] at hmem
+    have hfactor : factor = core := by simpa using hmem
+    rw [hfactor]; exact hcore_deg
+  · exact factorFastCoreWithBound_some_degree_pos hfast
+
 /-- Weakened-conclusion sibling of `exhaustiveCoreFactorsWithBound_degree_pos`:
 every emitted factor of the exhaustive recombination wrapper has positive
 `degree?` when the input core is primitive with positive leading coefficient

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2352,6 +2352,131 @@ theorem reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc
     (Hex.normalizeForFactor f).repeatedPart coreFactors hpos_lc hdegree
     exponents hlen hnot_dvd_tail hdecomp hfuel'
 
+/-- Sign-normalized sibling of
+`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`:
+derives the per-factor positive leading coefficient from the
+sign-normalization identity plus irreducibility (hence nonzero-ness), and the
+fuel bound from the per-factor `factorPower` size lower bound together with
+`size_le_of_dvd_nonzero`, so callers supply only the irreducible,
+sign-normalized, positive-degree cover of the square-free core. Consumed by
+the classical residual arm
+(`reassemblyExpansionComplete_classicalCore_of_ne_zero`) and the lattice tier
+(`reassemblyExpansionComplete_latticeCore_of_ne_zero`, `LatticeTier.lean`). -/
+theorem reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm
+    (f : Hex.ZPoly) (hf : f ≠ 0)
+    (coreFactors : Array Hex.ZPoly)
+    (hirr : ∀ q ∈ coreFactors.toList, Hex.ZPoly.Irreducible q)
+    (hprod : Array.polyProduct coreFactors =
+      (Hex.normalizeForFactor f).squareFreeCore)
+    (hnorm : ∀ q ∈ coreFactors.toList, Hex.normalizeFactorSign q = q)
+    (hdegree : ∀ q ∈ coreFactors.toList, 0 < q.degree?.getD 0) :
+    Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) coreFactors := by
+  classical
+  -- Per-factor positive leading coefficient from `normalizeFactorSign q = q`
+  -- and irreducibility (hence `q ≠ 0`).
+  have hpos_lc : ∀ q ∈ coreFactors.toList, 0 < Hex.DensePoly.leadingCoeff q := by
+    intro q hq
+    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
+    have hq_norm := hnorm q hq
+    have hq_nonneg : 0 ≤ Hex.DensePoly.leadingCoeff q := by
+      by_contra hlt
+      have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
+      unfold Hex.normalizeFactorSign at hq_norm
+      rw [if_pos hlt'] at hq_norm
+      apply hq_ne
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      have hcoeff :
+          (Hex.DensePoly.scale (-1 : Int) q).coeff n = q.coeff n := by
+        rw [hq_norm]
+      rw [Hex.DensePoly.coeff_scale (R := Int) (-1) q n
+        (by decide : (-1 : Int) * 0 = 0)] at hcoeff
+      rw [Hex.DensePoly.coeff_zero]
+      omega
+    have hq_lc_ne : Hex.DensePoly.leadingCoeff q ≠ 0 :=
+      Hex.ZPoly.leadingCoeff_ne_zero_of_ne_zero q hq_ne
+    omega
+  refine reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc
+    f hf coreFactors hirr hprod hnorm hpos_lc hdegree ?_
+  -- Fuel bound.
+  intro exponents hlen hdecomp
+  have hsize_ge : ∀ q ∈ coreFactors.toList, 2 ≤ q.size := by
+    intro q hq
+    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
+    have hq_size_pos : 0 < q.size := Hex.ZPoly.size_pos_of_ne_zero q hq_ne
+    have hq_deg := hdegree q hq
+    have hq_deg_eq : q.degree?.getD 0 = q.size - 1 := by
+      unfold Hex.DensePoly.degree?
+      simp [Nat.ne_of_gt hq_size_pos]
+    omega
+  have hrp_ne_zero : (Hex.normalizeForFactor f).repeatedPart ≠ 0 :=
+    Hex.repeatedPart_ne_zero_of_ne_zero f hf
+  have dvd_foldl_one_of_mem :
+      ∀ (x : Hex.ZPoly) (xs : List Hex.ZPoly),
+        x ∈ xs → x ∣ xs.foldl (· * ·) (1 : Hex.ZPoly) := by
+    intro x xs
+    induction xs with
+    | nil =>
+        intro hmem
+        exact absurd hmem List.not_mem_nil
+    | cons y ys ih =>
+        intro hmem
+        rcases List.mem_cons.mp hmem with rfl | hin
+        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
+              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one]
+          exact ⟨ys.foldl (· * ·) 1, rfl⟩
+        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
+              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one y ys]
+          obtain ⟨k, hk⟩ := ih hin
+          refine ⟨y * k, ?_⟩
+          rw [hk, ← Hex.DensePoly.mul_assoc_poly (S := Int),
+              Hex.DensePoly.mul_comm_poly (S := Int) y x,
+              Hex.DensePoly.mul_assoc_poly (S := Int)]
+  have factorPower_size_lb :
+      ∀ (q : Hex.ZPoly) (e : Nat),
+        2 ≤ q.size → e + 1 ≤ (Hex.Factorization.factorPower q e).size := by
+    intro q e hq_size
+    induction e with
+    | zero =>
+        show 1 ≤ (1 : Hex.ZPoly).size
+        rfl
+    | succ n ih =>
+        rw [Hex.Factorization.factorPower_succ]
+        have hprev_size_pos :
+            0 < (Hex.Factorization.factorPower q n).size := by omega
+        have hq_size_pos : 0 < q.size := by omega
+        have hmul_size :
+            (Hex.Factorization.factorPower q n * q).size =
+              (Hex.Factorization.factorPower q n).size + q.size - 1 :=
+          Hex.ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hprev_size_pos hq_size_pos
+        omega
+  intro qe hqe_mem
+  have hq_mem : qe.1 ∈ coreFactors.toList := List.of_mem_zip hqe_mem |>.1
+  have hq_size := hsize_ge qe.1 hq_mem
+  have hfp_size_lb :
+      qe.2 + 1 ≤ (Hex.Factorization.factorPower qe.1 qe.2).size :=
+    factorPower_size_lb qe.1 qe.2 hq_size
+  have hfp_ne_zero : Hex.Factorization.factorPower qe.1 qe.2 ≠ 0 := by
+    intro hzero
+    rw [hzero] at hfp_size_lb
+    have h0 : (0 : Hex.ZPoly).size = 0 := rfl
+    omega
+  have hfp_mem :
+      Hex.Factorization.factorPower qe.1 qe.2 ∈
+        ((coreFactors.toList.zip exponents).map
+          (fun qe' => Hex.Factorization.factorPower qe'.1 qe'.2)) :=
+    List.mem_map.mpr ⟨qe, hqe_mem, rfl⟩
+  have hfp_dvd_rp :
+      Hex.Factorization.factorPower qe.1 qe.2 ∣
+        (Hex.normalizeForFactor f).repeatedPart := by
+    rw [hdecomp]
+    exact dvd_foldl_one_of_mem _ _ hfp_mem
+  have hfp_size_le :
+      (Hex.Factorization.factorPower qe.1 qe.2).size ≤
+        (Hex.normalizeForFactor f).repeatedPart.size :=
+    Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne_zero hrp_ne_zero hfp_dvd_rp
+  omega
+
 /-- **#4597 HO-1 base task — small-mod singleton arm `factorPower` shape of
 the repeated part.** Singleton specialisation of
 `normalizeForFactor_repeatedPart_isFactorPower_polyProduct_of_irreducible_factors_cover`
@@ -7167,12 +7292,11 @@ public-bound classical-core irreducibility wrapper
 `classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible` (#8510),
 the polyProduct / normalizeFactorSign / degree-positivity structural companions
 (#8511, `classicalCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`),
-and the non-monic expansion-complete surface
-`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc`.
-Per-factor positive leading coefficient follows from the sign-normalisation
-identity and irreducibility; the fuel bound from the per-factor `factorPower`
-size lower bound and `size_le_of_dvd_nonzero`.  Consumed by the classical
-residual arm of `factorClassicalFactorsWithBound_factor_irreducible` (#8414). -/
+and the sign-normalized expansion-complete surface
+`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm` (which
+derives the per-factor positive leading coefficient and the fuel bound
+internally).  Consumed by the classical residual arm of
+`factorClassicalFactorsWithBound_factor_irreducible` (#8414). -/
 theorem reassemblyExpansionComplete_classicalCore_of_ne_zero
     (f : Hex.ZPoly) (hf : f ≠ 0) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
@@ -7187,120 +7311,13 @@ theorem reassemblyExpansionComplete_classicalCore_of_ne_zero
   have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
   have hcore_deg : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 :=
     Nat.pos_of_ne_zero hdeg_ne
-  have hirr : ∀ q ∈ cf.toList, Hex.ZPoly.Irreducible q :=
-    classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
-      f hf primeData hselected hdeg_ne hclassical
-  have hprod :
-      Array.polyProduct cf = (Hex.normalizeForFactor f).squareFreeCore :=
-    Hex.classicalCoreFactorsWithBound_polyProduct _ _ _ hclassical
-  have hnorm : ∀ q ∈ cf.toList, Hex.normalizeFactorSign q = q :=
-    Hex.classicalCoreFactorsWithBound_normalizeFactorSign _ _ _ hcore_pos hclassical
-  have hdegree : ∀ q ∈ cf.toList, 0 < q.degree?.getD 0 :=
-    Hex.classicalCoreFactorsWithBound_degree_pos _ _ _ hcore_deg hclassical
-  -- Per-factor positive leading coefficient from `normalizeFactorSign q = q`
-  -- and irreducibility (hence `q ≠ 0`).
-  have hpos_lc : ∀ q ∈ cf.toList, 0 < Hex.DensePoly.leadingCoeff q := by
-    intro q hq
-    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
-    have hq_norm := hnorm q hq
-    have hq_nonneg : 0 ≤ Hex.DensePoly.leadingCoeff q := by
-      by_contra hlt
-      have hlt' : Hex.DensePoly.leadingCoeff q < 0 := lt_of_not_ge hlt
-      unfold Hex.normalizeFactorSign at hq_norm
-      rw [if_pos hlt'] at hq_norm
-      apply hq_ne
-      apply Hex.DensePoly.ext_coeff
-      intro n
-      have hcoeff :
-          (Hex.DensePoly.scale (-1 : Int) q).coeff n = q.coeff n := by
-        rw [hq_norm]
-      rw [Hex.DensePoly.coeff_scale (R := Int) (-1) q n
-        (by decide : (-1 : Int) * 0 = 0)] at hcoeff
-      rw [Hex.DensePoly.coeff_zero]
-      omega
-    have hq_lc_ne : Hex.DensePoly.leadingCoeff q ≠ 0 :=
-      Hex.ZPoly.leadingCoeff_ne_zero_of_ne_zero q hq_ne
-    omega
-  refine IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_pos_lc
-    f hf cf hirr hprod hnorm hpos_lc hdegree ?_
-  -- Fuel bound.
-  intro exponents hlen hdecomp
-  have hsize_ge : ∀ q ∈ cf.toList, 2 ≤ q.size := by
-    intro q hq
-    have hq_ne : q ≠ 0 := (hirr q hq).not_zero
-    have hq_size_pos : 0 < q.size := Hex.ZPoly.size_pos_of_ne_zero q hq_ne
-    have hq_deg := hdegree q hq
-    have hq_deg_eq : q.degree?.getD 0 = q.size - 1 := by
-      unfold Hex.DensePoly.degree?
-      simp [Nat.ne_of_gt hq_size_pos]
-    omega
-  have hrp_ne_zero : (Hex.normalizeForFactor f).repeatedPart ≠ 0 :=
-    Hex.repeatedPart_ne_zero_of_ne_zero f hf
-  have dvd_foldl_one_of_mem :
-      ∀ (x : Hex.ZPoly) (xs : List Hex.ZPoly),
-        x ∈ xs → x ∣ xs.foldl (· * ·) (1 : Hex.ZPoly) := by
-    intro x xs
-    induction xs with
-    | nil =>
-        intro hmem
-        exact absurd hmem List.not_mem_nil
-    | cons y ys ih =>
-        intro hmem
-        rcases List.mem_cons.mp hmem with rfl | hin
-        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
-              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one]
-          exact ⟨ys.foldl (· * ·) 1, rfl⟩
-        · rw [List.foldl_cons, Hex.ZPoly.one_mul_zpoly,
-              Hex.ZPoly.list_foldl_mul_eq_mul_foldl_one y ys]
-          obtain ⟨k, hk⟩ := ih hin
-          refine ⟨y * k, ?_⟩
-          rw [hk, ← Hex.DensePoly.mul_assoc_poly (S := Int),
-              Hex.DensePoly.mul_comm_poly (S := Int) y x,
-              Hex.DensePoly.mul_assoc_poly (S := Int)]
-  have factorPower_size_lb :
-      ∀ (q : Hex.ZPoly) (e : Nat),
-        2 ≤ q.size → e + 1 ≤ (Hex.Factorization.factorPower q e).size := by
-    intro q e hq_size
-    induction e with
-    | zero =>
-        show 1 ≤ (1 : Hex.ZPoly).size
-        rfl
-    | succ n ih =>
-        rw [Hex.Factorization.factorPower_succ]
-        have hprev_size_pos :
-            0 < (Hex.Factorization.factorPower q n).size := by omega
-        have hq_size_pos : 0 < q.size := by omega
-        have hmul_size :
-            (Hex.Factorization.factorPower q n * q).size =
-              (Hex.Factorization.factorPower q n).size + q.size - 1 :=
-          Hex.ZPoly.mul_size_eq_top_succ_of_nonzero _ _ hprev_size_pos hq_size_pos
-        omega
-  intro qe hqe_mem
-  have hq_mem : qe.1 ∈ cf.toList := List.of_mem_zip hqe_mem |>.1
-  have hq_size := hsize_ge qe.1 hq_mem
-  have hfp_size_lb :
-      qe.2 + 1 ≤ (Hex.Factorization.factorPower qe.1 qe.2).size :=
-    factorPower_size_lb qe.1 qe.2 hq_size
-  have hfp_ne_zero : Hex.Factorization.factorPower qe.1 qe.2 ≠ 0 := by
-    intro hzero
-    rw [hzero] at hfp_size_lb
-    have h0 : (0 : Hex.ZPoly).size = 0 := rfl
-    omega
-  have hfp_mem :
-      Hex.Factorization.factorPower qe.1 qe.2 ∈
-        ((cf.toList.zip exponents).map
-          (fun qe' => Hex.Factorization.factorPower qe'.1 qe'.2)) :=
-    List.mem_map.mpr ⟨qe, hqe_mem, rfl⟩
-  have hfp_dvd_rp :
-      Hex.Factorization.factorPower qe.1 qe.2 ∣
-        (Hex.normalizeForFactor f).repeatedPart := by
-    rw [hdecomp]
-    exact dvd_foldl_one_of_mem _ _ hfp_mem
-  have hfp_size_le :
-      (Hex.Factorization.factorPower qe.1 qe.2).size ≤
-        (Hex.normalizeForFactor f).repeatedPart.size :=
-    Hex.ZPoly.size_le_of_dvd_nonzero hfp_ne_zero hrp_ne_zero hfp_dvd_rp
-  omega
+  exact IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm
+    f hf cf
+    (classicalCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
+      f hf primeData hselected hdeg_ne hclassical)
+    (Hex.classicalCoreFactorsWithBound_polyProduct _ _ _ hclassical)
+    (Hex.classicalCoreFactorsWithBound_normalizeFactorSign _ _ _ hcore_pos hclassical)
+    (Hex.classicalCoreFactorsWithBound_degree_pos _ _ _ hcore_deg hclassical)
 
 /-- **Trial-branch raw-factor irreducibility (hybrid guard form).**
 

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -392,6 +392,41 @@ where the `LatticeTier` core lemma is available.  `factor_irreducible_of_nonUnit
 (FactorSoundness) consumes `factorHybridFactors_factor_irreducible`.
 -/
 
+/-- **Lattice-core reassembly completeness (#8520).**  When the lattice tier
+returns core factors for the square-free core of `normalizeForFactor f` at
+adequate precision, the reassembly is expansion-complete.  The lattice analog of
+`reassemblyExpansionComplete_classicalCore_of_ne_zero` (#8511): it composes the
+`LatticeTier` core irreducibility lemma
+`latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible`, the
+polyProduct / normalizeFactorSign / degree-positivity structural companions
+`Hex.latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`,
+and the sign-normalized expansion-complete surface
+`reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm`.
+Consumed by the lattice residual arm of
+`factorLatticeFactorsWithBound_factor_irreducible`. -/
+theorem reassemblyExpansionComplete_latticeCore_of_ne_zero
+    (f : Hex.ZPoly) (hf : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
+    (hchoose : Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore
+      = some primeData)
+    (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    (hprec : 2 * Hex.bhksBound (Hex.normalizeForFactor f).squareFreeCore <
+      primeData.p ^ (Hex.ZPoly.toMonicLiftData
+        (Hex.normalizeForFactor f).squareFreeCore B primeData).k)
+    {cf : Array Hex.ZPoly}
+    (hlattice : Hex.latticeCoreFactorsWithBound
+      (Hex.normalizeForFactor f).squareFreeCore B primeData = some cf) :
+    Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f) cf := by
+  have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
+  have hcore_deg : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 :=
+    Nat.pos_of_ne_zero hdeg_ne
+  exact IntReductionMod.reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm
+    f hf cf
+    (latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
+      f hf B primeData hchoose hdeg_ne hprec hlattice)
+    (Hex.latticeCoreFactorsWithBound_polyProduct _ _ _ hlattice)
+    (Hex.latticeCoreFactorsWithBound_normalizeFactorSign _ _ _ hcore_pos hlattice)
+    (Hex.latticeCoreFactorsWithBound_degree_pos _ _ _ hcore_deg hlattice)
+
 /-- **Lattice-branch raw-factor irreducibility (#8417).**  Every raw factor of the
 CLD lattice tier's output that passes the recorded-factor filter is irreducible.
 Reduces through the reassembly bridge to the `LatticeTier` core lemma. -/
@@ -447,8 +482,11 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
           obtain ⟨coreFactors, hcore_lattice, rfl⟩ := hcf
           refine Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
             (Hex.normalizeForFactor f) coreFactors ?_ ?_ hmem
-          · -- reassemblyExpansionComplete side condition
-            sorry
+          · exact reassemblyExpansionComplete_latticeCore_of_ne_zero
+              f hf (Hex.factorFastPrecisionCap f) primeData hchoose hdeg0
+              (Hex.two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_choosePrimeData
+                f primeData hchoose)
+              hcore_lattice
           · exact latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
               f hf (Hex.factorFastPrecisionCap f) primeData hchoose hdeg0
               (Hex.two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_choosePrimeData

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -403,7 +403,12 @@ polyProduct / normalizeFactorSign / degree-positivity structural companions
 and the sign-normalized expansion-complete surface
 `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm`.
 Consumed by the lattice residual arm of
-`factorLatticeFactorsWithBound_factor_irreducible`. -/
+`factorLatticeFactorsWithBound_factor_irreducible`.
+
+The only analytic dependency is the core irreducibility input, which inherits
+the two open BHKS obligations (`latticeArm2_fastCore_count`,
+`latticeArm3_bhksSingleAllOnes_irreducible`); the reassembly side itself is
+fully proved — no new assumption is introduced here. -/
 theorem reassemblyExpansionComplete_latticeCore_of_ne_zero
     (f : Hex.ZPoly) (hf : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hchoose : Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore

--- a/progress/20260702T030153Z_issue-8520-lattice-reassembly.md
+++ b/progress/20260702T030153Z_issue-8520-lattice-reassembly.md
@@ -1,0 +1,48 @@
+# Lattice-tier reassembly completeness (#8520)
+
+## Accomplished
+
+Discharged the `reassemblyExpansionComplete` sorry in the lattice branch of
+`factorLatticeFactorsWithBound_factor_irreducible`
+(`HexBerlekampZassenhausMathlib/LatticeTier.lean`), stacked on the #8417
+lattice-tier PR (#8517) which introduced it. Three pieces:
+
+- **`HexBerlekampZassenhaus/Basic.lean`**: `latticeCoreFactorsWithBound_spec`
+  (private structural case-split: every `some cf` is the singleton `#[core]`
+  — small-mod and all-ones certification arms — or a `factorFastCoreWithBound`
+  success) plus the trio
+  `latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`,
+  mirroring the classical companions. The CLD-split arm reuses
+  `factorFastCoreWithBound_product` / `_some_normalizeFactorSign` /
+  `_some_degree_pos`, all already in-tree.
+- **`HexBerlekampZassenhausMathlib/IntReductionMod.lean`**: extracted the
+  shared tail of `reassemblyExpansionComplete_classicalCore_of_ne_zero`
+  (per-factor positive-leading-coefficient derivation + fuel bound) into
+  `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm`
+  (callers supply only the irreducible, sign-normalized, positive-degree
+  cover), and rewired the classical proof through it — the classical theorem
+  shrank from ~120 lines to a 4-argument composition.
+- **`HexBerlekampZassenhausMathlib/LatticeTier.lean`**:
+  `reassemblyExpansionComplete_latticeCore_of_ne_zero` (thin composition of
+  the `LatticeTier` core irreducibility lemma + the structural trio + the new
+  `_of_norm` surface) and the sorry discharge at the general-lattice arm,
+  supplying precision via
+  `two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_choosePrimeData`.
+
+## Current frontier
+
+LatticeTier.lean is down to the two deep BHKS obligations
+(`latticeArm2_fastCore_count`, `latticeArm3_bhksSingleAllOnes_irreducible` —
+the arm-3 `hclasses` sorry), which are #8417's remaining content and out of
+scope here.
+
+## Next step
+
+The deep van Hoeij adequacy content (#8417): the L5–L10 chain for arm 3 and
+the CLD count-equality for arm 2.
+
+## Blockers
+
+PR is stacked on #8517 (branch `issue-8417`), which is green and mergeable but
+not yet merged; this PR targets that branch (or rebases onto main once #8517
+lands).

--- a/progress/20260702T030438Z_review-8520-second-opinion.md
+++ b/progress/20260702T030438Z_review-8520-second-opinion.md
@@ -1,0 +1,34 @@
+# Review pass on lattice reassembly completeness (#8520)
+
+## Accomplished
+
+Reviewed the current #8520 lattice reassembly completeness change:
+
+- checked the `latticeCoreFactorsWithBound` implementation against the new
+  structural case split in `HexBerlekampZassenhaus/Basic.lean`;
+- checked the extracted
+  `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm` proof
+  shape in `HexBerlekampZassenhausMathlib/IntReductionMod.lean`;
+- checked the lattice composition and sorry discharge in
+  `HexBerlekampZassenhausMathlib/LatticeTier.lean`.
+
+No code changes were made beyond this progress note.
+
+## Current frontier
+
+The change appears to discharge the intended lattice
+`reassemblyExpansionComplete` obligation without weakening the caller-facing
+raw-factor irreducibility theorem. The main review risks are dependency and
+presentation issues: the proof relies on the existing BHKS-sorried lattice core
+irreducibility theorem, and the extracted `_of_norm` theorem may be considered
+broader/more hidden than some reviewers prefer.
+
+## Next step
+
+If revising before PR review, consider adding a short comment/doc note at the
+lattice use site that the only remaining analytic dependency is the existing
+BHKS core irreducibility theorem, not a new reassembly assumption.
+
+## Blockers
+
+None for this review pass.


### PR DESCRIPTION
This PR proves the lattice tier's reassembly-completeness side condition, discharging the `reassemblyExpansionComplete` sorry in `factorLatticeFactorsWithBound_factor_irreducible` (`HexBerlekampZassenhausMathlib/LatticeTier.lean`). It adds the structural case-split `latticeCoreFactorsWithBound_spec` and the companions `latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}` to the Mathlib-free layer (every `some cf` is the singleton `#[core]` — the small-mod and all-ones certification arms — or a `factorFastCoreWithBound` success, so the trio reuses `factorFastCoreWithBound_product` / `_some_normalizeFactorSign` / `_some_degree_pos`); extracts the shared tail of the proven classical analogue (the per-factor positive-leading-coefficient derivation and the fuel bound) into `reassemblyExpansionComplete_of_irreducible_squarefree_cover_of_norm`, rewiring `reassemblyExpansionComplete_classicalCore_of_ne_zero` through it; and composes them with the `LatticeTier` core irreducibility lemma into `reassemblyExpansionComplete_latticeCore_of_ne_zero`, which fills the sorry. The reassembly side is now fully proved; the completeness lemma's only analytic dependency is its core-irreducibility input, which inherits the two open BHKS obligations of https://github.com/kim-em/hex-dev/issues/8417 (feat: verify the lattice tier — prove the van Hoeij/CLD step lands on minimal subsets) and introduces no new assumption. Whole `HexBerlekampZassenhausMathlib` builds green; no new `axiom`/`native_decide`.

Stacked on https://github.com/kim-em/hex-dev/pull/8517 (feat: verified van Hoeij lattice tier — reduction + proven-LLL adequacy foundation (#8417)): this PR targets the `issue-8417` branch and should be retargeted/rebased onto `main` once #8517 merges.

Closes #8520.

🤖 Prepared with Claude Code