### PR TITLE
perf: kernel-cheap specs and Array-native @[csimp] impls for DensePoly add/sub/neg/derivative

### DIFF
--- a/HexPoly/Euclid/MulRing.lean
+++ b/HexPoly/Euclid/MulRing.lean
@@ -884,19 +884,8 @@ private theorem rat_weighted_diagonal_fold
     rw [hidx])
 
 private theorem rat_coeff_derivative_generic (p : DensePoly Rat) (n : Nat) :
-    (derivative p).coeff n = ((n + 1 : Nat) : Rat) * p.coeff (n + 1) := by
-  unfold derivative
-  rw [coeff_ofCoeffs_list]
-  change
-    ((List.range (p.size - 1)).map
-        (fun i => ((i + 1 : Nat) : Rat) * p.coeff (i + 1))).getD n 0 =
-      ((n + 1 : Nat) : Rat) * p.coeff (n + 1)
-  by_cases hn : n < p.size - 1
-  · simp [hn, List.getD]
-  · have hp : p.size ≤ n + 1 := by omega
-    have hcoeff : p.coeff (n + 1) = 0 :=
-      coeff_eq_zero_of_size_le p hp
-    simp [hn, List.getD, hcoeff]
+    (derivative p).coeff n = ((n + 1 : Nat) : Rat) * p.coeff (n + 1) :=
+  coeff_derivative p n (Rat.mul_zero _)
 
 /-- Rational-coefficient specialization of `mulCoeffSum_derivative_product_rule`:
 the `(n+1)` scaling factor is cast into `Rat`. -/

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -180,28 +180,201 @@ for the common algebraic setting. -/
       if k < i then (Zero.zero : S) else c * p.coeff (k - i) :=
   coeff_shift_scale i c p k (Lean.Grind.Semiring.mul_zero c)
 
-/-- Add two dense polynomials coefficientwise. -/
+omit [DecidableEq R] in
+/-- Default-indexed reads agree across `List.toArray`. -/
+private theorem toArray_getD_eq_getD (l : List R) (n : Nat) :
+    l.toArray.getD n (Zero.zero : R) = l.getD n (Zero.zero : R) := by
+  rw [Array.getD_eq_getD_getElem?, List.getElem?_toArray]
+  rfl
+
+/-- Reading the spec-level coefficient list with default zero agrees with
+`DensePoly.coeff`. -/
+theorem toList_getD_eq_coeff (p : DensePoly R) (n : Nat) :
+    p.toList.getD n (Zero.zero : R) = p.coeff n := by
+  unfold toList toArray coeff
+  rw [Array.getD_eq_getD_getElem?]
+  change p.coeffs.toList[n]?.getD (Zero.zero : R) =
+    p.coeffs[n]?.getD (Zero.zero : R)
+  rw [Array.getElem?_toList]
+
+/-- The zero polynomial has coefficient `0` at every index. -/
+@[simp, grind =] theorem coeff_zero (n : Nat) :
+    (0 : DensePoly R).coeff n = (0 : R) := by
+  exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)
+
+/-- Zip two coefficient lists with `f`, padding the shorter list with literal
+`Zero.zero` arguments: overhang entries become `f p Zero.zero` / `f Zero.zero q`
+rather than being passed through, so every output entry is literally
+`f (xs.getD i) (ys.getD i)` — the value the `Array.ofFn` runtime impls
+reproduce with no algebraic laws on `R`. -/
 @[expose]
-def add [Add R] (p q : DensePoly R) : DensePoly R :=
-  let size := max p.size q.size
-  ofCoeffs <| (List.range size).map (fun i => p.coeff i + q.coeff i) |>.toArray
+def zipPad (f : R → R → R) : List R → List R → List R
+  | [], [] => []
+  | [], q :: qs => f (Zero.zero : R) q :: zipPad f [] qs
+  | p :: ps, [] => f p (Zero.zero : R) :: zipPad f ps []
+  | p :: ps, q :: qs => f p q :: zipPad f ps qs
+
+/-- Default-indexed read of a padded zip: inside the padded range the entry is
+`f` of the two default-indexed reads, outside it is the default. -/
+private theorem zipPad_getD (f : R → R → R) (xs ys : List R) (n : Nat) :
+    (zipPad f xs ys).getD n (Zero.zero : R) =
+      if n < max xs.length ys.length
+      then f (xs.getD n (Zero.zero : R)) (ys.getD n (Zero.zero : R))
+      else (Zero.zero : R) := by
+  induction xs generalizing ys n with
+  | nil =>
+      induction ys generalizing n with
+      | nil => simp [zipPad]
+      | cons q qs ihq =>
+          cases n with
+          | zero => simp [zipPad]
+          | succ m => simpa [zipPad] using ihq m
+  | cons p ps ihp =>
+      cases ys with
+      | nil =>
+          cases n with
+          | zero => simp [zipPad]
+          | succ m => simpa [zipPad] using ihp [] m
+      | cons q qs =>
+          cases n with
+          | zero => simp [zipPad]
+          | succ m => simpa [zipPad] using ihp qs m
+
+/-- Default-indexed read of `Array.ofFn`: the generator inside the range,
+the default outside. -/
+private theorem array_ofFn_getD {n : Nat} (f : Fin n → R) (i : Nat) :
+    (Array.ofFn f).getD i (Zero.zero : R) =
+      if h : i < n then f ⟨i, h⟩ else (Zero.zero : R) := by
+  rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn]
+  by_cases h : i < n
+  · rw [dif_pos h, dif_pos h]
+    rfl
+  · rw [dif_neg h, dif_neg h]
+    rfl
+
+/-- Default-indexed read of `Array.map`: `g` of the entry inside the range,
+the default outside. -/
+private theorem array_map_getD (g : R → R) (a : Array R) (i : Nat) :
+    (a.map g).getD i (Zero.zero : R) =
+      if h : i < a.size then g a[i] else (Zero.zero : R) := by
+  rw [Array.getD_eq_getD_getElem?, Array.getElem?_map]
+  by_cases h : i < a.size
+  · rw [Array.getElem?_eq_getElem h, dif_pos h]
+    rfl
+  · rw [Array.getElem?_eq_none (Nat.le_of_not_gt h), dif_neg h]
+    rfl
+
+/-- Add two dense polynomials coefficientwise.
+
+Kernel-facing specification: a single padded walk of the two coefficient
+lists. Compiled code runs the one-allocation `Array.ofFn` loop `addImpl`
+via the `@[csimp]` proof `add_eq_impl`. -/
+@[expose]
+noncomputable def add [Add R] (p q : DensePoly R) : DensePoly R :=
+  ofCoeffs (zipPad (· + ·) p.toList q.toList).toArray
+
+/-- Runtime implementation of `add`: one `Array.ofFn` allocation over the
+padded index range (value-equal to `add` by `add_eq_impl`, registered
+`@[csimp]`). -/
+@[expose]
+def addImpl [Add R] (p q : DensePoly R) : DensePoly R :=
+  ofCoeffs (Array.ofFn (n := max p.size q.size) fun i => p.coeff i + q.coeff i)
+
+/-- The spec `add` and the `Array.ofFn` runtime loop compute the same
+polynomial: each output coefficient is literally `p.coeff i + q.coeff i` on
+both sides, so no algebraic laws on `R` are needed. -/
+theorem add_eq_addImpl [Add R] (p q : DensePoly R) : add p q = addImpl p q := by
+  apply ext_coeff
+  intro n
+  unfold add addImpl
+  rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD, array_ofFn_getD]
+  simp only [length_toList, toList_getD_eq_coeff]
+  by_cases hn : n < max p.size q.size
+  · rw [if_pos hn, dif_pos hn]
+  · rw [if_neg hn, dif_neg hn]
+
+/-- Register the `Array.ofFn` loop as the compiled implementation of `add`. -/
+@[csimp]
+theorem add_eq_impl : @add = @addImpl := by
+  funext R _ _ _ p q
+  exact add_eq_addImpl p q
 
 instance [Add R] : Add (DensePoly R) where
   add := add
 
-/-- Subtract two dense polynomials coefficientwise. -/
+/-- Subtract two dense polynomials coefficientwise.
+
+Kernel-facing specification; compiled code runs the `Array.ofFn` loop
+`subImpl` via the `@[csimp]` proof `sub_eq_impl`. -/
 @[expose]
-def sub [Sub R] (p q : DensePoly R) : DensePoly R :=
-  let size := max p.size q.size
-  ofCoeffs <| (List.range size).map (fun i => p.coeff i - q.coeff i) |>.toArray
+noncomputable def sub [Sub R] (p q : DensePoly R) : DensePoly R :=
+  ofCoeffs (zipPad (· - ·) p.toList q.toList).toArray
+
+/-- Runtime implementation of `sub` (value-equal to `sub` by `sub_eq_impl`,
+registered `@[csimp]`). -/
+@[expose]
+def subImpl [Sub R] (p q : DensePoly R) : DensePoly R :=
+  ofCoeffs (Array.ofFn (n := max p.size q.size) fun i => p.coeff i - q.coeff i)
+
+/-- The spec `sub` and the `Array.ofFn` runtime loop compute the same
+polynomial. -/
+theorem sub_eq_subImpl [Sub R] (p q : DensePoly R) : sub p q = subImpl p q := by
+  apply ext_coeff
+  intro n
+  unfold sub subImpl
+  rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD, array_ofFn_getD]
+  simp only [length_toList, toList_getD_eq_coeff]
+  by_cases hn : n < max p.size q.size
+  · rw [if_pos hn, dif_pos hn]
+  · rw [if_neg hn, dif_neg hn]
+
+/-- Register the `Array.ofFn` loop as the compiled implementation of `sub`. -/
+@[csimp]
+theorem sub_eq_impl : @sub = @subImpl := by
+  funext R _ _ _ p q
+  exact sub_eq_subImpl p q
 
 instance [Sub R] : Sub (DensePoly R) where
   sub := sub
 
-/-- Coefficientwise additive inverse, expressed through executable subtraction. -/
+/-- Coefficientwise additive inverse, expressed through executable subtraction.
+
+Kernel-facing specification (one `sub` against the zero polynomial); compiled
+code runs the single `Array.map` pass `negImpl` via the `@[csimp]` proof
+`neg_eq_impl`. -/
 @[expose]
-def neg [Sub R] (p : DensePoly R) : DensePoly R :=
+noncomputable def neg [Sub R] (p : DensePoly R) : DensePoly R :=
   0 - p
+
+/-- Runtime implementation of `neg`: one `Array.map` pass over the stored
+coefficients (value-equal to `neg` by `neg_eq_impl`, registered `@[csimp]`). -/
+@[expose]
+def negImpl [Sub R] (p : DensePoly R) : DensePoly R :=
+  ofCoeffs (p.toArray.map (fun a => (Zero.zero : R) - a))
+
+/-- The spec `neg` and the `Array.map` runtime pass compute the same
+polynomial: each coefficient is literally `Zero.zero - p.coeff i` on both
+sides. -/
+theorem neg_eq_negImpl [Sub R] (p : DensePoly R) : neg p = negImpl p := by
+  apply ext_coeff
+  intro n
+  show (sub 0 p).coeff n = (negImpl p).coeff n
+  rw [sub_eq_subImpl]
+  unfold subImpl negImpl
+  rw [coeff_ofCoeffs, coeff_ofCoeffs, array_ofFn_getD, array_map_getD]
+  simp only [size_zero, Nat.zero_max, toArray_size, coeff_zero]
+  by_cases hn : n < p.size
+  · rw [dif_pos hn, dif_pos hn,
+      show p.toArray[n] = p.coeff n by
+        rw [Array.getElem_eq_getD (Zero.zero : R), toArray_getD]]
+    rfl
+  · rw [dif_neg hn, dif_neg hn]
+
+/-- Register the `Array.map` pass as the compiled implementation of `neg`. -/
+@[csimp]
+theorem neg_eq_impl : @neg = @negImpl := by
+  funext R _ _ _ p
+  exact neg_eq_negImpl p
 
 instance [Sub R] : Neg (DensePoly R) where
   neg := neg
@@ -564,13 +737,6 @@ private theorem list_getD_replicate (k n : Nat) :
       | zero => rfl
       | succ m => simpa [List.replicate_succ] using ih m
 
-omit [DecidableEq R] in
-/-- Default-indexed reads agree across `List.toArray`. -/
-private theorem toArray_getD_eq_getD (l : List R) (n : Nat) :
-    l.toArray.getD n (Zero.zero : R) = l.getD n (Zero.zero : R) := by
-  rw [Array.getD_eq_getD_getElem?, List.getElem?_toArray]
-  rfl
-
 /-- `mulCoeffSum` collapsed to a single fold over the row index, with each
 row's inner fold replaced by its closed form from `foldl_mulCoeffStep_range`. -/
 private theorem mulCoeffSum_eq_singleFold [Add R] [Mul R]
@@ -666,16 +832,6 @@ private theorem mulRows_getD [Add R] [Mul R] (qs ps acc : List R) (n : Nat)
                     simp only [Nat.succ_eq_add_one, List.getD_cons_succ,
                       Nat.add_sub_add_right, Nat.add_le_add_iff_right,
                       List.length_cons]
-
-/-- Reading the spec-level coefficient list with default zero agrees with
-`DensePoly.coeff`. -/
-theorem toList_getD_eq_coeff (p : DensePoly R) (n : Nat) :
-    p.toList.getD n (Zero.zero : R) = p.coeff n := by
-  unfold toList toArray coeff
-  rw [Array.getD_eq_getD_getElem?]
-  change p.coeffs.toList[n]?.getD (Zero.zero : R) =
-    p.coeffs[n]?.getD (Zero.zero : R)
-  rw [Array.getElem?_toList]
 
 /-- The list-walking specification `mul` satisfies the same coefficient law as
 the `Array` loop: both fold the schoolbook terms into each output coefficient
@@ -819,52 +975,55 @@ private theorem ofList_coeff_range_eq (p : DensePoly R) {n : Nat} (hn : p.size �
     simp [hi, coeff_eq_zero_of_size_le p hp]
 
 omit [DecidableEq R] in
-private theorem evalCoeffList_zipWith_add [Add R] [Mul R] (xs ys : List R) (x : R)
-    (hlen : xs.length = ys.length)
-    (hzero : (Zero.zero : R) + (Zero.zero : R) = (Zero.zero : R))
+/-- Horner evaluation distributes over the padded coefficientwise sum, given
+the zero-preservation and one-step distributivity laws. -/
+private theorem evalCoeffList_zipPad_add [Add R] [Mul R] (xs ys : List R) (x : R)
+    (hzero_add : (Zero.zero : R) + (Zero.zero : R) = (Zero.zero : R))
+    (hzero_horner : (Zero.zero : R) * x + (Zero.zero : R) = (Zero.zero : R))
     (hstep : ∀ a b c d : R, (a + b) * x + (c + d) = (a * x + c) + (b * x + d)) :
-    evalCoeffList (List.zipWith (fun a b => a + b) xs ys) x =
+    evalCoeffList (zipPad (· + ·) xs ys) x =
       evalCoeffList xs x + evalCoeffList ys x := by
   induction xs generalizing ys with
   | nil =>
+      induction ys with
+      | nil => simpa [zipPad, evalCoeffList] using hzero_add.symm
+      | cons q qs ihq =>
+          simp only [zipPad, evalCoeffList] at ihq ⊢
+          rw [ihq, hstep, hzero_horner]
+  | cons c cs ihp =>
       cases ys with
       | nil =>
-          simpa [evalCoeffList] using hzero.symm
-      | cons _ _ =>
-          simp at hlen
-  | cons c cs ih =>
-      cases ys with
-      | nil =>
-          simp at hlen
-      | cons d ds =>
-          have htail : cs.length = ds.length := Nat.succ.inj hlen
-          simp only [List.zipWith, evalCoeffList]
-          rw [ih ds htail]
-          exact hstep (evalCoeffList cs x) (evalCoeffList ds x) c d
+          simp only [zipPad, evalCoeffList] at ihp ⊢
+          rw [ihp [], hstep]
+          simp only [evalCoeffList, hzero_horner]
+      | cons q qs =>
+          simp only [zipPad, evalCoeffList]
+          rw [ihp qs, hstep]
 
 omit [DecidableEq R] in
-private theorem evalCoeffList_zipWith_sub [Sub R] [Mul R] [Add R] (xs ys : List R) (x : R)
-    (hlen : xs.length = ys.length)
-    (hzero : (Zero.zero : R) - (Zero.zero : R) = (Zero.zero : R))
+/-- Horner evaluation distributes over the padded coefficientwise difference. -/
+private theorem evalCoeffList_zipPad_sub [Sub R] [Add R] [Mul R] (xs ys : List R) (x : R)
+    (hzero_sub : (Zero.zero : R) - (Zero.zero : R) = (Zero.zero : R))
+    (hzero_horner : (Zero.zero : R) * x + (Zero.zero : R) = (Zero.zero : R))
     (hstep : ∀ a b c d : R, (a - b) * x + (c - d) = (a * x + c) - (b * x + d)) :
-    evalCoeffList (List.zipWith (fun a b => a - b) xs ys) x =
+    evalCoeffList (zipPad (· - ·) xs ys) x =
       evalCoeffList xs x - evalCoeffList ys x := by
   induction xs generalizing ys with
   | nil =>
+      induction ys with
+      | nil => simpa [zipPad, evalCoeffList] using hzero_sub.symm
+      | cons q qs ihq =>
+          simp only [zipPad, evalCoeffList] at ihq ⊢
+          rw [ihq, hstep, hzero_horner]
+  | cons c cs ihp =>
       cases ys with
       | nil =>
-          simpa [evalCoeffList] using hzero.symm
-      | cons _ _ =>
-          simp at hlen
-  | cons c cs ih =>
-      cases ys with
-      | nil =>
-          simp at hlen
-      | cons d ds =>
-          have htail : cs.length = ds.length := Nat.succ.inj hlen
-          simp only [List.zipWith, evalCoeffList]
-          rw [ih ds htail]
-          exact hstep (evalCoeffList cs x) (evalCoeffList ds x) c d
+          simp only [zipPad, evalCoeffList] at ihp ⊢
+          rw [ihp [], hstep]
+          simp only [evalCoeffList, hzero_horner]
+      | cons q qs =>
+          simp only [zipPad, evalCoeffList]
+          rw [ihp qs, hstep]
 
 /-- Compose polynomials using Horner's method. -/
 @[expose]
@@ -906,15 +1065,18 @@ theorem compose_C [Add R] [Mul R] (c : R) (q : DensePoly R)
     intro n
     change (add (0 : DensePoly R) (C c)).coeff n = (C c).coeff n
     unfold add
-    rw [coeff_ofCoeffs_list]
-    have hzero_coeff : ∀ i, (0 : DensePoly R).coeff i = (Zero.zero : R) := by
-      intro i
-      exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)
-    cases n with
-    | zero =>
-        simp [size_C_of_ne_zero hc, hzero_coeff, hzero_add]
-    | succ n =>
-        simp [size_C_of_ne_zero hc, hzero_coeff]
+    rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
+    simp only [length_toList, toList_getD_eq_coeff, size_zero, Nat.zero_max, coeff_zero]
+    by_cases hn : n < (C c).size
+    · rw [if_pos hn]
+      have hn0 : n = 0 := by
+        have h1 := size_C_of_ne_zero (c := c) hc
+        omega
+      subst hn0
+      rw [coeff_C, if_pos rfl]
+      exact hzero_add
+    · rw [if_neg hn,
+        coeff_eq_zero_of_size_le (C c) (Nat.le_of_not_gt hn)]
 
 /-- Semiring-specialized composition law for constants. This packages the zero-addition
 law needed by the generic `compose_C`. -/
@@ -1026,11 +1188,96 @@ theorem toList_eq_coeff_range (p : DensePoly R) :
     rw [toList_getD_eq_coeff, list_getD_map_range]
     simp [hi_size]
 
-/-- Formal derivative. The coefficient of `x^i` becomes `(i + 1) * a_(i+1)`. -/
+/-- Index-carrying derivative walk: entry `j` of `derivList i cs` is
+`((i + j + 1 : Nat) : R) * cs[j]`. Applied at `i = 0` to the coefficient
+tail, it produces the formal-derivative coefficients in one cons walk. -/
 @[expose]
-def derivative [NatCast R] [Mul R] (p : DensePoly R) : DensePoly R :=
-  ofCoeffs <|
-    (List.range (p.size - 1)).map (fun i => ((i + 1 : Nat) : R) * p.coeff (i + 1)) |>.toArray
+def derivList [NatCast R] [Mul R] : Nat → List R → List R
+  | _, [] => []
+  | i, c :: cs => ((i + 1 : Nat) : R) * c :: derivList (i + 1) cs
+
+/-- Default-indexed read of the derivative walk. -/
+private theorem derivList_getD [NatCast R] [Mul R] (i : Nat) (cs : List R) (n : Nat) :
+    (derivList i cs).getD n (Zero.zero : R) =
+      if n < cs.length
+      then ((i + n + 1 : Nat) : R) * cs.getD n (Zero.zero : R)
+      else (Zero.zero : R) := by
+  induction cs generalizing i n with
+  | nil => simp [derivList]
+  | cons c cs ih =>
+      cases n with
+      | zero => simp [derivList]
+      | succ m =>
+          simp only [derivList, List.getD_cons_succ, List.length_cons,
+            Nat.add_lt_add_iff_right]
+          rw [ih]
+          have harith : i + 1 + m + 1 = i + (m + 1) + 1 := by omega
+          rw [harith]
+
+/-- Formal derivative. The coefficient of `x^i` becomes `(i + 1) * a_(i+1)`.
+
+Kernel-facing specification: one cons walk of the coefficient tail. Compiled
+code runs the `Array.ofFn` loop `derivativeImpl` via the `@[csimp]` proof
+`derivative_eq_impl`. -/
+@[expose]
+noncomputable def derivative [NatCast R] [Mul R] (p : DensePoly R) : DensePoly R :=
+  ofCoeffs (derivList 0 (p.toList.drop 1)).toArray
+
+/-- Runtime implementation of `derivative`: one `Array.ofFn` allocation
+(value-equal to `derivative` by `derivative_eq_impl`, registered `@[csimp]`). -/
+@[expose]
+def derivativeImpl [NatCast R] [Mul R] (p : DensePoly R) : DensePoly R :=
+  ofCoeffs (Array.ofFn (n := p.size - 1) fun i => ((i.1 + 1 : Nat) : R) * p.coeff (i.1 + 1))
+
+/-- Default-indexed read of the spec derivative coefficients. -/
+private theorem derivative_coeffs_getD [NatCast R] [Mul R] (p : DensePoly R) (n : Nat) :
+    (derivList 0 (p.toList.drop 1)).getD n (Zero.zero : R) =
+      if n < p.size - 1
+      then ((n + 1 : Nat) : R) * p.coeff (n + 1)
+      else (Zero.zero : R) := by
+  rw [derivList_getD]
+  simp only [List.length_drop, length_toList, Nat.zero_add]
+  by_cases hn : n < p.size - 1
+  · rw [if_pos hn, if_pos hn]
+    have hdrop : (p.toList.drop 1).getD n (Zero.zero : R) =
+        p.toList.getD (1 + n) (Zero.zero : R) := by
+      rw [List.getD_eq_getElem?_getD, List.getElem?_drop, ← List.getD_eq_getElem?_getD]
+    rw [hdrop, Nat.add_comm 1 n, toList_getD_eq_coeff]
+  · rw [if_neg hn, if_neg hn]
+
+/-- The spec `derivative` and the `Array.ofFn` runtime loop compute the same
+polynomial. -/
+theorem derivative_eq_derivativeImpl [NatCast R] [Mul R] (p : DensePoly R) :
+    derivative p = derivativeImpl p := by
+  apply ext_coeff
+  intro n
+  unfold derivative derivativeImpl
+  rw [coeff_ofCoeffs, coeff_ofCoeffs, toArray_getD_eq_getD,
+    derivative_coeffs_getD, array_ofFn_getD]
+  by_cases hn : n < p.size - 1
+  · rw [if_pos hn, dif_pos hn]
+  · rw [if_neg hn, dif_neg hn]
+
+/-- Register the `Array.ofFn` loop as the compiled implementation of
+`derivative`. -/
+@[csimp]
+theorem derivative_eq_impl : @derivative = @derivativeImpl := by
+  funext R _ _ _ _ p
+  exact derivative_eq_derivativeImpl p
+
+/-- The derivative walk preserves list length. -/
+private theorem derivList_length [NatCast R] [Mul R] (i : Nat) (cs : List R) :
+    (derivList i cs).length = cs.length := by
+  induction cs generalizing i with
+  | nil => rfl
+  | cons c cs ih => simpa [derivList] using ih (i + 1)
+
+/-- The derivative stores at most one fewer coefficient than its input. -/
+theorem size_derivative_le [NatCast R] [Mul R] (p : DensePoly R) :
+    (derivative p).size ≤ p.size - 1 := by
+  unfold derivative
+  refine Nat.le_trans (size_ofCoeffs_le _) ?_
+  simp [derivList_length]
 
 /-- Coefficient law for addition. The explicit zero law is needed because the generic
 `Add`/`Zero` interface does not imply `0 + 0 = 0`. -/
@@ -1039,13 +1286,14 @@ theorem coeff_add [Add R] (p q : DensePoly R) (n : Nat)
     (p + q).coeff n = (p.coeff n + q.coeff n) := by
   change (add p q).coeff n = (p.coeff n + q.coeff n)
   unfold add
-  rw [coeff_ofCoeffs_list, list_getD_map_range]
+  rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
+  simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · simp [hn]
+  · rw [if_pos hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn
     have hp : p.size ≤ n := Nat.le_trans (Nat.le_max_left p.size q.size) hmax
     have hq : q.size ≤ n := Nat.le_trans (Nat.le_max_right p.size q.size) hmax
-    simp [hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
+    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Semiring-specialized coefficient law for addition. -/
 @[simp, grind =] theorem coeff_add_semiring {S : Type u}
@@ -1062,13 +1310,14 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
     (p - q).coeff n = (p.coeff n - q.coeff n) := by
   change (sub p q).coeff n = (p.coeff n - q.coeff n)
   unfold sub
-  rw [coeff_ofCoeffs_list, list_getD_map_range]
+  rw [coeff_ofCoeffs, toArray_getD_eq_getD, zipPad_getD]
+  simp only [length_toList, toList_getD_eq_coeff]
   by_cases hn : n < max p.size q.size
-  · simp [hn]
+  · rw [if_pos hn]
   · have hmax : max p.size q.size ≤ n := Nat.le_of_not_gt hn
     have hp : p.size ≤ n := Nat.le_trans (Nat.le_max_left p.size q.size) hmax
     have hq : q.size ≤ n := Nat.le_trans (Nat.le_max_right p.size q.size) hmax
-    simp [hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
+    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, coeff_eq_zero_of_size_le q hq, hzero]
 
 /-- Ring-specialized coefficient law for subtraction. -/
 @[simp, grind =] theorem coeff_sub_ring {S : Type u}
@@ -1077,11 +1326,6 @@ theorem coeff_sub [Sub R] (p q : DensePoly R) (n : Nat)
     (hzero : SubZeroLaw S := by infer_instance) :
     (p - q).coeff n = p.coeff n - q.coeff n :=
   coeff_sub p q n hzero.sub_zero_zero
-
-/-- The zero polynomial has coefficient `0` at every index. -/
-@[simp, grind =] theorem coeff_zero (n : Nat) :
-    (0 : DensePoly R).coeff n = (0 : R) := by
-  exact coeff_eq_zero_of_size_le (0 : DensePoly R) (by simp)
 
 /-- Coefficient law for negation, expressed through subtraction from zero. The explicit zero law
 is inherited from the generic subtraction coefficient theorem. -/
@@ -1163,40 +1407,13 @@ theorem eval_add [Add R] [Mul R] (p q : DensePoly R) (x : R)
     (hzero_horner : (Zero.zero : R) * x + (Zero.zero : R) = (Zero.zero : R))
     (hstep : ∀ a b c d : R, (a + b) * x + (c + d) = (a * x + c) + (b * x + d)) :
     eval (p + q) x = eval p x + eval q x := by
-  let n := max p.size q.size
-  have hzip :
-      List.zipWith (fun a b : R => a + b)
-          ((List.range n).map (fun i => p.coeff i))
-          ((List.range n).map (fun i => q.coeff i)) =
-        (List.range n).map (fun i => p.coeff i + q.coeff i) := by
-    generalize List.range n = xs
-    induction xs with
-    | nil =>
-        rfl
-    | cons i is ih =>
-        simp [ih]
-  rw [show eval (p + q) x =
-      evalCoeffList ((List.range n).map (fun i => p.coeff i + q.coeff i)) x by
-    change eval (add p q) x =
-      evalCoeffList ((List.range n).map (fun i => p.coeff i + q.coeff i)) x
-    unfold add n
-    exact eval_ofList_eq_evalCoeffList ((List.range (max p.size q.size)).map
-      (fun i => p.coeff i + q.coeff i)) x hzero_horner]
-  rw [show eval p x = evalCoeffList ((List.range n).map (fun i => p.coeff i)) x by
-    rw [← eval_ofList_eq_evalCoeffList ((List.range n).map (fun i => p.coeff i)) x
-      hzero_horner]
-    rw [ofList_coeff_range_eq p (Nat.le_max_left p.size q.size)]
-  ]
-  rw [show eval q x = evalCoeffList ((List.range n).map (fun i => q.coeff i)) x by
-    rw [← eval_ofList_eq_evalCoeffList ((List.range n).map (fun i => q.coeff i)) x
-      hzero_horner]
-    rw [ofList_coeff_range_eq q (Nat.le_max_right p.size q.size)]
-  ]
-  rw [← evalCoeffList_zipWith_add
-    ((List.range n).map (fun i => p.coeff i))
-    ((List.range n).map (fun i => q.coeff i)) x (by simp)
-    hzero_add hstep]
-  rw [hzip]
+  have hadd : eval (p + q) x =
+      evalCoeffList (zipPad (· + ·) p.toList q.toList) x := by
+    change eval (add p q) x = _
+    unfold add
+    exact eval_ofList_eq_evalCoeffList _ x hzero_horner
+  rw [hadd, eval_eq_evalCoeffList, eval_eq_evalCoeffList]
+  exact evalCoeffList_zipPad_add p.toList q.toList x hzero_add hzero_horner hstep
 
 /-- Semiring-specialized evaluation law for addition. -/
 @[simp, grind =] theorem eval_add_semiring {S : Type u}
@@ -1217,40 +1434,13 @@ theorem eval_sub [Sub R] [Add R] [Mul R] (p q : DensePoly R) (x : R)
     (hzero_horner : (Zero.zero : R) * x + (Zero.zero : R) = (Zero.zero : R))
     (hstep : ∀ a b c d : R, (a - b) * x + (c - d) = (a * x + c) - (b * x + d)) :
     eval (p - q) x = eval p x - eval q x := by
-  let n := max p.size q.size
-  have hzip :
-      List.zipWith (fun a b : R => a - b)
-          ((List.range n).map (fun i => p.coeff i))
-          ((List.range n).map (fun i => q.coeff i)) =
-        (List.range n).map (fun i => p.coeff i - q.coeff i) := by
-    generalize List.range n = xs
-    induction xs with
-    | nil =>
-        rfl
-    | cons i is ih =>
-        simp [ih]
-  rw [show eval (p - q) x =
-      evalCoeffList ((List.range n).map (fun i => p.coeff i - q.coeff i)) x by
-    change eval (sub p q) x =
-      evalCoeffList ((List.range n).map (fun i => p.coeff i - q.coeff i)) x
-    unfold sub n
-    exact eval_ofList_eq_evalCoeffList ((List.range (max p.size q.size)).map
-      (fun i => p.coeff i - q.coeff i)) x hzero_horner]
-  rw [show eval p x = evalCoeffList ((List.range n).map (fun i => p.coeff i)) x by
-    rw [← eval_ofList_eq_evalCoeffList ((List.range n).map (fun i => p.coeff i)) x
-      hzero_horner]
-    rw [ofList_coeff_range_eq p (Nat.le_max_left p.size q.size)]
-  ]
-  rw [show eval q x = evalCoeffList ((List.range n).map (fun i => q.coeff i)) x by
-    rw [← eval_ofList_eq_evalCoeffList ((List.range n).map (fun i => q.coeff i)) x
-      hzero_horner]
-    rw [ofList_coeff_range_eq q (Nat.le_max_right p.size q.size)]
-  ]
-  rw [← evalCoeffList_zipWith_sub
-    ((List.range n).map (fun i => p.coeff i))
-    ((List.range n).map (fun i => q.coeff i)) x (by simp)
-    hzero_sub hstep]
-  rw [hzip]
+  have hsub : eval (p - q) x =
+      evalCoeffList (zipPad (· - ·) p.toList q.toList) x := by
+    change eval (sub p q) x = _
+    unfold sub
+    exact eval_ofList_eq_evalCoeffList _ x hzero_horner
+  rw [hsub, eval_eq_evalCoeffList, eval_eq_evalCoeffList]
+  exact evalCoeffList_zipPad_sub p.toList q.toList x hzero_sub hzero_horner hstep
 
 /-- Ring-specialized evaluation law for subtraction. -/
 @[simp, grind =] theorem eval_sub_ring {S : Type u}
@@ -1374,11 +1564,11 @@ theorem coeff_derivative [NatCast R] [Mul R] (p : DensePoly R) (n : Nat)
     (hzero : ((n + 1 : Nat) : R) * (Zero.zero : R) = (Zero.zero : R)) :
     (derivative p).coeff n = ((n + 1 : Nat) : R) * p.coeff (n + 1) := by
   unfold derivative
-  rw [coeff_ofCoeffs_list, list_getD_map_range]
+  rw [coeff_ofCoeffs, toArray_getD_eq_getD, derivative_coeffs_getD]
   by_cases hn : n < p.size - 1
-  · simp [hn]
+  · rw [if_pos hn]
   · have hp : p.size ≤ n + 1 := by omega
-    rw [coeff_eq_zero_of_size_le p hp, if_neg hn, hzero]
+    rw [if_neg hn, coeff_eq_zero_of_size_le p hp, hzero]
 
 attribute [local instance 1100] Lean.Grind.Semiring.natCast
 

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -209,11 +209,11 @@ rather than being passed through, so every output entry is literally
 reproduce with no algebraic laws on `R`. -/
 @[expose]
 def zipPad (f : R → R → R) : List R → List R → List R
-  | [], [] => []
-  | [], q :: qs => f (Zero.zero : R) q :: zipPad f [] qs
-  | p :: ps, [] => f p (Zero.zero : R) :: zipPad f ps []
-  | p :: ps, q :: qs => f p q :: zipPad f ps qs
+  | [], ys => ys.map (fun y => f (Zero.zero : R) y)
+  | x :: xs, [] => f x (Zero.zero : R) :: zipPad f xs []
+  | x :: xs, y :: ys => f x y :: zipPad f xs ys
 
+omit [DecidableEq R] in
 /-- Default-indexed read of a padded zip: inside the padded range the entry is
 `f` of the two default-indexed reads, outside it is the default. -/
 private theorem zipPad_getD (f : R → R → R) (xs ys : List R) (n : Nat) :
@@ -240,6 +240,7 @@ private theorem zipPad_getD (f : R → R → R) (xs ys : List R) (n : Nat) :
           | zero => simp [zipPad]
           | succ m => simpa [zipPad] using ihp qs m
 
+omit [DecidableEq R] in
 /-- Default-indexed read of `Array.ofFn`: the generator inside the range,
 the default outside. -/
 private theorem array_ofFn_getD {n : Nat} (f : Fin n → R) (i : Nat) :
@@ -252,6 +253,7 @@ private theorem array_ofFn_getD {n : Nat} (f : Fin n → R) (i : Nat) :
   · rw [dif_neg h, dif_neg h]
     rfl
 
+omit [DecidableEq R] in
 /-- Default-indexed read of `Array.map`: `g` of the entry inside the range,
 the default outside. -/
 private theorem array_map_getD (g : R → R) (a : Array R) (i : Nat) :
@@ -988,7 +990,7 @@ private theorem evalCoeffList_zipPad_add [Add R] [Mul R] (xs ys : List R) (x : R
       induction ys with
       | nil => simpa [zipPad, evalCoeffList] using hzero_add.symm
       | cons q qs ihq =>
-          simp only [zipPad, evalCoeffList] at ihq ⊢
+          simp only [zipPad, evalCoeffList, List.map_cons] at ihq ⊢
           rw [ihq, hstep, hzero_horner]
   | cons c cs ihp =>
       cases ys with
@@ -1013,7 +1015,7 @@ private theorem evalCoeffList_zipPad_sub [Sub R] [Add R] [Mul R] (xs ys : List R
       induction ys with
       | nil => simpa [zipPad, evalCoeffList] using hzero_sub.symm
       | cons q qs ihq =>
-          simp only [zipPad, evalCoeffList] at ihq ⊢
+          simp only [zipPad, evalCoeffList, List.map_cons] at ihq ⊢
           rw [ihq, hstep, hzero_horner]
   | cons c cs ihp =>
       cases ys with
@@ -1196,6 +1198,7 @@ def derivList [NatCast R] [Mul R] : Nat → List R → List R
   | _, [] => []
   | i, c :: cs => ((i + 1 : Nat) : R) * c :: derivList (i + 1) cs
 
+omit [DecidableEq R] in
 /-- Default-indexed read of the derivative walk. -/
 private theorem derivList_getD [NatCast R] [Mul R] (i : Nat) (cs : List R) (n : Nat) :
     (derivList i cs).getD n (Zero.zero : R) =
@@ -1265,6 +1268,7 @@ theorem derivative_eq_impl : @derivative = @derivativeImpl := by
   funext R _ _ _ _ p
   exact derivative_eq_derivativeImpl p
 
+omit [Zero R] [DecidableEq R] in
 /-- The derivative walk preserves list length. -/
 private theorem derivList_length [NatCast R] [Mul R] (i : Nat) (cs : List R) :
     (derivList i cs).length = cs.length := by

--- a/HexPolyFp/SquareFree/YunContribution.lean
+++ b/HexPolyFp/SquareFree/YunContribution.lean
@@ -252,18 +252,9 @@ private theorem derivative_coeff_pred_of_pos_lt
     (f : FpPoly p) {n : Nat} (hn0 : 0 < n) (hn : n < f.size) :
     (DensePoly.derivative f).coeff (n - 1) =
       ((n : Nat) : ZMod64 p) * f.coeff n := by
-  unfold DensePoly.derivative
-  rw [DensePoly.coeff_ofCoeffs_list]
-  have hpred : n - 1 < f.size - 1 := by omega
-  have hget :
-      (((List.range (f.size - 1)).map
-          (fun i => (((i + 1 : Nat) : ZMod64 p) * f.coeff (i + 1)))).getD
-        (n - 1) (0 : ZMod64 p)) =
-          (((n - 1 + 1 : Nat) : ZMod64 p) * f.coeff (n - 1 + 1)) := by
-    simp [List.getD, hpred]
-  have hsucc : n - 1 + 1 = n := by omega
-  rw [hsucc] at hget
-  exact hget
+  have h := DensePoly.coeff_derivative f (n - 1) (Lean.Grind.Semiring.mul_zero _)
+  rw [show n - 1 + 1 = n by omega] at h
+  exact h
 
 private theorem zmod64_natCast_ne_zero_of_mod_ne_zero
     (n : Nat) (hn : n % p ≠ 0) :
@@ -364,9 +355,9 @@ private theorem squareFreeAuxRevContribution_one
           DensePoly.coeffs_C_of_ne_zero (zmod64_one_ne_zero_of_prime hp)
         have hsize : (1 : FpPoly p).size = 1 := by
           simpa [DensePoly.size] using congrArg Array.size hcoeffs
-        unfold DensePoly.derivative
-        simp [hsize, DensePoly.isZero, DensePoly.ofCoeffs, DensePoly.trimTrailingZeros]
-        rfl
+        rw [DensePoly.isZero_eq_true_iff]
+        have h := DensePoly.size_derivative_le (1 : FpPoly p)
+        omega
       simp [hone_ne]
       rw [hdf_one, pthRoot_one hp]
       exact ih (multiplicity * p)
@@ -375,9 +366,9 @@ private theorem squareFreeAuxRevContribution_one
 private theorem derivative_isZero_true_of_size_one
     (f : FpPoly p) (hsize : f.size = 1) :
     (DensePoly.derivative f).isZero = true := by
-  unfold DensePoly.derivative
-  simp [hsize, DensePoly.isZero, DensePoly.ofCoeffs, DensePoly.trimTrailingZeros]
-  rfl
+  rw [DensePoly.isZero_eq_true_iff]
+  have h := DensePoly.size_derivative_le f
+  omega
 
 /-- Square-free contribution correctness on `pthRoot 1`: it equals `pow (pthRoot 1) multiplicity`, the constant base case of the `pthRoot` branch. -/
 private theorem squareFreeAuxRevContribution_pthRoot_constant_correct

--- a/HexPolyFp/SquareFree/YunContribution.lean
+++ b/HexPolyFp/SquareFree/YunContribution.lean
@@ -249,7 +249,7 @@ private theorem squareFreeAuxRevContribution_pthRoot_correct_pow
   exact hroot
 
 private theorem derivative_coeff_pred_of_pos_lt
-    (f : FpPoly p) {n : Nat} (hn0 : 0 < n) (hn : n < f.size) :
+    (f : FpPoly p) {n : Nat} (hn0 : 0 < n) (_hn : n < f.size) :
     (DensePoly.derivative f).coeff (n - 1) =
       ((n : Nat) : ZMod64 p) * f.coeff n := by
   have h := DensePoly.coeff_derivative f (n - 1) (Lean.Grind.Semiring.mul_zero _)

--- a/HexPolyFp/SquareFree/YunCorrect.lean
+++ b/HexPolyFp/SquareFree/YunCorrect.lean
@@ -872,9 +872,9 @@ private theorem squareFreeAuxRevResidualSatisfied_one
           DensePoly.coeffs_C_of_ne_zero (zmod64_one_ne_zero_of_prime hp)
         have hsize : (1 : FpPoly p).size = 1 := by
           simpa [DensePoly.size] using congrArg Array.size hcoeffs
-        unfold DensePoly.derivative
-        simp [hsize, DensePoly.isZero, DensePoly.ofCoeffs, DensePoly.trimTrailingZeros]
-        rfl
+        rw [DensePoly.isZero_eq_true_iff]
+        have h := DensePoly.size_derivative_le (1 : FpPoly p)
+        omega
       rw [if_neg (by simp [hone_ne]), if_pos hdf_one, pthRoot_one hp]
       exact ih (m * p)
 

--- a/HexPolyFp/SquareFree/YunReduce.lean
+++ b/HexPolyFp/SquareFree/YunReduce.lean
@@ -535,19 +535,8 @@ private theorem pow_C_form
 
 private theorem coeff_derivative (f : FpPoly p) (n : Nat) :
     (DensePoly.derivative f).coeff n =
-      ((n + 1 : Nat) : ZMod64 p) * f.coeff (n + 1) := by
-  unfold DensePoly.derivative
-  rw [DensePoly.coeff_ofCoeffs_list]
-  change
-    ((List.range (f.size - 1)).map
-        (fun i => ((i + 1 : Nat) : ZMod64 p) * f.coeff (i + 1))).getD n 0 =
-      ((n + 1 : Nat) : ZMod64 p) * f.coeff (n + 1)
-  by_cases hn : n < f.size - 1
-  · simp [hn, List.getD]
-  · have hf : f.size ≤ n + 1 := by omega
-    have hcoeff : f.coeff (n + 1) = 0 :=
-      DensePoly.coeff_eq_zero_of_size_le f hf
-    simp [hn, List.getD, hcoeff]
+      ((n + 1 : Nat) : ZMod64 p) * f.coeff (n + 1) :=
+  DensePoly.coeff_derivative f n (Lean.Grind.Semiring.mul_zero _)
 
 private theorem derivative_degree?_lt_self_of_ne_zero
     (f : FpPoly p) (hder_ne : DensePoly.derivative f ≠ 0) :

--- a/HexPolyZ/Rational.lean
+++ b/HexPolyZ/Rational.lean
@@ -303,20 +303,8 @@ private theorem rat_list_getD_map_range (size n : Nat) (f : Nat → Rat) :
 
 /-- The `n`-th coefficient of `DensePoly.derivative p` is `(n + 1) * p.coeff (n + 1)`. -/
 private theorem rat_coeff_derivative (p : DensePoly Rat) (n : Nat) :
-    (DensePoly.derivative p).coeff n = ((n + 1 : Nat) : Rat) * p.coeff (n + 1) := by
-  unfold DensePoly.derivative
-  rw [DensePoly.coeff_ofCoeffs_list]
-  change
-    ((List.range (p.size - 1)).map
-        (fun i => ((i + 1 : Nat) : Rat) * p.coeff (i + 1))).getD n 0 =
-      ((n + 1 : Nat) : Rat) * p.coeff (n + 1)
-  rw [rat_list_getD_map_range]
-  by_cases hn : n < p.size - 1
-  · simp [hn]
-  · have hp : p.size ≤ n + 1 := by omega
-    have hcoeff : p.coeff (n + 1) = 0 :=
-      DensePoly.coeff_eq_zero_of_size_le p hp
-    simp [hn, hcoeff]
+    (DensePoly.derivative p).coeff n = ((n + 1 : Nat) : Rat) * p.coeff (n + 1) :=
+  DensePoly.coeff_derivative p n (Rat.mul_zero _)
 
 /-- Differentiation commutes with scaling a rational dense polynomial by a unit `u`. -/
 private theorem rat_derivative_scale (u : Rat) (p : DensePoly Rat) :
@@ -1615,17 +1603,8 @@ private theorem size_le_one_of_toRatPoly_derivative_zero (p : ZPoly)
   simpa [size_toRatPoly p] using hrat
 
 private theorem rat_derivative_size_le_pred (p : DensePoly Rat) :
-    (DensePoly.derivative p).size ≤ p.size - 1 := by
-  unfold DensePoly.derivative
-  have hle := DensePoly.size_ofCoeffs_le
-    ((List.range (p.size - 1)).map
-      (fun i => ((i + 1 : Nat) : Rat) * p.coeff (i + 1))).toArray
-  have hlen :
-      ((List.range (p.size - 1)).map
-        (fun i => ((i + 1 : Nat) : Rat) * p.coeff (i + 1))).toArray.size =
-      p.size - 1 := by
-    simp
-  omega
+    (DensePoly.derivative p).size ≤ p.size - 1 :=
+  DensePoly.size_derivative_le p
 
 private theorem rat_derivative_zero_of_size_le_one (p : DensePoly Rat)
     (hp : p.size ≤ 1) :


### PR DESCRIPTION
This PR gives the coefficientwise `DensePoly` operations the kernel-facing-spec / `@[csimp]`-runtime-impl split of design principle 11 (PR 1 of the four-package plan). `add`/`sub` become `zipPad` walks over the two `toList` views: one cons step per coefficient under kernel reduction (these sit on the cross-check `decide` path via `curr + quot * f`), with literal `x + Zero.zero` overhang terms so the `@[csimp]` equalities need no algebraic laws on `R`; the runtime impls are single `Array.ofFn` allocations replacing the `List.range`-map round-trip. `neg` keeps the `0 - p` spec and gains a one-pass `Array.map` impl instead of paying `sub`'s full fold against the zero polynomial. `derivative` becomes a `derivList` cons walk with an `Array.ofFn` impl. All characterising lemma statements (`coeff_add`/`sub`/`neg`/`derivative`, `eval_add`/`eval_sub`, `compose_C`) are unchanged; the six external `derivative` body-unfold sites migrate to the characterisations, supported by the new `size_derivative_le`.

One trap found and fixed during development: the first `zipPad` formulation recursed on different arguments per clause, so Lean compiled it by well-founded recursion, which is opaque to kernel reduction and broke every downstream `decide`; it now recurses structurally on the first list.

Full `lake build` (4142 jobs) plus `HexConformance` are green (`HexGFq.CrossCheck` drops 32 s → 28 s); bench verify checksums pass for `hexpoly`/`hexpolyz`/`hexpolyfp`/`hexmodarith`; the spec symbols are absent from the generated C with the instance closures on the impls. Codex review: no blocking findings.

Part of https://github.com/kim-em/hex-dev/issues/8618.

🤖 Prepared with Claude Code