### PR TITLE
doc: review and revise the six planned-library SPECs in SPEC/Libraries

### DIFF
--- a/SPEC/Libraries/README.md
+++ b/SPEC/Libraries/README.md
@@ -1,103 +1,104 @@
 # Libraries
 
-- **hex-arith** — extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
-- **hex-poly** — dense `Array`-backed polynomial representation
-- **hex-matrix** — dense matrices, matrix/vector arithmetic, elementary row and column operations, submatrix slicing, the Gram matrix
-- **hex-row-reduce** — row reduction (RREF), rank, span, nullspace
-- **hex-determinant** — the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
-- **hex-bareiss** — the fraction-free Bareiss determinant algorithm
-- **hex-gram-schmidt** — Gram-Schmidt orthogonalization, GS coefficients, Gram determinants, update formulas under row operations
-- **hex-mod-arith** — `ZMod64 p`: `UInt64`-backed arithmetic in `Z/pZ`
-- **hex-poly-fp** — polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
-- **hex-gf2** — packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
-- **hex-poly-z** — polynomials over `Z`, content/primitive part, Mignotte bound
-- **hex-roots** — certified complex root isolation for `Z[x]` via dyadic squares + Pellet test + speculative Newton
-- **hex-resultant** — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
-- **hex-number-field** — `NumberField p x` (`ℚ(α)` element indexed by a complex root) and canonical `AlgebraicNumber` (any `α ∈ ℂ_alg`)
-- **hex-berlekamp** — Berlekamp factoring and Rabin irreducibility test over `F_p`
-- **hex-hensel** — Hensel lifting from `mod p` to `mod p^k`
-- **hex-lll** — LLL lattice basis reduction
-- **hex-berlekamp-zassenhaus** — complete factoring of `Z[x]`, initially with exhaustive recombination
-- **hex-conway** — Conway polynomial database
-- **hex-gfq-ring** — canonical quotient ring `F_p[x]/(f)` by a nonconstant modulus
-- **hex-gfq-field** — field structure on top of `hex-gfq-ring` when `f` is irreducible
-- **hex-gfq** — convenience wrapper: canonical `GFq p n` plus optimized `GF2q n` using Conway polynomials
+- **hex-arith**: extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
+- **hex-poly**: dense `Array`-backed polynomial representation
+- **hex-matrix**: dense matrices, matrix/vector arithmetic, elementary row and column operations, submatrix slicing, the Gram matrix
+- **hex-row-reduce**: row reduction (RREF), rank, span, nullspace
+- **hex-determinant**: the Leibniz determinant and its cofactor/Cauchy-Binet/Plücker theory
+- **hex-bareiss**: the fraction-free Bareiss determinant algorithm
+- **hex-gram-schmidt**: Gram-Schmidt orthogonalization, GS coefficients, Gram determinants, update formulas under row operations
+- **hex-mod-arith**: `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
+- **hex-poly-fp**: polynomials over `F_p`, Frobenius map, square-free decomposition, lazy reduction for small p
+- **hex-gf2**: packed bitwise polynomials over `F_2` (XOR + CLMUL), `GF(2^n)` elements
+- **hex-poly-z**: polynomials over `Z`, content/primitive part, Mignotte bound
+- **hex-roots**: certified complex root isolation for `Z[x]` via dyadic squares, Pellet tests, and speculative Newton iteration
+- **hex-resultant**: polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
+- **hex-number-field**: `QAdjoin p x` (an element of `ℚ(α)`, indexed by a complex root of `p`) and the canonical `AlgebraicNumber` (an arbitrary algebraic number in `ℂ`)
+- **hex-berlekamp**: Berlekamp factoring and Rabin irreducibility test over `F_p`
+- **hex-hensel**: Hensel lifting from `mod p` to `mod p^k`
+- **hex-lll**: LLL lattice basis reduction
+- **hex-berlekamp-zassenhaus**: complete factoring of `Z[x]`, initially with exhaustive recombination
+- **hex-conway**: Conway polynomial database
+- **hex-gfq-ring**: canonical quotient ring `F_p[x]/(f)` by a nonconstant modulus
+- **hex-gfq-field**: field structure on top of `hex-gfq-ring` when `f` is irreducible
+- **hex-gfq**: convenience wrapper, canonical `GFq p n` plus optimized `GF2q n` using Conway polynomials
 
-**Mathlib bridge libraries** (each depends on a computational lib + Mathlib,
-proving correspondence with Mathlib's mathematical definitions):
+**Mathlib companion libraries** (each depends on a computational
+library and Mathlib, and proves that the executable definitions agree
+with Mathlib's):
 
-- **hex-mod-arith-mathlib** — `ZMod64 p ≃+* ZMod p`
-- **hex-poly-mathlib** — `DensePoly R ≃+* Polynomial R`
-- **hex-matrix-mathlib** — matrix equivalence, row ops = transvections, and the Mathlib algebra tower transported onto our matrix type
-- **hex-row-reduce-mathlib** — rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
-- **hex-determinant-mathlib** — `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
-- **hex-bareiss-mathlib** — Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
-- **hex-gram-schmidt-mathlib** — `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
-- **hex-poly-z-mathlib** — `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
-- **hex-roots-mathlib** — Pellet on circles (built from `circleIntegral`) + Mahler/Mignotte separation bound; correctness of refinement and `isolate`
-- **hex-resultant-mathlib** — "subresultant zero ↔ common root" property (scope-limited; full bridge to `Polynomial.resultant` deferred)
-- **hex-number-field-mathlib** — `NumberField p x ≃+* AdjoinRoot p`, bijection of `AlgebraicNumber` with `ℂ_alg`, arithmetic correctness
-- **hex-berlekamp-mathlib** — `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
-- **hex-hensel-mathlib** — Hensel correctness, uniqueness, `coprime_mod_p_lifts`
-- **hex-lll-mathlib** — lattice = `Submodule ℤ`, short vector bound
-- **hex-gf2-mathlib** — `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
-- **hex-gfq-mathlib** — finiteness/cardinality for quotient fields, and `GFq p n ≃+* GaloisField p n`
-- **hex-berlekamp-zassenhaus-mathlib** — unconditional factoring correctness, `Decidable (Irreducible f)` for `Polynomial ℤ`
+- **hex-mod-arith-mathlib**: `ZMod64 p ≃+* ZMod p`
+- **hex-poly-mathlib**: `DensePoly R ≃+* Polynomial R`
+- **hex-matrix-mathlib**: matrix equivalence, row operations as transvections, and the Mathlib algebra tower transported onto our matrix type
+- **hex-row-reduce-mathlib**: rank = `Matrix.rank`, nullspace = `LinearMap.ker`, span agreement
+- **hex-determinant-mathlib**: `det` agreement with `Matrix.det`, plus the Plücker / Desnanot-Jacobi assembly
+- **hex-bareiss-mathlib**: Bareiss determinant = `Matrix.det`, via the bordered-minor invariant
+- **hex-gram-schmidt-mathlib**: `GramSchmidt.Int.basis` = Mathlib's `gramSchmidt`
+- **hex-poly-z-mathlib**: `DensePoly Int ≃+* Polynomial ℤ`, Mignotte bound (via Mathlib's Mahler measure)
+- **hex-roots-mathlib**: Pellet's test on circles (built from `circleIntegral`), the Mahler separation bound, soundness of refinement and `isolate`
+- **hex-resultant-mathlib**: "resultant zero iff common root" (scope-limited; equality with `Polynomial.resultant` deferred)
+- **hex-number-field-mathlib**: `QAdjoin p x ≃+* AdjoinRoot pℚ`, canonicity of `AlgebraicNumber`, arithmetic correctness
+- **hex-berlekamp-mathlib**: `Decidable (Irreducible f)` for `Polynomial (ZMod p)`
+- **hex-hensel-mathlib**: Hensel correctness, uniqueness, `coprime_mod_p_lifts`
+- **hex-lll-mathlib**: lattice = `Submodule ℤ`, short vector bound
+- **hex-gf2-mathlib**: `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
+- **hex-gfq-mathlib**: finiteness/cardinality for quotient fields, and `GFq p n ≃+* GaloisField p n`
+- **hex-berlekamp-zassenhaus-mathlib**: unconditional factoring correctness, `Decidable (Irreducible f)` for `Polynomial ℤ`
 
 ## Implementation dependencies
 
 Each library with its immediate dependencies:
 
-- **hex-arith** — (none)
-- **hex-poly** — (none)
-- **hex-matrix** — (none)
-- **hex-row-reduce** — hex-matrix
-- **hex-determinant** — hex-matrix
-- **hex-bareiss** — hex-determinant, hex-matrix
-- **hex-mod-arith** — hex-arith
-- **hex-gram-schmidt** — hex-row-reduce, hex-determinant, hex-bareiss
-- **hex-lll** — hex-gram-schmidt, hex-matrix
-- **hex-poly-fp** — hex-poly, hex-mod-arith
-- **hex-poly-z** — hex-poly
-- **hex-roots** — hex-poly-z
-- **hex-resultant** — hex-poly
-- **hex-number-field** — hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus
-- **hex-berlekamp** — hex-poly-fp, hex-matrix, hex-gfq-ring
-- **hex-hensel** — hex-poly-fp, hex-poly-z
-- **hex-conway** — hex-berlekamp
-- **hex-gfq-ring** — hex-poly-fp
-- **hex-gfq-field** — hex-gfq-ring
-- **hex-gfq** — hex-gfq-field, hex-conway, hex-gf2
-- **hex-gf2** — hex-poly
-- **hex-berlekamp-zassenhaus** — hex-berlekamp, hex-hensel, hex-lll
+- **hex-arith**: (none)
+- **hex-poly**: (none)
+- **hex-matrix**: (none)
+- **hex-row-reduce**: hex-matrix
+- **hex-determinant**: hex-matrix
+- **hex-bareiss**: hex-determinant, hex-matrix
+- **hex-mod-arith**: hex-arith
+- **hex-gram-schmidt**: hex-row-reduce, hex-determinant, hex-bareiss
+- **hex-lll**: hex-gram-schmidt, hex-matrix
+- **hex-poly-fp**: hex-poly, hex-mod-arith
+- **hex-poly-z**: hex-poly
+- **hex-roots**: hex-poly-z
+- **hex-resultant**: hex-poly
+- **hex-number-field**: hex-poly-z, hex-roots, hex-resultant, hex-berlekamp-zassenhaus, hex-matrix, hex-row-reduce
+- **hex-berlekamp**: hex-poly-fp, hex-matrix, hex-gfq-ring
+- **hex-hensel**: hex-poly-fp, hex-poly-z
+- **hex-conway**: hex-berlekamp
+- **hex-gfq-ring**: hex-poly-fp
+- **hex-gfq-field**: hex-gfq-ring
+- **hex-gfq**: hex-gfq-field, hex-conway, hex-gf2
+- **hex-gf2**: hex-poly
+- **hex-berlekamp-zassenhaus**: hex-berlekamp, hex-hensel, hex-lll
 
-Mathlib bridge libraries (each also depends on Mathlib):
+Mathlib companion libraries (each also depends on Mathlib):
 
-- **hex-mod-arith-mathlib** — hex-mod-arith
-- **hex-poly-mathlib** — hex-poly
-- **hex-poly-z-mathlib** — hex-poly-z, hex-poly-mathlib
-- **hex-roots-mathlib** — hex-roots, hex-poly-z-mathlib
-- **hex-resultant-mathlib** — hex-resultant, hex-poly-mathlib
-- **hex-number-field-mathlib** — hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
-- **hex-matrix-mathlib** — hex-matrix
-- **hex-row-reduce-mathlib** — hex-row-reduce, hex-matrix-mathlib
-- **hex-determinant-mathlib** — hex-determinant, hex-bareiss, hex-matrix-mathlib
-- **hex-bareiss-mathlib** — hex-determinant-mathlib
-- **hex-gram-schmidt-mathlib** — hex-gram-schmidt, hex-bareiss-mathlib
-- **hex-lll-mathlib** — hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib
-- **hex-berlekamp-mathlib** — hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib
-- **hex-hensel-mathlib** — hex-hensel, hex-poly-mathlib
-- **hex-gf2-mathlib** — hex-gf2, hex-poly-fp, hex-gfq-field
-- **hex-gfq-mathlib** — hex-gfq
-- **hex-berlekamp-zassenhaus-mathlib** — hex-berlekamp-zassenhaus, hex-poly-z-mathlib
+- **hex-mod-arith-mathlib**: hex-mod-arith
+- **hex-poly-mathlib**: hex-poly
+- **hex-poly-z-mathlib**: hex-poly-z, hex-poly-mathlib
+- **hex-roots-mathlib**: hex-roots, hex-poly-z-mathlib
+- **hex-resultant-mathlib**: hex-resultant, hex-poly-mathlib
+- **hex-number-field-mathlib**: hex-number-field, hex-resultant-mathlib, hex-berlekamp-zassenhaus-mathlib, hex-roots-mathlib, hex-poly-z-mathlib
+- **hex-matrix-mathlib**: hex-matrix
+- **hex-row-reduce-mathlib**: hex-row-reduce, hex-matrix-mathlib
+- **hex-determinant-mathlib**: hex-determinant, hex-bareiss, hex-matrix-mathlib
+- **hex-bareiss-mathlib**: hex-determinant-mathlib
+- **hex-gram-schmidt-mathlib**: hex-gram-schmidt, hex-bareiss-mathlib
+- **hex-lll-mathlib**: hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib
+- **hex-berlekamp-mathlib**: hex-berlekamp, hex-poly-mathlib, hex-mod-arith-mathlib
+- **hex-hensel-mathlib**: hex-hensel, hex-poly-mathlib
+- **hex-gf2-mathlib**: hex-gf2, hex-poly-fp, hex-gfq-field
+- **hex-gfq-mathlib**: hex-gfq
+- **hex-berlekamp-zassenhaus-mathlib**: hex-berlekamp-zassenhaus, hex-poly-z-mathlib
 
 LLL is the recombination primitive used by Berlekamp-Zassenhaus: BZ
-encodes its lifted local factors as a lattice basis and consumes
-`hex-lll`'s reduced basis / short-vector entry points. The two
-libraries can still be developed in parallel up to the point where BZ
-recombination is wired up, but the dependency edge `hex-lll →
-hex-berlekamp-zassenhaus` is part of the production graph, not an
-optional optimisation edge.
+encodes its lifted local factors as a lattice basis and calls
+`hex-lll`'s reduced-basis and short-vector functions. The two
+libraries can still be developed in parallel until BZ recombination is
+implemented, but the dependency of `hex-berlekamp-zassenhaus` on
+`hex-lll` is part of the production graph, not an optional
+optimisation.
 
 ## Library DAG
 
@@ -105,8 +106,8 @@ The matrix family splits internally: `hex-matrix` is the dense base;
 `hex-row-reduce`, `hex-determinant`, and `hex-bareiss` build on it
 (`hex-bareiss` also on `hex-determinant`); `hex-gram-schmidt` uses all
 three; and `hex-lll` builds on `hex-gram-schmidt`. Each has a matching
-`*-mathlib` bridge of the same shape. In the diagram below, `hex-matrix`
-stands for that whole family.
+`*-mathlib` companion of the same shape. In the diagram below,
+`hex-matrix` stands for that whole family.
 
 Three independent roots: hex-poly, hex-arith, hex-matrix.
 
@@ -139,45 +140,49 @@ hex-gfq-field   hex-conway   hex-gf2
 
 ## Index
 
-Libraries marked **(released)** are published as standalone repositories;
-see [PLAN/Releases.md §Published libraries](../../PLAN/Releases.md#published-libraries).
+Libraries marked **(released)** are published as standalone
+repositories; see
+[PLAN/Releases.md §Published libraries](../../PLAN/Releases.md#published-libraries).
+SPEC files for libraries already under development live with the
+library source (`HexFoo/SPEC/hex-foo.md`); the six SPECs kept in this
+directory belong to planned libraries not yet started.
 
-- [hex-arith.md](hex-arith.md) — extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
-- [hex-matrix](https://github.com/leanprover/hex-matrix/blob/main/SPEC/hex-matrix.md) (released) — dense matrices, arithmetic, elementary row/column operations, submatrix slicing, the Gram matrix
-- [hex-row-reduce](https://github.com/leanprover/hex-row-reduce/blob/main/SPEC/hex-row-reduce.md) (released) — row reduction, rank, span, nullspace
-- [hex-determinant](https://github.com/leanprover/hex-determinant/blob/main/SPEC/hex-determinant.md) (released) — Leibniz determinant and cofactor/Cauchy-Binet/Plücker theory
-- [hex-bareiss](https://github.com/leanprover/hex-bareiss/blob/main/SPEC/hex-bareiss.md) (released) — fraction-free Bareiss determinant algorithm
-- [hex-matrix-mathlib](https://github.com/leanprover/hex-matrix-mathlib/blob/main/SPEC/hex-matrix-mathlib.md) (released) — matrix equivalence, row operations as transvections, transported algebra tower
-- [hex-row-reduce-mathlib](https://github.com/leanprover/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released) — rank/nullspace/span correspondence
-- [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released) — `det` agreement with `Matrix.det`
-- [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released) — Bareiss determinant correctness
-- [hex-mod-arith.md](hex-mod-arith.md) — `ZMod64 p`: `UInt64`-backed arithmetic in `Z/pZ`
-- [hex-mod-arith-mathlib.md](hex-mod-arith-mathlib.md) — `ZMod64 p ≃+* ZMod p`
-- [hex-poly.md](hex-poly.md) — dense polynomial library, operations, GCD, CRT
-- [hex-poly-mathlib.md](hex-poly-mathlib.md) — `DensePoly R ≃+* Polynomial R`
-- [hex-poly-fp.md](hex-poly-fp.md) — polynomials over `F_p`, Frobenius, square-free decomposition
-- [hex-gf2.md](hex-gf2.md) — packed bitwise polynomials over `F_2`, `GF(2^n)` elements
-- [hex-gf2-mathlib.md](hex-gf2-mathlib.md) — `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
-- [hex-poly-z.md](hex-poly-z.md) — polynomials over `Z`, content/primitive part, Mignotte bound
-- [hex-poly-z-mathlib.md](hex-poly-z-mathlib.md) — Mignotte bound proof via Mathlib's Mahler measure
-- [hex-roots.md](hex-roots.md) — certified complex root isolation for `Z[x]`
-- [hex-roots-mathlib.md](hex-roots-mathlib.md) — Pellet on circles, Mahler/Mignotte separation bound, refinement and `isolate` correctness
-- [hex-resultant.md](hex-resultant.md) — polynomial resultant + discriminant via subresultant pseudo-remainder sequence
-- [hex-resultant-mathlib.md](hex-resultant-mathlib.md) — "subresultant zero ↔ common root"; discriminant non-vanishing under squarefreeness
-- [hex-number-field.md](hex-number-field.md) — `NumberField p x` and canonical `AlgebraicNumber` for arbitrary `α ∈ ℂ_alg`
-- [hex-number-field-mathlib.md](hex-number-field-mathlib.md) — `NumberField ≃+* AdjoinRoot`, bijection of `AlgebraicNumber` with `ℂ_alg`, arithmetic correctness
-- [hex-berlekamp.md](hex-berlekamp.md) — Berlekamp factoring and Rabin irreducibility test
-- [hex-berlekamp-mathlib.md](hex-berlekamp-mathlib.md) — Berlekamp/Rabin correctness proofs via Euclidean domain theory
-- [hex-hensel.md](hex-hensel.md) — Hensel lifting algorithms
-- [hex-hensel-mathlib.md](hex-hensel-mathlib.md) — Hensel correctness, uniqueness, coprimality lifting
-- [hex-conway.md](hex-conway.md) — Conway polynomial database
-- [hex-gfq-ring.md](hex-gfq-ring.md) — canonical quotient ring `F_p[x]/(f)`
-- [hex-gfq-field.md](hex-gfq-field.md) — field structure on top of the quotient ring when `f` is irreducible
-- [hex-gfq.md](hex-gfq.md) — convenience wrapper `GFq p n` and optimized `GF2q n` using Conway polynomials
-- [hex-gfq-mathlib.md](hex-gfq-mathlib.md) — finiteness/cardinality for quotient fields and `GFq p n ≃+* GaloisField p n`
-- [hex-gram-schmidt](https://github.com/leanprover/hex-gram-schmidt/blob/main/SPEC/hex-gram-schmidt.md) (released) — Gram-Schmidt orthogonalization, coefficients, Gram determinants
-- [hex-gram-schmidt-mathlib](https://github.com/leanprover/hex-gram-schmidt-mathlib/blob/main/SPEC/hex-gram-schmidt-mathlib.md) (released) — correspondence with Mathlib's `gramSchmidt`
-- [hex-lll](https://github.com/leanprover/hex-lll/blob/main/SPEC/hex-lll.md) (released) — LLL lattice basis reduction algorithm and proofs
-- [hex-lll-mathlib](https://github.com/leanprover/hex-lll-mathlib/blob/main/SPEC/hex-lll-mathlib.md) (released) — lattice = `Submodule Z`, short vector bound
-- [hex-berlekamp-zassenhaus.md](hex-berlekamp-zassenhaus.md) — complete factoring of `Z[x]`
-- [hex-berlekamp-zassenhaus-mathlib.md](hex-berlekamp-zassenhaus-mathlib.md) — unconditional factoring correctness
+- [hex-arith](../../HexArith/SPEC/hex-arith.md): extended GCD, Barrett/Montgomery reduction, binomial coefficients, Fermat's little theorem
+- [hex-matrix](https://github.com/leanprover/hex-matrix/blob/main/SPEC/hex-matrix.md) (released): dense matrices, arithmetic, elementary row/column operations, submatrix slicing, the Gram matrix
+- [hex-row-reduce](https://github.com/leanprover/hex-row-reduce/blob/main/SPEC/hex-row-reduce.md) (released): row reduction, rank, span, nullspace
+- [hex-determinant](https://github.com/leanprover/hex-determinant/blob/main/SPEC/hex-determinant.md) (released): Leibniz determinant and cofactor/Cauchy-Binet/Plücker theory
+- [hex-bareiss](https://github.com/leanprover/hex-bareiss/blob/main/SPEC/hex-bareiss.md) (released): fraction-free Bareiss determinant algorithm
+- [hex-matrix-mathlib](https://github.com/leanprover/hex-matrix-mathlib/blob/main/SPEC/hex-matrix-mathlib.md) (released): matrix equivalence, row operations as transvections, transported algebra tower
+- [hex-row-reduce-mathlib](https://github.com/leanprover/hex-row-reduce-mathlib/blob/main/SPEC/hex-row-reduce-mathlib.md) (released): rank/nullspace/span correspondence
+- [hex-determinant-mathlib](https://github.com/leanprover/hex-determinant-mathlib/blob/main/SPEC/hex-determinant-mathlib.md) (released): `det` agreement with `Matrix.det`
+- [hex-bareiss-mathlib](https://github.com/leanprover/hex-bareiss-mathlib/blob/main/SPEC/hex-bareiss-mathlib.md) (released): Bareiss determinant correctness
+- [hex-mod-arith](../../HexModArith/SPEC/hex-mod-arith.md): `ZMod64 p`, `UInt64`-backed arithmetic in `Z/pZ`
+- [hex-mod-arith-mathlib](../../HexModArithMathlib/SPEC/hex-mod-arith-mathlib.md): `ZMod64 p ≃+* ZMod p`
+- [hex-poly](../../HexPoly/SPEC/hex-poly.md): dense polynomial library, operations, GCD, CRT
+- [hex-poly-mathlib](../../HexPolyMathlib/SPEC/hex-poly-mathlib.md): `DensePoly R ≃+* Polynomial R`
+- [hex-poly-fp](../../HexPolyFp/SPEC/hex-poly-fp.md): polynomials over `F_p`, Frobenius, square-free decomposition
+- [hex-gf2](../../HexGF2/SPEC/hex-gf2.md): packed bitwise polynomials over `F_2`, `GF(2^n)` elements
+- [hex-gf2-mathlib](../../HexGF2Mathlib/SPEC/hex-gf2-mathlib.md): `GF2Poly ≃+* FpPoly 2`, `GF2n`/`GF2nPoly ≃+* FiniteField 2 f hf hirr`, packed-field finiteness/cardinality
+- [hex-poly-z](../../HexPolyZ/SPEC/hex-poly-z.md): polynomials over `Z`, content/primitive part, Mignotte bound
+- [hex-poly-z-mathlib](../../HexPolyZMathlib/SPEC/hex-poly-z-mathlib.md): Mignotte bound proof via Mathlib's Mahler measure
+- [hex-roots.md](hex-roots.md): certified complex root isolation for `Z[x]`
+- [hex-roots-mathlib.md](hex-roots-mathlib.md): Pellet's test on circles, the Mahler separation bound, soundness of refinement and `isolate`
+- [hex-resultant.md](hex-resultant.md): polynomial resultant and discriminant via the subresultant pseudo-remainder sequence
+- [hex-resultant-mathlib.md](hex-resultant-mathlib.md): "resultant zero iff common root"; discriminant non-vanishing under squarefreeness
+- [hex-number-field.md](hex-number-field.md): `QAdjoin p x` and the canonical `AlgebraicNumber`
+- [hex-number-field-mathlib.md](hex-number-field-mathlib.md): `QAdjoin ≃+* AdjoinRoot`, canonicity of `AlgebraicNumber`, arithmetic correctness
+- [hex-berlekamp](../../HexBerlekamp/SPEC/hex-berlekamp.md): Berlekamp factoring and Rabin irreducibility test
+- [hex-berlekamp-mathlib](../../HexBerlekampMathlib/SPEC/hex-berlekamp-mathlib.md): Berlekamp/Rabin correctness proofs via Euclidean domain theory
+- [hex-hensel](../../HexHensel/SPEC/hex-hensel.md): Hensel lifting algorithms
+- [hex-hensel-mathlib](../../HexHenselMathlib/SPEC/hex-hensel-mathlib.md): Hensel correctness, uniqueness, coprimality lifting
+- [hex-conway](../../HexConway/SPEC/hex-conway.md): Conway polynomial database
+- [hex-gfq-ring](../../HexGFqRing/SPEC/hex-gfq-ring.md): canonical quotient ring `F_p[x]/(f)`
+- [hex-gfq-field](../../HexGFqField/SPEC/hex-gfq-field.md): field structure on top of the quotient ring when `f` is irreducible
+- [hex-gfq](../../HexGFq/SPEC/hex-gfq.md): convenience wrapper `GFq p n` and optimized `GF2q n` using Conway polynomials
+- [hex-gfq-mathlib](../../HexGFqMathlib/SPEC/hex-gfq-mathlib.md): finiteness/cardinality for quotient fields and `GFq p n ≃+* GaloisField p n`
+- [hex-gram-schmidt](https://github.com/leanprover/hex-gram-schmidt/blob/main/SPEC/hex-gram-schmidt.md) (released): Gram-Schmidt orthogonalization, coefficients, Gram determinants
+- [hex-gram-schmidt-mathlib](https://github.com/leanprover/hex-gram-schmidt-mathlib/blob/main/SPEC/hex-gram-schmidt-mathlib.md) (released): correspondence with Mathlib's `gramSchmidt`
+- [hex-lll](https://github.com/leanprover/hex-lll/blob/main/SPEC/hex-lll.md) (released): LLL lattice basis reduction algorithm and proofs
+- [hex-lll-mathlib](https://github.com/leanprover/hex-lll-mathlib/blob/main/SPEC/hex-lll-mathlib.md) (released): lattice = `Submodule Z`, short vector bound
+- [hex-berlekamp-zassenhaus](../../HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md): complete factoring of `Z[x]`
+- [hex-berlekamp-zassenhaus-mathlib](../../HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md): unconditional factoring correctness

--- a/SPEC/Libraries/hex-number-field-mathlib.md
+++ b/SPEC/Libraries/hex-number-field-mathlib.md
@@ -1,214 +1,256 @@
 # hex-number-field-mathlib (depends on hex-number-field + hex-resultant-mathlib + hex-berlekamp-zassenhaus-mathlib + hex-roots-mathlib + hex-poly-z-mathlib)
 
-Mathlib bridge for `hex-number-field`. Proves correctness of the
-algebraic-number arithmetic against Mathlib's standard
-`Polynomial.AdjoinRoot`, `IsAlgebraic`, and field-extension
-infrastructure.
+Mathlib companion for `hex-number-field`. Proves that the
+algebraic-number arithmetic computes what it claims, against Mathlib's
+`AdjoinRoot`, `minpoly`, and field-extension API.
+
+Throughout, write `pℚ := (toPolynomial p).map (algebraMap ℤ ℚ)` for
+the ℚ-coefficient form of `p : ZPoly`. The passage between `p`
+(primitive, positive leading coefficient, irreducible over ℤ) and the
+monic `minpoly ℚ α` goes through `pℚ` and Gauss's lemma. Getting this
+boundary right is most of the definitional work.
 
 ## What we cite from Mathlib (no work)
 
-- `Polynomial.AdjoinRoot`, the natural map `Polynomial R → AdjoinRoot p`,
-  and the field structure on `AdjoinRoot p` when `p` is irreducible.
-- `IntermediateField`, `IsAlgebraic`, `Algebra ℚ ℂ`,
-  `MinpolyOver` and the `minpoly` definition.
+All names checked against the Mathlib revision this repository pins.
+Module names are given without line numbers, which rot.
+
+- `AdjoinRoot`, `AdjoinRoot.lift`, and the `Field (AdjoinRoot f)`
+  instance under `[Fact (Irreducible f)]`
+  (`Mathlib.RingTheory.AdjoinRoot`).
+- Gauss's lemma in the form
+  `Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast`
+  (`Mathlib.RingTheory.Polynomial.GaussLemma`): `p` irreducible over ℤ
+  iff `pℚ` irreducible over ℚ, for primitive `p`.
 - `Field.exists_primitive_element` for finite separable extensions
-  (which covers `ℚ ⊂ ℚ(α, β)` for distinct algebraic α, β).
-- `Polynomial.eval`, `Polynomial.aeval`, `Polynomial.IsRoot`.
+  (`Mathlib.FieldTheory.PrimitiveElement`); applies to `ℚ ⊆ ℚ(α, β)`
+  since ℚ has characteristic zero.
+- `IntermediateField` with the `F⟮α⟯` notation and its lattice API
+  (`Mathlib.FieldTheory.IntermediateField.Basic`,
+  `….Adjoin.Defs`).
+- `IsAlgebraic` (`Mathlib.RingTheory.Algebraic.Defs`).
+- `IntermediateField.algebraicClosure F E`
+  (`Mathlib.FieldTheory.AlgebraicClosure`): the relative algebraic
+  closure; `IntermediateField.algebraicClosure ℚ ℂ` is the subfield of
+  algebraic complex numbers, with the membership lemma
+  `x ∈ … ↔ IsAlgebraic ℚ x`.
+- `minpoly` and its API (`Mathlib.FieldTheory.Minpoly.Basic`); monic
+  by Mathlib convention, in `ℚ[X]` for our case.
+- `minpoly.equivAdjoin : AdjoinRoot (minpoly R x) ≃ₐ[R] adjoin R {x}`
+  for `x` integral
+  (`Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed`): the equivalence
+  between the abstract quotient and the concrete subfield.
+- `Polynomial.IsPrimitive`, `Polynomial.content`,
+  `Polynomial.primPart` (`Mathlib.RingTheory.Polynomial.Content`).
+- From the other companions: the `DensePoly Int ≃+* Polynomial ℤ`
+  ring equivalence (`hex-poly-z-mathlib`),
+  `resultant_eq_zero_iff_common_root` (`hex-resultant-mathlib`),
+  `RefinedIsolation.root` / `rootOf` and the `sameRoot` semantics
+  (`hex-roots-mathlib`), and
+  `Hex.ZPoly.IsIrreducible f ↔ Irreducible (toPolynomial f)`
+  (`hex-berlekamp-zassenhaus-mathlib`).
 
-## Bridging theorems
+## Correspondence theorems
 
-### `NumberField p x` semantics
-
-```lean
-/-- When `p` is irreducible, `NumberField p x` is the field `AdjoinRoot p`,
-    with embedding into ℂ given by evaluation at the simple root
-    identified by `x`. -/
-theorem NumberField.equiv_adjoinRoot {p : ZPoly} (hp : Hex.ZPoly.Irreducible p)
-    (x : SimpleRoot p) :
-    NumberField p x ≃+* AdjoinRoot (toPolynomial p)
-
-/-- The complex-valued embedding of `NumberField p x`. -/
-def NumberField.toComplex {p : ZPoly} (x : SimpleRoot p) :
-    NumberField p x →+* ℂ
-  -- defined as: `aeval (root corresponding to x)` post-composed with
-  -- AdjoinRoot's universal property
-
-theorem NumberField.toComplex_eq_eval {p : ZPoly} (x : SimpleRoot p)
-    (a : NumberField p x) :
-    NumberField.toComplex x a = (toPolynomial a.coeffs).eval (rootOf x)
-  -- where `rootOf x : ℂ` is the complex root identified by `x`
-  -- (defined via the SimpleRoot semantics in hex-roots-mathlib)
-```
-
-### `NumberField.approx` correctness
-
-```lean
-theorem NumberField.approx_contains (a : NumberField p x) (prec : Nat) :
-    NumberField.toComplex x a ∈ (a.approx prec).2.ball
-  -- the returned ball contains the true complex value
-```
-
-The first component of `approx` (the refreshed `NumberField p x`) is
-propositionally equal to the input via `SimpleRoot.refine_eq`; this
-is reflected as a separate theorem:
+### `QAdjoin p x` semantics
 
 ```lean
-theorem NumberField.approx_first_eq (a : NumberField p x) (prec : Nat) :
-    (a.approx prec).1 = a    -- propositionally
+/-- `QAdjoin p x` is the quotient `ℚ[X]/(pℚ)`. A ring equivalence for
+    any `p` of positive degree; when `p` is irreducible it is an
+    equivalence of fields (both sides then carry field structures). -/
+def QAdjoin.equivAdjoinRoot {p : ZPoly} (x : SimpleRoot p) :
+    QAdjoin p x ≃+* AdjoinRoot pℚ
+
+/-- Evaluation at the root: the embedding of `QAdjoin p x` into ℂ. -/
+def QAdjoin.toComplex {p : ZPoly} (x : SimpleRoot p) :
+    QAdjoin p x →+* ℂ
+  -- AdjoinRoot.lift at `rootOf x`, composed with equivAdjoinRoot
+
+theorem QAdjoin.toComplex_eq_eval {p : ZPoly} (x : SimpleRoot p)
+    (a : QAdjoin p x) :
+    QAdjoin.toComplex x a = (toPolynomial a.coeffs).aeval (rootOf x)
 ```
+
+Note `AdjoinRoot (toPolynomial p)` (over ℤ) would be the wrong target:
+that is `ℤ[X]/(p)`, an order, not the field `ℚ(α)`. The map to ℚ
+coefficients is what makes `equivAdjoinRoot` and the field structure
+correct, and Gauss's lemma is what transfers `p`'s irreducibility over
+ℤ to `pℚ`'s over ℚ.
+
+### `QAdjoin.approx` correctness
+
+```lean
+theorem QAdjoin.approx_sound (a : QAdjoin p x) (rep h prec) :
+    QAdjoin.toComplex x a ∈ (a.approx rep h prec).2.set ∧
+    SimpleRoot.mk (a.approx rep h prec).1 = x
+
+theorem QAdjoin.approx_radius (a : QAdjoin p x) (rep h prec) :
+    (a.approx rep h prec).2.radius ≤ 2^(−prec)
+```
+
+`approx` is total with a sound fallback, so `approx_sound` is
+unconditional: the ball always contains the true value, and the
+returned isolation always identifies the same root. Only the
+precision claim `approx_radius` depends on refinement succeeding,
+which is part of the bound-sufficiency work below.
 
 ### `AlgebraicNumber` semantics
 
 ```lean
-/-- The complex-number value of an `AlgebraicNumber`, given by the
-    SimpleRoot. -/
 def AlgebraicNumber.toComplex (a : AlgebraicNumber) : ℂ :=
   rootOf a.x
 
-/-- An `AlgebraicNumber`'s value is a root of its declared minimal
-    polynomial. -/
 theorem AlgebraicNumber.toComplex_isRoot (a : AlgebraicNumber) :
-    (toPolynomial a.p).IsRoot a.toComplex
+    (toPolynomial a.p).aeval a.toComplex = 0
 
-/-- The polynomial declared by `AlgebraicNumber.p` is in fact the
-    minimal polynomial. -/
+/-- The stored polynomial is the minimal polynomial: its ℚ-coefficient
+    form is the monic minimal polynomial scaled by the leading
+    coefficient. -/
 theorem AlgebraicNumber.p_eq_minpoly (a : AlgebraicNumber) :
-    toPolynomial a.p = (minpoly ℚ a.toComplex).primitivePart -- (up to leading-coefficient sign)
+    (a.p.leadingCoeff : ℚ)⁻¹ • (toPolynomial a.p).map (algebraMap ℤ ℚ)
+      = minpoly ℚ a.toComplex
 
-/-- AlgebraicNumber values are in bijection with `ℂ_alg`
-    (algebraic complex numbers). -/
-theorem AlgebraicNumber.bijective_to_ℂ_alg :
-    Function.Bijective AlgebraicNumber.toComplex.toFun ∧
-    ∀ z : ℂ, IsAlgebraic ℚ z ↔ ∃ a : AlgebraicNumber, a.toComplex = z
+/-- Canonicity: `toComplex` is injective (per `BEq`, below), and its
+    range is exactly the algebraic numbers. -/
+theorem AlgebraicNumber.range_toComplex :
+    Set.range AlgebraicNumber.toComplex = {z : ℂ | IsAlgebraic ℚ z}
+
+/-- `==` decides equality of values. -/
+theorem AlgebraicNumber.beq_iff (a b : AlgebraicNumber) :
+    a == b ↔ a.toComplex = b.toComplex
 ```
+
+(`toComplex` is not injective as a function on the raw structure,
+since two values may differ only in `rep`. `beq_iff` is the right
+statement, and injectivity holds on the `BEq`-quotient.)
 
 ### `commonField` correctness
 
 ```lean
-theorem AlgebraicNumber.commonField_correct (α β : AlgebraicNumber) :
-    let ⟨r, γ, hr, αIn, βIn⟩ := α.commonField β
-    Hex.ZPoly.Irreducible r ∧
-    NumberField.toComplex γ αIn = α.toComplex ∧
-    NumberField.toComplex γ βIn = β.toComplex
+theorem AlgebraicNumber.commonField?_sound (α β : AlgebraicNumber)
+    {cf} (h : α.commonField? β = some cf) :
+    QAdjoin.toComplex cf.γ cf.αIn = α.toComplex ∧
+    QAdjoin.toComplex cf.γ cf.βIn = β.toComplex
+
+theorem AlgebraicNumber.commonField?_isSome (α β : AlgebraicNumber) :
+    (α.commonField? β).isSome
 ```
 
-Uses the primitive-element theorem
-(`Field.exists_primitive_element`) plus our resultant-zero-iff-common-root
-result from `hex-resultant-mathlib` to certify that the chosen factor
-`r` of the resultant is indeed the minimal polynomial of α + c·β over
-ℚ. Numerical disambiguation correctness uses `HexRoots`'s
-`SimpleRoot` semantics.
+The proof certifies the algorithm's own checks rather than citing
+abstract existence: `resultant_eq_zero_iff_common_root`
+(hex-resultant-mathlib) shows `α + c·β` is a root of the resultant;
+the numerical disambiguation (hex-roots-mathlib `sameRoot` semantics
+plus ball arithmetic bounds) shows the chosen factor is the one
+vanishing at `α + c·β`; the multiplicity-1 check plus the classical
+primitive-element argument shows `γ` generates, so the linear system
+of step 5 is solvable and its solution unique.
+`Field.exists_primitive_element` is used only as a guide. The
+correctness proof is about the computed `γ`, not an abstract one.
 
 ### Arithmetic correctness
 
+The proofs are staged to match the `?`-form / total-form split in
+hex-number-field.md:
+
 ```lean
+-- Stage 1 (soundness): a computed certificate is correct.
+theorem AlgebraicNumber.add?_sound (α β : AlgebraicNumber)
+    {γ} (h : α.add? β = some γ) :
+    γ.toComplex = α.toComplex + β.toComplex
+
+-- Stage 2 (bound sufficiency): the certificate always appears.
+theorem AlgebraicNumber.add?_isSome (α β : AlgebraicNumber) :
+    (α.add? β).isSome
+
+-- Headline: unconditional, by composing the two; the `panicWith`
+-- branch of the total wrapper is dead by stage 2.
 theorem AlgebraicNumber.add_toComplex (α β : AlgebraicNumber) :
     (α.add β).toComplex = α.toComplex + β.toComplex
 
-theorem AlgebraicNumber.mul_toComplex (α β : AlgebraicNumber) :
-    (α.mul β).toComplex = α.toComplex * β.toComplex
-
-theorem AlgebraicNumber.inv_toComplex (α : AlgebraicNumber) (h : ¬ α.isZero) :
-    (α.inv h).toComplex = α.toComplex⁻¹
-
--- and similarly for sub, neg, isZero
+-- likewise for mul, sub, inv (with hypothesis ¬ α.isZero), the
+-- always-total neg, and isZero_iff
 ```
 
-Each follows from `commonField_correct` plus the corresponding
-`NumberField p x` ring axiom plus `toAlgebraicNumber`'s correctness
-(below).
+Stage 1 follows from `commonField?_sound`, the `QAdjoin` ring laws,
+and `toAlgebraicNumber?_sound` below; it is provable without any
+completeness input, because the algorithm checks its own
+certificates. Stage 2 is where the analysis lives (item 6 below).
 
-### `toNumberField` and `toAlgebraicNumber` correctness
+### Conversion correctness
 
 ```lean
-theorem AlgebraicNumber.toNumberField_toComplex (a : AlgebraicNumber) :
-    NumberField.toComplex a.x a.toNumberField = a.toComplex
+theorem AlgebraicNumber.toQAdjoin_toComplex (a : AlgebraicNumber) :
+    QAdjoin.toComplex a.x a.toQAdjoin = a.toComplex
 
-theorem NumberField.toAlgebraicNumber_toComplex (a : NumberField p x) :
-    a.toAlgebraicNumber.toComplex = NumberField.toComplex x a
+theorem QAdjoin.toAlgebraicNumber?_sound [Hex.ZPoly.IsIrreducible p]
+    (a : QAdjoin p x) (rep h) {b}
+    (hsome : a.toAlgebraicNumber? rep h = some b) :
+    b.toComplex = QAdjoin.toComplex x a
 ```
 
-The latter is the substantive theorem — it says that the minimal
-polynomial computation via `NumberField.toAlgebraicNumber` correctly
-identifies the value's minimal polynomial and matches the right
-SimpleRoot.
+`toAlgebraicNumber?_sound` is the substantive theorem: the
+minimal-polynomial computation (that the first linear dependence among
+the powers of the multiplication operator gives `minpoly ℚ` of the
+value, using that `ℚ[t]/(pℚ)` is a field) and the root identification
+(that the isolation selected by the ball test is the root equal to the
+value) both need real proofs.
 
-## Mathlib API used (verified citations)
-
-The bridge can rely on the following existing Mathlib infrastructure
-(all confirmed at the Mathlib commit currently checked out under
-`/Users/kim/projects/lean/hex/.lake/packages/mathlib/`):
-
-- `AdjoinRoot.lift` for ring homomorphisms `AdjoinRoot p → ℂ`
-  sending the root to a chosen `α ∈ ℂ` with `aeval α p = 0`
-  (`Mathlib/RingTheory/AdjoinRoot.lean:275`).
-- `Field (AdjoinRoot p)` instance under `[Fact (Irreducible f)]`
-  (`Mathlib/RingTheory/AdjoinRoot.lean:515`).
-- `Field.exists_primitive_element` for finite separable extensions
-  (`Mathlib/FieldTheory/PrimitiveElement.lean:213`). Directly
-  applicable to `ℚ ⊂ ℚ(α, β)` since ℚ has characteristic 0.
-- `IntermediateField` and `F⟮α⟯` notation, with full lattice API
-  (`Mathlib/FieldTheory/IntermediateField/{Basic,Adjoin/Defs}.lean`).
-- `IsAlgebraic ℚ z` predicate
-  (`Mathlib/RingTheory/Algebraic/Defs.lean:45`).
-- `algebraicClosure ℚ ℂ` as a subfield of ℂ containing exactly the
-  algebraic complex numbers
-  (`Mathlib/FieldTheory/AlgebraicClosure.lean:40`).
-- `minpoly` (monic by Mathlib convention, in `ℚ[x]` for our case)
-  with full API in `Mathlib/FieldTheory/Minpoly/Basic.lean`.
-- **`minpoly.equivAdjoin`**: for `α` integral over `R` in an
-  `R`-algebra `S`,
-  `AdjoinRoot (minpoly R α) ≃ₐ[R] adjoin R {α}`
-  (`Mathlib/FieldTheory/Minpoly/IsIntegrallyClosed.lean:213`). This
-  is the key abstract-↔-concrete equivalence we need for the
-  `NumberField p x ≃+* AdjoinRoot (toPolynomial p)` theorem.
-- `Polynomial.IsPrimitive`, `content`, `primPart`, and related API
-  (`Mathlib/RingTheory/Polynomial/Content.lean`).
-
-## Bridge-specific theorems we must build (~250 lines total)
+## New theorems this library must build
 
 1. **Monic-ℚ to primitive-positive-ℤ** (~50 lines):
    ```lean
-   theorem AlgebraicNumber.minpoly_to_primitive_Z (α : ℂ) (hα : IsAlgebraic ℚ α) :
+   theorem exists_unique_primitive_int_minpoly (α : ℂ) (hα : IsAlgebraic ℚ α) :
        ∃! p : ℤ[X], p.IsPrimitive ∧ 0 < p.leadingCoeff ∧
-                     (p.map (Int.castRingHom ℚ)).leadingCoeff⁻¹ • p.map (Int.castRingHom ℚ)
-                       = minpoly ℚ α
+         (p.leadingCoeff : ℚ)⁻¹ • p.map (algebraMap ℤ ℚ) = minpoly ℚ α
    ```
-   Standard denominator-clearing + primitive-part argument over the
-   monic ℚ-minimal polynomial.
-2. **`AlgebraicNumber` ↔ `ℂ_alg` bijection** (~100 lines): wrap (1)
-   into the `AlgebraicNumber` data structure and prove
-   `Function.Bijective AlgebraicNumber.toComplex.toFun ∧ (∀ z : ℂ,
-   IsAlgebraic ℚ z ↔ ∃ a, a.toComplex = z)`.
-3. **`NumberField p x ≃+* AdjoinRoot (toPolynomial p)`** (~100
-   lines): compose `HexPolyZMathlib.equiv` (the
-   `DensePoly Int ≃+* Polynomial ℤ` ring-equiv) with
-   `minpoly.equivAdjoin` (specialising `AdjoinRoot` to our
-   coefficient/index representation).
+   Denominator clearing plus the primitive part, over the monic
+   ℚ-minimal polynomial.
+2. **Canonicity of `AlgebraicNumber`** (~100 lines): wrap item 1 into
+   the structure and prove `range_toComplex` and `beq_iff` (the
+   latter also uses the `sameRoot` semantics from hex-roots-mathlib).
+3. **`QAdjoin.equivAdjoinRoot`** (~100 lines): compose the
+   `hex-poly-z-mathlib` ring equivalence with the quotient
+   presentation of `AdjoinRoot pℚ`; transfer the field structure
+   through Gauss's lemma and `[Fact (Irreducible pℚ)]`.
+4. **`toAlgebraicNumber?_sound`**: the minimal-polynomial-of-the-
+   multiplication-operator argument and the root identification.
+5. **`commonField?_sound`**: certification of the resultant, factor
+   choice, non-degeneracy, and change of basis, as described above.
+6. **Bound sufficiency** (the `_isSome` theorems, retiring every
+   `panicWith` branch): the `disambiguationPrec` estimate (a
+   classical lower bound on `|g(γ)|` for the wrong factors `g`, via
+   heights and resultants), the `maxShift` collision count, and the
+   root-refinement pieces imported from hex-roots-mathlib's
+   completeness development.
 
-`commonField`'s correctness reduces to citing
-`Field.exists_primitive_element` plus `minpoly.equivAdjoin` for the
-resulting field; no construction-from-scratch needed.
+Items 1-3 are bounded and small. Items 4 and 5 are the substantive
+soundness obligations, comparable in size to items 1-3 combined
+several times over, and there is no shortcut through abstract
+existence theorems. Item 6 can be deferred along with
+hex-roots-mathlib's completeness development: the stage-1 soundness
+theorems stand on their own, and the unconditional headline theorems
+land when item 6 does.
 
-## Layered file organisation
+## File organisation
 
 ```
 HexNumberFieldMathlib/
-  Basic.lean            — bridge definitions, `toComplex` constructors
-  AdjoinRoot.lean       — NumberField ≃+* AdjoinRoot, field structure bridge
-  Approx.lean           — `approx` correctness
-  Convert.lean          — toNumberField/toAlgebraicNumber correctness
-  CommonField.lean      — primitive-element theorem application
-  AlgOps.lean           — arithmetic correctness theorems
-  Algebraic.lean        — bijection with ℂ_alg
-  Conformance.lean      — fixture-based checks
+  Basic.lean            : pℚ notation, toComplex definitions
+  AdjoinRoot.lean       : equivAdjoinRoot and the field transfer (item 3)
+  Minpoly.lean          : items 1 and 2
+  Approx.lean           : approx_sound, approx_radius
+  Convert.lean          : toQAdjoin_toComplex, toAlgebraicNumber?_sound (item 4)
+  CommonField.lean      : commonField?_sound (item 5)
+  AlgOps.lean           : arithmetic correctness, staged (?_sound,
+                          ?_isSome, unconditional headlines)
 ```
+
+The library is verified by building it. Conformance fixtures live
+with `hex-number-field`.
 
 ## References
 
-- Cohen, *A Course in Computational Algebraic Number Theory* (1993),
-  for the algorithmic side; the same algorithms our `hex-number-field`
-  implements.
-- Lang, *Algebra* (Springer, 3rd ed.), for the abstract field-extension
-  results being bridged (primitive element theorem,
-  irreducibility-implies-field for `K[X]/(p)`).
+- Cohen, *A Course in Computational Algebraic Number Theory* (1993):
+  the algorithms whose correctness is being proved.
+- Lang, *Algebra* (Springer, 3rd ed.): the field-extension facts
+  (primitive element, `K[X]/(p)` is a field for irreducible `p`).

--- a/SPEC/Libraries/hex-number-field-mathlib.md
+++ b/SPEC/Libraries/hex-number-field-mathlib.md
@@ -142,8 +142,8 @@ abstract existence: `resultant_eq_zero_iff_common_root`
 the numerical disambiguation (hex-roots-mathlib `sameRoot` semantics
 plus ball arithmetic bounds) shows the chosen factor is the one
 vanishing at `α + c·β`; the multiplicity-1 check plus the classical
-primitive-element argument shows `γ` generates, so the linear system
-of step 5 is solvable and its solution unique.
+primitive-element argument shows `γ` generates, so the step-5 gcd is
+linear and its unique root is `β`.
 `Field.exists_primitive_element` is used only as a guide. The
 correctness proof is about the computed `γ`, not an abstract one.
 

--- a/SPEC/Libraries/hex-number-field.md
+++ b/SPEC/Libraries/hex-number-field.md
@@ -18,8 +18,8 @@ and directly useful when many operations happen in one fixed field.
 output of operations like `α + β`.
 
 The matrix dependencies (`hex-matrix`, `hex-row-reduce`) supply the
-dense ℚ-linear algebra used by `toAlgebraicNumber` and `commonField`
-(minimal-polynomial computation and change of basis).
+dense ℚ-linear algebra used by `toAlgebraicNumber` (the
+minimal-polynomial computation).
 
 ## Executable irreducibility
 
@@ -345,11 +345,22 @@ Implementation:
    shifts is a bounded loop.
 4. **Identify the root.** Run `HexRoots.isolate` on the chosen factor
    and locate the isolation whose disc meets the approximation ball.
-5. **Change of basis.** Express `α` and `β` in the basis
-   `{1, γ, γ², …, γ^(deg r − 1)}` by solving a
-   `(deg r) × (deg r)` ℚ-linear system (`hex-row-reduce`; fraction-
-   free elimination as in `hex-bareiss` is the expected
-   implementation).
+5. **Recover β, then α, as elements of ℚ(γ).** Work in the field
+   `QAdjoin r γ` (its `Field` instance is available, since `r`
+   passed the irreducibility check in step 4). Using HexPoly's
+   Euclidean algorithm over that field, compute
+
+   ```
+   g(y) := gcd( β.p(y), α.p(γ − c·y) )   in (QAdjoin r γ)[y]
+   ```
+
+   For a non-degenerate shift the two operands have exactly one
+   common root, `y = β`, so `g` is linear: `g(y) = y − B` with
+   `B : QAdjoin r γ`. Set `βIn := B` and `αIn := γ − c·βIn`. A gcd
+   of degree ≥ 2 is one more detector of a degenerate shift: restart
+   with the next `c`, in the same loop as step 3. (`DensePoly` over
+   `QAdjoin r γ` is the instantiation at work here; the coefficient
+   field supplies the `Div` that HexPoly's gcd needs.)
 
 The multiplicity test in step 3 is exactly the classical
 primitive-element condition: `γ = α + c·β` fails to generate
@@ -443,8 +454,9 @@ Per-operation costs, with `n = max(deg α.p, deg β.p)` and
     `≤ n²`): per the existing BZ complexity contract.
   - Numerical disambiguation: bounded by `mahlerPrec` of the chosen
     factor.
-  - Linear algebra: `O(n³)` ℚ-operations with fraction-free
-    elimination.
+  - Recovering β: one Euclidean gcd in `(QAdjoin r γ)[y]` on
+    operands of degree ≤ `n`, where each coefficient operation is
+    polynomial arithmetic mod `r`.
 - `1/α`: `O(deg α.p)` for the coefficient reversal, plus one disc
   transformation and witness re-check (one `O(n²)`-operation
   certification; see hex-roots.md).

--- a/SPEC/Libraries/hex-number-field.md
+++ b/SPEC/Libraries/hex-number-field.md
@@ -1,21 +1,84 @@
-# hex-number-field (algebraic numbers + number-field elements, depends on hex-poly-z + hex-roots + hex-resultant + hex-berlekamp-zassenhaus)
+# hex-number-field (algebraic numbers + number-field elements, depends on hex-poly-z + hex-roots + hex-resultant + hex-berlekamp-zassenhaus + hex-matrix + hex-row-reduce)
 
-Two related types representing algebraic numbers in `ℂ`:
+Two related types representing algebraic numbers in ℂ:
 
-- `NumberField p x` — an element of `ℚ(α)` where `α` is the simple
-  complex root of `p ∈ ℤ[x]` identified by `x : SimpleRoot p`.
-  Carries a rational-coefficient polynomial `coeffs` of degree
-  `< deg p`, evaluated at `α`.
-- `AlgebraicNumber` — a canonical representation of an arbitrary
-  `α ∈ ℂ_alg`, by its minimal polynomial (primitive, positive leading
-  coefficient, irreducible) and the `SimpleRoot` identifying which
-  complex root is meant. **No coefficient data**; the simple root
-  itself is the algebraic number.
+- `QAdjoin p x`: an element of `ℚ(α)`, where `α` is the simple complex
+  root of `p ∈ ℤ[x]` identified by `x : SimpleRoot p`. Carries a
+  rational-coefficient polynomial `coeffs` of degree `< deg p`,
+  representing the value `coeffs.eval α`.
+- `AlgebraicNumber`: a canonical representation of an arbitrary
+  algebraic `α ∈ ℂ`, by its minimal polynomial (primitive, positive
+  leading coefficient, irreducible) and the `SimpleRoot` identifying
+  which complex root is meant. No coefficient data: the identified
+  root *is* the algebraic number.
 
-`NumberField p x` is the *working* representation, used internally
-during arithmetic and useful when many operations happen in a fixed
-field. `AlgebraicNumber` is the *canonical* representation, used as
-the user-facing input/output of operations like `α + β`.
+`QAdjoin p x` is the working representation, used during arithmetic
+and directly useful when many operations happen in one fixed field.
+`AlgebraicNumber` is the canonical representation, the input and
+output of operations like `α + β`.
+
+The matrix dependencies (`hex-matrix`, `hex-row-reduce`) supply the
+dense ℚ-linear algebra used by `toAlgebraicNumber` and `commonField`
+(minimal-polynomial computation and change of basis).
+
+## Executable irreducibility
+
+The `AlgebraicNumber` invariants include irreducibility of the stored
+polynomial, and this library constructs such values, so it needs an
+irreducibility test **in the Mathlib-free layer**. `hex-berlekamp-
+zassenhaus` gains one small addition:
+
+```lean
+/-- `f` is irreducible over ℤ, in canonical form (primitive, positive
+    leading coefficient, positive degree). Tested by a ladder of
+    checks, cheapest first; the early rungs certify only `true`, and
+    the final rung decides both ways:
+
+    1. degree 1: canonical-form check alone;
+    2. degree 2 or 3: canonical form and no rational root
+       (a loop over the divisors of the constant and leading
+       coefficients);
+    3. any degree: canonical form, and Rabin's irreducibility test
+       (from hex-berlekamp) accepts `f mod p` at unchanged degree for
+       one of a fixed handful of small primes p (sound: an
+       irreducible mod-p image of a primitive polynomial forces
+       irreducibility over ℤ; incomplete: some irreducibles, such as
+       `x⁴ + 1`, are reducible mod every prime);
+    4. fallback: `HexBerlekampZassenhaus.factor f` reports the single
+       factor `f` itself with multiplicity 1. -/
+def Hex.ZPoly.isIrreducible (f : ZPoly) : Bool := …
+
+/-- Prop form, decidable by `decide`. -/
+class Hex.ZPoly.IsIrreducible (f : ZPoly) : Prop where
+  holds : isIrreducible f = true
+```
+
+Constructing an `AlgebraicNumber` from a candidate polynomial `g`
+tests `isIrreducible g` at runtime, and the proof field comes from the
+`if h : _` branch. At runtime the ladder is a fast path in front of
+`factor`, nothing more.
+
+The ladder is what makes proof-level `decide` viable, since
+`native_decide` is banned and the kernel would otherwise have to
+evaluate the whole factoring pipeline. Measured on this toolchain
+with a list-based model of the mod-p arithmetic: the Rabin rung on a
+degree-10 polynomial over `F_5` kernel-reduces in well under a second
+inside the default elaborator limits, and a deliberately oversized
+degree-20-over-`F_13` workload takes tens of seconds with raised
+`maxRecDepth`/`maxHeartbeats`. So `decide` is practical exactly for
+the small-degree literals that fixtures and worked examples use
+(`X² − 2`, `Φ₅`, `X² − 8`), and the rung-4 fallback should be treated
+as runtime-only. The constant `0 : AlgebraicNumber` carries an
+`isIrreducible X` proof through rung 1, which is kernel-trivial.
+
+The Mathlib companion of hex-berlekamp-zassenhaus proves
+`IsIrreducible f ↔ Irreducible (toPolynomial f)`. Its existing
+factor-correctness machinery
+(`Hex.ZPoly.Irreducible_iff_polynomialIrreducible` and
+`FactorSoundness`) covers rung 4; rungs 1-3 add the rational-root
+criterion and the mod-p lifting lemma (irreducible image at unchanged
+degree lifts, via Gauss's lemma), with the mod-p decidability already
+present in hex-berlekamp-mathlib.
 
 ## Types
 
@@ -23,285 +86,393 @@ the user-facing input/output of operations like `α + β`.
 namespace Hex
 
 /-- A number-field element indexed by a complex simple root.
-    `p` need not be irreducible structurally; field-specific operations
-    (notably `Inv`) use a `[Hex.ZPoly.Irreducible p]` instance argument.
-    The element this represents is `coeffs.eval α` where `α` is the
-    complex root identified by `x`. -/
-structure NumberField (p : ZPoly) (x : SimpleRoot p) where
+    `p` need not be irreducible for the ring operations; the field
+    operations (notably `Inv`) take a `[Hex.ZPoly.IsIrreducible p]`
+    instance argument. The represented value is `coeffs.eval α` where
+    `α` is the root identified by `x`. `degree?` compares in the
+    `Option Nat` order, where the zero polynomial (`none`) is below
+    everything. -/
+structure QAdjoin (p : ZPoly) (x : SimpleRoot p) where
   coeffs    : Hex.DensePoly Rat
-  degree_lt : coeffs.degree < p.degree
+  degree_lt : coeffs.degree? < p.degree?
 
-/-- Canonical representation of an arbitrary algebraic number `α ∈ ℂ_alg`.
-    The simple root *itself* is the algebraic number — there is no
-    coefficient data. `p` is `α`'s minimal polynomial in canonical form
-    (primitive, positive leading coefficient, irreducible) and `x`
-    identifies which complex root of `p` is `α`.
-
-    Decidable equality is structural: two `AlgebraicNumber` values are
-    equal iff `(p₁, x₁) = (p₂, x₂)`. This is genuinely canonical
-    because `α`'s minimal polynomial is unique up to associates,
-    normalised here to primitive + positive leading coefficient. -/
+/-- Canonical representation of an algebraic number `α ∈ ℂ`.
+    `p` is the minimal polynomial of `α` in canonical form (primitive,
+    positive leading coefficient, irreducible), `x` identifies which
+    complex root of `p` is `α`, and `rep` is a working isolation of
+    that root, kept at separation precision so that equality tests
+    need no further refinement. -/
 structure AlgebraicNumber where
   p      : ZPoly
   prim   : Hex.ZPoly.Primitive p
   pos_lc : 0 < p.leadingCoeff
-  irred  : Hex.ZPoly.Irreducible p
+  irred  : Hex.ZPoly.IsIrreducible p
   x      : SimpleRoot p
+  rep    : RefinedIsolation p
+  rep_mk : SimpleRoot.mk rep = x
 
 end Hex
 ```
 
-`AlgebraicNumber.x : SimpleRoot p` is a Quotient value; equality of
-`AlgebraicNumber`s reduces to equality of the `(p, x)` pair, both
-decidable via the corresponding `Decidable` instances from `HexPolyZ`
-and `HexRoots`.
+### Equality
+
+The library's equality on `AlgebraicNumber` is `BEq`:
+
+```lean
+instance : BEq AlgebraicNumber where
+  beq a b := a.p == b.p && (h ▸ a.rep).sameRoot b.rep
+  -- when the polynomials are equal, compare the isolations with
+  -- `sameRoot` (transporting along the polynomial equality)
+```
+
+This is a total Boolean test: minimal polynomials in canonical form
+are structurally comparable, and `sameRoot` on `RefinedIsolation`
+values is a single dyadic comparison (both representatives are at
+separation precision by the type). The Mathlib companion proves
+`a == b ↔ a.toComplex = b.toComplex`. Structural `=` on the record is
+finer (it also fixes the representative) and is not the intended
+notion of equality.
+
+```lean
+def AlgebraicNumber.isZero (a : AlgebraicNumber) : Bool :=
+  a.p == X   -- X is the canonical minimal polynomial of 0
+```
 
 ## Conversions between the two types
 
 ```lean
-/-- Embed an `AlgebraicNumber` into its own number field as the basis
-    element α. Trivial: coeffs is the polynomial representing α as a
-    variable (i.e., the polynomial `0 + 1·t`). -/
-def AlgebraicNumber.toNumberField (a : AlgebraicNumber) :
-    NumberField a.p a.x :=
-  { coeffs    := <basis element representing α: coeffs[1] = 1, others = 0>,
-    degree_lt := <follows from a.p.degree ≥ 1, by `irred.not_unit`> }
+/-- Embed an `AlgebraicNumber` into its own field. For `deg p ≥ 2` the
+    element α is represented by the polynomial `t` (degree 1, which is
+    then `< deg p`). For `deg p = 1` the value is the rational
+    `−p₀/p₁`, represented by a constant. The two cases are why this is
+    not simply `coeffs := t`. -/
+def AlgebraicNumber.toQAdjoin (a : AlgebraicNumber) : QAdjoin a.p a.x := …
 
-/-- Project a `NumberField` element down to an `AlgebraicNumber`,
-    computing its actual minimal polynomial and the corresponding
-    SimpleRoot. -/
-def NumberField.toAlgebraicNumber (a : NumberField p x) : AlgebraicNumber := ...
+/-- Project a `QAdjoin` element to canonical form, computing its
+    minimal polynomial and the matching `SimpleRoot`. Requires `p`
+    irreducible: on a reducible `p`, the multiplication operator on
+    `ℚ[t]/(p)` sees every factor of `p`, and its minimal polynomial is
+    not the minimal polynomial of the value at α. `none` only when a
+    root-isolation certificate fails to appear by its depth bound
+    (see hex-roots.md), which the companion proves impossible. -/
+def QAdjoin.toAlgebraicNumber? [Hex.ZPoly.IsIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) : Option AlgebraicNumber
+
+/-- Total form; see "Totalisation" below. -/
+def QAdjoin.toAlgebraicNumber [Hex.ZPoly.IsIrreducible p]
+    (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) : AlgebraicNumber :=
+  (a.toAlgebraicNumber? rep h).getD
+    (panicWith 0 "toAlgebraicNumber: certification failed")
 ```
 
-`toAlgebraicNumber` is the substantive operation:
+`toAlgebraicNumber?` is the substantive operation:
 
-1. Compute the multiplication-by-`a` operator on the `ℚ`-vector space
-   `NumberField p x` (a `(deg p) × (deg p)` matrix over `ℚ`).
-2. Compute its minimal polynomial via standard linear algebra (the
-   first `ℚ`-linear dependence among `{1, a, a², …, a^(deg p)}`).
-3. The result `m(t)` is the minimal polynomial of `a`'s value over
-   `ℚ` — a polynomial of degree dividing `deg p`.
-4. Take primitive part, normalise leading coefficient to positive.
-5. Identify the corresponding `SimpleRoot m`: numerically evaluate
-   `a.approx prec` for sufficient `prec` to get a complex disc
-   containing `a`'s value; isolate roots of `m` via
-   `HexRoots.isolate`; find the `SimpleRoot m` whose disc contains
-   `a`'s numerical value.
-6. Return `AlgebraicNumber { p := m, prim, pos_lc, irred, x }`.
+1. Form the multiplication-by-`a` operator on the ℚ-vector space
+   `ℚ[t]/(p)`, a `(deg p) × (deg p)` matrix over ℚ (`hex-matrix`).
+2. Compute its minimal polynomial: the first ℚ-linear dependence
+   among `{1, a, a², …, a^(deg p)}`, found by row reduction
+   (`hex-row-reduce`). Because `p` is irreducible, `ℚ[t]/(p)` is a
+   field, so this is the minimal polynomial of the *value* of `a` at
+   α, of degree dividing `deg p`.
+3. Clear denominators; take the primitive part; make the leading
+   coefficient positive. Call the result `m`.
+4. Certify `isIrreducible m` (true by construction, but the runtime
+   check is what produces the proof field).
+5. Identify the matching root of `m`: approximate `a`'s value from
+   `rep` (evaluate `coeffs` at the isolation's disc), isolate the
+   roots of `m` with `HexRoots.isolate`, refine until exactly one
+   isolation's disc meets the approximation ball, and take that one
+   as `rep`/`x` of the result.
 
-## `NumberField p x` operations
+## `QAdjoin p x` operations
 
-Pure ring operations don't need irreducibility:
+The ring operations need no irreducibility:
 
 ```lean
-instance : Zero (NumberField p x) := ⟨{coeffs := 0, degree_lt := …}⟩
-instance : One (NumberField p x) := ⟨{coeffs := 1, degree_lt := …}⟩
-instance : Add (NumberField p x) := ⟨fun a b => ⟨a.coeffs + b.coeffs, …⟩⟩
-instance : Mul (NumberField p x) := ⟨fun a b => ⟨(a.coeffs * b.coeffs) % p, …⟩⟩
-instance : Neg (NumberField p x) := ⟨fun a => ⟨-a.coeffs, …⟩⟩
--- and Sub, scalar multiplication by Int / Rat, etc.
+instance : Zero (QAdjoin p x) := ⟨{coeffs := 0, degree_lt := …}⟩
+instance : One (QAdjoin p x) := …   -- constant 1; needs deg p ≥ 1,
+                                    -- which follows from x
+instance : Add (QAdjoin p x) := ⟨fun a b => ⟨a.coeffs + b.coeffs, …⟩⟩
+instance : Mul (QAdjoin p x) :=
+  ⟨fun a b => ⟨(a.coeffs * b.coeffs) % (p.map Rat.cast), …⟩⟩
+-- and Neg, Sub, scalar multiplication by Int / Rat
 ```
 
-Field operations require `[Hex.ZPoly.Irreducible p]`:
+(`p` is cast to `DensePoly Rat` before the `%`. The reduction is
+Euclidean division over ℚ from `HexPoly`.)
+
+The field operations take the irreducibility instance:
 
 ```lean
-instance [Hex.ZPoly.Irreducible p] : Inv (NumberField p x) where
-  inv a := ...   -- via extended GCD on a.coeffs and p
+instance [Hex.ZPoly.IsIrreducible p] : Inv (QAdjoin p x) where
+  inv a := …   -- extended GCD of a.coeffs and p over ℚ (HexPoly.xgcd)
 
-instance [Hex.ZPoly.Irreducible p] : Field (NumberField p x) := ...
+instance [Hex.ZPoly.IsIrreducible p] : Field (QAdjoin p x) := …
 ```
 
-Users with a specific irreducibility proof `h : Hex.ZPoly.Irreducible
-myPoly` register it once via `haveI := h`, and `x⁻¹` notation works on
-subsequent `NumberField myPoly y` values. Discharging the instance by
-`decide` requires the `Decidable (Hex.ZPoly.Irreducible f)` instance,
-which is Mathlib-grade (it is backed by `Hex.ZPoly.isIrreducible_iff`,
-equivalent to full `factor` correctness) and so lives in
-`hex-berlekamp-zassenhaus-mathlib`. The `decide` shortcut is therefore
-available only when that bridge is imported — i.e. in
-`HexNumberFieldMathlib`, not in this Mathlib-free library. Here the
-instance must be supplied as a threaded `[Hex.ZPoly.Irreducible p]`
-argument.
+The `Field` instance carries real proof obligations in this
+Mathlib-free library: the ring axioms for arithmetic mod `p`, and
+`mul_inv_cancel`, which needs "gcd of `a.coeffs` and `p` is a unit
+when `p` is irreducible over ℚ and `a ≠ 0`". The precedent is
+`hex-gfq-field`, which proves the same shape of facts for
+`F_p[x]/(f)` without Mathlib. Budget comparable effort here.
 
-Numerical evaluation uses the threading pattern from `hex-roots.md`:
+Numerical evaluation threads the isolation explicitly (the threading
+pattern of hex-roots.md):
 
 ```lean
-/-- Numerical evaluation of `a : NumberField p x` to precision `prec`.
-    Returns a refreshed `NumberField p x` (with the SimpleRoot's internal
-    representative refined for cheap subsequent calls) alongside a complex
-    disc guaranteed to contain `a`'s true value. -/
-def NumberField.approx (a : NumberField p x) (prec : Nat) :
-    NumberField p x × DyadicComplexBall
+/-- Evaluate `a` to a complex ball. Refines the given isolation as
+    needed and returns it, so the caller can pass the refined value to
+    the next call. Evaluation is exact at the isolation's centre
+    (rational arithmetic), with a derivative bound for the radius,
+    rounded outward to dyadics. Total, and *always sound*: if
+    refinement stalls (hex-roots.md), the fallback result is the
+    input isolation with the ball derived from its current disc,
+    which still contains the true value, just wider than `2^{−prec}`.
+    The radius meets `2^{−prec}` whenever refinement succeeded, which
+    the companion proves is always. -/
+def QAdjoin.approx (a : QAdjoin p x) (rep : RefinedIsolation p)
+    (h : SimpleRoot.mk rep = x) (prec : Int) :
+    RefinedIsolation p × DyadicComplexBall
 ```
-
-The returned `NumberField` is propositionally equal to the input `a`
-but has its underlying `x : SimpleRoot p` refined. Callers should
-store/forward the returned value to keep subsequent `approx` calls on
-the cheap path.
 
 ## `AlgebraicNumber` operations
 
-All operations follow the **threading pattern**: each returns a
-refreshed `AlgebraicNumber` whose internal `SimpleRoot`
-representative has been refined to `mahlerPrec p + canonOverhead p`
-for the result's polynomial `p`. Callers store/forward the returned
-values.
+### Totalisation
 
-### `commonField` (public API)
+The user-facing arithmetic (`add`, `mul`, `sub`, `neg`, `inv`,
+`toAlgebraicNumber`) is **total**. Internally, each operation has an
+`Option`-valued form (`add?`, and so on) whose `none` branch means
+"a certificate failed to appear by an explicit, input-computable
+bound". The public form pins that branch to the junk value `0`:
 
 ```lean
-/-- Find a number field containing both `α` and `β`. Returns:
-    - a defining polynomial `r : ZPoly` (irreducible primitive)
-    - a SimpleRoot `r` identifying the primitive element γ
-    - α and β embedded as `NumberField r γ` elements. -/
-def AlgebraicNumber.commonField (α β : AlgebraicNumber) :
-    Σ' (r : ZPoly) (γ : SimpleRoot r),
-        Hex.ZPoly.Irreducible r ×
-        NumberField r γ × NumberField r γ
+/-- Print `msg` and return `v` (compiled code); definitionally `v`
+    (for reasoning). Lives in HexNumberField/Basic.lean; can move to
+    HexBasic if other libraries want it. -/
+@[never_extract] def Hex.panicWith (v : α) (msg : String) : α := …
+
+instance : Inhabited AlgebraicNumber := ⟨0⟩
+-- `0 : AlgebraicNumber` is the value with `p = X`; its invariant
+-- proofs reduce cheaply (the degree-1 fast path in isIrreducible).
+
+def AlgebraicNumber.add (α β : AlgebraicNumber) : AlgebraicNumber :=
+  (α.add? β).getD (panicWith 0 "AlgebraicNumber.add: certification failed")
+```
+
+The junk branch is loud, not silent: `panicWith` prints at runtime
+(this matters because `0` is also a legitimate output, of
+`α + (−α)` for example). Logically it is just the constant `0`, so
+the companion reasons about it directly: it proves soundness of the
+`?`-forms first, then that each `?`-form never returns `none`
+(certificates appear within the stated bounds), and the composition
+gives unconditional correctness of the total forms. Every internal
+loop has a computable bound: root refinement is bounded by
+`separationDepth` (hex-roots.md), and the two bounds specific to this
+library are named below.
+
+`neg`, `isZero`, and `==` are total with no junk branch.
+
+### `commonField?`
+
+```lean
+structure CommonField (α β : AlgebraicNumber) where
+  r     : ZPoly
+  irred : Hex.ZPoly.IsIrreducible r
+  γ     : SimpleRoot r
+  γrep  : RefinedIsolation r
+  γ_mk  : SimpleRoot.mk γrep = γ
+  αIn   : QAdjoin r γ
+  βIn   : QAdjoin r γ
+
+/-- Find one field containing both α and β: a defining polynomial `r`
+    with a distinguished root γ = α + c·β, and α, β expressed in the
+    basis `{1, γ, …, γ^(deg r − 1)}`. Algorithm-layer function, so it
+    keeps the informative `Option` signature; the arithmetic wrappers
+    absorb it. -/
+def AlgebraicNumber.commonField? (α β : AlgebraicNumber) :
+    Option (CommonField α β)
 ```
 
 Implementation:
 
-1. **Resultant.** Compute `r₀(t) := resultant_y(α.p(y), β.p(t − c·y))`
-   for a small integer shift `c` (default `c = 1`; on degenerate
-   cases — when `r₀` happens to have repeated factors crossing the
-   `α + β` value — try `c = 2`, `c = 3`, etc.).
+1. **Resultant.** Compute `r₀(t) := resultant_y(β.p(y), α.p(t − c·y))`
+   for a small integer shift `c` (default `c = 1`). The roots of `r₀`
+   are exactly the values `αᵢ + c·βⱼ` over the conjugates, so
+   `γ = α + c·β` is among them.
 2. **Factor.** `(HexBerlekampZassenhaus.factor r₀).factors` is an
-   `Array (ZPoly × Nat)` of `(irreducible primitive polynomial,
-   multiplicity)` pairs. The minimal polynomial of `α + c·β` is one
-   of these polynomial factors. (We ignore the `Factorization`'s
-   `scalar` field — the resultant's content/sign is irrelevant for
-   choosing the factor that vanishes at `α + c·β`.)
-3. **Numerical disambiguation.** Use `α.x.refine` then `α.x.out prec`
-   and similarly for β to get high-precision dyadic centres, sum to
-   get an approximation of `α + c·β`, evaluate each polynomial
-   factor at the approximation; the unique factor where the value
-   is "small" (within the propagated dyadic error) is the minimal
-   polynomial of `α + c·β`. Refine `prec` until the smallest factor
-   is unambiguous. Multiplicity > 1 indicates a degenerate shift `c`
-   — restart with a different `c`.
-4. **Identify the SimpleRoot.** Run `HexRoots.isolate` on the chosen
-   factor; locate the `SimpleRoot` whose disc contains the numerical
-   approximation.
-5. **Build the embeddings.** Express `α` and `β` in the `ℚ`-basis
-   `{1, γ, γ², …, γ^(deg r − 1)}` where `γ = α + c·β`. Standard
-   linear algebra: solve a `(deg r) × (deg r)` linear system. The
-   results are `NumberField r γ` values for `α` and `β`.
+   `Array (ZPoly × Nat)` of (irreducible primitive polynomial,
+   multiplicity) pairs. The minimal polynomial of `γ` is one of the
+   polynomials. (The `Factorization.scalar` field is ignored: the
+   resultant's content and sign do not affect which factor vanishes
+   at `γ`.)
+3. **Numerical disambiguation.** Approximate `γ` from `α.rep` and
+   `β.rep` (refining as needed), evaluate each factor on the
+   approximation ball, and shrink the ball until exactly one factor's
+   value straddles zero. The precision needed is bounded a priori.
+   Suppose `m` is the (unknown) minimal polynomial of `γ` among the
+   factors and `g` any other factor. Distinct irreducible factors are
+   coprime, so `Res(m, g)` is a nonzero integer, `|Res(m, g)| ≥ 1`,
+   and the root-product formula
+   `Res(m, g) = lc(m)^{deg g} · ∏_{m(γᵢ)=0} g(γᵢ)` gives
 
-### Arithmetic on `AlgebraicNumber`
+   ```
+   |g(γ)| ≥ ( ‖g‖₁^{deg m − 1} · M̄(m)^{deg g} )⁻¹,
+   M̄(m) := √(deg m + 1) · ‖m‖∞
+   ```
+
+   after bounding each other conjugate's contribution by
+   `|g(γᵢ)| ≤ ‖g‖₁ · max(1, |γᵢ|)^{deg g}` and
+   `∏ max(1, |γᵢ|) = M(m)/|lc m| ≤ M̄(m)/|lc m|` (Landau). All
+   quantities are read off the factor list, so
+
+   ```
+   disambiguationPrec := guard +
+     max over ordered pairs (m, g) of distinct factors of
+       ⌈log₂( ‖g‖₁^{deg m − 1} · M̄(m)^{deg g} )⌉
+   ```
+
+   with a small pinned `guard` for the ball-evaluation rounding. The
+   loop refines to that depth and no further: at that precision
+   exactly one factor's ball straddles zero.
+   If the chosen factor has multiplicity `> 1` in `r₀`, the shift is
+   degenerate (two conjugate pairs collide at the value `γ`): restart
+   with `c = 2`, then `c = 3`, and so on. At most
+   `maxShift α β := (deg α.p · deg β.p)²` shifts can be degenerate
+   (one per collision of conjugate pairs), so trying `maxShift + 1`
+   shifts is a bounded loop.
+4. **Identify the root.** Run `HexRoots.isolate` on the chosen factor
+   and locate the isolation whose disc meets the approximation ball.
+5. **Change of basis.** Express `α` and `β` in the basis
+   `{1, γ, γ², …, γ^(deg r − 1)}` by solving a
+   `(deg r) × (deg r)` ℚ-linear system (`hex-row-reduce`; fraction-
+   free elimination as in `hex-bareiss` is the expected
+   implementation).
+
+The multiplicity test in step 3 is exactly the classical
+primitive-element condition: `γ = α + c·β` fails to generate
+`ℚ(α, β)` only when some other conjugate pair gives the same value,
+which forces the chosen factor to appear squared in `r₀`.
+
+### Arithmetic
 
 ```lean
+def AlgebraicNumber.add? (α β : AlgebraicNumber) : Option AlgebraicNumber := do
+  let cf ← α.commonField? β
+  haveI := cf.irred
+  (cf.αIn + cf.βIn).toAlgebraicNumber? cf.γrep cf.γ_mk
+
 def AlgebraicNumber.add (α β : AlgebraicNumber) : AlgebraicNumber :=
-  let ⟨r, γ, _, αIn, βIn⟩ := commonField α β
-  haveI : Hex.ZPoly.Irreducible r := _   -- from commonField's third component
-  (αIn + βIn).toAlgebraicNumber
+  (α.add? β).getD (panicWith 0 "AlgebraicNumber.add: certification failed")
 ```
 
-(The conversion back to canonical `AlgebraicNumber` form via
-`toAlgebraicNumber` performs the field minimisation: the result might
-live in a smaller field than `r`, e.g., `α + (−α) = 0` lives in `ℚ`
-even though `α` and `−α` were in `ℚ(α)`.)
+The conversion back through `toAlgebraicNumber?` performs the field
+minimisation: the result may generate a smaller field than `ℚ(γ)`.
+For example `α + (−α) = 0` lands in ℚ even though both inputs live in
+`ℚ(α)`.
 
-`mul`, `sub`, `neg`, scalar action, and `inv` (under `α ≠ 0`) follow
-the same pattern. `inv` has a special-case implementation for
-efficiency: `1/α` has minimal polynomial obtained by reversing the
-coefficient sequence of `α.p` (then re-canonicalising), avoiding
-the resultant computation.
+`mul?`/`mul` and `sub?`/`sub` follow the same pattern. `neg` is total
+outright: the minimal polynomial of `−α` is `p(−t)` re-canonicalised,
+and the isolation is reflected exactly. `inv?` avoids the resultant:
+the minimal polynomial of `1/α` is `p` with its coefficient order
+reversed, re-canonicalised. The matching isolation is obtained by
+transforming `rep`'s disc under `z ↦ 1/z` with `Dyadic.invAtPrec` and
+re-certifying the witness; the re-certification is the one step of
+`inv?` that can decline, and `inv` pins it with `panicWith` like the
+others. On zero input, `inv 0 = 0` by definition (Mathlib's
+convention for division), so `inv` takes no hypothesis; the
+correctness theorem carries `¬ α.isZero`.
 
-```lean
-def AlgebraicNumber.isZero (a : AlgebraicNumber) : Bool :=
-  decide (a.p == X)   -- the polynomial whose only root is 0
-```
+## File organisation
 
-Decidable equality is structural on `(p, x)`, both with decidable
-equality from `HexPolyZ` and `HexRoots`.
+- `HexNumberField/Basic.lean`: `QAdjoin`, `AlgebraicNumber`,
+  constructors, accessors, `BEq`, `isZero`, `panicWith`, the
+  `Inhabited` instance.
+- `HexNumberField/Operations.lean`: `QAdjoin` arithmetic and the
+  `Field` instance.
+- `HexNumberField/Approx.lean`: `QAdjoin.approx`.
+- `HexNumberField/Convert.lean`: `toQAdjoin`,
+  `toAlgebraicNumber?`, `toAlgebraicNumber`.
+- `HexNumberField/CommonField.lean`: `commonField?`,
+  `disambiguationPrec`, `maxShift`.
+- `HexNumberField/AlgOps.lean`: `AlgebraicNumber` arithmetic
+  (`?`-forms and their total wrappers).
+- `conformance/HexNumberField/{Conformance,EmitFixtures}.lean` and
+  `bench/HexNumberField/Bench.lean`: conformance and bench drivers in
+  the shared sub-projects.
 
-## Layered file organisation
-
-- `HexNumberField/Basic.lean` — types `NumberField`,
-  `AlgebraicNumber`, basic constructors, accessors, decidable
-  equality.
-- `HexNumberField/Operations.lean` — `NumberField p x` arithmetic
-  (Add, Sub, Mul, Neg, scalar action, Inv with
-  `[Hex.ZPoly.Irreducible p]`). Field instance.
-- `HexNumberField/Approx.lean` — `NumberField.approx` via the
-  threading pattern (`x.refine` then `x.out`).
-- `HexNumberField/Convert.lean` — `AlgebraicNumber.toNumberField`
-  (trivial) and `NumberField.toAlgebraicNumber` (linear algebra +
-  minimal polynomial computation + SimpleRoot identification).
-- `HexNumberField/CommonField.lean` — public `commonField` via
-  resultant + factor + numerical disambiguation + linear algebra.
-- `HexNumberField/AlgOps.lean` — `AlgebraicNumber` arithmetic
-  (`add`, `mul`, `sub`, `neg`, `inv`, `isZero`) via `commonField` +
-  `NumberField.toAlgebraicNumber`.
-- `HexNumberField/Conformance.lean` — `core` fixtures.
-- `HexNumberField/Bench.lean`, `HexNumberField/EmitFixtures.lean` —
-  standard testing trio.
+The `isIrreducible` addition lands in `hex-berlekamp-zassenhaus`
+(one Bool-valued definition next to `factor`), not here.
 
 ## Conformance fixtures
 
-Per `SPEC/testing.md`:
+Per [SPEC/testing.md](../testing.md):
 
 - *core* (Lean-only):
-  - `√2 + √2 = 2·√2`: build `α := AlgebraicNumber` for the positive
-    root of `X² − 2`, compute `α + α`, verify the result has minimal
-    polynomial `X² − 8` with the matching `SimpleRoot`.
-  - `√2 · √2 = 2`: same setup, multiplication, verify result is the
-    `AlgebraicNumber` for `X − 2` (i.e., the integer 2).
-  - `√2 + (−√2) = 0`: verify field minimisation kicks in (result is
-    in `ℚ` not in `ℚ(√2)`).
-  - `(1 + √2) · (1 − √2) = −1`: cross-check.
-  - Cyclotomic check: `ζ_5 + ζ_5⁻¹ = (−1 + √5)/2`.
-  - `NumberField` ring axioms on a few committed elements of `ℚ(√2)`,
-    `ℚ(ζ_5)`.
-- *ci*: 30 random small-degree `(α, β, op)` triples with deterministic
-  seed; oracle from SageMath.
-- *local*: high-degree number-field arithmetic for performance
-  validation.
+  - `√2 + √2 = 2·√2`: build `α : AlgebraicNumber` for the positive
+    root of `X² − 2`, compute `α + α`, check the result's minimal
+    polynomial is `X² − 8` and `sameRoot` matches the positive root.
+  - `√2 · √2 = 2`: the result `==` the `AlgebraicNumber` of `X − 2`.
+  - `√2 + (−√2) = 0`: checks field minimisation (the result lies in
+    ℚ, not `ℚ(√2)`).
+  - `(1 + √2) · (1 − √2) = −1`.
+  - Cyclotomic check: `ζ₅ + ζ₅⁻¹ = (−1 + √5)/2`.
+  - `QAdjoin` ring identities on committed elements of `ℚ(√2)` and
+    `ℚ(ζ₅)`.
+- *ci*: 30 random small-degree `(α, β, op)` triples with a
+  deterministic seed; oracle from SageMath.
+- *local*: higher-degree arithmetic, timed against the complexity
+  contract.
 
 External oracles: SageMath
-(`R.<x> = ZZ[]; K.<a> = NumberField(...); ...`), python-flint.
+(`R.<x> = ZZ[]; K.<a> = NumberField(...)`), python-flint.
 
 ## Complexity contract
 
-Per-operation costs (with `n = max(deg α.p, deg β.p)`,
-`H = max(‖α.p‖∞, ‖β.p‖∞)`):
+Per-operation costs, with `n = max(deg α.p, deg β.p)` and
+`H = max(‖α.p‖∞, ‖β.p‖∞)`:
 
-- `α + β`, `α · β`: dominated by resultant + factor.
-  - Resultant: `O(n²)` polynomial-pseudodivision steps.
-  - Factor (Berlekamp–Zassenhaus on a polynomial of degree ≤ `n²` and
-    coefficient size ≤ exponential in `n` and `H`): per the existing
-    BZ complexity contract, polynomial in input size.
+- `α + β`, `α · β`: dominated by resultant + factoring.
+  - Resultant over `R = ZPoly`: `O(n)` pseudo-division steps and
+    `O(n²)` coefficient operations, where each coefficient is itself
+    a polynomial in `t` (see the hex-resultant complexity contract;
+    `deg r₀ ≤ n²`).
+  - Factoring (`hex-berlekamp-zassenhaus` on a polynomial of degree
+    `≤ n²`): per the existing BZ complexity contract.
   - Numerical disambiguation: bounded by `mahlerPrec` of the chosen
-    factor, polynomial in factor's data.
-  - Linear algebra in `commonField`: `O(n³)` over `ℚ` with
-    Bareiss-style fraction-free elimination.
-- `1/α`: `O(deg α.p)` for the coefficient reversal + canonicalisation.
-- `α + (rational q)`: `O(deg α.p)` (no field change).
-- `isZero`, equality: structural, `O(deg p)`.
+    factor.
+  - Linear algebra: `O(n³)` ℚ-operations with fraction-free
+    elimination.
+- `1/α`: `O(deg α.p)` for the coefficient reversal, plus one disc
+  transformation and witness re-check (one `O(n²)`-operation
+  certification; see hex-roots.md).
+- `α + q` for rational `q`: `O(deg α.p)`; no field change.
+- `isZero`, `==`: one polynomial comparison plus one dyadic
+  comparison.
 
-The threading pattern keeps `out` calls on the cheap path: per
-operation, one `refine` call (`O(refinement work to mahlerPrec p)`)
-amortises across all subsequent `out` calls in that operation and
-downstream callers.
+Each operation refines root isolations once and stores the refined
+representatives in its result, so repeated operations on the same
+numbers do not repeat refinement work.
 
 ## Time budgets (Phase 4 validation)
 
-Rough estimates, refined against SageMath comparisons:
+Rough estimates, to be measured against SageMath:
 
-- `α + β` for `α, β` of degrees ≤ 5: < 1 second.
-- Arithmetic in a fixed degree-10 number field: < 100ms per op.
-- `α + β` for `α, β` of degrees ≤ 20: < 30 seconds.
+- `α + β` for `α, β` of degree ≤ 5: under 1 second.
+- Arithmetic in a fixed degree-10 field: under 100 ms per operation.
+- `α + β` for `α, β` of degree ≤ 20: under 30 seconds.
 
 ## References
 
 - Cohen, H. *A Course in Computational Algebraic Number Theory.*
-  Springer, 1993. Standard reference for everything in this library.
-  Especially §3 (algebraic numbers + number fields), §4 (algorithms
-  on number fields).
+  Springer, 1993. The standard reference: especially §4.1-4.2
+  (algebraic numbers, resultant-based arithmetic) and §4.5 (number
+  field elements).
 - Belabas, K. *Topics in computational algebraic number theory.*
-  J. Théorie des Nombres de Bordeaux 16 (2004), 19–63. Survey
-  covering the algorithms used here.
+  J. Théorie des Nombres de Bordeaux 16 (2004), 19-63. A survey of
+  the algorithms used here.
 - Bostan, A.; Flajolet, P.; Salvy, B.; Schost, É. *Fast computation
-  of special resultants.* JSC 41 (2006), 1–29. Background on the
-  resultant computations used in `commonField`.
+  of special resultants.* JSC 41 (2006), 1-29. Faster alternatives
+  for the `commonField` resultant, if it becomes the bottleneck.

--- a/SPEC/Libraries/hex-resultant-mathlib.md
+++ b/SPEC/Libraries/hex-resultant-mathlib.md
@@ -1,68 +1,73 @@
 # hex-resultant-mathlib (depends on hex-resultant + hex-poly-mathlib + Mathlib)
 
-Mathlib bridge for `hex-resultant`. **Scope-limited**: proves only the
-"resultant zero iff common root" property, not the full equivalence
-between `Hex.DensePoly.resultant` and `Polynomial.resultant`.
+Mathlib companion for `hex-resultant`. **Scope-limited**: proves only
+the "resultant zero iff common root" property, not the equality of
+`Hex.DensePoly.resultant` with `Polynomial.resultant`.
 
 ## Why scope-limited
 
-The full `Hex.resultant f g = Polynomial.resultant (toPolynomial f)
-(toPolynomial g)` would require formalising the classical "subresultant
-chain ↔ Sylvester-matrix determinant" theorem (~1500–2000 lines of
-substantive computer-algebra theory in Mathlib): pseudo-remainders ↔
-elementary row operations on Sylvester with specific scale factors,
-subresultants are leading coefficients of reduced Sylvester
-submatrices, resultant = product over the chain with sign corrections.
+The full `Hex.DensePoly.resultant f g = Polynomial.resultant
+(toPolynomial f) (toPolynomial g)` would require formalising the
+classical correspondence between the subresultant chain and the
+Sylvester-matrix determinant, roughly 1500-2000 lines of substantive
+computer algebra in Mathlib: pseudo-remainder steps as row operations
+on the Sylvester matrix with specific scale factors, subresultants as
+leading coefficients of reduced Sylvester submatrices, and the
+resultant as a product over the chain with sign corrections.
 
-We don't need it. Downstream consumers (specifically
-`hex-number-field-mathlib`'s correctness theorems for
-`AlgebraicNumber` arithmetic) only need the **fundamental property**:
-"subresultant of two polynomials is zero iff they share a common root
-in the algebraic closure". That property suffices for proofs like
-"`α + β` is a root of `resultant_y(p_α(y), p_β(t − y))`" (which is the
-core ingredient of `commonField` correctness).
+We don't need it. The downstream consumer
+(`hex-number-field-mathlib`'s correctness theorems for
+`AlgebraicNumber` arithmetic) only needs the property "the resultant
+of two polynomials is zero iff they share a common root in the
+algebraic closure". That property suffices for proofs like "`α + c·β`
+is a root of `resultant_y(β.p(y), α.p(t − c·y))`", the key ingredient
+of `commonField` correctness.
 
-The narrower theorem can be proved via subresultant *chain analysis*
-without going through the Sylvester-determinant connection at all,
-in roughly 600 lines.
+The narrower theorem can be proved by analysing the pseudo-remainder
+chain directly, without the Sylvester-determinant connection, in
+roughly 600 lines.
 
 ## What we cite from Mathlib (no work)
 
 - `Polynomial`, `Polynomial.eval`, polynomial arithmetic.
-- `Polynomial.modByMonic` and friends — Mathlib has the monic case of
+- `Polynomial.modByMonic` and friends. Mathlib has the monic case of
   polynomial division. We define the non-monic pseudo-remainder on
   top.
-- `Polynomial.IsAlgClosed`, `algClosure`, polynomial roots over the
-  algebraic closure (`Mathlib.FieldTheory.IsAlgClosed.Basic` and
-  related).
-- `Polynomial.gcd_eq_zero_iff` and gcd theory over polynomial rings —
-  for the connection "gcd is constant iff no common roots".
+- `IsAlgClosed` and polynomial roots over ℂ
+  (`Mathlib.FieldTheory.IsAlgClosed.Basic`,
+  `Mathlib.Analysis.Complex.Polynomial.Basic`).
+- gcd theory over polynomial rings, for the connection "gcd is
+  constant iff no common roots" (for example
+  `EuclideanDomain.gcd_eq_zero_iff` and the `EuclideanDomain.gcd`
+  API for `ℚ[X]`).
 
 ## What we explicitly do NOT prove
 
 - `Hex.DensePoly.resultant f g = Polynomial.resultant (toPolynomial f)
-  (toPolynomial g)` — full resultant equality. Reserved for a future
-  Mathlib contribution that formalises the subresultant ↔ Sylvester
-  bridge upstream.
+  (toPolynomial g)`: full resultant equality. Reserved for a future
+  Mathlib contribution formalising the subresultant-Sylvester
+  correspondence.
 - The root-product formula `Hex.resultant f g = lc(f)^(deg g) · ∏
   g.eval αᵢ`. Requires splitting-field machinery; not needed for our
   use cases.
 - Discriminant equality `Hex.disc f = Polynomial.discr (toPolynomial
-  f)`. Provable from a stronger bridge but not from the narrow
-  property. Downstream uses (HexRootsMathlib's Mahler-bound
-  development) need `|disc p| ≥ 1` for nonzero squarefree `p`, which
-  follows from "disc is a nonzero integer when `p` is squarefree" via
-  the common-root path: `disc p = res(p, p') ≠ 0 ↔ p, p' have no
-  common roots ↔ p is squarefree`.
+  f)`. Provable from the full equality but not from the narrow
+  property.
 
 ## Theorem chain (~600 lines total)
+
+Stated for `f, g : ZPoly` with roots taken in ℂ, which is all the
+downstream consumers need. (The chain analysis itself works over any
+UFD with roots in the algebraic closure of its fraction field, but we
+do not state that generality.)
 
 1. **Pseudo-division correctness on `Polynomial`** (~100 lines).
    Define `Polynomial.pseudoRem (f g : Polynomial R) : Polynomial R`
    for any commutative ring `R`, satisfying
    `lc(g)^(deg f − deg g + 1) · f = q · g + pseudoRem f g`
-   for some `q : Polynomial R`, with `deg(pseudoRem f g) < deg g`.
-   Mathlib has the monic case; non-monic is straightforward induction.
+   for some `q : Polynomial R`, with `deg (pseudoRem f g) < deg g`.
+   Mathlib has the monic case, and the non-monic case is a
+   straightforward induction.
 
 2. **Subresultant chain construction over `Polynomial`** (~150 lines).
    `F₀ := f`, `F₁ := g`, `F_{k+1} := pseudoRem F_{k-1} F_k` while
@@ -70,46 +75,44 @@ in roughly 600 lines.
 
 3. **Pseudo-division preserves common roots forward** (~30 lines).
    If `α` is a common root of `F_{k-1}` and `F_k`, then `α` is a
-   root of `F_{k+1}`. Trivial: evaluate the pseudo-division
-   identity at `α`; the LHS vanishes (as `F_{k-1}(α) = 0`), so
-   `F_{k+1}(α) = -q(α) · F_k(α) = 0`.
+   root of `F_{k+1}`. Evaluate the pseudo-division identity at `α`:
+   the left side vanishes, so `F_{k+1}(α) = -q(α) · F_k(α) = 0`.
 
 4. **Pseudo-division preserves common roots backward** (~50 lines).
-   If `α` is a root of `F_k` and `F_{k+1}` (and `lc(F_k) ≠ 0` as a
-   constant in `R`, holding in the algebraic closure), then `α` is a
-   root of `F_{k-1}`. From the pseudo-division identity:
-   `lc(F_k)^d · F_{k-1}(α) = 0`, hence `F_{k-1}(α) = 0`.
+   If `α` is a root of `F_k` and `F_{k+1}`, then `α` is a root of
+   `F_{k-1}`. From the pseudo-division identity,
+   `lc(F_k)^d · F_{k-1}(α) = 0`. The leading coefficient `lc(F_k)`
+   is a nonzero integer, hence nonzero in ℂ, so `F_{k-1}(α) = 0`.
 
-5. **Termination behaviour: the chain computes a gcd** (~150 lines).
-   The chain ends with `F_N = 0`; the previous nonzero `F_{N-1}` is
-   `gcd(F₀, F₁) = gcd(f, g)` up to a unit (over the fraction field of
-   `R`). By induction using lemmas 3 and 4, the common roots of `f`
-   and `g` are precisely the roots of `F_{N-1}`.
+5. **The chain computes a gcd** (~150 lines).
+   The chain ends with `F_N = 0`; the last nonzero element `F_{N-1}`
+   is `gcd(f, g)` up to a nonzero rational factor. By induction using
+   items 3 and 4, the common complex roots of `f` and `g` are
+   precisely the roots of `F_{N-1}`.
 
-6. **`Hex.subresultant` value's connection to the chain** (~50 lines).
-   Our `Hex.DensePoly.subresultant f g` returns 0 iff
-   `deg F_{N-1} ≥ 1` (the chain ends with a non-constant element,
-   indicating a non-trivial gcd).
+6. **The `Hex.resultant` value and the chain** (~50 lines).
+   `Hex.DensePoly.resultant f g = 0` iff the chain's last nonzero
+   element has positive degree (a non-trivial gcd).
 
-7. **Hex ↔ Mathlib bridge** (~50 lines).
-   `Hex.DensePoly.subresultant f g = 0 ↔ Polynomial.subresultant
-   (toPolynomial f) (toPolynomial g) = 0` via the `HexPolyMathlib.equiv`
-   ring-equiv: structurally identical algorithms on isomorphic
-   representations. (Note: the Mathlib-side `subresultant` we define
-   in items 1–6 above can also be defined for the Mathlib-free
-   `Hex.DensePoly` path; the structural identity is then immediate.)
+7. **Hex-Mathlib transfer** (~50 lines).
+   The chain built from `Hex.DensePoly` values and the chain built
+   from `Polynomial` values correspond under the `HexPolyMathlib`
+   ring equivalence: the two constructions are structurally identical
+   on isomorphic representations, so the transfer is step-by-step.
 
 8. **Final theorem** (~50 lines):
 
    ```lean
-   theorem Hex.DensePoly.subresultant_zero_iff_common_root
-       (f g : Hex.DensePoly R) [IsAlgClosed (algClosure R)] :
+   theorem Hex.DensePoly.resultant_eq_zero_iff_common_root
+       (f g : ZPoly) (hf : f ≠ 0) (hg : g ≠ 0) :
        Hex.DensePoly.resultant f g = 0
-         ↔ ∃ α : algClosure R, (toPolynomial f).eval α = 0
-                             ∧ (toPolynomial g).eval α = 0
+         ↔ ∃ α : ℂ, (toPolynomial f).aeval α = 0
+                  ∧ (toPolynomial g).aeval α = 0
    ```
 
-   Combine items 5, 6, 7.
+   Combine items 5, 6, 7. The nonzeroness hypotheses rule out the
+   degenerate `resultant 0 g = 0` cases, which have no common-root
+   meaning.
 
 ## Discriminant non-vanishing corollary
 
@@ -119,40 +122,42 @@ theorem Hex.DensePoly.disc_ne_zero_of_squarefree (f : ZPoly)
     Hex.DensePoly.disc f ≠ 0
 ```
 
-Follows from item 8: `disc f = 0 ↔ resultant(f, f') = 0 ↔ f, f' share
+Follows from item 8: `disc f = 0 ↔ resultant f f' = 0 ↔ f, f' share
 a common root ↔ f has a multiple root ↔ ¬ Squarefree f`.
 
-This is what HexRootsMathlib's `mahlerPrec` correctness (item 4 in
-[hex-roots-mathlib.md](hex-roots-mathlib.md)) needs: the bound
-`|disc p| ≥ 1` for squarefree integer `p` follows from `disc p ≠ 0`
-plus `disc p ∈ ℤ`.
+Recorded because it is immediate from item 8 and gives consumers of
+`Hex.disc` the standard squarefreeness criterion. Note that
+`hex-roots-mathlib` does **not** need it: its `mahlerPrec` correctness
+argument uses Mathlib's `Polynomial.discr` throughout and never
+mentions `Hex.disc`.
 
-## Layered file organisation
+## File organisation
 
 ```
 HexResultantMathlib/
-  Basic.lean         — public statements (Hex.subresultant_zero_iff_common_root,
+  Basic.lean         : public statements (resultant_eq_zero_iff_common_root,
                        disc_ne_zero_of_squarefree)
-  Subresultant.lean  — items 1–6 (the core ~500-line chain analysis)
-  Discriminant.lean  — discriminant non-vanishing corollary
-  Conformance.lean   — fixture-based sanity checks of the bridge
+  Subresultant.lean  : items 1-7 (the chain analysis)
+  Discriminant.lean  : the discriminant corollary
 ```
 
-`Subresultant.lean` is the substantive file. It can be designed for
-upstream contribution to Mathlib (subresultant chain definition +
-common-root property), independent of the rest of `hex`.
+`Subresultant.lean` is the substantive file. Items 1-5 mention no
+`Hex` type, so that part can be prepared as a Mathlib contribution
+(subresultant chain definition plus the common-root property)
+independently of the rest of `hex`. The library is verified by
+building it. The conformance fixtures live with `hex-resultant`.
 
 ## Practical staging
 
-`hex-resultant` (computational, just subresultant) lands first in
-Phase 1. `hex-resultant-mathlib` lands in Phase 6 — substantial but
-bounded at ~600 lines, more tractable than the full bridge would be.
+`hex-resultant` (computational) lands first. `hex-resultant-mathlib`
+lands later: substantial but bounded at ~600 lines, far more tractable
+than the full Sylvester correspondence would be.
 
 ## References
 
 - See [hex-resultant.md](hex-resultant.md) for the subresultant
-  references (Brown, Collins, Geddes-Czapor-Labahn, von zur Gathen
+  references (Collins, Brown, Geddes-Czapor-Labahn, von zur Gathen
   and Gerhard).
-- For the common-root property specifically: any standard text on
-  computer algebra. The presentation here is closest to von zur
-  Gathen and Gerhard, *Modern Computer Algebra* (3rd ed. 2013), §6.
+- For the common-root property specifically: von zur Gathen and
+  Gerhard, *Modern Computer Algebra* (3rd ed. 2013), §6 is the
+  closest presentation to the one used here.

--- a/SPEC/Libraries/hex-resultant.md
+++ b/SPEC/Libraries/hex-resultant.md
@@ -1,149 +1,173 @@
 # hex-resultant (polynomial resultant via subresultant chain, depends on hex-poly)
 
 Polynomial resultant and discriminant for `Hex.DensePoly R` over a UFD
-`R` (in particular `ZPoly = DensePoly Int`). Computed via the
-**subresultant pseudo-remainder sequence** (Brown 1971; Collins 1967),
-the standard fraction-free algorithm.
+`R`. Computed via the **subresultant pseudo-remainder sequence**
+(Collins 1967; Brown 1978), the standard fraction-free algorithm.
+
+Two instantiations are used in this project: `R = Int` (that is,
+`ZPoly`), and `R = ZPoly` itself. The second gives bivariate
+resultants: `hex-number-field`'s `commonField` eliminates a variable
+`y` from polynomials whose coefficients are polynomials in `t`.
 
 ## Why subresultants, not Sylvester+Bareiss
 
-A naïve implementation could form the Sylvester matrix and take its
-Bareiss determinant. This works mathematically but is the wrong
-asymptotic regime: `O((n+m)³)` coefficient operations and a quadratic
-blowup in intermediate coefficient bit-length. The subresultant chain
-is `O(n·m)` polynomial-pseudodivision steps with provably-bounded
-intermediate coefficient growth (the "fundamental theorem of
-subresultants") — significantly faster on inputs of practical size.
+A naive implementation could form the `(n+m) × (n+m)` Sylvester matrix
+and take its Bareiss determinant. That costs `O((n+m)³)` coefficient
+operations. The subresultant chain reaches the same value in at most
+`min(n, m)` pseudo-division steps, `O(n·m)` coefficient operations
+total. Intermediate coefficients in both algorithms are (up to sign)
+minors of the Sylvester matrix, so both have the same well-controlled
+coefficient growth: bit-length `O((n+m) · (log(n+m) + log ‖f‖∞ +
+log ‖g‖∞))` over `R = Int`. The saving is the operation count, a
+factor of roughly `n+m`.
 
-It also keeps the dependency surface minimal: subresultants reduce to
-iterated polynomial pseudo-division, which lives in `HexPoly` already.
-No matrix dep, depth 1.
+It also keeps the dependency surface minimal. The algorithm is
+iterated polynomial pseudo-division plus scale-factor bookkeeping.
+Pseudo-division stays inside `R` and is defined in this library
+(`HexPoly` has only Euclidean division, which needs `Div` on the
+coefficients). No matrix dependency, depth 1.
 
 ## Contents
 
 ```lean
 namespace Hex.DensePoly
 
-/-- Polynomial pseudo-division: for `f, g : DensePoly R` with
-    `g.degree ≤ f.degree`, returns `(quotient, pseudoRemainder)` where
-    `lc(g)^(deg f - deg g + 1) · f = quotient * g + pseudoRemainder`
-    and `pseudoRemainder.degree < g.degree`. No division required:
-    pre-multiplication by `lc(g)^(deg f − deg g + 1)` ensures all
-    coefficients stay in `R`. -/
+/-- Polynomial pseudo-division: for `f, g : DensePoly R` with `g ≠ 0`
+    and `g.degree? ≤ f.degree?`, returns `(quotient, pseudoRemainder)`
+    where `lc(g)^(deg f - deg g + 1) · f = quotient * g + pseudoRemainder`
+    and `pseudoRemainder.degree? < g.degree?`. Pre-multiplying by
+    `lc(g)^(deg f − deg g + 1)` keeps all coefficients in `R`, so no
+    coefficient division occurs. -/
 def pseudoDivMod (f g : DensePoly R) : DensePoly R × DensePoly R := ...
 
 /-- Subresultant pseudo-remainder sequence:
-    `r₀ = f`, `r₁ = g`, `r_{k+1} = pseudoRemainder` of (rescaled)
-    `r_{k-1}` divided by `r_k`. The sequence terminates when some
-    `r_N = 0`. -/
+    `r₀ = f`, `r₁ = g`, and `r_{k+1}` is the pseudo-remainder of
+    `r_{k-1}` by `r_k`, divided by the scale factor `β_k` (the division
+    is exact). The sequence terminates when some `r_N = 0`. Requires
+    `g.degree? ≤ f.degree?`; `resultant` handles the swap. -/
 def subresultantChain (f g : DensePoly R) : Array (DensePoly R) := ...
 
-/-- Resultant of `f` and `g`. Returns `0` when the chain terminates
-    with a non-constant final non-zero element (i.e., when `gcd(f, g)`
-    has positive degree, which over the algebraic closure means
-    `f` and `g` share a common root); otherwise returns the appropriate
-    leading coefficient with sign and scale corrections. -/
+/-- Resultant of `f` and `g`. When `f.degree? < g.degree?`, computed as
+    `(-1)^(deg f · deg g) · resultant g f`. Returns `0` when the chain
+    terminates with a final nonzero element of positive degree (that
+    is, when `gcd(f, g)` has positive degree, which over the algebraic
+    closure of the fraction field means `f` and `g` share a common
+    root). Otherwise returns the constant `r_{N-1}` corrected by the
+    accumulated scale factors and signs from the chain. -/
 def resultant (f g : DensePoly R) : R := ...
 
-/-- Discriminant. Standard formula:
+/-- Discriminant, by the standard formula
     `disc f = (-1)^(n·(n-1)/2) · resultant f f.derivative / lc(f)`
-    where the division is exact when `lc(f) ≠ 0` (since
-    `lc(f) | resultant f f.derivative` for any nonzero `f`). -/
+    where `n = deg f`. For nonzero `f` the division is exact, since
+    `lc(f)` divides `resultant f f.derivative`. -/
 def disc (f : DensePoly R) : R := ...
 
 end Hex.DensePoly
 ```
 
 The implementation works for any commutative ring `R` with
-multiplicative cancellation (UFD suffices); used in this project for
-`R = Int` (via `ZPoly`).
+multiplicative cancellation (a UFD suffices). `DensePoly R` itself
+needs `[Zero R] [DecidableEq R]` plus the ring operations; both
+`R = Int` and `R = ZPoly` qualify.
 
 ## Algorithm exposition
 
-The subresultant chain construction (Brown 1971, with Collins 1967's
-later refinements):
+The subresultant chain construction (Collins 1967, in Brown's 1978
+formulation):
 
 - Start with `r₀ = f`, `r₁ = g`. Track auxiliary scale factors
-  `β_k` and `ψ_k` per the standard recurrence (these absorb the
-  pseudo-division blow-up so intermediate coefficients stay polynomial
-  in the input size).
-- At each step: pseudo-divide `r_{k-1}` by `r_k`, getting a remainder
-  `r_{k+1}`. Rescale by the appropriate combination of leading
-  coefficients of `r_k` and previous β's.
+  `β_k` and `ψ_k` per the standard recurrence. These absorb the
+  pseudo-division blow-up, so intermediate coefficients stay
+  polynomial-size in the input.
+- At each step: pseudo-divide `r_{k-1}` by `r_k` to get a remainder,
+  then divide it exactly by `β_k` (a specific product of leading
+  coefficients of `r_k` and earlier `ψ` values) to get `r_{k+1}`.
 - Continue until `r_N = 0`.
 
 The resultant is then:
-- `0` if the chain terminates with the previous element `r_{N-1}` of
-  positive degree (i.e., `f` and `g` share a common root);
-- otherwise, a specific scaled leading coefficient of `r_{N-1}`
-  (concretely: `ψ_{N-1}^(degree drop) · r_{N-1}.coeff 0` with sign
-  corrections from the chain's history).
 
-The exact scale-factor bookkeeping is standard textbook material
-(Geddes-Czapor-Labahn ch. 7; von zur Gathen and Gerhard ch. 6).
+- `0` if the last nonzero element `r_{N-1}` has positive degree (`f`
+  and `g` share a common root);
+- otherwise, the constant `r_{N-1}` scaled by a specific power of
+  `ψ_{N-1}` and a sign determined by the degree sequence of the chain.
 
-## Layered file organisation
+The exact recurrences for `β_k`, `ψ_k`, and the final correction are
+standard textbook material. Follow Geddes-Czapor-Labahn ch. 7
+(Algorithm 7.3 and the surrounding discussion), which spells out all
+of the bookkeeping; von zur Gathen and Gerhard ch. 6 covers the same
+ground.
 
-- `HexResultant/Basic.lean` — `pseudoDivMod`, `subresultantChain`,
-  `resultant`, basic computational invariants (e.g., chain
-  termination, `resultant f g = 0` detection).
-- `HexResultant/Discriminant.lean` — `disc` and basic algebraic
-  identities (e.g., `disc (f * g) = disc f · disc g · resultant f g²`,
-  to the extent we need them downstream).
-- `HexResultant/Conformance.lean` — `core` fixtures including small
-  hand-checkable cases, well-known resultants (Chebyshev, cyclotomic
-  pairs), and zero-on-shared-root cases.
-- `HexResultant/Bench.lean` — performance benchmarks against
-  Mathlib's noncomputable `Polynomial.resultant` (via small fixtures
-  in `EmitFixtures`) or against an external CAS.
-- `HexResultant/EmitFixtures.lean` — fixture emission for the
-  conformance harness.
+## File organisation
+
+- `HexResultant/Basic.lean`: `pseudoDivMod`, `subresultantChain`,
+  `resultant`, and their basic computational properties (chain
+  termination, degree bounds).
+- `HexResultant/Discriminant.lean`: `disc` and the algebraic
+  identities we need downstream (for example
+  `disc (f * g) = disc f · disc g · (resultant f g)²`).
+- `conformance/HexResultant/Conformance.lean` and
+  `conformance/HexResultant/EmitFixtures.lean`: conformance driver and
+  fixture emission, in the shared `conformance/` sub-project.
+- `bench/HexResultant/Bench.lean`: bench driver, in the shared
+  `bench/` sub-project. Benches time `resultant` and `disc` on
+  committed fixture families of increasing degree. They are
+  Mathlib-free, per [SPEC/benchmarking.md](../benchmarking.md); there
+  is nothing to compare against in-process, since Mathlib's
+  `Polynomial.resultant` is noncomputable. Cross-checking values
+  against external systems happens in the conformance oracle, not in
+  the bench.
 
 ## Conformance fixtures
 
-Per `SPEC/testing.md`, fixtures tiered into `core` / `ci` / `local`:
+Per [SPEC/testing.md](../testing.md), fixtures are tiered into
+`core` / `ci` / `local`:
 
 - *core* (Lean-only):
   - `resultant (X − a) (X − b) = a − b` for small integer `a, b`.
   - `resultant f 1 = 1` for any `f`.
-  - `resultant (X² + 1) (X − 1) = 2`; cross-check on a few small
+  - `resultant (X² + 1) (X − 1) = 2`, plus a few small
     quadratic-times-linear cases.
   - `disc (X² + b·X + c) = b² − 4·c` for small `b, c`.
   - Common-root cases: `resultant (X − 1) (X² − 1) = 0`,
     `resultant (X² + 1) (X² + 1) = 0`.
+  - A bivariate case over `R = ZPoly`, exercising the
+    `hex-number-field` instantiation: for example
+    `resultant_y (y² − t) (y − t) = t² − t`.
 - *ci* (CI, with external oracle when available):
-  - 30 random degree-10 pairs with deterministic seed; oracle from
+  - 30 random degree-10 pairs with a deterministic seed; oracle from
     SageMath or python-flint.
 - *local* (developer-driven):
-  - High-degree resultants for performance-checking against the
-    asymptotic claim.
+  - High-degree resultants, timed against the complexity contract.
 
-External oracles: SageMath (`R.<x> = ZZ[]; (f).resultant(g)`),
-python-flint (`fmpz_poly_q.resultant`).
+External oracles: SageMath (`R.<x> = ZZ[]; f.resultant(g)`),
+python-flint (`fmpz_poly.resultant`).
 
 ## Complexity contract
 
-- `pseudoDivMod` for `f, g` of degrees `n, m` runs in `O((n − m + 1) · m)`
-  coefficient operations (roughly equivalent to schoolbook polynomial
-  division).
-- `subresultantChain f g` runs in `O(n · m)` polynomial-pseudodivision
-  steps. Total coefficient operations: `O(n·m·max(n,m))` over a UFD,
-  with intermediate coefficients of bit-length `O((n+m) · log
-  ‖f, g‖∞)` (the subresultant theorem's bound).
-- `resultant`, `disc`: dominated by the chain construction; same
-  asymptotic.
+- `pseudoDivMod` for `f, g` of degrees `n, m` runs in
+  `O((n − m + 1) · m)` coefficient operations, the same as schoolbook
+  polynomial division.
+- `subresultantChain f g` has at most `min(n, m) + 1` elements, hence
+  `O(min(n, m))` pseudo-division steps and `O(n·m)` coefficient
+  operations total. Over `R = Int`, intermediate coefficients have
+  bit-length `O((n+m) · (log(n+m) + log ‖f‖∞ + log ‖g‖∞))`, since
+  every chain element's coefficients are (up to sign) minors of the
+  Sylvester matrix (the subresultant theorem) and Hadamard's bound
+  applies.
+- `resultant`, `disc`: dominated by the chain construction.
 
-This is asymptotically better than `O((n+m)³ · log² ‖f, g‖∞)` for the
-Sylvester+Bareiss approach, by a factor of roughly `(n+m)`.
+Sylvester+Bareiss costs `O((n+m)³)` coefficient operations on
+intermediate values of the same bit-length, so the subresultant chain
+is faster by a factor of roughly `n+m`.
 
 ## References
 
-- Brown, W. S. *The subresultant PRS algorithm.* ACM TOMS 4 (1978),
-  237–249. The standard reference for the modern formulation.
 - Collins, G. E. *Subresultants and reduced polynomial remainder
-  sequences.* J. ACM 14 (1967), 128–142. The original.
+  sequences.* J. ACM 14 (1967), 128-142. The original.
+- Brown, W. S. *The subresultant PRS algorithm.* ACM TOMS 4 (1978),
+  237-249. The standard reference for the modern formulation.
 - Geddes, K. O.; Czapor, S. R.; Labahn, G. *Algorithms for Computer
-  Algebra.* Kluwer 1992. Chapter 7 has a clean modern textbook
-  treatment with all the scale-factor bookkeeping spelt out.
+  Algebra.* Kluwer, 1992. Chapter 7 is a clean textbook treatment
+  with all the scale-factor bookkeeping spelt out.
 - von zur Gathen, J.; Gerhard, J. *Modern Computer Algebra.* CUP, 3rd
   ed. 2013. Chapter 6.

--- a/SPEC/Libraries/hex-roots-mathlib.md
+++ b/SPEC/Libraries/hex-roots-mathlib.md
@@ -1,263 +1,366 @@
 # hex-roots-mathlib (depends on hex-roots + hex-poly-z-mathlib + Mathlib)
 
-Proves correctness of the certified complex root isolation in
-[hex-roots](hex-roots.md): every `DyadicRootIsolation` certifies a
-unique simple complex root in its disc; every `DyadicRootCluster`
-certifies exactly `k` roots; refinement preserves roots; `isolate`
-under `Hex.HasOnlySimpleRoots` returns the full set of roots; and the
-`mahlerPrec` separation bound is correct.
+Mathlib companion for [hex-roots](hex-roots.md). Proves **soundness**
+of the certified root isolation: every `DyadicRootIsolation` witness
+implies a unique simple complex root in its disc; every
+`DyadicRootCluster` witness implies exactly `k` roots with
+multiplicity; refinement preserves roots; `sameRoot` decides whether
+two refined isolations isolate the same root; and `mahlerPrec` meets
+its separation contract. **Completeness** (every Pellet witness
+certifies by `separationDepth`, so `isolate` never returns `none` on
+squarefree input) is a separately scoped development, described at
+the end. The soundness theorems are stated conditionally on a `some`
+result and do not depend on it.
 
-**Scope warning.** This bridge library is significantly heavier than
-typical `-mathlib` companions. The two foundational theorems we need —
-**Pellet's inclusion test** and the **Mahler separation bound** —
-neither exist in Mathlib at the time of writing. The first is genuinely
-hard to land because Mathlib lacks general-contour winding-number
-infrastructure (Patrick Massot, Zulip
-[#maths > Multivariate complex analysis][zulip],
-2025-12-28); we sidestep that by restricting to *circular* contours,
-which is all our algorithm needs. The second is well-supported by
-Mathlib's existing Mahler measure / discriminant / resultant API but
-the standalone separation theorem hasn't been assembled yet.
+**Scope warning.** This companion is the heaviest of the `-mathlib`
+libraries. The two theorems everything rests on, **Pellet's
+root-counting test** and the **Mahler separation bound**, do not
+exist in Mathlib: no argument principle, Rouché, or residue theorem
+is in mainline (checked against the 2026-06-18 revision), the only
+open PRs in the area are two stalled new-contributor residue drafts
+([#29588](https://github.com/leanprover-community/mathlib4/pull/29588),
+[#39232](https://github.com/leanprover-community/mathlib4/pull/39232)),
+and the winding-number infrastructure for general contours remains
+future work (Patrick Massot, Zulip
+[#maths > Multivariate complex analysis][zulip], 2025-12-28; Junyan
+Xu's étale-space programme,
+[#31925](https://github.com/leanprover-community/mathlib4/pull/31925),
+aims there but has not landed).
 
-The library is organised so that both developments are
-**self-contained slices upstreamable to Mathlib** as separate PRs once
-they've been battle-tested here.
+None of that generality is needed here, and the restricted problem is
+bounded. For **polynomials** on **circles**, the hard analytic
+ingredients already exist in Mathlib: the circle integral of
+`(z − w)⁻¹` inside the disc
+(`circleIntegral.integral_sub_inv_of_mem_ball`), the vanishing of the
+circle integral of a function holomorphic on a neighbourhood of the
+closed disc (`DiffContOnCl.circleIntegral_eq_zero`), the derivative
+of a product (`Polynomial.derivative_prod`), and continuity of
+parametrised interval integrals
+(`intervalIntegral.continuous_parametric_intervalIntegral_of_continuous`).
+What remains for us is the polynomial partial-fraction identity,
+finite summation, and a homotopy argument, as itemised below.
+
+One deliberate restriction: everything is stated for `Polynomial ℂ`,
+never `MeromorphicOn`. Mathlib's `MeromorphicOn` permits the function
+value at an isolated point to differ from its analytic germ, and a
+Rouché statement phrased over it admits counterexamples through that
+decoupling. This is what made LeanEval's `rouche_zero_count_eq` false
+as stated (Zulip, Model comparisons for Lean > LeanEval, 2026-05).
+Polynomials have no such subtlety, and the polynomial statements
+remain worth contributing to Mathlib on their own.
+
+Both developments are organised as self-contained slices with no
+`HexRoots` dependence, so each can be contributed to Mathlib as a
+separate PR once it has been exercised here.
 
 [zulip]: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Multivariate%20complex%20analysis
 
 ## What we cite from Mathlib (no work)
 
-The following Mathlib API is used throughout. Library work is glue, not
-re-derivation:
+The following Mathlib API is used as-is (all names checked against the
+Mathlib revision this repository pins):
 
 - `Complex.isAlgClosed` (`Mathlib.Analysis.Complex.Polynomial.Basic`),
-  `Polynomial.roots`, `Polynomial.Splits.natDegree_eq_card_roots` —
-  fundamental theorem of algebra; root multiset for `ℂ[X]`.
+  `Polynomial.roots`, `Polynomial.Splits.natDegree_eq_card_roots`
+  (`Mathlib.Algebra.Polynomial.Splits`): fundamental theorem of
+  algebra; the root multiset of a complex polynomial.
 - `Polynomial.rootMultiplicity` and the
-  `Polynomial.derivative_rootMultiplicity_*` family — characterisation
-  of simple roots via `p.eval α = 0 ∧ p.derivative.eval α ≠ 0`.
+  `Polynomial.derivative_rootMultiplicity_*` lemmas
+  (`Mathlib.Algebra.Polynomial.FieldDivision`): simple roots are the
+  `α` with `p.eval α = 0 ∧ p.derivative.eval α ≠ 0`.
 - `Polynomial.Squarefree`,
-  `PerfectField.separable_iff_squarefree` (in `Mathlib.FieldTheory.Perfect`).
+  `PerfectField.separable_iff_squarefree` (`Mathlib.FieldTheory.Perfect`).
 - `Polynomial.newtonMap`,
   `Polynomial.aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`
-  (`Mathlib.Dynamics.Newton`) — algebraic side of Newton's method.
+  (`Mathlib.Dynamics.Newton`): the algebraic side of Newton's method.
 - `ContractingWith` and the Banach fixed-point theorem
-  (`Mathlib.Topology.MetricSpace.Contracting`) — analytic side of
+  (`Mathlib.Topology.MetricSpace.Contracting`): the analytic side of
   Newton convergence.
-- `Mathlib.Analysis.Complex.CauchyIntegral` — Cauchy integral formula
-  on circles, the substrate for our argument-principle development.
-- `Polynomial.cauchyBound` and `IsRoot.norm_lt_cauchyBound`
-  (`Mathlib.Analysis.Polynomial.CauchyBound`) — cited by the
-  `cauchy` constructor's correctness theorem.
+- `circleIntegral.integral_sub_inv_of_mem_ball`
+  (`Mathlib.MeasureTheory.Integral.CircleIntegral`):
+  `∮_{|z−c|=R} (z − w)⁻¹ dz = 2πi` for `w` inside the disc.
+- `DiffContOnCl.circleIntegral_eq_zero`
+  (`Mathlib.Analysis.Complex.CauchyIntegral`): the circle integral of
+  a function holomorphic near the closed disc vanishes; applied to
+  `(z − α)⁻¹` for roots `α` outside.
+- `Polynomial.derivative_prod`
+  (`Mathlib.Algebra.Polynomial.Derivative`): for the partial-fraction
+  identity.
+- `intervalIntegral.continuous_parametric_intervalIntegral_of_continuous`
+  (`Mathlib.MeasureTheory.Integral.DominatedConvergence`): for the
+  homotopy argument in Rouché.
+- `Polynomial.cauchyBound` and `Polynomial.IsRoot.norm_lt_cauchyBound`
+  (`Mathlib.Analysis.Polynomial.CauchyBound`): cited by the `cauchy`
+  constructor's correctness theorem.
 - `Polynomial.discr` and `Polynomial.resultant_deriv`
-  (`Mathlib.RingTheory.Polynomial.Resultant.Basic`) — discriminant
-  and the `resultant(f, f') = ±lc · discr` relation.
+  (`Mathlib.RingTheory.Polynomial.Resultant.Basic`): the polynomial
+  discriminant and `resultant(f, f') = ±lc · discr`.
 - `Polynomial.resultant`, `Polynomial.resultant_eq_prod_roots_sub`
-  (same file) — the full Sylvester-matrix toolkit.
-- `Polynomial.mahlerMeasure` and the suite in
+  (same file): the Sylvester-matrix toolkit.
+- `Polynomial.mahlerMeasure` and its lemmas in
   `Mathlib.Analysis.Polynomial.MahlerMeasure`:
   `mahlerMeasure_mul`, `mahlerMeasure_eq_leadingCoeff_mul_prod_roots`,
   `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm` (Landau).
-- `one_le_mahlerMeasure_of_ne_zero` (`Mathlib.NumberTheory.MahlerMeasure`)
-  for nonzero integer polynomials.
+- `one_le_mahlerMeasure_of_ne_zero`
+  (`Mathlib.NumberTheory.MahlerMeasure`) for nonzero integer
+  polynomials.
 - `Polynomial.supNorm` (`Mathlib.Analysis.Polynomial.Norm`).
+- `Dyadic.invAtPrec_mul_le_one` and
+  `Dyadic.one_lt_invAtPrec_add_inc_mul` (Lean standard library,
+  `Init.Data.Dyadic.Inv`): the rounding-error bounds for the Newton
+  step's reciprocal.
 
 ## Discriminant / separation development
 
-This is the smaller of the two new analytic developments, and the
-one needed *first* — `isolate`'s termination story leans on
-`mahlerPrec`'s correctness, which leans on the Mahler separation
-bound.
+The smaller of the two new developments, and the one needed first:
+`mahlerPrec`'s contract rests on the Mahler separation bound.
 
 ### Theorem chain
 
-1. **`Polynomial.discr ≠ 0 ↔ Squarefree`** for `ℤ[x]` (and char-zero
-   more generally). Bridge via the existing chain
+1. **`Polynomial.discr ≠ 0 ↔ Squarefree`** for `ℤ[x]` (and
+   characteristic zero generally). Assembled from the existing chain
    `separable_iff_squarefree` ↔ `IsCoprime f f'` ↔ `resultant ≠ 0` ↔
-   `discr ≠ 0`. Mostly assembly from existing Mathlib pieces. Lives in
+   `discr ≠ 0`. Lives in
    `HexRootsMathlib/DiscriminantSquarefree.lean`.
 
 2. **Discriminant root-product formula:**
    `discr f = lc(f)^{2n−2} · ∏_{i<j}(αᵢ − αⱼ)²` over the splitting
    field. Mathlib has the resultant version
    (`resultant_eq_prod_roots_sub`); we derive the discriminant version
-   on top using `resultant_deriv`. Lives in
+   through `resultant_deriv`. Lives in
    `HexRootsMathlib/DiscriminantRootProduct.lean`.
 
-3. **Mahler/Mignotte separation bound:**
+3. **Mahler separation bound:**
    ```
    ∀ i ≠ j, |αᵢ − αⱼ| ≥ √3 · n^{−(n+2)/2} · |disc p|^{1/2} · M(p)^{−(n−1)}
    ```
-   for squarefree `p ∈ ℤ[x]`. Standard textbook proof: take logs of the
-   root-product formula (item 2), bound each `|αᵢ − αⱼ| ≤ 2 · M(p)` for
-   pairs not equal to `(i, j)`, use `|disc p| ≥ 1`. Lives in
+   for squarefree `p ∈ ℤ[x]` of degree `n ≥ 2`. The proof bounds the
+   Vandermonde determinant of the roots two ways: its square is
+   `disc p / lc(p)^{2n−2}` by item 2, and Hadamard's inequality bounds
+   it above column-by-column, with one column rescaled to expose the
+   factor `|αᵢ − αⱼ|`. Mahler's original argument is exactly this;
+   Mignotte and Ştefănescu, ch. 4, give a self-contained version
+   suitable for direct formalisation. (A naive bound on the individual
+   factors `|αᵢ − αⱼ| ≤ 2·M(p)` does *not* reach the stated constant;
+   Hadamard is essential.) Lives in
    `HexRootsMathlib/MahlerSeparation.lean`.
 
 4. **`mahlerPrec` correctness:** the computational
    `Hex.mahlerPrec p : Nat` (defined in `HexRoots/MahlerPrec.lean`)
    satisfies
    ```
-   2^{-mahlerPrec p} ≤ (min_{i ≠ j} |αᵢ − αⱼ|) / 2
+   2^{−mahlerPrec p} · 1449/1024 < sep(p) / 4
    ```
-   for squarefree `p`. Combines item 3 with Landau's
-   `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm` to eliminate
-   `M(p)` in favour of the integer `‖p‖∞`, then takes `−log₂` of the
-   resulting bound. Lives in `HexRootsMathlib/MahlerPrec.lean`.
+   for squarefree `p`, where the left side bounds the
+   circumscribed-disc radius at that precision from above. Combines
+   item 3 with Landau's
+   `mahlerMeasure_le_sqrt_natDegree_add_one_mul_supNorm` to remove
+   `M(p)` in favour of the integer `‖p‖∞`. Lives in
+   `HexRootsMathlib/MahlerPrec.lean`.
 
-## Analytic core (Rouché-on-circles)
+## Rouché-on-circles development
 
-The harder of the two developments. Used to prove the semantics of
-`DyadicRootIsolation` and `DyadicRootCluster`.
+The harder of the two developments. It supplies the semantics of the
+Pellet witnesses.
 
 ### Theorem chain
 
-5. **Circle-integral lemmas** — logarithmic-derivative identities,
-   no-roots-on-boundary preservation, `(z − α)⁻¹` residue
-   computations on circles. The load-bearing intermediate layer; the
-   argument-principle proof becomes intractable without first
-   factoring this out. Lives in
-   `HexRootsMathlib/CircleIntegralLemmas.lean`.
+5. **Partial fractions for `p'/p`**: for `0 ≠ p : ℂ[X]` and `z` off
+   the roots,
+   ```
+   p'(z) / p(z) = Σ_{α ∈ p.roots} (z − α)⁻¹
+   ```
+   summing over the root multiset (so an m-fold root contributes m
+   terms). From the factorisation of `p` over ℂ and
+   `Polynomial.derivative_prod`, plus circle-integrability of each
+   summand. Lives in `HexRootsMathlib/CircleIntegralLemmas.lean`.
 
-6. **Argument principle on circles:**
+6. **Argument principle for polynomials on circles:**
    ```
    (1/2πi) · ∮_{|z−c|=r} (p'(z) / p(z)) dz = (Polynomial.roots p).countP (· ∈ ball c r)
    ```
-   for `p` analytic with no zeros on `|z−c| = r`. Built from Mathlib's
-   `circleIntegral` and Cauchy integral formula in
-   `Mathlib.Analysis.Complex.CauchyIntegral`. Lives in
+   for `p ≠ 0` with no zeros on `|z−c| = r`; the count is with
+   multiplicity, since `Polynomial.roots` is a multiset. By item 5
+   and linearity of the circle integral over the finite sum: each
+   root inside contributes `2πi`
+   (`circleIntegral.integral_sub_inv_of_mem_ball`), each root outside
+   contributes `0` (`DiffContOnCl.circleIntegral_eq_zero`, as
+   `(z − α)⁻¹` is then holomorphic near the closed disc). No winding
+   numbers and no meromorphic API. Lives in
    `HexRootsMathlib/ArgumentPrinciple.lean`.
 
-7. **Rouché on circles** — both classical (`|f − g| < |g|` on the
-   circle implies `f`, `g` have the same number of zeros inside) and
-   symmetric (`|f − g| < |f| + |g|` ditto) forms. Derived from item 6.
-   Lives in `HexRootsMathlib/Rouche.lean`.
+7. **Rouché for polynomials on circles**, classical form (`|f − g| <
+   |g|` on the circle implies `f` and `g` have the same number of
+   zeros inside) and symmetric form (`|f − g| < |f| + |g|` likewise).
+   Proof by homotopy: `h_t := g + t·(f − g)` has no zero on the
+   circle for `t ∈ [0, 1]`, its root count is given by item 6, the
+   count varies continuously in `t`
+   (`continuous_parametric_intervalIntegral_of_continuous`), and an
+   integer-valued continuous function on `[0, 1]` is constant. Lives
+   in `HexRootsMathlib/Rouche.lean`.
 
 8. **Pellet (BSSY Theorem 1):**
    ```
-   |c_k|·r^k > Σ_{i ≠ k} |c_i|·r^i ⇒ p has exactly k roots in D(0, r)
+   |c_k|·r^k > Σ_{i ≠ k} |c_i|·r^i   ⇒   p has exactly k roots in D(0, r)
    ```
-   where `cᵢ = p.coeff i`. Proved by Rouché-comparing `p` against the
-   monomial `c_k · z^k`. Lives in `HexRootsMathlib/Pellet.lean`.
+   where `cᵢ = p.coeff i` and the count is with multiplicity. Proved
+   by applying Rouché to `p` and the monomial `c_k · z^k`. Lives in
+   `HexRootsMathlib/Pellet.lean`.
 
-The squared-form Pellet inequality used in `HexRoots/Pellet.lean` is
-equivalent to the standard form in item 8, via the elementary
-`a > 0 ∧ b > 0 → (a > b ↔ a² > b²)`. We prove this equivalence in the
-bridge file `HexRootsMathlib/Geometry.lean` so that the analytic core
-can stay in the standard form (more upstream-friendly) while the
-computational library uses the squared form (decidable in dyadics).
+The computational library never states this inequality directly: its
+witness compares dyadic bounds (`lo`, `hi`, and the rational `√2`
+bounds; see [hex-roots.md](hex-roots.md)). The one-directional lemma
+"the dyadic-bound witness implies the exact Pellet inequality" lives
+in `HexRootsMathlib/Geometry.lean`, so the analytic development above
+stays in the standard form (the form worth contributing to Mathlib)
+while the computational library stays decidable. The converse
+direction, that a sufficiently isolating disc makes the witness hold
+despite the factor-2 slack, belongs to the completeness development
+below.
 
-## Bridge proper
+## Correspondence theorems
 
-These files use both `HexRoots` data structures and the analytic /
-discriminant cores above.
+These files connect the `HexRoots` data structures to the two
+developments above.
 
-- `HexRootsMathlib/Basic.lean` — definitional bridge: a `DyadicSquare`
-  determines a centre `c : ℂ` and a radius `r : ℝ`, and a
-  circumscribed disc `Metric.ball c (r·√2)`. Core simp lemmas
-  (`DyadicSquare.center_eq`, `DyadicSquare.disc_eq`).
-- `HexRootsMathlib/Geometry.lean` — the squared-radius bridge:
-  `circumscribed_radius_squared : (r · Real.sqrt 2)² = 2 · r²`, plus
-  the `T_k` squared-form ↔ standard-form equivalence.
+- `HexRootsMathlib/Basic.lean`: a `DyadicSquare` determines a centre
+  `c : ℂ` and a radius `r : ℝ`, and a circumscribed disc
+  `Metric.ball c (r·√2)`; all witness counts are counts in the open
+  disc, which equal counts in the closed disc because the strict
+  witness inequality excludes roots from the boundary circle. Simp
+  lemmas `DyadicSquare.center_eq`, `DyadicSquare.disc_eq`.
+- `HexRootsMathlib/Geometry.lean`: `lo(c) ≤ |c| ≤ hi(c)`, the
+  `181/128 < √2 < 1449/1024` bounds, and "witness implies Pellet".
 - `HexRootsMathlib/HasOnlySimpleRoots.lean`:
-  `Hex.HasOnlySimpleRoots p ↔ Squarefree (toPolynomial p)`. Combines
-  the `HexRoots`-side gcd-based decision procedure with Mathlib's
-  `separable_iff_squarefree`.
-- `HexRootsMathlib/MahlerPrec.lean` — item 4 above.
-- `HexRootsMathlib/Refine.lean` — correctness of the
-  `refineTo`/`refine` threading pattern from `hex-roots.md`:
+  `Hex.HasOnlySimpleRoots p ↔ Squarefree (toPolynomial p)`. Connects
+  the executable test (the `ℚ[x]` gcd of `p` and `p'` is constant)
+  with `separable_iff_squarefree`.
+- `HexRootsMathlib/MahlerPrec.lean`: item 4 above.
+- `HexRootsMathlib/SimpleRoot.lean`: the semantics of root identity.
   ```lean
-  theorem SimpleRoot.refine_eq (s : SimpleRoot p) (target : Nat) :
-      s.refine target = s
-  -- Follows from `Quotient.sound` plus `refineTo_respects_equiv`.
+  /-- The unique root inside a refined isolation's disc. -/
+  def RefinedIsolation.root (i : RefinedIsolation p) : ℂ
 
-  theorem SimpleRoot.out_refine_eq (s : SimpleRoot p) (t prec : Nat) :
-      (s.refine t).out prec = s.out prec
-  -- Follows from `refine_eq` by congruence.
+  theorem intersects_iff_root_eq (i₁ i₂ : RefinedIsolation p) :
+      Intersects i₁ i₂ ↔ i₁.root = i₂.root
   ```
-  These theorems make the threading pattern transparent at the
-  proof level: callers can substitute `s.refine target` for `s`
-  freely, knowing all downstream observations agree.
-- `HexRootsMathlib/Cauchy.lean` —
-  `DyadicRootCluster.cauchy` correctness: the cluster contains all
-  `Polynomial.roots p` and the strong `T_k` witness holds at radii
-  `r`, `2r`, `4r`. Uses `Polynomial.cauchyBound` for containment, and
-  the elementary observation that the leading-term inequality
-  `|aₙ|·Rⁿ > Σ_{i<n}|aᵢ|·Rⁱ` only strengthens for `R > Cauchy bound`.
-- `HexRootsMathlib/Newton.lean` —
-  `DyadicRootIsolation.refine?` correctness: when it returns
-  `some iso'`, `iso'` certifies the same simple root and `iso'.prec >
-  iso.prec`. Bridges to `Polynomial.newtonMap` and
-  `aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`; also requires a
-  small bound on the `Dyadic.invAtPrec` rounding error, supplied by
-  `Dyadic.invAtPrec_mul_le_one` and `Dyadic.one_lt_invAtPrec_add_inc_mul`
-  in the Lean stdlib.
-- `HexRootsMathlib/Bisection.lean` —
-  `DyadicRootCluster.refine1?` correctness: when it returns
-  `some children`, the multiset of root counts in the children's
-  discs (with multiplicity) equals the parent cluster's `k`. Uses
-  Pellet (item 8) and a finite case analysis over the 4-square
-  partition + edge-connected-components glue.
-- `HexRootsMathlib/IsolateAll.lean` —
-  `isolateAll?` and `isolate` correctness theorems:
+  Consequences: `Intersects` restricted to `RefinedIsolation p` is an
+  equivalence relation; `Hex.rootOf : SimpleRoot p → ℂ` is
+  well-defined by `Quot.lift`; `sameRoot i₁ i₂ = true ↔
+  SimpleRoot.mk i₁ = SimpleRoot.mk i₂`, so the Boolean test used by
+  the Mathlib-free layer decides equality in the quotient. The `<
+  sep/4` radius bound from item 4 is what makes
+  `intersects_iff_root_eq` true.
+- `HexRootsMathlib/Cauchy.lean`: `Component.cauchy`
+  correctness. The starting disc contains all of `Polynomial.roots p`
+  by `Polynomial.IsRoot.norm_lt_cauchyBound`, and the degree-`n`
+  witness holds at the base, doubled, and quadrupled radii because the
+  leading-term inequality `|aₙ|·Rⁿ > Σ_{i<n}|aᵢ|·Rⁱ` only improves as
+  `R` grows past the Cauchy bound.
+- `HexRootsMathlib/Newton.lean`: `newton1?` and `refineTo?`
+  soundness. When they return `some iso'`, `iso'` isolates the same
+  root and `iso'.square.prec > iso.square.prec`
+  (`sameRoot`-preservation is the statement the threading pattern in
+  hex-roots.md relies on). Uses `Polynomial.newtonMap`,
+  `aeval_pow_two_pow_dvd_aeval_iterate_newtonMap`, and the
+  `Dyadic.invAtPrec` error bounds.
+- `HexRootsMathlib/Bisection.lean`: `Component.refine1` and
+  `Component.certify?` soundness. A `T_0`-discarded child's disc
+  contains no root, so every root covered by the parent lies in some
+  retained child; and when `certify?` returns a cluster, its disc
+  contains exactly `k` roots with multiplicity (Pellet, item 8).
+- `HexRootsMathlib/IsolateAll.lean`: driver soundness. The multiset
+  equality below rests on two facts: the retained squares cover every
+  root (refine1 soundness), and the output discs are pairwise
+  disjoint (the driver's separation check), so the per-cluster counts
+  neither miss nor double-count a root.
   ```lean
-  theorem isolateAll?_eq_some_iff (p : ZPoly) (target : Nat) :
-      ∃ result, isolateAll? target [DyadicRootCluster.cauchy p] = some result ∧
-        (result.toList.bind (·.roots) : Multiset ℂ) = (toPolynomial p).roots
+  theorem isolateAll?_sound (p : ZPoly) (target : Int)
+      (h : 0 < p.degree?.getD 0) {result}
+      (hr : isolateAll? p target #[Component.cauchy p h] = some result) :
+      (result.toList.bind (·.roots) : Multiset ℂ) = (toPolynomial p).roots
 
-  theorem isolate_eq_some (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Nat) :
-      ∃ atoms, isolate p h atom_prec = some atoms ∧
-        (atoms.map (·.root) : Finset ℂ) = (toPolynomial p).roots.toFinset ∧
-        ∀ a ∈ atoms, a.square.prec ≥ atom_prec
+  theorem isolate_sound (p : ZPoly) (h : Hex.HasOnlySimpleRoots p)
+      (atom_prec : Int) {atoms}
+      (ha : isolate p h atom_prec = some atoms) :
+      (atoms.toList.map (·.root)).toFinset = (toPolynomial p).roots.toFinset ∧
+      ∀ a ∈ atoms, atom_prec ≤ a.square.prec
   ```
-- `HexRootsMathlib/Conformance.lean` — the standard conformance
-  module, asserting Mathlib-side properties on a small set of
-  committed fixtures.
+  (`HasOnlySimpleRoots p` rules out `p = 0`, so no separate
+  nonzeroness hypothesis is needed in the second statement.)
 
-## Layered file organisation
+## Completeness development (separately scoped)
+
+Soundness above never claims the drivers succeed. Completeness does,
+and it is the analytically hardest part:
+
+9. **Pellet converse with margin**: if the disc is
+   `(ρ₁, ρ₂)`-isolating with a ratio wide enough to absorb the
+   factor-2 witness slack, then the dyadic-bound witness holds. The
+   required ratio is a concrete constant derived from BSSY §2 plus the
+   slack analysis.
+10. **Newton success**: on a sufficiently refined atom the speculative
+    Newton step recertifies (via `ContractingWith` on the Newton map).
+11. **Certification by separation depth**: for squarefree `p`, at
+    depth `≥ separationDepth p` every rootless component has vanished
+    (all its squares `T_0`-certify), every surviving component passes
+    `certify?` with `k = 1` (items 9 and 10 supply the two
+    certification paths), and the certified discs are pairwise
+    disjoint (radius below `sep/4`). Hence
+    `isolate p h atom_prec ≠ none`. This is the theorem that retires
+    the drivers' `none` branch; it never mentions the recursion
+    structure, only depths and witnesses.
+
+Items 9-11 can be deferred: every theorem in this library is usable
+without them, and the conformance suite checks empirically that `none`
+does not occur on the committed fixtures. They are listed here so the
+scope is honest; nothing else in the plan silently depends on them.
+
+## File organisation
 
 ```
-Discriminant / separation core (upstreamable):
+Discriminant / separation development (candidate Mathlib contribution):
   HexRootsMathlib/DiscriminantSquarefree.lean
   HexRootsMathlib/DiscriminantRootProduct.lean
   HexRootsMathlib/MahlerSeparation.lean
 
-Analytic core (upstreamable, but depends on serious circle-integral
-work and is the harder of the two):
+Rouché-on-circles development (candidate Mathlib contribution;
+the harder of the two):
   HexRootsMathlib/CircleIntegralLemmas.lean
   HexRootsMathlib/ArgumentPrinciple.lean
   HexRootsMathlib/Rouche.lean
   HexRootsMathlib/Pellet.lean
 
-Bridge (depends on hex-roots data structures):
+Correspondence theorems (depend on hex-roots data structures):
   HexRootsMathlib/Basic.lean
   HexRootsMathlib/Geometry.lean
   HexRootsMathlib/HasOnlySimpleRoots.lean
   HexRootsMathlib/MahlerPrec.lean
-  HexRootsMathlib/Refine.lean
+  HexRootsMathlib/SimpleRoot.lean
   HexRootsMathlib/Cauchy.lean
   HexRootsMathlib/Newton.lean
   HexRootsMathlib/Bisection.lean
   HexRootsMathlib/IsolateAll.lean
-  HexRootsMathlib/Conformance.lean
+
+Completeness development (deferrable; see above):
+  HexRootsMathlib/Completeness/…
 ```
 
-The two cores have no `HexRoots`-dependence and may be split into their
-own libraries (or upstreamed to Mathlib) if they grow. The bridge
-files depend on `HexRoots`'s data definitions and on whichever core
-theorems they need.
+The two candidate contributions have no `HexRoots` dependence and can
+be split out or sent to Mathlib if they grow. The library is verified
+by building it. Conformance fixtures live with `hex-roots`.
 
 ## References
 
-See [hex-roots.md](hex-roots.md) for the BSSY paper, Pellet, Mahler,
-and Mignotte references. The discriminant and Mahler-measure
-infrastructure cited above is documented in:
+See [hex-roots.md](hex-roots.md) for the BSSY, Pellet, Mahler, and
+Mignotte references. In addition:
 
-- Becker, Sagraloff, Sharma, Yap, JSC 2018 — same as before; §2 has
-  the exact form of the Pellet inequality and its derivation from
-  Rouché.
-- Mignotte, Štefănescu. *Polynomials: An Algorithmic Approach.*
-  Springer, 1999. Chapter 4 has a clean self-contained proof of the
-  Mahler/Mignotte separation bound suitable for direct
+- Becker, Sagraloff, Sharma, Yap, JSC 2018, §2: the exact form of the
+  Pellet inequality and its derivation from Rouché.
+- Mignotte, Ştefănescu. *Polynomials: An Algorithmic Approach.*
+  Springer, 1999. Chapter 4 has a self-contained proof of the Mahler
+  separation bound (via Hadamard's inequality) suitable for direct
   formalisation.
 - Yap. *Fundamental Problems of Algorithmic Algebra.* Oxford, 2000.
-  §6.6 gives an alternative derivation via Liouville-style estimates.
+  §6.6 derives the same bound via Liouville-style estimates, an
+  alternative if the Hadamard route stalls.

--- a/SPEC/Libraries/hex-roots-mathlib.md
+++ b/SPEC/Libraries/hex-roots-mathlib.md
@@ -295,10 +295,13 @@ Soundness above never claims the drivers succeed. Completeness does,
 and it is the analytically hardest part:
 
 9. **Pellet converse with margin**: if the disc is
-   `(ρ₁, ρ₂)`-isolating with a ratio wide enough to absorb the
-   factor-2 witness slack, then the dyadic-bound witness holds. The
-   required ratio is a concrete constant derived from BSSY §2 plus the
-   slack analysis.
+   `(ρ₁, ρ₂)`-isolating with a wide enough ratio, then the
+   dyadic-bound witness holds. Without Graeffe iteration the required
+   ratio is *linear in `deg p`* (each remote root contributes to the
+   higher Taylor coefficients; the relevant bound is
+   `(1 + ρ/d)^{n−1} − 1`), times a fixed factor absorbing the
+   factor-2 witness slack. This is what `separationDepth`'s
+   `ceilLog2 (deg p)` term supplies.
 10. **Newton success**: on a sufficiently refined atom the speculative
     Newton step recertifies (via `ContractingWith` on the Newton map).
 11. **Certification by separation depth**: for squarefree `p`, at

--- a/SPEC/Libraries/hex-roots.md
+++ b/SPEC/Libraries/hex-roots.md
@@ -112,12 +112,14 @@ structure DyadicRootIsolation (p : ZPoly) where
 
 /-- A certified cluster: an edge-connected set of grid squares at a
     common `prec`, whose enclosing disc contains exactly `k` roots
-    with multiplicity. Kept as a set of squares, never re-boxed into a
-    single square: re-boxing can return the parent square and stall
-    refinement (a root that sits on a grid line keeps its component
-    spanning that line at every depth, while the squares themselves
-    shrink). This is an *output* type; the refinement worklist holds
-    uncertified `Component` values. -/
+    with multiplicity. The component squares are the data that
+    *refinement* operates on; subdividing the enclosing square
+    instead would stall (it can equal the parent square when a root
+    sits on a grid line, even as the component squares themselves
+    shrink). The Pellet certificate, by contrast, is attached to the
+    circumscribed disc of `encSquare squares`. This is an *output*
+    type; the refinement worklist holds uncertified `Component`
+    values. -/
 structure DyadicRootCluster (p : ZPoly) where
   squares   : Array DyadicSquare     -- nonempty, common prec, edge-connected
   k         : Nat
@@ -237,15 +239,11 @@ each depth, and give up at
 stopDepth p target := max target (separationDepth p) + stopSlack
 ```
 
-with `stopSlack := 8`. The constant can be generous at almost no
-cost: each subdivision level *doubles* a component's isolation ratio
-(the
-disc radius halves while the distance to the other roots is fixed
-past `mahlerPrec`), and the witness fires once that ratio clears a
-fixed constant, so the analysis can only ever require a handful of
-extra levels, independent of the input. Overshooting costs a few
-extra subdivision rounds in the rare case certification had not
-already happened, and nothing else. The completeness analysis
+with `stopSlack := 8`. The degree-dependent part of the required
+depth lives inside `separationDepth` (below); `stopSlack` is only a
+fixed margin on top, and it can be generous at almost no cost:
+overshooting costs a few extra subdivision rounds in the rare case
+certification had not already happened, and nothing else. The completeness analysis
 certifies the pinned value (or shows a smaller one suffices). A
 `none` from the drivers has one precise meaning: *a Pellet witness
 failed to appear at separation depth*. The Mathlib
@@ -319,22 +317,29 @@ applies. The Mathlib companion proves correctness; see
 [hex-roots-mathlib.md](hex-roots-mathlib.md).
 
 ```lean
-def separationDepth (p : ZPoly) : Nat := mahlerPrec p + sepSlack
+def separationDepth (p : ZPoly) : Nat :=
+  mahlerPrec p + ceilLog2 (max 2 (p.degree?.getD 0)) + sepSlack
 ```
 
 with `sepSlack := 8`. `separationDepth` is the depth at which the
-completeness analysis says every Pellet witness certifies: past
-`mahlerPrec p`, each component's disc contains at most one distinct
-root, its isolation ratio doubles with every further level, and the
-witness fires once the ratio clears a fixed constant. The required
-number of extra levels is therefore an absolute constant,
-independent of `p`: the factor-2 witness slack costs one level, the
-enclosing square of a multi-square component at most two, the
-circumscribed `√2` one, and the isolation ratio the Pellet converse
-needs a couple more. Eight comfortably exceeds that count. The
-completeness analysis certifies it (overshoot costs only a few extra
+completeness analysis says every Pellet witness certifies. Past
+`mahlerPrec p` each component's disc contains at most one distinct
+root, and its isolation ratio doubles with every further level. How
+large a ratio the witness needs is *degree-dependent*: for a disc of
+radius `ρ` around a simple root at distance `d` from the other
+roots, the higher Taylor coefficients collect contributions from all
+`n − 1` remote roots, and the ratio of the right side of the `T_1`
+inequality to the left is bounded by `(1 + ρ/d)^{n−1} − 1`, so the
+witness needs `ρ/d` of order `1/n`. That is what the
+`ceilLog2 (deg p)` term buys, one doubling at a time. (This is the
+price of omitting Graeffe iteration; the fixed-ratio test Graeffe
+enables would make this term a constant.) The remaining `sepSlack`
+covers the fixed factors: one level for the factor-2 witness slack,
+at most two for the enclosing square of a multi-square component,
+one for the circumscribed `√2`, and margin. The completeness
+analysis certifies the formula; overshoot costs only extra
 subdivision rounds on inputs where certification had not already
-happened). It is the depth bound used by `stopDepth` above.
+happened. It is the depth bound used by `stopDepth` above.
 
 ## `SimpleRoot`: identity of a root, up to isolation
 
@@ -412,10 +417,11 @@ inherit the precision.
 ## Differences from BSSY
 
 - **No Graeffe iteration.** Deferred as a future optimisation. Without
-  it the `k`-root witness needs a wider isolation ratio around a
-  cluster before it certifies, which costs subdivision depth when
-  distinct roots lie very close together. For typical inputs the
-  difference is small.
+  it the witness needs an isolation ratio of order `deg p` before it
+  certifies (every remote root contributes to the higher Taylor
+  coefficients), which costs the `ceilLog2 (deg p)` term in
+  `separationDepth`. Graeffe iteration would let a fixed ratio
+  suffice and reduce that term to a constant.
 - **No squarefree preprocessing.** A multiple root fails the `k = 1`
   witness at every radius, so it stays a `k ≥ 2` cluster and is
   reported as such. Squarefree inputs atomize. Non-squarefree inputs

--- a/SPEC/Libraries/hex-roots.md
+++ b/SPEC/Libraries/hex-roots.md
@@ -1,46 +1,97 @@
 # hex-roots (complex root isolation, depends on hex-poly-z)
 
 Certified isolation of complex roots of integer-coefficient
-polynomials. A "root isolation" is a Gaussian-dyadic centre and a
-dyadic-power-of-two radius together with a witness, dischargeable by
-`cbv_decide`, that the disc contains exactly one simple root (atom) or
-exactly `k` roots with multiplicity (cluster). Refinement combines
+polynomials. A root isolation is a square in the complex plane with
+Gaussian-dyadic centre and power-of-two half-width, together with a
+witness, dischargeable by `decide`, that the square's circumscribed
+disc contains exactly one simple root (an *atom*) or exactly `k` roots
+counted with multiplicity (a *cluster*). Refinement combines
 speculative Newton iteration (using `Dyadic.invAtPrec` from the Lean
-standard library) with subdivision-and-component-gluing as the
-bootstrap phase, following the hybrid algorithm of Becker–Sagraloff–
-Sharma–Yap, *J. Symbolic Computation* 86 (2018) 51–96 (arXiv:1509.06231;
-"BSSY" hereafter).
+standard library) with subdivision and component gluing as the
+fallback, following the hybrid algorithm of Becker, Sagraloff, Sharma,
+and Yap, *J. Symbolic Computation* 86 (2018) 51-96 (arXiv:1509.06231;
+"BSSY" below).
 
-## Witness arithmetic is exact
+## Exact witness arithmetic
 
-A `ZPoly` evaluated at a Gaussian-dyadic point `(a + b·i)` yields
-Taylor coefficients
+A `ZPoly` evaluated at a Gaussian-dyadic point `a + b·i` yields Taylor
+coefficients
 
 ```
 cₖ = Σ_{j ≥ k} binomial(j,k) · aⱼ · (a + b·i)^{j−k}
 ```
 
-each term an integer times a Gaussian-dyadic power, hence
-`cₖ ∈ Dyadic[i]` *exactly*. `|cₖ|² = (Re cₖ)² + (Im cₖ)²` is then an
-exact dyadic. Every witness in this library is a strict comparison
-between two exact dyadics — `Decidable` with no error budget. The
-Newton step itself uses `Dyadic.invAtPrec` and is approximate, but the
-witness re-check after Newton uses the new exact dyadic centre and is
-again exact. This eliminates an entire category of "interval
-arithmetic" infrastructure that one might naïvely expect.
+each term an integer times a Gaussian-dyadic power, so
+`cₖ ∈ Dyadic[i]` *exactly*.
 
-## Geometry: dyadic squares, circumscribed discs, squared radii
+The Pellet inequalities compare absolute values `|cₖ|` against sums of
+absolute values, and `|cₖ|` is irrational in general. The witnesses
+therefore replace each absolute value by an exact dyadic bound on the
+correct side:
 
-Subdivision works on dyadic squares (4-way clean partition); Pellet
-tests live on the **circumscribed disc** of each square. For a square
-of half-width `r = 2^{-prec}`, the circumscribed disc has radius `r·√2`.
-To keep all arithmetic dyadic, **every appearance of a radius in a
-witness is replaced by the squared form**. The `T_k`-inequality
-becomes `|cₖ|² · (r²·2)^k > S²` rather than `|cₖ|·(r·√2)^k > S`. The
-strong-witness `2·`-radius and `4·`-radius checks become `8r²` and
-`32r²` respectively. A single named lemma
-`circumscribed_radius_squared : (r·√2)² = 2·r²` is checked once;
-afterwards no `√2` appears.
+- lower bound `lo(c) := max(|Re c|, |Im c|)`, with
+  `lo(c) ≤ |c| ≤ √2 · lo(c)`;
+- upper bound `hi(c) := |Re c| + |Im c|`, with
+  `|c| ≤ hi(c) ≤ √2 · |c|`;
+- the factor `√2` in disc radii (below) is bounded by the dyadic
+  rationals `181/128 < √2 < 1449/1024`, each within `10⁻³` of `√2`.
+
+Every witness in this library is a strict comparison between two exact
+dyadics: `Decidable`, with no error budget and no interval-arithmetic
+infrastructure. The bounds cost slack: a witness holds only when the
+true Pellet inequality holds with a factor-2 margin (each side loses
+at most `√2`, plus the negligible slack from the rational `√2`
+bounds). Soundness is unaffected, since a witness implies the true
+inequality. The slack only tightens the isolation ratio a disc must
+reach before the witness fires, and it is carried through the
+completeness analysis in the Mathlib companion. The Newton step itself
+uses the approximate `Dyadic.invAtPrec`, but the witness re-check
+after Newton uses the new exact dyadic centre and is again exact.
+
+## Geometry: dyadic squares and circumscribed discs
+
+Subdivision works on dyadic squares (they partition cleanly 4-ways);
+Pellet tests run on the **circumscribed disc** of a square. For a
+square of half-width `2^{−prec}` the circumscribed disc has radius
+`2^{−prec} · √2`. In witnesses that radius appears only through its
+dyadic bounds `2^{−prec} · 181/128` and `2^{−prec} · 1449/1024`.
+
+`prec` is an `Int`, not a `Nat`: the initial square from the Cauchy
+bound has half-width `2^{−prec}` with `prec` negative whenever the
+root bound exceeds 1.
+
+Distances between centres are compared through their squares, which
+are exact dyadics. In particular "the discs of two squares intersect"
+is a single dyadic comparison: with radii `rᵢ = √2·2^{−pᵢ}`,
+
+```
+(r₁ + r₂)² = 2·4^{−p₁} + 2·4^{−p₂} + 4·2^{−p₁−p₂}
+```
+
+is exact, and so is the squared distance between the two
+Gaussian-dyadic centres.
+
+## Pellet witnesses
+
+```lean
+/-- Strong Pellet witness: with `(c₀, …, c_n)` the exact Taylor
+    coefficients of `p` at the centre of `s`, and `ρlo, ρhi` the dyadic
+    bounds on the circumscribed radius `2^{−s.prec}·√2`, the inequality
+
+      `lo(c_k) · ρlo^k > Σ_{i ≠ k} hi(c_i) · ρhi^i`
+
+    holds at the base radius and at 2 and 4 times the base radius.
+    Implies (Mathlib companion): `p` has exactly `k` roots, with
+    multiplicity, in each of the three discs. -/
+def witness (p : ZPoly) (s : DyadicSquare) (k : Nat) : Prop := …
+instance : Decidable (witness p s k) := …
+```
+
+The three-radius form is BSSY's condition for Newton readiness, and it
+makes an atom interchangeable with a one-square cluster (both carry
+the same witness shape). "No roots on the boundary circles" follows
+from the strict inequality and is exposed as a derived lemma in the
+Mathlib companion.
 
 ## Contents
 
@@ -50,345 +101,430 @@ namespace Hex
 structure DyadicSquare where
   re   : Dyadic
   im   : Dyadic
-  prec : Nat
-  -- half-width is 2^{-prec}; circumscribed disc has radius² = 2 · 4^{-prec}
+  prec : Int
+  -- half-width 2^{−prec}; circumscribed disc radius 2^{−prec}·√2
 
+/-- An atom: one square whose circumscribed disc contains exactly one
+    simple root. -/
 structure DyadicRootIsolation (p : ZPoly) where
   square  : DyadicSquare
-  witness : witness₁ p square    -- T_1 squared form on the circumscribed disc
+  witness : witness p square 1
 
+/-- A certified cluster: an edge-connected set of grid squares at a
+    common `prec`, whose enclosing disc contains exactly `k` roots
+    with multiplicity. Kept as a set of squares, never re-boxed into a
+    single square: re-boxing can return the parent square and stall
+    refinement (a root that sits on a grid line keeps its component
+    spanning that line at every depth, while the squares themselves
+    shrink). This is an *output* type; the refinement worklist holds
+    uncertified `Component` values. -/
 structure DyadicRootCluster (p : ZPoly) where
-  square  : DyadicSquare
-  k       : Nat                  -- ≥ 1
-  k_pos   : 0 < k
-  witness : witnessₖ p square k  -- strong T_k on disc, on 2·-radius, on 4·-radius
+  squares   : Array DyadicSquare     -- nonempty, common prec, edge-connected
+  k         : Nat
+  k_pos     : 0 < k
+  witness   : witness p (encSquare squares) k
 
-/-- p has only simple complex roots. Default-decidable via
-`Hex.HasOnlySimpleRoots.decide` (gcd(p, p') is a unit). The Mathlib
-companion proves equivalence with `Squarefree (toPolynomial p)`. -/
+/-- An uncertified component in the refinement worklist: an
+    edge-connected set of grid squares at a common `prec`, plus the
+    root count of its most recently certified ancestor. `candidateK`
+    only selects the order of the speculative Newton step; it is never
+    trusted, since every output is re-certified. -/
+structure Component where
+  squares    : Array DyadicSquare    -- nonempty, common prec, edge-connected
+  candidateK : Nat
+
+/-- The smallest square with power-of-two half-width and centre at the
+    component's bounding-box centre that contains every square of the
+    component. All witness tests run on its circumscribed disc. -/
+def encSquare (squares : Array DyadicSquare) : DyadicSquare := …
+
+/-- A complex ball with dyadic data, the output type of numerical
+    evaluation here and in hex-number-field. -/
+structure DyadicComplexBall where
+  re     : Dyadic
+  im     : Dyadic
+  radius : Dyadic
+
+/-- `p` has only simple complex roots. Decided by casting `p` and `p'`
+    to `DensePoly Rat` and testing whether HexPoly's Euclidean gcd is
+    constant. The Mathlib companion proves equivalence with
+    `Squarefree (toPolynomial p)`. -/
 def HasOnlySimpleRoots (p : ZPoly) : Prop := …
 instance : Decidable (HasOnlySimpleRoots p) := …
 ```
 
-Both `witness₁` and `witnessₖ` are `Decidable` Props built directly
-from dyadic comparisons; the structure-level `cbv_decide` on a fully-
-elaborated `DyadicRootIsolation p` value can prove the witness
-holds. The "no roots on the boundary circle" property of every
-isolation and cluster is implicit in the strict inequality and
-exposed as a derived lemma in the Mathlib companion.
-
 ## Operations
 
 ```lean
-namespace DyadicRootIsolation
-def refine1?  : DyadicRootIsolation p → Option (DyadicRootIsolation p)
-def refine?   : (target : Nat) → DyadicRootIsolation p → Option (DyadicRootIsolation p)
-end DyadicRootIsolation
+namespace Component
+/-- One subdivision round: split every square into 4 children one bit
+    finer, discard children whose disc certifiably contains no root
+    (the `T_0` test; a child whose `T_0` test fails to certify is
+    kept, which is always sound), and glue the survivors into
+    edge-connected components. Total: no certification is required
+    during refinement. -/
+def refine1 : Component → Array Component
 
-namespace DyadicRootCluster
-def refine1? : DyadicRootCluster p → Option (Array (DyadicRootCluster p ⊕ DyadicRootIsolation p))
-def cauchy   : (p : ZPoly) → DyadicRootCluster p
-def atomize  : (c : DyadicRootCluster p) → c.k = 1 → DyadicRootIsolation p
-end DyadicRootCluster
+/-- Try to certify the component as a cluster: a speculative Newton
+    recentring first, then the strong witness on the enclosing
+    square's disc, with `k = candidateK` first and then the remaining
+    `k ≤ deg p`. -/
+def certify? (p : ZPoly) : Component → Option (DyadicRootCluster p)
 
-/-- Refine every cluster in the worklist until each has prec ≥ target. -/
-def isolateAll? (target : Nat) (worklist : Array (DyadicRootCluster p)) :
+/-- The starting component: a single square centred at 0 covering the
+    Cauchy root bound, with `candidateK = deg p`. -/
+def cauchy (p : ZPoly) (h : 0 < p.degree?.getD 0) : Component
+end Component
+
+/-- Repackage a certified `k = 1` cluster as an atom. Total: the
+    cluster's witness already lives on the enclosing square's disc,
+    which is the atom's square. -/
+def DyadicRootCluster.atomize (c : DyadicRootCluster p) (h : c.k = 1) :
+    DyadicRootIsolation p
+
+/-- Refine to `target` precision: speculative Newton steps, falling
+    back to subdivision of the atom's square as a one-square
+    component. `none` only if certification has not reappeared by
+    `stopDepth p target` (see below). -/
+def DyadicRootIsolation.refineTo? (iso : DyadicRootIsolation p)
+    (target : Int) : Option (DyadicRootIsolation p)
+
+/-- Refine every component until certified at prec ≥ target, with the
+    certified discs pairwise disjoint (see "Separation of the output"
+    below). `none` only if this has not happened by
+    `stopDepth p target`. -/
+def isolateAll? (p : ZPoly) (target : Int) (worklist : Array Component) :
     Option (Array (DyadicRootCluster p))
 
-/-- All-atoms output for polynomials with no multiple roots. Implementation:
-    take target := max atom_prec (mahlerPrec p), then atomize. -/
-def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Nat) :
+/-- All-atoms output for polynomials with only simple roots: run
+    `isolateAll?` from `Component.cauchy` with
+    `target := max atom_prec (separationDepth p)`, then `atomize`
+    every cluster. `none` if `isolateAll?` fails or (impossible for
+    squarefree `p`, proven in the companion) some cluster reports
+    `k ≥ 2`. -/
+def isolate (p : ZPoly) (h : Hex.HasOnlySimpleRoots p) (atom_prec : Int) :
     Option (Array (DyadicRootIsolation p))
 ```
 
-`refine1?` (both atom and cluster) tries a speculative Newton step
-first, then falls back to bisection on failure. Newton uses
-`Dyadic.invAtPrec` for the Gaussian inversion `1/c₁ = c̄₁ / |c₁|²`;
-**we explicitly use `invAtPrec` rather than a hypothetical
-`divAtPrec`** because both the real and imaginary components of
-`c̄₁ / |c₁|²` reuse the same real reciprocal `1/|c₁|²`, so a
-precomputed reciprocal beats two separate divisions. The new candidate
-disc is recertified by re-running the witness; on failure (witness
-fails for the candidate disc), bisection is the fallback.
+The speculative Newton step computes `x' = x − k · c₀/c₁` (with
+`k = 1` for atoms; the k-order step for clusters is BSSY §5), places a
+much smaller square at `x'`, and re-runs the witness. If the witness
+certifies, the step gains quadratic precision. If not, the result is
+discarded and subdivision proceeds. There is no a-priori "Newton
+ready" precondition. The Gaussian inversion `1/c₁ = c̄₁ / |c₁|²` uses
+`Dyadic.invAtPrec` for the single real reciprocal `1/|c₁|²`, which
+both the real and imaginary components reuse. That is why the
+implementation calls `invAtPrec` rather than two separate
+`Dyadic.divAtPrec` divisions.
 
-Bisection 4-way-partitions a square into sub-squares of one bit higher
-precision, runs the `T_0` (no-roots) and `T_1` / `T_k` (`k`-roots)
-tests on each sub-square's circumscribed disc, discards `T_0`-positive
-sub-squares, and glues the remaining undecided / positive sub-squares
-into edge-connected components (BSSY, §4). The cluster-level test
-runs on the disc circumscribing the connected-component square.
-
-`refine?` for a single isolation terminates by `target − iso.prec : Nat`
-(strictly decreasing). `isolateAll?` terminates by
+**Termination.** Termination is structural, with no analytic input.
+Write `gap(c) := stopDepth p target − prec(c)` for a component `c` in
+the worklist. One `refine1` round replaces a component of `s` squares
+at gap `g` by components at gap `g − 1` totalling at most `4s`
+squares, so the measure
 
 ```
-Φ(W) := Σ_{c ∈ W, c.prec < target} (4^(target − c.prec) − 1)
+Φ(worklist) := Σ_c (#squares of c) · 5^(gap c)
 ```
 
-which strictly decreases by at least 3 per `refine1?` step (a cluster
-at prec `p` is replaced by at most 4 children at prec `p+1`; the
-contribution changes from `4^(target−p) − 1` to at most
-`4 · (4^(target−p−1) − 1) = 4^(target−p) − 4`). `isolate` is a thin
-wrapper over `isolateAll?` and inherits termination.
+strictly decreases per round (`4s · 5^{g−1} < s · 5^g`). Newton steps
+only jump precision further. What is *not* structural is
+certification: `certify?` can fail at any single depth. The drivers
+therefore keep subdividing past `target`, attempting certification at
+each depth, and give up at
 
-`isolate` returns `none` only if some primitive `refine1?` step has
-returned `none`. The Mathlib companion proves: under
-`Hex.HasOnlySimpleRoots`, the result is always `some` and contains
-exactly the simple-root set of `p` as atoms refined to ≥ `atom_prec`.
+```
+stopDepth p target := max target (separationDepth p) + stopSlack
+```
 
-For polynomials with multiple roots, there is no `isolate` analog.
-Use `isolateAll?` directly; multiple-root clusters never atomise (the
-`T_1` witness fails identically because `c₁ → 0` near a multiple root)
-and surface in the output with their `k ≥ 2` field.
+with `stopSlack := 8`. The constant can be generous at almost no
+cost: each subdivision level *doubles* a component's isolation ratio
+(the
+disc radius halves while the distance to the other roots is fixed
+past `mahlerPrec`), and the witness fires once that ratio clears a
+fixed constant, so the analysis can only ever require a handful of
+extra levels, independent of the input. Overshooting costs a few
+extra subdivision rounds in the rare case certification had not
+already happened, and nothing else. The completeness analysis
+certifies the pinned value (or shows a smaller one suffices). A
+`none` from the drivers has one precise meaning: *a Pellet witness
+failed to appear at separation depth*. The Mathlib
+companion's completeness development
+([hex-roots-mathlib.md](hex-roots-mathlib.md)) is expected to prove
+this impossible for squarefree inputs. Until it does, the soundness
+theorems (which are conditional on a `some` result) are unaffected,
+and the conformance suite checks that `none` does not occur on the
+committed fixtures.
 
-## `mahlerPrec` — termination bound for atomisation
+**Separation of the output.** Certification alone does not prevent
+double-counting. A component whose squares contain no root (its
+`T_0` tests merely failed to certify at this depth) can still pass
+`certify?` with `k = 1` when its enclosing disc overlaps a
+neighbouring component and captures the neighbour's root. The driver
+therefore emits a set of certified clusters only when their witness
+discs are **pairwise disjoint** (one dyadic comparison per pair, as
+in the `SimpleRoot` intersection test); components violating the
+check keep subdividing. Disjoint discs count disjoint root sets, and
+the retained squares cover all roots, so the output `k` values add up
+to exactly the root count. This is the analogue of the separation
+condition in BSSY §4. Rootless components die on their own: once
+every square of such a component is `T_0`-certified empty, the
+component disappears from the worklist.
+
+Roots that sit exactly on a dyadic grid point are not a problem for
+atomization: the Newton step recentres the square on the root itself
+(the arithmetic is exact at Gaussian-dyadic points), after which the
+one-square witness certifies. Roots on a grid *line* keep a two-square
+or four-square component under pure subdivision. Newton recentring is
+what turns those into single-square atoms.
+
+For polynomials with multiple roots there is no `isolate` analogue.
+Use `isolateAll?` directly: a multiple root never atomizes (the `k = 1`
+witness requires `c₁` bounded away from 0, and `c₁ → 0` near a
+multiple root), so it appears in the output as a cluster with its
+`k ≥ 2` field.
+
+## `mahlerPrec`: separation precision
 
 ```lean
 def mahlerPrec (p : ZPoly) : Nat
 ```
 
-For squarefree `p ∈ ℤ[x]` of degree `n` with sup-norm `‖p‖∞`, the
-Mahler/Mignotte separation bound says
+For squarefree `p ∈ ℤ[x]` of degree `n`, the Mahler separation bound
+gives
 
 ```
-min_{i ≠ j} |αᵢ − αⱼ| ≥ √3 · n^{−(n+2)/2} · |disc p|^{1/2} · M(p)^{−(n−1)}
+sep(p) := min_{i ≠ j} |αᵢ − αⱼ| ≥ √3 · n^{−(n+2)/2} · |disc p|^{1/2} · M(p)^{−(n−1)}
 ```
 
-Combined with `|disc p| ≥ 1` (nonzero integer for squarefree `p`) and
-Landau's `M(p) ≤ √(n+1) · ‖p‖∞`, this gives a closed-form lower bound
-on root separation in terms of `n` and `‖p‖∞` only. `mahlerPrec`
-returns a `Nat` such that bisecting to half-width `2^{-mahlerPrec p}`
-suffices to separate any two distinct roots. Pure integer arithmetic;
-no discriminant computation at runtime (we only need the lower bound
-`|disc p| ≥ 1`, not `disc p` itself). The Mathlib companion proves
-correctness — see [hex-roots-mathlib.md](hex-roots-mathlib.md).
+Combined with `|disc p| ≥ 1` (the discriminant of a squarefree integer
+polynomial is a nonzero integer) and Landau's
+`M(p) ≤ √(n+1) · ‖p‖∞`, this bounds `sep(p)` from below in terms of
+`n` and `‖p‖∞` alone. `mahlerPrec p` is a `Nat` such that the
+circumscribed-disc radius at that precision is strictly below
+`sep(p)/4`:
 
-## `SimpleRoot` quotient and the `refine`/`out` threading pattern
+```
+2^{−mahlerPrec p} · 1449/1024 < sep(p) / 4
+```
 
-The Mathlib-free quotient type:
+The `/4` margin is what the `SimpleRoot` intersection test below
+needs. The computation is pure integer arithmetic on the closed-form
+bound (logarithms by repeated squaring). No discriminant is computed
+at runtime; only the constant lower bound `|disc p| ≥ 1` is used. The
+Mahler bound concerns *distinct* roots, so `mahlerPrec` is meaningful
+even for non-squarefree `p`: if `p_sf` is the squarefree part then
+`M(p_sf) ≤ M(p)` and `|disc p_sf| ≥ 1`, so the same closed form
+applies. The Mathlib companion proves correctness; see
+[hex-roots-mathlib.md](hex-roots-mathlib.md).
+
+```lean
+def separationDepth (p : ZPoly) : Nat := mahlerPrec p + sepSlack
+```
+
+with `sepSlack := 8`. `separationDepth` is the depth at which the
+completeness analysis says every Pellet witness certifies: past
+`mahlerPrec p`, each component's disc contains at most one distinct
+root, its isolation ratio doubles with every further level, and the
+witness fires once the ratio clears a fixed constant. The required
+number of extra levels is therefore an absolute constant,
+independent of `p`: the factor-2 witness slack costs one level, the
+enclosing square of a multi-square component at most two, the
+circumscribed `√2` one, and the isolation ratio the Pellet converse
+needs a couple more. Eight comfortably exceeds that count. The
+completeness analysis certifies it (overshoot costs only a few extra
+subdivision rounds on inputs where certification had not already
+happened). It is the depth bound used by `stopDepth` above.
+
+## `SimpleRoot`: identity of a root, up to isolation
 
 ```lean
 namespace Hex
-def SimpleRoot (p : ZPoly) := Quotient (DyadicRootIsolation.setoid p)
 
-/-- Two isolations are equivalent iff they isolate the same simple
-    root of `p`. Generated by direct disc containment; symmetric and
-    transitive closure. Decidable via the Mahler separation bound. -/
-instance DyadicRootIsolation.setoid (p : ZPoly) :
-    Setoid (DyadicRootIsolation p) := …
+/-- An isolation refined at least to separation precision. At this
+    precision the disc radius is below `sep(p)/4`, so two refined
+    isolations isolate the same root exactly when their discs
+    intersect. -/
+def RefinedIsolation (p : ZPoly) :=
+  {iso : DyadicRootIsolation p // (mahlerPrec p : Int) ≤ iso.square.prec}
 
-instance : DecidableEq (SimpleRoot p) := Quotient.decidableEq
+/-- The circumscribed discs intersect. A single exact dyadic
+    comparison (squared centre distance against squared radius sum). -/
+def Intersects (i₁ i₂ : RefinedIsolation p) : Prop := …
+instance : Decidable (Intersects i₁ i₂) := …
 
-namespace SimpleRoot
-def mk (iso : DyadicRootIsolation p) : SimpleRoot p := Quotient.mk _ iso
-end SimpleRoot
+/-- The identity of a simple root, independent of which isolation
+    witnessed it. -/
+def SimpleRoot (p : ZPoly) := Quot (Intersects (p := p))
+
+def SimpleRoot.mk (iso : RefinedIsolation p) : SimpleRoot p := Quot.mk _ iso
+
+/-- Boolean form of `Intersects`, used for equality tests on data
+    containing roots (see hex-number-field). -/
+def RefinedIsolation.sameRoot (i₁ i₂ : RefinedIsolation p) : Bool := …
+
 end Hex
 ```
 
-Decidability of the equivalence: refine both isolations to precision
-`mahlerPrec p`; then either one disc strictly contains the other (→
-equivalent) or the discs are disjoint (→ not equivalent). `mahlerPrec
-p` is finite for any `p ∈ ℤ[x]` — note that the Mahler bound on
-*distinct* roots applies even when `p` itself is not squarefree, since
-`p_sf | p` gives `M(p_sf) ≤ M(p)` and `|disc p_sf| ≥ 1`.
-
-### Computable `out` via canonicalisation
-
-```lean
-def SimpleRoot.out (s : SimpleRoot p) (prec : Nat) : DyadicRootIsolation p
-```
-
-The canonicalisation: refine the underlying iso to precision
-`max prec (mahlerPrec p + canonOverhead p)` (where `canonOverhead p`
-shifts away from dyadic boundaries — `log₂ ‖p‖∞ + 1` suffices, since
-real dyadic roots `a/2^k` of `p ∈ ℤ[x]` have `2^k | lc(p)` by the
-rational root theorem, hence `k ≤ log₂ ‖p‖∞`), then round each
-coordinate down to a multiple of `2^{−prec}`, then re-check the
-witness on the resulting (coarser) disc. The construction is
-deterministic on the equivalence class — different equivalent isos
-produce the same dyadic centre after canonicalisation, so `out` is
-well-defined as a `Quotient.lift`.
-
-### `refineTo`, `refine`, and the threading pattern
-
-For efficiency: if the underlying iso is already at precision ≥
-target, the canonicalisation's refinement loop should short-circuit.
-Two new operations support this:
-
-```lean
-def DyadicRootIsolation.refineTo (iso : DyadicRootIsolation p)
-    (target : Nat) : DyadicRootIsolation p :=
-  if iso.prec ≥ target then iso else <do refinement work>
-
-theorem refineTo_respects_equiv {iso₁ iso₂ : DyadicRootIsolation p} (target : Nat)
-    (h : iso₁ ≈ iso₂) : iso₁.refineTo target ≈ iso₂.refineTo target
-
-def SimpleRoot.refine (s : SimpleRoot p) (target : Nat) : SimpleRoot p :=
-  Quotient.map (·.refineTo target) refineTo_respects_equiv s
-```
-
-Key facts:
-
-- `s.refine target = s` *propositionally*, by `Quotient.sound` plus
-  `refineTo_respects_equiv`. Refining never changes the abstract
-  identity of the simple root.
-- The internal *computational* representative of `s.refine target`
-  is `iso.refineTo target`. When that's already at precision ≥
-  target, this is the identity (zero work).
-- `Quotient.lift_mk`'s definitional reduction guarantees that calls
-  to `s.out prec` operate on the underlying representative directly,
-  so when the rep has precision ≥ `mahlerPrec p + canonOverhead p`,
-  `out`'s canonicalisation is *just* a round-down + witness re-check
-  — no refinement loop.
-
-**Performance contract.** If the internal representative of `s` has
-precision ≥ `mahlerPrec p + canonOverhead p`, then `s.out prec` runs
-in `O(deg p · prec²)` bit operations regardless of `prec`. If the
-internal representative is below that threshold, `out` does
-refinement work that scales with the gap.
+Why the radius bound is part of the type: without it, a coarse
+isolation whose disc overlaps several fine isolations would relate
+distinct roots, and the quotient would collapse them. With every disc
+strictly smaller than `sep(p)/4`, two intersecting discs contain
+points within `sep(p)` of both roots, forcing the roots to coincide.
+That argument is semantic, so this library takes the quotient with
+`Quot` (which needs no equivalence proof) and provides no
+`DecidableEq (SimpleRoot p)`. The Mathlib companion proves that
+`Intersects` restricted to `RefinedIsolation` is an equivalence
+relation whose classes are exactly the simple roots, and hence that
+`sameRoot` decides equality in the quotient. Code in the Mathlib-free
+layer compares roots with `sameRoot` directly.
 
 ### The threading pattern
 
-`SimpleRoot` is a Quotient, so `s.refine t = s` propositionally.
-But the value Lean computes with is *the refined representative*.
-Code that holds a `SimpleRoot` and may call `out` repeatedly should
-refine once and thread the refined value forward:
+`SimpleRoot p` values carry no usable computational content in this
+layer (nothing lifts out of the `Quot` here). Numerical work happens
+on `RefinedIsolation` representatives, which are plain data. A
+function that repeatedly needs high-precision approximations of the
+same root should refine its representative once and pass the refined
+value forward:
 
 ```lean
--- DON'T: each `out` call re-does refinement
-def slow (s : SimpleRoot p) : Foo :=
-  let a := s.out 32
-  let b := s.out 64    -- re-refines if rep is small
-  ...
+-- DON'T: each use re-refines from the stored representative
+def slow (r : RefinedIsolation p) : Foo :=
+  let a := (r.1.refineTo? 32).map …
+  let b := (r.1.refineTo? 64).map …   -- repeats the work up to 32
+  …
 
--- DO: refine once, thread refined value forward
-def fast (s : SimpleRoot p) : SimpleRoot p × Foo :=
-  let s' := s.refine (mahlerPrec p + canonOverhead p)
-  let a := s'.out 32   -- cheap (rep is already refined)
-  let b := s'.out 64   -- cheap
-  (s', ...)            -- caller stores `s'` going forward
+-- DO: refine once, thread the refined representative forward
+def fast (r : RefinedIsolation p) : Option (RefinedIsolation p × Foo) := do
+  let r' ← r.refineTo? 64
+  …                                   -- both uses read r' directly
+  return (r', …)                      -- caller stores r' going forward
 ```
 
-Because `s' = s` propositionally, callers can transparently
-substitute the refined value wherever the original was used.
-Functions producing data that contains a `SimpleRoot` field (e.g.
-`AlgebraicNumber` in `hex-number-field`) should set that field to
-the refined value, so downstream consumers automatically benefit.
+`refineTo?` preserves the root (`sameRoot r r' = true`, proved
+meaningful in the companion), so callers can substitute the refined
+representative wherever the original was used. Structures that contain
+a representative (such as `AlgebraicNumber` in `hex-number-field`)
+should store the refined value on return, so downstream consumers
+inherit the precision.
 
-## Algorithm exposition
+## Differences from BSSY
 
-The library implements the BSSY hybrid `subdivide → glue → speculative
-Newton` loop, restricted to simple `T_1` witnesses for atoms and `T_k`
-witnesses for clusters. Specific differences from BSSY:
+- **No Graeffe iteration.** Deferred as a future optimisation. Without
+  it the `k`-root witness needs a wider isolation ratio around a
+  cluster before it certifies, which costs subdivision depth when
+  distinct roots lie very close together. For typical inputs the
+  difference is small.
+- **No squarefree preprocessing.** A multiple root fails the `k = 1`
+  witness at every radius, so it stays a `k ≥ 2` cluster and is
+  reported as such. Squarefree inputs atomize. Non-squarefree inputs
+  yield the multiple roots as clusters.
+- **Squares partition, discs test.** Squares partition the plane
+  without overlap; circumscribed discs overlap slightly, but the
+  `T_0` discard and the component gluing recover the exact root
+  distribution (BSSY §4).
+- **Speculative Newton.** No precondition is checked before a Newton
+  step; the step is taken and the witness re-run on the result.
+  Certification success is the only acceptance criterion.
 
-- **No Graeffe iteration.** Deferred as a future optimisation; without
-  it, `T_k` requires the disc to be `(2√2/3, 4/3)`-isolating, which is
-  brittle for very tight clusters but adequate for typical inputs.
-- **No squarefree preprocessing.** Honest multiple roots cannot satisfy
-  the `T_1` simplicity-implying inequality at any radius (because
-  `c₁ → 0`), so they correctly stay as `k ≥ 2` clusters. Squarefree
-  inputs atomise; non-squarefree inputs surface the multiple roots as
-  clusters.
-- **Squares for partition; circumscribed discs for tests.** Squares
-  4-way partition without overlap; circumscribed discs harmlessly
-  over-count, but discarding via `T_0` and component-gluing recovers
-  the exact root distribution. (BSSY §4.)
-- **Speculative Newton, then re-test.** No a priori `newtonReady`
-  precondition; we just take the Newton step and re-run the witness on
-  the result. If it certifies, we earned quadratic convergence; if
-  not, we fall back to bisection.
+## File organisation
 
-## Layered file organisation
-
-- `HexRoots/Basic.lean` — types: `DyadicSquare`, `DyadicRootIsolation`,
-  `DyadicRootCluster`, `Hex.HasOnlySimpleRoots`. Also defines the
-  setoid for the equivalence on `DyadicRootIsolation`, the quotient
-  `SimpleRoot p`, decidable equality, `mk`, and `out`.
-- `HexRoots/Refine.lean` — `DyadicRootIsolation.refineTo` (with
-  short-circuit), `refineTo_respects_equiv`, `SimpleRoot.refine`,
-  and the `s.refine target = s` lemma. The threading-pattern
-  guidance lives here as a docstring on `SimpleRoot.refine`.
-- `HexRoots/Taylor.lean` — exact Gaussian-dyadic Taylor expansion of
-  a `ZPoly` at a Gaussian-dyadic centre. Returns the array
-  `(c₀, c₁, ..., c_n) : Array (Dyadic × Dyadic)`.
-- `HexRoots/Pellet.lean` — `T_0`, `T_1`, `T_k` squared-form witness
-  predicates and their `Decidable` instances.
-- `HexRoots/MahlerPrec.lean` — the closed-form `mahlerPrec` function.
-- `HexRoots/Cauchy.lean` — `DyadicRootCluster.cauchy` constructor.
-- `HexRoots/Newton.lean` — speculative Newton step using
-  `Dyadic.invAtPrec`; `DyadicRootIsolation.refine1?` and `refine?`.
-- `HexRoots/Bisection.lean` — 4-way subdivision, component gluing,
-  `DyadicRootCluster.refine1?`.
-- `HexRoots/IsolateAll.lean` — `isolateAll?` driver and the `isolate`
-  convenience wrapper.
-- `HexRoots/Conformance.lean`, `HexRoots/Bench.lean`,
-  `HexRoots/EmitFixtures.lean` — the standard testing trio.
+- `HexRoots/Basic.lean`: `DyadicSquare`, `DyadicComplexBall`,
+  `DyadicRootIsolation`, `DyadicRootCluster`, `Component`,
+  `encSquare`, `Hex.HasOnlySimpleRoots`.
+- `HexRoots/Taylor.lean`: exact Gaussian-dyadic Taylor expansion of a
+  `ZPoly` at a Gaussian-dyadic centre, returning
+  `Array (Dyadic × Dyadic)`.
+- `HexRoots/Pellet.lean`: the dyadic bounds `lo`/`hi`, the rational
+  `√2` constants with their `decide`-checked defining inequalities,
+  the `witness` predicate and its `Decidable` instance.
+- `HexRoots/MahlerPrec.lean`: the closed-form `mahlerPrec` and
+  `separationDepth`.
+- `HexRoots/Cauchy.lean`: `Component.cauchy`.
+- `HexRoots/Newton.lean`: the speculative Newton step (atom and
+  k-order component forms) using `Dyadic.invAtPrec`.
+- `HexRoots/Bisection.lean`: 4-way subdivision, `T_0` discard,
+  component gluing: `Component.refine1` and `Component.certify?`.
+- `HexRoots/Refine.lean`: `DyadicRootIsolation.refineTo?`, the Φ
+  termination measure, `stopDepth`.
+- `HexRoots/IsolateAll.lean`: `isolateAll?`, `atomize`, `isolate`.
+- `HexRoots/SimpleRoot.lean`: `RefinedIsolation`, `Intersects`,
+  `SimpleRoot`, `sameRoot`; the threading-pattern guidance lives here
+  as a docstring.
+- `conformance/HexRoots/{Conformance,EmitFixtures}.lean` and
+  `bench/HexRoots/Bench.lean`: the conformance and bench drivers, in
+  the shared sub-projects.
 
 ## Conformance fixtures
 
 Per [SPEC/testing.md](../testing.md), fixtures are tiered into
-`core` / `ci` / `local`. **Adversarial deterministic families take
-precedence over random samples** because random small-coefficient
-polynomials are weak at exposing clustered-root pathologies.
+`core` / `ci` / `local`. Deterministic adversarial families matter
+more than random samples here, because random small-coefficient
+polynomials rarely have clustered roots.
 
 - *core* (Lean-only, runs on every push):
-  - Sanity polynomials with rational roots: `(x−1)(x−2)(x+3)`, `x³ − x`.
-  - Cyclotomic Φ_n for `n ∈ {5, 7, 12}` — roots are roots of unity.
-  - Chebyshev T_n for `n ∈ {5, 10}` — roots at known `cos((2k−1)π/(2n))`.
-  - Small Mignotte `xⁿ − (a·x − 1)²` for `n = 5`, `a = 100`.
-  - Multiple-root case `(x²+1)·(x−5)²` — verifies that the `k = 2`
-    cluster around `5` does not atomise.
+  - Polynomials with rational roots: `(x−1)(x−2)(x+3)`, `x³ − x`.
+  - Cyclotomic `Φ_n` for `n ∈ {5, 7, 12}`: roots are roots of unity.
+  - Chebyshev `T_n` for `n ∈ {5, 10}`: roots at known
+    `cos((2k−1)π/(2n))`.
+  - Small Mignotte `xⁿ − (a·x − 1)²` for `n = 5`, `a = 100`: one
+    close root pair.
+  - Multiple-root case `(x²+1)·(x−5)²`: checks that the `k = 2`
+    cluster around `5` does not atomize.
 - *ci* (CI, with external oracle when available):
-  - 50 degree-20 polynomials with deterministic seed `0xHEC0FFEE` and
-    coefficients in `[−10, 10]`. Expected outputs serialised from
-    a local oracle run during fixture emission.
+  - 50 degree-20 polynomials with deterministic seed `0xC0FFEE` and
+    coefficients in `[−10, 10]`. Expected outputs serialised from a
+    local oracle run during fixture emission.
 - *local* (developer-driven):
-  - MPSolve-driven adversarial families: Mignotte `(n, a)` for
-    `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`, Wilkinson 20, Bring
-    quintics, Smale-pathological products.
+  - Adversarial families cross-checked against MPSolve: Mignotte
+    `(n, a)` for `n ∈ {10, 20}` and `a ∈ {1000, 10⁶}`, the Wilkinson
+    polynomial of degree 20, and products of two Mignotte polynomials
+    with different parameters (close root pairs at two scales).
 
-External oracles (in role order): MPSolve (primary, Brew-installable);
-FLINT/Arb (secondary, for cases where MPSolve precision is suspect);
-SageMath (fallback).
+External oracles, in role order: MPSolve (primary), FLINT/Arb
+(secondary, for cases where MPSolve's precision is in doubt), SageMath
+(fallback).
 
 ## Complexity contract
 
-- `mahlerPrec p` runs in `O(n · log ‖p‖∞)` integer operations
-  (logarithm by repeated squaring on the closed-form bound).
-- One `T_k` witness check at squared half-width `2^{-prec}` costs
-  `O(n²)` exact-dyadic operations on coefficients of bit-length
-  `O(prec + n · log ‖p‖∞)`, i.e. `O(n²·B²)` bit operations
-  schoolbook.
+Write `n = deg p` and `B = prec + n · log ‖p‖∞` for the working
+bit-length at precision `prec`.
+
+- `mahlerPrec p` runs in `O(n · log ‖p‖∞)` integer operations.
+- One witness check costs `O(n²)` exact-dyadic operations (the Taylor
+  shift dominates) on `B`-bit values, so `O(n² · B²)` bit operations
+  with schoolbook arithmetic.
 - One Newton step costs the same order as one witness check, plus a
   single `Dyadic.invAtPrec` call.
 - `isolate` for degree `n`, well-separated roots, target precision
-  `prec`: heuristically `O(n³ · B²)` bit operations. For tight
-  clusters add a `log(1/separation)` factor, bounded by
-  `mahlerPrec p` in the worst case.
+  `prec`: heuristically `O(n³ · B²)` bit operations. Tight root
+  clusters add subdivision depth up to `O(mahlerPrec p)`.
 
 ## Time budgets (Phase 4 validation)
 
-These are rough first guesses, to be refined against MPSolve on the
-same fixtures during Phase 4:
+Rough first guesses, to be measured against MPSolve on the same
+fixtures during Phase 4:
 
-- Degree 10, prec 32: < 1 second.
-- Degree 50, prec 64: < 10 seconds.
-- Degree 100, prec 128: < 1 minute.
+- Degree 10, prec 32: under 1 second.
+- Degree 50, prec 64: under 10 seconds.
+- Degree 100, prec 128: under 1 minute.
 
 ## References
 
 - Becker, Sagraloff, Sharma, Yap. *A near-optimal subdivision
   algorithm for complex root isolation based on the Pellet test and
-  Newton iteration.* J. Symbolic Computation 86 (2018) 51–96.
-  arXiv:1509.06231. **The reference**; pseudocode for everything in
-  this library traces back to this paper.
+  Newton iteration.* J. Symbolic Computation 86 (2018) 51-96.
+  arXiv:1509.06231. The algorithm implemented here, with the
+  deviations listed above.
 - Imbach, Pan, Yap. *Implementation of a near-optimal complex root
   clustering algorithm (Ccluster).* ICMS 2018, LNCS 10931. The C/Arb
-  implementation paper, with the soft-Pellet filter optimisations.
+  implementation, including the soft-Pellet filter optimisations.
 - Pellet. *Sur un mode de séparation des racines des équations et la
-  formule de Lagrange.* Bull. Sci. Math. 5 (1881) — origin of `T_k`.
-- Mahler. *On some inequalities for polynomials in several variables.*
-  J. London Math. Soc. 37 (1962) — original separation bound.
-- Mignotte. *Some useful bounds.* Computer Algebra: Symbolic and
-  Algebraic Computation, 1982. Standard textbook simplification of
-  Mahler.
+  formule de Lagrange.* Bull. Sci. Math. 5 (1881). Origin of the
+  `T_k` test.
+- Mahler. *An inequality for the discriminant of a polynomial.*
+  Michigan Math. J. 11 (1964) 257-262. The separation bound.
+- Mignotte. *Some useful bounds.* In *Computer Algebra: Symbolic and
+  Algebraic Computation*, Springer, 1982. The textbook form of the
+  bound used by `mahlerPrec`.

--- a/libraries.yml
+++ b/libraries.yml
@@ -469,7 +469,7 @@ libraries:
     done_through: 0
     status: planned
   HexNumberField:
-    deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus]
+    deps: [HexPolyZ, HexRoots, HexResultant, HexBerlekampZassenhaus, HexMatrix, HexRowReduce]
     mathlib: false
     done_through: 0
     status: planned

--- a/progress/20260703T024028Z_spec-libraries-review.md
+++ b/progress/20260703T024028Z_spec-libraries-review.md
@@ -1,0 +1,85 @@
+# Review and revision of the six SPEC/Libraries/ specs
+
+## Accomplished
+
+Interactive session with Kim: reviewed the six planned-library specs
+(hex-roots, hex-roots-mathlib, hex-resultant, hex-resultant-mathlib,
+hex-number-field, hex-number-field-mathlib) for mathematical errors,
+implementer-sufficiency, and language, then rewrote all six plus
+README.md, with Kim's approval of the plan and three decisions
+(rewrite design-level sections in place; rename `Hex.NumberField` to
+`Hex.QAdjoin`; full pass on README.md).
+
+Design-level fixes applied to the specs:
+
+- hex-roots: replaced the unsound "squared Pellet witness" with
+  per-term dyadic bounds (`max(|Re|,|Im|)` minorant, `|Re|+|Im|`
+  majorant, `181/128 < √2 < 1449/1024`); made clusters edge-connected
+  components of grid squares (re-boxing to one square stalled
+  refinement); made isolations carry the strong three-radius witness;
+  `prec` is now `Int` (Cauchy squares have half-width > 1); drivers
+  are fueled and `Option`-valued, with completeness explicitly
+  deferred to the companion; `SimpleRoot` is now a `Quot` over
+  disc-intersection on isolations refined past `mahlerPrec` (which
+  now guarantees radius < sep/4), with `sameRoot : Bool` and no
+  in-library `DecidableEq`; dropped the ill-defined round-down
+  canonicalisation (`out`) entirely.
+- hex-number-field: `AlgebraicNumber` now carries a working
+  `RefinedIsolation` representative and uses `BEq`; irreducibility is
+  an executable `Hex.ZPoly.isIrreducible : Bool` (a small planned
+  addition to hex-berlekamp-zassenhaus) so the Mathlib-free layer can
+  construct the proofs it needs; fixed the transposed `commonField`
+  resultant, the degree-1 `toQAdjoin` case, and the reducible-`p`
+  unsoundness of `toAlgebraicNumber`; added the missing
+  hex-matrix/hex-row-reduce dependencies (also in libraries.yml and
+  README).
+- hex-number-field-mathlib: `AdjoinRoot` now taken over ℚ (was ℤ, an
+  order, not the field); Gauss's lemma citation added; the false
+  bijectivity statement replaced by injectivity-per-BEq plus range
+  characterisation; scope re-stated honestly (Convert/CommonField
+  correctness are the substantive obligations).
+- hex-resultant(-mathlib): corrected complexity contract (O(min(n,m))
+  steps, O(n·m) coefficient ops), removed the impossible
+  bench-against-noncomputable-Mathlib plan, documented the `R = ZPoly`
+  bivariate instantiation, unified `subresultant`/`resultant` naming,
+  fixed the wrong claim that HexRootsMathlib needs
+  `disc_ne_zero_of_squarefree`.
+- Citation fixes throughout, verified against /home/kim/mathlib4 and
+  the v4.32.0-rc1 toolchain: `cbv_decide` does not exist (now
+  `decide`); `Dyadic.invAtPrec` and its two lemmas do exist (and
+  `divAtPrec` exists, contradicting the old "hypothetical" remark);
+  `MinpolyOver` does not exist; `IntermediateField.algebraicClosure`,
+  `primPart`, `EuclideanDomain.gcd_eq_zero_iff`,
+  `Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast`
+  are the right names; Mahler separation is the 1964 Michigan Math. J.
+  paper; Brown is 1978; python-flint class is `fmpz_poly`;
+  `0xHEC0FFEE` was not a hex literal.
+- Language pass per SPEC/writing-style.md over all seven files: no
+  em-dashes, no "bridge"/"core"/"smoke"/"gate", no semicolon run-ons,
+  metaphors literalised, conformance/bench paths corrected to the
+  `conformance/HexX/` + `bench/HexX/` layout, README dead links now
+  point at `HexFoo/SPEC/hex-foo.md`.
+
+Changes are uncommitted (8 files modified), awaiting Kim's review of
+the diff.
+
+## Current frontier
+
+The specs are internally consistent and, I believe, implementable.
+The known-open design risks are recorded inside the specs themselves:
+fuel sufficiency (hex-roots completeness development, deferrable) and
+the size of the Rouché-on-circles formalisation.
+
+## Next step
+
+Kim reviews the diff, then commit. When implementation starts,
+hex-resultant is the natural first library (smallest, no open
+questions); hex-roots next; hex-number-field last (its
+`isIrreducible` prerequisite lands in hex-berlekamp-zassenhaus
+first).
+
+## Blockers
+
+None. One note outside this change's scope:
+`SPEC/lean4-stdlib-inventory.md` predates `Init.Data.Dyadic` and
+should be refreshed.

--- a/progress/20260703T035511Z_spec-libraries-totalisation.md
+++ b/progress/20260703T035511Z_spec-libraries-totalisation.md
@@ -1,0 +1,117 @@
+# Totalisation redesign for the SPEC/Libraries/ specs
+
+Follow-up to `20260703T024028Z_spec-libraries-review.md`, after Kim
+rejected the fuel-based drivers and proposed junk-valued total
+arithmetic.
+
+## Accomplished
+
+Replaced the fuel design across hex-roots.md, hex-roots-mathlib.md,
+hex-number-field.md, hex-number-field-mathlib.md with the design Kim
+and I converged on:
+
+- hex-roots: termination is structural after all. The worklist holds
+  uncertified `Component` values (squares + candidateK); a subdivision
+  round is total (`T_0`-discard keeps children it cannot certify
+  empty, which is sound), and the measure
+  `Φ = Σ (#squares) · 5^(gap)` strictly decreases per round.
+  Certification (`Component.certify?`) happens only when producing
+  output, escalating past the target to
+  `stopDepth p target = max target (separationDepth p) + c₀`, with
+  `separationDepth p = mahlerPrec p + c₁` computable Mathlib-free.
+  `none` from the drivers now has exactly one meaning: a Pellet
+  witness failed to appear at separation depth. `atomize` became
+  total (the k = 1 cluster witness already lives on the enclosing
+  square).
+- hex-roots-mathlib: completeness item is now
+  `certifies_by_separationDepth` (plus `isolate ≠ none` corollary),
+  a statement about depths and witnesses with no recursion counter.
+- hex-number-field: user-facing arithmetic (`add`, `mul`, `sub`,
+  `neg`, `inv`, `toAlgebraicNumber`) is total. Internal `?`-forms
+  return `Option`; the public wrappers pin the `none` branch to `0`
+  via a new `Hex.panicWith (v : α) (msg : String) : α` (explicit junk
+  value per Kim; loud at runtime, definitionally `v`). Junk `0` needs
+  `isIrreducible X` to reduce in the kernel, so `isIrreducible` gets
+  a degree-1 fast path. `QAdjoin.approx` is total with a sound
+  fallback (the current disc's ball, wider than requested).
+  `commonField?` keeps the informative Option signature
+  (algorithm-layer). The two library-specific loop bounds are named:
+  `disambiguationPrec` (height/resultant lower bound on wrong-factor
+  values) and `maxShift` (conjugate-pair collision count).
+- hex-number-field-mathlib: theorems staged as `?_sound`
+  (certificate correct; provable without completeness), `?_isSome`
+  (bound sufficiency; item 6, deferrable with hex-roots
+  completeness), and unconditional headlines like
+  `(α.add β).toComplex = α.toComplex + β.toComplex` by composition.
+  `approx_sound` is unconditional; only `approx_radius` waits on
+  completeness.
+
+Checked: no "fuel" remains, no em-dashes/banned vocabulary, names
+consistent across the four files. All changes still uncommitted
+(along with the previous turn's), awaiting Kim's diff review.
+
+Final-review addendum (same session): a fresh read caught a
+soundness gap in the driver design as written: a rootless component
+(whose `T_0` tests merely failed at the current depth) can certify
+`k = 1` through disc overlap with a neighbour, double-counting that
+root. Fixed by requiring the output clusters' witness discs to be
+pairwise disjoint (a dyadic per-pair check, the analogue of BSSY §4's
+separation condition); hex-roots-mathlib's IsolateAll soundness and
+completeness item 11 updated to match. Also: renamed the pinned
+constants to `stopSlack`/`sepSlack` (they collided with the Taylor
+coefficients `c₀`, `c₁`), and pinned `inv 0 = 0` (Mathlib's division
+convention) so `inv` takes no hypothesis.
+
+## Current frontier
+
+Spec set is consistent under the totalisation design. `panicWith` and
+`isIrreducible` are the two small cross-library additions
+(HexNumberField/Basic.lean for now, and hex-berlekamp-zassenhaus
+respectively).
+
+## Next step
+
+Kim reviews the combined diff; then commit. Implementation order
+unchanged: hex-resultant, hex-roots, hex-number-field.
+
+## Blockers
+
+None.
+
+## Second addendum (same session): Kim's four follow-up concerns
+
+1. **Slack constants**: pinned `sepSlack = stopSlack = 8` in
+   hex-roots.md, with the argument for why a uniform constant
+   suffices (each subdivision level doubles the isolation ratio past
+   `mahlerPrec`, so the analysis can only need a handful of levels,
+   independent of the input; overshoot costs a few extra rounds).
+2. **`disambiguationPrec`**: spelled out the explicit formula in
+   hex-number-field.md (coprime factors give `|Res(m,g)| ≥ 1`; the
+   root-product formula plus Landau bound each conjugate; everything
+   reads off the factor list). Formal ingredients are all
+   already-verified Mathlib API.
+3. **Kernel decide**: measured on the v4.32.0-rc1 toolchain with a
+   list-based model (scratchpad kernel_decide_test.lean): a
+   degree-10/F₅ Rabin-style workload kernel-reduces in ~0.7 s inside
+   default limits; an oversized degree-20/F₁₃ workload takes ~46 s
+   with raised maxRecDepth/maxHeartbeats. Risk reduced by giving
+   `isIrreducible` a four-rung ladder (canonical-form check for
+   degree 1; rational-root test for degree ≤ 3; mod-p Rabin for a few
+   small primes; full factor fallback, runtime-only in practice),
+   documented in hex-number-field.md with the companion obligations
+   (mod-p lifting lemma).
+4. **Rouché status re-verified**: Mathlib mainline (2026-06-18) has
+   no argument principle / Rouché / residue theorem; open PRs are two
+   stalled residue drafts (#29588, #39232); Junyan Xu's étale-space
+   programme (#31925) targets general contours, not needed here. But
+   for polynomials on circles the hard ingredients EXIST:
+   `circleIntegral.integral_sub_inv_of_mem_ball`,
+   `DiffContOnCl.circleIntegral_eq_zero`,
+   `Polynomial.derivative_prod`,
+   `continuous_parametric_intervalIntegral_of_continuous`. Items 5-7
+   of hex-roots-mathlib.md rewritten: partial fractions + linearity +
+   the two integrals give the polynomial argument principle; Rouché
+   by integer-valued-continuous homotopy. Also recorded the
+   MeromorphicOn decoupling trap (LeanEval's rouche_zero_count_eq was
+   false for this reason; Zulip 2026-05): everything stays on
+   `Polynomial ℂ`.

--- a/progress/20260703T045846Z_pr8548-spec-review.md
+++ b/progress/20260703T045846Z_pr8548-spec-review.md
@@ -1,0 +1,16 @@
+# PR 8548 SPEC review
+
+**Accomplished**
+- Reviewed the PR 8548 diff and revised planned-library SPEC files under `SPEC/Libraries/`.
+- Cross-checked the root-isolation, number-field, resultant, and Mathlib companion plans against `SPEC/testing.md`, `SPEC/benchmarking.md`, and `SPEC/writing-style.md`.
+- Identified review findings focused on mathematical correctness and implementability.
+
+**Current frontier**
+- No source files were changed.
+- The main concerns are the constant-depth Pellet completeness claim and the underspecified `commonField?` change-of-basis construction.
+
+**Next step**
+- Send the review findings for PR #8548.
+
+**Blockers**
+- None.


### PR DESCRIPTION
This PR review and revise the six planned-library SPECs (hex-roots, hex-resultant, hex-number-field, and their Mathlib companions), plus README.md and libraries.yml for consistency. The review verified every Mathlib citation against the pinned revision, every hex-dev API claim against the tree, and Dyadic/decide behaviour against the v4.32.0-rc1 toolchain; the mathematical fixes include a transposed resultant in commonField, the degree-1 case of toQAdjoin, AdjoinRoot taken over Q rather than Z, and corrected complexity contracts and references. Four sections are redesigns rather than corrections: the Pellet witnesses now compare per-term dyadic bounds (the squared form was not decidable), clusters are edge-connected components of grid squares with a structural termination measure and a pairwise-disjointness condition on output discs, SimpleRoot is a Quot over disc intersection of separation-refined isolations, and irreducibility is an executable test ladder (canonical form, rational roots, mod-p Rabin, full factor) so the Mathlib-free layer can construct its own proofs, with decide viable at fixture sizes. The user-facing AlgebraicNumber arithmetic is total, pinning the never-hit failure branch to 0 through an explicit panicWith, with staged soundness / bound-sufficiency theorems in the companion; Hex.NumberField is renamed Hex.QAdjoin to avoid the Mathlib class; and the Rouche-on-circles plan now cites the existing circle-integral lemmas (integral_sub_inv_of_mem_ball, DiffContOnCl.circleIntegral_eq_zero) and deliberately avoids MeromorphicOn. All prose follows SPEC/writing-style.md.

🤖 Prepared with Claude Code