### PR TITLE
feat: re-key the standalone fast tier to toMonicPrimeData? (monic-coordinate coherence)

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9173,10 +9173,11 @@ namespace ZPoly
 /--
 Optional prime-choice data for the monic polynomial sent to Hensel lifting.
 
-The public factoring pipeline still chooses prime data from the original core.
-This adjacent surface is for proof callers that need Berlekamp-form modular
-factor data for `(toMonic core).monic`, the polynomial that `toMonicLiftData`
-passes to `henselLiftData`.
+This is the prime selector for every tier that lifts through
+`toMonicLiftData` (fast, classical, lattice, slow modular): the selected
+modular factor data is the Berlekamp-form mod-`p` factorisation of
+`(toMonic core).monic`, the polynomial that `toMonicLiftData` passes to
+`henselLiftData`, so the Hensel seeds match the lift target (#8519, #8533).
 -/
 def toMonicPrimeData? (core : ZPoly) : Option PrimeChoiceData :=
   choosePrimeData? (toMonic core).monic
@@ -9576,14 +9577,12 @@ Exposed publicly so the Mathlib-side layer can express per-branch
 irreducibility hypotheses for the assembled output theorem.  Internal callers
 still go through the `factorFast` wrapper.
 
-Note (#8519): this standalone tier still selects its prime with
-`choosePrimeData?` on the core itself, while the shared recovery runs the CLD
-lattice in the monic (`toMonic`) coordinate.  For `leadingCoeff core ≢ 1
-(mod p)` the Hensel seeds then do not match the lift target, so this tier
-remains a verification-guarded, decline-only heuristic there (sound but
-incomplete); the hybrid pipeline's lattice tier
-(`factorLatticeFactorsWithBound`) selects `toMonicPrimeData?` and is the
-coordinate-coherent, proof-carrying path. -/
+The prime is selected on the monic transform (`ZPoly.toMonicPrimeData?`,
+#8533): the shared recovery (`factorFastCoreWithBound` →
+`bhksRecoverClassified`) Hensel-lifts the selected modular factors against
+`(ZPoly.toMonic core).monic`, so the seeds must be that transform's mod-`p`
+factorisation.  Selecting on `core` itself breaks the lift invariant whenever
+`leadingCoeff core ≢ 1 (mod p)` (#8519). -/
 def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPoly) :=
   let normalized := normalizeForFactor f
   if normalized.squareFreeCore.degree?.getD 0 = 0 then
@@ -9592,7 +9591,7 @@ def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPoly) :=
     none
   else
     if B = 1 then
-      match choosePrimeData? normalized.squareFreeCore with
+      match ZPoly.toMonicPrimeData? normalized.squareFreeCore with
       | none => none
       | some primeData =>
           if primeData.factorsModP.size ≤ 1 then
@@ -9606,7 +9605,7 @@ def factorFastFactorsWithBound (f : ZPoly) (B : Nat) : Option (Array ZPoly) :=
       match quadraticIntegerRootFactors? normalized.squareFreeCore with
       | some coreFactors => some (reassemblePolynomialFactors normalized coreFactors)
       | none =>
-        match choosePrimeData? normalized.squareFreeCore with
+        match ZPoly.toMonicPrimeData? normalized.squareFreeCore with
         | none => none
         | some primeData =>
             if primeData.factorsModP.size ≤ 1 then
@@ -9639,8 +9638,8 @@ input is not zero-degree (`hdeg`), the recombination budget is at least one
 (`hB_pos`), the small-mod singleton predicate fails (`hnotsingleton`), and
 (when `B ≠ 1`) the quadratic-root short-circuit does not apply (`hquadratic`).
 The `hnotsingleton` premise is the post-#4605 form: the small-mod singleton
-branch fires when `(choosePrimeData? sf).isSome ∧ size ≤ 1` is true; its
-negation routes the dispatcher to the BHKS core call, which is what this
+branch fires when `(ZPoly.toMonicPrimeData? sf).isSome ∧ size ≤ 1` is true;
+its negation routes the dispatcher to the BHKS core call, which is what this
 lemma's `hcore` invariant uses.
 
 Exposed publicly so the Mathlib-side fast `h_raw` disjunct producer can
@@ -9650,7 +9649,8 @@ theorem factorFastFactorsWithBound_eq_some_of_core_success
     (f : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     (coreFactors : Array ZPoly)
     (hB_pos : 1 ≤ B)
-    (hchoose : choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (hnotsingleton :
       ¬ primeData.factorsModP.size ≤ 1)
@@ -9666,14 +9666,14 @@ theorem factorFastFactorsWithBound_eq_some_of_core_success
   rw [if_neg hdeg, if_neg (by omega : B ≠ 0)]
   by_cases hB1 : B = 1
   · rw [if_pos hB1]
-    simp [hchoose, hnotsingleton, hcore]
+    simp [hselected, hnotsingleton, hcore]
   · rw [if_neg hB1]
     have hq : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none := by
       cases hquadratic with
       | inl heq => exact absurd heq hB1
       | inr hnone => exact hnone
     rw [hq]
-    simp [hchoose, hnotsingleton, hcore]
+    simp [hselected, hnotsingleton, hcore]
 
 /-- Identify the fast-path raw factor array on the quadratic integer-root
 short-circuit. When the square-free core has positive degree (`hdeg`), the
@@ -9723,11 +9723,11 @@ theorem factorFastFactorsWithBound_branch (f : ZPoly) (B : Nat) :
       ((normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧ B = 0 ∨
        (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧
          B = 1 ∧
-         choosePrimeData? (normalizeForFactor f).squareFreeCore = none ∨
+         ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = none ∨
        (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0 ∧
          1 < B ∧
          quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none ∧
-         choosePrimeData? (normalizeForFactor f).squareFreeCore = none ∨
+         ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = none ∨
        True)) ∨
     (∃ factors, factorFastFactorsWithBound f B = some factors) := by
   cases hfast : factorFastFactorsWithBound f B with
@@ -9740,19 +9740,19 @@ theorem factorFastFactorsWithBound_branch (f : ZPoly) (B : Nat) :
 
 /-- Witness-form variant of `factorFastFactorsWithBound_branch`: the
 small-mod and BHKS disjuncts reference `primeData` directly rather than
-`choosePrimeData`, given an explicit
-`hchoose : choosePrimeData? sf = some primeData`. Since `hchoose`
-implies `primeData = choosePrimeData sf`, the (e), (i)
+the selector, given an explicit
+`hselected : ZPoly.toMonicPrimeData? sf = some primeData`. Since
+`hselected` pins the prime data, the (e), (i)
 fast-core-none disjuncts that depend on the prime-data shape collapse
 to a single fast-core-none disjunct (without the `isSome` clause, which
-is automatic from `hchoose`).
+is automatic from `hselected`).
 
-Disjuncts whose statements never mention `choosePrimeData(WithFallback)`
+Disjuncts whose statements never mention the prime selector
 ((a), (b), (f)) are reproduced verbatim. -/
-theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
+theorem factorFastFactorsWithBound_branch_of_toMonicPrimeData?_some
     (f : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData) :
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData) :
     -- (a) constant core
     (factorFastFactorsWithBound f B =
         some (reassemblePolynomialFactors (normalizeForFactor f)
@@ -9834,7 +9834,7 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
         by_cases hsmall : primeData.factorsModP.size ≤ 1
         · right; right; left
           refine ⟨?_, hdeg, hB1, hsmall⟩
-          simp [hchoose, hsmall]
+          simp [hselected, hsmall]
         · cases hcore :
             factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
               B primeData
@@ -9843,11 +9843,11 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
           | some coreFactors =>
               right; right; right; left
               refine ⟨coreFactors, ?_, hdeg, hB1, hsmall, rfl⟩
-              simp [hchoose, hsmall, hcore]
+              simp [hselected, hsmall, hcore]
           | none =>
               right; right; right; right; left
               refine ⟨?_, hdeg, hB1, hsmall, rfl⟩
-              simp [hchoose, hsmall, hcore]
+              simp [hselected, hsmall, hcore]
       · rw [if_neg hB1]
         have hBgt : 1 < B := by omega
         cases hquad : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
@@ -9859,7 +9859,7 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
             by_cases hsmall : primeData.factorsModP.size ≤ 1
             · right; right; right; right; right; right; left
               refine ⟨?_, hdeg, hBgt, rfl, hsmall⟩
-              simp [hchoose, hsmall]
+              simp [hselected, hsmall]
             · cases hcore :
                 factorFastCoreWithBound (normalizeForFactor f).squareFreeCore
                         B primeData
@@ -9868,11 +9868,11 @@ theorem factorFastFactorsWithBound_branch_of_choosePrimeData?_some
               | some coreFactors =>
                   right; right; right; right; right; right; right; left
                   refine ⟨coreFactors, ?_, hdeg, hBgt, rfl, hsmall, rfl⟩
-                  simp [hchoose, hsmall, hcore]
+                  simp [hselected, hsmall, hcore]
               | none =>
                   right; right; right; right; right; right; right; right
                   refine ⟨?_, hdeg, hBgt, rfl, hsmall, rfl⟩
-                  simp [hchoose, hsmall, hcore]
+                  simp [hselected, hsmall, hcore]
 
 /--
 Precision cap used by the public fast path.
@@ -10032,6 +10032,15 @@ def factorFast (f : ZPoly) : Option Factorization :=
 
 #guard (factorFast (DensePoly.ofCoeffs #[1, 1, 1, 1, 1])).map Factorization.product =
   some (DensePoly.ofCoeffs #[1, 1, 1, 1, 1])
+
+-- #8533 regression witness: `(2x+1)(x² + x + 1)`, a non-monic core whose
+-- leading coefficient is ≢ 1 modulo the core-keyed prime (`p = 5`).  Under the
+-- pre-#8533 core-keyed selection the Hensel seeds did not match the monic lift
+-- target and the fast tier declined (`none`); with the prime keyed on the
+-- monic transform it recovers both factors.
+#guard (factorFast (DensePoly.ofCoeffs #[1, 3, 3, 2])).map Factorization.product =
+  some (DensePoly.ofCoeffs #[1, 3, 3, 2])
+#guard (factorFast (DensePoly.ofCoeffs #[1, 3, 3, 2])).map (·.factors.size) = some 2
 
 #guard factorFastWithBound (DensePoly.ofCoeffs #[1, 0, 0, 0, 1]) 4 = none
 #guard factorFastWithBound cldGuardF 1 = none
@@ -10419,8 +10428,8 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
     {target : Nat} {coreFactors : Array ZPoly}
     (hB_pos : 1 ≤ factorFastPrecisionCap f)
     (hfloor : fastCoreFloor (normalizeForFactor f).squareFreeCore ≤ target)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hmem :
       target ∈
         henselPrecisionSchedule (factorFastPrecisionCap f)
@@ -10451,7 +10460,7 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
       rw [if_neg (by omega : B ≠ 0)]
       by_cases hB1 : B = 1
       · rw [if_pos hB1]
-        rw [hchoose]
+        rw [hselected]
         by_cases hpred : primeData.factorsModP.size ≤ 1
         · simp [hpred]
         · simp [hpred]
@@ -10469,7 +10478,7 @@ theorem factorFast_ne_none_of_core_recovery_on_schedule
         | some factors =>
             simp
         | none =>
-            rw [hchoose]
+            rw [hselected]
             by_cases hpred : primeData.factorsModP.size ≤ 1
             · simp [hpred]
             · simp [hpred]
@@ -10548,10 +10557,10 @@ theorem factor_eq_factorizationOfFactors (f : ZPoly) :
 Option-returning bounded factoring entry point that propagates explicit failure
 on no-admissible-prime. Returns `some (factorWithBound f B)` exactly on the
 constant-core early-out, the quadratic-integer-root short-circuit, and the
-fast- or slow-prime-data-available case. Returns `none` precisely when
-`quadraticIntegerRootFactors? sf` is `none` and both the fast selector
-`choosePrimeData? sf` and slow modular selector `ZPoly.toMonicPrimeData? sf`
-are `none` on the normalized square-free core `sf`.
+prime-data-available case. Returns `none` precisely when
+`quadraticIntegerRootFactors? sf` is `none` and the shared prime selector
+`ZPoly.toMonicPrimeData? sf` (used by both the fast and slow modular tiers,
+#8533) is `none` on the normalized square-free core `sf`.
 
 This is the additive Option-propagating boundary recommended by #5816 (and the
 SPEC `design-principles.md` §8 fallback-discipline clause that #5775 raises).
@@ -10562,8 +10571,7 @@ def factorWithBound? (f : ZPoly) (B : Nat) : Option Factorization :=
     some (factorWithBound f B)
   else if (quadraticIntegerRootFactors? normalized.squareFreeCore).isSome then
     some (factorWithBound f B)
-  else if (choosePrimeData? normalized.squareFreeCore).isSome ||
-      (ZPoly.toMonicPrimeData? normalized.squareFreeCore).isSome then
+  else if (ZPoly.toMonicPrimeData? normalized.squareFreeCore).isSome then
     some (factorWithBound f B)
   else
     none
@@ -10575,7 +10583,6 @@ theorem factorWithBound?_eq_some_iff_safe_branch (f : ZPoly) (B : Nat) :
     factorWithBound? f B =
       (if (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0 ∨
           (quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore).isSome ∨
-          (choosePrimeData? (normalizeForFactor f).squareFreeCore).isSome ∨
           (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
         then some (factorWithBound f B) else none) := by
   unfold factorWithBound?
@@ -10584,13 +10591,10 @@ theorem factorWithBound?_eq_some_iff_safe_branch (f : ZPoly) (B : Nat) :
   · by_cases hquad :
       (quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore).isSome
     · simp [hdeg, hquad]
-    · by_cases hprime :
-        (choosePrimeData? (normalizeForFactor f).squareFreeCore).isSome
-      · simp [hdeg, hquad, hprime]
-      · by_cases hmonicPrime :
-          (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
-        · simp [hdeg, hquad, hprime, hmonicPrime]
-        · simp [hdeg, hquad, hprime, hmonicPrime]
+    · by_cases hmonicPrime :
+        (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
+      · simp [hdeg, hquad, hmonicPrime]
+      · simp [hdeg, hquad, hmonicPrime]
 
 set_option maxHeartbeats 800000
 
@@ -11101,18 +11105,19 @@ is exactly the singleton square-free core. This is the branch-shape lemma needed
 by Mathlib-side irreducibility proofs; it still leaves the mathematical proof
 that the singleton core is irreducible to the Mathlib-side layer.
 
-The `hchoose` premise reflects the dispatcher contract: under the small-mod
+The `hselected` premise reflects the dispatcher contract: under the small-mod
 singleton dispatch (issue #4605), the fast path only fires the singleton arm
-when `choosePrimeData?` selects a good prime. When `choosePrimeData? sf = none`
-the fast path returns `none` and `factorWithBound` falls through to the
-exhaustive slow path, so the singleton branch-shape conclusion does not apply. -/
+when `ZPoly.toMonicPrimeData?` selects a good prime for the monic transform.
+When `ZPoly.toMonicPrimeData? sf = none` the fast path returns `none` and
+`factorWithBound` falls through to the exhaustive slow path, so the singleton
+branch-shape conclusion does not apply. -/
 theorem factorWithBound_entry_mem_small_mod_singleton_raw
     (f : ZPoly) (B : Nat) (entry : ZPoly × Nat)
     (primeData : PrimeChoiceData)
     (hB_pos : 1 ≤ B)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hsmall : primeData.factorsModP.size ≤ 1)
     (hquadratic : B = 1 ∨
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
@@ -11129,7 +11134,7 @@ theorem factorWithBound_entry_mem_small_mod_singleton_raw
     rw [if_neg hdeg, if_neg (by omega : B ≠ 0)]
     by_cases hB1 : B = 1
     · rw [if_pos hB1]
-      simp [hchoose, hsmall]
+      simp [hselected, hsmall]
     · rw [if_neg hB1]
       have hquad :
           quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore =
@@ -11138,7 +11143,7 @@ theorem factorWithBound_entry_mem_small_mod_singleton_raw
         | inl heq => exact absurd heq hB1
         | inr hnone => exact hnone
       rw [hquad]
-      simp [hchoose, hsmall]
+      simp [hselected, hsmall]
   apply factorizationOfFactors_entry_mem_normalized_raw
   simpa only [factorWithBound, factorFastWithBound, hfast, Option.map_some,
     Option.getD_some] using hmem
@@ -11205,16 +11210,16 @@ proofs; it leaves the mathematical proof that each core factor is irreducible
 to the Mathlib-side layer.
 
 The `primeData` parameter is paired with an explicit
-`hchoose : choosePrimeData? sf = some primeData` witness; downstream callers
-that already have a `choosePrimeData?` success witness in scope thread it
-through directly, without depending on the silent fallback dispatch. -/
+`hselected : ZPoly.toMonicPrimeData? sf = some primeData` witness; downstream
+callers that already have a `toMonicPrimeData?` success witness in scope thread
+it through directly, without depending on the silent fallback dispatch. -/
 theorem factorWithBound_entry_mem_fast_core_success_raw
     (f : ZPoly) (B : Nat) (entry : ZPoly × Nat)
     (primeData : PrimeChoiceData)
     (hB_pos : 1 ≤ B)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hmulti : 1 < primeData.factorsModP.size)
     (hquadratic : B = 1 ∨
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
@@ -11234,7 +11239,7 @@ theorem factorWithBound_entry_mem_fast_core_success_raw
         some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) :=
     factorFastFactorsWithBound_eq_some_of_core_success f B
       primeData coreFactors
-      hB_pos hchoose hdeg hnotsingleton hquadratic hcore
+      hB_pos hselected hdeg hnotsingleton hquadratic hcore
   apply factorizationOfFactors_entry_mem_normalized_raw
   simpa only [factorWithBound, factorFastWithBound, hfast, Option.map_some,
     Option.getD_some] using hmem
@@ -18428,7 +18433,7 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
       by_cases hB1 : B = 1
       · simp only [hB1, if_true] at hfast
         subst B
-        cases hchoose : choosePrimeData? (normalizeForFactor f).squareFreeCore with
+        cases hchoose : ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore with
         | none =>
             simp [hchoose] at hfast
         | some primeData =>
@@ -18468,7 +18473,7 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
               (quadraticIntegerRootFactors?_product hquad)
         | none =>
             simp only [hquad] at hfast
-            cases hchoose : choosePrimeData? (normalizeForFactor f).squareFreeCore with
+            cases hchoose : ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore with
             | none =>
                 simp [hchoose] at hfast
             | some primeData =>
@@ -18486,12 +18491,10 @@ private theorem factorFastFactorsWithBound_polyProduct_of_some
                         (initialHenselPrecision B)
                         (ZPoly.quadraticDoublingSteps B + 2) with
                   | none =>
-                      rw [hcore] at hfast
-                      contradiction
+                      simp [hcore] at hfast
                   | some coreFactors =>
-                      rw [hcore] at hfast
-                      have hfactors := Option.some.inj hfast
-                      rw [← hfactors]
+                      simp only [hcore, Option.some.injEq] at hfast
+                      rw [← hfast]
                       exact reassemblePolynomialFactors_product_eq_input f coreFactors
                         (factorFastCoreWithBound_product
                           (normalizeForFactor f).squareFreeCore
@@ -19949,8 +19952,8 @@ private theorem factorFastWithBound_product_of_small_mod_branch
     (hf : f ≠ 0)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (hB_pos : 1 ≤ B)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hsmall : primeData.factorsModP.size ≤ 1)
     (hquadratic : B = 1 ∨
       quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none)
@@ -19964,7 +19967,7 @@ private theorem factorFastWithBound_product_of_small_mod_branch
     rw [if_neg hdeg, if_neg (by omega : B ≠ 0)]
     by_cases hB1 : B = 1
     · rw [if_pos hB1]
-      simp [hchoose, hsmall]
+      simp [hselected, hsmall]
     · rw [if_neg hB1]
       have hq : quadraticIntegerRootFactors?
           (normalizeForFactor f).squareFreeCore = none := by
@@ -19972,7 +19975,7 @@ private theorem factorFastWithBound_product_of_small_mod_branch
         | inl heq => exact absurd heq hB1
         | inr hnone => exact hnone
       rw [hq]
-      simp [hchoose, hsmall]
+      simp [hselected, hsmall]
   have hphi :
       factorizationOfFactors f
           (reassemblePolynomialFactors (normalizeForFactor f)
@@ -20019,7 +20022,7 @@ private theorem factorFastWithBound_product_of_quadratic_branch
 
 /-- Inner kernel for `_product_of_core_success_branch`. Takes the
 `factorFastFactorsWithBound` success witness `hfast` directly after the
-caller has threaded the explicit `choosePrimeData? = some primeData`
+caller has threaded the explicit `ZPoly.toMonicPrimeData? = some primeData`
 witness through the fast-path dispatcher. The per-factor normalisation /
 recording facts go through `factorFastCoreWithBound_some_*`. -/
 private theorem factorFastWithBound_product_of_factorFastFactorsWithBound_some_core
@@ -20076,8 +20079,8 @@ private theorem factorFastWithBound_product_of_core_success_branch
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (hB_pos : 1 ≤ B)
     (primeData : PrimeChoiceData)
-    (hchoose :
-      choosePrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
+    (hselected :
+      ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore = some primeData)
     (hnotsingleton :
       ¬ primeData.factorsModP.size ≤ 1)
     (hquadratic : B = 1 ∨
@@ -20093,7 +20096,7 @@ private theorem factorFastWithBound_product_of_core_success_branch
       factorFastFactorsWithBound f B =
         some (reassemblePolynomialFactors (normalizeForFactor f) coreFactors) :=
     factorFastFactorsWithBound_eq_some_of_core_success
-      f B primeData coreFactors hB_pos hchoose hdeg hnotsingleton hquadratic hcore
+      f B primeData coreFactors hB_pos hselected hdeg hnotsingleton hquadratic hcore
   exact factorFastWithBound_product_of_factorFastFactorsWithBound_some_core
     f B primeData hf coreFactors hfast hcore h
 
@@ -20122,9 +20125,9 @@ private theorem factorFastWithBound_product_of_some
         simp at h
       · have hB_pos : 1 ≤ B := Nat.one_le_iff_ne_zero.mpr hB0
         by_cases hB1 : B = 1
-        · -- B = 1: dispatch on choosePrimeData? and small-mod predicate
+        · -- B = 1: dispatch on toMonicPrimeData? and small-mod predicate
           subst B
-          match hc : choosePrimeData? (normalizeForFactor f).squareFreeCore with
+          match hc : ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore with
           | some primeData =>
               by_cases hsmall : primeData.factorsModP.size ≤ 1
               · exact factorFastWithBound_product_of_small_mod_branch
@@ -20169,7 +20172,7 @@ private theorem factorFastWithBound_product_of_some
               exact factorFastWithBound_product_of_quadratic_branch
                 f B hf hdeg hB_ge_two coreFactors hquadNone h
           | none =>
-          match hc : choosePrimeData? (normalizeForFactor f).squareFreeCore with
+          match hc : ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore with
           | some primeData =>
               by_cases hsmall : primeData.factorsModP.size ≤ 1
               · exact factorFastWithBound_product_of_small_mod_branch
@@ -20507,7 +20510,6 @@ theorem factorWithBound?_product_of_some
   by_cases hsafe :
       (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0 ∨
         (quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore).isSome ∨
-        (choosePrimeData? (normalizeForFactor f).squareFreeCore).isSome ∨
         (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
   · rw [if_pos hsafe] at h
     cases h
@@ -20526,7 +20528,6 @@ theorem factorWithBound?_eq_some_eq_factorWithBound
   by_cases hsafe :
       (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0 ∨
         (quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore).isSome ∨
-        (choosePrimeData? (normalizeForFactor f).squareFreeCore).isSome ∨
         (ZPoly.toMonicPrimeData? (normalizeForFactor f).squareFreeCore).isSome
   · rw [if_pos hsafe] at h
     exact (Option.some.inj h).symm

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -2539,7 +2539,7 @@ the `repeatedPart` of `normalizeForFactor f` is exactly a
 and that factorPower is consumed completely by
 `Hex.expandRepeatedPartFactorArray` (deliverable 2). Consumed by the
 small-mod singleton arm umbrella
-`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+`factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData`
 (#4564 / PR #4581) so callers can drop the explicit `hcomplete` premise
 once the eventual capstone wiring (#4170) lands.
 
@@ -2623,7 +2623,7 @@ routes through the non-monic array-level public surface
 no-tail-divisibility precondition discharged by
 `factorPower_cover_not_dvd_tail_of_irreducible_squarefree` (#4807).
 The singleton-arm umbrella
-`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
+`factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData`
 threads `hcomplete` from the caller, so the value of this sibling is in
 letting downstream dispatchers discharge `hcomplete` under a non-monic
 primitive `squareFreeCore` (e.g. the `2X + 3` residual from
@@ -3557,64 +3557,69 @@ theorem liftedFactorSubsetPartition_outerBound_of_choosePrimeData
       (IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_squarefree f hf)
       hdescent hlifted_of_modP hinitial
 
-/--
-Branch-local substrate for the small-mod singleton arm, specialised to the
-square-free core produced by `Hex.normalizeForFactor`.
+/-- Descend irreducibility along the monic (`x ↦ x/ℓf`) transform: if the monic
+transform of a primitive positive-degree core is irreducible, so is the core.
+The dilation identity `dilate ℓf (toMonic core).monic = ℓf^(d-1) · core`
+identifies the two up to a positive constant, which `primitivePart` strips. -/
+theorem zpolyIrreducible_of_toMonicMonic_irreducible
+    (core : Hex.ZPoly)
+    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
+    (hcore_pos : 0 < core.degree?.getD 0)
+    (hcore_prim : Hex.ZPoly.Primitive core)
+    (hm_irr : Hex.ZPoly.Irreducible (Hex.ZPoly.toMonic core).monic) :
+    Hex.ZPoly.Irreducible core := by
+  have hdeg : 1 ≤ (Hex.ZPoly.toMonic core).degree := by
+    simp only [Hex.ZPoly.toMonic_degree]; omega
+  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
+    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos (by simp only [Hex.ZPoly.toMonic_degree]; omega)
+  have hkey : Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) (Hex.ZPoly.toMonic core).monic
+      = Hex.DensePoly.scale
+          (Hex.DensePoly.leadingCoeff core ^ ((Hex.ZPoly.toMonic core).degree - 1)) core := by
+    have h := Hex.ZPoly.dilate_monic_toMonic core hdeg
+    rwa [Hex.ZPoly.C_mul_eq_scale] at h
+  have hrecover : Hex.ZPoly.primitivePart
+      (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) (Hex.ZPoly.toMonic core).monic)
+      = core := by
+    rw [hkey]
+    exact Hex.DensePoly.primitivePart_scale_of_primitive
+      (pow_pos hcore_lc_pos _) hcore_prim
+  rw [Hex.ZPoly.Irreducible_iff_polynomialIrreducible] at hm_irr ⊢
+  exact (irreducible_toPolynomial_dilate_iff
+    (ne_of_gt hcore_lc_pos) hM_monic hcore_prim hrecover).mpr hm_irr
 
-This is the capstone-facing package of side conditions required by
-`IntReductionMod.squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squareFreeModP`:
-the primitive Mathlib image of the normalised square-free core, the selected
-prime's leading-coefficient nonvanishing after reduction, and the executable
-`choosePrimeData?`/singleton-factor-count witnesses in the exact shape used by
-the fast singleton branch.
--/
-theorem smallModSingletonBranchPreconditions_of_choosePrimeData
-    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
-    (primeData : Hex.PrimeChoiceData)
-    (hchoose :
-      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
-        some primeData)
-    (hsmall : primeData.factorsModP.size ≤ 1) :
-    (HexPolyZMathlib.toPolynomial
-        (Hex.normalizeForFactor f).squareFreeCore).IsPrimitive ∧
-      (Int.castRingHom (ZMod primeData.p))
-          (HexPolyZMathlib.toPolynomial
-            (Hex.normalizeForFactor f).squareFreeCore).leadingCoeff ≠ 0 ∧
-      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
-        some primeData ∧
-      primeData.factorsModP.size ≤ 1 := by
-  exact ⟨
-    IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive
-      f hf_ne,
-    IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero
-      (Hex.normalizeForFactor f).squareFreeCore primeData hchoose,
-    hchoose,
-    hsmall⟩
-
-/--
-Small-mod singleton irreducibility for the normalised square-free core, with
-all primitive, leading-coefficient, selected-prime, and singleton-count
-preconditions discharged from the executable branch state.
-
-This is the reusable bridge package consumed by the recorded-entry singleton
-umbrella below and by the `factor_irreducible_of_nonUnit` capstone path.
--/
-theorem squareFreeCore_irreducible_of_smallModSingletonBranch
-    (f : Hex.ZPoly) (hf_ne : f ≠ 0)
-    (primeData : Hex.PrimeChoiceData)
+/-- Small-mod singleton arm, keyed on the monic-transform prime selection
+`toMonicPrimeData?` (the selector shared by the fast, lattice, and slow modular
+tiers; #8519, #8533): a singleton mod-`p` factorisation of
+`(toMonic core).monic` certifies its irreducibility over `ℤ`, which descends to
+the primitive core along the dilation transform. -/
+theorem squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch
+    (f : Hex.ZPoly) (hf_ne : f ≠ 0) (primeData : Hex.PrimeChoiceData)
     (hcore_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0)
-    (hchoose :
-      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
-        some primeData)
+    (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
+      = some primeData)
     (hsmall : primeData.factorsModP.size ≤ 1) :
     Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore := by
-  rcases smallModSingletonBranchPreconditions_of_choosePrimeData
-      f hf_ne primeData hchoose hsmall with
-    ⟨hprim, hlc_map_ne, hchoose', hsmall'⟩
-  exact
+  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
+  have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
+    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
+  have hcore_prim : Hex.ZPoly.Primitive core :=
+    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
+  have hchoose : Hex.choosePrimeData? (Hex.ZPoly.toMonic core).monic = some primeData :=
+    hselected
+  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
+    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos (by simp only [Hex.ZPoly.toMonic_degree]; omega)
+  have hm_deg : 0 < (Hex.ZPoly.toMonic core).monic.degree?.getD 0 := by
+    rw [Hex.ZPoly.toMonic_monic_degree_eq_of_pos_degree core hcore_lc_pos
+      (by simp only [Hex.ZPoly.toMonic_degree]; omega)]
+    simpa using hcore_pos
+  have hm_irr : Hex.ZPoly.Irreducible (Hex.ZPoly.toMonic core).monic :=
     IntReductionMod.squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squareFreeModP
-      (Hex.normalizeForFactor f).squareFreeCore primeData hchoose' hcore_pos hsmall'
-      hprim hlc_map_ne
+      (Hex.ZPoly.toMonic core).monic primeData hchoose hm_deg hsmall
+      (HexHenselMathlib.toPolynomial_monic_of_dense_monic _ hM_monic).isPrimitive
+      (IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero
+        (Hex.ZPoly.toMonic core).monic primeData hchoose)
+  exact zpolyIrreducible_of_toMonicMonic_irreducible core hcore_lc_pos hcore_pos
+    hcore_prim hm_irr
 
 /-- **#4562 HO-1 base task — small-mod singleton arm umbrella.**
 
@@ -3622,7 +3627,8 @@ Per-branch HO-1 component for the small-mod singleton arm of the capstone
 `factor_irreducible_of_nonUnit` (#4170): every entry recorded by
 `Hex.factorWithBound f B` in this fast-path branch is `Hex.ZPoly.Irreducible`,
 given only `f ≠ 0`, the branch marker hypotheses, and the executable
-`choosePrimeData?` success witness `hchoose`. The reassembly
+`ZPoly.toMonicPrimeData?` success witness `hselected` (the monic-transform
+prime selection the fast dispatcher runs on; #8533). The reassembly
 expansion-complete side condition is discharged internally via
 `IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
 (#4956 / PR #4961), so the umbrella no longer requires an explicit
@@ -3633,13 +3639,9 @@ Composes:
   (`HexBerlekampZassenhaus/Basic.lean`) — the Mathlib-free branch-shape
   lemma identifying each recorded entry as the sign-normalisation of a raw
   factor in the singleton-core reassembly;
-* `IntReductionMod.squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squareFreeModP`
-  — the singleton-core irreducibility theorem from the chosen prime's
-  Berlekamp form;
-* the base dischargers from #4545
-  (`IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_isPrimitive`
-  and `IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero`),
-  which produce `hprim` and `hlc_map_ne` from `f ≠ 0` and `hchoose`;
+* `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch` — the
+  singleton-core irreducibility theorem from the monic transform's
+  Berlekamp form, descended along the dilation transform (#8519);
 * `IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`
   — the non-monic primitive singleton-arm `hcomplete` discharger from
   #4956 / PR #4961, producing the reassembly expansion-complete side
@@ -3658,7 +3660,7 @@ Composes:
 The slow-path exhaustive arm (#4561), the slow-path constant and quadratic
 sub-branches, and the fast BHKS arm (gated on #2567) are separate concerns
 and are out of scope here. -/
-theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
+theorem factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData
     (f : Hex.ZPoly) (hf_ne : f ≠ 0)
     (B : Nat) (hB_pos : 1 ≤ B)
     (entry : Hex.ZPoly × Nat)
@@ -3671,21 +3673,21 @@ theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
         Hex.quadraticIntegerRootFactors?
           (Hex.normalizeForFactor f).squareFreeCore = none)
     (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList)
-    (hchoose :
-      Hex.choosePrimeData?
+    (hselected :
+      Hex.ZPoly.toMonicPrimeData?
         (Hex.normalizeForFactor f).squareFreeCore = some primeData) :
     Hex.ZPoly.Irreducible entry.1 := by
   -- Branch-shape lemma: entry is the sign-normalisation of a raw factor in
   -- the singleton-core reassembly.
   obtain ⟨raw, hraw_mem, hentry_eq⟩ :=
     Hex.factorWithBound_entry_mem_small_mod_singleton_raw f B entry
-      primeData hB_pos hdeg hchoose hsmall hquadratic hentry_mem
-  -- Singleton-core irreducibility from the chosen prime's Berlekamp form,
-  -- with `hprim` and `hlc_map_ne` discharged by the #4545 base lemmas.
+      primeData hB_pos hdeg hselected hsmall hquadratic hentry_mem
+  -- Singleton-core irreducibility from the monic transform's Berlekamp form,
+  -- descended along the dilation transform.
   have hcore_irr :
       Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore :=
-    squareFreeCore_irreducible_of_smallModSingletonBranch
-      f hf_ne primeData (Nat.pos_of_ne_zero hdeg) hchoose hsmall
+    squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch
+      f hf_ne primeData (Nat.pos_of_ne_zero hdeg) hselected hsmall
   -- Discharge the reassembly expansion-complete side condition internally
   -- using the non-monic primitive singleton-arm discharger
   -- (#4956 / PR #4961).
@@ -3715,23 +3717,23 @@ theorem factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
   rw [hentry_eq]
   exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible hraw_irr
 
-/-- **#4605 HO-1 base task — `hchoose`-free small-mod singleton arm umbrella.**
+/-- **#4605 HO-1 base task — small-mod singleton arm umbrella.**
 
 Capstone-facing variant of
-`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`
-that takes no separate `hchoose` premise. The witness that `choosePrimeData?`
-selected a good prime is packed into the strengthened branch predicate
-`hsmall_chosen`, which is the **exact predicate** the post-#4605
+`factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData`
+with the selection witness in premise position before the branch markers.
+The witness that `ZPoly.toMonicPrimeData?` selected a good prime for the
+monic transform is the **exact predicate** the post-#8533
 `factorFastFactorsWithBound` dispatcher tests when deciding whether to fire
-the singleton arm: `(choosePrimeData? sf).isSome ∧ size ≤ 1`. The dispatcher
-restriction guarantees that this conjunction is *necessary* (not just
-sufficient) for the singleton branch to fire — when `choosePrimeData?` returns
-`none` the fast path returns `none` and `factorWithBound` falls through to the
-slow exhaustive path, so the singleton branch-shape lemma's conclusion does
-not apply in that case.
+the singleton arm: `(ZPoly.toMonicPrimeData? sf).isSome ∧ size ≤ 1`. The
+dispatcher restriction guarantees that this conjunction is *necessary* (not
+just sufficient) for the singleton branch to fire — when
+`ZPoly.toMonicPrimeData?` returns `none` the fast path returns `none` and
+`factorWithBound` falls through to the slow exhaustive path, so the
+singleton branch-shape lemma's conclusion does not apply in that case.
 
 The reassembly expansion-complete side condition is discharged internally
-by the `_of_choosePrimeData` umbrella above (via
+by the `_of_toMonicPrimeData` umbrella above (via
 `IntReductionMod.reassemblyExpansionComplete_singleton_of_irreducible_of_pos_lc`,
 #4956 / PR #4961), so this wrapper does not require an explicit
 `hcomplete` premise either. -/
@@ -3742,8 +3744,8 @@ theorem factor_small_mod_singleton_branch_entry_irreducible
     (hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (primeData : Hex.PrimeChoiceData)
-    (hchoose :
-      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+    (hselected :
+      Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore =
         some primeData)
     (hsmall : primeData.factorsModP.size ≤ 1)
     (hquadratic :
@@ -3752,9 +3754,9 @@ theorem factor_small_mod_singleton_branch_entry_irreducible
           (Hex.normalizeForFactor f).squareFreeCore = none)
     (hentry_mem : entry ∈ (Hex.factorWithBound f B).factors.toList) :
     Hex.ZPoly.Irreducible entry.1 :=
-  factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData
+  factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData
     f hf_ne B hB_pos entry hdeg primeData hsmall hquadratic hentry_mem
-    hchoose
+    hselected
 
 /-- **Fast-path small-mod singleton arm — raw guarded irreducibility.**
 
@@ -3765,11 +3767,11 @@ branch (`primeData.factorsModP.size ≤ 1`) is `Hex.ZPoly.Irreducible`, in the
 guarded shape consumed by the default factor irreducibility capstone (#8068).
 
 Under the branch markers — `f ≠ 0`, `1 ≤ B`, positive square-free-core degree
-(`hdeg`), the chosen prime `hchoose`, the singleton count `hsmall`, and the
+(`hdeg`), the selected prime `hselected`, the singleton count `hsmall`, and the
 quadratic-dispatch guard `hquadratic` — the dispatcher returns
 `Hex.reassemblePolynomialFactors (Hex.normalizeForFactor f)
 #[(Hex.normalizeForFactor f).squareFreeCore]`. The square-free core is
-irreducible by `squareFreeCore_irreducible_of_smallModSingletonBranch`, so both
+irreducible by `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`, so both
 the extracted `X`-power factors and the core entry of the reassembly are
 irreducible; the recorded-factor guard is therefore discharged for free (it is
 present only to compose with the constant arm, where the core is the unit `1`).
@@ -3784,8 +3786,8 @@ theorem factorFastFactorsWithBound_raw_guardedIrreducible_of_smallModSingleton
     (primeData : Hex.PrimeChoiceData)
     (hdeg :
       (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hchoose :
-      Hex.choosePrimeData? (Hex.normalizeForFactor f).squareFreeCore =
+    (hselected :
+      Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore =
         some primeData)
     (hsmall : primeData.factorsModP.size ≤ 1)
     (hquadratic :
@@ -3798,11 +3800,11 @@ theorem factorFastFactorsWithBound_raw_guardedIrreducible_of_smallModSingleton
       Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true →
         Hex.ZPoly.Irreducible raw := by
   intro raw hmem _hrecord
-  -- Singleton-core irreducibility from the chosen prime's Berlekamp form.
+  -- Singleton-core irreducibility from the monic transform's Berlekamp form.
   have hcore_irr :
       Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore :=
-    squareFreeCore_irreducible_of_smallModSingletonBranch
-      f hf_ne primeData (Nat.pos_of_ne_zero hdeg) hchoose hsmall
+    squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch
+      f hf_ne primeData (Nat.pos_of_ne_zero hdeg) hselected hsmall
   -- Discharge the reassembly expansion-complete side condition internally.
   have hcomplete :
       Hex.reassemblyExpansionComplete (Hex.normalizeForFactor f)
@@ -3833,8 +3835,8 @@ theorem factorFastFactorsWithBound_raw_guardedIrreducible_of_smallModSingleton
   -- singleton-core reassembly (the surviving disjuncts (c)/(g)); the other
   -- branches contradict the markers. The private reassembly value is named
   -- only through the public branch theorem's conclusion, never directly.
-  rcases Hex.factorFastFactorsWithBound_branch_of_choosePrimeData?_some f B primeData
-      hchoose with
+  rcases Hex.factorFastFactorsWithBound_branch_of_toMonicPrimeData?_some f B primeData
+      hselected with
     ⟨_, hd0⟩ | ⟨_, _, hB0⟩ | ⟨hv, _⟩ | ⟨_, _, _, _, hns, _⟩ |
       ⟨_, _, _, hns, _⟩ | ⟨_, _, _, hBgt, hqs⟩ | ⟨hv, _⟩ |
       ⟨_, _, _, _, _, hns, _⟩ | ⟨_, _, _, _, hns, _⟩
@@ -3904,7 +3906,7 @@ Composes:
   irreducibility.
 
 Sibling arms: the small-mod singleton arm #4564
-(`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`)
+(`factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData`)
 covers the `... ≠ 0` fast-path case with `factorsModP.size ≤ 1`; the slow
 exhaustive arm (#4561, in flight) covers the slow-path exhaustive case;
 the fast BHKS arm is gated on directive #2567. -/
@@ -4151,7 +4153,7 @@ branch-shape lemma differs (`_slow_quadratic_branch_raw` keys off
 Sibling arms: the fast-path constant arm #4565
 (`factor_constant_branch_entry_irreducible_of_choosePrimeData`); the fast-path
 small-mod singleton arm #4564
-(`factor_small_mod_singleton_branch_entry_irreducible_of_choosePrimeData`);
+(`factor_small_mod_singleton_branch_entry_irreducible_of_toMonicPrimeData`);
 the fast-path quadratic arm #4571
 (`factor_quadratic_branch_entry_irreducible_of_quadraticRoots`, above);
 the slow-path exhaustive arm #4561 (in flight); the fast BHKS arm gated on

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -47,69 +47,6 @@ noncomputable section
 
 open Polynomial
 
-/-- Descend irreducibility along the monic (`x ↦ x/ℓf`) transform: if the monic
-transform of a primitive positive-degree core is irreducible, so is the core.
-The dilation identity `dilate ℓf (toMonic core).monic = ℓf^(d-1) · core`
-identifies the two up to a positive constant, which `primitivePart` strips. -/
-theorem zpolyIrreducible_of_toMonicMonic_irreducible
-    (core : Hex.ZPoly)
-    (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
-    (hcore_pos : 0 < core.degree?.getD 0)
-    (hcore_prim : Hex.ZPoly.Primitive core)
-    (hm_irr : Hex.ZPoly.Irreducible (Hex.ZPoly.toMonic core).monic) :
-    Hex.ZPoly.Irreducible core := by
-  have hdeg : 1 ≤ (Hex.ZPoly.toMonic core).degree := by
-    simp only [Hex.ZPoly.toMonic_degree]; omega
-  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
-    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos (by simp only [Hex.ZPoly.toMonic_degree]; omega)
-  have hkey : Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) (Hex.ZPoly.toMonic core).monic
-      = Hex.DensePoly.scale
-          (Hex.DensePoly.leadingCoeff core ^ ((Hex.ZPoly.toMonic core).degree - 1)) core := by
-    have h := Hex.ZPoly.dilate_monic_toMonic core hdeg
-    rwa [Hex.ZPoly.C_mul_eq_scale] at h
-  have hrecover : Hex.ZPoly.primitivePart
-      (Hex.ZPoly.dilate (Hex.DensePoly.leadingCoeff core) (Hex.ZPoly.toMonic core).monic)
-      = core := by
-    rw [hkey]
-    exact Hex.DensePoly.primitivePart_scale_of_primitive
-      (pow_pos hcore_lc_pos _) hcore_prim
-  rw [Hex.ZPoly.Irreducible_iff_polynomialIrreducible] at hm_irr ⊢
-  exact (irreducible_toPolynomial_dilate_iff
-    (ne_of_gt hcore_lc_pos) hM_monic hcore_prim hrecover).mpr hm_irr
-
-/-- Small-mod singleton arm of the lattice tier, keyed on the monic-transform
-prime selection `toMonicPrimeData?`: a singleton mod-`p` factorisation of
-`(toMonic core).monic` certifies its irreducibility over `ℤ`, which descends to
-the primitive core along the dilation transform. -/
-theorem squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch
-    (f : Hex.ZPoly) (hf_ne : f ≠ 0) (primeData : Hex.PrimeChoiceData)
-    (hcore_pos : 0 < (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0)
-    (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
-      = some primeData)
-    (hsmall : primeData.factorsModP.size ≤ 1) :
-    Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore := by
-  set core := (Hex.normalizeForFactor f).squareFreeCore with hcore_def
-  have hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core :=
-    Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf_ne
-  have hcore_prim : Hex.ZPoly.Primitive core :=
-    IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf_ne
-  have hchoose : Hex.choosePrimeData? (Hex.ZPoly.toMonic core).monic = some primeData :=
-    hselected
-  have hM_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
-    Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos (by simp only [Hex.ZPoly.toMonic_degree]; omega)
-  have hm_deg : 0 < (Hex.ZPoly.toMonic core).monic.degree?.getD 0 := by
-    rw [Hex.ZPoly.toMonic_monic_degree_eq_of_pos_degree core hcore_lc_pos
-      (by simp only [Hex.ZPoly.toMonic_degree]; omega)]
-    simpa using hcore_pos
-  have hm_irr : Hex.ZPoly.Irreducible (Hex.ZPoly.toMonic core).monic :=
-    IntReductionMod.squareFreeCore_irreducible_of_small_mod_singleton_of_choosePrimeData_squareFreeModP
-      (Hex.ZPoly.toMonic core).monic primeData hchoose hm_deg hsmall
-      (HexHenselMathlib.toPolynomial_monic_of_dense_monic _ hM_monic).isPrimitive
-      (IntReductionMod.choosePrimeData?_leadingCoeff_castRingHom_ne_zero
-        (Hex.ZPoly.toMonic core).monic primeData hchoose)
-  exact zpolyIrreducible_of_toMonicMonic_irreducible core hcore_lc_pos hcore_pos
-    hcore_prim hm_irr
-
 /--
 **#8417 (lattice-tier irreducibility, reduced form).**  Every factor the
 van Hoeij CLD lattice tier `Hex.latticeCoreFactorsWithBound` returns for the

--- a/progress/20260702T130000Z_issue-8533.md
+++ b/progress/20260702T130000Z_issue-8533.md
@@ -1,0 +1,46 @@
+# issue #8533 — fast tier re-keyed to toMonicPrimeData?
+
+**Accomplished**
+- Completed the standalone fast tier's monic-coordinate re-key (#8533):
+  both `factorFastFactorsWithBound` dispatcher selection sites now use
+  `ZPoly.toMonicPrimeData?`, the branch theorem is
+  `factorFastFactorsWithBound_branch_of_toMonicPrimeData?_some`, the
+  schedule/termination wrappers and `factorWithBound?`'s selector
+  disjunction are re-keyed, and `#guard` regression witnesses record that
+  `factorFast` on `(2x+1)(x²+x+1)` now returns both factors
+  (commit 5d6184ce).
+- Repaired the two proof sites the re-key broke in
+  `HexBerlekampZassenhaus/Basic.lean`: the B≠1 arm of
+  `factorFastFactorsWithBound_polyProduct_of_some` (whnf timeout from
+  `rw`+`contradiction` on the symbolic-budget core call; replaced with
+  simp-based match reduction) and the stale 4-disjunct `by_cases`
+  predicates in `factorWithBound?_product_of_some` /
+  `factorWithBound?_eq_some_eq_factorWithBound`.
+- Re-keyed the Mathlib-layer fast-tier lemma surface
+  (`IntReductionMod.lean`): moved
+  `zpolyIrreducible_of_toMonicMonic_irreducible` and
+  `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch` from
+  `LatticeTier.lean` (same `HexBerlekampZassenhausMathlib` namespace, so
+  qualified names are unchanged), re-keyed the singleton umbrellas and the
+  raw guarded-irreducibility lemma onto the `toMonicPrimeData?` witness,
+  and deleted the two orphaned `choosePrimeData?`-keyed singleton helpers
+  (commit 1b701d2a).
+- Verified: `lake build HexBerlekampZassenhaus`,
+  `HexBerlekampZassenhausMathlib`, and `HexConformance` all green with no
+  new warnings; fresh `hexbz_emit_fixtures` emission byte-identical to the
+  committed `bz.jsonl`; `bz_trace_gate.py` 50/50; `bz_flint.py` oracle
+  100/100. No fixture regeneration needed — the public `factor` is the
+  hybrid pipeline, which never calls the standalone fast tier.
+
+**Current frontier**
+- The fast tier is now coordinate-coherent end to end; its success surface
+  covers non-monic cores exactly as the lattice tier's does.
+
+**Next step**
+- Optional follow-up flagged by the issue (non-deliverable): reuse
+  `normalizedFactors_card_le_bhksEquivalenceClassIndicators_size` for a
+  fast-tier irreducibility count theorem now that the `fastCoreFloor` gate
+  keeps accepted precisions partition-adequate.
+
+**Blockers**
+- None.


### PR DESCRIPTION
This PR re-keys the standalone fast tier's prime selection onto the monic transform, closing the coordinate mismatch #8519 left behind: `factorFastFactorsWithBound` now selects `ZPoly.toMonicPrimeData? normalized.squareFreeCore` at both dispatcher sites, so the Hensel seeds are the mod-p factorisation of `(ZPoly.toMonic core).monic` — the polynomial `toMonicLiftData` passes to `henselLiftData` — and the quadratic multifactor lift invariant holds on non-monic cores. Previously, whenever `leadingCoeff core ≢ 1 (mod p)`, the seeds did not multiply to the lift target and the tier was a decline-only heuristic; new `#guard` regression witnesses record that `factorFast` on `(2x+1)(x²+x+1)` (declined at the core-keyed `p = 5`) now recovers both factors.

The lemma surface follows the witness: the branch theorem becomes `factorFastFactorsWithBound_branch_of_toMonicPrimeData?_some`, the `hchoose` binders on `factorFastFactorsWithBound_eq_some_of_core_success`, `factorFast_ne_none_of_core_recovery_on_schedule`, and the small-mod singleton branch-shape lemmas become `hselected : ZPoly.toMonicPrimeData? … = some primeData`, and `factorWithBound?`'s selector disjunction collapses to the single shared selector. On the Mathlib side, the dilation-descent lemmas `zpolyIrreducible_of_toMonicMonic_irreducible` and `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch` move from `LatticeTier.lean` into `IntReductionMod.lean` (same namespace, qualified names unchanged) so the fast-tier singleton umbrellas can consume them; the two orphaned `choosePrimeData?`-keyed singleton helpers are removed with the dispatcher branch they described.

No fixture changes: the public `factor` is the hybrid pipeline, which never calls this tier. Fresh `hexbz_emit_fixtures` emission is byte-identical to the committed `bz.jsonl`, `bz_trace_gate.py` passes 50/50, and the `bz_flint.py` oracle passes 100/100. `HexBerlekampZassenhaus`, `HexBerlekampZassenhausMathlib`, and `HexConformance` all build green with no new warnings and no new `axiom`/`native_decide`/`sorry`.

Closes #8533.

🤖 Prepared with Claude Code
