### PR TITLE
feat(hex-roots): add subdivision, gluing, refine1, and certify?

### DIFF
--- a/HexRoots.lean
+++ b/HexRoots.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRoots.Basic
+public import HexRoots.Bisection
 public import HexRoots.Cauchy
 public import HexRoots.Kantorovich
 public import HexRoots.MahlerPrec

--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRoots.Newton
+public import HexRoots.Kantorovich
+
+public section
+
+/-!
+Four-way subdivision, the `T₀` discard, and component gluing: the
+worklist operations of the complex root isolator. `Component.refine1`
+splits every square of a component into four children one bit finer,
+discards children whose disc certifiably contains no root, and glues the
+survivors back into edge-connected components; it is total, requiring no
+certification. `Component.certify?` tries to certify a component, first
+by the Newton-Kantorovich atom witness on the doubled enclosing square
+(with a speculative Newton recentring attempted first under the coverage
+guard), then by the Pellet witness on the enclosing square's disc.
+
+The geometry helpers `DyadicSquare.subdivide`, `DyadicSquare.adjacent`,
+and `glue` are exact: subdivision offsets by exact dyadics, adjacency is
+a comparison of exact dyadic centre differences, and gluing is a
+fuel-bounded breadth-first search with mark-before-push, so each index is
+visited once and the output components are deterministic in index order.
+The witness re-checks that certification and the coverage guard perform
+run at runtime on the compiled code; the `decide`-reducible witness
+predicates themselves live in `Pellet.lean` and `Kantorovich.lean`.
+-/
+namespace Hex
+
+/-- The four children of `s`, one bit finer, in a fixed order
+    (SW, SE, NW, NE). They partition `s`: each child has half-width
+    `2^{−(prec+1)}` and centre offset by that half-width from `s`'s
+    centre along each axis. -/
+@[expose] def DyadicSquare.subdivide (s : DyadicSquare) : Array DyadicSquare :=
+  let q := s.prec + 1
+  let h : Dyadic := .ofIntWithPrec 1 q
+  #[⟨s.re - h, s.im - h, q⟩, ⟨s.re + h, s.im - h, q⟩,
+    ⟨s.re - h, s.im + h, q⟩, ⟨s.re + h, s.im + h, q⟩]
+
+/-- Edge adjacency of two same-`prec` grid squares, by exact dyadic centre
+    differences: the centres differ by exactly `2·2^{−prec}` on one axis
+    and `0` on the other. Works for translated grids (Newton lineages)
+    because gluing only ever compares children of one component's squares,
+    which share a grid. -/
+@[expose] def DyadicSquare.adjacent (s t : DyadicSquare) : Bool :=
+  if s.prec = t.prec then
+    let twoH : Dyadic := .ofIntWithPrec 1 (s.prec - 1)   -- 2·2^{−prec}
+    let dre := Hex.Dyadic.abs (s.re - t.re)
+    let dim := Hex.Dyadic.abs (s.im - t.im)
+    (decide (dre = twoH) && decide (dim = 0))
+      || (decide (dre = 0) && decide (dim = twoH))
+  else
+    false
+
+/-- Edge-connected components of a set of same-`prec` squares. Breadth-first
+    search with mark-before-push (each index is pushed at most once, so
+    `n+1` pop rounds of fuel suffice); the output is deterministic in index
+    order. `O(m²)` adjacency scans. -/
+@[expose] def glue (sqs : Array DyadicSquare) : Array (Array DyadicSquare) := Id.run do
+  let n := sqs.size
+  let mut seen : Array Bool := Array.replicate n false
+  let mut result : Array (Array DyadicSquare) := #[]
+  for i in [0:n] do
+    if !(seen.getD i false) then
+      let mut comp : Array DyadicSquare := #[]
+      let mut stack : Array Nat := #[i]
+      seen := seen.setIfInBounds i true
+      for _ in [0:n+1] do
+        match stack.back? with
+        | none => break
+        | some cur =>
+          stack := stack.pop
+          let curSq := sqs.getD cur ⟨0, 0, 0⟩
+          comp := comp.push curSq
+          for j in [0:n] do
+            if !(seen.getD j false) && curSq.adjacent (sqs.getD j ⟨0, 0, 0⟩) then
+              seen := seen.setIfInBounds j true
+              stack := stack.push j
+      result := result.push comp
+  return result
+
+namespace Component
+
+/-- One subdivision round: split every square into four children one bit
+    finer, discard children whose disc certifiably contains no root (the
+    `T₀` test; a child whose `T₀` test fails to certify is kept, which is
+    always sound), and glue the survivors into edge-connected components.
+    Total: no certification is required during refinement. -/
+def refine1 (p : ZPoly) (c : Component) : Array Component :=
+  let survivors := (c.squares.flatMap DyadicSquare.subdivide).filter
+    (fun s => !rootFree p s)
+  (glue survivors).map fun ss => { squares := ss, candidateK := c.candidateK }
+
+/-- Try to certify the component. Per `strategy`, first the
+    Newton-Kantorovich atom witness on the doubled enclosing square (with a
+    speculative Newton recentring attempted first), then the Pellet witness
+    on the enclosing square's disc with `k = candidateK` first and then the
+    remaining `k ≤ deg p`; a `k = 1` Pellet success is returned as an atom
+    via `atomize`. Speculative Newton results are accepted only under the
+    coverage guard: the base region must certify the same count in the same
+    certificate form, and the recentred certified region must be contained
+    in the base one. -/
+def certify? (p : ZPoly) (strategy : AtomStrategy := .nkThenPellet)
+    (c : Component) : Option (Certified p) := Id.run do
+  let enc := encSquare c.squares
+  -- Newton-Kantorovich attempt, on the doubled enclosing square.
+  match strategy with
+  | .nk | .nkThenPellet =>
+    let base := enc.doubled
+    if h : nkWitnessCheck p base = true then
+      -- `base` certifies; try to sharpen with a speculative Newton jump,
+      -- accepted only when the recentred square stays inside `base` and
+      -- certifies in the same (NK) form.
+      let cand := (newtonSquare p base 1).doubled
+      if cand.squareInside base = true then
+        if h' : nkWitnessCheck p cand = true then
+          return some (.atom ⟨cand, Or.inl h'⟩)
+      return some (.atom ⟨base, Or.inl h⟩)
+  | .pellet => pure ()
+  -- Pellet attempt, on the enclosing square's disc.
+  match strategy with
+  | .pellet | .nkThenPellet =>
+    let deg := p.degree?.getD 0
+    let ks := #[c.candidateK] ++ ((Array.range (deg + 1)).filter (· != c.candidateK))
+    for k in ks do
+      if hk : 0 < k then
+        if hw : witnessCheck p enc k = true then
+          -- Speculative `k`-order Newton jump, coverage-guarded (disc in disc).
+          let s' := newtonSquare p enc k
+          if s'.discInside enc = true then
+            if hw' : witnessCheck p (encSquare #[s']) k = true then
+              let cluster' : DyadicRootCluster p := ⟨#[s'], k, hk, hw'⟩
+              if hk1 : k = 1 then
+                return some (.atom (cluster'.atomize hk1))
+              else
+                return some (.cluster cluster')
+          let cluster : DyadicRootCluster p := ⟨c.squares, k, hk, hw⟩
+          if hk1 : k = 1 then
+            return some (.atom (cluster.atomize hk1))
+          else
+            return some (.cluster cluster)
+  | .nk => pure ()
+  return none
+
+end Component
+
+end Hex


### PR DESCRIPTION
This PR adds `HexRoots/Bisection.lean`, the worklist operations of the complex root isolator. `DyadicSquare.subdivide` splits a square into its four one-bit-finer children (SW, SE, NW, NE) that partition it, `DyadicSquare.adjacent` decides edge adjacency of two same-`prec` grid squares by an exact comparison of dyadic centre differences, and `glue` groups a set of squares into edge-connected components with a fuel-bounded mark-before-push breadth-first search (deterministic in index order, no well-founded recursion). On top of these, `Component.refine1` runs one total subdivision round (subdivide every square, discard children whose disc the `T₀` test certifies rootless, glue the survivors), and `Component.certify?` tries to certify a component: per strategy, first the Newton-Kantorovich atom witness on the doubled enclosing square with a coverage-guarded speculative Newton recentring attempted first, then the Pellet witness on the enclosing square's disc with `candidateK` tried first and the remaining `k ≤ deg p` after, atomizing a `k = 1` Pellet success. The speculative Newton results are accepted only under the coverage guard (same certificate form on the base region, recentred region contained in it: `squareInside` for the NK form, `discInside` for the Pellet form).

End-to-end on `(x-1)(x-2)(x+3)`, iterated `refine1` from `Component.cauchy` converges to exactly three components (one per root), each settling to a four-square grid-line block; `certify?` on a small square around a simple root yields an atom under every strategy (NK sharpened to prec 5, Pellet atomized at prec 8), and on the double root of `(x^2+1)(x-5)^2` the NK form correctly fails while the Pellet form certifies a `k = 2` cluster without atomizing. Two notes on the work-unit prompt's rough estimates, which do not reflect implementation issues: three components first appear at refinement depth 6 rather than the guessed 3-4 (the Cauchy bound gives an initial half-width of 8 for roots of magnitude at most 3, so the first rounds shrink the enclosure before the roots separate), and the transient peak square count is 42 at depth 3 rather than under 40 before the `T₀` discard drives it back down to 12-14.

🤖 Prepared with Claude Code