### PR TITLE
refactor(arith): give binom and choose a common home and dedup the two binomial folds

### DIFF
--- a/HexArith/Nat/Prime.lean
+++ b/HexArith/Nat/Prime.lean
@@ -171,7 +171,7 @@ private theorem choose_succ_mul_eq (n k : Nat) :
 
 /-- Within-row multiplicative recurrence `(k+1) · choose n (k+1) = (n - k) · choose n k`.
 Reading it left to right computes one Pascal row in a single linear pass, which is
-what `chooseFast` exploits. -/
+what `binom` exploits. -/
 theorem succ_mul_choose_succ (n k : Nat) :
     (k + 1) * choose n (k + 1) = (n - k) * choose n k := by
   have hcross := choose_succ_mul_eq n k
@@ -188,47 +188,90 @@ theorem succ_mul_choose_succ (n k : Nat) :
     rw [hsplit] at hcross
     omega
 
+/-- Pascal's triangle is symmetric across each row: `choose n (n - k) = choose n k`
+for `k ≤ n`. This is the symmetry the min-optimized `binom` fold exploits to walk
+the shorter half of the row. -/
+theorem choose_symm : ∀ {n k : Nat}, k ≤ n → choose n (n - k) = choose n k := by
+  intro n
+  induction n with
+  | zero =>
+      intro k hk
+      have : k = 0 := Nat.le_zero.mp hk
+      subst this; rfl
+  | succ n ih =>
+      intro k hk
+      cases k with
+      | zero => rw [Nat.sub_zero, choose_self, choose_zero_right]
+      | succ j =>
+          have hj : j ≤ n := Nat.le_of_succ_le_succ hk
+          rw [Nat.succ_sub_succ]
+          rcases Nat.lt_or_ge j n with hlt | hge
+          · have hnj : n - j = (n - (j + 1)) + 1 := by omega
+            rw [hnj]
+            simp only [choose_succ_succ]
+            have e : (n - (j + 1)) + 1 = n - j := by omega
+            rw [ih hlt, e, ih hj, Nat.add_comm]
+          · have hjn : j = n := Nat.le_antisymm hj hge
+            subst hjn
+            rw [Nat.sub_self, choose_zero_right, choose_self]
+
 /--
 Linear-time binomial coefficient.
 
-`chooseFast n k` walks a single Pascal row from `choose n 0 = 1` using the
-multiplicative recurrence `succ_mul_choose_succ`, so it costs `O(k)` natural-number
-operations.  The proof-facing `choose` is the exponential Pascal double recursion
-(`choose n k` spawns `Θ(choose n k)` calls); `chooseFast` is proven equal to it and
-registered `@[csimp]`, so every compiled caller of `choose` runs this instead.
--/
+`binom n k` walks a single Pascal row from `choose n 0 = 1` using the
+multiplicative recurrence `succ_mul_choose_succ`, folding over the shorter half
+`min k (n - k)` of the row (the row is symmetric, `choose_symm`), so it costs
+`O(min k (n - k))` natural-number operations.  The proof-facing `choose` is the
+exponential Pascal double recursion (`choose n k` spawns `Θ(choose n k)` calls);
+`binom` is proven equal to it (`binom_eq_choose`) and registered `@[csimp]`, so
+every compiled caller of `choose` runs this instead. -/
 @[expose]
-def chooseFast (n k : Nat) : Nat :=
+def binom (n k : Nat) : Nat :=
   if n < k then 0
-  else (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1
+  else (List.range (min k (n - k))).foldl (fun acc i => acc * (n - i) / (i + 1)) 1
 
-/-- The single-row multiplicative fold `acc * (n - j) / (j + 1)` over
-`List.range k` computes the Pascal `choose n k` for `k ≤ n`. This is the shared
-kernel behind `chooseFast` and any other executable single-row binomial. -/
-theorem chooseFast_foldl (n : Nat) :
-    ∀ k, k ≤ n →
-      (List.range k).foldl (fun acc j => acc * (n - j) / (j + 1)) 1 = choose n k := by
-  intro k
-  induction k with
+/-- The multiplicative fold over `List.range m` computes `choose n m` for `m ≤ n`. -/
+private theorem binom_foldl (n : Nat) :
+    ∀ m, m ≤ n →
+      (List.range m).foldl (fun acc i => acc * (n - i) / (i + 1)) 1 = choose n m := by
+  intro m
+  induction m with
   | zero => intro _; simp
-  | succ k ih =>
-      intro hk
-      rw [List.range_succ, List.foldl_append, ih (Nat.le_of_succ_le hk)]
+  | succ m ih =>
+      intro hm
+      rw [List.range_succ, List.foldl_append, ih (Nat.le_of_succ_le hm)]
       simp only [List.foldl_cons, List.foldl_nil]
-      have hid : choose n k * (n - k) = (k + 1) * choose n (k + 1) := by
+      have hid : choose n m * (n - m) = (m + 1) * choose n (m + 1) := by
         rw [Nat.mul_comm, succ_mul_choose_succ]
-      rw [hid, Nat.mul_div_cancel_left _ (Nat.succ_pos k)]
+      rw [hid, Nat.mul_div_cancel_left _ (Nat.succ_pos m)]
 
-/-- `chooseFast` agrees with the proof-facing Pascal `choose`. -/
-theorem chooseFast_eq (n k : Nat) : chooseFast n k = choose n k := by
-  unfold chooseFast
+/-- The min-optimized `binom` fold agrees with the proof-facing Pascal `choose`. -/
+theorem binom_eq_choose (n k : Nat) : binom n k = choose n k := by
+  unfold binom
   by_cases h : n < k
   · rw [if_pos h]; exact (choose_eq_zero_of_lt h).symm
-  · rw [if_neg h]; exact chooseFast_foldl n k (Nat.le_of_not_lt h)
+  · rw [if_neg h]
+    have hkn : k ≤ n := Nat.le_of_not_lt h
+    rcases Nat.le_total k (n - k) with hle | hle
+    · rw [Nat.min_eq_left hle]; exact binom_foldl n k hkn
+    · rw [Nat.min_eq_right hle, binom_foldl n (n - k) (Nat.sub_le n k)]
+      exact choose_symm hkn
 
-@[csimp] theorem choose_eq_chooseFast : @choose = @chooseFast := by
+@[csimp] theorem choose_eq_binom : @choose = @binom := by
   funext n k
-  exact (chooseFast_eq n k).symm
+  exact (binom_eq_choose n k).symm
+
+/-- Choosing `0` elements always gives `1`. -/
+@[simp, grind =] theorem binom_zero_right (n : Nat) : binom n 0 = 1 := by
+  simp [binom]
+
+/-- Choosing `k + 1` elements from `0` is impossible. -/
+@[simp, grind =] theorem binom_zero_succ (k : Nat) : binom 0 (k + 1) = 0 := by
+  simp [binom]
+
+/-- The binomial coefficient `binom n k` vanishes when `n < k`. -/
+theorem binom_eq_zero_of_lt {n k : Nat} (h : n < k) : binom n k = 0 := by
+  simp [binom, h]
 
 /-- The row of Pascal's triangle increases up to its centre: `choose k j ≤
 choose k (j + 1)` while `2 * (j + 1) ≤ k`. -/

--- a/HexBerlekampZassenhausMathlib/PublicSurface.lean
+++ b/HexBerlekampZassenhausMathlib/PublicSurface.lean
@@ -109,7 +109,7 @@ theorem defaultFactorCoeffBound_valid
       hmignotte.trans (mul_le_mul_of_nonneg_left hl2 hchoose_nonneg)
     have hbinom :
         (Nat.choose (HexPolyZMathlib.toPolynomial g).natDegree i : ℝ) =
-          (Hex.ZPoly.binom (HexPolyZMathlib.toPolynomial g).natDegree i : ℝ) := by
+          (Hex.Nat.binom (HexPolyZMathlib.toPolynomial g).natDegree i : ℝ) := by
       rw [HexPolyZMathlib.binom_eq_choose]
     rw [hbinom] at hstep
     have huniform_nat :=
@@ -118,11 +118,11 @@ theorem defaultFactorCoeffBound_valid
     have hmig_eq :
         Hex.ZPoly.mignotteCoeffBound f
             (HexPolyZMathlib.toPolynomial g).natDegree i =
-          Hex.ZPoly.binom (HexPolyZMathlib.toPolynomial g).natDegree i *
+          Hex.Nat.binom (HexPolyZMathlib.toPolynomial g).natDegree i *
             Hex.ZPoly.coeffL2NormBound f :=
       Hex.ZPoly.mignotteCoeffBound_eq f _ _
     have huniform_real :
-        (Hex.ZPoly.binom (HexPolyZMathlib.toPolynomial g).natDegree i : ℝ) *
+        (Hex.Nat.binom (HexPolyZMathlib.toPolynomial g).natDegree i : ℝ) *
           (Hex.ZPoly.coeffL2NormBound f : ℝ) ≤
           (Hex.ZPoly.defaultFactorCoeffBound f : ℝ) := by
       have := huniform_nat

--- a/HexManual/Chapters/HexPolyZ.lean
+++ b/HexManual/Chapters/HexPolyZ.lean
@@ -183,7 +183,7 @@ quantity.
 The pieces are an executable binomial coefficient and an integer
 ceiling square root.
 
-{docstring Hex.ZPoly.binom}
+{docstring Hex.Nat.binom}
 
 {docstring Hex.ZPoly.ceilSqrt}
 
@@ -224,8 +224,8 @@ private def g : ZPoly := ofCoeffs #[1, 1, 1, 1, 1]
 #guard ZPoly.coeffL2NormBound g = 3
 
 -- Executable binomial coefficients.
-#guard ZPoly.binom 4 2 = 6
-#guard ZPoly.binom 5 2 = 10
+#guard Nat.binom 4 2 = 6
+#guard Nat.binom 5 2 = 10
 
 -- Mignotte bound for the j=1 coefficient of a degree-2
 -- factor: binom 2 1 * coeffL2NormBound g = 2 * 3.

--- a/HexPolyZ/Mignotte.lean
+++ b/HexPolyZ/Mignotte.lean
@@ -25,15 +25,6 @@ namespace Hex
 
 namespace ZPoly
 
-/-- Executable binomial coefficients for the Mignotte bound. -/
-@[expose]
-def binom (n k : Nat) : Nat :=
-  if n < k then
-    0
-  else
-    let kk := min k (n - k)
-    (List.range kk).foldl (fun acc i => acc * (n - i) / (i + 1)) 1
-
 /-- One Newton step for the natural-number square-root iteration. -/
 private def sqrtStep (n x : Nat) : Nat :=
   (x + n / x) / 2
@@ -414,7 +405,7 @@ def coeffL2NormBound (f : ZPoly) : Nat :=
 factor of `f`, using the conservative `coeffL2NormBound`. -/
 @[expose]
 def mignotteCoeffBound (f : ZPoly) (k j : Nat) : Nat :=
-  binom k j * coeffL2NormBound f
+  Nat.binom k j * coeffL2NormBound f
 
 /--
 Uniform executable coefficient bound used by the default integer
@@ -438,20 +429,6 @@ noncomputable def defaultFactorCoeffBound (f : ZPoly) : Nat :=
         (fun acc j => max acc (mignotteCoeffBound f k j))
         acc)
     0
-
-/-- Base case of `binom`: choosing `0` elements always gives `1`, so the empty
-`foldl` over `List.range 0` normalizes `binom n 0` to `1`. -/
-@[simp, grind =] theorem binom_zero_right (n : Nat) : binom n 0 = 1 := by
-  simp [binom]
-
-/-- Base case of `binom`: choosing `k + 1` elements from `0` is impossible, so
-the `n < k` guard fires and normalizes `binom 0 (k + 1)` to `0`. -/
-@[simp, grind =] theorem binom_zero_succ (k : Nat) : binom 0 (k + 1) = 0 := by
-  simp [binom]
-
-/-- The executable binomial coefficient `binom n k` vanishes when `n < k`. -/
-theorem binom_eq_zero_of_lt {n k : Nat} (h : n < k) : binom n k = 0 := by
-  simp [binom, h]
 
 /-- Base case of `floorSqrt`: the `n = 0` guard fires before the Newton
 iteration, so `floorSqrt 0` normalizes to `0`. -/
@@ -545,7 +522,7 @@ theorem coeffL2NormBound_sq_le_two_mul_coeffNormSq (f : ZPoly) :
 /-- `mignotteCoeffBound f k j` equals the product `binom k j * coeffL2NormBound f`
 of the binomial coefficient and the conservative coefficient-norm bound. -/
 theorem mignotteCoeffBound_eq (f : ZPoly) (k j : Nat) :
-    mignotteCoeffBound f k j = binom k j * coeffL2NormBound f := rfl
+    mignotteCoeffBound f k j = Nat.binom k j * coeffL2NormBound f := rfl
 
 /-- Restates `defaultFactorCoeffBound f` as the nested `foldl` taking the maximum of
 `mignotteCoeffBound f k j` over factor degrees `k` up to `f.degree?.getD 0` and
@@ -616,7 +593,7 @@ normalizes to `0`. -/
 the coefficient index `j` exceeds the factor degree `k`. -/
 theorem mignotteCoeffBound_eq_zero_of_lt (f : ZPoly) (k j : Nat) (h : k < j) :
     mignotteCoeffBound f k j = 0 := by
-  simp [mignotteCoeffBound, binom_eq_zero_of_lt h]
+  simp [mignotteCoeffBound, Nat.binom_eq_zero_of_lt h]
 
 /-- The inner `max`-fold over `j ∈ range (k+1)` dominates each
 `mignotteCoeffBound f k j` at an in-range index, by `le_foldl_max_of_mem`. -/
@@ -809,39 +786,22 @@ supplies the monotonicity needed to prove the collapse; the compiled runtime
 then runs the closed form via a `@[csimp]` swap.
 -/
 
-/-- `binom` is symmetric: `binom n k = binom n (n - k)` for `k ≤ n`. This is
-definitional (the underlying fold's length `min k (n - k)` is symmetric). -/
-private theorem binom_symm {n k : Nat} (h : k ≤ n) : binom n k = binom n (n - k) := by
-  unfold binom
-  rw [if_neg (Nat.not_lt.mpr h), if_neg (Nat.not_lt.mpr (Nat.sub_le n k)),
-    Nat.sub_sub_self h, Nat.min_comm (n - k) k]
-
-/-- On the left half of a row (`k ≤ n - k`), `binom n k` agrees with the Pascal
-`Hex.Nat.choose n k`. -/
-private theorem binom_eq_choose_left {n k : Nat} (hk : k ≤ n) (hhalf : k ≤ n - k) :
-    binom n k = Hex.Nat.choose n k := by
-  unfold binom
-  rw [if_neg (Nat.not_lt.mpr hk), Nat.min_eq_left hhalf]
-  exact Hex.Nat.chooseFast_foldl n k hk
-
-/-- The executable binomial coefficient over the factor rectangle `j ≤ k ≤ n`
-is dominated by the central binomial of the top row: `binom k j ≤ binom n (n / 2)`.
-This is the monotonicity that collapses the `defaultFactorCoeffBound` double max. -/
+/-- The binomial coefficient over the factor rectangle `j ≤ k ≤ n` is dominated
+by the central binomial of the top row: `binom k j ≤ binom n (n / 2)`. This is the
+monotonicity that collapses the `defaultFactorCoeffBound` double max. -/
 theorem binom_le_central {n k j : Nat} (hjk : j ≤ k) (hkn : k ≤ n) :
-    binom k j ≤ binom n (n / 2) := by
+    Nat.binom k j ≤ Nat.binom n (n / 2) := by
+  rw [Nat.binom_eq_choose, Nat.binom_eq_choose]
   -- reduce `j` to the left-half index `j' = min j (k - j)`
-  have hbjk : binom k j = Hex.Nat.choose k (min j (k - j)) := by
+  have hbjk : Hex.Nat.choose k j = Hex.Nat.choose k (min j (k - j)) := by
     rcases Nat.le_total j (k - j) with hle | hle
-    · rw [Nat.min_eq_left hle]; exact binom_eq_choose_left hjk hle
-    · rw [Nat.min_eq_right hle, binom_symm hjk]
-      exact binom_eq_choose_left (Nat.sub_le k j) (by omega)
+    · rw [Nat.min_eq_left hle]
+    · rw [Nat.min_eq_right hle]; exact (Hex.Nat.choose_symm hjk).symm
   have h2j' : 2 * min j (k - j) ≤ k := by
     rcases Nat.le_total j (k - j) with hle | hle
     · rw [Nat.min_eq_left hle]; omega
     · rw [Nat.min_eq_right hle]; omega
-  have hn : binom n (n / 2) = Hex.Nat.choose n (n / 2) :=
-    binom_eq_choose_left (Nat.div_le_self n 2) (by omega)
-  rw [hbjk, hn]
+  rw [hbjk]
   exact Nat.le_trans
     (Hex.Nat.choose_le_center k (k / 2) (min j (k - j)) (Nat.sub_le _ _) h2j')
     (Hex.Nat.centralChoose_mono hkn)
@@ -851,7 +811,7 @@ binomial times the single loop-invariant norm. -/
 @[expose]
 def defaultFactorCoeffBoundImpl (f : ZPoly) : Nat :=
   let n := f.degree?.getD 0
-  binom n (n / 2) * coeffL2NormBound f
+  Nat.binom n (n / 2) * coeffL2NormBound f
 
 /-- Register the value-equal closed form `defaultFactorCoeffBoundImpl` as the
 compiled implementation of `defaultFactorCoeffBound`. The `@[csimp]` swap is

--- a/HexPolyZMathlib/Mignotte.lean
+++ b/HexPolyZMathlib/Mignotte.lean
@@ -207,8 +207,8 @@ private theorem foldl_binom_iter_eq_choose (n m : Nat) :
 
 /-- The executable Mignotte-bound binomial coefficient agrees with Mathlib's
 `Nat.choose`. -/
-theorem binom_eq_choose (n k : Nat) : Hex.ZPoly.binom n k = Nat.choose n k := by
-  unfold Hex.ZPoly.binom
+theorem binom_eq_choose (n k : Nat) : Hex.Nat.binom n k = Nat.choose n k := by
+  unfold Hex.Nat.binom
   by_cases hnk : n < k
   · rw [if_pos hnk, Nat.choose_eq_zero_of_lt hnk]
   · rw [if_neg hnk]

--- a/bench/HexPolyZ/Bench.lean
+++ b/bench/HexPolyZ/Bench.lean
@@ -188,7 +188,7 @@ def runPrimitivePartChecksum (input : ContentInput) : UInt64 :=
 
 /-- Benchmark target: compute a central binomial coefficient. -/
 def runBinom (n : Nat) : Nat :=
-  ZPoly.binom (2 * n) n
+  Nat.binom (2 * n) n
 
 /-- Benchmark target: compute floor square roots over a prepared batch. -/
 def runFloorSqrtChecksum (input : SqrtInput) : UInt64 :=
@@ -255,7 +255,7 @@ setup_benchmark runPrimitivePartChecksum n => n
   }
 
 /-
-`ZPoly.binom (2*n) n` folds across `min n n = n` multiplicative terms.
+`Nat.binom (2*n) n` folds across `min n n = n` multiplicative terms.
 For this central-binomial fixture the accumulator reaches linear bit width.
 Each compiled `Nat` multiply/divide step therefore scales with the accumulator
 limb count, so the scientific declaration models bit-cost growth rather than

--- a/conformance/HexPolyZ/Conformance.lean
+++ b/conformance/HexPolyZ/Conformance.lean
@@ -18,7 +18,7 @@ Covered operations:
 - Bezout-style modular coprimality via `ZPoly.coprimeModP`
 - `content`, `primitivePart`, `Primitive`, and primitive square-free
   decomposition
-- Mignotte helpers: `binom`, `floorSqrt`, `ceilSqrt`, `coeffNormSq`,
+- Mignotte helpers: `Nat.binom`, `floorSqrt`, `ceilSqrt`, `coeffNormSq`,
   `coeffL2NormBound`, and `mignotteCoeffBound`
 Covered properties:
 - normalized `ZPoly` values erase trailing zero coefficients while preserving
@@ -31,7 +31,7 @@ Covered properties:
 - primitive-part fixtures with nonzero content have content `1`
 - primitive square-free decomposition removes repeated rational factors after
   primitive-part extraction
-- Mignotte coefficient bounds equal `binom k j * coeffL2NormBound f`
+- Mignotte coefficient bounds equal `Nat.binom k j * coeffL2NormBound f`
 Covered edge cases:
 - zero polynomials and all-zero coefficient arrays
 - trailing-zero and internal-zero polynomial representations
@@ -213,11 +213,11 @@ example : Primitive (primitivePart contentPrimitive) := by
   change content (primitivePart contentPrimitive) = 1
   decide
 
--- `binom 12 5 = 792`: typical-degree request near the SPEC ceiling for the
+-- `Nat.binom 12 5 = 792`: typical-degree request near the SPEC ceiling for the
 -- core polynomial-degree band.
-#guard binom 12 5 = 792
-#guard binom 10 0 = 1
-#guard binom 7 12 = 0
+#guard Nat.binom 12 5 = 792
+#guard Nat.binom 10 0 = 1
+#guard Nat.binom 7 12 = 0
 
 -- `1000 = floorSqrt (10^6)`; `9999 = floorSqrt (10^8 - 1)` since
 -- `9999^2 = 99_980_001 < 99_999_999 < 100_000_000 = 10000^2`.
@@ -239,15 +239,15 @@ example : Primitive (primitivePart contentPrimitive) := by
 #guard coeffL2NormBound (0 : ZPoly) = 0
 #guard coeffL2NormBound (DensePoly.ofCoeffs #[-6, 0, 8, 0, 0, 0, 0, 0, 0, 0, 24]) = 26
 
--- Typical Mignotte: `binom 8 4 · 13 = 70 · 13 = 910`.
+-- Typical Mignotte: `Nat.binom 8 4 · 13 = 70 · 13 = 910`.
 #guard mignotteCoeffBound (DensePoly.ofCoeffs #[3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 12]) 8 4 = 910
 #guard mignotteCoeffBound (0 : ZPoly) 8 4 = 0
--- Adversarial Mignotte: `binom 12 6 · 26 = 924 · 26 = 24024`.
+-- Adversarial Mignotte: `Nat.binom 12 6 · 26 = 924 · 26 = 24024`.
 #guard mignotteCoeffBound
     (DensePoly.ofCoeffs #[-6, 0, 8, 0, 0, 0, 0, 0, 0, 0, 24]) 12 6 = 24024
 #guard mignotteCoeffBound
     (DensePoly.ofCoeffs #[-6, 0, 8, 0, 0, 0, 0, 0, 0, 0, 24]) 12 6 =
-  binom 12 6 *
+  Nat.binom 12 6 *
     coeffL2NormBound (DensePoly.ofCoeffs #[-6, 0, 8, 0, 0, 0, 0, 0, 0, 0, 24])
 
 end ZPoly

--- a/progress/2026-07-09T04-20-00Z.md
+++ b/progress/2026-07-09T04-20-00Z.md
@@ -1,0 +1,38 @@
+**Accomplished**
+
+- Issue #8692: gave the two executable binomial folds one home. Removed
+  `Hex.ZPoly.binom` (min-optimized) and `Hex.Nat.chooseFast` (plain fold);
+  introduced a single `Hex.Nat.binom` (min-optimized, over `min k (n - k)`)
+  in `HexArith/Nat/Prime.lean` next to `choose`.
+- Added a Mathlib-free `Hex.Nat.choose_symm : k ≤ n → choose n (n-k) = choose n k`
+  (Pascal induction, boundary cases handled explicitly) to justify the
+  min-optimization; proved `binom_eq_choose` and registered
+  `@[csimp] choose = binom`, replacing the old `choose = chooseFast`.
+- Moved the basic binom lemmas (`binom_zero_right`, `binom_zero_succ`,
+  `binom_eq_zero_of_lt`) upstream with the def.
+- Rewrote `HexPolyZ/Mignotte.lean`: `binom_le_central` now reduces to the pure
+  `choose` statement via `binom_eq_choose`, so the local `foldl_choose`,
+  `binom_symm`, and `binom_eq_choose_left` helpers are gone (net -80 lines
+  there). The central-monotonicity cluster stays (that is #8693's move).
+- Updated consumers: `HexPolyZMathlib/Mignotte.lean` (thin bridge now on
+  `Hex.Nat.binom`), `HexBerlekampZassenhausMathlib/PublicSurface.lean`,
+  `HexManual/Chapters/HexPolyZ.lean`, `bench/HexPolyZ/Bench.lean`,
+  `conformance/HexPolyZ/Conformance.lean`, plus stale-doc refs in
+  `scripts/oracle/polyz_flint.py` and `reports/hex-poly-z-performance.md`.
+- Full graph builds green: HexArith, HexPolyZ, both Mathlib bridges,
+  HexConformance, hexpolyz_bench, hexpolyz_emit_fixtures, and HexManual.
+  Values unchanged; conformance fixtures untouched. Codex second opinion found
+  no correctness issues (only the stale-doc refs, now fixed).
+
+**Current frontier**
+
+- Opening the PR for #8692.
+
+**Next step**
+
+- Check merge conflicts / CI after the PR is up.
+
+**Blockers**
+
+- None. Overlaps with #8693 (central-binomial monotonicity move); both touch
+  `binom_le_central`, so whichever lands second rebases.

--- a/reports/hex-poly-z-performance.md
+++ b/reports/hex-poly-z-performance.md
@@ -165,12 +165,12 @@ Command:
 scripts/profile/run_profile.sh ./.lake/build/bin/hexpolyz_bench Hex.PolyZBench.runBinom 131072 5000000000
 ```
 
-Representative case: central binomial coefficient `ZPoly.binom (2*n) n`,
+Representative case: central binomial coefficient `Nat.binom (2*n) n`,
 parameter `131072`, no seed. The child row reported `2` inner repeats,
 `3.731 s` total, `1.865 s` per call, and result hash
 `0x19491e050eb44246`. Leaf cost was GMP big-integer arithmetic `96.9%`,
 allocation/free `2.9%`, Lean runtime `0.2%`, and Lean own code `0.0%` at leaf
-self time. Inclusive cost was led by `ZPoly.binom` (`100.0%`) and its fold
+self time. Inclusive cost was led by `Nat.binom` (`100.0%`) and its fold
 over multiplicative terms (`99.9%`). The dominant leaf frames were
 `__gmpn_divrem_1` (`67.2%`), `__gmpn_copyi` (`20.8%`), and `__gmpn_mul_1`
 (`8.5%`), which is the expected limb arithmetic for the central-binomial

--- a/scripts/oracle/polyz_flint.py
+++ b/scripts/oracle/polyz_flint.py
@@ -94,7 +94,7 @@ def _ceil_sqrt(n: int) -> int:
 
 
 def _binom(n: int, k: int) -> int:
-    """Match `Hex.ZPoly.binom`: zero when `k > n`, otherwise the
+    """Match `Hex.Nat.binom`: zero when `k > n`, otherwise the
     standard symmetric formula."""
     if k > n:
         return 0


### PR DESCRIPTION
This PR gives the two executable binomial-coefficient folds a single home. The min-optimized fold `Hex.ZPoly.binom` and the plain fold `Hex.Nat.chooseFast` both computed the Pascal `Hex.Nat.choose`; this collapses them into one `Hex.Nat.binom` in `HexArith/Nat/Prime.lean`, next to `choose`. `binom` folds over the shorter half `min k (n - k)` of the row, is proven equal to `choose` (`binom_eq_choose`, Mathlib-free, using a new `choose_symm`), and is registered `@[csimp]` as the compiled implementation of `choose`, replacing `chooseFast`. Every compiled caller of `choose` now runs the shorter fold.

`Hex.ZPoly.binom` and its `chooseFast` twin are removed. Consumers move to `Hex.Nat.binom`: `HexPolyZ/Mignotte.lean`, `HexPolyZMathlib/Mignotte.lean`, `HexBerlekampZassenhausMathlib/PublicSurface.lean`, `HexManual/Chapters/HexPolyZ.lean`, `bench/HexPolyZ/Bench.lean`, and `conformance/HexPolyZ/Conformance.lean`. In `Mignotte.lean` the now-redundant `foldl_choose`, `binom_symm`, and `binom_eq_choose_left` helpers drop out, since `binom_le_central` reduces to the pure-`choose` statement through the full `binom_eq_choose`. Values are unchanged, so conformance fixtures are untouched.

Overlaps with #8693 (moving the central-binomial monotonicity lemmas upstream); the two touch `binom_le_central`, so whichever lands second rebases.

🤖 Prepared with Claude Code
