### PR TITLE
fix(hex-roots): Phase-2 review findings, threading and ball API

### DIFF
--- a/HexRoots/Bisection.lean
+++ b/HexRoots/Bisection.lean
@@ -25,7 +25,7 @@ guard), then by the Pellet witness on the enclosing square's disc.
 The geometry helpers `DyadicSquare.subdivide`, `DyadicSquare.adjacent`,
 and `glue` are exact: subdivision offsets by exact dyadics, adjacency is
 a comparison of exact dyadic centre differences, and gluing is a
-fuel-bounded breadth-first search with mark-before-push, so each index is
+fuel-bounded depth-first search with mark-before-push, so each index is
 visited once and the output components are deterministic in index order.
 The witness re-checks that certification and the coverage guard perform
 run at runtime on the compiled code; the `decide`-reducible witness
@@ -58,8 +58,8 @@ namespace Hex
   else
     false
 
-/-- Edge-connected components of a set of same-`prec` squares. Breadth-first
-    search with mark-before-push (each index is pushed at most once, so
+/-- Edge-connected components of a set of same-`prec` squares. Depth-first
+    (stack-based) search with mark-before-push (each index is pushed at most once, so
     `n+1` pop rounds of fuel suffice); the output is deterministic in index
     order. `O(m²)` adjacency scans. -/
 @[expose] def glue (sqs : Array DyadicSquare) : Array (Array DyadicSquare) := Id.run do

--- a/HexRoots/IsolateAll.lean
+++ b/HexRoots/IsolateAll.lean
@@ -7,6 +7,7 @@ Authors: Kim Morrison
 module
 
 public import HexRoots.Refine
+public import HexRoots.SimpleRoot
 
 public section
 
@@ -33,7 +34,8 @@ namespace Hex
 def isolateAll? (p : ZPoly) (target : Int) (worklist : Array Component)
     (strategy : AtomStrategy := .nkThenPellet) :
     Option (Array (Certified p)) :=
-  let start := worklist.foldl (fun m c => min m c.prec) 0
+  let start := worklist.foldl (fun m c => min m c.prec)
+    ((worklist[0]?.map (·.prec)).getD 0)
   isolateLoop p target strategy ((stopDepth p target - start).toNat + 1) worklist
 
 /-- All-atoms output for polynomials with only simple roots: run
@@ -54,5 +56,23 @@ def isolate (p : ZPoly) (h : HasOnlySimpleRoots p) (atom_prec : Int)
         | .atom iso => some iso
         | .cluster _ => none
   else if p.size = 0 then none else some #[]
+
+/-- Refine a refined isolation, staying in the refined type and returning
+    the proof that the result isolates the same root. The refinement target
+    is floored at `mahlerPrec p` so the subtype re-wrap always succeeds on a
+    `some`, and the identity proof comes from the decidable `Intersects`
+    re-check via `Quot.sound`. This is the threading-pattern operation the
+    `SimpleRoot` module docstring describes: refine once, store the returned
+    representative, and substitute it wherever the original was used. -/
+def RefinedIsolation.refineTo? {p : ZPoly} (r : RefinedIsolation p)
+    (target : Int) (strategy : AtomStrategy := .nkThenPellet) :
+    Option {r' : RefinedIsolation p // SimpleRoot.mk r' = SimpleRoot.mk r} := do
+  let iso' ← r.1.refineTo? (max target (mahlerPrec p : Int)) strategy
+  if h : (mahlerPrec p : Int) ≤ iso'.square.prec then
+    let r' : RefinedIsolation p := ⟨iso', h⟩
+    if hI : Intersects r' r then
+      some ⟨r', Quot.sound hI⟩
+    else none
+  else none
 
 end Hex

--- a/HexRoots/Kantorovich.lean
+++ b/HexRoots/Kantorovich.lean
@@ -152,4 +152,11 @@ def DyadicRootCluster.atomize {p : ZPoly} (c : DyadicRootCluster p) (h : c.k = 1
     DyadicRootIsolation p :=
   ⟨encSquare c.squares, Or.inr (h ▸ c.witness)⟩
 
+/-- Certify an arbitrary candidate square as an atom, deciding both
+    `atomWitness` disjuncts fresh. This is the documented way to build a
+    `DyadicRootIsolation` outside the drivers, e.g. after transforming an
+    isolation's square (hex-number-field's `inv?` re-certification). -/
+def certifyAtom? (p : ZPoly) (s : DyadicSquare) : Option (DyadicRootIsolation p) :=
+  if h : atomWitness p s then some ⟨s, h⟩ else none
+
 end Hex

--- a/HexRoots/Pellet.lean
+++ b/HexRoots/Pellet.lean
@@ -126,6 +126,57 @@ instance {p : ZPoly} {s : DyadicSquare} {k : Nat} : Decidable (witness p s k) :=
 @[expose] def rootFree (p : ZPoly) (s : DyadicSquare) : Bool :=
   pelletAt (taylor p s.center) 0 s.radiusLo s.radiusHi
 
+/-! ### Ball geometry and ball evaluation
+
+`DyadicComplexBall` consumers (numerical evaluation in this library's
+future callers, and `hex-number-field`'s root disambiguation) need the
+disc-to-ball view of a square, a sound enclosure of `p` on a square's
+disc, and the exclusion and intersection tests on balls. The radius
+conventions here reuse the audited `radiusHi` upper bound, so callers
+never re-derive the `√2` bookkeeping. -/
+
+/-- The circumscribed disc of `s` as a ball, with the dyadic upper-bound
+    radius `radiusHi` (`≥` the true radius `2^{−prec}·√2`). -/
+@[expose] def DyadicSquare.toBall (s : DyadicSquare) : DyadicComplexBall :=
+  ⟨s.re, s.im, s.radiusHi⟩
+
+/-- A ball containing `p(z)` for every `z` in the circumscribed disc of
+    `s`: centred at the exact value `p(centre) = c₀`, with radius
+    `Σ_{i ≥ 1} hi(cᵢ)·radiusHi^i ≥ |p(z) − p(centre)|` by the triangle
+    inequality on the Taylor expansion. `rootFree` is the corollary
+    `lo(c₀) > radius` (kept separate so the audited `pelletAt` shape is
+    unchanged). -/
+@[expose] def evalBall (p : ZPoly) (s : DyadicSquare) : DyadicComplexBall :=
+  let cs := taylor p s.center
+  let c0 := cs.getD 0 (0, 0)
+  let radius :=
+    ((List.range cs.size).foldl (init := ((0 : Dyadic), (1 : Dyadic)))
+      fun acc i =>
+        if 1 ≤ i then
+          (acc.1 + GaussDyadic.hi (cs.getD i (0, 0)) * (acc.2 * s.radiusHi),
+           acc.2 * s.radiusHi)
+        else acc).1
+  ⟨c0.1, c0.2, radius⟩
+
+/-- The ball certifiably excludes `0`: `radius < lo(centre) ≤ |centre|`,
+    an exact dyadic comparison. The sound direction for "this value is
+    certainly nonzero"; failing this test means only that `0` could not
+    be excluded. -/
+@[expose] def DyadicComplexBall.excludesZero (b : DyadicComplexBall) : Bool :=
+  decide (b.radius < Hex.Dyadic.max (Hex.Dyadic.abs b.re) (Hex.Dyadic.abs b.im))
+
+/-- The closed balls intersect: squared centre distance at most the
+    squared radius sum, all exact dyadics. -/
+@[expose] def DyadicComplexBall.meets (b₁ b₂ : DyadicComplexBall) : Bool :=
+  let rs := b₁.radius + b₂.radius
+  decide (GaussDyadic.distSq (b₁.re, b₁.im) (b₂.re, b₂.im) ≤ rs * rs)
+
+/-- The ball meets the circumscribed disc of `s` (conservative: uses the
+    `radiusHi` upper bound for the disc radius, so a `false` certifies
+    disjointness from the true disc as well). -/
+@[expose] def DyadicSquare.meetsBall (s : DyadicSquare) (b : DyadicComplexBall) : Bool :=
+  DyadicComplexBall.meets s.toBall b
+
 /-- A certified cluster: an edge-connected set of grid squares at a
     common `prec`, whose enclosing disc contains exactly `k` roots
     with multiplicity. The component squares are the data that

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -592,9 +592,22 @@ def fast (r : RefinedIsolation p) : Option (RefinedIsolation p × Foo) := do
   return (r', …)                      -- caller stores r' going forward
 ```
 
-`refineTo?` preserves the root (`sameRoot r r' = true`, proved
-meaningful in the companion), so callers can substitute the refined
-representative wherever the original was used. Structures that contain
+The committed refined-level operation is
+
+```lean
+def RefinedIsolation.refineTo? (r : RefinedIsolation p) (target : Int)
+    (strategy : AtomStrategy := .nkThenPellet) :
+    Option {r' : RefinedIsolation p // SimpleRoot.mk r' = SimpleRoot.mk r}
+```
+
+which floors the target at `mahlerPrec p` (so the subtype re-wrap
+always succeeds on a `some`) and derives the identity proof from the
+decidable `Intersects` re-check via `Quot.sound`; and
+`DyadicRootIsolation.toRefined?` records that an `isolate` output
+meets the separation precision. `refineTo?` preserves the root
+(`sameRoot r r' = true`, proved meaningful in the companion), so
+callers can substitute the refined representative wherever the
+original was used. Structures that contain
 a representative (such as `AlgebraicNumber` in `hex-number-field`)
 should store the refined value on return, so downstream consumers
 inherit the precision.
@@ -640,12 +653,18 @@ inherit the precision.
   `Array (Dyadic × Dyadic)`.
 - `HexRoots/Pellet.lean`: the dyadic bounds `lo`/`hi`, the rational
   `√2` constants with their `decide`-checked defining inequalities,
-  the `witness` predicate and its `Decidable` instance, and
-  `DyadicRootCluster` (whose field mentions `witness`).
+  the `witness` predicate and its `Decidable` instance,
+  `DyadicRootCluster` (whose field mentions `witness`), and the ball
+  view: `DyadicSquare.toBall`, the sound enclosure `evalBall`, and the
+  ball tests `excludesZero`/`meets`/`meetsBall` that consumers
+  (hex-number-field's disambiguation loops) use instead of re-deriving
+  the `√2` radius bookkeeping.
 - `HexRoots/Kantorovich.lean`: `nkWitness` with its `Decidable`
-  instance, `atomWitness`, `AtomStrategy`, and the
+  instance, `atomWitness`, `AtomStrategy`, the
   `atomWitness`-dependent `DyadicRootIsolation`, `Certified`, and
-  `atomize`.
+  `atomize`, and `certifyAtom?` (certify an arbitrary candidate
+  square, deciding both disjuncts fresh; the documented constructor
+  for re-certification after a square transform).
 - `HexRoots/MahlerPrec.lean`: the closed-form `mahlerPrec` and
   `separationDepth`.
 - `HexRoots/Cauchy.lean`: `Component.cauchy`.
@@ -657,10 +676,12 @@ inherit the precision.
   worklist, `stopDepth`, the Φ termination measure discussion, and
   `DyadicRootIsolation.refineTo?` as a thin wrapper.
 - `HexRoots/IsolateAll.lean`: `isolateAll?` and `isolate` as thin
-  wrappers over the shared driver loop.
+  wrappers over the shared driver loop, and the refined threading
+  operation `RefinedIsolation.refineTo?` (below).
 - `HexRoots/SimpleRoot.lean`: `RefinedIsolation`, `Intersects`,
-  `SimpleRoot`, `sameRoot`; the threading-pattern guidance lives here
-  as a docstring.
+  `SimpleRoot`, `sameRoot`, and the constructor
+  `DyadicRootIsolation.toRefined?`; the threading-pattern guidance
+  lives here as a docstring.
 - `conformance/HexRoots/{Conformance,EmitFixtures}.lean` and
   `bench/HexRoots/Bench.lean`: the conformance and bench drivers, in
   the shared sub-projects.

--- a/HexRoots/SimpleRoot.lean
+++ b/HexRoots/SimpleRoot.lean
@@ -82,15 +82,23 @@ instance {p : ZPoly} {i₁ i₂ : RefinedIsolation p} : Decidable (Intersects i�
 /-- The identity of a simple root, independent of which isolation witnessed it.
     (`Quot` of a bare relation; the companion proves `Intersects` is an
     equivalence on `RefinedIsolation` whose classes are the simple roots.) -/
-def SimpleRoot (p : ZPoly) := Quot (Intersects (p := p))
+@[expose] def SimpleRoot (p : ZPoly) := Quot (Intersects (p := p))
 
 /-- The simple root witnessed by a refined isolation. -/
-def SimpleRoot.mk {p : ZPoly} (iso : RefinedIsolation p) : SimpleRoot p :=
+@[expose] def SimpleRoot.mk {p : ZPoly} (iso : RefinedIsolation p) : SimpleRoot p :=
   Quot.mk _ iso
 
 /-- Boolean form of `Intersects`, used for equality tests on data containing
     roots (see `hex-number-field`). -/
 @[expose] def RefinedIsolation.sameRoot {p : ZPoly} (i₁ i₂ : RefinedIsolation p) : Bool :=
   DyadicSquare.discsMeet i₁.1.square i₂.1.square
+
+/-- Wrap an isolation as a `RefinedIsolation` when it meets the separation
+    precision, deciding the subtype bound. `isolate`'s output always
+    qualifies (its target has a `separationDepth ≥ mahlerPrec` floor); this
+    is the constructor consumers use to record that fact. -/
+def DyadicRootIsolation.toRefined? {p : ZPoly} (iso : DyadicRootIsolation p) :
+    Option (RefinedIsolation p) :=
+  if h : (mahlerPrec p : Int) ≤ iso.square.prec then some ⟨iso, h⟩ else none
 
 end Hex

--- a/libraries.yml
+++ b/libraries.yml
@@ -453,7 +453,7 @@ libraries:
   HexRoots:
     deps: [HexPolyZ]
     mathlib: false
-    done_through: 1
+    done_through: 2
     status: active
   HexRootsMathlib:
     deps: [HexRoots, HexPolyZMathlib]

--- a/progress/20260711T141746Z.md
+++ b/progress/20260711T141746Z.md
@@ -1,0 +1,22 @@
+# HexRoots Phase-2 review
+
+## Accomplished
+
+Reviewed the Phase-2 HexRoots fixes against the checked-out code, focusing on
+the requested hard points: `evalBall`'s running-power fold,
+`DyadicComplexBall.excludesZero`, `RefinedIsolation.refineTo?`, and the
+`isolateAll?` fuel seed. Ran `lake build HexRoots`, which completed
+successfully with only existing style warnings.
+
+## Current frontier
+
+No concrete correctness bug found in the reviewed Phase-2 changes.
+
+## Next step
+
+If this proceeds to merge, no follow-up is required from this review beyond
+the separately deferred companion lemmas already tracked elsewhere.
+
+## Blockers
+
+None.

--- a/status/hex-roots.scaffolding-reviewed
+++ b/status/hex-roots.scaffolding-reviewed
@@ -1,0 +1,11 @@
+Reviewed by a three-reader skeptical fan-out (SPEC-vs-code fidelity,
+placeholder/shape audit, downstream needs) in the Phase-1 session of
+2026-07-11; findings fixed in the same PR that commits this token.
+Findings: glue docstring mislabelled DFS as BFS (relabelled);
+isolateAll? fuel fold seeded with 0 instead of the worklist's true
+minimum prec (fixed); downstream gaps closed by RefinedIsolation.
+refineTo? (subtype-preserving, root-identity proof via Quot.sound),
+DyadicRootIsolation.toRefined?, certifyAtom?, and the ball API
+(toBall, evalBall, excludesZero, meets, meetsBall). Deferred with
+issues: a taylor characterization lemma for the companion, and the
+invFloor/invAtPrec agreement lemma for the completeness slice.


### PR DESCRIPTION
This PR closes the Phase-2 skeptical review of hex-roots (three parallel readers: SPEC-vs-code fidelity, placeholder/shape audit, downstream needs). It fixes the two findings (`glue` docstring mislabelled DFS as BFS; `isolateAll?`'s fuel fold seeded with 0 instead of the worklist's true minimum prec, over-fuelling all-positive-prec worklists past the pinned `stopDepth`), and closes the downstream gaps with `RefinedIsolation.refineTo?` (refines within the subtype and returns the root-identity proof via the decidable `Intersects` re-check and `Quot.sound`, making the SPEC's threading pattern typecheck), `DyadicRootIsolation.toRefined?`, `certifyAtom?`, and the ball API on the audited `radiusHi` convention (`toBall`, `evalBall`, `excludesZero`, `meets`, `meetsBall`) that hex-number-field's disambiguation loops need. `SimpleRoot`/`SimpleRoot.mk` gain `@[expose]` so `Quot.sound` transports across module boundaries. Deferred work is tracked in https://github.com/kim-em/hex-dev/issues/8730 (taylor characterization lemma) and https://github.com/kim-em/hex-dev/issues/8731 (invFloor/invAtPrec agreement). Commits `status/hex-roots.scaffolding-reviewed` and bumps `done_through` to 2. New-API sanity checks pass end to end (certifyAtom?, evalBall at and away from a root, threading refine 99 → 387 bits with sameRoot preserved).

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP