### PR TITLE
refactor: add noncomputable DensePoly.toList as the spec-level coefficient list view

### DIFF
--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -104,7 +104,7 @@ theorem normalize_lt (p n : Nat) [Bounds p] : normalize p n < p :=
 /--
 Build a reduced residue by taking the Nat representative mod `p`.
 
-The bound `p ≤ 2^64` ensures the reduced representative is stored faithfully in
+The bound `p < 2^64` ensures the reduced representative is stored faithfully in
 the backing `UInt64`.
 -/
 @[expose]

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -678,6 +678,20 @@ coefficient function. -/
     p.toArray.getD n (Zero.zero : R) = p.coeff n := by
   rfl
 
+/-- Spec-level view of the stored coefficients as a list, lowest degree first.
+`noncomputable` by design: kernel-facing specifications, theorem statements,
+and proofs read coefficients through this list view, while runtime code stays
+on the `Array` API. A deliberate runtime list round-trip spells out
+`toArray.toList` explicitly. -/
+@[expose]
+noncomputable def toList (p : DensePoly R) : List R :=
+  p.toArray.toList
+
+/-- The spec-level coefficient list has one entry per stored coefficient. -/
+@[simp, grind =] theorem length_toList (p : DensePoly R) :
+    p.toList.length = p.size := by
+  simp [toList, toArray, size]
+
 /-- Normalizing the already-normalized coefficient array reconstructs the same polynomial. -/
 @[simp, grind =] theorem ofCoeffs_toArray (p : DensePoly R) :
     ofCoeffs p.toArray = p := by
@@ -686,10 +700,10 @@ coefficient function. -/
   rw [coeff_ofCoeffs]
   rfl
 
-/-- Building from the exposed normalized coefficient list reconstructs the same polynomial. -/
-@[simp, grind =] theorem ofList_toArray_toList (p : DensePoly R) :
-    ofList p.toArray.toList = p := by
-  simp [ofList]
+/-- Building from the spec-level coefficient list reconstructs the same polynomial. -/
+@[simp, grind =] theorem ofList_toList (p : DensePoly R) :
+    ofList p.toList = p := by
+  simp [toList, ofList]
 
 /-- Normalizing an empty coefficient array gives the zero polynomial. -/
 @[simp, grind =] theorem ofCoeffs_empty :

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -77,7 +77,7 @@ private theorem list_getD_replicate_append_zero (n k : Nat) (coeffs : List R) :
 omit [DecidableEq R] in
 /-- Default-indexed read of `(List.range size).map f`: index `n` reads `f n` when
 `n < size` and the default `0` otherwise. The workhorse indexing fact for the coefficient-
-list extensionality proofs (e.g. `toArray_toList_eq_coeff_range`). -/
+list extensionality proofs (e.g. `toList_eq_coeff_range`). -/
 private theorem list_getD_map_range (size n : Nat) (f : Nat → R) :
     ((List.range size).map f).getD n (Zero.zero : R) =
       if n < size then f n else (Zero.zero : R) := by
@@ -272,7 +272,7 @@ per `Array` access. Compiled code instead runs the in-place `Array` loop
 noncomputable def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
   if p.isZero || q.isZero then 0 else
     let size := p.size + q.size - 1
-    ofCoeffs (mulRows q.toArray.toList p.toArray.toList
+    ofCoeffs (mulRows q.toList p.toList
       (List.replicate size (Zero.zero : R))).toArray
 
 /-- Runtime implementation of `mul`: the same schoolbook convolution computed
@@ -667,10 +667,11 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
                       Nat.add_sub_add_right, Nat.add_le_add_iff_right,
                       List.length_cons]
 
-/-- Reading a stored coefficient list with default zero agrees with `DensePoly.coeff`. -/
-theorem toArray_toList_getD_eq_coeff (p : DensePoly R) (n : Nat) :
-    p.toArray.toList.getD n (Zero.zero : R) = p.coeff n := by
-  unfold toArray coeff
+/-- Reading the spec-level coefficient list with default zero agrees with
+`DensePoly.coeff`. -/
+theorem toList_getD_eq_coeff (p : DensePoly R) (n : Nat) :
+    p.toList.getD n (Zero.zero : R) = p.coeff n := by
+  unfold toList toArray coeff
   rw [Array.getD_eq_getD_getElem?]
   change p.coeffs.toList[n]?.getD (Zero.zero : R) =
     p.coeffs[n]?.getD (Zero.zero : R)
@@ -703,10 +704,9 @@ private theorem coeff_mul_spec [Add R] [Mul R] (p q : DensePoly R) (n : Nat) :
     have hp_pos : 0 < p.size := (DensePoly.isZero_eq_false_iff p).1 hp_not
     have hq_pos : 0 < q.size := (DensePoly.isZero_eq_false_iff q).1 hq_not
     rw [coeff_ofCoeffs, toArray_getD_eq_getD, mulRows_getD, mulCoeffSum_eq_singleFold]
-    · simp only [toArray_toList_getD_eq_coeff, Array.length_toList, toArray_size,
-        list_getD_replicate]
+    · simp only [toList_getD_eq_coeff, length_toList, list_getD_replicate]
     · intro i hi j hj
-      simp only [Array.length_toList, toArray_size] at hi hj
+      simp only [length_toList] at hi hj
       simp only [List.length_replicate]
       omega
 
@@ -935,8 +935,8 @@ def composeScalarCoeffList [Add R] [Mul R] :
 when the caller supplies the algebraic step that commutes a Horner tail past `q`. -/
 theorem compose_eq_composeScalarCoeffList_of_step [Add R] [Mul R] (p q : DensePoly R)
     (hstep : ∀ acc c, acc * q + C c = C c + q * acc) :
-    compose p q = composeScalarCoeffList p.toArray.toList q := by
-  unfold compose
+    compose p q = composeScalarCoeffList p.toList q := by
+  unfold compose toList
   induction p.toArray.toList with
   | nil => rfl
   | cons c cs ih =>
@@ -988,7 +988,7 @@ theorem composeCoeffPowerSumFrom_range_eq_upTo [One R] [Add R] [Mul R]
 
 omit [DecidableEq R] in
 /-- List extensionality through default-indexed reads: two lists of equal length that agree
-under `getD` at every in-bounds index are equal. Used by `toArray_toList_eq_coeff_range` to
+under `getD` at every in-bounds index are equal. Used by `toList_eq_coeff_range` to
 identify the stored coefficient list with the range of coefficient reads. -/
 private theorem list_eq_of_length_eq_of_getD_eq
     {xs ys : List R}
@@ -1015,15 +1015,15 @@ private theorem list_eq_of_length_eq_of_getD_eq
             simpa using h
           rw [hhead, htail]
 
-/-- The stored coefficient list is the range of coefficient reads over `p.size`. -/
-theorem toArray_toList_eq_coeff_range (p : DensePoly R) :
-    p.toArray.toList = (List.range p.size).map (fun i => p.coeff i) := by
+/-- The spec-level coefficient list is the range of coefficient reads over `p.size`. -/
+theorem toList_eq_coeff_range (p : DensePoly R) :
+    p.toList = (List.range p.size).map (fun i => p.coeff i) := by
   apply list_eq_of_length_eq_of_getD_eq
-  · simp [toArray, size]
+  · simp [toList, toArray, size]
   · intro i hi
     have hi_size : i < p.size := by
-      simpa [toArray, size] using hi
-    rw [toArray_toList_getD_eq_coeff, list_getD_map_range]
+      simpa [toList, toArray, size] using hi
+    rw [toList_getD_eq_coeff, list_getD_map_range]
     simp [hi_size]
 
 /-- Formal derivative. The coefficient of `x^i` becomes `(i + 1) * a_(i+1)`. -/

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -165,15 +165,15 @@ private theorem composeScalarCoeffList_eq_powerSumFrom_zero (q : FpPoly p) :
 
 /-- `DensePoly.compose` agrees with the iterative power-sum form. -/
 private theorem compose_eq_powerSum (f q : FpPoly p) :
-    DensePoly.compose f q = composeCoeffPowerSumFrom f.toArray.toList 0 q := by
+    DensePoly.compose f q = composeCoeffPowerSumFrom f.toList 0 q := by
   rw [DensePoly.compose_eq_composeScalarCoeffList_of_step f q]
-  · exact composeScalarCoeffList_eq_powerSumFrom_zero q f.toArray.toList
+  · exact composeScalarCoeffList_eq_powerSumFrom_zero q f.toList
   · intro acc c
     rw [FpPoly.add_comm, FpPoly.mul_comm q acc]
 
 /-- `DensePoly.compose f q` agrees with the iterative Horner form. -/
 theorem compose_eq_composeScalarCoeffList (f q : FpPoly p) :
-    DensePoly.compose f q = DensePoly.composeScalarCoeffList f.toArray.toList q := by
+    DensePoly.compose f q = DensePoly.composeScalarCoeffList f.toList q := by
   apply DensePoly.compose_eq_composeScalarCoeffList_of_step
   intro acc c
   rw [FpPoly.add_comm, FpPoly.mul_comm q acc]
@@ -258,9 +258,9 @@ private theorem composeCoeffPowerSumFrom_replicate_zero_append_one
       congr 1
       omega
 
-private theorem monomial_one_toArray_toList_eq
+private theorem monomial_one_toList_eq
     [ZMod64.PrimeModulus p] (k : Nat) :
-    (DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).toArray.toList =
+    (DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).toList =
       List.replicate k (Zero.zero : ZMod64 p) ++ [(1 : ZMod64 p)] := by
   have h1 : (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := one_ne_zero_of_prime
   show ((DensePoly.monomial k (1 : ZMod64 p) : FpPoly p).coeffs.toList :
@@ -276,7 +276,7 @@ private theorem compose_monomial_k_one_eq
     DensePoly.compose
         ((DensePoly.monomial k (1 : ZMod64 p)) : FpPoly p) w =
       linearPow w k := by
-  rw [compose_eq_powerSum, monomial_one_toArray_toList_eq,
+  rw [compose_eq_powerSum, monomial_one_toList_eq,
     composeCoeffPowerSumFrom_replicate_zero_append_one]
   rw [Nat.zero_add]
 
@@ -361,7 +361,7 @@ extend-past-the-bound variant `compose_eq_coeff_power_sum_upTo_bound` follows. -
 private theorem compose_eq_coeff_power_sum_upTo_size (f w : FpPoly p) :
     DensePoly.compose f w =
       composeCoeffPowerSumUpTo (fun i => f.coeff i) f.size 0 w := by
-  rw [compose_eq_powerSum, DensePoly.toArray_toList_eq_coeff_range]
+  rw [compose_eq_powerSum, DensePoly.toList_eq_coeff_range]
   simpa using composeCoeffPowerSumFrom_range_eq_upTo (fun i => f.coeff i) w f.size 0
 
 /-- Single-step extension invariance: when the next coefficient
@@ -606,13 +606,13 @@ private theorem compose_ofCoeffs_eq_composeScalarCoeffList
     DensePoly.compose (DensePoly.ofCoeffs cs.toArray : FpPoly p) q =
       DensePoly.composeScalarCoeffList cs q := by
   rw [compose_eq_composeScalarCoeffList]
-  have htoArray :
-      (DensePoly.ofCoeffs cs.toArray : FpPoly p).toArray.toList =
+  have htoList :
+      (DensePoly.ofCoeffs cs.toArray : FpPoly p).toList =
         DensePoly.trimTrailingZerosList cs := by
     show (DensePoly.trimTrailingZeros cs.toArray).toList =
       DensePoly.trimTrailingZerosList cs
     simp [DensePoly.trimTrailingZeros]
-  rw [htoArray, composeScalarCoeffList_trim]
+  rw [htoList, composeScalarCoeffList_trim]
 
 /-- Generic add-comm-monoid rearrangement: `A + B + (C + D) = D + B + C + A`. -/
 private theorem fp_add_acm_rearrange
@@ -797,6 +797,7 @@ theorem compose_mul_X_sub_C [ZMod64.PrimeModulus p]
       DensePoly.compose a w * (w - FpPoly.C c) := by
   rw [mul_X_sub_C_eq_ofCoeffs_mulXSubCList, compose_ofCoeffs_eq_composeScalarCoeffList,
     composeScalarCoeffList_mulXSubCList, compose_eq_composeScalarCoeffList]
+  rfl
 
 /-! ### foldl transport for the prime-field linear product
 

--- a/progress/20260705T150000Z_bounds-noncomputable-tolist.md
+++ b/progress/20260705T150000Z_bounds-noncomputable-tolist.md
@@ -1,0 +1,36 @@
+# Bounds strictness, noncomputable specs, DensePoly.toList
+
+Session type: feature follow-ups to issue #8606, stacked branches
+`bounds-lt-word` <- `noncomputable-specs` <- `toList-spec`.
+
+## Accomplished
+
+- `ZMod64.Bounds.pLeR (p <= 2^64)` -> `pLtR (p < 2^64)` (PR #8612): the word
+  modulus had no consumer; `addImpl`/`subImpl`/`neg` lose the per-call
+  `p = 2^64` branch, their `toNat` proofs lose a case, prime selection and
+  `CertReify.boundsOfDecide` use the strict test.
+- The four csimp'd kernel-facing specs (`ZMod64.add`/`sub`, `DensePoly.mul`,
+  `DensePoly.trimTrailingZeros`) are `noncomputable` (PR #8614). Verified that
+  `@[csimp]` alone keeps all consumers compilable and that the spec bodies
+  vanish from the generated C entirely.
+- `noncomputable def DensePoly.toList := toArray.toList` (PR #8615), used by
+  the `mul` spec and the migrated core characterisations
+  (`toList_getD_eq_coeff`, `toList_eq_coeff_range`, `ofList_toList`,
+  `length_toList`, `compose_eq_composeScalarCoeffList*` and their HexPolyFp
+  users). No `@[csimp]` twin on purpose: the compiler rejects runtime uses.
+- One-sentence SPEC extension of design principle 11 (PR #8616, docs-only).
+
+## Current frontier
+
+All three full-tree builds green (4142 jobs each). CI running on the stack.
+
+## Next step
+
+Merge order once green and approved: #8612 -> #8614 -> #8615 -> #8616.
+Follow-up candidate: give `eval`/`scale`/`shift`/`compose` the same
+spec/impl split so their specs move onto `toList` and their runtime
+bodies stop round-tripping through lists.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds `DensePoly.toList := toArray.toList` as a `noncomputable` spec-level view of the stored coefficients and migrates the spec/proof layer to it: the kernel-facing `DensePoly.mul` specification, the core characterisations (`toList_getD_eq_coeff`, `toList_eq_coeff_range`, `ofList_toList`, `length_toList`, `compose_eq_composeScalarCoeffList`\*), and their users in `HexPolyFp`. Because `toList` is `noncomputable` with no `@[csimp]` twin, the compiler now enforces the boundary: executable definitions and cold-path serializers (conformance drivers, benches) cannot call it and keep the explicit `toArray.toList` spelling, which marks every remaining deliberate runtime list round-trip.

The executable bodies of `eval`/`scale`/`shift`/`compose` still round-trip through lists at runtime and so keep `toArray.toList`; giving them the same kernel-facing-spec / `@[csimp]`-impl split as `mul` (and moving their specs onto `toList`) is natural follow-up work.

Stacked on https://github.com/kim-em/hex-dev/pull/8614; full `lake build` (4142 jobs) is green.

🤖 Prepared with Claude Code