### PR TITLE
feat(berlekamp): delayed-reduction Barrett base kernel, config, and comparison

### DIFF
--- a/HexArith/Barrett/Accumulator.lean
+++ b/HexArith/Barrett/Accumulator.lean
@@ -242,4 +242,165 @@ theorem accReduce_lt (ctx : BarrettCtx p) (cR lo hi : UInt64)
   rw [UInt64.lt_iff_toNat_lt, toNat_accReduce ctx cR lo hi hcR]
   exact Nat.mod_lt _ (Nat.lt_trans (by decide : 0 < 1) ctx.p_gt)
 
+/-! ### The radix residue as a context-level constant
+
+`accReduce` needs the constant `2^64 % p`; storing it on the context (rather than
+threading a `cR` word plus its `hcR` proof through every caller) keeps the
+delayed-reduction fold below free of that plumbing. -/
+
+/-- `2^32 < 2^64`, the radix headroom that keeps a reduced residue and the
+window inside a single machine word. -/
+private theorem two_pow_32_lt_word : (2 : Nat) ^ 32 < UInt64.word := by
+  rw [UInt64.word]; exact Nat.pow_lt_pow_right (by decide) (by decide)
+
+/-- The radix residue `2^64 % p`, stored as a context-level constant so callers
+of `accReduce`/`foldReduce` need not carry the word and its correctness proof.
+Computed with a `Nat` reduction of the `2^64` radix (done once per context), so
+no `128`-bit machine literal is required. -/
+@[expose]
+def radixResidue (_ctx : BarrettCtx p) : UInt64 :=
+  UInt64.ofNat (UInt64.word % p.toNat)
+
+/-- `radixResidue` stores exactly `2^64 % p`, the `hcR` side condition every
+`accReduce`/`foldReduce` lemma needs. -/
+@[grind =]
+theorem toNat_radixResidue (ctx : BarrettCtx p) :
+    (radixResidue ctx).toNat = UInt64.word % p.toNat := by
+  have hp0 : 0 < p.toNat := Nat.lt_trans (by decide : 0 < 1) ctx.p_gt
+  have hlt : UInt64.word % p.toNat < p.toNat := Nat.mod_lt _ hp0
+  have hpw : p.toNat < UInt64.word := Nat.lt_trans ctx.p_lt two_pow_32_lt_word
+  have hb : UInt64.word % p.toNat < UInt64.size := by
+    simpa [UInt64.size, UInt64.word] using Nat.lt_trans hlt hpw
+  rw [radixResidue, UInt64.toNat_ofNat_of_lt' hb]
+
+/-! ### Periodic-reduction fold
+
+A delayed-reduction dot product accumulates one-word products into the two-word
+accumulator and flushes through `accReduce` every `barrettWindow` additions. The
+window is fixed and independent of the inner dimension, so a run of any length
+stays below `2^128`: each add grows the high word by at most one, and a flush
+resets it, so the high word never reaches the wraparound boundary
+(`accFold_spec`, the per-window no-overflow invariant). This is why periodic
+reduction is correct for *every* inner length, where a single end reduction is
+not. -/
+
+/-- Number of one-word products accumulated between reductions. Any value below
+`2^64` keeps the two-word accumulator's high word from overflowing (the add
+grows it by at most one per step); `2^32` sits comfortably above every realistic
+inner dimension, so a base-kernel dot product reduces exactly once. -/
+@[irreducible]
+def barrettWindow : Nat := 2 ^ 32
+
+theorem barrettWindow_pos : 0 < barrettWindow := by
+  unfold barrettWindow; exact Nat.two_pow_pos 32
+
+theorem barrettWindow_lt_word : barrettWindow < UInt64.word := by
+  unfold barrettWindow; exact two_pow_32_lt_word
+
+/-- One delayed-reduction step: add the product word `q` into the accumulator
+`(lo, hi)`, and when the window count reaches `barrettWindow` flush the two-word
+value through `accReduce` back to a single reduced word, resetting the count.
+
+Deliberately *not* `@[expose]`: leaving the body opaque to the kernel keeps
+reductions of `foldl accStep …` from unfolding the `accReduce`/`barrettReduce`
+machinery (which mentions the `2^64` radix) during defeq checks; all reasoning
+goes through `accFold_spec`, never kernel reduction of `accStep`. -/
+def accStep (ctx : BarrettCtx p) : UInt64 × UInt64 × Nat → UInt64 → UInt64 × UInt64 × Nat
+  | (lo, hi, count), q =>
+    let r := accAddWord lo hi q
+    if count + 1 = barrettWindow then
+      (accReduce ctx (radixResidue ctx) r.1 r.2, 0, 0)
+    else
+      (r.1, r.2, count + 1)
+
+/-- Sum of the `Nat` values of a list of accumulator product words. -/
+@[expose]
+def wordsSum (ws : List UInt64) : Nat :=
+  ws.foldr (fun w a => w.toNat + a) 0
+
+@[simp] theorem wordsSum_nil : wordsSum [] = 0 := rfl
+
+@[simp] theorem wordsSum_cons (q : UInt64) (ws : List UInt64) :
+    wordsSum (q :: ws) = q.toNat + wordsSum ws := rfl
+
+/-- **Per-window no-overflow invariant** for the delayed-reduction fold. From any
+in-window start state (`hi ≤ count < barrettWindow`), folding `accStep` over a
+list of product words keeps the state in-window (`hi ≤ count < barrettWindow`,
+so the next add cannot overflow the high word) and preserves the residue: the
+accumulator's value modulo `p` equals the starting value plus the sum of the
+added words modulo `p`. -/
+theorem accFold_spec (ctx : BarrettCtx p) (ws : List UInt64) :
+    ∀ (lo hi : UInt64) (count : Nat), hi.toNat ≤ count → count < barrettWindow →
+      (ws.foldl (accStep ctx) (lo, hi, count)).2.1.toNat ≤
+          (ws.foldl (accStep ctx) (lo, hi, count)).2.2 ∧
+        (ws.foldl (accStep ctx) (lo, hi, count)).2.2 < barrettWindow ∧
+        accVal (ws.foldl (accStep ctx) (lo, hi, count)).1
+            (ws.foldl (accStep ctx) (lo, hi, count)).2.1 % p.toNat =
+          (accVal lo hi + wordsSum ws) % p.toNat := by
+  induction ws with
+  | nil =>
+    intro lo hi count h1 h2
+    refine ⟨h1, h2, ?_⟩
+    rw [List.foldl_nil, wordsSum_nil, Nat.add_zero]
+  | cons q rest ih =>
+    intro lo hi count h1 h2
+    -- The next add cannot overflow the high word.
+    have hnw : hi.toNat + 1 < UInt64.word := by
+      have := barrettWindow_lt_word
+      omega
+    -- The add's exact value and its bounded high-word growth.
+    have hval : accVal (accAddWord lo hi q).1 (accAddWord lo hi q).2 =
+        accVal lo hi + q.toNat := accVal_accAddWord lo hi q hnw
+    have hgrow : (accAddWord lo hi q).2.toNat ≤ hi.toNat + 1 := by
+      dsimp [accAddWord]
+      by_cases hc : (UInt64.addCarry lo q false).2 = true
+      · rw [if_pos hc]
+        have hh : (hi + 1).toNat = hi.toNat + 1 := by
+          rw [UInt64.toNat_add]; simp only [UInt64.toNat_one]
+          exact Nat.mod_eq_of_lt hnw
+        omega
+      · rw [if_neg hc]; omega
+    rw [List.foldl_cons]
+    by_cases hcase : count + 1 = barrettWindow
+    · have hstep : accStep ctx (lo, hi, count) q =
+          (accReduce ctx (radixResidue ctx) (accAddWord lo hi q).1 (accAddWord lo hi q).2,
+            0, 0) := by
+        simp only [accStep]; rw [if_pos hcase]
+      rw [hstep]
+      have hres := ih (accReduce ctx (radixResidue ctx) (accAddWord lo hi q).1
+        (accAddWord lo hi q).2) 0 0 (Nat.le_of_eq UInt64.toNat_zero) barrettWindow_pos
+      refine ⟨hres.1, hres.2.1, ?_⟩
+      rw [hres.2.2]
+      have hR : accVal (accReduce ctx (radixResidue ctx) (accAddWord lo hi q).1
+          (accAddWord lo hi q).2) 0 = (accVal lo hi + q.toNat) % p.toNat := by
+        rw [accVal]
+        simp only [UInt64.toNat_zero, Nat.zero_mul, Nat.add_zero]
+        rw [toNat_accReduce ctx _ _ _ (toNat_radixResidue ctx), hval]
+      rw [hR, wordsSum_cons, Nat.mod_add_mod, Nat.add_assoc]
+    · have hstep : accStep ctx (lo, hi, count) q =
+          ((accAddWord lo hi q).1, (accAddWord lo hi q).2, count + 1) := by
+        simp only [accStep]; rw [if_neg hcase]
+      rw [hstep]
+      have hcount : count + 1 < barrettWindow := by omega
+      have hhi : (accAddWord lo hi q).2.toNat ≤ count + 1 := by omega
+      have hres := ih (accAddWord lo hi q).1 (accAddWord lo hi q).2 (count + 1) hhi hcount
+      refine ⟨hres.1, hres.2.1, ?_⟩
+      rw [hres.2.2, hval, wordsSum_cons, Nat.add_assoc]
+
+/-- Reduce a list of product words modulo `p` with periodic reduction: fold
+`accStep` from an empty accumulator and flush the final partial window. -/
+@[expose]
+def foldReduce (ctx : BarrettCtx p) (ws : List UInt64) : UInt64 :=
+  let s := ws.foldl (accStep ctx) (0, 0, 0)
+  accReduce ctx (radixResidue ctx) s.1 s.2.1
+
+/-- `foldReduce` computes `(Σ words) % p`: the delayed-reduction fold is exact for
+a run of any length, matching the residue of the fully-accumulated sum. -/
+@[grind =]
+theorem toNat_foldReduce (ctx : BarrettCtx p) (ws : List UInt64) :
+    (foldReduce ctx ws).toNat = wordsSum ws % p.toNat := by
+  have hspec := accFold_spec ctx ws 0 0 0 (by decide) barrettWindow_pos
+  rw [foldReduce, toNat_accReduce ctx _ _ _ (toNat_radixResidue ctx), hspec.2.2]
+  simp [accVal]
+
 end BarrettCtx

--- a/HexBerlekamp.lean
+++ b/HexBerlekamp.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexBerlekamp.Basic
+public import HexBerlekamp.DelayedKernel
 public import HexBerlekamp.DistinctDegree
 public import HexBerlekamp.Factor
 public import HexBerlekamp.Irreducibility

--- a/HexBerlekamp/DelayedKernel.lean
+++ b/HexBerlekamp/DelayedKernel.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexMatrix.Strassen
+public import HexModArith.HotLoop
+public import HexArith.Barrett.Accumulator
+
+public section
+
+/-!
+Delayed-reduction Barrett base kernel as a demonstration `StrassenConfig`.
+
+The default `StrassenConfig` base kernel (`strassenDefault`) reduces modulo `p`
+after every multiply-add. This module supplies the SPEC's demonstration
+non-default config for the Barrett-reduced prime field `ZMod64 p`: a base kernel
+whose dot product accumulates one-word residue products in the two-word
+accumulator and reduces modulo `p` only periodically (`delayedDot`, built on the
+`HexArith.Barrett.Accumulator` fold `foldReduce`).
+
+It lives here, above both `HexMatrix` and the Barrett layer, because the kernel
+needs `Matrix`/`StrassenConfig` *and* `Hex.BarrettCtx` in scope, and the placement
+rule forbids `hex-arith`/`hex-mod-arith` from importing `HexMatrix` (that would
+invert the released dependency order). `HexBerlekamp` already imports `HexMatrix`
+and is the library that consumes the prime-field multiply.
+
+`delayedDot_eq_dotProduct` proves the delayed dot product equals the naive
+`Vector.dotProduct` on `ZMod64 p`, from which `strassenBarrett_valid` follows: the
+config is `Valid`, so `mulStrassen (strassenBarrett ctx)` still equals the
+reference `mul`.
+
+**Measured outcome (honesty constraint (b)).** The delayed kernel is verified
+correct but does not beat the default base kernel here: benchmarked against
+default-base `mulStrassen` on the prime field it is roughly `7`–`10×` slower
+across `64…256`, because the two-word accumulator's per-term Lean-level
+bookkeeping (a boxed `(UInt64 × UInt64 × Nat)` accumulator threaded through
+`Fin.foldl`, plus a `UInt64.addCarry` extern call per term) costs more than the
+modular reductions it defers, relative to the tight single-extern `ZMod64.mul` of
+the default. So the shipped demonstration config is the trivial `strassenDemo`
+(naive base kernel, non-default cutoff), which still exercises the pluggable-
+kernel path; `strassenBarrett` stays as verified follow-up work. The committed
+comparison lives in `reports/figures/strassen-base-kernel-comparison.svg`.
+-/
+
+namespace Hex
+
+open Hex.Matrix
+
+variable {p : Nat} [ZMod64.Bounds p] {m : Nat}
+
+/-- The one-word residue product `a * b` has no `UInt64` wraparound: both factors
+are below `p < 2^31`, so the product is below `2^62 < 2^64`. -/
+private theorem toNat_prodWord (a b : ZMod64 p) :
+    (a.toUInt64 * b.toUInt64).toNat = a.toNat * b.toNat := by
+  have hp : p < 2 ^ 31 := ZMod64.Bounds.pLtR (p := p)
+  have ha : a.toNat < 2 ^ 31 := Nat.lt_trans a.toNat_lt hp
+  have hb : b.toNat < 2 ^ 31 := Nat.lt_trans b.toNat_lt hp
+  have hlt : a.toNat * b.toNat < UInt64.word := by
+    have h1 : a.toNat * b.toNat < 2 ^ 31 * 2 ^ 31 := Nat.mul_lt_mul'' ha hb
+    have h2 : (2 : Nat) ^ 31 * 2 ^ 31 ≤ UInt64.word := by
+      rw [UInt64.word, ← Nat.pow_add]
+      exact Nat.pow_le_pow_right (by decide) (by decide)
+    omega
+  simpa [UInt64.toNat_mul, UInt64.size, UInt64.word, ZMod64.toUInt64_eq_val,
+    ZMod64.toNat_eq_val] using Nat.mod_eq_of_lt hlt
+
+/-- Bridge lemma: the `ZMod64` dot-product fold, read through `toNat`, is the
+residue modulo `p` of the running accumulator plus the `Nat` sum of the remaining
+one-word products (`wordsSum` of the mapped list). Proved by list induction with a
+generalized accumulator. -/
+private theorem toNat_dotFoldl (u v : Vector (ZMod64 p) m) :
+    ∀ (l : List (Fin m)) (acc : ZMod64 p),
+      (l.foldl (fun a i => a + u[i] * v[i]) acc).toNat =
+        (acc.toNat +
+          BarrettCtx.wordsSum (l.map (fun i => u[i].toUInt64 * v[i].toUInt64))) % p := by
+  intro l
+  induction l with
+  | nil =>
+    intro acc
+    simp only [List.foldl_nil, List.map_nil, BarrettCtx.wordsSum_nil, Nat.add_zero]
+    exact (Nat.mod_eq_of_lt acc.toNat_lt).symm
+  | cons i rest ih =>
+    intro acc
+    have hstep : (acc + u[i] * v[i]).toNat = (acc.toNat + u[i].toNat * v[i].toNat) % p := by
+      show (ZMod64.add acc (ZMod64.mul u[i] v[i])).toNat = _
+      rw [ZMod64.toNat_add, ZMod64.toNat_mul, Nat.add_mod_mod]
+    simp only [List.foldl_cons, List.map_cons, BarrettCtx.wordsSum_cons]
+    rw [ih (acc + u[i] * v[i]), hstep, toNat_prodWord u[i] v[i], Nat.mod_add_mod,
+      Nat.add_assoc]
+
+/-- The naive `ZMod64` dot product, read through `toNat`, is the residue modulo
+`p` of the `Nat` sum of the one-word products. -/
+private theorem toNat_dotProduct (u v : Vector (ZMod64 p) m) :
+    (Vector.dotProduct u v).toNat =
+      BarrettCtx.wordsSum
+        ((List.finRange m).map (fun i => u[i].toUInt64 * v[i].toUInt64)) % p := by
+  have h := toNat_dotFoldl u v (List.finRange m) 0
+  have hz : (0 : ZMod64 p).toNat = 0 := ZMod64.toNat_zero
+  rw [hz, Nat.zero_add] at h
+  exact h
+
+/-- **Delayed-reduction Barrett dot product.** Accumulates each one-word residue
+product `u[i] * v[i]` into the two-word accumulator and reduces modulo `p` only
+every `barrettWindow` terms (`foldReduce`), then reduces the final partial window.
+The window is fixed and independent of the length `m`, so this is correct for
+every inner dimension. -/
+@[expose]
+def delayedDot (ctx : Hex.BarrettCtx p) (u v : Vector (ZMod64 p) m) : ZMod64 p :=
+  ZMod64.ofNat p
+    (BarrettCtx.foldReduce ctx.toUInt64Ctx
+      ((List.finRange m).map (fun i => u[i].toUInt64 * v[i].toUInt64))).toNat
+
+/-- Allocation-free implementation of `delayedDot`: a `Fin.foldl` loop over the
+indices that never materializes the `List.finRange m` product-word list. Swapped
+in for compiled code by the `@[csimp]` below; `delayedDot` stays the list-based
+reference form for proofs, mirroring `Vector.dotProduct`/`dotProductImpl`. -/
+@[expose]
+def delayedDotImpl (ctx : Hex.BarrettCtx p) (u v : Vector (ZMod64 p) m) : ZMod64 p :=
+  let s := Fin.foldl m
+    (fun st i => BarrettCtx.accStep ctx.toUInt64Ctx st (u[i].toUInt64 * v[i].toUInt64))
+    ((0, 0, 0) : UInt64 × UInt64 × Nat)
+  ZMod64.ofNat p (BarrettCtx.accReduce ctx.toUInt64Ctx
+    (BarrettCtx.radixResidue ctx.toUInt64Ctx) s.1 s.2.1).toNat
+
+@[csimp] theorem delayedDot_eq_impl : @delayedDot = @delayedDotImpl := by
+  funext p inst m ctx u v
+  have hfold :
+      ((List.finRange m).map (fun i => u[i].toUInt64 * v[i].toUInt64)).foldl
+          (BarrettCtx.accStep ctx.toUInt64Ctx) (0, 0, 0)
+        = Fin.foldl m (fun st i => BarrettCtx.accStep ctx.toUInt64Ctx st
+            (u[i].toUInt64 * v[i].toUInt64)) (0, 0, 0) := by
+    rw [List.foldl_map, Fin.foldl_eq_finRange_foldl]
+  -- Apply the fold equality under a fixed wrapper via `congrArg`, so the
+  -- `accReduce`/`barrett` machinery is never reduced (a `rw` would `kabstract`
+  -- into it and time out on the `2^64` radix). Both sides match the wrapper
+  -- applied to the two fold forms definitionally.
+  exact congrArg
+    (fun s : UInt64 × UInt64 × Nat =>
+      ZMod64.ofNat p (BarrettCtx.accReduce ctx.toUInt64Ctx
+        (BarrettCtx.radixResidue ctx.toUInt64Ctx) s.1 s.2.1).toNat)
+    hfold
+
+/-- **Correctness of the delayed dot product.** The periodically-reduced dot
+product equals the naive `Vector.dotProduct` on `ZMod64 p`: reduction modulo `p`
+is a ring homomorphism, so reducing periodically has the same residue as reducing
+at every step. -/
+theorem delayedDot_eq_dotProduct (ctx : Hex.BarrettCtx p) (u v : Vector (ZMod64 p) m) :
+    delayedDot ctx u v = Vector.dotProduct u v := by
+  apply ZMod64.ext_toNat
+  rw [delayedDot, ZMod64.toNat_ofNat, BarrettCtx.toNat_foldReduce, ctx.modulus_eq,
+    Nat.mod_mod, toNat_dotProduct]
+
+/-- **Delayed-reduction base kernel**, dispatching on the runtime inner dimension:
+the delayed dot product is the fast path once the dot-product length is nontrivial
+(`2 ≤ m`), and it falls back to the naive `mulImpl` on the trivial residual shapes.
+Both branches equal the reference `mul`, so the config built from this is `Valid`. -/
+@[expose]
+def barrettBaseMul (ctx : Hex.BarrettCtx p) {n m k : Nat}
+    (M : Matrix (ZMod64 p) n m) (N : Matrix (ZMod64 p) m k) : Matrix (ZMod64 p) n k :=
+  if 2 ≤ m then
+    Matrix.ofFn fun i j => delayedDot ctx (Matrix.row M i) (Matrix.col N j)
+  else
+    Matrix.mulImpl M N
+
+/-- The delayed-reduction base kernel agrees with the reference `mul` on every
+input and shape. -/
+theorem barrettBaseMul_eq_mul (ctx : Hex.BarrettCtx p) {n m k : Nat}
+    (M : Matrix (ZMod64 p) n m) (N : Matrix (ZMod64 p) m k) :
+    barrettBaseMul ctx M N = Matrix.mul M N := by
+  unfold barrettBaseMul
+  split
+  · apply Matrix.ext_getElem
+    intro i j
+    rw [Matrix.getElem_ofFn, delayedDot_eq_dotProduct]
+    exact (Matrix.getElem_mul M N i j).symm
+  · rw [Matrix.mul_eq_mulImpl]
+
+/-- The **demonstration non-default `StrassenConfig`**: the delayed-reduction
+Barrett base kernel over the prime field `ZMod64 p`, taking the `Hex.BarrettCtx`.
+Its cutoff matches the default (`64`); only the base kernel differs. -/
+@[expose]
+def strassenBarrett (ctx : Hex.BarrettCtx p) : Matrix.StrassenConfig (ZMod64 p) where
+  cutoff := 64
+  baseMul {_n _m _k} M N := barrettBaseMul ctx M N
+
+/-- The delayed config is `Valid`: its base kernel equals `mul`, so
+`mulStrassen (strassenBarrett ctx)` still computes the reference product. -/
+theorem strassenBarrett_valid (ctx : Hex.BarrettCtx p) :
+    (strassenBarrett ctx).Valid := by
+  intro n m k X Y
+  exact barrettBaseMul_eq_mul ctx X Y
+
+/-- **The shipped demonstration non-default config.** A trivial alternate config
+that plugs the naive `mulImpl` base kernel into a non-default `StrassenConfig`
+(with a distinct cutoff), exercising the pluggable-base-kernel path with a
+verified-`Valid` config supplied by the caller.
+
+Per honesty constraint (b) of `HexMatrix/SPEC/hex-matrix.md` § "A demonstration
+non-default config": the delayed-reduction kernel `strassenBarrett` above is
+verified correct but does **not** measurably beat the default base kernel on this
+type (the two-word accumulator's per-term Lean-level bookkeeping — a boxed
+`(UInt64 × UInt64 × Nat)` accumulator and a `UInt64.addCarry` extern call per term
+— outweighs the modular reductions it saves against the tight single-extern
+`ZMod64.mul`; see the committed comparison in `reports/figures/`). So the delayed
+kernel is not shipped as the performance demonstration; optimizing its constants
+(or a bit-packed GF(2) four-Russians kernel) is filed as follow-up work. -/
+@[expose]
+def strassenDemo : Matrix.StrassenConfig (ZMod64 p) where
+  cutoff := 48
+  baseMul := Matrix.mulImpl
+
+/-- The shipped demonstration config is `Valid`: its naive base kernel equals
+`mul` by `mul_eq_mulImpl`. -/
+theorem strassenDemo_valid : (strassenDemo (p := p)).Valid := by
+  intro n m k X Y
+  show Matrix.mulImpl X Y = Matrix.mul X Y
+  rw [Matrix.mul_eq_mulImpl]
+
+end Hex

--- a/HexBerlekamp/DelayedKernel.lean
+++ b/HexBerlekamp/DelayedKernel.lean
@@ -181,7 +181,9 @@ theorem barrettBaseMul_eq_mul (ctx : Hex.BarrettCtx p) {n m k : Nat}
 
 /-- The **demonstration non-default `StrassenConfig`**: the delayed-reduction
 Barrett base kernel over the prime field `ZMod64 p`, taking the `Hex.BarrettCtx`.
-Its cutoff matches the default (`64`); only the base kernel differs. -/
+Its cutoff is pinned at `64`, the value the committed comparison was measured at
+(the default cutoff is measured separately and may move); only the base kernel
+differs from the default config. -/
 @[expose]
 def strassenBarrett (ctx : Hex.BarrettCtx p) : Matrix.StrassenConfig (ZMod64 p) where
   cutoff := 64

--- a/HexBerlekamp/DelayedKernel.lean
+++ b/HexBerlekamp/DelayedKernel.lean
@@ -179,8 +179,10 @@ theorem barrettBaseMul_eq_mul (ctx : Hex.BarrettCtx p) {n m k : Nat}
     exact (Matrix.getElem_mul M N i j).symm
   · rw [Matrix.mul_eq_mulImpl]
 
-/-- The **demonstration non-default `StrassenConfig`**: the delayed-reduction
+/-- The **verified delayed-reduction candidate config**: the delayed-reduction
 Barrett base kernel over the prime field `ZMod64 p`, taking the `Hex.BarrettCtx`.
+Not the shipped demonstration (see `strassenDemo` and the measured outcome in the
+module docstring); kept as verified non-default code for the follow-up work.
 Its cutoff is pinned at `64`, the value the committed comparison was measured at
 (the default cutoff is measured separately and may move); only the base kernel
 differs from the default config. -/

--- a/bench/HexStrassen/Compare.lean
+++ b/bench/HexStrassen/Compare.lean
@@ -54,20 +54,23 @@ def cmpRun (delayed : Bool) (n salt : Nat) : Nat :=
   if delayed then cmpChecksum (mulStrassen (strassenBarrett cmpCtx) a b)
   else cmpChecksum (mulStrassen strassenDefault a b)
 
-/-- Best-of-`iters` wall time in nanoseconds. The branch on `r` forces the full
-`Nat` result before the clock is read, so the timed region includes the whole
-computation rather than a lazy thunk. -/
+/-- Best-of-`iters` wall time in nanoseconds. The checksums are accumulated into
+`sink` and printed outside the timed region, so the `cmpRun` results are live and
+the timed region includes the whole computation rather than a lazy thunk. -/
 def cmpBest (delayed : Bool) (n iters : Nat) : IO Nat := do
   let _ := cmpRun delayed n 5
   let mut best : Nat := 0
   let mut first := true
+  let mut sink : Nat := 0
   for k in [0:iters] do
     let salt := 1000 + k * 13
     let t0 ← IO.monoNanosNow
     let r := cmpRun delayed n salt
-    let t1 ← if r == 123456789 then IO.monoNanosNow else IO.monoNanosNow
+    let t1 ← IO.monoNanosNow
+    sink := sink + r
     let dt := t1 - t0
     if first || dt < best then best := dt; first := false
+  IO.eprintln s!"  (checksum sink n={n} delayed={delayed}: {sink % 1000000007})"
   return best
 
 def main : IO Unit := do

--- a/bench/HexStrassen/Compare.lean
+++ b/bench/HexStrassen/Compare.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+import HexBerlekamp
+
+/-!
+Local comparison measurement for the Strassen base kernel: default-base
+`mulStrassen strassenDefault` versus delayed-reduction-base
+`mulStrassen (strassenBarrett ctx)` on the prime field `ZMod64 p`.
+
+This is a **local** measurement tool, not a CI-gated bench (it carries no
+`LeanBench` registration and is not on the bench-verify list). It emits a JSON
+record on stdout consumed by `scripts/plots/strassen-base-kernel-comparison.py`
+to regenerate `reports/figures/strassen-base-kernel-comparison.svg`. It imports
+only the Mathlib-free `HexBerlekamp` closure, so it stays off the Mathlib link
+chain.
+
+A base kernel fires only below the cutoff, so it moves the constant factor and
+the crossover, never the asymptotic slope; this comparison is reported that way
+(a per-dimension speedup ratio, not a scaling slope).
+-/
+
+open Hex Hex.Matrix
+
+/-- A prime modulus near `2^31` so residue products exercise the full `~62`-bit
+width of the two-word accumulator. -/
+abbrev cmpPrime : Nat := 2147483647
+
+instance : ZMod64.Bounds cmpPrime := ⟨by decide, by decide⟩
+
+/-- The Barrett context for the delayed-reduction base kernel. -/
+def cmpCtx : Hex.BarrettCtx cmpPrime := Hex.BarrettCtx.ofModulus (by decide) (by decide)
+
+/-- Deterministic dense `n × n` matrix keyed by a runtime salt (so the timed
+computation cannot be constant-folded out of the loop). -/
+@[noinline]
+def cmpMat (n salt : Nat) : Matrix (ZMod64 cmpPrime) n n :=
+  Matrix.ofFn fun i j =>
+    ZMod64.ofNat cmpPrime ((i.val * 2654435761 + j.val * 40503 + salt * 97 + 1) % cmpPrime)
+
+/-- Sum of all entries (mod `p`) as a hashable observable of the product. -/
+def cmpChecksum {n : Nat} (M : Matrix (ZMod64 cmpPrime) n n) : Nat :=
+  (List.finRange n).foldl
+    (fun acc i => (List.finRange n).foldl (fun a j => (a + M[(i, j)].toNat) % cmpPrime) acc) 0
+
+/-- One product+checksum, dispatched on the base kernel and keyed by salt. -/
+@[noinline]
+def cmpRun (delayed : Bool) (n salt : Nat) : Nat :=
+  let a := cmpMat n salt
+  let b := cmpMat n (salt + 7)
+  if delayed then cmpChecksum (mulStrassen (strassenBarrett cmpCtx) a b)
+  else cmpChecksum (mulStrassen strassenDefault a b)
+
+/-- Best-of-`iters` wall time in nanoseconds. The branch on `r` forces the full
+`Nat` result before the clock is read, so the timed region includes the whole
+computation rather than a lazy thunk. -/
+def cmpBest (delayed : Bool) (n iters : Nat) : IO Nat := do
+  let _ := cmpRun delayed n 5
+  let mut best : Nat := 0
+  let mut first := true
+  for k in [0:iters] do
+    let salt := 1000 + k * 13
+    let t0 ← IO.monoNanosNow
+    let r := cmpRun delayed n salt
+    let t1 ← if r == 123456789 then IO.monoNanosNow else IO.monoNanosNow
+    let dt := t1 - t0
+    if first || dt < best then best := dt; first := false
+  return best
+
+def main : IO Unit := do
+  let dims := #[64, 96, 128, 160, 192, 256]
+  let mut rows : Array String := #[]
+  for n in dims do
+    let iters := if n ≤ 128 then 11 else 7
+    let d ← cmpBest false n iters
+    let b ← cmpBest true n iters
+    IO.eprintln s!"n={n}  default={(d.toFloat / 1e6)}ms  delayed={(b.toFloat / 1e6)}ms  speedup(default/delayed)={d.toFloat / b.toFloat}"
+    rows := rows.push
+      ("    " ++ "{" ++ "\"n\": " ++ toString n ++ ", \"default_ns\": " ++ toString d ++
+        ", \"delayed_ns\": " ++ toString b ++ "}")
+  IO.println "{"
+  IO.println ("  \"prime\": " ++ toString cmpPrime ++ ",")
+  IO.println "  \"cutoff\": 64,"
+  IO.println "  \"metric\": \"best_of_iters_wall_nanos\","
+  IO.println "  \"results\": ["
+  IO.println (String.intercalate ",\n" rows.toList)
+  IO.println "  ]"
+  IO.println "}"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -357,6 +357,12 @@ lean_exe hexberlekamp_bench where
   srcDir := "bench"
   root := `HexBerlekamp.Bench
 
+-- Local (non-CI, non-LeanBench) comparison driver for the Strassen base-kernel
+-- measurement; emits JSON for `scripts/plots/strassen-base-kernel-comparison.py`.
+lean_exe hexstrassen_compare where
+  srcDir := "bench"
+  root := `HexStrassen.Compare
+
 lean_exe hexconway_bench where
   srcDir := "bench"
   root := `HexConway.Bench

--- a/reports/bench-results/strassen-base-kernel-comparison.json
+++ b/reports/bench-results/strassen-base-kernel-comparison.json
@@ -1,0 +1,13 @@
+{
+  "prime": 2147483647,
+  "cutoff": 64,
+  "metric": "best_of_iters_wall_nanos",
+  "results": [
+    {"n": 64, "default_ns": 1611730, "delayed_ns": 14404894},
+    {"n": 96, "default_ns": 4396721, "delayed_ns": 46940608},
+    {"n": 128, "default_ns": 13689643, "delayed_ns": 104293918},
+    {"n": 160, "default_ns": 23481946, "delayed_ns": 197138316},
+    {"n": 192, "default_ns": 36125548, "delayed_ns": 336515807},
+    {"n": 256, "default_ns": 107963350, "delayed_ns": 757175076}
+  ]
+}

--- a/reports/figures/strassen-base-kernel-comparison.svg
+++ b/reports/figures/strassen-base-kernel-comparison.svg
@@ -1,0 +1,2382 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="684pt" height="288pt" viewBox="0 0 684 288" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.9, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 288
+L 684 288
+L 684 0
+L 0 0
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 50.015209 237.4
+L 397.130084 237.4
+L 397.130084 25.44
+L 50.015209 25.44
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <path d="M 83.872058 237.4
+L 83.872058 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_2">
+      <defs>
+       <path id="me4f81bb266" d="M 0 0
+L 0 3.5
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me4f81bb266" x="83.872058" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 75 -->
+      <g transform="translate(77.509558 251.998437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_3">
+      <path d="M 124.960466 237.4
+L 124.960466 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#me4f81bb266" x="124.960466" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 100 -->
+      <g transform="translate(115.416716 251.998437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_5">
+      <path d="M 166.048875 237.4
+L 166.048875 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#me4f81bb266" x="166.048875" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 125 -->
+      <g transform="translate(156.505125 251.998437) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_7">
+      <path d="M 207.137283 237.4
+L 207.137283 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#me4f81bb266" x="207.137283" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 150 -->
+      <g transform="translate(197.593533 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_9">
+      <path d="M 248.225691 237.4
+L 248.225691 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#me4f81bb266" x="248.225691" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 175 -->
+      <g transform="translate(238.681941 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_11">
+      <path d="M 289.3141 237.4
+L 289.3141 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#me4f81bb266" x="289.3141" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 200 -->
+      <g transform="translate(279.77035 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_13">
+      <path d="M 330.402508 237.4
+L 330.402508 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#me4f81bb266" x="330.402508" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 225 -->
+      <g transform="translate(320.858758 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_15">
+      <path d="M 371.490917 237.4
+L 371.490917 25.44
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#me4f81bb266" x="371.490917" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 250 -->
+      <g transform="translate(361.947167 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_9">
+     <!-- matrix dimension n (n x n over ZMod64 p) -->
+     <g transform="translate(117.633584 265.676562) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-78" d="M 3513 3500
+L 2247 1797
+L 3578 0
+L 2900 0
+L 1881 1375
+L 863 0
+L 184 0
+L 1544 1831
+L 300 3500
+L 978 3500
+L 1906 2253
+L 2834 3500
+L 3513 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856
+Q 1566 4138 1362 3434
+Q 1159 2731 1159 2009
+Q 1159 1288 1364 580
+Q 1569 -128 1984 -844
+L 1484 -844
+Q 1016 -109 783 600
+Q 550 1309 550 2009
+Q 550 2706 781 3412
+Q 1013 4119 1484 4856
+L 1984 4856
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-76" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5a" d="M 359 4666
+L 4025 4666
+L 4025 4184
+L 1075 531
+L 4097 531
+L 4097 0
+L 288 0
+L 288 481
+L 3238 4134
+L 359 4134
+L 359 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666
+L 1569 4666
+L 2759 1491
+L 3956 4666
+L 4897 4666
+L 4897 0
+L 4281 0
+L 4281 4097
+L 3078 897
+L 2444 897
+L 1241 4097
+L 1241 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856
+L 1013 4856
+Q 1481 4119 1714 3412
+Q 1947 2706 1947 2009
+Q 1947 1309 1714 600
+Q 1481 -109 1013 -844
+L 513 -844
+Q 928 -128 1133 580
+Q 1338 1288 1338 2009
+Q 1338 2731 1133 3434
+Q 928 4138 513 4856
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(158.691406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(197.900391 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(239.013672 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(266.796875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(325.976562 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(357.763672 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(421.240234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(449.023438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(546.435547 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(607.958984 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(671.337891 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(723.4375 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(751.220703 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(812.402344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(875.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(907.568359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(970.947266 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1002.734375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1041.748047 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1105.126953 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(1136.914062 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1196.09375 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1227.880859 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1291.259766 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1323.046875 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(1384.228516 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1443.408203 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1504.931641 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1546.044922 0)"/>
+      <use xlink:href="#DejaVuSans-5a" transform="translate(1577.832031 0)"/>
+      <use xlink:href="#DejaVuSans-4d" transform="translate(1646.337891 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1732.617188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(1793.798828 0)"/>
+      <use xlink:href="#DejaVuSans-36" transform="translate(1857.275391 0)"/>
+      <use xlink:href="#DejaVuSans-34" transform="translate(1920.898438 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1984.521484 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(2016.308594 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2079.785156 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_17">
+      <path d="M 50.015209 170.597395
+L 397.130084 170.597395
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <defs>
+       <path id="m928ff2d71f" d="M 0 0
+L -3.5 0
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m928ff2d71f" x="50.015209" y="170.597395" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(25.415209 174.396613) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.684375)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.684375)"/>
+       <use xlink:href="#DejaVuSans-31" transform="translate(128.203125 38.965625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_19">
+      <path d="M 50.015209 98.479943
+L 397.130084 98.479943
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="50.015209" y="98.479943" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(25.415209 102.279162) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-32" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_21">
+      <path d="M 50.015209 26.362491
+L 397.130084 26.362491
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="50.015209" y="26.362491" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(25.415209 30.16171) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31" transform="translate(0 0.765625)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0.765625)"/>
+       <use xlink:href="#DejaVuSans-33" transform="translate(128.203125 39.046875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_23">
+      <path d="M 50.015209 221.00533
+L 397.130084 221.00533
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <defs>
+       <path id="m749eede253" d="M 0 0
+L -2 0
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="221.00533" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_25">
+      <path d="M 50.015209 208.306077
+L 397.130084 208.306077
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="208.306077" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_27">
+      <path d="M 50.015209 199.295814
+L 397.130084 199.295814
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="199.295814" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_29">
+      <path d="M 50.015209 192.306911
+L 397.130084 192.306911
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="192.306911" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_31">
+      <path d="M 50.015209 186.596561
+L 397.130084 186.596561
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="186.596561" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_33">
+      <path d="M 50.015209 181.768529
+L 397.130084 181.768529
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="181.768529" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_35">
+      <path d="M 50.015209 177.586298
+L 397.130084 177.586298
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="177.586298" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_37">
+      <path d="M 50.015209 173.897308
+L 397.130084 173.897308
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="173.897308" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_39">
+      <path d="M 50.015209 148.887878
+L 397.130084 148.887878
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="148.887878" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_41">
+      <path d="M 50.015209 136.188626
+L 397.130084 136.188626
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="136.188626" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_43">
+      <path d="M 50.015209 127.178362
+L 397.130084 127.178362
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="127.178362" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_45">
+      <path d="M 50.015209 120.189459
+L 397.130084 120.189459
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="120.189459" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_47">
+      <path d="M 50.015209 114.479109
+L 397.130084 114.479109
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="114.479109" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_49">
+      <path d="M 50.015209 109.651077
+L 397.130084 109.651077
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="109.651077" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_51">
+      <path d="M 50.015209 105.468846
+L 397.130084 105.468846
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="105.468846" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_53">
+      <path d="M 50.015209 101.779856
+L 397.130084 101.779856
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="101.779856" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_55">
+      <path d="M 50.015209 76.770427
+L 397.130084 76.770427
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="76.770427" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_57">
+      <path d="M 50.015209 64.071174
+L 397.130084 64.071174
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="64.071174" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_59">
+      <path d="M 50.015209 55.060911
+L 397.130084 55.060911
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="55.060911" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_61">
+      <path d="M 50.015209 48.072007
+L 397.130084 48.072007
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="48.072007" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_63">
+      <path d="M 50.015209 42.361658
+L 397.130084 42.361658
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="42.361658" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_65">
+      <path d="M 50.015209 37.533626
+L 397.130084 37.533626
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="37.533626" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_67">
+      <path d="M 50.015209 33.351394
+L 397.130084 33.351394
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="33.351394" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_69">
+      <path d="M 50.015209 29.662405
+L 397.130084 29.662405
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m749eede253" x="50.015209" y="29.662405" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- best wall time (ms, log) -->
+     <g transform="translate(19.335522 190.4075) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2c" d="M 750 794
+L 1409 794
+L 1409 256
+L 897 -744
+L 494 -744
+L 750 256
+L 750 794
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-62"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(177.099609 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(216.308594 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(248.095703 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(329.882812 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(391.162109 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(418.945312 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(446.728516 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(478.515625 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(517.724609 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(545.507812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(642.919922 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(704.443359 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(736.230469 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(775.244141 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(872.65625 0)"/>
+      <use xlink:href="#DejaVuSans-2c" transform="translate(924.755859 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(956.542969 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(988.330078 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1016.113281 0)"/>
+      <use xlink:href="#DejaVuSans-67" transform="translate(1077.294922 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1140.771484 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_71">
+    <path d="M 65.793158 227.765455
+L 118.386321 196.334028
+L 170.979484 160.761142
+L 223.572646 143.860997
+L 276.165809 130.369238
+L 381.352135 96.080137
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="me66f70763a" d="M 0 3
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132
+C 2.683901 1.55874 3 0.795609 3 0
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132
+C 1.55874 -2.683901 0.795609 -3 0 -3
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132
+C -2.683901 -1.55874 -3 -0.795609 -3 0
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132
+C -1.55874 2.683901 -0.795609 3 0 3
+z
+" style="stroke: #1f77b4"/>
+    </defs>
+    <g clip-path="url(#p3faf36ce4b)">
+     <use xlink:href="#me66f70763a" x="65.793158" y="227.765455" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me66f70763a" x="118.386321" y="196.334028" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me66f70763a" x="170.979484" y="160.761142" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me66f70763a" x="223.572646" y="143.860997" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me66f70763a" x="276.165809" y="130.369238" style="fill: #1f77b4; stroke: #1f77b4"/>
+     <use xlink:href="#me66f70763a" x="381.352135" y="96.080137" style="fill: #1f77b4; stroke: #1f77b4"/>
+    </g>
+   </g>
+   <g id="line2d_72">
+    <path d="M 65.793158 159.166052
+L 118.386321 122.167013
+L 170.979484 97.163152
+L 223.572646 77.221806
+L 276.165809 60.473651
+L 381.352135 35.074545
+" clip-path="url(#p3faf36ce4b)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m8b6a0631d3" d="M -3 3
+L 3 3
+L 3 -3
+L -3 -3
+z
+" style="stroke: #d62728; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p3faf36ce4b)">
+     <use xlink:href="#m8b6a0631d3" x="65.793158" y="159.166052" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="118.386321" y="122.167013" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="170.979484" y="97.163152" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="223.572646" y="77.221806" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="276.165809" y="60.473651" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="381.352135" y="35.074545" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 50.015209 237.4
+L 50.015209 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 397.130084 237.4
+L 397.130084 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 50.015209 237.4
+L 397.130084 237.4
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 50.015209 25.44
+L 397.130084 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <!-- mulStrassen base-kernel comparison -->
+    <g transform="translate(121.684287 19.44) scale(0.11 -0.11)">
+     <defs>
+      <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513
+L 3425 3897
+Q 3066 4069 2747 4153
+Q 2428 4238 2131 4238
+Q 1616 4238 1336 4038
+Q 1056 3838 1056 3469
+Q 1056 3159 1242 3001
+Q 1428 2844 1947 2747
+L 2328 2669
+Q 3034 2534 3370 2195
+Q 3706 1856 3706 1288
+Q 3706 609 3251 259
+Q 2797 -91 1919 -91
+Q 1588 -91 1214 -16
+Q 841 59 441 206
+L 441 856
+Q 825 641 1194 531
+Q 1563 422 1919 422
+Q 2459 422 2753 634
+Q 3047 847 3047 1241
+Q 3047 1584 2836 1778
+Q 2625 1972 2144 2069
+L 1759 2144
+Q 1053 2284 737 2584
+Q 422 2884 422 3419
+Q 422 4038 858 4394
+Q 1294 4750 2059 4750
+Q 2388 4750 2728 4690
+Q 3069 4631 3425 4513
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2d" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6b" d="M 581 4863
+L 1159 4863
+L 1159 1991
+L 2875 3500
+L 3609 3500
+L 1753 1863
+L 3688 0
+L 2938 0
+L 1159 1709
+L 1159 0
+L 581 0
+L 581 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6d"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(97.412109 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(160.791016 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(188.574219 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(252.050781 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(291.259766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(332.373047 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(393.652344 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(445.751953 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(497.851562 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(559.375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(622.753906 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(654.541016 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(718.017578 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(779.296875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(831.396484 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(892.919922 0)"/>
+     <use xlink:href="#DejaVuSans-6b" transform="translate(929.003906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(983.289062 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1044.8125 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1084.175781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1147.554688 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1209.078125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1236.861328 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1268.648438 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1323.628906 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1384.810547 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1482.222656 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1545.699219 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1606.978516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1648.091797 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1675.875 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1727.974609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1789.15625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_7">
+     <path d="M 55.615209 55.325
+L 245.931459 55.325
+Q 247.531459 55.325 247.531459 53.725
+L 247.531459 31.04
+Q 247.531459 29.44 245.931459 29.44
+L 55.615209 29.44
+Q 54.015209 29.44 54.015209 31.04
+L 54.015209 53.725
+Q 54.015209 55.325 55.615209 55.325
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="line2d_73">
+     <path d="M 57.215209 35.91875
+L 65.215209 35.91875
+L 73.215209 35.91875
+" style="fill: none; stroke: #1f77b4; stroke-width: 1.5; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#me66f70763a" x="65.215209" y="35.91875" style="fill: #1f77b4; stroke: #1f77b4"/>
+     </g>
+    </g>
+    <g id="text_15">
+     <!-- default base (naive mulImpl) -->
+     <g transform="translate(79.615209 38.71875) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(160.205078 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(221.484375 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(284.863281 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(312.646484 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(351.855469 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(383.642578 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(447.119141 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(508.398438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(560.498047 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(622.021484 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(653.808594 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(692.822266 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(756.201172 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(817.480469 0)"/>
+      <use xlink:href="#DejaVuSans-76" transform="translate(845.263672 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(904.443359 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(965.966797 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(997.753906 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(1095.166016 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1158.544922 0)"/>
+      <use xlink:href="#DejaVuSans-49" transform="translate(1186.328125 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(1215.820312 0)"/>
+      <use xlink:href="#DejaVuSans-70" transform="translate(1313.232422 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1376.708984 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1404.492188 0)"/>
+     </g>
+    </g>
+    <g id="line2d_74">
+     <path d="M 57.215209 47.66125
+L 65.215209 47.66125
+L 73.215209 47.66125
+" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+     <g>
+      <use xlink:href="#m8b6a0631d3" x="65.215209" y="47.66125" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- delayed-reduction base (strassenBarrett) -->
+     <g transform="translate(79.615209 50.46125) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-42" d="M 1259 2228
+L 1259 519
+L 2272 519
+Q 2781 519 3026 730
+Q 3272 941 3272 1375
+Q 3272 1813 3026 2020
+Q 2781 2228 2272 2228
+L 1259 2228
+z
+M 1259 4147
+L 1259 2741
+L 2194 2741
+Q 2656 2741 2882 2914
+Q 3109 3088 3109 3444
+Q 3109 3797 2882 3972
+Q 2656 4147 2194 4147
+L 1259 4147
+z
+M 628 4666
+L 2241 4666
+Q 2963 4666 3353 4366
+Q 3744 4066 3744 3513
+Q 3744 3084 3544 2831
+Q 3344 2578 2956 2516
+Q 3422 2416 3680 2098
+Q 3938 1781 3938 1306
+Q 3938 681 3513 340
+Q 3088 0 2303 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(152.783203 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(214.0625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(273.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(334.765625 0)"/>
+      <use xlink:href="#DejaVuSans-2d" transform="translate(398.242188 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(434.326172 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(473.189453 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(534.712891 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(598.189453 0)"/>
+      <use xlink:href="#DejaVuSans-63" transform="translate(661.568359 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(716.548828 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(755.757812 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(783.541016 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(844.722656 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(908.101562 0)"/>
+      <use xlink:href="#DejaVuSans-62" transform="translate(939.888672 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1003.365234 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1064.644531 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1116.744141 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1178.267578 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(1210.054688 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1249.068359 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1301.167969 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1340.376953 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1381.490234 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1442.769531 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1494.869141 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1546.96875 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(1608.492188 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(1671.871094 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(1740.474609 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1801.753906 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1841.117188 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1879.980469 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1941.503906 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(1980.712891 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(2019.921875 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_8">
+    <path d="M 441.790084 237.4
+L 673.2 237.4
+L 673.2 25.44
+L 441.790084 25.44
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_9">
+     <g id="line2d_75">
+      <path d="M 491.753588 237.4
+L 491.753588 25.44
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_76">
+      <g>
+       <use xlink:href="#me4f81bb266" x="491.753588" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 100 -->
+      <g transform="translate(482.209838 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_77">
+      <path d="M 546.538133 237.4
+L 546.538133 25.44
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#me4f81bb266" x="546.538133" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 150 -->
+      <g transform="translate(536.994383 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_79">
+      <path d="M 601.322678 237.4
+L 601.322678 25.44
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_80">
+      <g>
+       <use xlink:href="#me4f81bb266" x="601.322678" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 200 -->
+      <g transform="translate(591.778928 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_81">
+      <path d="M 656.107222 237.4
+L 656.107222 25.44
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_82">
+      <g>
+       <use xlink:href="#me4f81bb266" x="656.107222" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 250 -->
+      <g transform="translate(646.563472 251.998437) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(127.246094 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_21">
+     <!-- matrix dimension n -->
+     <g transform="translate(508.948948 265.676562) scale(0.1 -0.1)">
+      <use xlink:href="#DejaVuSans-6d"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(97.412109 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(158.691406 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(197.900391 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(239.013672 0)"/>
+      <use xlink:href="#DejaVuSans-78" transform="translate(266.796875 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(325.976562 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(357.763672 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(421.240234 0)"/>
+      <use xlink:href="#DejaVuSans-6d" transform="translate(449.023438 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(546.435547 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(607.958984 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(671.337891 0)"/>
+      <use xlink:href="#DejaVuSans-69" transform="translate(723.4375 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(751.220703 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(812.402344 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(875.78125 0)"/>
+      <use xlink:href="#DejaVuSans-6e" transform="translate(907.568359 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_28">
+     <g id="line2d_83">
+      <path d="M 441.790084 237.4
+L 673.2 237.4
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_84">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="237.4" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 0 -->
+      <g transform="translate(428.427584 241.199219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_85">
+      <path d="M 441.790084 199.414643
+L 673.2 199.414643
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_86">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="199.414643" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 2 -->
+      <g transform="translate(428.427584 203.213862) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_87">
+      <path d="M 441.790084 161.429287
+L 673.2 161.429287
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_88">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="161.429287" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 4 -->
+      <g transform="translate(428.427584 165.228506) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_89">
+      <path d="M 441.790084 123.44393
+L 673.2 123.44393
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_90">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="123.44393" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 6 -->
+      <g transform="translate(428.427584 127.243149) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-36"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_91">
+      <path d="M 441.790084 85.458574
+L 673.2 85.458574
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_92">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="85.458574" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 8 -->
+      <g transform="translate(428.427584 89.257793) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_93">
+      <path d="M 441.790084 47.473217
+L 673.2 47.473217
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.5; stroke-width: 0.3; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m928ff2d71f" x="441.790084" y="47.473217" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 10 -->
+      <g transform="translate(422.065084 51.272436) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" transform="translate(63.623047 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_28">
+     <!-- delayed / default  (&gt;1 = slower) -->
+     <g transform="translate(415.985396 211.8825) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-2f" d="M 1625 4666
+L 2156 4666
+L 531 -594
+L 0 -594
+L 1625 4666
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3e" d="M 678 3150
+L 678 3719
+L 4684 2266
+L 4684 1747
+L 678 294
+L 678 863
+L 3897 2003
+L 678 3150
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3d" d="M 678 2906
+L 4684 2906
+L 4684 2381
+L 678 2381
+L 678 2906
+z
+M 678 1631
+L 4684 1631
+L 4684 1100
+L 678 1100
+L 678 1631
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-64"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(125 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(152.783203 0)"/>
+      <use xlink:href="#DejaVuSans-79" transform="translate(214.0625 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(273.242188 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(334.765625 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(398.242188 0)"/>
+      <use xlink:href="#DejaVuSans-2f" transform="translate(430.029297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(463.720703 0)"/>
+      <use xlink:href="#DejaVuSans-64" transform="translate(495.507812 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(558.984375 0)"/>
+      <use xlink:href="#DejaVuSans-66" transform="translate(620.507812 0)"/>
+      <use xlink:href="#DejaVuSans-61" transform="translate(655.712891 0)"/>
+      <use xlink:href="#DejaVuSans-75" transform="translate(716.992188 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(780.371094 0)"/>
+      <use xlink:href="#DejaVuSans-74" transform="translate(808.154297 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(847.363281 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(879.150391 0)"/>
+      <use xlink:href="#DejaVuSans-28" transform="translate(910.9375 0)"/>
+      <use xlink:href="#DejaVuSans-3e" transform="translate(949.951172 0)"/>
+      <use xlink:href="#DejaVuSans-31" transform="translate(1033.740234 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1097.363281 0)"/>
+      <use xlink:href="#DejaVuSans-3d" transform="translate(1129.150391 0)"/>
+      <use xlink:href="#DejaVuSans-20" transform="translate(1212.939453 0)"/>
+      <use xlink:href="#DejaVuSans-73" transform="translate(1244.726562 0)"/>
+      <use xlink:href="#DejaVuSans-6c" transform="translate(1296.826172 0)"/>
+      <use xlink:href="#DejaVuSans-6f" transform="translate(1324.609375 0)"/>
+      <use xlink:href="#DejaVuSans-77" transform="translate(1385.791016 0)"/>
+      <use xlink:href="#DejaVuSans-65" transform="translate(1467.578125 0)"/>
+      <use xlink:href="#DejaVuSans-72" transform="translate(1529.101562 0)"/>
+      <use xlink:href="#DejaVuSans-29" transform="translate(1570.214844 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_95">
+    <path d="M 452.308716 67.652265
+L 487.370825 34.62892
+L 522.432933 92.705151
+L 557.495042 77.950497
+L 592.55715 60.479875
+L 662.681367 104.199404
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke: #d62728; stroke-width: 1.5; stroke-linecap: square"/>
+    <g clip-path="url(#p2cf162a72d)">
+     <use xlink:href="#m8b6a0631d3" x="452.308716" y="67.652265" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="487.370825" y="34.62892" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="522.432933" y="92.705151" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="557.495042" y="77.950497" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="592.55715" y="60.479875" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+     <use xlink:href="#m8b6a0631d3" x="662.681367" y="104.199404" style="fill: #d62728; stroke: #d62728; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="line2d_96">
+    <path d="M 441.790084 218.407322
+L 673.2 218.407322
+" clip-path="url(#p2cf162a72d)" style="fill: none; stroke-dasharray: 2.96,1.28; stroke-dashoffset: 0; stroke: #555555; stroke-width: 0.8"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 441.790084 237.4
+L 441.790084 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 673.2 237.4
+L 673.2 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 441.790084 237.4
+L 673.2 237.4
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 441.790084 25.44
+L 673.2 25.44
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_29">
+    <!-- slowdown factor -->
+    <g transform="translate(512.536839 19.44) scale(0.11 -0.11)">
+     <use xlink:href="#DejaVuSans-73"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(52.099609 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(79.882812 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(141.064453 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(222.851562 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(286.328125 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(347.509766 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(429.296875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(492.675781 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(524.462891 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(559.667969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(620.947266 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(675.927734 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(715.136719 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(776.318359 0)"/>
+    </g>
+   </g>
+  </g>
+  <g id="text_30">
+   <!-- prime p = 2147483647, cutoff = 64; delayed kernel is 7.0-10.7x SLOWER (honest negative). A base kernel moves constants/crossover, never the asymptotic slope. -->
+   <g style="fill: #555555" transform="translate(54.945859 286.56) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-3b" d="M 750 3309
+L 1409 3309
+L 1409 2516
+L 750 2516
+L 750 3309
+z
+M 750 794
+L 1409 794
+L 1409 256
+L 897 -744
+L 494 -744
+L 750 256
+L 750 794
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2e" d="M 684 794
+L 1344 794
+L 1344 0
+L 684 0
+L 684 794
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4c" d="M 628 4666
+L 1259 4666
+L 1259 531
+L 3531 531
+L 3531 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-4f" d="M 2522 4238
+Q 1834 4238 1429 3725
+Q 1025 3213 1025 2328
+Q 1025 1447 1429 934
+Q 1834 422 2522 422
+Q 3209 422 3611 934
+Q 4013 1447 4013 2328
+Q 4013 3213 3611 3725
+Q 3209 4238 2522 4238
+z
+M 2522 4750
+Q 3503 4750 4090 4092
+Q 4678 3434 4678 2328
+Q 4678 1225 4090 567
+Q 3503 -91 2522 -91
+Q 1538 -91 948 565
+Q 359 1222 359 2328
+Q 359 3434 948 4092
+Q 1538 4750 2522 4750
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-57" d="M 213 4666
+L 850 4666
+L 1831 722
+L 2809 4666
+L 3519 4666
+L 4500 722
+L 5478 4666
+L 6119 4666
+L 4947 0
+L 4153 0
+L 3169 4050
+L 2175 0
+L 1381 0
+L 213 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-45" d="M 628 4666
+L 3578 4666
+L 3578 4134
+L 1259 4134
+L 1259 2753
+L 3481 2753
+L 3481 2222
+L 1259 2222
+L 1259 531
+L 3634 531
+L 3634 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-52" d="M 2841 2188
+Q 3044 2119 3236 1894
+Q 3428 1669 3622 1275
+L 4263 0
+L 3584 0
+L 2988 1197
+Q 2756 1666 2539 1819
+Q 2322 1972 1947 1972
+L 1259 1972
+L 1259 0
+L 628 0
+L 628 4666
+L 2053 4666
+Q 2853 4666 3247 4331
+Q 3641 3997 3641 3322
+Q 3641 2881 3436 2590
+Q 3231 2300 2841 2188
+z
+M 1259 4147
+L 1259 2491
+L 2053 2491
+Q 2509 2491 2742 2702
+Q 2975 2913 2975 3322
+Q 2975 3731 2742 3939
+Q 2509 4147 2053 4147
+L 1259 4147
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-41" d="M 2188 4044
+L 1331 1722
+L 3047 1722
+L 2188 4044
+z
+M 1831 4666
+L 2547 4666
+L 4325 0
+L 3669 0
+L 3244 1197
+L 1141 1197
+L 716 0
+L 50 0
+L 1831 4666
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-70"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(63.476562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(104.589844 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(132.373047 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(229.785156 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(291.308594 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(323.095703 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(386.572266 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(418.359375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(502.148438 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(533.935547 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(597.558594 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(661.181641 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(724.804688 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(788.427734 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(852.050781 0)"/>
+    <use xlink:href="#DejaVuSans-33" transform="translate(915.673828 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(979.296875 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1042.919922 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1106.542969 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1170.166016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1201.953125 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(1233.740234 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(1288.720703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1352.099609 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1391.308594 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(1452.490234 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(1487.695312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1522.900391 0)"/>
+    <use xlink:href="#DejaVuSans-3d" transform="translate(1554.6875 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1638.476562 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(1670.263672 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(1733.886719 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(1797.509766 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1831.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(1862.988281 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1926.464844 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1987.988281 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2015.771484 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(2077.050781 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2136.230469 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2197.753906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2261.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(2293.017578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2347.302734 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(2408.826172 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2448.189453 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2511.568359 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(2573.091797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2600.875 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2632.662109 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2660.445312 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2712.544922 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(2744.332031 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(2807.955078 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(2839.742188 0)"/>
+    <use xlink:href="#DejaVuSans-2d" transform="translate(2903.365234 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(2939.449219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(3003.072266 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(3066.695312 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(3098.482422 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(3162.105469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3221.285156 0)"/>
+    <use xlink:href="#DejaVuSans-53" transform="translate(3253.072266 0)"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(3316.548828 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(3368.636719 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(3447.347656 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(3546.224609 0)"/>
+    <use xlink:href="#DejaVuSans-52" transform="translate(3609.408203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3678.890625 0)"/>
+    <use xlink:href="#DejaVuSans-28" transform="translate(3710.677734 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(3749.691406 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3813.070312 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3874.251953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3937.630859 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3999.154297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4051.253906 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4090.462891 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4122.25 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4185.628906 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(4247.152344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4310.628906 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4371.908203 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4411.117188 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(4438.900391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4498.080078 0)"/>
+    <use xlink:href="#DejaVuSans-29" transform="translate(4559.603516 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(4598.617188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4630.404297 0)"/>
+    <use xlink:href="#DejaVuSans-41" transform="translate(4662.191406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4730.599609 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(4762.386719 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4825.863281 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4887.142578 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4939.242188 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5000.765625 0)"/>
+    <use xlink:href="#DejaVuSans-6b" transform="translate(5032.552734 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5086.837891 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(5148.361328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5187.724609 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5251.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(5312.626953 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5340.410156 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(5372.197266 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5469.609375 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(5530.791016 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(5589.970703 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5651.494141 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5703.59375 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(5735.380859 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(5790.361328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5851.542969 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(5914.921875 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5967.021484 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(6006.230469 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6067.509766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(6130.888672 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6170.097656 0)"/>
+    <use xlink:href="#DejaVuSans-2f" transform="translate(6222.197266 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(6255.888672 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6310.869141 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6349.732422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6410.914062 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(6463.013672 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(6515.113281 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6576.294922 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6635.474609 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(6696.998047 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(6738.111328 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(6769.898438 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(6801.685547 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6865.064453 0)"/>
+    <use xlink:href="#DejaVuSans-76" transform="translate(6926.587891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(6985.767578 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(7047.291016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7088.404297 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7120.191406 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(7159.400391 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(7222.779297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7284.302734 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(7316.089844 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7377.369141 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(7429.46875 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(7488.648438 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(7586.060547 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7649.537109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7688.746094 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(7749.927734 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(7789.136719 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(7816.919922 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(7871.900391 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(7903.6875 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(7955.787109 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(7983.570312 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(8044.751953 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(8108.228516 0)"/>
+    <use xlink:href="#DejaVuSans-2e" transform="translate(8169.751953 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p3faf36ce4b">
+   <rect x="50.015209" y="25.44" width="347.114874" height="211.96"/>
+  </clipPath>
+  <clipPath id="p2cf162a72d">
+   <rect x="441.790084" y="25.44" width="231.409916" height="211.96"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/scripts/plots/strassen-base-kernel-comparison.py
+++ b/scripts/plots/strassen-base-kernel-comparison.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Comparison plot: default-base vs delayed-reduction-base ``mulStrassen``.
+
+Reads the committed local measurement
+``reports/bench-results/strassen-base-kernel-comparison.json`` (emitted by the
+``hexstrassen_compare`` driver, ``bench/HexStrassen/Compare.lean``) and writes
+``reports/figures/strassen-base-kernel-comparison.svg``.
+
+The two series are the same recursive ``mulStrassen`` differing only in the
+pluggable base kernel on the prime field ``ZMod64 p``: ``strassenDefault`` (naive
+``mulImpl``, one Barrett reduction per multiply-add) versus ``strassenBarrett``
+(the delayed-reduction two-word accumulator, reducing once per window). A base
+kernel fires only below the cutoff, so it moves the constant factor and the
+crossover, **never the asymptotic slope** -- hence this is a per-dimension
+constant-factor comparison (log-y runtime and the speedup ratio), not a scaling
+slope. The committed measurement is the honest negative: the delayed kernel is
+verified correct but is ~7-10x slower here, so it does not ship as the
+performance demonstration (SPEC honesty constraint (b)).
+
+Run: ``python3 scripts/plots/strassen-base-kernel-comparison.py``
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+matplotlib.rcParams["svg.hashsalt"] = "strassen-base-kernel-comparison"
+import matplotlib.pyplot as plt
+
+ROOT = Path(__file__).resolve().parents[2]
+DATA = ROOT / "reports" / "bench-results" / "strassen-base-kernel-comparison.json"
+FIGURES = ROOT / "reports" / "figures"
+OUTPUT = FIGURES / "strassen-base-kernel-comparison.svg"
+
+
+def main() -> None:
+    record = json.loads(DATA.read_text(encoding="utf-8"))
+    results = sorted(record["results"], key=lambda r: r["n"])
+    dims = [r["n"] for r in results]
+    default_ms = [r["default_ns"] / 1e6 for r in results]
+    delayed_ms = [r["delayed_ns"] / 1e6 for r in results]
+    ratios = [r["delayed_ns"] / r["default_ns"] for r in results]
+
+    fig, (ax, axr) = plt.subplots(
+        1, 2, figsize=(9.5, 4.0), gridspec_kw={"width_ratios": [3, 2]}
+    )
+
+    ax.plot(dims, default_ms, color="#1f77b4", marker="o",
+            label="default base (naive mulImpl)")
+    ax.plot(dims, delayed_ms, color="#d62728", marker="s",
+            label="delayed-reduction base (strassenBarrett)")
+    ax.set_yscale("log")
+    ax.set_xlabel("matrix dimension n (n x n over ZMod64 p)")
+    ax.set_ylabel("best wall time (ms, log)")
+    ax.set_title("mulStrassen base-kernel comparison", fontsize=11)
+    ax.grid(True, which="both", linewidth=0.3, alpha=0.5)
+    ax.legend(fontsize=8, loc="upper left")
+
+    axr.plot(dims, ratios, color="#d62728", marker="s")
+    axr.axhline(1.0, color="#555555", linewidth=0.8, linestyle="--")
+    axr.set_xlabel("matrix dimension n")
+    axr.set_ylabel("delayed / default  (>1 = slower)")
+    axr.set_title("slowdown factor", fontsize=11)
+    axr.grid(True, which="both", linewidth=0.3, alpha=0.5)
+    axr.set_ylim(bottom=0)
+
+    worst = max(ratios)
+    best = min(ratios)
+    subtitle = (
+        f"prime p = {record['prime']}, cutoff = {record.get('cutoff', '?')}; "
+        f"delayed kernel is {best:.1f}-{worst:.1f}x SLOWER (honest negative). "
+        "A base kernel moves constants/crossover, never the asymptotic slope."
+    )
+    fig.text(0.5, 0.005, subtitle, ha="center", fontsize=7, color="#555555")
+
+    fig.tight_layout(rect=(0, 0.03, 1, 1))
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(OUTPUT, format="svg", metadata={"Date": None})
+    plt.close(fig)
+    svg = OUTPUT.read_text(encoding="utf-8")
+    OUTPUT.write_text(
+        "\n".join(line.rstrip() for line in svg.splitlines()) + "\n",
+        encoding="utf-8",
+    )
+    print(f"wrote {OUTPUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR completes the SPEC's demonstration non-default `StrassenConfig` for the Barrett-reduced prime field by adding, on top of the wide-accumulator layer, the periodic-reduction fold `BarrettCtx.foldReduce` with its per-window no-overflow invariant `accFold_spec` (the fold keeps `hi ≤ count < barrettWindow`, discharging `accVal_accAddWord`'s `hi + 1 < 2^64` hypothesis at every step, with `barrettWindow := 2^32 < 2^64`), a context-level `radixResidue = 2^64 % p` helper that cuts the `cR`-plus-proof plumbing, the ZMod64 dot-product bridge `delayedDot` (with an allocation-free `delayedDotImpl` swapped in by `@[csimp]`) proved equal to the naive `Vector.dotProduct` in `delayedDot_eq_dotProduct`, the size-dispatching base kernel `barrettBaseMul` (delayed fast path with a `mulImpl` fallback), and the verified config `strassenBarrett` with `strassenBarrett_valid`, all placed in `HexBerlekamp/DelayedKernel.lean` (above both HexMatrix and the Barrett layer, so hex-arith and hex-mod-arith gain no HexMatrix dependency). The committed comparison measurement (`hexstrassen_compare` driver, `reports/bench-results/strassen-base-kernel-comparison.json`, plotted by `scripts/plots/strassen-base-kernel-comparison.py` into `reports/figures/strassen-base-kernel-comparison.svg`) is an honest negative: default-base versus delayed-reduction-base `mulStrassen` on `ZMod64 2147483647` shows the delayed kernel is roughly 7-10x slower across dimensions 64..256, because its boxed two-word accumulator bookkeeping and per-term `UInt64.addCarry` extern call outweigh the modular reductions it defers relative to the default's tight single-extern `ZMod64.mul` (a base kernel moves the constant factor and crossover, never the asymptotic slope, and it is presented that way). Honesty constraint (b) therefore applies: the shipped demonstration config is the trivial `strassenDemo` (naive base kernel, non-default cutoff) that still exercises the pluggable-kernel path, and the verified `strassenBarrett` stays as follow-up work for its constant-factor optimization (or a bit-packed GF(2) four-Russians kernel). Whole-graph `lake build` is green; no `sorry`/`axiom`/`native_decide`.

Closes #8681.

🤖 Prepared with Claude Code