### PR TITLE
perf(polyz): collapse defaultFactorCoeffBound to a closed-form central binomial

### DIFF
--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBasic
+public import HexArith.Nat.Prime
 public import HexPolyZ.Decomposition
 
 public section
@@ -422,9 +423,14 @@ factorization entry point.
 It takes the maximum of the executable Mignotte coefficient bounds over every
 candidate factor degree up to `f.degree?.getD 0` and every coefficient index up
 to that degree.
+
+The compiled runtime uses the value-equal `defaultFactorCoeffBoundImpl` (proved
+by `defaultFactorCoeffBound_eq_impl`, registered `@[csimp]`), which computes the
+loop-invariant `coeffL2NormBound f` once instead of recomputing the whole bignum
+coefficient norm inside every one of the `O(deg^2)` `mignotteCoeffBound` terms.
 -/
 @[expose]
-def defaultFactorCoeffBound (f : ZPoly) : Nat :=
+noncomputable def defaultFactorCoeffBound (f : ZPoly) : Nat :=
   let degreeBound := f.degree?.getD 0
   (List.range (degreeBound + 1)).foldl
     (fun acc k =>
@@ -789,6 +795,175 @@ theorem defaultFactorCoeffBound_pos_of_ne_zero {f : ZPoly} (hf : f ≠ 0) :
     0 < defaultFactorCoeffBound f :=
   Nat.lt_of_lt_of_le (coeffL2NormBound_pos_of_ne_zero hf)
     (coeffL2NormBound_le_defaultFactorCoeffBound f)
+
+/-!
+### Closed-form runtime implementation of `defaultFactorCoeffBound`
+
+The specification maxes `binom k j * coeffL2NormBound f` over the whole
+`j ≤ k ≤ degree f` rectangle, recomputing the loop-invariant bignum norm
+`coeffL2NormBound f` inside every one of the `O(deg^2)` terms. Because
+`binom k j` peaks at the central binomial `binom n (n / 2)` (`n = degree f`),
+the entire double max collapses to `binom n (n / 2) * coeffL2NormBound f` — one
+norm, one binomial. The bridge to the Mathlib-free Pascal `Hex.Nat.choose`
+supplies the monotonicity needed to prove the collapse; the compiled runtime
+then runs the closed form via a `@[csimp]` swap.
+-/
+
+/-- The fold underlying `binom n m` (over `List.range m`) equals the Pascal
+`Hex.Nat.choose n m` for `m ≤ n`. -/
+private theorem foldl_choose (n : Nat) :
+    ∀ m, m ≤ n →
+      (List.range m).foldl (fun acc i => acc * (n - i) / (i + 1)) 1
+        = Hex.Nat.choose n m := by
+  intro m
+  induction m with
+  | zero => intro _; simp
+  | succ m ih =>
+      intro hm
+      rw [List.range_succ, List.foldl_append, ih (Nat.le_of_succ_le hm)]
+      simp only [List.foldl_cons, List.foldl_nil]
+      have hid : Hex.Nat.choose n m * (n - m) = (m + 1) * Hex.Nat.choose n (m + 1) := by
+        rw [Nat.mul_comm]; exact (Hex.Nat.succ_mul_choose_succ n m).symm
+      rw [hid, Nat.mul_div_cancel_left _ (Nat.succ_pos m)]
+
+/-- `binom` is symmetric: `binom n k = binom n (n - k)` for `k ≤ n`. This is
+definitional (the underlying fold's length `min k (n - k)` is symmetric). -/
+private theorem binom_symm {n k : Nat} (h : k ≤ n) : binom n k = binom n (n - k) := by
+  unfold binom
+  rw [if_neg (Nat.not_lt.mpr h), if_neg (Nat.not_lt.mpr (Nat.sub_le n k)),
+    Nat.sub_sub_self h, Nat.min_comm (n - k) k]
+
+/-- On the left half of a row (`k ≤ n - k`), `binom n k` agrees with the Pascal
+`Hex.Nat.choose n k`. -/
+private theorem binom_eq_choose_left {n k : Nat} (hk : k ≤ n) (hhalf : k ≤ n - k) :
+    binom n k = Hex.Nat.choose n k := by
+  unfold binom
+  rw [if_neg (Nat.not_lt.mpr hk), Nat.min_eq_left hhalf]
+  exact foldl_choose n k hk
+
+/-- The row of Pascal's triangle increases up to its centre: `choose k j ≤
+choose k (j + 1)` while `2 * (j + 1) ≤ k`. -/
+private theorem choose_le_succ_left {k j : Nat} (h : 2 * (j + 1) ≤ k) :
+    Hex.Nat.choose k j ≤ Hex.Nat.choose k (j + 1) := by
+  refine Nat.le_of_mul_le_mul_left ?_ (Nat.succ_pos j)
+  rw [Hex.Nat.succ_mul_choose_succ k j]
+  exact Nat.mul_le_mul_right (Hex.Nat.choose k j) (by omega)
+
+/-- Everything on the left half of a row is at most the central entry:
+`choose k j ≤ choose k (k / 2)` for `2 * j ≤ k`. -/
+private theorem choose_le_center (k : Nat) :
+    ∀ (fuel j : Nat), k / 2 - j ≤ fuel → 2 * j ≤ k →
+      Hex.Nat.choose k j ≤ Hex.Nat.choose k (k / 2) := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro j hfuel hj
+      have : j = k / 2 := by omega
+      subst this; exact Nat.le_refl _
+  | succ fuel ih =>
+      intro j hfuel hj
+      by_cases hjc : j = k / 2
+      · subst hjc; exact Nat.le_refl _
+      · exact Nat.le_trans (choose_le_succ_left (by omega))
+          (ih (j + 1) (by omega) (by omega))
+
+/-- Even-row step for central-binomial monotonicity: `choose (2t) t ≤ choose (2t+1) t`. -/
+private theorem central_even (t : Nat) :
+    Hex.Nat.choose (2 * t) t ≤ Hex.Nat.choose (2 * t + 1) t := by
+  cases t with
+  | zero => simp
+  | succ s =>
+      rw [Hex.Nat.choose_succ_succ (2 * (s + 1)) s]
+      exact Nat.le_add_left _ _
+
+/-- Odd-row step for central-binomial monotonicity: `choose (2t+1) t ≤ choose (2t+2) (t+1)`. -/
+private theorem central_odd (t : Nat) :
+    Hex.Nat.choose (2 * t + 1) t ≤ Hex.Nat.choose (2 * t + 2) (t + 1) := by
+  rw [show 2 * t + 2 = 2 * t + 1 + 1 from rfl, Hex.Nat.choose_succ_succ (2 * t + 1) t]
+  exact Nat.le_add_right _ _
+
+/-- The central binomial coefficient increases by one row at a time. -/
+private theorem centralChoose_le_succ (m : Nat) :
+    Hex.Nat.choose m (m / 2) ≤ Hex.Nat.choose (m + 1) ((m + 1) / 2) := by
+  rcases (by omega : m = 2 * (m / 2) ∨ m = 2 * (m / 2) + 1) with he | ho
+  · have e2 : m + 1 = 2 * (m / 2) + 1 := by omega
+    have e3 : (m + 1) / 2 = m / 2 := by omega
+    rw [e3]
+    calc Hex.Nat.choose m (m / 2)
+        = Hex.Nat.choose (2 * (m / 2)) (m / 2) := by rw [← he]
+      _ ≤ Hex.Nat.choose (2 * (m / 2) + 1) (m / 2) := central_even (m / 2)
+      _ = Hex.Nat.choose (m + 1) (m / 2) := by rw [← e2]
+  · have o2 : m + 1 = 2 * (m / 2) + 2 := by omega
+    have o3 : (m + 1) / 2 = m / 2 + 1 := by omega
+    rw [o3]
+    calc Hex.Nat.choose m (m / 2)
+        = Hex.Nat.choose (2 * (m / 2) + 1) (m / 2) := by rw [← ho]
+      _ ≤ Hex.Nat.choose (2 * (m / 2) + 2) (m / 2 + 1) := central_odd (m / 2)
+      _ = Hex.Nat.choose (m + 1) (m / 2 + 1) := by rw [← o2]
+
+/-- The central binomial coefficient is monotone in the row index. -/
+private theorem centralChoose_mono {k n : Nat} (h : k ≤ n) :
+    Hex.Nat.choose k (k / 2) ≤ Hex.Nat.choose n (n / 2) := by
+  induction n with
+  | zero =>
+      have : k = 0 := Nat.le_zero.mp h
+      subst this; exact Nat.le_refl _
+  | succ m ih =>
+      rcases Nat.lt_or_ge k (m + 1) with hlt | hge
+      · exact Nat.le_trans (ih (Nat.le_of_lt_succ hlt)) (centralChoose_le_succ m)
+      · have : k = m + 1 := Nat.le_antisymm h hge
+        subst this; exact Nat.le_refl _
+
+/-- The executable binomial coefficient over the factor rectangle `j ≤ k ≤ n`
+is dominated by the central binomial of the top row: `binom k j ≤ binom n (n / 2)`.
+This is the monotonicity that collapses the `defaultFactorCoeffBound` double max. -/
+theorem binom_le_central {n k j : Nat} (hjk : j ≤ k) (hkn : k ≤ n) :
+    binom k j ≤ binom n (n / 2) := by
+  -- reduce `j` to the left-half index `j' = min j (k - j)`
+  have hbjk : binom k j = Hex.Nat.choose k (min j (k - j)) := by
+    rcases Nat.le_total j (k - j) with hle | hle
+    · rw [Nat.min_eq_left hle]; exact binom_eq_choose_left hjk hle
+    · rw [Nat.min_eq_right hle, binom_symm hjk]
+      exact binom_eq_choose_left (Nat.sub_le k j) (by omega)
+  have h2j' : 2 * min j (k - j) ≤ k := by
+    rcases Nat.le_total j (k - j) with hle | hle
+    · rw [Nat.min_eq_left hle]; omega
+    · rw [Nat.min_eq_right hle]; omega
+  have hn : binom n (n / 2) = Hex.Nat.choose n (n / 2) :=
+    binom_eq_choose_left (Nat.div_le_self n 2) (by omega)
+  rw [hbjk, hn]
+  exact Nat.le_trans
+    (choose_le_center k (k / 2) (min j (k - j)) (Nat.sub_le _ _) h2j')
+    (centralChoose_mono hkn)
+
+/-- Runtime implementation of `defaultFactorCoeffBound`: the closed-form central
+binomial times the single loop-invariant norm. -/
+@[expose]
+def defaultFactorCoeffBoundImpl (f : ZPoly) : Nat :=
+  let n := f.degree?.getD 0
+  binom n (n / 2) * coeffL2NormBound f
+
+/-- Register the value-equal closed form `defaultFactorCoeffBoundImpl` as the
+compiled implementation of `defaultFactorCoeffBound`. The `@[csimp]` swap is
+backed by the proof, so the runtime one-norm/one-binomial evaluation is verified
+equal to the `O(deg^2)` specification. -/
+@[csimp]
+theorem defaultFactorCoeffBound_eq_impl :
+    @defaultFactorCoeffBound = @defaultFactorCoeffBoundImpl := by
+  funext f
+  show defaultFactorCoeffBound f = defaultFactorCoeffBoundImpl f
+  apply Nat.le_antisymm
+  · refine defaultFactorCoeffBound_le f ?_
+    intro k hk j hj
+    rw [mignotteCoeffBound_eq]
+    exact Nat.mul_le_mul_right (coeffL2NormBound f) (binom_le_central hj hk)
+  · have hcentral :
+        mignotteCoeffBound f (f.degree?.getD 0) (f.degree?.getD 0 / 2)
+          ≤ defaultFactorCoeffBound f :=
+      mignotteCoeffBound_le_defaultFactorCoeffBound f (Nat.le_refl _)
+        (Nat.div_le_self _ 2)
+    rw [mignotteCoeffBound_eq] at hcentral
+    exact hcentral
 
 end ZPoly
 end Hex

--- a/libraries.yml
+++ b/libraries.yml
@@ -182,7 +182,7 @@ libraries:
         - name: packed-vs-generic-comparison
           description: Shared deterministic GF(2) coefficient fixtures for cross-library comparisons of packed `GF2Poly` versus generic `FpPoly 2` polynomial gcd and Berlekamp-style Frobenius-column construction.
   HexPolyZ:
-    deps: [HexPoly, HexBasic]
+    deps: [HexPoly, HexArith, HexBasic]
     mathlib: false
     done_through: 7
     status: active

--- a/progress/2026-07-08T17-56-45Z.md
+++ b/progress/2026-07-08T17-56-45Z.md
@@ -1,0 +1,42 @@
+# Progress: issue #8677 — closed-form `defaultFactorCoeffBound`
+
+## Accomplished
+
+`ZPoly.defaultFactorCoeffBound` (`HexPolyZ/Mignotte.lean`) recomputed the
+loop-invariant bignum norm `coeffL2NormBound f` inside every one of its
+`O(deg^2)` `mignotteCoeffBound f k j = binom k j * coeffL2NormBound f` terms.
+Since `binom k j` peaks at the central binomial, the whole double max collapses
+to `binom n (n / 2) * coeffL2NormBound f` (`n = degree f`) — one norm, one
+binomial.
+
+Landed as the SPEC design-principle-11 twin: the public spec is now
+`noncomputable` (kernel `decide` still reduces it), and the compiled runtime uses
+`defaultFactorCoeffBoundImpl` (the closed form) via a proved `@[csimp]` swap
+`defaultFactorCoeffBound_eq_impl`. No downstream proof re-keying: every existing
+`defaultFactorCoeffBound_*` lemma reasons about the unchanged spec.
+
+Supporting Mathlib-free monotonicity (`binom_le_central : j ≤ k → k ≤ n →
+binom k j ≤ binom n (n / 2)`) is proved by bridging `binom` to the Mathlib-free
+Pascal `Hex.Nat.choose` (new import `HexArith.Nat.Prime`, acyclic) and porting
+central-binomial unimodality/monotonicity. `binom`'s own definitional symmetry
+avoids needing a choose-symmetry lemma.
+
+Verification: whole graph green (`HexPolyZ`, `HexBerlekampZassenhaus`,
+`HexPolyZMathlib`, `HexBerlekampZassenhausMathlib`, `hexbz_bench`,
+`hexbz_emit_fixtures`). A standalone check confirms the compiled csimp path is
+**value-identical** to the original double loop over a degree grid
+(0,1,2,3,5,8,12,16,20,24,25 × shifts) — so conformance fixtures / certification
+are untouched — and ~319× faster on the deg-24 split family (~16 ms → ~50 us per
+call, matching the issue's "few hundred times cheaper").
+
+## Current frontier
+
+Implementation complete and verified. PR pending.
+
+## Next step
+
+Second opinion (per issue), then open PR, check merge/CI.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR collapses `ZPoly.defaultFactorCoeffBound` from an `O(deg^2)` double loop to a single closed-form central binomial, eliminating the loop-invariant bignum norm that dominated its cost. The specification maxes `binom k j * coeffL2NormBound f` over the whole `j ≤ k ≤ degree f` rectangle, recomputing the full coefficient norm `coeffL2NormBound f` (n bignum squares plus a bignum `ceilSqrt`) inside every one of the `O(deg^2)` terms — about 300 norm evaluations at degree 24 where one suffices, roughly 7 ms per call on high-coefficient inputs and paid two to three times per classical-tier factorization. Because `binom k j` peaks at the central binomial, the entire double max equals `binom n (n / 2) * coeffL2NormBound f` (`n = degree f`): one norm, one binomial.

Land it as the SPEC design-principle-11 twin. The public specification stays as the kernel-facing definition (now `noncomputable`, so `decide`/`#guard` certification still reduces its `@[expose]` body) and the compiled runtime is redirected to the closed-form `defaultFactorCoeffBoundImpl` by a proved `@[csimp]` equality `defaultFactorCoeffBound_eq_impl`. Nothing re-keys: every existing `defaultFactorCoeffBound_*` lemma and its `IntReductionMod` consumers reason about the unchanged spec. The collapse is proved output-identical via `binom_le_central : j ≤ k → k ≤ n → binom k j ≤ binom n (n / 2)`, bridging the executable `binom` to the Mathlib-free Pascal `Hex.Nat.choose` (new acyclic import `HexArith.Nat.Prime`) and porting central-binomial row-monotonicity and unimodality; `binom`'s own definitional symmetry (`min k (n-k)`) avoids needing a choose-symmetry lemma.

Values are unchanged, verified value-identical against the original double loop over a degree grid (0 through 25, even and odd, across several shifts), so conformance fixtures and certification statements are untouched. `lake build` is green across the whole graph, the `hexbz_bench` and `hexbz_emit_fixtures` executables, and `HexManual` (whose `#guard ZPoly.defaultFactorCoeffBound g = 18` still reduces under the `noncomputable` spec). On the degree-24 `linearProductShift` split family the bound runs about 300x faster (~16 ms to ~50 us per call), reaching the irreducible single-norm floor.

Closes #8677.

🤖 Prepared with Claude Code