### PR TITLE
feat: prove Sturm's theorem, half-open and line forms

### DIFF
--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -344,6 +344,145 @@ theorem sturmVar_root_cross (_hp : p ≠ 0) (_hsf : Squarefree p)
   · rw [hSVa, hSVb, hEqA, hEqB]; omega
   · rw [hSVr, hSVb]; exact hEqB.symm
 
+/-- The finite set of real points at which some element of `chain` vanishes.
+Every chain element is nonzero (`IsSturmChain.nonzero_mem`), so each contributes
+finitely many zeros; their union is the telescope's set of break points. -/
+noncomputable def chainZeros (cs : List (Polynomial ℝ)) : Finset ℝ :=
+  cs.toFinset.biUnion (fun q => q.roots.toFinset)
+
+/-- Membership in `chainZeros`: a point lies in it exactly when some chain
+element vanishes there (using that every chain element is nonzero). -/
+theorem mem_chainZeros {cs : List (Polynomial ℝ)} (hne : ∀ q ∈ cs, q ≠ 0) {x : ℝ} :
+    x ∈ chainZeros cs ↔ ∃ q ∈ cs, q.eval x = 0 := by
+  unfold chainZeros
+  simp only [Finset.mem_biUnion, List.mem_toFinset, Multiset.mem_toFinset]
+  constructor
+  · rintro ⟨q, hq, hx⟩
+    exact ⟨q, hq, (Polynomial.mem_roots (hne q hq)).mp hx⟩
+  · rintro ⟨q, hq, hx⟩
+    exact ⟨q, hq, (Polynomial.mem_roots (hne q hq)).mpr hx⟩
+
+/-- A gap point just below `z` and above `lo`, lying above every element of the
+finite set `S` that is below `z`. Used to manufacture the artificial left
+neighbour a crossing lemma needs at a break point. -/
+theorem exists_gap_lt (S : Finset ℝ) (z lo : ℝ) (hlo : lo < z) :
+    ∃ a₀, lo < a₀ ∧ a₀ < z ∧ ∀ x ∈ S, x < z → x < a₀ := by
+  classical
+  set U : Finset ℝ := insert lo (S.filter (fun x => x < z)) with hU
+  have hUne : U.Nonempty := ⟨lo, Finset.mem_insert_self _ _⟩
+  have hmax_lt : U.max' hUne < z := by
+    rw [Finset.max'_lt_iff]
+    intro u hu
+    rw [hU, Finset.mem_insert] at hu
+    rcases hu with h | h
+    · rw [h]; exact hlo
+    · exact (Finset.mem_filter.mp h).2
+  refine ⟨(U.max' hUne + z) / 2, ?_, ?_, ?_⟩
+  · have : lo ≤ U.max' hUne := Finset.le_max' U lo (Finset.mem_insert_self _ _)
+    linarith
+  · linarith
+  · intro x hx hxz
+    have : x ≤ U.max' hUne :=
+      Finset.le_max' U x (Finset.mem_insert.mpr (Or.inr (Finset.mem_filter.mpr ⟨hx, hxz⟩)))
+    linarith
+
+/-- A gap point just above `z` and below `hi`, lying below every element of the
+finite set `S` that is above `z`. Used to manufacture the artificial right
+neighbour a crossing lemma needs at a break point. -/
+theorem exists_gap_gt (S : Finset ℝ) (z hi : ℝ) (hhi : z < hi) :
+    ∃ b₀, z < b₀ ∧ b₀ < hi ∧ ∀ x ∈ S, z < x → b₀ < x := by
+  classical
+  set U : Finset ℝ := insert hi (S.filter (fun x => z < x)) with hU
+  have hUne : U.Nonempty := ⟨hi, Finset.mem_insert_self _ _⟩
+  have hlt_min : z < U.min' hUne := by
+    rw [Finset.lt_min'_iff]
+    intro u hu
+    rw [hU, Finset.mem_insert] at hu
+    rcases hu with h | h
+    · rw [h]; exact hhi
+    · exact (Finset.mem_filter.mp h).2
+  refine ⟨(z + U.min' hUne) / 2, ?_, ?_, ?_⟩
+  · linarith
+  · have : U.min' hUne ≤ hi := Finset.min'_le U hi (Finset.mem_insert_self _ _)
+    linarith
+  · intro x hx hxz
+    have : U.min' hUne ≤ x :=
+      Finset.min'_le U x (Finset.mem_insert.mpr (Or.inr (Finset.mem_filter.mpr ⟨hx, hxz⟩)))
+    linarith
+
+/-- The head `p` of a Sturm chain is a member of the chain. -/
+theorem head_mem (hchain : IsSturmChain p chain) : p ∈ chain := by
+  cases chain with
+  | nil => exact absurd hchain.head (by simp)
+  | cons hd tl =>
+    have hhd : hd = p := by simpa using hchain.head
+    rw [← hhd]; exact List.mem_cons_self
+
+/-- **Right registration.** If no chain element vanishes anywhere in the
+half-open interval `(z, c]` (with `z ≤ c`), then `sturmVar` agrees at `z` and
+`c`, even if `z` itself is a chain zero: the value at a break point equals the
+value immediately to its right. -/
+theorem sturmVar_eq_right (hp : p ≠ 0) (hsf : Squarefree p)
+    (hchain : IsSturmChain p chain) {z c : ℝ} (hzc : z ≤ c)
+    (hclear : ∀ x, z < x → x ≤ c → x ∉ chainZeros chain) :
+    sturmVar chain z = sturmVar chain c := by
+  rcases eq_or_lt_of_le hzc with rfl | hlt
+  · rfl
+  have hne := hchain.nonzero_mem
+  by_cases hzZ : z ∈ chainZeros chain
+  · obtain ⟨a₀, _, ha₀z, ha₀gap⟩ := exists_gap_lt (chainZeros chain) z (z - 1) (by linarith)
+    have hz_ex : ∀ q ∈ chain, ∀ x ∈ Set.Icc a₀ c, x ≠ z → q.eval x ≠ 0 := by
+      intro q hq x hx hxz hqx
+      have hxZ : x ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨q, hq, hqx⟩
+      rcases lt_trichotomy x z with hlt' | heq | hgt'
+      · exact absurd (ha₀gap x hxZ hlt') (not_lt.mpr hx.1)
+      · exact hxz heq
+      · exact hclear x hgt' hx.2 hxZ
+    by_cases hroot : p.IsRoot z
+    · have hpz : ∀ x ∈ Set.Icc a₀ c, x ≠ z → ¬ p.IsRoot x := by
+        intro x hx hxz hpr
+        have hxZ : x ∈ chainZeros chain :=
+          (mem_chainZeros hne).mpr ⟨p, head_mem hchain, hpr⟩
+        rcases lt_trichotomy x z with hlt' | heq | hgt'
+        · exact absurd (ha₀gap x hxZ hlt') (not_lt.mpr hx.1)
+        · exact hxz heq
+        · exact hclear x hgt' hx.2 hxZ
+      exact (sturmVar_root_cross hp hsf hchain z hroot a₀ c ha₀z hlt hz_ex hpz).2
+    · exact (sturmVar_interior_cross hchain z hroot a₀ c ha₀z hlt hz_ex).2
+  · have hz_all : ∀ q ∈ chain, ∀ x ∈ Set.Icc z c, q.eval x ≠ 0 := by
+      intro q hq x hx hqx
+      have hxZ : x ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨q, hq, hqx⟩
+      rcases eq_or_lt_of_le hx.1 with heq | hgt
+      · exact hzZ (by rw [heq]; exact hxZ)
+      · exact hclear x hgt hx.2 hxZ
+    exact sturmVar_const_of_no_zero hchain z c hzc hz_all
+
+/-- Splitting a half-open interval count: for `a ≤ a' ≤ b`, the number of
+multiset entries in `(a, b]` is the sum of those in `(a, a']` and `(a', b]`. -/
+theorem card_filter_Ioc_split (s : Multiset ℝ) {a a' b : ℝ} (h1 : a ≤ a') (h2 : a' ≤ b) :
+    (s.filter (fun r => a < r ∧ r ≤ b)).card
+      = (s.filter (fun r => a < r ∧ r ≤ a')).card
+        + (s.filter (fun r => a' < r ∧ r ≤ b)).card := by
+  classical
+  have hand : s.filter (fun r => (a < r ∧ r ≤ a') ∧ (a' < r ∧ r ≤ b)) = 0 := by
+    rw [Multiset.filter_eq_nil]
+    rintro x _ ⟨⟨_, hxa'⟩, ha'x, _⟩
+    exact absurd ha'x (not_lt.mpr hxa')
+  have hor : s.filter (fun r => (a < r ∧ r ≤ a') ∨ (a' < r ∧ r ≤ b))
+      = s.filter (fun r => a < r ∧ r ≤ b) := by
+    apply Multiset.filter_congr
+    intro x _
+    constructor
+    · rintro (⟨h, h'⟩ | ⟨h, h'⟩)
+      · exact ⟨h, le_trans h' h2⟩
+      · exact ⟨lt_of_le_of_lt h1 h, h'⟩
+    · rintro ⟨h, h'⟩
+      rcases lt_trichotomy x a' with hx | hx | hx
+      · exact Or.inl ⟨h, hx.le⟩
+      · exact Or.inl ⟨h, hx.le⟩
+      · exact Or.inr ⟨hx, h'⟩
+  rw [← Multiset.card_add, Multiset.filter_add_filter, hand, Multiset.add_zero, hor]
+
 /-- **Sturm's theorem, half-open form.** For `p ≠ 0` squarefree with a
 generalised Sturm chain, the drop in `sturmVar` from `a` to `b` equals the
 number of real roots of `p` in the half-open interval `(a, b]`, counted as the
@@ -355,11 +494,121 @@ the chain elements in `(a, b]`. Zeros of interior elements are variation-neutral
 root under the half-open convention (step 3); between consecutive chain zeros
 `sturmVar` is constant (step 1). The signed total is therefore the number of
 roots of `p` in `(a, b]`. -/
-theorem sturm_half_open (_hp : p ≠ 0) (_hsf : Squarefree p)
-    (_hchain : IsSturmChain p chain) {a b : ℝ} (_hab : a < b) :
+theorem sturm_half_open (hp : p ≠ 0) (hsf : Squarefree p)
+    (hchain : IsSturmChain p chain) {a b : ℝ} (hab : a < b) :
     (sturmVar chain a : ℤ) - sturmVar chain b =
       (p.roots.filter (fun r => a < r ∧ r ≤ b)).card := by
-  sorry
+  classical
+  have hne := hchain.nonzero_mem
+  have hnod : p.roots.Nodup :=
+    Polynomial.nodup_roots (PerfectField.separable_iff_squarefree.mpr hsf)
+  suffices H : ∀ n : ℕ, ∀ a b : ℝ, a ≤ b →
+      ((chainZeros chain).filter (fun x => a < x ∧ x ≤ b)).card = n →
+      (sturmVar chain a : ℤ) - sturmVar chain b =
+        (p.roots.filter (fun r => a < r ∧ r ≤ b)).card by
+    exact H _ a b hab.le rfl
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro a b hab hcard
+    set F := (chainZeros chain).filter (fun x => a < x ∧ x ≤ b) with hF
+    by_cases hemp : F = ∅
+    · -- No break point in `(a, b]`: `sturmVar` is constant and there are no roots.
+      have hclear : ∀ x, a < x → x ≤ b → x ∉ chainZeros chain := by
+        intro x hx1 hx2 hxZ
+        have hxF : x ∈ F := by rw [hF, Finset.mem_filter]; exact ⟨hxZ, hx1, hx2⟩
+        rw [hemp] at hxF; exact absurd hxF (Finset.notMem_empty x)
+      have heqv : sturmVar chain a = sturmVar chain b :=
+        sturmVar_eq_right hp hsf hchain hab hclear
+      have hroots0 : p.roots.filter (fun r => a < r ∧ r ≤ b) = 0 := by
+        rw [Multiset.filter_eq_nil]
+        rintro x hx ⟨h1, h2⟩
+        exact hclear x h1 h2 ((mem_chainZeros hne).mpr ⟨p, head_mem hchain, (Polynomial.mem_roots hp).mp hx⟩)
+      rw [heqv, hroots0]; simp
+    · -- Peel off the largest break point `z` in `(a, b]`.
+      have hFne : F.Nonempty := Finset.nonempty_iff_ne_empty.mpr hemp
+      let z := F.max' hFne
+      have hzmem : z ∈ F := F.max'_mem hFne
+      have hzmax : ∀ x ∈ F, x ≤ z := fun x hx => F.le_max' x hx
+      obtain ⟨hzS, haz, hzb⟩ : z ∈ chainZeros chain ∧ a < z ∧ z ≤ b := by
+        have h := hzmem; rw [hF, Finset.mem_filter] at h; exact ⟨h.1, h.2.1, h.2.2⟩
+      obtain ⟨a', ha_a', ha'z, ha'gap⟩ := exists_gap_lt (chainZeros chain) z a haz
+      obtain ⟨b', hzb', _, hb'gap⟩ := exists_gap_gt (chainZeros chain) z (z + 1) (by linarith)
+      -- Only break point in `(a', b]` is `z`.
+      have honly : ∀ x, a' < x → x ≤ b → x ∈ chainZeros chain → x = z := by
+        intro x hx1 hx2 hxZ
+        rcases lt_trichotomy x z with hlt' | heq | hgt'
+        · exact absurd (ha'gap x hxZ hlt') (not_lt.mpr hx1.le)
+        · exact heq
+        · have hxF : x ∈ F := by rw [hF, Finset.mem_filter]; exact ⟨hxZ, lt_trans ha_a' hx1, hx2⟩
+          exact absurd (hzmax x hxF) (not_le.mpr hgt')
+      -- `[a', b']` has no break point except `z`.
+      have hz_ex : ∀ q ∈ chain, ∀ x ∈ Set.Icc a' b', x ≠ z → q.eval x ≠ 0 := by
+        intro q hq x hx hxz hqx
+        have hxZ : x ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨q, hq, hqx⟩
+        rcases lt_trichotomy x z with hlt' | heq | hgt'
+        · exact absurd (ha'gap x hxZ hlt') (not_lt.mpr hx.1)
+        · exact hxz heq
+        · exact absurd (hb'gap x hxZ hgt') (not_lt.mpr hx.2)
+      have hpz : ∀ x ∈ Set.Icc a' b', x ≠ z → ¬ p.IsRoot x := fun x hx hxz hpr =>
+        hz_ex p (head_mem hchain) x hx hxz hpr
+      -- Right registration: `sturmVar z = sturmVar b`.
+      have hzeqb : sturmVar chain z = sturmVar chain b := by
+        apply sturmVar_eq_right hp hsf hchain hzb
+        intro x hx1 hx2 hxZ
+        have hxF : x ∈ F := by rw [hF, Finset.mem_filter]; exact ⟨hxZ, lt_trans haz hx1, hx2⟩
+        exact absurd (hzmax x hxF) (not_le.mpr hx1)
+      -- Inductive hypothesis on `(a, a']`.
+      have hsub : (chainZeros chain).filter (fun x => a < x ∧ x ≤ a') ⊆ F := by
+        rw [hF]; intro x hx; rw [Finset.mem_filter] at hx ⊢
+        exact ⟨hx.1, hx.2.1, le_trans hx.2.2 (le_trans ha'z.le hzb)⟩
+      have hznotin : z ∉ (chainZeros chain).filter (fun x => a < x ∧ x ≤ a') := by
+        rw [Finset.mem_filter]; rintro ⟨_, _, hza'⟩; exact absurd hza' (not_le.mpr ha'z)
+      have hlt_card : ((chainZeros chain).filter (fun x => a < x ∧ x ≤ a')).card < n := by
+        rw [← hcard]
+        exact Finset.card_lt_card ((Finset.ssubset_iff_of_subset hsub).mpr ⟨z, hzmem, hznotin⟩)
+      have IHres := ih _ hlt_card a a' ha_a'.le rfl
+      have hsplitZ : ((p.roots.filter (fun r => a < r ∧ r ≤ b)).card : ℤ)
+          = ((p.roots.filter (fun r => a < r ∧ r ≤ a')).card : ℤ)
+            + ((p.roots.filter (fun r => a' < r ∧ r ≤ b)).card : ℤ) := by
+        exact_mod_cast card_filter_Ioc_split p.roots ha_a'.le (le_trans ha'z.le hzb)
+      by_cases hzroot : p.IsRoot z
+      · obtain ⟨hcrossL, hcrossR⟩ :=
+          sturmVar_root_cross hp hsf hchain z hzroot a' b' ha'z hzb' hz_ex hpz
+        have ha'bZ : (sturmVar chain a' : ℤ) = sturmVar chain b + 1 := by
+          have : sturmVar chain a' = sturmVar chain b + 1 := by
+            rw [hcrossL, ← hcrossR, hzeqb]
+          exact_mod_cast this
+        have hRZ : ((p.roots.filter (fun r => a' < r ∧ r ≤ b)).card : ℤ) = 1 := by
+          have hzrootmem : z ∈ p.roots := (Polynomial.mem_roots hp).mpr hzroot
+          have hfeq : p.roots.filter (fun r => a' < r ∧ r ≤ b)
+              = p.roots.filter (fun r => r = z) := by
+            apply Multiset.filter_congr
+            intro x hx
+            constructor
+            · rintro ⟨h1, h2⟩
+              exact honly x h1 h2
+                ((mem_chainZeros hne).mpr ⟨p, head_mem hchain, (Polynomial.mem_roots hp).mp hx⟩)
+            · rintro rfl; exact ⟨ha'z, hzb⟩
+          rw [hfeq, Multiset.filter_eq', Multiset.card_replicate,
+            Multiset.count_eq_one_of_mem hnod hzrootmem]
+          rfl
+        linarith [hsplitZ, hRZ, ha'bZ, IHres]
+      · obtain ⟨hcrossL, _⟩ :=
+          sturmVar_interior_cross hchain z hzroot a' b' ha'z hzb' hz_ex
+        have ha'bZ : (sturmVar chain a' : ℤ) = sturmVar chain b := by
+          have : sturmVar chain a' = sturmVar chain b := by rw [hcrossL, hzeqb]
+          exact_mod_cast this
+        have hRZ : ((p.roots.filter (fun r => a' < r ∧ r ≤ b)).card : ℤ) = 0 := by
+          have hfeq : p.roots.filter (fun r => a' < r ∧ r ≤ b) = 0 := by
+            rw [Multiset.filter_eq_nil]
+            rintro x hx ⟨h1, h2⟩
+            have hxz : x = z := honly x h1 h2
+              ((mem_chainZeros hne).mpr ⟨p, head_mem hchain, (Polynomial.mem_roots hp).mp hx⟩)
+            rw [hxz] at hx
+            exact hzroot ((Polynomial.mem_roots hp).mp hx)
+          rw [hfeq]; rfl
+        linarith [hsplitZ, hRZ, ha'bZ, IHres]
 
 /-- **Sturm's theorem, line form.** For `p ≠ 0` squarefree with a generalised
 Sturm chain, the total number of real roots of `p` equals the drop in `sturmVar`

--- a/HexRealRootsMathlib/SturmTheorem.lean
+++ b/HexRealRootsMathlib/SturmTheorem.lean
@@ -23,11 +23,12 @@ of real roots of `p` in a half-open interval `(a, b]` is the drop in
 `sturmVar` from `a` to `b`, and the total number of real roots is the drop
 from `−∞` to `+∞`.
 
-The theorem bodies are `sorry` in this scaffold PR; each carries the intended
-proof sketch from the SPEC. They are discharged by the follow-up PRs M2–M5.
-The `±∞` variation counts `Sturm.sturmVarNegInf` / `Sturm.sturmVarPosInf` are
-defined here as real definitions (no `sorry`), reading the sign of each chain
-element at infinity off its leading coefficient and degree parity.
+The half-open form telescopes the three local lemmas over the finitely many
+chain zeros in `(a, b]` (helpers `chainZeros`, `exists_gap_lt`/`exists_gap_gt`,
+`sturmVar_eq_right`, `card_filter_Ioc_split`). The line form evaluates the chain
+just beyond every root at `±M` and reads the `±∞` variation counts
+`Sturm.sturmVarNegInf` / `Sturm.sturmVarPosInf` off the leading coefficients and
+degree parities (helpers `eval_sign_pos_inf` / `eval_sign_neg_inf`).
 -/
 
 open Filter Topology
@@ -610,6 +611,41 @@ theorem sturm_half_open (hp : p ≠ 0) (hsf : Squarefree p)
           rw [hfeq]; rfl
         linarith [hsplitZ, hRZ, ha'bZ, IHres]
 
+/-- **Sign at `+∞`.** Past all its real roots, a nonzero real polynomial has the
+sign of its leading coefficient. -/
+theorem eval_sign_pos_inf {q : Polynomial ℝ} (hq : q ≠ 0) {x : ℝ}
+    (hbeyond : ∀ y, q.IsRoot y → y < x) :
+    SignType.sign (q.eval x) = SignType.sign q.leadingCoeff := by
+  have hlc : q.leadingCoeff ≠ 0 := Polynomial.leadingCoeff_ne_zero.mpr hq
+  rcases lt_or_gt_of_ne hlc with h | h
+  · rw [sign_neg (Polynomial.eval_lt_zero_of_roots_lt_of_leadingCoeff_nonpos hbeyond h.le),
+      sign_neg h]
+  · rw [sign_pos (Polynomial.zero_lt_eval_of_roots_lt_of_leadingCoeff_nonneg hbeyond h.le),
+      sign_pos h]
+
+/-- **Sign at `−∞`.** Below all its real roots, a nonzero real polynomial has the
+sign of `leadingCoeff · (-1) ^ natDegree`. -/
+theorem eval_sign_neg_inf {q : Polynomial ℝ} (hq : q ≠ 0) {x : ℝ}
+    (hbeyond : ∀ y, q.IsRoot y → x < y) :
+    SignType.sign (q.eval x) = SignType.sign (q.leadingCoeff * (-1) ^ q.natDegree) := by
+  set r := q.comp (-Polynomial.X) with hr
+  have hlcr : r.leadingCoeff = q.leadingCoeff * (-1) ^ q.natDegree := by
+    rw [hr, Polynomial.leadingCoeff_comp (by simp)]; simp
+  have hrne : r ≠ 0 := by
+    intro h; rw [h, Polynomial.leadingCoeff_zero] at hlcr
+    exact (mul_ne_zero (Polynomial.leadingCoeff_ne_zero.mpr hq)
+      (pow_ne_zero _ (by norm_num))) hlcr.symm
+  have heval : r.eval (-x) = q.eval x := by rw [hr, Polynomial.eval_comp]; simp
+  have hbeyond' : ∀ y, r.IsRoot y → y < -x := by
+    intro y hy
+    have hqy : q.IsRoot (-y) := by
+      rw [hr, Polynomial.IsRoot, Polynomial.eval_comp] at hy; simpa using hy
+    have := hbeyond (-y) hqy
+    linarith
+  have hsign := eval_sign_pos_inf hrne hbeyond'
+  rw [heval, hlcr] at hsign
+  exact hsign
+
 /-- **Sturm's theorem, line form.** For `p ≠ 0` squarefree with a generalised
 Sturm chain, the total number of real roots of `p` equals the drop in `sturmVar`
 from `−∞` to `+∞`.
@@ -620,9 +656,58 @@ Proof sketch (SPEC step 5): take `a` below and `b` above every real root
 constant sign past its largest real zero equal to its sign at the corresponding
 infinity, and `(a, b]` contains every real root. Apply `sturm_half_open`; the
 filtered multiset is all of `p.roots`. -/
-theorem sturm_line (_hp : p ≠ 0) (_hsf : Squarefree p)
-    (_hchain : IsSturmChain p chain) :
+theorem sturm_line (hp : p ≠ 0) (hsf : Squarefree p)
+    (hchain : IsSturmChain p chain) :
     (sturmVarNegInf chain : ℤ) - sturmVarPosInf chain = p.roots.card := by
-  sorry
+  classical
+  have hne := hchain.nonzero_mem
+  -- A bound `M > 0` strictly beyond every chain zero (hence every root of every element).
+  obtain ⟨M, hMpos, hM⟩ : ∃ M : ℝ, 0 < M ∧ ∀ x ∈ chainZeros chain, |x| < M := by
+    set B := insert (0 : ℝ) ((chainZeros chain).image (fun x => |x|)) with hB
+    have hBne : B.Nonempty := ⟨0, Finset.mem_insert_self _ _⟩
+    refine ⟨B.max' hBne + 1, ?_, ?_⟩
+    · have : (0 : ℝ) ≤ B.max' hBne := Finset.le_max' B 0 (Finset.mem_insert_self _ _)
+      linarith
+    · intro x hx
+      have : |x| ≤ B.max' hBne :=
+        Finset.le_max' B |x| (Finset.mem_insert.mpr (Or.inr (Finset.mem_image.mpr ⟨x, hx, rfl⟩)))
+      linarith
+  -- Sign of each element at `±M` is its sign at the corresponding infinity.
+  have hpos : ∀ q ∈ chain, SignType.sign (q.eval M) = SignType.sign q.leadingCoeff := by
+    intro q hq
+    apply eval_sign_pos_inf (hne q hq)
+    intro y hy
+    have hyz : y ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨q, hq, hy⟩
+    have hya := hM y hyz; rw [abs_lt] at hya; exact hya.2
+  have hneg : ∀ q ∈ chain,
+      SignType.sign (q.eval (-M)) = SignType.sign (q.leadingCoeff * (-1) ^ q.natDegree) := by
+    intro q hq
+    apply eval_sign_neg_inf (hne q hq)
+    intro y hy
+    have hyz : y ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨q, hq, hy⟩
+    have hya := hM y hyz; rw [abs_lt] at hya; exact hya.1
+  -- Hence `sturmVar` at `±M` equals the `±∞` counts.
+  have hMposEq : sturmVar chain M = sturmVarPosInf chain := by
+    show signVariations (chain.map (Polynomial.eval M))
+      = signVariations (chain.map Polynomial.leadingCoeff)
+    apply signVariations_congr
+    rw [List.forall₂_map_left_iff, List.forall₂_map_right_iff, List.forall₂_same]
+    exact hpos
+  have hMnegEq : sturmVar chain (-M) = sturmVarNegInf chain := by
+    show signVariations (chain.map (Polynomial.eval (-M)))
+      = signVariations (chain.map (fun q => q.leadingCoeff * (-1) ^ q.natDegree))
+    apply signVariations_congr
+    rw [List.forall₂_map_left_iff, List.forall₂_map_right_iff, List.forall₂_same]
+    exact hneg
+  -- Apply the half-open form on `(-M, M]`, which catches every root.
+  have hkey := sturm_half_open hp hsf hchain (a := -M) (b := M) (by linarith)
+  have hfilter : p.roots.filter (fun r => -M < r ∧ r ≤ M) = p.roots := by
+    rw [Multiset.filter_eq_self]
+    intro r hr
+    have hroot : p.eval r = 0 := (Polynomial.mem_roots hp).mp hr
+    have hrz : r ∈ chainZeros chain := (mem_chainZeros hne).mpr ⟨p, head_mem hchain, hroot⟩
+    have hra := hM r hrz; rw [abs_lt] at hra
+    exact ⟨hra.1, hra.2.le⟩
+  rw [← hMnegEq, ← hMposEq, hkey, hfilter]
 
 end Sturm

--- a/progress/2026-07-11T12-58-47Z-sturm-global.md
+++ b/progress/2026-07-11T12-58-47Z-sturm-global.md
@@ -1,0 +1,24 @@
+# Sturm global theorems
+
+## Accomplished
+- Proved `Sturm.sturm_half_open` and `Sturm.sturm_line` in
+  `HexRealRootsMathlib/SturmTheorem.lean`, filling both remaining `sorry`s.
+- Added helpers: `chainZeros`/`mem_chainZeros`, `exists_gap_lt`/`exists_gap_gt`,
+  `sturmVar_eq_right`, `head_mem`, `card_filter_Ioc_split`,
+  `eval_sign_pos_inf`/`eval_sign_neg_inf`.
+- `lake build HexRealRootsMathlib` green, zero sorry warnings.
+- `#print axioms` clean for both (`propext, Classical.choice, Quot.sound`).
+- PR https://github.com/kim-em/hex-dev/pull/8719 (branch
+  `real-roots-m5-sturm-global`).
+
+## Current frontier
+- Sturm abstract development is complete; the chain-correspondence and
+  executable-count consequences in SPEC §"Chain correspondence" remain future
+  work (separate files).
+
+## Next step
+- Land the PR after CI; then wire the executable `sturmChain`/`sturmCount`
+  correspondence to these abstract theorems.
+
+## Blockers
+- None.


### PR DESCRIPTION
This PR discharges the two remaining `sorry`s of the Sturm development, proving both global forms of Sturm's theorem over `Polynomial ℝ`. `sturm_half_open` telescopes the three proven local crossing lemmas over the finitely many chain zeros in `(a, b]`: it inducts on the number of break points, peeling off the largest one, registering each root of `p` as a drop of one and each interior-element zero as variation-neutral. `sturm_line` bounds `M` beyond every chain zero, evaluates the chain at `±M`, reads the `±∞` variation counts off the leading coefficients and degree parities, and applies the half-open form on `(-M, M]`, which catches every real root.

New public helpers: `chainZeros` and `mem_chainZeros` (the finite break-point set), `exists_gap_lt` / `exists_gap_gt` (gap points that manufacture the artificial neighbour a crossing lemma needs at a break point), `sturmVar_eq_right` (right registration: the value at a break point equals the value immediately to its right), `head_mem`, `card_filter_Ioc_split` (multiset interval-count splitting), and `eval_sign_pos_inf` / `eval_sign_neg_inf` (sign of a polynomial beyond all its roots, from `Mathlib.Analysis.Polynomial.Order`).

Both theorem statements are unchanged. `#print axioms` reports `[propext, Classical.choice, Quot.sound]` for each, with no `sorryAx`. `lake build HexRealRootsMathlib` is green with zero sorry warnings.

🤖 Prepared with Claude Code