### PR TITLE
feat: complete the row/column basic-theory grid and duplicate elementary column ops

### DIFF
--- a/HexDeterminant/ColumnLinear.lean
+++ b/HexDeterminant/ColumnLinear.lean
@@ -250,6 +250,17 @@ theorem det_setCol_smul {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         exact List.foldl_add_mul_left_zero
           (permutationVectors n) c (detTerm (setCol M dst v))
 
+/-- Determinant linearity in one replaced row, additive form. The row mirror of
+`det_setCol_add`, proved by transposing to the column law. -/
+theorem det_setRow_add {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R n n) (dst : Fin n) (v w : Vector R n) :
+    det (setRow M dst (Vector.ofFn fun c => v[c] + w[c])) =
+      det (setRow M dst v) + det (setRow M dst w) := by
+  rw [← det_transpose (setRow M dst (Vector.ofFn fun c => v[c] + w[c])),
+    ← det_transpose (setRow M dst v), ← det_transpose (setRow M dst w),
+    transpose_setRow, transpose_setRow, transpose_setRow]
+  simpa using det_setCol_add (transpose M) dst (fun a => v[a]) (fun a => w[a])
+
 /-- The assembled determinant `det` vanishes when the replaced column is zero. -/
 private theorem det_setCol_zero {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (dst : Fin n) :

--- a/HexDeterminant/RowOps.lean
+++ b/HexDeterminant/RowOps.lean
@@ -1003,25 +1003,21 @@ theorem det_colPermute_vector {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
         rw [permutationVectors_composePermutationValues_left_sum
           (R := R) sigma hsigma (fun tau => detTerm M tau)]
 
-/-- Swapping two columns negates determinant. -/
+/-- Swapping two distinct columns negates the determinant. The column mirror of
+`det_rowSwap`, proved by transposing to the row law. -/
+@[grind =]
 theorem det_colSwap {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
     (M : Matrix R n n) (i j : Fin n) (h : i ≠ j) :
-    det (ofFn fun r c => M[r][finTranspose i j c]) = -det M := by
-  let C : Matrix R n n := ofFn fun r c => M[r][finTranspose i j c]
-  have htranspose : C.transpose = rowSwap M.transpose i j := by
-    ext r hr c hc
-    let rr : Fin n := ⟨r, hr⟩
-    let cc : Fin n := ⟨c, hc⟩
-    change C.transpose[rr][cc] = (rowSwap M.transpose i j)[rr][cc]
-    rw [rowSwap_get_finTranspose M.transpose i j rr h cc,
-      show C.transpose[rr][cc] = C[cc][rr] by simp [Matrix.transpose, Matrix.col],
-      show C[cc][rr] = M[cc][finTranspose i j rr] by simp [C, ofFn]]
-    simp [Matrix.transpose, Matrix.col]
-  calc
-    det C = det C.transpose := (det_transpose C).symm
-    _ = det (rowSwap M.transpose i j) := by rw [htranspose]
-    _ = -det M.transpose := det_rowSwap M.transpose i j h
-    _ = -det M := by rw [det_transpose M]
+    det (colSwap M i j) = -det M := by
+  rw [← det_transpose (colSwap M i j), transpose_colSwap, det_rowSwap _ _ _ h, det_transpose]
+
+/-- Scaling a column by `c` scales the determinant by `c`. The column mirror of
+`det_rowScale`. -/
+@[grind =]
+theorem det_colScale {R : Type u} [Lean.Grind.CommRing R] {n : Nat}
+    (M : Matrix R n n) (j : Fin n) (c : R) :
+    det (colScale M j c) = c * det M := by
+  rw [← det_transpose (colScale M j c), transpose_colScale, det_rowScale, det_transpose]
 
 /-- Adding a multiple of one column to a distinct column preserves determinant. -/
 theorem det_colAdd {R : Type u} [Lean.Grind.CommRing R] {n : Nat}

--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -92,9 +92,12 @@ def memLattice (b : Matrix Int n m) (v : Vector Int m) : Prop :=
   ∃ c : Vector Int n, Matrix.vecMul c b = v
 
 /-- The `k`-th Gram determinant: the determinant of the `k × k` leading
-principal Gram matrix of the integer input. -/
+principal Gram matrix of the integer input.
+
+The bound `hk : k ≤ n` defaults to `by omega`, so callers with a concrete `k`
+and `n` (as in `#guard`s and examples) can omit it. -/
 @[expose]
-def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Nat :=
+def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n := by omega) : Nat :=
   (Matrix.bareiss (GramSchmidt.leadingGramMatrixInt b k hk)).toNat
 
 /-- Linear independence of the row prefix determinants used by the

--- a/HexGramSchmidt/SPEC/hex-gram-schmidt.md
+++ b/HexGramSchmidt/SPEC/hex-gram-schmidt.md
@@ -32,8 +32,9 @@ noncomputable def coeffs (b : Matrix Int n m) : Matrix Rat n n
 /-- The k-th Gram determinant: det of the k×k leading Gram submatrix.
     gramDet b 0 = 1 by convention. Returns Nat (always a positive integer
     for independent bases; an internal helper computes the Int determinant
-    and the public API wraps via .toNat). -/
-def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) : Nat
+    and the public API wraps via .toNat). The bound defaults to `by omega`
+    so callers with concrete k, n can omit it. -/
+def gramDet (b : Matrix Int n m) (k : Nat) (hk : k ≤ n := by omega) : Nat
 
 /-- All Gram determinants as a vector.
     Computed incrementally (e.g. one Bareiss-style elimination pass

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -227,6 +227,30 @@ protected def zero (n m : Nat) [OfNat R 0] : Matrix R n m :=
 instance [OfNat R 0] : Zero (Matrix R n m) where
   zero := Matrix.zero n m
 
+/-- Every entry of the zero matrix is `0`. -/
+@[grind =] theorem getElem_zero [OfNat R 0] (i : Fin n) (j : Fin m) :
+    (0 : Matrix R n m)[i][j] = 0 := by
+  show (Matrix.zero n m)[i][j] = 0
+  simp [Matrix.zero, ofFn]
+
+/-- Every row of the zero matrix is the zero vector. -/
+@[simp, grind =] theorem row_zero [OfNat R 0] (i : Fin n) :
+    row (0 : Matrix R n m) i = Vector.ofFn fun _ => (0 : R) := by
+  ext j hj
+  show (row (0 : Matrix R n m) i)[(⟨j, hj⟩ : Fin m)] =
+    (Vector.ofFn fun _ => (0 : R))[(⟨j, hj⟩ : Fin m)]
+  rw [getElem_row, getElem_zero]
+  simp
+
+/-- Every column of the zero matrix is the zero vector. -/
+@[simp, grind =] theorem col_zero [OfNat R 0] (j : Fin m) :
+    col (0 : Matrix R n m) j = Vector.ofFn fun _ => (0 : R) := by
+  ext i hi
+  show (col (0 : Matrix R n m) j)[(⟨i, hi⟩ : Fin n)] =
+    (Vector.ofFn fun _ => (0 : R))[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_zero]
+  simp
+
 /-- The identity matrix. -/
 @[expose]
 protected def identity (n : Nat) [OfNat R 0] [OfNat R 1] : Matrix R n n :=
@@ -282,6 +306,13 @@ def mulVec [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (v : Vector R m) :
     row (transpose M) j = col M j := by
   simp only [row, transpose, getRow_ofRows]
   grind
+
+/-- The `i`-th column of `transpose M` is the `i`-th row of `M`. -/
+@[simp, grind =] theorem col_transpose (M : Matrix R n m) (i : Fin n) :
+    col (transpose M) i = row M i := by
+  ext k hk
+  show (col (transpose M) i)[(⟨k, hk⟩ : Fin m)] = (row M i)[(⟨k, hk⟩ : Fin m)]
+  rw [getElem_col, getElem_transpose, getElem_row]
 
 /--
 Multiply two matrices, using the naive algorithm.
@@ -359,6 +390,28 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Vector R n) (Matrix R n m) (Vector 
   show (mul M N)[i][j] = (row M i).dotProduct (col N j)
   rw [mul, getElem_ofFn]
 
+/-- Row `i` of `M * N` is the row of dot products of `row M i` against the
+columns of `N`. -/
+@[simp, grind =] theorem row_mul [Mul R] [Add R] [OfNat R 0]
+    (M : Matrix R n m) (N : Matrix R m k) (i : Fin n) :
+    row (M * N) i = Vector.ofFn fun j => (row M i).dotProduct (col N j) := by
+  ext j hj
+  show (row (M * N) i)[(⟨j, hj⟩ : Fin k)] =
+    (Vector.ofFn fun j => (row M i).dotProduct (col N j))[(⟨j, hj⟩ : Fin k)]
+  rw [getElem_row, getElem_mul]
+  simp
+
+/-- Column `j` of `M * N` is the column of dot products of the rows of `M`
+against `col N j`. -/
+@[simp, grind =] theorem col_mul [Mul R] [Add R] [OfNat R 0]
+    (M : Matrix R n m) (N : Matrix R m k) (j : Fin k) :
+    col (M * N) j = Vector.ofFn fun i => (row M i).dotProduct (col N j) := by
+  ext i hi
+  show (col (M * N) j)[(⟨i, hi⟩ : Fin n)] =
+    (Vector.ofFn fun i => (row M i).dotProduct (col N j))[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_mul]
+  simp
+
 /-- The identity matrix entry function: `(identity n)[i][j] = 1` if `i = j`, else `0`. -/
 @[grind =] theorem getElem_identity [OfNat R 0] [OfNat R 1] {n : Nat} (i j : Fin n) :
     (Matrix.identity (R := R) n)[i][j] = if i = j then (1 : R) else 0 := by
@@ -376,6 +429,24 @@ instance [Mul R] [Add R] [OfNat R 0] : HMul (Vector R n) (Matrix R n m) (Vector 
     rw [if_pos hij, if_pos hji]
   · have hji : (⟨j, hj⟩ : Fin n) ≠ ⟨i, hi⟩ := fun h => hij h.symm
     rw [if_neg hij, if_neg hji]
+
+/-- Row `i` of the identity matrix has a `1` in position `i` and `0` elsewhere. -/
+@[simp, grind =] theorem row_identity [OfNat R 0] [OfNat R 1] {n : Nat} (i : Fin n) :
+    row (Matrix.identity (R := R) n) i = Vector.ofFn fun j => if i = j then (1 : R) else 0 := by
+  ext j hj
+  show (row (Matrix.identity (R := R) n) i)[(⟨j, hj⟩ : Fin n)] =
+    (Vector.ofFn fun j => if i = j then (1 : R) else 0)[(⟨j, hj⟩ : Fin n)]
+  rw [getElem_row, getElem_identity]
+  simp
+
+/-- Column `j` of the identity matrix has a `1` in position `j` and `0` elsewhere. -/
+@[simp, grind =] theorem col_identity [OfNat R 0] [OfNat R 1] {n : Nat} (j : Fin n) :
+    col (Matrix.identity (R := R) n) j = Vector.ofFn fun i => if i = j then (1 : R) else 0 := by
+  ext i hi
+  show (col (Matrix.identity (R := R) n) j)[(⟨i, hi⟩ : Fin n)] =
+    (Vector.ofFn fun i => if i = j then (1 : R) else 0)[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_identity]
+  simp
 
 /-- In-place modification of row `i`. Linear in `M`: destructuring consumes `M`,
 so when `M` is uniquely referenced the row is owned and `Vector.modify` updates
@@ -481,6 +552,21 @@ the replacement function and every other column is read from `M`. -/
   · rw [if_pos hc']
     exact congrArg (fun c' : Fin m => M[(⟨r, hr⟩ : Fin n)][c']) hc'.symm
   · rw [if_neg hc']
+
+/-- Transposing a row replacement is a column replacement on the transpose:
+`setRow` on `M` corresponds to `setCol` on `Mᵀ`. This is the bridge the
+determinant row laws route through to reuse the column laws. -/
+theorem transpose_setRow (M : Matrix R n m) (dst : Fin n) (v : Vector R m) :
+    transpose (setRow M dst v) = setCol (transpose M) dst (fun a => v[a]) := by
+  apply ext_getElem
+  intro a b
+  rw [getElem_transpose, getElem_setCol]
+  by_cases hb : b = dst
+  · subst hb
+    rw [show (setRow M b v)[b] = v from setRow_get_self M b v]
+    simp
+  · rw [if_neg hb, show (setRow M dst v)[b] = M[b] from setRow_row_ne M dst b v hb,
+      getElem_transpose]
 
 /-- In-place per-entry column modify: replace each entry `M[i][dst]` by
 `g i M[i][dst]`, every other column unchanged. In-place via `mapRowsIdx`,

--- a/HexMatrix/Elementary.lean
+++ b/HexMatrix/Elementary.lean
@@ -205,6 +205,42 @@ theorem rowAdd_eq_set [Mul R] [Add R] (M : Matrix R n m) (src dst : Fin n) (c : 
   rw [Vector.modify_eq_set _ _ _ dst.isLt]
   congr 1
 
+/-- Column `k` of `rowSwap M i j` is column `k` of `M` with entries `i` and `j`
+exchanged. -/
+@[grind =] theorem col_rowSwap (M : Matrix R n m) (i j : Fin n) (k : Fin m) :
+    col (rowSwap M i j) k =
+      Vector.ofFn fun r => if r = j then M[i][k] else if r = i then M[j][k] else M[r][k] := by
+  ext r hr
+  show (col (rowSwap M i j) k)[(⟨r, hr⟩ : Fin n)] =
+    (Vector.ofFn fun r =>
+      if r = j then M[i][k] else if r = i then M[j][k] else M[r][k])[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_rowSwap]
+  simp
+
+/-- Column `k` of `rowScale M i c` is column `k` of `M` with entry `i` scaled
+by `c`. -/
+@[grind =] theorem col_rowScale [Mul R] (M : Matrix R n m) (i : Fin n) (c : R) (k : Fin m) :
+    col (rowScale M i c) k =
+      Vector.ofFn fun r => if r = i then c * M[i][k] else M[r][k] := by
+  ext r hr
+  show (col (rowScale M i c) k)[(⟨r, hr⟩ : Fin n)] =
+    (Vector.ofFn fun r => if r = i then c * M[i][k] else M[r][k])[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_rowScale]
+  simp
+
+/-- Column `k` of `rowAdd M src dst c` is column `k` of `M` with the `dst` entry
+replaced by `M[dst][k] + c * M[src][k]`. -/
+@[grind =] theorem col_rowAdd [Mul R] [Add R]
+    (M : Matrix R n m) (src dst : Fin n) (c : R) (k : Fin m) :
+    col (rowAdd M src dst c) k =
+      Vector.ofFn fun r => if r = dst then M[dst][k] + c * M[src][k] else M[r][k] := by
+  ext r hr
+  show (col (rowAdd M src dst c) k)[(⟨r, hr⟩ : Fin n)] =
+    (Vector.ofFn fun r =>
+      if r = dst then M[dst][k] + c * M[src][k] else M[r][k])[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_rowAdd]
+  simp
+
 /-- Replace column `dst` by `col dst + c * col src`.
 
 Rather than rebuilding the whole matrix with `ofFn`, each row is mapped to its
@@ -323,6 +359,150 @@ theorem getElem_colAddRight_src_of_ne [Mul R] [Add R]
     (M : Matrix R n m) {src dst : Fin m} (c : R) (hsrcdst : src ≠ dst) :
     col (colAddRight M src dst c) src = col M src :=
   col_colAddRight_of_ne M src c hsrcdst
+
+/-- Row `i` of `colAdd M src dst c` is row `i` of `M` with the `dst` entry
+replaced by `M[i][dst] + c * M[i][src]`. -/
+@[grind =] theorem row_colAdd [Mul R] [Add R]
+    (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) :
+    row (colAdd M src dst c) i =
+      Vector.ofFn fun j => if j = dst then M[i][j] + c * M[i][src] else M[i][j] := by
+  ext j hj
+  show (row (colAdd M src dst c) i)[(⟨j, hj⟩ : Fin m)] =
+    (Vector.ofFn fun j =>
+      if j = dst then M[i][j] + c * M[i][src] else M[i][j])[(⟨j, hj⟩ : Fin m)]
+  rw [getElem_row, getElem_colAdd]
+  simp
+
+/-- Row `i` of `colAddRight M src dst c` is row `i` of `M` with the `dst` entry
+replaced by `M[i][dst] + M[i][src] * c`. -/
+@[grind =] theorem row_colAddRight [Mul R] [Add R]
+    (M : Matrix R n m) (src dst : Fin m) (c : R) (i : Fin n) :
+    row (colAddRight M src dst c) i =
+      Vector.ofFn fun j => if j = dst then M[i][j] + M[i][src] * c else M[i][j] := by
+  ext j hj
+  show (row (colAddRight M src dst c) i)[(⟨j, hj⟩ : Fin m)] =
+    (Vector.ofFn fun j =>
+      if j = dst then M[i][j] + M[i][src] * c else M[i][j])[(⟨j, hj⟩ : Fin m)]
+  rw [getElem_row, getElem_colAddRight]
+  simp
+
+/-- Swap columns `i` and `j` in a dense matrix.
+
+The swap is done row by row via `mapRows`: each row's `i` and `j` entries are
+exchanged with `Vector.swap`, reusing the freed row slot when `M` is uniquely
+referenced. The column mirror of `rowSwap`. -/
+@[expose]
+def colSwap (M : Matrix R n m) (i j : Fin m) : Matrix R n m :=
+  M.mapRows fun row => row.swap i j
+
+/-- Read an entry of `colSwap M i j` by cases on the column index: column `j`
+returns the original column `i`, column `i` returns the original column `j`, and
+any other column is unchanged. -/
+@[grind =] theorem getElem_colSwap (M : Matrix R n m) (i j : Fin m) (r : Fin n) (c : Fin m) :
+    (colSwap M i j)[r][c] =
+      if c = j then M[r][i] else if c = i then M[r][j] else M[r][c] := by
+  rw [colSwap]
+  simp only [getElem_eq_getRow, getRow, rows_mapRows, Vector.getElem_map,
+    Vector.getElem_swap, Fin.getElem_fin, Fin.ext_iff]
+  grind
+
+/-- Column `i` of `colSwap M i j` is the original column `j`. -/
+@[simp, grind =] theorem col_colSwap_left (M : Matrix R n m) (i j : Fin m) :
+    col (colSwap M i j) i = col M j := by
+  ext r hr
+  show (col (colSwap M i j) i)[(⟨r, hr⟩ : Fin n)] = (col M j)[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_col, getElem_colSwap]
+  by_cases hij : i = j <;> simp [hij]
+
+/-- Column `j` of `colSwap M i j` is the original column `i`. -/
+@[simp, grind =] theorem col_colSwap_right (M : Matrix R n m) (i j : Fin m) :
+    col (colSwap M i j) j = col M i := by
+  ext r hr
+  show (col (colSwap M i j) j)[(⟨r, hr⟩ : Fin n)] = (col M i)[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_col, getElem_colSwap]
+  simp
+
+/-- Any column other than `i` and `j` is unchanged by `colSwap M i j`. -/
+theorem col_colSwap_of_ne (M : Matrix R n m) {i j c : Fin m}
+    (hci : c ≠ i) (hcj : c ≠ j) :
+    col (colSwap M i j) c = col M c := by
+  ext r hr
+  show (col (colSwap M i j) c)[(⟨r, hr⟩ : Fin n)] = (col M c)[(⟨r, hr⟩ : Fin n)]
+  rw [getElem_col, getElem_col, getElem_colSwap]
+  simp [hci, hcj]
+
+/-- Row `r` of `colSwap M i j` is row `r` of `M` with entries `i` and `j`
+exchanged. -/
+@[grind =] theorem row_colSwap (M : Matrix R n m) (i j : Fin m) (r : Fin n) :
+    row (colSwap M i j) r =
+      Vector.ofFn fun c => if c = j then M[r][i] else if c = i then M[r][j] else M[r][c] := by
+  ext c hc
+  show (row (colSwap M i j) r)[(⟨c, hc⟩ : Fin m)] =
+    (Vector.ofFn fun c =>
+      if c = j then M[r][i] else if c = i then M[r][j] else M[r][c])[(⟨c, hc⟩ : Fin m)]
+  rw [getElem_row, getElem_colSwap]
+  simp
+
+/-- Transposing a column swap is the corresponding row swap on the transpose.
+This is the bridge the determinant column laws route through. -/
+theorem transpose_colSwap (M : Matrix R n m) (i j : Fin m) :
+    transpose (colSwap M i j) = rowSwap (transpose M) i j := by
+  apply ext_getElem
+  intro a b
+  rw [getElem_transpose, getElem_colSwap, getElem_rowSwap]
+  simp only [getElem_transpose]
+
+/-- Scale column `j` by `c`.
+
+In-place per-entry column update via `modifyCol`: each row's single `j` entry is
+multiplied by `c`, reusing the freed row slot when `M` is uniquely referenced.
+The column mirror of `rowScale`. -/
+@[expose]
+def colScale [Mul R] (M : Matrix R n m) (j : Fin m) (c : R) : Matrix R n m :=
+  M.modifyCol j fun _ x => c * x
+
+/-- Read an entry of `colScale M j c` by cases on the column index: column `j`
+returns `c * M[r][j]`, any other column is unchanged. -/
+@[grind =] theorem getElem_colScale [Mul R] (M : Matrix R n m) (j : Fin m) (c : R)
+    (r : Fin n) (k : Fin m) :
+    (colScale M j c)[r][k] = if k = j then c * M[r][j] else M[r][k] := by
+  rw [colScale, getElem_modifyCol]
+
+/-- Column `j` of `colScale M j c` is the pointwise scalar multiple of column `j`. -/
+@[simp, grind =] theorem col_colScale_self [Mul R] (M : Matrix R n m) (j : Fin m) (c : R) :
+    col (colScale M j c) j = Vector.ofFn fun i => c * M[i][j] := by
+  ext i hi
+  show (col (colScale M j c) j)[(⟨i, hi⟩ : Fin n)] =
+    (Vector.ofFn fun i => c * M[i][j])[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_colScale]
+  simp
+
+/-- Any column other than `j` is unchanged by `colScale M j c`. -/
+theorem col_colScale_of_ne [Mul R] (M : Matrix R n m) {j k : Fin m} (c : R) (hkj : k ≠ j) :
+    col (colScale M j c) k = col M k := by
+  ext i hi
+  show (col (colScale M j c) k)[(⟨i, hi⟩ : Fin n)] = (col M k)[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_col, getElem_colScale]
+  simp [hkj]
+
+/-- Row `r` of `colScale M j c` is row `r` of `M` with entry `j` scaled by `c`. -/
+@[grind =] theorem row_colScale [Mul R] (M : Matrix R n m) (j : Fin m) (c : R) (r : Fin n) :
+    row (colScale M j c) r =
+      Vector.ofFn fun k => if k = j then c * M[r][j] else M[r][k] := by
+  ext k hk
+  show (row (colScale M j c) r)[(⟨k, hk⟩ : Fin m)] =
+    (Vector.ofFn fun k => if k = j then c * M[r][j] else M[r][k])[(⟨k, hk⟩ : Fin m)]
+  rw [getElem_row, getElem_colScale]
+  simp
+
+/-- Transposing a column scaling is the corresponding row scaling on the
+transpose. -/
+theorem transpose_colScale [Mul R] (M : Matrix R n m) (j : Fin m) (c : R) :
+    transpose (colScale M j c) = rowScale (transpose M) j c := by
+  apply ext_getElem
+  intro a b
+  rw [getElem_transpose, getElem_colScale, getElem_rowScale]
+  simp only [getElem_transpose]
 
 end Matrix
 

--- a/HexMatrix/Gram.lean
+++ b/HexMatrix/Gram.lean
@@ -140,6 +140,27 @@ def gramMatrix [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) : Matrix R n n :=
     (gramMatrix M)[i][j] = (row M i).dotProduct (row M j) := by
   rw [gramMatrix, getElem_ofFn]
 
+/-- Row `i` of the Gram matrix pairs `row M i` against every row of `M`. -/
+@[simp, grind =] theorem row_gramMatrix [Mul R] [Add R] [OfNat R 0]
+    (M : Matrix R n m) (i : Fin n) :
+    row (gramMatrix M) i = Vector.ofFn fun j => (row M i).dotProduct (row M j) := by
+  ext j hj
+  show (row (gramMatrix M) i)[(⟨j, hj⟩ : Fin n)] =
+    (Vector.ofFn fun j => (row M i).dotProduct (row M j))[(⟨j, hj⟩ : Fin n)]
+  rw [getElem_row, getElem_gramMatrix]
+  simp
+
+/-- Column `j` of the Gram matrix pairs every row of `M` against `row M j`.
+The Gram matrix is symmetric, so this matches `row_gramMatrix`. -/
+@[simp, grind =] theorem col_gramMatrix [Mul R] [Add R] [OfNat R 0]
+    (M : Matrix R n m) (j : Fin n) :
+    col (gramMatrix M) j = Vector.ofFn fun i => (row M i).dotProduct (row M j) := by
+  ext i hi
+  show (col (gramMatrix M) j)[(⟨i, hi⟩ : Fin n)] =
+    (Vector.ofFn fun i => (row M i).dotProduct (row M j))[(⟨i, hi⟩ : Fin n)]
+  rw [getElem_col, getElem_gramMatrix]
+  simp
+
 /-- The Gram matrix of the identity is the identity. -/
 @[simp, grind =] theorem gramMatrix_identity {R : Type u} [Lean.Grind.CommRing R] {n : Nat} :
     gramMatrix (Matrix.identity (R := R) n) = (Matrix.identity (R := R) n) := by

--- a/HexMatrix/Notation.lean
+++ b/HexMatrix/Notation.lean
@@ -76,14 +76,21 @@ def render [Repr R] (M : Matrix R n m) : Std.Format :=
   Std.Format.text ("#m[" ++ ";\n   ".intercalate (cells.map rowText) ++ "]")
 
 /-- Show matrices in copy-pasteable `#m[...]` notation under `#eval`/`Repr`.
-Higher priority than the generic `Vector` instance so it wins for the
-nested-vector representation; plain (non-nested) vectors keep the default
-rendering. -/
+Higher priority than the `#v[...]` vector instance below so a matrix renders as
+a grid rather than as a nested vector of vectors. -/
 instance (priority := high) [Repr R] : Repr (Matrix R n m) where
   reprPrec M _ := M.render
 
 /-- The `#m[...]` rendering as a `String`. -/
 instance [Repr R] : ToString (Matrix R n m) where
   toString M := M.render.pretty
+
+/-- Render a vector in copy-pasteable `#v[...]` notation under `#eval`/`Repr`,
+mirroring the `#m[...]` matrix rendering. Higher priority than the core
+`deriving Repr` instance, so a bare vector (for example a matrix row or an LLL
+short vector) prints as `#v[...]` and can be pasted straight back as input. -/
+instance (priority := high) reprVector [Repr R] : Repr (Vector R n) where
+  reprPrec v _ :=
+    Std.Format.text ("#v[" ++ ", ".intercalate (v.toList.map fun x => (repr x).pretty) ++ "]")
 
 end Hex.Matrix

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -46,6 +46,42 @@ def takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n) : Matrix R k m :=
        M[ii][jj]) := by
   simp [principalSubmatrix, ofFn]
 
+/-- Row `i` of the `k × k` principal submatrix is row `i` of `M`, restricted to
+the first `k` columns. -/
+@[simp, grind =] theorem row_principalSubmatrix (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
+    (i : Fin k) :
+    row (principalSubmatrix M k hk) i =
+      Vector.ofFn fun j : Fin k =>
+        (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+         let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+         M[ii][jj]) := by
+  ext j hj
+  show (row (principalSubmatrix M k hk) i)[(⟨j, hj⟩ : Fin k)] =
+    (Vector.ofFn fun j : Fin k =>
+      (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+       let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+       M[ii][jj]))[(⟨j, hj⟩ : Fin k)]
+  rw [getElem_row, getElem_principalSubmatrix]
+  simp
+
+/-- Column `j` of the `k × k` principal submatrix is column `j` of `M`,
+restricted to the first `k` rows. -/
+@[simp, grind =] theorem col_principalSubmatrix (M : Matrix R n n) (k : Nat) (hk : k ≤ n)
+    (j : Fin k) :
+    col (principalSubmatrix M k hk) j =
+      Vector.ofFn fun i : Fin k =>
+        (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+         let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+         M[ii][jj]) := by
+  ext i hi
+  show (col (principalSubmatrix M k hk) j)[(⟨i, hi⟩ : Fin k)] =
+    (Vector.ofFn fun i : Fin k =>
+      (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
+       let jj : Fin n := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+       M[ii][jj]))[(⟨i, hi⟩ : Fin k)]
+  rw [getElem_col, getElem_principalSubmatrix]
+  simp
+
 /-- Entry formula for the first-`k`-rows slice. -/
 @[grind =] theorem getElem_takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) (j : Fin m) :

--- a/conformance/HexMatrix/Conformance.lean
+++ b/conformance/HexMatrix/Conformance.lean
@@ -101,7 +101,7 @@ private def spanVec : Vector Rat 3 :=
 -/
 #guard_msgs (whitespace := normalized) in #eval Matrix.transpose baseInt
 
-/-- info: { toArray := #[17, 39], size_toArray := _ } -/
+/-- info: #v[17, 39] -/
 #guard_msgs in #eval Matrix.mulVec baseInt vecInt
 
 /-- info:


### PR DESCRIPTION
This PR fills in the missing entry, row, and column description lemmas across `HexMatrix` so the basic-theory grid is complete: `getElem_`/`row_`/`col_` variants for the zero and identity matrices, matrix multiplication (all three product lemmas stated through `Vector.dotProduct`), transpose, the Gram matrix, principal submatrices, and the elementary row operations. It adds the column mirrors `colSwap` and `colScale` of `rowSwap` and `rowScale`, each with its full `getElem_`/`row_`/`col_` lemma set and a `transpose_colSwap`/`transpose_colScale` bridge to the row versions. Building on those bridges it restates `Hex.Matrix.det_colSwap` against the new `colSwap` operation, `det (colSwap M i j) = -det M`, replacing the previous `ofFn`/`finTranspose` phrasing, and adds `det_colScale` and the row mirror `det_setRow_add`, both proved by transposing to the existing column laws rather than duplicating any development. It gives `Hex.GramSchmidt.Int.gramDet` a `by omega` autoparam on its `k ≤ n` bound so callers with concrete dimensions can drop the explicit proof, and adds a `Repr (Vector R n)` instance rendering vectors as `#v[...]` to match the existing `#m[...]` matrix rendering, so matrix rows and short vectors print copy-pasteable.

The whole graph builds green, including the `HexMatrixMathlib`, `HexDeterminantMathlib`, `HexBareissMathlib`, `HexGramSchmidtMathlib`, and `HexLLLMathlib` bridge layers. All additions are new lemmas or additive defaults except the `det_colSwap` restatement, which has no downstream callers.

🤖 Prepared with Claude Code