### PR TITLE
refactor: localize the PrimeModulus assumption in the GFqRing/GFqField quotient algebra

### DIFF
--- a/HexGFqField/Operations.lean
+++ b/HexGFqField/Operations.lean
@@ -23,8 +23,6 @@ namespace Hex
 
 namespace GFqField
 
-set_option linter.unusedSectionVars false
-
 variable {p : Nat} [ZMod64.Bounds p] {hp : Hex.Nat.Prime p}
 
 /-- Natural-number literals reuse the quotient-ring cast and then rewrap the
@@ -99,7 +97,130 @@ def zsmul {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f
 
 section InverseInternals
 
-variable [ZMod64.PrimeModulus p]
+-- These helpers are modulus-agnostic (they use the `hp : Hex.Nat.Prime p`
+-- hypothesis where primality is needed, not the `ZMod64.PrimeModulus` instance),
+-- so they precede the `variable [ZMod64.PrimeModulus p]` that the inverse
+-- machinery below relies on.
+
+/-- Nonzero field elements have nonzero quotient representatives. This connects
+field-level hypotheses to the quotient-level helper lemmas. -/
+private theorem toQuotient_ne_zero
+    {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
+    {x : FiniteField f hf hp hirr} (hx : x ≠ zero f hf hp hirr) :
+    x.toQuotient ≠ (0 : GFqRing.PolyQuotient f hf) := by
+  intro hq
+  apply hx
+  exact GFqField.ext hq
+
+/-- A nonzero `ZMod64 p` scalar is coprime to prime `p`, supplying the unit
+fact needed for constant-scaling inverses. -/
+private theorem zmod64_coprime_of_prime_ne_zero
+    (hp : Hex.Nat.Prime p) {a : ZMod64 p} (ha : a ≠ 0) :
+    Nat.Coprime a.toNat p := by
+  rw [Nat.Coprime]
+  have hnot_dvd : ¬ p ∣ a.toNat := by
+    intro hdiv
+    rcases hdiv with ⟨k, hk⟩
+    have ha_pos : 0 < a.toNat := by
+      by_cases hnat : a.toNat = 0
+      · exfalso
+        apply ha
+        apply ZMod64.ext
+        apply UInt64.toNat_inj.mp
+        exact hnat
+      · exact Nat.pos_of_ne_zero hnat
+    have hk_pos : 0 < k := by
+      cases k with
+      | zero =>
+          exfalso
+          have : a.toNat = 0 := by simpa using hk
+          omega
+      | succ k => exact Nat.succ_pos k
+    have hle : p ≤ a.toNat := by
+      rw [hk]
+      simpa [Nat.mul_comm] using Nat.le_mul_of_pos_left p hk_pos
+    exact (Nat.not_le_of_gt a.toNat_lt) hle
+  have hgcd_dvd_p : Nat.gcd a.toNat p ∣ p := Nat.gcd_dvd_right a.toNat p
+  rcases hp.2 (Nat.gcd a.toNat p) hgcd_dvd_p with hgcd | hgcd
+  · exact hgcd
+  · exfalso
+    apply hnot_dvd
+    rcases Nat.gcd_dvd_left a.toNat p with ⟨k, hk⟩
+    rw [hgcd] at hk
+    exact ⟨k, hk⟩
+
+/-- Scaling the unit polynomial by `c` is the constant polynomial `C c`, the base
+case for relating scalar multiplication to constant-polynomial multiplication. -/
+private theorem scale_one_poly (c : ZMod64 p) :
+    DensePoly.scale c (1 : FpPoly p) = DensePoly.C c := by
+  apply DensePoly.ext_coeff
+  intro n
+  have hzero : c * (0 : ZMod64 p) = 0 := by grind
+  rw [DensePoly.coeff_scale _ _ _ hzero]
+  change c * (DensePoly.C (1 : ZMod64 p)).coeff n = (DensePoly.C c).coeff n
+  rw [DensePoly.coeff_C, DensePoly.coeff_C]
+  cases n with
+  | zero => grind
+  | succ n => exact hzero
+
+/-- Scaling a constant polynomial multiplies its constant coefficient, providing
+the coefficient-level normalization for constant factors. -/
+private theorem scale_C (c d : ZMod64 p) :
+    DensePoly.scale c (DensePoly.C d : FpPoly p) = DensePoly.C (c * d) := by
+  apply DensePoly.ext_coeff
+  intro n
+  have hzero : c * (0 : ZMod64 p) = 0 := by grind
+  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_C, DensePoly.coeff_C]
+  cases n with
+  | zero => rfl
+  | succ n => exact hzero
+
+/-- A polynomial with degree exactly zero is its constant coefficient polynomial,
+identifying degree-zero xgcd gcd witnesses as constants. -/
+private theorem eq_C_of_degree_eq_zero
+    (g : FpPoly p) (hdeg : g.degree? = some 0) :
+    g = DensePoly.C (g.coeff 0) := by
+  have hsize : g.size = 1 := by
+    unfold DensePoly.degree? at hdeg
+    by_cases hzero : g.size = 0
+    · simp [hzero] at hdeg
+    · have hpred : g.size - 1 = 0 := by
+        simpa [hzero] using hdeg
+      omega
+  apply DensePoly.ext_coeff
+  intro n
+  rw [DensePoly.coeff_C]
+  by_cases hn : n = 0
+  · simp [hn]
+  · have hle : g.size ≤ n := by omega
+    rw [DensePoly.coeff_eq_zero_of_size_le g hle]
+    simp [hn]
+
+/-- A degree-zero polynomial has nonzero constant coefficient, supplying the
+nonzero scalar needed to invert a constant xgcd gcd witness. -/
+private theorem coeff_zero_ne_zero_of_degree_eq_zero
+    (g : FpPoly p) (hdeg : g.degree? = some 0) :
+    g.coeff 0 ≠ 0 := by
+  have hsize : g.size = 1 := by
+    unfold DensePoly.degree? at hdeg
+    by_cases hzero : g.size = 0
+    · simp [hzero] at hdeg
+    · have hpred : g.size - 1 = 0 := by
+        simpa [hzero] using hdeg
+      omega
+  have h := DensePoly.coeff_last_ne_zero_of_pos_size g (by omega)
+  simp only [hsize] at h
+  exact h
+
+/-- Polynomial divisibility is transitive, chaining xgcd divisibility facts into
+the downstream inverse-soundness argument. -/
+private theorem dvd_trans_poly {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨u, hu⟩
+  rcases hbc with ⟨v, hv⟩
+  refine ⟨u * v, ?_⟩
+  rw [hv, hu]
+  exact DensePoly.mul_assoc_poly a u v
 
 /-- The inverse polynomial representative for a quotient element.
 
@@ -112,6 +233,74 @@ def invPoly {f : FpPoly p} {hf : 0 < FpPoly.degree f}
   let r := DensePoly.xgcd (GFqRing.repr x) f
   let unitInv : ZMod64 p := (r.gcd.coeff 0)⁻¹
   DensePoly.scale unitInv r.left
+
+/-- A nonzero `ZMod64 p` scalar multiplies with its inverse to one, turning the
+coprimality fact into the scalar cancellation used below. -/
+private theorem zmod64_mul_inv_eq_one_of_prime_ne_zero
+    (hp : Hex.Nat.Prime p) {a : ZMod64 p} (ha : a ≠ 0) :
+    a * a⁻¹ = 1 := by
+  have hcop := zmod64_coprime_of_prime_ne_zero hp ha
+  have hinv : (a⁻¹ * a).toNat = (1 : ZMod64 p).toNat := by
+    exact ZMod64.inv_mul_eq_one (p := p) a hcop
+  have hcomm : a * a⁻¹ = a⁻¹ * a := by grind
+  rw [hcomm]
+  apply ZMod64.ext
+  apply UInt64.toNat_inj.mp
+  simpa [ZMod64.toNat_eq_val] using hinv
+
+/-- Left multiplication by a constant polynomial agrees with `DensePoly.scale`,
+allowing inverse soundness proofs to move between the two forms. -/
+private theorem C_mul_eq_scale (c : ZMod64 p) (f : FpPoly p) :
+    DensePoly.C c * f = DensePoly.scale c f := by
+  have hscale := FpPoly.scale_mul_left c (1 : FpPoly p) f
+  rw [FpPoly.one_mul, scale_one_poly] at hscale
+  exact hscale.symm
+
+/-- A nonzero constant polynomial times its inverse constant is one, giving the
+polynomial-level cancellation used in divisibility reversal. -/
+private theorem C_mul_C_inv_of_ne_zero
+    (hp : Hex.Nat.Prime p) {c : ZMod64 p} (hc : c ≠ 0) :
+    (DensePoly.C c : FpPoly p) * DensePoly.C c⁻¹ = 1 := by
+  rw [C_mul_eq_scale, scale_C, zmod64_mul_inv_eq_one_of_prime_ne_zero hp hc]
+  rfl
+
+/-- Scaling a nonzero constant polynomial by the inverse scalar yields one,
+supporting the normalized xgcd gcd witness. -/
+private theorem scale_inv_C_eq_one_of_ne_zero
+    (hp : Hex.Nat.Prime p) {c : ZMod64 p} (hc : c ≠ 0) :
+    DensePoly.scale c⁻¹ (DensePoly.C c : FpPoly p) = 1 := by
+  rw [scale_C]
+  have hmul : c⁻¹ * c = 1 := by
+    have hright := zmod64_mul_inv_eq_one_of_prime_ne_zero hp hc
+    have hcomm : c⁻¹ * c = c * c⁻¹ := by grind
+    rw [hcomm]
+    exact hright
+  rw [hmul]
+  rfl
+
+/-- If multiplying `g` by a degree-zero factor gives `f`, then `f` divides `g`
+by cancelling the nonzero constant factor. -/
+private theorem dvd_left_of_mul_const_right_eq
+    (hp : Hex.Nat.Prime p) {g r f : FpPoly p}
+    (hfg : g * r = f) (hrdeg : r.degree? = some 0) :
+    f ∣ g := by
+  let c := r.coeff 0
+  have hrC : r = DensePoly.C c := eq_C_of_degree_eq_zero r hrdeg
+  have hc : c ≠ 0 := coeff_zero_ne_zero_of_degree_eq_zero r hrdeg
+  refine ⟨DensePoly.C c⁻¹, ?_⟩
+  have hfgC : g * DensePoly.C c = f := by
+    rw [← hfg, hrC]
+  calc
+    g = g * (1 : FpPoly p) := by rw [FpPoly.mul_one]
+    _ = g * (DensePoly.C c * DensePoly.C c⁻¹) := by
+      rw [C_mul_C_inv_of_ne_zero hp hc]
+    _ = (g * DensePoly.C c) * DensePoly.C c⁻¹ := by
+      exact (DensePoly.mul_assoc_poly g (DensePoly.C c) (DensePoly.C c⁻¹)).symm
+    _ = f * DensePoly.C c⁻¹ := by
+      rw [hfgC]
+
+-- The extended-gcd / inverse machinery below needs `ZMod64 p` to be a field.
+variable [ZMod64.PrimeModulus p]
 
 /-- The extended-gcd output gives the unscaled Bezout identity for the reduced
 representative and the modulus. -/
@@ -192,16 +381,6 @@ private theorem reduceMod_repr_mul_invPoly_eq_scaled_gcd
           (DensePoly.xgcd (GFqRing.repr x) f).gcd) := by
           rw [scaled_xgcd_repr_bezout x]
 
-/-- Nonzero field elements have nonzero quotient representatives. This connects
-field-level hypotheses to the quotient-level helper lemmas. -/
-private theorem toQuotient_ne_zero
-    {f : FpPoly p} {hf : 0 < FpPoly.degree f} {hirr : FpPoly.Irreducible f}
-    {x : FiniteField f hf hp hirr} (hx : x ≠ zero f hf hp hirr) :
-    x.toQuotient ≠ (0 : GFqRing.PolyQuotient f hf) := by
-  intro hq
-  apply hx
-  exact GFqField.ext hq
-
 /-- The xgcd gcd witness divides the nonzero field representative. -/
 private theorem xgcd_repr_gcd_dvd_repr
     {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -217,181 +396,6 @@ private theorem xgcd_repr_gcd_dvd_modulus
     (DensePoly.xgcd (GFqRing.repr x) f).gcd ∣ f := by
   simpa [← DensePoly.gcd_eq_xgcd_gcd]
     using DensePoly.gcd_dvd_right (GFqRing.repr x) f
-
-/-- A nonzero `ZMod64 p` scalar is coprime to prime `p`, supplying the unit
-fact needed for constant-scaling inverses. -/
-private theorem zmod64_coprime_of_prime_ne_zero
-    (hp : Hex.Nat.Prime p) {a : ZMod64 p} (ha : a ≠ 0) :
-    Nat.Coprime a.toNat p := by
-  rw [Nat.Coprime]
-  have hnot_dvd : ¬ p ∣ a.toNat := by
-    intro hdiv
-    rcases hdiv with ⟨k, hk⟩
-    have ha_pos : 0 < a.toNat := by
-      by_cases hnat : a.toNat = 0
-      · exfalso
-        apply ha
-        apply ZMod64.ext
-        apply UInt64.toNat_inj.mp
-        exact hnat
-      · exact Nat.pos_of_ne_zero hnat
-    have hk_pos : 0 < k := by
-      cases k with
-      | zero =>
-          exfalso
-          have : a.toNat = 0 := by simpa using hk
-          omega
-      | succ k => exact Nat.succ_pos k
-    have hle : p ≤ a.toNat := by
-      rw [hk]
-      simpa [Nat.mul_comm] using Nat.le_mul_of_pos_left p hk_pos
-    exact (Nat.not_le_of_gt a.toNat_lt) hle
-  have hgcd_dvd_p : Nat.gcd a.toNat p ∣ p := Nat.gcd_dvd_right a.toNat p
-  rcases hp.2 (Nat.gcd a.toNat p) hgcd_dvd_p with hgcd | hgcd
-  · exact hgcd
-  · exfalso
-    apply hnot_dvd
-    rcases Nat.gcd_dvd_left a.toNat p with ⟨k, hk⟩
-    rw [hgcd] at hk
-    exact ⟨k, hk⟩
-
-/-- A nonzero `ZMod64 p` scalar multiplies with its inverse to one, turning the
-coprimality fact into the scalar cancellation used below. -/
-private theorem zmod64_mul_inv_eq_one_of_prime_ne_zero
-    (hp : Hex.Nat.Prime p) {a : ZMod64 p} (ha : a ≠ 0) :
-    a * a⁻¹ = 1 := by
-  have hcop := zmod64_coprime_of_prime_ne_zero hp ha
-  have hinv : (a⁻¹ * a).toNat = (1 : ZMod64 p).toNat := by
-    exact ZMod64.inv_mul_eq_one (p := p) a hcop
-  have hcomm : a * a⁻¹ = a⁻¹ * a := by grind
-  rw [hcomm]
-  apply ZMod64.ext
-  apply UInt64.toNat_inj.mp
-  simpa [ZMod64.toNat_eq_val] using hinv
-
-/-- Scaling the unit polynomial by `c` is the constant polynomial `C c`, the base
-case for relating scalar multiplication to constant-polynomial multiplication. -/
-private theorem scale_one_poly (c : ZMod64 p) :
-    DensePoly.scale c (1 : FpPoly p) = DensePoly.C c := by
-  apply DensePoly.ext_coeff
-  intro n
-  have hzero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero]
-  change c * (DensePoly.C (1 : ZMod64 p)).coeff n = (DensePoly.C c).coeff n
-  rw [DensePoly.coeff_C, DensePoly.coeff_C]
-  cases n with
-  | zero => grind
-  | succ n => exact hzero
-
-/-- Left multiplication by a constant polynomial agrees with `DensePoly.scale`,
-allowing inverse soundness proofs to move between the two forms. -/
-private theorem C_mul_eq_scale (c : ZMod64 p) (f : FpPoly p) :
-    DensePoly.C c * f = DensePoly.scale c f := by
-  have hscale := FpPoly.scale_mul_left c (1 : FpPoly p) f
-  rw [FpPoly.one_mul, scale_one_poly] at hscale
-  exact hscale.symm
-
-/-- Scaling a constant polynomial multiplies its constant coefficient, providing
-the coefficient-level normalization for constant factors. -/
-private theorem scale_C (c d : ZMod64 p) :
-    DensePoly.scale c (DensePoly.C d : FpPoly p) = DensePoly.C (c * d) := by
-  apply DensePoly.ext_coeff
-  intro n
-  have hzero : c * (0 : ZMod64 p) = 0 := by grind
-  rw [DensePoly.coeff_scale _ _ _ hzero, DensePoly.coeff_C, DensePoly.coeff_C]
-  cases n with
-  | zero => rfl
-  | succ n => exact hzero
-
-/-- A nonzero constant polynomial times its inverse constant is one, giving the
-polynomial-level cancellation used in divisibility reversal. -/
-private theorem C_mul_C_inv_of_ne_zero
-    (hp : Hex.Nat.Prime p) {c : ZMod64 p} (hc : c ≠ 0) :
-    (DensePoly.C c : FpPoly p) * DensePoly.C c⁻¹ = 1 := by
-  rw [C_mul_eq_scale, scale_C, zmod64_mul_inv_eq_one_of_prime_ne_zero hp hc]
-  rfl
-
-/-- Scaling a nonzero constant polynomial by the inverse scalar yields one,
-supporting the normalized xgcd gcd witness. -/
-private theorem scale_inv_C_eq_one_of_ne_zero
-    (hp : Hex.Nat.Prime p) {c : ZMod64 p} (hc : c ≠ 0) :
-    DensePoly.scale c⁻¹ (DensePoly.C c : FpPoly p) = 1 := by
-  rw [scale_C]
-  have hmul : c⁻¹ * c = 1 := by
-    have hright := zmod64_mul_inv_eq_one_of_prime_ne_zero hp hc
-    have hcomm : c⁻¹ * c = c * c⁻¹ := by grind
-    rw [hcomm]
-    exact hright
-  rw [hmul]
-  rfl
-
-/-- A polynomial with degree exactly zero is its constant coefficient polynomial,
-identifying degree-zero xgcd gcd witnesses as constants. -/
-private theorem eq_C_of_degree_eq_zero
-    (g : FpPoly p) (hdeg : g.degree? = some 0) :
-    g = DensePoly.C (g.coeff 0) := by
-  have hsize : g.size = 1 := by
-    unfold DensePoly.degree? at hdeg
-    by_cases hzero : g.size = 0
-    · simp [hzero] at hdeg
-    · have hpred : g.size - 1 = 0 := by
-        simpa [hzero] using hdeg
-      omega
-  apply DensePoly.ext_coeff
-  intro n
-  rw [DensePoly.coeff_C]
-  by_cases hn : n = 0
-  · simp [hn]
-  · have hle : g.size ≤ n := by omega
-    rw [DensePoly.coeff_eq_zero_of_size_le g hle]
-    simp [hn]
-
-/-- A degree-zero polynomial has nonzero constant coefficient, supplying the
-nonzero scalar needed to invert a constant xgcd gcd witness. -/
-private theorem coeff_zero_ne_zero_of_degree_eq_zero
-    (g : FpPoly p) (hdeg : g.degree? = some 0) :
-    g.coeff 0 ≠ 0 := by
-  have hsize : g.size = 1 := by
-    unfold DensePoly.degree? at hdeg
-    by_cases hzero : g.size = 0
-    · simp [hzero] at hdeg
-    · have hpred : g.size - 1 = 0 := by
-        simpa [hzero] using hdeg
-      omega
-  have h := DensePoly.coeff_last_ne_zero_of_pos_size g (by omega)
-  simp only [hsize] at h
-  exact h
-
-/-- Polynomial divisibility is transitive, chaining xgcd divisibility facts into
-the downstream inverse-soundness argument. -/
-private theorem dvd_trans_poly {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
-    a ∣ c := by
-  rcases hab with ⟨u, hu⟩
-  rcases hbc with ⟨v, hv⟩
-  refine ⟨u * v, ?_⟩
-  rw [hv, hu]
-  exact DensePoly.mul_assoc_poly a u v
-
-/-- If multiplying `g` by a degree-zero factor gives `f`, then `f` divides `g`
-by cancelling the nonzero constant factor. -/
-private theorem dvd_left_of_mul_const_right_eq
-    (hp : Hex.Nat.Prime p) {g r f : FpPoly p}
-    (hfg : g * r = f) (hrdeg : r.degree? = some 0) :
-    f ∣ g := by
-  let c := r.coeff 0
-  have hrC : r = DensePoly.C c := eq_C_of_degree_eq_zero r hrdeg
-  have hc : c ≠ 0 := coeff_zero_ne_zero_of_degree_eq_zero r hrdeg
-  refine ⟨DensePoly.C c⁻¹, ?_⟩
-  have hfgC : g * DensePoly.C c = f := by
-    rw [← hfg, hrC]
-  calc
-    g = g * (1 : FpPoly p) := by rw [FpPoly.mul_one]
-    _ = g * (DensePoly.C c * DensePoly.C c⁻¹) := by
-      rw [C_mul_C_inv_of_ne_zero hp hc]
-    _ = (g * DensePoly.C c) * DensePoly.C c⁻¹ := by
-      exact (DensePoly.mul_assoc_poly g (DensePoly.C c) (DensePoly.C c⁻¹)).symm
-    _ = f * DensePoly.C c⁻¹ := by
-      rw [hfgC]
 
 /-- For a nonzero residue class modulo irreducible `f`, the xgcd gcd witness
 is a constant polynomial. -/

--- a/HexGFqRing/Basic.lean
+++ b/HexGFqRing/Basic.lean
@@ -36,9 +36,7 @@ end FpPoly
 
 namespace GFqRing
 
-set_option linter.unusedSectionVars false
-
-variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+variable {p : Nat} [ZMod64.Bounds p]
 
 /-- Canonical remainder reduction modulo `f`, using the existing division surface. -/
 @[expose]
@@ -127,6 +125,10 @@ instance {f : FpPoly p} {hf : 0 < FpPoly.degree f} : DecidableEq (PolyQuotient f
     exact hx ((eq_zero_iff_repr_eq_zero x).2 hrepr)
   · intro hx hzero
     exact hx ((eq_zero_iff_repr_eq_zero x).1 hzero)
+
+-- The remaining `reduceMod` algebra rests on `DensePoly` division laws that
+-- require `ZMod64 p` to be a field, so from here the modulus must be prime.
+variable [ZMod64.PrimeModulus p]
 
 /-- Canonical representatives have degree strictly below the modulus. -/
 @[simp] theorem degree_repr_lt_degree {f : FpPoly p} {hf : 0 < FpPoly.degree f}

--- a/HexGFqRing/Operations.lean
+++ b/HexGFqRing/Operations.lean
@@ -23,9 +23,7 @@ namespace Hex
 
 namespace GFqRing
 
-set_option linter.unusedSectionVars false
-
-variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+variable {p : Nat} [ZMod64.Bounds p]
 
 /-- The quotient zero element. -/
 @[expose]
@@ -329,18 +327,69 @@ theorem natCast_eq_natCast_iff_mod_eq
     repr (x ^ n) = repr (pow x n) :=
   rfl
 
-/-- Public alias for `reduceMod_mul_reduceMod_congr`: reducing both factors before quotient
-reduction preserves the canonical representative. -/
-theorem reduceMod_mul_reduceMod (f : FpPoly p) (a b : FpPoly p) :
-    reduceMod f (a * b) = reduceMod f (reduceMod f a * reduceMod f b) :=
-  reduceMod_mul_reduceMod_congr f a b
+/-- Proof-only linear recurrence `x^(n+1) = x^n * x`, used to discharge the
+`pow_zero` / `pow_succ` fields of the `Lean.Grind.Semiring` instance. The
+executable `pow` is square-and-multiply (`O(log n)`); `pow_eq_linearPow` ties
+the two together. -/
+@[expose]
+def linearPow {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) : Nat → PolyQuotient f hf
+  | 0 => 1
+  | n + 1 => linearPow x n * x
 
-/-- The canonical representative of a quotient element is already reduced. -/
-@[simp, grind =] theorem reduceMod_repr {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+@[simp] private theorem linearPow_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x : PolyQuotient f hf) :
-    reduceMod f (repr x) = repr x := by
-  rcases x.2 with ⟨g, hx⟩
-  simp [repr, hx]
+    linearPow x 0 = 1 :=
+  rfl
+
+@[simp] private theorem linearPow_succ {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) (n : Nat) :
+    linearPow x (n + 1) = linearPow x n * x :=
+  rfl
+
+private theorem fpPoly_C_add (a b : ZMod64 p) :
+    FpPoly.C (a + b) = (FpPoly.C a + FpPoly.C b : FpPoly p) := by
+  apply DensePoly.ext_coeff
+  intro i
+  by_cases hi : i = 0
+  · subst i
+    change DensePoly.coeff (DensePoly.C (a + b)) 0 =
+      DensePoly.coeff (DensePoly.C a + DensePoly.C b) 0
+    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
+      DensePoly.coeff_C, DensePoly.coeff_C]
+    simp
+  · change DensePoly.coeff (DensePoly.C (a + b)) i =
+      DensePoly.coeff (DensePoly.C a + DensePoly.C b) i
+    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
+      DensePoly.coeff_C, DensePoly.coeff_C]
+    simp [hi]
+    show (0 : ZMod64 p) = 0 + 0
+    grind
+
+/-- Textbook iterated addition `x + x + ⋯ + x` (`n` summands), used only as a proof
+device. The public `nsmul` runs binary decomposition via `nsmul.go`; this textbook
+form mediates between that implementation and the `Lean.Grind.Semiring` axioms via
+`nsmul_eq_linearNSmul`. -/
+private def linearNSmul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) : Nat → PolyQuotient f hf
+  | 0 => 0
+  | n + 1 => linearNSmul x n + x
+
+/-- Recurrence base of `linearNSmul`. Consumed indirectly by the public `nsmul_zero`
+through `nsmul_eq_linearNSmul`. -/
+@[simp] private theorem linearNSmul_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) :
+    linearNSmul x 0 = 0 :=
+  rfl
+
+/-- Recurrence step of `linearNSmul`. This is the textbook `n+1 ↦ pred + 1` shape
+that `Lean.Grind.Semiring.nsmul_succ` consumes (via `nsmul_eq_linearNSmul`); the
+shape is forbidden for the implementation `nsmul.go`, which uses binary
+decomposition. -/
+@[simp] private theorem linearNSmul_succ {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) (n : Nat) :
+    linearNSmul x (n + 1) = linearNSmul x n + x :=
+  rfl
 
 /-- `ofPoly` applied to the zero polynomial yields the canonical zero quotient element. -/
 @[simp, grind =] theorem ofPoly_zero_eq_zero
@@ -360,6 +409,173 @@ theorem reduceMod_mul_reduceMod (f : FpPoly p) (a b : FpPoly p) :
     ofPoly f hf (FpPoly.C c) = const f hf c :=
   rfl
 
+/-- The representative of a negated constructed quotient element is the
+canonical reduction of the negated canonical representative. -/
+@[simp, grind =] theorem repr_neg_ofPoly
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a : FpPoly p) :
+    repr (-(ofPoly f hf a)) = reduceMod f (-reduceMod f a) :=
+  rfl
+
+/-- The representative of a difference of constructed quotient elements is the
+canonical reduction of the difference of their canonical representatives. -/
+@[simp, grind =] theorem repr_sub_ofPoly
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a b : FpPoly p) :
+    repr (ofPoly f hf a - ofPoly f hf b) =
+      reduceMod f (reduceMod f a - reduceMod f b) :=
+  rfl
+
+/-- Representative-level commutativity of addition used by quotient additive reasoning. -/
+theorem repr_add_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x y : PolyQuotient f hf) :
+    repr (x + y) = repr (y + x) := by
+  simp [repr_add, FpPoly.add_comm]
+
+/-- Representative-level left zero multiplication used by the quotient semiring instance. -/
+theorem repr_zero_mul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) :
+    repr (0 * x) = 0 := by
+  rw [repr_mul, repr_zero]
+  calc
+    reduceMod f (reduceMod f 0 * repr x)
+        = reduceMod f (0 * repr x) := by
+          rw [reduceMod_zero f hf]
+    _ = reduceMod f 0 := by
+          rw [FpPoly.zero_mul]
+    _ = 0 := reduceMod_zero f hf
+
+/-- Representative-level right zero multiplication used by the quotient semiring instance. -/
+theorem repr_mul_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) :
+    repr (x * 0) = 0 := by
+  rw [repr_mul, repr_zero]
+  calc
+    reduceMod f (repr x * reduceMod f 0)
+        = reduceMod f (repr x * 0) := by
+          rw [reduceMod_zero f hf]
+    _ = reduceMod f 0 := by
+          rw [FpPoly.mul_zero]
+    _ = 0 := reduceMod_zero f hf
+
+/-- Representative-level commutativity of multiplication used by the quotient commutative ring instance. -/
+theorem repr_mul_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x y : PolyQuotient f hf) :
+    repr (x * y) = repr (y * x) := by
+  simp [repr_mul, FpPoly.mul_comm]
+
+private theorem const_add (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a b : ZMod64 p) :
+    const f hf (a + b) = const f hf a + const f hf b := by
+  apply ext
+  rw [repr_const, repr_add, repr_const, repr_const]
+  have ha :
+      reduceMod f (FpPoly.C a) = FpPoly.C a := by
+    apply reduceMod_eq_self_of_degree_lt
+    simpa using hf
+  have hb :
+      reduceMod f (FpPoly.C b) = FpPoly.C b := by
+    apply reduceMod_eq_self_of_degree_lt
+    simpa using hf
+  rw [ha, hb, ← fpPoly_C_add]
+
+/-- `linearPow_mul_comm` supplies commutativity for quotient multiplication when
+the odd binary-decomposition step reorders the final base factor. -/
+private theorem linearPow_mul_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (a b : PolyQuotient f hf) :
+    a * b = b * a := by
+  apply ext
+  exact repr_mul_comm a b
+
+/-- The `OfNat` literal at `n + 1` decomposes as the `OfNat` literal at `n` plus one in the
+quotient ring. Witnesses the `Lean.Grind.Semiring.natCast_succ` axiom field. -/
+theorem natCast_succ (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
+    (OfNat.ofNat (α := PolyQuotient f hf) (n + 1)) =
+      OfNat.ofNat (α := PolyQuotient f hf) n + 1 := by
+  change natCast f hf (n + 1) = natCast f hf n + natCast f hf 1
+  rw [natCast_eq_const, natCast_eq_const, natCast_eq_const]
+  have hsucc : ((n + 1 : Nat) : ZMod64 p) = (n : ZMod64 p) + 1 := by
+    exact Lean.Grind.Semiring.ofNat_succ (α := ZMod64 p) n
+  rw [hsucc]
+  exact const_add f hf (n : ZMod64 p) (1 : ZMod64 p)
+
+/-- Integer cast of a non-negative integer unfolds to the corresponding `natCast`. -/
+@[simp, grind =] theorem intCast_ofNat
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
+    intCast f hf (.ofNat n) = natCast f hf n :=
+  rfl
+
+/-- Integer cast of `-(n + 1)` is the negation of the `(n + 1)` natural-number cast. -/
+@[simp, grind =] theorem intCast_negSucc
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
+    intCast f hf (.negSucc n) = -(natCast f hf (n + 1)) :=
+  rfl
+
+/-- Canonical representative of `intCast (Int.ofNat n)` is the reduction of `C (n : ZMod64 p)`. -/
+@[simp, grind =] theorem repr_intCast_ofNat
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
+    repr (intCast f hf (.ofNat n)) = reduceMod f (FpPoly.C (n : ZMod64 p)) :=
+  rfl
+
+/-- Canonical representative of `intCast (Int.negSucc n)` is the reduction of the negation of the
+reduced `C (n + 1 : ZMod64 p)`. The double `reduceMod` is the projection of the negation of the
+canonical `natCast` representative. -/
+@[simp, grind =] theorem repr_intCast_negSucc
+    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
+    repr (intCast f hf (.negSucc n)) =
+      reduceMod f (-reduceMod f (FpPoly.C ((n + 1 : Nat) : ZMod64 p))) :=
+  rfl
+
+/-- Integer scalar multiplication by a non-negative integer unfolds to natural scalar
+multiplication. -/
+@[simp, grind =] theorem zsmul_ofNat {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (n : Nat) (x : PolyQuotient f hf) :
+    zsmul (.ofNat n) x = nsmul n x :=
+  rfl
+
+/-- Integer scalar multiplication by `-(n + 1)` is the negation of the `(n + 1)` natural scalar
+multiplication. -/
+@[simp, grind =] theorem zsmul_negSucc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (n : Nat) (x : PolyQuotient f hf) :
+    zsmul (.negSucc n) x = -(nsmul (n + 1) x) :=
+  rfl
+
+/-- Canonical representative of `zsmul (Int.ofNat n) x` reduces to the `nsmul`-level
+representative. -/
+@[simp, grind =] theorem repr_zsmul_ofNat {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (n : Nat) (x : PolyQuotient f hf) :
+    repr (zsmul (.ofNat n) x) = repr (nsmul n x) :=
+  rfl
+
+/-- Canonical representative of `zsmul (Int.negSucc n) x` is the reduction of the negation of the
+`(n + 1)` natural scalar multiplication's representative. -/
+@[simp, grind =] theorem repr_zsmul_negSucc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (n : Nat) (x : PolyQuotient f hf) :
+    repr (zsmul (.negSucc n) x) = reduceMod f (-repr (nsmul (n + 1) x)) :=
+  rfl
+
+/-- Negation of the quotient zero is the quotient zero. Used by `neg_zsmul_eq` and
+`intCast_neg_eq` (the `Lean.Grind.Ring.neg_zsmul` / `intCast_neg` axiom witnesses) for the
+boundary `n = 0` case. -/
+theorem neg_zero_eq {f : FpPoly p} {hf : 0 < FpPoly.degree f} :
+    -(0 : PolyQuotient f hf) = 0 := by
+  apply ext
+  rw [repr_neg, repr_zero, reduceMod_zero f hf, FpPoly.neg_zero, reduceMod_zero f hf]
+
+-- From here the quotient-ring algebra rests on `reduceMod` congruence lemmas
+-- that need `ZMod64 p` to be a field, so the modulus must be prime.
+variable [ZMod64.PrimeModulus p]
+
+/-- Public alias for `reduceMod_mul_reduceMod_congr`: reducing both factors before quotient
+reduction preserves the canonical representative. -/
+theorem reduceMod_mul_reduceMod (f : FpPoly p) (a b : FpPoly p) :
+    reduceMod f (a * b) = reduceMod f (reduceMod f a * reduceMod f b) :=
+  reduceMod_mul_reduceMod_congr f a b
+
+/-- The canonical representative of a quotient element is already reduced. -/
+@[simp, grind =] theorem reduceMod_repr {f : FpPoly p} {hf : 0 < FpPoly.degree f}
+    (x : PolyQuotient f hf) :
+    reduceMod f (repr x) = repr x := by
+  rcases x.2 with ⟨g, hx⟩
+  simp [repr, hx]
+
 /-- The representative of a sum of constructed quotient elements is the
 canonical reduction of the unreduced polynomial sum. This is the simp normal form
 for addition through `ofPoly`. -/
@@ -377,21 +593,6 @@ form for multiplication through `ofPoly`. -/
     repr (ofPoly f hf a * ofPoly f hf b) = reduceMod f (a * b) := by
   change reduceMod f (reduceMod f a * reduceMod f b) = reduceMod f (a * b)
   exact (reduceMod_mul_reduceMod_congr f a b).symm
-
-/-- The representative of a negated constructed quotient element is the
-canonical reduction of the negated canonical representative. -/
-@[simp, grind =] theorem repr_neg_ofPoly
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a : FpPoly p) :
-    repr (-(ofPoly f hf a)) = reduceMod f (-reduceMod f a) :=
-  rfl
-
-/-- The representative of a difference of constructed quotient elements is the
-canonical reduction of the difference of their canonical representatives. -/
-@[simp, grind =] theorem repr_sub_ofPoly
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a b : FpPoly p) :
-    repr (ofPoly f hf a - ofPoly f hf b) =
-      reduceMod f (reduceMod f a - reduceMod f b) :=
-  rfl
 
 /-- Representative-level left-zero law used to build the quotient `Lean.Grind.Semiring`. -/
 theorem repr_zero_add {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -419,12 +620,6 @@ theorem repr_add_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
           rw [FpPoly.add_zero]
     _ = repr x := reduceMod_repr x
 
-/-- Representative-level commutativity of addition used by quotient additive reasoning. -/
-theorem repr_add_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x y : PolyQuotient f hf) :
-    repr (x + y) = repr (y + x) := by
-  simp [repr_add, FpPoly.add_comm]
-
 /-- Representative-level associativity of addition used to build the quotient `Lean.Grind.Semiring`. -/
 theorem repr_add_assoc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     (x y z : PolyQuotient f hf) :
@@ -438,32 +633,6 @@ theorem repr_add_assoc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
           rw [FpPoly.add_assoc]
     _ = reduceMod f (repr x + reduceMod f (repr y + repr z)) := by
           exact (reduceMod_add_right_reduceMod f (repr x) (repr y + repr z)).symm
-
-/-- Representative-level left zero multiplication used by the quotient semiring instance. -/
-theorem repr_zero_mul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) :
-    repr (0 * x) = 0 := by
-  rw [repr_mul, repr_zero]
-  calc
-    reduceMod f (reduceMod f 0 * repr x)
-        = reduceMod f (0 * repr x) := by
-          rw [reduceMod_zero f hf]
-    _ = reduceMod f 0 := by
-          rw [FpPoly.zero_mul]
-    _ = 0 := reduceMod_zero f hf
-
-/-- Representative-level right zero multiplication used by the quotient semiring instance. -/
-theorem repr_mul_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) :
-    repr (x * 0) = 0 := by
-  rw [repr_mul, repr_zero]
-  calc
-    reduceMod f (repr x * reduceMod f 0)
-        = reduceMod f (repr x * 0) := by
-          rw [reduceMod_zero f hf]
-    _ = reduceMod f 0 := by
-          rw [FpPoly.mul_zero]
-    _ = 0 := reduceMod_zero f hf
 
 /-- Representative-level left identity law for multiplication used by the quotient semiring instance. -/
 theorem repr_one_mul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -492,12 +661,6 @@ theorem repr_mul_one {f : FpPoly p} {hf : 0 < FpPoly.degree f}
     _ = reduceMod f (repr x) := by
           rw [FpPoly.mul_one]
     _ = repr x := reduceMod_repr x
-
-/-- Representative-level commutativity of multiplication used by the quotient commutative ring instance. -/
-theorem repr_mul_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x y : PolyQuotient f hf) :
-    repr (x * y) = repr (y * x) := by
-  simp [repr_mul, FpPoly.mul_comm]
 
 /-- Representative-level associativity of multiplication used to build the quotient `Lean.Grind.Semiring`. -/
 theorem repr_mul_assoc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -569,31 +732,6 @@ theorem sub_eq_add_neg {f : FpPoly p} {hf : 0 < FpPoly.degree f}
           rw [FpPoly.sub_eq_add_neg]
     _ = reduceMod f (repr x + reduceMod f (-repr y)) := by
           exact (reduceMod_add_right_reduceMod f (repr x) (-repr y)).symm
-
-/-- Textbook iterated addition `x + x + ⋯ + x` (`n` summands), used only as a proof
-device. The public `nsmul` runs binary decomposition via `nsmul.go`; this textbook
-form mediates between that implementation and the `Lean.Grind.Semiring` axioms via
-`nsmul_eq_linearNSmul`. -/
-private def linearNSmul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) : Nat → PolyQuotient f hf
-  | 0 => 0
-  | n + 1 => linearNSmul x n + x
-
-/-- Recurrence base of `linearNSmul`. Consumed indirectly by the public `nsmul_zero`
-through `nsmul_eq_linearNSmul`. -/
-@[simp] private theorem linearNSmul_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) :
-    linearNSmul x 0 = 0 :=
-  rfl
-
-/-- Recurrence step of `linearNSmul`. This is the textbook `n+1 ↦ pred + 1` shape
-that `Lean.Grind.Semiring.nsmul_succ` consumes (via `nsmul_eq_linearNSmul`); the
-shape is forbidden for the implementation `nsmul.go`, which uses binary
-decomposition. -/
-@[simp] private theorem linearNSmul_succ {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) (n : Nat) :
-    linearNSmul x (n + 1) = linearNSmul x n + x :=
-  rfl
 
 /-- Even-index binary-decomposition gateway: doubling the base lets the recurrence
 step over two summands at once. Consumed by `nsmul_go_eq_acc_add_linearNSmul`'s
@@ -711,51 +849,6 @@ nsmul's representative and `repr x`. -/
     repr (nsmul (n + 1) x) = reduceMod f (repr (nsmul n x) + repr x) := by
   rw [nsmul_succ, repr_add]
 
-private theorem fpPoly_C_add (a b : ZMod64 p) :
-    FpPoly.C (a + b) = (FpPoly.C a + FpPoly.C b : FpPoly p) := by
-  apply DensePoly.ext_coeff
-  intro i
-  by_cases hi : i = 0
-  · subst i
-    change DensePoly.coeff (DensePoly.C (a + b)) 0 =
-      DensePoly.coeff (DensePoly.C a + DensePoly.C b) 0
-    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
-      DensePoly.coeff_C, DensePoly.coeff_C]
-    simp
-  · change DensePoly.coeff (DensePoly.C (a + b)) i =
-      DensePoly.coeff (DensePoly.C a + DensePoly.C b) i
-    rw [DensePoly.coeff_add_semiring, DensePoly.coeff_C,
-      DensePoly.coeff_C, DensePoly.coeff_C]
-    simp [hi]
-    show (0 : ZMod64 p) = 0 + 0
-    grind
-
-private theorem const_add (f : FpPoly p) (hf : 0 < FpPoly.degree f) (a b : ZMod64 p) :
-    const f hf (a + b) = const f hf a + const f hf b := by
-  apply ext
-  rw [repr_const, repr_add, repr_const, repr_const]
-  have ha :
-      reduceMod f (FpPoly.C a) = FpPoly.C a := by
-    apply reduceMod_eq_self_of_degree_lt
-    simpa using hf
-  have hb :
-      reduceMod f (FpPoly.C b) = FpPoly.C b := by
-    apply reduceMod_eq_self_of_degree_lt
-    simpa using hf
-  rw [ha, hb, ← fpPoly_C_add]
-
-/-- The `OfNat` literal at `n + 1` decomposes as the `OfNat` literal at `n` plus one in the
-quotient ring. Witnesses the `Lean.Grind.Semiring.natCast_succ` axiom field. -/
-theorem natCast_succ (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
-    (OfNat.ofNat (α := PolyQuotient f hf) (n + 1)) =
-      OfNat.ofNat (α := PolyQuotient f hf) n + 1 := by
-  change natCast f hf (n + 1) = natCast f hf n + natCast f hf 1
-  rw [natCast_eq_const, natCast_eq_const, natCast_eq_const]
-  have hsucc : ((n + 1 : Nat) : ZMod64 p) = (n : ZMod64 p) + 1 := by
-    exact Lean.Grind.Semiring.ofNat_succ (α := ZMod64 p) n
-  rw [hsucc]
-  exact const_add f hf (n : ZMod64 p) (1 : ZMod64 p)
-
 /-- Natural scalar multiplication agrees with multiplication by the corresponding `natCast`.
 Witnesses the `Lean.Grind.Semiring.nsmul_eq_natCast_mul` axiom field. -/
 theorem nsmul_eq_natCast_mul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -785,69 +878,6 @@ theorem nsmul_eq_natCast_mul {f : FpPoly p} {hf : 0 < FpPoly.degree f}
                 (Nat.cast n : PolyQuotient f hf) + 1 := by
             exact natCast_succ f hf n
           rw [hcast]
-
-/-- Integer cast of a non-negative integer unfolds to the corresponding `natCast`. -/
-@[simp, grind =] theorem intCast_ofNat
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
-    intCast f hf (.ofNat n) = natCast f hf n :=
-  rfl
-
-/-- Integer cast of `-(n + 1)` is the negation of the `(n + 1)` natural-number cast. -/
-@[simp, grind =] theorem intCast_negSucc
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
-    intCast f hf (.negSucc n) = -(natCast f hf (n + 1)) :=
-  rfl
-
-/-- Canonical representative of `intCast (Int.ofNat n)` is the reduction of `C (n : ZMod64 p)`. -/
-@[simp, grind =] theorem repr_intCast_ofNat
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
-    repr (intCast f hf (.ofNat n)) = reduceMod f (FpPoly.C (n : ZMod64 p)) :=
-  rfl
-
-/-- Canonical representative of `intCast (Int.negSucc n)` is the reduction of the negation of the
-reduced `C (n + 1 : ZMod64 p)`. The double `reduceMod` is the projection of the negation of the
-canonical `natCast` representative. -/
-@[simp, grind =] theorem repr_intCast_negSucc
-    (f : FpPoly p) (hf : 0 < FpPoly.degree f) (n : Nat) :
-    repr (intCast f hf (.negSucc n)) =
-      reduceMod f (-reduceMod f (FpPoly.C ((n + 1 : Nat) : ZMod64 p))) :=
-  rfl
-
-/-- Integer scalar multiplication by a non-negative integer unfolds to natural scalar
-multiplication. -/
-@[simp, grind =] theorem zsmul_ofNat {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (n : Nat) (x : PolyQuotient f hf) :
-    zsmul (.ofNat n) x = nsmul n x :=
-  rfl
-
-/-- Integer scalar multiplication by `-(n + 1)` is the negation of the `(n + 1)` natural scalar
-multiplication. -/
-@[simp, grind =] theorem zsmul_negSucc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (n : Nat) (x : PolyQuotient f hf) :
-    zsmul (.negSucc n) x = -(nsmul (n + 1) x) :=
-  rfl
-
-/-- Canonical representative of `zsmul (Int.ofNat n) x` reduces to the `nsmul`-level
-representative. -/
-@[simp, grind =] theorem repr_zsmul_ofNat {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (n : Nat) (x : PolyQuotient f hf) :
-    repr (zsmul (.ofNat n) x) = repr (nsmul n x) :=
-  rfl
-
-/-- Canonical representative of `zsmul (Int.negSucc n) x` is the reduction of the negation of the
-`(n + 1)` natural scalar multiplication's representative. -/
-@[simp, grind =] theorem repr_zsmul_negSucc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (n : Nat) (x : PolyQuotient f hf) :
-    repr (zsmul (.negSucc n) x) = reduceMod f (-repr (nsmul (n + 1) x)) :=
-  rfl
-
-/-- Negation of the quotient zero is the quotient zero. Used by `neg_zsmul_eq` and
-`intCast_neg_eq` (the `Lean.Grind.Ring.neg_zsmul` / `intCast_neg` axiom witnesses) for the
-boundary `n = 0` case. -/
-theorem neg_zero_eq {f : FpPoly p} {hf : 0 < FpPoly.degree f} :
-    -(0 : PolyQuotient f hf) = 0 := by
-  apply ext
-  rw [repr_neg, repr_zero, reduceMod_zero f hf, FpPoly.neg_zero, reduceMod_zero f hf]
 
 /-- Double negation in the quotient ring is the identity. Proved by the textbook additive-group
 calculation `-(-x) = -(-x) + (-x + x) = (-(-x) + -x) + x = 0 + x = x`. Used by `neg_zsmul_eq`
@@ -910,26 +940,6 @@ theorem intCast_neg_eq (f : FpPoly p) (hf : 0 < FpPoly.degree f)
   | negSucc n =>
       exact (neg_neg_eq (natCast f hf (n + 1))).symm
 
-/-- Proof-only linear recurrence `x^(n+1) = x^n * x`, used to discharge the
-`pow_zero` / `pow_succ` fields of the `Lean.Grind.Semiring` instance. The
-executable `pow` is square-and-multiply (`O(log n)`); `pow_eq_linearPow` ties
-the two together. -/
-@[expose]
-def linearPow {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) : Nat → PolyQuotient f hf
-  | 0 => 1
-  | n + 1 => linearPow x n * x
-
-@[simp] private theorem linearPow_zero {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) :
-    linearPow x 0 = 1 :=
-  rfl
-
-@[simp] private theorem linearPow_succ {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (x : PolyQuotient f hf) (n : Nat) :
-    linearPow x (n + 1) = linearPow x n * x :=
-  rfl
-
 /-- `linearPow_mul_assoc` supplies associativity for quotient multiplication in
 the proof-only recurrence used by the square-and-multiply correctness bridge. -/
 private theorem linearPow_mul_assoc {f : FpPoly p} {hf : 0 < FpPoly.degree f}
@@ -945,14 +955,6 @@ private theorem linearPow_mul_assoc_raw {f : FpPoly p} {hf : 0 < FpPoly.degree f
     mul (mul a b) c = mul a (mul b c) := by
   apply ext
   exact repr_mul_assoc a b c
-
-/-- `linearPow_mul_comm` supplies commutativity for quotient multiplication when
-the odd binary-decomposition step reorders the final base factor. -/
-private theorem linearPow_mul_comm {f : FpPoly p} {hf : 0 < FpPoly.degree f}
-    (a b : PolyQuotient f hf) :
-    a * b = b * a := by
-  apply ext
-  exact repr_mul_comm a b
 
 /-- `linearPow_mul_one_raw` restates the right-identity law in executable `mul`
 form for the zero-exponent branch of `pow.go`. -/


### PR DESCRIPTION
This PR removes the three remaining `set_option linter.unusedSectionVars false` file-level silences, in `HexGFqRing/Basic.lean`, `HexGFqRing/Operations.lean`, and `HexGFqField/Operations.lean`. Each masked a `[ZMod64.PrimeModulus p]` section variable that is genuinely used only by the reduceMod/ring-axiom/xgcd machinery requiring `ZMod64 p` to be a field; the surrounding modulus-agnostic structural lemmas (which thread the explicit `hp : Hex.Nat.Prime p` where primality is actually needed) never touch the instance. Rather than silence the linter, relocate the `[ZMod64.PrimeModulus p]` variable to a section boundary just before the first primality-dependent declaration in each file and move the agnostic declarations ahead of it, so no silence and no per-lemma `omit`/`variable ... in` annotation is required. Verified green through the Mathlib bridge (`lake build HexGFqRing HexGFqField HexGFq HexGFqMathlib`).

🤖 Prepared with Claude Code