### PR TITLE
feat: scaffold HexRealRoots with DyadicInterval and exact dyadic Horner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexRealRoots.lean
+++ b/HexRealRoots.lean
@@ -1,0 +1,31 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Basic
+
+public section
+
+/-!
+The `HexRealRoots` library certifies the isolation of the real roots of
+integer-coefficient polynomials. A real root isolation is a half-open
+dyadic interval `(lower, upper]` together with a witness, dischargeable
+by `decide`, that exactly one real root of `p ∈ ℤ[x]` lies in it. The
+witness is a Sturm count: the sign-variation difference of the Sturm
+chain of `p` evaluated at the two endpoints, which counts the roots in
+the interval exactly.
+
+Isolation runs two engines over the same output type — a fast Descartes
+search and a provably terminating Sturm search — and every emitted
+isolation carries a Sturm-count witness regardless of which engine found
+it. `ZPoly` values are evaluated at dyadic points by exact Horner
+arithmetic, so the sign of `p(x)` at a dyadic `x` is exact: no floats,
+no interval arithmetic, no error budget.
+
+This is the Mathlib-free computational layer; the correctness and
+completeness theorems live in the companion `HexRealRootsMathlib`.
+-/

--- a/HexRealRoots/Basic.lean
+++ b/HexRealRoots/Basic.lean
@@ -90,4 +90,20 @@ example : (DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)).midp
 example : (DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)).width
     = Dyadic.ofInt 1 := by decide
 
+-- The zero polynomial evaluates to `0` everywhere.
+example : ZPoly.evalDyadic (DensePoly.ofCoeffs (#[] : Array Int)) (Dyadic.ofInt 5)
+    = 0 := by decide
+
+-- `x² − 1` at the negative point `−1/2` is `1/4 − 1 = −3/4`.
+example : ZPoly.evalDyadic (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+    ((Dyadic.ofInt (-1)) >>> (1 : Int)) = (Dyadic.ofInt (-3)) >>> (2 : Int) := by decide
+
+-- A nonzero polynomial hitting an exact zero: `x − 1` at `1`.
+example : ZPoly.evalDyadic (DensePoly.ofCoeffs #[(-1 : Int), 1]) (Dyadic.ofInt 1)
+    = 0 := by decide
+
+-- The midpoint of the negative interval `(−2, −1]` is `−3/2`.
+example : (DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt (-1)) (by decide)).midpoint
+    = (Dyadic.ofInt (-3)) >>> (1 : Int) := by decide
+
 end Hex

--- a/HexRealRoots/Basic.lean
+++ b/HexRealRoots/Basic.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ
+
+public section
+
+/-!
+Basic data for real root isolation: the half-open dyadic interval type,
+exact dyadic Horner evaluation of an integer polynomial, and the exact
+sign of a dyadic value.
+
+Every witness in this library is an exact comparison between dyadic
+values or integer counts; there is no rounding and no error budget.
+`Dyadic` comes from Lean core (`Init.Data.Dyadic`).
+-/
+namespace Hex
+
+/-- A half-open dyadic interval `(lower, upper]`.
+
+The isolation convention throughout the library is half-open on the
+left: a root at `upper` belongs to the interval, a root at `lower` does
+not. This is what makes bisection at a midpoint have no endpoint case
+analysis — a root exactly at the midpoint `m` lands in the left child
+`(lower, m]`. The `lt` field records that the interval is nonempty. -/
+structure DyadicInterval where
+  /-- The excluded left endpoint. -/
+  lower : Dyadic
+  /-- The included right endpoint. -/
+  upper : Dyadic
+  /-- The interval is nonempty: `lower < upper`. -/
+  lt : lower < upper
+
+/-- The dyadic midpoint `(lower + upper) / 2` of the interval, computed
+by an exact arithmetic right shift of the sum by one bit. -/
+def DyadicInterval.midpoint (I : DyadicInterval) : Dyadic :=
+  (I.lower + I.upper) >>> (1 : Int)
+
+/-- The exact width `upper - lower` of the interval. -/
+def DyadicInterval.width (I : DyadicInterval) : Dyadic :=
+  I.upper - I.lower
+
+/-- The exact sign of a dyadic value as an integer in `{-1, 0, 1}`.
+
+A nonzero dyadic is `ofOdd n k` with `n` odd, and its sign is the sign
+of the odd numerator `n` (the power-of-two scale `2^{-k}` is positive),
+so no evaluation is needed. -/
+def dyadicSign : Dyadic → Int
+  | .zero => 0
+  | .ofOdd n _ _ => if n < 0 then -1 else 1
+
+namespace ZPoly
+
+/-- Evaluate an integer polynomial at a dyadic point by Horner's rule,
+returning an exact `Dyadic` value.
+
+This is exact witness arithmetic: a plain fold over the coefficient
+array with no rounding, so the sign of `p(x)` at a dyadic `x` is exact.
+Coefficients are stored in ascending degree order, so folding from the
+right accumulates `c₀ + x·(c₁ + x·(⋯ + x·cₙ))`. -/
+def evalDyadic (p : ZPoly) (x : Dyadic) : Dyadic :=
+  p.toArray.foldr (fun c acc => Dyadic.ofInt c + x * acc) 0
+
+end ZPoly
+
+/-! Sanity checks (kept light; conformance lives in the shared
+sub-project). -/
+
+-- `x² − 1` evaluated at `3/2` is `9/4 − 1 = 5/4`.
+example : ZPoly.evalDyadic (DensePoly.ofCoeffs #[(-1 : Int), 0, 1])
+    ((Dyadic.ofInt 3) >>> (1 : Int)) = (Dyadic.ofInt 5) >>> (2 : Int) := by decide
+
+-- The constant polynomial `7` evaluates to `7` at any point.
+example : ZPoly.evalDyadic (DensePoly.ofCoeffs #[(7 : Int)]) (Dyadic.ofInt 4)
+    = Dyadic.ofInt 7 := by decide
+
+-- Signs of `-3/2`, `0`, `5/4`.
+example : dyadicSign ((Dyadic.ofInt (-3)) >>> (1 : Int)) = -1 := by decide
+example : dyadicSign 0 = 0 := by decide
+example : dyadicSign ((Dyadic.ofInt 5) >>> (2 : Int)) = 1 := by decide
+
+-- The midpoint of `(1, 2]` is `3/2`; its width is `1`.
+example : (DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)).midpoint
+    = (Dyadic.ofInt 3) >>> (1 : Int) := by decide
+example : (DyadicInterval.mk (Dyadic.ofInt 1) (Dyadic.ofInt 2) (by decide)).width
+    = Dyadic.ofInt 1 := by decide
+
+end Hex

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -405,10 +405,11 @@ re-refine from a stored coarse representative. See
 ## File organisation
 
 - `HexRealRoots/Basic.lean`: `DyadicInterval`, exact dyadic Horner
-  evaluation, `RealRootIsolation`, `RealRootIsolations`.
+  evaluation, sign helper.
 - `HexRealRoots/Chain.lean`: `spem`, `sturmChain`.
 - `HexRealRoots/Var.lean`: `signVar`, `sturmVarAt`, the `±∞`
-  variants, `sturmCount`, `rootCount`.
+  variants, `sturmCount`, `rootCount`, `RealRootIsolation`,
+  `RealRootIsolations`.
 - `HexRealRoots/Prec.lean`: `sepPrec`, `isolationDepth`,
   `rootBound`.
 - `HexRealRoots/Mobius.lean`: `mobiusTransform` (Taylor shift based),

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -109,6 +109,8 @@ lean_lib HexGFq where
 
 lean_lib HexBerlekampZassenhaus where
 
+lean_lib HexRealRoots where
+
 @[default_target]
 lean_lib HexPolyMathlib where
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -484,7 +484,7 @@ libraries:
     deps: [HexPolyZ]
     mathlib: false
     done_through: 0
-    status: planned
+    status: active
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true


### PR DESCRIPTION
This PR scaffolds the Mathlib-free HexRealRoots computational library with its first module, Basic.lean, in namespace Hex. It adds the half-open DyadicInterval type (documenting the (lower, upper] convention) together with midpoint and width helpers, the exact dyadic Horner evaluator Hex.ZPoly.evalDyadic that folds a ZPoly's integer coefficient array against a Dyadic point with no rounding, and the dyadicSign helper that reads the exact sign off Lean core's Dyadic constructors. All arithmetic runs over Lean core's Dyadic, matching the library's exact-witness design, and a handful of by-decide examples sanity-check the definitions. The umbrella HexRealRoots.lean imports only Basic for now; later PRs append their own modules.

It wires the library into the build by adding a plain lean_lib HexRealRoots stanza to lakefile.lean and appending HexRealRoots to ci.yml's HEX_LIB_TARGETS so CI compiles it from this PR on. Because the library now builds, its libraries.yml entry flips from planned to active, which the Lake/libraries.yml alignment in scripts/check_dag.py requires (an active buildable lean_lib cannot be marked planned); check_dag.py passes.

It amends the file-organisation section of SPEC/Libraries/hex-real-roots.md: RealRootIsolation and RealRootIsolations move from the Basic.lean bullet to the Var.lean bullet, because both are defined in terms of sturmCount, which lives in Var.lean, so keeping them in Basic would create an import cycle. Basic.lean's bullet now reads DyadicInterval, exact dyadic Horner evaluation, sign helper.

🤖 Prepared with Claude Code