### PR TITLE
perf(bz): budget-bounded subset materialization in the classical size loop

### DIFF
--- a/HexBerlekampZassenhaus/Recombination.lean
+++ b/HexBerlekampZassenhaus/Recombination.lean
@@ -260,6 +260,46 @@ def subsetsOfSizeWithComplement {α : Type} : List α → Nat → List (List α 
       (subsetsOfSizeWithComplement xs k).map (fun sc => (x :: sc.1, sc.2)) ++
       (subsetsOfSizeWithComplement xs (k + 1)).map (fun sc => (sc.1, x :: sc.2))
 
+/-- Budget-bounded prefix of `subsetsOfSizeWithComplement xs k`: it produces the
+first `n` size-`k` sublists (with complements), in the same order, and stops as
+soon as that prefix is full. It returns at most `n` splits
+(`subsetsOfSizeWithComplementTake_length_le`) and, crucially, does not build the
+whole `C(xs.length, k)` level before taking the prefix — a subtree asked for `0`
+more splits returns immediately (the `n = 0` arm), so the level above `n` is
+never enumerated. Equal to `(subsetsOfSizeWithComplement xs k).take n`
+(`subsetsOfSizeWithComplementTake_eq`).
+
+The size-ordered classical search feeds this the running candidate `budget`. The
+candidate loop consumes at most `budget` subsets before its `budget = 0` guard
+fires, so building only the first `budget` of a size level is value-preserving
+while keeping the whole level from being realised when the running budget is not
+aligned to the level boundary (a quotient sub-search after a peel, or a
+non-default caller budget) — the surviving cases from #8535/#8537. -/
+@[expose]
+def subsetsOfSizeWithComplementTake {α : Type} :
+    List α → Nat → Nat → List (List α × List α)
+  | _, _, 0 => []
+  | xs, 0, _ + 1 => [([], xs)]
+  | [], _ + 1, _ + 1 => []
+  | x :: xs, k + 1, n + 1 =>
+      let withHead :=
+        (subsetsOfSizeWithComplementTake xs k (n + 1)).map (fun sc => (x :: sc.1, sc.2))
+      withHead ++
+        (subsetsOfSizeWithComplementTake xs (k + 1) (n + 1 - withHead.length)).map
+          (fun sc => (sc.1, x :: sc.2))
+
+-- The bounded generator agrees with the plain prefix; the level above the budget
+-- is never built (the `n = 0` base case returns immediately).
+#guard subsetsOfSizeWithComplementTake [1, 2, 3, 4] 2 3
+  = (subsetsOfSizeWithComplement [1, 2, 3, 4] 2).take 3
+#guard subsetsOfSizeWithComplementTake [1, 2, 3, 4] 2 100
+  = subsetsOfSizeWithComplement [1, 2, 3, 4] 2
+#guard subsetsOfSizeWithComplementTake [1, 2, 3] 0 5
+  = (subsetsOfSizeWithComplement [1, 2, 3] 0).take 5
+#guard subsetsOfSizeWithComplementTake ([] : List Nat) 2 5 = []
+#guard subsetsOfSizeWithComplementTake [1, 2, 3, 4, 5] 3 4
+  = (subsetsOfSizeWithComplement [1, 2, 3, 4, 5] 3).take 4
+
 /-- Sum of the degrees of a selected local-factor subset — the degree of the
 subset product whenever the leading coefficients do not cancel mod the lift
 modulus. -/
@@ -345,7 +385,8 @@ def scaledRecombinationSmartSizeLoop
       else match fuel with
         | 0 => (none, budget)
         | fuel + 1 =>
-            let splits := (subsetsOfSizeWithComplement tail d).map fun sc => (head :: sc.1, sc.2)
+            let splits :=
+              (subsetsOfSizeWithComplementTake tail d budget).map fun sc => (head :: sc.1, sc.2)
             match scaledRecombinationSmartCandLoop coreLc target modulus splits budget fuel with
             | (some res, b) => (some res, b)
             | (none, b) =>
@@ -407,10 +448,13 @@ The cap is applied once, at the `scaledRecombinationSmart` wrapper, from the
 top-level `r`. A recursive quotient search after a successful factor
 extraction inherits the remaining budget unaligned to its own (smaller) level
 boundaries, so a decline after at least one peel can still end mid-level —
-harmless for correctness (any exhaustion declines to the lattice tier) and
-bounded by the already-tightened top-level cap; re-aligning per recursion
-would churn `scaledRecombinationSmartAux` and its proof set for no verdict
-change. -/
+harmless for correctness (any exhaustion declines to the lattice tier). This
+mid-level decline is intentional and value-preserving, so this cap is not
+re-aligned per recursion; the orthogonal *materialisation* cost of a mid-level
+budget (building all `C(r-1, d)` splits of a level the sub-search cannot
+finish) is bounded separately by `subsetsOfSizeWithComplementTake`, which the
+size loop feeds the running budget so it never builds more than `budget` splits
+of a level (#8648). -/
 def levelAwareSubsetBudget (r budget : Nat) : Nat :=
   go r 0 1 0
 where

--- a/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
+++ b/HexBerlekampZassenhausMathlib/RecombinationCandidate.lean
@@ -124,6 +124,95 @@ theorem subsetsOfSizeWithComplement_mem_subsetSplits
             obtain ⟨rfl, rfl⟩ := heq
             exact Hex.subsetSplits_cons_right_mem (ih hmem)
 
+/-- The budget-bounded generator materialises exactly the length-`n` prefix of the
+full size-`k` enumeration.  The size-ordered classical search feeds it the running
+candidate `budget`, so the size level above the budget is never realised while the
+candidate list the loop iterates stays a prefix of the full enumeration. -/
+theorem subsetsOfSizeWithComplementTake_eq {α : Type} (xs : List α) (k n : Nat) :
+    Hex.subsetsOfSizeWithComplementTake xs k n
+      = (Hex.subsetsOfSizeWithComplement xs k).take n := by
+  induction xs generalizing k n with
+  | nil =>
+      match k, n with
+      | _, 0 => simp [Hex.subsetsOfSizeWithComplementTake]
+      | 0, _ + 1 => simp [Hex.subsetsOfSizeWithComplementTake, Hex.subsetsOfSizeWithComplement]
+      | _ + 1, _ + 1 => simp [Hex.subsetsOfSizeWithComplementTake, Hex.subsetsOfSizeWithComplement]
+  | cons x xs ih =>
+      match k, n with
+      | _, 0 => simp [Hex.subsetsOfSizeWithComplementTake]
+      | 0, _ + 1 => simp [Hex.subsetsOfSizeWithComplementTake, Hex.subsetsOfSizeWithComplement]
+      | j + 1, m + 1 =>
+          rw [show Hex.subsetsOfSizeWithComplement (x :: xs) (j + 1) =
+              (Hex.subsetsOfSizeWithComplement xs j).map (fun sc => (x :: sc.1, sc.2)) ++
+                (Hex.subsetsOfSizeWithComplement xs (j + 1)).map (fun sc => (sc.1, x :: sc.2))
+            from rfl]
+          simp only [Hex.subsetsOfSizeWithComplementTake, ih, List.map_take, List.take_append,
+            List.length_take, List.length_map]
+          congr 2
+          omega
+
+/-- The budget-bounded generator returns at most `n` splits: the size level above
+the running budget is never enumerated. -/
+theorem subsetsOfSizeWithComplementTake_length_le {α : Type} (xs : List α) (k n : Nat) :
+    (Hex.subsetsOfSizeWithComplementTake xs k n).length ≤ n := by
+  rw [subsetsOfSizeWithComplementTake_eq, List.length_take]
+  omega
+
+/-- The candidate loop consumes at most `budget` splits before its `budget = 0`
+guard fires, so replacing the split list by any prefix of length `≥ budget` leaves
+the result unchanged.  Fed exactly `budget` splits by the budget-bounded generator,
+the bounded size-ordered search is therefore identical to the full one — the fix is
+value-preserving (no decline-boundary shift, no trace regeneration). -/
+theorem scaledRecombinationSmartCandLoop_take
+    (coreLc : Int) (target : Hex.ZPoly) (modulus : Nat)
+    (splits : List (List Hex.ZPoly × List Hex.ZPoly)) (budget fuel n : Nat)
+    (hn : budget ≤ n) :
+    Hex.scaledRecombinationSmartCandLoop coreLc target modulus (splits.take n) budget fuel
+      = Hex.scaledRecombinationSmartCandLoop coreLc target modulus splits budget fuel := by
+  induction splits generalizing budget fuel n with
+  | nil => simp
+  | cons split rest ih =>
+    match n, hn with
+    | 0, hn =>
+      obtain rfl : budget = 0 := Nat.le_zero.mp hn
+      rw [List.take_zero, Hex.scaledRecombinationSmartCandLoop_budget_zero,
+        Hex.scaledRecombinationSmartCandLoop_budget_zero]
+    | m + 1, hn =>
+      rw [List.take_succ_cons]
+      by_cases hb : budget = 0
+      · rw [hb, Hex.scaledRecombinationSmartCandLoop_budget_zero,
+          Hex.scaledRecombinationSmartCandLoop_budget_zero]
+      · conv_lhs => rw [Hex.scaledRecombinationSmartCandLoop.eq_def]
+        conv_rhs => rw [Hex.scaledRecombinationSmartCandLoop.eq_def]
+        simp only [if_neg hb]
+        cases fuel with
+        | zero => rfl
+        | succ fuel' =>
+          simp only []
+          by_cases hpre : Hex.scaledCandidatePrefilter coreLc target modulus split.1 = true
+          · simp only [if_pos hpre]
+            by_cases hrec : Hex.shouldRecordPolynomialFactor
+                (Hex.normalizeFactorSign (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate coreLc
+                  (Hex.centeredLiftPoly (Array.polyProduct split.1.toArray) modulus)))) = true
+            · simp only [if_pos hrec]
+              cases hquot : Hex.exactQuotient? target
+                  (Hex.normalizeFactorSign (Hex.ZPoly.primitivePart (Hex.ZPoly.dilate coreLc
+                    (Hex.centeredLiftPoly (Array.polyProduct split.1.toArray) modulus)))) with
+              | none => simp only []; exact ih (budget - 1) fuel' m (by omega)
+              | some quotient =>
+                simp only []
+                cases haux : Hex.scaledRecombinationSmartAux coreLc quotient modulus split.2
+                    (budget - 1) fuel' with
+                | mk ores ob =>
+                  cases ores with
+                  | none =>
+                    simp only []
+                    exact ih ob fuel' m (le_trans
+                      (Hex.scaledRecombinationSmartAux_budget_le _ _ _ _ _ _ _ _ haux) (by omega))
+                  | some sub => simp only []
+            · simp only [if_neg hrec]; exact ih (budget - 1) fuel' m (by omega)
+          · simp only [if_neg hpre]; exact ih (budget - 1) fuel' m (by omega)
+
 /-- The head-forced size-ordered split lies in `subsetSplitsWithFirst`: this is
 the executable enumeration shape the size-ordered search actually iterates (the
 head lifted factor forced into the selected component, the tail partitioned by

--- a/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
+++ b/HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean
@@ -664,6 +664,10 @@ private theorem smartSizeLoop_none_budget_zero
           by_cases hd_eq : dsize = S_cov.card - 1
           · -- at `S_cov`'s size: CandLoop completeness forces `cb = 0`, then budget-zero
             subst hd_eq
+            -- The size loop feeds the candidate loop only the budget-bounded prefix of the
+            -- size level; realign `hcand` to the full enumeration (value-preserving, #8648).
+            rw [subsetsOfSizeWithComplementTake_eq, List.map_take,
+              scaledRecombinationSmartCandLoop_take _ _ _ _ _ _ budget (le_refl budget)] at hcand
             have hcb : cb = 0 :=
               smartCandLoop_none_budget_zero B' hcore_lc_le hvalid hcore_ne
                 hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic
@@ -1091,6 +1095,9 @@ private theorem smartSizeLoop_covers_of_bound
           simp only [Prod.mk.injEq, Option.some.injEq] at h
           obtain ⟨hres, _⟩ := h
           subst hres
+          -- Realign `hcand` from the budget-bounded prefix to the full size level (#8648).
+          rw [subsetsOfSizeWithComplementTake_eq, List.map_take,
+            scaledRecombinationSmartCandLoop_take _ _ _ _ _ _ budget (le_refl budget)] at hcand
           have hk_le : dsize ≤ S_cov.card - 1 := by
             rcases List.mem_cons.mp hcontains with hh | ht
             · omega
@@ -1106,6 +1113,8 @@ private theorem smartSizeLoop_covers_of_bound
           have hcb_le := Hex.scaledRecombinationSmartCandLoop_budget_le _ _ _ _ _ _ _ _ hcand
           by_cases hd_eq : dsize = S_cov.card - 1
           · subst hd_eq
+            rw [subsetsOfSizeWithComplementTake_eq, List.map_take,
+              scaledRecombinationSmartCandLoop_take _ _ _ _ _ _ budget (le_refl budget)] at hcand
             have hcb : cb = 0 :=
               smartCandLoop_none_budget_zero B' hcore_lc_le hvalid hcore_ne
                 hcore_primitive hcore_lc_pos hd_modulus hd_liftedFactor_monic

--- a/progress/20260708T160240Z_issue-8648-budget-bounded-subset-materialization.md
+++ b/progress/20260708T160240Z_issue-8648-budget-bounded-subset-materialization.md
@@ -1,0 +1,46 @@
+**Accomplished**
+
+Fixed #8648 (eager size-level materialization in the classical size loop).
+The surviving cases from #8535/#8537 were quotient sub-searches (and
+non-default-budget callers) inheriting a mid-level budget: the size loop
+built all `C(r-1, d)` splits of an unaffordable level via
+`(subsetsOfSizeWithComplement tail d).map`, then tried only a handful.
+
+Chose the value-preserving option (lazy materialization) over re-aligning the
+sub-search budget, because re-alignment shifts the decline boundary and needs
+trace-baseline regeneration, whereas the bounded generator changes nothing the
+search actually tries.
+
+- `HexBerlekampZassenhaus/Recombination.lean`: added `subsetsOfSizeWithComplementTake`,
+  a budget-bounded generator that builds at most `n` splits and never enumerates
+  the level above `n` (0-budget subtrees return immediately). Size loop now feeds
+  it the running `budget`. Existing size-loop soundness proofs are generic over
+  the split list, so unchanged.
+- `HexBerlekampZassenhausMathlib/RecombinationCandidate.lean`: proved
+  `subsetsOfSizeWithComplementTake_eq` (= `(...).take n`),
+  `subsetsOfSizeWithComplementTake_length_le`, and
+  `scaledRecombinationSmartCandLoop_take` (candidate loop over `splits.take n`
+  equals over `splits` when `budget ≤ n`; the loop consumes at most `budget`).
+- `HexBerlekampZassenhausMathlib/SmartSearchCoverage.lean`: in the two size-loop
+  coverage proofs, realign the now-bounded `hcand` back to the full enumeration
+  via the two bridging lemmas, leaving the covering-subset argument unchanged.
+
+**Current frontier**
+
+Full `lake build` green (4143 jobs). Regenerated `bz.jsonl` fixtures are
+byte-identical to committed (`diff` empty), so `bz_trace_gate.py` passes with no
+baseline change — the decline boundary is provably unchanged. Generator is
+empirically efficient: first 5 of `C(40,20)` instantly, full `C(12,6)=924` when
+budget exceeds the level. Second opinion (Codex) found no correctness issues;
+addressed its one Low flag by tightening the docstring and adding the
+`length_le` lemma.
+
+**Next step**
+
+Open the PR from branch `issue-8648`; FLINT oracle (`bz_flint.py`) runs in CI
+(python-flint not installed locally). Watch CI for the classical-tier bench
+wallclock step.
+
+**Blockers**
+
+None.


### PR DESCRIPTION
This PR caps size-level subset materialization in `scaledRecombinationSmartSizeLoop` by the running candidate budget, so a quotient sub-search after a peel (or a caller passing a non-default budget) that inherits a mid-level budget no longer builds an entire `C(r-1, d)` size level it cannot afford only to try a handful of splits. These are the cases that survived the level-aware decline boundary of https://github.com/kim-em/hex-dev/pull/8537 (level-aware classical decline boundary, `levelAwareSubsetBudget`), as noted in the scope of https://github.com/kim-em/hex-dev/issues/8535 (perf: cap classical size-level subset materialization by the running budget), and close https://github.com/kim-em/hex-dev/issues/8648 (perf(bz): level-aware budget alignment in quotient sub-searches of the classical size loop).

The fix adds `subsetsOfSizeWithComplementTake`, a budget-bounded generator that produces at most `n` size-`k` splits in the same order as `subsetsOfSizeWithComplement` and never enumerates the level above `n` (a subtree asked for `0` more splits returns immediately), and feeds the size loop the running `budget`. It chooses lazy materialization over re-aligning the sub-search budget precisely because it is value-preserving: the candidate loop already consumes at most `budget` splits before its `budget = 0` guard fires, so restricting the split list to its length-`budget` prefix cannot change what the search tries. `scaledRecombinationSmartCandLoop_take` proves the candidate-loop result is unchanged (using the existing budget-monotonicity lemma so a sub-search cannot refund budget past the built prefix), `subsetsOfSizeWithComplementTake_eq` identifies the generator with `(subsetsOfSizeWithComplement xs k).take n`, and the two size-loop coverage proofs in `SmartSearchCoverage` realign the now-bounded hypothesis back to the full enumeration so the covering-subset argument is unchanged. The existing size-loop soundness proofs are generic over the split list and need no change.

Because nothing the search tries changes, the decline boundary does not move: the regenerated `bz.jsonl` conformance fixtures are byte-identical to the committed ones, `bz_trace_gate.py` passes against the existing baseline, and no trace baseline regeneration is required. The generator is empirically efficient (it returns the first 5 splits of `C(40, 20)` instantly and the full `C(12, 6) = 924` when the budget exceeds the level).

🤖 Prepared with Claude Code