### PR TITLE
doc(hex-matrix): record the caller survey in the Strassen SPEC section

### DIFF
--- a/HexMatrix/SPEC/hex-matrix.md
+++ b/HexMatrix/SPEC/hex-matrix.md
@@ -93,9 +93,8 @@ generic `mul`: `mul` has no `[Sub R]`. This is a correction to the issue's
 literal wording "just use it by default in matrix multiplication at runtime".
 The generic-semiring `*` on `Matrix R n n` keeps the naive `mul` as its
 universal, type-correct fallback. Every coefficient type the project actually
-multiplies (`Int`, `Rat`, `ZMod64`, `Fp`) is a ring, so `mulStrassen` covers
-every real caller (`hex-determinant`, `hex-bareiss`, `hex-row-reduce`,
-`hex-lll`).
+multiplies (`Int`, `Rat`, `ZMod64`, `Fp`) is a ring, so `mulStrassen` is
+available to every ring-typed caller.
 
 Making Strassen "the default at runtime" therefore has a concrete, stated
 mechanism, not an implicit one:
@@ -109,13 +108,22 @@ mechanism, not an implicit one:
    kernel, add a `mulStrassenImpl` twin with a proved
    `@[csimp] mulStrassen_eq_impl`, mirroring `mul` / `mulImpl` /
    `mul_eq_mulImpl`, never `@[implemented_by]`.
-2. The hot ring-typed callers listed above are switched to call `mulStrassen`
-   instead of `*`. That caller switch is mechanical follow-up work, tracked
-   separately, not part of this SPEC.
+2. Ring-typed callers with genuine matrix-matrix products opt in by calling
+   `mulStrassen` at their own call sites. A survey of the tree found no such
+   caller: the dense consumers (`hex-determinant`, `hex-bareiss`,
+   `hex-row-reduce`, `hex-lll`, and the `hex-berlekamp` nullspace) are
+   elimination-based — row operations, not products; the Gram matrices are
+   built entrywise as dot products and exploit a symmetry a materialized
+   product would forfeit; and the LLL same-lattice certificate checks product
+   equality through packed dot products cheaper than any materialized product.
+   So no caller switch exists to perform, and `mulStrassen` is the entry point
+   a future product-shaped caller (for example matrix powering) adopts
+   directly.
 3. Widening `mul` itself to require `[Sub R]`, or redirecting the
    `Mul (Matrix R n n)` instance once the coefficient algebra is known to be a
-   ring, are possible later API changes. Both are out of scope here and neither
-   is needed for the callers above.
+   ring, are possible later API changes. Both are out of scope here and
+   neither is needed today, since no executable caller multiplies through the
+   instance.
 
 ### The Winograd schedule
 

--- a/progress/2026-07-09T03-55-00Z.md
+++ b/progress/2026-07-09T03-55-00Z.md
@@ -1,0 +1,33 @@
+# Caller-switch survey: no mulStrassen callers exist; SPEC corrected
+
+## Accomplished
+
+Executed the caller-switch follow-up (#8688) as a survey-first directive, and
+the survey refuted the premise on three independent sweeps (implementing
+agent, reviewer spot-check, independent Codex hunt across all libraries): no
+executable matrix-matrix product anywhere routes through `Matrix.mul` /
+`mulImpl` / the `Mul`/`HMul` instances. The dense consumers are
+elimination-based; the genuine runtime products are entrywise-`dotProduct`
+Gram matrices (symmetric, once per call) and `HexLLL`'s `mulEqCert`, which
+checks product equality through packed dots cheaper than materializing any
+product. #8688 closed as not planned with the evidence; the SPEC paragraph
+that predicted the switch ("hot ring-typed callers … mechanical follow-up")
+corrected to record the surveyed reality: `mulStrassen` is the opt-in entry
+point for future product-shaped callers.
+
+## Current frontier
+
+Strassen SPEC section fully implemented and now factually accurate about its
+callers. Remaining Strassen-adjacent work is performance-shaped: #8687
+(delayed-kernel constants) and #8652 (flat backing + views, which re-measures
+the crossover).
+
+## Next step
+
+Nothing urgent on this thread. If Gram-product acceleration ever matters, it
+needs its own issue with a symmetry-aware design and a size analysis against
+the measured cutoff.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR corrects the Strassen SPEC section's caller paragraphs after the #8688 survey: no executable matrix-matrix product in the tree routes through `mul`/`mulImpl`/the `Mul` instances (three independent sweeps — the dense consumers are elimination-based, Gram matrices are built entrywise as dot products, and the LLL same-lattice certificate checks product equality through packed dots), so the predicted "mechanical caller switch" does not exist; the SPEC now states `mulStrassen` as the opt-in entry point that future product-shaped callers adopt at their own call sites. Includes the session progress note.

🤖 Prepared with Claude Code