### PR TITLE
feat: scaffold the Sturm theorem slice over Polynomial R

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexRealRootsMathlib.lean
+++ b/HexRealRootsMathlib.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.SturmChainDefs
+public import HexRealRootsMathlib.SturmTheorem
+
+public section
+
+/-!
+The `HexRealRootsMathlib` library is the Mathlib companion for the executable
+real-root isolation library `HexRealRoots`.
+
+This umbrella currently exposes only the **self-contained Sturm slice**: the
+zero-skipping sign-variation count `Sturm.sturmVar`, the generalised-chain
+predicate `Sturm.IsSturmChain`, and the five-step statement of Sturm's theorem
+over `Polynomial ℝ`. The slice is deliberately free of any `HexRealRoots`
+dependence, so it can be contributed to Mathlib (which does not yet have
+Sturm's theorem) once exercised here.
+
+The executable-correspondence files — connecting `Hex.sturmChain`,
+`Hex.sturmCount`, and the isolation drivers to this abstract development, and
+the isolation-soundness and driver-completeness theorems — arrive in later PRs.
+-/

--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -100,6 +100,9 @@ The fields, in the numbering of the SPEC:
   left neighbourhood of `r` and positive on a punctured right neighbourhood.
   Phrasing the second element existentially forbids the degenerate witness in
   which `p` has a root but the chain has no derivative-like second entry;
+* `nonzero_mem` — no chain element is the zero polynomial, so each element
+  has finitely many zeros and the counting theorem's telescope over the
+  chain's zeros is finite;
 * `consec_coprime` — consecutive elements never vanish at a common point;
 * `interior_alternates` — when an interior element (one with both neighbours
   present) vanishes at a point, both neighbours are nonzero there and have
@@ -117,6 +120,8 @@ structure IsSturmChain (p : Polynomial ℝ) (chain : List (Polynomial ℝ)) : Pr
     q.eval r ≠ 0 ∧
     (∀ᶠ x in 𝓝[<] r, (p * q).eval x < 0) ∧
     (∀ᶠ x in 𝓝[>] r, 0 < (p * q).eval x)
+  /-- No chain element is the zero polynomial. -/
+  nonzero_mem : ∀ q ∈ chain, q ≠ 0
   /-- Consecutive elements have no common real zero. -/
   consec_coprime : ∀ (i : ℕ) (x : ℝ) (a b : Polynomial ℝ),
     chain[i]? = some a → chain[i + 1]? = some b → a.eval x = 0 → b.eval x ≠ 0

--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import Mathlib
+
+public section
+
+/-!
+Self-contained scaffolding for Sturm's theorem over `Polynomial ℝ`.
+
+This module defines the zero-skipping sign-variation count `Sturm.sturmVar`
+of a chain of real polynomials at a point, and the predicate
+`Sturm.IsSturmChain` capturing the sign axioms that the root-counting
+argument uses. Nothing here refers to any `HexRealRoots` executable type:
+the development is a slice over `Polynomial ℝ` that is intended to be
+upstreamable to Mathlib once exercised by the executable-correspondence
+files that arrive in later PRs.
+
+The zero-skipping convention: the variation count of a sign pattern such as
+`(+, 0, −)` is `1`. Concretely we drop the zero evaluations and count the
+adjacent pairs of opposite sign among what remains.
+-/
+
+open Filter Topology
+
+namespace Sturm
+
+/-- Count the sign changes of a real list: the number of adjacent pairs
+whose product is negative. Callers first drop the zero entries (see
+`Sturm.signVariations`), so on a zero-free list this is exactly the number
+of adjacent opposite-sign pairs. -/
+@[expose]
+noncomputable def countSignChanges : List ℝ → ℕ
+  | a :: b :: rest => (if a * b < 0 then 1 else 0) + countSignChanges (b :: rest)
+  | _ => 0
+
+@[simp] theorem countSignChanges_nil : countSignChanges [] = 0 := rfl
+
+@[simp] theorem countSignChanges_singleton (a : ℝ) : countSignChanges [a] = 0 := rfl
+
+theorem countSignChanges_cons_cons (a b : ℝ) (rest : List ℝ) :
+    countSignChanges (a :: b :: rest) =
+      (if a * b < 0 then 1 else 0) + countSignChanges (b :: rest) := rfl
+
+/-- Zero-skipping sign variations of a real list: drop the zeros, then count
+the adjacent opposite-sign pairs. This is the variation count that both the
+pointwise chain evaluations and the leading-coefficient signs at `±∞` feed
+into. -/
+@[expose]
+noncomputable def signVariations (l : List ℝ) : ℕ :=
+  countSignChanges (l.filter (fun v => decide (v ≠ 0)))
+
+@[simp] theorem signVariations_nil : signVariations [] = 0 := rfl
+
+/-- Prepending a zero entry does not change the sign variations. -/
+theorem signVariations_cons_zero (l : List ℝ) :
+    signVariations (0 :: l) = signVariations l := by
+  simp [signVariations]
+
+/-- Prepending a nonzero entry `a` to a list whose first surviving entry has
+the same sign as `a` (or which becomes empty after dropping zeros) is
+governed by `countSignChanges`; this unfolding lemma exposes the recursion to
+downstream local-sign arguments. -/
+theorem signVariations_cons_ne (a : ℝ) (l : List ℝ) (ha : a ≠ 0) :
+    signVariations (a :: l) =
+      countSignChanges (a :: l.filter (fun v => decide (v ≠ 0))) := by
+  simp [signVariations, ha]
+
+/-- Zero-skipping sign variations of the chain `chain` evaluated at `x`:
+the sign variations of the list of evaluations `chain.map (·.eval x)`. -/
+@[expose]
+noncomputable def sturmVar (chain : List (Polynomial ℝ)) (x : ℝ) : ℕ :=
+  signVariations (chain.map (Polynomial.eval x))
+
+@[simp] theorem sturmVar_nil (x : ℝ) : sturmVar [] x = 0 := rfl
+
+/-- A chain element that vanishes at `x` contributes no variation at `x`:
+`sturmVar` ignores it. -/
+theorem sturmVar_cons_zero {q : Polynomial ℝ} {x : ℝ} (h : q.eval x = 0)
+    (chain : List (Polynomial ℝ)) :
+    sturmVar (q :: chain) x = sturmVar chain x := by
+  simp [sturmVar, List.map_cons, signVariations, h]
+
+/-- A generalised Sturm chain for `p`: the sign axioms that the counting
+argument actually uses, packaged as explicit fields. The chain is stored as
+a plain `List (Polynomial ℝ)` and elements are addressed by index through
+`getElem?`, so no length lower bound is baked in (a nonzero constant `p` has
+the one-element chain `[p]`).
+
+The fields, in the numbering of the SPEC:
+
+* `nonempty` / `head` — the chain is nonempty and its head is `p`;
+* `root_flank` — at every real root `r` of `p` there is a second element
+  `q` (`chain[1] = q`), nonzero at `r`, with `p * q` negative on a punctured
+  left neighbourhood of `r` and positive on a punctured right neighbourhood.
+  Phrasing the second element existentially forbids the degenerate witness in
+  which `p` has a root but the chain has no derivative-like second entry;
+* `consec_coprime` — consecutive elements never vanish at a common point;
+* `interior_alternates` — when an interior element (one with both neighbours
+  present) vanishes at a point, both neighbours are nonzero there and have
+  opposite signs, so the local pattern is `(±, 0, ∓)`;
+* `last_no_root` — the last element has no real zero. -/
+structure IsSturmChain (p : Polynomial ℝ) (chain : List (Polynomial ℝ)) : Prop where
+  /-- The chain is nonempty. -/
+  nonempty : chain ≠ []
+  /-- The head of the chain is `p`. -/
+  head : chain.head? = some p
+  /-- At every real root `r` of `p`, the chain has a second element `q`,
+  nonzero at `r`, with `p * q` negative just left of `r` and positive just
+  right of `r`. -/
+  root_flank : ∀ r : ℝ, p.IsRoot r → ∃ q : Polynomial ℝ, chain[1]? = some q ∧
+    q.eval r ≠ 0 ∧
+    (∀ᶠ x in 𝓝[<] r, (p * q).eval x < 0) ∧
+    (∀ᶠ x in 𝓝[>] r, 0 < (p * q).eval x)
+  /-- Consecutive elements have no common real zero. -/
+  consec_coprime : ∀ (i : ℕ) (x : ℝ) (a b : Polynomial ℝ),
+    chain[i]? = some a → chain[i + 1]? = some b → a.eval x = 0 → b.eval x ≠ 0
+  /-- Whenever the interior element `b = chain[i+1]` vanishes at `x`, its two
+  neighbours `a = chain[i]` and `c = chain[i+2]` are nonzero there and have
+  opposite signs. -/
+  interior_alternates : ∀ (i : ℕ) (x : ℝ) (a b c : Polynomial ℝ),
+    chain[i]? = some a → chain[i + 1]? = some b → chain[i + 2]? = some c →
+    b.eval x = 0 → a.eval x ≠ 0 ∧ c.eval x ≠ 0 ∧ a.eval x * c.eval x < 0
+  /-- The last element of the chain has no real zero. -/
+  last_no_root : ∀ q : Polynomial ℝ, chain.getLast? = some q → ∀ x : ℝ, q.eval x ≠ 0
+
+end Sturm

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -60,7 +60,7 @@ and the intermediate value theorem (`intermediate_value_Icc`): a sign change
 would force a zero. The list of evaluation signs is therefore the same at `a`
 and `b`, so `signVariations` — which depends only on those signs — agrees. -/
 theorem sturmVar_const_of_no_zero (_hchain : IsSturmChain p chain)
-    (a b : ℝ)
+    (a b : ℝ) (_hab : a ≤ b)
     (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
     sturmVar chain a = sturmVar chain b := by
   sorry
@@ -74,11 +74,14 @@ and `[r, b]`. At `r` the vanishing interior elements sit between neighbours of
 opposite sign (`IsSturmChain.interior_alternates`), so each contributes exactly
 one variation both immediately before and immediately after `r` regardless of
 the sign it passes through, and the head pair (involving `p`, nonzero near `r`)
-is unaffected. Hence the count at `a`, at `r`, and at `b` coincide. -/
+is unaffected. Hence the count at `a`, at `r`, and at `b` coincide. The value
+at `r` itself is part of the statement because the global theorem places no
+restriction on its endpoints, so a telescoping step may need the count exactly
+at an interior-element zero. -/
 theorem sturmVar_interior_cross (_hchain : IsSturmChain p chain) (r : ℝ)
     (_hpr : ¬ p.IsRoot r) (a b : ℝ) (_har : a < r) (_hrb : r < b)
     (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0) :
-    sturmVar chain a = sturmVar chain b := by
+    sturmVar chain a = sturmVar chain r ∧ sturmVar chain r = sturmVar chain b := by
   sorry
 
 /-- **Simple-zero crossing of `p` drops `sturmVar` by one, registering at `r`.**

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRootsMathlib.SturmChainDefs
+
+public section
+
+/-!
+Sturm's theorem over `Polynomial ℝ`, stated as the five-step chain of the
+SPEC. Everything here is a slice over `Polynomial ℝ` with no `HexRealRoots`
+dependence.
+
+The three local lemmas (`sturmVar_const_of_no_zero`, `sturmVar_interior_cross`,
+`sturmVar_root_cross`) describe the behaviour of `Sturm.sturmVar` across the
+finitely many zeros of the chain elements. The two global results
+(`sturm_half_open`, `sturm_line`) are the telescoping consequences: the number
+of real roots of `p` in a half-open interval `(a, b]` is the drop in
+`sturmVar` from `a` to `b`, and the total number of real roots is the drop
+from `−∞` to `+∞`.
+
+The theorem bodies are `sorry` in this scaffold PR; each carries the intended
+proof sketch from the SPEC. They are discharged by the follow-up PRs M2–M5.
+The `±∞` variation counts `Sturm.sturmVarNegInf` / `Sturm.sturmVarPosInf` are
+defined here as real definitions (no `sorry`), reading the sign of each chain
+element at infinity off its leading coefficient and degree parity.
+-/
+
+open Filter Topology
+
+namespace Sturm
+
+/-- Sign variations of the chain at `+∞`: the sign of each element there is the
+sign of its leading coefficient, so this is the zero-skipping variation count
+of the leading coefficients. The zero polynomial contributes leading
+coefficient `0`, which the zero-skipping convention drops. -/
+@[expose]
+noncomputable def sturmVarPosInf (chain : List (Polynomial ℝ)) : ℕ :=
+  signVariations (chain.map Polynomial.leadingCoeff)
+
+/-- Sign variations of the chain at `−∞`: the sign of an element there is the
+sign of its leading coefficient times `(-1) ^ degree`, so this is the
+zero-skipping variation count of `leadingCoeff · (-1) ^ natDegree`. -/
+@[expose]
+noncomputable def sturmVarNegInf (chain : List (Polynomial ℝ)) : ℕ :=
+  signVariations (chain.map (fun q => q.leadingCoeff * (-1) ^ q.natDegree))
+
+variable {p : Polynomial ℝ} {chain : List (Polynomial ℝ)}
+
+/-- **Local constancy.** On a closed interval `[a, b]` containing no zero of
+any chain element, `sturmVar` takes the same value at the two endpoints.
+
+Proof sketch (SPEC step 1): each element keeps a constant nonzero sign across
+`[a, b]` by continuity of polynomial evaluation (`Polynomial.continuous_aeval`)
+and the intermediate value theorem (`intermediate_value_Icc`): a sign change
+would force a zero. The list of evaluation signs is therefore the same at `a`
+and `b`, so `signVariations` — which depends only on those signs — agrees. -/
+theorem sturmVar_const_of_no_zero (_hchain : IsSturmChain p chain)
+    (a b : ℝ)
+    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
+    sturmVar chain a = sturmVar chain b := by
+  sorry
+
+/-- **Interior-element crossing preserves `sturmVar`.** If `r` is not a root of
+`p` and the only chain zeros in `[a, b]` occur at `r` (necessarily zeros of
+interior elements), then `sturmVar` is unchanged from `a` to `b`.
+
+Proof sketch (SPEC step 2): away from `r` local constancy applies on `[a, r]`
+and `[r, b]`. At `r` the vanishing interior elements sit between neighbours of
+opposite sign (`IsSturmChain.interior_alternates`), so each contributes exactly
+one variation both immediately before and immediately after `r` regardless of
+the sign it passes through, and the head pair (involving `p`, nonzero near `r`)
+is unaffected. Hence the count at `a`, at `r`, and at `b` coincide. -/
+theorem sturmVar_interior_cross (_hchain : IsSturmChain p chain) (r : ℝ)
+    (_hpr : ¬ p.IsRoot r) (a b : ℝ) (_har : a < r) (_hrb : r < b)
+    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0) :
+    sturmVar chain a = sturmVar chain b := by
+  sorry
+
+/-- **Simple-zero crossing of `p` drops `sturmVar` by one, registering at `r`.**
+If `r` is a (simple, by squarefreeness) root of `p` and the only chain zeros in
+`[a, b]` occur at `r`, then `sturmVar` at `a` exceeds the value at `b` by
+exactly one, and the drop has already registered at `r`: the value at `r`
+equals the value at `b`.
+
+Proof sketch (SPEC step 3): the head pair `(p, q)` with `q = chain[1]` has
+`p * q < 0` just left of `r` and `p * q > 0` just right (`root_flank`), so this
+pair contributes one variation for `x < r` and none for `x ≥ r`; with the
+zero-skipping convention the zero of `p` at `r` is dropped, so the change
+registers at `r` itself. All interior crossings at `r` are variation-neutral by
+step 2, and away from `r` `sturmVar` is locally constant by step 1. The
+half-open registration is the one design-sensitive point: it is what makes the
+executable half-open counts match with no endpoint hypotheses. -/
+theorem sturmVar_root_cross (_hp : p ≠ 0) (_hsf : Squarefree p)
+    (_hchain : IsSturmChain p chain) (r : ℝ) (_hr : p.IsRoot r)
+    (a b : ℝ) (_har : a < r) (_hrb : r < b)
+    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0)
+    (_hpz : ∀ x ∈ Set.Icc a b, x ≠ r → ¬ p.IsRoot x) :
+    sturmVar chain a = sturmVar chain b + 1 ∧ sturmVar chain r = sturmVar chain b := by
+  sorry
+
+/-- **Sturm's theorem, half-open form.** For `p ≠ 0` squarefree with a
+generalised Sturm chain, the drop in `sturmVar` from `a` to `b` equals the
+number of real roots of `p` in the half-open interval `(a, b]`, counted as the
+cardinality of the corresponding filtered submultiset of `p.roots`.
+
+Proof sketch (SPEC step 4): telescope steps 1–3 over the finitely many zeros of
+the chain elements in `(a, b]`. Zeros of interior elements are variation-neutral
+(step 2); each root of `p` drops the count by exactly one and registers at the
+root under the half-open convention (step 3); between consecutive chain zeros
+`sturmVar` is constant (step 1). The signed total is therefore the number of
+roots of `p` in `(a, b]`. -/
+theorem sturm_half_open (_hp : p ≠ 0) (_hsf : Squarefree p)
+    (_hchain : IsSturmChain p chain) {a b : ℝ} (_hab : a < b) :
+    (sturmVar chain a : ℤ) - sturmVar chain b =
+      (p.roots.filter (fun r => a < r ∧ r ≤ b)).card := by
+  sorry
+
+/-- **Sturm's theorem, line form.** For `p ≠ 0` squarefree with a generalised
+Sturm chain, the total number of real roots of `p` equals the drop in `sturmVar`
+from `−∞` to `+∞`.
+
+Proof sketch (SPEC step 5): take `a` below and `b` above every real root
+(e.g. beyond a Cauchy bound). Then `sturmVar chain a = sturmVarNegInf chain` and
+`sturmVar chain b = sturmVarPosInf chain`, because each chain element has
+constant sign past its largest real zero equal to its sign at the corresponding
+infinity, and `(a, b]` contains every real root. Apply `sturm_half_open`; the
+filtered multiset is all of `p.roots`. -/
+theorem sturm_line (_hp : p ≠ 0) (_hsf : Squarefree p)
+    (_hchain : IsSturmChain p chain) :
+    (sturmVarNegInf chain : ℤ) - sturmVarPosInf chain = p.roots.card := by
+  sorry
+
+end Sturm

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -176,6 +176,9 @@ lean_lib HexGramSchmidtMathlib where
 @[default_target]
 lean_lib HexLLLMathlib where
 
+@[default_target]
+lean_lib HexRealRootsMathlib where
+
 lean_exe hexlll_provider_probe where
   root := `HexLLL.ProviderProbe
 

--- a/libraries.yml
+++ b/libraries.yml
@@ -489,7 +489,7 @@ libraries:
     deps: [HexRealRoots, HexPolyZMathlib]
     mathlib: true
     done_through: 0
-    status: planned
+    status: active
   HexRCF:
     deps: [HexRealRoots, HexRealRootsMathlib, HexPolyZ, HexPolyZMathlib]
     mathlib: true


### PR DESCRIPTION
This PR scaffolds the self-contained Sturm's-theorem slice of HexRealRootsMathlib per SPEC/Libraries/hex-real-roots-mathlib.md: the zero-skipping sign-variation count `Sturm.sturmVar`, the `Sturm.IsSturmChain` predicate packaging the sign axioms the counting argument uses, and the variation counts at plus/minus infinity read off leading coefficients and degree parities, all as real sorry-free definitions with basic API lemmas. The five-step theorem chain (local constancy, interior-element crossing, simple-zero crossing, the half-open counting theorem, and the line form) is stated with `sorry` bodies carrying the SPEC proof sketches; follow-up PRs discharge them. Nothing here references any HexRealRoots executable type, so the slice is upstreamable to Mathlib once exercised. It also activates `HexRealRootsMathlib` in libraries.yml, adds its lean_lib stanza, and wires it into the CI build targets. A Codex review tightened three statements before this PR opened: an interval-orientation hypothesis on local constancy (the statement was false for reversed endpoints via the vacuous Icc), the count at the crossing point itself in the interior-crossing lemma, and a nonzero-elements field on `IsSturmChain` so the counting telescope is finite.

🤖 Prepared with Claude Code
