### PR TITLE
perf(modarith): tighten ZMod64.Bounds to p < 2^31, speed up add/sub/mul

### DIFF
--- a/HexBerlekampZassenhaus/ChoosePrimeData.lean
+++ b/HexBerlekampZassenhaus/ChoosePrimeData.lean
@@ -314,15 +314,15 @@ private theorem choosePrimeDataScore_fold_isGoodPrime
 
 /--
 Build a `SmallPrimeCandidate` from an arbitrary natural number `p` if
-`p` passes the executable trial-division primality test and fits in one
-machine word. Used by the post-prefix prime walk to produce candidates beyond
+`p` passes the executable trial-division primality test and satisfies the
+small-modulus bound `p < 2^31`. Used by the post-prefix prime walk to produce candidates beyond
 the fixed `smallPrimeCandidates` list with explicit primality and
 `ZMod64.Bounds` evidence.
 -/
 private def mkExtendedSmallPrimeCandidate? (p : Nat) :
     Option SmallPrimeCandidate :=
   if hprime : Hex.Nat.isPrimeTrial p = true then
-    if hbound : p < UInt64.word then
+    if hbound : p < 2 ^ 31 then
       let prime := Hex.Nat.isPrimeTrial_isPrime hprime
       let bounds : ZMod64.Bounds p := { pPos := prime.pos, pLtR := hbound }
       some { p, bounds, prime }

--- a/HexBerlekampZassenhaus/PrimeSelection.lean
+++ b/HexBerlekampZassenhaus/PrimeSelection.lean
@@ -501,9 +501,10 @@ structure SmallPrimeCandidate where
   [bounds : ZMod64.Bounds p]
   prime : Nat.Prime p
 
-/-- Build a `SmallPrimeCandidate` from a trial-division primality witness and a word-size bound on `p`. -/
+/-- Build a `SmallPrimeCandidate` from a trial-division primality witness and the
+small-modulus bound `p < 2^31` on `p`. -/
 private def smallPrimeCandidateOfTrial (p : Nat)
-    (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p < UInt64.word) :
+    (hprime : Hex.Nat.isPrimeTrial p = true) (hbound : p < 2 ^ 31) :
     SmallPrimeCandidate :=
   let prime := Hex.Nat.isPrimeTrial_isPrime hprime
   { p, bounds := { pPos := prime.pos, pLtR := hbound }, prime }

--- a/HexBerlekampZassenhausMathlib/CertReify.lean
+++ b/HexBerlekampZassenhausMathlib/CertReify.lean
@@ -49,7 +49,7 @@ check. The reifier emits `boundsOfDecide p (Eq.refl true)` in every reified
 instance slot, so the kernel discharges both bounds by reduction.
 -/
 theorem boundsOfDecide (p : Nat)
-    (h : (decide (0 < p) && decide (p < UInt64.word)) = true) :
+    (h : (decide (0 < p) && decide (p < 2 ^ 31)) = true) :
     Hex.ZMod64.Bounds p := by
   rw [Bool.and_eq_true] at h
   exact ⟨of_decide_eq_true h.1, of_decide_eq_true h.2⟩

--- a/HexModArith/Basic.lean
+++ b/HexModArith/Basic.lean
@@ -25,14 +25,24 @@ namespace Hex
 
 namespace ZMod64
 
-/-- `ZMod64 p` is only valid when `p` is positive and strictly below the
-machine-word size `2^64`, so every residue and the modulus itself fit in a
-`UInt64`. -/
+/-- `ZMod64 p` is only valid when `p` is positive and strictly below `2^31`.
+This small-modulus invariant keeps every residue and the modulus in a `UInt64`,
+makes the sum of two residues fit in a word without carry, and keeps the product
+of two residues below `2^62`, so the modular multiply reduces a single word (no
+`__uint128_t`) and future convolution kernels can accumulate several products
+before one reduction (Barrett/lazy). Every current and anticipated application
+(Berlekamp-Zassenhaus, LLL, matrix work) uses small primes, so no needed
+generality is lost. -/
 class Bounds (p : Nat) : Prop where
   /-- The modulus is positive. -/
   pPos : 0 < p
-  /-- The modulus is strictly below the machine-word size `2^64`. -/
-  pLtR : p < UInt64.word
+  /-- The modulus is strictly below `2^31`. -/
+  pLtR : p < 2 ^ 31
+
+/-- The modulus is strictly below the machine-word size `2^64`, so it and every
+residue fit in a `UInt64`. Derived from the `p < 2^31` bound. -/
+theorem Bounds.pLtWord (p : Nat) [Bounds p] : p < UInt64.word :=
+  Nat.lt_trans (Bounds.pLtR (p := p)) (by decide)
 
 end ZMod64
 
@@ -111,14 +121,14 @@ the backing `UInt64`.
 def ofNat (p n : Nat) [Bounds p] : ZMod64 p := by
   let reduced := normalize p n
   have hred : reduced < p := normalize_lt p n
-  have hword : reduced < UInt64.word := Nat.lt_trans hred (Bounds.pLtR (p := p))
+  have hword : reduced < UInt64.word := Nat.lt_trans hred (Bounds.pLtWord p)
   refine ⟨UInt64.ofNatLT reduced hword, ?_⟩
   simpa [reduced, UInt64.toNat_ofNatLT] using hred
 
 /-- The Nat representative of `ofNat p n` is `n` reduced modulo `p`. -/
 @[simp, grind =] theorem toNat_ofNat (n : Nat) : (ofNat p n).toNat = n % p := by
   have hred : n % p < p := Nat.mod_lt _ (Bounds.pPos (p := p))
-  have hword : n % p < UInt64.word := Nat.lt_trans hred (Bounds.pLtR (p := p))
+  have hword : n % p < UInt64.word := Nat.lt_trans hred (Bounds.pLtWord p)
   simp [ofNat, normalize, UInt64.toNat_ofNatLT]
 
 /-- The stored word of `ofNat p n`, viewed as a Nat, is `n` reduced modulo `p`. -/
@@ -250,202 +260,96 @@ def complementWord (p : Nat) [Bounds p] (_hp : p < UInt64.word) : UInt64 :=
   UInt64.ofNatLT (UInt64.word - p) <| by
     exact Nat.sub_lt (by decide : 0 < 2 ^ 64) (Bounds.pPos (p := p))
 
-/-- Carry branch of `add`: when the unreduced sum `a.toNat + b.toNat`
-reaches the word size `2^64` (`hcarry`), the wrapped machine sum plus
-the complement word `2^64 - p` has representative `a.toNat + b.toNat - p`.
-Requires `p < 2^64` (`hpLt`) for the complement word to exist. -/
-private theorem add_carry_toNat (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : UInt64.word ≤ a.toNat + b.toNat) :
-    ((a.val + b.val) + complementWord p hpLt).toNat = a.toNat + b.toNat - p := by
-  have ha : a.toNat < p := a.isLt
-  have hb : b.toNat < p := b.isLt
-  have hpLe : p ≤ UInt64.word := Nat.le_of_lt (Bounds.pLtR (p := p))
-  have hsum_lt : a.toNat + b.toNat - UInt64.word < UInt64.word := by omega
-  have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat - UInt64.word := by
-    rw [UInt64.toNat_add]
-    simpa [toNat_eq_val, UInt64.word] using
-      (by rw [Nat.mod_eq_sub_mod hcarry, Nat.mod_eq_of_lt hsum_lt] :
-        (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat - UInt64.word)
-  have hcorr_lt : (a.toNat + b.toNat - UInt64.word) + (UInt64.word - p) < UInt64.word := by
-    omega
-  rw [UInt64.toNat_add, hsum_toNat]
-  simp [complementWord, UInt64.toNat_ofNatLT]
-  rw [Nat.mod_eq_of_lt (by simpa [toNat_eq_val, UInt64.word] using hcorr_lt)]
-  have hfinal :
-      (a.toNat + b.toNat - UInt64.word) + (UInt64.word - p) =
-        a.toNat + b.toNat - p := by
-    omega
-  simpa [toNat_eq_val, UInt64.word] using hfinal
-
-/-- Carry branch of `add`: the corrected representative `a.toNat + b.toNat - p`
-stays in canonical range `< p`, so the result is a valid `ZMod64 p`. -/
-private theorem add_carry_lt (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : UInt64.word ≤ a.toNat + b.toNat) :
-    ((a.val + b.val) + complementWord p hpLt).toNat < p := by
-  rw [add_carry_toNat a b hcarry]
-  have ha : a.toNat < p := a.isLt
-  have hb : b.toNat < p := b.isLt
-  omega
-
-/-- No-carry-with-reduce branch of `add`: the unreduced sum fits in a
-word (`hcarry`) but is at least the modulus (`hreduce`), so subtracting
-the modulus word `p` gives the representative `a.toNat + b.toNat - p`.
-Requires `p < 2^64` (`hpLt`) for the modulus word to exist. -/
-private theorem add_noCarry_reduce_toNat (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : ¬ UInt64.word ≤ a.toNat + b.toNat)
-    (hreduce : modulusWord p hpLt ≤ a.val + b.val) :
-    ((a.val + b.val) - modulusWord p hpLt).toNat = a.toNat + b.toNat - p := by
-  have hsum_lt : a.toNat + b.toNat < UInt64.word := by omega
-  have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat := by
-    rw [UInt64.toNat_add]
-    simpa [toNat_eq_val, UInt64.word] using
-      (by rw [Nat.mod_eq_of_lt hsum_lt] :
-        (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat)
-  have hreduceNat : p ≤ a.toNat + b.toNat := by
-    have := UInt64.le_iff_toNat_le.mp hreduce
-    simpa [hsum_toNat, modulusWord, UInt64.toNat_ofNatLT] using this
-  have hge : UInt64.word ≤ UInt64.word - p + (a.toNat + b.toNat) := by omega
-  have hlt : UInt64.word - p + (a.toNat + b.toNat) - UInt64.word < UInt64.word := by
-    omega
-  rw [UInt64.toNat_sub, hsum_toNat]
+/-- The modulus word, viewed as a `Nat`, is exactly `p`. -/
+private theorem modulusWord_toNat : (modulusWord p (Bounds.pLtWord p)).toNat = p := by
   simp [modulusWord, UInt64.toNat_ofNatLT]
-  rw [Nat.mod_eq_sub_mod (by simpa [toNat_eq_val, UInt64.word] using hge),
-    Nat.mod_eq_of_lt (by simpa [toNat_eq_val, UInt64.word] using hlt)]
-  have hfinal :
-      UInt64.word - p + (a.toNat + b.toNat) - UInt64.word =
-        a.toNat + b.toNat - p := by
-    omega
-  simpa [toNat_eq_val, UInt64.word] using hfinal
 
-/-- No-carry-with-reduce branch of `add`: the reduced representative
-`a.toNat + b.toNat - p` stays in canonical range `< p`. -/
-private theorem add_noCarry_reduce_lt (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : ¬ UInt64.word ≤ a.toNat + b.toNat)
-    (hreduce : modulusWord p hpLt ≤ a.val + b.val) :
-    ((a.val + b.val) - modulusWord p hpLt).toNat < p := by
-  rw [add_noCarry_reduce_toNat a b hcarry hreduce]
+/-- The unreduced sum of two residues is faithful in a machine word: since
+`a, b < p < 2^31`, we have `a.toNat + b.toNat < 2^32 ≤ 2^64`, so machine-word
+addition never wraps. This is why `add` needs no carry branch. -/
+private theorem toNat_val_add (a b : ZMod64 p) :
+    (a.val + b.val).toNat = a.toNat + b.toNat := by
   have ha : a.toNat < p := a.isLt
   have hb : b.toNat < p := b.isLt
-  omega
-
-/-- No-carry, no-reduce branch of `add`: the unreduced sum fits in a word
-(`hcarry`) and is already below the modulus (`_hreduce`), so its `toNat`
-is exactly `a.toNat + b.toNat` with no correction applied. -/
-private theorem add_noCarry_noReduce_toNat (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : ¬ UInt64.word ≤ a.toNat + b.toNat)
-    (_hreduce : ¬ modulusWord p hpLt ≤ a.val + b.val) :
-    (a.val + b.val).toNat = a.toNat + b.toNat := by
+  have hp : p < 2 ^ 31 := Bounds.pLtR (p := p)
+  have hbound : (2 : Nat) ^ 31 + 2 ^ 31 ≤ UInt64.word := by decide
   have hsum_lt : a.toNat + b.toNat < UInt64.word := by omega
   rw [UInt64.toNat_add]
   simpa [toNat_eq_val, UInt64.word] using
     (by rw [Nat.mod_eq_of_lt hsum_lt] :
       (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat)
 
-/-- No-carry, no-reduce branch of `add`: the uncorrected sum is already
-in canonical range `< p`. -/
-private theorem add_noCarry_noReduce_lt (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hcarry : ¬ UInt64.word ≤ a.toNat + b.toNat)
-    (hreduce : ¬ modulusWord p hpLt ≤ a.val + b.val) :
-    (a.val + b.val).toNat < p := by
-  have hsum_toNat := add_noCarry_noReduce_toNat a b hcarry hreduce
-  have hreduceNat : ¬ p ≤ a.toNat + b.toNat := by
-    intro hpSum
-    apply hreduce
-    apply UInt64.le_iff_toNat_le.mpr
-    simpa [hsum_toNat, modulusWord, UInt64.toNat_ofNatLT] using hpSum
-  omega
-
-/-- No-borrow branch of `sub`: when `b.val ≤ a.val` (`hba`) the
-machine-word difference does not wrap, so its `toNat` is exactly
-`a.toNat - b.toNat`. -/
-private theorem sub_noBorrow_toNat (a b : ZMod64 p)
-    (hba : b.val ≤ a.val) :
-    (a.val - b.val).toNat = a.toNat - b.toNat := by
-  have hbaNat : b.toNat ≤ a.toNat := by
-    simpa [toNat_eq_val] using UInt64.le_iff_toNat_le.mp hba
-  have hge : UInt64.word ≤ UInt64.word - b.toNat + a.toNat := by omega
-  have hlt : UInt64.word - b.toNat + a.toNat - UInt64.word < UInt64.word := by
-    have haWord : a.toNat < UInt64.word := by
-      simpa [toNat_eq_val, UInt64.word, UInt64.size] using UInt64.toNat_lt_size a.val
-    omega
-  rw [UInt64.toNat_sub]
-  rw [Nat.mod_eq_sub_mod (by simpa [toNat_eq_val, UInt64.word] using hge),
-    Nat.mod_eq_of_lt (by simpa [toNat_eq_val, UInt64.word] using hlt)]
-  have hbWord : b.toNat ≤ UInt64.word := by
-    have hbSize : b.toNat < UInt64.word := by
-      simpa [toNat_eq_val, UInt64.word, UInt64.size] using UInt64.toNat_lt_size b.val
-    exact Nat.le_of_lt hbSize
-  have hsum :
-      UInt64.word - b.toNat + a.toNat = UInt64.word + (a.toNat - b.toNat) := by
-    rw [← Nat.sub_add_comm hbWord, Nat.add_sub_assoc hbaNat]
-  have hfinal : UInt64.word - b.toNat + a.toNat - UInt64.word = a.toNat - b.toNat := by
-    rw [hsum, Nat.add_sub_cancel_left]
-  simpa [toNat_eq_val, UInt64.word] using hfinal
-
-/-- No-borrow branch of `sub`: the difference `a.toNat - b.toNat` is
-bounded by `a.toNat < p`, so it stays in canonical range `< p`. -/
-private theorem sub_noBorrow_lt (a b : ZMod64 p)
-    (hba : b.val ≤ a.val) :
-    (a.val - b.val).toNat < p := by
-  rw [sub_noBorrow_toNat a b hba]
+/-- The corrected word `a + (p - b)` used by `sub`'s borrow branch is faithful
+and equals `a.toNat + (p - b.toNat)`: the inner `p - b` stays below `p` and the
+outer sum below `2^32`, so neither subtraction nor addition wraps. -/
+private theorem toNat_val_sub (a b : ZMod64 p) :
+    (a.val + (modulusWord p (Bounds.pLtWord p) - b.val)).toNat
+      = a.toNat + (p - b.toNat) := by
+  have hmp := modulusWord_toNat (p := p)
+  have hb : b.toNat < p := b.isLt
+  have hble : b.val ≤ modulusWord p (Bounds.pLtWord p) :=
+    UInt64.le_iff_toNat_le.mpr (by rw [hmp]; exact Nat.le_of_lt b.isLt)
+  have hc : (modulusWord p (Bounds.pLtWord p) - b.val).toNat = p - b.toNat := by
+    rw [UInt64.toNat_sub_of_le _ b.val hble, hmp]; rfl
   have ha : a.toNat < p := a.isLt
+  have hp : p < 2 ^ 31 := Bounds.pLtR (p := p)
+  have hbound : (2 : Nat) ^ 31 + 2 ^ 31 ≤ UInt64.word := by decide
+  have hsum_lt : a.toNat + (p - b.toNat) < UInt64.word := by omega
+  rw [UInt64.toNat_add, hc]
+  simpa [toNat_eq_val, UInt64.word] using
+    (by rw [Nat.mod_eq_of_lt hsum_lt] :
+      (a.toNat + (p - b.toNat)) % UInt64.word = a.toNat + (p - b.toNat))
+
+/-- Reduce branch of `reduceOnce`: subtracting the modulus word from a faithful
+representative below `2 * p` lands back in canonical range `< p`. -/
+theorem reduceOnce_reduce_lt (s : UInt64) (hs : s.toNat < 2 * p)
+    (h : modulusWord p (Bounds.pLtWord p) ≤ s) :
+    (s - modulusWord p (Bounds.pLtWord p)).toNat < p := by
+  have hmp := modulusWord_toNat (p := p)
+  rw [UInt64.toNat_sub_of_le s _ h]
   omega
 
-/-- Borrow branch of `sub`: when `b.val > a.val` (`hba`) the machine-word
-difference wraps; subtracting the complement word `2^64 - p` and wrapping
-again recovers the representative `p - b.toNat + a.toNat`. Requires
-`p < 2^64` (`hpLt`) for the complement word to exist. -/
-private theorem sub_borrow_toNat (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hba : ¬ b.val ≤ a.val) :
-    ((a.val - b.val) - complementWord p hpLt).toNat = p - b.toNat + a.toNat := by
-  have hbaNat : ¬ b.toNat ≤ a.toNat := by
-    intro h
-    apply hba
-    apply UInt64.le_iff_toNat_le.mpr
-    simpa [toNat_eq_val] using h
-  have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
-  have hdiff_lt : UInt64.word - b.toNat + a.toNat < UInt64.word := by
-    have : a.toNat < b.toNat := by omega
-    omega
-  have hdiff_toNat : (a.val - b.val).toNat = UInt64.word - b.toNat + a.toNat := by
-    rw [UInt64.toNat_sub]
-    simpa [toNat_eq_val, UInt64.word] using
-      (by rw [Nat.mod_eq_of_lt hdiff_lt] :
-        (UInt64.word - b.toNat + a.toNat) % UInt64.word =
-          UInt64.word - b.toNat + a.toNat)
-  have hge :
-      UInt64.word ≤ UInt64.word - (UInt64.word - p) + (UInt64.word - b.toNat + a.toNat) := by
-    omega
-  have hlt :
-      UInt64.word - (UInt64.word - p) + (UInt64.word - b.toNat + a.toNat) -
-          UInt64.word < UInt64.word := by
-    have ha : a.toNat < p := a.isLt
-    omega
-  rw [UInt64.toNat_sub, hdiff_toNat]
-  simp [complementWord, UInt64.toNat_ofNatLT]
-  rw [Nat.mod_eq_sub_mod (by simpa [toNat_eq_val, UInt64.word] using hge),
-    Nat.mod_eq_of_lt (by simpa [toNat_eq_val, UInt64.word] using hlt)]
-  have hfinal :
-      UInt64.word - (UInt64.word - p) + (UInt64.word - b.toNat + a.toNat) -
-          UInt64.word =
-        p - b.toNat + a.toNat := by
-    omega
-  simpa [toNat_eq_val, UInt64.word] using hfinal
-
-/-- Borrow branch of `sub`: the corrected representative
-`p - b.toNat + a.toNat` stays in canonical range `< p`, since the borrow
-hypothesis forces `a.toNat < b.toNat`. -/
-private theorem sub_borrow_lt (a b : ZMod64 p) {hpLt : p < UInt64.word}
-    (hba : ¬ b.val ≤ a.val) :
-    ((a.val - b.val) - complementWord p hpLt).toNat < p := by
-  rw [sub_borrow_toNat a b hba]
-  have ha : a.toNat < p := a.isLt
-  have hbaNat : ¬ b.toNat ≤ a.toNat := by
-    intro h
-    apply hba
-    apply UInt64.le_iff_toNat_le.mpr
-    simpa [toNat_eq_val] using h
+/-- No-reduce branch of `reduceOnce`: a faithful representative already below the
+modulus word is already canonical. -/
+theorem reduceOnce_noReduce_lt (s : UInt64) (_hs : s.toNat < 2 * p)
+    (h : ¬ modulusWord p (Bounds.pLtWord p) ≤ s) :
+    s.toNat < p := by
+  have hmp := modulusWord_toNat (p := p)
+  have hnle : ¬ (modulusWord p (Bounds.pLtWord p)).toNat ≤ s.toNat :=
+    fun hh => h (UInt64.le_iff_toNat_le.mpr hh)
   omega
+
+/--
+Canonicalise a machine word whose value is a faithful representative in
+`[0, 2*p)` by one conditional subtraction of the modulus word.
+
+Under the `p < 2^31` bound `add` produces such a representative with no
+machine-word wraparound, so this single reduce branch replaces the former
+three-way carry analysis and keeps the runtime division-free.
+-/
+@[expose]
+def reduceOnce (s : UInt64) (hs : s.toNat < 2 * p) : ZMod64 p :=
+  if h : modulusWord p (Bounds.pLtWord p) ≤ s then
+    ⟨s - modulusWord p (Bounds.pLtWord p), reduceOnce_reduce_lt s hs h⟩
+  else
+    ⟨s, reduceOnce_noReduce_lt s hs h⟩
+
+/-- The reduction step returns the modular reduction of the faithful
+representative `s`. -/
+private theorem toNat_reduceOnce (s : UInt64) (hs : s.toNat < 2 * p) :
+    (reduceOnce s hs).toNat = s.toNat % p := by
+  have hmp := modulusWord_toNat (p := p)
+  unfold reduceOnce
+  split
+  · rename_i h
+    show (s - modulusWord p (Bounds.pLtWord p)).toNat = s.toNat % p
+    have hle : p ≤ s.toNat := by
+      have := UInt64.le_iff_toNat_le.mp h; omega
+    rw [UInt64.toNat_sub_of_le s _ h, hmp, Nat.mod_eq_sub_mod hle,
+      Nat.mod_eq_of_lt (by omega)]
+  · rename_i h
+    show s.toNat = s.toNat % p
+    exact (Nat.mod_eq_of_lt (reduceOnce_noReduce_lt s hs h)).symm
 
 /--
 Add two reduced residues: the residue of the sum of canonical representatives.
@@ -460,21 +364,18 @@ noncomputable def add (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + b.toNat)
 
 /--
-Runtime implementation of `add`: wrapped machine-word addition plus one
-correction step when `p < 2^64`, avoiding any division. Value-equal to `add`
-(`add_eq_impl`, registered `@[csimp]`).
+Runtime implementation of `add`: one faithful machine-word addition followed by
+a single conditional subtraction of the modulus (`reduceOnce`), with no carry
+branch and no division. Value-equal to `add` (`add_eq_impl`, registered
+`@[csimp]`). Under `p < 2^31` the sum `a.val + b.val` never overflows the word.
 -/
 @[expose]
-def addImpl (a b : ZMod64 p) : ZMod64 p := by
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
-  let p64 := modulusWord p hpLt
-  let c64 := complementWord p hpLt
-  let sum := a.val + b.val
-  by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
-  · exact ⟨sum + c64, by simpa [sum, c64] using add_carry_lt a b hcarry⟩
-  · by_cases hreduce : p64 ≤ sum
-    · exact ⟨sum - p64, by simpa [sum, p64] using add_noCarry_reduce_lt a b hcarry hreduce⟩
-    · exact ⟨sum, by simpa [sum] using add_noCarry_noReduce_lt a b hcarry hreduce⟩
+def addImpl (a b : ZMod64 p) : ZMod64 p :=
+  reduceOnce (a.val + b.val) (by
+    have h := toNat_val_add a b
+    have ha : a.toNat < p := a.isLt
+    have hb : b.toNat < p := b.isLt
+    omega)
 
 /--
 Subtract two residues: the residue of `a.toNat + (p - b.toNat)`, the canonical
@@ -487,19 +388,36 @@ runs the branchy machine-word `subImpl` via the `@[csimp]` proof `sub_eq_impl`.
 noncomputable def sub (a b : ZMod64 p) : ZMod64 p :=
   ofNat p (a.toNat + (p - b.toNat))
 
+/-- No-borrow branch of `sub`: when `b ≤ a` the machine-word difference is
+already the canonical representative `< p`. -/
+theorem sub_noBorrow_lt (a b : ZMod64 p) (h : b.val ≤ a.val) :
+    (a.val - b.val).toNat < p := by
+  rw [UInt64.toNat_sub_of_le a.val b.val h]
+  have ha : a.val.toNat < p := a.isLt
+  omega
+
+/-- Borrow branch of `sub`: when `a < b` the faithful word `a + (p - b)` has
+representative `p - (b - a)`, which stays in canonical range `< p`. -/
+theorem sub_borrow_lt (a b : ZMod64 p) (h : ¬ b.val ≤ a.val) :
+    (a.val + (modulusWord p (Bounds.pLtWord p) - b.val)).toNat < p := by
+  rw [toNat_val_sub]
+  have hab : a.toNat < b.toNat :=
+    Nat.lt_of_not_le (fun hh => h (UInt64.le_iff_toNat_le.mpr hh))
+  have hbp : b.toNat < p := b.toNat_lt
+  omega
+
 /--
-Runtime implementation of `sub`: machine-word subtraction with one
-complement-word correction on borrow, avoiding any division. Value-equal to
-`sub` (`sub_eq_impl`, registered `@[csimp]`).
+Runtime implementation of `sub`: a single sign test picks the fast common path
+`a - b` (already canonical when `b ≤ a`) or the corrected `a + (p - b)`, with no
+division and no wraparound reasoning. Value-equal to `sub` (`sub_eq_impl`,
+registered `@[csimp]`). Under `p < 2^31` neither branch overflows the word.
 -/
 @[expose]
-def subImpl (a b : ZMod64 p) : ZMod64 p := by
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
-  let c64 := complementWord p hpLt
-  let diff := a.val - b.val
-  by_cases hba : b.val ≤ a.val
-  · exact ⟨diff, by simpa [diff] using sub_noBorrow_lt a b hba⟩
-  · exact ⟨diff - c64, by simpa [diff, c64] using sub_borrow_lt a b hba⟩
+def subImpl (a b : ZMod64 p) : ZMod64 p :=
+  if h : b.val ≤ a.val then
+    ⟨a.val - b.val, sub_noBorrow_lt a b h⟩
+  else
+    ⟨a.val + (modulusWord p (Bounds.pLtWord p) - b.val), sub_borrow_lt a b h⟩
 
 /--
 Multiply two reduced residues and reduce the product mod `p`.
@@ -549,51 +467,11 @@ def inv (a : ZMod64 p) : ZMod64 p :=
   toNat_ofNat (a.toNat + b.toNat)
 
 /-- The runtime `addImpl` also computes the residue of the representative sum;
-the branch analysis is delegated to the carry/reduce case lemmas. -/
+the reduction is delegated to `reduceOnce` on the faithful word sum. -/
 private theorem toNat_addImpl (a b : ZMod64 p) :
     (addImpl a b).toNat = (a.toNat + b.toNat) % p := by
   unfold addImpl
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
-  by_cases hcarry : UInt64.word ≤ a.toNat + b.toNat
-  · rw [dif_pos hcarry]
-    change ((a.val + b.val) + complementWord p hpLt).toNat = (a.toNat + b.toNat) % p
-    rw [add_carry_toNat a b hcarry]
-    have ha : a.toNat < p := a.isLt
-    have hb : b.toNat < p := b.isLt
-    have hpSum : p ≤ a.toNat + b.toNat := by omega
-    have hlt : a.toNat + b.toNat - p < p := by omega
-    rw [Nat.mod_eq_sub_mod hpSum, Nat.mod_eq_of_lt hlt]
-  · rw [dif_neg hcarry]
-    let p64 := modulusWord p hpLt
-    let sum := a.val + b.val
-    by_cases hreduce : p64 ≤ sum
-    · rw [dif_pos hreduce]
-      change ((a.val + b.val) - modulusWord p hpLt).toNat = (a.toNat + b.toNat) % p
-      rw [add_noCarry_reduce_toNat a b hcarry hreduce]
-      have ha : a.toNat < p := a.isLt
-      have hb : b.toNat < p := b.isLt
-      have hsum_lt : a.toNat + b.toNat < UInt64.word := by omega
-      have hsum_toNat : (a.val + b.val).toNat = a.toNat + b.toNat := by
-        rw [UInt64.toNat_add]
-        simpa [toNat_eq_val, UInt64.word] using
-          (by rw [Nat.mod_eq_of_lt hsum_lt] :
-            (a.toNat + b.toNat) % UInt64.word = a.toNat + b.toNat)
-      have hreduceNat : p ≤ a.toNat + b.toNat := by
-        have := UInt64.le_iff_toNat_le.mp hreduce
-        simpa [p64, sum, hsum_toNat, modulusWord, UInt64.toNat_ofNatLT] using this
-      have hlt : a.toNat + b.toNat - p < p := by omega
-      rw [Nat.mod_eq_sub_mod hreduceNat, Nat.mod_eq_of_lt hlt]
-    · rw [dif_neg hreduce]
-      change (a.val + b.val).toNat = (a.toNat + b.toNat) % p
-      rw [add_noCarry_noReduce_toNat a b hcarry hreduce]
-      have hnot : ¬ p ≤ a.toNat + b.toNat := by
-        intro hpSum
-        apply hreduce
-        apply UInt64.le_iff_toNat_le.mpr
-        have hsum_toNat := add_noCarry_noReduce_toNat (p := p) a b hcarry hreduce
-        change (modulusWord p hpLt).toNat ≤ (a.val + b.val).toNat
-        simpa [modulusWord, UInt64.toNat_ofNatLT, hsum_toNat] using hpSum
-      rw [Nat.mod_eq_of_lt (by omega)]
+  rw [toNat_reduceOnce, toNat_val_add]
 
 /-- The kernel-facing `add` and the runtime `addImpl` compute the same residue.
 Registered `@[csimp]`, so compiled code runs the division-free machine-word
@@ -609,39 +487,26 @@ implementation while kernel reduction sees the one-line specification. -/
   toNat_ofNat (a.toNat + (p - b.toNat))
 
 /-- The runtime `subImpl` also computes the canonical modular difference;
-the branch analysis is delegated to the borrow case lemmas. -/
+the reduction is delegated to `reduceOnce` on the faithful word `a + (p - b)`. -/
 private theorem toNat_subImpl (a b : ZMod64 p) :
     (subImpl a b).toNat = (a.toNat + (p - b.toNat)) % p := by
   unfold subImpl
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
-  let c64 := complementWord p hpLt
-  let diff := a.val - b.val
-  by_cases hba : b.val ≤ a.val
-  · rw [dif_pos hba]
-    change (a.val - b.val).toNat = (a.toNat + (p - b.toNat)) % p
-    rw [sub_noBorrow_toNat a b hba]
-    have hbaNat : b.toNat ≤ a.toNat := by
-      simpa [toNat_eq_val] using UInt64.le_iff_toNat_le.mp hba
-    have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
-    have ha : a.toNat < p := a.isLt
-    have hge : p ≤ a.toNat + (p - b.toNat) := by omega
-    have hlt : a.toNat + (p - b.toNat) - p < p := by omega
-    rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt hlt]
-    omega
-  · rw [dif_neg hba]
-    change ((a.val - b.val) - complementWord p hpLt).toNat =
+  split
+  · rename_i h
+    show (a.val - b.val).toNat = (a.toNat + (p - b.toNat)) % p
+    rw [UInt64.toNat_sub_of_le a.val b.val h, ← toNat_eq_val, ← toNat_eq_val]
+    have hba : b.toNat ≤ a.toNat := UInt64.le_iff_toNat_le.mp h
+    have ha : a.toNat < p := a.toNat_lt
+    rw [show a.toNat + (p - b.toNat) = (a.toNat - b.toNat) + p by omega,
+      Nat.add_mod_right, Nat.mod_eq_of_lt (by omega)]
+  · rename_i h
+    show (a.val + (modulusWord p (Bounds.pLtWord p) - b.val)).toNat =
       (a.toNat + (p - b.toNat)) % p
-    rw [sub_borrow_toNat a b hba]
-    have hbaNat : ¬ b.toNat ≤ a.toNat := by
-      intro h
-      apply hba
-      apply UInt64.le_iff_toNat_le.mpr
-      simpa [toNat_eq_val] using h
-    have hbLe : b.toNat ≤ p := Nat.le_of_lt b.isLt
-    have ha : a.toNat < p := a.isLt
-    have hlt : a.toNat + (p - b.toNat) < p := by omega
-    rw [Nat.mod_eq_of_lt hlt]
-    omega
+    rw [toNat_val_sub]
+    have hab : a.toNat < b.toNat :=
+      Nat.lt_of_not_le (fun hh => h (UInt64.le_iff_toNat_le.mpr hh))
+    have hbp : b.toNat < p := b.toNat_lt
+    rw [Nat.mod_eq_of_lt (by omega)]
 
 /-- The kernel-facing `sub` and the runtime `subImpl` compute the same residue.
 Registered `@[csimp]`, so compiled code runs the division-free machine-word

--- a/HexModArith/Ring.lean
+++ b/HexModArith/Ring.lean
@@ -83,7 +83,7 @@ private theorem neg_nonzero_lt (a : ZMod64 p) {hpLt : p < UInt64.word}
 /-- The additive inverse represented by the complementary residue mod `p`. -/
 @[expose]
 def neg (a : ZMod64 p) : ZMod64 p := by
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  have hpLt : p < UInt64.word := Bounds.pLtWord p
   let c64 := complementWord p hpLt
   by_cases hzero : a.val = 0
   · refine ⟨0, ?_⟩
@@ -166,7 +166,7 @@ theorem natCast_op_eq_ofNat (n : Nat) :
 /-- Negation takes the complementary representative modulo `p`. -/
 @[simp, grind =] theorem toNat_neg (a : ZMod64 p) : (neg a).toNat = (p - a.toNat) % p := by
   unfold neg
-  have hpLt : p < UInt64.word := Bounds.pLtR (p := p)
+  have hpLt : p < UInt64.word := Bounds.pLtWord p
   by_cases hzero : a.val = 0
   · rw [dif_pos hzero]
     change (0 : UInt64).toNat = (p - a.toNat) % p

--- a/HexModArith/SPEC/hex-mod-arith.md
+++ b/HexModArith/SPEC/hex-mod-arith.md
@@ -10,10 +10,13 @@ types.
 
 ```lean
 /-- Project-local bounds class: `ZMod64 p` is a faithful model of
-`Z/pZ` only when `p` is positive and fits in a single machine word. -/
+`Z/pZ` only when `p` is positive and strictly below `2^31`. -/
 class ZMod64.Bounds (p : Nat) : Prop where
   pPos : 0 < p
-  pLtR : p < UInt64.word        -- = 2^64
+  pLtR : p < 2 ^ 31
+
+/-- Derived machine-word bound `p < UInt64.word` (= `2^64`). -/
+theorem ZMod64.Bounds.pLtWord (p : Nat) [Bounds p] : p < UInt64.word
 
 structure ZMod64 (p : Nat) [Bounds p] where
   val  : UInt64
@@ -23,11 +26,16 @@ structure ZMod64 (p : Nat) [Bounds p] where
 The bounds live in a typeclass that callers provide once per
 modulus, e.g. `instance : ZMod64.Bounds 7 := ⟨by decide, by decide⟩`.
 Every operation takes `[Bounds p]` implicitly; nothing is threaded
-through call sites. `p ≥ 2^64` is rejected at the type boundary
-because no `Bounds p` instance exists for it — a `UInt64` cannot hold
-the modulus itself, let alone residues above it, and excluding the
-word modulus `2^64` keeps `add`/`sub`/`neg` free of a per-call
-special case.
+through call sites. The `p < 2^31` bound is owner-blessed: every
+current and anticipated application (Berlekamp-Zassenhaus, LLL,
+matrix work) uses small primes. It is tight enough that `p`, every
+residue, and the *sum* of two residues all fit in a `UInt64` with no
+carry, and the *product* of two residues stays below `2^62` (one
+word, no `__uint128_t`). This keeps `add`/`sub`/`neg` free of any
+carry/borrow correction (`add` is a single conditional subtract of
+the modulus word, `sub` a single sign test) and the modular multiply
+a single-word product plus one `%`. Code that still needs the raw
+machine-word bound goes through the derived `Bounds.pLtWord`.
 
 Mathlib's `Fact` is unavailable to `hex-mod-arith` (it is a
 computational library, not a Mathlib bridge). The project-local
@@ -87,17 +95,18 @@ The runtime implementation is supplied by `lean_hex_zmod64_mul` in
 `HexModArith/ffi/zmod64_mul.c`. Acceptable runtime strategies for
 the C body, in order of simplicity:
 
-1. **Direct 128/64 modular reduction**, e.g. `__uint128_t` on
-   compilers that support it (the portable C reference shape).
-   Note: not every target has a single-instruction 128/64 divide —
-   x86_64 does (`divq`); AArch64 does not. Compilers may lower
-   `__uint128_t %` to a runtime helper. Acceptable as the Phase-1
-   default; later phases may swap to a faster strategy without
-   changing the extern symbol.
+1. **Single-word 64/64 modular reduction** (the current body). Under
+   the `p < 2^31` bound both residues are below `2^31`, so their
+   product is below `2^62` and fits in one `uint64_t`; the extern is
+   `uint64_t product = a * b; return product % modulus;` — a plain
+   64/64 divide with no `__uint128_t`. (Before the bound was
+   tightened this had to widen to `__uint128_t` for a 128/64 reduce.)
 
 2. **Barrett reduction** — precompute `pinv = ⌊2^64 / p⌋` once per
    modulus (lifted from `BarrettCtx` in `hex-arith`) when
-   `p < 2^32`. ~10 cycles per multiply.
+   `p < 2^32`. ~10 cycles per multiply. This needs a reused per-
+   modulus context, so it belongs in convolution kernels (poly/matrix
+   products), not the contextless `ZMod64.mul`.
 
 3. **Montgomery reduction** — precompute `p'` and `R^2 mod p` once
    per modulus (lifted from `MontCtx` in `hex-arith`) when

--- a/HexModArith/ffi/zmod64_mul.c
+++ b/HexModArith/ffi/zmod64_mul.c
@@ -17,16 +17,17 @@ extern void __gmpz_clear(mpz_t);
 extern void* __gmpz_export(void*, size_t*, int, size_t, int, size_t, const mpz_t);
 extern void lean_extract_mpz_value(lean_object*, mpz_t);
 
-/* `ZMod64.Bounds p` guarantees `0 < p < 2^64` (`Bounds.pLtR`), so the modulus
-   always fits in a `uint64_t` and the former `p = 2^64` "word modulus" case is
-   impossible. Reading the modulus with `lean_uint64_of_nat` therefore needs no
-   width check and, in particular, avoids the per-call bignum allocation
-   (`lean_uint64_to_nat(UINT64_MAX)`) the old width check paid on every call. */
+/* `ZMod64.Bounds p` guarantees `0 < p < 2^31` (`Bounds.pLtR`), so the modulus
+   fits in a `uint64_t` and reading it needs no width check. Because both inputs
+   are reduced residues `< p < 2^31`, their product is `< 2^62` and fits in a
+   single `uint64_t`: no `__uint128_t` is needed, and the reduction is a plain
+   64/64 division rather than a 128/64 one. The result is byte-identical to the
+   pure Lean fallback `ofNat p (a * b)`. */
 
 LEAN_EXPORT uint64_t lean_hex_zmod64_mul(b_lean_obj_arg p, uint64_t a, uint64_t b) {
     uint64_t modulus = lean_uint64_of_nat(p);
-    __uint128_t product = (__uint128_t)a * (__uint128_t)b;
-    return (uint64_t)(product % modulus);
+    uint64_t product = a * b;
+    return product % modulus;
 }
 
 static uint64_t lean_hex_mul_mod_word(uint64_t a, uint64_t b, uint64_t modulus) {

--- a/HexPolyFp/Packed.lean
+++ b/HexPolyFp/Packed.lean
@@ -20,13 +20,13 @@ operation. The packed kernel below mirrors the reference array long-division
 loop (`HexPoly/Euclid.lean`) over a bare `Array UInt64`, eliminating the boxing
 on the monic-division / Frobenius hot path.
 
-The arithmetic stays overflow-safe: `ZMod64.Bounds p` only gives `p < 2^64`, so
-`p` may exceed `2^32` and naive `UInt64` `(a*b) % p` would wrap mod `2^64`. The
-word helpers `ZMod64.mulWord` / `ZMod64.subWord` reconstruct residues and reuse
-`ZMod64.mul` / `ZMod64.sub` (the former extern-backed by a `__uint128_t`
-widening multiply, the latter compiled to the multi-branch division-free
-`subImpl` via `@[csimp]`), so the packed kernel equals the reference for
-*every* `Bounds p`.
+The arithmetic reuses the reference residue ops rather than doing raw-word
+arithmetic directly. The word helpers `ZMod64.mulWord` / `ZMod64.subWord`
+reconstruct residues and delegate to `ZMod64.mul` / `ZMod64.sub` (the former
+extern-backed by a single-word `a * b % p`, safe because `Bounds p` gives
+`p < 2^31` so the product stays below `2^62`; the latter compiled to the
+division-free sign-test `subImpl` via `@[csimp]`), so the packed kernel equals
+the reference for *every* `Bounds p`.
 
 `modByMonicPacked_eq` is the value-correspondence theorem; a later `@[csimp]`
 swap of `FpPoly.modByMonic` for `modByMonicPacked` is therefore

--- a/conformance/HexModArith/Conformance.lean
+++ b/conformance/HexModArith/Conformance.lean
@@ -38,14 +38,15 @@ Covered edge cases:
 - power-of-two modulus `16`
 - small Barrett-friendly moduli `2`, `7`, and `65535`
 - odd Montgomery-friendly moduli `3`, `7`, and `65537`
-- large word-sized modulus `2^63 + 29`
+- large small-modulus prime `2^31 - 1` (the Mersenne prime `M31`, the largest
+  admissible modulus under the `p < 2^31` bound)
 - zero operands, wraparound operands, and negative integer representatives
 -/
 
 namespace Hex
 namespace ZMod64
 
-private abbrev LargeMod : Nat := 2 ^ 63 + 29
+private abbrev LargeMod : Nat := 2 ^ 31 - 1
 private abbrev BarrettWideMod : Nat := 65535
 private abbrev MontWideMod : Nat := 65537
 
@@ -127,8 +128,8 @@ private def barrettWideA : ZMod64 BarrettWideMod := ofNat BarrettWideMod 65534
 private def barrettWideB : ZMod64 BarrettWideMod := ofNat BarrettWideMod 32769
 private def montWideA : ZMod64 MontWideMod := ofNat MontWideMod 65536
 private def montWideB : ZMod64 MontWideMod := ofNat MontWideMod 32771
-private def wideA : ZMod64 LargeMod := ofNat LargeMod (2 ^ 63 + 1)
-private def wideB : ZMod64 LargeMod := ofNat LargeMod (2 ^ 63 - 17)
+private def wideA : ZMod64 LargeMod := ofNat LargeMod (2 ^ 31 - 2)
+private def wideB : ZMod64 LargeMod := ofNat LargeMod (2 ^ 31 - 17)
 
 private def barrettCtx2 : Hex.BarrettCtx 2 :=
   Hex.BarrettCtx.ofModulus (p := 2) (by decide) (by decide)

--- a/conformance/HexModArith/FastCheck.lean
+++ b/conformance/HexModArith/FastCheck.lean
@@ -22,20 +22,14 @@ namespace Hex
 namespace ZMod64
 
 instance : Bounds (2 ^ 31 - 1) := ⟨by decide, by decide⟩
-instance : Bounds (2 ^ 63 + 29) := ⟨by decide, by decide⟩
 instance : Bounds 7 := ⟨by decide, by decide⟩
 
 private def mersenneA : ZMod64 (2 ^ 31 - 1) := ofNat _ (2 ^ 31 - 2)
 private def mersenneB : ZMod64 (2 ^ 31 - 1) := ofNat _ (2 ^ 31 - 3)
-private def wideA : ZMod64 (2 ^ 63 + 29) := ofNat _ (2 ^ 63 + 1)
-private def wideB : ZMod64 (2 ^ 63 + 29) := ofNat _ (2 ^ 63 - 17)
 private def smallA : ZMod64 7 := ofNat _ 3
 
 /-- info: 2 -/
 #guard_msgs in #eval (mul mersenneA mersenneB).toNat
-
-/-- info: 1288 -/
-#guard_msgs in #eval (mul wideA wideB).toNat
 
 /-- info: 5 -/
 #guard_msgs in #eval (pow smallA 5).toNat
@@ -47,7 +41,6 @@ private def smallA : ZMod64 7 := ofNat _ 3
 #guard_msgs in #eval (mul (inv smallA) smallA).toNat
 
 #guard (mul mersenneA mersenneB).toNat = 2
-#guard (mul wideA wideB).toNat = 1288
 #guard (pow smallA 5).toNat = 5
 #guard (inv smallA).toNat = 5
 #guard (mul (inv smallA) smallA).toNat = 1

--- a/progress/20260706T073608Z_issue-8637.md
+++ b/progress/20260706T073608Z_issue-8637.md
@@ -1,0 +1,60 @@
+# Issue #8637: tighten ZMod64.Bounds to p < 2^31, speed up add/sub/mul
+
+## Accomplished
+
+Landed the foundational half of #8637 (the follow-up to #8630):
+
+- **Bounds tightened** from `p < 2^64` (`UInt64.word`) to `p < 2^31`
+  (`Bounds.pLtR`), with a derived `Bounds.pLtWord : p < UInt64.word` for the
+  handful of proofs that still need the raw machine-word bound. Owner-blessed;
+  every application uses small primes.
+- **`add`** now reduces through a single `reduceOnce` conditional-subtract of the
+  modulus word (the three-way carry analysis is gone). **~2.5x faster.**
+- **`sub`** now uses a single sign test (`a - b` fast path, else `a + (p - b)`),
+  dropping the `complementWord` double-wrap reasoning. **~1.07x faster.**
+- **`mul`** C extern (`lean_hex_zmod64_mul`) drops `__uint128_t` for a single-word
+  `a * b % p` (product < 2^62). **~1.63x faster.**
+- The whole family of wraparound case lemmas is removed (net -160 lines in
+  `Basic.lean`); `addImpl`/`subImpl` stay `@[csimp]`-equal to the reference
+  `add`/`sub`, so compiled output is byte-identical.
+- Downstream `Bounds` constructors (BZ `smallPrimeCandidateOfTrial`,
+  `mkExtendedSmallPrimeCandidate?`, `CertReify.boundsOfDecide`) and the
+  conformance fixtures moved to `p < 2^31`; the large-modulus conformance case
+  retargeted `2^63 + 29` -> Mersenne prime `2^31 - 1`.
+- SPEC (`HexModArith/SPEC/hex-mod-arith.md`) and `HexPolyFp/Packed.lean` docs
+  updated to the new bound and multiply strategy.
+
+Verification: full `lake build` (4142 jobs, CI-gated Mathlib layer incl. the
+certificate round-trip tests), `HexConformance` (388 jobs, FastCheck/Conformance
+`#guard`s pass), all green with zero warnings. A/B measured on the compiled
+`hexmodarith_bench` binary (modulus 65537), old-vs-new normalized cost C: mul
+188.9->115.8, add 1576->630.9, sub 2512->2337. Codex second opinion: no
+blocker/major; validated soundness, csimp byte-identity, C extern, and the BZ
+range-reduction; flagged only doc drift (now fixed).
+
+## Current frontier
+
+The two remaining #8637 deliverables are **not** in this PR, by design:
+
+- **Wire the Barrett context into hot convolution kernels** and
+- **lazy-reduction poly/matrix kernels** (accumulate several `< 2^62` products
+  before one reduction).
+
+Both are the same architectural piece: a ZMod64-specialized convolution kernel.
+They need 128-bit accumulation (products are `< 2^62`; any poly degree > 3
+overflows a single `UInt64` when summed), i.e. a new C FFI extern plus a
+specialized `FpPoly`/`Matrix` multiply path and correspondence proofs. That is a
+large, separable follow-up, and it *depends on* this `p < 2^31` foundation (lazy
+reduction is only sound under the tighter bound). Barrett does **not** help the
+contextless `ZMod64.mul` (per-call reciprocal recompute is a division), so it
+too belongs in the kernels.
+
+## Next step
+
+Open a follow-up issue for the Barrett-context + lazy-reduction convolution
+kernels (FpPoly `O(n^2)` and ZMod64 matrix `O(n^3)`), exercised by
+`hexpolyfp_bench` and a ZMod64 matrix bench. This PR unblocks it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR tightens the global `Hex.ZMod64.Bounds` invariant from `p < 2^64` to `p < 2^31` (the owner-blessed bound: every current and anticipated application — Berlekamp-Zassenhaus, LLL, matrix work — uses small primes) and uses the tighter bound to speed up the hot modular add/sub/mul while keeping outputs byte-identical to their reference definitions. It is the foundational half of https://github.com/kim-em/hex-dev/issues/8637 (the follow-up to https://github.com/kim-em/hex-dev/issues/8630).

Under `p < 2^31` the sum of two residues fits in a machine word without carry and the product of two residues stays below `2^62`, so:

- `add` collapses its three-way carry analysis into a single conditional-subtract `reduceOnce` step (no carry branch);
- `sub` uses a single sign test — the fast common path `a - b`, else the corrected `a + (p - b)` — dropping the `complementWord` double-wrap reasoning;
- `mul`'s C extern `lean_hex_zmod64_mul` drops the `__uint128_t` product for a plain single-word `a * b % p`.

`addImpl`/`subImpl` remain `@[csimp]`-equal to the noncomputable reference `add`/`sub`, and the whole family of wraparound case lemmas is removed (net -160 lines in `Basic.lean`), so compiled output is unchanged. Downstream `Bounds` constructors (BZ prime selection, the extended prime walk, `CertReify.boundsOfDecide`) and the conformance fixtures move to `p < 2^31`; the large-modulus conformance case retargets from `2^63 + 29` to the Mersenne prime `2^31 - 1`, the largest now admissible.

Verified by a full `lake build` (4142 jobs, including the CI-gated Mathlib bridge layer and its certificate round-trip tests), the `HexConformance` `#guard`/`#eval` checks, and an A/B measurement on the compiled `hexmodarith_bench` binary (modulus 65537, normalized cost, lower is better): `mul` 188.9 → 115.8 (~1.6x), `add` 1576 → 630.9 (~2.5x), `sub` 2512 → 2337 (~1.07x).

Scope: this lands the `p < 2^31` foundation plus the scalar `add`/`sub`/`mul` wins from https://github.com/kim-em/hex-dev/issues/8637. The issue's remaining two deliverables — wiring the Barrett context into the hot convolution kernels and adding lazy-reduction poly/matrix kernels — are tracked as a follow-up in https://github.com/kim-em/hex-dev/issues/8639. They are one architectural piece (a ZMod64-specialized convolution kernel with 128-bit lazy accumulation via a new C FFI extern, plus specialized `FpPoly`/matrix multiply paths and correspondence proofs), they depend on this `p < 2^31` foundation for soundness, and Barrett does not help the contextless `ZMod64.mul` (a per-call reciprocal recompute is itself a division). This PR unblocks that work.

🤖 Prepared with Claude Code