### PR TITLE
chore: drop two redundant conditional GramSchmidt bridge lemmas

### DIFF
--- a/HexGramSchmidtMathlib/Int/Augmented.lean
+++ b/HexGramSchmidtMathlib/Int/Augmented.lean
@@ -1130,28 +1130,6 @@ theorem scaledCoeffs_lower_eq_det_scaledCoeffMatrix
         scaledCoeffMatrix_det_eq_zero_of_singularStep_lt b i j hji s h_sing
       rw [h_lhs, h_det]
 
-/-- Non-singular branch of the Cramer/Bareiss identity: when the no-pivot
-Bareiss pass over the Gram matrix reaches column `j` without recording a
-singular step, the executable scaled coefficient agrees with the public
-row-pivoted Bareiss determinant of the Cramer minor. Derived from the
-unconditional `scaledCoeffs_lower_eq_det_scaledCoeffMatrix` by casting back
-to `Int` and translating `Matrix.det` to `Matrix.bareiss` via the
-`det_eq` / `bareiss_eq_mathlib_det` cross-bridge. -/
-theorem scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular
-    (b : Matrix Int n m) (i j : Fin n) (hji : j.val < i.val)
-    (_h_nonsing :
-      (Matrix.noPivotLoop j.val
-          (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none) :
-    GramSchmidt.entry (scaledCoeffs b) i j =
-      Matrix.bareiss (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-  have h_det : GramSchmidt.entry (scaledCoeffs b) i j =
-      Matrix.det (GramSchmidt.scaledCoeffMatrix b i j hji) := by
-    exact_mod_cast scaledCoeffs_lower_eq_det_scaledCoeffMatrix b i j hji
-  rw [h_det]
-  exact ((HexMatrixMathlib.bareiss_eq_mathlib_det
-        (GramSchmidt.scaledCoeffMatrix b i j hji)).trans
-      (HexMatrixMathlib.det_eq (GramSchmidt.scaledCoeffMatrix b i j hji)).symm).symm
-
 /-- Cramer/Bareiss identity: below the diagonal, the integral scaled
 Gram-Schmidt coefficient is exactly the public Bareiss determinant of the
 Cramer minor `scaledCoeffMatrix`. Derived from the unconditional

--- a/HexGramSchmidtMathlib/Int/Swap.lean
+++ b/HexGramSchmidtMathlib/Int/Swap.lean
@@ -673,25 +673,6 @@ theorem scaledCoeffs_diag (b : Matrix Int n m) (i : Nat) (hi : i < n) :
     rw [hbareiss_eq]
     exact leadingGramMatrixInt_det_nonneg b (i + 1) hk
 
-/-- Stage-B rational closed form for the diagonal of `scaledCoeffs`,
-packaged with a no-singular hypothesis for the σ-chain singular-cascade
-consumer.
-
-The hypothesis is unused: `scaledCoeffs_diag` already gives the
-unconditional integer identification with `gramDet`, and the singular tail
-slots are exactly the zero values the public `gramDet` returns once a
-leading Gram prefix is singular. -/
-theorem scaledCoeffs_diag_eq_gramDet_of_no_singular
-    (b : Matrix Int n m) (i : Fin n)
-    (_h_nonsing :
-      (Matrix.noPivotLoop i.val
-        (Matrix.noPivotInitialState (Matrix.gramMatrix b))).singularStep = none) :
-    ((GramSchmidt.entry (scaledCoeffs b) i i : Int) : Rat) =
-      ((gramDet b (i + 1) (Nat.lt_iff_add_one_le.mp i.isLt) : Int) : Rat) := by
-  rw [scaledCoeffs_diag b i.val i.isLt]
-  push_cast
-  rfl
-
 /-- The leading executable Gram determinants of a square upper-triangular
 integer matrix with strictly positive diagonal are positive.
 


### PR DESCRIPTION
This PR remove two hypothesis-gated variant lemmas from `HexGramSchmidtMathlib` that are strictly weaker than unconditional siblings sitting directly beside them.

Both `scaledCoeffs_eq_scaledCoeffMatrix_bareiss_of_no_singular` and `scaledCoeffs_diag_eq_gramDet_of_no_singular` carry an explicitly-unused `_h_nonsing` no-singular hypothesis and duplicate (with identical proofs) the unconditional `scaledCoeffs_eq_scaledCoeffMatrix` and `scaledCoeffs_diag` respectively — the latter's own docstring already noted "The hypothesis is unused". Nothing in the tree consumes the conditional shapes (word-boundary grep: refs=0 after removal), and `HexGramSchmidtMathlib` plus its downstream consumers build green with no cascade.

This is the follow-up to the Phase 6 closeout (#8559), which surfaced these as part of a conditional-variant API family. The bridge's genuine public API is untouched: `int_basis_row_eq_gramSchmidt` (the headline correspondence to Mathlib's `gramSchmidt`, referenced) and `augmentedGram_trailing_row` (a structural characterising lemma) remain.

🤖 Prepared with Claude Code