### PR TITLE
doc(bz): SPEC describes the hybrid as implemented; drop the bounded combinator

### DIFF
--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -37,16 +37,6 @@ lattice tier wins *asymptotically* on hard (high-`r`) inputs. No
 `axiom` declarations are introduced in this library or its Mathlib
 bridge; every theorem has a real proof.
 
-> **Implementation note.** Public `factor` is the hybrid (classical tier
-> first, CLD lattice tier on decline, integer-trial backstop last). It
-> replaces the earlier lattice-first precision-cap dispatch, which was
-> exponential on easy reducible inputs (a low-cap lattice attempt missed,
-> then fell through to exhaustive recombination). `factor` is the design's
-> only public combinator: the pre-hybrid standalone tiers (`factorFast`,
-> `factorSlowModular`) and the bounded combinator `factorWithBound` are
-> legacy, scheduled for deletion via dispatched directives; until those
-> land, the code carries them as dead weight, not as SPEC surface.
-
 The public API accepts arbitrary input polynomials and normalizes
 internally: extract content, remove powers of `X`, and reduce to the
 primitive square-free case — then make that square-free core monic via
@@ -284,7 +274,7 @@ structure LiftData where
 
 `LiftData` is the pipeline's shared "we have factors mod `p^k`"
 record: it is the output of the Hensel-lift stage and the input to
-recombination. The fast-path recombination needs additional internal
+recombination. The lattice-tier recombination needs additional internal
 metadata (the CLD lattice basis, surviving short vectors, equivalence
 classes, candidate factors); these live in dedicated internal helper
 records inside the recombination implementation, rather than expanding
@@ -361,10 +351,10 @@ def factor (f : ZPoly) : Factorization :=
     | none => factorTrial f      -- total, prime-independent backstop
 ```
 
-(In the implementation each tier produces a raw factor array packed via
-`factorizationOfFactors f`; the acceptance guard is
-`Factorization.product (factorizationOfFactors f cf) = f`, so every
-accepted answer is self-certifying at the dispatch boundary.)
+(Each tier produces a raw factor array; the combinator packs it into a
+`Factorization` and accepts it only when the packed product reconstructs
+`f`, so every accepted answer is self-certifying at the dispatch
+boundary.)
 
 There is no up-front tier selection. The cost control lives inside the
 classical tier: it runs under a **level-aware subset budget** derived
@@ -456,9 +446,9 @@ Setting `a := defaultFactorCoeffBound f` makes `p^a` astronomically
 large (e.g. `3^1008` for Φ_11) and renders Hensel lifting
 intractable on inputs the algorithm could in principle solve.
 
-### Slow-path correctness sketch (in-bridge proof)
+### Exhaustive-recombination correctness sketch (in-bridge proof)
 
-Goal: `∀ f, factorSlow f = irreducibleFactorisationOf f` (up to ordering and units).
+Goal: for every `f`, a completed exhaustive subset recombination returns `irreducibleFactorisationOf f` (up to ordering and units).
 
 Argument:
 
@@ -541,14 +531,14 @@ where `Ã[i, j] := Ψ^a_{ℓ_j}([x^j] Φ(g_i))` for `i ∈ {1,…,r}, j ∈ {0,�
 
 ### Precision schedule
 
-Pinned: start at `a = 4`, double on lattice/verification failure, cap at `bhksBound core` for `core := (normalizeForFactor f).squareFreeCore` — the polynomial the pipeline actually lifts and separates. The papers have a single polynomial, but the executable normalizes first, and the square-free core's coefficient norm can *exceed* `f`'s (Mignotte divisor growth; witness `f = (x¹⁸−1)(x¹⁹−1)`, whose core `f/(x−1)` has `coeffNormSq 36` against `f`'s `4` and a strictly larger `bhksBound`), so keying the cap on `f` would undershoot the core's separation threshold. `bhksBound` is a Lean-computable integer upper bound for the BHKS Theorem 5.2 threshold `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`; an explicit choice is given below. The cap is the BHKS bound rather than the Mignotte coefficient bound because BHKS dominates Mignotte for every `n ≥ 2` (BHKS §5.3 explicitly: "an annoying extra factor of `n` … coming from a resultant upper bound"); a smaller cap would leave the CLD tier's `none` reachable on inputs the algorithm could in principle solve. The constant `4` start is what the current pipeline already does and continues to work.
+Pinned: start at `a = 4`, double on lattice/verification failure, cap at `bhksBound core` for `core := (normalizeForFactor f).squareFreeCore` — the polynomial the pipeline actually lifts and separates. The papers have a single polynomial, but the executable normalizes first, and the square-free core's coefficient norm can *exceed* `f`'s (Mignotte divisor growth; witness `f = (x¹⁸−1)(x¹⁹−1)`, whose core `f/(x−1)` has `coeffNormSq 36` against `f`'s `4` and a strictly larger `bhksBound`), so keying the cap on `f` would undershoot the core's separation threshold. `bhksBound` is a Lean-computable integer upper bound for the BHKS Theorem 5.2 threshold `c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`; an explicit choice is given below. The cap is the BHKS bound rather than the Mignotte coefficient bound because BHKS dominates Mignotte for every `n ≥ 2` (BHKS §5.3 explicitly: "an annoying extra factor of `n` … coming from a resultant upper bound"); a smaller cap would leave the CLD tier's `none` reachable on inputs the algorithm could in principle solve. The constant `4` start is pinned.
 
-The `bhksBound : ZPoly → Nat` helper is one of HO-1's deliverables. A safe explicit choice (sound integer upper bound for BHKS eq. 5.3): `bhksBound f := 1 + n · 4^(n²) · (sumSquared f + 1)^n · (log2 (sumSquared f + 1))^n` where `n := deg f` and `sumSquared f := Σ |a_i|²`. Pure `Nat` arithmetic; the upper-bound argument is straightforward (each factor of (5.3) bounded by the corresponding piece of `bhksBound`).
+The `bhksBound : ZPoly → Nat` helper is SPEC-pinned. A safe explicit choice (sound integer upper bound for BHKS eq. 5.3): `bhksBound f := 1 + n · 4^(n²) · (sumSquared f + 1)^n · (log2 (sumSquared f + 1))^n` where `n := deg f` and `sumSquared f := Σ |a_i|²`. Pure `Nat` arithmetic; the upper-bound argument is straightforward (each factor of (5.3) bounded by the corresponding piece of `bhksBound`).
 
 Termination of the doubling loop:
 
 - If the loop reaches a state where every equivalence-class candidate verifies via exact division and `∏ candidates = f` (up to `lc(f)` and content), the CLD tier returns `some gs`. This is the success path; conditional correctness applies. **In practice, the BHKS algorithm exits via this `L' = W` certificate at precision much lower than the BHKS-bound cap** (BHKS §4.4 explicitly: "a practical implementation should not use the precision bound … because the equations could already be sufficient for smaller values of `ℓ`"); the cap is a theoretical guarantee, not a usual exit condition.
-- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factor` then falls through to the `factorTrial` backstop. **The CLD fast tier makes no irreducibility claim on its own**; verified irreducibility is the property of `factor` (via the combinator) or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factor` correct without needing D1 first.
+- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factor` then falls through to the `factorTrial` backstop. **A recombination-exit `some` makes no irreducibility claim on its own**; verified irreducibility is the property of `factor` (via the combinator), the cap-precision certificate exit, or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factor` correct without needing D1 first.
 
 An additive-coefficient lattice that decodes short vectors as `Σ λ_i g_i (mod p^a)` candidate polynomials is *not* van Hoeij and is not admissible.
 
@@ -563,43 +553,37 @@ An additive-coefficient lattice that decodes short vectors as `Σ λ_i g_i (mod 
 7. **Coefficients of `g` (rather than CLD coefficients of `g_i`) in the lattice is the LLL82 algorithm, not van Hoeij.** Lattice dimension becomes `O(N)` not `O(r)`; entries grow exponentially.
 8. **The identity block `I_r` on the first `r` columns enforces the 0/1 structure.** Without it LLL recovers some short vector but not indicators. Don't omit or rescale.
 9. **If `dim(L') = dim(L)` after step 4, LLL has not made progress.** Remedy: lift more, not retry. (Manifests as `L'` having no nontrivial equivalence classes.)
-10. **Hensel-precision start is constant 4, not Landau–Mignotte.** Mignotte is a possible cap only for the slow path; the fast path's cap is `bhksBound f`.
+10. **Hensel-precision start is constant 4, not Landau–Mignotte.** Mignotte is a possible cap only for the classical tier; the lattice tier's cap is the BHKS bound on the square-free core.
 
 ## Proof obligations (for `hex-berlekamp-zassenhaus-mathlib`)
 
-Four groups. **Naming:** the obligation bodies below use the historical
-names `factorSlow` (the exhaustive-recombination math, unconditionally
-correct) and `factorFast` (the CLD lattice math, conditionally correct);
-the mathematical content is independent of which concrete tier realises
-each. In the hybrid, Group A's math is carried by `factorClassical`
-(budgeted, so it may decline) and by the unconditional `factorTrial`
-backstop; Group B's is carried by `factorLattice` (realized by
-`factorLatticeFactorsWithBound_factor_irreducible` in the bridge). So
-Group A gives the recombination/trial path's unconditional correctness;
-Group B gives the CLD path's conditional correctness; Group C gives
-`factor`'s correctness via the combinator (and the tier-equivalence /
-dispatch-soundness contracts above); Group D is the non-blocking leaf
-performance theorem. No axioms.
+Four groups. Group A gives the exhaustive-recombination mathematics
+(Hensel + Mignotte + UFD) backing `factorClassical`'s `some`-case
+correctness and, via direct divisor enumeration, the unconditional
+`factorTrial` backstop; Group B gives `factorLattice`'s conditional
+correctness; Group C gives `factor`'s correctness via the combinator
+(and the tier-equivalence / dispatch-soundness contracts above);
+Group D is the non-blocking leaf performance theorem. No axioms.
 
-### Group A — slow-path correctness (gives full mathematical guarantee for `factorSlow`)
+### Group A — exhaustive-recombination correctness (backs `factorClassical` and `factorTrial`)
 
 A1. **Hensel-correspondence subset bijection (squarefree case).** For `f ∈ ℤ[x]` squarefree primitive, `p` an admissible prime, `g_1, …, g_r ∈ (ℤ/p^a)[x]` the Hensel-lifted mod-`p` factorisation: every irreducible integer factor `g | f` over ℤ has a unique subset `S ⊆ {1, …, r}` with `g ≡ ∏_{i ∈ S} g_i (mod p^a)`.
     *Sketch:* `g mod p` factorises into a unique subset of `{g_i mod p}` (irreducible mod-`p` decomposition), and Hensel's lemma uniquely lifts that subset to mod `p^a`. Mathlib's `hensels_lemma` covers the analytic version; the explicit subset-correspondence form needs a small wrapper. Read BHKS §3 + Mathlib `Mathlib.NumberTheory.Padics.Hensel` before attempting.
 
 A2. **Mignotte recoverability (modulus form).** Let `B := defaultFactorCoeffBound f`. At precision `a` such that `p^a > 2 B`, the centred-residue lift in `(−p^a/2, p^a/2]` of `(∏_{i ∈ S} g_i mod p^a)` exactly recovers `g`'s integer coefficients.
-    *Sketch:* Mignotte's bound (the existing executable `defaultFactorCoeffBound` in [HexPolyZ/Mignotte.lean](../../HexPolyZ/Mignotte.lean), which Mathlib-side `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean) already establishes via Landau) gives `|coeff(g, j)| ≤ B`; the centred residue is then unique. Implementation note: `factorSlow` uses exponent `a := B` as a sufficient choice because `p ≥ 3` ⟹ `p^a ≥ 3^B > 2B`; this is a corollary, not the abstract statement.
+    *Sketch:* Mignotte's bound (the existing executable `defaultFactorCoeffBound` in [HexPolyZ/Mignotte.lean](../../HexPolyZ/Mignotte.lean), which Mathlib-side `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean) already establishes via Landau) gives `|coeff(g, j)| ≤ B`; the centred residue is then unique. The executable may use exponent `a := B` as a sufficient choice because `p ≥ 3` ⟹ `p^a ≥ 3^B > 2B`; this is a corollary, not the abstract statement.
 
 A3. **Exhaustive search soundness and completeness (squarefree case).** The exhaustive subset enumeration on `(henselLift f a)` returns the irreducible-factor list of squarefree primitive `f`.
     *Sketch:* Soundness: every accepted candidate passes exact division. Completeness: A1+A2 say every irreducible factor `g` corresponds to a subset `S` whose product reconstructs to `g`'s exact coefficients; the enumeration tries every subset; therefore `g` is found. Uniqueness: `Polynomial.UniqueFactorizationMonoid` over `Int` (Mathlib).
 
-A4. **Squarefree-core correctness.** For squarefree primitive `f`, `factorSlow f = irreducibleFactorisationOf f`. Follows from A1+A2+A3.
+A4. **Squarefree-core correctness.** For squarefree primitive `f`, a completed exhaustive subset recombination returns `irreducibleFactorisationOf f`. Follows from A1+A2+A3. A `factorClassical` search that completes within budget *is* an exhaustive search, so this gives the classical tier's `some`-case correctness; `factorTrial` reaches the same conclusion unconditionally by direct Mignotte-bounded divisor enumeration (no Hensel machinery; UFD gives uniqueness).
 
-A5. **Normalisation + reassembly bridges A4 to arbitrary input.** `factor f` (and `factorSlow f`) handle non-squarefree, non-primitive inputs by routing through `normalizeForFactor` and `reassembleNormalizedFactors`. The existing sorry'd theorems `normalizeForFactor_reassembles`, `reassembleNormalizedFactors_product`, `normalizedConstantFactors_product` (in [HexBerlekampZassenhaus/Basic.lean](../../HexBerlekampZassenhaus/Basic.lean)) must all be discharged; combined with A4, they yield `factorSlow f = irreducibleFactorisationOf f` for arbitrary `f`.
+A5. **Normalisation + reassembly extend A4 to arbitrary input.** `factor` handles non-squarefree, non-primitive inputs by routing through `normalizeForFactor` and `reassembleNormalizedFactors`. The reassembly obligations `normalizeForFactor_reassembles`, `reassembleNormalizedFactors_product`, `normalizedConstantFactors_product` combine with A4 to yield `irreducibleFactorisationOf f` for arbitrary `f`.
     *Sketch:* `normalizeForFactor` decomposes `f = content · X^k · h · h_repeated` where `h` is squarefree primitive. Each piece's irreducible factorisation is either standard (constants, X-powers) or given by A4 (squarefree primitive `h`); reassembly is multiplicative bookkeeping. Mathlib has `Polynomial.UniqueFactorizationMonoid` over `Int`; the GCD-based squarefree-core extraction is standard.
 
-### Group B — fast-path conditional correctness (`factorFast f = some gs ⟹ gs is the irreducible factorisation of f`)
+### Group B — lattice-tier conditional correctness (`factorLattice f = some gs ⟹ gs is the irreducible factorisation of f`)
 
-The fast path is allowed to return `none`; we only prove correctness conditional on `some` output. BHKS Theorem 5.2 (existence of a precision at which `none` is impossible) is *not* a Group B obligation — it's Group D.
+The lattice tier is allowed to return `none`; we only prove correctness conditional on `some` output. BHKS Theorem 5.2 (existence of a precision at which `none` is impossible) is *not* a Group B obligation — it's Group D.
 
 B1. **CLD additivity.** `Φ(g · h) = Φ(g) + Φ(h)` whenever `gh | f` in `(ℤ/p^a)[x]`. The identity is `(gh)'/(gh) = g'/g + h'/h`; no coprimality hypothesis. (BHKS Lemma 3.1.) Routine.
 
@@ -622,13 +606,13 @@ B7. **Equivalence-class identification given `L' = W` (BHKS Lemma 3.3).** When `
 B8. **Verification certifies `L' = W` (BHKS Lemma 3.4) — the load-bearing obligation.** Given B6 (so `W ⊆ L'`): if for every equivalence-class candidate `w_C` the reconstructed `g_{w_C}` divides `f` exactly in ℤ[x] and `∏_C g_{w_C} = f` (up to `lc(f)` and content), then `L' = W` and the `g_{w_C}` are exactly the irreducible factors of `f`.
     *Sketch:* The classes refine (or equal) the irreducible-factor partition because every class union must be an integer-factor support (else its product wouldn't lift to a true integer divisor). Pathway: import `Polynomial.UniqueFactorizationMonoid` over `Int` from Mathlib for uniqueness-of-factorisation; use `Polynomial.Gauss` infrastructure for content/primitivity; the verified divisibility witnesses + uniqueness give the irreducibility conclusion. This is the theorem that *justifies the algorithm's stopping criterion*; B7 alone is too weak. **Read BHKS Lemma 3.4 in §3 before attempting.**
 
-B9. **Conditional correctness of `factorFast`.** `factorFast f = some gs ⟹ gs is the irreducible factorisation of f` (up to associates and ordering).
-    *Sketch:* `factorFast` returns `some gs` only when (i) every candidate verified via exact division and (ii) `∏ gs = f`. By B8, conditions (i) + (ii) together imply `L' = W` and `gs = irreducible factors of f`. This is the headline theorem; the proof is one application of B8 to the algorithm's terminating state.
+B9. **Conditional correctness of `factorLattice`.** `factorLattice f = some gs ⟹ gs is the irreducible factorisation of f` (up to associates and ordering).
+    *Sketch:* the tier has two `some` exits. Recombination exit: `some gs` is returned only when (i) every candidate verified via exact division and (ii) `∏ gs = f`; by B8, (i) + (ii) together imply `L' = W` and `gs = irreducible factors of f`. Certificate exit: at cap precision the single all-ones equivalence class certifies the core irreducible (the forward count bound B6-side plus the class partition give exactly one factor), so `some #[core]` is correct. This is the tier's headline theorem; the proof is one application of B8 per exit.
 
 ### Group C — combined `factor` correctness (drives the public API)
 
 C1. **`factor` unconditional correctness.** `factor f = irreducibleFactorisationOf f`.
-    *Sketch:* `factor` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem (`factor_headline` in the bridge), assembled over the hybrid's three branches.
+    *Sketch:* `factor` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem, assembled over the hybrid's three branches.
 
 C2. **Public-API contracts** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`). Product preservation needs no separate bound-aware contract: it is clause 1 of the headline theorem, and the dispatch's acceptance guard makes it self-certifying per tier.
 
@@ -636,7 +620,7 @@ C2. **Public-API contracts** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreduc
 
 Required deliverable; structurally a leaf — no other proof obligation, public-API contract, `Decidable` instance, or theorem statement in the bridge depends on D1 or D2. Both are stated against the hybrid (see *Hybrid dispatch* above): D1 is the CLD lattice tier's completeness (`factorLattice f ≠ none` given a good prime), D2 the tight characterisation of the inputs that reach the `factorTrial` backstop.
 
-D1. **The lattice tier succeeds when a good prime exists on the core: `toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`.** The antecedent is keyed on `toMonicPrimeData?` of the square-free core — the monic-transform prime the CLD pipeline actually Hensel-lifts against — and the theorem is about the implementation as written, with the lattice tier's precision cap (keyed on the core, per *Precision schedule* below), not `bhksBound f`. BHKS Theorem 5.2 supplies the precision/recombination half, conditional on a good prime being available. The unconditional `factorLattice f ≠ none` is **false** against the implementation — `HexBerlekampZassenhaus/Basic.lean` ships `finitePrimeSearchNoneQuadratic` and the `1 + L·X` family as witnesses where the hot-path prime search exhausts its bounded candidate set. This is by design; the unconditional safety net is the hybrid combinator's `factorTrial` backstop (per *Hybrid dispatch* above), not inside any modular tier. D2 below pins down exactly which inputs reach that backstop.
+D1. **The lattice tier succeeds when a good prime exists on the core: `toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`.** The antecedent is keyed on `toMonicPrimeData?` of the square-free core — the monic-transform prime the CLD pipeline actually Hensel-lifts against — and the theorem is about the implementation as written, with the lattice tier's precision cap (keyed on the core, per *Precision schedule* below), not `bhksBound f`. BHKS Theorem 5.2 supplies the precision/recombination half, conditional on a good prime being available. The unconditional `factorLattice f ≠ none` is **false**: the `1 + L·X` family witnesses inputs where the hot-path prime search exhausts its bounded candidate set (the library keeps executable regression witnesses for this). This is by design; the unconditional safety net is the hybrid combinator's `factorTrial` backstop (per *Hybrid dispatch* above), not inside any modular tier. D2 below pins down exactly which inputs reach that backstop.
 
     **Pathway:**
 
@@ -858,7 +842,7 @@ re-measure is cheap after the first build.
 ## References
 
 - van Hoeij, *Factoring polynomials and the knapsack problem* (2002) "KP": https://www.math.fsu.edu/~hoeij/knapsack/paper/May16_2001/knapsack.pdf — original lattice + Lemma 2.6 (rounding error) + Lemma 2.8 (structural test).
-- Belabas, van Hoeij, Klüners, Steel, *Factoring polynomials over global fields* (2009) "BHKS": https://www.math.u-bordeaux.fr/~kbelabas/research/factor-2008.pdf — pinned variant. CLD §3.1.1; lattice §5.2 eq. 5.1; bound Lemma 5.1; rounding Lemma 5.2; norm bound Cor. 5.2; cut soundness Lemma 5.7 (the GS-only "cut", *not* the full LLL-reduction theorem); equivalence-class Lemma 3.3; verification (`L' = W` certified by exact division) Lemma 3.4; separation/termination Theorem 5.2 with explicit threshold eq. 5.3 (`v^ℓ > c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`) — formalised in HO-4 as obligation D1, not relied on by the rest of the project; §4.4 on why practical implementations exit early via the L'=W certificate; §5.3 for the resultant-based proof structure.
+- Belabas, van Hoeij, Klüners, Steel, *Factoring polynomials over global fields* (2009) "BHKS": https://www.math.u-bordeaux.fr/~kbelabas/research/factor-2008.pdf — pinned variant. CLD §3.1.1; lattice §5.2 eq. 5.1; bound Lemma 5.1; rounding Lemma 5.2; norm bound Cor. 5.2; cut soundness Lemma 5.7 (the GS-only "cut", *not* the full LLL-reduction theorem); equivalence-class Lemma 3.3; verification (`L' = W` certified by exact division) Lemma 3.4; separation/termination Theorem 5.2 with explicit threshold eq. 5.3 (`v^ℓ > c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`) — obligation D1, not relied on by the rest of the project; §4.4 on why practical implementations exit early via the L'=W certificate; §5.3 for the resultant-based proof structure.
 - Hart, van Hoeij, Novocin, *Practical polynomial factoring in polynomial time* (2011) "HHN": https://wrap.warwick.ac.uk/id/eprint/43600/1/WRAP_Hart_0584144-ma-270913-poly_factor.pdf — referenced for completeness; incremental-column refinements are *not* used.
 
 ## Certificate structures for Z[x] irreducibility

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -27,25 +27,25 @@ factors:
   modular reduction; the unconditional totality backstop, reached only
   when no admissible prime exists.
 
-The public combinator `factor` estimates the recombination cost from
-the modular factorisation and dispatches: `factorClassical` for small
-estimated cost, `factorLattice` for large `r`, `factorTrial` as the
-final backstop. All three return canonical factorisations; the tiers
+The public combinator `factor` runs `factorClassical` first under a
+budget read off the modular factorisation, `factorLattice` when the
+classical tier declines (large `r`), and `factorTrial` as the final
+backstop. All three return canonical factorisations; the tiers
 are result-equivalent, differing only in cost. The classical tier wins
 the *constant-factor* race against the reference on easy inputs; the
 lattice tier wins *asymptotically* on hard (high-`r`) inputs. No
 `axiom` declarations are introduced in this library or its Mathlib
 bridge; every theorem has a real proof.
 
-> **Implementation note.** Public `factor` is the cost-based hybrid
-> `factorHybrid` (classical tier first, CLD lattice tier on decline,
-> integer-trial backstop last). It replaces the earlier lattice-first
-> precision-cap dispatch, which was exponential on easy reducible inputs
-> (a low-cap lattice attempt missed, then fell through to exhaustive
-> recombination). The code still carries the standalone `factorFast` (a
-> proof-facing CLD tier without the irreducibility-certifying cap arm)
-> and `factorSlowModular` (the exhaustive modular tier) as the concrete
-> realisations the Group A/B obligations below are written against.
+> **Implementation note.** Public `factor` is the hybrid (classical tier
+> first, CLD lattice tier on decline, integer-trial backstop last). It
+> replaces the earlier lattice-first precision-cap dispatch, which was
+> exponential on easy reducible inputs (a low-cap lattice attempt missed,
+> then fell through to exhaustive recombination). `factor` is the design's
+> only public combinator: the pre-hybrid standalone tiers (`factorFast`,
+> `factorSlowModular`) and the bounded combinator `factorWithBound` are
+> legacy, scheduled for deletion via dispatched directives; until those
+> land, the code carries them as dead weight, not as SPEC surface.
 
 The public API accepts arbitrary input polynomials and normalizes
 internally: extract content, remove powers of `X`, and reduce to the
@@ -72,21 +72,22 @@ def factor          (f : ZPoly) : Factorization
 `factorClassical` and `factorLattice` are the two recombination tiers,
 both `Option`-valued because both require an admissible prime;
 `factorTrial` is the total trial-division backstop; `factor` is the
-public cost-based combinator. Each tier also exposes a bounded variant
+public hybrid combinator. Each tier also exposes a bounded variant
 `…WithBound f B` parameterised by a Mignotte coefficient bound `B`
-(used by the precision/conformance tests); `factor` runs the tiers at
-`ZPoly.defaultFactorCoeffBound f`.
+(used by the precision/conformance tests); `factor` runs the classical
+tier at `ZPoly.defaultFactorCoeffBound f` and the lattice tier at its
+own precision cap (see *Precision schedule*).
 
-The dispatch is **by estimated recombination cost, not by a precision
-cap** (see *Cost-based hybrid dispatch* below). The estimate is read
-off the modular factorisation: the lifted-factor count `r`, the
-degree distribution of the modular factors, the coefficient height /
-Mignotte precision, the expected size-ordered subset count, and the
-CLD lattice dimension. When the estimated classical cost is small,
-`factor` runs `factorClassical`; when `r` is large, it runs
-`factorLattice`; when no admissible prime exists, it runs
-`factorTrial`. The combinator is unconditionally correct because the
-final backstop is `choosePrimeData?`-independent.
+The dispatch is **classical-first with budgeted decline, not a
+precision-cap race** (see *Hybrid dispatch* below). `factor` runs
+`factorClassical` under a level-aware subset budget read off the
+modular factorisation (the lifted-factor count `r` and the degree
+distribution of the modular factors). Exhausting the budget is an
+untrustworthy "no split": the classical tier declines rather than
+claiming irreducibility, and `factorLattice` takes over. When no
+admissible prime exists, or the lattice tier misses too, `factorTrial`
+finishes. The combinator is unconditionally correct because the final
+backstop is `choosePrimeData?`-independent.
 
 **Output convention: the `Factorization` record.**
 
@@ -260,13 +261,13 @@ matches the verified Isabelle/AFP `Berlekamp_Zassenhaus` reference
 `berlekamp_zassenhaus_main` then runs `finite_field_factorization_int p f`
 once). It does not *exhaustively* minimise the modular-factor count
 across all candidate primes — that classical Zassenhaus heuristic costs
-one modular factorisation per candidate prime (≈95 per call here). But
-because `r` drives the cost-based dispatch (§*Cost-based hybrid
-dispatch*), when the first suitable prime yields an `r` **near the
-classical/lattice threshold**, the dispatcher may factor at one or two
-further admissible primes and keep the smallest `r` — a bounded retry,
-not a full sweep. On inputs comfortably inside the small-`r` regime,
-first-suitable factors `f mod p` exactly once.
+one modular factorisation per candidate prime (≈95 per call here). No
+per-prime `r` minimisation is needed: `r` drives the classical tier's
+subset budget (§*Hybrid dispatch*), so a first-suitable prime with
+unusually large `r` costs only a budgeted classical attempt before the
+lattice tier — polynomial in `r` — takes over. On inputs comfortably
+inside the small-`r` regime, first-suitable factors `f mod p` exactly
+once.
 
 **Explicit pipeline records:**
 ```lean
@@ -297,9 +298,8 @@ def bhksBound (f : ZPoly) : Nat
 ```
 
 `bhksBound` is the BHKS component of the lattice tier's precision cap
-`factorFastPrecisionCap` (keyed on the square-free core); it is the
-integer-arithmetic upper bound on BHKS Theorem 5.2's threshold (see
-*Precision schedule* below).
+(keyed on the square-free core); it is the integer-arithmetic upper
+bound on BHKS Theorem 5.2's threshold (see *Precision schedule* below).
 
 `choosePrimeData?` is `Option`-valued. The executable searches a
 **bounded hot-path candidate set** `HotPathCandidates`, fixed in
@@ -343,46 +343,43 @@ inside `choosePrimeData?` would cascade through every consumer of
 `PrimeChoiceData` (the `ZMod64.Bounds`-indexed fields prevent
 holding a non-ZMod64-backed `PrimeChoiceData`).
 
-### Cost-based hybrid dispatch
+### Hybrid dispatch: classical-first with budgeted decline
 
 **Load-bearing invariant: the dispatch always terminates in a
 `choosePrimeData?`-independent backstop.** This is what makes `factor`
-unconditionally correct on every `ZPoly`. The combinator chooses a
-recombination tier from the modular factorisation, then falls back if
-the chosen `Option`-tier returns `none`:
+unconditionally correct on every `ZPoly`. The combinator runs the
+classical tier first, accepts a tier's answer only when it reconstructs
+`f`, and falls through on decline:
 
 ```lean
 def factor (f : ZPoly) : Factorization :=
-  match choosePrimeData? f with
-  | none => factorTrial f                       -- no admissible prime: total backstop
-  | some d =>
-    let tier := dispatchTier f d                 -- cost estimate from `d`
-    match (if tier = .lattice then factorLattice f else factorClassical f) with
-    | some r => r
-    | none =>
-      -- the chosen tier missed (precision/lattice failure): try the
-      -- other recombination tier, then the unconditional trial backstop
-      match (if tier = .lattice then factorClassical f else factorLattice f) with
-      | some r => r
-      | none => factorTrial f
+  match factorClassical f with   -- level-aware subset budget inside
+  | some φ => if φ.product = f then φ else factorTrial f
+  | none =>                      -- classical declined (budget) or no admissible prime
+    match factorLattice f with   -- CLD at the lattice precision cap
+    | some φ => if φ.product = f then φ else factorTrial f
+    | none => factorTrial f      -- total, prime-independent backstop
 ```
 
-`dispatchTier f d` estimates the classical recombination cost from the
-lifted-factor count `r`, the modular factors' degree distribution, the
-coefficient height / Mignotte precision, the expected size-ordered
-subset count, and the CLD lattice dimension; near the threshold it may
-re-run `choosePrimeData?` at another admissible prime that yields a
-smaller `r` (`r` depends on the prime, not on `f` alone). Small
-estimated cost → `factorClassical`; large `r` → `factorLattice`.
+(In the implementation each tier produces a raw factor array packed via
+`factorizationOfFactors f`; the acceptance guard is
+`Factorization.product (factorizationOfFactors f cf) = f`, so every
+accepted answer is self-certifying at the dispatch boundary.)
+
+There is no up-front tier selection. The cost control lives inside the
+classical tier: it runs under a **level-aware subset budget** derived
+from the lifted-factor count `r` and the degree distribution of the
+modular factors. On small/medium-`r` inputs the classical tier answers
+cheaply; on high-`r` inputs it exhausts the budget quickly and declines,
+and the CLD lattice tier does the work.
 
 - **`factorClassical`** — Hensel lift + *size-ordered* subset
-  recombination with factor removal, under a **hard subset budget**
-  (a cap on candidate subsets tried, derived from the cost estimate).
-  Same algorithm class as the verified reference; the win is the
-  arithmetic constant. Returns `none` only when `choosePrimeData? f =
-  none` (which the outer `match` already handles) or when its subset
-  budget is exceeded — in which case the budget was mis-estimated and
-  `factorLattice` takes over.
+  recombination with factor removal, under the level-aware **hard subset
+  budget** (a cap on candidate subsets tried, read off the modular
+  factorisation). Same algorithm class as the verified reference; the
+  win is the arithmetic constant. Returns `none` when no admissible
+  prime exists or when its subset budget is exceeded — a decline, not an
+  irreducibility claim — and `factorLattice` takes over.
 - **`factorLattice`** — van Hoeij CLD lattice recombination; polynomial
   in `r`. Used when `r` is large enough that the classical subset
   search would exceed its budget (e.g. Swinnerton-Dyer inputs). May
@@ -422,9 +419,9 @@ No silent suite-shrinking, and no silent tier-downgrade.
 Three recombination tiers, all with full Mathlib-bridge proofs:
 
 - **`factorClassical : ZPoly → Option Factorization`.** Size-ordered subset recombination with factor removal, under a hard subset budget. Same algorithm class as the verified reference. **Unconditional correctness when it returns `some`:** the output is the irreducible factorisation of `f`. Returns `none` only on budget exhaustion or no admissible prime.
-- **`factorLattice : ZPoly → Option Factorization`.** Van Hoeij CLD at the full BHKS precision cap (`factorFastPrecisionCap f := max (bhksBound core) (defaultFactorCoeffBound f)` where `core := (normalizeForFactor f).squareFreeCore`; the BHKS component is keyed on the square-free core the CLD pipeline actually lifts, not on `f` — a core can have larger coefficient norm than `f`, e.g. `f = (x¹⁸−1)(x¹⁹−1)`, so `bhksBound f` can undershoot the core's separation threshold). **Conditional correctness:** `factorLattice f = some φ ⟹ φ is the irreducible factorisation of f`. May return `none`.
+- **`factorLattice : ZPoly → Option Factorization`.** Van Hoeij CLD at the full BHKS precision cap (`max (bhksBound core) (defaultFactorCoeffBound f)` where `core := (normalizeForFactor f).squareFreeCore`; the BHKS component is keyed on the square-free core the CLD pipeline actually lifts, not on `f` — a core can have larger coefficient norm than `f`, e.g. `f = (x¹⁸−1)(x¹⁹−1)`, so `bhksBound f` can undershoot the core's separation threshold). **Conditional correctness:** `factorLattice f = some φ ⟹ φ is the irreducible factorisation of f`. May return `none`.
 - **`factorTrial : ZPoly → Factorization`.** Exhaustive integer trial division. **Unconditional correctness:** `factorTrial f = irreducibleFactorisationOf f`.
-- **`factor : ZPoly → Factorization`.** The cost-based combinator (above): dispatch by estimated recombination cost, fall back to the other tier, then to `factorTrial`. Unconditionally correct.
+- **`factor : ZPoly → Factorization`.** The hybrid combinator (above): classical first, lattice on decline, `factorTrial` as the total backstop. Unconditionally correct.
 
 No axioms. BHKS Theorem 5.2 ("for precision exceeding a paper-stated
 bound, `factorLattice` always returns `some`") is a leaf theorem of
@@ -474,9 +471,9 @@ No BHKS termination theorem is needed: the loop is finite by subset enumeration,
 
 ## Large-r recombination: van Hoeij CLD lattice
 
-`factorLattice` — the tier the cost-based combinator selects when the
-lifted-factor count `r` is large enough that `factorClassical`'s
-size-ordered subset search would exceed its budget. It is **polynomial
+`factorLattice` — the tier the hybrid combinator falls through to when
+the lifted-factor count `r` is large enough that `factorClassical`'s
+size-ordered subset search exceeds its budget and declines. It is **polynomial
 in `r`** (the classical reference, and `factorClassical`, are `O(2^r)`
 there), so it is the asymptotically-correct path on the extreme-`r` tail
 — e.g. Swinnerton-Dyer inputs, which split into many small factors mod
@@ -550,8 +547,8 @@ The `bhksBound : ZPoly → Nat` helper is one of HO-1's deliverables. A safe exp
 
 Termination of the doubling loop:
 
-- If the loop reaches a state where every equivalence-class candidate verifies via exact division and `∏ candidates = f` (up to `lc(f)` and content), `factorFast` returns `some gs`. This is the success path; conditional correctness applies. **In practice, the BHKS algorithm exits via this `L' = W` certificate at precision much lower than the BHKS-bound cap** (BHKS §4.4 explicitly: "a practical implementation should not use the precision bound … because the equations could already be sufficient for smaller values of `ℓ`"); the cap is a theoretical guarantee, not a usual exit condition.
-- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factor` then falls through to the `factorSlowTrial` backstop. **The CLD fast tier makes no irreducibility claim on its own**; verified irreducibility is the property of `factor` (via the combinator) or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factor` correct without needing D1 first.
+- If the loop reaches a state where every equivalence-class candidate verifies via exact division and `∏ candidates = f` (up to `lc(f)` and content), the CLD tier returns `some gs`. This is the success path; conditional correctness applies. **In practice, the BHKS algorithm exits via this `L' = W` certificate at precision much lower than the BHKS-bound cap** (BHKS §4.4 explicitly: "a practical implementation should not use the precision bound … because the equations could already be sufficient for smaller values of `ℓ`"); the cap is a theoretical guarantee, not a usual exit condition.
+- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factor` then falls through to the `factorTrial` backstop. **The CLD fast tier makes no irreducibility claim on its own**; verified irreducibility is the property of `factor` (via the combinator) or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factor` correct without needing D1 first.
 
 An additive-coefficient lattice that decodes short vectors as `Σ λ_i g_i (mod p^a)` candidate polynomials is *not* van Hoeij and is not admissible.
 
@@ -570,18 +567,17 @@ An additive-coefficient lattice that decodes short vectors as `Σ λ_i g_i (mod 
 
 ## Proof obligations (for `hex-berlekamp-zassenhaus-mathlib`)
 
-Four groups. **Naming:** the obligations below use the abstract names
-`factorSlow` (the recombination/trial path, unconditionally correct) and
-`factorFast` (the CLD lattice path, conditionally correct); the
-mathematical content is independent of which concrete tier realises each.
-The cost-based hybrid `factor = factorHybrid` runs, in order, the
-classical recombination tier `factorClassical` (Group A math, budgeted so
-it may decline), the CLD tier `factorLattice` (Group B — the
-irreducibility-certifying refinement of the standalone `factorFast`), and
-the unconditional `factorSlowTrial` backstop (Group A). So Group A gives
-the recombination/trial path's unconditional correctness; Group B gives
-the CLD path's conditional correctness; Group C gives `factor`'s
-correctness via the combinator (and the tier-equivalence /
+Four groups. **Naming:** the obligation bodies below use the historical
+names `factorSlow` (the exhaustive-recombination math, unconditionally
+correct) and `factorFast` (the CLD lattice math, conditionally correct);
+the mathematical content is independent of which concrete tier realises
+each. In the hybrid, Group A's math is carried by `factorClassical`
+(budgeted, so it may decline) and by the unconditional `factorTrial`
+backstop; Group B's is carried by `factorLattice` (realized by
+`factorLatticeFactorsWithBound_factor_irreducible` in the bridge). So
+Group A gives the recombination/trial path's unconditional correctness;
+Group B gives the CLD path's conditional correctness; Group C gives
+`factor`'s correctness via the combinator (and the tier-equivalence /
 dispatch-soundness contracts above); Group D is the non-blocking leaf
 performance theorem. No axioms.
 
@@ -632,25 +628,15 @@ B9. **Conditional correctness of `factorFast`.** `factorFast f = some gs ⟹ gs 
 ### Group C — combined `factor` correctness (drives the public API)
 
 C1. **`factor` unconditional correctness.** `factor f = irreducibleFactorisationOf f`.
-    *Sketch:* `factor f = factorHybrid f` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the BHKS cap; otherwise the `factorSlowTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorSlowTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem (`factor_headline` in the bridge), assembled over the hybrid's three branches; the standalone `factorFast` is off `factor`'s correctness path, its conditional-correctness theorem being a separate Group B obligation (B9 above).
+    *Sketch:* `factor` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem (`factor_headline` in the bridge), assembled over the hybrid's three branches.
 
-C2. **Public-API contracts** (`factor_product_of_bound`, `checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`).
-
-The conditional correctness contract `factor_product_of_bound`:
-```lean
-theorem factor_product_of_bound (f : ZPoly) (B : Nat)
-    (hB : ∀ g : ZPoly, g ∣ f → ∀ i, |g.coeff i| ≤ B) :
-    Factorization.product (factorWithBound f B) = f
-```
-follows from C1 specialised to the bound-aware variant. (Old
-`Array.foldl`-based formulation superseded by `Factorization.product`
-per the new output-convention section above.)
+C2. **Public-API contracts** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`). Product preservation needs no separate bound-aware contract: it is clause 1 of the headline theorem, and the dispatch's acceptance guard makes it self-certifying per tier.
 
 ### Group D — leaf performance theorem (BHKS Theorem 5.2; not on the correctness critical path)
 
-Required deliverable; structurally a leaf — no other proof obligation, public-API contract, `Decidable` instance, or theorem statement in the bridge depends on D1 or D2. Both are stated against the cost-based hybrid (see *Cost-based hybrid dispatch* above): D1 is the CLD lattice tier's completeness (`factorLattice f ≠ none` given a good prime), D2 the tight characterisation of the inputs that reach the `factorTrial` backstop.
+Required deliverable; structurally a leaf — no other proof obligation, public-API contract, `Decidable` instance, or theorem statement in the bridge depends on D1 or D2. Both are stated against the hybrid (see *Hybrid dispatch* above): D1 is the CLD lattice tier's completeness (`factorLattice f ≠ none` given a good prime), D2 the tight characterisation of the inputs that reach the `factorTrial` backstop.
 
-D1. **The lattice tier succeeds when a good prime exists on the core: `toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`.** The antecedent is keyed on `toMonicPrimeData?` of the square-free core — the monic-transform prime the CLD pipeline actually Hensel-lifts against — and the theorem is about the implementation as written, with cap `factorFastPrecisionCap f` (keyed on the core, per *Precision schedule* below), not `bhksBound f`. BHKS Theorem 5.2 supplies the precision/recombination half, conditional on a good prime being available. The unconditional `factorLattice f ≠ none` is **false** against the implementation — `HexBerlekampZassenhaus/Basic.lean` ships `finitePrimeSearchNoneQuadratic` and the `1 + L·X` family as witnesses where the hot-path prime search exhausts its bounded candidate set. This is by design; the unconditional safety net is the cost-based combinator's `factorTrial` backstop (per *Cost-based hybrid dispatch* above), not inside any modular tier. D2 below pins down exactly which inputs reach that backstop.
+D1. **The lattice tier succeeds when a good prime exists on the core: `toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`.** The antecedent is keyed on `toMonicPrimeData?` of the square-free core — the monic-transform prime the CLD pipeline actually Hensel-lifts against — and the theorem is about the implementation as written, with the lattice tier's precision cap (keyed on the core, per *Precision schedule* below), not `bhksBound f`. BHKS Theorem 5.2 supplies the precision/recombination half, conditional on a good prime being available. The unconditional `factorLattice f ≠ none` is **false** against the implementation — `HexBerlekampZassenhaus/Basic.lean` ships `finitePrimeSearchNoneQuadratic` and the `1 + L·X` family as witnesses where the hot-path prime search exhausts its bounded candidate set. This is by design; the unconditional safety net is the hybrid combinator's `factorTrial` backstop (per *Hybrid dispatch* above), not inside any modular tier. D2 below pins down exactly which inputs reach that backstop.
 
     **Pathway:**
 
@@ -659,7 +645,7 @@ D1. **The lattice tier succeeds when a good prime exists on the core: `toMonicPr
     3. **BHKS Theorem 5.2 (eq. 5.3 termination).** At precision satisfying `v^ℓ > c · n · (2C)^(n²) · ‖f‖₂^(2n−1) · (log ‖f‖₂)^n`, the bad-vector lower bound from step 2 exceeds the LLL-cut radius `B'` from B4, so `L' \ W = ∅`. Combined with B6 (`W ⊆ L'`): `L' = W`. Read BHKS §5 (lines around eq. 5.3 and the proof following).
     4. **`bhksBound f` is a sound upper bound for the BHKS threshold.** Show that the integer-arithmetic `bhksBound f` (from the precision schedule) is `≥ ⌈log_v of the BHKS threshold⌉`. Step-by-step bounding of each factor: `n` direct; `(2C)^(n²) ≤ 4^(n²)` for `C ≥ 2` (which `hex-lll` uses); `‖f‖₂^(2n−1) ≤ (sumSquared f + 1)^n`; `(log ‖f‖₂)^n ≤ (log2 (sumSquared f + 1))^n`.
     5. **Forward verification at precision ≥ Mignotte.** The BHKS bound dominates Mignotte for every `n ≥ 2` (a one-line inequality), so any precision sufficient for separation is also sufficient for reconstruction. With `L' = W` from step 3 and precision ≥ Mignotte: B7 produces exactly the irreducible-factor indicators (Lemma 3.3), A2 gives exact integer-coefficient lifts of each `g_{w_C}`, and exact division of `f` succeeds for every candidate. So the algorithm exits via `some _`, not `none`, given a good prime is available.
-    6. **Final theorem.** `theorem factorLattice_ne_none_of_goodPrime : ∀ f : ZPoly, toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`. Internal proof structure is the chain above; the implementation-level statement is on the bounded raw tier, `factorLatticeFactorsWithBound f (factorFastPrecisionCap f) ≠ none`, with `factorLattice f ≠ none` as the `Factorization`-level corollary.
+    6. **Final theorem.** `theorem factorLattice_ne_none_of_goodPrime : ∀ f : ZPoly, toMonicPrimeData? (normalizeForFactor f).squareFreeCore ≠ none → factorLattice f ≠ none`. Internal proof structure is the chain above; the implementation-level statement is on the bounded raw tier at the lattice precision cap, `factorLatticeFactorsWithBound f cap ≠ none`, with `factorLattice f ≠ none` as the `Factorization`-level corollary.
 
     The bridge file gets one new theorem (`factorLattice_ne_none_of_goodPrime`) and a small handful of supporting lemmas (resultant Hadamard bound, BHKS Lemma 3.2, BHKS Theorem 5.2 instantiated at the core's `bhksBound`, BHKS-bound-dominates-Mignotte). Existing theorem statements (A1–A5, B1–B9, C1–C2) are unchanged.
 
@@ -677,7 +663,7 @@ D2. **Tight characterisation of trial-backstop inputs.** Statement shape:
 
     Equivalently, `|lc(f) · disc(f)| ≥ ∏ HotPathCandidates`, an astronomically large lower bound that no realistic polynomial reaches. (`HotPathCandidates` is the SPEC-fixed set defined in the algorithmic-architecture clause above.)
 
-    `factorTrial` is reached only when no admissible hot-path prime exists, i.e. `choosePrimeData? f = none` (both modular tiers rest on the same hot-path candidate set, so neither `factorClassical` nor `factorLattice` has a prime to lift when there isn't one). Given a good prime, D1 makes `factorLattice` succeed and the classical tier's completeness makes `factorClassical` succeed, so whichever tier the cost-based dispatch selects resolves in a modular tier and never falls through. So D2 is the tight delineation of inputs that hit the trial backstop: any `f` with `|lc(f) · disc(f)| < ∏ HotPathCandidates` is provably handled by `factorClassical` or `factorLattice`, runs at `ZMod64` speed, and never touches `factorTrial`.
+    `factorTrial` is reached only when no admissible hot-path prime exists, i.e. `choosePrimeData? f = none` (both modular tiers rest on the same hot-path candidate set, so neither `factorClassical` nor `factorLattice` has a prime to lift when there isn't one). Given a good prime, D1 makes `factorLattice` succeed on classical decline, so the classical-first dispatch resolves in a modular tier and never falls through. So D2 is the tight delineation of inputs that hit the trial backstop: any `f` with `|lc(f) · disc(f)| < ∏ HotPathCandidates` is provably handled by `factorClassical` or `factorLattice`, runs at `ZMod64` speed, and never touches `factorTrial`.
 
     **Pathway:**
 
@@ -725,7 +711,7 @@ that there is no clean theorem boundary):
   factorisation; the cost-based dispatch therefore cannot change the
   result, only the cost.
 - **Dispatch soundness.** `factor f` equals the canonical factorisation
-  for every `f`, independent of which tier `dispatchTier` selects and of
+  for every `f`, independent of which tier answers and of
   any fallback taken.
 - **Fallback semantics.** The trial backstop is a *correctness* backstop,
   not a silent recovery for a buggy tier: a tier returning `some` must be
@@ -837,7 +823,7 @@ the Verso manual). This is a re-runnable comparator sweep, **not CI** (see
 [SPEC/benchmarking.md § Cross-system comparator sweeps](../../SPEC/benchmarking.md)).
 
 **Standing expectation for any change to a public factor entry** (`factor`,
-`factorLattice`, `factorFast`, `factorClassicalNoDecline`, or the tiers beneath
+`factorLattice`, `factorClassicalNoDecline`, or the tiers beneath
 them) that could move performance: re-measure the hex entries and refresh the
 charts, then **show the updated charts to the requester**. The external
 comparators do *not* need re-running — the plotter merges records
@@ -847,7 +833,7 @@ correct charts:
 ```
 # 1. Re-measure only the hex entries against the current corpus (same cutoff):
 python3 scripts/bench/factor_sweep.py \
-    --systems hex-factor,hex-lattice,hex-fast,hex-classical-nodecline \
+    --systems hex-factor,hex-lattice,hex-classical-nodecline \
     --cutoff 10 --skip-unavailable
 # 2. Regenerate the charts (fresh hex curves win; external curves carried over):
 python3 scripts/plots/hexbz-cactus.py

--- a/progress/20260704T034828Z_bz-spec-hybrid-as-implemented.md
+++ b/progress/20260704T034828Z_bz-spec-hybrid-as-implemented.md
@@ -1,0 +1,50 @@
+# BZ SPEC: hybrid as implemented, bounded combinator dropped
+
+## Accomplished
+
+Authored the SPEC PR for the BZ factor-path cleanup (plan reviewed by a
+Codex second opinion; decisions: SPEC-to-code on dispatch, delete
+factorWithBound rather than re-shape). All changes in
+HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md:
+
+- Dispatch section retitled "Hybrid dispatch: classical-first with
+  budgeted decline"; pseudocode replaced with the implemented shape
+  (classical first, product-reconstruction acceptance guard per tier,
+  lattice on decline, factorTrial backstop) mirroring
+  factorHybridFactors (Basic.lean:10849). The never-implemented
+  `dispatchTier` cost estimator and the near-threshold prime-retry
+  clause are gone; the cost control is documented as the classical
+  tier's level-aware subset budget (#8537).
+- Intro paragraph and front-matter dispatch description aligned
+  (classical at defaultFactorCoeffBound, lattice at its own cap).
+- C2: dropped `factor_product_of_bound` (never implemented); product
+  preservation is headline clause 1 + the acceptance guard.
+- Implementation note: `factor` is the only public combinator;
+  `factorFast`, `factorSlowModular`, `factorWithBound` marked legacy,
+  scheduled for deletion via directives (target state).
+- Groups A/B naming note recast: historical names in obligation bodies,
+  concrete carriers factorClassical+factorTrial (A) and factorLattice
+  (B, realized by factorLatticeFactorsWithBound_factor_irreducible).
+- De-naming: `factorFastPrecisionCap` / `factorSlowTrial` /
+  `factorHybrid` def names removed from SPEC prose (role names instead)
+  so the upcoming renames don't re-stale it.
+- Cross-system sweep list: dropped `factorFast` / `hex-fast`.
+
+## Current frontier
+
+SPEC PR ready. Next: file the seven implementation directives
+(A: delete bounded combinator surface; B: retire factorFast;
+C1: prune Mathlib exhaustive-core proof clusters; C2: retire
+factorSlowModular; D: rename tiers/lattice internals; E: collapse
+factorHybrid* into factor*; F: SPEC final pass), strictly sequential,
+per the approved plan at
+~/.claude/plans/yes-we-should-certainly-adaptive-dusk.md.
+
+## Next step
+
+File the issues with dependency lines; pod workers execute
+A -> B -> C1 -> C2 -> D -> E -> F.
+
+## Blockers
+
+None.

--- a/progress/20260704T043510Z_bz-spec-timeless-pass.md
+++ b/progress/20260704T043510Z_bz-spec-timeless-pass.md
@@ -1,0 +1,44 @@
+# BZ SPEC: timeless pass over the hybrid rewrite
+
+## Accomplished
+
+Kim's correction on SPEC philosophy: the SPEC is a clean-room
+re-implementation specification and must not reference the vagaries or
+mistakes of the current implementation — migration state belongs in the
+issues. Second commit on the #8577 branch applying that:
+
+- Deleted the Implementation note entirely (history + "legacy, scheduled
+  for deletion" framing gone; the design speaks for itself).
+- Proof obligations recast in the design's tier vocabulary, removing the
+  "historical names" translation note: Group A is now
+  "exhaustive-recombination correctness (backs factorClassical and
+  factorTrial)" with A4/A5 restated (A4 explains how the classical
+  some-case and the trial backstop inherit it); Group B is "lattice-tier
+  conditional correctness" with B9 stated for factorLattice covering both
+  some-exits (recombination-verified and cap certificate). No factorSlow /
+  factorFast / factorHybrid / factorWithBound anywhere in the SPEC now.
+- Removed implementation-state references: A5's "existing sorry'd
+  theorems ... must be discharged", "the current pipeline already does",
+  HO-1 / HO-4 milestone labels, `factor_headline` bridge-theorem name,
+  `finitePrimeSearchNoneQuadratic` witness def name (kept the 1 + L·X
+  family as the mathematical witness), "In the implementation" phrasing
+  in the dispatch section (acceptance guard now stated as design).
+- Aligned residual fast/slow-path phrasing to tier roles (LiftData note,
+  Pitfall 10, precision-schedule termination bullets).
+
+This subsumes most of issue #8584's SPEC deliverables; #8584 rewritten
+to the residue (post-convergence consistency grep + refreshing the
+#8369/#8370 issue bodies after the renames land).
+
+## Current frontier
+
+PR #8577 carries the full timeless SPEC. Directives #8578-#8583 unchanged
+and still sequential; #8584 slimmed.
+
+## Next step
+
+Merge #8577 once CI is green; pod workers start on #8578.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR makes the BZ SPEC's dispatch design match the implementation and removes the bounded combinator from the SPEC surface, the first step of the factor-path cleanup (SPEC first, then dispatched deletion directives). It replaces the dispatch pseudocode — which showed a never-implemented `dispatchTier` cost estimator behind an outer prime match — with the classical-first design the code ships in `factorHybridFactors` (`Basic.lean:10849`): classical tier first, a product-reconstruction acceptance guard per tier, CLD lattice tier on decline, `factorTrial` backstop. The section is retitled "Hybrid dispatch: classical-first with budgeted decline"; the cost control is the classical tier's level-aware subset budget, and the speculative near-threshold prime-retry clause is dropped.

The SPEC is kept **timeless** — a clean-room re-implementation specification with no references to the vagaries or history of the current implementation (that is what the follow-up issues are for). Concretely: the implementation-history note is deleted rather than rewritten; the proof obligations are recast in the design's tier vocabulary (Group A = exhaustive-recombination correctness backing `factorClassical`'s `some`-case and the unconditional `factorTrial` backstop; Group B = `factorLattice`'s conditional correctness, with B9 covering both `some`-exits); C2 loses `factor_product_of_bound` (promised but never implemented; product preservation is clause 1 of the headline theorem plus the acceptance guard); and implementation-state references are removed throughout (the discharged "sorry'd theorems" clause in A5, HO-1/HO-4 milestone labels, bridge-theorem and witness def names, `factorFastPrecisionCap`/`factorSlowTrial`/`factorHybrid` identifiers). No `factorSlow*`, `factorFast*`, `factorHybrid`, or `factorWithBound` name appears in the SPEC. `factorFast`/`hex-fast` are dropped from the cross-system sweep list.

Follow-up implementation directives: https://github.com/kim-em/hex-dev/issues/8578 (delete the legacy bounded combinator surface), https://github.com/kim-em/hex-dev/issues/8579 (retire the standalone factorFast tier), https://github.com/kim-em/hex-dev/issues/8580 (prune the exhaustive-core proof clusters), https://github.com/kim-em/hex-dev/issues/8581 (retire the exhaustive factorSlowModular tier), https://github.com/kim-em/hex-dev/issues/8582 (rename tiers and lattice internals to SPEC names), https://github.com/kim-em/hex-dev/issues/8583 (collapse factorHybrid* into factor*), https://github.com/kim-em/hex-dev/issues/8584 (post-cleanup consistency pass). The plan behind this sequence was reviewed by a second opinion; its findings are incorporated. Relates to https://github.com/kim-em/hex-dev/issues/8369 (feat(bz): lattice-tier totality — factorLattice f ≠ none when a good prime exists on the core) and https://github.com/kim-em/hex-dev/issues/8370 (feat(bz): checkable prime-admissibility conditions + hybrid backstop-unreachability), which stay open.

🤖 Prepared with Claude Code