### PR TITLE
refactor: migrate the last List.finRange index fold (setPrefix) to Fin.foldl

### DIFF
--- a/HexLLLMathlib/Reducer.lean
+++ b/HexLLLMathlib/Reducer.lean
@@ -119,7 +119,7 @@ private theorem vector_modify_get_ne {α : Type*} {n : Nat}
 /-- Inner foldl in `swapStep`'s `setPrefixFrom`: setting positions `0..km1-1` of a
 row to `source[·]`. -/
 private def setPrefix (source row : Vector Int n) (km1 : Fin n) : Vector Int n :=
-  (List.finRange km1.val).foldl
+  Fin.foldl km1.val
     (fun row j =>
       let jFin : Fin n := ⟨j.val, Nat.lt_trans j.isLt km1.isLt⟩
       row.set jFin (source.get jFin))
@@ -201,14 +201,16 @@ private theorem setPrefix_get_lt {source row : Vector Int n} {km1 : Fin n}
     (l : Fin n) (hl : l.val < km1.val) :
     (setPrefix source row km1).get l = source.get l := by
   unfold setPrefix
-  rw [foldl_setSource_get_eq (Nat.le_of_lt km1.isLt) source row l]
+  rw [Fin.foldl_eq_finRange_foldl,
+    foldl_setSource_get_eq (Nat.le_of_lt km1.isLt) source row l]
   simp [hl]
 
 private theorem setPrefix_get_ge {source row : Vector Int n} {km1 : Fin n}
     (l : Fin n) (hl : km1.val ≤ l.val) :
     (setPrefix source row km1).get l = row.get l := by
   unfold setPrefix
-  rw [foldl_setSource_get_eq (Nat.le_of_lt km1.isLt) source row l]
+  rw [Fin.foldl_eq_finRange_foldl,
+    foldl_setSource_get_eq (Nat.le_of_lt km1.isLt) source row l]
   simp [Nat.not_lt.mpr hl]
 
 /-- Outer foldl in `swapStep` over rows above `k`. The update applied to row `i`
@@ -384,17 +386,19 @@ private theorem swapStep_valid (s : LLLState n m) (k : Nat)
             (setPrefix (s.ν.getRow km1) · km1) with hνRows_def
         set νPivot : Hex.Matrix Int n n := νRowsSwapped.modifyRow kFin.val (·.set km1 B)
           with hνPivot_def
-        -- Unfold the goal to expose the ν' foldl, then apply
-        -- `foldl_modify_rows_get`.
-        simp only [Fin.foldl_eq_finRange_foldl]
-        change
-          (((List.finRange n).foldl
+        -- Fold the goal's outer `ν'` loop over the opaque `νPivot` base, then
+        -- convert only that outer `Fin.foldl n` to `List.finRange` for
+        -- `foldl_modify_matrix_getRow`. The inner `setPrefix` folds live inside
+        -- `νPivot` and stay as `Fin.foldl`, matching its definition.
+        show
+          ((Fin.foldl n
               (fun (ν : Hex.Matrix Int n n) (i : Fin n) =>
                 if _ : k < i.val then
                   ν.modifyRow i.val (upd i)
                 else ν)
               νPivot).getRow iFin).get jFin =
             ((GramSchmidt.Int.scaledCoeffs b').getRow iFin).get jFin
+        rw [Fin.foldl_eq_finRange_foldl]
         have hν'_get :
             ((List.finRange n).foldl
                 (fun (ν : Hex.Matrix Int n n) (i : Fin n) =>

--- a/progress/20260705T224934Z_issue-8554.md
+++ b/progress/20260705T224934Z_issue-8554.md
@@ -1,0 +1,42 @@
+# Issue #8554 — migrate List.finRange folds to Fin.foldl
+
+## Accomplished
+
+- Investigated the scope of #8554 ("migrate `(List.finRange n).foldl`
+  index folds to core `Fin.foldl`"). Discovered that PR #8556 (same
+  title, merged 2026-07-04) already performed the substantive sweep
+  across HexMatrix / HexDeterminant / HexGramSchmidt / HexLLL and their
+  Mathlib bridge layers. #8554 remained open only because #8556
+  referenced it in prose without a closing keyword.
+- Audited every remaining `(List.finRange).foldl` occurrence in the
+  scoped libraries and classified each as one of the four categories
+  #8556 deliberately kept (kernel-reducible `dotProduct` reference form,
+  proof-internal bridge targets, enumerated-data folds over
+  `permutationVectors`/`columnTupleVectors`, and the public `*_foldl_*`
+  reference-form theorems paired with `*_finFoldl_*`). Independently
+  confirmed via grep that only two def-level `List.finRange` index folds
+  remain: `Vector.dotProduct` (intentionally kept, `@[csimp]`-bridged)
+  and `HexLLLMathlib/Reducer.lean`'s private `setPrefix`.
+- Migrated the one genuine leftover: `setPrefix` now runs
+  `Fin.foldl km1.val` directly, matching its already-migrated native
+  counterpart `setPrefixFrom` in `HexLLL/Native.lean`. Ported the two
+  characterization lemmas (`setPrefix_get_lt`/`_ge`) with
+  `Fin.foldl_eq_finRange_foldl`, and reworked the `swapStep_valid`
+  correspondence proof so it converts only the outer `ν'` fold to
+  `List.finRange` (via `show` over the opaque `νPivot` base, then a
+  single `rw`), leaving the inner `setPrefix` folds as `Fin.foldl`.
+- Full `lake build` green (4142 jobs), no new warnings.
+
+## Current frontier
+
+- Change confined to `HexLLLMathlib/Reducer.lean` (12 insertions,
+  8 deletions). Ready for second opinion + PR.
+
+## Next step
+
+- Get a second opinion, then open the PR against `main`. The PR
+  completes the last index-fold definition and lets #8554 close.
+
+## Blockers
+
+- None.

--- a/progress/20260705T225104Z_issue-8554-review.md
+++ b/progress/20260705T225104Z_issue-8554-review.md
@@ -1,0 +1,28 @@
+# Issue #8554 review pass
+
+## Accomplished
+
+- Reviewed the `HexLLLMathlib/Reducer.lean` diff that migrates private
+  `setPrefix` from `(List.finRange km1.val).foldl` to `Fin.foldl km1.val`.
+- Checked the surrounding `setPrefix_get_lt` / `setPrefix_get_ge` proofs and the
+  `swapStep_valid` rewrite site.
+- Ran `lake build HexLLLMathlib.Reducer`; it completed successfully.
+- Re-ran scoped `rg` searches over the split-library directories to distinguish
+  executable def-level index folds from proof/reference-form `List.finRange`
+  folds.
+
+## Current frontier
+
+- The migration still appears confined to `HexLLLMathlib/Reducer.lean`.
+- The one remaining untracked progress note from the implementation turn is
+  still present.
+
+## Next step
+
+- Open the PR with the reducer-local migration and mention the successful full
+  build from the implementation pass plus the targeted reducer build from this
+  review pass.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR migrates the private `setPrefix` model in `HexLLLMathlib/Reducer.lean` from `(List.finRange km1.val).foldl` to core `Fin.foldl km1.val`, matching its already-migrated native counterpart `setPrefixFrom` in `HexLLL/Native.lean`, and completes the sweep requested in https://github.com/kim-em/hex-dev/issues/8554 "refactor: migrate List.finRange folds to Fin.foldl across the library". The substantive migration across HexMatrix, HexDeterminant, HexGramSchmidt, and HexLLL landed earlier in https://github.com/kim-em/hex-dev/pull/8556 "refactor: migrate List.finRange folds to Fin.foldl across the library"; an audit of the scoped libraries shows `setPrefix` was the one remaining def-level `List.finRange` index fold, leaving only `Vector.dotProduct`'s intentionally kernel-reducible reference form (kept with a `@[csimp]` `Fin.foldl` implementation).

The two characterization lemmas `setPrefix_get_lt` / `setPrefix_get_ge` bridge back to the list form with `Fin.foldl_eq_finRange_foldl` before reusing the existing `foldl_setSource_get_eq` helper. The `swapStep_valid` correspondence proof previously converted both the outer `ν'` fold and the inner native folds to `List.finRange` with a single `simp only`; because `setPrefix` is now `Fin.foldl`, the proof instead `show`s the goal with the outer fold as `Fin.foldl n` over the opaque `set`-bound `νPivot` base and then rewrites only that outer fold, leaving the inner `setPrefix` folds as `Fin.foldl`.

Statement content is unchanged and the runtime path was already `Fin.foldl`, so this is purely the model form catching up to the native form. The full `lake build` is green.

🤖 Prepared with Claude Code