### PR TITLE
refactor: mark the csimp'd kernel-facing specs noncomputable

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -454,9 +454,11 @@ This is the kernel-reduction-friendly specification: reducing it unfolds to a
 single `Nat` addition and mod, so `decide`-style proofs walk a straight-line
 computation. Compiled code instead runs the branchy machine-word `addImpl`,
 registered by the `@[csimp]` proof `add_eq_impl`.
+Marked `noncomputable` so the specification itself is never compiled; every
+runtime caller compiles against the `@[csimp]`-registered implementation.
 -/
 @[expose]
-def add (a b : ZMod64 p) : ZMod64 p :=
+noncomputable def add (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + b.toNat)
 
 /--
@@ -482,9 +484,11 @@ representative of the modular difference.
 
 Like `add`, this is the kernel-reduction-friendly specification; compiled code
 runs the branchy machine-word `subImpl` via the `@[csimp]` proof `sub_eq_impl`.
+Marked `noncomputable` so the specification itself is never compiled; every
+runtime caller compiles against the `@[csimp]`-registered implementation.
 -/
 @[expose]
-def sub (a b : ZMod64 p) : ZMod64 p :=
+noncomputable def sub (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + (p - b.toNat))
 
 /--

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -148,9 +148,11 @@ private theorem trimTrailingZerosList_append_ne_zero (L : List R) {v : R}
 /-- Normalize a coefficient array by discarding all trailing zeros. The compiled runtime
 uses the value-equal `trimTrailingZerosImpl` (proved by `trimTrailingZeros_eq_impl`,
 registered `@[csimp]`), which pops trailing zeros off the array in place instead of
-round-tripping through `coeffs.toList`. -/
+round-tripping through `coeffs.toList`. Marked `noncomputable` so the
+specification itself is never compiled; every runtime caller compiles against
+`trimTrailingZerosImpl` through the `@[csimp]` equality. -/
 @[expose]
-def trimTrailingZeros (coeffs : Array R) : Array R :=
+noncomputable def trimTrailingZeros (coeffs : Array R) : Array R :=
   (trimTrailingZerosList coeffs.toList).toArray
 
 omit [Zero R] [DecidableEq R] in

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -267,9 +267,11 @@ This definition is the kernel-reduction-friendly specification: the accumulator
 is a plain list walked head-first, so reducing a concrete product costs one
 cons-step per `(i, j)` coefficient pair instead of an O(size) list traversal
 per `Array` access. Compiled code instead runs the in-place `Array` loop
-`mulImpl`, registered by the `@[csimp]` proof `mul_eq_impl`. -/
+`mulImpl`, registered by the `@[csimp]` proof `mul_eq_impl`. Marked
+`noncomputable` so the specification itself is never compiled; every runtime
+caller compiles against `mulImpl` through the `@[csimp]` equality. -/
 @[expose]
-def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
+noncomputable def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
   if p.isZero || q.isZero then 0 else
     let size := p.size + q.size - 1
     ofCoeffs (mulRows q.toArray.toList p.toArray.toList


### PR DESCRIPTION
This PR marks the four kernel-facing specifications that carry `@[csimp]` runtime implementations (`ZMod64.add`/`sub`, `DensePoly.mul`, `DensePoly.trimTrailingZeros`) as `noncomputable`, making it compiler-enforced that these definitions are not for computation. The `@[csimp]` equalities are sufficient for every consumer to compile against the impl twins, so nothing downstream changes; the spec bodies simply stop being compiled at all (verified absent from the generated C, with the operator-instance closures still pointing at `addImpl`/`subImpl`/`mulImpl`).

Stacked on https://github.com/kim-em/hex-dev/pull/8612; full `lake build` (4142 jobs) is green.

🤖 Prepared with Claude Code