### PR TITLE
perf(bz): balanced product-tree multifactor Hensel lift

### DIFF
--- a/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
+++ b/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
@@ -1458,17 +1458,37 @@ theorem factorsModP_ne_nil_of_factorsModPBerlekampForm
   rw [heq]
   simpa [List.map_eq_nil_iff] using hbl_ne
 
+/-- The Berlekamp factor product is multiplicative over list concatenation.
+Local restatement of the (private) `Hex.Berlekamp.factorProduct_append`, needed
+to relate the balanced-split halves `L`, `R` back to the whole list. -/
+private theorem factorProduct_append
+    {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
+    (xs ys : List (Hex.FpPoly p)) :
+    Hex.Berlekamp.factorProduct (xs ++ ys) =
+      Hex.Berlekamp.factorProduct xs * Hex.Berlekamp.factorProduct ys := by
+  induction xs with
+  | nil =>
+      rw [List.nil_append, Hex.Berlekamp.factorProduct_nil, Hex.FpPoly.one_mul]
+  | cons x rest ih =>
+      rw [List.cons_append, Hex.Berlekamp.factorProduct_cons,
+        Hex.Berlekamp.factorProduct_cons, ih]
+      exact (Hex.DensePoly.mul_assoc_poly x _ _).symm
+
 /-- Generalized inductive helper for the `factorsModP_coprime` discharger.
 
 For any list of factors in `FpPoly p` whose `factorProduct` divides a
 nonzero polynomial `X` with no positive-degree squared divisor, the
 recursive predicate `Hex.ZPoly.QuadraticMultifactorCoprimeSplits` holds.
 
-The recursion peels one head factor `g` off at a time:
-* `xgcd.gcd = 1` follows from the pairwise-coprime view of `g` against
-  `factorProduct rest`, identified via `modP_polyProduct_liftToZ_eq_factorProduct`.
-* The recursive tail satisfies the same divisibility-into-`X` invariant via
-  `factorProduct rest ∣ factorProduct (g :: rest) ∣ X`. -/
+The recursion follows the balanced product tree: at each non-singleton node the
+list splits into `L := take half` and `R := drop half`, and
+* `xgcd.gcd = 1` follows from the coprime view of `factorProduct L` against
+  `factorProduct R`, identified via `modP_polyProduct_liftToZ_eq_factorProduct`:
+  their `DensePoly.gcd` squares into `factorProduct (L ++ R) = factorProduct xs`,
+  hence into `X`, so the no-squared invariant forces it constant;
+* each half satisfies the same divisibility-into-`X` invariant via
+  `factorProduct L ∣ factorProduct xs ∣ X` (and symmetrically for `R`),
+  using `factorProduct_append`. -/
 private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
     {p : Nat} [Hex.ZMod64.Bounds p] [Hex.ZMod64.PrimeModulus p]
     [Lean.Grind.Field (Hex.ZMod64 p)]
@@ -1479,145 +1499,141 @@ private theorem quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared
     (xs : List (Hex.FpPoly p))
     (h_dvd : Hex.Berlekamp.factorProduct xs ∣ X) :
     Hex.ZPoly.QuadraticMultifactorCoprimeSplits p xs := by
-  induction xs with
-  | nil => exact True.intro
-  | cons g rest ih =>
-      cases rest with
-      | nil => exact True.intro
-      | cons h tail =>
-          -- The recursive predicate at `g :: h :: tail` expects
-          -- `xgcd.gcd = 1` and `QuadraticMultifactorCoprimeSplits p (h :: tail)`.
-          refine ⟨?_, ?_⟩
-          · -- `xgcd.gcd = 1` for the head split.
-            -- Unfold `normalizedXGCD` and identify the raw EEA gcd.
-            -- Reduce both `modP`-arguments to `FpPoly p` shape.
-            have hmodP_g : Hex.ZPoly.modP p (Hex.FpPoly.liftToZ g) = g :=
-              Hex.FpPoly.modP_liftToZ g
-            have hmodP_tail :
-                Hex.ZPoly.modP p
-                    (Array.polyProduct
-                      (((h :: tail).map Hex.FpPoly.liftToZ).toArray)) =
-                  Hex.Berlekamp.factorProduct (h :: tail) :=
-              modP_polyProduct_liftToZ_eq_factorProduct (h :: tail)
-            -- The raw EEA gcd is `DensePoly.gcd g (factorProduct (h :: tail))`.
-            set rawGcd : Hex.FpPoly p :=
-              Hex.DensePoly.gcd g (Hex.Berlekamp.factorProduct (h :: tail))
-              with hrawGcd_def
-            -- `normalizedXGCD.gcd = scale (lc⁻¹) rawGcd`.
-            have hnorm_def :
-                (Hex.ZPoly.normalizedXGCD p (Hex.FpPoly.liftToZ g)
-                  (Array.polyProduct
-                    (((h :: tail).map Hex.FpPoly.liftToZ).toArray))).gcd =
-                  Hex.DensePoly.scale
-                    (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd := by
-              show Hex.DensePoly.scale
-                  (Hex.DensePoly.leadingCoeff
-                    (Hex.DensePoly.xgcd
-                      (Hex.ZPoly.modP p (Hex.FpPoly.liftToZ g))
-                      (Hex.ZPoly.modP p
-                        (Array.polyProduct
-                          (((h :: tail).map Hex.FpPoly.liftToZ).toArray)))).gcd)⁻¹
-                  (Hex.DensePoly.xgcd
-                    (Hex.ZPoly.modP p (Hex.FpPoly.liftToZ g))
-                    (Hex.ZPoly.modP p
-                      (Array.polyProduct
-                        (((h :: tail).map Hex.FpPoly.liftToZ).toArray)))).gcd =
-                Hex.DensePoly.scale
-                  (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd
-              rw [hmodP_g, hmodP_tail, hrawGcd_def, Hex.DensePoly.gcd_eq_xgcd_gcd]
-            rw [hnorm_def]
-            -- The rest: show `scale (lc rawGcd)⁻¹ rawGcd = 1`.  This needs
-            -- `rawGcd` to be a nonzero constant in `FpPoly p`.
-            -- Step 1: `rawGcd² ∣ X`.
-            have hrawGcd_dvd_g : rawGcd ∣ g :=
-              Hex.DensePoly.gcd_dvd_left g (Hex.Berlekamp.factorProduct (h :: tail))
-            have hrawGcd_dvd_tail :
-                rawGcd ∣ Hex.Berlekamp.factorProduct (h :: tail) :=
-              Hex.DensePoly.gcd_dvd_right g (Hex.Berlekamp.factorProduct (h :: tail))
-            have hrawGcd_sq_dvd_prod :
-                rawGcd * rawGcd ∣ g * Hex.Berlekamp.factorProduct (h :: tail) :=
-              fpPoly_mul_dvd_mul hrawGcd_dvd_g hrawGcd_dvd_tail
-            have hcons_prod :
-                g * Hex.Berlekamp.factorProduct (h :: tail) =
-                  Hex.Berlekamp.factorProduct (g :: h :: tail) :=
-              (Hex.Berlekamp.factorProduct_cons g (h :: tail)).symm
-            have hrawGcd_sq_dvd_X : rawGcd * rawGcd ∣ X := by
-              rw [hcons_prod] at hrawGcd_sq_dvd_prod
-              exact fpPoly_dvd_trans hrawGcd_sq_dvd_prod h_dvd
-            -- Step 2: rawGcd has degree ≤ 0 by no-squared on X.
-            have hrawGcd_not_pos :
-                ¬ (0 < rawGcd.degree?.getD 0) :=
-              h_no_squared rawGcd hrawGcd_sq_dvd_X
-            -- Step 3: rawGcd ≠ 0 (via `rawGcd * rawGcd ∣ X` with `X ≠ 0`).
-            have hrawGcd_ne : rawGcd ≠ 0 := by
-              intro hraw
-              apply hX_ne
-              rcases hrawGcd_sq_dvd_X with ⟨k, hk⟩
-              rw [hraw, Hex.FpPoly.zero_mul, Hex.FpPoly.zero_mul] at hk
-              exact hk
-            -- Step 4: rawGcd.size = 1.
-            have hrawGcd_size_pos : 0 < rawGcd.size := by
-              apply Nat.pos_of_ne_zero
-              intro hsize
-              apply hrawGcd_ne
-              apply Hex.DensePoly.ext_coeff
-              intro i
-              rw [Hex.DensePoly.coeff_zero]
-              exact Hex.DensePoly.coeff_eq_zero_of_size_le rawGcd (by omega)
-            have hrawGcd_size_one : rawGcd.size = 1 := by
-              by_contra hsize_ne
-              apply hrawGcd_not_pos
-              have hsize_ge_two : 2 ≤ rawGcd.size := by omega
-              have hdeg_form : rawGcd.degree? = some (rawGcd.size - 1) := by
-                unfold Hex.DensePoly.degree?
-                have hne : rawGcd.size ≠ 0 := Nat.pos_iff_ne_zero.mp hrawGcd_size_pos
-                simp [hne]
-              rw [hdeg_form]; simp; omega
-            -- Step 5: lc rawGcd ≠ 0.
-            have hlc_ne :
-                Hex.DensePoly.leadingCoeff rawGcd ≠ (0 : Hex.ZMod64 p) :=
-              fpPoly_leadingCoeff_ne_zero_of_size_pos rawGcd hrawGcd_size_pos
-            -- Step 6: rawGcd.coeff 0 = lc rawGcd.
-            have hrawGcd_coeff_zero :
-                rawGcd.coeff 0 = Hex.DensePoly.leadingCoeff rawGcd := by
-              rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred rawGcd hrawGcd_size_pos]
-              congr 1; omega
-            -- Step 7: scale lc⁻¹ rawGcd = 1.
-            apply Hex.DensePoly.ext_coeff
-            intro n
-            have hzero_mul :
-                (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ * (0 : Hex.ZMod64 p) = 0 :=
-              Lean.Grind.Semiring.mul_zero _
-            rw [Hex.DensePoly.coeff_scale
-              (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd n hzero_mul]
-            change (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ * rawGcd.coeff n =
-              (Hex.DensePoly.C (1 : Hex.ZMod64 p)).coeff n
-            rw [Hex.DensePoly.coeff_C]
-            cases n with
-            | zero =>
-                rw [hrawGcd_coeff_zero]
-                simp
-                exact Hex.ZMod64.inv_mul_eq_one_of_prime
-                  (Hex.ZMod64.PrimeModulus.prime (p := p)) hlc_ne
-            | succ k =>
-                have hcoeff_zero : rawGcd.coeff (k + 1) = (0 : Hex.ZMod64 p) :=
-                  Hex.DensePoly.coeff_eq_zero_of_size_le rawGcd (by omega)
-                rw [hcoeff_zero, if_neg (Nat.succ_ne_zero k)]
-                exact hzero_mul
-          · -- Inductive call on `h :: tail`.
-            have hrest_dvd :
-                Hex.Berlekamp.factorProduct (h :: tail) ∣ X := by
-              have hcons_eq :
-                  Hex.Berlekamp.factorProduct (g :: h :: tail) =
-                    g * Hex.Berlekamp.factorProduct (h :: tail) :=
-                Hex.Berlekamp.factorProduct_cons g (h :: tail)
-              have htail_dvd_cons :
-                  Hex.Berlekamp.factorProduct (h :: tail) ∣
-                    Hex.Berlekamp.factorProduct (g :: h :: tail) := by
-                refine ⟨g, ?_⟩
-                rw [hcons_eq]; exact Hex.DensePoly.mul_comm_poly _ _
-              exact fpPoly_dvd_trans htail_dvd_cons h_dvd
-            exact ih hrest_dvd
+  revert h_dvd
+  induction xs using Hex.ZPoly.QuadraticMultifactorCoprimeSplits.induct (p := p) with
+  | case1 => intro _; simp only [Hex.ZPoly.QuadraticMultifactorCoprimeSplits]
+  | case2 _g => intro _; simp only [Hex.ZPoly.QuadraticMultifactorCoprimeSplits]
+  | case3 g₀ g₁ rest gs half L R ihL ihR =>
+      intro h_dvd
+      -- Balanced split of `g₀ :: g₁ :: rest` into `L ++ R` (the induct binders).
+      have happend : L ++ R = g₀ :: g₁ :: rest := List.take_append_drop half gs
+      have hfp_split :
+          Hex.Berlekamp.factorProduct (g₀ :: g₁ :: rest) =
+            Hex.Berlekamp.factorProduct L * Hex.Berlekamp.factorProduct R := by
+        conv_lhs => rw [← happend]
+        rw [factorProduct_append]
+      -- Each half's product divides `factorProduct (g₀ :: g₁ :: rest)`, hence `X`.
+      have hprod_dvd_X :
+          Hex.Berlekamp.factorProduct L * Hex.Berlekamp.factorProduct R ∣ X := by
+        rw [← hfp_split]; exact h_dvd
+      have hL_dvd_X : Hex.Berlekamp.factorProduct L ∣ X :=
+        fpPoly_dvd_trans ⟨Hex.Berlekamp.factorProduct R, hfp_split⟩ h_dvd
+      have hR_dvd_X : Hex.Berlekamp.factorProduct R ∣ X :=
+        fpPoly_dvd_trans
+          ⟨Hex.Berlekamp.factorProduct L,
+            by rw [hfp_split]; exact Hex.DensePoly.mul_comm_poly _ _⟩
+          h_dvd
+      -- Both `modP`-arguments of the split reduce to `factorProduct` shape.
+      have hmodP_L :
+          Hex.ZPoly.modP p (Array.polyProduct ((L.map Hex.FpPoly.liftToZ).toArray)) =
+            Hex.Berlekamp.factorProduct L :=
+        modP_polyProduct_liftToZ_eq_factorProduct L
+      have hmodP_R :
+          Hex.ZPoly.modP p (Array.polyProduct ((R.map Hex.FpPoly.liftToZ).toArray)) =
+            Hex.Berlekamp.factorProduct R :=
+        modP_polyProduct_liftToZ_eq_factorProduct R
+      -- The split gcd is `1`: proved for abstract `a`, `b` reducing mod `p` to
+      -- `factorProduct L`, `factorProduct R`, so `exact` matches by defeq.
+      have hgcd :
+          ∀ a b : Hex.ZPoly,
+            Hex.ZPoly.modP p a = Hex.Berlekamp.factorProduct L →
+            Hex.ZPoly.modP p b = Hex.Berlekamp.factorProduct R →
+            (Hex.ZPoly.normalizedXGCD p a b).gcd = (1 : Hex.FpPoly p) := by
+        intro a b hma hmb
+        -- The raw EEA gcd is `DensePoly.gcd (factorProduct L) (factorProduct R)`.
+        set rawGcd : Hex.FpPoly p :=
+          Hex.DensePoly.gcd (Hex.Berlekamp.factorProduct L) (Hex.Berlekamp.factorProduct R)
+          with hrawGcd_def
+        -- `normalizedXGCD.gcd = scale (lc⁻¹) rawGcd`.
+        have hnorm_def :
+            (Hex.ZPoly.normalizedXGCD p a b).gcd =
+              Hex.DensePoly.scale
+                (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd := by
+          show Hex.DensePoly.scale
+              (Hex.DensePoly.leadingCoeff
+                (Hex.DensePoly.xgcd
+                  (Hex.ZPoly.modP p a) (Hex.ZPoly.modP p b)).gcd)⁻¹
+              (Hex.DensePoly.xgcd
+                (Hex.ZPoly.modP p a) (Hex.ZPoly.modP p b)).gcd =
+            Hex.DensePoly.scale
+              (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd
+          rw [hma, hmb, hrawGcd_def, Hex.DensePoly.gcd_eq_xgcd_gcd]
+        rw [hnorm_def]
+        -- The rest: show `scale (lc rawGcd)⁻¹ rawGcd = 1`.  This needs
+        -- `rawGcd` to be a nonzero constant in `FpPoly p`.
+        -- Step 1: `rawGcd² ∣ X`.
+        have hrawGcd_dvd_L : rawGcd ∣ Hex.Berlekamp.factorProduct L :=
+          Hex.DensePoly.gcd_dvd_left _ _
+        have hrawGcd_dvd_R : rawGcd ∣ Hex.Berlekamp.factorProduct R :=
+          Hex.DensePoly.gcd_dvd_right _ _
+        have hrawGcd_sq_dvd_prod :
+            rawGcd * rawGcd ∣
+              Hex.Berlekamp.factorProduct L * Hex.Berlekamp.factorProduct R :=
+          fpPoly_mul_dvd_mul hrawGcd_dvd_L hrawGcd_dvd_R
+        have hrawGcd_sq_dvd_X : rawGcd * rawGcd ∣ X :=
+          fpPoly_dvd_trans hrawGcd_sq_dvd_prod hprod_dvd_X
+        -- Step 2: rawGcd has degree ≤ 0 by no-squared on X.
+        have hrawGcd_not_pos :
+            ¬ (0 < rawGcd.degree?.getD 0) :=
+          h_no_squared rawGcd hrawGcd_sq_dvd_X
+        -- Step 3: rawGcd ≠ 0 (via `rawGcd * rawGcd ∣ X` with `X ≠ 0`).
+        have hrawGcd_ne : rawGcd ≠ 0 := by
+          intro hraw
+          apply hX_ne
+          rcases hrawGcd_sq_dvd_X with ⟨k, hk⟩
+          rw [hraw, Hex.FpPoly.zero_mul, Hex.FpPoly.zero_mul] at hk
+          exact hk
+        -- Step 4: rawGcd.size = 1.
+        have hrawGcd_size_pos : 0 < rawGcd.size := by
+          apply Nat.pos_of_ne_zero
+          intro hsize
+          apply hrawGcd_ne
+          apply Hex.DensePoly.ext_coeff
+          intro i
+          rw [Hex.DensePoly.coeff_zero]
+          exact Hex.DensePoly.coeff_eq_zero_of_size_le rawGcd (by omega)
+        have hrawGcd_size_one : rawGcd.size = 1 := by
+          by_contra hsize_ne
+          apply hrawGcd_not_pos
+          have hsize_ge_two : 2 ≤ rawGcd.size := by omega
+          have hdeg_form : rawGcd.degree? = some (rawGcd.size - 1) := by
+            unfold Hex.DensePoly.degree?
+            have hne : rawGcd.size ≠ 0 := Nat.pos_iff_ne_zero.mp hrawGcd_size_pos
+            simp [hne]
+          rw [hdeg_form]; simp; omega
+        -- Step 5: lc rawGcd ≠ 0.
+        have hlc_ne :
+            Hex.DensePoly.leadingCoeff rawGcd ≠ (0 : Hex.ZMod64 p) :=
+          fpPoly_leadingCoeff_ne_zero_of_size_pos rawGcd hrawGcd_size_pos
+        -- Step 6: rawGcd.coeff 0 = lc rawGcd.
+        have hrawGcd_coeff_zero :
+            rawGcd.coeff 0 = Hex.DensePoly.leadingCoeff rawGcd := by
+          rw [Hex.FpPoly.leadingCoeff_eq_coeff_pred rawGcd hrawGcd_size_pos]
+          congr 1; omega
+        -- Step 7: scale lc⁻¹ rawGcd = 1.
+        apply Hex.DensePoly.ext_coeff
+        intro n
+        have hzero_mul :
+            (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ * (0 : Hex.ZMod64 p) = 0 :=
+          Lean.Grind.Semiring.mul_zero _
+        rw [Hex.DensePoly.coeff_scale
+          (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ rawGcd n hzero_mul]
+        change (Hex.DensePoly.leadingCoeff rawGcd)⁻¹ * rawGcd.coeff n =
+          (Hex.DensePoly.C (1 : Hex.ZMod64 p)).coeff n
+        rw [Hex.DensePoly.coeff_C]
+        cases n with
+        | zero =>
+            rw [hrawGcd_coeff_zero]
+            simp
+            exact Hex.ZMod64.inv_mul_eq_one_of_prime
+              (Hex.ZMod64.PrimeModulus.prime (p := p)) hlc_ne
+        | succ k =>
+            have hcoeff_zero : rawGcd.coeff (k + 1) = (0 : Hex.ZMod64 p) :=
+              Hex.DensePoly.coeff_eq_zero_of_size_le rawGcd (by omega)
+            rw [hcoeff_zero, if_neg (Nat.succ_ne_zero k)]
+            exact hzero_mul
+      rw [Hex.ZPoly.QuadraticMultifactorCoprimeSplits]
+      exact ⟨hgcd _ _ hmodP_L hmodP_R, ihL hL_dvd_X, ihR hR_dvd_X⟩
 
 set_option maxHeartbeats 400000 in
 /-- Discharge of the coprime-splits boundary premise on

--- a/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
+++ b/HexBerlekampZassenhausMathlib/HenselFactorProps.lean
@@ -1640,7 +1640,7 @@ set_option maxHeartbeats 400000 in
 `Hex.ZPoly.QuadraticMultifactorLiftInvariant_of_choosePrimeData`: given the
 `factorsModPBerlekampForm` invariant (which records that `primeData.factorsModP`
 is the Berlekamp factor array of the monic modular image of the input)
-together with a successful `isGoodPrime` check, the recursive sequential-split
+together with a successful `isGoodPrime` check, the recursive balanced-split
 coprime predicate `QuadraticMultifactorCoprimeSplits` holds on the stored
 factor list.
 

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -17,7 +17,7 @@ Quadratic multifactor Hensel lifting.
 This module exposes `multifactorLiftQuadratic`, the production multifactor
 Hensel lifter named on equal footing with `multifactorLift` in
 `hex-hensel`. The implementation reuses the per-step quadratic primitive
-`quadraticHenselStep` inside a sequential split tree that mirrors
+`quadraticHenselStep` inside a balanced product tree that mirrors
 `multifactorLift`. Iteration to the requested precision `p^k` is handled
 by a doubling loop on the Bezout-witnessed `QuadraticLiftResult`.
 
@@ -879,7 +879,7 @@ monic. The quadratic doubling loop preserves `Monic acc.g` via
 
 Consumed (alongside `henselLiftQuadratic_h_monic`) by
 `multifactorLiftQuadratic_each_monic` to discharge per-output monicness inside
-the sequential split tree. -/
+the balanced split tree. -/
 theorem henselLiftQuadratic_g_monic
     (p k : Nat) [ZMod64.Bounds p]
     (f g h s t : ZPoly)
@@ -909,7 +909,7 @@ when `f` is monic. Derived from the cofactor monic lemma
 
 Consumed (alongside `henselLiftQuadratic_g_monic`) by
 `multifactorLiftQuadratic_each_monic` to discharge per-output monicness inside
-the sequential split tree. -/
+the balanced split tree. -/
 theorem henselLiftQuadratic_h_monic
     (p k : Nat) [ZMod64.Bounds p]
     (f g h s t : ZPoly)

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -81,34 +81,49 @@ def henselLiftQuadratic
     s := ZPoly.reduceModPow lifted.s p k
     t := ZPoly.reduceModPow lifted.t p k }
 
-/-- Recursive list-shape worker behind `multifactorLiftQuadratic`. At each
-non-singleton step it lifts the head factor `g` against the running
-complementary product `Array.polyProduct rest.toArray` via
-`henselLiftQuadratic`, and recurses with `lifted.h` as the new target on
-`rest`. The singleton case returns the input reduced modulo `p^k`; the
-empty case returns the empty array. Mirrors `multifactorLiftList` in
-`HexHensel.Multifactor` but uses the quadratic doubling primitive. -/
+/-- Recursive list-shape worker behind `multifactorLiftQuadratic`, shaped as a
+balanced product tree. At each non-singleton step it splits the factor list in
+half, lifts the product of the left half `g` against the product of the right
+half `h` via `henselLiftQuadratic`, and recurses into each half with the lifted
+sub-products as the new targets. The two recursive outputs are concatenated
+`L`-then-`R`, so the returned array stays in the original factor order. The
+singleton case returns the input reduced modulo `p^k`; the empty case returns
+the empty array.
+
+This is an `O(log r)`-depth / `O(n log r)`-total-split-degree reshape of the
+sequential `O(n·r)` peel it replaces; every output is the same reduced value
+because the Hensel lift is unique modulo `p^k`. -/
 @[expose]
 def multifactorLiftQuadraticList
     (p k : Nat) [ZMod64.Bounds p]
     (f : ZPoly) : List ZPoly → Array ZPoly
   | [] => #[]
   | [_g] => #[ZPoly.reduceModPow f p k]
-  | g :: rest =>
-      let restFactors := rest.toArray
-      let h := Array.polyProduct restFactors
+  | g₀ :: g₁ :: rest =>
+      let gs := g₀ :: g₁ :: rest
+      let half := gs.length / 2
+      let L := gs.take half
+      let R := gs.drop half
+      let g := Array.polyProduct L.toArray
+      let h := Array.polyProduct R.toArray
       let xgcd := ZPoly.normalizedXGCD p g h
       let s := FpPoly.liftToZ xgcd.left
       let t := FpPoly.liftToZ xgcd.right
       let lifted := henselLiftQuadratic p k f g h s t
-      #[lifted.g] ++ multifactorLiftQuadraticList p k lifted.h rest
+      multifactorLiftQuadraticList p k lifted.g L ++
+        multifactorLiftQuadraticList p k lifted.h R
+  termination_by factors => factors.length
+  decreasing_by
+    all_goals
+      simp only [List.length_take, List.length_drop, List.length_cons]
+      omega
 
 /--
 Quadratic multifactor Hensel lift.
 
 Lifts an ordered array of factors of `f` from congruence modulo `p` to
 congruence modulo `p^k` using the doubling step `quadraticHenselStep`
-inside the same sequential split tree as `multifactorLift`.
+inside a balanced product tree.
 -/
 @[expose]
 def multifactorLiftQuadratic
@@ -569,17 +584,20 @@ theorem henselLiftQuadratic_bezout_spec
       hbez_loop_k
 
 /--
-Recursive preconditions required by the sequential quadratic multifactor lift.
+Recursive preconditions required by the balanced quadratic multifactor lift.
 
-In the `g :: h :: tail` arm, the two conjuncts are exactly the inputs
-`henselLiftQuadratic_spec` consumes for the binary split of `g` against the
-running complementary product `Array.polyProduct (h :: tail).toArray`,
-followed by the recursive precondition for the lifted complement:
+In the non-singleton arm the factor list is split in half; the three conjuncts
+are exactly the inputs `henselLiftQuadratic_spec` consumes for the binary split
+of the left product `g := Array.polyProduct L.toArray` against the right product
+`h := Array.polyProduct R.toArray`, followed by the recursive preconditions for
+each lifted sub-product:
 
 1. `QuadraticLiftLoopInvariant` at modulus `p` — initial state package
    (product congruence, Bezout, monicness) for the binary doubling loop;
-2. `QuadraticMultifactorLiftInvariant` for the recursive tail with
-   `lifted.h` as the new target.
+2. `QuadraticMultifactorLiftInvariant` for the left half with `lifted.g`
+   as the new target;
+3. `QuadraticMultifactorLiftInvariant` for the right half with `lifted.h`
+   as the new target.
 
 The base cases impose the trivial obligations: `congr 1 f (p ^ k)` for the
 empty list (vacuous product) and no preconditions for a singleton.
@@ -590,23 +608,36 @@ def QuadraticMultifactorLiftInvariant
     (f : ZPoly) : List ZPoly → Prop
   | [] => ZPoly.congr 1 f (p ^ k)
   | [_g] => True
-  | g :: rest =>
-      let h := Array.polyProduct rest.toArray
+  | g₀ :: g₁ :: rest =>
+      let gs := g₀ :: g₁ :: rest
+      let half := gs.length / 2
+      let L := gs.take half
+      let R := gs.drop half
+      let g := Array.polyProduct L.toArray
+      let h := Array.polyProduct R.toArray
       let xgcd := normalizedXGCD p g h
       let s := FpPoly.liftToZ xgcd.left
       let t := FpPoly.liftToZ xgcd.right
       let lifted := henselLiftQuadratic p k f g h s t
       QuadraticLiftLoopInvariant p f { g, h, s, t } ∧
-        QuadraticMultifactorLiftInvariant p k lifted.h rest
+        QuadraticMultifactorLiftInvariant p k lifted.g L ∧
+          QuadraticMultifactorLiftInvariant p k lifted.h R
+  termination_by factors => factors.length
+  decreasing_by
+    all_goals
+      simp only [List.length_take, List.length_drop, List.length_cons]
+      omega
 
 /--
 The split-coprimality boundary data needed to initialise every quadratic split
-in the sequential multifactor tree from factors modulo `p`.
+in the balanced multifactor tree from factors modulo `p`.
 
-In the `g :: h :: tail` arm the requirement is that the normalised XGCD of
-`g` against the lifted complementary product `Array.polyProduct ((h :: tail).map FpPoly.liftToZ).toArray`
-returns `gcd = 1` in `FpPoly p`, and that the same coprimality holds
-recursively on the tail. The base cases (empty list, singleton) are vacuous.
+In the non-singleton arm the factor list is split in half and the requirement is
+that the normalised XGCD of the left lifted product
+`Array.polyProduct ((L.map FpPoly.liftToZ).toArray)` against the right lifted
+product `Array.polyProduct ((R.map FpPoly.liftToZ).toArray)` returns `gcd = 1`
+in `FpPoly p`, and that the same coprimality holds recursively on each half.
+The base cases (empty list, singleton) are vacuous.
 
 Consumed by `quadraticMultifactorLiftInvariant_of_factorsModP`: the
 per-split `gcd = 1` lifts via `normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one`
@@ -617,11 +648,22 @@ def QuadraticMultifactorCoprimeSplits
     (p : Nat) [ZMod64.Bounds p] : List (FpPoly p) → Prop
   | [] => True
   | [_g] => True
-  | g :: rest =>
-      let h := Array.polyProduct ((rest.map FpPoly.liftToZ).toArray)
-      let xgcd := normalizedXGCD p (FpPoly.liftToZ g) h
+  | g₀ :: g₁ :: rest =>
+      let gs := g₀ :: g₁ :: rest
+      let half := gs.length / 2
+      let L := gs.take half
+      let R := gs.drop half
+      let g := Array.polyProduct ((L.map FpPoly.liftToZ).toArray)
+      let h := Array.polyProduct ((R.map FpPoly.liftToZ).toArray)
+      let xgcd := normalizedXGCD p g h
       xgcd.gcd = (1 : FpPoly p) ∧
-        QuadraticMultifactorCoprimeSplits p rest
+        QuadraticMultifactorCoprimeSplits p L ∧
+          QuadraticMultifactorCoprimeSplits p R
+  termination_by factors => factors.length
+  decreasing_by
+    all_goals
+      simp only [List.length_take, List.length_drop, List.length_cons]
+      omega
 
 /-- Induction-on-`factors` correctness statement feeding
 `multifactorLiftQuadratic_spec`: the ordered product of the lifted
@@ -638,57 +680,23 @@ private theorem multifactorLiftQuadraticList_spec
       (Array.polyProduct (multifactorLiftQuadraticList p k f factors))
       f
       (p ^ k) := by
-  induction factors generalizing f with
-  | nil =>
-      simpa [multifactorLiftQuadraticList, Array.polyProduct,
-        QuadraticMultifactorLiftInvariant] using hinv
-  | cons g rest ih =>
-      cases rest with
-      | nil =>
-          have hpow : 0 < p ^ k := Nat.pow_pos (ZMod64.Bounds.pPos (p := p))
-          simpa [multifactorLiftQuadraticList, polyProduct_singleton,
-            DensePoly.mul_one_right_poly] using
-            ZPoly.congr_reduceModPow f p k hpow
-      | cons h tail =>
-          let restFactors := (h :: tail).toArray
-          let splitProduct := Array.polyProduct restFactors
-          let xgcd := normalizedXGCD p g splitProduct
-          let s := FpPoly.liftToZ xgcd.left
-          let t := FpPoly.liftToZ xgcd.right
-          let lifted := henselLiftQuadratic p k f g splitProduct s t
-          rcases hinv with ⟨hstart, htail⟩
-          have htailCongr :
-              ZPoly.congr
-                (Array.polyProduct
-                  (multifactorLiftQuadraticList p k lifted.h (h :: tail)))
-                lifted.h
-                (p ^ k) := by
-            exact ih lifted.h htail
-          have hsplit :
-              ZPoly.congr (lifted.g * lifted.h) f (p ^ k) := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-              henselLiftQuadratic_spec p k f g splitProduct s t hk hp hstart
-          have hprod :
-              ZPoly.congr
-                (lifted.g *
-                  Array.polyProduct
-                    (multifactorLiftQuadraticList p k lifted.h (h :: tail)))
-                (lifted.g * lifted.h)
-                (p ^ k) := by
-            exact ZPoly.congr_mul _ _ _ _ (p ^ k)
-              (ZPoly.congr_refl lifted.g (p ^ k))
-              htailCongr
-          have hcombined :
-              ZPoly.congr
-                (lifted.g *
-                  Array.polyProduct
-                    (multifactorLiftQuadraticList p k lifted.h (h :: tail)))
-                f
-                (p ^ k) :=
-            ZPoly.congr_trans _ _ _ (p ^ k) hprod hsplit
-          simpa [multifactorLiftQuadraticList, restFactors, splitProduct, xgcd,
-            s, t, lifted, polyProduct_singleton_append,
-            DensePoly.mul_one_right_poly] using hcombined
+  induction f, factors using multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f =>
+      rw [multifactorLiftQuadraticList, polyProduct_empty]
+      rwa [QuadraticMultifactorLiftInvariant] at hinv
+  | case2 f _g =>
+      rw [multifactorLiftQuadraticList, polyProduct_singleton]
+      exact ZPoly.congr_reduceModPow f p k (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
+  | case3 f g₀ g₁ rest =>
+      rename_i ihL ihR
+      simp only [QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have hcL := ihL hinvL
+      have hcR := ihR hinvR
+      rw [multifactorLiftQuadraticList, polyProduct_append]
+      exact ZPoly.congr_trans _ _ _ (p ^ k)
+        (ZPoly.congr_mul _ _ _ _ (p ^ k) hcL hcR)
+        (henselLiftQuadratic_spec p k f _ _ _ _ hk hp hstart)
 
 /--
 The product of the lifted factors is congruent to `f` modulo `p^k`,
@@ -974,6 +982,48 @@ theorem henselLiftQuadratic_h_monic
       hpk_gt_one hcongr_form hg_monic_lifted hf_monic hh_red_ne_zero
   rw [hh_eq]; exact hmonic_reduce
 
+/-- The constant polynomial `1` is monic. -/
+private theorem monic_one : DensePoly.Monic (1 : ZPoly) := by
+  unfold DensePoly.Monic; simp
+
+/-- A product of monic integer polynomials is monic. -/
+private theorem monic_mul {a b : ZPoly}
+    (ha : DensePoly.Monic a) (hb : DensePoly.Monic b) :
+    DensePoly.Monic (a * b) := by
+  have ha0 : a ≠ 0 := by
+    intro h; rw [h] at ha; simp [DensePoly.Monic, DensePoly.leadingCoeff_zero] at ha
+  have hb0 : b ≠ 0 := by
+    intro h; rw [h] at hb; simp [DensePoly.Monic, DensePoly.leadingCoeff_zero] at hb
+  unfold DensePoly.Monic at *
+  rw [leadingCoeff_mul_of_nonzero a b ha0 hb0, ha, hb, Int.one_mul]
+
+/-- The `Array.polyProduct` of a list of monic integer polynomials is monic.
+Needed because a balanced split multiplies a whole half of the factor list into
+each side of the binary Hensel step, so the leading factor is a product rather
+than a single input factor. -/
+private theorem monic_polyProduct_toArray (l : List ZPoly)
+    (h : ∀ g ∈ l, DensePoly.Monic g) :
+    DensePoly.Monic (Array.polyProduct l.toArray) := by
+  induction l with
+  | nil => simpa using monic_one
+  | cons g rest ih =>
+      rw [polyProduct_cons_toArray]
+      exact monic_mul (h g (by simp)) (ih (fun q hq => h q (by simp [hq])))
+
+/-- The lifted product splits across a list concatenation: multiplying the
+lifted products of two halves equals the lifted product of the concatenation.
+This is the algebraic content that lets a balanced split's two sub-products
+recombine to the whole modular product. -/
+private theorem polyProduct_map_liftToZ_append
+    (p : Nat) [ZMod64.Bounds p] (L R : List (FpPoly p)) :
+    Array.polyProduct ((L.map FpPoly.liftToZ).toArray) *
+      Array.polyProduct ((R.map FpPoly.liftToZ).toArray) =
+    Array.polyProduct (((L ++ R).map FpPoly.liftToZ).toArray) := by
+  rw [List.map_append,
+    show ((L.map FpPoly.liftToZ ++ R.map FpPoly.liftToZ).toArray)
+        = (L.map FpPoly.liftToZ).toArray ++ (R.map FpPoly.liftToZ).toArray from by simp,
+    polyProduct_append]
+
 /--
 Build the recursive quadratic multifactor lift invariant from the natural
 mod-`p` boundary facts. The caller supplies, for the list of `FpPoly p`
@@ -1009,78 +1059,55 @@ theorem quadraticMultifactorLiftInvariant_of_factorsModP
     (hnonempty : factors ≠ []) :
     QuadraticMultifactorLiftInvariant p k f
       (factors.map FpPoly.liftToZ) := by
-  induction factors generalizing f with
-  | nil =>
-      exact (hnonempty rfl).elim
-  | cons g rest ih =>
-      cases rest with
-      | nil =>
-          simp [QuadraticMultifactorLiftInvariant]
-      | cons h tail =>
-          let restFactorsFp : List (FpPoly p) := h :: tail
-          let restFactorsZ : List ZPoly := restFactorsFp.map FpPoly.liftToZ
-          let splitProduct := Array.polyProduct restFactorsZ.toArray
-          let xgcd := normalizedXGCD p (FpPoly.liftToZ g) splitProduct
-          let s := FpPoly.liftToZ xgcd.left
-          let t := FpPoly.liftToZ xgcd.right
-          let lifted := henselLiftQuadratic p k f (FpPoly.liftToZ g)
-            splitProduct s t
-          have hprod_split :
-              ZPoly.congr (FpPoly.liftToZ g * splitProduct) f p := by
-            simpa [restFactorsFp, restFactorsZ, splitProduct,
-              polyProduct_cons_toArray] using hproduct_mod_p
-          have hcoprime_split :
-              xgcd.gcd = (1 : FpPoly p) := by
-            simpa [QuadraticMultifactorCoprimeSplits, restFactorsFp,
-              restFactorsZ, splitProduct, xgcd] using hcoprime.1
-          have hbezout :
-              ZPoly.congr (s * FpPoly.liftToZ g + t * splitProduct) 1 p := by
-            simpa [s, t, xgcd] using
-              normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one
-                p (FpPoly.liftToZ g) splitProduct hcoprime_split
-          have hg_monic : DensePoly.Monic (FpPoly.liftToZ g) :=
-            FpPoly.monic_liftToZ_of_monic g hp
-              (hfactors_monic g (by simp))
-          have hstart :
-              QuadraticLiftLoopInvariant p f
-                { g := FpPoly.liftToZ g, h := splitProduct, s := s, t := t } :=
-            QuadraticLiftLoopInvariant.of_product_bezout_monic
-              hprod_split hbezout hg_monic
-          have hh_congr :
-              ZPoly.congr lifted.h splitProduct p := by
-            simpa [lifted, splitProduct, xgcd, s, t] using
-              henselLiftQuadratic_h_congr_mod_base p k f
-                (FpPoly.liftToZ g) splitProduct s t hk hp hstart
-          have htail_product :
-              ZPoly.congr
-                (Array.polyProduct
-                  (((h :: tail).map FpPoly.liftToZ).toArray))
-                lifted.h p := by
-            simpa [restFactorsFp, restFactorsZ, splitProduct] using
-              ZPoly.congr_symm lifted.h splitProduct p hh_congr
-          have hh_monic : DensePoly.Monic lifted.h := by
-            simpa [lifted, splitProduct, xgcd, s, t] using
-              henselLiftQuadratic_h_monic p k f (FpPoly.liftToZ g)
-                splitProduct s t hk hp hf_monic hstart
-          have htail_monic :
-              ∀ g' ∈ (h :: tail), DensePoly.Monic g' := by
-            intro g' hg'
-            exact hfactors_monic g' (by simp [hg'])
-          have htail_coprime :
-              QuadraticMultifactorCoprimeSplits p (h :: tail) := by
-            simpa [QuadraticMultifactorCoprimeSplits, restFactorsFp,
-              restFactorsZ, splitProduct, xgcd] using hcoprime.2
-          have htail_nonempty : (h :: tail) ≠ [] := by simp
-          have htail_inv :
-              QuadraticMultifactorLiftInvariant p k lifted.h
-                ((h :: tail).map FpPoly.liftToZ) :=
-            ih lifted.h hh_monic htail_monic htail_product htail_coprime
-              htail_nonempty
-          exact ⟨by
-            simpa [restFactorsFp, restFactorsZ, splitProduct, xgcd, s, t,
-              lifted] using hstart, by
-            simpa [restFactorsFp, restFactorsZ, splitProduct, xgcd, s, t,
-              lifted] using htail_inv⟩
+  induction factors using QuadraticMultifactorCoprimeSplits.induct (p := p)
+      generalizing f with
+  | case1 => exact absurd rfl hnonempty
+  | case2 g => simp [QuadraticMultifactorLiftInvariant]
+  | case3 g₀ g₁ rest gs half L R ihL ihR =>
+      simp only [QuadraticMultifactorCoprimeSplits] at hcoprime
+      obtain ⟨hgcd, hcopL, hcopR⟩ := hcoprime
+      simp only [List.map_cons]
+      rw [QuadraticMultifactorLiftInvariant]
+      simp only [← List.map_cons, List.length_map, ← List.map_take, ← List.map_drop]
+      have hLmonic :
+          ∀ x ∈ (List.take ((g₀ :: g₁ :: rest).length / 2)
+              (g₀ :: g₁ :: rest)).map FpPoly.liftToZ, DensePoly.Monic x := by
+        intro x hx; rw [List.mem_map] at hx
+        obtain ⟨g, hgL, rfl⟩ := hx
+        exact FpPoly.monic_liftToZ_of_monic g hp
+          (hfactors_monic g (List.mem_of_mem_take hgL))
+      have hprod : ZPoly.congr
+          (Array.polyProduct ((List.take ((g₀ :: g₁ :: rest).length / 2)
+                (g₀ :: g₁ :: rest)).map FpPoly.liftToZ).toArray *
+            Array.polyProduct ((List.drop ((g₀ :: g₁ :: rest).length / 2)
+                (g₀ :: g₁ :: rest)).map FpPoly.liftToZ).toArray) f p := by
+        rw [polyProduct_map_liftToZ_append, List.take_append_drop]
+        exact hproduct_mod_p
+      have hbez := normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one p _ _ hgcd
+      have hstart := QuadraticLiftLoopInvariant.of_product_bezout_monic hprod hbez
+        (monic_polyProduct_toArray _ hLmonic)
+      refine ⟨hstart, ?_, ?_⟩
+      · refine ihL _ (henselLiftQuadratic_g_monic p k f _ _ _ _ hk hp hstart)
+          (fun g hg => hfactors_monic g (List.mem_of_mem_take hg))
+          (ZPoly.congr_symm _ _ _
+            (henselLiftQuadratic_g_congr_mod_base p k f _ _ _ _ hk hp hstart))
+          hcopL ?_
+        show List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest) ≠ []
+        apply List.ne_nil_of_length_pos
+        simp only [List.length_take, List.length_cons]; omega
+      · refine ihR _ (henselLiftQuadratic_h_monic p k f _ _ _ _ hk hp hf_monic hstart)
+          (fun g hg => hfactors_monic g (List.mem_of_mem_drop hg))
+          (ZPoly.congr_symm _ _ _
+            (henselLiftQuadratic_h_congr_mod_base p k f _ _ _ _ hk hp hstart))
+          hcopR ?_
+        show List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest) ≠ []
+        apply List.ne_nil_of_length_pos
+        simp only [List.length_drop, List.length_cons]; omega
+
+/-- The lengths of a list's `take`/`drop` split sum to the whole length. -/
+private theorem length_take_add_drop {α : Type} (l : List α) (n : Nat) :
+    (l.take n).length + (l.drop n).length = l.length := by
+  simp only [List.length_take, List.length_drop]; omega
 
 /-- Output length of `multifactorLiftQuadraticList` matches the input list length.
 This is the structural fact used by indexed per-output statements such as
@@ -1088,26 +1115,13 @@ This is the structural fact used by indexed per-output statements such as
 private theorem multifactorLiftQuadraticList_toList_length
     (p k : Nat) [ZMod64.Bounds p] (f : ZPoly) (factors : List ZPoly) :
     (multifactorLiftQuadraticList p k f factors).toList.length = factors.length := by
-  induction factors generalizing f with
-  | nil => simp [multifactorLiftQuadraticList]
-  | cons g rest ih =>
-      cases rest with
-      | nil => simp [multifactorLiftQuadraticList]
-      | cons h tail =>
-          let restFactors := (h :: tail).toArray
-          let splitProduct := Array.polyProduct restFactors
-          let xgcd := normalizedXGCD p g splitProduct
-          let s := FpPoly.liftToZ xgcd.left
-          let t := FpPoly.liftToZ xgcd.right
-          let lifted := henselLiftQuadratic p k f g splitProduct s t
-          have hexpand :
-              (multifactorLiftQuadraticList p k f (g :: h :: tail)).toList =
-                lifted.g ::
-                  (multifactorLiftQuadraticList p k lifted.h (h :: tail)).toList := by
-            simp [multifactorLiftQuadraticList, restFactors, splitProduct,
-              xgcd, s, t, lifted]
-          rw [hexpand]
-          simp [ih lifted.h]
+  induction f, factors using multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => simp [multifactorLiftQuadraticList]
+  | case2 f _g => simp [multifactorLiftQuadraticList]
+  | case3 f g₀ g₁ rest =>
+      rename_i ihL ihR
+      rw [multifactorLiftQuadraticList, Array.toList_append, List.length_append, ihL, ihR]
+      exact length_take_add_drop _ _
 
 /-- The `multifactorLiftQuadratic` output has one entry per input factor.
 Used by the Mathlib-side injectivity wrapper to relate output array
@@ -1135,6 +1149,22 @@ under the trivial split `f = f * 1`. -/
     multifactorLiftQuadratic p k f #[g] = #[ZPoly.reduceModPow f p k] := by
   simp [multifactorLiftQuadratic, multifactorLiftQuadraticList]
 
+/-- Per-index congruence transports across a list concatenation, given that the
+output/input prefixes have equal length. This is the index-bookkeeping surface
+for the balanced tree's `L`-then-`R` output split. -/
+private theorem congr_getD_append (p : Nat) (o1 o2 f1 f2 : List ZPoly)
+    (hlen : o1.length = f1.length)
+    (h1 : ∀ (i : Nat), ZPoly.congr (o1[i]?.getD 0) (f1[i]?.getD 0) p)
+    (h2 : ∀ (i : Nat), ZPoly.congr (o2[i]?.getD 0) (f2[i]?.getD 0) p) :
+    ∀ (i : Nat), ZPoly.congr ((o1 ++ o2)[i]?.getD 0) ((f1 ++ f2)[i]?.getD 0) p := by
+  intro i
+  by_cases hi : i < o1.length
+  · rw [List.getElem?_append_left hi, List.getElem?_append_left (hlen ▸ hi)]
+    exact h1 i
+  · rw [List.getElem?_append_right (Nat.le_of_not_lt hi),
+        List.getElem?_append_right (hlen ▸ Nat.le_of_not_lt hi), hlen]
+    exact h2 (i - f1.length)
+
 /-- Helper: list-level per-output mod-`p` preservation, stated via `getD 0` to
 avoid index-proof motive issues. Each entry of
 `(multifactorLiftQuadraticList p k f factors).toList` is congruent modulo `p`
@@ -1152,86 +1182,40 @@ private theorem multifactorLiftQuadraticList_each_congr_mod_base
       ZPoly.congr
         ((multifactorLiftQuadraticList p k f factors).toList[i]?.getD 0)
         (factors[i]?.getD 0) p := by
-  induction factors generalizing f with
-  | nil =>
+  induction f, factors using multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => intro i; rw [multifactorLiftQuadraticList]; simp; exact ZPoly.congr_refl 0 p
+  | case2 f _g =>
       intro i
-      simp [multifactorLiftQuadraticList]
-      exact ZPoly.congr_refl 0 p
-  | cons g rest ih =>
-      cases rest with
-      | nil =>
-          intro i
-          have hsingleton :
-              (multifactorLiftQuadraticList p k f [g]).toList =
-                [ZPoly.reduceModPow f p k] := by
-            simp [multifactorLiftQuadraticList]
-          rw [hsingleton]
-          match i with
-          | 0 =>
-              simp only [List.getElem?_cons_zero, Option.getD_some]
-              have hprod_g : ZPoly.congr g f p := by
-                have hpprod : Array.polyProduct [g].toArray = g := by
-                  simp [Array.polyProduct]
-                rw [hpprod] at hproduct
-                exact hproduct
-              have hreduce :
-                  ZPoly.congr (ZPoly.reduceModPow f p k) f p := by
-                have hreduce_pk : ZPoly.congr (ZPoly.reduceModPow f p k) f (p ^ k) :=
-                  ZPoly.congr_reduceModPow f p k (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
-                have hreduce_p : ZPoly.congr (ZPoly.reduceModPow f p k) f (p ^ 1) :=
-                  congr_of_pow_le p 1 k _ _ hk hreduce_pk
-                simpa [Nat.pow_one] using hreduce_p
-              exact ZPoly.congr_trans _ _ _ p hreduce (ZPoly.congr_symm _ _ _ hprod_g)
-          | Nat.succ i' =>
-              simp
-              exact ZPoly.congr_refl 0 p
-      | cons h tail =>
-          intro i
-          rcases hinv with ⟨hstart, htail⟩
-          let restFactors := (h :: tail).toArray
-          let splitProduct := Array.polyProduct restFactors
-          let xgcd := normalizedXGCD p g splitProduct
-          let s := FpPoly.liftToZ xgcd.left
-          let t := FpPoly.liftToZ xgcd.right
-          let lifted := henselLiftQuadratic p k f g splitProduct s t
-          have hstart' :
-              QuadraticLiftLoopInvariant p f { g, h := splitProduct, s, t } := by
-            simpa [restFactors, splitProduct, xgcd, s, t] using hstart
-          have htail' :
-              QuadraticMultifactorLiftInvariant p k lifted.h (h :: tail) := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using htail
-          have hh_monic : DensePoly.Monic lifted.h := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-              henselLiftQuadratic_h_monic p k f g splitProduct s t hk hp hf_monic hstart'
-          have htail_factors_monic :
-              ∀ q ∈ (h :: tail), DensePoly.Monic q := by
-            intro q hq
-            exact hfactors_monic q (by simp [hq])
-          have hh_congr_p : ZPoly.congr lifted.h splitProduct p := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-              henselLiftQuadratic_h_congr_mod_base p k f g splitProduct s t hk hp hstart'
-          have htail_product :
-              ZPoly.congr (Array.polyProduct (h :: tail).toArray) lifted.h p :=
-            ZPoly.congr_symm _ _ _ hh_congr_p
-          have ihtail :=
-            ih lifted.h hh_monic htail_factors_monic htail' htail_product
-          have hexpand :
-              (multifactorLiftQuadraticList p k f (g :: h :: tail)).toList =
-                lifted.g ::
-                  (multifactorLiftQuadraticList p k lifted.h (h :: tail)).toList := by
-            simp [multifactorLiftQuadraticList, restFactors, splitProduct,
-              xgcd, s, t, lifted]
-          rw [hexpand]
-          match i with
-          | 0 =>
-              simp only [List.getElem?_cons_zero, Option.getD_some]
-              have hg_congr_p : ZPoly.congr lifted.g g p := by
-                simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-                  henselLiftQuadratic_g_congr_mod_base p k f g splitProduct s t hk hp hstart'
-              exact hg_congr_p
-          | Nat.succ i' =>
-              simp only [List.getElem?_cons_succ]
-              exact ihtail i'
+      rw [multifactorLiftQuadraticList]
+      match i with
+      | 0 =>
+          simp only [List.getElem?_cons_zero, Option.getD_some]
+          have hg : ZPoly.congr _g f p := by
+            simpa [Array.polyProduct] using hproduct
+          have hred : ZPoly.congr (ZPoly.reduceModPow f p k) f p := by
+            have h1 : ZPoly.congr (ZPoly.reduceModPow f p k) f (p ^ k) :=
+              ZPoly.congr_reduceModPow f p k (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
+            have h2 := congr_of_pow_le p 1 k _ _ hk h1
+            simpa [Nat.pow_one] using h2
+          exact ZPoly.congr_trans _ _ _ p hred (ZPoly.congr_symm _ _ _ hg)
+      | Nat.succ i' => simp; exact ZPoly.congr_refl 0 p
+  | case3 f g₀ g₁ rest gs half L R gg hh xg ss tt lifted ihL ihR =>
+      simp only [QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have hg_monic := henselLiftQuadratic_g_monic p k f _ _ _ _ hk hp hstart
+      have hh_monic := henselLiftQuadratic_h_monic p k f _ _ _ _ hk hp hf_monic hstart
+      have hgc := henselLiftQuadratic_g_congr_mod_base p k f _ _ _ _ hk hp hstart
+      have hhc := henselLiftQuadratic_h_congr_mod_base p k f _ _ _ _ hk hp hstart
+      have ihL' := ihL hg_monic (fun q hq => hfactors_monic q (List.mem_of_mem_take hq))
+        hinvL (ZPoly.congr_symm _ _ _ hgc)
+      have ihR' := ihR hh_monic (fun q hq => hfactors_monic q (List.mem_of_mem_drop hq))
+        hinvR (ZPoly.congr_symm _ _ _ hhc)
+      have hlen := multifactorLiftQuadraticList_toList_length p k lifted.g L
+      have key := congr_getD_append p _ _ L R hlen ihL' ihR'
+      rw [List.take_append_drop] at key
+      intro i
+      rw [multifactorLiftQuadraticList, Array.toList_append]
+      exact key i
 
 /-- Each output of `multifactorLiftQuadratic` is congruent modulo `p` to the
 corresponding input factor, given the monic / lift-invariant / mod-`p` product
@@ -1281,54 +1265,27 @@ private theorem multifactorLiftQuadraticList_each_monic
     (hinv : QuadraticMultifactorLiftInvariant p k f factors) :
     ∀ entry ∈ (multifactorLiftQuadraticList p k f factors).toList,
       DensePoly.Monic entry := by
-  induction factors generalizing f with
-  | nil =>
-      simp [multifactorLiftQuadraticList]
-  | cons g rest ih =>
-      cases rest with
-      | nil =>
-          intro entry hmem
-          have hentry_eq : entry = ZPoly.reduceModPow f p k := by
-            simp [multifactorLiftQuadraticList] at hmem
-            exact hmem
-          rw [hentry_eq]
-          obtain ⟨k', rfl⟩ : ∃ k', k = k' + 1 := ⟨k - 1, by omega⟩
-          exact reduceModPow_monic_of_monic p k' f hp hf_monic
-      | cons h tail =>
-          intro entry hmem
-          rcases hinv with ⟨hstart, htail⟩
-          let restFactors := (h :: tail).toArray
-          let splitProduct := Array.polyProduct restFactors
-          let xgcd := normalizedXGCD p g splitProduct
-          let s := FpPoly.liftToZ xgcd.left
-          let t := FpPoly.liftToZ xgcd.right
-          let lifted := henselLiftQuadratic p k f g splitProduct s t
-          have hh_monic : DensePoly.Monic lifted.h := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-              henselLiftQuadratic_h_monic p k f g splitProduct s t hk hp hf_monic
-                (by simpa [restFactors, splitProduct, xgcd, s, t] using hstart)
-          have hg_monic : DensePoly.Monic lifted.g := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using
-              henselLiftQuadratic_g_monic p k f g splitProduct s t hk hp
-                (by simpa [restFactors, splitProduct, xgcd, s, t] using hstart)
-          have htail' :
-              QuadraticMultifactorLiftInvariant p k lifted.h (h :: tail) := by
-            simpa [lifted, splitProduct, restFactors, xgcd, s, t] using htail
-          have hmem' :
-              entry = lifted.g ∨
-                entry ∈
-                  (multifactorLiftQuadraticList p k lifted.h (h :: tail)).toList := by
-            have hexpand :
-                (multifactorLiftQuadraticList p k f (g :: h :: tail)).toList =
-                  lifted.g ::
-                    (multifactorLiftQuadraticList p k lifted.h (h :: tail)).toList := by
-              simp [multifactorLiftQuadraticList, restFactors, splitProduct,
-                xgcd, s, t, lifted]
-            rw [hexpand] at hmem
-            simpa using hmem
-          rcases hmem' with hg_eq | hh_mem
-          · rw [hg_eq]; exact hg_monic
-          · exact ih lifted.h hh_monic htail' entry hh_mem
+  induction f, factors using multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => rw [multifactorLiftQuadraticList]; intro entry hmem; simp at hmem
+  | case2 f _g =>
+      rw [multifactorLiftQuadraticList]
+      intro entry hmem
+      simp only [List.mem_singleton] at hmem
+      subst hmem
+      obtain ⟨k', rfl⟩ : ∃ k', k = k' + 1 := ⟨k - 1, by omega⟩
+      exact reduceModPow_monic_of_monic p k' f hp hf_monic
+  | case3 f g₀ g₁ rest =>
+      rename_i ihL ihR
+      simp only [QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have ihL' := ihL (henselLiftQuadratic_g_monic p k f _ _ _ _ hk hp hstart) hinvL
+      have ihR' := ihR (henselLiftQuadratic_h_monic p k f _ _ _ _ hk hp hf_monic hstart) hinvR
+      rw [multifactorLiftQuadraticList]
+      intro entry hmem
+      rw [Array.toList_append, List.mem_append] at hmem
+      rcases hmem with h | h
+      · exact ihL' entry h
+      · exact ihR' entry h
 
 /-- Every output of `multifactorLiftQuadratic` is monic when the input
 polynomial `f` is monic and the quadratic multifactor lift invariant package

--- a/HexHensel/QuadraticMultifactor.lean
+++ b/HexHensel/QuadraticMultifactor.lean
@@ -983,11 +983,11 @@ theorem henselLiftQuadratic_h_monic
   rw [hh_eq]; exact hmonic_reduce
 
 /-- The constant polynomial `1` is monic. -/
-private theorem monic_one : DensePoly.Monic (1 : ZPoly) := by
+theorem monic_one : DensePoly.Monic (1 : ZPoly) := by
   unfold DensePoly.Monic; simp
 
 /-- A product of monic integer polynomials is monic. -/
-private theorem monic_mul {a b : ZPoly}
+theorem monic_mul {a b : ZPoly}
     (ha : DensePoly.Monic a) (hb : DensePoly.Monic b) :
     DensePoly.Monic (a * b) := by
   have ha0 : a ≠ 0 := by
@@ -1001,7 +1001,7 @@ private theorem monic_mul {a b : ZPoly}
 Needed because a balanced split multiplies a whole half of the factor list into
 each side of the binary Hensel step, so the leading factor is a product rather
 than a single input factor. -/
-private theorem monic_polyProduct_toArray (l : List ZPoly)
+theorem monic_polyProduct_toArray (l : List ZPoly)
     (h : ∀ g ∈ l, DensePoly.Monic g) :
     DensePoly.Monic (Array.polyProduct l.toArray) := by
   induction l with
@@ -1014,7 +1014,7 @@ private theorem monic_polyProduct_toArray (l : List ZPoly)
 lifted products of two halves equals the lifted product of the concatenation.
 This is the algebraic content that lets a balanced split's two sub-products
 recombine to the whole modular product. -/
-private theorem polyProduct_map_liftToZ_append
+theorem polyProduct_map_liftToZ_append
     (p : Nat) [ZMod64.Bounds p] (L R : List (FpPoly p)) :
     Array.polyProduct ((L.map FpPoly.liftToZ).toArray) *
       Array.polyProduct ((R.map FpPoly.liftToZ).toArray) =

--- a/HexHenselMathlib/Correctness.lean
+++ b/HexHenselMathlib/Correctness.lean
@@ -523,6 +523,309 @@ theorem quadraticHenselStep_unique_mod_pow_two_mul
     (HexPolyMathlib.toPolynomial (Hex.ZPoly.quadraticHenselStep (p ^ k) f g h s t).h)
     g' h' p (2 * k) (by omega) hg_monic hg' hdeg hprod_2k hprod' hg1 hh1 hcop
 
+section BalancedBridgeHelpers
+open Hex Hex.ZPoly
+
+/-- `a⁻¹ ≠ 0` for a nonzero field element `a : ZMod64 p`. -/
+private theorem zmod64_inv_ne_zero {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    {a : ZMod64 p} (ha : a ≠ 0) : a⁻¹ ≠ 0 := by
+  intro ha0
+  have h1 : a * a⁻¹ = 1 := ZMod64.mul_inv_eq_one_of_ne_zero ha
+  rw [ha0, ZMod64.mul_zero] at h1
+  exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) h1.symm
+
+/-- The normalised XGCD gcd is `1` whenever every common divisor of the two
+`modP` images divides the unit polynomial. This is the coprimality-side entry
+to the split Bezout data, dual to the squarefree-side `gcd² ∣ X` argument used by
+the recombination discharger. -/
+private theorem normalizedXGCD_gcd_eq_one_of_common_dvd_one
+    (p : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p] (g h : ZPoly)
+    (hcommon : ∀ e : FpPoly p, e ∣ ZPoly.modP p g → e ∣ ZPoly.modP p h → e ∣ (1 : FpPoly p)) :
+    (normalizedXGCD p g h).gcd = 1 := by
+  have h1ne : (1 : FpPoly p) ≠ 0 := by
+    intro hh
+    have hcoeff : (DensePoly.C (1 : ZMod64 p) : FpPoly p).coeff 0 = (0 : FpPoly p).coeff 0 := by
+      rw [show (DensePoly.C (1 : ZMod64 p) : FpPoly p) = 1 from rfl, hh]
+    rw [DensePoly.coeff_C, DensePoly.coeff_zero] at hcoeff
+    simp only [if_true] at hcoeff
+    exact ZMod64.one_ne_zero_of_prime (ZMod64.PrimeModulus.prime (p := p)) hcoeff
+  have hr_dvd_one : DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h) ∣ (1 : FpPoly p) :=
+    hcommon _ (DensePoly.gcd_dvd_left _ _) (DensePoly.gcd_dvd_right _ _)
+  have hr_ne : DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h) ≠ 0 := by
+    intro hz; rw [hz] at hr_dvd_one; obtain ⟨u, hu⟩ := hr_dvd_one
+    rw [FpPoly.zero_mul] at hu; exact h1ne hu
+  have hsize_pos : 0 < DensePoly.size (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h)) :=
+    FpPoly.size_pos_of_ne_zero hr_ne
+  have hlc_ne : DensePoly.leadingCoeff (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h))
+      ≠ (0 : ZMod64 p) := by
+    rw [DensePoly.leadingCoeff_eq_coeff_last _ hsize_pos]
+    exact DensePoly.coeff_last_ne_zero_of_pos_size _ hsize_pos
+  have hinv_ne :
+      (DensePoly.leadingCoeff (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h)))⁻¹ ≠ 0 :=
+    zmod64_inv_ne_zero hlc_ne
+  have hshape : (normalizedXGCD p g h).gcd
+      = DensePoly.scale (DensePoly.leadingCoeff (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h)))⁻¹
+          (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h)) := by
+    show DensePoly.scale (DensePoly.leadingCoeff (DensePoly.xgcd (ZPoly.modP p g) (ZPoly.modP p h)).gcd)⁻¹
+        (DensePoly.xgcd (ZPoly.modP p g) (ZPoly.modP p h)).gcd = _
+    rw [DensePoly.gcd_eq_xgcd_gcd]
+  rw [hshape]
+  apply FpPoly.eq_one_of_monic_dvd_one
+  · unfold DensePoly.Monic
+    rw [FpPoly.leadingCoeff_scale_of_ne_zero_of_nonzero hinv_ne _
+      (Nat.pos_iff_ne_zero.mp hsize_pos)]
+    exact ZMod64.inv_mul_eq_one_of_prime (ZMod64.PrimeModulus.prime (p := p)) hlc_ne
+  · obtain ⟨q1, hq1⟩ := FpPoly.dvd_scale_self_of_ne_zero hinv_ne
+      (DensePoly.gcd (ZPoly.modP p g) (ZPoly.modP p h))
+    obtain ⟨q2, hq2⟩ := hr_dvd_one
+    exact ⟨q1 * q2, by rw [← FpPoly.mul_assoc, ← hq1, ← hq2]⟩
+
+/-- Balanced split coprimality over `ZPoly`, stated directly on the integer
+polynomials (via their `modP` images) rather than on the `FpPoly` factors. This
+is the `ZPoly`-level analogue of `QuadraticMultifactorCoprimeSplits` used to
+transport arbitrary monic factor lists (as arise in the linear/quadratic
+agreement) into the balanced quadratic invariant. -/
+def ZCoprimeSplits (p : Nat) [ZMod64.Bounds p] : List ZPoly → Prop
+  | [] => True
+  | [_g] => True
+  | g₀ :: g₁ :: rest =>
+      let gs := g₀ :: g₁ :: rest
+      let half := gs.length / 2
+      let L := gs.take half
+      let R := gs.drop half
+      (normalizedXGCD p (Array.polyProduct L.toArray) (Array.polyProduct R.toArray)).gcd
+          = (1 : FpPoly p) ∧ ZCoprimeSplits p L ∧ ZCoprimeSplits p R
+  termination_by factors => factors.length
+  decreasing_by all_goals (simp only [List.length_take, List.length_drop, List.length_cons]; omega)
+
+/-- Build the balanced quadratic multifactor lift invariant from `ZPoly`-level
+boundary facts: monic factors, split coprimality (`ZCoprimeSplits`), and the
+lifted product congruence modulo `p`. No monic-target hypothesis is required —
+the balanced invariant constrains only the leading factor of each split, which
+is a product of the (monic) input factors. -/
+theorem inv_of_ZCoprimeSplits (p k : Nat) [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (f : ZPoly) (factors : List ZPoly) (hp : 1 < p) (hk : 1 ≤ k)
+    (hfactors_monic : ∀ g ∈ factors, DensePoly.Monic g)
+    (hproduct : ZPoly.congr (Array.polyProduct factors.toArray) f p)
+    (hcop : ZCoprimeSplits p factors) (hne : factors ≠ []) :
+    QuadraticMultifactorLiftInvariant p k f factors := by
+  induction factors using ZCoprimeSplits.induct generalizing f with
+  | case1 => exact absurd rfl hne
+  | case2 g => simp [QuadraticMultifactorLiftInvariant]
+  | case3 g₀ g₁ rest gs half L R ihL ihR =>
+      simp only [ZCoprimeSplits] at hcop
+      obtain ⟨hgcd, hcopL, hcopR⟩ := hcop
+      rw [QuadraticMultifactorLiftInvariant]
+      have hLmonic : ∀ x ∈ (List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)),
+          DensePoly.Monic x := fun x hx => hfactors_monic x (List.mem_of_mem_take hx)
+      have hRmonic : ∀ x ∈ (List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)),
+          DensePoly.Monic x := fun x hx => hfactors_monic x (List.mem_of_mem_drop hx)
+      have hprod : ZPoly.congr
+          (Array.polyProduct (List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)).toArray *
+            Array.polyProduct (List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)).toArray)
+          f p := by
+        rw [← polyProduct_append,
+          show ((List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)).toArray ++
+                (List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)).toArray)
+              = ((List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest) ++
+                 List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest)).toArray) from by simp,
+          List.take_append_drop]
+        exact hproduct
+      have hbez := normalizedXGCD_liftToZ_bezout_congr_of_gcd_eq_one p _ _ hgcd
+      have hstart := QuadraticLiftLoopInvariant.of_product_bezout_monic hprod hbez
+        (monic_polyProduct_toArray _ hLmonic)
+      refine ⟨hstart, ?_, ?_⟩
+      · refine ihL _ hLmonic
+          (ZPoly.congr_symm _ _ _
+            (henselLiftQuadratic_g_congr_mod_base p k f _ _ _ _ hk hp hstart)) hcopL ?_
+        show List.take ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest) ≠ []
+        apply List.ne_nil_of_length_pos
+        simp only [List.length_take, List.length_cons]; omega
+      · refine ihR _ hRmonic
+          (ZPoly.congr_symm _ _ _
+            (henselLiftQuadratic_h_congr_mod_base p k f _ _ _ _ hk hp hstart)) hcopR ?_
+        show List.drop ((g₀ :: g₁ :: rest).length / 2) (g₀ :: g₁ :: rest) ≠ []
+        apply List.ne_nil_of_length_pos
+        simp only [List.length_drop, List.length_cons]; omega
+
+end BalancedBridgeHelpers
+
+section LinearToZCoprimeBridge
+open Hex Hex.ZPoly
+
+variable {p : Nat} [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+
+/-- Target-free common-divisor coprimality of two `FpPoly p` elements: every
+common divisor of `a` and `b` divides the unit polynomial. This is the
+squarefree-free coprimality carrier extracted from the linear Bezout data. -/
+private def CommonDvdOne (a b : FpPoly p) : Prop :=
+  ∀ e : FpPoly p, e ∣ a → e ∣ b → e ∣ (1 : FpPoly p)
+
+omit [ZMod64.PrimeModulus p] in
+private theorem CommonDvdOne.symm {a b : FpPoly p} (h : CommonDvdOne a b) :
+    CommonDvdOne b a :=
+  fun e he_b he_a => h e he_a he_b
+
+omit [ZMod64.PrimeModulus p] in
+/-- Transitivity of `FpPoly` divisibility, reconstructed manually because the
+`Dvd` instance does not carry a `Trans` chain usable by `calc`/`.trans`. -/
+private theorem fp_dvd_trans {a b c : FpPoly p} (hab : a ∣ b) (hbc : b ∣ c) :
+    a ∣ c := by
+  rcases hab with ⟨r, hr⟩
+  rcases hbc with ⟨s, hs⟩
+  exact ⟨r * s, by rw [hs, hr, FpPoly.mul_assoc]⟩
+
+/-- If `a` is coprime with both `b` and `c`, it is coprime with `b * c`. Local
+copy of the private Berlekamp-side `coprime_mul_of_coprime_both`. -/
+private theorem CommonDvdOne.mul {a b c : FpPoly p}
+    (hab : CommonDvdOne a b) (hac : CommonDvdOne a c) :
+    CommonDvdOne a (b * c) := by
+  intro e he_a he_bc
+  have he_coprime_b : ∀ d : FpPoly p, d ∣ b → d ∣ e → d ∣ (1 : FpPoly p) :=
+    fun d hdb hde => hab d (fp_dvd_trans hde he_a) hdb
+  have he_c : e ∣ c :=
+    FpPoly.dvd_of_dvd_mul_of_common_dvd_one he_bc he_coprime_b
+  exact hac e he_a he_c
+
+omit [ZMod64.PrimeModulus p] in
+/-- A `liftToZ` value congruent to `1` modulo `p` is the unit `FpPoly`. -/
+private theorem fpPoly_eq_one_of_congr_liftToZ (X : FpPoly p)
+    (h : ZPoly.congr (FpPoly.liftToZ X) 1 p) : X = 1 := by
+  have hmod := modP_eq_of_congr p (FpPoly.liftToZ X) 1 h
+  rwa [FpPoly.modP_liftToZ, modP_one] at hmod
+
+omit [ZMod64.PrimeModulus p] in
+/-- From a mod-`p` Bezout identity `s * a + t * b = 1` extract the coprimality
+carrier `CommonDvdOne a b`. -/
+private theorem commonDvdOne_of_bezout {a b s t : FpPoly p}
+    (h : s * a + t * b = 1) : CommonDvdOne a b := by
+  intro e he_a he_b
+  have h1 : e ∣ s * a := DensePoly.dvd_mul_left_poly s he_a
+  have h2 : e ∣ t * b := DensePoly.dvd_mul_left_poly t he_b
+  have h3 : e ∣ (s * a + t * b) := DensePoly.dvd_add_poly h1 h2
+  rwa [h] at h3
+
+/-- Any member of a factor list divides the ordered `Array.polyProduct` of that
+list. Local copy of the private Berlekamp-Zassenhaus lemma. -/
+private theorem zpoly_dvd_polyProduct {q : ZPoly} :
+    ∀ factors : List ZPoly, q ∈ factors → q ∣ Array.polyProduct factors.toArray
+  | [], hmem => absurd hmem List.not_mem_nil
+  | head :: tail, hmem => by
+      rw [ZPoly.polyProduct_cons_toArray]
+      rcases List.mem_cons.mp hmem with hhead | htail
+      · subst q
+        exact ⟨Array.polyProduct tail.toArray, rfl⟩
+      · rcases zpoly_dvd_polyProduct tail htail with ⟨c, hc⟩
+        refine ⟨head * c, ?_⟩
+        rw [hc, ← DensePoly.mul_assoc_poly (S := Int) head q c,
+          DensePoly.mul_comm_poly (S := Int) head q,
+          DensePoly.mul_assoc_poly (S := Int) q head c]
+
+omit [ZMod64.PrimeModulus p] in
+/-- `modP` is monotone under `ZPoly` divisibility. -/
+private theorem modP_dvd_of_dvd {a P : ZPoly} (h : a ∣ P) :
+    modP p a ∣ modP p P := by
+  rcases h with ⟨c, hc⟩
+  exact ⟨modP p c, by rw [hc, modP_mul]⟩
+
+/-- Coprimality against a fixed left factor lifts across a right-hand
+`Array.polyProduct` of a list, provided it holds against each list member. -/
+private theorem commonDvdOne_polyProduct_right (a : FpPoly p) :
+    ∀ (R : List ZPoly),
+      (∀ b ∈ R, CommonDvdOne a (modP p b)) →
+      CommonDvdOne a (modP p (Array.polyProduct R.toArray))
+  | [], _ => by
+      intro e _ he1
+      have hone : modP p (Array.polyProduct ([] : List ZPoly).toArray) = 1 := by simp
+      rw [hone] at he1
+      exact he1
+  | b :: rest, h => by
+      rw [ZPoly.polyProduct_cons_toArray, modP_mul]
+      exact CommonDvdOne.mul (h b (by simp))
+        (commonDvdOne_polyProduct_right a rest
+          (fun c hc => h c (List.mem_cons_of_mem b hc)))
+
+/-- Coprimality against a fixed right factor lifts across a left-hand
+`Array.polyProduct` of a list, provided it holds against each list member. -/
+private theorem commonDvdOne_polyProduct_left (X : FpPoly p) :
+    ∀ (L : List ZPoly),
+      (∀ a ∈ L, CommonDvdOne (modP p a) X) →
+      CommonDvdOne (modP p (Array.polyProduct L.toArray)) X
+  | [], _ => by
+      intro e he1 _
+      have hone : modP p (Array.polyProduct ([] : List ZPoly).toArray) = 1 := by simp
+      rw [hone] at he1
+      exact he1
+  | a :: rest, h => by
+      rw [ZPoly.polyProduct_cons_toArray, modP_mul]
+      exact (CommonDvdOne.mul (h a (by simp)).symm
+        (commonDvdOne_polyProduct_left X rest
+          (fun c hc => h c (List.mem_cons_of_mem a hc))).symm).symm
+
+/-- Cross coprimality of every left member with every right member lifts to
+coprimality of the two ordered products. -/
+private theorem commonDvdOne_products (L R : List ZPoly)
+    (h : ∀ a ∈ L, ∀ b ∈ R, CommonDvdOne (modP p a) (modP p b)) :
+    CommonDvdOne (modP p (Array.polyProduct L.toArray))
+      (modP p (Array.polyProduct R.toArray)) := by
+  apply commonDvdOne_polyProduct_left
+  intro a ha
+  exact commonDvdOne_polyProduct_right (modP p a) R (fun b hb => h a ha b hb)
+
+omit [ZMod64.PrimeModulus p] in
+/-- The linear multifactor invariant supplies target-free pairwise coprimality
+of the mod-`p` factor images: at each sequential split the Bezout witness
+gives `CommonDvdOne (modP g) (modP (∏ tail))`, from which coprimality of the
+head against every tail member follows. -/
+private theorem pairwise_commonDvdOne_of_multifactor (k : Nat)
+    (factors : List ZPoly) :
+    ∀ f, MultifactorLiftInvariant p k f factors →
+      List.Pairwise (fun a b => CommonDvdOne (modP p a) (modP p b)) factors := by
+  induction factors with
+  | nil => intro _ _; exact List.Pairwise.nil
+  | cons g rest ih =>
+      intro f hinv
+      cases rest with
+      | nil => exact List.Pairwise.cons (by simp) List.Pairwise.nil
+      | cons h tail =>
+          rcases hinv with ⟨hstart, _, _, htail⟩
+          have hbez_fp :
+              (Hex.ZPoly.normalizedXGCD p g (Array.polyProduct (h :: tail).toArray)).left *
+                  modP p g +
+                (Hex.ZPoly.normalizedXGCD p g (Array.polyProduct (h :: tail).toArray)).right *
+                  modP p (Array.polyProduct (h :: tail).toArray) = 1 := by
+            have hb := hstart.2.1
+            rw [modP_reduceModPow_of_pos p 1 g (by omega),
+              modP_reduceModPow_of_pos p 1 _ (by omega)] at hb
+            exact fpPoly_eq_one_of_congr_liftToZ _ hb
+          have hcommon_head :
+              CommonDvdOne (modP p g) (modP p (Array.polyProduct (h :: tail).toArray)) :=
+            commonDvdOne_of_bezout hbez_fp
+          refine List.Pairwise.cons ?_ (ih _ htail)
+          intro b hb e he_g he_b
+          have hbdvd : modP p b ∣ modP p (Array.polyProduct (h :: tail).toArray) :=
+            modP_dvd_of_dvd (zpoly_dvd_polyProduct (h :: tail) hb)
+          exact hcommon_head e he_g (fp_dvd_trans he_b hbdvd)
+
+/-- Balanced split coprimality (`ZCoprimeSplits`) follows from target-free
+pairwise coprimality of the mod-`p` factor images. -/
+private theorem zcoprime_of_pairwise (factors : List ZPoly) :
+    List.Pairwise (fun a b => CommonDvdOne (modP p a) (modP p b)) factors →
+    ZCoprimeSplits p factors := by
+  induction factors using ZCoprimeSplits.induct with
+  | case1 => intro _; simp only [ZCoprimeSplits]
+  | case2 g => intro _; simp only [ZCoprimeSplits]
+  | case3 g₀ g₁ rest gs half L R ihL ihR =>
+      intro hpw
+      have hsplit : L ++ R = g₀ :: g₁ :: rest := List.take_append_drop _ _
+      rw [← hsplit] at hpw
+      obtain ⟨hpwL, hpwR, hcross⟩ := List.pairwise_append.mp hpw
+      rw [ZCoprimeSplits]
+      exact ⟨normalizedXGCD_gcd_eq_one_of_common_dvd_one p _ _
+        (commonDvdOne_products L R hcross), ihL hpwL, ihR hpwR⟩
+
+end LinearToZCoprimeBridge
+
 /--
 The recursive linear multifactor invariant supplies enough mod-`p` split data
 to initialise the quadratic multifactor invariant, provided the raw input heads
@@ -543,112 +846,51 @@ private theorem quadraticMultifactorLiftInvariant_of_multifactorLiftInvariant_co
     (hnonempty : factors ≠ [])
     (hinv : Hex.ZPoly.MultifactorLiftInvariant p k f factors) :
     Hex.ZPoly.QuadraticMultifactorLiftInvariant p k f' factors := by
-  induction factors generalizing f f' with
-  | nil =>
-      exact (hnonempty rfl).elim
-  | cons g rest ih =>
+  have hp : 1 < p := (Fact.out (p := Nat.Prime p)).one_lt
+  cases factors with
+  | nil => exact absurd rfl hnonempty
+  | cons g rest =>
       cases rest with
-      | nil =>
-          simp [Hex.ZPoly.QuadraticMultifactorLiftInvariant]
+      | nil => simp [Hex.ZPoly.QuadraticMultifactorLiftInvariant]
       | cons h tail =>
-          let restFactors : Array Hex.ZPoly := (h :: tail).toArray
-          let splitProduct : Hex.ZPoly := Array.polyProduct restFactors
-          let xgcd := Hex.ZPoly.normalizedXGCD p g splitProduct
-          let s : Hex.ZPoly := Hex.FpPoly.liftToZ xgcd.left
-          let t : Hex.ZPoly := Hex.FpPoly.liftToZ xgcd.right
-          let linearLifted :=
-            Hex.ZPoly.henselLift p k f g splitProduct xgcd.left xgcd.right
-          let quadraticLifted :=
-            Hex.ZPoly.henselLiftQuadratic p k f' g splitProduct s t
-          rcases hinv with ⟨hstart, _hstepDegree, _hstepBezout, htail⟩
-          have hstart' :
-              Hex.ZPoly.LinearLiftLoopInvariant p 1 f xgcd.left xgcd.right
-                { g := Hex.ZPoly.reduceModPow g p 1
-                  h := Hex.ZPoly.reduceModPow splitProduct p 1 } := by
-            simpa [restFactors, splitProduct, xgcd] using hstart
-          have hprod_reduced :
-              Hex.ZPoly.congr
-                (Hex.ZPoly.reduceModPow g p 1 *
-                  Hex.ZPoly.reduceModPow splitProduct p 1) f p := by
-            simpa [Nat.pow_one] using hstart'.1
-          have hreduce_prod :
-              Hex.ZPoly.congr
-                (Hex.ZPoly.reduceModPow g p 1 *
-                  Hex.ZPoly.reduceModPow splitProduct p 1)
-                (g * splitProduct) p := by
-            apply Hex.ZPoly.congr_mul
-            · have hg :=
-                Hex.ZPoly.congr_reduceModPow g p 1
-                  (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-              simpa [Nat.pow_one] using hg
-            · have hh :=
-                Hex.ZPoly.congr_reduceModPow splitProduct p 1
-                  (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-              simpa [Nat.pow_one] using hh
-          have hprod_raw_f :
-              Hex.ZPoly.congr (g * splitProduct) f p :=
-            Hex.ZPoly.congr_trans _ _ _ p
-              (Hex.ZPoly.congr_symm _ _ _ hreduce_prod) hprod_reduced
-          have hprod_raw :
-              Hex.ZPoly.congr (g * splitProduct) f' p :=
-            Hex.ZPoly.congr_trans _ _ _ p hprod_raw_f htarget
-          have hbez_reduced :
-              Hex.ZPoly.congr
-                (Hex.FpPoly.liftToZ
-                  (xgcd.left * Hex.ZPoly.modP p g +
-                    xgcd.right * Hex.ZPoly.modP p splitProduct)) 1 p := by
-            simpa [Hex.ZPoly.modP_reduceModPow_of_pos p 1 g (by omega),
-              Hex.ZPoly.modP_reduceModPow_of_pos p 1 splitProduct (by omega)]
-              using hstart'.2.1
-          have hbez_lift :
-              Hex.ZPoly.congr
-                (Hex.FpPoly.liftToZ
-                  (xgcd.left * Hex.ZPoly.modP p g +
-                    xgcd.right * Hex.ZPoly.modP p splitProduct))
-                (s * g + t * splitProduct) p := by
-            apply Hex.ZPoly.congr_liftToZ_of_modP_eq
-            simp [s, t]
-          have hbez :
-              Hex.ZPoly.congr (s * g + t * splitProduct) 1 p :=
-            Hex.ZPoly.congr_trans _ _ _ p
-              (Hex.ZPoly.congr_symm _ _ _ hbez_lift) hbez_reduced
-          have hg_monic : Hex.DensePoly.Monic g := by
-            exact hmonic g (by simp)
-          have hquad_start :
-              Hex.ZPoly.QuadraticLiftLoopInvariant p f'
-                { g := g, h := splitProduct, s := s, t := t } :=
-            Hex.ZPoly.QuadraticLiftLoopInvariant.of_product_bezout_monic
-              hprod_raw hbez hg_monic
-          have hlinear_h :
-              Hex.ZPoly.congr linearLifted.h splitProduct p := by
-            simpa [linearLifted, splitProduct, xgcd] using
-              Hex.ZPoly.henselLift_h_congr_mod_base
-                p k f g splitProduct xgcd.left xgcd.right hk
-          have hquadratic_h :
-              Hex.ZPoly.congr quadraticLifted.h splitProduct p := by
-            simpa [quadraticLifted, splitProduct, xgcd, s, t] using
-              Hex.ZPoly.henselLiftQuadratic_h_congr_mod_base
-                p k f' g splitProduct s t hk (Fact.out (p := Nat.Prime p)).one_lt
-                hquad_start
-          have htail_target :
-              Hex.ZPoly.congr linearLifted.h quadraticLifted.h p :=
-            Hex.ZPoly.congr_trans _ _ _ p hlinear_h
-              (Hex.ZPoly.congr_symm _ _ _ hquadratic_h)
-          have htail_monic :
-              ∀ q ∈ (h :: tail), Hex.DensePoly.Monic q := by
-            intro q hq
-            exact hmonic q (by simp [hq])
-          have htail' :
-              Hex.ZPoly.MultifactorLiftInvariant p k linearLifted.h (h :: tail) := by
-            simpa [linearLifted, restFactors, splitProduct, xgcd] using htail
-          have hquad_tail :
-              Hex.ZPoly.QuadraticMultifactorLiftInvariant p k
-                quadraticLifted.h (h :: tail) :=
-            ih linearLifted.h quadraticLifted.h htail_monic htail_target
-              (by simp) htail'
-          exact ⟨by simpa [restFactors, splitProduct, xgcd, s, t] using hquad_start,
-            by simpa [quadraticLifted, restFactors, splitProduct, xgcd, s, t]
-              using hquad_tail⟩
+          -- Product congruence to `f'` modulo `p`, from the linear invariant.
+          have hprod_raw : Hex.ZPoly.congr
+              (Array.polyProduct (g :: h :: tail).toArray) f' p := by
+            rcases hinv with ⟨hstart, _, _, _⟩
+            have hstart1 := hstart.1
+            -- `hstart1 : congr (reduceModPow g p 1 * reduceModPow (∏ (h::tail)) p 1) f (p^1)`
+            have hprod_reduced :
+                Hex.ZPoly.congr
+                  (Hex.ZPoly.reduceModPow g p 1 *
+                    Hex.ZPoly.reduceModPow
+                      (Array.polyProduct (h :: tail).toArray) p 1) f p := by
+              simpa [Nat.pow_one] using hstart1
+            have hreduce_prod :
+                Hex.ZPoly.congr
+                  (Hex.ZPoly.reduceModPow g p 1 *
+                    Hex.ZPoly.reduceModPow
+                      (Array.polyProduct (h :: tail).toArray) p 1)
+                  (g * Array.polyProduct (h :: tail).toArray) p := by
+              apply Hex.ZPoly.congr_mul
+              · simpa [Nat.pow_one] using
+                  Hex.ZPoly.congr_reduceModPow g p 1
+                    (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
+              · simpa [Nat.pow_one] using
+                  Hex.ZPoly.congr_reduceModPow
+                    (Array.polyProduct (h :: tail).toArray) p 1
+                    (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
+            have hprod_raw_f :
+                Hex.ZPoly.congr
+                  (g * Array.polyProduct (h :: tail).toArray) f p :=
+              Hex.ZPoly.congr_trans _ _ _ p
+                (Hex.ZPoly.congr_symm _ _ _ hreduce_prod) hprod_reduced
+            rw [Hex.ZPoly.polyProduct_cons_toArray]
+            exact Hex.ZPoly.congr_trans _ _ _ p hprod_raw_f htarget
+          exact inv_of_ZCoprimeSplits p k f' (g :: h :: tail) hp hk hmonic
+            hprod_raw
+            (zcoprime_of_pairwise (g :: h :: tail)
+              (pairwise_commonDvdOne_of_multifactor k (g :: h :: tail) f hinv))
+            (by simp)
 
 /--
 The linear multifactor invariant can initialise the quadratic multifactor
@@ -671,6 +913,372 @@ theorem quadraticMultifactorLiftInvariant_of_multifactorLiftInvariant
         quadraticMultifactorLiftInvariant_of_multifactorLiftInvariant_congr
           p k f f (g :: rest) hk hmonic (Hex.ZPoly.congr_refl f p)
           (by simp) hinv
+
+section QuadraticOutputBridge
+open Hex
+
+/-- Local length lemma for the balanced quadratic list lifter. -/
+private theorem quad_toList_length (p k : Nat) [ZMod64.Bounds p]
+    (f : ZPoly) (factors : List ZPoly) :
+    (ZPoly.multifactorLiftQuadraticList p k f factors).toList.length = factors.length := by
+  induction f, factors using ZPoly.multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => simp [ZPoly.multifactorLiftQuadraticList]
+  | case2 f _g => simp [ZPoly.multifactorLiftQuadraticList]
+  | case3 f g₀ g₁ rest =>
+      rename_i ihL ihR
+      rw [ZPoly.multifactorLiftQuadraticList, Array.toList_append, List.length_append,
+        ihL, ihR, ← List.length_append, List.take_append_drop]
+
+/-- Per-index congruence transports across list concatenation with matching
+prefix length. Local copy of the private balanced-tree bookkeeping lemma. -/
+private theorem congr_getD_append (p : Nat) (o1 o2 f1 f2 : List ZPoly)
+    (hlen : o1.length = f1.length)
+    (h1 : ∀ (i : Nat), ZPoly.congr (o1[i]?.getD 0) (f1[i]?.getD 0) p)
+    (h2 : ∀ (i : Nat), ZPoly.congr (o2[i]?.getD 0) (f2[i]?.getD 0) p) :
+    ∀ (i : Nat), ZPoly.congr ((o1 ++ o2)[i]?.getD 0) ((f1 ++ f2)[i]?.getD 0) p := by
+  intro i
+  by_cases hi : i < o1.length
+  · rw [List.getElem?_append_left hi, List.getElem?_append_left (hlen ▸ hi)]
+    exact h1 i
+  · rw [List.getElem?_append_right (Nat.le_of_not_lt hi),
+        List.getElem?_append_right (hlen ▸ Nat.le_of_not_lt hi), hlen]
+    exact h2 (i - f1.length)
+
+/-- Monic-free per-output mod-`p` preservation for the balanced quadratic list
+lifter: each output is congruent modulo `p` to the corresponding input factor.
+This drops the raw-monicity hypothesis of the executable-side companion, which
+is only used there to feed the recursion. -/
+private theorem quad_each_congr_mod_base (p k : Nat) [ZMod64.Bounds p]
+    (f : ZPoly) (factors : List ZPoly) (hk : 1 ≤ k) (hp : 1 < p)
+    (hinv : ZPoly.QuadraticMultifactorLiftInvariant p k f factors)
+    (hproduct : ZPoly.congr (Array.polyProduct factors.toArray) f p) :
+    ∀ (i : Nat),
+      ZPoly.congr
+        ((ZPoly.multifactorLiftQuadraticList p k f factors).toList[i]?.getD 0)
+        (factors[i]?.getD 0) p := by
+  induction f, factors using ZPoly.multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => intro i; rw [ZPoly.multifactorLiftQuadraticList]; simp; exact ZPoly.congr_refl 0 p
+  | case2 f _g =>
+      intro i
+      rw [ZPoly.multifactorLiftQuadraticList]
+      match i with
+      | 0 =>
+          simp only [List.getElem?_cons_zero, Option.getD_some]
+          have hg : ZPoly.congr _g f p := by
+            simpa [Array.polyProduct] using hproduct
+          have hred : ZPoly.congr (ZPoly.reduceModPow f p k) f p := by
+            have h1 : ZPoly.congr (ZPoly.reduceModPow f p k) f (p ^ k) :=
+              ZPoly.congr_reduceModPow f p k (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
+            have h2 := ZPoly.congr_pow_of_le p 1 k _ _ hk h1
+            simpa [Nat.pow_one] using h2
+          exact ZPoly.congr_trans _ _ _ p hred (ZPoly.congr_symm _ _ _ hg)
+      | Nat.succ i' => simp; exact ZPoly.congr_refl 0 p
+  | case3 f g₀ g₁ rest gs half L R gg hh xg ss tt lifted ihL ihR =>
+      simp only [ZPoly.QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have hgc := ZPoly.henselLiftQuadratic_g_congr_mod_base p k f _ _ _ _ hk hp hstart
+      have hhc := ZPoly.henselLiftQuadratic_h_congr_mod_base p k f _ _ _ _ hk hp hstart
+      have ihL' := ihL hinvL (ZPoly.congr_symm _ _ _ hgc)
+      have ihR' := ihR hinvR (ZPoly.congr_symm _ _ _ hhc)
+      have hlen := quad_toList_length p k lifted.g L
+      have key := congr_getD_append p _ _ L R hlen ihL' ihR'
+      rw [List.take_append_drop] at key
+      intro i
+      rw [ZPoly.multifactorLiftQuadraticList, Array.toList_append]
+      exact key i
+
+/-- Target-monic per-output monicity for the balanced quadratic list lifter
+(list-membership form). Local copy of the private executable-side companion. -/
+private theorem quad_list_each_monic (p k : Nat) [ZMod64.Bounds p]
+    (f : ZPoly) (factors : List ZPoly) (hk : 1 ≤ k) (hp : 1 < p)
+    (hf_monic : DensePoly.Monic f)
+    (hinv : ZPoly.QuadraticMultifactorLiftInvariant p k f factors) :
+    ∀ entry ∈ (ZPoly.multifactorLiftQuadraticList p k f factors).toList,
+      DensePoly.Monic entry := by
+  induction f, factors using ZPoly.multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => rw [ZPoly.multifactorLiftQuadraticList]; intro entry hmem; simp at hmem
+  | case2 f _g =>
+      rw [ZPoly.multifactorLiftQuadraticList]
+      intro entry hmem
+      simp only [List.mem_singleton] at hmem
+      subst hmem
+      obtain ⟨k', rfl⟩ : ∃ k', k = k' + 1 := ⟨k - 1, by omega⟩
+      exact ZPoly.reduceModPow_monic_of_monic p k' f hp hf_monic
+  | case3 f g₀ g₁ rest =>
+      rename_i ihL ihR
+      simp only [ZPoly.QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have ihL' := ihL (ZPoly.henselLiftQuadratic_g_monic p k f _ _ _ _ hk hp hstart) hinvL
+      have ihR' := ihR (ZPoly.henselLiftQuadratic_h_monic p k f _ _ _ _ hk hp hf_monic hstart) hinvR
+      rw [ZPoly.multifactorLiftQuadraticList]
+      intro entry hmem
+      rw [Array.toList_append, List.mem_append] at hmem
+      rcases hmem with h | h
+      · exact ihL' entry h
+      · exact ihR' entry h
+
+/-- Every balanced quadratic output *except the last* is monic, with no
+monic-target hypothesis. Each split's left factor `lifted.g` is monic by
+`henselLiftQuadratic_g_monic` alone, so the whole left subtree is monic; only
+the global-rightmost leaf (a right-spine `reduceModPow` of the cofactor) needs a
+monic target, and it is excluded here. -/
+private theorem quad_all_but_last_monic (p k : Nat) [ZMod64.Bounds p]
+    (f : ZPoly) (factors : List ZPoly) (hk : 1 ≤ k) (hp : 1 < p)
+    (hinv : ZPoly.QuadraticMultifactorLiftInvariant p k f factors) :
+    ∀ (i : Nat), i + 1 < (ZPoly.multifactorLiftQuadraticList p k f factors).toList.length →
+      DensePoly.Monic ((ZPoly.multifactorLiftQuadraticList p k f factors).toList[i]?.getD 0) := by
+  induction f, factors using ZPoly.multifactorLiftQuadraticList.induct (p := p) (k := k) with
+  | case1 f => intro i hi; rw [ZPoly.multifactorLiftQuadraticList] at hi; simp at hi
+  | case2 f _g => intro i hi; rw [ZPoly.multifactorLiftQuadraticList] at hi; simp at hi
+  | case3 f g₀ g₁ rest gs half L R gg hh xg ss tt lifted ihL ihR =>
+      simp only [ZPoly.QuadraticMultifactorLiftInvariant] at hinv
+      obtain ⟨hstart, hinvL, hinvR⟩ := hinv
+      have hg_monic := ZPoly.henselLiftQuadratic_g_monic p k f _ _ _ _ hk hp hstart
+      have hLmonic := quad_list_each_monic p k lifted.g L hk hp hg_monic hinvL
+      have ihR' := ihR hinvR
+      have hlenL := quad_toList_length p k lifted.g L
+      intro i hi
+      rw [ZPoly.multifactorLiftQuadraticList, Array.toList_append] at hi ⊢
+      set oL := (ZPoly.multifactorLiftQuadraticList p k lifted.g L).toList with hoL
+      set oR := (ZPoly.multifactorLiftQuadraticList p k lifted.h R).toList with hoR
+      rw [List.length_append] at hi
+      by_cases hiL : i < oL.length
+      · rw [List.getElem?_append_left hiL, List.getElem?_eq_getElem hiL, Option.getD_some]
+        exact hLmonic _ (List.getElem_mem hiL)
+      · rw [List.getElem?_append_right (Nat.le_of_not_lt hiL)]
+        exact ihR' (i - oL.length) (by omega)
+
+/-- Congruence of ordered products from pointwise (getD-form) congruence of two
+equal-length lists. -/
+private theorem congr_polyProduct_of_pointwise (p : Nat) [ZMod64.Bounds p] :
+    ∀ (l1 l2 : List ZPoly), l1.length = l2.length →
+      (∀ (i : Nat), ZPoly.congr (l1[i]?.getD 0) (l2[i]?.getD 0) p) →
+      ZPoly.congr (Array.polyProduct l1.toArray) (Array.polyProduct l2.toArray) p
+  | [], [], _, _ => ZPoly.congr_refl _ p
+  | [], _ :: _, hlen, _ => by simp at hlen
+  | _ :: _, [], hlen, _ => by simp at hlen
+  | a :: as, b :: bs, hlen, h => by
+      rw [ZPoly.polyProduct_cons_toArray, ZPoly.polyProduct_cons_toArray]
+      apply ZPoly.congr_mul
+      · exact h 0
+      · exact congr_polyProduct_of_pointwise p as bs
+          (by simpa using hlen) (fun i => h (i + 1))
+
+/-- The abstract lock-step engine behind the linear/quadratic agreement. It
+inducts on the factor list following the *linear* (sequential) recursion, and
+compares against an abstract output list `out` constrained only by its length,
+its per-output mod-`p` residues, all-but-last monicity, and its product modulo
+`p ^ k`. At each non-singleton peel `hensel_unique` identifies the linear head
+with `out.head` and the linear complement with the product of `out.tail`; the
+complement equality is exactly the recursive target congruence. -/
+private theorem output_map_eq_linear (p k : Nat) [Fact (Nat.Prime p)]
+    [ZMod64.Bounds p] [ZMod64.PrimeModulus p]
+    (f : ZPoly) (factors out : List ZPoly)
+    (hk : 1 ≤ k) (hp : 1 < p)
+    (hlen : out.length = factors.length)
+    (hout_monic : ∀ (i : Nat), i + 1 < out.length → DensePoly.Monic (out[i]?.getD 0))
+    (hout_base : ∀ (i : Nat), ZPoly.congr (out[i]?.getD 0) (factors[i]?.getD 0) p)
+    (hout_prod : ZPoly.congr (Array.polyProduct out.toArray) f (p ^ k))
+    (hinv : ZPoly.MultifactorLiftInvariant p k f factors) :
+    (ZPoly.multifactorLiftList p k f factors).toList.map
+        (fun g => (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod (p ^ k)))) =
+      out.map
+        (fun g => (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod (p ^ k)))) := by
+  induction factors generalizing f out with
+  | nil =>
+      have hout_nil : out = [] := List.length_eq_zero_iff.mp (by simpa using hlen)
+      subst hout_nil
+      simp [ZPoly.multifactorLiftList]
+  | cons g rest ih =>
+      cases rest with
+      | nil =>
+          -- `factors = [g]`, so `out = [G]`.
+          match out, hlen, hout_prod with
+          | [G], _, hout_prod =>
+              have hGf : ZPoly.congr G f (p ^ k) := by
+                simpa [Array.polyProduct] using hout_prod
+              have hcongr : ZPoly.congr (ZPoly.reduceModPow f p k) G (p ^ k) :=
+                ZPoly.congr_trans _ _ _ (p ^ k)
+                  (ZPoly.congr_reduceModPow f p k
+                    (Nat.pow_pos (ZMod64.Bounds.pPos (p := p))))
+                  (ZPoly.congr_symm _ _ _ hGf)
+              have hmap := zpoly_congr_toPolynomial_map_eq
+                (ZPoly.reduceModPow f p k) G (p ^ k) hcongr
+              simpa [ZPoly.multifactorLiftList] using hmap
+      | cons h tail =>
+          match out, hlen, hout_monic, hout_base, hout_prod with
+          | G :: r, hlen, hout_monic, hout_base, hout_prod =>
+              rcases hinv with ⟨hstart, hstepDeg, hstepBez, htail⟩
+              set splitProduct : ZPoly := Array.polyProduct (h :: tail).toArray with hsplit
+              set xgcd := ZPoly.normalizedXGCD p g splitProduct with hxgcd
+              set s : ZPoly := Hex.FpPoly.liftToZ xgcd.left with hs
+              set t : ZPoly := Hex.FpPoly.liftToZ xgcd.right with ht
+              set linearLifted := ZPoly.henselLift p k f g splitProduct xgcd.left xgcd.right
+                with hll
+              have hstart' :
+                  ZPoly.LinearLiftLoopInvariant p 1 f xgcd.left xgcd.right
+                    { g := ZPoly.reduceModPow g p 1
+                      h := ZPoly.reduceModPow splitProduct p 1 } := hstart
+              have hlin_prod :
+                  ZPoly.congr (linearLifted.g * linearLifted.h) f (p ^ k) :=
+                ZPoly.henselLift_spec p k f g splitProduct xgcd.left xgcd.right hk hp
+                  hstart' hstepDeg hstepBez
+              have hlin_g_monic : DensePoly.Monic linearLifted.g :=
+                ZPoly.henselLift_monic p k f g splitProduct xgcd.left xgcd.right hk hp
+                  hstart' hstepDeg hstepBez
+              -- Bezout congruence for the mod-`p` coprimality of the linear split.
+              have hbez_reduced :
+                  ZPoly.congr
+                    (Hex.FpPoly.liftToZ
+                      (xgcd.left * ZPoly.modP p g + xgcd.right * ZPoly.modP p splitProduct)) 1 p := by
+                simpa [ZPoly.modP_reduceModPow_of_pos p 1 g (by omega),
+                  ZPoly.modP_reduceModPow_of_pos p 1 splitProduct (by omega)]
+                  using hstart'.2.1
+              have hbez_lift :
+                  ZPoly.congr
+                    (Hex.FpPoly.liftToZ
+                      (xgcd.left * ZPoly.modP p g + xgcd.right * ZPoly.modP p splitProduct))
+                    (s * g + t * splitProduct) p := by
+                apply ZPoly.congr_liftToZ_of_modP_eq
+                simp [hs, ht]
+              have hbez : ZPoly.congr (s * g + t * splitProduct) 1 p :=
+                ZPoly.congr_trans _ _ _ p
+                  (ZPoly.congr_symm _ _ _ hbez_lift) hbez_reduced
+              -- Base-prime facts.
+              have hlin_g_base : ZPoly.congr linearLifted.g g p :=
+                ZPoly.henselLift_g_congr_mod_base p k f g splitProduct
+                  xgcd.left xgcd.right hk
+              have hlin_h_base : ZPoly.congr linearLifted.h splitProduct p :=
+                ZPoly.henselLift_h_congr_mod_base p k f g splitProduct
+                  xgcd.left xgcd.right hk
+              -- `out`-side facts.
+              have hlen' : r.length = (h :: tail).length := by
+                simpa using hlen
+              have hrpos : 0 < r.length := by rw [hlen']; simp
+              have hGmonic : DensePoly.Monic G := by
+                have := hout_monic 0 (by simp only [List.length_cons]; omega)
+                simpa using this
+              have hGbase : ZPoly.congr G g p := by
+                have := hout_base 0
+                simpa using this
+              have hr_base : ∀ (i : Nat),
+                  ZPoly.congr (r[i]?.getD 0) ((h :: tail)[i]?.getD 0) p := by
+                intro i
+                have := hout_base (i + 1)
+                simpa using this
+              have hr_monic : ∀ (i : Nat), i + 1 < r.length →
+                  DensePoly.Monic (r[i]?.getD 0) := by
+                intro i hi
+                have := hout_monic (i + 1) (by simpa using hi)
+                simpa using this
+              have hprodGr : ZPoly.congr (G * Array.polyProduct r.toArray) f (p ^ k) := by
+                have := hout_prod
+                rwa [ZPoly.polyProduct_cons_toArray] at this
+              -- Mathlib-side inputs to `hensel_unique`.
+              have hg : (HexPolyMathlib.toPolynomial linearLifted.g).Monic :=
+                toPolynomial_monic_of_dense_monic _ hlin_g_monic
+              have hg' : (HexPolyMathlib.toPolynomial G).Monic :=
+                toPolynomial_monic_of_dense_monic _ hGmonic
+              have hg1 :
+                  (HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod p)) =
+                    (HexPolyMathlib.toPolynomial G).map (Int.castRingHom (ZMod p)) :=
+                zpoly_congr_toPolynomial_map_eq _ _ p
+                  (ZPoly.congr_trans _ _ _ p hlin_g_base (ZPoly.congr_symm _ _ _ hGbase))
+              have hh1 :
+                  (HexPolyMathlib.toPolynomial linearLifted.h).map (Int.castRingHom (ZMod p)) =
+                    (HexPolyMathlib.toPolynomial (Array.polyProduct r.toArray)).map
+                      (Int.castRingHom (ZMod p)) := by
+                have hpr : ZPoly.congr (Array.polyProduct r.toArray) splitProduct p := by
+                  have := congr_polyProduct_of_pointwise p r (h :: tail) hlen' hr_base
+                  simpa [hsplit] using this
+                exact zpoly_congr_toPolynomial_map_eq _ _ p
+                  (ZPoly.congr_trans _ _ _ p hlin_h_base (ZPoly.congr_symm _ _ _ hpr))
+              have hdeg :
+                  (HexPolyMathlib.toPolynomial linearLifted.g).natDegree =
+                    (HexPolyMathlib.toPolynomial G).natDegree :=
+                natDegree_eq_of_monic_map_eq p hg hg' hg1
+              have hprod :
+                  (HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod (p ^ k))) *
+                      (HexPolyMathlib.toPolynomial linearLifted.h).map
+                        (Int.castRingHom (ZMod (p ^ k))) =
+                    (HexPolyMathlib.toPolynomial f).map (Int.castRingHom (ZMod (p ^ k))) := by
+                have hmap := zpoly_congr_toPolynomial_map_eq
+                  (linearLifted.g * linearLifted.h) f (p ^ k) hlin_prod
+                simpa [HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul] using hmap
+              have hprod' :
+                  (HexPolyMathlib.toPolynomial G).map (Int.castRingHom (ZMod (p ^ k))) *
+                      (HexPolyMathlib.toPolynomial (Array.polyProduct r.toArray)).map
+                        (Int.castRingHom (ZMod (p ^ k))) =
+                    (HexPolyMathlib.toPolynomial f).map (Int.castRingHom (ZMod (p ^ k))) := by
+                have hmap := zpoly_congr_toPolynomial_map_eq
+                  (G * Array.polyProduct r.toArray) f (p ^ k) hprodGr
+                simpa [HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul] using hmap
+              have hcop :
+                  IsCoprime
+                    ((HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod p)))
+                    ((HexPolyMathlib.toPolynomial linearLifted.h).map (Int.castRingHom (ZMod p))) := by
+                have hbase := isCoprime_of_zpoly_bezout p g splitProduct s t hbez
+                have hgp : (HexPolyMathlib.toPolynomial linearLifted.g).map
+                    (Int.castRingHom (ZMod p)) =
+                    (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod p)) :=
+                  zpoly_congr_toPolynomial_map_eq _ _ p hlin_g_base
+                have hhp : (HexPolyMathlib.toPolynomial linearLifted.h).map
+                    (Int.castRingHom (ZMod p)) =
+                    (HexPolyMathlib.toPolynomial splitProduct).map (Int.castRingHom (ZMod p)) :=
+                  zpoly_congr_toPolynomial_map_eq _ _ p hlin_h_base
+                rw [hgp, hhp]; exact hbase
+              obtain ⟨hgeq, hheq⟩ := hensel_unique
+                (HexPolyMathlib.toPolynomial f)
+                (HexPolyMathlib.toPolynomial linearLifted.g)
+                (HexPolyMathlib.toPolynomial linearLifted.h)
+                (HexPolyMathlib.toPolynomial G)
+                (HexPolyMathlib.toPolynomial (Array.polyProduct r.toArray))
+                p k (by omega) hg hg' hdeg hprod hprod' hg1 hh1 hcop
+              -- Recurse on the lifted complement with target `linearLifted.h`, output `r`.
+              have hr_prod : ZPoly.congr (Array.polyProduct r.toArray) linearLifted.h (p ^ k) :=
+                ZPoly.congr_symm _ _ _
+                  (zpoly_congr_of_toPolynomial_map_eq linearLifted.h
+                    (Array.polyProduct r.toArray) (p ^ k) hheq)
+              have hrec := ih linearLifted.h r hlen' hr_monic hr_base hr_prod htail
+              have hexpandL :
+                  (ZPoly.multifactorLiftList p k f (g :: h :: tail)).toList =
+                    linearLifted.g ::
+                      (ZPoly.multifactorLiftList p k linearLifted.h (h :: tail)).toList := by
+                simp [ZPoly.multifactorLiftList, hsplit, hxgcd, hll]
+              rw [hexpandL, List.map_cons, List.map_cons]
+              exact List.cons_eq_cons.mpr ⟨hgeq, hrec⟩
+
+/-- The ordered product of a non-singleton factor list is congruent modulo `p`
+to any target `f'` congruent to the linear target `f`, extracted from the
+sequential linear invariant's mod-`p` loop start. -/
+private theorem congr_polyProduct_target (p k : Nat) [ZMod64.Bounds p]
+    (f f' g h : ZPoly) (tail : List ZPoly)
+    (htarget : ZPoly.congr f f' p)
+    (hinv : ZPoly.MultifactorLiftInvariant p k f (g :: h :: tail)) :
+    ZPoly.congr (Array.polyProduct (g :: h :: tail).toArray) f' p := by
+  rcases hinv with ⟨hstart, _, _, _⟩
+  have hprod_reduced :
+      ZPoly.congr
+        (ZPoly.reduceModPow g p 1 *
+          ZPoly.reduceModPow (Array.polyProduct (h :: tail).toArray) p 1) f p := by
+    simpa [Nat.pow_one] using hstart.1
+  have hreduce_prod :
+      ZPoly.congr
+        (ZPoly.reduceModPow g p 1 *
+          ZPoly.reduceModPow (Array.polyProduct (h :: tail).toArray) p 1)
+        (g * Array.polyProduct (h :: tail).toArray) p := by
+    apply ZPoly.congr_mul
+    · simpa [Nat.pow_one] using
+        ZPoly.congr_reduceModPow g p 1 (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
+    · simpa [Nat.pow_one] using
+        ZPoly.congr_reduceModPow (Array.polyProduct (h :: tail).toArray) p 1
+          (Nat.pow_pos (ZMod64.Bounds.pPos (p := p)))
+  have hprod_raw_f : ZPoly.congr (g * Array.polyProduct (h :: tail).toArray) f p :=
+    ZPoly.congr_trans _ _ _ p (ZPoly.congr_symm _ _ _ hreduce_prod) hprod_reduced
+  rw [ZPoly.polyProduct_cons_toArray]
+  exact ZPoly.congr_trans _ _ _ p hprod_raw_f htarget
+
+end QuadraticOutputBridge
 
 /--
 List-level agreement of the linear and quadratic multifactor lifters over
@@ -699,207 +1307,49 @@ private theorem multifactorLiftList_map_eq_quadratic
         (fun g => (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod (p ^ k)))) =
       (Hex.ZPoly.multifactorLiftQuadraticList p k f' factors).toList.map
         (fun g => (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod (p ^ k)))) := by
-  induction factors generalizing f f' with
+  have htarget_p : Hex.ZPoly.congr f f' p := by
+    have h := Hex.ZPoly.congr_pow_of_le p 1 k f f' hk htarget
+    simpa [Nat.pow_one] using h
+  cases factors with
   | nil =>
       simp [Hex.ZPoly.multifactorLiftList, Hex.ZPoly.multifactorLiftQuadraticList]
-  | cons g rest ih =>
+  | cons g rest =>
       cases rest with
       | nil =>
-          have hcongr :
-              Hex.ZPoly.congr (Hex.ZPoly.reduceModPow f p k)
-                (Hex.ZPoly.reduceModPow f' p k) (p ^ k) := by
-            have hf := Hex.ZPoly.congr_reduceModPow f p k
-              (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-            have hf' := Hex.ZPoly.congr_reduceModPow f' p k
-              (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-            exact Hex.ZPoly.congr_trans _ _ _ (p ^ k) hf
-              (Hex.ZPoly.congr_trans _ _ _ (p ^ k) htarget
-                (Hex.ZPoly.congr_symm _ _ _ hf'))
-          have hmap := zpoly_congr_toPolynomial_map_eq
-            (Hex.ZPoly.reduceModPow f p k) (Hex.ZPoly.reduceModPow f' p k) (p ^ k) hcongr
-          simpa [Hex.ZPoly.multifactorLiftList, Hex.ZPoly.multifactorLiftQuadraticList]
-            using hmap
+          have hred : Hex.ZPoly.reduceModPow f p k = Hex.ZPoly.reduceModPow f' p k :=
+            Hex.ZPoly.reduceModPow_eq_of_congr f f' p k htarget
+          simp [Hex.ZPoly.multifactorLiftList, Hex.ZPoly.multifactorLiftQuadraticList, hred]
       | cons h tail =>
-          rcases hinv with ⟨hstart, hstepDeg, hstepBez, htail⟩
-          let restFactors : Array Hex.ZPoly := (h :: tail).toArray
-          let splitProduct : Hex.ZPoly := Array.polyProduct restFactors
-          let xgcd := Hex.ZPoly.normalizedXGCD p g splitProduct
-          let s : Hex.ZPoly := Hex.FpPoly.liftToZ xgcd.left
-          let t : Hex.ZPoly := Hex.FpPoly.liftToZ xgcd.right
-          let linearLifted := Hex.ZPoly.henselLift p k f g splitProduct xgcd.left xgcd.right
-          let quadraticLifted := Hex.ZPoly.henselLiftQuadratic p k f' g splitProduct s t
-          -- Align the destructured invariant pieces with the local abbreviations.
-          have hstart' :
-              Hex.ZPoly.LinearLiftLoopInvariant p 1 f xgcd.left xgcd.right
-                { g := Hex.ZPoly.reduceModPow g p 1
-                  h := Hex.ZPoly.reduceModPow splitProduct p 1 } := hstart
-          -- Linear product spec modulo `p ^ k`.
-          have hlin_prod :
-              Hex.ZPoly.congr (linearLifted.g * linearLifted.h) f (p ^ k) :=
-            Hex.ZPoly.henselLift_spec p k f g splitProduct xgcd.left xgcd.right hk hp
-              hstart' hstepDeg hstepBez
-          have hlin_g_monic : Hex.DensePoly.Monic linearLifted.g :=
-            Hex.ZPoly.henselLift_monic p k f g splitProduct xgcd.left xgcd.right hk hp
-              hstart' hstepDeg hstepBez
-          -- Rebuild the quadratic loop-start from the linear loop-start, the
-          -- raw-product/Bezout congruences mod `p`, and raw head monicity.
-          have htarget_p : Hex.ZPoly.congr f f' p := by
-            have h := Hex.ZPoly.congr_pow_of_le p 1 k f f' hk htarget
-            simpa [Nat.pow_one] using h
-          have hprod_reduced :
-              Hex.ZPoly.congr
-                (Hex.ZPoly.reduceModPow g p 1 *
-                  Hex.ZPoly.reduceModPow splitProduct p 1) f p := by
-            simpa [Nat.pow_one] using hstart'.1
-          have hreduce_prod :
-              Hex.ZPoly.congr
-                (Hex.ZPoly.reduceModPow g p 1 *
-                  Hex.ZPoly.reduceModPow splitProduct p 1)
-                (g * splitProduct) p := by
-            apply Hex.ZPoly.congr_mul
-            · have hg :=
-                Hex.ZPoly.congr_reduceModPow g p 1
-                  (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-              simpa [Nat.pow_one] using hg
-            · have hh :=
-                Hex.ZPoly.congr_reduceModPow splitProduct p 1
-                  (Nat.pow_pos (Hex.ZMod64.Bounds.pPos (p := p)))
-              simpa [Nat.pow_one] using hh
-          have hprod_raw_f :
-              Hex.ZPoly.congr (g * splitProduct) f p :=
-            Hex.ZPoly.congr_trans _ _ _ p
-              (Hex.ZPoly.congr_symm _ _ _ hreduce_prod) hprod_reduced
-          have hprod_raw :
-              Hex.ZPoly.congr (g * splitProduct) f' p :=
-            Hex.ZPoly.congr_trans _ _ _ p hprod_raw_f htarget_p
-          have hbez_reduced :
-              Hex.ZPoly.congr
-                (Hex.FpPoly.liftToZ
-                  (xgcd.left * Hex.ZPoly.modP p g +
-                    xgcd.right * Hex.ZPoly.modP p splitProduct)) 1 p := by
-            simpa [Hex.ZPoly.modP_reduceModPow_of_pos p 1 g (by omega),
-              Hex.ZPoly.modP_reduceModPow_of_pos p 1 splitProduct (by omega)]
-              using hstart'.2.1
-          have hbez_lift :
-              Hex.ZPoly.congr
-                (Hex.FpPoly.liftToZ
-                  (xgcd.left * Hex.ZPoly.modP p g +
-                    xgcd.right * Hex.ZPoly.modP p splitProduct))
-                (s * g + t * splitProduct) p := by
-            apply Hex.ZPoly.congr_liftToZ_of_modP_eq
-            simp [s, t]
-          have hbez :
-              Hex.ZPoly.congr (s * g + t * splitProduct) 1 p :=
-            Hex.ZPoly.congr_trans _ _ _ p
-              (Hex.ZPoly.congr_symm _ _ _ hbez_lift) hbez_reduced
-          have hg_monic : Hex.DensePoly.Monic g := hmonic g (by simp)
-          have hquad_start :
-              Hex.ZPoly.QuadraticLiftLoopInvariant p f'
-                { g := g, h := splitProduct, s := s, t := t } :=
-            Hex.ZPoly.QuadraticLiftLoopInvariant.of_product_bezout_monic
-              hprod_raw hbez hg_monic
-          -- Quadratic product spec modulo `p ^ k`.
-          have hquad_prod :
-              Hex.ZPoly.congr (quadraticLifted.g * quadraticLifted.h) f' (p ^ k) :=
-            Hex.ZPoly.henselLiftQuadratic_spec p k f' g splitProduct s t hk hp hquad_start
-          have hquad_g_monic : Hex.DensePoly.Monic quadraticLifted.g :=
-            Hex.ZPoly.henselLiftQuadratic_g_monic p k f' g splitProduct s t hk hp hquad_start
-          -- Base-prime agreement of the lifted heads and complements.
-          have hlin_g_base : Hex.ZPoly.congr linearLifted.g g p :=
-            Hex.ZPoly.henselLift_g_congr_mod_base p k f g splitProduct
-              xgcd.left xgcd.right hk
-          have hlin_h_base : Hex.ZPoly.congr linearLifted.h splitProduct p :=
-            Hex.ZPoly.henselLift_h_congr_mod_base p k f g splitProduct
-              xgcd.left xgcd.right hk
-          have hquad_g_base : Hex.ZPoly.congr quadraticLifted.g g p :=
-            Hex.ZPoly.henselLiftQuadratic_g_congr_mod_base p k f' g splitProduct s t hk hp
-              hquad_start
-          have hquad_h_base : Hex.ZPoly.congr quadraticLifted.h splitProduct p :=
-            Hex.ZPoly.henselLiftQuadratic_h_congr_mod_base p k f' g splitProduct s t hk hp
-              hquad_start
-          -- Mathlib-side hypotheses for `hensel_unique`.
-          have hg : (HexPolyMathlib.toPolynomial linearLifted.g).Monic :=
-            toPolynomial_monic_of_dense_monic _ hlin_g_monic
-          have hg' : (HexPolyMathlib.toPolynomial quadraticLifted.g).Monic :=
-            toPolynomial_monic_of_dense_monic _ hquad_g_monic
-          have hg1 :
-              (HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod p)) =
-                (HexPolyMathlib.toPolynomial quadraticLifted.g).map (Int.castRingHom (ZMod p)) :=
-            zpoly_congr_toPolynomial_map_eq _ _ p
-              (Hex.ZPoly.congr_trans _ _ _ p hlin_g_base
-                (Hex.ZPoly.congr_symm _ _ _ hquad_g_base))
-          have hh1 :
-              (HexPolyMathlib.toPolynomial linearLifted.h).map (Int.castRingHom (ZMod p)) =
-                (HexPolyMathlib.toPolynomial quadraticLifted.h).map (Int.castRingHom (ZMod p)) :=
-            zpoly_congr_toPolynomial_map_eq _ _ p
-              (Hex.ZPoly.congr_trans _ _ _ p hlin_h_base
-                (Hex.ZPoly.congr_symm _ _ _ hquad_h_base))
-          have hdeg :
-              (HexPolyMathlib.toPolynomial linearLifted.g).natDegree =
-                (HexPolyMathlib.toPolynomial quadraticLifted.g).natDegree :=
-            natDegree_eq_of_monic_map_eq p hg hg' hg1
-          have hprod :
-              (HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod (p ^ k))) *
-                  (HexPolyMathlib.toPolynomial linearLifted.h).map
-                    (Int.castRingHom (ZMod (p ^ k))) =
-                (HexPolyMathlib.toPolynomial f).map (Int.castRingHom (ZMod (p ^ k))) := by
-            have hmap := zpoly_congr_toPolynomial_map_eq
-              (linearLifted.g * linearLifted.h) f (p ^ k) hlin_prod
-            simpa [HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul] using hmap
-          have hprod' :
-              (HexPolyMathlib.toPolynomial quadraticLifted.g).map (Int.castRingHom (ZMod (p ^ k))) *
-                  (HexPolyMathlib.toPolynomial quadraticLifted.h).map
-                    (Int.castRingHom (ZMod (p ^ k))) =
-                (HexPolyMathlib.toPolynomial f).map (Int.castRingHom (ZMod (p ^ k))) := by
-            have hmap := zpoly_congr_toPolynomial_map_eq
-              (quadraticLifted.g * quadraticLifted.h) f' (p ^ k) hquad_prod
-            have htgt := zpoly_congr_toPolynomial_map_eq f f' (p ^ k) htarget
-            simp only [HexPolyMathlib.toPolynomial_mul, Polynomial.map_mul] at hmap
-            simp only at htgt
-            rw [hmap]; exact htgt.symm
-          have hcop :
-              IsCoprime
-                ((HexPolyMathlib.toPolynomial linearLifted.g).map (Int.castRingHom (ZMod p)))
-                ((HexPolyMathlib.toPolynomial linearLifted.h).map (Int.castRingHom (ZMod p))) := by
-            have hbase := isCoprime_of_zpoly_bezout p g splitProduct s t hbez
-            have hgp : (HexPolyMathlib.toPolynomial linearLifted.g).map
-                (Int.castRingHom (ZMod p)) =
-                (HexPolyMathlib.toPolynomial g).map (Int.castRingHom (ZMod p)) :=
-              zpoly_congr_toPolynomial_map_eq _ _ p hlin_g_base
-            have hhp : (HexPolyMathlib.toPolynomial linearLifted.h).map
-                (Int.castRingHom (ZMod p)) =
-                (HexPolyMathlib.toPolynomial splitProduct).map (Int.castRingHom (ZMod p)) :=
-              zpoly_congr_toPolynomial_map_eq _ _ p hlin_h_base
-            rw [hgp, hhp]; exact hbase
-          obtain ⟨hgeq, hheq⟩ := hensel_unique
-            (HexPolyMathlib.toPolynomial f)
-            (HexPolyMathlib.toPolynomial linearLifted.g)
-            (HexPolyMathlib.toPolynomial linearLifted.h)
-            (HexPolyMathlib.toPolynomial quadraticLifted.g)
-            (HexPolyMathlib.toPolynomial quadraticLifted.h)
-            p k (by omega) hg hg' hdeg hprod hprod' hg1 hh1 hcop
-          -- Recurse on the lifted complements, congruent modulo `p ^ k`.
-          have htarget' : Hex.ZPoly.congr linearLifted.h quadraticLifted.h (p ^ k) :=
-            zpoly_congr_of_toPolynomial_map_eq linearLifted.h quadraticLifted.h (p ^ k) hheq
-          have hmonic' : ∀ q ∈ (h :: tail), Hex.DensePoly.Monic q :=
-            fun q hq => hmonic q (by simp [hq])
-          have hinv' :
-              Hex.ZPoly.MultifactorLiftInvariant p k linearLifted.h (h :: tail) := htail
-          have hexpandL :
-              (Hex.ZPoly.multifactorLiftList p k f (g :: h :: tail)).toList =
-                linearLifted.g ::
-                  (Hex.ZPoly.multifactorLiftList p k linearLifted.h (h :: tail)).toList := by
-            simp [Hex.ZPoly.multifactorLiftList, restFactors, splitProduct, xgcd, linearLifted]
-          have hexpandQ :
-              (Hex.ZPoly.multifactorLiftQuadraticList p k f' (g :: h :: tail)).toList =
-                quadraticLifted.g ::
-                  (Hex.ZPoly.multifactorLiftQuadraticList p k quadraticLifted.h
-                    (h :: tail)).toList := by
-            simp [Hex.ZPoly.multifactorLiftQuadraticList, restFactors, splitProduct, xgcd, s, t,
-              quadraticLifted]
-          rw [hexpandL, hexpandQ, List.map_cons, List.map_cons]
-          refine List.cons_eq_cons.mpr ⟨hgeq, ?_⟩
-          exact ih linearLifted.h quadraticLifted.h hmonic' htarget' hinv'
+          have hne : (g :: h :: tail) ≠ [] := by simp
+          have hqinv :
+              Hex.ZPoly.QuadraticMultifactorLiftInvariant p k f' (g :: h :: tail) :=
+            quadraticMultifactorLiftInvariant_of_multifactorLiftInvariant_congr
+              p k f f' (g :: h :: tail) hk hmonic htarget_p hne hinv
+          have hprod_p :
+              Hex.ZPoly.congr (Array.polyProduct (g :: h :: tail).toArray) f' p :=
+            congr_polyProduct_target p k f f' g h tail htarget_p hinv
+          set out := Hex.ZPoly.multifactorLiftQuadraticList p k f' (g :: h :: tail) with hout
+          have hlen : out.toList.length = (g :: h :: tail).length :=
+            quad_toList_length p k f' (g :: h :: tail)
+          have hout_base : ∀ (i : Nat),
+              Hex.ZPoly.congr (out.toList[i]?.getD 0) ((g :: h :: tail)[i]?.getD 0) p :=
+            quad_each_congr_mod_base p k f' (g :: h :: tail) hk hp hqinv hprod_p
+          have hout_monic : ∀ (i : Nat), i + 1 < out.toList.length →
+              Hex.DensePoly.Monic (out.toList[i]?.getD 0) :=
+            quad_all_but_last_monic p k f' (g :: h :: tail) hk hp hqinv
+          have hqprod :
+              Hex.ZPoly.congr (Array.polyProduct out) f' (p ^ k) := by
+            have h := Hex.ZPoly.multifactorLiftQuadratic_spec p k f' (g :: h :: tail).toArray hk hp
+              (by simpa [Hex.ZPoly.multifactorLiftQuadratic] using hqinv)
+            simpa [Hex.ZPoly.multifactorLiftQuadratic, hout] using h
+          have hout_prod :
+              Hex.ZPoly.congr (Array.polyProduct out.toList.toArray) f (p ^ k) := by
+            have htoarr : out.toList.toArray = out := by simp
+            rw [htoarr]
+            exact Hex.ZPoly.congr_trans _ _ _ (p ^ k) hqprod
+              (Hex.ZPoly.congr_symm _ _ _ htarget)
+          exact output_map_eq_linear p k f (g :: h :: tail) out.toList hk hp hlen
+            hout_monic hout_base hout_prod hinv
 
 /--
 The linear and quadratic multifactor lifters agree modulo `p ^ k` after

--- a/progress/20260707T223000Z_issue-8621-balanced-lift.md
+++ b/progress/20260707T223000Z_issue-8621-balanced-lift.md
@@ -1,0 +1,40 @@
+# issue-8621: balanced product-tree multifactor Hensel lift
+
+## Accomplished
+- Reshaped `Hex.ZPoly.multifactorLiftQuadraticList` (HexHensel/QuadraticMultifactor.lean)
+  from a sequential O(n·r) peel into a balanced product tree (split factor list
+  at length/2, lift prod(L) vs prod(R) via `henselLiftQuadratic`, recurse,
+  concatenate L-then-R). Well-founded on list length.
+- Redefined `QuadraticMultifactorLiftInvariant` and
+  `QuadraticMultifactorCoprimeSplits` on the same balanced recursion.
+- Reproved all 4 public consumers (`multifactorLiftQuadratic_spec`,
+  `_size_eq_input`, `_each_congr_mod_base`, `_each_monic`) via the generated
+  `.induct` principle, plus the producer
+  `quadraticMultifactorLiftInvariant_of_factorsModP`. NO Hensel-uniqueness
+  needed there. Added helpers: `monic_mul`, `monic_polyProduct_toArray`,
+  `polyProduct_map_liftToZ_append`, `congr_getD_append`, `length_take_add_drop`.
+- All public theorem STATEMENTS byte-identical. `HexHensel` and
+  `HexBerlekampZassenhaus` build green.
+
+## Current frontier
+- `lake build HexBerlekampZassenhausMathlib` fails only in
+  `HexHenselMathlib/Correctness.lean` at two UNUSED-but-gating cross-check
+  theorems lock-step-coupled to the old sequential shape:
+  `multifactorLift_eq_multifactorLiftQuadratic` (+ worker
+  `multifactorLiftList_map_eq_quadratic`) and the dead invariant bridge
+  `quadraticMultifactorLiftInvariant_of_multifactorLiftInvariant(_congr)`.
+- Also pending: HenselFactorProps discharger
+  `quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared` (balanced
+  coprime-splits, reuse gcd²∣X squarefree argument, split-agnostic).
+
+## Next step
+- Reprove the invariant bridge: linear invariant → balanced quadratic invariant,
+  deriving prod(L)-vs-prod(R) coprimality via FpPoly CommonDvdOne
+  (`gcd_eq_one_of_monic_of_common_dvd_one`, `coprime_mul_of_coprime_both`) +
+  normalizedXGCD scale-to-1.
+- Reprove the agreement via a generation-agnostic `output_map_eq_linear`
+  (lock-step on linear, balanced output abstract; feed balanced specs).
+- Reprove the discharger for balanced coprime-splits.
+
+## Blockers
+- None hard; main risk is Mathlib/FpPoly coprimality friction in the bridge.

--- a/progress/20260708T000000Z_issue-8621-bridge.md
+++ b/progress/20260708T000000Z_issue-8621-bridge.md
@@ -1,0 +1,31 @@
+# issue-8621: balanced lift — Mathlib bridge reproof in progress
+
+## Accomplished (this turn)
+- Added green helpers to HexHenselMathlib/Correctness.lean (section
+  BalancedBridgeHelpers): `normalizedXGCD_gcd_eq_one_of_common_dvd_one`
+  (coprimality → gcd=1 via FpPoly scale-to-1), `zmod64_inv_ne_zero`,
+  `ZCoprimeSplits` (ZPoly-level balanced split coprimality), and
+  `inv_of_ZCoprimeSplits` (ZPoly balanced invariant producer, no monic-target
+  needed). HexHenselMathlib builds (two remaining `sorry`s in the bridge and the
+  agreement worker).
+- Made monic_mul / monic_polyProduct_toArray / polyProduct_map_liftToZ_append
+  public in HexHensel/QuadraticMultifactor.lean.
+
+## Current frontier
+- Two subagents grinding in parallel:
+  - Bridge + agreement: fill the two Correctness.lean sorries
+    (`_multifactorLiftInvariant_congr` via A1 pairwise-coprime extraction + A2
+    ZCoprimeSplits + inv_of_ZCoprimeSplits; `multifactorLiftList_map_eq_quadratic`
+    via a generation-agnostic `output_map_eq_linear` lock-stepping the linear
+    side and feeding the balanced specs).
+  - Discharger: re-key
+    `quadraticMultifactorCoprimeSplits_of_factorProduct_no_squared` +
+    `factorsModP_coprime_of_factorsModPBerlekampForm` to the balanced
+    `QuadraticMultifactorCoprimeSplits`, reusing the gcd²∣X squarefree argument.
+
+## Next step
+- Integrate both agents' outputs; full `lake build HexBerlekampZassenhausMathlib`
+  green; conformance byte-identical; bench targets compile; second-opinion; PR.
+
+## Blockers
+- None; grinding.

--- a/progress/20260708T003000Z_issue-8621-complete.md
+++ b/progress/20260708T003000Z_issue-8621-complete.md
@@ -1,0 +1,34 @@
+# issue-8621: balanced product-tree multifactor Hensel lift — COMPLETE
+
+## Accomplished
+- HexHensel/QuadraticMultifactor.lean: balanced product-tree reshape of
+  `multifactorLiftQuadraticList` + invariant/coprime-splits redefined on the
+  balanced recursion + all 4 public consumers + producer reproved. Public
+  statements byte-identical to main. monic_mul/monic_polyProduct_toArray/
+  polyProduct_map_liftToZ_append made public for reuse.
+- HexHenselMathlib/Correctness.lean: reproved the linear/quadratic output
+  agreement (`multifactorLiftList_map_eq_quadratic` via a generation-agnostic
+  `output_map_eq_linear`, using an all-but-last monicity argument since the
+  balanced leaves are `reduceModPow(target)`) and the linear→balanced invariant
+  bridge (`_multifactorLiftInvariant_congr` via a target-free pairwise
+  CommonDvdOne extraction + `ZCoprimeSplits` + `inv_of_ZCoprimeSplits`). Added
+  the FpPoly `normalizedXGCD.gcd = 1`-from-coprimality helper.
+- HexBerlekampZassenhausMathlib/HenselFactorProps.lean: re-keyed the
+  coprime-splits discharger to the balanced shape, reusing the gcd²∣X squarefree
+  argument.
+
+## Verification
+- `lake build` (4143 jobs) and `lake build HexBerlekampZassenhausMathlib` green.
+- No sorry/axiom: `#print axioms` on the agreement, the public spec, and the
+  frozen `toMonicLiftData_..._injective` all report only [propext,
+  Classical.choice, Quot.sound].
+- Frozen public statements byte-identical to main.
+- Conformance fixtures byte-identical (hexhensel + hexbz emit == committed).
+- Bench verify: all 16 hexbz benches pass incl runFastPathPrecisionLocalChecksum;
+  hexhensel failures are all runFlint* (no local python-flint), not regressions.
+
+## Next step
+- Second-opinion, open PR, watch CI.
+
+## Blockers
+- None.


### PR DESCRIPTION
This PR reshapes the quadratic multifactor Hensel lift from a sequential O(n·r) peel into a balanced product tree: `multifactorLiftQuadraticList` now splits the factor list in half, lifts each half's product against the target via the existing proven `henselLiftQuadratic` primitive, and recurses into each half, concatenating the two results L-then-R so the lifted-factor array keeps the original order `g1..gn` with identical reduced values. This turns the O(n·r)-total split degree into O(log r) depth / O(n log r) total, giving the measured lift win on `runFastPathPrecisionLocalChecksum` and the verified-Isabelle precision rungs with no recombination-target regression.

The reshape preserves the public theorem surface exactly. `QuadraticMultifactorLiftInvariant` and `QuadraticMultifactorCoprimeSplits` are redefined on the balanced recursion and the four public consumers (`multifactorLiftQuadratic_spec`, `_size_eq_input`, `_each_congr_mod_base`, `_each_monic`) and the producer `quadraticMultifactorLiftInvariant_of_factorsModP` are reproved by well-founded induction — every public statement stays byte-identical, so `QuadraticMultifactorLiftInvariant_of_choosePrimeData`, `multifactorLiftQuadratic_spec`, and the `toMonicLiftData_*` / `LiftData` API are unchanged.

The Mathlib layer is remodelled to match. The linear/quadratic output agreement (`multifactorLiftList_map_eq_quadratic`) is reproved via a generation-agnostic n-ary Hensel-uniqueness engine `output_map_eq_linear` (the old lock-step is impossible once the quadratic side is a tree), and the linear→balanced invariant bridge is reproved via a target-free pairwise-coprimality extraction plus a new FpPoly `normalizedXGCD.gcd = 1`-from-coprimality helper. The coprime-splits discharger in `HenselFactorProps` is re-keyed to the balanced split, reusing the split-agnostic `gcd² ∣ X` squarefree argument.

Output is preserved because the Hensel lift is unique modulo `p^k`: the FLINT conformance fixtures (`hexhensel`, `hexbz`) emit byte-identical, the whole `HexBerlekampZassenhausMathlib` library stays green, and `#print axioms` on the agreement, the public spec, and the frozen `toMonicLiftData_..._injective` reports only the standard axioms.

Closes #8621.

🤖 Prepared with Claude Code
