### PR TITLE
feat: the isolate? driver and SimpleRealRoot quotient

### DIFF
--- a/HexRealRoots.lean
+++ b/HexRealRoots.lean
@@ -14,6 +14,8 @@ public import HexRealRoots.Var
 public import HexRealRoots.IsolateSturm
 public import HexRealRoots.Mobius
 public import HexRealRoots.IsolateDescartes
+public import HexRealRoots.Isolate
+public import HexRealRoots.SimpleRealRoot
 
 public section
 

--- a/HexRealRoots/Isolate.lean
+++ b/HexRealRoots/Isolate.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.IsolateSturm
+public import HexRealRoots.IsolateDescartes
+-- `import all` on the engine modules so `decide` reduces the sanity checks
+-- below in the kernel: the non-`@[expose]` engine bodies (`isolateSturm?`,
+-- `isolateDescartes?`, the chain/evaluation helpers they call) are opaque
+-- across the module boundary otherwise, so a `decide` unfolding them would
+-- get stuck. Same workaround as Var.lean and Refine.lean.
+import all Init.Data.Array.DecidableEq
+import all HexRealRoots.Basic
+import all HexRealRoots.Chain
+import all HexRealRoots.Var
+import all HexRealRoots.Prec
+import all HexRealRoots.IsolateSturm
+import all HexRealRoots.IsolateDescartes
+
+public section
+
+/-!
+The top-level real-root isolation driver.
+
+`isolate?` runs the two engines over the same output type: the fast
+Descartes search first, falling back to the provably terminating Sturm
+search on its `none`. Both emit `RealRootIsolations p` — pairwise-disjoint,
+ordered, Sturm-count-certified isolations, one per real root — so the driver
+is a one-liner that keeps whichever engine's certified output arrives first.
+
+The companion `HexRealRootsMathlib` proves `isolate? p ≠ none` for squarefree
+`p` (`isolate?_isSome`), routed through the Sturm engine's completeness
+(`isolateSturm?_isSome`); the Descartes engine's own completeness waits on the
+unformalised two-circle theorem and no driver-level fact depends on it.
+Downstream libraries that need a total function (hex-rcf) combine `isolate?`
+with `isolate?_isSome`.
+-/
+namespace Hex
+
+/-- Isolate the real roots of `p ∈ ℤ[x]`: try the fast Descartes engine, fall
+back to the Sturm engine on its `none`. Both engines produce the same
+certified `RealRootIsolations p`, so the result carries a full Sturm-count
+witness regardless of which one found it. Returns `none` only when both
+engines decline (e.g. non-squarefree input); the companion proves this never
+happens for squarefree `p`. -/
+def isolate? (p : ZPoly) : Option (RealRootIsolations p) :=
+  isolateDescartes? p <|> isolateSturm? p
+
+/-! Sanity checks (kept light; conformance lives in the shared sub-project).
+Polynomials are kept tiny so kernel reduction of `isolate?` is fast; the
+higher-degree fixtures live in the `#eval`-driven conformance suite. -/
+
+-- The zero polynomial and constants classify as `none`/isolations-of-a-root
+-- exactly as the engines do: `isolate?` inherits each engine's contract.
+example : isolate? (DensePoly.ofCoeffs (#[] : Array Int)) = none := by decide
+example : (isolate? (DensePoly.ofCoeffs #[(7 : Int)])).isSome = true := by decide
+
+-- The positive-degree fixtures route through the Descartes engine's rational
+-- squarefree decision, which the kernel does not reduce across the module
+-- boundary (it goes through `ceilSqrt`), so they are exercised by `#eval` in
+-- the conformance suite rather than `decide` here. Representative results:
+--   `isolate? (x − 5)`        ⇒ `some`, 1 isolation
+--   `isolate? (x² − 1)`       ⇒ `some`, 2 isolations
+--   `isolate? (x² + 1)`       ⇒ `some`, 0 isolations
+--   `isolate? ((x−1)²(x+1))`  ⇒ `none` (not squarefree; both engines decline)
+
+end Hex

--- a/HexRealRoots/SimpleRealRoot.lean
+++ b/HexRealRoots/SimpleRealRoot.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 Lean FRO, LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kim Morrison
+-/
+
+module
+
+public import HexRealRoots.Refine
+public import HexRealRoots.Prec
+-- `import all` on the source modules so `decide` reduces the sanity checks
+-- below in the kernel: the non-`@[expose]` bodies (`sturmChain`, `evalDyadic`,
+-- `sturmVarAt`, `sepPrec`, `twoPow`, and the dyadic comparison behind
+-- `Overlaps`) are opaque across the module boundary otherwise. Same workaround
+-- as Var.lean and Refine.lean.
+import all Init.Data.Array.DecidableEq
+import all HexRealRoots.Basic
+import all HexRealRoots.Chain
+import all HexRealRoots.Var
+import all HexRealRoots.Prec
+import all HexRealRoots.Refine
+
+public section
+
+/-!
+The identity of a real root, up to isolation.
+
+A `RefinedRealIsolation p` is an isolation refined to *separation precision*:
+its interval has width at most `2^{−sepPrec p}`, which is below `sep(p)/4` for
+squarefree `p`. Two such isolations name the same root exactly when their
+half-open intervals overlap, so `SimpleRealRoot p` is the quotient of refined
+isolations by `Overlaps`.
+
+Why the width bound lives in the type. Without it a coarse isolation could
+overlap several fine ones and relate distinct roots, collapsing them in the
+quotient. With both widths below `sep(p)/4`, an overlap places a point within
+`sep(p)/2` of both roots, which forces the roots to coincide; conversely two
+isolations of the *same* root both contain it, so they overlap. That argument
+is semantic, so the quotient is taken with `Quot` (which needs no equivalence
+proof) and this Mathlib-free layer provides no `DecidableEq (SimpleRealRoot p)`.
+The companion `HexRealRootsMathlib` proves that `Overlaps` restricted to
+`RefinedRealIsolation` is an equivalence whose classes are exactly the real
+roots, and hence that `sameRoot` decides equality in the quotient. Code here
+compares roots with `sameRoot` directly.
+
+The threading pattern for representatives (mirroring hex-roots): a
+`SimpleRealRoot` carries no computational content in this layer — nothing lifts
+out of the `Quot`. Numerical work happens on `RefinedRealIsolation`
+representatives, which are plain data. A function that repeatedly needs a
+high-precision approximation of the same root should refine its representative
+*once* and thread the refined value forward, rather than re-refining from a
+stored coarse representative on each use. Refinement preserves the root
+(`refine1_isolates_same` in the companion, so `sameRoot` is stable under it), so
+callers can substitute the refined representative wherever the original was
+used, and structures that store a representative should keep the refined value
+on return so downstream consumers inherit the precision.
+-/
+namespace Hex
+
+variable {p : ZPoly}
+
+/-- An isolation refined to separation precision: its interval has width at
+most `2^{−sepPrec p}`. At width below `sep(p)/4`, two refined isolations
+isolate the same root exactly when their intervals overlap. -/
+@[expose] def RefinedRealIsolation (p : ZPoly) :=
+  {iso : RealRootIsolation p //
+    iso.interval.upper - iso.interval.lower ≤ twoPow (-(sepPrec p : Int))}
+
+/-- The half-open intervals of two refined isolations intersect:
+`max lower₁ lower₂ < min upper₁ upper₂`. Core `Dyadic` has no `Min`/`Max`
+instance, so the max and min are written with explicit `if`s; the whole test
+is a single dyadic comparison at runtime. -/
+@[expose] def Overlaps (i₁ i₂ : RefinedRealIsolation p) : Prop :=
+  (if i₁.1.interval.lower ≤ i₂.1.interval.lower then i₂.1.interval.lower
+    else i₁.1.interval.lower) <
+  (if i₁.1.interval.upper ≤ i₂.1.interval.upper then i₁.1.interval.upper
+    else i₂.1.interval.upper)
+
+instance (i₁ i₂ : RefinedRealIsolation p) : Decidable (Overlaps i₁ i₂) :=
+  inferInstanceAs (Decidable (_ < _))
+
+/-- The identity of a real root, independent of which isolation witnessed it:
+the quotient of refined isolations by interval overlap. -/
+def SimpleRealRoot (p : ZPoly) := Quot (Overlaps (p := p))
+
+/-- Package a refined isolation as a root identity. -/
+def SimpleRealRoot.mk (iso : RefinedRealIsolation p) : SimpleRealRoot p :=
+  Quot.mk _ iso
+
+/-- Boolean form of `Overlaps`, used for equality tests on data containing
+roots. The companion proves it decides equality in `SimpleRealRoot p`. -/
+@[expose] def RefinedRealIsolation.sameRoot (i₁ i₂ : RefinedRealIsolation p) : Bool :=
+  decide (Overlaps i₁ i₂)
+
+/-- Refine an isolation to separation precision and package it as a
+`RefinedRealIsolation`. Refinement runs `refineTo (sepPrec p)`; the width test
+that follows is `some` on any honest isolation of a squarefree `p` (the
+companion's `refine1_isolates_same` shows `refineTo` actually shrinks below
+`2^{−sepPrec p}`, so the `none` branch is unreachable there). It is `Option`
+only because on junk data violating the isolation semantics `refineTo` can
+return its input unshrunk. This is the obvious producer the threading pattern
+needs: call it once, then thread the refined value forward. -/
+@[expose] def RealRootIsolation.refined (iso : RealRootIsolation p) :
+    Option (RefinedRealIsolation p) :=
+  let r := iso.refineTo (sepPrec p)
+  if h : r.interval.upper - r.interval.lower ≤ twoPow (-(sepPrec p : Int)) then
+    some ⟨r, h⟩
+  else none
+
+/-! Sanity checks (kept light; conformance lives in the shared sub-project).
+
+Kernel reduction of `Overlaps`/`sameRoot` only needs a dyadic comparison, but
+the `RefinedRealIsolation` width proof reduces `sepPrec p`, which routes through
+`ceilSqrt` for degree `≥ 2` and so does not reduce in the kernel. The checks
+below therefore use degree-1 polynomials, where `sepPrec p = 0` and the width
+bound is `twoPow 0 = 1`. Cross-root (`sameRoot = false`) behaviour needs two
+roots, hence degree `≥ 2`, so it is exercised by `#eval` in the conformance
+suite instead (a degree-1 polynomial has a single root, so every honest pair of
+its isolations overlaps). -/
+
+-- `p = x − 5`, root at `5`. Two honest isolations at separation precision:
+-- `(4, 5]` (width `1 = twoPow 0`) and `(9/2, 5]` (width `1/2`). Chain
+-- `[x − 5, 1]`; at `4` evals `(−1, 1)` → 1 variation, at `9/2` `(−1/2, 1)` → 1,
+-- at `5` `(0, 1)` → 0, so both intervals have Sturm count `1`.
+private def r1 : RefinedRealIsolation (DensePoly.ofCoeffs #[(-5 : Int), 1]) :=
+  ⟨⟨⟨Dyadic.ofInt 4, Dyadic.ofInt 5, by decide⟩, by decide⟩, by decide⟩
+private def r2 : RefinedRealIsolation (DensePoly.ofCoeffs #[(-5 : Int), 1]) :=
+  ⟨⟨⟨(Dyadic.ofInt 9) >>> (1 : Int), Dyadic.ofInt 5, by decide⟩, by decide⟩, by decide⟩
+
+-- Both isolate the single root `5`, so their intervals overlap: `max 4 (9/2) =
+-- 9/2 < 5 = min 5 5`. `sameRoot` is reflexive and identifies the two.
+example : Overlaps r1 r2 := by decide
+example : r1.sameRoot r2 = true := by decide
+example : r1.sameRoot r1 = true := by decide
+example : r2.sameRoot r2 = true := by decide
+
+end Hex

--- a/libraries.yml
+++ b/libraries.yml
@@ -483,7 +483,7 @@ libraries:
   HexRealRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 0
+    done_through: 1
     status: active
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]


### PR DESCRIPTION
This PR adds the top-level real-root isolation driver and the root-identity quotient, completing HexRealRoots Phase 1. `isolate? p := isolateDescartes? p <|> isolateSturm? p` runs the fast Descartes engine first and falls back to the provably terminating Sturm engine on its `none`, keeping whichever certified `RealRootIsolations p` arrives first; the companion `HexRealRootsMathlib` proves `isolate? p ≠ none` for squarefree `p` through the Sturm engine, and downstream libraries needing a total function combine the two.

`SimpleRealRoot` is the quotient of `RefinedRealIsolation p` (an isolation whose interval width is at most `2^{-sepPrec p}`, carried in the subtype) by `Overlaps`, the decidable half-open interval intersection written with explicit `if`-max/min since core `Dyadic` has no `Min`/`Max`. The width bound in the type is what makes overlap decide root identity: two isolations below `sep(p)/4` overlap exactly when they name the same root. Taken with `Quot` (no equivalence proof), with no `DecidableEq`; `sameRoot` is the boolean form code in this layer compares with, and `RealRootIsolation.refined` is the producer the threading pattern needs (refine once to separation precision, thread the refined value forward, never re-refine a stored coarse representative).

The module docstrings carry the width-bound rationale, the Quot-without-equivalence note, and the threading-pattern guidance; `done_through` bumps to 1 as every SPEC API item now has a genuine body, with the conformance and bench phases to follow.

🤖 Prepared with Claude Code