### PR TITLE
feat(lll): default `δ := 3/4`, and `η := 1/2` on the reducedness checkers

### DIFF
--- a/HexLLL/Checker.lean
+++ b/HexLLL/Checker.lean
@@ -47,7 +47,7 @@ the exact checker `lllReduced`, which keeps completeness structural.
 Soundness (`lllReducedInterval_sound`, HexLLLMathlib) entails
 `b.independent ∧ isLLLReduced b δ η` at the exact rational parameters. -/
 @[expose]
-def lllReducedInterval (b : Matrix Int n m) (δ η : Rat) : Bool :=
+def lllReducedInterval (b : Matrix Int n m) (δ : Rat := 3/4) (η : Rat := 1/2) : Bool :=
   let S : Int := (2 : Int) ^ intervalPrec
   let g := (Matrix.gramMatrix b).rows.toArray.map Vector.toArray
   match IntervalGS.pass S g n with
@@ -72,9 +72,11 @@ incompatible with a positive `d[j+1]` and the size-reduced bound, so the
 checker simply returns `false`. Soundness
 (`lllReduced_sound`, HexLLLMathlib) bridges to the rational predicate
 `isLLLReduced` via the integer correspondence
-(`Hex.GramSchmidt.Int.scaledCoeffs_eq`, `basis_normSq`, `gramDet_pos`). -/
+(`Hex.GramSchmidt.Int.scaledCoeffs_eq`, `basis_normSq`, `gramDet_pos`).
+`δ` and `η` default to the classical `3/4` and `1/2`, so `lllReduced b` tests
+textbook LLL-reducedness (the bound `lllNative` achieves). -/
 @[expose]
-def lllReduced (b : Matrix Int n m) (δ η : Rat) : Bool :=
+def lllReduced (b : Matrix Int n m) (δ : Rat := 3/4) (η : Rat := 1/2) : Bool :=
   let gs := GramSchmidt.Int.data b
   let d := gs.d
   let ν := gs.ν
@@ -218,7 +220,7 @@ when the interval pass is indecisive it falls back to the exact checker,
 so completeness stays structural rather than numerical. Records each
 decision in the checker tally, distinguishing all three outcomes. -/
 @[expose]
-def lllReducedCheck (b : Matrix Int n m) (δ η : Rat) : Bool :=
+def lllReducedCheck (b : Matrix Int n m) (δ : Rat := 3/4) (η : Rat := 1/2) : Bool :=
   if intervalWins b then
     if lllReducedInterval b δ η then
       withRecordCheckerOutcome .interval true

--- a/HexLLL/Dispatch.lean
+++ b/HexLLL/Dispatch.lean
@@ -28,9 +28,10 @@ if `LLLProvider.providerAvailable ()` is true and the candidate passes
 `certCheck B B' U V δ (11/20)`, the certified `B'` is returned; otherwise the
 exact `lllNative` runs. Both paths satisfy the identical post-condition
 (`isLLLReduced (lll …) δ (11/20)`, same lattice, the public short-vector bound),
-so dispatch is invisible to callers and to proofs. -/
+so dispatch is invisible to callers and to proofs. `δ` defaults to the
+classical LLL parameter `3/4`, so a call can be as short as `lll b`. -/
 @[expose]
-def lll (b : Matrix Int n m) (δ : Rat)
+def lll (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) :
     Matrix Int n m :=
@@ -72,7 +73,7 @@ the exact native path. It never consults an external provider and takes no
 `b.independent` hypothesis, so Mathlib-free callers can use it directly; its
 short-vector guarantee is `lllNative_first_row_norm_sq_le` at `η = 1/2`. -/
 @[expose]
-def lllNative.firstShortVector (b : Matrix Int n m) (δ : Rat)
+def lllNative.firstShortVector (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Vector Int m :=
   (lllNative b δ hδ hδ' hn).getRow ⟨0, hn⟩
@@ -83,7 +84,7 @@ LLL approximation factor relative to any nonzero lattice vector (see
 vector. Canonical short-vector entry point for downstream callers such as
 `hex-berlekamp-zassenhaus` recombination. -/
 @[expose]
-def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
+def lll.firstShortVector (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) :
     Vector Int m :=
@@ -93,7 +94,7 @@ def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
 `lll.shortVectors` counterpart on the exact native path, forgoing the external
 provider and the `b.independent` hypothesis. -/
 @[expose]
-def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat)
+def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=
   (lllNative b δ hδ hδ' hn).rows.toArray
@@ -101,7 +102,7 @@ def lllNative.shortVectors (b : Matrix Int n m) (δ : Rat)
 /-- The full reduced basis viewed as an ordered array of candidate short
 vectors. -/
 @[expose]
-def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
+def lll.shortVectors (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : (121 / 400 : Rat) < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=

--- a/HexLLL/Native.lean
+++ b/HexLLL/Native.lean
@@ -551,9 +551,10 @@ open Hex.Internal
 integer state via `LLLState.ofBasis` and dispatches to `lllAux`.
 This is the body the public `lll` runs by default; its output achieves the
 classical size-reduction bound `|μ| ≤ 1/2` (η = 1/2), so its short-vector
-guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`. -/
+guarantee uses `α = 1/(δ − 1/4)` with the classical precondition `1/4 < δ`.
+`δ` defaults to the classical `3/4`, so `lllNative b` reduces at that parameter. -/
 @[expose]
-def lllNative (b : Matrix Int n m) (δ : Rat)
+def lllNative (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 1/4 < δ := by grind) (hδ' : δ ≤ 1 := by grind) (hn : 1 ≤ n := by grind) :
     Matrix Int n m :=
   lllAux (LLLState.ofBasis b) 1 δ hδ hδ' (Nat.le_refl 1) hn

--- a/HexLLL/SPEC/hex-lll.md
+++ b/HexLLL/SPEC/hex-lll.md
@@ -248,7 +248,7 @@ def LLLState.ofBasis (b : Matrix Int n m) :
     ν_eq := by …   -- from scaledCoeffs_eq and gramDetVec_eq_gramDet
     d_eq := by … } -- from gramDetVec_eq_gramDet
 
-def lll (b : Matrix Int n m) (δ : Rat)
+def lll (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) : Matrix Int n m :=
   -- dispatch: certified external candidate, else the exact `lllNative`
@@ -260,8 +260,12 @@ precondition of the *theorems* about the output (`lll_short_vector`,
 `lll_independent`, …), not of the *computation*, so — exactly as with
 `lllNative` — the reducer runs on any input and callers who only want the
 reduced rows need not discharge it. The three proof arguments are
-`autoParam`s (`:= by grind`), so at a concrete `δ`/`n` a call is just
-`lll b δ`.
+`autoParam`s (`:= by grind`), and `δ` defaults to the classical `3/4`, so at a
+concrete `n` a call is just `lll b` (or `lll b δ` to pick another parameter).
+The reducedness checkers (`lllReduced`, `lllReducedInterval`, `lllReducedCheck`)
+default `δ` to `3/4` and `η` to the classical `1/2`, so `lllReduced b` tests
+textbook LLL-reducedness — the bound `lllNative` achieves. (The public `lll`
+lands at `η = 11/20`; check its output with `lllReduced (lll b) (3/4) (11/20)`.)
 
 The `ν_eq` and `d_eq` fields are discharged from the `hex-gram-schmidt`
 lemmas `GramSchmidt.Int.scaledCoeffs_eq` and
@@ -310,7 +314,7 @@ that consumer is:
 /-- The first row of the reduced basis (shortest vector under the
     LLL guarantee). Marked as the canonical short-vector entry point
     for downstream consumers such as hex-berlekamp-zassenhaus. -/
-def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
+def lll.firstShortVector (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) :
     Vector Int m :=
@@ -318,7 +322,7 @@ def lll.firstShortVector (b : Matrix Int n m) (δ : Rat)
 
 /-- The full reduced basis viewed as an ordered list of candidate
     short vectors. -/
-def lll.shortVectors (b : Matrix Int n m) (δ : Rat)
+def lll.shortVectors (b : Matrix Int n m) (δ : Rat := 3/4)
     (hδ : 121/400 < δ := by grind) (hδ' : δ ≤ 1 := by grind)
     (hn : 1 ≤ n := by grind) :
     Array (Vector Int m) :=

--- a/progress/2026-07-08T14-42-52Z.md
+++ b/progress/2026-07-08T14-42-52Z.md
@@ -1,0 +1,14 @@
+# Default `δ := 3/4` on the LLL reducers, `δ := 3/4`, `η := 1/2` on the checkers
+
+## Accomplished
+`lllNative`, `lll`, and their `firstShortVector`/`shortVectors` variants now
+default `δ := 3/4` (the classical LLL parameter); the reducedness checkers
+`lllReduced`, `lllReducedInterval`, `lllReducedCheck` default `δ := 3/4` and
+`η := 1/2` (textbook LLL-reduced), so `lll b` and `lllReduced b` work with no
+parameters. Composes with the existing `by grind` autoParams (they discharge
+the concrete preconditions). `certCheck` deliberately keeps explicit `δ η` (its
+public contract is `η = 11/20`, not `1/2`). Backward compatible; SPEC and
+docstrings updated. Full build green (2785 jobs).
+
+## Blockers
+None.


### PR DESCRIPTION
Give the LLL entry points a classical default so a call can be just `lll b` / `lllReduced b`.

- `lllNative`, `lll`, and their `firstShortVector`/`shortVectors` variants default `δ := 3/4` (the Lenstra-Lenstra-Lovász parameter).
- The reducedness checkers `lllReduced`, `lllReducedInterval`, `lllReducedCheck` default `δ := 3/4` and `η := 1/2`, so `lllReduced b` tests textbook LLL-reducedness — the bound `lllNative` achieves. Defaulting only makes the checker stricter, so it can never certify a bad basis. The public `lll` lands at `η = 11/20`; check that output with `lllReduced (lll b) (3/4) (11/20)`.
- `certCheck` deliberately keeps explicit `δ η` (its certificate contract is `11/20`).

Composes with the existing `by grind` autoParams and is backward compatible with every positional call. SPEC and docstrings updated. Full build green (2785 jobs). Second opinion (Codex): no soundness risk, mechanically clean.

🤖 Prepared with Claude Code