### PR TITLE
perf(bz): share CLD recovery data across the lattice loop's degenerate arm

### DIFF
--- a/HexBerlekampZassenhaus/BhksRecover.lean
+++ b/HexBerlekampZassenhaus/BhksRecover.lean
@@ -152,6 +152,11 @@ This executable glue builds the CLD lattice for the lifted factors, runs LLL
 plus the Gram-Schmidt cut, extracts BHKS Lemma 3.3 equivalence-class
 indicators by RREF, reconstructs every indicated candidate by centred lifting,
 and accepts only when the verified candidates multiply back to `f`.
+
+The lattice tier runs the fused `bhksRecoverClassifiedWithAllOnes` instead (one
+lattice build for both the classification and the all-ones certificate, #8543);
+keep the two bodies in sync — `bhksRecoverClassifiedWithAllOnes_fst` fails to
+build if they drift.
 -/
 private def bhksRecoverClassified (f : ZPoly) (d : LiftData) : BhksRecoveryResult :=
   -- The CLD lattice runs in the monic (`M2`, `x ↦ x/ℓf`) coordinate: `d` is a
@@ -179,6 +184,54 @@ private def bhksRecoverClassified (f : ZPoly) (d : LiftData) : BhksRecoveryResul
 
 def bhksRecover? (f : ZPoly) (d : LiftData) : Option (Array ZPoly) :=
   (bhksRecoverClassified f d).toOption
+
+/--
+Fused BHKS recovery step: run the CLD lattice / LLL / RREF-indicator pipeline
+**once** and return both the `bhksRecoverClassified` classification and the
+single-all-ones partition flag.
+
+The lattice tier's `.degenerate` arm needs the all-ones flag to certify
+irreducibility, but recomputing it through `bhksSingleAllOnesPartition` rebuilds
+the whole Hensel-lift/CLD-lattice/LLL/indicator pipeline that the classifier
+already ran (~1.5–2× on the step that dominates irreducible inputs, #8543).  This
+def shares that pass: `bhksRecoverClassifiedWithAllOnes_fst` pins `.1` to
+`bhksRecoverClassified` and `bhksRecoverClassifiedWithAllOnes_snd` (in
+`FactorEntryPoints`) pins `.2` to `bhksSingleAllOnesPartition`, so the loop reads
+both off one lattice build with no change to either public surface.
+-/
+private def bhksRecoverClassifiedWithAllOnes (f : ZPoly) (d : LiftData) :
+    BhksRecoveryResult × Bool :=
+  let L := bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors
+  if hrows : 1 ≤ L.factorCount + L.coeffWidth then
+    let projected := bhksProjectedRows L hrows
+    let indicators := bhksEquivalenceClassIndicators projected
+    let allOnes := !indicators.isEmpty && !projected.projectedRows.isEmpty &&
+      indicators.size == 1 && bhksIndicatorAllOnes projected.factorCount (indicators.getD 0 #[])
+    let result :=
+      if bhksDegenerateIndicatorPartition projected indicators then
+        BhksRecoveryResult.degenerate
+      else
+        match bhksIndicatorCandidates? f d indicators with
+        | none => .candidateFailure
+        | some candidates =>
+            if Array.polyProduct candidates == f then
+              .success candidates
+            else
+              .productMismatch candidates
+    (result, allOnes)
+  else
+    (.degenerate, false)
+
+/-- The fused recovery step's classification equals the standalone classifier:
+the control flow is identical, only the paired all-ones flag is extra (#8543). -/
+private theorem bhksRecoverClassifiedWithAllOnes_fst (f : ZPoly) (d : LiftData) :
+    (bhksRecoverClassifiedWithAllOnes f d).1 = bhksRecoverClassified f d := by
+  rw [bhksRecoverClassifiedWithAllOnes, bhksRecoverClassified]
+  by_cases hrows :
+      1 ≤ (bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors).factorCount +
+        (bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors).coeffWidth
+  · simp only [dif_pos hrows]
+  · simp only [dif_neg hrows]
 
 /--
 If the executable BHKS recovery guards all pass, `bhksRecover?` returns the

--- a/HexBerlekampZassenhaus/FactorEntryPoints.lean
+++ b/HexBerlekampZassenhaus/FactorEntryPoints.lean
@@ -555,6 +555,19 @@ def bhksSingleAllOnesPartition (f : ZPoly) (d : LiftData) : Bool :=
   else
     false
 
+/-- The fused recovery step's all-ones flag equals `bhksSingleAllOnesPartition`:
+both read the single-all-ones signature off the same CLD lattice / RREF indicator
+partition, so the lattice tier reads it off the one lattice build the classifier
+already ran (#8543). -/
+private theorem bhksRecoverClassifiedWithAllOnes_snd (f : ZPoly) (d : LiftData) :
+    (bhksRecoverClassifiedWithAllOnes f d).2 = bhksSingleAllOnesPartition f d := by
+  rw [bhksRecoverClassifiedWithAllOnes, bhksSingleAllOnesPartition]
+  by_cases hrows :
+      1 ≤ (bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors).factorCount +
+        (bhksLatticeBasis (ZPoly.toMonic f).monic d.p d.k d.liftedFactors).coeffWidth
+  · simp only [dif_pos hrows]
+  · simp only [dif_neg hrows]
+
 /-- Lattice-tier recombination loop: `bhksRecoveryLoop` plus certificate-backed
 early termination (#8395).  The split path is byte-identical to the fast loop —
 below `floor` every step is skipped, and at/above `floor` a classified recovery
@@ -583,7 +596,12 @@ private def latticeCoreLoop
         else
           latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
       else
-        match bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
+        -- Build the CLD lattice once per step and read both the classification
+        -- and the single-all-ones certificate off it (#8543): the `.degenerate`
+        -- arm below no longer re-runs `bhksSingleAllOnesPartition`, which would
+        -- rebuild the whole Hensel-lift/CLD/LLL/indicator pipeline.
+        let step := bhksRecoverClassifiedWithAllOnes core (ZPoly.toMonicLiftData core k primeData)
+        match step.1 with
         | .success factors =>
           some factors
         | .candidateFailure =>
@@ -597,7 +615,7 @@ private def latticeCoreLoop
           else
             latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
         | .degenerate =>
-          if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k primeData) then
+          if step.2 then
             some #[core]
           else if k ≥ B then
             none
@@ -612,6 +630,40 @@ def latticeCoreWithBound
     (core : ZPoly) (B : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
     Option (Array ZPoly) :=
   latticeCoreLoop core B (bhksRecoveryFloorGate core) primeData k fuel
+
+/-- Behavioural unfolding for the lattice-tier loop: the fused-step body is
+propositionally equal to the two-call form (`bhksRecoverClassified` for the
+classification, `bhksSingleAllOnesPartition` for the certificate).  The fused step
+only shares the one lattice build across the classification and the all-ones flag
+(#8543); `bhksRecoverClassifiedWithAllOnes_fst`/`_snd` pin the two projections to
+those surfaces, so the loop's spec reasons about it exactly as before. -/
+private theorem latticeCoreLoop_unfold
+    (core : ZPoly) (B floor : Nat) (primeData : PrimeChoiceData) (k fuel : Nat) :
+    latticeCoreLoop core B floor primeData k (fuel + 1) =
+      (if k < floor then
+        if k ≥ B then
+          none
+        else
+          latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+      else
+        match bhksRecoverClassified core (ZPoly.toMonicLiftData core k primeData) with
+        | .success factors => some factors
+        | .candidateFailure =>
+          if k ≥ B then none
+          else latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+        | .productMismatch _ =>
+          if k ≥ B then none
+          else latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel
+        | .degenerate =>
+          if bhksSingleAllOnesPartition core (ZPoly.toMonicLiftData core k primeData) then
+            some #[core]
+          else if k ≥ B then none
+          else latticeCoreLoop core B floor primeData (nextHenselPrecision k B) fuel) := by
+  rw [latticeCoreLoop]
+  by_cases hfl : k < floor
+  · rw [if_pos hfl, if_pos hfl]
+  · rw [if_neg hfl, if_neg hfl]
+    simp only [bhksRecoverClassifiedWithAllOnes_fst, bhksRecoverClassifiedWithAllOnes_snd]
 
 /-- Structural spec for the lattice-tier loop: every success is either a fast-loop
 success (the split path is untouched) or the certificate-backed early stop — the
@@ -632,7 +684,7 @@ private theorem latticeCoreLoop_some_spec
       simp [latticeCoreLoop] at h
   | succ fuel ih =>
       intro k cf h
-      rw [latticeCoreLoop] at h
+      rw [latticeCoreLoop_unfold] at h
       rw [bhksRecoveryLoop]
       by_cases hfl : k < floor
       · rw [if_pos hfl] at h ⊢

--- a/progress/2026-07-08T15-46-49Z.md
+++ b/progress/2026-07-08T15-46-49Z.md
@@ -1,0 +1,43 @@
+# issue #8543 — lattice-tier per-step constant factor (deliverable 1)
+
+**Accomplished**
+
+- Deliverable 1 of #8543: stop the lattice-tier loop recomputing the recovery
+  pipeline at the certification step. Added `bhksRecoverClassifiedWithAllOnes`
+  (`BhksRecover.lean`): one CLD-lattice / LLL / RREF-indicator pass returning
+  `(BhksRecoveryResult × Bool)`. `latticeCoreLoop` binds it once (`let step`) and
+  reads `step.1` / `step.2`, so the `.degenerate` arm no longer calls
+  `bhksSingleAllOnesPartition`, which rebuilt the whole pipeline.
+- Kept every proof-facing surface intact: `bhksRecoverClassifiedWithAllOnes_fst`
+  pins `.1` to `bhksRecoverClassified`, `_snd` pins `.2` to
+  `bhksSingleAllOnesPartition` (unconditionally), and `latticeCoreLoop_unfold`
+  re-expresses the fused body in the two-call form so `latticeCoreLoop_some_spec`
+  and the Mathlib layer's `latticeArm3_bhksSingleAllOnes_irreducible` witness are
+  untouched. The Mathlib bridge (`BhksRecoveryResult` is not referenced there)
+  needs no re-key.
+- Verified: `HexBerlekampZassenhaus.FactorEntryPoints` and the CI-gated
+  `HexBerlekampZassenhausMathlib.LatticeTier` build green (0 errors/warnings).
+- Perf, same-machine A/B on `hex_lattice_spike core`, byte-identical sinks
+  (semantics unchanged): SD4 23.85→18.77 ms (1.27×), SD5 224.5→138.4 ms (1.62×),
+  SD6 5033→2768 ms (1.82×) — matches the issue's ~1.5–2× target, growing with
+  degree.
+- Second opinion (Codex): confirmed single lattice build at runtime from the
+  generated C (`latticeCoreLoop` calls the fused fn once, projects `.1`/`.2`),
+  `_snd` soundness, and no correctness concerns. Only note was the duplicated
+  pipeline body; added a sync-reminder comment on `bhksRecoverClassified`
+  (`_fst` fails to build on drift).
+
+**Current frontier**
+
+- Deliverable 1 complete. Deliverables 2 (reuse CLD/lift across doublings via
+  quadratic Hensel continuation), 3 (word-sized modulus / ZMod64 Montgomery at
+  the floor), and 4 (re-measure crossover, revisit dispatch threshold — gated on
+  2/3) are each independent large efforts, filed as follow-up issues.
+
+**Next step**
+
+- Land the deliverable-1 PR against #8543. Pick up follow-up issues for 2/3/4.
+
+**Blockers**
+
+- None.


### PR DESCRIPTION
This PR shares the CLD recovery data across the lattice-tier loop so its `.degenerate` arm stops rebuilding the Hensel-lift / CLD-lattice / LLL / RREF-indicator pipeline it had just run. `latticeCoreLoop` previously classified each precision step through `bhksRecoverClassified` and then, on a degenerate partition, called `bhksSingleAllOnesPartition` to certify irreducibility — a second full pipeline build from the same seeds. A new fused `bhksRecoverClassifiedWithAllOnes` runs that pipeline once and returns both the classification and the single-all-ones flag; the loop binds it once and reads the certificate off the same lattice build.

Semantics are byte-identical. `bhksRecoverClassifiedWithAllOnes_fst` pins the first projection to `bhksRecoverClassified` and `bhksRecoverClassifiedWithAllOnes_snd` pins the second to `bhksSingleAllOnesPartition` (unconditionally — both read the same all-ones expression off the same `projected`/`indicators`), and `latticeCoreLoop_unfold` re-expresses the fused body in the original two-call form so `latticeCoreLoop_some_spec` and the Mathlib layer's `latticeArm3_bhksSingleAllOnes_irreducible` witness reason about the loop unchanged. `BhksRecoveryResult` and `bhksSingleAllOnesPartition` keep their exact signatures, so the Mathlib bridge needs no re-key.

Same-machine A/B on `hex_lattice_spike core` (this machine, not carica) records byte-identical output sinks before and after, confirming the factorisations are unchanged, with the per-step win growing as the degree doubles:

| input | before | after | speedup |
|-------|--------|-------|---------|
| SD4 deg 16 | 23.85 ms | 18.77 ms | 1.27× |
| SD5 deg 32 | 224.5 ms | 138.4 ms | 1.62× |
| SD6 deg 64 | 5033 ms | 2768 ms | 1.82× |

The generated C confirms the runtime sharing: `latticeCoreLoop` calls the fused function once and reads `.1`/`.2` as field projections, with no residual `bhksLatticeBasis` or `bhksSingleAllOnesPartition` call in the loop body.

This is deliverable 1 of https://github.com/kim-em/hex-dev/issues/8543 (perf(bz): lattice-tier per-step constant factor). Deliverables 2 (reuse CLD/lift data across doublings via quadratic Hensel continuation), 3 (word-sized modulus arithmetic at/below the floor), and 4 (re-measure the classical/lattice crossover and revisit the dispatch threshold, gated on 1–3) remain open on that issue.

🤖 Prepared with Claude Code
