### PR TITLE
doc: note the noncomputable convention for csimp'd specs and spec-level views

### DIFF
--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -193,8 +193,10 @@
     reduction), while the `@[csimp]` proof redirects each occurrence
     that reaches code generation to the `*Impl`, so the slow reference
     body is never emitted as dead compiled code. Proof-mode and kernel
-    `decide` uses still see the public specification. Characterising
-    lemmas stay on the public name. Precedents: `DensePoly.trimTrailingZeros`, `DensePoly.mul`,
+    `decide` uses still see the public specification. Spec-level views
+    without a runtime twin (e.g. `DensePoly.toList`) are likewise
+    `noncomputable`, so runtime code cannot silently round-trip through
+    them. Characterising lemmas stay on the public name. Precedents: `DensePoly.trimTrailingZeros`, `DensePoly.mul`,
     `ZMod64.add`/`sub`, `Matrix.mul`, `Vector.dotProduct`.
 
 ## Lakefile


### PR DESCRIPTION
This PR extends design principle 11 with one sentence: spec-level views without a runtime twin, such as `DensePoly.toList`, are likewise `noncomputable`, so runtime code cannot silently round-trip through them. (The rest of the earlier version of this PR landed independently via https://github.com/kim-em/hex-dev/pull/8623.)

Merge after https://github.com/kim-em/hex-dev/pull/8615.

🤖 Prepared with Claude Code