### PR TITLE
perf: kernel-cheap specs and Array.foldr @[csimp] impls for eval/compose/composeModMonic

### DIFF
--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -920,15 +920,16 @@ def evalCoeffList [Add R] [Mul R] :
 /-- Evaluate a polynomial using Horner's method.
 
 Kernel-facing specification: one cons walk of the coefficient list, highest
-degree innermost. Compiled code runs the zero-allocation downward `Array.foldr`
-loop `evalImpl` via the `@[csimp]` proof `eval_eq_impl`. -/
+degree innermost. Compiled code runs the downward `Array.foldr` loop
+`evalImpl` (no intermediate list or reverse allocation) via the `@[csimp]`
+proof `eval_eq_impl`. -/
 @[expose]
 noncomputable def eval [Add R] [Mul R] (p : DensePoly R) (x : R) : R :=
   evalCoeffList p.toList x
 
 /-- Runtime implementation of `eval`: a downward `Array.foldr` Horner loop over
-the stored coefficients with no intermediate allocation (value-equal to `eval`
-by `eval_eq_impl`, registered `@[csimp]`). -/
+the stored coefficients, with no intermediate coefficient-list or reverse
+allocation (value-equal to `eval` by `eval_eq_impl`, registered `@[csimp]`). -/
 @[expose]
 def evalImpl [Add R] [Mul R] (p : DensePoly R) (x : R) : R :=
   p.toArray.foldr (fun coeff acc => acc * x + coeff) (Zero.zero : R)

--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -908,35 +908,59 @@ theorem size_mul_le [Add R] [Mul R] (p q : DensePoly R) :
     refine Nat.le_trans (size_ofCoeffs_le _) ?_
     simp [mulRows_length]
 
-/-- Evaluate a polynomial using Horner's method. -/
-@[expose]
-def eval [Add R] [Mul R] (p : DensePoly R) (x : R) : R :=
-  p.toArray.toList.reverse.foldl (fun acc coeff => acc * x + coeff) (Zero.zero : R)
-
 omit [DecidableEq R] in
-/-- List-level Horner evaluation, reading coefficients from low to high degree. -/
-private def evalCoeffList [Add R] [Mul R] :
+/-- List-level Horner evaluation, reading coefficients from low to high degree.
+The body of the `eval` specification. -/
+@[expose]
+def evalCoeffList [Add R] [Mul R] :
     List R → R → R
   | [], _ => Zero.zero
   | c :: cs, x => evalCoeffList cs x * x + c
 
+/-- Evaluate a polynomial using Horner's method.
+
+Kernel-facing specification: one cons walk of the coefficient list, highest
+degree innermost. Compiled code runs the zero-allocation downward `Array.foldr`
+loop `evalImpl` via the `@[csimp]` proof `eval_eq_impl`. -/
+@[expose]
+noncomputable def eval [Add R] [Mul R] (p : DensePoly R) (x : R) : R :=
+  evalCoeffList p.toList x
+
+/-- Runtime implementation of `eval`: a downward `Array.foldr` Horner loop over
+the stored coefficients with no intermediate allocation (value-equal to `eval`
+by `eval_eq_impl`, registered `@[csimp]`). -/
+@[expose]
+def evalImpl [Add R] [Mul R] (p : DensePoly R) (x : R) : R :=
+  p.toArray.foldr (fun coeff acc => acc * x + coeff) (Zero.zero : R)
+
 omit [DecidableEq R] in
-private theorem reverse_foldl_evalCoeffList [Add R] [Mul R] (coeffs : List R) (x : R) :
-    coeffs.reverse.foldl (fun acc coeff => acc * x + coeff) (Zero.zero : R) =
-      evalCoeffList coeffs x := by
+/-- `evalCoeffList` is the `List.foldr` of the Horner step. -/
+private theorem evalCoeffList_eq_foldr [Add R] [Mul R] (coeffs : List R) (x : R) :
+    evalCoeffList coeffs x =
+      coeffs.foldr (fun coeff acc => acc * x + coeff) (Zero.zero : R) := by
   induction coeffs with
-  | nil =>
-      rfl
+  | nil => rfl
   | cons c cs ih =>
-      rw [List.reverse_cons, List.foldl_append]
-      simp only [List.foldl_cons, List.foldl_nil, evalCoeffList]
+      simp only [evalCoeffList, List.foldr_cons]
       rw [ih]
+
+/-- The spec `eval` and the `Array.foldr` runtime loop compute the same value. -/
+theorem eval_eq_evalImpl [Add R] [Mul R] (p : DensePoly R) (x : R) :
+    eval p x = evalImpl p x := by
+  unfold eval evalImpl
+  rw [← Array.foldr_toList, ← evalCoeffList_eq_foldr]
+  rfl
+
+/-- Register the `Array.foldr` loop as the compiled implementation of `eval`. -/
+@[csimp]
+theorem eval_eq_impl : @eval = @evalImpl := by
+  funext R _ _ _ _ p x
+  exact eval_eq_evalImpl p x
 
 /-- Horner evaluation agrees with the list-level Horner form over stored coefficients. -/
 private theorem eval_eq_evalCoeffList [Add R] [Mul R] (p : DensePoly R) (x : R) :
-    eval p x = evalCoeffList p.toArray.toList x := by
-  unfold eval
-  exact reverse_foldl_evalCoeffList p.toArray.toList x
+    eval p x = evalCoeffList p.toArray.toList x :=
+  rfl
 
 private theorem evalCoeffList_trimTrailingZerosList [Add R] [Mul R] (coeffs : List R) (x : R)
     (hzero : (Zero.zero : R) * x + (Zero.zero : R) = (Zero.zero : R)) :
@@ -1027,10 +1051,53 @@ private theorem evalCoeffList_zipPad_sub [Sub R] [Add R] [Mul R] (xs ys : List R
           simp only [zipPad, evalCoeffList]
           rw [ihp qs, hstep]
 
-/-- Compose polynomials using Horner's method. -/
+/-- List-level Horner composition, reading coefficients from low to high
+degree and preserving the `acc * q + C c` step orientation (for generic `R`
+this differs from `composeScalarCoeffList`'s `C c + q * acc`). -/
 @[expose]
-def compose [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
-  p.toArray.toList.reverse.foldl (fun acc coeff => acc * q + C coeff) (0 : DensePoly R)
+def composeCoeffList [Add R] [Mul R] : List R → DensePoly R → DensePoly R
+  | [], _ => 0
+  | c :: cs, q => composeCoeffList cs q * q + C c
+
+/-- Compose polynomials using Horner's method.
+
+Kernel-facing specification: one cons walk of the coefficient list. Compiled
+code runs the downward `Array.foldr` loop `composeImpl` via the `@[csimp]`
+proof `compose_eq_impl`. -/
+@[expose]
+noncomputable def compose [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
+  composeCoeffList p.toList q
+
+/-- Runtime implementation of `compose`: a downward `Array.foldr` Horner loop
+(value-equal to `compose` by `compose_eq_impl`, registered `@[csimp]`). -/
+@[expose]
+def composeImpl [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
+  p.toArray.foldr (fun coeff acc => acc * q + C coeff) (0 : DensePoly R)
+
+/-- `composeCoeffList` is the `List.foldr` of the polynomial Horner step. -/
+private theorem composeCoeffList_eq_foldr [Add R] [Mul R] (coeffs : List R) (q : DensePoly R) :
+    composeCoeffList coeffs q =
+      coeffs.foldr (fun coeff acc => acc * q + C coeff) (0 : DensePoly R) := by
+  induction coeffs with
+  | nil => rfl
+  | cons c cs ih =>
+      simp only [composeCoeffList, List.foldr_cons]
+      rw [ih]
+
+/-- The spec `compose` and the `Array.foldr` runtime loop compute the same
+polynomial. -/
+theorem compose_eq_composeImpl [Add R] [Mul R] (p q : DensePoly R) :
+    compose p q = composeImpl p q := by
+  unfold compose composeImpl
+  rw [← Array.foldr_toList, ← composeCoeffList_eq_foldr]
+  rfl
+
+/-- Register the `Array.foldr` loop as the compiled implementation of
+`compose`. -/
+@[csimp]
+theorem compose_eq_impl : @compose = @composeImpl := by
+  funext R _ _ _ _ p q
+  exact compose_eq_composeImpl p q
 
 /-- Left-composition by the zero polynomial is zero. -/
 @[simp, grind =] theorem compose_zero_left [Add R] [Mul R] (q : DensePoly R) :
@@ -1045,7 +1112,7 @@ theorem compose_C [Add R] [Mul R] (c : R) (q : DensePoly R)
   by_cases hc : c = (0 : R)
   · rw [hc]
     change compose (C (Zero.zero : R)) q = (C (Zero.zero : R))
-    unfold compose toArray
+    unfold compose toList toArray
     rw [show (C (Zero.zero : R)).coeffs = #[] by
       change (C (0 : R)).coeffs = #[]
       exact coeffs_C_zero]
@@ -1059,7 +1126,7 @@ theorem compose_C [Add R] [Mul R] (c : R) (q : DensePoly R)
     · simp [hn]
     · simp [hn]
   · change c ≠ Zero.zero at hc
-    unfold compose toArray
+    unfold compose toList toArray
     rw [coeffs_C_of_ne_zero hc]
     change (0 : DensePoly R) * q + C c = C c
     rw [show (0 : DensePoly R) * q = 0 by rfl]
@@ -1100,12 +1167,11 @@ when the caller supplies the algebraic step that commutes a Horner tail past `q`
 theorem compose_eq_composeScalarCoeffList_of_step [Add R] [Mul R] (p q : DensePoly R)
     (hstep : ∀ acc c, acc * q + C c = C c + q * acc) :
     compose p q = composeScalarCoeffList p.toList q := by
-  unfold compose toList
-  induction p.toArray.toList with
+  unfold compose
+  induction p.toList with
   | nil => rfl
   | cons c cs ih =>
-      rw [List.reverse_cons, List.foldl_append]
-      simp only [List.foldl_cons, List.foldl_nil]
+      simp only [composeCoeffList, composeScalarCoeffList]
       rw [ih]
       exact hstep (composeScalarCoeffList cs q) c
 
@@ -1492,13 +1558,14 @@ theorem eval_C [Add R] [Mul R] (c x : R)
   by_cases hc : c = (0 : R)
   · rw [hc]
     change eval (C (Zero.zero : R)) x = (Zero.zero : R)
-    unfold eval toArray
+    unfold eval toList toArray
     rw [show (C (Zero.zero : R)).coeffs = #[] by
       change (C (0 : R)).coeffs = #[]
       exact coeffs_C_zero]
     rfl
   · change c ≠ Zero.zero at hc
-    simp [eval, toArray, coeffs_C_of_ne_zero hc, hzero_mul, hzero_add]
+    simp [eval, toList, toArray, evalCoeffList, coeffs_C_of_ne_zero hc,
+      hzero_mul, hzero_add]
 
 /-- Semiring-specialized evaluation law for constants. This packages the
 zero-multiplication and zero-addition laws needed by the generic `eval_C`. -/
@@ -1524,17 +1591,21 @@ private theorem semiring_mul_pow_left {S : Type u} [Lean.Grind.Semiring S]
         _ = x ^ (n + 1 + 1) := by
           exact (Lean.Grind.Semiring.pow_succ x (n + 1)).symm
 
-private theorem eval_replicate_zero_semiring {S : Type u} [Lean.Grind.Semiring S]
-    (n : Nat) (c x : S) :
-    (List.replicate n (0 : S)).foldl (fun acc coeff => acc * x + coeff) c =
-      c * x ^ n := by
-  induction n generalizing c with
+private theorem evalCoeffList_replicate_zero_semiring {S : Type u}
+    [Lean.Grind.Semiring S] [DecidableEq S] (n : Nat) (c x : S) :
+    evalCoeffList (List.replicate n (0 : S) ++ [c]) x = c * x ^ n := by
+  induction n with
   | zero =>
-      simp [Lean.Grind.Semiring.pow_zero, Lean.Grind.Semiring.mul_one]
+      show (0 : S) * x + c = c * x ^ 0
+      rw [Lean.Grind.Semiring.zero_mul, Lean.Grind.Semiring.pow_zero,
+        Lean.Grind.Semiring.mul_one]
+      grind
   | succ n ih =>
-      rw [List.replicate_succ, List.foldl_cons, ih]
-      simp [Lean.Grind.Semiring.add_zero, Lean.Grind.Semiring.mul_assoc,
-        semiring_mul_pow_left]
+      rw [List.replicate_succ, List.cons_append]
+      show evalCoeffList (List.replicate n (0 : S) ++ [c]) x * x + (0 : S) =
+        c * x ^ (n + 1)
+      rw [ih, Lean.Grind.Semiring.add_zero, Lean.Grind.Semiring.mul_assoc,
+        ← Lean.Grind.Semiring.pow_succ]
 
 /-- Semiring-specialized evaluation law for monomials. -/
 @[simp, grind =] theorem eval_monomial_semiring {S : Type u}
@@ -1544,16 +1615,11 @@ private theorem eval_replicate_zero_semiring {S : Type u} [Lean.Grind.Semiring S
   by_cases hc : c = (0 : S)
   · rw [hc, monomial_zero, eval_zero]
     simp [Lean.Grind.Semiring.zero_mul]
-  · unfold eval toArray monomial
+  · unfold eval toList toArray monomial
     change c ≠ Zero.zero at hc
     rw [dif_neg hc]
-    simp [Array.toList_push]
-    have hinit : (Zero.zero : S) * x + c = c := by
-      change (0 : S) * x + c = c
-      rw [Lean.Grind.Semiring.zero_mul]
-      grind
-    rw [hinit]
-    exact eval_replicate_zero_semiring n c x
+    simp only [Array.toList_push, Array.toList_replicate]
+    exact evalCoeffList_replicate_zero_semiring n c x
 
 /-- The formal derivative of the zero polynomial is zero. -/
 @[simp, grind =] theorem derivative_zero [NatCast R] [Mul R] :

--- a/HexPolyFp/Compose.lean
+++ b/HexPolyFp/Compose.lean
@@ -60,18 +60,10 @@ private theorem C_zero_eq_zero :
     rw [C_zero_eq_zero]
     exact (C_zero_eq_zero (p := p)).symm
   · change c ≠ (Zero.zero : ZMod64 p) at hc
-    unfold DensePoly.compose DensePoly.toArray FpPoly.C
+    unfold DensePoly.compose DensePoly.toList DensePoly.toArray FpPoly.C
     rw [DensePoly.coeffs_C_of_ne_zero hc]
-    show (#[c].toList.reverse.foldl
-        (fun acc coeff => acc * q + DensePoly.C coeff) (0 : FpPoly p)) = DensePoly.C c
-    have hlist : #[c].toList = [c] := rfl
-    rw [hlist]
-    have hrev : ([c] : List (ZMod64 p)).reverse = [c] := rfl
-    rw [hrev]
-    simp only [List.foldl_cons, List.foldl_nil]
-    have : (0 : FpPoly p) * q + DensePoly.C c = DensePoly.C c := by
-      rw [FpPoly.zero_mul, FpPoly.zero_add]
-    exact this
+    show (0 : FpPoly p) * q + DensePoly.C c = DensePoly.C c
+    rw [FpPoly.zero_mul, FpPoly.zero_add]
 
 private theorem one_ne_zero_of_prime [ZMod64.PrimeModulus p] :
     (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := by
@@ -88,25 +80,17 @@ private theorem one_ne_zero_of_prime [ZMod64.PrimeModulus p] :
 composition. -/
 @[simp, grind =] theorem compose_X [ZMod64.PrimeModulus p] (q : FpPoly p) :
     DensePoly.compose (FpPoly.X : FpPoly p) q = q := by
-  unfold DensePoly.compose DensePoly.toArray FpPoly.X DensePoly.monomial
+  unfold DensePoly.compose DensePoly.toList DensePoly.toArray FpPoly.X DensePoly.monomial
   have h1 : (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := one_ne_zero_of_prime
   rw [dif_neg h1]
-  show ((((Array.replicate 1 (Zero.zero : ZMod64 p)).push 1).toList).reverse.foldl
-      (fun acc coeff => acc * q + DensePoly.C coeff) 0) = q
-  have hlist :
-      ((Array.replicate 1 (Zero.zero : ZMod64 p)).push 1).toList =
-        [(Zero.zero : ZMod64 p), 1] := rfl
-  rw [hlist]
-  have hrev : ([(Zero.zero : ZMod64 p), 1] : List (ZMod64 p)).reverse =
-      [(1 : ZMod64 p), Zero.zero] := rfl
-  rw [hrev]
-  simp only [List.foldl_cons, List.foldl_nil]
+  show ((0 : FpPoly p) * q + DensePoly.C (1 : ZMod64 p)) * q +
+      DensePoly.C (Zero.zero : ZMod64 p) = q
   have hstep1 : ((0 : FpPoly p) * q + DensePoly.C (1 : ZMod64 p)) = (1 : FpPoly p) := by
     rw [FpPoly.zero_mul, FpPoly.zero_add]
     rfl
-  rw [hstep1, FpPoly.one_mul]
-  show q + DensePoly.C (Zero.zero : ZMod64 p) = q
-  rw [show (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero, FpPoly.add_zero]
+  rw [hstep1, FpPoly.one_mul,
+    show (DensePoly.C (Zero.zero : ZMod64 p) : FpPoly p) = 0 from C_zero_eq_zero,
+    FpPoly.add_zero]
 
 /-- Composing the constant polynomial `1` with any `q` yields `1`: the
 multiplicative identity of `FpPoly` is fixed by substitution. This is the

--- a/HexPolyFp/ModCompose.lean
+++ b/HexPolyFp/ModCompose.lean
@@ -39,22 +39,15 @@ private theorem modByMonic_horner_step_eq
       modByMonic modulus (acc * g + C c) hmonic := by
   simp [modByMonic, DensePoly.modByMonic_eq_mod, mod_horner_step_eq]
 
-private theorem composeModMonic_fold_eq_mod
-    [ZMod64.PrimeModulus p]
-    (coeffs : List (ZMod64 p)) (init g modulus : FpPoly p)
-    (hmonic : DensePoly.Monic modulus) :
-    coeffs.foldl
-        (fun acc coeff => modByMonic modulus (acc * g + C coeff) hmonic)
-        (modByMonic modulus init hmonic) =
-      modByMonic modulus
-        (coeffs.foldl (fun acc coeff => acc * g + C coeff) init) hmonic := by
-  induction coeffs generalizing init with
-  | nil =>
-      rfl
-  | cons coeff coeffs ih =>
-      simp only [List.foldl_cons]
-      rw [modByMonic_horner_step_eq]
-      exact ih (init * g + C coeff)
+/-- List-level Horner form of modular composition, reading coefficients from
+low to high degree and preserving the `acc * g + C c` step orientation. The
+body of the `composeModMonic` specification. -/
+@[expose]
+def composeModMonicList (g modulus : FpPoly p)
+    (hmonic : DensePoly.Monic modulus) : List (ZMod64 p) → FpPoly p
+  | [] => 0
+  | c :: cs =>
+      modByMonic modulus (composeModMonicList g modulus hmonic cs * g + C c) hmonic
 
 /--
 Horner-style modular composition in the quotient `F_p[x] / (modulus)`.
@@ -62,13 +55,54 @@ Horner-style modular composition in the quotient `F_p[x] / (modulus)`.
 The reduction after each multiplication keeps the intermediate polynomials
 bounded by the modulus degree while preserving the same result as composing
 first and reducing once at the end.
--/
+
+Kernel-facing specification: one cons walk of the coefficient list. Compiled
+code runs the downward `Array.foldr` loop `composeModMonicImpl` via the
+`@[csimp]` proof `composeModMonic_eq_impl`. -/
 @[expose]
-def composeModMonic (f g modulus : FpPoly p)
+noncomputable def composeModMonic (f g modulus : FpPoly p)
     (hmonic : DensePoly.Monic modulus) : FpPoly p :=
-  f.toArray.toList.reverse.foldl
-    (fun acc coeff => modByMonic modulus (acc * g + C coeff) hmonic)
+  composeModMonicList g modulus hmonic f.toList
+
+/-- Runtime implementation of `composeModMonic`: a downward `Array.foldr`
+Horner loop (value-equal to `composeModMonic` by `composeModMonic_eq_impl`,
+registered `@[csimp]`). -/
+@[expose]
+def composeModMonicImpl (f g modulus : FpPoly p)
+    (hmonic : DensePoly.Monic modulus) : FpPoly p :=
+  f.toArray.foldr
+    (fun coeff acc => modByMonic modulus (acc * g + C coeff) hmonic)
     0
+
+/-- `composeModMonicList` is the `List.foldr` of the modular Horner step. -/
+private theorem composeModMonicList_eq_foldr
+    (g modulus : FpPoly p) (hmonic : DensePoly.Monic modulus)
+    (coeffs : List (ZMod64 p)) :
+    composeModMonicList g modulus hmonic coeffs =
+      coeffs.foldr
+        (fun coeff acc => modByMonic modulus (acc * g + C coeff) hmonic)
+        0 := by
+  induction coeffs with
+  | nil => rfl
+  | cons c cs ih =>
+      simp only [composeModMonicList, List.foldr_cons]
+      rw [ih]
+
+/-- The spec `composeModMonic` and the `Array.foldr` runtime loop compute the
+same polynomial. -/
+theorem composeModMonic_eq_composeModMonicImpl
+    (f g modulus : FpPoly p) (hmonic : DensePoly.Monic modulus) :
+    composeModMonic f g modulus hmonic = composeModMonicImpl f g modulus hmonic := by
+  unfold composeModMonic composeModMonicImpl
+  rw [← Array.foldr_toList, ← composeModMonicList_eq_foldr]
+  rfl
+
+/-- Register the `Array.foldr` loop as the compiled implementation of
+`composeModMonic`. -/
+@[csimp]
+theorem composeModMonic_eq_impl : @composeModMonic = @composeModMonicImpl := by
+  funext p _ f g modulus hmonic
+  exact composeModMonic_eq_composeModMonicImpl f g modulus hmonic
 
 /-- Modular composition of the zero polynomial is `0`. -/
 @[simp, grind =] theorem composeModMonic_zero
@@ -91,7 +125,15 @@ modulus. -/
     change 0 = modByMonic modulus (0 : FpPoly p) hmonic
     change 0 = DensePoly.modByMonic (0 : FpPoly p) modulus hmonic
     rw [DensePoly.modByMonic_zero]
-  · simp [composeModMonic, C, DensePoly.toArray, DensePoly.coeffs_C_of_ne_zero hc, zero_add]
+  · unfold composeModMonic
+    show composeModMonicList g modulus hmonic (DensePoly.C c : FpPoly p).toList =
+      modByMonic modulus (DensePoly.C c) hmonic
+    rw [show (DensePoly.C c : FpPoly p).toList = [c] by
+      show (DensePoly.C c : FpPoly p).coeffs.toList = [c]
+      rw [DensePoly.coeffs_C_of_ne_zero hc]]
+    show modByMonic modulus ((0 : FpPoly p) * g + DensePoly.C c) hmonic =
+      modByMonic modulus (DensePoly.C c) hmonic
+    rw [show (0 : FpPoly p) * g = 0 from rfl, zero_add]
 
 /--
 Executable modular composition agrees with ordinary dense-polynomial
@@ -102,14 +144,16 @@ theorem composeModMonic_eq_modByMonic_compose
     (f g modulus : FpPoly p) (hmonic : DensePoly.Monic modulus) :
     composeModMonic f g modulus hmonic =
       modByMonic modulus (DensePoly.compose f g) hmonic := by
-  rw [composeModMonic, DensePoly.compose]
-  have hfold :=
-    composeModMonic_fold_eq_mod
-      (f.toArray.toList.reverse) (0 : FpPoly p) g modulus hmonic
-  have hzero : modByMonic modulus (0 : FpPoly p) hmonic = 0 :=
-    DensePoly.modByMonic_zero modulus hmonic
-  rw [hzero] at hfold
-  exact hfold
+  unfold composeModMonic DensePoly.compose
+  induction f.toList with
+  | nil =>
+      symm
+      exact DensePoly.modByMonic_zero modulus hmonic
+  | cons c cs ih =>
+      show modByMonic modulus (composeModMonicList g modulus hmonic cs * g + C c) hmonic =
+        modByMonic modulus (DensePoly.composeCoeffList cs g * g + DensePoly.C c) hmonic
+      rw [ih, modByMonic_horner_step_eq]
+      rfl
 
 /--
 The converse rewrite direction for `composeModMonic_eq_modByMonic_compose`.

--- a/HexPolyFp/Quotient.lean
+++ b/HexPolyFp/Quotient.lean
@@ -243,8 +243,9 @@ project-side evaluation layer for root-counting arguments over
 quotient representation.
 -/
 @[expose]
-def eval (f : FpPoly p) (β : Quotient g hmonic hg_pos) : Quotient g hmonic hg_pos :=
-  f.toArray.toList.reverse.foldl
+noncomputable def eval (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
+    Quotient g hmonic hg_pos :=
+  f.toList.reverse.foldl
     (fun acc coeff =>
       acc * β + reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (DensePoly.C coeff))
@@ -253,8 +254,9 @@ def eval (f : FpPoly p) (β : Quotient g hmonic hg_pos) : Quotient g hmonic hg_p
 /-- Stored `FpPoly` coefficients embedded as quotient constants, in low-to-high
 coefficient order. -/
 @[expose]
-def evalQuotientCoeffs (f : FpPoly p) : List (Quotient g hmonic hg_pos) :=
-  f.toArray.toList.map
+noncomputable def evalQuotientCoeffs (f : FpPoly p) :
+    List (Quotient g hmonic hg_pos) :=
+  f.toList.map
     (fun coeff =>
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C coeff))
 
@@ -274,18 +276,18 @@ class. -/
         (DensePoly.C (0 : ZMod64 p)) β =
       reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         (DensePoly.C (0 : ZMod64 p))
-    unfold eval DensePoly.toArray
+    unfold eval DensePoly.toList DensePoly.toArray
     rw [show (DensePoly.C (0 : ZMod64 p)).coeffs = #[] by
       exact DensePoly.coeffs_C_zero]
     rfl
-  · simp [eval, DensePoly.toArray, DensePoly.coeffs_C_of_ne_zero hc]
+  · simp [eval, DensePoly.toList, DensePoly.toArray, DensePoly.coeffs_C_of_ne_zero hc]
 
 /-- Evaluating the polynomial indeterminate gives the input quotient element. -/
 @[simp, grind =] theorem eval_X (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (FpPoly.X (p := p)) β = β := by
   change eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
       (DensePoly.monomial 1 (1 : ZMod64 p)) β = β
-  unfold eval DensePoly.toArray DensePoly.monomial
+  unfold eval DensePoly.toList DensePoly.toArray DensePoly.monomial
   split
   · exact False.elim (zmod64_one_ne_zero ‹(1 : ZMod64 p) = 0›)
   · have hC1 : reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
@@ -454,7 +456,7 @@ theorem eval_eq_evalCoeffList (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
     eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β =
       evalCoeffList
         (evalQuotientCoeffs (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f) β := by
-  unfold eval evalQuotientCoeffs
+  unfold eval evalQuotientCoeffs DensePoly.toList
   rw [foldl_eval_reverse_eq_evalScalarCoeffList
     (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β f.toArray.toList]
   exact (evalCoeffList_map_reduce_C_eq_evalScalarCoeffList
@@ -463,7 +465,7 @@ theorem eval_eq_evalCoeffList (f : FpPoly p) (β : Quotient g hmonic hg_pos) :
 /-- `FpPoly`-specific divided-difference quotient evaluated between `α` and
 `β`, using the existing executable coefficient representation. -/
 @[expose]
-def evalDividedDifference (f : FpPoly p)
+noncomputable def evalDividedDifference (f : FpPoly p)
     (α β : Quotient g hmonic hg_pos) : Quotient g hmonic hg_pos :=
   dividedDifference
     (evalQuotientCoeffs (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f) α β
@@ -471,7 +473,7 @@ def evalDividedDifference (f : FpPoly p)
 /-- Synthetic quotient coefficients for the `FpPoly` divided difference at
 `α`. -/
 @[expose]
-def evalDividedDifferenceCoeffs (f : FpPoly p)
+noncomputable def evalDividedDifferenceCoeffs (f : FpPoly p)
     (α : Quotient g hmonic hg_pos) : List (Quotient g hmonic hg_pos) :=
   dividedDifferenceCoeffs
     (evalQuotientCoeffs (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f) α
@@ -550,7 +552,7 @@ private theorem eval_eq_coeff_power_sum (f : FpPoly p)
       evalCoeffPowerSumFrom
         (g := g) (hmonic := hmonic) (hg_pos := hg_pos)
         f.toArray.toList 0 β := by
-  unfold eval
+  unfold eval DensePoly.toList
   rw [foldl_eval_reverse_eq_evalScalarCoeffList
     (g := g) (hmonic := hmonic) (hg_pos := hg_pos) β f.toArray.toList]
   exact evalScalarCoeffList_eq_powerSumFrom_zero
@@ -1074,7 +1076,7 @@ private theorem eval_monomial_core (n : Nat) (c : ZMod64 p)
         β ^ n
     unfold DensePoly.monomial
     rw [dif_pos (show (0 : ZMod64 p) = Zero.zero from rfl), eval_zero, reduce_C_zero, zero_mul]
-  · unfold eval DensePoly.toArray DensePoly.monomial
+  · unfold eval DensePoly.toList DensePoly.toArray DensePoly.monomial
     have hc0 : ¬ c = (Zero.zero : ZMod64 p) := hc
     rw [dif_neg hc0]
     simp only [Array.toList_push, Array.toList_replicate, List.reverse_append,
@@ -1432,7 +1434,7 @@ theorem evalCoeffList_rootsIn_elements_length_le_degree
 private theorem evalQuotientCoeffs_length (f : FpPoly p) :
     (evalQuotientCoeffs (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f).length =
       f.size := by
-  simp [evalQuotientCoeffs, DensePoly.toArray, DensePoly.size]
+  simp [evalQuotientCoeffs, DensePoly.toList, DensePoly.toArray, DensePoly.size]
 
 omit [ZMod64.PrimeModulus p] in
 private theorem fpPoly_eq_zero_of_size_eq_zero {f : FpPoly p} (hsize : f.size = 0) :
@@ -1472,7 +1474,7 @@ private theorem evalQuotientCoeffs_topNonzero_of_ne_zero
   let topQuot :=
     reduce (g := g) (hmonic := hmonic) (hg_pos := hg_pos) (DensePoly.C topCoeff)
   refine ⟨topQuot, ?_, ?_⟩
-  · unfold evalQuotientCoeffs topQuot topCoeff DensePoly.toArray DensePoly.coeff
+  · unfold evalQuotientCoeffs topQuot topCoeff DensePoly.toList DensePoly.toArray DensePoly.coeff
     rw [List.getLast?_map, List.getLast?_eq_getElem?, Array.getElem?_toList]
     rw [Array.getElem?_eq_getElem
       (by simpa [DensePoly.size] using Nat.sub_one_lt_of_lt hsize_pos)]
@@ -1485,7 +1487,7 @@ private theorem evalQuotientCoeffs_topNonzero_of_ne_zero
 /-- Roots of an `FpPoly` quotient evaluation inside the canonical quotient
 enumeration. -/
 @[expose]
-def rootsOfFpPoly (f : FpPoly p) : List (Quotient g hmonic hg_pos) :=
+noncomputable def rootsOfFpPoly (f : FpPoly p) : List (Quotient g hmonic hg_pos) :=
   (elements (g := g) (hmonic := hmonic) (hg_pos := hg_pos)).filter
     (fun β => decide (eval (g := g) (hmonic := hmonic) (hg_pos := hg_pos) f β = 0))
 

--- a/HexPolyFp/Ring.lean
+++ b/HexPolyFp/Ring.lean
@@ -103,7 +103,7 @@ case to `eval_C` for reasoning about the evaluation map. -/
 @[simp, grind =]
 theorem eval_X [ZMod64.PrimeModulus p] (x : ZMod64 p) :
     DensePoly.eval (FpPoly.X : FpPoly p) x = x := by
-  unfold FpPoly.X DensePoly.eval DensePoly.toArray DensePoly.monomial
+  unfold FpPoly.X DensePoly.eval DensePoly.toList DensePoly.toArray DensePoly.monomial
   have h1 : (1 : ZMod64 p) ≠ (Zero.zero : ZMod64 p) := by
     intro h
     have h2 : 2 ≤ p := (ZMod64.PrimeModulus.prime (p := p)).two_le
@@ -114,47 +114,14 @@ theorem eval_X [ZMod64.PrimeModulus p] (x : ZMod64 p) :
         Nat.mod_eq_of_lt (by omega : 1 < p)] at htoNat
     exact absurd htoNat (by omega)
   rw [dif_neg h1]
-  simp
   change (((0 : ZMod64 p) * x + 1) * x + 0 = x)
   rw [zmod_zero_mul, zmod_zero_add, zmod_one_mul, zmod_add_zero]
-
-private theorem foldl_eval_replicate_zero (x : ZMod64 p) :
-    ∀ n acc,
-      (List.replicate n (0 : ZMod64 p)).foldl
-          (fun acc coeff => acc * x + coeff) acc =
-        acc * x ^ n := by
-  intro n
-  induction n with
-  | zero =>
-      intro acc
-      rw [Lean.Grind.Semiring.pow_zero]
-      exact (zmod_mul_one acc).symm
-  | succ n ih =>
-      intro acc
-      simp only [List.replicate_succ, List.foldl_cons]
-      rw [zmod_add_zero, ih (acc * x), Lean.Grind.Semiring.pow_succ x n,
-        Lean.Grind.Semiring.mul_assoc acc x (x ^ n), Lean.Grind.CommSemiring.mul_comm x (x ^ n)]
 
 /-- Evaluating a monomial gives the coefficient times the corresponding power. -/
 @[simp, grind =]
 theorem eval_monomial (n : Nat) (c x : ZMod64 p) :
-    DensePoly.eval (DensePoly.monomial n c : FpPoly p) x = c * x ^ n := by
-  by_cases hc : c = 0
-  · subst c
-    unfold DensePoly.monomial
-    rw [dif_pos (show (0 : ZMod64 p) = Zero.zero from rfl)]
-    exact (zmod_zero_mul (x ^ n)).symm
-  · unfold DensePoly.eval DensePoly.toArray DensePoly.monomial
-    have hc0 : ¬ c = (Zero.zero : ZMod64 p) := hc
-    rw [dif_neg hc0]
-    simp only [Array.toList_push, Array.toList_replicate, List.reverse_append,
-      List.reverse_cons, List.reverse_nil, List.nil_append, List.singleton_append,
-      List.foldl_cons]
-    change (List.replicate n (0 : ZMod64 p)).reverse.foldl
-        (fun acc coeff => acc * x + coeff) ((0 : ZMod64 p) * x + c) =
-      c * x ^ n
-    rw [zmod_zero_mul, zmod_zero_add, List.reverse_replicate]
-    exact foldl_eval_replicate_zero x n c
+    DensePoly.eval (DensePoly.monomial n c : FpPoly p) x = c * x ^ n :=
+  DensePoly.eval_monomial_semiring n c x
 
 /-- Coefficients of the constant polynomial wrapper are constant at degree zero and zero elsewhere. -/
 @[simp, grind =] theorem coeff_C (c : ZMod64 p) (n : Nat) :
@@ -227,28 +194,26 @@ private theorem evalScalarCoeffList_eq_powerSumFrom_zero
         mul_evalCoeffPowerSumFrom_eq_succ x coeffs 0]
       grind
 
-/-- The Horner-step left fold over the reversed coefficient list equals
-`evalScalarCoeffList`. -/
-private theorem foldl_eval_reverse_eq_evalScalarCoeffList
+/-- The generic low-to-high Horner walk equals `evalScalarCoeffList`; the two
+recursions differ only by the commutations `acc * x = x * acc` and
+`acc + c = c + acc`. -/
+private theorem evalCoeffList_eq_evalScalarCoeffList
     (x : ZMod64 p) :
     ∀ coeffs,
-      coeffs.reverse.foldl (fun acc coeff => acc * x + coeff) (Zero.zero : ZMod64 p) =
-        evalScalarCoeffList coeffs x
-  | [] => by
-      rfl
+      DensePoly.evalCoeffList coeffs x = evalScalarCoeffList coeffs x
+  | [] => rfl
   | coeff :: coeffs => by
-      rw [List.reverse_cons, List.foldl_append]
-      simp only [List.foldl_cons, List.foldl_nil]
-      rw [foldl_eval_reverse_eq_evalScalarCoeffList x coeffs, Lean.Grind.CommSemiring.mul_comm,
+      show DensePoly.evalCoeffList coeffs x * x + coeff =
+        coeff + x * evalScalarCoeffList coeffs x
+      rw [evalCoeffList_eq_evalScalarCoeffList x coeffs, Lean.Grind.CommSemiring.mul_comm,
         Lean.Grind.Semiring.add_comm]
-      rfl
 
 /-- `DensePoly.eval f x` equals the power sum of `f`'s coefficient list based at
 exponent zero. -/
 private theorem eval_eq_coeff_power_sum (f : FpPoly p) (x : ZMod64 p) :
     DensePoly.eval f x = evalCoeffPowerSumFrom f.toArray.toList 0 x := by
-  unfold DensePoly.eval
-  rw [foldl_eval_reverse_eq_evalScalarCoeffList x f.toArray.toList]
+  show DensePoly.evalCoeffList f.toArray.toList x = _
+  rw [evalCoeffList_eq_evalScalarCoeffList x f.toArray.toList]
   exact evalScalarCoeffList_eq_powerSumFrom_zero x f.toArray.toList
 
 /-- Indexing `f`'s coefficient list with default zero recovers `f.coeff n`. -/


### PR DESCRIPTION
This PR gives the Horner-loop operations the kernel-facing-spec / `@[csimp]`-runtime-impl split of design principle 11 (PR 2 of the four-package plan). `DensePoly.eval` and `compose` become `noncomputable` cons-walk specifications over `toList` (`evalCoeffList` promoted to public; the new `composeCoeffList` preserves the `acc * q + C c` step orientation, since `composeScalarCoeffList`'s `C c + q * acc` differs for generic `R` without commutativity), and their runtime impls are downward `Array.foldr` Horner loops with no intermediate coefficient-list or reverse allocation, replacing the two-list `toArray.toList.reverse.foldl` round-trip. The hot-path `FpPoly.composeModMonic` gets the same split via `composeModMonicList`, preserving the `modByMonic (acc * g + C c)` order. The spec-only `HexPolyFp` quotient evaluation layer (`Quotient.eval`, `evalQuotientCoeffs`, `evalDividedDifference`\*, `rootsOfFpPoly`) moves onto `toList` and becomes `noncomputable`. Characterising lemma statements are unchanged; `compose_eq_composeScalarCoeffList_of_step` keeps its `hstep` hypothesis, and `HexPolyFp`'s `eval_monomial` now reuses the generic `eval_monomial_semiring`.

Full `lake build` (4142 jobs) plus `HexConformance` are green; bench verify checksums pass (`hexpolyfp` 8/8 including `composeModMonic`; all `hexpoly`/`hexgfqfield` failures are the local python-flint absence). The `eval`/`compose` spec symbols are absent from the generated C with the impls referenced. Codex review: no correctness findings.

Part of https://github.com/kim-em/hex-dev/issues/8618 (closes its scope together with PR 1).

🤖 Prepared with Claude Code