### PR TITLE
fix(hex-roots): root coverage on cluster adoption, centre rounding, ready-hold

### DIFF
--- a/HexRoots/IsolateAll.lean
+++ b/HexRoots/IsolateAll.lean
@@ -36,7 +36,7 @@ def isolateAll? (p : ZPoly) (target : Int) (worklist : Array Component)
     Option (Array (Certified p)) :=
   let start := worklist.foldl (fun m c => min m c.prec)
     ((worklist[0]?.map (·.prec)).getD 0)
-  isolateLoop p target strategy ((stopDepth p target - start).toNat + 1) worklist
+  isolateLoop p target strategy (fuelFor p target start) worklist
 
 /-- All-atoms output for polynomials with only simple roots: run
     `isolateAll?` from `Component.cauchy` with

--- a/HexRoots/Newton.lean
+++ b/HexRoots/Newton.lean
@@ -56,16 +56,25 @@ namespace Hex
   let q := prec' + 2 + max 0 (Hex.Dyadic.ceilLog2 tb)
   let inv := d.invAtPrec q                               -- ONE real reciprocal 1/|c₁|²
   -- `invAtPrec` floors at precision `q` (error `< 2^{−q}` toward zero), so each
-  -- centre component's error is `< |tᵢ|·2^{−q} ≤ tb·2^{−q} ≤ 2^{−(prec'+2)}`
-  -- (strictness from the reciprocal rounding error), at most a
-  -- quarter of the new half-width `2^{−prec'}`: a genuinely converged Newton
-  -- step keeps the root inside the new square. `prec' = max (prec+2) (2·prec)`
+  -- centre component's reciprocal error is `< |tᵢ|·2^{−q} ≤ tb·2^{−q} ≤ 2^{−(prec'+2)}`
+  -- (strictness from the reciprocal rounding error). The final `roundDown` at
+  -- `prec' + 3` adds at most `2^{−(prec'+3)}` per component, for a total under
+  -- `3·2^{−(prec'+3)} < 2^{−(prec'+1)}`, half of the new half-width `2^{−prec'}`: a genuinely converged Newton
+  -- step keeps the root inside the new square. The rounding also pins the
+  -- centre's bit-length to about `prec' + 3` plus its magnitude, keeping every
+  -- downstream Taylor shift on `B`-bit values per the complexity contract;
+  -- without it, exact recentring compounds (each jump multiplies centre bits
+  -- by about `2·deg p`), which measured as 30k-digit centres by the fourth
+  -- jump on a degree-4 input. Certification never trusts the centre's
+  -- provenance, so rounding is harmless to soundness. `prec' = max (prec+2) (2·prec)`
   -- gives at least a quarter-size square always (also for `prec ≤ 0`) and
   -- precision doubling once `prec ≥ 2`; only success rate, never soundness,
   -- depends on this choice. `Dyadic.invAtPrec` returns `0` for a zero argument
   -- (`Init.Data.Dyadic.Inv.lean`: the `.zero` case), so `c₁ = 0` yields
   -- `inv = 0` and `x' = x` harmlessly.
-  { re := s.re - t.1 * inv, im := s.im - t.2 * inv, prec := prec' }
+  { re := (s.re - t.1 * inv).roundDown (prec' + 3),
+    im := (s.im - t.2 * inv).roundDown (prec' + 3),
+    prec := prec' }
 
 /-- The square concentric with `s`, one level coarser (half-width doubled).
     The Newton-Kantorovich certification convention tests and stores this. -/

--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -58,12 +58,25 @@ end Component
   | .atom iso => iso.square
   | .cluster cl => encSquare cl.squares
 
-/-- Re-enter a certification result into the worklist as a component: the
-    atom becomes a one-square component with `candidateK = 1`, the cluster
-    keeps its squares and root count. -/
+/-- Re-enter a certification result into the worklist as a component.
+
+    The retained square must *cover* the certified region, not merely be
+    certified: refinement preserves exactly the roots that lie in the
+    retained squares themselves (children partition the square, and the
+    `T₀` discard is sound), while a Pellet certificate counts roots in
+    the stored square's circumscribed *disc*. A root in the disc but
+    outside the square would be silently lost by the next subdivision;
+    with repeated Newton-jump adoptions this loses far roots of a
+    many-root cluster (the certified disc shrinks toward the cluster's
+    Newton centroid while still counting every root). Retaining the
+    *doubled* stored square (half-width `2·2^{−prec}` ≥ the disc radius
+    `√2·2^{−prec}`) restores the cover for both certificate forms, at
+    the cost of one precision level, which the strictly-finer adoption
+    guard in `isolateLoop` still absorbs (a Newton jump gains at least
+    two levels). -/
 def Certified.toComponent {p : ZPoly} : Certified p → Component
-  | .atom iso => ⟨#[iso.square], 1⟩
-  | .cluster cl => ⟨cl.squares, cl.k⟩
+  | .atom iso => ⟨#[iso.square.doubled], 1⟩
+  | .cluster cl => ⟨#[(encSquare cl.squares).doubled], cl.k⟩
 
 /-- All stored squares' circumscribed discs are pairwise disjoint, i.e.
     `!discsMeet` holds for every pair. One exact dyadic comparison per pair,
@@ -79,11 +92,14 @@ def Certified.toComponent {p : ZPoly} : Certified p → Component
 /-- The shared driver loop over the worklist. Each round certifies every
     component; if all certify at stored prec at least `target` with pairwise
     disjoint circumscribed discs (SPEC "Separation of the output"), the round
-    emits them. Otherwise every surviving component subdivides one level,
-    except that a component adopting a strictly finer certified result keeps
-    that result as a one-square component instead, so each non-emitting round
-    strictly increases every surviving component's prec; the loop then
-    recurses on the smaller fuel. `fuel = 0` returns `none`, the SPEC give-up
+    emits them. Otherwise: a component already certified at target whose
+    disc is disjoint from every other certified disc holds its position;
+    every other surviving component subdivides one level, except that one
+    adopting a strictly finer certified result keeps that result as a
+    one-square component instead. Each non-emitting round strictly
+    increases every non-held component's prec, and held components are at
+    target already, so the laggard's prec still reaches `stopDepth` within
+    the fuel; the loop recurses on the smaller fuel. `fuel = 0` returns `none`, the SPEC give-up
     semantics (up to a harmless constant of overshoot); a caller sizes the
     fuel as `(stopDepth p target − min prec).toNat + 1` so the loop reaches
     `stopDepth` before running out. The recursion is structural on the fuel
@@ -101,12 +117,30 @@ def isolateLoop (p : ZPoly) (target : Int) (strategy : AtomStrategy) :
     if allReady && disjoint then
       some (tried.filterMap (·.2))
     else
-      isolateLoop p target strategy fuel <| tried.flatMap fun (c, r) =>
-        match r with
-        | some res =>
-          let c' := res.toComponent
-          if c.prec < c'.prec then #[c'] else c.refine1 p
-        | none => c.refine1 p
+      -- A component whose certification already meets the target and whose
+      -- disc is disjoint from every other certified disc holds its position
+      -- (re-entering unchanged) while the laggards catch up; only
+      -- disjointness violators and unready components keep refining (SPEC
+      -- "Separation of the output"). Without the hold, a waiting component
+      -- would keep adopting Newton results, doubling its precision every
+      -- round and blowing the working bit-length while a slow sibling
+      -- (e.g. a tight cluster forced down to its separation depth)
+      -- subdivides.
+      let certSquares := tried.map fun t => t.2.map (·.square)
+      isolateLoop p target strategy fuel <|
+        (Array.range tried.size).flatMap fun i =>
+          match tried.getD i (⟨#[], 0⟩, none) with
+          | (c, some res) =>
+            let ready := target ≤ res.square.prec
+            let overlaps := (Array.range tried.size).any fun j =>
+              i ≠ j && (match certSquares.getD j none with
+                        | some sj => res.square.discsMeet sj
+                        | none => false)
+            if ready && !overlaps then #[c]
+            else
+              let c' := res.toComponent
+              if c.prec < c'.prec then #[c'] else c.refine1 p
+          | (c, none) => c.refine1 p
 
 /-- Refine to `target` precision: speculative Newton steps, falling back to
     subdivision of the atom's square as a one-square component. `none` only
@@ -116,7 +150,7 @@ def DyadicRootIsolation.refineTo? {p : ZPoly} (iso : DyadicRootIsolation p)
     Option (DyadicRootIsolation p) :=
   if target ≤ iso.square.prec then some iso else
   let fuel := (stopDepth p target - iso.square.prec).toNat + 1
-  match isolateLoop p target strategy fuel #[⟨#[iso.square], 1⟩] with
+  match isolateLoop p target strategy fuel #[⟨#[iso.square.doubled], 1⟩] with
   | some rs =>
     if rs.size = 1 then
       match rs[0]? with

--- a/HexRoots/Refine.lean
+++ b/HexRoots/Refine.lean
@@ -89,6 +89,13 @@ def Certified.toComponent {p : ZPoly} : Certified p → Component
       else
         true
 
+/-- Fuel for `isolateLoop`: the laggard's climb from the worklist's
+    coarsest prec to `stopDepth`, plus a second climb from `target` to
+    `stopDepth` for a held component forced back into refinement by a
+    late-certifying overlapping sibling (see `isolateLoop`). -/
+@[expose] def fuelFor (p : ZPoly) (target : Int) (start : Int) : Nat :=
+  (stopDepth p target - start).toNat + (stopDepth p target - target).toNat + 1
+
 /-- The shared driver loop over the worklist. Each round certifies every
     component; if all certify at stored prec at least `target` with pairwise
     disjoint circumscribed discs (SPEC "Separation of the output"), the round
@@ -97,13 +104,16 @@ def Certified.toComponent {p : ZPoly} : Certified p → Component
     every other surviving component subdivides one level, except that one
     adopting a strictly finer certified result keeps that result as a
     one-square component instead. Each non-emitting round strictly
-    increases every non-held component's prec, and held components are at
-    target already, so the laggard's prec still reaches `stopDepth` within
-    the fuel; the loop recurses on the smaller fuel. `fuel = 0` returns `none`, the SPEC give-up
-    semantics (up to a harmless constant of overshoot); a caller sizes the
-    fuel as `(stopDepth p target − min prec).toNat + 1` so the loop reaches
-    `stopDepth` before running out. The recursion is structural on the fuel
-    `Nat`. -/
+    increases every non-held component's prec, and held components sit at
+    target, so the laggard's prec reaches `stopDepth` within
+    `(stopDepth − min prec)` rounds. A held component can be forced back
+    into refinement late, when a slow sibling finally certifies with an
+    overlapping disc, so `fuelFor` budgets a second climb on top: past
+    `separationDepth` every certified disc is below `sep/4` and distinct
+    roots' discs are disjoint, so `(stopDepth − target)` further rounds
+    suffice. `fuel = 0` returns `none`, the SPEC give-up semantics (up to a
+    harmless constant of overshoot). The recursion is structural on the
+    fuel `Nat`. -/
 def isolateLoop (p : ZPoly) (target : Int) (strategy : AtomStrategy) :
     Nat → Array Component → Option (Array (Certified p))
   | 0, _ => none
@@ -149,7 +159,7 @@ def DyadicRootIsolation.refineTo? {p : ZPoly} (iso : DyadicRootIsolation p)
     (target : Int) (strategy : AtomStrategy := .nkThenPellet) :
     Option (DyadicRootIsolation p) :=
   if target ≤ iso.square.prec then some iso else
-  let fuel := (stopDepth p target - iso.square.prec).toNat + 1
+  let fuel := fuelFor p target iso.square.prec
   match isolateLoop p target strategy fuel #[⟨#[iso.square.doubled], 1⟩] with
   | some rs =>
     if rs.size = 1 then

--- a/HexRoots/SPEC/hex-roots.md
+++ b/HexRoots/SPEC/hex-roots.md
@@ -368,7 +368,13 @@ ready" precondition. The Gaussian inversion `1/c₁ = c̄₁ / |c₁|²` uses
 `Dyadic.invAtPrec` for the single real reciprocal `1/|c₁|²`, which
 both the real and imaginary components reuse. That is why the
 implementation calls `invAtPrec` rather than two separate
-`Dyadic.divAtPrec` divisions.
+`Dyadic.divAtPrec` divisions. The recentred components are rounded
+down to precision `prec' + 3` (a quarter of the reciprocal's error
+budget): certification never trusts the centre's provenance, so the
+rounding is harmless, and it pins the working bit-length to the
+complexity contract's `B`. Without it exact recentring compounds,
+multiplying the centre's bit-length by roughly `2·deg p` per
+accepted jump.
 
 **Coverage guard.** The witness re-check alone is not a sufficient
 acceptance criterion for a speculative Newton result. The separation
@@ -392,6 +398,23 @@ preserved. The guard costs one extra witness evaluation and never
 blocks the intended use (sharpening an already certified region); a
 jump whose base region fails to certify is discarded, and
 subdivision proceeds as usual.
+
+Acceptance is not the whole story: when a certified result re-enters
+the worklist (its precision is still below target), the component
+must retain a square that *covers* the certified region, not merely
+the certified square itself. Refinement preserves exactly the roots
+that lie in the retained squares (children partition the square and
+the `T₀` discard is sound), while a Pellet certificate counts roots
+in the stored square's circumscribed disc; a root in the disc but
+outside the square would be silently lost by the next subdivision.
+Repeated Newton-jump adoptions of a many-root cluster make this
+concrete: the jumped disc keeps counting all `k` roots while
+shrinking toward the cluster's Newton centroid, until far roots sit
+in the disc but outside the retained square and vanish. Re-entry
+therefore retains the doubled stored square (half-width
+`2·2^{−prec}`, which contains the disc of radius `√2·2^{−prec}`),
+costing one precision level, which the strictly-finer adoption rule
+still absorbs.
 
 **Termination.** Termination is structural, with no analytic input.
 Write `gap(c) := stopDepth p target − prec(c)` for a component `c` in
@@ -438,7 +461,12 @@ neighbouring component and captures the neighbour's root. The driver
 therefore emits a set of certified results only when the
 circumscribed discs of their stored squares are **pairwise
 disjoint** (one dyadic comparison per pair, as in the `SimpleRoot`
-intersection test); components violating the check keep subdividing.
+intersection test); components violating the check keep subdividing,
+while a component already certified at target with a disc disjoint
+from every other certified disc holds its position (continuing to
+refine while waiting would double its precision every round through
+Newton adoption, blowing the working bit-length whenever a sibling
+is slow, e.g. a tight cluster forced down to its separation depth).
 Every certified region is contained in its stored square's
 circumscribed disc (the square itself for the Newton-Kantorovich
 form, the enclosing disc for the Pellet form), so disjoint discs

--- a/progress/20260711T171113Z.md
+++ b/progress/20260711T171113Z.md
@@ -1,0 +1,15 @@
+# HexRoots complex isolator PR review
+
+**Accomplished**
+- Reviewed the bug-fix PR touching `HexRoots/Newton.lean`, `HexRoots/Refine.lean`, and `HexRoots/SPEC/hex-roots.md`.
+- Checked the doubled-square containment rationale, Newton rounding budget, `roundDown`/`invAtPrec` core contracts, and `isolateLoop` hold/index logic.
+- Ran `lake build HexRoots`; it completed successfully with only existing unused-variable warnings in `HexRoots/Cauchy.lean` and `HexRoots/IsolateAll.lean`.
+
+**Current frontier**
+- Review found one concrete fuel/liveness concern in the hold logic: held components are not actually advanced in the worklist while only their certificates are at target, so a later overlap with a previously uncertified component can force delayed refinement/adoption with fuel already spent.
+
+**Next step**
+- Adjust the hold/fuel argument or implementation so components ignored because another component is uncertified cannot run out of fuel if that other component later certifies with an overlapping disc.
+
+**Blockers**
+- None for the review itself.


### PR DESCRIPTION
This PR fixes the three driver defects behind https://github.com/kim-em/hex-dev/issues/8736 (isolate silently dropping the Mignotte quintic's three large-magnitude roots) and the 41-minute Nat.pow panic the fixtures work hit. (1) Worklist re-entry of a certified result now retains the *doubled* stored square: refinement preserves only roots inside retained squares, while a Pellet certificate counts roots in the circumscribed disc, so a root in disc∖square was silently lost — systematically so under repeated Newton-jump adoptions, whose certified disc shrinks toward the cluster's Newton centroid. (2) `newtonSquare` rounds the recentred components at `prec'+3` (within the step's error budget): exact recentring compounds centre bit-length by ~2·deg per jump (measured 30k-digit centres by the fourth jump at degree 4). (3) A component already certified at target with a disc disjoint from every other certified disc holds its position while laggards catch up; continuing to adopt Newton results doubled its precision every waiting round, which is what fed `invFloor` a multi-million-bit exponent. The acceptance suite runs in 2.2 s; Mignotte isolates to all 5 atoms under `.nk`, `.pellet`, and `.nkThenPellet`; the SPEC's coverage-guard and separation sections record the re-entry cover and hold rules.

🤖 Prepared with Claude Code

https://claude.ai/code/session_01SpYSH4swVcLJbN2Bn6NfSP