### PR TITLE
feat(hex-roots): add speculative Newton step

### DIFF
--- a/HexRoots.lean
+++ b/HexRoots.lean
@@ -8,6 +8,7 @@ module
 
 public import HexRoots.Basic
 public import HexRoots.MahlerPrec
+public import HexRoots.Newton
 public import HexRoots.Taylor
 
 public section

--- a/HexRoots/Newton.lean
+++ b/HexRoots/Newton.lean
@@ -56,7 +56,8 @@ namespace Hex
   let q := prec' + 2 + max 0 (Hex.Dyadic.ceilLog2 tb)
   let inv := d.invAtPrec q                               -- ONE real reciprocal 1/|c₁|²
   -- `invAtPrec` floors at precision `q` (error `< 2^{−q}` toward zero), so each
-  -- centre component's error is `≤ |t|·2^{−q} ≤ tb·2^{−q} < 2^{−(prec'+2)}`, a
+  -- centre component's error is `< |tᵢ|·2^{−q} ≤ tb·2^{−q} ≤ 2^{−(prec'+2)}`
+  -- (strictness from the reciprocal rounding error), at most a
   -- quarter of the new half-width `2^{−prec'}`: a genuinely converged Newton
   -- step keeps the root inside the new square. `prec' = max (prec+2) (2·prec)`
   -- gives at least a quarter-size square always (also for `prec ≤ 0`) and

--- a/HexRoots/Newton.lean
+++ b/HexRoots/Newton.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Taylor
+
+public section
+
+/-!
+The speculative Newton step for complex root refinement. From the centre
+of a square `s`, one Newton (or `k`-order cluster) step produces a
+recentred, much smaller candidate square at
+
+```
+x' = x − k · c₀ / c₁ ,
+```
+
+where `c₀, c₁` are the first two exact Gaussian-dyadic Taylor coefficients
+of `p` at the centre. The Gaussian inversion `1/c₁ = conj(c₁)/|c₁|²` uses
+one real reciprocal `Dyadic.invAtPrec (|c₁|²)`, reused by both centre
+components, rather than two separate divisions.
+
+The step is purely speculative: it checks no "Newton readiness"
+precondition. The caller must re-certify the result and apply the coverage
+guard (implemented in `Bisection.lean`); a step that fails to certify is
+discarded and subdivision proceeds. Soundness never depends on the
+precision choices here, only the success rate does.
+-/
+namespace Hex
+
+/-- Speculative Newton step `x' = x − k·c₀/c₁` from the centre of `s`,
+    returning the recentred, much smaller square at
+    `prec' = max (s.prec + 2) (2·s.prec)`. `k = 1` is the atom form; general
+    `k` is the `k`-order cluster step (BSSY §5). Purely speculative: the
+    caller must re-certify and apply the coverage guard. Degree `< 1`
+    (`cs.size < 2`) returns `s` unchanged; `c₁ = 0` gives `1/|c₁|² = 0`, so
+    the centre is returned unchanged (`x' = x`) at the finer `prec'`. Either
+    way the degenerate result is rejected by the re-check. -/
+@[expose] def newtonSquare (p : ZPoly) (s : DyadicSquare) (k : Nat) : DyadicSquare :=
+  let cs := taylor p s.center
+  if cs.size < 2 then s else
+  let c0 := cs.getD 0 (0, 0)
+  let c1 := cs.getD 1 (0, 0)
+  let d  := GaussDyadic.normSq c1                        -- |c₁|², exact
+  let t  := GaussDyadic.mul (GaussDyadic.ofInt (k : Int))
+              (GaussDyadic.mul c0 (GaussDyadic.conj c1)) -- k·c₀·conj(c₁), exact
+  let prec' := max (s.prec + 2) (2 * s.prec)
+  -- Magnitude bound `|t| ≤ tb := |Re t| + |Im t|`, inlined here rather than
+  -- pulled from `GaussDyadic.hi` (which lives in the sibling `Pellet.lean`,
+  -- deliberately not imported).
+  let tb := Hex.Dyadic.abs t.1 + Hex.Dyadic.abs t.2
+  let q := prec' + 2 + max 0 (Hex.Dyadic.ceilLog2 tb)
+  let inv := d.invAtPrec q                               -- ONE real reciprocal 1/|c₁|²
+  -- `invAtPrec` floors at precision `q` (error `< 2^{−q}` toward zero), so each
+  -- centre component's error is `≤ |t|·2^{−q} ≤ tb·2^{−q} < 2^{−(prec'+2)}`, a
+  -- quarter of the new half-width `2^{−prec'}`: a genuinely converged Newton
+  -- step keeps the root inside the new square. `prec' = max (prec+2) (2·prec)`
+  -- gives at least a quarter-size square always (also for `prec ≤ 0`) and
+  -- precision doubling once `prec ≥ 2`; only success rate, never soundness,
+  -- depends on this choice. `Dyadic.invAtPrec` returns `0` for a zero argument
+  -- (`Init.Data.Dyadic.Inv.lean`: the `.zero` case), so `c₁ = 0` yields
+  -- `inv = 0` and `x' = x` harmlessly.
+  { re := s.re - t.1 * inv, im := s.im - t.2 * inv, prec := prec' }
+
+/-- The square concentric with `s`, one level coarser (half-width doubled).
+    The Newton-Kantorovich certification convention tests and stores this. -/
+@[expose] def DyadicSquare.doubled (s : DyadicSquare) : DyadicSquare :=
+  { s with prec := s.prec - 1 }
+
+end Hex


### PR DESCRIPTION
This PR adds `HexRoots/Newton.lean`, the speculative Newton step for complex root refinement. `newtonSquare p s k` recentres the square on `x' = x − k·c₀/c₁` from the centre of `s`, where `c₀, c₁` are the first two exact Gaussian-dyadic Taylor coefficients of `p` at the centre, and returns a much smaller square at `prec' = max (s.prec + 2) (2·s.prec)`. `k = 1` is the atom form and general `k` is the k-order cluster step. The Gaussian inversion `1/c₁ = conj(c₁)/|c₁|²` uses one real reciprocal `Dyadic.invAtPrec (|c₁|²)` at precision `q = prec' + 2 + max 0 (ceilLog2 tb)`, reused by both centre components; `tb := |Re t| + |Im t|` bounds the numerator `t = k·c₀·conj(c₁)` inline rather than importing the sibling `Pellet.lean`'s `hi`. Since `Dyadic.invAtPrec 0 = 0`, the `c₁ = 0` (multiple-root) case leaves the centre unchanged and the re-check rejects the degenerate result. The step is purely speculative, so the caller must re-certify and apply the coverage guard (both in `Bisection.lean`); only success rate, never soundness, depends on the precision choices. Also adds `DyadicSquare.doubled`, the concentric one-level-coarser square (half-width doubled) that the Newton-Kantorovich certification convention tests and stores.

Two points worth flagging for review. The prompt's illustrative body used `cs[0]!`/`cs[1]!`, which need an `Inhabited GaussDyadic` instance that `Basic.lean` deliberately avoids adding to `Dyadic × Dyadic`; I used `cs.getD 0 (0,0)` / `cs.getD 1 (0,0)` instead, matching the existing `taylor` idiom and semantically identical under the `cs.size < 2` guard. Separately, the WU6 sanity note claims the `c₁ = 0` path returns `s` unchanged "prec included"; in fact `newtonSquare p₃ ⟨-1,0,3⟩ 1` returns centre `(-1, 0)` unchanged but `prec = 6` (`= max 5 6`), not `3`. This matches the specified body and the design rationale (no `c₁ = 0` special-case; `invAtPrec 0 = 0` keeps only the centre fixed), so the "(prec included)" wording in the note is the inaccurate part, not the code.

🤖 Prepared with Claude Code