### PR TITLE
perf: read the mulImpl accumulator with Array.getD instead of getElem?

### DIFF
--- a/HexPoly/Operations.lean
+++ b/HexPoly/Operations.lean
@@ -471,7 +471,7 @@ def mulImpl [Add R] [Mul R] (p q : DensePoly R) : DensePoly R :=
           (List.range q.size).foldl
             (fun acc j =>
               let k := i + j
-              acc.set! k ((acc[k]?).getD (Zero.zero : R) + pi * q.coeff j))
+              acc.set! k (acc.getD k (Zero.zero : R) + pi * q.coeff j))
             acc)
         (Array.replicate size (Zero.zero : R))
     ofCoeffs coeffs
@@ -494,7 +494,7 @@ in-bounds index `k` changes only the `k`-th coefficient, leaving every other `ge
 unchanged. Used by `mul_inner_array_coeff_fold` to unfold the inner multiplication fold. -/
 private theorem array_getD_set!_schoolbook [Add R] [Mul R]
     (acc : Array R) (n k : Nat) (term : R) (hk : k < acc.size) :
-    (acc.set! k (acc[k]?.getD (Zero.zero : R) + term)).getD n (Zero.zero : R) =
+    (acc.set! k (acc.getD k (Zero.zero : R) + term)).getD n (Zero.zero : R) =
       if k = n then acc.getD n (Zero.zero : R) + term else acc.getD n (Zero.zero : R) := by
   by_cases hkn : k = n
   · subst n
@@ -512,7 +512,7 @@ private theorem mul_inner_array_coeff_fold [Add R] [Mul R]
     (xs.foldl
         (fun acc j =>
           let k := i + j
-          acc.set! k ((acc[k]?).getD (Zero.zero : R) + p.coeff i * q.coeff j))
+          acc.set! k (acc.getD k (Zero.zero : R) + p.coeff i * q.coeff j))
         acc).getD n (Zero.zero : R) =
       xs.foldl (mulCoeffStep p q n i) (acc.getD n (Zero.zero : R)) := by
   induction xs generalizing acc with
@@ -535,7 +535,7 @@ private theorem mul_inner_array_size [Add R] [Mul R]
     (xs.foldl
         (fun acc j =>
           let k := i + j
-          acc.set! k ((acc[k]?).getD (Zero.zero : R) + p.coeff i * q.coeff j))
+          acc.set! k (acc.getD k (Zero.zero : R) + p.coeff i * q.coeff j))
         acc).size = acc.size := by
   induction xs generalizing acc with
   | nil =>
@@ -554,7 +554,7 @@ private theorem mul_array_coeff_fold [Add R] [Mul R]
           (List.range q.size).foldl
             (fun acc j =>
               let k := i + j
-              acc.set! k ((acc[k]?).getD (Zero.zero : R) + p.coeff i * q.coeff j))
+              acc.set! k (acc.getD k (Zero.zero : R) + p.coeff i * q.coeff j))
             acc)
         acc).getD n (Zero.zero : R) =
       xs.foldl (fun coeff i => (List.range q.size).foldl (mulCoeffStep p q n i) coeff)
@@ -568,7 +568,7 @@ private theorem mul_array_coeff_fold [Add R] [Mul R]
           ((List.range q.size).foldl
               (fun acc j =>
                 let k := i + j
-                acc.set! k ((acc[k]?).getD (Zero.zero : R) + p.coeff i * q.coeff j))
+                acc.set! k (acc.getD k (Zero.zero : R) + p.coeff i * q.coeff j))
               acc).getD n (Zero.zero : R) =
             (List.range q.size).foldl (mulCoeffStep p q n i)
               (acc.getD n (Zero.zero : R)) := by


### PR DESCRIPTION
This PR replaces the inner schoolbook read `acc[k]?.getD Zero.zero` in `DensePoly.mulImpl` with `acc.getD k Zero.zero` (PR 3 of the four-package plan): the same value with a bounds test and a direct read, avoiding the intermediate `Option` cell the source-level form constructs per `(i, j)` step — the hand-written `ArithFloor` bench floor already avoids it. Only the order-matching lemmas in `HexPoly/Operations.lean` restate the shape; the `mul` specification and every characterising lemma are untouched.

Full `lake build` (4142 jobs) green; bench verify checksums pass. Codex review: no blocking findings (noting the compiler may already have specialized away the `Option` in some monomorphic call sites, so this is partly a clarity win at the source level).

🤖 Prepared with Claude Code