### PR TITLE
refactor: require p < 2^64 in ZMod64.Bounds, dropping the word-modulus branches

### DIFF
--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -323,9 +323,9 @@ the fixed `smallPrimeCandidates` list with explicit primality and
 private def mkExtendedSmallPrimeCandidate? (p : Nat) :
     Option SmallPrimeCandidate :=
   if hprime : Hex.Nat.isPrimeTrial p = true then
-    if hbound : p ≤ UInt64.word then
+    if hbound : p < UInt64.word then
       let prime := Hex.Nat.isPrimeTrial_isPrime hprime
-      let bounds : ZMod64.Bounds p := { pPos := prime.pos, pLeR := hbound }
+      let bounds : ZMod64.Bounds p := { pPos := prime.pos, pLtR := hbound }
       some { p, bounds, prime }
     else
       none

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -504,10 +504,10 @@ structure SmallPrimeCandidate where
 
 /-- Build a `SmallPrimeCandidate` from a trial-division primality witness and a word-size bound on `p`. -/
 private def smallPrimeCandidateOfTrial (p : Nat)
-    (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p ≤ UInt64.word) :
+    (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p < UInt64.word) :
     SmallPrimeCandidate :=
   let prime := Hex.Nat.isPrimeTrial_isPrime hprime
-  { p, bounds := { pPos := prime.pos, pLeR := hbound }, prime }
+  { p, bounds := { pPos := prime.pos, pLtR := hbound }, prime }
 
 /-- A scored admissible small-prime candidate for default prime selection. -/
 structure PrimeCandidateScore where

--- a/HexBerlekampZassenhausMathlib/CertReify.lean
+++ b/HexBerlekampZassenhausMathlib/CertReify.lean
@@ -49,7 +49,7 @@ check. The reifier emits `boundsOfDecide p (Eq.refl true)` in every reified
 instance slot, so the kernel discharges both bounds by reduction.
 -/
 theorem boundsOfDecide (p : Nat)
-    (h : (decide (0 < p) && decide (p ≤ UInt64.word)) = true) :
+    (h : (decide (0 < p) && decide (p < UInt64.word)) = true) :
     Hex.ZMod64.Bounds p := by
   rw [Bool.and_eq_true] at h
   exact ⟨of_decide_eq_true h.1, of_decide_eq_true h.2⟩

--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -25,12 +25,14 @@ namespace Hex
 
 namespace ZMod64
 
-/-- `ZMod64 p` is only valid when `p` is positive and fits in one machine word. -/
+/-- `ZMod64 p` is only valid when `p` is positive and strictly below the
+machine-word size `2^64`, so every residue and the modulus itself fit in a
+`UInt64`. -/
 class Bounds (p : Nat) : Prop where
   /-- The modulus is positive. -/
   pPos : 0 < p
-  /-- The modulus fits in one machine word. -/
-  pLeR : p ≤ UInt64.word
+  /-- The modulus is strictly below the machine-word size `2^64`. -/
+  pLtR : p < UInt64.word
 
 end ZMod64
 
@@ -109,14 +111,14 @@ the backing `UInt64`.
 def ofNat (p n : Nat) [Bounds p] : ZMod64 p := by
   let reduced := normalize p n
   have hred : reduced < p := normalize_lt p n
-  have hword : reduced < UInt64.word := Nat.lt_of_lt_of_le hred (Bounds.pLeR (p := p))
+  have hword : reduced < UInt64.word := Nat.lt_trans hred (Bounds.pLtR (p := p))
   refine ⟨UInt64.ofNatLT reduced hword, ?_⟩
   simpa [reduced, UInt64.toNat_ofNatLT] using hred
 
 /-- The Nat representative of `ofNat p n` is `n` reduced modulo `p`. -/
 @[simp, grind =] theorem toNat_ofNat (n : Nat) : (ofNat p n).toNat = n % p := by
   have hred : n % p < p := Nat.mod_lt _ (Bounds.pPos (p := p))
-  have hword : n % p < UInt64.word := Nat.lt_of_lt_of_le hred (Bounds.pLeR (p := p))
+  have hword : n % p < UInt64.word := Nat.lt_trans hred (Bounds.pLtR (p := p))
   simp [ofNat, normalize, UInt64.toNat_ofNatLT]
 
 /-- The stored word of `ofNat p n`, viewed as a Nat, is `n` reduced modulo `p`. -/
@@ -257,7 +259,7 @@ private theorem add_carry_toNat (a b : ZMod64 p) {hpLt : p < UInt64.word}
     ((a.val + b.val) + complementWord p hpLt).toNat = a.toNat + b.toNat - p := by
   have ha : a.toNat < p := a.isLt
   have hb : b.toNat < p := b.isLt
-  have hpLe : p ≤ UInt64.word := Bounds.pLeR (p := p)
+  have hpLe : p ≤ UInt64.word := Nat.le_of_lt (Bounds.pLtR (p := p))
   have hsum_lt : a.toNat + b.toNat - UInt64.word < UInt64.word := by omega
   have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat - UInt64.word := by
     rw [UInt64.toNat_add]
@@ -464,18 +466,15 @@ correction step when `p < 2^64`, avoiding any division. Value-equal to `add`
 -/
 @[expose]
 def addImpl (a b : ZMod64 p) : ZMod64 p := by
-  by_cases hp : p = UInt64.word
-  · refine ⟨a.val + b.val, ?_⟩
-    simpa [hp, UInt64.size, UInt64.word] using (UInt64.toNat_lt_size (a.val + b.val))
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    let p64 := modulusWord p hpLt
-    let c64 := complementWord p hpLt
-    let sum := a.val + b.val
-    by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
-    · exact ⟨sum + c64, by simpa [sum, c64] using add_carry_lt a b hcarry⟩
-    · by_cases hreduce : p64 ≤ sum
-      · exact ⟨sum - p64, by simpa [sum, p64] using add_noCarry_reduce_lt a b hcarry hreduce⟩
-      · exact ⟨sum, by simpa [sum] using add_noCarry_noReduce_lt a b hcarry hreduce⟩
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  let p64 := modulusWord p hpLt
+  let c64 := complementWord p hpLt
+  let sum := a.val + b.val
+  by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
+  · exact ⟨sum + c64, by simpa [sum, c64] using add_carry_lt a b hcarry⟩
+  · by_cases hreduce : p64 ≤ sum
+    · exact ⟨sum - p64, by simpa [sum, p64] using add_noCarry_reduce_lt a b hcarry hreduce⟩
+    · exact ⟨sum, by simpa [sum] using add_noCarry_noReduce_lt a b hcarry hreduce⟩
 
 /--
 Subtract two residues: the residue of `a.toNat + (p - b.toNat)`, the canonical
@@ -495,15 +494,12 @@ complement-word correction on borrow, avoiding any division. Value-equal to
 -/
 @[expose]
 def subImpl (a b : ZMod64 p) : ZMod64 p := by
-  by_cases hp : p = UInt64.word
-  · refine ⟨a.val - b.val, ?_⟩
-    simpa [hp, UInt64.size, UInt64.word] using (UInt64.toNat_lt_size (a.val - b.val))
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    let c64 := complementWord p hpLt
-    let diff := a.val - b.val
-    by_cases hba : b.val ≤ a.val
-    · exact ⟨diff, by simpa [diff] using sub_noBorrow_lt a b hba⟩
-    · exact ⟨diff - c64, by simpa [diff, c64] using sub_borrow_lt a b hba⟩
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  let c64 := complementWord p hpLt
+  let diff := a.val - b.val
+  by_cases hba : b.val ≤ a.val
+  · exact ⟨diff, by simpa [diff] using sub_noBorrow_lt a b hba⟩
+  · exact ⟨diff - c64, by simpa [diff, c64] using sub_borrow_lt a b hba⟩
 
 /--
 Multiply two reduced residues and reduce the product mod `p`.
@@ -557,51 +553,47 @@ the branch analysis is delegated to the carry/reduce case lemmas. -/
 private theorem toNat_addImpl (a b : ZMod64 p) :
     (addImpl a b).toNat = (a.toNat + b.toNat) % p := by
   unfold addImpl
-  by_cases hp : p = UInt64.word
-  · rw [dif_pos hp]
-    simp [toNat_eq_val, UInt64.toNat_add, hp, UInt64.word]
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    rw [dif_neg hp]
-    by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
-    · rw [dif_pos hcarry]
-      change ((a.val + b.val) + complementWord p hpLt).toNat = (a.toNat + b.toNat) % p
-      rw [add_carry_toNat a b hcarry]
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
+  · rw [dif_pos hcarry]
+    change ((a.val + b.val) + complementWord p hpLt).toNat = (a.toNat + b.toNat) % p
+    rw [add_carry_toNat a b hcarry]
+    have ha : a.toNat < p := a.isLt
+    have hb : b.toNat < p := b.isLt
+    have hpSum : p ≤ a.toNat + b.toNat := by omega
+    have hlt : a.toNat + b.toNat - p < p := by omega
+    rw [Nat.mod_eq_sub_mod hpSum, Nat.mod_eq_of_lt hlt]
+  · rw [dif_neg hcarry]
+    let p64 := modulusWord p hpLt
+    let sum := a.val + b.val
+    by_cases hreduce : p64 ≤ sum
+    · rw [dif_pos hreduce]
+      change ((a.val + b.val) - modulusWord p hpLt).toNat = (a.toNat + b.toNat) % p
+      rw [add_noCarry_reduce_toNat a b hcarry hreduce]
       have ha : a.toNat < p := a.isLt
       have hb : b.toNat < p := b.isLt
-      have hpSum : p ≤ a.toNat + b.toNat := by omega
+      have hsum_lt : a.toNat + b.toNat < UInt64.word := by omega
+      have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat := by
+        rw [UInt64.toNat_add]
+        simpa [toNat_eq_val, UInt64.word] using
+          (by rw [Nat.mod_eq_of_lt hsum_lt] :
+            (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat)
+      have hreduceNat : p ≤ a.toNat + b.toNat := by
+        have := UInt64.le_iff_toNat_le.mp hreduce
+        simpa [p64, sum, hsum_toNat, modulusWord, UInt64.toNat_ofNatLT] using this
       have hlt : a.toNat + b.toNat - p < p := by omega
-      rw [Nat.mod_eq_sub_mod hpSum, Nat.mod_eq_of_lt hlt]
-    · rw [dif_neg hcarry]
-      let p64 := modulusWord p hpLt
-      let sum := a.val + b.val
-      by_cases hreduce : p64 ≤ sum
-      · rw [dif_pos hreduce]
-        change ((a.val + b.val) - modulusWord p hpLt).toNat = (a.toNat + b.toNat) % p
-        rw [add_noCarry_reduce_toNat a b hcarry hreduce]
-        have ha : a.toNat < p := a.isLt
-        have hb : b.toNat < p := b.isLt
-        have hsum_lt : a.toNat + b.toNat < UInt64.word := by omega
-        have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat := by
-          rw [UInt64.toNat_add]
-          simpa [toNat_eq_val, UInt64.word] using
-            (by rw [Nat.mod_eq_of_lt hsum_lt] :
-              (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat)
-        have hreduceNat : p ≤ a.toNat + b.toNat := by
-          have := UInt64.le_iff_toNat_le.mp hreduce
-          simpa [p64, sum, hsum_toNat, modulusWord, UInt64.toNat_ofNatLT] using this
-        have hlt : a.toNat + b.toNat - p < p := by omega
-        rw [Nat.mod_eq_sub_mod hreduceNat, Nat.mod_eq_of_lt hlt]
-      · rw [dif_neg hreduce]
-        change (a.val + b.val).toNat = (a.toNat + b.toNat) % p
-        rw [add_noCarry_noReduce_toNat a b hcarry hreduce]
-        have hnot : ¬ p ≤ a.toNat + b.toNat := by
-          intro hpSum
-          apply hreduce
-          apply UInt64.le_iff_toNat_le.mpr
-          have hsum_toNat := add_noCarry_noReduce_toNat (p := p) a b hcarry hreduce
-          change (modulusWord p hpLt).toNat ≤ (a.val + b.val).toNat
-          simpa [modulusWord, UInt64.toNat_ofNatLT, hsum_toNat] using hpSum
-        rw [Nat.mod_eq_of_lt (by omega)]
+      rw [Nat.mod_eq_sub_mod hreduceNat, Nat.mod_eq_of_lt hlt]
+    · rw [dif_neg hreduce]
+      change (a.val + b.val).toNat = (a.toNat + b.toNat) % p
+      rw [add_noCarry_noReduce_toNat a b hcarry hreduce]
+      have hnot : ¬ p ≤ a.toNat + b.toNat := by
+        intro hpSum
+        apply hreduce
+        apply UInt64.le_iff_toNat_le.mpr
+        have hsum_toNat := add_noCarry_noReduce_toNat (p := p) a b hcarry hreduce
+        change (modulusWord p hpLt).toNat ≤ (a.val + b.val).toNat
+        simpa [modulusWord, UInt64.toNat_ofNatLT, hsum_toNat] using hpSum
+      rw [Nat.mod_eq_of_lt (by omega)]
 
 /-- The kernel-facing `add` and the runtime `addImpl` compute the same residue.
 Registered `@[csimp]`, so compiled code runs the division-free machine-word
@@ -621,41 +613,35 @@ the branch analysis is delegated to the borrow case lemmas. -/
 private theorem toNat_subImpl (a b : ZMod64 p) :
     (subImpl a b).toNat = (a.toNat + (p - b.toNat)) % p := by
   unfold subImpl
-  by_cases hp : p = UInt64.word
-  · rw [dif_pos hp]
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  let c64 := complementWord p hpLt
+  let diff := a.val - b.val
+  by_cases hba : b.val ≤ a.val
+  · rw [dif_pos hba]
     change (a.val - b.val).toNat = (a.toNat + (p - b.toNat)) % p
-    rw [UInt64.toNat_sub]
-    simp [toNat_eq_val, hp, UInt64.word, Nat.add_comm]
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    rw [dif_neg hp]
-    let c64 := complementWord p hpLt
-    let diff := a.val - b.val
-    by_cases hba : b.val ≤ a.val
-    · rw [dif_pos hba]
-      change (a.val - b.val).toNat = (a.toNat + (p - b.toNat)) % p
-      rw [sub_noBorrow_toNat a b hba]
-      have hbaNat : b.toNat ≤ a.toNat := by
-        simpa [toNat_eq_val] using UInt64.le_iff_toNat_le.mp hba
-      have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
-      have ha : a.toNat < p := a.isLt
-      have hge : p ≤ a.toNat + (p - b.toNat) := by omega
-      have hlt : a.toNat + (p - b.toNat) - p < p := by omega
-      rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt hlt]
-      omega
-    · rw [dif_neg hba]
-      change ((a.val - b.val) - complementWord p hpLt).toNat =
-        (a.toNat + (p - b.toNat)) % p
-      rw [sub_borrow_toNat a b hba]
-      have hbaNat : ¬ b.toNat ≤ a.toNat := by
-        intro h
-        apply hba
-        apply UInt64.le_iff_toNat_le.mpr
-        simpa [toNat_eq_val] using h
-      have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
-      have ha : a.toNat < p := a.isLt
-      have hlt : a.toNat + (p - b.toNat) < p := by omega
-      rw [Nat.mod_eq_of_lt hlt]
-      omega
+    rw [sub_noBorrow_toNat a b hba]
+    have hbaNat : b.toNat ≤ a.toNat := by
+      simpa [toNat_eq_val] using UInt64.le_iff_toNat_le.mp hba
+    have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
+    have ha : a.toNat < p := a.isLt
+    have hge : p ≤ a.toNat + (p - b.toNat) := by omega
+    have hlt : a.toNat + (p - b.toNat) - p < p := by omega
+    rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt hlt]
+    omega
+  · rw [dif_neg hba]
+    change ((a.val - b.val) - complementWord p hpLt).toNat =
+      (a.toNat + (p - b.toNat)) % p
+    rw [sub_borrow_toNat a b hba]
+    have hbaNat : ¬ b.toNat ≤ a.toNat := by
+      intro h
+      apply hba
+      apply UInt64.le_iff_toNat_le.mpr
+      simpa [toNat_eq_val] using h
+    have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
+    have ha : a.toNat < p := a.isLt
+    have hlt : a.toNat + (p - b.toNat) < p := by omega
+    rw [Nat.mod_eq_of_lt hlt]
+    omega
 
 /-- The kernel-facing `sub` and the runtime `subImpl` compute the same residue.
 Registered `@[csimp]`, so compiled code runs the division-free machine-word

--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -83,15 +83,12 @@ private theorem neg_nonzero_lt (a : ZMod64 p) {hpLt : p < UInt64.word}
 /-- The additive inverse represented by the complementary residue mod `p`. -/
 @[expose]
 def neg (a : ZMod64 p) : ZMod64 p := by
-  by_cases hp : p = UInt64.word
-  · refine ⟨-a.val, ?_⟩
-    simpa [hp, UInt64.size, UInt64.word] using (UInt64.toNat_lt_size (-a.val))
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    let c64 := complementWord p hpLt
-    by_cases hzero : a.val = 0
-    · refine ⟨0, ?_⟩
-      simp [Bounds.pPos (p := p)]
-    · exact ⟨-a.val - c64, by simpa [c64] using neg_nonzero_lt a hzero⟩
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  let c64 := complementWord p hpLt
+  by_cases hzero : a.val = 0
+  · refine ⟨0, ?_⟩
+    simp [Bounds.pPos (p := p)]
+  · exact ⟨-a.val - c64, by simpa [c64] using neg_nonzero_lt a hzero⟩
 
 /-- Natural-number literals in `ZMod64`. -/
 @[expose]
@@ -169,31 +166,25 @@ theorem natCast_op_eq_ofNat (n : Nat) :
 /-- Negation takes the complementary representative modulo `p`. -/
 @[simp, grind =] theorem toNat_neg (a : ZMod64 p) : (neg a).toNat = (p - a.toNat) % p := by
   unfold neg
-  by_cases hp : p = UInt64.word
-  · rw [dif_pos hp]
-    change (-a.val).toNat = (p - a.toNat) % p
-    rw [UInt64.toNat_neg]
-    simp [toNat_eq_val, hp, UInt64.word]
-  · have hpLt : p < UInt64.word := Nat.lt_of_le_of_ne (Bounds.pLeR (p := p)) hp
-    rw [dif_neg hp]
-    by_cases hzero : a.val = 0
-    · rw [dif_pos hzero]
-      change (0 : UInt64).toNat = (p - a.toNat) % p
-      have htoNat : a.toNat = 0 := by simp [toNat_eq_val, hzero]
-      have hval : a.val.toNat = 0 := by simpa [toNat_eq_val] using htoNat
-      simp [toNat_eq_val, hval]
-    · rw [dif_neg hzero]
-      change (-a.val - complementWord p hpLt).toNat = (p - a.toNat) % p
-      rw [neg_nonzero_toNat a hzero]
-      have hzeroNat : a.toNat ≠ 0 := by
-        intro h
-        apply hzero
-        apply UInt64.toNat_inj.mp
-        simpa [toNat_eq_val] using h
-      have hlt : p - a.toNat < p := by
-        have ha : a.toNat < p := a.isLt
-        omega
-      rw [Nat.mod_eq_of_lt hlt]
+  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  by_cases hzero : a.val = 0
+  · rw [dif_pos hzero]
+    change (0 : UInt64).toNat = (p - a.toNat) % p
+    have htoNat : a.toNat = 0 := by simp [toNat_eq_val, hzero]
+    have hval : a.val.toNat = 0 := by simpa [toNat_eq_val] using htoNat
+    simp [toNat_eq_val, hval]
+  · rw [dif_neg hzero]
+    change (-a.val - complementWord p hpLt).toNat = (p - a.toNat) % p
+    rw [neg_nonzero_toNat a hzero]
+    have hzeroNat : a.toNat ≠ 0 := by
+      intro h
+      apply hzero
+      apply UInt64.toNat_inj.mp
+      simpa [toNat_eq_val] using h
+    have hlt : p - a.toNat < p := by
+      have ha : a.toNat < p := a.isLt
+      omega
+    rw [Nat.mod_eq_of_lt hlt]
 
 /-- Negation is the residue built from the complementary representative. -/
 theorem neg_eq_ofNat (a : ZMod64 p) :

--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -13,7 +13,7 @@ types.
 `Z/pZ` only when `p` is positive and fits in a single machine word. -/
 class ZMod64.Bounds (p : Nat) : Prop where
   pPos : 0 < p
-  pLeR : p ≤ UInt64.word        -- = 2^64
+  pLtR : p < UInt64.word        -- = 2^64
 
 structure ZMod64 (p : Nat) [Bounds p] where
   val  : UInt64
@@ -23,9 +23,11 @@ structure ZMod64 (p : Nat) [Bounds p] where
 The bounds live in a typeclass that callers provide once per
 modulus, e.g. `instance : ZMod64.Bounds 7 := ⟨by decide, by decide⟩`.
 Every operation takes `[Bounds p]` implicitly; nothing is threaded
-through call sites. `p > 2^64` is rejected at the type boundary
-because no `Bounds p` instance exists for it — and a `UInt64` cannot
-faithfully represent residues in `[2^64, p)` anyway.
+through call sites. `p ≥ 2^64` is rejected at the type boundary
+because no `Bounds p` instance exists for it — a `UInt64` cannot hold
+the modulus itself, let alone residues above it, and excluding the
+word modulus `2^64` keeps `add`/`sub`/`neg` free of a per-call
+special case.
 
 Mathlib's `Fact` is unavailable to `hex-mod-arith` (it is a
 computational library, not a Mathlib bridge). The project-local
@@ -123,7 +125,7 @@ bits while performing the same square-and-multiply recurrence on
 bit length instead of repeatedly dividing a shrinking arbitrary-
 precision `Nat` by two. The runtime result must agree with the
 logical body for every bounded modulus, including the degenerate
-modulus `1` and the word modulus `2^64`.
+modulus `1`.
 
 ## Hot-loop optimization (opt-in)
 

--- a/HexPolyFp/Packed.lean
+++ b/HexPolyFp/Packed.lean
@@ -20,7 +20,7 @@ operation. The packed kernel below mirrors the reference array long-division
 loop (`HexPoly/Euclid.lean`) over a bare `Array UInt64`, eliminating the boxing
 on the monic-division / Frobenius hot path.
 
-The arithmetic stays overflow-safe: `ZMod64.Bounds p` only gives `p ≤ 2^64`, so
+The arithmetic stays overflow-safe: `ZMod64.Bounds p` only gives `p < 2^64`, so
 `p` may exceed `2^32` and naive `UInt64` `(a*b) % p` would wrap mod `2^64`. The
 word helpers `ZMod64.mulWord` / `ZMod64.subWord` reconstruct residues and reuse
 `ZMod64.mul` / `ZMod64.sub` (the former extern-backed by a `__uint128_t`

--- a/bench/HexGF2Bench.lean
+++ b/bench/HexGF2Bench.lean
@@ -31,7 +31,7 @@ namespace Hex.GF2Bench
 
 private instance boundsTwo : ZMod64.Bounds 2 where
   pPos := by decide
-  pLeR := by decide
+  pLtR := by decide
 
 instance {p : Nat} [ZMod64.Bounds p] : Hashable (ZMod64 p) where
   hash a := hash a.toNat

--- a/bench/HexGFq/Bench.lean
+++ b/bench/HexGFq/Bench.lean
@@ -43,7 +43,7 @@ private abbrev Packed21 : Type :=
 
 private instance boundsTwo : ZMod64.Bounds 2 where
   pPos := by decide
-  pLeR := by decide
+  pLtR := by decide
 
 instance {p : Nat} [ZMod64.Bounds p] : Hashable (ZMod64 p) where
   hash a := hash a.toNat


### PR DESCRIPTION
This PR strengthens `ZMod64.Bounds` from `pLeR : p ≤ 2^64` to `pLtR : p < 2^64`. The word modulus `2^64` had no consumer in the tree (Hensel lifting keeps mod-`p^k` arithmetic on the Int-backed `ZPoly`, and `2^64` is not prime), yet supporting it cost a per-call `p = 2^64` test in `add`/`sub`/`neg` and a special branch that existed only because `modulusWord`/`complementWord` require `p < 2^64` to be definable. With the strict bound, `addImpl`/`subImpl`/`neg` lose the outer `by_cases`, their `toNat` proofs lose a branch, prime selection and the certificate reifier switch to the strict runtime test, and the `hex-mod-arith` SPEC is updated. The FFI C bodies are untouched; their word-modulus branch is now simply unreachable.

Full `lake build` (4142 jobs) plus the touched bench exes are green.

🤖 Prepared with Claude Code