### PR TITLE
chore: Phase 6 closeout for HexMatrixMathlib + HexGramSchmidtMathlib

### DIFF
--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -1170,24 +1170,6 @@ theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss
         (GramSchmidt.scaledCoeffMatrix b i j hji)).trans
       (HexMatrixMathlib.det_eq (GramSchmidt.scaledCoeffMatrix b i j hji)).symm).symm
 
-/-- The fraction-free scaled-coefficient loop computes the Cramer/Bareiss
-integer equal to `d[j+1] * μ[i,j]` below the diagonal. Derived from the
-unconditional `scaledCoeffs_lower_eq_det_scaledCoeffMatrix` and
-`scaledCoeffMatrix_det_eq_gramDet_mul_coeffs`. -/
-private theorem scaledCoeffRows_lower_eq_coeffs
-    (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
-    ((getArrayEntry (scaledCoeffRows b) i j : Int) : Rat) =
-      (gramDet b (j + 1) (Nat.succ_le_of_lt (Nat.lt_trans hj hi)) : Rat) *
-        GramSchmidt.entry (coeffs b) ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ := by
-  have hjlt : j < n := Nat.lt_trans hj hi
-  have h_array :
-      getArrayEntry (scaledCoeffRows b) i j =
-        GramSchmidt.entry (scaledCoeffs b) ⟨i, hi⟩ ⟨j, hjlt⟩ := by
-    rw [scaledCoeffs_entry_eq_getArrayEntry,
-      getArrayEntry_scaledCoeffRowsSchur_eq b (StepWitness.ofGram b)]
-  rw [h_array, scaledCoeffs_lower_eq_det_scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, hjlt⟩ hj]
-  exact scaledCoeffMatrix_det_eq_gramDet_mul_coeffs b i j hi hj
-
 /-- Below the diagonal, the rational image of the integer scaled
 Gram-Schmidt coefficient factors as `gramDet b (j+1) * coeffs[i,j]`. Derived
 from the unconditional `scaledCoeffs_lower_eq_det_scaledCoeffMatrix` and

--- a/HexGramSchmidtMathlib/Int/GramDet.lean
+++ b/HexGramSchmidtMathlib/Int/GramDet.lean
@@ -30,22 +30,6 @@ namespace Hex
 namespace GramSchmidt
 namespace Int
 
-/-- Bareiss agrees with the Leibniz determinant on the Cramer matrix used by
-the scaled-coefficient formula. -/
-private theorem scaledCoeffMatrix_bareiss_eq_det
-    (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i) :
-    ((Matrix.bareiss
-        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj) :
-          Int) : Rat) =
-      ((Matrix.det
-        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj) :
-          Int) : Rat) :=
-  by exact_mod_cast
-    (HexMatrixMathlib.bareiss_eq_mathlib_det
-        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj)).trans
-      (HexMatrixMathlib.det_eq
-        (GramSchmidt.scaledCoeffMatrix b ⟨i, hi⟩ ⟨j, Nat.lt_trans hj hi⟩ hj)).symm
-
 /-- Leading integer Gram determinants are nonnegative. -/
 theorem leadingGramMatrixInt_det_nonneg
     (b : Matrix Int n m) (t : Nat) (ht : t ≤ n) :
@@ -1184,44 +1168,6 @@ private theorem dot_castIntRow_castIntRow_eq
       rw [dot_castIntRow_basis_eq_zero_of_lt b p r hp hrn hpr]
       grind)
     ((j + 1) + d) hkdn (Nat.le_add_right (j + 1) d)
-
-private theorem dot_basisPrefixProjection_eq_castIntGram
-    (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i)
-    (p : Fin (j + 1)) :
-    Vector.dotProduct
-        (castIntRow b
-          ⟨p.val, Nat.lt_of_lt_of_le p.isLt
-            (Nat.succ_le_of_lt (Nat.lt_trans hj hi))⟩)
-        (basisPrefixProjection b i j hi (Nat.lt_trans hj hi)) =
-      ((Vector.dotProduct
-          (b.row
-            ⟨p.val, Nat.lt_of_lt_of_le p.isLt
-              (Nat.succ_le_of_lt (Nat.lt_trans hj hi))⟩)
-          (b.row ⟨i, hi⟩) : Int) : Rat) := by
-  rw [← dot_castIntRow_eq_cast_dot b
-    (⟨p.val, Nat.lt_of_lt_of_le p.isLt
-      (Nat.succ_le_of_lt (Nat.lt_trans hj hi))⟩ : Fin n)
-    (⟨i, hi⟩ : Fin n)]
-  exact
-    (dot_castIntRow_castIntRow_eq
-      b i j p.val hi hj (Nat.le_of_lt_succ p.isLt)
-      (Nat.lt_of_lt_of_le p.isLt
-        (Nat.succ_le_of_lt (Nat.lt_trans hj hi)))).symm
-
-private theorem scaledCoeffMatrix_replacementColumn_solve_intGram
-    (b : Matrix Int n m) (i j : Nat) (hi : i < n) (hj : j < i)
-    (p : Fin (j + 1)) :
-    (castIntDetMatrix
-        (GramSchmidt.leadingGramMatrixInt b (j + 1)
-          (Nat.succ_le_of_lt (Nat.lt_trans hj hi))) *
-        originalProjectionCoords b i j hi (Nat.lt_trans hj hi))[p] =
-      ((Vector.dotProduct
-          (b.row
-            ⟨p.val, Nat.lt_of_lt_of_le p.isLt
-              (Nat.succ_le_of_lt (Nat.lt_trans hj hi))⟩)
-          (b.row ⟨i, hi⟩) : Int) : Rat) := by
-  rw [scaledCoeffMatrix_replacementColumn_solve b i j hi hj p]
-  exact dot_basisPrefixProjection_eq_castIntGram b i j hi hj p
 
 /-- Isolate the last term in a `foldl` over `List.finRange (k + 1)` when every
 earlier term vanishes. -/

--- a/HexGramSchmidtMathlib/Int/RowAdd.lean
+++ b/HexGramSchmidtMathlib/Int/RowAdd.lean
@@ -49,14 +49,6 @@ private theorem rowAdd_row_eq_of_ne {R : Type u} [Mul R] [Add R] {n' m' : Nat}
   rw [Matrix.rowAdd_eq_set]
   exact Hex.Matrix.setRow_row_ne M dst r _ (fun heq => hr (congrArg Fin.val heq))
 
-/-- The row of `Matrix.rowAdd M src dst c` at index `dst` is the entry-wise
-sum `M[dst] + c * M[src]`. -/
-private theorem rowAdd_row_at {R : Type u} [Mul R] [Add R] {n' m' : Nat}
-    (M : Matrix R n' m') (src dst : Fin n') (c : R) :
-    (Matrix.rowAdd M src dst c)[dst] =
-      Vector.ofFn fun k => M[dst][k] + c * M[src][k] := by
-  simp [Matrix.rowAdd_eq_set, Hex.Matrix.getRow, Hex.Matrix.rows_setRow, Fin.getElem_fin]
-
 /-- Inductive helper for `dot_rowAdd_row_at_left`: distribution along a foldl. -/
 private theorem foldl_dot_rowAdd_at {n' m' : Nat}
     (M : Matrix Int n' m') (src dst : Fin n') (c : Int) (w : Vector Int m')
@@ -188,10 +180,10 @@ theorem scaledCoeffMatrix_rowAdd_pivot_det
         have hval := congrArg Fin.val hq_last
         simpa [last] using hval
       simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, Hex.Matrix.getElem_pair_eq_nested]
+        Hex.Matrix.getElem_ofFn]
       rw [if_pos hq_last, hq_lift]
     · simp only [M, gramCol, GramSchmidt.leadingGramMatrixInt, Hex.Matrix.getElem_setCol,
-        Hex.Matrix.getElem_ofFn, Hex.Matrix.getElem_pair_eq_nested]
+        Hex.Matrix.getElem_ofFn]
       rw [if_neg hq_last]
   calc
     Matrix.det (GramSchmidt.scaledCoeffMatrix (Matrix.rowAdd b j k c) k j hjk)

--- a/libraries.yml
+++ b/libraries.yml
@@ -376,7 +376,7 @@ libraries:
   HexMatrixMathlib:
     deps: [HexMatrix]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
     phase4:
       input_families:
@@ -409,7 +409,7 @@ libraries:
   HexGramSchmidtMathlib:
     deps: [HexGramSchmidt, HexBareissMathlib]
     mathlib: true
-    done_through: 5
+    done_through: 6
     status: active
   HexPolyZMathlib:
     deps: [HexPolyZ, HexHensel, HexPolyMathlib, HexModArithMathlib]

--- a/progress/20260703T070643Z_phase6-mathlib-closeouts.md
+++ b/progress/20260703T070643Z_phase6-mathlib-closeouts.md
@@ -1,0 +1,36 @@
+# Phase 6 closeout — HexMatrixMathlib + HexGramSchmidtMathlib (#8262/#8263/#8265)
+
+**Accomplished**
+- Discovered #8262/#8265 were premised on a HexMatrixMathlib structure that
+  no longer exists: the `Determinant/` subtree, `RankSpanNullspace.lean`,
+  `bareiss_eq_det`, and the 23 named unreferenced theorems were all removed
+  when `Hex.Matrix` was encapsulated behind a one-field structure (#8442) and
+  the docs rewritten (#8479/#8486). Retargeted the *goal* (Phase 6 closeout +
+  bump) onto the current files.
+- Calibrated the linter/dead-code bar against the done_through-6 sibling
+  HexPolyZMathlib (the exact pattern #8260 established): simpNF findings are
+  tolerated (the sibling carries 13), and unreferenced *public* documented
+  correspondence lemmas are kept as Mathlib-facing API (the sibling carries
+  15 public / 0 private).
+- HexMatrixMathlib: already clean (0 orphans, docBlame 0, no warnings, one
+  tolerated simpNF on `matrixEquiv_symm_apply`). Closeout is the bump.
+- HexGramSchmidtMathlib: fixed 2 build-time `unusedSimpArgs` warnings
+  (`RowAdd.lean` 191/194), excised 5 unreferenced private orphans
+  (`scaledCoeffMatrix_bareiss_eq_det`,
+  `scaledCoeffMatrix_replacementColumn_solve_intGram` and its now-orphaned
+  helper `dot_basisPrefixProjection_eq_castIntGram`, `scaledCoeffRows_lower_eq_coeffs`
+  [superseded by the adjacent public `scaledCoeffs_eq`], `rowAdd_row_at`),
+  leaving 4 public / 0 private orphans — matching the sibling profile.
+- Bumped both `done_through: 5 → 6`. `lake build` green with zero warnings;
+  `check_dag` exit 0; `status.py` now lists both under Phase 7.
+
+**Current frontier**
+- Both bridge libraries are at Phase 6. Their Phase 7 (reference-manual
+  chapters) is the next step, tracked separately.
+
+**Next step**
+- Close #8265 (obsolete — its 23-theorem target was removed by #8442) and
+  #8262/#8263 (delivered via this retargeted closeout).
+
+**Blockers**
+- None.


### PR DESCRIPTION
This PR closes out Phase 6 (proof polishing) for the `HexMatrixMathlib` and `HexGramSchmidtMathlib` bridge layers and bumps both to `done_through: 6`.

While executing the three tracking issues (#8262, #8263, #8265) it emerged that #8262 and #8265 were premised on a `HexMatrixMathlib` structure that no longer exists — the `Determinant/` subtree, `RankSpanNullspace.lean`, `bareiss_eq_det`, and the 23 named unreferenced theorems #8265 lists were all removed when `Hex.Matrix` was encapsulated behind a one-field structure (#8442) and the docs were rewritten (#8479/#8486). The Phase 6 *goal* still applied to the current files, so this retargets the closeout onto them.

The dead-code and linter bar is calibrated against the `done_through: 6` sibling `HexPolyZMathlib` (the pattern #8260 established): `simpNF` findings are tolerated (that sibling carries 13) and unreferenced *public* documented correspondence lemmas are kept as Mathlib-facing API (it carries 15 public / 0 private). `HexMatrixMathlib` is already Phase-6-clean — zero dead code, `docBlame` zero, no build warnings, one tolerated `simpNF` on `matrixEquiv_symm_apply` — so its closeout is the bump alone. `HexGramSchmidtMathlib` needed two build-time `unusedSimpArgs` warnings cleared (`Int/RowAdd.lean`) and five unreferenced private orphans excised (`scaledCoeffMatrix_bareiss_eq_det`, `scaledCoeffMatrix_replacementColumn_solve_intGram` with its cascade helper `dot_basisPrefixProjection_eq_castIntGram`, `scaledCoeffRows_lower_eq_coeffs` — superseded by the adjacent public `scaledCoeffs_eq` — and `rowAdd_row_at`); it now carries 4 public / 0 private unreferenced decls, matching the sibling profile.

The four retained public lemmas (`int_basis_row_eq_gramSchmidt`, `augmentedGram_trailing_row`, `scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular`, `scaledCoeffs_diag_eq_gramDet_of_no_singular`) are documented correspondence lemmas kept as intended bridge API; a reviewer with library context should veto any that are genuinely scaffolding rather than surface.

`lake build` is green for both libraries with zero warnings, `check_dag` exits 0, and `status.py` now lists both under Phase 7. The Phase 6 native-path / oracle / performance exit criteria are vacuous for these `noncomputable` proof-only bridges.

Closes #8262. Closes #8263. Closes #8265.

🤖 Prepared with Claude Code