### PR TITLE
chore: HexRealRoots Phase 2 scaffolding review

### DIFF
--- a/HexRealRoots/Mobius.lean
+++ b/HexRealRoots/Mobius.lean
@@ -206,9 +206,8 @@ example : descartesVar (mobiusTransform (DensePoly.ofCoeffs #[(-1 : Int), 2])
 -- transform `(−2+2x)²+(1+x)²`. Signs `(+,−,+)` → 2. This interval is *wide*
 -- relative to the imaginary root pair `±i`, so the Descartes count
 -- over-estimates by 2 — sound (an even over-count), but not a `V = 0` discard.
--- NOTE: the directive's expected `V = 0` here is a hand-computation slip; the
--- true count on `(−2,2]` is 2, and `V = 0` on this polynomial needs an interval
--- away from `±i` (see the next check).
+-- A genuine `V = 0` discard for this polynomial needs an interval away from
+-- `±i` (see the next check).
 example : mobiusTransform (DensePoly.ofCoeffs #[(1 : Int), 0, 1])
     (DyadicInterval.mk (Dyadic.ofInt (-2)) (Dyadic.ofInt 2) (by decide))
     = DensePoly.ofCoeffs #[(5 : Int), -6, 5] := by decide

--- a/SPEC/Libraries/hex-real-roots.md
+++ b/SPEC/Libraries/hex-real-roots.md
@@ -355,6 +355,15 @@ def SimpleRealRoot.mk (iso : RefinedRealIsolation p) : SimpleRealRoot p :=
     containing roots. -/
 def RefinedRealIsolation.sameRoot (i₁ i₂ : RefinedRealIsolation p) : Bool := …
 
+/-- Refine an isolation to separation precision and package it as a
+    `RefinedRealIsolation`: `refineTo (sepPrec p)`, then the width check.
+    `none` only on data violating the isolation semantics (unreachable
+    for squarefree `p`, per the companion's `refine1_isolates_same`).
+    The entry point of the threading pattern: call once, thread the
+    refined value forward. -/
+def RealRootIsolation.refined (iso : RealRootIsolation p) :
+    Option (RefinedRealIsolation p)
+
 end Hex
 ```
 
@@ -467,8 +476,8 @@ claim and re-testing it per fixture is noise.
 
 Write `n = deg p` and `h = log ‖p‖∞`.
 
-- `sturmChain p`: `O(n)` pseudo-divisions, `O(n²)` coefficient
-  operations plus the content gcds. Primitive-chain coefficient
+- `sturmChain p`: `O(n)` pseudo-divisions, each `O(n²)` coefficient
+  operations, plus the content gcds. Primitive-chain coefficient
   growth is `O(n·h)` bits per element. Computed once per polynomial.
 - `sturmVarAt`: one exact Horner evaluation per chain element,
   `O(n²)` dyadic operations per queried point, memoised per endpoint.

--- a/libraries.yml
+++ b/libraries.yml
@@ -483,7 +483,7 @@ libraries:
   HexRealRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexRealRootsMathlib:
     deps: [HexRealRoots, HexPolyZMathlib]

--- a/status/hex-real-roots.scaffolding-reviewed
+++ b/status/hex-real-roots.scaffolding-reviewed
@@ -1,0 +1,21 @@
+Reviewed by two independent reviewer agents against
+SPEC/Libraries/hex-real-roots.md (placeholder/algorithm-fidelity lens and
+API-completeness lens), 2026-07-11. Every def, structure field, and
+instance was checked against its SPEC algorithm: spem's positive-multiple
+contract, the primitive-chain signs, the zero-skipping variation
+convention, the strict Cauchy excess of rootBound, sepPrec's conservative
+roundings, the literal Mobius numerator with reversal at the original
+degree, both engines' dispatch tables and chain-once memoisation
+discipline, the half-open refinement semantics, and the Overlaps/sameRoot
+quotient surface. Adversarial probes (Mignotte x^10 - (100x-1)^2, 10^20
+coefficients, dyadic-midpoint roots, Chebyshev T5, non-squarefree
+rejection) all matched hand analysis with engine agreement. No data-level
+placeholders, trivial returns, wrong-shape scaffolds, extern trampolines,
+or native-type detours were found. Downstream check: the companion
+reaches all executable defs (including private visitors) via import all,
+matching the HexBerlekampZassenhaus pattern, and hex-rcf's full call
+surface exists, with its cross-polynomial root test served by sturmCount's
+general (p, I) signature. Findings applied in the same commit: the SPEC's
+SimpleRealRoot block gains the RealRootIsolation.refined producer, the
+sturmChain complexity line is tightened to per-division cost, and one
+process-history comment in Mobius.lean was rewritten.


### PR DESCRIPTION
This PR records the Phase 2 scaffolding review of HexRealRoots and apply its findings. Two independent reviewer agents audited every definition against SPEC/Libraries/hex-real-roots.md, one on the placeholder and algorithm-fidelity lens (adversarial probes included the Mignotte worst case, 10^20-scale coefficients, dyadic-midpoint roots, and non-squarefree rejection, all matching hand analysis with both engines agreeing) and one on API completeness for the companion and hex-rcf (import-all reaches all executable defs including private visitors, matching the HexBerlekampZassenhaus pattern; hex-rcf's full call surface exists). No blockers were found. The findings applied here: the SPEC's SimpleRealRoot block gains the RealRootIsolation.refined producer that the threading pattern needs, the sturmChain complexity line is tightened to per-division cost, one process-history comment in Mobius.lean is rewritten, the status/hex-real-roots.scaffolding-reviewed token is committed, and libraries.yml moves done_through to 2.

🤖 Prepared with Claude Code
