### PR TITLE
feat(hex-roots): activate library, dyadic geometry and Gaussian-dyadic core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
       # fresh against the restored libs, which is cheap.
       - name: Define the hex-dev cache + build target sets
         run: |
-          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib" >> "$GITHUB_ENV"
+          echo "HEX_LIB_TARGETS=HexBasic HexArith HexPoly HexModArith HexGF2 HexPolyZ HexRoots HexPolyFp HexGFqRing HexGFqField HexBerlekamp HexHensel HexConway HexGFq HexBerlekampZassenhaus HexRealRoots HexMatrix HexRowReduce HexDeterminant HexBareiss HexGramSchmidt HexLLL HexMatrixMathlib HexGramSchmidtMathlib HexLLLMathlib HexBerlekampZassenhausMathlib HexRealRootsMathlib" >> "$GITHUB_ENV"
           echo "HEX_EXE_TARGETS=hexarith_bench hexpoly_bench hexpolyz_bench hexpolyfp_bench hexmodarith_bench hexgf2_bench hexgfqring_bench hexgfqfield_bench hexgfq_bench hexhensel_bench hexberlekamp_bench hexbz_bench hexconway_bench hexmatrix_bench hexdeterminant_bench hexbareiss_bench hexgramschmidt_bench hexlll_bench hexlll_provider_probe" >> "$GITHUB_ENV"
       # Shared build. The libraries, bench exes, conformance #guard drivers, and
       # emit-fixture exes are all elaborated here so the two verification tails

--- a/HexRoots.lean
+++ b/HexRoots.lean
@@ -14,7 +14,7 @@ public section
 The `HexRoots` library certifies the isolation of the complex roots of
 integer-coefficient polynomials. A root isolation is a square in the
 complex plane with Gaussian-dyadic centre and power-of-two half-width,
-carrying a witness — dischargeable by `decide` — that a certified region
+carrying a witness, dischargeable by `decide`, that a certified region
 around the square contains exactly one simple root (an *atom*) or exactly
 `k` roots counted with multiplicity (a *cluster*). All witness arithmetic
 is exact: Gaussian-dyadic Taylor coefficients compared against dyadic

--- a/HexRoots.lean
+++ b/HexRoots.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Basic
+
+public section
+
+/-!
+The `HexRoots` library certifies the isolation of the complex roots of
+integer-coefficient polynomials. A root isolation is a square in the
+complex plane with Gaussian-dyadic centre and power-of-two half-width,
+carrying a witness — dischargeable by `decide` — that a certified region
+around the square contains exactly one simple root (an *atom*) or exactly
+`k` roots counted with multiplicity (a *cluster*). All witness arithmetic
+is exact: Gaussian-dyadic Taylor coefficients compared against dyadic
+bounds, with no floats and no error budget.
+
+This is the Mathlib-free computational layer; the correctness and
+completeness theorems live in the companion `HexRootsMathlib`.
+-/

--- a/HexRoots/Basic.lean
+++ b/HexRoots/Basic.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexPolyZ
+
+public section
+
+/-!
+Basic data for complex root isolation: the dyadic-square geometry the
+subdivision algorithm works on, the Gaussian-dyadic arithmetic its
+witnesses are built from, and the small dyadic helpers (`abs`, `min`,
+`max`, ceiling base-2 logarithms) the rest of the library uses.
+
+A `DyadicSquare` is an axis-aligned square in the complex plane with a
+Gaussian-dyadic centre and power-of-two half-width `2^{−prec}`; its
+circumscribed disc has radius `2^{−prec}·√2`. `GaussDyadic` is `ℤ[i]`
+extended to dyadic coefficients: exact centres, exact Taylor
+coefficients, exact witness comparisons. `encSquare` computes the
+smallest power-of-two square containing a component of squares, and
+`HasOnlySimpleRoots` decides squarefreeness over `ℚ[x]`.
+
+Every value here is exact — dyadic comparisons and integer counts, no
+floats and no error budget. `Dyadic` comes from Lean core
+(`Init.Data.Dyadic`); the helpers below live in namespace `Hex` (and
+`Hex.Dyadic`) so they never shadow the core `Dyadic` API, and must be
+called fully qualified. All data-level defs are `@[expose]` so kernel
+`decide` reduces the witnesses across module boundaries.
+-/
+namespace Hex
+
+/-! ### Dyadic helpers
+
+`Dyadic` in Lean core carries no `abs`/`min`/`max`; these supply them.
+They are placed in namespace `Hex.Dyadic`, so `Hex.Dyadic.abs` etc.
+name them; a bare `Dyadic.abs` on a term would instead try (and fail)
+to resolve against the core `Dyadic` namespace by dot notation. -/
+
+/-- Absolute value of a dyadic number. -/
+@[expose] def Dyadic.abs (x : Dyadic) : Dyadic := if x < 0 then -x else x
+
+/-- The larger of two dyadic numbers. -/
+@[expose] def Dyadic.max (x y : Dyadic) : Dyadic := if x ≤ y then y else x
+
+/-- The smaller of two dyadic numbers. -/
+@[expose] def Dyadic.min (x y : Dyadic) : Dyadic := if x ≤ y then x else y
+
+/-- Smallest `t` with `n ≤ 2^t` (junk `0` for `n ≤ 1`). -/
+@[expose] def ceilLog2 (n : Nat) : Nat := if n ≤ 1 then 0 else (n - 1).log2 + 1
+
+/-- For `x > 0`: smallest `t : Int` with `x ≤ 2^t`; junk `0` for `x ≤ 0`.
+    For `x = n·2^{−k}` with odd `n > 0`: `ceilLog2 n − k`. -/
+@[expose] def Dyadic.ceilLog2 : Dyadic → Int
+  | .zero => 0
+  | .ofOdd n k _ => if n < 0 then 0 else (Hex.ceilLog2 n.toNat : Int) - k
+
+/-! ### Gaussian dyadics
+
+`GaussDyadic` is a pair `(re, im)` of dyadic numbers standing for the
+Gaussian-dyadic number `re + im·i`. It carries no typeclass instances:
+declaring, say, `Add (Dyadic × Dyadic)` would leak componentwise
+addition onto every `Dyadic × Dyadic` pair in the codebase. The
+operations below are therefore named functions in the `GaussDyadic`
+namespace. -/
+
+/-- A Gaussian dyadic number `re + im·i`, represented as the pair
+    `(re, im)`. -/
+abbrev GaussDyadic := Dyadic × Dyadic
+
+namespace GaussDyadic
+
+/-- The Gaussian dyadic `i + 0·i` for an integer `i`. -/
+@[expose] def ofInt (i : Int) : GaussDyadic := (Dyadic.ofInt i, 0)
+
+/-- Sum of two Gaussian dyadics, `(a+bi) + (c+di) = (a+c) + (b+d)i`. -/
+@[expose] def add (z w : GaussDyadic) : GaussDyadic := (z.1 + w.1, z.2 + w.2)
+
+/-- Difference of two Gaussian dyadics, `(a+bi) − (c+di) = (a−c) + (b−d)i`. -/
+@[expose] def sub (z w : GaussDyadic) : GaussDyadic := (z.1 - w.1, z.2 - w.2)
+
+/-- Complex conjugate `a − b·i` of `a + b·i`. -/
+@[expose] def conj (z : GaussDyadic) : GaussDyadic := (z.1, -z.2)
+
+/-- Product of two Gaussian dyadics,
+    `(a+bi)(c+di) = (ac − bd) + (ad + bc)i`. -/
+@[expose] def mul (z w : GaussDyadic) : GaussDyadic :=
+  (z.1 * w.1 - z.2 * w.2, z.1 * w.2 + z.2 * w.1)
+
+/-- The squared modulus `a² + b²` of `a + b·i`, an exact dyadic. -/
+@[expose] def normSq (z : GaussDyadic) : Dyadic := z.1 * z.1 + z.2 * z.2
+
+/-- The squared distance `|z − w|²` between two Gaussian dyadics, an
+    exact dyadic. -/
+@[expose] def distSq (z w : GaussDyadic) : Dyadic := normSq (sub z w)
+
+end GaussDyadic
+
+/-! ### Dyadic squares
+
+A `DyadicSquare` is the closed axis-aligned square centred at
+`re + im·i` with half-width `2^{−prec}`. Its circumscribed disc — the
+region the Pellet tests run on — has radius `2^{−prec}·√2`. `prec` is an
+`Int`: the initial Cauchy-bound square has `prec` negative whenever the
+root bound exceeds 1. -/
+
+/-- A closed axis-aligned dyadic square in the complex plane: centre
+    `re + im·i`, half-width `2^{−prec}`, circumscribed disc radius
+    `2^{−prec}·√2`. -/
+structure DyadicSquare where
+  /-- Real part of the centre. -/
+  re : Dyadic
+  /-- Imaginary part of the centre. -/
+  im : Dyadic
+  /-- Base-2 exponent of the half-width `2^{−prec}`. -/
+  prec : Int
+deriving DecidableEq
+
+/-- The Gaussian-dyadic centre `re + im·i` of the square. -/
+@[expose] def DyadicSquare.center (s : DyadicSquare) : GaussDyadic := (s.re, s.im)
+
+/-- The half-width `2^{−prec}` of the square, an exact dyadic. -/
+@[expose] def DyadicSquare.halfWidth (s : DyadicSquare) : Dyadic := .ofIntWithPrec 1 s.prec
+
+/-- The circumscribed discs of `s` and `t` intersect (closed discs):
+    `distSq centres ≤ (r_s + r_t)²` with `r = √2·2^{−prec}`, so
+    `(r_s + r_t)² = 2·4^{−p_s} + 2·4^{−p_t} + 4·2^{−p_s−p_t}`, all exact dyadics. -/
+@[expose] def DyadicSquare.discsMeet (s t : DyadicSquare) : Bool :=
+  let a : Dyadic := .ofIntWithPrec 1 (2 * s.prec)      -- 4^{−p_s}
+  let b : Dyadic := .ofIntWithPrec 1 (2 * t.prec)      -- 4^{−p_t}
+  let c : Dyadic := .ofIntWithPrec 1 (s.prec + t.prec) -- 2^{−p_s−p_t}
+  let rhs : Dyadic := (2 : Dyadic) * a + (2 : Dyadic) * b + (4 : Dyadic) * c
+  decide (GaussDyadic.distSq s.center t.center ≤ rhs)
+
+/-- `inner`'s circumscribed disc is contained in `outer`'s:
+    `r_i ≤ r_o` (i.e. `outer.prec ≤ inner.prec`) and
+    `distSq centres ≤ (r_o − r_i)² = 2·4^{−p_o} + 2·4^{−p_i} − 4·2^{−p_o−p_i}`. -/
+@[expose] def DyadicSquare.discInside (inner outer : DyadicSquare) : Bool :=
+  let a : Dyadic := .ofIntWithPrec 1 (2 * outer.prec)          -- 4^{−p_o}
+  let b : Dyadic := .ofIntWithPrec 1 (2 * inner.prec)          -- 4^{−p_i}
+  let c : Dyadic := .ofIntWithPrec 1 (outer.prec + inner.prec) -- 2^{−p_o−p_i}
+  let rhs : Dyadic := (2 : Dyadic) * a + (2 : Dyadic) * b - (4 : Dyadic) * c
+  decide (outer.prec ≤ inner.prec ∧ GaussDyadic.distSq inner.center outer.center ≤ rhs)
+
+/-- `inner`'s closed square is contained in `outer`'s closed square:
+    `max |Δre| |Δim| + 2^{−p_i} ≤ 2^{−p_o}` (exact dyadics). -/
+@[expose] def DyadicSquare.squareInside (inner outer : DyadicSquare) : Bool :=
+  let dre : Dyadic := Hex.Dyadic.abs (inner.re - outer.re)
+  let dim : Dyadic := Hex.Dyadic.abs (inner.im - outer.im)
+  decide (Hex.Dyadic.max dre dim + inner.halfWidth ≤ outer.halfWidth)
+
+/-! ### Enclosing squares, balls, and components -/
+
+/-- A complex ball with dyadic data, the output type of numerical
+    evaluation here and in `hex-number-field`. -/
+structure DyadicComplexBall where
+  /-- Real part of the centre. -/
+  re     : Dyadic
+  /-- Imaginary part of the centre. -/
+  im     : Dyadic
+  /-- Radius of the ball. -/
+  radius : Dyadic
+
+/-- An uncertified component in the refinement worklist: an
+    edge-connected set of grid squares at a common `prec`, plus the root
+    count of its most recently certified ancestor. `candidateK` only
+    selects the order of the speculative Newton step; it is never
+    trusted, since every output is re-certified. -/
+structure Component where
+  /-- The component's grid squares: nonempty, common `prec`,
+      edge-connected. -/
+  squares    : Array DyadicSquare
+  /-- Root count carried from the most recently certified ancestor;
+      an untrusted hint for step ordering. -/
+  candidateK : Nat
+
+/-- The smallest square with power-of-two half-width, centred at the
+    bounding-box centre, containing every square. Junk `⟨0,0,0⟩` on the
+    empty array (callers keep components nonempty).
+
+    Each square contributes its own half-width to the bounding box
+    (robust to mixed `prec`), the centre is the exact midpoint of the
+    box (a right shift by one bit), and the result `prec` is chosen so
+    that its half-width `2^{−q}` is the smallest power of two at least
+    the box half-width. On a single square input this returns that
+    square exactly. -/
+@[expose] def encSquare (squares : Array DyadicSquare) : DyadicSquare :=
+  let box : Option (Dyadic × Dyadic × Dyadic × Dyadic) :=
+    squares.foldl (init := none) fun acc s =>
+      let hw := s.halfWidth
+      let xlo := s.re - hw; let xhi := s.re + hw
+      let ylo := s.im - hw; let yhi := s.im + hw
+      match acc with
+      | none => some (xlo, xhi, ylo, yhi)
+      | some (xmin, xmax, ymin, ymax) =>
+          some (Hex.Dyadic.min xmin xlo, Hex.Dyadic.max xmax xhi,
+                Hex.Dyadic.min ymin ylo, Hex.Dyadic.max ymax yhi)
+  match box with
+  | none => ⟨0, 0, 0⟩
+  | some (xmin, xmax, ymin, ymax) =>
+      let cx := (xmin + xmax) >>> (1 : Int)
+      let cy := (ymin + ymax) >>> (1 : Int)
+      let w := Hex.Dyadic.max ((xmax - xmin) >>> (1 : Int)) ((ymax - ymin) >>> (1 : Int))
+      let q := -(Hex.Dyadic.ceilLog2 w)
+      ⟨cx, cy, q⟩
+
+/-! ### Squarefreeness -/
+
+/-- `p` has only simple complex roots: the executable rational gcd of
+    `p` and `p'` is constant. Defeq to `ZPoly.SquareFreeRat`; the
+    companion relates it to `Squarefree` (for `p ≠ 0`). -/
+@[expose] def HasOnlySimpleRoots (p : ZPoly) : Prop := ZPoly.SquareFreeRat p
+
+instance (p : ZPoly) : Decidable (HasOnlySimpleRoots p) :=
+  inferInstanceAs
+    (Decidable ((DensePoly.gcd (ZPoly.toRatPoly p)
+      (DensePoly.derivative (ZPoly.toRatPoly p))).size ≤ 1))
+
+end Hex

--- a/HexRoots/Basic.lean
+++ b/HexRoots/Basic.lean
@@ -24,7 +24,7 @@ coefficients, exact witness comparisons. `encSquare` computes the
 smallest power-of-two square containing a component of squares, and
 `HasOnlySimpleRoots` decides squarefreeness over `ℚ[x]`.
 
-Every value here is exact — dyadic comparisons and integer counts, no
+Every value here is exact: dyadic comparisons and integer counts, no
 floats and no error budget. `Dyadic` comes from Lean core
 (`Init.Data.Dyadic`); the helpers below live in namespace `Hex` (and
 `Hex.Dyadic`) so they never shadow the core `Dyadic` API, and must be
@@ -102,8 +102,8 @@ end GaussDyadic
 /-! ### Dyadic squares
 
 A `DyadicSquare` is the closed axis-aligned square centred at
-`re + im·i` with half-width `2^{−prec}`. Its circumscribed disc — the
-region the Pellet tests run on — has radius `2^{−prec}·√2`. `prec` is an
+`re + im·i` with half-width `2^{−prec}`. Its circumscribed disc (the
+region the Pellet tests run on) has radius `2^{−prec}·√2`. `prec` is an
 `Int`: the initial Cauchy-bound square has `prec` negative whenever the
 root bound exceeds 1. -/
 

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -416,7 +416,7 @@ certifies the pinned value (or shows a smaller one suffices). A
 `none` from the drivers has one precise meaning: *no certificate the
 selected strategy attempts appeared by separation depth*. The
 Mathlib companion's completeness development
-([hex-roots-mathlib.md](hex-roots-mathlib.md)) is expected to prove
+([hex-roots-mathlib.md](../../SPEC/Libraries/hex-roots-mathlib.md)) is expected to prove
 this impossible for squarefree inputs, for each strategy it covers
 (the Pellet converse for strategies that attempt Pellet, the
 Newton-Kantorovich converse for `.nk`). Until it does, the soundness
@@ -493,7 +493,7 @@ Mahler bound concerns *distinct* roots, so `mahlerPrec` is meaningful
 even for non-squarefree `p`: if `p_sf` is the squarefree part then
 `M(p_sf) ≤ M(p)` and `|disc p_sf| ≥ 1`, so the same closed form
 applies. The Mathlib companion proves correctness; see
-[hex-roots-mathlib.md](hex-roots-mathlib.md).
+[hex-roots-mathlib.md](../../SPEC/Libraries/hex-roots-mathlib.md).
 
 ```lean
 def separationDepth (p : ZPoly) : Nat :=
@@ -661,7 +661,7 @@ inherit the precision.
 
 ## Conformance fixtures
 
-Per [SPEC/testing.md](../testing.md), fixtures are tiered into
+Per [SPEC/testing.md](../../SPEC/testing.md), fixtures are tiered into
 `core` / `ci` / `local`. Deterministic adversarial families matter
 more than random samples here, because random small-coefficient
 polynomials rarely have clustered roots.
@@ -689,7 +689,7 @@ External oracles. The ci-tier oracle is **python-flint**
 (`fmpz_poly.complex_roots()`, which returns certified Arb balls with
 multiplicities); it is already in the CI dependency set, consistent
 with the standing oracle doctrine in
-[SPEC/testing.md](../testing.md), and FLINT 3 subsumes Arb, so this
+[SPEC/testing.md](../../SPEC/testing.md), and FLINT 3 subsumes Arb, so this
 is also the "FLINT/Arb" role. MPSolve is the local-tier comparator
 and the Phase-4 external performance comparator; it is not wired
 into merge-facing CI. SageMath is not used (per SPEC/testing.md's

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -93,6 +93,8 @@ lean_lib HexGF2 where
 
 lean_lib HexPolyZ where
 
+lean_lib HexRoots where
+
 lean_lib HexPolyFp where
 
 lean_lib HexGFqRing where

--- a/libraries.yml
+++ b/libraries.yml
@@ -454,7 +454,7 @@ libraries:
     deps: [HexPolyZ]
     mathlib: false
     done_through: 0
-    status: planned
+    status: active
   HexRootsMathlib:
     deps: [HexRoots, HexPolyZMathlib]
     mathlib: true

--- a/progress/20260711T121014Z.md
+++ b/progress/20260711T121014Z.md
@@ -1,0 +1,21 @@
+# HexRoots PR review
+
+**Accomplished**
+
+- Reviewed the proposed first HexRoots work unit against `SPEC/Libraries/hex-roots.md`.
+- Checked the dyadic square geometry formulas for `encSquare`, disc intersection, disc containment, square containment, and `Dyadic.ceilLog2`.
+- Ran focused Lean probes for `Dyadic.ofIntWithPrec`, dyadic shifts, singleton and mixed-precision `encSquare`, representative disc predicates, and kernel `decide` reduction on the proposed definitions.
+- Checked current repository wiring conventions for `lakefile.lean`, `libraries.yml`, `.github/workflows/ci.yml`, and SPEC path handling.
+
+**Current frontier**
+
+- No concrete correctness bug was found in the reviewed diff.
+- The current checkout does not contain the PR files; the review used the provided diff plus temporary Lean stdin probes.
+
+**Next step**
+
+- If the PR branch is checked out locally, run `lake build HexRoots`, `python3 scripts/check_dag.py`, and `python3 scripts/status.py HexRoots` on the actual tree.
+
+**Blockers**
+
+- None for this review.


### PR DESCRIPTION
This PR activates the Mathlib-free `HexRoots` library (certified complex root isolation, depends on `hex-poly-z`) and scaffolds `HexRoots/Basic.lean`: the dyadic-square geometry the BSSY subdivision operates on (`DyadicSquare` with its circumscribed-disc `discsMeet`/`discInside` and closed-square `squareInside` tests), exact Gaussian-dyadic arithmetic (`GaussDyadic` with `ofInt`, `add`, `sub`, `conj`, `mul`, `normSq`, `distSq`), the `DyadicComplexBall` and `Component` records, the enclosing-square constructor `encSquare` (smallest power-of-two square at the bounding-box centre, returning a single square exactly), and the squarefreeness predicate `HasOnlySimpleRoots` with its `Decidable` instance. All data-level defs are `@[expose]` so the witness comparisons kernel-reduce across module boundaries. Activation flips `libraries.yml` `HexRoots.status` to `active`, adds the `lean_lib HexRoots` entry and the `HexRoots.lean` umbrella, appends `HexRoots` to the CI `HEX_LIB_TARGETS`, and relocates the SPEC into the released per-library layout at `HexRoots/SPEC/hex-roots.md` (fixing the relative links the move breaks). Beyond the SPEC-named declarations it adds small helper defs in namespace `Hex.Dyadic` (`abs`, `min`, `max`, `ceilLog2`) and a `Nat` `ceilLog2`, all called fully qualified so they never shadow the core `Dyadic` API.

One SPEC point does not hold as written: `HasOnlySimpleRoots` is `Decidable` and evaluates correctly under compiled `#eval` (true/true/false on the three sanity cases), but it is not kernel-reducible, so `by decide` cannot discharge it. Its SPEC-mandated implementation routes through `ZPoly.toRatPoly` and a gcd over `ℚ[x]`, and `Rat` normalization uses `Nat.gcd` (well-founded recursion), which the kernel does not unfold under `decide` — even `.size` of a Rat-cast polynomial gets stuck. The def follows the SPEC exactly; only the `by decide` sanity-check expectation for that one predicate is unachievable. Every dyadic/geometry sanity check discharges by `decide` as specified. A kernel-reducible reformulation (or a companion lemma) for discharging `HasOnlySimpleRoots` hypotheses is left to a follow-up.

🤖 Prepared with Claude Code