### PR TITLE
feat(bz): computable kernel-reducible Decidable for mod-p irreducibility

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -1222,4 +1222,137 @@ instance irreducibleDecidablePred (p : Nat) [Fact (Nat.Prime p)] :
 
 end
 
+/-!
+### Computable, kernel-reducible irreducibility over `F_p`
+
+The instance above is classical, so `decide +kernel` gets stuck on it. This
+block gives a *computable* `Bool`-valued irreducibility test backed by
+`Berlekamp.rabinTest`, proves it agrees with Mathlib irreducibility of the
+transported polynomial, and packages the agreement as a `Decidable` instance
+that `decide +kernel` reduces entirely in the kernel (never trusting compiled
+code).
+
+The block lives outside the file's `noncomputable section`, so `fpIsIrreducible`
+is genuinely computable (`rabinTest` is `@[expose]` and kernel-reducible; the
+`scale` used by `normalizeMonic` is `noncomputable` but carries a `@[csimp]`
+runtime implementation).
+-/
+
+section Computable
+
+open Polynomial
+
+variable {p : Nat} [Hex.ZMod64.Bounds p]
+
+/-- Monicity of an executable finite-field polynomial is decidable: `Monic m` is
+the equality `leadingCoeff m = 1`, and `ZMod64 p` has decidable equality. This is
+the instance that lets the `Bool`-valued `fpIsIrreducible` branch on monicity and
+still reduce in the kernel (obstacle 1 of the SPEC requirement). -/
+instance instDecidableMonic (m : Hex.FpPoly p) :
+    Decidable (Hex.DensePoly.Monic m) :=
+  inferInstanceAs (Decidable (Hex.DensePoly.leadingCoeff m = 1))
+
+/-- Computable, kernel-reducible irreducibility test for finite-field
+polynomials, backed by `Berlekamp.rabinTest` on the monic normalization.
+
+Zero inputs are rejected; every nonzero `f` normalizes to a monic polynomial
+`(normalizeMonic f).2` whose Rabin test decides irreducibility. `decide +kernel`
+reduces this test in the kernel, so via `fpIsIrreducible_iff` and
+`instDecidableIrreducibleToMathlibPolynomial` it certifies
+`Irreducible (toMathlibPolynomial f)` using only the kernel. -/
+def fpIsIrreducible (f : Hex.FpPoly p) : Bool :=
+  if f.isZero then false
+  else if hm : Hex.DensePoly.Monic (Hex.FpPoly.normalizeMonic f).2 then
+    Hex.Berlekamp.rabinTest (Hex.FpPoly.normalizeMonic f).2 hm
+  else false
+
+/-- The computable Rabin-backed test agrees with Mathlib irreducibility of the
+transported polynomial over `ZMod p`.
+
+For nonzero `f` the monic normalization `m = (normalizeMonic f).2` is a unit
+multiple of `f` (`f = leadingCoeff f • m` up to `C`), so irreducibility of
+`toMathlibPolynomial m` and of `toMathlibPolynomial f` coincide; `rabin_irreducible`
+supplies the former for the monic `m` (also in the constant case, where both the
+Rabin test and Mathlib irreducibility are `false`). -/
+theorem fpIsIrreducible_iff [Fact (Nat.Prime p)] (f : Hex.FpPoly p) :
+    fpIsIrreducible f = true ↔ Irreducible (toMathlibPolynomial f) := by
+  haveI hPM : Hex.ZMod64.PrimeModulus p := primeModulus_of_fact p
+  have hprime : Hex.Nat.Prime p := hPM.prime
+  by_cases hz : f.isZero = true
+  · -- Zero input: the test is `false` and the transported polynomial is `0`.
+    have hsize0 : f.size = 0 := (Hex.DensePoly.isZero_eq_true_iff f).mp hz
+    have hf0 : f = 0 := by
+      apply Hex.DensePoly.ext_coeff
+      intro n
+      rw [Hex.DensePoly.coeff_zero]
+      exact Hex.DensePoly.coeff_eq_zero_of_size_le f (by omega)
+    have hpoly0 : toMathlibPolynomial f = 0 := by
+      apply Polynomial.ext
+      intro n
+      rw [coeff_toMathlibPolynomial, hf0, Hex.DensePoly.coeff_zero, Polynomial.coeff_zero]
+      exact HexModArithMathlib.ZMod64.toZMod_zero
+    rw [fpIsIrreducible, if_pos hz, hpoly0]
+    simp only [Bool.false_eq_true, false_iff]
+    exact not_irreducible_zero
+  · -- Nonzero input: normalize to the monic `m` and bridge across the unit `C c⁻¹`.
+    have hzf : f.isZero = false := Bool.eq_false_iff.mpr hz
+    set c := Hex.DensePoly.leadingCoeff f with hc
+    have hc_ne : c ≠ 0 := Hex.FpPoly.fpPoly_leadingCoeff_ne_zero_of_isZero_false f hzf
+    have hinv_mul : c⁻¹ * c = (1 : Hex.ZMod64 p) :=
+      Hex.ZMod64.inv_mul_eq_one_of_prime hprime hc_ne
+    have hinv_ne : c⁻¹ ≠ (0 : Hex.ZMod64 p) := by
+      intro hinv
+      rw [hinv] at hinv_mul
+      have hzero : (0 : Hex.ZMod64 p) * c = 0 := by grind
+      rw [hzero] at hinv_mul
+      exact Hex.ZMod64.one_ne_zero_of_prime hprime hinv_mul.symm
+    have hnm2 : (Hex.FpPoly.normalizeMonic f).2 = Hex.DensePoly.scale c⁻¹ f := by
+      simp only [Hex.FpPoly.normalizeMonic, hzf, Bool.false_eq_true, if_false, ← hc]
+    have hm_monic : Hex.DensePoly.Monic (Hex.FpPoly.normalizeMonic f).2 := by
+      rw [hnm2]
+      unfold Hex.DensePoly.Monic
+      rw [Hex.FpPoly.leadingCoeff_scale_of_ne_zero_of_nonzero hinv_ne f
+        (Nat.pos_iff_ne_zero.mp ((Hex.DensePoly.isZero_eq_false_iff f).mp hzf)), ← hc]
+      exact hinv_mul
+    rw [fpIsIrreducible, if_neg hz, dif_pos hm_monic,
+      rabin_irreducible (Hex.FpPoly.normalizeMonic f).2 hm_monic
+        (Hex.Berlekamp.basisSize (Hex.FpPoly.normalizeMonic f).2) rfl]
+    -- `toMathlibPolynomial m = C (toZMod c⁻¹) * toMathlibPolynomial f`.
+    have hbridge : toMathlibPolynomial (Hex.FpPoly.normalizeMonic f).2
+        = Polynomial.C (HexModArithMathlib.ZMod64.toZMod c⁻¹) * toMathlibPolynomial f := by
+      rw [hnm2, ← Hex.FpPoly.C_mul_eq_scale, toMathlibPolynomial_mul, toMathlibPolynomial_C]
+    rw [hbridge]
+    have htoinv_ne : HexModArithMathlib.ZMod64.toZMod c⁻¹ ≠ 0 := by
+      intro h0
+      apply hinv_ne
+      have hround := congrArg HexModArithMathlib.ZMod64.ofZMod h0
+      rwa [HexModArithMathlib.ZMod64.ofZMod_toZMod, HexModArithMathlib.ZMod64.ofZMod_zero]
+        at hround
+    have hunit : IsUnit (Polynomial.C (HexModArithMathlib.ZMod64.toZMod c⁻¹)) :=
+      Polynomial.isUnit_C.mpr (isUnit_iff_ne_zero.mpr htoinv_ne)
+    exact irreducible_isUnit_mul hunit
+
+/-- Mathlib irreducibility of a transported finite-field polynomial is decidable
+by a kernel-reducible computation: `decide +kernel` runs `fpIsIrreducible` (hence
+`Berlekamp.rabinTest`) in the kernel and reads off the verdict. -/
+instance instDecidableIrreducibleToMathlibPolynomial
+    [Fact (Nat.Prime p)] (f : Hex.FpPoly p) :
+    Decidable (Irreducible (toMathlibPolynomial f)) :=
+  decidable_of_iff _ (fpIsIrreducible_iff f)
+
+/-- `X² + X + 1` is irreducible over `F₂`, certified by kernel reduction of
+`fpIsIrreducible` through `instDecidableIrreducibleToMathlibPolynomial`, using
+only the trusted kernel. -/
+example :
+    Irreducible (toMathlibPolynomial (Hex.DensePoly.ofCoeffs #[1, 1, 1] : Hex.FpPoly 2)) := by
+  decide +kernel
+
+/-- `X² + 1 = (X + 1)²` is reducible over `F₂`; the same kernel-reducible
+instance rejects it. -/
+example :
+    ¬ Irreducible (toMathlibPolynomial (Hex.DensePoly.ofCoeffs #[1, 0, 1] : Hex.FpPoly 2)) := by
+  decide +kernel
+
+end Computable
+
 end HexBerlekampMathlib

--- a/progress/2026-07-08T03-58-51Z_issue-8571.md
+++ b/progress/2026-07-08T03-58-51Z_issue-8571.md
@@ -1,0 +1,54 @@
+# Issue #8571: computable kernel-reducible Decidable for mod-p irreducibility
+
+## Accomplished
+
+Implemented the mod-`p` half of the certifying-irreducibility SPEC requirement
+(#8564). Added a new block to `HexBerlekampMathlib/Basic.lean`, placed **outside**
+the file's `noncomputable section` (after the `end` at the section close):
+
+- `instDecidableMonic` — `Decidable (DensePoly.Monic m)` for `m : FpPoly p`, via
+  the existing `DecidableEq (ZMod64 p)`. This is obstacle 1 (the load-bearing
+  missing piece) — it lets the `Bool`-valued test branch on monicity and reduce
+  in the kernel.
+- `fpIsIrreducible : FpPoly p → Bool` — `false` on zero; else `rabinTest` of the
+  monic normalization `(normalizeMonic f).2` (guarded by the `dite` on `Monic`).
+- `fpIsIrreducible_iff [Fact (Nat.Prime p)]` — agreement with
+  `Irreducible (toMathlibPolynomial f)`.
+- `instDecidableIrreducibleToMathlibPolynomial` — the `Decidable` instance.
+- Two `example`s proved `by decide +kernel`: `X²+X+1` irreducible over `F₂`
+  (positive), `X²+1=(X+1)²` reducible over `F₂` (negative).
+
+## Key decisions
+
+- **Simplified the issue's 3-case proof to 2 cases.** The issue proposed
+  zero / nonzero-constant / positive-degree. Instead, the nonzero case is
+  uniform: prove `Monic m` via the public `leadingCoeff_scale_of_ne_zero_of_nonzero`
+  (valid at degree 0, unlike `scale_inv_leadingCoeff_monic`), then
+  `rabin_irreducible` gives `rabinTest m hm = true ↔ Irreducible (toMathlibPolynomial m)`
+  for **any** monic `m` — including the constant `m = C 1`, where both sides are
+  `false`. No separate constant case needed.
+- **Unit bridge without `normalizeMonic_reconstruct` (private).** Unfolded
+  `normalizeMonic` (`@[expose]`) to `scale c⁻¹ f`, rewrote via `C_mul_eq_scale`
+  and `toMathlibPolynomial_mul`/`_C` to get
+  `toMathlibPolynomial m = C (toZMod c⁻¹) * toMathlibPolynomial f`, then
+  `irreducible_isUnit_mul` with `IsUnit (C (toZMod c⁻¹))` from `isUnit_iff_ne_zero`
+  (`ZMod p` is a field under `Fact (Nat.Prime p)`).
+- The existing `DecidableEq (ZMod64 p)` (`HexPolyFp/Field.lean`) is already
+  kernel-reducible, so obstacle 1 only needed the thin `Decidable (Monic ·)`
+  wrapper, not a new `DecidableEq`.
+
+## Verification
+
+- `lake build HexBerlekampMathlib.Basic` green; `lake build HexBerlekampZassenhausMathlib`
+  (the CI-gated target) green, 3808 jobs, 0 errors.
+- Added lines are `sorry`/`axiom`/`native_decide`-free (`git diff -U0 | grep` clean).
+- Both `decide +kernel` examples' axiom cone is exactly
+  `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
+
+## Next step
+
+Open PR closing #8571 after second-opinion review.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a computable, kernel-reducible `Decidable` instance for mod-`p` polynomial irreducibility backed by `Berlekamp.rabinTest`, so `example : Irreducible (toMathlibPolynomial f) := by decide +kernel` works over `F_p` using only the trusted kernel. It implements the mod-`p` half of the certifying-irreducibility SPEC requirement (#8564): the only prior instance was `Classical.decPred _`, on which `decide +kernel` gets stuck.

The new block lives outside the file's `noncomputable section`, so `fpIsIrreducible` is genuinely computable. It rejects zero inputs and otherwise returns `rabinTest` of the monic normalization `(normalizeMonic f).2` (guarded by a `dite` on monicity); `fpIsIrreducible_iff` proves it agrees with `Irreducible (toMathlibPolynomial f)`, and `instDecidableIrreducibleToMathlibPolynomial` packages that agreement. `instDecidableMonic` supplies the `Decidable (DensePoly.Monic ·)` the `Bool`-valued test branches on, reusing the existing kernel-reducible `DecidableEq (ZMod64 p)`.

The nonzero case is handled uniformly rather than splitting out the nonzero-constant case: monicity of the normalization comes from `leadingCoeff_scale_of_ne_zero_of_nonzero` (valid at degree 0, unlike `scale_inv_leadingCoeff_monic`), and `rabin_irreducible` decides irreducibility for any monic input — including a constant, where both the Rabin test and Mathlib irreducibility are `false`. The transported normalization is a unit multiple of `f` (`C (toZMod c⁻¹) * toMathlibPolynomial f`), so `irreducible_isUnit_mul` transfers irreducibility back to `f`.

Two `decide +kernel` examples over `F_2` demonstrate the positive (`X²+X+1`) and negative (`X²+1=(X+1)²`) cases in-module. The full CI-gated target `HexBerlekampZassenhausMathlib` builds green; the added lines are `sorry`/`axiom`/`native_decide`-free, and the examples' axiom cone is exactly `[propext, Classical.choice, Quot.sound]`.

Closes #8571.

🤖 Prepared with Claude Code