### PR TITLE
bench: measure recursive per-remainder re-lift for sub-floor classical certification

### DIFF
--- a/bench/HexBench/RecursiveReliftSpike.lean
+++ b/bench/HexBench/RecursiveReliftSpike.lean
@@ -1,0 +1,501 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekampZassenhaus
+
+/-!
+Measurement spike (UNPROVEN) for issue #8625: recursive per-remainder re-lift
+for sub-floor classical irreducibility certification.
+
+Today the classical tier runs ONE Hensel lift of the whole core at
+`precisionForCoeffBound (exhaustiveLiftBound core B) p` and certifies
+irreducibility of unsplit remainders through coverage of that single lift,
+whose partition completeness is gated at the monic-core Mignotte floor
+`2 * defaultFactorCoeffBound (toMonic core).monic < p^k` (see #8620). The only
+sound route below that floor is to give each unsplit remainder a FRESH
+lift/partition/coverage stack of its own, at the remainder's OWN monic floor.
+
+This file prototypes that recursion executably (unproven, like
+`classicalFactorIntK` in `ClassicalSpike.lean`) in two variants:
+
+* **fresh-prime**: each remainder gets its own `choosePrimeData?` (prime walk
+  plus Berlekamp) and its own escalation ladder. Maximum flexibility (a
+  remainder that is irreducible mod its fresh prime certifies with no lift at
+  all, via the `SmallModSingleton` chain), but re-pays prime selection per
+  node.
+* **same-prime**: each remainder keeps the parent's prime and its own
+  mod-p factors (known from the split that produced it), and re-lifts just
+  those to the remainder's own floor. No per-node prime walk or Berlekamp;
+  the inherited r = 1 case (a remainder covering a single local factor) still
+  certifies for free. This is also the smaller proof-surface variant.
+
+Accounting per certification node: target degree, prime, local factor count
+`r`, own floor exponent, ladder exponent reached, recombination scans run.
+Per input we compare today's single-lift exponent `k_today`, the core-local
+floor `k_corelocal` (#8620 rewrite-1 reference), and each recursion's
+`sum k` / degree-weighted work model `sum deg^2 * k` (lift cost scales with
+the square of the target degree at fixed exponent, so a raw `sum k` flatters
+neither side).
+
+The recombination scan shared by all arms prefilters candidates with the
+classic d-1 test and replaces `exactQuotient?`'s full `divMod` with a bounded
+division that aborts once a quotient coefficient exceeds the target's Mignotte
+factor bound (no true cofactor can). Without the bound, failing candidates in
+below-recovery-precision scans grow geometrically and their multi-limb
+divisions dominate wallclock, which would charge the ladder for a defect of
+the naive scan rather than for lifting. Production recombination
+(`scaledRecombinationSmart`) already has equivalent-or-stronger residue
+filters.
+
+Restricted to monic squarefree cores (every corpus core below is monic; the
+non-squarefree `adv/high_multiplicity` input enters via its squarefree core,
+exactly as production does after `normalizeForFactor`).
+
+Proves nothing. This is a measurement artifact gating deliverable 2 of #8625.
+-/
+
+open Hex
+
+local instance : Inhabited ZPoly := ⟨0⟩
+
+/-! ### Recombination (smart subset scan, after `ClassicalSpike.lean`) -/
+
+/-- All size-`k` sub-lists of `xs`, each paired with its complement. Structural;
+worst-case `2^|xs|`, but the caller tries small `k` first and stops early. -/
+def chooseWithComplement {α : Type} : List α → Nat → List (List α × List α)
+  | xs, 0 => [([], xs)]
+  | [], _ + 1 => []
+  | x :: xs, k + 1 =>
+      (chooseWithComplement xs k).map (fun sc => (x :: sc.1, sc.2)) ++
+      (chooseWithComplement xs (k + 1)).map (fun sc => (sc.1, x :: sc.2))
+
+def firstSomeList {α β : Type} : List α → (α → Option β) → Option β
+  | [], _ => none
+  | x :: xs, f => match f x with | some y => some y | none => firstSomeList xs f
+
+/-- Reduce every coefficient of `g` into `[0, m)`. -/
+def reduceModInt (g : ZPoly) (m : Nat) : ZPoly :=
+  DensePoly.ofCoeffs (g.toArray.map (fun c => Int.emod c (Int.ofNat m)))
+
+/-- Product of a subset of lifted factors, reduced mod `m` after each multiply. -/
+def productModInt (s : List ZPoly) (m : Nat) : ZPoly :=
+  s.foldl (fun acc g => reduceModInt (acc * g) m) (1 : ZPoly)
+
+/-- Exact division of `target` by a MONIC `cand` of degree >= 1, aborting as
+soon as a quotient coefficient exceeds `qbound` in absolute value — a true
+cofactor of `target` respects the Mignotte factor bound, while a failing
+candidate's synthetic-division coefficients grow geometrically. The abort caps
+each failing candidate at a few division steps instead of a full multi-limb
+`divMod`. -/
+def boundedExactQuotientMonic? (target cand : ZPoly) (qbound : Nat) :
+    Option ZPoly := Id.run do
+  let n := target.size
+  let m := cand.size
+  if m < 2 || m > n then return none
+  let mut rem := target.toArray
+  let dq := n - m
+  let mut q : Array Int := Array.replicate (dq + 1) 0
+  for step in [0:dq + 1] do
+    let i := dq - step
+    let c := rem[i + m - 1]!
+    if c.natAbs > qbound then return none
+    if c != 0 then
+      q := q.set! i c
+      for j in [0:m] do
+        rem := rem.set! (i + j) (rem[i + j]! - c * cand.coeff j)
+  for j in [0:m - 1] do
+    if rem[j]! != 0 then return none
+  return some (DensePoly.ofCoeffs q)
+
+/-- One recombination entry: the factor lifted to the current modulus paired
+with its base mod-`p` factor (lifted to `Z`), tracked so a split piece keeps
+its own local factors for the same-prime sub-lift. -/
+abbrev LiftedPair := ZPoly × ZPoly
+
+/-- First subset of `remaining` (sizes `size..hi`) whose centered product
+exactly divides `target`; returns the integer factor, the base mod-p factors
+it came from, the quotient, and the unused pairs. Smallest size first, so
+fully-split inputs peel singletons in O(r). Candidates pass the d-1
+trailing-coefficient test and the bounded division against `qbound`. -/
+partial def findDivisorPairs
+    (target : ZPoly) (remaining : List LiftedPair) (modulus qbound : Nat)
+    (size hi : Nat) :
+    Option (ZPoly × List ZPoly × ZPoly × List LiftedPair) :=
+  if size > hi then none
+  else
+    let t0 := target.coeff 0
+    let scan := firstSomeList (chooseWithComplement remaining size) fun sc =>
+      let cand := centeredLiftPoly (productModInt (sc.1.map (·.1)) modulus) modulus
+      let c0 := cand.coeff 0
+      if c0 != 0 && Int.emod t0 c0 != 0 then none
+      else
+        match boundedExactQuotientMonic? target cand qbound with
+        | some q => some (cand, sc.1.map (·.2), q, sc.2)
+        | none => none
+    match scan with
+    | some res => some res
+    | none => findDivisorPairs target remaining modulus qbound (size + 1) hi
+
+/-- Peel integer factors off `target` one at a time, each paired with its base
+mod-p factors; when no proper subset (size `1..r/2`) divides, the whole
+remaining target is pushed unsplit with all remaining base factors. -/
+partial def recombPairs
+    (target : ZPoly) (remaining : List LiftedPair) (modulus : Nat)
+    (acc : Array (ZPoly × List ZPoly)) : Array (ZPoly × List ZPoly) :=
+  let r := remaining.length
+  if r == 0 then acc
+  else
+    let qbound := ZPoly.defaultFactorCoeffBound target
+    match findDivisorPairs target remaining modulus qbound 1 (r / 2) with
+    | some (cand, candBase, quotient, rest) =>
+        recombPairs quotient rest modulus (acc.push (cand, candBase))
+    | none => acc.push (target, remaining.map (·.2))
+
+/-- Base-factor-blind wrapper (pairs each lifted factor with itself). -/
+def recombInt (target : ZPoly) (factors : List ZPoly) (modulus : Nat) :
+    Array ZPoly :=
+  (recombPairs target (factors.map fun g => (g, g)) modulus #[]).map (·.1)
+
+/-! ### The recursive per-remainder certification -/
+
+/-- Accounting record for one certification node (one remainder). -/
+structure NodeRec where
+  deg : Nat
+  p : Nat
+  r : Nat
+  /-- The remainder's own monic-transform Mignotte floor exponent at `p`. -/
+  floorK : Nat
+  /-- Ladder exponent actually reached (0 for the lift-free certificates). -/
+  kStop : Nat
+  /-- Number of lift+recombination rungs run on this node. -/
+  rungs : Nat
+  outcome : String
+  deriving Inhabited
+
+/-- Escalation ladder for one remainder under a FRESH prime selection: lift
+`g`'s modular factors to `k = 1, 2, 4, ...` (clamped at `floorK`) and try to
+recombine. Returns `(kStop, rungs, pieces)`; a singleton `pieces` means `g`
+never split, so the final rung was the floor and `g` is certified irreducible
+by fresh coverage. -/
+partial def reliftLadder
+    (g : ZPoly) (pd : PrimeChoiceData) (floorK k rungs : Nat) :
+    Nat × Nat × Array (ZPoly × List ZPoly) :=
+  let kk := min k floorK
+  let ld := henselLiftData g kk pd
+  letI := pd.bounds
+  let base := pd.factorsModP.toList.map FpPoly.liftToZ
+  let pairs := ld.liftedFactors.toList.zip base
+  let pieces := recombPairs g pairs (pd.p ^ kk) #[]
+  if pieces.size ≥ 2 then (kk, rungs + 1, pieces)
+  else if kk == floorK then (kk, rungs + 1, #[(g, base)])
+  else reliftLadder g pd floorK (k * 2) (rungs + 1)
+
+/-- Fresh-prime recursion: certify `g` (monic, squarefree) against a fresh
+prime selection and lift of its own, recursing on any split pieces. Returns
+the certified-irreducible factors and the per-node accounting. -/
+partial def certifyAux (g : ZPoly) (recs : Array NodeRec) :
+    Array ZPoly × Array NodeRec :=
+  let deg := g.degree?.getD 0
+  if deg ≤ 1 then
+    (#[g], recs.push { deg, p := 0, r := 0, floorK := 0, kStop := 0, rungs := 0,
+                       outcome := "deg<=1" })
+  else
+    match choosePrimeData? g with
+    | none =>
+        (#[g], recs.push { deg, p := 0, r := 0, floorK := 0, kStop := 0, rungs := 0,
+                           outcome := "NO-PRIME" })
+    | some pd =>
+        let r := pd.factorsModP.size
+        if r ≤ 1 then
+          (#[g], recs.push { deg, p := pd.p, r, floorK := 0, kStop := 0, rungs := 0,
+                             outcome := "modp-irreducible" })
+        else
+          let floorK :=
+            precisionForCoeffBound
+              (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic) pd.p
+          let (kStop, rungs, pieces) := reliftLadder g pd floorK 1 0
+          if pieces.size == 1 then
+            (#[g], recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
+                               outcome := "floor-certified" })
+          else
+            let recs := recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
+                                    outcome := "split" }
+            pieces.foldl (init := (#[], recs)) fun st piece =>
+              let (fs, rs) := certifyAux piece.1 st.2
+              (st.1 ++ fs, rs)
+
+/-- Factor-only wrapper for wallclock timing (fresh-prime variant). -/
+def recursiveFactorInt (core : ZPoly) : Array ZPoly :=
+  (certifyAux core #[]).1
+
+/-- Escalation ladder for one remainder at the PARENT's prime, re-lifting the
+remainder's own base mod-p factors to the remainder's own floor. -/
+partial def reliftLadderSamePrime
+    (pd : PrimeChoiceData) (g : ZPoly) (baseFactors : List ZPoly)
+    (floorK k rungs : Nat) : Nat × Nat × Array (ZPoly × List ZPoly) :=
+  letI := pd.bounds
+  let kk := min k floorK
+  let lifted := ZPoly.multifactorLiftQuadratic pd.p kk g baseFactors.toArray
+  let pairs := lifted.toList.zip baseFactors
+  let pieces := recombPairs g pairs (pd.p ^ kk) #[]
+  if pieces.size ≥ 2 then (kk, rungs + 1, pieces)
+  else if kk == floorK then (kk, rungs + 1, #[(g, baseFactors)])
+  else reliftLadderSamePrime pd g baseFactors floorK (k * 2) (rungs + 1)
+
+/-- Same-prime recursion: certify `g` against a fresh lift of its OWN base
+mod-p factors (inherited from the parent's split) at the parent's prime, to
+`g`'s own floor. No per-node prime walk or Berlekamp. -/
+partial def certifySamePrimeAux
+    (pd : PrimeChoiceData) (g : ZPoly) (baseFactors : List ZPoly)
+    (recs : Array NodeRec) : Array ZPoly × Array NodeRec :=
+  let deg := g.degree?.getD 0
+  let r := baseFactors.length
+  if deg ≤ 1 then
+    (#[g], recs.push { deg, p := pd.p, r, floorK := 0, kStop := 0, rungs := 0,
+                       outcome := "deg<=1" })
+  else if r ≤ 1 then
+    (#[g], recs.push { deg, p := pd.p, r, floorK := 0, kStop := 0, rungs := 0,
+                       outcome := "modp-irreducible" })
+  else
+    let floorK :=
+      precisionForCoeffBound
+        (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic) pd.p
+    let (kStop, rungs, pieces) := reliftLadderSamePrime pd g baseFactors floorK 1 0
+    if pieces.size == 1 then
+      (#[g], recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
+                         outcome := "floor-certified" })
+    else
+      let recs := recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
+                              outcome := "split" }
+      pieces.foldl (init := (#[], recs)) fun st piece =>
+        let (fs, rs) := certifySamePrimeAux pd piece.1 piece.2 st.2
+        (st.1 ++ fs, rs)
+
+/-- Same-prime recursion entry point. -/
+def certifySamePrime (core : ZPoly) : Array ZPoly × Array NodeRec :=
+  match choosePrimeData? core with
+  | none =>
+      (#[core], #[{ deg := core.degree?.getD 0, p := 0, r := 0, floorK := 0,
+                    kStop := 0, rungs := 0, outcome := "NO-PRIME" }])
+  | some pd =>
+      letI := pd.bounds
+      certifySamePrimeAux pd core (pd.factorsModP.toList.map FpPoly.liftToZ) #[]
+
+/-- Factor-only wrapper for wallclock timing (same-prime variant). -/
+def recursiveFactorSamePrime (core : ZPoly) : Array ZPoly :=
+  (certifySamePrime core).1
+
+/-- Today's single-lift classical run on a monic squarefree `core`, at the
+production precision for caller bound `B` (`exhaustiveLiftBound core B`). -/
+def classicalFactorTodayWithB (core : ZPoly) (B : Nat) : Array ZPoly :=
+  match ZPoly.toMonicPrimeData? core with
+  | none => #[]
+  | some pd =>
+      let k := precisionForCoeffBound (ZPoly.exhaustiveLiftBound core B) pd.p
+      let ld := henselLiftData core k pd
+      recombInt core ld.liftedFactors.toList (pd.p ^ k)
+
+/-! ### Inputs -/
+
+/-- `(x-1-s)(x-2-s)...(x-n-s)`: shifted fully-split family (distinct inputs). -/
+def linearProductShift (n s : Nat) : ZPoly :=
+  (List.range n).foldl
+    (fun acc i => acc * DensePoly.ofCoeffs #[-(Int.ofNat (i + 1 + s)), 1]) (1 : ZPoly)
+
+/-- Deterministic split family with roots scaled by `height + 1` (mirrors
+`splitDegreeHeightInput` in `bench/HexBerlekampZassenhaus/Bench.lean`). -/
+def splitDegreeHeight (degree height : Nat) : ZPoly :=
+  let scale := Int.ofNat (height + 1)
+  (Array.range degree).foldl
+    (fun acc i => acc * DensePoly.ofCoeffs #[-(scale * Int.ofNat (i + 1)), 1])
+    (1 : ZPoly)
+
+/-- 15th cyclotomic polynomial: irreducible over `Z`, splits mod p. -/
+def phi15 : ZPoly := DensePoly.ofCoeffs #[1, -1, 0, 1, -1, 1, 0, -1, 1]
+
+/-- Swinnerton-Dyer `SD_3`: irreducible, splits into low degrees mod every p. -/
+def advSD3 : ZPoly := DensePoly.ofCoeffs #[576, 0, -960, 0, 352, 0, -40, 0, 1]
+
+/-- Swinnerton-Dyer `SD_4` (degree 16). -/
+def advSD4 : ZPoly :=
+  DensePoly.ofCoeffs
+    #[46225, 0, -5596840, 0, 13950764, 0, -7453176, 0, 1513334, 0, -141912, 0,
+      6476, 0, -136, 0, 1]
+
+/-- `adv/mignotte_swell` fixture: `(x^4-100x+1)(x^4+100x+1)`, height-100
+quartic factors inside a height-10000 degree-8 core. -/
+def advMignotteSwell : ZPoly := DensePoly.ofCoeffs #[1, 0, -10000, 0, 2, 0, 0, 0, 1]
+
+/-- `adv/high_multiplicity` fixture: `(x^2+1)^3 (x-3)^2` (non-squarefree). -/
+def advHighMultiplicity : ZPoly :=
+  DensePoly.ofCoeffs #[9, -6, 28, -18, 30, -18, 12, -6, 1]
+
+/-- Taylor shift `g(x+s)` by Horner over polynomial arithmetic: distinct-input
+families from a single adversarial fixture (defeats hoisting; preserves degree,
+irreducibility, and the mod-p splitting pattern). -/
+def shiftPoly (g : ZPoly) (s : Int) : ZPoly :=
+  let xps : ZPoly := DensePoly.ofCoeffs #[s, 1]
+  g.toArray.foldr (fun c acc => acc * xps + DensePoly.C c) (0 : ZPoly)
+
+/-! ### Reporting -/
+
+/-- Sorted multiset of factor degrees, for a quick correctness signature. -/
+def degreeSignature (fs : Array ZPoly) : List Nat :=
+  (fs.toList.map (fun g => g.degree?.getD 0)).mergeSort (· ≤ ·)
+
+def sumBy (recs : Array NodeRec) (f : NodeRec → Nat) : Nat :=
+  recs.foldl (fun a n => a + f n) 0
+
+def NodeRec.line (n : NodeRec) : String :=
+  s!"      deg={n.deg} p={n.p} r={n.r} floorK={n.floorK} kStop={n.kStop} rungs={n.rungs} {n.outcome}"
+
+/-- Summarize one recursion variant's records against the core. -/
+def variantSummary (label : String) (core : ZPoly)
+    (result : Array ZPoly × Array NodeRec) : IO Unit := do
+  let (factors, recs) := result
+  let sumK := sumBy recs (·.kStop)
+  let maxK := recs.foldl (fun a n => max a n.kStop) 0
+  let rungs := sumBy recs (·.rungs)
+  let bigNodes := recs.foldl (fun a n => a + if n.p != 0 && n.r > 1 then 1 else 0) 0
+  let workRec := sumBy recs (fun n => n.deg * n.deg * n.kStop)
+  let productOk := (Array.polyProduct factors).toArray == core.toArray
+  IO.println s!"    {label}: sumK={sumK} maxK={maxK} work={workRec} nodes={recs.size} lifted_nodes={bigNodes} recomb_scans={rungs} factors={degreeSignature factors} product_ok={productOk}"
+  for n in recs do
+    if n.p != 0 || n.deg > 1 then IO.println n.line
+
+/-- Accounting report for one input: `f` is the full caller input (sets today's
+`B`), `core` its monic squarefree core (what the tier actually factors). -/
+def reportCase (name : String) (f core : ZPoly) : IO Unit := do
+  let degC := core.degree?.getD 0
+  match ZPoly.toMonicPrimeData? core with
+  | none => IO.println s!"{name}: NO PRIME SELECTED"
+  | some pd =>
+      let kToday :=
+        precisionForCoeffBound
+          (ZPoly.exhaustiveLiftBound core (ZPoly.defaultFactorCoeffBound f)) pd.p
+      let kLocal :=
+        precisionForCoeffBound
+          (max (ZPoly.defaultFactorCoeffBound core)
+            (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic)) pd.p
+      IO.println s!"{name} (deg {degC}, p {pd.p}): k_today={kToday} (work {degC * degC * kToday})  k_corelocal={kLocal} (work {degC * degC * kLocal})"
+      variantSummary "fresh-prime" core (certifyAux core #[])
+      variantSummary "same-prime " core (certifySamePrime core)
+  (← IO.getStdout).flush
+
+/-- Checksum the actual factor coefficients so the optimizer cannot drop the
+factorization (defeats CSE/dead-code elimination). -/
+def factorChecksum (fs : Array ZPoly) : UInt64 :=
+  fs.foldl (fun acc g =>
+    g.toArray.foldl (fun a c => a * 1000003 + UInt64.ofNat c.natAbs) acc) 7
+
+/-- Generic phase timer over a distinct-input family; `sink` forces evaluation. -/
+def timePhase (label : String) (reps : Nat) (inputs : Array ZPoly)
+    (act : ZPoly → UInt64) : IO Unit := do
+  let out ← IO.getStdout
+  let m := inputs.size
+  let mut w : UInt64 := 0
+  for i in [0:Nat.min m 4] do w := w + act inputs[i]!
+  let t0 ← IO.monoNanosNow
+  let mut acc : UInt64 := w
+  for i in [0:reps] do acc := acc + act (inputs[i % m]!)
+  let t1 ← IO.monoNanosNow
+  IO.println s!"  {label}: {(t1 - t0).toFloat / reps.toFloat / 1000.0} us/call (reps={reps}, sink={acc})"
+  out.flush
+
+/-- Wallclock triple: today vs both recursion variants on one family. -/
+def timeArms (reps : Nat) (inputs : Array ZPoly) (coreOf : ZPoly → ZPoly)
+    (bOf : ZPoly → Nat) : IO Unit := do
+  timePhase "today      " reps inputs
+    (fun f => factorChecksum (classicalFactorTodayWithB (coreOf f) (bOf f)))
+  timePhase "fresh-prime" reps inputs
+    (fun f => factorChecksum (recursiveFactorInt (coreOf f)))
+  timePhase "same-prime " reps inputs
+    (fun f => factorChecksum (recursiveFactorSamePrime (coreOf f)))
+
+def main : IO Unit := do
+  -- Focused profile mode: `RELIFT_PROFILE=today|recursive|sameprime|phases`
+  -- runs only the split deg-24 family under the selected arm (for
+  -- `perf record`), then exits.
+  if let some arm ← IO.getEnv "RELIFT_PROFILE" then
+    let inputs := (Array.range 8).map (linearProductShift 24)
+    if arm == "recursive" then
+      timePhase "profile recursive" 30 inputs
+        (fun f => factorChecksum (recursiveFactorInt f))
+    else if arm == "sameprime" then
+      timePhase "profile same-prime" 30 inputs
+        (fun f => factorChecksum (recursiveFactorSamePrime f))
+    else if arm == "phases" then
+      -- Per-phase breakdown of one recursive node level on the deg-24 split
+      -- input: prime selection, the k=1 lift, and the k=1 recombination scan.
+      timePhase "choosePrimeData?" 30 inputs (fun f =>
+        match choosePrimeData? f with
+        | none => 0
+        | some pd => UInt64.ofNat pd.p + UInt64.ofNat pd.factorsModP.size)
+      timePhase "lift k=1        " 30 inputs (fun f =>
+        match choosePrimeData? f with
+        | none => 0
+        | some pd => factorChecksum (henselLiftData f 1 pd).liftedFactors)
+      timePhase "recomb at k=1   " 30 inputs (fun f =>
+        match choosePrimeData? f with
+        | none => 0
+        | some pd =>
+            let ld := henselLiftData f 1 pd
+            factorChecksum (recombInt f ld.liftedFactors.toList (pd.p ^ 1)))
+    else
+      timePhase "profile today" 30 inputs
+        (fun f => factorChecksum (classicalFactorTodayWithB f (ZPoly.defaultFactorCoeffBound f)))
+    return
+  IO.println "=== recursive per-remainder re-lift spike (#8625): lift-precision accounting ==="
+  IO.println "    k_today: today's single lift at exhaustiveLiftBound core (mignotte f)"
+  IO.println "    k_corelocal: the #8620 rewrite-1 core-local floor (reference)"
+  IO.println "    work: degree-weighted lift model sum deg^2 * k"
+  IO.println ""
+  -- Split families (degree/height grid; the bzClassicalDegreeHeightComplexity axes).
+  for (d, h) in [(3, 2), (4, 2), (4, 8), (5, 8), (6, 32), (12, 32)] do
+    let g := splitDegreeHeight d h
+    reportCase s!"split deg{d} height{h}" g g
+  for d in [8, 12, 16, 20, 24] do
+    let g := splitDegreeHeight d 0
+    reportCase s!"split deg{d} height0" g g
+  -- High-content / high-multiplicity adversarial fixtures.
+  let hmCore := (normalizeForFactor advHighMultiplicity).squareFreeCore
+  reportCase "adv/high_multiplicity (core of (x^2+1)^3(x-3)^2)" advHighMultiplicity hmCore
+  reportCase "adv/mignotte_swell" advMignotteSwell advMignotteSwell
+  -- High-degree irreducibles: the predicted loss cases.
+  reportCase "cyclotomic phi15" phi15 phi15
+  reportCase "SD3" advSD3 advSD3
+  reportCase "SD4" advSD4 advSD4
+  -- Small factor of a large irreducible core: the other predicted loss case.
+  let sd3x := DensePoly.ofCoeffs #[-1, 1] * advSD3
+  let sd4x := DensePoly.ofCoeffs #[-1, 1] * advSD4
+  reportCase "(x-1)*SD3" sd3x sd3x
+  reportCase "(x-1)*SD4" sd4x sd4x
+
+  IO.println ""
+  IO.println "=== wallclock (distinct-input families; today = single production-precision lift) ==="
+  for n in [12, 16, 20, 24] do
+    let inputs := (Array.range 8).map (linearProductShift n)
+    IO.println s!"--- split deg{n} ---"
+    timeArms 30 inputs id (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- adv/mignotte_swell (shift family) ---"
+  let swellFamily := (Array.range 8).map (fun s => shiftPoly advMignotteSwell (Int.ofNat s))
+  timeArms 30 swellFamily id (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- adv/high_multiplicity (shift family; today's B from the full input) ---"
+  let hmFamily := (Array.range 8).map (fun s => shiftPoly advHighMultiplicity (Int.ofNat s))
+  timeArms 30 hmFamily (fun f => (normalizeForFactor f).squareFreeCore)
+    (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- phi15 (shift family) ---"
+  let phiFamily := (Array.range 8).map (fun s => shiftPoly phi15 (Int.ofNat s))
+  timeArms 30 phiFamily id (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- SD3 (shift family) ---"
+  let sd3Family := (Array.range 4).map (fun s => shiftPoly advSD3 (Int.ofNat s))
+  timeArms 10 sd3Family id (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- SD4 (shift family) ---"
+  let sd4Family := (Array.range 2).map (fun s => shiftPoly advSD4 (Int.ofNat s))
+  timeArms 2 sd4Family id (fun f => ZPoly.defaultFactorCoeffBound f)
+  IO.println "--- (x-1)*SD3 (shift family) ---"
+  let sd3xFamily := (Array.range 4).map (fun s => shiftPoly sd3x (Int.ofNat s))
+  timeArms 10 sd3xFamily id (fun f => ZPoly.defaultFactorCoeffBound f)

--- a/bench/HexBench/RecursiveReliftSpike.lean
+++ b/bench/HexBench/RecursiveReliftSpike.lean
@@ -471,6 +471,43 @@ def main : IO Unit := do
     else if arm == "sameprime" then
       timePhase "profile same-prime" 30 inputs
         (fun f => factorChecksum (recursiveFactorSamePrime f))
+    else if arm == "prime" then
+      -- Prime-selection cost breakdown: full choosePrimeData? across degrees
+      -- and families, plus the marginal cost of one isGoodPrime check at the
+      -- already-selected prime (the walk repeats that per candidate prime).
+      for n in [8, 12, 16, 20, 24] do
+        let fam := (Array.range 8).map (linearProductShift n)
+        timePhase s!"choosePrimeData? split deg{n}" 50 fam (fun f =>
+          match choosePrimeData? f with
+          | none => 0
+          | some pd => UInt64.ofNat pd.p + UInt64.ofNat pd.factorsModP.size)
+      let phiFam := (Array.range 8).map (fun s => shiftPoly phi15 (Int.ofNat s))
+      timePhase "choosePrimeData? phi15 (deg 8)" 50 phiFam (fun f =>
+        match choosePrimeData? f with
+        | none => 0
+        | some pd => UInt64.ofNat pd.p + UInt64.ofNat pd.factorsModP.size)
+      let sd4Fam := (Array.range 4).map (fun s => shiftPoly advSD4 (Int.ofNat s))
+      timePhase "choosePrimeData? SD4 (deg 16)" 20 sd4Fam (fun f =>
+        match choosePrimeData? f with
+        | none => 0
+        | some pd => UInt64.ofNat pd.p + UInt64.ofNat pd.factorsModP.size)
+      -- marginal isGoodPrime cost at the selected prime, deg 24
+      let prepared := (Array.range 8).filterMap (fun s =>
+        let f := linearProductShift 24 s
+        (choosePrimeData? f).map (fun pd => (f, pd)))
+      let out ← IO.getStdout
+      let t0 ← IO.monoNanosNow
+      let mut acc : UInt64 := 0
+      let reps := 400
+      for i in [0:reps] do
+        let (f, pd) := prepared[i % prepared.size]!
+        let good := letI := pd.bounds; isGoodPrime f pd.p
+        acc := acc + (if good then 1 else 0) + UInt64.ofNat i
+      let t1 ← IO.monoNanosNow
+      IO.println s!"  isGoodPrime@selected deg24: {(t1 - t0).toFloat / reps.toFloat / 1000.0} us/call (sink={acc})"
+      for (f, pd) in prepared do
+        IO.println s!"    deg {f.degree?.getD 0}: selected p={pd.p} r={pd.factorsModP.size}"
+      out.flush
     else if arm == "phases" then
       -- Per-phase breakdown of one recursive node level on the deg-24 split
       -- input: prime selection, the k=1 lift, and the k=1 recombination scan.

--- a/bench/HexBench/RecursiveReliftSpike.lean
+++ b/bench/HexBench/RecursiveReliftSpike.lean
@@ -95,6 +95,7 @@ def boundedExactQuotientMonic? (target cand : ZPoly) (qbound : Nat) :
   let n := target.size
   let m := cand.size
   if m < 2 || m > n then return none
+  if cand.coeff (m - 1) != 1 then return none
   let mut rem := target.toArray
   let dq := n - m
   let mut q : Array Int := Array.replicate (dq + 1) 0
@@ -359,8 +360,9 @@ def advHighMultiplicity : ZPoly :=
   DensePoly.ofCoeffs #[9, -6, 28, -18, 30, -18, 12, -6, 1]
 
 /-- Taylor shift `g(x+s)` by Horner over polynomial arithmetic: distinct-input
-families from a single adversarial fixture (defeats hoisting; preserves degree,
-irreducibility, and the mod-p splitting pattern). -/
+families from a single adversarial fixture (defeats hoisting; preserves degree
+and irreducibility over `Z`, though the selected prime and modular split may
+differ per shift). -/
 def shiftPoly (g : ZPoly) (s : Int) : ZPoly :=
   let xps : ZPoly := DensePoly.ofCoeffs #[s, 1]
   g.toArray.foldr (fun c acc => acc * xps + DensePoly.C c) (0 : ZPoly)
@@ -432,9 +434,20 @@ def timePhase (label : String) (reps : Nat) (inputs : Array ZPoly)
   IO.println s!"  {label}: {(t1 - t0).toFloat / reps.toFloat / 1000.0} us/call (reps={reps}, sink={acc})"
   out.flush
 
-/-- Wallclock triple: today vs both recursion variants on one family. -/
+/-- Production classical tier on the core (`classicalCoreFactorsWithBound`:
+`toMonicLiftData` + `scaledRecombinationSmart` with its own residue filters and
+subset budget). Anchors the shared-scan baseline against real production
+recombination; `none` (declined, budget exhausted) checksums as empty. -/
+def classicalFactorProduction (core : ZPoly) (B : Nat) : Array ZPoly :=
+  match ZPoly.toMonicPrimeData? core with
+  | none => #[]
+  | some pd => (classicalCoreFactorsWithBound core B pd).getD #[]
+
+/-- Wallclock arms: production, shared-scan baseline, recursion variants. -/
 def timeArms (reps : Nat) (inputs : Array ZPoly) (coreOf : ZPoly → ZPoly)
     (bOf : ZPoly → Nat) : IO Unit := do
+  timePhase "production " reps inputs
+    (fun f => factorChecksum (classicalFactorProduction (coreOf f) (bOf f)))
   timePhase "today      " reps inputs
     (fun f => factorChecksum (classicalFactorTodayWithB (coreOf f) (bOf f)))
   timePhase "fresh-prime" reps inputs

--- a/bench/HexBench/RecursiveReliftSpike.lean
+++ b/bench/HexBench/RecursiveReliftSpike.lean
@@ -141,23 +141,26 @@ partial def findDivisorPairs
 
 /-- Peel integer factors off `target` one at a time, each paired with its base
 mod-p factors; when no proper subset (size `1..r/2`) divides, the whole
-remaining target is pushed unsplit with all remaining base factors. -/
+remaining target is pushed unsplit with all remaining base factors. `qbound`
+is a Mignotte factor bound for the ORIGINAL node target, computed once by the
+caller (every peeled cofactor is a factor of it, so the bound stays sound down
+the peel chain; recomputing per quotient is expensive big-int work). -/
 partial def recombPairs
-    (target : ZPoly) (remaining : List LiftedPair) (modulus : Nat)
+    (target : ZPoly) (remaining : List LiftedPair) (modulus qbound hiCap : Nat)
     (acc : Array (ZPoly × List ZPoly)) : Array (ZPoly × List ZPoly) :=
   let r := remaining.length
   if r == 0 then acc
   else
-    let qbound := ZPoly.defaultFactorCoeffBound target
-    match findDivisorPairs target remaining modulus qbound 1 (r / 2) with
+    match findDivisorPairs target remaining modulus qbound 1 (min hiCap (r / 2)) with
     | some (cand, candBase, quotient, rest) =>
-        recombPairs quotient rest modulus (acc.push (cand, candBase))
+        recombPairs quotient rest modulus qbound hiCap (acc.push (cand, candBase))
     | none => acc.push (target, remaining.map (·.2))
 
 /-- Base-factor-blind wrapper (pairs each lifted factor with itself). -/
-def recombInt (target : ZPoly) (factors : List ZPoly) (modulus : Nat) :
+def recombInt (target : ZPoly) (factors : List ZPoly) (modulus qbound : Nat) :
     Array ZPoly :=
-  (recombPairs target (factors.map fun g => (g, g)) modulus #[]).map (·.1)
+  (recombPairs target (factors.map fun g => (g, g)) modulus qbound
+    factors.length #[]).map (·.1)
 
 /-! ### The recursive per-remainder certification -/
 
@@ -181,17 +184,19 @@ recombine. Returns `(kStop, rungs, pieces)`; a singleton `pieces` means `g`
 never split, so the final rung was the floor and `g` is certified irreducible
 by fresh coverage. -/
 partial def reliftLadder
-    (g : ZPoly) (pd : PrimeChoiceData) (floorK k rungs : Nat) :
+    (g : ZPoly) (pd : PrimeChoiceData) (singletonSubFloor : Bool)
+    (qbound floorK k rungs : Nat) :
     Nat × Nat × Array (ZPoly × List ZPoly) :=
   let kk := min k floorK
   let ld := henselLiftData g kk pd
   letI := pd.bounds
   let base := pd.factorsModP.toList.map FpPoly.liftToZ
   let pairs := ld.liftedFactors.toList.zip base
-  let pieces := recombPairs g pairs (pd.p ^ kk) #[]
+  let hiCap := if singletonSubFloor && kk != floorK then 1 else pairs.length
+  let pieces := recombPairs g pairs (pd.p ^ kk) qbound hiCap #[]
   if pieces.size ≥ 2 then (kk, rungs + 1, pieces)
   else if kk == floorK then (kk, rungs + 1, #[(g, base)])
-  else reliftLadder g pd floorK (k * 2) (rungs + 1)
+  else reliftLadder g pd singletonSubFloor qbound floorK (k * 2) (rungs + 1)
 
 /-- Fresh-prime recursion: certify `g` (monic, squarefree) against a fresh
 prime selection and lift of its own, recursing on any split pieces. Returns
@@ -213,10 +218,9 @@ partial def certifyAux (g : ZPoly) (recs : Array NodeRec) :
           (#[g], recs.push { deg, p := pd.p, r, floorK := 0, kStop := 0, rungs := 0,
                              outcome := "modp-irreducible" })
         else
-          let floorK :=
-            precisionForCoeffBound
-              (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic) pd.p
-          let (kStop, rungs, pieces) := reliftLadder g pd floorK 1 0
+          let qbound := ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic
+          let floorK := precisionForCoeffBound qbound pd.p
+          let (kStop, rungs, pieces) := reliftLadder g pd false qbound floorK 1 0
           if pieces.size == 1 then
             (#[g], recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
                                outcome := "floor-certified" })
@@ -234,22 +238,26 @@ def recursiveFactorInt (core : ZPoly) : Array ZPoly :=
 /-- Escalation ladder for one remainder at the PARENT's prime, re-lifting the
 remainder's own base mod-p factors to the remainder's own floor. -/
 partial def reliftLadderSamePrime
-    (pd : PrimeChoiceData) (g : ZPoly) (baseFactors : List ZPoly)
-    (floorK k rungs : Nat) : Nat × Nat × Array (ZPoly × List ZPoly) :=
+    (pd : PrimeChoiceData) (subFloorCap : Nat) (g : ZPoly)
+    (baseFactors : List ZPoly)
+    (qbound floorK k rungs : Nat) : Nat × Nat × Array (ZPoly × List ZPoly) :=
   letI := pd.bounds
   let kk := min k floorK
   let lifted := ZPoly.multifactorLiftQuadratic pd.p kk g baseFactors.toArray
   let pairs := lifted.toList.zip baseFactors
-  let pieces := recombPairs g pairs (pd.p ^ kk) #[]
+  let hiCap := if kk != floorK then min subFloorCap pairs.length else pairs.length
+  let pieces := recombPairs g pairs (pd.p ^ kk) qbound hiCap #[]
   if pieces.size ≥ 2 then (kk, rungs + 1, pieces)
   else if kk == floorK then (kk, rungs + 1, #[(g, baseFactors)])
-  else reliftLadderSamePrime pd g baseFactors floorK (k * 2) (rungs + 1)
+  else reliftLadderSamePrime pd subFloorCap g baseFactors qbound floorK
+    (k * 2) (rungs + 1)
 
 /-- Same-prime recursion: certify `g` against a fresh lift of its OWN base
 mod-p factors (inherited from the parent's split) at the parent's prime, to
 `g`'s own floor. No per-node prime walk or Berlekamp. -/
 partial def certifySamePrimeAux
-    (pd : PrimeChoiceData) (g : ZPoly) (baseFactors : List ZPoly)
+    (pd : PrimeChoiceData) (subFloorCap : Nat) (g : ZPoly)
+    (baseFactors : List ZPoly)
     (recs : Array NodeRec) : Array ZPoly × Array NodeRec :=
   let deg := g.degree?.getD 0
   let r := baseFactors.length
@@ -260,10 +268,10 @@ partial def certifySamePrimeAux
     (#[g], recs.push { deg, p := pd.p, r, floorK := 0, kStop := 0, rungs := 0,
                        outcome := "modp-irreducible" })
   else
-    let floorK :=
-      precisionForCoeffBound
-        (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic) pd.p
-    let (kStop, rungs, pieces) := reliftLadderSamePrime pd g baseFactors floorK 1 0
+    let qbound := ZPoly.defaultFactorCoeffBound (ZPoly.toMonic g).monic
+    let floorK := precisionForCoeffBound qbound pd.p
+    let (kStop, rungs, pieces) :=
+      reliftLadderSamePrime pd subFloorCap g baseFactors qbound floorK 1 0
     if pieces.size == 1 then
       (#[g], recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
                          outcome := "floor-certified" })
@@ -271,22 +279,38 @@ partial def certifySamePrimeAux
       let recs := recs.push { deg, p := pd.p, r, floorK, kStop, rungs,
                               outcome := "split" }
       pieces.foldl (init := (#[], recs)) fun st piece =>
-        let (fs, rs) := certifySamePrimeAux pd piece.1 piece.2 st.2
+        let (fs, rs) := certifySamePrimeAux pd subFloorCap piece.1 piece.2 st.2
         (st.1 ++ fs, rs)
 
-/-- Same-prime recursion entry point. -/
-def certifySamePrime (core : ZPoly) : Array ZPoly × Array NodeRec :=
+/-- Same-prime recursion entry point. `subFloorCap` caps the subset size the
+recombination scan tries at rungs BELOW the floor (the floor rung always runs
+the full scan). Sub-floor rungs necessarily fail on every candidate the rung
+cannot yet recover, and the failed tail costs one bounded division per
+candidate, so the cap trades sub-floor discovery of multi-local-factor splits
+(`cap >= 2`, e.g. the mignotte_swell quartics) against a failed tail that
+grows like `C(r, cap)` per rung. -/
+def certifySamePrime (core : ZPoly) (subFloorCap : Nat) :
+    Array ZPoly × Array NodeRec :=
   match choosePrimeData? core with
   | none =>
       (#[core], #[{ deg := core.degree?.getD 0, p := 0, r := 0, floorK := 0,
                     kStop := 0, rungs := 0, outcome := "NO-PRIME" }])
   | some pd =>
       letI := pd.bounds
-      certifySamePrimeAux pd core (pd.factorsModP.toList.map FpPoly.liftToZ) #[]
+      certifySamePrimeAux pd subFloorCap core
+        (pd.factorsModP.toList.map FpPoly.liftToZ) #[]
 
-/-- Factor-only wrapper for wallclock timing (same-prime variant). -/
+/-- Wallclock wrapper: same-prime, full scan at every rung. -/
 def recursiveFactorSamePrime (core : ZPoly) : Array ZPoly :=
-  (certifySamePrime core).1
+  (certifySamePrime core 1000000).1
+
+/-- Wallclock wrapper: same-prime, singleton-only sub-floor rungs. -/
+def recursiveFactorSamePrimeCap1 (core : ZPoly) : Array ZPoly :=
+  (certifySamePrime core 1).1
+
+/-- Wallclock wrapper: same-prime, sub-floor rungs capped at size-2 subsets. -/
+def recursiveFactorSamePrimeCap2 (core : ZPoly) : Array ZPoly :=
+  (certifySamePrime core 2).1
 
 /-- Today's single-lift classical run on a monic squarefree `core`, at the
 production precision for caller bound `B` (`exhaustiveLiftBound core B`). -/
@@ -294,9 +318,10 @@ def classicalFactorTodayWithB (core : ZPoly) (B : Nat) : Array ZPoly :=
   match ZPoly.toMonicPrimeData? core with
   | none => #[]
   | some pd =>
-      let k := precisionForCoeffBound (ZPoly.exhaustiveLiftBound core B) pd.p
+      let qbound := ZPoly.exhaustiveLiftBound core B
+      let k := precisionForCoeffBound qbound pd.p
       let ld := henselLiftData core k pd
-      recombInt core ld.liftedFactors.toList (pd.p ^ k)
+      recombInt core ld.liftedFactors.toList (pd.p ^ k) qbound
 
 /-! ### Inputs -/
 
@@ -381,8 +406,10 @@ def reportCase (name : String) (f core : ZPoly) : IO Unit := do
           (max (ZPoly.defaultFactorCoeffBound core)
             (ZPoly.defaultFactorCoeffBound (ZPoly.toMonic core).monic)) pd.p
       IO.println s!"{name} (deg {degC}, p {pd.p}): k_today={kToday} (work {degC * degC * kToday})  k_corelocal={kLocal} (work {degC * degC * kLocal})"
-      variantSummary "fresh-prime" core (certifyAux core #[])
-      variantSummary "same-prime " core (certifySamePrime core)
+      variantSummary "fresh-prime    " core (certifyAux core #[])
+      variantSummary "same-prime-full" core (certifySamePrime core 1000000)
+      variantSummary "same-prime-cap1" core (certifySamePrime core 1)
+      variantSummary "same-prime-cap2" core (certifySamePrime core 2)
   (← IO.getStdout).flush
 
 /-- Checksum the actual factor coefficients so the optimizer cannot drop the
@@ -414,6 +441,10 @@ def timeArms (reps : Nat) (inputs : Array ZPoly) (coreOf : ZPoly → ZPoly)
     (fun f => factorChecksum (recursiveFactorInt (coreOf f)))
   timePhase "same-prime " reps inputs
     (fun f => factorChecksum (recursiveFactorSamePrime (coreOf f)))
+  timePhase "same-p-cap1" reps inputs
+    (fun f => factorChecksum (recursiveFactorSamePrimeCap1 (coreOf f)))
+  timePhase "same-p-cap2" reps inputs
+    (fun f => factorChecksum (recursiveFactorSamePrimeCap2 (coreOf f)))
 
 def main : IO Unit := do
   -- Focused profile mode: `RELIFT_PROFILE=today|recursive|sameprime|phases`
@@ -443,7 +474,9 @@ def main : IO Unit := do
         | none => 0
         | some pd =>
             let ld := henselLiftData f 1 pd
-            factorChecksum (recombInt f ld.liftedFactors.toList (pd.p ^ 1)))
+            factorChecksum
+              (recombInt f ld.liftedFactors.toList (pd.p ^ 1)
+                (ZPoly.defaultFactorCoeffBound f)))
     else
       timePhase "profile today" 30 inputs
         (fun f => factorChecksum (classicalFactorTodayWithB f (ZPoly.defaultFactorCoeffBound f)))

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -251,6 +251,10 @@ lean_exe hex_lattice_spike where
   srcDir := "bench"
   root := `HexBench.LatticeSpike
 
+lean_exe hex_recursive_relift_spike where
+  srcDir := "bench"
+  root := `HexBench.RecursiveReliftSpike
+
 lean_exe hexbz_factor_service where
   srcDir := "bench"
   root := `HexBench.FactorService

--- a/progress/20260706T000000Z_issue-8625-investigation-plan.md
+++ b/progress/20260706T000000Z_issue-8625-investigation-plan.md
@@ -1,0 +1,73 @@
+# Issue 8625 spike: recursive per-remainder re-lift — investigation + plan
+
+## Accomplished
+
+Investigation only, no code yet. Claimed #8625 (assigned). Read the full
+#8620 history (premise check, wording clarification, corpus measurement,
+close rationale) and the code it cites:
+
+- `bench/HexBench/ClassicalSpike.lean` — the spike precedent: unproven
+  executable prototype (`classicalFactorInt`, `classicalFactorIntK`,
+  `balancedLift`, `recombInt`), `lean_exe hex_classical_spike` declared in
+  the root `lakefile.lean` (srcDir `bench`), timing harness
+  (`timePhase`/`factorChecksum`), findings report in
+  `reports/bz-classical-spike-findings.md`.
+- `HexBerlekampZassenhaus/FactorEntryPoints.lean` —
+  `exhaustiveLiftBound core B = max B (defaultFactorCoeffBound
+  (toMonic core).monic)`; `factorClassical` feeds `B = defaultFactorCoeffBound
+  f` (whole f, the over-lift #8620 measured as marginal).
+- `HexPolyZ/Mignotte.lean:427` `defaultFactorCoeffBound`,
+  `ReassemblyProofs.lean:170` `precisionForCoeffBound B p = ceilLogP p (2B+1)`.
+- `ChoosePrimeData.lean` — `choosePrimeData?` is FIRST-suitable prime
+  (Isabelle `find_prime` policy), not min-factor-count;
+  `henselLiftData f k pd` lifts `pd.factorsModP` to precision k.
+- `SmallModSingleton.lean` — r=1 (mod-p singleton) irreducibility chain
+  already exists Mathlib-free; relevant because per-remainder re-selection
+  makes r_g = 1 a free (k=0) certificate for the remainder.
+- Fixtures: `adv/high_multiplicity` = (x²+1)³(x-3)² (squarefree core
+  (x²+1)(x-3), monic); `adv/mignotte_swell` = two height-100 quartics
+  (x⁴±100x+1); SD3/SD4/Φ15 defined in `bench/HexBerlekampZassenhaus/
+  Bench.lean:176-190`; `splitDegreeHeightInput` family ibid:231.
+
+Key architectural fact (from #8620): classical irreducibility flows through
+coverage gated on partition completeness at
+`2·defaultFactorCoeffBound (toMonic core).monic < p^k`, inherited by
+`liftedFactorSubsetPartition_transport` at the same LiftData. Sub-floor
+certification requires a FRESH per-remainder lift/partition — the thing this
+spike measures before anyone builds it.
+
+## Current frontier
+
+Plan agreed shape (measurement-first, gating deliverable 1 of the issue):
+
+1. New `bench/HexBench/RecursiveReliftSpike.lean` + `lean_exe
+   hex_recursive_relift_spike` (mirroring ClassicalSpike; Mathlib-free;
+   not wired into CI). Self-contained copies of the small recomb helpers.
+2. Prototype `recursiveCertify g`: deg≤1 → free; choosePrimeData? g,
+   r=1 → free (mod-p singleton); else ladder k=1,2,4,…, clamped at
+   floor_g = precisionForCoeffBound (defaultFactorCoeffBound (toMonic
+   g).monic) p_g; at each rung lift+recombine; split → recurse on pieces,
+   no split at floor → certified irreducible. Record per-node
+   (deg, p, r, k_stop, outcome).
+3. Metrics per input: today's k (exhaustiveLiftBound core (mignotte f)),
+   core-local floor k (#8620 rewrite-1 reference), recursive Σk_stop and
+   degree-weighted Σ deg²·k_stop; wallclock secondary.
+4. Families: high_multiplicity core, mignotte_swell, Φ15, SD3, SD4 (loss
+   cases: irreducible), splitDegreeHeightInput grid extended to deg 8–24,
+   plus constructed loss case (x-1)·SD3 / (x-1)·SD4 (small factor of large
+   core).
+5. Report `reports/bz-recursive-relift-findings.md` + measurement comment
+   on #8625 with recommendation; deliverable 2 (proof remodel) only if the
+   win is robust, likely as a follow-up directive.
+
+Risk to watch: per-rung recombination rescans (SD4: r=16 → C(16,≤8)
+subsets per rung × ~7 rungs) may dominate the loss cases; measure it.
+
+## Next step
+
+Implement `RecursiveReliftSpike.lean`, run it, tabulate, write report,
+/second-opinion, PR on branch issue-8625.
+
+## Blockers
+
+None.

--- a/progress/20260706T011848Z.md
+++ b/progress/20260706T011848Z.md
@@ -1,0 +1,24 @@
+**Accomplished**
+
+Reviewed the recursive per-remainder re-lift spike and findings report for
+issue #8625. Checked the prototype, report claims, relevant classical entry
+points, Mignotte precision helper, production recombination, small-mod singleton
+chain, and quadratic multifactor lift surfaces. Verified `lake build
+hex_recursive_relift_spike` succeeds.
+
+**Current frontier**
+
+No implementation changes were made. The main review concerns are report
+precision around the shared-scan benchmark baseline, shifted-family modular
+splitting claims, and proof-surface caveats for same-prime factor tracking and
+bounded synthetic division.
+
+**Next step**
+
+If the spike is kept, tighten report wording and consider adding a small
+instrumented table for prime/factor-count stability across shifted families and
+a production-recombination comparison arm.
+
+**Blockers**
+
+None.

--- a/progress/20260706T020000Z_issue-8625-measurement-complete.md
+++ b/progress/20260706T020000Z_issue-8625-measurement-complete.md
@@ -1,0 +1,46 @@
+# Issue 8625 spike: measurement complete, report written
+
+## Accomplished
+
+Deliverable 1 of #8625 (the gating measurement) is done:
+
+- `bench/HexBench/RecursiveReliftSpike.lean` (`lean_exe
+  hex_recursive_relift_spike`, root lakefile, srcDir bench): executable
+  unproven prototype of the recursive per-remainder re-lift, in fresh-prime
+  and same-prime variants, the latter with a sub-floor scan-size cap
+  (full / cap1 / cap2). Shared recombination scan (all arms including the
+  today-baseline): smart subset scan + d-1 trailing filter + Mignotte-
+  bounded exact division. Per-node accounting (deg, p, r, floorK, kStop,
+  rungs, outcome), product/product_ok and degree-signature verification on
+  every case. `RELIFT_PROFILE=phases|today|recursive|sameprime` focused
+  profile modes.
+- `reports/bz-recursive-relift-findings.md`: full findings.
+
+Key numbers (run6, /tmp/relift-spike-run6.log):
+- Lift-work model (sum deg^2 k): 4-16x less lift work on split families,
+  9x on high_multiplicity, 0 on irreducibles (floor = core floor).
+- Naive recursion loses 2.5-3.8x wallclock on split deg16-24 to (a)
+  per-node choosePrimeData? (18.9 ms at deg 24 — measured via phases
+  profile) and (b) failed sub-floor scan tails (~108 ms at deg-24 k=1;
+  d-1 filter ineffective on factorial-content trailing coeffs; bounded
+  division only ~20% because the Mignotte abort bound is loose).
+- same-prime + cap2 policy: 1.8-2.1x end-to-end WIN on all split families,
+  1.6x on high_multiplicity; bounded 1.16-1.27x loss on Phi15/SD3/SD4;
+  swell 1.3x loss (cap1 would lose 2x there — cap must be >= 2);
+  (x-1)*SD3 1.09x loss.
+- Recommendation in report: mechanism viable in same-prime/cap2 form;
+  sequence deliverable 2 after #8621 (balanced lift) and re-measure the
+  residual wallclock win before committing to the ~5-file proof remodel.
+
+## Current frontier
+
+Report + prototype ready. Second opinion, then PR from branch issue-8625.
+
+## Next step
+
+/second-opinion on the spike + report; address concerns; open PR; comment
+the measurement summary on #8625; rebase/CI follow-up.
+
+## Blockers
+
+None.

--- a/progress/20260706T023000Z_issue-8625-pr-opened.md
+++ b/progress/20260706T023000Z_issue-8625-pr-opened.md
@@ -1,0 +1,33 @@
+# Issue 8625: PR #8628 opened, CI in progress
+
+## Accomplished
+
+- Second opinion (Codex) on the spike + report: methodology fair, soundness
+  reasoning right, recommendation supported. Four findings, all addressed:
+  production-recombination anchor arm (matches the shared-scan baseline
+  within noise on every family), monic guard in boundedExactQuotientMonic?,
+  shift-family wording (prime selection may differ per shift), explicit
+  same-prime deliverable-2 proof obligations in the report.
+- Final measurement run (run7, production-anchored) folded into
+  reports/bz-recursive-relift-findings.md.
+- PR opened: https://github.com/kim-em/hex-dev/pull/8628 (bench: measure
+  recursive per-remainder re-lift for sub-floor classical certification).
+  Mergeable, no conflicts against origin/main (d45df42f).
+- Measurement summary + recommendation posted on
+  https://github.com/kim-em/hex-dev/issues/8625.
+
+## Current frontier
+
+CI (single `build` job) pending on PR #8628. The change is bench-only
+(new lean_exe not in HEX_EXE_TARGETS, not in the release-sync manifest),
+so CI risk is limited to workspace-wide compile of unchanged targets.
+
+## Next step
+
+Watch CI; fix anything that surfaces; PR is otherwise complete. Deliverable
+2 disposition is recorded in the report/issue comment: same-prime + cap>=2
+form only, re-measure after #8621 lands.
+
+## Blockers
+
+None.

--- a/progress/20260706T033000Z_issue-8630-prime-selection-filed.md
+++ b/progress/20260706T033000Z_issue-8630-prime-selection-filed.md
@@ -1,0 +1,32 @@
+# Prime-selection profiling done; perf issue #8630 filed
+
+## Accomplished
+
+- Added RELIFT_PROFILE=prime mode to the spike (on PR #8628's branch):
+  choosePrimeData? costs 0.8/2.1/5.4/10.4/18.7 ms at split deg
+  8/12/16/20/24 (~cubic), phi15 0.48 ms, SD4 8.4 ms; a single
+  isGoodPrime check at deg 24 costs 424 us (should be ~1 us of word
+  arithmetic). perf: closure dispatch ~12%, allocator ~15%, box/unbox
+  shims, generic nullspace, Int-extgcd inverse fallbacks.
+- Root cause: the whole selection path (DensePoly.gcd in isGoodPrime and
+  the Berlekamp constant sweep, fixedSpaceKernel matrix/nullspace) runs
+  boxed typeclass-generic ZMod64 arithmetic. HexPolyFp/Packed.lean already
+  has the packed-kernel + csimp pattern; its documented modByMonic swap
+  never landed.
+- Filed https://github.com/kim-em/hex-dev/issues/8630 with four
+  deliverables (land the modByMonic csimp swap; packed FpPoly gcd; packed
+  ZMod64 nullspace; word-arithmetic ZMod64 inverse), all output-preserving.
+- Report section "Prime selection breakdown" added; cross-linked on #8625.
+
+## Current frontier
+
+PR #8628 CI pending on the latest push (monitor active).
+
+## Next step
+
+Confirm CI green on #8628. #8630 is ready to claim as the next perf item;
+then #8621; then re-measure the per-remainder recursion.
+
+## Blockers
+
+None.

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -205,6 +205,26 @@ structural facts fall out:
   singleton peels are cheap successes, and the failed tail drops from
   `C(r', r'/2)` to `O(r')` (cap1) or `O(r'^2)` (cap2) per rung.
 
+### Prime selection breakdown (follow-up measurement)
+
+`RELIFT_PROFILE=prime` isolates `choosePrimeData?` (us/call, split shift
+families): deg 8: 818; deg 12: 2113; deg 16: 5372; deg 20: 10414; deg 24:
+18666 (roughly cubic in degree); phi15: 484; SD4: 8417. A SINGLE
+`isGoodPrime` check on a deg-24 input costs 424 us — one `modP` plus one
+generic `DensePoly.gcd` that should be sub-microsecond word arithmetic —
+so the ~9 failing candidate primes account for ~4 ms and the Berlekamp
+factorization (`fixedSpaceKernel` matrix + nullspace + the `c = 0..p-1`
+constant sweep of `DensePoly.gcd f (witness - C c)`) for the remaining
+~15 ms. perf attributes the time to closure dispatch (`lean_apply_1/2`
+~12%), allocator traffic (~15%), box/unbox shims on `ZMod64` values, the
+generic nullspace, and `Int`-extgcd fallbacks for modular inverses: the
+whole path runs boxed, typeclass-generic arithmetic. `HexPolyFp/Packed.lean`
+already provides the fix pattern (packed `Array UInt64` kernels with
+correspondence theorems; its documented `@[csimp]` swap for
+`FpPoly.modByMonic` has not landed yet). Filed as a separate perf issue;
+this is the largest single lever on the classical tier's fast cases and is
+paid once per input by every tier.
+
 ## Win/loss geography
 
 * **Wins (robust, ~2x end to end with same-prime + cap2):** composite cores

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -221,7 +221,7 @@ generic nullspace, and `Int`-extgcd fallbacks for modular inverses: the
 whole path runs boxed, typeclass-generic arithmetic. `HexPolyFp/Packed.lean`
 already provides the fix pattern (packed `Array UInt64` kernels with
 correspondence theorems; its documented `@[csimp]` swap for
-`FpPoly.modByMonic` has not landed yet). Filed as a separate perf issue;
+`FpPoly.modByMonic` has not landed yet). Filed as https://github.com/kim-em/hex-dev/issues/8630;
 this is the largest single lever on the classical tier's fast cases and is
 paid once per input by every tier.
 

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -181,6 +181,37 @@ so the shared-scan normalization neither flatters nor penalizes either
 side on this corpus. Production declined nothing here (its subset budget
 was never exhausted).
 
+### Re-measurement on current main (post #8633 / #8638 / #8641)
+
+The ZMod64 arithmetic speedups that came out of
+https://github.com/kim-em/hex-dev/issues/8630 (dead per-multiply bignum
+allocation removed, `p < 2^31` bounds tightening, `-O3` externs) shifted
+the absolute numbers; the geography is unchanged and the recursion's win
+cases improved slightly (us/call, same arms as above):
+
+| family | production | today | cap1 | cap2 | cap2 vs today |
+|---|---|---|---|---|---|
+| split deg12 | 5189 | 5159 | 2482 | 2580 | **2.00x win** |
+| split deg16 | 16152 | 16167 | 6735 | 7019 | **2.30x win** |
+| split deg20 | 33057 | 33062 | 13439 | 13745 | **2.41x win** |
+| split deg24 | 56502 | 56548 | 23824 | 25790 | **2.19x win** |
+| adv/high_multiplicity | 105 | 102 | 58 | 58 | **1.76x win** |
+| adv/mignotte_swell | 1019 | 760 | 1606 | 983 | 1.29x loss |
+| phi15 | 349 | 344 | 435 | 439 | 1.27x loss |
+| SD3 | 655 | 650 | 887 | 896 | 1.38x loss |
+| SD4 | 6677 | 7279 | 9934 | 9990 | 1.37x loss |
+| (x-1)*SD3 | 1059 | 1048 | 1139 | 1151 | 1.10x loss |
+
+Prime selection after the same changes: deg-24 split 18.7 -> 13.8 ms,
+phi15 484 -> 183 us, SD4 8.4 -> 3.2 ms, single deg-24 `isGoodPrime`
+424 -> 299 us — still boxing/reduction-bound, consistent with
+https://github.com/kim-em/hex-dev/issues/8642 (packed `modByMonic` is the
+remaining lever there). The irreducible-core loss ratios worsened slightly
+(their baseline is exactly the gcd/Berlekamp/mod-p work that got faster,
+while the ladder's repeated scans did not), which strengthens the
+sequencing recommendation: re-measure after #8642 and #8621 before
+committing to deliverable 2.
+
 ## Where the recursion's time actually goes
 
 Per-phase breakdown on the deg-24 split family (fresh-prime, before the

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -153,8 +153,14 @@ lifts run on deg-4 targets; swell is a wash at best, by either metric.
 
 ## Wallclock (end to end, distinct-input families)
 
-us/call; "today" = single production-precision lift + recombination with
-the same scan filters. same-prime cap2 is the recommended policy.
+us/call. "today" is a **shared-scan baseline**, not production runtime: it
+runs today's single lift at production precision but recombines with the
+prototype's scan (same filters as every other arm), so lift-strategy
+differences are isolated from scan-implementation differences.
+"production" anchors that baseline: it is the real
+`classicalCoreFactorsWithBound` (`toMonicLiftData` +
+`scaledRecombinationSmart`, with its own residue filters and subset
+budget) at the same `B`. same-prime cap2 is the recommended policy.
 
 | family | today | fresh-prime | same-prime full | cap1 | cap2 | cap2 vs today |
 |---|---|---|---|---|---|---|
@@ -221,10 +227,18 @@ What the proven same-prime implementation needs, mirroring the issue text:
 * a fresh initial-partition producer keyed to a REMAINDER target at the
   same prime and a new precision (`LiftedFactorSubsetPartition remainder d'
   Finset.univ remainder` with `d'` the remainder's own `LiftData`), fed by
-  re-lifting the remainder's own local factors -- the remainder's mod-p
-  image is the product of a known sub-multiset of the core's Berlekamp
-  factors, so the squarefree/coprimality side conditions transport from the
-  core's;
+  re-lifting the remainder's own local factors. The concrete obligations,
+  not just "transport": (i) for every factor the recombination returns --
+  including the pushed-unsplit remainder -- its mod-p image equals the
+  product of its tracked base factors (for accepted divisors this is the
+  recovery congruence; for the final remainder it follows by dividing the
+  core congruence by the peeled ones, all monic); (ii) the tracked
+  sub-multiset inherits the Berlekamp-form invariants the lift needs
+  (irreducible, pairwise coprime, squarefree product mod p) from the
+  core's `factorsModPBerlekampForm`, which holds for any sublist; (iii)
+  `multifactorLiftQuadratic` applied to the remainder and its sublist at
+  the new precision yields the lifted-factor congruences the partition
+  producer consumes;
 * the ladder loop spec ("split found" or "floor reached with fresh
   coverage witness"), consumed by a per-remainder irreducibility lemma
   analogous to `classicalCoreFactorsWithBound_factor_irreducible_of_validBound`;

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -1,0 +1,255 @@
+# Berlekamp-Zassenhaus: recursive per-remainder re-lift measurement (#8625)
+
+This report records the measurement gating deliverable 2 of
+https://github.com/kim-em/hex-dev/issues/8625 ("spike(bz): investigate
+recursive per-remainder re-lift for sub-floor classical irreducibility
+certification"). It quantifies, on the adversarial and degree/height bench
+families, how much lift work the recursive per-remainder re-lift saves over
+today's single core-floor lift, and what the recursion costs end to end.
+
+## Headline
+
+1. **The sub-floor lift-work win is real and large on composite cores.** In
+   the degree-weighted lift model (`sum deg^2 * k`), the recursion does
+   4-16x less lift work than today's single core-floor lift on the split
+   degree/height families (deg 24: 12672 -> 776), and 9x less on
+   `adv/high_multiplicity`. On irreducible cores the win is zero by
+   definition (the sole remainder is the core, and its own floor is the
+   core floor).
+
+2. **A naive recursion loses that win back, with interest, to two
+   overheads.** (a) Sub-floor ladder rungs pay *failed recombination scans*:
+   at a rung below a factor's recovery precision that factor's subset always
+   fails, and after peeling the recoverable pieces the smart scan burns
+   `C(r', <= r'/2)` failed candidates, each costing big-int division work
+   against the target's huge coefficients. (b) The fresh-prime variant
+   re-pays `choosePrimeData?` (prime walk + Berlekamp) per remainder --
+   18.9 ms on a deg-24 input, a third of today's *entire* runtime. Net:
+   2.5-3.8x end-to-end LOSS on the very split families whose lift work the
+   recursion cuts 10-16x.
+
+3. **Both overheads are removable, and then the win is real end to end.**
+   Reusing the parent's prime and the remainder's own local factors
+   (same-prime variant, no per-node prime walk or Berlekamp) and capping
+   sub-floor rung scans at small subset sizes turns the recursion into a
+   robust ~2x end-to-end WIN on every split family measured (deg 24:
+   62.9 ms -> 30.1 ms) and 1.6x on `adv/high_multiplicity`, at a bounded
+   1.16-1.27x overhead on the irreducible adversarial inputs (Phi15, SD3,
+   SD4). The sub-floor scan cap must be >= 2 for `adv/mignotte_swell` (its
+   sub-floor split is a pair of size-2 subsets; singleton-only sub-floor
+   rungs push its certification back to the floor and lose 2x, vs 1.3x
+   with cap 2).
+
+4. **Recommendation: the mechanism is viable in the same-prime, small-cap
+   form, but deliverable 2 should be sequenced after #8621.** The balanced
+   product-tree lift attacks the same lift cost with an output-preserving
+   change and no certification re-key; landing it first shrinks the lift
+   share of runtime and therefore the residual value of per-remainder
+   precision reduction, which should be re-measured on top of it before
+   committing to the ~5-file proof remodel. Details in "Deliverable-2
+   assessment" below.
+
+## Background
+
+Classical-tier irreducibility flows through coverage
+(`RecoveredSmartSearch.covers_of_bound`), which consumes a complete
+`LiftedFactorSubsetPartition`. Every initial-partition producer is gated at
+the monic-core Mignotte floor
+`2 * defaultFactorCoeffBound (toMonic core).monic < p^k`, and the
+per-remainder recursion inherits that partition at the same `LiftData`
+(`liftedFactorSubsetPartition_transport`), so no remainder can be certified
+below the core floor inside the existing architecture (established in
+https://github.com/kim-em/hex-dev/issues/8620). The one sound sub-floor
+route is a FRESH lift/partition/coverage stack per unsplit remainder at the
+remainder's OWN floor. This spike measures that algorithm.
+
+Two lift-free certificates come along for free and matter a lot on split
+inputs: a degree <= 1 remainder is irreducible outright, and a remainder
+that is irreducible mod a good prime (r = 1, the `SmallModSingleton` chain)
+is irreducible over Z with no lift at all.
+
+## Prototype
+
+`bench/HexBench/RecursiveReliftSpike.lean` (`lake exe
+hex_recursive_relift_spike`), unproven, alongside `ClassicalSpike.lean` and
+reusing the library's `choosePrimeData?`, `henselLiftData`,
+`multifactorLiftQuadratic`, and bound definitions (`defaultFactorCoeffBound`,
+`exhaustiveLiftBound`, `precisionForCoeffBound`). Restricted to monic
+squarefree cores (all corpus cores here are monic; `adv/high_multiplicity`
+enters via its squarefree core, as production does after
+`normalizeForFactor`).
+
+The recursion: per remainder, run an escalation ladder `k = 1, 2, 4, ...`
+clamped at the remainder's own floor
+`precisionForCoeffBound (defaultFactorCoeffBound (toMonic g).monic) p`; at
+each rung lift and run the smart subset recombination; a split recurses on
+the pieces; reaching the floor without a split certifies the remainder
+irreducible (that is the rung whose fresh partition the deliverable-2 proof
+would consume). Variants:
+
+* **fresh-prime**: each remainder gets its own `choosePrimeData?`.
+* **same-prime**: each remainder keeps the parent's prime and its own
+  local factors (known from the split that produced it); a sub-`k` cap
+  parameter restricts which subset sizes the scan tries at rungs below the
+  floor (`cap1` = singletons only, `cap2` = up to pairs, `full` = no cap).
+
+All arms (including the "today" baseline) share the same recombination scan
+with a d-1 trailing-coefficient prefilter and a bounded exact division that
+aborts once a quotient coefficient exceeds the node's Mignotte factor bound.
+Production recombination has an equivalent trailing-coefficient residue
+test; without the bounded division the naive `exactQuotient?` full `divMod`
+inflates the recursion's failed scans by a further ~20-25%.
+
+Honest caveats, all of which overstate the recursion's cost:
+
+* every rung re-lifts from scratch (a real implementation continues the
+  quadratic Hensel ladder incrementally, so the ladder to `kStop` costs
+  about one lift to `kStop`);
+* the today-baseline for most families is fed `B = mignotte(core)` (the
+  input IS its own core), i.e. it already includes the #8620 "rewrite-1"
+  core-local tightening -- the measured wins are on top of that;
+* plain `Int` arithmetic throughout, as in `ClassicalSpike.lean`.
+
+Correctness cross-checks: every run re-multiplies the certified factors and
+compares with the core (`product_ok=true` on all 18 cases x 4 variants), and
+degree signatures match the known factorizations (checksums agree across
+arms on the irreducible families).
+
+## Lift-work accounting
+
+`k_today` is today's single-lift exponent
+`precisionForCoeffBound (exhaustiveLiftBound core (mignotte f)) p`;
+`work` is the `sum deg^2 * k` model. `sumK` sums the recursion's per-node
+ladder stops (0 for the lift-free certificates). fresh-prime and same-prime
+agree except where noted; cap1/cap2 differ from full only on
+`adv/mignotte_swell`.
+
+| input | deg | k_today (work) | rec sumK (work) | outcome shape |
+|---|---|---|---|---|
+| split deg3 h2 | 3 | 5 (45) | 2 (18) | split at k=2; 3 linear pieces free |
+| split deg4 h8 | 4 | 9 (144) | 6 (68) | two-level split |
+| split deg6 h32 | 6 | 17 (612) | 4 (144) | split at k=4; 6 linear pieces free |
+| split deg12 h32 | 12 | 28 (4032) | 6 (688) | two-level split |
+| split deg12 h0 | 12 | 12 (1728) | 3 (216) | split k=1, remainder k=2 |
+| split deg16 h0 | 16 | 16 (4096) | 3 (384) | split k=1, remainder k=2 |
+| split deg20 h0 | 20 | 19 (7600) | 3 (562) | split k=1, remainder k=2 |
+| split deg24 h0 | 24 | 22 (12672) | 3 (776) | split k=1, remainder k=2 |
+| adv/high_multiplicity core | 3 | 9 (81) | 1 (9) | split k=1; x^2+1 is r=1 (free), x-3 free |
+| adv/mignotte_swell | 8 | 13 (832) | 22 (736) | split k=8; quartics floor-certified k=7 each |
+| adv/mignotte_swell (cap1) | 8 | 13 (832) | 27 (1056) | sub-floor split lost; floor 13 + quartic floors |
+| cyclotomic Phi15 | 8 | 4 (256) | 4 (256) | floor-certified, no win possible |
+| SD3 | 8 | 7 (448) | 7 (448) | floor-certified, no win possible |
+| SD4 | 16 | 12 (3072) | 12 (3072) | floor-certified, no win possible |
+| (x-1)*SD3 | 9 | 7 (567) | 8 (529) | x-1 free; SD3 floor ~ core floor |
+| (x-1)*SD4 | 17 | 12 (3468) | 13 (3361) | x-1 free; SD4 floor ~ core floor |
+
+Notes: `k_corelocal` (#8620 rewrite-1) equals `k_today` on every case except
+`adv/high_multiplicity` (9 -> 4), confirming the earlier finding that the
+caller-B over-lift only matters on high-content/high-multiplicity inputs.
+On `adv/mignotte_swell` the recursion's raw `sumK` EXCEEDS today's `k`
+(22 vs 13: exploration to k=8 plus two quartic floors of 7) while the
+degree-weighted work is slightly below (736 vs 832) because the quartic
+lifts run on deg-4 targets; swell is a wash at best, by either metric.
+
+## Wallclock (end to end, distinct-input families)
+
+us/call; "today" = single production-precision lift + recombination with
+the same scan filters. same-prime cap2 is the recommended policy.
+
+| family | today | fresh-prime | same-prime full | cap1 | cap2 | cap2 vs today |
+|---|---|---|---|---|---|---|
+| split deg12 | 6065 | 6655 | 5888 | 3363 | 3432 | **1.77x win** |
+| split deg16 | 18283 | 46618 | 44689 | 8891 | 9094 | **2.01x win** |
+| split deg20 | 36409 | 113195 | 111453 | 16972 | 17252 | **2.11x win** |
+| split deg24 | 62912 | 239067 | 236889 | 29743 | 30071 | **2.09x win** |
+| adv/high_multiplicity | 129 | 97 | 80 | 80 | 80 | **1.62x win** |
+| adv/mignotte_swell | 998 | 1476 | 1307 | 1977 | 1312 | 1.32x loss |
+| phi15 | 686 | 796 | 795 | 792 | 795 | 1.16x loss |
+| SD3 | 1151 | 1460 | 1457 | 1446 | 1458 | 1.27x loss |
+| SD4 | 12507 | 16347 | 16321 | 15398 | 15519 | 1.24x loss |
+| (x-1)*SD3 | 1879 | 2841 | 2039 | 2024 | 2040 | 1.09x loss |
+
+## Where the recursion's time actually goes
+
+Per-phase breakdown on the deg-24 split family (fresh-prime, before the
+bounded division landed): `choosePrimeData?` 18.9 ms, lift to k=1 +0.8 ms,
+k=1 recombination +107.7 ms, against 62 ms for today's ENTIRE run. Two
+structural facts fall out:
+
+* **Prime selection is not a rounding error.** The prime walk (each
+  candidate prime pays a mod-p squarefree check on a high-content input
+  before one is accepted) plus one Berlekamp costs about a third of today's
+  total on deg-24 inputs. Any per-remainder design that re-selects primes
+  per node pays this per node; reusing the parent's prime and handing each
+  piece its own local factors (which the split already identifies) makes
+  the marginal certification cost of a node just its lift + scan.
+* **Sub-floor rungs fail combinatorially, and failures are not free.** The
+  d-1 trailing-coefficient filter is ineffective exactly on high-content
+  targets (a factorial-like constant term is divisible by nearly every
+  small candidate constant), and the Mignotte-bounded division still runs
+  most of each short division before the abort bound can fire (the bound
+  is orders of magnitude above the target's own coefficients). Capping
+  sub-floor rungs at small subset sizes is what actually removes the tail:
+  singleton peels are cheap successes, and the failed tail drops from
+  `C(r', r'/2)` to `O(r')` (cap1) or `O(r'^2)` (cap2) per rung.
+
+## Win/loss geography
+
+* **Wins (robust, ~2x end to end with same-prime + cap2):** composite cores
+  with several factors, i.e. exactly where the sum of per-remainder floors
+  sits far below the core floor. Linear pieces and r=1 pieces certify for
+  free; the win grows with degree and factor count. `adv/high_multiplicity`
+  adds the caller-B over-lift saving on top (1.6x, and 9x in lift work).
+* **Losses (bounded ~1.15-1.25x):** irreducible cores (Phi15, SD3, SD4) --
+  the ladder's sub-floor rungs are pure overhead ending at the same floor
+  lift today performs. The overhead is the sub-floor rungs' cheap failed
+  scans plus the from-scratch re-lifts, which an incremental ladder would
+  mostly remove.
+* **Cap-sensitive:** `adv/mignotte_swell`-type inputs, whose true factors
+  span >= 2 local factors and are only recoverable near the floor. cap1
+  loses 2x; cap2 recovers the sub-floor split and returns to the full-scan
+  level, a 1.3x loss vs today (the exploration rungs plus the two quartic
+  floor lifts slightly outweigh the saved core-floor precision). Larger
+  caps buy nothing further on this corpus.
+* **Wash:** a small factor times a large irreducible ((x-1)*SD3/SD4): the
+  big remainder's own floor is essentially the core floor.
+
+## Deliverable-2 assessment
+
+What the proven same-prime implementation needs, mirroring the issue text:
+
+* a fresh initial-partition producer keyed to a REMAINDER target at the
+  same prime and a new precision (`LiftedFactorSubsetPartition remainder d'
+  Finset.univ remainder` with `d'` the remainder's own `LiftData`), fed by
+  re-lifting the remainder's own local factors -- the remainder's mod-p
+  image is the product of a known sub-multiset of the core's Berlekamp
+  factors, so the squarefree/coprimality side conditions transport from the
+  core's;
+* the ladder loop spec ("split found" or "floor reached with fresh
+  coverage witness"), consumed by a per-remainder irreducibility lemma
+  analogous to `classicalCoreFactorsWithBound_factor_irreducible_of_validBound`;
+* the re-key of `factorClassicalFactorsWithBound_factor_irreducible` and its
+  dispatch in `factorFactors_factor_irreducible`;
+* trace-fixture churn: factor outputs are unchanged (FLINT conformance
+  stays byte-identical; the spike's product and signature checks confirm
+  the recursion computes the same factorizations), but the `trace` fixtures
+  record per-run prime/precision/candidate counts and would be
+  regenerated.
+
+Sequencing recommendation: #8621's balanced product-tree lift is
+output-preserving, needs no certification re-key, and attacks the same lift
+cost that per-remainder precision reduction attacks; with it in place
+today's lift share shrinks and the recursion's residual end-to-end win
+(currently ~2x on split families, of which the lift is roughly half) will
+compress. Land #8621 first, re-run this spike's wallclock arms against the
+balanced-lift baseline, and take up deliverable 2 only if the residual win
+still clears a bar worth the proof remodel. The accounting tables here are
+baseline-independent (they count lift exponents, not implementation), so
+only the wallclock section needs re-measuring.
+
+## Reproduction
+
+`lake build hex_recursive_relift_spike && .lake/build/bin/hex_recursive_relift_spike`
+prints the accounting and wallclock sections; `RELIFT_PROFILE=phases` (or
+`today|recursive|sameprime`) runs the focused deg-24 profile arms used in
+"Where the recursion's time actually goes".

--- a/reports/bz-recursive-relift-findings.md
+++ b/reports/bz-recursive-relift-findings.md
@@ -33,8 +33,8 @@ today's single core-floor lift, and what the recursion costs end to end.
    (same-prime variant, no per-node prime walk or Berlekamp) and capping
    sub-floor rung scans at small subset sizes turns the recursion into a
    robust ~2x end-to-end WIN on every split family measured (deg 24:
-   62.9 ms -> 30.1 ms) and 1.6x on `adv/high_multiplicity`, at a bounded
-   1.16-1.27x overhead on the irreducible adversarial inputs (Phi15, SD3,
+   61.4 ms -> 30.0 ms) and 1.6x on `adv/high_multiplicity`, at a bounded
+   1.17-1.25x overhead on the irreducible adversarial inputs (Phi15, SD3,
    SD4). The sub-floor scan cap must be >= 2 for `adv/mignotte_swell` (its
    sub-floor split is a pair of size-2 subsets; singleton-only sub-floor
    rungs push its certification back to the floor and lose 2x, vs 1.3x
@@ -162,18 +162,24 @@ differences are isolated from scan-implementation differences.
 `scaledRecombinationSmart`, with its own residue filters and subset
 budget) at the same `B`. same-prime cap2 is the recommended policy.
 
-| family | today | fresh-prime | same-prime full | cap1 | cap2 | cap2 vs today |
-|---|---|---|---|---|---|---|
-| split deg12 | 6065 | 6655 | 5888 | 3363 | 3432 | **1.77x win** |
-| split deg16 | 18283 | 46618 | 44689 | 8891 | 9094 | **2.01x win** |
-| split deg20 | 36409 | 113195 | 111453 | 16972 | 17252 | **2.11x win** |
-| split deg24 | 62912 | 239067 | 236889 | 29743 | 30071 | **2.09x win** |
-| adv/high_multiplicity | 129 | 97 | 80 | 80 | 80 | **1.62x win** |
-| adv/mignotte_swell | 998 | 1476 | 1307 | 1977 | 1312 | 1.32x loss |
-| phi15 | 686 | 796 | 795 | 792 | 795 | 1.16x loss |
-| SD3 | 1151 | 1460 | 1457 | 1446 | 1458 | 1.27x loss |
-| SD4 | 12507 | 16347 | 16321 | 15398 | 15519 | 1.24x loss |
-| (x-1)*SD3 | 1879 | 2841 | 2039 | 2024 | 2040 | 1.09x loss |
+| family | production | today | fresh-prime | same-prime full | cap1 | cap2 | cap2 vs today |
+|---|---|---|---|---|---|---|---|
+| split deg12 | 5844 | 5838 | 6468 | 5733 | 3275 | 3362 | **1.74x win** |
+| split deg16 | 17741 | 17718 | 46146 | 44058 | 8636 | 8946 | **1.98x win** |
+| split deg20 | 35661 | 35569 | 111782 | 108933 | 16492 | 16909 | **2.10x win** |
+| split deg24 | 61491 | 61425 | 240357 | 241262 | 29361 | 29955 | **2.05x win** |
+| adv/high_multiplicity | 126 | 124 | 96 | 79 | 79 | 79 | **1.57x win** |
+| adv/mignotte_swell | 969 | 968 | 1453 | 1284 | 1938 | 1279 | 1.32x loss |
+| phi15 | 678 | 673 | 786 | 784 | 784 | 784 | 1.17x loss |
+| SD3 | 1138 | 1145 | 1512 | 1438 | 1429 | 1435 | 1.25x loss |
+| SD4 | 11754 | 12399 | 16302 | 16277 | 15372 | 15476 | 1.25x loss |
+| (x-1)*SD3 | 1871 | 1859 | 2836 | 2030 | 2018 | 2030 | 1.09x loss |
+
+The production column matches the shared-scan baseline within noise on
+every family (identical factor checksums except ordering on (x-1)*SD3),
+so the shared-scan normalization neither flatters nor penalizes either
+side on this corpus. Production declined nothing here (its subset budget
+was never exhausted).
 
 ## Where the recursion's time actually goes
 


### PR DESCRIPTION
This PR adds the gating measurement for https://github.com/kim-em/hex-dev/issues/8625 (deliverable 1): an executable, unproven prototype of the recursive per-remainder re-lift for sub-floor classical irreducibility certification, plus the findings report. `bench/HexBench/RecursiveReliftSpike.lean` (`lake exe hex_recursive_relift_spike`, following the `ClassicalSpike.lean` precedent: bench-only, not in CI's exe target list, not in the release-sync manifest) prototypes the recursion in a fresh-prime variant (per-remainder `choosePrimeData?`) and a same-prime variant (reuse the parent prime and each remainder's own local factors, with a sub-floor scan-size cap), sharing one recombination scan across all arms including the today-baseline (d-1 trailing filter plus a Mignotte-bounded exact division). Every case re-multiplies the certified factors against the core and checks degree signatures.

Findings (`reports/bz-recursive-relift-findings.md`): the sub-floor lift-work win is real and large on composite cores (4-16x less degree-weighted lift work on the split degree/height families, 9x on `adv/high_multiplicity`, zero on irreducible cores); a naive recursion loses it back 2.5-3.8x end-to-end to failed sub-floor recombination scans and per-node prime selection (18.9 ms `choosePrimeData?` at deg 24, measured); the same-prime variant with sub-floor scans capped at size-2 subsets turns that into a robust 1.8-2.1x end-to-end win on all split families and 1.6x on `adv/high_multiplicity`, at a bounded 1.17-1.25x overhead on the irreducible adversarial inputs (Phi15, SD3, SD4) and 1.32x on `adv/mignotte_swell` (whose sub-floor split needs the size-2 cap; singletons-only loses 2x there). A production arm (`classicalCoreFactorsWithBound`) added after a Codex second-opinion review matches the shared-scan baseline within noise on every family, validating the baseline normalization. The report recommends sequencing deliverable 2 (the proven per-remainder partition/coverage stack) after https://github.com/kim-em/hex-dev/issues/8621 (balanced product-tree lift), which attacks the same lift cost without a certification re-key, and re-measuring the residual win on that baseline before committing to the ~5-file proof remodel.

No production code changes: the only non-bench edits are the `lean_exe` registration in `lakefile.lean` and the report/progress files, so FLINT conformance and the merge-gating `*Mathlib` layers are untouched.

🤖 Prepared with Claude Code
