### PR TITLE
feat(bz): irreducible_cert tactic, kernel-checked certifying irreducibility

### DIFF
--- a/HexBerlekamp/Irreducibility.lean
+++ b/HexBerlekamp/Irreducibility.lean
@@ -1282,6 +1282,51 @@ theorem checkIrreducibilityCertificateLinearIncremental_rabinTest
         (checkPowChainLinearIncremental_spec f hmonic samePrimeCert hpowCheck)
         hdividesWitness hwitnesses
 
+/--
+The incremental kernel checker implies the committed checker: a certificate
+accepted by `checkIrreducibilityCertificateLinearIncremental` is accepted by
+`checkIrreducibilityCertificate`. This lets kernel-replayed certificates feed
+consumers stated over the committed checker without restating their soundness.
+-/
+theorem checkIrreducibilityCertificate_of_linearIncremental
+    [ZMod64.PrimeModulus p]
+    (f : FpPoly p) (hmonic : DensePoly.Monic f)
+    (cert : IrreducibilityCertificate)
+    (hcheck : checkIrreducibilityCertificateLinearIncremental f hmonic cert = true) :
+    checkIrreducibilityCertificate f hmonic cert = true := by
+  unfold checkIrreducibilityCertificateLinearIncremental at hcheck
+  cases hambient : cert.toAmbient? p with
+  | none => simp [hambient] at hcheck
+  | some samePrimeCert =>
+      have hparts :
+          (((0 < samePrimeCert.n ∧ samePrimeCert.n = basisSize f) ∧
+              checkPowChainLinearIncremental f hmonic samePrimeCert = true) ∧
+              samePrimeCert.powChain[samePrimeCert.n]? =
+                some (FpPoly.modByMonic f FpPoly.X hmonic)) ∧
+            checkRabinBezoutWitnesses f hmonic samePrimeCert = true := by
+        simpa [checkIrreducibilityCertificateLinearIncremental, hambient,
+          Bool.and_eq_true] using hcheck
+      rcases hparts with ⟨⟨⟨⟨hnpos, hn⟩, hpowCheck⟩, hdividesWitness⟩, hwitnesses⟩
+      have hsize : samePrimeCert.powChain.size = samePrimeCert.n + 1 := by
+        unfold checkPowChainLinearIncremental at hpowCheck
+        simp only [Bool.and_eq_true, beq_iff_eq] at hpowCheck
+        exact hpowCheck.1.1
+      have hspec :=
+        checkPowChainLinearIncremental_spec f hmonic samePrimeCert hpowCheck
+      have hpow : checkPowChain f hmonic samePrimeCert = true := by
+        unfold checkPowChain
+        simp only [Bool.and_eq_true, beq_iff_eq]
+        refine ⟨hsize, ?_⟩
+        rw [List.all_eq_true]
+        intro k hkmem
+        have hk : k ≤ samePrimeCert.n := by
+          rw [List.mem_range] at hkmem
+          omega
+        simpa using hspec k hk
+      simp only [checkIrreducibilityCertificate, hambient, Bool.and_eq_true,
+        decide_eq_true_eq, beq_iff_eq]
+      exact ⟨⟨⟨⟨hnpos, hn⟩, hpow⟩, hdividesWitness⟩, hwitnesses⟩
+
 end Berlekamp
 
 end Hex

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -1943,6 +1943,144 @@ def checkIrreducibleCert
   cert.perPrime.all (fun primeData => primeData.checkForPolynomial f) &&
     cert.checkDegreeObstructions f
 
+namespace PrimeFactorData
+
+/--
+Kernel-reducible counterpart of `checkCertAtFactor`.
+
+Identical metadata alignment checks, but the nested Rabin certificate is
+replayed through `Berlekamp.checkIrreducibilityCertificateLinearIncremental`,
+whose pow-chain validation costs `O(n · p)` kernel multiplications per factor
+instead of the `O(Σ p^k)` recomputation against the committed
+`FpPoly.frobeniusXPowMod`. The incremental comparison is preferred over
+`Berlekamp.checkIrreducibilityCertificateLinear` because certificate replay
+targets degrees where `p^n` overwhelms any kernel budget while `n · p` stays
+cheap.
+-/
+def checkCertAtFactorLinear
+    (d : PrimeFactorData) (degree : Nat) (factor : @FpPoly d.p d.bounds)
+    (cert : Berlekamp.IrreducibilityCertificate) : Bool :=
+  letI := d.bounds
+  decide (cert.p = d.p) &&
+    decide (cert.n = degree) &&
+    d.containsDegree cert.n &&
+    factor.degree? == some degree &&
+    if hmonic : factor.leadingCoeff = 1 then
+      Berlekamp.checkIrreducibilityCertificateLinearIncremental factor (by exact hmonic) cert
+    else
+      false
+
+/-- Kernel-reducible counterpart of `checkFactorCerts`, replaying each nested
+certificate through `checkCertAtFactorLinear`. -/
+def checkFactorCertsLinear (d : PrimeFactorData) : Bool :=
+  d.factorDegrees.size == d.factorCerts.size &&
+    d.factorDegrees.size == d.factorPolys.size &&
+    (d.factorDegrees.toList.zip (d.factorPolys.toList.zip d.factorCerts.toList)).all fun pair =>
+      checkCertAtFactorLinear d pair.1 pair.2.1 pair.2.2
+
+/-- Kernel-reducible counterpart of `checkForPolynomial`, replaying the nested
+certificates through `checkFactorCertsLinear`. -/
+def checkForPolynomialLinear (f : ZPoly) (d : PrimeFactorData) : Bool :=
+  letI := d.bounds
+  isGoodPrime f d.p &&
+    d.factorDegrees.all (fun degree => 0 < degree) &&
+    d.degreeSum == (ZPoly.modP d.p f).degree?.getD 0 &&
+    d.factorProduct == ZPoly.modP d.p f &&
+    d.checkFactorCertsLinear
+
+/--
+`checkCertAtFactorLinear` implies `checkCertAtFactor` once the block's prime
+is genuinely prime: the two differ only in the nested pow-chain replay, which
+`Berlekamp.checkIrreducibilityCertificate_of_linearIncremental` bridges.
+-/
+theorem checkCertAtFactor_of_linear
+    (d : PrimeFactorData) (degree : Nat) (factor : @FpPoly d.p d.bounds)
+    (cert : Berlekamp.IrreducibilityCertificate)
+    (hp : Hex.Nat.Prime d.p)
+    (hcheck : d.checkCertAtFactorLinear degree factor cert = true) :
+    d.checkCertAtFactor degree factor cert = true := by
+  letI := d.bounds
+  letI : ZMod64.PrimeModulus d.p := ZMod64.primeModulusOfPrime hp
+  unfold checkCertAtFactorLinear at hcheck
+  unfold checkCertAtFactor
+  simp only [Bool.and_eq_true] at hcheck ⊢
+  rcases hcheck with ⟨hmeta, htail⟩
+  refine ⟨hmeta, ?_⟩
+  by_cases hmonic : factor.leadingCoeff = 1
+  · rw [dif_pos hmonic] at htail ⊢
+    exact Berlekamp.checkIrreducibilityCertificate_of_linearIncremental
+      factor _ cert htail
+  · rw [dif_neg hmonic] at htail
+    simp at htail
+
+/-- `checkFactorCertsLinear` implies `checkFactorCerts` once the block's prime
+is genuinely prime. -/
+theorem checkFactorCerts_of_linear
+    (d : PrimeFactorData) (hp : Hex.Nat.Prime d.p)
+    (hcheck : d.checkFactorCertsLinear = true) :
+    d.checkFactorCerts = true := by
+  unfold checkFactorCertsLinear at hcheck
+  unfold checkFactorCerts
+  simp only [Bool.and_eq_true] at hcheck ⊢
+  rcases hcheck with ⟨hsizes, hall⟩
+  refine ⟨hsizes, ?_⟩
+  rw [List.all_eq_true] at hall ⊢
+  intro pair hmem
+  exact checkCertAtFactor_of_linear d pair.1 pair.2.1 pair.2.2 hp (hall pair hmem)
+
+/-- `checkForPolynomialLinear` implies `checkForPolynomial` once the block's
+prime is genuinely prime. -/
+theorem checkForPolynomial_of_linear
+    (f : ZPoly) (d : PrimeFactorData) (hp : Hex.Nat.Prime d.p)
+    (hcheck : d.checkForPolynomialLinear f = true) :
+    d.checkForPolynomial f = true := by
+  unfold checkForPolynomialLinear at hcheck
+  unfold checkForPolynomial
+  simp only [Bool.and_eq_true] at hcheck ⊢
+  rcases hcheck with ⟨hmeta, hcerts⟩
+  exact ⟨hmeta, checkFactorCerts_of_linear d hp hcerts⟩
+
+end PrimeFactorData
+
+/--
+Kernel-reducible counterpart of `checkIrreducibleCert`: the same surface
+checks, with every nested Rabin certificate replayed through the incremental
+pow-chain checker so `decide` can reduce a literal certificate without
+re-running the committed `FpPoly.frobeniusXPowMod` in the kernel.
+
+Consumers discharge this checker on literal certificate data and cross to the
+committed checker (hence to `checkIrreducibleCert`'s soundness theorem) via
+`checkIrreducibleCert_of_linear`.
+-/
+def checkIrreducibleCertLinear
+    (f : ZPoly) (cert : ZPolyIrreducibilityCertificate) : Bool :=
+  cert.perPrime.all (fun primeData => primeData.checkForPolynomialLinear f) &&
+    cert.checkDegreeObstructions f
+
+/--
+The kernel-reducible integer checker implies the committed one, given that
+every recorded block prime is genuinely prime. Primality feeds the pow-chain
+recurrence `X^(p^(k+1)) ≡ (X^(p^k))^p (mod f)` that identifies the incremental
+replay with the committed Frobenius routine.
+-/
+theorem checkIrreducibleCert_of_linear
+    (f : ZPoly) (cert : ZPolyIrreducibilityCertificate)
+    (hprime : ∀ primeData ∈ cert.perPrime.toList, Hex.Nat.Prime primeData.p)
+    (hcheck : checkIrreducibleCertLinear f cert = true) :
+    checkIrreducibleCert f cert = true := by
+  unfold checkIrreducibleCertLinear at hcheck
+  unfold checkIrreducibleCert
+  simp only [Bool.and_eq_true] at hcheck ⊢
+  rcases hcheck with ⟨hblocks, hobs⟩
+  refine ⟨?_, hobs⟩
+  rw [Array.all_eq_true] at hblocks ⊢
+  intro i hi
+  have hmem : cert.perPrime[i] ∈ cert.perPrime.toList := by
+    rw [List.mem_iff_getElem]
+    exact ⟨i, by simpa using hi, by simp⟩
+  exact PrimeFactorData.checkForPolynomial_of_linear f cert.perPrime[i]
+    (hprime cert.perPrime[i] hmem) (hblocks i hi)
+
 /--
 Rabin certificates for every modular factor at a prime block, aligned with the
 factor array. Fails (returns `none`) if any modular factor is non-monic or is

--- a/HexBerlekampZassenhausMathlib.lean
+++ b/HexBerlekampZassenhausMathlib.lean
@@ -5,6 +5,9 @@ Authors: Kim Morrison
 -/
 
 import HexBerlekampZassenhausMathlib.Basic
+import HexBerlekampZassenhausMathlib.CertReify
+import HexBerlekampZassenhausMathlib.IrreducibleCert
+import HexBerlekampZassenhausMathlib.IrreducibleCertTest
 import HexBerlekampZassenhausMathlib.SignatureClasses
 import HexBerlekampZassenhausMathlib.Lattice
 import HexBerlekampZassenhausMathlib.CLDColumnBound

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -1353,6 +1353,58 @@ theorem checkIrreducibleCert_sound_zpoly
     (Hex.ZPoly.Irreducible_iff_polynomialIrreducible f).mpr
       (checkIrreducibleCert_sound f cert hprime hprim hpos hcert)
 
+/--
+Soundness of the kernel-reducible integer checker: a certificate accepted by
+`checkIrreducibleCertLinear` on literal data certifies irreducibility of the
+transported polynomial. The primality hypothesis feeds both the
+Linear→committed checker implication and the committed checker's own
+soundness theorem.
+-/
+theorem checkIrreducibleCertLinear_sound
+    (f : Hex.ZPoly) (cert : Hex.ZPolyIrreducibilityCertificate)
+    (hprime : ∀ primeData ∈ cert.perPrime.toList, Nat.Prime primeData.p)
+    (hprim : (HexPolyZMathlib.toPolynomial f).IsPrimitive)
+    (hpos : 0 < (HexPolyZMathlib.toPolynomial f).natDegree) :
+    Hex.checkIrreducibleCertLinear f cert = true →
+      Irreducible (HexPolyZMathlib.toPolynomial f) := by
+  intro hcert
+  refine checkIrreducibleCert_sound f cert hprime hprim hpos ?_
+  refine Hex.checkIrreducibleCert_of_linear f cert ?_ hcert
+  intro primeData hmem
+  exact ⟨(hprime primeData hmem).two_le,
+    fun m hm => (hprime primeData hmem).eq_one_or_self_of_dvd m hm⟩
+
+/--
+`checkIrreducibleCertLinear_sound` with every side condition stated as a
+kernel-decidable Boolean check: primality of the recorded primes, content one,
+and positive executable degree. This is the exact consumption shape of the
+`irreducible_cert` tactic: it applies this theorem to a reified literal
+certificate with an `Eq.refl true` proof in each hypothesis slot, so the whole
+obligation is discharged by kernel reduction on literal data.
+-/
+theorem irreducible_of_checkIrreducibleCertLinear
+    (f : Hex.ZPoly) (cert : Hex.ZPolyIrreducibilityCertificate)
+    (hprime : cert.perPrime.all (fun primeData => decide (Nat.Prime primeData.p)) = true)
+    (hcontent : decide (Hex.ZPoly.content f = 1) = true)
+    (hpos : decide (0 < f.degree?.getD 0) = true)
+    (hcert : Hex.checkIrreducibleCertLinear f cert = true) :
+    Irreducible (HexPolyZMathlib.toPolynomial f) := by
+  have hprime' : ∀ primeData ∈ cert.perPrime.toList, Nat.Prime primeData.p := by
+    rw [Array.all_eq_true] at hprime
+    intro primeData hmem
+    rw [List.mem_iff_getElem] at hmem
+    obtain ⟨i, hi, hget⟩ := hmem
+    have hiArray : i < cert.perPrime.size := by simpa using hi
+    have hdec := hprime i hiArray
+    rw [← hget]
+    simpa [Array.getElem_toList] using of_decide_eq_true hdec
+  have hcontent' : Hex.ZPoly.content f = 1 := of_decide_eq_true hcontent
+  have hdeg : (HexPolyZMathlib.toPolynomial f).natDegree = f.degree?.getD 0 :=
+    HexPolyMathlib.natDegree_toPolynomial f
+  exact checkIrreducibleCertLinear_sound f cert hprime'
+    (HexPolyZMathlib.isPrimitive_toPolynomial_of_primitive f hcontent')
+    (by rw [hdeg]; exact of_decide_eq_true hpos) hcert
+
 /-- Index type for the modular factors stored in executable prime-choice data. -/
 abbrev ModPFactorIndex (primeData : Hex.PrimeChoiceData) : Type :=
   Fin primeData.factorsModP.size

--- a/HexBerlekampZassenhausMathlib/CertReify.lean
+++ b/HexBerlekampZassenhausMathlib/CertReify.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekampZassenhaus
+import Lean
+
+/-!
+Elaboration-time reification of `Hex.ZPolyIrreducibilityCertificate` values as
+literal `Expr`s, for the `irreducible_cert` tactic.
+
+The reifier rebuilds every layer of the certificate tower from *public
+constructor functions* rather than raw structure-field literals, so all proof
+and instance obligations are supplied by the constructors themselves:
+
+- `Hex.ZMod64 p` residues via `Hex.ZMod64.ofNat p n` (reduction proof from the
+  smart constructor);
+- `Hex.FpPoly p` values via `Hex.FpPoly.ofCoeffs #[…]` (normalization proof
+  from the smart constructor);
+- `Hex.ZPoly` values via `Hex.DensePoly.ofCoeffs #[…]`;
+- `Hex.ZMod64.Bounds p` instance fields via `boundsOfDecide`, whose single
+  Boolean hypothesis the kernel discharges by reducing an `Eq.refl true`;
+- the structure layers (`RabinBezoutWitness`, `IrreducibilityCertificate`,
+  `PrimeFactorData`, `DegreeObstruction`, `ZPolyIrreducibilityCertificate`)
+  as constructor applications over the reified pieces.
+
+Every emitted proof obligation is a `_ = true` slot filled with `Eq.refl true`,
+so the kernel verifies the reified data by reduction alone; nothing in the
+output depends on elaborator-side evaluation.
+
+The round-trip tests live in `HexBerlekampZassenhausMathlib.IrreducibleCertTest`
+next to the tactic examples: each reified certificate is typechecked,
+evaluated back to a value, and compared field-by-field with the original.
+-/
+
+namespace HexBerlekampZassenhausMathlib.CertReify
+
+open Lean
+
+/--
+Rebuild a `ZMod64.Bounds` instance from a single kernel-decidable Boolean
+check. The reifier emits `boundsOfDecide p (Eq.refl true)` in every reified
+instance slot, so the kernel discharges both bounds by reduction.
+-/
+theorem boundsOfDecide (p : Nat)
+    (h : (decide (0 < p) && decide (p ≤ UInt64.word)) = true) :
+    Hex.ZMod64.Bounds p := by
+  rw [Bool.and_eq_true] at h
+  exact ⟨of_decide_eq_true h.1, of_decide_eq_true h.2⟩
+
+/-- The literal proof `Eq.refl true`, accepted in any `b = true` slot whose
+left-hand side the kernel can reduce to `true`. -/
+def reflTrue : Expr :=
+  mkApp2 (mkConst ``Eq.refl [Level.one]) (mkConst ``Bool) (mkConst ``Bool.true)
+
+/-- Literal `Array` expression `(List.toArray [x₁, …, xₙ] : Array ty)`. -/
+def arrayLit (ty : Expr) (xs : List Expr) : Expr :=
+  let nil := mkApp (mkConst ``List.nil [Level.zero]) ty
+  let listE := xs.foldr (fun x acc => mkApp3 (mkConst ``List.cons [Level.zero]) ty x acc) nil
+  mkApp2 (mkConst ``List.toArray [Level.zero]) ty listE
+
+/-- Reified `ZMod64.Bounds p` instance: `boundsOfDecide p (Eq.refl true)`. -/
+def reifyBounds (pE : Expr) : Expr :=
+  mkApp2 (mkConst ``boundsOfDecide) pE reflTrue
+
+/-- The type `Hex.ZMod64 p` at a reified prime and bounds instance. -/
+def zmodType (pE boundsE : Expr) : Expr :=
+  mkApp2 (mkConst ``Hex.ZMod64) pE boundsE
+
+/-- The type `Hex.FpPoly p` at a reified prime and bounds instance. -/
+def fpPolyType (pE boundsE : Expr) : Expr :=
+  mkApp2 (mkConst ``Hex.FpPoly) pE boundsE
+
+/-- Reify a `ZMod64 p` residue from its canonical `Nat` representative as
+`Hex.ZMod64.ofNat p n`. -/
+def reifyZMod64 (pE boundsE : Expr) (n : Nat) : Expr :=
+  mkApp3 (mkConst ``Hex.ZMod64.ofNat) pE (mkNatLit n) boundsE
+
+/-- Reify an `FpPoly p` from the canonical `Nat` representatives of its
+coefficients as `Hex.FpPoly.ofCoeffs #[…]`. -/
+def reifyFpPolyOfNats (pE boundsE : Expr) (coeffs : List Nat) : Expr :=
+  mkApp3 (mkConst ``Hex.FpPoly.ofCoeffs) pE boundsE
+    (arrayLit (zmodType pE boundsE) (coeffs.map (reifyZMod64 pE boundsE)))
+
+/-- Canonical `Nat` representatives of an `FpPoly p`'s coefficient array. -/
+def fpCoeffNats {p : Nat} [Hex.ZMod64.Bounds p] (g : Hex.FpPoly p) : List Nat :=
+  g.toArray.toList.map Hex.ZMod64.toNat
+
+/-- Reify a `RabinBezoutWitness p` as a constructor application over reified
+`FpPoly` values. -/
+def reifyRabinWitness {p : Nat} [bounds : Hex.ZMod64.Bounds p]
+    (pE boundsE : Expr) (w : Hex.Berlekamp.RabinBezoutWitness p) : Expr :=
+  mkApp4 (mkConst ``Hex.Berlekamp.RabinBezoutWitness.mk) pE boundsE
+    (reifyFpPolyOfNats pE boundsE (fpCoeffNats w.left))
+    (reifyFpPolyOfNats pE boundsE (fpCoeffNats w.right))
+
+/-- Reify a nested Rabin `IrreducibilityCertificate` as a constructor
+application over its reified prime, pow chain, and Bezout witnesses. -/
+def reifyRabinCert (cert : Hex.Berlekamp.IrreducibilityCertificate) : Expr :=
+  match cert with
+  | { p := p, bounds := bounds, n := n, powChain := powChain, bezout := bezout } =>
+      let pE := mkNatLit p
+      let boundsE := reifyBounds pE
+      let powChainE := arrayLit (fpPolyType pE boundsE)
+        (powChain.toList.map fun g =>
+          reifyFpPolyOfNats pE boundsE (@fpCoeffNats p bounds g))
+      let bezoutE := arrayLit
+        (mkApp2 (mkConst ``Hex.Berlekamp.RabinBezoutWitness) pE boundsE)
+        (bezout.toList.map fun w => @reifyRabinWitness p bounds pE boundsE w)
+      mkApp5 (mkConst ``Hex.Berlekamp.IrreducibilityCertificate.mk)
+        pE boundsE (mkNatLit n) powChainE bezoutE
+
+/-- Reify a `PrimeFactorData` block as a constructor application over its
+reified prime, degree array, factor array, and nested Rabin certificates. -/
+def reifyPrimeFactorData (d : Hex.PrimeFactorData) : Expr :=
+  match d with
+  | { p := p, bounds := bounds, factorDegrees := degrees, factorPolys := polys,
+      factorCerts := certs } =>
+      let pE := mkNatLit p
+      let boundsE := reifyBounds pE
+      let degreesE := arrayLit (mkConst ``Nat) (degrees.toList.map mkNatLit)
+      let polysE := arrayLit (fpPolyType pE boundsE)
+        (polys.toList.map fun g =>
+          reifyFpPolyOfNats pE boundsE (@fpCoeffNats p bounds g))
+      let certsE := arrayLit (mkConst ``Hex.Berlekamp.IrreducibilityCertificate)
+        (certs.toList.map reifyRabinCert)
+      mkApp5 (mkConst ``Hex.PrimeFactorData.mk) pE boundsE degreesE polysE certsE
+
+/-- Reify a `DegreeObstruction` as a constructor application. -/
+def reifyDegreeObstruction (o : Hex.DegreeObstruction) : Expr :=
+  mkApp2 (mkConst ``Hex.DegreeObstruction.mk)
+    (mkNatLit o.targetDegree) (mkNatLit o.primeIndex)
+
+/-- Reify a full `ZPolyIrreducibilityCertificate` as a literal `Expr`. -/
+def reifyCertificate (cert : Hex.ZPolyIrreducibilityCertificate) : Expr :=
+  mkApp2 (mkConst ``Hex.ZPolyIrreducibilityCertificate.mk)
+    (arrayLit (mkConst ``Hex.PrimeFactorData)
+      (cert.perPrime.toList.map reifyPrimeFactorData))
+    (arrayLit (mkConst ``Hex.DegreeObstruction)
+      (cert.degreeObstructions.toList.map reifyDegreeObstruction))
+
+/-- Reify a `ZPoly` as `Hex.DensePoly.ofCoeffs #[…]` with literal `Int`
+coefficients. -/
+def reifyZPoly (f : Hex.ZPoly) : Lean.Meta.MetaM Expr := do
+  Lean.Meta.mkAppM ``Hex.DensePoly.ofCoeffs
+    #[arrayLit (mkConst ``Int) (f.toArray.toList.map toExpr)]
+
+/-! ### Serialized views for round-trip testing
+
+The round-trip tests (in `HexBerlekampZassenhausMathlib.IrreducibleCertTest`)
+evaluate a reified certificate back to a value and compare it with the
+original. The certificate tower has no derivable `BEq` (its `FpPoly` fields
+live at per-block primes), so the comparison goes through these canonical
+serializations to plain `Nat` data.
+-/
+
+/-- Serialized view of a nested Rabin certificate. -/
+def rabinCertData (cert : Hex.Berlekamp.IrreducibilityCertificate) :
+    Nat × Nat × List (List Nat) × List (List Nat × List Nat) :=
+  match cert with
+  | { p := p, bounds := bounds, n := n, powChain := powChain, bezout := bezout } =>
+      (p, n, powChain.toList.map fun g => @fpCoeffNats p bounds g,
+        bezout.toList.map fun w =>
+          (@fpCoeffNats p bounds w.left, @fpCoeffNats p bounds w.right))
+
+/-- Serialized view of a per-prime certificate block. -/
+def primeFactorDataData (d : Hex.PrimeFactorData) :
+    Nat × List Nat × List (List Nat) ×
+      List (Nat × Nat × List (List Nat) × List (List Nat × List Nat)) :=
+  match d with
+  | { p := p, bounds := bounds, factorDegrees := degrees, factorPolys := polys,
+      factorCerts := certs } =>
+      (p, degrees.toList, polys.toList.map fun g => @fpCoeffNats p bounds g,
+        certs.toList.map rabinCertData)
+
+/-- Serialized view of a full integer irreducibility certificate. -/
+def certificateData (cert : Hex.ZPolyIrreducibilityCertificate) :
+    List (Nat × List Nat × List (List Nat) ×
+        List (Nat × Nat × List (List Nat) × List (List Nat × List Nat))) ×
+      List (Nat × Nat) :=
+  (cert.perPrime.toList.map primeFactorDataData,
+    cert.degreeObstructions.toList.map fun o => (o.targetDegree, o.primeIndex))
+
+end HexBerlekampZassenhausMathlib.CertReify

--- a/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekampZassenhausMathlib.Basic
+import HexBerlekampZassenhausMathlib.CertReify
+
+/-!
+The `irreducible_cert` tactic: certifying irreducibility for integer
+polynomials with compiled certificate prep and a cheap kernel check.
+
+For a goal `Irreducible (HexPolyZMathlib.toPolynomial f)` with `f` a closed
+`Hex.ZPoly` term, the tactic:
+
+1. evaluates `Hex.certifyIrreducible? f` at elaboration time (compiled
+   evaluation; Berlekamp factoring and Rabin certificate generation never
+   reach the kernel);
+2. reifies the resulting certificate as a literal `Expr`
+   (`HexBerlekampZassenhausMathlib.CertReify`);
+3. closes the goal with `irreducible_of_checkIrreducibleCertLinear` applied to
+   the reified certificate, filling all four Boolean hypothesis slots with
+   `Eq.refl true`.
+
+The only kernel work is reducing `checkIrreducibleCertLinear` (the incremental
+pow-chain replay, `O(n · p)` per modular factor) plus the three cheap side
+checks (primality of the handful of recorded primes, `content f = 1`, and
+`0 < degree`), all on literal data.
+-/
+
+namespace HexBerlekampZassenhausMathlib.IrreducibleCert
+
+open Lean Meta
+
+private unsafe def evalZPolyUnsafe (e : Expr) : MetaM (Option Hex.ZPoly) :=
+  return some (← evalExpr Hex.ZPoly (mkConst ``Hex.ZPoly) e)
+
+@[implemented_by evalZPolyUnsafe]
+private opaque evalZPolyOpt (e : Expr) : MetaM (Option Hex.ZPoly)
+
+/-- Evaluate a closed `Hex.ZPoly` expression to its runtime value at
+elaboration time (compiled/interpreted evaluation, not kernel reduction). -/
+def evalZPoly (e : Expr) : MetaM Hex.ZPoly := do
+  let some f ← evalZPolyOpt e
+    | throwError "irreducible_cert: failed to evaluate the polynomial\
+        {indentExpr e}"
+  return f
+
+private unsafe def evalCertificateUnsafe (e : Expr) :
+    MetaM (Option Hex.ZPolyIrreducibilityCertificate) :=
+  return some (← evalExpr Hex.ZPolyIrreducibilityCertificate
+    (mkConst ``Hex.ZPolyIrreducibilityCertificate) e)
+
+@[implemented_by evalCertificateUnsafe]
+private opaque evalCertificateOpt (e : Expr) :
+    MetaM (Option Hex.ZPolyIrreducibilityCertificate)
+
+/-- Evaluate a closed `Hex.ZPolyIrreducibilityCertificate` expression to its
+runtime value at elaboration time. Used by the reification round-trip tests. -/
+def evalCertificate (e : Expr) : MetaM Hex.ZPolyIrreducibilityCertificate := do
+  let some cert ← evalCertificateOpt e
+    | throwError "irreducible_cert: failed to evaluate the certificate\
+        {indentExpr e}"
+  return cert
+
+/--
+Match a goal of the form `Irreducible (HexPolyZMathlib.toPolynomial f)`
+(or the unfolded `HexPolyMathlib.toPolynomial` at `R = ℤ`) and return `f`.
+-/
+private def matchIrreducibleGoal (tgt : Expr) : MetaM (Option Expr) := do
+  let tgt ← whnfR tgt
+  let_expr Irreducible _M _inst arg := tgt | return none
+  if arg.getAppFn.isConstOf ``HexPolyZMathlib.toPolynomial &&
+      arg.getAppNumArgs == 1 then
+    return some arg.appArg!
+  let arg ← whnfR arg
+  if arg.getAppFn.isConstOf ``HexPolyMathlib.toPolynomial &&
+      arg.getAppNumArgs == 4 then
+    let args := arg.getAppArgs
+    if args[0]!.isConstOf ``Int then
+      return some args[3]!
+  return none
+
+/--
+`irreducible_cert` proves `Irreducible (HexPolyZMathlib.toPolynomial f)` for a
+closed `Hex.ZPoly` term `f` by running the compiled certificate generator
+`Hex.certifyIrreducible?` at elaboration time, reifying the certificate as
+literal data, and letting the kernel replay only the cheap
+`checkIrreducibleCertLinear` reduction plus the primality / content / degree
+side checks.
+
+The tactic fails cleanly when the generator declines: reducible, non-primitive,
+or constant inputs, and irreducible inputs whose balanced modular
+factorizations fall outside the per-prime degree-sum obstruction language
+(e.g. Swinnerton-Dyer polynomials).
+-/
+elab "irreducible_cert" : tactic => do
+  let goal ← Elab.Tactic.getMainGoal
+  goal.withContext do
+    let tgt ← instantiateMVars (← goal.getType)
+    let some fE ← matchIrreducibleGoal tgt
+      | throwError "irreducible_cert: the goal must have the form\
+          \n  Irreducible (HexPolyZMathlib.toPolynomial f)\
+          \nwith f a closed Hex.ZPoly term, but the goal is{indentExpr tgt}"
+    if fE.hasFVar || fE.hasExprMVar then
+      throwError "irreducible_cert: the polynomial{indentExpr fE}\
+          \nmust be a closed term (no local hypotheses or metavariables)"
+    let f ← evalZPoly fE
+    let some cert := Hex.certifyIrreducible? f
+      | throwError "irreducible_cert: certifyIrreducible? produced no \
+          certificate for{indentExpr fE}\
+          \nThe polynomial is reducible, non-primitive, or constant, or it \
+          is irreducible but its modular factorizations are balanced at every \
+          admissible prime (e.g. Swinnerton-Dyer polynomials), which the \
+          per-prime degree-sum obstruction language cannot certify."
+    unless Hex.checkIrreducibleCertLinear f cert do
+      throwError "irreducible_cert: internal error: the generated \
+          certificate fails checkIrreducibleCertLinear; please report this"
+    let certE := CertReify.reifyCertificate cert
+    -- Each hypothesis slot receives `Eq.refl true`; the kernel verifies it by
+    -- reducing the corresponding Boolean check on the literal certificate.
+    let proof := mkApp6
+      (mkConst ``HexBerlekampZassenhausMathlib.irreducible_of_checkIrreducibleCertLinear)
+      fE certE CertReify.reflTrue CertReify.reflTrue CertReify.reflTrue
+      CertReify.reflTrue
+    unless ← isDefEq (← inferType proof) tgt do
+      throwError "irreducible_cert: internal error: proof type mismatch"
+    goal.assign proof
+  Elab.Tactic.replaceMainGoal []
+
+end HexBerlekampZassenhausMathlib.IrreducibleCert

--- a/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
@@ -33,36 +33,45 @@ namespace HexBerlekampZassenhausMathlib.IrreducibleCert
 
 open Lean Meta
 
-private unsafe def evalZPolyUnsafe (e : Expr) : MetaM (Option Hex.ZPoly) :=
-  return some (← evalExpr Hex.ZPoly (mkConst ``Hex.ZPoly) e)
+private unsafe def evalZPolyUnsafe (e : Expr) :
+    MetaM (Except String Hex.ZPoly) :=
+  try
+    return .ok (← evalExpr Hex.ZPoly (mkConst ``Hex.ZPoly) e)
+  catch ex =>
+    return .error (← ex.toMessageData.toString)
 
 @[implemented_by evalZPolyUnsafe]
-private opaque evalZPolyOpt (e : Expr) : MetaM (Option Hex.ZPoly)
+private opaque evalZPolyCore (e : Expr) : MetaM (Except String Hex.ZPoly)
 
 /-- Evaluate a closed `Hex.ZPoly` expression to its runtime value at
 elaboration time (compiled/interpreted evaluation, not kernel reduction). -/
 def evalZPoly (e : Expr) : MetaM Hex.ZPoly := do
-  let some f ← evalZPolyOpt e
-    | throwError "irreducible_cert: failed to evaluate the polynomial\
-        {indentExpr e}"
-  return f
+  match ← evalZPolyCore e with
+  | .ok f => return f
+  | .error msg =>
+      throwError "irreducible_cert: failed to evaluate the polynomial\
+          {indentExpr e}\n{msg}"
 
 private unsafe def evalCertificateUnsafe (e : Expr) :
-    MetaM (Option Hex.ZPolyIrreducibilityCertificate) :=
-  return some (← evalExpr Hex.ZPolyIrreducibilityCertificate
-    (mkConst ``Hex.ZPolyIrreducibilityCertificate) e)
+    MetaM (Except String Hex.ZPolyIrreducibilityCertificate) :=
+  try
+    return .ok (← evalExpr Hex.ZPolyIrreducibilityCertificate
+      (mkConst ``Hex.ZPolyIrreducibilityCertificate) e)
+  catch ex =>
+    return .error (← ex.toMessageData.toString)
 
 @[implemented_by evalCertificateUnsafe]
-private opaque evalCertificateOpt (e : Expr) :
-    MetaM (Option Hex.ZPolyIrreducibilityCertificate)
+private opaque evalCertificateCore (e : Expr) :
+    MetaM (Except String Hex.ZPolyIrreducibilityCertificate)
 
 /-- Evaluate a closed `Hex.ZPolyIrreducibilityCertificate` expression to its
 runtime value at elaboration time. Used by the reification round-trip tests. -/
 def evalCertificate (e : Expr) : MetaM Hex.ZPolyIrreducibilityCertificate := do
-  let some cert ← evalCertificateOpt e
-    | throwError "irreducible_cert: failed to evaluate the certificate\
-        {indentExpr e}"
-  return cert
+  match ← evalCertificateCore e with
+  | .ok cert => return cert
+  | .error msg =>
+      throwError "irreducible_cert: failed to evaluate the certificate\
+          {indentExpr e}\n{msg}"
 
 /--
 Match a goal of the form `Irreducible (HexPolyZMathlib.toPolynomial f)`
@@ -125,7 +134,9 @@ elab "irreducible_cert" : tactic => do
       fE certE CertReify.reflTrue CertReify.reflTrue CertReify.reflTrue
       CertReify.reflTrue
     unless ← isDefEq (← inferType proof) tgt do
-      throwError "irreducible_cert: internal error: proof type mismatch"
+      throwError "irreducible_cert: the certified statement\
+          {indentExpr (← inferType proof)}\
+          \nis not definitionally equal to the goal{indentExpr tgt}"
     goal.assign proof
   Elab.Tactic.replaceMainGoal []
 

--- a/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekampZassenhausMathlib.IrreducibleCert
+
+/-!
+End-to-end tests for certificate reification and the `irreducible_cert`
+tactic, on the generator guard polynomials from the compiled-generator PR
+(#8552 Part 1): two monic quadratics, a linear polynomial (empty certificate),
+and the inert-prime cubic `x³ - x - 1`.
+
+The round-trip tests reify each generated certificate, typecheck the resulting
+`Expr`, evaluate it back to a value, and compare it field-by-field with the
+original through the canonical `certificateData` serialization.
+-/
+
+namespace HexBerlekampZassenhausMathlib.IrreducibleCertTest
+
+open Lean
+
+/-- `x² + 2`, irreducible with inert prime 3. -/
+def quadTwo : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[2, 0, 1]
+
+/-- `x² + x + 1`, irreducible with inert prime 5. -/
+def quadOmega : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[1, 1, 1]
+
+/-- `x + 3`, irreducible of degree 1 (empty certificate: no candidate factor
+degrees to obstruct). -/
+def linearThree : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[3, 1]
+
+/-- `x³ - x - 1`, irreducible with inert prime 3: the single inert block
+obstructs every proper factor degree at once. -/
+def cubicInert : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-1, -1, 0, 1]
+
+/-- Reify the generated certificate, typecheck it, evaluate it back, and
+compare with the original; also confirm the evaluated copy still passes the
+kernel checker's compiled form. -/
+private def roundTrips (f : Hex.ZPoly) : MetaM Bool := do
+  match Hex.certifyIrreducible? f with
+  | none => return false
+  | some cert => do
+      let certE := CertReify.reifyCertificate cert
+      Meta.check certE
+      let cert' ← IrreducibleCert.evalCertificate certE
+      return CertReify.certificateData cert == CertReify.certificateData cert'
+        && Hex.checkIrreducibleCertLinear f cert'
+
+run_meta do
+  for (name, f) in [("quadTwo", quadTwo), ("quadOmega", quadOmega),
+      ("linearThree", linearThree), ("cubicInert", cubicInert)] do
+    unless (← roundTrips f) do
+      throwError "certificate reification round-trip failed for {name}"
+
+/-! ### The tactic, end to end -/
+
+example : Irreducible (HexPolyZMathlib.toPolynomial quadTwo) := by
+  irreducible_cert
+
+example : Irreducible (HexPolyZMathlib.toPolynomial quadOmega) := by
+  irreducible_cert
+
+example : Irreducible (HexPolyZMathlib.toPolynomial linearThree) := by
+  irreducible_cert
+
+theorem cubicInert_irreducible :
+    Irreducible (HexPolyZMathlib.toPolynomial cubicInert) := by
+  irreducible_cert
+
+/--
+info: 'HexBerlekampZassenhausMathlib.IrreducibleCertTest.cubicInert_irreducible' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound]
+-/
+#guard_msgs in
+#print axioms cubicInert_irreducible
+
+/-! ### Clean failure on generator-declined inputs -/
+
+/-- `x² - 1`, reducible: the generator declines and the tactic fails with a
+diagnostic instead of handing the kernel a bogus certificate. -/
+def reducibleQuad : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-1, 0, 1]
+
+/--
+error: irreducible_cert: certifyIrreducible? produced no certificate for
+  reducibleQuad
+The polynomial is reducible, non-primitive, or constant, or it is irreducible but its modular factorizations are balanced at every admissible prime (e.g. Swinnerton-Dyer polynomials), which the per-prime degree-sum obstruction language cannot certify.
+-/
+#guard_msgs in
+example : Irreducible (HexPolyZMathlib.toPolynomial reducibleQuad) := by
+  irreducible_cert
+
+end HexBerlekampZassenhausMathlib.IrreducibleCertTest

--- a/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
@@ -35,9 +35,9 @@ def linearThree : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[3, 1]
 obstructs every proper factor degree at once. -/
 def cubicInert : Hex.ZPoly := Hex.DensePoly.ofCoeffs #[-1, -1, 0, 1]
 
-/-- Reify the generated certificate, typecheck it, evaluate it back, and
-compare with the original; also confirm the evaluated copy still passes the
-kernel checker's compiled form. -/
+/-- Reify the generated certificate (and the polynomial itself), typecheck
+them, evaluate them back, and compare with the originals; also confirm the
+evaluated copy still passes the kernel checker's compiled form. -/
 private def roundTrips (f : Hex.ZPoly) : MetaM Bool := do
   match Hex.certifyIrreducible? f with
   | none => return false
@@ -45,8 +45,12 @@ private def roundTrips (f : Hex.ZPoly) : MetaM Bool := do
       let certE := CertReify.reifyCertificate cert
       Meta.check certE
       let cert' ← IrreducibleCert.evalCertificate certE
+      let fE ← CertReify.reifyZPoly f
+      Meta.check fE
+      let f' ← IrreducibleCert.evalZPoly fE
       return CertReify.certificateData cert == CertReify.certificateData cert'
-        && Hex.checkIrreducibleCertLinear f cert'
+        && f.toArray == f'.toArray
+        && Hex.checkIrreducibleCertLinear f' cert'
 
 run_meta do
   for (name, f) in [("quadTwo", quadTwo), ("quadOmega", quadOmega),

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -658,12 +658,13 @@ These `#guard`s exercise the *compiled* checker path (executable correctness of
 the generator output). The complementary *kernel* replay — reducing the checker
 on literal certificate data under `decide` — is demonstrated for the
 finite-field layer by `validQuadCert_linear_check` in
-`conformance/HexBerlekamp/Conformance.lean`, which discharges
-`checkIrreducibilityCertificateLinear` on a literal certificate. Replaying the
-integer checker `checkIrreducibleCert` in the kernel on generator output (via
-elaboration-time reification of the certificate as literal data, plus a
-kernel-reducible integer checker) is the `irreducible_cert` tactic deliverable
-tracked as #8566 (Part 2 of #8552). -/
+`conformance/HexBerlekamp/Conformance.lean`, and for the integer checker by
+the `irreducible_cert` tactic (#8566, Part 2 of #8552): the tactic reifies
+generator output as literal data at elaboration time and lets the kernel
+reduce `checkIrreducibleCertLinear`; its end-to-end tests live in
+`HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean`. The `Linear`
+round-trip guards below pin the compiled form of exactly the check the kernel
+replays. -/
 
 /-- The Rabin certificate generator produces a certificate the executable
 checker accepts. -/
@@ -678,6 +679,14 @@ checker accepts. -/
 private def zCertRoundTrips (f : ZPoly) : Bool :=
   match certifyIrreducible? f with
   | some cert => checkIrreducibleCert f cert
+  | none => false
+
+/-- The integer certificate generator's output is accepted by the
+kernel-reducible checker as well; the `irreducible_cert` tactic replays
+exactly this check in the kernel. -/
+private def zCertRoundTripsLinear (f : ZPoly) : Bool :=
+  match certifyIrreducible? f with
+  | some cert => checkIrreducibleCertLinear f cert
   | none => false
 
 -- Rabin generator: irreducible monic `x² + 2` over `F₅` round-trips; the unit
@@ -712,6 +721,13 @@ private def zCertRoundTrips (f : ZPoly) : Bool :=
 -- modulo `3`): the single inert block obstructs every proper factor degree at
 -- once, so the generator scales past quadratics whenever a suitable prime exists.
 #guard zCertRoundTrips (zpoly #[-1, -1, 0, 1])
+
+-- The kernel-reducible checker accepts the same generator outputs (compiled
+-- form of the `irreducible_cert` kernel replay).
+#guard zCertRoundTripsLinear (zpoly #[2, 0, 1])
+#guard zCertRoundTripsLinear (zpoly #[1, 1, 1])
+#guard zCertRoundTripsLinear (zpoly #[3, 1])
+#guard zCertRoundTripsLinear (zpoly #[-1, -1, 0, 1])
 
 -- Design limitation, NOT a generator bug: the checker's per-prime degree-sum
 -- obstruction (`checkDegreeObstructions`) must rule out *every* candidate degree

--- a/progress/20260703T215746Z_issue-8566-irreducible-cert.md
+++ b/progress/20260703T215746Z_issue-8566-irreducible-cert.md
@@ -1,0 +1,70 @@
+# Issue #8566: irreducible_cert tactic (Part 2 of #8552)
+
+## Accomplished
+
+All of deliverables 1-3 on branch `issue-8566` (rebased onto main after
+Part 1 PR #8565 merged mid-session):
+
+1. `9d0b557e` — kernel-reducible integer checker. `checkCertAtFactorLinear` /
+   `checkFactorCertsLinear` / `checkForPolynomialLinear` /
+   `checkIrreducibleCertLinear` (`HexBerlekampZassenhaus/Basic.lean`) replay
+   nested Rabin certificates through
+   `Berlekamp.checkIrreducibilityCertificateLinearIncremental` (O(n·p) kernel
+   work per factor). Implication chain back to the committed checker:
+   `checkIrreducibilityCertificate_of_linearIncremental`
+   (`HexBerlekamp/Irreducibility.lean`, from
+   `checkPowChainLinearIncremental_spec`) and `checkIrreducibleCert_of_linear`
+   (per-prime `Hex.Nat.Prime` hypothesis), so `checkIrreducibleCert_sound` is
+   consumed unchanged.
+2. `a273f783` — Mathlib wrappers (`HexBerlekampZassenhausMathlib/Basic.lean`):
+   `checkIrreducibleCertLinear_sound` (∀-form primality) and
+   `irreducible_of_checkIrreducibleCertLinear` with all four hypotheses as
+   `Bool = true` slots — the tactic fills each with `Eq.refl true` and the
+   kernel does all verification by reduction.
+3. `811bc880` — `CertReify.lean` (pure `HexX → Expr` reifier via public
+   constructors: `ZMod64.ofNat`, `FpPoly.ofCoeffs`, `boundsOfDecide` for
+   instance fields; canonical serializations for comparison),
+   `IrreducibleCert.lean` (the tactic: unsafe-eval of `certifyIrreducible?`,
+   reify, emit; opaque/implemented_by eval helpers), and
+   `IrreducibleCertTest.lean` (round-trip tests reify→check→eval-back→compare;
+   end-to-end examples on the four Part 1 guard polynomials; axiom cone pinned
+   to `[propext, Classical.choice, Quot.sound]` via `#guard_msgs`; clean
+   failure message pinned on a reducible input).
+4. `1961485f` — conformance `#guard`s for `checkIrreducibleCertLinear`
+   round-trips (compiled form of the kernel replay).
+
+## Key findings
+
+- Array.all / Array.foldl / `decide (Nat.Prime p)` (Mathlib's
+  `Nat.decidablePrime`) all kernel-reduce on this toolchain — spiked before
+  building (`/tmp/kernel_spike.lean` pattern, `decide +kernel`).
+- `lake env lean` scratch files can NOT run the tactic (no `--load-dynlib` for
+  the `Hex.ZMod64.mul` extern); tactic examples must live in lake-built
+  modules. Editor sessions and CI are fine.
+- `of_decide_eq_true h` with an expected *defined* Prop (e.g. `Primitive f`)
+  makes the elaborator synthesize `Decidable` for the defined form; bind the
+  underlying equation with `have` first.
+- Incremental (not plain Linear) pow-chain replay chosen analytically:
+  O(n·p) vs O(Σ p^k); the empirical Linear-vs-Incremental comparison is
+  deferred to the deliverable-4 sweep.
+
+## Current frontier / Next step
+
+Deliverable 4 (kernel_factor_sweep.py certifying series) depends on the
+unmerged `kernel-decide-series` branch (2 commits: the sweep harness +
+frontier record). Per the issue's own dependency note, scoped as a follow-up
+commit on that branch — file a follow-up issue at PR time.
+
+Second opinion (Codex): no soundness or checker-correctness issues found;
+addressed its two actionable findings (exception-catching Except-based
+evalExpr wrappers with the underlying evaluator message surfaced in the
+tactic error, and a real diagnostic on the final defeq mismatch instead of
+"internal error"). Kept IrreducibleCertTest in the umbrella deliberately:
+that is what makes the end-to-end tests CI-gated; this repo has no separate
+test target for Mathlib layers.
+
+Remaining: open PR closing #8566, follow-up issue for deliverable 4.
+
+## Blockers
+
+None.

--- a/progress/20260703T220350Z_issue-8566-review.md
+++ b/progress/20260703T220350Z_issue-8566-review.md
@@ -1,0 +1,34 @@
+# Issue #8566 review
+
+## Accomplished
+
+Reviewed the branch implementation of the `irreducible_cert` tactic and
+kernel-reducible certificate checker against `origin/main`.
+
+Checked the soundness path from `checkIrreducibleCertLinear` through
+`checkIrreducibleCert_of_linear` and the existing
+`checkIrreducibleCert_sound` theorem, the certificate and polynomial reifier,
+and the tactic proof emission using `Eq.refl true` Boolean slots.
+
+Ran:
+
+```bash
+lake build HexBerlekampZassenhausMathlib.IrreducibleCertTest
+```
+
+The target built successfully.
+
+## Current frontier
+
+No implementation changes were made. Review findings are limited to
+maintainability and error-path robustness; no soundness or checker-correctness
+issue was found.
+
+## Next step
+
+Consider moving `IrreducibleCertTest` out of the public root import path and
+tightening the tactic's evaluation error handling.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds the `irreducible_cert` tactic: kernel-checked certifying irreducibility for integer polynomials, the consume half of the certificate architecture whose compiled generators landed in [PR #8565: feat(bz): compiled irreducibility-certificate generators](https://github.com/kim-em/hex-dev/pull/8565). For a goal `Irreducible (HexPolyZMathlib.toPolynomial f)` with `f` a closed `Hex.ZPoly` term, the tactic evaluates `Hex.certifyIrreducible? f` in compiled code at elaboration time, reifies the resulting certificate as a literal `Expr` built from public constructor functions (`ZMod64.ofNat`, `FpPoly.ofCoeffs`, `boundsOfDecide` for the instance fields; new module `HexBerlekampZassenhausMathlib/CertReify.lean`), and closes the goal with `irreducible_of_checkIrreducibleCertLinear`, filling all four Boolean hypothesis slots with `Eq.refl true` so the kernel verifies everything by reduction on literal data. The only kernel work is the new `checkIrreducibleCertLinear` (which replays each nested Rabin certificate through `Berlekamp.checkIrreducibilityCertificateLinearIncremental`, `O(n·p)` per modular factor instead of `O(Σ p^k)`) plus the three cheap side checks (primality of the recorded primes, `content f = 1`, positive degree). The implication chain `checkIrreducibleCertLinear → checkIrreducibleCert` (via the new `checkIrreducibilityCertificate_of_linearIncremental` and per-prime primality) means the existing `checkIrreducibleCert_sound` is consumed unchanged. The incremental pow-chain comparison is chosen over the plain Linear one on the analytic `O(n·p)` vs `O(Σ p^k)` argument; the empirical comparison is deferred to the sweep issue below.

End-to-end tests (`HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean`, imported by the umbrella so they are CI-gated) exercise the Part 1 guard polynomials: `x² + 2`, `x² + x + 1`, `x + 3` (empty certificate), and the inert-prime cubic `x³ - x - 1`, all proved by `by irreducible_cert`; reification round-trips (reify, typecheck, evaluate back, compare canonical serializations, re-check); the axiom cone pinned to `[propext, Classical.choice, Quot.sound]` via `#guard_msgs in #print axioms`; and the pinned clean-failure message on a reducible input. Conformance gains `#guard`s for the compiled form of exactly the check the kernel replays. Note the tactic requires the precompiled FFI dylibs that lake-built modules load; it does not run in bare `lake env lean` scratch files.

Deliverable 4 of the issue (the `kernel_factor_sweep.py` certifying series) depends on the unmerged `kernel-decide-series` branch and is split out per the issue's own dependency note as [issue #8569: bench(bz): certifying series for kernel_factor_sweep.py, measure irreducible_cert against the kernel-factor curve](https://github.com/kim-em/hex-dev/issues/8569).

A second opinion (Codex) found no soundness or checker-correctness issues; its error-path findings (exception handling around the unsafe `evalExpr` wrappers, a real diagnostic on the final defeq mismatch) are addressed in the last commit.

Closes #8566.

🤖 Prepared with Claude Code
