### PR TITLE
refactor: drop three unnecessary simpa linter silences

### DIFF
--- a/HexBerlekampZassenhaus/Lattice.lean
+++ b/HexBerlekampZassenhaus/Lattice.lean
@@ -745,19 +745,14 @@ def bhksRowsArrayToMatrix {m : Nat} (n : Nat) (rows : Array (Vector Int m)) :
     Matrix Int n m :=
   Matrix.ofFn fun i j => (rows.getD i.val (Vector.ofFn fun _ => 0))[j]
 
-set_option linter.unnecessarySimpa false in
 theorem bhksRowsArrayToMatrix_row {m n : Nat} (rows : Array (Vector Int m))
     (i : Fin n) :
     Matrix.row (bhksRowsArrayToMatrix n rows) i =
       rows.getD i.val (Vector.ofFn fun _ => 0) := by
   apply Vector.ext
   intro j hj
-  simpa [bhksRowsArrayToMatrix, Matrix.row, Matrix.ofFn] using
-    (show (Matrix.ofFn fun i j => (rows.getD i.val (Vector.ofFn fun _ => 0))[j])
-        [i][⟨j, hj⟩] = (rows.getD i.val (Vector.ofFn fun _ => 0))[⟨j, hj⟩] by
-      rfl)
+  simp [bhksRowsArrayToMatrix, Matrix.row, Matrix.ofFn]
 
-set_option linter.unnecessarySimpa false in
 theorem bhksRowsArrayToMatrix_toArray {m n : Nat} (B : Matrix Int n m) :
     bhksRowsArrayToMatrix n B.rows.toArray = B := by
   apply Hex.Matrix.ext
@@ -765,10 +760,7 @@ theorem bhksRowsArrayToMatrix_toArray {m n : Nat} (B : Matrix Int n m) :
   intro i hi
   apply Vector.ext
   intro j hj
-  simpa [bhksRowsArrayToMatrix, Matrix.ofFn, Vector.get] using
-    (show (Matrix.ofFn fun i j => B[i][j])[⟨i, hi⟩][⟨j, hj⟩] =
-        B[⟨i, hi⟩][⟨j, hj⟩] by
-      rfl)
+  simp [bhksRowsArrayToMatrix, Matrix.ofFn]
 
 theorem lll_delta_lower : (1 / 4 : Rat) < 3 / 4 := by
   grind

--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -796,14 +796,11 @@ theorem mul_inv_cancel
       (1 : GFqRing.PolyQuotient f hf) = GFqRing.one f hf := by
     change GFqRing.natCast f hf 1 = GFqRing.one f hf
     rfl
-  set_option linter.unnecessarySimpa false in
   have hmulReduce :
       GFqRing.reduceMod f
           (GFqRing.repr x.toQuotient * GFqRing.reduceMod f (invPoly x.toQuotient)) =
         GFqRing.reduceMod f (GFqRing.repr x.toQuotient * invPoly x.toQuotient) := by
-    simpa [hxrepr] using
-      (GFqRing.reduceMod_mul_reduceMod f (GFqRing.repr x.toQuotient)
-        (invPoly x.toQuotient)).symm
+    simp
   apply GFqField.ext
   apply GFqRing.ext
   calc


### PR DESCRIPTION
This PR removes three `set_option linter.unnecessarySimpa false in` sites in `HexBerlekampZassenhaus/Lattice.lean` and `HexGFqField/Operations.lean`. Each guarded a `simpa ... using ...` whose `using` term was redundant: plain `simp` closes the goal, so the silences were only masking that the `simpa` was doing no more than `simp`. Replacing each `simpa` with `simp` drops the silences with no proof changes.

🤖 Prepared with Claude Code