### PR TITLE
feat(gram-schmidt, lll): decidable instance for `independent`

### DIFF
--- a/HexGramSchmidt/Int/Core.lean
+++ b/HexGramSchmidt/Int/Core.lean
@@ -107,6 +107,14 @@ Gram-Schmidt theorem surface, stated over the Mathlib-free executable
 def independent (b : Matrix Int n m) : Prop :=
   ∀ k : Fin n, 0 < gramDet b (k.val + 1) (Nat.succ_le_of_lt k.isLt)
 
+/-- `independent` is decidable: it is a bounded conjunction of `Nat` positivity
+tests on the leading Gram determinants. When *evaluated* (compiled) this is
+efficient — each determinant is computed fraction-free (Bareiss) in cubic time.
+Note it is not reducible by `decide` in the kernel, since `gramDet` runs through
+Bareiss's well-founded recursion; use it for runtime tests, not kernel proofs. -/
+instance (b : Matrix Int n m) : Decidable (independent b) := by
+  unfold independent; infer_instance
+
 /-- Product of the squared Gram-Schmidt basis norms along the first `k` rows. -/
 @[expose]
 noncomputable def gramSchmidtNormProduct (b : Matrix Int n m) (k : Nat) (hk : k ≤ n) :

--- a/HexLLL/Lattice.lean
+++ b/HexLLL/Lattice.lean
@@ -74,6 +74,11 @@ executable leading Gram determinant. -/
 def independent (b : Matrix Int n m) : Prop :=
   GramSchmidt.Int.independent b
 
+/-- Independence is decidable (via `GramSchmidt.Int.independent`), so it can be
+tested at runtime. -/
+instance (b : Matrix Int n m) : Decidable (independent b) :=
+  inferInstanceAs (Decidable (GramSchmidt.Int.independent b))
+
 end Matrix
 
 namespace Internal

--- a/progress/2026-07-08T04-06-45Z.md
+++ b/progress/2026-07-08T04-06-45Z.md
@@ -1,0 +1,27 @@
+# Decidable instance for `Matrix.independent` / `GramSchmidt.Int.independent`
+
+## Accomplished
+Added `Decidable` instances for `GramSchmidt.Int.independent` and
+`Hex.Matrix.independent`. `independent b` unfolds to
+`∀ k : Fin n, 0 < gramDet b (k+1)`, a bounded conjunction of `Nat` positivity
+tests over a `Fintype`, so the instance follows from
+`Fintype.decidableForallFintype`.
+
+Efficient when *evaluated* (each `gramDet` is a cubic-time Bareiss determinant),
+so independence can be tested at runtime. Documented that it is **not**
+kernel-reducible by `decide`, because `gramDet` runs through Bareiss's
+well-founded recursion — a `by decide` proof of independence does not go
+through. Making `decide` work would need a kernel-reducible determinant path
+(e.g. the structural Leibniz `det`); left as a follow-up.
+
+Green: `HexGramSchmidt`, `HexLLL`, `HexConformance` (390 jobs).
+
+## Current frontier
+Part of the hex blog cleanup batch (LLL ergonomics already merged).
+
+## Next step
+Rename `lllReducedInt`; manual backports (bmod / match / .toList / arithmetic
+example) into HexManual.
+
+## Blockers
+None.


### PR DESCRIPTION
Add `Decidable` instances for `GramSchmidt.Int.independent` and `Hex.Matrix.independent`, so a basis's independence can be tested. `independent b` is `∀ k : Fin n, 0 < gramDet b (k+1)`, a bounded conjunction of `Nat` positivity tests over a `Fintype`, so the instance follows from `Fintype.decidableForallFintype`.

It is efficient when evaluated — each `gramDet` is a fraction-free (Bareiss) determinant in cubic time. It is **not** reducible by `decide` in the kernel, because `gramDet` runs through Bareiss's well-founded recursion; the docstring says so, and `native_decide` is banned. Making `decide` on independence efficient would need a kernel-reducible determinant path (e.g. the structural Leibniz `det`) and is left as a follow-up.

Green: `HexGramSchmidt`, `HexLLL`, `HexConformance` (390 jobs).

🤖 Prepared with Claude Code