### PR TITLE
refactor: rename confusing Unchecked/_unconditional API in HexLLL

### DIFF
--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -5359,7 +5359,7 @@ structure BhksProjectedRowsTrace (L : BhksLatticeBasis) where
 def bhksProjectedRowsTrace (L : BhksLatticeBasis)
     (hrows : 1 ≤ L.factorCount + L.coeffWidth) : BhksProjectedRowsTrace L :=
   let reducedRows :=
-    lll.shortVectorsUnchecked L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows
+    lllNative.shortVectors L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows
   let reducedMatrix :=
     bhksRowsArrayToMatrix (L.factorCount + L.coeffWidth) reducedRows
   let retainedIndices := bhksRetainedRowIndices L reducedMatrix
@@ -5374,7 +5374,7 @@ theorem bhksProjectedRowsTrace_reducedMatrix_eq
     (L : BhksLatticeBasis) (hrows : 1 ≤ L.factorCount + L.coeffWidth) :
     (bhksProjectedRowsTrace L hrows).reducedMatrix =
       lllNative L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows := by
-  simp [bhksProjectedRowsTrace, lll.shortVectorsUnchecked, bhksRowsArrayToMatrix_toArray]
+  simp [bhksProjectedRowsTrace, lllNative.shortVectors, bhksRowsArrayToMatrix_toArray]
 
 /--
 Run LLL on a BHKS row-basis lattice, discard rows whose Gram-Schmidt squared
@@ -5388,7 +5388,7 @@ equivalence-class recovery stage.
 def bhksProjectedRows (L : BhksLatticeBasis)
     (hrows : 1 ≤ L.factorCount + L.coeffWidth) : BhksProjectedRows :=
   let reducedRows :=
-    lll.shortVectorsUnchecked L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows
+    lllNative.shortVectors L.basis (3 / 4) lll_delta_lower lll_delta_upper hrows
   let reducedBasis :=
     bhksRowsArrayToMatrix (L.factorCount + L.coeffWidth) reducedRows
   { factorCount := L.factorCount

--- a/HexBerlekampZassenhausMathlib/Lattice.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice.lean
@@ -30,7 +30,7 @@ namespace BHKS
 /--
 The reduced matrix stored in the BHKS projected-row trace generates the same
 integer row lattice as the original BHKS basis.  This carries
-`lll.shortVectorsUnchecked`'s `.toArray` output back to the certified LLL
+`lllNative.shortVectors`'s `.toArray` output back to the certified LLL
 lattice-preservation theorem `Hex.lllNative_memLattice_iff`.
 -/
 theorem traceReducedMatrix_memLattice_iff

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -159,7 +159,7 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
 The van Hoeij knapsack basis `[I_r | Ã ; 0 | diag(p^(a-l_j))]` is upper-triangular
 with strictly positive diagonal (1's in the `I_r` block, `p^(a-l_j)` in the
 `D` block), so its rows are LLL-independent.  This is the entry gate to the
-proven LLL short-vector bound `HexLLLMathlib.lllNative_first_row_norm_sq_le_unconditional`.
+proven LLL short-vector bound `HexLLLMathlib.lllNative_first_row_norm_sq_le`.
 -/
 
 /-- The BHKS knapsack lattice basis is upper-triangular: below-diagonal entries
@@ -219,7 +219,7 @@ theorem bhksLatticeBasis_basis_independent
 lattice is a short vector: its squared Euclidean norm is bounded by the LLL
 approximation factor `(1/(δ-1/4))^(n-1)` (at `δ = 3/4`) times the squared norm
 of *any* nonzero lattice vector.  This is the direct application of the proven
-`HexLLLMathlib.lllNative_first_row_norm_sq_le_unconditional` to the BHKS basis,
+`HexLLLMathlib.lllNative_first_row_norm_sq_le` to the BHKS basis,
 using `bhksLatticeBasis_basis_independent`.  It is the concrete "the LLL-reduced
 basis contains a short vector" fact that the van Hoeij adequacy argument feeds:
 the true-factor `0-1` indicator vectors are short lattice vectors, so the reduced
@@ -241,7 +241,7 @@ theorem bhksLatticeBasis_lllNative_first_row_short
           (((Hex.bhksLatticeBasis f p a lifted).factorCount
             + (Hex.bhksLatticeBasis f p a lifted).coeffWidth) - 1) : Rat) : ℝ) *
         ‖HexLLLMathlib.intVectorToEuclidean x‖ ^ 2 :=
-  HexLLLMathlib.lllNative_first_row_norm_sq_le_unconditional
+  HexLLLMathlib.lllNative_first_row_norm_sq_le
     (Hex.bhksLatticeBasis f p a lifted).basis (3 / 4)
     Hex.lll_delta_lower Hex.lll_delta_upper hn
     (bhksLatticeBasis_basis_independent f p a hp lifted) x hx hx0

--- a/HexLLL/Dispatch.lean
+++ b/HexLLL/Dispatch.lean
@@ -67,17 +67,19 @@ side-effect-free apart from the one-shot static-symbol probe it may trigger. -/
 def lll.providerActive : IO Bool :=
   return Internal.LLLProvider.providerAvailable ()
 
-/-- Proof-free executable variant of `lll.firstShortVector`. Runs the exact
-`lllNative` reducer directly. -/
+/-- First row of `lllNative`'s output: the `lll.firstShortVector` counterpart on
+the exact native path. It never consults an external provider and takes no
+`b.independent` hypothesis, so Mathlib-free callers can use it directly; its
+short-vector guarantee is `lllNative_first_row_norm_sq_le` at `η = 1/2`. -/
 @[expose]
-def lll.firstShortVectorUnchecked (b : Matrix Int n m) (δ : Rat)
+def lllNative.firstShortVector (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Vector Int m :=
   (lllNative b δ hδ hδ' hn).getRow ⟨0, hn⟩
 
 /-- The first row of the reduced basis: a provably short vector, bounded by the
 LLL approximation factor relative to any nonzero lattice vector (see
-`lll_first_row_norm_sq_le_unconditional`), not necessarily the shortest lattice
+`lll_first_row_norm_sq_le`), not necessarily the shortest lattice
 vector. Canonical short-vector entry point for downstream callers such as
 `hex-berlekamp-zassenhaus` recombination. -/
 @[expose]
@@ -87,10 +89,11 @@ def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
     Vector Int m :=
   (lll b δ hδ hδ' hn hind).getRow ⟨0, hn⟩
 
-/-- Proof-free executable variant of `lll.shortVectors`. Runs the exact
-`lllNative` reducer directly. -/
+/-- Full `lllNative` output as an ordered array of candidate short vectors: the
+`lll.shortVectors` counterpart on the exact native path, forgoing the external
+provider and the `b.independent` hypothesis. -/
 @[expose]
-def lll.shortVectorsUnchecked (b : Matrix Int n m) (δ : Rat)
+def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Array (Vector Int m) :=
   (lllNative b δ hδ hδ' hn).rows.toArray

--- a/HexLLL/Native.lean
+++ b/HexLLL/Native.lean
@@ -430,23 +430,22 @@ theorem potential_eq_gramDetProduct (s : LLLState n m) (hvalid : s.Valid) :
         1 := by
   simp [potential, hvalid.d_eq]
 
-/-- Proof-free executable `LLLState` constructor. Mathlib-free callers that
-only need executable output (benchmarks, fixture emitters, BHKS projected-row
-computation) can use this directly without manufacturing a `b.independent`
-proof. The proof-carrying `ofBasis` is a thin wrapper. -/
+/-- Initial `LLLState` constructor: build the integer state directly from a
+basis matrix. The `ν` field is the integral scaled Gram-Schmidt coefficient
+matrix and the `d` field is the leading Gram-determinant vector.
+
+Takes no independence hypothesis: the construction is purely executable, and the
+resulting state is even `Valid` unconditionally (see
+`HexLLLMathlib.LLLState.ofBasis_valid`). `b.independent` enters only in the
+theorems about the reducer's *output* (`lllNative_isLLLReduced` and the
+short-vector bounds), never in building the state. Mathlib-free callers
+(benchmarks, fixture emitters, BHKS projected-row computation) use it directly. -/
 @[expose]
-def ofBasisUnchecked (b : Matrix Int n m) : LLLState n m :=
+def ofBasis (b : Matrix Int n m) : LLLState n m :=
   let gs := GramSchmidt.Int.data b
   { b
     ν := gs.ν
     d := gs.d }
-
-/-- Initial `LLLState` constructor: build the integer state directly from a
-basis matrix. The `ν` field is the integral scaled Gram-Schmidt coefficient
-matrix and the `d` field is the leading Gram-determinant vector. -/
-@[expose]
-def ofBasis (b : Matrix Int n m) (_hind : b.independent) : LLLState n m :=
-  ofBasisUnchecked b
 
 end LLLState
 
@@ -549,7 +548,7 @@ end Internal
 open Hex.Internal
 
 /-- Native (non-dispatched) executable LLL entry point. Builds the canonical
-integer state via `LLLState.ofBasisUnchecked` and dispatches to `lllAux`.
+integer state via `LLLState.ofBasis` and dispatches to `lllAux`.
 This is the body the public `lll` runs by default; its output achieves the
 classical size-reduction bound `|μ| ≤ 1/2` (η = 1/2), so its short-vector
 guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`. -/
@@ -557,7 +556,7 @@ guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`.
 def lllNative (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
     Matrix Int n m :=
-  lllAux (LLLState.ofBasisUnchecked b) 1 δ hδ hδ' (Nat.le_refl 1) hn
+  lllAux (LLLState.ofBasis b) 1 δ hδ hδ' (Nat.le_refl 1) hn
 
 namespace Internal
 

--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -52,7 +52,7 @@ def B : Matrix Int 3 3 := Matrix.ofFn fun i j =>
 -- The verified entry point. Given a proof `hind : B.independent`, `lll` returns
 -- a `(δ, 11/20)`-reduced basis of the same lattice and `lll.firstShortVector`
 -- reads off its provably short first row. The short-vector guarantee itself is
--- the theorem `lll_first_row_norm_sq_le_unconditional` in `hex-lll-mathlib`.
+-- the theorem `lll_first_row_norm_sq_le` in `hex-lll-mathlib`.
 #check @lll.firstShortVector
 #check @lll
 
@@ -60,8 +60,8 @@ def B : Matrix Int 3 3 := Matrix.ofFn fun i j =>
 -- proof-free variants. They run the exact `lllNative` directly (the body of
 -- `lll`'s native path, skipping the provider dispatch) and carry no exported
 -- short-vector theorem unless you separately prove `B.independent`.
-#eval lll.firstShortVectorUnchecked B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
-#eval lll.shortVectorsUnchecked B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
+#eval lllNative.firstShortVector B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
+#eval lllNative.shortVectors B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
 
 -- The executable integer reducedness oracle.
 #eval lllReducedInt (Matrix.identity 3) (3 / 4) (1 / 2)   -- true
@@ -96,7 +96,7 @@ The surface, by group:
 - `lllNative`: the exact integer reducer at the classical `η = 1/2`, with the
   tighter short-vector constant; call it directly to get the classical
   guarantee.
-- `lll.firstShortVectorUnchecked` and `lll.shortVectorsUnchecked`: proof-free
+- `lllNative.firstShortVector` and `lllNative.shortVectors`: proof-free
   variants of the entry points for callers without an independence proof.
 - `lllReducedInt`, `lllReducedInterval`, and `lllReducedCheck`: the exact,
   fixed-precision, and dispatched reducedness oracles; `certCheck` is the

--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -100,7 +100,7 @@ theorem lllNative_short_vector (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hli : b.independent)
     (v : Vector Int m) :
     b.memLattice v → v ≠ 0 →
-    (lllNative b δ hδ hδ' hn hli).row 0 |>.normSq ≤ (1/(δ - 1/4))^(n-1) * v.normSq
+    (lllNative b δ hδ hδ' hn).row 0 |>.normSq ≤ (1/(δ - 1/4))^(n-1) * v.normSq
 ```
 
 The classical bound and the wide `δ > 1/4` range live on `lllNative`: at
@@ -240,7 +240,7 @@ def lllAux (s : LLLState n m) (k : Nat) (δ : Rat)
     `hex-gram-schmidt` lemmas `GramSchmidt.Int.gramDetVec_eq_gramDet`
     and `GramSchmidt.Int.scaledCoeffs_eq` (suitably massaged through the
     `Rat` casts in their statements). -/
-def LLLState.ofBasis (b : Matrix Int n m) (hind : b.independent) :
+def LLLState.ofBasis (b : Matrix Int n m) :
     LLLState n m :=
   { b
     ν := GramSchmidt.Int.scaledCoeffs b
@@ -250,7 +250,7 @@ def LLLState.ofBasis (b : Matrix Int n m) (hind : b.independent) :
 
 def lll (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) : Matrix Int n m :=
-  lllAux (LLLState.ofBasis b hind) 1 δ hδ hδ' (by omega) (by omega)
+  lllAux (LLLState.ofBasis b) 1 δ hδ hδ' (by omega) (by omega)
 ```
 
 The `ν_eq` and `d_eq` fields are discharged from the `hex-gram-schmidt`

--- a/HexLLLMathlib/README.md
+++ b/HexLLLMathlib/README.md
@@ -32,7 +32,7 @@ import HexLLLMathlib
 open HexLLLMathlib
 
 -- The headline: the reduced first row is short relative to any lattice vector.
-#check @lll_first_row_norm_sq_le_unconditional
+#check @lll_first_row_norm_sq_le
 
 -- The executable row lattice as a Mathlib `Submodule ℤ`, and `Hex.lll`
 -- preserving it.
@@ -52,7 +52,7 @@ of `Hex.lll b δ …` has squared Euclidean norm at most
 `(1 / (δ − 121/400))^(n−1)` times that of `x`:
 
 ```lean
-theorem lll_first_row_norm_sq_le_unconditional
+theorem lll_first_row_norm_sq_le
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)
@@ -78,7 +78,7 @@ the native and certified-external paths establish the same `(δ, 11/20)`-reduced
 and same-lattice post-condition the bound consumes. The native entry
 `Hex.lllNative` carries the stronger classical statement at the tighter base
 `1/(δ − 1/4)` (length factor `(1 / (δ − 1/4))^((n−1)/2)`, the classical LLL
-bound) in `lllNative_first_row_norm_sq_le_unconditional`.
+bound) in `lllNative_first_row_norm_sq_le`.
 
 **Lattice preservation.** `Hex.lll` and `Hex.lllNative` leave the generated
 submodule unchanged:
@@ -107,8 +107,8 @@ algebra:
   squared norm. Together with `HexMatrixMathlib.vectorEquiv` (the bijection
   `Vector Int m ≃ (Fin m → ℤ)`) these turn the executable rational bound into
   the Euclidean statement above.
-- the short-vector capstones `lll_first_row_norm_sq_le_unconditional` and
-  `lllNative_first_row_norm_sq_le_unconditional`, and the lattice-preservation
+- the short-vector capstones `lll_first_row_norm_sq_le` and
+  `lllNative_first_row_norm_sq_le`, and the lattice-preservation
   transfer lemmas `lll_mem_latticeSubmodule_iff` and
   `lllNative_mem_latticeSubmodule_iff`.
 - the checker soundness theorems `lllReducedInt_sound`,

--- a/HexLLLMathlib/Reducer.lean
+++ b/HexLLLMathlib/Reducer.lean
@@ -1900,7 +1900,7 @@ recursion on a `fuel` argument, with `fuel = 0` returning the current
 basis as a pipeline-unreachable fallback (per SPEC §8).  This section
 proves the fallback unreachable for valid input: the bound
 `lllFuel s = (s.potential + 1) * (n + 1)` is sufficient for the loop
-started at `k = 1` on `s = ofBasis b hind`.
+started at `k = 1` on `s = ofBasis b`.
 
 The argument tracks the lexicographic measure
 `s.potential * (n + 1) + (n - k)`:
@@ -2371,12 +2371,12 @@ induction (`lllLoop_isLLLReduced_of_fuel_gt_measure`). -/
 theorem lllNative_isLLLReduced (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
     isLLLReduced (lllNative b δ hδ hδ' hn) δ (1 / 2) := by
-  show isLLLReduced (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))) δ (1 / 2)
-  set s := LLLState.ofBasisUnchecked b with hs_def
+  show isLLLReduced (lllLoop (LLLState.ofBasis b) 1 δ hδ hδ'
+    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasis b))) δ (1 / 2)
+  set s := LLLState.ofBasis b with hs_def
   have hs_valid : s.Valid := by
-    show (LLLState.ofBasis b hind).Valid
-    exact HexLLLMathlib.LLLState.ofBasis_valid b hind
+    show (LLLState.ofBasis b).Valid
+    exact HexLLLMathlib.LLLState.ofBasis_valid b
   have hs_ind : s.b.independent := hind
   have hs_pre : prefixLLLReduced s.b 1 δ := prefixLLLReduced_one s.b δ
   apply LLLState.lllLoop_isLLLReduced_of_fuel_gt_measure δ hδ hδ' (lllFuel s) s 1
@@ -2390,19 +2390,18 @@ theorem lllNative_memLattice_iff (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (v : Vector Int m) :
     Matrix.memLattice (lllNative b δ hδ hδ' hn) v ↔ Matrix.memLattice b v := by
-  show Matrix.memLattice (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))) v ↔ _
+  show Matrix.memLattice (lllLoop (LLLState.ofBasis b) 1 δ hδ hδ'
+    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasis b))) v ↔ _
   exact lllLoop_memLattice_iff _ 1 δ hδ hδ' (Nat.le_refl 1) hn _ v
 
 /-- Independence is preserved by `Hex.lllNative`. -/
 theorem lllNative_independent (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
     (lllNative b δ hδ hδ' hn).independent := by
-  have hs_valid : (LLLState.ofBasisUnchecked b).Valid := by
-    show (LLLState.ofBasis b hind).Valid
-    exact HexLLLMathlib.LLLState.ofBasis_valid b hind
-  show (lllLoop (LLLState.ofBasisUnchecked b) 1 δ hδ hδ'
-    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasisUnchecked b))).independent
+  have hs_valid : (LLLState.ofBasis b).Valid :=
+    HexLLLMathlib.LLLState.ofBasis_valid b
+  show (lllLoop (LLLState.ofBasis b) 1 δ hδ hδ'
+    (Nat.le_refl 1) hn (lllFuel (LLLState.ofBasis b))).independent
   exact LLLState.lllLoop_independent δ hδ hδ' _ _ 1
     (Nat.le_refl 1) hn hs_valid hind
 

--- a/HexLLLMathlib/SPEC/hex-lll-mathlib.md
+++ b/HexLLLMathlib/SPEC/hex-lll-mathlib.md
@@ -6,7 +6,7 @@ Connects hex-lll to Mathlib's linear algebra:
 
 ## Headline correctness theorem
 
-`lll_first_row_norm_sq_le_unconditional`: the Euclidean short-vector bound for
+`lll_first_row_norm_sq_le`: the Euclidean short-vector bound for
 the public `lll`, stated with Mathlib's `EuclideanSpace` norm and `Submodule ℤ`
 membership. For any nonzero lattice vector `x`,
 

--- a/HexLLLMathlib/ShortVector.lean
+++ b/HexLLLMathlib/ShortVector.lean
@@ -13,10 +13,12 @@ public import HexLLL.Basic
 public section
 
 /-!
-The headline Mathlib capstones: the unconditional Euclidean short-vector
-bounds `lll_first_row_norm_sq_le_unconditional` (at `η = 11/20`) and
-`lllNative_first_row_norm_sq_le_unconditional` (classical `η = 1/2`), and the
-submodule lattice-preservation transfers `lll_mem_latticeSubmodule_iff` and
+The headline Mathlib capstones: the Euclidean short-vector bounds on the
+algorithm outputs, `lll_first_row_norm_sq_le` (at `η = 11/20`) and
+`lllNative_first_row_norm_sq_le` (classical `η = 1/2`). Unlike the conditional
+`reduced_first_row_norm_sq_le`, these discharge the `isLLLReduced` hypothesis
+internally, so they apply directly to `Hex.lll` / `Hex.lllNative`. Also here are
+the submodule lattice-preservation transfers `lll_mem_latticeSubmodule_iff` and
 `lllNative_mem_latticeSubmodule_iff`.
 -/
 
@@ -55,7 +57,7 @@ theorem lll_mem_latticeSubmodule_iff
 `η = 1/2`. Combines `Hex.lllNative_isLLLReduced` with the conditional
 Euclidean bound `reduced_first_row_norm_sq_le` at
 `η = 1/2`. -/
-theorem lllNative_first_row_norm_sq_le_unconditional
+theorem lllNative_first_row_norm_sq_le
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (1 : Rat) / 4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)
@@ -79,11 +81,11 @@ theorem lllNative_first_row_norm_sq_le_unconditional
   rw [hηη] at hbnd
   exact hbnd
 
-/-- **Unconditional Mathlib-Euclidean LLL short-vector bound on `Hex.lll` at
-`η = 11/20`.** Combines `Hex.lll_isLLLReduced` (η = 11/20) with the
-conditional Euclidean bound `reduced_first_row_norm_sq_le`
-at `η = 11/20`. -/
-theorem lll_first_row_norm_sq_le_unconditional
+/-- **Mathlib-Euclidean LLL short-vector bound on `Hex.lll` at `η = 11/20`.**
+Combines `Hex.lll_isLLLReduced` (η = 11/20) with the conditional Euclidean bound
+`reduced_first_row_norm_sq_le` at `η = 11/20`, discharging its `isLLLReduced`
+hypothesis so the bound holds for the raw `Hex.lll` output. -/
+theorem lll_first_row_norm_sq_le
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)

--- a/HexLLLMathlib/State.lean
+++ b/HexLLLMathlib/State.lean
@@ -26,15 +26,15 @@ namespace HexLLLMathlib
 data. Lives on the Mathlib side because the diagonal Gram-determinant
 identification (`gramDetVec_eq_gramDet`) consumes a `StepWitness b`, which is
 supplied by `StepWitness.ofGram`. -/
-theorem LLLState.ofBasis_valid (b : Hex.Matrix Int n m) (hind : b.independent) :
-    (Hex.Internal.LLLState.ofBasis b hind).Valid := by
+theorem LLLState.ofBasis_valid (b : Hex.Matrix Int n m) :
+    (Hex.Internal.LLLState.ofBasis b).Valid := by
   let gs := Hex.GramSchmidt.Int.data b
   constructor
   · intro i j hi hj hji
-    simp [Hex.Internal.LLLState.ofBasis, Hex.Internal.LLLState.ofBasisUnchecked,
+    simp [Hex.Internal.LLLState.ofBasis,
       Hex.GramSchmidt.Int.scaledCoeffs]
   · intro i hi
-    simpa [Hex.Internal.LLLState.ofBasis, Hex.Internal.LLLState.ofBasisUnchecked,
+    simpa [Hex.Internal.LLLState.ofBasis,
       Hex.GramSchmidt.Int.gramDetVec, gs] using
       Hex.GramSchmidt.Int.gramDetVec_eq_gramDet b
         (Hex.GramSchmidt.Int.StepWitness.ofGram b) i (Nat.le_of_lt_succ hi)

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -197,19 +197,20 @@ basis as an ordered candidate list.
 
 {docstring Hex.lll.shortVectors}
 
-Each has an `Unchecked` variant. These call `lllNative` directly, so they
-take the tighter native precondition `1/4 < δ` and skip the provider
-dispatch and its certification. They also omit the `b.independent`
-hypothesis — and this is the key point: independence is a precondition of
-the *theorems* about the output, not of the *computation*. The reducer
-runs on any input; the `Unchecked` variants simply forgo the reduced-basis
-guarantees, so you get the reduced rows back without having to discharge an
-independence proof. That is what makes them convenient for quick
+Each has a counterpart under the {name}`Hex.lllNative` namespace.
+{name}`Hex.lllNative.firstShortVector` and {name}`Hex.lllNative.shortVectors`
+call `lllNative` directly, so they take the tighter native precondition
+`1/4 < δ` and skip the provider dispatch and its certification. They also omit
+the `b.independent` hypothesis — and this is the key point: independence is a
+precondition of the *theorems* about the output, not of the *computation*. The
+reducer runs on any input; the native-namespace variants simply forgo the
+reduced-basis guarantees, so you get the reduced rows back without having to
+discharge an independence proof. That is what makes them convenient for quick
 experimentation.
 
-{docstring Hex.lll.firstShortVectorUnchecked}
+{docstring Hex.lllNative.firstShortVector}
 
-{docstring Hex.lll.shortVectorsUnchecked}
+{docstring Hex.lllNative.shortVectors}
 
 # Certified external dispatch
 %%%

--- a/bench/HexLLLBench/Inputs.lean
+++ b/bench/HexLLLBench/Inputs.lean
@@ -35,7 +35,7 @@ instance : Hashable StateInput where
   hash input :=
     hash (input.rows, input.cols, input.j.val, input.k.val)
 
-/-- Matrix input for benchmarking `LLLState.ofBasisUnchecked` itself. -/
+/-- Matrix input for benchmarking `LLLState.ofBasis` itself. -/
 structure OfBasisInput where
   rows : Nat
   cols : Nat
@@ -48,7 +48,7 @@ instance : Hashable OfBasisInput where
   hash input :=
     hash (input.rows, input.cols, input.j.val, input.k.val)
 
-/-- Prepared basis for `lll.firstShortVectorUnchecked` benchmarks. -/
+/-- Prepared basis for `lllNative.firstShortVector` benchmarks. -/
 structure FirstShortVectorInput where
   rows : Nat
   cols : Nat
@@ -96,7 +96,7 @@ def generatedBasis (rows salt : Nat) : Matrix Int rows rows :=
 
 /-- Build the executable LLL state for a deterministic matrix. -/
 def stateOf (b : Matrix Int n m) : LLLState n m :=
-  LLLState.ofBasisUnchecked b
+  LLLState.ofBasis b
 
 /-- Per-parameter fixture: a prepared `(n + 3) x (n + 3)` LLL state. -/
 def prepStateInput (n : Nat) : StateInput :=
@@ -586,7 +586,7 @@ def ofBasisRandomBoundedBasis (rows salt : Nat) : Matrix Int rows rows :=
 def ofBasisHarshCubicBasis (rows salt : Nat) : Matrix Int rows rows :=
   Matrix.ofFn fun i j => ofBasisHarshCubicEntry rows i.val j.val salt
 
-/-- General constructor for an `LLLState.ofBasisUnchecked` benchmark fixture.
+/-- General constructor for an `LLLState.ofBasis` benchmark fixture.
 The benchmark parameter maps to `rows = n + 3`, so the final two row indices
 are always available for the result checksum. -/
 def prepOfBasisInput (n cols : Nat) (basis : Matrix Int (n + 3) cols) :
@@ -715,7 +715,7 @@ def ofBasisHarshCubicComplexity (n : Nat) : Nat :=
 
 /-- Benchmark target: construct the initial integer LLL state for a basis. -/
 def runOfBasisChecksum (input : OfBasisInput) : Int :=
-  let s := LLLState.ofBasisUnchecked input.basis
+  let s := LLLState.ofBasis input.basis
   stateUpdateChecksum s input.j input.k
 
 /-- Benchmark target for the BZ recombination input family. -/
@@ -779,7 +779,7 @@ private theorem lllCertifiedDeltaLower : (121 / 400 : Rat) < 3 / 4 := by
 /-- Benchmark target: run LLL on one prepared basis and checksum the first row. -/
 def runFirstShortVectorChecksum (input : FirstShortVectorInput) : Int :=
   intVectorChecksum
-    (lll.firstShortVectorUnchecked input.basis (3 / 4)
+    (lllNative.firstShortVector input.basis (3 / 4)
       lllDeltaLower lllDeltaUpper input.hn)
 
 /-- Explicitly install the fpLLL provider for the bench process from the shared
@@ -837,10 +837,10 @@ def runDispatchedFirstShortVectorChecksum (input : FirstShortVectorInput) : IO I
 
 /-- Benchmark comparator observable: squared norm of Lean's first LLL vector.
 The verified-Isabelle Haskell extraction reports the same scalar. Runs the
-exact native path (`lll.firstShortVectorUnchecked`, i.e. `lllNative`). -/
+exact native path (`lllNative.firstShortVector`, i.e. `lllNative`). -/
 def runFirstShortVectorNormSq (input : FirstShortVectorInput) : Int :=
   Vector.normSq
-    (lll.firstShortVectorUnchecked input.basis (3 / 4)
+    (lllNative.firstShortVector input.basis (3 / 4)
       lllDeltaLower lllDeltaUpper input.hn)
 
 /-- Benchmark comparator observable for the exact `d`/`ν` reducer: squared norm

--- a/progress/20260704T024430Z.md
+++ b/progress/20260704T024430Z.md
@@ -1,0 +1,35 @@
+# Rename `Unchecked` / `_unconditional` in HexLLL
+
+**Accomplished**
+- Renamed the confusing `Unchecked` / `_unconditional` API in HexLLL and its
+  Mathlib bridge for reader clarity:
+  - `lll.firstShortVectorUnchecked` / `lll.shortVectorsUnchecked` →
+    `lllNative.firstShortVector` / `lllNative.shortVectors` (reparented under
+    `lllNative`, which they run directly; `Unchecked` wrongly implied a runtime
+    check when the real distinction is bypassing the certified provider dispatch).
+  - `lll_first_row_norm_sq_le_unconditional` /
+    `lllNative_first_row_norm_sq_le_unconditional` → drop the `_unconditional`
+    suffix; the `lll_` / `lllNative_` subject already distinguishes them from the
+    conditional `reduced_first_row_norm_sq_le`.
+  - Merged `LLLState.ofBasisUnchecked` and its thin `ofBasis` wrapper (which took
+    an unused `_hind : b.independent`) into a single hypothesis-free `ofBasis`.
+- Dropped the now-vacuous `hind` from `HexLLLMathlib.LLLState.ofBasis_valid`:
+  `Valid` only asserts the stored `ν`/`d` equal their canonical Gram-Schmidt
+  definitions, which hold for any basis; the proof never used independence.
+- Updated all call sites (BZ recombination, bench inputs), docstrings, READMEs,
+  the HexLLL manual chapter, and the `hex-lll` / `hex-lll-mathlib` SPEC sketches.
+  Historical `progress/` and `reports/` files keep the old names by design.
+
+**Current frontier**
+- Full affected build green: `lake build HexLLL HexLLLMathlib
+  HexBerlekampZassenhaus HexBerlekampZassenhausMathlib HexLLLBenchSupport
+  HexManual` (3770 jobs), no new warnings. Codex second opinion confirmed the
+  renames are clear improvements and dropping `hind` is sound.
+
+**Next step**
+- These are public API of the released `hex-lll` / `hex-lll-mathlib` repos, so a
+  release sync will carry the breaking rename outward; downstream pins in `hex`
+  need the matching bump when synced.
+
+**Blockers**
+- None.


### PR DESCRIPTION
This PR renames the HexLLL and HexLLLMathlib defs and theorems whose `Unchecked` / `_unconditional` suffixes misled readers. `lll.firstShortVectorUnchecked` / `lll.shortVectorsUnchecked` become `lllNative.firstShortVector` / `lllNative.shortVectors`, since they run `lllNative` directly and the old suffix wrongly implied a runtime check when the real distinction is bypassing the certified external-provider dispatch that `lll.*` uses. The short-vector capstones `lll_first_row_norm_sq_le_unconditional` and its `lllNative_` sibling drop the `_unconditional` suffix, because the `lll_` / `lllNative_` subject already distinguishes them from the conditional `reduced_first_row_norm_sq_le`. `LLLState.ofBasisUnchecked` and its thin `ofBasis` wrapper (which took an unused `_hind : b.independent`) merge into a single hypothesis-free `ofBasis`, and the now-vacuous `hind` drops from `ofBasis_valid` — `Valid` only asserts the stored `ν`/`d` equal their canonical Gram-Schmidt definitions, which holds for any basis, so the proof never used independence. Call sites, docstrings, READMEs, the manual chapter, and the SPEC sketches are updated to match; this is a breaking change to the public API of the released `hex-lll` / `hex-lll-mathlib` repos, which a release sync will carry outward.

🤖 Prepared with Claude Code