### PR TITLE
refactor(bz): rename the last factorFastCore straggler to bhksRecovery

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -281,7 +281,7 @@ Never bend the implementation to a future proof. Never introduce an `axiom`.
   — classical tier: `scaledRecombinationSmart` (+ `subsetsOfSizeWithComplement`,
     `RecombStats`), `factorClassical` (+ `…WithBound`, `classicalCoreFactorsWithBound`);
   — lattice tier: `factorLattice` (+ `bhksSingleAllOnesPartition`) over the
-    `bhks*` / `factorFastCore*` machinery;
+    `bhks*` machinery (basis, recovery loop, floor);
   — hybrid (self-certifying): `factor` / `factorTraced`,
     `factor_product`, `factorFactors`;
   — public entry (now the hybrid, since #8404): `factor` / `factor?`.

--- a/HexBerlekampZassenhaus/Basic.lean
+++ b/HexBerlekampZassenhaus/Basic.lean
@@ -9523,7 +9523,7 @@ private theorem bhksRecoveryCoreWithBound_ne_none_of_recovery_on_schedule
   rw [hnone] at hsome
   simp at hsome
 
-private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
+private def bhksRecoveryGuardPrimeData : PrimeChoiceData :=
   letI := bounds_five
   let c : SmallPrimeCandidate :=
     { p := 5, bounds := bounds_five, prime := prime_five }
@@ -9531,7 +9531,7 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
     fModP := ZPoly.modP 5 cldGuardF
     factorsModP := berlekampFactorsModP cldGuardF c }
 
-#guard bhksRecoveryCoreWithBound cldGuardF 1 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 1 bhksRecoveryGuardPrimeData
     (initialHenselPrecision 1) (ZPoly.quadraticDoublingSteps 1 + 2) =
   none
 
@@ -9539,14 +9539,14 @@ private def factorFastCoreGuardPrimeData : PrimeChoiceData :=
 -- `cldCoeffFloor cldGuardF = 32` cannot be accepted: the schedule reaches the
 -- cap `B` while every success is still below the floor, so the loop reports
 -- `none`.
-#guard bhksRecoveryCoreWithBound cldGuardF 4 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 4 bhksRecoveryGuardPrimeData
     (initialHenselPrecision 4) (ZPoly.quadraticDoublingSteps 4 + 2) =
   none
 
 -- At a bound that reaches the floor the first gated success is accepted: for
 -- `cldGuardF` this is schedule index `k = 32` (lift precision `liftData.k = 3`,
 -- modulus `5 ^ 3 = 125`), recovering the same factors.
-#guard bhksRecoveryCoreWithBound cldGuardF 32 factorFastCoreGuardPrimeData
+#guard bhksRecoveryCoreWithBound cldGuardF 32 bhksRecoveryGuardPrimeData
     (initialHenselPrecision 32) (ZPoly.quadraticDoublingSteps 32 + 2) =
   some bhksGuardFactors
 

--- a/progress/20260704T085146Z_bz-cleanup-final-pass.md
+++ b/progress/20260704T085146Z_bz-cleanup-final-pass.md
@@ -1,0 +1,38 @@
+# BZ factor-path cleanup: final consistency pass (F, #8584)
+
+## Accomplished
+Closed out the BZ factor-path cleanup (issues #8578-#8584). All six code
+issues (A-E) are merged. This final pass:
+- Confirmed the SPEC is fully free of legacy vocabulary and uses the
+  timeless names (factorTrial / factorClassical / factorLattice); no SPEC
+  change needed.
+- Renamed the two D-rename stragglers that D's substring pass missed
+  (they contain factorFastCore but not the exact renamed tokens):
+  factorFastCoreGuardPrimeData -> bhksRecoveryGuardPrimeData (private test
+  fixture + its 3 #guards, Basic.lean), and the DEV.md architecture note
+  (factorFastCore* -> bhks* machinery).
+- Refreshed the two open lattice-totality directive bodies #8369 and #8370
+  to the post-cleanup names (factorTrial, latticePrecisionCap,
+  bhksRecoveryCoreWithBound, factorFactors; #8369 substrate pointer moved
+  from the deleted factorFast_ne_none_of_core_recovery_on_schedule to the
+  surviving bhksRecoveryCoreWithBound_ne_none_of_recovery_on_schedule;
+  #8370 target theorem factorHybrid_not_slowTrial_of_good_prime ->
+  factor_not_trial_of_good_prime), and marked their now-done SPEC-update
+  instructions as complete.
+
+End state: git grep over *.lean/*.py/DEV.md/SPEC (history exempt) for
+factorWithBound|factorSlowModular|factorFast|factorSlowTrial|factorHybrid|
+exhaustiveCoreFactorsWithBound|dispatchTier returns nothing. Public surface
+is factor / factorTraced / factorFactors / factorClassical / factorLattice
+/ factorTrial.
+
+## Current frontier
+The BZ factor path is now the clean hybrid: one public combinator, three
+tiers, no legacy indirection or dead proof surface.
+
+## Next step
+None for this cleanup. The lattice-totality leaf theorems (#8369/#8370)
+remain open as future non-blocking work, now correctly named.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR completes the BZ factor-path cleanup by renaming the two identifiers the earlier rename sweep (#8593) missed — they contain `factorFastCore` without matching the exact renamed tokens `factorFastCoreWithBound` / `factorFastCoreLoop`: the private test fixture `factorFastCoreGuardPrimeData` becomes `bhksRecoveryGuardPrimeData`, and the DEV.md architecture note drops its stale `factorFastCore*` mention. With this, no legacy factor-path vocabulary (`factorWithBound`, `factorSlowModular`, `factorFast`, `factorSlowTrial`, `factorHybrid`, `exhaustiveCoreFactorsWithBound`, `dispatchTier`) remains anywhere in the code, benches, conformance, scripts, DEV.md, or SPEC.

This is the final part (part 7, https://github.com/kim-em/hex-dev/issues/8584) of the BZ factor-path cleanup, following #8594. It is behaviour-neutral; the whole graph builds green. The two open lattice-totality directives #8369 and #8370 have also been refreshed to the post-cleanup naming (the SPEC portion of #8584 needed no change — the SPEC was kept timeless throughout).

🤖 Prepared with Claude Code