### PR TITLE
doc: group unreleased-library chapters into a Draft section in the manual

### DIFF
--- a/HexManual.lean
+++ b/HexManual.lean
@@ -63,28 +63,6 @@ and, where there is one, its correspondence with Mathlib.
 
 {include 0 HexManual.Chapters.HexLLL}
 
-{include 0 HexManual.Chapters.HexArith}
-
-{include 0 HexManual.Chapters.HexModArith}
-
-{include 0 HexManual.Chapters.HexPoly}
-
-{include 0 HexManual.Chapters.HexPolyZ}
-
-{include 0 HexManual.Chapters.HexPolyFp}
-
-{include 0 HexManual.Chapters.HexGF2}
-
-{include 0 HexManual.Chapters.HexHensel}
-
-{include 0 HexManual.Chapters.HexGFqRing}
-
-{include 0 HexManual.Chapters.HexGFqField}
-
-{include 0 HexManual.Chapters.HexConway}
-
-{include 0 HexManual.Chapters.HexGFq}
-
 # Tutorials
 %%%
 tag := "tutorials"
@@ -96,5 +74,37 @@ already cares about and shows the libraries carrying a recognizable
 end-to-end workflow, with every code snippet checked as part of this
 build.
 
-{include 1 HexManual.Tutorials.Coppersmith}
+{include 2 HexManual.Tutorials.Coppersmith}
+
+# Draft sections for unreleased libraries
+%%%
+tag := "unreleased"
+%%%
+
+These libraries are still incubating in the
+[`hex-dev`](https://github.com/kim-em/hex-dev) monorepo and have not been
+split out for release yet, so their APIs may still change. They are grouped
+here to keep the reference chapters above focused on the released libraries.
+
+{include 2 HexManual.Chapters.HexArith}
+
+{include 2 HexManual.Chapters.HexModArith}
+
+{include 2 HexManual.Chapters.HexPoly}
+
+{include 2 HexManual.Chapters.HexPolyZ}
+
+{include 2 HexManual.Chapters.HexPolyFp}
+
+{include 2 HexManual.Chapters.HexGF2}
+
+{include 2 HexManual.Chapters.HexHensel}
+
+{include 2 HexManual.Chapters.HexGFqRing}
+
+{include 2 HexManual.Chapters.HexGFqField}
+
+{include 2 HexManual.Chapters.HexConway}
+
+{include 2 HexManual.Chapters.HexGFq}
 

--- a/progress/20260704T0510Z_manual-unreleased-section.md
+++ b/progress/20260704T0510Z_manual-unreleased-section.md
@@ -1,0 +1,53 @@
+# Manual: Draft section for unreleased libraries; aggregator HexAll → Hex
+
+## Accomplished
+
+Interactive request spanning two repos.
+
+**`hex-dev` (this repo), branch `doc/manual-unreleased-section` off main:**
+- `HexManual.lean`: moved the eleven unreleased-library reference chapters
+  (HexArith … HexGFq) out of the top-level TOC into a new part
+  "Draft sections for unreleased libraries" at the end, nesting each with
+  `{include 2 ...}`. Fixed the Coppersmith tutorial from `{include 1 ...}`
+  (which rendered it as a sibling of Tutorials) to `{include 2 ...}` so it
+  is a child of Tutorials.
+- Verified: `lake build HexManual` green, then rendered with
+  `lake exe hexmanual --output _out`. Rendered TOC confirms part 7
+  "Tutorials" has child 7.1 "LLL in cryptanalysis" and part 8
+  "Draft sections for unreleased libraries" has children 8.1–8.11.
+  Top-level parts are now exactly the 6 released chapters + Tutorials +
+  Draft section.
+
+Verso `{include N X}` semantics (from `closePartsUntil` in
+`verso/.../Elab/Monad.lean`): after a literal `#` header (level 1),
+`{include 1 X}` closes back to root and adds X as a level-1 sibling;
+`{include 2 X}` adds X as a level-2 child. To nest under the immediately
+preceding `#` part, use `{include 2 ...}`.
+
+**`leanprover/hex` aggregator (cloned to `/tmp/hex-agg`, branch
+`rename-hexall-and-readme`, committed locally, NOT pushed):**
+- Renamed the umbrella `HexAll.lean` → `Hex.lean` (git mv), updated
+  `lakefile.toml` (`defaultTargets`, `lean_lib` name) and the module
+  docstring, so downstream code writes `import Hex`.
+- Reworked `README.md`: folded the separate Mathlib-free / Mathlib tables
+  into one three-column table (Component | Computational | Mathlib layer);
+  added a Quickstart section with the `require` snippet and a short worked
+  example (exact integer determinant + LLL short vector); linked the
+  manual (<https://kim-em.github.io/hex-dev/>); corrected released-repo
+  links from `kim-em/` to their real `leanprover/` homes.
+
+## Current frontier
+
+Both changes approved for merge. The `hex-dev` manual change is this PR
+(branch `doc/manual-unreleased-section`, rebased on main). The aggregator
+rename/README is a separate PR against `leanprover/hex` (that repo is
+`pins_only` in the sync manifest, so its README + umbrella are authored
+directly in the released repo, not generated from here).
+
+## Next step
+
+Merge both PRs once the required `build` check is green.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR moves the eleven unreleased-library reference chapters out of the top-level table of contents and into a single "Draft sections for unreleased libraries" part at the end of the manual, so the released libraries stay prominent on the TOC. It also nests each unreleased chapter and the Coppersmith tutorial under their parent parts with `{include 2 ...}`; the previous `{include 1 ...}` placed the tutorial as a sibling of Tutorials rather than a child of it. Rendered output confirms part 7 Tutorials now has child 7.1 and part 8 Draft sections has children 8.1 through 8.11.

🤖 Prepared with Claude Code