### PR TITLE
feat(bz): computable DecidablePred for irreducibility over Polynomial (ZMod p)

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -1215,11 +1215,6 @@ theorem checkIrreducibilityCertificate_irreducible
   exact rabinTest_true_irreducible f hmonic
     (Hex.Berlekamp.checkIrreducibilityCertificate_rabinTest f hmonic cert hcheck)
 
-/-- Mathlib irreducibility over `Polynomial (ZMod p)` is classically decidable. -/
-instance irreducibleDecidablePred (p : Nat) [Fact (Nat.Prime p)] :
-    DecidablePred (fun f : Polynomial (ZMod p) => Irreducible f) :=
-  Classical.decPred _
-
 end
 
 /-!
@@ -1339,6 +1334,28 @@ instance instDecidableIrreducibleToMathlibPolynomial
     [Fact (Nat.Prime p)] (f : Hex.FpPoly p) :
     Decidable (Irreducible (toMathlibPolynomial f)) :=
   decidable_of_iff _ (fpIsIrreducible_iff f)
+
+/-- Transporting a Mathlib polynomial to its executable `FpPoly p` preimage and
+back is the identity: `polynomialToFpPoly = fpPolyEquiv.symm` and
+`toMathlibPolynomial = fpPolyEquiv`, so this is `RingEquiv.apply_symm_apply`. -/
+theorem toMathlibPolynomial_polynomialToFpPoly (g : Polynomial (ZMod p)) :
+    toMathlibPolynomial (polynomialToFpPoly g) = g := by
+  rw [← fpPolyEquiv_symm_apply, ← fpPolyEquiv_apply, RingEquiv.apply_symm_apply]
+
+/-- Mathlib irreducibility over `Polynomial (ZMod p)` is decidable, by rebuilding
+the executable `FpPoly p` preimage and deciding irreducibility of its transport
+(which equals the original by `toMathlibPolynomial_polynomialToFpPoly`).
+
+This wraps `instDecidableIrreducibleToMathlibPolynomial`. Unlike that
+`FpPoly`-image instance, it is *not* meant for `decide +kernel`: Mathlib's
+`Polynomial` is `Finsupp`-based and does not reduce in the kernel, so the
+`FpPoly`-image instance remains the load-bearing one for kernel evaluation. This
+instance replaces the former `Classical.decPred _` with a genuinely computable
+decision. -/
+instance irreducibleDecidablePred [Fact (Nat.Prime p)] :
+    DecidablePred (fun g : Polynomial (ZMod p) => Irreducible g) := fun g =>
+  decidable_of_iff (Irreducible (toMathlibPolynomial (polynomialToFpPoly g)))
+    (by rw [toMathlibPolynomial_polynomialToFpPoly])
 
 /-- `X² + X + 1` is irreducible over `F₂`, certified by kernel reduction of
 `fpIsIrreducible` through `instDecidableIrreducibleToMathlibPolynomial`, using

--- a/progress/2026-07-08T06-31-10Z_issue-8571-roundtrip.md
+++ b/progress/2026-07-08T06-31-10Z_issue-8571-roundtrip.md
@@ -1,0 +1,46 @@
+# Issue #8571 follow-up: `DecidablePred (Irreducible ·)` over `Polynomial (ZMod p)`
+
+## Accomplished
+
+Landed the optional extension from #8571 (merged in #8653): a computable
+`DecidablePred (fun g : Polynomial (ZMod p) => Irreducible g)` via the
+`polynomialToFpPoly` (= `fpPolyEquiv.symm`) round-trip.
+
+Added to `HexBerlekampMathlib/Basic.lean`:
+
+- `toMathlibPolynomial_polynomialToFpPoly` — the round-trip identity
+  `toMathlibPolynomial (polynomialToFpPoly g) = g`, proved as
+  `RingEquiv.apply_symm_apply` through the `fpPolyEquiv_apply` /
+  `fpPolyEquiv_symm_apply` bridges.
+- `irreducibleDecidablePred` — the `DecidablePred` instance, wrapping
+  `instDecidableIrreducibleToMathlibPolynomial` on the executable preimage.
+
+Removed the former classical `irreducibleDecidablePred := Classical.decPred _`
+(unused downstream — the only other `irreducibleDecidablePred` is FactorSoundness's
+over `Polynomial ℤ`), so there is a single, computable instance rather than a
+classical/computable pair that would fight during resolution.
+
+## Key notes
+
+- This wrapper is *not* for `decide +kernel`: Mathlib `Polynomial` is `Finsupp`-based
+  and does not kernel-reduce; the `FpPoly`-image instance
+  `instDecidableIrreducibleToMathlibPolynomial` from #8653 remains the
+  load-bearing kernel-evaluable one. This matches the issue's framing
+  ("nice-to-have, not the point").
+- The new instance requires `[Bounds p]` (to build the executable preimage) in
+  addition to `[Fact (Nat.Prime p)]`; the old classical one needed only `Fact`,
+  but had no consumers relying on the weaker signature.
+
+## Verification
+
+- `lake build HexBerlekampZassenhausMathlib` (CI-gated target) green, 3808 jobs,
+  0 errors, on a branch rebased onto post-#8653 `main`.
+- Added lines are `sorry`/`axiom`/`native_decide`-free.
+
+## Next step
+
+Open follow-up PR.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR lands the optional extension of #8571 (implemented in #8653): a computable `DecidablePred (fun g : Polynomial (ZMod p) => Irreducible g)`, obtained by rebuilding the executable `FpPoly p` preimage via `polynomialToFpPoly` (= `fpPolyEquiv.symm`) and deciding irreducibility of its transport, which equals the original by the round-trip identity `toMathlibPolynomial_polynomialToFpPoly` (`RingEquiv.apply_symm_apply`).

The instance wraps the `FpPoly`-image instance `instDecidableIrreducibleToMathlibPolynomial` and replaces the former `Classical.decPred _` for the same predicate with a genuinely computable decision; the classical instance had no downstream consumers. Unlike the `FpPoly`-image instance, this wrapper is not intended for `decide +kernel`: Mathlib's `Polynomial` is `Finsupp`-based and does not reduce in the kernel, so the executable-image instance remains the load-bearing one for kernel evaluation.

The full CI-gated target `HexBerlekampZassenhausMathlib` builds green; the added lines are `sorry`/`axiom`/`native_decide`-free.

Follow-up to #8571 / #8653.

🤖 Prepared with Claude Code