### PR TITLE
refactor(lll): rename `lllReducedExact` to `lllReduced`

### DIFF
--- a/HexLLL/Checker.lean
+++ b/HexLLL/Checker.lean
@@ -12,7 +12,7 @@ public import HexLLL.Interval
 public section
 
 /-!
-Executable reducedness checkers: the exact integer `lllReducedExact`, the
+Executable reducedness checkers: the exact integer `lllReduced`, the
 fixed-precision `lllReducedInterval`, their cost-predicted dispatch
 `lllReducedCheck`, and the bundled external-candidate checker `certCheck`.
 -/
@@ -43,7 +43,7 @@ the Gram-Schmidt data of `b` from its exact integer Gram matrix and accepts
 only when every independence, size-reduction, and Lovász inequality is
 decided with the enclosure strictly on the correct side. `false` means
 "not reduced or indecisive at this precision": callers must fall back to
-the exact checker `lllReducedExact`, which keeps completeness structural.
+the exact checker `lllReduced`, which keeps completeness structural.
 Soundness (`lllReducedInterval_sound`, HexLLLMathlib) entails
 `b.independent ∧ isLLLReduced b δ η` at the exact rational parameters. -/
 @[expose]
@@ -70,11 +70,11 @@ Verifies, over integer arithmetic only:
 No validity hypothesis on `η` is required: a malformed `η` (e.g. negative) is
 incompatible with a positive `d[j+1]` and the size-reduced bound, so the
 checker simply returns `false`. Soundness
-(`lllReducedExact_sound`, HexLLLMathlib) bridges to the rational predicate
+(`lllReduced_sound`, HexLLLMathlib) bridges to the rational predicate
 `isLLLReduced` via the integer correspondence
 (`Hex.GramSchmidt.Int.scaledCoeffs_eq`, `basis_normSq`, `gramDet_pos`). -/
 @[expose]
-def lllReducedExact (b : Matrix Int n m) (δ η : Rat) : Bool :=
+def lllReduced (b : Matrix Int n m) (δ η : Rat) : Bool :=
   let gs := GramSchmidt.Int.data b
   let d := gs.d
   let ν := gs.ν
@@ -212,7 +212,7 @@ end Internal
 
 /-- Reducedness clause of the certified dispatch. On the same integer
 `d`/`ν` data, two checkers can decide reducedness: the exact integer
-checker `lllReducedExact`, always complete, and a faster fixed-precision
+checker `lllReduced`, always complete, and a faster fixed-precision
 interval pass. The size predictor `intervalWins` picks which to run first;
 when the interval pass is indecisive it falls back to the exact checker,
 so completeness stays structural rather than numerical. Records each
@@ -223,16 +223,16 @@ def lllReducedCheck (b : Matrix Int n m) (δ η : Rat) : Bool :=
     if lllReducedInterval b δ η then
       withRecordCheckerOutcome .interval true
     else
-      withRecordCheckerOutcome .exactFallback (lllReducedExact b δ η)
+      withRecordCheckerOutcome .exactFallback (lllReduced b δ η)
   else
-    withRecordCheckerOutcome .exactPrimary (lllReducedExact b δ η)
+    withRecordCheckerOutcome .exactPrimary (lllReduced b δ η)
 
 /-- Executable certified-dispatch checker: verifies that `(B', U, V)` is a valid
 external candidate for reducing `B`, i.e. `B` and `B'` generate the same integer
 row lattice (witnessed by `U`, `V`) and `B'` is `(δ, η)`-reduced.
 
 Composes the Mathlib-free Bool checkers `Matrix.sameLatticeCert` and
-`lllReducedCheck` (interval decision with exact `lllReducedExact` fallback).
+`lllReducedCheck` (interval decision with exact `lllReduced` fallback).
 Soundness (`certCheck_sound`, HexLLLMathlib) entails the property triple
 `(same lattice, B' independent, isLLLReduced B' δ η)` and is the single
 trusted bridge that the certified-dispatch path of `lll` depends on. -/

--- a/HexLLL/README.md
+++ b/HexLLL/README.md
@@ -66,7 +66,7 @@ def B : Matrix Int 3 3 := Matrix.ofFn fun i j =>
 #eval lllNative.shortVectors B (3 / 4)
 
 -- The executable integer reducedness oracle.
-#eval lllReducedExact (Matrix.identity 3) (3 / 4) (1 / 2)   -- true
+#eval lllReduced (Matrix.identity 3) (3 / 4) (1 / 2)   -- true
 ```
 
 # Functionality
@@ -100,7 +100,7 @@ The surface, by group:
   guarantee.
 - `lllNative.firstShortVector` and `lllNative.shortVectors`: proof-free
   variants of the entry points for callers without an independence proof.
-- `lllReducedExact`, `lllReducedInterval`, and `lllReducedCheck`: the exact,
+- `lllReduced`, `lllReducedInterval`, and `lllReducedCheck`: the exact,
   fixed-precision, and dispatched reducedness oracles; `certCheck` is the
   integer certificate checker for an external reducer's output.
 - `Matrix.memLattice`, `Matrix.independent`, and `Vector.normSq` for stating

--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -437,7 +437,7 @@ classification below is mirrored as structured metadata in
   architectural asymmetries the comparison is read against — the Isabelle path
   spawns the `fplll` binary per call (this library uses in-process `fplll-ffi`)
   and re-runs the full verified LLL to confirm reducedness (this library runs
-  the `lllReducedExact` integer check).
+  the `lllReduced` integer check).
 - **`verified Isabelle LLL`** — `gating`. The Bottesch–Divasón–
   Haslbeck–Joosten–Thiemann–Yamada formalisation in the Archive of
   Formal Proofs (entry `LLL_Basis_Reduction`) is the only other

--- a/HexLLLMathlib/Checker.lean
+++ b/HexLLLMathlib/Checker.lean
@@ -16,7 +16,7 @@ public section
 
 /-!
 Soundness of the executable reducedness checkers: acceptance of the exact
-`lllReducedExact`, the dispatched `lllReducedCheck`, and the bundled
+`lllReduced`, the dispatched `lllReducedCheck`, and the bundled
 `certCheck` entails the rational `Hex.isLLLReduced` predicate, independence,
 and the same-lattice property. The interval branch consumes
 `lllReducedInterval_sound`.
@@ -26,10 +26,10 @@ namespace HexLLLMathlib
 
 /-! ### Soundness of the integer reducedness checker
 
-`Hex.lllReducedExact b δ η` accepts iff three integer-only inequalities hold over
+`Hex.lllReduced b δ η` accepts iff three integer-only inequalities hold over
 `Hex.GramSchmidt.Int.data b`. This section bridges those integer inequalities
 to the rational predicate `Hex.isLLLReduced b δ η` and to `b.independent`, the
-last theorem (`Hex.lllReducedExact_sound`) being the D2 deliverable used by the
+last theorem (`Hex.lllReduced_sound`) being the D2 deliverable used by the
 combined `certCheck_sound` of `hex-lll` §"Certified external dispatch". -/
 
 /-- Independence from the executable checker's `d`-positivity pass.
@@ -363,12 +363,12 @@ both `b.independent` and the rational `isLLLReduced b δ η` predicate.
 This is one of the two soundness ingredients feeding the combined
 `certCheck_sound` of `hex-lll` §"Certified external dispatch". The
 companion same-lattice piece is `Hex.Matrix.sameLatticeCert_sound`. -/
-theorem lllReducedExact_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
-    Hex.lllReducedExact b δ η = true →
+theorem lllReduced_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
+    Hex.lllReduced b δ η = true →
       Hex.isLLLReduced b δ η ∧ Hex.Matrix.independent b := by
   intro hcheck
   -- Unfold the three pieces of the Bool check.
-  unfold Hex.lllReducedExact at hcheck
+  unfold Hex.lllReduced at hcheck
   simp only [Bool.and_eq_true, List.all_eq_true, List.mem_finRange,
     decide_eq_true_eq, forall_true_left] at hcheck
   obtain ⟨⟨hdPos, hsize⟩, hlovasz_raw⟩ := hcheck
@@ -413,7 +413,7 @@ theorem lllReducedExact_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
 whichever side decided — the fixed-precision interval checker
 (`HexLLLMathlib.lllReducedInterval_sound`), the exact integer checker
 chosen by the size predictor, or the exact fallback after interval
-indecision (both via `lllReducedExact_sound` above) — acceptance entails
+indecision (both via `lllReduced_sound` above) — acceptance entails
 the rational `isLLLReduced` predicate and independence. The predictor
 `Hex.Internal.intervalWins` only selects between sound checkers, so no hypothesis
 about it is needed. -/
@@ -428,9 +428,9 @@ theorem lllReducedCheck_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
     by_cases hint : Hex.lllReducedInterval b δ η = true
     · exact HexLLLMathlib.lllReducedInterval_sound b δ η hint
     · rw [if_neg (by simpa using hint)] at hcheck
-      exact lllReducedExact_sound b δ η hcheck
+      exact lllReduced_sound b δ η hcheck
   · rw [if_neg (by simpa using hwin)] at hcheck
-    exact lllReducedExact_sound b δ η hcheck
+    exact lllReduced_sound b δ η hcheck
 
 /-- Soundness of the certified-dispatch checker `Hex.certCheck`: an accepted
 certificate `(B', U, V)` proves that `B` and `B'` generate the same integer row

--- a/HexLLLMathlib/Interval.lean
+++ b/HexLLLMathlib/Interval.lean
@@ -895,7 +895,7 @@ private theorem independent_of_nrm_pos (b : Hex.Matrix Int n m)
 /-- Acceptance by the fixed-precision interval checker entails the exact
 rational reducedness predicate and independence. This is the trusted
 statement consumed by `lllReducedCheck_sound` / `certCheck_sound`; the
-exact-integer fallback path is covered by `lllReducedExact_sound`. -/
+exact-integer fallback path is covered by `lllReduced_sound`. -/
 theorem lllReducedInterval_sound (b : Hex.Matrix Int n m) (δ η : Rat) :
     Hex.lllReducedInterval b δ η = true →
       Hex.isLLLReduced b δ η ∧ Hex.Matrix.independent b := by

--- a/HexLLLMathlib/README.md
+++ b/HexLLLMathlib/README.md
@@ -111,7 +111,7 @@ algebra:
   `lllNative_first_row_norm_sq_le`, and the lattice-preservation
   transfer lemmas `lll_mem_latticeSubmodule_iff` and
   `lllNative_mem_latticeSubmodule_iff`.
-- the checker soundness theorems `lllReducedExact_sound`,
+- the checker soundness theorems `lllReduced_sound`,
   `lllReducedInterval_sound`, `lllReducedCheck_sound`, and `certCheck_sound`,
   which entail the rational `Hex.isLLLReduced` predicate and the same-lattice
   property from acceptance of the executable Bool checkers.

--- a/conformance/HexLLL/Conformance.lean
+++ b/conformance/HexLLL/Conformance.lean
@@ -316,12 +316,12 @@ private def independentCheck (b : Matrix Int n m) : Bool :=
 #guard !independentCheck zero8
 #guard !independentCheck dependent8x4
 
--- `lllReducedExact` is the executable reducedness oracle over
+-- `lllReduced` is the executable reducedness oracle over
 -- `GramSchmidt.Int.data`: identity is fully (3/4, 1/2)-reduced, while zero
 -- and dependent bases fail independence.
-#guard lllReducedExact identity8 (3/4 : Rat) (1/2 : Rat)
-#guard !lllReducedExact zero8 (3/4 : Rat) (1/2 : Rat)
-#guard !lllReducedExact dependent8x4 (3/4 : Rat) (1/2 : Rat)
+#guard lllReduced identity8 (3/4 : Rat) (1/2 : Rat)
+#guard !lllReduced zero8 (3/4 : Rat) (1/2 : Rat)
+#guard !lllReduced dependent8x4 (3/4 : Rat) (1/2 : Rat)
 
 #guard Matrix.row certReduced2 f0_2 = Matrix.row certInput2 f1_2
 #guard Matrix.row certReduced2 f1_2 =

--- a/progress/2026-07-08T06-07-42Z.md
+++ b/progress/2026-07-08T06-07-42Z.md
@@ -1,0 +1,14 @@
+# Rename `lllReducedExact` → `lllReduced`
+
+## Accomplished
+Renamed the exact all-integer LLL reducedness checker to `lllReduced` (from
+`lllReducedExact`, née `lllReducedInt`). `lllReducedInterval` and
+`lllReducedCheck` are unchanged; no collision with the `isLLLReduced`
+predicate. Compiler-driven rename, full build green (2785 jobs).
+
+## Next step
+Reconcile the leanprover/hex aggregate baseline (advance to 19d4797, the
+HexAll→Hex umbrella rename), then release-sync.
+
+## Blockers
+None.


### PR DESCRIPTION
Rename the exact all-integer reducedness checker to `lllReduced` (and `lllReducedExact_sound` → `lllReduced_sound`), following up on the earlier `lllReducedInt` → `lllReducedExact` rename — `lllReduced` is the name we actually want. It reads as the executable Bool checker alongside the `isLLLReduced` predicate, the fixed-precision `lllReducedInterval`, and the dispatching `lllReducedCheck`. Pure rename, no behavioural change; SPEC, READMEs, and conformance updated.

Green: full `lake build` (2785 jobs). Second opinion (Codex): no naming or mechanical concerns.

🤖 Prepared with Claude Code