### PR TITLE
doc(polyfp): record that packed modByMonic is not the FpPoly lever

### DIFF
--- a/HexPolyFp/Packed.lean
+++ b/HexPolyFp/Packed.lean
@@ -14,11 +14,9 @@ public section
 Packed `Array UInt64` monic-division kernel for `FpPoly` and its
 value-correspondence with the reference `FpPoly.modByMonic`.
 
-`FpPoly p = DensePoly (ZMod64 p)` stores coefficients as `Array (ZMod64 p)`,
-which boxes every element (`lean_ctor` per coefficient) and allocates per
-operation. The packed kernel below mirrors the reference array long-division
-loop (`HexPoly/Euclid.lean`) over a bare `Array UInt64`, eliminating the boxing
-on the monic-division / Frobenius hot path.
+`FpPoly p = DensePoly (ZMod64 p)` stores coefficients as `Array (ZMod64 p)`.
+The packed kernel below mirrors the reference array long-division loop
+(`HexPoly/Euclid.lean`) over a bare `Array UInt64`.
 
 The arithmetic reuses the reference residue ops rather than doing raw-word
 arithmetic directly. The word helpers `ZMod64.mulWord` / `ZMod64.subWord`
@@ -26,11 +24,35 @@ reconstruct residues and delegate to `ZMod64.mul` / `ZMod64.sub` (the former
 extern-backed by a single-word `a * b % p`, safe because `Bounds p` gives
 `p < 2^31` so the product stays below `2^62`; the latter compiled to the
 division-free sign-test `subImpl` via `@[csimp]`), so the packed kernel equals
-the reference for *every* `Bounds p`.
+the reference for *every* `Bounds p`. `modByMonicPacked_eq` is the
+value-correspondence theorem.
 
-`modByMonicPacked_eq` is the value-correspondence theorem; a later `@[csimp]`
-swap of `FpPoly.modByMonic` for `modByMonicPacked` is therefore
-behaviour-preserving.
+**Status: dormant, measured neutral — intentionally not wired.** This kernel
+was built to test the hypothesis (issue #8642) that `FpPoly` is *reduction*-
+bound and that a packed `modByMonic` on backing words is the speedup lever, the
+way `FpPoly.mulPacked` (`PackedMul.lean`) was the multiply analogue. It is not.
+Two facts kill the premise:
+
+* `Array UInt64` is **not** an unboxed word buffer: Lean boxes every element
+  (`lean_box_uint64` / `lean_unbox_uint64`, visible in the `lean_hex_fp_convolve`
+  extern), exactly as `Array (ZMod64 p)` boxes its trivially-wrapped `UInt64`
+  coefficients. Packing to words saves no boxing; it only adds two copy passes,
+  so a `@[csimp]` swap for the pure-Lean kernel here measures ~3% *slower* on the
+  `powModMonic` / Frobenius hot path.
+* Even a native C long-division extern that removes *all* boxing, per-term FFI
+  (`lean_hex_zmod64_mul` per coefficient) and Lean `foldl` overhead measures only
+  ~1% faster on the reduction in isolation and flat end-to-end. `modByMonic` is
+  bound by its intrinsic `O(n²)` modular-reduction `% p` divisions, which the
+  reference and any per-term packed kernel perform identically — not by boxing.
+
+The only representation that cuts the *division count* is lazy `__uint128_t`
+accumulation (one reduction per output coefficient). That works for the
+convolution `mulPacked` but not for long division, whose sequential
+pivot dependency forces each pivot to be reduced before use; a genuinely lazy
+long-division kernel (wider deferred-normalization accumulators) is a different,
+much larger piece, and given `mulPacked`'s null end-to-end result is unlikely to
+pay off. So this kernel is kept as proven, tested infrastructure but is **not**
+registered as the compiled implementation of `FpPoly.modByMonic`.
 -/
 
 namespace Hex
@@ -193,8 +215,9 @@ def divModArrayAuxPacked (p : Nat) [ZMod64.Bounds p]
             let rem := subtractScaledShiftPacked p rem q shift coeff
             divModArrayAuxPacked p q qDegree scaleLead fuel quot rem
 
-/-- Packed monic division remainder, identical in signature to
-`FpPoly.modByMonic` (csimp requirement). Packs both operand arrays, runs the
+/-- Packed monic division remainder, sharing the signature of `FpPoly.modByMonic`
+(so a `@[csimp]` swap would be well-typed, though it is intentionally not
+registered — see the module docstring). Packs both operand arrays, runs the
 packed loop with `scaleLead = id` (the divisor is monic), and reconstructs the
 remainder. -/
 @[expose]

--- a/progress/20260707T064957Z_issue-8642.md
+++ b/progress/20260707T064957Z_issue-8642.md
@@ -1,0 +1,50 @@
+# issue-8642 — packed modByMonic is not the FpPoly lever
+
+Session type: feature (issue #8642, "the FpPoly bottleneck is packed
+modByMonic (reduction), not the multiply").
+
+**Accomplished**
+
+Investigated and disproved the issue's premise with direct A/B measurement,
+then landed the honest negative result rather than forcing a neutral change.
+
+- Confirmed `HexPolyFp/Packed.lean` `modByMonicPacked` is dormant (no `@[csimp]`).
+- Established the key runtime fact: `Array UInt64` boxes every element
+  (`lean_box_uint64` / `lean_unbox_uint64`, visible in the existing
+  `lean_hex_fp_convolve` C extern), exactly like `Array (ZMod64 p)` boxes its
+  trivially-wrapped-`UInt64` coefficients. Packing to words saves no boxing.
+- A/B measured (F_65537, degrees 256..512, checksums identical throughout):
+  - powModMonic baseline (reference modByMonic): ~1310 ms
+  - powModMonic pure-Lean modByMonicPacked csimp: ~1350 ms (~3% SLOWER)
+  - powModMonic native C-extern modByMonic csimp: ~1305 ms (flat)
+  - isolated modByMonic baseline: ~7250 ms; native C extern: ~7172 ms (~1%)
+- Wrote a native C long-division extern (`lean_hex_fp_mod_by_monic`) as the
+  strongest-possible packed reduction (no boxing, no per-term FFI, no Lean
+  foldl) to stress-test the premise; it moved the reduction ~1% in isolation
+  and 0% end-to-end. So modByMonic is bound by its intrinsic O(n²) `% p`
+  hardware divisions, identical in reference and packed — not by boxing.
+- Got a second opinion (Codex): agreed — do not wire `@[csimp]` for a neutral
+  path; landing/documenting the negative result is the right call; lazy
+  `__uint128` long division is the only remaining lever but a different, larger
+  kernel unlikely to pay off given mulPacked's null result.
+- Reverted the experimental C extern / csimp / temp bench exe. Landed only a
+  docstring update in `Packed.lean` recording the measured finding (mirroring
+  `PackedMul.lean`'s dormant note for `mulPacked`), and corrected the false
+  "eliminates boxing" claim.
+
+**Current frontier**
+
+Issue premise resolved as false-for-the-proposed-lever. Kernel stays dormant,
+proven, tested; docstring now tells the next agent not to re-attempt wiring.
+
+**Next step**
+
+Post the premise-wrong finding on #8642 with the numbers; open a PR with the
+docstring change. If anyone still wants a reduction win, the only candidate is
+a lazy-`__uint128` deferred-normalization long division (cuts divisions n-fold)
+— a separate research effort, and the mulPacked precedent argues it will be
+flat end-to-end too.
+
+**Blockers**
+
+None.


### PR DESCRIPTION
This PR records the measured negative result for issue #8642 next to the dormant `FpPoly.modByMonicPacked` kernel, correcting the docstring so a future agent does not re-attempt wiring it. The issue hypothesised that `FpPoly` is reduction-bound and that a packed `modByMonic` on `Array UInt64` backing words is the speedup lever; benchmarking the compiled binary disproves that premise, reproducing the `mulPacked` cautionary tale the issue itself cites.

A/B on `powModMonic` (Frobenius-shaped, F_65537, degrees 256..512, checksums identical): the reference `modByMonic` runs ~1310 ms; a `@[csimp]` swap for the pure-Lean `modByMonicPacked` runs ~1350 ms (~3% slower, since packing adds two copy passes and saves no boxing); a native C long-division extern that removes all boxing, per-term FFI and Lean `foldl` overhead runs ~1305 ms (flat), and moves the reduction only ~1% in isolation. `Array UInt64` boxes every element (`lean_box_uint64`, visible in the existing `lean_hex_fp_convolve` extern) exactly like `Array (ZMod64 p)` boxes its trivially-wrapped `UInt64` coefficients, so packing eliminates no boxing; `modByMonic` is bound by its intrinsic O(n^2) modular `% p` divisions, which the reference and any per-term packed kernel perform identically. The kernel stays dormant, proven and tested; it is intentionally not registered as the compiled implementation of `FpPoly.modByMonic`. Full analysis is in the issue thread and the progress note.

Closes #8642

🤖 Prepared with Claude Code