### PR TITLE
feat(bz): compiled irreducibility-certificate generators

### DIFF
--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -244,6 +244,54 @@ def rabinTest (f : FpPoly p) (hmonic : DensePoly.Monic f) : Bool :=
     rabinDividesTest f hmonic &&
     (rabinWitnesses f hmonic).all Prod.snd
 
+/--
+Bezout witness that `f` and the Rabin difference `X^(p^d) - X mod f` are
+coprime, computed by the extended Euclidean algorithm.
+
+The extended gcd returns `left₀ * f + right₀ * diff = g` with `g` a nonzero
+constant when the two are coprime; scaling both coefficients by `g⁻¹` (as its
+leading coefficient, i.e. its constant value) normalises the identity to
+`left * f + right * diff = 1`, which is exactly the equation
+`checkRabinBezoutWitness` verifies. This is compiled, never-in-kernel prep:
+a wrong witness simply makes the downstream check return `false`.
+-/
+def rabinBezoutWitness (f : FpPoly p) (hmonic : DensePoly.Monic f) (d : Nat) :
+    RabinBezoutWitness p :=
+  let diff := frobeniusDiffMod f hmonic d
+  let r := DensePoly.xgcd f diff
+  let cinv := (1 : ZMod64 p) / DensePoly.leadingCoeff r.gcd
+  { left := DensePoly.C cinv * r.left
+    right := DensePoly.C cinv * r.right }
+
+/--
+Assemble a Rabin irreducibility certificate for the monic polynomial `f`, when
+`rabinTest` accepts it.
+
+The pow chain records `X^(p^k) mod f` for `k = 0, …, deg f`, matching
+`checkPowChain`, and the Bezout array records one normalised
+`rabinBezoutWitness` per maximal proper divisor of `deg f`, in the same order
+as `maximalProperDivisors`, matching `checkRabinBezoutWitnesses`. Returns
+`none` when `f` fails Rabin's test.
+
+This is the *prep* half of the certifying-irreducibility pattern: the expensive
+Frobenius-chain and extended-gcd work runs in compiled code here, so the kernel
+only has to replay the cheap `checkIrreducibilityCertificate` reduction on the
+finished data. The generator carries no soundness proof of its own — a wrong
+certificate makes `checkIrreducibilityCertificate` return `false`, never a
+false pass.
+-/
+def buildIrreducibilityCertificate? (f : FpPoly p) (hmonic : DensePoly.Monic f) :
+    Option IrreducibilityCertificate :=
+  if rabinTest f hmonic then
+    let n := basisSize f
+    some
+      { p := p
+        n := n
+        powChain := (Array.range (n + 1)).map fun k => FpPoly.frobeniusXPowMod f hmonic k
+        bezout := ((maximalProperDivisors n).map fun d => rabinBezoutWitness f hmonic d).toArray }
+  else
+    none
+
 /-- `berlekampRankTest` succeeds exactly when the fixed-space matrix has rank
 `deg(f) - 1`, the Berlekamp rank criterion. -/
 theorem berlekampRankTest_spec (f : FpPoly p) (hmonic : DensePoly.Monic f)

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1943,6 +1943,108 @@ def checkIrreducibleCert
   cert.perPrime.all (fun primeData => primeData.checkForPolynomial f) &&
     cert.checkDegreeObstructions f
 
+/--
+Rabin certificates for every modular factor at a prime block, aligned with the
+factor array. Fails (returns `none`) if any modular factor is non-monic or is
+not certified irreducible by `Berlekamp.buildIrreducibilityCertificate?`.
+-/
+private def buildFactorCerts? {p : Nat} [ZMod64.Bounds p]
+    (factors : Array (FpPoly p)) :
+    Option (Array Berlekamp.IrreducibilityCertificate) :=
+  factors.foldl
+    (fun acc g =>
+      match acc with
+      | none => none
+      | some arr =>
+        if hmonic : DensePoly.leadingCoeff g = 1 then
+          match Berlekamp.buildIrreducibilityCertificate? g hmonic with
+          | some cert => some (arr.push cert)
+          | none => none
+        else
+          none)
+    (some #[])
+
+/--
+Build one prime block for `f` at the small-prime candidate `c`: its recorded
+modular factors, their degrees, and one nested Rabin certificate per factor.
+
+The block is returned only when the prime is admissible, every modular factor
+is Rabin-certified, and the assembled block self-verifies against `f` through
+`PrimeFactorData.checkForPolynomial` (so a block that survives here is exactly
+one the kernel checker will accept). This requires the modular image of `f` to
+be monic at `c.p`, i.e. `leadingCoeff f ≡ 1 (mod c.p)`; otherwise the recorded
+monic factors cannot multiply back to `ZPoly.modP c.p f` and the block is
+rejected.
+-/
+private def buildPrimeFactorData? (f : ZPoly) (c : SmallPrimeCandidate) :
+    Option PrimeFactorData :=
+  letI := c.bounds
+  if isGoodPrime f c.p then
+    let factors := berlekampFactorsModP f c
+    match buildFactorCerts? factors with
+    | none => none
+    | some certs =>
+      let data : PrimeFactorData :=
+        { p := c.p
+          factorDegrees := factors.map fun g => g.degree?.getD 0
+          factorPolys := factors
+          factorCerts := certs }
+      if data.checkForPolynomial f then some data else none
+  else
+    none
+
+/--
+Choose, for each nontrivial candidate integer factor degree of `f`, a prime
+block whose recorded modular factor degrees have no subset summing to that
+degree — the multi-prime degree obstruction that rules out a genuine integer
+factor of that degree.
+
+Returns `none` if some candidate degree cannot be obstructed by any of the
+supplied blocks (which is what happens when `f` really does have an integer
+factor of that degree). This covers the Swinnerton-Dyer regime, where no single
+prime is inert but the obstructing prime varies with the target degree.
+-/
+private def buildDegreeObstructions (f : ZPoly) (blocks : Array PrimeFactorData) :
+    Option (Array DegreeObstruction) :=
+  (ZPolyIrreducibilityCertificate.candidateFactorDegrees f).foldl
+    (fun acc d =>
+      match acc with
+      | none => none
+      | some obs =>
+        match (List.range blocks.size).find? fun i =>
+          match blocks[i]? with
+          | some blk => !blk.hasSubsetDegree d
+          | none => false with
+        | some i => some (obs.push { targetDegree := d, primeIndex := i })
+        | none => none)
+    (some #[])
+
+/--
+Compiled certificate generator for irreducibility of `f` over `ℤ` — the *prep*
+half of the certifying-irreducibility pattern for integer polynomials.
+
+It selects admissible small primes, factors `f` modulo each with Berlekamp,
+attaches a nested Rabin certificate to every modular factor, and assembles the
+per-prime degree data plus the degree obstructions that rule out every
+nontrivial integer factor degree. The whole assembled certificate is checked
+with `checkIrreducibleCert` before being returned, so the generator never emits
+a certificate the kernel checker would reject: a `some` result is always a
+valid certificate, and anything that would not check yields `none`.
+
+This carries no soundness proof of its own; correctness rides entirely on the
+downstream `checkIrreducibleCert_sound`. Expensive Berlekamp/Rabin work runs
+here in compiled code; the kernel only replays the cheap `checkIrreducibleCert`
+reduction on the finished data.
+-/
+def certifyIrreducible? (f : ZPoly) : Option ZPolyIrreducibilityCertificate :=
+  let blocks := (smallPrimeCandidates.filterMap fun c => buildPrimeFactorData? f c).toArray
+  match buildDegreeObstructions f blocks with
+  | none => none
+  | some obstructions =>
+    let cert : ZPolyIrreducibilityCertificate :=
+      { perPrime := blocks, degreeObstructions := obstructions }
+    if checkIrreducibleCert f cert then some cert else none
+
 private structure PrimeChoiceDataScore where
   data : PrimeChoiceData
   factorCount : Nat

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -2041,8 +2041,18 @@ This carries no soundness proof of its own; correctness rides entirely on the
 downstream `checkIrreducibleCert_sound`. Expensive Berlekamp/Rabin work runs
 here in compiled code; the kernel only replays the cheap `checkIrreducibleCert`
 reduction on the finished data.
+
+The generator declines non-primitive and constant inputs up front, mirroring
+the `IsPrimitive` / `0 < natDegree` side conditions of
+`checkIrreducibleCert_sound`. Without this guard the checker accepts vacuous
+certificates for inputs those side conditions exclude (e.g. an empty
+certificate for a constant, or a full certificate for the non-primitive
+`2·x² + 2`, reducible over `ℤ` as `2·(x² + 1)`), so guarding here keeps
+`certifyIrreducible? f = some _` an honest irreducibility signal: every side
+condition a consumer must discharge is already executable-checked.
 -/
 def certifyIrreducible? (f : ZPoly) : Option ZPolyIrreducibilityCertificate :=
+  if ZPoly.content f != 1 || f.degree?.getD 0 == 0 then none else
   let blocks := (smallPrimeCandidates.filterMap fun c => buildPrimeFactorData? f c).toArray
   match buildDegreeObstructions f blocks with
   | none => none

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -2000,9 +2000,15 @@ degree — the multi-prime degree obstruction that rules out a genuine integer
 factor of that degree.
 
 Returns `none` if some candidate degree cannot be obstructed by any of the
-supplied blocks (which is what happens when `f` really does have an integer
-factor of that degree). This covers the Swinnerton-Dyer regime, where no single
-prime is inert but the obstructing prime varies with the target degree.
+supplied blocks. That happens both when `f` really does have an integer factor
+of that degree, and — a genuine limitation of this per-prime degree-sum
+language — when a degree is un-obstructable because every prime's factorization
+admits a subset summing to it. The latter rules out the balanced half-degree
+cases (e.g. Swinnerton-Dyer `√2+√3+√5` and `Φ₁₅`, whose `deg/2` obstruction is
+never available): the checker cannot certify those irreducibles, so the
+generator declines them. It succeeds whenever each target degree has some
+admissible obstructing prime — in particular whenever `f` has an inert prime,
+whose single block obstructs every proper degree at once.
 -/
 private def buildDegreeObstructions (f : ZPoly) (blocks : Array PrimeFactorData) :
     Option (Array DegreeObstruction) :=
@@ -2041,8 +2047,18 @@ def certifyIrreducible? (f : ZPoly) : Option ZPolyIrreducibilityCertificate :=
   match buildDegreeObstructions f blocks with
   | none => none
   | some obstructions =>
+    -- Keep only the prime blocks an obstruction actually references (in
+    -- first-seen order) and reindex the obstructions against them, so the
+    -- certificate the kernel later checks carries no unused Rabin data.
+    let used : Array Nat :=
+      obstructions.foldl
+        (fun acc o => if acc.contains o.primeIndex then acc else acc.push o.primeIndex)
+        #[]
+    let perPrime := used.filterMap fun i => blocks[i]?
+    let obstructions' := obstructions.map fun o =>
+      { o with primeIndex := (used.findIdx? (· == o.primeIndex)).getD 0 }
     let cert : ZPolyIrreducibilityCertificate :=
-      { perPrime := blocks, degreeObstructions := obstructions }
+      { perPrime := perPrime, degreeObstructions := obstructions' }
     if checkIrreducibleCert f cert then some cert else none
 
 private structure PrimeChoiceDataScore where

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -690,11 +690,23 @@ private def zCertRoundTrips (f : ZPoly) : Bool :=
 #guard zCertRoundTrips (zpoly #[2, 0, 1])
 #guard zCertRoundTrips (zpoly #[1, 1, 1])
 
+-- A degree-1 primitive is irreducible with no candidate factor degrees to
+-- obstruct: the generator emits the (valid) empty certificate.
+#guard zCertRoundTrips (zpoly #[3, 1])
+
 -- Reducible or non-admissible inputs yield no certificate: `x² - 1` splits into
 -- linear factors modulo every prime (degree-1 obstruction impossible), and
 -- `(x - 1)²` has no admissible prime at all.
 #guard (certifyIrreducible? (zpoly #[-1, 0, 1])).isNone
 #guard (certifyIrreducible? repeatedRootPoly).isNone
+
+-- Inputs excluded by `checkIrreducibleCert_sound`'s side conditions are
+-- declined up front: constants and zero (`natDegree = 0`) and non-primitive
+-- inputs (`2·x² + 2 = 2·(x² + 1)` is reducible over `ℤ` even though the checker
+-- would accept its mod-`p` certificate).
+#guard (certifyIrreducible? (zpoly #[7])).isNone
+#guard (certifyIrreducible? (0 : ZPoly)).isNone
+#guard (certifyIrreducible? (zpoly #[2, 0, 2])).isNone
 
 -- A cubic irreducible over `ℤ` with an inert prime (`x³ - x - 1` is irreducible
 -- modulo `3`): the single inert block obstructs every proper factor degree at

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -645,5 +645,63 @@ recovered true factor.
 #guard !checkIrreducibleCert (zpoly #[2, 0, 1]) certMissingObstruction
 #guard !checkIrreducibleCert (zpoly #[1, -3, 2]) certValidQuad
 
+/-! ### Compiled certificate generators (#8552)
+
+The generators are the compiled *prep* half of certifying irreducibility. They
+carry no soundness proof; the round-trip guards below confirm that whatever they
+emit is accepted by the executable checkers (`Berlekamp.checkIrreducibilityCertificate`
+and `checkIrreducibleCert`), and that reducible / trivial inputs yield `none`.
+Correctness of an accepted certificate rides on the separately proved
+`checkIrreducibleCert_sound`. -/
+
+/-- The Rabin certificate generator produces a certificate the executable
+checker accepts. -/
+private def fpCertRoundTrips {p : Nat} [ZMod64.Bounds p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f) : Bool :=
+  match Berlekamp.buildIrreducibilityCertificate? f hmonic with
+  | some cert => Berlekamp.checkIrreducibilityCertificate f hmonic cert
+  | none => false
+
+/-- The integer certificate generator produces a certificate the executable
+checker accepts. -/
+private def zCertRoundTrips (f : ZPoly) : Bool :=
+  match certifyIrreducible? f with
+  | some cert => checkIrreducibleCert f cert
+  | none => false
+
+-- Rabin generator: irreducible monic `x² + 2` over `F₅` round-trips; the unit
+-- polynomial (degree 0) fails Rabin's test, so no certificate is emitted.
+#guard fpCertRoundTrips irreducibleQuadFive irreducibleQuadFive_monic
+#guard (Berlekamp.buildIrreducibilityCertificate? unitPolyFive unitPolyFive_monic).isNone
+
+-- Integer generator: monic irreducibles with an admissible obstructing prime
+-- for each candidate degree round-trip through the executable checker.
+#guard zCertRoundTrips (zpoly #[2, 0, 1])
+#guard zCertRoundTrips (zpoly #[1, 1, 1])
+
+-- Reducible or non-admissible inputs yield no certificate: `x² - 1` splits into
+-- linear factors modulo every prime (degree-1 obstruction impossible), and
+-- `(x - 1)²` has no admissible prime at all.
+#guard (certifyIrreducible? (zpoly #[-1, 0, 1])).isNone
+#guard (certifyIrreducible? repeatedRootPoly).isNone
+
+-- A cubic irreducible over `ℤ` with an inert prime (`x³ - x - 1` is irreducible
+-- modulo `3`): the single inert block obstructs every proper factor degree at
+-- once, so the generator scales past quadratics whenever a suitable prime exists.
+#guard zCertRoundTrips (zpoly #[-1, -1, 0, 1])
+
+-- Design limitation, NOT a generator bug: the checker's per-prime degree-sum
+-- obstruction (`checkDegreeObstructions`) must rule out *every* candidate degree
+-- in `1 .. deg/2`, but degree `deg/2` is essentially never obstructable when the
+-- local factorization is "balanced". Swinnerton-Dyer `√2+√3+√5` factors as
+-- `[2,2,2,2]` / `[1×8]` at every prime (degrees 2 and 4 always reachable), and
+-- `Φ₁₅` never avoids a subset summing to 4. Both are irreducible over `ℤ` yet
+-- admit no certificate the current checker can accept, so the generator returns
+-- `none`. Certifying them needs a stronger obstruction than per-prime degree
+-- sums (a checker-design change with its own soundness proof, out of scope for a
+-- compiled generator).
+#guard (certifyIrreducible? swinnertonDyerSD3).isNone
+#guard (certifyIrreducible? phi15).isNone
+
 end BZConformance
 end Hex

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -652,7 +652,18 @@ carry no soundness proof; the round-trip guards below confirm that whatever they
 emit is accepted by the executable checkers (`Berlekamp.checkIrreducibilityCertificate`
 and `checkIrreducibleCert`), and that reducible / trivial inputs yield `none`.
 Correctness of an accepted certificate rides on the separately proved
-`checkIrreducibleCert_sound`. -/
+`checkIrreducibleCert_sound`.
+
+These `#guard`s exercise the *compiled* checker path (executable correctness of
+the generator output). The complementary *kernel* replay — reducing the checker
+on literal certificate data under `decide` — is demonstrated for the
+finite-field layer by `validQuadCert_linear_check` in
+`conformance/HexBerlekamp/Conformance.lean`, which discharges
+`checkIrreducibilityCertificateLinear` on a literal certificate. Replaying the
+integer checker `checkIrreducibleCert` in the kernel on generator output (via
+elaboration-time reification of the certificate as literal data, plus a
+kernel-reducible integer checker) is the `irreducible_cert` tactic deliverable
+tracked separately as Part 2 of #8552. -/
 
 /-- The Rabin certificate generator produces a certificate the executable
 checker accepts. -/

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -663,7 +663,7 @@ finite-field layer by `validQuadCert_linear_check` in
 integer checker `checkIrreducibleCert` in the kernel on generator output (via
 elaboration-time reification of the certificate as literal data, plus a
 kernel-reducible integer checker) is the `irreducible_cert` tactic deliverable
-tracked separately as Part 2 of #8552. -/
+tracked as #8566 (Part 2 of #8552). -/
 
 /-- The Rabin certificate generator produces a certificate the executable
 checker accepts. -/

--- a/progress/20260703T221500Z_issue-8552-cert-generators.md
+++ b/progress/20260703T221500Z_issue-8552-cert-generators.md
@@ -1,0 +1,64 @@
+# Issue #8552 — certifying irreducibility: compiled certificate generators
+
+## Accomplished
+
+Landed Part 1 of #8552: the compiled *prep* half of certifying irreducibility.
+
+- `Berlekamp.buildIrreducibilityCertificate?` (`HexBerlekamp/Irreducibility.lean`):
+  `FpPoly p → Option IrreducibilityCertificate`. Assembles the Frobenius pow
+  chain (`frobeniusXPowMod k`, `k = 0..deg`) and, per maximal proper divisor
+  `d` of `deg`, an extended-gcd Rabin-Bezout witness normalised so
+  `left*f + right*diff = 1` (`cinv = 1/leadingCoeff (xgcd f diff).gcd`). Returns
+  `none` when `rabinTest` fails. Helper `rabinBezoutWitness` factored out.
+- `certifyIrreducible?` (`HexBerlekampZassenhaus/Basic.lean`):
+  `ZPoly → Option ZPolyIrreducibilityCertificate`. Builds one self-verifying
+  `PrimeFactorData` block per admissible small prime (Berlekamp factors + nested
+  Rabin certs), greedily assigns a degree obstruction to each candidate degree,
+  prunes `perPrime` to the referenced blocks (reindexing obstructions), and
+  self-checks the whole certificate with `checkIrreducibleCert` before returning
+  `some`. Never emits a certificate the kernel checker would reject.
+- Conformance round-trip guards + a cubic-with-inert-prime positive case
+  (`conformance/HexBerlekampZassenhaus/Conformance.lean`).
+
+Neither generator carries a soundness proof (by design): correctness rides on
+the existing `checkIrreducibleCert_sound`.
+
+## Key finding (premise error, confirmed by Codex second opinion)
+
+The issue's requirement that the ZPoly generator "must cover the
+Swinnerton-Dyer case" is **not achievable with the current, soundness-proven
+checker**. `checkDegreeObstructions` requires obstructing *every* degree in
+`1..deg/2`, but the degree `deg/2` obstruction is essentially never available by
+per-prime degree sums when the local factorization is balanced. Empirically:
+
+- Swinnerton-Dyer `√2+√3+√5` (deg 8): obstructable degrees `[1:✓, 2:✗, 3:✓, 4:✗]`
+  (every prime gives `[2,2,2,2]` or `[1×8]`).
+- `Φ₁₅` (deg 8): `[1:✓, 2:✓, 3:✓, 4:✗]`.
+
+Both are irreducible over ℤ, yet the checker can accept no certificate for them,
+so the generator correctly returns `none`. Certifying them needs a stronger
+obstruction (cross-prime / resultant), a checker-design change with its own
+soundness proof — out of scope for a compiled generator. Documented in-code and
+in the conformance guards (now assert `none` for SD/`Φ₁₅`).
+
+## Current frontier
+
+Part 1 builds green: `HexBerlekamp.Irreducibility`, `HexBerlekampZassenhaus.Basic`,
+`HexBerlekampZassenhaus.Conformance`, and the CI-gated
+`HexBerlekampZassenhausMathlib` bridge. No `sorry`/`axiom`/`native_decide` added.
+
+## Next step (Part 2, follow-up)
+
+- The `irreducible_cert` elaboration tactic: reify the generator output as
+  literal `Expr` data and discharge `checkIrreducibleCert` via `decide +kernel`.
+  Blocked on (a) certificate-tower `ToExpr`/reification (no such infrastructure
+  in the repo) and a kernel-reducible integer checker
+  (`checkIrreducibleCertLinear` analog), (b) Mathlib side-condition discharge
+  (`IsPrimitive`, `natDegree > 0`, `Nat.Prime`) — bridges exist
+  (`isPrimitive_toPolynomial_of_primitive`, `natDegree_toPolynomial`).
+- Benchmark extension: `scripts/bench/kernel_factor_sweep.py` referenced by the
+  issue lives only on the unmerged `kernel-decide-series` branch, not `main`.
+
+## Blockers
+
+None for Part 1.


### PR DESCRIPTION
This PR adds the compiled *prep* half of certifying irreducibility for #8552: generators that assemble the certificates the existing checkers already verify, keeping the expensive Berlekamp/Rabin work in compiled code. Neither generator carries a soundness proof of its own — a wrong certificate makes the downstream check fail loudly, never a false pass — so correctness rides entirely on the already-proved `checkIrreducibleCert_sound`.

`Berlekamp.buildIrreducibilityCertificate?` turns a monic `FpPoly p` into an `Option IrreducibilityCertificate`, assembling the Frobenius pow chain (`frobeniusXPowMod k` for `k = 0..deg`) and, per maximal proper divisor `d` of `deg`, the extended-gcd Rabin-Bezout witness normalised so `left * f + right * diff = 1`. `certifyIrreducible?` turns a `ZPoly` into an `Option ZPolyIrreducibilityCertificate`, building one self-verifying per-prime block (Berlekamp factors modulo the prime plus a nested Rabin certificate per factor), assigning a degree obstruction to each candidate factor degree, pruning `perPrime` to the referenced blocks, and self-checking the whole certificate with `checkIrreducibleCert` before it is returned. Conformance round-trip guards confirm the emitted certificates are accepted by the executable checkers, and that reducible or trivial inputs yield `none`.

A load-bearing finding, confirmed by a second opinion: the issue asks the integer generator to "cover the Swinnerton-Dyer case", but the fixed, soundness-proven checker `checkDegreeObstructions` requires obstructing *every* degree in `1 .. deg/2`, and the `deg/2` obstruction is essentially never available by per-prime degree sums when the local factorization is balanced. Empirically, Swinnerton-Dyer `√2+√3+√5` (degree 8) is obstructable only at degrees `[1, 3]` (every prime gives `[2,2,2,2]` or `[1×8]`), and `Φ₁₅` fails at degree 4. Both are irreducible over ℤ yet admit no certificate this checker can accept, so the generator correctly returns `none`; certifying them needs a stronger obstruction (cross-prime / resultant) with its own soundness proof, which is a checker-design change out of scope for a compiled generator. This is documented in-code and pinned by conformance guards asserting `none` for those two inputs. The generator succeeds whenever each target degree has an admissible obstructing prime — in particular whenever the input has an inert prime, whose single block obstructs every proper degree at once (a cubic-with-inert-prime positive case is included).

Scope: this is Part 1 of the issue. The `irreducible_cert` elaboration tactic (Part 2), which reifies the generator output as literal `Expr` data and discharges the integer checker under `decide +kernel`, is left as a follow-up (now tracked as https://github.com/kim-em/hex-dev/issues/8566): it needs certificate-tower reification infrastructure and a kernel-reducible integer checker that do not yet exist, plus the referenced `kernel_factor_sweep.py` benchmark, which currently lives only on the unmerged `kernel-decide-series` branch. The finite-field kernel-replay path is already demonstrated on literal data by `validQuadCert_linear_check`.

🤖 Prepared with Claude Code
