### PR TITLE
doc: TODO to drop dotProduct csimp split once lean4#14267 lands

### DIFF
--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -42,7 +42,15 @@ This `List.finRange` form is the reference definition the entry lemmas reason
 about; crucially it kernel-reduces, so `#guard`/`decide` checks over
 `dotProduct` (e.g. `memLattice` membership) stay evaluable — core `Fin.foldl`
 does not reduce in the kernel. Compiled code runs the allocation-free
-`Fin.foldl` loop `dotProductImpl` via the `@[csimp]` below. -/
+`Fin.foldl` loop `dotProductImpl` via the `@[csimp]` below.
+
+TODO: once https://github.com/leanprover/lean4/pull/14267 (make `Fin.foldl`
+structurally recursive so it reduces in the kernel) lands and this project's
+toolchain is bumped past it, collapse this reference/compiled split: define
+`dotProduct` directly as the native `Fin.foldl` loop and delete `dotProductImpl`
+and `dotProduct_eq_impl`. The native form will then kernel-reduce on its own, so
+the `memLattice` `decide` checks keep working without the `List.finRange`
+reference allocation. -/
 @[expose]
 def dotProduct [Mul R] [Add R] [OfNat R 0] (u v : Vector R n) : R :=
   (List.finRange n).foldl (fun acc i => acc + u[i] * v[i]) 0

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -45,8 +45,8 @@ does not reduce in the kernel. Compiled code runs the allocation-free
 `Fin.foldl` loop `dotProductImpl` via the `@[csimp]` below.
 
 TODO: once https://github.com/leanprover/lean4/pull/14267 (make `Fin.foldl`
-structurally recursive so it reduces in the kernel) lands and this project's
-toolchain is bumped past it, collapse this reference/compiled split: define
+reduce in the kernel) lands and this project's toolchain is bumped past it,
+collapse this reference/compiled split: define
 `dotProduct` directly as the native `Fin.foldl` loop and delete `dotProductImpl`
 and `dotProduct_eq_impl`. The native form will then kernel-reduce on its own, so
 the `memLattice` `decide` checks keep working without the `List.finRange`


### PR DESCRIPTION
This PR adds a TODO note at the `Vector.dotProduct` call site in `HexMatrix/Basic.lean` recording that its `List.finRange` reference form plus `Fin.foldl` `dotProductImpl` plus `@[csimp]` split exists solely because core `Fin.foldl` does not currently reduce in the kernel, which the `memLattice` `decide` checks depend on. Once [leanprover/lean4#14267 (feat: make Fin.foldl reduce in the kernel)](https://github.com/leanprover/lean4/pull/14267) lands and this project's toolchain is bumped past it, the split can be collapsed: define `dotProduct` directly as the native `Fin.foldl` loop and delete `dotProductImpl` and `dotProduct_eq_impl`, since the native form will kernel-reduce on its own.

🤖 Prepared with Claude Code