### PR TITLE
feat(hex-roots): add Cauchy root-bound starting component

### DIFF
--- a/HexRoots.lean
+++ b/HexRoots.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRoots.Basic
+public import HexRoots.Cauchy
 
 public section
 

--- a/HexRoots/Cauchy.lean
+++ b/HexRoots/Cauchy.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Basic
+
+public section
+
+/-!
+The starting point of the subdivision: a single square, centred at the
+origin, whose circumscribed region covers the Cauchy root bound of the
+input polynomial. Every complex root of `p` lies strictly inside this
+square, so refinement can begin from it.
+
+The half-width is `2^{-prec}` with `prec := -(cauchyExp p)`, negative
+whenever the root bound exceeds `1`; `cauchyExp` is pure integer
+arithmetic on the coefficient magnitudes, with no floating point.
+-/
+namespace Hex
+
+/-- Smallest `e : Nat` with `2^e ≥ 1 + max_{i<n} |aᵢ| / |aₙ|` (the Cauchy
+    root bound): every complex root of `p` satisfies `|z| < 2^e`, so all
+    roots lie in the square of half-width `2^e` about `0`. Pure integer
+    arithmetic: with `L := |aₙ|` the leading magnitude and
+    `M := max_{i<n} |aᵢ|` the largest non-leading magnitude, take
+    `e := ceilLog2 ⌈(L + M) / L⌉ = ceilLog2 ((L + M + L - 1) / L)`. Junk
+    `0` when `p` is the zero polynomial (no leading coefficient). -/
+@[expose] def cauchyExp (p : ZPoly) : Nat :=
+  let L := p.leadingCoeff.natAbs
+  if L = 0 then 0
+  else
+    let M := (p.toArray.extract 0 (p.size - 1)).foldl
+      (init := 0) fun acc a => Nat.max acc a.natAbs
+    Hex.ceilLog2 ((L + M + L - 1) / L)
+
+namespace Component
+
+/-- The starting component: a single square centred at `0` covering the
+    Cauchy root bound, with `candidateK = deg p`. Its half-width is
+    `2^{-prec}` with `prec = -(cauchyExp p)`, so its closed square
+    contains every complex root of `p`. -/
+@[expose] def cauchy (p : ZPoly) (h : 0 < p.degree?.getD 0) : Component :=
+  { squares := #[⟨0, 0, -(cauchyExp p : Int)⟩], candidateK := p.degree?.getD 0 }
+
+end Component
+
+end Hex


### PR DESCRIPTION
This PR adds `HexRoots/Cauchy.lean`, seeding the complex-root-isolation subdivision. It defines `Hex.cauchyExp`, the Cauchy root bound as a base-2 exponent computed by pure integer arithmetic (`ceilLog2 ⌈(L + M) / L⌉` with `L = |leadingCoeff|` and `M` the largest non-leading coefficient magnitude, junk `0` for the zero polynomial), and `Component.cauchy`, the origin-centred single-square component of half-width `2^{cauchyExp p}` whose closed square contains every complex root of `p`. It threads the new module into the `HexRoots` umbrella.

`cauchyExp` is marked `@[expose]` per the convention; `Component.cauchy` is also `@[expose]` so its `prec` reduces under kernel `decide` (a sanity `by decide` on the seed square confirms `squares = #[⟨0,0,-3⟩]`, `candidateK = 3` for `#[6,-7,0,1]`). The SPEC hypothesis `h : 0 < p.degree?.getD 0` is not consumed by `Component.cauchy`'s body (the `L = 0` branch is dead under `h`), so the unused-variables linter fires on it; this is an accepted lint exception kept per the SPEC signature, since `@[nolint]` is unavailable in the Mathlib-free layer.

🤖 Prepared with Claude Code