### PR TITLE
feat(release): re-pin the leanprover/hex aggregate during sync

### DIFF
--- a/scripts/release/released.yml
+++ b/scripts/release/released.yml
@@ -21,6 +21,11 @@
 #   scripts/oracle/<o>                       -> scripts/oracle/<o>
 # `pins` lists the upstream repos whose git rev is rewritten in this repo's root
 # lakefile (matched by their github URL); `lakefile` is that file's format.
+#
+# A `pins_only: true` entry (the leanprover/hex aggregate) manages no source
+# from the monorepo — its umbrella lakefile, umbrella .lean and README live only
+# in the released repo. The sync just re-pins it to the SHAs published this run.
+# Such an entry is listed last so every upstream it pins is already synced.
 
 repos:
   - repo: leanprover/hex-basic
@@ -190,4 +195,12 @@ repos:
     fixtures: []
     oracles: []
     pins: [hex-lll, hex-gram-schmidt-mathlib, hex-row-reduce-mathlib, hex-determinant-mathlib, hex-bareiss-mathlib, hex-matrix-mathlib, hex-gram-schmidt, hex-row-reduce, hex-determinant, hex-bareiss, hex-matrix]
+    lakefile: toml
+
+  # Aggregate: re-pinned only, never regenerated from managed source (its
+  # umbrella lakefile.toml, HexAll.lean and README live only in the released
+  # repo). Listed last so every pin resolves to a commit synced this run.
+  - repo: leanprover/hex
+    pins_only: true
+    pins: [hex-matrix, hex-matrix-mathlib, hex-gram-schmidt, hex-gram-schmidt-mathlib, hex-lll, hex-lll-mathlib]
     lakefile: toml

--- a/scripts/release/sync_released.py
+++ b/scripts/release/sync_released.py
@@ -10,6 +10,11 @@ For each repo in scripts/release/released.yml (topological order), this:
   4. commits `chore: sync from hex-dev@<sha>` and pushes to `main`
      (unless --dry-run, which prints the planned changes and pin rewrites).
 
+A `pins_only` entry (the `leanprover/hex` aggregate) skips step 2 entirely: it
+manages no source from the monorepo, so the sync only re-pins it (steps 3-4) to
+the SHAs published this run. Listed last, after its upstreams, so its pins
+resolve to the freshly-pushed commits.
+
 Auth (non-dry-run): a token from --token or $RELEASED_SYNC_PAT is used as an
 `x-access-token` basic-auth credential for clone and push. Dry-run clones over
 public https and never pushes.
@@ -71,6 +76,11 @@ def managed_paths(entry: dict) -> list[tuple[Path, Path, bool]]:
 
     Sources are absolute monorepo paths; dest_rel is relative to the repo root.
     """
+    # Aggregate repos (e.g. leanprover/hex) manage no source from the monorepo:
+    # their umbrella lakefile, umbrella .lean and README live only in the released
+    # repo. The sync just rewrites their cross-repo pins + manifest.
+    if entry.get("pins_only"):
+        return []
     lib = entry["lib"]
     out: list[tuple[Path, Path, bool]] = []
     # explicit path list (e.g. hex-test-kit ships only `Hex/`)
@@ -115,6 +125,8 @@ def managed_paths(entry: dict) -> list[tuple[Path, Path, bool]]:
 
 def apply_paths(entry: dict, clone: Path) -> list[str]:
     notes: list[str] = []
+    if entry.get("pins_only"):
+        return notes
     lib = entry["lib"]
     for src, dest_rel, is_dir in managed_paths(entry):
         dest = clone / dest_rel


### PR DESCRIPTION
This PR teaches the publish-out sync to advance the `leanprover/hex` aggregate as part of the same run that publishes the split repos, so its cross-repo pins never drift behind the released libraries and its doc-gen4 site tracks the latest release without a manual pin bump.

It adds a `pins_only` entry kind to `released.yml`: an aggregate manages no source from the monorepo (its umbrella `lakefile.toml`, `HexAll.lean` and README live only in the released repo), so the sync skips the managed-path copy and only rewrites its lakefile pins and `lake-manifest.json` revisions. `leanprover/hex` is listed last so every pin resolves to a commit synced this run. A full `--dry-run` confirms it rewrites all six direct pins and the fourteen `hex-*` manifest entries while touching no source. No workflow YAML change is needed; the driver handles the new entry.

🤖 Prepared with Claude Code