### PR TITLE
perf: certificate-backed early termination for the CLD lattice tier

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -10180,17 +10180,155 @@ def bhksSingleAllOnesPartition (f : ZPoly) (d : LiftData) : Bool :=
   else
     false
 
+/-- Lattice-tier recombination loop: `factorFastCoreLoop` plus certificate-backed
+early termination (#8395).  The split path is byte-identical to the fast loop —
+below `floor` every step is skipped, and at/above `floor` a classified recovery
+success is accepted immediately.  The single change is the `.degenerate` arm: at
+`k ≥ floor` the loop re-examines the partition, and the single all-ones class is
+accepted as a **sound** irreducibility certificate (`some #[core]`) instead of
+advancing the schedule.  Soundness is not heuristic: at column-adequate precision
+(`fastCoreFloor core ≤ k`) the proven count lower bound forces a reducible core
+to exhibit ≥ 2 equivalence classes, so all-ones can only be reported for a
+genuinely irreducible core (`latticeArm3_bhksSingleAllOnes_irreducible` in the
+Mathlib layer consumes exactly the `⟨k, floor ≤ k, all-ones⟩` witness this loop
+produces).  Without the early stop the loop grinds the doubling schedule to the
+conservative BHKS cap on every irreducible input.
+
+Private: only `latticeCoreWithBound` (which passes `fastCoreFloorGate core`) is
+the semantically supported entry point; the bare `floor` parameter must not be
+set independently. -/
+private def latticeCoreLoop
+    (core : ZPoly) (B floor : Nat) (primeData : PrimeChoiceData) :
+    Nat → Nat → Option (Array ZPoly)
+  | _k, 0 => none
+  | k, fuel + 1 =>
+      if k < floor then
+        if k ≥ B then
+          none
+        else
+          latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+      else
+        match bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
+        | .success factors =>
+          some factors
+        | .candidateFailure =>
+          if k ≥ B then
+            none
+          else
+            latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+        | .productMismatch _ =>
+          if k ≥ B then
+            none
+          else
+            latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+        | .degenerate =>
+          if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k primeData) then
+            some #[core]
+          else if k ≥ B then
+            none
+          else
+            latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+
+/-- Lattice-tier core loop entry: `factorFastCoreWithBound` with certificate-backed
+early termination on the single all-ones partition (#8395).  Computes the CLD
+column-adequacy floor once (through the irreducible `fastCoreFloorGate`) and runs
+`latticeCoreLoop`. -/
+def latticeCoreWithBound
+    (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
+    Option (Array ZPoly) :=
+  latticeCoreLoop core B (fastCoreFloorGate core) primeData k fuel
+
+/-- Structural spec for the lattice-tier loop: every success is either a fast-loop
+success (the split path is untouched) or the certificate-backed early stop — the
+singleton `#[core]` together with a concrete witness precision `k'` at/above the
+column-adequacy floor whose partition is the single all-ones class. -/
+private theorem latticeCoreLoop_some_spec
+    (core : ZPoly) (B floor : Nat) (primeData : PrimeChoiceData) :
+    ∀ fuel k cf,
+      latticeCoreLoop core B floor primeData k fuel = some cf →
+        factorFastCoreLoop core B floor primeData k fuel = some cf ∨
+          (cf = #[core] ∧ ∃ k', floor ≤ k' ∧
+            bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k' primeData)
+              = true) := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro k cf h
+      simp [latticeCoreLoop] at h
+  | succ fuel ih =>
+      intro k cf h
+      rw [latticeCoreLoop] at h
+      rw [factorFastCoreLoop]
+      by_cases hfl : k < floor
+      · rw [if_pos hfl] at h ⊢
+        by_cases hk : k ≥ B
+        · simp [hk] at h
+        · rw [if_neg hk] at h ⊢
+          exact ih _ cf h
+      · rw [if_neg hfl] at h ⊢
+        cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
+        | success factors =>
+            rw [hclass] at h
+            exact Or.inl h
+        | candidateFailure =>
+            rw [hclass] at h
+            by_cases hk : k ≥ B
+            · simp [hk] at h
+            · rw [if_neg hk] at h ⊢
+              exact ih _ cf h
+        | productMismatch cands =>
+            rw [hclass] at h
+            by_cases hk : k ≥ B
+            · simp [hk] at h
+            · rw [if_neg hk] at h ⊢
+              exact ih _ cf h
+        | degenerate =>
+            rw [hclass] at h
+            by_cases hones :
+                bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k primeData) = true
+            · rw [if_pos hones] at h
+              exact Or.inr ⟨(Option.some.inj h).symm,
+                k, Nat.le_of_not_lt hfl, hones⟩
+            · rw [if_neg hones] at h
+              by_cases hk : k ≥ B
+              · simp [hk] at h
+              · rw [if_neg hk] at h ⊢
+                exact ih _ cf h
+
+/-- Public structural spec for `latticeCoreWithBound`: a success is either a
+`factorFastCoreWithBound` success or the early irreducibility certificate — the
+singleton `#[core]` with a witness precision `k'` clearing `fastCoreFloor core`
+whose partition is the single all-ones class.  The witness pair is exactly the
+`hB_floor`/`hbhks` input of the Mathlib layer's
+`latticeArm3_bhksSingleAllOnes_irreducible`. -/
+theorem latticeCoreWithBound_some_spec
+    {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData} {k fuel : Nat}
+    {cf : Array ZPoly}
+    (h : latticeCoreWithBound core B primeData k fuel = some cf) :
+    factorFastCoreWithBound core B primeData k fuel = some cf ∨
+      (cf = #[core] ∧ ∃ k', fastCoreFloor core ≤ k' ∧
+        bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k' primeData)
+          = true) := by
+  rw [latticeCoreWithBound, fastCoreFloorGate_eq] at h
+  rcases latticeCoreLoop_some_spec core B (fastCoreFloor core) primeData fuel k cf h with
+    hfast | hcert
+  · rw [factorFastCoreWithBound, fastCoreFloorGate_eq]
+    exact Or.inl hfast
+  · exact Or.inr hcert
+
 /-- Large-`r` lattice-tier core factorisation: the van Hoeij CLD recovery, plus
-**irreducibility certification at the cap**. When the recovery splits `core`, use
-its factors; when it declines (no split found), check the cap-precision partition:
-the single all-ones class means `core` is irreducible (`#[core]`), anything else
-is a genuine failure (`none`). -/
+**irreducibility certification**. When the recovery splits `core`, use its
+factors; when the loop's certificate-backed early stop fires (single all-ones
+partition at column-adequate precision, #8395), `core` is irreducible
+(`#[core]`); when the loop declines all the way to the cap, check the
+cap-precision partition once more: the single all-ones class means `core` is
+irreducible (`#[core]`), anything else is a genuine failure (`none`). -/
 def latticeCoreFactorsWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : Option (Array ZPoly) :=
   if primeData.factorsModP.size ≤ 1 then
     some #[core]
   else
-    match factorFastCoreWithBound core B primeData
+    match latticeCoreWithBound core B primeData
         (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
     | some coreFactors => some coreFactors
     | none =>
@@ -14858,8 +14996,9 @@ theorem classicalCoreFactorsWithBound_degree_pos
 
 /-- Structural case-split for the van Hoeij lattice-tier core. Every `some cf`
 result of `latticeCoreFactorsWithBound` is either the singleton `#[core]` (the
-small-mod and all-ones certification arms) or a `factorFastCoreWithBound`
-success (the CLD-split arm). The trio
+small-mod arm, the loop's certificate-backed early stop, and the cap all-ones
+certification arm) or a `factorFastCoreWithBound` success (the CLD-split arm,
+via `latticeCoreWithBound_some_spec`). The trio
 `latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`
 below are thin consumers, mirroring the classical structural trio. -/
 private theorem latticeCoreFactorsWithBound_spec
@@ -14873,8 +15012,10 @@ private theorem latticeCoreFactorsWithBound_spec
   split at h
   · exact Or.inl (Option.some.inj h).symm
   · split at h
-    · rename_i coreFactors hfast
-      exact Or.inr ((Option.some.inj h) ▸ hfast)
+    · rename_i coreFactors hlattice
+      rcases latticeCoreWithBound_some_spec hlattice with hfast | ⟨hsing, _⟩
+      · exact Or.inr ((Option.some.inj h) ▸ hfast)
+      · exact Or.inl ((Option.some.inj h) ▸ hsing)
     · split at h
       · exact Or.inl (Option.some.inj h).symm
       · exact absurd h.symm (Option.some_ne_none cf)

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -10163,12 +10163,16 @@ def factorFast (f : ZPoly) : Option Factorization :=
 
 /-- The CLD recovery's equivalence-class partition at this precision is the single
 all-ones class — the signature of an *irreducible* input (all lifted mod-`p`
-factors form the one integer factor). At cap precision this certifies
-irreducibility; below the cap it may instead mean the lattice has not separated
-the factors yet, so callers must only trust it at `k ≥ bhksBound`. (`factorFast`
+factors form the one integer factor). At column-adequate precision
+(`fastCoreFloor core ≤ k`) this certifies irreducibility — the proven count
+lower bound forces a reducible core to exhibit ≥ 2 classes there
+(`latticeArm3_bhksSingleAllOnes_irreducible` in the Mathlib layer) — while
+below the floor it may instead mean the lattice has not separated the factors
+yet, so callers must only trust it at `k ≥ fastCoreFloor core`. (`factorFast`
 itself treats this partition as `degenerate` and declines, which is why it
-"misses" on Swinnerton-Dyer inputs; the lattice tier uses this predicate to turn
-the declined-but-certified case into a positive irreducibility verdict.) -/
+"misses" on Swinnerton-Dyer inputs; the lattice tier uses this predicate, both
+in `latticeCoreLoop`'s early stop and in the trailing cap check, to turn the
+declined-but-certified case into a positive irreducibility verdict.) -/
 def bhksSingleAllOnesPartition (f : ZPoly) (d : LiftData) : Bool :=
   -- Monic (`M2`) coordinate, matching `bhksRecoverClassified` (#8519).
   let L := bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors
@@ -10322,7 +10326,14 @@ factors; when the loop's certificate-backed early stop fires (single all-ones
 partition at column-adequate precision, #8395), `core` is irreducible
 (`#[core]`); when the loop declines all the way to the cap, check the
 cap-precision partition once more: the single all-ones class means `core` is
-irreducible (`#[core]`), anything else is a genuine failure (`none`). -/
+irreducible (`#[core]`), anything else is a genuine failure (`none`).
+
+Both certification arms are gated on the column-adequacy floor: the loop's
+early stop only examines the partition at `k ≥ fastCoreFloorGate core`, and the
+trailing cap check requires `fastCoreFloorGate core ≤ B` — below the floor the
+all-ones partition may merely mean the lattice has not separated the factors
+yet, so certifying there would be unsound.  The public `factorLattice` supplies
+`factorFastPrecisionCap`, which clears the floor by construction. -/
 def latticeCoreFactorsWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : Option (Array ZPoly) :=
   if primeData.factorsModP.size ≤ 1 then
@@ -10332,8 +10343,11 @@ def latticeCoreFactorsWithBound
         (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
     | some coreFactors => some coreFactors
     | none =>
-        if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core B primeData) then
-          some #[core]
+        if fastCoreFloorGate core ≤ B then
+          if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core B primeData) then
+            some #[core]
+          else
+            none
         else
           none
 
@@ -15017,7 +15031,9 @@ private theorem latticeCoreFactorsWithBound_spec
       · exact Or.inr ((Option.some.inj h) ▸ hfast)
       · exact Or.inl ((Option.some.inj h) ▸ hsing)
     · split at h
-      · exact Or.inl (Option.some.inj h).symm
+      · split at h
+        · exact Or.inl (Option.some.inj h).symm
+        · exact absurd h.symm (Option.some_ne_none cf)
       · exact absurd h.symm (Option.some_ne_none cf)
 
 /-- PolyProduct identity for the van Hoeij lattice-tier core: every emitted

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -137,14 +137,19 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
           have hfl := Hex.defaultFactorCoeffBound_le_fastCoreFloor core
           omega
         exact fun g hg => hsingleton g hg (harm3_adequacy k' hk'_floor hk'_ne hk'_bhks)
-    · -- Arm 3: loop declined to the cap; all-ones certification at `B`.
+    · -- Arm 3: loop declined to the cap; all-ones certification at `B`, behind
+      -- the executable floor guard.
       rename_i hloop
       split at hlattice
-      · -- `bhksSingleAllOnesPartition = true`: output `#[core]`, core irreducible.
-        rename_i hbhks
-        obtain rfl := Option.some.inj hlattice
-        exact fun g hg => hsingleton g hg (harm3_adequacy B hB_floor hB_ne hbhks)
-      · -- `bhksSingleAllOnesPartition = false`: output `none`, contradiction.
+      · -- `fastCoreFloorGate core ≤ B`: the guarded all-ones check.
+        split at hlattice
+        · -- `bhksSingleAllOnesPartition = true`: output `#[core]`, core irreducible.
+          rename_i hbhks
+          obtain rfl := Option.some.inj hlattice
+          exact fun g hg => hsingleton g hg (harm3_adequacy B hB_floor hB_ne hbhks)
+        · -- `bhksSingleAllOnesPartition = false`: output `none`, contradiction.
+          exact absurd hlattice.symm (Option.some_ne_none cf)
+      · -- Guard rejected (`B` below the floor): output `none`, contradiction.
         exact absurd hlattice.symm (Option.some_ne_none cf)
 
 

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -23,17 +23,22 @@ Hensel seeds match the lift target; #8519) it has three arms:
    mod `p`, hence irreducible over `ℤ`.  **Proved unconditionally here** by
    reusing `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`.
 
-2. `factorFastCoreWithBound … = some coreFactors` → those factors.  The CLD
-   recovery split `core`.  Irreducibility of the emitted factors is the BHKS
-   count-equality obligation, already isolated by
-   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count`; it is
-   threaded here as the `harm2_count` hypothesis.
+2. `latticeCoreWithBound … = some coreFactors` → those factors.  Via
+   `latticeCoreWithBound_some_spec` this is either a genuine CLD split (a
+   `factorFastCoreWithBound` success; irreducibility of the emitted factors is
+   the BHKS count-equality obligation, already isolated by
+   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count` and threaded
+   here as the `harm2_count` hypothesis), or the certificate-backed early stop
+   (#8395): `some #[core]` with a witness precision `k'` at/above the
+   column-adequacy floor whose partition is the single all-ones class,
+   discharged by the adequacy hypothesis at `k'`.
 
-3. `factorFastCoreWithBound = none` ∧ `bhksSingleAllOnesPartition core d = true`
+3. `latticeCoreWithBound = none` ∧ `bhksSingleAllOnesPartition core d = true`
    → `some #[core]`.  The single all-ones equivalence class of the CLD lattice
    at cap precision certifies that `core` lands on exactly the minimal subsets
    (`L = W`), i.e. `core` is irreducible.  This is the deep van Hoeij adequacy
-   theorem; it is threaded here as the `harm3_adequacy` hypothesis.
+   theorem; it is threaded here as the `harm3_adequacy` hypothesis (quantified
+   over the certification precision, so it also covers arm 2's early stop).
 
 The reduction below discharges arm 1 and reduces the whole tier to the two BHKS
 obligations, mirroring the fast-path `_of_count` convention and the classical
@@ -53,25 +58,34 @@ van Hoeij CLD lattice tier `Hex.latticeCoreFactorsWithBound` returns for the
 square-free core of `normalizeForFactor f` is irreducible, given the two BHKS
 obligations as hypotheses.
 
-The three arms of `latticeCoreFactorsWithBound` are discharged as follows:
+The arms of `latticeCoreFactorsWithBound` are discharged as follows:
 
 * the small-mod singleton arm (`factorsModP.size ≤ 1`, output `#[core]`) is
   proved unconditionally from `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`;
-* the CLD-split arm (`factorFastCoreWithBound = some coreFactors`) is discharged
-  from the count-equality hypothesis `harm2_count` via
-  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count`;
-* the all-ones certification arm (`bhksSingleAllOnesPartition = true`, output
-  `#[core]`) is discharged from the adequacy hypothesis `harm3_adequacy`.
+* the loop-answer arm (`latticeCoreWithBound = some coreFactors`) splits via
+  `latticeCoreWithBound_some_spec` into the CLD-split case (a genuine
+  `factorFastCoreWithBound` success, discharged from the count-equality
+  hypothesis `harm2_count` via
+  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count`) and the
+  certificate-backed early stop (#8395: output `#[core]` with a witness
+  precision `k'` clearing the column-adequacy floor, discharged from the
+  adequacy hypothesis `harm3_adequacy` at `k'`);
+* the cap all-ones certification arm (`bhksSingleAllOnesPartition = true` at
+  `B`, output `#[core]`) is discharged from `harm3_adequacy` at `B`.
 
 `harm2_count` and `harm3_adequacy` are exactly the remaining deep BHKS content
 (the "lattice lands on minimal subsets" argument); every other side condition is
-discharged from `toMonicPrimeData?` and the square-free-core facts.
+discharged from `toMonicPrimeData?` and the square-free-core facts.  The
+adequacy hypothesis is quantified over the certification precision `B'` because
+the early stop certifies at the first adequate schedule point, not at the cap.
 -/
 theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bhks
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
+    (hB_floor : Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
+    (hB_ne : B ≠ 0)
     {cf : Array Hex.ZPoly}
     (hlattice : Hex.latticeCoreFactorsWithBound
       (Hex.normalizeForFactor f).squareFreeCore B primeData = some cf)
@@ -82,9 +96,10 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
       (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
         (UniqueFactorizationMonoid.normalizedFactors
           (HexPolyZMathlib.toPolynomial (Hex.normalizeForFactor f).squareFreeCore)).card)
-    (harm3_adequacy :
+    (harm3_adequacy : ∀ B' : Nat,
+      Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B' → B' ≠ 0 →
       Hex.bhksSingleAllOnesPartition (Hex.normalizeForFactor f).squareFreeCore
-          (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore B primeData)
+          (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore B' primeData)
           = true →
       Hex.ZPoly.Irreducible (Hex.normalizeForFactor f).squareFreeCore) :
     ∀ g ∈ cf.toList, Hex.ZPoly.Irreducible g := by
@@ -106,20 +121,29 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
     exact fun g hg => hsingleton g hg
       (squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch f hf_ne primeData
         (Nat.pos_of_ne_zero hdeg_ne) hselected hsmall)
-  · -- Arms 2/3: CLD recovery.
+  · -- Arms 2/3: CLD recovery loop (with the certificate-backed early stop).
     split at hlattice
-    · -- Arm 2: CLD split. Reduce to the count-equality obligation.
-      rename_i coreFactors hfast
+    · -- Arm 2: the loop answered. Either a genuine CLD split (count-equality
+      -- obligation) or the early irreducibility certificate at a witness
+      -- precision `k'` (adequacy obligation at `k'`).
+      rename_i coreFactors hloop
       obtain rfl := Option.some.inj hlattice
-      exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count
-        hcore_ne hfast (harm2_count coreFactors hfast)
-    · -- Arm 3: no split; all-ones certification.
-      rename_i hfast
+      rcases Hex.latticeCoreWithBound_some_spec hloop with
+        hfast | ⟨rfl, k', hk'_floor, hk'_bhks⟩
+      · exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count
+          hcore_ne hfast (harm2_count coreFactors hfast)
+      · have hk'_ne : k' ≠ 0 := by
+          have hpos := Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hcore_ne
+          have hfl := Hex.defaultFactorCoeffBound_le_fastCoreFloor core
+          omega
+        exact fun g hg => hsingleton g hg (harm3_adequacy k' hk'_floor hk'_ne hk'_bhks)
+    · -- Arm 3: loop declined to the cap; all-ones certification at `B`.
+      rename_i hloop
       split at hlattice
       · -- `bhksSingleAllOnesPartition = true`: output `#[core]`, core irreducible.
         rename_i hbhks
         obtain rfl := Option.some.inj hlattice
-        exact fun g hg => hsingleton g hg (harm3_adequacy hbhks)
+        exact fun g hg => hsingleton g hg (harm3_adequacy B hB_floor hB_ne hbhks)
       · -- `bhksSingleAllOnesPartition = false`: output `none`, contradiction.
         exact absurd hlattice.symm (Option.some_ne_none cf)
 
@@ -840,9 +864,11 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
       (Hex.normalizeForFactor f).squareFreeCore B primeData = some cf) :
     ∀ g ∈ cf.toList, Hex.ZPoly.Irreducible g :=
   latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bhks
-    f hf_ne B primeData hselected hdeg_ne hlattice
+    f hf_ne B primeData hselected hdeg_ne hB_floor hB_ne hlattice
     (latticeArm2_fastCore_count f hf_ne B primeData hselected hdeg_ne)
-    (latticeArm3_bhksSingleAllOnes_irreducible f hf_ne B primeData hselected hdeg_ne hB_floor hB_ne)
+    (fun B' hB'_floor hB'_ne hbhks =>
+      latticeArm3_bhksSingleAllOnes_irreducible f hf_ne B' primeData hselected hdeg_ne
+        hB'_floor hB'_ne hbhks)
 /-!
 ## Filling the capstone's lattice branch (#8417)
 

--- a/bench/HexBench/LatticeSpike.lean
+++ b/bench/HexBench/LatticeSpike.lean
@@ -29,6 +29,63 @@ def latticeSink (r : Option Factorization) : UInt64 :=
         7
   | none => 0xffffffffffffffff
 
+/-- Faithful reconstruction of the **pre-#8395** lattice-tier core: grind
+`factorFastCoreWithBound` to the cap `B`, then a single trailing all-ones
+check at cap precision.  Used by the `before` mode to measure the
+before/after ratio on the same build; the surrounding normalization and
+reassembly (µs, identical on both paths) are excluded on both sides. -/
+def beforeLatticeCore (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
+    Option (Array ZPoly) :=
+  if primeData.factorsModP.size ≤ 1 then
+    some #[core]
+  else
+    match factorFastCoreWithBound core B primeData
+        (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
+    | some coreFactors => some coreFactors
+    | none =>
+        if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core B primeData) then
+          some #[core]
+        else
+          none
+
+/-- Post-#8395 lattice-tier core at the same call shape as `beforeLatticeCore`
+(the early-stop loop plus the floor-guarded trailing check). -/
+def afterLatticeCore (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
+    Option (Array ZPoly) :=
+  latticeCoreFactorsWithBound core B primeData
+
+/-- Coefficient checksum over a raw core factor array; forces the result. -/
+def coreSink (r : Option (Array ZPoly)) : UInt64 :=
+  match r with
+  | some cf =>
+      cf.foldl
+        (fun acc g =>
+          g.toArray.foldl (fun a c => a * 1000003 + UInt64.ofNat c.natAbs) acc)
+        7
+  | none => 0xffffffffffffffff
+
+/-- Time one lattice-tier core call (before or after path) on the square-free
+core of the polynomial held in `ref`; normalization and prime selection happen
+outside the timed region. -/
+def timeLatticeCore (label : String) (ref : IO.Ref ZPoly)
+    (act : ZPoly → Nat → PrimeChoiceData → Option (Array ZPoly)) : IO Unit := do
+  let out ← IO.getStdout
+  let f ← ref.get
+  let core := (normalizeForFactor f).squareFreeCore
+  let cap := factorFastPrecisionCap f
+  match ZPoly.toMonicPrimeData? core with
+  | none => IO.println s!"{label}: no admissible prime"
+  | some primeData =>
+      let t0 ← IO.monoNanosNow
+      let (r, sink) ← IO.lazyPure (fun _ =>
+        let r := act core cap primeData
+        (r, coreSink r))
+      let t1 ← IO.monoNanosNow
+      let factors := (r.map (·.size)).getD 0
+      IO.println
+        s!"{label}: {(t1 - t0).toFloat / 1.0e6} ms (coreFactors={factors}, sink={sink})"
+      out.flush
+
 /-- Time one `factorLattice` call on the polynomial held in `ref`.  The call and
 its checksum run inside `IO.lazyPure` so the compiler cannot float the pure
 computation past the monotonic-clock reads. -/
@@ -44,7 +101,7 @@ def timeLattice (label : String) (ref : IO.Ref ZPoly) : IO Unit := do
   IO.println s!"{label}: {(t1 - t0).toFloat / 1.0e6} ms (factors={factors}, sink={sink})"
   out.flush
 
-def main : IO Unit := do
+def main (args : List String) : IO Unit := do
   IO.println "=== factorLattice wall-clock (#8395 early-termination spike) ==="
   let sd2 ← IO.mkRef (DensePoly.ofCoeffs #[1, 0, -10, 0, 1] : ZPoly)
   let phi15 ← IO.mkRef (DensePoly.ofCoeffs #[1, -1, 0, 1, -1, 1, 0, -1, 1] : ZPoly)
@@ -58,10 +115,44 @@ def main : IO Unit := do
       15459151516270592, 0, -2349014746136576, 0, 239210760462336, 0,
       -16665641517056, 0, 801918722048, 0, -26625650688, 0, 602397952, 0,
       -9028096, 0, 84864, 0, -448, 0, 1] : ZPoly)
+  let sd6 ← IO.mkRef (DensePoly.ofCoeffs
+    #[198828783273803025550632280753863681, 0, -8316202966928528723117528333532208416, 0,
+      100392008259975194458539996111340080624, 0, -511762449216265420619809586571618679392, 0,
+      1258829468814790188483900997578812102776, 0, -1771080720430629161685158978892152599456,
+      0, 1585722240968892813653220405983168716752, 0, -968316307427310602872375357706532108000,
+      0, 423140580409718469187953106123559340828, 0, -137048942135190916858196960829292680864,
+      0, 33785494292069713784801456649105169648, 0, -6471399892949448329687739464771529952, 0,
+      978878175154164215599705915851796296, 0, -118444912349891951852181962142375200, 0,
+      11582497564629879101390954172990800, 0, -922739669127277027441017551584608, 0,
+      60261059130667890854325275719238, 0, -3240853899326109989616514647392, 0,
+      143976257181996292530653998416, 0, -5292590468585153795497272608, 0,
+      161038437520893531719546696, 0, -4051269676739248306877664, 0, 84041236543621002233072,
+      0, -1431186296399427673760, 0, 19875965471079809820, 0, -223010452468129504, 0,
+      1995413247403984, 0, -13981172308896, 0, 74737287288, 0, -293134944, 0, 792048, 0, -1312,
+      0, 1] : ZPoly)
   let quad ← IO.mkRef (DensePoly.ofCoeffs #[6, 0, -5, 0, 1] : ZPoly)
-  timeLattice "reducible (x^2-2)(x^2-3) deg 4" quad
-  timeLattice "SD2   deg  4" sd2
-  timeLattice "Phi15 deg  8" phi15
-  timeLattice "SD3   deg  8" sd3
-  timeLattice "SD4   deg 16" sd4
-  timeLattice "SD5   deg 32" sd5
+  match args with
+  | ["before"] =>
+      -- Pre-#8395 core path (grind to cap).  SD5 is omitted: its cap-bound
+      -- schedule is out of reach (SD4 already exceeds two minutes).
+      timeLatticeCore "before reducible deg 4" quad beforeLatticeCore
+      timeLatticeCore "before SD2   deg  4" sd2 beforeLatticeCore
+      timeLatticeCore "before Phi15 deg  8" phi15 beforeLatticeCore
+      timeLatticeCore "before SD3   deg  8" sd3 beforeLatticeCore
+      timeLatticeCore "before SD4   deg 16" sd4 beforeLatticeCore
+  | ["core"] =>
+      -- Post-#8395 core path, same call shape as `before` for direct ratios.
+      timeLatticeCore "after  reducible deg 4" quad afterLatticeCore
+      timeLatticeCore "after  SD2   deg  4" sd2 afterLatticeCore
+      timeLatticeCore "after  Phi15 deg  8" phi15 afterLatticeCore
+      timeLatticeCore "after  SD3   deg  8" sd3 afterLatticeCore
+      timeLatticeCore "after  SD4   deg 16" sd4 afterLatticeCore
+      timeLatticeCore "after  SD5   deg 32" sd5 afterLatticeCore
+      timeLatticeCore "after  SD6   deg 64" sd6 afterLatticeCore
+  | _ =>
+      timeLattice "reducible (x^2-2)(x^2-3) deg 4" quad
+      timeLattice "SD2   deg  4" sd2
+      timeLattice "Phi15 deg  8" phi15
+      timeLattice "SD3   deg  8" sd3
+      timeLattice "SD4   deg 16" sd4
+      timeLattice "SD5   deg 32" sd5

--- a/bench/HexBench/LatticeSpike.lean
+++ b/bench/HexBench/LatticeSpike.lean
@@ -149,6 +149,24 @@ def main (args : List String) : IO Unit := do
       timeLatticeCore "after  SD4   deg 16" sd4 afterLatticeCore
       timeLatticeCore "after  SD5   deg 32" sd5 afterLatticeCore
       timeLatticeCore "after  SD6   deg 64" sd6 afterLatticeCore
+  | ["hybrid"] =>
+      -- Which tier answers each input under the public dispatcher, and how
+      -- long the full hybrid takes end to end.
+      let timeHybrid (label : String) (ref : IO.Ref ZPoly) : IO Unit := do
+        let f ← ref.get
+        let t0 ← IO.monoNanosNow
+        let (φ, trace) ← IO.lazyPure (fun _ => factorHybridTraced f)
+        let t1 ← IO.monoNanosNow
+        IO.println s!"{label}: {(t1 - t0).toFloat / 1.0e6} ms \
+          (tier={trace.tier}, declined={trace.declined}, factors={φ.factors.size})"
+        (← IO.getStdout).flush
+      timeHybrid "hybrid reducible deg 4" quad
+      timeHybrid "hybrid SD2   deg  4" sd2
+      timeHybrid "hybrid Phi15 deg  8" phi15
+      timeHybrid "hybrid SD3   deg  8" sd3
+      timeHybrid "hybrid SD4   deg 16" sd4
+      timeHybrid "hybrid SD5   deg 32" sd5
+      timeHybrid "hybrid SD6   deg 64" sd6
   | _ =>
       timeLattice "reducible (x^2-2)(x^2-3) deg 4" quad
       timeLattice "SD2   deg  4" sd2

--- a/bench/HexBench/LatticeSpike.lean
+++ b/bench/HexBench/LatticeSpike.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekampZassenhaus.Basic
+
+/-!
+Measurement artifact for the lattice tier's certificate-backed early
+termination (#8395): single-shot wall-clock for `factorLattice` on the
+Swinnerton-Dyer / cyclotomic irreducible family, where the pre-#8395 loop
+ground the doubling schedule to the conservative BHKS precision cap
+(SD2 14ms, Phi_15 216ms, SD3 1.8s, SD4 >120s).  Inputs are routed through an
+`IO.Ref` so the compiler cannot fold the factorization; the coefficient
+checksum sink forces the full result.  Proves nothing.
+-/
+
+open Hex
+
+/-- Coefficient checksum over all emitted factors; forces the result. -/
+def latticeSink (r : Option Factorization) : UInt64 :=
+  match r with
+  | some φ =>
+      φ.factors.foldl
+        (fun acc fp =>
+          fp.1.toArray.foldl
+            (fun a c => a * 1000003 + UInt64.ofNat c.natAbs) (acc + UInt64.ofNat fp.2))
+        7
+  | none => 0xffffffffffffffff
+
+/-- Time one `factorLattice` call on the polynomial held in `ref`.  The call and
+its checksum run inside `IO.lazyPure` so the compiler cannot float the pure
+computation past the monotonic-clock reads. -/
+def timeLattice (label : String) (ref : IO.Ref ZPoly) : IO Unit := do
+  let out ← IO.getStdout
+  let f ← ref.get
+  let t0 ← IO.monoNanosNow
+  let (r, sink) ← IO.lazyPure (fun _ =>
+    let r := factorLattice f
+    (r, latticeSink r))
+  let t1 ← IO.monoNanosNow
+  let factors := (r.map (·.factors.size)).getD 0
+  IO.println s!"{label}: {(t1 - t0).toFloat / 1.0e6} ms (factors={factors}, sink={sink})"
+  out.flush
+
+def main : IO Unit := do
+  IO.println "=== factorLattice wall-clock (#8395 early-termination spike) ==="
+  let sd2 ← IO.mkRef (DensePoly.ofCoeffs #[1, 0, -10, 0, 1] : ZPoly)
+  let phi15 ← IO.mkRef (DensePoly.ofCoeffs #[1, -1, 0, 1, -1, 1, 0, -1, 1] : ZPoly)
+  let sd3 ← IO.mkRef (DensePoly.ofCoeffs #[576, 0, -960, 0, 352, 0, -40, 0, 1] : ZPoly)
+  let sd4 ← IO.mkRef (DensePoly.ofCoeffs
+    #[46225, 0, -5596840, 0, 13950764, 0, -7453176, 0, 1513334, 0, -141912, 0,
+      6476, 0, -136, 0, 1] : ZPoly)
+  let sd5 ← IO.mkRef (DensePoly.ofCoeffs
+    #[2000989041197056, 0, -44660812492570624, 0, 183876928237731840, 0,
+      -255690851718529024, 0, 172580952324702208, 0, -65892492886671360, 0,
+      15459151516270592, 0, -2349014746136576, 0, 239210760462336, 0,
+      -16665641517056, 0, 801918722048, 0, -26625650688, 0, 602397952, 0,
+      -9028096, 0, 84864, 0, -448, 0, 1] : ZPoly)
+  let quad ← IO.mkRef (DensePoly.ofCoeffs #[6, 0, -5, 0, 1] : ZPoly)
+  timeLattice "reducible (x^2-2)(x^2-3) deg 4" quad
+  timeLattice "SD2   deg  4" sd2
+  timeLattice "Phi15 deg  8" phi15
+  timeLattice "SD3   deg  8" sd3
+  timeLattice "SD4   deg 16" sd4
+  timeLattice "SD5   deg 32" sd5

--- a/bench/HexBerlekampZassenhaus/Bench.lean
+++ b/bench/HexBerlekampZassenhaus/Bench.lean
@@ -80,6 +80,11 @@ HO-2 adversarial singletons (each pinned at `paramSchedule := #[0]`):
   for SD3 at the conformance prime, keeping the worst-case recombination
   shape visible without running the full integer factorization (which exceeds
   the `verify` budget).
+* `runFactorLatticeAdvSwinnertonDyerSD3Checksum`,
+  `runFactorLatticeAdvSwinnertonDyerSD4Checksum`: full `factorLattice` on SD3
+  and SD4 — the lattice tier's certificate-backed early stop (#8395) makes the
+  complete lattice factorization of these extreme-`r` irreducibles affordable
+  in `verify` (SD3 ~5ms, SD4 ~55ms vs >120s at the pre-#8395 cap grind).
 
 Gating external comparator:
 
@@ -180,6 +185,14 @@ def advQuadSqrt2Sqrt3 : ZPoly :=
 /-- HO-2 Swinnerton-Dyer `SD_3` input. -/
 def advSwinnertonDyerSD3 : ZPoly :=
   DensePoly.ofCoeffs #[576, 0, -960, 0, 352, 0, -40, 0, 1]
+
+/-- Swinnerton-Dyer `SD_4` input (minimal polynomial of `√2+√3+√5+√7`),
+degree 16: irreducible over `ℤ`, splits into 16 linear factors mod every
+prime. -/
+def advSwinnertonDyerSD4 : ZPoly :=
+  DensePoly.ofCoeffs
+    #[46225, 0, -5596840, 0, 13950764, 0, -7453176, 0, 1513334, 0, -141912, 0,
+      6476, 0, -136, 0, 1]
 
 /-- HO-2 cyclotomic `Phi_15` input. -/
 def advPhi15 : ZPoly :=
@@ -465,6 +478,30 @@ eight local linear factors.
 def runAdvSwinnertonDyerSD3ModularSplitChecksum (f : ZPoly) : UInt64 :=
   checksumOptionNatArray (modularFactorDegreesAt? f 71)
 
+/--
+Singleton benchmark target: CLD lattice tier (`factorLattice`) on
+Swinnerton-Dyer `SD_3`.  The certificate-backed early stop (#8395) certifies
+irreducibility at the first column-adequate precision instead of grinding the
+doubling schedule to the BHKS cap, which is what makes the full lattice-tier
+factorization affordable inside the `verify` budget (pre-#8395: ~1.8s; with
+the early stop: ~5ms).
+-/
+@[noinline]
+def runFactorLatticeAdvSwinnertonDyerSD3Checksum (f : ZPoly) : UInt64 :=
+  checksumOptionFactorization (factorLattice f)
+
+/--
+Singleton benchmark target: CLD lattice tier (`factorLattice`) on
+Swinnerton-Dyer `SD_4` (degree 16, 16-way modular split).  Pre-#8395 this
+input exceeded 120s (the doubling schedule ground to the conservative BHKS
+precision cap); the early-stop separation certificate terminates at the
+column-adequacy floor (~55ms), keeping the extreme-`r` tail visible in
+`verify`.
+-/
+@[noinline]
+def runFactorLatticeAdvSwinnertonDyerSD4Checksum (f : ZPoly) : UInt64 :=
+  checksumOptionFactorization (factorLattice f)
+
 /-- Constant prep returning the `X^4 + 1` adversarial fixture for the pinned singleton schedule. -/
 def prepAdvX4Plus1 (_ : Nat) : ZPoly :=
   advX4Plus1
@@ -476,6 +513,10 @@ def prepAdvQuadSqrt2Sqrt3 (_ : Nat) : ZPoly :=
 /-- Constant prep returning the Swinnerton-Dyer `SD_3` adversarial fixture. -/
 def prepAdvSwinnertonDyerSD3 (_ : Nat) : ZPoly :=
   advSwinnertonDyerSD3
+
+/-- Constant prep returning the Swinnerton-Dyer `SD_4` adversarial fixture. -/
+def prepAdvSwinnertonDyerSD4 (_ : Nat) : ZPoly :=
+  advSwinnertonDyerSD4
 
 /-- Constant prep returning the cyclotomic `Phi_15` adversarial fixture. -/
 def prepAdvPhi15 (_ : Nat) : ZPoly :=
@@ -1181,6 +1222,34 @@ setup_benchmark runAdvSwinnertonDyerSD3ModularSplitChecksum n => n + 1
     paramCeiling := 0
     paramSchedule := .custom #[0]
     maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton lattice-tier target: full `factorLattice` on Swinnerton-Dyer
+`SD_3`, certifying irreducibility via the early-stop separation certificate
+(#8395).  The constant `n + 1` model is the pinned singleton bound. -/
+setup_benchmark runFactorLatticeAdvSwinnertonDyerSD3Checksum n => n + 1
+  with prep := prepAdvSwinnertonDyerSD3
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 4.0
+    targetInnerNanos := 100000000
+    signalFloorMultiplier := 1.0
+  }
+
+/- Singleton lattice-tier target: full `factorLattice` on Swinnerton-Dyer
+`SD_4` (degree 16), the extreme-`r` tail case that exceeded 120s before the
+#8395 early stop.  The constant `n + 1` model is the pinned singleton bound. -/
+setup_benchmark runFactorLatticeAdvSwinnertonDyerSD4Checksum n => n + 1
+  with prep := prepAdvSwinnertonDyerSD4
+  where {
+    paramFloor := 0
+    paramCeiling := 0
+    paramSchedule := .custom #[0]
+    maxSecondsPerCall := 6.0
     targetInnerNanos := 100000000
     signalFloorMultiplier := 1.0
   }

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -243,6 +243,10 @@ lean_exe hex_classical_spike where
   srcDir := "bench"
   root := `HexBench.ClassicalSpike
 
+lean_exe hex_lattice_spike where
+  srcDir := "bench"
+  root := `HexBench.LatticeSpike
+
 lean_exe hexarith_bench where
   srcDir := "bench"
   root := `HexArith.Bench

--- a/progress/20260702T133437Z_issue-8395.md
+++ b/progress/20260702T133437Z_issue-8395.md
@@ -1,0 +1,51 @@
+# issue #8395 — certificate-backed early termination for the CLD lattice tier
+
+**Accomplished**
+- Feasibility spike answer: **YES**, and the certificate already existed in
+  proven form. The issue's referenced substrate (`lattice_eq_indicators`,
+  `BadVector`, `TerminationBound`) was rebuilt by #8517/#8384 as
+  `latticeArm3_bhksSingleAllOnes_irreducible`
+  (`HexBerlekampZassenhausMathlib/LatticeTier.lean`), which certifies
+  irreducibility from the single all-ones partition at **any** precision
+  clearing `fastCoreFloor core` — a computable Mignotte/CLD-floor inequality
+  the loop already gates on — not just at the conservative
+  `factorFastPrecisionCap` (which contains the astronomically larger
+  `bhksBound`).
+- Implemented the sound early stop (commit c2c74c08): new private
+  `latticeCoreLoop` + public `latticeCoreWithBound`
+  (`HexBerlekampZassenhaus/Basic.lean`), byte-identical to
+  `factorFastCoreLoop` on the split path, but in the `.degenerate` arm at
+  `k ≥ floor` it checks `bhksSingleAllOnesPartition` and returns
+  `some #[core]` on the first hit. `latticeCoreWithBound_some_spec` exposes
+  the `⟨k', floor ≤ k', all-ones⟩` witness. `latticeCoreFactorsWithBound`
+  swaps in the new loop; its structural spec disjunction is unchanged. The
+  fast tier (`factorFast`) is untouched.
+- Re-keyed the Mathlib layer (commit cdf29f52): `_of_bhks` gains
+  `hB_floor`/`hB_ne` and quantifies the adequacy hypothesis over the
+  certification precision; the assembly's signature is unchanged (arm-3 lemma
+  already held at every adequate precision). Zero sorries before and after;
+  no new warnings.
+- Measured (hex_lattice_spike, commit aef27252): SD2 14ms→0.42ms, Φ₁₅
+  216ms→1.6ms, SD3 1.8s→4.8ms, SD4 >120s→55ms, SD5 (deg 32, previously
+  unreachable) 514ms; reducible split path unregressed (0.25ms). Added
+  `runFactorLatticeAdvSwinnertonDyerSD{3,4}Checksum` bench targets (all 20
+  verify targets pass).
+- Conformance: fresh `hexbz_emit_fixtures` byte-identical to committed
+  `bz.jsonl`; `bz_trace_gate.py` 51/51; `bz_flint.py` 101/101.
+- Scope addition (classical-tier incremental-precision lift + product-tree
+  lift) re-homed to #8540 — it is a separate feature needing the per-remainder
+  Mignotte certificate, not the lattice certificate this issue shipped.
+
+**Current frontier**
+- The lattice tier terminates at the column-adequacy floor on irreducibles;
+  the extreme-`r` tail (SD5+) is now reachable, unblocking #8381's
+  strictly-beat-Isabelle comparator goal.
+
+**Next step**
+- #8540 (classical-tier lever). Optional micro-optimization: let-bind the
+  `toMonicLiftData` in `latticeCoreLoop`'s degenerate arm (the certification
+  step currently recomputes the lift + lattice pipeline once; ~2× on that one
+  step).
+
+**Blockers**
+- None.

--- a/progress/20260702T133437Z_issue-8395.md
+++ b/progress/20260702T133437Z_issue-8395.md
@@ -36,6 +36,15 @@
   lift) re-homed to #8540 — it is a separate feature needing the per-remainder
   Mignotte certificate, not the lattice certificate this issue shipped.
 
+- Second opinion (Codex): no high-severity soundness flaw; early-arm gating
+  confirmed airtight. Addressed its medium finding by gating the trailing
+  cap all-ones check on `fastCoreFloorGate core ≤ B` (pre-existing unsound
+  zone for direct bounded callers below the floor) and stating the floor
+  precondition in the wrapper and `bhksSingleAllOnesPartition` docstrings.
+  Declined (as documented follow-up): deduplicating the degenerate arm's
+  lift/lattice recomputation, which needs the classifier to expose its
+  partition data.
+
 **Current frontier**
 - The lattice tier terminates at the column-adequacy floor on irreducibles;
   the extreme-`r` tail (SD5+) is now reachable, unblocking #8381's

--- a/progress/20260702T133645Z_review-8395.md
+++ b/progress/20260702T133645Z_review-8395.md
@@ -1,0 +1,20 @@
+# issue #8395 review pass
+
+**Accomplished**
+- Reviewed the certificate-backed early termination diff around
+  `latticeCoreLoop`, `latticeCoreWithBound_some_spec`,
+  `latticeCoreFactorsWithBound_spec`, and the Mathlib lattice-tier assembly.
+- Checked the original fast loop and the public `factorLattice` call path to
+  compare precision gating and bounded-call behavior.
+
+**Current frontier**
+- The early-return soundness argument appears aligned with the Mathlib arm-3
+  theorem: the executable witness is gated by `fastCoreFloor`, and the proof
+  layer consumes the richer witness before collapsing singleton outputs.
+
+**Next step**
+- Consider tightening direct bounded-API documentation/guards and avoiding the
+  duplicated degenerate-arm lift/lattice work.
+
+**Blockers**
+- None.


### PR DESCRIPTION
This PR makes the van Hoeij CLD lattice tier terminate at the first column-adequate precision on irreducible inputs instead of grinding the Hensel doubling schedule to the conservative BHKS precision cap. The new `latticeCoreLoop` is byte-identical to `factorFastCoreLoop` on the split path, but when the classified recovery reports the degenerate partition at `k ≥ fastCoreFloor core` it re-examines the partition and accepts the single all-ones class as a sound irreducibility certificate (`some #[core]`). The certificate is proof-backed, not heuristic: `latticeArm3_bhksSingleAllOnes_irreducible` (landed by https://github.com/kim-em/hex-dev/pull/8517 for https://github.com/kim-em/hex-dev/issues/8417) already certifies irreducibility at any precision clearing the floor, because the proven count lower bound forces a reducible core to exhibit at least two equivalence classes there. `latticeCoreWithBound_some_spec` exposes the `⟨k', floor ≤ k', all-ones⟩` witness, and the Mathlib-layer reduction quantifies its adequacy hypothesis over the certification precision, so the assembled irreducibility, product, sign, degree, and reassembly-completeness theorems all go through unchanged in statement. The fast tier (`factorFast`) is untouched, and the trailing cap check is now also gated on `fastCoreFloorGate core ≤ B`, closing a pre-existing unsound zone for direct bounded callers below the floor (flagged by the Codex second-opinion review; the public `factorLattice` cap always clears the floor).

Measured wall-clock (`hex_lattice_spike`, new measurement artifact): SD2 14ms → 0.4ms, Φ₁₅ 216ms → 1.6ms, SD3 1.8s → 4.7ms, SD4 >120s → 54ms, and SD5 (degree 32, previously unreachable) now completes in 0.5s; the reducible split path is unregressed. New `runFactorLatticeAdvSwinnertonDyerSD{3,4}Checksum` bench singletons keep the full lattice-tier factorization visible in `verify` (all 20 targets pass). Conformance is unchanged: fresh `hexbz_emit_fixtures` output is byte-identical to the committed `bz.jsonl`, `bz_flint.py` passes 101/101, `bz_trace_gate.py` 51/51. Zero sorries before and after; no new warnings.

The classical-tier scope addition (incremental-precision Hensel lift with Mignotte backstop, balanced product-tree lift) is re-homed to https://github.com/kim-em/hex-dev/issues/8540 ("perf(bz): incremental-precision Hensel lift for the classical tier (Mignotte backstop + product-tree lift)"): it needs a per-remainder Mignotte certificate, not the lattice certificate shipped here. A follow-up micro-optimization is also noted there and in the progress file: the degenerate arm currently recomputes the lift/lattice pipeline once at the certification step; deduplicating it needs the classifier to expose its partition data.

Closes https://github.com/kim-em/hex-dev/issues/8395.

🤖 Prepared with Claude Code
