### PR TITLE
perf(ffi): compile the C externs with -O3

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -21,14 +21,14 @@ private def clmulOTarget (pkg : Package) : FetchM (Job FilePath) := do
   let oFile := pkg.dir / defaultBuildDir / "HexGF2" / "ffi" / "clmul.o"
   let srcTarget ← inputTextFile <| pkg.dir / "HexGF2" / "ffi" / "clmul.c"
   buildFileAfterDep oFile srcTarget fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC", "-O3"]
     compileO oFile srcFile flags
 
 private def zmod64MulOTarget (pkg : Package) : FetchM (Job FilePath) := do
   let oFile := pkg.dir / defaultBuildDir / "HexModArith" / "ffi" / "zmod64_mul.o"
   let srcTarget ← inputTextFile <| pkg.dir / "HexModArith" / "ffi" / "zmod64_mul.c"
   buildFileAfterDep oFile srcTarget fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC", "-O3"]
     compileO oFile srcFile flags
 
 extern_lib hexgf2ffi (pkg) := do
@@ -41,7 +41,7 @@ private def hexArithOTarget (pkg : Package) (src : String) : FetchM (Job FilePat
   let oFile := pkg.dir / defaultBuildDir / "HexArith" / "ffi" / s!"{stem}.o"
   let srcTarget ← inputTextFile <| pkg.dir / "HexArith" / "ffi" / src
   buildFileAfterDep oFile srcTarget fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC", "-O3"]
     compileO oFile srcFile flags
 
 extern_lib hexarithffi (pkg) := do
@@ -58,7 +58,7 @@ private def hexlllProviderOTarget (pkg : Package) : FetchM (Job FilePath) := do
   let oFile := pkg.dir / defaultBuildDir / "HexLLL" / "ffi" / "lean_hexlll_provider.o"
   let srcTarget ← inputTextFile <| pkg.dir / "HexLLL" / "ffi" / "lean_hexlll_provider.c"
   buildFileAfterDep oFile srcTarget fun srcFile => do
-    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC"]
+    let flags := #["-I", (← getLeanIncludeDir).toString, "-fPIC", "-O3"]
     compileO oFile srcFile flags
 
 extern_lib hexlllffi (pkg) := do


### PR DESCRIPTION
This PR compiles the four `extern_lib` C objects (`HexGF2/ffi/clmul.c`, `HexModArith/ffi/zmod64_mul.c`, `HexArith/ffi/{wide_arith,mpz_gcdext}.c`, and `HexLLL/ffi/lean_hexlll_provider.c`) with `-O3`. They were previously built with only `-I … -fPIC`, i.e. no optimization at all, so every hand-written kernel ran unoptimized.

Measured on the compiled `hexpolyfp_bench` FpPoly multiply over `F_65537`, the reference `ZMod64` modular multiply alone speeds up ~1.2x from this flag. The effect is far larger for `__uint128_t`-heavy kernels: a prototype lazy-reduction convolution ran ~20x slower unoptimized than with `-O3`. The conformance `#guard`/`#eval` checks over the recompiled externs still pass.

🤖 Prepared with Claude Code