### PR TITLE
refactor(bz): rename tiers and lattice internals to SPEC names

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -27,15 +27,15 @@ and `lllNative`. Key #8519 facts that supersede older notes below:
   `leadingCoeff f = 1`) apply directly. The standalone fast tier
   (`factorFastFactorsWithBound`) still selects `choosePrimeData?` and is a
   verification-guarded, decline-only heuristic for `lc ≢ 1 (mod p)`.
-- **The fast-core acceptance floor is `fastCoreFloor`** (CLD column adequacy
+- **The fast-core acceptance floor is `bhksRecoveryFloor`** (CLD column adequacy
   `cldCoeffFloor` joined with both Mignotte bounds), so a
-  `factorFastCoreWithBound` success carries `fastCoreFloor core ≤ k'` — enough
+  `bhksRecoveryCoreWithBound` success carries `bhksRecoveryFloor core ≤ k'` — enough
   for the partition machinery AND `hsep`/`hthr` at the witness precision. The
   old "L'=W is cap-only" analysis (#7985-era) no longer applies to the
   `W ⊆ L'` direction: `normalizedFactors_card_le_bhksEquivalenceClassIndicators_size`
   (`LatticeTier.lean`) proves it at any floor-cleared precision.
-- The cap (`factorFastPrecisionCap`) dominates every floor component by
-  construction (`fastCoreFloor_squareFreeCore_le_factorFastPrecisionCap`).
+- The cap (`latticePrecisionCap`) dominates every floor component by
+  construction (`bhksRecoveryFloor_squareFreeCore_le_latticePrecisionCap`).
 
 The executable types (`Hex.ZMod64 p`, `Hex.FpPoly p = Hex.DensePoly (ZMod64 p)`,
 `Hex.ZPoly = Hex.DensePoly Int`) carry **only `Lean.Grind` ring instances and a
@@ -441,7 +441,7 @@ early-return; reassembly is a power of `X`, the unit core fails the guard via
 `factorFastFactorsWithBound_raw_guardedIrreducible_of_recoveredLift` (BHKS
 core-success, routing through the #8058 capstone). Slow producers
 (`slowModularRaw_irreducible_of_fast_none`,
-`factorSlowTrialFactorsWithBound_factor_irreducible_of_fast_none`) keep their
+`factorTrialFactorsWithBound_factor_irreducible_of_fast_none`) keep their
 *unguarded* statements — `fast = none` forces `degree ≠ 0`, so there is no unit
 core — and imply the guarded form by `fun raw hmem _ => producer raw hmem`. Note
 this guarded contract is the fast-path counterpart to the `normalizeFactorSign`
@@ -502,7 +502,7 @@ The slow-path raw irreducibility (`slowModularRaw_irreducible_of_fast_none`,
 `exhaustiveCoreFactorsWithBound` at `exhaustiveLiftBound` — one deterministic
 array, so `hraw : … = some rawFactors` pins it directly and the irreducibility
 producer applies at that one precision. **Do not assume the fast path is the same
-shape.** `factorFastCoreWithBound` is a *schedule loop* (`Basic.lean:6935`): it
+shape.** `bhksRecoveryCoreWithBound` is a *schedule loop* (`Basic.lean:6935`): it
 starts at `Hex.initialHenselPrecision a`, walks `henselPrecisionSchedule`, and
 returns the array of the **first** precision where `bhksRecoverClassified`
 returns `.success`. A `ForwardRecoveryInputs` package sits at the cap `target`
@@ -517,13 +517,13 @@ Consequences for any fast-BHKS irreducibility / `h_raw` work:
   executable run, where `start = initialHenselPrecision a ≠ target = cap`. Use
   the decoupled `…_of_forwardInputs_on_schedule` wrappers
   (`PartitionRefinement.lean`, #7666): the count argument routes through
-  `factorFastCoreWithBound_some_factor_count_eq_of_cut`, whose loop-result params
+  `bhksRecoveryCoreWithBound_some_factor_count_eq_of_cut`, whose loop-result params
   (`k`,`fuel`) and cut-precision param (`L`) are already independent.
-- Those decoupled wrappers still take `h : factorFastCoreWithBound core B
+- Those decoupled wrappers still take `h : bhksRecoveryCoreWithBound core B
   primeData start fuel = some hinputs.expectedFactors` as a hypothesis. Producing
   that `h` for the real `start = initialHenselPrecision a` is the **scheduled-loop
   determinism obligation** (loop's first success returns the cap recovery). It is
-  *not* derivable from the cap package: `factorFastCoreWithBound_isSome_of_
+  *not* derivable from the cap package: `bhksRecoveryCoreWithBound_isSome_of_
   recovery_on_schedule` (`Basic.lean:7105`) proves existence, not factor
   identity, and `bhksRecoverClassified_success_*` (`Basic.lean:11238-11322`) give
   product/dvd/sign for any success but neither irreducibility nor equality to the
@@ -538,8 +538,8 @@ Consequences for any fast-BHKS irreducibility / `h_raw` work:
 `precisionForCoeffBound` is applied **twice** on the public fast path, so the
 CLD lattice runs at a precision far below the BHKS column-adequacy threshold.
 The public caller computes `a := precisionForCoeffBound B primeData.p`
-(`Basic.lean:7699/7714`, `B = factorFastPrecisionCap core`) and passes `a` as
-`factorFastCoreWithBound`'s coefficient-bound parameter; the loop then feeds the
+(`Basic.lean:7699/7714`, `B = latticePrecisionCap core`) and passes `a` as
+`bhksRecoveryCoreWithBound`'s coefficient-bound parameter; the loop then feeds the
 schedule variable `k` into `toMonicLiftData core k primeData`, which applies
 `precisionForCoeffBound` **again** (`:7001`, `(henselLiftData _ B _).k = B`).
 Net: the lattice's actual exponent is
@@ -555,7 +555,7 @@ empirically (true factor coefficients are tiny) but certifies nothing about
 column-adequacy. **Consequence:** no acceptance gate against the current
 `liftData.k` (the #7928 plan) can supply hsep/hthr — it would only flip fixtures
 `some → none`. Verify with a pure-integer `#eval` scratch (`bhksCoeffBound`,
-`precisionForCoeffBound`, `henselPrecisionSchedule`, `factorFastPrecisionCap` all
+`precisionForCoeffBound`, `henselPrecisionSchedule`, `latticePrecisionCap` all
 run under `lake env lean`, no extern). The real fix is a precision-*schedule*
 correction (drop the double `precisionForCoeffBound`), which is soundness-
 sensitive and touches the CI-gated determinism cluster — not a cheap gate.
@@ -566,20 +566,20 @@ clears the CLD floor; as of #7928 it did not.
 ### Resolved by #7938 (schedule) + #7951 (gate); the gate cascade is large
 
 #7938 dropped the double `precisionForCoeffBound` so the schedule now iterates
-*coefficient bounds* `k` up to the cap `factorFastPrecisionCap f` (single
+*coefficient bounds* `k` up to the cap `latticePrecisionCap f` (single
 conversion inside `toMonicLiftData`). #7951 then added the acceptance gate:
-`factorFastCoreWithBound`'s `.success` branch accepts only when
+`bhksRecoveryCoreWithBound`'s `.success` branch accepts only when
 `k ≥ cldCoeffFloor core = 2·max_j bhksCoeffBound (toMonic core).monic j`, else
 continues the schedule. Post-#7951, `success → k ≥ cldCoeffFloor core` (hence
 `hsep` via `precisionForCoeffBound_spec`) *is* derivable — that is the premise
 #7945's hsep/hthr proofs consume. Verify the floor numerically with a
-pure-integer `#eval` (`cldCoeffFloor`, `factorFastPrecisionCap`, the schedule)
+pure-integer `#eval` (`cldCoeffFloor`, `latticePrecisionCap`, the schedule)
 under `lake env lean` — for `cldGuardF` floor`=32`, cap`=50803201`, first gated
 success at `k=32`/`liftData.k=3` (`2·bhksCoeffBound=32 < 5^3=125`).
 
 Two traps when touching the gate:
 
-- **Adding an acceptance condition to `factorFastCoreWithBound` cascades through
+- **Adding an acceptance condition to `bhksRecoveryCoreWithBound` cascades through
   the entire CI-gated capstone chain, not just the obvious determinism lemmas.**
   Every wrapper whose conclusion asserts `factorFast … ≠ none` / `= some …`
   needs the new side condition threaded as an *open hypothesis* (like `hno`):
@@ -588,14 +588,14 @@ Two traps when touching the gate:
   `Recovery.lean` chain — the `_internalCapPositive*` variants and all ~18
   `factorFast_terminates*` capstones (which route through `factorFast_terminates`
   → `…_internalCapPositiveAndPrimeLowerBound`). Size it up front by grepping the
-  `hB_pos`/`one_le_factorFastPrecisionCap f`/`hchoose` arg chain (~30 lemmas);
+  `hB_pos`/`one_le_latticePrecisionCap f`/`hchoose` arg chain (~30 lemmas);
   do **not** regex-replace on `f primeData` (it appears pervasively in
   hypothesis *types* like `CanonicalRecoveryTailInputs f primeData …`, so a blind
   sed corrupts signatures — target exact call lines). The success→*property*
   lemmas (`_product`, `_dvd`, `_some_all_of_recovery`, `_some_classifiedSuccess`)
   stay signature-stable; they only need a `by_cases hfloor` in the `.success`
   case. Discharging the floor side condition needs
-  `cldCoeffFloor core ≤ factorFastPrecisionCap f` (a `toMonic` coefficient-norm
+  `cldCoeffFloor core ≤ latticePrecisionCap f` (a `toMonic` coefficient-norm
   vs `bhksBound`-slack analysis with no existing infra) — thread it, don't try
   to prove it inline.
 - **Reducing the gate `ite` on a `k ≥ cldCoeffFloor core` condition in a
@@ -610,7 +610,7 @@ Two traps when touching the gate:
 A "success ⟹ recovery package / `EquivalenceClassRecoveryHypotheses` /
 `ForwardRecoveryInputs` producer" directive (the #7917 prerequisite) looks like
 a thin assembly after #7980 landed hsep/hthr, but is **not** constructible.
-`factorFastCoreWithBound_some_indicatorCandidates` (`Basic.lean:11785`) already
+`bhksRecoveryCoreWithBound_some_indicatorCandidates` (`Basic.lean:11785`) already
 gives `k'`, `hrows`, `hcandidates`, non-degeneracy, and product=core from loop
 success with no extra hypotheses — so `hcandidates`/`hsize` are free. The whole
 deliverable collapses to the single field `hindicators`
@@ -620,14 +620,14 @@ trueSupports`), whose only route
 `Recovery.lean:572`) demands `lattice_eq_indicators` = the BHKS Lemma 3.3
 equality `L'=W`. That needs `SeparationHypotheses.no_projected_not_indicator`
 (bad-vector exclusion), whose **only** producer
-(`no_projected_not_indicator_of_factorFastPrecisionCap_le`,
-`TerminationBound.lean:508`) requires precision `≥ factorFastPrecisionCap` **and**
+(`no_projected_not_indicator_of_latticePrecisionCap_le`,
+`TerminationBound.lean:508`) requires precision `≥ latticePrecisionCap` **and**
 the still-open `BadVectorBridgeData` (BHKS Lemma 3.2 resultant divisibility).
 Crucially: the #7951 gate forces only `k' ≥ cldCoeffFloor core`, which feeds
 **only** the CLD column adequacy (`cut`/hsep/hthr, in `CLDColumnBound.lean`) —
 `cldCoeffFloor` appears in **zero** lines of `BadVector.lean`/`Lattice.lean`/
 `TerminationBound.lean`, all of which key the exclusion on
-`factorFastPrecisionCap … ≤ a`. And floor ≪ cap by orders of magnitude
+`latticePrecisionCap … ≤ a`. And floor ≪ cap by orders of magnitude
 (`cldGuardF`: floor=32, cap=50803201, both pure-integer `#eval`-checkable), so
 the cap producer cannot fire at the first-success precision. The `on_schedule`
 `hno` route is *worse than hard — it is false*: the gated loop returns at the
@@ -643,7 +643,7 @@ thin producer. (#7985 skipped on exactly this.)
 
 **#7938 fixed only the *cap*, not the success precision — the trap persists
 (#7945).** #7938 removed the *caller-side* double `precisionForCoeffBound` (the
-public path now passes the raw cap `B = factorFastPrecisionCap core`), so the
+public path now passes the raw cap `B = latticePrecisionCap core`), so the
 *cap* schedule entry is now adequate (cldGuardF: `liftData.k = 12` at `k = cap =
 50803201`). But the per-iteration lift still applies `precisionForCoeffBound` to
 the **schedule variable** `k` (`toMonicLiftData core k primeData` ⟹ `liftData.k
@@ -1330,7 +1330,7 @@ non-monic restatement before a non-monic consumer can use it.
 ### "Package the recovery witnesses into `TrueFactorLift`" is the centered/raw trap
 
 A directive asking you to derive a `TrueFactorLift` family (the hypothesis of
-`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_lift`,
+`bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_lift`,
 `PartitionRefinement.lean`) from `RepresentsIntegerFactorAtLift` recovery
 witnesses is **not** a packaging step — it asks for a witness recovery cannot
 provide. `TrueFactorLift.support_product_eq` needs the **raw** integer product
@@ -1384,7 +1384,7 @@ vector (`periodAdjustedVector`, `CLDColumnBound.lean`) — packaged as a
 #7872) plus `two_mul_natAbs_sum_psiCut_period_le` (#7869), and
 `cutProjectionHypotheses_of_shortVectors` (the existing `SupportShortVectorData`
 consumer) carries it to the fast-disjunct endpoint
-(`factorFastCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`). Two
+(`bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_recoveredLift`). Two
 load-bearing facts the earlier "skip" advice missed: (a) the period lemma's
 *proof* gives `2|d| < T.card+1`, i.e. `≤ T.card` over ℤ — the tight column bound,
 fitting the exact radius `4r+n·r²` (its stated `≤ T.card+1` was weaker than

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -8981,43 +8981,43 @@ def cldCoeffFloor (core : ZPoly) : Nat :=
 
 /-- Acceptance floor for the fast-core loop: the CLD column-adequacy floor
 `cldCoeffFloor` joined with the Mignotte recovery bounds of the core and of its
-monic transform.  A success accepted at `k ≥ fastCoreFloor core` is both
+monic transform.  A success accepted at `k ≥ bhksRecoveryFloor core` is both
 column-adequate and running at a Hensel modulus `p ^ precisionForCoeffBound k p`
 that clears twice both Mignotte bounds — which is what the lattice-tier
 count-equality and adequacy proofs consume (#8519): the toMonic partition
 producers need `2 * defaultFactorCoeffBound (toMonic core).monic < p ^ a`, and
 the true-support nonemptiness argument needs the same for `core` itself. -/
-def fastCoreFloor (core : ZPoly) : Nat :=
+def bhksRecoveryFloor (core : ZPoly) : Nat :=
   max (cldCoeffFloor core)
     (max (ZPoly.defaultFactorCoeffBound core)
       (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic))
 
-theorem cldCoeffFloor_le_fastCoreFloor (core : ZPoly) :
-    cldCoeffFloor core ≤ fastCoreFloor core :=
+theorem cldCoeffFloor_le_bhksRecoveryFloor (core : ZPoly) :
+    cldCoeffFloor core ≤ bhksRecoveryFloor core :=
   Nat.le_max_left _ _
 
-theorem defaultFactorCoeffBound_le_fastCoreFloor (core : ZPoly) :
-    ZPoly.defaultFactorCoeffBound core ≤ fastCoreFloor core :=
+theorem defaultFactorCoeffBound_le_bhksRecoveryFloor (core : ZPoly) :
+    ZPoly.defaultFactorCoeffBound core ≤ bhksRecoveryFloor core :=
   Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _)
 
-theorem defaultFactorCoeffBound_toMonic_le_fastCoreFloor (core : ZPoly) :
-    ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic ≤ fastCoreFloor core :=
+theorem defaultFactorCoeffBound_toMonic_le_bhksRecoveryFloor (core : ZPoly) :
+    ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic ≤ bhksRecoveryFloor core :=
   Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _)
 
 /-- The acceptance floor used solely as the fast-core loop's skip gate.
 
-Definitionally `fastCoreFloor`, but marked `irreducible` so that `whnf` in
-downstream proofs that case-split on a `factorFastCoreWithBound` application
+Definitionally `bhksRecoveryFloor`, but marked `irreducible` so that `whnf` in
+downstream proofs that case-split on a `bhksRecoveryCoreWithBound` application
 does not eagerly expand the (symbolic, structurally large) floor computation
 while reducing the loop's head `if`.  The loop's behavioural unfolding lemma
-`factorFastCoreWithBound_unfold` re-exposes the plain `fastCoreFloor`
+`bhksRecoveryCoreWithBound_unfold` re-exposes the plain `bhksRecoveryFloor`
 comparison, so proofs reason about the genuine floor. -/
-@[irreducible] def fastCoreFloorGate (core : ZPoly) : Nat :=
-  fastCoreFloor core
+@[irreducible] def bhksRecoveryFloorGate (core : ZPoly) : Nat :=
+  bhksRecoveryFloor core
 
-theorem fastCoreFloorGate_eq (core : ZPoly) :
-    fastCoreFloorGate core = fastCoreFloor core := by
-  simp only [fastCoreFloorGate]
+theorem bhksRecoveryFloorGate_eq (core : ZPoly) :
+    bhksRecoveryFloorGate core = bhksRecoveryFloor core := by
+  simp only [bhksRecoveryFloorGate]
 
 /-- Inner fast-core recombination loop, parameterised by a precomputed CLD
 column-adequacy `floor`.  Below `floor` a success cannot be accepted and every
@@ -9027,13 +9027,13 @@ and the loop steps straight to the next scheduled precision.  At/above `floor`
 a success is column-adequate and accepted immediately.
 
 `floor` is threaded as a parameter so the (structurally large, degree-
-exponential) `cldCoeffFloor` is evaluated once by `factorFastCoreWithBound`
+exponential) `cldCoeffFloor` is evaluated once by `bhksRecoveryCoreWithBound`
 rather than re-evaluated at every doubling step.
 
-Private: only `factorFastCoreWithBound` (which passes `cldCoeffFloorGate core`)
+Private: only `bhksRecoveryCoreWithBound` (which passes `cldCoeffFloorGate core`)
 is the semantically supported entry point; the bare `floor` parameter must not
 be set independently. -/
-private def factorFastCoreLoop
+private def bhksRecoveryLoop
     (core : ZPoly) (B floor : Nat) (primeData : PrimeChoiceData) :
     Nat → Nat → Option (Array ZPoly)
   | _k, 0 => none
@@ -9042,7 +9042,7 @@ private def factorFastCoreLoop
         if k ≥ B then
           none
         else
-          factorFastCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+          bhksRecoveryLoop core B floor primeData (nextHenselPrecision k B) fuel
       else
         match bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
         | .success factors =>
@@ -9051,26 +9051,26 @@ private def factorFastCoreLoop
           if k ≥ B then
             none
           else
-            factorFastCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+            bhksRecoveryLoop core B floor primeData (nextHenselPrecision k B) fuel
         | .productMismatch _ =>
           if k ≥ B then
             none
           else
-            factorFastCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+            bhksRecoveryLoop core B floor primeData (nextHenselPrecision k B) fuel
         | .degenerate =>
           if k ≥ B then
             none
           else
-            factorFastCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+            bhksRecoveryLoop core B floor primeData (nextHenselPrecision k B) fuel
 
 /-- BHKS fast-core recombination loop.  Computes the CLD column-adequacy floor
-once (through the irreducible `fastCoreFloorGate`, so `whnf` in downstream
+once (through the irreducible `bhksRecoveryFloorGate`, so `whnf` in downstream
 proofs that case-split on this application does not eagerly expand the symbolic
-floor) and runs `factorFastCoreLoop`. -/
-def factorFastCoreWithBound
+floor) and runs `bhksRecoveryLoop`. -/
+def bhksRecoveryCoreWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
     Option (Array ZPoly) :=
-  factorFastCoreLoop core B (fastCoreFloorGate core) primeData k fuel
+  bhksRecoveryLoop core B (bhksRecoveryFloorGate core) primeData k fuel
 
 /-- Behavioural unfolding for the optimized fast-core loop: the precision-floor
 short-circuit is propositionally equal to the original "recover at every step,
@@ -9078,46 +9078,46 @@ accept only at the floor" body.  Below the floor every recovery class steps to
 the next precision, and at/above the floor a success is column-adequate; both
 match the gated form, so this lemma lets the recovery-on-schedule proofs reason
 about the loop exactly as before. -/
-private theorem factorFastCoreWithBound_unfold
+private theorem bhksRecoveryCoreWithBound_unfold
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
-    factorFastCoreWithBound core B primeData k (fuel + 1) =
+    bhksRecoveryCoreWithBound core B primeData k (fuel + 1) =
       match bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | .success factors =>
-        if k ≥ fastCoreFloor core then
+        if k ≥ bhksRecoveryFloor core then
           some factors
         else if k ≥ B then
           none
         else
-          factorFastCoreWithBound core B primeData (nextHenselPrecision k B) fuel
+          bhksRecoveryCoreWithBound core B primeData (nextHenselPrecision k B) fuel
       | .candidateFailure =>
         if k ≥ B then
           none
         else
-          factorFastCoreWithBound core B primeData (nextHenselPrecision k B) fuel
+          bhksRecoveryCoreWithBound core B primeData (nextHenselPrecision k B) fuel
       | .productMismatch _ =>
         if k ≥ B then
           none
         else
-          factorFastCoreWithBound core B primeData (nextHenselPrecision k B) fuel
+          bhksRecoveryCoreWithBound core B primeData (nextHenselPrecision k B) fuel
       | .degenerate =>
         if k ≥ B then
           none
         else
-          factorFastCoreWithBound core B primeData (nextHenselPrecision k B) fuel := by
+          bhksRecoveryCoreWithBound core B primeData (nextHenselPrecision k B) fuel := by
   have hrec : ∀ k',
-      factorFastCoreLoop core B (fastCoreFloor core) primeData k' fuel =
-        factorFastCoreWithBound core B primeData k' fuel := by
+      bhksRecoveryLoop core B (bhksRecoveryFloor core) primeData k' fuel =
+        bhksRecoveryCoreWithBound core B primeData k' fuel := by
     intro k'
-    rw [factorFastCoreWithBound, fastCoreFloorGate_eq]
-  rw [factorFastCoreWithBound, fastCoreFloorGate_eq, factorFastCoreLoop]
+    rw [bhksRecoveryCoreWithBound, bhksRecoveryFloorGate_eq]
+  rw [bhksRecoveryCoreWithBound, bhksRecoveryFloorGate_eq, bhksRecoveryLoop]
   simp only [hrec]
-  by_cases hf : k < fastCoreFloor core
+  by_cases hf : k < bhksRecoveryFloor core
   · rw [if_pos hf]
-    have hfloor : ¬ k ≥ fastCoreFloor core := Nat.not_le.mpr hf
+    have hfloor : ¬ k ≥ bhksRecoveryFloor core := Nat.not_le.mpr hf
     cases bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) <;>
       simp only [hfloor, if_false]
   · rw [if_neg hf]
-    have hfloor : k ≥ fastCoreFloor core := Nat.le_of_not_lt hf
+    have hfloor : k ≥ bhksRecoveryFloor core := Nat.le_of_not_lt hf
     cases bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) <;>
       simp only [hfloor, if_true]
 
@@ -9267,22 +9267,22 @@ theorem cap_mem_henselPrecisionSchedule (B : Nat) :
               omega
     exact henselPrecisionSchedule_mem_cap _ _ hinit_pos hinit_le hbound
 
-private theorem factorFastCoreWithBound_isSome_of_recovery_on_schedule
+private theorem bhksRecoveryCoreWithBound_isSome_of_recovery_on_schedule
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
-    (hfloor : fastCoreFloor core ≤ target)
+    (hfloor : bhksRecoveryFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hrecover :
       bhksRecover? core (ZPoly.toMonicLiftData core target primeData) = some factors) :
-    (factorFastCoreWithBound core B primeData start fuel).isSome := by
+    (bhksRecoveryCoreWithBound core B primeData start fuel).isSome := by
   induction fuel generalizing start with
   | zero =>
       simp [henselPrecisionSchedule] at hmem
   | succ fuel ih =>
-      rw [factorFastCoreWithBound_unfold]
+      rw [bhksRecoveryCoreWithBound_unfold]
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core start primeData) with
       | success xs =>
-          by_cases hstart : start ≥ fastCoreFloor core
+          by_cases hstart : start ≥ bhksRecoveryFloor core
           · simp [hstart]
           · by_cases hk : start ≥ B
             · exfalso
@@ -9387,22 +9387,22 @@ This is the executable-loop determinism skeleton.  The BHKS precision theorem
 supplies the `hno` premise by ruling out successful recovery below the
 Mignotte/cap precision.
 -/
-theorem factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_recovery
+theorem bhksRecoveryCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_recovery
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
-    (hfloor : fastCoreFloor core ≤ target)
+    (hfloor : bhksRecoveryFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hno :
       ∀ k, k ∈ henselPrecisionSchedule B start fuel → k ≠ target →
         bhksRecover? core (ZPoly.toMonicLiftData core k primeData) = none)
     (hrecover :
       bhksRecover? core (ZPoly.toMonicLiftData core target primeData) = some factors) :
-    factorFastCoreWithBound core B primeData start fuel = some factors := by
+    bhksRecoveryCoreWithBound core B primeData start fuel = some factors := by
   induction fuel generalizing start with
   | zero =>
       simp [henselPrecisionSchedule] at hmem
   | succ fuel ih =>
-      rw [factorFastCoreWithBound_unfold]
+      rw [bhksRecoveryCoreWithBound_unfold]
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core start primeData) with
       | success xs =>
           by_cases htarget : start = target
@@ -9508,17 +9508,17 @@ theorem factorFastCoreWithBound_eq_some_of_recovery_on_schedule_of_no_prior_reco
               simp [henselPrecisionSchedule, hk, hk_mem]
             exact hno k hk_schedule hk_ne
 
-private theorem factorFastCoreWithBound_ne_none_of_recovery_on_schedule
+private theorem bhksRecoveryCoreWithBound_ne_none_of_recovery_on_schedule
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {start fuel target : Nat} {factors : Array ZPoly}
-    (hfloor : fastCoreFloor core ≤ target)
+    (hfloor : bhksRecoveryFloor core ≤ target)
     (hmem : target ∈ henselPrecisionSchedule B start fuel)
     (hrecover :
       bhksRecover? core (ZPoly.toMonicLiftData core target primeData) = some factors) :
-    factorFastCoreWithBound core B primeData start fuel ≠ none := by
+    bhksRecoveryCoreWithBound core B primeData start fuel ≠ none := by
   intro hnone
   have hsome :=
-    factorFastCoreWithBound_isSome_of_recovery_on_schedule
+    bhksRecoveryCoreWithBound_isSome_of_recovery_on_schedule
       core B primeData hfloor hmem hrecover
   rw [hnone] at hsome
   simp at hsome
@@ -9531,7 +9531,7 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
     fModP := ZPoly.modP 5 cldGuardF
     factorsModP := berlekampFactorsModP cldGuardF c }
 
-#guard factorFastCoreWithBound cldGuardF 1 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 1 factorFastCoreGuardPrimeData
     (initialHenselPrecision 1) (ZPoly.quadraticDoublingSteps 1 + 2) =
   none
 
@@ -9539,14 +9539,14 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
 -- `cldCoeffFloor cldGuardF = 32` cannot be accepted: the schedule reaches the
 -- cap `B` while every success is still below the floor, so the loop reports
 -- `none`.
-#guard factorFastCoreWithBound cldGuardF 4 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 4 factorFastCoreGuardPrimeData
     (initialHenselPrecision 4) (ZPoly.quadraticDoublingSteps 4 + 2) =
   none
 
 -- At a bound that reaches the floor the first gated success is accepted: for
 -- `cldGuardF` this is schedule index `k = 32` (lift precision `liftData.k = 3`,
 -- modulus `5 ^ 3 = 125`), recovering the same factors.
-#guard factorFastCoreWithBound cldGuardF 32 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 32 factorFastCoreGuardPrimeData
     (initialHenselPrecision 32) (ZPoly.quadraticDoublingSteps 32 + 2) =
   some bhksGuardFactors
 
@@ -9813,7 +9813,7 @@ constant/quadratic-root short-circuits as the classical tier; the residual
 exhaustive branch dispatches to the standalone integer trial-division core
 (`exhaustiveIntegerTrialCoreFactorsWithBound`). This is the trial-division
 tier of the three-tier `factor` combinator (SPEC PR #6580). -/
-def factorSlowTrialFactorsWithBound (f : ZPoly) (B : Nat) : Array ZPoly :=
+def factorTrialFactorsWithBound (f : ZPoly) (B : Nat) : Array ZPoly :=
   let normalized := normalizeForFactor f
   if normalized.squareFreeCore.degree?.getD 0 = 0 then
     reassemblePolynomialFactors normalized #[normalized.squareFreeCore]
@@ -9825,28 +9825,28 @@ def factorSlowTrialFactorsWithBound (f : ZPoly) (B : Nat) : Array ZPoly :=
           exhaustiveIntegerTrialCoreFactorsWithBound normalized.squareFreeCore B
         reassemblePolynomialFactors normalized coreFactors
 
-#guard factorSlowTrialFactorsWithBound exhaustiveNonMonicQuadraticGuard 4 =
+#guard factorTrialFactorsWithBound exhaustiveNonMonicQuadraticGuard 4 =
   #[exhaustiveNonMonicQuadraticGuard]
 
-def factorSlowTrialWithBound (f : ZPoly) (B : Nat) : Factorization :=
-  factorizationOfFactors f (factorSlowTrialFactorsWithBound f B)
+def factorTrialWithBound (f : ZPoly) (B : Nat) : Factorization :=
+  factorizationOfFactors f (factorTrialFactorsWithBound f B)
 
 /-- Characterise the bounded integer trial-division slow wrapper as the raw
 factor array packed into the public `Factorization` representation. -/
-theorem factorSlowTrialWithBound_eq_factorizationOfFactors
+theorem factorTrialWithBound_eq_factorizationOfFactors
     (f : ZPoly) (B : Nat) :
-    factorSlowTrialWithBound f B =
-      factorizationOfFactors f (factorSlowTrialFactorsWithBound f B) := rfl
+    factorTrialWithBound f B =
+      factorizationOfFactors f (factorTrialFactorsWithBound f B) := rfl
 
 /--
 Factor using the integer trial-division path at the default Mignotte
 coefficient bound. This is the trial-division tier of the three-tier
 `factor` combinator (SPEC PR #6580).
 -/
-def factorSlowTrial (f : ZPoly) : Factorization :=
-  factorSlowTrialWithBound f (ZPoly.defaultFactorCoeffBound f)
+def factorTrial (f : ZPoly) : Factorization :=
+  factorTrialWithBound f (ZPoly.defaultFactorCoeffBound f)
 
-#guard factorSlowTrial exhaustiveNonMonicQuadraticGuard =
+#guard factorTrial exhaustiveNonMonicQuadraticGuard =
   factorizationOfFactors exhaustiveNonMonicQuadraticGuard #[exhaustiveNonMonicQuadraticGuard]
 
 /--
@@ -9864,62 +9864,62 @@ The BHKS component is computed from `(normalizeForFactor f).squareFreeCore`
 against `f`'s `4`, and `bhksBound core > bhksBound f`), so a cap keyed on
 `f` can sit below the core's separation threshold (#8521).
 -/
-def factorFastPrecisionCap (f : ZPoly) : Nat :=
+def latticePrecisionCap (f : ZPoly) : Nat :=
   let core := (normalizeForFactor f).squareFreeCore
   max (max (bhksBound core) (cldCoeffFloor core))
     (max (ZPoly.defaultFactorCoeffBound f)
       (max (ZPoly.defaultFactorCoeffBound core)
         (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic)))
 
-theorem bhksBound_squareFreeCore_le_factorFastPrecisionCap (f : ZPoly) :
-    bhksBound (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f := by
-  unfold factorFastPrecisionCap
+theorem bhksBound_squareFreeCore_le_latticePrecisionCap (f : ZPoly) :
+    bhksBound (normalizeForFactor f).squareFreeCore ≤ latticePrecisionCap f := by
+  unfold latticePrecisionCap
   exact Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_left _ _)
 
 /-- The cap clears the CLD column-adequacy floor of the square-free core, so the
 lattice tier's cap-precision run is column-adequate by construction (#8519). -/
-theorem cldCoeffFloor_squareFreeCore_le_factorFastPrecisionCap (f : ZPoly) :
-    cldCoeffFloor (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f := by
-  unfold factorFastPrecisionCap
+theorem cldCoeffFloor_squareFreeCore_le_latticePrecisionCap (f : ZPoly) :
+    cldCoeffFloor (normalizeForFactor f).squareFreeCore ≤ latticePrecisionCap f := by
+  unfold latticePrecisionCap
   exact Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_left _ _)
 
-theorem defaultFactorCoeffBound_le_factorFastPrecisionCap (f : ZPoly) :
-    ZPoly.defaultFactorCoeffBound f ≤ factorFastPrecisionCap f := by
-  unfold factorFastPrecisionCap
+theorem defaultFactorCoeffBound_le_latticePrecisionCap (f : ZPoly) :
+    ZPoly.defaultFactorCoeffBound f ≤ latticePrecisionCap f := by
+  unfold latticePrecisionCap
   exact Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _)
 
 /-- The public precision cap clears the whole fast-core acceptance floor, so
 the gated loop always has admissible precisions on its schedule (#8519). -/
-theorem fastCoreFloor_squareFreeCore_le_factorFastPrecisionCap (f : ZPoly) :
-    fastCoreFloor (normalizeForFactor f).squareFreeCore ≤ factorFastPrecisionCap f := by
-  unfold fastCoreFloor
-  refine Nat.max_le.mpr ⟨cldCoeffFloor_squareFreeCore_le_factorFastPrecisionCap f,
+theorem bhksRecoveryFloor_squareFreeCore_le_latticePrecisionCap (f : ZPoly) :
+    bhksRecoveryFloor (normalizeForFactor f).squareFreeCore ≤ latticePrecisionCap f := by
+  unfold bhksRecoveryFloor
+  refine Nat.max_le.mpr ⟨cldCoeffFloor_squareFreeCore_le_latticePrecisionCap f,
     Nat.max_le.mpr ⟨?_, ?_⟩⟩
-  · unfold factorFastPrecisionCap
+  · unfold latticePrecisionCap
     exact Nat.le_trans (Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _))
       (Nat.le_max_right _ _)
-  · unfold factorFastPrecisionCap
+  · unfold latticePrecisionCap
     exact Nat.le_trans (Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _))
       (Nat.le_max_right _ _)
 
 /-- The cap dominates the Mignotte bound of the square-free core itself, needed
 by the true-support nonemptiness argument at cap precision (#8519). -/
-theorem defaultFactorCoeffBound_squareFreeCore_le_factorFastPrecisionCap (f : ZPoly) :
+theorem defaultFactorCoeffBound_squareFreeCore_le_latticePrecisionCap (f : ZPoly) :
     ZPoly.defaultFactorCoeffBound (normalizeForFactor f).squareFreeCore ≤
-      factorFastPrecisionCap f := by
-  unfold factorFastPrecisionCap
+      latticePrecisionCap f := by
+  unfold latticePrecisionCap
   exact Nat.le_trans (Nat.le_trans (Nat.le_max_left _ _) (Nat.le_max_right _ _))
     (Nat.le_max_right _ _)
 
 /-- The cap dominates the Mignotte bound of the monic transform of the
 square-free core, the `hbound` input of the toMonic partition producers
 (#8519). -/
-theorem defaultFactorCoeffBound_toMonic_squareFreeCore_le_factorFastPrecisionCap
+theorem defaultFactorCoeffBound_toMonic_squareFreeCore_le_latticePrecisionCap
     (f : ZPoly) :
     ZPoly.defaultFactorCoeffBound
         (ZPoly.toMonic (normalizeForFactor f).squareFreeCore).monic ≤
-      factorFastPrecisionCap f := by
-  unfold factorFastPrecisionCap
+      latticePrecisionCap f := by
+  unfold latticePrecisionCap
   exact Nat.le_trans (Nat.le_trans (Nat.le_max_right _ _) (Nat.le_max_right _ _))
     (Nat.le_max_right _ _)
 
@@ -9935,16 +9935,16 @@ theorem two_mul_bhksBound_squareFreeCore_lt_pow_cap
     2 * bhksBound (normalizeForFactor f).squareFreeCore <
       primeData.p ^
         (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
-          (factorFastPrecisionCap f) primeData).k := by
+          (latticePrecisionCap f) primeData).k := by
   have hk :
       (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
-          (factorFastPrecisionCap f) primeData).k =
-        precisionForCoeffBound (factorFastPrecisionCap f) primeData.p := by
+          (latticePrecisionCap f) primeData).k =
+        precisionForCoeffBound (latticePrecisionCap f) primeData.p := by
     unfold ZPoly.toMonicLiftData
     exact henselLiftData_k _ _ _
   rw [hk]
-  have hle := bhksBound_squareFreeCore_le_factorFastPrecisionCap f
-  have hspec := precisionForCoeffBound_spec hp (factorFastPrecisionCap f)
+  have hle := bhksBound_squareFreeCore_le_latticePrecisionCap f
+  have hspec := precisionForCoeffBound_spec hp (latticePrecisionCap f)
   omega
 
 /-- Variant of `two_mul_bhksBound_squareFreeCore_lt_pow_cap` keyed on the
@@ -9957,7 +9957,7 @@ theorem two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_choosePrimeData
     2 * bhksBound (normalizeForFactor f).squareFreeCore <
       primeData.p ^
         (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
-          (factorFastPrecisionCap f) primeData).k :=
+          (latticePrecisionCap f) primeData).k :=
   two_mul_bhksBound_squareFreeCore_lt_pow_cap f primeData
     (choosePrimeData?_prime _ primeData hchoose).two_le
 
@@ -9970,7 +9970,7 @@ theorem two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_toMonicPrimeData
     2 * bhksBound (normalizeForFactor f).squareFreeCore <
       primeData.p ^
         (ZPoly.toMonicLiftData (normalizeForFactor f).squareFreeCore
-          (factorFastPrecisionCap f) primeData).k :=
+          (latticePrecisionCap f) primeData).k :=
   two_mul_bhksBound_squareFreeCore_lt_pow_cap f primeData
     (ZPoly.toMonicPrimeData?_prime _ primeData hselected).two_le
 
@@ -9988,11 +9988,11 @@ theorem two_mul_bhksBound_squareFreeCore_lt_pow_cap_of_toMonicPrimeData
 /-- The CLD recovery's equivalence-class partition at this precision is the single
 all-ones class — the signature of an *irreducible* input (all lifted mod-`p`
 factors form the one integer factor). At column-adequate precision
-(`fastCoreFloor core ≤ k`) this certifies irreducibility — the proven count
+(`bhksRecoveryFloor core ≤ k`) this certifies irreducibility — the proven count
 lower bound forces a reducible core to exhibit ≥ 2 classes there
 (`latticeArm3_bhksSingleAllOnes_irreducible` in the Mathlib layer) — while
 below the floor it may instead mean the lattice has not separated the factors
-yet, so callers must only trust it at `k ≥ fastCoreFloor core`. (A cap-free
+yet, so callers must only trust it at `k ≥ bhksRecoveryFloor core`. (A cap-free
 CLD path would treat this partition as `degenerate` and decline, which is why
 such a path "misses" on Swinnerton-Dyer inputs; the lattice tier uses this predicate, both
 in `latticeCoreLoop`'s early stop and in the trailing cap check, to turn the
@@ -10008,21 +10008,21 @@ def bhksSingleAllOnesPartition (f : ZPoly) (d : LiftData) : Bool :=
   else
     false
 
-/-- Lattice-tier recombination loop: `factorFastCoreLoop` plus certificate-backed
+/-- Lattice-tier recombination loop: `bhksRecoveryLoop` plus certificate-backed
 early termination (#8395).  The split path is byte-identical to the fast loop —
 below `floor` every step is skipped, and at/above `floor` a classified recovery
 success is accepted immediately.  The single change is the `.degenerate` arm: at
 `k ≥ floor` the loop re-examines the partition, and the single all-ones class is
 accepted as a **sound** irreducibility certificate (`some #[core]`) instead of
 advancing the schedule.  Soundness is not heuristic: at column-adequate precision
-(`fastCoreFloor core ≤ k`) the proven count lower bound forces a reducible core
+(`bhksRecoveryFloor core ≤ k`) the proven count lower bound forces a reducible core
 to exhibit ≥ 2 equivalence classes, so all-ones can only be reported for a
 genuinely irreducible core (`latticeArm3_bhksSingleAllOnes_irreducible` in the
 Mathlib layer consumes exactly the `⟨k, floor ≤ k, all-ones⟩` witness this loop
 produces).  Without the early stop the loop grinds the doubling schedule to the
 conservative BHKS cap on every irreducible input.
 
-Private: only `latticeCoreWithBound` (which passes `fastCoreFloorGate core`) is
+Private: only `latticeCoreWithBound` (which passes `bhksRecoveryFloorGate core`) is
 the semantically supported entry point; the bare `floor` parameter must not be
 set independently. -/
 private def latticeCoreLoop
@@ -10057,14 +10057,14 @@ private def latticeCoreLoop
           else
             latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
 
-/-- Lattice-tier core loop entry: `factorFastCoreWithBound` with certificate-backed
+/-- Lattice-tier core loop entry: `bhksRecoveryCoreWithBound` with certificate-backed
 early termination on the single all-ones partition (#8395).  Computes the CLD
-column-adequacy floor once (through the irreducible `fastCoreFloorGate`) and runs
+column-adequacy floor once (through the irreducible `bhksRecoveryFloorGate`) and runs
 `latticeCoreLoop`. -/
 def latticeCoreWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
     Option (Array ZPoly) :=
-  latticeCoreLoop core B (fastCoreFloorGate core) primeData k fuel
+  latticeCoreLoop core B (bhksRecoveryFloorGate core) primeData k fuel
 
 /-- Structural spec for the lattice-tier loop: every success is either a fast-loop
 success (the split path is untouched) or the certificate-backed early stop — the
@@ -10074,7 +10074,7 @@ private theorem latticeCoreLoop_some_spec
     (core : ZPoly) (B floor : Nat) (primeData : PrimeChoiceData) :
     ∀ fuel k cf,
       latticeCoreLoop core B floor primeData k fuel = some cf →
-        factorFastCoreLoop core B floor primeData k fuel = some cf ∨
+        bhksRecoveryLoop core B floor primeData k fuel = some cf ∨
           (cf = #[core] ∧ ∃ k', floor ≤ k' ∧
             bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k' primeData)
               = true) := by
@@ -10086,7 +10086,7 @@ private theorem latticeCoreLoop_some_spec
   | succ fuel ih =>
       intro k cf h
       rw [latticeCoreLoop] at h
-      rw [factorFastCoreLoop]
+      rw [bhksRecoveryLoop]
       by_cases hfl : k < floor
       · rw [if_pos hfl] at h ⊢
         by_cases hk : k ≥ B
@@ -10124,8 +10124,8 @@ private theorem latticeCoreLoop_some_spec
                 exact ih _ cf h
 
 /-- Public structural spec for `latticeCoreWithBound`: a success is either a
-`factorFastCoreWithBound` success or the early irreducibility certificate — the
-singleton `#[core]` with a witness precision `k'` clearing `fastCoreFloor core`
+`bhksRecoveryCoreWithBound` success or the early irreducibility certificate — the
+singleton `#[core]` with a witness precision `k'` clearing `bhksRecoveryFloor core`
 whose partition is the single all-ones class.  The witness pair is exactly the
 `hB_floor`/`hbhks` input of the Mathlib layer's
 `latticeArm3_bhksSingleAllOnes_irreducible`. -/
@@ -10133,14 +10133,14 @@ theorem latticeCoreWithBound_some_spec
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData} {k fuel : Nat}
     {cf : Array ZPoly}
     (h : latticeCoreWithBound core B primeData k fuel = some cf) :
-    factorFastCoreWithBound core B primeData k fuel = some cf ∨
-      (cf = #[core] ∧ ∃ k', fastCoreFloor core ≤ k' ∧
+    bhksRecoveryCoreWithBound core B primeData k fuel = some cf ∨
+      (cf = #[core] ∧ ∃ k', bhksRecoveryFloor core ≤ k' ∧
         bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k' primeData)
           = true) := by
-  rw [latticeCoreWithBound, fastCoreFloorGate_eq] at h
-  rcases latticeCoreLoop_some_spec core B (fastCoreFloor core) primeData fuel k cf h with
+  rw [latticeCoreWithBound, bhksRecoveryFloorGate_eq] at h
+  rcases latticeCoreLoop_some_spec core B (bhksRecoveryFloor core) primeData fuel k cf h with
     hfast | hcert
-  · rw [factorFastCoreWithBound, fastCoreFloorGate_eq]
+  · rw [bhksRecoveryCoreWithBound, bhksRecoveryFloorGate_eq]
     exact Or.inl hfast
   · exact Or.inr hcert
 
@@ -10153,11 +10153,11 @@ cap-precision partition once more: the single all-ones class means `core` is
 irreducible (`#[core]`), anything else is a genuine failure (`none`).
 
 Both certification arms are gated on the column-adequacy floor: the loop's
-early stop only examines the partition at `k ≥ fastCoreFloorGate core`, and the
-trailing cap check requires `fastCoreFloorGate core ≤ B` — below the floor the
+early stop only examines the partition at `k ≥ bhksRecoveryFloorGate core`, and the
+trailing cap check requires `bhksRecoveryFloorGate core ≤ B` — below the floor the
 all-ones partition may merely mean the lattice has not separated the factors
 yet, so certifying there would be unsound.  The public `factorLattice` supplies
-`factorFastPrecisionCap`, which clears the floor by construction. -/
+`latticePrecisionCap`, which clears the floor by construction. -/
 def latticeCoreFactorsWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) : Option (Array ZPoly) :=
   if primeData.factorsModP.size ≤ 1 then
@@ -10167,7 +10167,7 @@ def latticeCoreFactorsWithBound
         (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
     | some coreFactors => some coreFactors
     | none =>
-        if fastCoreFloorGate core ≤ B then
+        if bhksRecoveryFloorGate core ≤ B then
           if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core B primeData) then
             some #[core]
           else
@@ -10207,7 +10207,7 @@ def factorLatticeWithBound (f : ZPoly) (B : Nat) : Option Factorization :=
 Certifies irreducibility (unlike a cap-free CLD path), so it returns `some` on
 Swinnerton-Dyer and cyclotomic high-`r` irreducibles. -/
 def factorLattice (f : ZPoly) : Option Factorization :=
-  factorLatticeWithBound f (factorFastPrecisionCap f)
+  factorLatticeWithBound f (latticePrecisionCap f)
 
 -- Swinnerton-Dyer SD2 and Φ₁₅: irreducible over ℤ but split mod p; a cap-free
 -- CLD path misses, `factorLattice` certifies them as single irreducible factors.
@@ -10237,7 +10237,7 @@ a fallback was taken (the merge gate asserts this never happens unexpectedly).
 **Self-certifying.** Each non-backstop tier's `Factorization` is accepted only
 when it reconstructs the input (`Factorization.product φ = f`, decidable on
 `ZPoly`); on the (corpus-never) miss it falls through to the proven
-`factorSlowTrial` backstop. This makes `Factorization.product (factorHybrid f) = f`
+`factorTrial` backstop. This makes `Factorization.product (factorHybrid f) = f`
 provable unconditionally without yet proving the classical recombination loop
 reconstructs (that, with per-factor irreducibility, is the separate re-proof
 step). The classical tier is correct on the whole conformance corpus, so the
@@ -10246,13 +10246,13 @@ def factorHybridTraced (f : ZPoly) : Factorization × FactorTrace :=
   match factorClassicalTraced f with
   | (some φ, trace) =>
       if Factorization.product φ = f then (φ, trace)   -- classical answered, certified
-      else (factorSlowTrial f, { trace with tier := "trial", declined := true })
+      else (factorTrial f, { trace with tier := "trial", declined := true })
   | (none, trace) =>
       match factorLattice f with
       | some φ =>
           if Factorization.product φ = f then (φ, { trace with tier := "lattice" })
-          else (factorSlowTrial f, { trace with tier := "trial", declined := true })
-      | none => (factorSlowTrial f, { trace with tier := "trial" })  -- totality backstop
+          else (factorTrial f, { trace with tier := "trial", declined := true })
+      | none => (factorTrial f, { trace with tier := "trial" })  -- totality backstop
 
 /-- Cost-based hybrid factorisation: classical-first, lattice on decline, trial
 backstop. Total. Not yet the public `factor` (swap is a separate step). -/
@@ -10316,7 +10316,7 @@ theorem factorClassicalTracedWithBound_fst (f : ZPoly) (B : Nat) :
 through `factorizationOfFactors f`. -/
 theorem factorLattice_eq_map (f : ZPoly) :
     factorLattice f =
-      (factorLatticeFactorsWithBound f (factorFastPrecisionCap f)).map
+      (factorLatticeFactorsWithBound f (latticePrecisionCap f)).map
         (factorizationOfFactors f) := rfl
 
 /-- Raw factor array assembled by the cost-based hybrid, the bridge counterpart
@@ -10325,20 +10325,20 @@ of `factorHybridFactors`-consuming structural lemmas.
 Each non-backstop tier (`factorClassicalFactorsWithBound` / lattice) is accepted
 only when its `factorizationOfFactors`-packed answer reconstructs `f` (the
 self-certifying guard mirrored here), and every fallback is the proven
-`factorSlowTrial` backstop's raw array. The headline contract
+`factorTrial` backstop's raw array. The headline contract
 `factorHybrid f = factorizationOfFactors f (factorHybridFactors f)` is
 `factorHybrid_eq_factorizationOfFactors`. -/
 def factorHybridFactors (f : ZPoly) : Array ZPoly :=
   match factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) with
   | some cf =>
       if Factorization.product (factorizationOfFactors f cf) = f then cf
-      else factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+      else factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
   | none =>
-      match factorLatticeFactorsWithBound f (factorFastPrecisionCap f) with
+      match factorLatticeFactorsWithBound f (latticePrecisionCap f) with
       | some cf =>
           if Factorization.product (factorizationOfFactors f cf) = f then cf
-          else factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
-      | none => factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+          else factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
+      | none => factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
 
 /-- The cost-based hybrid factorisation is the `factorizationOfFactors`-packed
 form of its raw factor array `factorHybridFactors`. Every tier (classical /
@@ -10347,10 +10347,10 @@ the structural `factorizationOfFactors_entry_*` lemmas re-point every
 `factor`-level entry contract onto the hybrid. -/
 theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
     factorHybrid f = factorizationOfFactors f (factorHybridFactors f) := by
-  have htrial : factorSlowTrial f =
+  have htrial : factorTrial f =
       factorizationOfFactors f
-        (factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) := by
-    rw [factorSlowTrial, factorSlowTrialWithBound_eq_factorizationOfFactors]
+        (factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) := by
+    rw [factorTrial, factorTrialWithBound_eq_factorizationOfFactors]
   unfold factorHybrid factorHybridTraced factorHybridFactors
   have hclassical :
       (factorClassicalTraced f).1 =
@@ -10373,7 +10373,7 @@ theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
       subst hclassical
       simp only
       rw [factorLattice_eq_map]
-      cases hl : factorLatticeFactorsWithBound f (factorFastPrecisionCap f) with
+      cases hl : factorLatticeFactorsWithBound f (latticePrecisionCap f) with
       | some cf =>
           simp only [Option.map_some]
           by_cases hp : Factorization.product (factorizationOfFactors f cf) = f
@@ -10384,7 +10384,7 @@ theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
 
 /-- Every raw factor of the cost-based hybrid comes from one of its three
 dispatch branches: the classical tier's certified output, the CLD lattice
-tier's certified output, or the `factorSlowTrial` totality backstop. It
+tier's certified output, or the `factorTrial` totality backstop. It
 exposes the branch source (mirroring `factor_entry_mem_raw_source` for the
 raw hybrid array) without leaking the private `factorizationOfFactors` guard, so
 the Mathlib-side irreducibility assembly can case-split over the branches. -/
@@ -10392,15 +10392,15 @@ theorem factorHybridFactors_mem_source (f : ZPoly) {raw : ZPoly}
     (hmem : raw ∈ (factorHybridFactors f).toList) :
     (∃ cf, factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
         some cf ∧ raw ∈ cf.toList) ∨
-      (∃ cf, factorLatticeFactorsWithBound f (factorFastPrecisionCap f) =
+      (∃ cf, factorLatticeFactorsWithBound f (latticePrecisionCap f) =
         some cf ∧ raw ∈ cf.toList) ∨
-      raw ∈ (factorSlowTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).toList := by
+      raw ∈ (factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).toList := by
   unfold factorHybridFactors at hmem
   rcases Option.eq_none_or_eq_some
       (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) with hcf | ⟨cf, hcf⟩
   · simp only [hcf] at hmem
     rcases Option.eq_none_or_eq_some
-        (factorLatticeFactorsWithBound f (factorFastPrecisionCap f)) with hl | ⟨cf, hl⟩
+        (factorLatticeFactorsWithBound f (latticePrecisionCap f)) with hl | ⟨cf, hl⟩
     · simp only [hl] at hmem
       exact Or.inr (Or.inr hmem)
     · simp only [hl] at hmem
@@ -10420,7 +10420,7 @@ multi-factor inputs; nothing in the production path routes through it (the
 production `latticeCoreLoop` still consumes `bhksRecover?`). -/
 private def coreRecoverSmoke? (c : ZPoly) : Option (Array ZPoly) :=
   match choosePrimeData? c with
-  | some pd => coreRecover? c (ZPoly.coreLiftData c (factorFastPrecisionCap c) pd)
+  | some pd => coreRecover? c (ZPoly.coreLiftData c (latticePrecisionCap c) pd)
   | none => none
 
 -- `(2x+1)(x⁴+1)`: recovers the two integer factors in `core`'s own coordinate.
@@ -10480,7 +10480,7 @@ subset budget and its answer is accepted only when the packed product
 reconstructs `f`; on decline (budget exhaustion or no admissible prime) the
 CLD lattice tier runs at the lattice precision cap under the same
 self-certifying acceptance check; and any residual falls through to the
-`factorSlowTrial` totality backstop, which is `choosePrimeData?`-independent
+`factorTrial` totality backstop, which is `choosePrimeData?`-independent
 and so makes `factor` unconditionally correct on every `ZPoly`.
 -/
 def factor (f : ZPoly) : Factorization :=
@@ -13185,22 +13185,22 @@ private theorem bhksRecover?_product
 /-- A successful fixed-precision BHKS fast-recombination loop preserves the
 polynomial product: every success branch comes from the classified BHKS
 recovery success case, which already certifies `Array.polyProduct = core`. -/
-theorem factorFastCoreWithBound_product
+theorem bhksRecoveryCoreWithBound_product
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
     ∀ k fuel coreFactors,
-      factorFastCoreWithBound core B primeData k fuel = some coreFactors →
+      bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors →
         Array.polyProduct coreFactors = core := by
   intro k fuel
   induction fuel generalizing k with
   | zero =>
       intro coreFactors hfast
-      simp [factorFastCoreWithBound, factorFastCoreLoop] at hfast
+      simp [bhksRecoveryCoreWithBound, bhksRecoveryLoop] at hfast
   | succ fuel ih =>
       intro coreFactors hfast
-      rw [factorFastCoreWithBound_unfold] at hfast
+      rw [bhksRecoveryCoreWithBound_unfold] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          by_cases hfloor : k ≥ fastCoreFloor core
+          by_cases hfloor : k ≥ bhksRecoveryFloor core
           · simp [hclass, hfloor] at hfast
             cases hfast
             exact bhksRecoverClassified_success_product hclass
@@ -13229,7 +13229,7 @@ reconstruction: there is a positive-dimension witness `hrows` for which the
 equivalence-class indicator candidates reconstruct exactly to `candidates`, and
 the chosen indicator partition is non-degenerate. Private because the conclusion
 names `bhksRecoverClassified`; the public extractor
-`factorFastCoreWithBound_some_indicatorCandidates` re-exposes this in
+`bhksRecoveryCoreWithBound_some_indicatorCandidates` re-exposes this in
 `bhksRecoverClassified`-free form. -/
 private theorem bhksRecoverClassified_success_indicatorCandidates
     {f : ZPoly} {d : LiftData} {candidates : Array ZPoly}
@@ -13431,28 +13431,28 @@ private theorem bhksRecoverClassifiedCore_success_indicatorCandidates
 /-- A successful fast-recombination loop is witnessed by a concrete precision
 schedule index `k'` at which the classified BHKS recovery succeeds. This retains
 the successful `toMonicLiftData` precision that the per-factor success lemmas
-(`factorFastCoreWithBound_some_dvd`, `_shouldRecord`, …) discard, so proof-facing
+(`bhksRecoveryCoreWithBound_some_dvd`, `_shouldRecord`, …) discard, so proof-facing
 callers can reconstruct the underlying recovery data and indicator candidates.
 Private because the conclusion names `bhksRecoverClassified`; the public extractor
-`factorFastCoreWithBound_some_indicatorCandidates` re-exposes the recovery data in
+`bhksRecoveryCoreWithBound_some_indicatorCandidates` re-exposes the recovery data in
 `bhksRecoverClassified`-free form. -/
-private theorem factorFastCoreWithBound_some_classifiedSuccess
+private theorem bhksRecoveryCoreWithBound_some_classifiedSuccess
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
     ∀ k fuel coreFactors,
-      factorFastCoreWithBound core B primeData k fuel = some coreFactors →
+      bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors →
         ∃ k', bhksRecoverClassified core (ZPoly.toMonicLiftData core k' primeData) =
-          .success coreFactors ∧ fastCoreFloor core ≤ k' := by
+          .success coreFactors ∧ bhksRecoveryFloor core ≤ k' := by
   intro k fuel
   induction fuel generalizing k with
   | zero =>
       intro coreFactors hfast
-      simp [factorFastCoreWithBound, factorFastCoreLoop] at hfast
+      simp [bhksRecoveryCoreWithBound, bhksRecoveryLoop] at hfast
   | succ fuel ih =>
       intro coreFactors hfast
-      rw [factorFastCoreWithBound_unfold] at hfast
+      rw [bhksRecoveryCoreWithBound_unfold] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          by_cases hfloor : k ≥ fastCoreFloor core
+          by_cases hfloor : k ≥ bhksRecoveryFloor core
           · simp [hclass, hfloor] at hfast
             cases hfast
             exact ⟨k, hclass, hfloor⟩
@@ -13478,17 +13478,17 @@ private theorem factorFastCoreWithBound_some_classifiedSuccess
 
 /-- Proof-facing recovery-data extractor for the fast-recombination loop, stated
 without reference to the private `bhksRecoverClassified`. A successful
-`factorFastCoreWithBound` call is witnessed by a concrete precision-schedule index
+`bhksRecoveryCoreWithBound` call is witnessed by a concrete precision-schedule index
 `k'`: at the `toMonicLiftData` for that precision there is a positive-dimension
 witness `hrows` whose equivalence-class indicator candidates reconstruct exactly
 to `coreFactors`, the indicator partition is non-degenerate, and the candidates
 multiply back to `core`. This is the bridge-side entry point used to rebuild the
 forward-recovery package (and hence the selected support/subset witnesses) that
 the per-factor success lemmas discard. -/
-theorem factorFastCoreWithBound_some_indicatorCandidates
+theorem bhksRecoveryCoreWithBound_some_indicatorCandidates
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array ZPoly}
-    (h : factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (h : bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors) :
     ∃ k',
       ∃ hrows :
         1 ≤ (bhksLatticeBasis (ZPoly.toMonic core).monic
@@ -13523,14 +13523,14 @@ theorem factorFastCoreWithBound_some_indicatorCandidates
                 (ZPoly.toMonicLiftData core k' primeData).liftedFactors)
               hrows)) =
         false ∧
-      Array.polyProduct coreFactors = core ∧ fastCoreFloor core ≤ k' := by
+      Array.polyProduct coreFactors = core ∧ bhksRecoveryFloor core ≤ k' := by
   obtain ⟨k', hsuccess, hfloor⟩ :=
-    factorFastCoreWithBound_some_classifiedSuccess core B primeData k fuel coreFactors h
+    bhksRecoveryCoreWithBound_some_classifiedSuccess core B primeData k fuel coreFactors h
   obtain ⟨hrows, hcand, hdeg⟩ :=
     bhksRecoverClassified_success_indicatorCandidates hsuccess
   exact ⟨k', hrows, hcand, hdeg, bhksRecoverClassified_success_product hsuccess, hfloor⟩
 
-private theorem factorFastCoreWithBound_some_all_of_recovery
+private theorem bhksRecoveryCoreWithBound_some_all_of_recovery
     (P : ZPoly → Prop)
     (hrecover :
       ∀ {core : ZPoly} {d : LiftData} {candidates : Array ZPoly},
@@ -13538,19 +13538,19 @@ private theorem factorFastCoreWithBound_some_all_of_recovery
           ∀ factor ∈ candidates.toList, P factor)
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
     ∀ k fuel coreFactors,
-      factorFastCoreWithBound core B primeData k fuel = some coreFactors →
+      bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors →
         ∀ factor ∈ coreFactors.toList, P factor := by
   intro k fuel
   induction fuel generalizing k with
   | zero =>
       intro coreFactors hfast
-      simp [factorFastCoreWithBound, factorFastCoreLoop] at hfast
+      simp [bhksRecoveryCoreWithBound, bhksRecoveryLoop] at hfast
   | succ fuel ih =>
       intro coreFactors hfast
-      rw [factorFastCoreWithBound_unfold] at hfast
+      rw [bhksRecoveryCoreWithBound_unfold] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          by_cases hfloor : k ≥ fastCoreFloor core
+          by_cases hfloor : k ≥ bhksRecoveryFloor core
           · simp [hclass, hfloor] at hfast
             cases hfast
             exact hrecover hclass
@@ -13574,32 +13574,32 @@ private theorem factorFastCoreWithBound_some_all_of_recovery
           · simp [hclass, hk] at hfast
             exact ih _ coreFactors hfast
 
-theorem factorFastCoreWithBound_some_normalizeFactorSign
+theorem bhksRecoveryCoreWithBound_some_normalizeFactorSign
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array ZPoly}
-    (h : factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (h : bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors) :
     ∀ factor ∈ coreFactors.toList, normalizeFactorSign factor = factor :=
-  factorFastCoreWithBound_some_all_of_recovery
+  bhksRecoveryCoreWithBound_some_all_of_recovery
     (fun factor => normalizeFactorSign factor = factor)
     (fun hrecover => bhksRecoverClassified_success_normalizeFactorSign hrecover)
     core B primeData k fuel coreFactors h
 
-theorem factorFastCoreWithBound_some_shouldRecord
+theorem bhksRecoveryCoreWithBound_some_shouldRecord
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array ZPoly}
-    (h : factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (h : bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors) :
     ∀ factor ∈ coreFactors.toList, shouldRecordPolynomialFactor factor = true :=
-  factorFastCoreWithBound_some_all_of_recovery
+  bhksRecoveryCoreWithBound_some_all_of_recovery
     (fun factor => shouldRecordPolynomialFactor factor = true)
     (fun hrecover => bhksRecoverClassified_success_shouldRecord hrecover)
     core B primeData k fuel coreFactors h
 
-theorem factorFastCoreWithBound_some_degree_pos
+theorem bhksRecoveryCoreWithBound_some_degree_pos
     {core : ZPoly} {B : Nat} {primeData : PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array ZPoly}
-    (h : factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (h : bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors) :
     ∀ factor ∈ coreFactors.toList, 0 < factor.degree?.getD 0 :=
-  factorFastCoreWithBound_some_all_of_recovery
+  bhksRecoveryCoreWithBound_some_all_of_recovery
     (fun factor => 0 < factor.degree?.getD 0)
     (fun hrecover =>
       bhksRecoverClassified_success_all_of_candidates
@@ -13611,22 +13611,22 @@ theorem factorFastCoreWithBound_some_degree_pos
 input core. The success branch is the only branch that exits with
 `some coreFactors`, and `bhksRecoverClassified_success_dvd` certifies
 divisibility for each candidate at that exit. -/
-theorem factorFastCoreWithBound_some_dvd
+theorem bhksRecoveryCoreWithBound_some_dvd
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
     ∀ k fuel coreFactors,
-      factorFastCoreWithBound core B primeData k fuel = some coreFactors →
+      bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors →
         ∀ factor ∈ coreFactors.toList, factor ∣ core := by
   intro k fuel
   induction fuel generalizing k with
   | zero =>
       intro coreFactors hfast
-      simp [factorFastCoreWithBound, factorFastCoreLoop] at hfast
+      simp [bhksRecoveryCoreWithBound, bhksRecoveryLoop] at hfast
   | succ fuel ih =>
       intro coreFactors hfast
-      rw [factorFastCoreWithBound_unfold] at hfast
+      rw [bhksRecoveryCoreWithBound_unfold] at hfast
       cases hclass : bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
       | success xs =>
-          by_cases hfloor : k ≥ fastCoreFloor core
+          by_cases hfloor : k ≥ bhksRecoveryFloor core
           · simp [hclass, hfloor] at hfast
             cases hfast
             exact bhksRecoverClassified_success_dvd hclass
@@ -13931,7 +13931,7 @@ theorem classicalCoreFactorsWithBound_degree_pos
 /-- Structural case-split for the van Hoeij lattice-tier core. Every `some cf`
 result of `latticeCoreFactorsWithBound` is either the singleton `#[core]` (the
 small-mod arm, the loop's certificate-backed early stop, and the cap all-ones
-certification arm) or a `factorFastCoreWithBound` success (the CLD-split arm,
+certification arm) or a `bhksRecoveryCoreWithBound` success (the CLD-split arm,
 via `latticeCoreWithBound_some_spec`). The trio
 `latticeCoreFactorsWithBound_{polyProduct,normalizeFactorSign,degree_pos}`
 below are thin consumers, mirroring the classical structural trio. -/
@@ -13940,7 +13940,7 @@ private theorem latticeCoreFactorsWithBound_spec
     {cf : Array ZPoly}
     (h : latticeCoreFactorsWithBound core B primeData = some cf) :
     cf = #[core] ∨
-      factorFastCoreWithBound core B primeData (initialHenselPrecision B)
+      bhksRecoveryCoreWithBound core B primeData (initialHenselPrecision B)
         (ZPoly.quadraticDoublingSteps B + 2) = some cf := by
   rw [latticeCoreFactorsWithBound] at h
   split at h
@@ -13959,7 +13959,7 @@ private theorem latticeCoreFactorsWithBound_spec
 /-- PolyProduct identity for the van Hoeij lattice-tier core: every emitted
 factor array multiplies back to `core`. Mirror of
 `classicalCoreFactorsWithBound_polyProduct`; the singleton arms are immediate
-and the CLD-split arm reuses `factorFastCoreWithBound_product`. -/
+and the CLD-split arm reuses `bhksRecoveryCoreWithBound_product`. -/
 theorem latticeCoreFactorsWithBound_polyProduct
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData)
     {cf : Array ZPoly}
@@ -13967,7 +13967,7 @@ theorem latticeCoreFactorsWithBound_polyProduct
     Array.polyProduct cf = core := by
   rcases latticeCoreFactorsWithBound_spec core B primeData h with hsing | hfast
   · rw [hsing]; exact ZPoly.polyProduct_singleton core
-  · exact factorFastCoreWithBound_product core B primeData _ _ cf hfast
+  · exact bhksRecoveryCoreWithBound_product core B primeData _ _ cf hfast
 
 /-- Each factor emitted by the van Hoeij lattice-tier core is fixed by
 `normalizeFactorSign`, provided `core` has positive leading coefficient. Mirror
@@ -13986,7 +13986,7 @@ theorem latticeCoreFactorsWithBound_normalizeFactorSign
     have hfactor : factor = core := by simpa using hmem
     rw [hfactor]
     exact normalizeFactorSign_eq_self_of_leadingCoeff_nonneg core (by omega)
-  · exact factorFastCoreWithBound_some_normalizeFactorSign hfast
+  · exact bhksRecoveryCoreWithBound_some_normalizeFactorSign hfast
 
 /-- Each factor emitted by the van Hoeij lattice-tier core has positive
 `degree?`, provided `core` itself has positive degree. Mirror of
@@ -14004,7 +14004,7 @@ theorem latticeCoreFactorsWithBound_degree_pos
     rw [hsing] at hmem
     have hfactor : factor = core := by simpa using hmem
     rw [hfactor]; exact hcore_deg
-  · exact factorFastCoreWithBound_some_degree_pos hfast
+  · exact bhksRecoveryCoreWithBound_some_degree_pos hfast
 
 private theorem polyProduct_push (factors : Array ZPoly) (factor : ZPoly) :
     Array.polyProduct (factors.push factor) =
@@ -18739,11 +18739,11 @@ private theorem polyProduct_filteredNormalizedFactors_append_one_of_all_recorded
   rw [filteredNormalizedFactors_append_one_of_all_recorded_normalized
     factors.toList hnormalized hrecorded]
 
-theorem factorSlowTrialFactorsWithBound_polyProduct
+theorem factorTrialFactorsWithBound_polyProduct
     (f : ZPoly) (B : Nat) :
     DensePoly.C (signedContentScalar f) *
-      Array.polyProduct (factorSlowTrialFactorsWithBound f B) = f := by
-  unfold factorSlowTrialFactorsWithBound
+      Array.polyProduct (factorTrialFactorsWithBound f B) = f := by
+  unfold factorTrialFactorsWithBound
   by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
   · simp only [hdeg, if_true]
     exact reassemblePolynomialFactors_product_eq_input f
@@ -18816,27 +18816,27 @@ private theorem primitive_of_signedContentScalar_mul_eq
   · show ZPoly.content P = 1
     omega
 
-private theorem factorSlowTrialWithBound_product_of_all_recorded_normalized
+private theorem factorTrialWithBound_product_of_all_recorded_normalized
     (f : ZPoly) (B : Nat)
     (hnormalized :
-      ∀ factor ∈ (factorSlowTrialFactorsWithBound f B).toList,
+      ∀ factor ∈ (factorTrialFactorsWithBound f B).toList,
         normalizeFactorSign factor = factor)
     (hrecorded :
-      ∀ factor ∈ (factorSlowTrialFactorsWithBound f B).toList,
+      ∀ factor ∈ (factorTrialFactorsWithBound f B).toList,
         shouldRecordPolynomialFactor factor = true) :
-    Factorization.product (factorSlowTrialWithBound f B) = f := by
-  unfold factorSlowTrialWithBound
+    Factorization.product (factorTrialWithBound f B) = f := by
+  unfold factorTrialWithBound
   exact
     factorizationOfFactors_product_of_raw_product_of_all_recorded_normalized
-      f (factorSlowTrialFactorsWithBound f B)
-      (factorSlowTrialFactorsWithBound_polyProduct f B) hnormalized hrecorded
+      f (factorTrialFactorsWithBound f B)
+      (factorTrialFactorsWithBound_polyProduct f B) hnormalized hrecorded
 
-private theorem factorSlowTrialWithBound_product_of_constant_branch
+private theorem factorTrialWithBound_product_of_constant_branch
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hbranch : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0) :
-    Factorization.product (factorSlowTrialWithBound f B) = f := by
-  unfold factorSlowTrialWithBound factorSlowTrialFactorsWithBound
+    Factorization.product (factorTrialWithBound f B) = f := by
+  unfold factorTrialWithBound factorTrialFactorsWithBound
   rw [if_pos hbranch]
   have hcore_one := squareFreeCore_eq_one_of_constant_of_ne_zero f hf hbranch
   rw [hcore_one]
@@ -18855,16 +18855,16 @@ private theorem factorSlowTrialWithBound_product_of_constant_branch
       exact polynomialNormalizationPrefixFactors_shouldRecord_of_ne_zero
         f hf factor hmem
 
-private theorem factorSlowTrialWithBound_product_of_quadratic_branch
+private theorem factorTrialWithBound_product_of_quadratic_branch
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (coreFactors : Array ZPoly)
     (hquad : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore =
       some coreFactors) :
-    Factorization.product (factorSlowTrialWithBound f B) = f := by
-  apply factorSlowTrialWithBound_product_of_all_recorded_normalized
-  · unfold factorSlowTrialFactorsWithBound
+    Factorization.product (factorTrialWithBound f B) = f := by
+  apply factorTrialWithBound_product_of_all_recorded_normalized
+  · unfold factorTrialFactorsWithBound
     rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
@@ -18872,7 +18872,7 @@ private theorem factorSlowTrialWithBound_product_of_quadratic_branch
     intro c hc
     exact quadraticIntegerRootFactors?_normalizeFactorSign
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) hquad c hc
-  · unfold factorSlowTrialFactorsWithBound
+  · unfold factorTrialFactorsWithBound
     rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
@@ -18881,14 +18881,14 @@ private theorem factorSlowTrialWithBound_product_of_quadratic_branch
     exact quadraticIntegerRootFactors?_shouldRecord
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) hquad c hc
 
-private theorem factorSlowTrialWithBound_product_of_trial_branch
+private theorem factorTrialWithBound_product_of_trial_branch
     (f : ZPoly) (B : Nat)
     (hf : f ≠ 0)
     (hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (hquad : quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore = none) :
-    Factorization.product (factorSlowTrialWithBound f B) = f := by
-  apply factorSlowTrialWithBound_product_of_all_recorded_normalized
-  · unfold factorSlowTrialFactorsWithBound
+    Factorization.product (factorTrialWithBound f B) = f := by
+  apply factorTrialWithBound_product_of_all_recorded_normalized
+  · unfold factorTrialFactorsWithBound
     rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_normalizeFactorSign_of_ne_zero f hf
@@ -18899,7 +18899,7 @@ private theorem factorSlowTrialWithBound_product_of_trial_branch
     exact exhaustiveIntegerTrialCoreFactorsWithBound_normalizeFactorSign
       (normalizeForFactor f).squareFreeCore B
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) c hc
-  · unfold factorSlowTrialFactorsWithBound
+  · unfold factorTrialFactorsWithBound
     rw [if_neg hdeg, hquad]
     intro factor hmem
     refine reassemblePolynomialFactors_shouldRecord_of_ne_zero f hf
@@ -18911,32 +18911,32 @@ private theorem factorSlowTrialWithBound_product_of_trial_branch
       (normalizeForFactor f).squareFreeCore B
       (squareFreeCore_leadingCoeff_pos_of_ne_zero f hf) c hc
 
-theorem factorSlowTrialWithBound_product (f : ZPoly) (B : Nat) :
-    Factorization.product (factorSlowTrialWithBound f B) = f := by
+theorem factorTrialWithBound_product (f : ZPoly) (B : Nat) :
+    Factorization.product (factorTrialWithBound f B) = f := by
   by_cases hf : f = 0
   · subst f
-    unfold factorSlowTrialWithBound
-    exact factorizationOfFactors_product_of_zero (factorSlowTrialFactorsWithBound 0 B)
+    unfold factorTrialWithBound
+    exact factorizationOfFactors_product_of_zero (factorTrialFactorsWithBound 0 B)
   · by_cases hdeg : (normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
-    · exact factorSlowTrialWithBound_product_of_constant_branch f B hf hdeg
+    · exact factorTrialWithBound_product_of_constant_branch f B hf hdeg
     · cases hquad :
         quadraticIntegerRootFactors? (normalizeForFactor f).squareFreeCore with
       | some coreFactors =>
-          exact factorSlowTrialWithBound_product_of_quadratic_branch
+          exact factorTrialWithBound_product_of_quadratic_branch
             f B hf hdeg coreFactors hquad
       | none =>
-          exact factorSlowTrialWithBound_product_of_trial_branch
+          exact factorTrialWithBound_product_of_trial_branch
             f B hf hdeg hquad
 
 /-- Product contract for the public trial-division slow-path entry point. -/
-theorem factorSlowTrial_product (f : ZPoly) :
-    Factorization.product (factorSlowTrial f) = f := by
-  exact factorSlowTrialWithBound_product f (ZPoly.defaultFactorCoeffBound f)
+theorem factorTrial_product (f : ZPoly) :
+    Factorization.product (factorTrial f) = f := by
+  exact factorTrialWithBound_product f (ZPoly.defaultFactorCoeffBound f)
 
 /-- Product preservation for the cost-based hybrid. Holds unconditionally: each
 non-backstop tier's result is accepted only when it reconstructs `f` (the
 self-certifying guard in `factorHybridTraced`), and every fallback is the proven
-`factorSlowTrial` backstop. This is the headline contract the public `factor`
+`factorTrial` backstop. This is the headline contract the public `factor`
 swap inherits, established without proving the classical recombination loop
 reconstructs (that, with per-factor irreducibility, is the still-blocked re-proof
 capstone #8384). -/
@@ -18948,14 +18948,14 @@ theorem factorHybrid_product (f : ZPoly) :
   | some φ =>
       by_cases hp : Factorization.product φ = f
       · simp [hp]
-      · simp only [hp, if_false]; exact factorSlowTrial_product f
+      · simp only [hp, if_false]; exact factorTrial_product f
   | none =>
       cases hl : factorLattice f with
       | some φ =>
           by_cases hp : Factorization.product φ = f
           · simp [hp]
-          · simp only [hp, if_false]; exact factorSlowTrial_product f
-      | none => exact factorSlowTrial_product f
+          · simp only [hp, if_false]; exact factorTrial_product f
+      | none => exact factorTrial_product f
 
 /-- Product contract for the public total factorization entry point: the
 self-certifying hybrid always reconstructs its input. -/

--- a/HexBerlekampZassenhaus/CrossCheck.lean
+++ b/HexBerlekampZassenhaus/CrossCheck.lean
@@ -15,7 +15,7 @@ Mode: always
 `SPEC/Libraries/hex-berlekamp-zassenhaus.md` pins the production fast path
 to the van Hoeij/BHKS CLD lattice, with exhaustive subset recombination
 retained only as the slow backstop.  This module operationalises that
-contract: for each fixture polynomial we run `factorSlowTrial`, and when
+contract: for each fixture polynomial we run `factorTrial`, and when
 fixed-precision `bhksRecover?` returns `some` on the committed lifted-factor
 set we check that the certified fast result preserves the same input product.
 If fixed-precision recovery returns `none`, the fast path has made no
@@ -128,11 +128,11 @@ the fixture product when recovery succeeds.
 
 The `none` branch means the fixed-precision fast path did not certify a
 recombination at `liftP ^ liftK`; it is accepted here because the public
-factorization API falls back to `factorSlowTrial` in that case. -/
+factorization API falls back to `factorTrial` in that case. -/
 private def crossCheck (roots : List Int) : Bool :=
   let f := fromRoots roots
   let liftData := liftDataOf roots
-  let slow := factorSlowTrial f
+  let slow := factorTrial f
   let fastMatches :=
     match bhksRecover? f liftData with
     | none => true
@@ -164,7 +164,7 @@ return `none`; if it returns `some`, the recovered buckets must match the
 committed integer factorization shape. -/
 private def crossCheckBuckets
     (f : ZPoly) (liftData : LiftData) (expectedFactors : Array ZPoly) : Bool :=
-  let slow := factorSlowTrial f
+  let slow := factorTrial f
   let fastMatches :=
     match bhksRecover? f liftData with
     | none => true

--- a/HexBerlekampZassenhausMathlib/Basic.lean
+++ b/HexBerlekampZassenhausMathlib/Basic.lean
@@ -16455,11 +16455,11 @@ in `HexBerlekampZassenhaus/Basic.lean` with the `toPolynomial` map.
 The remaining count-equality hypothesis is the open obligation of
 #4022 — once supplied, this lemma feeds directly into
 `HexBerlekampZassenhausMathlib.UFDPartition.irreducible_of_partition_card_eq_normalizedFactors_card`. -/
-theorem factorFastCoreWithBound_some_factor_irreducible_of_count
+theorem bhksRecoveryCoreWithBound_some_factor_irreducible_of_count
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
     (hcore_ne : core ≠ 0)
-    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (h : Hex.bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors)
     (hcount :
       (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
         (UniqueFactorizationMonoid.normalizedFactors
@@ -16476,7 +16476,7 @@ theorem factorFastCoreWithBound_some_factor_irreducible_of_count
     coreFactors.toList.map HexPolyZMathlib.toPolynomial with hgs_def
   have hprod : Associated gs.prod f := by
     have hp_core : Array.polyProduct coreFactors = core :=
-      Hex.factorFastCoreWithBound_product core B primeData k fuel coreFactors h
+      Hex.bhksRecoveryCoreWithBound_product core B primeData k fuel coreFactors h
     have hp_poly :
         (coreFactors.toList.map HexPolyZMathlib.toPolynomial).prod =
           HexPolyZMathlib.toPolynomial core := by
@@ -16484,11 +16484,11 @@ theorem factorFastCoreWithBound_some_factor_irreducible_of_count
     rw [hgs_def, hp_poly, hf_def]
   have hdvd_all :
       ∀ factor ∈ coreFactors.toList, factor ∣ core :=
-    Hex.factorFastCoreWithBound_some_dvd core B primeData k fuel coreFactors h
+    Hex.bhksRecoveryCoreWithBound_some_dvd core B primeData k fuel coreFactors h
   have hrecord_all :
       ∀ factor ∈ coreFactors.toList,
         Hex.shouldRecordPolynomialFactor factor = true :=
-    Hex.factorFastCoreWithBound_some_shouldRecord h
+    Hex.bhksRecoveryCoreWithBound_some_shouldRecord h
   have hne_all : ∀ g ∈ gs, g ≠ 0 := by
     intro g hg
     rw [hgs_def, List.mem_map] at hg
@@ -16519,11 +16519,11 @@ theorem factorFastCoreWithBound_some_factor_irreducible_of_count
 The emitted factor list consists of non-zero non-units whose product is
 associated to `core`, so the abstract UFD partition bound applies after
 transporting the executable factors to `Polynomial ℤ`. -/
-theorem factorFastCoreWithBound_some_factor_count_le
+theorem bhksRecoveryCoreWithBound_some_factor_count_le
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
     (hcore_ne : core ≠ 0)
-    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors) :
+    (h : Hex.bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors) :
     (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length ≤
       (UniqueFactorizationMonoid.normalizedFactors
         (HexPolyZMathlib.toPolynomial core)).card := by
@@ -16537,7 +16537,7 @@ theorem factorFastCoreWithBound_some_factor_count_le
     coreFactors.toList.map HexPolyZMathlib.toPolynomial with hgs_def
   have hprod : Associated gs.prod f := by
     have hp_core : Array.polyProduct coreFactors = core :=
-      Hex.factorFastCoreWithBound_product core B primeData k fuel coreFactors h
+      Hex.bhksRecoveryCoreWithBound_product core B primeData k fuel coreFactors h
     have hp_poly :
         (coreFactors.toList.map HexPolyZMathlib.toPolynomial).prod =
           HexPolyZMathlib.toPolynomial core := by
@@ -16546,7 +16546,7 @@ theorem factorFastCoreWithBound_some_factor_count_le
   have hrecord_all :
       ∀ factor ∈ coreFactors.toList,
         Hex.shouldRecordPolynomialFactor factor = true :=
-    Hex.factorFastCoreWithBound_some_shouldRecord h
+    Hex.bhksRecoveryCoreWithBound_some_shouldRecord h
   have hne_all : ∀ g ∈ gs, g ≠ 0 := by
     intro g hg
     rw [hgs_def, List.mem_map] at hg
@@ -16574,11 +16574,11 @@ The remaining BHKS/B8 work is to derive the `hirr` hypothesis from the
 equivalence-class partition-refinement argument for the concrete success
 state.  Once supplied, the abstract UFD partition theorem gives the reverse
 count inequality needed to pair with
-`factorFastCoreWithBound_some_factor_count_le`. -/
-theorem factorFastCoreWithBound_some_factor_count_ge_of_irreducible
+`bhksRecoveryCoreWithBound_some_factor_count_le`. -/
+theorem bhksRecoveryCoreWithBound_some_factor_count_ge_of_irreducible
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
-    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (h : Hex.bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors)
     (hirr :
       ∀ factor ∈ coreFactors.toList,
         Irreducible (HexPolyZMathlib.toPolynomial factor)) :
@@ -16590,7 +16590,7 @@ theorem factorFastCoreWithBound_some_factor_count_ge_of_irreducible
     coreFactors.toList.map HexPolyZMathlib.toPolynomial with hgs_def
   have hprod : Associated gs.prod f := by
     have hp_core : Array.polyProduct coreFactors = core :=
-      Hex.factorFastCoreWithBound_product core B primeData k fuel coreFactors h
+      Hex.bhksRecoveryCoreWithBound_product core B primeData k fuel coreFactors h
     have hp_poly :
         (coreFactors.toList.map HexPolyZMathlib.toPolynomial).prod =
           HexPolyZMathlib.toPolynomial core := by
@@ -16608,11 +16608,11 @@ theorem factorFastCoreWithBound_some_factor_count_ge_of_irreducible
 
 /-- Cardinality equality for a successful BHKS fast-core branch once the
 BHKS/B8 proof has certified every emitted candidate irreducible. -/
-theorem factorFastCoreWithBound_some_factor_count_eq_of_irreducible
+theorem bhksRecoveryCoreWithBound_some_factor_count_eq_of_irreducible
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
     (hcore_ne : core ≠ 0)
-    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (h : Hex.bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors)
     (hirr :
       ∀ factor ∈ coreFactors.toList,
         Irreducible (HexPolyZMathlib.toPolynomial factor)) :
@@ -16620,12 +16620,12 @@ theorem factorFastCoreWithBound_some_factor_count_eq_of_irreducible
       (UniqueFactorizationMonoid.normalizedFactors
         (HexPolyZMathlib.toPolynomial core)).card := by
   apply le_antisymm
-  · exact factorFastCoreWithBound_some_factor_count_le hcore_ne h
-  · exact factorFastCoreWithBound_some_factor_count_ge_of_irreducible h hirr
+  · exact bhksRecoveryCoreWithBound_some_factor_count_le hcore_ne h
+  · exact bhksRecoveryCoreWithBound_some_factor_count_ge_of_irreducible h hirr
 
 /-- Branch-local fast-core success irreducibility, expressed in the Mathlib-free
 `Hex.ZPoly.Irreducible` predicate. This is the `Hex.ZPoly` transport of
-`factorFastCoreWithBound_some_factor_irreducible_of_count`, obtained by
+`bhksRecoveryCoreWithBound_some_factor_irreducible_of_count`, obtained by
 composing that scaffold with the existing
 `Hex.ZPoly.Irreducible_iff_polynomialIrreducible` equivalence.
 
@@ -16633,11 +16633,11 @@ The remaining count-equality hypothesis is the residual #4030 obligation; once
 supplied, this lemma yields fast-core branch irreducibility directly in the
 executable `Hex.ZPoly` form needed by callers that do not import Mathlib's
 `Polynomial` model. -/
-theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count
+theorem bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_count
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {k fuel : Nat} {coreFactors : Array Hex.ZPoly}
     (hcore_ne : core ≠ 0)
-    (h : Hex.factorFastCoreWithBound core B primeData k fuel = some coreFactors)
+    (h : Hex.bhksRecoveryCoreWithBound core B primeData k fuel = some coreFactors)
     (hcount :
       (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
         (UniqueFactorizationMonoid.normalizedFactors
@@ -16646,7 +16646,7 @@ theorem factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count
   intro factor hfactor_mem
   exact
     (Hex.ZPoly.Irreducible_iff_polynomialIrreducible factor).mpr
-      (factorFastCoreWithBound_some_factor_irreducible_of_count
+      (bhksRecoveryCoreWithBound_some_factor_irreducible_of_count
         hcore_ne h hcount factor hfactor_mem)
 
 /--

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -3757,7 +3757,7 @@ The divisor coefficient bound is discharged directly by
 `defaultFactorCoeffBound_valid` applied to the (nonzero) square-free core.
 This is the natural specialisation for callers that have already routed
 through the core's intrinsic Mignotte data; the public slow-trial dispatch
-in `Hex.factorSlowTrialFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f)`
+in `Hex.factorTrialFactorsWithBound f (Hex.ZPoly.defaultFactorCoeffBound f)`
 uses the outer bound `Hex.ZPoly.defaultFactorCoeffBound f`, which requires
 an additional `(Hex.normalizeForFactor f).squareFreeCore ∣ f` divisibility
 chain (tracked separately) to discharge against this wrapper's `hbound`. -/
@@ -3974,7 +3974,7 @@ theorem fastCoreReassemblyComplete_of_coreIrreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     {expectedFactors : Array Hex.ZPoly}
     (hcore :
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
+      Hex.bhksRecoveryCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B
         primeData (Hex.initialHenselPrecision B)
         (Hex.ZPoly.quadraticDoublingSteps B + 2) =
           some expectedFactors)
@@ -3984,18 +3984,18 @@ theorem fastCoreReassemblyComplete_of_coreIrreducible
       Array.polyProduct expectedFactors =
         (Hex.normalizeForFactor f).squareFreeCore := by
     simpa using
-      Hex.factorFastCoreWithBound_product
+      Hex.bhksRecoveryCoreWithBound_product
         (Hex.normalizeForFactor f).squareFreeCore B primeData
         (Hex.initialHenselPrecision B) (Hex.ZPoly.quadraticDoublingSteps B + 2)
         expectedFactors hcore
   have hnorm :
       ∀ q ∈ expectedFactors.toList, Hex.normalizeFactorSign q = q := by
     intro q hq
-    exact Hex.factorFastCoreWithBound_some_normalizeFactorSign hcore q hq
+    exact Hex.bhksRecoveryCoreWithBound_some_normalizeFactorSign hcore q hq
   have hdegree :
       ∀ q ∈ expectedFactors.toList, 0 < q.degree?.getD 0 := by
     intro q hq
-    exact Hex.factorFastCoreWithBound_some_degree_pos hcore q hq
+    exact Hex.bhksRecoveryCoreWithBound_some_degree_pos hcore q hq
   have hpos_lc :
       ∀ q ∈ expectedFactors.toList, 0 < Hex.DensePoly.leadingCoeff q := by
     intro q hq
@@ -4378,17 +4378,17 @@ short-circuit is reachable, the raw output can contain the unit `1`, so the
 statement carries the `shouldRecordPolynomialFactor` guard that excludes it.  The
 two positive-degree arms reuse the quadratic and exhaustive integer-trial
 completeness/irreducibility content. -/
-theorem factorSlowTrialFactorsWithBound_factor_irreducible
+theorem factorTrialFactorsWithBound_factor_irreducible
     (f : Hex.ZPoly) (hf : f ≠ 0)
     {raw : Hex.ZPoly}
-    (hmem : raw ∈ (Hex.factorSlowTrialFactorsWithBound f
+    (hmem : raw ∈ (Hex.factorTrialFactorsWithBound f
       (Hex.ZPoly.defaultFactorCoeffBound f)).toList)
     (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
     Hex.ZPoly.Irreducible raw := by
   have hcore_pos := Hex.squareFreeCore_leadingCoeff_pos_of_ne_zero f hf
   have hcore_prim :=
     IntReductionMod.normalizeForFactor_squareFreeCore_primitive_of_ne_zero f hf
-  simp only [Hex.factorSlowTrialFactorsWithBound] at hmem
+  simp only [Hex.factorTrialFactorsWithBound] at hmem
   by_cases hdeg : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 = 0
   · rw [if_pos hdeg] at hmem
     have hcomplete := Hex.reassemblyExpansionComplete_constant_of_ne_zero f hf hdeg

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -25,9 +25,9 @@ Hensel seeds match the lift target; #8519) it has three arms:
 
 2. `latticeCoreWithBound … = some coreFactors` → those factors.  Via
    `latticeCoreWithBound_some_spec` this is either a genuine CLD split (a
-   `factorFastCoreWithBound` success; irreducibility of the emitted factors is
+   `bhksRecoveryCoreWithBound` success; irreducibility of the emitted factors is
    the BHKS count-equality obligation, already isolated by
-   `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count` and threaded
+   `bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_count` and threaded
    here as the `harm2_count` hypothesis), or the certificate-backed early stop
    (#8395): `some #[core]` with a witness precision `k'` at/above the
    column-adequacy floor whose partition is the single all-ones class,
@@ -64,9 +64,9 @@ The arms of `latticeCoreFactorsWithBound` are discharged as follows:
   proved unconditionally from `squareFreeCore_irreducible_of_toMonicSmallModSingletonBranch`;
 * the loop-answer arm (`latticeCoreWithBound = some coreFactors`) splits via
   `latticeCoreWithBound_some_spec` into the CLD-split case (a genuine
-  `factorFastCoreWithBound` success, discharged from the count-equality
+  `bhksRecoveryCoreWithBound` success, discharged from the count-equality
   hypothesis `harm2_count` via
-  `factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count`) and the
+  `bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_count`) and the
   certificate-backed early stop (#8395: output `#[core]` with a witness
   precision `k'` clearing the column-adequacy floor, discharged from the
   adequacy hypothesis `harm3_adequacy` at `k'`);
@@ -84,20 +84,20 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hB_floor : Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
+    (hB_floor : Hex.bhksRecoveryFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
     (hB_ne : B ≠ 0)
     {cf : Array Hex.ZPoly}
     (hlattice : Hex.latticeCoreFactorsWithBound
       (Hex.normalizeForFactor f).squareFreeCore B primeData = some cf)
     (harm2_count : ∀ coreFactors : Array Hex.ZPoly,
-      Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B primeData
+      Hex.bhksRecoveryCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B primeData
           (Hex.initialHenselPrecision B) (Hex.ZPoly.quadraticDoublingSteps B + 2)
           = some coreFactors →
       (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
         (UniqueFactorizationMonoid.normalizedFactors
           (HexPolyZMathlib.toPolynomial (Hex.normalizeForFactor f).squareFreeCore)).card)
     (harm3_adequacy : ∀ B' : Nat,
-      Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B' → B' ≠ 0 →
+      Hex.bhksRecoveryFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B' → B' ≠ 0 →
       Hex.bhksSingleAllOnesPartition (Hex.normalizeForFactor f).squareFreeCore
           (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore B' primeData)
           = true →
@@ -130,18 +130,18 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible_of_bh
       obtain rfl := Option.some.inj hlattice
       rcases Hex.latticeCoreWithBound_some_spec hloop with
         hfast | ⟨rfl, k', hk'_floor, hk'_bhks⟩
-      · exact factorFastCoreWithBound_some_factor_zpolyIrreducible_of_count
+      · exact bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible_of_count
           hcore_ne hfast (harm2_count coreFactors hfast)
       · have hk'_ne : k' ≠ 0 := by
           have hpos := Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hcore_ne
-          have hfl := Hex.defaultFactorCoeffBound_le_fastCoreFloor core
+          have hfl := Hex.defaultFactorCoeffBound_le_bhksRecoveryFloor core
           omega
         exact fun g hg => hsingleton g hg (harm3_adequacy k' hk'_floor hk'_ne hk'_bhks)
     · -- Arm 3: loop declined to the cap; all-ones certification at `B`, behind
       -- the executable floor guard.
       rename_i hloop
       split at hlattice
-      · -- `fastCoreFloorGate core ≤ B`: the guarded all-ones check.
+      · -- `bhksRecoveryFloorGate core ≤ B`: the guarded all-ones check.
         split at hlattice
         · -- `bhksSingleAllOnesPartition = true`: output `#[core]`, core irreducible.
           rename_i hbhks
@@ -440,7 +440,7 @@ theorem normalizedFactors_card_le_bhksEquivalenceClassIndicators_size
     (hcore_pos : 0 < core.degree?.getD 0)
     (hcore_prim : Hex.ZPoly.Primitive core)
     (hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core))
-    (hB_floor : Hex.fastCoreFloor core ≤ B)
+    (hB_floor : Hex.bhksRecoveryFloor core ≤ B)
     (hB_ne : B ≠ 0)
     {L : Hex.BhksLatticeBasis}
     (hL : L = Hex.bhksLatticeBasis (Hex.ZPoly.toMonic core).monic
@@ -475,9 +475,9 @@ theorem normalizedFactors_card_le_bhksEquivalenceClassIndicators_size
     exact Hex.henselLiftData_p _ _ _
   have hm_monic : Hex.DensePoly.Monic (Hex.ZPoly.toMonic core).monic :=
     Hex.ZPoly.toMonic_monic_isMonic_of_pos_degree core hcore_lc_pos hcore_pos
-  have hfloor_dfcb_m := Hex.defaultFactorCoeffBound_toMonic_le_fastCoreFloor core
-  have hfloor_dfcb := Hex.defaultFactorCoeffBound_le_fastCoreFloor core
-  have hfloor_cld := Hex.cldCoeffFloor_le_fastCoreFloor core
+  have hfloor_dfcb_m := Hex.defaultFactorCoeffBound_toMonic_le_bhksRecoveryFloor core
+  have hfloor_dfcb := Hex.defaultFactorCoeffBound_le_bhksRecoveryFloor core
+  have hfloor_cld := Hex.cldCoeffFloor_le_bhksRecoveryFloor core
   have hbound_monic :
       2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
         primeData.p ^ Hex.precisionForCoeffBound B primeData.p := by omega
@@ -683,12 +683,12 @@ with reducibility, the arm-3 `≥ 2`-classes contradiction.
 
 /--
 **Arm-2 deep obligation (BHKS CLD count-equality).**  When the CLD recovery
-`factorFastCoreWithBound` splits `core`, the number of emitted factors equals the
+`bhksRecoveryCoreWithBound` splits `core`, the number of emitted factors equals the
 number of irreducible factors of `core` over `ℤ` — the count-equality that turns
 the fast-core coverage into per-factor irreducibility.
 
 The `≤` half is the proven UFD partition bound
-(`factorFastCoreWithBound_some_factor_count_le`); the `≥` half is the van Hoeij
+(`bhksRecoveryCoreWithBound_some_factor_count_le`); the `≥` half is the van Hoeij
 `W ⊆ L'` adequacy: the acceptance gate guarantees the witness precision clears
 the fast-core floor, so every true-factor support survives the LLL/Gram-Schmidt
 cut as a distinct equivalence class, and one verified candidate is emitted per
@@ -700,7 +700,7 @@ theorem latticeArm2_fastCore_count
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
     (coreFactors : Array Hex.ZPoly)
-    (hfast : Hex.factorFastCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B primeData
+    (hfast : Hex.bhksRecoveryCoreWithBound (Hex.normalizeForFactor f).squareFreeCore B primeData
         (Hex.initialHenselPrecision B) (Hex.ZPoly.quadraticDoublingSteps B + 2)
         = some coreFactors) :
     (coreFactors.toList.map HexPolyZMathlib.toPolynomial).length =
@@ -715,13 +715,13 @@ theorem latticeArm2_fastCore_count
   have hcore_sqfree : Squarefree (HexPolyZMathlib.toPolynomial core) :=
     IntReductionMod.normalizeForFactor_squareFreeCore_toPolynomial_squarefree f hf_ne
   -- the ≤ half: the emitted factors are nonunit divisors with product `core`
-  have hle := factorFastCoreWithBound_some_factor_count_le hcore_ne hfast
+  have hle := bhksRecoveryCoreWithBound_some_factor_count_le hcore_ne hfast
   -- the ≥ half through the recovery-data extractor at the gated witness precision
   obtain ⟨k', hrows, hcand, _hdegen, _hprod, hfloor⟩ :=
-    Hex.factorFastCoreWithBound_some_indicatorCandidates hfast
+    Hex.bhksRecoveryCoreWithBound_some_indicatorCandidates hfast
   have hk_ne : k' ≠ 0 := by
     have hpos := Hex.ZPoly.defaultFactorCoeffBound_pos_of_ne_zero hcore_ne
-    have hfl := Hex.defaultFactorCoeffBound_le_fastCoreFloor core
+    have hfl := Hex.defaultFactorCoeffBound_le_bhksRecoveryFloor core
     omega
   have hsize := Hex.bhksIndicatorCandidates?_size_eq hcand
   have hge := normalizedFactors_card_le_bhksEquivalenceClassIndicators_size
@@ -745,14 +745,14 @@ The precision hypothesis is essential, not incidental: at precision below the
 separation threshold the lattice may not have separated the modular factors,
 so `bhksSingleAllOnesPartition` could report `true` on a *reducible* core.
 The `factorLattice` call site supplies adequate precision via
-`factorFastPrecisionCap`, which contains the floor by construction.
+`latticePrecisionCap`, which contains the floor by construction.
 -/
 theorem latticeArm3_bhksSingleAllOnes_irreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hB_floor : Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
+    (hB_floor : Hex.bhksRecoveryFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
     (hB_ne : B ≠ 0)
     (hbhks : Hex.bhksSingleAllOnesPartition (Hex.normalizeForFactor f).squareFreeCore
         (Hex.ZPoly.toMonicLiftData (Hex.normalizeForFactor f).squareFreeCore B primeData)
@@ -855,14 +855,14 @@ square-free core of `normalizeForFactor f` is irreducible over `ℤ`, provided t
 precision clears the fast-core acceptance floor (`hB_floor`).  Arm 1 (small-mod
 singleton) is proved directly; arms 2/3 are the deep CLD obligations
 `latticeArm2_fastCore_count` / `latticeArm3_bhksSingleAllOnes_irreducible`.  The
-`factorLattice` call site supplies `hB_floor` via `factorFastPrecisionCap`.
+`factorLattice` call site supplies `hB_floor` via `latticePrecisionCap`.
 -/
 theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
     (f : Hex.ZPoly) (hf_ne : f ≠ 0) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hB_floor : Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
+    (hB_floor : Hex.bhksRecoveryFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
     (hB_ne : B ≠ 0)
     {cf : Array Hex.ZPoly}
     (hlattice : Hex.latticeCoreFactorsWithBound
@@ -906,7 +906,7 @@ theorem reassemblyExpansionComplete_latticeCore_of_ne_zero
     (hselected : Hex.ZPoly.toMonicPrimeData? (Hex.normalizeForFactor f).squareFreeCore
       = some primeData)
     (hdeg_ne : (Hex.normalizeForFactor f).squareFreeCore.degree?.getD 0 ≠ 0)
-    (hB_floor : Hex.fastCoreFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
+    (hB_floor : Hex.bhksRecoveryFloor (Hex.normalizeForFactor f).squareFreeCore ≤ B)
     (hB_ne : B ≠ 0)
     {cf : Array Hex.ZPoly}
     (hlattice : Hex.latticeCoreFactorsWithBound
@@ -929,7 +929,7 @@ Reduces through the reassembly bridge to the `LatticeTier` core lemma. -/
 theorem factorLatticeFactorsWithBound_factor_irreducible
     (f : Hex.ZPoly) (hf : f ≠ 0)
     {cf : Array Hex.ZPoly}
-    (hcf : Hex.factorLatticeFactorsWithBound f (Hex.factorFastPrecisionCap f) = some cf)
+    (hcf : Hex.factorLatticeFactorsWithBound f (Hex.latticePrecisionCap f) = some cf)
     {raw : Hex.ZPoly}
     (hmem : raw ∈ cf.toList)
     (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
@@ -953,7 +953,7 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
       rw [hraw_one, Hex.normalizeFactorSign_one, Hex.shouldRecordPolynomialFactor_one] at hrec
       exact absurd hrec (by decide)
   · rw [if_neg hdeg0] at hcf
-    by_cases hB0 : Hex.factorFastPrecisionCap f = 0
+    by_cases hB0 : Hex.latticePrecisionCap f = 0
     · rw [if_pos hB0] at hcf; exact absurd hcf.symm (Option.some_ne_none cf)
     · rw [if_neg hB0] at hcf
       cases hquad : Hex.quadraticIntegerRootFactors? (Hex.normalizeForFactor f).squareFreeCore with
@@ -979,12 +979,12 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
           refine Hex.reassemblePolynomialFactors_factor_irreducible_of_complete_and_core_irreducible
             (Hex.normalizeForFactor f) coreFactors ?_ ?_ hmem
           · exact reassemblyExpansionComplete_latticeCore_of_ne_zero
-              f hf (Hex.factorFastPrecisionCap f) primeData hselected hdeg0
-              (Hex.fastCoreFloor_squareFreeCore_le_factorFastPrecisionCap f) hB0
+              f hf (Hex.latticePrecisionCap f) primeData hselected hdeg0
+              (Hex.bhksRecoveryFloor_squareFreeCore_le_latticePrecisionCap f) hB0
               hcore_lattice
           · exact latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
-              f hf (Hex.factorFastPrecisionCap f) primeData hselected hdeg0
-              (Hex.fastCoreFloor_squareFreeCore_le_factorFastPrecisionCap f) hB0
+              f hf (Hex.latticePrecisionCap f) primeData hselected hdeg0
+              (Hex.bhksRecoveryFloor_squareFreeCore_le_latticePrecisionCap f) hB0
               hcore_lattice
 
 /-- **Hybrid raw-factor irreducibility assembly.**  Every raw factor of
@@ -1000,7 +1000,7 @@ theorem factorHybridFactors_factor_irreducible
     ⟨cf, hcf, hraw⟩ | ⟨cf, hcf, hraw⟩ | htrial
   · exact factorClassicalFactorsWithBound_factor_irreducible f hf hcf hraw hrec
   · exact factorLatticeFactorsWithBound_factor_irreducible f hf hcf hraw hrec
-  · exact factorSlowTrialFactorsWithBound_factor_irreducible f hf htrial hrec
+  · exact factorTrialFactorsWithBound_factor_irreducible f hf htrial hrec
 
 end
 

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -211,7 +211,7 @@ This composes the lifted-support partition count
 (`supportPartitionByMinColumn_length_eq_liftedTrueSupports_ncard`) with the
 support-to-factor bijection (`liftedTrueSupports.ncard_eq_normalizedFactors_card`),
 exposing exactly the `hpartition` hypothesis consumed by
-`factorFastCoreWithBound_some_factor_zpolyIrreducible`.
+`bhksRecoveryCoreWithBound_some_factor_zpolyIrreducible`.
 -/
 theorem supportPartitionByMinColumn_length_eq_normalizedFactors_card
     {core : Hex.ZPoly} {d : Hex.LiftData}

--- a/bench/HexBench/LatticeSpike.lean
+++ b/bench/HexBench/LatticeSpike.lean
@@ -30,7 +30,7 @@ def latticeSink (r : Option Factorization) : UInt64 :=
   | none => 0xffffffffffffffff
 
 /-- Faithful reconstruction of the **pre-#8395** lattice-tier core: grind
-`factorFastCoreWithBound` to the cap `B`, then a single trailing all-ones
+`bhksRecoveryCoreWithBound` to the cap `B`, then a single trailing all-ones
 check at cap precision.  Used by the `before` mode to measure the
 before/after ratio on the same build; the surrounding normalization and
 reassembly (µs, identical on both paths) are excluded on both sides. -/
@@ -39,7 +39,7 @@ def beforeLatticeCore (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) :
   if primeData.factorsModP.size ≤ 1 then
     some #[core]
   else
-    match factorFastCoreWithBound core B primeData
+    match bhksRecoveryCoreWithBound core B primeData
         (initialHenselPrecision B) (ZPoly.quadraticDoublingSteps B + 2) with
     | some coreFactors => some coreFactors
     | none =>
@@ -72,7 +72,7 @@ def timeLatticeCore (label : String) (ref : IO.Ref ZPoly)
   let out ← IO.getStdout
   let f ← ref.get
   let core := (normalizeForFactor f).squareFreeCore
-  let cap := factorFastPrecisionCap f
+  let cap := latticePrecisionCap f
   match ZPoly.toMonicPrimeData? core with
   | none => IO.println s!"{label}: no admissible prime"
   | some primeData =>

--- a/bench/HexBerlekampZassenhaus/Bench.lean
+++ b/bench/HexBerlekampZassenhaus/Bench.lean
@@ -391,7 +391,7 @@ while the full lattice factorization remains too expensive for the `verify`
 budget.
 -/
 def checksumFastPathSetup (f : ZPoly) (p : Nat) : UInt64 :=
-  mixHash (hash (factorFastPrecisionCap f)) (checksumOptionNatArray (modularFactorDegreesAt? f p))
+  mixHash (hash (latticePrecisionCap f)) (checksumOptionNatArray (modularFactorDegreesAt? f p))
 
 /-- Benchmark target: public fast-with-slow-fallback factorization. -/
 def runFactorChecksum (f : ZPoly) : UInt64 :=
@@ -404,7 +404,7 @@ def runFactorFallbackProbeChecksum (f : ZPoly) : UInt64 :=
 
 /-- Benchmark target: public exhaustive slow backstop. -/
 def runFactorSlowChecksum (f : ZPoly) : UInt64 :=
-  checksumFactorization (factorSlowTrial f)
+  checksumFactorization (factorTrial f)
 
 /-- Shared-domain compare target: public factorization on deterministic splits. -/
 def runFactorCompareChecksum (f : ZPoly) : UInt64 :=
@@ -412,7 +412,7 @@ def runFactorCompareChecksum (f : ZPoly) : UInt64 :=
 
 /-- Shared-domain compare target: exhaustive slow factorization on deterministic splits. -/
 def runFactorSlowCompareChecksum (f : ZPoly) : UInt64 :=
-  checksumFactorization (factorSlowTrial f)
+  checksumFactorization (factorTrial f)
 
 /-- Singleton benchmark target: public factorization on `X^4 + 1`. -/
 @[noinline]
@@ -498,7 +498,7 @@ def runFactorDegreeHeightChecksum (input : DegreeHeightInput) : UInt64 :=
 
 /-- Benchmark target: bounded slow-path diagnostic over small degree/height cases. -/
 def runFactorSlowDegreeHeightChecksum (input : DegreeHeightInput) : UInt64 :=
-  checksumFactorization (factorSlowTrial input.poly)
+  checksumFactorization (factorTrial input.poly)
 
 /--
 Benchmark target: `verify`-budget-safe fast-path setup over encoded degree,
@@ -511,7 +511,7 @@ def runFastPathPrecisionLocalChecksum (input : PrecisionLocalInput) : UInt64 :=
   mixHash (hash input.precision) <|
     mixHash (hash input.localFactorCount) <|
       mixHash (checksumZPolyArray lifted) <|
-        mixHash (hash (factorFastPrecisionCap input.poly)) (checksumOptionNatArray splitProfile)
+        mixHash (hash (latticePrecisionCap input.poly)) (checksumOptionNatArray splitProfile)
 
 initialize isabelleBZBinaryRef : IO.Ref (Option String) ← IO.mkRef none
 

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -18,7 +18,7 @@ Covered operations:
 - `normalizeForFactor`, `normalizationPrefixFactors`, and
   `reassembleNormalizedFactors`
 - `henselLiftData`
-- `bhksRecover?`, `recombinationSearch`, `factorSlowTrial`,
+- `bhksRecover?`, `recombinationSearch`, `factorTrial`,
   and `factorClassicalNoDecline`
 - `factor`
 - `PrimeFactorData.degreeSum`, `PrimeFactorData.factorProduct`,
@@ -525,9 +525,9 @@ recovered true factor.
   | none => false
 
 #guard
-  Factorization.product (factorSlowTrial liftedTarget3) = liftedTarget3
+  Factorization.product (factorTrial liftedTarget3) = liftedTarget3
 #guard
-  let φ := factorSlowTrial quadSqrt2Sqrt3
+  let φ := factorTrial quadSqrt2Sqrt3
   Factorization.product φ = quadSqrt2Sqrt3 &&
     sameFactorCoeffSet (factorizationCoeffSummary φ)
       (factorCoeffSummary quadSqrt2Sqrt3ExpectedFactors |>.map fun coeffs =>

--- a/progress/20260704T075608Z_bz-rename-spec-names.md
+++ b/progress/20260704T075608Z_bz-rename-spec-names.md
@@ -1,0 +1,36 @@
+# BZ factor-path cleanup part 5 — rename tiers and lattice internals to SPEC names (#8582)
+
+## Accomplished
+- Pure mechanical, behaviour-neutral rename sweep aligning code identifiers
+  with the SPEC's timeless tier vocabulary. Five renames applied as
+  whole-identifier substring replacements across all non-history files:
+  - `factorSlowTrial` → `factorTrial` (cascades to `factorTrialWithBound`,
+    `factorTrialFactorsWithBound`, and every embedding lemma name)
+  - `factorFastPrecisionCap` → `latticePrecisionCap`
+  - `factorFastCoreWithBound` → `bhksRecoveryCoreWithBound`
+  - `factorFastCoreLoop` → `bhksRecoveryLoop`
+  - `fastCoreFloor` → `bhksRecoveryFloor` (cascades to `bhksRecoveryFloorGate`)
+- Files touched: HexBerlekampZassenhaus/{Basic,CrossCheck}.lean,
+  HexBerlekampZassenhausMathlib/{Basic,IntReductionMod,LatticeTier,
+  PartitionRefinement}.lean, bench/HexBench/LatticeSpike.lean,
+  bench/HexBerlekampZassenhaus/Bench.lean,
+  conformance/HexBerlekampZassenhaus/Conformance.lean, and the
+  hex-lean-mathlib-boundary skill doc.
+- `git diff --stat`: 321 insertions / 321 deletions (balanced = pure rename).
+- SPEC and DEV.md already carried the `factorTrial`/`latticePrecisionCap`
+  vocabulary (de-named in #8577), so they needed no changes.
+
+## Current frontier
+- Whole-graph `lake build` green (4088 jobs); BZ bench + conformance targets
+  built; `hexbz_bench verify` all 16 pass; conformance `#guard` module compiles.
+- `git grep` for the five old tokens over *.lean/*.py/*.md (excl.
+  progress/reports/status) returns nothing.
+- sorry/axiom counts in touched files unchanged (11 == 11).
+- No conformance fixture / jsonl / bz-trace-baseline changed; the
+  FactorTrace.tier role strings are untouched.
+
+## Next step
+- None for this issue; ready to merge. Part 5 of the BZ factor-path cleanup done.
+
+## Blockers
+- None.


### PR DESCRIPTION
This PR renames the surviving tier and lattice-internal identifiers to the SPEC's timeless vocabulary, now that the legacy tiers are gone. It is a pure, behaviour-neutral whole-identifier rename with no logic, statement, or proof-body changes: `factorSlowTrial` → `factorTrial` (the SPEC role name; cascades through `factorTrialWithBound` / `factorTrialFactorsWithBound` and every embedding lemma), `factorFastPrecisionCap` → `latticePrecisionCap`, and the shared CLD recovery core off the misleading `factorFast*` prefix — `factorFastCoreWithBound` → `bhksRecoveryCoreWithBound`, `factorFastCoreLoop` → `bhksRecoveryLoop`, `fastCoreFloor` → `bhksRecoveryFloor` (cascading `fastCoreFloorGate` → `bhksRecoveryFloorGate`). The `bhksRecovery*` prefix names what the core actually implements (BHKS recovery, now driven by `factorLattice`) and avoids confusion with the existing `latticeCore*` family.

This is part 5 of the BZ factor-path cleanup (https://github.com/kim-em/hex-dev/issues/8582), following #8592. Occurrence counts transfer 1:1 (factorTrial 76, latticePrecisionCap 47, bhksRecoveryCoreWithBound 107, bhksRecoveryLoop 16, bhksRecoveryFloor 65, bhksRecoveryFloorGate 17); the whole-graph `lake build`, conformance, and bench targets are green; `sorry`/`axiom` counts are unchanged; the `FactorTrace.tier` role strings and all conformance fixtures are untouched; and none of the five old identifiers remains anywhere outside history. The `hex-lean-mathlib-boundary` skill doc is updated to the new names.

🤖 Prepared with Claude Code