### PR TITLE
refactor(bz): collapse factorHybrid* into factor*

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -64,7 +64,7 @@ The dispatch is **classical-first** (not an up-front cost estimator), and
 **self-certifying**:
 
 ```
-def factorHybrid f :=                              -- (factorHybridTraced f).1
+def factor f :=                              -- (factorTraced f).1
   match factorClassical f with
   | some φ => if Factorization.product φ = f then φ      -- certified classical answer
               else factorTrial f                          -- (corpus-never) miss → backstop
@@ -124,7 +124,7 @@ reverse. We have thrashed too often bending the implementation to ease proofs.
 | Adversarial corpus + metamorphic relations | #8378 | #8387 | ✅ merged |
 | Merge-blocking conformance + counter + wall-clock gate (+ budget soundness) | #8379 | #8390 | ✅ merged |
 | CLD lattice tier: certify irreducibility (Swinnerton-Dyer / high-`r`) | #8380 | #8393 | ✅ merged (correctness); speed = #8395 stretch |
-| Cost-based hybrid dispatch (classical-first, self-certifying) | #8381 | #8397, #8398 | ✅ merged (`factorHybrid` + `factorHybrid_product`) |
+| Cost-based hybrid dispatch (classical-first, self-certifying) | #8381 | #8397, #8398 | ✅ merged (`factor` + `factor_product`) |
 | Classical recombination structurally recursive + reconstruction proved | — | #8401 | ✅ merged (capstone foundation) |
 | **Swap public `factor` to the hybrid** (re-point ~100 theorems, both layers) | #8383 | #8404 | ✅ **merged — the public `factor` is now the hybrid** |
 | Optimize the easy regime (arithmetic constants) | #8382 | — | ⏸️ deferred — sound part overlaps #8395 (see below) |
@@ -134,7 +134,7 @@ The public `factor` now **is** the cost-based hybrid (since #8404): the
 exponential-on-easy-inputs blow-up is gone (deg-22 reducible: 781.8 ms → 82.75 ms),
 product preservation holds over the hybrid, and the unconditional per-factor
 contracts (normalization, primitivity from `f ≠ 0`, pairwise-distinct, scalar)
-re-point through the `factorHybrid f = factorizationOfFactors f (factorHybridFactors f)`
+re-point through the `factor f = factorizationOfFactors f (factorFactors f)`
 bridge. Conformance stands at 100 checks / 0 failures (50 `factor` + 50
 `factorClassical`); heavy high-`r` cases (SD4/SD5/Φ₁₀₅) are staged in
 `conformance-fixtures/HexBerlekampZassenhaus/bz-scheduled.jsonl`.
@@ -217,16 +217,16 @@ Everything else in the migration is merged and verified. See History.
   it is the **correct fallback** for the extreme-`r` tail; speed is #8395. The
   classical tier already covers everything up to its budget (incl. SD2–SD5) fast, so
   the practical goal is **parity** with Isabelle, lattice as the safety net.
-- **#8381 → #8397:** `factorHybrid`/`factorHybridTraced` — classical-first dispatch,
+- **#8381 → #8397:** `factor`/`factorTraced` — classical-first dispatch,
   lattice on decline, trial backstop, traced. (Chose classical-first over the
   directive's up-front cost estimator: classical declines cheaply, lattice grinds.)
-- **#8398:** self-certifying hybrid + `factorHybrid_product` (product preservation
+- **#8398:** self-certifying hybrid + `factor_product` (product preservation
   proven unconditionally, no public swap).
 - **#8401:** `scaledRecombinationSmart*` made structurally recursive (drop `partial`,
   explicit `fuel`, behavior-identical) + reconstruction proved — the classical-tier
   capstone foundation (steps 1-2).
 - **#8383 → #8404:** swapped the public `factor`/`factor?` to the hybrid; added
-  `factorHybridFactors` + the `factor f = factorizationOfFactors f (factorHybridFactors f)`
+  `factorFactors` + the `factor f = factorizationOfFactors f (factorFactors f)`
   bridge; re-pointed ~100 `factor`-level theorems across both layers. The conditional
   `h_raw` primitivity hypotheses collapsed to just `f ≠ 0` (the self-certifying
   product reconstruction makes primitivity derivable). Headline irreducibility stays a
@@ -282,8 +282,8 @@ Never bend the implementation to a future proof. Never introduce an `axiom`.
     `RecombStats`), `factorClassical` (+ `…WithBound`, `classicalCoreFactorsWithBound`);
   — lattice tier: `factorLattice` (+ `bhksSingleAllOnesPartition`) over the
     `bhks*` / `factorFastCore*` machinery;
-  — hybrid (self-certifying): `factorHybrid` / `factorHybridTraced`,
-    `factorHybrid_product`, `factorHybridFactors`;
+  — hybrid (self-certifying): `factor` / `factorTraced`,
+    `factor_product`, `factorFactors`;
   — public entry (now the hybrid, since #8404): `factor` / `factor?`.
 - **Reused tiers:** `HexBerlekamp/` (mod-`p` Berlekamp), `HexHensel/` (lift),
   `HexLLL/` (van Hoeij short vectors), `HexPoly*/` (arithmetic).

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -10237,12 +10237,12 @@ a fallback was taken (the merge gate asserts this never happens unexpectedly).
 **Self-certifying.** Each non-backstop tier's `Factorization` is accepted only
 when it reconstructs the input (`Factorization.product φ = f`, decidable on
 `ZPoly`); on the (corpus-never) miss it falls through to the proven
-`factorTrial` backstop. This makes `Factorization.product (factorHybrid f) = f`
+`factorTrial` backstop. This makes `Factorization.product (factor f) = f`
 provable unconditionally without yet proving the classical recombination loop
 reconstructs (that, with per-factor irreducibility, is the separate re-proof
 step). The classical tier is correct on the whole conformance corpus, so the
 guard always passes there and the emitted factor/trace values are unchanged. -/
-def factorHybridTraced (f : ZPoly) : Factorization × FactorTrace :=
+def factorTraced (f : ZPoly) : Factorization × FactorTrace :=
   match factorClassicalTraced f with
   | (some φ, trace) =>
       if Factorization.product φ = f then (φ, trace)   -- classical answered, certified
@@ -10254,22 +10254,30 @@ def factorHybridTraced (f : ZPoly) : Factorization × FactorTrace :=
           else (factorTrial f, { trace with tier := "trial", declined := true })
       | none => (factorTrial f, { trace with tier := "trial" })  -- totality backstop
 
-/-- Cost-based hybrid factorisation: classical-first, lattice on decline, trial
-backstop. Total. Not yet the public `factor` (swap is a separate step). -/
-def factorHybrid (f : ZPoly) : Factorization :=
-  (factorHybridTraced f).1
+/--
+The public factorisation (SPEC *Hybrid dispatch*). There is no up-front tier
+selection: the classical tier runs first under a level-aware subset budget and
+its answer is accepted only when the packed product reconstructs `f`; on decline
+(budget exhaustion or no admissible prime) the CLD lattice tier runs at the
+lattice precision cap under the same self-certifying acceptance check; and any
+residual falls through to the `factorTrial` totality backstop, which is
+`choosePrimeData?`-independent and so makes `factor` unconditionally correct on
+every `ZPoly`. Total.
+-/
+def factor (f : ZPoly) : Factorization :=
+  (factorTraced f).1
 
 -- classical answers the corpus, including small/medium-r Swinnerton-Dyer / cyclotomic
 -- irreducibles, so no fallback is taken (the lattice/trial arms cover only the
 -- budget-exceeding tail and the no-prime case).
-#guard Factorization.product (factorHybrid (DensePoly.ofCoeffs #[6, 0, -5, 0, 1]))
+#guard Factorization.product (factor (DensePoly.ofCoeffs #[6, 0, -5, 0, 1]))
   = DensePoly.ofCoeffs #[6, 0, -5, 0, 1]                                      -- reducible
-#guard (factorHybridTraced (DensePoly.ofCoeffs #[6, 0, -5, 0, 1])).2.tier = "classical"
-#guard Factorization.product (factorHybrid (DensePoly.ofCoeffs #[1, 0, -10, 0, 1]))
+#guard (factorTraced (DensePoly.ofCoeffs #[6, 0, -5, 0, 1])).2.tier = "classical"
+#guard Factorization.product (factor (DensePoly.ofCoeffs #[1, 0, -10, 0, 1]))
   = DensePoly.ofCoeffs #[1, 0, -10, 0, 1]                                     -- SD2, irreducible
-#guard ((factorHybrid (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).factors.size) = 1
-#guard (factorHybridTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.tier = "classical"
-#guard (factorHybridTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.declined = false
+#guard ((factor (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).factors.size) = 1
+#guard (factorTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.tier = "classical"
+#guard (factorTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.declined = false
 
 /-- The classical traced tier's `Factorization` agrees with the raw classical
 factor array packed through `factorizationOfFactors f`. The traced variant only
@@ -10320,15 +10328,15 @@ theorem factorLattice_eq_map (f : ZPoly) :
         (factorizationOfFactors f) := rfl
 
 /-- Raw factor array assembled by the cost-based hybrid, the bridge counterpart
-of `factorHybridFactors`-consuming structural lemmas.
+of `factorFactors`-consuming structural lemmas.
 
 Each non-backstop tier (`factorClassicalFactorsWithBound` / lattice) is accepted
 only when its `factorizationOfFactors`-packed answer reconstructs `f` (the
 self-certifying guard mirrored here), and every fallback is the proven
 `factorTrial` backstop's raw array. The headline contract
-`factorHybrid f = factorizationOfFactors f (factorHybridFactors f)` is
-`factorHybrid_eq_factorizationOfFactors`. -/
-def factorHybridFactors (f : ZPoly) : Array ZPoly :=
+`factor f = factorizationOfFactors f (factorFactors f)` is
+`factor_eq_factorizationOfFactors`. -/
+def factorFactors (f : ZPoly) : Array ZPoly :=
   match factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) with
   | some cf =>
       if Factorization.product (factorizationOfFactors f cf) = f then cf
@@ -10341,17 +10349,17 @@ def factorHybridFactors (f : ZPoly) : Array ZPoly :=
       | none => factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)
 
 /-- The cost-based hybrid factorisation is the `factorizationOfFactors`-packed
-form of its raw factor array `factorHybridFactors`. Every tier (classical /
+form of its raw factor array `factorFactors`. Every tier (classical /
 lattice / trial) assembles via `factorizationOfFactors f`, so this bridge lets
 the structural `factorizationOfFactors_entry_*` lemmas re-point every
 `factor`-level entry contract onto the hybrid. -/
-theorem factorHybrid_eq_factorizationOfFactors (f : ZPoly) :
-    factorHybrid f = factorizationOfFactors f (factorHybridFactors f) := by
+theorem factor_eq_factorizationOfFactors (f : ZPoly) :
+    factor f = factorizationOfFactors f (factorFactors f) := by
   have htrial : factorTrial f =
       factorizationOfFactors f
         (factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) := by
     rw [factorTrial, factorTrialWithBound_eq_factorizationOfFactors]
-  unfold factorHybrid factorHybridTraced factorHybridFactors
+  unfold factor factorTraced factorFactors
   have hclassical :
       (factorClassicalTraced f).1 =
         (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).map
@@ -10388,14 +10396,14 @@ tier's certified output, or the `factorTrial` totality backstop. It
 exposes the branch source (mirroring `factor_entry_mem_raw_source` for the
 raw hybrid array) without leaking the private `factorizationOfFactors` guard, so
 the Mathlib-side irreducibility assembly can case-split over the branches. -/
-theorem factorHybridFactors_mem_source (f : ZPoly) {raw : ZPoly}
-    (hmem : raw ∈ (factorHybridFactors f).toList) :
+theorem factorFactors_mem_source (f : ZPoly) {raw : ZPoly}
+    (hmem : raw ∈ (factorFactors f).toList) :
     (∃ cf, factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) =
         some cf ∧ raw ∈ cf.toList) ∨
       (∃ cf, factorLatticeFactorsWithBound f (latticePrecisionCap f) =
         some cf ∧ raw ∈ cf.toList) ∨
       raw ∈ (factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).toList := by
-  unfold factorHybridFactors at hmem
+  unfold factorFactors at hmem
   rcases Option.eq_none_or_eq_some
       (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) with hcf | ⟨cf, hcf⟩
   · simp only [hcf] at hmem
@@ -10472,27 +10480,6 @@ private def finitePrimeSearchNoneQuadratic : ZPoly :=
   match choosePrimeData? finitePrimeSearchNoneQuadratic with
   | none => false
   | some data => data.p == 29
-
-/--
-Factor with the hybrid combinator (SPEC *Hybrid dispatch*). There is no
-up-front tier selection: the classical tier runs first under a level-aware
-subset budget and its answer is accepted only when the packed product
-reconstructs `f`; on decline (budget exhaustion or no admissible prime) the
-CLD lattice tier runs at the lattice precision cap under the same
-self-certifying acceptance check; and any residual falls through to the
-`factorTrial` totality backstop, which is `choosePrimeData?`-independent
-and so makes `factor` unconditionally correct on every `ZPoly`.
--/
-def factor (f : ZPoly) : Factorization :=
-  factorHybrid f
-
-/-- The public factorisation is the `factorizationOfFactors`-packed form of the
-hybrid's raw factor array. This bridge re-points every `factor`-level entry
-contract onto the hybrid via the structural `factorizationOfFactors_entry_*`
-lemmas. -/
-theorem factor_eq_factorizationOfFactors (f : ZPoly) :
-    factor f = factorizationOfFactors f (factorHybridFactors f) :=
-  factorHybrid_eq_factorizationOfFactors f
 
 set_option maxHeartbeats 800000
 
@@ -10579,12 +10566,12 @@ theorem factor_scalar (f : ZPoly) :
       else
         ZPoly.content f := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_scalar f (factorHybridFactors f)
+  exact factorizationOfFactors_scalar f (factorFactors f)
 
 @[simp, grind =] theorem factor_scalar_zero :
     (factor 0).scalar = 0 := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_scalar_zero (factorHybridFactors 0)
+  exact factorizationOfFactors_scalar_zero (factorFactors 0)
 
 /-- The default factorization of `0` records no polynomial factors: the
 square-free core of `0` is the unit `1`, so every reassembled raw factor is
@@ -10598,18 +10585,18 @@ theorem factor_scalar_of_leadingCoeff_neg
     {f : ZPoly} (hf : f ≠ 0) (hneg : DensePoly.leadingCoeff f < 0) :
     (factor f).scalar = -ZPoly.content f := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_scalar_of_leadingCoeff_neg (factorHybridFactors f) hf hneg
+  exact factorizationOfFactors_scalar_of_leadingCoeff_neg (factorFactors f) hf hneg
 
 theorem factor_scalar_of_leadingCoeff_pos
     {f : ZPoly} (hf : f ≠ 0) (hpos : 0 < DensePoly.leadingCoeff f) :
     (factor f).scalar = ZPoly.content f := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_scalar_of_leadingCoeff_pos (factorHybridFactors f) hf hpos
+  exact factorizationOfFactors_scalar_of_leadingCoeff_pos (factorFactors f) hf hpos
 
 theorem factor_scalar_eq_zero_iff (f : ZPoly) :
     (factor f).scalar = 0 ↔ f = 0 := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_scalar_eq_zero_iff f (factorHybridFactors f)
+  exact factorizationOfFactors_scalar_eq_zero_iff f (factorFactors f)
 
 /-- Every recorded entry of the default public factorization has positive
 multiplicity. -/
@@ -10618,7 +10605,7 @@ theorem factor_entry_multiplicity_pos
     (hmem : entry ∈ (factor f).factors.toList) :
     0 < entry.2 := by
   rw [factor_eq_factorizationOfFactors] at hmem
-  exact factorizationOfFactors_entry_multiplicity_pos f (factorHybridFactors f) entry hmem
+  exact factorizationOfFactors_entry_multiplicity_pos f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is fixed by
 `normalizeFactorSign`. -/
@@ -10627,7 +10614,7 @@ theorem factor_entry_normalizeFactorSign_id
     (hmem : entry ∈ (factor f).factors.toList) :
     normalizeFactorSign entry.1 = entry.1 := by
   rw [factor_eq_factorizationOfFactors] at hmem
-  exact factorizationOfFactors_entry_normalizeFactorSign_id f (factorHybridFactors f) entry hmem
+  exact factorizationOfFactors_entry_normalizeFactorSign_id f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization has positive
 leading coefficient. -/
@@ -10636,7 +10623,7 @@ theorem factor_entry_leadingCoeff_pos
     (hmem : entry ∈ (factor f).factors.toList) :
     0 < DensePoly.leadingCoeff entry.1 := by
   rw [factor_eq_factorizationOfFactors] at hmem
-  exact factorizationOfFactors_entry_leadingCoeff_pos f (factorHybridFactors f) entry hmem
+  exact factorizationOfFactors_entry_leadingCoeff_pos f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization passes the
 `shouldRecordPolynomialFactor` filter. -/
@@ -10645,25 +10632,25 @@ theorem factor_entry_shouldRecord
     (hmem : entry ∈ (factor f).factors.toList) :
     shouldRecordPolynomialFactor entry.1 = true := by
   rw [factor_eq_factorizationOfFactors] at hmem
-  have hmem' : entry ∈ (collectFactorMultiplicities (factorHybridFactors f)).toList := by
+  have hmem' : entry ∈ (collectFactorMultiplicities (factorFactors f)).toList := by
     simpa only [factorizationOfFactors] using hmem
-  exact collectFactorMultiplicities_entry_shouldRecord (factorHybridFactors f) entry hmem'
+  exact collectFactorMultiplicities_entry_shouldRecord (factorFactors f) entry hmem'
 
 /-- Any recorded entry of the default public factorization comes from the
-hybrid's raw factor array `factorHybridFactors`, up to sign normalization. -/
+hybrid's raw factor array `factorFactors`, up to sign normalization. -/
 theorem factor_entry_mem_raw_source
     (f : ZPoly) (entry : ZPoly × Nat)
     (hmem : entry ∈ (factor f).factors.toList) :
-    ∃ raw ∈ (factorHybridFactors f).toList, entry.1 = normalizeFactorSign raw := by
+    ∃ raw ∈ (factorFactors f).toList, entry.1 = normalizeFactorSign raw := by
   rw [factor_eq_factorizationOfFactors] at hmem
-  exact factorizationOfFactors_entry_mem_normalized_raw f (factorHybridFactors f) entry hmem
+  exact factorizationOfFactors_entry_mem_normalized_raw f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is primitive once
 every raw factor in the hybrid's raw factor array is primitive. -/
 theorem factor_entry_primitive_of_chosen_raw_primitive
     {f : ZPoly} {entry : ZPoly × Nat}
     (hmem : entry ∈ (factor f).factors.toList)
-    (h_raw : ∀ raw ∈ (factorHybridFactors f).toList, ZPoly.Primitive raw) :
+    (h_raw : ∀ raw ∈ (factorFactors f).toList, ZPoly.Primitive raw) :
     ZPoly.Primitive entry.1 := by
   obtain ⟨raw, hraw_mem, hentry_eq⟩ := factor_entry_mem_raw_source f entry hmem
   rw [hentry_eq]
@@ -10673,7 +10660,7 @@ theorem factor_entry_primitive_of_chosen_raw_primitive
 hybrid's raw factor array is primitive entrywise. -/
 theorem factor_entries_primitive
     (f : ZPoly)
-    (h_raw : ∀ raw ∈ (factorHybridFactors f).toList, ZPoly.Primitive raw) :
+    (h_raw : ∀ raw ∈ (factorFactors f).toList, ZPoly.Primitive raw) :
     ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 := by
   intro entry hentry
   exact factor_entry_primitive_of_chosen_raw_primitive
@@ -10685,7 +10672,7 @@ theorem factor_pairwise_first
     List.Pairwise (fun a b : ZPoly × Nat => a.1 ≠ b.1)
       (factor f).factors.toList := by
   rw [factor_eq_factorizationOfFactors]
-  exact factorizationOfFactors_pairwise_first f (factorHybridFactors f)
+  exact factorizationOfFactors_pairwise_first f (factorFactors f)
 
 private def quadraticSquareRegression : ZPoly :=
   let q : ZPoly := DensePoly.ofCoeffs #[-1, 0, 1]
@@ -18933,16 +18920,15 @@ theorem factorTrial_product (f : ZPoly) :
     Factorization.product (factorTrial f) = f := by
   exact factorTrialWithBound_product f (ZPoly.defaultFactorCoeffBound f)
 
-/-- Product preservation for the cost-based hybrid. Holds unconditionally: each
-non-backstop tier's result is accepted only when it reconstructs `f` (the
-self-certifying guard in `factorHybridTraced`), and every fallback is the proven
-`factorTrial` backstop. This is the headline contract the public `factor`
-swap inherits, established without proving the classical recombination loop
-reconstructs (that, with per-factor irreducibility, is the still-blocked re-proof
-capstone #8384). -/
-theorem factorHybrid_product (f : ZPoly) :
-    Factorization.product (factorHybrid f) = f := by
-  unfold factorHybrid factorHybridTraced
+/-- Product contract for the public total factorization entry point. Holds
+unconditionally: each non-backstop tier's result is accepted only when it
+reconstructs `f` (the self-certifying guard in `factorTraced`), and every
+fallback is the proven `factorTrial` backstop. Established without proving the
+classical recombination loop reconstructs (that, with per-factor irreducibility,
+is the still-blocked re-proof capstone #8384). -/
+theorem factor_product (f : ZPoly) :
+    Factorization.product (factor f) = f := by
+  unfold factor factorTraced
   rcases hcl : factorClassicalTraced f with ⟨cres, trace⟩
   cases cres with
   | some φ =>
@@ -18956,12 +18942,6 @@ theorem factorHybrid_product (f : ZPoly) :
           · simp [hp]
           · simp only [hp, if_false]; exact factorTrial_product f
       | none => exact factorTrial_product f
-
-/-- Product contract for the public total factorization entry point: the
-self-certifying hybrid always reconstructs its input. -/
-theorem factor_product (f : ZPoly) :
-    Factorization.product (factor f) = f :=
-  factorHybrid_product f
 
 /-- Every recorded entry of the default factorization of a nonzero `f` is
 primitive, with no raw-source hypothesis. The hybrid's `factorizationOfFactors`
@@ -18977,17 +18957,17 @@ theorem factor_entries_primitive_of_ne_zero
   have hfiltered_prod :
       DensePoly.C (signedContentScalar f) *
         Array.polyProduct
-          (filteredNormalizedFactors (factorHybridFactors f).toList).toArray = f := by
+          (filteredNormalizedFactors (factorFactors f).toList).toArray = f := by
     have hp := factor_product f
     rw [factor_eq_factorizationOfFactors, factorizationOfFactors_product] at hp
     exact hp
   have hprim :
       ZPoly.Primitive
         (Array.polyProduct
-          (filteredNormalizedFactors (factorHybridFactors f).toList).toArray) :=
+          (filteredNormalizedFactors (factorFactors f).toList).toArray) :=
     primitive_of_signedContentScalar_mul_eq f _ hf hfiltered_prod
   have hmem_filtered :
-      ∀ g ∈ (filteredNormalizedFactors (factorHybridFactors f).toList).toArray.toList,
+      ∀ g ∈ (filteredNormalizedFactors (factorFactors f).toList).toArray.toList,
         ZPoly.Primitive g :=
     polyProduct_mem_primitive_of_primitive _ hprim
   -- The entry lies in the filtered list (it equals a sign-normalized raw factor
@@ -18997,7 +18977,7 @@ theorem factor_entries_primitive_of_ne_zero
     have := factor_entry_shouldRecord f entry hmem
     rwa [hentry_eq] at this
   have hentry_in :
-      entry.1 ∈ (filteredNormalizedFactors (factorHybridFactors f).toList).toArray.toList := by
+      entry.1 ∈ (filteredNormalizedFactors (factorFactors f).toList).toArray.toList := by
     rw [List.toList_toArray, hentry_eq]
     unfold filteredNormalizedFactors
     rw [List.mem_filterMap]

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -34,7 +34,7 @@ theorem factor_irreducible_of_nonUnit (f : Hex.ZPoly) :
     have hrec := Hex.factor_entry_shouldRecord f entry hmem
     rw [hentry_eq] at hrec ⊢
     exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
-      (factorHybridFactors_factor_irreducible f hf hraw_mem hrec)
+      (factorFactors_factor_irreducible f hf hraw_mem hrec)
 
 /--
 Every polynomial factor emitted by the default executable factorization is

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -879,9 +879,9 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
 
 `factorLatticeFactorsWithBound_factor_irreducible` was a forward `sorry` in
 `IntReductionMod` (it cannot import the LLL machinery); it is filled here and,
-with its assembly `factorHybridFactors_factor_irreducible`, moved into this file
+with its assembly `factorFactors_factor_irreducible`, moved into this file
 where the `LatticeTier` core lemma is available.  `factor_irreducible_of_nonUnit`
-(FactorSoundness) consumes `factorHybridFactors_factor_irreducible`.
+(FactorSoundness) consumes `factorFactors_factor_irreducible`.
 -/
 
 /-- **Lattice-core reassembly completeness (#8520).**  When the lattice tier
@@ -988,15 +988,15 @@ theorem factorLatticeFactorsWithBound_factor_irreducible
               hcore_lattice
 
 /-- **Hybrid raw-factor irreducibility assembly.**  Every raw factor of
-`factorHybridFactors f` passing the recorded-factor filter is irreducible,
+`factorFactors f` passing the recorded-factor filter is irreducible,
 dispatched over the classical / lattice / trial tiers. -/
-theorem factorHybridFactors_factor_irreducible
+theorem factorFactors_factor_irreducible
     (f : Hex.ZPoly) (hf : f ≠ 0)
     {raw : Hex.ZPoly}
-    (hmem : raw ∈ (Hex.factorHybridFactors f).toList)
+    (hmem : raw ∈ (Hex.factorFactors f).toList)
     (hrec : Hex.shouldRecordPolynomialFactor (Hex.normalizeFactorSign raw) = true) :
     Hex.ZPoly.Irreducible raw := by
-  rcases Hex.factorHybridFactors_mem_source f hmem with
+  rcases Hex.factorFactors_mem_source f hmem with
     ⟨cf, hcf, hraw⟩ | ⟨cf, hcf, hraw⟩ | htrial
   · exact factorClassicalFactorsWithBound_factor_irreducible f hf hcf hraw hrec
   · exact factorLatticeFactorsWithBound_factor_irreducible f hf hcf hraw hrec

--- a/bench/HexBench/LatticeSpike.lean
+++ b/bench/HexBench/LatticeSpike.lean
@@ -155,7 +155,7 @@ def main (args : List String) : IO Unit := do
       let timeHybrid (label : String) (ref : IO.Ref ZPoly) : IO Unit := do
         let f ← ref.get
         let t0 ← IO.monoNanosNow
-        let (φ, trace) ← IO.lazyPure (fun _ => factorHybridTraced f)
+        let (φ, trace) ← IO.lazyPure (fun _ => factorTraced f)
         let t1 ← IO.monoNanosNow
         IO.println s!"{label}: {(t1 - t0).toFloat / 1.0e6} ms \
           (tier={trace.tier}, declined={trace.declined}, factors={φ.factors.size})"

--- a/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
+++ b/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
@@ -82,7 +82,7 @@ exhausting all nontrivial subset products takes — far past its
 level-aware budget (`levelAwareSubsetBudget 32 defaultSubsetBudget =
 206368`), so it provably declines and the hybrid falls through to the
 van Hoeij CLD lattice arm.  Both cases emit the
-*hybrid* trace (`factorHybridTraced`) rather than the classical one,
+*hybrid* trace (`factorTraced`) rather than the classical one,
 making the tier a merge requirement three ways: the emit helper itself
 errors unless the lattice tier answered, the committed-fixture
 byte-diff pins the exact trace (`tier = "lattice"`, `declined = true`,
@@ -402,7 +402,7 @@ private def cases_adversarial : List Case :=
 /-! ## Lattice-tier merge requirement
 
 See the module docstring §"Lattice-tier merge requirement".  The cases are
-emitted through the public `factor` path (`factorHybridTraced`, whose `.1`
+emitted through the public `factor` path (`factorTraced`, whose `.1`
 is `factor`) so the pinned trace catches dispatch regressions, not just
 lattice ones. -/
 
@@ -520,7 +520,7 @@ private def emitPinnedCase (c : PinnedCase) : IO Unit := do
   emitClassicalResult c.id f
 
 /-- Emit one lattice-sentinel fixture through the *hybrid* traced path: a
-single `factorHybridTraced` run supplies the `factor` result (its `.1` is the
+single `factorTraced` run supplies the `factor` result (its `.1` is the
 public `factor`) **and** the trace, so the committed trace pins the tier
 `factor` actually used.  The helper is sentinel-only: it errors out unless the
 classical tier declined and the lattice tier answered, which is the case's
@@ -535,7 +535,7 @@ values are pinned by the committed-fixture byte-diff in
 tier/decline and upper-bounds `subsetCandidates`. -/
 private def emitHybridTracedCase (c : PinnedCase) : IO Unit := do
   let f := DensePoly.ofCoeffs c.coeffs
-  let (φ, trace) := factorHybridTraced f
+  let (φ, trace) := factorTraced f
   unless trace.tier == "lattice" && trace.declined do
     throw <| IO.userError
       s!"emitHybridTracedCase {c.id}: expected the classical tier to decline and \

--- a/progress/20260704T083253Z_bz-collapse-factorhybrid.md
+++ b/progress/20260704T083253Z_bz-collapse-factorhybrid.md
@@ -1,0 +1,35 @@
+# BZ: collapse factorHybrid* into factor*
+
+## Accomplished
+Part 6 of the BZ factor-path cleanup (#8583). Collapsed the
+factor -> factorHybrid -> factorHybridTraced indirection now that the
+pre-hybrid combinator is gone and factor IS the hybrid. Substring-renamed
+factorHybrid -> factor across the repo (cascading factorHybridTraced ->
+factorTraced, factorHybridFactors -> factorFactors,
+factorHybridFactors_factor_irreducible -> factorFactors_factor_irreducible,
+factorHybrid_eq_factorizationOfFactors -> factor_eq_factorizationOfFactors),
+then resolved the two resulting duplicates: deleted the circular
+def factor := factor f wrapper (keeping the inlined def factor :=
+(factorTraced f).1 with the public hybrid-dispatch docstring), and deleted
+the self-referential factor_eq_factorizationOfFactors wrapper (keeping the
+substantive proof). FactorTrace and its tier/declined fields unchanged.
+
+Files: HexBerlekampZassenhaus/Basic.lean, HexBerlekampZassenhausMathlib/
+{FactorSoundness,LatticeTier}.lean, bench/HexBench/LatticeSpike.lean,
+conformance/HexBerlekampZassenhaus/EmitFixtures.lean, DEV.md.
+
+Verify: whole-graph lake build green (4088 jobs); hexbz_bench /
+HexConformance / hexbz_emit_fixtures / hexbz_factor_service green (452
+jobs, conformance #guards pass); factorHybrid grep-clean; zero sorry/axiom
+introduced.
+
+## Current frontier
+Public API is now factor / factorTraced / factorFactors with no hybrid
+indirection. Only F (SPEC/directive consistency pass) remains.
+
+## Next step
+Issue F (#8584): confirm SPEC clean; refresh #8369/#8370 directive bodies
+to the new names.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR collapses the `factor → factorHybrid → factorHybridTraced` indirection now that the pre-hybrid combinator is gone and `factor` is itself the hybrid. It renames `factorHybrid` to `factor` throughout — cascading `factorHybridTraced` to `factorTraced`, `factorHybridFactors` to `factorFactors`, and `factorHybridFactors_factor_irreducible` to `factorFactors_factor_irreducible` — inlines the trivial `def factor := factorHybrid f` wrapper into `def factor := (factorTraced f).1` (carrying the public hybrid-dispatch docstring), and drops the now self-referential `factor_eq_factorizationOfFactors` wrapper in favour of its substantive proof. The `FactorTrace` diagnostic and its `tier` / `declined` fields are unchanged, so the conformance trace fixtures are untouched.

This is part 6 of the BZ factor-path cleanup (https://github.com/kim-em/hex-dev/issues/8583), following #8593. Behaviour-neutral: the whole-graph `lake build` (4088 jobs) and the `hexbz_bench` / `HexConformance` / `hexbz_emit_fixtures` / `hexbz_factor_service` targets are green, no `sorry` or `axiom` is introduced, and `factorHybrid` no longer appears anywhere outside history. The public API surface is now `factor` / `factorTraced` / `factorFactors`.

🤖 Prepared with Claude Code