### PR TITLE
refactor(bz): rename `factor` → `ZPoly.factorize`, add `ZPoly.factors`

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -100,7 +100,7 @@ reverse. We have thrashed too often bending the implementation to ease proofs.
   multiplicities, per-factor irreducibility) plus metamorphic relations
   (`f` vs `−f` vs `content·f` vs `f(X+k)`; multiply-then-factor; different-prime →
   same result).
-- **Performance (merge-blocking):** a counter + wall-clock gate. `factor` exposes
+- **Performance (merge-blocking):** a counter + wall-clock gate. `ZPoly.factorize` exposes
   a `FactorTrace` (chosen tier, prime, `r`, Hensel precision, subset count,
   lattice dimension, **fallback-used**). The gate asserts on the *counters*, not
   just elapsed time — a pure timing gate is gameable (a regression can "pass" by
@@ -130,7 +130,7 @@ reverse. We have thrashed too often bending the implementation to ease proofs.
 | Optimize the easy regime (arithmetic constants) | #8382 | — | ⏸️ deferred — sound part overlaps #8395 (see below) |
 | Prove output factors irreducible (the headline) | #8384 | #8412/#8413/#8517 | ✅ **DONE — `factor_headline` axiom-clean, zero sorries** |
 
-The public `factor` now **is** the cost-based hybrid (since #8404): the
+The public `ZPoly.factorize` (renamed from `factor` in #8651) now **is** the cost-based hybrid (since #8404): the
 exponential-on-easy-inputs blow-up is gone (deg-22 reducible: 781.8 ms → 82.75 ms),
 product preservation holds over the hybrid, and the unconditional per-factor
 contracts (normalization, primitivity from `f ≠ 0`, pairwise-distinct, scalar)
@@ -306,7 +306,7 @@ Never bend the implementation to a future proof. Never introduce an `axiom`.
 
 ## End state
 
-Public `factor` is the cost-based hybrid (since #8404): it reaches **parity** with
+Public `ZPoly.factorize` is the cost-based hybrid (since #8404): it reaches **parity** with
 the verified Isabelle reference on every input the classical tier covers —
 everything up to the classical subset budget, including the Swinnerton-Dyer ladder
 up to SD5; the verified-LLL lattice tier handles the extreme-`r` tail (SD6+) where

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -43,7 +43,7 @@ public section
 set_option backward.proofsInPublic true
 
 /-!
-This module collects `factorClassical`/`Trial`/`Lattice`/`factor` and the `factor_scalar` theorems.
+This module collects `factorClassical`/`Trial`/`Lattice`/`factorize` and the `factorize_scalar` theorems.
 -/
 namespace Hex
 
@@ -198,7 +198,7 @@ no admissible prime is available or the subset budget is exceeded. -/
 def factorClassical (f : ZPoly) : Option Factorization :=
   factorClassicalWithBound f (ZPoly.defaultFactorCoeffBound f)
 
-/-- Per-`factor` diagnostic trace, consumed by the merge-blocking performance gate.
+/-- Per-`factorize` diagnostic trace, consumed by the merge-blocking performance gate.
 `tier` records which path produced the answer (`constant` / `quadratic` /
 `classical` / `noPrime`); `declined = true` marks an untrustworthy result (no
 admissible prime, or subset-budget exhaustion) that the dispatcher routes onward.
@@ -269,7 +269,7 @@ supplied `budget` is used directly instead of `levelAwareSubsetBudget r budget`,
 so the search runs to the full budget rather than stopping at the last completable
 subset-size level. Reuses the same proven size/candidate loops; used only by the
 benchmark `factorClassicalNoDecline` entry to expose the classical exponential
-wall. Production `factor` (via `scaledRecombinationSmart`) is untouched. -/
+wall. Production `factorize` (via `scaledRecombinationSmart`) is untouched. -/
 def scaledRecombinationFull
     (coreLc : Int) (f : ZPoly) (modulus : Nat) (localFactors : List ZPoly)
     (budget : Nat) : Option (List ZPoly) × RecombStats :=
@@ -321,7 +321,7 @@ aware early decline disabled. The `hexbz_factor_service --entry
 factorClassicalNoDecline` line uses this to make the classical exponential wall
 visible on the cross-system cactus charts: it runs the full subset enumeration
 (so its answers are correct where it terminates) instead of declining high-`r`
-cores to the lattice tier. Production `factor`/`factorClassical` are untouched. -/
+cores to the lattice tier. Production `factorize`/`factorClassical` are untouched. -/
 def factorClassicalNoDecline (f : ZPoly) : Option Factorization :=
   factorClassicalNoDeclineWithBound f (ZPoly.defaultFactorCoeffBound f)
 
@@ -356,7 +356,7 @@ Handles the deg-0 core and integer-root cases up front via the same
 constant/quadratic-root short-circuits as the classical tier; the residual
 exhaustive branch dispatches to the standalone integer trial-division core
 (`exhaustiveIntegerTrialCoreFactorsWithBound`). This is the trial-division
-tier of the three-tier `factor` combinator (SPEC PR #6580). -/
+tier of the three-tier `factorize` combinator (SPEC PR #6580). -/
 @[expose]
 def factorTrialFactorsWithBound (f : ZPoly) (B : Nat) : Array ZPoly :=
   let normalized := normalizeForFactor f
@@ -387,7 +387,7 @@ theorem factorTrialWithBound_eq_factorizationOfFactors
 /--
 Factor using the integer trial-division path at the default Mignotte
 coefficient bound. This is the trial-division tier of the three-tier
-`factor` combinator (SPEC PR #6580).
+`factorize` combinator (SPEC PR #6580).
 -/
 def factorTrial (f : ZPoly) : Factorization :=
   factorTrialWithBound f (ZPoly.defaultFactorCoeffBound f)
@@ -788,7 +788,7 @@ a fallback was taken (the merge gate asserts this never happens unexpectedly).
 **Self-certifying.** Each non-backstop tier's `Factorization` is accepted only
 when it reconstructs the input (`Factorization.product φ = f`, decidable on
 `ZPoly`); on the (corpus-never) miss it falls through to the proven
-`factorTrial` backstop. This makes `Factorization.product (factor f) = f`
+`factorTrial` backstop. This makes `Factorization.product (ZPoly.factorize f) = f`
 provable unconditionally without yet proving the classical recombination loop
 reconstructs (that, with per-factor irreducibility, is the separate re-proof
 step). The classical tier is correct on the whole conformance corpus, so the
@@ -813,22 +813,31 @@ its answer is accepted only when the packed product reconstructs `f`; on decline
 (budget exhaustion or no admissible prime) the CLD lattice tier runs at the
 lattice precision cap under the same self-certifying acceptance check; and any
 residual falls through to the `factorTrial` totality backstop, which is
-`choosePrimeData?`-independent and so makes `factor` unconditionally correct on
-every `ZPoly`. Total.
+`choosePrimeData?`-independent and so makes `factorize` unconditionally correct
+on every `ZPoly`. Total.
+
+Lives in the `ZPoly` namespace so the public surface is dot-notation on a
+polynomial: `f.factorize`.
 -/
 @[expose]
-def factor (f : ZPoly) : Factorization :=
+def ZPoly.factorize (f : ZPoly) : Factorization :=
   (factorTraced f).1
+
+/-- The irreducible factors of `f` with their multiplicities: the `factors`
+field of the full factorisation `f.factorize`. -/
+@[expose]
+def ZPoly.factors (f : ZPoly) : Array (ZPoly × Nat) :=
+  (ZPoly.factorize f).factors
 
 -- classical answers the corpus, including small/medium-r Swinnerton-Dyer / cyclotomic
 -- irreducibles, so no fallback is taken (the lattice/trial arms cover only the
 -- budget-exceeding tail and the no-prime case).
-#guard Factorization.product (factor (DensePoly.ofCoeffs #[6, 0, -5, 0, 1]))
+#guard Factorization.product (ZPoly.factorize (DensePoly.ofCoeffs #[6, 0, -5, 0, 1]))
   = DensePoly.ofCoeffs #[6, 0, -5, 0, 1]                                      -- reducible
 #guard (factorTraced (DensePoly.ofCoeffs #[6, 0, -5, 0, 1])).2.tier = "classical"
-#guard Factorization.product (factor (DensePoly.ofCoeffs #[1, 0, -10, 0, 1]))
+#guard Factorization.product (ZPoly.factorize (DensePoly.ofCoeffs #[1, 0, -10, 0, 1]))
   = DensePoly.ofCoeffs #[1, 0, -10, 0, 1]                                     -- SD2, irreducible
-#guard ((factor (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).factors.size) = 1
+#guard ((ZPoly.factorize (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).factors.size) = 1
 #guard (factorTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.tier = "classical"
 #guard (factorTraced (DensePoly.ofCoeffs #[1, 0, -10, 0, 1])).2.declined = false
 
@@ -887,8 +896,8 @@ Each non-backstop tier (`factorClassicalFactorsWithBound` / lattice) is accepted
 only when its `factorizationOfFactors`-packed answer reconstructs `f` (the
 self-certifying guard mirrored here), and every fallback is the proven
 `factorTrial` backstop's raw array. The headline contract
-`factor f = factorizationOfFactors f (factorFactors f)` is
-`factor_eq_factorizationOfFactors`. -/
+`ZPoly.factorize f = factorizationOfFactors f (factorFactors f)` is
+`factorize_eq_factorizationOfFactors`. -/
 def factorFactors (f : ZPoly) : Array ZPoly :=
   match factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f) with
   | some cf =>
@@ -905,14 +914,14 @@ def factorFactors (f : ZPoly) : Array ZPoly :=
 form of its raw factor array `factorFactors`. Every tier (classical /
 lattice / trial) assembles via `factorizationOfFactors f`, so this bridge lets
 the structural `factorizationOfFactors_entry_*` lemmas re-point every
-`factor`-level entry contract onto the hybrid. -/
-theorem factor_eq_factorizationOfFactors (f : ZPoly) :
-    factor f = factorizationOfFactors f (factorFactors f) := by
+`factorize`-level entry contract onto the hybrid. -/
+theorem factorize_eq_factorizationOfFactors (f : ZPoly) :
+    ZPoly.factorize f = factorizationOfFactors f (factorFactors f) := by
   have htrial : factorTrial f =
       factorizationOfFactors f
         (factorTrialFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)) := by
     rw [factorTrial, factorTrialWithBound_eq_factorizationOfFactors]
-  unfold factor factorTraced factorFactors
+  unfold ZPoly.factorize factorTraced factorFactors
   have hclassical :
       (factorClassicalTraced f).1 =
         (factorClassicalFactorsWithBound f (ZPoly.defaultFactorCoeffBound f)).map
@@ -946,7 +955,7 @@ theorem factor_eq_factorizationOfFactors (f : ZPoly) :
 /-- Every raw factor of the cost-based hybrid comes from one of its three
 dispatch branches: the classical tier's certified output, the CLD lattice
 tier's certified output, or the `factorTrial` totality backstop. It
-exposes the branch source (mirroring `factor_entry_mem_raw_source` for the
+exposes the branch source (mirroring `factorize_entry_mem_raw_source` for the
 raw hybrid array) without leaking the private `factorizationOfFactors` guard, so
 the Mathlib-side irreducibility assembly can case-split over the branches. -/
 theorem factorFactors_mem_source (f : ZPoly) {raw : ZPoly}
@@ -1110,63 +1119,61 @@ theorem factorizationOfFactors_scalar_eq_zero_iff
   exact signedContentScalarContract_eq_zero_iff f
 
 /-- Scalar contract for the default public factorization entry point. -/
-theorem factor_scalar (f : ZPoly) :
-    (factor f).scalar =
+theorem factorize_scalar (f : ZPoly) :
+    (ZPoly.factorize f).scalar =
       if f = 0 then
         0
       else if DensePoly.leadingCoeff f < 0 then
         -ZPoly.content f
       else
         ZPoly.content f := by
-  rw [factor_eq_factorizationOfFactors]
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar f (factorFactors f)
 
-@[simp, grind =] theorem factor_scalar_zero :
-    (factor 0).scalar = 0 := by
-  rw [factor_eq_factorizationOfFactors]
+@[simp, grind =] theorem factorize_scalar_zero :
+    (ZPoly.factorize 0).scalar = 0 := by
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar_zero (factorFactors 0)
 
 /-- The default factorization of `0` records no polynomial factors: the
 square-free core of `0` is the unit `1`, so every reassembled raw factor is
 dropped by the `shouldRecordPolynomialFactor` filter.  This lets the capstone
-`factor_irreducible_of_nonUnit` discharge the degenerate `f = 0` case
+`factorize_irreducible_of_nonUnit` discharge the degenerate `f = 0` case
 vacuously, without a nonzero hypothesis. -/
-theorem factor_zero_factors : (factor (0 : ZPoly)).factors = #[] := by
+theorem factorize_zero_factors : (ZPoly.factorize (0 : ZPoly)).factors = #[] := by
   decide
 
-theorem factor_scalar_of_leadingCoeff_neg
+theorem factorize_scalar_of_leadingCoeff_neg
     {f : ZPoly} (hf : f ≠ 0) (hneg : DensePoly.leadingCoeff f < 0) :
-    (factor f).scalar = -ZPoly.content f := by
-  rw [factor_eq_factorizationOfFactors]
+    (ZPoly.factorize f).scalar = -ZPoly.content f := by
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar_of_leadingCoeff_neg (factorFactors f) hf hneg
 
-theorem factor_scalar_of_leadingCoeff_pos
+theorem factorize_scalar_of_leadingCoeff_pos
     {f : ZPoly} (hf : f ≠ 0) (hpos : 0 < DensePoly.leadingCoeff f) :
-    (factor f).scalar = ZPoly.content f := by
-  rw [factor_eq_factorizationOfFactors]
+    (ZPoly.factorize f).scalar = ZPoly.content f := by
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar_of_leadingCoeff_pos (factorFactors f) hf hpos
 
-theorem factor_scalar_eq_zero_iff (f : ZPoly) :
-    (factor f).scalar = 0 ↔ f = 0 := by
-  rw [factor_eq_factorizationOfFactors]
+theorem factorize_scalar_eq_zero_iff (f : ZPoly) :
+    (ZPoly.factorize f).scalar = 0 ↔ f = 0 := by
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_scalar_eq_zero_iff f (factorFactors f)
 
 /-- Every recorded entry of the default public factorization has positive
 multiplicity. -/
-theorem factor_entry_multiplicity_pos
+theorem factorize_entry_multiplicity_pos
     (f : ZPoly) (entry : ZPoly × Nat)
-    (hmem : entry ∈ (factor f).factors.toList) :
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList) :
     0 < entry.2 := by
-  rw [factor_eq_factorizationOfFactors] at hmem
+  rw [factorize_eq_factorizationOfFactors] at hmem
   exact factorizationOfFactors_entry_multiplicity_pos f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is fixed by
 `normalizeFactorSign`. -/
-theorem factor_entry_normalizeFactorSign_id
+theorem factorize_entry_normalizeFactorSign_id
     (f : ZPoly) (entry : ZPoly × Nat)
-    (hmem : entry ∈ (factor f).factors.toList) :
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList) :
     normalizeFactorSign entry.1 = entry.1 := by
-  rw [factor_eq_factorizationOfFactors] at hmem
+  rw [factorize_eq_factorizationOfFactors] at hmem
   exact factorizationOfFactors_entry_normalizeFactorSign_id f (factorFactors f) entry hmem
-
-end Hex

--- a/HexBerlekampZassenhaus/IrreducibleCore.lean
+++ b/HexBerlekampZassenhaus/IrreducibleCore.lean
@@ -50,74 +50,74 @@ namespace Hex
 
 /-- Every recorded entry of the default public factorization has positive
 leading coefficient. -/
-theorem factor_entry_leadingCoeff_pos
+theorem factorize_entry_leadingCoeff_pos
     (f : ZPoly) (entry : ZPoly × Nat)
-    (hmem : entry ∈ (factor f).factors.toList) :
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList) :
     0 < DensePoly.leadingCoeff entry.1 := by
-  rw [factor_eq_factorizationOfFactors] at hmem
+  rw [factorize_eq_factorizationOfFactors] at hmem
   exact factorizationOfFactors_entry_leadingCoeff_pos f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization passes the
 `shouldRecordPolynomialFactor` filter. -/
-theorem factor_entry_shouldRecord
+theorem factorize_entry_shouldRecord
     (f : ZPoly) (entry : ZPoly × Nat)
-    (hmem : entry ∈ (factor f).factors.toList) :
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList) :
     shouldRecordPolynomialFactor entry.1 = true := by
-  rw [factor_eq_factorizationOfFactors] at hmem
+  rw [factorize_eq_factorizationOfFactors] at hmem
   have hmem' : entry ∈ (collectFactorMultiplicities (factorFactors f)).toList := by
     simpa only [factorizationOfFactors] using hmem
   exact collectFactorMultiplicities_entry_shouldRecord (factorFactors f) entry hmem'
 
 /-- Any recorded entry of the default public factorization comes from the
 hybrid's raw factor array `factorFactors`, up to sign normalization. -/
-theorem factor_entry_mem_raw_source
+theorem factorize_entry_mem_raw_source
     (f : ZPoly) (entry : ZPoly × Nat)
-    (hmem : entry ∈ (factor f).factors.toList) :
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList) :
     ∃ raw ∈ (factorFactors f).toList, entry.1 = normalizeFactorSign raw := by
-  rw [factor_eq_factorizationOfFactors] at hmem
+  rw [factorize_eq_factorizationOfFactors] at hmem
   exact factorizationOfFactors_entry_mem_normalized_raw f (factorFactors f) entry hmem
 
 /-- Every recorded entry of the default public factorization is primitive once
 every raw factor in the hybrid's raw factor array is primitive. -/
-theorem factor_entry_primitive_of_chosen_raw_primitive
+theorem factorize_entry_primitive_of_chosen_raw_primitive
     {f : ZPoly} {entry : ZPoly × Nat}
-    (hmem : entry ∈ (factor f).factors.toList)
+    (hmem : entry ∈ (ZPoly.factorize f).factors.toList)
     (h_raw : ∀ raw ∈ (factorFactors f).toList, ZPoly.Primitive raw) :
     ZPoly.Primitive entry.1 := by
-  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factor_entry_mem_raw_source f entry hmem
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factorize_entry_mem_raw_source f entry hmem
   rw [hentry_eq]
   exact normalizeFactorSign_primitive _ (h_raw raw hraw_mem)
 
 /-- Public-entry specialisation: every recorded entry is primitive once the
 hybrid's raw factor array is primitive entrywise. -/
-theorem factor_entries_primitive
+theorem factorize_entries_primitive
     (f : ZPoly)
     (h_raw : ∀ raw ∈ (factorFactors f).toList, ZPoly.Primitive raw) :
-    ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 := by
+    ∀ entry ∈ (ZPoly.factorize f).factors, ZPoly.Primitive entry.1 := by
   intro entry hentry
-  exact factor_entry_primitive_of_chosen_raw_primitive
+  exact factorize_entry_primitive_of_chosen_raw_primitive
     (Array.mem_toList_iff.mpr hentry) h_raw
 
 /-- The default public factorization has no duplicate polynomial keys. -/
-theorem factor_pairwise_first
+theorem factorize_pairwise_first
     (f : ZPoly) :
     List.Pairwise (fun a b : ZPoly × Nat => a.1 ≠ b.1)
-      (factor f).factors.toList := by
-  rw [factor_eq_factorizationOfFactors]
+      (ZPoly.factorize f).factors.toList := by
+  rw [factorize_eq_factorizationOfFactors]
   exact factorizationOfFactors_pairwise_first f (factorFactors f)
 
 private def quadraticSquareRegression : ZPoly :=
   let q : ZPoly := DensePoly.ofCoeffs #[-1, 0, 1]
   q * q
 
-#guard (factor quadraticSquareRegression).factors =
+#guard (ZPoly.factorize quadraticSquareRegression).factors =
   #[(linearFactorForRoot (-1), 2), (linearFactorForRoot 1, 2)]
 
 private def quadraticCubeRegression : ZPoly :=
   let q : ZPoly := DensePoly.ofCoeffs #[-1, 0, 1]
   q * q * q
 
-#guard (factor quadraticCubeRegression).factors =
+#guard (ZPoly.factorize quadraticCubeRegression).factors =
   #[(linearFactorForRoot (-1), 3), (linearFactorForRoot 1, 3)]
 
 /-- Soundness regression for issue #6799: the primitive non-monic cubic
@@ -129,16 +129,16 @@ fell back to `#[core]`. -/
 private def nonMonicCubicRegression : ZPoly :=
   DensePoly.ofCoeffs #[3, 10, 9, 2]
 
-#guard (factor nonMonicCubicRegression).factors.size = 3
-#guard Factorization.product (factor nonMonicCubicRegression) = nonMonicCubicRegression
+#guard (ZPoly.factorize nonMonicCubicRegression).factors.size = 3
+#guard Factorization.product (ZPoly.factorize nonMonicCubicRegression) = nonMonicCubicRegression
 
 /-- Non-monic quadratic with two integer roots, `2(X-1)(X+1) = 2X²-2`:
-content `2`, primitive part `(X-1)(X+1)`, so `factor` records two factors. -/
+content `2`, primitive part `(X-1)(X+1)`, so `factorize` records two factors. -/
 private def nonMonicQuadraticTwoRoots : ZPoly :=
   DensePoly.ofCoeffs #[-2, 0, 2]
 
-#guard (factor nonMonicQuadraticTwoRoots).factors.size = 2
-#guard Factorization.product (factor nonMonicQuadraticTwoRoots) = nonMonicQuadraticTwoRoots
+#guard (ZPoly.factorize nonMonicQuadraticTwoRoots).factors.size = 2
+#guard Factorization.product (ZPoly.factorize nonMonicQuadraticTwoRoots) = nonMonicQuadraticTwoRoots
 
 /-- Non-monic quartic `(2X+1)(X+1)(X²+1)`, primitive with leading coefficient
 `2` and a mix of non-monic linear, monic linear, and irreducible quadratic
@@ -147,18 +147,18 @@ private def nonMonicQuarticRegression : ZPoly :=
   DensePoly.ofCoeffs #[1, 2] * DensePoly.ofCoeffs #[1, 1] *
     DensePoly.ofCoeffs #[1, 0, 1]
 
-#guard (factor nonMonicQuarticRegression).factors.size = 3
-#guard Factorization.product (factor nonMonicQuarticRegression) = nonMonicQuarticRegression
+#guard (ZPoly.factorize nonMonicQuarticRegression).factors.size = 3
+#guard Factorization.product (ZPoly.factorize nonMonicQuarticRegression) = nonMonicQuarticRegression
 
 /-- Non-monic core carrying nontrivial content, `6(X-1)(X+1) = 6X²-6`: the signed
 content scalar is `6` and the primitive factors are the two integer roots. -/
 private def nonMonicWithContentRegression : ZPoly :=
   DensePoly.ofCoeffs #[-6, 0, 6]
 
-#guard (factor nonMonicWithContentRegression).factors.size = 2
-#guard Factorization.product (factor nonMonicWithContentRegression) =
+#guard (ZPoly.factorize nonMonicWithContentRegression).factors.size = 2
+#guard Factorization.product (ZPoly.factorize nonMonicWithContentRegression) =
   nonMonicWithContentRegression
-#guard (factor nonMonicWithContentRegression).scalar = 6
+#guard (ZPoly.factorize nonMonicWithContentRegression).scalar = 6
 
 namespace ZPoly
 
@@ -204,7 +204,7 @@ def isIrreducible (f : ZPoly) : Bool :=
     let k := (f.coeff 0).natAbs
     isNatPrime k
   else
-    let φ := factor f
+    let φ := ZPoly.factorize f
     decide (φ.scalar.natAbs = 1) &&
       φ.factors.size == 1 &&
       match φ.factors.toList with

--- a/HexBerlekampZassenhaus/ProductProofs.lean
+++ b/HexBerlekampZassenhaus/ProductProofs.lean
@@ -49,7 +49,7 @@ public section
 set_option backward.proofsInPublic true
 
 /-!
-This module collects `factorTrial_product`, `factor_product`, and the `checkIrreducibleCert_*` proofs.
+This module collects `factorTrial_product`, `factorize_product`, and the `checkIrreducibleCert_*` proofs.
 -/
 namespace Hex
 
@@ -357,9 +357,9 @@ reconstructs `f` (the self-certifying guard in `factorTraced`), and every
 fallback is the proven `factorTrial` backstop. Established without proving the
 classical recombination loop reconstructs (that, with per-factor irreducibility,
 is the still-blocked re-proof capstone #8384). -/
-theorem factor_product (f : ZPoly) :
-    Factorization.product (factor f) = f := by
-  unfold factor factorTraced
+theorem factorize_product (f : ZPoly) :
+    Factorization.product (ZPoly.factorize f) = f := by
+  unfold ZPoly.factorize factorTraced
   rcases hcl : factorClassicalTraced f with ⟨cres, trace⟩
   cases cres with
   | some φ =>
@@ -377,20 +377,20 @@ theorem factor_product (f : ZPoly) :
 /-- Every recorded entry of the default factorization of a nonzero `f` is
 primitive, with no raw-source hypothesis. The hybrid's `factorizationOfFactors`
 packing certifies the *filtered* product reconstructs `f`
-(`factor_product` + `factorizationOfFactors_product`), so that product is
+(`factorize_product` + `factorizationOfFactors_product`), so that product is
 primitive and hence so is every recorded (filtered) entry. -/
-theorem factor_entries_primitive_of_ne_zero
+theorem factorize_entries_primitive_of_ne_zero
     (f : ZPoly) (hf : f ≠ 0) :
-    ∀ entry ∈ (factor f).factors, ZPoly.Primitive entry.1 := by
+    ∀ entry ∈ (ZPoly.factorize f).factors, ZPoly.Primitive entry.1 := by
   intro entry hentry
-  have hmem : entry ∈ (factor f).factors.toList := Array.mem_toList_iff.mpr hentry
+  have hmem : entry ∈ (ZPoly.factorize f).factors.toList := Array.mem_toList_iff.mpr hentry
   -- The filtered product reconstructs `f`, hence is primitive.
   have hfiltered_prod :
       DensePoly.C (signedContentScalar f) *
         Array.polyProduct
           (filteredNormalizedFactors (factorFactors f).toList).toArray = f := by
-    have hp := factor_product f
-    rw [factor_eq_factorizationOfFactors, factorizationOfFactors_product] at hp
+    have hp := factorize_product f
+    rw [factorize_eq_factorizationOfFactors, factorizationOfFactors_product] at hp
     exact hp
   have hprim :
       ZPoly.Primitive
@@ -403,9 +403,9 @@ theorem factor_entries_primitive_of_ne_zero
     polyProduct_mem_primitive_of_primitive _ hprim
   -- The entry lies in the filtered list (it equals a sign-normalized raw factor
   -- and passes the recording filter).
-  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factor_entry_mem_raw_source f entry hmem
+  obtain ⟨raw, hraw_mem, hentry_eq⟩ := factorize_entry_mem_raw_source f entry hmem
   have hrecord : shouldRecordPolynomialFactor (normalizeFactorSign raw) = true := by
-    have := factor_entry_shouldRecord f entry hmem
+    have := factorize_entry_shouldRecord f entry hmem
     rwa [hentry_eq] at this
   have hentry_in :
       entry.1 ∈ (filteredNormalizedFactors (factorFactors f).toList).toArray.toList := by

--- a/HexBerlekampZassenhaus/ReassemblyProofs.lean
+++ b/HexBerlekampZassenhaus/ReassemblyProofs.lean
@@ -1344,7 +1344,7 @@ theorem normalizeFactorSign_one :
 
 /-- The `shouldRecordPolynomialFactor` filter rejects the unit `1`.  Exposed
 publicly so Mathlib-side per-branch umbrellas can contradict
-`factor_entry_shouldRecord` directly when an entry collapses to a
+`factorize_entry_shouldRecord` directly when an entry collapses to a
 unit (in particular the fast-path constant arm, where the singleton
 square-free core is `1`). -/
 theorem shouldRecordPolynomialFactor_one :

--- a/HexBerlekampZassenhaus/Recombination.lean
+++ b/HexBerlekampZassenhaus/Recombination.lean
@@ -434,7 +434,7 @@ where
 #guard levelAwareSubsetBudget 64 defaultSubsetBudget = 41728
 
 /-- Diagnostic counters for one classical recombination search. Consumed by the
-performance-conformance gate (the wider `FactorTrace` carries the per-`factor`
+performance-conformance gate (the wider `FactorTrace` carries the per-`factorize`
 counters).
 
 `budgetExhausted` distinguishes the two ways the search returns no

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -27,7 +27,7 @@ factors:
   modular reduction; the unconditional totality backstop, reached only
   when no admissible prime exists.
 
-The public combinator `factor` runs `factorClassical` first under a
+The public combinator `factorize` runs `factorClassical` first under a
 budget read off the modular factorisation, `factorLattice` when the
 classical tier declines (large `r`), and `factorTrial` as the final
 backstop. All three return canonical factorisations; the tiers
@@ -56,20 +56,26 @@ of that order.
 def factorClassical (f : ZPoly) : Option Factorization
 def factorLattice   (f : ZPoly) : Option Factorization
 def factorTrial     (f : ZPoly) : Factorization
-def factor          (f : ZPoly) : Factorization
+def ZPoly.factorize (f : ZPoly) : Factorization
+def ZPoly.factors   (f : ZPoly) : Array (ZPoly × Nat)
 ```
+
+`ZPoly.factorize` lives in the `ZPoly` namespace so the public surface is
+dot-notation on a polynomial: `f.factorize`. `ZPoly.factors f :=
+(f.factorize).factors` is the convenience accessor for the irreducible
+factors with their multiplicities (`f.factors`).
 
 `factorClassical` and `factorLattice` are the two recombination tiers,
 both `Option`-valued because both require an admissible prime;
-`factorTrial` is the total trial-division backstop; `factor` is the
+`factorTrial` is the total trial-division backstop; `factorize` is the
 public hybrid combinator. Each tier also exposes a bounded variant
 `…WithBound f B` parameterised by a Mignotte coefficient bound `B`
-(used by the precision/conformance tests); `factor` runs the classical
+(used by the precision/conformance tests); `factorize` runs the classical
 tier at `ZPoly.defaultFactorCoeffBound f` and the lattice tier at its
 own precision cap (see *Precision schedule*).
 
 The dispatch is **classical-first with budgeted decline, not a
-precision-cap race** (see *Hybrid dispatch* below). `factor` runs
+precision-cap race** (see *Hybrid dispatch* below). `factorize` runs
 `factorClassical` under a level-aware subset budget read off the
 modular factorisation (the lifted-factor count `r` and the degree
 distribution of the modular factors). Exhausting the budget is an
@@ -97,7 +103,7 @@ def Factorization.product (φ : Factorization) : ZPoly :=
   φ.factors.foldl (fun acc ⟨g, m⟩ => acc * g^m) (DensePoly.C φ.scalar)
 ```
 
-For `f : ZPoly`, `factor f` returns a `Factorization` such that:
+For `f : ZPoly`, `factorize f` returns a `Factorization` such that:
 
 1. `scalar = sign(lc(f)) · ZPoly.content(f)`. Zero iff `f = 0`.
 2. Each `(g, m) ∈ factors` has:
@@ -107,11 +113,11 @@ For `f : ZPoly`, `factor f` returns a `Factorization` such that:
    - `m > 0`.
 3. **No duplicate polynomial factors**: distinct entries in `factors`
    have distinct first components.
-4. **Product preservation**: `Factorization.product (factor f) = f`.
+4. **Product preservation**: `Factorization.product (factorize f) = f`.
 5. Factor order is operationally array order; the mathematical
    contract is product + membership (an array of pairs as a multiset).
 
-**Convention: don't break content into primes.** `factor 6 = ⟨6, #[]⟩`,
+**Convention: don't break content into primes.** `factorize 6 = ⟨6, #[]⟩`,
 not `⟨1, #[(C 2, 1), (C 3, 1)]⟩`. The `factors` field carries
 *polynomial* factors of `primitivePart(f)`; the integer
 factorisation of the content lives in the `scalar` field as a single
@@ -119,7 +125,7 @@ signed integer. This matches FLINT and SymPy.
 
 ### Edge cases
 
-| Input `f` | `factor f` |
+| Input `f` | `factorize f` |
 |---|---|
 | `0` | `⟨0, #[]⟩` |
 | `1` | `⟨1, #[]⟩` |
@@ -142,7 +148,7 @@ a constant element?** Two reasons:
    `Array ZPoly`, sign would have to be encoded as a constant-
    polynomial factor or as a separately-tracked `Int`, neither
    ergonomic. The Mathlib-bridge product theorem
-   `Factorization.product (factor f) = f` then becomes provably
+   `Factorization.product (factorize f) = f` then becomes provably
    exact (no "up to sign" caveat).
 2. Multiplicity is explicit, matching how mature CAS systems
    (FLINT's `fmpz_poly_factor_t`, SageMath's `Factorization`,
@@ -188,10 +194,10 @@ def isIrreducible (f : ZPoly) : Bool :=
     let k := (f.coeff 0).natAbs
     1 < k && k.Prime
   else
-    -- Polynomial case: irreducible iff `factor f` returns a
+    -- Polynomial case: irreducible iff `factorize f` returns a
     -- `Factorization` whose scalar is a unit (±1) and whose
     -- factors array has exactly one entry with multiplicity 1.
-    let φ := factor f
+    let φ := factorize f
     decide (φ.scalar.natAbs = 1) &&
     φ.factors.size == 1 &&
     decide ((φ.factors.get! 0).snd = 1)
@@ -206,8 +212,8 @@ This library provides the `Irreducible` *class* and the executable
 
 The reason is a library-layering fact, not an oversight: that
 biconditional is logically equivalent to the full forward
-correctness of `factor` (its forward direction asserts the checker's
-single-factor verdict implies genuine irreducibility — i.e. `factor`
+correctness of `factorize` (its forward direction asserts the checker's
+single-factor verdict implies genuine irreducibility — i.e. `factorize`
 found *every* factor; its backward direction asserts an irreducible
 input yields exactly one factor). That correctness is the Group A/B/C
 capstone, and the SPEC assigns those proofs to the Mathlib bridge
@@ -336,13 +342,13 @@ holding a non-ZMod64-backed `PrimeChoiceData`).
 ### Hybrid dispatch: classical-first with budgeted decline
 
 **Load-bearing invariant: the dispatch always terminates in a
-`choosePrimeData?`-independent backstop.** This is what makes `factor`
+`choosePrimeData?`-independent backstop.** This is what makes `factorize`
 unconditionally correct on every `ZPoly`. The combinator runs the
 classical tier first, accepts a tier's answer only when it reconstructs
 `f`, and falls through on decline:
 
 ```lean
-def factor (f : ZPoly) : Factorization :=
+def ZPoly.factorize (f : ZPoly) : Factorization :=
   match factorClassical f with   -- level-aware subset budget inside
   | some φ => if φ.product = f then φ else factorTrial f
   | none =>                      -- classical declined (budget) or no admissible prime
@@ -382,7 +388,7 @@ and the CLD lattice tier does the work.
   by D2 below means `|lc(f)·disc(f)| ≥ ∏ HotPathCandidates`.
 
 **Dispatch must be observable, and the merge gate asserts on it
-(not just on wall-clock).** `factor` records a `FactorTrace` —
+(not just on wall-clock).** `factorize` records a `FactorTrace` —
 chosen tier, prime `p`, `r`, Hensel precision, subset candidates
 tried, lattice dimension, and **whether the trial backstop ran**.
 A pure timing gate is gameable (a regression can "pass" by silently
@@ -411,12 +417,12 @@ Three recombination tiers, all with full Mathlib-bridge proofs:
 - **`factorClassical : ZPoly → Option Factorization`.** Size-ordered subset recombination with factor removal, under a hard subset budget. Same algorithm class as the verified reference. **Unconditional correctness when it returns `some`:** the output is the irreducible factorisation of `f`. Returns `none` only on budget exhaustion or no admissible prime.
 - **`factorLattice : ZPoly → Option Factorization`.** Van Hoeij CLD at the full BHKS precision cap (`max (bhksBound core) (defaultFactorCoeffBound f)` where `core := (normalizeForFactor f).squareFreeCore`; the BHKS component is keyed on the square-free core the CLD pipeline actually lifts, not on `f` — a core can have larger coefficient norm than `f`, e.g. `f = (x¹⁸−1)(x¹⁹−1)`, so `bhksBound f` can undershoot the core's separation threshold). **Conditional correctness:** `factorLattice f = some φ ⟹ φ is the irreducible factorisation of f`. May return `none`.
 - **`factorTrial : ZPoly → Factorization`.** Exhaustive integer trial division. **Unconditional correctness:** `factorTrial f = irreducibleFactorisationOf f`.
-- **`factor : ZPoly → Factorization`.** The hybrid combinator (above): classical first, lattice on decline, `factorTrial` as the total backstop. Unconditionally correct.
+- **`ZPoly.factorize : ZPoly → Factorization`.** The hybrid combinator (above): classical first, lattice on decline, `factorTrial` as the total backstop. Unconditionally correct.
 
 No axioms. BHKS Theorem 5.2 ("for precision exceeding a paper-stated
 bound, `factorLattice` always returns `some`") is a leaf theorem of
 this development: it is in the project's requirements (Group D
-obligation D1 below) but no `Decidable` instance, no `factor`
+obligation D1 below) but no `Decidable` instance, no `factorize`
 correctness theorem, and no public-API contract depends on it.
 
 ## Classical recombination (small r)
@@ -439,7 +445,7 @@ the regime handed to `factorLattice`.
 The Mignotte coefficient bound `defaultFactorCoeffBound f` and the
 Hensel precision exponent `a` are different quantities and **must
 not be conflated**. The coefficient bound is a magnitude in ℤ — a
-number like 1008 — describing how large any factor's coefficient
+number like 1008 — describing how large any factorize's coefficient
 can be. The precision exponent `a` is the small integer with
 `p^a > 2·(coefficient bound)` — typically a single-digit number.
 Setting `a := defaultFactorCoeffBound f` makes `p^a` astronomically
@@ -454,7 +460,7 @@ Argument:
 
 1. **Hensel correspondence.** Every irreducible integer factor `g | f` over ℤ corresponds to a unique subset `S ⊆ {1, …, r}` such that `g ≡ ∏_{i ∈ S} g_i (mod p^a)`. Mathlib has `hensels_lemma` in `Mathlib.NumberTheory.Padics.Hensel`; the explicit subset-correspondence form may need a small wrapper lemma but follows directly.
 2. **Mignotte recoverability.** At precision `a` such that `p^a > 2 · defaultFactorCoeffBound f`, the centred-residue lift in `(−p^a/2, p^a/2]` of `(∏_{i ∈ S} g_i mod p^a)` exactly recovers `g`'s integer coefficients. Mathlib has `Polynomial.mahlerMeasure_le_sqrt_sum_sq_coeff` (Landau); the repo wraps it as `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean).
-3. **Exhaustive search soundness.** The search enumerates all `2^r` subsets, accepts only those whose product reconstructs to a true integer factor (verified by exact division). By (1) and (2) every irreducible factor is found.
+3. **Exhaustive search soundness.** The search enumerates all `2^r` subsets, accepts only those whose product reconstructs to a true integer factorize (verified by exact division). By (1) and (2) every irreducible factor is found.
 4. **Uniqueness.** ℤ[x] is a UFD (Mathlib: `Polynomial.UniqueFactorizationMonoid` over `Int`). The output array contains exactly one representative of each associate class.
 
 No BHKS termination theorem is needed: the loop is finite by subset enumeration, and correctness is by Hensel + Mignotte + UFD.
@@ -538,7 +544,7 @@ The `bhksBound : ZPoly → Nat` helper is SPEC-pinned. A safe explicit choice (s
 Termination of the doubling loop:
 
 - If the loop reaches a state where every equivalence-class candidate verifies via exact division and `∏ candidates = f` (up to `lc(f)` and content), the CLD tier returns `some gs`. This is the success path; conditional correctness applies. **In practice, the BHKS algorithm exits via this `L' = W` certificate at precision much lower than the BHKS-bound cap** (BHKS §4.4 explicitly: "a practical implementation should not use the precision bound … because the equations could already be sufficient for smaller values of `ℓ`"); the cap is a theoretical guarantee, not a usual exit condition.
-- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factor` then falls through to the `factorTrial` backstop. **A recombination-exit `some` makes no irreducibility claim on its own**; verified irreducibility is the property of `factor` (via the combinator), the cap-precision certificate exit, or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factor` correct without needing D1 first.
+- If the loop reaches the precision cap without satisfying that condition, the CLD tier returns `none`. The hybrid combinator `factorize` then falls through to the `factorTrial` backstop. **A recombination-exit `some` makes no irreducibility claim on its own**; verified irreducibility is the property of `factorize` (via the combinator), the cap-precision certificate exit, or the unconditional trial backstop. D1 will prove the `none` branch is unreachable given a good prime, but the existence of the branch makes `factorize` correct without needing D1 first.
 
 An additive-coefficient lattice that decodes short vectors as `Σ λ_i g_i (mod p^a)` candidate polynomials is *not* van Hoeij and is not admissible.
 
@@ -561,7 +567,7 @@ Four groups. Group A gives the exhaustive-recombination mathematics
 (Hensel + Mignotte + UFD) backing `factorClassical`'s `some`-case
 correctness and, via direct divisor enumeration, the unconditional
 `factorTrial` backstop; Group B gives `factorLattice`'s conditional
-correctness; Group C gives `factor`'s correctness via the combinator
+correctness; Group C gives `factorize`'s correctness via the combinator
 (and the tier-equivalence / dispatch-soundness contracts above);
 Group D is the non-blocking leaf performance theorem. No axioms.
 
@@ -578,7 +584,7 @@ A3. **Exhaustive search soundness and completeness (squarefree case).** The exha
 
 A4. **Squarefree-core correctness.** For squarefree primitive `f`, a completed exhaustive subset recombination returns `irreducibleFactorisationOf f`. Follows from A1+A2+A3. A `factorClassical` search that completes within budget *is* an exhaustive search, so this gives the classical tier's `some`-case correctness; `factorTrial` reaches the same conclusion unconditionally by direct Mignotte-bounded divisor enumeration (no Hensel machinery; UFD gives uniqueness).
 
-A5. **Normalisation + reassembly extend A4 to arbitrary input.** `factor` handles non-squarefree, non-primitive inputs by routing through `normalizeForFactor` and `reassembleNormalizedFactors`. The reassembly obligations `normalizeForFactor_reassembles`, `reassembleNormalizedFactors_product`, `normalizedConstantFactors_product` combine with A4 to yield `irreducibleFactorisationOf f` for arbitrary `f`.
+A5. **Normalisation + reassembly extend A4 to arbitrary input.** `factorize` handles non-squarefree, non-primitive inputs by routing through `normalizeForFactor` and `reassembleNormalizedFactors`. The reassembly obligations `normalizeForFactor_reassembles`, `reassembleNormalizedFactors_product`, `normalizedConstantFactors_product` combine with A4 to yield `irreducibleFactorisationOf f` for arbitrary `f`.
     *Sketch:* `normalizeForFactor` decomposes `f = content · X^k · h · h_repeated` where `h` is squarefree primitive. Each piece's irreducible factorisation is either standard (constants, X-powers) or given by A4 (squarefree primitive `h`); reassembly is multiplicative bookkeeping. Mathlib has `Polynomial.UniqueFactorizationMonoid` over `Int`; the GCD-based squarefree-core extraction is standard.
 
 ### Group B — lattice-tier conditional correctness (`factorLattice f = some gs ⟹ gs is the irreducible factorisation of f`)
@@ -609,10 +615,10 @@ B8. **Verification certifies `L' = W` (BHKS Lemma 3.4) — the load-bearing obli
 B9. **Conditional correctness of `factorLattice`.** `factorLattice f = some gs ⟹ gs is the irreducible factorisation of f` (up to associates and ordering).
     *Sketch:* the tier has two `some` exits. Recombination exit: `some gs` is returned only when (i) every candidate verified via exact division and (ii) `∏ gs = f`; by B8, (i) + (ii) together imply `L' = W` and `gs = irreducible factors of f`. Certificate exit: at cap precision the single all-ones equivalence class certifies the core irreducible (the forward count bound B6-side plus the class partition give exactly one factor), so `some #[core]` is correct. This is the tier's headline theorem; the proof is one application of B8 per exit.
 
-### Group C — combined `factor` correctness (drives the public API)
+### Group C — combined `factorize` correctness (drives the public API)
 
-C1. **`factor` unconditional correctness.** `factor f = irreducibleFactorisationOf f`.
-    *Sketch:* `factor` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem, assembled over the hybrid's three branches.
+C1. **`factorize` unconditional correctness.** `factorize f = irreducibleFactorisationOf f`.
+    *Sketch:* `factorize` dispatches classical-first: try `factorClassical` at the default Mignotte bound; on its decline try `factorLattice` at the lattice precision cap; otherwise the `factorTrial` backstop. Case analysis on the three branches, using each tier's correctness from *Recombination tiers* above — a product-checked `some` from `factorClassical` (Group A) or `factorLattice` (Group B) is the irreducible factorisation, and the `factorTrial` branch is unconditionally the irreducible factorisation (Group A, via A4/A5). Each tier is entered at its own precision, so no single bound drives the whole combinator. This is the headline correctness theorem, assembled over the hybrid's three branches.
 
 C2. **Public-API contracts** (`checkIrreducibleCert_sound`, `Hex.ZPoly.isIrreducible_iff`, and the `Decidable (Hex.ZPoly.Irreducible f)` instance it backs) follow from C1. Like C1 itself, these are bridge-side and are stated in `hex-berlekamp-zassenhaus-mathlib` (the Mathlib-free library provides only the `Irreducible` class and the `isIrreducible` checker — see the §`Mathlib-free Hex.ZPoly.Irreducible class`). Product preservation needs no separate bound-aware contract: it is clause 1 of the headline theorem, and the dispatch's acceptance guard makes it self-certifying per tier.
 
@@ -663,7 +669,7 @@ D2. **Tight characterisation of trial-backstop inputs.** Statement shape:
 
 `HexBerlekampZassenhausMathlib` must carry, and the `done_through ≥ 4` bump is blocked on, an end-to-end theorem with the following **semantic shape**:
 
-> For every nonzero `f : Hex.ZPoly`, the public-API output `φ := Hex.factor f : Hex.Factorization` satisfies all five clauses:
+> For every nonzero `f : Hex.ZPoly`, the public-API output `φ := Hex.factorize f : Hex.Factorization` satisfies all five clauses:
 >
 > 1. **Product preservation.** `Hex.Factorization.product φ = f`.
 > 2. **Primitive irreducibility.** Every `entry ∈ φ.factors` is primitive and `Polynomial.Irreducible (HexPolyZMathlib.toPolynomial entry.1)` holds in the Mathlib sense.
@@ -694,7 +700,7 @@ that there is no clean theorem boundary):
   (when `some`), and `factorTrial f` all return the *same* canonical
   factorisation; the cost-based dispatch therefore cannot change the
   result, only the cost.
-- **Dispatch soundness.** `factor f` equals the canonical factorisation
+- **Dispatch soundness.** `factorize f` equals the canonical factorisation
   for every `f`, independent of which tier answers and of
   any fallback taken.
 - **Fallback semantics.** The trial backstop is a *correctness* backstop,
@@ -752,8 +758,8 @@ and the JSONL fixtures, not in this spec):
 - seeded random differential cases vs FLINT;
 - the boundary cases (`0`, `±1`, constants, `X^k`, linears).
 
-**Metamorphic relations** (no external oracle): `factor f` vs
-`factor (−f)` vs `factor (content · f)` vs `factor (f(X + k))` agree up to
+**Metamorphic relations** (no external oracle): `factorize f` vs
+`factorize (−f)` vs `factorize (content · f)` vs `factorize (f(X + k))` agree up to
 the documented scalar/shift bookkeeping; multiply known factors then
 re-factor → same canonical multiset; re-run with a different admissible
 prime → identical result.
@@ -806,7 +812,7 @@ into the committed SVGs under `reports/figures/hexbz-*.svg` (auto-published on
 the Verso manual). This is a re-runnable comparator sweep, **not CI** (see
 [SPEC/benchmarking.md § Cross-system comparator sweeps](../../SPEC/benchmarking.md)).
 
-**Standing expectation for any change to a public factor entry** (`factor`,
+**Standing expectation for any change to a public factor entry** (`factorize`,
 `factorLattice`, `factorClassicalNoDecline`, or the tiers beneath
 them) that could move performance: re-measure the hex entries and refresh the
 charts, then **show the updated charts to the requester**. The external
@@ -878,7 +884,7 @@ Soundness split:
   checker data flow and degree-obstruction computation.
 - `hex-berlekamp-zassenhaus-mathlib` proves
   `checkIrreducibleCert f cert = true → Irreducible f`. This follows
-  from C1 (`factor` correctness) plus the certificate's per-prime
+  from C1 (`factorize` correctness) plus the certificate's per-prime
   degree-obstruction soundness.
 
 ### Kernel-checked irreducibility MUST be certificate-verifying
@@ -891,20 +897,20 @@ The certificate is prepared by *compiled* code; the kernel checks only
 - `checkIrreducibleCert g cert = true` for each factor `g`, against the
   soundness theorem `checkIrreducibleCert f cert = true → Irreducible f`.
 
-`factor` / `factorLattice` and the certificate construction MUST NOT run in
+`factorize` / `factorLattice` and the certificate construction MUST NOT run in
 the kernel — that is compiled preparation. (Pratt certificates for
 irreducibility: the witness is expensive to find, cheap to check.)
 
 Why (`native_decide` is banned): kernel reduction of the recombination is
-exponential, so kernel-running `factor` terminates only up to small degree.
-Any decision whose Boolean predicate calls `factor` inherits that wall and
+exponential, so kernel-running `factorize` terminates only up to small degree.
+Any decision whose Boolean predicate calls `factorize` inherits that wall and
 is at most a small-degree fallback — in particular a plain `Decidable`
 instance consumed by `decide` cannot satisfy this requirement, since
 `decide` reduces the instance in the kernel. The certifying path is
 therefore a tactic (or other elaboration-time preparation) that runs
-compiled `factor` + certificate generation, reifies the certificate, and
+compiled `factorize` + certificate generation, reifies the certificate, and
 emits the kernel check. A re-runnable benchmark SHOULD measure the frontier
-— the degree at which kernel `decide` on `factor` stops terminating within
+— the degree at which kernel `decide` on `factorize` stops terminating within
 a fixed budget. Downstream specs that kernel-check `Irreducible` /
 `IsIrreducible` obligations (`SPEC/Libraries/hex-roots.md`,
 `SPEC/Libraries/hex-number-field.md`) depend on this.

--- a/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
+++ b/HexBerlekampZassenhaus/SPEC/hex-berlekamp-zassenhaus.md
@@ -445,7 +445,7 @@ the regime handed to `factorLattice`.
 The Mignotte coefficient bound `defaultFactorCoeffBound f` and the
 Hensel precision exponent `a` are different quantities and **must
 not be conflated**. The coefficient bound is a magnitude in ℤ — a
-number like 1008 — describing how large any factorize's coefficient
+number like 1008 — describing how large any factor's coefficient
 can be. The precision exponent `a` is the small integer with
 `p^a > 2·(coefficient bound)` — typically a single-digit number.
 Setting `a := defaultFactorCoeffBound f` makes `p^a` astronomically
@@ -460,7 +460,7 @@ Argument:
 
 1. **Hensel correspondence.** Every irreducible integer factor `g | f` over ℤ corresponds to a unique subset `S ⊆ {1, …, r}` such that `g ≡ ∏_{i ∈ S} g_i (mod p^a)`. Mathlib has `hensels_lemma` in `Mathlib.NumberTheory.Padics.Hensel`; the explicit subset-correspondence form may need a small wrapper lemma but follows directly.
 2. **Mignotte recoverability.** At precision `a` such that `p^a > 2 · defaultFactorCoeffBound f`, the centred-residue lift in `(−p^a/2, p^a/2]` of `(∏_{i ∈ S} g_i mod p^a)` exactly recovers `g`'s integer coefficients. Mathlib has `Polynomial.mahlerMeasure_le_sqrt_sum_sq_coeff` (Landau); the repo wraps it as `mignotte_bound` in [HexPolyZMathlib/Mignotte.lean](../../HexPolyZMathlib/Mignotte.lean).
-3. **Exhaustive search soundness.** The search enumerates all `2^r` subsets, accepts only those whose product reconstructs to a true integer factorize (verified by exact division). By (1) and (2) every irreducible factor is found.
+3. **Exhaustive search soundness.** The search enumerates all `2^r` subsets, accepts only those whose product reconstructs to a true integer factor (verified by exact division). By (1) and (2) every irreducible factor is found.
 4. **Uniqueness.** ℤ[x] is a UFD (Mathlib: `Polynomial.UniqueFactorizationMonoid` over `Int`). The output array contains exactly one representative of each associate class.
 
 No BHKS termination theorem is needed: the loop is finite by subset enumeration, and correctness is by Hensel + Mignotte + UFD.

--- a/HexBerlekampZassenhausMathlib/FactorSoundness.lean
+++ b/HexBerlekampZassenhausMathlib/FactorSoundness.lean
@@ -26,16 +26,16 @@ open Polynomial
 Every polynomial factor emitted by the default executable factorization is
 irreducible in the executable `Hex.ZPoly` sense.
 -/
-theorem factor_irreducible_of_nonUnit (f : Hex.ZPoly) :
-    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Irreducible entry.1 := by
+theorem factorize_irreducible_of_nonUnit (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors, Hex.ZPoly.Irreducible entry.1 := by
   intro entry hentry
   by_cases hf : f = 0
   · subst hf
-    rw [Hex.factor_zero_factors] at hentry
+    rw [Hex.factorize_zero_factors] at hentry
     simp at hentry
-  · have hmem : entry ∈ (Hex.factor f).factors.toList := Array.mem_toList_iff.mpr hentry
-    obtain ⟨raw, hraw_mem, hentry_eq⟩ := Hex.factor_entry_mem_raw_source f entry hmem
-    have hrec := Hex.factor_entry_shouldRecord f entry hmem
+  · have hmem : entry ∈ (Hex.ZPoly.factorize f).factors.toList := Array.mem_toList_iff.mpr hentry
+    obtain ⟨raw, hraw_mem, hentry_eq⟩ := Hex.factorize_entry_mem_raw_source f entry hmem
+    have hrec := Hex.factorize_entry_shouldRecord f entry hmem
     rw [hentry_eq] at hrec ⊢
     exact zpolyIrreducible_normalizeFactorSign_of_zpolyIrreducible
       (factorFactors_factor_irreducible f hf hraw_mem hrec)
@@ -44,23 +44,23 @@ theorem factor_irreducible_of_nonUnit (f : Hex.ZPoly) :
 Every polynomial factor emitted by the default executable factorization is
 irreducible after transport to `Polynomial ℤ`.
 -/
-theorem factor_polynomialIrreducible_of_nonUnit (f : Hex.ZPoly) :
-    ∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_polynomialIrreducible_of_nonUnit (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors,
       Irreducible (HexPolyZMathlib.toPolynomial entry.1) := by
   intro entry hentry
   exact
     (Hex.ZPoly.Irreducible_iff_polynomialIrreducible entry.1).mp
-      (factor_irreducible_of_nonUnit f entry hentry)
+      (factorize_irreducible_of_nonUnit f entry hentry)
 
 /--
 Every polynomial factor emitted by the default executable factorization has
 positive leading coefficient.
 -/
-theorem factor_entries_leadingCoeff_pos (f : Hex.ZPoly) :
-    ∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_entries_leadingCoeff_pos (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors,
       0 < Hex.DensePoly.leadingCoeff entry.1 := by
   intro entry hentry
-  exact Hex.factor_entry_leadingCoeff_pos f entry (Array.mem_toList_iff.mpr hentry)
+  exact Hex.factorize_entry_leadingCoeff_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
 Bundled public contract currently available for the default executable
@@ -73,91 +73,91 @@ duplicate polynomial keys, and the signed-content scalar convention. The
 remaining HO-1 headline strengthening is to replace the syntactic distinct-key
 clause with non-association and to add the primitive-factor clause.
 -/
-theorem factor_headline_contract_core (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.factor f) = f ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_headline_contract_core (f : Hex.ZPoly) :
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.factor f).factors.toList ∧
-      (Hex.factor f).scalar =
+        (Hex.ZPoly.factorize f).factors.toList ∧
+      (Hex.ZPoly.factorize f).scalar =
         if f = 0 then
           0
         else if Hex.DensePoly.leadingCoeff f < 0 then
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f := by
-  refine ⟨factor_product f, ?_, ?_, Hex.factor_pairwise_first f, Hex.factor_scalar f⟩
+  refine ⟨factorize_product f, ?_, ?_, Hex.factorize_pairwise_first f, Hex.factorize_scalar f⟩
   · intro entry hentry
-    exact factor_polynomialIrreducible_of_nonUnit f entry hentry
+    exact factorize_polynomialIrreducible_of_nonUnit f entry hentry
   · intro entry hentry
-    exact Hex.factor_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
+    exact Hex.factorize_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
-Positive-leading-coefficient sibling of `factor_headline_contract_core`.
+Positive-leading-coefficient sibling of `factorize_headline_contract_core`.
 
 This keeps the existing default public factorization clauses and additionally
 packages the canonical positive-leading convention for every recorded
 polynomial factor.
 -/
-theorem factor_headline_contract_core_with_posLeading (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.factor f) = f ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_headline_contract_core_with_posLeading (f : Hex.ZPoly) :
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         0 < Hex.DensePoly.leadingCoeff entry.1) ∧
-      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.factor f).factors.toList ∧
-      (Hex.factor f).scalar =
+        (Hex.ZPoly.factorize f).factors.toList ∧
+      (Hex.ZPoly.factorize f).scalar =
         if f = 0 then
           0
         else if Hex.DensePoly.leadingCoeff f < 0 then
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f := by
-  rcases factor_headline_contract_core f with
+  rcases factorize_headline_contract_core f with
     ⟨hproduct, hirreducible, hmultiplicity, hpairwise, hscalar⟩
   exact
-    ⟨hproduct, hirreducible, factor_entries_leadingCoeff_pos f, hmultiplicity,
+    ⟨hproduct, hirreducible, factorize_entries_leadingCoeff_pos f, hmultiplicity,
       hpairwise, hscalar⟩
 
 /--
-Primitive-strengthened sibling of `factor_headline_contract_core`.
+Primitive-strengthened sibling of `factorize_headline_contract_core`.
 
 This is the same default public factorization contract, but packages the
 headline primitive-irreducibility clause as a single per-entry conjunction under
 the raw-branch primitive hypothesis supplied by the executable layer.
 -/
-theorem factor_headline_contract_core_with_primitive
+theorem factorize_headline_contract_core_with_primitive
     (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.Factorization.product (Hex.factor f) = f ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Hex.ZPoly.Primitive entry.1 ∧
           Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.factor f).factors.toList ∧
-      (Hex.factor f).scalar =
+        (Hex.ZPoly.factorize f).factors.toList ∧
+      (Hex.ZPoly.factorize f).scalar =
         if f = 0 then
           0
         else if Hex.DensePoly.leadingCoeff f < 0 then
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f := by
-  refine ⟨factor_product f, ?_, ?_, Hex.factor_pairwise_first f, Hex.factor_scalar f⟩
+  refine ⟨factorize_product f, ?_, ?_, Hex.factorize_pairwise_first f, Hex.factorize_scalar f⟩
   · intro entry hentry
     exact
-      ⟨factor_entries_primitive_of_chosen_raw_primitive f hf entry hentry,
-        factor_polynomialIrreducible_of_nonUnit f entry hentry⟩
+      ⟨factorize_entries_primitive_of_chosen_raw_primitive f hf entry hentry,
+        factorize_polynomialIrreducible_of_nonUnit f entry hentry⟩
   · intro entry hentry
-    exact Hex.factor_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
+    exact Hex.factorize_entry_multiplicity_pos f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
 Closed primitive-strengthened headline for the default executable factorization
 of a nonzero input.
 
-This is the same bundle as `factor_headline_contract_core_with_primitive` but
+This is the same bundle as `factorize_headline_contract_core_with_primitive` but
 with the raw-source primitivity hypothesis `h_raw` discharged internally via
 `Hex.factor_chosen_raw_primitive_of_ne_zero`, so callers no longer supply it:
 product preservation, primitive plus Mathlib irreducibility per recorded factor,
@@ -169,29 +169,29 @@ square-free core is `0` (content `0`, hence not primitive), so the raw-source
 primitivity statement quantified over the dispatch is literally false; the
 factorization of `0` is itself degenerate (`scalar = 0`, product `0`).
 -/
-theorem factor_headline_primitive (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.Factorization.product (Hex.factor f) = f ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_headline_primitive (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Hex.ZPoly.Primitive entry.1 ∧
           Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise (fun a b : Hex.ZPoly × Nat => a.1 ≠ b.1)
-        (Hex.factor f).factors.toList ∧
-      (Hex.factor f).scalar =
+        (Hex.ZPoly.factorize f).factors.toList ∧
+      (Hex.ZPoly.factorize f).scalar =
         if f = 0 then
           0
         else if Hex.DensePoly.leadingCoeff f < 0 then
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f :=
-  factor_headline_contract_core_with_primitive f hf
+  factorize_headline_contract_core_with_primitive f hf
 
 /--
 The HO-1 headline contract for the default executable factorization of a nonzero
 input.
 
 This is the strengthened public surface required by directive #2564: it is the
-same bundle as `factor_headline_primitive` but replaces the syntactic
+same bundle as `factorize_headline_primitive` but replaces the syntactic
 distinct-key clause `a.1 ≠ b.1` with genuine pairwise non-association after
 transport to `Polynomial ℤ`. The clauses are product preservation, primitive
 plus Mathlib irreducibility per recorded factor, positive multiplicities,
@@ -201,47 +201,47 @@ signed-content scalar convention.
 Non-association is the headline strengthening: distinct `ZPoly` keys could in
 principle be associated in `Polynomial ℤ` (differ by a unit); this rules that
 out, so the recorded factors are genuinely distinct irreducibles up to
-association. The clause is discharged via `factor_entries_not_associated` with
+association. The clause is discharged via `factorize_entries_not_associated` with
 the raw-source primitivity hypothesis supplied internally by
 `Hex.factor_chosen_raw_primitive_of_ne_zero`, which is why `f ≠ 0` is required
-(see `factor_headline_primitive` for why the `f = 0` case is degenerate).
+(see `factorize_headline_primitive` for why the `f = 0` case is degenerate).
 -/
-theorem factor_headline (f : Hex.ZPoly) (hf : f ≠ 0) :
-    Hex.Factorization.product (Hex.factor f) = f ∧
-      (∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_headline (f : Hex.ZPoly) (hf : f ≠ 0) :
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors,
         Hex.ZPoly.Primitive entry.1 ∧
           Irreducible (HexPolyZMathlib.toPolynomial entry.1)) ∧
-      (∀ entry ∈ (Hex.factor f).factors, 0 < entry.2) ∧
+      (∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.2) ∧
       List.Pairwise
         (fun a b : Hex.ZPoly × Nat =>
           ¬ Associated (HexPolyZMathlib.toPolynomial a.1)
             (HexPolyZMathlib.toPolynomial b.1))
-        (Hex.factor f).factors.toList ∧
-      (Hex.factor f).scalar =
+        (Hex.ZPoly.factorize f).factors.toList ∧
+      (Hex.ZPoly.factorize f).scalar =
         if f = 0 then
           0
         else if Hex.DensePoly.leadingCoeff f < 0 then
           -Hex.ZPoly.content f
         else
           Hex.ZPoly.content f := by
-  rcases factor_headline_primitive f hf with
+  rcases factorize_headline_primitive f hf with
     ⟨hproduct, hentries, hmultiplicity, _, hscalar⟩
   exact
     ⟨hproduct, hentries, hmultiplicity,
-      factor_entries_not_associated f hf,
+      factorize_entries_not_associated f hf,
       hscalar⟩
 
 /--
 The sign-normalization side condition for the default executable factorization:
 every recorded polynomial factor is fixed by `normalizeFactorSign`. This is the
 `hψ_norm` clause that uniqueness/checker callers would otherwise reconstruct from
-the executable `Hex.factor_entry_normalizeFactorSign_id`.
+the executable `Hex.factorize_entry_normalizeFactorSign_id`.
 -/
-theorem factor_entries_normalizeFactorSign (f : Hex.ZPoly) :
-    ∀ entry ∈ (Hex.factor f).factors,
+theorem factorize_entries_normalizeFactorSign (f : Hex.ZPoly) :
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors,
       Hex.normalizeFactorSign entry.1 = entry.1 := by
   intro entry hentry
-  exact Hex.factor_entry_normalizeFactorSign_id f entry (Array.mem_toList_iff.mpr hentry)
+  exact Hex.factorize_entry_normalizeFactorSign_id f entry (Array.mem_toList_iff.mpr hentry)
 
 /--
 The nonconstant side condition for the default executable factorization: every
@@ -252,81 +252,81 @@ Positive degree is *not* derivable from `shouldRecordPolynomialFactor` alone —
 constant like `Hex.DensePoly.C 2` passes the recording filter, has positive
 leading coefficient, and is sign-normalized. The constant case is excluded by
 *primitivity* (content `1` forces a constant to be `±1`), so this carries the
-`f ≠ 0` side condition that `Hex.factor_entries_primitive_of_ne_zero` needs
+`f ≠ 0` side condition that `Hex.factorize_entries_primitive_of_ne_zero` needs
 (the self-certifying hybrid, #8383). The constant-exclusion argument itself is
 `Hex.degree_pos_of_primitive_norm_record`.
 -/
-theorem factor_entries_degree_pos
+theorem factorize_entries_degree_pos
     (f : Hex.ZPoly) (hf : f ≠ 0) :
-    ∀ entry ∈ (Hex.factor f).factors, 0 < entry.1.degree?.getD 0 := by
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors, 0 < entry.1.degree?.getD 0 := by
   intro entry hentry
   have hmem := Array.mem_toList_iff.mpr hentry
   exact Hex.degree_pos_of_primitive_norm_record entry.1
-    (Hex.factor_entries_primitive_of_ne_zero f hf entry hentry)
-    (Hex.factor_entry_normalizeFactorSign_id f entry hmem)
-    (Hex.factor_entry_shouldRecord f entry hmem)
+    (Hex.factorize_entries_primitive_of_ne_zero f hf entry hentry)
+    (Hex.factorize_entry_normalizeFactorSign_id f entry hmem)
+    (Hex.factorize_entry_shouldRecord f entry hmem)
 
 /--
 Uniqueness specialised against the default executable factorization, so callers
 only provide the competing product, irreducibility, sign-normalization, and
 nonconstant-factor facts, plus that the input is nonzero. The default
 factorization's own well-formedness is supplied by
-`factor_irreducible_of_nonUnit` and its sibling lemmas.
+`factorize_irreducible_of_nonUnit` and its sibling lemmas.
 -/
-theorem factor_unique_of_product
+theorem factorize_unique_of_product
     (f : Hex.ZPoly) (φ : Hex.Factorization) (hf_ne : f ≠ 0)
     (hproduct : Hex.Factorization.product φ = f)
     (hφ_norm : ∀ entry ∈ φ.factors, Hex.normalizeFactorSign entry.1 = entry.1)
-    (hψ_norm : ∀ entry ∈ (Hex.factor f).factors,
+    (hψ_norm : ∀ entry ∈ (Hex.ZPoly.factorize f).factors,
       Hex.normalizeFactorSign entry.1 = entry.1)
     (hφ_nonconst : ∀ entry ∈ φ.factors, 0 < entry.1.degree?.getD 0)
-    (hψ_nonconst : ∀ entry ∈ (Hex.factor f).factors,
+    (hψ_nonconst : ∀ entry ∈ (Hex.ZPoly.factorize f).factors,
       0 < entry.1.degree?.getD 0)
     (hirr : ∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1) :
-    φ.scalar = (Hex.factor f).scalar ∧
+    φ.scalar = (Hex.ZPoly.factorize f).scalar ∧
       (φ.factors.toList.map (fun e => Multiset.replicate e.2 e.1)).sum =
-        ((Hex.factor f).factors.toList.map
+        ((Hex.ZPoly.factorize f).factors.toList.map
           (fun e => Multiset.replicate e.2 e.1)).sum :=
-  factor_unique φ (Hex.factor f) hφ_norm hψ_norm hφ_nonconst hψ_nonconst hirr
-    (factor_irreducible_of_nonUnit f)
+  factorize_unique φ (Hex.ZPoly.factorize f) hφ_norm hψ_norm hφ_nonconst hψ_nonconst hirr
+    (factorize_irreducible_of_nonUnit f)
     (by rw [hproduct]; exact hf_ne)
-    (by rw [hproduct, factor_product f])
+    (by rw [hproduct, factorize_product f])
 
 /--
-Default-specialised sibling of `factor_unique_of_product` that discharges the
+Default-specialised sibling of `factorize_unique_of_product` that discharges the
 default factorization's own sign-normalization and nonconstant side conditions
 internally, so callers no longer supply `hψ_norm` or `hψ_nonconst`. The
 nonconstant clause needs only `f ≠ 0` (the same `hf_ne` already supplied), via
-`factor_entries_degree_pos`; `hψ_norm` is discharged unconditionally.
+`factorize_entries_degree_pos`; `hψ_norm` is discharged unconditionally.
 -/
-theorem factor_unique_of_product_default
+theorem factorize_unique_of_product_default
     (f : Hex.ZPoly) (φ : Hex.Factorization) (hf_ne : f ≠ 0)
     (hproduct : Hex.Factorization.product φ = f)
     (hφ_norm : ∀ entry ∈ φ.factors, Hex.normalizeFactorSign entry.1 = entry.1)
     (hφ_nonconst : ∀ entry ∈ φ.factors, 0 < entry.1.degree?.getD 0)
     (hirr : ∀ entry ∈ φ.factors, Hex.ZPoly.Irreducible entry.1) :
-    φ.scalar = (Hex.factor f).scalar ∧
+    φ.scalar = (Hex.ZPoly.factorize f).scalar ∧
       (φ.factors.toList.map (fun e => Multiset.replicate e.2 e.1)).sum =
-        ((Hex.factor f).factors.toList.map
+        ((Hex.ZPoly.factorize f).factors.toList.map
           (fun e => Multiset.replicate e.2 e.1)).sum :=
-  factor_unique_of_product f φ hf_ne hproduct hφ_norm
-    (factor_entries_normalizeFactorSign f) hφ_nonconst
-    (factor_entries_degree_pos f hf_ne) hirr
+  factorize_unique_of_product f φ hf_ne hproduct hφ_norm
+    (factorize_entries_normalizeFactorSign f) hφ_nonconst
+    (factorize_entries_degree_pos f hf_ne) hirr
 
 set_option maxHeartbeats 1000000 in
 /--
 The executable irreducibility checker `Hex.ZPoly.isIrreducible` agrees with the
 `Hex.ZPoly.Irreducible` class.
 
-`isIrreducible` runs `factor` and checks the result is a single primitive factor
+`isIrreducible` runs `factorize` and checks the result is a single primitive factor
 of multiplicity 1 (with a `±1` scalar), so this is exactly the statement that the
 default factorization is a correct irreducible factorization.  The degree-0
 (constant) arm is the elementary-primality characterisation
 (`irreducible_C_of_isNatPrime` / `isNatPrime_natAbs_of_irreducible_C`); the
-positive-degree arm composes `factor_irreducible_of_nonUnit` (forward) with
-`factor_unique_of_product_default` (backward, which pins the factor count to the
+positive-degree arm composes `factorize_irreducible_of_nonUnit` (forward) with
+`factorize_unique_of_product_default` (backward, which pins the factor count to the
 `normalizedFactors` cardinality).  It therefore inherits the lattice-tier `sorry`
-of `factor_irreducible_of_nonUnit` (#8417) and nothing else.
+of `factorize_irreducible_of_nonUnit` (#8417) and nothing else.
 -/
 theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
     Hex.ZPoly.isIrreducible f = true ↔ Hex.ZPoly.Irreducible f := by
@@ -359,8 +359,8 @@ theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
         exact Hex.ZPoly.isNatPrime_natAbs_of_irreducible_C hk_ne h
     · -- positive-degree arm
       rw [if_neg hdeg]
-      set φ := Hex.factor f with hφ_def
-      have hprod : Hex.Factorization.product φ = f := Hex.factor_product f
+      set φ := Hex.ZPoly.factorize f with hφ_def
+      have hprod : Hex.Factorization.product φ = f := Hex.factorize_product f
       have hfp1 : ∀ q : Hex.ZPoly, Hex.Factorization.factorPower q 1 = q := fun q => by
         rw [show (1 : Nat) = 0 + 1 from rfl, Hex.Factorization.factorPower_succ,
           Hex.Factorization.factorPower_zero, Hex.ZPoly.one_mul_zpoly]
@@ -377,7 +377,7 @@ theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
         rw [hentry_list] at hmatch
         have hmult1 : entry.2 = 1 := by simpa using hmatch
         have hirr_entry : Hex.ZPoly.Irreducible entry.1 :=
-          factor_irreducible_of_nonUnit f entry hentry_mem
+          factorize_irreducible_of_nonUnit f entry hentry_mem
         have hirr_P : Irreducible (HexPolyZMathlib.toPolynomial entry.1) :=
           (Hex.ZPoly.Irreducible_iff_polynomialIrreducible entry.1).mp hirr_entry
         -- product of a single (g, 1) entry is `C scalar * g`
@@ -440,7 +440,7 @@ theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
           simp only [hψ_def, Array.mem_singleton] at hmem
           rw [hmem]; exact hg_irr
         obtain ⟨hscalar_eq, hmulti_eq⟩ :=
-          factor_unique_of_product_default f ψ hf0 hψ_prod hψ_norm hψ_nonconst hψ_irr
+          factorize_unique_of_product_default f ψ hf0 hψ_prod hψ_norm hψ_nonconst hψ_irr
         -- the ψ multiset is the singleton {g}; take cardinalities
         have hψ_card : Multiset.card
             (ψ.factors.toList.map (fun e => Multiset.replicate e.2 e.1)).sum = 1 := by
@@ -464,7 +464,7 @@ theorem Hex.ZPoly.isIrreducible_iff (f : Hex.ZPoly) :
           rw [List.mem_map] at hx
           obtain ⟨e, he_mem, he_eq⟩ := hx
           rw [← he_eq]
-          exact Hex.factor_entry_multiplicity_pos f e he_mem
+          exact Hex.factorize_entry_multiplicity_pos f e he_mem
         -- a list of positive naturals summing to `1` has length `1`
         have list_length_le_sum : ∀ (L : List Nat), (∀ x ∈ L, 1 ≤ x) → L.length ≤ L.sum := by
           intro L

--- a/HexBerlekampZassenhausMathlib/IntReductionMod.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod.lean
@@ -144,7 +144,7 @@ theorem slowPathHenselSubstrate_of_toMonicPrimeData
 
 Specialisation of `liftedFactorSubsetPartition_of_choosePrimeData`
 (`HexBerlekampZassenhausMathlib`) at the precision count
-actually consumed by the slow exhaustive branch of `Hex.factor f`.
+actually consumed by the slow exhaustive branch of `Hex.ZPoly.factorize f`.
 The resulting partition value has the exact `core` / `d` /
 `J = Finset.univ` / `target = core` shape expected by the `hpartition`
 hypothesis of the slow-path exhaustive-branch irreducibility wrapper

--- a/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
+++ b/HexBerlekampZassenhausMathlib/IntReductionMod/Descent.lean
@@ -798,7 +798,7 @@ The two lemmas below feed `squareFreeCore_irreducible_of_small_mod_singleton`
 its `hprim` and `hlc_map_ne` side-conditions from the executable invariants
 that `normalizeForFactor` and `choosePrimeData?` already maintain. They
 form the base lemmas for the small-mod singleton arm of the HO-1 capstone
-`factor_irreducible_of_nonUnit` (issue #4170, decomposed in #4544).
+`factorize_irreducible_of_nonUnit` (issue #4170, decomposed in #4544).
 -/
 
 /--

--- a/HexBerlekampZassenhausMathlib/LatticeTier.lean
+++ b/HexBerlekampZassenhausMathlib/LatticeTier.lean
@@ -885,7 +885,7 @@ theorem latticeCoreFactorsWithBound_squareFreeCore_factor_zpolyIrreducible
 `factorLatticeFactorsWithBound_factor_irreducible` was a forward `sorry` in
 `IntReductionMod` (it cannot import the LLL machinery); it is filled here and,
 with its assembly `factorFactors_factor_irreducible`, moved into this file
-where the `LatticeTier` core lemma is available.  `factor_irreducible_of_nonUnit`
+where the `LatticeTier` core lemma is available.  `factorize_irreducible_of_nonUnit`
 (FactorSoundness) consumes `factorFactors_factor_irreducible`.
 -/
 

--- a/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
+++ b/HexBerlekampZassenhausMathlib/MonicCorrespondent.lean
@@ -48,7 +48,7 @@ open Polynomial
 /-- **#5214 supporting bundle (HO-1 slow-path substrate).**
 
 Bundled substrate package for the slow-path arm of the HO-1 capstone
-`factor_irreducible_of_nonUnit` (#4170).  The seven fields are exactly the
+`factorize_irreducible_of_nonUnit` (#4170).  The seven fields are exactly the
 hypothesis set on the lifted-Hensel side consumed by the slow-path
 exhaustive-branch irreducibility reasoning,
 packaged so the capstone can obtain all of them from a single

--- a/HexBerlekampZassenhausMathlib/PublicSurface.lean
+++ b/HexBerlekampZassenhausMathlib/PublicSurface.lean
@@ -21,7 +21,7 @@ public section
 set_option backward.proofsInPublic true
 
 /-!
-This module collects the transport bounds, `factor_product`, `factor_unique`, and `checkIrreducibleCert_sound`.
+This module collects the transport bounds, `factorize_product`, `factorize_unique`, and `checkIrreducibleCert_sound`.
 -/
 
 namespace HexBerlekampZassenhausMathlib
@@ -166,9 +166,9 @@ def irreducibleByFactorization (f : Polynomial ℤ) : Bool :=
 
 /-- The default executable factorization multiplies back to the input. -/
 @[simp, grind =]
-theorem factor_product (f : Hex.ZPoly) :
-    Hex.Factorization.product (Hex.factor f) = f :=
-  Hex.factor_product f
+theorem factorize_product (f : Hex.ZPoly) :
+    Hex.Factorization.product (Hex.ZPoly.factorize f) = f :=
+  Hex.factorize_product f
 
 /--
 The Mathlib-free executable irreducibility predicate agrees with Mathlib's
@@ -269,10 +269,10 @@ nonzero input is primitive. The public path is the self-certifying hybrid
 (#8383), so primitivity is discharged from `f ≠ 0` alone (the filtered product
 reconstructs `f`); no raw-source hypothesis is needed.
 -/
-theorem factor_entries_primitive_of_chosen_raw_primitive
+theorem factorize_entries_primitive_of_chosen_raw_primitive
     (f : Hex.ZPoly) (hf : f ≠ 0) :
-    ∀ entry ∈ (Hex.factor f).factors, Hex.ZPoly.Primitive entry.1 :=
-  Hex.factor_entries_primitive_of_ne_zero f hf
+    ∀ entry ∈ (Hex.ZPoly.factorize f).factors, Hex.ZPoly.Primitive entry.1 :=
+  Hex.factorize_entries_primitive_of_ne_zero f hf
 
 private theorem toPolynomial_foldl_mul (lst : List Hex.ZPoly) (init : Hex.ZPoly) :
     HexPolyZMathlib.toPolynomial (lst.foldl (· * ·) init) =
@@ -464,22 +464,22 @@ Recorded entries of the default executable factorization of a nonzero input are
 pairwise non-associated after transport to `Polynomial ℤ`. Primitivity is
 discharged from `f ≠ 0` (the self-certifying hybrid, #8383).
 -/
-theorem factor_entries_not_associated
+theorem factorize_entries_not_associated
     (f : Hex.ZPoly) (hf : f ≠ 0) :
     List.Pairwise
       (fun a b : Hex.ZPoly × Nat =>
         ¬ Associated (HexPolyZMathlib.toPolynomial a.1)
           (HexPolyZMathlib.toPolynomial b.1))
-      (Hex.factor f).factors.toList := by
+      (Hex.ZPoly.factorize f).factors.toList := by
   exact List.Pairwise.imp_of_mem
     (fun {a b} ha hb hab =>
       zpoly_not_associated_of_ne_of_primitive_pos_leading
-        (Hex.factor_entries_primitive_of_ne_zero f hf a (Array.mem_toList_iff.mp ha))
-        (Hex.factor_entries_primitive_of_ne_zero f hf b (Array.mem_toList_iff.mp hb))
-        (Hex.factor_entry_leadingCoeff_pos f a ha)
-        (Hex.factor_entry_leadingCoeff_pos f b hb)
+        (Hex.factorize_entries_primitive_of_ne_zero f hf a (Array.mem_toList_iff.mp ha))
+        (Hex.factorize_entries_primitive_of_ne_zero f hf b (Array.mem_toList_iff.mp hb))
+        (Hex.factorize_entry_leadingCoeff_pos f a ha)
+        (Hex.factorize_entry_leadingCoeff_pos f b hb)
         hab)
-    (Hex.factor_pairwise_first f)
+    (Hex.factorize_pairwise_first f)
 
 private theorem mem_factorizationFlattenedFactors_iff
     {φ : Hex.Factorization} {f : Hex.ZPoly} :
@@ -520,7 +520,7 @@ constrain factor sign, multiplicity packing, or constant factors. The
 `normalizeFactorSign` and `nonconst` hypotheses rule out the corresponding
 counterexamples.
 -/
-theorem factor_unique
+theorem factorize_unique
     (φ ψ : Hex.Factorization)
     (hφ_norm : ∀ entry ∈ φ.factors, Hex.normalizeFactorSign entry.1 = entry.1)
     (hψ_norm : ∀ entry ∈ ψ.factors, Hex.normalizeFactorSign entry.1 = entry.1)

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -6,10 +6,10 @@ with the Mignotte bound from hex-poly-z-mathlib, giving unconditional
 results. All statements use the `Factorization` record from
 `hex-berlekamp-zassenhaus.md`'s output-convention section.
 
-The headline theorems below hold over the **cost-based hybrid `factor`**
+The headline theorems below hold over the **cost-based hybrid `factorize`**
 (the `factorClassical` / `factorLattice` / `factorTrial` tiers). By the
 tier-result-equivalence and dispatch-soundness contracts (main spec
-§*Invariant contracts and dispatch soundness*), `factor`'s output is
+§*Invariant contracts and dispatch soundness*), `factorize`'s output is
 independent of which tier the dispatcher selects, so these theorems
 reduce to the per-tier correctness — Group A for the classical tier,
 Group B for the lattice tier, Group C for the combinator. Per the
@@ -19,10 +19,10 @@ not reshaped to ease them.
 
 ```lean
 theorem factorize_product (f : ZPoly) :
-    Factorization.product (factor f) = f
+    Factorization.product (ZPoly.factorize f) = f
 
 theorem factorize_irreducible_of_nonUnit (f : ZPoly) :
-    ∀ (g, m) ∈ (factor f).factors, Hex.ZPoly.Irreducible g
+    ∀ (g, m) ∈ (ZPoly.factorize f).factors, Hex.ZPoly.Irreducible g
 
 theorem factorize_unique (f : ZPoly) (φ ψ : Factorization) :
     Factorization.product φ = f →
@@ -71,7 +71,7 @@ rewrites `IsUnit` and `(· * ·)` through `toPolynomial`.
 **Correctness of the executable checker.** The biconditional linking
 the Mathlib-free `isIrreducible` *checker* to the `Irreducible`
 *class* lives here, not in `hex-berlekamp-zassenhaus`, because it is
-equivalent to the full forward correctness of `factor` (Group C; see
+equivalent to the full forward correctness of `factorize` (Group C; see
 that library's §`Mathlib-free Hex.ZPoly.Irreducible class` for why a
 Mathlib-free file cannot state it):
 
@@ -83,9 +83,9 @@ instance (f : ZPoly) : Decidable (Hex.ZPoly.Irreducible f) :=
   decidable_of_iff _ (Hex.ZPoly.isIrreducible_iff f)
 ```
 
-The forward direction follows from C1 (`factor f` is the irreducible
+The forward direction follows from C1 (`factorize f` is the irreducible
 factorisation): a single primitive unit-scalar factor of multiplicity
-one is `f` itself up to a unit, and completeness of `factor` rules out
+one is `f` itself up to a unit, and completeness of `factorize` rules out
 any finer decomposition. The backward direction is the converse. The
 constant case reduces to `Nat.Prime` decidability. This is the only
 route to `decide`-ing `Hex.ZPoly.Irreducible` for concrete inputs;

--- a/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
+++ b/HexBerlekampZassenhausMathlib/SPEC/hex-berlekamp-zassenhaus-mathlib.md
@@ -18,13 +18,13 @@ proofs adapt to the committed executable tiers; the implementation is
 not reshaped to ease them.
 
 ```lean
-theorem factor_product (f : ZPoly) :
+theorem factorize_product (f : ZPoly) :
     Factorization.product (factor f) = f
 
-theorem factor_irreducible_of_nonUnit (f : ZPoly) :
+theorem factorize_irreducible_of_nonUnit (f : ZPoly) :
     ∀ (g, m) ∈ (factor f).factors, Hex.ZPoly.Irreducible g
 
-theorem factor_unique (f : ZPoly) (φ ψ : Factorization) :
+theorem factorize_unique (f : ZPoly) (φ ψ : Factorization) :
     Factorization.product φ = f →
     Factorization.product ψ = f →
     (∀ (g, m) ∈ φ.factors, Hex.ZPoly.Irreducible g) →
@@ -44,7 +44,7 @@ theorem checkIrreducibleCert_sound
     checkIrreducibleCert f cert = true → Irreducible f
 ```
 
-`factor_irreducible_of_nonUnit` is the corrected form of the old
+`factorize_irreducible_of_nonUnit` is the corrected form of the old
 `factor_irreducible` (which incorrectly claimed *every* element of
 the old `Array ZPoly` output was irreducible — false for content
 factors like `[C 6, ...]` since `C 6 = C 2 · C 3` is reducible in

--- a/HexBerlekampZassenhausMathlib/SearchAssembly.lean
+++ b/HexBerlekampZassenhausMathlib/SearchAssembly.lean
@@ -1518,7 +1518,7 @@ theorem henselSubsetCorrespondenceHypotheses_of_choosePrimeData_success_descent
 
 Successful-descent specialisation of
 `henselSubsetCorrespondenceHypotheses_of_choosePrimeData_success_descent` at the
-precision count consumed by the slow exhaustive branch of `Hex.factor f`. -/
+precision count consumed by the slow exhaustive branch of `Hex.ZPoly.factorize f`. -/
 theorem henselSubsetCorrespondenceHypotheses_outerBound_of_choosePrimeData
     (f : Hex.ZPoly)
     (primeData : Hex.PrimeChoiceData)

--- a/HexManual/Tutorials/Coppersmith.lean
+++ b/HexManual/Tutorials/Coppersmith.lean
@@ -180,9 +180,10 @@ about `N^(1/6)` toward `N^(1/3)`, comfortably covering the 400-bit secret.
 Second, the root search changes. The reduced short vector is again a
 polynomial `g` with `x₀` as an integer root, but `x₀` is now a 120-digit
 number and `g` has degree eight; no bounded scan can find the root.
-Instead we factor `g` over the integers with {name}`Hex.factor`, the
-project's Berlekamp-Zassenhaus factorizer, and read the secret straight
-off the linear factor `x - x₀`. Factoring a degree-eight integer
+Instead we factor `g` over the integers with {name}`Hex.ZPoly.factorize`
+(via the `.factors` accessor), the project's Berlekamp-Zassenhaus
+factorizer, and read the secret straight off the linear factor `x - x₀`.
+Factoring a degree-eight integer
 polynomial, even with its very large coefficients, is instant; the lattice
 reduction is the only real cost.
 
@@ -273,7 +274,8 @@ private def g : Poly := Id.run do
 -- the root of its linear factor x - x0. Scanning x below
 -- X ~ 2^400 is hopeless; factoring degree-8 g is instant.
 private def recovered : Option Int := Id.run do
-  for (fac, _) in (factor (DensePoly.ofCoeffs g)).factors do
+  let gz : ZPoly := DensePoly.ofCoeffs g
+  for (fac, _) in gz.factors do
     -- Linear factor `p·x + q` has root `-q/p` when `p ∣ q`.
     match fac.toArray with
     | #[q, p] =>

--- a/bench/HexBench/FactorService.lean
+++ b/bench/HexBench/FactorService.lean
@@ -24,7 +24,7 @@ Isabelle comparator `scripts/oracle/bz-isabelle/Main.hs`):
 
 The `--entry` flag selects which library entry answers each request:
 
-* `factor` — the production cost-based hybrid (`Hex.factor`); never declines.
+* `factor` — the production cost-based hybrid (`Hex.ZPoly.factorize`); never declines.
 * `factorLattice` — the van Hoeij CLD lattice tier (`Hex.factorLattice`).
 * `factorClassicalNoDecline` — classical recombination run to completion or
   cutoff (`Hex.factorClassicalNoDecline`), exposing the classical exponential
@@ -56,7 +56,7 @@ def Entry.ofString? : String → Option Entry
 /-- Dispatch to the selected entry. `none` means the entry declined; the
 production `factor` never declines (it wraps its total `Factorization`). -/
 def Entry.run : Entry → ZPoly → Option Factorization
-  | .factor, f => some (Hex.factor f)
+  | .factor, f => some (Hex.ZPoly.factorize f)
   | .factorLattice, f => Hex.factorLattice f
   | .factorClassicalNoDecline, f => Hex.factorClassicalNoDecline f
 

--- a/bench/HexBerlekampZassenhaus/Bench.lean
+++ b/bench/HexBerlekampZassenhaus/Bench.lean
@@ -395,7 +395,7 @@ def checksumFastPathSetup (f : ZPoly) (p : Nat) : UInt64 :=
 
 /-- Benchmark target: public fast-with-slow-fallback factorization. -/
 def runFactorChecksum (f : ZPoly) : UInt64 :=
-  checksumFactorization (factor f)
+  checksumFactorization (ZPoly.factorize f)
 
 /-- Benchmark target: public factorization on explicit fallback-prime probes. -/
 @[noinline]
@@ -408,7 +408,7 @@ def runFactorSlowChecksum (f : ZPoly) : UInt64 :=
 
 /-- Shared-domain compare target: public factorization on deterministic splits. -/
 def runFactorCompareChecksum (f : ZPoly) : UInt64 :=
-  checksumFactorization (factor f)
+  checksumFactorization (ZPoly.factorize f)
 
 /-- Shared-domain compare target: exhaustive slow factorization on deterministic splits. -/
 def runFactorSlowCompareChecksum (f : ZPoly) : UInt64 :=
@@ -494,7 +494,7 @@ def prepAdvPhi15 (_ : Nat) : ZPoly :=
 
 /-- Benchmark target: public combinator over the degree/height matrix. -/
 def runFactorDegreeHeightChecksum (input : DegreeHeightInput) : UInt64 :=
-  checksumFactorization (factor input.poly)
+  checksumFactorization (ZPoly.factorize input.poly)
 
 /-- Benchmark target: bounded slow-path diagnostic over small degree/height cases. -/
 def runFactorSlowDegreeHeightChecksum (input : DegreeHeightInput) : UInt64 :=
@@ -635,7 +635,7 @@ def ensureIsabelleBZCrossCheck : IO Unit := do
   if (← isabelleBZCrossCheckRef.get) then
     return ()
   for f in isabelleFixtureInputs do
-    let leanChecksum := checksumCanonicalLeanFactorization (factor f)
+    let leanChecksum := checksumCanonicalLeanFactorization (ZPoly.factorize f)
     let (scalar, factors) ← requestIsabelleBZFactorizationRaw f
     let isabelleChecksum := checksumCanonicalFactorization scalar factors
     if leanChecksum != isabelleChecksum then
@@ -650,7 +650,7 @@ def requestIsabelleBZFactorization (f : ZPoly) : IO (Int × Array (List Int × N
 
 /-- Fixed Lean-side target matching the Isabelle comparator's canonical input. -/
 def runFactorIsabelleDomainChecksum : Unit → IO UInt64 := fun _ => do
-  return checksumCanonicalLeanFactorization (factor advQuadSqrt2Sqrt3)
+  return checksumCanonicalLeanFactorization (ZPoly.factorize advQuadSqrt2Sqrt3)
 
 /-- Fixed verified-Isabelle BZ comparator target on the same canonical input. -/
 def runIsabelleFactorChecksum : Unit → IO UInt64 := fun _ => do
@@ -766,7 +766,7 @@ list of `n` distinct monic linears; this is the canonical-truth comparator the
 match on these rungs.
 
 `expectedHash` is left as `none` rather than computing
-`checksumCanonicalLeanFactorization (factor (prepFallbackProbeInput n))` at
+`checksumCanonicalLeanFactorization (ZPoly.factorize (prepFallbackProbeInput n))` at
 elaboration time, because that compile-time call would invoke the same cascade
 the post-mortem documents (200×–2,400× slower than Isabelle plus reducible
 factor entries on these inputs), inflating compile time. Bench-time multiset
@@ -1158,14 +1158,14 @@ the verified-to-verified ratio. -/
 setup_fixed_benchmark runFactorIsabelleDomainChecksum where {
     repeats := 3
     maxSecondsPerCall := 20.0
-    expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization (factor advQuadSqrt2Sqrt3)))
+    expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize advQuadSqrt2Sqrt3)))
     tags := #[scheduledHardwareTag]
   }
 
 setup_fixed_benchmark runIsabelleFactorChecksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
-    expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization (factor advQuadSqrt2Sqrt3)))
+    expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize advQuadSqrt2Sqrt3)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1186,7 +1186,7 @@ setup_fixed_benchmark runIsabelleSplitN2Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor (smokeInput 2))))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize (smokeInput 2))))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1194,7 +1194,7 @@ setup_fixed_benchmark runIsabelleSplitN3Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor (smokeInput 3))))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize (smokeInput 3))))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1202,7 +1202,7 @@ setup_fixed_benchmark runIsabelleSplitN4Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor (smokeInput 4))))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize (smokeInput 4))))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1210,7 +1210,7 @@ setup_fixed_benchmark runIsabelleSplitN5Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor (smokeInput 5))))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize (smokeInput 5))))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1224,7 +1224,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight3x2Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 3 2)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 3 2)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1232,7 +1232,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight4x2Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 4 2)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 4 2)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1240,7 +1240,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight4x8Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 4 8)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 4 8)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1248,7 +1248,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight5x8Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 5 8)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 5 8)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1256,7 +1256,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight6x32Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 6 32)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 6 32)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1264,7 +1264,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight1x2Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 1 2)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 1 2)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1272,7 +1272,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight2x2Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 2 2)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 2 2)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1280,7 +1280,7 @@ setup_fixed_benchmark runIsabelleDegreeHeight3x8Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash := some (Hashable.hash (checksumCanonicalLeanFactorization
-      (factor (prepDegreeHeightInput (encodeDegreeHeightParam 3 8)).poly)))
+      (ZPoly.factorize (prepDegreeHeightInput (encodeDegreeHeightParam 3 8)).poly)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1297,7 +1297,7 @@ setup_fixed_benchmark runIsabelleAdvX4Plus1Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor advX4Plus1)))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize advX4Plus1)))
     tags := #[scheduledHardwareTag]
   }
 
@@ -1305,7 +1305,7 @@ setup_fixed_benchmark runIsabelleAdvPhi15Checksum where {
     repeats := 3
     maxSecondsPerCall := 60.0
     expectedHash :=
-      some (Hashable.hash (checksumCanonicalLeanFactorization (factor advPhi15)))
+      some (Hashable.hash (checksumCanonicalLeanFactorization (ZPoly.factorize advPhi15)))
     tags := #[scheduledHardwareTag]
   }
 

--- a/conformance/HexBerlekampZassenhaus/Conformance.lean
+++ b/conformance/HexBerlekampZassenhaus/Conformance.lean
@@ -99,7 +99,7 @@ private def sameFactorCoeffSet (actual expected : List (List Int × Nat)) : Bool
 
 /-- Product preservation guard for the public default `factor` entry point. -/
 private def factorPreservesProduct (f : ZPoly) : Bool :=
-  Factorization.product (factor f) = f
+  Factorization.product (ZPoly.factorize f) = f
 
 private def sameCoeffSet (actual expected : List (List Int)) : Bool :=
   actual.length == expected.length &&
@@ -334,7 +334,7 @@ private def factorizationEdgeCases : List FactorizationCase :=
 /-- Edge-case table guard: expected signed scalar/multiplicity buckets and
 exact product preservation must both hold for the public `factor` output. -/
 private def factorizationCaseMatches (c : FactorizationCase) : Bool :=
-  let φ := factor c.input
+  let φ := ZPoly.factorize c.input
   φ == c.expected && Factorization.product φ == c.input
 
 #guard
@@ -544,30 +544,30 @@ recovered true factor.
             (coeffs, 1))
   | none => false
 #guard
-  let factors := factor monomialWithContent
+  let factors := ZPoly.factorize monomialWithContent
   Factorization.product factors = monomialWithContent
 #guard
-  let φ := factor monomialWithContent
+  let φ := ZPoly.factorize monomialWithContent
   φ.scalar = 6 && φ.factors == #[(ZPoly.X, 2)]
 #guard
-  let φ := factor negativeMonomial
+  let φ := ZPoly.factorize negativeMonomial
   φ.scalar = -1 && φ.factors == #[(ZPoly.X, 1)]
 #guard
-  let φ := factor repeatedRootPoly
+  let φ := ZPoly.factorize repeatedRootPoly
   φ.scalar = 1 && φ.factors == #[(linear 1, 2)]
 #guard
-  let φ := factor negativeRepeatedRootWithContent
+  let φ := ZPoly.factorize negativeRepeatedRootWithContent
   φ.scalar = -2 && φ.factors == #[(linear 1, 2)] &&
     Factorization.product φ = negativeRepeatedRootWithContent
 #guard
   factorPreservesProduct cubicLinear123
 #guard
-  let factors := factor cyclo11Times22
+  let factors := ZPoly.factorize cyclo11Times22
   factorPreservesProduct cyclo11Times22 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[phi11, phi22] |>.map fun coeffs => (coeffs, 1))
 #guard
-  let factors := factor quadSqrt2Sqrt3
+  let factors := ZPoly.factorize quadSqrt2Sqrt3
   factorPreservesProduct quadSqrt2Sqrt3 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[zpoly #[-3, 0, 1], zpoly #[-2, 0, 1]] |>.map fun coeffs =>
@@ -576,7 +576,7 @@ recovered true factor.
 -- irreducible over `ℤ`, so the fast recombination "misses" and the public
 -- `factor` falls back to returning the single irreducible input.
 #guard
-  let factors := factor x4Plus1
+  let factors := ZPoly.factorize x4Plus1
   factorPreservesProduct x4Plus1 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[x4Plus1] |>.map fun coeffs => (coeffs, 1))
@@ -596,7 +596,7 @@ recovered true factor.
           (factorCoeffSummary #[swinnertonDyerSD3] |>.map fun coeffs => (coeffs, 1))
   | none => false
 #guard
-  let factors := factor swinnertonDyerSD3
+  let factors := ZPoly.factorize swinnertonDyerSD3
   factorPreservesProduct swinnertonDyerSD3 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[swinnertonDyerSD3] |>.map fun coeffs => (coeffs, 1))
@@ -608,7 +608,7 @@ recovered true factor.
           (factorCoeffSummary #[phi15] |>.map fun coeffs => (coeffs, 1))
   | none => false
 #guard
-  let factors := factor phi15
+  let factors := ZPoly.factorize phi15
   factorPreservesProduct phi15 &&
     sameFactorCoeffSet (factorizationCoeffSummary factors)
       (factorCoeffSummary #[phi15] |>.map fun coeffs => (coeffs, 1))

--- a/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
+++ b/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
@@ -402,8 +402,8 @@ private def cases_adversarial : List Case :=
 /-! ## Lattice-tier merge requirement
 
 See the module docstring §"Lattice-tier merge requirement".  The cases are
-emitted through the public `factor` path (`factorTraced`, whose `.1`
-is `factor`) so the pinned trace catches dispatch regressions, not just
+emitted through the public `factorize` path (`factorTraced`, whose `.1`
+is `factorize`) so the pinned trace catches dispatch regressions, not just
 lattice ones. -/
 
 /-- The two lattice-only cases, one per lattice answer arm:
@@ -520,9 +520,9 @@ private def emitPinnedCase (c : PinnedCase) : IO Unit := do
   emitClassicalResult c.id f
 
 /-- Emit one lattice-sentinel fixture through the *hybrid* traced path: a
-single `factorTraced` run supplies the `factor` result (its `.1` is the
-public `factor`) **and** the trace, so the committed trace pins the tier
-`factor` actually used.  The helper is sentinel-only: it errors out unless the
+single `factorTraced` run supplies the `factorize` result (its `.1` is the
+public `factorize`) **and** the trace, so the committed trace pins the tier
+`factorize` actually used.  The helper is sentinel-only: it errors out unless the
 classical tier declined and the lattice tier answered, which is the case's
 whole point — a case that stops routing to the lattice arm must not emit
 quietly.  (The merge still fails either way: a tier change also breaks the

--- a/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
+++ b/conformance/HexBerlekampZassenhaus/EmitFixtures.lean
@@ -97,7 +97,7 @@ of build time; the compiled emit executable covers it in seconds.
 Cross-checked operation
 -----------------------
 
-* `factor` — `Hex.factor` from `HexBerlekampZassenhaus` (the
+* `factor` — `Hex.ZPoly.factorize` from `HexBerlekampZassenhaus` (the
   default-bound public entry point).  Lean serialises the resulting
   `Factorization` as `[scalar, [[coeffs, multiplicity], ...]]`;
   python-flint cross-checks each reported nonconstant component directly
@@ -176,7 +176,7 @@ private def emitClassicalResult (case : String) (f : ZPoly) : IO Unit := do
 /-- Emit one fixture record plus the `factor` and `classicalFactor` result records. -/
 private def emitFactorCase (case : String) (f : ZPoly) : IO Unit := do
   emitPolyFixture lib case (liftCoeffs f) none
-  emitResult lib case "factor" (factorValue (factor f))
+  emitResult lib case "factor" (factorValue (ZPoly.factorize f))
   emitClassicalResult case f
 
 /-- One fixture whose result is emitted by running the public Lean `factor`. -/
@@ -516,7 +516,7 @@ private def emitExpectedCase (c : ExpectedCase) : IO Unit := do
 private def emitPinnedCase (c : PinnedCase) : IO Unit := do
   let f := DensePoly.ofCoeffs c.coeffs
   emitPolyFixtureWithModFactorDegrees lib c.id (liftCoeffs f) c.p c.degrees
-  emitResult lib c.id "factor" (factorValue (factor f))
+  emitResult lib c.id "factor" (factorValue (ZPoly.factorize f))
   emitClassicalResult c.id f
 
 /-- Emit one lattice-sentinel fixture through the *hybrid* traced path: a

--- a/progress/20260708T090306Z_issue-8651-factorize-rename.md
+++ b/progress/20260708T090306Z_issue-8651-factorize-rename.md
@@ -1,0 +1,47 @@
+# Rename `factor` → `ZPoly.factorize`, add `ZPoly.factors` (#8651)
+
+## Accomplished
+Renamed the Berlekamp-Zassenhaus integer entry point `Hex.factor` to
+`Hex.ZPoly.factorize` (in the `ZPoly` namespace, so `f.factorize`
+dot-notation works) and added the convenience accessor
+`Hex.ZPoly.factors f := (f.factorize).factors` returning the irreducible
+factors with multiplicities (`f.factors`).
+
+- `def factor` → `def ZPoly.factorize` in `FactorEntryPoints.lean`; added
+  `def ZPoly.factors`.
+- Renamed the 32 associated `factor_*` theorems → `factorize_*` across
+  `HexBerlekampZassenhaus/`, `HexBerlekampZassenhausMathlib/`, and the two
+  SPECs. These are disjoint from the unrelated mod-p `factor_*` names
+  (`factor_ne_zero_of_ne_zero`, `factor_degree_lt*`), which were left alone.
+- Fixed every bare `factor` def-reference (compiler-driven) → `ZPoly.factorize`,
+  including the capstone `FactorSoundness.lean`/`PublicSurface.lean`
+  (`Hex.factor` → `Hex.ZPoly.factorize`). Bound variables named `factor`
+  (e.g. `fun factor => …`, `{factor g : ZPoly}`) were preserved.
+- Updated SPEC `hex-berlekamp-zassenhaus.md` (signature block + prose), the
+  `#guard` examples, the conformance drivers, bench drivers/service, and the
+  manual Coppersmith tutorial (now iterates `gz.factors` via the new accessor).
+
+Note on dot-notation: `ZPoly` is `abbrev ZPoly := DensePoly Int`. Field
+notation `x.factorize` resolves to `ZPoly.factorize` only when `x`'s declared
+type is the abbrev `ZPoly`; on a value typed directly as `DensePoly Int`
+(e.g. `DensePoly.ofCoeffs g`) it resolves to `DensePoly.*`. The manual
+therefore binds `let gz : ZPoly := DensePoly.ofCoeffs g` before `gz.factors`.
+
+The conformance/bench protocol string `"factor"` (CLI `--entry` name, oracle
+key) was intentionally kept — it is an interface name, not the Lean symbol —
+so no fixtures need regenerating.
+
+## Current frontier
+`lake build` green for `HexBerlekampZassenhaus`,
+`HexBerlekampZassenhausMathlib`, `HexConformance`, and the BZ bench/service
+exes: 0 errors, 0 sorries.
+
+## Next step
+Second opinion, then PR.
+
+## Blockers
+None for this rename. Pre-existing, unrelated: `HexManual` does not build
+because `HexLLL.lean`/`Coppersmith.lean` reference `lllReducedInt`, renamed to
+`lllReduced` by #4655/#8658 without updating the manual (present on `main`, in
+files this PR does not touch). All factor-related manual code is correct.
+`HexManual` is not in the CI merge-gating target set (only the pages deploy).


### PR DESCRIPTION
This PR renames the Berlekamp-Zassenhaus integer entry point `Hex.factor` into the `ZPoly` namespace as `ZPoly.factorize`, so the public surface is dot-notation on a polynomial (`f.factorize`), and adds the convenience accessor `ZPoly.factors f := (f.factorize).factors` returning the irreducible factors with their multiplicities (`f.factors`). It renames the 32 associated `factor_*` theorems to `factorize_*` across both the computational (`HexBerlekampZassenhaus`) and Mathlib (`HexBerlekampZassenhausMathlib`) layers, and updates the SPECs, the `#guard` examples, the conformance and bench drivers, and the manual Coppersmith tutorial (which now iterates `f.factors`). It is a pure rename with no proof content changes.

The `factorize_*` lemmas stay in the `Hex` namespace (only the value-level `factorize`/`factors` moved to `ZPoly`, which is what the `f.factorize`/`f.factors` dot-notation ergonomics require); the surrounding proof lemmas keep their `Hex` home, so no broader public-API churn is introduced. The unrelated mod-p `factor_*` names (`factor_ne_zero_of_ne_zero`, `factor_degree_lt*`) are disjoint from the renamed set and untouched. The conformance/bench CLI/protocol string `"factor"` (an interface name matched against the oracle cross-check, not the Lean symbol) is deliberately kept, so no fixtures are regenerated.

Because `ZPoly` is `abbrev ZPoly := DensePoly Int`, `f.factorize` dot-notation resolves to `ZPoly.factorize` only when the value's declared type is the abbrev `ZPoly`; on a value typed directly as `DensePoly Int` it resolves through the structure head, so the manual binds `let gz : ZPoly := DensePoly.ofCoeffs g` before iterating `gz.factors`.

`lake build` is green (0 errors, 0 sorries) for `HexBerlekampZassenhaus`, `HexBerlekampZassenhausMathlib`, `HexConformance`, the BZ bench/service exes, and `HexManual` (rebased onto https://github.com/kim-em/hex-dev/pull/8661, which fixed the manual's `lllReducedInt` references).

Closes #8651

🤖 Prepared with Claude Code