### PR TITLE
refactor(arith): move central-binomial monotonicity lemmas upstream to HexArith.Nat

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -202,7 +202,10 @@ def chooseFast (n k : Nat) : Nat :=
   if n < k then 0
   else (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1
 
-private theorem chooseFast_foldl (n : Nat) :
+/-- The single-row multiplicative fold `acc * (n - j) / (j + 1)` over
+`List.range k` computes the Pascal `choose n k` for `k ≤ n`. This is the shared
+kernel behind `chooseFast` and any other executable single-row binomial. -/
+theorem chooseFast_foldl (n : Nat) :
     ∀ k, k ≤ n →
       (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1 = choose n k := by
   intro k
@@ -226,6 +229,81 @@ theorem chooseFast_eq (n k : Nat) : chooseFast n k = choose n k := by
 @[csimp] theorem choose_eq_chooseFast : @choose = @chooseFast := by
   funext n k
   exact (chooseFast_eq n k).symm
+
+/-- The row of Pascal's triangle increases up to its centre: `choose k j ≤
+choose k (j + 1)` while `2 * (j + 1) ≤ k`. -/
+theorem choose_le_succ_left {k j : Nat} (h : 2 * (j + 1) ≤ k) :
+    choose k j ≤ choose k (j + 1) := by
+  refine Nat.le_of_mul_le_mul_left ?_ (Nat.succ_pos j)
+  rw [succ_mul_choose_succ k j]
+  exact Nat.mul_le_mul_right (choose k j) (by omega)
+
+/-- Everything on the left half of a row is at most the central entry:
+`choose k j ≤ choose k (k / 2)` for `2 * j ≤ k`. -/
+theorem choose_le_center (k : Nat) :
+    ∀ (fuel j : Nat), k / 2 - j ≤ fuel → 2 * j ≤ k →
+      choose k j ≤ choose k (k / 2) := by
+  intro fuel
+  induction fuel with
+  | zero =>
+      intro j hfuel hj
+      have : j = k / 2 := by omega
+      subst this; exact Nat.le_refl _
+  | succ fuel ih =>
+      intro j hfuel hj
+      by_cases hjc : j = k / 2
+      · subst hjc; exact Nat.le_refl _
+      · exact Nat.le_trans (choose_le_succ_left (by omega))
+          (ih (j + 1) (by omega) (by omega))
+
+/-- Even-row step for central-binomial monotonicity:
+`choose (2t) t ≤ choose (2t+1) t`. -/
+private theorem central_even (t : Nat) :
+    choose (2 * t) t ≤ choose (2 * t + 1) t := by
+  cases t with
+  | zero => simp
+  | succ s =>
+      rw [choose_succ_succ (2 * (s + 1)) s]
+      exact Nat.le_add_left _ _
+
+/-- Odd-row step for central-binomial monotonicity:
+`choose (2t+1) t ≤ choose (2t+2) (t+1)`. -/
+private theorem central_odd (t : Nat) :
+    choose (2 * t + 1) t ≤ choose (2 * t + 2) (t + 1) := by
+  rw [show 2 * t + 2 = 2 * t + 1 + 1 from rfl, choose_succ_succ (2 * t + 1) t]
+  exact Nat.le_add_right _ _
+
+/-- The central binomial coefficient increases by one row at a time. -/
+theorem centralChoose_le_succ (m : Nat) :
+    choose m (m / 2) ≤ choose (m + 1) ((m + 1) / 2) := by
+  rcases (by omega : m = 2 * (m / 2) ∨ m = 2 * (m / 2) + 1) with he | ho
+  · have e2 : m + 1 = 2 * (m / 2) + 1 := by omega
+    have e3 : (m + 1) / 2 = m / 2 := by omega
+    rw [e3]
+    calc choose m (m / 2)
+        = choose (2 * (m / 2)) (m / 2) := by rw [← he]
+      _ ≤ choose (2 * (m / 2) + 1) (m / 2) := central_even (m / 2)
+      _ = choose (m + 1) (m / 2) := by rw [← e2]
+  · have o2 : m + 1 = 2 * (m / 2) + 2 := by omega
+    have o3 : (m + 1) / 2 = m / 2 + 1 := by omega
+    rw [o3]
+    calc choose m (m / 2)
+        = choose (2 * (m / 2) + 1) (m / 2) := by rw [← ho]
+      _ ≤ choose (2 * (m / 2) + 2) (m / 2 + 1) := central_odd (m / 2)
+      _ = choose (m + 1) (m / 2 + 1) := by rw [← o2]
+
+/-- The central binomial coefficient is monotone in the row index. -/
+theorem centralChoose_mono {k n : Nat} (h : k ≤ n) :
+    choose k (k / 2) ≤ choose n (n / 2) := by
+  induction n with
+  | zero =>
+      have : k = 0 := Nat.le_zero.mp h
+      subst this; exact Nat.le_refl _
+  | succ m ih =>
+      rcases Nat.lt_or_ge k (m + 1) with hlt | hge
+      · exact Nat.le_trans (ih (Nat.le_of_lt_succ hlt)) (centralChoose_le_succ m)
+      · have : k = m + 1 := Nat.le_antisymm h hge
+        subst this; exact Nat.le_refl _
 
 /-- Euclid-step bridge turning the multiplicative Pascal identity into `p ∣ choose p k`. -/
 private theorem choose_prime_dvd_from_mul_identity {p k : Nat} (hp : Prime p)

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -809,23 +809,6 @@ supplies the monotonicity needed to prove the collapse; the compiled runtime
 then runs the closed form via a `@[csimp]` swap.
 -/
 
-/-- The fold underlying `binom n m` (over `List.range m`) equals the Pascal
-`Hex.Nat.choose n m` for `m ≤ n`. -/
-private theorem foldl_choose (n : Nat) :
-    ∀ m, m ≤ n →
-      (List.range m).foldl (fun acc i => acc * (n - i) / (i + 1)) 1
-        = Hex.Nat.choose n m := by
-  intro m
-  induction m with
-  | zero => intro _; simp
-  | succ m ih =>
-      intro hm
-      rw [List.range_succ, List.foldl_append, ih (Nat.le_of_succ_le hm)]
-      simp only [List.foldl_cons, List.foldl_nil]
-      have hid : Hex.Nat.choose n m * (n - m) = (m + 1) * Hex.Nat.choose n (m + 1) := by
-        rw [Nat.mul_comm]; exact (Hex.Nat.succ_mul_choose_succ n m).symm
-      rw [hid, Nat.mul_div_cancel_left _ (Nat.succ_pos m)]
-
 /-- `binom` is symmetric: `binom n k = binom n (n - k)` for `k ≤ n`. This is
 definitional (the underlying fold's length `min k (n - k)` is symmetric). -/
 private theorem binom_symm {n k : Nat} (h : k ≤ n) : binom n k = binom n (n - k) := by
@@ -839,80 +822,7 @@ private theorem binom_eq_choose_left {n k : Nat} (hk : k ≤ n) (hhalf : k ≤ n
     binom n k = Hex.Nat.choose n k := by
   unfold binom
   rw [if_neg (Nat.not_lt.mpr hk), Nat.min_eq_left hhalf]
-  exact foldl_choose n k hk
-
-/-- The row of Pascal's triangle increases up to its centre: `choose k j ≤
-choose k (j + 1)` while `2 * (j + 1) ≤ k`. -/
-private theorem choose_le_succ_left {k j : Nat} (h : 2 * (j + 1) ≤ k) :
-    Hex.Nat.choose k j ≤ Hex.Nat.choose k (j + 1) := by
-  refine Nat.le_of_mul_le_mul_left ?_ (Nat.succ_pos j)
-  rw [Hex.Nat.succ_mul_choose_succ k j]
-  exact Nat.mul_le_mul_right (Hex.Nat.choose k j) (by omega)
-
-/-- Everything on the left half of a row is at most the central entry:
-`choose k j ≤ choose k (k / 2)` for `2 * j ≤ k`. -/
-private theorem choose_le_center (k : Nat) :
-    ∀ (fuel j : Nat), k / 2 - j ≤ fuel → 2 * j ≤ k →
-      Hex.Nat.choose k j ≤ Hex.Nat.choose k (k / 2) := by
-  intro fuel
-  induction fuel with
-  | zero =>
-      intro j hfuel hj
-      have : j = k / 2 := by omega
-      subst this; exact Nat.le_refl _
-  | succ fuel ih =>
-      intro j hfuel hj
-      by_cases hjc : j = k / 2
-      · subst hjc; exact Nat.le_refl _
-      · exact Nat.le_trans (choose_le_succ_left (by omega))
-          (ih (j + 1) (by omega) (by omega))
-
-/-- Even-row step for central-binomial monotonicity: `choose (2t) t ≤ choose (2t+1) t`. -/
-private theorem central_even (t : Nat) :
-    Hex.Nat.choose (2 * t) t ≤ Hex.Nat.choose (2 * t + 1) t := by
-  cases t with
-  | zero => simp
-  | succ s =>
-      rw [Hex.Nat.choose_succ_succ (2 * (s + 1)) s]
-      exact Nat.le_add_left _ _
-
-/-- Odd-row step for central-binomial monotonicity: `choose (2t+1) t ≤ choose (2t+2) (t+1)`. -/
-private theorem central_odd (t : Nat) :
-    Hex.Nat.choose (2 * t + 1) t ≤ Hex.Nat.choose (2 * t + 2) (t + 1) := by
-  rw [show 2 * t + 2 = 2 * t + 1 + 1 from rfl, Hex.Nat.choose_succ_succ (2 * t + 1) t]
-  exact Nat.le_add_right _ _
-
-/-- The central binomial coefficient increases by one row at a time. -/
-private theorem centralChoose_le_succ (m : Nat) :
-    Hex.Nat.choose m (m / 2) ≤ Hex.Nat.choose (m + 1) ((m + 1) / 2) := by
-  rcases (by omega : m = 2 * (m / 2) ∨ m = 2 * (m / 2) + 1) with he | ho
-  · have e2 : m + 1 = 2 * (m / 2) + 1 := by omega
-    have e3 : (m + 1) / 2 = m / 2 := by omega
-    rw [e3]
-    calc Hex.Nat.choose m (m / 2)
-        = Hex.Nat.choose (2 * (m / 2)) (m / 2) := by rw [← he]
-      _ ≤ Hex.Nat.choose (2 * (m / 2) + 1) (m / 2) := central_even (m / 2)
-      _ = Hex.Nat.choose (m + 1) (m / 2) := by rw [← e2]
-  · have o2 : m + 1 = 2 * (m / 2) + 2 := by omega
-    have o3 : (m + 1) / 2 = m / 2 + 1 := by omega
-    rw [o3]
-    calc Hex.Nat.choose m (m / 2)
-        = Hex.Nat.choose (2 * (m / 2) + 1) (m / 2) := by rw [← ho]
-      _ ≤ Hex.Nat.choose (2 * (m / 2) + 2) (m / 2 + 1) := central_odd (m / 2)
-      _ = Hex.Nat.choose (m + 1) (m / 2 + 1) := by rw [← o2]
-
-/-- The central binomial coefficient is monotone in the row index. -/
-private theorem centralChoose_mono {k n : Nat} (h : k ≤ n) :
-    Hex.Nat.choose k (k / 2) ≤ Hex.Nat.choose n (n / 2) := by
-  induction n with
-  | zero =>
-      have : k = 0 := Nat.le_zero.mp h
-      subst this; exact Nat.le_refl _
-  | succ m ih =>
-      rcases Nat.lt_or_ge k (m + 1) with hlt | hge
-      · exact Nat.le_trans (ih (Nat.le_of_lt_succ hlt)) (centralChoose_le_succ m)
-      · have : k = m + 1 := Nat.le_antisymm h hge
-        subst this; exact Nat.le_refl _
+  exact Hex.Nat.chooseFast_foldl n k hk
 
 /-- The executable binomial coefficient over the factor rectangle `j ≤ k ≤ n`
 is dominated by the central binomial of the top row: `binom k j ≤ binom n (n / 2)`.
@@ -933,8 +843,8 @@ theorem binom_le_central {n k j : Nat} (hjk : j ≤ k) (hkn : k ≤ n) :
     binom_eq_choose_left (Nat.div_le_self n 2) (by omega)
   rw [hbjk, hn]
   exact Nat.le_trans
-    (choose_le_center k (k / 2) (min j (k - j)) (Nat.sub_le _ _) h2j')
-    (centralChoose_mono hkn)
+    (Hex.Nat.choose_le_center k (k / 2) (min j (k - j)) (Nat.sub_le _ _) h2j')
+    (Hex.Nat.centralChoose_mono hkn)
 
 /-- Runtime implementation of `defaultFactorCoeffBound`: the closed-form central
 binomial times the single loop-invariant norm. -/

--- a/progress/20260709T040409Z_issue-8693.md
+++ b/progress/20260709T040409Z_issue-8693.md
@@ -1,0 +1,27 @@
+# Progress — issue #8693 (relocate central-binomial monotonicity lemmas)
+
+## Accomplished
+- Moved the pure-Pascal central-binomial monotonicity chain from
+  `HexPolyZ/Mignotte.lean` up into `HexArith/Nat/Prime.lean` (the
+  `Hex.Nat` namespace, next to `choose`), needing no new imports.
+  Public now: `choose_le_succ_left`, `choose_le_center`,
+  `centralChoose_le_succ`, `centralChoose_mono`; the even/odd step
+  lemmas `central_even`/`central_odd` stay private (scaffolding).
+- Dedup: deleted `foldl_choose` from Mignotte; made the existing
+  `chooseFast_foldl` public and had `binom_eq_choose_left` delegate to it.
+- `binom_le_central` now delegates to `Hex.Nat.choose_le_center` and
+  `Hex.Nat.centralChoose_mono`; `binom_symm`, `binom_eq_choose_left`
+  stay as thin `binom`-facing wrappers.
+- No behavioural change. Full graph builds green (4165 jobs, incl.
+  HexBerlekampZassenhaus* and the Mathlib bridge). No sorry/axiom added.
+- Second opinion (Codex) applied: dependency-neutral upstream docstring,
+  kept step lemmas private.
+
+## Current frontier
+- PR open against `main` from branch `issue-8693`.
+
+## Next step
+- Watch CI; rebase if merge conflicts.
+
+## Blockers
+- None.


### PR DESCRIPTION
This PR moves the pure-Pascal central-binomial monotonicity lemmas from `HexPolyZ/Mignotte.lean` up into `HexArith/Nat/Prime.lean`, next to the `Hex.Nat.choose` definition, needing no new imports. `choose_le_succ_left` (a row increases up to its centre), `choose_le_center` (the left half is bounded by the central entry), `centralChoose_le_succ`, and `centralChoose_mono` (the central binomial is monotone in the row) become reusable public `Hex.Nat` lemmas; the even/odd single-step case-split lemmas `central_even` and `central_odd` stay private scaffolding.

It also dedups the `foldl_choose` lemma against the pre-existing `chooseFast_foldl` in the same target file: `foldl_choose` is deleted, `chooseFast_foldl` is made public, and `binom_eq_choose_left` delegates to it. `binom_le_central` now delegates to the moved `Hex.Nat.choose_le_center` and `Hex.Nat.centralChoose_mono`, while `binom_symm` and `binom_eq_choose_left` remain thin wrappers over `binom` (which stays in `HexPolyZ`).

This is a pure relocation and dedup with no behavioural change: the whole graph (`HexArith`, `HexPolyZ`, `HexBerlekampZassenhaus*`, and the Mathlib bridge, 4165 jobs) builds green and no `sorry` or `axiom` is introduced.

Closes #8693.

🤖 Prepared with Claude Code