### PR TITLE
style: drop redundant @[expose] on private declarations

### DIFF
--- a/HexBerlekampZassenhaus/Certificate.lean
+++ b/HexBerlekampZassenhaus/Certificate.lean
@@ -50,7 +50,6 @@ for higher-multiplicity inputs. Falls back to the un-expanded
 fully consume `repeatedPart` (e.g. when the BZ pipeline emitted the raw
 square-free core as a single core factor).
 -/
-@[expose]
 private def reassemblePolynomialFactors
     (d : FactorNormalizationData) (coreFactors : Array ZPoly) : Array ZPoly :=
   let (expanded, residual) := expandRepeatedPartFactorArray d.repeatedPart coreFactors
@@ -59,7 +58,6 @@ private def reassemblePolynomialFactors
   else
     polynomialNormalizationPrefixFactors d ++ coreFactors
 
-@[expose]
 private def factorizationOfFactors (f : ZPoly) (factors : Array ZPoly) : Factorization :=
   { scalar := signedContentScalar f
     factors := collectFactorMultiplicities factors }

--- a/HexBerlekampZassenhaus/ReassemblyProofs.lean
+++ b/HexBerlekampZassenhaus/ReassemblyProofs.lean
@@ -791,7 +791,6 @@ private theorem collectFactorMultiplicities_eq_foldl (factors : Array ZPoly) :
     collectFactorMultiplicities factors =
       (factors.toList.foldl collectFactorStep []).reverse.toArray := rfl
 
-@[expose]
 private def filteredNormalizedFactors (factors : List ZPoly) : List ZPoly :=
   factors.filterMap fun f =>
     let f := normalizeFactorSign f

--- a/HexBerlekampZassenhaus/Records.lean
+++ b/HexBerlekampZassenhaus/Records.lean
@@ -119,12 +119,10 @@ structure ToMonicData where
 
 namespace ToMonicData
 
-@[expose]
 private def transformedCoeffs (core : ZPoly) (degree : Nat) : Array Int :=
   ((List.range degree).map fun i =>
       core.coeff i * (DensePoly.leadingCoeff core) ^ (degree - 1 - i)).toArray.push 1
 
-@[expose]
 private def transformedCore (core : ZPoly) (degree : Nat) : ZPoly :=
   { coeffs := transformedCoeffs core degree
     normalized := by
@@ -249,7 +247,6 @@ deriving DecidableEq
 
 namespace Factorization
 
-@[expose]
 private def polyPow (f : ZPoly) : Nat → ZPoly
   | 0 => 1
   | n + 1 => polyPow f n * f
@@ -305,18 +302,15 @@ private def contentFactorArray (content : Int) : Array ZPoly :=
   else
     #[DensePoly.C content]
 
-@[expose]
 private def xPowerFactorArray (power : Nat) : Array ZPoly :=
   (List.replicate power ZPoly.X).toArray
 
-@[expose]
 private def repeatedPartFactorArray (repeatedPart : ZPoly) : Array ZPoly :=
   if repeatedPart = 1 then
     #[]
   else
     #[repeatedPart]
 
-@[expose]
 private def signedContentScalar (f : ZPoly) : Int :=
   if f = 0 then
     0
@@ -351,7 +345,6 @@ private def bumpFactorMultiplicity (f : ZPoly) : List (ZPoly × Nat) → List (Z
       else
         entry :: bumpFactorMultiplicity f entries
 
-@[expose]
 private def collectFactorMultiplicities (factors : Array ZPoly) : Array (ZPoly × Nat) :=
   factors.toList.foldl
     (fun acc factor =>
@@ -363,7 +356,6 @@ private def collectFactorMultiplicities (factors : Array ZPoly) : Array (ZPoly �
     []
   |>.reverse.toArray
 
-@[expose]
 private def polynomialNormalizationPrefixFactors (d : FactorNormalizationData) : Array ZPoly :=
   xPowerFactorArray d.xPower ++ repeatedPartFactorArray d.repeatedPart
 
@@ -450,7 +442,6 @@ Compute `(emitted, residual)` where each candidate factor `q` from
 `q^k` exactly divides the running repeated-part. The fuel is the source
 size, which dominates any irreducible's multiplicity in `repeatedPart`.
 -/
-@[expose]
 private def expandRepeatedPartFactorArray (rp : ZPoly) (coreFactors : Array ZPoly) :
     Array ZPoly × ZPoly :=
   expandRepeatedPartFactorsAux coreFactors.toList rp (rp.size + 1)

--- a/conformance/HexBerlekampZassenhaus/CrossCheck.lean
+++ b/conformance/HexBerlekampZassenhaus/CrossCheck.lean
@@ -70,7 +70,6 @@ roots, all factors linear). -/
 private def sortedRoots (factors : Array ZPoly) : Array Int :=
   (factors.map fun p => -(p.coeff 0)).qsort (· ≤ ·)
 
-@[expose]
 private def coeffs (f : ZPoly) : List Int :=
   f.toArray.toList
 


### PR DESCRIPTION
This PR removes 13 `@[expose]` attributes that sit on `private` declarations, where the attribute is inert: `@[expose]` controls cross-module body visibility, and a `private` declaration has none, so Lean emits a "redundant `[expose]`" warning for each. The affected declarations (in the BerlekampZassenhaus records, certificate, and reassembly layers, plus the relocated conformance cross-check) remain reachable through `backward.privateInPublic` exactly as before; only the dead attribute and its warning are gone. A full `lake build HexBerlekampZassenhaus HexConformance` is green with no remaining redundant-expose warnings.

🤖 Prepared with Claude Code