### PR TITLE
chore: clear all lake build warnings

### DIFF
--- a/HexArith/Montgomery/Context.lean
+++ b/HexArith/Montgomery/Context.lean
@@ -10,7 +10,6 @@ public import HexArith.Montgomery.Redc
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 set_option maxHeartbeats 1000000
 
 /-!
@@ -32,7 +31,7 @@ private def doubleMod (p acc : UInt64) : UInt64 :=
     acc + acc
 
 /-- Compute `R^2 mod p` by repeated doubling in native-word arithmetic. -/
-private def r2Loop (p : UInt64) : Nat → UInt64 → UInt64
+def r2Loop (p : UInt64) : Nat → UInt64 → UInt64
   | 0, acc => acc
   | n + 1, acc => r2Loop p n (doubleMod p acc)
 
@@ -124,7 +123,7 @@ private theorem toNat_r2Loop (p : UInt64) :
               ac_rfl
 
 /-- The executable `r2OfModulus` computes `R^2 mod p` for positive moduli. -/
-private theorem toNat_r2OfModulus (p : UInt64) (hp_pos : 0 < p.toNat) :
+theorem toNat_r2OfModulus (p : UInt64) (hp_pos : 0 < p.toNat) :
     (r2OfModulus p).toNat = (UInt64.word * UInt64.word) % p.toNat := by
   have hp_lt_word : p.toNat < UInt64.word := by
     simpa [UInt64.word, UInt64.size] using UInt64.toNat_lt_size p
@@ -639,7 +638,7 @@ end MontCtx
 namespace HexArith
 
 /-- Number of binary digits in a natural number. -/
-private def bitLength (n : Nat) : Nat :=
+def bitLength (n : Nat) : Nat :=
   if n = 0 then 0 else n.log2 + 1
 
 private theorem lt_two_pow_bitLength (n : Nat) : n < 2 ^ bitLength n := by
@@ -668,7 +667,7 @@ private def powMontBitsGo (ctx : MontCtx p) (k : Nat) :
       powMontBitsGo ctx k remaining (bit + 1) acc' base'
 
 /-- Exponentiate a Montgomery-form base by repeated squaring. -/
-private def powMont (ctx : MontCtx p) (base : UInt64) (n : Nat) : UInt64 :=
+def powMont (ctx : MontCtx p) (base : UInt64) (n : Nat) : UInt64 :=
   powMontBitsGo ctx n (bitLength n) 0 (ctx.toMont (UInt64.ofNat (1 % p.toNat))) base
 
 /-- Word-sized odd-modulus modular exponentiation via Montgomery arithmetic. -/
@@ -679,7 +678,7 @@ def powModWordOdd (a n : Nat) (p : UInt64) (hp : p % 2 = 1) : Nat :=
   (ctx.fromMont (powMont ctx base n)).toNat
 
 /-- Tail-recursive Nat fallback for modular exponentiation. -/
-private def powModNatGo (n p : Nat) : Nat → Nat → Nat → Nat → Nat
+def powModNatGo (n p : Nat) : Nat → Nat → Nat → Nat → Nat
   | 0, _, acc, _ => acc
   | remaining + 1, bit, acc, base =>
       let acc' := if n.testBit bit then (acc * base) % p else acc

--- a/HexBerlekamp/RabinSoundness.lean
+++ b/HexBerlekamp/RabinSoundness.lean
@@ -19,7 +19,6 @@ import all HexBerlekamp.RabinSoundness.KernelWitness
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Project-side soundness of `Berlekamp.rabinTest` against

--- a/HexBerlekamp/RabinSoundness/KernelWitness.lean
+++ b/HexBerlekamp/RabinSoundness/KernelWitness.lean
@@ -18,7 +18,6 @@ import all HexBerlekamp.RabinSoundness.RabinShape
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Distinct-degree saturation and square-free kernel-witness

--- a/HexBerlekamp/RabinSoundness/RabinCore.lean
+++ b/HexBerlekamp/RabinSoundness/RabinCore.lean
@@ -15,7 +15,6 @@ public import HexArith.Nat.Pow
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 CRT candidate constructions (`xPowSubX`, `primeFieldLinearProduct`,

--- a/HexBerlekamp/RabinSoundness/RabinShape.lean
+++ b/HexBerlekamp/RabinSoundness/RabinShape.lean
@@ -17,7 +17,6 @@ import all HexBerlekamp.RabinSoundness.RabinCore
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The prime-field product identity and `xPowSubX 1` shape, the structural

--- a/HexBerlekampZassenhaus/BhksCandidates.lean
+++ b/HexBerlekampZassenhaus/BhksCandidates.lean
@@ -38,7 +38,6 @@ import all HexBerlekampZassenhaus.Lattice
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `bhksIndicatorCandidates?`, the dilate lemmas, and candidate-correctness proofs.
@@ -155,7 +154,8 @@ def bhksProjectedRowsAsRatMatrix
   Matrix.ofFn fun i j =>
     ((rows.getD i.val #[]).getD j.val (0 : Int) : Rat)
 
-private def bhksColumnSignature
+@[expose]
+def bhksColumnSignature
     (echelonRows : Array (Array Rat)) (j : Nat) : Array Rat :=
   echelonRows.map (·.getD j 0)
 
@@ -168,7 +168,8 @@ def bhksInsertSignatureClass
       if s = sig then (s, members ++ [j]) :: rest
       else (s, members) :: bhksInsertSignatureClass sig j rest
 
-private def bhksClassIndicator (r : Nat) (members : List Nat) : Array Int :=
+@[expose]
+def bhksClassIndicator (r : Nat) (members : List Nat) : Array Int :=
   ((List.range r).map (fun i => if i ∈ members then (1 : Int) else 0)).toArray
 
 /--

--- a/HexBerlekampZassenhaus/BhksRecover.lean
+++ b/HexBerlekampZassenhaus/BhksRecover.lean
@@ -39,7 +39,6 @@ import all HexBerlekampZassenhaus.BhksCandidates
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `bhksRecover?`/`coreRecover?` and the core-recovery correctness proofs.

--- a/HexBerlekampZassenhaus/Certificate.lean
+++ b/HexBerlekampZassenhaus/Certificate.lean
@@ -34,7 +34,6 @@ import all HexBerlekampZassenhaus.Records
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the irreducibility-certificate structures, their checkers, and `certifyIrreducible?`.
@@ -50,7 +49,8 @@ for higher-multiplicity inputs. Falls back to the un-expanded
 fully consume `repeatedPart` (e.g. when the BZ pipeline emitted the raw
 square-free core as a single core factor).
 -/
-private def reassemblePolynomialFactors
+@[expose]
+def reassemblePolynomialFactors
     (d : FactorNormalizationData) (coreFactors : Array ZPoly) : Array ZPoly :=
   let (expanded, residual) := expandRepeatedPartFactorArray d.repeatedPart coreFactors
   if residual = 1 then
@@ -58,7 +58,8 @@ private def reassemblePolynomialFactors
   else
     polynomialNormalizationPrefixFactors d ++ coreFactors
 
-private def factorizationOfFactors (f : ZPoly) (factors : Array ZPoly) : Factorization :=
+@[expose]
+def factorizationOfFactors (f : ZPoly) (factors : Array ZPoly) : Factorization :=
   { scalar := signedContentScalar f
     factors := collectFactorMultiplicities factors }
 

--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -35,7 +35,6 @@ import all HexBerlekampZassenhaus.Certificate
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `choosePrimeData?`/`Walk?`/`Score` with their correctness lemmas and `henselLiftData`.
@@ -88,7 +87,7 @@ def certifyIrreducible? (f : ZPoly) : Option ZPolyIrreducibilityCertificate :=
       { perPrime := perPrime, degreeObstructions := obstructions' }
     if checkIrreducibleCert f cert then some cert else none
 
-private structure PrimeChoiceDataScore where
+structure PrimeChoiceDataScore where
   data : PrimeChoiceData
   factorCount : Nat
 
@@ -111,7 +110,7 @@ private def betterPrimeChoiceDataScore
   else
     old
 
-private def choosePrimeDataScoreStep
+def choosePrimeDataScoreStep
     (f : ZPoly) (best : Option PrimeChoiceDataScore) (c : SmallPrimeCandidate) :
     Option PrimeChoiceDataScore :=
   -- First-suitable selection (matching the verified Isabelle/AFP

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -41,7 +41,6 @@ import all HexBerlekampZassenhaus.Recombination
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `factorClassical`/`Trial`/`Lattice`/`factor` and the `factor_scalar` theorems.

--- a/HexBerlekampZassenhaus/IrreducibleCore.lean
+++ b/HexBerlekampZassenhaus/IrreducibleCore.lean
@@ -42,7 +42,6 @@ import all HexBerlekampZassenhaus.FactorEntryPoints
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the `Irreducible` class, the constant/linear/size-two arms, and the main mod-p theorem.
@@ -187,7 +186,7 @@ by the greedy expansion helper. -/
 def Associated (a b : ZPoly) : Prop :=
   ∃ u : ZPoly, ZPoly.IsUnit u ∧ b = a * u
 
-private def isNatPrime (n : Nat) : Bool :=
+def isNatPrime (n : Nat) : Bool :=
   2 ≤ n && !((List.range n).any fun d => 2 ≤ d && d * d ≤ n && n % d == 0)
 
 /--

--- a/HexBerlekampZassenhaus/Lattice.lean
+++ b/HexBerlekampZassenhaus/Lattice.lean
@@ -37,7 +37,6 @@ import all HexBerlekampZassenhaus.ReassemblyProofs
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the trial/root candidate definitions, centred-lift/CLD helpers, and the BHKS lattice basis.
@@ -87,12 +86,12 @@ theorem exactQuotient?_eq_some_of_pos_lc_pos_degree_mul_eq
 private def positiveDivisors (n : Nat) : List Nat :=
   (List.range (n + 1)).filter fun d => d != 0 && n % d == 0
 
-private def integerRootCandidates (f : ZPoly) : List Int :=
+def integerRootCandidates (f : ZPoly) : List Int :=
   (positiveDivisors (f.coeff 0).natAbs).flatMap fun d =>
     let r : Int := Int.ofNat d
     [r, -r]
 
-private def linearFactorForRoot (r : Int) : ZPoly :=
+def linearFactorForRoot (r : Int) : ZPoly :=
   DensePoly.ofCoeffs #[-r, 1]
 
 private theorem leadingCoeff_linearFactorForRoot (r : Int) :
@@ -148,7 +147,7 @@ private theorem shouldRecordPolynomialFactor_linearFactorForRoot (r : Int) :
   simp [linearFactorForRoot_ne_zero, linearFactorForRoot_ne_one,
     linearFactorForRoot_ne_C_neg_one]
 
-private def splitIntegerRootFactorsAux :
+def splitIntegerRootFactorsAux :
     ZPoly → List Int → Nat → Array ZPoly × ZPoly
   | target, _roots, 0 => (#[], target)
   | target, [], _fuel + 1 => (#[], target)

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -30,7 +30,6 @@ import all Init.Data.Array.DecidableEq
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects X/xPower extraction, good-prime predicates, small-prime primality certificates, prime candidates, the monic mod-p image, and prime scoring/`choosePrime`.
@@ -517,7 +516,7 @@ structure PrimeCandidateScore where
   factorCount : Nat
 
 /-- The default list of small primes (`3` through `71`) used for Berlekamp-Zassenhaus trial division. -/
-private def smallPrimeCandidates : List SmallPrimeCandidate :=
+def smallPrimeCandidates : List SmallPrimeCandidate :=
   [ smallPrimeCandidateOfTrial 3 (by decide) (by decide),
     smallPrimeCandidateOfTrial 5 (by decide) (by decide),
     smallPrimeCandidateOfTrial 7 (by decide) (by decide),
@@ -540,7 +539,7 @@ private def smallPrimeCandidates : List SmallPrimeCandidate :=
 
 set_option maxRecDepth 10000 in
 /-- The extended list of larger small-prime candidates, tried when `smallPrimeCandidates` is exhausted. -/
-private def extendedSmallPrimeCandidates : List SmallPrimeCandidate :=
+def extendedSmallPrimeCandidates : List SmallPrimeCandidate :=
   [ smallPrimeCandidateOfTrial 73 (by decide) (by decide),
     smallPrimeCandidateOfTrial 79 (by decide) (by decide),
     smallPrimeCandidateOfTrial 83 (by decide) (by decide),

--- a/HexBerlekampZassenhaus/PrimitivityProofs.lean
+++ b/HexBerlekampZassenhaus/PrimitivityProofs.lean
@@ -46,7 +46,6 @@ import all HexBerlekampZassenhaus.QuadraticRootProofs
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `squareFreeCore`/`expandRepeatedPart`/reassembly primitivity.

--- a/HexBerlekampZassenhaus/ProductProofs.lean
+++ b/HexBerlekampZassenhaus/ProductProofs.lean
@@ -47,7 +47,6 @@ import all HexBerlekampZassenhaus.PrimitivityProofs
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `factorTrial_product`, `factor_product`, and the `checkIrreducibleCert_*` proofs.

--- a/HexBerlekampZassenhaus/QuadraticRootProofs.lean
+++ b/HexBerlekampZassenhaus/QuadraticRootProofs.lean
@@ -45,7 +45,6 @@ import all HexBerlekampZassenhaus.TrialProofs
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the quadratic-integer-root correctness proofs.

--- a/HexBerlekampZassenhaus/ReassemblyProofs.lean
+++ b/HexBerlekampZassenhaus/ReassemblyProofs.lean
@@ -36,7 +36,6 @@ import all HexBerlekampZassenhaus.ChoosePrimeData
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the BHKS bounds and reassembly-correctness theorems.
@@ -130,7 +129,7 @@ def bhksCoeffBound (f : ZPoly) (j : Nat) : Nat :=
   let n := f.degree?.getD 0
   Nat.choose (n - 1) j * n * ZPoly.coeffL2NormBound f
 
-private def ceilLogPAux (p target : Nat) : Nat → Nat → Nat → Nat
+def ceilLogPAux (p target : Nat) : Nat → Nat → Nat → Nat
   | 0, ell, _ => ell
   | fuel + 1, ell, power =>
       if target ≤ power then

--- a/HexBerlekampZassenhaus/Recombination.lean
+++ b/HexBerlekampZassenhaus/Recombination.lean
@@ -40,7 +40,6 @@ import all HexBerlekampZassenhaus.BhksRecover
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the recombination-search definitions (the mutual blocks) and Hensel-precision helpers.

--- a/HexBerlekampZassenhaus/RecombineProofs.lean
+++ b/HexBerlekampZassenhaus/RecombineProofs.lean
@@ -43,7 +43,6 @@ import all HexBerlekampZassenhaus.IrreducibleCore
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the recombination and `bhksRecover*` correctness proofs and core-factors specifications.

--- a/HexBerlekampZassenhaus/Records.lean
+++ b/HexBerlekampZassenhaus/Records.lean
@@ -33,7 +33,6 @@ import all HexBerlekampZassenhaus.PrimeSelection
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the executable data records, `Factorization` product, and normalization-pipeline definitions.
@@ -119,11 +118,13 @@ structure ToMonicData where
 
 namespace ToMonicData
 
-private def transformedCoeffs (core : ZPoly) (degree : Nat) : Array Int :=
+@[expose]
+def transformedCoeffs (core : ZPoly) (degree : Nat) : Array Int :=
   ((List.range degree).map fun i =>
       core.coeff i * (DensePoly.leadingCoeff core) ^ (degree - 1 - i)).toArray.push 1
 
-private def transformedCore (core : ZPoly) (degree : Nat) : ZPoly :=
+@[expose]
+def transformedCore (core : ZPoly) (degree : Nat) : ZPoly :=
   { coeffs := transformedCoeffs core degree
     normalized := by
       right
@@ -247,7 +248,8 @@ deriving DecidableEq
 
 namespace Factorization
 
-private def polyPow (f : ZPoly) : Nat → ZPoly
+@[expose]
+def polyPow (f : ZPoly) : Nat → ZPoly
   | 0 => 1
   | n + 1 => polyPow f n * f
 
@@ -302,16 +304,19 @@ private def contentFactorArray (content : Int) : Array ZPoly :=
   else
     #[DensePoly.C content]
 
-private def xPowerFactorArray (power : Nat) : Array ZPoly :=
+@[expose]
+def xPowerFactorArray (power : Nat) : Array ZPoly :=
   (List.replicate power ZPoly.X).toArray
 
-private def repeatedPartFactorArray (repeatedPart : ZPoly) : Array ZPoly :=
+@[expose]
+def repeatedPartFactorArray (repeatedPart : ZPoly) : Array ZPoly :=
   if repeatedPart = 1 then
     #[]
   else
     #[repeatedPart]
 
-private def signedContentScalar (f : ZPoly) : Int :=
+@[expose]
+def signedContentScalar (f : ZPoly) : Int :=
   if f = 0 then
     0
   else if DensePoly.leadingCoeff f < 0 then
@@ -337,7 +342,8 @@ Mathlib-side lemmas can transport the predicate into `¬ IsUnit` over
 def shouldRecordPolynomialFactor (f : ZPoly) : Bool :=
   f ≠ 0 && f ≠ 1 && f ≠ DensePoly.C (-1)
 
-private def bumpFactorMultiplicity (f : ZPoly) : List (ZPoly × Nat) → List (ZPoly × Nat)
+@[expose]
+def bumpFactorMultiplicity (f : ZPoly) : List (ZPoly × Nat) → List (ZPoly × Nat)
   | [] => [(f, 1)]
   | entry :: entries =>
       if entry.1 = f then
@@ -345,7 +351,8 @@ private def bumpFactorMultiplicity (f : ZPoly) : List (ZPoly × Nat) → List (Z
       else
         entry :: bumpFactorMultiplicity f entries
 
-private def collectFactorMultiplicities (factors : Array ZPoly) : Array (ZPoly × Nat) :=
+@[expose]
+def collectFactorMultiplicities (factors : Array ZPoly) : Array (ZPoly × Nat) :=
   factors.toList.foldl
     (fun acc factor =>
       let factor := normalizeFactorSign factor
@@ -356,7 +363,8 @@ private def collectFactorMultiplicities (factors : Array ZPoly) : Array (ZPoly �
     []
   |>.reverse.toArray
 
-private def polynomialNormalizationPrefixFactors (d : FactorNormalizationData) : Array ZPoly :=
+@[expose]
+def polynomialNormalizationPrefixFactors (d : FactorNormalizationData) : Array ZPoly :=
   xPowerFactorArray d.xPower ++ repeatedPartFactorArray d.repeatedPart
 
 /-- Factors that come from normalization before the square-free core is factored. -/
@@ -415,7 +423,8 @@ Returns `(residual, multiplicity)` with the invariant
 `candidate ^ multiplicity * residual = target`. The recursion is bounded by
 `fuel`, which the caller chooses based on the source degree.
 -/
-private def consumeExactPower (target candidate : ZPoly) : Nat → ZPoly × Nat
+@[expose]
+def consumeExactPower (target candidate : ZPoly) : Nat → ZPoly × Nat
   | 0 => (target, 0)
   | fuel + 1 =>
       match exactQuotient? target candidate with
@@ -429,7 +438,8 @@ Fold `consumeExactPower` over a list of candidate factors, accumulating
 emitted copies and tracking the residual that has not yet been factored.
 Invariant: `polyProduct emitted * residual = initialRepeatedPart`.
 -/
-private def expandRepeatedPartFactorsAux : List ZPoly → ZPoly → Nat → Array ZPoly × ZPoly
+@[expose]
+def expandRepeatedPartFactorsAux : List ZPoly → ZPoly → Nat → Array ZPoly × ZPoly
   | [], rp, _ => (#[], rp)
   | q :: qs, rp, fuel =>
       let (rp', m) := consumeExactPower rp q fuel
@@ -442,7 +452,8 @@ Compute `(emitted, residual)` where each candidate factor `q` from
 `q^k` exactly divides the running repeated-part. The fuel is the source
 size, which dominates any irreducible's multiplicity in `repeatedPart`.
 -/
-private def expandRepeatedPartFactorArray (rp : ZPoly) (coreFactors : Array ZPoly) :
+@[expose]
+def expandRepeatedPartFactorArray (rp : ZPoly) (coreFactors : Array ZPoly) :
     Array ZPoly × ZPoly :=
   expandRepeatedPartFactorsAux coreFactors.toList rp (rp.size + 1)
 

--- a/HexBerlekampZassenhaus/TrialProofs.lean
+++ b/HexBerlekampZassenhaus/TrialProofs.lean
@@ -44,7 +44,6 @@ import all HexBerlekampZassenhaus.RecombineProofs
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the trial-division and integer-root correctness proofs.

--- a/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
+++ b/HexBerlekampZassenhausMathlib/CLDColumnBound.lean
@@ -17,7 +17,6 @@ public import Mathlib.Data.Nat.Choose.Bounds
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 BHKS CLD-column coefficient bounds (van Hoeij `W ⊆ L'` analytics, #8519).

--- a/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
+++ b/HexBerlekampZassenhausMathlib/ForwardHenselTransport.lean
@@ -28,7 +28,6 @@ import all HexBerlekampZassenhausMathlib.SubsetCoprimality
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the forward Hensel transport for the canonical lifted subset.
@@ -1222,7 +1221,7 @@ private theorem zpoly_size_pos_of_pos_lc {f : Hex.ZPoly}
   rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
   · exfalso
     have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
-      simp [Hex.DensePoly.leadingCoeff, hcs_zero, Array.getD] <;> rfl
+      simp [Hex.DensePoly.leadingCoeff, hcs_zero, Array.getD]; rfl
     rw [hlc_zero] at hpos
     omega
   · exact hcs_pos

--- a/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
+++ b/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
@@ -26,7 +26,6 @@ import all HexBerlekampZassenhausMathlib.RecombinationCandidate
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the monic-primitive helpers, `henselLiftData` properties, and Berlekamp-form `factorsModP`.
@@ -45,7 +44,7 @@ private theorem zpoly_size_pos_of_monic {f : Hex.ZPoly}
   rcases Nat.eq_zero_or_pos f.coeffs.size with hcs_zero | hcs_pos
   · exfalso
     have hlc_zero : Hex.DensePoly.leadingCoeff f = (0 : Int) := by
-      simp [Hex.DensePoly.leadingCoeff, hcs_zero, Array.getD] <;> rfl
+      simp [Hex.DensePoly.leadingCoeff, hcs_zero, Array.getD]; rfl
     rw [hlc_zero] at hlead
     exact absurd hlead (by decide)
   · exact hcs_pos
@@ -844,7 +843,7 @@ theorem factorsModP_nodup_of_factorsModPBerlekampForm
       -- Hence `g₁ = g₂` (both equal to the unique factor), contradicting `hne`.
       have hsize_le_one : (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).size ≤ 1 := by
         by_contra h
-        push_neg at h
+        push Not at h
         apply hpos_image
         have hsize_ne : (Hex.monicModularImage (Hex.ZPoly.modP data.p f)).size ≠ 0 := by
           omega
@@ -1491,11 +1490,6 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
           refine ⟨?_, ?_⟩
           · -- `xgcd.gcd = 1` for the head split.
             -- Unfold `normalizedXGCD` and identify the raw EEA gcd.
-            change
-              (Hex.ZPoly.normalizedXGCD p (Hex.FpPoly.liftToZ g)
-                (Array.polyProduct
-                  (((h :: tail).map Hex.FpPoly.liftToZ).toArray))).gcd =
-                (1 : Hex.FpPoly p)
             -- Reduce both `modP`-arguments to `FpPoly p` shape.
             have hmodP_g : Hex.ZPoly.modP p (Hex.FpPoly.liftToZ g) = g :=
               Hex.FpPoly.modP_liftToZ g

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -23,7 +23,6 @@ import all HexBerlekampZassenhausMathlib.IntReductionMod.Transport
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Reduction-mod-`p` irreducibility for primitive integer polynomials. The

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -20,7 +20,6 @@ public import Mathlib.RingTheory.Polynomial.GaussLemma
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Reduction-mod-`p` irreducibility descent for primitive integer

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Transport.lean
@@ -22,7 +22,6 @@ import all HexBerlekampZassenhausMathlib.IntReductionMod.Descent
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Rational repeatedPart-divides-squareFreeCore-power transport, factorPower

--- a/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCert.lean
@@ -12,7 +12,6 @@ public import HexBerlekampZassenhausMathlib.CertReify
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The `irreducible_cert` tactic: certifying irreducibility for integer

--- a/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
+++ b/HexBerlekampZassenhausMathlib/IrreducibleCertTest.lean
@@ -33,7 +33,6 @@ import all Init.Data.Array.DecidableEq
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 End-to-end tests for certificate reification and the `irreducible_cert`

--- a/HexBerlekampZassenhausMathlib/Lattice.lean
+++ b/HexBerlekampZassenhausMathlib/Lattice.lean
@@ -12,7 +12,6 @@ public import HexLLLMathlib.ShortVector
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 BHKS lattice-side objects for the van Hoeij `W ⊆ L'` adequacy (#8519).
@@ -871,7 +870,7 @@ survivor-span lemma only needs lattice membership plus the tight cut-radius
 bound, and the final projection only needs the first block to be the support
 indicator.
 -/
-def cutProjectionHypotheses_of_shortVectors
+theorem cutProjectionHypotheses_of_shortVectors
     (L : Hex.BhksLatticeBasis) (hrows : 1 ≤ L.factorCount + L.coeffWidth)
     (hbasis : L.basis.independent)
     (trueSupports : Set (Set (Fin (Hex.bhksProjectedRows L hrows).factorCount)))

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -15,7 +15,6 @@ public import HexLLLMathlib.ShortVector
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 # Irreducibility of the van Hoeij / CLD lattice tier (#8417)

--- a/HexBerlekampZassenhausMathlib/LiftedFactor.lean
+++ b/HexBerlekampZassenhausMathlib/LiftedFactor.lean
@@ -22,7 +22,6 @@ import all HexBerlekampZassenhausMathlib.ModPFactor
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the lifted-factor infrastructure, candidate definitions, and Hensel-subset correspondence.
@@ -70,7 +69,6 @@ def modPIndexToLiftedEmbedding
   inj' := by
     intro i j hij
     apply Fin.ext
-    change i.val = j.val
     have hval :=
       congrArg (fun x : LiftedFactorIndex d => x.val) hij
     simpa [liftedIndexOfModPIndex] using hval
@@ -847,7 +845,7 @@ The mod-`p` partition plus Hensel transport produces the existing
 use the stable lifted-factor API without depending on the intermediate
 mod-`p` vocabulary.
 -/
-def henselSubsetCorrespondence_of_modPSubsetPartition
+theorem henselSubsetCorrespondence_of_modPSubsetPartition
     {core : Hex.ZPoly} {B : Nat} {primeData : Hex.PrimeChoiceData}
     {d : Hex.LiftData}
     {admissiblePrime squareFreeReduction successfulLift coprimeLift : Prop}

--- a/HexBerlekampZassenhausMathlib/M1Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/M1Recovery.lean
@@ -23,7 +23,6 @@ import all HexBerlekampZassenhausMathlib.LiftedFactor
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects M1 recovery, the Hensel-lift invariant, and `LiftedFactorSubsetPartition`.
@@ -415,7 +414,7 @@ theorem existsUnique_recoveringLiftedFactorSubset_of_henselSubsetCorrespondence_
     (hdvd : factor ∣ core)
     (hprecision : 2 * B' < d.p ^ d.k) :
     ∃! S : LiftedFactorSubset d,
-      ∃ hrec : RecoveredAtLift core d factor S,
+      ∃ _hrec : RecoveredAtLift core d factor S,
         liftedRecoveryCandidate core d S = factor := by
   rcases h.exists_subset hfactor_norm hirr hdvd with ⟨S, hS⟩
   rcases hS with ⟨hrecS⟩
@@ -459,7 +458,7 @@ theorem existsUnique_recoveringLiftedFactorSubset_of_henselSubsetCorrespondence
     (hdvd : factor ∣ core)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
     ∃! S : LiftedFactorSubset d,
-      ∃ hrec : RecoveredAtLift core d factor S,
+      ∃ _hrec : RecoveredAtLift core d factor S,
         liftedRecoveryCandidate core d S = factor :=
   existsUnique_recoveringLiftedFactorSubset_of_henselSubsetCorrespondence_of_bound
     h (Hex.ZPoly.defaultFactorCoeffBound core)
@@ -488,7 +487,7 @@ theorem existsUnique_recoveringLiftedFactorSubset_at_defaultPrecision
     (hdvd : factor ∣ core)
     (hprecision : 2 * Hex.ZPoly.defaultFactorCoeffBound core < d.p ^ d.k) :
     ∃! S : LiftedFactorSubset d,
-      ∃ hrec : RecoveredAtLift core d factor S,
+      ∃ _hrec : RecoveredAtLift core d factor S,
         liftedRecoveryCandidate core d S = factor :=
   existsUnique_recoveringLiftedFactorSubset_of_henselSubsetCorrespondence
     h hvalid hfactor_norm hirr hdvd hprecision

--- a/HexBerlekampZassenhausMathlib/ModPFactor.lean
+++ b/HexBerlekampZassenhausMathlib/ModPFactor.lean
@@ -21,7 +21,6 @@ import all HexBerlekampZassenhausMathlib.PublicSurface
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `modPFactor`/`monicModPImage` and `ModPSubsetPartitionHypotheses`.
@@ -215,7 +214,8 @@ theorem modP_mul
   have hmod := Hex.ZPoly.modP_eq_of_congr p
     (Hex.FpPoly.liftToZ (Hex.ZPoly.modP p f * Hex.ZPoly.modP p g))
     (f * g) hprod
-  simpa [Hex.FpPoly.modP_liftToZ] using hmod.symm
+  simp only [Hex.FpPoly.modP_liftToZ] at hmod
+  exact hmod.symm
 
 theorem modP_dvd_modP_of_dvd
     (p : Nat) [Hex.ZMod64.Bounds p] {factor core : Hex.ZPoly}
@@ -495,7 +495,7 @@ theorem mem_modPSubset_of_dvd
     simpa [F] using hdvd
   have hi_prime : Prime (F i) := by
     simpa [F] using (hpart.factors_irreducible i).prime
-  rcases (Prime.dvd_finset_prod_iff hi_prime F).mp hdvd_prod with ⟨j, hjS, hdvd_ij⟩
+  rcases (Prime.dvd_finsetProd_iff hi_prime F).mp hdvd_prod with ⟨j, hjS, hdvd_ij⟩
   have hij_poly : F i = F j := by
     have hassoc : Associated (F i) (F j) := by
       exact (hpart.factors_irreducible i).associated_of_dvd

--- a/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
+++ b/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
@@ -34,7 +34,6 @@ import all HexBerlekampZassenhausMathlib.SearchAssembly
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the `ZPoly` scale/dilate helpers and the forward monic correspondent.

--- a/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
+++ b/HexBerlekampZassenhausMathlib/PartitionRefinement.lean
@@ -11,7 +11,6 @@ public import HexBerlekampZassenhausMathlib.ToMonicUniqueness
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Support-partition counting for the BHKS class-count lower bound (#8519).

--- a/HexBerlekampZassenhausMathlib/PrimitivityDegreeCover.lean
+++ b/HexBerlekampZassenhausMathlib/PrimitivityDegreeCover.lean
@@ -30,7 +30,6 @@ import all HexBerlekampZassenhausMathlib.RecombinationMonic
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects primitivity, leading coefficient, and `normalizeFactorSign`.
@@ -266,7 +265,7 @@ private theorem leadingCoeff_primitivePart_pos
               (Hex.ZPoly.content q) (Hex.ZPoly.primitivePart q) hcontent_ne]
       _ = Hex.DensePoly.leadingCoeff q := by rw [h]
   by_contra hle
-  push_neg at hle
+  push Not at hle
   have hnonpos :
       Hex.ZPoly.content q *
           Hex.DensePoly.leadingCoeff (Hex.ZPoly.primitivePart q) ≤ 0 :=

--- a/HexBerlekampZassenhausMathlib/PublicSurface.lean
+++ b/HexBerlekampZassenhausMathlib/PublicSurface.lean
@@ -19,7 +19,6 @@ public import Mathlib.RingTheory.PrincipalIdealDomain
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the transport bounds, `factor_product`, `factor_unique`, and `checkIrreducibleCert_sound`.

--- a/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
@@ -25,7 +25,6 @@ import all HexBerlekampZassenhausMathlib.RecombinationSplit
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `recombinationCandidate` and the candidate-equals-factor lemmas.

--- a/HexBerlekampZassenhausMathlib/RecombinationMonic.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationMonic.lean
@@ -29,7 +29,6 @@ import all HexBerlekampZassenhausMathlib.ForwardHenselTransport
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects monicness/squarefreeness of the recombination candidate and the degree cover.
@@ -347,7 +346,7 @@ theorem exists_mem_representedSubset_of_degree_cover_of_primitive_pos_lc_core_of
       ∀ i, 0 < (HexPolyZMathlib.toPolynomial (liftedFactor d i)).natDegree)
     (hprecision : 2 * B' < d.p ^ d.k)
     (hpartition : LiftedFactorSubsetPartition core d J target)
-    (htarget_dvd_core : target ∣ core)
+    (_htarget_dvd_core : target ∣ core)
     (_hTJ : T ⊆ J)
     (gs : Finset Hex.ZPoly)
     (S_of : Hex.ZPoly → LiftedFactorSubset d)

--- a/HexBerlekampZassenhausMathlib/RecombinationSplit.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationSplit.lean
@@ -24,7 +24,6 @@ import all HexBerlekampZassenhausMathlib.M1Recovery
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the mask/list combinatorics bridging `Finset` subsets to executable enumeration.
@@ -247,7 +246,7 @@ private theorem finRange_filter_mem_perm_toList
   · exact (List.nodup_finRange n).filter _
   · exact S.nodup_toList
   · simp [List.toFinset_filter, List.toFinset_finRange,
-      Finset.filter_univ_mem, Finset.toList_toFinset]
+      Finset.toList_toFinset]
 
 /-- The rejected list has the dual `filter`/`map` characterisation: it is the
 order-preserving filter of the universe of lifted-factor indices by

--- a/HexBerlekampZassenhausMathlib/Recovery.lean
+++ b/HexBerlekampZassenhausMathlib/Recovery.lean
@@ -11,7 +11,6 @@ public import HexBerlekampZassenhausMathlib.SignatureClasses
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Executable class-count semantics for the BHKS equivalence-class indicators

--- a/HexBerlekampZassenhausMathlib/ScaledSearchCoverage.lean
+++ b/HexBerlekampZassenhausMathlib/ScaledSearchCoverage.lean
@@ -31,7 +31,6 @@ import all HexBerlekampZassenhausMathlib.PrimitivityDegreeCover
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the scaled-tier search coverage and `RecoveredScaledSearch`.

--- a/HexBerlekampZassenhausMathlib/SearchAssembly.lean
+++ b/HexBerlekampZassenhausMathlib/SearchAssembly.lean
@@ -33,7 +33,6 @@ import all HexBerlekampZassenhausMathlib.SmartSearchCoverage
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the associated-factor lemmas and `choosePrimeData` partition assembly.
@@ -130,7 +129,7 @@ theorem recombinationSearchModAux_some_factor_associated_of_liftedFactorSubsetPa
     {core target factor : Hex.ZPoly} {d : Hex.LiftData}
     {J : LiftedFactorSubset d} {localFactors : List Hex.ZPoly} {fuel : Nat}
     (B' : Nat)
-    (hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
+    (_hcore_lc_le : (Hex.DensePoly.leadingCoeff core).natAbs ≤ B')
     (hvalid : ∀ g : Hex.ZPoly, g ∣ core → ∀ i, (g.coeff i).natAbs ≤ B')
     (hcore_ne : core ≠ 0)
     (hcore_monic : Hex.DensePoly.Monic core)
@@ -1006,7 +1005,7 @@ branch of the integer-irreducible → mod-`p` representing-subset existence
 and uniqueness statement. -/
 theorem existsUnique_modPFactorSubset_of_choosePrimeData_of_some
     (core : Hex.ZPoly) {factor : Hex.ZPoly}
-    (hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
+    (_hirr : Irreducible (HexPolyZMathlib.toPolynomial factor))
     (hdvd : factor ∣ core)
     (hcore_ne : core ≠ 0)
     (hcore_pos : 0 < core.degree?.getD 0)

--- a/HexBerlekampZassenhausMathlib/SignatureClasses.lean
+++ b/HexBerlekampZassenhausMathlib/SignatureClasses.lean
@@ -12,7 +12,6 @@ public import HexRowReduceMathlib.RankSpanNullspace
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Partition semantics for the executable `bhksInsertSignatureClass` fold.

--- a/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
+++ b/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
@@ -32,7 +32,6 @@ import all HexBerlekampZassenhausMathlib.ScaledSearchCoverage
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects size-ordered coverage, both mutual blocks, and `RecoveredSmartSearch`.

--- a/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
+++ b/HexBerlekampZassenhausMathlib/SubsetCoprimality.lean
@@ -27,7 +27,6 @@ import all HexBerlekampZassenhausMathlib.HenselFactorProps
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects `choosePrimeData` degree/injectivity plus subset/complement coprimality.

--- a/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
+++ b/HexBerlekampZassenhausMathlib/ToMonicUniqueness.lean
@@ -35,7 +35,6 @@ import all HexBerlekampZassenhausMathlib.MonicCorrespondent
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 This module collects the non-circular lift-stage subset-uniqueness core (#7474).
@@ -669,7 +668,7 @@ theorem toMonicLiftData_liftedRecoveryCandidate_eq
     (core : Hex.ZPoly) (B : Nat) (primeData : Hex.PrimeChoiceData)
     (hcore_lc_pos : 0 < Hex.DensePoly.leadingCoeff core)
     (hcore_pos : 0 < core.degree?.getD 0)
-    (hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
+    (_hselected : Hex.ZPoly.toMonicPrimeData? core = some primeData)
     (hbound :
       2 * Hex.ZPoly.defaultFactorCoeffBound (Hex.ZPoly.toMonic core).monic <
         primeData.p ^ Hex.precisionForCoeffBound B primeData.p)

--- a/HexBerlekampZassenhausMathlib/UFDPartition.lean
+++ b/HexBerlekampZassenhausMathlib/UFDPartition.lean
@@ -15,7 +15,6 @@ public import Mathlib.RingTheory.Polynomial.UniqueFactorization
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Abstract UFD partition-cardinality bound used by the BHKS Group B

--- a/HexGF2/Field.lean
+++ b/HexGF2/Field.lean
@@ -481,7 +481,6 @@ def zero : GF2n n irr hn hn64 hirr :=
     show 0 < 2 ^ n
     exact Nat.pow_pos (by decide : 0 < 2)⟩
 
-@[expose]
 instance : Zero (GF2n n irr hn hn64 hirr) where
   zero := zero
 
@@ -496,7 +495,6 @@ instance : One (GF2n n irr hn hn64 hirr) where
 instance : NatCast (GF2n n irr hn hn64 hirr) where
   natCast := natCast
 
-@[expose]
 instance (k : Nat) : OfNat (GF2n n irr hn hn64 hirr) k where
   ofNat := natCast k
 
@@ -629,7 +627,7 @@ instance : HPow (GF2n n irr hn hn64 hirr) Int (GF2n n irr hn hn64 hirr) where
 inversion total). -/
 @[simp, grind =] theorem inv_zero : (0 : GF2n n irr hn hn64 hirr)⁻¹ = 0 := by
   have hzeroVal : (0 : GF2n n irr hn hn64 hirr).val = 0 := by
-    simp [OfNat.ofNat, natCast, zero]
+    simp [OfNat.ofNat, natCast]
   apply eq_of_val_eq
   simp [Inv.inv, inv, hzeroVal]
 
@@ -904,7 +902,6 @@ private theorem dvd_of_mod_eq_zero {p f : GF2Poly} (h : p % f = 0) :
 def zero : GF2nPoly f hirr :=
   ⟨0, zero_reduced (f := f)⟩
 
-@[expose]
 instance : Zero (GF2nPoly f hirr) where
   zero := zero
 
@@ -1158,7 +1155,6 @@ def natCast (k : Nat) : GF2nPoly f hirr :=
 instance : NatCast (GF2nPoly f hirr) where
   natCast := natCast
 
-@[expose]
 instance (k : Nat) : OfNat (GF2nPoly f hirr) k where
   ofNat := natCast k
 
@@ -1653,7 +1649,7 @@ def dividedDifference
 /-- The divided difference of an empty coefficient list is zero. -/
 @[simp, grind =] theorem dividedDifference_nil (α β : GF2nPoly f hirr) :
     dividedDifference ([] : List (GF2nPoly f hirr)) α β = 0 := by
-  simp [dividedDifference, dividedDifferenceCoeffs, evalCoeffList]
+  simp [dividedDifference, dividedDifferenceCoeffs]
 
 /-- The divided difference of a nonconstant list satisfies the synthetic
 recurrence used by the root-count induction. -/

--- a/HexGF2/Irreducibility.lean
+++ b/HexGF2/Irreducibility.lean
@@ -30,7 +30,6 @@ namespace GF2Poly
 /-- Decidable equality on packed `GF(2)` polynomials, derived from the
 underlying `Array UInt64` representation. The `wf` field is a `Prop`, so
 its proofs are irrelevant for the structural comparison. -/
-@[expose]
 instance instDecidableEq : DecidableEq GF2Poly := fun p q =>
   match decEq p.words.toList q.words.toList with
   | isTrue hw =>
@@ -47,7 +46,6 @@ instance instDecidableEq : DecidableEq GF2Poly := fun p q =>
 
 /-- Boolean equality on packed `GF(2)` polynomials, computed by `decide`
 on the decidable propositional equality. -/
-@[expose]
 instance instBEq : BEq GF2Poly where
   beq p q := decide (p = q)
 

--- a/HexGF2/Multiply.lean
+++ b/HexGF2/Multiply.lean
@@ -18,7 +18,6 @@ import all HexGF2.Multiply.Assoc
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Packed `GF2Poly` multiplication. The word-level machinery lives in the

--- a/HexGF2/Multiply/Assoc.lean
+++ b/HexGF2/Multiply/Assoc.lean
@@ -17,7 +17,6 @@ import all HexGF2.Multiply.SourceTriple
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The associativity/commutativity collapse lemmas for

--- a/HexGF2/Multiply/Coeff.lean
+++ b/HexGF2/Multiply/Coeff.lean
@@ -15,7 +15,6 @@ import all HexGF2.Multiply.MulWords
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Coefficient-level scaffolding: `clmulCoeffAt`, `xorBoolList`,

--- a/HexGF2/Multiply/MulWords.lean
+++ b/HexGF2/Multiply/MulWords.lean
@@ -14,7 +14,6 @@ import all HexGF2.Multiply.WordFold
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Raw packed-word multiplication `mulWords` and its `coeffWords_mulWords`

--- a/HexGF2/Multiply/SourceTriple.lean
+++ b/HexGF2/Multiply/SourceTriple.lean
@@ -16,7 +16,6 @@ import all HexGF2.Multiply.Coeff
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Source-pair and source-triple coefficient definitions and the low-word

--- a/HexGF2/Multiply/WordBits.lean
+++ b/HexGF2/Multiply/WordBits.lean
@@ -11,7 +11,6 @@ public import HexGF2.Clmul
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Bit-level carry-less multiplication over packed `UInt64` words:

--- a/HexGF2/Multiply/WordFold.lean
+++ b/HexGF2/Multiply/WordFold.lean
@@ -13,7 +13,6 @@ import all HexGF2.Multiply.WordBits
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The `foldl_xorClmulAt` / `foldl_mulWords` monomial fold lemmas over word

--- a/HexManual/Chapters/HexBareiss.lean
+++ b/HexManual/Chapters/HexBareiss.lean
@@ -125,7 +125,8 @@ open Hex Hex.Matrix
 namespace HexBareissChapterExample
 
 -- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]], det = 3.
-private def A : Hex.Matrix Int 3 3 := #m[2, 0, 1; 1, 3, 2; 0, 1, 1]
+private def A : Hex.Matrix Int 3 3 :=
+  #m[2, 0, 1; 1, 3, 2; 0, 1, 1]
 
 -- The Bareiss determinant is 3, agreeing with Leibniz.
 #guard bareiss A = 3

--- a/HexManual/Chapters/HexDeterminant.lean
+++ b/HexManual/Chapters/HexDeterminant.lean
@@ -146,7 +146,8 @@ open Hex Hex.Matrix
 namespace HexDeterminantChapterExample
 
 -- A = [[2, 0, 1], [1, 3, 2], [0, 1, 1]], det = 3.
-private def A : Hex.Matrix Int 3 3 := #m[2, 0, 1; 1, 3, 2; 0, 1, 1]
+private def A : Hex.Matrix Int 3 3 :=
+  #m[2, 0, 1; 1, 3, 2; 0, 1, 1]
 
 -- The Leibniz determinant evaluates to 3.
 #guard det A = 3

--- a/HexManual/Chapters/HexGramSchmidt.lean
+++ b/HexManual/Chapters/HexGramSchmidt.lean
@@ -110,7 +110,8 @@ namespace HexGramSchmidtChapter
 
 -- A 3×3 integer matrix with rows
 --   (1,1,0), (1,0,1), (0,1,1).
-private def m : Hex.Matrix Int 3 3 := #m[1, 1, 0; 1, 0, 1; 0, 1, 1]
+private def m : Hex.Matrix Int 3 3 :=
+  #m[1, 1, 0; 1, 0, 1; 0, 1, 1]
 
 -- Leading Gram determinants d_0 .. d_3. The empty
 -- prefix is 1 by convention; d_k is the determinant

--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -344,7 +344,8 @@ private theorem hhi : (3 / 4 : Rat) ≤ 1 := by grind
 #guard lllNative B (3 / 4) hlo hhi (by decide) = R
 
 -- Its first row is a shortest lattice vector.
-#guard (lllNative B (3 / 4) hlo hhi (by decide)).row ⟨0, by decide⟩ = #v[0, 1]
+#guard (lllNative B (3 / 4) hlo hhi (by decide)).row
+    ⟨0, by decide⟩ = #v[0, 1]
 
 -- The verified checker rejects the input basis
 -- (not size-reduced) and accepts the output.
@@ -395,7 +396,8 @@ private theorem hhi : (3 / 4 : Rat) ≤ 1 := by grind
 -- (a₀, a₁, a₂, a₃, a₄) = (-1, -1, 0, 0, 1) with a zero
 -- last coordinate: the relation -1 - α + α⁴ = 0, i.e.
 -- the minimal polynomial x⁴ - x - 1.
-#guard (lllNative L (3 / 4) hlo hhi (by decide)).row ⟨0, by decide⟩ = #v[-1, -1, 0, 0, 1, 0]
+#guard (lllNative L (3 / 4) hlo hhi (by decide)).row
+    ⟨0, by decide⟩ = #v[-1, -1, 0, 0, 1, 0]
 
 end HexLLLMinPoly
 ```

--- a/HexPoly/Dense.lean
+++ b/HexPoly/Dense.lean
@@ -10,7 +10,6 @@ public import Std
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Dense array-backed polynomials with the invariant that the stored coefficient array has no
@@ -195,7 +194,8 @@ private theorem trimTrailingZeros_pop (coeffs : Array R)
 /-- Runtime loop for `trimTrailingZeros`: pop trailing zeros off the array, up to `n` of
 them. With `n = coeffs.size` it pops the whole trailing-zero run, reusing the input
 storage in place when it is uniquely referenced rather than allocating a list. -/
-private def trimTrailingZerosGo (coeffs : Array R) : Nat → Array R
+@[expose]
+def trimTrailingZerosGo (coeffs : Array R) : Nat → Array R
   | 0 => coeffs
   | n + 1 =>
       if coeffs.back? = some (Zero.zero : R) then trimTrailingZerosGo coeffs.pop n else coeffs

--- a/HexPoly/Euclid.lean
+++ b/HexPoly/Euclid.lean
@@ -17,7 +17,6 @@ import all HexPoly.Euclid.Content
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Executable Euclidean-algorithm operations for dense array-backed

--- a/HexPoly/Euclid/Content.lean
+++ b/HexPoly/Euclid/Content.lean
@@ -16,7 +16,6 @@ import all HexPoly.Euclid.Reconstruction
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Integer content and primitive part for `DensePoly Int`, with the
@@ -29,7 +28,8 @@ universe u
 
 namespace DensePoly
 /-- The nonnegative gcd of the coefficients of an integer polynomial. -/
-private def contentNat (p : DensePoly Int) : Nat :=
+@[expose]
+def contentNat (p : DensePoly Int) : Nat :=
   p.toArray.toList.foldl (fun acc coeff => Nat.gcd acc coeff.natAbs) 0
 
 /-- The integer content of a polynomial. This is always nonnegative. -/

--- a/HexPoly/Euclid/DivGcd.lean
+++ b/HexPoly/Euclid/DivGcd.lean
@@ -12,7 +12,6 @@ public import HexPoly.Operations
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Field-based long division, `modByMonic`, and the derived `gcd`/`xgcd`
@@ -85,7 +84,7 @@ theorem monic_iff_leadingCoeff_eq_one [One R] {p : DensePoly R} :
 
 /-- For a nonzero normalized dense polynomial, `leadingCoeff` is the coefficient
 at the last stored index. -/
-theorem leadingCoeff_eq_coeff_last (p : DensePoly R) (hpos : 0 < p.size) :
+theorem leadingCoeff_eq_coeff_last (p : DensePoly R) (_hpos : 0 < p.size) :
     p.leadingCoeff = p.coeff (p.size - 1) := by
   simp only [leadingCoeff, coeff, size]
 
@@ -552,7 +551,7 @@ private def divModArrayAuxImplGo [Sub R] [Mul R]
 /-- Runtime implementation of `divModArrayAux`. Seeds the scan ceiling at `rem.size`, so
 the first iteration is identical to the reference's `arrayDegree? rem`; thereafter the
 ceiling tracks the working degree (see `divModArrayAuxImplGo`). -/
-private def divModArrayAuxImpl [Sub R] [Mul R]
+def divModArrayAuxImpl [Sub R] [Mul R]
     (q : Array R) (qDegree : Nat) (scaleLead : R → R)
     (fuel : Nat) (quot rem : Array R) : Array R × Array R :=
   divModArrayAuxImplGo q qDegree scaleLead fuel rem.size quot rem
@@ -1089,7 +1088,8 @@ structure XGCDResult (R : Type u) [Zero R] [DecidableEq R] where
   right : DensePoly R
 
 /-- Tail-recursive extended Euclidean algorithm. -/
-private def xgcdAux [One R] [Add R] [Sub R] [Mul R] [Div R]
+@[expose]
+def xgcdAux [One R] [Add R] [Sub R] [Mul R] [Div R]
     (r₀ s₀ t₀ r₁ s₁ t₁ : DensePoly R) (fuel : Nat) : XGCDResult R :=
   match fuel with
   | 0 => { gcd := r₀, left := s₀, right := t₀ }
@@ -1115,7 +1115,8 @@ step on polynomials whose degree grows through the run — that is `O(deg³)` wo
 and pure waste when only the gcd value is wanted (the common case: the square-free
 / separability test `gcd(f, f') = 1`). `gcdAux` keeps only the remainders and is
 `O(deg²)`. -/
-private def gcdAux [One R] [Add R] [Sub R] [Mul R] [Div R]
+@[expose]
+def gcdAux [One R] [Add R] [Sub R] [Mul R] [Div R]
     (r₀ r₁ : DensePoly R) (fuel : Nat) : DensePoly R :=
   match fuel with
   | 0 => r₀

--- a/HexPoly/Euclid/MulRing.lean
+++ b/HexPoly/Euclid/MulRing.lean
@@ -14,7 +14,6 @@ import all HexPoly.Euclid.DivGcd
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Diagonal multiplication-coefficient convolution and the commutative-ring

--- a/HexPoly/Euclid/Reconstruction.lean
+++ b/HexPoly/Euclid/Reconstruction.lean
@@ -15,7 +15,6 @@ import all HexPoly.Euclid.MulRing
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Division-reconstruction identities, divisibility lemmas, the concrete

--- a/HexPolyFp/Degree.lean
+++ b/HexPolyFp/Degree.lean
@@ -16,7 +16,6 @@ import all HexPolyFp.Ring
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Scalar scaling, degree and leading-coefficient lemmas, size/divisibility/
@@ -297,7 +296,7 @@ theorem scale_degree?_getD_eq_of_ne_zero [ZMod64.PrimeModulus p]
 top index `size - 1`. Gives callers a concrete index for the leading
 coefficient when they need to compute or rewrite it. -/
 theorem leadingCoeff_eq_coeff_pred
-    (f : FpPoly p) (hpos : 0 < f.size) :
+    (f : FpPoly p) (_hpos : 0 < f.size) :
     DensePoly.leadingCoeff f = f.coeff (f.size - 1) := by
   simp [DensePoly.leadingCoeff, DensePoly.coeff, DensePoly.size]
 

--- a/HexPolyFp/Field.lean
+++ b/HexPolyFp/Field.lean
@@ -13,7 +13,6 @@ public import Init.Data.List.Perm
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The `ZMod64 p` coefficient field for executable prime-field polynomials:

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -12,7 +12,6 @@ import all HexPolyFp.Quotient.Ring
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Project-side quotient API for `F_p[X] / (g)`. The ring/field construction

--- a/HexPolyFp/Quotient/Ring.lean
+++ b/HexPolyFp/Quotient/Ring.lean
@@ -10,7 +10,6 @@ public import HexPolyFp.Enumeration
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Quotient ring/field construction for `F_p[X] / (g)`: the `Quotient`

--- a/HexPolyFp/Ring.lean
+++ b/HexPolyFp/Ring.lean
@@ -15,7 +15,6 @@ import all HexPolyFp.Field
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Core `FpPoly` definitions (constructors, evaluation), the additive

--- a/HexPolyFp/SquareFree.lean
+++ b/HexPolyFp/SquareFree.lean
@@ -19,7 +19,6 @@ import all HexPolyFp.SquareFree.YunCorrect
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Executable Yun-style square-free decomposition for `F_p[x]`. The algebra

--- a/HexPolyFp/SquareFree/Algebra.lean
+++ b/HexPolyFp/SquareFree/Algebra.lean
@@ -13,7 +13,6 @@ public import HexPolyFp.Degree
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Scalar-multiple and characteristic-`p` algebra foundations for the Yun

--- a/HexPolyFp/SquareFree/YunContribution.lean
+++ b/HexPolyFp/SquareFree/YunContribution.lean
@@ -15,7 +15,6 @@ import all HexPolyFp.SquareFree.Algebra
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Yun-loop definitions (`yunFactorsWithLevel`, `yunFactors`,

--- a/HexPolyFp/SquareFree/YunCorrect.lean
+++ b/HexPolyFp/SquareFree/YunCorrect.lean
@@ -18,7 +18,6 @@ import all HexPolyFp.SquareFree.YunMeasure
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Terminal Yun-engine correctness: the contribution pow obligations,

--- a/HexPolyFp/SquareFree/YunMeasure.lean
+++ b/HexPolyFp/SquareFree/YunMeasure.lean
@@ -17,7 +17,6 @@ import all HexPolyFp.SquareFree.YunReduce
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Derivative-active reachability, the level-measure decrease lemmas, and

--- a/HexPolyFp/SquareFree/YunReduce.lean
+++ b/HexPolyFp/SquareFree/YunReduce.lean
@@ -16,7 +16,6 @@ import all HexPolyFp.SquareFree.YunContribution
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 The `squareFreeAuxRev` / `squareFreeAux` recursion and its reconstruction

--- a/HexPolyZ/Core.lean
+++ b/HexPolyZ/Core.lean
@@ -10,7 +10,6 @@ public import HexPoly
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Core `ZPoly` (integer dense polynomial) definitions: the `ZPoly`

--- a/HexPolyZ/Decomposition.lean
+++ b/HexPolyZ/Decomposition.lean
@@ -13,7 +13,6 @@ import all HexPolyZ.Rational
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Integer primitive-square-free decomposition correctness: reassembly over

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -12,7 +12,6 @@ import all HexPolyZ.Core
 
 public section
 set_option backward.proofsInPublic true
-set_option backward.privateInPublic true
 
 /-!
 Rational-coefficient machinery for the primitive-square-free pipeline:


### PR DESCRIPTION
This PR clears every warning from `lake build`, leaving only two that originate in upstream dependencies (subverso and verso). It fixes the mechanical lints (deprecated `push_neg` and `Prime.dvd_finset_prod_iff`, unused hypotheses, `def`-for-a-proposition, redundant `@[expose]`, over-long manual code lines, and a few tactic-style lints), resolves the `backward.privateInPublic` leaks by exposing the executable helper definitions that were already publicly reachable through that flag, and removes the now-unnecessary `backward.privateInPublic` options throughout the tree.

The `privateInPublic` resolution is behaviour-preserving: the affected helpers were already reachable and body-exposed through the backward flag (that is why they warned), so making them `public`/`@[expose]` only declares what the flag was doing implicitly. Two of them are genuinely reduced through by downstream proofs (`gcdAux` in `HexPolyZ/Decomposition.lean`, and `bhksColumnSignature`/`bhksClassIndicator` via a `change` in `Recovery.lean`), which the whole-graph build confirms still elaborate.

🤖 Prepared with Claude Code