### PR TITLE
doc: backport blog example cleanups into HexManual

### DIFF
--- a/HexManual/Chapters/HexLLL.lean
+++ b/HexManual/Chapters/HexLLL.lean
@@ -108,7 +108,7 @@ leading Gram determinants `d` and the integer scaled coefficients `ν`),
 so a `Bool` answer needs only exact integer comparisons. The base checker
 clears denominators in both the size-reduced and Lovász clauses.
 
-{docstring Hex.lllReducedInt}
+{docstring Hex.lllReduced}
 
 The exact integer checker is complete, but its operands grow with the
 input. For larger inputs an unverified fixed-precision interval pass over
@@ -349,8 +349,8 @@ private theorem hhi : (3 / 4 : Rat) ≤ 1 := by grind
 
 -- The verified checker rejects the input basis
 -- (not size-reduced) and accepts the output.
-#guard lllReducedInt B (3 / 4) (11 / 20) = false
-#guard lllReducedInt R (3 / 4) (11 / 20) = true
+#guard lllReduced B (3 / 4) (11 / 20) = false
+#guard lllReduced R (3 / 4) (11 / 20) = true
 
 -- U, V certify that B and R share a lattice, and
 -- certCheck combines that with reducedness of R.
@@ -423,7 +423,7 @@ proofs in `HexLLLMathlib`:
   {ref "hex-lll-checkers"}[integer checkers] are defined. Through it,
   `HexLLL` rests transitively on the fraction-free integer determinant
   libraries `HexBareiss`, `HexDeterminant`, and `HexRowReduce`.
-* `HexLLLMathlib` carries the soundness theorems. `lllReducedInt_sound`
+* `HexLLLMathlib` carries the soundness theorems. `lllReduced_sound`
   and `lllReducedCheck_sound` relate the integer checkers to
   {name}`Hex.isLLLReduced`, and `certCheck_sound` combines those with
   {name}`Hex.Matrix.sameLatticeCert_sound` into the property triple (same

--- a/HexManual/Chapters/HexMatrix.lean
+++ b/HexManual/Chapters/HexMatrix.lean
@@ -83,6 +83,42 @@ the Bareiss recurrence:
 
 {docstring Hex.Matrix.principalSubmatrix}
 
+# Arithmetic worked example
+%%%
+tag := "hex-matrix-arithmetic"
+%%%
+
+A compact tour of the core arithmetic: {name}`Hex.Matrix.getRow` reads a
+row and `M[(i, j)]` reads a single entry, {name}`Hex.Matrix.mulVec`
+multiplies by a vector, and `+`, `•`, and {name}`Hex.Matrix.identity` are
+the entrywise sum, scalar action, and identity.
+
+```lean
+open Hex
+
+namespace HexMatrixArithmetic
+
+def M : Matrix Int 2 2 := #m[1, 2; 3, 4]
+def v : Vector Int 2 := #v[5, 6]
+
+-- A single entry, read with M[(row, col)].
+def corner : Int := M[(1, 1)]
+
+-- getRow reads a whole row; `corner` holds one entry.
+#guard M.getRow 1 = #v[3, 4]
+#guard corner = 4
+
+-- Matrix-vector product, entrywise sum, scalar action.
+#guard M.mulVec v = #v[17, 39]
+#guard M + M = #m[2, 4; 6, 8]
+#guard (2 : Int) • M = #m[2, 4; 6, 8]
+
+-- The identity fixes every vector.
+#guard (Matrix.identity (R := Int) 2).mulVec v = v
+
+end HexMatrixArithmetic
+```
+
 # Entry, row, and column lemmas
 %%%
 tag := "hex-matrix-lemmas"

--- a/HexManual/Chapters/HexRowReduce.lean
+++ b/HexManual/Chapters/HexRowReduce.lean
@@ -128,11 +128,13 @@ tag := "hex-row-reduce-recipe-kernel"
 %%%
 
 You have a matrix over a field and want a basis for its kernel: the
-vectors `x` with `M * x = 0`. {name}`Hex.Matrix.nullspaceBasisMatrix`
-returns the basis as the columns of a matrix, one column per free
-(non-pivot) column of `M`.
+vectors `x` with `M * x = 0`. {name}`Hex.Matrix.nullspace` returns that
+basis as a length-indexed vector of basis vectors, one per free
+(non-pivot) column of `M`; the recipe reads it back with `.toList`.
+({name}`Hex.Matrix.nullspaceBasisMatrix` returns the same vectors as the
+columns of a matrix.)
 
-```lean (name := kernelBasis)
+```lean
 open Hex Hex.Matrix
 
 namespace HexRowReduceKernelRecipe
@@ -143,22 +145,14 @@ def M : Matrix Rat 2 3 := #m[1, 2, 3; 2, 4, 6]
 -- The reduction reports rank 1, so nullity is 3 - 1 = 2.
 #guard (Matrix.rowReduce M).rank = 1
 
--- The kernel basis, as the columns of a matrix.
-#eval Matrix.nullspaceBasisMatrix M
-
--- The nullity is m - rank = 3 - 1 = 2.
-#guard (Matrix.nullspace M).toArray.size = 2
+-- The nullity-2 kernel basis, one vector per free column.
+#guard (nullspace M).toList = [#v[-2, 1, 0], #v[-3, 0, 1]]
 
 end HexRowReduceKernelRecipe
 ```
-```leanOutput kernelBasis
-#m[-2, -3;
-    1,  0;
-    0,  1]
-```
 
-Each column is a basis vector: the kernel is spanned by `(-2, 1, 0)` and
-`(-3, 0, 1)`. It is a genuine basis, not just a spanning set:
+The two vectors `(-2, 1, 0)` and `(-3, 0, 1)` span the kernel. It is a
+genuine basis, not just a spanning set:
 {name}`Hex.Matrix.nullspace_sound` says each vector is annihilated by
 `M`, and {name}`Hex.Matrix.nullspace_complete` that every `x` with
 `M * x = 0` is a combination of them.
@@ -222,8 +216,8 @@ namespace HexRowReduceSpanRecipe
 
 def M : Matrix Rat 2 3 := #m[1, 2, 3; 2, 4, 6]
 
--- (1, 2, 3) is the first row, so it is in the row span.
-#eval Matrix.spanContains M #v[1, 2, 3]
+-- (3, 6, 9) = 3·(1, 2, 3) is in the row span.
+#eval Matrix.spanContains M #v[3, 6, 9]
 
 -- A vector off the rows' line is not.
 #guard Matrix.spanContains M #v[1, 0, 0] = false

--- a/HexManual/Tutorials/Coppersmith.lean
+++ b/HexManual/Tutorials/Coppersmith.lean
@@ -105,25 +105,20 @@ open Hex
 namespace TutorialCoppersmith
 
 -- Public data the attacker starts from.
-private def N : Int := 10_000_004_400_000_259
-private def X : Int := 100
+private def N : Nat := 10_000_004_400_000_259
+private def X : Nat := 100
 private def a : Int := 55_555_500
 private def c : Int := 3_100_253_145_270_284
 
--- Least residue of z modulo n, in (-n/2, n/2].
-private def centerMod (n z : Int) : Int :=
-  let r := ((z % n) + n) % n
-  if 2 * r > n then r - n else r
-
--- Coefficients of f(x) = (a + x)^3 - c, reduced mod N.
-private def a0 : Int := centerMod N (a ^ 3 - c)
-private def a1 : Int := centerMod N (3 * a ^ 2)
-private def a2 : Int := centerMod N (3 * a)
+-- Coefficients of f(x) = (a + x)^3 - c, balanced mod N.
+private def a0 : Int := Int.bmod (a ^ 3 - c) N
+private def a1 : Int := Int.bmod (3 * a ^ 2) N
+private def a2 : Int := Int.bmod (3 * a) N
 
 -- The Coppersmith lattice, one polynomial per row,
 -- degree-j column scaled by X^j.
 private def B : Matrix Int 4 4 :=
-  #m[N,   0,      0,          0;
+  #m[(N : Int), 0,      0,          0;
      0,   N * X,  0,          0;
      0,   0,      N * X * X,  0;
      a0,  a1 * X, a2 * X * X, X * X * X]
@@ -153,13 +148,12 @@ private def recover : Option Int := Id.run do
     | none => pure ()
     | some g =>
       for x in [0:100] do
-        let xi : Int := (x : Int)
-        if evalPoly g xi == 0 && (a + xi) ^ 3 % N == c then
-          return some xi
+        if evalPoly g x == 0 && (a + x) ^ 3 % N == c then
+          return some x
   return none
 
 -- LLL actually reduced the basis.
-#guard lllReducedInt reduced (3 / 4) (1 / 2) == true
+#guard lllReduced reduced (3 / 4) (1 / 2) == true
 
 -- The recovered code is 42.
 #guard recover == some 42
@@ -199,21 +193,17 @@ namespace TutorialCoppersmithFactor
 
 -- A 2048-bit RSA modulus N = p * q, with p and q the primes
 -- just below 2^1024. Exponent e = 3, no padding.
-private def p : Int := 2 ^ 1024 - 105
-private def q : Int := 2 ^ 1024 - 179
-private def N : Int := p * q
+private def p : Nat := 2 ^ 1024 - 105
+private def q : Nat := 2 ^ 1024 - 179
+private def N : Nat := p * q
 
 -- The known 1202-bit template a and unknown 400-bit secret
 -- x0 give c = (a + x0)^3 mod N. The attacker sees only the
 -- public data N, a, c, and the bound X.
 private def a  : Int := 3 ^ 758
 private def x0 : Int := 2 ^ 399 + 271828182
-private def X  : Int := 2 ^ 400
+private def X  : Nat := 2 ^ 400
 private def c  : Int := (a + x0) ^ 3 % N
-
-private def centerMod (n z : Int) : Int :=
-  let r := ((z % n) + n) % n
-  if 2 * r > n then r - n else r
 
 -- Little-endian polynomials: coefficient k is the x^k term.
 private abbrev Poly := Array Int
@@ -236,10 +226,10 @@ private def pow (u : Poly) : Nat → Poly
   | 0 => #[1]
   | n + 1 => mul (pow u n) u
 
--- f(x) = (a + x)^3 - c, reduced mod N to small coeffs.
+-- f(x) = (a + x)^3 - c, balanced mod N with `Int.bmod`.
 private def f : Poly :=
-  #[centerMod N (a ^ 3 - c), centerMod N (3 * a ^ 2),
-    centerMod N (3 * a), 1]
+  #[Int.bmod (a ^ 3 - c) N, Int.bmod (3 * a ^ 2) N,
+    Int.bmod (3 * a) N, 1]
 
 -- Nine rows N^(2-j) * x^i * f(x)^j (j, i in 0,1,2), col k
 -- scaled by X^k. Each vanishes at x0 mod N^2; added shift
@@ -250,7 +240,7 @@ private def rows : Array Poly := Id.run do
   for j in [0:3] do
     let fj := pow f j
     for i in [0:3] do
-      let row := scale (N ^ (2 - j)) (shift i fj)
+      let row := scale ((N : Int) ^ (2 - j)) (shift i fj)
       rs := rs.push
         ((Array.range 9).map fun k => row.getD k 0 * X ^ k)
   return rs
@@ -284,14 +274,14 @@ private def g : Poly := Id.run do
 -- X ~ 2^400 is hopeless; factoring degree-8 g is instant.
 private def recovered : Option Int := Id.run do
   for (fac, _) in (factor (DensePoly.ofCoeffs g)).factors do
-    let cs := fac.toArray
-    if cs.size == 2 then
-      let c0 := cs.getD 0 0
-      let c1 := cs.getD 1 0
-      if c1 != 0 && c0 % c1 == 0 then
-        let r := -c0 / c1
+    -- Linear factor `p·x + q` has root `-q/p` when `p ∣ q`.
+    match fac.toArray with
+    | #[q, p] =>
+      if p != 0 && q % p == 0 then
+        let r := -q / p
         if 0 ≤ r && r < X && (a + r) ^ 3 % N == c then
           return some r
+    | _ => pure ()
   return none
 
 -- The modulus is 2048 bits; the secret is about 400 bits.
@@ -299,7 +289,7 @@ private def recovered : Option Int := Id.run do
 #guard x0 > 2 ^ 399
 
 -- LLL reduces the basis; factoring g gives back x0.
-#guard lllReducedInt reduced (3 / 4) (1 / 2) == true
+#guard lllReduced reduced (3 / 4) (1 / 2) == true
 #guard recovered == some x0
 
 end TutorialCoppersmithFactor

--- a/progress/20260708T085513Z_issue-8656.md
+++ b/progress/20260708T085513Z_issue-8656.md
@@ -1,0 +1,45 @@
+# Accomplished
+
+Backported the blog's verified example cleanups into `HexManual`
+(issue #8656):
+
+- **Coppersmith tutorial** (`HexManual/Tutorials/Coppersmith.lean`,
+  both the toy and 2048-bit blocks): replaced the hand-rolled
+  `centerMod` with `Int.bmod`, making `N` and `X` `Nat` and casting
+  `(N : Int)` where an `Int` is needed. Replaced the index-juggling
+  `recovered` with a pattern match `match fac.toArray with | #[q, p] =>`
+  on the linear factor (`p·x + q`, root `-q/p` when `p ∣ q`). Dropped
+  the `let xi := (x : Int)` in the toy `recover`.
+- **HexRowReduce chapter**: the kernel recipe now uses the single
+  assertion `#guard (nullspace M).toList = [#v[-2, 1, 0], #v[-3, 0, 1]]`
+  instead of an `#eval nullspaceBasisMatrix` plus a `.toArray.size`
+  check; the span recipe uses the non-trivial `spanContains M #v[3, 6, 9]`
+  (= 3·row 0) rather than the literal first row.
+- **HexMatrix chapter**: added a compact "Arithmetic worked example"
+  section exercising `getRow`, `M[(1, 1)]` indexing, `mulVec`, `+`, `•`,
+  and `Matrix.identity`.
+
+Prerequisite build repair (required for the green-build acceptance):
+`lllReducedInt` was renamed to `lllReduced` by #8655/#8658, which never
+updated the manual, so `lake build HexManual` was already red on `main`.
+Propagated the rename in the HexLLL chapter and Coppersmith.
+
+# Current frontier
+
+`lake build HexManual` is green; every `#guard` (including
+`recover == some 42` and `recovered == some x0`) passes. Codex second
+opinion found no correctness issues and endorsed both judgement calls
+(bundling the rename fix; the `def corner` binding that qualifies the
+`M[(1,1)]` bounds proof to dodge a root-level `_proof_1` import clash
+with HexGramSchmidt).
+
+# Next step
+
+Open the PR, then watch for merge conflicts / CI.
+
+# Blockers
+
+None. Note: the blog's `examples/hex/HexExamples/*` are not yet published
+in `kim-em/kim-em.github.io`, so the ports were made from the issue's
+descriptions and verified by the Verso build rather than diffed against
+the blog sources.


### PR DESCRIPTION
This PR backports the polish from the hex blog post's verified examples into `HexManual`, so the manual and the blog show the same, cleaner code. Every ported block is Verso-checked, so `lake build HexManual` stays green and each `#guard` (including `recover == some 42` and `recovered == some x0`) passes.

In the Coppersmith tutorial (both the toy and 2048-bit blocks) it replaces the hand-rolled `centerMod` with Lean's balanced `Int.bmod`, making the modulus `N` and bound `X` into `Nat` and casting `(N : Int)` where an `Int` is needed; it reads the recovered secret off a pattern match on the linear factor (`match fac.toArray with | #[q, p] => …`, root `-q/p` when `p ∣ q`) instead of index juggling; and it drops the redundant `let xi := (x : Int)` in the toy `recover`. In the HexRowReduce chapter it checks the kernel basis with the single assertion `#guard (nullspace M).toList = [#v[-2, 1, 0], #v[-3, 0, 1]]` in place of an `#eval` plus a separate size check, and uses the non-trivial span example `spanContains M #v[3, 6, 9]`. In the HexMatrix chapter it adds a compact arithmetic worked example exercising `getRow`, `M[(1, 1)]` indexing, `mulVec`, `+`, `•`, and `Matrix.identity`.

It also propagates the `lllReducedInt` → `lllReduced` rename from https://github.com/kim-em/hex-dev/pull/8655 ("refactor(lll): rename `lllReducedInt` to `lllReducedExact`") and https://github.com/kim-em/hex-dev/pull/8658 ("refactor(lll): rename `lllReducedExact` to `lllReduced`") into the HexLLL chapter and Coppersmith tutorial. Those renames never updated the manual, so `lake build HexManual` was already red on `main`; this fix is a prerequisite for the green-build acceptance, not part of the blog backport itself.

Closes #8656

🤖 Prepared with Claude Code