### PR TITLE
perf(modarith): drop dead word-modulus branch from ZMod64 mul/pow externs

### DIFF
--- a/HexModArith/ffi/zmod64_mul.c
+++ b/HexModArith/ffi/zmod64_mul.c
@@ -17,48 +17,33 @@ extern void __gmpz_clear(mpz_t);
 extern void* __gmpz_export(void*, size_t*, int, size_t, int, size_t, const mpz_t);
 extern void lean_extract_mpz_value(lean_object*, mpz_t);
 
+/* `ZMod64.Bounds p` guarantees `0 < p < 2^64` (`Bounds.pLtR`), so the modulus
+   always fits in a `uint64_t` and the former `p = 2^64` "word modulus" case is
+   impossible. Reading the modulus with `lean_uint64_of_nat` therefore needs no
+   width check and, in particular, avoids the per-call bignum allocation
+   (`lean_uint64_to_nat(UINT64_MAX)`) the old width check paid on every call. */
+
 LEAN_EXPORT uint64_t lean_hex_zmod64_mul(b_lean_obj_arg p, uint64_t a, uint64_t b) {
-    lean_object* max_word_nat = lean_uint64_to_nat(UINT64_MAX);
+    uint64_t modulus = lean_uint64_of_nat(p);
     __uint128_t product = (__uint128_t)a * (__uint128_t)b;
-    uint64_t result;
-
-    if (lean_nat_lt(max_word_nat, p)) {
-        /* The only bounded modulus above UINT64_MAX is 2^64 itself. */
-        result = (uint64_t)product;
-    } else {
-        uint64_t modulus = lean_uint64_of_nat(p);
-        result = (uint64_t)(product % modulus);
-    }
-
-    lean_dec(max_word_nat);
-    return result;
-}
-
-static bool lean_hex_modulus_is_word(lean_object* p) {
-    lean_object* max_word_nat = lean_uint64_to_nat(UINT64_MAX);
-    bool is_word = lean_nat_lt(max_word_nat, p);
-    lean_dec(max_word_nat);
-    return is_word;
-}
-
-static uint64_t lean_hex_mul_mod_word(uint64_t a, uint64_t b, uint64_t modulus, bool word_modulus) {
-    __uint128_t product = (__uint128_t)a * (__uint128_t)b;
-    if (word_modulus) {
-        return (uint64_t)product;
-    }
     return (uint64_t)(product % modulus);
 }
 
-static uint64_t lean_hex_pow_mod_u64(uint64_t base, uint64_t exponent, uint64_t modulus, bool word_modulus) {
-    uint64_t acc = word_modulus ? 1 : 1 % modulus;
+static uint64_t lean_hex_mul_mod_word(uint64_t a, uint64_t b, uint64_t modulus) {
+    __uint128_t product = (__uint128_t)a * (__uint128_t)b;
+    return (uint64_t)(product % modulus);
+}
+
+static uint64_t lean_hex_pow_mod_u64(uint64_t base, uint64_t exponent, uint64_t modulus) {
+    uint64_t acc = 1 % modulus;
 
     while (exponent != 0) {
         if ((exponent & 1) != 0) {
-            acc = lean_hex_mul_mod_word(acc, base, modulus, word_modulus);
+            acc = lean_hex_mul_mod_word(acc, base, modulus);
         }
         exponent >>= 1;
         if (exponent != 0) {
-            base = lean_hex_mul_mod_word(base, base, modulus, word_modulus);
+            base = lean_hex_mul_mod_word(base, base, modulus);
         }
     }
 
@@ -86,10 +71,10 @@ static uint64_t* lean_hex_nat_to_u64_limbs(b_lean_obj_arg exponent, size_t* limb
 }
 
 static uint64_t lean_hex_pow_mod_big_nat(uint64_t base, b_lean_obj_arg exponent,
-        uint64_t modulus, bool word_modulus) {
+        uint64_t modulus) {
     size_t limb_count = 0;
     uint64_t* limbs = lean_hex_nat_to_u64_limbs(exponent, &limb_count);
-    uint64_t acc = word_modulus ? 1 : 1 % modulus;
+    uint64_t acc = 1 % modulus;
 
     if (limb_count != 0) {
         size_t top_bits = lean_hex_bit_length_u64(limbs[limb_count - 1]);
@@ -97,9 +82,9 @@ static uint64_t lean_hex_pow_mod_big_nat(uint64_t base, b_lean_obj_arg exponent,
             uint64_t limb = limbs[limb_index - 1];
             size_t bit_limit = (limb_index == limb_count) ? top_bits : 64;
             for (size_t bit = bit_limit; bit > 0; --bit) {
-                acc = lean_hex_mul_mod_word(acc, acc, modulus, word_modulus);
+                acc = lean_hex_mul_mod_word(acc, acc, modulus);
                 if (((limb >> (bit - 1)) & 1) != 0) {
-                    acc = lean_hex_mul_mod_word(acc, base, modulus, word_modulus);
+                    acc = lean_hex_mul_mod_word(acc, base, modulus);
                 }
             }
         }
@@ -110,18 +95,17 @@ static uint64_t lean_hex_pow_mod_big_nat(uint64_t base, b_lean_obj_arg exponent,
 }
 
 LEAN_EXPORT uint64_t lean_hex_zmod64_pow(b_lean_obj_arg p, uint64_t a, b_lean_obj_arg n) {
-    bool word_modulus = lean_hex_modulus_is_word(p);
-    uint64_t modulus = word_modulus ? 0 : lean_uint64_of_nat(p);
+    uint64_t modulus = lean_uint64_of_nat(p);
 
-    if (!word_modulus && modulus == 1) {
+    if (modulus == 1) {
         return 0;
     }
 
-    uint64_t base = word_modulus ? a : a % modulus;
+    uint64_t base = a % modulus;
 
     if (lean_is_scalar(n)) {
-        return lean_hex_pow_mod_u64(base, (uint64_t)lean_unbox(n), modulus, word_modulus);
+        return lean_hex_pow_mod_u64(base, (uint64_t)lean_unbox(n), modulus);
     }
 
-    return lean_hex_pow_mod_big_nat(base, n, modulus, word_modulus);
+    return lean_hex_pow_mod_big_nat(base, n, modulus);
 }

--- a/progress/20260706T060000Z_issue-8630.md
+++ b/progress/20260706T060000Z_issue-8630.md
@@ -1,0 +1,32 @@
+# Issue #8630: prime selection is boxing-bound — the real win
+
+## Outcome
+The packed-kernel premise did not hold. Benchmarking (`hexberlekamp_bench`,
+A/B on the compiled binary) showed:
+- packed `FpPoly` gcd: 1.6-2.7x **regression** (per-Euclidean-step re-pack
+  across the boxed boundary + a `Nat`/`ofNat` round-trip in `mulWord`);
+- packed `modByMonic`: performance-neutral.
+
+The actual runtime cost was a **per-multiply bignum allocation** in the core
+modular-arithmetic extern `lean_hex_zmod64_mul` (`HexModArith/ffi/zmod64_mul.c`):
+it allocated `lean_uint64_to_nat(UINT64_MAX)` on every call to test whether the
+modulus was `2^64` (the "word modulus"). Since #8612 tightened `ZMod64.Bounds`
+to `p < 2^64` strictly (`Bounds.pLtR`), that case is impossible — the branch is
+dead code left behind in the C after the Lean side was cleaned. Removing it
+(reading the modulus with `lean_uint64_of_nat`, no width check) and the same
+dead machinery in `lean_hex_zmod64_pow` gives, with no Lean/proof changes and
+byte-identical outputs:
+- gcd path (`runBerlekampFactorChecksum`): 1.6-2.3x, growing with degree
+  (deg 256: 12.8ms -> 5.6ms);
+- Frobenius path (`runRabinTestChecksum`): ~1.9x (deg 24: 8.3ms -> 4.5ms).
+
+This speeds up **all** `ZMod64` modular multiplication in the codebase, matching
+the profile's "allocator traffic ~15%".
+
+## Follow-up
+- Barrett reduction for `p < 2^32` (division-free modmul). The repo already has
+  `HexArith/Barrett` + `HexModArith/HotLoop.lean` `BarrettCtx`/`Montgomery`
+  gated on `p < 2^32`, unused by `ZMod64.mul`. `p < 2^31` further makes add/sub
+  overflow-trivial and enables lazy reduction in convolution kernels.
+- The packed-kernel exploration (D1/D2) is abandoned; D3 (nullspace) / D4 (word
+  inverse) reassessed in light of the extern-alloc root cause.


### PR DESCRIPTION
This PR removes a per-multiply heap allocation from the core `ZMod64` modular-arithmetic externs, speeding up all `ZMod64` modular multiplication in the codebase.

`lean_hex_zmod64_mul` allocated a bignum (`lean_uint64_to_nat(UINT64_MAX)`) on every call, purely to test whether the modulus was `2^64` (the "word modulus" case, where `% 2^64` cannot be computed in 64 bits). Since https://github.com/kim-em/hex-dev/pull/8612 tightened `ZMod64.Bounds` to `p < 2^64` strictly (`Bounds.pLtR`), that case is impossible — the branch is dead code the Lean-side cleanup left behind in the C extern. This reads the modulus directly with `lean_uint64_of_nat` (no width check, no allocation) and drops the same dead word-modulus machinery from `lean_hex_zmod64_pow`.

Semantics are unchanged for every `Bounds p`, so outputs are byte-identical (the extern's Lean reference `ZMod64.mul` / `ZMod64.pow` and all proofs are untouched). On `hexberlekamp_bench` (compiled binary, measured A/B):

| path | before | after | speedup |
|---|---|---|---|
| gcd (`runBerlekampFactorChecksum`) deg 64 | 1.02 ms | 511 µs | 2.0× |
| gcd deg 256 | 12.8 ms | 5.6 ms | 2.3× |
| Frobenius (`runRabinTestChecksum`) deg 24 | 8.32 ms | 4.53 ms | 1.8× |

This is the runtime win behind https://github.com/kim-em/hex-dev/issues/8630. The issue's proposed packed `Array UInt64` kernels turned out not to be the fix: benchmarking showed the packed gcd was a 1.6-2.7× regression (it re-crossed the boxed boundary every Euclidean step) and packed `modByMonic` was neutral. The actual cost was this allocation in the shared modular multiply, which the packed kernels also paid. See the PR discussion for the full A/B evidence.

Follow-up: Barrett reduction for `p < 2^32` (division-free modmul; the repo already has `HexArith/Barrett` + `HexModArith/HotLoop.lean` gated on `p < 2^32`, currently unused by `ZMod64.mul`).

🤖 Prepared with Claude Code
