### PR TITLE
doc: record the kernel-facing-spec / @[csimp]-impl pattern as design principle 11

### DIFF
--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -36,8 +36,10 @@ Mathlib dependency.
 
 Operations are stated as semantic contracts on the canonical
 representative. `mul` and `pow` carry mandatory `@[extern]` runtime
-paths; `add`/`sub`/`zero`/`one` lower to native `UInt64` arithmetic
-in pure Lean already, and `inv` routes through the
+paths; `add`/`sub` are one-line `ofNat` specifications, with the
+division-free branchy `UInt64` bodies in `addImpl`/`subImpl` behind
+proved `@[csimp]` equalities (design principle 11), and `inv` routes
+through the
 `@[extern "lean_hex_mpz_gcdext"]`-bearing `extGcd` declared in
 `HexArith.Int` (see "Extern contract: `mpz_gcdext`" in
 `SPEC/Libraries/hex-arith.md`). **`inv` must NOT call
@@ -51,8 +53,8 @@ blob per recursive step (the same regression class as omitting
 ```lean
 @[extern "lean_hex_zmod64_mul"]
 def ZMod64.mul (a b : ZMod64 p) : ZMod64 p := ...   -- contract below
-def ZMod64.add (a b : ZMod64 p) : ZMod64 p          -- pure Lean: native add + cond. sub
-def ZMod64.sub (a b : ZMod64 p) : ZMod64 p          -- pure Lean
+def ZMod64.add (a b : ZMod64 p) : ZMod64 p          -- spec: ofNat; runtime: addImpl (@[csimp])
+def ZMod64.sub (a b : ZMod64 p) : ZMod64 p          -- spec: ofNat; runtime: subImpl (@[csimp])
 def ZMod64.zero : ZMod64 p
 def ZMod64.one  : ZMod64 p                          -- equals zero when p = 1
 def ZMod64.inv  (a : ZMod64 p) : ZMod64 p           -- via Hex.Int.extGcd

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -179,6 +179,18 @@
     its backing store, so a later switch (e.g. to a flat
     `Vector R (n*m)`) stays invisible.
 
+11. **Kernel-facing specification, `@[csimp]` runtime implementation.**
+    Always-on cross-checks discharge concrete identities with `decide`,
+    so definitions on that path must reduce cheaply in the kernel: no
+    `dite` plumbing on the value path, no per-access `Array` list
+    traversal inside a loop. When the fast executable shape conflicts
+    with this, the public name carries the kernel-friendly
+    specification and the optimized body moves to a `*Impl` twin
+    registered by a proved `@[csimp]` equality (never
+    `@[implemented_by]`, which is unverified). Characterising lemmas
+    stay on the public name. Precedents: `DensePoly.trimTrailingZeros`,
+    `DensePoly.mul`, `ZMod64.add`/`sub`.
+
 ## Lakefile
 
 Use `precompileModules := true` only on libraries that export


### PR DESCRIPTION
This PR records the kernel-facing-specification / `@[csimp]`-runtime-implementation pattern introduced by https://github.com/kim-em/hex-dev/pull/8610 as design principle 11 in `SPEC/design-principles.md`, and updates the `hex-mod-arith` SPEC's operations section to match (`add`/`sub` are `ofNat` specifications with the division-free `UInt64` bodies in `addImpl`/`subImpl`).

Merge after https://github.com/kim-em/hex-dev/pull/8610.

🤖 Prepared with Claude Code