### PR TITLE
refactor(lll): autoParam the proof args and drop the independent argument

### DIFF
--- a/HexLLL/Dispatch.lean
+++ b/HexLLL/Dispatch.lean
@@ -31,8 +31,8 @@ exact `lllNative` runs. Both paths satisfy the identical post-condition
 so dispatch is invisible to callers and to proofs. -/
 @[expose]
 def lll (b : Matrix Int n m) (δ : Rat)
-    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
-    (_hind : b.independent) :
+    (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) :
     Matrix Int n m :=
   match LLLProvider.dispatch b δ with
   | some B' => B'
@@ -73,7 +73,7 @@ the exact native path. It never consults an external provider and takes no
 short-vector guarantee is `lllNative_first_row_norm_sq_le` at `η = 1/2`. -/
 @[expose]
 def lllNative.firstShortVector (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
+    (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Vector Int m :=
   (lllNative b δ hδ hδ' hn).getRow ⟨0, hn⟩
 
@@ -84,17 +84,17 @@ vector. Canonical short-vector entry point for downstream callers such as
 `hex-berlekamp-zassenhaus` recombination. -/
 @[expose]
 def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
-    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
-    (hind : b.independent) :
+    (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) :
     Vector Int m :=
-  (lll b δ hδ hδ' hn hind).getRow ⟨0, hn⟩
+  (lll b δ hδ hδ' hn).getRow ⟨0, hn⟩
 
 /-- Full `lllNative` output as an ordered array of candidate short vectors: the
 `lll.shortVectors` counterpart on the exact native path, forgoing the external
 provider and the `b.independent` hypothesis. -/
 @[expose]
 def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
+    (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=
   (lllNative b δ hδ hδ' hn).rows.toArray
 
@@ -102,9 +102,9 @@ def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat)
 vectors. -/
 @[expose]
 def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
-    (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
-    (hind : b.independent) :
+    (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=
-  (lll b δ hδ hδ' hn hind).rows.toArray
+  (lll b δ hδ hδ' hn).rows.toArray
 
 end Hex

--- a/HexLLL/Native.lean
+++ b/HexLLL/Native.lean
@@ -554,7 +554,7 @@ classical size-reduction bound `|μ| ≤ 1/2` (η = 1/2), so its short-vector
 guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`. -/
 @[expose]
 def lllNative (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) :
+    (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Matrix Int n m :=
   lllAux (LLLState.ofBasis b) 1 δ hδ hδ' (Nat.le_refl 1) hn
 

--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -49,19 +49,21 @@ def B : Matrix Int 3 3 := Matrix.ofFn fun i j =>
   | 2, 0 => 3 | 2, 1 => 5 | 2, 2 => 6
   | _, _ => 0
 
--- The verified entry point. Given a proof `hind : B.independent`, `lll` returns
--- a `(δ, 11/20)`-reduced basis of the same lattice and `lll.firstShortVector`
--- reads off its provably short first row. The short-vector guarantee itself is
--- the theorem `lll_first_row_norm_sq_le` in `hex-lll-mathlib`.
+-- The verified entry point. `lll` returns a `(δ, 11/20)`-reduced basis of the
+-- same lattice and `lll.firstShortVector` reads off its provably short first
+-- row. The three proof arguments are `autoParam`s (`:= by grind`), so a call at
+-- a concrete `δ` is just `lll B (3 / 4)`. The short-vector guarantee itself is
+-- the theorem `lll_first_row_norm_sq_le` in `hex-lll-mathlib`, which takes the
+-- `B.independent` hypothesis separately — a precondition of the theorem, not of
+-- the computation.
 #check @lll.firstShortVector
 #check @lll
 
--- To run the reducer on data without supplying an independence proof, use the
--- proof-free variants. They run the exact `lllNative` directly (the body of
--- `lll`'s native path, skipping the provider dispatch) and carry no exported
--- short-vector theorem unless you separately prove `B.independent`.
-#eval lllNative.firstShortVector B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
-#eval lllNative.shortVectors B (3 / 4) (by decide +kernel) (by decide +kernel) (by decide)
+-- `lllNative.firstShortVector` / `lllNative.shortVectors` run the exact
+-- `lllNative` directly (the body of `lll`'s native path, skipping the provider
+-- dispatch). Like `lll`, their proof arguments are filled by `by grind`.
+#eval lllNative.firstShortVector B (3 / 4)
+#eval lllNative.shortVectors B (3 / 4)
 
 -- The executable integer reducedness oracle.
 #eval lllReducedInt (Matrix.identity 3) (3 / 4) (1 / 2)   -- true

--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -94,7 +94,7 @@ theorem lll_short_vector (b : Matrix Int n m) (δ : Rat)
     (hn : 1 ≤ n) (hli : b.independent)
     (v : Vector Int m) :
     b.memLattice v → v ≠ 0 →
-    (lll b δ hδ hδ' hn hli).row 0 |>.normSq ≤ (1/(δ - 121/400))^(n-1) * v.normSq
+    (lll b δ hδ hδ' hn).row 0 |>.normSq ≤ (1/(δ - 121/400))^(n-1) * v.normSq
 
 theorem lllNative_short_vector (b : Matrix Int n m) (δ : Rat)
     (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hli : b.independent)
@@ -249,9 +249,19 @@ def LLLState.ofBasis (b : Matrix Int n m) :
     d_eq := by … } -- from gramDetVec_eq_gramDet
 
 def lll (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) : Matrix Int n m :=
-  lllAux (LLLState.ofBasis b) 1 δ hδ hδ' (by omega) (by omega)
+    (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) : Matrix Int n m :=
+  -- dispatch: certified external candidate, else the exact `lllNative`
+  ...
 ```
+
+`lll` does **not** take a `b.independent` argument: independence is a
+precondition of the *theorems* about the output (`lll_short_vector`,
+`lll_independent`, …), not of the *computation*, so — exactly as with
+`lllNative` — the reducer runs on any input and callers who only want the
+reduced rows need not discharge it. The three proof arguments are
+`autoParam`s (`:= by grind`), so at a concrete `δ`/`n` a call is just
+`lll b δ`.
 
 The `ν_eq` and `d_eq` fields are discharged from the `hex-gram-schmidt`
 lemmas `GramSchmidt.Int.scaledCoeffs_eq` and
@@ -301,16 +311,18 @@ that consumer is:
     LLL guarantee). Marked as the canonical short-vector entry point
     for downstream consumers such as hex-berlekamp-zassenhaus. -/
 def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) :
     Vector Int m :=
-  (lll b δ hδ hδ' hn hind)[0]
+  (lll b δ hδ hδ' hn)[0]
 
 /-- The full reduced basis viewed as an ordered list of candidate
     short vectors. -/
 def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
-    (hδ : 1/4 < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n) (hind : b.independent) :
+    (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
+    (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=
-  (lll b δ hδ hδ' hn hind).toArray
+  (lll b δ hδ hδ' hn).toArray
 ```
 
 Both entry points are Phase 1 deliverables; conformance must exercise

--- a/HexLLLMathlib/README.md
+++ b/HexLLLMathlib/README.md
@@ -58,7 +58,7 @@ theorem lll_first_row_norm_sq_le
     (hind : b.independent)
     (x : Fin m → ℤ) (hx : x ∈ latticeSubmodule b) (hx0 : x ≠ 0) :
     ‖intRowToEuclidean
-        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn hind)
+        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn)
           ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩)‖ ^ 2 ≤
       (((1 / (δ - 121 / 400)) ^ (n - 1) : Rat) : ℝ) *
         ‖intVectorToEuclidean x‖ ^ 2
@@ -88,7 +88,7 @@ theorem lll_mem_latticeSubmodule_iff
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) (x : Fin m → ℤ) :
-    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) ↔ x ∈ latticeSubmodule b
+    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn) ↔ x ∈ latticeSubmodule b
 ```
 
 # Functionality

--- a/HexLLLMathlib/Reducer.lean
+++ b/HexLLLMathlib/Reducer.lean
@@ -2452,7 +2452,7 @@ by `isLLLReduced.mono_η`. On the certified-dispatch path it follows from
 theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) :
-    isLLLReduced (lll b δ hδ hδ' hn hind) δ (11 / 20) := by
+    isLLLReduced (lll b δ hδ hδ' hn) δ (11 / 20) := by
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
@@ -2466,7 +2466,7 @@ theorem lll_isLLLReduced (b : Matrix Int n m) (δ : Rat)
 theorem lll_memLattice_iff (b : Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) (v : Vector Int m) :
-    Matrix.memLattice (lll b δ hδ hδ' hn hind) v ↔ Matrix.memLattice b v := by
+    Matrix.memLattice (lll b δ hδ hδ' hn) v ↔ Matrix.memLattice b v := by
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
@@ -2479,7 +2479,7 @@ theorem lll_memLattice_iff (b : Matrix Int n m) (δ : Rat)
 theorem lll_independent (b : Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) :
-    (lll b δ hδ hδ' hn hind).independent := by
+    (lll b δ hδ hδ' hn).independent := by
   unfold lll
   cases hd : LLLProvider.dispatch b δ with
   | none =>
@@ -2489,7 +2489,7 @@ theorem lll_independent (b : Matrix Int n m) (δ : Rat)
       exact (dispatch_some_property hd).2.1
 
 /-- Public LLL short-vector bound at `η = 11/20`. For any independent
-integer basis `b`, the first row of `Hex.lll b δ ... hind` has squared norm at
+integer basis `b`, the first row of `Hex.lll b δ …` has squared norm at
 most `(1 / (δ − 121/400))^(n − 1)` times the squared norm of any nonzero
 lattice vector. -/
 theorem lll_short_vector
@@ -2497,19 +2497,19 @@ theorem lll_short_vector
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent)
     {v : Vector Int m} (hv : Matrix.memLattice b v) (hv' : v ≠ 0) :
-    ((((lll b δ hδ hδ' hn hind).row
+    ((((lll b δ hδ hδ' hn).row
         ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩).normSq : Int) : Rat) ≤
       (1 / (δ - 121 / 400)) ^ (n - 1) * ((v.normSq : Int) : Rat) := by
-  have hred : isLLLReduced (lll b δ hδ hδ' hn hind) δ (11 / 20) :=
+  have hred : isLLLReduced (lll b δ hδ hδ' hn) δ (11 / 20) :=
     lll_isLLLReduced b δ hδ hδ' hn hind
-  have hind' : (lll b δ hδ hδ' hn hind).independent :=
+  have hind' : (lll b δ hδ hδ' hn).independent :=
     lll_independent b δ hδ hδ' hn hind
-  have hv_lll : Matrix.memLattice (lll b δ hδ hδ' hn hind) v :=
+  have hv_lll : Matrix.memLattice (lll b δ hδ hδ' hn) v :=
     (lll_memLattice_iff b δ hδ hδ' hn hind v).mpr hv
   have hδη : (11 / 20 : Rat) * (11 / 20) < δ := by
     have : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
     grind
-  have hbnd := Hex.short_vector_bound_of_size_bound (lll b δ hδ hδ' hn hind)
+  have hbnd := Hex.short_vector_bound_of_size_bound (lll b δ hδ hδ' hn)
     hind' hred (by grind) hδη hδ' hn hv_lll hv'
   have hηη : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
   simpa [hηη] using hbnd

--- a/HexLLLMathlib/ShortVector.lean
+++ b/HexLLLMathlib/ShortVector.lean
@@ -44,12 +44,12 @@ theorem lll_mem_latticeSubmodule_iff
     (b : Hex.Matrix Int n m) (δ : Rat)
     (hδ : (121 / 400 : Rat) < δ) (hδ' : δ ≤ 1) (hn : 1 ≤ n)
     (hind : b.independent) (x : Fin m → ℤ) :
-    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) ↔ x ∈ latticeSubmodule b := by
+    x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn) ↔ x ∈ latticeSubmodule b := by
   let v := HexMatrixMathlib.vectorEquiv.symm x
   have hxv : x = HexMatrixMathlib.vectorEquiv v :=
     (Equiv.apply_symm_apply _ x).symm
   rw [hxv]
-  rw [mem_latticeSubmodule_iff (Hex.lll b δ hδ hδ' hn hind) v,
+  rw [mem_latticeSubmodule_iff (Hex.lll b δ hδ hδ' hn) v,
       mem_latticeSubmodule_iff b v]
   exact Hex.lll_memLattice_iff b δ hδ hδ' hn hind v
 
@@ -91,21 +91,21 @@ theorem lll_first_row_norm_sq_le
     (hind : b.independent)
     (x : Fin m → ℤ) (hx : x ∈ latticeSubmodule b) (hx0 : x ≠ 0) :
     ‖intRowToEuclidean
-        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn hind)
+        (Hex.Matrix.row (Hex.lll b δ hδ hδ' hn)
           ⟨0, Nat.lt_of_lt_of_le Nat.zero_lt_one hn⟩)‖ ^ 2 ≤
       (((1 / (δ - 121 / 400)) ^ (n - 1) : Rat) : ℝ) *
         ‖intVectorToEuclidean x‖ ^ 2 := by
-  have hred : Hex.isLLLReduced (Hex.lll b δ hδ hδ' hn hind) δ (11 / 20) :=
+  have hred : Hex.isLLLReduced (Hex.lll b δ hδ hδ' hn) δ (11 / 20) :=
     Hex.lll_isLLLReduced b δ hδ hδ' hn hind
-  have hind' : (Hex.lll b δ hδ hδ' hn hind).independent :=
+  have hind' : (Hex.lll b δ hδ hδ' hn).independent :=
     Hex.lll_independent b δ hδ hδ' hn hind
-  have hx_lll : x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn hind) :=
+  have hx_lll : x ∈ latticeSubmodule (Hex.lll b δ hδ hδ' hn) :=
     (lll_mem_latticeSubmodule_iff b δ hδ hδ' hn hind x).mpr hx
   have hδη : (11 / 20 : Rat) * (11 / 20) < δ := by
     have : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
     grind
   have hbnd := reduced_first_row_norm_sq_le
-    (Hex.lll b δ hδ hδ' hn hind) δ (11 / 20) (by grind) hδη hδ' hn hind'
+    (Hex.lll b δ hδ hδ' hn) δ (11 / 20) (by grind) hδη hδ' hn hind'
     hred x hx_lll hx0
   have hηη : (11 / 20 : Rat) * (11 / 20) = 121 / 400 := by grind
   simpa [hηη] using hbnd

--- a/conformance/HexLLL/Conformance.lean
+++ b/conformance/HexLLL/Conformance.lean
@@ -390,16 +390,22 @@ private def typicalState : LLLState 8 8 := stateOf typical8
 #guard (Matrix.row bzStyleBasis f1_3).get f3_4 = -1
 #guard (Matrix.row bzStyleBasis f2_3).get f3_4 = 2
 
-example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
-    (hind : bzStyleBasis.independent) :
-    lll.firstShortVector bzStyleBasis (3 / 4) hδ hδ' (by decide) hind =
-      Matrix.row (lll bzStyleBasis (3 / 4) hδ hδ' (by decide) hind) f0_3 := by
+example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1) :
+    lll.firstShortVector bzStyleBasis (3 / 4) hδ hδ' (by decide) =
+      Matrix.row (lll bzStyleBasis (3 / 4) hδ hδ' (by decide)) f0_3 := by
   rfl
 
-example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1)
-    (hind : bzStyleBasis.independent) :
-    lll.shortVectors bzStyleBasis (3 / 4) hδ hδ' (by decide) hind =
-      (lll bzStyleBasis (3 / 4) hδ hδ' (by decide) hind).rows.toArray := by
+example (hδ : (121 / 400 : Rat) < 3 / 4) (hδ' : (3 / 4 : Rat) ≤ 1) :
+    lll.shortVectors bzStyleBasis (3 / 4) hδ hδ' (by decide) =
+      (lll bzStyleBasis (3 / 4) hδ hδ' (by decide)).rows.toArray := by
+  rfl
+
+-- The three proof arguments are `autoParam`s (`:= by grind`), so at a concrete
+-- `δ`/`n` the public entry points take no proof arguments at all.
+example : lll.firstShortVector bzStyleBasis (3 / 4) = Matrix.row (lll bzStyleBasis (3 / 4)) f0_3 := by
+  rfl
+
+example : lll.shortVectors bzStyleBasis (3 / 4) = (lll bzStyleBasis (3 / 4)).rows.toArray := by
   rfl
 
 example :

--- a/progress/2026-07-07T21-37-33Z.md
+++ b/progress/2026-07-07T21-37-33Z.md
@@ -1,0 +1,36 @@
+# LLL entry-point ergonomics: autoparams + drop the `independent` argument
+
+## Accomplished
+Reworked the public LLL entry-point signatures in `hex-lll` so callers write
+`lll b δ` (or `lll b δ (1/3)`) instead of threading three proofs and an
+independence witness:
+
+- `lllNative`, `lll`, and the `firstShortVector` / `shortVectors` variants of
+  both now take their `hδ` / `hδ'` / `hn` proof arguments as `autoParam`s
+  (`:= by grind`). Backward compatible: explicit proofs still override.
+- `lll`, `lll.firstShortVector`, `lll.shortVectors` no longer take a
+  `b.independent` argument. Independence was never used in the computation —
+  only in the *theorems* about the output — exactly as with `lllNative`. The
+  `lll_*` theorems (`lll_short_vector`, `lll_independent`, `lll_memLattice_iff`,
+  `lll_isLLLReduced`, `lll_first_row_norm_sq_le`, `lll_mem_latticeSubmodule_iff`)
+  keep `b.independent` as a hypothesis; only the `lll …` term application drops
+  the trailing argument.
+
+Updated SPEC (`HexLLL/SPEC/hex-lll.md`), both READMEs, and the HexLLL
+conformance examples.
+
+Green: `HexLLL`, `HexLLLMathlib`, full `lake build` (4143 jobs), `HexConformance`
+(389), `HexLLLBench` (260).
+
+## Current frontier
+This is one item from a larger cleanup batch driven by the hex blog post.
+
+## Next step
+Remaining sibling items (separate PRs): rename `factor` → `ZPoly.factorize`
+plus a `ZPoly.factors` accessor; consider renaming `lllReducedInt`
+(`lllReducedInterval` is live — used by `lllReducedCheck` — so it stays);
+make `Hex.Matrix.independent` efficiently decidable (now non-blocking for
+callers since the argument is gone).
+
+## Blockers
+None.

--- a/progress/20260707T050954Z.md
+++ b/progress/20260707T050954Z.md
@@ -1,0 +1,24 @@
+# PR 8645 Lake extern_lib link-path review
+
+**Accomplished**
+- Reviewed PR 8645's single `lakefile.lean` change dropping explicit relative
+  `libhexarithffi.a` / `libhexmodarithffi.a` paths from `moreLinkArgs`.
+- Checked Lake v4.32.0-rc1 source: `LeanLib.recBuildShared` fetches every
+  package `extern_lib` dynlib before linking a Lean library shared facet, and
+  `moreLinkArgs` are appended after linked extern objects.
+- Checked the local commit and nearby project docs for conflicting guidance.
+
+**Current frontier**
+- The fix matches Lake's extern library model and the existing `HexGF2` pattern.
+- `extraDepTargets` are not needed for the `HexArith` / `HexModArith` shared
+  dynlib link itself because the extern libraries are already fetched by the
+  shared facet.
+
+**Next step**
+- Merge is reasonable once CI passes, with the dependency-build evidence as the
+  important end-to-end validation.
+
+**Blockers**
+- A local `lake build HexArith:dynlib HexModArith:dynlib HexGF2:dynlib` could not
+  run in this fresh worktree because Lake attempted to clone mathlib and network
+  access was unavailable.


### PR DESCRIPTION
This PR makes the public LLL entry points ergonomic, so a caller reduces a basis with `lll b δ` instead of threading three proofs and an independence witness.

`lllNative`, `lll`, and the `firstShortVector`/`shortVectors` variants of both now take their `hδ`/`hδ'`/`hn` proof arguments as `autoParam`s (`:= by grind`); at a concrete δ/n the proofs are filled automatically, and explicit proofs still override.

`lll`, `lll.firstShortVector`, and `lll.shortVectors` no longer take a `b.independent` argument. Independence was never used in the computation — it is a precondition of the *theorems* about the output, exactly as `lllNative` already omits it. The `lll_*` theorems keep `b.independent` as a hypothesis; only the `lll …` term application drops the trailing argument. Mathlib-free callers can now reduce a basis without discharging an independence proof.

Updates the SPEC, both READMEs, and adds conformance coverage exercising the proof-free surface. Verified green: `HexLLL`, `HexLLLMathlib`, full `lake build` (4143 jobs), `HexConformance`, `HexLLLBench`.

🤖 Prepared with Claude Code