### PR TITLE
perf: mark kernel-facing @[csimp] specs noncomputable

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -26,7 +26,7 @@ namespace Nat
 Binomial coefficients on natural numbers, defined by the Pascal recursion.
 -/
 @[expose]
-def choose : Nat -> Nat -> Nat
+noncomputable def choose : Nat -> Nat -> Nat
   | _, 0 => 1
   | 0, _ + 1 => 0
   | n + 1, k + 1 => choose n k + choose n (k + 1)

--- a/HexMatrix/Basic.lean
+++ b/HexMatrix/Basic.lean
@@ -52,7 +52,7 @@ and `dotProduct_eq_impl`. The native form will then kernel-reduce on its own, so
 the `memLattice` `decide` checks keep working without the `List.finRange`
 reference allocation. -/
 @[expose]
-def dotProduct [Mul R] [Add R] [OfNat R 0] (u v : Vector R n) : R :=
+noncomputable def dotProduct [Mul R] [Add R] [OfNat R 0] (u v : Vector R n) : R :=
   (List.finRange n).foldl (fun acc i => acc + u[i] * v[i]) 0
 
 /-- Allocation-free implementation of `dotProduct`: a `Fin.foldl` loop that never
@@ -335,7 +335,7 @@ rebuilt for every row of `M`.
 We intend to provide Strassen-Winograd with a customizable algorithm for small sizes later.
 -/
 @[expose]
-def mul [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (N : Matrix R m k) :
+noncomputable def mul [Mul R] [Add R] [OfNat R 0] (M : Matrix R n m) (N : Matrix R m k) :
     Matrix R n k :=
   ofFn fun i j => (row M i).dotProduct (col N j)
 

--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -456,7 +456,7 @@ computation. Compiled code instead runs the branchy machine-word `addImpl`,
 registered by the `@[csimp]` proof `add_eq_impl`.
 -/
 @[expose]
-def add (a b : ZMod64 p) : ZMod64 p :=
+noncomputable def add (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + b.toNat)
 
 /--
@@ -484,7 +484,7 @@ Like `add`, this is the kernel-reduction-friendly specification; compiled code
 runs the branchy machine-word `subImpl` via the `@[csimp]` proof `sub_eq_impl`.
 -/
 @[expose]
-def sub (a b : ZMod64 p) : ZMod64 p :=
+noncomputable def sub (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + (p - b.toNat))
 
 /--

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -150,7 +150,7 @@ uses the value-equal `trimTrailingZerosImpl` (proved by `trimTrailingZeros_eq_im
 registered `@[csimp]`), which pops trailing zeros off the array in place instead of
 round-tripping through `coeffs.toList`. -/
 @[expose]
-def trimTrailingZeros (coeffs : Array R) : Array R :=
+noncomputable def trimTrailingZeros (coeffs : Array R) : Array R :=
   (trimTrailingZerosList coeffs.toList).toArray
 
 omit [Zero R] [DecidableEq R] in

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -564,7 +564,7 @@ the final `(quotient, remainder)` pair. The compiled runtime uses the value-equa
 `divModArrayAuxImpl` (proved by `divModArrayAux_eq_impl`, registered `@[csimp]`), which
 tracks the working degree instead of rescanning. -/
 @[expose]
-def divModArrayAux [Sub R] [Mul R]
+noncomputable def divModArrayAux [Sub R] [Mul R]
     (q : Array R) (qDegree : Nat) (scaleLead : R → R)
     (fuel : Nat) (quot rem : Array R) : Array R × Array R :=
   match fuel with

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -269,7 +269,7 @@ cons-step per `(i, j)` coefficient pair instead of an O(size) list traversal
 per `Array` access. Compiled code instead runs the in-place `Array` loop
 `mulImpl`, registered by the `@[csimp]` proof `mul_eq_impl`. -/
 @[expose]
-def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
+noncomputable def mul [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
   if p.isZero || q.isZero then 0 else
     let size := p.size + q.size - 1
     ofCoeffs (mulRows q.toArray.toList p.toArray.toList

--- a/SPEC/design-principles.md
+++ b/SPEC/design-principles.md
@@ -187,9 +187,15 @@
     with this, the public name carries the kernel-friendly
     specification and the optimized body moves to a `*Impl` twin
     registered by a proved `@[csimp]` equality (never
-    `@[implemented_by]`, which is unverified). Characterising lemmas
-    stay on the public name. Precedents: `DensePoly.trimTrailingZeros`,
-    `DensePoly.mul`, `ZMod64.add`/`sub`.
+    `@[implemented_by]`, which is unverified). Mark the specification
+    `noncomputable`: the kernel still reduces its body for `decide`
+    (`noncomputable` suppresses only code generation, not kernel
+    reduction), while the `@[csimp]` proof redirects each occurrence
+    that reaches code generation to the `*Impl`, so the slow reference
+    body is never emitted as dead compiled code. Proof-mode and kernel
+    `decide` uses still see the public specification. Characterising
+    lemmas stay on the public name. Precedents: `DensePoly.trimTrailingZeros`, `DensePoly.mul`,
+    `ZMod64.add`/`sub`, `Matrix.mul`, `Vector.dotProduct`.
 
 ## Lakefile
 

--- a/progress/20260705T232618Z_noncomputable-csimp-specs.md
+++ b/progress/20260705T232618Z_noncomputable-csimp-specs.md
@@ -1,0 +1,39 @@
+# Mark kernel-facing `@[csimp]` specs `noncomputable`
+
+## Accomplished
+
+- Established empirically that a `noncomputable` spec with a proved
+  `@[csimp]` twin is fully viable: the spec still kernel-reduces for
+  `decide` (`noncomputable` suppresses only code generation), compiled
+  callers are redirected to the `*Impl` by csimp, and this holds through
+  transitive callers and the polymorphic typeclass signatures used here.
+  This keeps the proof-carrying csimp guarantee (unlike the forbidden
+  `@[implemented_by]`) while no longer emitting the slow reference body
+  as dead compiled code.
+- Marked all eight kernel-facing `@[csimp]` specs `noncomputable`:
+  `ZMod64.add`/`sub` (HexModArith), `Vector.dotProduct` /
+  `Matrix.mul` (HexMatrix), `DensePoly.mul` (HexPoly.Operations),
+  `Nat.choose` (HexArith.Nat.Prime), `divModArrayAux`
+  (HexPoly.Euclid.DivGcd), `trimTrailingZeros` (HexPoly.Dense). The
+  `*Impl` twins stay computable.
+- Updated design principle 11 (SPEC/design-principles.md) to mandate the
+  `noncomputable` spec and refreshed its precedent list.
+- Verified: full `lake build` green (4142 jobs); `HexConformance` and the
+  bench exes build green; `hexmatrix_bench` / `hexmodarith_bench` /
+  `hexarith_bench` verify pass; `hexpoly_bench` non-Flint benchmarks all
+  pass (the 44 Flint failures are environmental -- `python-flint` is not
+  installed here -- not from this change).
+
+## Current frontier
+
+- Change confined to 8 spec defs + principle 11. Ready for second opinion
+  and PR.
+
+## Next step
+
+- Second opinion, then PR against `main`; branch
+  `noncomputable-csimp-specs`.
+
+## Blockers
+
+- None.

--- a/progress/20260705T232743Z_noncomputable-csimp-review.md
+++ b/progress/20260705T232743Z_noncomputable-csimp-review.md
@@ -1,0 +1,34 @@
+# Review noncomputable `@[csimp]` specs
+
+## Accomplished
+
+- Reviewed the current `noncomputable` markings for the eight active
+  proof-backed `@[csimp]` specification definitions:
+  `Hex.Nat.choose`, `Vector.dotProduct`, `Matrix.mul`, `ZMod64.add`,
+  `ZMod64.sub`, `DensePoly.trimTrailingZeros`, `DensePoly.mul`, and
+  `DensePoly.divModArrayAux`.
+- Grepped the repository for live `@[csimp]` declarations and found no
+  additional active source-level spec/implementation pair that needs the same
+  marking for consistency.
+- Probed representative compiled-call shapes against the current tree:
+  direct application, partial application, first-class function binding,
+  higher-order argument passing, and a `Decidable`/`decide` use of
+  `Hex.Nat.choose`. These compiled/evaluated successfully.
+- Reviewed design principle 11 wording for the main mechanism and identified
+  one wording nuance: `csimp` redirects compiled occurrences that survive to
+  code generation; theorem/proof/kernel normalization still sees the public
+  specification.
+
+## Current frontier
+
+- No source change recommended from this review. The only optional polish would
+  be wording principle 11 a little less absolutely around "every compiled
+  caller".
+
+## Next step
+
+- Use the second-opinion findings in the PR review or issue comment.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
This PR marks the eight kernel-facing `@[csimp]` specification definitions `noncomputable` so the compiler no longer emits their slow reference bodies as dead compiled code: `ZMod64.add`/`sub`, `Vector.dotProduct`, `Matrix.mul`, `DensePoly.mul`, `Nat.choose`, `divModArrayAux`, and `trimTrailingZeros`. Each keeps its computable `*Impl` twin and the proved `@[csimp]` equality that redirects every compiled occurrence to it, so runtime is unchanged and the replacement stays proof-carrying (unlike `@[implemented_by]`). `noncomputable` suppresses only code generation, not kernel reduction, so the `decide`/`#guard` cross-checks that evaluate these specs in the kernel keep working, and proof-mode uses still see the public specification.

This completes design principle 11 (SPEC/design-principles.md), whose text is updated to mandate the `noncomputable` spec and whose precedent list is refreshed. Previously the specs were plain `def`s that generated a slow compiled body which csimp then made unreachable.

Verified: full `lake build` green (4142 jobs); `HexConformance` and the bench executables build green; the `hexmatrix`, `hexmodarith`, and `hexarith` bench `verify` suites pass; the `hexpoly` non-Flint benchmarks pass (the Flint benchmarks require `python-flint`, which CI installs and which is unrelated to this change).

🤖 Prepared with Claude Code