### PR TITLE
style(manual): left-align the landing page body content

### DIFF
--- a/HexManual/Theme.lean
+++ b/HexManual/Theme.lean
@@ -225,22 +225,22 @@ input[type='search']:focus {
 .titlepage + p,
 .titlepage ~ p {
   max-width: 38rem;
-  margin-left: auto;
+  margin-left: 0;
   margin-right: auto;
-  text-align: center;
+  text-align: left;
   color: #444;
   line-height: 1.6;
 }
 
 /* Home page Contents heading */
 .titlepage ~ section > h2 {
-  text-align: center;
+  text-align: left;
   margin-top: 2rem;
 }
 .titlepage ~ section .section-toc {
   list-style: none;
   padding: 0;
-  text-align: center;
+  text-align: left;
 }
 .titlepage ~ section .section-toc li {
   padding: 0.4rem 0;


### PR DESCRIPTION
This PR left-aligns the intro paragraph, Contents heading, and section table of contents on the manual's landing page, while keeping the title and authors centred. The centred body columns read awkwardly against the otherwise left-aligned manual chapters.

The change is confined to the `.titlepage`-scoped rules in \`HexManual/Theme.lean\`; the site re-renders and publishes on the next push to \`main\` via the Pages workflow.

🤖 Prepared with Claude Code