### PR TITLE
doc: add toy Coppersmith LLL cryptanalysis tutorial

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -25,6 +25,8 @@ import HexManual.Chapters.HexGFqRing
 import HexManual.Chapters.HexGFqField
 import HexManual.Chapters.HexConway
 import HexManual.Chapters.HexGFq
+-- Tutorials (application-first capstone pages, see SPEC/tutorials.md).
+import HexManual.Tutorials.Coppersmith
 
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
@@ -82,4 +84,17 @@ and, where there is one, its correspondence with Mathlib.
 {include 0 HexManual.Chapters.HexConway}
 
 {include 0 HexManual.Chapters.HexGFq}
+
+# Tutorials
+%%%
+tag := "tutorials"
+%%%
+
+The reference chapters above document each library on its own terms. The
+tutorials here are application-first: each leads with a problem a reader
+already cares about and shows the libraries carrying a recognizable
+end-to-end workflow, with every code snippet checked as part of this
+build.
+
+{include 1 HexManual.Tutorials.Coppersmith}
 

--- a/HexManual/Tutorials/Coppersmith.lean
+++ b/HexManual/Tutorials/Coppersmith.lean
@@ -1,0 +1,203 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import VersoManual
+
+import HexLLL.Basic
+
+open Verso.Genre Manual
+open Verso.Genre.Manual.InlineLean
+
+set_option pp.rawOnError true
+
+#doc (Manual) "LLL in cryptanalysis: a toy Coppersmith attack" =>
+%%%
+tag := "tutorial-coppersmith"
+%%%
+
+# The story
+%%%
+tag := "tutorial-coppersmith-story"
+%%%
+
+A courier sends the same templated message every day: a fixed body with
+one short field that changes, say a two-digit code. An eavesdropper knows
+the template and knows the day's ciphertext, and wants the code.
+
+The message is RSA-encrypted with public exponent `e = 3`. That small
+exponent, with no random padding, is the weakness. Write the plaintext as
+`m = a + x₀`, where `a` is the known template (as an integer) and `x₀` is
+the unknown code, with `0 ≤ x₀ < X` for a small bound `X`. The ciphertext
+is `c = m³ mod N`. Everything except `x₀` is public: the modulus `N`, the
+exponent `3`, the ciphertext `c`, the template `a`, and the bound `X`.
+
+Knowing that `m³` genuinely wraps around the modulus (`m³ > N`, so `c` is
+not just the integer cube of `m`) rules out the trivial cube-root attack.
+The unknown `x₀` is a *small root* of a polynomial modulo `N`:
+`f(x) = (a + x)³ − c`, and `f(x₀) ≡ 0 (mod N)`. Coppersmith's method finds
+small modular roots by lattice reduction, and that is what this page does
+with the project's LLL layer. See the {ref "hex-lll"}[HexLLL chapter] for
+the reducer itself.
+
+# From a modular root to a lattice
+%%%
+tag := "tutorial-coppersmith-lattice"
+%%%
+
+Expanding, `f(x) = x³ + 3a·x² + 3a²·x + (a³ − c)`, a monic cubic whose
+coefficients we reduce modulo `N` to small representatives. The idea due
+to Howgrave-Graham turns "small root mod `N`" into "root over the
+integers". If we can find another polynomial `g` that also has `x₀` as a
+root modulo `N`, but whose coefficients are *small enough* that
+`g(x₀)`, evaluated at the small integer `x₀`, is smaller in absolute value
+than `N`, then `g(x₀) ≡ 0 (mod N)` forces `g(x₀) = 0` over the integers.
+An integer root of a known polynomial is then read off by a search.
+
+Such small-coefficient combinations are exactly the short vectors of a
+lattice. Encode a polynomial by its coefficient vector, scaling the
+degree-`j` coefficient by `Xʲ` so that "coefficients small after
+substituting `x = X·y`" becomes "vector short". The lattice is spanned by
+four rows, each a polynomial vanishing at `x₀` modulo `N`: the three
+multiples `N`, `N·x`, `N·x²`, and `f` itself.
+
+```
+row N       : [ N,     0,      0,       0   ]
+row N·x     : [ 0,     N·X,    0,       0   ]
+row N·x²    : [ 0,     0,      N·X²,    0   ]
+row f       : [ a₀,    a₁·X,   a₂·X²,   X³  ]
+```
+
+Reducing this basis with LLL produces a short vector whose polynomial `g`
+is a small-coefficient integer combination of the four rows. The
+short-vector guarantee is the Lean-proved
+{name}`Hex.short_vector_bound_of_size_bound`. The Howgrave-Graham bound
+that turns "short enough" into "root over the integers" is classical
+number theory, asserted here in prose rather than formalized; this page
+demonstrates the computational step, it does not prove the Coppersmith
+theorem.
+
+# The attack, end to end
+%%%
+tag := "tutorial-coppersmith-attack"
+%%%
+
+The instance below uses two nine-digit primes, a known template
+`a = 55_555_500`, and a two-digit code `x₀ = 42`, hidden inside
+`c = m³ mod N`. The attacker uses only the public data `N`, `a`, `c`, and
+`X = 100` to rebuild the lattice, reduce it with the exact integer reducer
+{name}`Hex.lllNative`, and recover the code.
+
+Every basis row has its degree-`j` column divisible by `Xʲ`, so every
+lattice vector does too; de-scaling a reduced row back to integer
+coefficients therefore always succeeds. The recovery scans all reduced
+rows, de-scales each to a candidate polynomial `g`, searches
+`0 ≤ x < X` for an integer root, and accepts the first `x` that also
+reproduces the ciphertext. The verification is that the recovered code is
+`42`.
+
+```lean
+open Hex
+
+namespace TutorialCoppersmith
+
+-- Public data the attacker starts from.
+private def N : Int := 10_000_004_400_000_259
+private def X : Int := 100
+private def a : Int := 55_555_500
+private def c : Int := 3_100_253_145_270_284
+
+-- Least residue of z modulo n, in (-n/2, n/2].
+private def centerMod (n z : Int) : Int :=
+  let r := ((z % n) + n) % n
+  if 2 * r > n then r - n else r
+
+-- Coefficients of f(x) = (a + x)^3 - c, reduced mod N.
+private def a0 : Int := centerMod N (a ^ 3 - c)
+private def a1 : Int := centerMod N (3 * a ^ 2)
+private def a2 : Int := centerMod N (3 * a)
+
+-- The Coppersmith lattice, one polynomial per row,
+-- degree-j column scaled by X^j.
+private def B : Matrix Int 4 4 :=
+  Matrix.ofFn fun i j =>
+    match i.val, j.val with
+    | 0, 0 => N
+    | 1, 1 => N * X
+    | 2, 2 => N * X * X
+    | 3, 0 => a0
+    | 3, 1 => a1 * X
+    | 3, 2 => a2 * X * X
+    | 3, 3 => X * X * X
+    | _, _ => 0
+
+private theorem hlo : (1 / 4 : Rat) < 3 / 4 := by grind
+private theorem hhi : (3 / 4 : Rat) ≤ 1 := by grind
+
+-- LLL-reduce at delta = 3/4.
+private def reduced : Matrix Int 4 4 :=
+  lllNative B (3 / 4) hlo hhi (by decide)
+
+-- De-scale a reduced row to integer coefficients.
+private def descale (r : Array Int) : Option (Array Int) :=
+  Id.run do
+    let mut g : Array Int := #[]
+    let mut xp : Int := 1
+    for k in [0:4] do
+      if r[k]! % xp != 0 then return none
+      g := g.push (r[k]! / xp)
+      xp := xp * X
+    return some g
+
+-- Horner evaluation of a degree-3 integer polynomial.
+private def evalPoly (g : Array Int) (x : Int) : Int :=
+  ((g[3]! * x + g[2]!) * x + g[1]!) * x + g[0]!
+
+-- Scan reduced rows for an integer root that reproduces c.
+private def recover : Option Int := Id.run do
+  let rows := reduced.rows.toArray.map (·.toArray)
+  for row in rows do
+    match descale row with
+    | none => pure ()
+    | some g =>
+      for x in [0:100] do
+        let xi : Int := (x : Int)
+        if evalPoly g xi == 0 && (a + xi) ^ 3 % N == c then
+          return some xi
+  return none
+
+-- The ciphertext really wraps mod N, not a raw cube.
+#guard (a + 42) ^ 3 % N == c
+#guard (a + 42) ^ 3 != c
+
+-- LLL actually reduced the basis.
+#guard lllReducedInt reduced (3 / 4) (1 / 2) == true
+
+-- The recovered code is 42.
+#guard recover == some 42
+
+end TutorialCoppersmith
+```
+
+# Toy versus real
+%%%
+tag := "tutorial-coppersmith-boundary"
+%%%
+
+This instance is deliberately small and honest about it. The modulus is
+tiny, the lattice is the minimal single-shift construction, and the final
+root search is a bounded scan rather than an integer factorization of `g`.
+The single-shift lattice recovers roots only up to about `N^(1/6)`, well
+short of the `N^(1/3)` that the full method reaches; the chosen `x₀` sits
+comfortably inside that margin.
+
+A real attack differs in degree, not in kind. It adds many shift
+polynomials `xⁱ·f(x)ʲ` to enlarge the lattice and push the recoverable
+bound toward `N^(1/3)`, extracts the integer root of `g` by factoring over
+the integers (for which `hex-poly-z` is the project's tool) rather than
+scanning, and appears in settings such as stereotyped-message recovery,
+partial key exposure, and the Boneh-Durfee attack on small RSA private
+exponents. The computational heart, encode the constraint as a lattice and
+reduce it, is exactly what ran above.

--- a/progress/20260703T052501Z_tutorial-coppersmith.md
+++ b/progress/20260703T052501Z_tutorial-coppersmith.md
@@ -1,0 +1,54 @@
+# Tutorial 4: LLL in cryptanalysis (toy Coppersmith attack)
+
+Wrote the fourth capstone tutorial page specified in
+[SPEC/tutorials.md](../SPEC/tutorials.md) §4, the LLL-anchored Phase 7
+tutorial ([PLAN/Phase7.md](../PLAN/Phase7.md) table).
+
+## Accomplished
+
+- New Verso chapter `HexManual/Tutorials/Coppersmith.lean`: an
+  application-first page that presents a weak RSA `e = 3`
+  stereotyped-message instance, encodes the missing suffix as a small
+  modular root of `f(x) = (a + x)^3 - c`, builds the minimal single-shift
+  Coppersmith / Howgrave-Graham lattice, LLL-reduces it with the exact
+  integer reducer `Hex.lllNative`, and recovers the hidden code from the
+  reduced basis.
+- The worked example is fully build-checked. Coefficients are computed
+  live from public data via a `centerMod` helper (no magic constants).
+  Recovery scans all reduced rows, de-scales each (every basis column is
+  divisible by its `X^j` scale, so de-scaling always succeeds), searches
+  `0 <= x < X` for an integer root, and accepts the first that reproduces
+  the ciphertext. Four `#guard`s pin: the ciphertext genuinely wraps mod
+  `N` (not a raw cube), the reduced basis passes `lllReducedInt`, and the
+  recovered code is `42`.
+- Concrete instance: `p = 100000007`, `q = 100000037`,
+  `N = 10000004400000259`, template `a = 55555500`, bound `X = 100`,
+  hidden `x0 = 42`. Validated first in Python, then authoritatively in
+  Lean via a temporary compiled `lean_exe` (needed because `lllNative`
+  routes through the `@[extern]` `Matrix.exactDiv`, which the plain
+  interpreter cannot run): Lean's `lllNative` produces the same reduced
+  basis Python does, and recovery returns `some 42`. The reduction is
+  nontrivial (the recovered short polynomial has leading coefficient 27,
+  a genuine integer combination of the four rows), so the page shows LLL
+  doing real work rather than returning `f` unchanged.
+- Wired into the aggregator: `HexManual.lean` gains the import and a new
+  `# Tutorials` section that includes the page at heading depth 1. No
+  `lakefile.lean` change (the `HexManual` lean_lib discovers modules by
+  import); no `libraries.yml` change (`HexLLL` is already
+  `done_through: 7`, this closes its outstanding tutorial exit criterion).
+
+## Current frontier
+
+Page builds clean inside the `HexManual` lean_lib (all embedded `#guard`s
+green, zero line-length warnings after shortening four lines) and the
+full manual renders.
+
+## Next step
+
+None for this page. The remaining tutorials (AES arithmetic, AES modulus
+irreducibility, Kummer-Dedekind splitting) are separate anchor-library
+work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds the LLL-anchored tutorial specified in SPEC/tutorials.md section 4, the toy Coppersmith attack, as a new Verso chapter `HexManual/Tutorials/Coppersmith.lean` and a `Tutorials` section in the `HexManual` aggregator. The page is application-first: it presents a weak RSA `e = 3` stereotyped-message instance whose plaintext is a known template plus a short unknown suffix, encodes the missing suffix as a small modular root of `f(x) = (a + x)^3 - c`, builds the minimal single-shift Coppersmith/Howgrave-Graham lattice, LLL-reduces it with the exact integer reducer `Hex.lllNative`, and recovers the hidden code from the reduced basis. Coefficients are computed live from public data, recovery scans all reduced rows and de-scales each, and four `#guard`s pin the result (the ciphertext genuinely wraps mod `N`, the reduced basis passes `lllReducedInt`, and the recovered code is `42`), so every snippet is checked by the docs build. A closing section draws the boundary between the toy setup and real cryptanalysis. No `lakefile.lean` change is needed (the `HexManual` lean_lib discovers modules by import) and no `libraries.yml` change (`HexLLL` is already `done_through: 7`; this closes its outstanding tutorial exit criterion in PLAN/Phase7.md).

🤖 Prepared with Claude Code