### PR TITLE
perf: kernel-cheap specs and Array-native @[csimp] impls for contentNat/primitivePart

### DIFF
--- a/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
+++ b/.claude/skills/hex-lean-mathlib-boundary/SKILL.md
@@ -1477,3 +1477,22 @@ lemma proved by the destructure pattern the namespace already uses
 `RecoveredLift.p_eq`/`precision_eq`/`cutThresholds_eq` — then consume it with
 `:=` or `simp only [hLp]` (simp rewrites the *projection term* fine; only the
 `rw [D.basis_eq]` whole-`L` abstraction fails).
+
+### Kernel-facing recursive specs: structural recursion only
+
+Definitions that cross-check `decide`s must kernel-reduce (design principle
+11). Two traps, verified on v4.32.0-rc1:
+
+- A multi-clause recursion whose clauses decrease *different* arguments (the
+  padded-zip shape) gets an **auto-derived lexicographic measure**
+  (`invImage`/`Prod.instWellFoundedRelation`), which does **not**
+  kernel-reduce — even `decide +kernel` sticks. Restructure so one argument
+  decreases in every clause (fold the asymmetric clause into a `List.map`,
+  as in `DensePoly.zipPad`).
+- Well-founded recursion with an explicit Nat measure
+  (`termination_by xs.length + ys.length`) *does* kernel-reduce, but the
+  definition is `@[irreducible]` by default, so plain `decide` still fails
+  at every use site until you add `unseal foo in` or switch to
+  `decide +kernel` (`@[semireducible]` is warned ineffective for WF
+  definitions). For a spec with many downstream `decide` sites, structural
+  recursion avoids all per-site annotations.

--- a/HexPoly/Euclid/Content.lean
+++ b/HexPoly/Euclid/Content.lean
@@ -27,26 +27,83 @@ namespace Hex
 universe u
 
 namespace DensePoly
-/-- The nonnegative gcd of the coefficients of an integer polynomial. -/
+/-- The nonnegative gcd of the coefficients of an integer polynomial.
+
+Kernel-facing specification: one fold over the spec-level coefficient list.
+Compiled code runs the `Array.foldl` loop `contentNatImpl` via the `@[csimp]`
+proof `contentNat_eq_impl`. -/
 @[expose]
-def contentNat (p : DensePoly Int) : Nat :=
-  p.toArray.toList.foldl (fun acc coeff => Nat.gcd acc coeff.natAbs) 0
+noncomputable def contentNat (p : DensePoly Int) : Nat :=
+  p.toList.foldl (fun acc coeff => Nat.gcd acc coeff.natAbs) 0
+
+/-- Runtime implementation of `contentNat`: a direct `Array.foldl` with no
+intermediate list (value-equal to `contentNat` by `contentNat_eq_impl`,
+registered `@[csimp]`). -/
+@[expose]
+def contentNatImpl (p : DensePoly Int) : Nat :=
+  p.toArray.foldl (fun acc coeff => Nat.gcd acc coeff.natAbs) 0
+
+/-- The spec `contentNat` and the `Array.foldl` runtime loop agree. -/
+theorem contentNat_eq_contentNatImpl (p : DensePoly Int) :
+    contentNat p = contentNatImpl p := by
+  unfold contentNat contentNatImpl
+  rw [← Array.foldl_toList]
+  rfl
+
+/-- Register the `Array.foldl` loop as the compiled implementation of
+`contentNat`. -/
+@[csimp]
+theorem contentNat_eq_impl : @contentNat = @contentNatImpl :=
+  funext contentNat_eq_contentNatImpl
 
 /-- The integer content of a polynomial. This is always nonnegative. -/
 @[expose]
 def content (p : DensePoly Int) : Int :=
   Int.ofNat (contentNat p)
 
-/-- The primitive part obtained by dividing every coefficient by the content. -/
+/-- The primitive part obtained by dividing every coefficient by the content.
+
+Kernel-facing specification: one map over the spec-level coefficient list.
+Compiled code runs the `Array.map` pass `primitivePartImpl` via the `@[csimp]`
+proof `primitivePart_eq_impl`. -/
 @[expose]
-def primitivePart (p : DensePoly Int) : DensePoly Int :=
+noncomputable def primitivePart (p : DensePoly Int) : DensePoly Int :=
   let cNat := contentNat p
   if cNat = 0 then
     0
   else
     let c := Int.ofNat cNat
-    ofCoeffs <|
-      p.toArray.toList.map (fun coeff => coeff / c) |>.toArray
+    ofCoeffs (p.toList.map (fun coeff => coeff / c)).toArray
+
+/-- Runtime implementation of `primitivePart`: one `Array.map` pass over the
+stored coefficients (value-equal to `primitivePart` by
+`primitivePart_eq_impl`, registered `@[csimp]`). -/
+@[expose]
+def primitivePartImpl (p : DensePoly Int) : DensePoly Int :=
+  let cNat := contentNatImpl p
+  if cNat = 0 then
+    0
+  else
+    let c := Int.ofNat cNat
+    ofCoeffs (p.toArray.map (fun coeff => coeff / c))
+
+/-- The spec `primitivePart` and the `Array.map` runtime pass agree. -/
+theorem primitivePart_eq_primitivePartImpl (p : DensePoly Int) :
+    primitivePart p = primitivePartImpl p := by
+  simp only [primitivePart, primitivePartImpl, ← contentNat_eq_contentNatImpl]
+  by_cases h : contentNat p = 0
+  · rw [if_pos h, if_pos h]
+  · rw [if_neg h, if_neg h]
+    congr 1
+    show ((p.toArray.toList).map
+        (fun coeff => coeff / Int.ofNat (contentNat p))).toArray = _
+    rw [← Array.toList_map, Array.toArray_toList]
+
+/-- Register the `Array.map` pass as the compiled implementation of
+`primitivePart`. -/
+@[csimp]
+theorem primitivePart_eq_impl : @primitivePart = @primitivePartImpl :=
+  funext primitivePart_eq_primitivePartImpl
 
 /-- Folding `Nat.gcd` over `xs` starting from `acc` yields a divisor of the seed `acc`, the base step for showing `contentNat` divides each coefficient. -/
 private theorem foldl_gcd_dvd_acc (xs : List Nat) (acc : Nat) :
@@ -79,7 +136,7 @@ private theorem contentNat_dvd_coeff (p : DensePoly Int) (n : Nat) :
     (contentNat p : Int) ∣ p.coeff n := by
   by_cases hn : n < p.size
   · rw [Int.ofNat_dvd_left]
-    unfold contentNat coeff toArray
+    unfold contentNat coeff toList toArray
     have hmem : p.coeffs[n].natAbs ∈ p.coeffs.toList.map Int.natAbs := by
       apply List.mem_map.mpr
       refine ⟨p.coeffs[n], ?_, rfl⟩
@@ -129,9 +186,10 @@ private theorem dvd_contentNat_of_dvd_coeff (p : DensePoly Int) (d : Nat)
     rcases hcoeff with ⟨n, hn, hget⟩
     have hcoeff_eq : p.coeff n = coeff := by
       have hnArray : n < p.coeffs.size := by
-        simpa [toArray] using hn
+        rw [length_toList] at hn
+        exact hn
       have hgetArray : p.coeffs[n] = coeff := by
-        simpa [toArray, Array.getElem_toList] using hget
+        simpa [toList, toArray, Array.getElem_toList] using hget
       change p.coeffs.getD n (0 : Int) = coeff
       rw [← Array.getElem_eq_getD (0 : Int)]
       exact hgetArray
@@ -771,7 +829,7 @@ theorem content_mul_primitivePart (p : DensePoly Int) :
             (primitivePart p).coeff n = p.coeff n / content p := by
           unfold primitivePart content
           rw [if_neg hc, coeff_ofCoeffs_list, list_getD_map_ediv_zero]
-          unfold coeff toArray Array.getD
+          unfold coeff toList toArray Array.getD
           by_cases hn : n < p.coeffs.size
           · simp [hn]
           · simp [hn]
@@ -894,9 +952,9 @@ theorem content_scale_int (c : Int) (p : DensePoly Int) :
   -- Goal: contentNat (scale c p) = c.natAbs * contentNat p.
   unfold contentNat
   have hscale_coeffs :
-      (scale c p).toArray.toList =
+      (scale c p).toList =
         trimTrailingZerosList (p.toArray.toList.map (fun x => c * x)) := by
-    unfold scale ofCoeffs toArray trimTrailingZeros
+    unfold scale ofCoeffs toList toArray trimTrailingZeros
     simp
   rw [hscale_coeffs, foldl_gcd_natAbs_trim_eq, List.foldl_map]
   have h := foldl_gcd_natAbs_mul_const_int c p.toArray.toList 0
@@ -922,7 +980,7 @@ constant. -/
 @[simp, grind =]
 theorem content_C (c : Int) :
     content (C c) = Int.ofNat c.natAbs := by
-  unfold content contentNat toArray
+  unfold content contentNat toList toArray
   by_cases hc : c = 0
   · simp [hc]
   · rw [coeffs_C_of_ne_zero hc]

--- a/progress/20260706T053000Z_densepoly-spec-impl-splits.md
+++ b/progress/20260706T053000Z_densepoly-spec-impl-splits.md
@@ -1,0 +1,42 @@
+# DensePoly executable-layer spec/impl splits (4-PR plan)
+
+Session type: feature (approved plan in ~/.claude/plans, follow-up to
+issue #8606 / #8618), stacked branches densepoly-arith-split -> horner-split
+-> mulimpl-boxing -> content-split.
+
+## Accomplished
+
+- PR 1 (#8626, merged): add/sub via zipPad toList specs + Array.ofFn impls;
+  neg via Array.map impl; derivative via derivList spec + ofFn impl;
+  size_derivative_le; six external derivative body-unfolds migrated.
+  Key incident: zipPad's first four-clause form compiled via well-founded
+  recursion (kernel-opaque, broke every downstream decide, e.g. HexConway
+  certificates); restructured to structural recursion on the first list.
+- PR 2 (#8627, CI running): eval/compose noncomputable cons-walk specs
+  (evalCoeffList public, new orientation-preserving composeCoeffList) with
+  downward Array.foldr impls; composeModMonic same split
+  (composeModMonicList); Quotient.eval layer noncomputable on toList.
+- PR 3 (mulimpl-boxing, local): acc[k]?.getD -> acc.getD k in mulImpl.
+- PR 4 (content-split, local): contentNat/primitivePart toList specs +
+  Array.foldl/map impls.
+
+All four validated: full 4142-job builds, HexConformance
+(HexGFq.CrossCheck 32 s -> 28 s after PR 1, stable after PR 2), bench
+verify checksums (only python-flint runner failures locally), IR checks
+(spec symbols absent, impls referenced), Codex reviews (no blocking
+findings on any package).
+
+## Current frontier
+
+Waiting on #8627 CI; then push mulimpl-boxing and content-split as PRs in
+sequence and merge each when green.
+
+## Next step
+
+Merge train for PRs 2-4; then #8618 can close (PRs 1+2 cover it).
+Possible later follow-up from the issue's note: domain-aware trim skip for
+field-coefficient products.
+
+## Blockers
+
+None.

--- a/progress/20260706T053000Z_densepoly-spec-impl-splits.md
+++ b/progress/20260706T053000Z_densepoly-spec-impl-splits.md
@@ -10,8 +10,16 @@ issue #8606 / #8618), stacked branches densepoly-arith-split -> horner-split
   neg via Array.map impl; derivative via derivList spec + ofFn impl;
   size_derivative_le; six external derivative body-unfolds migrated.
   Key incident: zipPad's first four-clause form compiled via well-founded
-  recursion (kernel-opaque, broke every downstream decide, e.g. HexConway
-  certificates); restructured to structural recursion on the first list.
+  recursion with an AUTO-DERIVED lexicographic measure
+  (invImage/Prod.instWellFoundedRelation), which does not kernel-reduce
+  (decide +kernel fails) and broke every downstream decide (HexConway
+  certificates). Corrected analysis after review: WF recursion is NOT
+  kernel-opaque in general -- with an explicit Nat measure the kernel
+  reduces it, and plain decide fails only because WF definitions are
+  @[irreducible] by default (unseal or decide +kernel unblocks;
+  @[semireducible] is warned ineffective for WF). Structural recursion
+  remains the right shape for kernel-facing specs: no per-site unseal at
+  the ~50 cross-check decides, ordinary defeq, cheaper reduction.
 - PR 2 (#8627, CI running): eval/compose noncomputable cons-walk specs
   (evalCoeffList public, new orientation-preserving composeCoeffList) with
   downward Array.foldr impls; composeModMonic same split


### PR DESCRIPTION
This PR completes the four-package plan (PR 4): `DensePoly.contentNat` becomes a `noncomputable` fold over the spec-level `toList` with a direct `Array.foldl` runtime impl, and `primitivePart` maps over `toList` with a one-pass `Array.map` impl, both behind proved `@[csimp]` equalities (near-`rfl` via the `Array.foldl_toList` / `Array.toList_map` bridges). The `Content.lean` body-shape proofs align on the `toList` view; the `content` wrapper, the `HexPolyZ` wrappers, and every characterising statement are unchanged.

The PR also carries the session progress note, including the corrected well-founded-recursion analysis from the review of https://github.com/kim-em/hex-dev/pull/8626, and a new `hex-lean-mathlib-boundary` skill section recording the two kernel-reduction traps for recursive kernel-facing specs (auto-derived lex measures do not kernel-reduce; explicit-Nat-measure WF definitions do, but are `@[irreducible]` by default).

Full `lake build` (4142 jobs) plus `HexConformance` green; `hexpolyz` bench checksums (the content/primitivePart consumers) pass 10/10. Codex review: no blocking findings, with the impl routing verified in the generated C.

🤖 Prepared with Claude Code