### PR TITLE
feat(hex-matrix): zero-padding and the top-left-block product lemma

### DIFF
--- a/HexMatrix.lean
+++ b/HexMatrix.lean
@@ -13,6 +13,7 @@ public import HexMatrix.DotProduct
 public import HexMatrix.MatrixAlgebra
 public import HexMatrix.Elementary
 public import HexMatrix.Submatrix
+public import HexMatrix.Pad
 public import HexMatrix.Gram
 
 public section

--- a/HexMatrix/DotProduct.lean
+++ b/HexMatrix/DotProduct.lean
@@ -18,6 +18,72 @@ universe u v
 
 namespace Vector
 
+/-- A dot product of two `ofFn` vectors is the `List.finRange` fold of their
+pointwise products. The reference `dotProduct` reduction that keeps `ofFn`-built
+rows and columns visible to the fold-algebra lemmas. -/
+theorem dotProduct_ofFn {R : Type u} [Mul R] [Add R] [OfNat R 0] {n : Nat}
+    (f g : Fin n → R) :
+    dotProduct (Vector.ofFn f) (Vector.ofFn g)
+      = (List.finRange n).foldl (fun acc i => acc + f i * g i) 0 := by
+  simp only [dotProduct, Fin.getElem_fin, Vector.getElem_ofFn, Fin.eta]
+
+/-- Peel the final index off an additive fold over `List.finRange (n+1)`. -/
+private theorem foldl_finRange_succ_last {R : Type u} [Lean.Grind.Ring R] {n : Nat}
+    (F : Fin (n + 1) → R) :
+    (List.finRange (n + 1)).foldl (fun acc i => acc + F i) 0
+      = (List.finRange n).foldl (fun acc i => acc + F i.castSucc) 0 + F (Fin.last n) := by
+  rw [List.finRange_succ_last, List.foldl_append, List.foldl_map]
+  simp only [List.foldl_cons, List.foldl_nil]
+
+/-- Trailing zeros in a fold of pointwise products vanish: folding the products of
+two length-`m + d` zero-extensions equals folding the length-`m` products. -/
+private theorem foldl_extend_zero {R : Type u} [Lean.Grind.Ring R] (m d : Nat)
+    (F G : Fin m → R) :
+    (List.finRange (m + d)).foldl
+        (fun acc i => acc
+          + (if h : i.val < m then F ⟨i.val, h⟩ else 0)
+            * (if h : i.val < m then G ⟨i.val, h⟩ else 0)) 0
+      = (List.finRange m).foldl (fun acc i => acc + F i * G i) 0 := by
+  induction d with
+  | zero =>
+    apply List.foldl_add_congr
+    intro i _
+    have hi : i.val < m := i.isLt
+    rw [dif_pos hi, dif_pos hi]
+    congr 1
+  | succ d ih =>
+    show (List.finRange ((m + d) + 1)).foldl
+        (fun acc i => acc
+          + (if h : i.val < m then F ⟨i.val, h⟩ else 0)
+            * (if h : i.val < m then G ⟨i.val, h⟩ else 0)) 0 = _
+    rw [foldl_finRange_succ_last]
+    have hlast : ¬ ((Fin.last (m + d)).val < m) := by simp [Fin.last]
+    rw [dif_neg hlast]
+    have hpre : (List.finRange (m + d)).foldl
+        (fun acc i => acc
+          + (if h : (Fin.castSucc i).val < m then F ⟨(Fin.castSucc i).val, h⟩ else 0)
+            * (if h : (Fin.castSucc i).val < m then G ⟨(Fin.castSucc i).val, h⟩ else 0)) 0
+        = (List.finRange (m + d)).foldl
+        (fun acc i => acc
+          + (if h : i.val < m then F ⟨i.val, h⟩ else 0)
+            * (if h : i.val < m then G ⟨i.val, h⟩ else 0)) 0 := by
+      apply List.foldl_add_congr
+      intro i _
+      rfl
+    rw [hpre, ih]
+    grind
+
+/-- Zero-extending two vectors on the right (to a common larger length `m + d`)
+leaves their dot product unchanged: every added term is `0 * _` or `_ * 0`. This
+is the vector-level engine behind the matrix padding lemma. -/
+theorem dotProduct_extendZero {R : Type u} [Lean.Grind.Ring R] (m d : Nat)
+    (F G : Fin m → R) :
+    dotProduct
+        (Vector.ofFn fun i : Fin (m + d) => if h : i.val < m then F ⟨i.val, h⟩ else 0)
+        (Vector.ofFn fun i : Fin (m + d) => if h : i.val < m then G ⟨i.val, h⟩ else 0)
+      = dotProduct (Vector.ofFn F) (Vector.ofFn G) := by
+  rw [dotProduct_ofFn, dotProduct_ofFn, foldl_extend_zero]
+
 /-- Dot product is additive in its left argument. -/
 theorem dotProduct_add_left {R : Type u} [Lean.Grind.Ring R]
     (u v w : Vector R n) :

--- a/HexMatrix/Pad.lean
+++ b/HexMatrix/Pad.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrix.Submatrix
+public import HexMatrix.DotProduct
+
+public section
+
+/-!
+Zero-padding of dense matrices and the top-left-block product lemma.
+
+`pad M n' m'` places `M` in the top-left corner of an `n' × m'` matrix and fills
+the border with zeros. Its correctness lemma — the **padding lemma** — says that
+bordering each operand with zero rows and columns and reading back the top-left
+block of the product returns the unpadded product (`takeCols_takeRows_mul_pad`).
+This is the second of the three lemmas the SPEC decomposes `mulStrassen_eq_mul`
+into; it lets the Strassen recursion pad an odd dimension up to even and recover
+the true product from the padded one.
+-/
+
+namespace Hex
+
+universe u
+
+namespace Matrix
+
+variable {R : Type u} {n m k : Nat}
+
+/-- `M` embedded in the top-left corner of an `n' × m'` matrix, with zeros filling
+the rest. Truncation semantics: an entry whose row is `≥ n` or column is `≥ m` is
+`0`, and if `n' < n` or `m' < m` the overhanging entries of `M` are dropped. The
+padding lemmas below assume `n ≤ n'` / `m ≤ m'`, the regime where this is genuine
+zero-padding. -/
+@[expose]
+def pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) : Matrix R n' m' :=
+  ofFn fun i j =>
+    if h : i.val < n ∧ j.val < m then M[((⟨i.val, h.1⟩ : Fin n), (⟨j.val, h.2⟩ : Fin m))] else 0
+
+/-- Entry formula for a padded matrix: the original entry inside the block, `0`
+outside. -/
+@[grind =] theorem getElem_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat)
+    (i : Fin n') (j : Fin m') :
+    (pad M n' m')[i][j] =
+      if h : i.val < n ∧ j.val < m then M[((⟨i.val, h.1⟩ : Fin n), (⟨j.val, h.2⟩ : Fin m))]
+      else 0 := by
+  simp only [pad, getElem_ofFn]
+
+/-- Taking the top-left `n × m` block of `pad M n' m'` returns `M`. -/
+theorem takeCols_takeRows_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat)
+    (hn : n ≤ n') (hm : m ≤ m') :
+    takeCols (takeRows (pad M n' m') n hn) m hm = M := by
+  apply ext_getElem
+  intro i j
+  rw [getElem_takeCols, getElem_takeRows, getElem_pad,
+    dif_pos (⟨i.isLt, j.isLt⟩ : i.val < n ∧ j.val < m)]
+  rfl
+
+/-- An in-range row of a padded matrix is the source row followed by zeros. -/
+theorem row_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) (I : Fin n') (hI : I.val < n) :
+    row (pad M n' m') I
+      = Vector.ofFn (fun t : Fin m' =>
+          if h : t.val < m then M[((⟨I.val, hI⟩ : Fin n), (⟨t.val, h⟩ : Fin m))] else 0) := by
+  apply Vector.ext
+  intro t ht
+  rw [Vector.getElem_ofFn]
+  show (pad M n' m')[I][(⟨t, ht⟩ : Fin m')] = _
+  rw [getElem_pad]
+  by_cases htm : t < m
+  · rw [dif_pos htm, dif_pos (⟨hI, htm⟩ : I.val < n ∧ (⟨t, ht⟩ : Fin m').val < m)]
+  · rw [dif_neg (by simp [htm]), dif_neg htm]
+
+/-- An in-range column of a padded matrix is the source column followed by zeros. -/
+theorem col_pad [OfNat R 0] (M : Matrix R n m) (n' m' : Nat) (J : Fin m') (hJ : J.val < m) :
+    col (pad M n' m') J
+      = Vector.ofFn (fun t : Fin n' =>
+          if h : t.val < n then M[((⟨t.val, h⟩ : Fin n), (⟨J.val, hJ⟩ : Fin m))] else 0) := by
+  apply Vector.ext
+  intro t ht
+  rw [Vector.getElem_ofFn]
+  show (col (pad M n' m') J)[(⟨t, ht⟩ : Fin n')] = _
+  rw [getElem_col, getElem_pad]
+  by_cases htn : t < n
+  · rw [dif_pos htn, dif_pos (⟨htn, hJ⟩ : (⟨t, ht⟩ : Fin n').val < n ∧ J.val < m)]
+  · rw [dif_neg htn, dif_neg (by simp [htn])]
+
+/-- **Padding lemma.** Zero-padding each operand to a common larger middle
+dimension and reading back the top-left `n × k` block of the product returns the
+unpadded product `A * B`. The border entries are zero, so every extended term of
+each dot product is `0 * _` or `_ * 0` and drops out (`dotProduct_extendZero`). -/
+theorem takeCols_takeRows_mul_pad [Lean.Grind.Ring R]
+    (A : Matrix R n m) (B : Matrix R m k) (n' m' k' : Nat)
+    (hn : n ≤ n') (hm : m ≤ m') (hk : k ≤ k') :
+    takeCols (takeRows (mul (pad A n' m') (pad B m' k')) n hn) k hk = mul A B := by
+  apply ext_getElem
+  intro i j
+  simp only [getElem_takeCols, getElem_takeRows]
+  rw [show mul (pad A n' m') (pad B m' k') = pad A n' m' * pad B m' k' from rfl,
+    show mul A B = A * B from rfl, getElem_mul, getElem_mul]
+  obtain ⟨d, rfl⟩ := Nat.le.dest hm
+  rw [row_pad A n' (m + d) _ i.isLt, col_pad B (m + d) k' _ j.isLt,
+    Vector.dotProduct_extendZero m d (fun t : Fin m => A[((⟨i.val, i.isLt⟩ : Fin n), t)])
+      (fun t : Fin m => B[(t, (⟨j.val, j.isLt⟩ : Fin k))])]
+  have hrowA : row A i = Vector.ofFn (fun t : Fin m => A[((⟨i.val, i.isLt⟩ : Fin n), t)]) := by
+    apply Vector.ext; intro t ht; rw [Vector.getElem_ofFn]; rfl
+  have hcolB : col B j = Vector.ofFn (fun t : Fin m => B[(t, (⟨j.val, j.isLt⟩ : Fin k))]) := by
+    apply Vector.ext; intro t ht
+    rw [Vector.getElem_ofFn]
+    show (col B j)[(⟨t, ht⟩ : Fin m)] = _
+    rw [getElem_col]
+    rfl
+  rw [hrowA, hcolB]
+
+end Matrix
+
+end Hex

--- a/HexMatrix/Submatrix.lean
+++ b/HexMatrix/Submatrix.lean
@@ -82,6 +82,13 @@ restricted to the first `k` rows. -/
   rw [getElem_col, getElem_principalSubmatrix]
   simp
 
+/-- The first `k` columns of a matrix, retaining all source rows. -/
+@[expose]
+def takeCols (M : Matrix R n m) (k : Nat) (hk : k ≤ m) : Matrix R n k :=
+  ofFn fun i j =>
+    let jj : Fin m := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+    M[(i, jj)]
+
 /-- Entry formula for the first-`k`-rows slice. -/
 @[grind =] theorem getElem_takeRows (M : Matrix R n m) (k : Nat) (hk : k ≤ n)
     (i : Fin k) (j : Fin m) :
@@ -89,6 +96,14 @@ restricted to the first `k` rows. -/
       (let ii : Fin n := ⟨i.val, Nat.lt_of_lt_of_le i.isLt hk⟩
        M[ii][j]) := by
   simp [takeRows, ofFn]
+
+/-- Entry formula for the first-`k`-columns slice. -/
+@[grind =] theorem getElem_takeCols (M : Matrix R n m) (k : Nat) (hk : k ≤ m)
+    (i : Fin n) (j : Fin k) :
+    (takeCols M k hk)[i][j] =
+      (let jj : Fin m := ⟨j.val, Nat.lt_of_lt_of_le j.isLt hk⟩
+       M[i][jj]) := by
+  simp [takeCols, ofFn]
 
 /-- The leading principal `k × k` submatrix of the identity is the identity. -/
 @[simp, grind =] theorem principalSubmatrix_identity {R : Type u} [OfNat R 0] [OfNat R 1] {n : Nat}


### PR DESCRIPTION
This PR adds `Matrix.pad`, which embeds a matrix in the top-left corner of a larger `n' × m'` matrix and fills the border with zeros, together with the padding lemma `takeCols_takeRows_mul_pad`: zero-padding each operand to a common larger middle dimension and reading back the top-left `n × k` block of the product returns the unpadded product `A * B`. It adds the column analogue `takeCols` (with `getElem_takeCols`) of the existing `takeRows`, the round-trip `takeCols_takeRows_pad`, the padded row/column shape lemmas `row_pad`/`col_pad`, and the vector-level engine `dotProduct_extendZero`, which says a dot product is unchanged by zero-extending both operands on the right because every added term is `0 * _` or `_ * 0`. This is the second of the three named lemmas the SPEC decomposes `mulStrassen_eq_mul` into, and it is pure proof infrastructure independent of the Strassen recursion.

Closes #8667.

🤖 Prepared with Claude Code