### PR TITLE
feat: prove the local lemmas of Sturm's theorem

### DIFF
--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -86,6 +86,56 @@ theorem sturmVar_cons_zero {q : Polynomial ℝ} {x : ℝ} (h : q.eval x = 0)
     sturmVar (q :: chain) x = sturmVar chain x := by
   simp [sturmVar, List.map_cons, signVariations, h]
 
+/-- Two real lists whose entries have pointwise equal signs have equal
+`countSignChanges`: the sign-change count reads only the signs of the entries. -/
+theorem countSignChanges_congr {l₁ l₂ : List ℝ}
+    (h : List.Forall₂ (fun u v => SignType.sign u = SignType.sign v) l₁ l₂) :
+    countSignChanges l₁ = countSignChanges l₂ := by
+  induction h with
+  | nil => rfl
+  | @cons a b l₁' l₂' hab htail ih =>
+    cases htail with
+    | nil => rfl
+    | @cons c d l₁'' l₂'' hcd _ =>
+      rw [countSignChanges_cons_cons, countSignChanges_cons_cons]
+      have hiff : (a * c < 0) ↔ (b * d < 0) := by
+        rw [← sign_eq_neg_one_iff, ← sign_eq_neg_one_iff, sign_mul, sign_mul, hab, hcd]
+      by_cases hc : a * c < 0
+      · rw [if_pos hc, if_pos (hiff.mp hc), ih]
+      · rw [if_neg hc, if_neg (fun h => hc (hiff.mpr h)), ih]
+
+/-- Dropping the zero entries commutes with a pointwise sign-equal
+correspondence: the filtered lists remain pointwise sign-equal. -/
+theorem filter_ne_zero_congr {l₁ l₂ : List ℝ}
+    (h : List.Forall₂ (fun u v => SignType.sign u = SignType.sign v) l₁ l₂) :
+    List.Forall₂ (fun u v => SignType.sign u = SignType.sign v)
+      (l₁.filter (fun v => decide (v ≠ 0))) (l₂.filter (fun v => decide (v ≠ 0))) := by
+  induction h with
+  | nil => exact List.Forall₂.nil
+  | @cons a b l₁' l₂' hab htail ih =>
+    have hzero : (a = 0) ↔ (b = 0) := by
+      rw [← sign_eq_zero_iff (a := a), ← sign_eq_zero_iff (a := b), hab]
+    by_cases ha : a = 0
+    · have hb : b = 0 := hzero.mp ha
+      have e1 : (a :: l₁').filter (fun v => decide (v ≠ 0))
+          = l₁'.filter (fun v => decide (v ≠ 0)) := by rw [List.filter_cons]; simp [ha]
+      have e2 : (b :: l₂').filter (fun v => decide (v ≠ 0))
+          = l₂'.filter (fun v => decide (v ≠ 0)) := by rw [List.filter_cons]; simp [hb]
+      rw [e1, e2]; exact ih
+    · have hb : b ≠ 0 := fun h => ha (hzero.mpr h)
+      have e1 : (a :: l₁').filter (fun v => decide (v ≠ 0))
+          = a :: l₁'.filter (fun v => decide (v ≠ 0)) := by rw [List.filter_cons]; simp [ha]
+      have e2 : (b :: l₂').filter (fun v => decide (v ≠ 0))
+          = b :: l₂'.filter (fun v => decide (v ≠ 0)) := by rw [List.filter_cons]; simp [hb]
+      rw [e1, e2]; exact List.Forall₂.cons hab ih
+
+/-- `signVariations` reads only the signs of the entries: two real lists whose
+entries are pointwise sign-equal have equal sign variations. -/
+theorem signVariations_congr {l₁ l₂ : List ℝ}
+    (h : List.Forall₂ (fun u v => SignType.sign u = SignType.sign v) l₁ l₂) :
+    signVariations l₁ = signVariations l₂ :=
+  countSignChanges_congr (filter_ne_zero_congr h)
+
 /-- A generalised Sturm chain for `p`: the sign axioms that the counting
 argument actually uses, packaged as explicit fields. The chain is stored as
 a plain `List (Polynomial ℝ)` and elements are addressed by index through

--- a/HexRealRootsMathlib/SturmChainDefs.lean
+++ b/HexRealRootsMathlib/SturmChainDefs.lean
@@ -136,6 +136,103 @@ theorem signVariations_congr {l₁ l₂ : List ℝ}
     signVariations l₁ = signVariations l₂ :=
   countSignChanges_congr (filter_ne_zero_congr h)
 
+/-- The sign of the first surviving (nonzero) entry of a real list, as an
+`Option SignType`: `none` when every entry is zero. This is the piece of local
+state that governs how prepending a nonzero entry changes `signVariations`. -/
+@[expose]
+noncomputable def firstSign (l : List ℝ) : Option SignType :=
+  (l.filter (fun v => decide (v ≠ 0))).head?.map (fun a => SignType.sign a)
+
+@[simp] theorem firstSign_nil : firstSign [] = none := rfl
+
+theorem firstSign_cons_zero {a : ℝ} (l : List ℝ) (ha : a = 0) :
+    firstSign (a :: l) = firstSign l := by
+  unfold firstSign; rw [List.filter_cons_of_neg (by simp [ha])]
+
+theorem firstSign_cons_ne {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
+    firstSign (a :: l) = some (SignType.sign a) := by
+  unfold firstSign
+  rw [List.filter_cons_of_pos (by simp [ha]), List.head?_cons, Option.map_some]
+
+private theorem sign_mul_eq_neg_one {a b : ℝ} :
+    (SignType.sign a * SignType.sign b = -1) ↔ a * b < 0 := by
+  rw [← sign_mul, sign_eq_neg_one_iff]
+
+/-- Prepending a nonzero entry `a` adds one variation exactly when its sign is
+opposite the sign of the next surviving entry. -/
+theorem signVariations_cons_pos {a : ℝ} (l : List ℝ) (ha : a ≠ 0) :
+    signVariations (a :: l) =
+      (firstSign l).elim 0
+        (fun t => if SignType.sign a * t = -1 then 1 else 0) + signVariations l := by
+  induction l with
+  | nil => rw [signVariations_cons_ne a [] ha]; simp [firstSign]
+  | cons b l' ih =>
+    by_cases hb : b = 0
+    · subst hb
+      rw [firstSign_cons_zero l' rfl, signVariations_cons_zero l',
+        signVariations_cons_ne a (0 :: l') ha, List.filter_cons_of_neg (by simp),
+        ← signVariations_cons_ne a l' ha]
+      exact ih
+    · rw [firstSign_cons_ne l' hb, signVariations_cons_ne a (b :: l') ha,
+        List.filter_cons_of_pos (by simp [hb]), countSignChanges_cons_cons,
+        ← signVariations_cons_ne b l' hb]
+      simp only [Option.elim_some]
+      congr 1
+      by_cases hlt : a * b < 0
+      · rw [if_pos hlt, if_pos (sign_mul_eq_neg_one.mpr hlt)]
+      · rw [if_neg hlt, if_neg (fun h => hlt (sign_mul_eq_neg_one.mp h))]
+
+/-- A local sign-pattern relation between two real lists: they agree entry by
+entry except that a nonzero entry flanked by two opposite-sign neighbours may
+collapse to `0`. Such a collapse is variation-neutral, so `signVariations` and
+the leading sign are preserved (`SVRel.signVariations_eq`). -/
+inductive SVRel : List ℝ → List ℝ → Prop
+  | nil : SVRel [] []
+  | same {x y : ℝ} {l m : List ℝ} (hx : x ≠ 0) (hy : y ≠ 0)
+      (hs : SignType.sign x = SignType.sign y) (h : SVRel l m) :
+      SVRel (x :: l) (y :: m)
+  | collapse {x X x' : ℝ} {l m : List ℝ} {y y' : ℝ}
+      (hx : x ≠ 0) (hX : X ≠ 0) (hy' : y' ≠ 0)
+      (hsx : SignType.sign x = SignType.sign x')
+      (hsy : SignType.sign y = SignType.sign y')
+      (hopp : SignType.sign x * SignType.sign y = -1)
+      (h : SVRel (y :: l) (y' :: m)) :
+      SVRel (x :: X :: y :: l) (x' :: 0 :: y' :: m)
+
+private theorem svrel_flank_arith (u v w : SignType) (huw : u * w = -1) (hv : v ≠ 0) :
+    (if u * v = -1 then (1 : ℕ) else 0) + (if v * w = -1 then 1 else 0) = 1 := by
+  revert huw hv; revert u v w; decide
+
+/-- The core combinatorial fact: an `SVRel`-related pair of lists has equal
+sign variations and equal leading sign. -/
+theorem SVRel.signVariations_eq {L M : List ℝ} (h : SVRel L M) :
+    signVariations L = signVariations M ∧ firstSign L = firstSign M := by
+  induction h with
+  | nil => exact ⟨rfl, rfl⟩
+  | @same x y l m hx hy hs h ih =>
+    refine ⟨?_, ?_⟩
+    · rw [signVariations_cons_pos l hx, signVariations_cons_pos m hy, ih.1, ih.2, hs]
+    · rw [firstSign_cons_ne l hx, firstSign_cons_ne m hy, hs]
+  | @collapse x X x' l m y y' hx hX hy' hsx hsy hopp h ih =>
+    have hy : y ≠ 0 := by
+      intro hy0; rw [hy0, sign_zero, mul_zero] at hopp; exact absurd hopp (by decide)
+    have hx' : x' ≠ 0 := by
+      intro hx0; rw [hx0, sign_zero] at hsx; exact hx (sign_eq_zero_iff.mp hsx)
+    refine ⟨?_, ?_⟩
+    · -- signVariations L
+      rw [signVariations_cons_pos (X :: y :: l) hx,
+        firstSign_cons_ne (y :: l) hX, signVariations_cons_pos (y :: l) hX,
+        firstSign_cons_ne l hy]
+      rw [signVariations_cons_pos (0 :: y' :: m) hx',
+        firstSign_cons_zero (y' :: m) rfl, firstSign_cons_ne m hy',
+        signVariations_cons_zero]
+      simp only [Option.elim_some]
+      rw [← add_assoc, ih.1]
+      congr 1
+      rw [← hsx, ← hsy, if_pos hopp]
+      exact svrel_flank_arith _ _ _ hopp (fun h => hX (sign_eq_zero_iff.mp h))
+    · rw [firstSign_cons_ne (X :: y :: l) hx, firstSign_cons_ne (0 :: y' :: m) hx', hsx]
+
 /-- A generalised Sturm chain for `p`: the sign axioms that the counting
 argument actually uses, packaged as explicit fields. The chain is stored as
 a plain `List (Polynomial ℝ)` and elements are addressed by index through

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -49,6 +49,32 @@ zero-skipping variation count of `leadingCoeff · (-1) ^ natDegree`. -/
 noncomputable def sturmVarNegInf (chain : List (Polynomial ℝ)) : ℕ :=
   signVariations (chain.map (fun q => q.leadingCoeff * (-1) ^ q.natDegree))
 
+/-- **Sign persistence.** A polynomial with no zero on `[a, b]` keeps a constant
+sign there: its evaluation signs at the two endpoints agree. If they differed,
+the two endpoint values would straddle `0` and the intermediate value theorem
+would supply an interior zero. -/
+theorem eval_sign_eq_of_no_zero {q : Polynomial ℝ} {a b : ℝ} (hab : a ≤ b)
+    (hz : ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
+    SignType.sign (q.eval a) = SignType.sign (q.eval b) := by
+  have hna : q.eval a ≠ 0 := hz a ⟨le_refl a, hab⟩
+  have hnb : q.eval b ≠ 0 := hz b ⟨hab, le_refl b⟩
+  have hpos : 0 < q.eval a * q.eval b := by
+    rcases lt_or_gt_of_ne (mul_ne_zero hna hnb) with hlt | hgt
+    · exfalso
+      have hmem : (0 : ℝ) ∈ Set.uIcc (q.eval a) (q.eval b) := by
+        rcases mul_neg_iff.mp hlt with ⟨hx, hy⟩ | ⟨hx, hy⟩
+        · exact Set.mem_uIcc.mpr (Or.inr ⟨hy.le, hx.le⟩)
+        · exact Set.mem_uIcc.mpr (Or.inl ⟨hx.le, hy.le⟩)
+      have hsub := intermediate_value_uIcc (a := a) (b := b)
+        (f := fun x => q.eval x) q.continuousOn
+      obtain ⟨c, hc, hc0⟩ := hsub hmem
+      rw [Set.uIcc_of_le hab] at hc
+      exact hz c hc hc0
+    · exact hgt
+  rcases mul_pos_iff.mp hpos with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · rw [sign_pos h1, sign_pos h2]
+  · rw [sign_neg h1, sign_neg h2]
+
 variable {p : Polynomial ℝ} {chain : List (Polynomial ℝ)}
 
 /-- **Local constancy.** On a closed interval `[a, b]` containing no zero of
@@ -60,10 +86,15 @@ and the intermediate value theorem (`intermediate_value_Icc`): a sign change
 would force a zero. The list of evaluation signs is therefore the same at `a`
 and `b`, so `signVariations` — which depends only on those signs — agrees. -/
 theorem sturmVar_const_of_no_zero (_hchain : IsSturmChain p chain)
-    (a b : ℝ) (_hab : a ≤ b)
-    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
+    (a b : ℝ) (hab : a ≤ b)
+    (hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, q.eval x ≠ 0) :
     sturmVar chain a = sturmVar chain b := by
-  sorry
+  show signVariations (chain.map (Polynomial.eval a))
+    = signVariations (chain.map (Polynomial.eval b))
+  apply signVariations_congr
+  rw [List.forall₂_map_left_iff, List.forall₂_map_right_iff, List.forall₂_same]
+  intro q hq
+  exact eval_sign_eq_of_no_zero hab (fun x hx => hz q hq x hx)
 
 /-- **Interior-element crossing preserves `sturmVar`.** If `r` is not a root of
 `p` and the only chain zeros in `[a, b]` occur at `r` (necessarily zeros of

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -75,6 +75,86 @@ theorem eval_sign_eq_of_no_zero {q : Polynomial ℝ} {a b : ℝ} (hab : a ≤ b)
   · rw [sign_pos h1, sign_pos h2]
   · rw [sign_neg h1, sign_neg h2]
 
+/-- Build the sign-pattern relation `SVRel` between the evaluations of a
+polynomial list at a "generic" point `a` (where every element is nonzero) and a
+"special" point `r` (where some interior elements may vanish). The hypotheses
+are exactly what an `IsSturmChain` supplies restricted to the relevant interval:
+every element is nonzero at `a`; the head and last elements are nonzero at `r`;
+whenever an interior element vanishes at `r` its neighbours are nonzero there
+with opposite signs; and every element nonzero at `r` has the same sign at `a`
+and `r`. -/
+private theorem buildSVRel (a r : ℝ) :
+    ∀ (cs : List (Polynomial ℝ)),
+      (∀ q ∈ cs, q.eval a ≠ 0) →
+      (∀ q, cs.head? = some q → q.eval r ≠ 0) →
+      (∀ q, cs.getLast? = some q → q.eval r ≠ 0) →
+      (∀ (i : ℕ) (q0 q1 q2 : Polynomial ℝ), cs[i]? = some q0 → cs[i + 1]? = some q1 →
+        cs[i + 2]? = some q2 → q1.eval r = 0 →
+        q0.eval r ≠ 0 ∧ q2.eval r ≠ 0 ∧ q0.eval r * q2.eval r < 0) →
+      (∀ q ∈ cs, q.eval r ≠ 0 → SignType.sign (q.eval a) = SignType.sign (q.eval r)) →
+      SVRel (cs.map (Polynomial.eval a)) (cs.map (Polynomial.eval r))
+  | [], _, _, _, _, _ => SVRel.nil
+  | [q0], hne0, hfront, _, _, hsame => by
+      have hr : q0.eval r ≠ 0 := hfront q0 rfl
+      exact SVRel.same (hne0 q0 (by simp)) hr (hsame q0 (by simp) hr) SVRel.nil
+  | q0 :: q1 :: rest, hne0, hfront, hlast, halt, hsame => by
+      have hr0 : q0.eval r ≠ 0 := hfront q0 rfl
+      have ha0 : q0.eval a ≠ 0 := hne0 q0 (by simp)
+      by_cases hq1 : q1.eval r = 0
+      · cases rest with
+        | nil => exact absurd hq1 (hlast q1 (by simp))
+        | cons q2 rest' =>
+            obtain ⟨hn0, hn2, hoppR⟩ := halt 0 q0 q1 q2 rfl rfl rfl hq1
+            have hsx : SignType.sign (q0.eval a) = SignType.sign (q0.eval r) :=
+              hsame q0 (by simp) hn0
+            have hsy : SignType.sign (q2.eval a) = SignType.sign (q2.eval r) :=
+              hsame q2 (by simp) hn2
+            have hoppA : SignType.sign (q0.eval a) * SignType.sign (q2.eval a) = -1 := by
+              rw [hsx, hsy, ← sign_mul, sign_eq_neg_one_iff]; exact hoppR
+            have hne0' : ∀ q ∈ q2 :: rest', q.eval a ≠ 0 := fun q hq =>
+              hne0 q (List.mem_cons_of_mem _ (List.mem_cons_of_mem _ hq))
+            have hfront' : ∀ q, (q2 :: rest').head? = some q → q.eval r ≠ 0 := by
+              intro q hq; rw [List.head?_cons] at hq; cases hq; exact hn2
+            have hlast' : ∀ q, (q2 :: rest').getLast? = some q → q.eval r ≠ 0 := by
+              intro q hq
+              exact hlast q (by rw [List.getLast?_cons_cons, List.getLast?_cons_cons]; exact hq)
+            have halt' : ∀ (i : ℕ) (p0 p1 p2 : Polynomial ℝ), (q2 :: rest')[i]? = some p0 →
+                (q2 :: rest')[i + 1]? = some p1 → (q2 :: rest')[i + 2]? = some p2 →
+                p1.eval r = 0 → p0.eval r ≠ 0 ∧ p2.eval r ≠ 0 ∧ p0.eval r * p2.eval r < 0 := by
+              intro i p0 p1 p2 h0 h1 h2 hz
+              exact halt (i + 2) p0 p1 p2
+                (by rw [List.getElem?_cons_succ, List.getElem?_cons_succ]; exact h0)
+                (by rw [List.getElem?_cons_succ, List.getElem?_cons_succ]; exact h1)
+                (by rw [List.getElem?_cons_succ, List.getElem?_cons_succ]; exact h2) hz
+            have hsame' : ∀ q ∈ q2 :: rest', q.eval r ≠ 0 →
+                SignType.sign (q.eval a) = SignType.sign (q.eval r) := fun q hq =>
+              hsame q (List.mem_cons_of_mem _ (List.mem_cons_of_mem _ hq))
+            have IH := buildSVRel a r (q2 :: rest') hne0' hfront' hlast' halt' hsame'
+            simp only [List.map_cons] at IH ⊢
+            rw [hq1]
+            exact SVRel.collapse ha0 (hne0 q1 (by simp)) hn2 hsx hsy hoppA IH
+      · have hne0' : ∀ q ∈ q1 :: rest, q.eval a ≠ 0 := fun q hq =>
+          hne0 q (List.mem_cons_of_mem _ hq)
+        have hfront' : ∀ q, (q1 :: rest).head? = some q → q.eval r ≠ 0 := by
+          intro q hq; rw [List.head?_cons] at hq; cases hq; exact hq1
+        have hlast' : ∀ q, (q1 :: rest).getLast? = some q → q.eval r ≠ 0 := by
+          intro q hq
+          exact hlast q (by rw [List.getLast?_cons_cons]; exact hq)
+        have halt' : ∀ (i : ℕ) (p0 p1 p2 : Polynomial ℝ), (q1 :: rest)[i]? = some p0 →
+            (q1 :: rest)[i + 1]? = some p1 → (q1 :: rest)[i + 2]? = some p2 →
+            p1.eval r = 0 → p0.eval r ≠ 0 ∧ p2.eval r ≠ 0 ∧ p0.eval r * p2.eval r < 0 := by
+          intro i p0 p1 p2 h0 h1 h2 hz
+          exact halt (i + 1) p0 p1 p2
+            (by rw [List.getElem?_cons_succ]; exact h0)
+            (by rw [List.getElem?_cons_succ]; exact h1)
+            (by rw [List.getElem?_cons_succ]; exact h2) hz
+        have hsame' : ∀ q ∈ q1 :: rest, q.eval r ≠ 0 →
+            SignType.sign (q.eval a) = SignType.sign (q.eval r) := fun q hq =>
+          hsame q (List.mem_cons_of_mem _ hq)
+        have IH := buildSVRel a r (q1 :: rest) hne0' hfront' hlast' halt' hsame'
+        simp only [List.map_cons] at IH ⊢
+        exact SVRel.same ha0 hr0 (hsame q0 (by simp) hr0) IH
+
 variable {p : Polynomial ℝ} {chain : List (Polynomial ℝ)}
 
 /-- **Local constancy.** On a closed interval `[a, b]` containing no zero of
@@ -109,11 +189,39 @@ is unaffected. Hence the count at `a`, at `r`, and at `b` coincide. The value
 at `r` itself is part of the statement because the global theorem places no
 restriction on its endpoints, so a telescoping step may need the count exactly
 at an interior-element zero. -/
-theorem sturmVar_interior_cross (_hchain : IsSturmChain p chain) (r : ℝ)
-    (_hpr : ¬ p.IsRoot r) (a b : ℝ) (_har : a < r) (_hrb : r < b)
-    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0) :
+theorem sturmVar_interior_cross (hchain : IsSturmChain p chain) (r : ℝ)
+    (hpr : ¬ p.IsRoot r) (a b : ℝ) (har : a < r) (hrb : r < b)
+    (hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0) :
     sturmVar chain a = sturmVar chain r ∧ sturmVar chain r = sturmVar chain b := by
-  sorry
+  have hab : a ≤ b := (har.trans hrb).le
+  have hpr' : p.eval r ≠ 0 := hpr
+  -- Chain-structure hypotheses at the special point `r`, shared by both calls.
+  have hfront : ∀ q, chain.head? = some q → q.eval r ≠ 0 := by
+    intro q hq; rw [hchain.head] at hq; cases hq; exact hpr'
+  have hlast : ∀ q, chain.getLast? = some q → q.eval r ≠ 0 :=
+    fun q hq => hchain.last_no_root q hq r
+  have halt : ∀ (i : ℕ) (q0 q1 q2 : Polynomial ℝ), chain[i]? = some q0 →
+      chain[i + 1]? = some q1 → chain[i + 2]? = some q2 → q1.eval r = 0 →
+      q0.eval r ≠ 0 ∧ q2.eval r ≠ 0 ∧ q0.eval r * q2.eval r < 0 :=
+    fun i q0 q1 q2 h0 h1 h2 hz => hchain.interior_alternates i r q0 q1 q2 h0 h1 h2 hz
+  constructor
+  · show signVariations (chain.map (Polynomial.eval a))
+      = signVariations (chain.map (Polynomial.eval r))
+    refine (buildSVRel a r chain (fun q hq => hz q hq a ⟨le_refl a, hab⟩ (ne_of_lt har))
+      hfront hlast halt (fun q hq hqr => ?_)).signVariations_eq.1
+    exact eval_sign_eq_of_no_zero har.le (fun x hx => by
+      by_cases hxr : x = r
+      · rw [hxr]; exact hqr
+      · exact hz q hq x ⟨hx.1, hx.2.trans hrb.le⟩ hxr)
+  · show signVariations (chain.map (Polynomial.eval r))
+      = signVariations (chain.map (Polynomial.eval b))
+    refine ((buildSVRel b r chain
+      (fun q hq => hz q hq b ⟨hab, le_refl b⟩ (ne_of_lt hrb).symm)
+      hfront hlast halt (fun q hq hqr => ?_)).signVariations_eq.1).symm
+    exact (eval_sign_eq_of_no_zero hrb.le (fun x hx => by
+      by_cases hxr : x = r
+      · rw [hxr]; exact hqr
+      · exact hz q hq x ⟨har.le.trans hx.1, hx.2⟩ hxr)).symm
 
 /-- **Simple-zero crossing of `p` drops `sturmVar` by one, registering at `r`.**
 If `r` is a (simple, by squarefreeness) root of `p` and the only chain zeros in

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -238,12 +238,111 @@ step 2, and away from `r` `sturmVar` is locally constant by step 1. The
 half-open registration is the one design-sensitive point: it is what makes the
 executable half-open counts match with no endpoint hypotheses. -/
 theorem sturmVar_root_cross (_hp : p ≠ 0) (_hsf : Squarefree p)
-    (_hchain : IsSturmChain p chain) (r : ℝ) (_hr : p.IsRoot r)
-    (a b : ℝ) (_har : a < r) (_hrb : r < b)
-    (_hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0)
-    (_hpz : ∀ x ∈ Set.Icc a b, x ≠ r → ¬ p.IsRoot x) :
+    (hchain : IsSturmChain p chain) (r : ℝ) (hr : p.IsRoot r)
+    (a b : ℝ) (har : a < r) (hrb : r < b)
+    (hz : ∀ q ∈ chain, ∀ x ∈ Set.Icc a b, x ≠ r → q.eval x ≠ 0)
+    (hpz : ∀ x ∈ Set.Icc a b, x ≠ r → ¬ p.IsRoot x) :
     sturmVar chain a = sturmVar chain b + 1 ∧ sturmVar chain r = sturmVar chain b := by
-  sorry
+  have hab : a ≤ b := (har.trans hrb).le
+  obtain ⟨q, hq1, hqr, hflL, hflR⟩ := hchain.root_flank r hr
+  -- Split the chain into its head `p` and second element `q`.
+  rcases chain with _ | ⟨p0, _ | ⟨q0, tail⟩⟩
+  · exact absurd hchain.head (by simp)
+  · exact absurd hq1 (by simp)
+  have hp0 : p0 = p := by simpa using hchain.head
+  subst p0
+  have hq0 : q0 = q := by simpa using hq1
+  subst q0
+  -- Basic nonvanishing facts.
+  have hpr0 : p.eval r = 0 := hr
+  have hpa : p.eval a ≠ 0 := fun h => hpz a ⟨le_refl a, hab⟩ (ne_of_lt har) h
+  have hpb : p.eval b ≠ 0 := fun h => hpz b ⟨hab, le_refl b⟩ (ne_of_lt hrb).symm h
+  have hqa : q.eval a ≠ 0 := hz q (by simp) a ⟨le_refl a, hab⟩ (ne_of_lt har)
+  have hqb : q.eval b ≠ 0 := hz q (by simp) b ⟨hab, le_refl b⟩ (ne_of_lt hrb).symm
+  -- The head pair `p * q` is negative just left of `r` and positive just right,
+  -- and (only zero at `r`) this persists to the endpoints.
+  have hpqa : (p * q).eval a < 0 := by
+    obtain ⟨c, hclt, hcmem⟩ := (hflL.and (Ioo_mem_nhdsLT har)).exists
+    have hsg : SignType.sign ((p * q).eval a) = SignType.sign ((p * q).eval c) :=
+      eval_sign_eq_of_no_zero hcmem.1.le (fun x hx => by
+        have hxr : x ≠ r := ne_of_lt (lt_of_le_of_lt hx.2 hcmem.2)
+        have hxab : x ∈ Set.Icc a b := ⟨hx.1, hx.2.trans (hcmem.2.le.trans hrb.le)⟩
+        rw [Polynomial.eval_mul]
+        exact mul_ne_zero (fun h => hpz x hxab hxr h) (hz q (by simp) x hxab hxr))
+    rw [sign_neg hclt] at hsg
+    exact sign_eq_neg_one_iff.mp hsg
+  have hpqb : 0 < (p * q).eval b := by
+    obtain ⟨c, hcgt, hcmem⟩ := (hflR.and (Ioo_mem_nhdsGT hrb)).exists
+    have hsg : SignType.sign ((p * q).eval c) = SignType.sign ((p * q).eval b) :=
+      eval_sign_eq_of_no_zero hcmem.2.le (fun x hx => by
+        have hxr : x ≠ r := (ne_of_lt (lt_of_lt_of_le hcmem.1 hx.1)).symm
+        have hxab : x ∈ Set.Icc a b :=
+          ⟨har.le.trans (hcmem.1.le.trans hx.1), hx.2⟩
+        rw [Polynomial.eval_mul]
+        exact mul_ne_zero (fun h => hpz x hxab hxr h) (hz q (by simp) x hxab hxr))
+    rw [sign_pos hcgt] at hsg
+    exact sign_eq_one_iff.mp hsg.symm
+  have hsignA : SignType.sign (p.eval a) * SignType.sign (q.eval a) = -1 := by
+    rw [← sign_mul, sign_eq_neg_one_iff, ← Polynomial.eval_mul]; exact hpqa
+  have hsignB : ¬ (SignType.sign (p.eval b) * SignType.sign (q.eval b) = -1) := by
+    rw [← sign_mul, sign_eq_neg_one_iff, ← Polynomial.eval_mul]
+    exact not_lt.mpr hpqb.le
+  -- Point-`r` chain hypotheses for the tail `q :: tail`, shared by both calls.
+  have hfront_rest : ∀ s, (q :: tail).head? = some s → s.eval r ≠ 0 := by
+    intro s hs; rw [List.head?_cons] at hs; cases hs; exact hqr
+  have hlast_rest : ∀ s, (q :: tail).getLast? = some s → s.eval r ≠ 0 := by
+    intro s hs
+    exact hchain.last_no_root s (by rw [List.getLast?_cons_cons]; exact hs) r
+  have halt_rest : ∀ (i : ℕ) (s0 s1 s2 : Polynomial ℝ), (q :: tail)[i]? = some s0 →
+      (q :: tail)[i + 1]? = some s1 → (q :: tail)[i + 2]? = some s2 → s1.eval r = 0 →
+      s0.eval r ≠ 0 ∧ s2.eval r ≠ 0 ∧ s0.eval r * s2.eval r < 0 := by
+    intro i s0 s1 s2 h0 h1 h2 hz0
+    exact hchain.interior_alternates (i + 1) r s0 s1 s2
+      (by rw [List.getElem?_cons_succ]; exact h0)
+      (by rw [List.getElem?_cons_succ]; exact h1)
+      (by rw [List.getElem?_cons_succ]; exact h2) hz0
+  -- Sign persistence for the tail elements, at `a` and at `b`.
+  have hsame_a : ∀ s ∈ q :: tail, s.eval r ≠ 0 →
+      SignType.sign (s.eval a) = SignType.sign (s.eval r) := fun s hs hsr =>
+    eval_sign_eq_of_no_zero har.le (fun x hx => by
+      by_cases hxr : x = r
+      · rw [hxr]; exact hsr
+      · exact hz s (List.mem_cons_of_mem _ hs) x ⟨hx.1, hx.2.trans hrb.le⟩ hxr)
+  have hsame_b : ∀ s ∈ q :: tail, s.eval r ≠ 0 →
+      SignType.sign (s.eval b) = SignType.sign (s.eval r) := fun s hs hsr =>
+    (eval_sign_eq_of_no_zero hrb.le (fun x hx => by
+      by_cases hxr : x = r
+      · rw [hxr]; exact hsr
+      · exact hz s (List.mem_cons_of_mem _ hs) x ⟨har.le.trans hx.1, hx.2⟩ hxr)).symm
+  -- The tail's `sturmVar` is the same at `a`, `r`, `b` (interior-crossing).
+  have hEqA : sturmVar (q :: tail) a = sturmVar (q :: tail) r :=
+    (buildSVRel a r (q :: tail)
+      (fun s hs => hz s (List.mem_cons_of_mem _ hs) a ⟨le_refl a, hab⟩ (ne_of_lt har))
+      hfront_rest hlast_rest halt_rest hsame_a).signVariations_eq.1
+  have hEqB : sturmVar (q :: tail) b = sturmVar (q :: tail) r :=
+    (buildSVRel b r (q :: tail)
+      (fun s hs => hz s (List.mem_cons_of_mem _ hs) b ⟨hab, le_refl b⟩ (ne_of_lt hrb).symm)
+      hfront_rest hlast_rest halt_rest hsame_b).signVariations_eq.1
+  -- Head-pair bookkeeping at each point.
+  have hSVa : sturmVar (p :: q :: tail) a = 1 + sturmVar (q :: tail) a := by
+    show signVariations (p.eval a :: (q :: tail).map (Polynomial.eval a))
+      = 1 + signVariations ((q :: tail).map (Polynomial.eval a))
+    rw [signVariations_cons_pos _ hpa]
+    simp only [List.map_cons]
+    rw [firstSign_cons_ne _ hqa, Option.elim_some, if_pos hsignA]
+  have hSVb : sturmVar (p :: q :: tail) b = sturmVar (q :: tail) b := by
+    show signVariations (p.eval b :: (q :: tail).map (Polynomial.eval b))
+      = signVariations ((q :: tail).map (Polynomial.eval b))
+    rw [signVariations_cons_pos _ hpb]
+    simp only [List.map_cons]
+    rw [firstSign_cons_ne _ hqb, Option.elim_some, if_neg hsignB, zero_add]
+  have hSVr : sturmVar (p :: q :: tail) r = sturmVar (q :: tail) r := by
+    show signVariations (p.eval r :: (q :: tail).map (Polynomial.eval r))
+      = signVariations ((q :: tail).map (Polynomial.eval r))
+    rw [hpr0]; exact signVariations_cons_zero _
+  refine ⟨?_, ?_⟩
+  · rw [hSVa, hSVb, hEqA, hEqB]; omega
+  · rw [hSVr, hSVb]; exact hEqB.symm
 
 /-- **Sturm's theorem, half-open form.** For `p ≠ 0` squarefree with a
 generalised Sturm chain, the drop in `sturmVar` from `a` to `b` equals the

--- a/progress/2026-07-11T12-25-00Z.md
+++ b/progress/2026-07-11T12-25-00Z.md
@@ -1,0 +1,36 @@
+# Sturm local lemmas (steps 1-3)
+
+## Accomplished
+Proved the three local lemmas of Sturm's theorem in
+`HexRealRootsMathlib/SturmTheorem.lean`, replacing their sorries:
+
+- `sturmVar_const_of_no_zero` (step 1, local constancy)
+- `sturmVar_interior_cross` (step 2, interior-crossing neutrality)
+- `sturmVar_root_cross` (step 3, simple-root crossing)
+
+Supporting infrastructure added in `HexRealRootsMathlib/SturmChainDefs.lean`
+(generic sign / `signVariations` combinatorics):
+
+- `countSignChanges_congr`, `filter_ne_zero_congr`, `signVariations_congr`
+  — `signVariations` reads only entry signs.
+- `firstSign` + `firstSign_cons_zero/ne` and `signVariations_cons_pos`
+  — leading-sign state governing how a prepended nonzero entry changes the
+  count.
+- `SVRel` inductive relation and `SVRel.signVariations_eq` — a nonzero
+  entry flanked by opposite-sign neighbours may collapse to `0` without
+  changing the variation count.
+
+Analysis helpers in `SturmTheorem.lean`: `eval_sign_eq_of_no_zero`
+(interval sign persistence via IVT) and `buildSVRel` (bridge from
+`IsSturmChain` fields to `SVRel`).
+
+## Current frontier
+`sturm_half_open` and `sturm_line` remain sorried (not in scope for this
+turn; they telescope the three local lemmas).
+
+## Next step
+Discharge `sturm_half_open` by induction over the finitely many chain
+zeros in `(a, b]`, then `sturm_line` past a Cauchy bound.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR proves the three local lemmas of Sturm's theorem over `Polynomial ℝ` in `HexRealRootsMathlib/SturmTheorem.lean`, replacing their sorries with complete proofs: `sturmVar_const_of_no_zero` (local constancy), `sturmVar_interior_cross` (interior-element crossings are variation-neutral), and `sturmVar_root_cross` (a simple root of `p` drops `sturmVar` by one, registering at `r`). The two global telescoping results `sturm_half_open` and `sturm_line` remain sorried, as intended for follow-up work; no other declaration in the library carries a sorry, and none of the three proven theorems depends on `sorryAx`.

The generic sign-variation combinatorics live in `HexRealRootsMathlib/SturmChainDefs.lean`. `signVariations` is shown to read only the entry signs (`countSignChanges_congr`, `filter_ne_zero_congr`, `signVariations_congr`). A leading-sign helper `firstSign` and the rewrite `signVariations_cons_pos` expose how prepending a nonzero entry changes the count. The inductive relation `SVRel` captures the one nontrivial move: a nonzero entry flanked by two opposite-sign neighbours may collapse to zero without changing the variation count, and `SVRel.signVariations_eq` proves this preserves both the count and the leading sign.

The analysis side sits in `SturmTheorem.lean`: `eval_sign_eq_of_no_zero` establishes interval sign persistence from the intermediate value theorem, and `buildSVRel` translates the `IsSturmChain` fields (`interior_alternates`, `last_no_root`, head/consecutive data) into an `SVRel` between the chain's evaluations at a generic point and at the special point. Step 3 additionally uses `root_flank` together with `Ioo_mem_nhdsLT` / `Ioo_mem_nhdsGT` to pin the sign of the head pair `p * q` at the endpoints, then reuses `buildSVRel` on the tail for the interior crossings.

🤖 Prepared with Claude Code