### PR TITLE
refactor(bz): drop the Polynomial (ZMod p) irreducibility DecidablePred

### DIFF
--- a/HexBerlekampMathlib/Basic.lean
+++ b/HexBerlekampMathlib/Basic.lean
@@ -1335,28 +1335,6 @@ instance instDecidableIrreducibleToMathlibPolynomial
     Decidable (Irreducible (toMathlibPolynomial f)) :=
   decidable_of_iff _ (fpIsIrreducible_iff f)
 
-/-- Transporting a Mathlib polynomial to its executable `FpPoly p` preimage and
-back is the identity: `polynomialToFpPoly = fpPolyEquiv.symm` and
-`toMathlibPolynomial = fpPolyEquiv`, so this is `RingEquiv.apply_symm_apply`. -/
-theorem toMathlibPolynomial_polynomialToFpPoly (g : Polynomial (ZMod p)) :
-    toMathlibPolynomial (polynomialToFpPoly g) = g := by
-  rw [← fpPolyEquiv_symm_apply, ← fpPolyEquiv_apply, RingEquiv.apply_symm_apply]
-
-/-- Mathlib irreducibility over `Polynomial (ZMod p)` is decidable, by rebuilding
-the executable `FpPoly p` preimage and deciding irreducibility of its transport
-(which equals the original by `toMathlibPolynomial_polynomialToFpPoly`).
-
-This wraps `instDecidableIrreducibleToMathlibPolynomial`. Unlike that
-`FpPoly`-image instance, it is *not* meant for `decide +kernel`: Mathlib's
-`Polynomial` is `Finsupp`-based and does not reduce in the kernel, so the
-`FpPoly`-image instance remains the load-bearing one for kernel evaluation. This
-instance replaces the former `Classical.decPred _` with a genuinely computable
-decision. -/
-instance irreducibleDecidablePred [Fact (Nat.Prime p)] :
-    DecidablePred (fun g : Polynomial (ZMod p) => Irreducible g) := fun g =>
-  decidable_of_iff (Irreducible (toMathlibPolynomial (polynomialToFpPoly g)))
-    (by rw [toMathlibPolynomial_polynomialToFpPoly])
-
 /-- `X² + X + 1` is irreducible over `F₂`, certified by kernel reduction of
 `fpIsIrreducible` through `instDecidableIrreducibleToMathlibPolynomial`, using
 only the trusted kernel. -/


### PR DESCRIPTION
This PR removes `irreducibleDecidablePred` over `Polynomial (ZMod p)` and its supporting round-trip lemma `toMathlibPolynomial_polynomialToFpPoly`, both added in #8659. The instance cannot actually be run by `decide`: Mathlib's `Polynomial` is `Finsupp`-based and does not kernel-reduce, and `polynomialToFpPoly` is noncomputable, so neither `decide`/`decide +kernel` nor `native_decide` can evaluate it on a `Polynomial (ZMod p)` literal. With no consumers, it is pure clutter.

The load-bearing, kernel-runnable instance `instDecidableIrreducibleToMathlibPolynomial` over the executable `FpPoly p` image (from #8653) is unaffected; the full CI-gated target `HexBerlekampZassenhausMathlib` builds green.

Reverts the substance of #8659.

🤖 Prepared with Claude Code