### PR TITLE
refactor: explicit Lean loader for the fpLLL LLL provider

### DIFF
--- a/HexLLL/Dispatch.lean
+++ b/HexLLL/Dispatch.lean
@@ -38,6 +38,34 @@ def lll (b : Matrix Int n m) (δ : Rat)
   | some B' => B'
   | none => lllNative b δ (one_quarter_lt_of_eta_eleven_twentieths hδ) hδ' hn
 
+/-- Install an external LLL acceleration provider from the shared library at
+`path` for the rest of this process, returning whether the load succeeded.
+
+The library must export `lean_fplll_lll_reduce` (the fpLLL-ffi shim built by
+`scripts/oracle/setup_fplll_ffi.sh`); `loadProvider` `dlopen`s it, resolves that
+symbol, and points the dispatch at it. Once installed, a `lll` call whose
+provider candidate certifies under `Hex.certCheck` returns the accelerated
+basis; an absent provider, a load failure, or a rejected candidate all fall
+through to the exact `lllNative`. Loading is an explicit, idempotent action —
+there is no environment-variable read and no implicit load — and the trust
+boundary is unchanged: every provider candidate is still checked before use.
+
+Returns `false` (and writes the `dlopen`/`dlsym` diagnostic to stderr) when the
+library cannot be loaded or does not export the expected symbol; the process
+then keeps whatever provider state it had. -/
+@[expose]
+def lll.loadProvider (path : System.FilePath) : IO Bool :=
+  Internal.LLLProvider.loadProviderImpl path.toString
+
+/-- Whether an external LLL acceleration provider is currently installed in this
+process (via `Hex.lll.loadProvider` or a statically-linked provider symbol).
+When this is `false`, `lll` runs the exact `lllNative`; when it is `true`, `lll`
+attempts the certified external path first. Querying availability is
+side-effect-free apart from the one-shot static-symbol probe it may trigger. -/
+@[expose]
+def lll.providerActive : IO Bool :=
+  return Internal.LLLProvider.providerAvailable ()
+
 /-- Proof-free executable variant of `lll.firstShortVector`. Runs the exact
 `lllNative` reducer directly. -/
 @[expose]

--- a/HexLLL/Dispatch.lean
+++ b/HexLLL/Dispatch.lean
@@ -46,13 +46,14 @@ The library must export `lean_fplll_lll_reduce` (the fpLLL-ffi shim built by
 symbol, and points the dispatch at it. Once installed, a `lll` call whose
 provider candidate certifies under `Hex.certCheck` returns the accelerated
 basis; an absent provider, a load failure, or a rejected candidate all fall
-through to the exact `lllNative`. Loading is an explicit, idempotent action —
-there is no environment-variable read and no implicit load — and the trust
-boundary is unchanged: every provider candidate is still checked before use.
+through to the exact `lllNative`. Loading is an explicit action — there is no
+environment-variable read and no implicit load — and the trust boundary is
+unchanged: every provider candidate is still checked before use.
 
-Returns `false` (and writes the `dlopen`/`dlsym` diagnostic to stderr) when the
-library cannot be loaded or does not export the expected symbol; the process
-then keeps whatever provider state it had. -/
+A later successful load replaces the current provider; a failed load leaves the
+existing state untouched and returns `false` (writing the `dlopen`/`dlsym`
+diagnostic to stderr) when the library cannot be loaded or does not export the
+expected symbol. -/
 @[expose]
 def lll.loadProvider (path : System.FilePath) : IO Bool :=
   Internal.LLLProvider.loadProviderImpl path.toString

--- a/HexLLL/Provider.lean
+++ b/HexLLL/Provider.lean
@@ -21,9 +21,12 @@ namespace Hex
 
 /-! ## External LLL provider
 
-Optional runtime hook for an external reducer (e.g. fpLLL) loaded through the
-C FFI shim in `HexLLL/ffi/`. `providerAvailable` reports whether a provider is
-registered (driven by the `HEX_FPLLL_FFI_LIB` environment variable); when none
+Optional runtime hook for an external reducer (e.g. fpLLL) reached through the
+C FFI shim in `HexLLL/ffi/`. A provider is installed either by the explicit
+Lean loader `Hex.lll.loadProvider` (which `dlopen`s a named shared library) or,
+for a provider linked into the process, by a one-shot static-symbol probe;
+there is no environment-variable read and no implicit `dlopen`.
+`providerAvailable` reports whether a provider is currently installed; when none
 is present, or a returned candidate fails validation, callers fall back to the
 verified native reducer `lllNative`. The provider is acceleration only and is
 never part of the trusted path — every candidate it returns is checked before
@@ -37,6 +40,14 @@ opaque providerAvailable : Unit → Bool
 opaque providerReduce (rows cols : USize) (entries : @& Array String)
     (delta eta : Float) (method : UInt8) (withInverse : Bool) :
     Except String (Array Int)
+
+/-- Install the external provider from the shared library at `path`: `dlopen`
+the library, resolve `lean_fplll_lll_reduce` from it, and set the process
+provider slot. Returns `true` on success and `false` when the library cannot be
+loaded or the symbol is missing (the loader diagnostic is written to stderr).
+This is the raw FFI entry point behind the public `Hex.lll.loadProvider`. -/
+@[extern "lean_hexlll_load_provider"]
+opaque loadProviderImpl (path : @& String) : IO Bool
 
 /-- Decoded result returned by the external LLL provider.
 

--- a/HexLLL/ProviderProbe.lean
+++ b/HexLLL/ProviderProbe.lean
@@ -14,11 +14,16 @@ public section
 Executable probe entry point for the `hex-lll` external reduction provider.
 
 This module defines a small `main` driver that checks the optional native LLL
-provider against an expected `absent`/`present` state.  It compares
-`Hex.Internal.LLLProvider.providerAvailable` to the argument, and when the provider is
-expected to be absent it additionally confirms that `Hex.Internal.LLLProvider.providerReduce`
-reports `.error` rather than succeeding.  The driver returns process exit codes
-(`0` on agreement, `1`/`2` on mismatch or misuse) for use as a CI check.
+provider against an expected `absent`/`present` state, exercising the public
+`Hex.lll.loadProvider` / `Hex.lll.providerActive` surface:
+
+* `absent` — with nothing loaded, confirm `Hex.lll.providerActive` is `false`
+  and that `providerReduce` reports `.error` rather than succeeding.
+* `present <path>` — `Hex.lll.loadProvider <path>` must succeed and
+  `Hex.lll.providerActive` must then be `true`.
+
+The driver returns process exit codes (`0` on agreement, `1`/`2` on mismatch or
+misuse) for use as a CI check.
 -/
 
 namespace Hex
@@ -28,25 +33,28 @@ namespace LLLProviderProbe
 
 @[expose]
 def main (args : List String) : IO UInt32 := do
-  let expected ←
-    match args with
-    | ["absent"] => pure false
-    | ["present"] => pure true
-    | _ =>
-        IO.eprintln "usage: hexlll_provider_probe absent|present"
-        return 2
-  let actual := LLLProvider.providerAvailable ()
-  if actual = expected then
-    if !expected then
+  match args with
+  | ["absent"] =>
+      if ← Hex.lll.providerActive then
+        IO.eprintln "providerActive = true, expected false"
+        return 1
       match LLLProvider.providerReduce 0 0 #[] 0.75 0.55 0 false with
       | .error _ => return 0
       | .ok _ =>
           IO.eprintln "providerReduce unexpectedly succeeded while provider is absent"
           return 1
-    return 0
-  else
-    IO.eprintln s!"providerAvailable = {actual}, expected {expected}"
-    return 1
+  | ["present", path] =>
+      if !(← Hex.lll.loadProvider path) then
+        IO.eprintln s!"loadProvider failed for {path}"
+        return 1
+      if ← Hex.lll.providerActive then
+        return 0
+      else
+        IO.eprintln "providerActive = false after a successful loadProvider"
+        return 1
+  | _ =>
+      IO.eprintln "usage: hexlll_provider_probe absent | present <path>"
+      return 2
 
 end LLLProviderProbe
 end Hex

--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -76,8 +76,8 @@ produces output correct to that same contract, so the result is correct no
 matter which one runs. `lll` dispatches through them in order:
 
 - **External provider** (`LLLProvider.dispatch`). If an external reducer is
-  reachable in the process — probed through an `@[extern]` hook, in practice by
-  setting `HEX_FPLLL_FFI_LIB` to a built fpLLL-ffi shared library (see
+  installed in the process — via the explicit loader `Hex.lll.loadProvider`
+  pointed at a built fpLLL-ffi shared library (see
   [Performance comparison](#performance-comparison)) — `lll` runs it and
   *certifies* the returned candidate with the integer-only checker `certCheck`.
   An absent or rejected candidate falls through. The provider is an independent
@@ -223,16 +223,19 @@ output at close to floating-point cost.
 
 **Selecting the certified vs native path — a runtime choice, not an import.**
 `HexLLL` always builds its FFI shim, and the *same* `lll` call picks its path by
-whether an external provider symbol is resolvable in the process:
+whether an external provider is installed in the process:
 
-- set the environment variable **`HEX_FPLLL_FFI_LIB`** to a built fpLLL-ffi
-  shared library and `lll` takes the **certified path** (the shim `dlopen`s it,
-  `Hex.providerAvailable` returns true, the candidate is certified by
-  `certCheck`);
-- leave it unset (or if certification ever failed) and `lll` runs the exact
+- call **`Hex.lll.loadProvider path`** with the path to a built fpLLL-ffi shared
+  library (`scripts/oracle/setup_fplll_ffi.sh` builds one and prints its path);
+  it returns `true` on success, after which `lll` takes the **certified path**
+  (the candidate is certified by `certCheck`). `Hex.lll.providerActive : IO Bool`
+  reports whether a provider is currently installed;
+- load nothing (or if certification ever failed) and `lll` runs the exact
   **`lllNative`** directly.
 
-Either way the result satisfies the same `(δ, 11/20)`-reduced contract. To force
+Loading is an explicit, discoverable Lean action next to `lll` itself — there is
+no environment variable read on the `lll` path and no implicit `dlopen`. Either
+way the result satisfies the same `(δ, 11/20)`-reduced contract. To force
 the exact path unconditionally — and get the tighter `η = 1/2` guarantee
 (precondition `1/4 < δ`, constant `1/(δ − 1/4)`; see [Verification](#verification))
 — call `lllNative` directly.

--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -455,11 +455,12 @@ classification below is mirrored as structured metadata in
 
   **Comparator-call protocol.** `fpLLL` is an in-process FFI call through
   `fplll-ffi` (one C++ call per request). The bench obtains `fplll-ffi` the
-  same way the certified dispatch resolves it at runtime, and with **no Lake
+  same way the certified dispatch installs it at runtime, and with **no Lake
   dependency** on it: a setup script builds the `fplll-ffi` shared library and
-  a path override (env var, mirroring the Isabelle binary-path overrides) makes
-  the bench `dlopen` it at start-up, after which the dispatch's `dlsym` probe
-  resolves the provider and the fpLLL comparator calls it directly. The two
+  the bench explicitly installs it via `Hex.lll.loadProvider`, reading the
+  library path from the `HEX_FPLLL_FFI_LIB` override (mirroring the Isabelle
+  binary-path overrides) at start-up, after which the dispatch and the fpLLL
+  comparator call the installed provider directly. The two
   Isabelle comparators (`verified Isabelle LLL` and `verified Isabelle certified-LLL`)
   are wired as persistent subprocesses per
   [SPEC/benchmarking.md §External comparators — Process call](https://github.com/kim-em/hex-dev/blob/main/SPEC/benchmarking.md#external-comparators):
@@ -690,16 +691,40 @@ depends only on `certCheck_sound`, and the checker internals are not relied on
 elsewhere.
 
 **Provider hook.** `lll` consults an `opaque @[extern]` hook that supplies a
-candidate when an external reducer is registered and signals absence
+candidate when an external reducer is installed and signals absence
 otherwise (governed by the *untrusted dispatch hooks* clause in
-[SPEC/SPEC.md §Project-wide proof policy](https://github.com/kim-em/hex-dev/blob/main/SPEC/SPEC.md#project-wide-proof-policy)). The hook is process-stable (availability is fixed
-at first probe and cached), returns only a candidate, and is queried for
+[SPEC/SPEC.md §Project-wide proof policy](https://github.com/kim-em/hex-dev/blob/main/SPEC/SPEC.md#project-wide-proof-policy)). The hook is queried for
 availability *before* any input marshalling, so the native path pays at most a
-single cached probe. The hook's C body probes for the provider's versioned
-public symbol at runtime; the provider is an independent package that this
-library neither depends on nor names in its build, and which has no knowledge
-of this library. The candidate's shape (dimensions, array lengths) is
-validated in Lean before use; a malformed candidate is a rejection.
+single slot read; it returns only a candidate. The provider is an independent
+artifact that this library neither depends on nor names in its build, and which
+has no knowledge of this library. The candidate's shape (dimensions, array
+lengths) is validated in Lean before use; a malformed candidate is a rejection.
+
+*Installation is an explicit Lean action, not an environment read.* A provider
+is installed into the process slot by the public loader `Hex.lll.loadProvider :
+System.FilePath → IO Bool`, which `dlopen`s the named shared library, resolves
+the provider's versioned public symbol from it, and points the hook at it;
+`Hex.lll.providerActive : IO Bool` reports whether a provider is currently
+installed. There is no `getenv` and no implicit `dlopen` on the `lll` path — the
+knob is a discoverable Lean function next to `lll`, and the loaded state is
+process-global (a pure `lll` cannot thread it per-call). For a provider *linked*
+into the process, a one-shot `dlsym(RTLD_DEFAULT, …)` probe on first
+availability query self-installs it with no loader call, so a future in-tree
+statically-linked adapter activates purely by being imported. The slot is
+process-stable in practice: `loadProvider` is a process-init action, and once a
+provider is installed availability stays fixed.
+
+*Why a runtime loader rather than a linked-in adapter.* The natural
+"import-to-register" design — a separate Lake package that statically links the
+provider and self-registers on import, dropping the `dlopen` entirely — is
+deliberately **not** used, because this library carries **no Lake dependency on
+fpLLL**: the fpLLL-ffi shim is built out of tree by
+`scripts/oracle/setup_fplll_ffi.sh` and reached only at runtime. A statically
+linked adapter would force fpLLL (a C++ library with GMP/MPFR) into every build
+and into merge-gating CI, contradicting that decision. The explicit loader keeps
+fpLLL out of the build while still making activation explicit, discoverable, and
+Lean-controlled; the static-symbol probe leaves the import-to-register door open
+for any provider that *is* linked in without reintroducing an environment read.
 
 **Reliability is empirical, soundness is not.** A candidate whose exact
 `|μ|` exceeds `11/20` is rejected and the native path runs; the `11/20` bound

--- a/HexLLL/ffi/lean_hexlll_provider.c
+++ b/HexLLL/ffi/lean_hexlll_provider.c
@@ -14,51 +14,33 @@ typedef lean_obj_res (*lean_fplll_lll_reduce_fn)(
     uint8_t method,
     uint8_t with_inverse);
 
+/* Provider slot state:
+     0 — not yet probed for a statically-linked provider symbol,
+     1 — probed, none linked and none installed by the loader,
+     2 — a provider is installed (`lean_hexlll_provider_ptr` is valid).
+   The slot is set either by `lean_hexlll_load_provider` (the explicit Lean
+   loader `Hex.lll.loadProvider`) or, for a statically-linked provider, by the
+   one-shot `RTLD_DEFAULT` probe in `lean_hexlll_resolve_provider`. There is no
+   environment-variable read and no implicit `dlopen`: activation is always an
+   explicit Lean action or a link-time fact. */
 static atomic_int lean_hexlll_provider_state = 0;
 static atomic_uintptr_t lean_hexlll_provider_ptr = 0;
-static atomic_int lean_hexlll_provider_dlopen_done = 0;
 
-/* If `HEX_FPLLL_FFI_LIB` is set, `dlopen` the named shared library with
-   `RTLD_GLOBAL` so its symbols (in particular `lean_fplll_lll_reduce`) become
-   visible to `dlsym(RTLD_DEFAULT, ...)` below. Tried at most once per process.
-   When the env var is unset the call is a no-op. When the env var is set but
-   `dlopen` fails, the error is written to stderr so CI surfaces the actual
-   loader diagnostic (typically an unresolved transitive dep like
-   `libLake_shared`) instead of silently falling through to "provider
-   absent". */
-static void lean_hexlll_dlopen_provider_lib(void) {
-    int done = atomic_load_explicit(&lean_hexlll_provider_dlopen_done, memory_order_acquire);
-    if (done) {
-        return;
-    }
-    int expected = 0;
-    if (!atomic_compare_exchange_strong_explicit(
-            &lean_hexlll_provider_dlopen_done, &expected, 1,
-            memory_order_acq_rel, memory_order_acquire)) {
-        return;
-    }
-    const char *path = getenv("HEX_FPLLL_FFI_LIB");
-    if (path == NULL || path[0] == '\0') {
-        return;
-    }
-    if (dlopen(path, RTLD_NOW | RTLD_GLOBAL) == NULL) {
-        const char *err = dlerror();
-        fprintf(stderr, "hexlll: dlopen(\"%s\") failed: %s\n",
-                path, err != NULL ? err : "(no dlerror)");
-    }
-}
-
+/* Resolve the active provider, if any. State 2 returns the installed pointer;
+   state 1 returns NULL. From the initial state 0 we probe *once* for a
+   statically-linked `lean_fplll_lll_reduce` via `dlsym(RTLD_DEFAULT, ...)` so a
+   provider linked into the process (a future in-tree adapter) self-activates
+   with no loader call; a miss latches state 1. The probe never `dlopen`s and
+   never reads the environment. */
 static lean_fplll_lll_reduce_fn lean_hexlll_resolve_provider(void) {
     int state = atomic_load_explicit(&lean_hexlll_provider_state, memory_order_acquire);
-    if (state == 1) {
-        return NULL;
-    }
     if (state == 2) {
         return (lean_fplll_lll_reduce_fn)
             atomic_load_explicit(&lean_hexlll_provider_ptr, memory_order_acquire);
     }
-
-    lean_hexlll_dlopen_provider_lib();
+    if (state == 1) {
+        return NULL;
+    }
 
     void *sym = dlsym(RTLD_DEFAULT, "lean_fplll_lll_reduce");
     if (sym == NULL) {
@@ -79,6 +61,36 @@ static lean_obj_res lean_hexlll_except_error(const char *msg) {
     lean_object *res = lean_alloc_ctor(0, 1, 0);
     lean_ctor_set(res, 0, err);
     return res;
+}
+
+/* `Hex.lll.loadProvider`: explicitly `dlopen` the shared library at `path`
+   (with `RTLD_GLOBAL` so its symbols satisfy the provider's transitive deps),
+   resolve `lean_fplll_lll_reduce` from that handle, and install it as the
+   active provider. Returns `true` on success and `false` on failure; on failure
+   the `dlopen`/`dlsym` diagnostic is written to stderr so a caller sees why the
+   library did not load (typically an unresolved transitive dep or a wrong
+   path). Installing overrides a prior "absent" latch (state 1), so a load may
+   follow an earlier availability probe. */
+LEAN_EXPORT lean_obj_res lean_hexlll_load_provider(b_lean_obj_arg path, lean_obj_arg w) {
+    (void)w;
+    const char *cpath = lean_string_cstr(path);
+    void *handle = dlopen(cpath, RTLD_NOW | RTLD_GLOBAL);
+    if (handle == NULL) {
+        const char *err = dlerror();
+        fprintf(stderr, "hexlll: dlopen(\"%s\") failed: %s\n",
+                cpath, err != NULL ? err : "(no dlerror)");
+        return lean_io_result_mk_ok(lean_box(0));
+    }
+    void *sym = dlsym(handle, "lean_fplll_lll_reduce");
+    if (sym == NULL) {
+        const char *err = dlerror();
+        fprintf(stderr, "hexlll: dlsym(\"%s\", \"lean_fplll_lll_reduce\") failed: %s\n",
+                cpath, err != NULL ? err : "(no dlerror)");
+        return lean_io_result_mk_ok(lean_box(0));
+    }
+    atomic_store_explicit(&lean_hexlll_provider_ptr, (uintptr_t)sym, memory_order_release);
+    atomic_store_explicit(&lean_hexlll_provider_state, 2, memory_order_release);
+    return lean_io_result_mk_ok(lean_box(1));
 }
 
 LEAN_EXPORT uint8_t lean_hexlll_provider_available(uint8_t unit) {

--- a/HexLLL/ffi/lean_hexlll_provider.c
+++ b/HexLLL/ffi/lean_hexlll_provider.c
@@ -70,9 +70,11 @@ static lean_obj_res lean_hexlll_except_error(const char *msg) {
    the `dlopen`/`dlsym` diagnostic is written to stderr so a caller sees why the
    library did not load (typically an unresolved transitive dep or a wrong
    path). Installing overrides a prior "absent" latch (state 1), so a load may
-   follow an earlier availability probe. */
-LEAN_EXPORT lean_obj_res lean_hexlll_load_provider(b_lean_obj_arg path, lean_obj_arg w) {
-    (void)w;
+   follow an earlier availability probe; a later successful load replaces the
+   current provider, and a failed load leaves the current state unchanged.
+   Bound to `IO Bool`: the world token is erased in the generated call (a single
+   object argument), and the return is an IO result carrying the boxed flag. */
+LEAN_EXPORT lean_obj_res lean_hexlll_load_provider(b_lean_obj_arg path) {
     const char *cpath = lean_string_cstr(path);
     void *handle = dlopen(cpath, RTLD_NOW | RTLD_GLOBAL);
     if (handle == NULL) {
@@ -86,6 +88,7 @@ LEAN_EXPORT lean_obj_res lean_hexlll_load_provider(b_lean_obj_arg path, lean_obj
         const char *err = dlerror();
         fprintf(stderr, "hexlll: dlsym(\"%s\", \"lean_fplll_lll_reduce\") failed: %s\n",
                 cpath, err != NULL ? err : "(no dlerror)");
+        dlclose(handle);
         return lean_io_result_mk_ok(lean_box(0));
     }
     atomic_store_explicit(&lean_hexlll_provider_ptr, (uintptr_t)sym, memory_order_release);
@@ -93,7 +96,7 @@ LEAN_EXPORT lean_obj_res lean_hexlll_load_provider(b_lean_obj_arg path, lean_obj
     return lean_io_result_mk_ok(lean_box(1));
 }
 
-LEAN_EXPORT uint8_t lean_hexlll_provider_available(uint8_t unit) {
+LEAN_EXPORT uint8_t lean_hexlll_provider_available(lean_obj_arg unit) {
     (void)unit;
     return lean_hexlll_resolve_provider() != NULL;
 }

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -217,12 +217,16 @@ tag := "hex-lll-dispatch"
 %%%
 
 By default `Hex.lll` runs the exact `Hex.lllNative`. To let it accelerate
-through the external `fpLLL` provider instead, point the environment
-variable `HEX_FPLLL_FFI_LIB` at a built fpLLL-ffi shared library before the
-process starts; leave it unset to stay on the native path. This is a runtime
-switch, not a matter of importing a different module — `HexLLL` always links
-its small provider shim, and the *same* `Hex.lll` call takes the certified
-path exactly when the provider library is resolvable.
+through the external `fpLLL` provider instead, call {name}`Hex.lll.loadProvider`
+with the path to a built fpLLL-ffi shared library
+(`scripts/oracle/setup_fplll_ffi.sh` builds one and prints its path); it
+`dlopen`s the library, installs it as the process provider, and returns `true`
+on success. {name}`Hex.lll.providerActive` reports whether one is installed.
+This is a runtime switch, not a matter of importing a different module —
+`HexLLL` always links its small provider shim, and the *same* `Hex.lll` call
+takes the certified path exactly when a provider is installed. Loading is an
+explicit, discoverable Lean action next to `lll`: there is no environment
+variable read on the `lll` path and no implicit `dlopen`.
 
 Either way the result is `(δ, 11/20)`-reduced. When the provider is in use,
 `Hex.lll` asks it for a reduced basis and re-checks the candidate with
@@ -231,6 +235,10 @@ or an absent provider, falls straight through to the native reducer. The
 foreign numerics can therefore speed things up but can never affect
 correctness: nothing the provider returns is trusted until the verified
 integer checker has accepted it.
+
+{docstring Hex.lll.loadProvider}
+
+{docstring Hex.lll.providerActive}
 
 # Performance comparison
 %%%

--- a/bench/HexLLLBench/Inputs.lean
+++ b/bench/HexLLLBench/Inputs.lean
@@ -782,10 +782,24 @@ def runFirstShortVectorChecksum (input : FirstShortVectorInput) : Int :=
     (lll.firstShortVectorUnchecked input.basis (3 / 4)
       lllDeltaLower lllDeltaUpper input.hn)
 
+/-- Explicitly install the fpLLL provider for the bench process from the shared
+library named by `HEX_FPLLL_FFI_LIB`, if that variable is set and non-empty.
+Idempotent: once a provider is active this is a cheap no-op, so the provider
+targets can call it lazily. This is the bench's opt-in replacement for the old
+implicit env read — the public `Hex.lll` surface no longer consults the
+environment; the bench does so explicitly here via `Hex.lll.loadProvider`. -/
+def ensureProviderLoaded : IO Unit := do
+  if ← lll.providerActive then
+    return
+  match ← IO.getEnv "HEX_FPLLL_FFI_LIB" with
+  | some path => if path != "" then discard <| lll.loadProvider path
+  | none => pure ()
+
 /-- Benchmark target: run the public dispatched LLL path and checksum the
 first row. If a real external provider is loaded, this target fails unless the
 certified dispatch accepts at least one candidate. -/
 def runDispatchedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO Int := do
+  ensureProviderLoaded
   LLLProvider.resetDiagnostics
   have hrows : 1 ≤ input.rows := input.hn
   let f0 : Fin input.rows := ⟨0, by omega⟩
@@ -1025,6 +1039,7 @@ certified path (`LLLProvider.certifyFlat`), so one FFI call covers both.
 Raises `IO.userError` if the provider is absent (no `HEX_FPLLL_FFI_LIB` /
 unresolved `lean_fplll_lll_reduce`) or returns an error from `libfplll`. -/
 def requestFpLLLFlat (input : FirstShortVectorInput) : IO (Array Int) := do
+  ensureProviderLoaded
   if !LLLProvider.providerAvailable () then
     throw <| IO.userError
       "fplll-ffi provider absent — set HEX_FPLLL_FFI_LIB to libfplllffi"

--- a/bench/HexLLLBench/Main.lean
+++ b/bench/HexLLLBench/Main.lean
@@ -47,10 +47,12 @@ Informational external comparator:
 
 * `fpLLL via fplll-ffi`: in-process FFI registrations call `libfplll`
   through the `fplll-ffi` shim — one C++ call per request, no
-  subprocess. The shim's `lean_fplll_lll_reduce` symbol is resolved
-  by `HexLLL/ffi/lean_hexlll_provider.c` via `dlsym(RTLD_DEFAULT, ...)`
-  after an opportunistic `dlopen` of `HEX_FPLLL_FFI_LIB`, mirroring
-  the Isabelle binary-path override. The shim is built by
+  subprocess. The bench installs the shim explicitly via
+  `Hex.lll.loadProvider` (see `ensureProviderLoaded`), reading the
+  library path from `HEX_FPLLL_FFI_LIB` and `dlopen`ing it once;
+  `HexLLL/ffi/lean_hexlll_provider.c` then resolves
+  `lean_fplll_lll_reduce` from that handle. This mirrors the
+  Isabelle binary-path override. The shim is built by
   `scripts/oracle/setup_fplll_ffi.sh` (clone+lake build of
   `leanprover/fplll`), keeping hex free of any Lake dependency on
   it. The comparator is classified informational in
@@ -68,8 +70,9 @@ Informational external comparator:
   checker-only targets cache one candidate after warmup and re-run
   only `certCheck`, giving the checker's cost share. Public-dispatch
   verify targets check that, when an `fplll-ffi` provider is
-  intentionally loaded via `HEX_FPLLL_FFI_LIB`, the dispatch tally
-  records at least one accepted candidate.
+  intentionally installed via `Hex.lll.loadProvider` (path from
+  `HEX_FPLLL_FFI_LIB`), the dispatch tally records at least one
+  accepted candidate.
 
 External comparator:
 
@@ -146,12 +149,14 @@ benchmark, so each repeat starts with a cold `isabelleChildRef`; the
 process-call comparator registrations set `minTotalSeconds := 1.0`,
 forcing the fixed child to run enough inner iterations to amortize
 the one-time GHC start inside the child. For `fplll-ffi`, the
-per-process cost is the one-time `dlopen` performed lazily on the
-first probe via `HEX_FPLLL_FFI_LIB`.
+per-process cost is the one-time `dlopen` performed on the first
+`ensureProviderLoaded` call (`Hex.lll.loadProvider` with the path from
+`HEX_FPLLL_FFI_LIB`).
 
 **Driver path overrides.** `HEX_FPLLL_FFI_LIB` selects the
-`fplll-ffi` shared library that the bench `dlopen`s at start-up
-(see `HexLLL/ffi/lean_hexlll_provider.c`). The Isabelle binary path
+`fplll-ffi` shared library that the bench installs at start-up via
+`Hex.lll.loadProvider` (see `ensureProviderLoaded` and
+`HexLLL/ffi/lean_hexlll_provider.c`). The Isabelle binary path
 is controlled by `HEX_LLL_ISABELLE_SVP`; the Isabelle certified binary
 path is controlled by `HEX_LLL_ISABELLE_CERTIFIED_SVP`.
 

--- a/progress/20260703T070954Z_issue-8555.md
+++ b/progress/20260703T070954Z_issue-8555.md
@@ -1,0 +1,46 @@
+# issue-8555: user-friendly fpLLL provider switch
+
+## Accomplished
+
+Replaced the invisible `HEX_FPLLL_FFI_LIB` env-var + implicit `dlopen`
+mechanism for the optional fpLLL LLL provider with an explicit,
+discoverable Lean loader.
+
+- `HexLLL/ffi/lean_hexlll_provider.c`: dropped `getenv`/auto-`dlopen`.
+  Added `lean_hexlll_load_provider(path)` (explicit `dlopen`+`dlsym`,
+  installs the provider slot, returns success). `resolve_provider` now
+  does a one-shot `dlsym(RTLD_DEFAULT, …)` static-symbol probe only — no
+  env read, no implicit `dlopen`. A `loadProvider` overrides an earlier
+  "absent" latch.
+- `HexLLL/Provider.lean`: `opaque loadProviderImpl : @& String → IO Bool`
+  extern; module docstring updated.
+- `HexLLL/Dispatch.lean`: public `Hex.lll.loadProvider : FilePath → IO Bool`
+  and `Hex.lll.providerActive : IO Bool`, sitting next to `Hex.lll`.
+- `HexLLL/ProviderProbe.lean`: `absent` | `present <path>` modes exercising
+  the public loader.
+- `bench/HexLLLBench/Inputs.lean`: `ensureProviderLoaded` (reads
+  `HEX_FPLLL_FFI_LIB` explicitly, calls `loadProvider`, idempotent) wired
+  into the two provider entry points.
+- Docs: README, HexManual chapter (+`{docstring}` for the two new defs),
+  SPEC `Provider hook` section (explains the runtime-loader-vs-linked-adapter
+  trade-off and why no Lake dep on fpLLL), bench Main doc comment, setup
+  script comments.
+
+The trust boundary is unchanged: every provider candidate is still gated
+by `Hex.certCheck`.
+
+## Current frontier
+
+`lake build HexLLL hexlll_provider_probe hexlll_bench HexLLLMathlib` all
+green. Probe verified at runtime: `absent`→0, bad path→1 (clear stderr),
+bad usage→2. HexManual build in progress.
+
+## Next step
+
+Confirm HexManual green. `/second-opinion` on the design+diff, address
+concerns, open PR, check merge/CI. Could not end-to-end test a *successful*
+load (no cached fplll shim; building it clones+compiles fplll from source).
+
+## Blockers
+
+None.

--- a/scripts/oracle/setup_fplll_ffi.sh
+++ b/scripts/oracle/setup_fplll_ffi.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Build `leanprover/fplll` and print the path to its `libfplllffi` shared
 # library — the FFI shim that exports `lean_fplll_lll_reduce`, the symbol the
-# HexLLL provider hook (`HexLLL/ffi/lean_hexlll_provider.c`) resolves at
-# runtime via `dlsym(RTLD_DEFAULT, ...)`.
+# HexLLL provider hook (`HexLLL/ffi/lean_hexlll_provider.c`) resolves after
+# `Hex.lll.loadProvider` `dlopen`s this library at the printed path.
 #
 # Usage:
 #
@@ -114,8 +114,8 @@ fi
 # static archive into a clean shared library here: link directly against
 # `libleanshared` (which provides `lean_alloc_mpz` and friends) plus the
 # system fplll/MPFR/GMP, and bake the toolchain lib dir into the rpath so
-# the dlopen at `HEX_FPLLL_FFI_LIB` does not depend on the caller's
-# `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`.
+# `Hex.lll.loadProvider`'s dlopen of this library does not depend on the
+# caller's `LD_LIBRARY_PATH`/`DYLD_LIBRARY_PATH`.
 lean_lib_dir="$(cd "$(dirname "$(elan which lean)")/../lib/lean" && pwd)"
 fplll_install_lib="${src_dir}/.lake/build/fplll-install/lib"
 out_dir="${cache_root}/shim"


### PR DESCRIPTION
This PR replaces the invisible `HEX_FPLLL_FFI_LIB` environment-variable read plus implicit `dlopen`-at-first-probe that switched on `Hex.lll`'s optional fpLLL acceleration path with an explicit, discoverable Lean loader. `Hex.lll.loadProvider : System.FilePath → IO Bool` `dlopen`s a named fpLLL-ffi shared library, resolves `lean_fplll_lll_reduce`, and installs it in the process provider slot, returning whether the load succeeded; `Hex.lll.providerActive : IO Bool` reports whether one is installed. Both sit next to `Hex.lll`, so the switch is a documented Lean function rather than a bare env var buried in a C shim, and the manual's "Certified external dispatch" section now gives the concrete `loadProvider` instruction with no `.Internal.` identifiers.

The C shim drops `getenv` and the implicit `dlopen`, keeping only a one-shot `dlsym(RTLD_DEFAULT, …)` static-symbol probe so that a provider *linked* into the process self-activates with no environment read — leaving the "import-to-register" door open for a future in-tree statically-linked adapter. The bench installs the shim explicitly via `ensureProviderLoaded`, which reads `HEX_FPLLL_FFI_LIB` in Lean and calls `loadProvider`, so the existing bench workflow and `scripts/oracle/setup_fplll_ffi.sh` are unchanged; the env var is now an explicit, opt-in path source rather than an implicit read on the `lll` path.

The recommended import-to-register design that statically links fpLLL and drops the `dlopen` entirely is deliberately not taken: this library carries no Lake dependency on fpLLL (it is built out of tree by `scripts/oracle/setup_fplll_ffi.sh` and reached only at runtime), and a static-link adapter would force fpLLL/GMP/MPFR into every build and merge-gating CI, contradicting that architecture. The SPEC's "Provider hook" section documents this trade-off. The runtime loader delivers the issue's goal (explicit, discoverable, Lean-controlled activation) while keeping fpLLL out of the build; the static-symbol probe keeps the import-to-register path available for any provider that is linked in, without reintroducing an env read.

The trust boundary is unchanged: every provider candidate is still gated by `Hex.certCheck` before use, exactly as before.

Closes #8555.

🤖 Prepared with Claude Code