### PR TITLE
fix: link GMP FFI libs so hex is usable as a dependency

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -72,19 +72,21 @@ lean_lib HexBasic where
 
 lean_lib HexArith where
   precompileModules := true
-  moreLinkArgs := #[
-    s!"{(defaultBuildDir / "lib" / nameToStaticLib "hexarithffi").toString}",
-    "-lgmp"
-  ]
+  -- The `hexarithffi` extern_lib is linked into this precompiled library's
+  -- dynlib automatically (as with `hexgf2ffi` and `HexGF2`); we only need to
+  -- add the system GMP library. Passing the static lib by an explicit path
+  -- broke consumers: that path was relative to the *root* package's build dir,
+  -- so when hex is a dependency it resolved against the wrong project and the
+  -- dynlink failed.
+  moreLinkArgs := #["-lgmp"]
 
 lean_lib HexPoly where
 
 lean_lib HexModArith where
   precompileModules := true
-  moreLinkArgs := #[
-    s!"{(defaultBuildDir / "lib" / nameToStaticLib "hexmodarithffi").toString}",
-    "-lgmp"
-  ]
+  -- See `HexArith`: the `hexmodarithffi` extern_lib links in automatically, so
+  -- we pass only the system GMP library rather than an explicit static-lib path.
+  moreLinkArgs := #["-lgmp"]
 
 lean_lib HexGF2 where
   precompileModules := true


### PR DESCRIPTION
This PR fixes linking of the GMP FFI libraries so that `hex` can be required as a dependency without link failures.

`HexArith` and `HexModArith` passed their extern static archive (`libhexarithffi.a` / `libhexmodarithffi.a`) to `moreLinkArgs` by an explicit path built from `defaultBuildDir`, which is relative to the *root* package's build directory. That resolves correctly only when `hex` is the root package. When `hex` is required as a dependency, the same relative path resolves against the *consuming* project, where the archive does not exist, so linking the precompiled dynlibs fails:

```
clang: error: no such file or directory: '.lake/build/lib/libhexarithffi.a'
```

The fix links these extern libraries the way `HexGF2` already links `hexgf2ffi`: rely on Lake's automatic linking of a package's extern libraries into its precompiled dynlibs, and pass only `-lgmp` (the system library) in `moreLinkArgs`. The archive is still linked, now by an absolute path Lake computes itself.

Verified by requiring this branch from a separate project and building `HexArith` and `HexModArith` with no workaround: the previously-failing `HexArith.Nat.ModArith:dynlib` target now links, and the full example build (including the Berlekamp-Zassenhaus factorizer) succeeds.

🤖 Prepared with Claude Code